### PR TITLE
PR6: postSubmitBudget de 10s → 14s (calibrado pelo trace real)

### DIFF
--- a/supabase/functions/enviar-pedido-portal-sayerlack/index.ts
+++ b/supabase/functions/enviar-pedido-portal-sayerlack/index.ts
@@ -957,7 +957,12 @@ export default async ({ page, context }) => {
     // Arma os 4 sinais ANTES do click — qualquer um que cumpra ganha. Ignora
     // rejeições individuais via Promise.any. Substitui o waitForFunction de
     // banner único do PR1/PR2 (sinal frágil que perdia respostas atrasadas).
-    const postSubmitBudget = budgetFor('submit-pedido', 10_000, { reserveSubmit: false, minMs: 2_000 });
+    // PR6: 14s em vez de 10s. Calibrado pelo trace real (15/05/2026 trace
+    // do pedido #179): POST /order-creation/form/add às vezes leva >10s
+    // mesmo retornando OK. Com remaining médio de ~15s no click e
+    // RETURN_GUARD=2s, dá até 13s — usar 14s deixa a função reduzir pelo
+    // remaining real se necessário (min(idealMs, restante - reserva)).
+    const postSubmitBudget = budgetFor('submit-pedido', 14_000, { reserveSubmit: false, minMs: 2_000 });
     const signalPromise = waitForPositiveSubmitSignal(page, postSubmitBudget);
 
     await page.click('#btnSalvarNovoPedido');


### PR DESCRIPTION
## Problema

Trace real do pedido #179 (15/05/2026, run das 13:25):

- Login + nav até cliente: 12.8s
- 4 itens × ~7.4s = 29.6s
- pre-efetivar + diag: 95ms
- **Remaining no click do Efetivar: 15.5s**
- postSubmitBudget calculado: **10s** (cap do idealMs)
- POST `/order-creation/form/add` provavelmente levou >10s (vs 9.48s observado por DevTools antes)
- Resultado: `first_signal.kind = 'none'` → indeterminado_requer_conciliacao

Snapshot 6ms após o click prova que o portal recebeu:
```json
{
  "btnDisabled": true,
  "bodyTextSnippet": "...Voltar Salvar Proposta Efetivando Estabelecimento..."
}
```

Botão virou disabled, texto mudou pra "Efetivando" — submit em voo, só não conseguimos esperar.

## Correção

Uma linha: `budgetFor('submit-pedido', 10_000, ...)` → `budgetFor('submit-pedido', 14_000, ...)`.

A própria `budgetFor` já limita pelo remaining real:
```ts
const allowed = Math.min(idealMs, remainingMs() - reserved);
```

Então subir o `idealMs` pra 14s só amplia o teto quando há folga. Com remaining=15.5s e RETURN_GUARD=2s, o cálculo dá `min(14000, 13500) = 13500ms` — usa tudo que pode. Em pedidos mais lentos, cai automaticamente pra o mínimo viável.

Risk: nenhum — comportamento idêntico nos casos em que sobravam menos de 10s; melhor capture em casos em que sobra mais.

## Test plan

- [ ] Pedido novo de 4 SKUs Sayerlack agora completa em `sucesso_portal` (ou pelo menos `aceito_portal_sem_protocolo` se o protocolo não vier no body em tempo)
- [ ] `evidence->>'firstSignalKind' = 'network'` na auditoria
- [ ] Pedidos antigos travados em `indeterminado_requer_conciliacao` (179, etc) podem ser resolvidos via **botão "Conciliar manualmente"** (cola o número do portal Sayerlack que você confirmou ter recebido)

🤖 Generated with [Claude Code](https://claude.com/claude-code)