### PR TITLE
perf(engines): fix 3 N+1 patterns em hooks IA (CrossSell + Experiments)

### DIFF
--- a/src/hooks/useCrossSellEngine.ts
+++ b/src/hooks/useCrossSellEngine.ts
@@ -368,24 +368,25 @@ export const useCrossSellEngine = () => {
 
       setRecommendations(allRecs);
 
-      // Persist recommendations
-      for (const cr of allRecs) {
-        for (const rec of [...cr.crossSell, ...cr.upSell]) {
-          await supabase.from('farmer_recommendations' as any).upsert({
-            farmer_id: user.id,
-            customer_user_id: rec.customerId,
-            recommendation_type: rec.type,
-            product_id: rec.productId,
-            current_product_id: rec.currentProductId || null,
-            p_ij: rec.pij,
-            m_ij: rec.mij,
-            lie: rec.lie,
-            complexity_factor: rec.complexityFactor,
-            cluster_volume_estimate: rec.clusterVolume,
-            status: 'pendente',
-            updated_at: new Date().toISOString(),
-          } as any);
-        }
+      // Persist recommendations (batch upsert único — antes era N×M serial)
+      const recRows = allRecs.flatMap((cr) =>
+        [...cr.crossSell, ...cr.upSell].map((rec) => ({
+          farmer_id: user.id,
+          customer_user_id: rec.customerId,
+          recommendation_type: rec.type,
+          product_id: rec.productId,
+          current_product_id: rec.currentProductId || null,
+          p_ij: rec.pij,
+          m_ij: rec.mij,
+          lie: rec.lie,
+          complexity_factor: rec.complexityFactor,
+          cluster_volume_estimate: rec.clusterVolume,
+          status: 'pendente',
+          updated_at: new Date().toISOString(),
+        })),
+      );
+      if (recRows.length > 0) {
+        await supabase.from('farmer_recommendations' as any).upsert(recRows as any);
       }
     } catch (error) {
       console.error('Error calculating recommendations:', error);

--- a/src/hooks/useFarmerExperiments.ts
+++ b/src/hooks/useFarmerExperiments.ts
@@ -63,19 +63,28 @@ export const useFarmerExperiments = () => {
         .order('created_at', { ascending: false }) as any;
 
       if (data) {
-        // Load client counts per experiment
-        const enriched = await Promise.all(data.map(async (exp: any) => {
-          const { data: clients } = await supabase
-            .from('farmer_experiment_clients' as any)
-            .select('group_type')
-            .eq('experiment_id', exp.id) as any;
+        // Load client counts em 1 query (antes era N+1: 1 select por experimento)
+        const expIds = data.map((e: any) => e.id);
+        const { data: allClients } = expIds.length > 0
+          ? await supabase
+              .from('farmer_experiment_clients' as any)
+              .select('experiment_id, group_type')
+              .in('experiment_id', expIds) as any
+          : { data: [] };
 
-          return {
-            ...exp,
-            control_count: (clients || []).filter((c: any) => c.group_type === 'controle').length,
-            test_count: (clients || []).filter((c: any) => c.group_type === 'teste').length,
-          };
-        }));
+        // Agrupa client-side: experiment_id → { controle, teste }
+        const counts = new Map<string, { controle: number; teste: number }>();
+        for (const c of (allClients || []) as Array<{ experiment_id: string; group_type: string }>) {
+          const existing = counts.get(c.experiment_id) || { controle: 0, teste: 0 };
+          if (c.group_type === 'controle') existing.controle++;
+          else if (c.group_type === 'teste') existing.teste++;
+          counts.set(c.experiment_id, existing);
+        }
+
+        const enriched = data.map((exp: any) => {
+          const c = counts.get(exp.id) || { controle: 0, teste: 0 };
+          return { ...exp, control_count: c.controle, test_count: c.teste };
+        });
         setExperiments(enriched);
       }
     } catch (e) {
@@ -190,21 +199,25 @@ export const useFarmerExperiments = () => {
       clientMetrics.set(call.customer_user_id, existing);
     }
 
-    // Update experiment clients
-    for (const ec of expClients) {
-      const m = clientMetrics.get(ec.customer_user_id);
-      if (m) {
-        await supabase.from('farmer_experiment_clients' as any)
-          .update({
-            revenue_generated: m.revenue,
-            margin_generated: m.margin,
-            calls_count: m.calls,
-            total_time_seconds: m.time,
-            metric_value: computeMetric(exp.primary_metric, m),
-            updated_at: new Date().toISOString(),
-          } as any)
-          .eq('id', ec.id);
-      }
+    // Update experiment clients (batch upsert único — antes era N updates sequenciais)
+    const updateRows = expClients
+      .map((ec: any) => {
+        const m = clientMetrics.get(ec.customer_user_id);
+        if (!m) return null;
+        return {
+          id: ec.id,
+          revenue_generated: m.revenue,
+          margin_generated: m.margin,
+          calls_count: m.calls,
+          total_time_seconds: m.time,
+          metric_value: computeMetric(exp.primary_metric, m),
+          updated_at: new Date().toISOString(),
+        };
+      })
+      .filter((r): r is NonNullable<typeof r> => r !== null);
+
+    if (updateRows.length > 0) {
+      await supabase.from('farmer_experiment_clients' as any).upsert(updateRows as any);
     }
 
     // Reload clients after update


### PR DESCRIPTION
## Sumário

Auditoria identificou **3 N+1 patterns críticos** em hooks que servem o farmer (vendedor). Os 3 colocavam pressão desproporcional no Supabase + **travavam a UI durante o calculate** (até 50s pra 100 clientes). Esta correção mantém a semântica e troca por queries em batch.

## Fixes

### 1. [useCrossSellEngine.ts:372-389](src/hooks/useCrossSellEngine.ts#L372) — duplo loop com upserts serializados
**Antes**: `for of allRecs { for of [...crossSell, ...upSell] { await upsert(row) } }`
- Pra **100 clientes × 5 recs = 500 round-trips serializados** ≈ 25-50s travando UI

**Agora**: 1 `upsert([...allRows])` em batch — PostgREST insere/atualiza array de uma vez.

### 2. [useFarmerExperiments.ts:67-78](src/hooks/useFarmerExperiments.ts#L67) — N+1 select de client_count por experimento
**Antes**: `Promise.all(data.map(async exp => select('group_type').eq('experiment_id', exp.id)))`
- N round-trips paralelos (1 por experimento), agregação no client

**Agora**: 1 `select('experiment_id, group_type').in('experiment_id', expIds)` + group client-side com `Map`. Same agregação, 1 query.

### 3. [useFarmerExperiments.ts:194-208](src/hooks/useFarmerExperiments.ts#L194) — N updates sequenciais em measureExperiment
**Antes**: `for of expClients { await update({...}).eq('id', ec.id) }`
- N round-trips serializados durante measure (cresce com sample size do experimento)

**Agora**: collect rows com `id` + 1 `upsert([...rows])` — PostgREST resolve por conflict key (`id`). Updates atômicos em batch.

## Out of scope

- **Edge Functions Omie** ([omie-vendas-sync:765,772](supabase/functions/omie-vendas-sync/index.ts#L765) + [omie-sync:1182-1196](supabase/functions/omie-sync/index.ts#L1182)) — também têm N+1 patterns mas envolvem API externa (Omie REST), risco/escopo diferente. PR próprio.

## Validação
- [x] `bun test` — 98/98 passam
- [x] `bun build` — limpa
- [x] `bun lint` — 1396 problemas (idêntico baseline; zero regressão)

## Net diff
2 files changed, 60 insertions(+), 46 deletions(-)

🤖 Generated with [Claude Code](https://claude.com/claude-code)