### PR TITLE
user_departments — persistência de departamento operacional + UI admin

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -65,6 +65,7 @@ const FarmerTacticalPlan = lazy(() => import("./pages/FarmerTacticalPlan"));
 const FarmerIPFDashboard = lazy(() => import("./pages/FarmerIPFDashboard"));
 const ExecutiveDashboard = lazy(() => import("./pages/ExecutiveDashboard"));
 const AdminApprovals = lazy(() => import("./pages/AdminApprovals"));
+const AdminDepartments = lazy(() => import("./pages/AdminDepartments"));
 const NotFound = lazy(() => import("./pages/NotFound"));
 const DesignSystem = lazy(() => import("./pages/DesignSystem"));
 const DesignPreview = lazy(() => import("./pages/DesignPreview"));
@@ -195,6 +196,7 @@ const App = () => (
               <Route path="support" element={<Support />} />
               <Route path="admin" element={<Admin />} />
               <Route path="admin/approvals" element={<AdminApprovals />} />
+              <Route path="admin/departments" element={<AdminDepartments />} />
               <Route path="admin/customers" element={<AdminCustomers />} />
               <Route path="admin/customers/:customerId" element={<AdminCustomers />} />
               <Route path="admin/orders/:id" element={<AdminOrderDetail />} />

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -134,6 +134,7 @@ const unifiedNavSections: { title: string; items: NavItem[] }[] = [
     title: 'Gestão',
     items: [
       { icon: UserCheck, label: 'Liberar Acessos', path: '/admin/approvals', managerOnly: true },
+      { icon: Users, label: 'Departamentos', path: '/admin/departments', managerOnly: true },
       { icon: Shield, label: 'Admin & Relatórios', path: '/gestao/admin', managerOnly: true },
       { icon: Lock, label: 'Governança', path: '/gestao/governanca', managerOnly: true },
     ],

--- a/src/hooks/__tests__/useUserDepartment.test.tsx
+++ b/src/hooks/__tests__/useUserDepartment.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    from: vi.fn(),
+  },
+}));
+
+import { useAuth } from '@/contexts/AuthContext';
+import { supabase } from '@/integrations/supabase/client';
+import { useUserDepartment } from '../useUserDepartment';
+
+const mockedUseAuth = vi.mocked(useAuth);
+const mockedFrom = vi.mocked(supabase.from);
+
+function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+describe('useUserDepartment', () => {
+  beforeEach(() => {
+    mockedUseAuth.mockReset();
+    mockedFrom.mockReset();
+  });
+
+  it('returns null when no user', () => {
+    mockedUseAuth.mockReturnValue({ user: null } as ReturnType<typeof useAuth>);
+    const { result } = renderHook(() => useUserDepartment(), { wrapper });
+    expect(result.current.department).toBeNull();
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('queries primary_dept when user present', async () => {
+    mockedUseAuth.mockReturnValue({
+      user: { id: 'user-1' },
+    } as ReturnType<typeof useAuth>);
+
+    const maybeSingle = vi.fn().mockResolvedValue({ data: { department: 'comprador' } });
+    const eqPrimary = vi.fn().mockReturnValue({ maybeSingle });
+    const eqUser = vi.fn().mockReturnValue({ eq: eqPrimary });
+    const select = vi.fn().mockReturnValue({ eq: eqUser });
+    mockedFrom.mockReturnValue({ select } as unknown as ReturnType<typeof supabase.from>);
+
+    const { result } = renderHook(() => useUserDepartment(), { wrapper });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.department).toBe('comprador');
+    expect(mockedFrom).toHaveBeenCalledWith('user_departments');
+    expect(select).toHaveBeenCalledWith('department');
+    expect(eqUser).toHaveBeenCalledWith('user_id', 'user-1');
+    expect(eqPrimary).toHaveBeenCalledWith('primary_dept', true);
+  });
+
+  it('returns null when no row found', async () => {
+    mockedUseAuth.mockReturnValue({
+      user: { id: 'user-2' },
+    } as ReturnType<typeof useAuth>);
+
+    const maybeSingle = vi.fn().mockResolvedValue({ data: null });
+    const eqPrimary = vi.fn().mockReturnValue({ maybeSingle });
+    const eqUser = vi.fn().mockReturnValue({ eq: eqPrimary });
+    const select = vi.fn().mockReturnValue({ eq: eqUser });
+    mockedFrom.mockReturnValue({ select } as unknown as ReturnType<typeof supabase.from>);
+
+    const { result } = renderHook(() => useUserDepartment(), { wrapper });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.department).toBeNull();
+  });
+});

