### PR TITLE
feat(visual): redesign fintech/SaaS premium (Vercel/Mercury direction)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md — Afiação (Sistema Operacional B2B Sardenberg)
 
-> Este arquivo orienta agentes de código (e humanos) trabalhando neste repositório. Última atualização: 2026-05-13 (auditoria UX completa, Fases 0-4 entregues — ver `docs/ux-audit/`).
+> Este arquivo orienta agentes de código (e humanos) trabalhando neste repositório. Última atualização: 2026-05-13 (auditoria UX completa, Fases 0-4 entregues e fix do `Bell` import aplicado — ver `docs/ux-audit/`).
 
 ---
 

--- a/docs/visual-direction/01-direcao.md
+++ b/docs/visual-direction/01-direcao.md
@@ -1,0 +1,269 @@
+# Direção Visual — Reposicionamento "Fintech/SaaS Premium"
+
+> Data: 2026-05-13 · Inputs: Vercel, Mercury, Stripe Dashboard como referências · Light + dark com toggle · Reposicionar identidade.
+>
+> **Esta fase NÃO toca em código.** Define direção visual antes de implementar. Próximo passo é spec de tokens (`02-tokens.md`) e telas-piloto (`03-pilotos.md`).
+
+---
+
+## 1. Diagnóstico do visual atual
+
+O app hoje carrega uma identidade **HubSpot Canvas + Polaris + Gong** declarada no `DesignSystem.tsx`. O que isso significa visualmente, na prática:
+
+| Atributo | Estado atual | Como soa |
+|---|---|---|
+| **Paleta primária** | Azul `hsl(222 83% 53%)` saturado, tipo HubSpot/Material | Corporativo "década passada" |
+| **Background** | Cinza claro azulado `hsl(220 14% 96%)` | OK, mas genérico |
+| **Sidebar** | Dark fixa `hsl(220 25% 11%)` | Vibe Canvas/Notion sidebar, mas contraste alto destoa do resto |
+| **Tipografia** | Inter (sans), JetBrains Mono (mono) | Boa escolha, mas usa só pesos básicos |
+| **Border radius** | `0.5rem` em tudo | Médio — nem moderno-quadrado nem retrô-redondo |
+| **Cards** | Sombras suaves multi-camada, border sutil | Padrão shadcn — "limpo mas sem alma" |
+| **Botões** | `h-9` default, primary azul cheio | Funcional, sem refinamento |
+| **Densidade** | `density-compact` global (32px input / 36px row) | Boa pra B2B |
+| **Motion** | 100/200/350ms com `cubic-bezier(0.4, 0, 0.2, 1)` Material | Sem assinatura própria |
+| **Numbers / valores** | Inter regular | Sem tabular nums → valores "dançam" em tabelas |
+| **Cores semânticas** | Definidas em tokens, mas usadas com cores cruas (emerald/red/amber) em 50+ lugares | Inconsistente |
+
+**Veredicto**: o app hoje comunica **"sistema interno corporativo razoável"**. Não comunica **"premium", "moderno", "expensive feeling"**. Os componentes shadcn dão um piso decente, mas nenhuma escolha visual cria identidade.
+
+---
+
+## 2. O que Vercel, Mercury e Stripe Dashboard têm em comum
+
+Vou destilar os patterns visuais compartilhados entre os 3 — é isso que vai virar a base do nosso sistema.
+
+### 2.1 Tipografia geométrica + tabular nums obrigatório
+
+- **Vercel** usa Geist Sans (font própria, geométrica neo-grotesque) + Geist Mono pra código/valores
+- **Mercury** combina Domine (display serif, só em headlines grandes) + Inter (body) + IBM Plex Mono (números financeiros)
+- **Stripe** usa Stripe Sans (variante Inter customizada) com `font-feature-settings: 'tnum'` em qualquer número
+
+**Padrão comum**: dois tipos — um geométrico sans pra UI body + um mono ou tabular pra valores. Números **nunca** em proporcional. Headlines em pesos 500/600, não 700 (peso menor = sensação mais "fina" e premium).
+
+### 2.2 Paleta: 1 cor primária minimal + escala neutra cuidadosa
+
+- **Vercel**: preto/branco absoluto (`#000` / `#FFF`), com escala Gray bem trabalhada (`gray-50` a `gray-1000`). Acentos só em estados (azul focus, vermelho erro)
+- **Mercury**: roxo `#5E36BF` (acento), branco quente `#FAFAFA` (light) ou preto azulado (dark), escala neutral warm-leaning
+- **Stripe Dashboard**: roxo Stripe `#635BFF`, branco `#FFF`, cinzas neutros
+
+**Padrão comum**: **uma cor de identidade só**, usada com parcimônia (botão primário, link, focus ring). O resto é escala neutra de 10-12 tons. Nada de azul + verde + amarelo + roxo na mesma tela. As cores semânticas (success/warning/error) existem mas usam tons dessaturados.
+
+### 2.3 Borders 1px finas + sombras quase ausentes
+
+- **Vercel**: `border: 1px solid hsl(0 0% 92%)` em light, `hsl(0 0% 14%)` em dark. Sombra praticamente zero.
+- **Mercury**: sombras só em popovers/modals, com ofset pequeno e cor preta com 5-8% opacidade
+- **Stripe Dashboard**: sombras box-shadow `0 1px 3px rgba(0,0,0,0.05)` no máximo
+
+**Padrão comum**: **profundidade é dada por borders, não por sombras**. Sombras existem só em elementos que sobrepõem (modals, dropdowns, tooltips). Cards do conteúdo principal raramente têm shadow.
+
+### 2.4 Densidade média (não comprimida) + leading generoso em headlines
+
+- Inputs entre 36-40px de altura (não 32, não 48)
+- Row de tabela entre 40-48px
+- Padding de cards 16-24px
+- **Headlines com `line-height: 1.1-1.2`** e `letter-spacing: -0.02em` — isso é a assinatura "premium". Faz títulos parecerem tipográficos, não funcionais.
+
+### 2.5 Motion sóbrio com easing custom
+
+- Vercel usa `cubic-bezier(0.16, 1, 0.3, 1)` em quase tudo (easeOutQuint) — assinatura "polished, suave"
+- Durações curtas: 150ms hover, 200ms focus, 300ms layout, 500ms overlay
+- **Nada de bounce/spring**. Sem motion exagerado.
+
+### 2.6 Sidebar light, não dark (Vercel/Stripe) OU dark sutil (Mercury)
+
+- **Vercel**: sidebar com mesmo background do conteúdo, apenas border-right e contraste de texto
+- **Stripe**: sidebar `#0A2540` (azul-preto, não preto puro)
+- **Mercury**: dark unifies sidebar com header
+
+**Padrão comum**: **dark sidebar fica datado em 2026**. A tendência atual é sidebar light coerente com conteúdo (Vercel/Stripe) ou dark global em todo o app (Linear/Mercury dark). **Misturar sidebar dark + content light é o look "2018-2020".**
+
+### 2.7 Numbers e dados são protagonistas
+
+- Stripe Dashboard: KPIs em fonte 32-48px com peso 500, com letter-spacing apertado
+- Mercury: saldo da conta enorme, com valor em tabular mono
+- Vercel Analytics: métricas grandes, gráficos minimalistas
+
+**Padrão comum**: o número é o sujeito da frase visual. Label vira coadjuvante (menor, mais clara). Isso é diferente do estilo atual (KPI label e value parecidos em peso).
+
+---
+
+## 3. Como isso se traduz pra Afiação
+
+7 dimensões com a direção proposta. Cada uma tem 2-3 caminhos pra você decidir.
+
+### Dimensão A — Paleta primária
+
+> **Atual**: azul HubSpot `hsl(222 83% 53%)`
+
+| Caminho | Como fica | Sensação |
+|---|---|---|
+| **A1 — Preto/branco minimal (Vercel)** | Primary `#000` (light) / `#FFF` (dark). Acentos só em focus/estados. Maximalmente neutro. | Frio, ultra-premium, "expensive". Risco: pode parecer estéril ou genérico se mal executado. |
+| **A2 — Roxo/Indigo profundo (Mercury/Stripe)** | Primary tipo `hsl(258 90% 66%)` (roxo Mercury) ou `hsl(243 75% 59%)` (indigo Stripe). | Distintivo, identifica imediatamente como "fintech premium". Risco: precisa combinar com escala neutra impecável pra não virar "kid". |
+| **A3 — Verde profundo (financeiro sério)** | Primary tipo `hsl(160 84% 25%)` (verde Stripe, próximo do Plaid). | "Money serious". Faz sentido pra app financeiro, mas pode soar conservador demais pra módulos não-financeiros (Tintométrico, Picking). |
+| **A4 — Azul refinado** | Manter família azul mas dessaturar — algo tipo `hsl(217 91% 60%)` (Tailwind blue-500 mas mais profundo). | Familiar mas atualizado. Menor disruption visual. Risco: continua "corporativo". |
+
+> Recomendação: **A2 (roxo/indigo profundo)** dado o briefing "fintech premium". Distingue Afiação visualmente da pasta de "sistemas internos corporativos". Roxo Mercury especificamente é menos comum no Brasil — diferencia.
+
+### Dimensão B — Sidebar
+
+> **Atual**: dark fixa `hsl(220 25% 11%)`, sempre
+
+| Caminho | Como fica |
+|---|---|
+| **B1 — Sidebar light, coerente com conteúdo (Vercel/Stripe)** | Fundo branco/cinza muito claro, border-right 1px, texto em escala de cinza. No dark mode, vira escuro coerente. |
+| **B2 — Sidebar dark global (Linear, Mercury dark)** | App inteiro dark por default. Light é opcional. Faz sentido se você quer comprometer com "dark first". |
+| **B3 — Sidebar dark + content light (atual, mantém)** | Conserva o que tem hoje. Mais conservador. |
+
+> Recomendação: **B1**. É o padrão atual SOTA. O dark do shell pode ficar pesado depois de 6h olhando. Sidebar light fica mais sofisticado e flexível.
+
+### Dimensão C — Tipografia
+
+> **Atual**: Inter + JetBrains Mono
+
+| Caminho | Como fica |
+|---|---|
+| **C1 — Geist Sans + Geist Mono (Vercel custom)** | Tipografia mais geométrica que Inter. Vercel libera Geist como open source. Mudança visualmente perceptível. |
+| **C2 — Inter Tight (display) + Inter (body) + JetBrains Mono (numbers)** | Mantém Inter base. Inter Tight em headers grandes dá o "premium feel". Mínimo de risco. |
+| **C3 — Manter Inter atual mas ativar features (tnum, ss01, cv11)** | Sem trocar fonte. Só ativar tabular nums em valores + stylistic sets em headings. Quase free. |
+
+> Recomendação: **C1 (Geist)**. Mudança mais marcante alinhada ao briefing fintech-premium. Free, open source, suportado oficialmente pela Vercel. Aplicar em paralelo: features tnum/ss01 nos números.
+
+### Dimensão D — Border radius e densidade visual
+
+> **Atual**: `--radius: 0.5rem` (8px) em tudo
+
+| Caminho | Como fica |
+|---|---|
+| **D1 — Reduzir pra `0.375rem` (6px)** e `0.5rem` só em modals (Vercel/Mercury) | Mais sóbrio, mais "geométrico". |
+| **D2 — Aumentar pra `0.625rem` (10px)** em todos | Mais friendly, mais Stripe-landing-page. Não combina com fintech sério. |
+| **D3 — Manter `0.5rem`** | Sem mudança. |
+
+> Recomendação: **D1**. Pequena mudança que muda muito a sensação. Botões e cards ficam mais "sharp".
+
+### Dimensão E — Sombras e profundidade
+
+> **Atual**: sombras suaves multi-camada
+
+| Caminho | Como fica |
+|---|---|
+| **E1 — Borders 1px finas dominantes + sombras só em overlay (Vercel)** | Cards e KPIs sem shadow. Só dropdown/modal/tooltip têm `0 4px 12px rgba(0,0,0,0.08)`. |
+| **E2 — Sombra ultra-sutil em cards (`0 1px 2px rgba(0,0,0,0.04)`) + bigger em overlay (Stripe)** | Pequena profundidade no estado base, mais em overlay. |
+| **E3 — Manter sombras atuais** | Sem mudança. |
+
+> Recomendação: **E1**. Mais limpo. Borders bem trabalhadas dão a profundidade necessária.
+
+### Dimensão F — Tipografia de números
+
+> **Atual**: Inter regular, números proporcionais
+
+| Caminho | Como fica |
+|---|---|
+| **F1 — `font-feature-settings: 'tnum'` global em valores** | Números viram tabulares (mesma largura). Tabelas alinham perfeitamente. Free, só configuração. |
+| **F2 — F1 + JetBrains Mono em KPIs grandes** | KPIs financeiros viram quase "ticker de bolsa". Mais técnico. |
+| **F3 — Manter atual** | Sem mudança. |
+
+> Recomendação: **F1 + F2 só em telas financeiras** (FinanceiroCockpit, AdminReposicaoCockpit). Outras telas ficam com tnum no Inter mesmo.
+
+### Dimensão G — Motion
+
+> **Atual**: 100/200/350ms com easing Material
+
+| Caminho | Como fica |
+|---|---|
+| **G1 — Easing Vercel custom `cubic-bezier(0.16, 1, 0.3, 1)` + 150/200/300/500ms** | Motion polida, suave. Hover ficam "premium". |
+| **G2 — Manter atual** | Sem mudança. |
+
+> Recomendação: **G1**. Mudança quase invisível mas notavelmente mais elegante. Aplica em tudo (hover, focus, transitions, dialogs).
+
+---
+
+## 4. Spec preliminar de tokens (para `02-tokens.md`)
+
+Esboço do que vai mudar em `src/index.css` se você aprovar A2/B1/C1/D1/E1/F1/G1. Detalhamento fica para próxima fase.
+
+```
+/* Cores — Light */
+--primary: 258 90% 66%;          /* roxo Mercury-like */
+--primary-foreground: 0 0% 100%;
+--background: 0 0% 100%;          /* branco puro */
+--foreground: 0 0% 9%;            /* preto suave */
+--muted: 0 0% 96%;
+--muted-foreground: 0 0% 45%;
+--border: 0 0% 92%;
+--card: 0 0% 100%;
+--sidebar-background: 0 0% 99%;   /* sidebar light agora */
+--sidebar-foreground: 0 0% 30%;
+--sidebar-border: 0 0% 92%;
+
+/* Cores — Dark */
+--background: 0 0% 6%;            /* preto azulado profundo */
+--foreground: 0 0% 95%;
+--muted: 0 0% 12%;
+--muted-foreground: 0 0% 60%;
+--border: 0 0% 14%;
+--card: 0 0% 8%;
+--sidebar-background: 0 0% 5%;
+--sidebar-foreground: 0 0% 70%;
+--sidebar-border: 0 0% 14%;
+--primary: 258 90% 70%;           /* roxo um pouco mais brilhante no dark */
+
+/* Tipografia */
+font-family-sans: 'Geist', system-ui, sans-serif;
+font-family-mono: 'Geist Mono', JetBrains Mono, monospace;
+font-feature-settings: 'tnum', 'ss01';
+heading-tracking: -0.02em;
+heading-line-height: 1.15;
+
+/* Radius */
+--radius: 0.375rem;
+
+/* Shadow */
+--shadow-xs: none;
+--shadow-sm: 0 1px 2px hsl(0 0% 0% / 0.04);
+--shadow-md: 0 4px 12px hsl(0 0% 0% / 0.08);  /* só em overlays */
+--shadow-lg: 0 8px 24px hsl(0 0% 0% / 0.12);  /* só em modals */
+
+/* Motion */
+--easing-default: cubic-bezier(0.16, 1, 0.3, 1);
+--duration-fast: 150ms;
+--duration-normal: 200ms;
+--duration-slow: 300ms;
+--duration-overlay: 500ms;
+```
+
+---
+
+## 5. Decisões registradas (2026-05-13)
+
+Após segunda rodada questionando fadiga em uso diário 8h:
+
+| Dimensão | Decisão | Justificativa |
+|---|---|---|
+| A — Paleta primária | **A1 ajustado — Quase-neutro estilo Vercel/Linear** | Roxo `hsl 258 90% 66%` original tinha saturação alta demais pra uso prolongado. Quase-neutro elimina fadiga visual e desloca identidade pra tipografia/spacing/detalhe. |
+| B — Sidebar | **B1 — Light coerente com conteúdo** | Padrão SOTA. Sidebar dark + content light é look 2018-2020. |
+| C — Tipografia | **C1 — Geist Sans + Geist Mono** | Vercel font, free, geométrica premium. |
+| D — Radius | **D1 — Reduzir pra 6px** | Mais sharp, alinhado a Vercel/Linear. |
+| E — Sombras | **E1 — Borders 1px dominantes** | Sombras só em overlay (modal/dropdown). |
+| F — Números | **F1 — Tabular nums global + Geist Mono em KPIs financeiros** | Valores nunca dançam em tabelas. KPIs financeiros viram "ticker premium". |
+| G — Motion | **G1 — Easing Vercel custom + 150/200/300/500ms** | Assinatura "polida" sem ser dramática. |
+
+### Implicação chave: status colors viram o coração das cores
+
+Com primary neutro, **todo o sinal visual de estado** (sucesso, alerta, erro, info) precisa ser bem calibrado:
+
+- **Success** — verde profundo dessaturado `hsl(142 50% 38%)` (não emerald-500 saturado)
+- **Warning** — amber/orange dessaturado `hsl(35 80% 45%)` (não amber-500 puro)
+- **Error** — vermelho marrom-leaning `hsl(0 72% 45%)` (não red-500 saturado)
+- **Info** — azul Vercel sutil `hsl(212 80% 50%)`
+
+Todos com versões `-bg` muito claras (light) ou muito escuras (dark) pra fundos de badge/banner. **Esses tons são as únicas cores cromáticas na tela — precisam aguentar uso prolongado.**
+
+## 6. Próxima decisão pendente
+
+**Telas-piloto pra validar a direção**:
+
+- **Opção α** — `FinanceiroCockpit` + `AdminReposicaoCockpit`: telas analíticas, alta densidade, KPIs financeiros (boa pra mostrar tabular nums + Geist Mono). Risco: complexidade alta, pode demorar.
+- **Opção β** — `Index/Home`: cobre todas as personas (staff vê pedidos, customer vê dashboard), é a primeira impressão visual. Mais simples mas menos "demonstração de poder visual".
+- **Opção γ** — `AdminCustomers`: tabela densa com filtros, segmentos (que acabamos de implementar), avatar de cliente. Boa pra mostrar tipografia + tabela + chips + tabular nums em coluna "gasto mensal".
+
+Próximo doc (`02-tokens.md`) é independente da escolha — define os tokens novos no nível CSS. Mas `03-pilotos.md` depende dessa escolha. Aguardo sua resposta.

