### PR TITLE
PR13: scrollIntoView no botão Efetivar — fix do navbar sticky tapando o click

### DIFF
--- a/supabase/functions/enviar-pedido-portal-sayerlack/index.ts
+++ b/supabase/functions/enviar-pedido-portal-sayerlack/index.ts
@@ -941,6 +941,18 @@ export default async ({ page, context }) => {
     }, { timeout: budgetFor('validacao-pre-efetivar', 15_000), polling: 250 });
     trace.push({ step: 'validacao_data_entrega_ok_pre_efetivar', t: Date.now() - t0, remaining: remainingMs() });
 
+    // PR13: scroll do botão "Efetivar Pedido" pra dentro da viewport ANTES do
+    // click. O navbar sticky do portal Sayerlack cobre o topo da página; quando
+    // há vários itens no formulário, a rolagem deixa o botão atrás do navbar
+    // (y negativo). O Puppeteer clica na coordenada certa mas o navbar
+    // intercepta — click some silenciosamente. Reproduzido em pedido de 6 SKUs
+    // (trace mostrou rect.y=-17, elementoNoCentro=div.navbar-nav).
+    await page.evaluate(() => {
+      const btn = document.querySelector('#btnSalvarNovoPedido');
+      if (btn) btn.scrollIntoView({ block: 'center' });
+    });
+    await sleep(300); // tempo do scroll completar e DOM estabilizar
+
     // Diagnóstico rico pré-click: estado do botão, contexto, hit-test, listeners jQuery
     const preClickDiag = await page.evaluate(function() {
       const btn = document.querySelector('#btnSalvarNovoPedido');


### PR DESCRIPTION
## Descoberta nova

Teste de pedido com 6 SKUs (PR12 working: todos itens com item_X_save_confirmed). Submit clicado às t=58801, postSubmitBudget=60000 (PR11 ativo). Mas:

```json
"snapshot_pos_efetivar_imediato": {
  "btnDisabled": false,                                     ← click NÃO foi efetivo
  "bodyTextSnippet": "...Voltar Salvar Proposta Efetivar Pedido..."  ← texto não mudou pra "Efetivando"
}
```

E zero POST `/order-creation/form/add` na network log. O click foi ignorado.

## Causa raiz: navbar sticky cobrindo o botão

Diag pré-click:
```json
"rect": { "h": 34, "w": 113, "x": 302, "y": -17 },   // y NEGATIVO
"elementoNoCentro": {
  "tag": "DIV",
  "classes": "navbar-nav",                          // navbar, não o botão!
  "mesmoBotaoOuFilho": false
}
```

Com 6+ itens no formulário, a página rolou pra mostrar a linha de "Incluir Item". O botão Efetivar ficou parcialmente acima do viewport (17px), e o navbar sticky do portal cobriu o que sobrou. `document.elementFromPoint(centro_do_botão)` retorna `div.navbar-nav`. Puppeteer manda o click pra (358, 0), mas o navbar intercepta.

Comparação com teste de 5 SKUs (que funcionou):
- rect.y = 147 → botão visível
- elementoNoCentro = btnSalvarNovoPedido ✓

## Fix (5 linhas)

```ts
// Antes da diag pré-click
await page.evaluate(() => {
  const btn = document.querySelector('#btnSalvarNovoPedido');
  if (btn) btn.scrollIntoView({ block: 'center' });
});
await sleep(300);
```

Centraliza o botão no viewport, abaixo do navbar. Puppeteer clica e o evento chega no lugar certo.

## Por que não apareceu antes

Sayerlack portal só fica com botão off-screen quando o formulário tem **muitos itens**. Testes com pedidos pequenos não rolavam a página o suficiente. Pedidos grandes (16+ itens, splits) também tinham, mas eram afetados por outros bugs (concorrência, timeouts) que mascaravam esse.

## Não é regressão

Era um bug latente — apenas se manifestava em pedidos com várias linhas. Agora com PR1-PR12 estabilizados, esse caso passou a ser visível.

## Test plan

- [ ] Pedido de 6+ SKUs Sayerlack: trace mostra `rect.y > 0` no diag pré-click, `elementoNoCentro = btnSalvarNovoPedido`
- [ ] Snapshot pós-click: btnDisabled=true, "Efetivando" no body
- [ ] POST /order-creation/form/add capturado na network
- [ ] sucesso_portal + protocolo + Omie

🤖 Generated with [Claude Code](https://claude.com/claude-code)