### PR TITLE
PR3: wait composto pós-submit + classificação por evidência (sobre PR2)

### DIFF
--- a/supabase/functions/enviar-pedido-portal-sayerlack/index.ts
+++ b/supabase/functions/enviar-pedido-portal-sayerlack/index.ts
@@ -234,6 +234,58 @@ export default async ({ page, context }) => {
     return null;
   };
 
+  // === PR3: Wait composto pós-submit ===
+  // Promise.any de 4 sinais positivos. Vence o primeiro que cumprir; rejeições
+  // individuais são ignoradas (até todos rejeitarem). É a substituição do
+  // waitForFunction de banner único, frágil. Os 4 sinais são complementares:
+  //  - network:  POST de efetivação capturado (evidência primária + body).
+  //  - banner:   "Pedido NNN criado com sucesso" no DOM (fonte clássica).
+  //  - modal:    modal de sucesso (Bootstrap, SweetAlert, toast).
+  //  - url:      URL muda para /pedidos (navegação pós-submit comum).
+  const SUBMIT_SUSPECT_RE = /pedido|efetivar|salvar|criar|order|novo[-_]?pedido/i;
+  const waitForPositiveSubmitSignal = (pg, timeoutMs) => {
+    const networkSignal = pg.waitForResponse(
+      (r) => {
+        try {
+          return r.request().method() === 'POST' && SUBMIT_SUSPECT_RE.test(r.url());
+        } catch (e) { return false; }
+      },
+      { timeout: timeoutMs }
+    ).then((resp) => ({ kind: 'network', response: resp }));
+    const bannerSignal = pg.waitForFunction(
+      () => /Pedido\\s+\\d+\\s+criado/i.test(document.body && document.body.innerText || ''),
+      { timeout: timeoutMs }
+    ).then(() => ({ kind: 'banner' }));
+    const modalSignal = pg.waitForSelector(
+      '.modal.show .alert-success, .swal2-success, .toast.show.bg-success',
+      { timeout: timeoutMs }
+    ).then(() => ({ kind: 'modal' }));
+    const urlSignal = pg.waitForFunction(
+      () => /pedidos?\\/?($|\\?)/.test(location.pathname || ''),
+      { timeout: timeoutMs }
+    ).then(() => ({ kind: 'url' }));
+    return Promise.any([networkSignal, bannerSignal, modalSignal, urlSignal]);
+  };
+
+  // === PR3: leitura defensiva do corpo da resposta ===
+  // Puppeteer pode lançar ao ler body de resposta consumida / redirect / etc.
+  // Devolve sempre um envelope simples; nunca propaga exception.
+  const readResponseBodySafe = async (resp) => {
+    if (!resp) return { status: null, ok: false, contentType: null, body: null, parsed: null };
+    let status = null;
+    try { status = resp.status(); } catch (e) {}
+    const headers = (() => { try { return resp.headers() || {}; } catch (e) { return {}; } })();
+    const contentType = headers['content-type'] || null;
+    const ok = typeof status === 'number' && status >= 200 && status < 300;
+    let body = null;
+    try { body = await resp.text(); } catch (e) { body = null; }
+    let parsed = null;
+    if (body) {
+      try { parsed = JSON.parse(body); } catch (e) { parsed = null; }
+    }
+    return { status, ok, contentType, body, parsed };
+  };
+
   // === PR1: Envelope estruturado ===
   // Traduz o resultado bruto do runFlow (legado: { data: {...} }) + a evidência
   // do recorder na máquina de estados. Regra de ouro: requestSent === true

