### PR TITLE
PR12: confirma save de cada item via waitForResponse + retry no click

### DIFF
--- a/supabase/functions/enviar-pedido-portal-sayerlack/index.ts
+++ b/supabase/functions/enviar-pedido-portal-sayerlack/index.ts
@@ -866,8 +866,54 @@ export default async ({ page, context }) => {
       trace.push({ step: 'debug_btn_gravar_iter_' + i, t: Date.now() - t0, debugGravarItem: debugGravarItem });
       console.log('[DEBUG_BTN_GRAVAR]', JSON.stringify({ iteration: i, ...debugGravarItem }));
 
+      // PR12: o portal Sayerlack às vezes ignora o click do #btnGravarItem
+      // silenciosamente — o POST /save-tab-preco-session não dispara e a row
+      // fica em modo edit no DOM. O script anterior achava que salvou
+      // (waitForFunction de row count passava porque a row já existe na UI),
+      // continuava pro próximo item, e a próxima iteração travava na validação
+      // (15s timeout em validacao_data_entrega) porque o portal estava em
+      // estado inconsistente.
+      //
+      // Correção: armar waitForResponse('save-tab-preco-session') ANTES do
+      // click. Se o POST não vier em 7s, retentamos o click uma vez.
+      const SAVE_TAB_RE = /save-tab-preco-session/i;
+      const armarSaveWait = (label) => page.waitForResponse(
+        (resp) => {
+          try {
+            return resp.request().method() === 'POST' && SAVE_TAB_RE.test(resp.url());
+          } catch (e) { return false; }
+        },
+        { timeout: budgetFor(label, 7_000, { minMs: 1_000 }) }
+      ).then((r) => ({ ok: true, status: r.status() })).catch(() => ({ ok: false }));
+
+      let saveConfirm = armarSaveWait('item-' + i + '-save-confirm');
       await page.click('#btnGravarItem');
-      // Aguarda a linha aparecer/atualizar no datatable
+      let saveResult = await saveConfirm;
+
+      if (!saveResult.ok) {
+        // Retry: portal ignorou o click. Tenta de novo.
+        console.warn('[DEBUG_ITEM_SAVE_RETRY]', JSON.stringify({ iteration: i, sku: item.sku_portal }));
+        trace.push({ step: 'item_' + i + '_save_retry', t: Date.now() - t0 });
+        saveConfirm = armarSaveWait('item-' + i + '-save-retry');
+        await page.click('#btnGravarItem');
+        saveResult = await saveConfirm;
+
+        if (!saveResult.ok) {
+          // Falhou 2x — POST do save nunca saiu. Aborta o pedido com erro
+          // específico pra ficar claro na auditoria que foi o save do item
+          // que travou (não outra coisa). Sem POST de submit ainda → vira
+          // erro_retentavel via buildEnvelope.
+          const errSave = new Error(
+            'Portal Sayerlack ignorou o click do Gravar Item duas vezes para o item ' +
+            i + ' (SKU ' + item.sku_portal + '). Save POST nunca disparou.'
+          );
+          errSave.code = 'ITEM_SAVE_NAO_CONFIRMADO';
+          throw errSave;
+        }
+      }
+      trace.push({ step: 'item_' + i + '_save_confirmed', t: Date.now() - t0, httpStatus: saveResult.status });
+
+      // Mantém o waitForFunction da row count como segunda checagem (defensivo).
       await page.waitForFunction(
         (esperado) => {
           const rows = document.querySelectorAll('#datatable_itens tbody tr');
@@ -1144,7 +1190,9 @@ export default async ({ page, context }) => {
     };
   } catch (err) {
     const errorScreenshot = await page.screenshot({ type: 'png', encoding: 'base64' }).catch(() => null);
-    const erroTipo = (err && err.code === 'BUDGET_EXHAUSTED') ? 'BUDGET_EXHAUSTED' : 'EXCEPTION';
+    // PR12: propaga qualquer err.code conhecido (BUDGET_EXHAUSTED, ITEM_SAVE_NAO_CONFIRMADO, ...)
+    // pra auditoria. Sem code → EXCEPTION genérico.
+    const erroTipo = (err && err.code) ? err.code : 'EXCEPTION';
     return {
       data: {
         success: false,
@@ -1169,7 +1217,9 @@ export default async ({ page, context }) => {
   } catch (err) {
     // Rede de segurança: runFlow tem try/catch interno, mas qualquer escape
     // ainda devolve envelope estruturado (nunca um throw nu para o Browserless).
-    const erroTipo = (err && err.code === 'BUDGET_EXHAUSTED') ? 'BUDGET_EXHAUSTED' : 'EXCEPTION';
+    // PR12: propaga qualquer err.code conhecido (BUDGET_EXHAUSTED, ITEM_SAVE_NAO_CONFIRMADO, ...)
+    // pra auditoria. Sem code → EXCEPTION genérico.
+    const erroTipo = (err && err.code) ? err.code : 'EXCEPTION';
     raw = {
       data: {
         success: false,


### PR DESCRIPTION
## Problema reproduzido (com screenshot)

Trace de teste novo (5 SKUs, screenshot capturado no momento exato):

| t | step | rede |
|---|---|---|
| 18.5s | item_0_saved | POST /save-tab-preco-session WP04.3900QT ✓ |
| 26.2s | item_1_saved | POST /save-tab-preco-session FC.6902L5 ✓ |
| 33.6s | item_2_saved | POST /save-tab-preco-session DEZ.8014L5 ✓ |
| 40.6s | **item_3_saved** | ❌ **NENHUM POST capturado** |
| 40.6s | item_4_start | — |
| ~55s | EXCEPTION: Waiting failed 15000ms | (waitForFunction validacao timeout) |

Screenshot confirma: row 40 (NLO.9525.00LT) está em **modo edit** — o portal não persistiu o save apesar do script ter clicado em "Gravar Item".

## Causa raiz

Portal Sayerlack tem flakiness no `#btnGravarItem` — o click é registrado mas o jQuery handler não dispara o POST. Pode ser:
- Handler não anexado ainda
- Race com cálculo de preço/desconto
- DOM mutation interceptando o evento

Resultado: row fica no DOM em edit mode, mas backend não tem o item. Script acha que salvou (waitForFunction de row count passa porque a row visualmente existe). Próximo item trava na validação porque o portal está em estado inconsistente.

## Correção

```diff
+ const SAVE_TAB_RE = /save-tab-preco-session/i;
+ const armarSaveWait = (label) => page.waitForResponse(
+   (resp) => resp.request().method() === 'POST' && SAVE_TAB_RE.test(resp.url()),
+   { timeout: budgetFor(label, 7_000, { minMs: 1_000 }) }
+ ).then((r) => ({ ok: true, status: r.status() })).catch(() => ({ ok: false }));
+
+ let saveConfirm = armarSaveWait('item-' + i + '-save-confirm');
  await page.click('#btnGravarItem');
+ let saveResult = await saveConfirm;
+
+ if (!saveResult.ok) {
+   // Retry click — portal ignorou o primeiro
+   saveConfirm = armarSaveWait('item-' + i + '-save-retry');
+   await page.click('#btnGravarItem');
+   saveResult = await saveConfirm;
+   if (!saveResult.ok) {
+     throw { code: 'ITEM_SAVE_NAO_CONFIRMADO', message: '...' };
+   }
+ }
+ trace.push({ step: 'item_' + i + '_save_confirmed', httpStatus: saveResult.status });
```

Mantém o `waitForFunction(row_count)` como segunda checagem defensiva.

## Bonus: catch propaga err.code

```diff
- const erroTipo = (err && err.code === 'BUDGET_EXHAUSTED') ? 'BUDGET_EXHAUSTED' : 'EXCEPTION';
+ const erroTipo = (err && err.code) ? err.code : 'EXCEPTION';
```

Agora ITEM_SAVE_NAO_CONFIRMADO (e qualquer outro futuro) aparece direto no `evidence.erroTipo` da auditoria.

## Comportamento esperado

| Cenário | Resultado |
|---|---|
| Portal responde no 1º click (caminho feliz) | item_X_save_confirmed em ~200ms |
| Portal ignora 1º click, responde no 2º | item_X_save_retry → item_X_save_confirmed |
| Portal ignora 2 clicks | throw ITEM_SAVE_NAO_CONFIRMADO → erro_retentavel (cron retenta) |

## Test plan

- [ ] Pedido de 20 SKUs Sayerlack: TODOS os itens têm item_X_save_confirmed no trace
- [ ] Em algum momento, se a flakiness acontecer, ver item_X_save_retry no trace seguido de item_X_save_confirmed
- [ ] Se acontecer raro: PR12 catches it, pedido vira erro_retentavel, cron retenta com sucesso

🤖 Generated with [Claude Code](https://claude.com/claude-code)