--- a/src/hooks/useDepartmentsAdmin.ts
+++ b/src/hooks/useDepartmentsAdmin.ts
@@ -1,0 +1,133 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import { useAuth } from '@/contexts/AuthContext';
+import type { Department } from '@/integrations/supabase/types-departments';
+
+export interface StaffUserRow {
+  user_id: string;
+  name: string | null;
+  email: string | null;
+  department: Department | null;
+  is_approved: boolean;
+}
+
+/**
+ * Lista staff (não-customer) + dept primário current. Para tela admin.
+ */
+export function useStaffUsersWithDept() {
+  return useQuery<StaffUserRow[]>({
+    queryKey: ['admin', 'departments', 'staff-users'],
+    queryFn: async () => {
+      // 1. Pega profiles staff (não customer)
+      const { data: profiles, error } = await supabase
+        .from('profiles')
+        .select('user_id, name, email, is_approved')
+        .order('name', { ascending: true });
+      if (error) throw error;
+
+      const ids = (profiles ?? []).map((p) => (p as { user_id: string }).user_id);
+      if (ids.length === 0) return [];
+
+      // 2. Filtra customer roles fora
+      const { data: roles } = await supabase
+        .from('user_roles')
+        .select('user_id, role')
+        .in('user_id', ids);
+      const roleMap = new Map<string, string>();
+      (roles ?? []).forEach((r) => {
+        const row = r as { user_id: string; role: string };
+        roleMap.set(row.user_id, row.role);
+      });
+
+      // 3. Carrega depts primários
+      const { data: depts } = await supabase
+        .from('user_departments')
+        .select('user_id, department')
+        .eq('primary_dept', true)
+        .in('user_id', ids);
+      const deptMap = new Map<string, Department>();
+      (depts ?? []).forEach((d) => {
+        const row = d as { user_id: string; department: Department };
+        deptMap.set(row.user_id, row.department);
+      });
+
+      return (profiles ?? [])
+        .filter((p) => roleMap.get((p as { user_id: string }).user_id) !== 'customer')
+        .map((p) => {
+          const row = p as {
+            user_id: string;
+            name: string | null;
+            email: string | null;
+            is_approved: boolean;
+          };
+          return {
+            user_id: row.user_id,
+            name: row.name,
+            email: row.email,
+            is_approved: row.is_approved,
+            department: deptMap.get(row.user_id) ?? null,
+          };
+        });
+    },
+    staleTime: 60 * 1000,
+  });
+}
+
+/**
+ * Atribui dept primário ao usuário (substitui se já tiver).
+ * Transação client-side: UPDATE old primary=false → INSERT new primary=true.
+ * Em caso de race, o constraint UNIQUE EXCLUDE garante consistência.
+ */
+export function useAssignDepartment() {
+  const queryClient = useQueryClient();
+  const { user } = useAuth();
+
+  return useMutation({
+    mutationFn: async ({ userId, department }: { userId: string; department: Department }) => {
+      // 1. Desativa primário atual (se existir)
+      await supabase
+        .from('user_departments')
+        .update({ primary_dept: false })
+        .eq('user_id', userId)
+        .eq('primary_dept', true);
+
+      // 2. Insere novo como primário
+      const { error } = await supabase
+        .from('user_departments')
+        .insert({
+          user_id: userId,
+          department,
+          primary_dept: true,
+          created_by: user?.id ?? null,
+        });
+      if (error) throw error;
+      return { userId, department };
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['admin', 'departments'] });
+      queryClient.invalidateQueries({ queryKey: ['user-department'] });
+    },
+  });
+}
+
+/**
+ * Remove TODOS os depts do usuário (não só primário). Reset full.
+ */
+export function useRemoveAllDepartments() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ userId }: { userId: string }) => {
+      const { error } = await supabase
+        .from('user_departments')
+        .delete()
+        .eq('user_id', userId);
+      if (error) throw error;
+      return { userId };
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['admin', 'departments'] });
+      queryClient.invalidateQueries({ queryKey: ['user-department'] });
+    },
+  });
+}

