### PR TITLE
ci: adiciona workflow de validação (typecheck + test + build blocking)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,57 @@
+# CI — roda em PRs + pushes pra main.
+#
+# Lição do PR #4 (visual redesign, mergeado em 2026-05-14): o PR mergeou com 66
+# classes Tailwind quebradas em produção (sed cego deixou `bg-status-*-bg0` em
+# vez de `bg-status-*-bg`). Build NUNCA rodou antes do merge. Este workflow
+# garante que isso não repita.
+#
+# Decisões de bloqueio:
+# - typecheck (tsc --noEmit): blocking — qualquer regressão de tipos quebra o PR
+# - test (vitest run): blocking — regressão de comportamento documentado
+# - build (vite build): blocking — pega Tailwind quebrado + import errors + PWA setup
+# - lint (eslint): informational — main hoje tem 1300 errors herdados (97%
+#   no-explicit-any). Bloqueá-lo pararia todo PR. Quando TypeScript strict mode
+#   roadmap zerar a dívida, virar blocking.
+
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install deps
+        run: bun install --frozen-lockfile
+
+      # ─── Blocking checks ────────────────────────────────────────────
+      - name: Type check
+        run: bunx tsc --noEmit
+
+      - name: Tests
+        run: bun run test
+
+      - name: Build
+        run: bun run build
+        env:
+          # Build precisa do mesmo ambiente que Lovable produção.
+          # Se algum VITE_* for required no futuro, adicionar aqui.
+          NODE_ENV: production
+
+      # ─── Informational (não bloqueia merge) ─────────────────────────
+      - name: Lint (informational)
+        run: bun lint
+        continue-on-error: true


### PR DESCRIPTION
## Sumário

**Lição do PR #4** (visual redesign, mergeado em 2026-05-14): mergeou com **66 classes Tailwind quebradas em produção** (sed cego deixou `bg-status-*-bg0` em vez de `bg-status-*-bg`). Build **NUNCA rodou** antes do merge. Este workflow garante que isso não repita.

## Decisões de bloqueio

| Check | Status | Por quê |
|---|---|---|
| `typecheck` (tsc --noEmit) | 🔴 Blocking | Regressões de tipos quebram PR |
| `test` (vitest run) | 🔴 Blocking | Regressão de comportamento documentado |
| `build` (vite build) | 🔴 Blocking | Pega Tailwind quebrado + import errors + PWA setup |
| `lint` (eslint) | 🟡 Informational (continue-on-error) | Main hoje tem 1300 errors herdados (97% `no-explicit-any`). Bloqueá-lo pararia todo PR. Quando TS strict mode roadmap zerar a dívida, virar blocking. |

## Setup

- Runner: `ubuntu-latest`, timeout 15min
- Bun via `oven-sh/setup-bun@v2`
- Trigger: PR pra `main` + push pra `main`

## Próximos passos (no GitHub UI — não cabe em PR)

Pra fechar o loop totalmente, configurar **Branch Protection** em Settings → Branches → main:
- [ ] Require status checks to pass before merging: marcar `validate` job
- [ ] Require branches to be up to date before merging (opcional)
- [ ] Restrict who can push to matching branches (opcional)

## Validação

Como este é o **primeiro workflow do repo**, ele vai rodar pela primeira vez quando este próprio PR for aberto — auto-validação. Se passar nas 4 checks, está bom pra mergear.

## Net diff
1 file changed, 57 insertions(+)

🤖 Generated with [Claude Code](https://claude.com/claude-code)