### PR TITLE
PR5: split de pedidos Sayerlack > 4 itens em filhos menores

### DIFF
--- a/src/pages/AdminReposicaoPedidos.tsx
+++ b/src/pages/AdminReposicaoPedidos.tsx
@@ -93,6 +93,12 @@ interface PedidoSugerido {
   cancelado_por?: string | null;
   justificativa_cancelamento?: string | null;
   omie_registrado_em?: string | null;
+  // PR5: split de pedidos grandes Sayerlack. Pai tem split_total preenchido
+  // e status='split_em_filhos'. Filhos têm split_parent_id+split_lote+split_total
+  // e status normal (aprovado_aguardando_disparo / disparado / etc).
+  split_parent_id?: number | null;
+  split_lote?: number | null;
+  split_total?: number | null;
 }
 
 interface CondicaoPagamento {
@@ -135,6 +141,8 @@ const statusMeta: Record<string, { label: string; variant: 'default' | 'secondar
   cancelado: { label: 'Cancelado', variant: 'outline' },
   cancelado_humano: { label: 'Cancelado (vazio)', variant: 'outline' },
   expirado_sem_aprovacao: { label: 'Expirado sem aprovação', variant: 'secondary', className: 'bg-muted text-muted-foreground border-border' },
+  // PR5: pedido pai de um split — não tem mais itens próprios, foi dividido em filhos.
+  split_em_filhos: { label: 'Dividido', variant: 'secondary', className: 'bg-purple-100 text-purple-800 border-purple-300' },
 };
 
 function formatBRL(v: number | null | undefined) {
@@ -157,6 +165,32 @@ function StatusBadge({ status }: { status: Status }) {
       {meta.label}
     </Badge>
   );
+}
+
+// PR5: indica visualmente o split. Renderiza algo só quando o pedido
+// participa de um split (pai ou filho); senão é null e não polui a UI.
+function SplitInfo({ pedido }: { pedido: PedidoSugerido }) {
+  // Pai (status_em_filhos): mostra "em N partes"
+  if (pedido.status === 'split_em_filhos' && pedido.split_total) {
+    return (
+      <Badge variant="outline" className="bg-purple-50 text-purple-700 border-purple-200 ml-1">
+        em {pedido.split_total} partes
+      </Badge>
+    );
+  }
+  // Filho (split_parent_id preenchido): mostra "Lote X/N"
+  if (pedido.split_parent_id && pedido.split_lote && pedido.split_total) {
+    return (
+      <Badge
+        variant="outline"
+        className="bg-purple-50 text-purple-700 border-purple-200 ml-1"
+        title={`Filho do pedido #${pedido.split_parent_id}`}
+      >
+        Lote {pedido.split_lote}/{pedido.split_total}
+      </Badge>
+    );
+  }
+  return null;
 }
 
 /* ─── Portal B2B Badge + Drawer ─── */
@@ -807,9 +841,10 @@ function DetalhesModal({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-7xl xl:max-w-screen-2xl w-[95vw] max-h-[90vh] overflow-y-auto">
         <DialogHeader>
-          <DialogTitle className="flex items-center gap-3">
+          <DialogTitle className="flex items-center gap-3 flex-wrap">
             Pedido #{pedido.id} — {pedido.fornecedor_nome}
             <StatusBadge status={pedido.status} />
+            <SplitInfo pedido={pedido} />
           </DialogTitle>
         </DialogHeader>
 
@@ -1174,7 +1209,12 @@ function PedidoRow({
 
   return (
     <TableRow className={p.status === 'bloqueado_guardrail' ? 'bg-destructive/5' : ''}>
-      <TableCell><StatusBadge status={p.status} /></TableCell>
+      <TableCell>
+        <div className="flex flex-wrap items-center gap-1">
+          <StatusBadge status={p.status} />
+          <SplitInfo pedido={p} />
+        </div>
+      </TableCell>
       <TableCell>
         <div className="font-medium">{p.fornecedor_nome}</div>
         <div className="text-xs text-muted-foreground">{p.grupo_codigo ?? '—'}</div>

--- a/supabase/functions/disparar-pedidos-aprovados/index.ts
+++ b/supabase/functions/disparar-pedidos-aprovados/index.ts
@@ -36,9 +36,21 @@ interface PedidoRow {
   nome_contato?: string | null;
   // PR4: data de entrega confirmada pelo portal Sayerlack (ISO YYYY-MM-DD).
   // Quando presente em pedido Sayerlack/OBEN, vira base do dDtPrevisao do
-  // Omie (+ 2 dias corridos). Quando ausente, cai no fallback de lead time.
+  // Omie (+ 2 dias úteis). Quando ausente, cai no fallback de lead time.
   portal_data_entrega?: string | null;
+  // PR5: split de pedidos grandes em filhos com <= 4 itens cada.
+  // Preenchidos só nos filhos (e split_total também no pai). Quando um filho
+  // chega no fluxo, é tratado como pedido independente — segue caminho normal.
+  split_parent_id?: number | null;
+  split_lote?: number | null;
+  split_total?: number | null;
 }
+
+// PR5: tamanho máximo de cada chunk no split. Pelo trace real de 15/05/2026:
+// login+nav (~12s) + N×7.5s/item + submit (~10s) + margem (~2s) <= 60s do
+// Browserless → N máximo viável = 4 itens. Constante única pra ficar fácil
+// recalibrar quando o p95 por item mudar.
+const SPLIT_CHUNK_SIZE = 4;
 
 interface ItemRow {
   sku_codigo_omie: string;
@@ -202,6 +214,103 @@ function isSayerlackOben(pedido: PedidoRow): boolean {
     (pedido.empresa ?? "").toUpperCase() === "OBEN" &&
     /sayerlack/i.test(pedido.fornecedor_nome ?? "")
   );
+}
+
+/**
+ * PR5: divide pedidos Sayerlack/OBEN com mais de SPLIT_CHUNK_SIZE itens em
+ * filhos menores. Cada filho cabe na janela de 60s do Browserless.
+ *
+ * Só atua em modo "producao" — dry_run não toca o banco. Só atua em pedidos
+ * Sayerlack/OBEN, e nunca em pedidos que já são filhos de um split anterior.
+ *
+ * Retorna a lista expandida: pedidos não-Sayerlack ou pequenos passam direto;
+ * pedidos grandes são substituídos pelos seus filhos. Se a RPC falhar, deixa
+ * o pedido original na lista (vai bater o teto do Browserless e ser tratado
+ * pelo PR2/PR3 — degradação suave).
+ */
+async function dividirPedidosGrandesSayerlack(
+  db: any,
+  aprovados: PedidoRow[],
+  modo: "dry_run" | "producao",
+): Promise<PedidoRow[]> {
+  if (modo !== "producao") return aprovados;
+
+  const expandido: PedidoRow[] = [];
+  for (const pedido of aprovados) {
+    if (pedido.split_parent_id) {
+      // Já é filho — não redivide.
+      expandido.push(pedido);
+      continue;
+    }
+    if (!isSayerlackOben(pedido)) {
+      expandido.push(pedido);
+      continue;
+    }
+
+    const { count: itensCount, error: countErr } = await db
+      .from("pedido_compra_item")
+      .select("id", { count: "exact", head: true })
+      .eq("pedido_id", pedido.id);
+
+    if (countErr) {
+      console.error(`[disparar-pedidos] Falha ao contar itens do pedido ${pedido.id}: ${countErr.message}`);
+      expandido.push(pedido);
+      continue;
+    }
+    if (!itensCount || itensCount <= SPLIT_CHUNK_SIZE) {
+      expandido.push(pedido);
+      continue;
+    }
+
+    console.log(`[disparar-pedidos] Pedido ${pedido.id} tem ${itensCount} itens — dividindo em chunks de ${SPLIT_CHUNK_SIZE}`);
+
+    const { data: filhos, error: splitErr } = await db.rpc("pedido_compra_split", {
+      p_pedido_id: pedido.id,
+      p_chunk_size: SPLIT_CHUNK_SIZE,
+    });
+
+    if (splitErr) {
+      console.error(`[disparar-pedidos] Falha no RPC pedido_compra_split para ${pedido.id}: ${splitErr.message}`);
+      // RPC é atômica: se falhou, o pai está intocado. Cai no fallback.
+      expandido.push(pedido);
+      continue;
+    }
+
+    const filhoIds = ((filhos ?? []) as Array<{ filho_id: number }>).map((f) => Number(f.filho_id));
+    if (filhoIds.length === 0) {
+      console.warn(`[disparar-pedidos] RPC retornou 0 filhos para ${pedido.id} (count=${itensCount}) — processando original`);
+      expandido.push(pedido);
+      continue;
+    }
+
+    const { data: filhoRows, error: fetchErr } = await db
+      .from("pedido_compra_sugerido")
+      .select("id, empresa, fornecedor_nome, grupo_codigo, data_ciclo, valor_total, num_skus, status, condicao_pagamento_codigo, condicao_pagamento_descricao, num_parcelas, portal_data_entrega, split_parent_id, split_lote, split_total")
+      .in("id", filhoIds)
+      .order("split_lote", { ascending: true });
+
+    if (fetchErr || !filhoRows) {
+      console.error(`[disparar-pedidos] Falha ao carregar filhos do split do pedido ${pedido.id}: ${fetchErr?.message ?? "sem dados"}`);
+      // Filhos existem no banco mas não conseguimos carregar agora — vão ser
+      // pegos no próximo run normal do cron (ficaram aprovado_aguardando_disparo).
+      continue;
+    }
+
+    // Replica enrichment de fornecedor que o caller faz nos aprovados originais.
+    for (const fr of filhoRows as PedidoRow[]) {
+      const { data: fh } = await db
+        .from("fornecedor_habilitado_reposicao")
+        .select("canal_pedido, email_pedido, whatsapp_pedido, observacoes_pedido, nome_contato")
+        .eq("empresa", fr.empresa)
+        .eq("fornecedor_nome", fr.fornecedor_nome)
+        .maybeSingle();
+      if (fh) Object.assign(fr, fh);
+    }
+
+    console.log(`[disparar-pedidos] Pedido ${pedido.id} → ${filhoIds.length} filhos: [${filhoIds.join(", ")}]`);
+    expandido.push(...(filhoRows as PedidoRow[]));
+  }
+  return expandido;
 }
 
 /**
@@ -780,7 +889,7 @@ Deno.serve(async (req: Request) => {
     // 2. Pedidos aprovados (com dados do fornecedor)
     let aprovadosQuery = db
       .from("pedido_compra_sugerido")
-      .select("id, empresa, fornecedor_nome, grupo_codigo, data_ciclo, valor_total, num_skus, status, condicao_pagamento_codigo, condicao_pagamento_descricao, num_parcelas, portal_data_entrega")
+      .select("id, empresa, fornecedor_nome, grupo_codigo, data_ciclo, valor_total, num_skus, status, condicao_pagamento_codigo, condicao_pagamento_descricao, num_parcelas, portal_data_entrega, split_parent_id, split_lote, split_total")
       .eq("empresa", empresa);
 
     aprovadosQuery = pedidoId
@@ -789,7 +898,7 @@ Deno.serve(async (req: Request) => {
 
     const { data: aprovadosRaw, error: aprErr } = await aprovadosQuery;
     if (aprErr) throw new Error(`Aprovados: ${aprErr.message}`);
-    const aprovados = (aprovadosRaw ?? []) as PedidoRow[];
+    let aprovados = (aprovadosRaw ?? []) as PedidoRow[];
     if (pedidoId && aprovados[0]?.data_ciclo) dataCiclo = aprovados[0].data_ciclo;
 
     // Enrich com dados do fornecedor
@@ -802,6 +911,11 @@ Deno.serve(async (req: Request) => {
         .maybeSingle();
       if (fh) Object.assign(p, fh);
     }
+
+    // PR5: divide pedidos Sayerlack/OBEN com >4 itens em filhos menores que
+    // caibam na janela de 60s do Browserless. Cada filho vira um pedido
+    // independente no banco e segue o caminho normal (portal → Omie).
+    aprovados = await dividirPedidosGrandesSayerlack(db, aprovados, modo);
 
     // 3. Expirar não aprovados
     let expirados = 0;

--- a/supabase/migrations/20260515050000_3ad7ffe3-a6f9-420f-8f1d-557467b555d2.sql
+++ b/supabase/migrations/20260515050000_3ad7ffe3-a6f9-420f-8f1d-557467b555d2.sql
@@ -1,0 +1,155 @@
+-- PR5 — Split de pedidos Sayerlack > 4 itens em filhos menores
+-- O Browserless mata a função em 60s. Pelo trace real (15/05/2026), cada
+-- item leva ~7.5s e setup/submit consome ~22s, então um pedido com mais
+-- de 4 itens corre risco de não caber. Em vez de torcer, divide:
+--   1 pedido aprovado (pai) → N filhos com até 4 itens cada.
+-- Cada filho passa pelo fluxo normal (portal → protocolo → Omie),
+-- gerando N pedidos Sayerlack e N pedidos de compra no Omie distintos.
+
+-- 1. Colunas de relacionamento e auditoria
+ALTER TABLE public.pedido_compra_sugerido
+  ADD COLUMN IF NOT EXISTS split_parent_id bigint REFERENCES public.pedido_compra_sugerido(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS split_lote integer,
+  ADD COLUMN IF NOT EXISTS split_total integer;
+
+CREATE INDEX IF NOT EXISTS idx_pedido_compra_split_parent
+  ON public.pedido_compra_sugerido (split_parent_id)
+  WHERE split_parent_id IS NOT NULL;
+
+COMMENT ON COLUMN public.pedido_compra_sugerido.split_parent_id IS
+  'Se preenchido, este pedido é um filho gerado por pedido_compra_split() a partir do pedido referenciado (que ficou com status=split_em_filhos).';
+COMMENT ON COLUMN public.pedido_compra_sugerido.split_lote IS
+  'Lote 1-based deste filho dentro do split (1=primeiro chunk, 2=segundo, ...). Null em pedidos não divididos.';
+COMMENT ON COLUMN public.pedido_compra_sugerido.split_total IS
+  'Quantidade total de filhos gerados no split. No pai: total de filhos criados. Nos filhos: igual ao do pai. Null em pedidos não divididos.';
+
+-- 2. RPC pedido_compra_split — atômica.
+--    Carrega pedido com FOR UPDATE, valida estado, conta itens, cria N
+--    filhos clonando metadados, MOVE chunks de itens para cada filho,
+--    recalcula valor_total/num_skus dos filhos e marca o pai como
+--    'split_em_filhos'. Tudo em uma única transação Postgres.
+CREATE OR REPLACE FUNCTION public.pedido_compra_split(
+  p_pedido_id bigint,
+  p_chunk_size integer DEFAULT 4
+)
+RETURNS TABLE(filho_id bigint, lote integer, total integer)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO public, pg_temp
+AS $function$
+DECLARE
+  v_status text;
+  v_split_parent bigint;
+  v_itens_total integer;
+  v_total_chunks integer;
+  v_chunk_idx integer;
+  v_filho_id bigint;
+BEGIN
+  -- ACL: service_role (sem auth.uid()) passa direto; user JWT exige staff.
+  IF auth.uid() IS NOT NULL THEN
+    IF NOT (public.has_role(auth.uid(), 'employee'::app_role) OR public.has_role(auth.uid(), 'master'::app_role)) THEN
+      RAISE EXCEPTION 'Acesso negado: requer perfil staff' USING ERRCODE = '42501';
+    END IF;
+  END IF;
+
+  IF p_chunk_size < 1 THEN
+    RAISE EXCEPTION 'chunk_size deve ser >= 1';
+  END IF;
+
+  -- Lock no pai pra evitar split concorrente.
+  SELECT status, split_parent_id INTO v_status, v_split_parent
+  FROM public.pedido_compra_sugerido
+  WHERE id = p_pedido_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Pedido % não encontrado', p_pedido_id;
+  END IF;
+
+  IF v_status <> 'aprovado_aguardando_disparo' THEN
+    RAISE EXCEPTION 'Pedido % com status=% não pode ser dividido (esperado: aprovado_aguardando_disparo)', p_pedido_id, v_status;
+  END IF;
+
+  IF v_split_parent IS NOT NULL THEN
+    RAISE EXCEPTION 'Pedido % já é filho de um split (parent=%)', p_pedido_id, v_split_parent;
+  END IF;
+
+  -- Conta itens. Se cabe num chunk, não divide.
+  SELECT count(*) INTO v_itens_total FROM public.pedido_compra_item WHERE pedido_id = p_pedido_id;
+
+  IF v_itens_total <= p_chunk_size THEN
+    RETURN;
+  END IF;
+
+  v_total_chunks := ceil(v_itens_total::numeric / p_chunk_size)::integer;
+
+  -- Cria N filhos clonando metadados relevantes do pai (sem itens).
+  FOR v_chunk_idx IN 1..v_total_chunks LOOP
+    INSERT INTO public.pedido_compra_sugerido (
+      empresa, fornecedor_nome, grupo_codigo, data_ciclo,
+      horario_geracao, horario_corte_planejado,
+      valor_total, num_skus,
+      status,
+      condicao_pagamento_codigo, condicao_pagamento_descricao,
+      num_parcelas, dias_parcelas, condicao_origem,
+      aprovado_em, aprovado_por,
+      criado_em, atualizado_em,
+      split_parent_id, split_lote, split_total
+    )
+    SELECT
+      p.empresa, p.fornecedor_nome, p.grupo_codigo, p.data_ciclo,
+      p.horario_geracao, p.horario_corte_planejado,
+      0, 0,
+      'aprovado_aguardando_disparo',
+      p.condicao_pagamento_codigo, p.condicao_pagamento_descricao,
+      p.num_parcelas, p.dias_parcelas, p.condicao_origem,
+      p.aprovado_em, p.aprovado_por,
+      now(), now(),
+      p_pedido_id, v_chunk_idx, v_total_chunks
+    FROM public.pedido_compra_sugerido p
+    WHERE p.id = p_pedido_id
+    RETURNING id INTO v_filho_id;
+
+    -- Move chunk de itens pro filho atual (ORDER BY id, OFFSET, LIMIT).
+    WITH lote_ids AS (
+      SELECT id FROM public.pedido_compra_item
+      WHERE pedido_id = p_pedido_id
+      ORDER BY id
+      OFFSET (v_chunk_idx - 1) * p_chunk_size
+      LIMIT p_chunk_size
+    )
+    UPDATE public.pedido_compra_item pci
+    SET pedido_id = v_filho_id
+    FROM lote_ids
+    WHERE pci.id = lote_ids.id;
+
+    -- Recalcula totais do filho a partir dos itens já reapontados.
+    UPDATE public.pedido_compra_sugerido f
+    SET
+      num_skus = (SELECT count(*) FROM public.pedido_compra_item WHERE pedido_id = f.id),
+      valor_total = COALESCE(
+        (SELECT sum(COALESCE(valor_linha, qtde_final * preco_unitario, 0))
+         FROM public.pedido_compra_item WHERE pedido_id = f.id),
+        0
+      )
+    WHERE f.id = v_filho_id;
+
+    filho_id := v_filho_id;
+    lote := v_chunk_idx;
+    total := v_total_chunks;
+    RETURN NEXT;
+  END LOOP;
+
+  -- Marca o pai como dividido. NÃO entra em fila de envio nem de Omie.
+  UPDATE public.pedido_compra_sugerido SET
+    status = 'split_em_filhos',
+    status_envio_portal = 'nao_aplicavel',
+    split_total = v_total_chunks,
+    atualizado_em = now()
+  WHERE id = p_pedido_id;
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public.pedido_compra_split(bigint, integer) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.pedido_compra_split(bigint, integer) FROM anon;
+GRANT EXECUTE ON FUNCTION public.pedido_compra_split(bigint, integer) TO authenticated, service_role;


### PR DESCRIPTION
## Objetivo

Pedidos Sayerlack/OBEN com mais de 4 itens não cabem na janela de 60s do Browserless. PR2/PR3 fazem o script morrer limpo; este PR faz com que **a maioria desses pedidos nem chegue a precisar** — divide o pedido grande em N filhos com até 4 itens cada, automaticamente, antes do envio.

Pelo trace real (15/05/2026):
- Login + navegação: ~12s
- Cada item: ~7.5s
- Submit + sinal pós-submit: ~10s
- Margem: ~2s
- **Disponível para itens**: ~38s
- **Máximo viável**: 4 itens

Conta simples: se > 4 itens, divide.

## O que muda

### Schema + RPC (commit A)

3 colunas novas em `pedido_compra_sugerido`:
- `split_parent_id bigint` — FK para o pai (só preenchido nos filhos)
- `split_lote integer` — 1-based dentro do split (só nos filhos)
- `split_total integer` — total de filhos gerados (pai e filhos)

Status novo `split_em_filhos` para o pai: não entra em fila de envio nem de Omie.

RPC `pedido_compra_split(p_pedido_id bigint, p_chunk_size int default 4)`:
1. `FOR UPDATE` no pai pra evitar split concorrente
2. Valida estado (`aprovado_aguardando_disparo`, não é filho já)
3. Conta itens; se ≤ chunk_size, retorna vazio (não divide)
4. Cria N filhos clonando metadados (sem itens) via `INSERT…SELECT`
5. Move chunks de itens via `UPDATE…WHERE id IN (… ORDER BY id OFFSET LIMIT)`
6. Recalcula `num_skus` e `valor_total` de cada filho
7. Marca o pai como `status='split_em_filhos'`

Tudo numa transação atômica — falha em qualquer etapa = rollback total.

### Backend (commit B)

`disparar-pedidos-aprovados` chama `dividirPedidosGrandesSayerlack` entre o enrichment de fornecedor e o loop principal. Pra cada aprovado:
- Não-Sayerlack ou ≤ 4 itens: passa direto.
- Sayerlack/OBEN + producao + > 4 itens: chama a RPC, substitui o pedido pelos filhos na lista.
- Filhos seguem o caminho normal: portal → protocolo → Omie. Cada um vira 1 pedido Sayerlack e 1 pedido de compra Omie.

Degradação suave: se a RPC falhar (raro, transação atômica), processa o pedido original — vai bater 60s e ser tratado pelo PR2/PR3.

### UI (commit C)

`AdminReposicaoPedidos`:
- `statusMeta` entende `split_em_filhos` (badge roxo "Dividido")
- Novo componente `SplitInfo` renderiza:
  - No pai: badge "em N partes"
  - No filho: badge "Lote X/N" com tooltip "Filho do pedido #PARENT"
- Inserido ao lado do `StatusBadge` no dialog e na linha da tabela
- Zero impacto em pedidos não divididos (`SplitInfo` retorna null)

## Test plan

- [ ] Migration roda sem erro; coluna `split_parent_id` aparece no `information_schema`
- [ ] Pedido com 5 itens: divide em 2 (4+1)
- [ ] Pedido com 10 itens: divide em 3 (4+4+2)
- [ ] Pedido com 4 itens: NÃO divide (passa direto)
- [ ] Pedido não-Sayerlack com 20 itens: NÃO divide
- [ ] Dry-run com pedido grande: NÃO divide (não toca banco)
- [ ] Após split, cada filho tem seu próprio `portal_protocolo` e `omie_pedido_compra_numero`
- [ ] Pai fica visível na lista com badge "Dividido em N partes"
- [ ] Filhos aparecem com "Lote X/N"
- [ ] `deno check` clean nas edge functions; `bunx tsc --noEmit` clean

## Query útil pós-deploy

```sql
-- Splits feitos nos últimos 7 dias:
SELECT
  pai.id AS pai_id,
  pai.split_total,
  pai.status AS pai_status,
  count(filho.id) AS filhos_criados,
  count(filho.id) FILTER (WHERE filho.status = 'disparado') AS filhos_disparados,
  count(filho.id) FILTER (WHERE filho.portal_protocolo IS NOT NULL) AS filhos_com_protocolo
FROM pedido_compra_sugerido pai
LEFT JOIN pedido_compra_sugerido filho ON filho.split_parent_id = pai.id
WHERE pai.status = 'split_em_filhos'
  AND pai.criado_em > now() - interval '7 days'
GROUP BY pai.id, pai.split_total, pai.status
ORDER BY pai.id DESC;
```

## Importante sobre o deploy

Ainda estamos diagnosticando por que PR2/PR3/PR4 não foram para o ar (veja conversa anterior). Esse PR5 só vai funcionar quando as Edge Functions estiverem deployando de fato. A migration roda independente — se rodar antes do deploy das functions, o schema já fica pronto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)