### PR TITLE
feat(perf): infinite scroll pagination em SalesOrders + AdminCustomers

### DIFF
--- a/src/hooks/useInfiniteScroll.ts
+++ b/src/hooks/useInfiniteScroll.ts
@@ -1,0 +1,38 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * IntersectionObserver-based infinite scroll trigger.
+ *
+ * Use:
+ *   const sentinelRef = useInfiniteScroll(
+ *     () => query.fetchNextPage(),
+ *     !!query.hasNextPage && !query.isFetchingNextPage,
+ *   );
+ *   ...
+ *   <div ref={sentinelRef} />   // sentinela invisível no fim da lista
+ *
+ * O `rootMargin: '200px'` antecipa o load — o trigger dispara 200px ANTES da
+ * sentinela entrar no viewport, fica fluido sem "barrar" o scroll.
+ */
+export function useInfiniteScroll(
+  onLoadMore: () => void,
+  enabled: boolean,
+): React.RefObject<HTMLDivElement> {
+  const sentinelRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = sentinelRef.current;
+    if (!enabled || !el) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting) onLoadMore();
+      },
+      { rootMargin: '200px' },
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [enabled, onLoadMore]);
+
+  return sentinelRef;
+}

--- a/src/pages/AdminCustomers.tsx
+++ b/src/pages/AdminCustomers.tsx
@@ -1,4 +1,8 @@
 import { useState, useEffect, useMemo } from 'react';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
+
+const PAGE_SIZE = 100;
 import { RecommendationsPanel } from '@/components/RecommendationsPanel';
 import { useNavigate, useParams } from 'react-router-dom';
 
