### PR TITLE
Dashboard V3 — polish + drag-reorder + 4 specs follow-up

### DIFF
--- a/src/hooks/dashboard/useEstoqueZone.ts
+++ b/src/hooks/dashboard/useEstoqueZone.ts
@@ -5,6 +5,7 @@ import { supabase } from '@/integrations/supabase/client';
 import { useDashboardCompany } from '@/hooks/useDashboardCompany';
 import { useCockpitChannel } from '@/hooks/dashboard/useCockpitChannel';
 import { variantFromScore, type PriorityCandidate } from '@/lib/dashboard/priority-rules';
+import { formatCount } from '@/lib/dashboard/format';
 import type { KpiSpec } from '@/components/dashboard/cockpit/CockpitKpiRow';
 import type { TopListItem } from '@/components/dashboard/cockpit/CockpitTopList';
 
@@ -116,9 +117,9 @@ export function useEstoqueZone() {
   const kpis: KpiSpec[] = useMemo(() => {
     if (!data) return [];
     return [
-      { label: 'NF pendentes', value: String(data.nfPendentes) },
-      { label: 'Picking abertos', value: String(data.pickingAbertos) },
-      { label: 'Recebidos hoje', value: String(data.recebimentosHoje) },
+      { label: 'NF pendentes', value: formatCount(data.nfPendentes) },
+      { label: 'Picking abertos', value: formatCount(data.pickingAbertos) },
+      { label: 'Recebidos hoje', value: formatCount(data.recebimentosHoje) },
     ];
   }, [data]);
 

--- a/src/hooks/dashboard/useReposicaoZone.ts
+++ b/src/hooks/dashboard/useReposicaoZone.ts
@@ -5,6 +5,7 @@ import { supabase } from '@/integrations/supabase/client';
 import { useDashboardCompany } from '@/hooks/useDashboardCompany';
 import { useCockpitChannel } from '@/hooks/dashboard/useCockpitChannel';
 import { variantFromScore, type PriorityCandidate } from '@/lib/dashboard/priority-rules';
+import { formatCount } from '@/lib/dashboard/format';
 import type { KpiSpec } from '@/components/dashboard/cockpit/CockpitKpiRow';
 import type { TopListItem } from '@/components/dashboard/cockpit/CockpitTopList';
 
@@ -81,9 +82,9 @@ export function useReposicaoZone() {
   const kpis: KpiSpec[] = useMemo(() => {
     if (!data) return [];
     return [
-      { label: 'Sugeridos prontos', value: String(data.sugeridosProntos) },
-      { label: 'Alertas ativos', value: String(data.alertasAtivos) },
-      { label: 'Aumentos 7d', value: String(data.aumentos7d) },
+      { label: 'Sugeridos prontos', value: formatCount(data.sugeridosProntos) },
+      { label: 'Alertas ativos', value: formatCount(data.alertasAtivos) },
+      { label: 'Aumentos 7d', value: formatCount(data.aumentos7d) },
     ];
   }, [data]);
 

--- a/src/hooks/dashboard/useSistemaZone.ts
+++ b/src/hooks/dashboard/useSistemaZone.ts
@@ -4,6 +4,7 @@ import { UserCheck } from 'lucide-react';
 import { supabase } from '@/integrations/supabase/client';
 import { useCockpitChannel } from '@/hooks/dashboard/useCockpitChannel';
 import { variantFromScore, type PriorityCandidate } from '@/lib/dashboard/priority-rules';
+import { formatCount } from '@/lib/dashboard/format';
 import type { KpiSpec } from '@/components/dashboard/cockpit/CockpitKpiRow';
 import type { TopListItem } from '@/components/dashboard/cockpit/CockpitTopList';
 
@@ -84,7 +85,7 @@ export function useSistemaZone() {
   const kpis: KpiSpec[] = useMemo(() => {
     if (!data) return [];
     return [
-      { label: 'Aprovações', value: String(data.aprovacoesPendentes) },
+      { label: 'Aprovações', value: formatCount(data.aprovacoesPendentes) },
       { label: 'Sync Omie', value: data.syncOmie ?? '—' },
       { label: 'Sync Sayerlack', value: data.syncSayerlack ?? '—' },
     ];

--- a/src/hooks/dashboard/useSistemaZone.ts
+++ b/src/hooks/dashboard/useSistemaZone.ts
@@ -2,7 +2,6 @@ import { useQuery } from '@tanstack/react-query';
 import { useMemo } from 'react';
 import { UserCheck } from 'lucide-react';
 import { supabase } from '@/integrations/supabase/client';
-import { useCockpitChannel } from '@/hooks/dashboard/useCockpitChannel';
 import { variantFromScore, type PriorityCandidate } from '@/lib/dashboard/priority-rules';
 import { formatCount } from '@/lib/dashboard/format';
 import type { KpiSpec } from '@/components/dashboard/cockpit/CockpitKpiRow';
@@ -11,12 +10,9 @@ import type { TopListItem } from '@/components/dashboard/cockpit/CockpitTopList'
 export function useSistemaZone() {
   const queryKey = ['dashboard', 'sistema'];
 
-  const { isLive } = useCockpitChannel({
-    zone: 'sistema',
-    table: 'profiles',
-    filter: 'is_approved=eq.false',
-    queryKeys: [queryKey],
-  });
+  // Sem Realtime channel intencional: tabela `profiles` é barulhenta demais pra
+  // streamar (qualquer login atualiza). Refetch 60s cobre o caso de uso.
+  const isLive = false;
 
   const { data, isLoading, isError, refetch } = useQuery({
     queryKey,

--- a/src/hooks/dashboard/useTintometricoZone.ts
+++ b/src/hooks/dashboard/useTintometricoZone.ts
@@ -5,6 +5,7 @@ import { supabase } from '@/integrations/supabase/client';
 import { useDashboardCompany } from '@/hooks/useDashboardCompany';
 import { useCockpitChannel } from '@/hooks/dashboard/useCockpitChannel';
 import { variantFromScore, type PriorityCandidate } from '@/lib/dashboard/priority-rules';
+import { formatCount, formatImportStatus } from '@/lib/dashboard/format';
 import type { KpiSpec } from '@/components/dashboard/cockpit/CockpitKpiRow';
 import type { TopListItem } from '@/components/dashboard/cockpit/CockpitTopList';
 
@@ -110,10 +111,11 @@ export function useTintometricoZone() {
 
   const kpis: KpiSpec[] = useMemo(() => {
     if (!data) return [];
+    const lastImport = data.lastImport as { status?: string | null } | null;
     return [
-      { label: 'Fórmulas', value: String(data.totalFormulas) },
-      { label: 'SKUs mapeados', value: `${data.skusMapped}/${data.skusTotal}` },
-      { label: 'Última import.', value: data.lastImport?.status ?? '—' },
+      { label: 'Fórmulas', value: formatCount(data.totalFormulas) },
+      { label: 'SKUs mapeados', value: `${formatCount(data.skusMapped)}/${formatCount(data.skusTotal)}` },
+      { label: 'Última import.', value: formatImportStatus(lastImport?.status) },
     ];
   }, [data]);
 

--- a/src/hooks/dashboard/useVendasZone.ts
+++ b/src/hooks/dashboard/useVendasZone.ts
@@ -5,6 +5,7 @@ import { supabase } from '@/integrations/supabase/client';
 import { useDashboardCompany } from '@/hooks/useDashboardCompany';
 import { useCockpitChannel } from '@/hooks/dashboard/useCockpitChannel';
 import { variantFromScore, type PriorityCandidate } from '@/lib/dashboard/priority-rules';
+import { formatCount } from '@/lib/dashboard/format';
 import type { KpiSpec } from '@/components/dashboard/cockpit/CockpitKpiRow';
 import type { TopListItem } from '@/components/dashboard/cockpit/CockpitTopList';
 
@@ -116,8 +117,8 @@ export function useVendasZone() {
     if (!data) return [];
     return [
       { label: 'Faturado hoje', value: fmtBRL(data.faturadoHoje), deltaPct: data.deltaPct },
-      { label: 'Pedidos hoje', value: String(data.pedidosHoje) },
-      { label: 'Aguardando', value: String(data.orcamentosAguardando) },
+      { label: 'Pedidos hoje', value: formatCount(data.pedidosHoje) },
+      { label: 'Aguardando', value: formatCount(data.orcamentosAguardando) },
     ];
   }, [data]);
 

--- a/src/lib/dashboard/__tests__/format.test.ts
+++ b/src/lib/dashboard/__tests__/format.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { formatCount, formatImportStatus } from '../format';
+
+describe('formatCount', () => {
+  it('renders small counts raw', () => {
+    expect(formatCount(0)).toBe('0');
+    expect(formatCount(7)).toBe('7');
+    expect(formatCount(999)).toBe('999');
+  });
+
+  it('renders 4-digit counts with pt-BR separator', () => {
+    expect(formatCount(1000)).toBe('1.000');
+    expect(formatCount(5273)).toBe('5.273');
+    expect(formatCount(9999)).toBe('9.999');
+  });
+
+  it('renders 5-6 digit counts compact "k"', () => {
+    expect(formatCount(10_000)).toBe('10k');
+    expect(formatCount(481_721)).toBe('482k');
+    expect(formatCount(999_999)).toBe('1000k');
+  });
+
+  it('renders 7+ digit counts compact "M"', () => {
+    expect(formatCount(1_000_000)).toBe('1,0M');
+    expect(formatCount(1_234_567)).toBe('1,2M');
+  });
+
+  it('handles non-finite gracefully', () => {
+    expect(formatCount(Number.NaN)).toBe('—');
+    expect(formatCount(Number.POSITIVE_INFINITY)).toBe('—');
+  });
+});
+
+describe('formatImportStatus', () => {
+  it('maps known statuses to short labels', () => {
+    expect(formatImportStatus('processado')).toBe('ok');
+    expect(formatImportStatus('concluido')).toBe('ok');
+    expect(formatImportStatus('processando')).toBe('em curso');
+    expect(formatImportStatus('erro')).toBe('erro');
+    expect(formatImportStatus('parcial')).toBe('parcial');
+  });
+
+  it('returns em-dash for null/undefined/empty', () => {
+    expect(formatImportStatus(null)).toBe('—');
+    expect(formatImportStatus(undefined)).toBe('—');
+    expect(formatImportStatus('')).toBe('—');
+  });
+
+  it('truncates unknown long statuses with ellipsis', () => {
+    expect(formatImportStatus('algumarararara')).toBe('algumarar…');
+    expect(formatImportStatus('curto')).toBe('curto');
+  });
+});

--- a/src/lib/dashboard/format.ts
+++ b/src/lib/dashboard/format.ts
@@ -1,0 +1,46 @@
+/**
+ * Formatadores compactos pra KPIs do cockpit.
+ * Ficam aqui (e não em `delta-aggregators`) pra ser reusados em qualquer zona
+ * sem acoplar com a lógica de "desde a última visita".
+ */
+
+/**
+ * Formata contagens inteiras com pt-BR thousand separator + sufixo compacto.
+ *
+ * - `< 1_000`        → "847"
+ * - `< 10_000`       → "5.273"   (mantém precisão pra 4 dígitos)
+ * - `< 1_000_000`    → "481k"
+ * - `>= 1_000_000`   → "1,2M"
+ *
+ * Mantém legibilidade em KPI cell estreita (~120px @ text-xl).
+ */
+export function formatCount(n: number): string {
+  if (!Number.isFinite(n)) return '—';
+  const abs = Math.abs(n);
+  if (abs < 1_000) return String(Math.round(n));
+  if (abs < 10_000) return n.toLocaleString('pt-BR');
+  if (abs < 1_000_000) return `${Math.round(n / 1_000)}k`;
+  return `${(n / 1_000_000).toFixed(1).replace('.', ',')}M`;
+}
+
+/**
+ * Labels curtas pros status de `tint_importacoes.status` que aparecem no KPI
+ * "Última import." — o texto cru ("processado", "processando") estoura o cell
+ * e vira "processa..." truncado feio.
+ */
+export function formatImportStatus(status: string | null | undefined): string {
+  if (!status) return '—';
+  switch (status) {
+    case 'concluido':
+    case 'processado':
+      return 'ok';
+    case 'processando':
+      return 'em curso';
+    case 'erro':
+      return 'erro';
+    case 'parcial':
+      return 'parcial';
+    default:
+      return status.length > 10 ? `${status.slice(0, 9)}…` : status;
+  }
+}

--- a/supabase/migrations/20260517100000_enable_realtime_dashboard_v3.sql
+++ b/supabase/migrations/20260517100000_enable_realtime_dashboard_v3.sql
@@ -1,0 +1,58 @@
+-- Dashboard V3: habilita Realtime nas tabelas que cada zona escuta via
+-- `useCockpitChannel`. Sem isso a Subscribe callback nunca recebe SUBSCRIBED
+-- e o LiveBadge nunca aparece.
+--
+-- Já estavam habilitadas: orders, nfe_recebimentos, pedido_compra_sugerido,
+-- sku_parametros, farmer_calls (em migrations anteriores).
+--
+-- Adicionando as 4 restantes que as zonas do Dashboard V3 escutam:
+-- - sales_orders   → VendasZone
+-- - picking_tasks  → EstoqueZone (complementa nfe_recebimentos)
+-- - eventos_outlier → ReposicaoZone (alertas)
+-- - tint_importacoes → TintometricoZone
+--
+-- Não habilitamos `profiles` (SistemaZone) por enquanto: tabela tem volume
+-- alto de mudanças (logins atualizam last_seen etc.) e o canal é filtrado
+-- por `is_approved=eq.false` que o Realtime filter respeita só no client —
+-- backend ainda envia tudo. Trade-off documentado: SistemaZone fica sem
+-- LiveBadge, atualiza via `refetchInterval 60s`. Revisar quando houver
+-- dashboard_visits stream.
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_publication WHERE pubname = 'supabase_realtime'
+  ) THEN
+    -- sales_orders
+    IF NOT EXISTS (
+      SELECT 1 FROM pg_publication_tables
+      WHERE pubname = 'supabase_realtime' AND tablename = 'sales_orders'
+    ) THEN
+      ALTER PUBLICATION supabase_realtime ADD TABLE public.sales_orders;
+    END IF;
+
+    -- picking_tasks
+    IF NOT EXISTS (
+      SELECT 1 FROM pg_publication_tables
+      WHERE pubname = 'supabase_realtime' AND tablename = 'picking_tasks'
+    ) THEN
+      ALTER PUBLICATION supabase_realtime ADD TABLE public.picking_tasks;
+    END IF;
+
+    -- eventos_outlier
+    IF NOT EXISTS (
+      SELECT 1 FROM pg_publication_tables
+      WHERE pubname = 'supabase_realtime' AND tablename = 'eventos_outlier'
+    ) THEN
+      ALTER PUBLICATION supabase_realtime ADD TABLE public.eventos_outlier;
+    END IF;
+
+    -- tint_importacoes
+    IF NOT EXISTS (
+      SELECT 1 FROM pg_publication_tables
+      WHERE pubname = 'supabase_realtime' AND tablename = 'tint_importacoes'
+    ) THEN
+      ALTER PUBLICATION supabase_realtime ADD TABLE public.tint_importacoes;
+    END IF;
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary

Polish do Dashboard V3 (PR #35) + drag-reorder funcional + schema audit fixes + 4 specs novas pro próximo sprint.

### Onda 1 — fixes imediatos
- **`formatCount` + `formatImportStatus`** (8 tests): `481721` → `482k`, `5273` → `5.273`, `processado` → `ok` (evita `processa...` truncado feio). Aplicado em 5 zonas.
- **Realtime publication**: migration habilita `sales_orders`/`picking_tasks`/`eventos_outlier`/`tint_importacoes`. Sem isso LiveBadge nunca aparecia.
- **Schema audit**: 
  - FinanceiroZone agora usa `supabase.rpc('fin_projecao_13_semanas', ...)` (é FUNCTION, não tabela)
  - SistemaZone substitui Sync Omie/Sayerlack (`sync_logs` não existe) por **Staff ativos** + **Última atividade** (max created_at de orders/sales_orders)
- **`useLastVisit` F5 bug**: só escreve unmount se sessão ≥ 5min (antes F5 anulava deltas)
- **Drag-reorder + hide zonas**: botão "Personalizar dashboard" do footer agora funciona. Per-persona localStorage. Esc/Concluir sai do edit mode. Banner mostra zonas escondidas.

### Onda 1.4 — spec PostHog
[docs/superpowers/specs/2026-05-17-posthog-dashboard-v3-analytics.md](docs/superpowers/specs/2026-05-17-posthog-dashboard-v3-analytics.md): 8 charts + 2 alerts pra criar no PostHog UI. Mede adoção, persona accuracy, funil engage, bounce zones, realtime reliability.

### Onda 2 — specs próximo sprint
- [user-departments-design.md](docs/superpowers/specs/2026-05-17-user-departments-design.md): substitui heurística de persona por persistência server (3-5d)
- [dashboard-visits-design.md](docs/superpowers/specs/2026-05-17-dashboard-visits-design.md): cross-device lastVisit + análise histórica (1-2d)
- [customer-dashboard-redesign-brainstorm.md](docs/superpowers/specs/2026-05-17-customer-dashboard-redesign-brainstorm.md): pré-spec, exige research

### Onda 3 — backlog explícito
[dashboard-v3-backlog.md](docs/superpowers/specs/2026-05-17-dashboard-v3-backlog.md): 10 itens deferidos com razão + critério de reativação.

## Stats
- 11 arquivos modificados, +1200 / -90 LOC
- 139/139 tests pass (8 novos pra `format.ts`)
- `bun build` exit 0
- 3 eventos PostHog novos pra drag-reorder

## Pós-merge
1. Aplicar migration `20260517100000_enable_realtime_dashboard_v3.sql` no Supabase
2. Criar PostHog dashboard seguindo spec
3. Avaliar specs Onda 2 (user_departments tem maior ROI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)