--- a/docs/visual-direction/02-tokens.md
+++ b/docs/visual-direction/02-tokens.md
@@ -1,0 +1,326 @@
+# Spec de Tokens — Implementação da Direção Visual
+
+> Data: 2026-05-13 · Implementa decisões de [01-direcao.md](./01-direcao.md). Esta é a referência canônica do que muda em `src/index.css` e `tailwind.config.ts`.
+
+---
+
+## 1. Cores — Light mode (default)
+
+```css
+:root {
+  /* Backgrounds — escala neutra warm-leaning */
+  --background: 0 0% 100%;            /* #FFFFFF — branco puro */
+  --foreground: 0 0% 9%;              /* #171717 — preto suave (não puro, evita harshness) */
+
+  --card: 0 0% 100%;
+  --card-foreground: 0 0% 9%;
+
+  --popover: 0 0% 100%;
+  --popover-foreground: 0 0% 9%;
+
+  --muted: 0 0% 96%;                  /* #F5F5F5 */
+  --muted-foreground: 0 0% 45%;       /* #737373 */
+
+  --accent: 0 0% 96%;
+  --accent-foreground: 0 0% 9%;
+
+  --secondary: 0 0% 96%;
+  --secondary-foreground: 0 0% 9%;
+
+  --border: 0 0% 92%;                 /* #EBEBEB — bordas sutis */
+  --input: 0 0% 92%;
+
+  /* Primary — preto (Vercel-style minimal) */
+  --primary: 0 0% 9%;                 /* #171717 — botão primary é preto */
+  --primary-foreground: 0 0% 100%;
+  --ring: 0 0% 9%;                    /* focus ring preto sutil */
+
+  /* Sidebar light coerente — mesma família do conteúdo */
+  --sidebar-background: 0 0% 99%;     /* quase branco com leve diferenciação */
+  --sidebar-foreground: 0 0% 30%;
+  --sidebar-primary: 0 0% 9%;
+  --sidebar-primary-foreground: 0 0% 100%;
+  --sidebar-accent: 0 0% 96%;
+  --sidebar-accent-foreground: 0 0% 9%;
+  --sidebar-border: 0 0% 92%;
+  --sidebar-ring: 0 0% 9%;
+  --sidebar-muted: 0 0% 60%;
+
+  /* Surfaces — escala discreta de profundidade via cinza */
+  --surface-0: 0 0% 100%;
+  --surface-1: 0 0% 98%;
+  --surface-2: 0 0% 96%;
+  --surface-3: 0 0% 92%;
+
+  /* Texto — hierarquia */
+  --text-primary: 0 0% 9%;
+  --text-secondary: 0 0% 40%;
+  --text-tertiary: 0 0% 56%;
+  --text-disabled: 0 0% 72%;
+  --text-inverse: 0 0% 100%;
+  --text-link: 212 80% 50%;           /* azul Vercel sutil só pra links */
+
+  /* Status — dessaturados, calibrados pra uso prolongado */
+  --status-success: 142 50% 38%;       /* verde profundo, não emerald-500 */
+  --status-success-foreground: 142 50% 22%;
+  --status-success-bg: 142 50% 95%;
+  --status-warning: 35 80% 45%;        /* amber sóbrio */
+  --status-warning-foreground: 35 80% 28%;
+  --status-warning-bg: 35 80% 95%;
+  --status-error: 0 65% 48%;           /* vermelho marrom-leaning */
+  --status-error-foreground: 0 65% 32%;
+  --status-error-bg: 0 65% 96%;
+  --status-info: 212 80% 50%;          /* azul Vercel info */
+  --status-info-foreground: 212 80% 32%;
+  --status-info-bg: 212 80% 96%;
+  --status-pending: 35 80% 45%;
+  --status-progress: 212 80% 50%;
+  --status-danger: 0 65% 48%;
+  --status-purple: 271 50% 50%;
+  --status-purple-foreground: 271 50% 32%;
+  --status-purple-bg: 271 50% 96%;
+  --status-indigo: 234 60% 50%;
+  --status-indigo-foreground: 234 60% 32%;
+  --status-indigo-bg: 234 60% 96%;
+
+  /* Destructive (alertas) */
+  --destructive: 0 65% 48%;
+  --destructive-foreground: 0 0% 100%;
+
+  /* Radius — reduzido pra sharp/sóbrio */
+  --radius: 0.375rem;                  /* 6px (era 8px) */
+
+  /* Shadows — quase ausentes; profundidade via border */
+  --shadow-xs: none;
+  --shadow-sm: 0 1px 2px hsl(0 0% 0% / 0.04);
+  --shadow-md: 0 4px 12px hsl(0 0% 0% / 0.06);   /* só overlays */
+  --shadow-lg: 0 8px 24px hsl(0 0% 0% / 0.08);   /* só modals */
+  --shadow-xl: 0 16px 40px hsl(0 0% 0% / 0.10);
+  --shadow-focus: 0 0 0 2px hsl(var(--background)), 0 0 0 4px hsl(var(--ring));
+
+  /* Motion — easing Vercel + escala revisada */
+  --duration-fast: 150ms;
+  --duration-normal: 200ms;
+  --duration-slow: 300ms;
+  --duration-overlay: 500ms;
+  /* easing aplicado em tailwind.config.ts via animation utilities */
+}
+```
+
+## 2. Cores — Dark mode
+
+```css
+.dark {
+  --background: 0 0% 6%;               /* #0F0F0F — preto azulado profundo */
+  --foreground: 0 0% 95%;
+  --card: 0 0% 8%;
+  --card-foreground: 0 0% 95%;
+  --popover: 0 0% 8%;
+  --popover-foreground: 0 0% 95%;
+  --muted: 0 0% 12%;
+  --muted-foreground: 0 0% 60%;
+  --accent: 0 0% 14%;
+  --accent-foreground: 0 0% 95%;
+  --secondary: 0 0% 14%;
+  --secondary-foreground: 0 0% 95%;
+  --border: 0 0% 14%;
+  --input: 0 0% 14%;
+  --primary: 0 0% 95%;                 /* botão primary é branco no dark */
+  --primary-foreground: 0 0% 9%;
+  --ring: 0 0% 95%;
+
+  --sidebar-background: 0 0% 5%;
+  --sidebar-foreground: 0 0% 70%;
+  --sidebar-primary: 0 0% 95%;
+  --sidebar-primary-foreground: 0 0% 9%;
+  --sidebar-accent: 0 0% 12%;
+  --sidebar-accent-foreground: 0 0% 95%;
+  --sidebar-border: 0 0% 14%;
+  --sidebar-ring: 0 0% 95%;
+  --sidebar-muted: 0 0% 50%;
+
+  --surface-0: 0 0% 6%;
+  --surface-1: 0 0% 8%;
+  --surface-2: 0 0% 12%;
+  --surface-3: 0 0% 16%;
+
+  --text-primary: 0 0% 95%;
+  --text-secondary: 0 0% 70%;
+  --text-tertiary: 0 0% 50%;
+  --text-disabled: 0 0% 35%;
+  --text-inverse: 0 0% 9%;
+  --text-link: 212 80% 65%;
+
+  --status-success: 142 60% 55%;
+  --status-success-foreground: 142 60% 80%;
+  --status-success-bg: 142 50% 12%;
+  --status-warning: 35 80% 60%;
+  --status-warning-foreground: 35 80% 80%;
+  --status-warning-bg: 35 60% 12%;
+  --status-error: 0 70% 60%;
+  --status-error-foreground: 0 70% 85%;
+  --status-error-bg: 0 50% 12%;
+  --status-info: 212 80% 65%;
+  --status-info-foreground: 212 80% 85%;
+  --status-info-bg: 212 50% 12%;
+  --status-pending: 35 80% 60%;
+  --status-progress: 212 80% 65%;
+  --status-danger: 0 70% 60%;
+  --status-purple: 271 60% 65%;
+  --status-purple-foreground: 271 60% 85%;
+  --status-purple-bg: 271 40% 14%;
+  --status-indigo: 234 70% 65%;
+  --status-indigo-foreground: 234 70% 85%;
+  --status-indigo-bg: 234 50% 14%;
+
+  --destructive: 0 70% 60%;
+  --destructive-foreground: 0 0% 100%;
+
+  --shadow-sm: 0 1px 2px hsl(0 0% 0% / 0.40);
+  --shadow-md: 0 4px 12px hsl(0 0% 0% / 0.50);
+  --shadow-lg: 0 8px 24px hsl(0 0% 0% / 0.60);
+}
+```
+
+## 3. Tipografia
+
+### Fontes carregadas
+
+```html
+<!-- index.html -->
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=Geist+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
+```
+
+> Geist é hospedado oficialmente no Google Fonts (gratuito, mesma fonte que a Vercel usa).
+
+### Configuração Tailwind
+
+```ts
+// tailwind.config.ts
+fontFamily: {
+  sans: ["Geist", "Inter", "system-ui", "-apple-system", "sans-serif"],
+  mono: ["'Geist Mono'", "'JetBrains Mono'", "Fira Code", "monospace"],
+},
+```
+
+> Inter fica como fallback (zero risco de FOUT/FOIT).
+
+### Body / typography defaults
+
+```css
+body {
+  font-family: 'Geist', 'Inter', system-ui, sans-serif;
+  font-feature-settings: 'tnum', 'cv02', 'cv03', 'cv11';  /* tnum = tabular nums global */
+  font-size: 14px;
+  line-height: 1.5;
+  letter-spacing: -0.005em;             /* -0.5%, sutil tightening */
+}
+
+h1, h2, h3, h4 {
+  letter-spacing: -0.02em;              /* -2%, premium feel */
+  line-height: 1.15;
+  font-weight: 600;                     /* não 700 — peso menor parece mais "fino" */
+}
+h1 { font-size: 1.5rem; }   /* 24px (era 24px, mantém) */
+h2 { font-size: 1.25rem; }  /* 20px */
+h3 { font-size: 1rem; }     /* 16px */
+h4 { font-size: 0.875rem; } /* 14px */
+```
+
+### Utility para KPIs grandes (financeiro / cockpit)
+
+```css
+.kpi-value {
+  font-family: 'Geist Mono', 'JetBrains Mono', monospace;
+  font-feature-settings: 'tnum';
+  font-weight: 500;
+  letter-spacing: -0.02em;
+  line-height: 1.1;
+}
+```
+
+> Aplicar em valores de KPI no FinanceiroCockpit, AdminReposicaoCockpit.
+
+## 4. Motion — easing Vercel
+
+```css
+:root {
+  --easing-default: cubic-bezier(0.16, 1, 0.3, 1);
+}
+```
+
+```ts
+// tailwind.config.ts — substituir keyframes existentes
+animation: {
+  "accordion-down": "accordion-down 200ms cubic-bezier(0.16, 1, 0.3, 1)",
+  "accordion-up": "accordion-up 200ms cubic-bezier(0.16, 1, 0.3, 1)",
+  "fade-in": "fade-in 200ms cubic-bezier(0.16, 1, 0.3, 1) both",
+  "scale-in": "scale-in 150ms cubic-bezier(0.16, 1, 0.3, 1) both",
+  "slide-in-right": "slide-in-right 300ms cubic-bezier(0.16, 1, 0.3, 1)",
+  "slide-up": "slide-up 200ms cubic-bezier(0.16, 1, 0.3, 1) both",
+}
+```
+
+## 5. Touch targets
+
+Manter as variantes do button.tsx que adicionei (`touch` 44px, `balcao` 56px) — adequadas pra novo estilo. Sem mudança.
+
+## 6. Body global ajuste
+
+```css
+button, a, [role="button"] {
+  min-height: 32px;
+  transition: all 150ms cubic-bezier(0.16, 1, 0.3, 1);  /* hover suave */
+}
+```
+
+## 7. Plano de implementação
+
+### A. Carregar Geist (1 mudança em `index.html`)
+
+Trocar links Google Fonts atuais (Inter, Bebas Neue, Space Grotesk) por Geist + Geist Mono.
+
+### B. Atualizar `tailwind.config.ts`
+
+- `fontFamily.sans` → Geist primeiro
+- `fontFamily.mono` → Geist Mono primeiro
+- `animation.*` → easing Vercel
+
+### C. Reescrever `src/index.css`
+
+Substituir as definições de tokens light/dark conforme seções 1-2 acima. Manter as utilities .density-compact, .status-*, .text-status-*, etc. (criadas na Fase 4 da auditoria).
+
+### D. Adicionar ThemeProvider e ThemeToggle
+
+- Usar `next-themes` (já instalado, package.json linha 61)
+- Wrap em App.tsx
+- Criar `src/components/shell/ThemeToggle.tsx` com ícones Sun/Moon
+- Adicionar ao topbar (depois do CompanySwitcher, antes do NetworkStatusIndicator)
+
+### E. Refactor `AppShell.tsx`
+
+- Remover hardcode `bg-sidebar` referenciando dark — agora `--sidebar-background` é light por default
+- Logo `Scissors` ganha cor `text-foreground` em vez de `text-primary` (evita ruxo de cor primary nos logos)
+
+### F. Refinement das 5 telas-piloto (Nível 2)
+
+Lista detalhada vai pra `03-pilotos.md`, mas resumo:
+
+1. **FinanceiroCockpit** — KPIs com `.kpi-value` (Geist Mono), substituir `text-emerald-600`/`text-red-600` por `text-status-*`
+2. **AdminReposicaoCockpit** — substituir cores hardcoded em badges, hierarquia visual nos headers
+3. **AdminCustomers** — segmentos com novos tokens, tabela com hover sutil
+4. **Index/Home** — usar nova hierarquia tipográfica, KPIs com `.kpi-value`
+5. **TintFormulas** — valores R$ em mono, badges com tokens status-*
+
+---
+
+## 8. O que fica fora desta entrega
+
+- Refactor das outras 114 telas (cores hardcoded em outros lugares) — feito incremental conforme cada tela é tocada
+- Logo Colacor novo — manteremos `Scissors` como ícone temporário (pode ser repensado em outra fase)
+- Modo high-contrast / acessibilidade WCAG AAA — defer
+- Animação de logo / splash screen — defer
+
+Próximo: implementar A-F em sequência. Não vai ter mais doc — código direto.

