### PR TITLE
refactor(toast): migrate 48 remaining files de useToast wrapper pra sonner direto

### DIFF
--- a/src/components/AddToolDialog.tsx
+++ b/src/components/AddToolDialog.tsx
@@ -6,7 +6,7 @@ import { Input } from '@/components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
-import { useToast } from '@/hooks/use-toast';
+import { toast } from 'sonner';
 import { Loader2, Plus, ChevronRight, ChevronLeft, Search } from 'lucide-react';
 import { ToolImageIdentifier } from '@/components/ToolImageIdentifier';
 
@@ -37,8 +37,7 @@ interface AddToolDialogProps {
 
 export function AddToolDialog({ open, onOpenChange, onToolAdded, categories, targetUserId }: AddToolDialogProps) {
   const { user, isStaff } = useAuth();
-  const { toast } = useToast();
-  
+
   const [step, setStep] = useState<'category' | 'specs'>('category');
   const [selectedCategory, setSelectedCategory] = useState<string>('');
   const [specifications, setSpecifications] = useState<ToolSpecification[]>([]);
@@ -149,10 +148,8 @@ export function AddToolDialog({ open, onOpenChange, onToolAdded, categories, tar
   const validateSpecs = (): boolean => {
     for (const spec of specifications) {
       if (spec.is_required && !specValues[spec.spec_key]) {
-        toast({
-          title: 'Campo obrigatório',
+        toast.error('Campo obrigatório', {
           description: `Preencha o campo: ${spec.spec_label}`,
-          variant: 'destructive',
         });
         return false;
       }
@@ -180,8 +177,7 @@ export function AddToolDialog({ open, onOpenChange, onToolAdded, categories, tar
 
       if (error) throw error;
 
-      toast({
-        title: 'Ferramenta adicionada!',
+      toast.success('Ferramenta adicionada!', {
         description: generatedName,
       });
 
@@ -189,10 +185,8 @@ export function AddToolDialog({ open, onOpenChange, onToolAdded, categories, tar
       onToolAdded();
     } catch (error) {
       console.error('Error adding tool:', error);
-      toast({
-        title: 'Erro ao adicionar',
+      toast.error('Erro ao adicionar', {
         description: 'Não foi possível adicionar a ferramenta',
-        variant: 'destructive',
       });
     } finally {
       setIsLoading(false);

--- a/src/components/ForgotPasswordDialog.tsx
+++ b/src/components/ForgotPasswordDialog.tsx
@@ -11,7 +11,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
-import { useToast } from '@/hooks/use-toast';
+import { toast } from 'sonner';
 import { supabase } from '@/integrations/supabase/client';
 import { cn } from '@/lib/utils';
 
@@ -23,7 +23,6 @@ interface ForgotPasswordDialogProps {
 }
 
 export const ForgotPasswordDialog = ({ open, onOpenChange }: ForgotPasswordDialogProps) => {
-  const { toast } = useToast();
   const [email, setEmail] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const [isSent, setIsSent] = useState(false);
@@ -52,16 +51,13 @@ export const ForgotPasswordDialog = ({ open, onOpenChange }: ForgotPasswordDialo
       if (error) throw error;
 
       setIsSent(true);
-      toast({
-        title: 'E-mail enviado!',
+      toast.success('E-mail enviado!', {
         description: 'Verifique sua caixa de entrada',
       });
     } catch (error: any) {
       console.error('Error sending reset email:', error);
-      toast({
-        title: 'Erro ao enviar e-mail',
+      toast.error('Erro ao enviar e-mail', {
         description: error.message || 'Tente novamente mais tarde',
-        variant: 'destructive',
       });
     } finally {
       setIsLoading(false);

--- a/src/components/OrderChat.tsx
+++ b/src/components/OrderChat.tsx
@@ -4,7 +4,7 @@ import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
-import { useToast } from '@/hooks/use-toast';
+import { toast } from 'sonner';
 import { Send, Loader2 } from 'lucide-react';
 import { format } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
@@ -26,7 +26,6 @@ interface OrderChatProps {
 
 export function OrderChat({ orderId }: OrderChatProps) {
   const { user, isStaff } = useAuth();
-  const { toast } = useToast();
   const [messages, setMessages] = useState<Message[]>([]);
   const [newMessage, setNewMessage] = useState('');
   const [sending, setSending] = useState(false);
@@ -94,7 +93,7 @@ export function OrderChat({ orderId }: OrderChatProps) {
       setNewMessage('');
     } catch (error) {
       console.error('Error sending message:', error);
-      toast({ title: 'Erro ao enviar mensagem', variant: 'destructive' });
+      toast.error('Erro ao enviar mensagem');
     } finally {
       setSending(false);
     }

--- a/src/components/OrderReview.tsx
+++ b/src/components/OrderReview.tsx
@@ -4,7 +4,7 @@ import { Textarea } from '@/components/ui/textarea';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
-import { useToast } from '@/hooks/use-toast';
+import { toast } from 'sonner';
 import { Star, Loader2 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
@@ -15,7 +15,6 @@ interface OrderReviewProps {
 
 export function OrderReview({ orderId, onReviewSubmitted }: OrderReviewProps) {
   const { user } = useAuth();
-  const { toast } = useToast();
   const [open, setOpen] = useState(false);
   const [rating, setRating] = useState(0);
   const [hoveredRating, setHoveredRating] = useState(0);
@@ -36,18 +35,18 @@ export function OrderReview({ orderId, onReviewSubmitted }: OrderReviewProps) {
 
       if (error) {
         if (error.code === '23505') {
-          toast({ title: 'Você já avaliou este pedido', variant: 'default' });
+          toast('Você já avaliou este pedido');
         } else {
           throw error;
         }
       } else {
-        toast({ title: '⭐ Obrigado pela avaliação!' });
+        toast.success('⭐ Obrigado pela avaliação!');
         onReviewSubmitted?.();
       }
       setOpen(false);
     } catch (error) {
       console.error('Error submitting review:', error);
-      toast({ title: 'Erro ao enviar avaliação', variant: 'destructive' });
+      toast.error('Erro ao enviar avaliação');
     } finally {
       setSubmitting(false);
     }

--- a/src/components/PhotoUpload.tsx
+++ b/src/components/PhotoUpload.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef } from 'react';
 import { Button } from '@/components/ui/button';
 import { supabase } from '@/integrations/supabase/client';
-import { useToast } from '@/hooks/use-toast';
+import { toast } from 'sonner';
 import { logger } from '@/lib/logger';
 import { Camera, X, Loader2, Image as ImageIcon } from 'lucide-react';
 import { cn } from '@/lib/utils';
@@ -15,7 +15,6 @@ interface PhotoUploadProps {
 }
 
 export function PhotoUpload({ photos, onPhotosChange, userId, maxPhotos = 5, disabled = false }: PhotoUploadProps) {
-  const { toast } = useToast();
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [uploading, setUploading] = useState(false);
 
@@ -24,10 +23,8 @@ export function PhotoUpload({ photos, onPhotosChange, userId, maxPhotos = 5, dis
     if (!files || files.length === 0) return;
 
     if (photos.length + files.length > maxPhotos) {
-      toast({
-        title: 'Limite de fotos',
+      toast.error('Limite de fotos', {
         description: `Você pode adicionar no máximo ${maxPhotos} fotos`,
-        variant: 'destructive',
       });
       return;
     }
@@ -39,20 +36,16 @@ export function PhotoUpload({ photos, onPhotosChange, userId, maxPhotos = 5, dis
       for (const file of Array.from(files)) {
         // Validate file type
         if (!file.type.startsWith('image/')) {
-          toast({
-            title: 'Arquivo inválido',
+          toast.error('Arquivo inválido', {
             description: 'Apenas imagens são permitidas',
-            variant: 'destructive',
           });
           continue;
         }
 
         // Validate file size (max 5MB)
         if (file.size > 5 * 1024 * 1024) {
-          toast({
-            title: 'Arquivo muito grande',
+          toast.error('Arquivo muito grande', {
             description: 'O tamanho máximo é 5MB por foto',
-            variant: 'destructive',
           });
           continue;
         }
@@ -73,10 +66,8 @@ export function PhotoUpload({ photos, onPhotosChange, userId, maxPhotos = 5, dis
             fileType: file.type,
             error,
           });
-          toast({
-            title: 'Erro ao enviar foto',
+          toast.error('Erro ao enviar foto', {
             description: error.message,
-            variant: 'destructive',
           });
           continue;
         }
@@ -91,17 +82,14 @@ export function PhotoUpload({ photos, onPhotosChange, userId, maxPhotos = 5, dis
 
       if (newPhotos.length > 0) {
         onPhotosChange([...photos, ...newPhotos]);
-        toast({
-          title: 'Fotos adicionadas!',
+        toast.success('Fotos adicionadas!', {
           description: `${newPhotos.length} foto(s) enviada(s) com sucesso`,
         });
       }
     } catch (error) {
       logger.error('Unexpected error uploading photos', { stage: 'upload', error });
-      toast({
-        title: 'Erro ao enviar fotos',
+      toast.error('Erro ao enviar fotos', {
         description: 'Tente novamente',
-        variant: 'destructive',
       });
     } finally {
       setUploading(false);

--- a/src/components/SendingQualityChecklist.tsx
+++ b/src/components/SendingQualityChecklist.tsx
@@ -5,7 +5,7 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
-import { useToast } from '@/hooks/use-toast';
+import { toast } from 'sonner';
 import { ClipboardCheck, Loader2, CheckCircle2, Package } from 'lucide-react';
 
 interface SendingQualityChecklistProps {
@@ -31,7 +31,6 @@ const CRITERIA = [
 
 export const SendingQualityChecklist = ({ orderId, userId }: SendingQualityChecklistProps) => {
   const { user } = useAuth();
-  const { toast } = useToast();
   const [existingLog, setExistingLog] = useState<QualityLog | null>(null);
   const [checks, setChecks] = useState({
     is_clean: false,
@@ -107,18 +106,15 @@ export const SendingQualityChecklist = ({ orderId, userId }: SendingQualityCheck
         if (error) throw error;
       }
 
-      toast({
-        title: 'Avaliação salva!',
+      toast.success('Avaliação salva!', {
         description: `Qualidade do envio: ${score}%`,
       });
 
       await loadExisting();
     } catch (err) {
       console.error('Error saving quality log:', err);
-      toast({
-        title: 'Erro',
+      toast.error('Erro', {
         description: 'Não foi possível salvar a avaliação',
-        variant: 'destructive',
       });
     } finally {
       setSaving(false);

--- a/src/components/ToolImageIdentifier.tsx
+++ b/src/components/ToolImageIdentifier.tsx
@@ -2,7 +2,7 @@ import { useState, useRef } from 'react';
 import { Camera, Loader2, X, CheckCircle, AlertCircle, Image } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { supabase } from '@/integrations/supabase/client';
-import { useToast } from '@/hooks/use-toast';
+import { toast } from 'sonner';
 import { cn } from '@/lib/utils';
 
 interface ToolCategory {
@@ -32,7 +32,6 @@ export function ToolImageIdentifier({ categories, onCategoryIdentified, onClose,
   const [preview, setPreview] = useState<string | null>(null);
   const [result, setResult] = useState<IdentificationResult | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const { toast } = useToast();
 
   const handleFileSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -40,13 +39,13 @@ export function ToolImageIdentifier({ categories, onCategoryIdentified, onClose,
 
     // Validate file type
     if (!file.type.startsWith('image/')) {
-      toast({ title: 'Selecione uma imagem', variant: 'destructive' });
+      toast.error('Selecione uma imagem');
       return;
     }
 
     // Validate file size (max 5MB)
     if (file.size > 5 * 1024 * 1024) {
-      toast({ title: 'Imagem muito grande', description: 'Máximo 5MB', variant: 'destructive' });
+      toast.error('Imagem muito grande', { description: 'Máximo 5MB' });
       return;
     }
 
@@ -84,10 +83,8 @@ export function ToolImageIdentifier({ categories, onCategoryIdentified, onClose,
       setResult(data as IdentificationResult);
     } catch (error) {
       console.error('Erro ao analisar imagem:', error);
-      toast({
-        title: 'Erro na análise',
+      toast.error('Erro na análise', {
         description: 'Não foi possível analisar a imagem. Tente novamente.',
-        variant: 'destructive',
       });
     } finally {
       setIsAnalyzing(false);
@@ -103,15 +100,12 @@ export function ToolImageIdentifier({ categories, onCategoryIdentified, onClose,
 
     if (matchedCategory) {
       onCategoryIdentified(matchedCategory.id, result.specs_detected || {});
-      toast({
-        title: 'Ferramenta identificada!',
+      toast.success('Ferramenta identificada!', {
         description: `${matchedCategory.name} selecionada`,
       });
     } else {
-      toast({
-        title: 'Categoria não encontrada',
+      toast.error('Categoria não encontrada', {
         description: `"${result.category_name}" não corresponde a nenhuma categoria cadastrada. Selecione manualmente.`,
-        variant: 'destructive',
       });
     }
   };

--- a/src/components/UnifiedAIAssistant.tsx
+++ b/src/components/UnifiedAIAssistant.tsx
@@ -3,7 +3,7 @@ import { Mic, Send, Loader2, Sparkles, X, Square, Camera, Package, Wrench, Image
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { cn, decodeHtmlEntities } from '@/lib/utils';
-import { useToast } from '@/hooks/use-toast';
+import { toast } from 'sonner';
 import { invokeFunction } from '@/lib/invoke-function';
 
 export interface AIProduct {
@@ -91,7 +91,6 @@ interface UnifiedAIAssistantProps {
 const fmt = (v: number) => v.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
 
 export function UnifiedAIAssistant({ products, userTools, onItemsIdentified, onCustomerIdentified, customerUserId, hasCustomerSelected = false, isLoading = false }: UnifiedAIAssistantProps) {
-  const { toast } = useToast();
   const [text, setText] = useState('');
   const [isRecording, setIsRecording] = useState(false);
   const [isTranscribing, setIsTranscribing] = useState(false);
@@ -146,7 +145,7 @@ export function UnifiedAIAssistant({ products, userTools, onItemsIdentified, onC
         }
       };
       mr.onerror = () => {
-        toast({ title: 'Erro na gravação', variant: 'destructive' });
+        toast.error('Erro na gravação');
         stopRecording();
       };
 
@@ -156,12 +155,12 @@ export function UnifiedAIAssistant({ products, userTools, onItemsIdentified, onC
       timerRef.current = window.setInterval(() => setRecordingDuration(p => p + 1), 1000);
     } catch (err: any) {
       if (err.name === 'NotAllowedError') {
-        toast({ title: 'Permissão negada', description: 'Permita o acesso ao microfone.', variant: 'destructive' });
+        toast.error('Permissão negada', { description: 'Permita o acesso ao microfone.' });
       } else {
-        toast({ title: 'Erro ao gravar', description: err.message, variant: 'destructive' });
+        toast.error('Erro ao gravar', { description: err.message });
       }
     }
-  }, [toast]);
+  }, []);
 
   const stopRecording = useCallback(() => {
     if (timerRef.current) { clearInterval(timerRef.current); timerRef.current = null; }
@@ -185,12 +184,12 @@ export function UnifiedAIAssistant({ products, userTools, onItemsIdentified, onC
       const result = await invokeFunction<{ text?: string }>('elevenlabs-transcribe', fd as any);
       if (result.text) {
         setText(prev => prev + (prev ? ' ' : '') + result.text);
-        toast({ title: 'Transcrição concluída' });
+        toast.success('Transcrição concluída');
       } else {
-        toast({ title: 'Nenhum texto detectado', variant: 'destructive' });
+        toast.error('Nenhum texto detectado');
       }
     } catch (e: any) {
-      toast({ title: 'Erro na transcrição', description: e.message, variant: 'destructive' });
+      toast.error('Erro na transcrição', { description: e.message });
     } finally {
       setIsTranscribing(false);
     }
@@ -204,11 +203,11 @@ export function UnifiedAIAssistant({ products, userTools, onItemsIdentified, onC
     for (let i = 0; i < files.length; i++) {
       const file = files[i];
       if (!file.type.startsWith('audio/')) {
-        toast({ title: `"${file.name}" não é um áudio`, variant: 'destructive' });
+        toast.error(`"${file.name}" não é um áudio`);
         continue;
       }
       if (file.size > 10 * 1024 * 1024) {
-        toast({ title: `"${file.name}" muito grande (máx 10MB)`, variant: 'destructive' });
+        toast.error(`"${file.name}" muito grande (máx 10MB)`);
         continue;
       }
       await transcribeAudio(file);
@@ -224,9 +223,9 @@ export function UnifiedAIAssistant({ products, userTools, onItemsIdentified, onC
 
     for (let i = 0; i < files.length; i++) {
       const file = files[i];
-      if (!file.type.startsWith('image/')) { toast({ title: 'Selecione uma imagem', variant: 'destructive' }); continue; }
-      if (file.size > 5 * 1024 * 1024) { toast({ title: `"${file.name}" muito grande (máx 5MB)`, variant: 'destructive' }); continue; }
-      if (images.length >= 5) { toast({ title: 'Máximo de 5 fotos', variant: 'destructive' }); break; }
+      if (!file.type.startsWith('image/')) { toast.error('Selecione uma imagem'); continue; }
+      if (file.size > 5 * 1024 * 1024) { toast.error(`"${file.name}" muito grande (máx 5MB)`); continue; }
+      if (images.length >= 5) { toast.error('Máximo de 5 fotos'); break; }
 
       const preview = URL.createObjectURL(file);
       const b64 = await new Promise<string>((resolve) => {
@@ -254,7 +253,7 @@ export function UnifiedAIAssistant({ products, userTools, onItemsIdentified, onC
 
   const analyze = async () => {
     if (!text.trim() && images.length === 0) {
-      toast({ title: 'Digite, grave, anexe áudio ou tire uma foto', variant: 'destructive' });
+      toast.error('Digite, grave, anexe áudio ou tire uma foto');
       return;
     }
     if (isRecording) stopRecording();
@@ -312,8 +311,7 @@ export function UnifiedAIAssistant({ products, userTools, onItemsIdentified, onC
       console.error('[UnifiedOrder AI] Falha ao analisar pedido:', e);
       setAiFallbackActive(true);
       setAiMessage('A análise inteligente está indisponível no momento. Você pode continuar montando o pedido manualmente.');
-      toast({
-        title: 'Análise indisponível',
+      toast.success('Análise indisponível', {
         description: 'Continue montando o pedido manualmente. Você pode tentar novamente depois.',
       });
     } finally {
@@ -331,14 +329,14 @@ export function UnifiedAIAssistant({ products, userTools, onItemsIdentified, onC
     setIdentifiedCustomer(null);
     clearImages();
     const total = identifiedProducts.length + identifiedServices.length;
-    toast({ title: 'Itens adicionados!', description: `${total} item(ns) adicionado(s) ao pedido.` });
+    toast.success('Itens adicionados!', { description: `${total} item(ns) adicionado(s) ao pedido.` });
   };
 
   const confirmCustomer = () => {
     if (identifiedCustomer && onCustomerIdentified) {
       onCustomerIdentified(identifiedCustomer);
       setIdentifiedCustomer(null);
-      toast({ title: 'Cliente selecionado!', description: decodeHtmlEntities(identifiedCustomer.nome_fantasia || identifiedCustomer.razao_social) });
+      toast.success('Cliente selecionado!', { description: decodeHtmlEntities(identifiedCustomer.nome_fantasia || identifiedCustomer.razao_social) });
       // Note: we intentionally do NOT clear identifiedProducts/suggestions
       // so the user can add them after customer is set
     }
@@ -355,7 +353,7 @@ export function UnifiedAIAssistant({ products, userTools, onItemsIdentified, onC
         unit_price: suggestion.unit_price,
       };
       onItemsIdentified({ products: [prod], services: [] });
-      toast({ title: 'Produto adicionado!', description: suggestion.descricao });
+      toast.success('Produto adicionado!', { description: suggestion.descricao });
     } else if (suggestion.type === 'product' && (!suggestion.product_id || suggestion.product_id === '')) {
       // Suggestion without exact product_id - try to find it in products list
       const matchProd = products.find(p => 
@@ -372,9 +370,9 @@ export function UnifiedAIAssistant({ products, userTools, onItemsIdentified, onC
           unit_price: suggestion.unit_price,
         };
         onItemsIdentified({ products: [prod], services: [] });
-        toast({ title: 'Produto adicionado!', description: matchProd.descricao });
+        toast.success('Produto adicionado!', { description: matchProd.descricao });
       } else {
-        toast({ title: 'Produto não encontrado', description: 'Busque manualmente no catálogo.', variant: 'destructive' });
+        toast.error('Produto não encontrado', { description: 'Busque manualmente no catálogo.' });
       }
     } else if (suggestion.type === 'service' && suggestion.userToolId && suggestion.omie_codigo_servico) {
       const svc: AIService = {
@@ -384,7 +382,7 @@ export function UnifiedAIAssistant({ products, userTools, onItemsIdentified, onC
         quantity: suggestion.quantity || 1,
       };
       onItemsIdentified({ products: [], services: [svc] });
-      toast({ title: 'Serviço adicionado!', description: suggestion.descricao });
+      toast.success('Serviço adicionado!', { description: suggestion.descricao });
     }
     setSuggestions(prev => prev.filter(s => s !== suggestion));
   };

--- a/src/components/VoiceServiceInput.tsx
+++ b/src/components/VoiceServiceInput.tsx
@@ -3,7 +3,7 @@ import { invokeFunction } from '@/lib/invoke-function';
 import { Mic, Send, Loader2, Sparkles, X, Square, Wrench } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
-import { useToast } from '@/hooks/use-toast';
+import { toast } from 'sonner';
 import { logger } from '@/lib/logger';
 
 interface UserTool {
@@ -32,7 +32,6 @@ interface VoiceServiceInputProps {
 }
 
 export function VoiceServiceInput({ userTools, onItemsIdentified, isLoading = false }: VoiceServiceInputProps) {
-  const { toast } = useToast();
   const [text, setText] = useState('');
   const [isRecording, setIsRecording] = useState(false);
   const [isTranscribing, setIsTranscribing] = useState(false);
@@ -108,10 +107,8 @@ export function VoiceServiceInput({ userTools, onItemsIdentified, isLoading = fa
 
       mediaRecorder.onerror = (event) => {
         logger.error('MediaRecorder runtime error', { stage: 'start_recording', event });
-        toast({
-          title: 'Erro na gravação',
+        toast.error('Erro na gravação', {
           description: 'Ocorreu um erro ao gravar o áudio.',
-          variant: 'destructive',
         });
         stopRecording();
       };
@@ -133,26 +130,20 @@ export function VoiceServiceInput({ userTools, onItemsIdentified, isLoading = fa
         logger.error('Failed to start voice recording', { stage: 'request_mic_permission', errorName: err.name, error });
       }
       if (err.name === 'NotAllowedError') {
-        toast({
-          title: 'Permissão negada',
+        toast.error('Permissão negada', {
           description: 'Permita o acesso ao microfone nas configurações do navegador.',
-          variant: 'destructive',
         });
       } else if (err.name === 'NotFoundError') {
-        toast({
-          title: 'Microfone não encontrado',
+        toast.error('Microfone não encontrado', {
           description: 'Verifique se um microfone está conectado ao dispositivo.',
-          variant: 'destructive',
         });
       } else {
-        toast({
-          title: 'Erro ao iniciar gravação',
+        toast.error('Erro ao iniciar gravação', {
           description: err.message || 'Não foi possível acessar o microfone.',
-          variant: 'destructive',
         });
       }
     }
-  }, [toast]);
+  }, []);
 
   const stopRecording = useCallback(() => {
     if (timerRef.current) {
@@ -190,23 +181,18 @@ export function VoiceServiceInput({ userTools, onItemsIdentified, isLoading = fa
 
       if (result.text) {
         setText(prev => prev + (prev ? ' ' : '') + result.text);
-        toast({
-          title: 'Transcrição concluída',
+        toast.success('Transcrição concluída', {
           description: 'O áudio foi convertido em texto.',
         });
       } else {
-        toast({
-          title: 'Nenhum texto detectado',
+        toast.error('Nenhum texto detectado', {
           description: 'Não foi possível identificar fala no áudio.',
-          variant: 'destructive',
         });
       }
     } catch (error) {
       logger.error('Audio transcription failed', { stage: 'transcribe', error });
-      toast({
-        title: 'Erro na transcrição',
+      toast.error('Erro na transcrição', {
         description: error instanceof Error ? error.message : 'Tente novamente.',
-        variant: 'destructive',
       });
     } finally {
       setIsTranscribing(false);
@@ -229,19 +215,15 @@ export function VoiceServiceInput({ userTools, onItemsIdentified, isLoading = fa
 
   const analyzeText = async () => {
     if (!text.trim()) {
-      toast({
-        title: 'Texto vazio',
+      toast.error('Texto vazio', {
         description: 'Digite ou grave o que você precisa.',
-        variant: 'destructive',
       });
       return;
     }
 
     if (userTools.length === 0) {
-      toast({
-        title: 'Nenhuma ferramenta cadastrada',
+      toast.error('Nenhuma ferramenta cadastrada', {
         description: 'Cadastre suas ferramentas antes de usar o assistente por voz.',
-        variant: 'destructive',
       });
       return;
     }
@@ -274,10 +256,8 @@ export function VoiceServiceInput({ userTools, onItemsIdentified, isLoading = fa
       }
     } catch (error) {
       logger.error('Voice service analysis failed', { stage: 'parse_items', textLength: text.trim().length, error });
-      toast({
-        title: 'Erro na análise',
+      toast.error('Erro na análise', {
         description: error instanceof Error ? error.message : 'Tente novamente.',
-        variant: 'destructive',
       });
     } finally {
       setIsAnalyzing(false);
@@ -289,8 +269,7 @@ export function VoiceServiceInput({ userTools, onItemsIdentified, isLoading = fa
     setText('');
     setAiMessage(null);
     setIdentifiedItems([]);
-    toast({
-      title: 'Itens adicionados!',
+    toast.success('Itens adicionados!', {
       description: `${identifiedItems.length} item(ns) adicionado(s) ao pedido. Adicione fotos se desejar.`,
     });
   };

--- a/src/components/auth/SignupForm.tsx
+++ b/src/components/auth/SignupForm.tsx
@@ -6,7 +6,7 @@ import { Label } from '@/components/ui/label';
 import { cn } from '@/lib/utils';
 import { z } from 'zod';
 import { supabase } from '@/integrations/supabase/client';
-import { useToast } from '@/hooks/use-toast';
+import { toast } from 'sonner';
 import {
   documentSchema, signupSchema, BRAZILIAN_STATES,
   formatPhone, formatZipCode,
@@ -29,7 +29,6 @@ interface SignupFormProps {
 }
 
 export function SignupForm({ formData, onInputChange, isLoading, onFinalSubmit, onSwitchToLogin, toolCategories }: SignupFormProps) {
-  const { toast } = useToast();
   const [signupStep, setSignupStep] = useState<SignupStep>('document');
   const [isCheckingDocument, setIsCheckingDocument] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
@@ -77,7 +76,7 @@ export function SignupForm({ formData, onInputChange, isLoading, onFinalSubmit, 
       const { data: existingProfile } = await supabase.from('profiles').select('id').eq('document', docLimpo).maybeSingle();
       if (existingProfile) {
         setExistingUserError(true);
-        toast({ title: 'Cadastro existente', description: 'Este documento já está cadastrado. Faça login com seu e-mail.', variant: 'destructive' });
+        toast.error('Cadastro existente', { description: 'Este documento já está cadastrado. Faça login com seu e-mail.' });
         setIsCheckingDocument(false);
         return;
       }
@@ -90,7 +89,7 @@ export function SignupForm({ formData, onInputChange, isLoading, onFinalSubmit, 
       setCnae(data.cnae || null);
       setCnaeDescricao(data.cnaeDescricao || null);
       if (data.isEmployee) {
-        toast({ title: 'Funcionário identificado!', description: 'Você terá acesso ao painel administrativo após o cadastro.' });
+        toast.success('Funcionário identificado!', { description: 'Você terá acesso ao painel administrativo após o cadastro.' });
       }
       if (data.cliente) {
         const cliente = data.cliente as OmieClienteData;
@@ -106,15 +105,15 @@ export function SignupForm({ formData, onInputChange, isLoading, onFinalSubmit, 
         onInputChange('city', cliente.cidade || '');
         onInputChange('state', cliente.estado || '');
         onInputChange('zipCode', cliente.cep ? formatZipCode(cliente.cep) : '');
-        toast({ title: data.found ? 'Cliente encontrado!' : 'Dados carregados', description: data.found ? 'Seus dados foram carregados do cadastro existente.' : 'Dados da empresa carregados. Complete o cadastro.' });
+        toast.success(data.found ? 'Cliente encontrado!' : 'Dados carregados', { description: data.found ? 'Seus dados foram carregados do cadastro existente.' : 'Dados da empresa carregados. Complete o cadastro.' });
       } else {
         setOmieCliente(null);
-        toast({ title: 'Novo cadastro', description: 'Preencha seus dados para criar uma conta.' });
+        toast.success('Novo cadastro', { description: 'Preencha seus dados para criar uma conta.' });
       }
       setSignupStep('form');
     } catch (error) {
       console.error('Erro ao verificar documento:', error);
-      toast({ title: 'Erro ao verificar documento', description: 'Não foi possível verificar o documento. Tente novamente.', variant: 'destructive' });
+      toast.error('Erro ao verificar documento', { description: 'Não foi possível verificar o documento. Tente novamente.' });
     } finally {
       setIsCheckingDocument(false);
     }

--- a/src/components/unified-order/ServiceItemForm.tsx
+++ b/src/components/unified-order/ServiceItemForm.tsx
@@ -6,7 +6,7 @@ import {
   Loader2, Plus, Minus, Trash2, Wrench, AlertCircle, MapPin, Clock, Check,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import { useToast } from '@/hooks/use-toast';
+import { toast } from 'sonner';
 import { DELIVERY_OPTIONS, TIME_SLOTS, DeliveryOption } from '@/types';
 import type {
   UserTool, ServiceCartItem, CartItem, AddressData,
@@ -61,8 +61,6 @@ export function ServiceItemForm({
   onUpdateServiceServico, onUpdateServiceNotes, onUpdateServicePhotos,
   onVoiceItemsIdentified, getFilteredServicos, getServicePrice, setAddToolDialogOpen,
 }: ServiceItemFormProps) {
-  const { toast } = useToast();
-
   return (
     <Card>
       <CardHeader className="pb-2">
@@ -140,7 +138,7 @@ export function ServiceItemForm({
                           <Button size="sm" variant="outline" className="h-8 w-8 p-0" onClick={() => {
                             const maxQty = item.userTool.quantity || 1;
                             if (item.quantity >= maxQty) {
-                              toast({ title: 'Quantidade máxima atingida', description: `Esta ferramenta possui apenas ${maxQty} unidade(s).` });
+                              toast.success('Quantidade máxima atingida', { description: `Esta ferramenta possui apenas ${maxQty} unidade(s).` });
                               return;
                             }
                             onUpdateQuantity(cartIdx, 1);

--- a/src/contexts/WebRTCCallContext.tsx
+++ b/src/contexts/WebRTCCallContext.tsx
@@ -2,7 +2,7 @@ import { createContext, useContext, useEffect, useRef, useState, useCallback, ty
 import { SipClient } from '@/lib/sip/sip-client';
 import type { SipCallState } from '@/lib/sip/types';
 import { invokeFunction } from '@/lib/invoke-function';
-import { useToast } from '@/hooks/use-toast';
+import { toast } from 'sonner';
 import { normalizeBrPhone, formatBrPhone } from '@/lib/phone';
 import { mixPrerollWithMic } from '@/lib/sip/audio-preroll';
 import { useTranscription } from '@/hooks/useTranscription';
@@ -71,7 +71,6 @@ interface ProviderProps {
 }
 
 export function WebRTCCallProvider({ children }: ProviderProps) {
-  const { toast } = useToast();
   const [callState, setCallState] = useState<WebRTCCallState>('idle');
   const [callDuration, setCallDuration] = useState(0);
   const [localStream, setLocalStream] = useState<MediaStream | null>(null);
@@ -108,7 +107,7 @@ export function WebRTCCallProvider({ children }: ProviderProps) {
         client.on('remoteStream', (s) => setRemoteStream(s));
         client.on('error', (e) => {
           setError(e.message);
-          toast({ title: 'Erro WebRTC', description: e.message, variant: 'destructive' });
+          toast.error('Erro WebRTC', { description: e.message });
         });
 
         client.connect();
@@ -196,7 +195,7 @@ export function WebRTCCallProvider({ children }: ProviderProps) {
     if (normalized.length < 10) {
       const msg = 'Telefone inválido. É necessário DDD + número.';
       setError(msg);
-      toast({ title: 'Erro', description: msg, variant: 'destructive' });
+      toast.error('Erro', { description: msg });
       return;
     }
 
@@ -223,21 +222,21 @@ export function WebRTCCallProvider({ children }: ProviderProps) {
       }
 
       clientRef.current.makeCall(normalized, streamForCall);
-      toast({ title: '📞 Chamada iniciada', description: `Ligando para ${formatBrPhone(normalized)}...` });
+      toast.success('📞 Chamada iniciada', { description: `Ligando para ${formatBrPhone(normalized)}...` });
     } catch (err) {
       const msg = err instanceof Error ? err.message : 'Erro ao iniciar chamada';
       setError(msg);
       cleanupAudioResources();
-      toast({ title: 'Erro na chamada', description: msg, variant: 'destructive' });
+      toast.error('Erro na chamada', { description: msg });
     }
-  }, [toast, prerollUrl]);
+  }, [prerollUrl]);
 
   const endCall = useCallback(async () => {
     clientRef.current?.hangUp();
     cleanupAudioResources();
     setIsMuted(false);
-    toast({ title: 'Chamada encerrada' });
-  }, [toast]);
+    toast.success('Chamada encerrada');
+  }, []);
 
   const toggleMute = useCallback(() => {
     if (!clientRef.current) return;

--- a/src/hooks/unifiedOrder/useCart.ts
+++ b/src/hooks/unifiedOrder/useCart.ts
@@ -1,5 +1,5 @@
 import { useState, useMemo, useCallback } from 'react';
-import { useToast } from '@/hooks/use-toast';
+import { toast } from 'sonner';
 import type { OmieServico } from '@/services/omieService';
 import type {
   Product,
@@ -19,8 +19,6 @@ interface UseCartArgs {
 }
 
 export function useCart({ getProductPrice, getServicePrice, servicos }: UseCartArgs) {
-  const { toast } = useToast();
-
   const [cart, setCart] = useState<CartItem[]>([]);
   const [tintPendingProduct, setTintPendingProduct] = useState<Product | null>(null);
   const [activeTab, setActiveTab] = useState('oben');
@@ -171,10 +169,10 @@ export function useCart({ getProductPrice, getServicePrice, servicos }: UseCartA
         ];
       });
       if (alreadyExists) {
-        toast({ title: 'Já adicionada', description: 'Esta ferramenta já está no carrinho.' });
+        toast.success('Já adicionada', { description: 'Esta ferramenta já está no carrinho.' });
       }
     },
-    [toast],
+    [],
   );
 
   const updateServiceServico = useCallback(
@@ -221,7 +219,7 @@ export function useCart({ getProductPrice, getServicePrice, servicos }: UseCartA
           if (c.type === 'service') {
             const maxQty = (c as ServiceCartItem).userTool.quantity || 1;
             if (newQty > maxQty) {
-              toast({ title: 'Quantidade máxima', description: `Máximo: ${maxQty} unidades.` });
+              toast.success('Quantidade máxima', { description: `Máximo: ${maxQty} unidades.` });
               return c;
             }
           }
@@ -229,7 +227,7 @@ export function useCart({ getProductPrice, getServicePrice, servicos }: UseCartA
         }),
       );
     },
-    [toast],
+    [],
   );
 
   const updateProductPrice = useCallback((index: number, price: number) => {

--- a/src/hooks/unifiedOrder/useCustomerSelection.ts
+++ b/src/hooks/unifiedOrder/useCustomerSelection.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
-import { useToast } from '@/hooks/use-toast';
+import { toast } from 'sonner';
 import { logger } from '@/lib/logger';
 import { maskDocument } from '@/lib/format';
 import type {
@@ -36,7 +36,6 @@ export function useCustomerSelection({
   onLocalUserResolved,
   reloadPriceHistory,
 }: UseCustomerSelectionArgs = {}) {
-  const { toast } = useToast();
   const queryClient = useQueryClient();
 
   /* ─── State ─── */
@@ -436,8 +435,7 @@ export function useCustomerSelection({
       const afiacaoClientResult = getResult(6);
 
       if (failedParts.length > 0) {
-        toast({
-          title: 'Alguns dados do cliente não foram carregados',
+        toast.success('Alguns dados do cliente não foram carregados', {
           description: `Falharam: ${failedParts.join(', ')}. Você pode continuar, mas preços/parcelas podem não refletir o contrato.`,
         });
       }
@@ -497,7 +495,7 @@ export function useCustomerSelection({
       if (parcelaColacor.data?.ultima_parcela) setSelectedParcelaColacor(parcelaColacor.data.ultima_parcela);
       if (parcelaColacor.data?.parcela_ranking) setCustomerParcelaRankingColacor(parcelaColacor.data.parcela_ranking.map((r: any) => r.codigo));
     } catch (error: any) {
-      toast({ title: 'Erro', description: error.message, variant: 'destructive' });
+      toast.error('Erro', { description: error.message });
     } finally {
       setLoadingCustomer(false);
     }
@@ -524,7 +522,7 @@ export function useCustomerSelection({
     }
   }, [
     resolveLocalUserId, autoCreateInMissingAccounts, resolveLocalPricesByOmieCode,
-    onLocalUserResolved, reloadPriceHistory, toast,
+    onLocalUserResolved, reloadPriceHistory,
   ]);
 
   const clearCustomer = useCallback(() => {

--- a/src/hooks/useAdminOrderDetail.ts
+++ b/src/hooks/useAdminOrderDetail.ts
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
-import { useToast } from '@/hooks/use-toast';
+import { toast } from 'sonner';
 import { usePriceHistory } from '@/hooks/usePriceHistory';
 import { usePricingEngine } from '@/hooks/usePricingEngine';
 import { updateOrderInOmie, deleteOrderFromOmie, checkOsExistsInOmie } from '@/services/omieService';
@@ -12,7 +12,6 @@ import type { Order, OrderItem, Profile } from '@/components/admin-order/types';
 export function useAdminOrderDetail(id: string | undefined) {
   const navigate = useNavigate();
   const { user, isStaff, loading: authLoading, role } = useAuth();
-  const { toast } = useToast();
 
   const [order, setOrder] = useState<Order | null>(null);
   const [profile, setProfile] = useState<Profile | null>(null);
@@ -164,10 +163,8 @@ export function useAdminOrderDetail(id: string | undefined) {
 
       const osCheck = await checkOsExistsInOmie(data.id);
       if (!osCheck.exists) {
-        toast({
-          title: 'Pedido excluído no Omie',
+        toast.error('Pedido excluído no Omie', {
           description: 'Esta OS foi excluída no Omie. O pedido será removido.',
-          variant: 'destructive',
         });
         await deleteOrderFromOmie(data.id);
         navigate('/admin');
@@ -175,10 +172,8 @@ export function useAdminOrderDetail(id: string | undefined) {
       }
     } catch (error) {
       logger.error('Failed to load order', { stage: 'load_order', orderId: id, error });
-      toast({
-        title: 'Erro',
+      toast.error('Erro', {
         description: 'Não foi possível carregar o pedido',
-        variant: 'destructive',
       });
     } finally {
       setLoading(false);
@@ -189,7 +184,7 @@ export function useAdminOrderDetail(id: string | undefined) {
     const lastPrice = getLastPrice(item.userToolId, item.category);
     if (lastPrice !== null) {
       setItemPrices((prev) => ({ ...prev, [index]: lastPrice.toString() }));
-      toast({ title: 'Preço do histórico aplicado', description: `Último preço cobrado: R$ ${lastPrice.toFixed(2)}` });
+      toast.success('Preço do histórico aplicado', { description: `Último preço cobrado: R$ ${lastPrice.toFixed(2)}` });
       return;
     }
 
@@ -200,12 +195,12 @@ export function useAdminOrderDetail(id: string | undefined) {
       });
       if (tablePrice !== null) {
         setItemPrices((prev) => ({ ...prev, [index]: tablePrice.toString() }));
-        toast({ title: 'Preço da tabela aplicado', description: `Valor da tabela padrão: R$ ${tablePrice.toFixed(2)}` });
+        toast.success('Preço da tabela aplicado', { description: `Valor da tabela padrão: R$ ${tablePrice.toFixed(2)}` });
         return;
       }
     }
 
-    toast({ title: 'Sem preço sugerido', description: 'Nenhum preço encontrado no histórico ou tabela padrão' });
+    toast.success('Sem preço sugerido', { description: 'Nenhum preço encontrado no histórico ou tabela padrão' });
   };
 
   const hasAnySuggestedPrice = (item: OrderItem): boolean => {
@@ -277,15 +272,15 @@ export function useAdminOrderDetail(id: string | undefined) {
         });
 
         if (omieResult.success) {
-          toast({ title: 'Pedido sincronizado!', description: `OS ${omieResult.cNumOS} atualizada no Omie` });
+          toast.success('Pedido sincronizado!', { description: `OS ${omieResult.cNumOS} atualizada no Omie` });
         } else {
-          toast({ title: 'Erro ao sincronizar com Omie', description: omieResult.error || 'Tente novamente', variant: 'destructive' });
+          toast.error('Erro ao sincronizar com Omie', { description: omieResult.error || 'Tente novamente' });
           setSaving(false);
           setSyncingOmie(false);
           return;
         }
       } else {
-        toast({ title: 'Pedido atualizado!', description: 'Preços salvos localmente' });
+        toast.success('Pedido atualizado!', { description: 'Preços salvos localmente' });
       }
 
       navigate('/admin');
@@ -293,7 +288,7 @@ export function useAdminOrderDetail(id: string | undefined) {
       logger.critical('Failed to save order — possible data inconsistency', {
         stage: 'update_status', orderId: order.id, syncToOmie, error,
       });
-      toast({ title: 'Erro', description: 'Não foi possível salvar o pedido', variant: 'destructive' });
+      toast.error('Erro', { description: 'Não foi possível salvar o pedido' });
     } finally {
       setSaving(false);
       setSyncingOmie(false);
@@ -306,14 +301,14 @@ export function useAdminOrderDetail(id: string | undefined) {
     try {
       const result = await deleteOrderFromOmie(order.id);
       if (result.success) {
-        toast({ title: 'Pedido excluído', description: 'O pedido foi excluído do app e do Omie' });
+        toast.success('Pedido excluído', { description: 'O pedido foi excluído do app e do Omie' });
         navigate('/admin');
       } else {
-        toast({ title: 'Erro ao excluir', description: result.error, variant: 'destructive' });
+        toast.error('Erro ao excluir', { description: result.error });
       }
     } catch (error) {
       logger.error('Failed to delete order', { stage: 'delete_order', orderId: order.id, error });
-      toast({ title: 'Erro', description: 'Não foi possível excluir o pedido', variant: 'destructive' });
+      toast.error('Erro', { description: 'Não foi possível excluir o pedido' });
     } finally {
       setDeleting(false);
     }

--- a/src/hooks/useBiometricAuth.ts
+++ b/src/hooks/useBiometricAuth.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { supabase } from '@/integrations/supabase/client';
-import { useToast } from '@/hooks/use-toast';
+import { toast } from 'sonner';
 import { logger } from '@/lib/logger';
 
 interface BiometricAuthResult {
@@ -48,7 +48,6 @@ export const useBiometricAuth = (): BiometricAuthHook => {
   const [isSupported, setIsSupported] = useState(false);
   const [isRegistered, setIsRegistered] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
-  const { toast } = useToast();
 
   // Check if WebAuthn is supported
   useEffect(() => {
@@ -88,10 +87,8 @@ export const useBiometricAuth = (): BiometricAuthHook => {
   // Register biometric credential
   const register = useCallback(async (): Promise<boolean> => {
     if (!isSupported) {
-      toast({
-        title: 'Não suportado',
+      toast.error('Não suportado', {
         description: 'Seu dispositivo não suporta autenticação biométrica',
-        variant: 'destructive',
       });
       return false;
     }
@@ -102,10 +99,8 @@ export const useBiometricAuth = (): BiometricAuthHook => {
       // Get current user
       const { data: { user } } = await supabase.auth.getUser();
       if (!user) {
-        toast({
-          title: 'Erro',
+        toast.error('Erro', {
           description: 'Você precisa estar logado para registrar biometria',
-          variant: 'destructive',
         });
         return false;
       }
@@ -171,8 +166,7 @@ export const useBiometricAuth = (): BiometricAuthHook => {
       localStorage.setItem('biometric_email', btoa(user.email || ''));
 
       setIsRegistered(true);
-      toast({
-        title: 'Biometria registrada!',
+      toast.success('Biometria registrada!', {
         description: 'Agora você pode fazer login com Face ID ou impressão digital',
       });
 
@@ -180,31 +174,25 @@ export const useBiometricAuth = (): BiometricAuthHook => {
     } catch (error: any) {
       logger.error('Biometric registration failed', { stage: 'register', errorName: error?.name, error });
       if (error.name === 'NotAllowedError') {
-        toast({
-          title: 'Acesso negado',
+        toast.error('Acesso negado', {
           description: 'Você precisa permitir o uso de biometria',
-          variant: 'destructive',
         });
       } else {
-        toast({
-          title: 'Erro ao registrar biometria',
+        toast.error('Erro ao registrar biometria', {
           description: error.message || 'Tente novamente mais tarde',
-          variant: 'destructive',
         });
       }
       return false;
     } finally {
       setIsLoading(false);
     }
-  }, [isSupported, toast]);
+  }, [isSupported]);
 
   // Authenticate with biometric
   const authenticate = useCallback(async (): Promise<BiometricAuthResult | null> => {
     if (!isSupported) {
-      toast({
-        title: 'Não suportado',
+      toast.error('Não suportado', {
         description: 'Seu dispositivo não suporta autenticação biométrica',
-        variant: 'destructive',
       });
       return null;
     }
@@ -250,23 +238,19 @@ export const useBiometricAuth = (): BiometricAuthHook => {
     } catch (error: any) {
       logger.warn('Biometric authentication failed', { stage: 'authenticate', errorName: error?.name, error });
       if (error.name === 'NotAllowedError') {
-        toast({
-          title: 'Acesso negado',
+        toast.error('Acesso negado', {
           description: 'Autenticação biométrica cancelada',
-          variant: 'destructive',
         });
       } else {
-        toast({
-          title: 'Erro na autenticação',
+        toast.error('Erro na autenticação', {
           description: 'Não foi possível autenticar com biometria',
-          variant: 'destructive',
         });
       }
       return null;
     } finally {
       setIsLoading(false);
     }
-  }, [isSupported, toast]);
+  }, [isSupported]);
 
   // Remove biometric credential
   const removeCredential = useCallback(async (): Promise<boolean> => {
@@ -286,24 +270,21 @@ export const useBiometricAuth = (): BiometricAuthHook => {
       localStorage.removeItem('biometric_email');
       setIsRegistered(false);
 
-      toast({
-        title: 'Biometria removida',
+      toast.success('Biometria removida', {
         description: 'Autenticação biométrica desativada',
       });
 
       return true;
     } catch (error) {
       logger.error('Failed to remove biometric credential', { stage: 'remove_credential', error });
-      toast({
-        title: 'Erro',
+      toast.error('Erro', {
         description: 'Não foi possível remover a biometria',
-        variant: 'destructive',
       });
       return false;
     } finally {
       setIsLoading(false);
     }
-  }, [toast]);
+  }, []);
 
   return {
     isSupported,

--- a/src/hooks/useBundleArguments.ts
+++ b/src/hooks/useBundleArguments.ts
@@ -1,6 +1,6 @@
 import { useState, useCallback } from 'react';
 import { supabase } from '@/integrations/supabase/client';
-import { useToast } from '@/hooks/use-toast';
+import { toast } from 'sonner';
 
 export interface BundleArgument {
   diagnostico: string;
@@ -38,7 +38,6 @@ export const profileLabels: Record<CustomerProfile, { label: string; emoji: stri
 };
 
 export const useBundleArguments = () => {
-  const { toast } = useToast();
   const [arguments_, setArguments] = useState<Record<string, BundleArgument>>({});
   const [generating, setGenerating] = useState<Record<string, boolean>>({});
 
@@ -72,7 +71,7 @@ export const useBundleArguments = () => {
       if (error) throw error;
 
       if (data?.error) {
-        toast({ title: data.error, variant: 'destructive' });
+        toast.error(data.error);
         return null;
       }
 
@@ -81,12 +80,12 @@ export const useBundleArguments = () => {
       return argument;
     } catch (error) {
       console.error('Error generating argument:', error);
-      toast({ title: 'Erro ao gerar argumentação', variant: 'destructive' });
+      toast.error('Erro ao gerar argumentação');
       return null;
     } finally {
       setGenerating(prev => ({ ...prev, [bundleKey]: false }));
     }
-  }, [toast]);
+  }, []);
 
   const saveArgumentToBundle = useCallback(async (
     bundleId: string,

--- a/src/hooks/useDiagnosticQuestions.ts
+++ b/src/hooks/useDiagnosticQuestions.ts
@@ -1,7 +1,7 @@
 import { useState, useCallback } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
-import { useToast } from '@/hooks/use-toast';
+import { toast } from 'sonner';
 import type { CustomerProfile } from '@/hooks/useBundleArguments';
 
 export interface DiagnosticQuestion {
@@ -31,7 +31,6 @@ export { typeLabels };
 
 export const useDiagnosticQuestions = () => {
   const { user } = useAuth();
-  const { toast } = useToast();
   const [questions, setQuestions] = useState<Record<string, QuestionWithResponse[]>>({});
   const [generating, setGenerating] = useState<Record<string, boolean>>({});
 
@@ -63,7 +62,7 @@ export const useDiagnosticQuestions = () => {
 
       if (error) throw error;
       if (data?.error) {
-        toast({ title: data.error, variant: 'destructive' });
+        toast.error(data.error);
         return null;
       }
 
@@ -76,12 +75,12 @@ export const useDiagnosticQuestions = () => {
       return qs;
     } catch (error) {
       console.error('Error generating diagnostic questions:', error);
-      toast({ title: 'Erro ao gerar perguntas diagnósticas', variant: 'destructive' });
+      toast.error('Erro ao gerar perguntas diagnósticas');
       return null;
     } finally {
       setGenerating(prev => ({ ...prev, [bundleKey]: false }));
     }
-  }, [toast]);
+  }, []);
 
   const setResponse = useCallback((bundleKey: string, questionIndex: number, response: QuestionResponse, notes?: string) => {
     setQuestions(prev => {
@@ -135,12 +134,12 @@ export const useDiagnosticQuestions = () => {
           time_spent_seconds: timeSpentSeconds || 0,
         } as any);
       }
-      toast({ title: 'Respostas salvas com sucesso' });
+      toast.success('Respostas salvas com sucesso');
     } catch (error) {
       console.error('Error saving questions:', error);
-      toast({ title: 'Erro ao salvar respostas', variant: 'destructive' });
+      toast.error('Erro ao salvar respostas');
     }
-  }, [user?.id, questions, toast]);
+  }, [user?.id, questions]);
 
   const getEffectivenessStats = useCallback(async () => {
     if (!user?.id) return null;

--- a/src/hooks/useFarmerGovernance.ts
+++ b/src/hooks/useFarmerGovernance.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
-import { useToast } from '@/hooks/use-toast';
+import { toast } from 'sonner';
 
 export interface GovernanceProposal {
   id: string;
@@ -26,7 +26,6 @@ export interface GovernanceProposal {
 
 export const useFarmerGovernance = () => {
   const { user } = useAuth();
-  const { toast } = useToast();
   const [proposals, setProposals] = useState<GovernanceProposal[]>([]);
   const [auditLogs, setAuditLogs] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
@@ -93,7 +92,7 @@ export const useFarmerGovernance = () => {
     } as any);
 
     if (error) {
-      toast({ title: 'Erro ao criar proposta', variant: 'destructive' });
+      toast.error('Erro ao criar proposta');
       return;
     }
 
@@ -112,13 +111,13 @@ export const useFarmerGovernance = () => {
       },
     } as any);
 
-    toast({ title: 'Proposta criada com sucesso' });
+    toast.success('Proposta criada com sucesso');
     loadData();
   };
 
   const approveProposal = async (proposalId: string) => {
     if (!user || !isGovernor) {
-      toast({ title: 'Apenas o governador pode aprovar propostas', variant: 'destructive' });
+      toast.error('Apenas o governador pode aprovar propostas');
       return;
     }
 
@@ -157,13 +156,13 @@ export const useFarmerGovernance = () => {
       },
     } as any);
 
-    toast({ title: 'Proposta aprovada e aplicada' });
+    toast.success('Proposta aprovada e aplicada');
     loadData();
   };
 
   const rejectProposal = async (proposalId: string, reason: string) => {
     if (!user || !isGovernor) {
-      toast({ title: 'Apenas o governador pode rejeitar propostas', variant: 'destructive' });
+      toast.error('Apenas o governador pode rejeitar propostas');
       return;
     }
 
@@ -182,7 +181,7 @@ export const useFarmerGovernance = () => {
       notes: reason,
     } as any);
 
-    toast({ title: 'Proposta rejeitada' });
+    toast.success('Proposta rejeitada');
     loadData();
   };
 

--- a/src/hooks/useNvoipCall.ts
+++ b/src/hooks/useNvoipCall.ts
@@ -1,6 +1,6 @@
 import { useState, useRef, useCallback, useEffect } from 'react';
 import { invokeFunction } from '@/lib/invoke-function';
-import { useToast } from '@/hooks/use-toast';
+import { toast } from 'sonner';
 import { normalizeBrPhone, formatBrPhone } from '@/lib/phone';
 
 export type NvoipCallState =
@@ -37,7 +37,6 @@ interface UseNvoipCallReturn {
 }
 
 export function useNvoipCall(): UseNvoipCallReturn {
-  const { toast } = useToast();
   const [callState, setCallState] = useState<NvoipCallState>('idle');
   const [callId, setCallId] = useState<string | null>(null);
   const [callDuration, setCallDuration] = useState(0);
@@ -131,18 +130,16 @@ export function useNvoipCall(): UseNvoipCallReturn {
           pollCallStatus(data.callId);
         }, 2000);
 
-        toast({ title: '📞 Chamada iniciada', description: `Ligando para ${formatBrPhone(normalized)}...` });
+        toast.success('📞 Chamada iniciada', { description: `Ligando para ${formatBrPhone(normalized)}...` });
       } catch (err: any) {
         setCallState('error');
         setError(err.message || 'Erro ao realizar chamada');
-        toast({
-          title: 'Erro na chamada',
+        toast.error('Erro na chamada', {
           description: err.message || 'Não foi possível realizar a chamada',
-          variant: 'destructive',
         });
       }
     },
-    [pollCallStatus, toast]
+    [pollCallStatus]
   );
 
   const endCall = useCallback(async () => {
@@ -152,16 +149,14 @@ export function useNvoipCall(): UseNvoipCallReturn {
       await invokeFunction('nvoip-calls', { action: 'end_call', callId });
       setCallState('finished');
       stopPolling();
-      toast({ title: 'Chamada encerrada' });
+      toast.success('Chamada encerrada');
     } catch (err: any) {
       console.error('Error ending call:', err);
-      toast({
-        title: 'Erro ao encerrar',
+      toast.error('Erro ao encerrar', {
         description: err.message,
-        variant: 'destructive',
       });
     }
-  }, [callId, stopPolling, toast]);
+  }, [callId, stopPolling]);
 
   const isActive = !['idle', 'finished', 'noanswer', 'busy', 'failed', 'error'].includes(callState);
   const isConnecting = callState === 'connecting';

--- a/src/hooks/useUnifiedOrder.ts
+++ b/src/hooks/useUnifiedOrder.ts
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
-import { useToast } from '@/hooks/use-toast';
+import { toast } from 'sonner';
 import { OmieServico } from '@/services/omieService';
 import { usePricingEngine } from '@/hooks/usePricingEngine';
 import { usePriceHistory } from '@/hooks/usePriceHistory';
@@ -65,7 +65,6 @@ export const getToolName = (t: UserTool) => t.generated_name || t.custom_name ||
 export function useUnifiedOrder() {
   const navigate = useNavigate();
   const { user, isStaff, loading: authLoading } = useAuth();
-  const { toast } = useToast();
 
   // Company profiles (printing) — react-query, 1h stale
   const { data: companyProfiles = {} } = useQuery({
@@ -393,7 +392,7 @@ export function useUnifiedOrder() {
     );
 
     if (filteredNew.length === 0) {
-      toast({ title: 'Ferramentas já adicionadas', description: 'Todas as ferramentas identificadas já estão no pedido.' });
+      toast.success('Ferramentas já adicionadas', { description: 'Todas as ferramentas identificadas já estão no pedido.' });
       return;
     }
     setCart([...cart, ...filteredNew]);
@@ -410,10 +409,10 @@ export function useUnifiedOrder() {
         }
       });
       if (addedCount > 0) {
-        toast({ title: 'Ferramenta encontrada!', description: `${addedCount} ferramenta(s) adicionada(s) ao pedido` });
+        toast.success('Ferramenta encontrada!', { description: `${addedCount} ferramenta(s) adicionada(s) ao pedido` });
       }
     } else {
-      toast({ title: 'Ferramenta não cadastrada', description: 'Nenhuma ferramenta dessa categoria foi encontrada no cadastro.', variant: 'destructive' });
+      toast.error('Ferramenta não cadastrada', { description: 'Nenhuma ferramenta dessa categoria foi encontrada no cadastro.' });
     }
   };
 
@@ -547,7 +546,7 @@ export function useUnifiedOrder() {
       if (!localUserId) throw new Error('Falha ao criar perfil');
       setCustomerUserId(localUserId);
       setSelectedCustomer(prev => prev ? { ...prev, local_user_id: localUserId } : prev);
-      toast({ title: 'Perfil criado', description: 'Agora cadastre as ferramentas.' });
+      toast.success('Perfil criado', { description: 'Agora cadastre as ferramentas.' });
       setAddToolDialogOpen(true);
     } catch (e) {
       logger.error('Failed to prepare local profile for staff add-tool flow', {
@@ -557,7 +556,7 @@ export function useUnifiedOrder() {
         codigoCliente: selectedCustomer.codigo_cliente,
         error: e,
       });
-      toast({ title: 'Erro', description: 'Não foi possível preparar o cadastro.', variant: 'destructive' });
+      toast.error('Erro', { description: 'Não foi possível preparar o cadastro.' });
     } finally {
       setCreatingLocalProfile(false);
     }
@@ -582,15 +581,13 @@ export function useUnifiedOrder() {
         supabase,
       });
       if (result.success) {
-        toast({ title: 'Orçamento salvo', description: result.results.join(' | ') });
+        toast.success('Orçamento salvo', { description: result.results.join(' | ') });
         clearCart();
         setNotes('');
         navigate('/sales/quotes');
       } else {
-        toast({
-          title: 'Erro ao salvar orçamento',
+        toast.error('Erro ao salvar orçamento', {
           description: result.errors[0]?.message || 'Falha desconhecida',
-          variant: 'destructive',
         });
       }
     } finally {
@@ -600,7 +597,7 @@ export function useUnifiedOrder() {
     selectedCustomer, cart.length, user, customerUserId,
     obenProductItems, colacorProductItems, obenSubtotal, colacorProdSubtotal,
     deliveryOption, addresses, selectedAddress, notes,
-    clearCart, toast, navigate,
+    clearCart, navigate,
   ]);
 
   const submitOrder = useCallback(async () => {
@@ -637,20 +634,17 @@ export function useUnifiedOrder() {
         clearCart();
         setNotes('');
         if (result.errors.length > 0) {
-          toast({
-            title: 'Pedido criado com avisos',
+          toast.success('Pedido criado com avisos', {
             description: result.errors.map(e => e.message).join(' | '),
           });
         }
       } else {
-        toast({
-          title: 'Erro ao criar pedido',
+        toast.error('Erro ao criar pedido', {
           description: result.errors[0]?.message || 'Falha desconhecida',
-          variant: 'destructive',
         });
       }
     } catch (error: any) {
-      toast({ title: 'Erro ao criar pedido', description: error.message, variant: 'destructive' });
+      toast.error('Erro ao criar pedido', { description: error.message });
     } finally {
       setSubmitting(false);
     }
@@ -664,7 +658,7 @@ export function useUnifiedOrder() {
     deliveryOption, addresses, selectedAddress,
     notes, readyByDate, ordemCompra,
     companyProfiles, defaultProductionAssigneeId,
-    getServicePrice, clearCart, toast,
+    getServicePrice, clearCart,
   ]);
 
   // clearCustomer defined earlier (wraps useCustomerSelection.clearCustomer + clears cart/ordemCompra/userTools)

--- a/src/pages/Addresses.tsx
+++ b/src/pages/Addresses.tsx
@@ -6,7 +6,7 @@ import { supabase } from '@/integrations/supabase/client';
 import { MapPin, Plus, Loader2, Home, Building, Trash2, Cloud, X, Truck, Info } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
-import { useToast } from '@/hooks/use-toast';
+import { toast } from 'sonner';
 import {
   Dialog,
   DialogContent,
@@ -45,7 +45,6 @@ const Addresses = () => {
   const [showAddDialog, setShowAddDialog] = useState(false);
   const [saving, setSaving] = useState(false);
   const [fetchingCep, setFetchingCep] = useState(false);
-  const { toast } = useToast();
 
   const [newAddress, setNewAddress] = useState({
     label: '',
@@ -68,7 +67,7 @@ const Addresses = () => {
       const data = await response.json();
       
       if (data.erro) {
-        toast({ title: 'CEP não encontrado', variant: 'destructive' });
+        toast.error('CEP não encontrado');
         return;
       }
 
@@ -133,9 +132,7 @@ const Addresses = () => {
       .update({ is_default: true })
       .eq('id', addressId);
 
-    toast({
-      title: 'Endereço padrão atualizado',
-    });
+    toast.success('Endereço padrão atualizado');
     
     loadAddresses();
   };
@@ -143,10 +140,8 @@ const Addresses = () => {
   const handleDelete = async (addressId: string) => {
     const address = addresses.find(a => a.id === addressId);
     if (address?.is_from_omie) {
-      toast({
-        title: 'Não é possível excluir',
+      toast.error('Não é possível excluir', {
         description: 'Este endereço está sincronizado com o Omie',
-        variant: 'destructive',
       });
       return;
     }
@@ -157,25 +152,17 @@ const Addresses = () => {
       .eq('id', addressId);
 
     if (!error) {
-      toast({
-        title: 'Endereço removido',
-      });
+      toast.success('Endereço removido');
       loadAddresses();
     } else {
-      toast({
-        title: 'Erro ao remover endereço',
-        variant: 'destructive',
-      });
+      toast.error('Erro ao remover endereço');
     }
   };
 
   const handleAddAddress = async () => {
     if (!newAddress.label || !newAddress.street || !newAddress.number || 
         !newAddress.neighborhood || !newAddress.city || !newAddress.state || !newAddress.zip_code) {
-      toast({
-        title: 'Preencha todos os campos obrigatórios',
-        variant: 'destructive',
-      });
+      toast.error('Preencha todos os campos obrigatórios');
       return;
     }
 
@@ -202,9 +189,7 @@ const Addresses = () => {
     setSaving(false);
 
     if (!error) {
-      toast({
-        title: 'Endereço adicionado',
-      });
+      toast.success('Endereço adicionado');
       setShowAddDialog(false);
       setNewAddress({
         label: '',
@@ -218,10 +203,7 @@ const Addresses = () => {
       });
       loadAddresses();
     } else {
-      toast({
-        title: 'Erro ao adicionar endereço',
-        variant: 'destructive',
-      });
+      toast.error('Erro ao adicionar endereço');
     }
   };
 

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -5,7 +5,7 @@ import { Card, CardContent } from '@/components/ui/card';
 import { KanbanBoard } from '@/components/KanbanBoard';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
-import { useToast } from '@/hooks/use-toast';
+import { toast } from 'sonner';
 import { Loader2, Users, ChevronRight, Clock, MapPin, Mail, BarChart3, Trophy, Gamepad2, BookOpen, DollarSign, Phone, FlaskConical } from 'lucide-react';
 
 interface OrderWithProfile {
@@ -27,8 +27,7 @@ interface OrderWithProfile {
 const Admin = () => {
   const navigate = useNavigate();
   const { user, isStaff, isAdmin, loading: authLoading } = useAuth();
-  const { toast } = useToast();
-  
+
   const [orders, setOrders] = useState<OrderWithProfile[]>([]);
   const [loading, setLoading] = useState(true);
   const [updatingOrder, setUpdatingOrder] = useState<string | null>(null);
@@ -102,18 +101,15 @@ const Admin = () => {
 
       if (error) throw error;
 
-      toast({
-        title: 'Status atualizado!',
+      toast.success('Status atualizado!', {
         description: `Status do pedido atualizado com sucesso`,
       });
 
       loadOrders();
     } catch (error) {
       console.error('Error updating order:', error);
-      toast({
-        title: 'Erro ao atualizar',
+      toast.error('Erro ao atualizar', {
         description: 'Não foi possível atualizar o status',
-        variant: 'destructive',
       });
     } finally {
       setUpdatingOrder(null);

--- a/src/pages/AdminApprovals.tsx
+++ b/src/pages/AdminApprovals.tsx
@@ -5,7 +5,7 @@ import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
-import { useToast } from '@/hooks/use-toast';
+import { toast } from 'sonner';
 import { Loader2, Check, X, UserCheck, Clock, Link2, AlertTriangle } from 'lucide-react';
 
 interface PendingUser {
@@ -22,7 +22,6 @@ interface PendingUser {
 const AdminApprovals = () => {
   const navigate = useNavigate();
   const { user, isStaff, loading: authLoading } = useAuth();
-  const { toast } = useToast();
   const [pendingUsers, setPendingUsers] = useState<PendingUser[]>([]);
   const [loading, setLoading] = useState(true);
   const [processing, setProcessing] = useState<string | null>(null);
@@ -146,43 +145,35 @@ const AdminApprovals = () => {
       // Step 3: Show feedback
       switch (omieResult) {
         case 'linked':
-          toast({
-            title: 'Aprovado e vinculado ao Omie ✓',
+          toast.success('Aprovado e vinculado ao Omie ✓', {
             description: `${pendingUser.name} foi aprovado e vinculado automaticamente.`,
           });
           break;
         case 'already_linked':
-          toast({
-            title: 'Usuário aprovado',
+          toast.success('Usuário aprovado', {
             description: 'Vínculo com Omie já existia.',
           });
           break;
         case 'not_found':
-          toast({
-            title: 'Aprovado — sem vínculo Omie',
+          toast.success('Aprovado — sem vínculo Omie', {
             description: 'Cliente não encontrado no Omie. Vincule manualmente se necessário.',
           });
           break;
         case 'no_data':
-          toast({
-            title: 'Usuário aprovado',
+          toast.success('Usuário aprovado', {
             description: 'Sem CPF/CNPJ para busca automática no Omie.',
           });
           break;
         case 'error':
-          toast({
-            title: 'Aprovado — erro no vínculo Omie',
+          toast.error('Aprovado — erro no vínculo Omie', {
             description: 'O usuário foi aprovado, mas a vinculação Omie falhou. Tente vincular manualmente.',
-            variant: 'destructive',
           });
           break;
       }
     } catch (error) {
       console.error('Error approving user:', error);
-      toast({
-        title: 'Erro',
+      toast.error('Erro', {
         description: 'Não foi possível aprovar o usuário.',
-        variant: 'destructive',
       });
     } finally {
       setProcessing(null);
@@ -200,16 +191,13 @@ const AdminApprovals = () => {
       if (error) throw error;
 
       setPendingUsers(prev => prev.filter(u => u.user_id !== profileUserId));
-      toast({
-        title: 'Cadastro rejeitado',
+      toast.success('Cadastro rejeitado', {
         description: 'O usuário foi removido.',
       });
     } catch (error) {
       console.error('Error rejecting user:', error);
-      toast({
-        title: 'Erro',
+      toast.error('Erro', {
         description: 'Não foi possível rejeitar o usuário.',
-        variant: 'destructive',
       });
     } finally {
       setProcessing(null);

--- a/src/pages/AdminCustomers.tsx
+++ b/src/pages/AdminCustomers.tsx
@@ -15,7 +15,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { AddToolDialog } from '@/components/AddToolDialog';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
-import { useToast } from '@/hooks/use-toast';
+import { toast } from 'sonner';
 import { cn } from '@/lib/utils';
 import {
   Loader2, Plus, Wrench, Trash2, Search, User, Phone, FileText,
@@ -397,7 +397,6 @@ function CustomerListView({
 
 /* ─── Customer 360 Profile View ─── */
 function RequiresPoToggle({ customer }: { customer: Customer }) {
-  const { toast } = useToast();
   const [checked, setChecked] = useState<boolean>(!!customer.requires_po);
   const [saving, setSaving] = useState(false);
 
@@ -412,10 +411,10 @@ function RequiresPoToggle({ customer }: { customer: Customer }) {
         .eq('user_id', customer.user_id);
       if (error) throw error;
       customer.requires_po = next;
-      toast({ title: next ? 'Cliente exige ordem de compra' : 'Ordem de compra desativada' });
+      toast.success(next ? 'Cliente exige ordem de compra' : 'Ordem de compra desativada');
     } catch (e: any) {
       setChecked(prev);
-      toast({ title: 'Erro ao salvar', description: e?.message, variant: 'destructive' });
+      toast.error('Erro ao salvar', { description: e?.message });
     } finally {
       setSaving(false);
     }
@@ -728,7 +727,6 @@ const AdminCustomers = () => {
   const navigate = useNavigate();
   const { customerId } = useParams<{ customerId?: string }>();
   const { user, isStaff, loading: authLoading } = useAuth();
-  const { toast } = useToast();
 
   const [selectedCustomer, setSelectedCustomer] = useState<Customer | null>(null);
   const [customerTools, setCustomerTools] = useState<UserTool[]>([]);
@@ -874,10 +872,10 @@ const AdminCustomers = () => {
     try {
       const { error } = await supabase.from('user_tools').delete().eq('id', toolId);
       if (error) throw error;
-      toast({ title: 'Ferramenta removida' });
+      toast.success('Ferramenta removida');
       setCustomerTools(prev => prev.filter(t => t.id !== toolId));
     } catch (error) {
-      toast({ title: 'Erro ao remover', variant: 'destructive' });
+      toast.error('Erro ao remover');
     }
   };
 

--- a/src/pages/AdminLoyalty.tsx
+++ b/src/pages/AdminLoyalty.tsx
@@ -7,7 +7,7 @@ import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
-import { useToast } from '@/hooks/use-toast';
+import { toast } from 'sonner';
 import { Loader2, Trophy, Search, Plus, Minus, Gift, Users, TrendingUp, DollarSign, BarChart3, Crown } from 'lucide-react';
 import { format } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
@@ -67,7 +67,6 @@ function getTier(balance: number) {
 export default function AdminLoyalty() {
   const navigate = useNavigate();
   const { user, isStaff, loading: authLoading } = useAuth();
-  const { toast } = useToast();
 
   const [customers, setCustomers] = useState<CustomerPoints[]>([]);
   const [allPoints, setAllPoints] = useState<PointRecord[]>([]);
@@ -153,7 +152,7 @@ export default function AdminLoyalty() {
     try {
       const pts = parseInt(adjustPoints);
       if (isNaN(pts) || pts <= 0) {
-        toast({ title: 'Pontos inválidos', variant: 'destructive' });
+        toast.error('Pontos inválidos');
         return;
       }
 
@@ -166,14 +165,14 @@ export default function AdminLoyalty() {
 
       if (error) throw error;
 
-      toast({ title: adjustType === 'earn' ? 'Pontos adicionados!' : 'Resgate aprovado!' });
+      toast.success(adjustType === 'earn' ? 'Pontos adicionados!' : 'Resgate aprovado!');
       setAdjustOpen(false);
       setAdjustPoints('');
       setAdjustDescription('');
       loadData();
     } catch (err) {
       console.error('Error adjusting points:', err);
-      toast({ title: 'Erro ao ajustar pontos', variant: 'destructive' });
+      toast.error('Erro ao ajustar pontos');
     } finally {
       setAdjusting(false);
     }

--- a/src/pages/AdminMonthlyReports.tsx
+++ b/src/pages/AdminMonthlyReports.tsx
@@ -6,7 +6,7 @@ import { Badge } from '@/components/ui/badge';
 import { Separator } from '@/components/ui/separator';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
-import { useToast } from '@/hooks/use-toast';
+import { toast } from 'sonner';
 import { 
   Loader2, Send, MessageCircle, Mail, Users, 
   AlertTriangle, CheckCircle, Wrench, Eye, ExternalLink 
@@ -40,7 +40,6 @@ interface CustomerReport {
 const AdminMonthlyReports = () => {
   const navigate = useNavigate();
   const { isStaff } = useAuth();
-  const { toast } = useToast();
 
   const [reports, setReports] = useState<CustomerReport[]>([]);
   const [loading, setLoading] = useState(false);
@@ -68,17 +67,14 @@ const AdminMonthlyReports = () => {
       setReports(data.reports || []);
       
       if (sendEmail) {
-        toast({
-          title: 'E-mails enviados!',
+        toast.success('E-mails enviados!', {
           description: `Relatórios enviados para ${data.reports_count} cliente(s)`,
         });
       }
     } catch (error: any) {
       console.error('Error:', error);
-      toast({
-        title: 'Erro',
+      toast.error('Erro', {
         description: error.message || 'Falha ao gerar relatórios',
-        variant: 'destructive',
       });
     } finally {
       setLoading(false);

--- a/src/pages/AdminPriceTable.tsx
+++ b/src/pages/AdminPriceTable.tsx
@@ -7,7 +7,7 @@ import { Badge } from '@/components/ui/badge';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
-import { useToast } from '@/hooks/use-toast';
+import { toast } from 'sonner';
 import { Loader2, Save, DollarSign } from 'lucide-react';
 
 interface DefaultPrice {
@@ -27,7 +27,6 @@ interface ToolCategory {
 const AdminPriceTable = () => {
   const navigate = useNavigate();
   const { user, loading: authLoading } = useAuth();
-  const { toast } = useToast();
 
   const [prices, setPrices] = useState<DefaultPrice[]>([]);
   const [categories, setCategories] = useState<ToolCategory[]>([]);
@@ -104,18 +103,15 @@ const AdminPriceTable = () => {
         if (error) throw error;
       }
 
-      toast({
-        title: 'Tabela atualizada!',
+      toast.success('Tabela atualizada!', {
         description: `${updates.length} preço(s) alterado(s)`,
       });
 
       loadData();
     } catch (error) {
       console.error('Error saving prices:', error);
-      toast({
-        title: 'Erro ao salvar',
+      toast.error('Erro ao salvar', {
         description: 'Não foi possível atualizar os preços',
-        variant: 'destructive',
       });
     } finally {
       setSaving(false);

--- a/src/pages/AdminRoutePlanner.tsx
+++ b/src/pages/AdminRoutePlanner.tsx
@@ -13,7 +13,7 @@ import { Checkbox } from '@/components/ui/checkbox';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
 import { useFarmerScoring } from '@/hooks/useFarmerScoring';
-import { useToast } from '@/hooks/use-toast';
+import { toast } from 'sonner';
 import { Loader2, MapPin, Clock, Route, Filter, Navigation, ExternalLink, Truck, ShoppingBag, Wrench, Layers, Phone, ArrowUp, ArrowRight, ArrowDown, Search, CheckCircle2, XCircle, Users } from 'lucide-react';
 import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
@@ -158,7 +158,6 @@ const STOP_CONFIG: Record<StopType, { label: string; color: string; bgClass: str
 const AdminRoutePlanner = () => {
   const navigate = useNavigate();
   const { user, isStaff, loading: authLoading } = useAuth();
-  const { toast } = useToast();
   const mapRef = useRef<HTMLDivElement>(null);
   const leafletMap = useRef<L.Map | null>(null);
   const markersRef = useRef<L.LayerGroup | null>(null);
@@ -295,7 +294,7 @@ const AdminRoutePlanner = () => {
       setLogisticStops(stops);
     } catch (error) {
       console.error('Error loading logistic stops:', error);
-      toast({ title: 'Erro ao carregar pedidos', variant: 'destructive' });
+      toast.error('Erro ao carregar pedidos');
     } finally {
       setLoading(false);
     }
@@ -394,7 +393,7 @@ const AdminRoutePlanner = () => {
       setManualCustomers(customers);
     } catch (error) {
       console.error('Error loading manual customers:', error);
-      toast({ title: 'Erro ao carregar clientes', variant: 'destructive' });
+      toast.error('Erro ao carregar clientes');
     } finally {
       setLoadingManual(false);
     }
@@ -467,10 +466,10 @@ const AdminRoutePlanner = () => {
         }));
         
         await loadTodayVisits();
-        toast({ title: 'Check-in realizado!', description: `Visita iniciada: ${customer.name}` });
+        toast.success('Check-in realizado!', { description: `Visita iniciada: ${customer.name}` });
       } catch (err) {
         console.error('Check-in error:', err);
-        toast({ title: 'Erro ao fazer check-in', variant: 'destructive' });
+        toast.error('Erro ao fazer check-in');
       }
     };
     
@@ -514,14 +513,14 @@ const AdminRoutePlanner = () => {
       
       setCheckoutOpen(false);
       await loadTodayVisits();
-      toast({ title: 'Check-out realizado!', description: `Visita finalizada: ${customerName}` });
-      
+      toast.success('Check-out realizado!', { description: `Visita finalizada: ${customerName}` });
+
       if (result === 'pedido_fechado') {
         navigate(`/sales/new?customer=${userId}`);
       }
     } catch (err) {
       console.error('Check-out error:', err);
-      toast({ title: 'Erro ao fazer check-out', variant: 'destructive' });
+      toast.error('Erro ao fazer check-out');
     }
   };
   
@@ -568,9 +567,9 @@ const AdminRoutePlanner = () => {
         }));
         
         await loadTodayVisits();
-        toast({ title: 'Check-in realizado!', description: `Visita iniciada: ${stop.customerName}` });
+        toast.success('Check-in realizado!', { description: `Visita iniciada: ${stop.customerName}` });
       } catch (err) {
-        toast({ title: 'Erro ao fazer check-in', variant: 'destructive' });
+        toast.error('Erro ao fazer check-in');
       }
     };
     
@@ -1342,7 +1341,7 @@ const AdminRoutePlanner = () => {
                 const tooMany = optimizedRoute.filter(s => s.lat && s.lng).length > 25;
 
                 if (tooMany) {
-                  toast({ title: 'Google Maps suporta até 25 paradas', description: 'Mostrando as 25 de maior prioridade.' });
+                  toast.success('Google Maps suporta até 25 paradas', { description: 'Mostrando as 25 de maior prioridade.' });
                 }
 
                 const waypoints = stopsWithCoords.map(s => `${s.lat},${s.lng}`);

--- a/src/pages/AdminTraining.tsx
+++ b/src/pages/AdminTraining.tsx
@@ -10,7 +10,7 @@ import { Badge } from '@/components/ui/badge';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
-import { useToast } from '@/hooks/use-toast';
+import { toast } from 'sonner';
 import { Loader2, Plus, Trash2, BookOpen, Edit, GripVertical } from 'lucide-react';
 
 interface QuizQuestion {
@@ -36,7 +36,6 @@ const emptyQuestion: QuizQuestion = { question: '', options: ['', '', '', ''], c
 const AdminTraining = () => {
   const navigate = useNavigate();
   const { isStaff, loading: authLoading, role } = useAuth();
-  const { toast } = useToast();
 
   const [modules, setModules] = useState<TrainingModule[]>([]);
   const [loading, setLoading] = useState(true);
@@ -95,12 +94,12 @@ const AdminTraining = () => {
 
   const handleSave = async () => {
     if (!title.trim()) {
-      toast({ title: 'Título obrigatório', variant: 'destructive' });
+      toast.error('Título obrigatório');
       return;
     }
     const validQuestions = questions.filter(q => q.question.trim() && q.options.some(o => o.trim()));
     if (validQuestions.length === 0) {
-      toast({ title: 'Adicione pelo menos uma pergunta válida', variant: 'destructive' });
+      toast.error('Adicione pelo menos uma pergunta válida');
       return;
     }
 
@@ -123,9 +122,9 @@ const AdminTraining = () => {
     }
 
     if (error) {
-      toast({ title: 'Erro ao salvar', description: error.message, variant: 'destructive' });
+      toast.error('Erro ao salvar', { description: error.message });
     } else {
-      toast({ title: editingId ? 'Módulo atualizado!' : 'Módulo criado!' });
+      toast.success(editingId ? 'Módulo atualizado!' : 'Módulo criado!');
       setDialogOpen(false);
       resetForm();
       loadModules();
@@ -136,7 +135,7 @@ const AdminTraining = () => {
   const deleteModule = async (id: string) => {
     const { error } = await supabase.from('training_modules').delete().eq('id', id);
     if (!error) {
-      toast({ title: 'Módulo excluído' });
+      toast.success('Módulo excluído');
       loadModules();
     }
   };

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Loader2, Wrench } from 'lucide-react';
 import { useAuth } from '@/contexts/AuthContext';
-import { useToast } from '@/hooks/use-toast';
+import { toast } from 'sonner';
 import { supabase } from '@/integrations/supabase/client';
 import { cn } from '@/lib/utils';
 import { LoginForm } from '@/components/auth/LoginForm';
@@ -13,7 +13,6 @@ import type { AuthMode, AuthFormData, OmieClienteData, ToolCategory } from '@/co
 const Auth = () => {
   const navigate = useNavigate();
   const { user, loading: authLoading, signIn } = useAuth();
-  const { toast } = useToast();
 
   const [mode, setMode] = useState<AuthMode>('login');
   const [isLoading, setIsLoading] = useState(false);
@@ -43,15 +42,15 @@ const Auth = () => {
       const { error } = await signIn(email, password);
       if (error) {
         if (error.message.includes('Invalid login credentials')) {
-          toast({ title: 'Erro ao entrar', description: 'E-mail ou senha incorretos', variant: 'destructive' });
+          toast.error('Erro ao entrar', { description: 'E-mail ou senha incorretos' });
         } else if (error.message.includes('Email not confirmed')) {
-          toast({ title: 'E-mail não confirmado', description: 'Verifique sua caixa de entrada para confirmar seu e-mail', variant: 'destructive' });
+          toast.error('E-mail não confirmado', { description: 'Verifique sua caixa de entrada para confirmar seu e-mail' });
         } else {
-          toast({ title: 'Erro ao entrar', description: error.message, variant: 'destructive' });
+          toast.error('Erro ao entrar', { description: error.message });
         }
         return;
       }
-      toast({ title: 'Bem-vindo!', description: 'Login realizado com sucesso' });
+      toast.success('Bem-vindo!', { description: 'Login realizado com sucesso' });
       navigate('/', { replace: true });
     } finally {
       setIsLoading(false);
@@ -76,9 +75,9 @@ const Auth = () => {
 
       if (signUpError) {
         if (signUpError.message.includes('User already registered')) {
-          toast({ title: 'E-mail já cadastrado', description: 'Este e-mail já está em uso. Tente fazer login.', variant: 'destructive' });
+          toast.error('E-mail já cadastrado', { description: 'Este e-mail já está em uso. Tente fazer login.' });
         } else {
-          toast({ title: 'Erro ao cadastrar', description: signUpError.message, variant: 'destructive' });
+          toast.error('Erro ao cadastrar', { description: signUpError.message });
         }
         return;
       }
@@ -119,7 +118,7 @@ const Auth = () => {
         }
       }
 
-      toast({ title: 'Conta criada!', description: 'Verifique seu e-mail para confirmar o cadastro' });
+      toast.success('Conta criada!', { description: 'Verifique seu e-mail para confirmar o cadastro' });
       setMode('login');
     } finally {
       setIsLoading(false);

--- a/src/pages/FarmerBundles.tsx
+++ b/src/pages/FarmerBundles.tsx
@@ -15,7 +15,7 @@ import {
   HelpCircle, ThumbsUp, ThumbsDown, Minus, RotateCcw, Save,
   ShoppingCart
 } from 'lucide-react';
-import { useToast } from '@/hooks/use-toast';
+import { toast } from 'sonner';
 
 const fmt = (v: number) => v.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
 
@@ -231,12 +231,11 @@ const BundleCardFull = ({
   const [argTab, setArgTab] = useState<'phone' | 'whatsapp' | 'tecnica'>('phone');
   const [activeSection, setActiveSection] = useState<'none' | 'args' | 'questions'>('none');
   const [copied, setCopied] = useState(false);
-  const { toast } = useToast();
 
   const copyText = (text: string) => {
     navigator.clipboard.writeText(text);
     setCopied(true);
-    toast({ title: 'Copiado!' });
+    toast.success('Copiado!');
     setTimeout(() => setCopied(false), 2000);
   };
 

--- a/src/pages/FarmerCalls.tsx
+++ b/src/pages/FarmerCalls.tsx
@@ -13,7 +13,7 @@ import { Separator } from '@/components/ui/separator';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
-import { useToast } from '@/hooks/use-toast';
+import { toast } from 'sonner';
 import { useFarmerScoring } from '@/hooks/useFarmerScoring';
 import { cn } from '@/lib/utils';
 import { Dialer } from '@/components/call/Dialer';
@@ -192,7 +192,6 @@ const AGENDA_TYPE_META: Record<string, { label: string; icon: typeof AlertTriang
 const FarmerCalls = () => {
   const navigate = useNavigate();
   const { user, isStaff, loading: authLoading } = useAuth();
-  const { toast } = useToast();
   const { agenda, clientScores, loading: agendaLoading } = useFarmerScoring();
 
   // Real Nvoip call integration for the dialog timer
@@ -447,10 +446,8 @@ const FarmerCalls = () => {
         if (mapping?.user_id) customerUserId = mapping.user_id;
       }
       if (!customerUserId) {
-        toast({
-          title: 'Cliente sem cadastro local',
+        toast.error('Cliente sem cadastro local', {
           description: 'Esse cliente Omie ainda não tem perfil no app. Crie um pedido primeiro para vinculá-lo.',
-          variant: 'destructive',
         });
         setSaving(false);
         return;
@@ -471,22 +468,20 @@ const FarmerCalls = () => {
       const noContactResults = ['sem_resposta', 'ocupado', 'caixa_postal', 'numero_errado'];
 
       if (noContactResults.includes(callResult)) {
-        toast({
-          title: 'Registrado — tente novamente',
+        toast.success('Registrado — tente novamente', {
           description: `Tentativa ${attemptNumber} anotada. Reagende para manter o contato ativo.`,
         });
       } else if (rev > 0) {
-        toast({
-          title: `🎯 Boa! ${rev.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' })} gerados`,
+        toast.success(`🎯 Boa! ${rev.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' })} gerados`, {
           description: 'Receita registrada com sucesso.',
         });
       } else {
-        toast({ title: 'Ligação registrada com sucesso' });
+        toast.success('Ligação registrada com sucesso');
       }
 
       resetForm(); setShowNewCall(false); loadCallLogs();
     } catch (error) {
-      toast({ title: 'Erro ao salvar ligação', variant: 'destructive' });
+      toast.error('Erro ao salvar ligação');
     } finally { setSaving(false); }
   };
 

--- a/src/pages/FarmerCopilot.tsx
+++ b/src/pages/FarmerCopilot.tsx
@@ -17,7 +17,7 @@ import {
   Minus, AlertTriangle, Loader2, ChevronRight, Phone, FileText,
   ChevronDown, ChevronUp, Type, Send
 } from 'lucide-react';
-import { useToast } from '@/hooks/use-toast';
+import { toast } from 'sonner';
 import { cn } from '@/lib/utils';
 
 // ─── Helpers ───────────────────────────────────────────────────────
@@ -56,7 +56,6 @@ type InputMode = 'voice' | 'text';
 const FarmerCopilot = () => {
   const navigate = useNavigate();
   const { user, isStaff } = useAuth();
-  const { toast } = useToast();
   const copilot = useCopilotEngine();
   const { getActivePlan } = useTacticalPlan();
   const [selectedCustomer, setSelectedCustomer] = useState<string>('');
@@ -156,7 +155,7 @@ const FarmerCopilot = () => {
       if (plan) {
         setActivePlan(plan);
         setShowPlan(true);
-        toast({ title: 'PTPL carregado', description: `Plano ${plan.planType} ativo para ${plan.customerName}` });
+        toast.success('PTPL carregado', { description: `Plano ${plan.planType} ativo para ${plan.customerName}` });
         bundleContext = plan.topBundle;
         if (customerContext) {
           customerContext.activePlan = {
@@ -172,7 +171,7 @@ const FarmerCopilot = () => {
     }
 
     return { customerContext, customerName, bundleContext };
-  }, [selectedCustomer, user, getActivePlan, toast]);
+  }, [selectedCustomer, user, getActivePlan]);
 
   // Start voice recording
   const handleStartVoice = useCallback(async () => {
@@ -198,20 +197,18 @@ const FarmerCopilot = () => {
         },
       });
 
-      toast({ title: 'Copiloto ativado', description: 'Transcrição em tempo real iniciada' });
+      toast.success('Copiloto ativado', { description: 'Transcrição em tempo real iniciada' });
     } catch (err: any) {
       console.error('Start error:', err);
       // Auto-fallback to text mode
       setInputMode('text');
-      toast({
-        variant: 'destructive',
-        title: 'Voz indisponível',
+      toast.error('Voz indisponível', {
         description: 'Transcrição por voz falhou. Modo texto ativado automaticamente.',
       });
     } finally {
       setIsConnecting(false);
     }
-  }, [selectedCustomer, user, copilot, scribe, toast, prepareSessionContext]);
+  }, [selectedCustomer, user, copilot, scribe, prepareSessionContext]);
 
   // Start text mode session
   const handleStartText = useCallback(async () => {
@@ -226,14 +223,14 @@ const FarmerCopilot = () => {
         bundleContext,
       });
 
-      toast({ title: 'Copiloto ativado', description: 'Modo texto — cole ou digite trechos da conversa' });
+      toast.success('Copiloto ativado', { description: 'Modo texto — cole ou digite trechos da conversa' });
     } catch (err: any) {
       console.error('Start error:', err);
-      toast({ variant: 'destructive', title: 'Erro', description: err.message || 'Falha ao iniciar copiloto' });
+      toast.error('Erro', { description: err.message || 'Falha ao iniciar copiloto' });
     } finally {
       setIsConnecting(false);
     }
-  }, [selectedCustomer, copilot, toast, prepareSessionContext]);
+  }, [selectedCustomer, copilot, prepareSessionContext]);
 
   // Unified start handler
   const handleStart = useCallback(async () => {
@@ -247,7 +244,7 @@ const FarmerCopilot = () => {
   // Analyze manual text — reuses same pipeline
   const handleAnalyzeManualText = useCallback(async () => {
     if (!manualText.trim() || manualText.trim().length < 10) {
-      toast({ variant: 'destructive', title: 'Texto curto', description: 'Digite pelo menos 10 caracteres para análise.' });
+      toast.error('Texto curto', { description: 'Digite pelo menos 10 caracteres para análise.' });
       return;
     }
     setIsManualAnalyzing(true);
@@ -257,7 +254,7 @@ const FarmerCopilot = () => {
     await copilot.triggerAnalysis();
     setManualText('');
     setIsManualAnalyzing(false);
-  }, [manualText, copilot, toast]);
+  }, [manualText, copilot]);
 
   // Stop recording
   const handleStop = useCallback(async () => {
@@ -265,8 +262,8 @@ const FarmerCopilot = () => {
       scribe.disconnect();
     }
     await copilot.endSession();
-    toast({ title: 'Sessão encerrada' });
-  }, [scribe, copilot, toast, inputMode]);
+    toast.success('Sessão encerrada');
+  }, [scribe, copilot, inputMode]);
 
   // Copy suggestion
   const handleCopySuggestion = useCallback((text: string) => {

--- a/src/pages/FarmerTacticalPlan.tsx
+++ b/src/pages/FarmerTacticalPlan.tsx
@@ -19,7 +19,7 @@ import {
   Plus, FileText, Brain, DollarSign, Clock, Zap, BarChart3,
   AlertCircle, Layers
 } from 'lucide-react';
-import { useToast } from '@/hooks/use-toast';
+import { toast } from 'sonner';
 
 // ─── Helpers ───────────────────────────────────────────────────────
 const fmt = (v: number) => v.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
@@ -42,7 +42,6 @@ const profileLabels: Record<string, string> = {
 const FarmerTacticalPlan = () => {
   const navigate = useNavigate();
   const { user, isStaff } = useAuth();
-  const { toast } = useToast();
   const { plans, loading, generating, loadPlans, generatePlan, checkEfficiency, recordResult } = useTacticalPlan();
   const [customers, setCustomers] = useState<{ id: string; name: string; healthScore: number; churnRisk: number }[]>([]);
   const [expandedPlan, setExpandedPlan] = useState<string | null>(null);

--- a/src/pages/FinanceiroConciliacao.tsx
+++ b/src/pages/FinanceiroConciliacao.tsx
@@ -8,7 +8,7 @@ import { Input } from '@/components/ui/input';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { COMPANIES, ALL_COMPANIES, type Company } from '@/contexts/CompanyContext';
 import { supabase } from '@/integrations/supabase/client';
-import { useToast } from '@/hooks/use-toast';
+import { toast } from 'sonner';
 import {
   Loader2, CheckCircle2, XCircle, AlertTriangle, ArrowLeftRight,
   Building2, Search, Filter, Ban, Eye
@@ -25,7 +25,6 @@ const statusConfig: Record<string, { label: string; color: string; icon: any }> 
 };
 
 const FinanceiroConciliacao = () => {
-  const { toast } = useToast();
   const [company, setCompany] = useState<Company>('oben');
   const [statusFilter, setStatusFilter] = useState('pendente');
   const [items, setItems] = useState<any[]>([]);
@@ -70,7 +69,7 @@ const FinanceiroConciliacao = () => {
       }
       setStats(s);
     } catch (e: any) {
-      toast({ title: 'Erro', description: e.message, variant: 'destructive' });
+      toast.error('Erro', { description: e.message });
     } finally {
       setLoading(false);
     }
@@ -90,12 +89,12 @@ const FinanceiroConciliacao = () => {
         updated_at: new Date().toISOString(),
       })
       .eq('id', id);
-    toast({ title: status === 'conciliado' ? 'Conciliado' : 'Ignorado' });
+    toast.success(status === 'conciliado' ? 'Conciliado' : 'Ignorado');
     load();
   };
 
   const gerarConciliacao = async () => {
-    toast({ title: 'Gerando fila de conciliação...' });
+    toast.success('Gerando fila de conciliação...');
     try {
       // Buscar movimentações não conciliadas
       const { data: movs } = await supabase
@@ -164,10 +163,10 @@ const FinanceiroConciliacao = () => {
 
         if (!error) criados++;
       }
-      toast({ title: `${criados} itens gerados na fila de conciliação` });
+      toast.success(`${criados} itens gerados na fila de conciliação`);
       load();
     } catch (e: any) {
-      toast({ title: 'Erro', description: e.message, variant: 'destructive' });
+      toast.error('Erro', { description: e.message });
     }
   };
 

--- a/src/pages/FinanceiroFechamento.tsx
+++ b/src/pages/FinanceiroFechamento.tsx
@@ -10,7 +10,7 @@ import {
   type Fechamento, type FechamentoLog,
 } from '@/services/financeiroV2Service';
 import { triggerFinanceiroSync } from '@/services/financeiroService';
-import { useToast } from '@/hooks/use-toast';
+import { toast } from 'sonner';
 import {
   Loader2, Building2, Lock, Unlock, CheckCircle2, Clock,
   FileText, Eye, RotateCcw, Plus, History, ShieldCheck, AlertTriangle
@@ -26,7 +26,6 @@ const statusConfig: Record<string, { label: string; color: string; icon: any }> 
 };
 
 const FinanceiroFechamento = () => {
-  const { toast } = useToast();
   const [company, setCompany] = useState<Company | 'all'>('all');
   const [ano, setAno] = useState(new Date().getFullYear());
   const [fechamentos, setFechamentos] = useState<Fechamento[]>([]);
@@ -41,7 +40,7 @@ const FinanceiroFechamento = () => {
       const data = await getFechamentos(company, ano);
       setFechamentos(data);
     } catch (e: any) {
-      toast({ title: 'Erro', description: e.message, variant: 'destructive' });
+      toast.error('Erro', { description: e.message });
     } finally {
       setLoading(false);
     }
@@ -55,10 +54,10 @@ const FinanceiroFechamento = () => {
       // First recalculate DRE for this month
       await triggerFinanceiroSync('calcular_dre', [co], { ano, meses: [mes] });
       await criarFechamento(co, ano, mes);
-      toast({ title: `Fechamento ${mesesNome[mes - 1]}/${ano} criado para ${COMPANIES[co].shortName}` });
+      toast.success(`Fechamento ${mesesNome[mes - 1]}/${ano} criado para ${COMPANIES[co].shortName}`);
       await load();
     } catch (e: any) {
-      toast({ title: 'Erro', description: e.message, variant: 'destructive' });
+      toast.error('Erro', { description: e.message });
     } finally {
       setActing(false);
     }
@@ -68,10 +67,10 @@ const FinanceiroFechamento = () => {
     setActing(true);
     try {
       await atualizarFechamento(id, acao, detalhes);
-      toast({ title: `Ação "${acao}" executada com sucesso` });
+      toast.success(`Ação "${acao}" executada com sucesso`);
       await load();
     } catch (e: any) {
-      toast({ title: 'Erro', description: e.message, variant: 'destructive' });
+      toast.error('Erro', { description: e.message });
     } finally {
       setActing(false);
     }

--- a/src/pages/FinanceiroIntercompany.tsx
+++ b/src/pages/FinanceiroIntercompany.tsx
@@ -8,13 +8,12 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@
 import { COMPANIES, ALL_COMPANIES, type Company } from '@/contexts/CompanyContext';
 import { getEliminacoes, upsertEliminacao, deleteEliminacao, type EliminacaoRegra } from '@/services/financeiroV2Service';
 import { supabase } from '@/integrations/supabase/client';
-import { useToast } from '@/hooks/use-toast';
+import { toast } from 'sonner';
 import { Loader2, Plus, Trash2, ArrowRight, Building2, Save, BarChart3 } from 'lucide-react';
 
 const fmt = (v: number) => v.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
 
 const FinanceiroIntercompany = () => {
-  const { toast } = useToast();
   const [regras, setRegras] = useState<EliminacaoRegra[]>([]);
   const [loading, setLoading] = useState(true);
   const [consolidado, setConsolidado] = useState<any[]>([]);
@@ -45,7 +44,7 @@ const FinanceiroIntercompany = () => {
         setConsolidado(cons || []);
       } catch { /* RPC may not exist */ }
     } catch (e: any) {
-      toast({ title: 'Erro', description: e.message, variant: 'destructive' });
+      toast.error('Erro', { description: e.message });
     } finally {
       setLoading(false);
     }
@@ -54,7 +53,7 @@ const FinanceiroIntercompany = () => {
   useEffect(() => { load(); }, [load]);
 
   const handleAdd = async () => {
-    if (!newRegra.descricao) return toast({ title: 'Preencha a descrição' });
+    if (!newRegra.descricao) { toast.success('Preencha a descrição'); return; }
     try {
       await upsertEliminacao({
         ...newRegra,
@@ -64,17 +63,17 @@ const FinanceiroIntercompany = () => {
         categoria_destino: null,
         ativo: true,
       } as any);
-      toast({ title: 'Regra criada' });
+      toast.success('Regra criada');
       setNewRegra(prev => ({ ...prev, descricao: '', cnpj_origem: '', cnpj_destino: '' }));
       load();
     } catch (e: any) {
-      toast({ title: 'Erro', description: e.message, variant: 'destructive' });
+      toast.error('Erro', { description: e.message });
     }
   };
 
   const handleDelete = async (id: string) => {
     await deleteEliminacao(id);
-    toast({ title: 'Regra removida' });
+    toast.success('Regra removida');
     load();
   };
 

--- a/src/pages/FinanceiroOrcamento.tsx
+++ b/src/pages/FinanceiroOrcamento.tsx
@@ -9,7 +9,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@
 import { COMPANIES, ALL_COMPANIES, type Company } from '@/contexts/CompanyContext';
 import { getDRE, DRE_LINHAS, type FinDRE } from '@/services/financeiroService';
 import { getOrcamento, upsertOrcamento, type OrcamentoLinha } from '@/services/financeiroV2Service';
-import { useToast } from '@/hooks/use-toast';
+import { toast } from 'sonner';
 import { Loader2, Save, Building2, Calendar, TrendingUp, TrendingDown, Target } from 'lucide-react';
 
 const fmt = (v: number) => v.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
@@ -24,7 +24,6 @@ const dreLinhas = DRE_LINHAS.map(l => l.value);
 const dreLabelMap = Object.fromEntries(DRE_LINHAS.map(l => [l.value, l.label]));
 
 const FinanceiroOrcamento = () => {
-  const { toast } = useToast();
   const [company, setCompany] = useState<Company>('oben');
   const [ano, setAno] = useState(new Date().getFullYear());
   const [orcamento, setOrcamento] = useState<OrcamentoLinha[]>([]);
@@ -49,7 +48,7 @@ const FinanceiroOrcamento = () => {
       for (const o of orc) d[`${o.mes}_${o.dre_linha}`] = o.valor_orcado;
       setDraft(d);
     } catch (e: any) {
-      toast({ title: 'Erro', description: e.message, variant: 'destructive' });
+      toast.error('Erro', { description: e.message });
     } finally {
       setLoading(false);
     }
@@ -67,11 +66,11 @@ const FinanceiroOrcamento = () => {
         linhas.push({ company, ano, mes: Number(mesStr), dre_linha: linha, valor_orcado: val });
       }
       await upsertOrcamento(linhas);
-      toast({ title: 'Orçamento salvo' });
+      toast.success('Orçamento salvo');
       setEditMode(false);
       load();
     } catch (e: any) {
-      toast({ title: 'Erro', description: e.message, variant: 'destructive' });
+      toast.error('Erro', { description: e.message });
     } finally {
       setSaving(false);
     }

--- a/src/pages/GovernanceCompanies.tsx
+++ b/src/pages/GovernanceCompanies.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
-import { useToast } from '@/hooks/use-toast';
+import { toast } from 'sonner';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -26,7 +26,6 @@ const ACCOUNT_LABEL: Record<string, string> = {
 export default function GovernanceCompanies() {
   const { user, role, loading: authLoading } = useAuth();
   const roleLoading = authLoading;
-  const { toast } = useToast();
   const [profiles, setProfiles] = useState<CompanyProfile[]>([]);
   const [loading, setLoading] = useState(true);
   const [savingId, setSavingId] = useState<string | null>(null);
@@ -41,13 +40,13 @@ export default function GovernanceCompanies() {
         .select('id, account, legal_name, cnpj, phone, address')
         .order('account');
       if (error) {
-        toast({ title: 'Erro ao carregar empresas', description: error.message, variant: 'destructive' });
+        toast.error('Erro ao carregar empresas', { description: error.message });
       } else {
         setProfiles((data || []) as CompanyProfile[]);
       }
       setLoading(false);
     })();
-  }, [user, toast]);
+  }, [user]);
 
   const updateField = (id: string, field: keyof CompanyProfile, value: string) => {
     setProfiles(prev => prev.map(p => (p.id === id ? { ...p, [field]: value } : p)));
@@ -66,9 +65,9 @@ export default function GovernanceCompanies() {
       .eq('id', profile.id);
     setSavingId(null);
     if (error) {
-      toast({ title: 'Erro ao salvar', description: error.message, variant: 'destructive' });
+      toast.error('Erro ao salvar', { description: error.message });
     } else {
-      toast({ title: 'Empresa atualizada' });
+      toast.success('Empresa atualizada');
     }
   };
 

--- a/src/pages/Loyalty.tsx
+++ b/src/pages/Loyalty.tsx
@@ -6,7 +6,7 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
-import { useToast } from '@/hooks/use-toast';
+import { toast } from 'sonner';
 import { format } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
 
@@ -36,7 +36,6 @@ const REWARDS = [
 export default function Loyalty() {
   const navigate = useNavigate();
   const { user } = useAuth();
-  const { toast } = useToast();
   const [history, setHistory] = useState<LoyaltyPoint[]>([]);
   const [loading, setLoading] = useState(true);
   const [redeemingReward, setRedeemingReward] = useState<string | null>(null);
@@ -74,7 +73,7 @@ export default function Loyalty() {
   const handleRedeem = async (reward: typeof REWARDS[0]) => {
     if (!user || redeemingReward) return;
     if (balance < reward.points) {
-      toast({ title: 'Saldo insuficiente', description: `Você precisa de ${reward.points} pontos. Saldo atual: ${balance}.`, variant: 'destructive' });
+      toast.error('Saldo insuficiente', { description: `Você precisa de ${reward.points} pontos. Saldo atual: ${balance}.` });
       return;
     }
 
@@ -102,11 +101,11 @@ export default function Loyalty() {
         });
       if (pointsError) throw pointsError;
 
-      toast({ title: 'Resgate realizado!', description: `${reward.name} resgatado com sucesso. Aguarde processamento.` });
+      toast.success('Resgate realizado!', { description: `${reward.name} resgatado com sucesso. Aguarde processamento.` });
       await loadPoints();
     } catch (err: any) {
       console.error('[Loyalty] Erro ao resgatar:', err);
-      toast({ title: 'Erro no resgate', description: err.message || 'Tente novamente.', variant: 'destructive' });
+      toast.error('Erro no resgate', { description: err.message || 'Tente novamente.' });
     } finally {
       setRedeemingReward(null);
     }

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -7,7 +7,7 @@ import { Label } from '@/components/ui/label';
 import { SharpeningSuggestions } from '@/components/SharpeningSuggestions';
 import { useAuth } from '@/contexts/AuthContext';
 import { supabase } from '@/integrations/supabase/client';
-import { useToast } from '@/hooks/use-toast';
+import { toast } from 'sonner';
 import { cn } from '@/lib/utils';
 import { useBiometricAuth } from '@/hooks/useBiometricAuth';
 import { useProfile, useProfileStats } from '@/queries/useProfile';
@@ -17,7 +17,6 @@ import { useQueryClient } from '@tanstack/react-query';
 const Profile = () => {
   const navigate = useNavigate();
   const { user, signOut, isStaff } = useAuth();
-  const { toast } = useToast();
   const fileInputRef = useRef<HTMLInputElement>(null);
   const queryClient = useQueryClient();
   
@@ -67,19 +66,15 @@ const Profile = () => {
     if (!file || !user) return;
 
     if (!file.type.startsWith('image/')) {
-      toast({
-        title: 'Arquivo inválido',
+      toast.error('Arquivo inválido', {
         description: 'Por favor, selecione uma imagem',
-        variant: 'destructive',
       });
       return;
     }
 
     if (file.size > 5 * 1024 * 1024) {
-      toast({
-        title: 'Arquivo muito grande',
+      toast.error('Arquivo muito grande', {
         description: 'A imagem deve ter no máximo 5MB',
-        variant: 'destructive',
       });
       return;
     }
@@ -109,16 +104,13 @@ const Profile = () => {
 
       queryClient.invalidateQueries({ queryKey: ['profile', user.id] });
 
-      toast({
-        title: 'Foto atualizada!',
+      toast.success('Foto atualizada!', {
         description: 'Sua foto de perfil foi alterada com sucesso',
       });
     } catch (error) {
       console.error('Error uploading avatar:', error);
-      toast({
-        title: 'Erro ao enviar foto',
+      toast.error('Erro ao enviar foto', {
         description: 'Tente novamente mais tarde',
-        variant: 'destructive',
       });
     } finally {
       setUploading(false);
@@ -128,15 +120,12 @@ const Profile = () => {
   const handleLogout = async () => {
     try {
       await signOut();
-      toast({
-        title: 'Até logo!',
+      toast.success('Até logo!', {
         description: 'Você saiu da sua conta',
       });
     } catch (error) {
-      toast({
-        title: 'Erro ao sair',
+      toast.error('Erro ao sair', {
         description: 'Tente novamente',
-        variant: 'destructive',
       });
     }
   };
@@ -177,19 +166,15 @@ const Profile = () => {
       // Validate delivery time against business hours and lunch
       if (editDeliveryTime && editBusinessOpen && editBusinessClose) {
         if (editDeliveryTime < editBusinessOpen || editDeliveryTime >= editBusinessClose) {
-          toast({
-            title: 'Horário inválido',
+          toast.error('Horário inválido', {
             description: `O horário de entrega deve ser entre ${editBusinessOpen} e ${editBusinessClose}`,
-            variant: 'destructive',
           });
           setSaving(false);
           return;
         }
         if (editLunchStart && editLunchEnd && editDeliveryTime >= editLunchStart && editDeliveryTime < editLunchEnd) {
-          toast({
-            title: 'Horário inválido',
+          toast.error('Horário inválido', {
             description: `O horário de entrega não pode ser durante o almoço (${editLunchStart} - ${editLunchEnd})`,
-            variant: 'destructive',
           });
           setSaving(false);
           return;
@@ -206,16 +191,13 @@ const Profile = () => {
       queryClient.invalidateQueries({ queryKey: ['profile', user.id] });
 
       setIsEditing(false);
-      toast({
-        title: 'Perfil atualizado!',
+      toast.success('Perfil atualizado!', {
         description: 'Suas informações foram salvas com sucesso',
       });
     } catch (error) {
       console.error('Error saving profile:', error);
-      toast({
-        title: 'Erro ao salvar',
+      toast.error('Erro ao salvar', {
         description: 'Tente novamente mais tarde',
-        variant: 'destructive',
       });
     } finally {
       setSaving(false);

--- a/src/pages/QualityChecklist.tsx
+++ b/src/pages/QualityChecklist.tsx
@@ -8,7 +8,7 @@ import { Label } from '@/components/ui/label';
 import { Badge } from '@/components/ui/badge';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
-import { useToast } from '@/hooks/use-toast';
+import { toast } from 'sonner';
 import { Loader2, Camera, CheckCircle2, XCircle, Upload, Shield } from 'lucide-react';
 
 interface OrderItem {
@@ -41,7 +41,6 @@ const CRITERIA = [
 const QualityChecklist = () => {
   const { id: orderId } = useParams<{ id: string }>();
   const { user, isStaff } = useAuth();
-  const { toast } = useToast();
 
   const [orderItems, setOrderItems] = useState<OrderItem[]>([]);
   const [checklists, setChecklists] = useState<Map<number, Checklist>>(new Map());
@@ -127,10 +126,10 @@ const QualityChecklist = () => {
       const photoField = type === 'before' ? 'before_photos' : 'after_photos';
       const updatedPhotos = [...current[photoField], urlData.publicUrl];
       updateChecklistField(itemIndex, photoField, updatedPhotos);
-      toast({ title: 'Foto enviada!' });
+      toast.success('Foto enviada!');
     } catch (error) {
       console.error('Error uploading photo:', error);
-      toast({ title: 'Erro ao enviar foto', variant: 'destructive' });
+      toast.error('Erro ao enviar foto');
     } finally {
       setUploadingPhoto(null);
     }
@@ -145,7 +144,7 @@ const QualityChecklist = () => {
       const allOk = cl.sharpness_ok && cl.balance_ok && cl.finish_ok && cl.dimensions_ok;
 
       if (cl.after_photos.length === 0) {
-        toast({ title: 'Foto obrigatória', description: 'Adicione pelo menos uma foto "Depois"', variant: 'destructive' });
+        toast.error('Foto obrigatória', { description: 'Adicione pelo menos uma foto "Depois"' });
         setSaving(false);
         return;
       }
@@ -176,10 +175,10 @@ const QualityChecklist = () => {
         }
       }
 
-      toast({ title: allOk ? '✅ Item aprovado!' : '⚠️ Checklist salvo com pendências' });
+      toast.success(allOk ? '✅ Item aprovado!' : '⚠️ Checklist salvo com pendências');
     } catch (error) {
       console.error('Error saving checklist:', error);
-      toast({ title: 'Erro ao salvar', variant: 'destructive' });
+      toast.error('Erro ao salvar');
     } finally {
       setSaving(false);
     }

--- a/src/pages/RecurringSchedules.tsx
+++ b/src/pages/RecurringSchedules.tsx
@@ -8,7 +8,7 @@ import { Checkbox } from '@/components/ui/checkbox';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
-import { useToast } from '@/hooks/use-toast';
+import { toast } from 'sonner';
 import { CalendarClock, Plus, Loader2, Trash2, Wrench, Pause, Play } from 'lucide-react';
 import { format, addDays } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
@@ -51,7 +51,6 @@ const FREQUENCY_OPTIONS = [
 
 const RecurringSchedules = () => {
   const { user } = useAuth();
-  const { toast } = useToast();
   const [schedules, setSchedules] = useState<Schedule[]>([]);
   const [userTools, setUserTools] = useState<UserTool[]>([]);
   const [addresses, setAddresses] = useState<AddressData[]>([]);
@@ -122,13 +121,13 @@ const RecurringSchedules = () => {
         next_order_date: format(nextDate, 'yyyy-MM-dd'),
       });
       if (error) throw error;
-      toast({ title: 'Agendamento criado!', description: `Próximo pedido em ${format(nextDate, "dd 'de' MMMM", { locale: ptBR })}` });
+      toast.success('Agendamento criado!', { description: `Próximo pedido em ${format(nextDate, "dd 'de' MMMM", { locale: ptBR })}` });
       setDialogOpen(false);
       setSelectedTools([]);
       loadData();
     } catch (error) {
       console.error('Error creating schedule:', error);
-      toast({ title: 'Erro', description: 'Não foi possível criar o agendamento', variant: 'destructive' });
+      toast.error('Erro', { description: 'Não foi possível criar o agendamento' });
     } finally {
       setSaving(false);
     }
@@ -141,7 +140,7 @@ const RecurringSchedules = () => {
         .eq('id', scheduleId);
       if (error) throw error;
       setSchedules(prev => prev.map(s => s.id === scheduleId ? { ...s, is_active: !currentActive } : s));
-      toast({ title: !currentActive ? 'Agendamento ativado' : 'Agendamento pausado' });
+      toast.success(!currentActive ? 'Agendamento ativado' : 'Agendamento pausado');
     } catch (error) {
       console.error('Error toggling schedule:', error);
     }
@@ -152,7 +151,7 @@ const RecurringSchedules = () => {
       const { error } = await (supabase as any).from('recurring_schedules').delete().eq('id', scheduleId);
       if (error) throw error;
       setSchedules(prev => prev.filter(s => s.id !== scheduleId));
-      toast({ title: 'Agendamento removido' });
+      toast.success('Agendamento removido');
     } catch (error) {
       console.error('Error deleting schedule:', error);
     }

--- a/src/pages/ResetPassword.tsx
+++ b/src/pages/ResetPassword.tsx
@@ -5,7 +5,7 @@ import { Loader2, Lock, Eye, EyeOff, Wrench, CheckCircle } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { useToast } from '@/hooks/use-toast';
+import { toast } from 'sonner';
 import { supabase } from '@/integrations/supabase/client';
 import { cn } from '@/lib/utils';
 
@@ -20,8 +20,7 @@ const resetPasswordSchema = z.object({
 const ResetPassword = () => {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
-  const { toast } = useToast();
-  
+
   const [isLoading, setIsLoading] = useState(false);
   const [isSuccess, setIsSuccess] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
@@ -42,17 +41,15 @@ const ResetPassword = () => {
       const type = searchParams.get('type');
       
       if (!session && !accessToken && type !== 'recovery') {
-        toast({
-          title: 'Link inválido',
+        toast.error('Link inválido', {
           description: 'O link de recuperação expirou ou é inválido',
-          variant: 'destructive',
         });
         navigate('/auth');
       }
     };
-    
+
     checkSession();
-  }, [navigate, searchParams, toast]);
+  }, [navigate, searchParams]);
 
   const handleInputChange = (field: string, value: string) => {
     setFormData(prev => ({ ...prev, [field]: value }));
@@ -90,8 +87,7 @@ const ResetPassword = () => {
       if (error) throw error;
 
       setIsSuccess(true);
-      toast({
-        title: 'Senha alterada!',
+      toast.success('Senha alterada!', {
         description: 'Sua senha foi redefinida com sucesso',
       });
 
@@ -101,10 +97,8 @@ const ResetPassword = () => {
       }, 2000);
     } catch (error: any) {
       console.error('Error resetting password:', error);
-      toast({
-        title: 'Erro ao redefinir senha',
+      toast.error('Erro ao redefinir senha', {
         description: error.message || 'Tente novamente mais tarde',
-        variant: 'destructive',
       });
     } finally {
       setIsLoading(false);

--- a/src/pages/SalesProducts.tsx
+++ b/src/pages/SalesProducts.tsx
@@ -7,7 +7,7 @@ import { Badge } from '@/components/ui/badge';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
-import { useToast } from '@/hooks/use-toast';
+import { toast } from 'sonner';
 import { Loader2, Search, RefreshCw, Package, ShoppingCart, BarChart3, Building2, ChevronLeft } from 'lucide-react';
 
 type Account = 'oben' | 'colacor';
@@ -28,7 +28,6 @@ interface Product {
 const SalesProducts = () => {
   const navigate = useNavigate();
   const { isStaff, loading: authLoading } = useAuth();
-  const { toast } = useToast();
 
   const [account, setAccount] = useState<Account>('oben');
   const [products, setProducts] = useState<Product[]>([]);
@@ -87,18 +86,15 @@ const SalesProducts = () => {
         nextPage = data.nextPage || null;
       }
 
-      toast({
-        title: 'Sincronização concluída!',
+      toast.success('Sincronização concluída!', {
         description: `${totalSynced} produtos sincronizados (${account === 'oben' ? 'Oben' : 'Colacor'}).`,
       });
 
       await loadProducts();
     } catch (error: any) {
       console.error('Erro ao sincronizar:', error);
-      toast({
-        title: 'Erro na sincronização',
+      toast.error('Erro na sincronização', {
         description: error.message || 'Não foi possível sincronizar os produtos.',
-        variant: 'destructive',
       });
     } finally {
       setSyncing(false);
@@ -118,17 +114,14 @@ const SalesProducts = () => {
         totalUpdated += data.totalUpdated || 0;
         nextPage = data.nextPage || null;
       }
-      toast({
-        title: 'Estoque atualizado!',
+      toast.success('Estoque atualizado!', {
         description: `${totalUpdated} produtos com estoque atualizado (${account === 'oben' ? 'Oben' : 'Colacor'}).`,
       });
       await loadProducts();
     } catch (error: any) {
       console.error('Erro ao sincronizar estoque:', error);
-      toast({
-        title: 'Erro ao atualizar estoque',
+      toast.error('Erro ao atualizar estoque', {
         description: error.message || 'Não foi possível sincronizar o estoque.',
-        variant: 'destructive',
       });
     } finally {
       setSyncingStock(false);

--- a/src/pages/Tools.tsx
+++ b/src/pages/Tools.tsx
@@ -6,7 +6,7 @@ import { Badge } from '@/components/ui/badge';
 import { AddToolDialog } from '@/components/AddToolDialog';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
-import { useToast } from '@/hooks/use-toast';
+import { toast } from 'sonner';
 import { Loader2, Plus, Wrench, Calendar, Trash2, Hash, Users, AlertTriangle, ShieldCheck, Clock, HelpCircle } from 'lucide-react';
 import { differenceInDays, format } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
@@ -69,7 +69,6 @@ function getCriticality(nextDue: string | null): Criticality {
 const Tools = () => {
   const navigate = useNavigate();
   const { user, isStaff } = useAuth();
-  const { toast } = useToast();
   const queryClient = useQueryClient();
 
   const { data: tools = [], isLoading: loading } = useUserTools(user?.id);
@@ -95,10 +94,10 @@ const Tools = () => {
     try {
       const { error } = await supabase.from('user_tools').delete().eq('id', toolId);
       if (error) throw error;
-      toast({ title: 'Ferramenta removida' });
+      toast.success('Ferramenta removida');
       queryClient.invalidateQueries({ queryKey: ['user-tools', user?.id] });
     } catch {
-      toast({ title: 'Erro ao remover', variant: 'destructive' });
+      toast.error('Erro ao remover');
     }
   };
 

--- a/src/pages/Training.tsx
+++ b/src/pages/Training.tsx
@@ -7,7 +7,7 @@ import { Progress } from '@/components/ui/progress';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
-import { useToast } from '@/hooks/use-toast';
+import { toast } from 'sonner';
 import { Loader2, BookOpen, CheckCircle2, XCircle, PlayCircle, Award, Sparkles, ArrowRight, Trophy, Target } from 'lucide-react';
 
 interface QuizQuestion {
@@ -36,7 +36,6 @@ interface Completion {
 const Training = () => {
   const navigate = useNavigate();
   const { user } = useAuth();
-  const { toast } = useToast();
 
   const [modules, setModules] = useState<TrainingModule[]>([]);
   const [completions, setCompletions] = useState<Completion[]>([]);
@@ -93,12 +92,12 @@ const Training = () => {
     });
 
     if (error) {
-      toast({ title: 'Erro ao salvar resultado', variant: 'destructive' });
+      toast.error('Erro ao salvar resultado');
     } else {
       if (passed) {
-        toast({ title: `Parabéns! Você ganhou ${activeModule.points_reward} pontos de educação!`, description: `Nota: ${scorePercent}%` });
+        toast.success(`Parabéns! Você ganhou ${activeModule.points_reward} pontos de educação!`, { description: `Nota: ${scorePercent}%` });
       } else {
-        toast({ title: 'Não atingiu a nota mínima', description: `Nota: ${scorePercent}% (mínimo: ${activeModule.min_score}%)`, variant: 'destructive' });
+        toast.error('Não atingiu a nota mínima', { description: `Nota: ${scorePercent}% (mínimo: ${activeModule.min_score}%)` });
       }
       setCompletions(prev => [...prev, { module_id: activeModule.id, passed, quiz_score: scorePercent }]);
     }


### PR DESCRIPTION
## Sumário

Auditoria identificou que 70% dos callsites de toast ainda usavam o wrapper `@deprecated` (`use-toast.ts`). PR #29 migrou os 4 engines IA. Este PR **fecha o loop** migrando os 48 files restantes (229 callsites totais).

## Conversão (mesmo padrão do PR #29)

```ts
// import
import { useToast } from '@/hooks/use-toast';
// →
import { toast } from 'sonner';

// hook destructure (deletado)
const { toast } = useToast();
// → (linha removida)

// destructive
toast({ title: X, variant: 'destructive' })           → toast.error(X)
toast({ title: X, variant: 'destructive', description: Y }) → toast.error(X, { description: Y })

// success (default)
toast({ title: X })                                    → toast.success(X)
toast({ title: X, description: Y })                    → toast.success(X, { description: Y })
```

Bonus: `toast` removido das deps de `useCallback`/`useEffect` (sonner `toast` é stable).

## Files migrados (48)

| Tipo | Qtd | Exemplos |
|---|---|---|
| Components | 11 | UnifiedAIAssistant (16 calls), VoiceServiceInput (11), SendingQualityChecklist |
| Hooks | 10 | useAdminOrderDetail (12), useBiometricAuth (10), useUnifiedOrder (10) |
| Pages | 27 | Profile (10), AdminRoutePlanner (9), AdminApprovals (8), Addresses (8), FarmerCopilot (7) |

## Casos especiais tratados

- **`OrderReview.tsx:39`** — `variant: 'default'` convertido pra `toast(...)` neutro (mantém semântica info do wrapper original)
- **`FinanceiroIntercompany.tsx:57`** — `return toast({...})` early-exit rewriting: separado em `{ toast.success(...); return; }` (sonner toast retorna id, não é early-exit válido)
- **Zero ocorrências** de `.dismiss()`, `.update()`, ou `action: <ToastAction />`
- **Zero renames** `const { toast: notify } = useToast()`

## Status do wrapper

`use-toast.ts` permanece como `@deprecated` mas SEM consumidores em `src/` agora. Pode ser deletado em PR futuro, mas mantido por enquanto pra evitar surpresa se algum arquivo novo importar (CI/lint não bloqueia).

## Validação
- [x] `bun test` — 131/131 passam
- [x] `bun build` — limpa em ~42s
- [x] `bun lint` — **1394 problemas** (era 1398; **net -4** — destructure removals)

## Net diff
48 files changed, 310 insertions(+), 512 deletions(-)

🤖 Generated with [Claude Code](https://claude.com/claude-code)