### PR TITLE
PR8: serializa disparo de filhos Sayerlack (evita concorrência Browserless)

### DIFF
--- a/supabase/functions/disparar-pedidos-aprovados/index.ts
+++ b/supabase/functions/disparar-pedidos-aprovados/index.ts
@@ -217,6 +217,52 @@ function isSayerlackOben(pedido: PedidoRow): boolean {
 }
 
 /**
+ * PR8: aguarda um pedido sair do estado `enviando_portal` (background task
+ * de enviar-pedido-portal-sayerlack terminou). Usado pra serializar disparos
+ * de filhos Sayerlack/OBEN do mesmo split — evita burst de chamadas
+ * concorrentes no Browserless, que rejeita por concorrência e devolve
+ * "200 sem envelope" → indeterminado_requer_conciliacao indevido.
+ *
+ * Faz polling no banco. Retorna o status final encontrado ou null se
+ * estourou o timeout (caso em que seguimos pro próximo mesmo assim,
+ * pra não travar o loop).
+ *
+ * Estados que consideramos "terminou":
+ *   sucesso_portal, enviado_portal (legado), aceito_portal_sem_protocolo,
+ *   indeterminado_requer_conciliacao, erro_retentavel, erro_nao_retentavel,
+ *   falha_envio_portal (legado).
+ * Estado que ainda está rodando: enviando_portal.
+ */
+async function aguardarPortalTerminar(
+  db: any,
+  pedidoId: number,
+  timeoutMs: number,
+): Promise<string | null> {
+  const POLL_INTERVAL_MS = 3000;
+  const ESTADOS_FINAIS = new Set([
+    "sucesso_portal",
+    "enviado_portal",
+    "aceito_portal_sem_protocolo",
+    "indeterminado_requer_conciliacao",
+    "erro_retentavel",
+    "erro_nao_retentavel",
+    "falha_envio_portal",
+  ]);
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const { data } = await db
+      .from("pedido_compra_sugerido")
+      .select("status_envio_portal")
+      .eq("id", pedidoId)
+      .maybeSingle();
+    const s = (data?.status_envio_portal ?? null) as string | null;
+    if (s && ESTADOS_FINAIS.has(s)) return s;
+    await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+  }
+  return null;
+}
+
+/**
  * PR5: divide pedidos Sayerlack/OBEN com mais de SPLIT_CHUNK_SIZE itens em
  * filhos menores. Cada filho cabe na janela de 60s do Browserless.
  *
@@ -940,6 +986,24 @@ Deno.serve(async (req: Request) => {
     const resultados: ProcessResult[] = [];
     for (const p of aprovados) {
       const r = await processarPedido(db, p, modo, creds);
+
+      // PR8: serializa filhos Sayerlack que foram enfileirados pro portal
+      // (status_final === aguardando_portal_sayerlack). Sem isso, N filhos
+      // de um split disparam N chamadas async em sucessão e o Browserless
+      // rejeita as excedentes por concorrência (200 sem envelope, gerando
+      // indeterminado_requer_conciliacao indevido).
+      //
+      // Espera até 90s pelo background task do enviar-pedido-portal-sayerlack
+      // terminar. Se estourar (raro), seguimos pro próximo mesmo assim — o
+      // pior caso é a próxima execução do cron pegar o resto.
+      if (r.status_final === "aguardando_portal_sayerlack" && isSayerlackOben(p)) {
+        const splitTag = p.split_parent_id ? `Lote ${p.split_lote ?? "?"}/${p.split_total ?? "?"} de #${p.split_parent_id}` : "individual";
+        console.log(`[disparar-pedidos] PR8: aguardando #${p.id} (${splitTag}) sair de enviando_portal antes do próximo...`);
+        const tWait = Date.now();
+        const finalStatus = await aguardarPortalTerminar(db, p.id, 90_000);
+        const waitMs = Date.now() - tWait;
+        console.log(`[disparar-pedidos] PR8: #${p.id} portal terminou em ${waitMs}ms com status_envio_portal=${finalStatus ?? "TIMEOUT"}`);
+      }
 
       // 5. Se produção e Omie OK: notificar fornecedor
       if (


### PR DESCRIPTION
## Problema reproduzido em produção

Pedido #201 dividido em 5 filhos pelo PR5/PR7 (4 itens cada). disparar-pedidos-aprovados loop processou os 5 em rápida sucessão, disparando 5 chamadas `async_mode:true` para `enviar-pedido-portal-sayerlack` em milissegundos. Browserless aceitou 2 concorrentes:

| filho | status_envio_portal | elapsed_ms |
|---|---|---|
| #202 | sucesso_portal ✓ | 55.120s |
| #203 | sucesso_portal ✓ | 54.955s |
| #204 | indeterminado_requer_conciliacao | **1.873s** |
| #205 | indeterminado_requer_conciliacao | **3.063s** |
| #206 | indeterminado_requer_conciliacao | **1.873s** |

Tempos de 1.8-3s nos rejeitados são prova de que **o script não rodou** — Browserless devolveu HTTP 200 com body de "fila cheia"/queueLength, e o classificador caiu no fallback "200 sem envelope" → `indeterminado_requer_conciliacao`.

## Correção

Novo helper `aguardarPortalTerminar(db, pedidoId, timeoutMs)` faz polling a cada 3s no `status_envio_portal` do pedido, retornando quando ele sair de `enviando_portal` (entra em qualquer um dos 7 estados finais).

No main loop do `Deno.serve`, **após cada `processarPedido`** que devolveu `status_final === "aguardando_portal_sayerlack"` num pedido Sayerlack/OBEN, espera até 90s pelo background task terminar antes de iterar pro próximo. Cada filho do split entra no Browserless em série.

```ts
if (r.status_final === "aguardando_portal_sayerlack" && isSayerlackOben(p)) {
  await aguardarPortalTerminar(db, p.id, 90_000);
}
```

## Trade-off conhecido

`disparar-pedidos-aprovados` fica mais longo: para 5 filhos × ~60s cada = 300s no pior caso. Compatível com Supabase Pro+ (timeout estendido até 400s). Se algum dia a janela exceder, o filho que não couber fica em `aprovado_aguardando_disparo` + `pendente_envio_portal` pra próxima execução pegar — segurança via design da máquina de estados do PR1.

## Não toca em

- Não-Sayerlack: passa direto, sem espera.
- Sayerlack/OBEN dry_run: vai pro Omie sem portal, sem espera.
- Sayerlack/OBEN com `already_sent` (re-disparo pós-conciliação): processa Omie direto, sem espera.

## Test plan

- [ ] Pedido grande Sayerlack (10+ SKUs) dividido em 3+ filhos: TODOS os filhos terminam em `sucesso_portal` em vez de 2 ok + N indeterminados
- [ ] Log mostra `PR8: aguardando #X (Lote N/M de #PAI) sair de enviando_portal antes do próximo`
- [ ] Tempo total da execução do disparar ≈ N × 60s para N filhos (esperado)
- [ ] Pedidos não-Sayerlack continuam processando rapidamente (sem espera)
- [ ] `deno check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)