### PR TITLE
perf(bundle): agrupa 119 lazy pages em 9 feature chunks

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -96,13 +96,48 @@ export default defineConfig(({ mode }) => ({
   build: {
     rollupOptions: {
       output: {
-        manualChunks: {
-          'vendor-react': ['react', 'react-dom', 'react-router-dom'],
-          'vendor-query': ['@tanstack/react-query'],
-          'vendor-ui': ['@radix-ui/react-dialog', '@radix-ui/react-popover', '@radix-ui/react-select', '@radix-ui/react-tabs', '@radix-ui/react-tooltip', '@radix-ui/react-dropdown-menu'],
-          'vendor-supabase': ['@supabase/supabase-js'],
-          'vendor-charts': ['recharts'],
-          'vendor-motion': ['framer-motion'],
+        // Function-form pra agrupar lazy pages por módulo + manter vendors split.
+        // Antes: 119 chunks separados (1 por lazy page) → TTFB extra por navegação.
+        // Agora: peers de um mesmo módulo no mesmo chunk (ex: 22 pages de Reposição = 1 chunk).
+        // Vendors continuam separados (cacheable, raramente mudam).
+        manualChunks(id) {
+          // ─── Vendors ──────────────────────────────────────────────────
+          if (id.includes('node_modules')) {
+            if (/[\\/](react|react-dom|react-router-dom|scheduler)[\\/]/.test(id)) return 'vendor-react';
+            if (id.includes('@tanstack/react-query')) return 'vendor-query';
+            if (id.includes('@supabase/supabase-js')) return 'vendor-supabase';
+            if (id.includes('recharts') || id.includes('d3-')) return 'vendor-charts';
+            if (id.includes('framer-motion')) return 'vendor-motion';
+            if (id.includes('@radix-ui/')) return 'vendor-ui';
+            if (id.includes('lucide-react')) return 'vendor-icons';
+            if (id.includes('date-fns')) return 'vendor-dates';
+            return; // resto: deixar Rollup decidir
+          }
+
+          // ─── Feature chunks (agrupa lazy pages do mesmo módulo) ──────
+          // ORDEM IMPORTA: AdminReposicao deve vir ANTES de Admin (catchall)
+          if (id.includes('/src/pages/')) {
+            if (id.includes('/AdminReposicao')) return 'feature-reposicao';
+            if (id.includes('/Farmer')) return 'feature-farmer';
+            if (id.includes('/Financeiro')) return 'feature-financeiro';
+            if (id.includes('/Tint') || id.includes('/AdminTint')) return 'feature-tintometrico';
+            if (id.includes('/Governance')) return 'feature-governance';
+            if (id.includes('/Sales')) return 'feature-sales';
+            if (id.includes('/Recebimento')) return 'feature-estoque';
+            if (id.includes('/picking/')) return 'feature-estoque';
+            // Docs internos: baixo uso, cabe num bundle único
+            if (
+              id.includes('/DesignSystem') ||
+              id.includes('/DesignPreview') ||
+              id.includes('/UXRules') ||
+              id.includes('/TechnicalDocs') ||
+              id.includes('/TintApiContract')
+            ) return 'feature-docs';
+            // Admin (catchall depois de AdminReposicao + AdminTint)
+            if (id.includes('/Admin')) return 'feature-admin';
+            // Restantes (~15 pages cliente: Orders, Tools, Profile, etc.) ficam
+            // no chunk principal pra navegação inicial rápida do customer
+          }
         },
       },
     },


### PR DESCRIPTION
## Sumário

App.tsx lazy-loadava **119 páginas em chunks separados** — cada navegação inicial pra uma página nova pagava TTFB extra por chunk download. Esta mudança usa function-form de `manualChunks` pra agrupar peers do mesmo módulo em chunks compartilhados.

## Antes vs Depois

| Métrica | Antes | Depois |
|---|---|---|
| **Precache entries (PWA)** | 295 | **69** (4× menos) |
| **Lazy chunks por page** | 119 separados | Agrupados por feature |
| **Round-trips em navegação intra-módulo** | N pages = N chunks | 1 chunk pelo módulo inteiro |

## Feature chunks criados

| Chunk | Pages | Gzip |
|---|---|---|
| `feature-reposicao` | 22 | 224 KB |
| `feature-admin` | 20 | 179 KB |
| `feature-farmer` | 9 | 48 KB |
| `feature-sales` | 5 | 51 KB |
| `feature-docs` | DesignSystem/UXRules/TechnicalDocs/TintApiContract | 36 KB |
| `feature-financeiro` | 13 | 33 KB |
| `feature-tintometrico` | 12 | 38 KB |
| `feature-estoque` | Recebimento + picking | 15 KB |
| `feature-governance` | 6 | 10 KB |

Vendor splits expandidos: `vendor-icons` (lucide), `vendor-dates` (date-fns) adicionados além dos existentes (react, query, ui, supabase, charts, motion).

## Trade-off explícito

Chunks ficam maiores (`feature-reposicao` 783 KB raw / 224 KB gzip). Vite avisa via "chunks >500 kB". Trade-off intencional:

- **Cold cache**: 9 round-trips em vez de 119 (~13× menos)
- **Quente**: feature chunks raramente mudam (só quando alguma page do módulo é tocada); vendor chunks NUNCA mudam exceto em upgrade de dep
- **Padrão típico de uso**: usuário navega dentro de 1 módulo (vendedor em `/sales/*`, comprador em `/admin/reposicao/*`) — chunk fica em cache do browser pra demais navs

## Validação
- [x] `bun test` — 98/98 passam
- [x] `bun build` — limpa em 1m50s, **69 precache entries** (era 295)
- [x] `bun lint` — 1396 problemas (idêntico baseline; zero regressão)

## Net diff
1 file changed, 42 insertions(+), 7 deletions(-)

🤖 Generated with [Claude Code](https://claude.com/claude-code)