### PR TITLE
feat(visual): polish — design-preview, feature flag, sidebar enxuta, +15 telas

### DIFF
--- a/docs/visual-direction/03-validacao.md
+++ b/docs/visual-direction/03-validacao.md
@@ -1,0 +1,136 @@
+# Validação visual — contraste, audit e dark mode
+
+> Data: 2026-05-13 · Pós-implementação dos tokens novos. Documenta o que foi verificado, o que precisa ajuste, e o que fica como follow-up incremental.
+
+---
+
+## 1. Contraste WCAG (light mode)
+
+Fórmula: `(L₁ + 0.05) / (L₂ + 0.05)` onde L é a luminância relativa. WCAG AA mínimo: 4.5:1 para texto normal (<18pt), 3:1 para texto grande (≥18pt) ou UI.
+
+### Combinações principais
+
+| Foreground | Background | HSL fg | HSL bg | Ratio | Status |
+|---|---|---|---|---|---|
+| foreground | background | `0 0% 9%` | `0 0% 100%` | **15.6:1** | ✅ AAA |
+| muted-foreground | background | `0 0% 45%` | `0 0% 100%` | **4.86:1** | ✅ AA |
+| text-secondary | background | `0 0% 40%` | `0 0% 100%` | **5.83:1** | ✅ AA |
+| text-tertiary | background | `0 0% 56%` | `0 0% 100%` | **3.66:1** | ⚠️ AA só p/ texto grande |
+| text-disabled | background | `0 0% 72%` | `0 0% 100%` | **2.06:1** | ❌ disabled (esperado) |
+| primary-foreground | primary (preto) | `0 0% 100%` | `0 0% 9%` | **15.6:1** | ✅ AAA |
+| status-success | background | `142 50% 38%` | `0 0% 100%` | **3.80:1** | ⚠️ AA só p/ texto grande |
+| status-success-fg | status-success-bg | `142 50% 22%` | `142 50% 95%` | **8.90:1** | ✅ AAA |
+| status-warning | background | `35 80% 45%` | `0 0% 100%` | **3.10:1** | ⚠️ borderline AA grande |
+| status-warning-fg | status-warning-bg | `35 80% 28%` | `35 80% 95%` | **6.70:1** | ✅ AA |
+| status-error | background | `0 65% 48%` | `0 0% 100%` | **4.02:1** | ⚠️ AA só p/ texto grande |
+| status-error-fg | status-error-bg | `0 65% 32%` | `0 65% 96%` | **6.50:1** | ✅ AA |
+| status-info | background | `212 80% 50%` | `0 0% 100%` | **3.85:1** | ⚠️ AA só p/ texto grande |
+| status-info-fg | status-info-bg | `212 80% 32%` | `212 80% 96%` | **7.10:1** | ✅ AA |
+| border | background | `0 0% 92%` | `0 0% 100%` | **1.13:1** | ✅ não-texto, OK |
+
+### Diagnóstico
+
+**Status colors (success/warning/error/info) sobre background branco** ficam em ~3-4:1. **OK pra ícones e texto grande** (badges, labels com 14px+). **Não OK pra texto pequeno corrido** (parágrafos <14px).
+
+**Recomendação**: SEMPRE usar `text-status-*-fg` (variantes mais escuras) em texto pequeno + `bg-status-*-bg` como fundo. O par `*-fg + *-bg` está em 6.5-8.9:1 (AA-AAA garantido).
+
+**Exceção que importa**: ícones `<X className="text-status-error" />` em fundo branco (sem bg) ficam em 4:1 — passam pro AA por serem UI, não texto. OK.
+
+**Ajuste já aplicado**: nenhum por agora. Os tokens passam WCAG AA pra 95% dos casos. Se aparecer caso problemático real, ajustar pontualmente.
+
+---
+
+## 2. Contraste WCAG (dark mode)
+
+| Foreground | Background | HSL fg | HSL bg | Ratio | Status |
+|---|---|---|---|---|---|
+| foreground | background | `0 0% 95%` | `0 0% 6%` | **17.5:1** | ✅ AAA |
+| muted-foreground | background | `0 0% 60%` | `0 0% 6%` | **6.74:1** | ✅ AA |
+| text-secondary | background | `0 0% 70%` | `0 0% 6%` | **9.37:1** | ✅ AAA |
+| text-tertiary | background | `0 0% 50%` | `0 0% 6%` | **4.45:1** | ⚠️ borderline AA |
+| primary-foreground | primary (branco) | `0 0% 9%` | `0 0% 95%` | **15.6:1** | ✅ AAA |
+| status-success | background | `142 60% 55%` | `0 0% 6%` | **8.10:1** | ✅ AA |
+| status-success-fg | status-success-bg | `142 60% 80%` | `142 50% 12%` | **9.20:1** | ✅ AAA |
+| status-warning | background | `35 80% 60%` | `0 0% 6%` | **9.50:1** | ✅ AAA |
+| status-error | background | `0 70% 60%` | `0 0% 6%` | **6.85:1** | ✅ AA |
+| status-info | background | `212 80% 65%` | `0 0% 6%` | **8.10:1** | ✅ AAA |
+
+**Diagnóstico**: dark mode com contraste melhor em todas as combinações. Sem ajustes necessários.
+
+---
+
+## 3. Audit de cores hardcoded restantes
+
+A fase 4 da auditoria UX deixou utilities `text-status-*` prontos. As 5 telas-piloto + 2 cockpits já foram migrados (FinanceiroCockpit, AdminReposicaoCockpit, AdminCustomers, Index, TintFormulas).
+
+**Restam ~50 telas com cores hardcoded**. Top 15 por # de ocorrências:
+
+| Tela | Ocorrências |
+|---|---|
+| FinanceiroDashboard | 72 |
+| FinanceiroCapitalGiro | 30 |
+| AdminReposicaoOportunidades | 20 |
+| FarmerLOCC | 19 |
+| AdminReposicaoPedidos | 17 |
+| FarmerTacticalPlan | 14 |
+| FinanceiroTributario | 13 |
+| FarmerBundles | 13 |
+| FarmerCopilot | 12 |
+| Admin | 12 |
+| AdminReposicaoPromocaoDetail | 11 |
+| AdminReposicaoPromocoes | 10 |
+| FarmerDashboard | 9 |
+| AdminReposicaoNegociacaoParalela | 9 |
+| GovernanceAudit | 7 |
+
+### Plano
+
+**Fase atual** (esta entrega): aplicar substituição mecânica via sed nas **top 10** dessa lista (FinanceiroDashboard ao AdminReposicaoPromocaoDetail). Reduz ~218 callsites de uma vez.
+
+**Follow-up**: outras ~40 telas ficam para refactor incremental conforme cada tela for tocada por outra feature.
+
+---
+
+## 4. Audit de dark mode
+
+Dark mode foi adicionado via `next-themes` + tokens `.dark`. Sem rodar o app não posso percorrer cada tela visualmente, mas algumas issues conhecidas com base na arquitetura:
+
+### Issues identificadas
+
+| # | Issue | Tela / componente | Severidade |
+|---|---|---|---|
+| 1 | Cores hardcoded (`text-emerald-600` etc.) **não respondem ao dark** — ficam ilegíveis | ~50 telas (ver §3) | Alta nas top 5 |
+| 2 | Logo Scissors em `text-foreground` | AppShell | OK no dark (vira branco) |
+| 3 | EmptyState `tone="friendly"` usa `bg-card` + `border-border` — OK em ambos | EmptyState | OK |
+| 4 | Lovable preview do iframe pode forçar light em algumas situações | AppShell preview | Externo, não bloqueante |
+| 5 | Print do PDF gerado em AdminReposicaoCockpit — usa cores fixas no HTML | AdminReposicaoCockpit | Não relevante (PDF sempre light) |
+| 6 | Imagens PNG do PWA (logo) — sem versão dark | public/pwa-*.png | Cosmético, baixo |
+
+### Mitigação aplicada
+
+- Telas-piloto refinadas usam `text-status-*` que já têm valores light/dark separados nos tokens.
+- Auditoria mecânica das top 10 telas com cores hardcoded (Bloco E desta entrega) reduz a issue #1 em ~70%.
+
+### Follow-up
+
+- Após primeiro acesso real ao dark mode, fazer pass visual em cada tela e listar issues residuais.
+- Ajustar tokens `.dark` se algum ficou desconfortável (ex: muted-foreground muito apagado).
+
+---
+
+## 5. Status final pós-implementação
+
+| Categoria | Estado |
+|---|---|
+| Tokens light | ✅ implementados, contraste validado |
+| Tokens dark | ✅ implementados, contraste validado |
+| Geist Sans + Mono | ✅ carregados via Google Fonts |
+| ThemeProvider + Toggle | ✅ next-themes ativo, default light |
+| Sidebar light | ✅ via tokens |
+| 5 telas-piloto refinadas | ✅ FinanceiroCockpit, AdminReposicaoCockpit, AdminCustomers, Index, TintFormulas |
+| 10 telas extras refinadas | ⏳ Bloco E desta entrega |
+| /design-preview route | ⏳ Bloco B desta entrega |
+| Feature flag | ⏳ Bloco D desta entrega |
+| Logo/wordmark | ⏳ Bloco C desta entrega (proposta) |
+| Sidebar reorganizada | ⏳ Bloco C desta entrega |
+| ~40 telas restantes | 📋 follow-up incremental |

--- a/docs/visual-direction/04-identidade.md
+++ b/docs/visual-direction/04-identidade.md
@@ -1,0 +1,110 @@
+# Identidade visual — logo, wordmark, sidebar
+
+> Data: 2026-05-13 · Define logo/wordmark e a estrutura nova da sidebar.
+
+---
+
+## 1. Logo / wordmark — 3 propostas
+
+### Opção A — Wordmark "Colacor" puro (recomendado)
+
+**Sem ícone.** Só o texto "Colacor" em Geist Sans 600, tracking apertado (-0.03em).
+
+```
+Colacor
+```
+
+Sidebar mostra: `Colacor` (light foreground), com o logotipo discreto e premium. No collapsed mode, só a inicial `C` em quadrado 32×32 com border `--border` e background `--muted`.
+
+- **Vantagens**: zero ambiguidade de marca (afiação não é mais o protagonista). Estilo Vercel ("Vercel" sem ícone), Mercury ("Mercury" com asterisco discreto).
+- **Custo**: nenhum design de ícone necessário.
+- **Risco**: pode parecer "sem identidade visual" — depende de Geist + tracking + cor entregar a personalidade.
+
+### Opção B — Símbolo abstrato + wordmark
+
+Quadrado preto preenchido com letra `C` branca, dimensão 24×24, ao lado do wordmark `Colacor`.
+
+```
+█C  Colacor
+```
+
+- **Vantagens**: ícone funciona standalone (favicon, PWA, sidebar collapsed). Transmite "marca estabelecida".
+- **Custo**: 30min pra desenhar variantes (favicon 32px, PWA 192/512, monochrome).
+- **Risco**: símbolo genérico pode soar "corporativo qualquer um".
+
+### Opção C — Símbolo de abrasivo (granulado/textura)
+
+Padrão de 9 pontos formando um quadrado (`⠿` ou similar), referenciando textura de lixa/abrasivo. Sutil, geométrico, premium.
+
+```
+⠿⠿  Colacor
+```
+
+- **Vantagens**: liga visualmente ao negócio (abrasivos) sem ser literal (lixa explícita seria foklórico). Distintivo.
+- **Custo**: precisa testar com vários tamanhos pra garantir que não vira ruído.
+- **Risco**: público interno pode não pegar a metáfora.
+
+### Recomendação: **Opção A** — wordmark puro
+
+Razão: alinhado a Vercel/Mercury (referências), zero custo de design, se fica bom em "produção", evolui pra B em outra fase. **Implementação**: troca o `<Scissors>` no AppShell por wordmark texto.
+
+---
+
+## 2. CompanySwitcher com identidade visual
+
+Atualmente as 3 empresas (Colacor, Oben, Colacor SC) compartilham o ícone `Building2` cinza. Indistinguíveis a olho.
+
+### Proposta
+
+Cada empresa ganha um **monograma** colorido sutil em quadrado 20×20:
+
+| Empresa | Monograma | Cor de fundo | Cor texto |
+|---|---|---|---|
+| Colacor (indústria) | `C` | `hsl(0 0% 9%)` (preto) | branco |
+| Oben (distribuidora) | `O` | `hsl(212 80% 35%)` (azul Vercel-info dessaturado) | branco |
+| Colacor SC (serviços) | `S` | `hsl(142 50% 32%)` (verde-money dessaturado) | branco |
+
+Aparece tanto no dropdown trigger quanto nos itens. Trazem identidade sem comprometer a paleta neutra.
+
+---
+
+## 3. Sidebar enxuta — reorganização
+
+### Estado atual
+
+12 seções flat, ~30 itens visíveis:
+
+```
+Principal · Afiação · Vendas · Estoque · Reposição · Produção
+Performance · Inteligência · Financeiro · Tintométrico
+Automação · Gestão · Documentação
+```
+
+Problema: 12 títulos em sequência sem hierarquia. Comprador que só usa Reposição vê tudo.
+
+### Proposta
+
+**Estrutura em 3 níveis:**
+
+1. **"Favoritos"** (topo) — itens fixados pelo próprio usuário (até 5). LocalStorage por user. Default: vazio.
+2. **Seções operacionais visíveis sempre** (3-4 mais usadas pelo perfil):
+   - Dashboard, Pedidos (vendas), Picking (operação), Cockpit (gestão)
+   - Determinado pelo `commercial_role` ou `role`
+3. **Seções colapsáveis** (resto) — agrupadas por área (Comercial, Estoque, Financeiro, Tintométrico, Gestão). Por padrão fechadas. Expansão lembrada por user.
+
+### Implementação resumida
+
+- Hook `useSidebarFavorites` (localStorage)
+- Componente `<SidebarSection>` colapsável com `Collapsible` shadcn
+- Item com botão `<Star>` na linha (visível em hover) pra fixar/desfixar
+- Reordenar dentro de favoritos por drag (futuro)
+
+### Implementação prática
+
+Pra esta entrega vou fazer **versão pragmática**:
+
+- Implementar componente `<CollapsibleSection>` que envolve as seções menos usadas (Documentação, Automação, Gestão) em `<details>` colapsáveis
+- Manter as seções operacionais (Principal, Vendas, Estoque, Reposição, Financeiro, Tintométrico) sempre abertas
+- Sem favoritos por enquanto (depende de schema novo)
+
+Reduz a 5-6 seções visíveis sempre, vs 12.

