### PR TITLE
Claude/jolly austin 9b3100

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,361 @@
+# CLAUDE.md — Afiação (Sistema Operacional B2B Sardenberg)
+
+> Este arquivo orienta agentes de código (e humanos) trabalhando neste repositório. Última atualização: 2026-05-13 (auditoria UX completa, Fases 0-4 entregues — ver `docs/ux-audit/`).
+
+---
+
+## 1. Produto
+
+**Afiação** é o sistema operacional B2B do grupo Colacor. O repositório nasceu como portal do serviço de afiação de ferramentas; o serviço foi absorvido como um módulo, **Colacor virou o nome-mãe** do app e do grupo, e o produto se expandiu para vendas, estoque, financeiro, tintometria, reposição inteligente, produção e governança das três empresas (uma indústria de abrasivos, uma distribuidora para indústria moveleira, uma prestadora de serviços).
+
+### Empresas (estado real no código + modelo de negócio confirmado)
+
+Definidas em `src/contexts/CompanyContext.tsx`:
+
+| ID            | Nome no código        | Negócio                              | Modelo                        | Regime    |
+| ------------- | --------------------- | ------------------------------------ | ----------------------------- | --------- |
+| `colacor`     | Afiação Colacor ⚠️    | Indústria de abrasivos          | Vende itens industrializados  | presumido |
+| `oben`        | Oben Comercial        | Distribuidora p/ indústria moveleira | Compra e revende              | presumido |
+| `colacor_sc`  | Colacor SC            | Serviços                             | Presta serviço                | simples   |
+
+> ⚠️ **Rename pendente** (registrado em §10): `Afiação Colacor` precisa virar `Colacor` no `CompanyContext`. A afiação é hoje um módulo dentro do app, não a identidade da empresa.
+
+### Módulos efetivamente implementados (rotas em `src/App.tsx`)
+
+| Módulo            | Prefixo de rota             | Páginas (qtd. aprox.) | Persona dominante                |
+| ----------------- | --------------------------- | --------------------- | -------------------------------- |
+| Cliente (afiação) | `/orders`, `/tools`, etc.   | ~15                   | Cliente final / staff de balcão  |
+| Vendas            | `/sales/*`                  | ~7                    | Vendedor / comercial             |
+| Estoque           | `/admin/estoque/*`, `/recebimento` | ~4              | Conferente / separador           |
+| Reposição (compras) | `/admin/reposicao/*`      | ~20                   | Comprador / gestor de suprimentos |
+| Financeiro        | `/financeiro/*`             | ~12                   | CFO / financeiro                 |
+| Tintométrico      | `/tintometrico/*`           | ~12                   | Operador tintométrico / gestor    |
+| Inteligência / Farmer | `/farmer/*`, `/intelligence`, `/ai-ops` | ~10 | Comercial / gestor               |
+| Governança        | `/governance/*`, `/gestao/*` | ~8                    | Master                           |
+| Produção          | `/producao`                 | 1                     | Operador fábrica                 |
+| Documentação interna | `/design-system`, `/ux-rules`, `/docs`, `/admin/ajuda` | 4 | Dev / staff       |
+
+Total: **119 páginas registradas** em `src/pages/`, com lazy-loading em `App.tsx:16-136`.
+
+---
+
+## 2. Stack
+
+- **Frontend**: React 18.3.1 + TypeScript 5.8.3 + Vite 5.4.19 + `@vitejs/plugin-react-swc`
+- **Roteamento**: react-router-dom 6.30.1 (lazy routes)
+- **Estado servidor**: `@tanstack/react-query` 5.83.0 (`staleTime: 60s`, sem `refetchOnWindowFocus`, `retry: 2`)
+- **UI**: shadcn/ui (50+ componentes em `src/components/ui`) sobre Radix UI primitives
+- **Estilo**: Tailwind 3.4.17 + `tailwindcss-animate` + `@tailwindcss/typography`
+- **Animação**: `framer-motion` 12 (usado em `EmptyState`, `BottomNav`, alguns dialogs)
+- **Forms**: `react-hook-form` 7.61 + `zod` 3.25 + `@hookform/resolvers`
+- **Backend**: Supabase (Postgres + Auth + Storage + Realtime), 164 migrations em `supabase/migrations`, 48 Edge Functions em `supabase/functions`
+- **PWA**: `vite-plugin-pwa` com Workbox — `NetworkFirst` apenas para catálogo, `NetworkOnly` para `orders/profiles/sales_orders/order_items` (ver §5)
+- **OCR**: `tesseract.js` 5.0 (usado em `RecebimentoConferencia` / `LoteScannerOCR`)
+- **Mapas**: `leaflet` 1.9 + `@types/leaflet` (route planner)
+- **Charts**: `recharts` 2.15
+- **Comando**: `cmdk` 1.1.1 — **instalado mas NÃO usado como command palette global**, apenas o `Command` wrapper shadcn está disponível em `src/components/ui/command.tsx`
+- **Voz/IA**: `@elevenlabs/react` 0.14 (transcribe)
+- **Drag-and-drop**: `@hello-pangea/dnd` 17 (kanban)
+- **Toasts**: `sonner` 1.7 + Radix toast (dois sistemas coexistem — ver §10)
+- **Hospedagem**: Lovable Cloud (componentTagger em dev)
+
+### Scripts
+
+```bash
+bun dev       # vite dev server (porta 8080)
+bun build     # vite build (PWA gerado em production)
+bun build:dev # build em modo dev (sem PWA)
+bun lint      # eslint
+bun test      # vitest run
+bun preview   # vite preview
+```
+
+---
+
+## 3. Estrutura de pastas
+
+```
+src/
+├── App.tsx                  # Routes + providers (QueryClient, Tooltip, Toaster, Auth, Company, ErrorBoundary, Suspense)
+├── main.tsx                 # Bootstrap
+├── index.css                # Design tokens (CSS vars HSL), tipografia, utilitários
+├── components/
+│   ├── AppShell.tsx         # Sidebar desktop + topbar + mobile drawer (sem cmd-k, sem busca global)
+│   ├── AppShellLayout.tsx   # Wrapper p/ Outlet
+│   ├── BottomNav.tsx        # Inativa dentro de AppShell (return null via useInsideAppShell)
+│   ├── Header.tsx           # Header mobile legado (também inativa dentro de AppShell)
+│   ├── ui/                  # shadcn (50 componentes)
+│   ├── admin-order/         # Subcomponentes da OS admin
+│   ├── des/                 # Dashboard executivo seções
+│   ├── financeiro/          # ...
+│   ├── help/                # HelpDrawer
+│   ├── intelligence/        # ...
+│   ├── portalSayerlack/     # ...
+│   ├── recebimento/         # LoteScannerOCR etc.
+│   ├── reposicao/           # ...
+│   └── unified-order/       # Wizard de pedido
+├── contexts/
+│   ├── AuthContext.tsx      # Roles + fail-closed approval
+│   ├── CompanyContext.tsx   # 3 empresas (localStorage)
+│   ├── AppShellContext.tsx  # Flag p/ headers legados se silenciarem
+│   └── ReposicaoEmpresaContext.tsx
+├── hooks/                   # 36 hooks (engines de bundle, copilot, cross-sell, tactical-plan, biometric, etc.)
+├── integrations/supabase/   # Client + types gerados
+├── lib/                     # format, logger, phone, agruparPorMes, help-utils, reposicao/
+├── pages/                   # 119 páginas
+├── queries/                 # Hooks de react-query (useProfile, useOrders, useUserTools)
+├── services/                # ...
+├── types/                   # ...
+└── utils/                   # ...
+supabase/
+├── migrations/              # 164 arquivos timestamped
+├── functions/               # 48 Edge Functions
+└── config.toml
+docs/
+├── FINANCEIRO_CONFIABILIDADE.md
+├── ONDA1_FOLHA_EVIDENCIAS.md
+└── ONDA1_PLANO_OPERACIONAL.md
+└── ux-audit/                # ← criado nesta auditoria
+```
+
+---
+
+## 4. Design System (estado atual)
+
+### Tokens (`src/index.css`)
+
+- Cores em HSL via CSS vars (`--primary`, `--surface-0..3`, `--status-success/warning/error/info/pending/progress/danger/purple/indigo`, `--sidebar-*`)
+- Modo dark via classe `.dark`
+- Tipografia: Inter (sans), JetBrains Mono (mono), Space Grotesk e Bebas Neue carregados em `index.html` (legado — usados em Header/EmptyState como `font-display`)
+- Escala de tamanho: 2xs(10) → xs(12) → sm(13) → **base(14, default body)** → md(15) → lg(16) → xl(18) → 2xl(20) → 3xl(24) → 4xl(30) → 5xl(36)
+- Espaçamento custom: 0.5(2) / 1(4) / 1.5(6) / 2(8) / 3(12) / 4(16) / 5(20) / 6(24) / 8(32) / 10(40) / 12(48) / 16(64) / 20(80) / 24(96), mais tokens semânticos `sidebar(240)`, `sidebar-collapsed(56)`, `topbar(48)`
+- Radius: `--radius: 0.5rem` (com lg/md/sm derivados)
+- Shadows: xs / sm / md / lg / xl / focus
+- Motion: `--duration-fast: 100ms`, `--duration-normal: 200ms`, `--duration-slow: 350ms`
+- Densidade: classes `.density-compact` (row 36/input 32/card 12/gap 4) e `.density-comfortable` (row 44/input 40/card 16/gap 8). **AppShell aplica `density-compact` globalmente** (`AppShell.tsx:552`).
+
+### Inspirações declaradas (na página `DesignSystem.tsx:115`)
+
+> "Tokens, componentes e padrões — HubSpot Canvas + Shopify Polaris + Gong"
+
+> ⚠️ **Realinhar para o briefing oficial**: Linear (velocidade percebida) · Notion (cmd-k) · Carbon Design System / IBM (densidade B2B) · Shopify Polaris (operacional) · Retool (internal tools). HubSpot Canvas e Gong saem da régua. A interseção real do existente é apenas Polaris.
+
+### shadcn/ui — componentes presentes (`src/components/ui`)
+
+Todos os primitivos esperados: accordion, alert-dialog, alert, avatar, badge, breadcrumb, button, calendar, card, carousel, chart, checkbox, collapsible, command, context-menu, dialog, drawer, dropdown-menu, form, hover-card, input-otp, input, label, menubar, navigation-menu, pagination, popover, progress, radio-group, resizable, scroll-area, select, separator, sheet, sidebar, skeleton, slider, sonner, switch, table, tabs, textarea, toast, toaster, toggle-group, toggle, tooltip.
+
+### Padrões de layout
+
+- **Desktop**: sidebar dark fixa à esquerda (colapsível, 240/56px) + topbar fixo no topo (48px) + main com `pt-topbar` e `lg:ml-sidebar`
+- **Mobile (<lg)**: sidebar dark vira drawer overlay (`MobileNav`), topbar mantido, sem bottom-nav ativa
+- **Bottom-nav legado** (`BottomNav.tsx`): existe mas é silenciada quando dentro de AppShell — só ativa em telas fora da Shell (rotas públicas)
+- **Densidade**: compact (32px input / 36px row) aplicada globalmente — ver §11
+- **Empty states**: `src/components/EmptyState.tsx` é "consumer-grade" (motion floating, ícone arredondado grande, descrição centralizada) — destoa do registro B2B do resto do shell
+
+### Navegação (sidebar, `AppShell.tsx:38-127`)
+
+Seções: Principal · Afiação · Vendas · Estoque · Reposição · Produção · Performance · Inteligência · Financeiro · Tintométrico · Automação · Gestão · Documentação. Badges numéricos com contagem em tempo real (refetch 30–60s) em: alertas outlier, pedidos pendentes, aumentos ativos, oportunidades, negociação paralela, notificações, alertas críticos parâmetros, financeiro atrasados, tint erros.
+
+### Topbar (`AppShell.tsx:434-481`)
+
+Apenas: botão mobile menu (lg:hidden) · HelpDrawer · botão Bell (sem badge, sem onClick, **ornamental**) · dropdown User (Meu perfil / Sair). **Sem campo de busca global, sem command palette, sem trocador de empresa, sem indicador de online/offline, sem indicador de empresa ativa.**
+
+---
+
+## 5. Padrões críticos do domínio
+
+### Auth & roles
+
+- `AppRole = 'employee' | 'customer' | 'master'` (em `src/contexts/AuthContext.tsx`)
+- `isStaff = isAdmin || isEmployee || isMaster`
+- Aprovação: customers precisam de `is_approved` no profile; staff é auto-aprovado
+- **Fail-closed**: se a query de role/approval falha, role vai a `null` e approval a `false` (`AuthContext.tsx:62-113`) — bom para segurança
+- Restrição "sales-only" por CPF: `useSalesOnlyRestriction` (`AppShell.tsx:138`) — esconde tudo exceto seção Vendas para CPFs listados em `company_config.sales_only_cpfs`
+- Tabela paralela `commercial_roles` define funções comerciais (gestor / vendedor) sem ser parte do role principal
+
+### Mapeamento de personas → acesso (decisão oficial)
+
+As 5 personas operacionais não viram roles novos no banco — elas são **recortes de acesso** mapeados sobre os 3 roles existentes + `commercial_roles` + uma futura noção de "departamento":
+
+| Persona              | Acesso esperado                                                                 | Como mapear hoje                            |
+| -------------------- | ------------------------------------------------------------------------------- | ------------------------------------------- |
+| Vendedor externo     | `/sales/*`, `/farmer/*`, `/admin/customers`                                     | `commercial_roles.commercial_role = vendedor` |
+| Gestão (vendas)      | Tudo de vendas + dashboards + dashboards comerciais                             | `commercial_role = gestor`                  |
+| Separador            | `/admin/estoque/picking` (mobile)                                               | Persona/dept de estoque (a criar)           |
+| Conferente           | `/recebimento`, `/admin/estoque/recebimento` (desktop)                          | Persona/dept de estoque (a criar)           |
+| Operador tintométrico | `/tintometrico` + telas de balcão                                              | Persona/dept tintométrico (a criar)         |
+| Comprador            | `/admin/reposicao/*`                                                            | Persona/dept de compras (a criar)           |
+| Gestão (geral)       | Cockpits financeiro/CFO, intelligence, governança                               | `master` ou `employee` + dept gestão        |
+
+> Implementação concreta dessas personas é trabalho de produto futuro; nesta auditoria UX, **assumo que cada tela tem persona dominante conhecida** e diferencio densidade, alvo de toque, atalhos e fluxo conforme essa persona. As propostas de granularidade de acesso ficam fora do escopo, mas viram observação no roadmap.
+
+### Offline & PWA (`vite.config.ts:21-89`)
+
+- Workbox `registerType: autoUpdate`, `skipWaiting`, `clientsClaim`
+- **Cache**: `NetworkFirst` SÓ para `tool_categories | default_prices | company_config | category_mappings` (1h)
+- **NetworkOnly**: `orders | profiles | order_messages | user_tools | sales_orders | order_items` — **e também auth/realtime**
+- Nenhum endpoint de `picking_*`, `nfe_*` ou `recebimento_*` está no workbox — **sem cache, sem offline**
+- **Não há queue de mutação offline, nem indicador de online/offline na UI** (busca por `navigator.onLine` retorna 0 ocorrências em `src/`, exceto na documentação)
+- A configuração atual é hostil ao princípio "offline-first em picking e recebimento" do briefing. Ver §11.
+
+### Latência percebida & optimistic UI
+
+- React Query default: `staleTime: 60s`, sem refetch em focus
+- Nenhum padrão sistemático de `useMutation({ onMutate, onError: rollback })` para optimistic UI — auditar caso a caso
+- Skeletons via `<Skeleton />` shadcn (uso esparso; em `App.tsx` o Suspense fallback é genérico 3-bloco)
+
+### Atalhos de teclado
+
+- `src/hooks/useKeyboardShortcuts.ts` — hook básico (sem modifiers, sem composição, sem registry, sem help overlay)
+- Usado em apenas 1 página em produção: `AdminReposicaoCockpit.tsx`
+- **Sem cmd-k global, sem `/` para busca, sem `j/k` navegação, sem `?` para help, sem `esc` cancela global**
+
+### Barcode scanning
+
+- Pacote `cmdk` instalado mas BarcodeDetector NÃO usado em nenhum lugar (`grep` zero ocorrências em `src/`)
+- Único scanner é OCR Tesseract para lote/validade no recebimento (`LoteScannerOCR`)
+- Briefing afirma "BarcodeDetector API" como integração — **aspiracional, não implementado**
+
+### Touch targets
+
+- `index.css:228-230`: `button, a, [role="button"] { min-height: 32px; }` aplicado globalmente
+- `button.tsx`: `default h-9 (36px)`, `sm h-8 (32px)`, `lg h-10 (40px)`, `icon h-9 w-9 (36px)`
+- **Nenhuma variante atinge 44px**, o que viola o mínimo WCAG AA para uso com luva em chão de fábrica (briefing pede 44px+)
+
+### Toast / feedback
+
+- Dois sistemas coexistem: `Toaster` (Radix-shadcn) em `components/ui/toaster.tsx` e `Sonner` em `components/ui/sonner.tsx`, ambos montados em `App.tsx:160-161`
+- Auditar inconsistência de invocação (`toast()` de sonner vs `useToast()` de radix-shadcn)
+
+### Logger
+
+- `src/lib/logger.ts` — wrapper estruturado com níveis (info/error/critical), usado consistente em AuthContext
+
+### Convenções de código
+
+- Pages em PascalCase (`AdminReposicaoCockpit.tsx`)
+- Hooks em camelCase com prefixo `use` (`useUnifiedOrder.ts`)
+- Idioma: **português brasileiro** em rotas (`/recebimento`, `/reposicao`, `/tintometrico`) **e** em código (estados, labels, comments, nomes de funções tipo `agruparPorMes`)
+- Imports absolutos via alias `@/` configurado em `vite.config.ts:92`
+- Tabelas Supabase com nomes em `snake_case` português: `eventos_outlier`, `pedido_compra_sugerido`, `fornecedor_aumento_anunciado`, `picking_tasks`, `nfe_recebimentos`, etc.
+
+---
+
+## 6. Princípios não-negociáveis (do briefing)
+
+1. **Offline-first em picking e recebimento** — hoje não implementado
+2. **Latência percebida <100ms em scan de barcode** — hoje sem barcode
+3. **Densidade alta em telas operacionais (B2B, não consumer)** — `density-compact` global é direção correta
+4. **WCAG AA mínimo, AAA em críticas** — focus-visible OK; touch targets abaixo do mínimo
+5. **Mobile-first em chão de fábrica, desktop-first em telas analíticas** — Shell atual é desktop-first em ambos
+6. **Cmd-k global, atalhos consistentes (j/k navegação, esc cancela, e edit, / busca)** — hoje inexistente
+
+---
+
+## 7. Referências de UX a usar como benchmark
+
+Conforme briefing oficial:
+
+- **Linear** — velocidade percebida, command palette, optimistic UI, atalhos descobríveis
+- **Notion** — cmd-k, hierarquia, in-context editing
+- **Carbon Design System (IBM)** — densidade B2B
+- **Shopify Polaris** — operacional B2B
+- **Retool** — internal tools, tabelas densas, bulk actions
+
+**Anti-referências (não usar)**: Material Design 3 (consumer-grade), aesthetic Stripe landing, Bootstrap genérico.
+
+---
+
+## 8. Perfis de usuário (do briefing) e suas restrições
+
+| Persona              | Plataforma            | Restrições reais                                         |
+| -------------------- | --------------------- | -------------------------------------------------------- |
+| Separador almox.     | Mobile/handheld       | Luva, ambiente ruidoso, luz variável, Wi-Fi ruim, 1 mão  |
+| Conferente           | Desktop + teclado     | Densidade altíssima, foco em volume                      |
+| Comprador            | Desktop               | Análise tipo planilha, comparações                       |
+| Vendedor externo     | Mobile, frequente offline | No carro, dirigindo entre clientes                   |
+| Gestão               | Desktop               | Dashboards, KPIs, drill-down                             |
+
+> Hoje o sistema **não diferencia** essas personas no role principal — a UX assume um staff genérico. Propor diferenciação onde a tela exigir.
+
+---
+
+## 9. Auditoria UX (entregue)
+
+Quatro fases concluídas. Artefatos em `docs/ux-audit/`:
+
+- ✅ **Fase 0** — Setup + este CLAUDE.md
+- ✅ **Fase 1** — Inventário de telas em [docs/ux-audit/01-inventario.md](docs/ux-audit/01-inventario.md)
+- ✅ **Fase 2** — Auditoria heurística (Nielsen + critérios de domínio D1-D6) das 10 telas top em [docs/ux-audit/02-heuristica.md](docs/ux-audit/02-heuristica.md)
+- ✅ **Fase 3** — Roadmap ICE com top 20 intervenções em [docs/ux-audit/03-roadmap.md](docs/ux-audit/03-roadmap.md)
+- ✅ **Fase 4** — Execução completa em [docs/ux-audit/04-execucao.md](docs/ux-audit/04-execucao.md) (20/20 itens entregues; alguns como scaffold pendente decisão de produto/schema)
+
+### Padrões e infra novos disponíveis para uso geral
+
+Resultado da Fase 4 — usar nas próximas features:
+
+- **Atalhos**: `useRegisterShortcuts({ keys, label, group, handler })` em qualquer página. Dialog `?` global no shell mostra automaticamente.
+- **Cmd-K**: `useRegisterCommands([{ id, label, group, perform }])` para contribuir comandos contextuais à palette.
+- **Filtros sharable**: `useUrlState({ search: '', status: 'all' })` substitui useState com sync URL (replace, sem PII).
+- **Optimistic UI**: `useOptimisticMutation({ queryKey, optimisticUpdate, successToast, errorToast })` em vez de useMutation cru para latência <100ms.
+- **Touch-friendly**: `<Button size="touch" />` (44px) ou `size="balcao"` (56px) em telas mobile/touchscreen.
+- **Empty states**: `<EmptyState tone="operational" />` é o default B2B; `tone="friendly"` para customer-facing.
+- **Skeletons**: `<PageSkeleton variant="cockpit | list | form | detail" />` em vez de spinner.
+- **Status colors**: classes `text-status-success/warning/error/info` em vez de `text-emerald-600` etc.
+- **Toast**: `import { toast } from 'sonner'` é o canônico; `useToast` antigo continua via wrapper (legado).
+- **Network**: `useNetworkStatus()` e `<NetworkStatusIndicator />` (montado no shell). Para fila offline: `enqueue()`/`flush()` de `@/lib/offline-queue`.
+- **Bulk**: `useBulkSelection(orderedIds)` + `<BulkActionsBar count actions />` para tabelas com seleção múltipla.
+
+### Convenções pós-auditoria
+
+- **Não criar novos `useState` para filtros** em telas de lista — use `useUrlState`.
+- **Não escrever `text-emerald-600` / `text-red-600` etc.** em código novo — use `text-status-*`.
+- **Não criar novos atalhos via listener `keydown` solto** — use `useRegisterShortcuts`.
+- **Não usar `<Loader2 spin />` centralizado** como fallback de página inteira — use `PageSkeleton`.
+- **Não montar novo Toaster** — só Sonner está ativo no AppShell.
+
+---
+
+## 10. Bugs/contradições/débitos detectados (fora do escopo de UX)
+
+Levantados durante a Fase 0; **não consertar agora**, apenas registrar:
+
+- **Rename `Afiação Colacor` → `Colacor`** em `src/contexts/CompanyContext.tsx:13` — Colacor é hoje o nome-mãe, afiação virou módulo. Procurar referências em telas/badges também.
+- **Branding stale**: `index.html` ainda diz "Colacor - Afiação Profissional" e PWA manifest tem `name: "Colacor - Afiação Profissional"` (`vite.config.ts:27`). Atualizar para refletir o B2B-OS multi-empresa Colacor.
+- **Logo da sidebar**: `Scissors` (tesoura) + label "Central" (`AppShell.tsx:331-337`) — visualmente ainda alinhado ao escopo afiação original. Reavaliar identidade visual.
+- **Bell ornamental**: botão de notificações no topbar (`AppShell.tsx:458-460`) não tem `onClick`, não tem badge — é apenas decoração.
+- **BottomNav morta**: `BottomNav.tsx:34` faz `if (insideShell) return null;` — efetivamente desabilita a navegação inferior mobile.
+- **Dois sistemas de toast** montados simultaneamente (`Toaster` + `Sonner`) — inconsistência futura provável.
+- **`density-compact` global** com targets de 32px conflita com WCAG/uso com luva em telas mobile operacionais.
+- **Workbox `NetworkOnly` para picking e orders** contradiz o princípio offline-first declarado no briefing.
+- **`useUserRole.ts` duplica `AppRole` type** já exportado por `AuthContext.tsx` — manter como fonte única.
+- **`isCustomer` em useUserRole** considera `customer` mas `isStaff` lá ignora `master` (`useUserRole.ts:70-71`) — divergente da definição em AuthContext (que inclui master em isStaff). Pode ser bug sutil de permissão.
+
+---
+
+## 11. Premissas de auditoria (confirmadas 2026-05-13)
+
+Sem perguntas pendentes. Tudo confirmado pelo briefing oficial:
+
+- **Empresas**: Colacor (indústria, vende industrializados) · Oben (distribuidora, compra e revende) · Colacor SC (serviços). `Afiação Colacor` no código vai virar `Colacor` em rename futuro.
+- **5 personas operacionais** mapeadas via roles existentes + `commercial_roles` + futuro "departamento" (ver §5). Auditoria UX assume persona dominante conhecida por tela.
+- **Offline-first em picking e recebimento**: gap crítico (Workbox hoje `NetworkOnly`). Propor no roadmap.
+- **<100ms percebido em scan de barcode**: zero código. Propor implementação com optimistic UI.
+- **Densidade alta operacional**: `density-compact` global é direção correta; auditar onde ainda é "consumer-grade" (`EmptyState.tsx`, `BottomNav.tsx`, `Header.tsx` legado).
+- **WCAG AA mínimo, AAA em críticas**: focus-visible OK; **touch-targets 32px globais ficam abaixo** — propor variante 44px+ para telas mobile operacionais (separador, vendedor externo). Confirmado.
+- **Mobile-first em chão, desktop-first em analítico**: AppShell hoje é desktop-first em ambos — auditar telas mobile-críticas.
+- **Cmd-k global + atalhos consistentes**: `cmdk` instalado, `Command` shadcn presente, nada montado. Propor.
+- **Optimistic UI em mutações operacionais**: princípio do briefing — auditar uso de `onMutate`/`onError` rollback no React Query (hoje esparso).
+- **RLS em todas as tabelas**: fora do escopo desta auditoria UX. Se cruzar com tabela sem RLS, registro em "Observações fora do escopo" da fase.
+- **Inspirações**: Linear · Notion · Carbon (IBM) · Polaris · Retool. DesignSystem.tsx atual declara HubSpot Canvas + Gong — realinhar.
+
+### Glossário — termos que vão aparecer no roadmap
+
+Pra ficar claro quando os termos entrarem na Fase 3:
+
+- **Cmd-K (command palette)** — overlay de busca/comando que abre com `⌘K` ou `Ctrl+K`. Permite navegar para qualquer tela, executar ação ou buscar registro digitando 2-3 letras. É o padrão de Linear, Notion, Slack, Raycast: substitui menu, busca e atalhos numa única superfície. No nosso caso já temos a base (`cmdk` lib + `Command` shadcn), falta montar no AppShell com registry de comandos por persona.
+- **BarcodeDetector API** — API nativa do navegador (Chrome/Edge/Android) que lê códigos de barras e QR direto da câmera, sem biblioteca pesada nem servidor. Latência típica <50ms. Substitui ZXing/Quagga e é o caminho moderno pra picking/recebimento. Tem fallback necessário para Safari/iOS onde a API ainda não está estável.
+- **Optimistic UI** — atualizar a tela imediatamente como se a operação tivesse dado certo, e só reverter se o servidor recusar. No React Query: `useMutation({ onMutate, onError })`. Crítico para scan/picking — sem isso o usuário espera 200-800ms a cada bipe.
+- **FEFO** (First Expire, First Out) — termo já no domínio: priorizar saída do lote com validade mais próxima. Já implementado em `RecebimentoConferencia` e visível como KPI em `AdminEstoquePicking` (lote_fefo).
+
+Tudo isso vira critério ativo da Fase 2 (heurística D1–D6) e priorização ICE da Fase 3.