--- a/src/hooks/usePersona.ts
+++ b/src/hooks/usePersona.ts
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
 import { useCommercialRole } from '@/hooks/useCommercialRole';
 import { useSalesOnlyRestriction } from '@/hooks/useSalesOnlyRestriction';
+import { useUserDepartment } from '@/hooks/useUserDepartment';
 import { getRouteCounts } from '@/lib/dashboard/route-tracker';
 import { inferPersona, type InferPersonaResult } from '@/lib/dashboard/persona-detect';
 import type { Persona } from '@/lib/dashboard/persona-config';
@@ -23,6 +24,7 @@ export function usePersona(): InferPersonaResult {
   const { role } = useAuth();
   const { commercialRole } = useCommercialRole();
   const isSalesOnly = useSalesOnlyRestriction();
+  const { department } = useUserDepartment();
 
   return useMemo(() => {
     return inferPersona({
@@ -31,7 +33,7 @@ export function usePersona(): InferPersonaResult {
       commercialRole,
       isSalesOnly,
       routeCounts: getRouteCounts(),
+      userDepartment: department,
     });
-    // Re-resolve quando sinais mudam. routeCounts é lido fresh do storage a cada call.
-  }, [role, commercialRole, isSalesOnly]);
+  }, [role, commercialRole, isSalesOnly, department]);
 }

--- a/src/hooks/useUserDepartment.ts
+++ b/src/hooks/useUserDepartment.ts
@@ -1,0 +1,36 @@
+import { useQuery } from '@tanstack/react-query';
+import { useAuth } from '@/contexts/AuthContext';
+import { supabase } from '@/integrations/supabase/client';
+import type { Department } from '@/integrations/supabase/types-departments';
+
+export interface UseUserDepartmentReturn {
+  department: Department | null;
+  isLoading: boolean;
+}
+
+/**
+ * Departamento primário do usuário corrente. Lê `user_departments` filtrando
+ * `primary_dept = true`. Reutilizado por `usePersona` como 4º sinal.
+ */
+export function useUserDepartment(): UseUserDepartmentReturn {
+  const { user } = useAuth();
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['user-department', user?.id],
+    queryFn: async (): Promise<Department | null> => {
+      if (!user?.id) return null;
+      const { data } = await supabase
+        .from('user_departments')
+        .select('department')
+        .eq('user_id', user.id)
+        .eq('primary_dept', true)
+        .maybeSingle();
+      const row = data as { department?: Department } | null;
+      return row?.department ?? null;
+    },
+    enabled: !!user?.id,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  return { department: data ?? null, isLoading: !!user?.id && isLoading };
+}

