### PR TITLE
fix(ui): tabelas — remove phantom scrollbar e bloqueia swipe-back

### DIFF
--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -4,53 +4,9 @@ import { cn } from "@/lib/utils";
 
 const Table = React.forwardRef<HTMLTableElement, React.HTMLAttributes<HTMLTableElement>>(
   ({ className, ...props }, ref) => {
-    const scrollRef = React.useRef<HTMLDivElement>(null);
-    const phantomRef = React.useRef<HTMLDivElement>(null);
-    const innerRef = React.useRef<HTMLDivElement>(null);
-    const [width, setWidth] = React.useState(0);
-    const [overflowing, setOverflowing] = React.useState(false);
-
-    React.useEffect(() => {
-      const el = scrollRef.current;
-      if (!el) return;
-      const update = () => {
-        setWidth(el.scrollWidth);
-        setOverflowing(el.scrollWidth > el.clientWidth + 1);
-      };
-      update();
-      const ro = new ResizeObserver(update);
-      ro.observe(el);
-      if (el.firstElementChild) ro.observe(el.firstElementChild as Element);
-      return () => ro.disconnect();
-    }, []);
-
-    const syncScroll = (source: HTMLDivElement | null, target: HTMLDivElement | null) => {
-      if (!source || !target) return;
-      if (Math.abs(target.scrollLeft - source.scrollLeft) > 1) {
-        target.scrollLeft = source.scrollLeft;
-      }
-    };
-
-    const onScrollMain = () => syncScroll(scrollRef.current, phantomRef.current);
-    const onScrollPhantom = () => syncScroll(phantomRef.current, scrollRef.current);
-
     return (
-      <div className="relative w-full">
-        <div ref={scrollRef} onScroll={onScrollMain} className="relative w-full overflow-auto">
-          <div ref={innerRef}>
-            <table ref={ref} className={cn("w-full caption-bottom text-sm", className)} {...props} />
-          </div>
-        </div>
-        {overflowing && (
-          <div
-            ref={phantomRef}
-            onScroll={onScrollPhantom}
-            className="sticky bottom-2 z-20 overflow-x-auto overflow-y-hidden h-3 bg-background/90 backdrop-blur-sm rounded-full shadow-md border border-border/50 mt-1"
-            aria-hidden="true"
-          >
-            <div style={{ width, height: 1 }} />
-          </div>
-        )}
+      <div className="relative w-full overflow-auto overscroll-contain rounded-md">
+        <table ref={ref} className={cn("w-full caption-bottom text-sm", className)} {...props} />
       </div>
     );
   },

--- a/src/index.css
+++ b/src/index.css
@@ -361,6 +361,22 @@
   .no-scrollbar::-webkit-scrollbar { display: none; }
   .no-scrollbar { -ms-overflow-style: none; scrollbar-width: none; }
 
+  /* ── Overscroll containment ──
+     Bloqueia o gesto swipe-back do navegador (macOS trackpad / iOS) quando
+     o usuário arrasta para a esquerda no início de um scroll horizontal.
+     Sem isso, o navegador interpreta o gesto como "voltar página" e
+     recarrega a página anterior. Aplica em qualquer container de scroll
+     da app — tabelas (shadcn <Table>), wrappers .overflow-x-auto legados,
+     ScrollArea, etc. */
+  [class*="overflow-auto"],
+  [class*="overflow-x-auto"],
+  [class*="overflow-x-scroll"],
+  [class*="overflow-y-auto"],
+  [class*="overflow-y-scroll"],
+  [class*="overflow-scroll"] {
+    overscroll-behavior: contain;
+  }
+
   /* ── Compact density ── */
   .density-compact {
     --table-row-height: 36px;


### PR DESCRIPTION
## Summary

- Remove a **phantom scrollbar** sticky em `src/components/ui/table.tsx` que duplicava a barra na mesma tabela e cuja lógica de `syncScroll` (threshold 1px) gerava resistência ao scroll, dando a sensação de "só anda pra direita".
- Adiciona regra global em `src/index.css` aplicando `overscroll-behavior: contain` em qualquer container de scroll (`overflow-auto`, `overflow-x-auto`, etc). Isso **bloqueia o gesto swipe-back do navegador** que recarregava a página anterior quando o usuário arrastava pra esquerda no início de uma tabela larga.
- Cobre **todas as ~36 telas com `<Table>`** + os **44+ wrappers `<div className=\"overflow-x-auto\">`** existentes sem precisar editar cada uma. Tabelas futuras herdam o comportamento correto de fábrica.

## Sintomas resolvidos

- 2 scrollbars na mesma tabela.
- Scroll horizontal travando ao tentar voltar pra esquerda.
- Página recarregando a anterior ao arrastar pra esquerda (swipe-back).

## Diff size

`+18 / -46` em 2 arquivos. Sem mudança em nenhuma página/componente de consumo.

## Test plan

- [ ] Abrir uma tela com tabela larga (ex.: `/financeiro` → Dashboard → tabelas com 4+ colunas; `/admin/reposicao/cockpit`; `/sales/orders`)
- [ ] Verificar: apenas **1 scrollbar horizontal** visível
- [ ] Arrastar pra direita e pra esquerda — deve rolar nas duas direções
- [ ] No início do scroll, arrastar pra esquerda no trackpad — **não deve voltar pra página anterior**
- [ ] Verificar tabelas com sticky column (ex.: `FinanceiroDashboard` linhas 1054, 1167) — coluna fixa permanece alinhada
- [ ] Testar em Safari (gesto swipe-back nativo é mais agressivo) e Chrome

🤖 Generated with [Claude Code](https://claude.com/claude-code)