### PR TITLE
feat(sales): soft-delete em sales_orders pra audit trail (compliance)

### DIFF
--- a/src/pages/SalesOrders.tsx
+++ b/src/pages/SalesOrders.tsx
@@ -84,6 +84,9 @@ const SalesOrders = () => {
       const { data, error } = await supabase
         .from('sales_orders')
         .select('*')
+        // Filtra soft-deletes (deleted_at IS NOT NULL = pedido excluído).
+        // Usa partial index idx_sales_orders_active em deleted_at IS NULL.
+        .is('deleted_at', null)
         .order('created_at', { ascending: false })
         .range(start, start + PAGE_SIZE - 1);
       if (error) throw error;
@@ -170,7 +173,12 @@ const SalesOrders = () => {
 
   const loading = salesQuery.isLoading || afiacaoQuery.isLoading;
 
-  // Optimistic delete — atualiza cache de useInfiniteQuery, rollback em erro
+  // Soft-delete + Omie exclude. Fluxo:
+  // 1. Optimistic remove do cache (UI atualiza instantaneamente)
+  // 2. UPDATE sales_orders SET deleted_at = now() (audit trail compliance)
+  // 3. Call Omie excluir_pedido
+  // 4. Se Omie falhar: rollback do soft-delete + restaura cache
+  // 5. Se Supabase update falhar: rollback do cache, NÃO chama Omie
   const deleteOrder = async (order: SalesOrder) => {
     const snapshot = queryClient.getQueryData(['sales-orders-paginated']);
     queryClient.setQueryData(['sales-orders-paginated'], (old: any) => {
@@ -185,6 +193,21 @@ const SalesOrders = () => {
       next.delete(order.id);
       return next;
     });
+
+    // 1. Soft-delete local primeiro (audit trail antes do Omie)
+    const { error: softErr } = await supabase
+      .from('sales_orders')
+      .update({ deleted_at: new Date().toISOString() })
+      .eq('id', order.id);
+
+    if (softErr) {
+      console.error(softErr);
+      queryClient.setQueryData(['sales-orders-paginated'], snapshot);
+      toast.error('Erro ao excluir pedido', { description: softErr.message });
+      return;
+    }
+
+    // 2. Omie exclude — se falhar, rollback do soft-delete
     try {
       const { error } = await supabase.functions.invoke('omie-vendas-sync', {
         body: {
@@ -197,7 +220,12 @@ const SalesOrders = () => {
       toast.success('Pedido excluído');
     } catch (e: any) {
       console.error(e);
-      queryClient.setQueryData(['sales-orders-paginated'], snapshot); // rollback
+      // Rollback do soft-delete (deleted_at = null) — pedido volta a ser ativo
+      await supabase
+        .from('sales_orders')
+        .update({ deleted_at: null })
+        .eq('id', order.id);
+      queryClient.setQueryData(['sales-orders-paginated'], snapshot);
       toast.error('Erro ao excluir pedido', { description: e?.message });
     }
   };
@@ -217,8 +245,23 @@ const SalesOrders = () => {
     });
     setSelectedIds(new Set());
 
+    // 1. Soft-delete em batch (1 UPDATE com .in('id', ...))
+    const nowIso = new Date().toISOString();
+    const { error: softErr } = await supabase
+      .from('sales_orders')
+      .update({ deleted_at: nowIso })
+      .in('id', Array.from(deleteIds));
+
+    if (softErr) {
+      console.error(softErr);
+      queryClient.setQueryData(['sales-orders-paginated'], snapshot);
+      toast.error(`Erro ao excluir pedidos`, { description: softErr.message });
+      return;
+    }
+
+    // 2. Omie exclude sequencial (não floodar). Rollback do deleted_at em falhas.
+    const failedIds: string[] = [];
     let success = 0;
-    let failed = 0;
     for (const o of toDelete) {
       try {
         const { error } = await supabase.functions.invoke('omie-vendas-sync', {
@@ -231,9 +274,18 @@ const SalesOrders = () => {
         if (error) throw error;
         success++;
       } catch (e) {
-        failed++;
+        failedIds.push(o.id);
         console.error(e);
       }
+    }
+    const failed = failedIds.length;
+
+    // Rollback do soft-delete só pros que falharam no Omie
+    if (failedIds.length > 0) {
+      await supabase
+        .from('sales_orders')
+        .update({ deleted_at: null })
+        .in('id', failedIds);
     }
 
     if (failed === 0) {
@@ -242,7 +294,21 @@ const SalesOrders = () => {
       queryClient.setQueryData(['sales-orders-paginated'], snapshot); // rollback completo
       toast.error(`Falhou: ${failed} pedido(s) não puderam ser excluídos`);
     } else {
-      // Parcial — mantém o sucesso
+      // Parcial — restaura os que falharam no cache (já temos deleted_at=null no DB)
+      const failedSet = new Set(failedIds);
+      queryClient.setQueryData(['sales-orders-paginated'], (old: any) => {
+        if (!old || !snapshot) return old;
+        // Pega as rows que falharam do snapshot original e reinjeta na primeira página
+        const failedRows = (snapshot as any).pages
+          .flat()
+          .filter((o: SalesOrder) => failedSet.has(o.id));
+        return {
+          ...old,
+          pages: old.pages.map((page: SalesOrder[], i: number) =>
+            i === 0 ? [...failedRows, ...page] : page,
+          ),
+        };
+      });
       toast.warning(`${success} excluído(s), ${failed} falharam`);
     }
   };

--- a/supabase/migrations/20260517125150_2991bf14-9827-4ca1-932c-06548ba21692.sql
+++ b/supabase/migrations/20260517125150_2991bf14-9827-4ca1-932c-06548ba21692.sql
@@ -1,0 +1,23 @@
+-- Soft-delete em sales_orders pra audit trail de exclusões.
+-- Identificado pela auditoria (CLAUDE.md §10): SalesOrders.deleteOrder hoje chama
+-- excluir_pedido no Omie direto sem registro local de quando/por-quem foi excluído.
+-- Esta migration adiciona deleted_at pra:
+--   1. Audit trail (compliance) — sabemos exatamente quando cada pedido foi removido
+--   2. Optimistic rollback — se chamada do Omie falhar, restauramos deleted_at = NULL
+--   3. Base pra "Lixeira" / restore UI no futuro (out of scope deste PR)
+--
+-- UX permanece como "excluir permanentemente do usuário" — soft-delete é
+-- transparente pra ele. O Omie ainda é chamado (sem mudança semântica).
+
+ALTER TABLE public.sales_orders
+  ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ NULL;
+
+COMMENT ON COLUMN public.sales_orders.deleted_at IS
+  'Soft-delete timestamp. NULL = ativo. SalesOrders.deleteOrder seta antes de chamar Omie; se Omie falhar, rollback pra NULL. Queries default filtram WHERE deleted_at IS NULL.';
+
+-- Index parcial — queries default filtram WHERE deleted_at IS NULL.
+-- Partial index é mais eficiente que index full porque a maioria das rows nunca
+-- vai estar excluída.
+CREATE INDEX IF NOT EXISTS idx_sales_orders_active
+  ON public.sales_orders (created_at DESC)
+  WHERE deleted_at IS NULL;


### PR DESCRIPTION
## Sumário

Auditoria identificou que `SalesOrders.deleteOrder` chamava Omie `excluir_pedido` direto **sem registro local de quando o pedido foi removido** — risco de compliance. Este PR adiciona `deleted_at` e refatora o fluxo pra:

1. **Soft-delete primeiro** (audit trail)
2. **Omie exclude depois**
3. **Rollback automático** se Omie falhar

**UX permanece** como "excluir permanentemente" do ponto de vista do usuário. Soft-delete é transparente — só compliance/auditoria ganham acesso ao histórico.

## Mudanças

### Migration (nova)
- [`supabase/migrations/20260517125150_*.sql`](supabase/migrations/20260517125150_2991bf14-9827-4ca1-932c-06548ba21692.sql)
- `ALTER TABLE sales_orders ADD COLUMN deleted_at TIMESTAMPTZ NULL`
- `CREATE INDEX idx_sales_orders_active ON (created_at DESC) WHERE deleted_at IS NULL` — partial index, eficiente porque maioria das rows nunca está excluída

### SalesOrders.tsx
- `salesQuery`: adiciona `.is('deleted_at', null)` no select (usa o partial index)
- `deleteOrder`: novo fluxo
  1. Optimistic cache remove
  2. `UPDATE sales_orders SET deleted_at = now()`
  3. Se UPDATE falha → rollback cache, toast erro, **ABORT** (não chama Omie)
  4. Omie `excluir_pedido`
  5. Se Omie falha → `UPDATE deleted_at = null`, rollback cache, toast erro
- `deleteSelected` (bulk): mesmo padrão + restaura no cache os IDs que falharam no Omie

## Trade-offs / escopo

- **Sem UI de "restore"** — soft-delete é só audit trail. Quando precisar de Lixeira/restore, criar tab "Excluídos" + action de restore (PR próprio).
- **Omie continua sendo chamado** — não é soft-delete "verdadeiro" (reversível). Pra reversibilidade total, precisaria postpone do Omie call (job assíncrono).
- `deleted_at` agora existe em todos os pedidos cancelados via UI. Pedidos deletados manualmente no DB antes desta migration ficam sem registro (`deleted_at = null` mesmo se removidos do Omie). Aceitável (sem dado histórico pra retroceder).

## Validação

- [x] `bun test` — 98/98 passam
- [x] `bun build` — limpa
- [x] `bun lint` — 1398 problemas (+2 vs baseline 1396 — `(old: any)` em queryClient calls, mesmo padrão do PR #30)

## ⚠️ Próximo passo MANUAL

A migration precisa ser aplicada no Supabase:
```bash
supabase db push
# OU
# Dashboard → SQL Editor → Run migration
```

Sem isso, o `deleteOrder` vai falhar no step UPDATE (coluna não existe).

## Net diff
2 files changed, 94 insertions(+), 5 deletions(-)

🤖 Generated with [Claude Code](https://claude.com/claude-code)