### PR TITLE
refactor(design): sweep 59 files migrando cores hardcoded → tokens text-status-*

### DIFF
--- a/src/components/ForgotPasswordDialog.tsx
+++ b/src/components/ForgotPasswordDialog.tsx
@@ -80,8 +80,8 @@ export const ForgotPasswordDialog = ({ open, onOpenChange }: ForgotPasswordDialo
       <DialogContent className="sm:max-w-md">
         {isSent ? (
           <div className="text-center py-4">
-            <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-green-100 mb-4">
-              <CheckCircle className="w-8 h-8 text-green-600" />
+            <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-status-success-bg mb-4">
+              <CheckCircle className="w-8 h-8 text-status-success" />
             </div>
             <DialogHeader className="text-center">
               <DialogTitle className="text-xl">E-mail enviado!</DialogTitle>

--- a/src/components/KanbanBoard.tsx
+++ b/src/components/KanbanBoard.tsx
@@ -279,7 +279,7 @@ const KanbanCard = React.memo(function KanbanCard({ order, column, updatingOrder
         {urgency !== 'normal' && (
           <div className={cn(
             'text-[10px] font-medium px-2 py-0.5 rounded-full mb-2 inline-block',
-            urgency === 'urgent' ? 'bg-destructive/10 text-destructive' : 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400'
+            urgency === 'urgent' ? 'bg-destructive/10 text-destructive' : 'bg-status-warning-bg text-status-warning'
           )}>
             {urgency === 'urgent' ? '⚠️ Parado há mais de 48h' : '⏰ Parado há mais de 24h'}
           </div>

--- a/src/components/OnboardingWizard.tsx
+++ b/src/components/OnboardingWizard.tsx
@@ -111,7 +111,7 @@ export function OnboardingWizard({ hasTools, hasOrders }: OnboardingWizardProps)
               >
                 <div className={cn(
                   'w-10 h-10 rounded-xl flex items-center justify-center flex-shrink-0 transition-colors',
-                  isCompleted ? 'bg-emerald-100 text-emerald-600' : isCurrent ? 'bg-primary/10 text-primary' : 'bg-muted text-muted-foreground'
+                  isCompleted ? 'bg-status-success-bg text-status-success' : isCurrent ? 'bg-primary/10 text-primary' : 'bg-muted text-muted-foreground'
                 )}>
                   {isCompleted ? (
                     <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>

--- a/src/components/OrderCard.tsx
+++ b/src/components/OrderCard.tsx
@@ -26,13 +26,13 @@ interface OrderCardProps {
 const STATUS_MAP: Record<string, { label: string; nextStep: string; className: string }> = {
   pedido_recebido: { label: 'Recebido', nextStep: 'Aguardando triagem', className: 'border-primary/30 bg-primary/5 text-primary' },
   aguardando_coleta: { label: 'Aguardando Coleta', nextStep: 'Coleta será agendada', className: 'border-status-warning/30 bg-status-warning-bg text-status-warning' },
-  em_triagem: { label: 'Em Triagem', nextStep: 'Orçamento em breve', className: 'border-purple-400/30 bg-purple-50 text-purple-700 dark:bg-purple-900/20 dark:text-purple-300' },
+  em_triagem: { label: 'Em Triagem', nextStep: 'Orçamento em breve', className: 'border-status-purple/30 bg-status-purple-bg text-status-purple' },
   orcamento_enviado: { label: 'Orçamento Enviado', nextStep: 'Aguardando sua aprovação', className: 'border-status-warning/40 bg-status-warning-bg text-status-warning' },
-  aprovado: { label: 'Aprovado', nextStep: 'Entrando na fila de afiação', className: 'border-emerald-400/30 bg-emerald-50 text-emerald-700 dark:bg-emerald-900/20 dark:text-emerald-300' },
+  aprovado: { label: 'Aprovado', nextStep: 'Entrando na fila de afiação', className: 'border-status-success/30 bg-status-success-bg text-status-success' },
   em_afiacao: { label: 'Em Afiação', nextStep: 'Ferramenta sendo afiada', className: 'border-primary/30 bg-primary/5 text-primary' },
-  controle_qualidade: { label: 'Qualidade', nextStep: 'Verificação final', className: 'border-indigo-400/30 bg-indigo-50 text-indigo-700 dark:bg-indigo-900/20 dark:text-indigo-300' },
-  pronto_entrega: { label: 'Pronto p/ Entrega', nextStep: 'Entrega será agendada', className: 'border-emerald-400/30 bg-emerald-50 text-emerald-700 dark:bg-emerald-900/20 dark:text-emerald-300' },
-  em_rota: { label: 'Em Rota', nextStep: 'A caminho do seu endereço', className: 'border-indigo-400/30 bg-indigo-50 text-indigo-700 dark:bg-indigo-900/20 dark:text-indigo-300' },
+  controle_qualidade: { label: 'Qualidade', nextStep: 'Verificação final', className: 'border-status-indigo/30 bg-status-indigo-bg text-status-indigo' },
+  pronto_entrega: { label: 'Pronto p/ Entrega', nextStep: 'Entrega será agendada', className: 'border-status-success/30 bg-status-success-bg text-status-success' },
+  em_rota: { label: 'Em Rota', nextStep: 'A caminho do seu endereço', className: 'border-status-indigo/30 bg-status-indigo-bg text-status-indigo' },
   entregue: { label: 'Entregue', nextStep: 'Pedido concluído', className: 'border-border bg-muted text-muted-foreground' },
 };
 

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -29,8 +29,8 @@ export const ProtectedRoute = ({ children }: ProtectedRouteProps) => {
       <div className="min-h-screen flex items-center justify-center bg-background p-4">
         <Card className="max-w-md w-full">
           <CardContent className="pt-6 text-center space-y-4">
-            <div className="mx-auto w-16 h-16 rounded-full bg-amber-100 flex items-center justify-center">
-              <Clock className="w-8 h-8 text-amber-600" />
+            <div className="mx-auto w-16 h-16 rounded-full bg-status-warning-bg flex items-center justify-center">
+              <Clock className="w-8 h-8 text-status-warning" />
             </div>
             <h2 className="text-xl font-bold">Cadastro Pendente de Aprovação</h2>
             <p className="text-muted-foreground">

--- a/src/components/SendingQualityChecklist.tsx
+++ b/src/components/SendingQualityChecklist.tsx
@@ -151,10 +151,10 @@ export const SendingQualityChecklist = ({ orderId, userId }: SendingQualityCheck
               variant="secondary"
               className={
                 existingLog.score >= 75
-                  ? 'bg-emerald-100 text-emerald-700'
+                  ? 'bg-status-success-bg text-status-success'
                   : existingLog.score >= 50
-                  ? 'bg-amber-100 text-amber-700'
-                  : 'bg-red-100 text-red-700'
+                  ? 'bg-status-warning-bg text-status-warning'
+                  : 'bg-status-error-bg text-status-error'
               }
             >
               {existingLog.score}%
@@ -183,7 +183,7 @@ export const SendingQualityChecklist = ({ orderId, userId }: SendingQualityCheck
               <p className="text-xs text-muted-foreground">{description}</p>
             </div>
             {checks[key as keyof typeof checks] && (
-              <CheckCircle2 className="w-4 h-4 text-emerald-500 mt-0.5 shrink-0" />
+              <CheckCircle2 className="w-4 h-4 text-status-success mt-0.5 shrink-0" />
             )}
           </label>
         ))}

--- a/src/components/SharpeningSuggestions.tsx
+++ b/src/components/SharpeningSuggestions.tsx
@@ -63,16 +63,16 @@ export const SharpeningSuggestions = React.forwardRef<HTMLDivElement, Sharpening
 
     if (hasDueSoon) {
       return (
-        <div className="bg-amber-50 border border-amber-200 rounded-xl p-4">
+        <div className="bg-status-warning-bg border border-status-warning/30 rounded-xl p-4">
           <div className="flex items-start gap-3">
-            <div className="w-10 h-10 rounded-full bg-amber-100 flex items-center justify-center flex-shrink-0">
-              <Bell className="w-5 h-5 text-amber-600" />
+            <div className="w-10 h-10 rounded-full bg-status-warning/15 flex items-center justify-center flex-shrink-0">
+              <Bell className="w-5 h-5 text-status-warning" />
             </div>
             <div className="flex-1">
-              <p className="font-semibold text-amber-900">
+              <p className="font-semibold text-status-warning-foreground">
                 {dueSoonTools.length} ferramenta(s) precisam de afiação em breve
               </p>
-              <p className="text-sm text-amber-700 mt-1">
+              <p className="text-sm text-status-warning mt-1">
                 {dueSoonTools.slice(0, 2).map(t => t.categoryName).join(', ')}
                 {dueSoonTools.length > 2 && ` e mais ${dueSoonTools.length - 2}`}
               </p>
@@ -119,8 +119,8 @@ export const SharpeningSuggestions = React.forwardRef<HTMLDivElement, Sharpening
 
       {/* Due Soon Tools */}
       {hasDueSoon && (
-        <div className="bg-amber-50 border border-amber-200 rounded-xl p-4">
-          <h3 className="font-semibold text-amber-900 flex items-center gap-2 mb-3">
+        <div className="bg-status-warning-bg border border-status-warning/30 rounded-xl p-4">
+          <h3 className="font-semibold text-status-warning-foreground flex items-center gap-2 mb-3">
             <Clock className="w-4 h-4" />
             Afiação em Breve
           </h3>
@@ -180,19 +180,19 @@ function ToolCard({ tool, variant }: ToolCardProps) {
     <div className={cn(
       'flex items-center gap-3 p-3 rounded-lg',
       variant === 'overdue' && 'bg-destructive/5',
-      variant === 'soon' && 'bg-amber-100/50',
+      variant === 'soon' && 'bg-status-warning/10',
       variant === 'upcoming' && 'bg-muted/50'
     )}>
       <div className={cn(
         'w-8 h-8 rounded-full flex items-center justify-center',
         variant === 'overdue' && 'bg-destructive/20',
-        variant === 'soon' && 'bg-amber-200',
+        variant === 'soon' && 'bg-status-warning/20',
         variant === 'upcoming' && 'bg-muted'
       )}>
         <Wrench className={cn(
           'w-4 h-4',
           variant === 'overdue' && 'text-destructive',
-          variant === 'soon' && 'text-amber-700',
+          variant === 'soon' && 'text-status-warning',
           variant === 'upcoming' && 'text-muted-foreground'
         )} />
       </div>
@@ -200,7 +200,7 @@ function ToolCard({ tool, variant }: ToolCardProps) {
         <p className={cn(
           'font-medium text-sm',
           variant === 'overdue' && 'text-destructive',
-          variant === 'soon' && 'text-amber-900',
+          variant === 'soon' && 'text-status-warning-foreground',
           variant === 'upcoming' && 'text-foreground'
         )}>
           {tool.categoryName}
@@ -208,7 +208,7 @@ function ToolCard({ tool, variant }: ToolCardProps) {
         <p className={cn(
           'text-xs',
           variant === 'overdue' && 'text-destructive/70',
-          variant === 'soon' && 'text-amber-700',
+          variant === 'soon' && 'text-status-warning',
           variant === 'upcoming' && 'text-muted-foreground'
         )}>
           {getDaysText()}
@@ -221,7 +221,7 @@ function ToolCard({ tool, variant }: ToolCardProps) {
         <span className={cn(
           'text-xs font-medium px-2 py-1 rounded-full',
           variant === 'overdue' && 'bg-destructive/20 text-destructive',
-          variant === 'soon' && 'bg-amber-200 text-amber-800',
+          variant === 'soon' && 'bg-status-warning/20 text-status-warning-foreground',
           variant === 'upcoming' && 'bg-muted text-muted-foreground'
         )}>
           {format(tool.nextSharpeningDue, "dd/MM")}

--- a/src/components/TintColorSelectDialog.tsx
+++ b/src/components/TintColorSelectDialog.tsx
@@ -400,13 +400,13 @@ export function TintColorSelectDialog({ product, open, onClose, onConfirm, custo
               <>
                 {globalColorMatches && globalColorMatches.length > 0 ? (
                   <div className="space-y-3">
-                    <div className="flex items-start gap-2 p-3 rounded-md bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-800">
-                      <AlertTriangle className="w-5 h-5 text-amber-600 shrink-0 mt-0.5" />
+                    <div className="flex items-start gap-2 p-3 rounded-md bg-status-warning-bg border border-status-warning/30">
+                      <AlertTriangle className="w-5 h-5 text-status-warning shrink-0 mt-0.5" />
                       <div>
-                        <p className="text-sm font-semibold text-amber-800 dark:text-amber-300">
+                        <p className="text-sm font-semibold text-status-warning-foreground">
                           Esta cor não pode ser feita nesta base
                         </p>
-                        <p className="text-xs text-amber-700 dark:text-amber-400 mt-1">
+                        <p className="text-xs text-status-warning mt-1">
                           A cor pesquisada não está disponível em <strong>{product.descricao}</strong>. Veja abaixo as embalagens onde ela pode ser produzida:
                         </p>
                       </div>
@@ -485,7 +485,7 @@ export function TintColorSelectDialog({ product, open, onClose, onConfirm, custo
                       <div className="text-xs">
                         <span className="font-medium text-primary">Último preço cliente: {fmt(lastPracticedPrice.price)}</span>
                         {precoCsv > 0 && lastPracticedPrice.price < precoCsv && (
-                          <Badge variant="secondary" className="ml-1.5 text-[9px] px-1.5 py-0 text-orange-600 bg-orange-50 border-orange-200">
+                          <Badge variant="secondary" className="ml-1.5 text-[9px] px-1.5 py-0 text-status-warning-bold bg-status-warning-bg border-status-warning/30">
                             -{Math.round((1 - lastPracticedPrice.price / precoCsv) * 100)}% da tabela
                           </Badge>
                         )}

--- a/src/components/ToolImageIdentifier.tsx
+++ b/src/components/ToolImageIdentifier.tsx
@@ -123,8 +123,8 @@ export function ToolImageIdentifier({ categories, onCategoryIdentified, onClose,
   };
 
   const confidenceColor = {
-    alta: 'text-emerald-600',
-    media: 'text-amber-600',
+    alta: 'text-status-success',
+    media: 'text-status-warning',
     baixa: 'text-destructive',
   };
 
@@ -188,7 +188,7 @@ export function ToolImageIdentifier({ categories, onCategoryIdentified, onClose,
               {result.identified ? (
                 <>
                   <div className="flex items-start gap-3">
-                    <CheckCircle className="w-5 h-5 text-emerald-600 mt-0.5 flex-shrink-0" />
+                    <CheckCircle className="w-5 h-5 text-status-success mt-0.5 flex-shrink-0" />
                     <div className="flex-1">
                       <p className="font-semibold text-foreground">{result.category_name}</p>
                       <p className="text-sm text-muted-foreground mt-0.5">{result.description}</p>

--- a/src/components/UnifiedAIAssistant.tsx
+++ b/src/components/UnifiedAIAssistant.tsx
@@ -658,13 +658,13 @@ export function UnifiedAIAssistant({ products, userTools, onItemsIdentified, onC
           )}
 
           {(identifiedProducts.length > 0 || identifiedServices.length > 0) && !hasCustomerSelected && !identifiedCustomer && (
-            <p className="text-xs text-amber-600 bg-amber-50 dark:bg-amber-950/20 p-2 rounded">
+            <p className="text-xs text-status-warning bg-status-warning-bg p-2 rounded">
               ⚠️ Selecione o cliente primeiro para adicionar os itens ao pedido.
             </p>
           )}
 
           {(identifiedProducts.length > 0 || identifiedServices.length > 0) && !hasCustomerSelected && identifiedCustomer && (
-            <p className="text-xs text-amber-600 bg-amber-50 dark:bg-amber-950/20 p-2 rounded">
+            <p className="text-xs text-status-warning bg-status-warning-bg p-2 rounded">
               ⚠️ Clique em "Selecionar" no cliente acima para depois adicionar os itens.
             </p>
           )}
@@ -672,7 +672,7 @@ export function UnifiedAIAssistant({ products, userTools, onItemsIdentified, onC
           {/* Suggestions */}
           {suggestions.length > 0 && (
             <div className="space-y-2 pt-2 border-t border-border">
-              <p className="text-xs font-medium text-amber-600 flex items-center gap-1.5">
+              <p className="text-xs font-medium text-status-warning flex items-center gap-1.5">
                 <Lightbulb className="w-3.5 h-3.5" /> Sugestões ({suggestions.length})
               </p>
               <p className="text-xs text-muted-foreground">
@@ -682,20 +682,20 @@ export function UnifiedAIAssistant({ products, userTools, onItemsIdentified, onC
                 const prod = sug.type === 'product' && sug.product_id ? products.find(p => p.id === sug.product_id) : null;
                 const tool = sug.type === 'service' && sug.userToolId ? userTools.find(t => t.id === sug.userToolId) : null;
                 return (
-                  <div key={idx} className="bg-amber-50 dark:bg-amber-950/20 rounded-lg p-3 border border-amber-200 dark:border-amber-800">
+                  <div key={idx} className="bg-status-warning-bg rounded-lg p-3 border border-status-warning/30">
                     <div className="flex justify-between items-start gap-2">
                       <div className="flex-1 min-w-0">
                         <div className="flex items-center gap-1.5">
                           {sug.type === 'product' ? (
-                            <Package className="w-3.5 h-3.5 text-amber-600 flex-shrink-0" />
+                            <Package className="w-3.5 h-3.5 text-status-warning flex-shrink-0" />
                           ) : (
-                            <Wrench className="w-3.5 h-3.5 text-amber-600 flex-shrink-0" />
+                            <Wrench className="w-3.5 h-3.5 text-status-warning flex-shrink-0" />
                           )}
                           <p className="font-medium text-sm truncate">
                             {prod?.descricao || (tool ? getToolName(tool) : sug.descricao)}
                           </p>
                         </div>
-                        <p className="text-xs text-amber-700 dark:text-amber-400 mt-1 italic">
+                        <p className="text-xs text-status-warning mt-1 italic">
                           💡 {sug.reason}
                         </p>
                         {sug.type === 'product' && (prod || sug.unit_price) && (
@@ -716,7 +716,7 @@ export function UnifiedAIAssistant({ products, userTools, onItemsIdentified, onC
                         <Button
                           size="sm"
                           variant="outline"
-                          className="flex-shrink-0 text-xs border-amber-300 hover:bg-amber-100 dark:hover:bg-amber-900/30"
+                          className="flex-shrink-0 text-xs border-status-warning/40 hover:bg-status-warning/10"
                           onClick={() => acceptSuggestion(sug)}
                         >
                           <Plus className="w-3 h-3 mr-1" />

--- a/src/components/auth/SignupForm.tsx
+++ b/src/components/auth/SignupForm.tsx
@@ -206,7 +206,7 @@ export function SignupForm({ formData, onInputChange, isLoading, onFinalSubmit, 
             </div>
             {omieCliente && <p className="text-xs text-primary mt-1">✓ Cliente existente no Omie</p>}
             {cnaeDescricao && <p className="text-xs text-muted-foreground mt-1">CNAE: {cnae} - {cnaeDescricao}</p>}
-            <p className="text-xs text-emerald-600 mt-1">✓ Frete gratuito em todos os pedidos</p>
+            <p className="text-xs text-status-success mt-1">✓ Frete gratuito em todos os pedidos</p>
           </div>
 
           <div className="space-y-3">

--- a/src/components/des/HistoricoTab.tsx
+++ b/src/components/des/HistoricoTab.tsx
@@ -402,7 +402,7 @@ function HistoricoTabImpl({ empresa, ano: anoAtual, trimestre: trimestreAtual }:
             c.meta > 0 ? Math.min((c.faturado / c.meta) * 100, 100) : 0;
           const atingiu = c.meta > 0 && c.faturado >= c.meta;
           return (
-            <Card key={`${c.ano}-${c.trimestre}`} className={cn(c.isAtual && "border-blue-500/40")}>
+            <Card key={`${c.ano}-${c.trimestre}`} className={cn(c.isAtual && "border-status-info/40")}>
               <CardHeader className="pb-3">
                 <div className="flex items-start justify-between gap-3 flex-wrap">
                   <div>
@@ -413,17 +413,17 @@ function HistoricoTabImpl({ empresa, ano: anoAtual, trimestre: trimestreAtual }:
                   </div>
                   <div className="flex items-center gap-2">
                     {c.isAtual && (
-                      <Badge variant="outline" className="bg-blue-500/10 border-blue-500/40 text-blue-700 text-xs">
+                      <Badge variant="outline" className="bg-status-info/10 border-status-info/40 text-status-info text-xs">
                         Em andamento
                       </Badge>
                     )}
                     {!c.isAtual && c.meta > 0 && (
                       atingiu ? (
-                        <Badge variant="outline" className="bg-green-500/10 border-green-500/40 text-green-700 text-xs">
+                        <Badge variant="outline" className="bg-status-success/10 border-status-success/40 text-status-success text-xs">
                           Meta atingida
                         </Badge>
                       ) : (
-                        <Badge variant="outline" className="bg-red-500/10 border-red-500/40 text-red-700 text-xs">
+                        <Badge variant="outline" className="bg-status-error/10 border-status-error/40 text-status-error text-xs">
                           Meta não atingida
                         </Badge>
                       )
@@ -441,7 +441,7 @@ function HistoricoTabImpl({ empresa, ano: anoAtual, trimestre: trimestreAtual }:
                     <p className="text-xs text-muted-foreground">
                       {c.isAtual ? "Faturado (ao vivo)" : "Faturado final"}
                     </p>
-                    <p className={cn("text-sm font-medium mt-1", atingiu ? "text-green-700" : "text-foreground")}>
+                    <p className={cn("text-sm font-medium mt-1", atingiu ? "text-status-success" : "text-foreground")}>
                       {fmtBRL(c.faturado)}
                     </p>
                   </div>
@@ -465,7 +465,7 @@ function HistoricoTabImpl({ empresa, ano: anoAtual, trimestre: trimestreAtual }:
                       <div
                         className={cn(
                           "h-full transition-all",
-                          progress >= 100 ? "bg-green-500" : progress >= 75 ? "bg-amber-500" : "bg-blue-500",
+                          progress >= 100 ? "bg-status-success" : progress >= 75 ? "bg-status-warning" : "bg-status-info",
                         )}
                         style={{ width: `${progress}%` }}
                       />

--- a/src/components/des/PosicaoAtualTab.tsx
+++ b/src/components/des/PosicaoAtualTab.tsx
@@ -92,9 +92,9 @@ function StarsDisplay({ count, max = 6 }: { count: number; max?: number }) {
 
 function ZonaConfiancaBadge({ zona }: { zona: string | null }) {
   const map: Record<string, { label: string; cls: string }> = {
-    verde: { label: "Segura", cls: "bg-green-500/10 text-green-700 border-green-500/30" },
-    amarelo: { label: "Atenção", cls: "bg-amber-500/10 text-amber-700 border-amber-500/30" },
-    vermelho: { label: "Risco", cls: "bg-red-500/10 text-red-700 border-red-500/30" },
+    verde: { label: "Segura", cls: "bg-status-success/10 text-status-success border-status-success/30" },
+    amarelo: { label: "Atenção", cls: "bg-status-warning/10 text-status-warning border-status-warning/30" },
+    vermelho: { label: "Risco", cls: "bg-status-error/10 text-status-error border-status-error/30" },
     fora_trimestre: { label: "Fora trimestre", cls: "bg-muted text-muted-foreground border-border" },
   };
   const cfg = map[zona ?? ""] ?? { label: zona ?? "—", cls: "bg-muted text-muted-foreground" };
@@ -198,7 +198,7 @@ export function PosicaoAtualTab({ empresa, ano, trimestre }: Props) {
   const meta = Number(pos.meta_pessoal ?? 0);
   const progress = meta > 0 ? Math.min((conserv / meta) * 100, 100) : 0;
   const progressColor =
-    progress >= 100 ? "bg-green-500" : progress >= 75 ? "bg-amber-500" : "bg-red-500";
+    progress >= 100 ? "bg-status-success" : progress >= 75 ? "bg-status-warning" : "bg-status-error";
 
   const faixaConserv = pos.faixa_conservadora?.estrelas ?? 0;
   const faixaOtim = pos.faixa_otimista?.estrelas ?? 0;
@@ -208,10 +208,10 @@ export function PosicaoAtualTab({ empresa, ano, trimestre }: Props) {
     dias < 10 ? "destructive" : dias < 20 ? "default" : "secondary";
   const diasCls =
     dias < 10
-      ? "bg-red-500/10 text-red-700 border-red-500/30"
+      ? "bg-status-error/10 text-status-error border-status-error/30"
       : dias < 20
-        ? "bg-amber-500/10 text-amber-700 border-amber-500/30"
-        : "bg-green-500/10 text-green-700 border-green-500/30";
+        ? "bg-status-warning/10 text-status-warning border-status-warning/30"
+        : "bg-status-success/10 text-status-success border-status-success/30";
 
   return (
     <TooltipProvider>
@@ -238,7 +238,7 @@ export function PosicaoAtualTab({ empresa, ano, trimestre }: Props) {
             </div>
           </CardHeader>
           <CardContent>
-            <p className="text-2xl font-bold text-green-600">{fmtBRL(conserv)}</p>
+            <p className="text-2xl font-bold text-status-success">{fmtBRL(conserv)}</p>
             <p className="text-xs text-muted-foreground mt-1.5">
               + {fmtBRL(pos.valor_em_transito_risco)} em pedidos de risco ={" "}
               <span className="font-medium text-foreground">{fmtBRL(otim)}</span> otimista
@@ -291,7 +291,7 @@ export function PosicaoAtualTab({ empresa, ano, trimestre }: Props) {
                 <p className="text-xs text-muted-foreground mt-1.5 cursor-help">
                   (Faixa conservadora){" "}
                   {faixaOtim !== faixaConserv && (
-                    <span className="text-amber-600 font-medium">· otim. {faixaOtim}★</span>
+                    <span className="text-status-warning font-medium">· otim. {faixaOtim}★</span>
                   )}
                 </p>
               </TooltipTrigger>
@@ -337,10 +337,10 @@ export function PosicaoAtualTab({ empresa, ano, trimestre }: Props) {
               <strong className="text-foreground">{fmtBRL(transitoStats.totalValor)}</strong>
             </span>
             <span>
-              · <strong className="text-green-700">{fmtBRL(transitoStats.seguro)}</strong> em zona segura
+              · <strong className="text-status-success">{fmtBRL(transitoStats.seguro)}</strong> em zona segura
             </span>
             <span>
-              · <strong className="text-amber-700">{fmtBRL(transitoStats.risco)}</strong> em zona de risco
+              · <strong className="text-status-warning">{fmtBRL(transitoStats.risco)}</strong> em zona de risco
             </span>
             <span>
               · <strong className="text-muted-foreground">{fmtBRL(transitoStats.foraTrimestre)}</strong>{" "}
@@ -426,7 +426,7 @@ export function PosicaoAtualTab({ empresa, ano, trimestre }: Props) {
               </div>
               <div>
                 <p className="text-xs text-muted-foreground">Fat. bruto confirmado</p>
-                <p className="text-sm font-medium text-green-700 mt-1">
+                <p className="text-sm font-medium text-status-success mt-1">
                   {fmtBRL(pos.fat_bruto_confirmado)}
                 </p>
               </div>

--- a/src/components/des/SimuladorTab.tsx
+++ b/src/components/des/SimuladorTab.tsx
@@ -201,15 +201,15 @@ function SimulationPanel({
       case "compensa":
         return {
           icon: ThumbsUp,
-          color: "text-green-700",
-          bg: "bg-green-500/10 border-green-500/40",
+          color: "text-status-success",
+          bg: "bg-status-success/10 border-status-success/40",
           label: "Compensa",
         };
       case "compensa_marginalmente":
         return {
           icon: AlertCircle,
-          color: "text-amber-700",
-          bg: "bg-amber-500/10 border-amber-500/40",
+          color: "text-status-warning",
+          bg: "bg-status-warning/10 border-status-warning/40",
           label: "Compensa marginalmente",
         };
       case "indiferente":
@@ -222,8 +222,8 @@ function SimulationPanel({
       case "nao_compensa":
         return {
           icon: ThumbsDown,
-          color: "text-red-700",
-          bg: "bg-red-500/10 border-red-500/40",
+          color: "text-status-error",
+          bg: "bg-status-error/10 border-status-error/40",
           label: "Não compensa",
         };
       default:
@@ -282,7 +282,7 @@ function SimulationPanel({
             {faltamProximaFaixa != null && faltamProximaFaixa > 0 && (
               <button
                 type="button"
-                className="inline-flex items-center text-xs px-2 py-1 rounded-md bg-amber-500/10 text-amber-700 border border-amber-500/30 hover:bg-amber-500/20 transition-colors"
+                className="inline-flex items-center text-xs px-2 py-1 rounded-md bg-status-warning/10 text-status-warning border border-status-warning/30 hover:bg-status-warning/20 transition-colors"
                 onClick={() => setValorExtra(Math.round(faltamProximaFaixa))}
               >
                 Faltam para próxima faixa: {fmtBRL(faltamProximaFaixa)}
@@ -374,28 +374,28 @@ function SimulationPanel({
           <>
             <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
               {/* Card 1 - Posição após puxar */}
-              <Card className="bg-blue-500/5 border-blue-500/30">
+              <Card className="bg-status-info/5 border-status-info/30">
                 <CardHeader className="pb-2">
                   <CardTitle className="text-xs text-muted-foreground uppercase tracking-wide">
                     Posição após puxar
                   </CardTitle>
                 </CardHeader>
                 <CardContent className="space-y-2">
-                  <p className="text-xl font-bold text-blue-700">
+                  <p className="text-xl font-bold text-status-info">
                     {fmtBRL(resultado.posicao?.com_extra)}
                   </p>
                   <p className="text-xs text-muted-foreground">
                     + {fmtBRL(resultado.posicao?.nominal_adicional_na_nf)}
                   </p>
                   {fator > 1 && (
-                    <Badge variant="outline" className="bg-amber-500/10 border-amber-500/40 text-amber-700 text-xs">
+                    <Badge variant="outline" className="bg-status-warning/10 border-status-warning/40 text-status-warning text-xs">
                       NF inflada em {fator.toFixed(2)}x pelo prazo
                     </Badge>
                   )}
                   <div className="pt-1">
                     {resultado.posicao?.mudou_faixa ? (
                       <div className="flex items-center gap-1.5">
-                        <Badge className="bg-green-500/10 border-green-500/40 text-green-700 text-xs" variant="outline">
+                        <Badge className="bg-status-success/10 border-status-success/40 text-status-success text-xs" variant="outline">
                           Sobe para {resultado.posicao.faixa_nova?.estrelas ?? 0}★
                         </Badge>
                         <StarsRow count={resultado.posicao.faixa_nova?.estrelas ?? 0} />
@@ -413,14 +413,14 @@ function SimulationPanel({
               </Card>
 
               {/* Card 2 - Ganho futuro */}
-              <Card className="bg-green-500/5 border-green-500/30">
+              <Card className="bg-status-success/5 border-status-success/30">
                 <CardHeader className="pb-2">
                   <CardTitle className="text-xs text-muted-foreground uppercase tracking-wide">
                     Ganho futuro
                   </CardTitle>
                 </CardHeader>
                 <CardContent className="space-y-2">
-                  <p className="text-xl font-bold text-green-700">
+                  <p className="text-xl font-bold text-status-success">
                     {fmtBRL(resultado.projecao?.ganho_futuro_rs)}
                   </p>
                   <p className="text-xs text-muted-foreground">
@@ -433,14 +433,14 @@ function SimulationPanel({
               </Card>
 
               {/* Card 3 - Perdas */}
-              <Card className="bg-red-500/5 border-red-500/30">
+              <Card className="bg-status-error/5 border-status-error/30">
                 <CardHeader className="pb-2">
                   <CardTitle className="text-xs text-muted-foreground uppercase tracking-wide">
                     Perdas no pedido atual
                   </CardTitle>
                 </CardHeader>
                 <CardContent className="space-y-2">
-                  <p className="text-xl font-bold text-red-700">
+                  <p className="text-xl font-bold text-status-error">
                     {fmtBRL(perdas.total_rs)}
                   </p>
                   <div className="space-y-0.5 text-xs">
@@ -611,10 +611,10 @@ export function SimuladorTab({ empresa, ano, trimestre }: Props) {
   return (
     <div className="space-y-6">
       {/* Card explicativo */}
-      <Card className="bg-blue-500/5 border-blue-500/30">
+      <Card className="bg-status-info/5 border-status-info/30">
         <CardContent className="pt-4 pb-4">
           <div className="flex items-start gap-3">
-            <Info className="h-4 w-4 text-blue-600 mt-0.5 shrink-0" />
+            <Info className="h-4 w-4 text-status-info mt-0.5 shrink-0" />
             <p className="text-xs text-foreground leading-relaxed">
               Simule o impacto financeiro de puxar volume extra no trimestre atual. Considera todos os custos
               (perda de antecipado, encargos, frete, custo de capital) e o ganho futuro de subir de faixa DES no

--- a/src/components/financeiro/CockpitDrillDown.tsx
+++ b/src/components/financeiro/CockpitDrillDown.tsx
@@ -156,7 +156,7 @@ function CaixaTable({ data }: { data: any[] }) {
             <TableCell><Badge variant="outline">{r.company}</Badge></TableCell>
             <TableCell className="text-sm">{r.banco || '—'}</TableCell>
             <TableCell className="text-sm">{r.descricao || '—'}</TableCell>
-            <TableCell className={`text-right font-medium ${(r.saldo_atual || 0) >= 0 ? 'text-emerald-600' : 'text-red-600'}`}>
+            <TableCell className={`text-right font-medium ${(r.saldo_atual || 0) >= 0 ? 'text-status-success' : 'text-status-error'}`}>
               {fmt(r.saldo_atual || 0)}
             </TableCell>
           </TableRow>

--- a/src/components/intelligence/IntelligenceManagerialTab.tsx
+++ b/src/components/intelligence/IntelligenceManagerialTab.tsx
@@ -123,7 +123,7 @@ function IntelligenceManagerialTabImpl() {
                     <td className="text-center py-2">{fm.avgMargin.toFixed(1)}%</td>
                     <td className="text-center py-2">{fm.avgCategories.toFixed(1)}</td>
                     <td className="text-center py-2">
-                      <span className={fm.avgCategories < globalAvgCategories ? 'text-destructive' : 'text-emerald-600'}>
+                      <span className={fm.avgCategories < globalAvgCategories ? 'text-destructive' : 'text-status-success'}>
                         {(fm.avgCategories - globalAvgCategories).toFixed(1)}
                       </span>
                     </td>

--- a/src/components/intelligence/IntelligenceOperationalTab.tsx
+++ b/src/components/intelligence/IntelligenceOperationalTab.tsx
@@ -143,7 +143,7 @@ export function IntelligenceOperationalTab({ farmerId }: OperationalTabProps) {
         <Card>
           <CardHeader className="pb-2">
             <CardTitle className="text-sm font-semibold flex items-center gap-2">
-              <AlertTriangle className="w-4 h-4 text-amber-500" />
+              <AlertTriangle className="w-4 h-4 text-status-warning" />
               Clientes em Risco
             </CardTitle>
           </CardHeader>

--- a/src/components/intelligence/IntelligenceStrategicTab.tsx
+++ b/src/components/intelligence/IntelligenceStrategicTab.tsx
@@ -126,11 +126,11 @@ export function IntelligenceStrategicTab() {
   return (
     <div className="space-y-4">
       {/* Algoritmo A – Margin Gap */}
-      <div className="rounded-lg border border-amber-500/30 bg-amber-500/5 p-3">
+      <div className="rounded-lg border border-status-warning/30 bg-status-warning/5 p-3">
         <div className="flex items-center justify-between mb-3">
           <div className="flex items-center gap-2">
-            <ShieldCheck className="w-4 h-4 text-amber-500" />
-            <span className="text-xs font-semibold text-amber-600 uppercase tracking-wider">Algoritmo A — Auditoria de Margem (Confidencial)</span>
+            <ShieldCheck className="w-4 h-4 text-status-warning" />
+            <span className="text-xs font-semibold text-status-warning uppercase tracking-wider">Algoritmo A — Auditoria de Margem (Confidencial)</span>
           </div>
           <Button size="sm" variant="outline" onClick={runAlgoA} disabled={runningAlgoA} className="h-7 text-xs">
             <RefreshCw className={`w-3 h-3 mr-1 ${runningAlgoA ? 'animate-spin' : ''}`} />

--- a/src/components/intelligence/IntelligenceUserSimulator.tsx
+++ b/src/components/intelligence/IntelligenceUserSimulator.tsx
@@ -35,7 +35,7 @@ export function IntelligenceUserSimulator({ onSelect, currentSimulation }: UserS
         </SelectContent>
       </Select>
       {currentSimulation && (
-        <Badge variant="outline" className="text-2xs bg-amber-500/10 text-amber-700 border-amber-500/30">
+        <Badge variant="outline" className="text-2xs bg-status-warning/10 text-status-warning border-status-warning/30">
           <Eye className="w-3 h-3 mr-1" /> Simulando
         </Badge>
       )}

--- a/src/components/intelligence/KpiCard.tsx
+++ b/src/components/intelligence/KpiCard.tsx
@@ -14,7 +14,7 @@ export interface KpiCardProps {
 
 export function KpiCard({ title, value, subtitle, icon: Icon, trend, trendValue, className }: KpiCardProps) {
   const TrendIcon = trend === 'up' ? ArrowUpRight : trend === 'down' ? ArrowDownRight : Minus;
-  const trendColor = trend === 'up' ? 'text-emerald-600' : trend === 'down' ? 'text-red-500' : 'text-muted-foreground';
+  const trendColor = trend === 'up' ? 'text-status-success' : trend === 'down' ? 'text-status-error' : 'text-muted-foreground';
 
   return (
     <Card className={className}>

--- a/src/components/portalSayerlack/PortalDetailDrawer.tsx
+++ b/src/components/portalSayerlack/PortalDetailDrawer.tsx
@@ -229,8 +229,8 @@ export function PortalDetailDrawer({ pedidoId, open, onOpenChange, isAdmin }: Pr
             </Card>
 
             {itemsSemMapeamento.length > 0 && (
-              <Card className="border-red-300 bg-red-50">
-                <CardContent className="flex items-start gap-2 pt-4 text-sm text-red-800">
+              <Card className="border-status-error/40 bg-status-error-bg">
+                <CardContent className="flex items-start gap-2 pt-4 text-sm text-status-error-foreground">
                   <AlertCircle className="h-4 w-4 mt-0.5" />
                   <div>
                     <strong>{itemsSemMapeamento.length} item(s) sem mapeamento ativo</strong> em
@@ -260,7 +260,7 @@ export function PortalDetailDrawer({ pedidoId, open, onOpenChange, isAdmin }: Pr
                         <tr key={it.id} className="border-b">
                           <td className="py-1 font-mono">{it.sku_codigo_omie}</td>
                           <td className="py-1 font-mono">
-                            {it.sku_portal ?? <span className="text-red-600">sem mapeamento</span>}
+                            {it.sku_portal ?? <span className="text-status-error">sem mapeamento</span>}
                           </td>
                           <td className="py-1">{it.sku_descricao}</td>
                           <td className="py-1 text-right">{it.qtde_final}</td>
@@ -311,12 +311,12 @@ export function PortalDetailDrawer({ pedidoId, open, onOpenChange, isAdmin }: Pr
             )}
 
             {pedido.portal_erro && (
-              <Card className="border-red-300 bg-red-50">
+              <Card className="border-status-error/40 bg-status-error-bg">
                 <CardHeader className="pb-2">
-                  <CardTitle className="text-base text-red-800">Erro</CardTitle>
+                  <CardTitle className="text-base text-status-error-foreground">Erro</CardTitle>
                 </CardHeader>
                 <CardContent>
-                  <pre className="text-xs whitespace-pre-wrap text-red-900">
+                  <pre className="text-xs whitespace-pre-wrap text-status-error-foreground">
                     {pedido.portal_erro}
                   </pre>
                 </CardContent>
@@ -324,8 +324,8 @@ export function PortalDetailDrawer({ pedidoId, open, onOpenChange, isAdmin }: Pr
             )}
 
             {isConciliacao && (
-              <Card className="border-amber-300 bg-amber-50">
-                <CardContent className="flex items-start gap-2 pt-4 text-sm text-amber-900">
+              <Card className="border-status-warning/40 bg-status-warning-bg">
+                <CardContent className="flex items-start gap-2 pt-4 text-sm text-status-warning-foreground">
                   <AlertCircle className="h-4 w-4 mt-0.5 shrink-0" />
                   <div>
                     <strong>Requer conciliação manual.</strong>{' '}
@@ -353,7 +353,7 @@ export function PortalDetailDrawer({ pedidoId, open, onOpenChange, isAdmin }: Pr
                   if (!o) setConciliarProtocolo('');
                 }}>
                   <DialogTrigger asChild>
-                    <Button variant="default" className="bg-amber-600 hover:bg-amber-700">
+                    <Button variant="default" className="bg-status-warning-bold hover:bg-status-warning-bold/90">
                       <CheckCircle2 className="h-4 w-4 mr-2" />
                       Conciliar manualmente
                     </Button>

--- a/src/components/portalSayerlack/PortalStatusBadge.tsx
+++ b/src/components/portalSayerlack/PortalStatusBadge.tsx
@@ -27,7 +27,7 @@ export function PortalStatusBadge({ status, className }: Props) {
       return (
         <Badge
           variant="outline"
-          className={cn('border-blue-300 bg-blue-50 text-blue-700', className)}
+          className={cn('border-status-info/40 bg-status-info-bg text-status-info', className)}
         >
           Aguardando
         </Badge>
@@ -37,7 +37,7 @@ export function PortalStatusBadge({ status, className }: Props) {
         <Badge
           variant="outline"
           className={cn(
-            'border-blue-400 bg-blue-100 text-blue-800 animate-pulse',
+            'border-status-info/60 bg-status-info/15 text-status-info animate-pulse',
             className,
           )}
         >
@@ -48,7 +48,7 @@ export function PortalStatusBadge({ status, className }: Props) {
       return (
         <Badge
           variant="outline"
-          className={cn('border-blue-300 bg-blue-50 text-blue-700', className)}
+          className={cn('border-status-info/40 bg-status-info-bg text-status-info', className)}
         >
           Retentável
         </Badge>
@@ -58,7 +58,7 @@ export function PortalStatusBadge({ status, className }: Props) {
       return (
         <Badge
           variant="outline"
-          className={cn('border-green-300 bg-green-50 text-green-700', className)}
+          className={cn('border-status-success/40 bg-status-success-bg text-status-success', className)}
         >
           ✓ Enviado
         </Badge>
@@ -67,7 +67,7 @@ export function PortalStatusBadge({ status, className }: Props) {
       return (
         <Badge
           variant="outline"
-          className={cn('border-amber-300 bg-amber-50 text-amber-800', className)}
+          className={cn('border-status-warning/40 bg-status-warning-bg text-status-warning', className)}
           title="Portal aceitou o pedido mas sem protocolo confirmado — requer conciliação manual"
         >
           Sem protocolo
@@ -77,7 +77,7 @@ export function PortalStatusBadge({ status, className }: Props) {
       return (
         <Badge
           variant="outline"
-          className={cn('border-amber-300 bg-amber-50 text-amber-800', className)}
+          className={cn('border-status-warning/40 bg-status-warning-bg text-status-warning', className)}
           title="Resultado ambíguo — verifique o portal e confirme manualmente"
         >
           Requer conciliação
@@ -87,7 +87,7 @@ export function PortalStatusBadge({ status, className }: Props) {
       return (
         <Badge
           variant="outline"
-          className={cn('border-red-300 bg-red-50 text-red-700', className)}
+          className={cn('border-status-error/40 bg-status-error-bg text-status-error', className)}
           title="Falha definitiva — não será retentado automaticamente"
         >
           Falha definitiva
@@ -97,7 +97,7 @@ export function PortalStatusBadge({ status, className }: Props) {
       return (
         <Badge
           variant="outline"
-          className={cn('border-red-300 bg-red-50 text-red-700', className)}
+          className={cn('border-status-error/40 bg-status-error-bg text-status-error', className)}
         >
           Falhou
         </Badge>

--- a/src/components/recebimento/LoteScannerOCR.tsx
+++ b/src/components/recebimento/LoteScannerOCR.tsx
@@ -208,8 +208,8 @@ export default function LoteScannerOCR({ onLoteCapturado, onCancelar }: LoteScan
         <div className={cn(
           'mx-4 mt-3 p-3 rounded-lg flex items-center gap-2 text-sm',
           ocrResult === 'success'
-            ? 'bg-green-50 text-green-800 dark:bg-green-950 dark:text-green-300'
-            : 'bg-amber-50 text-amber-800 dark:bg-amber-950 dark:text-amber-300'
+            ? 'bg-status-success-bg text-status-success-foreground'
+            : 'bg-status-warning-bg text-status-warning-foreground'
         )}>
           {ocrResult === 'success' ? (
             <>

--- a/src/components/reposicao/ConfirmacaoPanel.tsx
+++ b/src/components/reposicao/ConfirmacaoPanel.tsx
@@ -125,9 +125,9 @@ export function ConfirmacaoPanel() {
           <div className="flex items-center justify-between flex-wrap gap-2">
             <CardTitle className="flex items-center gap-2 text-base">
               {concluido ? (
-                <CheckCircle2 className="h-5 w-5 text-emerald-500" />
+                <CheckCircle2 className="h-5 w-5 text-status-success" />
               ) : (
-                <Clock className="h-5 w-5 text-amber-500" />
+                <Clock className="h-5 w-5 text-status-warning" />
               )}
               Resumo do ciclo de hoje
             </CardTitle>
@@ -136,8 +136,8 @@ export function ConfirmacaoPanel() {
                 variant="outline"
                 className={
                   concluido
-                    ? "border-emerald-500/40 bg-emerald-500/10 text-emerald-700"
-                    : "border-amber-500/40 bg-amber-500/10 text-amber-700"
+                    ? "border-status-success/40 bg-status-success/10 text-status-success"
+                    : "border-status-warning/40 bg-status-warning/10 text-status-warning"
                 }
               >
                 {concluido ? "Ciclo concluído" : "Em andamento"}
@@ -185,17 +185,17 @@ export function ConfirmacaoPanel() {
               {resumo && (resumo.pendentes > 0 || resumo.bloqueados > 0 || resumo.aprovados > 0) && (
                 <div className="mt-4 flex items-center gap-2 flex-wrap text-xs">
                   {resumo.pendentes > 0 && (
-                    <Badge variant="outline" className="border-amber-400/40 bg-amber-100/40 text-amber-800">
+                    <Badge variant="outline" className="border-status-warning/40 bg-status-warning-bg text-status-warning">
                       {resumo.pendentes} pendente{resumo.pendentes > 1 ? "s" : ""} de aprovação
                     </Badge>
                   )}
                   {resumo.aprovados > 0 && (
-                    <Badge variant="outline" className="border-blue-400/40 bg-blue-100/40 text-blue-800">
+                    <Badge variant="outline" className="border-status-info/40 bg-status-info-bg text-status-info">
                       {resumo.aprovados} aguardando disparo
                     </Badge>
                   )}
                   {resumo.bloqueados > 0 && (
-                    <Badge variant="outline" className="border-red-400/40 bg-red-100/40 text-red-800">
+                    <Badge variant="outline" className="border-status-error/40 bg-status-error-bg text-status-error">
                       {resumo.bloqueados} bloqueado{resumo.bloqueados > 1 ? "s" : ""}
                     </Badge>
                   )}

--- a/src/components/reposicao/EtapaChecklist.tsx
+++ b/src/components/reposicao/EtapaChecklist.tsx
@@ -117,17 +117,17 @@ export function EtapaChecklist({ step }: Props) {
   const allDone = def.items.every((i) => i.done);
 
   return (
-    <Card className={cn(allDone && "border-emerald-500/30 bg-emerald-500/5")}>
+    <Card className={cn(allDone && "border-status-success/30 bg-status-success/5")}>
       <CardHeader className="pb-2">
         <CardTitle className="text-sm flex items-center gap-2">
           {allDone ? (
-            <CheckCircle2 className="h-4 w-4 text-emerald-500" />
+            <CheckCircle2 className="h-4 w-4 text-status-success" />
           ) : (
             <Circle className="h-4 w-4 text-muted-foreground" />
           )}
           {def.title}
           {allDone && (
-            <span className="text-xs font-normal text-emerald-700 ml-auto">
+            <span className="text-xs font-normal text-status-success ml-auto">
               tudo pronto
             </span>
           )}
@@ -139,7 +139,7 @@ export function EtapaChecklist({ step }: Props) {
             <li key={idx} className="flex items-center justify-between gap-2 text-sm">
               <div className="flex items-center gap-2 min-w-0">
                 {item.done ? (
-                  <CheckCircle2 className="h-4 w-4 text-emerald-500 shrink-0" />
+                  <CheckCircle2 className="h-4 w-4 text-status-success shrink-0" />
                 ) : (
                   <Circle className="h-4 w-4 text-muted-foreground shrink-0" />
                 )}

--- a/src/components/reposicao/EtapasGrid.tsx
+++ b/src/components/reposicao/EtapasGrid.tsx
@@ -75,7 +75,7 @@ export function EtapasGrid() {
               className={cn(
                 "h-full transition-colors",
                 isCurrent && "border-primary/40 bg-primary/5",
-                isDone && "border-emerald-500/30 bg-emerald-500/5",
+                isDone && "border-status-success/30 bg-status-success/5",
                 isLocked && "border-dashed opacity-70",
                 !isCurrent && !isDone && !isLocked && "hover:bg-muted/40",
               )}
@@ -87,7 +87,7 @@ export function EtapasGrid() {
                       className={cn(
                         "flex h-7 w-7 items-center justify-center rounded-full text-xs font-semibold",
                         isCurrent && "bg-primary text-primary-foreground",
-                        isDone && "bg-emerald-500 text-white",
+                        isDone && "bg-status-success text-white",
                         !isCurrent && !isDone && "bg-muted text-foreground/70",
                       )}
                     >
@@ -103,7 +103,7 @@ export function EtapasGrid() {
                     </Badge>
                   )}
                   {isDone && (
-                    <Badge className="h-4 px-1.5 text-[9px] bg-emerald-500 text-white border-0">
+                    <Badge className="h-4 px-1.5 text-[9px] bg-status-success text-white border-0">
                       ok
                     </Badge>
                   )}

--- a/src/components/reposicao/ProcessoComprasStepper.tsx
+++ b/src/components/reposicao/ProcessoComprasStepper.tsx
@@ -96,7 +96,7 @@ export function ProcessoComprasStepper({
                 className={cn(
                   "flex items-center gap-2 rounded-md px-3 py-2 w-full text-left transition-colors",
                   isCurrent && "bg-primary/10 text-primary border border-primary/30",
-                  isDone && "bg-emerald-500/5 text-foreground border border-emerald-500/20",
+                  isDone && "bg-status-success/5 text-foreground border border-status-success/20",
                   isFuture && !isLocked && "bg-muted/40 text-muted-foreground border border-transparent",
                   isLocked && "bg-muted/30 text-muted-foreground/70 border border-dashed border-muted-foreground/20 opacity-70",
                   !isCurrent && !isLocked && "hover:bg-muted hover:text-foreground cursor-pointer",
@@ -107,7 +107,7 @@ export function ProcessoComprasStepper({
                   className={cn(
                     "flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-xs font-semibold",
                     isCurrent && "bg-primary text-primary-foreground",
-                    isDone && "bg-emerald-500 text-white",
+                    isDone && "bg-status-success text-white",
                     isFuture && !isLocked && "bg-muted text-foreground/70",
                     isLocked && "bg-muted text-muted-foreground/60",
                   )}
@@ -126,7 +126,7 @@ export function ProcessoComprasStepper({
                       Etapa {stepNum}
                     </span>
                     {isDone && (
-                      <Badge className="h-4 px-1.5 text-[9px] bg-emerald-500 hover:bg-emerald-500 text-white border-0">
+                      <Badge className="h-4 px-1.5 text-[9px] bg-status-success hover:bg-status-success text-white border-0">
                         ok
                       </Badge>
                     )}

--- a/src/components/reposicao/SmartAlertsSection.tsx
+++ b/src/components/reposicao/SmartAlertsSection.tsx
@@ -118,7 +118,7 @@ export function SmartAlertsSection() {
     l === "yellow"
       ? "border-status-warning/40 bg-status-warning-bg text-status-warning-fg"
       : l === "orange"
-        ? "border-orange-500/40 bg-orange-500/5 text-orange-900 dark:text-orange-200"
+        ? "border-status-warning-bold/40 bg-status-warning-bold/5 text-status-warning-bold"
         : "border-destructive/40 bg-destructive/5 text-destructive";
 
   const Icon = ({ l }: { l: SmartAlert["level"] }) =>

--- a/src/components/unified-order/CartSummaryBar.tsx
+++ b/src/components/unified-order/CartSummaryBar.tsx
@@ -232,7 +232,7 @@ export function CartSummaryBar({
             </div>
           )}
           {serviceItems.some(s => !s.servico) && (
-            <p className="text-xs text-amber-600">
+            <p className="text-xs text-status-warning">
               <AlertCircle className="w-3 h-3 inline mr-1" />
               Selecione o serviço para cada ferramenta na aba Afiação.
             </p>

--- a/src/components/unified-order/CustomerSearch.tsx
+++ b/src/components/unified-order/CustomerSearch.tsx
@@ -48,7 +48,7 @@ export function CustomerSearch({
                 {selectedCustomer.atividade && (
                   <p className="text-[10px] text-muted-foreground mt-0.5">Atividade: {selectedCustomer.atividade}</p>
                 )}
-                {!customerUserId && <p className="text-xs text-amber-600 mt-0.5">Sem cadastro no app</p>}
+                {!customerUserId && <p className="text-xs text-status-warning mt-0.5">Sem cadastro no app</p>}
               </div>
               <Button variant="ghost" size="sm" onClick={onClearCustomer}>Trocar</Button>
             </div>

--- a/src/components/unified-order/ProductItemForm.tsx
+++ b/src/components/unified-order/ProductItemForm.tsx
@@ -81,7 +81,7 @@ export function ProductItemForm({
                           <Badge variant="secondary" className="text-[9px] px-1 py-0">Preço cliente</Badge>
                         )}
                         {lastOrderDate && (
-                          <span className="text-[9px] text-green-700 dark:text-green-400">
+                          <span className="text-[9px] text-status-success">
                             {formatDate(lastOrderDate)}
                           </span>
                         )}

--- a/src/pages/AdminApprovals.tsx
+++ b/src/pages/AdminApprovals.tsx
@@ -252,7 +252,7 @@ const AdminApprovals = () => {
         ) : (
           <div className="space-y-3">
             <div className="flex items-center gap-2 mb-4">
-              <Clock className="w-5 h-5 text-amber-600" />
+              <Clock className="w-5 h-5 text-status-warning" />
               <span className="font-medium">{pendingUsers.length} pendente(s)</span>
             </div>
 
@@ -275,7 +275,7 @@ const AdminApprovals = () => {
                           CPF/CNPJ: {formatDocument(pendingUser.document)}
                         </p>
                         {!pendingUser.document && (
-                          <AlertTriangle className="w-3.5 h-3.5 text-amber-500" />
+                          <AlertTriangle className="w-3.5 h-3.5 text-status-warning" />
                         )}
                       </div>
                       <p className="text-xs text-muted-foreground">

--- a/src/pages/AdminDemandForecast.tsx
+++ b/src/pages/AdminDemandForecast.tsx
@@ -233,13 +233,13 @@ const AdminDemandForecast = () => {
           
           <Card className={cn(
             "text-center cursor-pointer transition-all",
-            selectedTab === 'soon' && "ring-2 ring-amber-500"
+            selectedTab === 'soon' && "ring-2 ring-status-warning"
           )} onClick={() => setSelectedTab('soon')}>
             <CardContent className="pt-4 pb-3">
-              <div className="w-8 h-8 rounded-full bg-amber-100 flex items-center justify-center mx-auto mb-2">
-                <Clock className="w-4 h-4 text-amber-600" />
+              <div className="w-8 h-8 rounded-full bg-status-warning-bg flex items-center justify-center mx-auto mb-2">
+                <Clock className="w-4 h-4 text-status-warning" />
               </div>
-              <p className="text-2xl font-bold text-amber-600">{dueSoonCount}</p>
+              <p className="text-2xl font-bold text-status-warning">{dueSoonCount}</p>
               <p className="text-xs text-muted-foreground">Em 7 dias</p>
             </CardContent>
           </Card>
@@ -322,9 +322,9 @@ const CustomerCard = ({ customer, onViewCustomer, onCreateOrder }: CustomerCardP
         };
       case 'soon':
         return {
-          border: 'border-amber-300',
-          bg: 'bg-amber-50',
-          badge: 'bg-amber-500 text-white',
+          border: 'border-status-warning/40',
+          bg: 'bg-status-warning-bg',
+          badge: 'bg-status-warning text-white',
           badgeText: 'Em breve',
         };
       default:

--- a/src/pages/AdminMonthlyReports.tsx
+++ b/src/pages/AdminMonthlyReports.tsx
@@ -146,7 +146,7 @@ const AdminMonthlyReports = () => {
             </Card>
             <Card className="text-center">
               <CardContent className="pt-4 pb-3">
-                <p className="text-2xl font-bold text-amber-600">
+                <p className="text-2xl font-bold text-status-warning">
                   {reports.reduce((sum, r) => sum + r.due_soon_count, 0)}
                 </p>
                 <p className="text-xs text-muted-foreground">Vencem em breve</p>
@@ -186,7 +186,7 @@ const AdminMonthlyReports = () => {
                       </Badge>
                     )}
                     {report.due_soon_count > 0 && (
-                      <Badge className="text-xs bg-amber-100 text-amber-800 hover:bg-amber-100">
+                      <Badge className="text-xs bg-status-warning-bg text-status-warning-foreground hover:bg-status-warning-bg">
                         {report.due_soon_count} em breve
                       </Badge>
                     )}
@@ -211,9 +211,9 @@ const AdminMonthlyReports = () => {
                           {tool.is_overdue ? (
                             <AlertTriangle className="w-3.5 h-3.5 text-destructive" />
                           ) : tool.is_due_soon ? (
-                            <AlertTriangle className="w-3.5 h-3.5 text-amber-500" />
+                            <AlertTriangle className="w-3.5 h-3.5 text-status-warning" />
                           ) : (
-                            <CheckCircle className="w-3.5 h-3.5 text-emerald-500" />
+                            <CheckCircle className="w-3.5 h-3.5 text-status-success" />
                           )}
                           <span className="text-foreground">{tool.name}</span>
                           {tool.internal_code && (

--- a/src/pages/AdminNotificacoes.tsx
+++ b/src/pages/AdminNotificacoes.tsx
@@ -68,12 +68,12 @@ function fmtDate(iso: string | null): string {
 
 function SeveridadeBadge({ s }: { s: Severidade }) {
   if (s === 'urgente') return <Badge className="bg-destructive text-destructive-foreground">urgente</Badge>;
-  if (s === 'atencao') return <Badge className="bg-yellow-500 text-white">atenção</Badge>;
+  if (s === 'atencao') return <Badge className="bg-status-warning text-white">atenção</Badge>;
   return <Badge variant="secondary">info</Badge>;
 }
 
 function StatusBadge({ s }: { s: string | null }) {
-  if (s === 'notificado') return <Badge className="bg-green-600 text-white">notificado</Badge>;
+  if (s === 'notificado') return <Badge className="bg-status-success text-white">notificado</Badge>;
   if (s === 'falha_notificacao') return <Badge variant="destructive">falha</Badge>;
   return <Badge variant="outline">{s ?? '—'}</Badge>;
 }

--- a/src/pages/AdminPortalSayerlack.tsx
+++ b/src/pages/AdminPortalSayerlack.tsx
@@ -336,12 +336,12 @@ export default function AdminPortalSayerlack() {
   // KPI colors
   const pendCor = !kpis ? 'text-muted-foreground'
     : kpis.pendentes === 0 ? 'text-muted-foreground'
-    : kpis.pendentes <= 2 ? 'text-blue-600'
-    : 'text-orange-600';
+    : kpis.pendentes <= 2 ? 'text-status-info'
+    : 'text-status-warning';
   const taxaCor = kpis?.taxa == null ? 'text-muted-foreground'
-    : kpis.taxa >= 95 ? 'text-green-600'
-    : kpis.taxa >= 80 ? 'text-yellow-600'
-    : 'text-red-600';
+    : kpis.taxa >= 95 ? 'text-status-success'
+    : kpis.taxa >= 80 ? 'text-status-warning'
+    : 'text-status-error';
 
   // CSV Export
   const handleExportCSV = async () => {
@@ -395,7 +395,7 @@ export default function AdminPortalSayerlack() {
 
   const concilCor = !kpis ? 'text-muted-foreground'
     : kpis.conciliacao === 0 ? 'text-muted-foreground'
-    : 'text-amber-600';
+    : 'text-status-warning';
 
   return (
     <div className="container mx-auto p-4 sm:p-6 space-y-6 max-w-7xl">
@@ -420,7 +420,7 @@ export default function AdminPortalSayerlack() {
         <Card>
           <CardHeader className="pb-2"><CardTitle className="text-sm text-muted-foreground">Enviados últimos 7d</CardTitle></CardHeader>
           <CardContent>
-            <div className="text-4xl font-bold text-green-600">{kpis?.enviados7d ?? '—'}</div>
+            <div className="text-4xl font-bold text-status-success">{kpis?.enviados7d ?? '—'}</div>
             <div className="text-xs text-muted-foreground mt-1">pedidos finalizados</div>
           </CardContent>
         </Card>
@@ -448,7 +448,7 @@ export default function AdminPortalSayerlack() {
           <TabsTrigger value="conciliar">
             Conciliar
             {kpis?.conciliacao ? (
-              <span className="ml-1.5 inline-flex items-center justify-center rounded-full bg-amber-500/20 px-1.5 text-xs font-semibold text-amber-700">
+              <span className="ml-1.5 inline-flex items-center justify-center rounded-full bg-status-warning/20 px-1.5 text-xs font-semibold text-status-warning">
                 {kpis.conciliacao}
               </span>
             ) : null}
@@ -491,7 +491,7 @@ export default function AdminPortalSayerlack() {
                   <TableBody>
                     {filteredPend.map((p) => {
                       const t = p.portal_tentativas ?? 0;
-                      const tCor = t <= 1 ? 'text-green-600' : t === 2 ? 'text-yellow-600' : 'text-red-600';
+                      const tCor = t <= 1 ? 'text-status-success' : t === 2 ? 'text-status-warning' : 'text-status-error';
                       const retryFut = p.portal_proximo_retry_em && new Date(p.portal_proximo_retry_em) > new Date();
                       return (
                         <TableRow key={p.id}>
@@ -527,7 +527,7 @@ export default function AdminPortalSayerlack() {
 
         {/* ---------- CONCILIAR (PR1.5) ---------- */}
         <TabsContent value="conciliar" className="space-y-3">
-          <div className="rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900">
+          <div className="rounded-md border border-status-warning/40 bg-status-warning-bg p-3 text-sm text-status-warning-foreground">
             <strong>Conciliação manual:</strong> pedidos abaixo podem ter sido recebidos pelo
             portal Sayerlack mas o sistema não confirmou o protocolo. Abra o detalhe, verifique
             no portal e informe o número do pedido para liberar o registro no Omie.

--- a/src/pages/AdminReposicaoAumentoDetail.tsx
+++ b/src/pages/AdminReposicaoAumentoDetail.tsx
@@ -131,11 +131,11 @@ const ESTADOS_LABEL: Record<string, string> = {
 function estadoBadgeClass(estado: string): string {
   switch (estado) {
     case "rascunho":
-      return "bg-amber-500/15 text-amber-700 dark:text-amber-400 border-amber-500/30";
+      return "bg-status-warning/15 text-status-warning border-status-warning/30";
     case "ativo":
-      return "bg-blue-500/15 text-blue-700 dark:text-blue-400 border-blue-500/30";
+      return "bg-status-info/15 text-status-info border-status-info/30";
     case "vigente":
-      return "bg-emerald-500/15 text-emerald-700 dark:text-emerald-400 border-emerald-500/30";
+      return "bg-status-success/15 text-status-success border-status-success/30";
     case "expirado":
       return "bg-muted text-muted-foreground border-border";
     case "cancelado":
@@ -149,8 +149,8 @@ function confiancaClass(c: number | null): string {
   if (c === null) return "";
   if (c < 0.5) return "bg-destructive/15 text-destructive border-destructive/30";
   if (c <= 0.8)
-    return "bg-amber-500/15 text-amber-700 dark:text-amber-400 border-amber-500/30";
-  return "bg-emerald-500/15 text-emerald-700 dark:text-emerald-400 border-emerald-500/30";
+    return "bg-status-warning/15 text-status-warning border-status-warning/30";
+  return "bg-status-success/15 text-status-success border-status-success/30";
 }
 
 function diasEntre(data: string): number {
@@ -766,7 +766,7 @@ export default function AdminReposicaoAumentoDetail() {
                         <span className="text-muted-foreground">Sem mapeamento</span>
                         <span
                           className={`font-medium tabular-nums ${
-                            itensSemMapeamento > 0 ? "text-amber-600" : ""
+                            itensSemMapeamento > 0 ? "text-status-warning" : ""
                           }`}
                         >
                           {itensSemMapeamento}

--- a/src/pages/AdminReposicaoAumentos.tsx
+++ b/src/pages/AdminReposicaoAumentos.tsx
@@ -73,11 +73,11 @@ const ESTADOS: Array<{ value: string; label: string }> = [
 function estadoBadgeClass(estado: string): string {
   switch (estado) {
     case "rascunho":
-      return "bg-amber-500/15 text-amber-700 dark:text-amber-400 border-amber-500/30";
+      return "bg-status-warning/15 text-status-warning border-status-warning/30";
     case "ativo":
-      return "bg-blue-500/15 text-blue-700 dark:text-blue-400 border-blue-500/30";
+      return "bg-status-info/15 text-status-info border-status-info/30";
     case "vigente":
-      return "bg-emerald-500/15 text-emerald-700 dark:text-emerald-400 border-emerald-500/30";
+      return "bg-status-success/15 text-status-success border-status-success/30";
     case "expirado":
       return "bg-muted text-muted-foreground border-border";
     case "cancelado":
@@ -292,10 +292,10 @@ export default function AdminReposicaoAumentos() {
       </header>
 
       {ativosAguardando > 0 && filtroEstado !== "ativo" && (
-        <Card className="border-blue-500/40 bg-blue-500/5">
+        <Card className="border-status-info/40 bg-status-info/5">
           <CardContent className="flex items-center justify-between gap-3 py-4">
             <div className="flex items-center gap-3">
-              <TrendingUp className="h-5 w-5 text-blue-600 dark:text-blue-400" />
+              <TrendingUp className="h-5 w-5 text-status-info" />
               <div>
                 <p className="font-medium">
                   {ativosAguardando}{" "}

--- a/src/pages/AdminReposicaoNegociacaoParalela.tsx
+++ b/src/pages/AdminReposicaoNegociacaoParalela.tsx
@@ -181,7 +181,7 @@ function statusBadgeClass(status: StatusSugestao): string {
     case "visualizada":
       return "bg-status-info/15 text-status-info border-status-info/30";
     case "acao_tomada":
-      return "bg-orange-500/15 text-orange-700 dark:text-orange-400 border-orange-500/30";
+      return "bg-status-warning-bold/15 text-status-warning-bold border-status-warning-bold/30";
     default:
       return "bg-muted text-muted-foreground border-border";
   }

--- a/src/pages/AdminReposicaoOportunidades.tsx
+++ b/src/pages/AdminReposicaoOportunidades.tsx
@@ -180,7 +180,7 @@ function cenarioIcon(cenario: Cenario) {
     case "promo_volume":
       return <Package className="h-4 w-4 text-status-info" />;
     case "promo_e_aumento":
-      return <Zap className="h-4 w-4 text-purple-500" />;
+      return <Zap className="h-4 w-4 text-status-purple" />;
     case "aumento_apenas":
       return <TrendingUp className="h-4 w-4 text-status-error" />;
   }

--- a/src/pages/AdminReposicaoPedidos.tsx
+++ b/src/pages/AdminReposicaoPedidos.tsx
@@ -141,7 +141,7 @@ const statusMeta: Record<string, { label: string; variant: 'default' | 'secondar
   cancelado_humano: { label: 'Cancelado (vazio)', variant: 'outline' },
   expirado_sem_aprovacao: { label: 'Expirado sem aprovação', variant: 'secondary', className: 'bg-muted text-muted-foreground border-border' },
   // PR5: pedido pai de um split — não tem mais itens próprios, foi dividido em filhos.
-  split_em_filhos: { label: 'Dividido', variant: 'secondary', className: 'bg-purple-100 text-purple-800 border-purple-300' },
+  split_em_filhos: { label: 'Dividido', variant: 'secondary', className: 'bg-status-purple-bg text-status-purple-foreground border-status-purple/30' },
 };
 
 function formatBRL(v: number | null | undefined) {
@@ -172,7 +172,7 @@ function SplitInfo({ pedido }: { pedido: PedidoSugerido }) {
   // Pai (status_em_filhos): mostra "em N partes"
   if (pedido.status === 'split_em_filhos' && pedido.split_total) {
     return (
-      <Badge variant="outline" className="bg-purple-50 text-purple-700 border-purple-200 ml-1">
+      <Badge variant="outline" className="bg-status-purple-bg text-status-purple border-status-purple/30 ml-1">
         em {pedido.split_total} partes
       </Badge>
     );
@@ -182,7 +182,7 @@ function SplitInfo({ pedido }: { pedido: PedidoSugerido }) {
     return (
       <Badge
         variant="outline"
-        className="bg-purple-50 text-purple-700 border-purple-200 ml-1"
+        className="bg-status-purple-bg text-status-purple border-status-purple/30 ml-1"
         title={`Filho do pedido #${pedido.split_parent_id}`}
       >
         Lote {pedido.split_lote}/{pedido.split_total}

--- a/src/pages/AdminRoutePlanner.tsx
+++ b/src/pages/AdminRoutePlanner.tsx
@@ -142,8 +142,8 @@ const STOP_DURATION_MIN: Record<StopType, number> = {
 };
 
 const PRIORITY_CONFIG: Record<RouteStop['priorityLabel'], { label: string; bgClass: string; icon: typeof ArrowUp }> = {
-  alta: { label: 'Alta', bgClass: 'bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300', icon: ArrowUp },
-  media: { label: 'Média', bgClass: 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900 dark:text-yellow-300', icon: ArrowRight },
+  alta: { label: 'Alta', bgClass: 'bg-status-error-bg text-status-error', icon: ArrowUp },
+  media: { label: 'Média', bgClass: 'bg-status-warning-bg text-status-warning', icon: ArrowRight },
   baixa: { label: 'Baixa', bgClass: 'bg-muted text-muted-foreground', icon: ArrowDown },
 };
 
@@ -1418,7 +1418,7 @@ const AdminRoutePlanner = () => {
             optimizedRoute.map((stop, idx) => {
               const cfg = STOP_CONFIG[stop.stopType];
               return (
-                <Card key={stop.id} className={`hover:shadow-md transition-shadow ${visitStatuses.get(stop.customerUserId)?.isCheckedIn ? 'border-green-400 bg-green-50/40 dark:bg-green-950/20' : ''}`}>
+                <Card key={stop.id} className={`hover:shadow-md transition-shadow ${visitStatuses.get(stop.customerUserId)?.isCheckedIn ? 'border-status-success/60 bg-status-success-bg/40' : ''}`}>
                   <CardContent className="py-3 px-4">
                     <div className="flex items-start gap-3">
                       {/* Number circle colored by type */}
@@ -1486,7 +1486,7 @@ const AdminRoutePlanner = () => {
                               return (
                                 <Button
                                   size="sm" variant="outline"
-                                  className="h-7 text-xs gap-1 border-green-500 text-green-600 hover:bg-green-50 dark:hover:bg-green-950"
+                                  className="h-7 text-xs gap-1 border-status-success text-status-success hover:bg-status-success-bg"
                                   onClick={() => handleCheckInStop(stop)}
                                 >
                                   <CheckCircle2 className="w-3 h-3" /> Check-in
@@ -1495,12 +1495,12 @@ const AdminRoutePlanner = () => {
                             }
                             return (
                               <div className="flex items-center gap-1.5">
-                                <span className="text-xs font-mono text-green-600">
+                                <span className="text-xs font-mono text-status-success">
                                   {formatTimer(visitTimers.get(stop.customerUserId) ?? 0)}
                                 </span>
                                 <Button
                                   size="sm" variant="outline"
-                                  className="h-7 text-xs gap-1 border-orange-400 text-orange-600 hover:bg-orange-50 dark:hover:bg-orange-950"
+                                  className="h-7 text-xs gap-1 border-status-warning text-status-warning hover:bg-status-warning-bg"
                                   onClick={() => openCheckoutDialog(stop.customerUserId, stop.customerName)}
                                 >
                                   <XCircle className="w-3 h-3" /> Check-out
@@ -1556,10 +1556,10 @@ const AdminRoutePlanner = () => {
                 ? new Date(visit.check_in_at).toLocaleTimeString('pt-BR', { hour: '2-digit', minute: '2-digit' })
                 : '—';
               return (
-                <Card key={visit.id} className={isActive ? 'border-green-400' : ''}>
+                <Card key={visit.id} className={isActive ? 'border-status-success/60' : ''}>
                   <CardContent className="py-3 px-4">
                     <div className="flex items-center gap-3">
-                      <div className={`w-2.5 h-2.5 rounded-full flex-shrink-0 ${isActive ? 'bg-green-500 animate-pulse' : 'bg-muted-foreground'}`} />
+                      <div className={`w-2.5 h-2.5 rounded-full flex-shrink-0 ${isActive ? 'bg-status-success animate-pulse' : 'bg-muted-foreground'}`} />
                       <div className="flex-1 min-w-0">
                         <p className="text-sm font-medium">{visit.customerName}</p>
                         <p className="text-xs text-muted-foreground">

--- a/src/pages/AdminSkuMapeamento.tsx
+++ b/src/pages/AdminSkuMapeamento.tsx
@@ -341,7 +341,7 @@ export default function AdminSkuMapeamento() {
                         <TableCell>{Number(m.fator_conversao)}</TableCell>
                         <TableCell>
                           {m.ativo
-                            ? <Badge className="bg-green-600">Ativo</Badge>
+                            ? <Badge className="bg-status-success">Ativo</Badge>
                             : <Badge variant="secondary">Inativo</Badge>}
                         </TableCell>
                         <TableCell className="text-xs max-w-[220px] truncate" title={m.observacoes ?? ''}>

--- a/src/pages/ExecutiveDashboard.tsx
+++ b/src/pages/ExecutiveDashboard.tsx
@@ -16,10 +16,10 @@ import {
 const fmt = (v: number) => v.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
 
 const scoreColor = (v: number) =>
-  v >= 75 ? 'text-emerald-600' : v >= 50 ? 'text-amber-600' : 'text-red-600';
+  v >= 75 ? 'text-status-success' : v >= 50 ? 'text-status-warning' : 'text-status-error';
 
 const scoreBarColor = (v: number) =>
-  v >= 75 ? '[&>div]:bg-emerald-500' : v >= 50 ? '[&>div]:bg-amber-500' : '[&>div]:bg-red-500';
+  v >= 75 ? '[&>div]:bg-status-success' : v >= 50 ? '[&>div]:bg-status-warning' : '[&>div]:bg-status-error';
 
 const ExecutiveDashboard = () => {
   const navigate = useNavigate();

--- a/src/pages/FinanceiroAnalytics.tsx
+++ b/src/pages/FinanceiroAnalytics.tsx
@@ -172,9 +172,9 @@ const FinanceiroAnalytics = () => {
             <p className="text-xs text-muted-foreground">Total Documento</p>
             <p className="text-sm font-bold">{fmtCompact(total)}</p>
           </div>
-          <div className={`p-3 rounded-lg text-center ${tipo === 'cr' ? 'bg-emerald-50' : 'bg-red-50'}`}>
+          <div className={`p-3 rounded-lg text-center ${tipo === 'cr' ? 'bg-status-success-bg' : 'bg-status-error-bg'}`}>
             <p className="text-xs text-muted-foreground">{tipo === 'cr' ? 'Recebido' : 'Pago'}</p>
-            <p className={`text-sm font-bold ${tipo === 'cr' ? 'text-emerald-600' : 'text-red-600'}`}>
+            <p className={`text-sm font-bold ${tipo === 'cr' ? 'text-status-success' : 'text-status-error'}`}>
               {fmtCompact(totalPagoRecebido)}
             </p>
           </div>
@@ -216,7 +216,7 @@ const FinanceiroAnalytics = () => {
                         </TableCell>
                         <TableCell className="text-right text-sm">{row.qtd_titulos}</TableCell>
                         <TableCell className="text-right text-sm font-medium">{fmtCompact(row.total_documento)}</TableCell>
-                        <TableCell className={`text-right text-sm ${tipo === 'cr' ? 'text-emerald-600' : 'text-red-600'}`}>
+                        <TableCell className={`text-right text-sm ${tipo === 'cr' ? 'text-status-success' : 'text-status-error'}`}>
                           {fmtCompact(row.total_pago_recebido)}
                         </TableCell>
                         <TableCell className="text-right text-sm font-bold">

--- a/src/pages/FinanceiroConciliacao.tsx
+++ b/src/pages/FinanceiroConciliacao.tsx
@@ -18,10 +18,10 @@ const fmt = (v: number) => v.toLocaleString('pt-BR', { style: 'currency', curren
 const fmtDate = (d: string | null) => d ? new Date(d + 'T00:00:00').toLocaleDateString('pt-BR') : '—';
 
 const statusConfig: Record<string, { label: string; color: string; icon: any }> = {
-  pendente: { label: 'Pendente', color: 'bg-amber-100 text-amber-700', icon: AlertTriangle },
-  conciliado: { label: 'Conciliado', color: 'bg-emerald-100 text-emerald-700', icon: CheckCircle2 },
-  divergencia: { label: 'Divergência', color: 'bg-red-100 text-red-700', icon: XCircle },
-  ignorado: { label: 'Ignorado', color: 'bg-gray-100 text-gray-500', icon: Ban },
+  pendente: { label: 'Pendente', color: 'bg-status-warning-bg text-status-warning', icon: AlertTriangle },
+  conciliado: { label: 'Conciliado', color: 'bg-status-success-bg text-status-success', icon: CheckCircle2 },
+  divergencia: { label: 'Divergência', color: 'bg-status-error-bg text-status-error', icon: XCircle },
+  ignorado: { label: 'Ignorado', color: 'bg-muted text-muted-foreground', icon: Ban },
 };
 
 const FinanceiroConciliacao = () => {
@@ -279,7 +279,7 @@ const FinanceiroConciliacao = () => {
                     const cfg = statusConfig[item.status] || statusConfig.pendente;
                     const Icon = cfg.icon;
                     return (
-                      <TableRow key={item.id} className={item.status === 'divergencia' ? 'bg-red-50/50' : ''}>
+                      <TableRow key={item.id} className={item.status === 'divergencia' ? 'bg-status-error-bg/50' : ''}>
                         <TableCell className="text-sm">{fmtDate(item.mov_data)}</TableCell>
                         <TableCell>
                           <p className="text-sm truncate max-w-[250px]">{item.mov_descricao || '—'}</p>
@@ -290,7 +290,7 @@ const FinanceiroConciliacao = () => {
                         <TableCell className="text-right text-sm font-medium">{fmt(item.mov_valor || 0)}</TableCell>
                         <TableCell className="text-right text-sm">{item.titulo_valor ? fmt(item.titulo_valor) : '—'}</TableCell>
                         <TableCell className={`text-right text-sm font-bold ${
-                          Math.abs(item.diferenca || 0) > 0.01 ? 'text-red-600' : 'text-emerald-600'
+                          Math.abs(item.diferenca || 0) > 0.01 ? 'text-status-error' : 'text-status-success'
                         }`}>
                           {item.diferenca != null ? fmt(item.diferenca) : '—'}
                         </TableCell>
@@ -307,7 +307,7 @@ const FinanceiroConciliacao = () => {
                         <TableCell>
                           {(item.status === 'pendente' || item.status === 'divergencia') && (
                             <div className="flex gap-1">
-                              <Button size="sm" variant="ghost" className="h-7 text-[10px] text-emerald-600"
+                              <Button size="sm" variant="ghost" className="h-7 text-[10px] text-status-success"
                                 onClick={() => resolver(item.id, 'conciliado')}>
                                 <CheckCircle2 className="w-3 h-3 mr-0.5" /> OK
                               </Button>

--- a/src/pages/FinanceiroDashboard.tsx
+++ b/src/pages/FinanceiroDashboard.tsx
@@ -829,7 +829,7 @@ function AgingCard({ title, data, type }: { title: string; data: any; type: 'rec
   const bars = [
     { label: 'A vencer', value: data.a_vencer_valor, qtd: data.a_vencer_qtd, color: 'bg-status-info' },
     { label: '1-30 dias', value: data.vencido_1_30_valor, qtd: data.vencido_1_30_qtd, color: 'bg-status-warning' },
-    { label: '31-60 dias', value: data.vencido_31_60_valor, qtd: data.vencido_31_60_qtd, color: 'bg-orange-500' },
+    { label: '31-60 dias', value: data.vencido_31_60_valor, qtd: data.vencido_31_60_qtd, color: 'bg-status-warning-bold' },
     { label: '61-90 dias', value: data.vencido_61_90_valor, qtd: data.vencido_61_90_qtd, color: 'bg-status-error' },
     { label: '+90 dias', value: data.vencido_90_plus_valor, qtd: data.vencido_90_plus_qtd, color: 'bg-status-error' },
   ];

--- a/src/pages/FinanceiroFechamento.tsx
+++ b/src/pages/FinanceiroFechamento.tsx
@@ -19,10 +19,10 @@ import {
 const mesesNome = ['Janeiro','Fevereiro','Março','Abril','Maio','Junho','Julho','Agosto','Setembro','Outubro','Novembro','Dezembro'];
 
 const statusConfig: Record<string, { label: string; color: string; icon: any }> = {
-  aberto: { label: 'Aberto', color: 'bg-blue-100 text-blue-700', icon: Clock },
-  em_revisao: { label: 'Em Revisão', color: 'bg-amber-100 text-amber-700', icon: Eye },
-  fechado: { label: 'Fechado', color: 'bg-emerald-100 text-emerald-700', icon: Lock },
-  reaberto: { label: 'Reaberto', color: 'bg-red-100 text-red-700', icon: Unlock },
+  aberto: { label: 'Aberto', color: 'bg-status-info-bg text-status-info', icon: Clock },
+  em_revisao: { label: 'Em Revisão', color: 'bg-status-warning-bg text-status-warning', icon: Eye },
+  fechado: { label: 'Fechado', color: 'bg-status-success-bg text-status-success', icon: Lock },
+  reaberto: { label: 'Reaberto', color: 'bg-status-error-bg text-status-error', icon: Unlock },
 };
 
 const FinanceiroFechamento = () => {
@@ -151,7 +151,7 @@ const FinanceiroFechamento = () => {
                       key={mes}
                       className={`p-3 rounded-lg border text-center space-y-2 ${
                         isFuture ? 'opacity-40' : ''
-                      } ${fech?.status === 'fechado' ? 'border-emerald-200 bg-emerald-50/30' : ''}`}
+                      } ${fech?.status === 'fechado' ? 'border-status-success/40 bg-status-success-bg/30' : ''}`}
                     >
                       <p className="text-xs font-medium">{mesesNome[mes - 1].slice(0, 3)}</p>
 
@@ -184,7 +184,7 @@ const FinanceiroFechamento = () => {
                               </Button>
                             )}
                             {fech.status === 'fechado' && (
-                              <Button size="sm" variant="ghost" className="text-[10px] h-6 text-red-500"
+                              <Button size="sm" variant="ghost" className="text-[10px] h-6 text-status-error"
                                 onClick={() => {
                                   if (motivoReabertura || confirm('Confirma reabertura?')) {
                                     handleAcao(fech.id, 'reabrir', { motivo: motivoReabertura || 'Correção necessária' });

--- a/src/pages/FinanceiroIntercompany.tsx
+++ b/src/pages/FinanceiroIntercompany.tsx
@@ -139,12 +139,12 @@ const FinanceiroIntercompany = () => {
                   }>
                     <TableCell className="text-sm">{dreLabels[row.dre_linha] || row.dre_linha}</TableCell>
                     <TableCell className="text-right text-sm">{fmt(row.valor_bruto)}</TableCell>
-                    <TableCell className={`text-right text-sm ${row.eliminacoes !== 0 ? 'text-red-600 font-medium' : ''}`}>
+                    <TableCell className={`text-right text-sm ${row.eliminacoes !== 0 ? 'text-status-error font-medium' : ''}`}>
                       {row.eliminacoes !== 0 ? fmt(row.eliminacoes) : '—'}
                     </TableCell>
                     <TableCell className={`text-right text-sm font-medium ${
                       row.dre_linha === 'resultado_liquido'
-                        ? (row.valor_liquido >= 0 ? 'text-emerald-600' : 'text-red-600')
+                        ? (row.valor_liquido >= 0 ? 'text-status-success' : 'text-status-error')
                         : ''
                     }`}>{fmt(row.valor_liquido)}</TableCell>
                   </TableRow>
@@ -175,7 +175,7 @@ const FinanceiroIntercompany = () => {
                   <span>{r.descricao}</span>
                   <Badge variant="secondary" className="text-[9px]">{r.match_por}</Badge>
                 </div>
-                <Button variant="ghost" size="sm" className="text-red-500" onClick={() => handleDelete(r.id)}>
+                <Button variant="ghost" size="sm" className="text-status-error" onClick={() => handleDelete(r.id)}>
                   <Trash2 className="w-3.5 h-3.5" />
                 </Button>
               </div>

--- a/src/pages/FinanceiroMapping.tsx
+++ b/src/pages/FinanceiroMapping.tsx
@@ -104,10 +104,10 @@ const FinanceiroMapping = () => {
         </Select>
       </div>
 
-      <Card className="border-blue-200 bg-blue-50/30">
-        <CardContent className="p-4 text-sm text-blue-800">
+      <Card className="border-status-info/40 bg-status-info-bg/30">
+        <CardContent className="p-4 text-sm text-status-info-foreground">
           <p className="font-medium">Como funciona o mapeamento:</p>
-          <p className="mt-1 text-blue-700">
+          <p className="mt-1 text-status-info">
             Cada categoria do Omie (ex: "1.01.02 - Venda de produtos") precisa ser vinculada a uma linha da DRE.
             O mapeamento "Padrão" se aplica a todas as empresas. Mapeamentos por empresa têm prioridade sobre o padrão.
             Categorias sem mapeamento explícito usam heurística por nome — o ideal é mapear todas manualmente.
@@ -140,9 +140,9 @@ const FinanceiroMapping = () => {
 
       {/* Unmapped categories */}
       {showUnmapped && unmappedCategorias.length > 0 && (
-        <Card className="border-amber-200">
+        <Card className="border-status-warning/40">
           <CardHeader className="pb-3">
-            <CardTitle className="text-base flex items-center gap-2 text-amber-700">
+            <CardTitle className="text-base flex items-center gap-2 text-status-warning">
               <AlertTriangle className="w-4 h-4" />
               Categorias sem mapeamento
             </CardTitle>
@@ -222,7 +222,7 @@ const FinanceiroMapping = () => {
                           <SelectContent>
                             {DRE_LINHAS.map(l => (
                               <SelectItem key={l.value} value={l.value}>
-                                <span className={l.tipo === 'R' ? 'text-emerald-600' : 'text-red-600'}>
+                                <span className={l.tipo === 'R' ? 'text-status-success' : 'text-status-error'}>
                                   {l.label}
                                 </span>
                               </SelectItem>
@@ -235,7 +235,7 @@ const FinanceiroMapping = () => {
                           variant="ghost"
                           size="sm"
                           onClick={() => handleDelete(m.id)}
-                          className="text-red-500 hover:text-red-700"
+                          className="text-status-error hover:text-status-error/80"
                         >
                           <Trash2 className="w-3.5 h-3.5" />
                         </Button>
@@ -271,7 +271,7 @@ function UnmappedRow({ cat, saving, onSave }: {
       <TableCell className="font-mono text-sm">{cat.omie_codigo}</TableCell>
       <TableCell className="text-sm">{cat.descricao}</TableCell>
       <TableCell>
-        <Badge variant="outline" className={`text-xs ${cat.tipo === 'R' ? 'text-emerald-600' : 'text-red-600'}`}>
+        <Badge variant="outline" className={`text-xs ${cat.tipo === 'R' ? 'text-status-success' : 'text-status-error'}`}>
           {cat.tipo === 'R' ? 'Rec' : cat.tipo === 'D' ? 'Desp' : 'Trf'}
         </Badge>
       </TableCell>

--- a/src/pages/FinanceiroOrcamento.tsx
+++ b/src/pages/FinanceiroOrcamento.tsx
@@ -171,7 +171,7 @@ const FinanceiroOrcamento = () => {
                       <TableCell className="sticky left-0 bg-background text-sm font-medium">{s.label}</TableCell>
                       <TableCell className="text-right text-sm">{fmtCompact(s.orcYtd)}</TableCell>
                       <TableCell className="text-right text-sm font-medium">{fmtCompact(s.realYtd)}</TableCell>
-                      <TableCell className={`text-right text-sm font-bold ${isGood ? 'text-emerald-600' : 'text-red-600'}`}>
+                      <TableCell className={`text-right text-sm font-bold ${isGood ? 'text-status-success' : 'text-status-error'}`}>
                         {s.variacao > 0 ? '+' : ''}{s.variacao.toFixed(1)}%
                       </TableCell>
                       <TableCell>
@@ -180,9 +180,9 @@ const FinanceiroOrcamento = () => {
                         ) : (
                           <div className="flex items-center gap-1">
                             {isGood
-                              ? <TrendingUp className="w-3.5 h-3.5 text-emerald-600" />
-                              : <TrendingDown className="w-3.5 h-3.5 text-red-600" />}
-                            <span className={`text-xs ${isGood ? 'text-emerald-600' : 'text-red-600'}`}>
+                              ? <TrendingUp className="w-3.5 h-3.5 text-status-success" />
+                              : <TrendingDown className="w-3.5 h-3.5 text-status-error" />}
+                            <span className={`text-xs ${isGood ? 'text-status-success' : 'text-status-error'}`}>
                               {isGood ? 'Favorável' : 'Desfavorável'}
                             </span>
                           </div>
@@ -247,7 +247,7 @@ const FinanceiroOrcamento = () => {
                           <div className="text-muted-foreground">{orc > 0 ? fmtCompact(orc) : '—'}</div>
                           <div className="font-medium">{real > 0 ? fmtCompact(real) : '—'}</div>
                           {orc > 0 && real > 0 && (
-                            <div className={`text-[10px] ${diff >= 0 ? 'text-emerald-600' : 'text-red-600'}`}>
+                            <div className={`text-[10px] ${diff >= 0 ? 'text-status-success' : 'text-status-error'}`}>
                               {diff > 0 ? '+' : ''}{fmtCompact(diff)}
                             </div>
                           )}

--- a/src/pages/FinanceiroSync.tsx
+++ b/src/pages/FinanceiroSync.tsx
@@ -143,16 +143,16 @@ const FinanceiroSync = () => {
                             </Badge>
                             {!result && <span className="text-muted-foreground">—</span>}
                             {result?.status === 'running' && (
-                              <Loader2 className="w-3 h-3 animate-spin text-blue-500" />
+                              <Loader2 className="w-3 h-3 animate-spin text-status-info" />
                             )}
                             {result?.status === 'done' && (
-                              <span className="flex items-center gap-0.5 text-emerald-600">
+                              <span className="flex items-center gap-0.5 text-status-success">
                                 <CheckCircle2 className="w-3 h-3" />
                                 {result.total != null ? `${result.total}` : 'OK'}
                               </span>
                             )}
                             {result?.status === 'error' && (
-                              <span className="flex items-center gap-0.5 text-red-500" title={result.error}>
+                              <span className="flex items-center gap-0.5 text-status-error" title={result.error}>
                                 <XCircle className="w-3 h-3" />
                                 Erro
                               </span>
@@ -211,16 +211,16 @@ const FinanceiroSync = () => {
       </Card>
 
       {/* Env vars reminder */}
-      <Card className="border-amber-200 bg-amber-50/50">
+      <Card className="border-status-warning/40 bg-status-warning-bg/50">
         <CardContent className="p-4">
-          <p className="text-sm font-medium text-amber-800 flex items-center gap-2">
+          <p className="text-sm font-medium text-status-warning-foreground flex items-center gap-2">
             <Clock className="w-4 h-4" />
             Variáveis de ambiente necessárias no Supabase
           </p>
-          <div className="mt-2 text-xs text-amber-700 space-y-1">
-            <p>Oben: <code className="bg-amber-100 px-1 rounded">OMIE_VENDAS_APP_KEY</code> / <code className="bg-amber-100 px-1 rounded">OMIE_VENDAS_APP_SECRET</code></p>
-            <p>Colacor: <code className="bg-amber-100 px-1 rounded">OMIE_COLACOR_VENDAS_APP_KEY</code> / <code className="bg-amber-100 px-1 rounded">OMIE_COLACOR_VENDAS_APP_SECRET</code></p>
-            <p>Colacor SC: <code className="bg-amber-100 px-1 rounded">OMIE_COLACOR_SC_APP_KEY</code> / <code className="bg-amber-100 px-1 rounded">OMIE_COLACOR_SC_APP_SECRET</code></p>
+          <div className="mt-2 text-xs text-status-warning space-y-1">
+            <p>Oben: <code className="bg-status-warning/20 px-1 rounded">OMIE_VENDAS_APP_KEY</code> / <code className="bg-status-warning/20 px-1 rounded">OMIE_VENDAS_APP_SECRET</code></p>
+            <p>Colacor: <code className="bg-status-warning/20 px-1 rounded">OMIE_COLACOR_VENDAS_APP_KEY</code> / <code className="bg-status-warning/20 px-1 rounded">OMIE_COLACOR_VENDAS_APP_SECRET</code></p>
+            <p>Colacor SC: <code className="bg-status-warning/20 px-1 rounded">OMIE_COLACOR_SC_APP_KEY</code> / <code className="bg-status-warning/20 px-1 rounded">OMIE_COLACOR_SC_APP_SECRET</code></p>
           </div>
         </CardContent>
       </Card>

--- a/src/pages/OrderDetail.tsx
+++ b/src/pages/OrderDetail.tsx
@@ -265,7 +265,7 @@ const OrderDetail = () => {
                           : `Item ${qd.item_index + 1}`}
                       </span>
                       {qd.approved && (
-                        <Badge variant="outline" className="text-[10px] ml-auto border-emerald-400 text-emerald-600 bg-emerald-50 dark:bg-emerald-900/20 dark:text-emerald-300">
+                        <Badge variant="outline" className="text-[10px] ml-auto border-status-success/60 text-status-success bg-status-success-bg">
                           ✓ Qualidade aprovada
                         </Badge>
                       )}
@@ -363,7 +363,7 @@ const OrderDetail = () => {
                 </div>
                 <div className="flex justify-between text-sm">
                   <span className="text-muted-foreground">Status</span>
-                  <span className={order.paymentStatus === 'paid' ? 'text-emerald-600' : 'text-status-warning'}>
+                  <span className={order.paymentStatus === 'paid' ? 'text-status-success' : 'text-status-warning'}>
                     {order.paymentStatus === 'paid' ? 'Pago' : 'Pendente'}
                   </span>
                 </div>

--- a/src/pages/Recebimento.tsx
+++ b/src/pages/Recebimento.tsx
@@ -23,10 +23,10 @@ import {
 type NfeStatus = 'pendente' | 'em_conferencia' | 'divergencia' | 'conferido' | 'efetivado';
 
 const STATUS_CONFIG: Record<NfeStatus, { label: string; className: string }> = {
-  pendente: { label: 'Pendente', className: 'bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200' },
-  em_conferencia: { label: 'Em Conferência', className: 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200' },
-  divergencia: { label: 'Divergência', className: 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200' },
-  conferido: { label: 'Conferido', className: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200' },
+  pendente: { label: 'Pendente', className: 'bg-status-warning-bg text-status-warning-foreground' },
+  em_conferencia: { label: 'Em Conferência', className: 'bg-status-info-bg text-status-info-foreground' },
+  divergencia: { label: 'Divergência', className: 'bg-status-error-bg text-status-error-foreground' },
+  conferido: { label: 'Conferido', className: 'bg-status-success-bg text-status-success-foreground' },
   efetivado: { label: 'Efetivado', className: 'bg-muted text-muted-foreground' },
 };
 
@@ -307,7 +307,7 @@ export default function Recebimento({ statusFilter }: { statusFilter?: string[] 
                         <span>{totalItens} {totalItens === 1 ? 'item' : 'itens'}</span>
                         {totalItens > 0 && (
                           <span className={cn(
-                            conferidos === totalItens ? 'text-green-600' : 'text-amber-600'
+                            conferidos === totalItens ? 'text-status-success' : 'text-status-warning'
                           )}>
                             {conferidos} de {totalItens} conferidos
                           </span>

--- a/src/pages/RecebimentoConferencia.tsx
+++ b/src/pages/RecebimentoConferencia.tsx
@@ -28,9 +28,9 @@ type ItemStatus = 'pendente' | 'em_conferencia' | 'conferido' | 'divergencia';
 
 const STATUS_COLORS: Record<ItemStatus, string> = {
   pendente: 'bg-muted text-muted-foreground',
-  em_conferencia: 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200',
-  conferido: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200',
-  divergencia: 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200',
+  em_conferencia: 'bg-status-info-bg text-status-info-foreground',
+  conferido: 'bg-status-success-bg text-status-success-foreground',
+  divergencia: 'bg-status-error-bg text-status-error-foreground',
 };
 
 const STATUS_LABELS: Record<ItemStatus, string> = {
@@ -400,7 +400,7 @@ export default function RecebimentoConferencia() {
                         {decodeHtmlEntities(cte.razao_social_transportadora) || 'Transportadora'} · {formatCurrency(cte.valor_frete)}
                       </p>
                     </div>
-                    <Badge className={cn('text-xs', cte.status === 'efetivado' ? 'bg-muted text-muted-foreground' : 'bg-amber-100 text-amber-800')}>
+                    <Badge className={cn('text-xs', cte.status === 'efetivado' ? 'bg-muted text-muted-foreground' : 'bg-status-warning-bg text-status-warning-foreground')}>
                       {cte.status}
                     </Badge>
                   </CardContent>
@@ -559,7 +559,7 @@ export default function RecebimentoConferencia() {
 
               {activeConferida >= activeEsperada ? (
                 <div className="text-center py-6">
-                  <CheckCircle2 className="h-16 w-16 text-green-500 mx-auto mb-3" />
+                  <CheckCircle2 className="h-16 w-16 text-status-success mx-auto mb-3" />
                   <p className="text-lg font-semibold text-foreground">Todas as unidades conferidas!</p>
                   <Button className="mt-4" onClick={() => setActiveItemId(null)}>Fechar</Button>
                 </div>

--- a/src/pages/ResetPassword.tsx
+++ b/src/pages/ResetPassword.tsx
@@ -120,8 +120,8 @@ const ResetPassword = () => {
         
         <div className="flex-1 flex flex-col items-center justify-center px-4 py-8 relative z-10">
           <div className="w-full max-w-md text-center">
-            <div className="inline-flex items-center justify-center w-20 h-20 rounded-full bg-green-100 mb-6">
-              <CheckCircle className="w-10 h-10 text-green-600" />
+            <div className="inline-flex items-center justify-center w-20 h-20 rounded-full bg-status-success-bg mb-6">
+              <CheckCircle className="w-10 h-10 text-status-success" />
             </div>
             <h1 className="font-display font-bold text-2xl mb-2">Senha alterada!</h1>
             <p className="text-muted-foreground mb-6">

--- a/src/pages/SavingsDashboard.tsx
+++ b/src/pages/SavingsDashboard.tsx
@@ -149,7 +149,7 @@ const SavingsDashboard = () => {
           </Card>
           <Card>
             <CardContent className="p-3 text-center">
-              <Leaf className="w-5 h-5 text-emerald-500 mx-auto mb-1" />
+              <Leaf className="w-5 h-5 text-status-success mx-auto mb-1" />
               <p className="text-lg font-bold">{totalTools}</p>
               <p className="text-xs text-muted-foreground">Ferramentas salvas</p>
             </CardContent>
@@ -223,12 +223,12 @@ const SavingsDashboard = () => {
         </Card>
 
         {/* Eco impact */}
-        <Card className="bg-emerald-50 dark:bg-emerald-950/30 border-emerald-200 dark:border-emerald-800">
+        <Card className="bg-status-success-bg border-status-success/40">
           <CardContent className="p-4 flex gap-3">
-            <Leaf className="w-5 h-5 text-emerald-600 flex-shrink-0 mt-0.5" />
+            <Leaf className="w-5 h-5 text-status-success flex-shrink-0 mt-0.5" />
             <div>
-              <p className="text-sm font-medium text-emerald-800 dark:text-emerald-200">Impacto Ambiental</p>
-              <p className="text-xs text-emerald-700 dark:text-emerald-300">
+              <p className="text-sm font-medium text-status-success-foreground">Impacto Ambiental</p>
+              <p className="text-xs text-status-success-foreground">
                 Ao afiar {totalTools} ferramenta{totalTools !== 1 ? 's' : ''} ao invés de descartá-la{totalTools !== 1 ? 's' : ''}, 
                 você evitou {(totalTools * 0.5).toFixed(1)} kg de resíduos metálicos.
               </p>

--- a/src/pages/ToolHistory.tsx
+++ b/src/pages/ToolHistory.tsx
@@ -55,7 +55,7 @@ const CRITICALITY_CONFIG: Record<Criticality, {
 }> = {
   critical: { label: 'Crítica', icon: AlertTriangle, badgeClass: 'border-destructive/40 bg-destructive/10 text-destructive', iconClass: 'text-destructive', bgClass: 'bg-destructive/10' },
   attention: { label: 'Atenção', icon: Clock, badgeClass: 'border-status-warning/40 bg-status-warning-bg text-status-warning', iconClass: 'text-status-warning', bgClass: 'bg-status-warning-bg' },
-  healthy: { label: 'Saudável', icon: ShieldCheck, badgeClass: 'border-emerald-400/40 bg-emerald-50 text-emerald-700 dark:bg-emerald-900/20 dark:text-emerald-300', iconClass: 'text-emerald-600 dark:text-emerald-400', bgClass: 'bg-emerald-50 dark:bg-emerald-900/20' },
+  healthy: { label: 'Saudável', icon: ShieldCheck, badgeClass: 'border-status-success/40 bg-status-success-bg text-status-success', iconClass: 'text-status-success', bgClass: 'bg-status-success-bg' },
   unscheduled: { label: 'Não agendada', icon: HelpCircle, badgeClass: 'border-border bg-muted text-muted-foreground', iconClass: 'text-muted-foreground', bgClass: 'bg-muted' },
 };
 
@@ -72,7 +72,7 @@ function getCriticality(nextDue: string | null): Criticality {
 const EVENT_TYPE_CONFIG: Record<string, { label: string; icon: typeof Wrench; color: string; bg: string; sortWeight: number }> = {
   anomaly: { label: 'Anomalia', icon: AlertTriangle, color: 'text-destructive', bg: 'bg-destructive/10', sortWeight: 0 },
   sharpening: { label: 'Afiação', icon: Wrench, color: 'text-primary', bg: 'bg-primary/10', sortWeight: 1 },
-  inspection: { label: 'Inspeção', icon: CheckCircle, color: 'text-emerald-600 dark:text-emerald-400', bg: 'bg-emerald-50 dark:bg-emerald-900/20', sortWeight: 2 },
+  inspection: { label: 'Inspeção', icon: CheckCircle, color: 'text-status-success', bg: 'bg-status-success-bg', sortWeight: 2 },
   repair: { label: 'Reparo', icon: Settings, color: 'text-status-warning', bg: 'bg-status-warning-bg', sortWeight: 3 },
   note: { label: 'Observação', icon: FileText, color: 'text-muted-foreground', bg: 'bg-muted', sortWeight: 4 },
 };
@@ -116,7 +116,7 @@ const RECOMMENDATION_STYLES: Record<string, { border: string; bg: string; icon: 
   destructive: { border: 'border-destructive/40', bg: 'bg-destructive/5', icon: AlertTriangle, iconClass: 'text-destructive' },
   warning: { border: 'border-status-warning/40', bg: 'bg-status-warning-bg/50', icon: Clock, iconClass: 'text-status-warning' },
   info: { border: 'border-primary/30', bg: 'bg-primary/5', icon: TrendingUp, iconClass: 'text-primary' },
-  success: { border: 'border-emerald-400/30', bg: 'bg-emerald-50 dark:bg-emerald-900/10', icon: ShieldCheck, iconClass: 'text-emerald-600 dark:text-emerald-400' },
+  success: { border: 'border-status-success/30', bg: 'bg-status-success-bg', icon: ShieldCheck, iconClass: 'text-status-success' },
 };
 
 /* ═══════════════════════════════════════════════

--- a/src/pages/Tools.tsx
+++ b/src/pages/Tools.tsx
@@ -43,9 +43,9 @@ const CRITICALITY_CONFIG: Record<Criticality, {
   healthy: {
     label: 'Saudável',
     icon: ShieldCheck,
-    badgeClass: 'border-emerald-400/40 bg-emerald-50 text-emerald-700 dark:bg-emerald-900/20 dark:text-emerald-300',
-    iconClass: 'text-emerald-600 dark:text-emerald-400',
-    bgClass: 'bg-emerald-50 dark:bg-emerald-900/20',
+    badgeClass: 'border-status-success/40 bg-status-success-bg text-status-success',
+    iconClass: 'text-status-success',
+    bgClass: 'bg-status-success-bg',
     sortOrder: 2,
   },
   unscheduled: {
@@ -201,7 +201,7 @@ const Tools = () => {
               <SummaryPill value={tools.length} label="Total" className="text-foreground" />
               <SummaryPill value={counts.critical} label="Críticas" className="text-destructive" />
               <SummaryPill value={counts.attention} label="Atenção" className="text-status-warning" />
-              <SummaryPill value={counts.healthy} label="Saudáveis" className="text-emerald-600 dark:text-emerald-400" />
+              <SummaryPill value={counts.healthy} label="Saudáveis" className="text-status-success" />
             </div>
 
             {/* ═══ TOOLS LIST ═══ */}


### PR DESCRIPTION
## Sumário

Auditoria identificou **~516 ocorrências** de cores Tailwind hardcoded (`text-emerald-*`, `text-red-*`, `text-amber-*` etc.) em status badges/KPIs/alertas — violavam convenção CLAUDE.md §9 ("usar `text-status-*`"). Esta PR migra os files com semântica clara de status; **preserva** files com uso categórico/branding.

## Conversão

```
text-emerald-* / text-green-*  →  text-status-success
text-red-* / text-rose-*       →  text-status-error
text-amber-* / text-yellow-*   →  text-status-warning
text-orange-*                  →  text-status-warning-bold
text-blue-*                    →  text-status-info
text-purple-* / text-violet-*  →  text-status-purple
text-indigo-*                  →  text-status-indigo

Combos badge style:
bg-{X}-500/10 text-{X}-700 border-{X}-500/30
→ bg-status-{kind}/10 text-status-{kind} border-status-{kind}/30
```

## Files MIGRADOS (59 total)

| Área | Files |
|---|---|
| **DES + Intelligence** | PosicaoAtualTab, SimuladorTab, HistoricoTab, KpiCard, IntelligenceStrategicTab, IntelligenceOperationalTab, IntelligenceManagerialTab, IntelligenceUserSimulator, ExecutiveDashboard |
| **Financeiro** | Dashboard (aging buckets), Analytics, Conciliacao, Fechamento, Intercompany, Mapping, Orcamento, Sync, CockpitDrillDown |
| **Reposição** | ConfirmacaoPanel, EtapaChecklist, EtapasGrid, ProcessoComprasStepper, SmartAlertsSection, Aumentos, AumentoDetail, NegociacaoParalela, Oportunidades, Pedidos |
| **Portal Sayerlack** | KPIs traffic-light, PortalStatusBadge, PortalDetailDrawer |
| **Order/Customer** | OrderCard, OrderDetail, AdminApprovals, KanbanBoard, SendingQualityChecklist, SharpeningSuggestions, ToolImageIdentifier, UnifiedAIAssistant |
| **Outros** | Recebimento, LoteScannerOCR, Tools, ToolHistory, SavingsDashboard, ProtectedRoute, OnboardingWizard, etc. |

## Files PRESERVED (categórico/branding, NÃO status)

- **`Admin.tsx`** — orange/purple/yellow classificadores de módulo (Aprovações/Produtividade/Loyalty/etc.)
- **`AdminRoutePlanner`** STOP_CONFIG + markerColor — hex de markers no mapa
- **`SignupForm`/`Profile`** amber "Industrial" badge — categoria de cliente
- **`ExecutiveDashboard`** text-blue-* IEE / text-emerald-* IPF — branding de KPIs específicos
- **Star ratings** `fill-amber-400` — decorativo gold
- **Recharts** `Cell fill="hsl(...)"` — palette de chart

## Decisões ambíguas resolvidas

| Caso | Decisão |
|---|---|
| `bg-orange-500` aging "31-60 dias" | `bg-status-warning-bold` (entre warning amarelo e error vermelho) |
| OrderCard "em_triagem/controle_qualidade/em_rota" | `status-purple` + `status-indigo` (preserva distinção visual entre etapas) |
| Confidence "alta/media/baixa" | success/warning/destructive (severity clara) |

## 🛡️ Anti-PR-#4 check

Todas as 30 unique class names geradas foram validadas como **existentes em `tailwind.config.ts`** (`status-{success,warning,error,info,purple,indigo}` + `-bg`/`-foreground`/`-bold`). **Zero classes malformadas** tipo `*-bg0` (que foi o bug do PR #4 que motivou esta auditoria).

## Validação
- [x] `bun test` — 167/167 passam
- [x] `bun build` — limpa em ~14s, 69 precache entries
- [x] `bun lint` — 1401 problems (sem regressão; pure substitution = 248 ins / 248 del)

## Out of scope

~55 files com cores hardcoded ficaram intocados (Tint*, Farmer*, AIops, DesignSystem) — uso categórico ou requer análise tela-por-tela mais cuidadosa. Próximo sweep se desejado.

## Net diff
59 files changed, 248 insertions(+), 248 deletions(-)

🤖 Generated with [Claude Code](https://claude.com/claude-code)