### PR TITLE
perf(edge): fix N+1 em omie-vendas-sync + omie-sync (Promise.all com concurrency)

### DIFF
--- a/supabase/functions/omie-sync/index.ts
+++ b/supabase/functions/omie-sync/index.ts
@@ -1179,33 +1179,42 @@ serve(async (req) => {
 
         let deletedCount = 0;
         
-        for (const os of (allOs || [])) {
-          try {
-            const consultaResult = await callOmieApi("servicos/os/", "ConsultarOS", {
-              nCodOS: os.omie_codigo_os,
-            }) as any;
-            
-            if (consultaResult.faultstring) {
-              console.log(`[Omie] OS ${os.omie_numero_os} não existe mais no Omie, excluindo localmente...`);
-              // Hard delete
-              await supabaseAdmin.from("omie_ordens_servico").delete().eq("order_id", os.order_id);
-              await supabaseAdmin.from("order_messages").delete().eq("order_id", os.order_id);
-              await supabaseAdmin.from("order_reviews").delete().eq("order_id", os.order_id);
-              await supabaseAdmin.from("loyalty_points").delete().eq("order_id", os.order_id);
-              await supabaseAdmin.from("sending_quality_logs").delete().eq("order_id", os.order_id);
-              await supabaseAdmin.from("orders").delete().eq("id", os.order_id);
+        // Helper: deleta a OS de todas as 6 tabelas em paralelo (independentes)
+        // Antes: 6 awaits sequenciais — O(6 round-trips) por OS. Agora: Promise.all =
+        // 1 round-trip (6 paralelos), reduz tempo total ~6×.
+        const deleteOrphanOs = async (orderId: string) => {
+          await Promise.all([
+            supabaseAdmin.from("omie_ordens_servico").delete().eq("order_id", orderId),
+            supabaseAdmin.from("order_messages").delete().eq("order_id", orderId),
+            supabaseAdmin.from("order_reviews").delete().eq("order_id", orderId),
+            supabaseAdmin.from("loyalty_points").delete().eq("order_id", orderId),
+            supabaseAdmin.from("sending_quality_logs").delete().eq("order_id", orderId),
+            supabaseAdmin.from("orders").delete().eq("id", orderId),
+          ]);
+        };
+
+        // Outer loop também paraleliza (chunks de 5) pra não floodar API Omie.
+        // ConsultarOS chama API externa; manter concorrência conservadora.
+        const CHUNK = 5;
+        for (let i = 0; i < (allOs || []).length; i += CHUNK) {
+          const chunk = (allOs || []).slice(i, i + CHUNK);
+          await Promise.all(chunk.map(async (os) => {
+            try {
+              const consultaResult = await callOmieApi("servicos/os/", "ConsultarOS", {
+                nCodOS: os.omie_codigo_os,
+              }) as any;
+
+              if (consultaResult.faultstring) {
+                console.log(`[Omie] OS ${os.omie_numero_os} não existe mais no Omie, excluindo localmente...`);
+                await deleteOrphanOs(os.order_id);
+                deletedCount++;
+              }
+            } catch {
+              console.log(`[Omie] OS ${os.omie_numero_os} possivelmente excluída, removendo...`);
+              await deleteOrphanOs(os.order_id);
               deletedCount++;
             }
-          } catch {
-            console.log(`[Omie] OS ${os.omie_numero_os} possivelmente excluída, removendo...`);
-            await supabaseAdmin.from("omie_ordens_servico").delete().eq("order_id", os.order_id);
-            await supabaseAdmin.from("order_messages").delete().eq("order_id", os.order_id);
-            await supabaseAdmin.from("order_reviews").delete().eq("order_id", os.order_id);
-            await supabaseAdmin.from("loyalty_points").delete().eq("order_id", os.order_id);
-            await supabaseAdmin.from("sending_quality_logs").delete().eq("order_id", os.order_id);
-            await supabaseAdmin.from("orders").delete().eq("id", os.order_id);
-            deletedCount++;
-          }
+          }));
         }
 
         console.log(`[Omie] Sincronização de exclusões concluída: ${deletedCount} pedidos removidos`);

--- a/supabase/functions/omie-vendas-sync/index.ts
+++ b/supabase/functions/omie-vendas-sync/index.ts
@@ -761,15 +761,23 @@ async function syncPedidos(
     const uniqueClientCodes = [...new Set(pedidos.map((p: any) => p.cabecalho?.codigo_cliente).filter(Boolean))] as number[];
     const unknownCodes = uniqueClientCodes.filter(c => !clientCache.has(c));
     if (unknownCodes.length > 0) {
-      console.log(`[sync_pedidos][${account}] Resolving ${unknownCodes.length} unknown clients via API`);
-      for (const code of unknownCodes) await resolveClientUserId(code);
+      console.log(`[sync_pedidos][${account}] Resolving ${unknownCodes.length} unknown clients via API (concurrency=5)`);
+      // Antes: for of await (serial). Agora: chunks de 5 em paralelo pra acelerar
+      // sem floodar API Omie (rate limits Omie não documentados; 5 é conservador).
+      const CHUNK = 5;
+      for (let i = 0; i < unknownCodes.length; i += CHUNK) {
+        await Promise.all(unknownCodes.slice(i, i + CHUNK).map(c => resolveClientUserId(c)));
+      }
     }
 
     // Pre-fetch address/phone for all clients on this page that aren't cached yet
     const codesNeedingAddress = uniqueClientCodes.filter(c => !clientAddressCache.has(c) && clientCache.has(c) && clientCache.get(c));
     if (codesNeedingAddress.length > 0) {
-      console.log(`[sync_pedidos][${account}] Fetching address/phone for ${codesNeedingAddress.length} clients`);
-      for (const code of codesNeedingAddress) await getClientAddressPhone(code);
+      console.log(`[sync_pedidos][${account}] Fetching address/phone for ${codesNeedingAddress.length} clients (concurrency=5)`);
+      const CHUNK = 5;
+      for (let i = 0; i < codesNeedingAddress.length; i += CHUNK) {
+        await Promise.all(codesNeedingAddress.slice(i, i + CHUNK).map(c => getClientAddressPhone(c)));
+      }
     }
 
     // ── Prepare batch arrays ──


### PR DESCRIPTION
## Sumário

Auditoria identificou **3 N+1 patterns em Edge Functions Omie**. Esta PR corrige com concorrência conservadora (chunks de 5 paralelos) pra não floodar API externa Omie (rate limits não documentados publicamente).

## Fixes

### omie-vendas-sync:765,772
- `for of unknownCodes await resolveClientUserId(c)` — serial → **chunks de 5 paralelos**
- `for of codesNeedingAddress await getClientAddressPhone(c)` — serial → **chunks de 5 paralelos**

Ambos chamam Omie API; serial era ~5× mais lento que necessário.

### omie-sync:1182-1208 — outer loop + inner 6 deletes
- **Outer**: `for of allOs await ConsultarOS` — agora chunks de 5 paralelos
- **Inner**: 6 deletes sequenciais (omie_ordens_servico, order_messages, order_reviews, loyalty_points, sending_quality_logs, orders) → extraído pra helper `deleteOrphanOs` usando `Promise.all([6 deletes em paralelo])`

| Métrica | Antes | Depois |
|---|---|---|
| Round-trips Supabase por orphan | 6 sequenciais | 1 (6 paralelos) |
| Round-trips Omie por chunk | 5 sequenciais | 1 (5 paralelos) |
| Pra 100 orphans | 600 awaits | ~20 awaits |

## Concorrência conservadora

`CHUNK=5` escolhido sem ter rate limits Omie documentados. Se vier 429 em prod, fácil ajustar pra 3 ou 1.

## Validação
- [x] `bun test` — 167/167 passam
- [x] `bun build` — limpa
- [x] `bun lint` — 1401 problemas (era 1394; +7 — patterns `any` em Edge Function continuam, helper novo adiciona ~3 lines com tipo implícito Supabase)

## Net diff
2 files changed, 46 insertions(+), 29 deletions(-)

## Trade-offs

- Edge Functions Deno: NÃO testáveis localmente sem Deno + supabase functions serve. Validação é tsc do client + leitura de código.
- Recomendado: deploy em staging e observar logs de "[sync_pedidos] Resolving N unknown clients via API (concurrency=5)" + tempo total reduzido vs antes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)