### PR TITLE
PR4: data de entrega do portal Sayerlack + 2 dias vira dDtPrevisao do Omie

### DIFF
--- a/supabase/functions/disparar-pedidos-aprovados/index.ts
+++ b/supabase/functions/disparar-pedidos-aprovados/index.ts
@@ -410,14 +410,20 @@ async function processarPedido(
     const nQtdeParc = Math.max(1, Number(pedido.num_parcelas ?? 1) || 1);
 
     // PR4: para Sayerlack/OBEN, usa a data de entrega confirmada pelo portal
-    // + 2 dias corridos como dDtPrevisao do Omie. Cai no fallback de lead time
-    // logístico se não capturamos a data do portal (ex.: caminho PR1.5 do
-    // recorder fallback, ou pedidos antigos antes da coluna existir).
+    // + 2 dias ÚTEIS como dDtPrevisao do Omie (pula sábado/domingo). Cai no
+    // fallback de lead time logístico se não capturamos a data do portal
+    // (ex.: caminho PR1.5 do recorder fallback, ou pedidos antigos antes da
+    // coluna existir).
     const dDtPrevisao = (() => {
       const portalDate = pedido.portal_data_entrega;
       if (typeof portalDate === "string" && /^\d{4}-\d{2}-\d{2}$/.test(portalDate)) {
         const d = new Date(`${portalDate}T00:00:00Z`);
-        d.setUTCDate(d.getUTCDate() + 2);
+        let adicionados = 0;
+        while (adicionados < 2) {
+          d.setUTCDate(d.getUTCDate() + 1);
+          const dow = d.getUTCDay(); // 0=domingo, 6=sábado
+          if (dow !== 0 && dow !== 6) adicionados++;
+        }
         return `${String(d.getUTCDate()).padStart(2, "0")}/${
           String(d.getUTCMonth() + 1).padStart(2, "0")
         }/${d.getUTCFullYear()}`;

--- a/supabase/functions/disparar-pedidos-aprovados/index.ts
+++ b/supabase/functions/disparar-pedidos-aprovados/index.ts
@@ -34,6 +34,10 @@ interface PedidoRow {
   whatsapp_pedido?: string | null;
   observacoes_pedido?: string | null;
   nome_contato?: string | null;
+  // PR4: data de entrega confirmada pelo portal Sayerlack (ISO YYYY-MM-DD).
+  // Quando presente em pedido Sayerlack/OBEN, vira base do dDtPrevisao do
+  // Omie (+ 2 dias corridos). Quando ausente, cai no fallback de lead time.
+  portal_data_entrega?: string | null;
 }
 
 interface ItemRow {
@@ -405,9 +409,25 @@ async function processarPedido(
     const cCodParc = String(condRaw).trim().slice(0, 3);
     const nQtdeParc = Math.max(1, Number(pedido.num_parcelas ?? 1) || 1);
 
+    // PR4: para Sayerlack/OBEN, usa a data de entrega confirmada pelo portal
+    // + 2 dias corridos como dDtPrevisao do Omie. Cai no fallback de lead time
+    // logístico se não capturamos a data do portal (ex.: caminho PR1.5 do
+    // recorder fallback, ou pedidos antigos antes da coluna existir).
+    const dDtPrevisao = (() => {
+      const portalDate = pedido.portal_data_entrega;
+      if (typeof portalDate === "string" && /^\d{4}-\d{2}-\d{2}$/.test(portalDate)) {
+        const d = new Date(`${portalDate}T00:00:00Z`);
+        d.setUTCDate(d.getUTCDate() + 2);
+        return `${String(d.getUTCDate()).padStart(2, "0")}/${
+          String(d.getUTCMonth() + 1).padStart(2, "0")
+        }/${d.getUTCFullYear()}`;
+      }
+      return diasUteisFromHoje(ltDias);
+    })();
+
     const cabecalho_incluir: Record<string, unknown> = {
       cCodIntPed: `AFI-${pedido.id}`,
-      dDtPrevisao: diasUteisFromHoje(ltDias),
+      dDtPrevisao,
       nCodFor: Number(fornecedor.codigo),
       // cNumPedido (Nº do Pedido do Fornecedor) deixado em branco — preenchido pelo
       // fornecedor quando confirmar. Para Sayerlack, usamos o protocolo do portal
@@ -754,7 +774,7 @@ Deno.serve(async (req: Request) => {
     // 2. Pedidos aprovados (com dados do fornecedor)
     let aprovadosQuery = db
       .from("pedido_compra_sugerido")
-      .select("id, empresa, fornecedor_nome, grupo_codigo, data_ciclo, valor_total, num_skus, status, condicao_pagamento_codigo, condicao_pagamento_descricao, num_parcelas")
+      .select("id, empresa, fornecedor_nome, grupo_codigo, data_ciclo, valor_total, num_skus, status, condicao_pagamento_codigo, condicao_pagamento_descricao, num_parcelas, portal_data_entrega")
       .eq("empresa", empresa);
 
     aprovadosQuery = pedidoId

--- a/supabase/functions/enviar-pedido-portal-sayerlack/index.ts
+++ b/supabase/functions/enviar-pedido-portal-sayerlack/index.ts
@@ -234,6 +234,58 @@ export default async ({ page, context }) => {
     return null;
   };
 
+  // === PR3: Wait composto pós-submit ===
+  // Promise.any de 4 sinais positivos. Vence o primeiro que cumprir; rejeições
+  // individuais são ignoradas (até todos rejeitarem). É a substituição do
+  // waitForFunction de banner único, frágil. Os 4 sinais são complementares:
+  //  - network:  POST de efetivação capturado (evidência primária + body).
+  //  - banner:   "Pedido NNN criado com sucesso" no DOM (fonte clássica).
+  //  - modal:    modal de sucesso (Bootstrap, SweetAlert, toast).
+  //  - url:      URL muda para /pedidos (navegação pós-submit comum).
+  const SUBMIT_SUSPECT_RE = /pedido|efetivar|salvar|criar|order|novo[-_]?pedido/i;
+  const waitForPositiveSubmitSignal = (pg, timeoutMs) => {
+    const networkSignal = pg.waitForResponse(
+      (r) => {
+        try {
+          return r.request().method() === 'POST' && SUBMIT_SUSPECT_RE.test(r.url());
+        } catch (e) { return false; }
+      },
+      { timeout: timeoutMs }
+    ).then((resp) => ({ kind: 'network', response: resp }));
+    const bannerSignal = pg.waitForFunction(
+      () => /Pedido\\s+\\d+\\s+criado/i.test(document.body && document.body.innerText || ''),
+      { timeout: timeoutMs }
+    ).then(() => ({ kind: 'banner' }));
+    const modalSignal = pg.waitForSelector(
+      '.modal.show .alert-success, .swal2-success, .toast.show.bg-success',
+      { timeout: timeoutMs }
+    ).then(() => ({ kind: 'modal' }));
+    const urlSignal = pg.waitForFunction(
+      () => /pedidos?\\/?($|\\?)/.test(location.pathname || ''),
+      { timeout: timeoutMs }
+    ).then(() => ({ kind: 'url' }));
+    return Promise.any([networkSignal, bannerSignal, modalSignal, urlSignal]);
+  };
+
+  // === PR3: leitura defensiva do corpo da resposta ===
+  // Puppeteer pode lançar ao ler body de resposta consumida / redirect / etc.
+  // Devolve sempre um envelope simples; nunca propaga exception.
+  const readResponseBodySafe = async (resp) => {
+    if (!resp) return { status: null, ok: false, contentType: null, body: null, parsed: null };
+    let status = null;
+    try { status = resp.status(); } catch (e) {}
+    const headers = (() => { try { return resp.headers() || {}; } catch (e) { return {}; } })();
+    const contentType = headers['content-type'] || null;
+    const ok = typeof status === 'number' && status >= 200 && status < 300;
+    let body = null;
+    try { body = await resp.text(); } catch (e) { body = null; }
+    let parsed = null;
+    if (body) {
+      try { parsed = JSON.parse(body); } catch (e) { parsed = null; }
+    }
+    return { status, ok, contentType, body, parsed };
+  };
+
   // === PR1: Envelope estruturado ===
   // Traduz o resultado bruto do runFlow (legado: { data: {...} }) + a evidência
   // do recorder na máquina de estados. Regra de ouro: requestSent === true

--- a/supabase/functions/enviar-pedido-portal-sayerlack/index.ts
+++ b/supabase/functions/enviar-pedido-portal-sayerlack/index.ts
@@ -165,36 +165,53 @@ export default async ({ page, context }) => {
   // Conservador por design: só extrai com padrões específicos (JSON com chave
   // conhecida ou texto "Pedido NNN criado"). Falso positivo geraria pedido
   // duplicado no Omie, então preferimos errar pra "indeterminado".
+  // Chaves conhecidas para extração de protocolo. Lista ordenada por
+  // confiabilidade (mais específicas e reais do Sayerlack primeiro).
+  // Capturado via DevTools real do portal Sayerlack (15/05/2026):
+  //   POST /order-creation/form/add → 200 JSON com nr_pedido (number),
+  //   nr_pedido_cliente (string), data.ordernum (number), data.ordercust (string).
+  const PROTOCOLO_KEYS_SAYERLACK = ['nr_pedido', 'nr_pedido_cliente', 'ordernum', 'ordercust'];
+  // Padrões genéricos para outros portais (mantidos pra futuro/defesa).
+  const PROTOCOLO_KEYS_GENERICOS = ['nNumPed', 'numero_pedido', 'numeroPedido', 'protocolo', 'cNumPed', 'numero', 'pedido', 'idPedido', 'id_pedido', 'codigoPedido', 'codigo_pedido'];
+
+  const tryExtractProtocoloFromObject = (obj) => {
+    if (!obj || typeof obj !== 'object') return null;
+    // Gate de sucesso: se o JSON tem success: false explicitamente, NÃO extrai —
+    // a resposta indica falha mesmo que contenha um número.
+    if (obj.success === false) return null;
+    const KEYS = PROTOCOLO_KEYS_SAYERLACK.concat(PROTOCOLO_KEYS_GENERICOS);
+    const isProtocolo = (v) => v != null && /^\\d{3,12}$/.test(String(v).trim());
+    const checkObj = (o) => {
+      for (const k of KEYS) {
+        if (o && Object.prototype.hasOwnProperty.call(o, k) && isProtocolo(o[k])) return String(o[k]).trim();
+      }
+      return null;
+    };
+    const top = checkObj(obj);
+    if (top) return top;
+    // 1 nível aninhado (resposta normalmente vem como { data: {...} } / { result: {...} }).
+    for (const k of Object.keys(obj)) {
+      const v = obj[k];
+      if (v && typeof v === 'object') {
+        const nested = checkObj(v);
+        if (nested) return nested;
+      }
+    }
+    return null;
+  };
+
   const tryExtractProtocolo = (body) => {
     if (typeof body !== 'string' || !body) return null;
-    // 1. JSON com campos conhecidos do portal Sayerlack / padrões Omie-like.
+    // 1. JSON estruturado (caminho principal do Sayerlack).
     try {
       const obj = JSON.parse(body);
-      if (obj && typeof obj === 'object') {
-        const KEYS = ['nNumPed', 'numero_pedido', 'numeroPedido', 'protocolo', 'cNumPed', 'numero', 'pedido', 'idPedido', 'id_pedido', 'codigoPedido', 'codigo_pedido'];
-        const isProtocolo = (v) => v != null && /^\\d{3,12}$/.test(String(v));
-        const checkObj = (o) => {
-          for (const k of KEYS) {
-            if (o && Object.prototype.hasOwnProperty.call(o, k) && isProtocolo(o[k])) return String(o[k]);
-          }
-          return null;
-        };
-        const top = checkObj(obj);
-        if (top) return top;
-        // 1 nível aninhado (resposta normalmente vem como { data: {...} } / { result: {...} })
-        for (const k of Object.keys(obj)) {
-          const v = obj[k];
-          if (v && typeof v === 'object') {
-            const nested = checkObj(v);
-            if (nested) return nested;
-          }
-        }
-      }
+      const fromJson = tryExtractProtocoloFromObject(obj);
+      if (fromJson) return fromJson;
     } catch (e) { /* não é JSON, segue pro fallback de texto */ }
-    // 2. Regex textual conservadora (HTML / texto puro).
+    // 2. Regex textual conservadora (HTML / texto puro / JSON mal formado).
     const PATTERNS = [
       /Pedido\\s+(\\d{3,12})\\s+(?:criado|cadastrado|salvo|registrado)/i,
-      /"(?:nNumPed|numero_pedido|numeroPedido|protocolo|cNumPed|codigoPedido)"\\s*:\\s*"?(\\d{3,12})"?/i,
+      /"(?:nr_pedido|nr_pedido_cliente|ordernum|ordercust|nNumPed|numero_pedido|numeroPedido|protocolo|cNumPed|codigoPedido)"\\s*:\\s*"?(\\d{3,12})"?/i,
     ];
     for (const re of PATTERNS) {
       const m = body.match(re);

--- a/supabase/functions/enviar-pedido-portal-sayerlack/index.ts
+++ b/supabase/functions/enviar-pedido-portal-sayerlack/index.ts
@@ -352,11 +352,14 @@ export default async ({ page, context }) => {
 
     // Mantém a forma externa { data, type, screenshot, preLoginScreenshot } que
     // o Browserless v2 já serializa hoje; o envelope estruturado vai dentro de data.
+    // PR4: portal_data_entrega vem do submit quando o sinal vencedor foi
+    // network e o JSON foi parseado (ISO YYYY-MM-DD); null nos outros casos.
     return {
       data: {
         ok,
         status,
         protocolo,
+        portal_data_entrega: data.portal_data_entrega || null,
         safeToRetry,
         needsReconciliation,
         evidence: {
@@ -1626,6 +1629,13 @@ async function processarPedido(
     };
     if (opts.protocolo !== undefined) update.portal_protocolo = opts.protocolo;
     if (opts.enviadoPortalEm) update.enviado_portal_em = new Date().toISOString();
+    // PR4: persiste a data_entrega devolvida pelo portal (formato ISO YYYY-MM-DD).
+    // Só grava se veio um valor válido — não sobrescreve com null em re-tentativas
+    // que não capturaram a data (ex.: caminho PR1.5 do recorder fallback).
+    const portalDataEntrega = (envelope as any)?.portal_data_entrega;
+    if (typeof portalDataEntrega === "string" && /^\d{4}-\d{2}-\d{2}$/.test(portalDataEntrega)) {
+      update.portal_data_entrega = portalDataEntrega;
+    }
     await supabase.from("pedido_compra_sugerido").update(update).eq("id", pedido.id);
     await gravarTentativa(supabase, pedido.id, {
       iniciadoEm,

--- a/supabase/functions/enviar-pedido-portal-sayerlack/index.ts
+++ b/supabase/functions/enviar-pedido-portal-sayerlack/index.ts
@@ -1001,6 +1001,10 @@ export default async ({ page, context }) => {
     let protocoloSource = null;
     let responseInfo = null;
     let bodySuccessFalse = false;  // portal devolveu success:false explícito
+    // PR4: data_entrega devolvida pelo portal (campo top-level "data_entrega"
+    // do JSON em formato ISO YYYY-MM-DD; ex.: "2026-05-22"). Usada pelo
+    // disparar-pedidos-aprovados como base do dDtPrevisao do Omie (+ 2 dias).
+    let portalDataEntrega = null;
 
     if (firstSignal.kind === 'network' && firstSignal.response) {
       const r = await readResponseBodySafe(firstSignal.response);
@@ -1014,6 +1018,11 @@ export default async ({ page, context }) => {
       if (r.parsed && !bodySuccessFalse) {
         protocolo = tryExtractProtocoloFromObject(r.parsed);
         if (protocolo) protocoloSource = 'network_json';
+        // PR4: data_entrega top-level (ISO YYYY-MM-DD). Validação estrita
+        // para não persistir lixo no banco.
+        if (typeof r.parsed.data_entrega === 'string' && /^\\d{4}-\\d{2}-\\d{2}$/.test(r.parsed.data_entrega)) {
+          portalDataEntrega = r.parsed.data_entrega;
+        }
       }
       if (!protocolo && r.body && !bodySuccessFalse) {
         protocolo = tryExtractProtocolo(r.body);
@@ -1046,12 +1055,13 @@ export default async ({ page, context }) => {
       firstSignalKind: firstSignal.kind,
       protocolo,
       protocoloSource,
+      portalDataEntrega,
       responseInfo,
       bodySuccessFalse,
       t: Date.now() - t0
     });
     console.log('[DEBUG_SUBMIT_CLASSIFIED]', JSON.stringify({
-      firstSignalKind: firstSignal.kind, protocolo, protocoloSource, responseInfo, bodySuccessFalse
+      firstSignalKind: firstSignal.kind, protocolo, protocoloSource, portalDataEntrega, responseInfo, bodySuccessFalse
     }));
 
     const screenshot = await page.screenshot({ type: 'jpeg', quality: 70, fullPage: false, encoding: 'base64' }).catch(() => null);
@@ -1085,12 +1095,13 @@ export default async ({ page, context }) => {
 
     const positiveKinds = ['network', 'banner', 'modal'];
     if (positiveKinds.indexOf(firstSignal.kind) !== -1 || protocolo) {
-      trace.push({ step: 'success_detected', protocolo, source: protocoloSource, t: Date.now() - t0 });
+      trace.push({ step: 'success_detected', protocolo, source: protocoloSource, portalDataEntrega, t: Date.now() - t0 });
       return {
         data: {
           success: true,
           protocolo,
           protocoloSource,
+          portal_data_entrega: portalDataEntrega,
           firstSignal: { kind: firstSignal.kind },
           responseInfo,
           successText: protocolo ? ('Pedido ' + protocolo + ' criado com sucesso') : null,

--- a/supabase/functions/enviar-pedido-portal-sayerlack/index.ts
+++ b/supabase/functions/enviar-pedido-portal-sayerlack/index.ts
@@ -950,10 +950,17 @@ export default async ({ page, context }) => {
     trace.push({ step: 'pre_click_efetivar_diag', t: Date.now() - t0, diag: preClickDiag });
     console.log('[DEBUG_PRE_CLICK_EFETIVAR]', JSON.stringify(preClickDiag));
 
-    await page.click('#btnSalvarNovoPedido');
-    trace.push({ step: 'efetivar_clicked', t: Date.now() - t0 });
+    // === PR3: wait composto pós-submit ===
+    // Arma os 4 sinais ANTES do click — qualquer um que cumpra ganha. Ignora
+    // rejeições individuais via Promise.any. Substitui o waitForFunction de
+    // banner único do PR1/PR2 (sinal frágil que perdia respostas atrasadas).
+    const postSubmitBudget = budgetFor('submit-pedido', 10_000, { reserveSubmit: false, minMs: 2_000 });
+    const signalPromise = waitForPositiveSubmitSignal(page, postSubmitBudget);
 
-    // Snapshot imediato (sem sleep) pra capturar mudança instantânea no DOM
+    await page.click('#btnSalvarNovoPedido');
+    trace.push({ step: 'efetivar_clicked', t: Date.now() - t0, postSubmitBudget, remaining: remainingMs() });
+
+    // Snapshot imediato (sem sleep) pra capturar mudança instantânea no DOM.
     const snapImediato = await page.evaluate(function() {
       const btn = document.querySelector('#btnSalvarNovoPedido');
       return {
@@ -968,100 +975,142 @@ export default async ({ page, context }) => {
     trace.push({ step: 'snapshot_pos_efetivar_imediato', t: Date.now() - t0, snapshot: snapImediato });
     console.log('[DEBUG_POS_EFETIVAR_IMEDIATO]', JSON.stringify(snapImediato));
 
-    // Diagnóstico do estado da página pós-efetivar.
-    // Faz 3 snapshots em janelas de tempo distintas pra capturar evolução: 1s, 4s, 8s pós-click.
-    const snapshotPosEfetivar = async function(label, delayMs) {
-      await sleep(delayMs);
-      const snap = await page.evaluate(function() {
-        // Banner verde de sucesso (caso já tenha aparecido)
-        const corpo = document.body ? document.body.innerText : '';
-        const bannerSucesso = corpo.match(/Pedido\s*(\d+)\s*criado\s*com\s*sucesso/i);
+    // Aguarda o primeiro sinal positivo. Se nenhum cumprir no budget, lança
+    // AggregateError (Promise.any) — capturado e classificado abaixo.
+    let firstSignal;
+    try {
+      firstSignal = await signalPromise;
+    } catch (err) {
+      firstSignal = { kind: 'none', error: (err && err.message) || String(err) };
+    }
+    trace.push({ step: 'first_signal', kind: firstSignal.kind, t: Date.now() - t0, remaining: remainingMs() });
+    console.log('[DEBUG_FIRST_SIGNAL]', JSON.stringify({ kind: firstSignal.kind, error: firstSignal.error || null }));
 
-        // Modais visíveis (Bootstrap modal padrão do portal)
-        const modais = Array.from(document.querySelectorAll('.modal.show, .modal.in, [role="dialog"]'))
-          .filter(function(m) { return m.offsetParent !== null; })
-          .map(function(m) {
-            return {
-              texto: (m.innerText || '').trim().substring(0, 300),
-              classes: (m.className || '').substring(0, 100)
-            };
-          });
+    // Microjanela: 250ms a mais pro recorder receber o body da response caso o
+    // sinal vencedor tenha sido banner/modal/url (que chegam antes do network
+    // em alguns cenários).
+    if (remainingMs() > 800) {
+      await sleep(250);
+    }
 
-        // Mensagens de erro/validação inline (alerts, toasts, validações)
-        const alertas = Array.from(document.querySelectorAll('.alert, .toast, .invalid-feedback, .help-block, .validation-message, .error-message, [role="alert"]'))
-          .filter(function(a) { return a.offsetParent !== null; })
-          .map(function(a) {
-            return {
-              texto: (a.innerText || '').trim().substring(0, 200),
-              classes: (a.className || '').substring(0, 80)
-            };
-          })
-          .filter(function(info) { return info.texto.length > 0; });
+    // Extrai protocolo via cascata de fontes confiáveis:
+    //   1. body da response do POST capturado pelo Promise.any (mais confiável)
+    //   2. DOM do banner (quando o sinal vencedor foi banner)
+    //   3. fallback PR1.5: qualquer response capturada pelo recorder
+    let protocolo = null;
+    let protocoloSource = null;
+    let responseInfo = null;
+    let bodySuccessFalse = false;  // portal devolveu success:false explícito
 
-        // Campos com classe de erro/inválido
-        const camposInvalidos = Array.from(document.querySelectorAll('.is-invalid, .has-error, .field-error, [aria-invalid="true"]'))
-          .filter(function(el) { return el.offsetParent !== null; })
-          .map(function(el) {
-            return {
-              tag: el.tagName,
-              id: el.id || '',
-              name: el.getAttribute('name') || '',
-              classes: (el.className || '').substring(0, 80)
-            };
-          })
-          .slice(0, 10);
+    if (firstSignal.kind === 'network' && firstSignal.response) {
+      const r = await readResponseBodySafe(firstSignal.response);
+      responseInfo = {
+        status: r.status,
+        ok: r.ok,
+        contentType: r.contentType,
+        parsedKind: r.parsed ? 'json' : (r.body ? 'text' : 'empty'),
+      };
+      if (r.parsed && r.parsed.success === false) bodySuccessFalse = true;
+      if (r.parsed && !bodySuccessFalse) {
+        protocolo = tryExtractProtocoloFromObject(r.parsed);
+        if (protocolo) protocoloSource = 'network_json';
+      }
+      if (!protocolo && r.body && !bodySuccessFalse) {
+        protocolo = tryExtractProtocolo(r.body);
+        if (protocolo) protocoloSource = 'network_text';
+      }
+    }
 
-        // Botão "Efetivar Pedido" ainda existe? (se sim, o submit não foi aceito)
-        const btnEfetivarAindaPresente = !!document.querySelector('#btnSalvarNovoPedido');
-
-        return {
-          url: location.href,
-          title: document.title,
-          bannerSucesso: bannerSucesso ? bannerSucesso[0] : null,
-          pedidoNumero: bannerSucesso ? bannerSucesso[1] : null,
-          modais: modais,
-          modaisCount: modais.length,
-          alertas: alertas,
-          alertasCount: alertas.length,
-          camposInvalidos: camposInvalidos,
-          camposInvalidosCount: camposInvalidos.length,
-          btnEfetivarAindaPresente: btnEfetivarAindaPresente
-        };
+    if (!protocolo && firstSignal.kind === 'banner') {
+      protocolo = await page.evaluate(() => {
+        const body = (document.body && document.body.innerText) || '';
+        const m = body.match(/Pedido\\s+(\\d+)\\s+criado/i);
+        return m ? m[1] : null;
       });
-      trace.push({ step: 'snapshot_pos_efetivar_' + label, t: Date.now() - t0, snapshot: snap });
-      console.log('[DEBUG_POS_EFETIVAR_' + label + ']', JSON.stringify(snap));
-    };
-    // Captura só 1 snapshot rápido. O pedido #116 clicou em Efetivar perto de 53s;
-    // os snapshots de 4s/8s consumiam a janela restante do Browserless antes da confirmação.
-    await snapshotPosEfetivar('1s', 1000);
+      if (protocolo) protocoloSource = 'banner_dom';
+    }
 
-    // Aguarda o texto de sucesso aparecer. PR2: usa o que sobrou do budget,
-    // sem reservar mais nada (já estamos no submit). Se o banner não vier a
-    // tempo, o catch externo classifica via evidência do recorder (PR1) —
-    // se o POST saiu, vira indeterminado; se não, erro_retentavel.
-    await page.waitForFunction(
-      () => {
-        const body = document.body.innerText;
-        return /Pedido \\d+ criado com sucesso/.test(body);
-      },
-      { timeout: budgetFor('submit-pedido-banner', 10_000, { reserveSubmit: false, minMs: 2_000 }) }
-    );
-    // Extrai o texto via evaluate puro
-    const successStr = await page.evaluate(() => {
-      const body = document.body.innerText;
-      const match = body.match(/Pedido (\\d+) criado com sucesso/);
-      return match ? match[0] : null;
+    if (!protocolo && !bodySuccessFalse) {
+      // Fallback PR1.5: olha qualquer response no recorder (não só a que o
+      // Promise.any pegou — outros POSTs podem ter trazido o número também).
+      const evidenceForExtract = recorder.getSubmitEvidence();
+      const fromRecorder = extractProtocoloFromEvidence(evidenceForExtract);
+      if (fromRecorder) {
+        protocolo = fromRecorder.protocolo;
+        protocoloSource = 'recorder_fallback';
+      }
+    }
+
+    trace.push({
+      step: 'submit_classified',
+      firstSignalKind: firstSignal.kind,
+      protocolo,
+      protocoloSource,
+      responseInfo,
+      bodySuccessFalse,
+      t: Date.now() - t0
     });
-    const protocoloMatch = successStr ? successStr.match(/Pedido (\\d+) criado com sucesso/) : null;
-    const protocolo = protocoloMatch ? protocoloMatch[1] : null;
-    trace.push({ step: 'success_detected', protocolo, t: Date.now() - t0 });
+    console.log('[DEBUG_SUBMIT_CLASSIFIED]', JSON.stringify({
+      firstSignalKind: firstSignal.kind, protocolo, protocoloSource, responseInfo, bodySuccessFalse
+    }));
 
-    const screenshot = await page.screenshot({ type: 'jpeg', quality: 70, fullPage: false, encoding: 'base64' });
+    const screenshot = await page.screenshot({ type: 'jpeg', quality: 70, fullPage: false, encoding: 'base64' }).catch(() => null);
+
+    // Decisão final (alinhada com a cascata de classifySubmitResult do doc):
+    //  - Portal devolveu success:false explícito → falha; buildEnvelope vê
+    //    requestSent e classifica como indeterminado (operador concilia).
+    //  - Sinal positivo (network/banner/modal) OU protocolo extraído de
+    //    qualquer fonte → success:true; buildEnvelope mapeia para
+    //    sucesso_portal (com protocolo) ou aceito_portal_sem_protocolo.
+    //  - firstSignal === 'url' (só URL change, sem nada mais) → success:false
+    //    com erroTipo AMBIGUO_URL_ONLY → indeterminado.
+    //  - firstSignal === 'none' → success:false com erroTipo NO_POSITIVE_SIGNAL
+    //    → buildEnvelope decide via requestSent (POST capturado → indeterminado;
+    //    sem POST → erro_retentavel).
+    if (bodySuccessFalse) {
+      return {
+        data: {
+          success: false,
+          erroTipo: 'PORTAL_RESPONSE_FAILURE',
+          erro: 'Portal devolveu success:false na resposta do POST de efetivação',
+          firstSignal: { kind: firstSignal.kind },
+          responseInfo,
+          durationMs: Date.now() - t0,
+          trace,
+        },
+        type: 'application/json',
+        screenshot,
+      };
+    }
+
+    const positiveKinds = ['network', 'banner', 'modal'];
+    if (positiveKinds.indexOf(firstSignal.kind) !== -1 || protocolo) {
+      trace.push({ step: 'success_detected', protocolo, source: protocoloSource, t: Date.now() - t0 });
+      return {
+        data: {
+          success: true,
+          protocolo,
+          protocoloSource,
+          firstSignal: { kind: firstSignal.kind },
+          responseInfo,
+          successText: protocolo ? ('Pedido ' + protocolo + ' criado com sucesso') : null,
+          durationMs: Date.now() - t0,
+          trace,
+        },
+        type: 'application/json',
+        screenshot,
+      };
+    }
+
+    // firstSignal === 'url' ou 'none', sem protocolo.
     return {
       data: {
-        success: true,
-        protocolo,
-        successText: successStr,
+        success: false,
+        erroTipo: firstSignal.kind === 'url' ? 'AMBIGUO_URL_ONLY' : 'NO_POSITIVE_SIGNAL',
+        erro: firstSignal.kind === 'url'
+          ? 'Apenas mudança de URL detectada após submit — sem protocolo, requer conciliação'
+          : 'Nenhum sinal positivo de submit em ' + postSubmitBudget + 'ms (banner/modal/network/url todos timed out)',
+        firstSignal: { kind: firstSignal.kind, error: firstSignal.error || null },
         durationMs: Date.now() - t0,
         trace,
       },

--- a/supabase/migrations/20260515040000_f90d3873-e5fc-44d1-8d42-45bbfeec56ab.sql
+++ b/supabase/migrations/20260515040000_f90d3873-e5fc-44d1-8d42-45bbfeec56ab.sql
@@ -1,0 +1,11 @@
+-- PR4 — Repassar a data de entrega do portal Sayerlack para o pedido de compra Omie
+-- Adiciona coluna para guardar a data_entrega devolvida pelo portal Sayerlack
+-- (campo "data_entrega" no JSON top-level do POST /order-creation/form/add).
+-- A função disparar-pedidos-aprovados consulta essa coluna e usa
+-- (portal_data_entrega + 2 dias corridos) como dDtPrevisao no Omie para
+-- pedidos OBEN/Sayerlack que já têm protocolo confirmado.
+ALTER TABLE public.pedido_compra_sugerido
+  ADD COLUMN IF NOT EXISTS portal_data_entrega date;
+
+COMMENT ON COLUMN public.pedido_compra_sugerido.portal_data_entrega IS
+  'Data de entrega confirmada pelo portal Sayerlack no momento do submit (campo "data_entrega" do response do POST /order-creation/form/add). Usada por disparar-pedidos-aprovados para calcular o dDtPrevisao do pedido de compra no Omie (= portal_data_entrega + 2 dias corridos).';


### PR DESCRIPTION
> ⚠️ **Dependência**: este PR está em cima do PR3 ([#10](https://github.com/LucasSardenbergL/afiacao/pull/10)). Os commits do PR3 aparecem no diff abaixo até o PR3 ser mergeado — depois o GitHub remove eles e o diff fica só com os 4 commits do PR4.

## Objetivo

Quando o pedido de compra é criado no Omie para Sayerlack/OBEN, usar a **data de entrega confirmada pelo portal** (campo `data_entrega` do JSON do POST `/order-creation/form/add`) **+ 2 dias corridos** como `dDtPrevisao` do Omie. Pedidos antigos / outros fornecedores / cenários sem captura caem no fallback de `diasUteisFromHoje(lt_logistica_dias)`.

## O que muda

### Commit A — migration

Nova coluna `portal_data_entrega DATE` em `pedido_compra_sugerido` (nullable, sem default). Pedidos antigos seguem nulos; o disparar cai no fallback quando ela for nula.

### Commit B — extração no submit

No bloco do PR3 que lê `r.parsed` (body JSON da response do Promise.any), captura também o campo top-level `data_entrega` (formato ISO `YYYY-MM-DD`). Validação estrita por regex pra não persistir lixo no banco. Passa via `envelope.data.portal_data_entrega`.

### Commit C — gravação

`buildEnvelope` propaga `data.portal_data_entrega` no envelope. `aplicarTransicao` inclui no `UPDATE` quando o valor veio válido. **NÃO sobrescreve para null** em re-tentativas que falham em capturar — preserva o valor de um envio anterior bem-sucedido.

### Commit D — uso no Omie

`disparar-pedidos-aprovados`:
```ts
const dDtPrevisao = pedido.portal_data_entrega
  ? formatBR(addDays(pedido.portal_data_entrega, 2))   // PR4
  : diasUteisFromHoje(ltDias);                          // legado
```

Aritmética em UTC pra evitar surpresa de timezone (a coluna é DATE puro). Output mantém formato `DD/MM/YYYY` que o Omie espera.

## Decisão de design

**+2 dias = corridos, não úteis.** Interpretei "dois dias a mais" como o caminho mais simples. Se você queria dias úteis, troca pra `diasUteisFromHoje` com um offset (uma linha mudada). Me avisa.

## Test plan

- [ ] Migration aplicada
- [ ] Pedido novo: `portal_data_entrega` é gravado no banco junto com `portal_protocolo`
- [ ] Omie recebe `dDtPrevisao = portal_data_entrega + 2 dias` (ex.: portal `2026-05-22` → Omie `24/05/2026`)
- [ ] Pedido sem `portal_data_entrega` (legado / não-Sayerlack / fallback PR1.5) ainda usa `diasUteisFromHoje(ltDias)` — comportamento intacto
- [ ] `deno check` clean nas duas edge functions

## Query útil pós-deploy

```sql
SELECT id, portal_data_entrega, portal_protocolo,
       (portal_data_entrega + INTERVAL '2 days')::date AS prev_omie
FROM pedido_compra_sugerido
WHERE empresa = 'OBEN'
  AND fornecedor_nome ILIKE '%SAYERLACK%'
  AND portal_data_entrega IS NOT NULL
ORDER BY id DESC
LIMIT 20;
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)