### PR TITLE
offline-first(recebimento): completa ciclo — divergência + CT-e + guard em finalize

### DIFF
--- a/src/pages/RecebimentoConferencia.tsx
+++ b/src/pages/RecebimentoConferencia.tsx
@@ -27,6 +27,7 @@ import { useOfflineMutation } from '@/hooks/useOfflineMutation';
 import { registerOfflineHandler } from '@/hooks/useOfflineFlush';
 import { confirmUnit, type ConfirmUnitVars } from '@/services/recebimento-confirm';
 import { reportDivergencia, type ReportDivergenciaVars } from '@/services/recebimento-divergencia';
+import { addCte, type AddCteVars } from '@/services/recebimento-cte';
 
 type ItemStatus = 'pendente' | 'em_conferencia' | 'conferido' | 'divergencia';
 
@@ -123,6 +124,12 @@ export default function RecebimentoConferencia() {
     mutationFn: reportDivergencia,
   });
 
+  // Offline-aware mutation pra handleAddCte
+  const addCteMutation = useOfflineMutation<{ ok: true }, AddCteVars>({
+    kind: 'recebimento.add-cte',
+    mutationFn: addCte,
+  });
+
   // Registra handler pra processar items enfileirados quando reconectar
   useEffect(() => {
     return registerOfflineHandler<ConfirmUnitVars>('recebimento.confirm-unit', async (vars) => {
@@ -134,6 +141,13 @@ export default function RecebimentoConferencia() {
   useEffect(() => {
     return registerOfflineHandler<ReportDivergenciaVars>('recebimento.report-divergencia', async (vars) => {
       await reportDivergencia(vars);
+      return true;
+    });
+  }, []);
+
+  useEffect(() => {
+    return registerOfflineHandler<AddCteVars>('recebimento.add-cte', async (vars) => {
+      await addCte(vars);
       return true;
     });
   }, []);
@@ -287,19 +301,27 @@ export default function RecebimentoConferencia() {
       toast.error('Informe a chave de acesso (44 dígitos) ou o XML');
       return;
     }
+    if (!id) return;
     setCteSaving(true);
     try {
-      await supabase.from('cte_associados').insert({
-        nfe_recebimento_id: id!,
-        chave_acesso_cte: clean || `XML-${Date.now()}`,
-        xml_cte: cteXml.trim() || null,
-        status: 'pendente',
-      });
-      toast.success('CT-e vinculado');
+      const vars: AddCteVars = {
+        nfeId: id,
+        chaveAcesso: clean || `XML-${Date.now()}`,
+        xmlCte: cteXml.trim() || null,
+      };
+
+      await addCteMutation.mutateAsync(vars);
+
       setCteModalOpen(false);
       setCteChave('');
       setCteXml('');
       queryClient.invalidateQueries({ queryKey: ['nfe_conferencia', id] });
+
+      if (addCteMutation.queued) {
+        toast.info('Salvo offline — sincroniza quando reconectar');
+      } else {
+        toast.success('CT-e vinculado');
+      }
     } catch (err: any) {
       toast.error('Erro: ' + err.message);
     } finally {

--- a/src/pages/RecebimentoConferencia.tsx
+++ b/src/pages/RecebimentoConferencia.tsx
@@ -331,6 +331,10 @@ export default function RecebimentoConferencia() {
 
   // Finalize
   const handleFinalize = async () => {
+    if (typeof navigator !== 'undefined' && !navigator.onLine) {
+      toast.error('Finalizar exige conexão (sincroniza com Omie). Conecte e tente novamente.');
+      return;
+    }
     setFinalizing(true);
     try {
       const { data: { user } } = await supabase.auth.getUser();

--- a/src/pages/RecebimentoConferencia.tsx
+++ b/src/pages/RecebimentoConferencia.tsx
@@ -26,6 +26,7 @@ import LoteScannerOCR from '@/components/recebimento/LoteScannerOCR';
 import { useOfflineMutation } from '@/hooks/useOfflineMutation';
 import { registerOfflineHandler } from '@/hooks/useOfflineFlush';
 import { confirmUnit, type ConfirmUnitVars } from '@/services/recebimento-confirm';
+import { reportDivergencia, type ReportDivergenciaVars } from '@/services/recebimento-divergencia';
 
 type ItemStatus = 'pendente' | 'em_conferencia' | 'conferido' | 'divergencia';
 
@@ -116,10 +117,23 @@ export default function RecebimentoConferencia() {
     mutationFn: confirmUnit,
   });
 
+  // Offline-aware mutation pra handleReportDivergencia
+  const divergenciaMutation = useOfflineMutation<{ ok: true }, ReportDivergenciaVars>({
+    kind: 'recebimento.report-divergencia',
+    mutationFn: reportDivergencia,
+  });
+
   // Registra handler pra processar items enfileirados quando reconectar
   useEffect(() => {
     return registerOfflineHandler<ConfirmUnitVars>('recebimento.confirm-unit', async (vars) => {
       await confirmUnit(vars);
+      return true;
+    });
+  }, []);
+
+  useEffect(() => {
+    return registerOfflineHandler<ReportDivergenciaVars>('recebimento.report-divergencia', async (vars) => {
+      await reportDivergencia(vars);
       return true;
     });
   }, []);
@@ -239,20 +253,26 @@ export default function RecebimentoConferencia() {
 
   // Report divergence
   const handleReportDivergencia = async () => {
-    if (!divergenciaItemId || !divergenciaText.trim()) return;
+    if (!divergenciaItemId || !divergenciaText.trim() || !id) return;
     setSaving(true);
     try {
-      await supabase
-        .from('nfe_recebimento_itens')
-        .update({ status_item: 'divergencia', observacao: divergenciaText.trim() })
-        .eq('id', divergenciaItemId);
+      const vars: ReportDivergenciaVars = {
+        itemId: divergenciaItemId,
+        nfeId: id,
+        observacao: divergenciaText.trim(),
+      };
 
-      await supabase.from('nfe_recebimentos').update({ status: 'divergencia' }).eq('id', id!);
+      await divergenciaMutation.mutateAsync(vars);
 
-      toast.success('Divergência registrada');
       setDivergenciaItemId(null);
       setDivergenciaText('');
       queryClient.invalidateQueries({ queryKey: ['nfe_conferencia', id] });
+
+      if (divergenciaMutation.queued) {
+        toast.info('Salvo offline — sincroniza quando reconectar');
+      } else {
+        toast.success('Divergência registrada');
+      }
     } catch (err: any) {
       toast.error('Erro: ' + err.message);
     } finally {

--- a/src/services/recebimento-cte.ts
+++ b/src/services/recebimento-cte.ts
@@ -1,0 +1,29 @@
+import { supabase } from '@/integrations/supabase/client';
+
+export interface AddCteVars {
+  nfeId: string;
+  chaveAcesso: string;
+  xmlCte: string | null;
+}
+
+/**
+ * Encapsula o INSERT de `handleAddCte` no service pra ser offline-capable.
+ *
+ * Nota de idempotência:
+ * - INSERT em cte_associados pode duplicar se a fila reprocessar (não há unique
+ *   constraint por (nfe_recebimento_id, chave_acesso_cte) garantida nesta camada).
+ *   Aceita pq duplicatas são detectáveis visualmente pelo conferente e o impacto
+ *   é baixo (apenas listagem). Resolução futura: unique constraint no schema.
+ */
+export async function addCte(vars: AddCteVars): Promise<{ ok: true }> {
+  const { error } = await supabase
+    .from('cte_associados')
+    .insert({
+      nfe_recebimento_id: vars.nfeId,
+      chave_acesso_cte: vars.chaveAcesso,
+      xml_cte: vars.xmlCte,
+      status: 'pendente',
+    });
+  if (error) throw error;
+  return { ok: true };
+}

--- a/src/services/recebimento-divergencia.ts
+++ b/src/services/recebimento-divergencia.ts
@@ -1,0 +1,32 @@
+import { supabase } from '@/integrations/supabase/client';
+
+export interface ReportDivergenciaVars {
+  itemId: string;
+  nfeId: string;
+  observacao: string;
+}
+
+/**
+ * Encapsula as 2 mutations de `handleReportDivergencia` numa operação
+ * idempotente o suficiente pra processar offline-then-online.
+ *
+ * Notas de idempotência:
+ * - UPDATE de status_item + observacao usa valor absoluto, rodar 2x não causa
+ *   efeito colateral.
+ * - UPDATE de status do NF-e idem (valor absoluto 'divergencia').
+ */
+export async function reportDivergencia(vars: ReportDivergenciaVars): Promise<{ ok: true }> {
+  const { error: e1 } = await supabase
+    .from('nfe_recebimento_itens')
+    .update({ status_item: 'divergencia', observacao: vars.observacao })
+    .eq('id', vars.itemId);
+  if (e1) throw e1;
+
+  const { error: e2 } = await supabase
+    .from('nfe_recebimentos')
+    .update({ status: 'divergencia' })
+    .eq('id', vars.nfeId);
+  if (e2) throw e2;
+
+  return { ok: true };
+}


### PR DESCRIPTION
## Summary

Fecha o ciclo de offline-first do recebimento, complementando PR #51 (que cobriu `handleConfirmUnit`).

3 mudanças em `RecebimentoConferencia.tsx`:

### 1. `handleReportDivergencia` → offline-capable
- Service `src/services/recebimento-divergencia.ts` encapsula as 2 mutations (update item + update nfe)
- Usa `useOfflineMutation` com kind `recebimento.report-divergencia`
- Toast diferenciado: salvo offline vs registrado

### 2. `handleAddCte` → offline-capable
- Service `src/services/recebimento-cte.ts` encapsula 1 insert (cte_associados)
- Kind `recebimento.add-cte`

### 3. `handleFinalize` → guard online-only (intencional)
- Invoca Edge Function `omie-nfe-recebimento` que chama Omie API externa
- Não tem como fazer offline (precisa do código real de retorno do Omie)
- Adiciona guard: se `!navigator.onLine`, toast "Finalizar exige conexão" e retorna
- Resto do fluxo inalterado

## Stats
- 3 arquivos: 2 services novos + RecebimentoConferencia.tsx
- 201/201 tests pass (sem regressão; infra de offline-first já era testada em PR #51)
- `bun build` exit 0
- 3 commits separados

## Pós-merge

Conferente agora cobre **100% do recebimento offline-resiliente** exceto a finalização (que exige Omie). Cenário típico: conferente perde sinal no chão da fábrica → confere unidades + registra divergências + vincula CTE offline → fila acumula → sinal volta → flush automático → conferente clica Finalizar (que pode exigir conexão estável pra Omie).

🤖 Generated with [Claude Code](https://claude.com/claude-code)