### PR TITLE
perf(shell): gate AppShell polls por persona + memo 3 chart components

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -357,6 +357,14 @@ function AppSidebar({ collapsed, onToggle }: { collapsed: boolean; onToggle: () 
   const isSalesOnly = useSalesOnlyRestriction();
   const { favorites, isFavorite, toggle: toggleFavorite } = useSidebarFavorites();
 
+  // Os 6 contadores de badges abaixo são todos da seção Reposição. Não fazem
+  // sentido pra vendedor sales-only (que não acessa /admin/reposicao). Gate por
+  // `!isSalesOnly` evita ~6 req/min por usuário sales-only em idle.
+  // `refetchIntervalInBackground: false` (default do React Query) já pausa
+  // polls quando o tab está hidden — explicitado abaixo pra deixar a intenção
+  // clara e evitar mudança silenciosa se algum dia alguém ligar pra true.
+  const enableReposicaoPolls = isStaff && !isSalesOnly;
+
   // Contador de alertas de outlier pendentes (críticos + atenção)
   const { data: outlierPendentes } = useQuery({
     queryKey: ['outlier-pendentes-count'],
@@ -368,8 +376,9 @@ function AppSidebar({ collapsed, onToggle }: { collapsed: boolean; onToggle: () 
         .in('severidade', ['critico', 'atencao']);
       return count ?? 0;
     },
-    enabled: isStaff,
+    enabled: enableReposicaoPolls,
     refetchInterval: 60000,
+    refetchIntervalInBackground: false,
     staleTime: 30000,
   });
 
@@ -385,12 +394,14 @@ function AppSidebar({ collapsed, onToggle }: { collapsed: boolean; onToggle: () 
         .in('status', ['pendente_aprovacao', 'bloqueado_guardrail']);
       return count ?? 0;
     },
-    enabled: isStaff,
+    enabled: enableReposicaoPolls,
     refetchInterval: 30000,
+    refetchIntervalInBackground: false,
     staleTime: 15000,
   });
 
   // Contador de aumentos ativos aguardando vigência
+  // (corrige bug: faltava `enabled` — antes polava pra customer também)
   const { data: aumentosAtivos } = useQuery({
     queryKey: ['aumentos-ativos-count'],
     queryFn: async () => {
@@ -400,7 +411,9 @@ function AppSidebar({ collapsed, onToggle }: { collapsed: boolean; onToggle: () 
         .eq('estado', 'ativo');
       return count ?? 0;
     },
+    enabled: enableReposicaoPolls,
     refetchInterval: 60000,
+    refetchIntervalInBackground: false,
   });
 
   // Contador de oportunidades econômicas ativas hoje (OBEN)
@@ -413,8 +426,9 @@ function AppSidebar({ collapsed, onToggle }: { collapsed: boolean; onToggle: () 
         .eq('empresa', 'OBEN');
       return count ?? 0;
     },
-    enabled: isStaff,
+    enabled: enableReposicaoPolls,
     refetchInterval: 60000,
+    refetchIntervalInBackground: false,
     staleTime: 30000,
   });
 
@@ -429,8 +443,9 @@ function AppSidebar({ collapsed, onToggle }: { collapsed: boolean; onToggle: () 
         .eq('status', 'nova');
       return count ?? 0;
     },
-    enabled: isStaff,
+    enabled: enableReposicaoPolls,
     refetchInterval: 60000,
+    refetchIntervalInBackground: false,
     staleTime: 30000,
   });
 
@@ -444,8 +459,9 @@ function AppSidebar({ collapsed, onToggle }: { collapsed: boolean; onToggle: () 
         .eq('status', 'pendente_notificacao');
       return count ?? 0;
     },
-    enabled: isStaff,
+    enabled: enableReposicaoPolls,
     refetchInterval: 60000,
+    refetchIntervalInBackground: false,
     staleTime: 30000,
   });
 

--- a/src/components/des/HistoricoTab.tsx
+++ b/src/components/des/HistoricoTab.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { memo, useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "react-router-dom";
 import {
@@ -129,7 +129,7 @@ function quarterDates(ano: number, trimestre: number): { inicio: string; fim: st
   return { inicio: iso(inicio), fim: iso(fim) };
 }
 
-export function HistoricoTab({ empresa, ano: anoAtual, trimestre: trimestreAtual }: Props) {
+function HistoricoTabImpl({ empresa, ano: anoAtual, trimestre: trimestreAtual }: Props) {
   const [filtroAno, setFiltroAno] = useState<string>("__todos__");
   const [filtroStatus, setFiltroStatus] = useState<string>("todos");
   const [detalhesOpen, setDetalhesOpen] = useState<QuarterCard | null>(null);
@@ -580,3 +580,5 @@ export function HistoricoTab({ empresa, ano: anoAtual, trimestre: trimestreAtual
     </div>
   );
 }
+
+export const HistoricoTab = memo(HistoricoTabImpl);

--- a/src/components/intelligence/IntelligenceManagerialTab.tsx
+++ b/src/components/intelligence/IntelligenceManagerialTab.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { memo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
@@ -8,7 +8,7 @@ import { Users, AlertTriangle, Layers } from 'lucide-react';
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip as RechartsTooltip, ResponsiveContainer } from 'recharts';
 import { KpiCard } from './KpiCard';
 
-export function IntelligenceManagerialTab() {
+function IntelligenceManagerialTabImpl() {
   const { data: allScores, isLoading } = useQuery({
     queryKey: ['intel-all-scores'],
     queryFn: async () => {
@@ -167,3 +167,5 @@ export function IntelligenceManagerialTab() {
     </div>
   );
 }
+
+export const IntelligenceManagerialTab = memo(IntelligenceManagerialTabImpl);

--- a/src/components/reposicao/HistoricoComChart.tsx
+++ b/src/components/reposicao/HistoricoComChart.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useMemo, useState } from "react";
+import { lazy, memo, Suspense, useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { format, subDays } from "date-fns";
 import { toast } from "sonner";
@@ -261,7 +261,7 @@ function CompareCyclesSection({ cycles }: { cycles: string[] }) {
   );
 }
 
-export function HistoricoComChart() {
+function HistoricoComChartImpl() {
   const { data = [], isLoading } = useHistoricoChart();
   const cycles = useMemo(() => data.map((d) => d.data).reverse(), [data]);
   return (
@@ -328,3 +328,5 @@ export function HistoricoComChart() {
   );
 }
 
+
+export const HistoricoComChart = memo(HistoricoComChartImpl);


### PR DESCRIPTION
## Sumário

Auditoria identificou:
1. **9 useQuery paralelos** do `AppShell` rodavam pra TODOS staff (incluindo vendedores sales-only que não acessam Reposição) — ~6 req/min em idle por usuário
2. **Zero `React.memo`** em componentes de chart Recharts — re-render a cada parent update mesmo quando nada muda

## Mudanças

### AppShell.tsx — gate polls Reposição por persona
- Introduzido `enableReposicaoPolls = isStaff && !isSalesOnly`
- **6 useQuery de contadores Reposição** passam a usar este gate:
  - `outlier-pendentes`
  - `pedidos-pendentes`
  - `aumentos-ativos`
  - `oportunidades-ativas`
  - `negociacao-paralela-sugestoes`
  - `notificacoes-pendentes`
- **🐛 Bug fix**: `aumentos-ativos` não tinha `enabled` antes — polava pra customer também
- Adicionado `refetchIntervalInBackground: false` explícito (já é o default do React Query) pra documentar intenção e evitar regressão silenciosa

**Impacto**: vendedor sales-only deixa de pagar 6 req/min em idle. Customer não dispara mais o `aumentos-ativos` (regressão silenciosa fechada).

### 3 chart components com React.memo

| Component | Por que importa |
|---|---|
| [IntelligenceManagerialTab](src/components/intelligence/IntelligenceManagerialTab.tsx) | BarChart pesado, re-render a cada parent update |
| [HistoricoTab](src/components/des/HistoricoTab.tsx) | BarChart + props estáveis `{empresa, ano, trimestre}` |
| [HistoricoComChart](src/components/reposicao/HistoricoComChart.tsx) | BarChart em cockpit (alto tráfego) |

Padrão: `function XImpl()` privado + `export const X = memo(XImpl)`. Preserva nome no devtools.

## Validação
- [x] `bun test` — 98/98 passam
- [x] `bun build` — limpa
- [x] `bun lint` — 1391 problemas (idêntico baseline; zero regressão)

## Net diff
4 files changed, 33 insertions(+), 11 deletions(-)

## Out of scope
- Memoizar os ~10 outros chart components no repo — gradual, à medida que arquivos forem tocados
- Refatorar 7 god-components da Reposição — multi-sprint, decisão de arquitetura
- TypeScript strict mode (1300 lint errors) — decisão estratégica

🤖 Generated with [Claude Code](https://claude.com/claude-code)