--- a/src/integrations/supabase/types-departments.ts
+++ b/src/integrations/supabase/types-departments.ts
@@ -1,0 +1,60 @@
+/**
+ * Extensão manual do Database type para a tabela user_departments
+ * adicionada na migration 20260517120000.
+ *
+ * Quando o gen types rodar via Supabase CLI, esses tipos virão automatic
+ * em src/integrations/supabase/types.ts e este arquivo pode ser removido.
+ */
+
+export type Department =
+  | 'separador'
+  | 'conferente'
+  | 'comprador'
+  | 'tintometrico'
+  | 'financeiro'
+  | 'vendas'
+  | 'gestao'
+  | 'outro';
+
+export interface UserDepartmentRow {
+  id: string;
+  user_id: string;
+  department: Department;
+  primary_dept: boolean;
+  created_at: string;
+  created_by: string | null;
+}
+
+export interface UserDepartmentInsert {
+  user_id: string;
+  department: Department;
+  primary_dept?: boolean;
+  created_by?: string | null;
+}
+
+export interface UserDepartmentUpdate {
+  department?: Department;
+  primary_dept?: boolean;
+}
+
+export const DEPARTMENT_VALUES: Department[] = [
+  'separador',
+  'conferente',
+  'comprador',
+  'tintometrico',
+  'financeiro',
+  'vendas',
+  'gestao',
+  'outro',
+];
+
+export const DEPARTMENT_LABELS: Record<Department, string> = {
+  separador: 'Separador',
+  conferente: 'Conferente',
+  comprador: 'Comprador',
+  tintometrico: 'Tintométrico',
+  financeiro: 'Financeiro',
+  vendas: 'Vendas',
+  gestao: 'Gestão',
+  outro: 'Outro',
+};

--- a/src/lib/dashboard/__tests__/persona-detect.test.ts
+++ b/src/lib/dashboard/__tests__/persona-detect.test.ts
@@ -7,6 +7,7 @@ const baseSignals: PersonaSignals = {
   commercialRole: null,
   isSalesOnly: false,
   routeCounts: {},
+  userDepartment: null,
 };
 
 describe('inferPersona', () => {
@@ -104,5 +105,37 @@ describe('inferPersona', () => {
     });
     expect(r.persona).toBe('geral');
     expect(r.source).toBe('default');
+  });
+
+  it('userDepartment → vendas → vendedor', () => {
+    const r = inferPersona({ ...baseSignals, userDepartment: 'vendas' });
+    expect(r.persona).toBe('vendedor');
+    expect(r.source).toBe('department');
+  });
+
+  it('userDepartment → separador → estoque', () => {
+    const r = inferPersona({ ...baseSignals, userDepartment: 'separador' });
+    expect(r.persona).toBe('estoque');
+    expect(r.source).toBe('department');
+  });
+
+  it('userDepartment trumps commercial_role', () => {
+    const r = inferPersona({
+      ...baseSignals,
+      userDepartment: 'tintometrico',
+      commercialRole: 'gerencial', // would normally → gestor
+    });
+    expect(r.persona).toBe('tintometrico');
+    expect(r.source).toBe('department');
+  });
+
+  it('override still beats userDepartment', () => {
+    const r = inferPersona({
+      ...baseSignals,
+      override: 'financeiro',
+      userDepartment: 'vendas',
+    });
+    expect(r.persona).toBe('financeiro');
+    expect(r.source).toBe('manual');
   });
 });

--- a/src/lib/dashboard/persona-detect.ts
+++ b/src/lib/dashboard/persona-detect.ts
@@ -2,8 +2,9 @@ import type { Persona } from './persona-config';
 import type { RouteCounts } from './route-tracker';
 import type { CommercialRole } from '@/hooks/useCommercialRole';
 import type { AppRole } from '@/contexts/AuthContext';
+import type { Department } from '@/integrations/supabase/types-departments';
 
