### PR TITLE
chore(branding): rename "Afiação Colacor" → "Colacor"

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0" />
-    <title>Colacor - Afiação Profissional</title>
+    <title>Colacor</title>
     <meta name="description" content="Colacor - Serviço profissional de afiação de ferramentas. Agende sua coleta!">
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -28,8 +28,8 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="@Colacor" />
     <meta name="twitter:image" content="https://storage.googleapis.com/gpt-engineer-file-uploads/attachments/og-images/95e8aa89-acc7-4729-9eef-705203a88c8b?Expires=1771773771&amp;GoogleAccessId=go-api-on-aws%40gpt-engineer-390607.iam.gserviceaccount.com&amp;Signature=lYjLXg4ZeAu3eXyqAZA1YA8%2B0tM0ur1qb8AHN9WVgS8tha7YsUm5VnObQhLznP7XumpRu6CDwsRkqpcibjLckFytOl8V0JmWVEuBl2Dk%2F74SrxknLJF7V%2BJhgcsFja6I6hEfEJZkLGT54NDFXsv2ncIJK1DogzViheJLsIwlbw03x1NNaBT7f701Psf6FuzHycEtaG42YnXuzC3CXzwQXTfzM%2FRyVkxGW%2BX8Bpoa%2FO0cHr3eCZCmfY2DQBF0sx8d6E4ZC9gzdzR6dgp9eQZ79Pu%2BZm7r%2FZBS9meKimxb5XqvIFgvKTRioE9ErL6KPj6UIZK1aPCCprUvTfIKI2yQag%3D%3D">
-    <meta property="og:title" content="Colacor - Afiação Profissional">
-  <meta name="twitter:title" content="Colacor - Afiação Profissional">
+    <meta property="og:title" content="Colacor">
+  <meta name="twitter:title" content="Colacor">
   <meta property="og:description" content="Colacor - Serviço profissional de afiação de ferramentas. Agende sua coleta!">
   <meta name="twitter:description" content="Colacor - Serviço profissional de afiação de ferramentas. Agende sua coleta!">
 </head>

--- a/src/contexts/CompanyContext.tsx
+++ b/src/contexts/CompanyContext.tsx
@@ -10,7 +10,7 @@ interface CompanyInfo {
 }
 
 export const COMPANIES: Record<Company, CompanyInfo> = {
-  colacor: { id: 'colacor', name: 'Afiação Colacor', shortName: 'Colacor', regime: 'presumido' },
+  colacor: { id: 'colacor', name: 'Colacor', shortName: 'Colacor', regime: 'presumido' },
   oben: { id: 'oben', name: 'Oben Comercial', shortName: 'Oben', regime: 'presumido' },
   colacor_sc: { id: 'colacor_sc', name: 'Colacor SC', shortName: 'Colacor SC', regime: 'simples' },
 };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -23,9 +23,9 @@ export default defineConfig(({ mode }) => ({
       injectRegister: "script-defer",
       includeAssets: ["favicon.ico", "robots.txt"],
       manifest: {
-        name: "Colacor - Afiação Profissional",
+        name: "Colacor",
         short_name: "Colacor",
-        description: "Serviço profissional de afiação de ferramentas",
+        description: "Sistema operacional B2B do grupo Colacor",
         theme_color: "#1a1a2e",
         background_color: "#1a1a2e",
         display: "standalone",


### PR DESCRIPTION
## Sumário

CLAUDE.md §1 documenta que "Colacor virou o nome-mãe do app e do grupo, e o produto se expandiu para vendas, estoque, financeiro, tintometria, reposição inteligente, produção e governança". A afiação é hoje **apenas um módulo**, não a identidade.

## Mudanças

| Local | De | Para |
|---|---|---|
| `src/contexts/CompanyContext.tsx:13` | `name: 'Afiação Colacor'` | `'Colacor'` |
| `index.html` `<title>` + og:title + twitter:title | `"Colacor - Afiação Profissional"` | `"Colacor"` |
| `vite.config.ts` PWA `manifest.name` | `"Colacor - Afiação Profissional"` | `"Colacor"` |
| `vite.config.ts` PWA `manifest.description` | `"Serviço profissional de afiação de ferramentas"` | `"Sistema operacional B2B do grupo Colacor"` |

`short_name` já era "Colacor" — sem mudança.

## ⚠️ Atenção: deploy coordenado pra cache PWA

O `manifest.webmanifest` muda → service worker vai invalidar caches dos usuários PWA-instalados na próxima visita. Eles vão ver "atualização disponível" (e se auto-update tiver, vai aplicar sozinho). Mudança benigna mas **vale aviso em release notes**.

## Não tocado (separate concern)

- Descriptions em `index.html` (linhas 7, 33, 34) ainda dizem `"Colacor - Serviço profissional de afiação de ferramentas. Agende sua coleta!"` — copy de marketing legada, **decisão de produto** se vale reescrever pra refletir o sistema operacional B2B.
- `og:image` / `twitter:image` apontam pra storage GCS antigo (separate concern).
- `apple-mobile-web-app-title` já era "Colacor".

## Validação

- [x] `bun test` — 98/98 passam
- [x] `bun build` — limpa
- [x] `bun lint` — idêntico ao baseline

**Net diff: 3 files changed, 6 insertions(+), 6 deletions(-)**

🤖 Generated with [Claude Code](https://claude.com/claude-code)