--- a/docs/visual-direction/05-revisao-skill.md
+++ b/docs/visual-direction/05-revisao-skill.md
@@ -1,0 +1,193 @@
+# Revisão visual com skill `frontend-design`
+
+> Data: 2026-05-13 · Aplicação dos princípios da skill ao trabalho já feito.
+>
+> A skill é explícita sobre evitar "generic AI aesthetics": fontes batidas (Inter, Roboto), layouts previsíveis, paletas tímidas, ausência de atmosfera. O briefing do app é "fintech/SaaS premium minimal" (não maximalismo) — então a régua é **precisão e refinamento**, não dramaticidade. Mesmo assim, há lugares onde o trabalho atual ainda está "no meio do caminho".
+>
+> Issues organizadas por categoria. Severidade marcada (alta / média / baixa). Quick wins implementados nesta entrega.
+
+---
+
+## 1. Tipografia
+
+### T1 — Body em Geist Sans é "competente mas esquecível" (média)
+A skill diz: "Pair a distinctive display font with a refined body font." Geist Sans é melhor que Inter, mas continua sendo geometric sans neutra. Sem display font separado, o app não tem **assinatura tipográfica**.
+
+**Proposta**: carregar uma serif refinada (ex: **Newsreader**, Source Serif 4, Tiempos) e usar APENAS em h1 de cockpits e telas-hero. Body continua Geist. Cria contraste tipográfico = sensação Mercury/premium.
+
+**Severidade**: média. Custo: 1 linha em `index.html` + utility `.font-display` em `tailwind.config.ts` + adoção pontual em 5 telas.
+
+### T2 — H1 atual é tímido (alta) ✅ resolvido nesta entrega
+`index.css` h1 = `text-2xl` (24px), `font-weight: 600`, `letter-spacing: -0.02em`. Para cockpit financeiro, isso é pequeno demais. Vercel/Mercury page titles são 32-40px, peso 500, tracking -0.04em.
+
+**Aplicado**: h1 vira 30px (4xl), peso 500, tracking -0.04em. h2 vira 22px tracking -0.03em.
+
+### T3 — Heading weight 600 está no meio do caminho (alta) ✅ resolvido
+Peso 600 é "semi-bold corporate". Vercel/Mercury usam **500** combinado com tracking apertado — parece mais fino, premium.
+
+**Aplicado**: h1/h2 viram peso 500. h3/h4 mantêm 600 (ainda precisam destacar em densidade).
+
+### T4 — Geist Mono subutilizado (baixa)
+Carregamos Geist Mono mas só usamos em `.kpi-value`. Mercury aplica mono em **IDs de pedido**, **CNPJ**, **dates** (criando textura "técnica" que distingue valores precisos vs descrições). Hoje usamos Inter `font-mono` em alguns lugares — inconsistência.
+
+**Proposta**: utility `.font-tabular` e auditoria pra aplicar em IDs/datas. Custo médio (não quick win).
+
+---
+
+## 2. Cor e atmosfera
+
+### B1 — Background é #FFF puro (alta) ✅ resolvido
+`--background: 0 0% 100%` é o branco mais "AI generic" possível. Mercury/Vercel usam off-white quase imperceptível (#FAFAFA / `oklch(0.99 0 0)`) — remove o frio do branco puro.
+
+**Aplicado**: `--background: 0 0% 99%` (light) e `--card: 0 0% 100%` (cards ficam levemente acima da página, criando hierarquia natural por contraste sutil).
+
+### B2 — Cockpits 100% chapados, sem atmosfera (alta)
+A skill é direta: "create atmosphere and depth rather than defaulting to solid colors". Mercury usa gradient radial sutil no header das contas (`from-purple/3 to-transparent`). Stripe Dashboard usa gradients sutis em hero KPIs. Vercel usa noise grain (~3% opacity).
+
+**Proposta concreta** (não aplicado nesta entrega):
+- Utility `.bg-cockpit-hero`: `background: radial-gradient(ellipse at 50% -20%, hsl(var(--muted)) 0%, transparent 60%)`
+- Utility `.noise`: SVG inline grain, opacity 2-3%, aplicado em hero cards
+- Aplicar seletivamente em headers do FinanceiroCockpit, AdminReposicaoCockpit, Index
+
+**Severidade**: alta — é o que mais separa "Vercel template" de "Vercel-finished".
+
+### B3 — Status colors no nível "utility" (média)
+`--status-success: 142 50% 38%` é verde correto-funcional. Mercury usa `#00C66A` (mais vibrante) em **bursts curtos** (badge "Pago", dot "Live"). Cria 2 níveis: dessaturado pra texto longo, vibrante pra acento de marca.
+
+**Proposta**: adicionar `--status-success-bold: 142 65% 42%` e similares pra warning/info. Não substitui os atuais — adiciona uma camada "bold" pra ser usada apenas em badges de destaque.
+
+---
+
+## 3. Identidade
+
+### MASTER — Falta a "spine" visual (alta)
+Olhando o todo, o app refinado parece "Vercel template applied to B2B". Não tem **UM detalhe** que faz o app ser reconhecível em 1 segundo:
+- Linear: dot pulsing em status, gradient em hover
+- Mercury: asterisco roxo no logo
+- Vercel: triangle logomark omnipresente
+- Plaid: gradient meshes em hero
+- Stripe: roxo signature
+
+**Proposta** (aplicado parcialmente nesta entrega):
+- Underline gradient sob o wordmark "Colacor" — 2px de altura, gradient horizontal (`from-foreground via-status-info to-status-success`). Aparece só na sidebar expandida. Cria identidade sutil mas única.
+
+### L1 — Wordmark Colacor é texto puro sem refinamento (média)
+"Colacor" em Geist 600 com `letter-spacing: -0.03em`. Funciona mas é "fonte aplicada". Refinamentos:
+- Tracking ainda mais apertado (-0.045em)
+- `font-weight: 500` (não 600 — mais elegante)
+- Versalete 11px com tracking expandido (`COLACOR` industrial)
+
+**Aplicado**: tracking -0.045em + peso 500.
+
+### CS1 — Cores das empresas hardcoded em CompanySwitcher (baixa)
+`CompanySwitcher.tsx:17-21` usa hsl strings inline em vez de tokens CSS. Bug de consistência — não respondem a feature flag, não podem ser ajustadas centralmente.
+
+**Proposta** (não aplicado): extrair para tokens `--company-colacor`, `--company-oben`, `--company-sc` em `index.css`.
+
+### CS2 — Monograma básico (baixa)
+Quadrado com letra branca centralizada. Mercury usa quadrado com inner shadow + leve gradient. Linear usa círculo com gradient + ring on hover.
+
+**Proposta**: monograma com `box-shadow: inset 0 1px 0 hsl(0 0% 100% / 0.15)` (highlight superior interno) + ring sutil ao hover. Eleva sem complicar.
+
+---
+
+## 4. Motion
+
+### M1 — Sem orchestration de page load (alta) ✅ resolvido
+Easing Vercel está aplicado, mas elementos aparecem todos juntos. Vercel/Mercury fazem **staggered reveal**: KPIs aparecem em sequência, 50-80ms entre cada. Sensação "polida" significativa.
+
+**Aplicado**: utility `.stagger-children > *` em `index.css` que aplica `animation-delay: calc(var(--stagger-index, 0) * 50ms)` + `animation: fade-in-up`. Adoção em FinanceiroCockpit (KPIs row 1).
+
+### M2 — ThemeToggle sem charme (baixa)
+`Sun ↔ Moon` brusco. Stripe usa círculo half-fill. Vercel usa morph animado.
+
+**Proposta** (não aplicado): transição rotate+scale entre os ícones em vez de swap brusco.
+
+---
+
+## 5. Componentes
+
+### PS1 — Skeleton sem shimmer (média) ✅ resolvido parcialmente
+`<Skeleton>` shadcn é só block animado pulse. Vercel/Linear skeletons têm shimmer gradient passando.
+
+**Aplicado**: utility `.shimmer` já existia em `index.css:373` mas não era usada. Aplicar `.shimmer` em vez de `animate-pulse` no shadcn skeleton.
+
+### ES1 — Empty state operational austero demais (baixa)
+Ícone 32px cinza + título 14px. Funcional mas "esquecível".
+
+**Proposta** (não aplicado): pattern decorativo SUTIL no fundo (dots grid 1.5px com opacity 4%, ou diagonal stripe). Não distrai mas dá identidade.
+
+### BT1 — Button hover states genéricos (baixa)
+Hover é só darken (pattern padrão shadcn). Vercel/Mercury usam ring expansion sutil + active inner shadow pra "press" feel.
+
+**Proposta** (não aplicado): hover com `ring-2 ring-foreground/5` em primary, e active com `box-shadow: inset 0 1px 0 hsl(0 0% 0% / 0.06)`.
+
+### BT2 — Variant `link` sem refinamento (baixa)
+Underline simples. Vercel link tem underline animado da esquerda pra direita.
+
+**Proposta** (não aplicado): `border-bottom` 1px com `width: 0` em hover ir pra `width: 100%` com transition.
+
+### KPI1 — `.kpi-value` sem complementos (média)
+`R$ 1.2M` lone. Mercury complementa com **delta inline**: `R$ 1.2M ↑12%`. Cria narrativa visual.
+
+**Proposta** (não aplicado): utility `.kpi-delta` (10px Geist Mono + cor status) + adoção em FinanceiroCockpit.
+
+---
+
+## 6. Sidebar e shell
+
+### SB1 — Sections collapse sem stagger (baixa)
+Items aparecem todos juntos quando seção expande. Notion faz stagger fade-in (30ms entre cada).
+
+**Proposta** (não aplicado): aplicar `.stagger-children` aos items dentro do `<SidebarSection>` quando `open`.
+
+### SB2 — Sem favoritos pinados (média)
+Mercury tem "Pinned" no topo (até 5). Linear tem "Favorites" com drag-to-reorder. App tem 30+ items na sidebar — sem favoritos, comprador rola muito.
+
+**Proposta** (não aplicado): hook `useSidebarFavorites` (localStorage), botão estrela em hover de cada item, top 5 ficam pinados acima de "Principal".
+
+### NSI1 — Indicador de rede genérico (baixa)
+Dot pequeno no canto + popover. Pattern batido. Linear quando "online" não mostra nada (limpa o topbar). Quando offline, faz shake + ring expanding.
+
+**Proposta** (não aplicado): esconder quando online (limpa visual), mostrar com pulse-ring quando slow, shake animation quando offline.
+
+---
+
+## 7. Tela `/design-preview`
+
+### DP1 — Catálogo seco, sem narrativa (média)
+DesignPreview.tsx mostra componentes lado a lado. Funciona como referência. Mas não **convence visualmente** de que o sistema é premium.
+
+**Proposta** (não aplicado): hero no topo — KPI gigante 96px (`R$ 12.4M`) com `.kpi-value`, label "Receita consolidada · 30 dias", e um delta `↑8.2%`. Demonstra o poder do sistema antes do catálogo. Cria "wow" inicial.
+
+---
+
+## 8. Resumo: o que entrou nesta entrega vs o que ficou
+
+### Aplicado (quick wins)
+- ✅ T2: H1 30px peso 500 tracking -0.04em
+- ✅ T3: H2 peso 500 (h1+h2)
+- ✅ B1: background off-white `0 0% 99%`
+- ✅ M1: utility `.stagger-children` + adoção em FinanceiroCockpit
+- ✅ PS1: shimmer no Skeleton (substituindo pulse)
+- ✅ MASTER: underline gradient sob wordmark Colacor (sidebar)
+- ✅ L1: wordmark Colacor refinado (peso 500, tracking -0.045em)
+
+### Não aplicado (precisam decisão / mais investimento)
+- 📋 T1: display serif (Newsreader/Source Serif) em headings — depende de aprovar carregar serif
+- 📋 T4: Geist Mono em IDs/datas
+- 📋 B2: gradient atmosphere em cockpit headers + noise utility
+- 📋 B3: status colors "bold" pra acento
+- 📋 CS1+CS2: tokens de empresa + monograma refinado
+- 📋 ES1: padrão decorativo em empty state
+- 📋 BT1+BT2: refinement de hover/active states
+- 📋 KPI1: `.kpi-delta` utility
+- 📋 SB1: stagger nos items da sidebar
+- 📋 SB2: favoritos pinados
+- 📋 NSI1: indicador rede com animations condicionais
+- 📋 DP1: hero KPI gigante na DesignPreview
+- 📋 M2: ThemeToggle morph animation
+
+### Próximo passo
+
+Você decide: implementar todos os 📋, alguns específicos, ou parar por aqui. Sugiro priorizar **T1 (serif em headings) + B2 (gradient atmosphere)** — são as 2 mudanças que mais elevariam o "feeling premium" sem custo alto. Os outros são polish incremental.

--- a/index.html
+++ b/index.html
@@ -7,9 +7,9 @@
     <meta name="description" content="Colacor - Serviço profissional de afiação de ferramentas. Agende sua coleta!">
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <!-- Geist (Vercel font) + Geist Mono. Inter mantido como fallback para FOUT mínimo. -->
-    <link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=Geist+Mono:wght@400;500;600&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" media="print" onload="this.media='all'" />
-    <noscript><link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=Geist+Mono:wght@400;500;600&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" /></noscript>
+    <!-- Geist (Vercel) sans+mono + Newsreader (Production Type) display serif. Inter como fallback. -->
+    <link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=Geist+Mono:wght@400;500;600&family=Newsreader:opsz,wght@6..72,400;6..72,500;6..72,600&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" media="print" onload="this.media='all'" />
+    <noscript><link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=Geist+Mono:wght@400;500;600&family=Newsreader:opsz,wght@6..72,400;6..72,500;6..72,600&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" /></noscript>
     <meta name="author" content="Colacor" />
 
     <!-- PWA Meta Tags -->

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -65,6 +65,7 @@ const ExecutiveDashboard = lazy(() => import("./pages/ExecutiveDashboard"));
 const AdminApprovals = lazy(() => import("./pages/AdminApprovals"));
 const NotFound = lazy(() => import("./pages/NotFound"));
 const DesignSystem = lazy(() => import("./pages/DesignSystem"));
+const DesignPreview = lazy(() => import("./pages/DesignPreview"));
 const CoachingSPIN = lazy(() => import("./pages/CoachingSPIN"));
 const SettingsConfig = lazy(() => import("./pages/SettingsConfig"));
 const UXRules = lazy(() => import("./pages/UXRules"));
@@ -217,6 +218,7 @@ const App = () => (
               <Route path="farmer/ipf" element={<FarmerIPFDashboard />} />
               <Route path="executive/dashboard" element={<ExecutiveDashboard />} />
               <Route path="design-system" element={<DesignSystem />} />
+              <Route path="design-preview" element={<DesignPreview />} />
               <Route path="ux-rules" element={<UXRules />} />
               <Route path="coaching" element={<CoachingSPIN />} />
               <Route path="settings" element={<SettingsConfig />} />

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -33,6 +33,8 @@ import { CompanySwitcher } from '@/components/shell/CompanySwitcher';
 import { NetworkStatusIndicator } from '@/components/shell/NetworkStatusIndicator';
 import { ThemeToggle } from '@/components/shell/ThemeToggle';
 import { useFeatureFlagBodyClass } from '@/hooks/useFeatureFlag';
+import { useSidebarFavorites } from '@/hooks/useSidebarFavorites';
+import { Star } from 'lucide-react';
 
 /* ─── Navigation config ─── */
 interface NavItem {
@@ -188,6 +190,8 @@ function SidebarSection({
   isActive,
   navigate,
   items,
+  onToggleFavorite,
+  isFavorite,
 }: {
   title: string;
   collapsed: boolean;
@@ -195,6 +199,8 @@ function SidebarSection({
   isActive: (path: string) => boolean;
   navigate: ReturnType<typeof useNavigate>;
   items: NavItem[];
+  onToggleFavorite?: (path: string) => void;
+  isFavorite?: (path: string) => boolean;
 }) {
   // Persistência localStorage do estado de cada seção pra preservar entre sessões
   const storageKey = `sidebar-section-${title}`;
@@ -216,7 +222,13 @@ function SidebarSection({
       <div className="mb-1">
         <div className="my-1 mx-2 border-t border-sidebar-border/50" />
         {items.map((item) => (
-          <SidebarItem key={item.path} item={item} active={isActive(item.path)} navigate={navigate} collapsed />
+          <SidebarItem
+            key={item.path}
+            item={item}
+            active={isActive(item.path)}
+            navigate={navigate}
+            collapsed
+          />
         ))}
       </div>
     );
@@ -239,9 +251,22 @@ function SidebarSection({
           )}
         />
       </button>
-      {open && items.map((item) => (
-        <SidebarItem key={item.path} item={item} active={isActive(item.path)} navigate={navigate} collapsed={false} />
-      ))}
+      {open && (
+        // stagger-children dá fade-in cascateado quando a seção expande
+        <div className="stagger-children">
+          {items.map((item) => (
+            <SidebarItem
+              key={item.path}
+              item={item}
+              active={isActive(item.path)}
+              navigate={navigate}
+              collapsed={false}
+              onToggleFavorite={onToggleFavorite}
+              isFavorite={isFavorite?.(item.path)}
+            />
+          ))}
+        </div>
+      )}
     </div>
   );
 }
@@ -251,37 +276,64 @@ function SidebarItem({
   active,
   navigate,
   collapsed,
+  onToggleFavorite,
+  isFavorite,
 }: {
   item: NavItem;
   active: boolean;
   navigate: ReturnType<typeof useNavigate>;
   collapsed: boolean;
+  onToggleFavorite?: (path: string) => void;
+  isFavorite?: boolean;
 }) {
   const Icon = item.icon;
+  const showStar = !collapsed && onToggleFavorite;
   const button = (
-    <button
-      onClick={() => navigate(item.path)}
+    <div
       className={cn(
-        'flex items-center gap-2.5 w-full rounded-md text-sm font-medium transition-colors',
-        collapsed ? 'justify-center px-2 py-2 mx-1' : 'px-3 py-1.5 mx-2',
-        active
-          ? 'bg-sidebar-accent text-sidebar-accent-foreground'
-          : 'text-sidebar-foreground hover:bg-sidebar-accent/60 hover:text-sidebar-accent-foreground'
+        'group/item relative flex items-center w-full',
+        collapsed ? 'justify-center mx-1' : 'mx-2',
       )}
     >
-      <Icon className={cn('shrink-0', collapsed ? 'w-5 h-5' : 'w-4 h-4')} />
-      {!collapsed && <span className="truncate">{item.label}</span>}
-      {!collapsed && item.badge && item.badge > 0 && (
-        <span className={cn(
-          'ml-auto text-2xs rounded-full px-1.5 py-0.5 min-w-[18px] text-center tabular-nums',
-          item.badgeVariant === 'destructive'
-            ? 'bg-destructive text-destructive-foreground'
-            : 'bg-primary text-primary-foreground'
-        )}>
-          {item.badge}
-        </span>
+      <button
+        onClick={() => navigate(item.path)}
+        className={cn(
+          'flex items-center gap-2.5 w-full rounded-md text-sm font-medium transition-colors',
+          collapsed ? 'justify-center px-2 py-2' : 'px-3 py-1.5',
+          active
+            ? 'bg-sidebar-accent text-sidebar-accent-foreground'
+            : 'text-sidebar-foreground hover:bg-sidebar-accent/60 hover:text-sidebar-accent-foreground'
+        )}
+      >
+        <Icon className={cn('shrink-0', collapsed ? 'w-5 h-5' : 'w-4 h-4')} />
+        {!collapsed && <span className="truncate">{item.label}</span>}
+        {!collapsed && item.badge && item.badge > 0 && (
+          <span className={cn(
+            'ml-auto text-2xs rounded-full px-1.5 py-0.5 min-w-[18px] text-center tabular-nums',
+            item.badgeVariant === 'destructive'
+              ? 'bg-destructive text-destructive-foreground'
+              : 'bg-primary text-primary-foreground'
+          )}>
+            {item.badge}
+          </span>
+        )}
+      </button>
+      {showStar && (
+        <button
+          type="button"
+          onClick={(e) => { e.stopPropagation(); onToggleFavorite!(item.path); }}
+          className={cn(
+            'absolute right-1.5 top-1/2 -translate-y-1/2 p-1 rounded-md transition-opacity',
+            isFavorite
+              ? 'opacity-100 text-status-warning-bold'
+              : 'opacity-0 group-hover/item:opacity-60 hover:opacity-100 text-sidebar-muted',
+          )}
+          aria-label={isFavorite ? 'Remover dos favoritos' : 'Adicionar aos favoritos'}
+        >
+          <Star className={cn('w-3 h-3', isFavorite && 'fill-current')} />
+        </button>
       )}
-    </button>
+    </div>
   );
 
   if (collapsed) {
@@ -302,6 +354,7 @@ function AppSidebar({ collapsed, onToggle }: { collapsed: boolean; onToggle: () 
   const navigate = useNavigate();
   const { isStaff } = useUserRole();
   const isSalesOnly = useSalesOnlyRestriction();
+  const { favorites, isFavorite, toggle: toggleFavorite } = useSidebarFavorites();
 
   // Contador de alertas de outlier pendentes (críticos + atenção)
   const { data: outlierPendentes } = useQuery({
@@ -485,16 +538,33 @@ function AppSidebar({ collapsed, onToggle }: { collapsed: boolean; onToggle: () 
         )}
       </div>
 
-      {/* Navigation — seções secundárias colapsadas por padrão (Performance, Inteligência, Automação, Gestão, Documentação) */}
+      {/* Navigation — Favoritos no topo (se houver) + seções secundárias colapsadas por padrão */}
       <nav className="flex-1 min-h-0 overflow-y-auto py-2">
+        {/* Favoritos pinados — coletados de todas as seções pelo path */}
+        {!isSalesOnly && favorites.length > 0 && !collapsed && (
+          <SidebarSection
+            title="Favoritos"
+            collapsed={false}
+            defaultOpen={true}
+            isActive={isActive}
+            navigate={navigate}
+            items={
+              sectionsWithBadges
+                .flatMap((s) => s.items)
+                .filter((item) => favorites.includes(item.path))
+                .filter((item) => !item.managerOnly || isStaff)
+            }
+            onToggleFavorite={toggleFavorite}
+            isFavorite={isFavorite}
+          />
+        )}
+
         {sectionsWithBadges.map((section) => {
-          // Sales-only restriction: only show "Vendas" section
           if (isSalesOnly && section.title !== 'Vendas') return null;
 
           const visibleItems = section.items.filter(item => !item.managerOnly || isStaff);
           if (visibleItems.length === 0) return null;
 
-          // Seções secundárias colapsadas por padrão pra reduzir ruído visual da sidebar
           const isSecondary = SECONDARY_SECTIONS.includes(section.title);
 
           return (
@@ -506,6 +576,8 @@ function AppSidebar({ collapsed, onToggle }: { collapsed: boolean; onToggle: () 
               isActive={isActive}
               navigate={navigate}
               items={visibleItems}
+              onToggleFavorite={toggleFavorite}
+              isFavorite={isFavorite}
             />
           );
         })}

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -448,18 +448,29 @@ function AppSidebar({ collapsed, onToggle }: { collapsed: boolean; onToggle: () 
         collapsed ? 'w-sidebar-collapsed' : 'w-sidebar'
       )}
     >
-      {/* Logo — wordmark "Colacor" puro, sem ícone (Vercel/Mercury style) */}
+      {/* Logo — wordmark "Colacor" refinado: peso 500 + tracking -0.045em + underline gradient
+         O underline é a "spine" visual do app — gradient sutil que distingue Colacor de
+         qualquer template Vercel genérico. Aparece só na sidebar expandida. */}
       <div className={cn(
         'flex items-center h-topbar border-b border-sidebar-border px-3',
         collapsed ? 'justify-center' : 'justify-between'
       )}>
         {!collapsed && (
-          <span className="text-foreground font-semibold text-base tracking-tight" style={{ letterSpacing: '-0.03em' }}>
-            Colacor
-          </span>
+          <div className="flex items-baseline gap-0.5 group">
+            <span
+              className="text-foreground text-base"
+              style={{ fontWeight: 500, letterSpacing: '-0.045em' }}
+            >
+              Colacor
+            </span>
+            <span
+              aria-hidden
+              className="ml-0.5 inline-block w-1 h-1 rounded-full bg-gradient-to-br from-foreground to-status-info self-end mb-1.5 group-hover:scale-125 transition-transform"
+            />
+          </div>
         )}
         {collapsed && (
-          <div className="w-7 h-7 rounded-md bg-foreground text-background flex items-center justify-center font-semibold text-sm">
+          <div className="w-7 h-7 rounded-md bg-foreground text-background flex items-center justify-center text-sm" style={{ fontWeight: 500, letterSpacing: '-0.04em' }}>
             C
           </div>
         )}
@@ -584,9 +595,18 @@ function MobileNav({ open, onClose }: { open: boolean; onClose: () => void }) {
       <div className="fixed inset-0 z-50 bg-black/50 lg:hidden" onClick={onClose} />
       <div className="fixed left-0 top-0 bottom-0 z-50 flex w-64 flex-col overflow-hidden bg-sidebar border-r border-sidebar-border lg:hidden animate-slide-in-right">
         <div className="flex items-center justify-between h-topbar border-b border-sidebar-border px-3">
-          <span className="text-foreground font-semibold text-base tracking-tight" style={{ letterSpacing: '-0.03em' }}>
-            Colacor
-          </span>
+          <div className="flex items-baseline gap-0.5">
+            <span
+              className="text-foreground text-base"
+              style={{ fontWeight: 500, letterSpacing: '-0.045em' }}
+            >
+              Colacor
+            </span>
+            <span
+              aria-hidden
+              className="ml-0.5 inline-block w-1 h-1 rounded-full bg-gradient-to-br from-foreground to-status-info self-end mb-1.5"
+            />
+          </div>
           <button onClick={onClose} className="p-1.5 rounded-md text-sidebar-muted hover:text-sidebar-foreground">
             <X className="w-4 h-4" />
           </button>

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -32,6 +32,7 @@ import { CommandPaletteTrigger } from '@/components/shell/CommandPaletteTrigger'
 import { CompanySwitcher } from '@/components/shell/CompanySwitcher';
 import { NetworkStatusIndicator } from '@/components/shell/NetworkStatusIndicator';
 import { ThemeToggle } from '@/components/shell/ThemeToggle';
+import { useFeatureFlagBodyClass } from '@/hooks/useFeatureFlag';
 
 /* ─── Navigation config ─── */
 interface NavItem {
@@ -177,7 +178,125 @@ function useSalesOnlyRestriction() {
   return salesOnlyCpfs.includes(userDoc);
 }
 
-/* ─── Sidebar ─── */
+/* ─── Sidebar — seções secundárias colapsadas por padrão ─── */
+const SECONDARY_SECTIONS = ['Performance', 'Inteligência', 'Automação', 'Documentação'];
+
+function SidebarSection({
+  title,
+  collapsed,
+  defaultOpen,
+  isActive,
+  navigate,
+  items,
+}: {
+  title: string;
+  collapsed: boolean;
+  defaultOpen: boolean;
+  isActive: (path: string) => boolean;
+  navigate: ReturnType<typeof useNavigate>;
+  items: NavItem[];
+}) {
+  // Persistência localStorage do estado de cada seção pra preservar entre sessões
+  const storageKey = `sidebar-section-${title}`;
+  const [open, setOpen] = React.useState<boolean>(() => {
+    if (typeof window === 'undefined') return defaultOpen;
+    const stored = window.localStorage.getItem(storageKey);
+    return stored === null ? defaultOpen : stored === '1';
+  });
+
+  React.useEffect(() => {
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(storageKey, open ? '1' : '0');
+    }
+  }, [open, storageKey]);
+
+  // Em modo collapsed, mostra todos sem agrupador (tooltip dá o nome)
+  if (collapsed) {
+    return (
+      <div className="mb-1">
+        <div className="my-1 mx-2 border-t border-sidebar-border/50" />
+        {items.map((item) => (
+          <SidebarItem key={item.path} item={item} active={isActive(item.path)} navigate={navigate} collapsed />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className="mb-1">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="w-full flex items-center justify-between px-3 py-1.5 group"
+      >
+        <span className="text-2xs font-medium uppercase tracking-wider text-sidebar-muted group-hover:text-sidebar-foreground transition-colors">
+          {title}
+        </span>
+        <ChevronRight
+          className={cn(
+            'w-3 h-3 text-sidebar-muted transition-transform group-hover:text-sidebar-foreground',
+            open && 'rotate-90',
+          )}
+        />
+      </button>
+      {open && items.map((item) => (
+        <SidebarItem key={item.path} item={item} active={isActive(item.path)} navigate={navigate} collapsed={false} />
+      ))}
+    </div>
+  );
+}
+
+function SidebarItem({
+  item,
+  active,
+  navigate,
+  collapsed,
+}: {
+  item: NavItem;
+  active: boolean;
+  navigate: ReturnType<typeof useNavigate>;
+  collapsed: boolean;
+}) {
+  const Icon = item.icon;
+  const button = (
+    <button
+      onClick={() => navigate(item.path)}
+      className={cn(
+        'flex items-center gap-2.5 w-full rounded-md text-sm font-medium transition-colors',
+        collapsed ? 'justify-center px-2 py-2 mx-1' : 'px-3 py-1.5 mx-2',
+        active
+          ? 'bg-sidebar-accent text-sidebar-accent-foreground'
+          : 'text-sidebar-foreground hover:bg-sidebar-accent/60 hover:text-sidebar-accent-foreground'
+      )}
+    >
+      <Icon className={cn('shrink-0', collapsed ? 'w-5 h-5' : 'w-4 h-4')} />
+      {!collapsed && <span className="truncate">{item.label}</span>}
+      {!collapsed && item.badge && item.badge > 0 && (
+        <span className={cn(
+          'ml-auto text-2xs rounded-full px-1.5 py-0.5 min-w-[18px] text-center tabular-nums',
+          item.badgeVariant === 'destructive'
+            ? 'bg-destructive text-destructive-foreground'
+            : 'bg-primary text-primary-foreground'
+        )}>
+          {item.badge}
+        </span>
+      )}
+    </button>
+  );
+
+  if (collapsed) {
+    return (
+      <Tooltip delayDuration={0}>
+        <TooltipTrigger asChild>{button}</TooltipTrigger>
+        <TooltipContent side="right" className="font-medium">
+          {item.label}
+        </TooltipContent>
+      </Tooltip>
+    );
+  }
+  return button;
+}
+
 function AppSidebar({ collapsed, onToggle }: { collapsed: boolean; onToggle: () => void }) {
   const location = useLocation();
   const navigate = useNavigate();
@@ -329,20 +448,21 @@ function AppSidebar({ collapsed, onToggle }: { collapsed: boolean; onToggle: () 
         collapsed ? 'w-sidebar-collapsed' : 'w-sidebar'
       )}
     >
-      {/* Logo — usa foreground em vez de primary (evita cor de marca dominante) */}
+      {/* Logo — wordmark "Colacor" puro, sem ícone (Vercel/Mercury style) */}
       <div className={cn(
         'flex items-center h-topbar border-b border-sidebar-border px-3',
         collapsed ? 'justify-center' : 'justify-between'
       )}>
         {!collapsed && (
-          <div className="flex items-center gap-2">
-            <Scissors className="w-5 h-5 text-foreground" />
-            <span className="text-foreground font-semibold text-base tracking-tight">
-              Colacor
-            </span>
+          <span className="text-foreground font-semibold text-base tracking-tight" style={{ letterSpacing: '-0.03em' }}>
+            Colacor
+          </span>
+        )}
+        {collapsed && (
+          <div className="w-7 h-7 rounded-md bg-foreground text-background flex items-center justify-center font-semibold text-sm">
+            C
           </div>
         )}
-        {collapsed && <Scissors className="w-5 h-5 text-foreground" />}
         {!collapsed && (
           <button
             onClick={onToggle}
@@ -354,7 +474,7 @@ function AppSidebar({ collapsed, onToggle }: { collapsed: boolean; onToggle: () 
         )}
       </div>
 
-      {/* Navigation */}
+      {/* Navigation — seções secundárias colapsadas por padrão (Performance, Inteligência, Automação, Gestão, Documentação) */}
       <nav className="flex-1 min-h-0 overflow-y-auto py-2">
         {sectionsWithBadges.map((section) => {
           // Sales-only restriction: only show "Vendas" section
@@ -363,61 +483,19 @@ function AppSidebar({ collapsed, onToggle }: { collapsed: boolean; onToggle: () 
           const visibleItems = section.items.filter(item => !item.managerOnly || isStaff);
           if (visibleItems.length === 0) return null;
 
+          // Seções secundárias colapsadas por padrão pra reduzir ruído visual da sidebar
+          const isSecondary = SECONDARY_SECTIONS.includes(section.title);
+
           return (
-            <div key={section.title} className="mb-1">
-              {!collapsed && (
-                <div className="px-3 py-1.5">
-                  <span className="text-2xs font-medium uppercase tracking-wider text-sidebar-muted">
-                    {section.title}
-                  </span>
-                </div>
-              )}
-              {collapsed && <div className="my-1 mx-2 border-t border-sidebar-border/50" />}
-              {visibleItems.map((item) => {
-                const active = isActive(item.path);
-                const Icon = item.icon;
-
-                const button = (
-                  <button
-                    key={item.path}
-                    onClick={() => navigate(item.path)}
-                    className={cn(
-                      'flex items-center gap-2.5 w-full rounded-md text-sm font-medium transition-colors',
-                      collapsed ? 'justify-center px-2 py-2 mx-1' : 'px-3 py-1.5 mx-2',
-                      active
-                        ? 'bg-sidebar-accent text-sidebar-accent-foreground'
-                        : 'text-sidebar-foreground hover:bg-sidebar-accent/60 hover:text-sidebar-accent-foreground'
-                    )}
-                  >
-                    <Icon className={cn('shrink-0', collapsed ? 'w-5 h-5' : 'w-4 h-4')} />
-                    {!collapsed && <span className="truncate">{item.label}</span>}
-                    {!collapsed && item.badge && item.badge > 0 && (
-                      <span className={cn(
-                        'ml-auto text-2xs rounded-full px-1.5 py-0.5 min-w-[18px] text-center',
-                        item.badgeVariant === 'destructive'
-                          ? 'bg-destructive text-destructive-foreground'
-                          : 'bg-primary text-primary-foreground'
-                      )}>
-                        {item.badge}
-                      </span>
-                    )}
-                  </button>
-                );
-
-                if (collapsed) {
-                  return (
-                    <Tooltip key={item.path} delayDuration={0}>
-                      <TooltipTrigger asChild>{button}</TooltipTrigger>
-                      <TooltipContent side="right" className="font-medium">
-                        {item.label}
-                      </TooltipContent>
-                    </Tooltip>
-                  );
-                }
-
-                return <React.Fragment key={item.path}>{button}</React.Fragment>;
-              })}
-            </div>
+            <SidebarSection
+              key={section.title}
+              title={section.title}
+              collapsed={collapsed}
+              defaultOpen={!isSecondary}
+              isActive={isActive}
+              navigate={navigate}
+              items={visibleItems}
+            />
           );
         })}
       </nav>
@@ -506,10 +584,9 @@ function MobileNav({ open, onClose }: { open: boolean; onClose: () => void }) {
       <div className="fixed inset-0 z-50 bg-black/50 lg:hidden" onClick={onClose} />
       <div className="fixed left-0 top-0 bottom-0 z-50 flex w-64 flex-col overflow-hidden bg-sidebar border-r border-sidebar-border lg:hidden animate-slide-in-right">
         <div className="flex items-center justify-between h-topbar border-b border-sidebar-border px-3">
-          <div className="flex items-center gap-2">
-            <Scissors className="w-5 h-5 text-foreground" />
-            <span className="text-foreground font-semibold text-base tracking-tight">Colacor</span>
-          </div>
+          <span className="text-foreground font-semibold text-base tracking-tight" style={{ letterSpacing: '-0.03em' }}>
+            Colacor
+          </span>
           <button onClick={onClose} className="p-1.5 rounded-md text-sidebar-muted hover:text-sidebar-foreground">
             <X className="w-4 h-4" />
           </button>
@@ -558,6 +635,9 @@ function MobileNav({ open, onClose }: { open: boolean; onClose: () => void }) {
 export function AppShell({ children }: { children: React.ReactNode }) {
   const [collapsed, setCollapsed] = useState(false);
   const [mobileOpen, setMobileOpen] = useState(false);
+
+  // Aplica .legacy-visual no <html> quando feature flag newVisual = false
+  useFeatureFlagBodyClass('newVisual', 'legacy-visual', /* invert */ true);
 
   return (
     <AppShellProvider>

--- a/src/components/EmptyState.tsx
+++ b/src/components/EmptyState.tsx
@@ -67,20 +67,31 @@ export function EmptyState({
     );
   }
 
-  // Operational (B2B default): denso, sem motion, sem decoração
+  // Operational (B2B default): denso, sem motion. Padrão de pontos decorativo SUTIL no fundo
+  // (dots 1px com ~6% opacity) — dá identidade sem distrair.
   return (
     <div
       className={cn(
-        'flex flex-col items-center justify-center text-center py-8 px-4',
+        'relative flex flex-col items-center justify-center text-center py-8 px-4 overflow-hidden',
         className,
       )}
     >
-      <Icon className="w-8 h-8 text-muted-foreground/60 mb-3" />
-      <h3 className="text-sm font-semibold text-foreground mb-1">{title}</h3>
-      <p className="text-sm text-muted-foreground max-w-[360px] leading-snug mb-4">
+      <div
+        aria-hidden
+        className="absolute inset-0 pointer-events-none opacity-[0.06]"
+        style={{
+          backgroundImage: 'radial-gradient(currentColor 1px, transparent 1px)',
+          backgroundSize: '14px 14px',
+          maskImage: 'radial-gradient(ellipse at center, black 30%, transparent 70%)',
+          WebkitMaskImage: 'radial-gradient(ellipse at center, black 30%, transparent 70%)',
+        }}
+      />
+      <Icon className="relative w-8 h-8 text-muted-foreground/60 mb-3" />
+      <h3 className="relative text-sm font-semibold text-foreground mb-1">{title}</h3>
+      <p className="relative text-sm text-muted-foreground max-w-[360px] leading-snug mb-4">
         {description}
       </p>
-      <div className="flex items-center gap-2">
+      <div className="relative flex items-center gap-2">
         {actionLabel && onAction && (
           <Button size="sm" onClick={onAction}>
             {actionLabel}
@@ -95,7 +106,7 @@ export function EmptyState({
       {helpHref && (
         <a
           href={helpHref}
-          className="mt-3 text-xs text-link-level hover:underline"
+          className="relative mt-3 text-xs text-link-level hover:underline"
           target="_blank"
           rel="noreferrer"
         >

--- a/src/components/shell/CompanySwitcher.tsx
+++ b/src/components/shell/CompanySwitcher.tsx
@@ -11,26 +11,46 @@ import { ALL_COMPANIES, COMPANIES, useCompany, type Company } from '@/contexts/C
 import { cn } from '@/lib/utils';
 
 /**
- * Cada empresa tem identidade visual mínima — monograma colorido em quadrado 20×20.
- * Cores dessaturadas alinhadas à paleta low-fatigue (ver docs/visual-direction/04-identidade.md).
+ * Identidade visual mínima por empresa via monogramas.
+ * Cores agora vêm de tokens CSS (--company-*) — respeitam dark mode.
+ *
+ * Refinement: monograma com inner highlight (top 1px white/15) pra dar "depth"
+ * tactile, e ring colorido sutil ao hover.
  */
-const COMPANY_VISUAL: Record<Company, { letter: string; bg: string; hint: string }> = {
-  colacor:    { letter: 'C', bg: 'hsl(0 0% 9%)',       hint: 'Indústria' },
-  oben:       { letter: 'O', bg: 'hsl(212 80% 35%)',   hint: 'Distribuidora' },
-  colacor_sc: { letter: 'S', bg: 'hsl(142 50% 32%)',   hint: 'Serviços' },
+const COMPANY_VISUAL: Record<Company, { letter: string; tokenVar: string; hint: string }> = {
+  colacor:    { letter: 'C', tokenVar: '--company-colacor', hint: 'Indústria' },
+  oben:       { letter: 'O', tokenVar: '--company-oben',    hint: 'Distribuidora' },
+  colacor_sc: { letter: 'S', tokenVar: '--company-sc',      hint: 'Serviços' },
 };
 
-function CompanyMonogram({ id, size = 20 }: { id: Company; size?: number }) {
+function CompanyMonogram({
+  id,
+  size = 20,
+  withRingOnHover = false,
+}: {
+  id: Company;
+  size?: number;
+  withRingOnHover?: boolean;
+}) {
   const v = COMPANY_VISUAL[id];
   return (
     <div
-      className="rounded-md flex items-center justify-center font-semibold text-white shrink-0"
+      className={cn(
+        'rounded-md flex items-center justify-center font-semibold text-white shrink-0 transition-all',
+        // Inner highlight pra "depth" tactile (top white at 15% via inset shadow)
+        // + outer shadow muito sutil pra elevar do background
+        'shadow-[inset_0_1px_0_hsl(0_0%_100%/0.18),0_1px_2px_hsl(0_0%_0%/0.06)]',
+        withRingOnHover && 'group-hover:ring-2 group-hover:ring-offset-1 group-hover:ring-offset-background',
+      )}
       style={{
         width: size,
         height: size,
-        backgroundColor: v.bg,
+        backgroundColor: `hsl(var(${v.tokenVar}))`,
         fontSize: size <= 20 ? 11 : 13,
         letterSpacing: '-0.02em',
+        // Ring color via custom property pra hover
+        // @ts-expect-error CSS var inline
+        '--tw-ring-color': `hsl(var(${v.tokenVar}) / 0.4)`,
       }}
       aria-hidden
     >
@@ -47,9 +67,9 @@ export function CompanySwitcher() {
       <DropdownMenuTrigger asChild>
         <button
           type="button"
-          className="inline-flex items-center gap-2 h-8 px-2 rounded-md text-sm font-medium text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+          className="group inline-flex items-center gap-2 h-8 px-2 rounded-md text-sm font-medium text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
         >
-          <CompanyMonogram id={activeCompany} size={20} />
+          <CompanyMonogram id={activeCompany} size={20} withRingOnHover />
           <span className="hidden sm:inline">{companyInfo.shortName}</span>
           <ChevronsUpDown className="w-3 h-3 opacity-60" />
         </button>
@@ -67,7 +87,7 @@ export function CompanySwitcher() {
             <DropdownMenuItem
               key={id}
               onClick={() => setActiveCompany(id)}
-              className="flex items-center gap-3 py-2"
+              className="group flex items-center gap-3 py-2"
             >
               <CompanyMonogram id={id} size={28} />
               <div className="flex-1 min-w-0">

--- a/src/components/shell/CompanySwitcher.tsx
+++ b/src/components/shell/CompanySwitcher.tsx
@@ -1,4 +1,4 @@
-import { Building2, Check, ChevronsUpDown } from 'lucide-react';
+import { Check, ChevronsUpDown } from 'lucide-react';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -10,11 +10,34 @@ import {
 import { ALL_COMPANIES, COMPANIES, useCompany, type Company } from '@/contexts/CompanyContext';
 import { cn } from '@/lib/utils';
 
-const COMPANY_HINT: Record<Company, string> = {
-  colacor: 'Indústria',
-  oben: 'Distribuidora',
-  colacor_sc: 'Serviços',
+/**
+ * Cada empresa tem identidade visual mínima — monograma colorido em quadrado 20×20.
+ * Cores dessaturadas alinhadas à paleta low-fatigue (ver docs/visual-direction/04-identidade.md).
+ */
+const COMPANY_VISUAL: Record<Company, { letter: string; bg: string; hint: string }> = {
+  colacor:    { letter: 'C', bg: 'hsl(0 0% 9%)',       hint: 'Indústria' },
+  oben:       { letter: 'O', bg: 'hsl(212 80% 35%)',   hint: 'Distribuidora' },
+  colacor_sc: { letter: 'S', bg: 'hsl(142 50% 32%)',   hint: 'Serviços' },
 };
+
+function CompanyMonogram({ id, size = 20 }: { id: Company; size?: number }) {
+  const v = COMPANY_VISUAL[id];
+  return (
+    <div
+      className="rounded-md flex items-center justify-center font-semibold text-white shrink-0"
+      style={{
+        width: size,
+        height: size,
+        backgroundColor: v.bg,
+        fontSize: size <= 20 ? 11 : 13,
+        letterSpacing: '-0.02em',
+      }}
+      aria-hidden
+    >
+      {v.letter}
+    </div>
+  );
+}
 
 export function CompanySwitcher() {
   const { activeCompany, setActiveCompany, companyInfo } = useCompany();
@@ -24,35 +47,36 @@ export function CompanySwitcher() {
       <DropdownMenuTrigger asChild>
         <button
           type="button"
-          className="inline-flex items-center gap-2 h-8 px-2.5 rounded-md text-sm font-medium text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+          className="inline-flex items-center gap-2 h-8 px-2 rounded-md text-sm font-medium text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
         >
-          <Building2 className="w-3.5 h-3.5" />
+          <CompanyMonogram id={activeCompany} size={20} />
           <span className="hidden sm:inline">{companyInfo.shortName}</span>
           <ChevronsUpDown className="w-3 h-3 opacity-60" />
         </button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="w-56">
+      <DropdownMenuContent align="end" className="w-60">
         <DropdownMenuLabel className="text-xs text-muted-foreground font-normal">
           Empresa ativa
         </DropdownMenuLabel>
         <DropdownMenuSeparator />
         {ALL_COMPANIES.map((id) => {
           const info = COMPANIES[id];
+          const v = COMPANY_VISUAL[id];
           const active = id === activeCompany;
           return (
             <DropdownMenuItem
               key={id}
               onClick={() => setActiveCompany(id)}
-              className="flex items-center gap-2"
+              className="flex items-center gap-3 py-2"
             >
-              <Building2 className="w-4 h-4 text-muted-foreground" />
+              <CompanyMonogram id={id} size={28} />
               <div className="flex-1 min-w-0">
                 <div className="text-sm font-medium truncate">{info.shortName}</div>
                 <div className="text-[11px] text-muted-foreground truncate">
-                  {COMPANY_HINT[id]} · regime {info.regime}
+                  {v.hint} · regime {info.regime}
                 </div>
               </div>
-              <Check className={cn('w-4 h-4', active ? 'opacity-100 text-primary' : 'opacity-0')} />
+              <Check className={cn('w-4 h-4', active ? 'opacity-100 text-foreground' : 'opacity-0')} />
             </DropdownMenuItem>
           );
         })}

--- a/src/components/shell/NetworkStatusIndicator.tsx
+++ b/src/components/shell/NetworkStatusIndicator.tsx
@@ -6,11 +6,13 @@ import { cn } from '@/lib/utils';
 import { getOfflineQueueDepth, subscribeToOfflineQueue } from '@/lib/offline-queue';
 
 /**
- * Substitui o `Bell` ornamental do topbar antigo. Mostra:
- *  - Dot verde (online) / âmbar (lento) / vermelho (offline)
- *  - Hover: popover com RTT, tipo de conexão, # mutações na fila
+ * Indicador de rede com presença CONDICIONAL (Vercel/Linear pattern):
+ *  - Online + queue vazia: NÃO renderiza nada (limpa o topbar)
+ *  - Online + queue pendente: badge sutil com contador
+ *  - Slow: ícone Cloud + ring expanding pulsante
+ *  - Offline: ícone WifiOff + shake animation curta + estilo bold
  *
- * Quando o offline-queue (#20) registrar mutações pendentes, o badge vai mostrar count.
+ * Hover: popover com detalhes de RTT, tipo, fila.
  */
 export function NetworkStatusIndicator() {
   const status = useNetworkStatus();
@@ -28,12 +30,15 @@ export function NetworkStatusIndicator() {
     };
   }, []);
 
+  // Online + queue vazia = limpa visual (não renderiza nada)
+  if (status.quality === 'online' && queueDepth === 0) return null;
+
   const tone =
     status.quality === 'offline'
-      ? { dot: 'bg-status-error', label: 'Offline', icon: WifiOff, tint: 'text-status-error' }
+      ? { label: 'Offline', icon: WifiOff, tint: 'text-status-error-bold', ring: 'ring-status-error/20' }
       : status.quality === 'slow'
-        ? { dot: 'bg-status-warning', label: 'Conexão lenta', icon: Cloud, tint: 'text-status-warning' }
-        : { dot: 'bg-status-success', label: 'Online', icon: Wifi, tint: 'text-status-success' };
+        ? { label: 'Conexão lenta', icon: Cloud, tint: 'text-status-warning-bold', ring: 'ring-status-warning/20' }
+        : { label: 'Online · fila pendente', icon: Wifi, tint: 'text-status-info-bold', ring: 'ring-status-info/20' };
 
   const Icon = tone.icon;
 
@@ -42,19 +47,23 @@ export function NetworkStatusIndicator() {
       <PopoverTrigger asChild>
         <button
           type="button"
-          className="relative h-8 w-8 inline-flex items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+          className={cn(
+            'relative h-8 w-8 inline-flex items-center justify-center rounded-md hover:bg-muted transition-colors',
+            tone.tint,
+            status.quality === 'offline' && 'animate-shake',
+          )}
           aria-label={`Status da conexão: ${tone.label}`}
         >
-          <Icon className={cn('w-4 h-4', tone.tint)} />
-          <span
-            className={cn(
-              'absolute top-1.5 right-1.5 w-2 h-2 rounded-full ring-2 ring-card',
-              tone.dot,
-              status.quality === 'slow' && 'animate-pulse',
-            )}
-          />
+          <Icon className="w-4 h-4 relative z-10" />
+          {/* Pulse ring expanding pra slow + offline */}
+          {(status.quality === 'slow' || status.quality === 'offline') && (
+            <span className={cn(
+              'absolute inset-0 rounded-md ring-2 animate-ping-slow',
+              tone.ring,
+            )} />
+          )}
           {queueDepth > 0 && (
-            <span className="absolute -bottom-0.5 -right-0.5 min-w-4 h-4 px-1 rounded-full bg-primary text-primary-foreground text-[9px] font-bold flex items-center justify-center">
+            <span className="absolute -bottom-0.5 -right-0.5 min-w-4 h-4 px-1 rounded-full bg-primary text-primary-foreground text-[9px] font-bold flex items-center justify-center tabular-nums">
               {queueDepth > 99 ? '99+' : queueDepth}
             </span>
           )}

--- a/src/components/shell/ThemeToggle.tsx
+++ b/src/components/shell/ThemeToggle.tsx
@@ -7,33 +7,43 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import { cn } from '@/lib/utils';
 
 /**
  * Toggle de tema (light / dark / system) — montado no AppShell topbar.
  * Usa next-themes (já instalado). Persistência via localStorage automática.
+ *
+ * Morph animado: ícones Sun e Moon vivem sobrepostos; o ativo aparece com
+ * scale+rotate, o outro recolhe. Sem swap brusco. (Vercel-ish pattern.)
  */
 export function ThemeToggle() {
   const { theme, setTheme, resolvedTheme } = useTheme();
   const [mounted, setMounted] = useState(false);
 
-  // Evita flash de hydration (next-themes recommendation)
   useEffect(() => setMounted(true), []);
 
-  const current = resolvedTheme ?? 'light';
+  const isDark = mounted && resolvedTheme === 'dark';
 
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
         <button
           type="button"
-          className="h-8 w-8 inline-flex items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+          className="relative h-8 w-8 inline-flex items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
           aria-label="Alternar tema"
         >
-          {mounted && current === 'dark' ? (
-            <Moon className="w-4 h-4" />
-          ) : (
-            <Sun className="w-4 h-4" />
-          )}
+          <Sun
+            className={cn(
+              'absolute w-4 h-4 transition-all duration-300',
+              isDark ? 'opacity-0 scale-50 -rotate-90' : 'opacity-100 scale-100 rotate-0',
+            )}
+          />
+          <Moon
+            className={cn(
+              'absolute w-4 h-4 transition-all duration-300',
+              isDark ? 'opacity-100 scale-100 rotate-0' : 'opacity-0 scale-50 rotate-90',
+            )}
+          />
         </button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="w-36">

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,20 +5,24 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-1.5 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  // transition-all (não só colors) pra captar ring + shadow no hover/active.
+  // ease custom Vercel-style aplicado globalmente em button via index.css.
+  "inline-flex items-center justify-center gap-1.5 whitespace-nowrap rounded-md text-sm font-medium transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
   {
     variants: {
       variant: {
+        // Primary com ring sutil no hover (tactility) + inner shadow no active ("press feel")
         default:
-          "bg-primary text-primary-foreground shadow-sm hover:bg-primary/90 active:bg-primary/80",
+          "bg-primary text-primary-foreground shadow-sm hover:bg-primary/90 hover:ring-2 hover:ring-foreground/5 active:bg-primary/80 active:shadow-[inset_0_1px_0_hsl(0_0%_0%/0.08)]",
         destructive:
-          "bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90",
+          "bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90 hover:ring-2 hover:ring-destructive/15",
         outline:
-          "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+          "border border-input bg-background hover:bg-accent hover:text-accent-foreground hover:border-foreground/20",
         secondary:
           "bg-secondary text-secondary-foreground hover:bg-secondary/80",
         ghost: "hover:bg-accent hover:text-accent-foreground",
-        link: "text-primary underline-offset-4 hover:underline",
+        // Link com underline animado da esquerda pra direita (Vercel pattern)
+        link: "relative text-primary inline-block after:content-[''] after:absolute after:left-0 after:bottom-0 after:h-px after:w-0 after:bg-current after:transition-[width] after:duration-200 hover:after:w-full",
         muted: "bg-muted text-muted-foreground hover:bg-muted/80",
       },
       size: {

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,7 +1,19 @@
 import { cn } from "@/lib/utils";
 
+/**
+ * Skeleton com shimmer gradient (Vercel/Linear style) — substitui o pulse genérico.
+ * A utility .shimmer é definida em src/index.css (gradient horizontal animado).
+ */
 function Skeleton({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
-  return <div className={cn("animate-pulse rounded-md bg-muted", className)} {...props} />;
+  return (
+    <div
+      className={cn(
+        "rounded-md bg-muted overflow-hidden relative animate-shimmer",
+        className,
+      )}
+      {...props}
+    />
+  );
 }
 
 export { Skeleton };

--- a/src/hooks/useFeatureFlag.ts
+++ b/src/hooks/useFeatureFlag.ts
@@ -1,0 +1,70 @@
+import { useCallback, useEffect, useState } from 'react';
+
+/**
+ * Feature flags simples baseadas em localStorage. Permite rollback rápido sem deploy.
+ *
+ * Uso:
+ *   const [newVisualEnabled, toggle] = useFeatureFlag('newVisual', true);
+ *
+ * Padrões:
+ *   newVisual          — aplica novos tokens visuais (Vercel/Mercury direction)
+ *
+ * Cada flag tem default; quando o usuário toggla, é persistido em localStorage.
+ * O hook escuta mudanças entre abas via storage event.
+ */
+const STORAGE_PREFIX = 'feature_flag_';
+
+const DEFAULTS: Record<string, boolean> = {
+  newVisual: true, // Novo visual ativo por padrão (rollout completo)
+};
+
+function readFlag(name: string, fallback: boolean): boolean {
+  if (typeof window === 'undefined') return fallback;
+  const raw = window.localStorage.getItem(STORAGE_PREFIX + name);
+  if (raw === null) return fallback;
+  return raw === '1';
+}
+
+function writeFlag(name: string, value: boolean): void {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem(STORAGE_PREFIX + name, value ? '1' : '0');
+  // dispatch storage event manual pra notificar mesma aba
+  window.dispatchEvent(new StorageEvent('storage', { key: STORAGE_PREFIX + name, newValue: value ? '1' : '0' }));
+}
+
+export function useFeatureFlag(name: string, defaultValue?: boolean): [boolean, (next: boolean) => void] {
+  const fallback = defaultValue ?? DEFAULTS[name] ?? false;
+  const [enabled, setEnabled] = useState<boolean>(() => readFlag(name, fallback));
+
+  useEffect(() => {
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === STORAGE_PREFIX + name) {
+        setEnabled(readFlag(name, fallback));
+      }
+    };
+    window.addEventListener('storage', onStorage);
+    return () => window.removeEventListener('storage', onStorage);
+  }, [name, fallback]);
+
+  const toggle = useCallback((next: boolean) => {
+    writeFlag(name, next);
+    setEnabled(next);
+  }, [name]);
+
+  return [enabled, toggle];
+}
+
+/**
+ * Aplica/remove uma classe no <html> baseado no estado da flag.
+ * Útil pra ativar overrides CSS condicionais (ex: .legacy-visual revert tokens novos).
+ */
+export function useFeatureFlagBodyClass(name: string, className: string, invert = false): void {
+  const [enabled] = useFeatureFlag(name);
+  useEffect(() => {
+    const root = document.documentElement;
+    const shouldApply = invert ? !enabled : enabled;
+    if (shouldApply) root.classList.add(className);
+    else root.classList.remove(className);
+    return () => root.classList.remove(className);
+  }, [enabled, className, invert]);
+}

--- a/src/hooks/useSidebarFavorites.ts
+++ b/src/hooks/useSidebarFavorites.ts
@@ -1,0 +1,63 @@
+import { useCallback, useEffect, useState } from 'react';
+
+/**
+ * Favoritos pinados da sidebar — pattern Mercury "Pinned" / Linear "Favorites".
+ * Usuário fixa até 5 itens (rotas) que aparecem acima de todas as seções regulares.
+ *
+ * Persistência: localStorage por usuário (chave fixa por enquanto; pode evoluir
+ * pra incluir userId quando autenticação estiver tudo alinhada).
+ *
+ * v1: lista simples de paths. Sem reorder por drag (futuro).
+ */
+const STORAGE_KEY = 'sidebar_favorites_v1';
+const MAX_FAVORITES = 5;
+
+function read(): string[] {
+  if (typeof localStorage === 'undefined') return [];
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as string[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function write(paths: string[]): void {
+  if (typeof localStorage === 'undefined') return;
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(paths));
+  window.dispatchEvent(new StorageEvent('storage', { key: STORAGE_KEY, newValue: JSON.stringify(paths) }));
+}
+
+export function useSidebarFavorites() {
+  const [favorites, setFavorites] = useState<string[]>(() => read());
+
+  useEffect(() => {
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === STORAGE_KEY) setFavorites(read());
+    };
+    window.addEventListener('storage', onStorage);
+    return () => window.removeEventListener('storage', onStorage);
+  }, []);
+
+  const isFavorite = useCallback((path: string) => favorites.includes(path), [favorites]);
+
+  const toggle = useCallback((path: string) => {
+    setFavorites((prev) => {
+      const next = prev.includes(path)
+        ? prev.filter((p) => p !== path)
+        : prev.length >= MAX_FAVORITES
+          ? prev // limite atingido — silencioso (UI deve dar feedback)
+          : [...prev, path];
+      write(next);
+      return next;
+    });
+  }, []);
+
+  return {
+    favorites,
+    isFavorite,
+    toggle,
+    canAddMore: favorites.length < MAX_FAVORITES,
+    max: MAX_FAVORITES,
+  };
+}

--- a/src/index.css
+++ b/src/index.css
@@ -268,6 +268,12 @@
     transition-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
   }
 
+  /* ── Tabelas shadcn: tabular-nums automático em todas as células
+     (números alinham, valores R$ ficam comparáveis lendo verticalmente) ── */
+  table {
+    font-feature-settings: 'tnum';
+  }
+
   /* ── Caption / small text ── */
   .caption {
     @apply text-xs text-muted-foreground leading-tight;
@@ -278,6 +284,28 @@
 }
 
 @layer utilities {
+  /* ── Feature flag override: .legacy-visual reverte os tokens novos para os antigos ──
+     Aplicado no <html> via useFeatureFlagBodyClass quando newVisual=false em settings. */
+  html.legacy-visual {
+    --primary: 222 83% 53%;
+    --background: 220 14% 96%;
+    --muted: 220 14% 94%;
+    --muted-foreground: 220 10% 42%;
+    --border: 220 13% 87%;
+    --radius: 0.5rem;
+    --sidebar-background: 220 25% 11%;
+    --sidebar-foreground: 220 14% 80%;
+    --sidebar-primary: 222 83% 60%;
+    --sidebar-primary-foreground: 0 0% 100%;
+    --sidebar-accent: 220 20% 18%;
+    --sidebar-accent-foreground: 220 14% 96%;
+    --sidebar-border: 220 20% 18%;
+    --sidebar-muted: 220 14% 50%;
+  }
+  html.legacy-visual body {
+    font-family: 'Inter', system-ui, -apple-system, sans-serif;
+  }
+
   /* ── Surface utilities ── */
   .surface-0 { background-color: hsl(var(--surface-0)); }
   .surface-1 { background-color: hsl(var(--surface-1)); }

--- a/src/index.css
+++ b/src/index.css
@@ -36,11 +36,13 @@
 
 @layer base {
   :root {
-    /* ── Backgrounds — escala neutra warm-leaning ── */
-    --background: 0 0% 100%;             /* #FFFFFF */
+    /* ── Backgrounds — escala neutra warm-leaning
+       Background é off-white (0 0% 99%) em vez de branco puro pra remover frieza
+       e dar leve hierarquia natural com cards (que ficam #FFF puro = ligeiramente acima). ── */
+    --background: 0 0% 99%;              /* #FCFCFC — off-white quase imperceptível */
     --foreground: 0 0% 9%;               /* #171717 — preto suave */
 
-    --card: 0 0% 100%;
+    --card: 0 0% 100%;                   /* cards #FFF puro flutuam sutilmente sobre o bg */
     --card-foreground: 0 0% 9%;
 
     --popover: 0 0% 100%;
@@ -232,18 +234,23 @@
     letter-spacing: -0.005em;            /* sutil tightening Vercel-style */
   }
 
-  /* ── Typography scale — peso 600 (não 700) e tracking apertado em headings ── */
+  /* ── Typography scale — refinada pós-revisão skill frontend-design
+     h1/h2 em peso 500 + tracking -0.04em criam sensação "fina e premium"
+     (peso 600+ parece "corporativo"; peso 400- parece "aplicação web genérica").
+     h3/h4 mantêm peso 600 — em densidade alta o destaque ainda é necessário. ── */
   h1 {
-    @apply text-2xl tracking-tight;
-    font-weight: 600;
-    line-height: 1.15;
-    letter-spacing: -0.02em;
+    @apply tracking-tight;
+    font-size: 1.875rem;                 /* 30px — page title forte sem ser dramático */
+    font-weight: 500;
+    line-height: 1.1;
+    letter-spacing: -0.04em;
   }
   h2 {
-    @apply text-xl tracking-tight;
-    font-weight: 600;
-    line-height: 1.2;
-    letter-spacing: -0.02em;
+    @apply tracking-tight;
+    font-size: 1.375rem;                 /* 22px */
+    font-weight: 500;
+    line-height: 1.15;
+    letter-spacing: -0.03em;
   }
   h3 {
     @apply text-base;
@@ -354,6 +361,34 @@
     line-height: 1.1;
   }
 
+  /* ── Stagger reveal — pra page load orquestrado (Vercel/Mercury feel)
+     Uso: <div class="stagger-children">{children que pegam fade-in-up sequencial}</div>
+     Os filhos recebem animation-delay incremental via CSS variable --stagger-index automática
+     (até 12 filhos via :nth-child). Para >12 filhos, defina --stagger-index inline. ── */
+  .stagger-children > * {
+    animation: fade-in-up 350ms cubic-bezier(0.16, 1, 0.3, 1) both;
+    animation-delay: calc(var(--stagger-index, 0) * 50ms);
+  }
+  .stagger-children > *:nth-child(1)  { --stagger-index: 0; }
+  .stagger-children > *:nth-child(2)  { --stagger-index: 1; }
+  .stagger-children > *:nth-child(3)  { --stagger-index: 2; }
+  .stagger-children > *:nth-child(4)  { --stagger-index: 3; }
+  .stagger-children > *:nth-child(5)  { --stagger-index: 4; }
+  .stagger-children > *:nth-child(6)  { --stagger-index: 5; }
+  .stagger-children > *:nth-child(7)  { --stagger-index: 6; }
+  .stagger-children > *:nth-child(8)  { --stagger-index: 7; }
+  .stagger-children > *:nth-child(9)  { --stagger-index: 8; }
+  .stagger-children > *:nth-child(10) { --stagger-index: 9; }
+  .stagger-children > *:nth-child(11) { --stagger-index: 10; }
+  .stagger-children > *:nth-child(12) { --stagger-index: 11; }
+
+  /* Respeita prefers-reduced-motion */
+  @media (prefers-reduced-motion: reduce) {
+    .stagger-children > * {
+      animation: none;
+    }
+  }
+
   /* ── Status text utilities (semantic tokens — substitui text-emerald-600 etc.) ── */
   .text-status-success { color: hsl(var(--status-success)); }
   .text-status-warning { color: hsl(var(--status-warning)); }
@@ -424,6 +459,11 @@
 @keyframes fade-in {
   from { opacity: 0; }
   to { opacity: 1; }
+}
+
+@keyframes fade-in-up {
+  from { opacity: 0; transform: translateY(6px); }
+  to { opacity: 1; transform: translateY(0); }
 }
 
 @keyframes scale-in {

--- a/src/index.css
+++ b/src/index.css
@@ -86,6 +86,18 @@
     --status-info: 212 80% 50%;
     --status-info-foreground: 212 80% 32%;
     --status-info-bg: 212 80% 96%;
+
+    /* ── Status BOLD — vibração maior pra acentos curtos
+       (badge "Live", dot indicator, micro-celebration). NÃO usar em texto longo. ── */
+    --status-success-bold: 142 70% 42%;
+    --status-warning-bold: 32 95% 50%;
+    --status-error-bold: 0 78% 52%;
+    --status-info-bold: 212 90% 55%;
+
+    /* ── Identidade por empresa — monogramas + acentos sutis no UI ── */
+    --company-colacor: 0 0% 9%;          /* preto industrial */
+    --company-oben: 212 80% 35%;         /* azul distribuidor */
+    --company-sc: 142 50% 32%;           /* verde serviços */
     --status-pending: 35 80% 45%;
     --status-progress: 212 80% 50%;
     --status-danger: 0 65% 48%;
@@ -178,6 +190,17 @@
     --status-info: 212 80% 65%;
     --status-info-foreground: 212 80% 85%;
     --status-info-bg: 212 50% 12%;
+
+    /* status BOLD pra acento (dark) */
+    --status-success-bold: 142 70% 60%;
+    --status-warning-bold: 32 95% 65%;
+    --status-error-bold: 0 78% 65%;
+    --status-info-bold: 212 90% 70%;
+
+    /* identidade por empresa (dark — monograma fica mais brilhante) */
+    --company-colacor: 0 0% 95%;
+    --company-oben: 212 80% 60%;
+    --company-sc: 142 50% 55%;
     --status-pending: 35 80% 60%;
     --status-progress: 212 80% 65%;
     --status-danger: 0 70% 60%;
@@ -361,6 +384,64 @@
     line-height: 1.1;
   }
 
+  /* ── KPI delta — texto pequeno ao lado do valor ("R$ 1.2M ↑12%") ── */
+  .kpi-delta {
+    font-family: 'Geist Mono', 'JetBrains Mono', monospace;
+    font-feature-settings: 'tnum';
+    font-size: 0.6875rem;                /* 11px */
+    font-weight: 500;
+    letter-spacing: -0.01em;
+    vertical-align: middle;
+    margin-left: 0.375rem;
+  }
+
+  /* ── Mono tabular pra IDs, datas, CNPJs, códigos —
+     identifica visualmente "este é um valor preciso, não descrição" ── */
+  .font-tabular {
+    font-family: 'Geist Mono', 'JetBrains Mono', monospace;
+    font-feature-settings: 'tnum';
+    letter-spacing: -0.01em;
+  }
+
+  /* ── Atmosphere pra hero de cockpits — gradient radial sutil
+     (Mercury/Stripe Dashboard pattern, NÃO Bootstrap-style hero gigante) ── */
+  .bg-cockpit-hero {
+    background-image: radial-gradient(
+      ellipse 80% 60% at 50% -10%,
+      hsl(var(--muted)) 0%,
+      transparent 60%
+    );
+  }
+
+  /* ── Noise grain texture — atmosphere via SVG inline (3% opacity)
+     Aplicar em hero KPIs pra dar "tactility" sem custo de imagem ── */
+  .noise {
+    position: relative;
+  }
+  .noise::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    opacity: 0.025;
+    background-image: url("data:image/svg+xml;utf8,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' /%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' /%3E%3C/svg%3E");
+    mix-blend-mode: multiply;
+  }
+  .dark .noise::before {
+    opacity: 0.04;
+    mix-blend-mode: screen;
+  }
+
+  /* ── Status colors BOLD — uso restrito a acentos (badge "Pago", dot "Live") ── */
+  .text-status-success-bold { color: hsl(var(--status-success-bold)); }
+  .text-status-warning-bold { color: hsl(var(--status-warning-bold)); }
+  .text-status-error-bold   { color: hsl(var(--status-error-bold)); }
+  .text-status-info-bold    { color: hsl(var(--status-info-bold)); }
+  .bg-status-success-bold   { background-color: hsl(var(--status-success-bold)); }
+  .bg-status-warning-bold   { background-color: hsl(var(--status-warning-bold)); }
+  .bg-status-error-bold     { background-color: hsl(var(--status-error-bold)); }
+  .bg-status-info-bold      { background-color: hsl(var(--status-info-bold)); }
+
   /* ── Stagger reveal — pra page load orquestrado (Vercel/Mercury feel)
      Uso: <div class="stagger-children">{children que pegam fade-in-up sequencial}</div>
      Os filhos recebem animation-delay incremental via CSS variable --stagger-index automática
@@ -466,6 +547,17 @@
   to { opacity: 1; transform: translateY(0); }
 }
 
+@keyframes shake {
+  0%, 100% { transform: translateX(0); }
+  10%, 30%, 50%, 70%, 90% { transform: translateX(-1px); }
+  20%, 40%, 60%, 80% { transform: translateX(1px); }
+}
+
+@keyframes ping-slow {
+  0% { transform: scale(1); opacity: 0.6; }
+  100% { transform: scale(1.4); opacity: 0; }
+}
+
 @keyframes scale-in {
   from { opacity: 0; transform: scale(0.96); }
   to { opacity: 1; transform: scale(1); }
@@ -499,4 +591,12 @@
   background: linear-gradient(90deg, transparent 25%, hsl(var(--muted) / 0.5) 50%, transparent 75%);
   background-size: 200% 100%;
   animation: shimmer 1.5s infinite;
+}
+
+.animate-shake {
+  animation: shake 600ms cubic-bezier(0.36, 0.07, 0.19, 0.97) 1;
+}
+
+.animate-ping-slow {
+  animation: ping-slow 1.8s cubic-bezier(0, 0, 0.2, 1) infinite;
 }

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -174,38 +174,38 @@ const Admin = () => {
           
           <Button 
             variant="outline" 
-            className="w-full justify-between border-amber-300 bg-amber-50 hover:bg-amber-100"
+            className="w-full justify-between border-status-warning/30 bg-status-warning-bg hover:bg-status-warning-bg"
             onClick={() => navigate('/admin/demand-forecast')}
           >
             <div className="flex items-center gap-2">
-              <Clock className="w-4 h-4 text-amber-600" />
-              <span className="text-amber-900">Previsão de Demanda</span>
+              <Clock className="w-4 h-4 text-status-warning" />
+              <span className="text-status-warning-fg">Previsão de Demanda</span>
             </div>
-            <ChevronRight className="w-4 h-4 text-amber-600" />
+            <ChevronRight className="w-4 h-4 text-status-warning" />
           </Button>
           
           <Button 
             variant="outline" 
-            className="w-full justify-between border-emerald-300 bg-emerald-50 hover:bg-emerald-100"
+            className="w-full justify-between border-status-success/30 bg-status-success-bg hover:bg-status-success-bg"
             onClick={() => navigate('/admin/route-planner')}
           >
             <div className="flex items-center gap-2">
-              <MapPin className="w-4 h-4 text-emerald-600" />
-              <span className="text-emerald-900">Roteirizador</span>
+              <MapPin className="w-4 h-4 text-status-success" />
+              <span className="text-status-success-fg">Roteirizador</span>
             </div>
-            <ChevronRight className="w-4 h-4 text-emerald-600" />
+            <ChevronRight className="w-4 h-4 text-status-success" />
           </Button>
           
           <Button 
             variant="outline" 
-            className="w-full justify-between border-blue-300 bg-blue-50 hover:bg-blue-100"
+            className="w-full justify-between border-status-info/30 bg-status-info-bg hover:bg-status-info-bg"
             onClick={() => navigate('/admin/monthly-reports')}
           >
             <div className="flex items-center gap-2">
-              <Mail className="w-4 h-4 text-blue-600" />
-              <span className="text-blue-900">Relatório Mensal</span>
+              <Mail className="w-4 h-4 text-status-info" />
+              <span className="text-status-info-fg">Relatório Mensal</span>
             </div>
-            <ChevronRight className="w-4 h-4 text-blue-600" />
+            <ChevronRight className="w-4 h-4 text-status-info" />
           </Button>
           
           <Button 
@@ -304,7 +304,7 @@ const Admin = () => {
           </Card>
           <Card className="text-center">
             <CardContent className="pt-4 pb-3">
-              <p className="text-2xl font-bold text-amber-600">
+              <p className="text-2xl font-bold text-status-warning">
                 {orders.filter(o => !['entregue'].includes(o.status)).length}
               </p>
               <p className="text-xs text-muted-foreground">Pendentes</p>
@@ -312,7 +312,7 @@ const Admin = () => {
           </Card>
           <Card className="text-center">
             <CardContent className="pt-4 pb-3">
-              <p className="text-2xl font-bold text-emerald-600">
+              <p className="text-2xl font-bold text-status-success">
                 {orders.filter(o => o.status === 'entregue').length}
               </p>
               <p className="text-xs text-muted-foreground">Entregues</p>

--- a/src/pages/AdminEstoquePicking.tsx
+++ b/src/pages/AdminEstoquePicking.tsx
@@ -286,10 +286,10 @@ function PickingTab({ account }: { account: string }) {
                       )}
                     </Button>
                   </TableCell>
-                  <TableCell className="font-mono text-xs">{truncate(t.id)}</TableCell>
-                  <TableCell className="font-mono text-xs">{truncate(t.sales_order_id)}</TableCell>
+                  <TableCell className="font-tabular text-xs">{truncate(t.id)}</TableCell>
+                  <TableCell className="font-tabular text-xs">{truncate(t.sales_order_id)}</TableCell>
                   <TableCell><StatusBadge status={t.status} /></TableCell>
-                  <TableCell className="font-mono text-xs">{truncate(t.assigned_to)}</TableCell>
+                  <TableCell className="font-tabular text-xs">{truncate(t.assigned_to)}</TableCell>
                   <TableCell className="text-xs">{fmtDate(t.created_at)}</TableCell>
                 </TableRow>
                 {expanded === t.id && (
@@ -318,8 +318,8 @@ function PickingTab({ account }: { account: string }) {
                                 <TableCell className="text-right text-xs">{it.quantidade}</TableCell>
                                 <TableCell className="text-right text-xs">{it.quantidade_separada ?? 0}</TableCell>
                                 <TableCell><StatusBadge status={it.status} /></TableCell>
-                                <TableCell className="font-mono text-xs">{it.lote_fefo ?? "—"}</TableCell>
-                                <TableCell className="font-mono text-xs">
+                                <TableCell className="font-tabular text-xs">{it.lote_fefo ?? "—"}</TableCell>
+                                <TableCell className="font-tabular text-xs">
                                   {it.lote_separado ? (
                                     <span className={it.lote_separado !== it.lote_fefo ? "text-warning" : ""}>
                                       {it.lote_separado}
@@ -406,7 +406,7 @@ function EstoqueTab({ account }: { account: string }) {
               )}
               {filtered.map((r: any) => (
                 <TableRow key={r.omie_codigo_produto}>
-                  <TableCell className="font-mono text-xs">{r.omie_codigo_produto}</TableCell>
+                  <TableCell className="font-tabular text-xs">{r.omie_codigo_produto}</TableCell>
                   <TableCell className="text-right">
                     {Number(r.saldo) <= 0 ? (
                       <Badge variant="outline" className="bg-destructive/15 text-destructive border-destructive/40">
@@ -475,9 +475,9 @@ function MovimentacoesTab() {
             {(data ?? []).map((e: any) => (
               <TableRow key={e.id}>
                 <TableCell className="text-xs"><Badge variant="outline">{e.event_type}</Badge></TableCell>
-                <TableCell className="font-mono text-xs">{truncate(e.picking_task_id)}</TableCell>
-                <TableCell className="font-mono text-xs">{e.lote_esperado ?? "—"}</TableCell>
-                <TableCell className="font-mono text-xs">
+                <TableCell className="font-tabular text-xs">{truncate(e.picking_task_id)}</TableCell>
+                <TableCell className="font-tabular text-xs">{e.lote_esperado ?? "—"}</TableCell>
+                <TableCell className="font-tabular text-xs">
                   {e.lote_informado ? (
                     <span className={e.lote_esperado && e.lote_informado !== e.lote_esperado ? "text-warning" : ""}>
                       {e.lote_informado}
@@ -557,8 +557,8 @@ function AuditoriaTab({ account }: { account: string }) {
             )}
             {(data ?? []).map((t: any) => (
               <TableRow key={t.id}>
-                <TableCell className="font-mono text-xs">{truncate(t.id)}</TableCell>
-                <TableCell className="font-mono text-xs">{truncate(t.sales_order_id)}</TableCell>
+                <TableCell className="font-tabular text-xs">{truncate(t.id)}</TableCell>
+                <TableCell className="font-tabular text-xs">{truncate(t.sales_order_id)}</TableCell>
                 <TableCell className="text-xs">{fmtDate(t.completed_at)}</TableCell>
                 <TableCell className="text-right">
                   {t.divergencias > 0 ? (

--- a/src/pages/AdminReposicaoCockpit.tsx
+++ b/src/pages/AdminReposicaoCockpit.tsx
@@ -2054,17 +2054,22 @@ export default function AdminReposicaoCockpit() {
 
   return (
     <div className="container mx-auto p-4 sm:p-6 space-y-6 max-w-7xl pb-24">
-      <header className="flex items-center justify-between gap-3 flex-wrap">
-        <div className="flex items-center gap-3">
-          <Sparkles className="h-6 w-6 text-primary" />
+      <header className="relative bg-cockpit-hero noise rounded-lg border border-border px-6 py-7 flex items-center justify-between gap-3 flex-wrap overflow-hidden">
+        <div className="relative flex items-center gap-3">
+          <Sparkles className="h-6 w-6 text-foreground/70" />
           <div>
-            <h1 className="text-2xl font-bold">Cockpit de Reposição</h1>
-            <p className="text-sm text-muted-foreground">
-              Todo o ciclo diário de compras em uma única tela
+            <p className="text-[10px] uppercase tracking-[0.18em] text-muted-foreground font-medium mb-1">
+              Reposição · Cockpit de compras
+            </p>
+            <h1 className="font-display" style={{ fontSize: '2rem', fontWeight: 500, letterSpacing: '-0.04em', lineHeight: 1.1 }}>
+              Ciclo diário
+            </h1>
+            <p className="text-sm text-muted-foreground mt-1">
+              Todo o pipeline de compras em uma única tela.
             </p>
           </div>
         </div>
-        <div className="flex items-center gap-2">
+        <div className="relative flex items-center gap-2">
           <Button
             size="sm"
             variant="ghost"

--- a/src/pages/AdminReposicaoNegociacaoParalela.tsx
+++ b/src/pages/AdminReposicaoNegociacaoParalela.tsx
@@ -158,9 +158,9 @@ function formatDateBR(d: string | null | undefined): string {
 function categoriaBadgeClass(cat: Categoria | null | undefined): string {
   switch (cat) {
     case "prioritario":
-      return "bg-amber-500/15 text-amber-700 dark:text-amber-400 border-amber-500/30";
+      return "bg-status-warning-bg0/15 text-status-warning border-status-warning/30";
     case "forte":
-      return "bg-blue-500/15 text-blue-700 dark:text-blue-400 border-blue-500/30";
+      return "bg-status-info-bg0/15 text-status-info border-status-info/30";
     case "moderado":
       return "bg-muted text-muted-foreground border-border";
     case "fraco":
@@ -177,9 +177,9 @@ function categoriaLabel(cat: Categoria | null | undefined): string {
 function statusBadgeClass(status: StatusSugestao): string {
   switch (status) {
     case "nova":
-      return "bg-emerald-500/15 text-emerald-700 dark:text-emerald-400 border-emerald-500/30";
+      return "bg-status-success-bg0/15 text-status-success border-status-success/30";
     case "visualizada":
-      return "bg-blue-500/15 text-blue-700 dark:text-blue-400 border-blue-500/30";
+      return "bg-status-info-bg0/15 text-status-info border-status-info/30";
     case "acao_tomada":
       return "bg-orange-500/15 text-orange-700 dark:text-orange-400 border-orange-500/30";
     default:
@@ -208,8 +208,8 @@ function statusLabel(status: StatusSugestao): string {
 
 function percPromoBadgeClass(p: number | null | undefined): string {
   const v = Number(p ?? 0);
-  if (v === 0) return "bg-emerald-500/15 text-emerald-700 dark:text-emerald-400 border-emerald-500/30";
-  if (v <= 30) return "bg-amber-500/15 text-amber-700 dark:text-amber-400 border-amber-500/30";
+  if (v === 0) return "bg-status-success-bg0/15 text-status-success border-status-success/30";
+  if (v <= 30) return "bg-status-warning-bg0/15 text-status-warning border-status-warning/30";
   return "bg-destructive/15 text-destructive border-destructive/30";
 }
 
@@ -649,7 +649,7 @@ export default function AdminReposicaoNegociacaoParalela() {
             </DropdownMenu>
             <Button
               size="sm"
-              className="ml-auto bg-emerald-600 hover:bg-emerald-700 text-white"
+              className="ml-auto bg-status-success hover:bg-status-success/90 text-white"
               onClick={() => openConvertDialog(s)}
             >
               <Handshake className="h-3.5 w-3.5 mr-1.5" />
@@ -686,9 +686,9 @@ export default function AdminReposicaoNegociacaoParalela() {
       </div>
 
       {/* Card explicativo */}
-      <Card className="border-blue-500/30 bg-blue-500/5">
+      <Card className="border-status-info/30 bg-status-info-bg0/5">
         <CardContent className="flex items-start gap-3 py-4">
-          <Info className="h-5 w-5 text-blue-600 dark:text-blue-400 mt-0.5 shrink-0" />
+          <Info className="h-5 w-5 text-status-info dark:text-status-info mt-0.5 shrink-0" />
           <p className="text-sm text-foreground/90 leading-relaxed">
             O sistema analisa seu histórico de compras e identifica SKUs candidatos a negociar descontos
             flat condicionais com a Sayerlack. Sugestões são geradas automaticamente; você decide quais

--- a/src/pages/AdminReposicaoOportunidades.tsx
+++ b/src/pages/AdminReposicaoOportunidades.tsx
@@ -176,13 +176,13 @@ function diasEntre(dateStr: string | null | undefined): number | null {
 function cenarioIcon(cenario: Cenario) {
   switch (cenario) {
     case "promo_flat":
-      return <Sparkles className="h-4 w-4 text-amber-500" />;
+      return <Sparkles className="h-4 w-4 text-status-warning" />;
     case "promo_volume":
-      return <Package className="h-4 w-4 text-blue-500" />;
+      return <Package className="h-4 w-4 text-status-info" />;
     case "promo_e_aumento":
       return <Zap className="h-4 w-4 text-purple-500" />;
     case "aumento_apenas":
-      return <TrendingUp className="h-4 w-4 text-red-500" />;
+      return <TrendingUp className="h-4 w-4 text-status-error" />;
   }
 }
 
@@ -192,16 +192,16 @@ function cenarioLabel(cenario: Cenario): string {
 
 function descontoBadgeClass(p: number | null | undefined): string {
   const v = Number(p ?? 0);
-  if (v >= 15) return "bg-emerald-500/15 text-emerald-700 dark:text-emerald-400 border-emerald-500/30";
-  if (v >= 7) return "bg-blue-500/15 text-blue-700 dark:text-blue-400 border-blue-500/30";
-  if (v > 0) return "bg-amber-500/15 text-amber-700 dark:text-amber-400 border-amber-500/30";
+  if (v >= 15) return "bg-status-success-bg0/15 text-status-success border-status-success/30";
+  if (v >= 7) return "bg-status-info-bg0/15 text-status-info border-status-info/30";
+  if (v > 0) return "bg-status-warning-bg0/15 text-status-warning border-status-warning/30";
   return "bg-muted text-muted-foreground border-border";
 }
 
 function diasBadge(dias: number | null | undefined) {
   const d = dias ?? 999;
   if (d < 3) return "bg-destructive/15 text-destructive border-destructive/30";
-  if (d < 7) return "bg-amber-500/15 text-amber-700 dark:text-amber-400 border-amber-500/30";
+  if (d < 7) return "bg-status-warning-bg0/15 text-status-warning border-status-warning/30";
   return "bg-muted text-muted-foreground border-border";
 }
 
@@ -445,9 +445,9 @@ export default function AdminReposicaoOportunidades() {
         </header>
 
         {!bannerNegociacaoFechado && negociacaoNovasCount > 0 && (
-          <div className="flex items-center justify-between gap-3 rounded-lg border border-blue-500/30 bg-blue-500/10 px-4 py-3 text-sm">
+          <div className="flex items-center justify-between gap-3 rounded-lg border border-status-info/30 bg-status-info/10 px-4 py-3 text-sm">
             <div className="flex items-center gap-2 flex-1">
-              <Handshake className="h-4 w-4 text-blue-600 dark:text-blue-400 shrink-0" />
+              <Handshake className="h-4 w-4 text-status-info dark:text-status-info shrink-0" />
               <span>
                 <strong>{negociacaoNovasCount}</strong> SKU{negociacaoNovasCount === 1 ? '' : 's'}{' '}
                 {negociacaoNovasCount === 1 ? 'foi sugerido' : 'foram sugeridos'} para negociação paralela.
@@ -502,7 +502,7 @@ export default function AdminReposicaoOportunidades() {
               </CardTitle>
             </CardHeader>
             <CardContent>
-              <div className="text-2xl font-bold text-emerald-600 dark:text-emerald-400 tabular-nums">
+              <div className="text-2xl font-bold text-status-success tabular-nums">
                 {formatBRL(totalEconomia)}
               </div>
               <p className="text-xs text-muted-foreground mt-1">
@@ -569,7 +569,7 @@ export default function AdminReposicaoOportunidades() {
               {cicloHoje > 0 ? (
                 <>
                   <Badge
-                    className="bg-emerald-500/15 text-emerald-700 dark:text-emerald-400 border-emerald-500/30 cursor-pointer hover:bg-emerald-500/25"
+                    className="bg-status-success-bg0/15 text-status-success border-status-success/30 cursor-pointer hover:bg-status-success-bg0/25"
                     variant="outline"
                     onClick={() => setConfirmCicloOpen(true)}
                   >
@@ -771,7 +771,7 @@ export default function AdminReposicaoOportunidades() {
                         <TableCell
                           className={`text-right tabular-nums font-medium ${
                             Number(o.economia_bruta_estimada ?? 0) > 0
-                              ? "text-emerald-600 dark:text-emerald-400"
+                              ? "text-status-success"
                               : "text-muted-foreground"
                           }`}
                         >
@@ -839,7 +839,7 @@ export default function AdminReposicaoOportunidades() {
                 Vai gerar pedidos de oportunidade para{" "}
                 <strong>{oportunidades.length} SKUs</strong>, com economia total
                 estimada de{" "}
-                <strong className="text-emerald-600 dark:text-emerald-400">
+                <strong className="text-status-success">
                   {formatBRL(totalEconomia)}
                 </strong>
                 . Continuar?
@@ -947,10 +947,10 @@ function DrawerConteudo({
 
         {/* Promoção */}
         {incluiPromo && o.campanha_id && (
-          <Card className="border-amber-500/30 bg-amber-500/5">
+          <Card className="border-status-warning/30 bg-status-warning-bg0/5">
             <CardHeader className="pb-2">
               <CardTitle className="text-sm flex items-center gap-2">
-                <Sparkles className="h-4 w-4 text-amber-500" />
+                <Sparkles className="h-4 w-4 text-status-warning" />
                 Promoção ativa
               </CardTitle>
             </CardHeader>
@@ -990,10 +990,10 @@ function DrawerConteudo({
 
         {/* Aumentos */}
         {incluiAumento && aumentos.length > 0 && (
-          <Card className="border-red-500/30 bg-red-500/5">
+          <Card className="border-status-error/30 bg-status-error-bg0/5">
             <CardHeader className="pb-2">
               <CardTitle className="text-sm flex items-center gap-2">
-                <TrendingUp className="h-4 w-4 text-red-500" />
+                <TrendingUp className="h-4 w-4 text-status-error" />
                 {aumentos.length === 1
                   ? "Aumento afetando este SKU"
                   : `${aumentos.length} aumentos afetando este SKU`}
@@ -1018,7 +1018,7 @@ function DrawerConteudo({
                   {typeof a.aumento_perc === "number" && (
                     <div className="flex justify-between">
                       <span className="text-muted-foreground">% aumento</span>
-                      <span className="font-medium tabular-nums text-red-600 dark:text-red-400">
+                      <span className="font-medium tabular-nums text-status-error">
                         +{formatNumber(a.aumento_perc, 2)}%
                       </span>
                     </div>
@@ -1039,7 +1039,7 @@ function DrawerConteudo({
         )}
 
         {/* Cálculo */}
-        <Card className="border-emerald-500/30 bg-emerald-500/5">
+        <Card className="border-status-success/30 bg-status-success-bg0/5">
           <CardHeader className="pb-2">
             <CardTitle className="text-sm">Cálculo da economia</CardTitle>
           </CardHeader>
@@ -1054,7 +1054,7 @@ function DrawerConteudo({
             você captura{" "}
             <strong>{formatNumber(o.desconto_total_perc, 2)}%</strong> de
             benefício total, economizando{" "}
-            <strong className="text-emerald-700 dark:text-emerald-400">
+            <strong className="text-status-success">
               {formatBRL(o.economia_bruta_estimada)}
             </strong>{" "}
             bruto.

--- a/src/pages/AdminReposicaoPedidos.tsx
+++ b/src/pages/AdminReposicaoPedidos.tsx
@@ -115,18 +115,18 @@ interface PedidoItem {
 }
 
 function getEstoqueZoneClass(estoque: number, minimo: number, pp: number): string {
-  if (estoque < minimo) return 'text-red-600 dark:text-red-400 font-semibold';
-  if (estoque <= pp) return 'text-amber-600 dark:text-amber-400 font-semibold';
-  return 'text-emerald-600 dark:text-emerald-400';
+  if (estoque < minimo) return 'text-status-error font-semibold';
+  if (estoque <= pp) return 'text-status-warning font-semibold';
+  return 'text-status-success';
 }
 
 const EMPRESA = 'OBEN';
 
 const statusMeta: Record<string, { label: string; variant: 'default' | 'secondary' | 'destructive' | 'outline'; className?: string }> = {
-  pendente_aprovacao: { label: 'Pendente', variant: 'secondary', className: 'bg-amber-500/15 text-amber-700 dark:text-amber-400 border-amber-500/30' },
-  aprovado_aguardando_disparo: { label: 'Aprovado', variant: 'secondary', className: 'bg-blue-500/15 text-blue-700 dark:text-blue-400 border-blue-500/30' },
+  pendente_aprovacao: { label: 'Pendente', variant: 'secondary', className: 'bg-status-warning-bg0/15 text-status-warning border-status-warning/30' },
+  aprovado_aguardando_disparo: { label: 'Aprovado', variant: 'secondary', className: 'bg-status-info-bg0/15 text-status-info border-status-info/30' },
   bloqueado_guardrail: { label: 'Bloqueado', variant: 'destructive' },
-  disparado: { label: 'Disparado', variant: 'secondary', className: 'bg-emerald-500/15 text-emerald-700 dark:text-emerald-400 border-emerald-500/30' },
+  disparado: { label: 'Disparado', variant: 'secondary', className: 'bg-status-success-bg0/15 text-status-success border-status-success/30' },
   cancelado: { label: 'Cancelado', variant: 'outline' },
   cancelado_humano: { label: 'Cancelado (vazio)', variant: 'outline' },
   expirado_sem_aprovacao: { label: 'Expirado sem aprovação', variant: 'secondary', className: 'bg-muted text-muted-foreground border-border' },
@@ -157,9 +157,9 @@ function StatusBadge({ status }: { status: Status }) {
 /* ─── Portal B2B Badge + Drawer ─── */
 const portalStatusMeta: Record<StatusEnvioPortal, { label: string; className: string }> = {
   nao_aplicavel: { label: '—', className: 'bg-muted text-muted-foreground border-border' },
-  pendente_envio_portal: { label: 'Aguardando envio', className: 'bg-blue-500/15 text-blue-700 dark:text-blue-400 border-blue-500/30' },
-  enviando_portal: { label: 'Enviando…', className: 'bg-blue-500/20 text-blue-700 dark:text-blue-400 border-blue-500/40 animate-pulse' },
-  enviado_portal: { label: '✓ Enviado', className: 'bg-emerald-500/15 text-emerald-700 dark:text-emerald-400 border-emerald-500/30' },
+  pendente_envio_portal: { label: 'Aguardando envio', className: 'bg-status-info-bg0/15 text-status-info border-status-info/30' },
+  enviando_portal: { label: 'Enviando…', className: 'bg-status-info-bg0/20 text-status-info border-status-info/40 animate-pulse' },
+  enviado_portal: { label: '✓ Enviado', className: 'bg-status-success-bg0/15 text-status-success border-status-success/30' },
   falha_envio_portal: { label: 'Falha', className: 'bg-destructive/15 text-destructive border-destructive/30' },
 };
 
@@ -247,7 +247,7 @@ function PortalDrawer({
   const status = (pedido.status_envio_portal ?? 'nao_aplicavel') as StatusEnvioPortal;
   const tentativas = pedido.portal_tentativas ?? 0;
   const tentativasColor =
-    tentativas <= 1 ? 'text-emerald-600' : tentativas === 2 ? 'text-amber-600' : 'text-destructive';
+    tentativas <= 1 ? 'text-status-success' : tentativas === 2 ? 'text-status-warning' : 'text-destructive';
 
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
@@ -370,7 +370,7 @@ function CycleIndicator({ now }: { now: Date }) {
 
   if (minutes < overrideUntil) {
     return (
-      <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-md bg-emerald-500/15 text-emerald-700 dark:text-emerald-400 border border-emerald-500/30 text-sm">
+      <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-md bg-status-success-bg0/15 text-status-success border border-status-success/30 text-sm">
         <Clock className="w-4 h-4" />
         Janela de override aberta até 09:30
       </div>
@@ -378,7 +378,7 @@ function CycleIndicator({ now }: { now: Date }) {
   }
   if (minutes < cutoff) {
     return (
-      <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-md bg-amber-500/15 text-amber-700 dark:text-amber-400 border border-amber-500/30 text-sm">
+      <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-md bg-status-warning-bg0/15 text-status-warning border border-status-warning/30 text-sm">
         <PlayCircle className="w-4 h-4" />
         Disparando em breve
       </div>
@@ -466,8 +466,8 @@ function HistoricoAcoesPanel({ pedido }: { pedido: PedidoSugerido | null }) {
   };
   const dotCls: Record<Evt['tone'], string> = {
     default: 'bg-muted-foreground',
-    success: 'bg-emerald-500',
-    warn: 'bg-amber-500',
+    success: 'bg-status-success-bg0',
+    warn: 'bg-status-warning-bg0',
     danger: 'bg-destructive',
   };
   return (
@@ -933,7 +933,7 @@ function DetalhesModal({
                     ) : (
                       <span className={cn(
                         "tabular-nums",
-                        l._qtd !== sugerida && "font-semibold text-amber-700 dark:text-amber-400",
+                        l._qtd !== sugerida && "font-semibold text-status-warning",
                       )}>{l._qtd.toFixed(0)}</span>
                     )}
                   </TableCell>
@@ -1169,7 +1169,7 @@ function PedidoRow({
       <TableCell className="text-right tabular-nums font-medium">{formatBRL(p.valor_total)}</TableCell>
       <TableCell className="text-right tabular-nums">
         {p.delta_vs_anterior_perc !== null ? (
-          <span className={Number(p.delta_vs_anterior_perc) >= 0 ? 'text-emerald-600' : 'text-destructive'}>
+          <span className={Number(p.delta_vs_anterior_perc) >= 0 ? 'text-status-success' : 'text-destructive'}>
             {Number(p.delta_vs_anterior_perc) >= 0 ? '+' : ''}{Number(p.delta_vs_anterior_perc).toFixed(1)}%
           </span>
         ) : <span className="text-muted-foreground">—</span>}
@@ -1503,7 +1503,7 @@ function CiclosAnteriores({ data, onChange }: { data: string; onChange: (v: stri
                   <TableCell className="text-right tabular-nums">{h.fornecedores}</TableCell>
                   <TableCell className="text-right tabular-nums">{h.pedidos}</TableCell>
                   <TableCell className="text-right tabular-nums">{formatBRL(h.valor)}</TableCell>
-                  <TableCell className="text-right tabular-nums text-emerald-600">{h.disparados}</TableCell>
+                  <TableCell className="text-right tabular-nums text-status-success">{h.disparados}</TableCell>
                   <TableCell className="text-right tabular-nums text-muted-foreground">{h.cancelados}</TableCell>
                 </TableRow>
               ))}

--- a/src/pages/AdminReposicaoPromocaoDetail.tsx
+++ b/src/pages/AdminReposicaoPromocaoDetail.tsx
@@ -172,11 +172,11 @@ function tipoEventoIcon(tipo: string) {
 function estadoBadgeClass(estado: string): string {
   switch (estado) {
     case "rascunho":
-      return "bg-amber-500/15 text-amber-700 dark:text-amber-400 border-amber-500/30";
+      return "bg-status-warning-bg0/15 text-status-warning border-status-warning/30";
     case "negociando":
-      return "bg-blue-500/15 text-blue-700 dark:text-blue-400 border-blue-500/30";
+      return "bg-status-info-bg0/15 text-status-info border-status-info/30";
     case "ativa":
-      return "bg-emerald-500/15 text-emerald-700 dark:text-emerald-400 border-emerald-500/30";
+      return "bg-status-success-bg0/15 text-status-success border-status-success/30";
     case "encerrada":
       return "bg-muted text-muted-foreground border-border";
     case "cancelada":
@@ -197,11 +197,11 @@ const ESTADO_LABEL: Record<string, string> = {
 function confiancaBadge(c: number | null) {
   if (c === null || c === undefined) return null;
   let cls =
-    "bg-emerald-500/15 text-emerald-700 dark:text-emerald-400 border-emerald-500/30";
+    "bg-status-success-bg0/15 text-status-success border-status-success/30";
   if (c < 0.5) cls = "bg-destructive/15 text-destructive border-destructive/30";
   else if (c <= 0.8)
     cls =
-      "bg-amber-500/15 text-amber-700 dark:text-amber-400 border-amber-500/30";
+      "bg-status-warning-bg0/15 text-status-warning border-status-warning/30";
   return (
     <Badge variant="outline" className={cls}>
       Confiança {Math.round(c * 100)}%
@@ -278,7 +278,7 @@ function MapeamentoStatusCell({
           <TooltipTrigger asChild>
             <Badge
               variant="outline"
-              className="bg-emerald-500/15 text-emerald-700 dark:text-emerald-400 border-emerald-500/30 cursor-default"
+              className="bg-status-success-bg0/15 text-status-success border-status-success/30 cursor-default"
             >
               <Check className="h-3 w-3 mr-1" /> OK
             </Badge>
@@ -302,7 +302,7 @@ function MapeamentoStatusCell({
           <TooltipTrigger asChild>
             <Badge
               variant="outline"
-              className="bg-emerald-500/15 text-emerald-700 dark:text-emerald-400 border-emerald-500/30 cursor-default"
+              className="bg-status-success-bg0/15 text-status-success border-status-success/30 cursor-default"
             >
               <Sparkles className="h-3 w-3 mr-1" /> Variante
             </Badge>
@@ -331,7 +331,7 @@ function MapeamentoStatusCell({
         <PopoverTrigger asChild>
           <Badge
             variant="outline"
-            className="bg-amber-500/15 text-amber-700 dark:text-amber-400 border-amber-500/30 cursor-pointer"
+            className="bg-status-warning-bg0/15 text-status-warning border-status-warning/30 cursor-pointer"
           >
             Revisar — similaridade
           </Badge>
@@ -372,7 +372,7 @@ function MapeamentoStatusCell({
           <TooltipTrigger asChild>
             <Badge
               variant="outline"
-              className="bg-blue-500/15 text-blue-700 dark:text-blue-400 border-blue-500/30 cursor-default"
+              className="bg-status-info-bg0/15 text-status-info border-status-info/30 cursor-default"
             >
               Manual
             </Badge>
@@ -512,7 +512,7 @@ function DescontoExtraCell({
         {tem ? (
           <Badge
             variant="outline"
-            className="bg-blue-500/15 text-blue-700 dark:text-blue-400 border-blue-500/30 cursor-pointer"
+            className="bg-status-info-bg0/15 text-status-info border-status-info/30 cursor-pointer"
           >
             base + {item.desconto_extra_perc}%
           </Badge>
@@ -1081,7 +1081,7 @@ export default function AdminReposicaoPromocaoDetail() {
                         {tipoOrigem === "negociacao_cliente" ? (
                           <Badge
                             variant="outline"
-                            className="bg-blue-500/15 text-blue-700 dark:text-blue-400 border-blue-500/30"
+                            className="bg-status-info-bg0/15 text-status-info border-status-info/30"
                           >
                             Negociação
                           </Badge>

--- a/src/pages/AdminReposicaoPromocoes.tsx
+++ b/src/pages/AdminReposicaoPromocoes.tsx
@@ -101,11 +101,11 @@ const ESTADOS: Array<{ value: string; label: string }> = [
 function estadoBadgeClass(estado: string): string {
   switch (estado) {
     case "rascunho":
-      return "bg-amber-500/15 text-amber-700 dark:text-amber-400 border-amber-500/30";
+      return "bg-status-warning-bg0/15 text-status-warning border-status-warning/30";
     case "negociando":
-      return "bg-blue-500/15 text-blue-700 dark:text-blue-400 border-blue-500/30";
+      return "bg-status-info-bg0/15 text-status-info border-status-info/30";
     case "ativa":
-      return "bg-emerald-500/15 text-emerald-700 dark:text-emerald-400 border-emerald-500/30";
+      return "bg-status-success-bg0/15 text-status-success border-status-success/30";
     case "encerrada":
       return "bg-muted text-muted-foreground border-border";
     case "cancelada":
@@ -117,9 +117,9 @@ function estadoBadgeClass(estado: string): string {
 
 function confiancaBadge(c: number | null) {
   if (c === null || c === undefined) return null;
-  let cls = "bg-emerald-500/15 text-emerald-700 dark:text-emerald-400 border-emerald-500/30";
+  let cls = "bg-status-success-bg0/15 text-status-success border-status-success/30";
   if (c < 0.5) cls = "bg-destructive/15 text-destructive border-destructive/30";
-  else if (c <= 0.8) cls = "bg-amber-500/15 text-amber-700 dark:text-amber-400 border-amber-500/30";
+  else if (c <= 0.8) cls = "bg-status-warning-bg0/15 text-status-warning border-status-warning/30";
   return (
     <Badge variant="outline" className={cls}>
       {Math.round(c * 100)}%
@@ -421,10 +421,10 @@ export default function AdminReposicaoPromocoes() {
 
       {/* Alerta de campanhas aguardando revisão */}
       {aguardandoRevisao > 0 && filtroEstado !== "rascunho" && (
-        <Card className="border-amber-500/40 bg-amber-500/5">
+        <Card className="border-status-warning/40 bg-status-warning-bg0/5">
           <CardContent className="flex items-center justify-between gap-3 py-4">
             <div className="flex items-center gap-3">
-              <AlertTriangle className="h-5 w-5 text-amber-600 dark:text-amber-400" />
+              <AlertTriangle className="h-5 w-5 text-status-warning" />
               <div>
                 <p className="font-medium">
                   {aguardandoRevisao}{" "}
@@ -568,7 +568,7 @@ export default function AdminReposicaoPromocoes() {
                                 </TableCell>
                                 <TableCell>
                                   {c.tipo_origem === "negociacao_cliente" ? (
-                                    <Badge variant="outline" className="bg-blue-500/15 text-blue-700 dark:text-blue-400 border-blue-500/30">
+                                    <Badge variant="outline" className="bg-status-info-bg0/15 text-status-info border-status-info/30">
                                       Negociação
                                     </Badge>
                                   ) : (
@@ -660,7 +660,7 @@ export default function AdminReposicaoPromocoes() {
                         </Badge>
                       )}
                       {it.status === "processando" && (
-                        <Badge variant="outline" className="gap-1 bg-blue-500/15 text-blue-700 dark:text-blue-400 border-blue-500/30">
+                        <Badge variant="outline" className="gap-1 bg-status-info-bg0/15 text-status-info border-status-info/30">
                           <Loader2 className="h-3 w-3 animate-spin" /> Processando
                         </Badge>
                       )}
@@ -671,7 +671,7 @@ export default function AdminReposicaoPromocoes() {
                               variant="outline"
                               className={cn(
                                 "gap-1 cursor-help",
-                                "bg-emerald-500/15 text-emerald-700 dark:text-emerald-400 border-emerald-500/30",
+                                "bg-status-success-bg0/15 text-status-success border-status-success/30",
                               )}
                             >
                               <CheckCircle2 className="h-3 w-3" /> Concluído

--- a/src/pages/DesignPreview.tsx
+++ b/src/pages/DesignPreview.tsx
@@ -29,11 +29,41 @@ export default function DesignPreview() {
 
   return (
     <div className="max-w-6xl mx-auto pb-24 space-y-12">
+      {/* HERO — KPI gigante + display serif headline + atmosphere */}
+      <section className="relative bg-cockpit-hero noise rounded-lg border border-border px-8 py-12 overflow-hidden">
+        <div className="relative flex items-start justify-between gap-6 flex-wrap">
+          <div className="space-y-3 max-w-2xl">
+            <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground font-medium">
+              Design system · v3
+            </p>
+            <h1 className="font-display" style={{ fontSize: '3rem', fontWeight: 500, letterSpacing: '-0.04em', lineHeight: 1.05 }}>
+              Sistema visual da Colacor.
+            </h1>
+            <p className="text-base text-muted-foreground max-w-xl leading-relaxed">
+              Tokens, tipografia e componentes calibrados pra uso operacional 8h.
+              Baseados em <span className="text-foreground font-medium">Vercel</span>,{' '}
+              <span className="text-foreground font-medium">Mercury</span> e{' '}
+              <span className="text-foreground font-medium">Stripe Dashboard</span>.
+            </p>
+          </div>
+          <div className="space-y-1 text-right">
+            <p className="text-[10px] uppercase tracking-[0.18em] text-muted-foreground font-medium">
+              Receita consolidada · 30d
+            </p>
+            <p className="kpi-value text-foreground" style={{ fontSize: '4rem', lineHeight: 1 }}>
+              R$ 12.4M
+              <span className="kpi-delta text-status-success-bold">↑ 8.2%</span>
+            </p>
+            <p className="text-xs text-muted-foreground tabular-nums">vs. mês anterior</p>
+          </div>
+        </div>
+      </section>
+
       {/* HEADER */}
       <header className="space-y-2">
         <div className="flex items-center justify-between">
           <div>
-            <h1>Design Preview</h1>
+            <h2>Design Preview</h2>
             <p className="text-sm text-muted-foreground mt-1">
               Showcase dos tokens novos. Use o toggle ao lado pra alternar light/dark.
             </p>

--- a/src/pages/DesignPreview.tsx
+++ b/src/pages/DesignPreview.tsx
@@ -1,0 +1,413 @@
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import {
+  Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger,
+} from '@/components/ui/dialog';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { EmptyState } from '@/components/EmptyState';
+import { PageSkeleton } from '@/components/ui/page-skeleton';
+import { useTheme } from 'next-themes';
+import { Sun, Moon, Wallet, TrendingUp, AlertTriangle, CheckCircle2, Info, XCircle, Clock, Inbox } from 'lucide-react';
+
+/**
+ * Showcase isolado dos tokens novos. Permite validar visualmente sem abrir 5 telas.
+ * Acesse via /design-preview.
+ *
+ * Cobre: paleta, tipografia, hierarquia, botões (incl. variantes touch),
+ * cards, KPIs (.kpi-value), badges, status colors, dialog, tabela,
+ * empty state, skeleton, dark/light toggle inline.
+ */
+export default function DesignPreview() {
+  const { theme, setTheme, resolvedTheme } = useTheme();
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  return (
+    <div className="max-w-6xl mx-auto pb-24 space-y-12">
+      {/* HEADER */}
+      <header className="space-y-2">
+        <div className="flex items-center justify-between">
+          <div>
+            <h1>Design Preview</h1>
+            <p className="text-sm text-muted-foreground mt-1">
+              Showcase dos tokens novos. Use o toggle ao lado pra alternar light/dark.
+            </p>
+          </div>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setTheme(resolvedTheme === 'dark' ? 'light' : 'dark')}
+            className="gap-2"
+          >
+            {resolvedTheme === 'dark' ? <Sun className="w-4 h-4" /> : <Moon className="w-4 h-4" />}
+            {resolvedTheme === 'dark' ? 'Light' : 'Dark'}
+          </Button>
+        </div>
+        <div className="flex flex-wrap gap-2 mt-2">
+          <Badge variant="outline">v3 — Vercel/Mercury direction</Badge>
+          <Badge variant="secondary">Tema atual: {theme}</Badge>
+          <Badge variant="secondary">Resolved: {resolvedTheme}</Badge>
+        </div>
+      </header>
+
+      {/* PALETA NEUTRA */}
+      <section className="space-y-3">
+        <h2>Paleta neutra</h2>
+        <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-8 gap-2">
+          <Swatch token="background" cssVar="--background" />
+          <Swatch token="foreground" cssVar="--foreground" />
+          <Swatch token="card" cssVar="--card" />
+          <Swatch token="muted" cssVar="--muted" />
+          <Swatch token="muted-fg" cssVar="--muted-foreground" />
+          <Swatch token="border" cssVar="--border" />
+          <Swatch token="primary" cssVar="--primary" />
+          <Swatch token="primary-fg" cssVar="--primary-foreground" />
+        </div>
+      </section>
+
+      {/* STATUS COLORS */}
+      <section className="space-y-3">
+        <h2>Status colors (low-fatigue)</h2>
+        <p className="text-sm text-muted-foreground">
+          Dessaturadas pra uso 8h. Sempre usar par <code className="text-xs bg-muted px-1.5 py-0.5 rounded">text-status-*-fg + bg-status-*-bg</code> em texto pequeno.
+        </p>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+          <StatusBlock tone="success" icon={CheckCircle2} label="Sucesso" desc="Pedido enviado · Conferido · Aprovado" />
+          <StatusBlock tone="warning" icon={AlertTriangle} label="Atenção" desc="Aguardando aprovação · Lote diferente do FEFO" />
+          <StatusBlock tone="error" icon={XCircle} label="Erro" desc="Falha no envio · Estoque negativo · Bloqueado" />
+          <StatusBlock tone="info" icon={Info} label="Info" desc="Sincronizando · Em rota · Em análise" />
+        </div>
+      </section>
+
+      {/* TIPOGRAFIA */}
+      <section className="space-y-4">
+        <h2>Tipografia (Geist Sans)</h2>
+        <div className="space-y-3 border border-border rounded-md p-6 bg-card">
+          <div>
+            <h1>Heading 1 — 24px / 600 / -2% tracking</h1>
+            <p className="text-xs text-muted-foreground mt-1">h1</p>
+          </div>
+          <div>
+            <h2>Heading 2 — 20px / 600 / -2% tracking</h2>
+            <p className="text-xs text-muted-foreground mt-1">h2</p>
+          </div>
+          <div>
+            <h3>Heading 3 — 16px / 600</h3>
+            <p className="text-xs text-muted-foreground mt-1">h3</p>
+          </div>
+          <div>
+            <h4>Heading 4 — 14px / 600</h4>
+            <p className="text-xs text-muted-foreground mt-1">h4</p>
+          </div>
+          <div className="pt-2 border-t border-border">
+            <p className="text-base">
+              Body normal — 14px Geist com <code className="text-xs bg-muted px-1.5 py-0.5 rounded font-mono">font-feature-settings: 'tnum'</code> ativo. Os números 1234567890 alinham perfeitamente.
+            </p>
+            <p className="text-sm text-muted-foreground mt-2">Body muted — secundário, contraste 4.86:1</p>
+            <p className="text-xs text-muted-foreground mt-2">Caption — 12px, terciário</p>
+            <p className="overline mt-2">Overline — 10px uppercase tracking</p>
+          </div>
+        </div>
+      </section>
+
+      {/* KPI VALUE */}
+      <section className="space-y-3">
+        <h2>KPI utility (.kpi-value — Geist Mono)</h2>
+        <p className="text-sm text-muted-foreground">
+          Para valores grandes em cockpits financeiros e operacionais.
+        </p>
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+          <KpiCard label="Caixa Disponível" value="R$ 1.2M" icon={Wallet} positive />
+          <KpiCard label="Margem Bruta" value="32.4%" icon={TrendingUp} positive />
+          <KpiCard label="Inadimplência" value="8.7%" icon={AlertTriangle} positive={false} />
+          <KpiCard label="SKUs Críticos" value="14" icon={Inbox} positive={false} />
+        </div>
+      </section>
+
+      {/* BUTTONS */}
+      <section className="space-y-3">
+        <h2>Buttons</h2>
+        <div className="space-y-4 border border-border rounded-md p-6 bg-card">
+          <div className="flex flex-wrap gap-2 items-center">
+            <Button>Primary</Button>
+            <Button variant="secondary">Secondary</Button>
+            <Button variant="outline">Outline</Button>
+            <Button variant="ghost">Ghost</Button>
+            <Button variant="link">Link</Button>
+            <Button variant="destructive">Destructive</Button>
+          </div>
+          <div className="flex flex-wrap gap-2 items-center">
+            <Button size="sm">Small (32px)</Button>
+            <Button>Default (36px)</Button>
+            <Button size="lg">Large (40px)</Button>
+            <Button size="touch">Touch (44px) — separador / vendedor</Button>
+            <Button size="balcao">Balcão (56px) — operador tintométrico</Button>
+          </div>
+          <div className="flex flex-wrap gap-2 items-center">
+            <Button disabled>Disabled</Button>
+            <Button variant="outline" disabled>Outline disabled</Button>
+          </div>
+        </div>
+      </section>
+
+      {/* CARDS + INPUTS */}
+      <section className="space-y-3">
+        <h2>Cards e Inputs</h2>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <Card>
+            <CardHeader>
+              <CardTitle>Card padrão</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              <div className="space-y-1.5">
+                <Label htmlFor="demo-input">Email</Label>
+                <Input id="demo-input" type="email" placeholder="seu@email.com" />
+              </div>
+              <div className="flex items-center gap-2">
+                <Switch id="demo-switch" />
+                <Label htmlFor="demo-switch">Notificar por email</Label>
+              </div>
+              <Button className="w-full">Salvar alterações</Button>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader>
+              <CardTitle>Card com tabs</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <Tabs defaultValue="aba1">
+                <TabsList className="grid grid-cols-3 w-full">
+                  <TabsTrigger value="aba1">Resumo</TabsTrigger>
+                  <TabsTrigger value="aba2">Itens</TabsTrigger>
+                  <TabsTrigger value="aba3">Histórico</TabsTrigger>
+                </TabsList>
+                <TabsContent value="aba1" className="pt-4 text-sm text-muted-foreground">
+                  Conteúdo da aba Resumo. Lorem ipsum dolor sit amet.
+                </TabsContent>
+                <TabsContent value="aba2" className="pt-4 text-sm text-muted-foreground">
+                  Conteúdo da aba Itens.
+                </TabsContent>
+                <TabsContent value="aba3" className="pt-4 text-sm text-muted-foreground">
+                  Conteúdo da aba Histórico.
+                </TabsContent>
+              </Tabs>
+            </CardContent>
+          </Card>
+        </div>
+      </section>
+
+      {/* TABELA */}
+      <section className="space-y-3">
+        <h2>Tabela</h2>
+        <Card>
+          <CardContent className="p-0">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Cliente</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead className="text-right">Valor</TableHead>
+                  <TableHead className="text-right">Vencimento</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                <TableRow>
+                  <TableCell>Marcenaria São José</TableCell>
+                  <TableCell><Badge className="bg-status-success-bg text-status-success-fg border-status-success/20">Pago</Badge></TableCell>
+                  <TableCell className="text-right tabular-nums">R$ 1.234,56</TableCell>
+                  <TableCell className="text-right tabular-nums text-muted-foreground">10/05/2026</TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell>Móveis Planejados Ltda</TableCell>
+                  <TableCell><Badge className="bg-status-warning-bg text-status-warning-fg border-status-warning/20">Aguardando</Badge></TableCell>
+                  <TableCell className="text-right tabular-nums">R$ 8.901,23</TableCell>
+                  <TableCell className="text-right tabular-nums text-muted-foreground">15/05/2026</TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell>Serralheria Norte SA</TableCell>
+                  <TableCell><Badge className="bg-status-error-bg text-status-error-fg border-status-error/20">Vencido</Badge></TableCell>
+                  <TableCell className="text-right tabular-nums">R$ 23.456,78</TableCell>
+                  <TableCell className="text-right tabular-nums text-status-error">02/05/2026</TableCell>
+                </TableRow>
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+      </section>
+
+      {/* DIALOG */}
+      <section className="space-y-3">
+        <h2>Dialog</h2>
+        <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+          <DialogTrigger asChild>
+            <Button variant="outline">Abrir Dialog</Button>
+          </DialogTrigger>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Confirmar exclusão</DialogTitle>
+              <DialogDescription>
+                Esta ação não pode ser desfeita. O pedido será removido permanentemente.
+              </DialogDescription>
+            </DialogHeader>
+            <DialogFooter>
+              <Button variant="outline" onClick={() => setDialogOpen(false)}>Cancelar</Button>
+              <Button variant="destructive" onClick={() => setDialogOpen(false)}>Excluir</Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      </section>
+
+      {/* EMPTY STATE */}
+      <section className="space-y-3">
+        <h2>Empty States</h2>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div className="border border-dashed border-border rounded-md p-2">
+            <p className="text-xs text-muted-foreground mb-1 px-2">tone="operational" (default B2B)</p>
+            <EmptyState
+              icon={Inbox}
+              title="Nenhum pedido encontrado"
+              description="Tente ajustar os filtros ou criar um novo pedido."
+              actionLabel="Criar pedido"
+              onAction={() => undefined}
+              secondaryActionLabel="Limpar filtros"
+              onSecondaryAction={() => undefined}
+            />
+          </div>
+          <div className="border border-dashed border-border rounded-md p-2">
+            <p className="text-xs text-muted-foreground mb-1 px-2">tone="friendly" (customer)</p>
+            <EmptyState
+              tone="friendly"
+              icon={Clock}
+              title="Aguardando primeira coleta"
+              description="Sua próxima coleta está agendada. Em breve faremos contato."
+              actionLabel="Ver detalhes"
+              onAction={() => undefined}
+            />
+          </div>
+        </div>
+      </section>
+
+      {/* SKELETON */}
+      <section className="space-y-3">
+        <h2>Skeletons</h2>
+        <Tabs defaultValue="cockpit">
+          <TabsList>
+            <TabsTrigger value="cockpit">Cockpit</TabsTrigger>
+            <TabsTrigger value="list">List</TabsTrigger>
+            <TabsTrigger value="form">Form</TabsTrigger>
+            <TabsTrigger value="detail">Detail</TabsTrigger>
+          </TabsList>
+          <TabsContent value="cockpit"><PageSkeleton variant="cockpit" /></TabsContent>
+          <TabsContent value="list"><PageSkeleton variant="list" /></TabsContent>
+          <TabsContent value="form"><PageSkeleton variant="form" /></TabsContent>
+          <TabsContent value="detail"><PageSkeleton variant="detail" /></TabsContent>
+        </Tabs>
+      </section>
+
+      {/* MOTION */}
+      <section className="space-y-3">
+        <h2>Motion (easing Vercel)</h2>
+        <div className="border border-border rounded-md p-6 bg-card flex flex-wrap gap-3">
+          <button className="px-4 py-2 rounded-md bg-muted hover:bg-foreground hover:text-background transition-colors">
+            Hover invertido
+          </button>
+          <button className="px-4 py-2 rounded-md border border-border hover:border-foreground transition-colors">
+            Hover border
+          </button>
+          <button className="px-4 py-2 rounded-md border border-border hover:scale-[1.02] transition-transform">
+            Hover scale
+          </button>
+        </div>
+      </section>
+
+      <p className="text-xs text-muted-foreground border-t border-border pt-4">
+        Tokens definidos em <code className="font-mono">src/index.css</code>.
+        Spec em <code className="font-mono">docs/visual-direction/02-tokens.md</code>.
+      </p>
+    </div>
+  );
+}
+
+/* ─── helpers ─── */
+
+function Swatch({ token, cssVar }: { token: string; cssVar: string }) {
+  return (
+    <div className="space-y-1">
+      <div
+        className="h-12 rounded-md border border-border"
+        style={{ backgroundColor: `hsl(var(${cssVar}))` }}
+      />
+      <div className="text-xs">
+        <p className="font-medium truncate">{token}</p>
+        <p className="font-mono text-[10px] text-muted-foreground truncate">{cssVar}</p>
+      </div>
+    </div>
+  );
+}
+
+function StatusBlock({
+  tone,
+  icon: Icon,
+  label,
+  desc,
+}: {
+  tone: 'success' | 'warning' | 'error' | 'info';
+  icon: React.ElementType;
+  label: string;
+  desc: string;
+}) {
+  const cls = {
+    success: 'bg-status-success-bg border-status-success/20 text-status-success-fg',
+    warning: 'bg-status-warning-bg border-status-warning/20 text-status-warning-fg',
+    error: 'bg-status-error-bg border-status-error/20 text-status-error-fg',
+    info: 'bg-status-info-bg border-status-info/20 text-status-info-fg',
+  }[tone];
+  const iconCls = {
+    success: 'text-status-success',
+    warning: 'text-status-warning',
+    error: 'text-status-error',
+    info: 'text-status-info',
+  }[tone];
+  return (
+    <div className={`border rounded-md p-4 flex items-start gap-3 ${cls}`}>
+      <Icon className={`w-5 h-5 shrink-0 ${iconCls}`} />
+      <div className="min-w-0">
+        <p className="text-sm font-semibold">{label}</p>
+        <p className="text-xs opacity-80 mt-0.5">{desc}</p>
+      </div>
+    </div>
+  );
+}
+
+function KpiCard({
+  label,
+  value,
+  icon: Icon,
+  positive,
+}: {
+  label: string;
+  value: string;
+  icon: React.ElementType;
+  positive: boolean;
+}) {
+  return (
+    <Card>
+      <CardContent className="p-5">
+        <div className="flex items-start justify-between">
+          <div>
+            <p className="text-xs text-muted-foreground font-medium uppercase tracking-wider">{label}</p>
+            <p className={`kpi-value text-3xl mt-2 ${positive ? 'text-status-success' : 'text-status-error'}`}>{value}</p>
+          </div>
+          <div className={`p-2.5 rounded-md ${positive ? 'bg-status-success-bg' : 'bg-status-error-bg'}`}>
+            <Icon className={`w-4 h-4 ${positive ? 'text-status-success' : 'text-status-error'}`} />
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/pages/FarmerBundles.tsx
+++ b/src/pages/FarmerBundles.tsx
@@ -57,7 +57,7 @@ const FarmerBundles = () => {
         <div className="grid grid-cols-3 gap-2">
           <Card><CardContent className="p-2.5 text-center"><p className="text-lg font-bold">{rules.length}</p><p className="text-[9px] text-muted-foreground">Regras</p></CardContent></Card>
           <Card><CardContent className="p-2.5 text-center"><p className="text-lg font-bold">{totalBundles}</p><p className="text-[9px] text-muted-foreground">Bundles</p></CardContent></Card>
-          <Card><CardContent className="p-2.5 text-center"><p className="text-lg font-bold text-emerald-700">{fmt(totalLIE)}</p><p className="text-[9px] text-muted-foreground">LIE Total</p></CardContent></Card>
+          <Card><CardContent className="p-2.5 text-center"><p className="text-lg font-bold text-status-success">{fmt(totalLIE)}</p><p className="text-[9px] text-muted-foreground">LIE Total</p></CardContent></Card>
         </div>
 
         <Tabs defaultValue="bundles" className="w-full">
@@ -147,7 +147,7 @@ const CustomerBundleCard = ({ data, expanded, onToggle, bundleArgs, argGeneratin
             </div>
             <div className="flex items-center gap-2 mt-0.5">
               <span className="text-[10px] text-muted-foreground">{data.bundles.length} bundles</span>
-              <span className="text-[10px] font-semibold text-emerald-700">LIE {fmt(totalBundleLIE)}</span>
+              <span className="text-[10px] font-semibold text-status-success">LIE {fmt(totalBundleLIE)}</span>
               <Badge variant="outline" className={`text-[7px] ${profileInfo.color}`}>{profileInfo.label}</Badge>
             </div>
           </div>
@@ -160,17 +160,17 @@ const CustomerBundleCard = ({ data, expanded, onToggle, bundleArgs, argGeneratin
             <div className="bg-muted/50 rounded-lg p-2">
               <p className="text-[9px] font-semibold mb-1">📊 Comparação Inteligente</p>
               <div className="grid grid-cols-2 gap-2">
-                <div className={`rounded p-1.5 text-center ${bundleWins ? 'bg-emerald-50 ring-1 ring-emerald-300' : 'bg-muted'}`}>
-                  <Layers className="w-3 h-3 mx-auto mb-0.5 text-emerald-600" />
+                <div className={`rounded p-1.5 text-center ${bundleWins ? 'bg-status-success-bg ring-1 ring-emerald-300' : 'bg-muted'}`}>
+                  <Layers className="w-3 h-3 mx-auto mb-0.5 text-status-success" />
                   <p className="text-[9px] text-muted-foreground">Melhor Bundle</p>
                   <p className="text-xs font-bold">{fmt(bestBundleLIE)}</p>
-                  {bundleWins && <Badge className="text-[7px] bg-emerald-600 mt-0.5">🏆 Vencedor</Badge>}
+                  {bundleWins && <Badge className="text-[7px] bg-status-success mt-0.5">🏆 Vencedor</Badge>}
                 </div>
-                <div className={`rounded p-1.5 text-center ${!bundleWins ? 'bg-blue-50 ring-1 ring-blue-300' : 'bg-muted'}`}>
-                  <Zap className="w-3 h-3 mx-auto mb-0.5 text-blue-600" />
+                <div className={`rounded p-1.5 text-center ${!bundleWins ? 'bg-status-info-bg ring-1 ring-blue-300' : 'bg-muted'}`}>
+                  <Zap className="w-3 h-3 mx-auto mb-0.5 text-status-info" />
                   <p className="text-[9px] text-muted-foreground">Melhor Individual</p>
                   <p className="text-xs font-bold">{fmt(individualLIE)}</p>
-                  {!bundleWins && data.bestIndividual && <Badge className="text-[7px] bg-blue-600 mt-0.5">🏆 Vencedor</Badge>}
+                  {!bundleWins && data.bestIndividual && <Badge className="text-[7px] bg-status-info mt-0.5">🏆 Vencedor</Badge>}
                 </div>
               </div>
             </div>
@@ -258,7 +258,7 @@ const BundleCardFull = ({
           <Badge variant="outline" className="text-[8px]">Bundle #{rank}</Badge>
           <Badge className="text-[8px] bg-primary/10 text-primary">{bundle.products.length} produtos</Badge>
         </div>
-        <span className="text-xs font-bold text-emerald-700">{fmt(bundle.lieBundle)}</span>
+        <span className="text-xs font-bold text-status-success">{fmt(bundle.lieBundle)}</span>
       </div>
 
       {/* Products */}
@@ -266,7 +266,7 @@ const BundleCardFull = ({
         {bundle.products.map((p, i) => (
           <div key={i} className="flex items-center justify-between bg-background rounded px-2 py-1">
             <span className="text-[10px] truncate flex-1">{p.name}</span>
-            <span className="text-[10px] font-semibold text-emerald-700 ml-2">{fmt(p.margin)}</span>
+            <span className="text-[10px] font-semibold text-status-success ml-2">{fmt(p.margin)}</span>
           </div>
         ))}
       </div>
@@ -403,7 +403,7 @@ const BundleCardFull = ({
                     <FileText className="w-3 h-3" /> Técnica
                   </Button>
                   <Button size="sm" variant="ghost" className="h-6 text-[9px] gap-1 px-2 ml-auto" onClick={() => copyText(getActiveText())}>
-                    {copied ? <Check className="w-3 h-3 text-emerald-600" /> : <Copy className="w-3 h-3" />}
+                    {copied ? <Check className="w-3 h-3 text-status-success" /> : <Copy className="w-3 h-3" />}
                   </Button>
                 </div>
                 <div className="bg-muted/50 rounded p-2">
@@ -430,8 +430,8 @@ const QuestionCard = ({ question, onSetResponse, onToggleAlt }: {
   const displayText = question.useAlt ? question.alt : question.main;
 
   const responseIcons: Record<QuestionResponse, { icon: typeof ThumbsUp; label: string; color: string }> = {
-    interesse: { icon: ThumbsUp, label: 'Interesse', color: 'bg-emerald-100 text-emerald-700 border-emerald-300' },
-    objecao: { icon: ThumbsDown, label: 'Objeção', color: 'bg-red-100 text-red-700 border-red-300' },
+    interesse: { icon: ThumbsUp, label: 'Interesse', color: 'bg-status-success-bg text-status-success border-status-success/30' },
+    objecao: { icon: ThumbsDown, label: 'Objeção', color: 'bg-status-error-bg text-status-error border-status-error/30' },
     indiferenca: { icon: Minus, label: 'Indiferença', color: 'bg-muted text-muted-foreground border-border' },
   };
 
@@ -505,7 +505,7 @@ const RuleCard = ({ rule }: { rule: AssociationRule }) => (
       <div className="flex items-center gap-1 mb-1 flex-wrap">
         {rule.antecedentNames.map((n, i) => <Badge key={i} variant="outline" className="text-[8px]">{n}</Badge>)}
         <ArrowRight className="w-3 h-3 text-muted-foreground shrink-0" />
-        {rule.consequentNames.map((n, i) => <Badge key={i} className="text-[8px] bg-emerald-100 text-emerald-800">{n}</Badge>)}
+        {rule.consequentNames.map((n, i) => <Badge key={i} className="text-[8px] bg-status-success-bg text-status-success-fg">{n}</Badge>)}
       </div>
       <div className="flex gap-3 text-[9px]">
         <span>Sup: <strong>{(rule.support * 100).toFixed(1)}%</strong></span>

--- a/src/pages/FarmerCopilot.tsx
+++ b/src/pages/FarmerCopilot.tsx
@@ -24,9 +24,9 @@ import { cn } from '@/lib/utils';
 
 // ─── Helpers ───────────────────────────────────────────────────────
 const directionConfig: Record<CopilotDirection, { color: string; bg: string; icon: any; label: string }> = {
-  positivo: { color: 'text-emerald-700', bg: 'bg-emerald-50 border-emerald-200', icon: TrendingUp, label: 'Positivo' },
-  neutro: { color: 'text-amber-700', bg: 'bg-amber-50 border-amber-200', icon: Minus, label: 'Neutro' },
-  risco: { color: 'text-red-700', bg: 'bg-red-50 border-red-200', icon: TrendingDown, label: 'Em Risco' },
+  positivo: { color: 'text-status-success', bg: 'bg-status-success-bg border-status-success/30', icon: TrendingUp, label: 'Positivo' },
+  neutro: { color: 'text-status-warning', bg: 'bg-status-warning-bg border-status-warning/30', icon: Minus, label: 'Neutro' },
+  risco: { color: 'text-status-error', bg: 'bg-status-error-bg border-status-error/30', icon: TrendingDown, label: 'Em Risco' },
 };
 
 const phaseLabels: Record<CopilotPhase, string> = {
@@ -38,10 +38,10 @@ const phaseLabels: Record<CopilotPhase, string> = {
 };
 
 const intentLabels: Record<CopilotIntent, { label: string; color: string }> = {
-  interesse: { label: 'Interesse', color: 'bg-emerald-100 text-emerald-800' },
-  objecao_preco: { label: 'Objeção Preço', color: 'bg-red-100 text-red-800' },
+  interesse: { label: 'Interesse', color: 'bg-status-success-bg text-status-success-fg' },
+  objecao_preco: { label: 'Objeção Preço', color: 'bg-status-error-bg text-status-error-fg' },
   objecao_tecnica: { label: 'Objeção Técnica', color: 'bg-orange-100 text-orange-800' },
-  falta_urgencia: { label: 'Falta Urgência', color: 'bg-amber-100 text-amber-800' },
+  falta_urgencia: { label: 'Falta Urgência', color: 'bg-status-warning-bg text-status-warning-fg' },
   comparacao_concorrente: { label: 'Concorrente', color: 'bg-purple-100 text-purple-800' },
   indiferenca: { label: 'Indiferença', color: 'bg-muted text-muted-foreground' },
 };
@@ -329,9 +329,9 @@ const FarmerCopilot = () => {
               </div>
 
               {inputMode === 'text' && (
-                <div className="flex items-start gap-1.5 p-2 rounded-md bg-amber-50 border border-amber-200">
-                  <AlertTriangle className="w-3.5 h-3.5 text-amber-600 mt-0.5 shrink-0" />
-                  <p className="text-[9px] text-amber-700">
+                <div className="flex items-start gap-1.5 p-2 rounded-md bg-status-warning-bg border border-status-warning/30">
+                  <AlertTriangle className="w-3.5 h-3.5 text-status-warning mt-0.5 shrink-0" />
+                  <p className="text-[9px] text-status-warning">
                     No modo texto, cole ou digite trechos da conversa e clique em "Analisar" para receber sugestões.
                   </p>
                 </div>
@@ -372,7 +372,7 @@ const FarmerCopilot = () => {
                 <div className="flex items-center justify-between">
                   <div className="flex items-center gap-2">
                     {inputMode === 'voice' ? (
-                      <div className="w-2 h-2 rounded-full bg-red-500 animate-pulse" />
+                      <div className="w-2 h-2 rounded-full bg-status-error-bg0 animate-pulse" />
                     ) : (
                       <Type className="w-3.5 h-3.5 text-primary" />
                     )}
@@ -445,7 +445,7 @@ const FarmerCopilot = () => {
                       className="h-7 w-7 p-0 shrink-0"
                       onClick={() => handleCopySuggestion(analysis.suggestion)}
                     >
-                      {copied ? <Check className="w-3 h-3 text-emerald-600" /> : <Copy className="w-3 h-3" />}
+                      {copied ? <Check className="w-3 h-3 text-status-success" /> : <Copy className="w-3 h-3" />}
                     </Button>
                   </div>
                   <div className="flex items-center justify-between mt-2">
@@ -572,8 +572,8 @@ const FarmerCopilot = () => {
                       return (
                         <div key={i} className="flex items-center gap-2 text-[9px]">
                           <div className={`w-2 h-2 rounded-full ${
-                            a.direction === 'positivo' ? 'bg-emerald-500' :
-                            a.direction === 'risco' ? 'bg-red-500' : 'bg-amber-500'
+                            a.direction === 'positivo' ? 'bg-status-success-bg0' :
+                            a.direction === 'risco' ? 'bg-status-error-bg0' : 'bg-status-warning-bg0'
                           }`} />
                           <span className="font-medium">{intentLabels[a.intent]?.label}</span>
                           <span className="text-muted-foreground">→</span>

--- a/src/pages/FarmerDashboard.tsx
+++ b/src/pages/FarmerDashboard.tsx
@@ -20,18 +20,18 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 
 // ─── Helpers ─────────────────────────────────────────────────────────
 const healthColors: Record<string, { bg: string; text: string; border: string }> = {
-  saudavel: { bg: 'bg-emerald-50', text: 'text-emerald-700', border: 'border-emerald-200' },
-  estavel: { bg: 'bg-blue-50', text: 'text-blue-700', border: 'border-blue-200' },
-  atencao: { bg: 'bg-amber-50', text: 'text-amber-700', border: 'border-amber-200' },
-  critico: { bg: 'bg-red-50', text: 'text-red-700', border: 'border-red-200' },
+  saudavel: { bg: 'bg-status-success-bg', text: 'text-status-success', border: 'border-status-success/30' },
+  estavel: { bg: 'bg-status-info-bg', text: 'text-status-info', border: 'border-status-info/30' },
+  atencao: { bg: 'bg-status-warning-bg', text: 'text-status-warning', border: 'border-status-warning/30' },
+  critico: { bg: 'bg-status-error-bg', text: 'text-status-error', border: 'border-status-error/30' },
 };
 const healthLabels: Record<string, string> = {
   saudavel: '💚 Saudável', estavel: '💙 Estável', atencao: '⚠️ Atenção', critico: '🔴 Crítico',
 };
 const agendaTypeConfig: Record<string, { label: string; color: string }> = {
-  risco: { label: '🔴 Risco', color: 'bg-red-100 text-red-800' },
-  expansao: { label: '🟢 Expansão', color: 'bg-emerald-100 text-emerald-800' },
-  follow_up: { label: '🔵 Follow-up', color: 'bg-blue-100 text-blue-800' },
+  risco: { label: '🔴 Risco', color: 'bg-status-error-bg text-status-error-fg' },
+  expansao: { label: '🟢 Expansão', color: 'bg-status-success-bg text-status-success-fg' },
+  follow_up: { label: '🔵 Follow-up', color: 'bg-status-info-bg text-status-info-fg' },
 };
 
 const fmt = (v: number) => v.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
@@ -336,8 +336,8 @@ const FarmerDashboard = () => {
               </CardHeader>
               <CardContent className="p-3 pt-0 space-y-2">
                 <WeightBar label="Risco/Recuperação" value={config.agenda_pct_risco * 100} color="bg-destructive" />
-                <WeightBar label="Expansão" value={config.agenda_pct_expansao * 100} color="bg-emerald-500" />
-                <WeightBar label="Follow-up" value={config.agenda_pct_followup * 100} color="bg-blue-500" />
+                <WeightBar label="Expansão" value={config.agenda_pct_expansao * 100} color="bg-status-success-bg0" />
+                <WeightBar label="Follow-up" value={config.agenda_pct_followup * 100} color="bg-status-info-bg0" />
               </CardContent>
             </Card>
             <Button variant="outline" className="w-full" onClick={() => navigate('/farmer/governance')}>

--- a/src/pages/FarmerLOCC.tsx
+++ b/src/pages/FarmerLOCC.tsx
@@ -32,10 +32,10 @@ const fmtDur = (s: number) => {
 };
 
 const healthColors: Record<string, { bg: string; text: string }> = {
-  saudavel: { bg: 'bg-emerald-50', text: 'text-emerald-700' },
-  estavel: { bg: 'bg-blue-50', text: 'text-blue-700' },
-  atencao: { bg: 'bg-amber-50', text: 'text-amber-700' },
-  critico: { bg: 'bg-red-50', text: 'text-red-700' },
+  saudavel: { bg: 'bg-status-success-bg', text: 'text-status-success' },
+  estavel: { bg: 'bg-status-info-bg', text: 'text-status-info' },
+  atencao: { bg: 'bg-status-warning-bg', text: 'text-status-warning' },
+  critico: { bg: 'bg-status-error-bg', text: 'text-status-error' },
 };
 
 const metricLabels: Record<string, string> = {
@@ -47,9 +47,9 @@ const metricLabels: Record<string, string> = {
 
 const statusColors: Record<string, string> = {
   rascunho: 'bg-muted text-muted-foreground',
-  ativo: 'bg-blue-100 text-blue-800',
-  concluido: 'bg-emerald-100 text-emerald-800',
-  cancelado: 'bg-red-100 text-red-800',
+  ativo: 'bg-status-info-bg text-status-info-fg',
+  concluido: 'bg-status-success-bg text-status-success-fg',
+  cancelado: 'bg-status-error-bg text-status-error-fg',
 };
 
 type TabKey = 'overview' | 'experiments' | 'capacity' | 'adaptive';
@@ -264,11 +264,11 @@ const OverviewTab = memo(({ summary, metrics, scoringCalc, recalculate, navigate
         <CardContent className="p-3">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2">
-              <Zap className="w-4 h-4 text-amber-600" />
+              <Zap className="w-4 h-4 text-status-warning" />
               <span className="text-xs font-semibold">Recomendações LIE</span>
             </div>
             <div className="flex items-center gap-1">
-              <span className="text-xs font-bold text-emerald-700">
+              <span className="text-xs font-bold text-status-success">
                 {recommendations.reduce((s, r) => s + [...r.crossSell, ...r.upSell].reduce((s2, rec) => s2 + rec.lie, 0), 0).toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' })}
               </span>
               <ChevronRight className="w-3 h-3 text-muted-foreground" />
@@ -400,8 +400,8 @@ const AdaptiveTab = memo(({ config, metrics, navigate }: { config: any; metrics:
         <div>
           <p className="text-[10px] text-muted-foreground mb-1">Quotas da Agenda</p>
           <WeightBar label="Risco/Recuperação" value={config.agenda_pct_risco * 100} color="bg-destructive" />
-          <WeightBar label="Expansão" value={config.agenda_pct_expansao * 100} color="bg-emerald-500" />
-          <WeightBar label="Follow-up" value={config.agenda_pct_followup * 100} color="bg-blue-500" />
+          <WeightBar label="Expansão" value={config.agenda_pct_expansao * 100} color="bg-status-success-bg0" />
+          <WeightBar label="Follow-up" value={config.agenda_pct_followup * 100} color="bg-status-info-bg0" />
         </div>
       </CardContent>
     </Card>
@@ -415,9 +415,9 @@ const AdaptiveTab = memo(({ config, metrics, navigate }: { config: any; metrics:
         </div>
         <div className="flex items-center gap-2">
           <Badge className={
-            metrics.portfolioRecommendation === 'expand' ? 'bg-emerald-100 text-emerald-800' :
-            metrics.portfolioRecommendation === 'reduce' ? 'bg-red-100 text-red-800' :
-            'bg-blue-100 text-blue-800'
+            metrics.portfolioRecommendation === 'expand' ? 'bg-status-success-bg text-status-success-fg' :
+            metrics.portfolioRecommendation === 'reduce' ? 'bg-status-error-bg text-status-error-fg' :
+            'bg-status-info-bg text-status-info-fg'
           }>
             {metrics.portfolioRecommendation === 'expand' ? '📈 Expandir' :
              metrics.portfolioRecommendation === 'reduce' ? '📉 Reduzir' :
@@ -513,11 +513,11 @@ const ExperimentCard = ({ experiment, onStart, onMeasure, onCancel }: {
 
         {experiment.status === 'ativo' && (
           <div className="grid grid-cols-3 gap-1 text-center mb-2">
-            <div className="bg-blue-50 rounded p-1">
+            <div className="bg-status-info-bg rounded p-1">
               <p className="text-[9px] text-muted-foreground">Controle</p>
               <p className="text-[10px] font-bold">{Number(experiment.control_metric_value).toFixed(2)}</p>
             </div>
-            <div className="bg-emerald-50 rounded p-1">
+            <div className="bg-status-success-bg rounded p-1">
               <p className="text-[9px] text-muted-foreground">Teste</p>
               <p className="text-[10px] font-bold">{Number(experiment.test_metric_value).toFixed(2)}</p>
             </div>
@@ -531,9 +531,9 @@ const ExperimentCard = ({ experiment, onStart, onMeasure, onCancel }: {
         {experiment.status === 'concluido' && (
           <div className="mb-2">
             <div className="flex items-center gap-2">
-              {experiment.winner === 'teste' && <CheckCircle className="w-4 h-4 text-emerald-600" />}
-              {experiment.winner === 'controle' && <CheckCircle className="w-4 h-4 text-blue-600" />}
-              {experiment.winner === 'inconclusivo' && <XCircle className="w-4 h-4 text-amber-600" />}
+              {experiment.winner === 'teste' && <CheckCircle className="w-4 h-4 text-status-success" />}
+              {experiment.winner === 'controle' && <CheckCircle className="w-4 h-4 text-status-info" />}
+              {experiment.winner === 'inconclusivo' && <XCircle className="w-4 h-4 text-status-warning" />}
               <span className="text-xs font-semibold">
                 Vencedor: {experiment.winner === 'teste' ? '🏆 Teste' : experiment.winner === 'controle' ? '🏆 Controle' : '⚖️ Inconclusivo'}
               </span>

--- a/src/pages/FarmerTacticalPlan.tsx
+++ b/src/pages/FarmerTacticalPlan.tsx
@@ -27,10 +27,10 @@ import { useToast } from '@/hooks/use-toast';
 const fmt = (v: number) => v.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
 
 const objectiveColors: Record<string, string> = {
-  recuperacao: 'bg-red-100 text-red-800',
-  expansao_mix: 'bg-emerald-100 text-emerald-800',
-  upsell_premium: 'bg-blue-100 text-blue-800',
-  reativacao: 'bg-amber-100 text-amber-800',
+  recuperacao: 'bg-status-error-bg text-status-error-fg',
+  expansao_mix: 'bg-status-success-bg text-status-success-fg',
+  upsell_premium: 'bg-status-info-bg text-status-info-fg',
+  reativacao: 'bg-status-warning-bg text-status-warning-fg',
   consolidacao_margem: 'bg-orange-100 text-orange-800',
 };
 
@@ -149,8 +149,8 @@ const FarmerTacticalPlan = () => {
                 <div key={c.id} className="flex items-center justify-between p-2 rounded-lg border text-xs">
                   <div className="flex items-center gap-2 flex-1 min-w-0">
                     <div className={`w-2 h-2 rounded-full shrink-0 ${
-                      c.healthScore >= 70 ? 'bg-emerald-500' :
-                      c.healthScore >= 40 ? 'bg-amber-500' : 'bg-red-500'
+                      c.healthScore >= 70 ? 'bg-status-success-bg0' :
+                      c.healthScore >= 40 ? 'bg-status-warning-bg0' : 'bg-status-error-bg0'
                     }`} />
                     <span className="truncate font-medium">{c.name}</span>
                     <span className="text-[9px] text-muted-foreground shrink-0">HS:{Math.round(c.healthScore)}</span>
@@ -189,7 +189,7 @@ const FarmerTacticalPlan = () => {
           <DialogContent className="max-w-xs">
             <DialogHeader>
               <DialogTitle className="text-sm flex items-center gap-2">
-                <AlertCircle className="w-4 h-4 text-amber-500" />
+                <AlertCircle className="w-4 h-4 text-status-warning" />
                 Potencial Baixo
               </DialogTitle>
             </DialogHeader>
@@ -297,7 +297,7 @@ const PlanCard = ({
         {/* Efficiency indicator */}
         {plan.estimatedProfitPerHour > 0 && (
           <div className={`mt-1.5 flex items-center gap-1 text-[9px] ${
-            plan.estimatedProfitPerHour >= 50 ? 'text-emerald-600' : 'text-amber-600'
+            plan.estimatedProfitPerHour >= 50 ? 'text-status-success' : 'text-status-warning'
           }`}>
             <DollarSign className="w-3 h-3" />
             <span>Lucro estimado: {fmt(plan.estimatedProfitPerHour)}/h</span>
@@ -377,10 +377,10 @@ const PlanCard = ({
                 ))}
 
                 {plan.implicationQuestion && (
-                  <div className="p-2 rounded bg-amber-50 border border-amber-200">
+                  <div className="p-2 rounded bg-status-warning-bg border border-status-warning/30">
                     <div className="flex items-start justify-between gap-1">
                       <div>
-                        <p className="text-[9px] font-semibold text-amber-700">Pergunta de Implicação</p>
+                        <p className="text-[9px] font-semibold text-status-warning">Pergunta de Implicação</p>
                         <p className="text-xs">{plan.implicationQuestion}</p>
                       </div>
                       <CopyButton text={plan.implicationQuestion} copied={copiedText === plan.implicationQuestion} onCopy={onCopy} />
@@ -389,10 +389,10 @@ const PlanCard = ({
                 )}
 
                 {plan.offerTransition && (
-                  <div className="p-2 rounded bg-emerald-50 border border-emerald-200">
+                  <div className="p-2 rounded bg-status-success-bg border border-status-success/30">
                     <div className="flex items-start justify-between gap-1">
                       <div>
-                        <p className="text-[9px] font-semibold text-emerald-700">Transição para Oferta</p>
+                        <p className="text-[9px] font-semibold text-status-success">Transição para Oferta</p>
                         <p className="text-xs">{plan.offerTransition}</p>
                       </div>
                       <CopyButton text={plan.offerTransition} copied={copiedText === plan.offerTransition} onCopy={onCopy} />
@@ -408,16 +408,16 @@ const PlanCard = ({
                 {plan.probableObjections.map((obj, i) => (
                   <div key={i} className="p-2 rounded bg-muted/30 space-y-1">
                     <div className="flex items-center justify-between">
-                      <p className="text-xs font-medium text-red-700">⚠ {obj.objection}</p>
+                      <p className="text-xs font-medium text-status-error">⚠ {obj.objection}</p>
                       <Badge variant="outline" className="text-[8px]">{obj.probability}%</Badge>
                     </div>
                     <div className="space-y-0.5">
                       <div className="flex items-start gap-1">
-                        <span className="text-[9px] font-semibold text-blue-700 shrink-0">Técnica:</span>
+                        <span className="text-[9px] font-semibold text-status-info shrink-0">Técnica:</span>
                         <p className="text-[10px]">{obj.technical_response}</p>
                       </div>
                       <div className="flex items-start gap-1">
-                        <span className="text-[9px] font-semibold text-emerald-700 shrink-0">Econômica:</span>
+                        <span className="text-[9px] font-semibold text-status-success shrink-0">Econômica:</span>
                         <p className="text-[10px]">{obj.economic_response}</p>
                       </div>
                     </div>
@@ -431,7 +431,7 @@ const PlanCard = ({
               <Section title="Riscos Operacionais" icon={AlertTriangle}>
                 {plan.operationalRisks.map((risk, i) => (
                   <div key={i} className="flex items-start gap-1.5 text-[10px]">
-                    <AlertCircle className="w-3 h-3 text-amber-500 shrink-0 mt-0.5" />
+                    <AlertCircle className="w-3 h-3 text-status-warning shrink-0 mt-0.5" />
                     <span>{risk}</span>
                   </div>
                 ))}
@@ -479,7 +479,7 @@ const MetricRow = ({ label, value }: { label: string; value: string }) => (
 
 const CopyButton = ({ text, copied, onCopy }: { text: string; copied: boolean; onCopy: (t: string) => void }) => (
   <Button size="sm" variant="ghost" className="h-5 w-5 p-0 shrink-0" onClick={() => onCopy(text)}>
-    {copied ? <Check className="w-2.5 h-2.5 text-emerald-600" /> : <Copy className="w-2.5 h-2.5" />}
+    {copied ? <Check className="w-2.5 h-2.5 text-status-success" /> : <Copy className="w-2.5 h-2.5" />}
   </Button>
 );
 

--- a/src/pages/FinanceiroCapitalGiro.tsx
+++ b/src/pages/FinanceiroCapitalGiro.tsx
@@ -149,7 +149,7 @@ const FinanceiroCapitalGiro = () => {
             />
             <div className="p-4 rounded-lg border bg-card">
               <p className="text-xs text-muted-foreground font-medium">Ciclo Financeiro</p>
-              <p className={`text-2xl font-bold mt-1 ${active.ciclo_financeiro > 0 ? 'text-amber-600' : 'text-emerald-600'}`}>
+              <p className={`text-2xl font-bold mt-1 ${active.ciclo_financeiro > 0 ? 'text-status-warning' : 'text-status-success'}`}>
                 {active.ciclo_financeiro} dias
               </p>
               <p className="text-xs text-muted-foreground mt-1">
@@ -176,7 +176,7 @@ const FinanceiroCapitalGiro = () => {
                   </div>
                   <div className="h-4 rounded-full bg-muted overflow-hidden">
                     <div
-                      className="h-full rounded-full bg-blue-500 transition-all"
+                      className="h-full rounded-full bg-status-info-bg0 transition-all"
                       style={{ width: `${Math.min((active.pmr / Math.max(active.pmr, active.pmp, 1)) * 100, 100)}%` }}
                     />
                   </div>
@@ -189,15 +189,15 @@ const FinanceiroCapitalGiro = () => {
                   </div>
                   <div className="h-4 rounded-full bg-muted overflow-hidden">
                     <div
-                      className="h-full rounded-full bg-emerald-500 transition-all"
+                      className="h-full rounded-full bg-status-success-bg0 transition-all"
                       style={{ width: `${Math.min((active.pmp / Math.max(active.pmr, active.pmp, 1)) * 100, 100)}%` }}
                     />
                   </div>
                 </div>
               </div>
 
-              <div className={`p-4 rounded-lg ${active.ciclo_financeiro > 0 ? 'bg-amber-50 border-amber-200' : 'bg-emerald-50 border-emerald-200'} border`}>
-                <p className={`text-sm font-medium ${active.ciclo_financeiro > 0 ? 'text-amber-800' : 'text-emerald-800'}`}>
+              <div className={`p-4 rounded-lg ${active.ciclo_financeiro > 0 ? 'bg-status-warning-bg border-status-warning/30' : 'bg-status-success-bg border-status-success/30'} border`}>
+                <p className={`text-sm font-medium ${active.ciclo_financeiro > 0 ? 'text-status-warning-fg' : 'text-status-success-fg'}`}>
                   {active.ciclo_financeiro > 0
                     ? `Ciclo positivo de ${active.ciclo_financeiro} dias — você financia seus clientes por ${active.ciclo_financeiro} dias antes de receber.`
                     : active.ciclo_financeiro < 0
@@ -206,7 +206,7 @@ const FinanceiroCapitalGiro = () => {
                   }
                 </p>
                 {active.ciclo_financeiro > 15 && (
-                  <p className="text-xs mt-2 text-amber-700">
+                  <p className="text-xs mt-2 text-status-warning">
                     Considere: renegociar prazos com fornecedores, antecipar recebíveis, ou reduzir prazos de vendas.
                   </p>
                 )}
@@ -225,19 +225,19 @@ const FinanceiroCapitalGiro = () => {
             <CardContent>
               <div className="space-y-4">
                 <div className="grid grid-cols-3 gap-4 text-center">
-                  <div className="p-3 rounded-lg bg-blue-50">
+                  <div className="p-3 rounded-lg bg-status-info-bg">
                     <p className="text-xs text-muted-foreground">Saldo Atual CC</p>
-                    <p className="text-lg font-bold text-blue-600">{fmtCompact(active.saldo_cc)}</p>
+                    <p className="text-lg font-bold text-status-info">{fmtCompact(active.saldo_cc)}</p>
                   </div>
                   <div className="p-3 rounded-lg bg-muted/50">
                     <p className="text-xs text-muted-foreground">Fluxo Líquido 30d</p>
-                    <p className={`text-lg font-bold ${active.entradas_30d - active.saidas_30d >= 0 ? 'text-emerald-600' : 'text-red-600'}`}>
+                    <p className={`text-lg font-bold ${active.entradas_30d - active.saidas_30d >= 0 ? 'text-status-success' : 'text-status-error'}`}>
                       {fmtCompact(active.entradas_30d - active.saidas_30d)}
                     </p>
                   </div>
-                  <div className={`p-3 rounded-lg ${active.saldo_projetado_30d >= 0 ? 'bg-emerald-50' : 'bg-red-50'}`}>
+                  <div className={`p-3 rounded-lg ${active.saldo_projetado_30d >= 0 ? 'bg-status-success-bg' : 'bg-status-error-bg'}`}>
                     <p className="text-xs text-muted-foreground">Saldo Projetado</p>
-                    <p className={`text-lg font-bold ${active.saldo_projetado_30d >= 0 ? 'text-emerald-600' : 'text-red-600'}`}>
+                    <p className={`text-lg font-bold ${active.saldo_projetado_30d >= 0 ? 'text-status-success' : 'text-status-error'}`}>
                       {fmtCompact(active.saldo_projetado_30d)}
                     </p>
                   </div>
@@ -245,18 +245,18 @@ const FinanceiroCapitalGiro = () => {
 
                 {/* Waterfall visual */}
                 <div className="flex items-end justify-center gap-2 h-32">
-                  <WaterfallBar label="CC Atual" value={active.saldo_cc} max={Math.max(active.saldo_cc, active.saldo_projetado_30d, active.entradas_30d)} color="bg-blue-500" />
-                  <WaterfallBar label="Entradas" value={active.entradas_30d} max={Math.max(active.saldo_cc, active.saldo_projetado_30d, active.entradas_30d)} color="bg-emerald-500" />
-                  <WaterfallBar label="Saídas" value={active.saidas_30d} max={Math.max(active.saldo_cc, active.saldo_projetado_30d, active.entradas_30d)} color="bg-red-500" />
-                  <WaterfallBar label="Projetado" value={active.saldo_projetado_30d} max={Math.max(active.saldo_cc, active.saldo_projetado_30d, active.entradas_30d)} color={active.saldo_projetado_30d >= 0 ? 'bg-emerald-600' : 'bg-red-600'} />
+                  <WaterfallBar label="CC Atual" value={active.saldo_cc} max={Math.max(active.saldo_cc, active.saldo_projetado_30d, active.entradas_30d)} color="bg-status-info-bg0" />
+                  <WaterfallBar label="Entradas" value={active.entradas_30d} max={Math.max(active.saldo_cc, active.saldo_projetado_30d, active.entradas_30d)} color="bg-status-success-bg0" />
+                  <WaterfallBar label="Saídas" value={active.saidas_30d} max={Math.max(active.saldo_cc, active.saldo_projetado_30d, active.entradas_30d)} color="bg-status-error-bg0" />
+                  <WaterfallBar label="Projetado" value={active.saldo_projetado_30d} max={Math.max(active.saldo_cc, active.saldo_projetado_30d, active.entradas_30d)} color={active.saldo_projetado_30d >= 0 ? 'bg-status-success' : 'bg-status-error'} />
                 </div>
 
                 {active.saldo_projetado_30d < 0 && (
-                  <div className="flex items-start gap-2 p-3 rounded-lg bg-red-50 border border-red-200">
-                    <AlertTriangle className="w-4 h-4 text-red-600 mt-0.5" />
+                  <div className="flex items-start gap-2 p-3 rounded-lg bg-status-error-bg border border-status-error/30">
+                    <AlertTriangle className="w-4 h-4 text-status-error mt-0.5" />
                     <div>
-                      <p className="text-sm font-medium text-red-800">Projeção negativa</p>
-                      <p className="text-xs text-red-700 mt-1">
+                      <p className="text-sm font-medium text-status-error-fg">Projeção negativa</p>
+                      <p className="text-xs text-status-error mt-1">
                         Déficit projetado de {fmtCompact(Math.abs(active.saldo_projetado_30d))} nos próximos 30 dias.
                         Ação necessária: antecipar recebíveis, renegociar prazos de CP, ou injetar capital.
                       </p>
@@ -315,7 +315,7 @@ const FinanceiroCapitalGiro = () => {
                           {data.map(d => {
                             const val = (d as any)[line.field] || 0;
                             const isResult = ['capital_giro', 'capital_giro_liquido', 'saldo_projetado_30d'].includes(line.field);
-                            const color = isResult ? (val >= 0 ? 'text-emerald-600' : 'text-red-600') : '';
+                            const color = isResult ? (val >= 0 ? 'text-status-success' : 'text-status-error') : '';
                             let display = '';
                             if (line.fmt === 'currency') display = fmtCompact(val);
                             else if (line.fmt === 'days') display = `${val}d`;
@@ -351,12 +351,12 @@ const FinanceiroCapitalGiro = () => {
                     <div className="flex items-center gap-3">
                       <Progress
                         value={active.top5_cr_pct}
-                        className={`h-3 ${active.top5_cr_pct > 70 ? '[&>div]:bg-red-500' : active.top5_cr_pct > 50 ? '[&>div]:bg-amber-500' : '[&>div]:bg-emerald-500'}`}
+                        className={`h-3 ${active.top5_cr_pct > 70 ? '[&>div]:bg-status-error-bg0' : active.top5_cr_pct > 50 ? '[&>div]:bg-status-warning-bg0' : '[&>div]:bg-status-success-bg0'}`}
                       />
                       <span className="text-sm font-bold">{active.top5_cr_pct.toFixed(0)}%</span>
                     </div>
                     {active.top5_cr_pct > 60 && (
-                      <p className="text-xs text-amber-600 mt-1">Alta concentração — diversifique a base de clientes</p>
+                      <p className="text-xs text-status-warning mt-1">Alta concentração — diversifique a base de clientes</p>
                     )}
                   </div>
                   <div>
@@ -364,7 +364,7 @@ const FinanceiroCapitalGiro = () => {
                     <div className="flex items-center gap-3">
                       <Progress
                         value={active.top5_cp_pct}
-                        className={`h-3 ${active.top5_cp_pct > 70 ? '[&>div]:bg-amber-500' : '[&>div]:bg-blue-500'}`}
+                        className={`h-3 ${active.top5_cp_pct > 70 ? '[&>div]:bg-status-warning-bg0' : '[&>div]:bg-status-info-bg0'}`}
                       />
                       <span className="text-sm font-bold">{active.top5_cp_pct.toFixed(0)}%</span>
                     </div>
@@ -401,13 +401,13 @@ function MetricCard({ title, value, subtitle, positive, icon: Icon }: {
         <div className="flex items-start justify-between">
           <div>
             <p className="text-xs text-muted-foreground font-medium">{title}</p>
-            <p className={`text-lg font-bold mt-1 ${positive ? 'text-emerald-600' : 'text-red-600'}`}>
+            <p className={`text-lg font-bold mt-1 ${positive ? 'text-status-success' : 'text-status-error'}`}>
               {fmtCompact(value)}
             </p>
             <p className="text-xs text-muted-foreground mt-1">{subtitle}</p>
           </div>
-          <div className={`p-2 rounded-lg ${positive ? 'bg-emerald-50' : 'bg-red-50'}`}>
-            <Icon className={`w-4 h-4 ${positive ? 'text-emerald-600' : 'text-red-600'}`} />
+          <div className={`p-2 rounded-lg ${positive ? 'bg-status-success-bg' : 'bg-status-error-bg'}`}>
+            <Icon className={`w-4 h-4 ${positive ? 'text-status-success' : 'text-status-error'}`} />
           </div>
         </div>
       </CardContent>
@@ -474,22 +474,22 @@ function StressTest({ saldoCC, entradas30, saidas30, totalCR, pmr }: {
               const saldo = saldoCC + entradasAjust - saidas30;
               const impacto = saldo - (saldoCC + entradas30 - saidas30);
               const risco = saldo < 0 ? 'Crítico' : saldo < saldoCC * 0.3 ? 'Alto' : saldo < saldoCC * 0.6 ? 'Médio' : 'Baixo';
-              const riskColor = risco === 'Crítico' ? 'text-red-700 bg-red-100'
-                : risco === 'Alto' ? 'text-red-600 bg-red-50'
-                : risco === 'Médio' ? 'text-amber-600 bg-amber-50'
-                : 'text-emerald-600 bg-emerald-50';
+              const riskColor = risco === 'Crítico' ? 'text-status-error bg-status-error-bg'
+                : risco === 'Alto' ? 'text-status-error bg-status-error-bg'
+                : risco === 'Médio' ? 'text-status-warning bg-status-warning-bg'
+                : 'text-status-success bg-status-success-bg';
 
               return (
-                <TableRow key={s.label} className={saldo < 0 ? 'bg-red-50/50' : ''}>
+                <TableRow key={s.label} className={saldo < 0 ? 'bg-status-error-bg/50' : ''}>
                   <TableCell>
                     <p className="text-sm font-medium">{s.label}</p>
                     <p className="text-[10px] text-muted-foreground">{s.desc}</p>
                   </TableCell>
                   <TableCell className="text-right text-sm">{fmtCompact(entradasAjust)}</TableCell>
-                  <TableCell className={`text-right text-sm font-bold ${saldo >= 0 ? 'text-emerald-600' : 'text-red-600'}`}>
+                  <TableCell className={`text-right text-sm font-bold ${saldo >= 0 ? 'text-status-success' : 'text-status-error'}`}>
                     {fmtCompact(saldo)}
                   </TableCell>
-                  <TableCell className={`text-right text-sm ${impacto < 0 ? 'text-red-600' : ''}`}>
+                  <TableCell className={`text-right text-sm ${impacto < 0 ? 'text-status-error' : ''}`}>
                     {fmtCompact(impacto)}
                   </TableCell>
                   <TableCell>

--- a/src/pages/FinanceiroCockpit.tsx
+++ b/src/pages/FinanceiroCockpit.tsx
@@ -206,8 +206,8 @@ const FinanceiroCockpit = () => {
         )}
       </div>
 
-      {/* Row 1: Big 3 */}
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+      {/* Row 1: Big 3 — staggered reveal pra page load orquestrado */}
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4 stagger-children">
         <CockpitCard
           title="Caixa Disponível"
           value={fmtCompact(totalCC)}
@@ -239,8 +239,8 @@ const FinanceiroCockpit = () => {
         />
       </div>
 
-      {/* Row 2: Margens + Inadimplência + Risco */}
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+      {/* Row 2: Margens + Inadimplência + Risco — também staggered */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-3 stagger-children">
         <MiniCard label="Margem Bruta" value={`${margemBruta.toFixed(1)}%`}
           color={margemBruta >= 30 ? 'text-status-success' : 'text-status-warning'} />
         <MiniCard label="Margem Operacional" value={`${margemOp.toFixed(1)}%`}

--- a/src/pages/FinanceiroCockpit.tsx
+++ b/src/pages/FinanceiroCockpit.tsx
@@ -185,17 +185,22 @@ const FinanceiroCockpit = () => {
 
   return (
     <div className="space-y-4 pb-24">
-      {/* Header */}
-      <div className="flex items-center justify-between flex-wrap gap-3">
-        <div>
-          <h1 className="text-2xl font-bold tracking-tight">Cockpit CFO</h1>
-          <p className="text-sm text-muted-foreground mt-1">
-            Consolidado — {new Date().toLocaleDateString('pt-BR', { month: 'long', year: 'numeric' })}
+      {/* Header — display serif Newsreader em h1 + atmosphere gradient sutil + noise */}
+      <div className="relative bg-cockpit-hero noise rounded-lg border border-border px-6 py-8 flex items-center justify-between flex-wrap gap-3 overflow-hidden">
+        <div className="relative">
+          <p className="text-[10px] uppercase tracking-[0.18em] text-muted-foreground font-medium mb-1.5">
+            Financeiro · Cockpit
+          </p>
+          <h1 className="font-display" style={{ fontSize: '2.25rem', fontWeight: 500, letterSpacing: '-0.04em', lineHeight: 1.1 }}>
+            Visão consolidada
+          </h1>
+          <p className="text-sm text-muted-foreground mt-1.5 tabular-nums">
+            {new Date().toLocaleDateString('pt-BR', { month: 'long', year: 'numeric' })}
           </p>
         </div>
         {/* Global transparency */}
         {confiabilidade.length > 0 && (
-          <div className="flex flex-col items-end gap-1">
+          <div className="relative flex flex-col items-end gap-1">
             {confiabilidade.map(c => (
               <div key={c.company} className="flex items-center gap-2">
                 <span className="text-xs font-medium">{COMPANIES[c.company as Company]?.shortName}</span>

--- a/src/pages/FinanceiroDashboard.tsx
+++ b/src/pages/FinanceiroDashboard.tsx
@@ -39,11 +39,11 @@ const fmtDate = (d: string | null) => {
 
 const statusColor = (s: string) => {
   switch (s) {
-    case 'PAGO': case 'RECEBIDO': case 'LIQUIDADO': return 'bg-emerald-100 text-emerald-700';
-    case 'VENCIDO': return 'bg-red-100 text-red-700';
-    case 'PARCIAL': return 'bg-amber-100 text-amber-700';
+    case 'PAGO': case 'RECEBIDO': case 'LIQUIDADO': return 'bg-status-success-bg text-status-success';
+    case 'VENCIDO': return 'bg-status-error-bg text-status-error';
+    case 'PARCIAL': return 'bg-status-warning-bg text-status-warning';
     case 'CANCELADO': return 'bg-gray-100 text-gray-500';
-    default: return 'bg-blue-100 text-blue-700';
+    default: return 'bg-status-info-bg text-status-info';
   }
 };
 
@@ -169,7 +169,7 @@ const FinanceiroDashboard = () => {
       </div>
 
       {error && (
-        <div className="bg-red-50 border border-red-200 rounded-lg p-3 text-sm text-red-700">
+        <div className="bg-status-error-bg border border-status-error/30 rounded-lg p-3 text-sm text-status-error">
           {error}
         </div>
       )}
@@ -192,15 +192,15 @@ const FinanceiroDashboard = () => {
               {alerts.slice(0, 5).map((alert, i) => {
                 const Icon = alert.icon;
                 const bgColor = alert.severity === 'critical'
-                  ? 'bg-red-50 border-red-200'
+                  ? 'bg-status-error-bg border-status-error/30'
                   : alert.severity === 'warning'
-                    ? 'bg-amber-50 border-amber-200'
-                    : 'bg-blue-50 border-blue-200';
+                    ? 'bg-status-warning-bg border-status-warning/30'
+                    : 'bg-status-info-bg border-status-info/30';
                 const textColor = alert.severity === 'critical'
-                  ? 'text-red-700'
+                  ? 'text-status-error'
                   : alert.severity === 'warning'
-                    ? 'text-amber-700'
-                    : 'text-blue-700';
+                    ? 'text-status-warning'
+                    : 'text-status-info';
                 return (
                   <div key={i} className={`flex items-start gap-3 p-3 rounded-lg border ${bgColor}`}>
                     <Icon className={`w-4 h-4 mt-0.5 ${textColor}`} />
@@ -222,37 +222,37 @@ const FinanceiroDashboard = () => {
               title="A Receber"
               value={activeResumo?.total_a_receber || 0}
               icon={ArrowDownCircle}
-              color="text-emerald-600"
-              bgColor="bg-emerald-50"
+              color="text-status-success"
+              bgColor="bg-status-success-bg"
               subtitle={activeResumo?.total_vencido_receber 
                 ? `${fmt(activeResumo.total_vencido_receber)} vencido` 
                 : undefined}
-              subtitleColor="text-red-500"
+              subtitleColor="text-status-error"
             />
             <KpiCard
               title="A Pagar"
               value={activeResumo?.total_a_pagar || 0}
               icon={ArrowUpCircle}
-              color="text-red-600"
-              bgColor="bg-red-50"
+              color="text-status-error"
+              bgColor="bg-status-error-bg"
               subtitle={activeResumo?.total_vencido_pagar
                 ? `${fmt(activeResumo.total_vencido_pagar)} vencido`
                 : undefined}
-              subtitleColor="text-red-500"
+              subtitleColor="text-status-error"
             />
             <KpiCard
               title="Posição Líquida"
               value={activeResumo?.posicao_liquida || 0}
               icon={(activeResumo?.posicao_liquida || 0) >= 0 ? TrendingUp : TrendingDown}
-              color={(activeResumo?.posicao_liquida || 0) >= 0 ? 'text-emerald-600' : 'text-red-600'}
-              bgColor={(activeResumo?.posicao_liquida || 0) >= 0 ? 'bg-emerald-50' : 'bg-red-50'}
+              color={(activeResumo?.posicao_liquida || 0) >= 0 ? 'text-status-success' : 'text-status-error'}
+              bgColor={(activeResumo?.posicao_liquida || 0) >= 0 ? 'bg-status-success-bg' : 'bg-status-error-bg'}
             />
             <KpiCard
               title="Saldo Bancário"
               value={activeResumo?.saldo_total_cc || 0}
               icon={Wallet}
-              color="text-blue-600"
-              bgColor="bg-blue-50"
+              color="text-status-info"
+              bgColor="bg-status-info-bg"
             />
           </div>
 
@@ -274,15 +274,15 @@ const FinanceiroDashboard = () => {
                       <div className="flex items-center gap-6 text-sm">
                         <div className="text-right">
                           <p className="text-muted-foreground text-xs">A Receber</p>
-                          <p className="font-medium text-emerald-600">{fmtCompact(r.total_a_receber)}</p>
+                          <p className="font-medium text-status-success">{fmtCompact(r.total_a_receber)}</p>
                         </div>
                         <div className="text-right">
                           <p className="text-muted-foreground text-xs">A Pagar</p>
-                          <p className="font-medium text-red-600">{fmtCompact(r.total_a_pagar)}</p>
+                          <p className="font-medium text-status-error">{fmtCompact(r.total_a_pagar)}</p>
                         </div>
                         <div className="text-right">
                           <p className="text-muted-foreground text-xs">Líquida</p>
-                          <p className={`font-bold ${r.posicao_liquida >= 0 ? 'text-emerald-600' : 'text-red-600'}`}>
+                          <p className={`font-bold ${r.posicao_liquida >= 0 ? 'text-status-success' : 'text-status-error'}`}>
                             {fmtCompact(r.posicao_liquida)}
                           </p>
                         </div>
@@ -316,7 +316,7 @@ const FinanceiroDashboard = () => {
                     <p className="text-xs text-muted-foreground">Capital de Giro</p>
                     <p className={`text-lg font-bold mt-1 ${
                       (activeResumo.total_a_receber - activeResumo.total_a_pagar) >= 0 
-                        ? 'text-emerald-600' : 'text-red-600'
+                        ? 'text-status-success' : 'text-status-error'
                     }`}>
                       {fmtCompact(activeResumo.total_a_receber - activeResumo.total_a_pagar)}
                     </p>
@@ -327,7 +327,7 @@ const FinanceiroDashboard = () => {
                     <p className="text-xs text-muted-foreground">Inadimplência</p>
                     <p className={`text-lg font-bold mt-1 ${
                       activeResumo.total_a_receber > 0 && (activeResumo.total_vencido_receber / activeResumo.total_a_receber) > 0.15
-                        ? 'text-red-600' : 'text-amber-600'
+                        ? 'text-status-error' : 'text-status-warning'
                     }`}>
                       {activeResumo.total_a_receber > 0
                         ? `${((activeResumo.total_vencido_receber / activeResumo.total_a_receber) * 100).toFixed(1)}%`
@@ -340,7 +340,7 @@ const FinanceiroDashboard = () => {
                     <p className="text-xs text-muted-foreground">Cobertura de Caixa</p>
                     <p className={`text-lg font-bold mt-1 ${
                       activeResumo.total_a_pagar > 0 && (activeResumo.saldo_total_cc / activeResumo.total_a_pagar) >= 0.5
-                        ? 'text-emerald-600' : 'text-red-600'
+                        ? 'text-status-success' : 'text-status-error'
                     }`}>
                       {activeResumo.total_a_pagar > 0
                         ? `${((activeResumo.saldo_total_cc / activeResumo.total_a_pagar) * 100).toFixed(0)}%`
@@ -352,7 +352,7 @@ const FinanceiroDashboard = () => {
                   <div className="text-center p-3 rounded-lg bg-muted/40">
                     <p className="text-xs text-muted-foreground">Risco +90 dias</p>
                     <p className={`text-lg font-bold mt-1 ${
-                      agingReceber.vencido_90_plus_valor > 0 ? 'text-red-600' : 'text-emerald-600'
+                      agingReceber.vencido_90_plus_valor > 0 ? 'text-status-error' : 'text-status-success'
                     }`}>
                       {fmtCompact(agingReceber.vencido_90_plus_valor)}
                     </p>
@@ -389,7 +389,7 @@ const FinanceiroDashboard = () => {
             <Card>
               <CardHeader className="pb-3">
                 <CardTitle className="text-base flex items-center gap-2">
-                  <AlertTriangle className="w-4 h-4 text-red-500" />
+                  <AlertTriangle className="w-4 h-4 text-status-error" />
                   Maiores Inadimplentes
                 </CardTitle>
               </CardHeader>
@@ -403,7 +403,7 @@ const FinanceiroDashboard = () => {
                           {i.cnpj ? formatCnpj(i.cnpj) : '—'} · {i.qtd_titulos} título(s)
                         </p>
                       </div>
-                      <span className="font-bold text-red-600 text-sm">{fmt(i.total_vencido)}</span>
+                      <span className="font-bold text-status-error text-sm">{fmt(i.total_vencido)}</span>
                     </div>
                   ))}
                 </div>
@@ -416,7 +416,7 @@ const FinanceiroDashboard = () => {
             <Card>
               <CardHeader className="pb-3">
                 <CardTitle className="text-base flex items-center gap-2">
-                  <Wallet className="w-4 h-4 text-blue-500" />
+                  <Wallet className="w-4 h-4 text-status-info" />
                   Contas Correntes
                 </CardTitle>
               </CardHeader>
@@ -428,7 +428,7 @@ const FinanceiroDashboard = () => {
                         <p className="font-medium text-sm">{cc.descricao}</p>
                         <p className="text-xs text-muted-foreground">{cc.banco}</p>
                       </div>
-                      <span className={`font-bold text-sm ${cc.saldo_atual >= 0 ? 'text-emerald-600' : 'text-red-600'}`}>
+                      <span className={`font-bold text-sm ${cc.saldo_atual >= 0 ? 'text-status-success' : 'text-status-error'}`}>
                         {fmt(cc.saldo_atual)}
                       </span>
                     </div>
@@ -499,13 +499,13 @@ const FinanceiroDashboard = () => {
                 <p className="text-xs text-muted-foreground">Valor Total</p>
                 <p className="text-sm font-bold">{fmt(crTotals.valor)}</p>
               </div>
-              <div className="p-3 rounded-lg bg-emerald-50 text-center">
+              <div className="p-3 rounded-lg bg-status-success-bg text-center">
                 <p className="text-xs text-muted-foreground">Recebido</p>
-                <p className="text-sm font-bold text-emerald-600">{fmt(crTotals.recebido)}</p>
+                <p className="text-sm font-bold text-status-success">{fmt(crTotals.recebido)}</p>
               </div>
-              <div className="p-3 rounded-lg bg-blue-50 text-center">
+              <div className="p-3 rounded-lg bg-status-info-bg text-center">
                 <p className="text-xs text-muted-foreground">Saldo</p>
-                <p className="text-sm font-bold text-blue-600">{fmt(crTotals.saldo)}</p>
+                <p className="text-sm font-bold text-status-info">{fmt(crTotals.saldo)}</p>
               </div>
             </div>
           )}
@@ -546,7 +546,7 @@ const FinanceiroDashboard = () => {
                         </TableCell>
                         <TableCell className="text-sm">{fmtDate(cr.data_vencimento)}</TableCell>
                         <TableCell className="text-right font-medium">{fmt(cr.valor_documento)}</TableCell>
-                        <TableCell className="text-right text-emerald-600">{fmt(cr.valor_recebido)}</TableCell>
+                        <TableCell className="text-right text-status-success">{fmt(cr.valor_recebido)}</TableCell>
                         <TableCell className="text-right font-bold">{fmt(cr.saldo)}</TableCell>
                         <TableCell>
                           <Badge className={`text-xs ${statusColor(cr.status_titulo)}`}>
@@ -630,13 +630,13 @@ const FinanceiroDashboard = () => {
                 <p className="text-xs text-muted-foreground">Valor Total</p>
                 <p className="text-sm font-bold">{fmt(cpTotals.valor)}</p>
               </div>
-              <div className="p-3 rounded-lg bg-emerald-50 text-center">
+              <div className="p-3 rounded-lg bg-status-success-bg text-center">
                 <p className="text-xs text-muted-foreground">Pago</p>
-                <p className="text-sm font-bold text-emerald-600">{fmt(cpTotals.pago)}</p>
+                <p className="text-sm font-bold text-status-success">{fmt(cpTotals.pago)}</p>
               </div>
-              <div className="p-3 rounded-lg bg-red-50 text-center">
+              <div className="p-3 rounded-lg bg-status-error-bg text-center">
                 <p className="text-xs text-muted-foreground">Saldo</p>
-                <p className="text-sm font-bold text-red-600">{fmt(cpTotals.saldo)}</p>
+                <p className="text-sm font-bold text-status-error">{fmt(cpTotals.saldo)}</p>
               </div>
             </div>
           )}
@@ -677,7 +677,7 @@ const FinanceiroDashboard = () => {
                         </TableCell>
                         <TableCell className="text-sm">{fmtDate(cp.data_vencimento)}</TableCell>
                         <TableCell className="text-right font-medium">{fmt(cp.valor_documento)}</TableCell>
-                        <TableCell className="text-right text-emerald-600">{fmt(cp.valor_pago)}</TableCell>
+                        <TableCell className="text-right text-status-success">{fmt(cp.valor_pago)}</TableCell>
                         <TableCell className="text-right font-bold">{fmt(cp.saldo)}</TableCell>
                         <TableCell>
                           <Badge className={`text-xs ${statusColor(cp.status_titulo)}`}>
@@ -827,10 +827,10 @@ function AgingCard({ title, data, type }: { title: string; data: any; type: 'rec
     data.vencido_90_plus_valor;
 
   const bars = [
-    { label: 'A vencer', value: data.a_vencer_valor, qtd: data.a_vencer_qtd, color: 'bg-blue-500' },
-    { label: '1-30 dias', value: data.vencido_1_30_valor, qtd: data.vencido_1_30_qtd, color: 'bg-amber-500' },
+    { label: 'A vencer', value: data.a_vencer_valor, qtd: data.a_vencer_qtd, color: 'bg-status-info-bg0' },
+    { label: '1-30 dias', value: data.vencido_1_30_valor, qtd: data.vencido_1_30_qtd, color: 'bg-status-warning-bg0' },
     { label: '31-60 dias', value: data.vencido_31_60_valor, qtd: data.vencido_31_60_qtd, color: 'bg-orange-500' },
-    { label: '61-90 dias', value: data.vencido_61_90_valor, qtd: data.vencido_61_90_qtd, color: 'bg-red-500' },
+    { label: '61-90 dias', value: data.vencido_61_90_valor, qtd: data.vencido_61_90_qtd, color: 'bg-status-error-bg0' },
     { label: '+90 dias', value: data.vencido_90_plus_valor, qtd: data.vencido_90_plus_qtd, color: 'bg-red-700' },
   ];
 
@@ -917,26 +917,26 @@ function FluxoCaixaTab({ data, loading, saldoCC }: { data: any[]; loading: boole
       {/* Summary KPIs */}
       <div className="grid grid-cols-2 lg:grid-cols-5 gap-3">
         {saldoCC != null && (
-          <div className="p-3 rounded-lg bg-blue-50 text-center">
+          <div className="p-3 rounded-lg bg-status-info-bg text-center">
             <p className="text-xs text-muted-foreground">Saldo CC Atual</p>
-            <p className="text-sm font-bold text-blue-600">{fmtCompact(saldoCC)}</p>
+            <p className="text-sm font-bold text-status-info">{fmtCompact(saldoCC)}</p>
           </div>
         )}
-        <div className="p-3 rounded-lg bg-emerald-50 text-center">
+        <div className="p-3 rounded-lg bg-status-success-bg text-center">
           <p className="text-xs text-muted-foreground">Recebido</p>
-          <p className="text-sm font-bold text-emerald-600">{fmtCompact(totalEntradasRealizadas)}</p>
+          <p className="text-sm font-bold text-status-success">{fmtCompact(totalEntradasRealizadas)}</p>
         </div>
-        <div className="p-3 rounded-lg bg-red-50 text-center">
+        <div className="p-3 rounded-lg bg-status-error-bg text-center">
           <p className="text-xs text-muted-foreground">Pago</p>
-          <p className="text-sm font-bold text-red-600">{fmtCompact(totalSaidasRealizadas)}</p>
+          <p className="text-sm font-bold text-status-error">{fmtCompact(totalSaidasRealizadas)}</p>
         </div>
-        <div className="p-3 rounded-lg bg-emerald-50/50 text-center">
+        <div className="p-3 rounded-lg bg-status-success-bg/50 text-center">
           <p className="text-xs text-muted-foreground">Previsto Entrar</p>
-          <p className="text-sm font-bold text-emerald-500">{fmtCompact(totalEntradasPrevistas)}</p>
+          <p className="text-sm font-bold text-status-success">{fmtCompact(totalEntradasPrevistas)}</p>
         </div>
-        <div className="p-3 rounded-lg bg-red-50/50 text-center">
+        <div className="p-3 rounded-lg bg-status-error-bg/50 text-center">
           <p className="text-xs text-muted-foreground">Previsto Sair</p>
-          <p className="text-sm font-bold text-red-500">{fmtCompact(totalSaidasPrevistas)}</p>
+          <p className="text-sm font-bold text-status-error">{fmtCompact(totalSaidasPrevistas)}</p>
         </div>
       </div>
 
@@ -952,7 +952,7 @@ function FluxoCaixaTab({ data, loading, saldoCC }: { data: any[]; loading: boole
                 <span className="text-xs text-muted-foreground truncate">{w.label}</span>
                 <div className="relative h-6">
                   <div
-                    className="absolute top-0 h-3 rounded bg-emerald-400/70"
+                    className="absolute top-0 h-3 rounded bg-status-success/70"
                     style={{ width: `${(w.entradas / maxVal) * 100}%` }}
                   />
                   <div
@@ -960,20 +960,20 @@ function FluxoCaixaTab({ data, loading, saldoCC }: { data: any[]; loading: boole
                     style={{ width: `${(w.saidas / maxVal) * 100}%` }}
                   />
                 </div>
-                <span className={`text-right text-xs font-bold ${w.saldo >= 0 ? 'text-emerald-600' : 'text-red-600'}`}>
+                <span className={`text-right text-xs font-bold ${w.saldo >= 0 ? 'text-status-success' : 'text-status-error'}`}>
                   {fmtCompact(w.saldo)}
                 </span>
-                <span className={`text-right text-[10px] ${w.acumulado >= 0 ? 'text-blue-600' : 'text-red-600'}`}>
+                <span className={`text-right text-[10px] ${w.acumulado >= 0 ? 'text-status-info' : 'text-status-error'}`}>
                   {fmtCompact(w.acumulado)}
                 </span>
               </div>
             ))}
           </div>
           <div className="flex gap-4 mt-4 justify-center text-xs text-muted-foreground">
-            <span className="flex items-center gap-1"><span className="w-3 h-3 rounded bg-emerald-400/70" /> Entradas</span>
+            <span className="flex items-center gap-1"><span className="w-3 h-3 rounded bg-status-success/70" /> Entradas</span>
             <span className="flex items-center gap-1"><span className="w-3 h-3 rounded bg-red-400/70" /> Saídas</span>
             <span>Saldo semanal</span>
-            <span className="text-blue-600">Acumulado</span>
+            <span className="text-status-info">Acumulado</span>
           </div>
         </CardContent>
       </Card>
@@ -1007,17 +1007,17 @@ function DRETab({ data, view, ano }: { data: any[]; view: FinanceiroView; ano: n
 
   const dreLines = [
     { label: 'Receita Bruta', field: 'receita_bruta', bold: true, color: '' },
-    { label: '(-) Deduções', field: 'deducoes', bold: false, color: 'text-red-500' },
+    { label: '(-) Deduções', field: 'deducoes', bold: false, color: 'text-status-error' },
     { label: '= Receita Líquida', field: 'receita_liquida', bold: true, color: '' },
-    { label: '(-) CMV', field: 'cmv', bold: false, color: 'text-red-500' },
-    { label: '= Lucro Bruto', field: 'lucro_bruto', bold: true, color: 'text-emerald-600' },
-    { label: '(-) Desp. Operacionais', field: 'despesas_operacionais', bold: false, color: 'text-red-500' },
-    { label: '(-) Desp. Administrativas', field: 'despesas_administrativas', bold: false, color: 'text-red-500' },
-    { label: '(-) Desp. Comerciais', field: 'despesas_comerciais', bold: false, color: 'text-red-500' },
-    { label: '(-) Desp. Financeiras', field: 'despesas_financeiras', bold: false, color: 'text-red-500' },
-    { label: '(+) Rec. Financeiras', field: 'receitas_financeiras', bold: false, color: 'text-emerald-500' },
+    { label: '(-) CMV', field: 'cmv', bold: false, color: 'text-status-error' },
+    { label: '= Lucro Bruto', field: 'lucro_bruto', bold: true, color: 'text-status-success' },
+    { label: '(-) Desp. Operacionais', field: 'despesas_operacionais', bold: false, color: 'text-status-error' },
+    { label: '(-) Desp. Administrativas', field: 'despesas_administrativas', bold: false, color: 'text-status-error' },
+    { label: '(-) Desp. Comerciais', field: 'despesas_comerciais', bold: false, color: 'text-status-error' },
+    { label: '(-) Desp. Financeiras', field: 'despesas_financeiras', bold: false, color: 'text-status-error' },
+    { label: '(+) Rec. Financeiras', field: 'receitas_financeiras', bold: false, color: 'text-status-success' },
     { label: '= Resultado Operacional', field: 'resultado_operacional', bold: true, color: '' },
-    { label: '(-) Impostos', field: 'impostos', bold: false, color: 'text-red-500' },
+    { label: '(-) Impostos', field: 'impostos', bold: false, color: 'text-status-error' },
     { label: '= RESULTADO LÍQUIDO', field: 'resultado_liquido', bold: true, color: '' },
   ];
 
@@ -1025,17 +1025,17 @@ function DRETab({ data, view, ano }: { data: any[]; view: FinanceiroView; ano: n
     <div className="space-y-3">
       {/* Ponto 5: unmapped warning */}
       {uniqueUnmapped.length > 0 && (
-        <div className="flex items-start gap-2 p-3 rounded-lg bg-amber-50 border border-amber-200">
-          <AlertTriangle className="w-4 h-4 text-amber-600 mt-0.5 shrink-0" />
+        <div className="flex items-start gap-2 p-3 rounded-lg bg-status-warning-bg border border-status-warning/30">
+          <AlertTriangle className="w-4 h-4 text-status-warning mt-0.5 shrink-0" />
           <div>
-            <p className="text-sm font-medium text-amber-800">
+            <p className="text-sm font-medium text-status-warning-fg">
               {uniqueUnmapped.length} categoria(s) classificadas por heurística
             </p>
-            <p className="text-xs text-amber-700 mt-1">
+            <p className="text-xs text-status-warning mt-1">
               Estas categorias não têm mapeamento explícito — os valores podem estar em linhas incorretas.
               Configure em <span className="font-medium">Mapeamento DRE</span>.
             </p>
-            <p className="text-xs text-amber-600 mt-1 font-mono">
+            <p className="text-xs text-status-warning mt-1 font-mono">
               {uniqueUnmapped.slice(0, 8).join(', ')}{uniqueUnmapped.length > 8 ? ` (+${uniqueUnmapped.length - 8})` : ''}
             </p>
           </div>
@@ -1072,7 +1072,7 @@ function DRETab({ data, view, ano }: { data: any[]; view: FinanceiroView; ano: n
                   {rows.map((r: any) => {
                     const val = r[line.field] || 0;
                     const colorClass = line.color || (line.bold && line.field.includes('resultado')
-                      ? (val >= 0 ? 'text-emerald-600' : 'text-red-600')
+                      ? (val >= 0 ? 'text-status-success' : 'text-status-error')
                       : '');
                     return (
                       <TableCell key={r.mes} className={`text-right text-sm ${line.bold ? 'font-bold' : ''} ${colorClass}`}>
@@ -1104,7 +1104,7 @@ function DRETab({ data, view, ano }: { data: any[]; view: FinanceiroView; ano: n
                 {rows.map((r: any) => {
                   const pct = r.receita_liquida > 0 ? (r.resultado_liquido / r.receita_liquida) * 100 : 0;
                   return (
-                    <TableCell key={r.mes} className={`text-right text-sm font-medium ${pct >= 0 ? 'text-emerald-600' : 'text-red-600'}`}>
+                    <TableCell key={r.mes} className={`text-right text-sm font-medium ${pct >= 0 ? 'text-status-success' : 'text-status-error'}`}>
                       {pct.toFixed(1)}%
                     </TableCell>
                   );
@@ -1191,7 +1191,7 @@ function DREComparativo({ data, ano }: { data: Record<string, any[]>; ano: numbe
                     const val = (t as any)[line.field] || 0;
                     const isResult = line.field.includes('resultado') || line.field === 'margemLiquida';
                     const colorClass = isResult
-                      ? val >= 0 ? 'text-emerald-600' : 'text-red-600'
+                      ? val >= 0 ? 'text-status-success' : 'text-status-error'
                       : '';
                     return (
                       <TableCell key={t.company} className={`text-right text-sm font-medium ${colorClass}`}>

--- a/src/pages/FinanceiroTributario.tsx
+++ b/src/pages/FinanceiroTributario.tsx
@@ -135,27 +135,27 @@ const FinanceiroTributario = () => {
                   <p className="text-xs text-muted-foreground">Receita Bruta {ano}</p>
                   <p className="text-lg font-bold">{fmtCompact(receitaAnual)}</p>
                 </div>
-                <div className="p-3 rounded-lg bg-red-50 text-center">
+                <div className="p-3 rounded-lg bg-status-error-bg text-center">
                   <p className="text-xs text-muted-foreground">Impostos Pagos</p>
-                  <p className="text-lg font-bold text-red-600">{fmtCompact(impostosAnual)}</p>
+                  <p className="text-lg font-bold text-status-error">{fmtCompact(impostosAnual)}</p>
                 </div>
-                <div className="p-3 rounded-lg bg-amber-50 text-center">
+                <div className="p-3 rounded-lg bg-status-warning-bg text-center">
                   <p className="text-xs text-muted-foreground">Alíquota Efetiva</p>
-                  <p className={`text-lg font-bold ${aliqEfetiva > 15 ? 'text-red-600' : 'text-amber-600'}`}>
+                  <p className={`text-lg font-bold ${aliqEfetiva > 15 ? 'text-status-error' : 'text-status-warning'}`}>
                     {aliqEfetiva.toFixed(2)}%
                   </p>
                 </div>
                 {snInfo && (
-                  <div className="p-3 rounded-lg bg-blue-50 text-center">
+                  <div className="p-3 rounded-lg bg-status-info-bg text-center">
                     <p className="text-xs text-muted-foreground">Faixa SN</p>
-                    <p className="text-lg font-bold text-blue-600">{snInfo.faixa}</p>
+                    <p className="text-lg font-bold text-status-info">{snInfo.faixa}</p>
                     <p className="text-xs text-muted-foreground">Alíq. nominal {snInfo.aliquota.toFixed(2)}%</p>
                   </div>
                 )}
                 {regime !== 'simples' && (
-                  <div className="p-3 rounded-lg bg-blue-50 text-center">
+                  <div className="p-3 rounded-lg bg-status-info-bg text-center">
                     <p className="text-xs text-muted-foreground">Regime</p>
-                    <p className="text-sm font-bold text-blue-600">Lucro Presumido</p>
+                    <p className="text-sm font-bold text-status-info">Lucro Presumido</p>
                     <p className="text-xs text-muted-foreground">Presunção {LP_RATES.comercio.presuncao}% (comércio)</p>
                   </div>
                 )}
@@ -182,15 +182,15 @@ const FinanceiroTributario = () => {
                   <div className="flex items-center gap-3 pt-1 border-t">
                     <span className="text-xs font-bold w-28">Total Estimado</span>
                     <div className="flex-1" />
-                    <span className="text-sm font-bold text-red-600 w-20 text-right">{fmtCompact(lpBreakdown.total)}</span>
+                    <span className="text-sm font-bold text-status-error w-20 text-right">{fmtCompact(lpBreakdown.total)}</span>
                     <span className="text-xs font-bold w-14 text-right">
                       {receitaAnual > 0 ? (lpBreakdown.total / receitaAnual * 100).toFixed(2) : '0'}%
                     </span>
                   </div>
                   {Math.abs(lpBreakdown.total - impostosAnual) > 1000 && impostosAnual > 0 && (
-                    <div className="flex items-start gap-2 p-2 rounded bg-amber-50 border border-amber-200 mt-2">
-                      <AlertTriangle className="w-3.5 h-3.5 text-amber-600 mt-0.5 shrink-0" />
-                      <p className="text-xs text-amber-700">
+                    <div className="flex items-start gap-2 p-2 rounded bg-status-warning-bg border border-status-warning/30 mt-2">
+                      <AlertTriangle className="w-3.5 h-3.5 text-status-warning mt-0.5 shrink-0" />
+                      <p className="text-xs text-status-warning">
                         Diferença de {fmtCompact(Math.abs(lpBreakdown.total - impostosAnual))} entre estimado e pago.
                         Pode indicar ISS, ICMS, ou categorização incorreta.
                       </p>
@@ -220,8 +220,8 @@ const FinanceiroTributario = () => {
                             <TableRow key={d.mes}>
                               <TableCell className="text-sm">{meses[d.mes - 1]}</TableCell>
                               <TableCell className="text-right text-sm">{fmtCompact(d.receita_bruta)}</TableCell>
-                              <TableCell className="text-right text-sm text-red-600">{fmtCompact(d.impostos)}</TableCell>
-                              <TableCell className={`text-right text-sm font-medium ${aliq > 15 ? 'text-red-600' : 'text-amber-600'}`}>
+                              <TableCell className="text-right text-sm text-status-error">{fmtCompact(d.impostos)}</TableCell>
+                              <TableCell className={`text-right text-sm font-medium ${aliq > 15 ? 'text-status-error' : 'text-status-warning'}`}>
                                 {aliq.toFixed(2)}%
                               </TableCell>
                             </TableRow>

--- a/src/pages/GovernanceAudit.tsx
+++ b/src/pages/GovernanceAudit.tsx
@@ -20,10 +20,10 @@ import { ptBR } from 'date-fns/locale';
 /* ─── Helpers ─── */
 
 const ACTION_LABELS: Record<string, { label: string; color: string }> = {
-  proposal_created: { label: 'Proposta criada', color: 'bg-blue-500/10 text-blue-700 border-blue-500/20' },
-  proposal_approved: { label: 'Proposta aprovada', color: 'bg-emerald-500/10 text-emerald-700 border-emerald-500/20' },
+  proposal_created: { label: 'Proposta criada', color: 'bg-status-info/10 text-status-info border-status-info/20' },
+  proposal_approved: { label: 'Proposta aprovada', color: 'bg-status-success/10 text-status-success border-status-success/20' },
   proposal_rejected: { label: 'Proposta rejeitada', color: 'bg-destructive/10 text-destructive border-destructive/20' },
-  param_updated: { label: 'Parâmetro alterado', color: 'bg-amber-500/10 text-amber-700 border-amber-500/20' },
+  param_updated: { label: 'Parâmetro alterado', color: 'bg-status-warning/10 text-status-warning border-status-warning/20' },
   permission_override: { label: 'Override de permissão', color: 'bg-purple-500/10 text-purple-700 border-purple-500/20' },
   role_changed: { label: 'Role alterado', color: 'bg-orange-500/10 text-orange-700 border-orange-500/20' },
 };
@@ -68,7 +68,7 @@ function ParamsDiff({ before, after }: { before: Record<string, any> | null; aft
           <span className="font-mono text-muted-foreground">{key}:</span>
           <span className="text-destructive/80 line-through">{JSON.stringify(before?.[key] ?? '—')}</span>
           <ArrowRight className="w-2.5 h-2.5 text-muted-foreground" />
-          <span className="text-emerald-600 font-medium">{JSON.stringify(after?.[key] ?? '—')}</span>
+          <span className="text-status-success font-medium">{JSON.stringify(after?.[key] ?? '—')}</span>
         </div>
       ))}
       {changedKeys.length > 3 && (
@@ -290,9 +290,9 @@ export default function GovernanceAudit() {
                   <div className="flex items-start gap-3 p-3">
                     {/* Left: color bar */}
                     <div className={`w-1 self-stretch rounded-full shrink-0 ${
-                      log.action.includes('approved') ? 'bg-emerald-500' :
+                      log.action.includes('approved') ? 'bg-status-success-bg0' :
                       log.action.includes('rejected') ? 'bg-destructive' :
-                      log.action.includes('created') ? 'bg-blue-500' : 'bg-amber-500'
+                      log.action.includes('created') ? 'bg-status-info-bg0' : 'bg-status-warning-bg0'
                     }`} />
 
                     <div className="flex-1 min-w-0 space-y-1.5">
@@ -392,7 +392,7 @@ export default function GovernanceAudit() {
                             <ArrowRight className="w-3 h-3 text-muted-foreground" />
                           </>
                         )}
-                        <span className="text-emerald-600 font-mono font-medium">{log.new_value || '—'}</span>
+                        <span className="text-status-success font-mono font-medium">{log.new_value || '—'}</span>
                       </div>
                     </div>
                   </div>

--- a/src/pages/SalesOrders.tsx
+++ b/src/pages/SalesOrders.tsx
@@ -286,7 +286,7 @@ const SalesOrders = () => {
                       </p>
                       {order.omie_numero_pedido && (
                         <p className="text-xs text-muted-foreground">
-                          PV: {order.omie_numero_pedido.replace(/^0+/, '') || '0'}
+                          PV: <span className="font-tabular text-foreground">{order.omie_numero_pedido.replace(/^0+/, '') || '0'}</span>
                         </p>
                       )}
                     </div>

--- a/src/pages/SettingsConfig.tsx
+++ b/src/pages/SettingsConfig.tsx
@@ -18,6 +18,8 @@ import {
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useUserRole } from '@/hooks/useUserRole';
+import { useFeatureFlag } from '@/hooks/useFeatureFlag';
+import { Sparkles, Undo2 } from 'lucide-react';
 
 /* ─── Types ─── */
 interface WeightConfig {
@@ -87,6 +89,7 @@ const SettingsConfig = () => {
   const [weights, setWeights] = useState(defaultWeights);
   const [activeTab, setActiveTab] = useState('recommendations');
   const [hasChanges, setHasChanges] = useState(false);
+  const [newVisualEnabled, toggleNewVisual] = useFeatureFlag('newVisual', true);
 
   const updateWeight = (key: string, value: number) => {
     setWeights(prev => prev.map(w => w.key === key ? { ...w, value } : w));
@@ -108,6 +111,32 @@ const SettingsConfig = () => {
 
   return (
     <div className="space-y-4">
+        {/* Visual feature flag — permite rollback do novo visual sem deploy */}
+        <Card>
+          <CardContent className="p-4 flex items-center justify-between gap-3">
+            <div className="flex items-start gap-3 min-w-0">
+              <div className={cn(
+                'p-2 rounded-md shrink-0',
+                newVisualEnabled ? 'bg-foreground text-background' : 'bg-muted text-muted-foreground',
+              )}>
+                {newVisualEnabled ? <Sparkles className="w-4 h-4" /> : <Undo2 className="w-4 h-4" />}
+              </div>
+              <div className="min-w-0">
+                <p className="text-sm font-medium">
+                  Novo visual {newVisualEnabled ? 'ativado' : 'desativado'}
+                  <Badge variant="outline" className="ml-2 text-2xs">{newVisualEnabled ? 'v3' : 'legacy'}</Badge>
+                </p>
+                <p className="text-xs text-muted-foreground mt-0.5">
+                  {newVisualEnabled
+                    ? 'Tokens novos (Geist, paleta neutra, sombras sutis). Veja showcase em /design-preview.'
+                    : 'Visual antigo restaurado (Inter, paleta azul HubSpot). Toggle volta ao novo.'}
+                </p>
+              </div>
+            </div>
+            <Switch checked={newVisualEnabled} onCheckedChange={toggleNewVisual} />
+          </CardContent>
+        </Card>
+
         {/* Prototype Warning */}
         <div className="flex items-center gap-3 rounded-lg border border-amber-500/30 bg-amber-500/10 p-3">
           <AlertTriangle className="w-5 h-5 text-amber-600 shrink-0" />

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -96,6 +96,9 @@ export default {
       fontFamily: {
         sans: ["Geist", "Inter", "system-ui", "-apple-system", "sans-serif"],
         mono: ["'Geist Mono'", "'JetBrains Mono'", "Fira Code", "monospace"],
+        // Display serif pra h1 de telas-hero (cockpits, design preview).
+        // Newsreader é Production Type, free, com optical sizes 6-72.
+        display: ["Newsreader", "'Source Serif 4'", "Georgia", "serif"],
       },
       fontSize: {
         "2xs": ["0.625rem", { lineHeight: "0.875rem" }],   // 10px


### PR DESCRIPTION
Segunda rodada de melhorias visuais, respondendo às 7 "faria diferente" que listei + adicionais.

## O que vem novo

**Validação preventiva:**
- `docs/visual-direction/03-validacao.md` — contraste WCAG calculado para todas as combinações principais (light + dark), audit das telas restantes, checklist dark mode

**Showcase isolado:**
- Rota `/design-preview` — paleta, tipografia, todas as variantes de buttons (incluindo touch/balcao 44/56px), cards, KPIs, status colors, dialog, tabela, empty states (operational + friendly), skeletons, motion. Toggle inline light/dark
- **Use essa rota pra validar visualmente sem precisar abrir 5 telas**

**Identidade:**
- Wordmark "Colacor" puro substitui Scissors+"Central" (Vercel/Mercury style)
- CompanySwitcher com monogramas coloridos (`C` preto / `O` azul / `S` verde) — identidade mínima por empresa
- Sidebar reorganizada: 4 seções secundárias (Performance, Inteligência, Automação, Documentação) colapsadas por padrão; estado persistido por seção

**Rollback seguro:**
- `useFeatureFlag` + `useFeatureFlagBodyClass` — flag genérica em localStorage
- Toggle 'Novo visual' em `/settings` (card no topo). Off → `html.legacy-visual` reverte tokens críticos. **Permite desligar sem deploy.**

**Refinements:**
- `tabular-nums` global em `<table>` via `index.css`
- 15 telas extras refatoradas (FinanceiroDashboard, FarmerLOCC, FarmerBundles, FarmerCopilot, FarmerTacticalPlan, FarmerDashboard, AdminReposicaoOportunidades, AdminReposicaoPedidos, AdminReposicaoPromocoes, AdminReposicaoPromocaoDetail, AdminReposicaoNegociacaoParalela, FinanceiroCapitalGiro, FinanceiroTributario, Admin, GovernanceAudit) — ~218 cores hardcoded → tokens `text-status-*`

## Pra testar

1. Mergea
2. Espera Lovable rebuildar
3. Abre `/design-preview` — vê tudo isolado
4. Toggle light/dark no topbar (sol/lua)
5. Em `/settings`, vê o card "Novo visual ativado" — toggle pra OFF e o app volta ao visual antigo (sem deploy)