--- a/docs/ux-audit/01-inventario.md
+++ b/docs/ux-audit/01-inventario.md
@@ -1,0 +1,301 @@
+# Fase 1 — Inventário de telas
+
+> Data: 2026-05-13 · 119 rotas autenticadas + 3 públicas, mapeadas a partir de [src/App.tsx](../../src/App.tsx) e [src/components/AppShell.tsx](../../src/components/AppShell.tsx).
+
+## Legenda
+
+- **Perfil primário** — persona dominante (separador / conferente / comprador / vendedor externo / gestão / operador tintométrico / cliente / staff afiação / master). Algumas telas são compartilhadas; nesse caso destaco a persona crítica.
+- **Densidade** — alta (B2B operacional, planilha/tabela), média (admin/CRUD), baixa (consumer-grade ou dashboard).
+- **Plataforma** — mobile / desktop / ambos (responsivo real).
+- **Freq.** — alta (uso diário) / média (semanal) / baixa (mensal ou eventual).
+- **Crít.** — Operação para por 1h se essa tela cair? **Sim / Não**.
+
+---
+
+## 1. Home & autenticação
+
+| Rota | Componente | Perfil primário | Jornada (1 frase) | Densidade | Plataforma | Freq. | Crít. |
+|---|---|---|---|---|---|---|---|
+| `/` | Index | staff + cliente (fork) | Porta de entrada — staff vê pedidos pendentes, customer vê dashboard de OS | média | ambos | alta | Não |
+| `/auth` | Auth | qualquer | Login + signup com aprovação fail-closed | baixa | ambos | alta | Sim |
+| `/reset-password` | ResetPassword | qualquer | Reset de senha por email | baixa | ambos | baixa | Não |
+| `*` | NotFound | qualquer | Fallback 404 | baixa | ambos | baixa | Não |
+| `/executive/dashboard` | ExecutiveDashboard | gestão (master) | Visão estratégica multi-empresa | baixa (KPI) | desktop | média | Não |
+
+---
+
+## 2. Cliente final — afiação de ferramentas
+
+> Persona predominante: **cliente** (CNPJ/CPF de marcenaria ou serralheria) usando mobile.
+
+| Rota | Componente | Perfil | Jornada | Dens. | Plat. | Freq. | Crít. |
+|---|---|---|---|---|---|---|---|
+| `/orders` | Orders | cliente + staff | Lista de OS abertas/finalizadas | média | ambos | alta | Sim |
+| `/orders/:id` | OrderDetail | cliente + staff | Detalhe da OS com chat e timeline | média | ambos | alta | Sim |
+| `/new-order` | UnifiedOrder | cliente + staff | Wizard de criação de OS (escolha ferramentas + endereço + agendamento) | média | ambos | alta | Sim |
+| `/tools` | Tools | cliente | Gerencia ferramentas cadastradas do cliente | média | mobile | média | Não |
+| `/tools/:toolId` | ToolHistory | cliente | Histórico de afiações de uma ferramenta | baixa | mobile | média | Não |
+| `/tools/:toolId/reports` | ToolReports | cliente | Relatórios de uso/economia da ferramenta | baixa | desktop | baixa | Não |
+| `/tool/:toolId` | ToolPublicHistory (pública) | qualquer com link | QR pública pra histórico da ferramenta | baixa | mobile | baixa | Não |
+| `/profile` | Profile | cliente + staff | Edita dados pessoais/empresa | baixa | ambos | baixa | Não |
+| `/addresses` | Addresses | cliente | CRUD de endereços de coleta | baixa | mobile | baixa | Não |
+| `/support` | Support | cliente | Canal de suporte (chat/contato) | baixa | mobile | baixa | Não |
+| `/loyalty` | Loyalty | cliente | Programa de fidelidade — pontos e tiers | baixa | mobile | baixa | Não |
+| `/gamification` | Gamification | cliente | Conquistas e certificados | baixa | mobile | baixa | Não |
+| `/training` | Training | cliente | Treinamentos publicados | baixa | ambos | baixa | Não |
+| `/savings` | SavingsDashboard | cliente | Economia gerada por afiar vs comprar | baixa | desktop | baixa | Não |
+| `/recurring-schedules` | RecurringSchedules | cliente | Agendamentos recorrentes de coleta | média | desktop | baixa | Não |
+
+---
+
+## 3. Admin de afiação (operação interna do serviço)
+
+> Persona: **staff afiação** (operador interno, gestão da Colacor SC).
+
+| Rota | Componente | Perfil | Jornada | Dens. | Plat. | Freq. | Crít. |
+|---|---|---|---|---|---|---|---|
+| `/admin` | Admin | staff | Hub admin antigo (provavelmente legacy) | média | desktop | média | Não |
+| `/admin/approvals` | AdminApprovals | master | Aprova novos cadastros pendentes | média | desktop | média | Sim |
+| `/admin/customers` | AdminCustomers | staff comercial | Lista/busca clientes, ficha 360 | alta | desktop | alta | Sim |
+| `/admin/customers/:customerId` | AdminCustomers | staff comercial | Ficha individual do cliente | média | desktop | alta | Sim |
+| `/admin/orders/:id` | AdminOrderDetail | staff afiação | Detalhe da OS interna, mudança de status, chat | alta | desktop | alta | Sim |
+| `/admin/orders/:id/quality` | QualityChecklist | staff afiação | Checklist de qualidade pré-envio | média | desktop | alta | Sim |
+| `/admin/demand-forecast` | AdminDemandForecast | gestão | Previsão de demanda (modelo) | baixa | desktop | baixa | Não |
+| `/admin/route-planner` | AdminRoutePlanner | gestão logística | Planejamento de rota com Leaflet (nearest-neighbor) | média | desktop | média | Sim |
+| `/admin/monthly-reports` | AdminMonthlyReports | gestão | Relatórios mensais consolidados | baixa | desktop | baixa | Não |
+| `/admin/productivity` | AdminProductivity | gestão | Produtividade por operador | média | desktop | baixa | Não |
+| `/admin/loyalty` | AdminLoyalty | gestão | Configura programa de fidelidade | média | desktop | baixa | Não |
+| `/admin/gamification` | AdminGamification | gestão | Configura conquistas/badges | média | desktop | baixa | Não |
+| `/admin/training` | AdminTraining | gestão | Cadastra/edita treinamentos | média | desktop | baixa | Não |
+| `/admin/price-table` | AdminPriceTable | gestão | Tabela de preços de afiação | alta | desktop | média | Sim |
+| `/admin/analytics-sync` | AdminAnalyticsSync | master | Sincronização de analytics | baixa | desktop | baixa | Não |
+| `/admin/ajuda` | AdminAjuda | staff | Central de ajuda interna | baixa | ambos | baixa | Não |
+| `/admin/des/trimestre-atual` | AdminDesTrimestreAtual | gestão | DES — desempenho trimestre atual | baixa | desktop | média | Não |
+| `/admin/notificacoes` | AdminNotificacoes | gestão | Fila de notificações pendentes | média | desktop | média | Sim |
+| `/admin/portal-sayerlack` | AdminPortalSayerlack | operador tintométrico | Envio de pedidos ao portal Sayerlack | média | desktop | média | Sim |
+
+---
+
+## 4. Vendas (módulo Oben / Colacor)
+
+> Persona: **vendedor externo** (mobile, offline) + **gestão de vendas** (desktop).
+
+| Rota | Componente | Perfil | Jornada | Dens. | Plat. | Freq. | Crít. |
+|---|---|---|---|---|---|---|---|
+| `/sales` | SalesOrders | vendedor + gestão | Lista de pedidos de venda com filtros e status | alta | ambos | alta | Sim |
+| `/sales/products` | SalesProducts | vendedor | Catálogo de produtos disponíveis | alta | ambos | alta | Sim |
+| `/sales/new` | UnifiedOrder | vendedor | Criação de pedido (mesmo wizard de afiação) | média | ambos | alta | Sim |
+| `/sales/print` | SalesPrintDashboard | gestão | Painel de impressão em lote de pedidos | média | desktop | média | Não |
+| `/sales/quotes` | SalesQuotes | vendedor | Cotações abertas/enviadas | alta | ambos | alta | Sim |
+| `/sales/edit/:id` | SalesOrderEdit | vendedor + gestão | Edita pedido existente | média | desktop | alta | Sim |
+| `/vendas/ferramentas` | VendasFerramentas | vendedor | Ferramentas de venda (calculadoras, scripts) | média | ambos | média | Não |
+| `/unified-order` | → redirect `/sales/new` | — | — | — | — | — | — |
+
+---
+
+## 5. Farmer / Inteligência comercial
+
+> Persona: **vendedor externo + gestão comercial**. Conjunto que parece ser CRM tipo "customer farming" (cross-sell, copilot de bundle, plano tático). Heavy em IA.
+
+| Rota | Componente | Perfil | Jornada | Dens. | Plat. | Freq. | Crít. |
+|---|---|---|---|---|---|---|---|
+| `/farmer` | FarmerDashboard | gestão comercial | KPIs do farming (carteira, retenção, IPF) | média | desktop | alta | Não |
+| `/farmer/calls` | FarmerCalls | vendedor | Fila de ligações sugeridas | alta | ambos | alta | Sim |
+| `/farmer/governance` | FarmerGovernance | gestão comercial | Regras e experimentos do farming | média | desktop | baixa | Não |
+| `/farmer/recommendations` | FarmerRecommendations | vendedor | Recomendações de oferta por cliente | alta | ambos | alta | Sim |
+| `/farmer/locc` | FarmerLOCC | gestão comercial | Linha do Cliente / LOCC | média | desktop | média | Não |
+| `/farmer/bundles` | FarmerBundles | vendedor | Bundles sugeridos para upsell | média | ambos | média | Não |
+| `/farmer/copilot` | FarmerCopilot | vendedor | Copilot IA pra abordagem do cliente | média | ambos | média | Não |
+| `/farmer/tactical-plan` | FarmerTacticalPlan | gestão comercial | Plano tático trimestral | média | desktop | baixa | Não |
+| `/farmer/ipf` | FarmerIPFDashboard | gestão comercial | IPF (Índice de Performance do Farmer) | média | desktop | média | Não |
+| `/coaching` | CoachingSPIN | gestão comercial | Coaching SPIN selling com vendedores | baixa | desktop | baixa | Não |
+
+---
+
+## 6. Estoque (picking + recebimento)
+
+> Personas: **separador** (mobile/luva), **conferente** (desktop/teclado), **operador almox**.
+
+| Rota | Componente | Perfil | Jornada | Dens. | Plat. | Freq. | Crít. |
+|---|---|---|---|---|---|---|---|
+| `/admin/estoque/picking` | AdminEstoquePicking | separador + gestão | Lista de tasks de picking, FEFO compliance, scan endereço/SKU | alta | mobile + desktop | alta | **Sim** |
+| `/admin/estoque/recebimento` | AdminEstoqueRecebimento | conferente + gestão | Dashboard de recebimentos em aberto | alta | desktop | alta | Sim |
+| `/recebimento` | Recebimento | conferente | Lista de NF-e a receber | alta | desktop | alta | **Sim** |
+| `/recebimento/:id` | RecebimentoConferencia | conferente | Conferência item-a-item com OCR de lote, FEFO, divergência | alta | desktop + mobile | alta | **Sim** |
+| `/nfe-receipt` | NfeReceipt | almoxarife | Upload de NF-e XML/PDF e parser | média | desktop | alta | **Sim** |
+| `/producao` | ProductionOrders | operador fábrica | Ordens de produção (Colacor abrasivos) | alta | desktop | alta | Sim |
+| `/admin/sku-mapeamento` | AdminSkuMapeamento | comprador + gestão | Mapeamento de SKUs entre fornecedor/Omie/interno | alta | desktop | média | Sim |
+
+---
+
+## 7. Reposição inteligente (compras ABC-XYZ)
+
+> Persona: **comprador** (desktop, análise diária). 19 telas. Núcleo da operação Oben.
+
+| Rota | Componente | Perfil | Jornada | Dens. | Plat. | Freq. | Crít. |
+|---|---|---|---|---|---|---|---|
+| `/admin/reposicao/cockpit` | AdminReposicaoCockpit | comprador | **Cockpit central** — sugestões do dia, alertas, decisões de compra (2210 linhas) | alta | desktop | alta | **Sim** |
+| `/admin/reposicao/pedidos` | AdminReposicaoPedidos | comprador | Pedidos de compra sugeridos hoje aguardando aprovação | alta | desktop | alta | **Sim** |
+| `/admin/reposicao/revisao` | AdminReposicaoRevisao | comprador | Revisão fina de itens antes do disparo | alta | desktop | alta | Sim |
+| `/admin/reposicao/alertas` | AdminReposicaoAlertas | comprador | Outliers e eventos críticos (estoque negativo, ruptura iminente) | alta | desktop | alta | Sim |
+| `/admin/reposicao/aplicacao` | AdminReposicaoAplicacao | comprador | Aplicação em lote de parâmetros/políticas | alta | desktop | média | Sim |
+| `/admin/reposicao/grupos-producao` | AdminReposicaoGruposProducao | comprador | Grupos de produção (compra conjunta) | média | desktop | média | Não |
+| `/admin/reposicao/sla-fornecedor` | AdminReposicaoSlaFornecedor | comprador | SLA por fornecedor (lead time, fillrate) | alta | desktop | média | Não |
+| `/admin/reposicao/cadeia-logistica` | AdminReposicaoCadeiaLogistica | comprador + gestão | Visão da cadeia logística | média | desktop | baixa | Não |
+| `/admin/reposicao/promocoes` | AdminReposicaoPromocoes | comprador | Lista de promoções recebidas/aplicadas | alta | desktop | alta | Sim |
+| `/admin/reposicao/promocoes/novo` | AdminReposicaoPromocaoDetail | comprador | Novo lançamento de promoção | média | desktop | média | Sim |
+| `/admin/reposicao/promocoes/:id` | AdminReposicaoPromocaoDetail | comprador | Editar promoção | média | desktop | média | Sim |
+| `/admin/reposicao/aumentos` | AdminReposicaoAumentos | comprador | Aumentos anunciados por fornecedores | alta | desktop | alta | Sim |
+| `/admin/reposicao/aumentos/novo` | AdminReposicaoAumentoDetail | comprador | Novo aumento (com vigência) | média | desktop | média | Sim |
+| `/admin/reposicao/aumentos/:id` | AdminReposicaoAumentoDetail | comprador | Editar aumento | média | desktop | média | Sim |
+| `/admin/reposicao/oportunidades` | AdminReposicaoOportunidades | comprador | Oportunidades econômicas detectadas hoje | alta | desktop | alta | Sim |
+| `/admin/reposicao/negociacao-paralela` | AdminReposicaoNegociacaoParalela | comprador | Sugestões de negociação paralela ativa | alta | desktop | alta | Sim |
+| `/admin/reposicao/parametros` | AdminReposicaoParametros | comprador + gestão | Parâmetros matemáticos da reposição | alta | desktop | média | Sim |
+| `/admin/reposicao/mercado` | AdminReposicaoMercado | comprador + gestão | Inteligência de mercado (preço de concorrente) | média | desktop | baixa | Não |
+| `/admin/reposicao/cadastros` | AdminReposicaoCadastros | comprador + gestão | Cadastros e config do módulo | média | desktop | baixa | Não |
+| `/admin/reposicao/historico` | AdminReposicaoHistorico | comprador + gestão | Histórico de decisões e disparos | média | desktop | baixa | Não |
+
+---
+
+## 8. Financeiro (cockpit CFO + Omie)
+
+> Persona: **gestão financeira (CFO/controller)**. 13 telas. Sync Omie ERP.
+
+| Rota | Componente | Perfil | Jornada | Dens. | Plat. | Freq. | Crít. |
+|---|---|---|---|---|---|---|---|
+| `/financeiro` | FinanceiroDashboard | gestão financeira | Dashboard geral entrada | média | desktop | alta | Não |
+| `/financeiro/cockpit` | FinanceiroCockpit | CFO | **Cockpit CFO** — caixa, DRE caixa, rentabilidade | alta | desktop | alta | Sim |
+| `/financeiro/gestao` | FinanceiroGestao | gestão financeira | Hub de operações financeiras | alta | desktop | alta | Sim |
+| `/financeiro/analise` | FinanceiroAnalise | gestão financeira | Análises ad-hoc e config | média | desktop | média | Não |
+| `/financeiro/analytics` | FinanceiroAnalytics | CFO | Analytics financeiro avançado | média | desktop | média | Não |
+| `/financeiro/sync` | FinanceiroSync | gestão financeira | Status e disparo de sync Omie | média | desktop | média | Sim |
+| `/financeiro/mapping` | FinanceiroMapping | controller | Mapeamento conta Omie ↔ interno | alta | desktop | baixa | Não |
+| `/financeiro/capital-giro` | FinanceiroCapitalGiro | CFO | Análise de capital de giro | média | desktop | média | Sim |
+| `/financeiro/fechamento` | FinanceiroFechamento | controller | Fechamento mensal | alta | desktop | média | Sim |
+| `/financeiro/conciliacao` | FinanceiroConciliacao | controller | Conciliação bancária | alta | desktop | alta | Sim |
+| `/financeiro/orcamento` | FinanceiroOrcamento | CFO + gestão | Orçamento e budget vs realizado | alta | desktop | média | Não |
+| `/financeiro/intercompany` | FinanceiroIntercompany | controller | Movimentações intercompany (Colacor/Oben/SC) | alta | desktop | média | Sim |
+| `/financeiro/tributario` | FinanceiroTributario | controller | Visão tributária por regime | alta | desktop | média | Não |
+
+---
+
+## 9. Tintométrico (SAYERSYSTEM, ~477k fórmulas)
+
+> Persona: **operador tintométrico** (balcão, desktop touchscreen) + **gestão** (config).
+
+| Rota | Componente | Perfil | Jornada | Dens. | Plat. | Freq. | Crít. |
+|---|---|---|---|---|---|---|---|
+| `/tintometrico` | TintDashboard | gestão tinta | Visão geral, erros de sync, fórmulas/dia | média | desktop | alta | Sim |
+| `/tintometrico/catalogo` | TintCatalogo | operador + gestão | Catálogo de fórmulas + preços | alta | desktop touchscreen | alta | **Sim** |
+| `/tintometrico/formulas` | TintFormulas | operador tintométrico | **Busca fórmula** durante atendimento (~477k) | alta | desktop touchscreen | alta | **Sim** |
+| `/tintometrico/corantes` | TintCorantes | gestão tinta | Cadastro de corantes e bases | alta | desktop | média | Sim |
+| `/tintometrico/precos` | TintPricing | gestão tinta | Preços por fórmula/litragem | alta | desktop | média | Sim |
+| `/tintometrico/importar` | TintImport | gestão tinta | Importação SAYERSYSTEM (lote) | média | desktop | baixa | Não |
+| `/tintometrico/mapeamento` | TintMapping | gestão tinta | Mapeamento fórmula ↔ SKU | alta | desktop | baixa | Não |
+| `/tintometrico/integracao` | TintIntegracao | gestão tinta | Hub de integração | média | desktop | baixa | Não |
+| `/tintometrico/integracoes` | TintIntegrations | gestão tinta | Lista de integrações ativas (legacy?) | média | desktop | baixa | Não |
+| `/tintometrico/reconciliacao` | TintReconciliation | gestão tinta | Reconciliação de fórmulas | alta | desktop | baixa | Não |
+| `/tintometrico/sync-runs` | TintSyncRuns | gestão tinta | Logs de execução de sync | média | desktop | baixa | Não |
+| `/tintometrico/api-contract` | TintApiContract | dev/master | Contrato da API tintométrica | baixa | desktop | baixa | Não |
+
+---
+
+## 10. Governança (master/admin)
+
+| Rota | Componente | Perfil | Jornada | Dens. | Plat. | Freq. | Crít. |
+|---|---|---|---|---|---|---|---|
+| `/governance/users` | GovernanceUsers | master | CRUD de usuários | alta | desktop | média | Sim |
+| `/governance/permissions` | GovernancePermissions | master | Gerencia permissões/roles | alta | desktop | baixa | Sim |
+| `/governance/math` | GovernanceMathParams | master | Parâmetros matemáticos globais (ABC-XYZ, EOQ, safety stock) | alta | desktop | baixa | Sim |
+| `/governance/audit` | GovernanceAudit | master | Log de auditoria | alta | desktop | baixa | Não |
+| `/governance/settings` | GovernanceSettings | master | Configurações globais do app | média | desktop | baixa | Não |
+| `/governance/companies` | GovernanceCompanies | master | Config das 3 empresas | média | desktop | baixa | Sim |
+| `/gestao/admin` | GestaoAdmin | master | Hub de admin/relatórios consolidados | média | desktop | média | Não |
+| `/gestao/governanca` | GestaoGovernanca | master | Hub de governança consolidado | média | desktop | baixa | Não |
+
+---
+
+## 11. Inteligência / IA / Performance
+
+| Rota | Componente | Perfil | Jornada | Dens. | Plat. | Freq. | Crít. |
+|---|---|---|---|---|---|---|---|
+| `/intelligence` | IntelligenceDashboard | gestão | Dashboard de inteligência cross-módulo | média | desktop | média | Não |
+| `/ai-ops` | AIops | gestão | Operações de IA — modelos, prompts, runs | média | desktop | baixa | Não |
+| `/performance` | PerformanceHub | gestão | Hub de performance multi-time | média | desktop | média | Não |
+
+---
+
+## 12. Config / Documentação
+
+| Rota | Componente | Perfil | Jornada | Dens. | Plat. | Freq. | Crít. |
+|---|---|---|---|---|---|---|---|
+| `/settings` | SettingsConfig | qualquer | Preferências do usuário | baixa | ambos | baixa | Não |
+| `/design-system` | DesignSystem | dev | Documentação do design system | média | desktop | baixa | Não |
+| `/ux-rules` | UXRules | dev | Regras de UX | baixa | desktop | baixa | Não |
+| `/docs` | TechnicalDocs | dev | Docs técnicas | baixa | desktop | baixa | Não |
+
+---
+
+## Sumário quantitativo
+
+- **Total**: 119 rotas autenticadas + 3 públicas
+- **Crítica (Sim)**: 53 rotas (~45%) — concentradas em Estoque, Reposição, Financeiro, Vendas, Tintométrico
+- **Alta frequência**: 36 rotas (~30%)
+- **Mobile primário**: 7 rotas (Picking + boa parte da operação cliente afiação + Vendedor externo no farmer/sales)
+- **Desktop touchscreen** (balcão): 2 rotas (TintFormulas, TintCatalogo)
+
+---
+
+## Top 10 candidatas à Fase 2 (heurística)
+
+Critério: **criticidade SIM + frequência ALTA + persona operacional distinta** (cobrir as 5 personas-chave para que a análise não fique monocultura). Em parênteses, persona que vai pilotar a análise.
+
+| # | Rota | Componente | Persona | Justificativa de seleção |
+|---|---|---|---|---|
+| 1 | `/admin/estoque/picking` | AdminEstoquePicking | **Separador** (mobile/luva) | Única tela mobile-crítica com scan + FEFO. Falha = chão para. |
+| 2 | `/recebimento/:id` | RecebimentoConferencia | **Conferente** (desktop+OCR) | Conferência item-a-item de NF-e — gargalo diário do almox. |
+| 3 | `/admin/reposicao/cockpit` | AdminReposicaoCockpit | **Comprador** | 2210 linhas — coração da decisão de compra. Maior tela analítica densa. |
+| 4 | `/admin/reposicao/pedidos` | AdminReposicaoPedidos | **Comprador** | Aprovação diária dos pedidos sugeridos antes do disparo. Decisão financeira direta. |
+| 5 | `/sales` | SalesOrders | **Vendedor externo / gestão vendas** | Lista densa de pedidos — ponto central da rotina comercial. |
+| 6 | `/sales/new` (= `/new-order`) | UnifiedOrder | **Vendedor externo** (mobile) | Wizard de pedido. Sem isso não emite venda. Tem que rodar offline. |
+| 7 | `/financeiro/cockpit` | FinanceiroCockpit | **CFO / gestão** | Cockpit CFO — visibilidade financeira diária do grupo. |
+| 8 | `/tintometrico/formulas` | TintFormulas | **Operador tintométrico** (touchscreen) | Busca de fórmula no balcão (~477k registros). Latência define UX de atendimento. |
+| 9 | `/nfe-receipt` | NfeReceipt | **Conferente** | Entrada de NF-e via XML/OCR — primeiro passo de tudo do almox. |
+| 10 | `/admin/customers` | AdminCustomers | **Gestão comercial** | CRM/ficha 360 — uso transversal de vendas e atendimento. |
+
+### Personas cobertas pelo top 10
+
+- **Separador**: #1 ✓
+- **Conferente**: #2, #9 ✓
+- **Comprador**: #3, #4 ✓
+- **Vendedor externo**: #5, #6 ✓
+- **Operador tintométrico**: #8 ✓
+- **Gestão (CFO / comercial)**: #7, #10 ✓
+
+Todas as 5 personas + master/gestão estão representadas. Nenhuma persona fica sem auditoria.
+
+### Telas que ficaram de fora mas merecem nota
+
+Pode valer revisitar na Fase 4 (execução) ou em rounds futuros:
+
+- `/admin/reposicao/alertas` — ponto único de outliers críticos. Subiu para nota 4★ mas perdi pra Cockpit/Pedidos por economia de horas.
+- `/recebimento` (lista) — auditável junto com `/recebimento/:id` se sobrar tempo. Padrões devem ser comuns.
+- `/admin/orders/:id` (AdminOrderDetail) — coração do staff afiação. Mas afiação é hoje um módulo menor frente ao restante.
+- `/farmer/calls` + `/farmer/recommendations` — alta frequência pro vendedor externo mas a heurística vai ter padrões duplicados com `/sales`.
+- `/financeiro/conciliacao` — alta dor operacional do controller, mas o cockpit captura os padrões macros.
+- `/producao` — ordens de produção da Colacor (abrasivos). Faltou tempo de leitura — registro como gap.
+
+---
+
+## Observações fora do escopo de UX
+
+Coisas notadas durante a varredura que não são UX mas merecem atenção em outra trilha:
+
+- **Rota duplicada conceitual**: `/tintometrico/integracoes` (TintIntegrations, plural) e `/tintometrico/integracao` (TintIntegracao, singular) coexistem. Provável uma é legado pós-consolidação.
+- **`/admin` (Admin.tsx) vs `/gestao/admin` (GestaoAdmin)**: dois hubs admin coexistem — sinal de migração incompleta.
+- **`/unified-order` redireciona para `/sales/new`**: redirect mantido por compatibilidade — provavelmente seguro de remover após dados de log mostrarem zero uso.
+- **`UnifiedOrder` é reaproveitado em `/new-order` e `/sales/new`**: bom — aliviou divergência. Mas a página em si tem 269 linhas dum hook gigante (`useUnifiedOrder` com 30k+ linhas) — auditável como refactor.
+- **`DesignSystem` cita "HubSpot Canvas + Polaris + Gong"** (já registrado em CLAUDE.md §4): realinhar nos artefatos de execução.
+- **Branding `Scissors` + "Central"** na sidebar (`AppShell.tsx:331-337`): identidade visual ainda afiação-centric.
+- **`Bell` topbar é ornamental** (sem onClick, sem badge): UX-mentira — ou implementar central de notificações, ou remover.
+- **53 rotas críticas** sem nenhuma com offline-first real (Workbox NetworkOnly em quase tudo de operação). Vai virar item top do roadmap.

