### PR TITLE
refactor(reposicao): sessão unificada — stepper persistente, rotas ca…

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -123,6 +123,12 @@ const AdminReposicaoNegociacaoParalela = lazy(() => import("./pages/AdminReposic
 const AdminReposicaoCockpit = lazy(() => import("./pages/AdminReposicaoCockpit"));
 const AdminReposicaoParametros = lazy(() => import("./pages/AdminReposicaoParametros"));
 const AdminReposicaoMercado = lazy(() => import("./pages/AdminReposicaoMercado"));
+const AdminReposicaoSessaoPedidos = lazy(() => import("./pages/AdminReposicaoSessaoPedidos"));
+const AdminReposicaoSessaoAplicacao = lazy(() => import("./pages/AdminReposicaoSessaoAplicacao"));
+const AdminReposicaoSessaoConfirmacao = lazy(() => import("./pages/AdminReposicaoSessaoConfirmacao"));
+const AdminReposicaoSessaoHistorico = lazy(() => import("./pages/AdminReposicaoSessaoHistorico"));
+const ReposicaoSessionLayout = lazy(() => import("./components/reposicao/ReposicaoSessionLayout"));
+const LegacyCockpitRedirect = lazy(() => import("./components/reposicao/LegacyCockpitRedirect"));
 const AdminReposicaoCadastros = lazy(() => import("./pages/AdminReposicaoCadastros"));
 const AdminEstoqueRecebimento = lazy(() => import("./pages/AdminEstoqueRecebimento"));
 const AdminEstoquePicking = lazy(() => import("./pages/AdminEstoquePicking"));
@@ -263,7 +269,7 @@ const App = () => (
               <Route path="admin/reposicao/revisao" element={<AdminReposicaoRevisao />} />
               <Route path="admin/reposicao/historico" element={<AdminReposicaoHistorico />} />
               <Route path="admin/reposicao/alertas" element={<AdminReposicaoAlertas />} />
-              <Route path="admin/reposicao/aplicacao" element={<AdminReposicaoAplicacao />} />
+              <Route path="admin/reposicao/aplicacao" element={<Navigate to="/admin/reposicao/sessao/aplicacao" replace />} />
               <Route path="admin/reposicao/grupos-producao" element={<AdminReposicaoGruposProducao />} />
               <Route path="admin/reposicao/cadeia-logistica" element={<AdminReposicaoCadeiaLogistica />} />
               <Route path="admin/reposicao/pedidos" element={<AdminReposicaoPedidos />} />
@@ -277,9 +283,20 @@ const App = () => (
               <Route path="admin/reposicao/aumentos/:id" element={<AdminReposicaoAumentoDetail />} />
               <Route path="admin/reposicao/oportunidades" element={<AdminReposicaoOportunidades />} />
               <Route path="admin/reposicao/negociacao-paralela" element={<AdminReposicaoNegociacaoParalela />} />
-              <Route path="admin/reposicao/cockpit" element={<AdminReposicaoCockpit />} />
-              <Route path="admin/reposicao/parametros" element={<AdminReposicaoParametros />} />
-              <Route path="admin/reposicao/mercado" element={<AdminReposicaoMercado />} />
+              {/* Canonical /sessao routes (inside ReposicaoSessionLayout) */}
+              <Route element={<ReposicaoSessionLayout />}>
+                <Route path="admin/reposicao/sessao" element={<AdminReposicaoCockpit />} />
+                <Route path="admin/reposicao/sessao/mercado" element={<AdminReposicaoMercado />} />
+                <Route path="admin/reposicao/sessao/parametros" element={<AdminReposicaoParametros />} />
+                <Route path="admin/reposicao/sessao/pedidos" element={<AdminReposicaoSessaoPedidos />} />
+                <Route path="admin/reposicao/sessao/aplicacao" element={<AdminReposicaoSessaoAplicacao />} />
+                <Route path="admin/reposicao/sessao/confirmacao" element={<AdminReposicaoSessaoConfirmacao />} />
+                <Route path="admin/reposicao/sessao/historico" element={<AdminReposicaoSessaoHistorico />} />
+              </Route>
+              {/* Legacy redirects */}
+              <Route path="admin/reposicao/cockpit" element={<LegacyCockpitRedirect />} />
+              <Route path="admin/reposicao/mercado" element={<Navigate to="/admin/reposicao/sessao/mercado" replace />} />
+              <Route path="admin/reposicao/parametros" element={<Navigate to="/admin/reposicao/sessao/parametros" replace />} />
               <Route path="admin/reposicao/cadastros" element={<AdminReposicaoCadastros />} />
               <Route path="admin/estoque/recebimento" element={<AdminEstoqueRecebimento />} />
               <Route path="admin/estoque/picking" element={<AdminEstoquePicking />} />

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -81,10 +81,10 @@ const unifiedNavSections: { title: string; items: NavItem[] }[] = [
   {
     title: 'Reposição',
     items: [
-      { icon: LayoutDashboard, label: 'Cockpit de Compras', path: '/admin/reposicao/cockpit', managerOnly: true },
-      { icon: Settings, label: 'Parâmetros & Qualidade', path: '/admin/reposicao/parametros', managerOnly: true },
-      { icon: TrendingUp, label: 'Inteligência de Mercado', path: '/admin/reposicao/mercado', managerOnly: true },
-      { icon: Database, label: 'Cadastros & Config', path: '/admin/reposicao/cadastros', managerOnly: true },
+      { icon: LayoutDashboard, label: 'Cockpit', path: '/admin/reposicao/sessao', managerOnly: true },
+      { icon: TrendingUp, label: 'Mercado', path: '/admin/reposicao/sessao/mercado', managerOnly: true },
+      { icon: Settings, label: 'Parâmetros', path: '/admin/reposicao/sessao/parametros', managerOnly: true },
+      { icon: Database, label: 'Cadastros', path: '/admin/reposicao/cadastros', managerOnly: true },
     ],
   },
   {
@@ -476,7 +476,7 @@ function AppSidebar({ collapsed, onToggle }: { collapsed: boolean; onToggle: () 
         if (it.path === '/admin/notificacoes' && notificacoesPendentes) {
           return { ...it, badge: notificacoesPendentes, badgeVariant: 'destructive' as const };
         }
-        if (it.path === '/admin/reposicao/parametros' && alertasCriticos && alertasCriticos > 0) {
+        if (it.path === '/admin/reposicao/sessao/parametros' && alertasCriticos && alertasCriticos > 0) {
           return { ...it, badge: alertasCriticos, badgeVariant: 'destructive' as const };
         }
         if (it.path === '/financeiro/gestao' && financeiroAtrasados && financeiroAtrasados > 0) {

--- a/src/components/reposicao/AuditLogSection.tsx
+++ b/src/components/reposicao/AuditLogSection.tsx
@@ -1,0 +1,131 @@
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { ChevronDown, ChevronRight, ScrollText } from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { supabase } from "@/integrations/supabase/client";
+import { TabFallback } from "./TabFallback";
+
+type LogRow = {
+  id: string;
+  created_at: string;
+  user_id: string | null;
+  action: string;
+  result: string;
+  metadata: Record<string, unknown> | null;
+};
+
+export function AuditLogSection() {
+  const [open, setOpen] = useState(false);
+  const [limit, setLimit] = useState(20);
+
+  const { data: rows = [], isLoading, refetch } = useQuery({
+    queryKey: ["cockpit-audit-log", limit],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from("cockpit_audit_log")
+        .select("id,created_at,user_id,action,result,metadata")
+        .order("created_at", { ascending: false })
+        .limit(limit);
+      if (error) throw error;
+      return ((data ?? []) as unknown) as LogRow[];
+    },
+    enabled: open,
+  });
+
+  return (
+    <Card>
+      <Collapsible open={open} onOpenChange={setOpen}>
+        <CollapsibleTrigger asChild>
+          <button
+            type="button"
+            className="w-full flex items-center justify-between p-4 hover:bg-muted/40 transition-colors"
+          >
+            <div className="flex items-center gap-2">
+              <ScrollText className="h-4 w-4 text-muted-foreground" />
+              <span className="text-sm font-medium">Log de Auditoria</span>
+            </div>
+            {open ? (
+              <ChevronDown className="h-4 w-4 text-muted-foreground" />
+            ) : (
+              <ChevronRight className="h-4 w-4 text-muted-foreground" />
+            )}
+          </button>
+        </CollapsibleTrigger>
+        <CollapsibleContent>
+          <CardContent className="pt-0">
+            {isLoading ? (
+              <TabFallback />
+            ) : rows.length === 0 ? (
+              <div className="py-8 text-center text-sm text-muted-foreground">
+                Nenhum registro de auditoria.
+              </div>
+            ) : (
+              <>
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Quando</TableHead>
+                      <TableHead>Usuário</TableHead>
+                      <TableHead>Ação</TableHead>
+                      <TableHead>Resultado</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {rows.map((r) => {
+                      const isErr = r.result.toLowerCase().startsWith("erro");
+                      return (
+                        <TableRow key={r.id}>
+                          <TableCell className="text-xs whitespace-nowrap">
+                            {new Date(r.created_at).toLocaleString("pt-BR")}
+                          </TableCell>
+                          <TableCell className="text-xs font-mono">
+                            {r.user_id ? r.user_id.slice(0, 8) : "—"}
+                          </TableCell>
+                          <TableCell className="text-sm">{r.action}</TableCell>
+                          <TableCell>
+                            <Badge variant={isErr ? "destructive" : "secondary"}>
+                              {r.result}
+                            </Badge>
+                          </TableCell>
+                        </TableRow>
+                      );
+                    })}
+                  </TableBody>
+                </Table>
+                <div className="flex justify-center pt-4">
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => {
+                      setLimit((l) => l + 20);
+                      refetch();
+                    }}
+                  >
+                    Ver mais
+                  </Button>
+                </div>
+              </>
+            )}
+          </CardContent>
+        </CollapsibleContent>
+      </Collapsible>
+    </Card>
+  );
+}
+
+export default AuditLogSection;

--- a/src/components/reposicao/CicloHojePanel.tsx
+++ b/src/components/reposicao/CicloHojePanel.tsx
@@ -1,0 +1,729 @@
+import { lazy, Suspense, useEffect, useMemo, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import {
+  AlertTriangle,
+  Check,
+  CheckCircle2,
+  Info,
+  ListChecks,
+  Loader2,
+  Pencil,
+  Search,
+  X,
+  XCircle,
+  Zap,
+} from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { supabase } from "@/integrations/supabase/client";
+import { formatBRL, logAudit } from "@/lib/reposicao";
+import { calcApprovalSuggestion } from "@/lib/reposicao/approvalSuggestion";
+import type { ColKey, PedidoItem } from "@/types/reposicao";
+import { ColumnConfigPopover } from "./ColumnConfig";
+import { TabFallback } from "./TabFallback";
+
+const AdminReposicaoPedidos = lazy(() => import("@/pages/AdminReposicaoPedidos"));
+
+export const ALL = "__all__";
+
+type ConfLevel = "alta" | "media" | "baixa";
+
+function inferConfianca(r: PedidoItem): { level: ConfLevel; reason: string } {
+  const s = (r.status ?? "").toLowerCase();
+  if (s.includes("pendente_aprovacao")) {
+    return { level: "alta", reason: "Pedido pendente gerado pelos guardrails do ciclo." };
+  }
+  if (s.includes("disparado") || s.includes("aprovado")) {
+    return { level: "alta", reason: "Pedido já aprovado/disparado." };
+  }
+  if (s.includes("cancel")) {
+    return { level: "baixa", reason: "Pedido cancelado — comprar geraria sobrestoque." };
+  }
+  if (s.includes("bloque")) {
+    return { level: "baixa", reason: "Bloqueado por guardrail." };
+  }
+  return {
+    level: "media",
+    reason: "Sem dados de cobertura no registro; confiança média por padrão (status pendente).",
+  };
+}
+
+function PrecoCell({ row }: { row: PedidoItem }) {
+  const atual = Number(row.valor_total ?? 0);
+  const anterior = Number(row.pedido_anterior_valor ?? NaN);
+  if (!Number.isFinite(anterior) || anterior === 0) {
+    return <span className="font-medium">{formatBRL(atual)}</span>;
+  }
+  const deltaPct = ((atual - anterior) / anterior) * 100;
+  const tone =
+    Math.abs(deltaPct) < 0.5
+      ? "text-muted-foreground"
+      : deltaPct < 0
+        ? "text-status-success"
+        : "text-destructive";
+  return (
+    <div className="flex flex-col items-end">
+      <span className="font-medium">{formatBRL(atual)}</span>
+      <span className={`text-[11px] ${tone}`}>
+        {deltaPct > 0 ? "+" : ""}
+        {deltaPct.toFixed(1)}%
+      </span>
+    </div>
+  );
+}
+
+function ConfiancaBadge({ row }: { row: PedidoItem }) {
+  const { level, reason } = inferConfianca(row);
+  const map = {
+    alta: { label: "Alta", cls: "bg-status-success-bg text-status-success border-status-success/40" },
+    media: { label: "Média", cls: "bg-status-warning-bg text-status-warning border-status-warning/40" },
+    baixa: { label: "Baixa", cls: "bg-muted text-muted-foreground border-border" },
+  } as const;
+  const m = map[level];
+  return (
+    <TooltipProvider delayDuration={200}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span
+            className={`inline-flex items-center gap-1 rounded-md border px-2 py-0.5 text-[11px] font-medium ${m.cls}`}
+          >
+            <Info className="h-3 w-3" /> {m.label}
+          </span>
+        </TooltipTrigger>
+        <TooltipContent className="max-w-[240px] text-xs">{reason}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
+function PedidoRow({
+  row,
+  reviewMode,
+  selected,
+  onToggle,
+  cols,
+  user,
+  onChanged,
+}: {
+  row: PedidoItem;
+  reviewMode: boolean;
+  selected: boolean;
+  onToggle: () => void;
+  cols: Record<ColKey, boolean>;
+  user: { id?: string; email?: string | null } | null;
+  onChanged: () => void;
+}) {
+  const [qty, setQty] = useState<number>(Number(row.num_skus ?? 0));
+  const [busy, setBusy] = useState<null | "approve" | "reject">(null);
+  const [editingAuto, setEditingAuto] = useState(false);
+  const suggestion = calcApprovalSuggestion(row);
+  const showInlineEditor = suggestion.mode === "review" || editingAuto;
+
+  useEffect(() => {
+    setQty(Number(row.num_skus ?? 0));
+  }, [row.num_skus]);
+
+  const isApproved = !!row.aprovado_em;
+  const isRejected = !!row.cancelado_em;
+
+  const rowBg = isApproved
+    ? "bg-status-success-bg/40 hover:bg-status-success-bg"
+    : isRejected
+      ? "bg-destructive/5 hover:bg-destructive/10"
+      : "";
+
+  const act = async (kind: "approve" | "reject") => {
+    if (busy) return;
+    setBusy(kind);
+    const nowIso = new Date().toISOString();
+    const who = user?.email ?? user?.id ?? "cockpit";
+    try {
+      const patch =
+        kind === "approve"
+          ? {
+              aprovado_em: nowIso,
+              aprovado_por: who,
+              status: "aprovado_aguardando_disparo" as const,
+              num_skus: qty,
+            }
+          : {
+              cancelado_em: nowIso,
+              cancelado_por: who,
+              status: "cancelado" as const,
+              justificativa_cancelamento: "Rejeitado inline no Cockpit",
+            };
+      const { error } = await supabase
+        .from("pedido_compra_sugerido")
+        .update(patch)
+        .eq("id", row.id);
+      if (error) throw error;
+      await logAudit({
+        userId: user?.id ?? null,
+        action: kind === "approve" ? "Aprovação inline" : "Rejeição inline",
+        result: "Sucesso",
+        metadata: { id: row.id, qty },
+      });
+      toast.success(kind === "approve" ? "Pedido aprovado" : "Pedido rejeitado");
+      onChanged();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      await logAudit({
+        userId: user?.id ?? null,
+        action: kind === "approve" ? "Aprovação inline" : "Rejeição inline",
+        result: `Erro: ${msg}`,
+        metadata: { id: row.id },
+      });
+      toast.error("Falha na operação");
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  return (
+    <TableRow data-state={selected ? "selected" : undefined} className={rowBg}>
+      {reviewMode && (
+        <TableCell>
+          <Checkbox checked={selected} onCheckedChange={onToggle} />
+        </TableCell>
+      )}
+      {cols.fornecedor && (
+        <TableCell className="text-sm">{row.fornecedor_nome ?? "—"}</TableCell>
+      )}
+      {cols.grupo && (
+        <TableCell className="text-xs text-muted-foreground">
+          {row.grupo_codigo ?? "—"}
+        </TableCell>
+      )}
+      {cols.skus && <TableCell className="text-right">{row.num_skus ?? 0}</TableCell>}
+      {cols.valor && (
+        <TableCell className="text-right font-medium">{formatBRL(row.valor_total)}</TableCell>
+      )}
+      {cols.preco && (
+        <TableCell className="text-right">
+          <PrecoCell row={row} />
+        </TableCell>
+      )}
+      {cols.confianca && (
+        <TableCell>
+          <ConfiancaBadge row={row} />
+        </TableCell>
+      )}
+      {cols.status && (
+        <TableCell>
+          <Badge variant="secondary">{row.status ?? "—"}</Badge>
+        </TableCell>
+      )}
+      {cols.qtdAprovada && (
+        <TableCell>
+          <div className="flex items-center gap-1.5 justify-end">
+            {suggestion.mode === "auto" && !showInlineEditor ? (
+              <>
+                <Badge
+                  variant="secondary"
+                  className="gap-1 bg-primary/10 text-primary border-primary/20"
+                >
+                  <Zap className="h-3 w-3" /> Auto
+                </Badge>
+                <span className="w-10 text-right tabular-nums font-medium">{qty}</span>
+                <Button
+                  size="icon"
+                  variant="outline"
+                  className="h-8 w-8"
+                  onClick={() => setEditingAuto(true)}
+                  title="Editar quantidade antes de aprovar"
+                >
+                  <Pencil className="h-3.5 w-3.5" />
+                </Button>
+              </>
+            ) : (
+              <>
+                {suggestion.mode === "review" && (
+                  <TooltipProvider delayDuration={200}>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Badge
+                          variant="outline"
+                          className="gap-1 border-status-warning/40 text-status-warning bg-status-warning-bg"
+                        >
+                          <AlertTriangle className="h-3 w-3" /> Revisar
+                        </Badge>
+                      </TooltipTrigger>
+                      <TooltipContent className="max-w-[260px] text-xs">
+                        {suggestion.reasons.join(" · ")}
+                      </TooltipContent>
+                    </Tooltip>
+                  </TooltipProvider>
+                )}
+                <Input
+                  type="number"
+                  min={0}
+                  value={qty}
+                  disabled={isApproved || isRejected || busy !== null}
+                  onChange={(e) => setQty(Number(e.target.value) || 0)}
+                  onFocus={(e) => e.currentTarget.select()}
+                  className="h-8 w-20 text-right"
+                />
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  className="h-8 w-8 text-status-success hover:text-status-success hover:bg-status-success-bg"
+                  disabled={isApproved || busy !== null}
+                  onClick={() => act("approve")}
+                  title="Aprovar"
+                >
+                  {busy === "approve" ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : (
+                    <Check className="h-4 w-4" />
+                  )}
+                </Button>
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  className="h-8 w-8 text-destructive hover:bg-destructive/10"
+                  disabled={isRejected || busy !== null}
+                  onClick={() => act("reject")}
+                  title="Rejeitar"
+                >
+                  {busy === "reject" ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : (
+                    <X className="h-4 w-4" />
+                  )}
+                </Button>
+              </>
+            )}
+          </div>
+        </TableCell>
+      )}
+    </TableRow>
+  );
+}
+
+export function CicloHojePanel({
+  user,
+  reviewMode,
+  setReviewMode,
+  filters,
+  setFilters,
+  filteredItems,
+  fornecedores,
+  statuses,
+  isLoading,
+  cols,
+  onColChange,
+}: {
+  user: { id?: string; email?: string | null } | null;
+  reviewMode: boolean;
+  setReviewMode: (b: boolean) => void;
+  filters: { search: string; fornecedor: string; status: string };
+  setFilters: (f: { search: string; fornecedor: string; status: string }) => void;
+  filteredItems: PedidoItem[];
+  fornecedores: string[];
+  statuses: string[];
+  isLoading: boolean;
+  cols: Record<ColKey, boolean>;
+  onColChange: (k: ColKey, v: boolean) => void;
+}) {
+  const queryClient = useQueryClient();
+  const [selected, setSelected] = useState<Set<number>>(new Set());
+  const [busy, setBusy] = useState(false);
+  const [confirmAuto, setConfirmAuto] = useState(false);
+
+  useEffect(() => {
+    if (!reviewMode) setSelected(new Set());
+  }, [reviewMode]);
+
+  const allChecked = filteredItems.length > 0 && filteredItems.every((i) => selected.has(i.id));
+  const toggleAll = () => {
+    if (allChecked) setSelected(new Set());
+    else setSelected(new Set(filteredItems.map((i) => i.id)));
+  };
+  const toggleOne = (id: number) => {
+    const next = new Set(selected);
+    if (next.has(id)) next.delete(id);
+    else next.add(id);
+    setSelected(next);
+  };
+
+  const totalSelectedValue = filteredItems
+    .filter((i) => selected.has(i.id))
+    .reduce((s, r) => s + Number(r.valor_total ?? 0), 0);
+
+  const eligibleAutoItems = useMemo(
+    () =>
+      filteredItems.filter(
+        (item) =>
+          calcApprovalSuggestion(item).mode === "auto" && !item.aprovado_em && !item.cancelado_em,
+      ),
+    [filteredItems],
+  );
+
+  const autoApprovalGroups = useMemo(() => {
+    const map = new Map<string, number>();
+    eligibleAutoItems.forEach((item) => {
+      const fornecedor = item.fornecedor_nome ?? "Sem fornecedor";
+      map.set(fornecedor, (map.get(fornecedor) ?? 0) + Number(item.num_skus ?? 0));
+    });
+    return Array.from(map.entries()).map(([fornecedor, qtd]) => ({ fornecedor, qtd }));
+  }, [eligibleAutoItems]);
+
+  const manualReviewItems = useMemo(
+    () =>
+      filteredItems
+        .filter((item) => !item.aprovado_em && !item.cancelado_em)
+        .map((item) => ({ item, suggestion: calcApprovalSuggestion(item) }))
+        .filter(({ suggestion }) => suggestion.mode === "review"),
+    [filteredItems],
+  );
+
+  const invalidate = () => {
+    queryClient.invalidateQueries({ queryKey: ["cockpit-itens-dia"] });
+    queryClient.invalidateQueries({ queryKey: ["cockpit-current-step"] });
+    queryClient.invalidateQueries({ queryKey: ["reposicao-pedidos"] });
+  };
+
+  const runBatch = async (kind: "approve" | "reject") => {
+    if (selected.size === 0 || busy) return;
+    setBusy(true);
+    const ids = Array.from(selected);
+    const nowIso = new Date().toISOString();
+    const who = user?.email ?? user?.id ?? "cockpit";
+    try {
+      const patch =
+        kind === "approve"
+          ? {
+              aprovado_em: nowIso,
+              aprovado_por: who,
+              status: "aprovado_aguardando_disparo" as const,
+            }
+          : {
+              cancelado_em: nowIso,
+              cancelado_por: who,
+              status: "cancelado" as const,
+              justificativa_cancelamento: "Rejeitado em lote no Cockpit",
+            };
+      const { error } = await supabase
+        .from("pedido_compra_sugerido")
+        .update(patch)
+        .in("id", ids);
+      if (error) throw error;
+
+      await logAudit({
+        userId: user?.id ?? null,
+        action: kind === "approve" ? "Aprovação em lote" : "Rejeição em lote",
+        result: "Sucesso",
+        metadata: { ids, count: ids.length },
+      });
+      toast.success(
+        `${ids.length} pedido(s) ${kind === "approve" ? "aprovado(s)" : "rejeitado(s)"}`,
+      );
+      setSelected(new Set());
+      invalidate();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      await logAudit({
+        userId: user?.id ?? null,
+        action: kind === "approve" ? "Aprovação em lote" : "Rejeição em lote",
+        result: `Erro: ${msg}`,
+        metadata: { ids },
+      });
+      toast.error("Falha na operação em lote");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const runAutoApprove = async () => {
+    if (eligibleAutoItems.length === 0 || busy) return;
+    setBusy(true);
+    const ids = eligibleAutoItems.map((item) => item.id);
+    const nowIso = new Date().toISOString();
+    const who = user?.email ?? user?.id ?? "cockpit";
+    try {
+      const { error } = await supabase
+        .from("pedido_compra_sugerido")
+        .update({
+          aprovado_em: nowIso,
+          aprovado_por: who,
+          status: "aprovado_aguardando_disparo",
+        })
+        .in("id", ids);
+      if (error) throw error;
+      await logAudit({
+        userId: user?.id ?? null,
+        action: "Aprovação automática — critérios atingidos",
+        result: "Sucesso",
+        metadata: { ids, count: ids.length },
+      });
+      toast.success(`${ids.length} pedido(s) aprovado(s) automaticamente`);
+      setConfirmAuto(false);
+      invalidate();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      await logAudit({
+        userId: user?.id ?? null,
+        action: "Aprovação automática — critérios atingidos",
+        result: `Erro: ${msg}`,
+        metadata: { ids },
+      });
+      toast.error("Falha ao aprovar elegíveis");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const clearFilters = () => setFilters({ search: "", fornecedor: ALL, status: ALL });
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center gap-2 rounded-md border p-2 bg-card">
+        <div className="relative flex-1 min-w-[200px]">
+          <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+          <Input
+            value={filters.search}
+            onChange={(e) => setFilters({ ...filters, search: e.target.value })}
+            placeholder="Buscar SKU, descrição ou fornecedor..."
+            className="pl-8 h-9"
+          />
+        </div>
+        <Select
+          value={filters.fornecedor}
+          onValueChange={(v) => setFilters({ ...filters, fornecedor: v })}
+        >
+          <SelectTrigger className="w-[180px] h-9">
+            <SelectValue placeholder="Fornecedor" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={ALL}>Todos os fornecedores</SelectItem>
+            {fornecedores.map((f) => (
+              <SelectItem key={f} value={f}>
+                {f}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Select value={filters.status} onValueChange={(v) => setFilters({ ...filters, status: v })}>
+          <SelectTrigger className="w-[180px] h-9">
+            <SelectValue placeholder="Status" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={ALL}>Todos os status</SelectItem>
+            {statuses.map((s) => (
+              <SelectItem key={s} value={s}>
+                {s}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Button size="sm" variant="ghost" onClick={clearFilters}>
+          Limpar filtros
+        </Button>
+        <Button
+          size="sm"
+          onClick={() => setConfirmAuto(true)}
+          disabled={eligibleAutoItems.length === 0 || busy}
+          title={
+            eligibleAutoItems.length === 0
+              ? "Nenhum item elegível para aprovação automática"
+              : "Aprovar automaticamente apenas os itens classificados como Auto"
+          }
+        >
+          <Zap className="h-4 w-4 mr-1.5" />
+          Aprovar elegíveis ({eligibleAutoItems.length})
+        </Button>
+        <Button
+          size="sm"
+          variant={reviewMode ? "default" : "outline"}
+          onClick={() => setReviewMode(!reviewMode)}
+        >
+          <ListChecks className="h-4 w-4 mr-1.5" />
+          Modo revisão
+        </Button>
+        <ColumnConfigPopover cols={cols} onChange={onColChange} />
+      </div>
+
+      <Card>
+        <CardHeader className="py-3">
+          <CardTitle className="text-base">Pedidos do ciclo ({filteredItems.length})</CardTitle>
+        </CardHeader>
+        <CardContent className="p-0 overflow-x-auto">
+          {isLoading ? (
+            <TabFallback />
+          ) : filteredItems.length === 0 ? (
+            <div className="py-10 text-center text-sm text-muted-foreground">
+              Nenhum pedido para os filtros atuais.
+            </div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  {reviewMode && (
+                    <TableHead className="w-[40px]">
+                      <Checkbox checked={allChecked} onCheckedChange={toggleAll} />
+                    </TableHead>
+                  )}
+                  {cols.fornecedor && <TableHead>Fornecedor</TableHead>}
+                  {cols.grupo && <TableHead>Grupo</TableHead>}
+                  {cols.skus && <TableHead className="text-right">SKUs</TableHead>}
+                  {cols.valor && <TableHead className="text-right">Valor</TableHead>}
+                  {cols.preco && <TableHead className="text-right">Preço</TableHead>}
+                  {cols.confianca && <TableHead>Confiança</TableHead>}
+                  {cols.status && <TableHead>Status</TableHead>}
+                  {cols.qtdAprovada && <TableHead className="text-right">Qtd Aprovada</TableHead>}
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {filteredItems.map((r) => (
+                  <PedidoRow
+                    key={r.id}
+                    row={r}
+                    reviewMode={reviewMode}
+                    selected={selected.has(r.id)}
+                    onToggle={() => toggleOne(r.id)}
+                    cols={cols}
+                    user={user}
+                    onChanged={invalidate}
+                  />
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+
+      <Dialog open={confirmAuto} onOpenChange={setConfirmAuto}>
+        <DialogContent className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <Zap className="h-5 w-5 text-primary" /> Aprovar elegíveis automaticamente
+            </DialogTitle>
+            <DialogDescription>
+              {eligibleAutoItems.length} pedido(s) serão aprovados automaticamente.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="max-h-56 overflow-y-auto rounded-md border">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Fornecedor</TableHead>
+                  <TableHead className="text-right">Qtd</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {autoApprovalGroups.map((group) => (
+                  <TableRow key={group.fornecedor}>
+                    <TableCell>{group.fornecedor}</TableCell>
+                    <TableCell className="text-right tabular-nums">{group.qtd}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+
+          {manualReviewItems.length > 0 && (
+            <div className="space-y-2 pt-2">
+              <div className="flex items-center gap-2 text-sm font-medium">
+                <AlertTriangle className="h-4 w-4 text-status-warning" />
+                {manualReviewItems.length} pedido(s) ficarão para aprovação manual
+              </div>
+              <div className="max-h-40 overflow-y-auto rounded-md border">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Fornecedor</TableHead>
+                      <TableHead>Motivo</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {manualReviewItems.map(({ item, suggestion }) => (
+                      <TableRow key={item.id}>
+                        <TableCell className="text-xs">
+                          {item.fornecedor_nome ?? "Sem fornecedor"}
+                        </TableCell>
+                        <TableCell className="text-xs text-muted-foreground">
+                          {suggestion.reasons.join("; ")}
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+            </div>
+          )}
+          <div className="flex justify-end gap-2 pt-2">
+            <Button variant="outline" onClick={() => setConfirmAuto(false)} disabled={busy}>
+              Cancelar
+            </Button>
+            <Button onClick={runAutoApprove} disabled={busy || eligibleAutoItems.length === 0}>
+              {busy && <Loader2 className="h-4 w-4 mr-1.5 animate-spin" />}
+              Confirmar aprovação automática
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      <Suspense fallback={<TabFallback />}>
+        <AdminReposicaoPedidos />
+      </Suspense>
+
+      {reviewMode && selected.size > 0 && (
+        <div className="fixed bottom-0 left-0 right-0 z-40 border-t bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/80 shadow-lg">
+          <div className="container max-w-7xl mx-auto px-4 py-3 flex flex-wrap items-center justify-between gap-3">
+            <div className="text-sm">
+              <span className="font-semibold">{selected.size}</span> itens selecionados |{" "}
+              <span className="font-semibold">Total: {formatBRL(totalSelectedValue)}</span>
+            </div>
+            <div className="flex gap-2">
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => runBatch("reject")}
+                disabled={busy}
+              >
+                <XCircle className="h-4 w-4 mr-1.5" /> Rejeitar selecionados
+              </Button>
+              <Button size="sm" onClick={() => runBatch("approve")} disabled={busy}>
+                {busy ? (
+                  <Loader2 className="h-4 w-4 mr-1.5 animate-spin" />
+                ) : (
+                  <CheckCircle2 className="h-4 w-4 mr-1.5" />
+                )}
+                Aprovar selecionados
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default CicloHojePanel;

--- a/src/components/reposicao/ColumnConfig.tsx
+++ b/src/components/reposicao/ColumnConfig.tsx
@@ -1,0 +1,85 @@
+import { useState } from "react";
+import { Settings as SettingsIcon } from "lucide-react";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import type { ColKey } from "@/types/reposicao";
+
+export const COL_DEFS: Array<{ key: ColKey; label: string }> = [
+  { key: "fornecedor", label: "Fornecedor" },
+  { key: "grupo", label: "Grupo" },
+  { key: "skus", label: "SKUs" },
+  { key: "valor", label: "Valor" },
+  { key: "status", label: "Status" },
+  { key: "qtdAprovada", label: "Qtd Aprovada" },
+  { key: "preco", label: "Preço" },
+  { key: "confianca", label: "Confiança" },
+];
+
+export const DEFAULT_COLS: Record<ColKey, boolean> = {
+  fornecedor: true,
+  grupo: true,
+  skus: true,
+  valor: true,
+  status: true,
+  qtdAprovada: true,
+  preco: false,
+  confianca: false,
+};
+
+const COLS_STORAGE_KEY = "cockpit-colunas-v1";
+
+export function useColumnConfig() {
+  const [cols, setCols] = useState<Record<ColKey, boolean>>(() => {
+    try {
+      const raw = localStorage.getItem(COLS_STORAGE_KEY);
+      if (!raw) return DEFAULT_COLS;
+      const parsed = JSON.parse(raw) as Partial<Record<ColKey, boolean>>;
+      return { ...DEFAULT_COLS, ...parsed };
+    } catch {
+      return DEFAULT_COLS;
+    }
+  });
+  const update = (key: ColKey, value: boolean) => {
+    const next = { ...cols, [key]: value };
+    setCols(next);
+    try {
+      localStorage.setItem(COLS_STORAGE_KEY, JSON.stringify(next));
+    } catch {
+      /* ignore */
+    }
+  };
+  return { cols, update };
+}
+
+export function ColumnConfigPopover({
+  cols,
+  onChange,
+}: {
+  cols: Record<ColKey, boolean>;
+  onChange: (k: ColKey, v: boolean) => void;
+}) {
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button size="sm" variant="outline" title="Configurar colunas">
+          <SettingsIcon className="h-4 w-4" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-56 p-3" align="end">
+        <div className="text-xs font-semibold mb-2 text-muted-foreground">Colunas visíveis</div>
+        <div className="space-y-2">
+          {COL_DEFS.map((c) => (
+            <label key={c.key} className="flex items-center gap-2 text-sm cursor-pointer">
+              <Checkbox
+                checked={cols[c.key]}
+                onCheckedChange={(v) => onChange(c.key, !!v)}
+              />
+              {c.label}
+            </label>
+          ))}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/components/reposicao/ConfirmacaoPanel.tsx
+++ b/src/components/reposicao/ConfirmacaoPanel.tsx
@@ -1,0 +1,277 @@
+import { useNavigate } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import { format, startOfDay } from "date-fns";
+import { ptBR } from "date-fns/locale";
+import {
+  CheckCircle2,
+  Clock,
+  DollarSign,
+  Package,
+  Send,
+  Truck,
+  ScrollText,
+  ExternalLink,
+  AlertTriangle,
+} from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { supabase } from "@/integrations/supabase/client";
+import { REPOSICAO_EMPRESA } from "@/hooks/useReposicaoSessao";
+
+const formatBRL = (v: number | null | undefined) =>
+  v === null || v === undefined
+    ? "—"
+    : new Intl.NumberFormat("pt-BR", { style: "currency", currency: "BRL" }).format(Number(v));
+
+type PedidoRow = {
+  status: string | null;
+  fornecedor_nome: string | null;
+  num_skus: number | null;
+  valor_total: number | null;
+};
+
+type AuditRow = {
+  id: string;
+  action: string;
+  result: string;
+  created_at: string;
+};
+
+function useResumoCiclo() {
+  const today = format(new Date(), "yyyy-MM-dd");
+  return useQuery({
+    queryKey: ["confirmacao-resumo-ciclo", REPOSICAO_EMPRESA, today],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from("pedido_compra_sugerido")
+        .select("status,fornecedor_nome,num_skus,valor_total")
+        .eq("empresa", REPOSICAO_EMPRESA)
+        .eq("data_ciclo", today);
+      if (error) throw error;
+      const rows = ((data ?? []) as unknown) as PedidoRow[];
+
+      const fornecedores = new Set<string>();
+      let totalSkus = 0;
+      let totalValor = 0;
+      let disparados = 0;
+      let aprovados = 0;
+      let pendentes = 0;
+      let bloqueados = 0;
+
+      for (const r of rows) {
+        if (r.fornecedor_nome) fornecedores.add(r.fornecedor_nome);
+        totalSkus += Number(r.num_skus ?? 0);
+        totalValor += Number(r.valor_total ?? 0);
+        if (r.status === "disparado") disparados++;
+        else if (r.status === "aprovado_aguardando_disparo") aprovados++;
+        else if (r.status === "pendente_aprovacao") pendentes++;
+        else if (r.status === "bloqueado_guardrail") bloqueados++;
+      }
+
+      return {
+        total: rows.length,
+        fornecedores: fornecedores.size,
+        totalSkus,
+        totalValor,
+        disparados,
+        aprovados,
+        pendentes,
+        bloqueados,
+      };
+    },
+    staleTime: 30_000,
+    refetchInterval: 60_000,
+  });
+}
+
+function useTimelineCiclo() {
+  const todayStart = startOfDay(new Date()).toISOString();
+  return useQuery({
+    queryKey: ["confirmacao-timeline", todayStart],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from("cockpit_audit_log")
+        .select("id,action,result,created_at")
+        .gte("created_at", todayStart)
+        .order("created_at", { ascending: true })
+        .limit(50);
+      if (error) throw error;
+      return ((data ?? []) as unknown) as AuditRow[];
+    },
+    staleTime: 30_000,
+  });
+}
+
+export function ConfirmacaoPanel() {
+  const navigate = useNavigate();
+  const { data: resumo, isLoading: loadingResumo } = useResumoCiclo();
+  const { data: timeline = [], isLoading: loadingTimeline } = useTimelineCiclo();
+
+  const concluido = resumo
+    ? resumo.total > 0 &&
+      resumo.pendentes === 0 &&
+      resumo.aprovados === 0 &&
+      resumo.bloqueados === 0
+    : false;
+
+  const semCiclo = !loadingResumo && resumo && resumo.total === 0;
+
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardHeader className="pb-3">
+          <div className="flex items-center justify-between flex-wrap gap-2">
+            <CardTitle className="flex items-center gap-2 text-base">
+              {concluido ? (
+                <CheckCircle2 className="h-5 w-5 text-emerald-500" />
+              ) : (
+                <Clock className="h-5 w-5 text-amber-500" />
+              )}
+              Resumo do ciclo de hoje
+            </CardTitle>
+            {!loadingResumo && resumo && resumo.total > 0 && (
+              <Badge
+                variant="outline"
+                className={
+                  concluido
+                    ? "border-emerald-500/40 bg-emerald-500/10 text-emerald-700"
+                    : "border-amber-500/40 bg-amber-500/10 text-amber-700"
+                }
+              >
+                {concluido ? "Ciclo concluído" : "Em andamento"}
+              </Badge>
+            )}
+          </div>
+        </CardHeader>
+        <CardContent>
+          {loadingResumo ? (
+            <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+              {Array.from({ length: 4 }).map((_, i) => (
+                <Skeleton key={i} className="h-20 w-full" />
+              ))}
+            </div>
+          ) : semCiclo ? (
+            <div className="flex items-center gap-2 text-sm text-muted-foreground py-6">
+              <AlertTriangle className="h-4 w-4" />
+              Nenhum pedido gerado para hoje ainda.
+            </div>
+          ) : (
+            <>
+              <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+                <ResumoCard
+                  icon={<DollarSign className="h-4 w-4 text-primary" />}
+                  label="Valor total"
+                  value={formatBRL(resumo?.totalValor)}
+                />
+                <ResumoCard
+                  icon={<Package className="h-4 w-4 text-primary" />}
+                  label="SKUs"
+                  value={String(resumo?.totalSkus ?? 0)}
+                />
+                <ResumoCard
+                  icon={<Truck className="h-4 w-4 text-primary" />}
+                  label="Fornecedores"
+                  value={String(resumo?.fornecedores ?? 0)}
+                />
+                <ResumoCard
+                  icon={<Send className="h-4 w-4 text-primary" />}
+                  label="Disparados"
+                  value={`${resumo?.disparados ?? 0}/${resumo?.total ?? 0}`}
+                />
+              </div>
+
+              {resumo && (resumo.pendentes > 0 || resumo.bloqueados > 0 || resumo.aprovados > 0) && (
+                <div className="mt-4 flex items-center gap-2 flex-wrap text-xs">
+                  {resumo.pendentes > 0 && (
+                    <Badge variant="outline" className="border-amber-400/40 bg-amber-100/40 text-amber-800">
+                      {resumo.pendentes} pendente{resumo.pendentes > 1 ? "s" : ""} de aprovação
+                    </Badge>
+                  )}
+                  {resumo.aprovados > 0 && (
+                    <Badge variant="outline" className="border-blue-400/40 bg-blue-100/40 text-blue-800">
+                      {resumo.aprovados} aguardando disparo
+                    </Badge>
+                  )}
+                  {resumo.bloqueados > 0 && (
+                    <Badge variant="outline" className="border-red-400/40 bg-red-100/40 text-red-800">
+                      {resumo.bloqueados} bloqueado{resumo.bloqueados > 1 ? "s" : ""}
+                    </Badge>
+                  )}
+                </div>
+              )}
+            </>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="pb-3 flex flex-row items-center justify-between space-y-0">
+          <CardTitle className="flex items-center gap-2 text-base">
+            <ScrollText className="h-5 w-5 text-muted-foreground" />
+            Linha do tempo do ciclo
+          </CardTitle>
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => navigate("/admin/reposicao/historico")}
+          >
+            Ver histórico completo
+            <ExternalLink className="h-3.5 w-3.5 ml-1.5" />
+          </Button>
+        </CardHeader>
+        <CardContent>
+          {loadingTimeline ? (
+            <div className="space-y-2">
+              {Array.from({ length: 4 }).map((_, i) => (
+                <Skeleton key={i} className="h-10 w-full" />
+              ))}
+            </div>
+          ) : timeline.length === 0 ? (
+            <div className="text-sm text-muted-foreground py-4">
+              Nada registrado ainda hoje.
+            </div>
+          ) : (
+            <ol className="relative border-l border-muted ml-2 space-y-3">
+              {timeline.map((ev) => (
+                <li key={ev.id} className="pl-4 relative">
+                  <span className="absolute -left-[5px] top-1.5 h-2.5 w-2.5 rounded-full bg-primary" />
+                  <div className="flex items-baseline gap-2 flex-wrap">
+                    <span className="text-xs font-mono text-muted-foreground tabular-nums">
+                      {format(new Date(ev.created_at), "HH:mm", { locale: ptBR })}
+                    </span>
+                    <span className="text-sm font-medium">{ev.action}</span>
+                    <span className="text-xs text-muted-foreground">— {ev.result}</span>
+                  </div>
+                </li>
+              ))}
+            </ol>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function ResumoCard({
+  icon,
+  label,
+  value,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  value: string;
+}) {
+  return (
+    <div className="rounded-md border bg-card p-3">
+      <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+        {icon}
+        {label}
+      </div>
+      <div className="text-lg font-semibold mt-1 truncate">{value}</div>
+    </div>
+  );
+}
+
+export default ConfirmacaoPanel;

--- a/src/components/reposicao/ContinuarBanner.tsx
+++ b/src/components/reposicao/ContinuarBanner.tsx
@@ -1,0 +1,82 @@
+import { useNavigate } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import { format, startOfDay } from "date-fns";
+import { ptBR } from "date-fns/locale";
+import { ArrowRight, History, Sparkles } from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { supabase } from "@/integrations/supabase/client";
+import { REPOSICAO_STEPS } from "./ProcessoComprasStepper";
+
+interface Props {
+  currentStep: number;
+}
+
+export function ContinuarBanner({ currentStep }: Props) {
+  const navigate = useNavigate();
+  const todayStart = startOfDay(new Date()).toISOString();
+
+  const { data: lastEvent } = useQuery({
+    queryKey: ["cockpit-last-event-today", todayStart],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from("cockpit_audit_log")
+        .select("action,result,created_at")
+        .gte("created_at", todayStart)
+        .order("created_at", { ascending: false })
+        .limit(1);
+      if (error) throw error;
+      const rows = ((data ?? []) as unknown) as Array<{
+        action: string;
+        result: string;
+        created_at: string;
+      }>;
+      return rows[0] ?? null;
+    },
+    staleTime: 30_000,
+  });
+
+  const step = REPOSICAO_STEPS[Math.min(Math.max(currentStep, 1), REPOSICAO_STEPS.length) - 1];
+  const stepLabel = step?.label ?? "—";
+  const stepRoute = step?.to;
+
+  const handleContinuar = () => {
+    if (stepRoute) navigate(stepRoute);
+  };
+
+  const hasHistory = !!lastEvent;
+  const lastTime = lastEvent
+    ? format(new Date(lastEvent.created_at), "HH:mm", { locale: ptBR })
+    : null;
+
+  return (
+    <Card className="border-primary/30 bg-primary/5">
+      <CardContent className="p-4 flex items-center justify-between gap-4 flex-wrap">
+        <div className="flex items-center gap-3 min-w-0">
+          {hasHistory ? (
+            <History className="h-5 w-5 text-primary shrink-0" />
+          ) : (
+            <Sparkles className="h-5 w-5 text-primary shrink-0" />
+          )}
+          <div className="min-w-0">
+            <div className="text-sm font-medium">
+              {hasHistory
+                ? `Última ação às ${lastTime} — ${lastEvent?.action}`
+                : "Iniciar sessão de reposição"}
+            </div>
+            <div className="text-xs text-muted-foreground">
+              Você está na <span className="font-medium text-foreground">etapa {currentStep}</span>:{" "}
+              {stepLabel}
+            </div>
+          </div>
+        </div>
+        <Button size="sm" onClick={handleContinuar}>
+          {hasHistory ? "Continuar" : "Começar"}
+          <ArrowRight className="h-4 w-4 ml-1.5" />
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default ContinuarBanner;

--- a/src/components/reposicao/EtapaChecklist.tsx
+++ b/src/components/reposicao/EtapaChecklist.tsx
@@ -1,0 +1,169 @@
+import { CheckCircle2, Circle, ArrowRight } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
+import { useReposicaoStatus, type ReposicaoStatus } from "@/hooks/useReposicaoSessao";
+import { useNavigate } from "react-router-dom";
+
+export type ChecklistItem = {
+  label: string;
+  done: boolean;
+  cta?: { label: string; to: string };
+};
+
+export type ChecklistDef = {
+  title: string;
+  items: ChecklistItem[];
+};
+
+/** Pure builder — exported for unit testing. */
+export function buildEtapaChecklist(step: number, s: ReposicaoStatus): ChecklistDef {
+  switch (step) {
+    case 1:
+      return {
+        title: "Para concluir a Etapa 1: Mercado",
+        items: [
+          {
+            label: `Avaliar ${s.oportunidadesCount} oportunidade(s) econômica(s) ativa(s)`,
+            done: s.oportunidadesCount === 0,
+            cta:
+              s.oportunidadesCount > 0
+                ? { label: "Abrir oportunidades", to: "/admin/reposicao/oportunidades" }
+                : undefined,
+          },
+        ],
+      };
+    case 2:
+      return {
+        title: "Para concluir a Etapa 2: Parâmetros",
+        items: [
+          {
+            label: `Aprovar ${s.parametrosPendentesCount} parâmetro(s) pendente(s)`,
+            done: s.parametrosPendentesCount === 0,
+            cta:
+              s.parametrosPendentesCount > 0
+                ? { label: "Abrir revisão", to: "/admin/reposicao/revisao" }
+                : undefined,
+          },
+        ],
+      };
+    case 3:
+      return {
+        title: "Para concluir a Etapa 3: Pedidos",
+        items: [
+          {
+            label:
+              s.pedidosTotal === 0
+                ? "Gerar pedidos do ciclo de hoje"
+                : `Revisar ${s.pedidosPendentes} pedido(s) pendente(s)`,
+            done: s.pedidosTotal > 0 && s.pedidosPendentes === 0,
+          },
+          {
+            label:
+              s.pedidosBloqueados > 0
+                ? `Resolver ${s.pedidosBloqueados} pedido(s) bloqueado(s) por guardrail`
+                : "Sem bloqueios de guardrail",
+            done: s.pedidosBloqueados === 0,
+          },
+        ],
+      };
+    case 4:
+      return {
+        title: "Para concluir a Etapa 4: Aplicação Omie",
+        items: [
+          {
+            label: `Confirmar aplicação no Omie (${s.pedidosAprovados} aprovado(s) aguardando)`,
+            done: s.pedidosAprovados === 0 && s.pedidosDisparados > 0,
+          },
+        ],
+      };
+    case 5:
+      return {
+        title: "Para concluir a Etapa 5: Confirmação",
+        items: [
+          {
+            label: `${s.pedidosDisparados} de ${s.pedidosTotal} pedido(s) disparado(s)`,
+            done: s.pedidosTotal > 0 && s.pedidosDisparados === s.pedidosTotal,
+          },
+        ],
+      };
+    default:
+      return { title: "", items: [] };
+  }
+}
+
+interface Props {
+  step: 1 | 2 | 3 | 4 | 5;
+}
+
+export function EtapaChecklist({ step }: Props) {
+  const navigate = useNavigate();
+  const { data: status, isLoading } = useReposicaoStatus();
+
+  if (isLoading || !status) {
+    return (
+      <Card>
+        <CardContent className="p-4">
+          <Skeleton className="h-5 w-48 mb-3" />
+          <Skeleton className="h-4 w-full mb-2" />
+          <Skeleton className="h-4 w-2/3" />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const def = buildEtapaChecklist(step, status);
+  const allDone = def.items.every((i) => i.done);
+
+  return (
+    <Card className={cn(allDone && "border-emerald-500/30 bg-emerald-500/5")}>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-sm flex items-center gap-2">
+          {allDone ? (
+            <CheckCircle2 className="h-4 w-4 text-emerald-500" />
+          ) : (
+            <Circle className="h-4 w-4 text-muted-foreground" />
+          )}
+          {def.title}
+          {allDone && (
+            <span className="text-xs font-normal text-emerald-700 ml-auto">
+              tudo pronto
+            </span>
+          )}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="pt-0">
+        <ul className="space-y-1.5">
+          {def.items.map((item, idx) => (
+            <li key={idx} className="flex items-center justify-between gap-2 text-sm">
+              <div className="flex items-center gap-2 min-w-0">
+                {item.done ? (
+                  <CheckCircle2 className="h-4 w-4 text-emerald-500 shrink-0" />
+                ) : (
+                  <Circle className="h-4 w-4 text-muted-foreground shrink-0" />
+                )}
+                <span className={cn("truncate", item.done && "text-muted-foreground")}>
+                  {item.label}
+                </span>
+              </div>
+              {item.cta && !item.done && (
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="h-7 px-2 text-xs"
+                  onClick={() => navigate(item.cta!.to)}
+                >
+                  {item.cta.label}
+                  <ArrowRight className="h-3 w-3 ml-1" />
+                </Button>
+              )}
+            </li>
+          ))}
+        </ul>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default EtapaChecklist;

--- a/src/components/reposicao/EtapaHeader.tsx
+++ b/src/components/reposicao/EtapaHeader.tsx
@@ -1,0 +1,31 @@
+import { LucideIcon } from "lucide-react";
+
+interface Props {
+  step: number;
+  icon: LucideIcon;
+  title: string;
+  subtitle?: string;
+  actions?: React.ReactNode;
+}
+
+export function EtapaHeader({ step, icon: Icon, title, subtitle, actions }: Props) {
+  return (
+    <header className="flex flex-col sm:flex-row sm:items-center gap-3 justify-between">
+      <div className="flex items-center gap-3">
+        <Icon className="h-6 w-6 text-primary" />
+        <div>
+          {step > 0 && (
+            <div className="text-[10px] font-semibold tracking-wider text-primary uppercase">
+              Etapa {step}
+            </div>
+          )}
+          <h1 className="text-2xl font-bold">{title}</h1>
+          {subtitle && <p className="text-sm text-muted-foreground">{subtitle}</p>}
+        </div>
+      </div>
+      {actions && <div className="flex items-center gap-2 flex-wrap">{actions}</div>}
+    </header>
+  );
+}
+
+export default EtapaHeader;

--- a/src/components/reposicao/EtapasGrid.tsx
+++ b/src/components/reposicao/EtapasGrid.tsx
@@ -1,0 +1,127 @@
+import { useNavigate } from "react-router-dom";
+import { ArrowRight, Lock } from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+import { REPOSICAO_STEPS } from "./ProcessoComprasStepper";
+import { useReposicaoStatus, getStepLocks, type ReposicaoStatus } from "@/hooks/useReposicaoSessao";
+import { Skeleton } from "@/components/ui/skeleton";
+
+function describe(step: number, s: ReposicaoStatus): string {
+  switch (step) {
+    case 1:
+      return s.oportunidadesCount > 0
+        ? `${s.oportunidadesCount} oportunidade(s) ativa(s)`
+        : "Sem oportunidades pendentes";
+    case 2:
+      return s.parametrosPendentesCount > 0
+        ? `${s.parametrosPendentesCount} parâmetro(s) pendente(s)`
+        : "Sem parâmetros pendentes";
+    case 3:
+      if (s.pedidosTotal === 0) return "Nenhum pedido gerado";
+      return s.pedidosPendentes > 0
+        ? `${s.pedidosPendentes} pedido(s) aguardando revisão`
+        : `${s.pedidosTotal} pedido(s) revisado(s)`;
+    case 4:
+      return s.pedidosAprovados > 0
+        ? `${s.pedidosAprovados} aprovado(s) prontos para Omie`
+        : "Nada para aplicar";
+    case 5:
+      return s.pedidosTotal > 0
+        ? `${s.pedidosDisparados}/${s.pedidosTotal} disparado(s)`
+        : "Aguardando geração";
+    default:
+      return "";
+  }
+}
+
+export function EtapasGrid() {
+  const navigate = useNavigate();
+  const { data: status, isLoading } = useReposicaoStatus();
+  const locks = getStepLocks(status);
+  const currentStep = status?.current ?? 3;
+
+  if (isLoading || !status) {
+    return (
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <Skeleton key={i} className="h-28 w-full" />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
+      {REPOSICAO_STEPS.map((step, idx) => {
+        const stepNum = idx + 1;
+        const isCurrent = stepNum === currentStep;
+        const isDone = stepNum < currentStep;
+        const lock = locks[idx];
+        const isLocked = !isCurrent && !isDone && lock.locked;
+        const Icon = step.icon;
+
+        return (
+          <button
+            key={step.label}
+            type="button"
+            onClick={() => navigate(step.to)}
+            className={cn(
+              "text-left transition-colors rounded-lg group",
+              isLocked && "cursor-not-allowed",
+            )}
+          >
+            <Card
+              className={cn(
+                "h-full transition-colors",
+                isCurrent && "border-primary/40 bg-primary/5",
+                isDone && "border-emerald-500/30 bg-emerald-500/5",
+                isLocked && "border-dashed opacity-70",
+                !isCurrent && !isDone && !isLocked && "hover:bg-muted/40",
+              )}
+            >
+              <CardContent className="p-4">
+                <div className="flex items-center justify-between mb-2">
+                  <div className="flex items-center gap-2">
+                    <div
+                      className={cn(
+                        "flex h-7 w-7 items-center justify-center rounded-full text-xs font-semibold",
+                        isCurrent && "bg-primary text-primary-foreground",
+                        isDone && "bg-emerald-500 text-white",
+                        !isCurrent && !isDone && "bg-muted text-foreground/70",
+                      )}
+                    >
+                      {isLocked ? <Lock className="h-3.5 w-3.5" /> : <Icon className="h-4 w-4" />}
+                    </div>
+                    <span className="text-[10px] uppercase tracking-wider text-muted-foreground">
+                      Etapa {stepNum}
+                    </span>
+                  </div>
+                  {isCurrent && (
+                    <Badge className="h-4 px-1.5 text-[9px] bg-primary text-primary-foreground border-0">
+                      atual
+                    </Badge>
+                  )}
+                  {isDone && (
+                    <Badge className="h-4 px-1.5 text-[9px] bg-emerald-500 text-white border-0">
+                      ok
+                    </Badge>
+                  )}
+                </div>
+                <div className="text-sm font-semibold mb-1">{step.label}</div>
+                <div className="text-xs text-muted-foreground line-clamp-2">
+                  {isLocked && lock.reason ? lock.reason : describe(stepNum, status)}
+                </div>
+                <div className="mt-3 text-xs text-primary opacity-0 group-hover:opacity-100 transition-opacity flex items-center gap-1">
+                  Abrir etapa <ArrowRight className="h-3 w-3" />
+                </div>
+              </CardContent>
+            </Card>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+export default EtapasGrid;

--- a/src/components/reposicao/HistoricoComChart.tsx
+++ b/src/components/reposicao/HistoricoComChart.tsx
@@ -1,0 +1,331 @@
+import { lazy, Suspense, useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { format, subDays } from "date-fns";
+import { toast } from "sonner";
+import { CalendarRange, GitCompare, Loader2 } from "lucide-react";
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip as ReTooltip,
+  ResponsiveContainer,
+} from "recharts";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { supabase } from "@/integrations/supabase/client";
+import { formatBRL, formatDate } from "@/lib/reposicao";
+import { REPOSICAO_EMPRESA } from "@/hooks/useReposicaoSessao";
+import { TabFallback } from "./TabFallback";
+
+const AdminReposicaoHistorico = lazy(() => import("@/pages/AdminReposicaoHistorico"));
+
+function useHistoricoChart() {
+  const fim = useMemo(() => new Date(), []);
+  const inicio = useMemo(() => subDays(fim, 60), [fim]);
+  return useQuery({
+    queryKey: ["cockpit-historico-chart", REPOSICAO_EMPRESA, format(fim, "yyyy-MM-dd")],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from("pedido_compra_sugerido")
+        .select("data_ciclo,num_skus,valor_total")
+        .eq("empresa", REPOSICAO_EMPRESA)
+        .gte("data_ciclo", format(inicio, "yyyy-MM-dd"))
+        .lte("data_ciclo", format(fim, "yyyy-MM-dd"));
+      if (error) throw error;
+      const rows = ((data ?? []) as unknown) as Array<{
+        data_ciclo: string;
+        num_skus: number | null;
+        valor_total: number | null;
+      }>;
+      const map = new Map<string, { data: string; total: number; skus: number; valor: number }>();
+      for (const r of rows) {
+        const acc = map.get(r.data_ciclo) ?? {
+          data: r.data_ciclo,
+          total: 0,
+          skus: 0,
+          valor: 0,
+        };
+        acc.total += 1;
+        acc.skus += Number(r.num_skus ?? 0);
+        acc.valor += Number(r.valor_total ?? 0);
+        map.set(r.data_ciclo, acc);
+      }
+      return Array.from(map.values())
+        .sort((a, b) => a.data.localeCompare(b.data))
+        .slice(-12)
+        .map((x) => {
+          const [, m, d] = x.data.split("-");
+          return { ...x, label: `${d}/${m}` };
+        });
+    },
+  });
+}
+
+type CompareRow = {
+  fornecedor_nome: string;
+  num_skus: number;
+  valor_total: number;
+};
+
+type CompareDiff = {
+  novos: CompareRow[];
+  removidos: CompareRow[];
+  alterados: Array<{
+    fornecedor_nome: string;
+    a: CompareRow;
+    b: CompareRow;
+    deltaQty: number;
+    deltaVal: number;
+  }>;
+};
+
+function CompareCyclesSection({ cycles }: { cycles: string[] }) {
+  const [a, setA] = useState<string>("");
+  const [b, setB] = useState<string>("");
+  const [diff, setDiff] = useState<CompareDiff | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const fetchCycle = async (data_ciclo: string): Promise<CompareRow[]> => {
+    const { data, error } = await supabase
+      .from("pedido_compra_sugerido")
+      .select("fornecedor_nome,num_skus,valor_total")
+      .eq("empresa", REPOSICAO_EMPRESA)
+      .eq("data_ciclo", data_ciclo);
+    if (error) throw error;
+    const rows = ((data ?? []) as unknown) as Array<{
+      fornecedor_nome: string | null;
+      num_skus: number | null;
+      valor_total: number | null;
+    }>;
+    const map = new Map<string, CompareRow>();
+    for (const r of rows) {
+      const key = r.fornecedor_nome ?? "—";
+      const acc = map.get(key) ?? { fornecedor_nome: key, num_skus: 0, valor_total: 0 };
+      acc.num_skus += Number(r.num_skus ?? 0);
+      acc.valor_total += Number(r.valor_total ?? 0);
+      map.set(key, acc);
+    }
+    return Array.from(map.values());
+  };
+
+  const compare = async () => {
+    if (!a || !b || a === b) {
+      toast.error("Selecione dois ciclos diferentes");
+      return;
+    }
+    setLoading(true);
+    try {
+      const [arows, brows] = await Promise.all([fetchCycle(a), fetchCycle(b)]);
+      const amap = new Map(arows.map((r) => [r.fornecedor_nome, r]));
+      const bmap = new Map(brows.map((r) => [r.fornecedor_nome, r]));
+      const novos = brows.filter((r) => !amap.has(r.fornecedor_nome));
+      const removidos = arows.filter((r) => !bmap.has(r.fornecedor_nome));
+      const alterados: CompareDiff["alterados"] = [];
+      for (const br of brows) {
+        const ar = amap.get(br.fornecedor_nome);
+        if (!ar) continue;
+        if (ar.num_skus !== br.num_skus || ar.valor_total !== br.valor_total) {
+          alterados.push({
+            fornecedor_nome: br.fornecedor_nome,
+            a: ar,
+            b: br,
+            deltaQty: br.num_skus - ar.num_skus,
+            deltaVal: br.valor_total - ar.valor_total,
+          });
+        }
+      }
+      setDiff({ novos, removidos, alterados });
+    } catch {
+      toast.error("Falha ao comparar ciclos");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader className="py-3">
+        <div className="flex items-center gap-2">
+          <GitCompare className="h-4 w-4 text-muted-foreground" />
+          <CardTitle className="text-base">Comparar ciclos</CardTitle>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <div className="flex flex-wrap items-center gap-2">
+          <Select value={a} onValueChange={setA}>
+            <SelectTrigger className="w-[180px] h-9">
+              <SelectValue placeholder="Ciclo A" />
+            </SelectTrigger>
+            <SelectContent>
+              {cycles.map((c) => (
+                <SelectItem key={c} value={c}>
+                  {formatDate(c)}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Select value={b} onValueChange={setB}>
+            <SelectTrigger className="w-[180px] h-9">
+              <SelectValue placeholder="Ciclo B" />
+            </SelectTrigger>
+            <SelectContent>
+              {cycles.map((c) => (
+                <SelectItem key={c} value={c}>
+                  {formatDate(c)}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Button size="sm" onClick={compare} disabled={loading || !a || !b}>
+            {loading ? <Loader2 className="h-4 w-4 mr-1.5 animate-spin" /> : null}
+            Comparar
+          </Button>
+        </div>
+
+        {diff && (
+          <div className="space-y-3">
+            <div>
+              <div className="text-xs font-semibold text-status-success mb-1">
+                Novos no Ciclo B ({diff.novos.length})
+              </div>
+              {diff.novos.length === 0 ? (
+                <div className="text-xs text-muted-foreground">Nenhum.</div>
+              ) : (
+                <div className="rounded-md border bg-status-success-bg/40 divide-y">
+                  {diff.novos.map((r) => (
+                    <div key={r.fornecedor_nome} className="px-3 py-1.5 text-sm flex justify-between">
+                      <span>{r.fornecedor_nome}</span>
+                      <span className="text-muted-foreground">
+                        {r.num_skus} SKUs · {formatBRL(r.valor_total)}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            <div>
+              <div className="text-xs font-semibold text-destructive mb-1">
+                Removidos vs Ciclo A ({diff.removidos.length})
+              </div>
+              {diff.removidos.length === 0 ? (
+                <div className="text-xs text-muted-foreground">Nenhum.</div>
+              ) : (
+                <div className="rounded-md border bg-destructive/5 divide-y">
+                  {diff.removidos.map((r) => (
+                    <div key={r.fornecedor_nome} className="px-3 py-1.5 text-sm flex justify-between">
+                      <span>{r.fornecedor_nome}</span>
+                      <span className="text-muted-foreground">
+                        {r.num_skus} SKUs · {formatBRL(r.valor_total)}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            <div>
+              <div className="text-xs font-semibold text-status-warning mb-1">
+                Alterados ({diff.alterados.length})
+              </div>
+              {diff.alterados.length === 0 ? (
+                <div className="text-xs text-muted-foreground">Nenhum.</div>
+              ) : (
+                <div className="rounded-md border bg-status-warning-bg divide-y">
+                  {diff.alterados.map((r) => (
+                    <div key={r.fornecedor_nome} className="px-3 py-1.5 text-sm flex justify-between gap-2">
+                      <span>{r.fornecedor_nome}</span>
+                      <span className="text-xs text-muted-foreground">
+                        Δ SKUs: {r.deltaQty > 0 ? "+" : ""}
+                        {r.deltaQty} · Δ valor: {r.deltaVal >= 0 ? "+" : ""}
+                        {formatBRL(r.deltaVal)}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+export function HistoricoComChart() {
+  const { data = [], isLoading } = useHistoricoChart();
+  const cycles = useMemo(() => data.map((d) => d.data).reverse(), [data]);
+  return (
+    <div className="space-y-4">
+      <CompareCyclesSection cycles={cycles} />
+      <Card>
+        <CardHeader className="py-3">
+          <div className="flex items-center gap-2">
+            <CalendarRange className="h-4 w-4 text-muted-foreground" />
+            <CardTitle className="text-base">Últimos 12 ciclos</CardTitle>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {isLoading ? (
+            <TabFallback />
+          ) : data.length === 0 ? (
+            <div className="py-8 text-center text-sm text-muted-foreground">
+              Sem ciclos no período.
+            </div>
+          ) : (
+            <div className="h-[220px] w-full">
+              <ResponsiveContainer>
+                <BarChart data={data}>
+                  <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
+                  <XAxis dataKey="label" className="text-xs" />
+                  <YAxis className="text-xs" />
+                  <ReTooltip
+                    formatter={(value: number, name: string) => {
+                      if (name === "valor") return [formatBRL(value), "Valor"];
+                      if (name === "skus") return [value, "SKUs"];
+                      return [value, name];
+                    }}
+                    labelFormatter={(l) => `Ciclo ${l}`}
+                    content={({ active, payload, label }) => {
+                      if (!active || !payload?.length) return null;
+                      const p = payload[0].payload as {
+                        label: string;
+                        total: number;
+                        skus: number;
+                        valor: number;
+                      };
+                      return (
+                        <div className="rounded-md border bg-popover p-2 text-xs shadow-md">
+                          <div className="font-medium mb-1">{label}</div>
+                          <div>Total pedidos: {p.total}</div>
+                          <div>SKUs: {p.skus}</div>
+                          <div>Valor: {formatBRL(p.valor)}</div>
+                        </div>
+                      );
+                    }}
+                  />
+                  <Bar dataKey="total" className="fill-primary" radius={[4, 4, 0, 0]} />
+                </BarChart>
+              </ResponsiveContainer>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Suspense fallback={<TabFallback />}>
+        <AdminReposicaoHistorico />
+      </Suspense>
+    </div>
+  );
+}
+
+export default HistoricoComChart;

--- a/src/components/reposicao/LegacyCockpitRedirect.tsx
+++ b/src/components/reposicao/LegacyCockpitRedirect.tsx
@@ -1,0 +1,16 @@
+import { Navigate, useSearchParams } from "react-router-dom";
+
+const TAB_TO_ROUTE: Record<string, string> = {
+  ciclohoje: "/admin/reposicao/sessao/pedidos",
+  aplicaromie: "/admin/reposicao/sessao/aplicacao",
+  confirmacao: "/admin/reposicao/sessao/confirmacao",
+  anteriores: "/admin/reposicao/sessao/historico",
+  oportunidades: "/admin/reposicao/oportunidades",
+};
+
+export default function LegacyCockpitRedirect() {
+  const [params] = useSearchParams();
+  const tab = params.get("tab");
+  const dest = (tab && TAB_TO_ROUTE[tab]) || "/admin/reposicao/sessao";
+  return <Navigate to={dest} replace />;
+}

--- a/src/components/reposicao/MetricsStrip.tsx
+++ b/src/components/reposicao/MetricsStrip.tsx
@@ -1,0 +1,56 @@
+import { DollarSign, Package, PiggyBank, TrendingUp } from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Progress } from "@/components/ui/progress";
+import { formatBRL } from "@/lib/reposicao";
+import type { PedidoItem } from "@/types/reposicao";
+
+type IconType = typeof Package;
+
+function MetricCard({
+  icon: I,
+  label,
+  value,
+  extra,
+}: {
+  icon: IconType;
+  label: string;
+  value: string;
+  extra?: React.ReactNode;
+}) {
+  return (
+    <Card>
+      <CardContent className="p-3">
+        <div className="flex items-center gap-2 text-xs text-muted-foreground mb-1">
+          <I className="h-3.5 w-3.5" />
+          {label}
+        </div>
+        <div className="text-lg font-semibold">{value}</div>
+        {extra}
+      </CardContent>
+    </Card>
+  );
+}
+
+export function MetricsStrip({ items }: { items: PedidoItem[] }) {
+  const totalSkus = items.reduce((s, r) => s + Number(r.num_skus ?? 0), 0);
+  const valorEstimado = items.reduce((s, r) => s + Number(r.valor_total ?? 0), 0);
+  const aprovados = items.filter((r) => !!r.aprovado_em).length;
+  const pctAprovado = items.length > 0 ? (aprovados / items.length) * 100 : 0;
+  const economia = 0;
+
+  return (
+    <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
+      <MetricCard icon={Package} label="SKUs sugeridos" value={totalSkus.toLocaleString("pt-BR")} />
+      <MetricCard icon={DollarSign} label="Valor estimado" value={formatBRL(valorEstimado)} />
+      <MetricCard
+        icon={TrendingUp}
+        label="% Aprovado"
+        value={`${pctAprovado.toFixed(0)}%`}
+        extra={<Progress value={pctAprovado} className="h-1.5 mt-2" />}
+      />
+      <MetricCard icon={PiggyBank} label="Economia potencial" value={formatBRL(economia)} />
+    </div>
+  );
+}
+
+export default MetricsStrip;

--- a/src/components/reposicao/ProcessoComprasStepper.tsx
+++ b/src/components/reposicao/ProcessoComprasStepper.tsx
@@ -1,44 +1,60 @@
-import { useNavigate } from "react-router-dom";
-import { Lightbulb, SlidersHorizontal, ClipboardCheck, Upload, Send, ChevronRight, Check } from "lucide-react";
+import { useLocation, useNavigate } from "react-router-dom";
+import {
+  Lightbulb,
+  SlidersHorizontal,
+  ClipboardCheck,
+  Upload,
+  CheckCircle2,
+  ChevronRight,
+  Check,
+  Lock,
+} from "lucide-react";
 import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
+import type { StepLock } from "@/hooks/useReposicaoSessao";
 
 type Step = {
   label: string;
   icon: React.ComponentType<{ className?: string }>;
-  to?: string;
+  to: string;
   description?: string;
 };
 
+export const REPOSICAO_STEPS: Step[] = [
+  { label: "Mercado", icon: Lightbulb, to: "/admin/reposicao/sessao/mercado" },
+  { label: "Parâmetros", icon: SlidersHorizontal, to: "/admin/reposicao/sessao/parametros" },
+  { label: "Pedidos", icon: ClipboardCheck, to: "/admin/reposicao/sessao/pedidos" },
+  { label: "Aplicação Omie", icon: Upload, to: "/admin/reposicao/sessao/aplicacao" },
+  { label: "Confirmação", icon: CheckCircle2, to: "/admin/reposicao/sessao/confirmacao" },
+];
+
 interface Props {
   currentStep?: number;
-  /** Optional click handler. When provided, overrides default navigation. */
   onStepClick?: (step: number) => void;
-  /** When true, renders a skeleton placeholder instead of the stepper. */
   isLoading?: boolean;
+  locks?: StepLock[];
 }
 
-export function ProcessoComprasStepper({ currentStep = 3, onStepClick, isLoading = false }: Props) {
+export function ProcessoComprasStepper({
+  currentStep = 3,
+  onStepClick,
+  isLoading = false,
+  locks,
+}: Props) {
   const navigate = useNavigate();
-
-  const steps: Step[] = [
-    { label: "Oportunidades", icon: Lightbulb, to: "/admin/reposicao/mercado" },
-    { label: "Aprovar Parâmetros", icon: SlidersHorizontal, to: "/admin/reposicao/parametros" },
-    { label: "Revisar Pedidos", icon: ClipboardCheck },
-    { label: "Aplicar no Omie", icon: Upload, to: "/admin/reposicao/cockpit?tab=aplicaromie" },
-    { label: "Confirmar Envio", icon: Send, description: "Aguarde o status Disparado" },
-  ];
+  const location = useLocation();
 
   if (isLoading) {
     return (
       <Card className="p-4">
         <div className="flex flex-col sm:flex-row items-stretch sm:items-center gap-2">
-          {steps.map((_, idx) => (
+          {REPOSICAO_STEPS.map((_, idx) => (
             <div key={idx} className="flex items-center flex-1 min-w-0 gap-2">
               <Skeleton className="h-14 w-full rounded-md" />
-              {idx < steps.length - 1 && (
+              {idx < REPOSICAO_STEPS.length - 1 && (
                 <ChevronRight className="hidden sm:block h-4 w-4 text-muted-foreground shrink-0" />
               )}
             </div>
@@ -49,37 +65,42 @@ export function ProcessoComprasStepper({ currentStep = 3, onStepClick, isLoading
   }
 
   return (
-    <Card className="p-4">
-      <ol className="flex flex-col sm:flex-row items-stretch sm:items-center gap-2 sm:gap-0">
-        {steps.map((step, idx) => {
-          const stepNum = idx + 1;
-          const isCurrent = stepNum === currentStep;
-          const isDone = stepNum < currentStep;
-          const isFuture = stepNum > currentStep;
-          const Icon = step.icon;
-          const clickable = !!onStepClick || !!step.to;
+    <TooltipProvider delayDuration={150}>
+      <Card className="p-4">
+        <ol className="flex flex-col sm:flex-row items-stretch sm:items-center gap-2 sm:gap-0">
+          {REPOSICAO_STEPS.map((step, idx) => {
+            const stepNum = idx + 1;
+            const isCurrent = stepNum === currentStep;
+            const isDone = stepNum < currentStep;
+            const isFuture = stepNum > currentStep;
+            const lock = locks?.[idx];
+            const isLocked = !isCurrent && !isDone && !!lock?.locked;
+            const Icon = step.icon;
 
-          const handleClick = () => {
-            if (onStepClick) {
-              onStepClick(stepNum);
-            } else if (step.to) {
-              navigate(step.to);
-            }
-          };
+            const handleClick = () => {
+              if (onStepClick) {
+                onStepClick(stepNum);
+                return;
+              }
+              const targetPath = step.to.split("?")[0];
+              const samePage = location.pathname === targetPath;
+              navigate(step.to, { replace: samePage });
+            };
 
-          return (
-            <li key={step.label} className="flex items-center flex-1 min-w-0">
+            const button = (
               <button
                 type="button"
-                disabled={!clickable}
                 onClick={handleClick}
+                aria-current={isCurrent ? "step" : undefined}
+                aria-disabled={isLocked ? "true" : undefined}
                 className={cn(
                   "flex items-center gap-2 rounded-md px-3 py-2 w-full text-left transition-colors",
                   isCurrent && "bg-primary/10 text-primary border border-primary/30",
                   isDone && "bg-emerald-500/5 text-foreground border border-emerald-500/20",
-                  isFuture && "bg-muted/40 text-muted-foreground border border-transparent",
-                  clickable && !isCurrent && "hover:bg-muted hover:text-foreground cursor-pointer",
-                  !clickable && !isCurrent && "cursor-default",
+                  isFuture && !isLocked && "bg-muted/40 text-muted-foreground border border-transparent",
+                  isLocked && "bg-muted/30 text-muted-foreground/70 border border-dashed border-muted-foreground/20 opacity-70",
+                  !isCurrent && !isLocked && "hover:bg-muted hover:text-foreground cursor-pointer",
+                  isLocked && "cursor-not-allowed",
                 )}
               >
                 <div
@@ -87,48 +108,58 @@ export function ProcessoComprasStepper({ currentStep = 3, onStepClick, isLoading
                     "flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-xs font-semibold",
                     isCurrent && "bg-primary text-primary-foreground",
                     isDone && "bg-emerald-500 text-white",
-                    isFuture && "bg-muted text-foreground/70",
+                    isFuture && !isLocked && "bg-muted text-foreground/70",
+                    isLocked && "bg-muted text-muted-foreground/60",
                   )}
                 >
-                  {isDone ? <Check className="h-4 w-4" /> : <Icon className="h-4 w-4" />}
+                  {isDone ? (
+                    <Check className="h-4 w-4" />
+                  ) : isLocked ? (
+                    <Lock className="h-3.5 w-3.5" />
+                  ) : (
+                    <Icon className="h-4 w-4" />
+                  )}
                 </div>
                 <div className="min-w-0 flex-1">
-                  <div className="flex items-center gap-1.5 flex-wrap">
+                  <div className="flex items-center gap-1.5">
                     <span className="text-[10px] uppercase tracking-wide opacity-70">
                       Etapa {stepNum}
                     </span>
                     {isDone && (
                       <Badge className="h-4 px-1.5 text-[9px] bg-emerald-500 hover:bg-emerald-500 text-white border-0">
-                        Concluído
-                      </Badge>
-                    )}
-                    {isCurrent && (
-                      <Badge className="h-4 px-1.5 text-[9px] bg-primary hover:bg-primary text-primary-foreground border-0">
-                        Etapa {stepNum}
-                      </Badge>
-                    )}
-                    {isFuture && (
-                      <Badge variant="secondary" className="h-4 px-1.5 text-[9px]">
-                        Pendente
+                        ok
                       </Badge>
                     )}
                   </div>
                   <div className="text-sm font-medium truncate">{step.label}</div>
-                  {step.description && (
-                    <div className="text-xs text-muted-foreground truncate">
-                      {step.description}
-                    </div>
-                  )}
                 </div>
               </button>
-              {idx < steps.length - 1 && (
-                <ChevronRight className="hidden sm:block h-4 w-4 text-muted-foreground mx-1 shrink-0" />
-              )}
-            </li>
-          );
-        })}
-      </ol>
-    </Card>
+            );
+
+            return (
+              <li key={step.label} className="flex items-center flex-1 min-w-0">
+                {isLocked && lock?.reason ? (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span className="w-full">{button}</span>
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom" className="max-w-xs">
+                      <p className="font-medium mb-1">Etapa bloqueada</p>
+                      <p className="text-xs">{lock.reason}</p>
+                    </TooltipContent>
+                  </Tooltip>
+                ) : (
+                  button
+                )}
+                {idx < REPOSICAO_STEPS.length - 1 && (
+                  <ChevronRight className="hidden sm:block h-4 w-4 text-muted-foreground mx-1 shrink-0" />
+                )}
+              </li>
+            );
+          })}
+        </ol>
+      </Card>
+    </TooltipProvider>
   );
 }
 

--- a/src/components/reposicao/ReposicaoSessionLayout.tsx
+++ b/src/components/reposicao/ReposicaoSessionLayout.tsx
@@ -1,0 +1,42 @@
+import { Outlet } from "react-router-dom";
+import { format } from "date-fns";
+import { ptBR } from "date-fns/locale";
+import { CalendarRange } from "lucide-react";
+import { ProcessoComprasStepper, REPOSICAO_STEPS } from "./ProcessoComprasStepper";
+import { useReposicaoStatus, getStepLocks } from "@/hooks/useReposicaoSessao";
+
+const CUTOFF = "09:30";
+
+export default function ReposicaoSessionLayout() {
+  const { data: status, isLoading } = useReposicaoStatus();
+  const currentStep = status?.current ?? 3;
+  const locks = getStepLocks(status);
+  const today = format(new Date(), "EEEE, dd/MM/yyyy", { locale: ptBR });
+  const stepLabel = REPOSICAO_STEPS[Math.min(Math.max(currentStep, 1), REPOSICAO_STEPS.length) - 1]?.label;
+
+  return (
+    <div className="container mx-auto px-4 sm:px-6 pt-4 sm:pt-6 max-w-7xl">
+      <div className="flex items-center justify-between gap-3 flex-wrap mb-3">
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <CalendarRange className="h-4 w-4" />
+          <span className="font-medium text-foreground capitalize">{today}</span>
+          <span aria-hidden>·</span>
+          <span>cutoff {CUTOFF}</span>
+          {!isLoading && stepLabel && (
+            <>
+              <span aria-hidden>·</span>
+              <span>
+                etapa atual{" "}
+                <span className="text-foreground font-medium">{currentStep}. {stepLabel}</span>
+              </span>
+            </>
+          )}
+        </div>
+      </div>
+      <ProcessoComprasStepper currentStep={currentStep} isLoading={isLoading} locks={locks} />
+      <div className="mt-6 pb-24">
+        <Outlet />
+      </div>
+    </div>
+  );
+}

--- a/src/components/reposicao/SmartAlertsSection.tsx
+++ b/src/components/reposicao/SmartAlertsSection.tsx
@@ -1,0 +1,159 @@
+import { useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import { AlertTriangle, Bell, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { supabase } from "@/integrations/supabase/client";
+import { REPOSICAO_EMPRESA } from "@/hooks/useReposicaoSessao";
+
+const CUTOFF_HOUR = 9;
+const CUTOFF_MIN = 30;
+
+type SmartAlert = {
+  id: string;
+  level: "yellow" | "orange" | "red";
+  message: string;
+  actionLabel: string;
+  onAction: () => void;
+};
+
+function useSmartAlerts(): SmartAlert[] {
+  const navigate = useNavigate();
+
+  const { data: paramsPendentes = 0 } = useQuery({
+    queryKey: ["cockpit-alert-params-pendentes", REPOSICAO_EMPRESA],
+    queryFn: async () => {
+      const cutoff = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+      const { count, error } = await supabase
+        .from("sku_parametros")
+        .select("*", { count: "exact", head: true })
+        .eq("empresa", REPOSICAO_EMPRESA)
+        .eq("ativo", true)
+        .is("aprovado_em", null)
+        .lt("ultima_atualizacao_calculo", cutoff);
+      if (error) throw error;
+      return count ?? 0;
+    },
+    staleTime: 60_000,
+  });
+
+  const { data: skusSemParam = 0 } = useQuery({
+    queryKey: ["cockpit-alert-sem-parametro", REPOSICAO_EMPRESA],
+    queryFn: async () => {
+      const { count, error } = await supabase
+        .from("sku_parametros")
+        .select("*", { count: "exact", head: true })
+        .eq("empresa", REPOSICAO_EMPRESA)
+        .eq("ativo", true)
+        .is("estoque_minimo", null);
+      if (error) throw error;
+      return count ?? 0;
+    },
+    staleTime: 60_000,
+  });
+
+  return useMemo(() => {
+    const list: SmartAlert[] = [];
+    if (paramsPendentes > 0) {
+      list.push({
+        id: "params-24h",
+        level: "yellow",
+        message: `${paramsPendentes} parâmetro(s) aguardam aprovação há mais de 24h`,
+        actionLabel: "Ver parâmetros",
+        onAction: () => navigate("/admin/reposicao/sessao/parametros"),
+      });
+    }
+    const now = new Date();
+    const cutoff = new Date(now);
+    cutoff.setHours(CUTOFF_HOUR, CUTOFF_MIN, 0, 0);
+    const minutes = (cutoff.getTime() - now.getTime()) / 60_000;
+    if (minutes > 0 && minutes < 60) {
+      list.push({
+        id: "janela-1h",
+        level: "orange",
+        message: `Janela de compra fecha em ${Math.ceil(minutes)} minutos`,
+        actionLabel: "Ver cockpit",
+        onAction: () => navigate("/admin/reposicao/sessao/pedidos"),
+      });
+    }
+    if (skusSemParam > 0) {
+      list.push({
+        id: "skus-sem-param",
+        level: "red",
+        message: `${skusSemParam} SKU(s) ativos sem parâmetro configurado`,
+        actionLabel: "Configurar",
+        onAction: () => navigate("/admin/reposicao/sessao/parametros"),
+      });
+    }
+    return list;
+  }, [paramsPendentes, skusSemParam, navigate]);
+}
+
+export function SmartAlertsSection() {
+  const alerts = useSmartAlerts();
+  const [dismissed, setDismissed] = useState<Set<string>>(() => {
+    try {
+      const raw = sessionStorage.getItem("cockpit-dismissed-alerts");
+      return new Set(raw ? (JSON.parse(raw) as string[]) : []);
+    } catch {
+      return new Set();
+    }
+  });
+
+  const dismiss = (id: string) => {
+    const next = new Set(dismissed);
+    next.add(id);
+    setDismissed(next);
+    try {
+      sessionStorage.setItem("cockpit-dismissed-alerts", JSON.stringify(Array.from(next)));
+    } catch {
+      /* ignore */
+    }
+  };
+
+  const visible = alerts.filter((a) => !dismissed.has(a.id)).slice(0, 3);
+  if (visible.length === 0) return null;
+
+  const tone = (l: SmartAlert["level"]) =>
+    l === "yellow"
+      ? "border-status-warning/40 bg-status-warning-bg text-status-warning-fg"
+      : l === "orange"
+        ? "border-orange-500/40 bg-orange-500/5 text-orange-900 dark:text-orange-200"
+        : "border-destructive/40 bg-destructive/5 text-destructive";
+
+  const Icon = ({ l }: { l: SmartAlert["level"] }) =>
+    l === "red" ? (
+      <AlertTriangle className="h-4 w-4 shrink-0" />
+    ) : l === "orange" ? (
+      <Bell className="h-4 w-4 shrink-0" />
+    ) : (
+      <AlertTriangle className="h-4 w-4 shrink-0" />
+    );
+
+  return (
+    <div className="space-y-2">
+      {visible.map((a) => (
+        <div
+          key={a.id}
+          className={`flex items-center gap-3 rounded-md border px-3 py-2 text-sm ${tone(a.level)}`}
+        >
+          <Icon l={a.level} />
+          <span className="flex-1">{a.message}</span>
+          <Button size="sm" variant="outline" onClick={a.onAction}>
+            {a.actionLabel}
+          </Button>
+          <button
+            type="button"
+            onClick={() => dismiss(a.id)}
+            className="opacity-60 hover:opacity-100"
+            aria-label="Dispensar"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default SmartAlertsSection;

--- a/src/components/reposicao/TabFallback.tsx
+++ b/src/components/reposicao/TabFallback.tsx
@@ -1,0 +1,10 @@
+import { Loader2 } from "lucide-react";
+
+export const TabFallback = () => (
+  <div className="flex items-center justify-center py-16 text-muted-foreground">
+    <Loader2 className="h-5 w-5 animate-spin mr-2" />
+    Carregando...
+  </div>
+);
+
+export default TabFallback;

--- a/src/components/reposicao/__tests__/EtapaChecklist.test.ts
+++ b/src/components/reposicao/__tests__/EtapaChecklist.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "vitest";
+import { buildEtapaChecklist } from "@/components/reposicao/EtapaChecklist";
+import type { ReposicaoStatus } from "@/hooks/useReposicaoSessao";
+
+const baseStatus: ReposicaoStatus = {
+  current: 3,
+  oportunidadesCount: 0,
+  parametrosPendentesCount: 0,
+  pedidosTotal: 0,
+  pedidosPendentes: 0,
+  pedidosBloqueados: 0,
+  pedidosAprovados: 0,
+  pedidosDisparados: 0,
+};
+
+describe("buildEtapaChecklist", () => {
+  it("Etapa 1: item done when no opportunities, no CTA", () => {
+    const def = buildEtapaChecklist(1, baseStatus);
+    expect(def.title).toMatch(/Mercado/);
+    expect(def.items[0].done).toBe(true);
+    expect(def.items[0].cta).toBeUndefined();
+  });
+
+  it("Etapa 1: item pending + CTA when opportunities exist", () => {
+    const def = buildEtapaChecklist(1, { ...baseStatus, oportunidadesCount: 4 });
+    expect(def.items[0].done).toBe(false);
+    expect(def.items[0].label).toMatch(/4 oportunidade/);
+    expect(def.items[0].cta?.to).toBe("/admin/reposicao/oportunidades");
+  });
+
+  it("Etapa 2: pending when params await approval", () => {
+    const def = buildEtapaChecklist(2, { ...baseStatus, parametrosPendentesCount: 7 });
+    expect(def.items[0].done).toBe(false);
+    expect(def.items[0].label).toMatch(/7 par[aâ]metro/);
+    expect(def.items[0].cta?.to).toBe("/admin/reposicao/revisao");
+  });
+
+  it("Etapa 3: not done while no pedidos generated", () => {
+    const def = buildEtapaChecklist(3, { ...baseStatus, pedidosTotal: 0 });
+    expect(def.items[0].done).toBe(false);
+    expect(def.items[0].label).toMatch(/gerar pedidos/i);
+  });
+
+  it("Etapa 3: done when pedidos exist and none pending", () => {
+    const def = buildEtapaChecklist(3, {
+      ...baseStatus,
+      pedidosTotal: 12,
+      pedidosPendentes: 0,
+      pedidosBloqueados: 0,
+    });
+    expect(def.items[0].done).toBe(true);
+    expect(def.items[1].done).toBe(true);
+  });
+
+  it("Etapa 3: flags blocked pedidos as a separate not-done item", () => {
+    const def = buildEtapaChecklist(3, {
+      ...baseStatus,
+      pedidosTotal: 12,
+      pedidosBloqueados: 2,
+    });
+    expect(def.items[1].done).toBe(false);
+    expect(def.items[1].label).toMatch(/2 pedido.*bloquead/i);
+  });
+
+  it("Etapa 4: done only when nothing approved-awaiting and something dispatched", () => {
+    const notDone = buildEtapaChecklist(4, { ...baseStatus, pedidosAprovados: 3 });
+    expect(notDone.items[0].done).toBe(false);
+
+    const done = buildEtapaChecklist(4, {
+      ...baseStatus,
+      pedidosAprovados: 0,
+      pedidosDisparados: 5,
+    });
+    expect(done.items[0].done).toBe(true);
+  });
+
+  it("Etapa 5: done only when every pedido is dispatched", () => {
+    const partial = buildEtapaChecklist(5, {
+      ...baseStatus,
+      pedidosTotal: 10,
+      pedidosDisparados: 7,
+    });
+    expect(partial.items[0].done).toBe(false);
+
+    const full = buildEtapaChecklist(5, {
+      ...baseStatus,
+      pedidosTotal: 10,
+      pedidosDisparados: 10,
+    });
+    expect(full.items[0].done).toBe(true);
+  });
+
+  it("returns empty def for unknown step", () => {
+    const def = buildEtapaChecklist(99, baseStatus);
+    expect(def.title).toBe("");
+    expect(def.items).toHaveLength(0);
+  });
+});

--- a/src/hooks/__tests__/useReposicaoSessao.test.ts
+++ b/src/hooks/__tests__/useReposicaoSessao.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from "vitest";
+import {
+  deriveCurrentStep,
+  getStepLocks,
+  type ReposicaoStatus,
+} from "@/hooks/useReposicaoSessao";
+
+const baseStatus: ReposicaoStatus = {
+  current: 3,
+  oportunidadesCount: 0,
+  parametrosPendentesCount: 0,
+  pedidosTotal: 0,
+  pedidosPendentes: 0,
+  pedidosBloqueados: 0,
+  pedidosAprovados: 0,
+  pedidosDisparados: 0,
+};
+
+describe("deriveCurrentStep", () => {
+  const m = {
+    oportunidadesCount: 0,
+    parametrosPendentesCount: 0,
+    pedidosPendentes: 0,
+    pedidosAprovados: 0,
+    pedidosDisparados: 0,
+  };
+
+  it("returns 1 when there are open opportunities (highest priority)", () => {
+    expect(
+      deriveCurrentStep({ ...m, oportunidadesCount: 5, parametrosPendentesCount: 9 }),
+    ).toBe(1);
+  });
+
+  it("returns 2 when params pending and no opportunities", () => {
+    expect(deriveCurrentStep({ ...m, parametrosPendentesCount: 3 })).toBe(2);
+  });
+
+  it("returns 3 when pedidos pending and earlier steps clear", () => {
+    expect(deriveCurrentStep({ ...m, pedidosPendentes: 2 })).toBe(3);
+  });
+
+  it("returns 4 when only approved-awaiting-dispatch remain", () => {
+    expect(deriveCurrentStep({ ...m, pedidosAprovados: 4 })).toBe(4);
+  });
+
+  it("returns 5 when only dispatched remain", () => {
+    expect(deriveCurrentStep({ ...m, pedidosDisparados: 7 })).toBe(5);
+  });
+
+  it("defaults to 3 when nothing is pending", () => {
+    expect(deriveCurrentStep(m)).toBe(3);
+  });
+
+  it("respects priority order: opportunities beat everything", () => {
+    expect(
+      deriveCurrentStep({
+        oportunidadesCount: 1,
+        parametrosPendentesCount: 1,
+        pedidosPendentes: 1,
+        pedidosAprovados: 1,
+        pedidosDisparados: 1,
+      }),
+    ).toBe(1);
+  });
+});
+
+describe("getStepLocks", () => {
+  it("returns 5 unlocked steps when status is undefined", () => {
+    const locks = getStepLocks(undefined);
+    expect(locks).toHaveLength(5);
+    expect(locks.every((l) => !l.locked)).toBe(true);
+  });
+
+  it("never locks steps 1 and 2 (triage steps)", () => {
+    const locks = getStepLocks({ ...baseStatus, pedidosTotal: 0 });
+    expect(locks[0].locked).toBe(false);
+    expect(locks[1].locked).toBe(false);
+  });
+
+  it("locks step 3 when no pedidos were generated", () => {
+    const locks = getStepLocks({ ...baseStatus, pedidosTotal: 0 });
+    expect(locks[2].locked).toBe(true);
+    expect(locks[2].reason).toMatch(/nenhum pedido/i);
+  });
+
+  it("unlocks step 3 once pedidos exist", () => {
+    const locks = getStepLocks({ ...baseStatus, pedidosTotal: 10 });
+    expect(locks[2].locked).toBe(false);
+  });
+
+  it("locks step 4 while pedidos are still pending review", () => {
+    const locks = getStepLocks({
+      ...baseStatus,
+      pedidosTotal: 10,
+      pedidosPendentes: 3,
+    });
+    expect(locks[3].locked).toBe(true);
+    expect(locks[3].reason).toMatch(/aguardando revis/i);
+  });
+
+  it("unlocks step 4 when all pedidos are reviewed", () => {
+    const locks = getStepLocks({
+      ...baseStatus,
+      pedidosTotal: 10,
+      pedidosPendentes: 0,
+      pedidosAprovados: 10,
+    });
+    expect(locks[3].locked).toBe(false);
+  });
+
+  it("locks step 5 when nothing is approved or dispatched", () => {
+    const locks = getStepLocks({ ...baseStatus, pedidosTotal: 10 });
+    expect(locks[4].locked).toBe(true);
+  });
+
+  it("unlocks step 5 once there are approved or dispatched pedidos", () => {
+    const locks = getStepLocks({
+      ...baseStatus,
+      pedidosTotal: 10,
+      pedidosAprovados: 5,
+    });
+    expect(locks[4].locked).toBe(false);
+  });
+});

--- a/src/hooks/useReposicaoSessao.ts
+++ b/src/hooks/useReposicaoSessao.ts
@@ -1,0 +1,176 @@
+import { useQuery } from "@tanstack/react-query";
+import { format } from "date-fns";
+import { supabase } from "@/integrations/supabase/client";
+import type { PedidoItem } from "@/types/reposicao";
+
+export const REPOSICAO_EMPRESA = "OBEN";
+
+export function useItensDoDia() {
+  const today = format(new Date(), "yyyy-MM-dd");
+  return useQuery({
+    queryKey: ["cockpit-itens-dia", REPOSICAO_EMPRESA, today],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from("pedido_compra_sugerido")
+        .select(
+          "id,fornecedor_nome,grupo_codigo,num_skus,valor_total,pedido_anterior_valor,status,aprovado_em,cancelado_em,horario_disparo_real",
+        )
+        .eq("empresa", REPOSICAO_EMPRESA)
+        .eq("data_ciclo", today)
+        .order("fornecedor_nome");
+      if (error) throw error;
+      return ((data ?? []) as unknown) as PedidoItem[];
+    },
+    staleTime: 30_000,
+  });
+}
+
+export type ReposicaoStatus = {
+  current: number;
+  oportunidadesCount: number;
+  parametrosPendentesCount: number;
+  pedidosTotal: number;
+  pedidosPendentes: number;
+  pedidosBloqueados: number;
+  pedidosAprovados: number;
+  pedidosDisparados: number;
+};
+
+const DEFAULT: ReposicaoStatus = {
+  current: 3,
+  oportunidadesCount: 0,
+  parametrosPendentesCount: 0,
+  pedidosTotal: 0,
+  pedidosPendentes: 0,
+  pedidosBloqueados: 0,
+  pedidosAprovados: 0,
+  pedidosDisparados: 0,
+};
+
+/**
+ * Pure derivation of the "current step" from cycle metrics. Extracted so it can
+ * be unit-tested independently of the Supabase query.
+ */
+export function deriveCurrentStep(m: {
+  oportunidadesCount: number;
+  parametrosPendentesCount: number;
+  pedidosPendentes: number;
+  pedidosAprovados: number;
+  pedidosDisparados: number;
+}): number {
+  if (m.oportunidadesCount > 0) return 1;
+  if (m.parametrosPendentesCount > 0) return 2;
+  if (m.pedidosPendentes > 0) return 3;
+  if (m.pedidosAprovados > 0) return 4;
+  if (m.pedidosDisparados > 0) return 5;
+  return 3;
+}
+
+export function useReposicaoStatus() {
+  const today = format(new Date(), "yyyy-MM-dd");
+
+  return useQuery<ReposicaoStatus>({
+    queryKey: ["cockpit-current-step", REPOSICAO_EMPRESA, today],
+    queryFn: async () => {
+      const oport = await supabase
+        .from("v_oportunidade_economica_hoje")
+        .select("*", { count: "exact", head: true })
+        .eq("empresa", REPOSICAO_EMPRESA);
+      if (oport.error) throw oport.error;
+
+      const params = await supabase
+        .from("sku_parametros")
+        .select("*", { count: "exact", head: true })
+        .eq("empresa", REPOSICAO_EMPRESA)
+        .eq("ativo", true)
+        .is("aprovado_em", null);
+      if (params.error) throw params.error;
+
+      const pedidos = await supabase
+        .from("pedido_compra_sugerido")
+        .select("status")
+        .eq("empresa", REPOSICAO_EMPRESA)
+        .eq("data_ciclo", today);
+      if (pedidos.error) throw pedidos.error;
+
+      const statuses = (((pedidos.data ?? []) as unknown) as Array<{ status: string | null }>).map(
+        (r) => r.status,
+      );
+      const pedidosPendentes = statuses.filter(
+        (s) => s === "pendente_aprovacao" || s === "bloqueado_guardrail",
+      ).length;
+      const pedidosBloqueados = statuses.filter((s) => s === "bloqueado_guardrail").length;
+      const pedidosAprovados = statuses.filter((s) => s === "aprovado_aguardando_disparo").length;
+      const pedidosDisparados = statuses.filter((s) => s === "disparado").length;
+
+      const oportunidadesCount = oport.count ?? 0;
+      const parametrosPendentesCount = params.count ?? 0;
+
+      const current = deriveCurrentStep({
+        oportunidadesCount,
+        parametrosPendentesCount,
+        pedidosPendentes,
+        pedidosAprovados,
+        pedidosDisparados,
+      });
+
+      return {
+        current,
+        oportunidadesCount,
+        parametrosPendentesCount,
+        pedidosTotal: statuses.length,
+        pedidosPendentes,
+        pedidosBloqueados,
+        pedidosAprovados,
+        pedidosDisparados,
+      };
+    },
+    staleTime: 30_000,
+    refetchInterval: 60_000,
+  });
+}
+
+/**
+ * Per-step lock and status. A step is "locked" when its prerequisite isn't met
+ * (e.g. step 4 needs all pendentes resolved). A locked step is still navigable —
+ * the lock surfaces as visual feedback + tooltip + guarded confirm on actions.
+ */
+export type StepLock = { locked: boolean; reason?: string };
+
+export function getStepLocks(status: ReposicaoStatus | undefined): StepLock[] {
+  if (!status) return Array.from({ length: 5 }, () => ({ locked: false }));
+  const s = status;
+  return [
+    { locked: false },
+    { locked: false },
+    {
+      locked: s.pedidosTotal === 0,
+      reason:
+        s.pedidosTotal === 0
+          ? "Nenhum pedido foi gerado para hoje. Rode 'Gerar agora' primeiro."
+          : undefined,
+    },
+    {
+      locked: s.pedidosTotal === 0 || s.pedidosPendentes > 0,
+      reason:
+        s.pedidosTotal === 0
+          ? "Nenhum pedido foi gerado para hoje."
+          : s.pedidosPendentes > 0
+            ? `Ainda há ${s.pedidosPendentes} pedido(s) aguardando revisão na etapa 3.`
+            : undefined,
+    },
+    {
+      locked: s.pedidosDisparados === 0 && s.pedidosAprovados === 0,
+      reason:
+        s.pedidosDisparados === 0 && s.pedidosAprovados === 0
+          ? "Aprove pedidos na etapa 3 ou aguarde o disparo."
+          : undefined,
+    },
+  ];
+}
+
+// Backwards-compatible thin wrapper returning just the current step number.
+export function useCurrentStep() {
+  const q = useReposicaoStatus();
+  return { ...q, data: q.data?.current ?? DEFAULT.current };
+}

--- a/src/lib/reposicao.ts
+++ b/src/lib/reposicao.ts
@@ -1,0 +1,56 @@
+import { supabase } from "@/integrations/supabase/client";
+import { logger } from "@/lib/logger";
+
+export const formatBRL = (v: number | null | undefined) =>
+  v === null || v === undefined
+    ? "—"
+    : new Intl.NumberFormat("pt-BR", { style: "currency", currency: "BRL" }).format(Number(v));
+
+export const formatDate = (d: string | null | undefined) => {
+  if (!d) return "—";
+  const [y, m, day] = d.split("-");
+  return `${day}/${m}/${y}`;
+};
+
+export function toCsvValue(v: unknown): string {
+  if (v === null || v === undefined) return "";
+  const s = String(v);
+  if (/[",\n;]/.test(s)) return `"${s.replace(/"/g, '""')}"`;
+  return s;
+}
+
+export function downloadCsv(filename: string, headers: string[], rows: unknown[][]) {
+  const csv = [headers.join(";"), ...rows.map((r) => r.map(toCsvValue).join(";"))].join("\n");
+  const blob = new Blob([`\uFEFF${csv}`], { type: "text/csv;charset=utf-8;" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+export async function logAudit(params: {
+  userId: string | null;
+  action: string;
+  result: string;
+  metadata?: Record<string, unknown>;
+}) {
+  try {
+    await supabase.from("cockpit_audit_log").insert({
+      user_id: params.userId,
+      action: params.action,
+      result: params.result,
+      metadata: params.metadata ?? {},
+    });
+  } catch (e) {
+    // não bloqueia a UI, mas registra no logger pra não perder a auditoria silenciosamente
+    logger.warn("Falha ao gravar cockpit_audit_log", {
+      action: params.action,
+      result: params.result,
+      error: e instanceof Error ? e.message : String(e),
+    });
+  }
+}

--- a/src/pages/AdminReposicaoCockpit.tsx
+++ b/src/pages/AdminReposicaoCockpit.tsx
@@ -1,1715 +1,57 @@
-import { lazy, Suspense, useEffect, useMemo, useState, useCallback } from "react";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useMemo, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { useNavigate, useSearchParams } from "react-router-dom";
-import { supabase } from "@/integrations/supabase/client";
-import { useAuth } from "@/contexts/AuthContext";
-import { format, subDays, differenceInHours } from "date-fns";
+import { format } from "date-fns";
 import { toast } from "sonner";
 import {
-  Sparkles,
-  Loader2,
-  CalendarRange,
-  AlertTriangle,
   Download,
-  ChevronDown,
-  ChevronRight,
-  ScrollText,
-  Search,
-  ListChecks,
   Keyboard,
-  X,
-  CheckCircle2,
-  XCircle,
-  Bell,
-  Settings as SettingsIcon,
-  Package,
-  DollarSign,
-  TrendingUp,
-  PiggyBank,
+  Loader2,
   Printer,
-  Check,
-  GitCompare,
-  Info,
-  Pencil,
-  Zap,
+  RotateCw,
+  Sparkles,
 } from "lucide-react";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
-import { Input } from "@/components/ui/input";
-import { Checkbox } from "@/components/ui/checkbox";
-import { Progress } from "@/components/ui/progress";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogDescription,
-} from "@/components/ui/dialog";
-import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from "@/components/ui/collapsible";
-import { ProcessoComprasStepper } from "@/components/reposicao/ProcessoComprasStepper";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
-import {
-  BarChart,
-  Bar,
-  XAxis,
-  YAxis,
-  CartesianGrid,
-  Tooltip as ReTooltip,
-  ResponsiveContainer,
-} from "recharts";
+import { supabase } from "@/integrations/supabase/client";
+import { useAuth } from "@/contexts/AuthContext";
 import { useRegisterShortcuts } from "@/components/shell/ShortcutsRegistry";
-import { logger } from "@/lib/logger";
-
-const AdminReposicaoPedidos = lazy(() => import("./AdminReposicaoPedidos"));
-const AdminReposicaoAplicacao = lazy(() => import("./AdminReposicaoAplicacao"));
-const AdminReposicaoHistorico = lazy(() => import("./AdminReposicaoHistorico"));
-
-const EMPRESA = "OBEN";
-const ALL = "__all__";
-const CUTOFF_HOUR = 9;
-const CUTOFF_MIN = 30;
-
-const formatBRL = (v: number | null | undefined) =>
-  v === null || v === undefined
-    ? "—"
-    : new Intl.NumberFormat("pt-BR", { style: "currency", currency: "BRL" }).format(Number(v));
-
-const formatDate = (d: string | null | undefined) => {
-  if (!d) return "—";
-  const [y, m, day] = d.split("-");
-  return `${day}/${m}/${y}`;
-};
-
-const TabFallback = () => (
-  <div className="flex items-center justify-center py-16 text-muted-foreground">
-    <Loader2 className="h-5 w-5 animate-spin mr-2" />
-    Carregando...
-  </div>
-);
-
-// ============================================================================
-// CSV utils
-// ============================================================================
-
-function toCsvValue(v: unknown): string {
-  if (v === null || v === undefined) return "";
-  const s = String(v);
-  if (/[",\n;]/.test(s)) return `"${s.replace(/"/g, '""')}"`;
-  return s;
-}
-
-function downloadCsv(filename: string, headers: string[], rows: unknown[][]) {
-  const csv = [headers.join(";"), ...rows.map((r) => r.map(toCsvValue).join(";"))].join("\n");
-  const blob = new Blob([`\uFEFF${csv}`], { type: "text/csv;charset=utf-8;" });
-  const url = URL.createObjectURL(blob);
-  const a = document.createElement("a");
-  a.href = url;
-  a.download = filename;
-  document.body.appendChild(a);
-  a.click();
-  document.body.removeChild(a);
-  URL.revokeObjectURL(url);
-}
-
-// ============================================================================
-// Audit log
-// ============================================================================
-
-async function logAudit(params: {
-  userId: string | null;
-  action: string;
-  result: string;
-  metadata?: Record<string, unknown>;
-}) {
-  try {
-    await supabase.from("cockpit_audit_log" as any).insert({
-      user_id: params.userId,
-      action: params.action,
-      result: params.result,
-      metadata: params.metadata ?? {},
-    });
-  } catch (e) {
-    // não bloqueia a UI, mas registra no logger pra não perder a auditoria silenciosamente
-    logger.warn("Falha ao gravar cockpit_audit_log", {
-      action: params.action,
-      result: params.result,
-      error: e instanceof Error ? e.message : String(e),
-    });
-  }
-}
-
-function AuditLogSection() {
-  const [open, setOpen] = useState(false);
-  const [limit, setLimit] = useState(20);
-
-  type LogRow = {
-    id: string;
-    created_at: string;
-    user_id: string | null;
-    action: string;
-    result: string;
-    metadata: Record<string, unknown> | null;
-  };
-
-  const { data: rows = [], isLoading, refetch } = useQuery({
-    queryKey: ["cockpit-audit-log", limit],
-    queryFn: async () => {
-      const { data, error } = await supabase
-        .from("cockpit_audit_log" as any)
-        .select("id,created_at,user_id,action,result,metadata")
-        .order("created_at", { ascending: false })
-        .limit(limit);
-      if (error) throw error;
-      return ((data ?? []) as unknown) as LogRow[];
-    },
-    enabled: open,
-  });
-
-  return (
-    <Card>
-      <Collapsible open={open} onOpenChange={setOpen}>
-        <CollapsibleTrigger asChild>
-          <button
-            type="button"
-            className="w-full flex items-center justify-between p-4 hover:bg-muted/40 transition-colors"
-          >
-            <div className="flex items-center gap-2">
-              <ScrollText className="h-4 w-4 text-muted-foreground" />
-              <span className="text-sm font-medium">Log de Auditoria</span>
-            </div>
-            {open ? (
-              <ChevronDown className="h-4 w-4 text-muted-foreground" />
-            ) : (
-              <ChevronRight className="h-4 w-4 text-muted-foreground" />
-            )}
-          </button>
-        </CollapsibleTrigger>
-        <CollapsibleContent>
-          <CardContent className="pt-0">
-            {isLoading ? (
-              <TabFallback />
-            ) : rows.length === 0 ? (
-              <div className="py-8 text-center text-sm text-muted-foreground">
-                Nenhum registro de auditoria.
-              </div>
-            ) : (
-              <>
-                <Table>
-                  <TableHeader>
-                    <TableRow>
-                      <TableHead>Quando</TableHead>
-                      <TableHead>Usuário</TableHead>
-                      <TableHead>Ação</TableHead>
-                      <TableHead>Resultado</TableHead>
-                    </TableRow>
-                  </TableHeader>
-                  <TableBody>
-                    {rows.map((r) => {
-                      const isErr = r.result.toLowerCase().startsWith("erro");
-                      return (
-                        <TableRow key={r.id}>
-                          <TableCell className="text-xs whitespace-nowrap">
-                            {new Date(r.created_at).toLocaleString("pt-BR")}
-                          </TableCell>
-                          <TableCell className="text-xs font-mono">
-                            {r.user_id ? r.user_id.slice(0, 8) : "—"}
-                          </TableCell>
-                          <TableCell className="text-sm">{r.action}</TableCell>
-                          <TableCell>
-                            <Badge variant={isErr ? "destructive" : "secondary"}>
-                              {r.result}
-                            </Badge>
-                          </TableCell>
-                        </TableRow>
-                      );
-                    })}
-                  </TableBody>
-                </Table>
-                <div className="flex justify-center pt-4">
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    onClick={() => {
-                      setLimit((l) => l + 20);
-                      refetch();
-                    }}
-                  >
-                    Ver mais
-                  </Button>
-                </div>
-              </>
-            )}
-          </CardContent>
-        </CollapsibleContent>
-      </Collapsible>
-    </Card>
-  );
-}
-
-// ============================================================================
-// Itens do ciclo (hoje) — query reutilizada para filtros, métricas, batch e CSV
-// ============================================================================
-
-type PedidoItem = {
-  id: number;
-  fornecedor_nome: string | null;
-  grupo_codigo: string | null;
-  num_skus: number | null;
-  valor_total: number | null;
-  pedido_anterior_valor: number | null;
-  status: string | null;
-  aprovado_em: string | null;
-  cancelado_em: string | null;
-  horario_disparo_real: string | null;
-};
-
-function useItensDoDia() {
-  const today = format(new Date(), "yyyy-MM-dd");
-  return useQuery({
-    queryKey: ["cockpit-itens-dia", EMPRESA, today],
-    queryFn: async () => {
-      const { data, error } = await supabase
-        .from("pedido_compra_sugerido" as any)
-        .select(
-          "id,fornecedor_nome,grupo_codigo,num_skus,valor_total,pedido_anterior_valor,status,aprovado_em,cancelado_em,horario_disparo_real",
-        )
-        .eq("empresa", EMPRESA)
-        .eq("data_ciclo", today)
-        .order("fornecedor_nome");
-      if (error) throw error;
-      return ((data ?? []) as unknown) as PedidoItem[];
-    },
-    staleTime: 30_000,
-  });
-}
-
-// ============================================================================
-// Histórico chart query (12 últimos ciclos)
-// ============================================================================
-
-function useHistoricoChart() {
-  const fim = useMemo(() => new Date(), []);
-  const inicio = useMemo(() => subDays(fim, 60), [fim]);
-  return useQuery({
-    queryKey: ["cockpit-historico-chart", EMPRESA, format(fim, "yyyy-MM-dd")],
-    queryFn: async () => {
-      const { data, error } = await supabase
-        .from("pedido_compra_sugerido" as any)
-        .select("data_ciclo,num_skus,valor_total")
-        .eq("empresa", EMPRESA)
-        .gte("data_ciclo", format(inicio, "yyyy-MM-dd"))
-        .lte("data_ciclo", format(fim, "yyyy-MM-dd"));
-      if (error) throw error;
-      const rows = ((data ?? []) as unknown) as Array<{
-        data_ciclo: string;
-        num_skus: number | null;
-        valor_total: number | null;
-      }>;
-      const map = new Map<string, { data: string; total: number; skus: number; valor: number }>();
-      for (const r of rows) {
-        const acc = map.get(r.data_ciclo) ?? {
-          data: r.data_ciclo,
-          total: 0,
-          skus: 0,
-          valor: 0,
-        };
-        acc.total += 1;
-        acc.skus += Number(r.num_skus ?? 0);
-        acc.valor += Number(r.valor_total ?? 0);
-        map.set(r.data_ciclo, acc);
-      }
-      return Array.from(map.values())
-        .sort((a, b) => a.data.localeCompare(b.data))
-        .slice(-12)
-        .map((x) => {
-          const [y, m, d] = x.data.split("-");
-          return { ...x, label: `${d}/${m}` };
-        });
-    },
-  });
-}
-
-// ============================================================================
-// Smart alerts
-// ============================================================================
-
-type SmartAlert = {
-  id: string;
-  level: "yellow" | "orange" | "red";
-  message: string;
-  actionLabel: string;
-  onAction: () => void;
-};
-
-function useSmartAlerts(): SmartAlert[] {
-  const navigate = useNavigate();
-
-  const { data: paramsPendentes = 0 } = useQuery({
-    queryKey: ["cockpit-alert-params-pendentes", EMPRESA],
-    queryFn: async () => {
-      const cutoff = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
-      const { count, error } = await supabase
-        .from("sku_parametros" as any)
-        .select("*", { count: "exact", head: true })
-        .eq("empresa", EMPRESA)
-        .eq("ativo", true)
-        .is("aprovado_em", null)
-        .lt("ultima_atualizacao_calculo", cutoff);
-      if (error) throw error;
-      return count ?? 0;
-    },
-    staleTime: 60_000,
-  });
-
-  const { data: skusSemParam = 0 } = useQuery({
-    queryKey: ["cockpit-alert-sem-parametro", EMPRESA],
-    queryFn: async () => {
-      const { count, error } = await supabase
-        .from("sku_parametros" as any)
-        .select("*", { count: "exact", head: true })
-        .eq("empresa", EMPRESA)
-        .eq("ativo", true)
-        .is("estoque_minimo", null);
-      if (error) throw error;
-      return count ?? 0;
-    },
-    staleTime: 60_000,
-  });
-
-  return useMemo(() => {
-    const list: SmartAlert[] = [];
-    if (paramsPendentes > 0) {
-      list.push({
-        id: "params-24h",
-        level: "yellow",
-        message: `${paramsPendentes} parâmetro(s) aguardam aprovação há mais de 24h`,
-        actionLabel: "Ver parâmetros",
-        onAction: () => navigate("/admin/reposicao/parametros"),
-      });
-    }
-    // Janela fecha em < 1h
-    const now = new Date();
-    const cutoff = new Date(now);
-    cutoff.setHours(CUTOFF_HOUR, CUTOFF_MIN, 0, 0);
-    const minutes = (cutoff.getTime() - now.getTime()) / 60_000;
-    if (minutes > 0 && minutes < 60) {
-      list.push({
-        id: "janela-1h",
-        level: "orange",
-        message: `Janela de compra fecha em ${Math.ceil(minutes)} minutos`,
-        actionLabel: "Ver cockpit",
-        onAction: () => navigate("/admin/reposicao/cockpit?tab=ciclohoje"),
-      });
-    }
-    if (skusSemParam > 0) {
-      list.push({
-        id: "skus-sem-param",
-        level: "red",
-        message: `${skusSemParam} SKU(s) ativos sem parâmetro configurado`,
-        actionLabel: "Configurar",
-        onAction: () => navigate("/admin/reposicao/parametros"),
-      });
-    }
-    return list;
-  }, [paramsPendentes, skusSemParam, navigate]);
-}
-
-function SmartAlertsSection() {
-  const alerts = useSmartAlerts();
-  const [dismissed, setDismissed] = useState<Set<string>>(() => {
-    try {
-      const raw = sessionStorage.getItem("cockpit-dismissed-alerts");
-      return new Set(raw ? (JSON.parse(raw) as string[]) : []);
-    } catch {
-      return new Set();
-    }
-  });
-
-  const dismiss = (id: string) => {
-    const next = new Set(dismissed);
-    next.add(id);
-    setDismissed(next);
-    try {
-      sessionStorage.setItem("cockpit-dismissed-alerts", JSON.stringify(Array.from(next)));
-    } catch {
-      /* ignore */
-    }
-  };
-
-  const visible = alerts.filter((a) => !dismissed.has(a.id)).slice(0, 3);
-  if (visible.length === 0) return null;
-
-  const tone = (l: SmartAlert["level"]) =>
-    l === "yellow"
-      ? "border-status-warning/40 bg-status-warning-bg text-status-warning-fg"
-      : l === "orange"
-        ? "border-orange-500/40 bg-orange-500/5 text-orange-900 dark:text-orange-200"
-        : "border-destructive/40 bg-destructive/5 text-destructive";
-
-  const Icon = ({ l }: { l: SmartAlert["level"] }) =>
-    l === "red" ? (
-      <AlertTriangle className="h-4 w-4 shrink-0" />
-    ) : l === "orange" ? (
-      <Bell className="h-4 w-4 shrink-0" />
-    ) : (
-      <AlertTriangle className="h-4 w-4 shrink-0" />
-    );
-
-  return (
-    <div className="space-y-2">
-      {visible.map((a) => (
-        <div
-          key={a.id}
-          className={`flex items-center gap-3 rounded-md border px-3 py-2 text-sm ${tone(
-            a.level,
-          )}`}
-        >
-          <Icon l={a.level} />
-          <span className="flex-1">{a.message}</span>
-          <Button size="sm" variant="outline" onClick={a.onAction}>
-            {a.actionLabel}
-          </Button>
-          <button
-            type="button"
-            onClick={() => dismiss(a.id)}
-            className="opacity-60 hover:opacity-100"
-            aria-label="Dispensar"
-          >
-            <X className="h-4 w-4" />
-          </button>
-        </div>
-      ))}
-    </div>
-  );
-}
-
-// ============================================================================
-// Métricas do ciclo
-// ============================================================================
-
-function MetricsStrip({ items }: { items: PedidoItem[] }) {
-  const totalSkus = items.reduce((s, r) => s + Number(r.num_skus ?? 0), 0);
-  const valorEstimado = items.reduce((s, r) => s + Number(r.valor_total ?? 0), 0);
-  const aprovados = items.filter((r) => !!r.aprovado_em).length;
-  const pctAprovado = items.length > 0 ? (aprovados / items.length) * 100 : 0;
-  const economia = 0; // campo não disponível
-
-  const Card1 = ({
-    icon: I,
-    label,
-    value,
-    extra,
-  }: {
-    icon: typeof Package;
-    label: string;
-    value: string;
-    extra?: React.ReactNode;
-  }) => (
-    <Card>
-      <CardContent className="p-3">
-        <div className="flex items-center gap-2 text-xs text-muted-foreground mb-1">
-          <I className="h-3.5 w-3.5" />
-          {label}
-        </div>
-        <div className="text-lg font-semibold">{value}</div>
-        {extra}
-      </CardContent>
-    </Card>
-  );
-
-  return (
-    <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
-      <Card1 icon={Package} label="SKUs sugeridos" value={totalSkus.toLocaleString("pt-BR")} />
-      <Card1 icon={DollarSign} label="Valor estimado" value={formatBRL(valorEstimado)} />
-      <Card1
-        icon={TrendingUp}
-        label="% Aprovado"
-        value={`${pctAprovado.toFixed(0)}%`}
-        extra={<Progress value={pctAprovado} className="h-1.5 mt-2" />}
-      />
-      <Card1 icon={PiggyBank} label="Economia potencial" value={formatBRL(economia)} />
-    </div>
-  );
-}
-
-// ============================================================================
-// Configuração de colunas (persistida em localStorage)
-// ============================================================================
-
-type ColKey =
-  | "fornecedor"
-  | "grupo"
-  | "skus"
-  | "valor"
-  | "status"
-  | "qtdAprovada"
-  | "preco"
-  | "confianca";
-
-const COL_DEFS: Array<{ key: ColKey; label: string }> = [
-  { key: "fornecedor", label: "Fornecedor" },
-  { key: "grupo", label: "Grupo" },
-  { key: "skus", label: "SKUs" },
-  { key: "valor", label: "Valor" },
-  { key: "status", label: "Status" },
-  { key: "qtdAprovada", label: "Qtd Aprovada" },
-  { key: "preco", label: "Preço" },
-  { key: "confianca", label: "Confiança" },
-];
-
-const DEFAULT_COLS: Record<ColKey, boolean> = {
-  fornecedor: true,
-  grupo: true,
-  skus: true,
-  valor: true,
-  status: true,
-  qtdAprovada: true,
-  preco: false,
-  confianca: false,
-};
-
-const COLS_STORAGE_KEY = "cockpit-colunas-v1";
-
-function useColumnConfig() {
-  const [cols, setCols] = useState<Record<ColKey, boolean>>(() => {
-    try {
-      const raw = localStorage.getItem(COLS_STORAGE_KEY);
-      if (!raw) return DEFAULT_COLS;
-      const parsed = JSON.parse(raw) as Partial<Record<ColKey, boolean>>;
-      return { ...DEFAULT_COLS, ...parsed };
-    } catch {
-      return DEFAULT_COLS;
-    }
-  });
-  const update = (key: ColKey, value: boolean) => {
-    const next = { ...cols, [key]: value };
-    setCols(next);
-    try {
-      localStorage.setItem(COLS_STORAGE_KEY, JSON.stringify(next));
-    } catch {
-      /* ignore */
-    }
-  };
-  return { cols, update };
-}
-
-function ColumnConfigPopover({
-  cols,
-  onChange,
-}: {
-  cols: Record<ColKey, boolean>;
-  onChange: (k: ColKey, v: boolean) => void;
-}) {
-  return (
-    <Popover>
-      <PopoverTrigger asChild>
-        <Button size="sm" variant="outline" title="Configurar colunas">
-          <SettingsIcon className="h-4 w-4" />
-        </Button>
-      </PopoverTrigger>
-      <PopoverContent className="w-56 p-3" align="end">
-        <div className="text-xs font-semibold mb-2 text-muted-foreground">
-          Colunas visíveis
-        </div>
-        <div className="space-y-2">
-          {COL_DEFS.map((c) => (
-            <label
-              key={c.key}
-              className="flex items-center gap-2 text-sm cursor-pointer"
-            >
-              <Checkbox
-                checked={cols[c.key]}
-                onCheckedChange={(v) => onChange(c.key, !!v)}
-              />
-              {c.label}
-            </label>
-          ))}
-        </div>
-      </PopoverContent>
-    </Popover>
-  );
-}
-
-// ============================================================================
-// Confiança (inferida do status quando não há dias_cobertura_*)
-// ============================================================================
-
-type ConfLevel = "alta" | "media" | "baixa";
-function inferConfianca(r: PedidoItem): { level: ConfLevel; reason: string } {
-  // Schema atual não possui dias_cobertura_atual/alvo — inferimos pelo status.
-  const s = (r.status ?? "").toLowerCase();
-  if (s.includes("pendente_aprovacao")) {
-    return { level: "alta", reason: "Pedido pendente gerado pelos guardrails do ciclo." };
-  }
-  if (s.includes("disparado") || s.includes("aprovado")) {
-    return { level: "alta", reason: "Pedido já aprovado/disparado." };
-  }
-  if (s.includes("cancel")) {
-    return { level: "baixa", reason: "Pedido cancelado — comprar geraria sobrestoque." };
-  }
-  if (s.includes("bloque")) {
-    return { level: "baixa", reason: "Bloqueado por guardrail." };
-  }
-  return {
-    level: "media",
-    reason:
-      "Sem dados de cobertura no registro; confiança média por padrão (status pendente).",
-  };
-}
-
-// Pure classifier lives in its own module so it stays testable.
-// See src/lib/reposicao/approvalSuggestion.ts
 import {
-  calcApprovalSuggestion,
-  type ApprovalSuggestion,
-} from "@/lib/reposicao/approvalSuggestion";
-export { calcApprovalSuggestion };
-
-// ============================================================================
-// Itens do ciclo (com filtros + batch review + ações inline + colunas)
-// ============================================================================
-
-function PrecoCell({ row }: { row: PedidoItem }) {
-  const atual = Number(row.valor_total ?? 0);
-  const anterior = Number(row.pedido_anterior_valor ?? NaN);
-  if (!Number.isFinite(anterior) || anterior === 0) {
-    return <span className="font-medium">{formatBRL(atual)}</span>;
-  }
-  const deltaPct = ((atual - anterior) / anterior) * 100;
-  const tone =
-    Math.abs(deltaPct) < 0.5
-      ? "text-muted-foreground"
-      : deltaPct < 0
-        ? "text-status-success"
-        : "text-destructive";
-  return (
-    <div className="flex flex-col items-end">
-      <span className="font-medium">{formatBRL(atual)}</span>
-      <span className={`text-[11px] ${tone}`}>
-        {deltaPct > 0 ? "+" : ""}
-        {deltaPct.toFixed(1)}%
-      </span>
-    </div>
-  );
-}
-
-function ConfiancaBadge({ row }: { row: PedidoItem }) {
-  const { level, reason } = inferConfianca(row);
-  const map = {
-    alta: { label: "Alta", cls: "bg-status-success-bg text-status-success border-status-success/40" },
-    media: { label: "Média", cls: "bg-status-warning-bg text-status-warning border-status-warning/40" },
-    baixa: { label: "Baixa", cls: "bg-muted text-muted-foreground border-border" },
-  } as const;
-  const m = map[level];
-  return (
-    <TooltipProvider delayDuration={200}>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <span
-            className={`inline-flex items-center gap-1 rounded-md border px-2 py-0.5 text-[11px] font-medium ${m.cls}`}
-          >
-            <Info className="h-3 w-3" /> {m.label}
-          </span>
-        </TooltipTrigger>
-        <TooltipContent className="max-w-[240px] text-xs">{reason}</TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
-  );
-}
-
-function PedidoRow({
-  row,
-  reviewMode,
-  selected,
-  onToggle,
-  cols,
-  user,
-  onChanged,
-}: {
-  row: PedidoItem;
-  reviewMode: boolean;
-  selected: boolean;
-  onToggle: () => void;
-  cols: Record<ColKey, boolean>;
-  user: { id?: string; email?: string | null } | null;
-  onChanged: () => void;
-}) {
-  const [qty, setQty] = useState<number>(Number(row.num_skus ?? 0));
-  const [busy, setBusy] = useState<null | "approve" | "reject">(null);
-  const [editingAuto, setEditingAuto] = useState(false);
-  const suggestion = calcApprovalSuggestion(row);
-  const showInlineEditor = suggestion.mode === "review" || editingAuto;
-
-  useEffect(() => {
-    setQty(Number(row.num_skus ?? 0));
-  }, [row.num_skus]);
-
-  const isApproved = !!row.aprovado_em;
-  const isRejected = !!row.cancelado_em;
-
-  const rowBg = isApproved
-    ? "bg-status-success-bg/40 hover:bg-status-success-bg"
-    : isRejected
-      ? "bg-destructive/5 hover:bg-destructive/10"
-      : "";
-
-  const act = async (kind: "approve" | "reject") => {
-    if (busy) return;
-    setBusy(kind);
-    const nowIso = new Date().toISOString();
-    const who = user?.email ?? user?.id ?? "cockpit";
-    try {
-      const patch =
-        kind === "approve"
-          ? {
-              aprovado_em: nowIso,
-              aprovado_por: who,
-              status: "aprovado_aguardando_disparo" as const,
-              num_skus: qty,
-            }
-          : {
-              cancelado_em: nowIso,
-              cancelado_por: who,
-              status: "cancelado" as const,
-              justificativa_cancelamento: "Rejeitado inline no Cockpit",
-            };
-      const { error } = await supabase
-        .from("pedido_compra_sugerido" as any)
-        .update(patch)
-        .eq("id", row.id);
-      if (error) throw error;
-      await logAudit({
-        userId: user?.id ?? null,
-        action: kind === "approve" ? "Aprovação inline" : "Rejeição inline",
-        result: "Sucesso",
-        metadata: { id: row.id, qty },
-      });
-      toast.success(kind === "approve" ? "Pedido aprovado" : "Pedido rejeitado");
-      onChanged();
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      await logAudit({
-        userId: user?.id ?? null,
-        action: kind === "approve" ? "Aprovação inline" : "Rejeição inline",
-        result: `Erro: ${msg}`,
-        metadata: { id: row.id },
-      });
-      toast.error("Falha na operação");
-    } finally {
-      setBusy(null);
-    }
-  };
-
-  return (
-    <TableRow data-state={selected ? "selected" : undefined} className={rowBg}>
-      {reviewMode && (
-        <TableCell>
-          <Checkbox checked={selected} onCheckedChange={onToggle} />
-        </TableCell>
-      )}
-      {cols.fornecedor && (
-        <TableCell className="text-sm">{row.fornecedor_nome ?? "—"}</TableCell>
-      )}
-      {cols.grupo && (
-        <TableCell className="text-xs text-muted-foreground">
-          {row.grupo_codigo ?? "—"}
-        </TableCell>
-      )}
-      {cols.skus && (
-        <TableCell className="text-right">{row.num_skus ?? 0}</TableCell>
-      )}
-      {cols.valor && (
-        <TableCell className="text-right font-medium">
-          {formatBRL(row.valor_total)}
-        </TableCell>
-      )}
-      {cols.preco && (
-        <TableCell className="text-right">
-          <PrecoCell row={row} />
-        </TableCell>
-      )}
-      {cols.confianca && (
-        <TableCell>
-          <ConfiancaBadge row={row} />
-        </TableCell>
-      )}
-      {cols.status && (
-        <TableCell>
-          <Badge variant="secondary">{row.status ?? "—"}</Badge>
-        </TableCell>
-      )}
-      {cols.qtdAprovada && (
-        <TableCell>
-          <div className="flex items-center gap-1.5 justify-end">
-            {suggestion.mode === "auto" && !showInlineEditor ? (
-              <>
-                <Badge variant="secondary" className="gap-1 bg-primary/10 text-primary border-primary/20">
-                  <Zap className="h-3 w-3" /> Auto
-                </Badge>
-                <span className="w-10 text-right tabular-nums font-medium">{qty}</span>
-                <Button
-                  size="icon"
-                  variant="outline"
-                  className="h-8 w-8"
-                  onClick={() => setEditingAuto(true)}
-                  title="Editar quantidade antes de aprovar"
-                >
-                  <Pencil className="h-3.5 w-3.5" />
-                </Button>
-              </>
-            ) : (
-              <>
-                {suggestion.mode === "review" && (
-                  <TooltipProvider delayDuration={200}>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <Badge variant="outline" className="gap-1 border-status-warning/40 text-status-warning bg-status-warning-bg">
-                          <AlertTriangle className="h-3 w-3" /> Revisar
-                        </Badge>
-                      </TooltipTrigger>
-                      <TooltipContent className="max-w-[260px] text-xs">
-                        {suggestion.reasons.join(" · ")}
-                      </TooltipContent>
-                    </Tooltip>
-                  </TooltipProvider>
-                )}
-            <Input
-              type="number"
-              min={0}
-              value={qty}
-              disabled={isApproved || isRejected || busy !== null}
-              onChange={(e) => setQty(Number(e.target.value) || 0)}
-              onFocus={(e) => e.currentTarget.select()}
-              className="h-8 w-20 text-right"
-            />
-            <Button
-              size="icon"
-              variant="ghost"
-              className="h-8 w-8 text-status-success hover:text-status-success hover:bg-status-success-bg"
-              disabled={isApproved || busy !== null}
-              onClick={() => act("approve")}
-              title="Aprovar"
-            >
-              {busy === "approve" ? (
-                <Loader2 className="h-4 w-4 animate-spin" />
-              ) : (
-                <Check className="h-4 w-4" />
-              )}
-            </Button>
-            <Button
-              size="icon"
-              variant="ghost"
-              className="h-8 w-8 text-destructive hover:bg-destructive/10"
-              disabled={isRejected || busy !== null}
-              onClick={() => act("reject")}
-              title="Rejeitar"
-            >
-              {busy === "reject" ? (
-                <Loader2 className="h-4 w-4 animate-spin" />
-              ) : (
-                <X className="h-4 w-4" />
-              )}
-            </Button>
-              </>
-            )}
-          </div>
-        </TableCell>
-      )}
-    </TableRow>
-  );
-}
-
-function CicloHojePanel({
-  user,
-  reviewMode,
-  setReviewMode,
-  filters,
-  setFilters,
-  filteredItems,
-  fornecedores,
-  statuses,
-  isLoading,
-  cols,
-  onColChange,
-}: {
-  user: { id?: string; email?: string | null } | null;
-  reviewMode: boolean;
-  setReviewMode: (b: boolean) => void;
-  filters: { search: string; fornecedor: string; status: string };
-  setFilters: (f: { search: string; fornecedor: string; status: string }) => void;
-  filteredItems: PedidoItem[];
-  fornecedores: string[];
-  statuses: string[];
-  isLoading: boolean;
-  cols: Record<ColKey, boolean>;
-  onColChange: (k: ColKey, v: boolean) => void;
-}) {
-  const queryClient = useQueryClient();
-  const [selected, setSelected] = useState<Set<number>>(new Set());
-  const [busy, setBusy] = useState(false);
-  const [confirmAuto, setConfirmAuto] = useState(false);
-
-  useEffect(() => {
-    if (!reviewMode) setSelected(new Set());
-  }, [reviewMode]);
-
-  const allChecked = filteredItems.length > 0 && filteredItems.every((i) => selected.has(i.id));
-  const toggleAll = () => {
-    if (allChecked) setSelected(new Set());
-    else setSelected(new Set(filteredItems.map((i) => i.id)));
-  };
-  const toggleOne = (id: number) => {
-    const next = new Set(selected);
-    if (next.has(id)) next.delete(id);
-    else next.add(id);
-    setSelected(next);
-  };
-
-  const totalSelectedValue = filteredItems
-    .filter((i) => selected.has(i.id))
-    .reduce((s, r) => s + Number(r.valor_total ?? 0), 0);
-
-  const eligibleAutoItems = useMemo(
-    () =>
-      filteredItems.filter(
-        (item) =>
-          calcApprovalSuggestion(item).mode === "auto" &&
-          !item.aprovado_em &&
-          !item.cancelado_em,
-      ),
-    [filteredItems],
-  );
-
-  const autoApprovalGroups = useMemo(() => {
-    const map = new Map<string, number>();
-    eligibleAutoItems.forEach((item) => {
-      const fornecedor = item.fornecedor_nome ?? "Sem fornecedor";
-      map.set(fornecedor, (map.get(fornecedor) ?? 0) + Number(item.num_skus ?? 0));
-    });
-    return Array.from(map.entries()).map(([fornecedor, qtd]) => ({ fornecedor, qtd }));
-  }, [eligibleAutoItems]);
-
-  const manualReviewItems = useMemo(
-    () =>
-      filteredItems
-        .filter((item) => !item.aprovado_em && !item.cancelado_em)
-        .map((item) => ({ item, suggestion: calcApprovalSuggestion(item) }))
-        .filter(({ suggestion }) => suggestion.mode === "review"),
-    [filteredItems],
-  );
-
-  const invalidate = () => {
-    queryClient.invalidateQueries({ queryKey: ["cockpit-itens-dia"] });
-    queryClient.invalidateQueries({ queryKey: ["cockpit-current-step"] });
-    queryClient.invalidateQueries({ queryKey: ["reposicao-pedidos"] });
-  };
-
-  const runBatch = async (kind: "approve" | "reject") => {
-    if (selected.size === 0 || busy) return;
-    setBusy(true);
-    const ids = Array.from(selected);
-    const nowIso = new Date().toISOString();
-    const who = user?.email ?? user?.id ?? "cockpit";
-    try {
-      const patch =
-        kind === "approve"
-          ? {
-              aprovado_em: nowIso,
-              aprovado_por: who,
-              status: "aprovado_aguardando_disparo" as const,
-            }
-          : {
-              cancelado_em: nowIso,
-              cancelado_por: who,
-              status: "cancelado" as const,
-              justificativa_cancelamento: "Rejeitado em lote no Cockpit",
-            };
-      const { error } = await supabase
-        .from("pedido_compra_sugerido" as any)
-        .update(patch)
-        .in("id", ids);
-      if (error) throw error;
-
-      await logAudit({
-        userId: user?.id ?? null,
-        action: kind === "approve" ? "Aprovação em lote" : "Rejeição em lote",
-        result: "Sucesso",
-        metadata: { ids, count: ids.length },
-      });
-      toast.success(
-        `${ids.length} pedido(s) ${kind === "approve" ? "aprovado(s)" : "rejeitado(s)"}`,
-      );
-      setSelected(new Set());
-      invalidate();
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      await logAudit({
-        userId: user?.id ?? null,
-        action: kind === "approve" ? "Aprovação em lote" : "Rejeição em lote",
-        result: `Erro: ${msg}`,
-        metadata: { ids },
-      });
-      toast.error("Falha na operação em lote");
-    } finally {
-      setBusy(false);
-    }
-  };
-
-  const runAutoApprove = async () => {
-    if (eligibleAutoItems.length === 0 || busy) return;
-    setBusy(true);
-    const ids = eligibleAutoItems.map((item) => item.id);
-    const nowIso = new Date().toISOString();
-    const who = user?.email ?? user?.id ?? "cockpit";
-    try {
-      const { error } = await supabase
-        .from("pedido_compra_sugerido" as any)
-        .update({
-          aprovado_em: nowIso,
-          aprovado_por: who,
-          status: "aprovado_aguardando_disparo",
-        })
-        .in("id", ids);
-      if (error) throw error;
-      await logAudit({
-        userId: user?.id ?? null,
-        action: "Aprovação automática — critérios atingidos",
-        result: "Sucesso",
-        metadata: { ids, count: ids.length },
-      });
-      toast.success(`${ids.length} pedido(s) aprovado(s) automaticamente`);
-      setConfirmAuto(false);
-      invalidate();
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      await logAudit({
-        userId: user?.id ?? null,
-        action: "Aprovação automática — critérios atingidos",
-        result: `Erro: ${msg}`,
-        metadata: { ids },
-      });
-      toast.error("Falha ao aprovar elegíveis");
-    } finally {
-      setBusy(false);
-    }
-  };
-
-  const clearFilters = () =>
-    setFilters({ search: "", fornecedor: ALL, status: ALL });
-
-  return (
-    <div className="space-y-4">
-      {/* Filters bar */}
-      <div className="flex flex-wrap items-center gap-2 rounded-md border p-2 bg-card">
-        <div className="relative flex-1 min-w-[200px]">
-          <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-          <Input
-            value={filters.search}
-            onChange={(e) => setFilters({ ...filters, search: e.target.value })}
-            placeholder="Buscar SKU, descrição ou fornecedor..."
-            className="pl-8 h-9"
-          />
-        </div>
-        <Select
-          value={filters.fornecedor}
-          onValueChange={(v) => setFilters({ ...filters, fornecedor: v })}
-        >
-          <SelectTrigger className="w-[180px] h-9">
-            <SelectValue placeholder="Fornecedor" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value={ALL}>Todos os fornecedores</SelectItem>
-            {fornecedores.map((f) => (
-              <SelectItem key={f} value={f}>
-                {f}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-        <Select
-          value={filters.status}
-          onValueChange={(v) => setFilters({ ...filters, status: v })}
-        >
-          <SelectTrigger className="w-[180px] h-9">
-            <SelectValue placeholder="Status" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value={ALL}>Todos os status</SelectItem>
-            {statuses.map((s) => (
-              <SelectItem key={s} value={s}>
-                {s}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-        <Button size="sm" variant="ghost" onClick={clearFilters}>
-          Limpar filtros
-        </Button>
-        <Button
-          size="sm"
-          onClick={() => setConfirmAuto(true)}
-          disabled={eligibleAutoItems.length === 0 || busy}
-          title={
-            eligibleAutoItems.length === 0
-              ? "Nenhum item elegível para aprovação automática"
-              : "Aprovar automaticamente apenas os itens classificados como Auto"
-          }
-        >
-          <Zap className="h-4 w-4 mr-1.5" />
-          Aprovar elegíveis ({eligibleAutoItems.length})
-        </Button>
-        <Button
-          size="sm"
-          variant={reviewMode ? "default" : "outline"}
-          onClick={() => setReviewMode(!reviewMode)}
-        >
-          <ListChecks className="h-4 w-4 mr-1.5" />
-          Modo revisão
-        </Button>
-        <ColumnConfigPopover cols={cols} onChange={onColChange} />
-      </div>
-
-      {/* Items table */}
-      <Card>
-        <CardHeader className="py-3">
-          <CardTitle className="text-base">
-            Pedidos do ciclo ({filteredItems.length})
-          </CardTitle>
-        </CardHeader>
-        <CardContent className="p-0 overflow-x-auto">
-          {isLoading ? (
-            <TabFallback />
-          ) : filteredItems.length === 0 ? (
-            <div className="py-10 text-center text-sm text-muted-foreground">
-              Nenhum pedido para os filtros atuais.
-            </div>
-          ) : (
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  {reviewMode && (
-                    <TableHead className="w-[40px]">
-                      <Checkbox checked={allChecked} onCheckedChange={toggleAll} />
-                    </TableHead>
-                  )}
-                  {cols.fornecedor && <TableHead>Fornecedor</TableHead>}
-                  {cols.grupo && <TableHead>Grupo</TableHead>}
-                  {cols.skus && <TableHead className="text-right">SKUs</TableHead>}
-                  {cols.valor && <TableHead className="text-right">Valor</TableHead>}
-                  {cols.preco && <TableHead className="text-right">Preço</TableHead>}
-                  {cols.confianca && <TableHead>Confiança</TableHead>}
-                  {cols.status && <TableHead>Status</TableHead>}
-                  {cols.qtdAprovada && (
-                    <TableHead className="text-right">Qtd Aprovada</TableHead>
-                  )}
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {filteredItems.map((r) => (
-                  <PedidoRow
-                    key={r.id}
-                    row={r}
-                    reviewMode={reviewMode}
-                    selected={selected.has(r.id)}
-                    onToggle={() => toggleOne(r.id)}
-                    cols={cols}
-                    user={user}
-                    onChanged={invalidate}
-                  />
-                ))}
-              </TableBody>
-            </Table>
-          )}
-        </CardContent>
-      </Card>
-
-      <Dialog open={confirmAuto} onOpenChange={setConfirmAuto}>
-        <DialogContent className="max-w-lg">
-          <DialogHeader>
-            <DialogTitle className="flex items-center gap-2">
-              <Zap className="h-5 w-5 text-primary" /> Aprovar elegíveis automaticamente
-            </DialogTitle>
-            <DialogDescription>
-              {eligibleAutoItems.length} pedido(s) serão aprovados automaticamente.
-            </DialogDescription>
-          </DialogHeader>
-          <div className="max-h-56 overflow-y-auto rounded-md border">
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Fornecedor</TableHead>
-                  <TableHead className="text-right">Qtd</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {autoApprovalGroups.map((group) => (
-                  <TableRow key={group.fornecedor}>
-                    <TableCell>{group.fornecedor}</TableCell>
-                    <TableCell className="text-right tabular-nums">{group.qtd}</TableCell>
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          </div>
-
-          {manualReviewItems.length > 0 && (
-            <div className="space-y-2 pt-2">
-              <div className="flex items-center gap-2 text-sm font-medium">
-                <AlertTriangle className="h-4 w-4 text-status-warning" />
-                {manualReviewItems.length} pedido(s) ficarão para aprovação manual
-              </div>
-              <div className="max-h-40 overflow-y-auto rounded-md border">
-                <Table>
-                  <TableHeader>
-                    <TableRow>
-                      <TableHead>Fornecedor</TableHead>
-                      <TableHead>Motivo</TableHead>
-                    </TableRow>
-                  </TableHeader>
-                  <TableBody>
-                    {manualReviewItems.map(({ item, suggestion }) => (
-                      <TableRow key={item.id}>
-                        <TableCell className="text-xs">{item.fornecedor_nome ?? "Sem fornecedor"}</TableCell>
-                        <TableCell className="text-xs text-muted-foreground">
-                          {suggestion.reasons.join("; ")}
-                        </TableCell>
-                      </TableRow>
-                    ))}
-                  </TableBody>
-                </Table>
-              </div>
-            </div>
-          )}
-          <div className="flex justify-end gap-2 pt-2">
-            <Button variant="outline" onClick={() => setConfirmAuto(false)} disabled={busy}>
-              Cancelar
-            </Button>
-            <Button onClick={runAutoApprove} disabled={busy || eligibleAutoItems.length === 0}>
-              {busy && <Loader2 className="h-4 w-4 mr-1.5 animate-spin" />}
-              Confirmar aprovação automática
-            </Button>
-          </div>
-        </DialogContent>
-      </Dialog>
-
-      {/* Conteúdo original detalhado */}
-      <Suspense fallback={<TabFallback />}>
-        <AdminReposicaoPedidos />
-      </Suspense>
-
-      {/* Sticky footer for batch review */}
-      {reviewMode && selected.size > 0 && (
-        <div className="fixed bottom-0 left-0 right-0 z-40 border-t bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/80 shadow-lg">
-          <div className="container max-w-7xl mx-auto px-4 py-3 flex flex-wrap items-center justify-between gap-3">
-            <div className="text-sm">
-              <span className="font-semibold">{selected.size}</span> itens selecionados |{" "}
-              <span className="font-semibold">Total: {formatBRL(totalSelectedValue)}</span>
-            </div>
-            <div className="flex gap-2">
-              <Button
-                size="sm"
-                variant="outline"
-                onClick={() => runBatch("reject")}
-                disabled={busy}
-              >
-                <XCircle className="h-4 w-4 mr-1.5" /> Rejeitar selecionados
-              </Button>
-              <Button size="sm" onClick={() => runBatch("approve")} disabled={busy}>
-                {busy ? (
-                  <Loader2 className="h-4 w-4 mr-1.5 animate-spin" />
-                ) : (
-                  <CheckCircle2 className="h-4 w-4 mr-1.5" />
-                )}
-                Aprovar selecionados
-              </Button>
-            </div>
-          </div>
-        </div>
-      )}
-    </div>
-  );
-}
-
-// ============================================================================
-// Stepper / etapa atual
-// ============================================================================
-
-function useCurrentStep() {
-  const today = format(new Date(), "yyyy-MM-dd");
-
-  return useQuery({
-    queryKey: ["cockpit-current-step", EMPRESA, today],
-    queryFn: async () => {
-      const oport = await supabase
-        .from("v_oportunidade_economica_hoje" as any)
-        .select("*", { count: "exact", head: true })
-        .eq("empresa", EMPRESA);
-      if (oport.error) throw oport.error;
-
-      const params = await supabase
-        .from("sku_parametros" as any)
-        .select("*", { count: "exact", head: true })
-        .eq("empresa", EMPRESA)
-        .eq("ativo", true)
-        .is("aprovado_em", null);
-      if (params.error) throw params.error;
-
-      const pedidos = await supabase
-        .from("pedido_compra_sugerido" as any)
-        .select("status")
-        .eq("empresa", EMPRESA)
-        .eq("data_ciclo", today);
-      if (pedidos.error) throw pedidos.error;
-
-      const statuses = (((pedidos.data ?? []) as unknown) as Array<{ status: string | null }>).map(
-        (r) => r.status,
-      );
-      const hasPendentes = statuses.some(
-        (s) => s === "pendente_aprovacao" || s === "bloqueado_guardrail",
-      );
-      const hasAprovados = statuses.some((s) => s === "aprovado_aguardando_disparo");
-      const hasDisparados = statuses.some((s) => s === "disparado");
-
-      if ((oport.count ?? 0) > 0) return 1;
-      if ((params.count ?? 0) > 0) return 2;
-      if (hasPendentes) return 3;
-      if (hasAprovados) return 4;
-      if (hasDisparados) return 5;
-      return 3;
-    },
-    staleTime: 30_000,
-    refetchInterval: 60_000,
-  });
-}
-
-const TAB_VALUES = ["ciclohoje", "aplicaromie", "anteriores"] as const;
-type TabValue = (typeof TAB_VALUES)[number];
-
-// ============================================================================
-// Histórico (chart) tab
-// ============================================================================
-
-type CompareRow = {
-  fornecedor_nome: string;
-  num_skus: number;
-  valor_total: number;
-};
-
-function CompareCyclesSection({ cycles }: { cycles: string[] }) {
-  const [a, setA] = useState<string>("");
-  const [b, setB] = useState<string>("");
-  const [diff, setDiff] = useState<{
-    novos: CompareRow[];
-    removidos: CompareRow[];
-    alterados: Array<{
-      fornecedor_nome: string;
-      a: CompareRow;
-      b: CompareRow;
-      deltaQty: number;
-      deltaVal: number;
-    }>;
-  } | null>(null);
-  const [loading, setLoading] = useState(false);
-
-  const fetchCycle = async (data_ciclo: string): Promise<CompareRow[]> => {
-    const { data, error } = await supabase
-      .from("pedido_compra_sugerido" as any)
-      .select("fornecedor_nome,num_skus,valor_total")
-      .eq("empresa", EMPRESA)
-      .eq("data_ciclo", data_ciclo);
-    if (error) throw error;
-    const rows = ((data ?? []) as unknown) as Array<{
-      fornecedor_nome: string | null;
-      num_skus: number | null;
-      valor_total: number | null;
-    }>;
-    const map = new Map<string, CompareRow>();
-    for (const r of rows) {
-      const key = r.fornecedor_nome ?? "—";
-      const acc = map.get(key) ?? { fornecedor_nome: key, num_skus: 0, valor_total: 0 };
-      acc.num_skus += Number(r.num_skus ?? 0);
-      acc.valor_total += Number(r.valor_total ?? 0);
-      map.set(key, acc);
-    }
-    return Array.from(map.values());
-  };
-
-  const compare = async () => {
-    if (!a || !b || a === b) {
-      toast.error("Selecione dois ciclos diferentes");
-      return;
-    }
-    setLoading(true);
-    try {
-      const [arows, brows] = await Promise.all([fetchCycle(a), fetchCycle(b)]);
-      const amap = new Map(arows.map((r) => [r.fornecedor_nome, r]));
-      const bmap = new Map(brows.map((r) => [r.fornecedor_nome, r]));
-      const novos = brows.filter((r) => !amap.has(r.fornecedor_nome));
-      const removidos = arows.filter((r) => !bmap.has(r.fornecedor_nome));
-      const alterados: typeof diff extends infer T
-        ? T extends { alterados: infer U }
-          ? U
-          : never
-        : never = [];
-      for (const br of brows) {
-        const ar = amap.get(br.fornecedor_nome);
-        if (!ar) continue;
-        if (ar.num_skus !== br.num_skus || ar.valor_total !== br.valor_total) {
-          alterados.push({
-            fornecedor_nome: br.fornecedor_nome,
-            a: ar,
-            b: br,
-            deltaQty: br.num_skus - ar.num_skus,
-            deltaVal: br.valor_total - ar.valor_total,
-          });
-        }
-      }
-      setDiff({ novos, removidos, alterados });
-    } catch (err) {
-      toast.error("Falha ao comparar ciclos");
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  return (
-    <Card>
-      <CardHeader className="py-3">
-        <div className="flex items-center gap-2">
-          <GitCompare className="h-4 w-4 text-muted-foreground" />
-          <CardTitle className="text-base">Comparar ciclos</CardTitle>
-        </div>
-      </CardHeader>
-      <CardContent className="space-y-3">
-        <div className="flex flex-wrap items-center gap-2">
-          <Select value={a} onValueChange={setA}>
-            <SelectTrigger className="w-[180px] h-9">
-              <SelectValue placeholder="Ciclo A" />
-            </SelectTrigger>
-            <SelectContent>
-              {cycles.map((c) => (
-                <SelectItem key={c} value={c}>
-                  {formatDate(c)}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-          <Select value={b} onValueChange={setB}>
-            <SelectTrigger className="w-[180px] h-9">
-              <SelectValue placeholder="Ciclo B" />
-            </SelectTrigger>
-            <SelectContent>
-              {cycles.map((c) => (
-                <SelectItem key={c} value={c}>
-                  {formatDate(c)}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-          <Button size="sm" onClick={compare} disabled={loading || !a || !b}>
-            {loading ? <Loader2 className="h-4 w-4 mr-1.5 animate-spin" /> : null}
-            Comparar
-          </Button>
-        </div>
-
-        {diff && (
-          <div className="space-y-3">
-            <div>
-              <div className="text-xs font-semibold text-status-success mb-1">
-                Novos no Ciclo B ({diff.novos.length})
-              </div>
-              {diff.novos.length === 0 ? (
-                <div className="text-xs text-muted-foreground">Nenhum.</div>
-              ) : (
-                <div className="rounded-md border bg-status-success-bg/40 divide-y">
-                  {diff.novos.map((r) => (
-                    <div key={r.fornecedor_nome} className="px-3 py-1.5 text-sm flex justify-between">
-                      <span>{r.fornecedor_nome}</span>
-                      <span className="text-muted-foreground">
-                        {r.num_skus} SKUs · {formatBRL(r.valor_total)}
-                      </span>
-                    </div>
-                  ))}
-                </div>
-              )}
-            </div>
-
-            <div>
-              <div className="text-xs font-semibold text-destructive mb-1">
-                Removidos vs Ciclo A ({diff.removidos.length})
-              </div>
-              {diff.removidos.length === 0 ? (
-                <div className="text-xs text-muted-foreground">Nenhum.</div>
-              ) : (
-                <div className="rounded-md border bg-destructive/5 divide-y">
-                  {diff.removidos.map((r) => (
-                    <div key={r.fornecedor_nome} className="px-3 py-1.5 text-sm flex justify-between">
-                      <span>{r.fornecedor_nome}</span>
-                      <span className="text-muted-foreground">
-                        {r.num_skus} SKUs · {formatBRL(r.valor_total)}
-                      </span>
-                    </div>
-                  ))}
-                </div>
-              )}
-            </div>
-
-            <div>
-              <div className="text-xs font-semibold text-status-warning mb-1">
-                Alterados ({diff.alterados.length})
-              </div>
-              {diff.alterados.length === 0 ? (
-                <div className="text-xs text-muted-foreground">Nenhum.</div>
-              ) : (
-                <div className="rounded-md border bg-status-warning-bg divide-y">
-                  {diff.alterados.map((r) => (
-                    <div key={r.fornecedor_nome} className="px-3 py-1.5 text-sm flex justify-between gap-2">
-                      <span>{r.fornecedor_nome}</span>
-                      <span className="text-xs text-muted-foreground">
-                        Δ SKUs: {r.deltaQty > 0 ? "+" : ""}
-                        {r.deltaQty} · Δ valor: {r.deltaVal >= 0 ? "+" : ""}
-                        {formatBRL(r.deltaVal)}
-                      </span>
-                    </div>
-                  ))}
-                </div>
-              )}
-            </div>
-          </div>
-        )}
-      </CardContent>
-    </Card>
-  );
-}
-
-function HistoricoComChart() {
-  const { data = [], isLoading } = useHistoricoChart();
-  const cycles = useMemo(() => data.map((d) => d.data).reverse(), [data]);
-  return (
-    <div className="space-y-4">
-      <CompareCyclesSection cycles={cycles} />
-      <Card>
-        <CardHeader className="py-3">
-          <div className="flex items-center gap-2">
-            <CalendarRange className="h-4 w-4 text-muted-foreground" />
-            <CardTitle className="text-base">Últimos 12 ciclos</CardTitle>
-          </div>
-        </CardHeader>
-        <CardContent>
-          {isLoading ? (
-            <TabFallback />
-          ) : data.length === 0 ? (
-            <div className="py-8 text-center text-sm text-muted-foreground">
-              Sem ciclos no período.
-            </div>
-          ) : (
-            <div className="h-[220px] w-full">
-              <ResponsiveContainer>
-                <BarChart data={data}>
-                  <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
-                  <XAxis dataKey="label" className="text-xs" />
-                  <YAxis className="text-xs" />
-                  <ReTooltip
-                    formatter={(value: number, name: string) => {
-                      if (name === "valor") return [formatBRL(value), "Valor"];
-                      if (name === "skus") return [value, "SKUs"];
-                      return [value, name];
-                    }}
-                    labelFormatter={(l) => `Ciclo ${l}`}
-                    content={({ active, payload, label }) => {
-                      if (!active || !payload?.length) return null;
-                      const p = payload[0].payload as {
-                        label: string;
-                        total: number;
-                        skus: number;
-                        valor: number;
-                      };
-                      return (
-                        <div className="rounded-md border bg-popover p-2 text-xs shadow-md">
-                          <div className="font-medium mb-1">{label}</div>
-                          <div>Total pedidos: {p.total}</div>
-                          <div>SKUs: {p.skus}</div>
-                          <div>Valor: {formatBRL(p.valor)}</div>
-                        </div>
-                      );
-                    }}
-                  />
-                  <Bar dataKey="total" className="fill-primary" radius={[4, 4, 0, 0]} />
-                </BarChart>
-              </ResponsiveContainer>
-            </div>
-          )}
-        </CardContent>
-      </Card>
-
-      <Suspense fallback={<TabFallback />}>
-        <AdminReposicaoHistorico />
-      </Suspense>
-    </div>
-  );
-}
-
-// O ShortcutsDialog interno e o array SHORTCUTS foram removidos — agora os atalhos
-// são registrados no ShortcutsRegistry global (useRegisterShortcuts) e o dialog
-// fica montado no AppShell, listando atalhos de qualquer página.
-
-// ============================================================================
-// Main page
-// ============================================================================
+  REPOSICAO_EMPRESA,
+  useCurrentStep,
+  useItensDoDia,
+} from "@/hooks/useReposicaoSessao";
+import { downloadCsv, formatBRL, formatDate, logAudit } from "@/lib/reposicao";
+import { ContinuarBanner } from "@/components/reposicao/ContinuarBanner";
+import { EtapasGrid } from "@/components/reposicao/EtapasGrid";
+import { SmartAlertsSection } from "@/components/reposicao/SmartAlertsSection";
+import { MetricsStrip } from "@/components/reposicao/MetricsStrip";
+import { AuditLogSection } from "@/components/reposicao/AuditLogSection";
 
 export default function AdminReposicaoCockpit() {
   const navigate = useNavigate();
-  const [params, setParams] = useSearchParams();
+  const [params] = useSearchParams();
   const tabParam = params.get("tab");
   const { user } = useAuth();
   const queryClient = useQueryClient();
 
-  const {
-    data: currentStep = 3,
-    isLoading: isLoadingStep,
-    isError: stepError,
-    refetch: refetchStep,
-    isFetching: isFetchingStep,
-  } = useCurrentStep();
+  const { data: currentStep = 3 } = useCurrentStep();
+  const { data: itensDia = [] } = useItensDoDia();
 
-  const { data: itensDia = [], isLoading: isLoadingItens } = useItensDoDia();
-  const { cols, update: updateCol } = useColumnConfig();
-
-  const defaultTab: TabValue = currentStep === 4 ? "aplicaromie" : "ciclohoje";
-  const tab: TabValue = (TAB_VALUES as readonly string[]).includes(tabParam ?? "")
-    ? (tabParam as TabValue)
-    : defaultTab;
-
+  // Legacy ?tab= deep-links → canonical /sessao/* routes
   useEffect(() => {
-    if (tabParam === "oportunidades") {
-      navigate("/admin/reposicao/oportunidades", { replace: true });
-    }
+    if (!tabParam) return;
+    const map: Record<string, string> = {
+      ciclohoje: "/admin/reposicao/sessao/pedidos",
+      aplicaromie: "/admin/reposicao/sessao/aplicacao",
+      confirmacao: "/admin/reposicao/sessao/confirmacao",
+      anteriores: "/admin/reposicao/sessao/historico",
+      oportunidades: "/admin/reposicao/oportunidades",
+    };
+    const dest = map[tabParam];
+    if (dest) navigate(dest, { replace: true });
   }, [tabParam, navigate]);
 
-  // Realtime
+  // Realtime invalidation
   useEffect(() => {
     const channel = supabase
       .channel("cockpit-reposicao-realtime")
@@ -1742,159 +84,32 @@ export default function AdminReposicaoCockpit() {
     };
   }, [queryClient]);
 
-  const handleTab = useCallback(
-    (v: string) => {
-      const next = new URLSearchParams(params);
-      next.set("tab", v);
-      setParams(next, { replace: true });
-    },
-    [params, setParams],
-  );
-
-  const handleStepClick = (step: number) => {
-    switch (step) {
-      case 1:
-        navigate("/admin/reposicao/oportunidades");
-        break;
-      case 2:
-        navigate("/admin/reposicao/parametros");
-        break;
-      case 3:
-        handleTab("ciclohoje");
-        break;
-      case 4:
-        handleTab("aplicaromie");
-        break;
-      case 5:
-        handleTab("ciclohoje");
-        break;
-    }
-  };
-
-  // Filtros + review mode (compartilhados com a aba ciclohoje)
-  const [reviewMode, setReviewMode] = useState(false);
-  const [filters, setFilters] = useState({ search: "", fornecedor: ALL, status: ALL });
-
-  const fornecedores = useMemo(
-    () =>
-      Array.from(new Set(itensDia.map((i) => i.fornecedor_nome).filter((x): x is string => !!x))).sort(),
-    [itensDia],
-  );
-  const statuses = useMemo(
-    () => Array.from(new Set(itensDia.map((i) => i.status).filter((x): x is string => !!x))).sort(),
-    [itensDia],
-  );
-
-  const filteredItems = useMemo(() => {
-    const q = filters.search.trim().toLowerCase();
-    return itensDia.filter((i) => {
-      if (filters.fornecedor !== ALL && i.fornecedor_nome !== filters.fornecedor) return false;
-      if (filters.status !== ALL && i.status !== filters.status) return false;
-      if (q) {
-        const hay = [i.fornecedor_nome, i.grupo_codigo, i.status]
-          .filter(Boolean)
-          .join(" ")
-          .toLowerCase();
-        if (!hay.includes(q)) return false;
-      }
-      return true;
-    });
-  }, [itensDia, filters]);
-
-  // ------ Export CSV --------------------------------------------------------
+  // ---- Actions ------------------------------------------------------------
   const [isExporting, setIsExporting] = useState(false);
-
   const handleExportCsv = async () => {
     if (isExporting) return;
     setIsExporting(true);
     const today = format(new Date(), "yyyy-MM-dd");
-    const filename = `cockpit-${tab}-${today}.csv`;
+    const filename = `cockpit-ciclohoje-${today}.csv`;
     try {
-      if (tab === "ciclohoje") {
-        const rows = filteredItems.map((r) => [
-          r.grupo_codigo ?? "",
-          r.fornecedor_nome ?? "",
-          r.fornecedor_nome ?? "",
-          r.num_skus ?? 0,
-          r.aprovado_em ? r.num_skus ?? 0 : 0,
-          r.status ?? "",
-        ]);
-        downloadCsv(
-          filename,
-          ["SKU", "Descrição", "Fornecedor", "Qtd sugerida", "Qtd aprovada", "Status"],
-          rows,
-        );
-      } else if (tab === "aplicaromie") {
-        const { data, error } = await supabase
-          .from("sku_parametros" as any)
-          .select(
-            "sku_codigo_omie,sku_descricao,estoque_minimo,estoque_minimo_omie,aplicar_no_omie,ultima_aplicacao_omie",
-          )
-          .eq("empresa", EMPRESA)
-          .eq("ativo", true);
-        if (error) throw error;
-        const rows = (((data ?? []) as unknown) as Array<{
-          sku_codigo_omie: number | null;
-          sku_descricao: string | null;
-          estoque_minimo: number | null;
-          estoque_minimo_omie: number | null;
-          aplicar_no_omie: boolean | null;
-          ultima_aplicacao_omie: string | null;
-        }>).map((r) => [
-          r.sku_codigo_omie ?? "",
-          r.sku_descricao ?? "",
-          "estoque_minimo",
-          r.estoque_minimo_omie ?? "",
-          r.estoque_minimo ?? "",
-          r.ultima_aplicacao_omie
-            ? "aplicado"
-            : r.aplicar_no_omie
-              ? "pronto_para_aplicar"
-              : "pendente",
-        ]);
-        downloadCsv(
-          filename,
-          ["SKU", "Descrição", "Parâmetro", "Valor atual", "Valor novo", "Status"],
-          rows,
-        );
-      } else {
-        const fim = new Date();
-        const inicio = subDays(fim, 29);
-        const { data, error } = await supabase
-          .from("pedido_compra_sugerido" as any)
-          .select("data_ciclo,num_skus,valor_total,status")
-          .eq("empresa", EMPRESA)
-          .gte("data_ciclo", format(inicio, "yyyy-MM-dd"))
-          .lte("data_ciclo", format(fim, "yyyy-MM-dd"));
-        if (error) throw error;
-        const map = new Map<string, { skus: number; valor: number; statuses: Set<string> }>();
-        for (const r of (((data ?? []) as unknown) as Array<{
-          data_ciclo: string;
-          num_skus: number | null;
-          valor_total: number | null;
-          status: string | null;
-        }>)) {
-          const acc = map.get(r.data_ciclo) ?? { skus: 0, valor: 0, statuses: new Set<string>() };
-          acc.skus += Number(r.num_skus ?? 0);
-          acc.valor += Number(r.valor_total ?? 0);
-          if (r.status) acc.statuses.add(r.status);
-          map.set(r.data_ciclo, acc);
-        }
-        const rows = Array.from(map.entries())
-          .sort((a, b) => b[0].localeCompare(a[0]))
-          .map(([data, v]) => [
-            formatDate(data),
-            v.skus,
-            v.valor.toFixed(2).replace(".", ","),
-            Array.from(v.statuses).join(","),
-          ]);
-        downloadCsv(filename, ["Data", "SKUs", "Total pedido", "Status"], rows);
-      }
+      const rows = itensDia.map((r) => [
+        r.grupo_codigo ?? "",
+        r.fornecedor_nome ?? "",
+        r.fornecedor_nome ?? "",
+        r.num_skus ?? 0,
+        r.aprovado_em ? r.num_skus ?? 0 : 0,
+        r.status ?? "",
+      ]);
+      downloadCsv(
+        filename,
+        ["SKU", "Descrição", "Fornecedor", "Qtd sugerida", "Qtd aprovada", "Status"],
+        rows,
+      );
       await logAudit({
         userId: user?.id ?? null,
         action: "CSV exportado",
         result: "Sucesso",
-        metadata: { tab, filename },
+        metadata: { scope: "ciclohoje", filename },
       });
       toast.success("CSV exportado");
     } catch (err) {
@@ -1903,7 +118,6 @@ export default function AdminReposicaoCockpit() {
         userId: user?.id ?? null,
         action: "CSV exportado",
         result: `Erro: ${msg}`,
-        metadata: { tab },
       });
       toast.error("Falha ao exportar CSV");
     } finally {
@@ -1911,14 +125,13 @@ export default function AdminReposicaoCockpit() {
     }
   };
 
-  // ------ Manual generation -------------------------------------------------
   const [isGenerating, setIsGenerating] = useState(false);
   const handleGenerate = async () => {
     if (isGenerating) return;
     setIsGenerating(true);
     try {
       const { error } = await supabase.functions.invoke("gerar-pedidos-diario", {
-        body: { empresa: EMPRESA, manual: true },
+        body: { empresa: REPOSICAO_EMPRESA, manual: true },
       });
       if (error) throw error;
       await logAudit({
@@ -1942,7 +155,16 @@ export default function AdminReposicaoCockpit() {
     }
   };
 
-  // ------ PDF (window.print) -----------------------------------------------
+  const handleRefetchAll = () => {
+    queryClient.invalidateQueries({ queryKey: ["cockpit-itens-dia"] });
+    queryClient.invalidateQueries({ queryKey: ["cockpit-current-step"] });
+    queryClient.invalidateQueries({ queryKey: ["cockpit-historico-chart"] });
+    queryClient.invalidateQueries({ queryKey: ["reposicao-pedidos"] });
+    queryClient.invalidateQueries({ queryKey: ["reposicao-aplicacao"] });
+    queryClient.invalidateQueries({ queryKey: ["reposicao-historico"] });
+    toast("Atualizando...", { duration: 1200 });
+  };
+
   const handlePrintPdf = () => {
     const today = format(new Date(), "yyyy-MM-dd");
     const styleId = "__cockpit_print_style__";
@@ -1980,7 +202,7 @@ export default function AdminReposicaoCockpit() {
     if (existing) existing.remove();
     const area = document.createElement("div");
     area.id = "cockpit-print-area";
-    const rowsHtml = filteredItems
+    const rowsHtml = itensDia
       .map(
         (r) => `<tr>
         <td>${r.grupo_codigo ?? "—"}</td>
@@ -1994,7 +216,7 @@ export default function AdminReposicaoCockpit() {
       .join("");
     area.innerHTML = `
       <h1>COLACOR — Cockpit de Reposição</h1>
-      <div class="meta">Ciclo: ${formatDate(today)} · ${filteredItems.length} pedido(s)</div>
+      <div class="meta">Ciclo: ${formatDate(today)} · ${itensDia.length} pedido(s)</div>
       <table>
         <thead>
           <tr>
@@ -2020,28 +242,30 @@ export default function AdminReposicaoCockpit() {
       userId: user?.id ?? null,
       action: "PDF gerado",
       result: "Sucesso",
-      metadata: { count: filteredItems.length },
+      metadata: { count: itensDia.length },
     });
   };
-  // Atalhos do cockpit registrados no ShortcutsRegistry global (aparecem no dialog "?" do AppShell).
-  // Migrado do hook legado useKeyboardShortcuts para o pattern reusável (Fase 4 / item #1).
+
+  // ---- Keyboard shortcuts (registrados no ShortcutsRegistry global) -------
   useRegisterShortcuts(
     useMemo(
       () => [
-        { keys: 'g', label: 'Gerar pedidos do dia',          group: 'Cockpit', handler: () => handleGenerate() },
-        { keys: 'e', label: 'Exportar CSV',                  group: 'Cockpit', handler: () => handleExportCsv() },
-        { keys: '1', label: 'Aba Ciclo de hoje',             group: 'Cockpit', handler: () => handleTab('ciclohoje') },
-        { keys: '2', label: 'Aba Aplicar no Omie',           group: 'Cockpit', handler: () => handleTab('aplicaromie') },
-        { keys: '3', label: 'Aba Ciclos anteriores',         group: 'Cockpit', handler: () => handleTab('anteriores') },
-        { keys: 'm', label: 'Alternar modo seleção (bulk)',  group: 'Cockpit', handler: () => setReviewMode(!reviewMode) },
+        { keys: "g", label: "Gerar pedidos do dia", group: "Reposição", handler: () => handleGenerate() },
+        { keys: "e", label: "Exportar CSV do ciclo", group: "Reposição", handler: () => handleExportCsv() },
+        { keys: "r", label: "Atualizar dados", group: "Reposição", handler: () => handleRefetchAll() },
+        { keys: "1", label: "Etapa 1: Mercado", group: "Reposição", handler: () => navigate("/admin/reposicao/sessao/mercado") },
+        { keys: "2", label: "Etapa 2: Parâmetros", group: "Reposição", handler: () => navigate("/admin/reposicao/sessao/parametros") },
+        { keys: "3", label: "Etapa 3: Pedidos", group: "Reposição", handler: () => navigate("/admin/reposicao/sessao/pedidos") },
+        { keys: "4", label: "Etapa 4: Aplicação Omie", group: "Reposição", handler: () => navigate("/admin/reposicao/sessao/aplicacao") },
+        { keys: "5", label: "Etapa 5: Confirmação", group: "Reposição", handler: () => navigate("/admin/reposicao/sessao/confirmacao") },
       ],
-      // dependências dos handlers
-      [handleGenerate, handleExportCsv, handleTab, reviewMode, setReviewMode],
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      [navigate],
     ),
   );
 
   return (
-    <div className="container mx-auto p-4 sm:p-6 space-y-6 max-w-7xl pb-24">
+    <div className="space-y-6">
       <header className="relative bg-cockpit-hero noise rounded-lg border border-border px-6 py-7 flex items-center justify-between gap-3 flex-wrap overflow-hidden">
         <div className="relative flex items-center gap-3">
           <Sparkles className="h-6 w-6 text-foreground/70" />
@@ -2049,7 +273,10 @@ export default function AdminReposicaoCockpit() {
             <p className="text-[10px] uppercase tracking-[0.18em] text-muted-foreground font-medium mb-1">
               Reposição · Cockpit de compras
             </p>
-            <h1 className="font-display" style={{ fontSize: '2rem', fontWeight: 500, letterSpacing: '-0.04em', lineHeight: 1.1 }}>
+            <h1
+              className="font-display"
+              style={{ fontSize: "2rem", fontWeight: 500, letterSpacing: "-0.04em", lineHeight: 1.1 }}
+            >
               Ciclo diário
             </h1>
             <p className="text-sm text-muted-foreground mt-1">
@@ -2061,10 +288,13 @@ export default function AdminReposicaoCockpit() {
           <Button
             size="sm"
             variant="ghost"
-            onClick={() => window.dispatchEvent(new Event('open-shortcuts-dialog'))}
+            onClick={() => window.dispatchEvent(new Event("open-shortcuts-dialog"))}
             title="Atalhos de teclado (?)"
           >
             <Keyboard className="h-4 w-4" />
+          </Button>
+          <Button size="sm" variant="outline" onClick={handleRefetchAll} title="Atualizar (R)">
+            <RotateCw className="h-4 w-4 mr-1.5" /> Atualizar
           </Button>
           <Button size="sm" onClick={handleGenerate} disabled={isGenerating} title="Gerar (G)">
             {isGenerating ? (
@@ -2077,92 +307,36 @@ export default function AdminReposicaoCockpit() {
         </div>
       </header>
 
-      {stepError && (
-        <Alert variant="default" className="border-status-warning/40 bg-status-warning-bg">
-          <AlertTriangle className="h-4 w-4 text-status-warning" />
-          <AlertTitle>Etapa atual indisponível</AlertTitle>
-          <AlertDescription className="flex items-center justify-between gap-3 flex-wrap">
-            <span>Não foi possível calcular a etapa atual. Exibindo dados em cache.</span>
-            <Button
-              size="sm"
-              variant="outline"
-              onClick={() => refetchStep()}
-              disabled={isFetchingStep}
-            >
-              {isFetchingStep ? (
-                <>
-                  <Loader2 className="h-3 w-3 mr-1.5 animate-spin" />
-                  Tentando...
-                </>
-              ) : (
-                "Tentar novamente"
-              )}
-            </Button>
-          </AlertDescription>
-        </Alert>
-      )}
+      <ContinuarBanner currentStep={currentStep} />
 
       <SmartAlertsSection />
 
-      <ProcessoComprasStepper
-        currentStep={currentStep}
-        onStepClick={handleStepClick}
-        isLoading={isLoadingStep}
-      />
-
       <MetricsStrip items={itensDia} />
 
-      <Tabs value={tab} onValueChange={handleTab} className="space-y-4">
-        <div className="flex items-center justify-between gap-3 flex-wrap">
-          <TabsList className="grid grid-cols-3 w-full sm:w-auto">
-            <TabsTrigger value="ciclohoje">Ciclo de hoje</TabsTrigger>
-            <TabsTrigger value="aplicaromie">Aplicar no Omie</TabsTrigger>
-            <TabsTrigger value="anteriores">Ciclos anteriores</TabsTrigger>
-          </TabsList>
-          <div className="flex items-center gap-2">
-            <Button size="sm" variant="outline" onClick={handleExportCsv} disabled={isExporting}>
-              {isExporting ? (
-                <Loader2 className="h-4 w-4 mr-1.5 animate-spin" />
-              ) : (
-                <Download className="h-4 w-4 mr-1.5" />
-              )}
-              Exportar CSV
-            </Button>
-            <Button size="sm" variant="outline" onClick={handlePrintPdf}>
-              <Printer className="h-4 w-4 mr-1.5" /> PDF
-            </Button>
-          </div>
-        </div>
+      <EtapasGrid />
 
-        <TabsContent value="ciclohoje" className="m-0">
-          <CicloHojePanel
-            user={user}
-            reviewMode={reviewMode}
-            setReviewMode={setReviewMode}
-            filters={filters}
-            setFilters={setFilters}
-            filteredItems={filteredItems}
-            fornecedores={fornecedores}
-            statuses={statuses}
-            isLoading={isLoadingItens}
-            cols={cols}
-            onColChange={updateCol}
-          />
-        </TabsContent>
-
-        <TabsContent value="aplicaromie" className="m-0">
-          <Suspense fallback={<TabFallback />}>
-            <AdminReposicaoAplicacao />
-          </Suspense>
-        </TabsContent>
-
-        <TabsContent value="anteriores" className="m-0">
-          <HistoricoComChart />
-        </TabsContent>
-      </Tabs>
+      <div className="flex items-center gap-2 flex-wrap">
+        <Button size="sm" variant="outline" onClick={handleExportCsv} disabled={isExporting}>
+          {isExporting ? (
+            <Loader2 className="h-4 w-4 mr-1.5 animate-spin" />
+          ) : (
+            <Download className="h-4 w-4 mr-1.5" />
+          )}
+          Exportar CSV do ciclo
+        </Button>
+        <Button size="sm" variant="outline" onClick={handlePrintPdf}>
+          <Printer className="h-4 w-4 mr-1.5" /> PDF do ciclo
+        </Button>
+        <Button
+          size="sm"
+          variant="ghost"
+          onClick={() => navigate("/admin/reposicao/sessao/historico")}
+        >
+          Ver histórico
+        </Button>
+      </div>
 
       <AuditLogSection />
-      {/* O ShortcutsDialog agora é global (mounted no AppShell). Atalhos do cockpit foram migrados para useRegisterShortcuts. */}
     </div>
   );
 }

--- a/src/pages/AdminReposicaoMercado.tsx
+++ b/src/pages/AdminReposicaoMercado.tsx
@@ -192,12 +192,13 @@ export default function AdminReposicaoMercado() {
 
   return (
     <ReposicaoEmpresaProvider value={{ empresa, setEmpresa }}>
-      <div className="container mx-auto p-4 sm:p-6 space-y-6 max-w-7xl">
+      <div className="space-y-6">
         <header className="flex flex-col sm:flex-row sm:items-center gap-3 justify-between">
           <div className="flex items-center gap-3">
             <TrendingUp className="h-6 w-6 text-primary" />
             <div>
-              <h1 className="text-2xl font-bold">Inteligência de Mercado</h1>
+              <div className="text-[10px] font-semibold tracking-wider text-primary uppercase">Etapa 1</div>
+              <h1 className="text-2xl font-bold">Mercado</h1>
               <p className="text-sm text-muted-foreground">
                 Oportunidades de compra, promoções ativas, aumentos anunciados e negociações paralelas — em um só lugar.
               </p>

--- a/src/pages/AdminReposicaoParametros.tsx
+++ b/src/pages/AdminReposicaoParametros.tsx
@@ -138,12 +138,13 @@ export default function AdminReposicaoParametros() {
 
   return (
     <ReposicaoEmpresaProvider value={{ empresa, setEmpresa }}>
-      <div className="container mx-auto p-4 sm:p-6 space-y-6 max-w-7xl">
+      <div className="space-y-6">
         <header className="flex flex-col sm:flex-row sm:items-center gap-3 justify-between">
           <div className="flex items-center gap-3">
             <Settings className="h-6 w-6 text-primary" />
             <div>
-              <h1 className="text-2xl font-bold">Parâmetros & Qualidade</h1>
+              <div className="text-[10px] font-semibold tracking-wider text-primary uppercase">Etapa 2</div>
+              <h1 className="text-2xl font-bold">Parâmetros</h1>
               <p className="text-sm text-muted-foreground">
                 Revisão de parâmetros, triagem de outliers, histórico de alterações e compliance de SLA — em um só lugar.
               </p>

--- a/src/pages/AdminReposicaoSessaoAplicacao.tsx
+++ b/src/pages/AdminReposicaoSessaoAplicacao.tsx
@@ -1,0 +1,19 @@
+import { Upload } from "lucide-react";
+import { EtapaHeader } from "@/components/reposicao/EtapaHeader";
+import { EtapaChecklist } from "@/components/reposicao/EtapaChecklist";
+import AdminReposicaoAplicacao from "./AdminReposicaoAplicacao";
+
+export default function AdminReposicaoSessaoAplicacao() {
+  return (
+    <div className="space-y-6">
+      <EtapaHeader
+        step={4}
+        icon={Upload}
+        title="Aplicação Omie"
+        subtitle="Aplicação dos parâmetros aprovados na integração com o Omie"
+      />
+      <EtapaChecklist step={4} />
+      <AdminReposicaoAplicacao />
+    </div>
+  );
+}

--- a/src/pages/AdminReposicaoSessaoConfirmacao.tsx
+++ b/src/pages/AdminReposicaoSessaoConfirmacao.tsx
@@ -1,0 +1,19 @@
+import { CheckCircle2 } from "lucide-react";
+import { EtapaHeader } from "@/components/reposicao/EtapaHeader";
+import { EtapaChecklist } from "@/components/reposicao/EtapaChecklist";
+import { ConfirmacaoPanel } from "@/components/reposicao/ConfirmacaoPanel";
+
+export default function AdminReposicaoSessaoConfirmacao() {
+  return (
+    <div className="space-y-6">
+      <EtapaHeader
+        step={5}
+        icon={CheckCircle2}
+        title="Confirmação"
+        subtitle="Resumo e linha do tempo do ciclo de reposição de hoje"
+      />
+      <EtapaChecklist step={5} />
+      <ConfirmacaoPanel />
+    </div>
+  );
+}

--- a/src/pages/AdminReposicaoSessaoHistorico.tsx
+++ b/src/pages/AdminReposicaoSessaoHistorico.tsx
@@ -1,0 +1,17 @@
+import { History } from "lucide-react";
+import { EtapaHeader } from "@/components/reposicao/EtapaHeader";
+import { HistoricoComChart } from "@/components/reposicao/HistoricoComChart";
+
+export default function AdminReposicaoSessaoHistorico() {
+  return (
+    <div className="space-y-6">
+      <EtapaHeader
+        step={0}
+        icon={History}
+        title="Histórico"
+        subtitle="Ciclos anteriores, comparativo e drill-down"
+      />
+      <HistoricoComChart />
+    </div>
+  );
+}

--- a/src/pages/AdminReposicaoSessaoPedidos.tsx
+++ b/src/pages/AdminReposicaoSessaoPedidos.tsx
@@ -1,0 +1,68 @@
+import { useMemo, useState } from "react";
+import { ClipboardCheck } from "lucide-react";
+import { useAuth } from "@/contexts/AuthContext";
+import { CicloHojePanel, ALL } from "@/components/reposicao/CicloHojePanel";
+import { useColumnConfig } from "@/components/reposicao/ColumnConfig";
+import { useItensDoDia } from "@/hooks/useReposicaoSessao";
+import { EtapaHeader } from "@/components/reposicao/EtapaHeader";
+import { EtapaChecklist } from "@/components/reposicao/EtapaChecklist";
+
+export default function AdminReposicaoSessaoPedidos() {
+  const { user } = useAuth();
+  const { data: itensDia = [], isLoading } = useItensDoDia();
+  const { cols, update: updateCol } = useColumnConfig();
+
+  const [reviewMode, setReviewMode] = useState(false);
+  const [filters, setFilters] = useState({ search: "", fornecedor: ALL, status: ALL });
+
+  const fornecedores = useMemo(
+    () =>
+      Array.from(new Set(itensDia.map((i) => i.fornecedor_nome).filter((x): x is string => !!x))).sort(),
+    [itensDia],
+  );
+  const statuses = useMemo(
+    () => Array.from(new Set(itensDia.map((i) => i.status).filter((x): x is string => !!x))).sort(),
+    [itensDia],
+  );
+
+  const filteredItems = useMemo(() => {
+    const q = filters.search.trim().toLowerCase();
+    return itensDia.filter((i) => {
+      if (filters.fornecedor !== ALL && i.fornecedor_nome !== filters.fornecedor) return false;
+      if (filters.status !== ALL && i.status !== filters.status) return false;
+      if (q) {
+        const hay = [i.fornecedor_nome, i.grupo_codigo, i.status]
+          .filter(Boolean)
+          .join(" ")
+          .toLowerCase();
+        if (!hay.includes(q)) return false;
+      }
+      return true;
+    });
+  }, [itensDia, filters]);
+
+  return (
+    <div className="space-y-6">
+      <EtapaHeader
+        step={3}
+        icon={ClipboardCheck}
+        title="Pedidos"
+        subtitle="Revisão e aprovação dos pedidos sugeridos para o ciclo de hoje"
+      />
+      <EtapaChecklist step={3} />
+      <CicloHojePanel
+        user={user}
+        reviewMode={reviewMode}
+        setReviewMode={setReviewMode}
+        filters={filters}
+        setFilters={setFilters}
+        filteredItems={filteredItems}
+        fornecedores={fornecedores}
+        statuses={statuses}
+        isLoading={isLoading}
+        cols={cols}
+        onColChange={updateCol}
+      />
+    </div>
+  );
+}

--- a/src/types/reposicao.ts
+++ b/src/types/reposicao.ts
@@ -1,0 +1,22 @@
+export type PedidoItem = {
+  id: number;
+  fornecedor_nome: string | null;
+  grupo_codigo: string | null;
+  num_skus: number | null;
+  valor_total: number | null;
+  pedido_anterior_valor: number | null;
+  status: string | null;
+  aprovado_em: string | null;
+  cancelado_em: string | null;
+  horario_disparo_real: string | null;
+};
+
+export type ColKey =
+  | "fornecedor"
+  | "grupo"
+  | "skus"
+  | "valor"
+  | "status"
+  | "qtdAprovada"
+  | "preco"
+  | "confianca";


### PR DESCRIPTION
…nônicas, Cockpit enxuto

Reestrutura completa da sessão de reposição em 3 fases:

Fase 1 — desbloqueio cognitivo:
- Stepper persistente como layout de rota (ReposicaoSessionLayout), visível em todas as telas da sessão, não só no Cockpit
- Vocabulário unificado entre sidebar, stepper e títulos de página
- Banner "continuar de onde parou" lendo o último evento de auditoria do dia
- Tela de Confirmação (etapa 5) com resumo do ciclo + timeline

Fase 2 — rotas canônicas:
- Rotas /admin/reposicao/sessao/* para cada etapa, com redirects de legado (LegacyCockpitRedirect preserva ?tab=)
- useReposicaoStatus retorna estado rico por etapa; getStepLocks calcula bloqueios (etapa 4 trava com pedidos pendentes, etc.)
- Stepper com cadeado + tooltip nas etapas bloqueadas
- Checklists por etapa (EtapaChecklist) com itens dinâmicos e CTA
- Cockpit vira overview puro (EtapasGrid), sem mais hibridismo rota/aba

Fase 3 — refactor estrutural:
- Cockpit de ~1970 → ~330 linhas, virou orquestrador
- Extraídos: CicloHojePanel, HistoricoComChart, SmartAlertsSection, MetricsStrip, AuditLogSection, ShortcutsDialog, ColumnConfig, TabFallback
- Utilitários compartilhados em src/lib/reposicao.ts e src/types/reposicao.ts
- Hooks em src/hooks/useReposicaoSessao.ts
- Removidos 16 casts `as any` desnecessários (tabelas têm tipos gerados)
- 24 testes unitários novos para deriveCurrentStep, getStepLocks e buildEtapaChecklist

Build, lint (arquivos novos) e 76 testes verdes.