--- a/supabase/functions/enviar-pedido-portal-sayerlack/index.ts
+++ b/supabase/functions/enviar-pedido-portal-sayerlack/index.ts
@@ -165,36 +165,53 @@ export default async ({ page, context }) => {
   // Conservador por design: só extrai com padrões específicos (JSON com chave
   // conhecida ou texto "Pedido NNN criado"). Falso positivo geraria pedido
   // duplicado no Omie, então preferimos errar pra "indeterminado".
+  // Chaves conhecidas para extração de protocolo. Lista ordenada por
+  // confiabilidade (mais específicas e reais do Sayerlack primeiro).
+  // Capturado via DevTools real do portal Sayerlack (15/05/2026):
+  //   POST /order-creation/form/add → 200 JSON com nr_pedido (number),
+  //   nr_pedido_cliente (string), data.ordernum (number), data.ordercust (string).
+  const PROTOCOLO_KEYS_SAYERLACK = ['nr_pedido', 'nr_pedido_cliente', 'ordernum', 'ordercust'];
+  // Padrões genéricos para outros portais (mantidos pra futuro/defesa).
+  const PROTOCOLO_KEYS_GENERICOS = ['nNumPed', 'numero_pedido', 'numeroPedido', 'protocolo', 'cNumPed', 'numero', 'pedido', 'idPedido', 'id_pedido', 'codigoPedido', 'codigo_pedido'];
+
+  const tryExtractProtocoloFromObject = (obj) => {
+    if (!obj || typeof obj !== 'object') return null;
+    // Gate de sucesso: se o JSON tem success: false explicitamente, NÃO extrai —
+    // a resposta indica falha mesmo que contenha um número.
+    if (obj.success === false) return null;
+    const KEYS = PROTOCOLO_KEYS_SAYERLACK.concat(PROTOCOLO_KEYS_GENERICOS);
+    const isProtocolo = (v) => v != null && /^\\d{3,12}$/.test(String(v).trim());
+    const checkObj = (o) => {
+      for (const k of KEYS) {
+        if (o && Object.prototype.hasOwnProperty.call(o, k) && isProtocolo(o[k])) return String(o[k]).trim();
+      }
+      return null;
+    };
+    const top = checkObj(obj);
+    if (top) return top;
+    // 1 nível aninhado (resposta normalmente vem como { data: {...} } / { result: {...} }).
+    for (const k of Object.keys(obj)) {
+      const v = obj[k];
+      if (v && typeof v === 'object') {
+        const nested = checkObj(v);
+        if (nested) return nested;
+      }
+    }
+    return null;
+  };
+
   const tryExtractProtocolo = (body) => {
     if (typeof body !== 'string' || !body) return null;
-    // 1. JSON com campos conhecidos do portal Sayerlack / padrões Omie-like.
+    // 1. JSON estruturado (caminho principal do Sayerlack).
     try {
       const obj = JSON.parse(body);
-      if (obj && typeof obj === 'object') {
-        const KEYS = ['nNumPed', 'numero_pedido', 'numeroPedido', 'protocolo', 'cNumPed', 'numero', 'pedido', 'idPedido', 'id_pedido', 'codigoPedido', 'codigo_pedido'];
-        const isProtocolo = (v) => v != null && /^\\d{3,12}$/.test(String(v));
-        const checkObj = (o) => {
-          for (const k of KEYS) {
-            if (o && Object.prototype.hasOwnProperty.call(o, k) && isProtocolo(o[k])) return String(o[k]);
-          }
-          return null;
-        };
-        const top = checkObj(obj);
-        if (top) return top;
-        // 1 nível aninhado (resposta normalmente vem como { data: {...} } / { result: {...} })
-        for (const k of Object.keys(obj)) {
-          const v = obj[k];
-          if (v && typeof v === 'object') {
-            const nested = checkObj(v);
-            if (nested) return nested;
-          }
-        }
-      }
+      const fromJson = tryExtractProtocoloFromObject(obj);
+      if (fromJson) return fromJson;
     } catch (e) { /* não é JSON, segue pro fallback de texto */ }
-    // 2. Regex textual conservadora (HTML / texto puro).
+    // 2. Regex textual conservadora (HTML / texto puro / JSON mal formado).
     const PATTERNS = [
       /Pedido\\s+(\\d{3,12})\\s+(?:criado|cadastrado|salvo|registrado)/i,
-      /"(?:nNumPed|numero_pedido|numeroPedido|protocolo|cNumPed|codigoPedido)"\\s*:\\s*"?(\\d{3,12})"?/i,
+      /"(?:nr_pedido|nr_pedido_cliente|ordernum|ordercust|nNumPed|numero_pedido|numeroPedido|protocolo|cNumPed|codigoPedido)"\\s*:\\s*"?(\\d{3,12})"?/i,
     ];
     for (const re of PATTERNS) {
       const m = body.match(re);

--- a/supabase/functions/enviar-pedido-portal-sayerlack/index.ts
+++ b/supabase/functions/enviar-pedido-portal-sayerlack/index.ts
@@ -950,10 +950,17 @@ export default async ({ page, context }) => {
     trace.push({ step: 'pre_click_efetivar_diag', t: Date.now() - t0, diag: preClickDiag });
     console.log('[DEBUG_PRE_CLICK_EFETIVAR]', JSON.stringify(preClickDiag));
 
-    await page.click('#btnSalvarNovoPedido');
-    trace.push({ step: 'efetivar_clicked', t: Date.now() - t0 });
+    // === PR3: wait composto pós-submit ===
+    // Arma os 4 sinais ANTES do click — qualquer um que cumpra ganha. Ignora
+    // rejeições individuais via Promise.any. Substitui o waitForFunction de
+    // banner único do PR1/PR2 (sinal frágil que perdia respostas atrasadas).
+    const postSubmitBudget = budgetFor('submit-pedido', 10_000, { reserveSubmit: false, minMs: 2_000 });
+    const signalPromise = waitForPositiveSubmitSignal(page, postSubmitBudget);
 
-    // Snapshot imediato (sem sleep) pra capturar mudança instantânea no DOM
+    await page.click('#btnSalvarNovoPedido');
+    trace.push({ step: 'efetivar_clicked', t: Date.now() - t0, postSubmitBudget, remaining: remainingMs() });
+
+    // Snapshot imediato (sem sleep) pra capturar mudança instantânea no DOM.
     const snapImediato = await page.evaluate(function() {
       const btn = document.querySelector('#btnSalvarNovoPedido');
       return {
@@ -968,100 +975,142 @@ export default async ({ page, context }) => {
     trace.push({ step: 'snapshot_pos_efetivar_imediato', t: Date.now() - t0, snapshot: snapImediato });
     console.log('[DEBUG_POS_EFETIVAR_IMEDIATO]', JSON.stringify(snapImediato));
 
-    // Diagnóstico do estado da página pós-efetivar.
-    // Faz 3 snapshots em janelas de tempo distintas pra capturar evolução: 1s, 4s, 8s pós-click.
-    const snapshotPosEfetivar = async function(label, delayMs) {
-      await sleep(delayMs);
-      const snap = await page.evaluate(function() {
-        // Banner verde de sucesso (caso já tenha aparecido)
-        const corpo = document.body ? document.body.innerText : '';
-        const bannerSucesso = corpo.match(/Pedido\s*(\d+)\s*criado\s*com\s*sucesso/i);
+    // Aguarda o primeiro sinal positivo. Se nenhum cumprir no budget, lança
+    // AggregateError (Promise.any) — capturado e classificado abaixo.
+    let firstSignal;
+    try {
+      firstSignal = await signalPromise;
+    } catch (err) {
+      firstSignal = { kind: 'none', error: (err && err.message) || String(err) };
+    }
+    trace.push({ step: 'first_signal', kind: firstSignal.kind, t: Date.now() - t0, remaining: remainingMs() });
+    console.log('[DEBUG_FIRST_SIGNAL]', JSON.stringify({ kind: firstSignal.kind, error: firstSignal.error || null }));
 
-        // Modais visíveis (Bootstrap modal padrão do portal)
-        const modais = Array.from(document.querySelectorAll('.modal.show, .modal.in, [role="dialog"]'))
-          .filter(function(m) { return m.offsetParent !== null; })
-          .map(function(m) {
-            return {
-              texto: (m.innerText || '').trim().substring(0, 300),
-              classes: (m.className || '').substring(0, 100)
-            };
-          });
+    // Microjanela: 250ms a mais pro recorder receber o body da response caso o
+    // sinal vencedor tenha sido banner/modal/url (que chegam antes do network
+    // em alguns cenários).
+    if (remainingMs() > 800) {
+      await sleep(250);
+    }
 
-        // Mensagens de erro/validação inline (alerts, toasts, validações)
-        const alertas = Array.from(document.querySelectorAll('.alert, .toast, .invalid-feedback, .help-block, .validation-message, .error-message, [role="alert"]'))
-          .filter(function(a) { return a.offsetParent !== null; })
-          .map(function(a) {
-            return {
-              texto: (a.innerText || '').trim().substring(0, 200),
-              classes: (a.className || '').substring(0, 80)
-            };
-          })
-          .filter(function(info) { return info.texto.length > 0; });
+    // Extrai protocolo via cascata de fontes confiáveis:
+    //   1. body da response do POST capturado pelo Promise.any (mais confiável)
+    //   2. DOM do banner (quando o sinal vencedor foi banner)
+    //   3. fallback PR1.5: qualquer response capturada pelo recorder
+    let protocolo = null;
+    let protocoloSource = null;
+    let responseInfo = null;
+    let bodySuccessFalse = false;  // portal devolveu success:false explícito
 
-        // Campos com classe de erro/inválido
-        const camposInvalidos = Array.from(document.querySelectorAll('.is-invalid, .has-error, .field-error, [aria-invalid="true"]'))
-          .filter(function(el) { return el.offsetParent !== null; })
-          .map(function(el) {
-            return {
-              tag: el.tagName,
-              id: el.id || '',
-              name: el.getAttribute('name') || '',
-              classes: (el.className || '').substring(0, 80)
-            };
-          })
-          .slice(0, 10);
+    if (firstSignal.kind === 'network' && firstSignal.response) {
+      const r = await readResponseBodySafe(firstSignal.response);
+      responseInfo = {
+        status: r.status,
+        ok: r.ok,
+        contentType: r.contentType,
+        parsedKind: r.parsed ? 'json' : (r.body ? 'text' : 'empty'),
+      };
+      if (r.parsed && r.parsed.success === false) bodySuccessFalse = true;
+      if (r.parsed && !bodySuccessFalse) {
+        protocolo = tryExtractProtocoloFromObject(r.parsed);
+        if (protocolo) protocoloSource = 'network_json';
+      }
+      if (!protocolo && r.body && !bodySuccessFalse) {
+        protocolo = tryExtractProtocolo(r.body);
+        if (protocolo) protocoloSource = 'network_text';
+      }
+    }
 
-        // Botão "Efetivar Pedido" ainda existe? (se sim, o submit não foi aceito)
-        const btnEfetivarAindaPresente = !!document.querySelector('#btnSalvarNovoPedido');
-
-        return {
-          url: location.href,
-          title: document.title,
-          bannerSucesso: bannerSucesso ? bannerSucesso[0] : null,
-          pedidoNumero: bannerSucesso ? bannerSucesso[1] : null,
-          modais: modais,
-          modaisCount: modais.length,
-          alertas: alertas,
-          alertasCount: alertas.length,
-          camposInvalidos: camposInvalidos,
-          camposInvalidosCount: camposInvalidos.length,
-          btnEfetivarAindaPresente: btnEfetivarAindaPresente
-        };
+    if (!protocolo && firstSignal.kind === 'banner') {
+      protocolo = await page.evaluate(() => {
+        const body = (document.body && document.body.innerText) || '';
+        const m = body.match(/Pedido\\s+(\\d+)\\s+criado/i);
+        return m ? m[1] : null;
       });
-      trace.push({ step: 'snapshot_pos_efetivar_' + label, t: Date.now() - t0, snapshot: snap });
-      console.log('[DEBUG_POS_EFETIVAR_' + label + ']', JSON.stringify(snap));
-    };
-    // Captura só 1 snapshot rápido. O pedido #116 clicou em Efetivar perto de 53s;
-    // os snapshots de 4s/8s consumiam a janela restante do Browserless antes da confirmação.
-    await snapshotPosEfetivar('1s', 1000);
+      if (protocolo) protocoloSource = 'banner_dom';
+    }
 
-    // Aguarda o texto de sucesso aparecer. PR2: usa o que sobrou do budget,
-    // sem reservar mais nada (já estamos no submit). Se o banner não vier a
-    // tempo, o catch externo classifica via evidência do recorder (PR1) —
-    // se o POST saiu, vira indeterminado; se não, erro_retentavel.
-    await page.waitForFunction(
-      () => {
-        const body = document.body.innerText;
-        return /Pedido \\d+ criado com sucesso/.test(body);
-      },
-      { timeout: budgetFor('submit-pedido-banner', 10_000, { reserveSubmit: false, minMs: 2_000 }) }
-    );
-    // Extrai o texto via evaluate puro
-    const successStr = await page.evaluate(() => {
-      const body = document.body.innerText;
-      const match = body.match(/Pedido (\\d+) criado com sucesso/);
-      return match ? match[0] : null;
+    if (!protocolo && !bodySuccessFalse) {
+      // Fallback PR1.5: olha qualquer response no recorder (não só a que o
+      // Promise.any pegou — outros POSTs podem ter trazido o número também).
+      const evidenceForExtract = recorder.getSubmitEvidence();
+      const fromRecorder = extractProtocoloFromEvidence(evidenceForExtract);
+      if (fromRecorder) {
+        protocolo = fromRecorder.protocolo;
+        protocoloSource = 'recorder_fallback';
+      }
+    }
+
+    trace.push({
+      step: 'submit_classified',
+      firstSignalKind: firstSignal.kind,
+      protocolo,
+      protocoloSource,
+      responseInfo,
+      bodySuccessFalse,
+      t: Date.now() - t0
     });
-    const protocoloMatch = successStr ? successStr.match(/Pedido (\\d+) criado com sucesso/) : null;
-    const protocolo = protocoloMatch ? protocoloMatch[1] : null;
-    trace.push({ step: 'success_detected', protocolo, t: Date.now() - t0 });
+    console.log('[DEBUG_SUBMIT_CLASSIFIED]', JSON.stringify({
+      firstSignalKind: firstSignal.kind, protocolo, protocoloSource, responseInfo, bodySuccessFalse
+    }));
 
-    const screenshot = await page.screenshot({ type: 'jpeg', quality: 70, fullPage: false, encoding: 'base64' });
+    const screenshot = await page.screenshot({ type: 'jpeg', quality: 70, fullPage: false, encoding: 'base64' }).catch(() => null);
+
+    // Decisão final (alinhada com a cascata de classifySubmitResult do doc):
+    //  - Portal devolveu success:false explícito → falha; buildEnvelope vê
+    //    requestSent e classifica como indeterminado (operador concilia).
+    //  - Sinal positivo (network/banner/modal) OU protocolo extraído de
+    //    qualquer fonte → success:true; buildEnvelope mapeia para
+    //    sucesso_portal (com protocolo) ou aceito_portal_sem_protocolo.
+    //  - firstSignal === 'url' (só URL change, sem nada mais) → success:false
+    //    com erroTipo AMBIGUO_URL_ONLY → indeterminado.
+    //  - firstSignal === 'none' → success:false com erroTipo NO_POSITIVE_SIGNAL
+    //    → buildEnvelope decide via requestSent (POST capturado → indeterminado;
+    //    sem POST → erro_retentavel).
+    if (bodySuccessFalse) {
+      return {
+        data: {
+          success: false,
+          erroTipo: 'PORTAL_RESPONSE_FAILURE',
+          erro: 'Portal devolveu success:false na resposta do POST de efetivação',
+          firstSignal: { kind: firstSignal.kind },
+          responseInfo,
+          durationMs: Date.now() - t0,
+          trace,
+        },
+        type: 'application/json',
+        screenshot,
+      };
+    }
+
+    const positiveKinds = ['network', 'banner', 'modal'];
+    if (positiveKinds.indexOf(firstSignal.kind) !== -1 || protocolo) {
+      trace.push({ step: 'success_detected', protocolo, source: protocoloSource, t: Date.now() - t0 });
+      return {
+        data: {
+          success: true,
+          protocolo,
+          protocoloSource,
+          firstSignal: { kind: firstSignal.kind },
+          responseInfo,
+          successText: protocolo ? ('Pedido ' + protocolo + ' criado com sucesso') : null,
+          durationMs: Date.now() - t0,
+          trace,
+        },
+        type: 'application/json',
+        screenshot,
+      };
+    }
+
+    // firstSignal === 'url' ou 'none', sem protocolo.
     return {
       data: {
-        success: true,
-        protocolo,
-        successText: successStr,
+        success: false,
+        erroTipo: firstSignal.kind === 'url' ? 'AMBIGUO_URL_ONLY' : 'NO_POSITIVE_SIGNAL',
+        erro: firstSignal.kind === 'url'
+          ? 'Apenas mudança de URL detectada após submit — sem protocolo, requer conciliação'
+          : 'Nenhum sinal positivo de submit em ' + postSubmitBudget + 'ms (banner/modal/network/url todos timed out)',
+        firstSignal: { kind: firstSignal.kind, error: firstSignal.error || null },
         durationMs: Date.now() - t0,
         trace,
       },


### PR DESCRIPTION
> ⚠️ **Dependência**: este PR está em cima do PR2 ([#9](https://github.com/LucasSardenbergL/afiacao/pull/9)). Os commits do PR2 aparecem no diff abaixo até o PR2 ser mergeado — depois disso, GitHub remove eles automaticamente e o diff fica só com os 3 commits do PR3.

## Objetivo

Substituir o sinal único frágil (regex de banner único pós-submit) por uma cascata determinística de **4 sinais armados em paralelo ANTES do click**, com classificação baseada em evidência primária (network). Fecha o último vetor de "pedido subiu mas vira indeterminado" mesmo quando o Browserless mata o script.

Cenário motivador, capturado via DevTools real (15/05/2026):
- POST `http://portal.sayerlack.com.br:9092/order-creation/form/add`
- Status `200 OK`, Content-Type `application/json`, **9.48s** de tempo
- Body: `{ "success": true, "nr_pedido": 2094759, "nr_pedido_cliente": "2094759", "data": { "ordernum": 2094759, "ordercust": "2094759", ... } }`

No fluxo do PR1/PR2, esse POST respondia OK aos ~9s, mas o `waitForFunction` do banner podia perder o evento (o banner soma com classe `animate-fade-out` em alguns casos) → script morria no teto de 60s → pedido virava `indeterminado`. Agora o sinal `network` do Promise.any pega a response direto e o protocolo sai do JSON.

## O que muda

### Commit A — extrator afinado

`tryExtractProtocolo` ganha 4 chaves novas reais do Sayerlack (`nr_pedido`, `nr_pedido_cliente`, `ordernum`, `ordercust`) e um **gate de sucesso**: `success: false` no JSON não extrai (resposta de falha não deve gerar protocolo, mesmo com número). Novo helper `tryExtractProtocoloFromObject` exposto pra reuso direto no submit.

### Commit B — helpers

- **`waitForPositiveSubmitSignal(page, timeoutMs)`** — `Promise.any` de 4 sinais:
  - `network`: `waitForResponse` com o mesmo regex do recorder. Devolve `{ kind, response }` com o objeto Response pronto.
  - `banner`: `Pedido NNN criado` no `document.body.innerText`.
  - `modal`: `.modal.show .alert-success, .swal2-success, .toast.show.bg-success`.
  - `url`: pathname casa `/pedidos`.
  Vence o primeiro. Rejeições individuais ignoradas — só lança AggregateError se todos os 4 rejeitarem.

- **`readResponseBodySafe(response)`** — Puppeteer pode lançar ao ler body de response consumida/redirect; este helper devolve sempre `{ status, ok, contentType, body, parsed }` sem propagar exception.

### Commit C — refator do submit

Antes:
```js
await page.click('#btnSalvarNovoPedido');
await sleep(1000);  // snapshotPosEfetivar
await page.waitForFunction(/banner regex/, { timeout: ... });  // sinal único
// extract via regex no DOM
```

Depois:
```js
const signalPromise = waitForPositiveSubmitSignal(page, postSubmitBudget);  // armado ANTES
await page.click('#btnSalvarNovoPedido');
const firstSignal = await signalPromise.catch(err => ({ kind: 'none', error: ... }));
if (remainingMs() > 800) await sleep(250);  // microjanela
// extrair via cascata: response JSON → response texto → banner DOM → recorder fallback
// classificar via cascata determinística
```

Cascata de classificação:
| Cenário | Resultado | Status final via buildEnvelope |
|---|---|---|
| `body.success === false` | `PORTAL_RESPONSE_FAILURE` | indeterminado (operador concilia) |
| sinal positivo (network/banner/modal) + protocolo | `success:true` | **sucesso_portal** |
| sinal positivo, sem protocolo | `success:true, protocolo:null` | aceito_portal_sem_protocolo |
| firstSignal === 'url' sozinho | `AMBIGUO_URL_ONLY` | indeterminado |
| firstSignal === 'none' | `NO_POSITIVE_SIGNAL` | indeterminado se POST capturado, senão erro_retentavel |

## Test plan

- [ ] `deno check` clean
- [ ] Pedido normal: vem `sucesso_portal` com `protocoloSource: "network_json"` (nova fonte mais rápida e segura)
- [ ] Pedido grande que antes virava `indeterminado` agora vem `sucesso_portal` automático
- [ ] `SELECT evidence->>'protocoloSource' AS fonte, COUNT(*) FROM pedidos_portal_tentativas WHERE status_resultado='sucesso_portal' GROUP BY 1;` — distribuição esperada: `network_json` na maioria, `banner_dom` em pedidos rápidos, `recorder_fallback` raros
- [ ] Trace `submit_classified` mostra `firstSignalKind`, `protocoloSource`, `responseInfo` na auditoria

🤖 Generated with [Claude Code](https://claude.com/claude-code)