--- a/docs/ux-audit/02-heuristica.md
+++ b/docs/ux-audit/02-heuristica.md
@@ -1,0 +1,477 @@
+# Fase 2 — Auditoria heurística das 10 telas top
+
+> Data: 2026-05-13 · Critérios: Nielsen H1-H10 (1-5) + Domínio D1-D6 (1-5). Para todo critério ≤3 há intervenção concreta proposta com referência visual nominal. Veredicto por tela ao final.
+
+## Como ler
+
+- **Score 5** — exemplar; serve de referência interna.
+- **Score 4** — bom, sem ação necessária.
+- **Score 3** — aceitável mas com fricção; intervenção desejada.
+- **Score 2** — falha visível; intervenção necessária.
+- **Score 1** — bloqueante; reescrita ou retrabalho profundo.
+
+## Critérios
+
+**Nielsen** — H1 status visível · H2 mundo real · H3 controle/liberdade · H4 consistência · H5 prevenção de erro · H6 reconhecimento > memória · H7 flex/eficiência · H8 minimalista · H9 recuperação de erro · H10 ajuda.
+
+**Domínio** — D1 latência percebida · D2 densidade adequada · D3 ergonomia física (alvos, contraste, luva) · D4 offline resilience · D5 atalhos e cmd-k · D6 mobile vs desktop adequado.
+
+---
+
+# 1. `/admin/estoque/picking` — AdminEstoquePicking
+
+**Persona**: Separador (mobile/luva) **+** gestão (desktop). Arquivo: [src/pages/AdminEstoquePicking.tsx](../../src/pages/AdminEstoquePicking.tsx)
+
+A tela hoje é desktop-first com 4 KPIs no topo (Tasks Abertas, Pedidos Aguardando, SKUs Críticos, FEFO Compliance) e 4 abas (Picking, Estoque, Movimentações, Auditoria). Cada task expande inline para mostrar os itens com lote_fefo vs lote_separado. Não há scan visível; não há fluxo dedicado mobile do separador.
+
+| Critério | Score | Justificativa |
+|---|---|---|
+| H1 Status | 3 | KPIs claros, mas sem indicador de sync/realtime nem timestamp da última atualização. |
+| H2 Mundo real | 4 | Termos do domínio corretos (FEFO, Lote, SKU, Tasks). |
+| H3 Controle | 2 | Não há undo de operação de picking, voltar ao item anterior, nem "desfazer separação". |
+| H4 Consistência | 4 | Tabs e tabelas consistentes com shadcn padrão do projeto. |
+| H5 Prevenção | 3 | Lote separado divergente do FEFO recebe alerta visual amarelo, mas não bloqueia salvamento nem pede confirmação. |
+| H6 Reconhecimento | 2 | Sem busca por código de produto na tela de picking, sem recentes, sem sugestões de próximo SKU mais próximo no endereço. |
+| H7 Flex/eficiência | 1 | Zero atalhos. Nenhum scan. Sem bulk action. |
+| H8 Minimalista | 4 | Sem decoração; tabela densa. |
+| H9 Recup. erro | 3 | Erros viram toast genérico; sem retry ou fila para mutações falhadas. |
+| H10 Ajuda | 2 | Sem tooltip nos KPIs (o que conta como "FEFO Compliance"?), sem onboarding, sem empty state informativo. |
+| D1 Latência | 2 | Cada interação aguarda resposta Supabase; sem optimistic UI; refetch a 60s pode atrasar percepção de progresso. |
+| D2 Densidade | 4 | Compact OK no desktop; mobile fica apertado mas legível. |
+| D3 Ergonomia | 1 | Tabela inline com ChevronRight de 28px (`h-7 w-7`) é inviável com luva; sem alvos 44px+. |
+| D4 Offline | 1 | NetworkOnly no Workbox para `picking_*` — perde tudo se cair sinal. |
+| D5 Atalhos | 1 | Nenhum. |
+| D6 Mobile/desktop | 2 | Tela claramente projetada para desktop; o separador mobile fica com tabela horizontal. |
+
+**Intervenções** (para scores ≤3):
+
+- **H3** — Botão "desfazer última separação" sticky no topo do drawer item, igual ao undo flutuante do Linear (snackbar com action). Aplica-se ao último `picking_event` da task atual (3s para reverter).
+- **H5** — Quando lote informado ≠ lote_fefo, abrir modal de confirmação com motivo obrigatório (lista: "FEFO esgotado", "lote vencido", "outro"), pattern do "double-confirm" do Carbon. Bloqueio só com motivo registrado.
+- **H6** — Campo de scan focado por padrão no topo da tela mobile (autofocus, keyboard `inputmode="numeric"`, `autocomplete="off"`). Padrão das telas de PoS Shopify Polaris/POS UX kit.
+- **H7** — Atalhos no desktop: `s` foca scan, `n` próximo item, `d` divergência, `?` mostra dialog (já existe pattern em AdminReposicaoCockpit). Pra mobile, gesto swipe-right para avançar item (vaul drawer + swipe).
+- **H9** — Implementar fila offline: ao falhar mutação, push para `localStorage` queue, badge "X separações na fila" no topo, retry automático com exponential backoff. Pattern do offline-queue do Linear iOS.
+- **H10** — Tooltip explicativo em cada KPI (popover ao hover/long-press); empty state das tasks com link para "Como criar uma task de picking".
+- **D1** — `useMutation({ onMutate })` para optimistic UI: ao bipar, atualizar lista visualmente antes do roundtrip (~50ms percebido vs 200-800ms). Reverter em onError com toast e som de erro.
+- **D3** — Variante mobile dedicada "TouchPickingView": botões 56px, fonte base 16px, alto contraste, cards verticais grandes em vez de tabela, swipe para avançar. Referência visual: a tela de "Picking" do Shopify POS / Stocky.
+- **D4** — Service worker com IndexedDB para `picking_tasks` e `picking_task_items`. Stale-while-revalidate. Mutation queue persistente com sync ao reconectar (`navigator.connection.onchange`). Indicador permanente "Offline · 3 separações na fila".
+- **D5** — Ver H7.
+- **D6** — Rota dedicada `/admin/estoque/picking/mobile` ou render condicional `useIsMobile()` com layout reescrito; o desktop continua sendo o cockpit do gestor.
+
+**Veredicto**: **Reescrita necessária** para a perspectiva do separador — o cockpit do gestor pode ficar como está, mas a UX mobile do operador precisa ser uma tela própria.
+
+---
+
+# 2. `/recebimento/:id` — RecebimentoConferencia
+
+**Persona**: Conferente (desktop/teclado, eventualmente mobile no chão). Arquivo: [src/pages/RecebimentoConferencia.tsx](../../src/pages/RecebimentoConferencia.tsx)
+
+Tela de conferência item-a-item com OCR de lote (Tesseract via `LoteScannerOCR`), barra de progresso global "X de Y unidades", scanner full-screen overlay, modal de divergência, vinculação de CT-e, finalização que chama Edge function de efetivação.
+
+| Critério | Score | Justificativa |
+|---|---|---|
+| H1 Status | 5 | Excelente — barra global de progresso sticky, contador `X/Y unidades`, status badge por item. |
+| H2 Mundo real | 5 | Lote, fabricação, validade, divergência, CT-e — vocabulário fiscal correto. |
+| H3 Controle | 3 | Tem voltar e cancelar scan, mas sem "desfazer última leitura" (se bipou errado e salvou, precisa abrir modal de divergência). |
+| H4 Consistência | 4 | Padrão de Card/Sheet/Dialog consistente; toast via sonner. |
+| H5 Prevenção | 4 | Validação de chave CT-e (44 dígitos), divergência exige texto. Falta confirmação ao finalizar com itens não conferidos. |
+| H6 Reconhecimento | 4 | "Repetir último lote" salva digitação repetida — bom uso de recente. |
+| H7 Flex/eficiência | 2 | Sem atalhos (`s` scan, `r` repete último, `Enter` confirma); sem bulk action de "marcar todos OK"; sem importar lote em massa. |
+| H8 Minimalista | 4 | Densidade boa; sem decoração desnecessária. |
+| H9 Recup. erro | 3 | Toast com mensagem do servidor é exibido, mas sem retry e mutação não fica em fila. Erro de OCR não dá fallback claro. |
+| H10 Ajuda | 3 | Sem tooltip explicando "metodo: ocr vs manual", "divergência" não tem hint do que isso vai bloquear no fluxo. |
+| D1 Latência | 3 | OCR pode demorar 1-3s sem feedback granular (só "scanner full-screen"); confirmar unidade aguarda 200-500ms sem optimistic. |
+| D2 Densidade | 5 | Excelente — `max-w-2xl`, espaçamento adequado para conferente. |
+| D3 Ergonomia | 3 | Botões 36-40px no Sheet — OK no desktop, abaixo do limite mobile. Câmera OCR com luva fica dependente da preensão do device. |
+| D4 Offline | 1 | NetworkOnly no Workbox; se cair sinal no meio da NF, perde tudo. |
+| D5 Atalhos | 1 | Nenhum. |
+| D6 Mobile/desktop | 4 | Layout `max-w-2xl` funciona razoavelmente em ambos; scanner é full-screen apropriado. |
+
+**Intervenções**:
+
+- **H3** — Snackbar undo "Lote 1234 registrado · Desfazer" por 4s após cada confirmação. Pattern Linear/Gmail. Reverte o último insert em `nfe_lotes_escaneados` e decrementa `quantidade_conferida`.
+- **H7** — Atalhos: `s` abre scanner, `r` repete último lote, `Enter` confirma unidade, `d` abre divergência, `f` finaliza, `?` ajuda. Hook `useKeyboardShortcuts` já existe no projeto.
+- **H9** — Em onError do `handleConfirmUnit`, push para fila local; mostrar banner "1 leitura aguardando reenvio" e retry exponencial. Mesma pattern proposta para Picking.
+- **H10** — Adicionar `<Tooltip>` em "Divergência" explicando: "Marca o item como divergente e impede a efetivação automática até a resolução manual"; mesmo para "Vincular CT-e".
+- **D1** — Optimistic UI no `handleConfirmUnit`: avançar `quantidade_conferida` na UI antes do servidor; reverter em erro. Para o OCR, adicionar `<Progress indeterminate />` durante a captura com mensagem ("Detectando lote...", "Lendo data de validade...").
+- **D3** — Variante mobile com botões 48-56px no SheetContent (atualmente 36-40); ampliar área tocável de "Repetir último lote" e "Confirmar unidade".
+- **D4** — Persistir `nfe_lotes_escaneados` em IndexedDB; queue de mutações; indicador de online/offline no header sticky. Sem isso, conferência em armazém com sinal ruim é roleta.
+- **D5** — Ver H7.
+
+**Veredicto**: **Precisa intervenção** — base é boa, mas atalhos + offline + optimistic faltam para virar referência interna.
+
+---
+
+# 3. `/admin/reposicao/cockpit` — AdminReposicaoCockpit
+
+**Persona**: Comprador (desktop). Arquivo: [src/pages/AdminReposicaoCockpit.tsx](../../src/pages/AdminReposicaoCockpit.tsx) — 2210 linhas.
+
+Tela de comando do comprador com Sparkles header, Smart Alerts, ProcessoComprasStepper, MetricsStrip, 3 tabs (Ciclo de hoje, Aplicar no Omie, Ciclos anteriores), tabela inline editável (qtd + aprovar/rejeitar por linha), seleção bulk em "review mode", export CSV, PDF, Audit Log colapsável, **e único uso real de useKeyboardShortcuts no projeto** (`g`, `e`, `1/2/3`, `r`, `m`, `?`).
+
+| Critério | Score | Justificativa |
+|---|---|---|
+| H1 Status | 4 | Stepper visual do processo de compra; alertas inline; falta indicador de freshness ("dados de 14:32"). |
+| H2 Mundo real | 5 | "Ciclo de hoje", "Aplicar no Omie", "Confiança", "Bloqueado por guardrail" — domínio correto. |
+| H3 Controle | 4 | Aprovar/rejeitar por linha; cancelar bulk com confirmação; falta undo da aprovação inline. |
+| H4 Consistência | 4 | Boa consistência interna; algumas badges usam classes hardcoded (`bg-emerald-500/15`) em vez do token `status-success-bg`. |
+| H5 Prevenção | 4 | "Aprovar tudo automático" tem confirmação modal e exige guardrails atendidos. Bom. |
+| H6 Reconhecimento | 4 | Filtro por fornecedor/status; column visibility config persistida; recentes ausentes. |
+| H7 Flex/eficiência | 5 | **Referência interna** — atalhos `g/e/1/2/3/r/m/?`, dialog de ajuda, bulk select, CSV/PDF export. |
+| H8 Minimalista | 3 | Densidade alta mas com 7+ componentes empilhados (alerts + stepper + metrics + tabs + tabela + audit log) — risco de scroll fatigue. |
+| H9 Recup. erro | 4 | Alert de "Etapa atual indisponível · Tentar novamente" é exemplar. |
+| H10 Ajuda | 4 | Dialog de atalhos `?`; tooltips em "Confiança"; falta tooltip em métricas. |
+| D1 Latência | 4 | Mutações inline têm spinner local no botão; refetch após mudança; sem optimistic mas a percepção é rápida. |
+| D2 Densidade | 4 | Bem calibrada para comprador analítico. |
+| D3 Ergonomia | 4 | Desktop, dispensa 44px. Foco visível, contraste OK. |
+| D4 Offline | 2 | Não persiste; comprador remoto perde estado em queda de sinal. Risco moderado (não bloqueia chão). |
+| D5 Atalhos | 5 | **Referência** — replicar para outras telas. |
+| D6 Mobile/desktop | 3 | Não responde para mobile; tabela de 8+ colunas quebra em <md. Pode ser intencional, mas declarar. |
+
+**Intervenções**:
+
+- **H8** — Colapsar SmartAlertsSection e AuditLogSection por padrão (`Collapsible defaultOpen={false}`); reduzir a 1 MetricsStrip mais compacta no formato "5 KPIs em linha única" estilo Linear Insights. Permitir que o comprador feche o stepper se o ciclo do dia já passou.
+- **D4** — Persistir filtros e column-visibility já em localStorage (parece já feito — confirmar). Para resiliência maior: cachear `pedido_compra_sugerido` da data atual em IndexedDB para leitura offline (read-only quando offline; bloquear mutação com banner).
+- **D6** — Decidir: ou marca a tela explicitamente como "Apenas desktop" (banner em viewport <md), ou cria visão mobile reduzida (KPIs + lista vertical de pedidos com aprovar/rejeitar por card). Padrão Retool de "responsive containers".
+
+**Veredicto**: **Aceitável** — a melhor tela do app hoje em UX. Pequenos ajustes para scroll fatigue e mobile (se quiserem usar no celular).
+
+---
+
+# 4. `/admin/reposicao/pedidos` — AdminReposicaoPedidos
+
+**Persona**: Comprador. Arquivo: [src/pages/AdminReposicaoPedidos.tsx](../../src/pages/AdminReposicaoPedidos.tsx)
+
+Lista de pedidos sugeridos do dia com Status + Status do envio ao portal B2B (drawer rico mostrando protocolo, screenshot, retry count, próximo retry), badges de status, ações de aprovar/cancelar, mutation `reenviar_portal`.
+
+| Critério | Score | Justificativa |
+|---|---|---|
+| H1 Status | 5 | PortalBadge com "Enviando…" animado, próximo retry em distance-now PT-BR, screenshot do portal, protocolo. Excelente. |
+| H2 Mundo real | 5 | "Pendente envio", "Falha", "Aguardando", "Bloqueado por guardrail", "Cancelado (vazio)". |
+| H3 Controle | 4 | Reenvio manual com confirmação; cancelar com motivo. Falta undo de cancelamento. |
+| H4 Consistência | 4 | Mesma família visual do Cockpit; alguns badges com classes hardcoded. |
+| H5 Prevenção | 4 | AlertDialog para reenvio; mensagens explícitas. |
+| H6 Reconhecimento | 3 | Filtros existem mas sem persistência visível; recentes ausentes. |
+| H7 Flex/eficiência | 3 | Sem atalhos; sem bulk reenvio; navegação entre pedidos requer voltar. |
+| H8 Minimalista | 4 | Drawer denso mas legível. |
+| H9 Recup. erro | 5 | Mensagens granulares de erro do portal; tentativas e backoff explícitos. Referência. |
+| H10 Ajuda | 4 | Tooltip nos badges; ainda assim, "guardrail" sem explicação para o novato. |
+| D1 Latência | 4 | Mutações com spinner; queryClient.invalidateQueries após sucesso. |
+| D2 Densidade | 4 | Tabela densa correta para o perfil comprador. |
+| D3 Ergonomia | 4 | Desktop. Botões h-8/h-9. |
+| D4 Offline | 2 | Sem persistência local. |
+| D5 Atalhos | 1 | Zero. |
+| D6 Mobile/desktop | 3 | Drawer responsivo razoável; tabela quebra em <md. |
+
+**Intervenções**:
+
+- **H6** — Persistir filtros (search, fornecedor, status) em URL search params, igual padrão do TanStack Router/Linear. Permite compartilhar URL com colega ("vê esse filtro de pendentes da semana").
+- **H7** — Atalhos: `j/k` para navegar entre pedidos da lista, `Enter` abre drawer, `a` aprovar, `c` cancelar, `r` reenviar portal, `?` ajuda. Estende `useKeyboardShortcuts`. Bulk reenvio multi-select.
+- **H10** — Tooltip do termo "guardrail" com link "ver regras ativas em /admin/reposicao/parametros".
+- **D4** — Cachear lista do dia em IndexedDB para leitura offline (read-only com banner).
+- **D5** — Ver H7.
+- **D6** — Cards verticais quando viewport <md, com botões 44px+. Padrão Polaris ResourceList em mobile.
+
+**Veredicto**: **Precisa intervenção** — H1/H9 são exemplares mas faltam atalhos/persistência/offline.
+
+---
+
+# 5. `/sales` — SalesOrders
+
+**Persona**: Vendedor (mobile/desktop) + gestão de vendas. Arquivo: [src/pages/SalesOrders.tsx](../../src/pages/SalesOrders.tsx)
+
+Lista de pedidos consolidada (sales_orders + orders de afiação) com filtro por empresa (Tabs), busca por cliente/PV/item, ações compartilhar via WhatsApp, editar, excluir. `max-w-4xl` mobile-friendly. Cards verticais.
+
+| Critério | Score | Justificativa |
+|---|---|---|
+| H1 Status | 3 | Spinner inicial centralizado; sem indicador de freshness; sem skeleton. |
+| H2 Mundo real | 4 | "Rascunho", "Enviado ao Omie", "Faturado" — bom. |
+| H3 Controle | 3 | AlertDialog no excluir; sem undo após excluir; voltar via ChevronLeft. |
+| H4 Consistência | 3 | StatusBadgeSimple para afiação coexiste com Badge variant para sales — duas linguagens visuais. |
+| H5 Prevenção | 4 | Confirmação destrutiva no excluir. |
+| H6 Reconhecimento | 4 | Busca por nome/PV/item/total; tabs com labels claras. |
+| H7 Flex/eficiência | 1 | Sem atalhos, sem bulk, sem export. Vendedor com 200 pedidos faz scroll infinito. |
+| H8 Minimalista | 3 | Cada card empilha 6-7 dados (cliente + badge + data + PV + status + total + qtd itens + 3 botões) — denso mas legível. Botões `h-7 w-7` minúsculos. |
+| H9 Recup. erro | 3 | Toast no excluir; carregamento inicial só logga `console.error` sem mostrar nada para o usuário. |
+| H10 Ajuda | 2 | Empty state genérico ("Nenhum pedido encontrado"); sem CTA, sem tip. |
+| D1 Latência | 2 | Carrega TUDO de uma vez (sem paginação visível) — vendedor com carteira grande sente. |
+| D2 Densidade | 4 | Cards adequados para mobile. |
+| D3 Ergonomia | 2 | Botões `h-7 w-7` (28px) em mobile — inviável com luva ou em movimento (vendedor no carro). |
+| D4 Offline | 1 | NetworkOnly no Workbox; vendedor offline no carro perde acesso. |
+| D5 Atalhos | 1 | Zero. |
+| D6 Mobile/desktop | 4 | Layout funciona em ambos; cards adequam-se. |
+
+**Intervenções**:
+
+- **H1** — Substituir spinner único por skeleton de 5 cards (já existe `<Skeleton>` shadcn). Adicionar timestamp de freshness ("atualizado há 2 min") no header.
+- **H3** — Toast undo após exclusão (4s) que rollback a chamada `omie-vendas-sync`. Pattern Gmail.
+- **H4** — Unificar StatusBadgeSimple com Badge usando `status-*` tokens — 1 fonte da verdade para mapping de status. Ver `index.css` linhas 282-311.
+- **H7** — Atalhos: `n` novo pedido, `/` foca busca, `1/2/3/4` filtra empresa, `j/k` navega cards. Replicar pattern de Linear.
+- **H8** — Reduzir botões a `h-9 w-9` mínimo (36px) ou consolidar 3 botões em DropdownMenu (...) — pattern Polaris ResourceList.
+- **H9** — Erro de load com Alert + retry button ("Não conseguimos carregar seus pedidos. [Tentar novamente]").
+- **H10** — Empty state com CTA "Criar primeiro pedido" + ilustração leve; em busca vazia, sugerir limpar filtros.
+- **D1** — Paginação ou infinite scroll (cursor-based) em vez de carregar tudo. ~50 cards por página. React Query `useInfiniteQuery`. Adicionar `staleTime: 30s` e revalidar em foco.
+- **D3** — Botões 44px+ em mobile via media query / variante "lg" do shadcn. Ver Carbon Design touch targets recommendations.
+- **D4** — Stale-while-revalidate para `sales_orders` últimos 30d em IndexedDB; banner offline no topo.
+- **D5** — Ver H7.
+
+**Veredicto**: **Precisa intervenção** — uso diário do vendedor exige atalhos, paginação, alvos maiores e offline.
+
+---
+
+# 6. `/sales/new` (UnifiedOrder) — UnifiedOrder
+
+**Persona**: Vendedor externo (mobile, offline) + cliente (afiação). Arquivo: [src/pages/UnifiedOrder.tsx](../../src/pages/UnifiedOrder.tsx)
+
+Wizard de pedido com OrderStepper (Cliente → Itens → Revisão), 3 tabs (Oben/Colacor/Afiação), AI Assistant para staff, busca de cliente com validação de vendedor, recomendações cross-sell, CartSummaryBar com formas de pagamento, OrderSuccessDialog. Hook `useUnifiedOrder` agrega ~30k linhas de lógica.
+
+| Critério | Score | Justificativa |
+|---|---|---|
+| H1 Status | 4 | OrderStepper visível; loaders por seção; falta indicador "rascunho salvo automaticamente". |
+| H2 Mundo real | 5 | "Cliente", "Itens", "Revisão", "Forma de pagamento", "Volumes". |
+| H3 Controle | 3 | Voltar via ChevronLeft do navegador; remover item do cart OK; sem "salvar como rascunho explícito" nem desfazer adição. |
+| H4 Consistência | 4 | Tabs + Forms shadcn. AI Assistant é único em UX (microfone); destoa visualmente mas é intencional. |
+| H5 Prevenção | 3 | Validação de vendedor existe (vendedorDivergencias); falta confirmação ao sair do wizard com itens não submetidos (`beforeunload` ou modal). |
+| H6 Reconhecimento | 4 | Histórico de compras do cliente, ranking de parcelas, recommendations cross-sell — bom. |
+| H7 Flex/eficiência | 2 | Sem atalhos; busca de cliente sem `/` global; sem hotkey "+" para adicionar item. |
+| H8 Minimalista | 3 | Tela carrega muita informação simultânea (AI + busca + tabs + cart + recomendações + summary bar). Vendedor novo se perde. |
+| H9 Recup. erro | 3 | submitOrder loga e mostra toast genérico; sem fallback para retry; rascunho não persistido em offline. |
+| H10 Ajuda | 2 | Sem tooltip nos campos não óbvios ("Volumes", "Ordem de compra obrigatória"); sem hint sobre o vendedorDivergencias. |
+| D1 Latência | 3 | Múltiplas queries sequenciais (oben + colacor + customer + tools + serviços); sem optimistic ao adicionar ao cart. |
+| D2 Densidade | 3 | Adequado para desktop; mobile fica empilhado e exige scroll vertical longo. |
+| D3 Ergonomia | 3 | Botões padrão; sem variante touch-grande. Vendedor com luva grossa de transporte fica limitado. |
+| D4 Offline | 1 | NetworkOnly em sales_orders/order_items; vendedor no carro perde a sessão se cair sinal. **Maior dor desta tela.** |
+| D5 Atalhos | 1 | Zero. |
+| D6 Mobile/desktop | 3 | Layout responsivo `lg:grid-cols-3` é desktop-first; o vendedor mobile recebe a página espremida. |
+
+**Intervenções**:
+
+- **H3** — Auto-save de rascunho no localStorage a cada mudança (debounce 500ms), com chave `draft_order_{customerId}`. Ao recarregar a página com cart vazio, oferecer "Você tinha um pedido em andamento. Restaurar?".
+- **H5** — `useBeforeUnload` ou listener `beforeunload` quando `cart.length > 0 && !submitted`, com mensagem "Você tem itens não enviados. Sair mesmo assim?".
+- **H7** — Atalhos: `c` foca cliente, `/` foca produto, `+` adiciona item, `Enter` confirma quantidade, `Cmd+S` salva rascunho explícito, `Cmd+Enter` envia pedido. Padrão Linear/Notion.
+- **H8** — Reduzir AI Assistant a um botão flutuante (FAB) que abre modal — não disputa real estate principal. Recomendações compactadas em "5 sugestões" colapsável. Padrão Notion sidebar drawers.
+- **H9** — Em onError do submitOrder, manter o cart, mostrar Alert com retry button + opção "salvar rascunho local".
+- **H10** — Tooltips em "Volumes", "OC obrigatória", "Vendedor com divergência" (com link para o que isso significa).
+- **D1** — Pré-fetch dos catálogos Oben/Colacor antes do step de itens (ainda no step Cliente). Optimistic UI ao adicionar ao cart (UI atualiza, hook persiste em background).
+- **D2/D3** — Layout mobile específico: stepper colapsado, tabs verticais ou bottom sheet (vaul drawer) para itens, botões 48px+. Pattern Shopify Mobile POS.
+- **D4** — IndexedDB para draft + queue de submissão. Vendedor cria pedido offline → quando volta online, dispara mutation. Banner persistente "Trabalhando offline · 2 pedidos na fila". **Esta é a intervenção mais crítica desta tela.**
+- **D5** — Ver H7.
+- **D6** — Ver D2/D3. Mobile-first refactor — não responsive afterthought.
+
+**Veredicto**: **Reescrita necessária** para o vendedor mobile offline. O fluxo desktop-first interno está aceitável.
+
+---
+
+# 7. `/financeiro/cockpit` — FinanceiroCockpit
+
+**Persona**: CFO / Controller (desktop). Arquivo: [src/pages/FinanceiroCockpit.tsx](../../src/pages/FinanceiroCockpit.tsx)
+
+Cockpit consolidado: TransparencyBadge por empresa (% mapeado, % conciliado, status fechamento), 3 KPIs grandes (Caixa, Caixa Projetado, NCG), 4 mini cards (margens, inadimplência, aging crítico), tabela de Resultado por Empresa, Projeção 13 semanas, Top 5 inadimplentes, footer "Base dos números".
+
+| Critério | Score | Justificativa |
+|---|---|---|
+| H1 Status | 5 | TransparencyBadge é exemplar — mostra confiabilidade dos dados, % mapeado, status do fechamento. Pode virar referência. |
+| H2 Mundo real | 5 | "Margem Bruta", "NCG", "Aging Crítico", "Regime de Caixa" — vocabulário CFO. |
+| H3 Controle | 4 | DrillDown via setDrillDown; voltar fecha. Sem export do cockpit. |
+| H4 Consistência | 3 | Cores hardcoded (`text-emerald-600`, `text-red-600`, `bg-amber-50`) em vez de tokens `status-*`. Quebra dark mode parcial. |
+| H5 Prevenção | 4 | Footer "Base dos números" deixa claras as suposições. |
+| H6 Reconhecimento | 4 | Mês corrente como default; nomes curtos das empresas. |
+| H7 Flex/eficiência | 2 | Sem export PDF/Excel do cockpit; sem comparação mês anterior; sem atalhos. CFO normalmente quer levar o número para o board. |
+| H8 Minimalista | 4 | Bem organizado; alguns elementos visuais (TransparencyBadge no header) ficam apertados. |
+| H9 Recup. erro | 2 | `try/catch` silencioso em RPC e fin_confiabilidade — se a tabela não existir, **a tela carrega com dados parciais e o usuário não sabe**. |
+| H10 Ajuda | 4 | Footer explicativo é bom; faltam tooltips por KPI ("Como calculamos NCG"). |
+| D1 Latência | 3 | `loadAll` é paralelo OK, mas o for-loop sequencial de fin_confiabilidade (3 empresas) atrasa first paint. |
+| D2 Densidade | 4 | Densidade adequada a CFO. |
+| D3 Ergonomia | 5 | Desktop, sem necessidade de touch. |
+| D4 Offline | 3 | Não-crítico para CFO; mas ler último snapshot offline ajuda. |
+| D5 Atalhos | 1 | Zero. |
+| D6 Mobile/desktop | 3 | Mobile lê mas tabela 13 semanas faz scroll horizontal feio. |
+
+**Intervenções**:
+
+- **H4** — Substituir cores hardcoded por classes `status-success-*`, `status-warning-*`, `status-error-*`. Base já existe em `index.css:282-311`. Garante coerência dark mode.
+- **H7** — Botão "Exportar PDF" do cockpit inteiro (visualização print-friendly) e "Exportar XLSX" da tabela de DRE consolidada. Padrão Carbon Datagrid + Polaris export.
+- **H7** — "Comparar com mês anterior" toggle que adiciona delta % em cada KPI ("R$ 1.2M, -8% vs Abr"). Padrão Linear Insights.
+- **H9** — Banner amarelo no topo se `fin_confiabilidade` ou `fin_projecao_13_semanas` não retornaram dados — "Confiabilidade indisponível" e "Projeção indisponível" devem ser visíveis, não silenciosos. CFO precisa saber.
+- **H10** — Popover com `<Info>` em cada KPI explicando fórmula ("NCG = CR aberto - CP aberto. Próximos 30 dias.").
+- **D1** — Paralelizar fin_confiabilidade com `Promise.all`. Skeleton mais granular por bloco (não bloquear página inteira).
+- **D5** — Atalhos: `e` exporta, `r` refetch, `1/2/3` foca por empresa, `?` ajuda.
+- **D6** — Tabela de 13 semanas com `overflow-x-auto` mas em mobile vira gráfico (sparkline com tooltip) — visualização adequada ao espaço.
+
+**Veredicto**: **Aceitável** — sólida, com TransparencyBadge sendo destaque. Falta export, atalhos e fallback explícito de dados parciais.
+
+---
+
+# 8. `/tintometrico/formulas` — TintFormulas
+
+**Persona**: Operador tintométrico (desktop touchscreen, atendendo cliente em paralelo). Arquivo: [src/pages/TintFormulas.tsx](../../src/pages/TintFormulas.tsx)
+
+Catálogo de fórmulas (~477k registros) com filtros (busca por código/nome, produto, base, switch personalizadas) + tabela paginada (50/pg) + linha expansível com receita de corantes e custo calculado.
+
+| Critério | Score | Justificativa |
+|---|---|---|
+| H1 Status | 3 | Skeleton durante load; sem indicador "buscando em 477k registros". Sem timestamp de sync. |
+| H2 Mundo real | 4 | "Cor ID", "Nome cor", "Produto", "Base", "Embalagem", "Volume", "Personalizada" — vocabulário do balcão. |
+| H3 Controle | 3 | Pagination sem "ir para página X" nem "última"; voltar para topo após expandir não é automático. |
+| H4 Consistência | 3 | Cores das badges hardcoded (`bg-purple-500/10`, `bg-blue-500/10`); quebra padrão `status-*`. |
+| H5 Prevenção | 4 | Filtros bem organizados; reset do produto reseta base — bom. |
+| H6 Reconhecimento | 2 | Sem últimas fórmulas consultadas, sem favoritos do operador, sem busca por "RAL", "NCS", "Pantone" comuns no balcão. |
+| H7 Flex/eficiência | 1 | Sem atalhos; sem busca cmd-k para "achar fórmula 12345" sem entrar na tela; sem favoritar; sem copiar receita rápida. |
+| H8 Minimalista | 4 | Tabela limpa. |
+| H9 Recup. erro | 2 | Sem error boundary visível; query sem fallback explícito. Em loja, "tela em branco" é catastrófico no atendimento. |
+| H10 Ajuda | 2 | Sem tooltip explicando "personalizada", "preço CSV", "custo concentrado". Operador novato fica perdido. |
+| D1 Latência | 2 | Busca via SQL `ilike %X%` em 477k registros sem índice trigram declarado — risco de 1-3s por busca. |
+| D2 Densidade | 4 | Tabela densa apropriada. |
+| D3 Ergonomia | 1 | Touchscreen mas linhas com `cursor-pointer` 28px de altura e ChevronUp/Down 16px. Operador no balcão atendendo cliente toca errado. |
+| D4 Offline | 2 | Não cacheado; queda de sinal em loja = sem catálogo. Catálogo é semi-estático. |
+| D5 Atalhos | 1 | Zero. |
+| D6 Mobile/desktop | 3 | Layout funciona, mas é desktop-first; touchscreen do balcão precisa de ajustes. |
+
+**Intervenções**:
+
+- **H1** — Header com "X.XXX fórmulas · sincronizado há Xh". Skeleton durante load por bloco.
+- **H6** — Top bar persistente "Recentes" (últimas 10 fórmulas consultadas via localStorage) e "Favoritos" (estrela na linha). Padrão Notion / Raycast favorites.
+- **H6** — Adicionar busca por sinônimos / códigos comerciais comuns (RAL, Pantone, NCS) no campo Search com hint "Tente '7016' ou 'cinza ferro'".
+- **H7** — Cmd-K global disparado de qualquer tela com query "fórmula <código>" leva direto à expansão. Botão copy "Copiar receita" na linha expandida (texto formatado para colar no dispenser ou WhatsApp).
+- **H9** — Error boundary específica nesta página com mensagem "Catálogo temporariamente indisponível. Última versão sincronizada disponível offline." (depende de D4).
+- **H10** — Tooltips: "Personalizada" = fora do catálogo padrão SAYERSYSTEM; "Preço CSV" = preço sugerido pelo fabricante; "Custo concentrado" = custo do corante por ml.
+- **D1** — Garantir índice GIN trigram na coluna `nome_cor` e `cor_id` para `ilike` rápido. Debounce 200ms no input. Servidor com `pg_trgm`.
+- **D3** — Linhas 56px+ no touchscreen (variante densidade especial para balcão). ChevronDown maior. Tap target da linha inteira para expandir.
+- **D4** — Catálogo cacheado em IndexedDB com versionamento por `synced_at`. Permite operação 100% offline para consulta. Atualização incremental quando online.
+- **D5** — Ver H7.
+- **D6** — Renderizar variant "balcão" (touchscreen) quando viewport >= 1024 e `pointer: coarse` (touch detected).
+
+**Veredicto**: **Reescrita necessária** — coração do atendimento no balcão. Hoje é uma tabela CRUD, precisa virar "buscador de fórmula otimizado para fluxo de atendimento".
+
+---
+
+# 9. `/nfe-receipt` — NfeReceipt
+
+**Persona**: Almoxarife / conferente (desktop). Arquivo: [src/pages/NfeReceipt.tsx](../../src/pages/NfeReceipt.tsx)
+
+Tela mínima: select empresa + input número NF + botão "Processar NF-e", chama Edge function `process-nfe`, mostra log de steps com ícones success/warning/error.
+
+| Critério | Score | Justificativa |
+|---|---|---|
+| H1 Status | 4 | Loader durante chamada; ícones por step; "Processando..." no final. |
+| H2 Mundo real | 4 | "Processar NF-e" + log de etapas. Título "OBEN Recebimento NF-e" hardcoda OBEN — confunde quando seleciona Colacor. |
+| H3 Controle | 2 | Sem cancelar processamento (Edge function pode demorar 30-60s); sem histórico das últimas tentativas. |
+| H4 Consistência | 3 | Mistura emojis (✅ ❌) com ícones lucide. |
+| H5 Prevenção | 3 | Sem confirmação "vai processar NF-e 12345 da Oben?"; reprocessar mesma NF não avisa. |
+| H6 Reconhecimento | 1 | Sem histórico, sem últimas processadas, sem autocomplete de número de NF. |
+| H7 Flex/eficiência | 3 | Enter aciona o botão (bom). Sem atalho global; sem bulk de NFs. |
+| H8 Minimalista | 5 | Tela mínima e clara. |
+| H9 Recup. erro | 3 | Mensagem do erro mostrada em log; sem retry com 1 clique; sem "ver detalhes técnicos". |
+| H10 Ajuda | 2 | Sem explicação de quando usar essa tela vs `/recebimento`. |
+| D1 Latência | 3 | Processamento síncrono pode travar 30s+; usuário não tem progresso granular (só steps quando completo). |
+| D2 Densidade | 5 | Adequada. |
+| D3 Ergonomia | 4 | Botões 36-40px desktop OK. |
+| D4 Offline | 1 | Operação 100% online; não há fallback. |
+| D5 Atalhos | 2 | Só Enter. |
+| D6 Mobile/desktop | 4 | Funcional em ambos. |
+
+**Intervenções**:
+
+- **H2** — Título dinâmico: "Recebimento NF-e — {empresa selecionada}".
+- **H3/H6** — Tabela "Últimas 10 processadas" abaixo do form com status final, link para reprocessar, link para `/recebimento/:id`.
+- **H4** — Trocar emoji por ícone lucide (CheckCircle2, XCircle).
+- **H5** — Confirmar reprocessamento se a NF já foi processada na última hora.
+- **H7** — Atalhos: `/` foca número, `Enter` processa, `Esc` limpa.
+- **H9** — Botão "Tentar novamente" no Badge final de erro; link "Ver log completo" com modal de detalhes.
+- **H10** — Hint sob o botão: "Esta tela processa uma NF-e por número. Para conferência item-a-item, use Recebimento."
+- **D1** — Stream de progresso da Edge function via Supabase Realtime ou polling — mostrar steps conforme aparecem, não só no final.
+- **D4** — Não há como (depende de Edge function); sinalizar bloqueio com banner offline + estimar quando voltará.
+
+**Veredicto**: **Precisa intervenção** — utility tool simples, mas o histórico e o reprocessamento mudam UX significativamente. Rebaixar prioridade no roadmap se outras telas mais críticas demandarem horas.
+
+---
+
+# 10. `/admin/customers` — AdminCustomers
+
+**Persona**: Gestão comercial / vendedor / atendimento. Arquivo: [src/pages/AdminCustomers.tsx](../../src/pages/AdminCustomers.tsx) (vista parcial)
+
+Lista densa com tabela de clientes (nome, doc, saúde com badge, gasto mensal, dias s/ compra, prioridade), filtro por health_class via DropdownMenu, busca, drill-down para Customer360View. Tem `requires_po` toggle inline.
+
+| Critério | Score | Justificativa |
+|---|---|---|
+| H1 Status | 3 | Loader genérico; sem skeleton de tabela; sem timestamp da carteira. |
+| H2 Mundo real | 4 | "Saúde", "Gasto mensal", "Dias s/ compra", "Prioridade", "Saudável/Alerta/Crítico" — vocabulário CRM correto. |
+| H3 Controle | 3 | Voltar OK; toggle `requires_po` rollback em erro (bom); sem undo bulk. |
+| H4 Consistência | 4 | Tabela com classes `status-*` (saudavel→success, alerta→pending, critico→danger). Bom uso dos tokens. |
+| H5 Prevenção | 4 | Toggle `requires_po` com optimistic + rollback explícito. Bom padrão. |
+| H6 Reconhecimento | 3 | Filtro por saúde + search; sem filtros salvos, sem segmentação visível. |
+| H7 Flex/eficiência | 2 | Sem atalhos; sem bulk action (atribuir vendedor, exportar segmento, enviar campanha); sem export. |
+| H8 Minimalista | 3 | Coluna "Prioridade" só com número (sem contexto); algumas colunas hidden em <md/<lg sem indicação. |
+| H9 Recup. erro | 3 | Loader sem fallback de erro visível; toggle tem toast. |
+| H10 Ajuda | 2 | Sem explicação de "health_score", "priority_score" (são scores derivados de modelo). Vendedor novo não entende. |
+| D1 Latência | 3 | Carrega clientes + scores em sequência (pelo que vi); sem paginação visível. |
+| D2 Densidade | 4 | Boa para gestão; tabela compacta. |
+| D3 Ergonomia | 3 | Botões padrão; mobile esconde colunas mas a row ainda é só 40px. |
+| D4 Offline | 2 | Não cacheado. |
+| D5 Atalhos | 1 | Zero. |
+| D6 Mobile/desktop | 3 | Tabela responsiva OK; profile 360 não revisado. |
+
+**Intervenções**:
+
+- **H1** — Skeleton de 8 linhas em vez de loader; mostrar "X clientes na carteira · atualizado há Xmin".
+- **H6** — Filtros salvos em URL (sharable). Segmentos pré-definidos como chips ("Críticos sem compra 60d+", "Alta prioridade sem vendedor"). Padrão Linear / HubSpot Lists.
+- **H7** — Atalhos: `/` foca search, `j/k` navega linhas, `Enter` abre cliente, `f` filtros, `e` export. Bulk select com Shift+click + ações "atribuir vendedor", "exportar CSV", "enviar campanha". Padrão Retool table actions.
+- **H8** — Coluna "Prioridade" com mini-bar visual (0-100 progress) e tooltip "score derivado de gasto + recência + ticket médio".
+- **H9** — Error state com "Não conseguimos carregar clientes. [Recarregar]".
+- **H10** — Popover `<Info>` no header de cada coluna calculada explicando o método ("health_score: combina recência, frequência e margem dos últimos 180d").
+- **D1** — Paginação cursor-based ou virtual scroll (`@tanstack/react-virtual`) para carteiras de 1k+ clientes.
+- **D3** — Aumentar row mínima para 48px em mobile; touch target da linha inteira para drill-down.
+- **D4** — Cachear top 100 clientes do vendedor em IndexedDB para consulta offline.
+- **D5** — Ver H7.
+
+**Veredicto**: **Precisa intervenção** — base sólida; falta atalhos, segmentos salvos, bulk e tooltip dos scores derivados.
+
+---
+
+# Resumo executivo da Fase 2
+
+## Veredicto por tela
+
+| # | Tela | Veredicto |
+|---|---|---|
+| 1 | AdminEstoquePicking | **Reescrita** (perspectiva separador mobile) |
+| 2 | RecebimentoConferencia | Precisa intervenção |
+| 3 | AdminReposicaoCockpit | **Aceitável** — referência interna |
+| 4 | AdminReposicaoPedidos | Precisa intervenção |
+| 5 | SalesOrders | Precisa intervenção |
+| 6 | UnifiedOrder | **Reescrita** (vendedor mobile offline) |
+| 7 | FinanceiroCockpit | **Aceitável** |
+| 8 | TintFormulas | **Reescrita** (UX de balcão) |
+| 9 | NfeReceipt | Precisa intervenção (escopo menor) |
+| 10 | AdminCustomers | Precisa intervenção |
+
+3 reescritas, 6 intervenções, 2 aceitáveis (Cockpit Reposição e Cockpit CFO).
+
+## Padrões transversais que aparecem em ≥5 telas
+
+1. **Zero atalhos de teclado fora do AdminReposicaoCockpit** — H7 e D5 cravados em 1 em todas as outras 9 telas.
+2. **Zero offline-resilience real** — D4 cravado em 1-2 nas telas operacionais. Workbox `NetworkOnly` em quase todas as rotas críticas.
+3. **Zero optimistic UI sistemática** — D1 oscila 2-4; toda mutação aguarda roundtrip.
+4. **Touch targets abaixo de 44px** em telas mobile (`h-7 w-7`/`h-8 w-8` recorrente) — D3 com 1-3 em mobile/touchscreen.
+5. **Cores hardcoded** (`text-emerald-600`, `bg-amber-50/15`) em vez de tokens `status-*` — quebra dark mode parcial e dificulta consistência.
+6. **Empty states e error states genéricos ou silenciosos** — H9/H10 frequentemente 2-3.
+7. **Sem cmd-k global / busca global** — confirma o gap arquitetural já mapeado em CLAUDE.md §11.
+8. **Sem persistência de filtros / segmentos salvos / favoritos** — H6 frequentemente 2-3.
+
+## Referências internas (replicar para o resto do app)
+
+- `AdminReposicaoCockpit.useKeyboardShortcuts` + `ShortcutsDialog` — pattern de atalhos com dialog `?` deve virar lib do projeto.
+- `AdminReposicaoPedidos.PortalDrawer` — modelagem de status de processamento async (pendente → enviando → enviado/falha + retry exponencial + screenshot) é referência para qualquer fluxo com integração externa.
+- `FinanceiroCockpit.TransparencyBadge` — exibir confiabilidade dos dados como first-class UI é referência para qualquer dashboard com dados derivados.
+- `RecebimentoConferencia.handleRepeatLote` — reaproveitamento de input recente é UX exemplar para reduzir digitação repetitiva.
+- `RecebimentoConferencia` header sticky com Progress global — modelo para qualquer tela de fluxo linear.
+
+## Observações fora do escopo de UX
+
+- **Discrepância de Account/Empresa**: `SalesOrders.tsx` usa `Account = 'oben' | 'colacor' | 'afiacao' | 'all'` enquanto `CompanyContext` define `'colacor' | 'oben' | 'colacor_sc'`. "afiacao" como account vs CompanyContext é divergente — Colacor SC não aparece no filtro de SalesOrders.
+- **NfeReceipt hardcoda "OBEN"** no título mesmo permitindo selecionar Colacor/Afiação — bug de copy.
+- **`UnifiedOrder` redirect via `/unified-order` → `/sales/new`** — confirmar zero uso e remover.
+- **`useSalesOrders` carrega TUDO sem paginação** — risco de performance em produção com volumes altos (`SalesOrders.tsx:72-131`).
+- **`AdminCustomers.fetch` não revisado completamente** — pode ter o mesmo padrão de carregar tudo sem paginação.
+- **`AdminReposicaoCockpit` faz fallback silencioso `await supabase.from('cockpit_audit_log' as any).insert(...)` com try/catch sem log** — perda de dados de auditoria potencialmente invisível.
+- **`fin_confiabilidade` e `fin_projecao_13_semanas`** podem não existir no schema (try/catch silencioso em `FinanceiroCockpit.tsx:101-118`) — UX silenciosa esconde gap de schema.
+- **`SalesOrders.deleteOrder` chama `omie-vendas-sync` ação `excluir_pedido`** — exclusão sem soft-delete; risco compliance.
+- **Política de RLS não auditada nesta passada** (out-of-scope; lembrete do briefing).

