### PR TITLE
PR2: budget management — morrer controlado antes dos 60s do Browserless

### DIFF
--- a/supabase/functions/enviar-pedido-portal-sayerlack/index.ts
+++ b/supabase/functions/enviar-pedido-portal-sayerlack/index.ts
@@ -808,8 +808,8 @@ export default async ({ page, context }) => {
       const btnEfetivar = document.querySelector('#btnSalvarNovoPedido');
       const efetivarHabilitado = btnEfetivar && !btnEfetivar.disabled;
       return !temValidando && efetivarHabilitado;
-    }, { timeout: 15000, polling: 250 });
-    trace.push({ step: 'validacao_data_entrega_ok_pre_efetivar', t: Date.now() - t0 });
+    }, { timeout: budgetFor('validacao-pre-efetivar', 15_000), polling: 250 });
+    trace.push({ step: 'validacao_data_entrega_ok_pre_efetivar', t: Date.now() - t0, remaining: remainingMs() });
 
     // Diagnóstico rico pré-click: estado do botão, contexto, hit-test, listeners jQuery
     const preClickDiag = await page.evaluate(function() {
@@ -957,13 +957,16 @@ export default async ({ page, context }) => {
     // os snapshots de 4s/8s consumiam a janela restante do Browserless antes da confirmação.
     await snapshotPosEfetivar('1s', 1000);
 
-    // Aguarda o texto de sucesso aparecer (Puppeteer suporta waitForFunction sem jsonValue)
+    // Aguarda o texto de sucesso aparecer. PR2: usa o que sobrou do budget,
+    // sem reservar mais nada (já estamos no submit). Se o banner não vier a
+    // tempo, o catch externo classifica via evidência do recorder (PR1) —
+    // se o POST saiu, vira indeterminado; se não, erro_retentavel.
     await page.waitForFunction(
       () => {
         const body = document.body.innerText;
         return /Pedido \\d+ criado com sucesso/.test(body);
       },
-      { timeout: 7000 }
+      { timeout: budgetFor('submit-pedido-banner', 10_000, { reserveSubmit: false, minMs: 2_000 }) }
     );
     // Extrai o texto via evaluate puro
     const successStr = await page.evaluate(() => {

--- a/supabase/functions/enviar-pedido-portal-sayerlack/index.ts
+++ b/supabase/functions/enviar-pedido-portal-sayerlack/index.ts
@@ -42,6 +42,60 @@ export default async ({ page, context }) => {
   // nunca lançar ReferenceError (que mascararia o envelope estruturado).
   let preLoginScreenshot = null;
 
+  // === PR2: Budget management (deadline global) ===
+  // O Browserless mata a função em ~60s. Em vez de esperar isso acontecer com
+  // um waitFor pendurado (cenário do bug original — "Waiting failed: 7000ms"
+  // mascarando o teto externo), morremos controlado dentro de 58s e devolvemos
+  // envelope estruturado. Todos os timeouts do script passam por budgetFor.
+  const HARD_CEILING_MS = 58_000;   // 2s margem abaixo dos 60s do Browserless
+  const RETURN_GUARD_MS = 2_000;    // tempo para Browserless serializar o JSON
+  const SUBMIT_RESERVED_MS = 8_000; // reservado para o click + sinal pós-submit
+  const ITEM_MIN_BUDGET_MS = 3_000; // tempo mínimo viável por item do loop
+  const deadline = t0 + HARD_CEILING_MS;
+
+  const remainingMs = () => Math.max(0, deadline - Date.now());
+
+  // budgetFor: calcula min(idealMs, restante - reserva); lança BUDGET_EXHAUSTED
+  // se o resultado for menor que minMs. NUNCA retorna fallback silencioso —
+  // preferimos abortar limpo a deixar um waitFor pendurado quando o teto chega.
+  const budgetFor = (label, idealMs, opts) => {
+    const reserveSubmit = !(opts && opts.reserveSubmit === false);
+    const minMs = (opts && typeof opts.minMs === 'number') ? opts.minMs : 500;
+    const reserved = (reserveSubmit ? SUBMIT_RESERVED_MS : 0) + RETURN_GUARD_MS;
+    const budget = Math.max(0, remainingMs() - reserved);
+    const allowed = Math.min(idealMs, budget);
+    if (allowed < minMs) {
+      const err = new Error(
+        'BUDGET_EXHAUSTED em "' + label + '": precisava de >=' + minMs +
+        'ms mas só restam ' + allowed + 'ms (deadline em ' + remainingMs() + 'ms)'
+      );
+      err.code = 'BUDGET_EXHAUSTED';
+      err.label = label;
+      throw err;
+    }
+    return allowed;
+  };
+
+  // Verificação antes de cada item: se o restante não comporta os itens que
+  // faltam + reserva de submit + return guard, aborta agora. Evita o pior
+  // cenário (montar 80% do pedido, chegar no submit com budget zero e gerar
+  // indeterminado por timeout do banner).
+  const assertEnoughTimeForRemainingItems = (currentIndex, totalItems) => {
+    const remainingItems = Math.max(0, totalItems - currentIndex);
+    const need = remainingItems * ITEM_MIN_BUDGET_MS + SUBMIT_RESERVED_MS + RETURN_GUARD_MS;
+    const rem = remainingMs();
+    if (rem < need) {
+      const err = new Error(
+        'BUDGET_EXHAUSTED: faltam ' + need + 'ms para completar ' + remainingItems +
+        ' itens + submit, mas só restam ' + rem + 'ms (item ' + currentIndex +
+        ' de ' + totalItems + ')'
+      );
+      err.code = 'BUDGET_EXHAUSTED';
+      err.label = 'remaining-items-' + currentIndex + '-of-' + totalItems;
+      throw err;
+    }
+  };
+
   // === PR1: Network Recorder ===
   // Listener global armado ANTES de qualquer navegação. Captura todo POST que
   // bate em endpoints suspeitos de efetivação. É a fonte primária de evidência
@@ -935,11 +989,15 @@ export default async ({ page, context }) => {
     };
   } catch (err) {
     const errorScreenshot = await page.screenshot({ type: 'png', encoding: 'base64' }).catch(() => null);
+    const erroTipo = (err && err.code === 'BUDGET_EXHAUSTED') ? 'BUDGET_EXHAUSTED' : 'EXCEPTION';
     return {
       data: {
         success: false,
         erro: (err && err.message) ? err.message : String(err),
-        erroTipo: 'EXCEPTION',
+        erroTipo,
+        budgetLabel: (err && err.label) || null,
+        elapsedMs: Date.now() - t0,
+        remainingMs: remainingMs(),
         trace,
       },
       type: 'application/json',
@@ -956,11 +1014,15 @@ export default async ({ page, context }) => {
   } catch (err) {
     // Rede de segurança: runFlow tem try/catch interno, mas qualquer escape
     // ainda devolve envelope estruturado (nunca um throw nu para o Browserless).
+    const erroTipo = (err && err.code === 'BUDGET_EXHAUSTED') ? 'BUDGET_EXHAUSTED' : 'EXCEPTION';
     raw = {
       data: {
         success: false,
         erro: (err && err.message) ? err.message : String(err),
-        erroTipo: 'EXCEPTION',
+        erroTipo,
+        budgetLabel: (err && err.label) || null,
+        elapsedMs: Date.now() - t0,
+        remainingMs: remainingMs(),
         trace,
       },
       type: 'application/json',

--- a/supabase/functions/enviar-pedido-portal-sayerlack/index.ts
+++ b/supabase/functions/enviar-pedido-portal-sayerlack/index.ts
@@ -590,7 +590,11 @@ export default async ({ page, context }) => {
 
     for (let i = 0; i < items.length; i++) {
       const item = items[i];
-      trace.push({ step: 'item_' + i + '_start', sku: item.sku_portal, t: Date.now() - t0 });
+      // PR2: aborta cedo se não há janela para os itens restantes + submit.
+      // Evita o pior cenário (montar 80% do pedido, chegar no submit com
+      // budget zero e gerar indeterminado).
+      assertEnoughTimeForRemainingItems(i, items.length);
+      trace.push({ step: 'item_' + i + '_start', sku: item.sku_portal, t: Date.now() - t0, remaining: remainingMs() });
 
       // Aguardar fim da janela de validação assíncrona da data de entrega.
       // O portal Sayerlack substitui os botões "Incluir Item" por "Validando data de entrega"
@@ -606,7 +610,7 @@ export default async ({ page, context }) => {
           return (b.innerText || '').includes('Validando');
         });
         return temIncluirItem && !temValidando;
-      }, { timeout: 15000, polling: 250 });
+      }, { timeout: budgetFor('item-' + i + '-validacao-data', 15_000), polling: 250 });
       // Buffer mínimo pós-validação pra DOM estabilizar
       await sleep(300);
       trace.push({ step: 'validacao_data_entrega_ok_iter_' + i, t: Date.now() - t0 });
@@ -712,7 +716,7 @@ export default async ({ page, context }) => {
           trace.push({ step: 'select2_fallback_iter_' + i, sel: select2ContainerSel, t: Date.now() - t0 });
         }
       }
-      await page.waitForSelector(select2ContainerSel, { timeout: 12000 });
+      await page.waitForSelector(select2ContainerSel, { timeout: budgetFor('item-' + i + '-select2-container', 12_000) });
       const debugPosIncluir = await page.evaluate(() => {
         const allBtns = Array.from(document.querySelectorAll('#panel_novo_pedido button.btn-primary, #colSpanBtnIncluirItem button.btn-primary, tfoot button.btn-primary'));
         return {
@@ -725,7 +729,7 @@ export default async ({ page, context }) => {
       console.log('[DEBUG_POS_INCLUIR_ITEM]', JSON.stringify({ iteration: i, ...debugPosIncluir }));
       await page.click(select2ContainerSel);
       await sleep(300);
-      await page.waitForSelector('.select2-search__field', { timeout: 5000 });
+      await page.waitForSelector('.select2-search__field', { timeout: budgetFor('item-' + i + '-select2-search', 5_000) });
       await fillInput('.select2-search__field', item.sku_portal);
       await sleep(2000);
       const skuOption = await page.$('.select2-results__option:not(.select2-results__message)');
@@ -789,7 +793,7 @@ export default async ({ page, context }) => {
           const rows = document.querySelectorAll('#datatable_itens tbody tr');
           return rows.length === esperado;
         },
-        { timeout: 5000 },
+        { timeout: budgetFor('item-' + i + '-row-count', 5_000) },
         i + 1
       ).catch(() => null);
       await sleep(400); // buffer pos-render

--- a/supabase/functions/enviar-pedido-portal-sayerlack/index.ts
+++ b/supabase/functions/enviar-pedido-portal-sayerlack/index.ts
@@ -371,20 +371,25 @@ export default async ({ page, context }) => {
 
     await applyStealth();
     trace.push({ step: 'login_start', t: Date.now() - t0 });
-    await page.goto(portalUrl + '/login', { waitUntil: 'domcontentloaded', timeout: 30000 });
-    await page.waitForSelector('#user', { timeout: 10000 });
+    await page.goto(portalUrl + '/login', { waitUntil: 'domcontentloaded', timeout: budgetFor('login-goto', 30_000) });
+    await page.waitForSelector('#user', { timeout: budgetFor('login-form', 10_000) });
     await fillInput('#user', user);
     await fillInput('#password', pass);
 
-    const navPromise = page.waitForNavigation({ timeout: 15000 }).catch(() => null);
+    const navPromise = page.waitForNavigation({ timeout: budgetFor('login-nav', 15_000) }).catch(() => null);
     await clickButtonByText('Entrar');
     await navPromise;
 
     // Heuristica robusta: aguarda evidencia POSITIVA de login bem-sucedido
     // (URL mudou para fora de /login OU elemento exclusivo da area logada apareceu)
+    // PR2: budget único para os 3 caminhos da Promise.race. Computado FORA dos
+    // IIFEs para que um BUDGET_EXHAUSTED propague pelo catch externo em vez de
+    // virar primeiro-settle da race (que mataria os outros caminhos cedo).
+    const loginCheckMs = budgetFor('login-check', 15_000);
+    const loginCheckPolls = Math.max(2, Math.floor(loginCheckMs / 500));
     const loginCheck = await Promise.race([
       (async () => {
-        for (let i = 0; i < 30; i++) { // 30 * 500ms = 15s max
+        for (let i = 0; i < loginCheckPolls; i++) {
           const url = page.url();
           if (!url.includes('/login')) return { ok: true, via: 'url_changed', url };
           await sleep(500);
@@ -393,7 +398,7 @@ export default async ({ page, context }) => {
       })(),
       (async () => {
         try {
-          await page.waitForSelector('#sidebar, .app-sidebar', { timeout: 15000 });
+          await page.waitForSelector('#sidebar, .app-sidebar', { timeout: loginCheckMs });
           return { ok: true, via: 'sidebar_found', url: page.url() };
         } catch {
           return { ok: false, via: 'sidebar_not_found', url: page.url() };
@@ -406,7 +411,7 @@ export default async ({ page, context }) => {
               const userSpan = document.querySelector('.navbar-user .d-md-inline');
               return userSpan && userSpan.innerText.trim().length > 0;
             },
-            { timeout: 15000 }
+            { timeout: loginCheckMs }
           );
           return { ok: true, via: 'user_in_header', url: page.url() };
         } catch {
@@ -482,7 +487,7 @@ export default async ({ page, context }) => {
         const sidebarLinks = document.querySelectorAll('#sidebar .menu-link, .app-sidebar .menu-link');
         return sidebarLinks.length > 0;
       },
-      { timeout: 15000 }
+      { timeout: budgetFor('sidebar-links', 15_000) }
     ).catch(() => null);
 
     // Click em "Vendas" para expandir submenu
@@ -502,7 +507,7 @@ export default async ({ page, context }) => {
       return links.some(function(a) {
         return a.getAttribute('href') === '/order-creation' && a.offsetParent !== null;
       });
-    }, { timeout: 3000, polling: 100 });
+    }, { timeout: budgetFor('sidebar-pedidos-link', 3_000, { minMs: 300 }), polling: 100 });
 
     // Click em "Pedidos / Propostas" — esse SIM navega corretamente
     const clicou_pedidos = await page.evaluate(() => {
@@ -552,7 +557,7 @@ export default async ({ page, context }) => {
     // Aguarda navegação completar (URL muda para /order-creation)
     await page.waitForFunction(
       () => window.location.href.endsWith('/order-creation'),
-      { timeout: 15000 }
+      { timeout: budgetFor('nav-order-creation', 15_000) }
     ).catch(() => null);
     await sleep(2000); // dá tempo do DOM da página de pedidos estabilizar
 
@@ -560,14 +565,14 @@ export default async ({ page, context }) => {
     console.log('[DEBUG_AFTER_CLICK_PEDIDOS]', JSON.stringify({ url: urlAposClick, chegou_em_order_creation: urlAposClick.endsWith('/order-creation') }));
     trace.push({ step: 'after_click_pedidos', url: urlAposClick, t: Date.now() - t0 });
 
-    await page.waitForSelector('#btnNovoPedido', { timeout: 25000 });
+    await page.waitForSelector('#btnNovoPedido', { timeout: budgetFor('btn-novo-pedido', 25_000) });
     await page.click('#btnNovoPedido');
-    await page.waitForSelector('#select2-cliente-container', { timeout: 10000 });
+    await page.waitForSelector('#select2-cliente-container', { timeout: budgetFor('select2-cliente-container', 10_000) });
     trace.push({ step: 'novo_pedido_open', t: Date.now() - t0 });
 
     await page.click('#select2-cliente-container');
     await sleep(300);
-    await page.waitForSelector('.select2-search__field', { timeout: 5000 });
+    await page.waitForSelector('.select2-search__field', { timeout: budgetFor('select2-cliente-search', 5_000) });
     await fillInput('.select2-search__field', clienteCodigo);
     await sleep(2000);
     const clienteOption = await page.$('.select2-results__option:not(.select2-results__message)');


### PR DESCRIPTION
## Objetivo

Atacar a causa raiz do problema do PR1/PR1.5: o script bate o teto rígido de 60s do Browserless, que mata o container com qualquer waitFor pendurado. Agora o script morre **controlado em 58s** e devolve envelope estruturado, com classificação correta via evidência do recorder.

## Como funciona

Adiciona um **deadline global** (`t0 + 58s`) e 3 helpers que substituem todos os timeouts hardcoded do script:

- `remainingMs()` — quanto resta até o deadline.
- `budgetFor(label, idealMs, opts)` — retorna `min(idealMs, restante - reserva)` e **lança `BUDGET_EXHAUSTED`** se for menor que `minMs` (default 500ms). NUNCA retorna fallback silencioso.
- `assertEnoughTimeForRemainingItems(currentIndex, totalItems)` — chamado no início de cada iteração do loop de itens. Aborta antes de começar o próximo item se `restante < itensRestantes × 3s + 8s (submit) + 2s (return guard)`.

Quando `BUDGET_EXHAUSTED` dispara, o catch externo já existente do PR1 classifica via `buildEnvelope` + evidência do recorder:
- **POST capturado** → `indeterminado_requer_conciliacao` (PR1.5 pode auto-extrair protocolo do corpo da resposta)
- **Sem POST** → `erro_retentavel`

## Migração por zonas (4 commits revertíveis)

| Zona | Commit | Antes | Depois |
|---|---|---|---|
| Helpers + catch enrichment | A | — | `BUDGET_EXHAUSTED` virou `erroTipo` próprio com `budgetLabel`, `elapsedMs`, `remainingMs` |
| Pós-submit | B | banner regex `7s` fixo | `submit-pedido-banner 10s` com `reserveSubmit:false, minMs:2000` |
| Loop de itens | C | 15s + 12s + 5s + 5s fixos por item | budgetFor por etapa + `assertEnoughTimeForRemainingItems` antes de cada item |
| Login + navegação | D | 30s + 10s + 15s + 25s + 10s + 5s fixos | budgetFor por etapa; Promise.race do login check com budget único computado FORA dos IIFEs |

Nenhum `waitForSelector` / `waitForFunction` / `waitForNavigation` / `goto` no script tem mais timeout hardcoded.

## Comportamento esperado

- **Pedido grande** (15+ SKUs, tudo lento): hoje volta em ~61s com timeout mascarado; agora morre limpo em ~58s, marca `erro_retentavel` ou `indeterminado` conforme a evidência, e o operador entende o motivo via `evidence.budgetLabel` na auditoria.
- **Pedido normal** (~30s total): nada muda. Os `budgetFor` retornam o `idealMs` porque o restante é muito maior que a reserva.
- **Pedido que não cabe em 58s** (ex.: 25 SKUs × 3s + login + submit > 58s): `assertEnoughTimeForRemainingItems` aborta antes de mexer no portal → `erro_retentavel` → após N tentativas vira `erro_nao_retentavel` (operador percebe que precisa quebrar o pedido).

## Test plan

- [ ] `deno check` passa limpo
- [ ] Pedido normal (~5 SKUs) ainda flui sem `BUDGET_EXHAUSTED`
- [ ] Pedido grande que antes morria com "Waiting failed: 7000ms" agora retorna `elapsedMs < 58000` e envelope estruturado
- [ ] `SELECT evidence->>'erroTipo' AS tipo, evidence->>'budgetLabel' AS where_, COUNT(*) FROM pedidos_portal_tentativas WHERE evidence->>'erroTipo' = 'BUDGET_EXHAUSTED' GROUP BY 1,2;` — identifica em qual etapa o teto foi atingido
- [ ] Browserless deixa de retornar HTTP 200 em 60-61s; tempo máximo observado ~58s + RTT

## Próximo PR

PR3 — wait composto pós-submit (`Promise.any` de network/banner/modal/URL) + classificação determinística via body parsing. **Precisa de uma captura real do POST do Sayerlack via DevTools** para os regexes finais não serem chute. PR1.5 já antecipou a parte de body-parsing conservadora — PR3 expande com mais sinais.

🤖 Generated with [Claude Code](https://claude.com/claude-code)