@@ -92,12 +96,19 @@ function CustomerListView({
   scores,
   loading,
   onSelect,
+  hasNextPage,
+  isFetchingNextPage,
+  onLoadMore,
 }: {
   customers: Customer[];
   scores: Map<string, ClientScore>;
   loading: boolean;
   onSelect: (c: Customer) => void;
+  hasNextPage: boolean;
+  isFetchingNextPage: boolean;
+  onLoadMore: () => void;
 }) {
+  const sentinelRef = useInfiniteScroll(onLoadMore, hasNextPage && !isFetchingNextPage);
   // Filtros sincronizados com URL (compartilhável, sobrevive a F5)
   const [urlState, setUrlState] = useUrlState({ search: '', health: 'all' });
   const searchQuery = urlState.search;
@@ -360,6 +371,24 @@ function CustomerListView({
             actionLabel={searchQuery || filterHealth !== 'all' ? 'Limpar filtros' : undefined}
             onAction={searchQuery || filterHealth !== 'all' ? () => setUrlState({ search: '', health: 'all' }) : undefined}
           />
+        )}
+
+        {/* Infinite scroll sentinel + fallback botão */}
+        {hasNextPage && (
+          <div ref={sentinelRef} className="py-4 flex justify-center border-t">
+            {isFetchingNextPage ? (
+              <Loader2 className="w-5 h-5 animate-spin text-muted-foreground" />
+            ) : (
+              <Button variant="outline" size="sm" onClick={onLoadMore}>
+                Carregar mais
+              </Button>
+            )}
+          </div>
+        )}
+        {!hasNextPage && customers.length > 0 && (
+          <p className="text-center text-xs text-muted-foreground py-4 border-t">
+            Todos os clientes carregados ({customers.length})
+          </p>
         )}
       </Card>
     </div>
@@ -701,13 +730,11 @@ const AdminCustomers = () => {
   const { user, isStaff, loading: authLoading } = useAuth();
   const { toast } = useToast();
 
-  const [customers, setCustomers] = useState<Customer[]>([]);
   const [selectedCustomer, setSelectedCustomer] = useState<Customer | null>(null);
   const [customerTools, setCustomerTools] = useState<UserTool[]>([]);
   const [categories, setCategories] = useState<ToolCategory[]>([]);
   const [scores, setScores] = useState<Map<string, ClientScore>>(new Map());
   const [orders, setOrders] = useState<SalesOrder[]>([]);
-  const [loading, setLoading] = useState(true);
   const [loadingTools, setLoadingTools] = useState(false);
   const [loadingOrders, setLoadingOrders] = useState(false);
   const [addToolDialogOpen, setAddToolDialogOpen] = useState(false);
@@ -716,9 +743,55 @@ const AdminCustomers = () => {
     if (!authLoading && !isStaff) navigate('/', { replace: true });
   }, [authLoading, isStaff, navigate]);
 
+  /* ─── Customers: infinite query (100 por página) ─── */
+  // Buscamos employee_ids 1× pra filtrar client-side (defensivo — eq('is_employee', false)
+  // já filtra no DB, mas mantemos a verificação contra user_roles caso o flag esteja stale)
+  const employeeIdsQuery = useInfiniteQuery({
+    queryKey: ['admin-customers-employee-ids'],
+    enabled: isStaff,
+    staleTime: 5 * 60_000,
+    initialPageParam: 0,
+    queryFn: async () => {
+      const { data } = await supabase
+        .from('user_roles')
+        .select('user_id')
+        .in('role', ['master', 'employee']);
+      return new Set((data || []).map((r: any) => r.user_id));
+    },
+    getNextPageParam: () => undefined,
+  });
+  const employeeIds = employeeIdsQuery.data?.pages[0] || new Set<string>();
+
+  const customersQuery = useInfiniteQuery({
+    queryKey: ['admin-customers-paginated'],
+    enabled: isStaff,
+    initialPageParam: 0,
+    queryFn: async ({ pageParam }) => {
+      const start = (pageParam as number) * PAGE_SIZE;
+      const { data, error } = await supabase
+        .from('profiles')
+        .select('user_id, name, email, phone, document, customer_type, created_at, requires_po')
+        .eq('is_employee', false)
+        .order('name')
+        .range(start, start + PAGE_SIZE - 1);
+      if (error) throw error;
+      return (data || []) as Customer[];
+    },
+    getNextPageParam: (lastPage, allPages) =>
+      lastPage.length === PAGE_SIZE ? allPages.length : undefined,
+  });
+
+  // Customers visíveis (filter defensivo de employees depois do fetch — pode reduzir
+  // tamanho da page mas não afeta getNextPageParam que olha o raw 100)
+  const customers = useMemo<Customer[]>(() => {
+    const raw = customersQuery.data?.pages.flat() || [];
+    return raw.filter((p) => !employeeIds.has(p.user_id));
+  }, [customersQuery.data, employeeIds]);
+
+  const loading = customersQuery.isLoading;
+
   useEffect(() => {
     if (user && isStaff) {
-      loadCustomers();
       loadCategories();
       loadScores();
     }
@@ -738,33 +811,6 @@ const AdminCustomers = () => {
   const loadCategories = async () => {
     const { data } = await supabase.from('tool_categories').select('*').order('name');
     if (data) setCategories(data);
-  };
-
-  const loadCustomers = async () => {
-    try {
-      // Get employee user_ids to exclude them
-      const { data: employeeRoles } = await supabase
-        .from('user_roles')
-        .select('user_id')
-        .in('role', ['master', 'employee']);
-
-      const employeeIds = new Set((employeeRoles || []).map(r => r.user_id));
-
-      const { data, error } = await supabase
-        .from('profiles')
-        .select('user_id, name, email, phone, document, customer_type, created_at, requires_po')
-        .eq('is_employee', false)
-        .order('name');
-      if (error) throw error;
-
-      // Filter out any staff users
-      const filtered = (data || []).filter(p => !employeeIds.has(p.user_id));
-      setCustomers(filtered);
-    } catch (error) {
-      console.error('Error loading customers:', error);
-    } finally {
-      setLoading(false);
-    }
   };
 
   const loadScores = async () => {
@@ -877,6 +923,9 @@ const AdminCustomers = () => {
           scores={scores}
           loading={loading}
           onSelect={handleSelectCustomer}
+          hasNextPage={!!customersQuery.hasNextPage}
+          isFetchingNextPage={customersQuery.isFetchingNextPage}
+          onLoadMore={() => customersQuery.fetchNextPage()}
         />
       )}
     </>

--- a/src/pages/SalesOrders.tsx
+++ b/src/pages/SalesOrders.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useInfiniteQuery, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
@@ -17,8 +18,11 @@ import { ptBR } from 'date-fns/locale';
 import { toast } from 'sonner';
 import { StatusBadgeSimple } from '@/components/StatusBadge';
 import { shareOrderViaWhatsApp } from '@/utils/whatsappShare';
+import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
 
 type Account = 'oben' | 'colacor' | 'afiacao' | 'all';
+
+const PAGE_SIZE = 50;
 
 const decodeHtml = (s: string): string =>
   s
@@ -57,41 +61,49 @@ const statusLabels: Record<string, { label: string; variant: 'default' | 'second
 
 const SalesOrders = () => {
   const navigate = useNavigate();
-  const { isStaff, loading: authLoading } = useAuth();
-  const [orders, setOrders] = useState<SalesOrder[]>([]);
-  const [profiles, setProfiles] = useState<Record<string, string>>({});
-  const [loading, setLoading] = useState(true);
+  const queryClient = useQueryClient();
+  const { isStaff, loading: authLoading, role } = useAuth();
   const [accountFilter, setAccountFilter] = useState<Account>('all');
   const [search, setSearch] = useState('');
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
-  const { role } = useAuth();
+
   useEffect(() => {
     if (!authLoading && role !== null && !isStaff) navigate('/', { replace: true });
   }, [authLoading, role, isStaff, navigate]);
 
-  useEffect(() => {
-    if (isStaff) loadOrders();
-  }, [isStaff]);
-
-  const loadOrders = async () => {
-    try {
-      // Load sales orders
-      const { data: salesData, error: salesError } = await supabase
+  /* ─── Sales orders: infinite query (50 por página) ─── */
+  const salesQuery = useInfiniteQuery({
+    queryKey: ['sales-orders-paginated'],
+    enabled: isStaff,
+    initialPageParam: 0,
+    queryFn: async ({ pageParam }) => {
+      const start = (pageParam as number) * PAGE_SIZE;
+      const { data, error } = await supabase
         .from('sales_orders')
         .select('*')
-        .order('created_at', { ascending: false });
+        .order('created_at', { ascending: false })
+        .range(start, start + PAGE_SIZE - 1);
+      if (error) throw error;
+      return (data || []).map((o: any) => ({ ...o, _source: 'sales' as const })) as SalesOrder[];
+    },
+    getNextPageParam: (lastPage, allPages) =>
+      lastPage.length === PAGE_SIZE ? allPages.length : undefined,
+  });
 
-      if (salesError) throw salesError;
-      const salesOrders = (salesData || []).map((o: any) => ({ ...o, _source: 'sales' as const })) as SalesOrder[];
-
-      // Load afiação orders
-      const { data: afiacaoData, error: afiacaoError } = await supabase
+  /* ─── Afiação orders: infinite query (50 por página) ─── */
+  const afiacaoQuery = useInfiniteQuery({
+    queryKey: ['afiacao-orders-paginated'],
+    enabled: isStaff,
+    initialPageParam: 0,
+    queryFn: async ({ pageParam }) => {
+      const start = (pageParam as number) * PAGE_SIZE;
+      const { data, error } = await supabase
         .from('orders')
         .select('*')
-        .order('created_at', { ascending: false });
-
-      if (afiacaoError) throw afiacaoError;
-      const afiacaoOrders = (afiacaoData || []).map((o: any) => ({
+        .order('created_at', { ascending: false })
+        .range(start, start + PAGE_SIZE - 1);
+      if (error) throw error;
+      return (data || []).map((o: any) => ({
         id: o.id,
         customer_user_id: o.user_id,
         items: Array.isArray(o.items) ? o.items.map((i: any) => ({
@@ -110,34 +122,61 @@ const SalesOrders = () => {
         account: 'afiacao',
         _source: 'afiacao' as const,
       })) as SalesOrder[];
+    },
+    getNextPageParam: (lastPage, allPages) =>
+      lastPage.length === PAGE_SIZE ? allPages.length : undefined,
+  });
 
-      const allOrders = [...salesOrders, ...afiacaoOrders].sort(
-        (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
-      );
-      setOrders(allOrders);
+  /* ─── Lista mergeada ─── */
+  const orders = useMemo<SalesOrder[]>(() => {
+    const sales = salesQuery.data?.pages.flat() || [];
+    const afiacao = afiacaoQuery.data?.pages.flat() || [];
+    return [...sales, ...afiacao].sort(
+      (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
+    );
+  }, [salesQuery.data, afiacaoQuery.data]);
 
-      // Load customer names
-      const customerIds = [...new Set(allOrders.map((o) => o.customer_user_id))];
-      if (customerIds.length > 0) {
-        const { data: profs } = await supabase
-          .from('profiles')
-          .select('user_id, name')
-          .in('user_id', customerIds);
-        const map: Record<string, string> = {};
-        (profs || []).forEach((p: any) => { map[p.user_id] = p.name; });
-        setProfiles(map);
-      }
-    } catch (e) {
-      console.error(e);
-    } finally {
-      setLoading(false);
-    }
-  };
+  /* ─── Profiles (nomes dos clientes) ─── */
+  const customerIds = useMemo(() => [...new Set(orders.map((o) => o.customer_user_id))], [orders]);
+  const profilesQuery = useQuery({
+    queryKey: ['sales-orders-profiles', customerIds.sort().join(',')],
+    enabled: isStaff && customerIds.length > 0,
+    staleTime: 60_000,
+    queryFn: async () => {
+      const { data } = await supabase
+        .from('profiles')
+        .select('user_id, name')
+        .in('user_id', customerIds);
+      const map: Record<string, string> = {};
+      (data || []).forEach((p: any) => { map[p.user_id] = p.name; });
+      return map;
+    },
+  });
+  const profiles = profilesQuery.data || {};
 
-  // Optimistic delete — remove imediatamente da lista, restaura em caso de erro
+  /* ─── Infinite scroll: dispara fetchNextPage de quem ainda tem páginas ─── */
+  const hasNext = !!salesQuery.hasNextPage || !!afiacaoQuery.hasNextPage;
+  const isFetching = salesQuery.isFetchingNextPage || afiacaoQuery.isFetchingNextPage;
+  const sentinelRef = useInfiniteScroll(
+    () => {
+      if (salesQuery.hasNextPage && !salesQuery.isFetchingNextPage) salesQuery.fetchNextPage();
+      if (afiacaoQuery.hasNextPage && !afiacaoQuery.isFetchingNextPage) afiacaoQuery.fetchNextPage();
+    },
+    hasNext && !isFetching,
+  );
+
+  const loading = salesQuery.isLoading || afiacaoQuery.isLoading;
+
+  // Optimistic delete — atualiza cache de useInfiniteQuery, rollback em erro
   const deleteOrder = async (order: SalesOrder) => {
-    const snapshot = orders;
-    setOrders((prev) => prev.filter((o) => o.id !== order.id));
+    const snapshot = queryClient.getQueryData(['sales-orders-paginated']);
+    queryClient.setQueryData(['sales-orders-paginated'], (old: any) => {
+      if (!old) return old;
+      return {
+        ...old,
+        pages: old.pages.map((page: SalesOrder[]) => page.filter((o) => o.id !== order.id)),
+      };
+    });
     setSelectedIds((prev) => {
       const next = new Set(prev);
       next.delete(order.id);
@@ -155,7 +194,7 @@ const SalesOrders = () => {
       toast.success('Pedido excluído');
     } catch (e: any) {
       console.error(e);
-      setOrders(snapshot); // rollback
+      queryClient.setQueryData(['sales-orders-paginated'], snapshot); // rollback
       toast.error('Erro ao excluir pedido', { description: e?.message });
     }
   };
@@ -164,9 +203,15 @@ const SalesOrders = () => {
   const deleteSelected = async () => {
     if (selectedIds.size === 0) return;
     const toDelete = orders.filter((o) => selectedIds.has(o.id) && o._source === 'sales');
-    const snapshot = orders;
-    // Optimistic: remove tudo da lista de uma vez
-    setOrders((prev) => prev.filter((o) => !selectedIds.has(o.id)));
+    const snapshot = queryClient.getQueryData(['sales-orders-paginated']);
+    const deleteIds = new Set(toDelete.map((o) => o.id));
+    queryClient.setQueryData(['sales-orders-paginated'], (old: any) => {
+      if (!old) return old;
+      return {
+        ...old,
+        pages: old.pages.map((page: SalesOrder[]) => page.filter((o) => !deleteIds.has(o.id))),
+      };
+    });
     setSelectedIds(new Set());
 
     let success = 0;
@@ -191,7 +236,7 @@ const SalesOrders = () => {
     if (failed === 0) {
       toast.success(`${success} pedido(s) excluído(s)`);
     } else if (success === 0) {
-      setOrders(snapshot); // rollback completo
+      queryClient.setQueryData(['sales-orders-paginated'], snapshot); // rollback completo
       toast.error(`Falhou: ${failed} pedido(s) não puderam ser excluídos`);
     } else {
       // Parcial — mantém o sucesso
@@ -437,6 +482,31 @@ const SalesOrders = () => {
               </Card>
             );
           })}
+
+          {/* Infinite scroll sentinel + carregar mais fallback */}
+          {hasNext && (
+            <div ref={sentinelRef} className="py-4 flex justify-center">
+              {isFetching ? (
+                <Loader2 className="w-5 h-5 animate-spin text-muted-foreground" />
+              ) : (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => {
+                    if (salesQuery.hasNextPage) salesQuery.fetchNextPage();
+                    if (afiacaoQuery.hasNextPage) afiacaoQuery.fetchNextPage();
+                  }}
+                >
+                  Carregar mais
+                </Button>
+              )}
+            </div>
+          )}
+          {!hasNext && orders.length >= PAGE_SIZE && (
+            <p className="text-center text-xs text-muted-foreground py-4">
+              Todos os pedidos carregados ({orders.length})
+            </p>
+          )}
         </div>
       )}
 


### PR DESCRIPTION
## Sumário

Auditoria identificou risco de **freeze >1s** e **payload >1MB** nas duas telas que carregavam toda a base de pedidos/clientes sem paginação ([CLAUDE.md §10](CLAUDE.md)). Esta mudança quebra os fetches em páginas e adiciona infinite scroll via IntersectionObserver, com botão "Carregar mais" como fallback acessível.

## Mudanças

### Novo hook: [src/hooks/useInfiniteScroll.ts](src/hooks/useInfiniteScroll.ts) (38 LoC)
- IntersectionObserver-based trigger pra `fetchNextPage`
- `rootMargin: '200px'` antecipa o load (fluido, sem barrar scroll)
- Genérico, reusável em qualquer tela com `useInfiniteQuery`

### [SalesOrders.tsx](src/pages/SalesOrders.tsx) (rewrite)
- Substitui `loadOrders()` state-based por **2× `useInfiniteQuery` paralelos** (`sales_orders` + `orders`/afiação, página de 50)
- Merge no client + sort por `created_at desc` (mantém comportamento atual)
- Optimistic delete migrado de `setState` pra `queryClient.setQueryData` (com rollback)
- Profiles query separado via `useQuery` dependent
- Sentinel + botão "Carregar mais" no fim da lista
- "Todos os pedidos carregados (N)" quando `hasNext=false`

### [AdminCustomers.tsx](src/pages/AdminCustomers.tsx) (refactor mínimo)
- Substitui `loadCustomers()` por `useInfiniteQuery` (página de 100)
- `employee_ids` query separado (1× com 5min cache) — filtro client-side defensivo **não afeta** `getNextPageParam` (este olha o raw `page.length`)
- `CustomerListView` ganha props `hasNextPage` / `isFetchingNextPage` / `onLoadMore`
- Sentinel + botão "Carregar mais" dentro do `Card`, depois da tabela

## Trade-offs conhecidos

- **Search/filter** (search query + filter health) agora aplicam apenas a páginas já carregadas. Pra volumes grandes, usuário pode precisar clicar "Carregar mais" pra encontrar registros antigos. Server-side search é PR próprio.
- O lookup `customers.find(c => c.user_id === customerId)` em deep-link `/admin/customers/:id` pode falhar se o customer está em página não carregada. Edge case aceitável; PR de fix separado pode adicionar fetch direto por id.

## Validação
- [x] `bun test` — 98/98 passam
- [x] `bun build` — limpa
- [x] `bun lint` — 1396 problemas (+5 vs baseline 1391). Todos `no-explicit-any` em callbacks de query — mesmo padrão dos `(o: any) =>` já presentes na base (97% dos 1300 erros existentes são desta regra)

## Net diff
3 files changed, 240 insertions(+), 83 deletions(-)

🤖 Generated with [Claude Code](https://claude.com/claude-code)