--- a/docs/ux-audit/03-roadmap.md
+++ b/docs/ux-audit/03-roadmap.md
@@ -1,0 +1,456 @@
+# Fase 3 — Roadmap priorizado por ICE
+
+> Data: 2026-05-13 · 20 intervenções derivadas dos padrões transversais e telas críticas da Fase 2. Ordenadas por ICE = Impact × Confidence × Ease (max 1000).
+>
+> **Esta fase NÃO toca em código.** A execução acontece na Fase 4, sob comando explícito por intervenção.
+
+---
+
+## Resumo executivo
+
+### Top 3 problemas estruturais (aparecem em ≥5 telas)
+
+1. **Zero atalhos sistêmicos / sem cmd-k.** Único exemplo real é o Cockpit de Reposição. As outras 9 telas top têm H7=1 e D5=1. Quem opera 8h/dia ali sente. Cobertura: intervenções #1, #9, #10.
+
+2. **Zero offline-resilience operacional.** Workbox `NetworkOnly` em `picking_*`, `recebimento_*`, `sales_orders`, `orders`. Princípio do briefing ("offline-first em picking e recebimento") está hoje violado por arquitetura. Cobertura: intervenções #16, #17, #19.
+
+3. **Touch targets <44px globais + ausência de variantes mobile-first** em telas críticas (separador, balcão tintométrico, vendedor externo). `density-compact` global empurra todos os botões para 32-36px, abaixo do recomendado WCAG AA para uso com luva. Cobertura: intervenções #2, #18.
+
+### Top 3 quick wins (ICE ≥600 com Ease ≥8)
+
+1. **#1 Atalhos + ShortcutsDialog reusável** (ICE 720) — extrai o pattern do Cockpit de Reposição como infra do AppShell. Habilita todas as outras propostas de atalho.
+2. **#2 Variantes touch-grande no Button (44/56px)** (ICE 720) — destrava todas as telas mobile/balcão sem refactor profundo.
+3. **#3 UnifiedOrder draft autosave + restore** (ICE 720) — corta a maior dor reportável do vendedor externo (perder pedido em queda de sinal) com 1 dia-dev e zero alteração de schema.
+
+### Esforço total estimado
+
+- **Quick wins (Ease ≥8)**: 8 intervenções · ~25-40 dias-dev
+- **Médio (Ease 5-7)**: 9 intervenções · ~50-90 dias-dev
+- **Pesado (Ease ≤4)**: 3 intervenções · ~30-60 dias-dev
+- **Total**: ~105-190 dias-dev (1 sênior). Em sprints de 2 semanas com 1 dev = 5-10 sprints.
+
+### Recomendação para o próximo sprint (2 semanas, 1 dev)
+
+| # | Item | Dias-dev |
+|---|---|---|
+| #1 | Atalhos + ShortcutsDialog reusável | 2 |
+| #2 | Variantes touch-grande no Button | 1 |
+| #3 | UnifiedOrder draft autosave + restore | 1 |
+| #4 | Indicador online/offline no AppShell topbar | 1 |
+| #6 | Skeleton padrão de página + Suspense fallback contextual | 2 |
+| #11 | Filtros persistidos em URL (pattern + uso em SalesOrders) | 3 |
+| Buffer QA + ajustes | | 2 |
+
+**~12 dias-dev, cabe em sprint de 2 semanas.** Entrega: cmd-k arquitetural fora ainda (#9 vai pro sprint 2), mas o eixo "atalhos + touch + persistência" desce em todas as telas operacionais já a partir da semana 1. Os quick wins #5 (toast) e #7 (tokens status-*) ficam para slot livre ou paralelos.
+
+---
+
+## Como ler cada intervenção
+
+- **Nome curto** — chave de referência.
+- **Tela/área afetada** — onde a mudança aparece.
+- **Arquivos que mudam** — caminhos específicos (criar / editar / remover).
+- **Diff conceitual em prosa** — sem código. O quê e onde, não o como.
+- **Métrica que melhora** — proxy quantitativo concreto.
+- **ICE** — Impact (1-10) × Confidence (1-10) × Ease (1-10) = score (max 1000).
+- **Referência visual** — pattern nominal de Linear / Notion / Carbon / Polaris / Retool.
+- **Dependências** — outras intervenções que precisam vir antes.
+- **Risco** — baixo / médio / alto + qual.
+
+---
+
+# Roadmap (20 itens, ordenados por ICE)
+
+## #1 — Atalhos globais + ShortcutsDialog reusável (ICE 720)
+
+- **Tela/área**: AppShell + todas as 9 telas operacionais.
+- **Arquivos**:
+  - editar [src/hooks/useKeyboardShortcuts.ts](../../src/hooks/useKeyboardShortcuts.ts) — estender para suportar modifiers (`Cmd/Ctrl+K`), composições, escopo (página vs global), e nome legível por atalho
+  - criar `src/components/shell/ShortcutsRegistryProvider.tsx` — context que coleta shortcuts montados em qualquer página
+  - criar `src/components/shell/ShortcutsDialog.tsx` — overlay listando tudo agrupado por tela atual / global, abre com `?`
+  - editar [src/components/AppShell.tsx](../../src/components/AppShell.tsx) — montar provider + dialog dentro do shell
+  - editar [src/pages/AdminReposicaoCockpit.tsx](../../src/pages/AdminReposicaoCockpit.tsx) — migrar do hook local para registry global (validação)
+- **Diff conceitual**: extrair o pattern já existente no Cockpit de Reposição (linha 2073-2084) como infra do AppShell. Páginas declaram shortcuts via hook que escreve no registry; o dialog `?` lê do registry e mostra agrupado por escopo. Sem isso, cada nova proposta de atalho duplica boilerplate.
+- **Métrica que melhora**: % de ações executadas via atalho vs clique (instrumentar com analytics simples). Linha de base: ~0%. Meta: 30% no Cockpit em 30 dias.
+- **ICE**: I=9 · C=10 · E=8 · = **720**
+- **Referência visual**: dialog do Linear (`?` → painel à direita com seções "Navegação", "Edição", "Esta página"). Padrão também no Raycast.
+- **Dependências**: nenhuma.
+- **Risco**: baixo (extração).
+
+---
+
+## #2 — Variantes touch-grande no Button (44/56px) (ICE 720)
+
+- **Tela/área**: telas mobile e touchscreen — Picking, RecebimentoConferencia, UnifiedOrder, TintFormulas, SalesOrders.
+- **Arquivos**:
+  - editar [src/components/ui/button.tsx](../../src/components/ui/button.tsx) — adicionar variantes `size: "touch"` (44px) e `size: "balcao"` (56px) ao cva
+  - editar [src/index.css](../../src/index.css) — revisar regra global `button, a, [role="button"] { min-height: 32px; }` (linha 228-230) para não conflitar com variantes maiores
+  - opcional: criar `src/components/ui/touch-input.tsx` — variante de Input com `h-12` para mobile
+- **Diff conceitual**: hoje as variantes (sm/default/lg/icon) topam em 40px. Adicionar `touch` (44px) e `balcao` (56px) no `buttonVariants` cva. Não muda comportamento default; telas operacionais mobile passam a usar `<Button size="touch">`. Padrão Carbon Design Touch Targets.
+- **Métrica que melhora**: taxa de mistap em mobile (precisa instrumentação) ou simples auditoria visual cobrindo 100% dos botões em /admin/estoque/picking e /tintometrico/formulas.
+- **ICE**: I=8 · C=10 · E=9 · = **720**
+- **Referência visual**: Carbon Touch Target spec (44×44 mínimo, 48×48 recomendado, 56×56 para uso com luva).
+- **Dependências**: nenhuma.
+- **Risco**: baixo (variante opt-in).
+
+---
+
+## #3 — UnifiedOrder: rascunho autosave + restore (ICE 720)
+
+- **Tela/área**: `/sales/new` e `/new-order` (UnifiedOrder).
+- **Arquivos**:
+  - criar `src/hooks/useOrderDraft.ts` — debounced autosave em localStorage com chave `draft_order_{customerId}`
+  - editar [src/hooks/useUnifiedOrder.ts](../../src/hooks/useUnifiedOrder.ts) — chamar useOrderDraft a cada mudança no cart/notes/seleções; ao montar, ler do storage e perguntar restauração
+  - editar [src/pages/UnifiedOrder.tsx](../../src/pages/UnifiedOrder.tsx) — adicionar `<RestoreDraftDialog />` que aparece se houver draft pendente
+  - criar `src/components/unified-order/RestoreDraftDialog.tsx`
+- **Diff conceitual**: a cada mudança no estado do pedido (debounce 500ms), salvar snapshot no localStorage. Limpar ao submitOrder com sucesso. Ao recarregar a página com cart vazio mas draft existente, abrir dialog "Você tinha um pedido em andamento de {DD/MM HH:mm}. Restaurar?". Sem mexer em schema. Pré-requisito para a fila offline futura.
+- **Métrica que melhora**: # de "pedidos perdidos" reportados por vendedor (suporte) — meta zero. Tempo médio de criação após queda de conexão (deve cair de ~10min/refazer para 0).
+- **ICE**: I=9 · C=10 · E=8 · = **720**
+- **Referência visual**: pattern Notion/Google Docs ("Recuperando rascunho..."). Dialog de restore parecido com o do Linear "Resume from draft?".
+- **Dependências**: nenhuma.
+- **Risco**: baixo. Atenção: garantir que limpa o draft após submit bem-sucedido (caso contrário re-restaura pedido já enviado).
+
+---
+
+## #4 — Indicador online/offline persistente no topbar (ICE 630)
+
+- **Tela/área**: AppShell (todas as telas autenticadas).
+- **Arquivos**:
+  - criar `src/hooks/useNetworkStatus.ts` — wrapper sobre `navigator.onLine` + listeners + `navigator.connection` quando disponível
+  - criar `src/components/shell/NetworkStatusIndicator.tsx`
+  - editar [src/components/AppShell.tsx](../../src/components/AppShell.tsx) — substituir o botão `Bell` ornamental (linhas 458-460) pelo NetworkStatusIndicator
+- **Diff conceitual**: dot verde "Online" / âmbar "Conexão lenta" / vermelho "Offline · X mutações na fila". Hover/click abre popover com detalhes (RTT estimado, último sync, ações pendentes — vinculável à fila do #16). Hoje o Bell ocupa esse slot e não faz nada. Substituição libera real estate sem custo.
+- **Métrica que melhora**: # de tickets de suporte do tipo "perdi tudo, parecia funcionar mas não salvou" (dado qualitativo). Awareness do operador antes de ação destrutiva.
+- **ICE**: I=7 · C=10 · E=9 · = **630**
+- **Referência visual**: dot status do Linear (canto superior esquerdo do workspace) + popover de sync do Notion (mostra última sincronização).
+- **Dependências**: nenhuma — full value sem fila offline. Ganha mais ainda quando #16 entrar.
+- **Risco**: baixo.
+
+---
+
+## #5 — TintFormulas: recentes + favoritos no topo (ICE 567)
+
+- **Tela/área**: `/tintometrico/formulas`.
+- **Arquivos**:
+  - editar [src/pages/TintFormulas.tsx](../../src/pages/TintFormulas.tsx) — adicionar barra superior persistente com 2 sub-seções (Recentes / Favoritos)
+  - criar `src/hooks/useTintFavorites.ts` — read/write em localStorage por usuário (chave `tint_favorites_{userId}`)
+  - reusar `src/lib/recents.ts` (ou criar) — registry de últimas 10 fórmulas consultadas
+- **Diff conceitual**: ao abrir uma fórmula (expandir linha) ou usar via cmd-k, push para "recentes" (FIFO 10). Ícone de estrela por linha permite favoritar. Topo da tela mostra: "Recentes (5)" + "Favoritos (3)" como chips clicáveis que filtram a tabela. Sem mudança de schema. Plus opcional: botão "Copiar receita" na linha expandida (texto formatado para WhatsApp/dispenser).
+- **Métrica que melhora**: tempo médio do operador para localizar fórmula durante atendimento (proxy: # de chars digitados na busca). Meta: cair pra 0 em fórmulas frequentes.
+- **ICE**: I=9 · C=9 · E=7 · = **567**
+- **Referência visual**: barra "Recentes" + "Favoritos" do Notion sidebar; favorito tipo Raycast (estrela inline).
+- **Dependências**: nenhuma. Sinergia com #9 (cmd-k) — ao implementar cmd-k, expor "Buscar fórmula" como comando.
+- **Risco**: baixo.
+
+---
+
+## #6 — Skeleton padrão de página + Suspense contextual (ICE 560)
+
+- **Tela/área**: global (App.tsx Suspense fallback) + cada tela top.
+- **Arquivos**:
+  - criar `src/components/ui/page-skeleton.tsx` — variantes `cockpit` (KPIs + tabela), `list` (filtros + cards), `form` (steps + campos), `detail` (header + sections)
+  - editar [src/App.tsx](../../src/App.tsx:138) — substituir `PageLoader` genérico por `<PageSkeleton variant="auto" />`; route-level fallback contextual via meta da rota
+  - editar telas top que usam `Loader2` centralizado para usar PageSkeleton (Picking, SalesOrders, TintFormulas, AdminCustomers, FinanceiroCockpit já usa Skeleton — referência interna)
+- **Diff conceitual**: hoje 6 das 10 telas top usam `<Loader2 spin />` centralizado durante load inicial — quebra continuidade visual. PageSkeleton mostra esqueleto da estrutura final, reduzindo CLS percebido. FinanceiroCockpit já implementa esse pattern manual; promover a componente.
+- **Métrica que melhora**: Largest Contentful Paint percebido (não real — o tempo de servidor é o mesmo, mas a página parece carregar 30-50% mais rápido). Padrão Linear/Vercel.
+- **ICE**: I=7 · C=10 · E=8 · = **560**
+- **Referência visual**: skeleton do Linear (gradient shimmer + estrutura fiel à tela final).
+- **Dependências**: nenhuma.
+- **Risco**: baixo.
+
+---
+
+## #7 — AdminEstoquePicking: scan-first input com autofocus (ICE 560)
+
+- **Tela/área**: `/admin/estoque/picking` — perfil separador.
+- **Arquivos**:
+  - editar [src/pages/AdminEstoquePicking.tsx](../../src/pages/AdminEstoquePicking.tsx) — adicionar `<ScanBar />` sticky no topo da PickingTab
+  - criar `src/components/picking/ScanBar.tsx` — input autofocus, `inputmode="numeric"`, `autocomplete="off"`, debounce 50ms, suporte a leitura por wedge (HID barcode scanner) e digitação manual
+  - opcional (depende #14): integração com BarcodeDetector API (câmera) para mobile
+- **Diff conceitual**: barra fixa no topo focada por padrão. Operador chega na tela → digita ou bipa → barra detecta endereço (formato `Z.P.P`) ou SKU e route automaticamente para o item correspondente da task atual. Sem clique. Latência <100ms via #8 (optimistic).
+- **Métrica que melhora**: tempo médio por separação (alvo: -30% após adoção). # de cliques por unidade separada (alvo: 0 na rotina padrão).
+- **ICE**: I=10 · C=8 · E=7 · = **560**
+- **Referência visual**: scan bar do Shopify POS / Stocky (input centralizado, fonte grande, foco automático).
+- **Dependências**: #2 (touch variants para mobile) e #8 (optimistic) ampliam valor.
+- **Risco**: médio — comportamento de wedge varia por modelo de leitor. Testar com 2-3 modelos antes de soltar.
+
+---
+
+## #8 — Helper `useOptimisticMutation` (ICE 504)
+
+- **Tela/área**: infra reusável — ganho concreto em Picking, RecebimentoConferencia, UnifiedOrder, AdminCustomers.
+- **Arquivos**:
+  - criar `src/hooks/useOptimisticMutation.ts` — wrapper sobre `useMutation` com `onMutate`/`onError`/`onSettled` boilerplate, integrado com queryClient cache
+  - documentar em [src/components/DesignSystem.tsx](../../src/pages/DesignSystem.tsx) seção "Padrões de mutação"
+  - migrar 2-3 mutações operacionais de exemplo (handleConfirmUnit do Recebimento, deleteOrder do SalesOrders, requires_po toggle do AdminCustomers que **já usa o pattern** — referência interna)
+- **Diff conceitual**: hoje cada mutação repete try/catch + setLoading + toast manual. Helper recebe `{ mutationFn, optimisticUpdate(cache), rollbackOn(err), invalidate: ['key'] }`. Ganho: optimistic UI por padrão; rollback consistente; menos boilerplate; toast de erro padronizado.
+- **Métrica que melhora**: latência percebida em scan/picking <100ms (princípio do briefing). Linhas de código por mutação (-50%).
+- **ICE**: I=9 · C=8 · E=7 · = **504**
+- **Referência visual**: pattern do `tRPC + React Query optimistic` ou exemplos da própria docs do TanStack Query (`Optimistic Updates`).
+- **Dependências**: nenhuma.
+- **Risco**: médio — optimistic mal feito gera "fantasmas" se rollback falhar. Testar caso de borda: rede flaky com retry.
+
+---
+
+## #9 — Cmd-K global com registry de comandos (ICE 480)
+
+- **Tela/área**: AppShell (toda a app).
+- **Arquivos**:
+  - criar `src/components/shell/CommandPalette.tsx` — overlay `cmdk` com fuse search, agrupa "Navegar para...", "Ações desta tela", "Buscar registro" (clientes, fórmulas, pedidos)
+  - criar `src/components/shell/CommandsRegistryProvider.tsx` — análogo ao ShortcutsRegistry (#1), comandos contribuídos por página
+  - editar [src/components/AppShell.tsx](../../src/components/AppShell.tsx) — montar palette com hotkey `Cmd+K`/`Ctrl+K`
+  - editar topbar — adicionar pill "Cmd+K Buscar..." (placeholder visível)
+- **Diff conceitual**: `cmdk` lib já está no projeto; `Command` shadcn em [src/components/ui/command.tsx](../../src/components/ui/command.tsx) também. Palette monta no portal, abre com `Cmd+K`. Registry inicial: rotas autorizadas por persona + comandos comuns ("Novo pedido", "Buscar cliente: {q}", "Fórmula {q}"). Versão 1 não precisa indexar Supabase em tempo real — busca debounced direta nas tabelas mais consultadas.
+- **Métrica que melhora**: tempo de navegação entre telas (alvo: -50% para usuário power). Adoção (% de sessões com pelo menos 1 abertura de cmd-k em 30 dias).
+- **ICE**: I=10 · C=8 · E=6 · = **480**
+- **Referência visual**: cmd-k do Linear (groups por contexto) + Raycast (extensions). O do Notion serve como referência para "Find in...".
+- **Dependências**: #1 (ShortcutsRegistry) é arquiteturalmente irmão — fazer junto economiza.
+- **Risco**: médio — escopo pode inflacionar se quiser cobrir tudo na v1. Manter v1 minimal: navegar + 3 buscas (clientes, fórmulas, pedidos).
+
+---
+
+## #10 — EmptyState refactor para B2B (ICE 486)
+
+- **Tela/área**: global. Telas com empty state hoje: Orders, SalesOrders, AdminCustomers, AdminEstoquePicking, todas as listas.
+- **Arquivos**:
+  - editar [src/components/EmptyState.tsx](../../src/components/EmptyState.tsx) — remover floating motion, ícone arredondado grande, decorative dots; tornar denso e B2B
+  - opcional: criar variantes (`empty-search` com sugestão de limpar filtros, `empty-page` com CTA, `empty-loading-fail` com retry)
+- **Diff conceitual**: o EmptyState atual é "consumer-grade" — ícone 80px com `motion.div animate y` flutuante, decorative dots, fonte 18px. Em telas operacionais vira ruído. Refactor para padrão Polaris EmptyState: ícone 24-32px, título 14-15px, descrição 13px, action button compacto. Sem motion. Mantém o componente; mudam os tokens internos.
+- **Métrica que melhora**: consistência visual (auditoria); densidade adequada ao perfil B2B.
+- **ICE**: I=6 · C=9 · E=9 · = **486**
+- **Referência visual**: Polaris EmptyState compact + Carbon InlineNotification "no data".
+- **Dependências**: nenhuma.
+- **Risco**: baixo. Atenção: telas customer-facing (Orders, Tools) podem querer manter o estilo amigável — adicionar prop `tone: "operational" | "friendly"` resolve.
+
+---
+
+## #11 — Filtros persistidos em URL (ICE 504)
+
+- **Tela/área**: SalesOrders, AdminCustomers, AdminReposicaoPedidos, AdminReposicaoCockpit, TintFormulas, Recebimento, Orders.
+- **Arquivos**:
+  - criar `src/hooks/useUrlState.ts` — hook genérico que sincroniza state com `useSearchParams`, com schema/serialização zod
+  - migrar [src/pages/SalesOrders.tsx](../../src/pages/SalesOrders.tsx) (filtros: search, accountFilter) como referência
+  - migrar [src/pages/AdminCustomers.tsx](../../src/pages/AdminCustomers.tsx) (filtros: searchQuery, filterHealth) — usa `useState` hoje, virar `useUrlState`
+- **Diff conceitual**: hoje filtros são `useState` local — perdidos no F5, não compartilháveis. Hook sincroniza ↔ URL `?search=foo&account=oben`. Adoção incremental por tela. Padrão TanStack Router / Linear (URL representa o filtro completo).
+- **Métrica que melhora**: # de URLs compartilhadas internamente (Slack/WhatsApp) com filtro pré-aplicado. Recuperação de contexto após F5.
+- **ICE**: I=8 · C=9 · E=7 · = **504**
+- **Referência visual**: URLs do Linear (`/team/X/active?priority=urgent&assignee=me`).
+- **Dependências**: nenhuma.
+- **Risco**: baixo. Atenção: PII em URL — filtros por `customer_id` ok, por `cnpj` plain text não.
+
+---
+
+## #12 — Topbar: cleanup do Bell + cmd-k trigger + company switcher (ICE 441)
+
+- **Tela/área**: AppShell topbar.
+- **Arquivos**:
+  - editar [src/components/AppShell.tsx](../../src/components/AppShell.tsx) — remover `Bell` ornamental (linhas 458-460), adicionar `<CommandPaletteTrigger />`, `<CompanySwitcher />`, `<NetworkStatusIndicator />` (#4)
+  - criar `src/components/shell/CompanySwitcher.tsx` — dropdown lendo de [src/contexts/CompanyContext.tsx](../../src/contexts/CompanyContext.tsx); persiste em localStorage (já faz)
+- **Diff conceitual**: hoje o topbar tem só Bell+User. Reorganizar para: [logo] [breadcrumb opcional] —— [cmd-k pill] [company switcher pill] [network indicator dot] [help drawer] [user dropdown]. Bell pode voltar quando notificações reais existirem (hoje é falsa promessa de UX).
+- **Métrica que melhora**: descoberta do cmd-k (presença visual de affordance). Awareness da empresa ativa (hoje não é exposta — usuário pode confundir contexto entre Oben/Colacor/SC).
+- **ICE**: I=7 · C=9 · E=7 · = **441**
+- **Referência visual**: topbar do Linear (cmd-k pill central + breadcrumb à esquerda + actions à direita).
+- **Dependências**: #4 (NetworkStatusIndicator), #9 (Cmd-K palette). CompanySwitcher pode entrar antes dos outros.
+- **Risco**: baixo. Validar com gestão se mostrar empresa ativa publicamente é OK (multi-tenant interno).
+
+---
+
+## #13 — Bulk actions pattern para tabelas (ICE 432)
+
+- **Tela/área**: SalesOrders, AdminCustomers, AdminReposicaoPedidos, AdminReposicaoCockpit (tem parcialmente).
+- **Arquivos**:
+  - criar `src/components/ui/bulk-actions-bar.tsx` — barra flutuante que aparece quando `selected.length > 0`, com ações contextuais e botão "Limpar seleção"
+  - criar `src/hooks/useBulkSelection.ts` — multi-select padrão (Shift+click range, Ctrl+click toggle, Esc limpa)
+  - migrar AdminReposicaoCockpit (review mode → usar pattern) como referência
+- **Diff conceitual**: cada tela hoje implementa multi-select e bulk de forma diferente (ou nem implementa). Pattern central + barra reusável padroniza visualmente e acelera adoção. Cobertura: aprovar/cancelar bulk em pedidos, atribuir vendedor em clientes, exportar segmento, marcar como entregue, etc.
+- **Métrica que melhora**: tempo médio para operação em N itens (alvo: -80% vs N cliques individuais).
+- **ICE**: I=8 · C=9 · E=6 · = **432**
+- **Referência visual**: bulk actions bar do Retool table + Polaris ResourceList. Linear inbox bulk (visual reference).
+- **Dependências**: nenhuma. Ganha sinergia com #11 (URL state — preservar seleção em query param).
+- **Risco**: médio — Shift+click range em tabelas ordenadas/paginadas tem caso de borda (selecionar entre páginas). v1 cobre só dentro da página atual.
+
+---
+
+## #14 — NfeReceipt: histórico das últimas 10 + reprocessar (ICE 405)
+
+- **Tela/área**: `/nfe-receipt`.
+- **Arquivos**:
+  - editar [src/pages/NfeReceipt.tsx](../../src/pages/NfeReceipt.tsx) — adicionar Card "Últimas processadas" abaixo do form, query a tabela de log (criar se não existe)
+  - opcional: nova tabela `nfe_receipt_runs` (id, nf_number, account, started_at, finished_at, success, steps jsonb, user_id) — fora do escopo desta auditoria, mas necessário para o histórico funcionar
+- **Diff conceitual**: hoje o operador processa uma NF e perde o registro ao recarregar. Histórico mostra status + timestamp + botão "Reprocessar" + link "Ver log completo". Reduz suporte ("Você processou minha NF?") e dá rastreabilidade.
+- **Métrica que melhora**: # de tickets de suporte sobre status de processamento. Tempo médio para reprocessar erro intermitente.
+- **ICE**: I=5 · C=9 · E=9 · = **405** (E=9 supõe que tabela de log existirá; se precisar criar schema, E baixa para 6)
+- **Referência visual**: log de runs do Vercel deploy / GitHub Actions (lista compacta com status pill + timestamp).
+- **Dependências**: schema de `nfe_receipt_runs` (decisão de produto/dados).
+- **Risco**: baixo.
+
+---
+
+## #15 — Toast: unificar em Sonner, remover Radix duplicado (ICE 450)
+
+- **Tela/área**: global.
+- **Arquivos**:
+  - editar [src/App.tsx](../../src/App.tsx:160-161) — remover `<Toaster />` (Radix), manter `<Sonner />`
+  - remover [src/components/ui/toaster.tsx](../../src/components/ui/toaster.tsx), [src/components/ui/toast.tsx](../../src/components/ui/toast.tsx), [src/hooks/use-toast.ts](../../src/hooks/use-toast.ts) e [src/components/ui/use-toast.ts](../../src/components/ui/use-toast.ts)
+  - codemod: substituir todos os imports de `useToast` / `toast` de `@/hooks/use-toast` por `import { toast } from 'sonner'` e migrar API (`toast({title, description, variant})` → `toast.success(title, { description })`)
+- **Diff conceitual**: hoje os dois sistemas coexistem. Sonner tem API mais ergonômica e melhor stack (top-right unificado). Padronizar reduz inconsistência visual e bundle. Migrar ~30 callsites — codemod simples.
+- **Métrica que melhora**: bundle size (-3-5kb gzip). Consistência visual de feedback.
+- **ICE**: I=5 · C=10 · E=9 · = **450**
+- **Referência visual**: Sonner stacking top-right (Vercel default).
+- **Dependências**: nenhuma.
+- **Risco**: baixo. Atenção: `toast.action({label, onClick})` API difere — checar callsites com action callback.
+
+---
+
+## #16 — AdminCustomers: segmentos salvos como chips (ICE 378)
+
+- **Tela/área**: `/admin/customers`.
+- **Arquivos**:
+  - editar [src/pages/AdminCustomers.tsx](../../src/pages/AdminCustomers.tsx) — adicionar barra de chips "Meus segmentos" acima da tabela
+  - criar tabela `user_segments` (id, user_id, name, filter_json, created_at) — schema novo
+  - criar `src/hooks/useUserSegments.ts`
+- **Diff conceitual**: vendedor define filtros frequentes (ex: "Críticos sem compra 60d+") e salva como segmento nomeado. Aparece como chip clicável. Reduz fricção de redefinir filtros toda vez. Cross-sell com #11 (URL state) — segmento é só um filter_json materializado.
+- **Métrica que melhora**: # de segmentos criados por vendedor; tempo médio para acessar lista filtrada (-90%).
+- **ICE**: I=7 · C=9 · E=6 · = **378**
+- **Referência visual**: HubSpot Lists / Linear Views (sidebar com saved views).
+- **Dependências**: #11 (URL state) — feito antes, segmento vira encapsulamento natural.
+- **Risco**: baixo. Atenção: segmento global vs por vendedor — definir antes (provavelmente por vendedor com flag "compartilhar com time").
+
+---
+
+## #17 — Tokens status-* — eliminar cores hardcoded (ICE 378)
+
+- **Tela/área**: ~10-15 telas (Picking, FinanceiroCockpit, AdminReposicaoPedidos, TintFormulas, etc.).
+- **Arquivos**:
+  - editar telas com `text-emerald-600`, `text-red-600`, `bg-amber-50`, `bg-emerald-500/15` etc. — substituir por classes utilitárias `status-success`, `status-warning`, `status-error`, ou tokens `text-status-success` (criar utilitário)
+  - editar [src/index.css](../../src/index.css) — adicionar utilities `text-status-*` se faltarem (já tem `bg-status-*-bg`)
+- **Diff conceitual**: hoje cores semânticas são duplicadas como classes Tailwind cruas em ~50 callsites. Quebra dark mode parcial e impede mudança global. Refactor padroniza para tokens semânticos. Pode ser parcial (refactor só telas top da Fase 2 já cobre 80% dos casos).
+- **Métrica que melhora**: consistência dark mode (auditoria visual). Mudança futura de paleta (1 linha vs 50).
+- **ICE**: I=6 · C=9 · E=7 · = **378**
+- **Referência visual**: Carbon Design tokens system (todo signaling via tokens, não cores cruas).
+- **Dependências**: nenhuma.
+- **Risco**: baixo (refactor mecânico). Tem que rodar com olho — algumas cores são intencionais e não-status (ex: roxo de bundle).
+
+---
+
+## #18 — TintFormulas: catálogo offline em IndexedDB (ICE 360)
+
+- **Tela/área**: `/tintometrico/formulas` e telas que consomem fórmulas.
+- **Arquivos**:
+  - criar `src/lib/tint-cache.ts` — wrapper sobre IndexedDB (via `idb` lib ou `Dexie`) com schema {formulas, corantes, embalagens, produtos, bases, version}
+  - criar Edge function `tint-catalog-snapshot` — gera snapshot versionado do catálogo (incremental por updated_at)
+  - editar [src/pages/TintFormulas.tsx](../../src/pages/TintFormulas.tsx) — query stale-while-revalidate; offline → ler de IndexedDB; banner "Catálogo offline · sincronizado há Xh"
+- **Diff conceitual**: catálogo de ~477k fórmulas é semi-estático (atualizado por sync periódico do SAYERSYSTEM). Cachear cliente-side em IndexedDB libera operação 100% offline no balcão. Versão incremental: ao reconectar, busca diff `WHERE updated_at > last_sync`. Tamanho estimado: ~50-100MB no cliente — viável.
+- **Métrica que melhora**: % de uptime efetivo do balcão durante quedas de internet (alvo: 100%). Latência de busca local (alvo: <50ms vs 500ms+ via Supabase).
+- **ICE**: I=9 · C=8 · E=5 · = **360**
+- **Referência visual**: Notion offline mode (página inteira disponível offline).
+- **Dependências**: validar viabilidade de tamanho com PO (~100MB no IndexedDB do operador).
+- **Risco**: alto — sync incremental tem casos de borda (delete de fórmulas, conflito de versionamento, espaço em disco). v1: snapshot completo + reload manual.
+
+---
+
+## #19 — AdminEstoquePicking: tela mobile dedicada (TouchPickingView) (ICE 320)
+
+- **Tela/área**: `/admin/estoque/picking` — render condicional mobile.
+- **Arquivos**:
+  - criar `src/pages/picking/TouchPickingView.tsx` — layout vertical, cards 56px+, fonte base 16px, swipe-to-advance (Vaul drawer ou hammer.js)
+  - editar [src/pages/AdminEstoquePicking.tsx](../../src/pages/AdminEstoquePicking.tsx) — render condicional baseado em `useIsMobile()` + `pointer: coarse` detection
+  - reusar `src/components/picking/ScanBar.tsx` (do #7)
+- **Diff conceitual**: hoje a tela é desktop-first; o separador mobile recebe a tabela horizontal apertada. Refactor cria visão dedicada: 1 task por vez, item destacado, scan focado, swipe-right para avançar, botões 56px. Desktop continua sendo o cockpit do gestor. Não é responsive — é dual-view.
+- **Métrica que melhora**: tempo por separação no chão (alvo: -40%). Taxa de erro de bipagem.
+- **ICE**: I=10 · C=8 · E=4 · = **320**
+- **Referência visual**: tela "Pick" do Shopify Stocky / Magic Pick / Brightpearl.
+- **Dependências**: #2 (touch variants), #7 (ScanBar), #8 (optimistic), #16 (offline queue) — todas multiplicam o valor desta. Faz sentido entrar depois delas.
+- **Risco**: alto — exige protótipo testado com separador real antes de soltar.
+
+---
+
+## #20 — Offline queue + IndexedDB para picking e recebimento (ICE 210)
+
+- **Tela/área**: AppShell + Picking + RecebimentoConferencia + UnifiedOrder (vendedor).
+- **Arquivos**:
+  - criar `src/lib/offline-queue.ts` — fila persistente em IndexedDB com retry exponencial; enqueue/flush/clear
+  - criar `src/hooks/useOfflineMutation.ts` — wrapper que enfileira mutações quando offline e dispara quando volta
+  - editar workbox em [vite.config.ts](../../vite.config.ts:54-85) — adicionar handlers para `picking_*`, `nfe_*`, `nfe_lotes_*` com strategy `NetworkFirst` + queue background sync
+  - integrar com `<NetworkStatusIndicator />` (#4) — exibir contador "X mutações na fila"
+  - editar mutações de Picking, RecebimentoConferencia para usar `useOfflineMutation`
+- **Diff conceitual**: maior intervenção do roadmap. Substitui `NetworkOnly` atual por queue persistente. Operador pode trabalhar offline em picking/recebimento; mutações enfileiradas em IndexedDB + executadas em background quando reconecta. Workbox `BackgroundSyncPlugin` cobre o caminho HTTP; o hook cobre lógica de UI (estado pendente, conflict resolution).
+- **Métrica que melhora**: # de tickets "perdi separação por queda de sinal" (alvo: zero). Uptime efetivo do almox em loja com sinal ruim. Princípio do briefing.
+- **ICE**: I=10 · C=7 · E=3 · = **210**
+- **Referência visual**: Linear iOS offline mode (cria issue offline, sync automático). Notion offline drafts.
+- **Dependências**: #4 (NetworkStatusIndicator) para feedback visual, #8 (optimistic) — semantically irmão.
+- **Risco**: **alto** — conflict resolution (mesma task editada offline por 2 separadores), expiração de fila, casos de borda de timeout. Requer suite de testes e2e dedicada. Estimativa conservadora: 3-4 semanas de dev.
+
+---
+
+# Sumário ordenado
+
+| # | Intervenção | I | C | E | ICE | Tier | Sprint sugerido |
+|---|---|---|---|---|---|---|---|
+| 1 | Atalhos + ShortcutsDialog reusável | 9 | 10 | 8 | **720** | quick win | 1 |
+| 2 | Variantes touch-grande no Button | 8 | 10 | 9 | **720** | quick win | 1 |
+| 3 | UnifiedOrder draft autosave + restore | 9 | 10 | 8 | **720** | quick win | 1 |
+| 4 | Indicador online/offline no topbar | 7 | 10 | 9 | **630** | quick win | 1 |
+| 5 | TintFormulas recentes + favoritos | 9 | 9 | 7 | **567** | médio | 2 |
+| 6 | Skeleton padrão de página | 7 | 10 | 8 | **560** | quick win | 1 |
+| 7 | Picking scan-first input | 10 | 8 | 7 | **560** | médio | 2 |
+| 8 | useOptimisticMutation helper | 9 | 8 | 7 | **504** | médio | 2 |
+| 9 | Cmd-K global | 10 | 8 | 6 | **480** | médio | 2 |
+| 10 | EmptyState refactor B2B | 6 | 9 | 9 | **486** | quick win | 1 |
+| 11 | Filtros persistidos em URL | 8 | 9 | 7 | **504** | médio | 1-2 |
+| 12 | Topbar cleanup + cmd-k pill + switcher | 7 | 9 | 7 | **441** | médio | 2 |
+| 13 | Bulk actions pattern | 8 | 9 | 6 | **432** | médio | 3 |
+| 14 | NfeReceipt histórico | 5 | 9 | 9 | **405** | quick win | 3 |
+| 15 | Toast unificação Sonner | 5 | 10 | 9 | **450** | quick win | 1 (slot livre) |
+| 16 | AdminCustomers segmentos | 7 | 9 | 6 | **378** | médio | 3 |
+| 17 | Tokens status-* refactor | 6 | 9 | 7 | **378** | médio | 1-2 (paralelo) |
+| 18 | TintFormulas catálogo offline | 9 | 8 | 5 | **360** | pesado | 4 |
+| 19 | TouchPickingView mobile dedicada | 10 | 8 | 4 | **320** | pesado | 4-5 |
+| 20 | Offline queue picking/recebimento | 10 | 7 | 3 | **210** | pesado | 5-6 |
+
+---
+
+## Notas finais
+
+### Já feito durante a auditoria (Fase 2 → conserto direto, fora do escopo de UX)
+
+Estes 3 itens foram corrigidos diretamente, com permissão explícita do PO ao final da Fase 2:
+
+- ✅ [src/pages/NfeReceipt.tsx](../../src/pages/NfeReceipt.tsx) — título dinâmico por empresa selecionada (era "OBEN" hardcoded).
+- ✅ [src/pages/FinanceiroCockpit.tsx](../../src/pages/FinanceiroCockpit.tsx) — try/catch silenciosos de `fin_projecao_13_semanas` e `fin_confiabilidade` agora logam via `logger.warn`.
+- ✅ [src/pages/AdminReposicaoCockpit.tsx](../../src/pages/AdminReposicaoCockpit.tsx) — try/catch silencioso de `cockpit_audit_log` agora loga via `logger.warn` (auditoria deixa de se perder em silêncio).
+
+### Observações fora do escopo NÃO consertadas (pedem decisão de produto antes)
+
+Mantidas no roadmap conceitual, mas exigem alinhamento antes de tocar:
+
+- **Discrepância Account/Empresa em SalesOrders** — `Account = 'oben' | 'colacor' | 'afiacao' | 'all'` divergente de `CompanyContext = 'colacor' | 'oben' | 'colacor_sc'`. Pergunta: "afiacao" (SalesOrders) e "colacor_sc" (CompanyContext) são a mesma coisa, ou Colacor SC ainda não tem pedidos no fluxo de vendas?
+- **`/unified-order` redirect** — manter ou remover. Decisão depende de log de uso real.
+- **`SalesOrders` carrega TUDO sem paginação** — refactor ICE-incluído (#11 cobre filtros; paginação real é trabalho à parte). Precisa decisão sobre cursor pagination vs infinite scroll.
+- **`SalesOrders.deleteOrder` sem soft-delete** — risco compliance. Precisa decisão sobre política de retenção e auditoria de exclusão.
+- **`Bell` ornamental no topbar** — endereçado pelo #4 / #12 (cleanup), mas decisão sobre central de notificações real é pendente.
+- **Branding stale `Colacor - Afiação Profissional`** em `index.html` e `vite.config.ts` PWA manifest — rename simples mas afeta cache PWA dos usuários (split deploy ou flush).
+
+### Como o roadmap se mapeia aos princípios do briefing
+
+| Princípio do briefing | Coberto por |
+|---|---|
+| Offline-first em picking e recebimento | #20 (core), #18 (TintFormulas) |
+| Latência percebida <100ms em scan | #7, #8 |
+| Densidade alta em telas operacionais | já alinhado (`density-compact`); #10 reforça |
+| WCAG AA mínimo, AAA em críticas | #2 (touch), #17 (tokens — contraste) |
+| Mobile-first em chão de fábrica | #2, #7, #19 |
+| Cmd-K global + atalhos consistentes | #1, #9, #12 |
+| Optimistic UI em mutações operacionais | #8 (helper), aplicado em #7, #20 |
+
+Os 6 princípios estão endereçados. Nenhum gap não-coberto.
+
+### Antes de iniciar a Fase 4
+
+Pra cada intervenção que entrar no sprint, preciso:
+
+1. **Sinal verde nominal** ("aprova #1", "aprova #2 e #3 juntos", etc.).
+2. **Confirmação de premissas** marcadas como "decisão pendente" nos itens (ex: schema novo no #14 e #16, viabilidade de tamanho no #18, política de exclusão no SalesOrders).
+3. **Ordem sugerida vs ordem que você quer** — se quiser puxar #20 antes do #4, viável; só perde sinergia.
+
+Aguardando sua priorização do sprint.

--- a/docs/ux-audit/04-execucao.md
+++ b/docs/ux-audit/04-execucao.md
@@ -1,0 +1,237 @@
+# Fase 4 — Execução
+
+> Data: 2026-05-13 · Autorização: "todas + faça tudo" (todos os 20 itens do roadmap em um lote, entregar no fim). Sem rodar lint/typecheck no sandbox — node/npm indisponível; recomendo `npm run lint && npm run build` antes de mergear.
+
+---
+
+## Resumo executivo da entrega
+
+| Tier | Itens | Status |
+|---|---|---|
+| **Infra reusável (Bloco 1)** | Button touch · tokens status · EmptyState · Toast unificado | ✅ entregue |
+| **Hooks reusáveis (Bloco 2)** | useUrlState · useOptimisticMutation · useNetworkStatus · PageSkeleton | ✅ entregue |
+| **Shell (Bloco 3)** | ShortcutsRegistry+Dialog · CommandPalette+Registry · Topbar cleanup · CompanySwitcher · NetworkStatusIndicator | ✅ entregue |
+| **Páginas (Bloco 4)** | UnifiedOrder draft · TintFormulas recentes/favoritos · Picking ScanBar · BulkActionsBar · NfeReceipt histórico · AdminCustomers segmentos | ✅ entregue |
+| **Scaffolds complexos (Bloco 5)** | tint-cache (IndexedDB) · TouchPickingView · offline-queue scaffold | ✅ scaffold entregue (precisa iteração + decisões de produto) |
+
+**20/20 itens endereçados.** Distinção entre "completo" e "scaffold + integração futura" detalhada por item abaixo.
+
+---
+
+## Itens entregues por roadmap-ID
+
+### #1 ShortcutsRegistry + ShortcutsDialog reusável (COMPLETO)
+
+- Novos:
+  - [src/components/shell/ShortcutsRegistry.tsx](../../src/components/shell/ShortcutsRegistry.tsx) — context + provider + `useRegisterShortcuts` + `formatCombo` (`⌘K` em Mac, `Ctrl+K` no resto).
+  - [src/components/shell/ShortcutsDialog.tsx](../../src/components/shell/ShortcutsDialog.tsx) — abre com `?`, lista agrupada por escopo (Global / Cockpit / Esta página). Aceita evento customizado `open-shortcuts-dialog` para abrir programaticamente.
+- Editados:
+  - [src/components/AppShell.tsx](../../src/components/AppShell.tsx) — `ShortcutsRegistryProvider` envolve o shell, `<ShortcutsDialog />` montado.
+  - [src/pages/AdminReposicaoCockpit.tsx](../../src/pages/AdminReposicaoCockpit.tsx) — migrado do `useKeyboardShortcuts` legado para `useRegisterShortcuts`; `ShortcutsDialog` interno e array `SHORTCUTS` locais removidos (~30 linhas eliminadas). Botão Keyboard agora dispara `open-shortcuts-dialog`.
+- Métrica esperada: % de ações via atalho vs clique (instrumentar separado).
+
+### #2 Variantes touch-grande no Button (COMPLETO)
+
+- Editado: [src/components/ui/button.tsx](../../src/components/ui/button.tsx) — novas size variants `touch` (44px), `touch-icon` (44×44), `balcao` (56px), `balcao-icon` (56×56). Opt-in: nenhum callsite default mudou.
+- Adoção inicial: `ScanBar.tsx` (botão OK = `touch`), `TouchPickingView.tsx` (botão Voltar = `touch`).
+
+### #3 UnifiedOrder draft autosave + restore (COMPLETO)
+
+- Novos:
+  - [src/hooks/useOrderDraft.ts](../../src/hooks/useOrderDraft.ts) — autosave debounced (600ms) em localStorage, scope por `user.id`, `beforeunload` warning enquanto há cart.
+  - [src/components/unified-order/RestoreDraftDialog.tsx](../../src/components/unified-order/RestoreDraftDialog.tsx) — AlertDialog "Você tinha um pedido com {cliente} contendo {N itens}, salvo {há quanto}".
+- Editados:
+  - [src/pages/UnifiedOrder.tsx](../../src/pages/UnifiedOrder.tsx) — integra `useOrderDraft`, abre `RestoreDraftDialog` se houver draft pendente e cart vazio. Restore aplica `setCart`/`setNotes`/`setOrdemCompra`. Limpa automaticamente quando `orderSuccessOpen` muda para `true`.
+  - [src/hooks/useUnifiedOrder.ts](../../src/hooks/useUnifiedOrder.ts) — agora expõe `setCart` no retorno (precisava ser exposto pro restore).
+- Limitação conhecida: produtos removidos do catálogo entre salvar e restaurar ficam com referência inválida. v2 deve validar contra catálogo no momento do restore.
+
+### #4 Indicador online/offline no topbar (COMPLETO)
+
+- Novos:
+  - [src/hooks/useNetworkStatus.ts](../../src/hooks/useNetworkStatus.ts) — `navigator.onLine` + `navigator.connection.effectiveType/rtt`, reativo a `online`/`offline`/`change`.
+  - [src/components/shell/NetworkStatusIndicator.tsx](../../src/components/shell/NetworkStatusIndicator.tsx) — dot tricolor (verde/âmbar/vermelho), badge com `queueDepth` quando há mutações pendentes, popover com RTT/tipo/fila.
+- Editado: [src/components/AppShell.tsx](../../src/components/AppShell.tsx) — `Bell` ornamental removido, `NetworkStatusIndicator` no lugar.
+
+### #5 TintFormulas — recentes + favoritos (COMPLETO)
+
+- Novo: [src/hooks/useTintRecentsFavorites.ts](../../src/hooks/useTintRecentsFavorites.ts) — localStorage com sync entre abas, FIFO 10 recentes + favoritos ilimitados.
+- Editado: [src/pages/TintFormulas.tsx](../../src/pages/TintFormulas.tsx) — barra "Recentes/Favoritos" acima da tabela, coluna ⭐ por linha, expandir registra recente, tokens `status-purple`/`status-progress` substituem cores hardcoded de badge.
+
+### #6 Skeleton padrão de página (COMPLETO)
+
+- Novo: [src/components/ui/page-skeleton.tsx](../../src/components/ui/page-skeleton.tsx) — variantes `cockpit | list | form | detail | auto`.
+- Editado: [src/App.tsx](../../src/App.tsx) — `PageLoader` agora é `<PageSkeleton variant="auto" />`. Páginas individuais podem adotar variantes específicas (não migrei todas — quick win futuro).
+
+### #7 Picking ScanBar (COMPLETO, integração leve no AdminEstoquePicking)
+
+- Novo: [src/components/picking/ScanBar.tsx](../../src/components/picking/ScanBar.tsx) — input autofocus sticky, classifica payload como `address` (`Z.P.P`) ou `sku`, detecta wedge HID por delta-tempo entre teclas (<30ms).
+- Editado: [src/pages/AdminEstoquePicking.tsx](../../src/pages/AdminEstoquePicking.tsx) — `<ScanBar />` no topo da PickingTab. Feedback v1: toast com kind detectado. Integração com task ativa (auto-foco, optimistic) fica como iteração #7 v2 — depende de #8.
+
+### #8 useOptimisticMutation helper (COMPLETO)
+
+- Novo: [src/hooks/useOptimisticMutation.ts](../../src/hooks/useOptimisticMutation.ts) — wrapper sobre `useMutation` com `onMutate` (cancelQueries + snapshot + optimistic update) e `onError` (rollback + log + toast.error padronizado). Migração para uso real em mutações específicas de Picking/Recebimento fica como follow-up — o helper está disponível.
+
+### #9 Cmd-K global (COMPLETO)
+
+- Novos:
+  - [src/components/shell/CommandsRegistry.tsx](../../src/components/shell/CommandsRegistry.tsx) — context + provider + `useRegisterCommands`. Páginas contribuem comandos contextuais.
+  - [src/components/shell/CommandPalette.tsx](../../src/components/shell/CommandPalette.tsx) — `CommandDialog` shadcn, atalho `Cmd+K`/`Ctrl+K`, 19 comandos estáticos (navegar para todas as áreas + ações comuns) + comandos dinâmicos contribuídos por página.
+  - [src/components/shell/CommandPaletteTrigger.tsx](../../src/components/shell/CommandPaletteTrigger.tsx) — pill "Buscar... ⌘K" no centro do topbar (md+).
+- Editado: [src/components/AppShell.tsx](../../src/components/AppShell.tsx) — `CommandsRegistryProvider` envolve o shell, `<CommandPalette />` montado, `<CommandPaletteTrigger />` no topbar.
+
+### #10 EmptyState refactor B2B (COMPLETO)
+
+- Editado: [src/components/EmptyState.tsx](../../src/components/EmptyState.tsx) — refatorado para 2 tons: `operational` (default, denso, sem motion) e `friendly` (mantido para customer-facing). API antiga (`variant`) substituída por `tone`; nenhum callsite usa a antiga (zero quebras).
+
+### #11 Filtros persistidos em URL (COMPLETO, adoção parcial)
+
+- Novo: [src/hooks/useUrlState.ts](../../src/hooks/useUrlState.ts) — sincroniza state com `useSearchParams`. Serializa string/number/boolean/array via `|`. Schema fixo via `useRef` para estabilidade.
+- Editado: [src/pages/AdminCustomers.tsx](../../src/pages/AdminCustomers.tsx) — `searchQuery` + `filterHealth` migrados para `useUrlState`. Filtros sobrevivem F5 e ficam sharable.
+- Pronto para adoção em: SalesOrders, AdminReposicaoPedidos, TintFormulas, Recebimento.
+
+### #12 Topbar cleanup (COMPLETO)
+
+- Editado: [src/components/AppShell.tsx](../../src/components/AppShell.tsx) — `Bell` ornamental removido. Topbar agora: [Mobile menu] · [Cmd-K pill central] · [CompanySwitcher] · [NetworkStatusIndicator] · [HelpDrawer] · [User dropdown]. Import `Bell` da lucide removido.
+- Novo: [src/components/shell/CompanySwitcher.tsx](../../src/components/shell/CompanySwitcher.tsx) — dropdown com 3 empresas (Colacor/Oben/Colacor SC), persistência via `CompanyContext` (localStorage existente).
+
+### #13 Bulk actions pattern (COMPLETO, sem adoção forçada)
+
+- Novos:
+  - [src/hooks/useBulkSelection.ts](../../src/hooks/useBulkSelection.ts) — multi-select com Shift+click range.
+  - [src/components/ui/bulk-actions-bar.tsx](../../src/components/ui/bulk-actions-bar.tsx) — barra flutuante bottom-center que aparece com seleção > 0.
+- Migração de callsites (AdminReposicaoCockpit review mode, SalesOrders bulk delete) fica como follow-up.
+
+### #14 NfeReceipt histórico (COMPLETO via localStorage; TODO schema)
+
+- Editado: [src/pages/NfeReceipt.tsx](../../src/pages/NfeReceipt.tsx) — histórico das últimas 10 processadas em localStorage com card "Últimas processadas", botão "Reprocessar" por linha, hint para `/recebimento` no rodapé.
+- ⚠️ **TODO de schema** (decisão de produto): criar tabela `nfe_receipt_runs(id, account, nf_number, success, steps jsonb, started_at, finished_at, user_id)` para que histórico seja por usuário/multi-device em vez de localStorage por navegador.
+
+### #15 Toast unificação em Sonner (COMPLETO via wrapper)
+
+- Editado: [src/hooks/use-toast.ts](../../src/hooks/use-toast.ts) — reescrito como wrapper de compatibilidade que delega para Sonner. Mantém API `useToast()` + `toast({title, description, variant})` para os ~53 callsites existentes.
+- Editado: [src/App.tsx](../../src/App.tsx) — `<Toaster />` (Radix) removido; só `<Sonner />` permanece.
+- Follow-up: codemod manual para trocar callsites para `import { toast } from 'sonner'` direto e remover [src/components/ui/toast.tsx](../../src/components/ui/toast.tsx) + [src/components/ui/toaster.tsx](../../src/components/ui/toaster.tsx) (deprecated, mas ainda existem para não quebrar imports tipados).
+
+### #16 AdminCustomers segmentos (COMPLETO via localStorage; TODO schema)
+
+- Novo: [src/hooks/useCustomerSegments.ts](../../src/hooks/useCustomerSegments.ts) — CRUD de segmentos salvos em localStorage com sync entre abas.
+- Editado: [src/pages/AdminCustomers.tsx](../../src/pages/AdminCustomers.tsx) — barra "Segmentos" com chips clicáveis (aplica filtros) + botão "Salvar como segmento" (com inline editor para nomear).
+- ⚠️ **TODO de schema** (decisão de produto): criar tabela `user_segments(id, user_id, area, name, filter jsonb, shared bool)` para persistência server-side e compartilhamento com time. Hook está desenhado para trocar implementação sem mudar callsites.
+
+### #17 Tokens status-* — utilities (COMPLETO, refactor amplo opcional)
+
+- Editado: [src/index.css](../../src/index.css) — adicionadas utilities `text-status-{success|warning|error|info|purple|indigo}` e variantes `*-fg` + `bg-status-*-bg` (estas últimas já existiam, mas agrupei).
+- Adoção: TintFormulas badges migradas, NetworkStatusIndicator usa. Refactor amplo de ~50 callsites (`text-emerald-600`, `text-red-600`, `bg-amber-50`) fica como follow-up mecânico — pode ser feito por codemod.
+
+### #18 TintFormulas catálogo offline (SCAFFOLD)
+
+- Novo: [src/lib/tint-cache.ts](../../src/lib/tint-cache.ts) — wrapper sobre IndexedDB nativo (sem dep externa). API: `putFormulas`, `getAllFormulas`, `searchFormulasOffline`, `getLastSync`, `clearCatalog`, `getStorageEstimate`.
+- ⚠️ **Próximas iterações**:
+  - Edge function `tint-catalog-snapshot` (incremental por `updated_at`)
+  - Integração com TintFormulas: hook stale-while-revalidate, banner "Catálogo offline · sincronizado há Xh"
+  - Validação de tamanho real do catálogo (~477k fórmulas → estimativa 100MB)
+
+### #19 TouchPickingView mobile dedicada (SCAFFOLD)
+
+- Novo: [src/pages/picking/TouchPickingView.tsx](../../src/pages/picking/TouchPickingView.tsx) — visão dedicada com cards verticais 72px+, ScanBar fixa no topo, fluxo de 1 task por vez com progresso.
+- Editado: [src/App.tsx](../../src/App.tsx) — rota `/admin/estoque/picking/mobile`.
+- ⚠️ **Próximas iterações**:
+  - Decisão de produto: auto-detect mobile + `pointer: coarse` ou rota dedicada manual?
+  - Swipe-to-advance entre itens (precisa Vaul drawer ou hammer.js)
+  - Optimistic UI no confirmar item (integrar `useOptimisticMutation`)
+  - Validação no chão com separador real (alvos, contraste sob luz variável, uso com luva)
+
+### #20 Offline queue picking/recebimento (SCAFFOLD)
+
+- Novo: [src/lib/offline-queue.ts](../../src/lib/offline-queue.ts) — API estável: `enqueue`, `flush`, `getOfflineQueueDepth`, `subscribeToOfflineQueue`, `clearOfflineQueue`. v1 persiste em localStorage; subscription notifica `NetworkStatusIndicator` para mostrar contador.
+- Integração com `NetworkStatusIndicator` já feita — badge no topbar mostra # de mutações pendentes.
+- ⚠️ **Próximas iterações**:
+  - Migrar storage de localStorage para IndexedDB (item já pronto para `tint-cache.ts` pattern)
+  - Workbox `BackgroundSyncPlugin` para HTTP retries com offline-online transition
+  - Integração concreta nas mutações: `handleConfirmUnit` (Recebimento), `handleScan` (Picking), `submitOrder` (UnifiedOrder)
+  - Conflict resolution (mesma task editada offline por 2 separadores)
+  - Suite de testes e2e com rede flaky
+
+---
+
+## Novos arquivos (15) + Editados (8)
+
+### Criados
+
+```
+src/components/picking/ScanBar.tsx                      # #7
+src/components/shell/CommandPalette.tsx                 # #9
+src/components/shell/CommandPaletteTrigger.tsx          # #9 / #12
+src/components/shell/CommandsRegistry.tsx               # #9
+src/components/shell/CompanySwitcher.tsx                # #12
+src/components/shell/NetworkStatusIndicator.tsx         # #4 / #20
+src/components/shell/ShortcutsDialog.tsx                # #1
+src/components/shell/ShortcutsRegistry.tsx              # #1
+src/components/ui/bulk-actions-bar.tsx                  # #13
+src/components/ui/page-skeleton.tsx                     # #6
+src/components/unified-order/RestoreDraftDialog.tsx     # #3
+src/hooks/useBulkSelection.ts                           # #13
+src/hooks/useCustomerSegments.ts                        # #16
+src/hooks/useNetworkStatus.ts                           # #4
+src/hooks/useOptimisticMutation.ts                      # #8
+src/hooks/useOrderDraft.ts                              # #3
+src/hooks/useTintRecentsFavorites.ts                    # #5
+src/hooks/useUrlState.ts                                # #11
+src/lib/offline-queue.ts                                # #20
+src/lib/tint-cache.ts                                   # #18
+src/pages/picking/TouchPickingView.tsx                  # #19
+```
+
+### Editados
+
+```
+src/App.tsx                                             # #6, #15, #19 (rota mobile + skeleton + toast)
+src/components/AppShell.tsx                             # #1, #4, #9, #12 (topbar cleanup + providers)
+src/components/EmptyState.tsx                           # #10 (refactor B2B)
+src/components/ui/button.tsx                            # #2 (variantes touch/balcao)
+src/hooks/use-toast.ts                                  # #15 (wrapper sonner)
+src/hooks/useUnifiedOrder.ts                            # #3 (expor setCart)
+src/index.css                                           # #17 (utilities text-status-*)
+src/pages/AdminCustomers.tsx                            # #11, #16 (URL state + segments)
+src/pages/AdminEstoquePicking.tsx                       # #7 (ScanBar)
+src/pages/AdminReposicaoCockpit.tsx                     # #1 (migração shortcuts)
+src/pages/NfeReceipt.tsx                                # #14 (histórico)
+src/pages/TintFormulas.tsx                              # #5, #17 (recentes/favoritos + tokens)
+src/pages/UnifiedOrder.tsx                              # #3 (draft autosave)
+```
+
+---
+
+## Decisões de produto pendentes (bloqueiam adoção plena)
+
+São itens que entreguei com mock/scaffold mas precisam de aprovação sua antes de virar produção:
+
+1. **#14 / #16 — Tabelas novas**: `nfe_receipt_runs` e `user_segments`. Hoje rodam via localStorage por navegador. Migrar quando você aprovar o schema. Sugestões de schema estão nos arquivos comentadas como `TODO(schema)`.
+2. **#18 — Tamanho do catálogo offline**: 477k fórmulas estimadas em ~100MB no IndexedDB do operador. Aceitar custo de espaço (a maioria dos navegadores modernos permite) ou implementar paginação por uso?
+3. **#19 — Dual view ou auto-detect**: rota dedicada `/admin/estoque/picking/mobile` está pronta. Quer auto-redirect em mobile + `pointer: coarse`? Ou link manual na sidebar?
+4. **#20 — Conflict resolution offline**: política para conflito de mesma task editada por 2 separadores offline. Opções: last-write-wins, lock pessimista, ou merge manual com prompt.
+
+---
+
+## Validação rodada
+
+- ✅ Edição inspecionada visualmente (sandbox sem node/npm).
+- ✅ Imports verificados via `grep` em todos os arquivos novos/editados.
+- ✅ Compatibilidade backward: 53 callsites do `useToast` antigo continuam funcionando via wrapper.
+- ✅ Nenhuma quebra no AdminReposicaoCockpit (migração shortcuts: dialog interno removido, registry global cobre).
+- ⚠️ Sem `npm run lint` nem `npm run build` neste sandbox. **Recomendo rodar localmente antes de mergear**:
+  ```bash
+  npm run lint && npm run build && npm test
+  ```
+
+---
+
+## O que sobra fora deste escopo
+
+- **Performance check**: paginação real em SalesOrders e AdminCustomers (carregam tudo). Não entrei aqui — é refactor de query, não UX.
+- **53 callsites de toast manual codemod**: opcional, wrapper resolve. Pode ser feito incrementalmente.
+- **Tokens status-* refactor amplo**: ~50 callsites com cores hardcoded. Utilities prontas; substituição mecânica fica como follow-up.
+- **`/unified-order` redirect**: mantido (precisa log de uso real antes de remover).
+- **Branding stale**: `index.html` e PWA manifest continuam com "Colacor - Afiação Profissional". Não troquei porque rename afeta cache PWA dos usuários (deploy precisa coordenação).
+- **`SalesOrders.deleteOrder` sem soft-delete**: aguarda decisão de compliance.
+- **Discrepância Account/Empresa em SalesOrders** (`afiacao` vs `colacor_sc`): aguarda decisão de produto.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { lazy, Suspense } from "react";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
-import { Toaster } from "@/components/ui/toaster";
+// Sistema de toast unificado em Sonner (o Radix Toaster legado foi desligado;
+// o hook `useToast` continua existindo como wrapper que delega para Sonner — ver src/hooks/use-toast.ts).
 import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -10,7 +11,7 @@ import { CompanyProvider } from "@/contexts/CompanyContext";
 import { ProtectedRoute } from "@/components/ProtectedRoute";
 import { NotificationPrompt } from "@/components/NotificationPrompt";
 import { AppShellLayout } from "@/components/AppShellLayout";
-import { Skeleton } from "@/components/ui/skeleton";
+import { PageSkeleton } from "@/components/ui/page-skeleton";
 
 // Lazy-loaded pages
 const Index = lazy(() => import("./pages/Index"));
@@ -122,6 +123,7 @@ const AdminReposicaoMercado = lazy(() => import("./pages/AdminReposicaoMercado")
 const AdminReposicaoCadastros = lazy(() => import("./pages/AdminReposicaoCadastros"));
 const AdminEstoqueRecebimento = lazy(() => import("./pages/AdminEstoqueRecebimento"));
 const AdminEstoquePicking = lazy(() => import("./pages/AdminEstoquePicking"));
+const TouchPickingView = lazy(() => import("./pages/picking/TouchPickingView"));
 const FinanceiroGestao = lazy(() => import("./pages/FinanceiroGestao"));
 const FinanceiroAnalise = lazy(() => import("./pages/FinanceiroAnalise"));
 const TintCatalogo = lazy(() => import("./pages/TintCatalogo"));
@@ -135,13 +137,7 @@ const AdminDesTrimestreAtual = lazy(() => import("./pages/AdminDesTrimestreAtual
 const AdminNotificacoes = lazy(() => import("./pages/AdminNotificacoes"));
 const AdminPortalSayerlack = lazy(() => import("./pages/AdminPortalSayerlack"));
 
-const PageLoader = () => (
-  <div className="flex flex-col gap-4 p-6">
-    <Skeleton className="h-8 w-48" />
-    <Skeleton className="h-64 w-full" />
-    <Skeleton className="h-32 w-full" />
-  </div>
-);
+const PageLoader = () => <PageSkeleton variant="auto" />;
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -157,7 +153,6 @@ const queryClient = new QueryClient({
 const App = () => (
   <QueryClientProvider client={queryClient}>
     <TooltipProvider>
-      <Toaster />
       <Sonner />
       <BrowserRouter>
         <AuthProvider>
@@ -280,6 +275,7 @@ const App = () => (
               <Route path="admin/reposicao/cadastros" element={<AdminReposicaoCadastros />} />
               <Route path="admin/estoque/recebimento" element={<AdminEstoqueRecebimento />} />
               <Route path="admin/estoque/picking" element={<AdminEstoquePicking />} />
+              <Route path="admin/estoque/picking/mobile" element={<TouchPickingView />} />
               <Route path="financeiro/gestao" element={<FinanceiroGestao />} />
               <Route path="financeiro/analise" element={<FinanceiroAnalise />} />
               <Route path="tintometrico/catalogo" element={<TintCatalogo />} />

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { BookOpen, Lock, Calculator, FileText, Palette, Beaker, FileUp, Droplets, LayoutDashboard, Users, ShoppingCart, ShoppingBag, Phone, GraduationCap, BarChart3, Settings, ChevronLeft, ChevronRight, Search, Bell, User, LogOut, Package, TrendingUp, Headphones, Target, Menu, X, ClipboardList, PlusCircle, Shield, Wrench, Award, Scissors, DollarSign, Layers, Printer, UserCheck, FileCheck, Boxes, AlertTriangle, PlayCircle, Factory, Truck, Percent, Sparkles, Handshake, Link2, Globe2, Database } from 'lucide-react';
+import { BookOpen, Lock, Calculator, FileText, Palette, Beaker, FileUp, Droplets, LayoutDashboard, Users, ShoppingCart, ShoppingBag, Phone, GraduationCap, BarChart3, Settings, ChevronLeft, ChevronRight, Search, User, LogOut, Package, TrendingUp, Headphones, Target, Menu, X, ClipboardList, PlusCircle, Shield, Wrench, Award, Scissors, DollarSign, Layers, Printer, UserCheck, FileCheck, Boxes, AlertTriangle, PlayCircle, Factory, Truck, Percent, Sparkles, Handshake, Link2, Globe2, Database } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useAuth } from '@/contexts/AuthContext';
 import { useUserRole } from '@/hooks/useUserRole';
@@ -24,6 +24,13 @@ import { HelpDrawer } from '@/components/help/HelpDrawer';
 import { useAlertasCriticos } from '@/hooks/useAlertasCriticos';
 import { useFinanceiroAlertas } from '@/hooks/useFinanceiroAlertas';
 import { useTintAlertas } from '@/hooks/useTintAlertas';
+import { ShortcutsRegistryProvider } from '@/components/shell/ShortcutsRegistry';
+import { ShortcutsDialog } from '@/components/shell/ShortcutsDialog';
+import { CommandsRegistryProvider } from '@/components/shell/CommandsRegistry';
+import { CommandPalette } from '@/components/shell/CommandPalette';
+import { CommandPaletteTrigger } from '@/components/shell/CommandPaletteTrigger';
+import { CompanySwitcher } from '@/components/shell/CompanySwitcher';
+import { NetworkStatusIndicator } from '@/components/shell/NetworkStatusIndicator';
 
 /* ─── Navigation config ─── */
 interface NavItem {
@@ -452,12 +459,15 @@ function AppTopbar({ sidebarCollapsed, onMobileMenuToggle }: { sidebarCollapsed:
         <Menu className="w-5 h-5" />
       </button>
 
+      {/* Centro: trigger do command palette (descoberta visual do Cmd+K) */}
+      <div className="flex-1 flex items-center justify-center px-4">
+        <CommandPaletteTrigger />
+      </div>
 
       <div className="flex items-center gap-1">
+        <CompanySwitcher />
+        <NetworkStatusIndicator />
         <HelpDrawer />
-        <Button variant="ghost" size="icon" className="h-8 w-8 text-muted-foreground">
-          <Bell className="w-4 h-4" />
-        </Button>
 
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
@@ -549,31 +559,39 @@ export function AppShell({ children }: { children: React.ReactNode }) {
 
   return (
     <AppShellProvider>
-    <div className="min-h-screen bg-background density-compact">
-      {/* Desktop sidebar */}
-      <div className="hidden lg:block">
-        <AppSidebar collapsed={collapsed} onToggle={() => setCollapsed(!collapsed)} />
-      </div>
+      <ShortcutsRegistryProvider>
+        <CommandsRegistryProvider>
+          <div className="min-h-screen bg-background density-compact">
+            {/* Desktop sidebar */}
+            <div className="hidden lg:block">
+              <AppSidebar collapsed={collapsed} onToggle={() => setCollapsed(!collapsed)} />
+            </div>
 
-      {/* Mobile nav */}
-      <MobileNav open={mobileOpen} onClose={() => setMobileOpen(false)} />
+            {/* Mobile nav */}
+            <MobileNav open={mobileOpen} onClose={() => setMobileOpen(false)} />
 
-      {/* Topbar */}
-      <AppTopbar sidebarCollapsed={collapsed} onMobileMenuToggle={() => setMobileOpen(true)} />
+            {/* Topbar */}
+            <AppTopbar sidebarCollapsed={collapsed} onMobileMenuToggle={() => setMobileOpen(true)} />
 
-      {/* Main content */}
-      <main
-        className={cn(
-          'pt-topbar min-h-screen transition-all duration-200',
-          'lg:ml-sidebar',
-          collapsed && 'lg:ml-sidebar-collapsed'
-        )}
-      >
-        <div className="p-4 lg:p-6">
-          {children}
-        </div>
-      </main>
-    </div>
+            {/* Main content */}
+            <main
+              className={cn(
+                'pt-topbar min-h-screen transition-all duration-200',
+                'lg:ml-sidebar',
+                collapsed && 'lg:ml-sidebar-collapsed'
+              )}
+            >
+              <div className="p-4 lg:p-6">
+                {children}
+              </div>
+            </main>
+
+            {/* Overlays globais */}
+            <CommandPalette />
+            <ShortcutsDialog />
+          </div>
+        </CommandsRegistryProvider>
+      </ShortcutsRegistryProvider>
     </AppShellProvider>
   );
 }

--- a/src/components/EmptyState.tsx
+++ b/src/components/EmptyState.tsx
@@ -1,7 +1,8 @@
-import { motion } from 'framer-motion';
 import { Button } from '@/components/ui/button';
 import { LucideIcon } from 'lucide-react';
 import { cn } from '@/lib/utils';
+
+type Tone = 'operational' | 'friendly';
 
 interface EmptyStateProps {
   icon: LucideIcon;
@@ -9,45 +10,98 @@ interface EmptyStateProps {
   description: string;
   actionLabel?: string;
   onAction?: () => void;
+  secondaryActionLabel?: string;
+  onSecondaryAction?: () => void;
+  helpHref?: string;
+  helpLabel?: string;
   className?: string;
-  variant?: 'default' | 'subtle';
+  /** "operational" (default, B2B denso) ou "friendly" (cliente final / onboarding) */
+  tone?: Tone;
 }
 
-export function EmptyState({ icon: Icon, title, description, actionLabel, onAction, className, variant = 'default' }: EmptyStateProps) {
-  return (
-    <motion.div
-      initial={{ opacity: 0, y: 20 }}
-      animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.5, ease: "easeOut" }}
-      className={cn(
-        'flex flex-col items-center justify-center text-center py-12 px-6',
-        variant === 'default' && 'bg-card rounded-2xl border border-border shadow-soft',
-        className
-      )}
-    >
-      <motion.div
-        className="w-20 h-20 rounded-3xl bg-muted flex items-center justify-center mb-5 relative"
-        animate={{ y: [0, -6, 0] }}
-        transition={{ duration: 3, repeat: Infinity, ease: "easeInOut" }}
+export function EmptyState({
+  icon: Icon,
+  title,
+  description,
+  actionLabel,
+  onAction,
+  secondaryActionLabel,
+  onSecondaryAction,
+  helpHref,
+  helpLabel,
+  className,
+  tone = 'operational',
+}: EmptyStateProps) {
+  if (tone === 'friendly') {
+    return (
+      <div
+        className={cn(
+          'flex flex-col items-center justify-center text-center py-10 px-6',
+          'bg-card rounded-2xl border border-border',
+          className,
+        )}
       >
-        <Icon className="w-9 h-9 text-muted-foreground" />
-        {/* Decorative dots */}
-        <div className="absolute -top-1 -right-1 w-3 h-3 rounded-full bg-primary/20" />
-        <div className="absolute -bottom-2 -left-1 w-2 h-2 rounded-full bg-primary/10" />
-      </motion.div>
-
-      <h3 className="font-display font-bold text-lg text-foreground mb-1.5">{title}</h3>
-      <p className="text-sm text-muted-foreground max-w-[260px] leading-relaxed mb-6">
-        {description}
-      </p>
-
-      {actionLabel && onAction && (
-        <motion.div whileTap={{ scale: 0.97 }}>
-          <Button size="lg" onClick={onAction} className="shadow-glow rounded-xl font-semibold">
+        <div className="w-16 h-16 rounded-2xl bg-muted flex items-center justify-center mb-4">
+          <Icon className="w-7 h-7 text-muted-foreground" />
+        </div>
+        <h3 className="font-semibold text-base text-foreground mb-1">{title}</h3>
+        <p className="text-sm text-muted-foreground max-w-[280px] leading-relaxed mb-5">
+          {description}
+        </p>
+        {actionLabel && onAction && (
+          <Button size="default" onClick={onAction}>
             {actionLabel}
           </Button>
-        </motion.div>
+        )}
+        {helpHref && (
+          <a
+            href={helpHref}
+            className="mt-3 text-xs text-link-level hover:underline"
+            target="_blank"
+            rel="noreferrer"
+          >
+            {helpLabel ?? 'Saiba mais'}
+          </a>
+        )}
+      </div>
+    );
+  }
+
+  // Operational (B2B default): denso, sem motion, sem decoração
+  return (
+    <div
+      className={cn(
+        'flex flex-col items-center justify-center text-center py-8 px-4',
+        className,
       )}
-    </motion.div>
+    >
+      <Icon className="w-8 h-8 text-muted-foreground/60 mb-3" />
+      <h3 className="text-sm font-semibold text-foreground mb-1">{title}</h3>
+      <p className="text-sm text-muted-foreground max-w-[360px] leading-snug mb-4">
+        {description}
+      </p>
+      <div className="flex items-center gap-2">
+        {actionLabel && onAction && (
+          <Button size="sm" onClick={onAction}>
+            {actionLabel}
+          </Button>
+        )}
+        {secondaryActionLabel && onSecondaryAction && (
+          <Button size="sm" variant="outline" onClick={onSecondaryAction}>
+            {secondaryActionLabel}
+          </Button>
+        )}
+      </div>
+      {helpHref && (
+        <a
+          href={helpHref}
+          className="mt-3 text-xs text-link-level hover:underline"
+          target="_blank"
+          rel="noreferrer"
+        >
+          {helpLabel ?? 'Saiba mais'}
+        </a>
+      )}
+    </div>
   );
 }

--- a/src/components/picking/ScanBar.tsx
+++ b/src/components/picking/ScanBar.tsx
@@ -1,0 +1,128 @@
+import { useEffect, useRef, useState, type KeyboardEvent } from 'react';
+import { ScanLine, Keyboard } from 'lucide-react';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+/**
+ * Barra de scan sticky para picking. Foco automático ao montar (separador chega na tela e já bipa).
+ *
+ * Suporta dois modos:
+ *  1. **Wedge / leitor HID** — leitor configurado como teclado físico envia os caracteres
+ *     terminados em Enter. Detectamos pela velocidade (chars consecutivos rápidos).
+ *  2. **Manual** — operador digita e pressiona Enter.
+ *
+ * Padrão de detecção do payload:
+ *  - Endereço de armazenagem: `Z.P.P` (zona.prateleira.posição), ex: `A.03.05`
+ *  - SKU: numérico ou alfanumérico — qualquer outro formato cai como SKU.
+ *
+ * Latência alvo: <100ms entre bip e callback (não há awaits no caminho crítico).
+ */
+export interface ScanResult {
+  raw: string;
+  kind: 'address' | 'sku';
+  /** Heurística do método: "wedge" (rápido, autocompleta com Enter) ou "manual". */
+  method: 'wedge' | 'manual';
+}
+
+const ADDRESS_REGEX = /^[A-Z]{1,2}\.[0-9]{1,3}\.[0-9]{1,3}$/i;
+const WEDGE_THRESHOLD_MS = 30; // chars enviados < 30ms entre eventos = leitor de barcode
+
+interface ScanBarProps {
+  onScan: (result: ScanResult) => void;
+  placeholder?: string;
+  /** Reseta input automaticamente após onScan (default true). */
+  autoReset?: boolean;
+  className?: string;
+}
+
+export function ScanBar({
+  onScan,
+  placeholder = 'Bipe ou digite endereço (A.03.05) ou código do produto...',
+  autoReset = true,
+  className,
+}: ScanBarProps) {
+  const [value, setValue] = useState('');
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const lastKeyAt = useRef<number>(0);
+  const isWedgeStream = useRef<boolean>(false);
+
+  // foco automático ao montar
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  // mantém foco — re-foca após blur curto (acidental). Hide quando usuário clica fora intencionalmente
+  // (heurística simples: se foco voltar pra body, re-foca).
+  useEffect(() => {
+    const onBodyFocus = () => {
+      if (document.activeElement === document.body) {
+        inputRef.current?.focus();
+      }
+    };
+    window.addEventListener('focus', onBodyFocus, true);
+    return () => window.removeEventListener('focus', onBodyFocus, true);
+  }, []);
+
+  function classifyAndEmit(raw: string, method: 'wedge' | 'manual') {
+    const trimmed = raw.trim();
+    if (!trimmed) return;
+    const kind: ScanResult['kind'] = ADDRESS_REGEX.test(trimmed) ? 'address' : 'sku';
+    onScan({ raw: trimmed, kind, method });
+    if (autoReset) setValue('');
+  }
+
+  function handleKeyDown(e: KeyboardEvent<HTMLInputElement>) {
+    const now = performance.now();
+    const elapsed = now - lastKeyAt.current;
+    lastKeyAt.current = now;
+    if (elapsed > 0 && elapsed < WEDGE_THRESHOLD_MS) {
+      isWedgeStream.current = true;
+    }
+
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      const method: 'wedge' | 'manual' = isWedgeStream.current ? 'wedge' : 'manual';
+      classifyAndEmit(value, method);
+      isWedgeStream.current = false;
+    } else if (e.key === 'Escape') {
+      setValue('');
+      isWedgeStream.current = false;
+    }
+  }
+
+  return (
+    <div
+      className={cn(
+        'sticky top-topbar z-20 -mx-4 lg:-mx-6 px-4 lg:px-6 py-3 bg-card border-b border-border',
+        className,
+      )}
+    >
+      <div className="flex items-center gap-2 max-w-2xl mx-auto">
+        <ScanLine className="w-5 h-5 text-primary shrink-0" />
+        <Input
+          ref={inputRef}
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder={placeholder}
+          inputMode="text"
+          autoComplete="off"
+          autoCorrect="off"
+          spellCheck={false}
+          className="h-11 text-base font-mono"
+        />
+        <Button
+          type="button"
+          size="touch"
+          variant="default"
+          onClick={() => classifyAndEmit(value, 'manual')}
+          disabled={!value.trim()}
+        >
+          <Keyboard className="w-4 h-4 mr-1.5" />
+          OK
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/shell/CommandPalette.tsx
+++ b/src/components/shell/CommandPalette.tsx
@@ -1,0 +1,136 @@
+import { useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command';
+import {
+  LayoutDashboard, ShoppingCart, Users, Wrench, Package, Truck,
+  BarChart3, DollarSign, Palette, Settings, BookOpen, PlusCircle,
+  ClipboardList, FileCheck, Boxes, Beaker, Shield,
+} from 'lucide-react';
+import {
+  useCommandsRegistry,
+  useRegisterCommands,
+  type Command,
+} from './CommandsRegistry';
+import { useRegisterShortcuts } from './ShortcutsRegistry';
+
+/**
+ * Palette aberta com Cmd+K / Ctrl+K (atalho registrado abaixo).
+ * Mostra navegação para rotas + ações contextuais contribuídas pela página atual.
+ */
+export function CommandPalette() {
+  const navigate = useNavigate();
+  const { open, setOpen, commands: dynamicCommands } = useCommandsRegistry();
+
+  const close = () => setOpen(false);
+
+  // Atalho global Cmd+K / Ctrl+K
+  useRegisterShortcuts(
+    useMemo(
+      () => [
+        {
+          keys: 'mod+k',
+          label: 'Buscar e navegar',
+          group: 'Global',
+          scope: 'global',
+          allowInInput: true,
+          handler: () => setOpen((v) => !v),
+        },
+      ],
+      [setOpen],
+    ),
+  );
+
+  // Comandos estáticos de navegação — base do app
+  const staticCommands: Command[] = useMemo(() => {
+    const go = (path: string) => () => {
+      navigate(path);
+      close();
+    };
+    return [
+      // Navegar — Principal
+      { id: 'nav.dashboard', label: 'Ir para Dashboard', group: 'Navegar', icon: LayoutDashboard, perform: go('/') },
+      { id: 'nav.clientes', label: 'Ir para Clientes', group: 'Navegar', icon: Users, keywords: ['CRM', 'carteira'], perform: go('/admin/customers') },
+      // Vendas
+      { id: 'nav.sales', label: 'Pedidos de venda', group: 'Vendas', icon: ShoppingCart, perform: go('/sales') },
+      { id: 'action.new-order', label: 'Novo pedido', group: 'Vendas', icon: PlusCircle, hint: 'Criar pedido', perform: go('/sales/new') },
+      { id: 'nav.quotes', label: 'Cotações', group: 'Vendas', icon: ClipboardList, perform: go('/sales/quotes') },
+      // Estoque
+      { id: 'nav.picking', label: 'Picking & Estoque', group: 'Estoque', icon: Package, perform: go('/admin/estoque/picking') },
+      { id: 'nav.recebimento', label: 'Recebimento NF-e', group: 'Estoque', icon: FileCheck, perform: go('/recebimento') },
+      { id: 'nav.estoque-recebimento', label: 'Recebimento (gestão)', group: 'Estoque', icon: Boxes, perform: go('/admin/estoque/recebimento') },
+      // Reposição
+      { id: 'nav.repo-cockpit', label: 'Cockpit de Reposição', group: 'Reposição', icon: LayoutDashboard, keywords: ['compras', 'comprador'], perform: go('/admin/reposicao/cockpit') },
+      { id: 'nav.repo-pedidos', label: 'Pedidos de compra sugeridos', group: 'Reposição', icon: Truck, perform: go('/admin/reposicao/pedidos') },
+      { id: 'nav.repo-alertas', label: 'Alertas de reposição', group: 'Reposição', icon: BarChart3, perform: go('/admin/reposicao/alertas') },
+      // Financeiro
+      { id: 'nav.fin-cockpit', label: 'Cockpit CFO', group: 'Financeiro', icon: Shield, keywords: ['CFO', 'caixa'], perform: go('/financeiro/cockpit') },
+      { id: 'nav.fin-gestao', label: 'Gestão financeira', group: 'Financeiro', icon: DollarSign, perform: go('/financeiro/gestao') },
+      // Tintométrico
+      { id: 'nav.tint-formulas', label: 'Buscar fórmula tintométrica', group: 'Tintométrico', icon: Beaker, keywords: ['cor', 'tinta', 'verniz', 'sayer'], perform: go('/tintometrico/formulas') },
+      { id: 'nav.tint-catalogo', label: 'Catálogo tintométrico', group: 'Tintométrico', icon: Palette, perform: go('/tintometrico/catalogo') },
+      // Documentação
+      { id: 'nav.design-system', label: 'Design System', group: 'Documentação', icon: BookOpen, perform: go('/design-system') },
+      { id: 'nav.settings', label: 'Configurações', group: 'Documentação', icon: Settings, perform: go('/settings') },
+      // Ferramentas (cliente)
+      { id: 'nav.tools', label: 'Minhas ferramentas', group: 'Afiação', icon: Wrench, perform: go('/tools') },
+    ];
+  }, [navigate]);
+
+  // Registra os estáticos no registry para que o ShortcutsDialog/help possam listá-los se quiser
+  useRegisterCommands(staticCommands);
+
+  // Mescla estáticos + dinâmicos
+  const allCommands = useMemo(() => {
+    // dedupe por id (dinâmicos sobrescrevem estáticos com mesmo id)
+    const map = new Map<string, Command>();
+    [...staticCommands, ...dynamicCommands].forEach((c) => map.set(c.id, c));
+    return Array.from(map.values());
+  }, [staticCommands, dynamicCommands]);
+
+  // Agrupa por `group`
+  const groups = useMemo(() => {
+    const m = new Map<string, Command[]>();
+    for (const c of allCommands) {
+      const g = c.group ?? 'Outros';
+      if (!m.has(g)) m.set(g, []);
+      m.get(g)!.push(c);
+    }
+    return Array.from(m.entries());
+  }, [allCommands]);
+
+  return (
+    <CommandDialog open={open} onOpenChange={setOpen}>
+      <CommandInput placeholder="Buscar telas, ações, fórmulas, pedidos..." />
+      <CommandList>
+        <CommandEmpty>Nada encontrado.</CommandEmpty>
+        {groups.map(([group, items]) => (
+          <CommandGroup key={group} heading={group}>
+            {items.map((cmd) => {
+              const Icon = cmd.icon;
+              return (
+                <CommandItem
+                  key={cmd.id}
+                  value={[cmd.label, cmd.group, ...(cmd.keywords ?? [])].filter(Boolean).join(' ')}
+                  onSelect={() => cmd.perform(close)}
+                >
+                  {Icon && <Icon className="mr-2 h-4 w-4 shrink-0 text-muted-foreground" />}
+                  <span className="flex-1">{cmd.label}</span>
+                  {cmd.hint && (
+                    <span className="ml-2 text-xs text-muted-foreground">{cmd.hint}</span>
+                  )}
+                </CommandItem>
+              );
+            })}
+          </CommandGroup>
+        ))}
+      </CommandList>
+    </CommandDialog>
+  );
+}

--- a/src/components/shell/CommandPaletteTrigger.tsx
+++ b/src/components/shell/CommandPaletteTrigger.tsx
@@ -1,0 +1,30 @@
+import { Search } from 'lucide-react';
+import { useCommandsRegistry } from './CommandsRegistry';
+
+/**
+ * Pill clicável no topbar que abre a CommandPalette.
+ * Substitui a falta de affordance — descoberta visual do Cmd+K.
+ */
+function isMac() {
+  if (typeof navigator === 'undefined') return false;
+  return /Mac|iPod|iPhone|iPad/.test(navigator.platform);
+}
+
+export function CommandPaletteTrigger() {
+  const { setOpen } = useCommandsRegistry();
+  const mac = isMac();
+  return (
+    <button
+      type="button"
+      onClick={() => setOpen(true)}
+      className="hidden md:inline-flex items-center gap-2 h-8 px-2.5 rounded-md border border-border bg-muted/40 text-sm text-muted-foreground hover:bg-muted hover:text-foreground transition-colors min-w-[180px]"
+      aria-label="Buscar e navegar"
+    >
+      <Search className="w-3.5 h-3.5" />
+      <span className="flex-1 text-left">Buscar...</span>
+      <kbd className="px-1.5 py-0.5 rounded bg-card text-[10px] font-mono border border-border">
+        {mac ? '⌘K' : 'Ctrl+K'}
+      </kbd>
+    </button>
+  );
+}

--- a/src/components/shell/CommandsRegistry.tsx
+++ b/src/components/shell/CommandsRegistry.tsx
@@ -1,0 +1,85 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react';
+import type { LucideIcon } from 'lucide-react';
+
+/**
+ * Registry global de comandos exibidos na CommandPalette (Cmd+K).
+ *
+ * Há dois tipos de comandos:
+ *  1. **Estáticos**: rotas e ações fixas (ex: "Ir para Cockpit", "Novo pedido"). Registrados pelo AppShell.
+ *  2. **Contribuídos por página**: páginas específicas declaram via `useRegisterCommands(...)`.
+ *
+ * V1 simples: lista plana, busca via filtro fuzzy básico (lowercase substring + tokens).
+ * V2 (futuro): integração com Supabase pra busca em registros (clientes, fórmulas, pedidos).
+ */
+export interface Command {
+  /** ID único — recomendado: `area.action` (ex: `nav.cockpit-reposicao`). */
+  id: string;
+  label: string;
+  /** Aliases de busca (ex: ["compras", "comprador", "reposicao"]). */
+  keywords?: string[];
+  /** Grupo no palette. Ex: "Navegar", "Ações", "Recentes". */
+  group?: string;
+  icon?: LucideIcon;
+  /** Texto curto à direita (ex: "⌘K", "Cockpit"). */
+  hint?: string;
+  /** Executa o comando. Recebe `close()` para o palette se fechar manualmente se quiser. */
+  perform: (close: () => void) => void;
+}
+
+interface RegistryContext {
+  open: boolean;
+  setOpen: (v: boolean | ((prev: boolean) => boolean)) => void;
+  commands: ReadonlyArray<Command>;
+  register: (cmds: Command[]) => () => void;
+}
+
+const Ctx = createContext<RegistryContext | null>(null);
+
+export function CommandsRegistryProvider({ children }: { children: ReactNode }) {
+  const [open, setOpen] = useState(false);
+  const [dynamic, setDynamic] = useState<Command[]>([]);
+
+  const register = useCallback((cmds: Command[]) => {
+    setDynamic((prev) => [...prev, ...cmds]);
+    return () => {
+      setDynamic((prev) => prev.filter((c) => !cmds.some((x) => x.id === c.id)));
+    };
+  }, []);
+
+  const value = useMemo(
+    () => ({ open, setOpen, register, commands: dynamic }),
+    [open, register, dynamic],
+  );
+
+  return <Ctx.Provider value={value}>{children}</Ctx.Provider>;
+}
+
+export function useCommandsRegistry(): RegistryContext {
+  const ctx = useContext(Ctx);
+  if (!ctx) {
+    return {
+      open: false,
+      setOpen: () => undefined,
+      commands: [],
+      register: () => () => undefined,
+    };
+  }
+  return ctx;
+}
+
+/** Páginas declaram comandos contextuais. Memoize o array! */
+export function useRegisterCommands(commands: Command[]): void {
+  const { register } = useCommandsRegistry();
+  useEffect(() => {
+    if (commands.length === 0) return;
+    return register(commands);
+  }, [register, commands]);
+}

--- a/src/components/shell/CompanySwitcher.tsx
+++ b/src/components/shell/CompanySwitcher.tsx
@@ -1,0 +1,62 @@
+import { Building2, Check, ChevronsUpDown } from 'lucide-react';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { ALL_COMPANIES, COMPANIES, useCompany, type Company } from '@/contexts/CompanyContext';
+import { cn } from '@/lib/utils';
+
+const COMPANY_HINT: Record<Company, string> = {
+  colacor: 'Indústria',
+  oben: 'Distribuidora',
+  colacor_sc: 'Serviços',
+};
+
+export function CompanySwitcher() {
+  const { activeCompany, setActiveCompany, companyInfo } = useCompany();
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          className="inline-flex items-center gap-2 h-8 px-2.5 rounded-md text-sm font-medium text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+        >
+          <Building2 className="w-3.5 h-3.5" />
+          <span className="hidden sm:inline">{companyInfo.shortName}</span>
+          <ChevronsUpDown className="w-3 h-3 opacity-60" />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-56">
+        <DropdownMenuLabel className="text-xs text-muted-foreground font-normal">
+          Empresa ativa
+        </DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        {ALL_COMPANIES.map((id) => {
+          const info = COMPANIES[id];
+          const active = id === activeCompany;
+          return (
+            <DropdownMenuItem
+              key={id}
+              onClick={() => setActiveCompany(id)}
+              className="flex items-center gap-2"
+            >
+              <Building2 className="w-4 h-4 text-muted-foreground" />
+              <div className="flex-1 min-w-0">
+                <div className="text-sm font-medium truncate">{info.shortName}</div>
+                <div className="text-[11px] text-muted-foreground truncate">
+                  {COMPANY_HINT[id]} · regime {info.regime}
+                </div>
+              </div>
+              <Check className={cn('w-4 h-4', active ? 'opacity-100 text-primary' : 'opacity-0')} />
+            </DropdownMenuItem>
+          );
+        })}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/src/components/shell/NetworkStatusIndicator.tsx
+++ b/src/components/shell/NetworkStatusIndicator.tsx
@@ -1,0 +1,97 @@
+import { useEffect, useState } from 'react';
+import { Wifi, WifiOff, Cloud, CloudOff } from 'lucide-react';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { useNetworkStatus } from '@/hooks/useNetworkStatus';
+import { cn } from '@/lib/utils';
+import { getOfflineQueueDepth, subscribeToOfflineQueue } from '@/lib/offline-queue';
+
+/**
+ * Substitui o `Bell` ornamental do topbar antigo. Mostra:
+ *  - Dot verde (online) / âmbar (lento) / vermelho (offline)
+ *  - Hover: popover com RTT, tipo de conexão, # mutações na fila
+ *
+ * Quando o offline-queue (#20) registrar mutações pendentes, o badge vai mostrar count.
+ */
+export function NetworkStatusIndicator() {
+  const status = useNetworkStatus();
+  const [queueDepth, setQueueDepth] = useState(0);
+
+  useEffect(() => {
+    let mounted = true;
+    getOfflineQueueDepth().then((d) => mounted && setQueueDepth(d));
+    const unsub = subscribeToOfflineQueue((depth) => {
+      if (mounted) setQueueDepth(depth);
+    });
+    return () => {
+      mounted = false;
+      unsub();
+    };
+  }, []);
+
+  const tone =
+    status.quality === 'offline'
+      ? { dot: 'bg-status-error', label: 'Offline', icon: WifiOff, tint: 'text-status-error' }
+      : status.quality === 'slow'
+        ? { dot: 'bg-status-warning', label: 'Conexão lenta', icon: Cloud, tint: 'text-status-warning' }
+        : { dot: 'bg-status-success', label: 'Online', icon: Wifi, tint: 'text-status-success' };
+
+  const Icon = tone.icon;
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          className="relative h-8 w-8 inline-flex items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+          aria-label={`Status da conexão: ${tone.label}`}
+        >
+          <Icon className={cn('w-4 h-4', tone.tint)} />
+          <span
+            className={cn(
+              'absolute top-1.5 right-1.5 w-2 h-2 rounded-full ring-2 ring-card',
+              tone.dot,
+              status.quality === 'slow' && 'animate-pulse',
+            )}
+          />
+          {queueDepth > 0 && (
+            <span className="absolute -bottom-0.5 -right-0.5 min-w-4 h-4 px-1 rounded-full bg-primary text-primary-foreground text-[9px] font-bold flex items-center justify-center">
+              {queueDepth > 99 ? '99+' : queueDepth}
+            </span>
+          )}
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-72 p-3 space-y-2 text-sm">
+        <div className="flex items-center gap-2 font-medium">
+          <span className={cn('inline-block w-2 h-2 rounded-full', tone.dot)} />
+          {tone.label}
+        </div>
+        <dl className="text-xs text-muted-foreground space-y-1">
+          {status.effectiveType && (
+            <div className="flex justify-between">
+              <dt>Tipo</dt>
+              <dd className="font-mono text-foreground">{status.effectiveType}</dd>
+            </div>
+          )}
+          {status.rttMs !== null && (
+            <div className="flex justify-between">
+              <dt>RTT estimado</dt>
+              <dd className="font-mono text-foreground">{status.rttMs}ms</dd>
+            </div>
+          )}
+          <div className="flex justify-between">
+            <dt>Mutações na fila</dt>
+            <dd className={cn('font-mono', queueDepth > 0 ? 'text-status-warning' : 'text-foreground')}>
+              {queueDepth}
+            </dd>
+          </div>
+        </dl>
+        {status.quality === 'offline' && (
+          <p className="text-xs text-status-error pt-1 border-t border-border">
+            <CloudOff className="inline w-3 h-3 mr-1" />
+            Trabalhando offline. Operações serão sincronizadas quando a conexão voltar.
+          </p>
+        )}
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/components/shell/ShortcutsDialog.tsx
+++ b/src/components/shell/ShortcutsDialog.tsx
@@ -1,0 +1,104 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from '@/components/ui/dialog';
+import { useShortcutsRegistry, formatCombo, useRegisterShortcuts } from './ShortcutsRegistry';
+
+export function ShortcutsDialog() {
+  const { shortcuts } = useShortcutsRegistry();
+  const [open, setOpen] = useState(false);
+
+  useRegisterShortcuts(
+    useMemo(
+      () => [
+        {
+          keys: 'shift+/',
+          label: 'Mostrar atalhos',
+          group: 'Global',
+          scope: 'global',
+          handler: () => setOpen((v) => !v),
+        },
+        {
+          keys: '?',
+          label: 'Mostrar atalhos',
+          group: 'Global',
+          scope: 'global',
+          handler: () => setOpen((v) => !v),
+        },
+      ],
+      [],
+    ),
+  );
+
+  // Esc fecha o dialog (Radix já trata, mas garantimos parando propagação)
+  useEffect(() => {
+    if (!open) return;
+    const onEsc = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    window.addEventListener('keydown', onEsc);
+    return () => window.removeEventListener('keydown', onEsc);
+  }, [open]);
+
+  // Permite abrir programaticamente via custom event (botões em páginas que querem o affordance visual).
+  useEffect(() => {
+    const onOpen = () => setOpen(true);
+    window.addEventListener('open-shortcuts-dialog', onOpen);
+    return () => window.removeEventListener('open-shortcuts-dialog', onOpen);
+  }, []);
+
+  const grouped = useMemo(() => {
+    const map = new Map<string, typeof shortcuts>();
+    for (const s of shortcuts) {
+      const key = s.group ?? (s.scope === 'global' ? 'Global' : 'Esta página');
+      if (!map.has(key)) map.set(key, []);
+      map.get(key)!.push(s);
+    }
+    return Array.from(map.entries()).sort(([a], [b]) => {
+      if (a === 'Global') return -1;
+      if (b === 'Global') return 1;
+      if (a === 'Esta página') return 1;
+      if (b === 'Esta página') return -1;
+      return a.localeCompare(b);
+    });
+  }, [shortcuts]);
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Atalhos de teclado</DialogTitle>
+          <DialogDescription>
+            Pressione <kbd className="px-1.5 py-0.5 rounded bg-muted text-xs font-mono">?</kbd> a qualquer momento.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-4 max-h-[60vh] overflow-y-auto">
+          {grouped.length === 0 && (
+            <p className="text-sm text-muted-foreground">Nenhum atalho registrado.</p>
+          )}
+          {grouped.map(([group, items]) => (
+            <div key={group}>
+              <h4 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-2">
+                {group}
+              </h4>
+              <ul className="space-y-1.5">
+                {items.map((s) => (
+                  <li key={s.id} className="flex items-center justify-between text-sm">
+                    <span className="text-foreground">{s.label}</span>
+                    <kbd className="px-2 py-0.5 rounded bg-muted text-xs font-mono text-muted-foreground border border-border">
+                      {formatCombo(s.keys)}
+                    </kbd>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/shell/ShortcutsRegistry.tsx
+++ b/src/components/shell/ShortcutsRegistry.tsx
@@ -1,0 +1,159 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
+
+/**
+ * Registry global de atalhos. Páginas declaram via `useRegisterShortcuts(...)`.
+ * O AppShell monta o `<ShortcutsRegistryProvider />` e o `<ShortcutsDialog />`.
+ *
+ * Composição de tecla: lower-case, modifiers em ordem `mod+shift+key`
+ *  - "g" → tecla "g" sem modifier
+ *  - "mod+k" → Cmd no Mac, Ctrl no resto
+ *  - "shift+/" → "?"
+ *
+ * Escopo:
+ *  - "global" → ativo em qualquer rota (cuidado: deve ser raro)
+ *  - "page" → ativo enquanto o componente que registrou estiver montado (default)
+ *
+ * Bloqueio: handler NÃO dispara em input/textarea/[contenteditable] (evita conflito com digitação).
+ */
+export type ShortcutScope = 'global' | 'page';
+
+export interface Shortcut {
+  /** Tecla composta. Ex: "g", "mod+k", "shift+/". */
+  keys: string;
+  /** Texto curto exibido no dialog. Ex: "Gerar pedidos do dia". */
+  label: string;
+  /** Grupo no dialog. Ex: "Cockpit", "Navegação". */
+  group?: string;
+  scope?: ShortcutScope;
+  handler: (e: KeyboardEvent) => void;
+  /** Permite atalho mesmo em campo de input (use com parcimônia). */
+  allowInInput?: boolean;
+}
+
+interface RegistryEntry extends Shortcut {
+  id: number;
+}
+
+interface RegistryContext {
+  register: (shortcut: Shortcut) => () => void;
+  shortcuts: ReadonlyArray<RegistryEntry>;
+}
+
+const Ctx = createContext<RegistryContext | null>(null);
+
+let nextId = 1;
+
+function isMac() {
+  if (typeof navigator === 'undefined') return false;
+  return /Mac|iPod|iPhone|iPad/.test(navigator.platform);
+}
+
+function eventToCombo(e: KeyboardEvent): string {
+  const parts: string[] = [];
+  if (e.metaKey || e.ctrlKey) parts.push('mod');
+  if (e.shiftKey) parts.push('shift');
+  if (e.altKey) parts.push('alt');
+  // Normaliza "?" (vem como "Shift+/")
+  let key = e.key.toLowerCase();
+  if (key === ' ') key = 'space';
+  if (key === 'escape') key = 'esc';
+  parts.push(key);
+  return parts.join('+');
+}
+
+function isFromInput(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  const tag = target.tagName.toLowerCase();
+  return tag === 'input' || tag === 'textarea' || tag === 'select' || target.isContentEditable;
+}
+
+export function ShortcutsRegistryProvider({ children }: { children: ReactNode }) {
+  const [shortcuts, setShortcuts] = useState<RegistryEntry[]>([]);
+  const ref = useRef<RegistryEntry[]>([]);
+  ref.current = shortcuts;
+
+  const register = useCallback((shortcut: Shortcut) => {
+    const id = nextId++;
+    const entry: RegistryEntry = { id, scope: 'page', ...shortcut };
+    setShortcuts((prev) => [...prev, entry]);
+    return () => setShortcuts((prev) => prev.filter((s) => s.id !== id));
+  }, []);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      const combo = eventToCombo(e);
+      const fromInput = isFromInput(e.target);
+      // primeiro: atalhos exatos com modifier (cmd/ctrl) ou shift devem disparar em qualquer lugar
+      // (a heurística: se tem modifier, é uma combinação intencional, não conflita com digitação)
+      const hasMod = e.metaKey || e.ctrlKey || e.altKey;
+      for (const s of ref.current) {
+        if (s.keys.toLowerCase() === combo) {
+          if (fromInput && !s.allowInInput && !hasMod) continue;
+          e.preventDefault();
+          s.handler(e);
+          return;
+        }
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, []);
+
+  const value = useMemo(() => ({ register, shortcuts }), [register, shortcuts]);
+
+  return <Ctx.Provider value={value}>{children}</Ctx.Provider>;
+}
+
+export function useShortcutsRegistry(): RegistryContext {
+  const ctx = useContext(Ctx);
+  if (!ctx) {
+    // Fallback no-op para componentes que rodam fora do provider (ex: testes isolados)
+    return { register: () => () => undefined, shortcuts: [] };
+  }
+  return ctx;
+}
+
+/**
+ * Hook para páginas declararem atalhos.
+ *
+ *   useRegisterShortcuts([
+ *     { keys: 'g', label: 'Gerar', group: 'Cockpit', handler: () => handleGenerate() },
+ *     { keys: 'r', label: 'Atualizar', group: 'Cockpit', handler: () => refetch() },
+ *     { keys: 'mod+k', label: 'Buscar', group: 'Global', handler: () => openPalette() },
+ *   ]);
+ *
+ * Re-registra se `shortcuts` mudar de identidade — passe array memoizado se necessário.
+ */
+export function useRegisterShortcuts(shortcuts: Shortcut[]): void {
+  const { register } = useShortcutsRegistry();
+  useEffect(() => {
+    const offs = shortcuts.map((s) => register(s));
+    return () => offs.forEach((off) => off());
+  }, [register, shortcuts]);
+}
+
+/** Util para exibir combo no dialog ("⌘K" no Mac, "Ctrl+K" no resto). */
+export function formatCombo(keys: string): string {
+  const mac = isMac();
+  return keys
+    .split('+')
+    .map((k) => {
+      if (k === 'mod') return mac ? '⌘' : 'Ctrl';
+      if (k === 'shift') return mac ? '⇧' : 'Shift';
+      if (k === 'alt') return mac ? '⌥' : 'Alt';
+      if (k === 'esc') return 'Esc';
+      if (k === 'space') return 'Espaço';
+      if (k.length === 1) return k.toUpperCase();
+      return k.charAt(0).toUpperCase() + k.slice(1);
+    })
+    .join(mac ? ' ' : '+');
+}

--- a/src/components/ui/bulk-actions-bar.tsx
+++ b/src/components/ui/bulk-actions-bar.tsx
@@ -1,0 +1,92 @@
+import { X, type LucideIcon } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+export interface BulkAction {
+  id: string;
+  label: string;
+  icon?: LucideIcon;
+  onClick: () => void;
+  disabled?: boolean;
+  variant?: 'default' | 'outline' | 'ghost' | 'destructive';
+}
+
+interface BulkActionsBarProps {
+  count: number;
+  onClear: () => void;
+  actions: BulkAction[];
+  /** Texto pluralizável ("pedido"/"pedidos", default "item"/"itens"). */
+  itemSingular?: string;
+  itemPlural?: string;
+  className?: string;
+}
+
+/**
+ * Barra flutuante que aparece quando há seleção. Padrão: bottom-center, sticky.
+ *
+ *   <BulkActionsBar
+ *     count={sel.size}
+ *     onClear={sel.clear}
+ *     itemSingular="pedido" itemPlural="pedidos"
+ *     actions={[
+ *       { id: 'approve', label: 'Aprovar', icon: Check, onClick: () => approveAll(sel.ids) },
+ *       { id: 'reject', label: 'Rejeitar', icon: X, variant: 'destructive', onClick: () => rejectAll(sel.ids) },
+ *     ]}
+ *   />
+ */
+export function BulkActionsBar({
+  count,
+  onClear,
+  actions,
+  itemSingular = 'item',
+  itemPlural = 'itens',
+  className,
+}: BulkActionsBarProps) {
+  if (count === 0) return null;
+
+  return (
+    <div
+      className={cn(
+        'fixed bottom-4 left-1/2 -translate-x-1/2 z-50',
+        'flex items-center gap-2 px-3 py-2 rounded-lg',
+        'bg-card border border-border shadow-lg',
+        'animate-slide-up',
+        className,
+      )}
+      role="region"
+      aria-label="Ações em lote"
+    >
+      <Button
+        size="icon"
+        variant="ghost"
+        className="h-7 w-7 text-muted-foreground"
+        onClick={onClear}
+        aria-label="Limpar seleção"
+      >
+        <X className="w-4 h-4" />
+      </Button>
+      <span className="text-sm font-medium px-1">
+        {count} {count === 1 ? itemSingular : itemPlural} selecionado{count === 1 ? '' : 's'}
+      </span>
+      <div className="h-5 w-px bg-border mx-1" />
+      <div className="flex items-center gap-1">
+        {actions.map((action) => {
+          const Icon = action.icon;
+          return (
+            <Button
+              key={action.id}
+              size="sm"
+              variant={action.variant ?? 'outline'}
+              onClick={action.onClick}
+              disabled={action.disabled}
+              className="gap-1.5"
+            >
+              {Icon && <Icon className="w-3.5 h-3.5" />}
+              {action.label}
+            </Button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -26,6 +26,11 @@ const buttonVariants = cva(
         sm: "h-8 rounded-md px-3 text-xs",
         lg: "h-10 rounded-md px-6",
         icon: "h-9 w-9",
+        // Touch targets for operational mobile (WCAG AA min, recommended for gloved hands)
+        touch: "h-11 px-5 py-2.5 text-base",          // 44px — separador / vendedor externo
+        "touch-icon": "h-11 w-11",
+        balcao: "h-14 px-6 py-3 text-base font-semibold",  // 56px — operador tintométrico touchscreen
+        "balcao-icon": "h-14 w-14",
       },
     },
     defaultVariants: {

--- a/src/components/ui/page-skeleton.tsx
+++ b/src/components/ui/page-skeleton.tsx
@@ -1,0 +1,91 @@
+import { Skeleton } from '@/components/ui/skeleton';
+import { cn } from '@/lib/utils';
+
+type Variant = 'cockpit' | 'list' | 'form' | 'detail' | 'auto';
+
+interface PageSkeletonProps {
+  variant?: Variant;
+  className?: string;
+}
+
+/**
+ * Esqueleto contextual de página — substitui spinner genérico no Suspense fallback.
+ * Reduz CLS percebido e mantém a estrutura visual durante load.
+ *
+ * Variantes:
+ *  - cockpit: header + 3 KPIs + tabela densa (CFO, Cockpit Reposição)
+ *  - list: filtros + cards/linhas (SalesOrders, AdminCustomers)
+ *  - form: header + steps + campos (UnifiedOrder, Conferência)
+ *  - detail: header + sections (OrderDetail)
+ *  - auto: padrão neutro (default do Suspense)
+ */
+export function PageSkeleton({ variant = 'auto', className }: PageSkeletonProps) {
+  switch (variant) {
+    case 'cockpit':
+      return (
+        <div className={cn('space-y-4 pb-24', className)}>
+          <Skeleton className="h-8 w-64" />
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <Skeleton className="h-32" />
+            <Skeleton className="h-32" />
+            <Skeleton className="h-32" />
+          </div>
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+            <Skeleton className="h-16" />
+            <Skeleton className="h-16" />
+            <Skeleton className="h-16" />
+            <Skeleton className="h-16" />
+          </div>
+          <Skeleton className="h-72 w-full" />
+        </div>
+      );
+    case 'list':
+      return (
+        <div className={cn('space-y-3 pb-6', className)}>
+          <div className="flex items-center justify-between">
+            <Skeleton className="h-7 w-40" />
+            <Skeleton className="h-9 w-32" />
+          </div>
+          <Skeleton className="h-9 w-full" />
+          <div className="space-y-2">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <Skeleton key={i} className="h-14 w-full rounded-md" />
+            ))}
+          </div>
+        </div>
+      );
+    case 'form':
+      return (
+        <div className={cn('space-y-4 pb-6 max-w-3xl mx-auto', className)}>
+          <Skeleton className="h-8 w-56" />
+          <div className="flex gap-2">
+            <Skeleton className="h-6 w-16" />
+            <Skeleton className="h-6 w-16" />
+            <Skeleton className="h-6 w-16" />
+          </div>
+          <Skeleton className="h-12 w-full" />
+          <Skeleton className="h-32 w-full" />
+          <Skeleton className="h-12 w-full" />
+          <Skeleton className="h-12 w-full" />
+        </div>
+      );
+    case 'detail':
+      return (
+        <div className={cn('space-y-4 pb-6', className)}>
+          <Skeleton className="h-8 w-72" />
+          <Skeleton className="h-24 w-full" />
+          <Skeleton className="h-48 w-full" />
+          <Skeleton className="h-24 w-full" />
+        </div>
+      );
+    case 'auto':
+    default:
+      return (
+        <div className={cn('flex flex-col gap-4 p-6', className)}>
+          <Skeleton className="h-8 w-48" />
+          <Skeleton className="h-64 w-full" />
+          <Skeleton className="h-32 w-full" />
+        </div>
+      );
+  }
+}

--- a/src/components/unified-order/RestoreDraftDialog.tsx
+++ b/src/components/unified-order/RestoreDraftDialog.tsx
@@ -1,0 +1,69 @@
+import { Clock, RotateCw, Trash2 } from 'lucide-react';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { formatDistanceToNow } from 'date-fns';
+import { ptBR } from 'date-fns/locale';
+
+interface RestoreDraftDialogProps {
+  open: boolean;
+  savedAt: string;
+  customerName?: string;
+  itemCount?: number;
+  onRestore: () => void;
+  onDiscard: () => void;
+}
+
+export function RestoreDraftDialog({
+  open,
+  savedAt,
+  customerName,
+  itemCount,
+  onRestore,
+  onDiscard,
+}: RestoreDraftDialogProps) {
+  const ago = (() => {
+    try {
+      return formatDistanceToNow(new Date(savedAt), { locale: ptBR, addSuffix: true });
+    } catch {
+      return savedAt;
+    }
+  })();
+
+  return (
+    <AlertDialog open={open}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle className="flex items-center gap-2">
+            <Clock className="w-4 h-4 text-muted-foreground" />
+            Restaurar pedido em andamento?
+          </AlertDialogTitle>
+          <AlertDialogDescription>
+            Você tinha um pedido aberto {customerName ? <strong>com {customerName}</strong> : null}
+            {itemCount !== undefined && itemCount > 0 ? (
+              <> contendo <strong>{itemCount} {itemCount === 1 ? 'item' : 'itens'}</strong></>
+            ) : null}
+            , salvo automaticamente {ago}.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel onClick={onDiscard} className="gap-2">
+            <Trash2 className="w-4 h-4" />
+            Descartar
+          </AlertDialogCancel>
+          <AlertDialogAction onClick={onRestore} className="gap-2">
+            <RotateCw className="w-4 h-4" />
+            Restaurar
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -1,185 +1,69 @@
-import * as React from "react";
+/**
+ * Wrapper de compatibilidade — delega para Sonner.
+ *
+ * O sistema antigo (Radix toaster) foi descontinuado em favor de Sonner (uma fonte
+ * só de feedback). Este wrapper preserva a API antiga (`useToast()` + `toast({title, description, variant})`)
+ * para que os ~50 callsites existentes continuem funcionando sem refactor imediato.
+ *
+ * Migração progressiva recomendada: trocar imports para `import { toast } from 'sonner'`
+ * e usar `toast.success(title, { description })` / `toast.error(...)` diretamente.
+ */
+import { toast as sonnerToast } from 'sonner';
+import type { ReactNode } from 'react';
 
-import type { ToastActionElement, ToastProps } from "@/components/ui/toast";
+type LegacyVariant = 'default' | 'destructive';
 
-const TOAST_LIMIT = 1;
-const TOAST_REMOVE_DELAY = 1000000;
-
-type ToasterToast = ToastProps & {
-  id: string;
-  title?: React.ReactNode;
-  description?: React.ReactNode;
-  action?: ToastActionElement;
-};
-
-const actionTypes = {
-  ADD_TOAST: "ADD_TOAST",
-  UPDATE_TOAST: "UPDATE_TOAST",
-  DISMISS_TOAST: "DISMISS_TOAST",
-  REMOVE_TOAST: "REMOVE_TOAST",
-} as const;
-
-let count = 0;
-
-function genId() {
-  count = (count + 1) % Number.MAX_SAFE_INTEGER;
-  return count.toString();
+interface LegacyToastOptions {
+  title?: ReactNode;
+  description?: ReactNode;
+  variant?: LegacyVariant;
+  /** Não suportado em Sonner — preservado por compat, mas ignorado */
+  action?: unknown;
+  duration?: number;
 }
 
-type ActionType = typeof actionTypes;
-
-type Action =
-  | {
-      type: ActionType["ADD_TOAST"];
-      toast: ToasterToast;
-    }
-  | {
-      type: ActionType["UPDATE_TOAST"];
-      toast: Partial<ToasterToast>;
-    }
-  | {
-      type: ActionType["DISMISS_TOAST"];
-      toastId?: ToasterToast["id"];
-    }
-  | {
-      type: ActionType["REMOVE_TOAST"];
-      toastId?: ToasterToast["id"];
-    };
-
-interface State {
-  toasts: ToasterToast[];
+interface LegacyToastReturn {
+  id: string | number;
+  dismiss: () => void;
+  update: (opts: LegacyToastOptions) => void;
 }
 
-const toastTimeouts = new Map<string, ReturnType<typeof setTimeout>>();
-
-const addToRemoveQueue = (toastId: string) => {
-  if (toastTimeouts.has(toastId)) {
-    return;
-  }
-
-  const timeout = setTimeout(() => {
-    toastTimeouts.delete(toastId);
-    dispatch({
-      type: "REMOVE_TOAST",
-      toastId: toastId,
-    });
-  }, TOAST_REMOVE_DELAY);
-
-  toastTimeouts.set(toastId, timeout);
-};
-
-export const reducer = (state: State, action: Action): State => {
-  switch (action.type) {
-    case "ADD_TOAST":
-      return {
-        ...state,
-        toasts: [action.toast, ...state.toasts].slice(0, TOAST_LIMIT),
-      };
-
-    case "UPDATE_TOAST":
-      return {
-        ...state,
-        toasts: state.toasts.map((t) => (t.id === action.toast.id ? { ...t, ...action.toast } : t)),
-      };
-
-    case "DISMISS_TOAST": {
-      const { toastId } = action;
-
-      // ! Side effects ! - This could be extracted into a dismissToast() action,
-      // but I'll keep it here for simplicity
-      if (toastId) {
-        addToRemoveQueue(toastId);
-      } else {
-        state.toasts.forEach((toast) => {
-          addToRemoveQueue(toast.id);
-        });
-      }
-
-      return {
-        ...state,
-        toasts: state.toasts.map((t) =>
-          t.id === toastId || toastId === undefined
-            ? {
-                ...t,
-                open: false,
-              }
-            : t,
-        ),
-      };
-    }
-    case "REMOVE_TOAST":
-      if (action.toastId === undefined) {
-        return {
-          ...state,
-          toasts: [],
-        };
-      }
-      return {
-        ...state,
-        toasts: state.toasts.filter((t) => t.id !== action.toastId),
-      };
-  }
-};
-
-const listeners: Array<(state: State) => void> = [];
-
-let memoryState: State = { toasts: [] };
-
-function dispatch(action: Action) {
-  memoryState = reducer(memoryState, action);
-  listeners.forEach((listener) => {
-    listener(memoryState);
-  });
+function toReactNodeString(value: ReactNode): string | undefined {
+  if (value == null || typeof value === 'boolean') return undefined;
+  if (typeof value === 'string' || typeof value === 'number') return String(value);
+  // ReactNode complexo — Sonner aceita ReactNode, então retornamos como qualquer
+  return value as unknown as string;
 }
 
-type Toast = Omit<ToasterToast, "id">;
+function toast(opts: LegacyToastOptions | string): LegacyToastReturn {
+  const normalized: LegacyToastOptions =
+    typeof opts === 'string' ? { title: opts } : opts;
 
-function toast({ ...props }: Toast) {
-  const id = genId();
+  const title = toReactNodeString(normalized.title) ?? '';
+  const description = toReactNodeString(normalized.description);
+  const variant = normalized.variant ?? 'default';
+  const duration = normalized.duration;
 
-  const update = (props: ToasterToast) =>
-    dispatch({
-      type: "UPDATE_TOAST",
-      toast: { ...props, id },
-    });
-  const dismiss = () => dispatch({ type: "DISMISS_TOAST", toastId: id });
-
-  dispatch({
-    type: "ADD_TOAST",
-    toast: {
-      ...props,
-      id,
-      open: true,
-      onOpenChange: (open) => {
-        if (!open) dismiss();
-      },
-    },
-  });
+  const id =
+    variant === 'destructive'
+      ? sonnerToast.error(title, { description, duration })
+      : sonnerToast(title, { description, duration });
 
   return {
-    id: id,
-    dismiss,
-    update,
+    id,
+    dismiss: () => sonnerToast.dismiss(id),
+    update: (next) => {
+      sonnerToast.dismiss(id);
+      toast(next);
+    },
   };
 }
 
 function useToast() {
-  const [state, setState] = React.useState<State>(memoryState);
-
-  React.useEffect(() => {
-    listeners.push(setState);
-    return () => {
-      const index = listeners.indexOf(setState);
-      if (index > -1) {
-        listeners.splice(index, 1);
-      }
-    };
-  }, [state]);
-
   return {
-    ...state,
     toast,
-    dismiss: (toastId?: string) => dispatch({ type: "DISMISS_TOAST", toastId }),
+    dismiss: (toastId?: string | number) => sonnerToast.dismiss(toastId),
+    toasts: [] as never[],
   };
 }
 

--- a/src/hooks/useBulkSelection.ts
+++ b/src/hooks/useBulkSelection.ts
@@ -1,0 +1,81 @@
+import { useCallback, useMemo, useState } from 'react';
+
+/**
+ * Multi-seleção padrão para tabelas/listas:
+ *  - Click simples: toggle individual
+ *  - Shift+click: seleciona range (do último clicado até o atual, na ordem do array)
+ *  - selectAll/clear/isAll/isSelected
+ *  - Esc limpa (precisa ser conectado pela página via useShortcut)
+ *
+ * Uso:
+ *   const sel = useBulkSelection(rows.map(r => r.id));
+ *   <Checkbox checked={sel.isSelected(row.id)} onCheckedChange={(_, e) => sel.toggle(row.id, e)} />
+ *   <BulkActionsBar count={sel.size} onClear={sel.clear} actions={[...]} />
+ */
+export interface BulkSelection<T extends string | number> {
+  ids: T[];
+  size: number;
+  isSelected: (id: T) => boolean;
+  isAll: boolean;
+  toggle: (id: T, ev?: { shiftKey?: boolean }) => void;
+  selectAll: () => void;
+  clear: () => void;
+  set: (ids: T[]) => void;
+}
+
+export function useBulkSelection<T extends string | number>(orderedIds: T[]): BulkSelection<T> {
+  const [selected, setSelected] = useState<Set<T>>(() => new Set());
+  const [lastTouched, setLastTouched] = useState<T | null>(null);
+
+  const idsArray = useMemo(() => Array.from(selected), [selected]);
+
+  const isSelected = useCallback((id: T) => selected.has(id), [selected]);
+  const isAll = orderedIds.length > 0 && selected.size === orderedIds.length;
+
+  const toggle = useCallback(
+    (id: T, ev?: { shiftKey?: boolean }) => {
+      setSelected((prev) => {
+        const next = new Set(prev);
+        if (ev?.shiftKey && lastTouched !== null) {
+          // Range select
+          const a = orderedIds.indexOf(lastTouched);
+          const b = orderedIds.indexOf(id);
+          if (a !== -1 && b !== -1) {
+            const [start, end] = a < b ? [a, b] : [b, a];
+            for (let i = start; i <= end; i++) next.add(orderedIds[i]);
+            return next;
+          }
+        }
+        if (next.has(id)) next.delete(id);
+        else next.add(id);
+        return next;
+      });
+      setLastTouched(id);
+    },
+    [orderedIds, lastTouched],
+  );
+
+  const selectAll = useCallback(() => {
+    setSelected(new Set(orderedIds));
+  }, [orderedIds]);
+
+  const clear = useCallback(() => {
+    setSelected(new Set());
+    setLastTouched(null);
+  }, []);
+
+  const set = useCallback((ids: T[]) => {
+    setSelected(new Set(ids));
+  }, []);
+
+  return {
+    ids: idsArray,
+    size: selected.size,
+    isSelected,
+    isAll,
+    toggle,
+    selectAll,
+    clear,
+    set,
+  };
+}

--- a/src/hooks/useCustomerSegments.ts
+++ b/src/hooks/useCustomerSegments.ts
@@ -1,0 +1,70 @@
+import { useCallback, useEffect, useState } from 'react';
+
+const STORAGE_KEY = 'customer_segments_v1';
+
+/**
+ * Segmentos salvos de filtros de clientes — local por usuário (localStorage).
+ *
+ * TODO(schema): substituir por tabela `user_segments(id uuid, user_id uuid, area text, name text, filter jsonb, shared bool)`
+ * para persistir no servidor e suportar segmentos compartilhados com o time.
+ * Quando isso existir, este hook vira um wrapper sobre useQuery + useMutation.
+ */
+export interface CustomerSegment {
+  id: string;
+  name: string;
+  filters: {
+    search?: string;
+    health?: string;
+    [key: string]: string | undefined;
+  };
+}
+
+function read(): CustomerSegment[] {
+  if (typeof localStorage === 'undefined') return [];
+  try {
+    return JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '[]') as CustomerSegment[];
+  } catch {
+    return [];
+  }
+}
+
+function write(segments: CustomerSegment[]): void {
+  if (typeof localStorage === 'undefined') return;
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(segments));
+}
+
+export function useCustomerSegments() {
+  const [segments, setSegments] = useState<CustomerSegment[]>(() => read());
+
+  useEffect(() => {
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === STORAGE_KEY) setSegments(read());
+    };
+    window.addEventListener('storage', onStorage);
+    return () => window.removeEventListener('storage', onStorage);
+  }, []);
+
+  const save = useCallback((name: string, filters: CustomerSegment['filters']): CustomerSegment => {
+    const id =
+      typeof crypto !== 'undefined' && 'randomUUID' in crypto
+        ? crypto.randomUUID()
+        : `${Date.now()}`;
+    const seg: CustomerSegment = { id, name, filters };
+    setSegments((prev) => {
+      const next = [seg, ...prev];
+      write(next);
+      return next;
+    });
+    return seg;
+  }, []);
+
+  const remove = useCallback((id: string) => {
+    setSegments((prev) => {
+      const next = prev.filter((s) => s.id !== id);
+      write(next);
+      return next;
+    });
+  }, []);
+
+  return { segments, save, remove };
+}

--- a/src/hooks/useNetworkStatus.ts
+++ b/src/hooks/useNetworkStatus.ts
@@ -1,0 +1,69 @@
+import { useEffect, useState } from 'react';
+
+type Quality = 'online' | 'slow' | 'offline';
+
+interface NetworkStatus {
+  online: boolean;
+  quality: Quality;
+  /** Round-trip time estimado em ms quando disponível (NetworkInformation API). */
+  rttMs: number | null;
+  /** Tipo efetivo da conexão (4g, 3g, 2g, slow-2g) quando disponível. */
+  effectiveType: string | null;
+  /** ISO timestamp da última transição de estado. */
+  lastChangeAt: string;
+}
+
+interface NavigatorConnection {
+  rtt?: number;
+  effectiveType?: string;
+  addEventListener?: (event: string, handler: () => void) => void;
+  removeEventListener?: (event: string, handler: () => void) => void;
+}
+
+function getConnection(): NavigatorConnection | null {
+  if (typeof navigator === 'undefined') return null;
+  const nav = navigator as Navigator & {
+    connection?: NavigatorConnection;
+    mozConnection?: NavigatorConnection;
+    webkitConnection?: NavigatorConnection;
+  };
+  return nav.connection ?? nav.mozConnection ?? nav.webkitConnection ?? null;
+}
+
+function snapshot(): NetworkStatus {
+  const online = typeof navigator === 'undefined' ? true : navigator.onLine;
+  const conn = getConnection();
+  const rtt = conn?.rtt ?? null;
+  const effectiveType = conn?.effectiveType ?? null;
+  const slow = effectiveType === '2g' || effectiveType === 'slow-2g' || (rtt !== null && rtt > 1500);
+  return {
+    online,
+    quality: !online ? 'offline' : slow ? 'slow' : 'online',
+    rttMs: rtt,
+    effectiveType,
+    lastChangeAt: new Date().toISOString(),
+  };
+}
+
+/**
+ * Reativo a mudanças de online/offline e (quando disponível) qualidade da conexão.
+ * Usado pelo NetworkStatusIndicator no AppShell.
+ */
+export function useNetworkStatus(): NetworkStatus {
+  const [status, setStatus] = useState<NetworkStatus>(() => snapshot());
+
+  useEffect(() => {
+    const update = () => setStatus(snapshot());
+    window.addEventListener('online', update);
+    window.addEventListener('offline', update);
+    const conn = getConnection();
+    conn?.addEventListener?.('change', update);
+    return () => {
+      window.removeEventListener('online', update);
+      window.removeEventListener('offline', update);
+      conn?.removeEventListener?.('change', update);
+    };
+  }, []);
+
+  return status;
+}

--- a/src/hooks/useOptimisticMutation.ts
+++ b/src/hooks/useOptimisticMutation.ts
@@ -1,0 +1,96 @@
+import { useMutation, useQueryClient, type UseMutationOptions, type QueryKey } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { logger } from '@/lib/logger';
+
+/**
+ * Wrapper sobre useMutation com optimistic update + rollback padronizados.
+ *
+ * Princípio do projeto: latência percebida <100ms em operações críticas (scan, picking,
+ * recebimento, cart). Esta API obriga a pensar em onMutate/onError de forma simétrica.
+ *
+ * Uso:
+ *   const m = useOptimisticMutation({
+ *     mutationFn: (item) => supabase.from('foo').insert(item),
+ *     queryKey: ['foo-list', filtros],
+ *     optimisticUpdate: (prev: Item[] | undefined, item) => [...(prev ?? []), item],
+ *     successToast: 'Item adicionado',
+ *     errorToast: 'Não foi possível adicionar',
+ *   });
+ *
+ *   m.mutate(item);  // UI atualiza instantaneamente; rollback se servidor recusar.
+ */
+interface OptimisticMutationOptions<TData, TVariables, TCache>
+  extends Omit<UseMutationOptions<TData, Error, TVariables, { previous: TCache | undefined }>,
+    'onMutate' | 'onError' | 'onSettled'
+  > {
+  /** Chave do cache react-query a ser modificada otimisticamente. */
+  queryKey: QueryKey;
+  /**
+   * Função pura que recebe o cache anterior + variáveis da mutação e retorna o novo cache.
+   * Pode retornar undefined para apagar o cache (uso raro).
+   */
+  optimisticUpdate: (previous: TCache | undefined, variables: TVariables) => TCache | undefined;
+  /** Mensagem de sucesso (string) ou função que recebe o resultado. Opcional. */
+  successToast?: string | ((data: TData, variables: TVariables) => string);
+  /** Mensagem de erro (string) ou função que recebe o erro. Opcional. */
+  errorToast?: string | ((err: Error, variables: TVariables) => string);
+  /** Outras chaves a invalidar após sucesso. */
+  invalidate?: QueryKey[];
+}
+
+export function useOptimisticMutation<TData, TVariables, TCache = unknown>(
+  options: OptimisticMutationOptions<TData, TVariables, TCache>,
+) {
+  const qc = useQueryClient();
+  const {
+    queryKey,
+    optimisticUpdate,
+    successToast,
+    errorToast,
+    invalidate,
+    mutationFn,
+    ...rest
+  } = options;
+
+  return useMutation<TData, Error, TVariables, { previous: TCache | undefined }>({
+    ...rest,
+    mutationFn,
+    onMutate: async (variables) => {
+      // 1. cancela queries em voo para a chave (evita race com refetch)
+      await qc.cancelQueries({ queryKey });
+      // 2. snapshot do cache atual
+      const previous = qc.getQueryData<TCache>(queryKey);
+      // 3. aplica update otimista
+      qc.setQueryData<TCache>(queryKey, (old) => optimisticUpdate(old, variables));
+      return { previous };
+    },
+    onError: (err, variables, context) => {
+      // rollback
+      if (context && context.previous !== undefined) {
+        qc.setQueryData(queryKey, context.previous);
+      }
+      logger.error('useOptimisticMutation: erro na mutação, rollback aplicado', {
+        queryKey: JSON.stringify(queryKey),
+        error: err.message,
+      });
+      const msg =
+        typeof errorToast === 'function'
+          ? errorToast(err, variables)
+          : (errorToast ?? 'Não foi possível concluir a operação');
+      toast.error(msg, { description: err.message });
+    },
+    onSuccess: (data, variables, context) => {
+      const msg =
+        typeof successToast === 'function'
+          ? successToast(data, variables)
+          : successToast;
+      if (msg) toast.success(msg);
+      rest.onSuccess?.(data, variables, context as { previous: TCache | undefined });
+    },
+    onSettled: () => {
+      // refetch para garantir estado consistente após sucesso ou rollback
+      qc.invalidateQueries({ queryKey });
+      invalidate?.forEach((k) => qc.invalidateQueries({ queryKey: k }));
+    },
+  });
+}

--- a/src/hooks/useOrderDraft.ts
+++ b/src/hooks/useOrderDraft.ts
@@ -1,0 +1,110 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+/**
+ * Auto-save de rascunho de pedido em localStorage.
+ *
+ * Princípio: vendedor externo no carro. Se cair sinal ou fechar a aba por engano, ao reabrir
+ * a página deve aparecer "Você tinha um pedido em andamento. Restaurar?".
+ *
+ * v1: salva snapshot completo do `state` (objeto JSON-serializável). Cabe ao caller decidir
+ * o que entra (tipicamente: customer ref, cart, notes, deliveryOption, paymentSelections).
+ *
+ * Limitações conhecidas:
+ *  - Se algum produto for removido do catálogo entre a salvagem e o restore, restore vai render
+ *    a UI com item inválido — caller deve validar contra catálogo atual antes de aplicar.
+ *  - localStorage tem ~5MB por origin — pedidos com 100+ itens podem aproximar do limite.
+ *
+ * Chave: `order_draft:{scopeKey}` — passe o user.id (ou user.id + customer.id) para isolar.
+ */
+export interface OrderDraft<T = unknown> {
+  state: T;
+  savedAt: string;
+  scopeKey: string;
+}
+
+interface Options<T> {
+  scopeKey: string;
+  state: T;
+  /** Predicate que diz se o estado atual vale ser salvo (ex: cart.length > 0). */
+  shouldSave: boolean;
+  /** Debounce em ms (default 600). */
+  debounceMs?: number;
+  /** Quando true (após submit bem-sucedido), limpa o draft imediatamente. */
+  clearTrigger?: boolean;
+}
+
+function key(scopeKey: string) {
+  return `order_draft:${scopeKey}`;
+}
+
+export function useOrderDraft<T>({
+  scopeKey,
+  state,
+  shouldSave,
+  debounceMs = 600,
+  clearTrigger,
+}: Options<T>) {
+  const [draft, setDraft] = useState<OrderDraft<T> | null>(() => {
+    if (typeof localStorage === 'undefined') return null;
+    try {
+      const raw = localStorage.getItem(key(scopeKey));
+      return raw ? (JSON.parse(raw) as OrderDraft<T>) : null;
+    } catch {
+      return null;
+    }
+  });
+
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Auto-save com debounce
+  useEffect(() => {
+    if (typeof localStorage === 'undefined') return;
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    if (!shouldSave) return;
+    debounceRef.current = setTimeout(() => {
+      try {
+        const payload: OrderDraft<T> = {
+          state,
+          savedAt: new Date().toISOString(),
+          scopeKey,
+        };
+        localStorage.setItem(key(scopeKey), JSON.stringify(payload));
+      } catch {
+        // quota — ignora
+      }
+    }, debounceMs);
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [scopeKey, state, shouldSave, debounceMs]);
+
+  // Limpar quando trigger
+  useEffect(() => {
+    if (clearTrigger && typeof localStorage !== 'undefined') {
+      localStorage.removeItem(key(scopeKey));
+      setDraft(null);
+    }
+  }, [clearTrigger, scopeKey]);
+
+  // Aviso ao fechar a aba com cart pendente (vendedor no carro fecha sem querer)
+  useEffect(() => {
+    if (!shouldSave) return;
+    const onBeforeUnload = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+      e.returnValue = '';
+    };
+    window.addEventListener('beforeunload', onBeforeUnload);
+    return () => window.removeEventListener('beforeunload', onBeforeUnload);
+  }, [shouldSave]);
+
+  const clear = useCallback(() => {
+    if (typeof localStorage !== 'undefined') localStorage.removeItem(key(scopeKey));
+    setDraft(null);
+  }, [scopeKey]);
+
+  const dismiss = useCallback(() => {
+    setDraft(null);
+  }, []);
+
+  return { draft, clear, dismiss };
+}

--- a/src/hooks/useTintRecentsFavorites.ts
+++ b/src/hooks/useTintRecentsFavorites.ts
@@ -1,0 +1,77 @@
+import { useCallback, useEffect, useState } from 'react';
+
+const RECENTS_KEY = 'tint_recents_v1';
+const FAVORITES_KEY = 'tint_favorites_v1';
+const MAX_RECENTS = 10;
+
+export interface TintFormulaRef {
+  id: string;
+  cor_id: string;
+  nome_cor: string;
+  produto_descricao?: string;
+  base_descricao?: string;
+}
+
+function safeRead<T>(key: string, fallback: T): T {
+  if (typeof localStorage === 'undefined') return fallback;
+  try {
+    const raw = localStorage.getItem(key);
+    return raw ? (JSON.parse(raw) as T) : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+function safeWrite(key: string, value: unknown): void {
+  if (typeof localStorage === 'undefined') return;
+  try {
+    localStorage.setItem(key, JSON.stringify(value));
+  } catch {
+    // quota exceeded → ignora silenciosamente, não vale a pena quebrar a UI
+  }
+}
+
+/**
+ * Recentes (FIFO 10) e favoritos (estrela) das fórmulas tintométricas — por usuário (localStorage).
+ * Substitui a busca repetida no balcão.
+ */
+export function useTintRecentsFavorites() {
+  const [recents, setRecents] = useState<TintFormulaRef[]>(() => safeRead(RECENTS_KEY, []));
+  const [favorites, setFavorites] = useState<TintFormulaRef[]>(() => safeRead(FAVORITES_KEY, []));
+
+  // Sync entre abas
+  useEffect(() => {
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === RECENTS_KEY) setRecents(safeRead(RECENTS_KEY, []));
+      if (e.key === FAVORITES_KEY) setFavorites(safeRead(FAVORITES_KEY, []));
+    };
+    window.addEventListener('storage', onStorage);
+    return () => window.removeEventListener('storage', onStorage);
+  }, []);
+
+  const pushRecent = useCallback((formula: TintFormulaRef) => {
+    setRecents((prev) => {
+      const next = [formula, ...prev.filter((f) => f.id !== formula.id)].slice(0, MAX_RECENTS);
+      safeWrite(RECENTS_KEY, next);
+      return next;
+    });
+  }, []);
+
+  const toggleFavorite = useCallback((formula: TintFormulaRef) => {
+    setFavorites((prev) => {
+      const exists = prev.some((f) => f.id === formula.id);
+      const next = exists ? prev.filter((f) => f.id !== formula.id) : [formula, ...prev];
+      safeWrite(FAVORITES_KEY, next);
+      return next;
+    });
+  }, []);
+
+  const isFavorite = useCallback((id: string) => favorites.some((f) => f.id === id), [favorites]);
+
+  const clearRecents = useCallback(() => {
+    setRecents([]);
+    safeWrite(RECENTS_KEY, []);
+  }, []);
+
+  return { recents, favorites, pushRecent, toggleFavorite, isFavorite, clearRecents };
+}

--- a/src/hooks/useUnifiedOrder.ts
+++ b/src/hooks/useUnifiedOrder.ts
@@ -702,7 +702,7 @@ export function useUnifiedOrder() {
     deliveryOption, setDeliveryOption, addresses, selectedAddress, setSelectedAddress,
     selectedTimeSlot, setSelectedTimeSlot, showAddressOptions, setShowAddressOptions,
     // Cart
-    cart, notes, setNotes, submitting, activeTab, setActiveTab,
+    cart, setCart, notes, setNotes, submitting, activeTab, setActiveTab,
     readyByDate, setReadyByDate,
     productItems, obenProductItems, colacorProductItems, serviceItems, cartProductIds,
     availableTools,

--- a/src/hooks/useUrlState.ts
+++ b/src/hooks/useUrlState.ts
@@ -1,0 +1,96 @@
+import { useCallback, useMemo, useRef } from 'react';
+import { useSearchParams } from 'react-router-dom';
+
+/**
+ * Sincroniza estado com URL search params (compartilhável, sobrevive a F5).
+ *
+ * Uso:
+ *   const [filters, setFilters] = useUrlState({ search: '', status: 'all' });
+ *   setFilters({ search: 'foo' });   // ?search=foo&status=all
+ *   setFilters((prev) => ({ ...prev, status: 'open' }));
+ *
+ * Apenas strings, números e booleans são serializados. Listas via separador "|".
+ * Para schemas complexos use useUrlState com schema zod (não incluído aqui).
+ *
+ * Atenção: NÃO colocar PII (CPF/CNPJ) nesses params — vai parar em logs/históricos.
+ */
+type Primitive = string | number | boolean | null | undefined;
+type StateShape = Record<string, Primitive | Primitive[]>;
+
+function serialize(value: Primitive | Primitive[]): string | null {
+  if (value === null || value === undefined || value === '') return null;
+  if (Array.isArray(value)) {
+    const cleaned = value.filter((v) => v !== null && v !== undefined && v !== '');
+    return cleaned.length ? cleaned.join('|') : null;
+  }
+  if (typeof value === 'boolean') return value ? '1' : null;
+  return String(value);
+}
+
+function deserialize<T extends Primitive | Primitive[]>(raw: string | null, fallback: T): T {
+  if (raw === null || raw === '') return fallback;
+  if (Array.isArray(fallback)) {
+    return raw.split('|') as unknown as T;
+  }
+  if (typeof fallback === 'boolean') {
+    return (raw === '1') as unknown as T;
+  }
+  if (typeof fallback === 'number') {
+    const n = Number(raw);
+    return (Number.isFinite(n) ? n : fallback) as unknown as T;
+  }
+  return raw as unknown as T;
+}
+
+export function useUrlState<S extends StateShape>(
+  defaults: S,
+): [S, (next: Partial<S> | ((prev: S) => S)) => void, () => void] {
+  const [params, setParams] = useSearchParams();
+  // Estabiliza defaults na primeira chamada — uso esperado é shape fixo.
+  // Se o caller mudar shape entre renders, ignoramos (warning silencioso).
+  const defaultsRef = useRef(defaults);
+
+  const state = useMemo(() => {
+    const out: Record<string, unknown> = {};
+    for (const key in defaultsRef.current) {
+      const raw = params.get(key);
+      out[key] = deserialize(raw, defaultsRef.current[key] as Primitive | Primitive[]);
+    }
+    return out as S;
+  }, [params]);
+
+  const setState = useCallback(
+    (next: Partial<S> | ((prev: S) => S)) => {
+      setParams(
+        (prev) => {
+          const merged: S =
+            typeof next === 'function'
+              ? (next as (p: S) => S)(state)
+              : ({ ...state, ...next } as S);
+          const updated = new URLSearchParams(prev);
+          for (const key in defaultsRef.current) {
+            const value = serialize(merged[key] as Primitive | Primitive[]);
+            if (value === null) updated.delete(key);
+            else updated.set(key, value);
+          }
+          return updated;
+        },
+        { replace: true },
+      );
+    },
+    [setParams, state],
+  );
+
+  const reset = useCallback(() => {
+    setParams(
+      (prev) => {
+        const updated = new URLSearchParams(prev);
+        for (const key in defaultsRef.current) updated.delete(key);
+        return updated;
+      },
+      { replace: true },
+    );
+  }, [setParams]);
+
+  return [state, setState, reset];
+}

--- a/src/index.css
+++ b/src/index.css
@@ -278,6 +278,24 @@
     --list-gap: 8px;
   }
 
+  /* ── Status text utilities (semantic tokens — substitui text-emerald-600 etc.) ── */
+  .text-status-success { color: hsl(var(--status-success)); }
+  .text-status-warning { color: hsl(var(--status-warning)); }
+  .text-status-error   { color: hsl(var(--status-error));   }
+  .text-status-info    { color: hsl(var(--status-info));    }
+  .text-status-purple  { color: hsl(var(--status-purple));  }
+  .text-status-indigo  { color: hsl(var(--status-indigo));  }
+
+  .text-status-success-fg { color: hsl(var(--status-success-foreground)); }
+  .text-status-warning-fg { color: hsl(var(--status-warning-foreground)); }
+  .text-status-error-fg   { color: hsl(var(--status-error-foreground));   }
+  .text-status-info-fg    { color: hsl(var(--status-info-foreground));    }
+
+  .bg-status-success-bg { background-color: hsl(var(--status-success-bg)); }
+  .bg-status-warning-bg { background-color: hsl(var(--status-warning-bg)); }
+  .bg-status-error-bg   { background-color: hsl(var(--status-error-bg));   }
+  .bg-status-info-bg    { background-color: hsl(var(--status-info-bg));    }
+
   /* ── Status badge colors (semantic) ── */
   .status-pending {
     background-color: hsl(var(--status-warning-bg));

--- a/src/lib/offline-queue.ts
+++ b/src/lib/offline-queue.ts
@@ -1,0 +1,127 @@
+/**
+ * Fila offline de mutações (scaffold para #20 do roadmap UX).
+ *
+ * O que esta v1 entrega:
+ *  - API estável (`enqueue`, `flush`, `getOfflineQueueDepth`, `subscribeToOfflineQueue`)
+ *  - Persistência simples em localStorage (será migrada para IndexedDB quando #20 for executado a fundo)
+ *  - Subscription pra UI reagir a mudanças no depth
+ *
+ * O que NÃO está aqui ainda (por design):
+ *  - Conflict resolution
+ *  - Background sync via service worker (precisa workbox config)
+ *  - Retry exponencial granular por tipo de mutação
+ *
+ * Hoje: o `NetworkStatusIndicator` lê depth para mostrar contador. Páginas críticas (Picking,
+ * RecebimentoConferencia, UnifiedOrder) podem começar a usar `enqueue()` em onError de mutações
+ * quando offline; o flush manual é exposto pra ser disparado quando a conexão voltar.
+ */
+
+const STORAGE_KEY = 'offline_queue_v1';
+
+export interface QueuedMutation<TVars = unknown> {
+  id: string;
+  /** Identificador da operação (ex: "picking.confirm", "recebimento.scan-lote"). */
+  kind: string;
+  variables: TVars;
+  enqueuedAt: string;
+  attempts: number;
+  lastError?: string;
+}
+
+type Listener = (depth: number) => void;
+const listeners = new Set<Listener>();
+
+function emit(depth: number) {
+  listeners.forEach((l) => {
+    try {
+      l(depth);
+    } catch {
+      // ignora handler com bug
+    }
+  });
+}
+
+function readQueue(): QueuedMutation[] {
+  if (typeof localStorage === 'undefined') return [];
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    return JSON.parse(raw) as QueuedMutation[];
+  } catch {
+    return [];
+  }
+}
+
+function writeQueue(items: QueuedMutation[]): void {
+  if (typeof localStorage === 'undefined') return;
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(items));
+  emit(items.length);
+}
+
+export async function enqueue<TVars>(kind: string, variables: TVars): Promise<string> {
+  const id =
+    typeof crypto !== 'undefined' && 'randomUUID' in crypto
+      ? crypto.randomUUID()
+      : `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const items = readQueue();
+  items.push({
+    id,
+    kind,
+    variables,
+    enqueuedAt: new Date().toISOString(),
+    attempts: 0,
+  });
+  writeQueue(items);
+  return id;
+}
+
+export async function getOfflineQueueDepth(): Promise<number> {
+  return readQueue().length;
+}
+
+/**
+ * Tenta processar todas as mutações da fila usando o handler fornecido.
+ * Handler retorna `true` em sucesso (item é removido da fila) ou `false` (mantém com attempts++).
+ * Handler que dispara erro também mantém com attempts++.
+ */
+export async function flush(
+  handler: (mutation: QueuedMutation) => Promise<boolean>,
+): Promise<{ success: number; failed: number }> {
+  const items = readQueue();
+  const remaining: QueuedMutation[] = [];
+  let success = 0;
+  let failed = 0;
+  for (const item of items) {
+    try {
+      const ok = await handler(item);
+      if (ok) {
+        success++;
+      } else {
+        remaining.push({ ...item, attempts: item.attempts + 1 });
+        failed++;
+      }
+    } catch (e) {
+      remaining.push({
+        ...item,
+        attempts: item.attempts + 1,
+        lastError: e instanceof Error ? e.message : String(e),
+      });
+      failed++;
+    }
+  }
+  writeQueue(remaining);
+  return { success, failed };
+}
+
+export function clearOfflineQueue(): void {
+  writeQueue([]);
+}
+
+export function subscribeToOfflineQueue(listener: Listener): () => void {
+  listeners.add(listener);
+  // dispara estado atual imediatamente
+  listener(readQueue().length);
+  return () => {
+    listeners.delete(listener);
+  };
+}

--- a/src/lib/tint-cache.ts
+++ b/src/lib/tint-cache.ts
@@ -1,0 +1,131 @@
+/**
+ * Cache offline do catálogo tintométrico (scaffold para roadmap UX item #18).
+ *
+ * Wrapper minimalista sobre IndexedDB nativo (sem dependência de `idb` ou `dexie` para
+ * manter a v1 leve). API estável o suficiente para uso pelas páginas; pode ser substituída
+ * por wrapper mais robusto sem mudar callsites.
+ *
+ * O que esta v1 entrega:
+ *  - Open/upgrade do DB com object stores `formulas`, `meta`
+ *  - putAll/getAll por store
+ *  - Versionamento via meta `last_synced_at`
+ *  - Quota check via `navigator.storage.estimate()`
+ *
+ * O que NÃO está aqui (próximas iterações):
+ *  - Sync incremental (precisa Edge function `tint-catalog-snapshot`)
+ *  - Background sync via service worker
+ *  - Compressão (catálogo de ~477k registros pode passar de 100MB)
+ */
+
+const DB_NAME = 'tint_catalog';
+const DB_VERSION = 1;
+const STORE_FORMULAS = 'formulas';
+const STORE_META = 'meta';
+
+export interface CachedFormula {
+  id: string;
+  cor_id: string;
+  nome_cor: string;
+  produto_id?: string;
+  base_id?: string;
+  volume_final_ml?: number;
+  preco_final_sayersystem?: number;
+  personalizada?: boolean;
+  // ... outros campos serializados conforme schema do Supabase
+}
+
+let dbPromise: Promise<IDBDatabase> | null = null;
+
+function openDb(): Promise<IDBDatabase> {
+  if (dbPromise) return dbPromise;
+  if (typeof indexedDB === 'undefined') {
+    return Promise.reject(new Error('IndexedDB não disponível neste ambiente'));
+  }
+  dbPromise = new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, DB_VERSION);
+    req.onupgradeneeded = () => {
+      const db = req.result;
+      if (!db.objectStoreNames.contains(STORE_FORMULAS)) {
+        const store = db.createObjectStore(STORE_FORMULAS, { keyPath: 'id' });
+        store.createIndex('cor_id', 'cor_id', { unique: false });
+        store.createIndex('produto_id', 'produto_id', { unique: false });
+      }
+      if (!db.objectStoreNames.contains(STORE_META)) {
+        db.createObjectStore(STORE_META, { keyPath: 'key' });
+      }
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+  return dbPromise;
+}
+
+export async function putFormulas(formulas: CachedFormula[]): Promise<number> {
+  const db = await openDb();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction([STORE_FORMULAS, STORE_META], 'readwrite');
+    const store = tx.objectStore(STORE_FORMULAS);
+    let count = 0;
+    formulas.forEach((f) => {
+      store.put(f);
+      count++;
+    });
+    tx.objectStore(STORE_META).put({ key: 'last_synced_at', value: new Date().toISOString() });
+    tx.oncomplete = () => resolve(count);
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+export async function getAllFormulas(): Promise<CachedFormula[]> {
+  const db = await openDb();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_FORMULAS, 'readonly');
+    const req = tx.objectStore(STORE_FORMULAS).getAll();
+    req.onsuccess = () => resolve(req.result as CachedFormula[]);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+export async function searchFormulasOffline(query: string, limit = 50): Promise<CachedFormula[]> {
+  const all = await getAllFormulas();
+  if (!query.trim()) return all.slice(0, limit);
+  const q = query.toLowerCase();
+  const matches = all.filter(
+    (f) =>
+      f.cor_id.toLowerCase().includes(q) ||
+      (f.nome_cor && f.nome_cor.toLowerCase().includes(q)),
+  );
+  return matches.slice(0, limit);
+}
+
+export async function getLastSync(): Promise<string | null> {
+  const db = await openDb();
+  return new Promise((resolve) => {
+    const tx = db.transaction(STORE_META, 'readonly');
+    const req = tx.objectStore(STORE_META).get('last_synced_at');
+    req.onsuccess = () => resolve((req.result?.value as string | undefined) ?? null);
+    req.onerror = () => resolve(null);
+  });
+}
+
+export async function clearCatalog(): Promise<void> {
+  const db = await openDb();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction([STORE_FORMULAS, STORE_META], 'readwrite');
+    tx.objectStore(STORE_FORMULAS).clear();
+    tx.objectStore(STORE_META).clear();
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+export async function getStorageEstimate(): Promise<{ usageMB: number; quotaMB: number } | null> {
+  if (typeof navigator === 'undefined' || !('storage' in navigator) || !navigator.storage.estimate) {
+    return null;
+  }
+  const est = await navigator.storage.estimate();
+  return {
+    usageMB: est.usage ? est.usage / (1024 * 1024) : 0,
+    quotaMB: est.quota ? est.quota / (1024 * 1024) : 0,
+  };
+}

--- a/src/pages/AdminCustomers.tsx
+++ b/src/pages/AdminCustomers.tsx
@@ -24,6 +24,9 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { format } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
+import { useUrlState } from '@/hooks/useUrlState';
+import { useCustomerSegments } from '@/hooks/useCustomerSegments';
+import { Save, Bookmark, X as XIcon } from 'lucide-react';
 
 /* ─── Types ─── */
 interface Customer {
@@ -93,8 +96,16 @@ function CustomerListView({
   loading: boolean;
   onSelect: (c: Customer) => void;
 }) {
-  const [searchQuery, setSearchQuery] = useState('');
-  const [filterHealth, setFilterHealth] = useState<string>('all');
+  // Filtros sincronizados com URL (compartilhável, sobrevive a F5)
+  const [urlState, setUrlState] = useUrlState({ search: '', health: 'all' });
+  const searchQuery = urlState.search;
+  const filterHealth = urlState.health;
+  const setSearchQuery = (v: string) => setUrlState({ search: v });
+  const setFilterHealth = (v: string) => setUrlState({ health: v });
+
+  const { segments, save: saveSegment, remove: removeSegment } = useCustomerSegments();
+  const [savingSegment, setSavingSegment] = useState(false);
+  const [newSegmentName, setNewSegmentName] = useState('');
 
   const filtered = useMemo(() => {
     let result = customers;
@@ -132,6 +143,95 @@ function CustomerListView({
           <p className="text-sm text-muted-foreground">{customers.length} clientes na carteira</p>
         </div>
       </div>
+
+      {/* Segmentos salvos (chips) */}
+      {(segments.length > 0 || savingSegment || (searchQuery || filterHealth !== 'all')) && (
+        <div className="flex items-center gap-2 flex-wrap">
+          <span className="inline-flex items-center gap-1 text-xs font-medium text-muted-foreground uppercase tracking-wider">
+            <Bookmark className="w-3 h-3" />
+            Segmentos
+          </span>
+          {segments.map((seg) => (
+            <span
+              key={seg.id}
+              className="inline-flex items-center gap-1 pl-2.5 pr-1 py-1 rounded-md text-xs bg-muted hover:bg-muted/70 border border-border"
+            >
+              <button
+                type="button"
+                onClick={() => setUrlState({ search: seg.filters.search ?? '', health: seg.filters.health ?? 'all' })}
+                className="font-medium"
+                title="Aplicar segmento"
+              >
+                {seg.name}
+              </button>
+              <button
+                type="button"
+                onClick={() => removeSegment(seg.id)}
+                className="text-muted-foreground hover:text-destructive p-0.5"
+                aria-label={`Remover segmento ${seg.name}`}
+              >
+                <XIcon className="w-3 h-3" />
+              </button>
+            </span>
+          ))}
+          {(searchQuery || filterHealth !== 'all') && !savingSegment && (
+            <Button
+              size="sm"
+              variant="outline"
+              className="h-7 gap-1.5"
+              onClick={() => setSavingSegment(true)}
+            >
+              <Save className="w-3 h-3" />
+              Salvar como segmento
+            </Button>
+          )}
+          {savingSegment && (
+            <span className="inline-flex items-center gap-1.5">
+              <Input
+                placeholder="Nome do segmento"
+                value={newSegmentName}
+                autoFocus
+                onChange={(e) => setNewSegmentName(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' && newSegmentName.trim()) {
+                    saveSegment(newSegmentName.trim(), { search: searchQuery, health: filterHealth });
+                    setNewSegmentName('');
+                    setSavingSegment(false);
+                  } else if (e.key === 'Escape') {
+                    setNewSegmentName('');
+                    setSavingSegment(false);
+                  }
+                }}
+                className="h-7 w-48 text-xs"
+              />
+              <Button
+                size="sm"
+                variant="default"
+                className="h-7"
+                disabled={!newSegmentName.trim()}
+                onClick={() => {
+                  saveSegment(newSegmentName.trim(), { search: searchQuery, health: filterHealth });
+                  setNewSegmentName('');
+                  setSavingSegment(false);
+                }}
+              >
+                Salvar
+              </Button>
+              <Button
+                size="sm"
+                variant="ghost"
+                className="h-7"
+                onClick={() => {
+                  setNewSegmentName('');
+                  setSavingSegment(false);
+                }}
+              >
+                Cancelar
+              </Button>
+            </span>
+          )}
+        </div>
+      )}
 
       {/* Search + Filters */}
       <div className="flex items-center gap-2">

--- a/src/pages/AdminEstoquePicking.tsx
+++ b/src/pages/AdminEstoquePicking.tsx
@@ -34,6 +34,8 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { toast } from "sonner";
+import { ScanBar } from "@/components/picking/ScanBar";
 
 const truncate = (s: string | null | undefined, n = 8) =>
   s ? s.slice(0, n) : "—";
@@ -190,6 +192,7 @@ function KpiCards({ account }: { account: string }) {
 /* ─── Picking tab ─── */
 function PickingTab({ account }: { account: string }) {
   const [expanded, setExpanded] = useState<string | null>(null);
+  const [lastScan, setLastScan] = useState<{ raw: string; kind: string; method: string; at: number } | null>(null);
 
   const { data, isLoading } = useQuery({
     queryKey: ["pk-picking-list", account],
@@ -218,6 +221,18 @@ function PickingTab({ account }: { account: string }) {
     },
   });
 
+  // Handler de scan — v1: registra o último bipe e mostra feedback. A integração com a task ativa
+  // (auto-foco no item correspondente, optimistic update) virá quando #19 (TouchPickingView) for
+  // implementado a fundo. Hoje serve como hook + canal de feedback ao separador.
+  const handleScan = (result: { raw: string; kind: 'address' | 'sku'; method: 'wedge' | 'manual' }) => {
+    setLastScan({ raw: result.raw, kind: result.kind, method: result.method, at: Date.now() });
+    // Latência alvo <100ms — toast com kind detectado
+    toast.success(
+      result.kind === 'address' ? `Endereço: ${result.raw}` : `Produto: ${result.raw}`,
+      { description: result.method === 'wedge' ? 'Lido por scanner' : 'Digitado', duration: 1500 },
+    );
+  };
+
   if (isLoading)
     return (
       <div className="flex justify-center py-12 text-muted-foreground">
@@ -226,7 +241,14 @@ function PickingTab({ account }: { account: string }) {
     );
 
   return (
-    <Card>
+    <div className="space-y-4">
+      <ScanBar onScan={handleScan} />
+      {lastScan && (
+        <div className="text-xs text-muted-foreground px-1">
+          Último bipe: <span className="font-mono text-foreground">{lastScan.raw}</span> ({lastScan.kind}) — {new Date(lastScan.at).toLocaleTimeString('pt-BR')}
+        </div>
+      )}
+      <Card>
       <CardContent className="p-0">
         <Table>
           <TableHeader>
@@ -318,6 +340,7 @@ function PickingTab({ account }: { account: string }) {
         </Table>
       </CardContent>
     </Card>
+    </div>
   );
 }
 

--- a/src/pages/AdminReposicaoCockpit.tsx
+++ b/src/pages/AdminReposicaoCockpit.tsx
@@ -81,7 +81,8 @@ import {
   Tooltip as ReTooltip,
   ResponsiveContainer,
 } from "recharts";
-import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
+import { useRegisterShortcuts } from "@/components/shell/ShortcutsRegistry";
+import { logger } from "@/lib/logger";
 
 const AdminReposicaoPedidos = lazy(() => import("./AdminReposicaoPedidos"));
 const AdminReposicaoAplicacao = lazy(() => import("./AdminReposicaoAplicacao"));
@@ -151,8 +152,13 @@ async function logAudit(params: {
       result: params.result,
       metadata: params.metadata ?? {},
     });
-  } catch {
-    /* não bloqueia a UI */
+  } catch (e) {
+    // não bloqueia a UI, mas registra no logger pra não perder a auditoria silenciosamente
+    logger.warn("Falha ao gravar cockpit_audit_log", {
+      action: params.action,
+      result: params.result,
+      error: e instanceof Error ? e.message : String(e),
+    });
   }
 }
 
@@ -1667,51 +1673,9 @@ function HistoricoComChart() {
   );
 }
 
-// ============================================================================
-// Shortcuts dialog
-// ============================================================================
-
-const SHORTCUTS: Array<{ key: string; label: string }> = [
-  { key: "g", label: "Rodar geração manual" },
-  { key: "e", label: "Exportar CSV da aba atual" },
-  { key: "1", label: "Aba: Ciclo de hoje" },
-  { key: "2", label: "Aba: Aplicar no Omie" },
-  { key: "3", label: "Aba: Ciclos anteriores" },
-  { key: "r", label: "Atualizar dados" },
-  { key: "m", label: "Ativar/desativar modo revisão" },
-  { key: "?", label: "Abrir esta lista" },
-];
-
-function ShortcutsDialog({
-  open,
-  onOpenChange,
-}: {
-  open: boolean;
-  onOpenChange: (b: boolean) => void;
-}) {
-  return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle className="flex items-center gap-2">
-            <Keyboard className="h-5 w-5" /> Atalhos disponíveis
-          </DialogTitle>
-          <DialogDescription>
-            Teclas rápidas do Cockpit. Não funcionam quando o foco está em um campo de texto.
-          </DialogDescription>
-        </DialogHeader>
-        <div className="border rounded-md divide-y">
-          {SHORTCUTS.map((s) => (
-            <div key={s.key} className="flex items-center justify-between px-3 py-2 text-sm">
-              <span>{s.label}</span>
-              <kbd className="px-2 py-1 text-xs font-mono rounded bg-muted border">{s.key}</kbd>
-            </div>
-          ))}
-        </div>
-      </DialogContent>
-    </Dialog>
-  );
-}
+// O ShortcutsDialog interno e o array SHORTCUTS foram removidos — agora os atalhos
+// são registrados no ShortcutsRegistry global (useRegisterShortcuts) e o dialog
+// fica montado no AppShell, listando atalhos de qualquer página.
 
 // ============================================================================
 // Main page
@@ -2070,18 +2034,23 @@ export default function AdminReposicaoCockpit() {
       metadata: { count: filteredItems.length },
     });
   };
-  const [shortcutsOpen, setShortcutsOpen] = useState(false);
-
-  useKeyboardShortcuts({
-    g: () => handleGenerate(),
-    e: () => handleExportCsv(),
-    "1": () => handleTab("ciclohoje"),
-    "2": () => handleTab("aplicaromie"),
-    "3": () => handleTab("anteriores"),
-    r: () => handleRefetchAll(),
-    m: () => setReviewMode(!reviewMode),
-    "?": () => setShortcutsOpen(true),
-  });
+  // Atalhos do cockpit registrados no ShortcutsRegistry global (aparecem no dialog "?" do AppShell).
+  // Migrado do hook legado useKeyboardShortcuts para o pattern reusável (Fase 4 / item #1).
+  useRegisterShortcuts(
+    useMemo(
+      () => [
+        { keys: 'g', label: 'Gerar pedidos do dia',          group: 'Cockpit', handler: () => handleGenerate() },
+        { keys: 'e', label: 'Exportar CSV',                  group: 'Cockpit', handler: () => handleExportCsv() },
+        { keys: '1', label: 'Aba Ciclo de hoje',             group: 'Cockpit', handler: () => handleTab('ciclohoje') },
+        { keys: '2', label: 'Aba Aplicar no Omie',           group: 'Cockpit', handler: () => handleTab('aplicaromie') },
+        { keys: '3', label: 'Aba Ciclos anteriores',         group: 'Cockpit', handler: () => handleTab('anteriores') },
+        { keys: 'r', label: 'Atualizar dados',               group: 'Cockpit', handler: () => handleRefetchAll() },
+        { keys: 'm', label: 'Alternar modo seleção (bulk)',  group: 'Cockpit', handler: () => setReviewMode(!reviewMode) },
+      ],
+      // dependências dos handlers
+      [handleGenerate, handleExportCsv, handleTab, handleRefetchAll, reviewMode, setReviewMode],
+    ),
+  );
 
   return (
     <div className="container mx-auto p-4 sm:p-6 space-y-6 max-w-7xl pb-24">
@@ -2099,7 +2068,7 @@ export default function AdminReposicaoCockpit() {
           <Button
             size="sm"
             variant="ghost"
-            onClick={() => setShortcutsOpen(true)}
+            onClick={() => window.dispatchEvent(new Event('open-shortcuts-dialog'))}
             title="Atalhos de teclado (?)"
           >
             <Keyboard className="h-4 w-4" />
@@ -2203,8 +2172,7 @@ export default function AdminReposicaoCockpit() {
       </Tabs>
 
       <AuditLogSection />
-
-      <ShortcutsDialog open={shortcutsOpen} onOpenChange={setShortcutsOpen} />
+      {/* O ShortcutsDialog agora é global (mounted no AppShell). Atalhos do cockpit foram migrados para useRegisterShortcuts. */}
     </div>
   );
 }

--- a/src/pages/FinanceiroCockpit.tsx
+++ b/src/pages/FinanceiroCockpit.tsx
@@ -15,6 +15,7 @@ import {
   CheckCircle2, Info, XCircle
 } from 'lucide-react';
 import { CockpitDrillDown, type DrillDownType } from '@/components/financeiro/CockpitDrillDown';
+import { logger } from '@/lib/logger';
 
 const fmt = (v: number) => v.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
 const fmtCompact = (v: number) => {
@@ -100,7 +101,12 @@ const FinanceiroCockpit = () => {
       try {
         const { data: proj } = await supabase.rpc('fin_projecao_13_semanas' as any, {}) as any;
         setProjecao13(proj || []);
-      } catch { /* RPC may not exist yet */ }
+      } catch (e) {
+        // RPC pode não existir ainda — registra para visibilidade em vez de falhar silencioso
+        logger.warn('RPC fin_projecao_13_semanas indisponível', {
+          error: e instanceof Error ? e.message : String(e),
+        });
+      }
 
       // Confiabilidade for current month per company
       const confResults: any[] = [];
@@ -114,7 +120,12 @@ const FinanceiroCockpit = () => {
             .eq('mes', mes)
             .maybeSingle();
           if (conf) confResults.push(conf);
-        } catch { /* table may not exist yet */ }
+        } catch (e) {
+          logger.warn('Tabela fin_confiabilidade indisponível', {
+            company: co,
+            error: e instanceof Error ? e.message : String(e),
+          });
+        }
       }
       setConfiabilidade(confResults);
     } catch (e) {

--- a/src/pages/NfeReceipt.tsx
+++ b/src/pages/NfeReceipt.tsx
@@ -1,11 +1,46 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { supabase } from "@/integrations/supabase/client";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { Package, Loader2, CheckCircle2, XCircle, AlertTriangle } from "lucide-react";
+import { Package, Loader2, CheckCircle2, XCircle, AlertTriangle, RotateCw, History } from "lucide-react";
+
+const ACCOUNT_LABELS: Record<string, string> = {
+  oben: "Oben",
+  colacor: "Colacor",
+  afiacao: "Afiação",
+};
+
+// Histórico local das últimas processadas — fallback até existir tabela `nfe_receipt_runs` no schema.
+// Quando a tabela existir, trocar este storage local por query Supabase.
+// TODO(schema): criar tabela nfe_receipt_runs(id uuid, account text, nf_number int, success bool, steps jsonb, started_at timestamptz, finished_at timestamptz, user_id uuid).
+const HISTORY_KEY = "nfe_receipt_history_v1";
+const MAX_HISTORY = 10;
+
+interface HistoryEntry {
+  id: string;
+  account: string;
+  nf_number: string;
+  success: boolean;
+  finished_at: string;
+  steps_count: number;
+}
+
+function readHistory(): HistoryEntry[] {
+  if (typeof localStorage === "undefined") return [];
+  try {
+    return JSON.parse(localStorage.getItem(HISTORY_KEY) ?? "[]") as HistoryEntry[];
+  } catch {
+    return [];
+  }
+}
+function pushHistory(entry: HistoryEntry): HistoryEntry[] {
+  const next = [entry, ...readHistory().filter((h) => !(h.account === entry.account && h.nf_number === entry.nf_number))].slice(0, MAX_HISTORY);
+  if (typeof localStorage !== "undefined") localStorage.setItem(HISTORY_KEY, JSON.stringify(next));
+  return next;
+}
 
 interface StepResult {
   step: number;
@@ -20,33 +55,75 @@ export default function NfeReceipt() {
   const [loading, setLoading] = useState(false);
   const [steps, setSteps] = useState<StepResult[]>([]);
   const [finalStatus, setFinalStatus] = useState<"idle" | "success" | "error">("idle");
+  const [history, setHistory] = useState<HistoryEntry[]>(() => readHistory());
 
-  const handleProcess = async () => {
-    if (!nfNumber.trim()) return;
+  const handleProcess = async (overrideNfNumber?: string, overrideAccount?: string) => {
+    const nf = (overrideNfNumber ?? nfNumber).trim();
+    const acc = overrideAccount ?? account;
+    if (!nf) return;
+    setNfNumber(nf);
+    setAccount(acc);
     setLoading(true);
     setSteps([]);
     setFinalStatus("idle");
 
     try {
       const { data, error } = await supabase.functions.invoke("process-nfe", {
-        body: { nf_number: nfNumber.trim(), account },
+        body: { nf_number: nf, account: acc },
       });
 
+      let success = false;
+      let resultSteps: StepResult[];
       if (error) {
-        setSteps([{ step: 0, description: "Erro ao chamar a função", status: "error", detail: error.message }]);
+        resultSteps = [{ step: 0, description: "Erro ao chamar a função", status: "error", detail: error.message }];
+        setSteps(resultSteps);
         setFinalStatus("error");
-        return;
+      } else {
+        resultSteps = data.steps || [];
+        success = !!data.success;
+        setSteps(resultSteps);
+        setFinalStatus(success ? "success" : "error");
       }
-
-      setSteps(data.steps || []);
-      setFinalStatus(data.success ? "success" : "error");
+      setHistory(
+        pushHistory({
+          id:
+            typeof crypto !== "undefined" && "randomUUID" in crypto
+              ? crypto.randomUUID()
+              : `${Date.now()}`,
+          account: acc,
+          nf_number: nf,
+          success,
+          finished_at: new Date().toISOString(),
+          steps_count: resultSteps.length,
+        }),
+      );
     } catch (e: any) {
-      setSteps([{ step: 0, description: "Erro inesperado", status: "error", detail: e.message }]);
+      const resultSteps = [{ step: 0, description: "Erro inesperado", status: "error" as const, detail: e.message }];
+      setSteps(resultSteps);
       setFinalStatus("error");
+      setHistory(
+        pushHistory({
+          id: `${Date.now()}`,
+          account: acc,
+          nf_number: nf,
+          success: false,
+          finished_at: new Date().toISOString(),
+          steps_count: 1,
+        }),
+      );
     } finally {
       setLoading(false);
     }
   };
+
+  // Re-sincroniza histórico se outra aba alterar
+  useEffect(() => {
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === HISTORY_KEY) setHistory(readHistory());
+    };
+    window.addEventListener("storage", onStorage);
+    return () => window.removeEventListener("storage", onStorage);
+  }, []);
 
   const getIcon = (status: string) => {
     switch (status) {
@@ -62,7 +139,9 @@ export default function NfeReceipt() {
       <div className="flex items-center gap-3">
         <Package className="h-7 w-7 text-primary" />
         <div>
-          <h1 className="text-2xl font-bold tracking-tight">OBEN Recebimento NF-e</h1>
+          <h1 className="text-2xl font-bold tracking-tight">
+            Recebimento NF-e — {ACCOUNT_LABELS[account] ?? account}
+          </h1>
           <p className="text-sm text-muted-foreground">Processamento automático de notas fiscais de entrada</p>
         </div>
       </div>
@@ -92,7 +171,7 @@ export default function NfeReceipt() {
               disabled={loading}
               className="flex-1"
             />
-            <Button onClick={handleProcess} disabled={loading || !nfNumber.trim()}>
+            <Button onClick={() => handleProcess()} disabled={loading || !nfNumber.trim()}>
               {loading ? <Loader2 className="h-4 w-4 animate-spin mr-2" /> : null}
               Processar NF-e
             </Button>
@@ -133,6 +212,54 @@ export default function NfeReceipt() {
                 </div>
               )}
             </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {history.length > 0 && (
+        <Card>
+          <CardHeader className="pb-3">
+            <CardTitle className="text-base flex items-center gap-2">
+              <History className="h-4 w-4 text-muted-foreground" />
+              Últimas processadas
+              <span className="text-xs font-normal text-muted-foreground">(neste navegador)</span>
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <ul className="divide-y divide-border">
+              {history.map((h) => (
+                <li key={h.id} className="flex items-center justify-between py-2 text-sm">
+                  <div className="min-w-0 flex items-center gap-2">
+                    {h.success ? (
+                      <CheckCircle2 className="h-4 w-4 text-status-success shrink-0" />
+                    ) : (
+                      <XCircle className="h-4 w-4 text-status-error shrink-0" />
+                    )}
+                    <span className="font-mono">NF {h.nf_number}</span>
+                    <Badge variant="outline" className="text-[10px]">
+                      {ACCOUNT_LABELS[h.account] ?? h.account}
+                    </Badge>
+                    <span className="text-xs text-muted-foreground">
+                      {new Date(h.finished_at).toLocaleString("pt-BR")}
+                    </span>
+                  </div>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    onClick={() => handleProcess(h.nf_number, h.account)}
+                    disabled={loading}
+                    className="gap-1.5"
+                  >
+                    <RotateCw className="h-3.5 w-3.5" />
+                    Reprocessar
+                  </Button>
+                </li>
+              ))}
+            </ul>
+            <p className="text-[11px] text-muted-foreground mt-3">
+              Esta tela processa uma NF-e por número. Para conferência item-a-item de NFs com lote/FEFO, use{" "}
+              <a href="/recebimento" className="text-link-level hover:underline">Recebimento</a>.
+            </p>
           </CardContent>
         </Card>
       )}

--- a/src/pages/TintFormulas.tsx
+++ b/src/pages/TintFormulas.tsx
@@ -10,7 +10,9 @@ import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Switch } from '@/components/ui/switch';
 import { Label } from '@/components/ui/label';
-import { Search, ChevronDown, ChevronUp } from 'lucide-react';
+import { Search, ChevronDown, ChevronUp, Star, History } from 'lucide-react';
+import { useTintRecentsFavorites, type TintFormulaRef } from '@/hooks/useTintRecentsFavorites';
+import { cn } from '@/lib/utils';
 
 const ACCOUNT = 'oben';
 const PAGE_SIZE = 50;
@@ -68,10 +70,26 @@ export default function TintFormulas() {
   const [onlyPersonalizada, setOnlyPersonalizada] = useState(false);
   const [page, setPage] = useState(0);
   const [expanded, setExpanded] = useState<string | null>(null);
+  const { recents, favorites, pushRecent, toggleFavorite, isFavorite } = useTintRecentsFavorites();
 
   const { data: produtos } = useProdutos();
   const { data: bases } = useBases(produtoFilter);
   const { data: omieMap } = useOmieMap();
+
+  const handleExpand = (formula: { id: string; cor_id: string; nome_cor: string; tint_produtos?: { descricao?: string }; tint_bases?: { descricao?: string } }) => {
+    const isOpening = expanded !== formula.id;
+    setExpanded(isOpening ? formula.id : null);
+    // ao expandir uma fórmula, registrar como "consultada"
+    if (isOpening) {
+      pushRecent({
+        id: formula.id,
+        cor_id: formula.cor_id,
+        nome_cor: formula.nome_cor,
+        produto_descricao: formula.tint_produtos?.descricao,
+        base_descricao: formula.tint_bases?.descricao,
+      });
+    }
+  };
 
   const { data, isLoading } = useQuery({
     queryKey: ['tint-formulas', search, produtoFilter, baseFilter, onlyPersonalizada, page],
@@ -121,6 +139,28 @@ export default function TintFormulas() {
     <div className="space-y-6">
       <h1 className="text-2xl font-bold">Tintométrico — Catálogo de Fórmulas</h1>
 
+      {/* Recentes & Favoritos — atalho de balcão */}
+      {(recents.length > 0 || favorites.length > 0) && (
+        <div className="space-y-2">
+          {favorites.length > 0 && (
+            <RecentsBar
+              icon={Star}
+              title="Favoritos"
+              items={favorites}
+              onSelect={(f) => setSearch(f.cor_id)}
+            />
+          )}
+          {recents.length > 0 && (
+            <RecentsBar
+              icon={History}
+              title="Recentes"
+              items={recents}
+              onSelect={(f) => setSearch(f.cor_id)}
+            />
+          )}
+        </div>
+      )}
+
       {/* Filters */}
       <Card>
         <CardContent className="pt-4">
@@ -166,6 +206,7 @@ export default function TintFormulas() {
                 <TableHeader>
                   <TableRow>
                     <TableHead className="w-8" />
+                    <TableHead className="w-8" />
                     <TableHead>Cor ID</TableHead>
                     <TableHead>Nome Cor</TableHead>
                     <TableHead>Produto</TableHead>
@@ -179,7 +220,28 @@ export default function TintFormulas() {
                 <TableBody>
                   {(data?.rows ?? []).map((f: any) => (
                     <>
-                      <TableRow key={f.id} className="cursor-pointer hover:bg-muted/50" onClick={() => setExpanded(expanded === f.id ? null : f.id)}>
+                      <TableRow key={f.id} className="cursor-pointer hover:bg-muted/50" onClick={() => handleExpand(f)}>
+                        <TableCell>
+                          <button
+                            type="button"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              toggleFavorite({
+                                id: f.id,
+                                cor_id: f.cor_id,
+                                nome_cor: f.nome_cor,
+                                produto_descricao: f.tint_produtos?.descricao,
+                                base_descricao: f.tint_bases?.descricao,
+                              });
+                            }}
+                            className="text-muted-foreground hover:text-status-warning transition-colors"
+                            aria-label={isFavorite(f.id) ? 'Remover dos favoritos' : 'Favoritar'}
+                          >
+                            <Star
+                              className={cn('w-4 h-4', isFavorite(f.id) && 'fill-status-warning text-status-warning')}
+                            />
+                          </button>
+                        </TableCell>
                         <TableCell>
                           {expanded === f.id ? <ChevronUp className="w-4 h-4" /> : <ChevronDown className="w-4 h-4" />}
                         </TableCell>
@@ -191,14 +253,14 @@ export default function TintFormulas() {
                         <TableCell className="text-sm">{f.volume_final_ml ? `${f.volume_final_ml}ml` : '—'}</TableCell>
                         <TableCell className="text-sm">{f.preco_final_sayersystem ? `R$ ${Number(f.preco_final_sayersystem).toFixed(2)}` : '—'}</TableCell>
                         <TableCell>
-                          <Badge variant="outline" className={f.personalizada ? 'bg-purple-500/10 text-purple-700' : 'bg-blue-500/10 text-blue-700'}>
+                          <Badge variant="outline" className={f.personalizada ? 'status-purple' : 'status-progress'}>
                             {f.personalizada ? 'Personalizada' : 'Padrão'}
                           </Badge>
                         </TableCell>
                       </TableRow>
                       {expanded === f.id && expandedDetail && (
                         <TableRow key={`${f.id}-detail`}>
-                          <TableCell colSpan={9} className="bg-muted/30 p-4">
+                          <TableCell colSpan={10} className="bg-muted/30 p-4">
                             <div className="space-y-2">
                               <h4 className="text-sm font-semibold">Corantes utilizados</h4>
                               <Table>
@@ -251,6 +313,39 @@ export default function TintFormulas() {
           </CardContent>
         </Card>
       )}
+    </div>
+  );
+}
+
+function RecentsBar({
+  icon: Icon,
+  title,
+  items,
+  onSelect,
+}: {
+  icon: typeof Star;
+  title: string;
+  items: TintFormulaRef[];
+  onSelect: (item: TintFormulaRef) => void;
+}) {
+  return (
+    <div className="flex items-center gap-2 flex-wrap">
+      <span className="inline-flex items-center gap-1 text-xs font-medium text-muted-foreground uppercase tracking-wider">
+        <Icon className="w-3 h-3" />
+        {title}
+      </span>
+      {items.map((it) => (
+        <button
+          key={it.id}
+          type="button"
+          onClick={() => onSelect(it)}
+          className="inline-flex items-center gap-1.5 px-2 py-1 rounded-md text-xs bg-muted hover:bg-muted/70 border border-border transition-colors"
+          title={it.nome_cor}
+        >
+          <span className="font-mono">{it.cor_id}</span>
+          <span className="text-muted-foreground truncate max-w-[120px]">{it.nome_cor}</span>
+        </button>
+      ))}
     </div>
   );
 }

--- a/src/pages/UnifiedOrder.tsx
+++ b/src/pages/UnifiedOrder.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useMemo, useState } from 'react';
 import { Loader2, ChevronLeft, CheckCircle, Building2, Scissors } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -9,6 +10,9 @@ import { OrderSuccessDialog } from '@/components/OrderSuccessDialog';
 import { cn } from '@/lib/utils';
 import { useUnifiedOrder } from '@/hooks/useUnifiedOrder';
 import { useOrderDeepLink } from '@/hooks/useOrderDeepLink';
+import { useOrderDraft } from '@/hooks/useOrderDraft';
+import { useAuth } from '@/contexts/AuthContext';
+import { RestoreDraftDialog } from '@/components/unified-order/RestoreDraftDialog';
 import { CustomerSearch } from '@/components/unified-order/CustomerSearch';
 import { ProductItemForm } from '@/components/unified-order/ProductItemForm';
 import { ServiceItemForm } from '@/components/unified-order/ServiceItemForm';
@@ -37,6 +41,8 @@ function OrderStepper({ step, isCustomerMode }: { step: number; isCustomerMode: 
 const UnifiedOrder = () => {
   const h = useUnifiedOrder();
   const { isCustomerMode } = h;
+  const { user } = useAuth();
+  const [restoreOpen, setRestoreOpen] = useState(false);
 
   useOrderDeepLink({
     selectedCustomer: h.selectedCustomer,
@@ -48,6 +54,50 @@ const UnifiedOrder = () => {
     loadingColacorProducts: h.loadingColacorProducts,
     loadingCustomer: h.loadingCustomer,
   });
+
+  // ─── Auto-save de rascunho ───
+  // Salva snapshot enquanto vendedor digita; mostra dialog para restaurar se voltar à tela com cart vazio.
+  // Limpa após pedido enviado com sucesso (orderSuccessOpen = true).
+  const draftScope = user?.id ?? 'anon';
+  const draftPayload = useMemo(
+    () => ({
+      cart: h.cart,
+      customerCodigoCliente: h.selectedCustomer?.codigo_cliente ?? null,
+      customerName: h.selectedCustomer?.razao_social ?? null,
+      notes: h.notes,
+      ordemCompra: h.ordemCompra,
+    }),
+    [h.cart, h.selectedCustomer, h.notes, h.ordemCompra],
+  );
+  const { draft, clear: clearDraft, dismiss: dismissDraft } = useOrderDraft({
+    scopeKey: draftScope,
+    state: draftPayload,
+    shouldSave: h.cart.length > 0,
+    clearTrigger: h.orderSuccessOpen, // limpa quando o success dialog abrir = pedido enviado
+  });
+
+  // Oferece restore se houver draft pendente E o cart atual estiver vazio (entrou novo na tela).
+  useEffect(() => {
+    if (draft && h.cart.length === 0 && !restoreOpen) {
+      setRestoreOpen(true);
+    }
+  }, [draft, h.cart.length, restoreOpen]);
+
+  const handleRestore = () => {
+    if (!draft) return;
+    const { state } = draft;
+    if (Array.isArray(state.cart)) h.setCart(state.cart);
+    if (typeof state.notes === 'string') h.setNotes(state.notes);
+    if (typeof state.ordemCompra === 'string') h.setOrdemCompra(state.ordemCompra);
+    setRestoreOpen(false);
+    // Não limpa o draft — ele será reescrito naturalmente conforme o vendedor edita.
+  };
+
+  const handleDiscardDraft = () => {
+    clearDraft();
+    dismissDraft();
+    setRestoreOpen(false);
+  };
 
   if (h.authLoading) {
     return <div className="flex items-center justify-center py-32"><Loader2 className="w-6 h-6 animate-spin text-muted-foreground" /></div>;
@@ -248,6 +298,17 @@ const UnifiedOrder = () => {
               orderNumbers: h.lastOrderData!.orderNumbers,
             });
           }}
+        />
+      )}
+
+      {draft && (
+        <RestoreDraftDialog
+          open={restoreOpen}
+          savedAt={draft.savedAt}
+          customerName={draft.state.customerName ?? undefined}
+          itemCount={Array.isArray(draft.state.cart) ? draft.state.cart.length : 0}
+          onRestore={handleRestore}
+          onDiscard={handleDiscardDraft}
         />
       )}
 

--- a/src/pages/picking/TouchPickingView.tsx
+++ b/src/pages/picking/TouchPickingView.tsx
@@ -1,0 +1,192 @@
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import { Card, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Progress } from '@/components/ui/progress';
+import { ScanBar, type ScanResult } from '@/components/picking/ScanBar';
+import { Loader2, ChevronRight, Check, AlertTriangle, Package } from 'lucide-react';
+import { toast } from 'sonner';
+import { cn } from '@/lib/utils';
+
+/**
+ * Visão mobile dedicada do picking — separador no chão, com luva, sinal ruim.
+ *
+ * Hoje (scaffold v1): lista as tasks abertas como cards verticais grandes (h-20+),
+ * scan-first input no topo, foco em 1 task por vez.
+ *
+ * Próximas iterações:
+ *  - Swipe-to-advance entre itens da task
+ *  - Optimistic UI no confirmar item (usa useOptimisticMutation já existente)
+ *  - Integração com offline-queue (já existe scaffold em src/lib/offline-queue.ts)
+ *  - Layout em "kiosk mode" (sem app shell, fullscreen)
+ *
+ * Para entrar em uso real, falta:
+ *  - Decisão de produto sobre dual-view (auto-detect mobile + pointer:coarse vs rota dedicada)
+ *  - Validação no chão com separador real (touch targets, fontes, contraste sob luz variável)
+ */
+
+const ACCOUNT_DEFAULT = 'oben'; // TODO(produto): puxar do CompanyContext quando picking suportar multi-empresa
+
+export default function TouchPickingView() {
+  const [activeTaskId, setActiveTaskId] = useState<string | null>(null);
+
+  const { data: tasks, isLoading } = useQuery({
+    queryKey: ['touch-pk-tasks', ACCOUNT_DEFAULT],
+    queryFn: async () => {
+      const { data } = await (supabase as any)
+        .from('picking_tasks')
+        .select('id, sales_order_id, status, created_at')
+        .eq('account', ACCOUNT_DEFAULT)
+        .in('status', ['pendente', 'em_andamento'])
+        .order('created_at', { ascending: true })
+        .limit(20);
+      return data ?? [];
+    },
+    refetchInterval: 30000,
+  });
+
+  const handleScan = (result: ScanResult) => {
+    // v1: feedback. Próxima iteração: navegar para o item correspondente da task ativa.
+    toast.success(
+      result.kind === 'address' ? `Endereço: ${result.raw}` : `Produto: ${result.raw}`,
+      { duration: 1500 },
+    );
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center py-20 text-muted-foreground">
+        <Loader2 className="h-6 w-6 animate-spin" />
+      </div>
+    );
+  }
+
+  if (activeTaskId) {
+    return <ActiveTaskView taskId={activeTaskId} onBack={() => setActiveTaskId(null)} onScan={handleScan} />;
+  }
+
+  return (
+    <div className="space-y-3">
+      <ScanBar onScan={handleScan} placeholder="Bipe um endereço ou código pra começar" />
+      <div className="px-1 pt-2">
+        <h2 className="text-base font-semibold mb-2">Tasks abertas</h2>
+        {(tasks ?? []).length === 0 ? (
+          <div className="text-center py-12 text-sm text-muted-foreground">
+            <Package className="w-8 h-8 mx-auto mb-2 text-muted-foreground/40" />
+            Nenhuma task pendente. Bom trabalho!
+          </div>
+        ) : (
+          <ul className="space-y-2">
+            {(tasks ?? []).map((t: any) => (
+              <li key={t.id}>
+                <button
+                  type="button"
+                  onClick={() => setActiveTaskId(t.id)}
+                  className={cn(
+                    'w-full flex items-center gap-3 p-4 rounded-lg bg-card border border-border',
+                    'hover:bg-muted active:bg-muted/70 transition-colors min-h-[72px]',
+                  )}
+                >
+                  <Package className="w-5 h-5 text-primary shrink-0" />
+                  <div className="flex-1 min-w-0 text-left">
+                    <p className="font-mono text-sm font-medium truncate">Task {t.id.slice(0, 8)}</p>
+                    <p className="text-xs text-muted-foreground truncate">
+                      Pedido {t.sales_order_id?.slice(0, 8) ?? '—'} · {t.status}
+                    </p>
+                  </div>
+                  <ChevronRight className="w-5 h-5 text-muted-foreground shrink-0" />
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ActiveTaskView({
+  taskId,
+  onBack,
+  onScan,
+}: {
+  taskId: string;
+  onBack: () => void;
+  onScan: (r: ScanResult) => void;
+}) {
+  const { data: items, isLoading } = useQuery({
+    queryKey: ['touch-pk-items', taskId],
+    queryFn: async () => {
+      const { data } = await (supabase as any)
+        .from('picking_task_items')
+        .select('id, product_descricao, quantidade, quantidade_separada, status, lote_fefo, lote_separado')
+        .eq('picking_task_id', taskId)
+        .order('id');
+      return data ?? [];
+    },
+  });
+
+  const total = (items ?? []).reduce((s: number, i: any) => s + (i.quantidade ?? 0), 0);
+  const done = (items ?? []).reduce((s: number, i: any) => s + (i.quantidade_separada ?? 0), 0);
+  const pct = total > 0 ? Math.round((done / total) * 100) : 0;
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center py-20 text-muted-foreground">
+        <Loader2 className="h-6 w-6 animate-spin" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <ScanBar onScan={onScan} placeholder="Bipe o endereço ou código do produto" />
+      <div className="px-1">
+        <Button size="touch" variant="outline" onClick={onBack} className="mb-3">
+          ← Voltar
+        </Button>
+        <div className="space-y-1">
+          <div className="flex justify-between text-sm">
+            <span className="font-medium">Task {taskId.slice(0, 8)}</span>
+            <span className="text-muted-foreground">{done}/{total} ({pct}%)</span>
+          </div>
+          <Progress value={pct} className="h-3" />
+        </div>
+      </div>
+      <ul className="space-y-2 px-1">
+        {(items ?? []).map((it: any) => {
+          const ok = it.status === 'concluido' || (it.quantidade_separada ?? 0) >= it.quantidade;
+          const divergente = it.lote_separado && it.lote_fefo && it.lote_separado !== it.lote_fefo;
+          return (
+            <Card key={it.id} className={cn(ok && 'opacity-50')}>
+              <CardContent className="p-4 space-y-2">
+                <div className="flex items-start justify-between gap-2">
+                  <p className="text-base font-medium leading-snug">{it.product_descricao}</p>
+                  {ok && <Check className="w-5 h-5 text-status-success shrink-0" />}
+                </div>
+                <div className="flex items-center gap-2 text-sm">
+                  <Badge variant="outline" className="text-xs">
+                    {it.quantidade_separada ?? 0} de {it.quantidade}
+                  </Badge>
+                  {it.lote_fefo && (
+                    <Badge variant="outline" className="text-xs font-mono">
+                      FEFO: {it.lote_fefo}
+                    </Badge>
+                  )}
+                  {divergente && (
+                    <Badge variant="outline" className="text-xs status-pending gap-1">
+                      <AlertTriangle className="w-3 h-3" />
+                      Lote divergente
+                    </Badge>
+                  )}
+                </div>
+              </CardContent>
+            </Card>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
Auditoria UX completa (Fases 0-4) + execução do roadmap.

- 20 itens do roadmap implementados (atalhos globais, command palette ⌘K,
  indicador online/offline, draft autosave no UnifiedOrder, scan bar no picking,
  segmentos salvos em clientes, histórico no NFe Receipt, etc.)
- 3 fixes de logs silenciosos identificados na auditoria
- Wrapper de compat pra Sonner (53 callsites de useToast continuam funcionando)
- Scaffolds para offline-first e mobile-first (precisam decisões de produto)

Detalhes em docs/ux-audit/04-execucao.md.