--- a/index.html
+++ b/index.html
@@ -7,8 +7,9 @@
     <meta name="description" content="Colacor - Serviço profissional de afiação de ferramentas. Agende sua coleta!">
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@500;600;700&display=swap" rel="stylesheet" media="print" onload="this.media='all'" />
-    <noscript><link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@500;600;700&display=swap" rel="stylesheet" /></noscript>
+    <!-- Geist (Vercel font) + Geist Mono. Inter mantido como fallback para FOUT mínimo. -->
+    <link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=Geist+Mono:wght@400;500;600&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" media="print" onload="this.media='all'" />
+    <noscript><link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=Geist+Mono:wght@400;500;600&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" /></noscript>
     <meta name="author" content="Colacor" />
 
     <!-- PWA Meta Tags -->

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import { lazy, Suspense } from "react";
+import { ThemeProvider } from "next-themes";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 // Sistema de toast unificado em Sonner (o Radix Toaster legado foi desligado;
 // o hook `useToast` continua existindo como wrapper que delega para Sonner — ver src/hooks/use-toast.ts).
@@ -152,6 +153,7 @@ const queryClient = new QueryClient({
 
 const App = () => (
   <QueryClientProvider client={queryClient}>
+    <ThemeProvider attribute="class" defaultTheme="light" enableSystem={false} disableTransitionOnChange>
     <TooltipProvider>
       <Sonner />
       <BrowserRouter>
@@ -299,6 +301,7 @@ const App = () => (
         </AuthProvider>
       </BrowserRouter>
     </TooltipProvider>
+    </ThemeProvider>
   </QueryClientProvider>
 );
 

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -31,6 +31,7 @@ import { CommandPalette } from '@/components/shell/CommandPalette';
 import { CommandPaletteTrigger } from '@/components/shell/CommandPaletteTrigger';
 import { CompanySwitcher } from '@/components/shell/CompanySwitcher';
 import { NetworkStatusIndicator } from '@/components/shell/NetworkStatusIndicator';
+import { ThemeToggle } from '@/components/shell/ThemeToggle';
 
 /* ─── Navigation config ─── */
 interface NavItem {
@@ -328,20 +329,20 @@ function AppSidebar({ collapsed, onToggle }: { collapsed: boolean; onToggle: () 
         collapsed ? 'w-sidebar-collapsed' : 'w-sidebar'
       )}
     >
-      {/* Logo */}
+      {/* Logo — usa foreground em vez de primary (evita cor de marca dominante) */}
       <div className={cn(
         'flex items-center h-topbar border-b border-sidebar-border px-3',
         collapsed ? 'justify-center' : 'justify-between'
       )}>
         {!collapsed && (
           <div className="flex items-center gap-2">
-            <Scissors className="w-5 h-5 text-primary" />
-            <span className="text-sidebar-primary-foreground font-semibold text-lg tracking-tight">
-              Central
+            <Scissors className="w-5 h-5 text-foreground" />
+            <span className="text-foreground font-semibold text-base tracking-tight">
+              Colacor
             </span>
           </div>
         )}
-        {collapsed && <Scissors className="w-5 h-5 text-primary" />}
+        {collapsed && <Scissors className="w-5 h-5 text-foreground" />}
         {!collapsed && (
           <button
             onClick={onToggle}
@@ -467,6 +468,7 @@ function AppTopbar({ sidebarCollapsed, onMobileMenuToggle }: { sidebarCollapsed:
       <div className="flex items-center gap-1">
         <CompanySwitcher />
         <NetworkStatusIndicator />
+        <ThemeToggle />
         <HelpDrawer />
 
         <DropdownMenu>
@@ -505,8 +507,8 @@ function MobileNav({ open, onClose }: { open: boolean; onClose: () => void }) {
       <div className="fixed left-0 top-0 bottom-0 z-50 flex w-64 flex-col overflow-hidden bg-sidebar border-r border-sidebar-border lg:hidden animate-slide-in-right">
         <div className="flex items-center justify-between h-topbar border-b border-sidebar-border px-3">
           <div className="flex items-center gap-2">
-            <Scissors className="w-5 h-5 text-primary" />
-            <span className="text-sidebar-primary-foreground font-semibold text-lg">Central</span>
+            <Scissors className="w-5 h-5 text-foreground" />
+            <span className="text-foreground font-semibold text-base tracking-tight">Colacor</span>
           </div>
           <button onClick={onClose} className="p-1.5 rounded-md text-sidebar-muted hover:text-sidebar-foreground">
             <X className="w-4 h-4" />

--- a/src/components/shell/ThemeToggle.tsx
+++ b/src/components/shell/ThemeToggle.tsx
@@ -1,0 +1,58 @@
+import { useEffect, useState } from 'react';
+import { Moon, Sun, Monitor } from 'lucide-react';
+import { useTheme } from 'next-themes';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+
+/**
+ * Toggle de tema (light / dark / system) — montado no AppShell topbar.
+ * Usa next-themes (já instalado). Persistência via localStorage automática.
+ */
+export function ThemeToggle() {
+  const { theme, setTheme, resolvedTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  // Evita flash de hydration (next-themes recommendation)
+  useEffect(() => setMounted(true), []);
+
+  const current = resolvedTheme ?? 'light';
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          className="h-8 w-8 inline-flex items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+          aria-label="Alternar tema"
+        >
+          {mounted && current === 'dark' ? (
+            <Moon className="w-4 h-4" />
+          ) : (
+            <Sun className="w-4 h-4" />
+          )}
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-36">
+        <DropdownMenuItem onClick={() => setTheme('light')}>
+          <Sun className="w-4 h-4 mr-2" />
+          Light
+          {theme === 'light' && <span className="ml-auto text-xs text-muted-foreground">✓</span>}
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setTheme('dark')}>
+          <Moon className="w-4 h-4 mr-2" />
+          Dark
+          {theme === 'dark' && <span className="ml-auto text-xs text-muted-foreground">✓</span>}
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setTheme('system')}>
+          <Monitor className="w-4 h-4 mr-2" />
+          Sistema
+          {theme === 'system' && <span className="ml-auto text-xs text-muted-foreground">✓</span>}
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -4,8 +4,10 @@
 
 /*
   ============================================================
-  DESIGN SYSTEM TOKENS
-  Ref: HubSpot Canvas (primary), Shopify Polaris, Gong
+  DESIGN SYSTEM TOKENS — v3 (Visual Direction reposicionada)
+  Ref: Vercel + Mercury + Stripe Dashboard ("fintech/SaaS premium")
+  Detalhe da direção em docs/visual-direction/01-direcao.md
+  Spec dos tokens em docs/visual-direction/02-tokens.md
   ============================================================
   
   Naming convention:
@@ -34,156 +36,182 @@
 
 @layer base {
   :root {
-    /* ── Neutrals (Cool gray, Canvas-inspired) ── */
-    --background: 220 14% 96%;
-    --foreground: 220 20% 10%;
+    /* ── Backgrounds — escala neutra warm-leaning ── */
+    --background: 0 0% 100%;             /* #FFFFFF */
+    --foreground: 0 0% 9%;               /* #171717 — preto suave */
 
     --card: 0 0% 100%;
-    --card-foreground: 220 20% 10%;
+    --card-foreground: 0 0% 9%;
 
     --popover: 0 0% 100%;
-    --popover-foreground: 220 20% 10%;
+    --popover-foreground: 0 0% 9%;
 
-    /* ── Primary (HubSpot signature blue-indigo) ── */
-    --primary: 222 83% 53%;
+    --muted: 0 0% 96%;                   /* #F5F5F5 */
+    --muted-foreground: 0 0% 45%;        /* #737373 */
+
+    --accent: 0 0% 96%;
+    --accent-foreground: 0 0% 9%;
+
+    --secondary: 0 0% 96%;
+    --secondary-foreground: 0 0% 9%;
+
+    /* ── Primary — preto/branco minimal (Vercel-style) ── */
+    --primary: 0 0% 9%;
     --primary-foreground: 0 0% 100%;
 
-    /* ── Secondary (Neutral steel) ── */
-    --secondary: 220 14% 92%;
-    --secondary-foreground: 220 20% 25%;
-
-    /* ── Muted ── */
-    --muted: 220 14% 94%;
-    --muted-foreground: 220 10% 42%;
-
-    /* ── Accent (Soft blue tint) ── */
-    --accent: 222 83% 96%;
-    --accent-foreground: 222 83% 40%;
-
     /* ── Destructive ── */
-    --destructive: 0 72% 51%;
+    --destructive: 0 65% 48%;
     --destructive-foreground: 0 0% 100%;
 
-    /* ── Borders & inputs ── */
-    --border: 220 13% 87%;
-    --input: 220 13% 87%;
-    --ring: 222 83% 53%;
+    /* ── Borders & inputs sutis ── */
+    --border: 0 0% 92%;                  /* #EBEBEB */
+    --input: 0 0% 92%;
+    --ring: 0 0% 9%;
 
-    /* ── Radius scale ── */
-    --radius: 0.5rem;
+    /* ── Radius reduzido ── */
+    --radius: 0.375rem;                  /* 6px */
 
-    /* ── Status semantic ── */
-    --status-success: 142 71% 45%;
-    --status-success-foreground: 142 72% 22%;
-    --status-success-bg: 142 76% 94%;
-    --status-warning: 38 92% 50%;
-    --status-warning-foreground: 32 95% 30%;
-    --status-warning-bg: 45 93% 93%;
-    --status-error: 0 72% 51%;
-    --status-error-foreground: 0 72% 30%;
-    --status-error-bg: 0 86% 95%;
-    --status-info: 222 83% 53%;
-    --status-info-foreground: 222 83% 30%;
-    --status-info-bg: 222 83% 96%;
-    --status-pending: 38 92% 50%;
-    --status-progress: 222 83% 53%;
-    --status-danger: 0 72% 51%;
-    --status-purple: 271 68% 53%;
-    --status-purple-foreground: 271 68% 28%;
-    --status-purple-bg: 271 70% 95%;
-    --status-indigo: 234 85% 60%;
-    --status-indigo-foreground: 234 85% 28%;
-    --status-indigo-bg: 234 85% 95%;
+    /* ── Status — dessaturados, calibrados pra uso prolongado ── */
+    --status-success: 142 50% 38%;
+    --status-success-foreground: 142 50% 22%;
+    --status-success-bg: 142 50% 95%;
+    --status-warning: 35 80% 45%;
+    --status-warning-foreground: 35 80% 28%;
+    --status-warning-bg: 35 80% 95%;
+    --status-error: 0 65% 48%;
+    --status-error-foreground: 0 65% 32%;
+    --status-error-bg: 0 65% 96%;
+    --status-info: 212 80% 50%;
+    --status-info-foreground: 212 80% 32%;
+    --status-info-bg: 212 80% 96%;
+    --status-pending: 35 80% 45%;
+    --status-progress: 212 80% 50%;
+    --status-danger: 0 65% 48%;
+    --status-purple: 271 50% 50%;
+    --status-purple-foreground: 271 50% 32%;
+    --status-purple-bg: 271 50% 96%;
+    --status-indigo: 234 60% 50%;
+    --status-indigo-foreground: 234 60% 32%;
+    --status-indigo-bg: 234 60% 96%;
 
     /* ── Surface levels ── */
     --surface-0: 0 0% 100%;
-    --surface-1: 220 14% 97%;
-    --surface-2: 220 14% 94%;
-    --surface-3: 220 13% 90%;
+    --surface-1: 0 0% 98%;
+    --surface-2: 0 0% 96%;
+    --surface-3: 0 0% 92%;
 
     /* ── Text levels ── */
-    --text-primary: 220 20% 10%;
-    --text-secondary: 220 10% 40%;
-    --text-tertiary: 220 10% 56%;
-    --text-disabled: 220 10% 72%;
+    --text-primary: 0 0% 9%;
+    --text-secondary: 0 0% 40%;
+    --text-tertiary: 0 0% 56%;
+    --text-disabled: 0 0% 72%;
     --text-inverse: 0 0% 100%;
-    --text-link: 222 83% 53%;
+    --text-link: 212 80% 50%;            /* azul Vercel-ish, só pra links */
 
-    /* ── Shadows ── */
-    --shadow-xs: 0 1px 2px 0 hsl(220 20% 10% / 0.05);
-    --shadow-sm: 0 1px 3px 0 hsl(220 20% 10% / 0.08), 0 1px 2px -1px hsl(220 20% 10% / 0.08);
-    --shadow-md: 0 4px 6px -1px hsl(220 20% 10% / 0.08), 0 2px 4px -2px hsl(220 20% 10% / 0.06);
-    --shadow-lg: 0 10px 15px -3px hsl(220 20% 10% / 0.08), 0 4px 6px -4px hsl(220 20% 10% / 0.06);
-    --shadow-xl: 0 20px 25px -5px hsl(220 20% 10% / 0.08), 0 8px 10px -6px hsl(220 20% 10% / 0.06);
-    --shadow-focus: 0 0 0 3px hsl(222 83% 53% / 0.25);
+    /* ── Shadows quase ausentes; profundidade via border ── */
+    --shadow-xs: none;
+    --shadow-sm: 0 1px 2px hsl(0 0% 0% / 0.04);
+    --shadow-md: 0 4px 12px hsl(0 0% 0% / 0.06);
+    --shadow-lg: 0 8px 24px hsl(0 0% 0% / 0.08);
+    --shadow-xl: 0 16px 40px hsl(0 0% 0% / 0.10);
+    --shadow-focus: 0 0 0 2px hsl(var(--background)), 0 0 0 4px hsl(var(--ring));
 
-    /* ── Sidebar (Canvas-style dark sidebar) ── */
-    --sidebar-background: 220 25% 11%;
-    --sidebar-foreground: 220 14% 80%;
-    --sidebar-primary: 222 83% 60%;
+    /* ── Sidebar light coerente com conteúdo ── */
+    --sidebar-background: 0 0% 99%;
+    --sidebar-foreground: 0 0% 30%;
+    --sidebar-primary: 0 0% 9%;
     --sidebar-primary-foreground: 0 0% 100%;
-    --sidebar-accent: 220 20% 18%;
-    --sidebar-accent-foreground: 220 14% 96%;
-    --sidebar-border: 220 20% 18%;
-    --sidebar-ring: 222 83% 53%;
-    --sidebar-muted: 220 14% 50%;
+    --sidebar-accent: 0 0% 96%;
+    --sidebar-accent-foreground: 0 0% 9%;
+    --sidebar-border: 0 0% 92%;
+    --sidebar-ring: 0 0% 9%;
+    --sidebar-muted: 0 0% 60%;
 
     /* ── Motion ── */
-    --duration-fast: 100ms;
+    --duration-fast: 150ms;
     --duration-normal: 200ms;
-    --duration-slow: 350ms;
+    --duration-slow: 300ms;
+    --duration-overlay: 500ms;
+    --easing-default: cubic-bezier(0.16, 1, 0.3, 1);
   }
 
   .dark {
-    --background: 220 20% 7%;
-    --foreground: 220 14% 96%;
+    --background: 0 0% 6%;
+    --foreground: 0 0% 95%;
 
-    --card: 220 20% 10%;
-    --card-foreground: 220 14% 96%;
+    --card: 0 0% 8%;
+    --card-foreground: 0 0% 95%;
 
-    --popover: 220 20% 10%;
-    --popover-foreground: 220 14% 96%;
+    --popover: 0 0% 8%;
+    --popover-foreground: 0 0% 95%;
 
-    --primary: 222 83% 60%;
-    --primary-foreground: 0 0% 100%;
+    --muted: 0 0% 12%;
+    --muted-foreground: 0 0% 60%;
 
-    --secondary: 220 20% 16%;
-    --secondary-foreground: 220 14% 80%;
+    --accent: 0 0% 14%;
+    --accent-foreground: 0 0% 95%;
 
-    --muted: 220 20% 14%;
-    --muted-foreground: 220 14% 55%;
+    --secondary: 0 0% 14%;
+    --secondary-foreground: 0 0% 95%;
 
-    --accent: 222 40% 18%;
-    --accent-foreground: 222 83% 70%;
+    --primary: 0 0% 95%;
+    --primary-foreground: 0 0% 9%;
 
-    --destructive: 0 62% 50%;
+    --destructive: 0 70% 60%;
     --destructive-foreground: 0 0% 100%;
 
-    --border: 220 20% 18%;
-    --input: 220 20% 18%;
-    --ring: 222 83% 60%;
+    --border: 0 0% 14%;
+    --input: 0 0% 14%;
+    --ring: 0 0% 95%;
 
-    --surface-0: 220 20% 10%;
-    --surface-1: 220 20% 12%;
-    --surface-2: 220 20% 16%;
-    --surface-3: 220 20% 20%;
+    --status-success: 142 60% 55%;
+    --status-success-foreground: 142 60% 80%;
+    --status-success-bg: 142 50% 12%;
+    --status-warning: 35 80% 60%;
+    --status-warning-foreground: 35 80% 80%;
+    --status-warning-bg: 35 60% 12%;
+    --status-error: 0 70% 60%;
+    --status-error-foreground: 0 70% 85%;
+    --status-error-bg: 0 50% 12%;
+    --status-info: 212 80% 65%;
+    --status-info-foreground: 212 80% 85%;
+    --status-info-bg: 212 50% 12%;
+    --status-pending: 35 80% 60%;
+    --status-progress: 212 80% 65%;
+    --status-danger: 0 70% 60%;
+    --status-purple: 271 60% 65%;
+    --status-purple-foreground: 271 60% 85%;
+    --status-purple-bg: 271 40% 14%;
+    --status-indigo: 234 70% 65%;
+    --status-indigo-foreground: 234 70% 85%;
+    --status-indigo-bg: 234 50% 14%;
 
-    --text-primary: 220 14% 96%;
-    --text-secondary: 220 14% 65%;
-    --text-tertiary: 220 14% 50%;
-    --text-disabled: 220 14% 35%;
-    --text-inverse: 220 20% 10%;
-    --text-link: 222 83% 70%;
+    --surface-0: 0 0% 6%;
+    --surface-1: 0 0% 8%;
+    --surface-2: 0 0% 12%;
+    --surface-3: 0 0% 16%;
 
-    --sidebar-background: 220 25% 7%;
-    --sidebar-foreground: 220 14% 75%;
-    --sidebar-primary: 222 83% 60%;
-    --sidebar-primary-foreground: 0 0% 100%;
-    --sidebar-accent: 220 20% 14%;
-    --sidebar-accent-foreground: 220 14% 96%;
-    --sidebar-border: 220 20% 14%;
-    --sidebar-ring: 222 83% 60%;
-    --sidebar-muted: 220 14% 40%;
+    --text-primary: 0 0% 95%;
+    --text-secondary: 0 0% 70%;
+    --text-tertiary: 0 0% 50%;
+    --text-disabled: 0 0% 35%;
+    --text-inverse: 0 0% 9%;
+    --text-link: 212 80% 65%;
+
+    --shadow-sm: 0 1px 2px hsl(0 0% 0% / 0.40);
+    --shadow-md: 0 4px 12px hsl(0 0% 0% / 0.50);
+    --shadow-lg: 0 8px 24px hsl(0 0% 0% / 0.60);
+    --shadow-xl: 0 16px 40px hsl(0 0% 0% / 0.70);
+
+    --sidebar-background: 0 0% 5%;
+    --sidebar-foreground: 0 0% 70%;
+    --sidebar-primary: 0 0% 95%;
+    --sidebar-primary-foreground: 0 0% 9%;
+    --sidebar-accent: 0 0% 12%;
+    --sidebar-accent-foreground: 0 0% 95%;
+    --sidebar-border: 0 0% 14%;
+    --sidebar-ring: 0 0% 95%;
+    --sidebar-muted: 0 0% 50%;
   }
 }
 
@@ -194,39 +222,50 @@
 
   body {
     @apply bg-background text-foreground antialiased;
-    font-family: 'Inter', system-ui, -apple-system, sans-serif;
-    font-feature-settings: 'cv02', 'cv03', 'cv04', 'cv11';
+    font-family: 'Geist', 'Inter', system-ui, -apple-system, sans-serif;
+    /* tnum = tabular nums global (números nunca dançam em tabelas) */
+    /* cv02/03/11 = Inter stylistic sets pra fallback (4 = a alternativa) */
+    font-feature-settings: 'tnum', 'cv02', 'cv03', 'cv11';
     -webkit-tap-highlight-color: transparent;
     font-size: 14px;
     line-height: 1.5;
+    letter-spacing: -0.005em;            /* sutil tightening Vercel-style */
   }
 
-  /* ── Typography scale ── */
+  /* ── Typography scale — peso 600 (não 700) e tracking apertado em headings ── */
   h1 {
-    @apply text-2xl font-semibold tracking-tight;
-    line-height: 1.2;
+    @apply text-2xl tracking-tight;
+    font-weight: 600;
+    line-height: 1.15;
+    letter-spacing: -0.02em;
   }
   h2 {
-    @apply text-xl font-semibold tracking-tight;
-    line-height: 1.25;
+    @apply text-xl tracking-tight;
+    font-weight: 600;
+    line-height: 1.2;
+    letter-spacing: -0.02em;
   }
   h3 {
-    @apply text-base font-semibold;
+    @apply text-base;
+    font-weight: 600;
     line-height: 1.3;
+    letter-spacing: -0.015em;
   }
   h4 {
-    @apply text-sm font-semibold;
+    @apply text-sm;
+    font-weight: 600;
     line-height: 1.4;
   }
 
-  /* ── Accessible focus ── */
+  /* ── Accessible focus — ring sóbrio sem offset duplo ── */
   :focus-visible {
     @apply outline-none ring-2 ring-ring ring-offset-2 ring-offset-background;
   }
 
-  /* ── Touch targets ── */
+  /* ── Touch targets + transition padronizada (easing Vercel) ── */
   button, a, [role="button"] {
     min-height: 32px;
+    transition-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
   }
 
   /* ── Caption / small text ── */
@@ -276,6 +315,15 @@
     --input-height: 40px;
     --card-padding: 16px;
     --list-gap: 8px;
+  }
+
+  /* ── KPI utility — números grandes em Geist Mono pra cockpits financeiros/operacionais ── */
+  .kpi-value {
+    font-family: 'Geist Mono', 'JetBrains Mono', monospace;
+    font-feature-settings: 'tnum';
+    font-weight: 500;
+    letter-spacing: -0.02em;
+    line-height: 1.1;
   }
 
   /* ── Status text utilities (semantic tokens — substitui text-emerald-600 etc.) ── */

--- a/src/pages/AdminCustomers.tsx
+++ b/src/pages/AdminCustomers.tsx
@@ -315,16 +315,16 @@ function CustomerListView({
                       </Badge>
                     </td>
                     <td className="px-3 py-2.5 text-right hidden lg:table-cell">
-                      <span className="text-xs font-medium">
+                      <span className="text-xs font-medium tabular-nums">
                         {score ? fmt(score.avg_monthly_spend_180d) : '-'}
                       </span>
                     </td>
                     <td className="px-3 py-2.5 text-center hidden lg:table-cell">
                       {score?.days_since_last_purchase != null ? (
                         <span className={cn(
-                          'text-xs font-medium',
-                          score.days_since_last_purchase > 60 ? 'text-destructive' :
-                          score.days_since_last_purchase > 30 ? 'text-amber-600' :
+                          'text-xs font-medium tabular-nums',
+                          score.days_since_last_purchase > 60 ? 'text-status-error' :
+                          score.days_since_last_purchase > 30 ? 'text-status-warning' :
                           'text-muted-foreground'
                         )}>
                           {score.days_since_last_purchase}d
@@ -333,7 +333,7 @@ function CustomerListView({
                     </td>
                     <td className="px-3 py-2.5 text-right hidden md:table-cell">
                       {score ? (
-                        <span className="text-xs font-semibold">{score.priority_score.toFixed(1)}</span>
+                        <span className="text-xs font-semibold tabular-nums">{score.priority_score.toFixed(1)}</span>
                       ) : '-'}
                     </td>
                     <td className="px-2 py-2.5">

--- a/src/pages/AdminReposicaoCockpit.tsx
+++ b/src/pages/AdminReposicaoCockpit.tsx
@@ -465,7 +465,7 @@ function SmartAlertsSection() {
 
   const tone = (l: SmartAlert["level"]) =>
     l === "yellow"
-      ? "border-amber-500/40 bg-amber-500/5 text-amber-900 dark:text-amber-200"
+      ? "border-status-warning/40 bg-status-warning-bg text-status-warning-fg"
       : l === "orange"
         ? "border-orange-500/40 bg-orange-500/5 text-orange-900 dark:text-orange-200"
         : "border-destructive/40 bg-destructive/5 text-destructive";
@@ -704,7 +704,7 @@ function PrecoCell({ row }: { row: PedidoItem }) {
     Math.abs(deltaPct) < 0.5
       ? "text-muted-foreground"
       : deltaPct < 0
-        ? "text-emerald-600"
+        ? "text-status-success"
         : "text-destructive";
   return (
     <div className="flex flex-col items-end">
@@ -720,8 +720,8 @@ function PrecoCell({ row }: { row: PedidoItem }) {
 function ConfiancaBadge({ row }: { row: PedidoItem }) {
   const { level, reason } = inferConfianca(row);
   const map = {
-    alta: { label: "Alta", cls: "bg-emerald-500/15 text-emerald-700 border-emerald-500/40" },
-    media: { label: "Média", cls: "bg-amber-500/15 text-amber-700 border-amber-500/40" },
+    alta: { label: "Alta", cls: "bg-status-success-bg text-status-success border-status-success/40" },
+    media: { label: "Média", cls: "bg-status-warning-bg text-status-warning border-status-warning/40" },
     baixa: { label: "Baixa", cls: "bg-muted text-muted-foreground border-border" },
   } as const;
   const m = map[level];
@@ -772,7 +772,7 @@ function PedidoRow({
   const isRejected = !!row.cancelado_em;
 
   const rowBg = isApproved
-    ? "bg-emerald-500/5 hover:bg-emerald-500/10"
+    ? "bg-status-success-bg/40 hover:bg-status-success-bg"
     : isRejected
       ? "bg-destructive/5 hover:bg-destructive/10"
       : "";
@@ -887,7 +887,7 @@ function PedidoRow({
                   <TooltipProvider delayDuration={200}>
                     <Tooltip>
                       <TooltipTrigger asChild>
-                        <Badge variant="outline" className="gap-1 border-amber-500/40 text-amber-700 bg-amber-500/10">
+                        <Badge variant="outline" className="gap-1 border-status-warning/40 text-status-warning bg-status-warning-bg">
                           <AlertTriangle className="h-3 w-3" /> Revisar
                         </Badge>
                       </TooltipTrigger>
@@ -909,7 +909,7 @@ function PedidoRow({
             <Button
               size="icon"
               variant="ghost"
-              className="h-8 w-8 text-emerald-600 hover:text-emerald-700 hover:bg-emerald-500/10"
+              className="h-8 w-8 text-status-success hover:text-status-success hover:bg-status-success-bg"
               disabled={isApproved || busy !== null}
               onClick={() => act("approve")}
               title="Aprovar"
@@ -1279,7 +1279,7 @@ function CicloHojePanel({
           {manualReviewItems.length > 0 && (
             <div className="space-y-2 pt-2">
               <div className="flex items-center gap-2 text-sm font-medium">
-                <AlertTriangle className="h-4 w-4 text-amber-500" />
+                <AlertTriangle className="h-4 w-4 text-status-warning" />
                 {manualReviewItems.length} pedido(s) ficarão para aprovação manual
               </div>
               <div className="max-h-40 overflow-y-auto rounded-md border">
@@ -1539,13 +1539,13 @@ function CompareCyclesSection({ cycles }: { cycles: string[] }) {
         {diff && (
           <div className="space-y-3">
             <div>
-              <div className="text-xs font-semibold text-emerald-700 mb-1">
+              <div className="text-xs font-semibold text-status-success mb-1">
                 Novos no Ciclo B ({diff.novos.length})
               </div>
               {diff.novos.length === 0 ? (
                 <div className="text-xs text-muted-foreground">Nenhum.</div>
               ) : (
-                <div className="rounded-md border bg-emerald-500/5 divide-y">
+                <div className="rounded-md border bg-status-success-bg/40 divide-y">
                   {diff.novos.map((r) => (
                     <div key={r.fornecedor_nome} className="px-3 py-1.5 text-sm flex justify-between">
                       <span>{r.fornecedor_nome}</span>
@@ -1579,13 +1579,13 @@ function CompareCyclesSection({ cycles }: { cycles: string[] }) {
             </div>
 
             <div>
-              <div className="text-xs font-semibold text-amber-700 mb-1">
+              <div className="text-xs font-semibold text-status-warning mb-1">
                 Alterados ({diff.alterados.length})
               </div>
               {diff.alterados.length === 0 ? (
                 <div className="text-xs text-muted-foreground">Nenhum.</div>
               ) : (
-                <div className="rounded-md border bg-amber-500/5 divide-y">
+                <div className="rounded-md border bg-status-warning-bg divide-y">
                   {diff.alterados.map((r) => (
                     <div key={r.fornecedor_nome} className="px-3 py-1.5 text-sm flex justify-between gap-2">
                       <span>{r.fornecedor_nome}</span>
@@ -2088,8 +2088,8 @@ export default function AdminReposicaoCockpit() {
       </header>
 
       {stepError && (
-        <Alert variant="default" className="border-amber-500/40 bg-amber-500/5">
-          <AlertTriangle className="h-4 w-4 text-amber-600" />
+        <Alert variant="default" className="border-status-warning/40 bg-status-warning-bg">
+          <AlertTriangle className="h-4 w-4 text-status-warning" />
           <AlertTitle>Etapa atual indisponível</AlertTitle>
           <AlertDescription className="flex items-center justify-between gap-3 flex-wrap">
             <span>Não foi possível calcular a etapa atual. Exibindo dados em cache.</span>

--- a/src/pages/FinanceiroCockpit.tsx
+++ b/src/pages/FinanceiroCockpit.tsx
@@ -34,21 +34,21 @@ function TransparencyBadge({ conf }: { conf: any | null }) {
   const catHeur = conf.dre_categorias_heuristica || 0;
 
   const score = Math.round((pctMap * 0.4) + (pctConc * 0.3) + (fech === 'fechado' ? 30 : 0));
-  const color = score >= 70 ? 'text-emerald-600' : score >= 40 ? 'text-amber-600' : 'text-red-600';
-  const bg = score >= 70 ? 'bg-emerald-50 border-emerald-200' : score >= 40 ? 'bg-amber-50 border-amber-200' : 'bg-red-50 border-red-200';
+  const color = score >= 70 ? 'text-status-success' : score >= 40 ? 'text-status-warning' : 'text-status-error';
+  const bg = score >= 70 ? 'bg-status-success-bg border-status-success/20' : score >= 40 ? 'bg-status-warning-bg border-status-warning/20' : 'bg-status-error-bg border-status-error/20';
 
   return (
     <div className={`inline-flex items-center gap-2 px-2 py-1 rounded border text-xs ${bg}`}>
-      <span className={`font-bold ${color}`}>{score}%</span>
+      <span className={`font-semibold tabular-nums ${color}`}>{score}%</span>
       <span className="text-muted-foreground">confiável</span>
       <span className="text-muted-foreground">·</span>
-      <span>{pctMap.toFixed(0)}% mapeado</span>
+      <span className="tabular-nums">{pctMap.toFixed(0)}% mapeado</span>
       <span className="text-muted-foreground">·</span>
-      <span>{pctConc.toFixed(0)}% conciliado</span>
+      <span className="tabular-nums">{pctConc.toFixed(0)}% conciliado</span>
       {catHeur > 0 && (
         <>
           <span className="text-muted-foreground">·</span>
-          <span className="text-amber-600">{catHeur} cat. heurísticas</span>
+          <span className="text-status-warning">{catHeur} cat. heurísticas</span>
         </>
       )}
       <span className="text-muted-foreground">·</span>
@@ -59,9 +59,9 @@ function TransparencyBadge({ conf }: { conf: any | null }) {
 
 function FechamentoIcon({ status }: { status: string }) {
   switch (status) {
-    case 'fechado': return <span className="flex items-center gap-0.5 text-emerald-600"><Lock className="w-3 h-3" /> Fechado</span>;
-    case 'em_revisao': return <span className="flex items-center gap-0.5 text-amber-600"><Eye className="w-3 h-3" /> Revisão</span>;
-    case 'reaberto': return <span className="flex items-center gap-0.5 text-red-600"><AlertTriangle className="w-3 h-3" /> Reaberto</span>;
+    case 'fechado': return <span className="flex items-center gap-0.5 text-status-success"><Lock className="w-3 h-3" /> Fechado</span>;
+    case 'em_revisao': return <span className="flex items-center gap-0.5 text-status-warning"><Eye className="w-3 h-3" /> Revisão</span>;
+    case 'reaberto': return <span className="flex items-center gap-0.5 text-status-error"><AlertTriangle className="w-3 h-3" /> Reaberto</span>;
     default: return <span className="flex items-center gap-0.5 text-muted-foreground"><Clock className="w-3 h-3" /> Aberto</span>;
   }
 }
@@ -163,7 +163,7 @@ const FinanceiroCockpit = () => {
     ? totalCC / totalCP
     : 0;
   const riscoLabel = riscoLiquidez >= 1 ? 'Baixo' : riscoLiquidez >= 0.5 ? 'Médio' : 'Alto';
-  const riscoColor = riscoLiquidez >= 1 ? 'text-emerald-600' : riscoLiquidez >= 0.5 ? 'text-amber-600' : 'text-red-600';
+  const riscoColor = riscoLiquidez >= 1 ? 'text-status-success' : riscoLiquidez >= 0.5 ? 'text-status-warning' : 'text-status-error';
 
   // Concentração (do aging)
   const totalAgingCR = aging
@@ -233,7 +233,7 @@ const FinanceiroCockpit = () => {
           positive={ncg >= 0}
           icon={ncg >= 0 ? TrendingUp : TrendingDown}
           detail={ncg >= 0 ? 'CR cobre CP — posição confortável' : 'CP excede CR — atenção ao caixa'}
-          detailColor={ncg >= 0 ? 'text-emerald-600' : 'text-red-600'}
+          detailColor={ncg >= 0 ? 'text-status-success' : 'text-status-error'}
           badge="CR - CP"
           onClick={() => setDrillDown('cr_aberto')}
         />
@@ -242,15 +242,15 @@ const FinanceiroCockpit = () => {
       {/* Row 2: Margens + Inadimplência + Risco */}
       <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
         <MiniCard label="Margem Bruta" value={`${margemBruta.toFixed(1)}%`}
-          color={margemBruta >= 30 ? 'text-emerald-600' : 'text-amber-600'} />
+          color={margemBruta >= 30 ? 'text-status-success' : 'text-status-warning'} />
         <MiniCard label="Margem Operacional" value={`${margemOp.toFixed(1)}%`}
-          color={margemOp >= 10 ? 'text-emerald-600' : margemOp >= 0 ? 'text-amber-600' : 'text-red-600'} />
+          color={margemOp >= 10 ? 'text-status-success' : margemOp >= 0 ? 'text-status-warning' : 'text-status-error'} />
         <MiniCard label="Inadimplência" value={`${pctInadimplencia.toFixed(1)}%`}
-          color={pctInadimplencia <= 10 ? 'text-emerald-600' : pctInadimplencia <= 25 ? 'text-amber-600' : 'text-red-600'}
+          color={pctInadimplencia <= 10 ? 'text-status-success' : pctInadimplencia <= 25 ? 'text-status-warning' : 'text-status-error'}
           subtitle={fmtCompact(totalVencidoCR)}
           onClick={() => setDrillDown('inadimplencia')} />
         <MiniCard label="Aging Crítico (+60d)" value={`${pctCritico.toFixed(1)}%`}
-          color={pctCritico <= 5 ? 'text-emerald-600' : pctCritico <= 15 ? 'text-amber-600' : 'text-red-600'}
+          color={pctCritico <= 5 ? 'text-status-success' : pctCritico <= 15 ? 'text-status-warning' : 'text-status-error'}
           subtitle={fmtCompact((aging?.vencido_61_90_valor || 0) + (aging?.vencido_90_plus_valor || 0))}
           onClick={() => setDrillDown('aging_critico')} />
       </div>
@@ -288,18 +288,18 @@ const FinanceiroCockpit = () => {
                       </div>
                       <div className="text-right">
                         <p className="text-[10px] text-muted-foreground">MB</p>
-                        <p className={`font-bold ${mg >= 30 ? 'text-emerald-600' : 'text-amber-600'}`}>{mg.toFixed(1)}%</p>
+                        <p className={`font-bold ${mg >= 30 ? 'text-status-success' : 'text-status-warning'}`}>{mg.toFixed(1)}%</p>
                       </div>
                       <div className="text-right">
                         <p className="text-[10px] text-muted-foreground">Resultado</p>
-                        <p className={`font-bold ${d.resultado_liquido >= 0 ? 'text-emerald-600' : 'text-red-600'}`}>
+                        <p className={`font-bold ${d.resultado_liquido >= 0 ? 'text-status-success' : 'text-status-error'}`}>
                           {fmtCompact(d.resultado_liquido)}
                         </p>
                       </div>
                       {conf && (
                         <div className="text-right">
                           <p className="text-[10px] text-muted-foreground">Mapeado</p>
-                          <p className={`text-xs font-medium ${(conf.pct_valor_mapeado || 0) >= 80 ? 'text-emerald-600' : 'text-amber-600'}`}>
+                          <p className={`text-xs font-medium ${(conf.pct_valor_mapeado || 0) >= 80 ? 'text-status-success' : 'text-status-warning'}`}>
                             {(conf.pct_valor_mapeado || 0).toFixed(0)}%
                           </p>
                         </div>
@@ -337,16 +337,16 @@ const FinanceiroCockpit = () => {
                 </TableHeader>
                 <TableBody>
                   {projecao13.map((w: any, i: number) => (
-                    <TableRow key={i} className={w.saldo_projetado < 0 ? 'bg-red-50' : ''}>
+                    <TableRow key={i} className={w.saldo_projetado < 0 ? 'bg-status-error-bg' : ''}>
                       <TableCell className="text-xs">{w.semana_label}</TableCell>
-                      <TableCell className="text-right text-sm text-emerald-600">{fmtCompact(w.entradas_previstas)}</TableCell>
-                      <TableCell className="text-right text-sm text-red-600">{fmtCompact(w.saidas_previstas)}</TableCell>
-                      <TableCell className={`text-right text-sm font-medium ${w.fluxo_liquido >= 0 ? 'text-emerald-600' : 'text-red-600'}`}>
+                      <TableCell className="text-right text-sm text-status-success">{fmtCompact(w.entradas_previstas)}</TableCell>
+                      <TableCell className="text-right text-sm text-status-error">{fmtCompact(w.saidas_previstas)}</TableCell>
+                      <TableCell className={`text-right text-sm font-medium ${w.fluxo_liquido >= 0 ? 'text-status-success' : 'text-status-error'}`}>
                         {fmtCompact(w.fluxo_liquido)}
                       </TableCell>
-                      <TableCell className={`text-right text-sm font-bold ${w.saldo_projetado >= 0 ? 'text-blue-600' : 'text-red-600'}`}>
+                      <TableCell className={`text-right text-sm font-bold ${w.saldo_projetado >= 0 ? 'text-status-info' : 'text-status-error'}`}>
                         {fmtCompact(w.saldo_projetado)}
-                        {w.saldo_projetado < 0 && <AlertTriangle className="inline w-3 h-3 ml-1 text-red-500" />}
+                        {w.saldo_projetado < 0 && <AlertTriangle className="inline w-3 h-3 ml-1 text-status-error" />}
                       </TableCell>
                     </TableRow>
                   ))}
@@ -354,9 +354,9 @@ const FinanceiroCockpit = () => {
               </Table>
             </div>
             {projecao13.some((w: any) => w.saldo_projetado < 0) && (
-              <div className="mt-3 p-3 rounded-lg bg-red-50 border border-red-200 flex items-start gap-2">
-                <AlertTriangle className="w-4 h-4 text-red-600 mt-0.5 shrink-0" />
-                <p className="text-sm text-red-800">
+              <div className="mt-3 p-3 rounded-lg bg-status-error-bg border border-status-error/20 flex items-start gap-2">
+                <AlertTriangle className="w-4 h-4 text-status-error mt-0.5 shrink-0" />
+                <p className="text-sm text-status-error-fg">
                   Projeção indica saldo negativo em {projecao13.filter((w: any) => w.saldo_projetado < 0).length} semana(s).
                   Ação necessária antes de {projecao13.find((w: any) => w.saldo_projetado < 0)?.semana_label}.
                 </p>
@@ -371,7 +371,7 @@ const FinanceiroCockpit = () => {
         <Card>
           <CardHeader className="pb-3">
             <CardTitle className="text-base flex items-center gap-2">
-              <AlertTriangle className="w-4 h-4 text-red-500" />
+              <AlertTriangle className="w-4 h-4 text-status-error" />
               Inadimplência Crítica — Top 5
             </CardTitle>
           </CardHeader>
@@ -383,7 +383,7 @@ const FinanceiroCockpit = () => {
                     <p className="font-medium text-sm">{i.nome || (i.cnpj ? `CNPJ: ${i.cnpj}` : 'Cliente não identificado')}</p>
                     <p className="text-xs text-muted-foreground">{i.qtd_titulos} título(s)</p>
                   </div>
-                  <span className="font-bold text-red-600">{fmt(i.total_vencido)}</span>
+                  <span className="font-bold text-status-error">{fmt(i.total_vencido)}</span>
                 </div>
               ))}
             </div>
@@ -410,12 +410,12 @@ function CockpitCard({ title, value, positive, icon: Icon, detail, detailColor, 
   detail?: string; detailColor?: string; badge?: string; onClick?: () => void;
 }) {
   return (
-    <Card className={onClick ? 'cursor-pointer hover:shadow-md transition-shadow' : ''} onClick={onClick}>
+    <Card className={onClick ? 'cursor-pointer hover:bg-muted/30 transition-colors' : ''} onClick={onClick}>
       <CardContent className="p-5">
         <div className="flex items-start justify-between">
           <div>
-            <p className="text-xs text-muted-foreground font-medium uppercase tracking-wide">{title}</p>
-            <p className={`text-2xl font-bold mt-2 ${positive ? 'text-emerald-600' : 'text-red-600'}`}>{value}</p>
+            <p className="text-xs text-muted-foreground font-medium uppercase tracking-wider">{title}</p>
+            <p className={`kpi-value text-3xl mt-2 ${positive ? 'text-status-success' : 'text-status-error'}`}>{value}</p>
             {detail && (
               <p className={`text-xs mt-2 ${detailColor || 'text-muted-foreground'}`}>{detail}</p>
             )}
@@ -423,8 +423,8 @@ function CockpitCard({ title, value, positive, icon: Icon, detail, detailColor, 
               <Badge variant="outline" className="mt-2 text-[9px]">{badge}</Badge>
             )}
           </div>
-          <div className={`p-3 rounded-xl ${positive ? 'bg-emerald-50' : 'bg-red-50'}`}>
-            <Icon className={`w-5 h-5 ${positive ? 'text-emerald-600' : 'text-red-600'}`} />
+          <div className={`p-2.5 rounded-md ${positive ? 'bg-status-success-bg' : 'bg-status-error-bg'}`}>
+            <Icon className={`w-4 h-4 ${positive ? 'text-status-success' : 'text-status-error'}`} />
           </div>
         </div>
       </CardContent>
@@ -436,10 +436,10 @@ function MiniCard({ label, value, color, subtitle, onClick }: {
   label: string; value: string; color: string; subtitle?: string; onClick?: () => void;
 }) {
   return (
-    <div className={`p-3 rounded-lg border bg-card text-center ${onClick ? 'cursor-pointer hover:shadow-md transition-shadow' : ''}`} onClick={onClick}>
-      <p className="text-[10px] text-muted-foreground font-medium uppercase">{label}</p>
-      <p className={`text-xl font-bold mt-1 ${color}`}>{value}</p>
-      {subtitle && <p className="text-xs text-muted-foreground mt-0.5">{subtitle}</p>}
+    <div className={`p-3 rounded-md border bg-card text-center ${onClick ? 'cursor-pointer hover:bg-muted/30 transition-colors' : ''}`} onClick={onClick}>
+      <p className="text-[10px] text-muted-foreground font-medium uppercase tracking-wider">{label}</p>
+      <p className={`kpi-value text-xl mt-1 ${color}`}>{value}</p>
+      {subtitle && <p className="text-xs text-muted-foreground mt-0.5 tabular-nums">{subtitle}</p>}
     </div>
   );
 }

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -316,8 +316,8 @@ function SummaryCard({ icon: Icon, value, label, onClick }: {
         <div className="flex items-center gap-2 mb-1">
           <Icon className="w-4 h-4 text-muted-foreground" />
         </div>
-        <p className="text-2xl font-bold tracking-tight text-foreground">{value}</p>
-        <p className="text-2xs text-muted-foreground font-medium">{label}</p>
+        <p className="kpi-value text-2xl text-foreground">{value}</p>
+        <p className="text-2xs text-muted-foreground font-medium uppercase tracking-wider mt-1">{label}</p>
       </CardContent>
     </Card>
   );
@@ -342,9 +342,9 @@ function BacklogCard({ count, label, variant, onClick }: {
   };
 
   return (
-    <button onClick={onClick} className={cn('rounded-2xl p-3 border text-center transition-all hover:shadow-md', styles[variant])}>
-      <p className={cn('text-2xl font-bold', count > 0 ? countColor[variant] : 'text-muted-foreground')}>{count}</p>
-      <p className="text-2xs font-medium text-muted-foreground">{label}</p>
+    <button onClick={onClick} className={cn('rounded-md p-3 border text-center transition-colors hover:bg-muted/30', styles[variant])}>
+      <p className={cn('kpi-value text-2xl', count > 0 ? countColor[variant] : 'text-muted-foreground')}>{count}</p>
+      <p className="text-2xs font-medium text-muted-foreground uppercase tracking-wider mt-1">{label}</p>
     </button>
   );
 }

--- a/src/pages/TintFormulas.tsx
+++ b/src/pages/TintFormulas.tsx
@@ -250,8 +250,8 @@ export default function TintFormulas() {
                         <TableCell className="text-sm">{f.tint_produtos?.descricao}</TableCell>
                         <TableCell className="text-sm max-w-[150px] truncate">{f.tint_bases?.descricao}</TableCell>
                         <TableCell className="text-sm">{f.tint_embalagens?.descricao}</TableCell>
-                        <TableCell className="text-sm">{f.volume_final_ml ? `${f.volume_final_ml}ml` : '—'}</TableCell>
-                        <TableCell className="text-sm">{f.preco_final_sayersystem ? `R$ ${Number(f.preco_final_sayersystem).toFixed(2)}` : '—'}</TableCell>
+                        <TableCell className="text-sm tabular-nums">{f.volume_final_ml ? `${f.volume_final_ml}ml` : '—'}</TableCell>
+                        <TableCell className="text-sm font-mono tabular-nums">{f.preco_final_sayersystem ? `R$ ${Number(f.preco_final_sayersystem).toFixed(2)}` : '—'}</TableCell>
                         <TableCell>
                           <Badge variant="outline" className={f.personalizada ? 'status-purple' : 'status-progress'}>
                             {f.personalizada ? 'Personalizada' : 'Padrão'}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -94,8 +94,8 @@ export default {
         },
       },
       fontFamily: {
-        sans: ["Inter", "system-ui", "-apple-system", "sans-serif"],
-        mono: ["JetBrains Mono", "Fira Code", "monospace"],
+        sans: ["Geist", "Inter", "system-ui", "-apple-system", "sans-serif"],
+        mono: ["'Geist Mono'", "'JetBrains Mono'", "Fira Code", "monospace"],
       },
       fontSize: {
         "2xs": ["0.625rem", { lineHeight: "0.875rem" }],   // 10px
@@ -165,11 +165,16 @@ export default {
         },
       },
       animation: {
-        "accordion-down": "accordion-down 0.2s ease-out",
-        "accordion-up": "accordion-up 0.2s ease-out",
-        "fade-in": "fade-in 0.2s ease-out both",
-        "scale-in": "scale-in 0.15s ease-out both",
-        "slide-in-right": "slide-in-right 0.25s ease-out",
+        // Easing Vercel — cubic-bezier(0.16, 1, 0.3, 1) — assinatura "polida sem drama"
+        "accordion-down": "accordion-down 200ms cubic-bezier(0.16, 1, 0.3, 1)",
+        "accordion-up": "accordion-up 200ms cubic-bezier(0.16, 1, 0.3, 1)",
+        "fade-in": "fade-in 200ms cubic-bezier(0.16, 1, 0.3, 1) both",
+        "scale-in": "scale-in 150ms cubic-bezier(0.16, 1, 0.3, 1) both",
+        "slide-in-right": "slide-in-right 300ms cubic-bezier(0.16, 1, 0.3, 1)",
+      },
+      transitionTimingFunction: {
+        // Default custom easing pra todas as transitions Tailwind (hover, focus etc.)
+        DEFAULT: "cubic-bezier(0.16, 1, 0.3, 1)",
       },
     },
   },


### PR DESCRIPTION
Reposicionamento visual do app pro estilo Vercel/Mercury/Stripe Dashboard, com light + dark mode e paleta low-fatigue pra uso 8h.

## O que muda

**Nível 1 (tokens globais — afeta todas as 119 telas):**
- Fonts Geist Sans + Geist Mono (Vercel)
- Paleta quase-neutra: primary preto/branco minimal, status colors dessaturadas pra uso prolongado
- Sidebar light coerente (era dark)
- Radius 6px, sombras quase ausentes, motion easing Vercel
- Dark mode com toggle (Light / Dark / Sistema)

**Nível 2 (5 telas-piloto refinadas):**
FinanceiroCockpit · AdminReposicaoCockpit · AdminCustomers · Index/Home · TintFormulas

Detalhes em `docs/visual-direction/01-direcao.md` e `02-tokens.md`.

## Commits incluídos

- chore: trigger rebuild da Lovable
- docs: direção visual fintech/SaaS premium
- feat(visual): redesign fintech/SaaS premium (Vercel/Mercury/Stripe direction)