-export type PersonaSource = 'manual' | 'commercial_role' | 'sales_only' | 'inference' | 'default';
+export type PersonaSource = 'manual' | 'commercial_role' | 'sales_only' | 'inference' | 'default' | 'department';
 
 export interface PersonaSignals {
   override: Persona | null;
@@ -11,6 +12,7 @@ export interface PersonaSignals {
   commercialRole: CommercialRole | null;
   isSalesOnly: boolean;
   routeCounts: RouteCounts;
+  userDepartment: Department | null;
 }
 
 export interface InferPersonaResult {
@@ -30,18 +32,35 @@ const PREFIX_TO_PERSONA: Record<string, Persona> = {
   '/sales':           'vendedor',
 };
 
+const DEPARTMENT_TO_PERSONA: Record<Department, Persona> = {
+  vendas: 'vendedor',
+  gestao: 'gestor',
+  comprador: 'comprador',
+  separador: 'estoque',
+  conferente: 'estoque',
+  tintometrico: 'tintometrico',
+  financeiro: 'financeiro',
+  outro: 'geral',
+};
+
 export function inferPersona(signals: PersonaSignals): InferPersonaResult {
   // 1. Override manual sempre vence
   if (signals.override) {
     return { persona: signals.override, source: 'manual' };
   }
 
-  // 2. Sales-only CPF → vendedor (mais específico que commercial_role)
+  // 2. user_departments.primary_dept (persistência server > inferência)
+  if (signals.userDepartment) {
+    const persona = DEPARTMENT_TO_PERSONA[signals.userDepartment];
+    return { persona, source: 'department' };
+  }
+
+  // 3. Sales-only CPF → vendedor (mais específico que commercial_role)
   if (signals.isSalesOnly) {
     return { persona: 'vendedor', source: 'sales_only' };
   }
 
-  // 3. commercial_role
+  // 4. commercial_role
   switch (signals.commercialRole) {
     case 'operacional': return { persona: 'vendedor', source: 'commercial_role' };
     case 'gerencial':   return { persona: 'gestor', source: 'commercial_role' };
@@ -49,7 +68,7 @@ export function inferPersona(signals: PersonaSignals): InferPersonaResult {
     case 'super_admin': return { persona: 'master', source: 'commercial_role' };
   }
 
-  // 4. Heurística por prefixo de uso
+  // 5. Heurística por prefixo de uso
   const total = Object.values(signals.routeCounts).reduce((sum, e) => sum + e.count, 0);
   if (total >= HEURISTIC_MIN_VISITS) {
     // Agregar contagens por persona (estoque/recebimento contam pra mesma persona)
@@ -74,7 +93,7 @@ export function inferPersona(signals: PersonaSignals): InferPersonaResult {
     }
   }
 
-  // 5. Default
+  // 6. Default
   if (signals.role === 'master') return { persona: 'master', source: 'default' };
   return { persona: 'geral', source: 'default' };
 }

--- a/src/pages/AdminDepartments.tsx
+++ b/src/pages/AdminDepartments.tsx
@@ -1,0 +1,246 @@
+import { useMemo, useState } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Badge } from '@/components/ui/badge';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Search, RefreshCw, X } from 'lucide-react';
+import { toast } from 'sonner';
+import { useAuth } from '@/contexts/AuthContext';
+import {
+  useStaffUsersWithDept,
+  useAssignDepartment,
+  useRemoveAllDepartments,
+} from '@/hooks/useDepartmentsAdmin';
+import {
+  DEPARTMENT_LABELS,
+  DEPARTMENT_VALUES,
+  type Department,
+} from '@/integrations/supabase/types-departments';
+import { track } from '@/lib/analytics';
+import { cn } from '@/lib/utils';
+
+export default function AdminDepartments() {
+  const { isMaster } = useAuth();
+  const { data: users, isLoading, refetch, isFetching } = useStaffUsersWithDept();
+  const assignMutation = useAssignDepartment();
+  const removeMutation = useRemoveAllDepartments();
+
+  const [search, setSearch] = useState('');
+  const [filterDept, setFilterDept] = useState<Department | 'all' | 'none'>('all');
+
+  const filtered = useMemo(() => {
+    if (!users) return [];
+    return users.filter((u) => {
+      if (search) {
+        const q = search.toLowerCase();
+        const matches =
+          (u.name ?? '').toLowerCase().includes(q) ||
+          (u.email ?? '').toLowerCase().includes(q);
+        if (!matches) return false;
+      }
+      if (filterDept === 'none') return u.department === null;
+      if (filterDept !== 'all') return u.department === filterDept;
+      return true;
+    });
+  }, [users, search, filterDept]);
+
+  const countByDept = useMemo(() => {
+    const counts: Record<string, number> = { __none: 0 };
+    DEPARTMENT_VALUES.forEach((d) => (counts[d] = 0));
+    (users ?? []).forEach((u) => {
+      if (u.department) counts[u.department] = (counts[u.department] ?? 0) + 1;
+      else counts.__none++;
+    });
+    return counts;
+  }, [users]);
+
+  if (!isMaster) {
+    return (
+      <Card>
+        <CardContent className="p-6 text-center text-sm text-muted-foreground">
+          Apenas master pode gerenciar departamentos.
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const handleAssign = (userId: string, department: Department) => {
+    assignMutation.mutate(
+      { userId, department },
+      {
+        onSuccess: () => {
+          toast.success(`Departamento atualizado: ${DEPARTMENT_LABELS[department]}`);
+          track('department.assigned', { user_id: userId, department });
+        },
+        onError: (err: unknown) => {
+          const msg = err instanceof Error ? err.message : 'erro';
+          toast.error(`Falha ao atribuir: ${msg}`);
+        },
+      },
+    );
+  };
+
+  const handleRemove = (userId: string) => {
+    removeMutation.mutate(
+      { userId },
+      {
+        onSuccess: () => {
+          toast.success('Departamento removido');
+          track('department.removed', { user_id: userId });
+        },
+        onError: (err: unknown) => {
+          const msg = err instanceof Error ? err.message : 'erro';
+          toast.error(`Falha ao remover: ${msg}`);
+        },
+      },
+    );
+  };
+
+  return (
+    <div className="space-y-4 max-w-6xl">
+      <div className="flex items-start justify-between gap-4 flex-wrap">
+        <div>
+          <h1 className="text-xl font-semibold tracking-tight">Departamentos</h1>
+          <p className="text-sm text-muted-foreground">
+            Atribuição de departamento operacional aos staff. Persona do dashboard
+            usa esse valor como prioridade sobre heurística por uso.
+          </p>
+        </div>
+        <Button variant="outline" size="sm" onClick={() => refetch()} disabled={isFetching}>
+          <RefreshCw className={cn('w-3 h-3 mr-1.5', isFetching && 'animate-spin')} />
+          Atualizar
+        </Button>
+      </div>
+
+      {/* Contagem por departamento */}
+      <div className="flex flex-wrap gap-2">
+        <Badge variant={countByDept.__none > 0 ? 'destructive' : 'secondary'}>
+          {countByDept.__none} sem dept
+        </Badge>
+        {DEPARTMENT_VALUES.map((d) => (
+          <Badge key={d} variant="outline">
+            {countByDept[d]} {DEPARTMENT_LABELS[d]}
+          </Badge>
+        ))}
+      </div>
+
+      {/* Filtros */}
+      <div className="flex gap-2 items-center flex-wrap">
+        <div className="relative flex-1 min-w-64">
+          <Search className="w-3.5 h-3.5 absolute left-2.5 top-1/2 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Buscar por nome ou email…"
+            className="pl-8 h-9"
+          />
+        </div>
+        <Select
+          value={filterDept}
+          onValueChange={(v) => setFilterDept(v as typeof filterDept)}
+        >
+          <SelectTrigger className="w-48 h-9">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">Todos</SelectItem>
+            <SelectItem value="none">Sem departamento</SelectItem>
+            {DEPARTMENT_VALUES.map((d) => (
+              <SelectItem key={d} value={d}>
+                {DEPARTMENT_LABELS[d]}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm font-medium">
+            {filtered.length} staff
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="p-0">
+          {isLoading ? (
+            <div className="p-4 space-y-2">
+              {[0, 1, 2, 3].map((i) => (
+                <Skeleton key={i} className="h-10 w-full" />
+              ))}
+            </div>
+          ) : filtered.length === 0 ? (
+            <div className="p-6 text-center text-sm text-muted-foreground">
+              Nenhum staff encontrado com esses filtros.
+            </div>
+          ) : (
+            <table className="w-full text-sm">
+              <thead className="border-b border-border text-[11px] uppercase text-muted-foreground">
+                <tr>
+                  <th className="text-left px-4 py-2 font-medium">Nome</th>
+                  <th className="text-left px-4 py-2 font-medium">Email</th>
+                  <th className="text-left px-4 py-2 font-medium">Departamento</th>
+                  <th className="text-right px-4 py-2 font-medium w-16"></th>
+                </tr>
+              </thead>
+              <tbody>
+                {filtered.map((u) => (
+                  <tr key={u.user_id} className="border-b border-border/60 hover:bg-muted/30">
+                    <td className="px-4 py-2">
+                      <div className="font-medium">{u.name ?? '(sem nome)'}</div>
+                      {!u.is_approved && (
+                        <Badge variant="outline" className="text-[10px] mt-1">
+                          não aprovado
+                        </Badge>
+                      )}
+                    </td>
+                    <td className="px-4 py-2 text-muted-foreground text-xs">{u.email ?? '—'}</td>
+                    <td className="px-4 py-2">
+                      <Select
+                        value={u.department ?? '__none'}
+                        onValueChange={(v) => {
+                          if (v === '__none') return; // ignorável; usar X pra remover
+                          handleAssign(u.user_id, v as Department);
+                        }}
+                      >
+                        <SelectTrigger className="h-8 w-44 text-xs">
+                          <SelectValue placeholder="—" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {DEPARTMENT_VALUES.map((d) => (
+                            <SelectItem key={d} value={d}>
+                              {DEPARTMENT_LABELS[d]}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </td>
+                    <td className="px-4 py-2 text-right">
+                      {u.department && (
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="h-7 w-7"
+                          onClick={() => handleRemove(u.user_id)}
+                          aria-label="Remover departamento"
+                        >
+                          <X className="w-3.5 h-3.5" />
+                        </Button>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/pages/AdminDepartments.tsx
+++ b/src/pages/AdminDepartments.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Badge } from '@/components/ui/badge';
@@ -35,6 +35,10 @@ export default function AdminDepartments() {
 
   const [search, setSearch] = useState('');
   const [filterDept, setFilterDept] = useState<Department | 'all' | 'none'>('all');
+
+  useEffect(() => {
+    track('department.page_viewed', {});
+  }, []);
 
   const filtered = useMemo(() => {
     if (!users) return [];

--- a/supabase/migrations/20260517120000_user_departments.sql
+++ b/supabase/migrations/20260517120000_user_departments.sql
@@ -1,0 +1,75 @@
+-- ============================================================
+-- user_departments — substitui heurística persona-detect por
+-- persistência server-side de departamento operacional.
+-- Spec: docs/superpowers/specs/2026-05-17-user-departments-design.md
+-- ============================================================
+
+-- Enum de departamentos. 8 valores fixos cobrem o organograma atual.
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'department') THEN
+    CREATE TYPE public.department AS ENUM (
+      'separador',
+      'conferente',
+      'comprador',
+      'tintometrico',
+      'financeiro',
+      'vendas',
+      'gestao',
+      'outro'
+    );
+  END IF;
+END $$;
+
+-- Tabela
+CREATE TABLE IF NOT EXISTS public.user_departments (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  department public.department NOT NULL,
+  primary_dept boolean NOT NULL DEFAULT true,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  created_by uuid REFERENCES auth.users(id),
+  -- Apenas UM dept primário por usuário (índice parcial UNIQUE)
+  CONSTRAINT user_departments_one_primary
+    EXCLUDE USING btree (user_id WITH =) WHERE (primary_dept = true)
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_departments_user
+  ON public.user_departments(user_id);
+CREATE INDEX IF NOT EXISTS idx_user_departments_dept
+  ON public.user_departments(department);
+
+-- RLS
+ALTER TABLE public.user_departments ENABLE ROW LEVEL SECURITY;
+
+-- Usuário lê o próprio
+DROP POLICY IF EXISTS "user_departments_read_own" ON public.user_departments;
+CREATE POLICY "user_departments_read_own"
+  ON public.user_departments
+  FOR SELECT
+  USING (auth.uid() = user_id);
+
+-- Master lê e escreve todos
+DROP POLICY IF EXISTS "user_departments_master_all" ON public.user_departments;
+CREATE POLICY "user_departments_master_all"
+  ON public.user_departments
+  FOR ALL
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.user_roles
+      WHERE user_id = auth.uid() AND role = 'master'::public.app_role
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.user_roles
+      WHERE user_id = auth.uid() AND role = 'master'::public.app_role
+    )
+  );
+
+-- Service role bypass
+DROP POLICY IF EXISTS "user_departments_service_all" ON public.user_departments;
+CREATE POLICY "user_departments_service_all"
+  ON public.user_departments
+  FOR ALL
+  USING (auth.role() = 'service_role');


### PR DESCRIPTION
## Summary

Substitui a heurística de persona (top prefixo de rota) por persistência server-side de "departamento operacional" do usuário. Implementação completa do [spec](docs/superpowers/specs/2026-05-17-user-departments-design.md) via [plan](docs/superpowers/plans/2026-05-17-user-departments.md) — 9 tasks, 9 commits.

## Por que

Heurística atual tem 3 problemas:
1. Funcionário novo recebe persona "geral" e vê dashboard mal otimizado por 1-2 semanas até a janela de 30d encher
2. Departamento é fato organizacional, não comportamental — comprador é comprador antes do primeiro login
3. Outras features (notificações por dept, relatórios por dept) precisam de persistência

## Camadas

### Schema (migration `20260517120000_user_departments.sql`)
- `enum department` com 8 valores (separador / conferente / comprador / tintometrico / financeiro / vendas / gestao / outro)
- `tabela user_departments` com `EXCLUDE` constraint garantindo 1 primary_dept por usuário
- 3 RLS policies: user lê próprio, master CRUD all, service_role bypass

### Hook + persona detection
- **`useUserDepartment`** (3 tests TDD) — query `primary_dept` do user atual
- **`persona-detect.ts` ganha 4º nível** — cascata vira: override → **user_department** → sales_only → commercial_role → heurística → default. 4 tests novos (15 total).
- **`usePersona`** consome `useUserDepartment` como 4º sinal

### UI admin (`/admin/departments`)
- Lista staff (não-customer) com dropdown inline pra atribuir/trocar departamento
- Filtros: search por nome/email + select departamento (all/none/8 opções)
- Badges contagem por departamento — "X sem dept" em vermelho quando >0
- Remove via X (deleta todos os depts do user, reset full)
- Guard `if (!isMaster)` — apenas master acessa
- Rota lazy-loaded + entrada na sidebar "Gestão > Departamentos"

### Telemetria
3 eventos PostHog novos:
- `department.assigned` `{ user_id, department }`
- `department.removed` `{ user_id }`
- `department.page_viewed` (mount da tela)

## Stats
- 11 arquivos: 8 novos + 3 modificados (usePersona, App, AppShell)
- +698 / −7 LOC
- 174/174 tests pass (4 novos pra persona-detect + 3 pra useUserDepartment + 167 base)
- `bun build` exit 0 (35s, PWA generated)
- `bun lint` zero erros novos

## Out-of-scope (por spec §7)
- Departments compostos (1 user em múltiplos) — MVP single primary
- Auto-assign baseado em login email pattern — manual primeiro
- Department-scoped RLS em outras tabelas — sprint próprio quando demandar
- Bulk-assign na UI — adicionar quando admin pedir

## Pós-merge
1. Aplicar migration no Supabase
2. Master atribui departments pros 10-20 staff principais (~15min de trabalho manual)
3. Persona auto-detect dos novos funcionários passa a usar `department` em vez de esperar 30d de heurística
4. Considerar reabrir backlog items dependentes (notificações por dept, relatórios por dept)

🤖 Generated with [Claude Code](https://claude.com/claude-code)