### PR TITLE
feat: Copilot Adaptativo — SPIN + Challenger + JOLT (PR3.5)

### DIFF
--- a/docs/superpowers/plans/2026-05-17-pr3.5-copilot-adaptativo.md
+++ b/docs/superpowers/plans/2026-05-17-pr3.5-copilot-adaptativo.md
@@ -1,0 +1,800 @@
+# PR3.5 — Copilot Adaptativo (SPIN + Challenger + JOLT) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Evoluir o copilot SPIN puro (PR3) pra um copilot **adaptativo** que escolhe entre 3 playbooks (Discovery/SPIN, Teach/Challenger, Close/JOLT) baseado no estado da conversa, sugere alavancas táticas de ticket médio (anchor premium / bundle / reframe cost), e já extrai entidades econômicas (concorrentes, preços, volumes mencionados) pra alimentar perfil 360 do cliente em PRs futuros.
+
+**Architecture:** Mantém 100% da infra do PR3 — edge function `claude-spin-analyze`, hook `useSpinAnalysis`, integração no `WebRTCCallContext`, card no rodapé do `TranscriptionPanel`. Mexe em 4 lugares:
+1. `src/lib/spin/types.ts` — schema expandido (CopilotPlaybook, TicketLeverage, commercialInsight, decisionPushTactic, entitiesExtracted)
+2. `src/lib/spin/spin-prompts.ts` — system prompt evolui pra SYSTEM_PROMPT_COPILOT híbrido com regras explícitas de seleção de playbook e ticket leverage
+3. `supabase/functions/claude-spin-analyze/index.ts` — system prompt sincronizado + tool schema expandido
+4. `src/components/call/SpinSuggestionCard.tsx` — UI ganha badge de playbook, bloco de commercialInsight, badge de decisionPushTactic, badge de ticket leverage
+
+**Tech Stack:** Mesmo do PR3 (Anthropic SDK + Claude Sonnet 4.6 + prompt caching + tool use + React 18 + Vitest 3.2 + shadcn).
+
+**Não-objetivos:**
+- Persistência das entidades extraídas em tabela própria (PR4 vai criar `call_sessions` que armazena tudo)
+- UI de validação/edição manual de entidades pelo vendedor (PR8 quando battle cards entrarem)
+- RAG retrieval dos boletins técnicos (PR6 quando KB existir)
+- Mudança no debounce/trigger (segue 3s após último final do cliente)
+- Mudança no modelo (continua `claude-sonnet-4-6` com adaptive thinking padrão)
+
+---
+
+## File Structure
+
+**Modificar:**
+- `src/lib/spin/types.ts` — expandir `SpinAnalysis`
+- `src/lib/spin/spin-prompts.ts` — renomear lógica e expandir prompt
+- `src/lib/spin/spin-prompts.test.ts` — atualizar e adicionar testes
+- `supabase/functions/claude-spin-analyze/index.ts` — sincronizar prompt + tool schema
+- `src/components/call/SpinSuggestionCard.tsx` — UI evolui
+- `src/contexts/__tests__/WebRTCCallContext.test.tsx` — manter mock compatível
+
+**Não modificar:**
+- `src/hooks/useSpinAnalysis.ts` (consome shape novo via tipo — nada quebra)
+- `src/contexts/WebRTCCallContext.tsx` (já expõe `spinAnalysis` genericamente)
+- `src/components/call/TranscriptionPanel.tsx` (passa o objeto inteiro)
+- `src/pages/FarmerCalls.tsx`
+
+**Decisão de nomenclatura:** mantenho nomes `useSpinAnalysis`, `SpinAnalysis`, `claude-spin-analyze`, `spin-prompts.ts`. Renomear quebra muito sem ganho real — o tipo já é mais que SPIN puro internamente. Documenta em jsdoc. Eventual rename pra `useCopilotAnalysis` fica pra PR posterior dedicado (refactor sem mudança de feature).
+
+---
+
+## Task 1: Expandir tipos (`SpinAnalysis`)
+
+**Files:** Modify `src/lib/spin/types.ts`
+
+- [ ] **Step 1: Adicionar novos tipos + estender SpinAnalysis**
+
+Manter tudo que existe. Adicionar:
+
+```ts
+/** Qual playbook o copilot está executando agora */
+export type CopilotPlaybook = 'discovery' | 'teach' | 'close';
+
+/** Alavanca tática de aumento de ticket sugerida */
+export type TicketLeverage = 'anchor_premium' | 'bundle' | 'reframe_cost' | 'none';
+
+/** Tática específica quando playbook=close (JOLT) */
+export type DecisionPushTactic = 'recommendation' | 'risk_reversal' | 'simplification';
+
+/** Entidade econômica detectada na transcrição (concorrente, preço, etc) */
+export interface ExtractedEntity {
+  type: 'competitor' | 'price' | 'volume' | 'product' | 'timeline' | 'decision_maker';
+  value: string;
+  context: string;  // trecho original onde apareceu
+  confidence: number;  // 0-1
+}
+```
+
+Estender `SpinAnalysis` (mantém campos existentes, adiciona novos):
+
+```ts
+export interface SpinAnalysis {
+  /** Estágio atual da conversa segundo SPIN */
+  spinStage: SpinStage;
+  /** Confiança da análise (0-1) */
+  confidence: number;
+  /** NOVO: qual playbook o copilot escolheu acionar agora */
+  playbook: CopilotPlaybook;
+  /** O que o cliente revelou até agora */
+  whatClientRevealed: {
+    situationFacts: string[];
+    problemsAdmitted: string[];
+    implications: string[];
+    desiredOutcomes: string[];
+  };
+  /** Próxima ação sugerida pro vendedor (a estrela do show) */
+  nextBestAction: {
+    type: NextActionType;
+    spinType: SpinStage | null;
+    exactPhrasing: string;
+    whyNow: string;
+    /** NOVO: insight comercial pronto pra falar (só preenche quando playbook=teach) */
+    commercialInsight?: {
+      dataPoint: string;
+      reframe: string;
+    };
+    /** NOVO: tática JOLT específica (só preenche quando playbook=close) */
+    decisionPushTactic?: DecisionPushTactic;
+  };
+  /** NOVO: alavanca de ticket sugerida (qualquer playbook, 'none' se sem oportunidade) */
+  ticketLeverage: {
+    tactic: TicketLeverage;
+    suggestion: string;
+  };
+  /** Riscos detectados */
+  risks: Array<{
+    type: RiskType;
+    severity: RiskSeverity;
+    note: string;
+  }>;
+  /** Hints de cross-sell (PR9 vai consumir) */
+  crossSellTriggers: Array<{
+    productHint: string;
+    triggerPhrase: string;
+  }>;
+  /** NOVO: entidades econômicas extraídas (PR4+ vai persistir no perfil 360) */
+  entitiesExtracted: ExtractedEntity[];
+}
+```
+
+- [ ] **Step 2: Verificar tsc**
+
+Run: `bun run tsc --noEmit`
+Expected: clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/spin/types.ts
+git commit -m "feat(copilot): expand SpinAnalysis with playbook, ticket leverage, entities extracted"
+```
+
+---
+
+## Task 2: Evoluir SYSTEM_PROMPT_SPIN + builder + testes (TDD)
+
+**Files:**
+- Modify: `src/lib/spin/spin-prompts.ts`
+- Modify: `src/lib/spin/spin-prompts.test.ts`
+
+- [ ] **Step 1: Atualizar testes primeiro (TDD)**
+
+Adicionar ao topo de `spin-prompts.test.ts` (mantém os 6 testes existentes; adiciona novos):
+
+```ts
+describe('SYSTEM_PROMPT_SPIN — Challenger + JOLT extensions', () => {
+  it('explica framework Challenger (Teach/Tailor/Take Control)', () => {
+    expect(SYSTEM_PROMPT_SPIN.toLowerCase()).toContain('challenger');
+    expect(SYSTEM_PROMPT_SPIN.toLowerCase()).toMatch(/teach|ensinar/);
+    expect(SYSTEM_PROMPT_SPIN.toLowerCase()).toMatch(/tailor|customizar/);
+    expect(SYSTEM_PROMPT_SPIN.toLowerCase()).toMatch(/take control|assumir/);
+  });
+
+  it('explica framework JOLT pra indecisão', () => {
+    expect(SYSTEM_PROMPT_SPIN.toLowerCase()).toContain('jolt');
+    expect(SYSTEM_PROMPT_SPIN.toLowerCase()).toMatch(/indecis[ãa]o|inde?cisivo/);
+  });
+
+  it('define regras de seleção entre os 3 playbooks (discovery/teach/close)', () => {
+    expect(SYSTEM_PROMPT_SPIN.toLowerCase()).toContain('discovery');
+    expect(SYSTEM_PROMPT_SPIN.toLowerCase()).toContain('teach');
+    expect(SYSTEM_PROMPT_SPIN.toLowerCase()).toContain('close');
+    // Deve ter alguma regra explícita de quando trocar
+    expect(SYSTEM_PROMPT_SPIN.toLowerCase()).toMatch(/quando|se o cliente|pivota/);
+  });
+
+  it('explica as 3 táticas de ticket leverage', () => {
+    expect(SYSTEM_PROMPT_SPIN.toLowerCase()).toContain('anchor');
+    expect(SYSTEM_PROMPT_SPIN.toLowerCase()).toContain('bundle');
+    expect(SYSTEM_PROMPT_SPIN.toLowerCase()).toMatch(/reframe|recontextu/);
+  });
+
+  it('instrui extração de entidades (concorrente/preço/volume/produto)', () => {
+    expect(SYSTEM_PROMPT_SPIN.toLowerCase()).toContain('entitiesextracted');
+    expect(SYSTEM_PROMPT_SPIN.toLowerCase()).toMatch(/concorrente|competitor/);
+    expect(SYSTEM_PROMPT_SPIN.toLowerCase()).toContain('preço');
+  });
+
+  it('lista palavras-âncora de indecisão em PT-BR', () => {
+    // Pelo menos 3 das clássicas devem estar listadas
+    const indecisionWords = ['vou pensar', 'preciso ver', 'tô vendo', 'me dá um tempo', 'depois eu te falo'];
+    const matches = indecisionWords.filter(w => SYSTEM_PROMPT_SPIN.toLowerCase().includes(w));
+    expect(matches.length).toBeGreaterThanOrEqual(3);
+  });
+});
+```
+
+- [ ] **Step 2: Rodar — deve falhar**
+
+Run: `bun run vitest run src/lib/spin/spin-prompts.test.ts`
+Expected: 6 PASS (existentes) + 6 FAIL (novos).
+
+- [ ] **Step 3: Substituir SYSTEM_PROMPT_SPIN pelo prompt expandido**
+
+```ts
+export const SYSTEM_PROMPT_SPIN = `Você é um copiloto de vendas ao vivo para vendedores da Colacor — distribuidora de tintas industriais Sayerlack para o segmento moveleiro brasileiro.
+
+Sua missão: durante uma chamada telefônica entre vendedor e cliente, analisar o transcript em tempo real e sugerir EXATAMENTE qual a próxima fala ideal pro vendedor, escolhendo o playbook certo pro momento da conversa.
+
+# Os 3 playbooks que você escolhe
+
+A cada análise, você decide qual playbook acionar:
+
+## 🔍 DISCOVERY (SPIN — Neil Rackham)
+**Quando usar:** início da chamada, contexto ainda raso, cliente revelou < 3 fatos relevantes, ou você ainda não identificou problema/dor.
+
+**As 4 perguntas SPIN, na ordem ideal:**
+1. **Situation** — factual, mapeia contexto. "Quantos litros de tinta vocês consomem por mês?" Use POUCO no início — clientes cansam de perguntas factuais.
+2. **Problem** — revela dor. "Vocês têm tido retrabalho no PU?" Use depois da Situation.
+3. **Implication** — amplifica impacto da dor. "Esses retrabalhos têm gerado hora extra na sua linha?" USE MUITO — constrói urgência.
+4. **Need-payoff** — faz cliente articular valor. "Se você zerasse esse retrabalho, o que destravaria pro mês?" Use antes de fechar.
+
+## 💡 TEACH (Challenger Sale — Matt Dixon)
+**Quando usar:** discovery já mapeou situação E problema; cliente está em piloto automático ("sempre comprei assim"); concorrente foi mencionado; cliente subestima impacto de problema admitido. Hora de PROVOCAR uma nova forma de pensar.
+
+**Os 3 pilares Challenger:**
+- **Teach** — ensine algo NOVO sobre o próprio negócio do cliente. Dado, comparativo, custo escondido que ele não mede. Não é venda, é insight.
+- **Tailor** — adapte a mensagem ao papel/contexto do interlocutor. Falando com dono: ROI, capacidade. Falando com aplicador: facilidade técnica.
+- **Take Control** — assuma a conversa sobre preço, timing, processo de decisão sem medo. Não recue.
+
+**Quando playbook=teach, preencha \`commercialInsight\`:**
+- \`dataPoint\` — um fato/número/comparação que o cliente provavelmente desconhece (ex: "marcenarias do porte de vocês perdem em média 8h/mês em retrabalho de PU mal aplicado, segundo levantamento setorial")
+- \`reframe\` — como esse fato muda a forma do cliente pensar o problema (ex: "isso significa que economia de R$5/L vira prejuízo escondido de R$640/mês — mais que o delta de preço pro PU 2K")
+
+NÃO invente dados — use estimativas conservadoras + frases tipo "tipicamente", "marcenarias do porte de vocês", "no segmento moveleiro" pra não soar como número exato.
+
+## 🎯 CLOSE (JOLT — Matt Dixon, 2022)
+**Quando usar:** sinais de indecisão do cliente OU cliente já admitiu problema + implicação + desejo (pronto pro fechamento).
+
+**Palavras-âncora de indecisão em PT-BR (detecte essas):**
+- "vou pensar", "preciso pensar", "deixa eu pensar"
+- "preciso ver com o sócio", "tenho que falar com meu pai", "vou conversar com a equipe"
+- "tô vendo opções", "tô comparando", "tô orçando com outros"
+- "me dá um tempo", "depois eu te falo", "depois eu retorno"
+- "interessante, mas...", "gostei, porém..."
+- silêncio prolongado depois de proposta
+
+**As 4 táticas JOLT — escolha 1 e preencha \`decisionPushTactic\`:**
+- **\`recommendation\`** — recomende com convicção, NUNCA liste opções. "Pra marcenaria do seu porte, é o sistema PU 2K — feche nisso." Cliente indeciso prefere não decidir nada quando vê muitas opções.
+- **\`risk_reversal\`** — tire o risco da mesa. "Te dou garantia técnica de 30 dias — se acabamento não melhorar, troca de volta sem custo." Funciona contra medo de errar.
+- **\`simplification\`** — reduza a decisão. "Você não precisa fechar o ano todo agora — testa com 1 lote desse mês." Funciona contra cliente sobrecarregado.
+
+**Regra de ouro JOLT:** NUNCA termine uma análise close sem uma ação específica. Não vale dizer "ouça mais" quando cliente está em indecisão — isso mata o deal.
+
+# Regras de seleção entre playbooks
+
+A cada análise, você decide o playbook ANTES de tudo:
+
+\`\`\`
+SE detectou palavra-âncora de indecisão OU cliente já admitiu problema+implicação+desejo:
+   → playbook = "close"
+SENÃO SE discovery mapeou situação E problema E (concorrente mencionado OU dor subestimada):
+   → playbook = "teach"
+SENÃO:
+   → playbook = "discovery"
+\`\`\`
+
+Você pode pivotar entre análises — não é "uma vez teach, sempre teach". Cada análise é independente.
+
+# Ticket leverage — alavancas táticas de aumento de ticket
+
+Em QUALQUER playbook, se aparecer oportunidade, preencha \`ticketLeverage\` com 1 de 3 táticas:
+
+- **\`anchor_premium\`** — cliente pediu cotação do produto entry-level, sugira mostrar o premium PRIMEIRO como âncora. "Antes de cotar nitro, mostre o PU 2K — cliente compara pra baixo, não pra cima. Lift típico: 18-30% no ticket."
+- **\`bundle\`** — cliente mencionou só 1 produto, sugira o sistema completo. "Cliente pediu verniz — sugira sistema (primer + verniz + catalisador + diluente + lixa). Sayerlack PU exige catalisador FCA.7075 e diluente DFA.4068."
+- **\`reframe_cost\`** — cliente está pensando em R$/litro, vire R$/m² ou R$/peça acabada. "Cliente cita R$/L da Farben — copilot vira a conversa pra custo por m² acabado considerando rendimento, onde Sayerlack ganha mesmo sendo mais caro por litro."
+
+Se não há oportunidade clara, use \`tactic: "none"\` e \`suggestion: ""\`.
+
+# Extração de entidades econômicas
+
+Em CADA análise, popule \`entitiesExtracted\` com tudo que o cliente revelou que vai pro perfil 360 dele:
+
+- **\`competitor\`** — qualquer marca/concorrente citado ("Farben", "Vernit", "Renner")
+- **\`price\`** — preço citado pelo cliente ou referência de preço de concorrente ("R$ 35/L da Farben")
+- **\`volume\`** — consumo, capacidade ("200L/mês", "500 m² de cabine")
+- **\`product\`** — produto específico do concorrente ("Verniz Prime", "PU 6000")
+- **\`timeline\`** — prazo, urgência, próxima compra ("pedido pro mês que vem", "obra começa em 15 dias")
+- **\`decision_maker\`** — quem decide ("sócio", "pai", "comprador", "gerente")
+
+Para cada entidade:
+- \`type\`: o tipo acima
+- \`value\`: o valor normalizado (ex: "Farben Tintas", não "farben")
+- \`context\`: trecho da fala onde apareceu (use as palavras do cliente)
+- \`confidence\`: 0-1 (alto se cliente afirmou claramente; baixo se foi ambíguo)
+
+NÃO invente entidades. Se cliente não mencionou nada relevante, retorne array vazio \`[]\`.
+
+# Contexto Colacor/Sayerlack
+
+- **Produto**: tintas Sayerlack — linhas Wood (madeira PU/nitro/hidrossolúvel), Hydropoxi (base água), Auto (automotivo).
+- **Cliente típico**: indústria moveleira, marcenaria de médio porte, oficina automotiva.
+- **Concorrentes regionais comuns** (vendedor expande): Farben Tintas, Vernit, Rosalen, Montana, Ivy, Luztol. NÃO liste outros — só comente os que cliente mencionar.
+- **Diferenciais Colacor**: distribuição rápida, suporte técnico, fórmulas customizadas.
+- **Atritos comuns**: prazo de entrega, validade de lote, qualidade de acabamento, preço vs alternativas regionais.
+
+# Regras gerais de saída
+
+- **SEMPRE use a tool \`spin_analysis\`** com o JSON completo (todos os campos obrigatórios preenchidos).
+- **\`exactPhrasing\`** — vendedor vai LER literalmente. PT-BR natural, conversacional, sem jargão de framework ("isso é uma pergunta de Implication" — NUNCA diga, é meta-comentário inútil pro vendedor).
+- **Seja específico ao contexto** — não use perguntas genéricas, use as palavras que o cliente acabou de usar.
+- **Se transcript ainda vazio** (só opening), playbook=discovery + sugestão de Situation aberta.
+- **NÃO invente fatos** — \`whatClientRevealed\` e \`entitiesExtracted\` só listam o que efetivamente apareceu.
+- **Confiança baixa (<0.6)** se transcript curto/ambíguo; alta (>0.8) se evidência clara.`;
+```
+
+A função `buildUserMessage` permanece igual.
+
+- [ ] **Step 4: Rodar testes**
+
+Run: `bun run vitest run src/lib/spin/spin-prompts.test.ts`
+Expected: 12 PASS (6 antigos + 6 novos).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/spin/spin-prompts.ts src/lib/spin/spin-prompts.test.ts
+git commit -m "feat(copilot): SYSTEM_PROMPT_SPIN evolves to adaptive copilot (SPIN+Challenger+JOLT)"
+```
+
+---
+
+## Task 3: Sincronizar prompt + expandir tool schema na Edge Function
+
+**Files:** Modify `supabase/functions/claude-spin-analyze/index.ts`
+
+> **NOTA**: edge function tem o prompt INLINE (não importa de `src/lib/spin/spin-prompts.ts` porque é Deno). Manter os dois sincronizados é decisão consciente do PR3.
+
+- [ ] **Step 1: Substituir o SYSTEM_PROMPT_SPIN inline pelo novo prompt**
+
+Copiar o **mesmo texto exato** da Task 2 (a string `SYSTEM_PROMPT_SPIN = \`...\``). Manter a constante com o mesmo nome `SYSTEM_PROMPT_SPIN` (nome interno, não exposto).
+
+- [ ] **Step 2: Expandir `SPIN_ANALYSIS_TOOL.input_schema`**
+
+Adicionar os novos campos no schema. Manter os existentes. O resultado final:
+
+```ts
+const SPIN_ANALYSIS_TOOL = {
+  name: "spin_analysis",
+  description: "Retorna a análise adaptativa estruturada da conversa atual (SPIN/Challenger/JOLT).",
+  input_schema: {
+    type: "object",
+    properties: {
+      spinStage: {
+        type: "string",
+        enum: ["opening", "situation", "problem", "implication", "need_payoff", "closing"],
+      },
+      confidence: { type: "number", minimum: 0, maximum: 1 },
+
+      // NOVO
+      playbook: {
+        type: "string",
+        enum: ["discovery", "teach", "close"],
+        description: "Qual playbook o copilot está acionando agora",
+      },
+
+      whatClientRevealed: {
+        type: "object",
+        properties: {
+          situationFacts: { type: "array", items: { type: "string" } },
+          problemsAdmitted: { type: "array", items: { type: "string" } },
+          implications: { type: "array", items: { type: "string" } },
+          desiredOutcomes: { type: "array", items: { type: "string" } },
+        },
+        required: ["situationFacts", "problemsAdmitted", "implications", "desiredOutcomes"],
+      },
+
+      nextBestAction: {
+        type: "object",
+        properties: {
+          type: { type: "string", enum: ["question", "response", "transition", "close", "listen"] },
+          spinType: {
+            type: ["string", "null"],
+            enum: ["opening", "situation", "problem", "implication", "need_payoff", "closing", null],
+          },
+          exactPhrasing: { type: "string" },
+          whyNow: { type: "string" },
+          // NOVO
+          commercialInsight: {
+            type: ["object", "null"],
+            properties: {
+              dataPoint: { type: "string" },
+              reframe: { type: "string" },
+            },
+            required: ["dataPoint", "reframe"],
+            description: "Preencha SÓ quando playbook=teach. null caso contrário.",
+          },
+          // NOVO
+          decisionPushTactic: {
+            type: ["string", "null"],
+            enum: ["recommendation", "risk_reversal", "simplification", null],
+            description: "Preencha SÓ quando playbook=close. null caso contrário.",
+          },
+        },
+        required: ["type", "spinType", "exactPhrasing", "whyNow"],
+      },
+
+      // NOVO
+      ticketLeverage: {
+        type: "object",
+        properties: {
+          tactic: { type: "string", enum: ["anchor_premium", "bundle", "reframe_cost", "none"] },
+          suggestion: { type: "string", description: "vazio quando tactic=none" },
+        },
+        required: ["tactic", "suggestion"],
+      },
+
+      risks: {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            type: {
+              type: "string",
+              enum: ["price_objection", "competitor_mentioned", "lack_of_urgency", "wrong_decision_maker", "technical_doubt", "other"],
+            },
+            severity: { type: "string", enum: ["low", "medium", "high"] },
+            note: { type: "string" },
+          },
+          required: ["type", "severity", "note"],
+        },
+      },
+
+      crossSellTriggers: {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            productHint: { type: "string" },
+            triggerPhrase: { type: "string" },
+          },
+          required: ["productHint", "triggerPhrase"],
+        },
+      },
+
+      // NOVO
+      entitiesExtracted: {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            type: {
+              type: "string",
+              enum: ["competitor", "price", "volume", "product", "timeline", "decision_maker"],
+            },
+            value: { type: "string" },
+            context: { type: "string" },
+            confidence: { type: "number", minimum: 0, maximum: 1 },
+          },
+          required: ["type", "value", "context", "confidence"],
+        },
+      },
+    },
+    required: [
+      "spinStage",
+      "confidence",
+      "playbook",
+      "whatClientRevealed",
+      "nextBestAction",
+      "ticketLeverage",
+      "risks",
+      "crossSellTriggers",
+      "entitiesExtracted",
+    ],
+  },
+};
+```
+
+- [ ] **Step 3: Verificar Deno deploy (syntax check local)**
+
+Não há test runner Deno no projeto. Verificar com tsc do projeto (parcialmente cobre o arquivo, não a runtime Deno):
+
+```bash
+bun run tsc --noEmit 2>&1 | grep "claude-spin-analyze" | head -5
+```
+
+Expected: zero erros (arquivo Deno não é tipado pelo tsconfig do projeto, então fica silencioso — esperado).
+
+Verificar manualmente que o arquivo é JSON-válido lendo a estrutura.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add supabase/functions/claude-spin-analyze/index.ts
+git commit -m "feat(copilot): edge function sync prompt + expand tool schema (playbook, leverage, entities)"
+```
+
+---
+
+## Task 4: Evoluir UI do `SpinSuggestionCard`
+
+**Files:** Modify `src/components/call/SpinSuggestionCard.tsx`
+
+- [ ] **Step 1: Adicionar imports + maps de tradução**
+
+No topo do arquivo, adicionar:
+
+```ts
+import { Loader2, AlertCircle, Lightbulb, AlertTriangle, ShoppingCart, Search, GraduationCap, Target, TrendingUp } from 'lucide-react';
+import type { SpinAnalysis, SpinAnalysisStatus, SpinStage, CopilotPlaybook, TicketLeverage, DecisionPushTactic } from '@/lib/spin/types';
+
+const PLAYBOOK_LABEL: Record<CopilotPlaybook, string> = {
+  discovery: 'Descoberta',
+  teach: 'Ensine',
+  close: 'Feche',
+};
+
+const PLAYBOOK_ICON: Record<CopilotPlaybook, typeof Search> = {
+  discovery: Search,
+  teach: GraduationCap,
+  close: Target,
+};
+
+const PLAYBOOK_COLOR: Record<CopilotPlaybook, string> = {
+  discovery: 'bg-blue-100 text-blue-700 border-blue-200 dark:bg-blue-950/40 dark:text-blue-300',
+  teach: 'bg-amber-100 text-amber-700 border-amber-200 dark:bg-amber-950/40 dark:text-amber-300',
+  close: 'bg-emerald-100 text-emerald-700 border-emerald-200 dark:bg-emerald-950/40 dark:text-emerald-300',
+};
+
+const LEVERAGE_LABEL: Record<TicketLeverage, string> = {
+  anchor_premium: 'Apresente o premium primeiro',
+  bundle: 'Sugira o sistema completo',
+  reframe_cost: 'Vire pra custo por m²',
+  none: '',
+};
+
+const TACTIC_LABEL: Record<DecisionPushTactic, string> = {
+  recommendation: 'Recomende com convicção',
+  risk_reversal: 'Tire o risco da mesa',
+  simplification: 'Simplifique a decisão',
+};
+```
+
+- [ ] **Step 2: Atualizar o bloco de render quando `analysis` existe**
+
+Substituir o bloco `if (!analysis) return null; ... return (...)` por (mantém os 3 estados anteriores `idle`/`analyzing`/`error`):
+
+```tsx
+if (!analysis) return null;
+
+const { spinStage, confidence, playbook, nextBestAction, ticketLeverage, risks, crossSellTriggers } = analysis;
+const stageColor = STAGE_COLOR[spinStage];
+const stageLabel = STAGE_LABEL[spinStage];
+const playbookColor = PLAYBOOK_COLOR[playbook];
+const playbookLabel = PLAYBOOK_LABEL[playbook];
+const PlaybookIcon = PLAYBOOK_ICON[playbook];
+
+return (
+  <div className="border-t border-border bg-card p-3 space-y-3">
+    {/* Header: playbook + stage + confidence */}
+    <div className="flex items-center justify-between gap-2">
+      <div className="flex items-center gap-2 flex-wrap">
+        <Badge variant="outline" className={cn('text-2xs gap-1', playbookColor)}>
+          <PlaybookIcon className="w-3 h-3" />
+          {playbookLabel}
+        </Badge>
+        <Badge variant="outline" className={cn('text-2xs', stageColor)}>
+          {stageLabel}
+        </Badge>
+      </div>
+      <span className="text-2xs text-muted-foreground tabular-nums">
+        {Math.round(confidence * 100)}% conf.
+      </span>
+    </div>
+
+    {/* Próxima ação — destaque visual */}
+    <div className="space-y-1">
+      <div className="text-2xs uppercase tracking-wide text-muted-foreground flex items-center gap-1">
+        <Lightbulb className="w-3 h-3 text-status-warning" />
+        Próxima fala sugerida:
+      </div>
+      <blockquote className="text-sm font-medium text-foreground border-l-2 border-status-success pl-3 italic">
+        "{nextBestAction.exactPhrasing}"
+      </blockquote>
+      <div className="text-2xs text-muted-foreground">
+        <span className="font-medium">Por quê:</span> {nextBestAction.whyNow}
+      </div>
+    </div>
+
+    {/* TEACH: commercial insight (só quando playbook=teach + tem dataPoint) */}
+    {playbook === 'teach' && nextBestAction.commercialInsight && (
+      <div className="rounded-md border border-amber-200 dark:border-amber-900/50 bg-amber-50/50 dark:bg-amber-950/20 p-2.5 space-y-1.5">
+        <div className="text-2xs uppercase tracking-wide text-amber-700 dark:text-amber-300 flex items-center gap-1">
+          <GraduationCap className="w-3 h-3" />
+          Insight pra ensinar
+        </div>
+        <div className="text-xs text-foreground">{nextBestAction.commercialInsight.dataPoint}</div>
+        <div className="text-2xs text-muted-foreground">
+          <span className="font-medium">Reframe:</span> {nextBestAction.commercialInsight.reframe}
+        </div>
+      </div>
+    )}
+
+    {/* CLOSE: decisionPushTactic (só quando playbook=close + tem tactic) */}
+    {playbook === 'close' && nextBestAction.decisionPushTactic && (
+      <div className="flex items-center gap-1.5">
+        <Target className="w-3 h-3 text-emerald-600 dark:text-emerald-400" />
+        <span className="text-2xs font-medium text-emerald-700 dark:text-emerald-300">
+          Tática JOLT: {TACTIC_LABEL[nextBestAction.decisionPushTactic]}
+        </span>
+      </div>
+    )}
+
+    {/* TICKET LEVERAGE: sempre, exceto quando tactic=none */}
+    {ticketLeverage.tactic !== 'none' && (
+      <div className="rounded-md border border-orange-200 dark:border-orange-900/50 bg-orange-50/50 dark:bg-orange-950/20 p-2.5 space-y-1">
+        <div className="text-2xs uppercase tracking-wide text-orange-700 dark:text-orange-300 flex items-center gap-1">
+          <TrendingUp className="w-3 h-3" />
+          Subir ticket — {LEVERAGE_LABEL[ticketLeverage.tactic]}
+        </div>
+        <div className="text-2xs text-foreground">{ticketLeverage.suggestion}</div>
+      </div>
+    )}
+
+    {/* Riscos (mantém igual) */}
+    {risks.length > 0 && (
+      <div className="flex flex-wrap gap-1.5">
+        {risks.map((risk, idx) => (
+          <Badge
+            key={idx}
+            variant="outline"
+            className={cn(
+              'text-2xs gap-1',
+              risk.severity === 'high' && 'border-status-error text-status-error',
+              risk.severity === 'medium' && 'border-status-warning text-status-warning',
+            )}
+            title={risk.note}
+          >
+            <AlertTriangle className="w-2.5 h-2.5" />
+            {risk.type.replace(/_/g, ' ')}
+          </Badge>
+        ))}
+      </div>
+    )}
+
+    {/* Cross-sell hints (mantém igual) */}
+    {crossSellTriggers.length > 0 && (
+      <div className="flex flex-wrap gap-1.5 pt-2 border-t border-border/50">
+        <div className="text-2xs text-muted-foreground flex items-center gap-1">
+          <ShoppingCart className="w-3 h-3" />
+          Oportunidade cross-sell:
+        </div>
+        {crossSellTriggers.map((t, idx) => (
+          <Badge key={idx} variant="outline" className="text-2xs">
+            {t.productHint}
+          </Badge>
+        ))}
+      </div>
+    )}
+  </div>
+);
+```
+
+- [ ] **Step 3: Verificar tsc + build**
+
+Run: `bun run tsc --noEmit`
+Expected: clean.
+
+Run: `bun run vitest run`
+Expected: still 181 passing (testes existentes não quebram; novos testes do prompt já adicionados na Task 2).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/call/SpinSuggestionCard.tsx
+git commit -m "feat(copilot): UI evolves with playbook badge, commercial insight, JOLT tactic, ticket leverage"
+```
+
+---
+
+## Task 5: QA final + abrir PR
+
+- [ ] **Step 1: Suite completa**
+
+Run: `bun run vitest run`
+Expected: 187 tests passing (181 + 6 novos do prompt expandido).
+
+- [ ] **Step 2: Lint dos arquivos tocados**
+
+```bash
+bun lint 2>&1 | grep -E "(spin|copilot|SpinSuggestion|claude-spin)" | head -10
+```
+
+Expected: zero erros.
+
+- [ ] **Step 3: Build production**
+
+Run: `bun build`
+Expected: passa. Bundle do feature-farmer pode crescer ~5KB (textos novos no card) — aceitável.
+
+```bash
+grep -l "playbook\|ticketLeverage\|entitiesExtracted" dist/assets/*.js | head -3
+```
+
+Expected: alguns matches no feature-farmer (UI consome esses tipos). Zero matches contendo Anthropic SDK ou system prompt (esses só na edge).
+
+- [ ] **Step 4: TypeScript**
+
+Run: `bun run tsc --noEmit`
+Expected: clean.
+
+- [ ] **Step 5: Push + PR**
+
+```bash
+git push -u origin claude/pr3.5-copilot-adaptativo
+gh pr create --base main --head claude/pr3.5-copilot-adaptativo \
+  --title "feat: Copilot Adaptativo — SPIN + Challenger + JOLT (PR3.5)" \
+  --body "$(cat <<'EOF'
+## Summary
+
+PR3.5 — Evolução do copilot SPIN puro (PR3) pra **copilot adaptativo** que escolhe entre 3 playbooks baseado no estado da conversa:
+
+| Modo | Quando aciona | Framework |
+|---|---|---|
+| 🔍 **Discovery** | Início, contexto raso, < 3 fatos relevantes | SPIN (Rackham) |
+| 💡 **Teach** | Discovery mapeou + cliente em piloto automático ou concorrente mencionado | Challenger (Dixon) |
+| 🎯 **Close** | Palavras-âncora de indecisão OU cliente admitiu problema+implicação+desejo | JOLT (Dixon, 2022) |
+
+Além disso:
+- **Ticket leverage** em qualquer modo: `anchor_premium` (mostra premium antes), `bundle` (sistema completo), `reframe_cost` (R$/m² em vez de R$/L).
+- **`entitiesExtracted`**: copilot extrai concorrentes, preços, volumes, produtos, prazos e decisores citados pelo cliente — pronto pra alimentar perfil 360 em PR4+.
+
+## Por que não SPIN puro
+
+SPIN funciona pra mapear, mas vira chato em chamada #2 com mesmo cliente (já mapeou tudo) e não tem ferramenta pra reverter indecisão — empiricamente a causa #1 de venda perdida em B2B (estudo JOLT, 2.5M chamadas analisadas).
+
+Challenger eleva qualidade (vendedor vira professor, não interrogador). JOLT fecha indecisão. Adaptativo combina os três no momento certo da conversa.
+
+## Mudanças
+
+- `src/lib/spin/types.ts`: `SpinAnalysis` ganha `playbook`, `ticketLeverage`, `entitiesExtracted`, e `nextBestAction` opcional `commercialInsight` + `decisionPushTactic`.
+- `src/lib/spin/spin-prompts.ts`: `SYSTEM_PROMPT_SPIN` expandido com Challenger + JOLT + regras de seleção de playbook + lista de palavras-âncora de indecisão em PT-BR + lista vazia de concorrentes (vendedor expande, sem hardcode além dos regionais do briefing).
+- `supabase/functions/claude-spin-analyze/index.ts`: prompt sincronizado, schema da tool expandido.
+- `src/components/call/SpinSuggestionCard.tsx`: badge de playbook colorido, bloco amber pra `commercialInsight` (Teach), badge verde pra `decisionPushTactic` (Close), badge laranja pra ticket leverage.
+
+## Testes
+
+- 181 → 187 (6 testes novos no `spin-prompts.test.ts` cobrindo Challenger, JOLT, regras de seleção, ticket leverage, entidades, palavras-âncora)
+- `tsc --noEmit`: clean
+- `bun build`: passa, sem vazamento de SDK Anthropic pro client
+
+## Não-objetivos
+
+- Persistência de `entitiesExtracted` → PR4 (call_sessions)
+- UI pra vendedor editar entidades extraídas → PR8 (battle cards)
+- RAG dos boletins técnicos → PR6 (knowledge base)
+
+## Test plan
+
+- [ ] Smoke test em chamada real após `ANTHROPIC_API_KEY` configurada:
+  - [ ] Discovery: copilot abre em Discovery + pergunta de Situation
+  - [ ] Teach: depois do cliente revelar problema, copilot pivota pra Teach + traz insight comercial
+  - [ ] Close: vendedor diz "vou pensar" (simulando cliente) → copilot pivota pra Close + sugere recommendation/risk_reversal/simplification
+  - [ ] Ticket leverage: cliente cita produto entry-level → copilot sugere anchor_premium
+  - [ ] Entities: cliente menciona "Farben R$ 35/L" → copilot extrai competitor + price
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+
+| Spec | Task |
+|---|---|
+| Híbrido SPIN+Challenger+JOLT com seleção de playbook | Tasks 1+2+3 |
+| Ticket leverage (anchor/bundle/reframe) | Tasks 1+2+3+4 |
+| Auto-extração de entidades (concorrentes, preços, etc) | Tasks 1+2+3 |
+| Sem hardcode de concorrentes (lista regional só como guia, vendedor expande) | Task 2 (system prompt) |
+| UI mostra qual playbook está ativo | Task 4 |
+| Backward compatible com PR3 (não quebra nada) | Schema é aditivo, hook e context inalterados |
+
+**2. Placeholder scan:** sem TBD. Todo código está completo.
+
+**3. Type consistency:**
+
+- `SpinAnalysis` campos novos são todos opcionais ou populados sempre (`playbook`, `ticketLeverage`, `entitiesExtracted` sempre presentes; `commercialInsight`/`decisionPushTactic` opcionais condicionalmente)
+- Edge function tool schema mantém `required: [...]` com os 9 campos top-level
+- UI consome `playbook`, `ticketLeverage`, `commercialInsight?`, `decisionPushTactic?` — todos definidos no types
+
+**4. Riscos:**
+
+- **Custo Anthropic sobe** ~10-15% (output tokens crescem com `entitiesExtracted` + `commercialInsight`). Aceitável; ainda <$0.02 por análise. PR16 (triggers inteligentes) vai reduzir frequência depois.
+- **Qualidade de `commercialInsight`** — Claude pode inventar dados. Mitigação no prompt: "use estimativas conservadoras + frases tipo 'tipicamente'". Iterar pós-smoke test.
+- **`entitiesExtracted` ainda não persiste** — vivem só na análise atual, somem na próxima. PR4 resolve.
+- **Edge function tem prompt duplicado** (inline em Deno + arquivo TS) — manter sincronizado é manual. Aceito; PR posterior pode mover pra arquivo `.txt` shared.
+
+---
+
+## Execution Handoff
+
+Plan salvo em `docs/superpowers/plans/2026-05-17-pr3.5-copilot-adaptativo.md`.
+
+Execução: **Subagent-Driven** (igual PRs anteriores). Tasks 1-4 cada uma vai pra subagent fresh; Task 5 fica no main agent pra abrir o PR.

--- a/src/components/call/SpinSuggestionCard.tsx
+++ b/src/components/call/SpinSuggestionCard.tsx
@@ -1,7 +1,24 @@
-import { Loader2, AlertCircle, Lightbulb, AlertTriangle, ShoppingCart } from 'lucide-react';
+import {
+  Loader2,
+  AlertCircle,
+  Lightbulb,
+  AlertTriangle,
+  ShoppingCart,
+  Search,
+  GraduationCap,
+  Target,
+  TrendingUp,
+} from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Badge } from '@/components/ui/badge';
-import type { SpinAnalysis, SpinAnalysisStatus, SpinStage } from '@/lib/spin/types';
+import type {
+  SpinAnalysis,
+  SpinAnalysisStatus,
+  SpinStage,
+  CopilotPlaybook,
+  TicketLeverage,
+  DecisionPushTactic,
+} from '@/lib/spin/types';
 
 interface SpinSuggestionCardProps {
   status: SpinAnalysisStatus;
@@ -27,16 +44,52 @@ const STAGE_COLOR: Record<SpinStage, string> = {
   closing: 'bg-purple-100 text-purple-700 border-purple-200 dark:bg-purple-950/40 dark:text-purple-300',
 };
 
+const PLAYBOOK_LABEL: Record<CopilotPlaybook, string> = {
+  discovery: 'Descoberta',
+  teach: 'Ensine',
+  close: 'Feche',
+};
+
+const PLAYBOOK_ICON: Record<CopilotPlaybook, typeof Search> = {
+  discovery: Search,
+  teach: GraduationCap,
+  close: Target,
+};
+
+const PLAYBOOK_COLOR: Record<CopilotPlaybook, string> = {
+  discovery: 'bg-blue-100 text-blue-700 border-blue-200 dark:bg-blue-950/40 dark:text-blue-300',
+  teach: 'bg-amber-100 text-amber-700 border-amber-200 dark:bg-amber-950/40 dark:text-amber-300',
+  close: 'bg-emerald-100 text-emerald-700 border-emerald-200 dark:bg-emerald-950/40 dark:text-emerald-300',
+};
+
+const LEVERAGE_LABEL: Record<TicketLeverage, string> = {
+  anchor_premium: 'Apresente o premium primeiro',
+  bundle: 'Sugira o sistema completo',
+  reframe_cost: 'Vire pra custo por m²',
+  none: '',
+};
+
+const TACTIC_LABEL: Record<DecisionPushTactic, string> = {
+  recommendation: 'Recomende com convicção',
+  risk_reversal: 'Tire o risco da mesa',
+  simplification: 'Simplifique a decisão',
+};
+
 /**
- * Card sticky no rodapé do TranscriptionPanel mostrando a sugestão SPIN atual.
+ * Card sticky no rodapé do TranscriptionPanel mostrando a sugestão do copilot adaptativo.
  * Vendedor LÊ literalmente o `exactPhrasing` da próxima ação.
+ *
+ * Renderiza por playbook (discovery/teach/close) com elementos extras:
+ * - teach → bloco amber com commercialInsight (dataPoint + reframe)
+ * - close → badge verde com decisionPushTactic JOLT
+ * - qualquer → bloco laranja de ticketLeverage quando tactic !== 'none'
  */
 export function SpinSuggestionCard({ status, analysis, error }: SpinSuggestionCardProps) {
   if (status === 'idle') {
     return (
       <div className="border-t border-border p-3 bg-muted/30">
         <div className="text-2xs text-muted-foreground text-center">
-          Copilot SPIN aguardando a primeira fala do cliente…
+          Copilot aguardando a primeira fala do cliente…
         </div>
       </div>
     );
@@ -59,7 +112,7 @@ export function SpinSuggestionCard({ status, analysis, error }: SpinSuggestionCa
         <div className="flex items-start gap-2 text-xs">
           <AlertCircle className="w-3.5 h-3.5 text-status-error shrink-0 mt-0.5" />
           <div>
-            <div className="font-medium text-status-error">Erro no copilot SPIN</div>
+            <div className="font-medium text-status-error">Erro no copilot</div>
             {error && <div className="text-muted-foreground mt-0.5 font-mono text-[10px]">{error}</div>}
           </div>
         </div>
@@ -69,19 +122,22 @@ export function SpinSuggestionCard({ status, analysis, error }: SpinSuggestionCa
 
   if (!analysis) return null;
 
-  const { spinStage, confidence, nextBestAction, risks, crossSellTriggers } = analysis;
+  const { spinStage, confidence, playbook, nextBestAction, ticketLeverage, risks, crossSellTriggers } = analysis;
   const stageColor = STAGE_COLOR[spinStage];
   const stageLabel = STAGE_LABEL[spinStage];
+  const playbookColor = PLAYBOOK_COLOR[playbook];
+  const playbookLabel = PLAYBOOK_LABEL[playbook];
+  const PlaybookIcon = PLAYBOOK_ICON[playbook];
 
   return (
     <div className="border-t border-border bg-card p-3 space-y-3">
-      {/* Header: stage + confidence */}
+      {/* Header: playbook + stage + confidence */}
       <div className="flex items-center justify-between gap-2">
-        <div className="flex items-center gap-2">
-          <Lightbulb className="w-4 h-4 text-status-warning" />
-          <span className="text-2xs font-medium uppercase tracking-wide text-muted-foreground">
-            Sugestão Copilot
-          </span>
+        <div className="flex items-center gap-2 flex-wrap">
+          <Badge variant="outline" className={cn('text-2xs gap-1', playbookColor)}>
+            <PlaybookIcon className="w-3 h-3" />
+            {playbookLabel}
+          </Badge>
           <Badge variant="outline" className={cn('text-2xs', stageColor)}>
             {stageLabel}
           </Badge>
@@ -93,8 +149,9 @@ export function SpinSuggestionCard({ status, analysis, error }: SpinSuggestionCa
 
       {/* Próxima ação — destaque visual */}
       <div className="space-y-1">
-        <div className="text-2xs uppercase tracking-wide text-muted-foreground">
-          Próxima pergunta sugerida:
+        <div className="text-2xs uppercase tracking-wide text-muted-foreground flex items-center gap-1">
+          <Lightbulb className="w-3 h-3 text-status-warning" />
+          Próxima fala sugerida:
         </div>
         <blockquote className="text-sm font-medium text-foreground border-l-2 border-status-success pl-3 italic">
           "{nextBestAction.exactPhrasing}"
@@ -104,7 +161,42 @@ export function SpinSuggestionCard({ status, analysis, error }: SpinSuggestionCa
         </div>
       </div>
 
-      {/* Riscos (se houver) */}
+      {/* TEACH: commercial insight (só quando playbook=teach + tem dataPoint) */}
+      {playbook === 'teach' && nextBestAction.commercialInsight && (
+        <div className="rounded-md border border-amber-200 dark:border-amber-900/50 bg-amber-50/50 dark:bg-amber-950/20 p-2.5 space-y-1.5">
+          <div className="text-2xs uppercase tracking-wide text-amber-700 dark:text-amber-300 flex items-center gap-1">
+            <GraduationCap className="w-3 h-3" />
+            Insight pra ensinar
+          </div>
+          <div className="text-xs text-foreground">{nextBestAction.commercialInsight.dataPoint}</div>
+          <div className="text-2xs text-muted-foreground">
+            <span className="font-medium">Reframe:</span> {nextBestAction.commercialInsight.reframe}
+          </div>
+        </div>
+      )}
+
+      {/* CLOSE: decisionPushTactic (só quando playbook=close + tem tactic) */}
+      {playbook === 'close' && nextBestAction.decisionPushTactic && (
+        <div className="flex items-center gap-1.5">
+          <Target className="w-3 h-3 text-emerald-600 dark:text-emerald-400" />
+          <span className="text-2xs font-medium text-emerald-700 dark:text-emerald-300">
+            Tática JOLT: {TACTIC_LABEL[nextBestAction.decisionPushTactic]}
+          </span>
+        </div>
+      )}
+
+      {/* TICKET LEVERAGE: sempre, exceto quando tactic=none */}
+      {ticketLeverage.tactic !== 'none' && (
+        <div className="rounded-md border border-orange-200 dark:border-orange-900/50 bg-orange-50/50 dark:bg-orange-950/20 p-2.5 space-y-1">
+          <div className="text-2xs uppercase tracking-wide text-orange-700 dark:text-orange-300 flex items-center gap-1">
+            <TrendingUp className="w-3 h-3" />
+            Subir ticket — {LEVERAGE_LABEL[ticketLeverage.tactic]}
+          </div>
+          <div className="text-2xs text-foreground">{ticketLeverage.suggestion}</div>
+        </div>
+      )}
+
+      {/* Riscos */}
       {risks.length > 0 && (
         <div className="flex flex-wrap gap-1.5">
           {risks.map((risk, idx) => (
@@ -125,7 +217,7 @@ export function SpinSuggestionCard({ status, analysis, error }: SpinSuggestionCa
         </div>
       )}
 
-      {/* Cross-sell hints (PR4 vai consumir) */}
+      {/* Cross-sell hints (PR9 vai consumir KB pra resolver pra SKU real) */}
       {crossSellTriggers.length > 0 && (
         <div className="flex flex-wrap gap-1.5 pt-2 border-t border-border/50">
           <div className="text-2xs text-muted-foreground flex items-center gap-1">

--- a/src/lib/spin/spin-prompts.test.ts
+++ b/src/lib/spin/spin-prompts.test.ts
@@ -21,6 +21,47 @@ describe('SYSTEM_PROMPT_SPIN', () => {
   });
 });
 
+describe('SYSTEM_PROMPT_SPIN — Challenger + JOLT extensions', () => {
+  it('explica framework Challenger (Teach/Tailor/Take Control)', () => {
+    expect(SYSTEM_PROMPT_SPIN.toLowerCase()).toContain('challenger');
+    expect(SYSTEM_PROMPT_SPIN.toLowerCase()).toMatch(/teach|ensinar/);
+    expect(SYSTEM_PROMPT_SPIN.toLowerCase()).toMatch(/tailor|customizar/);
+    expect(SYSTEM_PROMPT_SPIN.toLowerCase()).toMatch(/take control|assumir/);
+  });
+
+  it('explica framework JOLT pra indecisão', () => {
+    expect(SYSTEM_PROMPT_SPIN.toLowerCase()).toContain('jolt');
+    expect(SYSTEM_PROMPT_SPIN.toLowerCase()).toMatch(/indecis[ãa]o|inde?cisivo/);
+  });
+
+  it('define regras de seleção entre os 3 playbooks (discovery/teach/close)', () => {
+    expect(SYSTEM_PROMPT_SPIN.toLowerCase()).toContain('discovery');
+    expect(SYSTEM_PROMPT_SPIN.toLowerCase()).toContain('teach');
+    expect(SYSTEM_PROMPT_SPIN.toLowerCase()).toContain('close');
+    // Deve ter alguma regra explícita de quando trocar
+    expect(SYSTEM_PROMPT_SPIN.toLowerCase()).toMatch(/quando|se o cliente|pivota/);
+  });
+
+  it('explica as 3 táticas de ticket leverage', () => {
+    expect(SYSTEM_PROMPT_SPIN.toLowerCase()).toContain('anchor');
+    expect(SYSTEM_PROMPT_SPIN.toLowerCase()).toContain('bundle');
+    expect(SYSTEM_PROMPT_SPIN.toLowerCase()).toMatch(/reframe|recontextu/);
+  });
+
+  it('instrui extração de entidades (concorrente/preço/volume/produto)', () => {
+    expect(SYSTEM_PROMPT_SPIN.toLowerCase()).toContain('entitiesextracted');
+    expect(SYSTEM_PROMPT_SPIN.toLowerCase()).toMatch(/concorrente|competitor/);
+    expect(SYSTEM_PROMPT_SPIN.toLowerCase()).toContain('preço');
+  });
+
+  it('lista palavras-âncora de indecisão em PT-BR', () => {
+    // Pelo menos 3 das clássicas devem estar listadas
+    const indecisionWords = ['vou pensar', 'preciso ver', 'tô vendo', 'me dá um tempo', 'depois eu te falo'];
+    const matches = indecisionWords.filter(w => SYSTEM_PROMPT_SPIN.toLowerCase().includes(w));
+    expect(matches.length).toBeGreaterThanOrEqual(3);
+  });
+});
+
 describe('buildUserMessage', () => {
   it('formata turnos com [VENDEDOR]/[CLIENTE] e timestamps relativos', () => {
     const turns: TranscriptTurnLite[] = [

--- a/src/lib/spin/spin-prompts.ts
+++ b/src/lib/spin/spin-prompts.ts
@@ -1,61 +1,122 @@
 import type { TranscriptTurnLite } from './types';
 
 /**
- * System prompt cacheado pela Anthropic prompt caching API.
- * Mudanças aqui INVALIDAM o cache — só editar quando realmente necessário.
+ * System prompt cacheado pra copilot adaptativo SPIN+Challenger+JOLT.
+ * Mudanças aqui INVALIDAM o cache da Anthropic prompt caching API — só editar
+ * quando realmente necessário.
  *
- * Estrutura: persona (curto) → framework SPIN explicado (denso) → contexto
- * Colacor/Sayerlack (específico) → regras de saída (estritas).
+ * Estrutura: persona (curto) → 3 playbooks (Discovery/Teach/Close, denso) →
+ * regras de seleção de playbook → ticket leverage → extração de entidades →
+ * contexto Colacor/Sayerlack → regras de saída (estritas).
  */
-export const SYSTEM_PROMPT_SPIN = `Você é um copiloto de vendas SPIN ao vivo para vendedores da Colacor — distribuidora de tintas industriais Sayerlack para o segmento moveleiro brasileiro.
+export const SYSTEM_PROMPT_SPIN = `Você é um copiloto de vendas ao vivo para vendedores da Colacor — distribuidora de tintas industriais Sayerlack para o segmento moveleiro brasileiro.
 
-Sua missão: durante uma chamada telefônica entre vendedor e cliente, analisar o transcript em tempo real e sugerir EXATAMENTE qual a próxima pergunta SPIN ideal pro vendedor fazer, baseado no estágio da conversa.
+Sua missão: durante uma chamada telefônica entre vendedor e cliente, analisar o transcript em tempo real e sugerir EXATAMENTE qual a próxima fala ideal pro vendedor, escolhendo o playbook certo pro momento da conversa.
 
-## Framework SPIN (Neil Rackham)
+# Os 3 playbooks que você escolhe
 
-Toda venda consultiva passa por 4 tipos de pergunta, nesta ordem ideal:
+A cada análise, você decide qual playbook acionar:
 
-1. **Situation** — perguntas factuais que mapeiam o contexto do cliente.
-   Ex: "Qual o volume mensal de tinta que vocês usam hoje?", "Quantos operadores na cabine?"
-   Use no INÍCIO da chamada. Não abuse — clientes se cansam de perguntas factuais.
+## 🔍 DISCOVERY (SPIN — Neil Rackham)
+**Quando usar:** início da chamada, contexto ainda raso, cliente revelou < 3 fatos relevantes, ou você ainda não identificou problema/dor.
 
-2. **Problem** — perguntas que revelam dificuldades, insatisfações, gaps.
-   Ex: "Vocês têm tido problema de acabamento no PU?", "A entrega da concorrência costuma atrasar?"
-   Use quando você já mapeou a situação e quer expor dores.
+**As 4 perguntas SPIN, na ordem ideal:**
+1. **Situation** — factual, mapeia contexto. "Quantos litros de tinta vocês consomem por mês?" Use POUCO no início — clientes cansam de perguntas factuais.
+2. **Problem** — revela dor. "Vocês têm tido retrabalho no PU?" Use depois da Situation.
+3. **Implication** — amplifica impacto da dor. "Esses retrabalhos têm gerado hora extra na sua linha?" USE MUITO — constrói urgência.
+4. **Need-payoff** — faz cliente articular valor. "Se você zerasse esse retrabalho, o que destravaria pro mês?" Use antes de fechar.
 
-3. **Implication** — perguntas que amplificam o impacto dos problemas que o cliente admitiu.
-   Ex: "Esses atrasos têm gerado retrabalho na sua linha?", "Quanto isso custa por mês em horas perdidas?"
-   USE MUITO. É o estágio que constrói a urgência. SPIN ganha aqui.
+## 💡 TEACH (Challenger Sale — Matt Dixon)
+**Quando usar:** discovery já mapeou situação E problema; cliente está em piloto automático ("sempre comprei assim"); concorrente foi mencionado; cliente subestima impacto de problema admitido. Hora de PROVOCAR uma nova forma de pensar.
 
-4. **Need-payoff** — perguntas que fazem o cliente articular o VALOR de resolver o problema.
-   Ex: "Se a entrega fosse 100% no prazo, o que isso destravaria pra produção de vocês?"
-   Use quando o cliente já admitiu problemas + implicações. Prepara o close.
+**Os 3 pilares Challenger:**
+- **Teach** — ensine algo NOVO sobre o próprio negócio do cliente. Dado, comparativo, custo escondido que ele não mede. Não é venda, é insight.
+- **Tailor** — adapte/customize a mensagem ao papel/contexto do interlocutor. Falando com dono: ROI, capacidade. Falando com aplicador: facilidade técnica.
+- **Take Control** — assuma a conversa sobre preço, timing, processo de decisão sem medo. Não recue.
 
-## Contexto Sayerlack/Colacor
+**Quando playbook=teach, preencha \`commercialInsight\`:**
+- \`dataPoint\` — um fato/número/comparação que o cliente provavelmente desconhece (ex: "marcenarias do porte de vocês perdem em média 8h/mês em retrabalho de PU mal aplicado, segundo levantamento setorial")
+- \`reframe\` — como esse fato muda a forma do cliente pensar o problema (ex: "isso significa que economia de R$5/L vira prejuízo escondido de R$640/mês — mais que o delta de preço pro PU 2K")
 
-- Produto: tintas PU automotivas + linhas Hydropoxi (água), Wood (madeira), Auto (auto).
-- Cliente típico: indústria moveleira, marcenaria de médio porte, oficina automotiva.
-- Concorrentes: Renner, Pantone, Brasilac, importados.
-- Diferenciais Colacor: distribuição rápida, suporte técnico, fórmulas customizadas.
-- Atritos comuns: prazo de entrega, validade de lote, qualidade de acabamento, preço vs importado.
+NÃO invente dados — use estimativas conservadoras + frases tipo "tipicamente", "marcenarias do porte de vocês", "no segmento moveleiro" pra não soar como número exato.
 
-## Sua tarefa
+## 🎯 CLOSE (JOLT — Matt Dixon, 2022)
+**Quando usar:** sinais de indecisão do cliente OU cliente já admitiu problema + implicação + desejo (pronto pro fechamento). O framework JOLT existe pra reverter indecisão — causa #1 de venda perdida em B2B.
 
-A cada chamada da minha tool \`spin_analysis\`, você recebe o transcript bidirecional (vendedor + cliente) acumulado até agora. Você deve:
+**Palavras-âncora de indecisão em PT-BR (detecte essas):**
+- "vou pensar", "preciso pensar", "deixa eu pensar"
+- "preciso ver com o sócio", "preciso ver", "tenho que falar com meu pai", "vou conversar com a equipe"
+- "tô vendo opções", "tô vendo", "tô comparando", "tô orçando com outros"
+- "me dá um tempo", "depois eu te falo", "depois eu retorno"
+- "interessante, mas...", "gostei, porém..."
+- silêncio prolongado depois de proposta
 
-1. Identificar o **estágio atual** da conversa (opening / situation / problem / implication / need-payoff / closing).
-2. Mapear o que o cliente JÁ REVELOU (fatos, problemas admitidos, implicações, desejos).
-3. Sugerir a **próxima ação ideal** pro vendedor — geralmente uma pergunta SPIN com texto EXATO pra falar em PT-BR natural mineiro/brasileiro neutro.
-4. Sinalizar riscos detectados (objeção de preço, menção a concorrente, falta de urgência, etc).
-5. Identificar hints de cross-sell (cliente mencionou produto adjacente).
+**As 4 táticas JOLT — escolha 1 e preencha \`decisionPushTactic\`:**
+- **\`recommendation\`** — recomende com convicção, NUNCA liste opções. "Pra marcenaria do seu porte, é o sistema PU 2K — feche nisso." Cliente indecisivo prefere não decidir nada quando vê muitas opções.
+- **\`risk_reversal\`** — tire o risco da mesa. "Te dou garantia técnica de 30 dias — se acabamento não melhorar, troca de volta sem custo." Funciona contra medo de errar.
+- **\`simplification\`** — reduza a decisão. "Você não precisa fechar o ano todo agora — testa com 1 lote desse mês." Funciona contra cliente sobrecarregado.
 
-## Regras de saída
+**Regra de ouro JOLT:** NUNCA termine uma análise close sem uma ação específica. Não vale dizer "ouça mais" quando cliente está em indecisão — isso mata o deal.
 
-- **SEMPRE use a tool \`spin_analysis\`** com o JSON estruturado completo.
-- **Texto da sugestão deve ser EXATO** — vendedor vai LER literalmente. PT-BR natural, sem jargão de SPIN ("isso é uma pergunta de Implication" — NUNCA fale isso pro vendedor; fale só pra ferramenta).
-- **Seja específico ao contexto do cliente** — não use perguntas genéricas, use as palavras que o cliente acabou de usar.
-- **Se o cliente ainda não falou nada relevante** (só opening trivial), retorne uma pergunta de Situation pra começar a mapear.
-- **NÃO invente fatos** — só liste em \`whatClientRevealed\` o que efetivamente apareceu no transcript.
+# Regras de seleção entre playbooks
+
+A cada análise, você decide o playbook ANTES de tudo:
+
+\`\`\`
+SE detectou palavra-âncora de indecisão OU se o cliente já admitiu problema+implicação+desejo:
+   → playbook = "close"
+SENÃO SE discovery mapeou situação E problema E (concorrente mencionado OU dor subestimada):
+   → playbook = "teach"
+SENÃO:
+   → playbook = "discovery"
+\`\`\`
+
+Você pode pivotar entre análises — não é "uma vez teach, sempre teach". Cada análise é independente. Quando o estado da conversa muda, pivota o playbook.
+
+# Ticket leverage — alavancas táticas de aumento de ticket
+
+Em QUALQUER playbook, se aparecer oportunidade, preencha \`ticketLeverage\` com 1 de 3 táticas:
+
+- **\`anchor_premium\`** — cliente pediu cotação do produto entry-level, sugira mostrar o premium PRIMEIRO como anchor/âncora. "Antes de cotar nitro, mostre o PU 2K — cliente compara pra baixo, não pra cima. Lift típico: 18-30% no ticket."
+- **\`bundle\`** — cliente mencionou só 1 produto, sugira o sistema completo como bundle. "Cliente pediu verniz — sugira sistema (primer + verniz + catalisador + diluente + lixa). Sayerlack PU exige catalisador FCA.7075 e diluente DFA.4068."
+- **\`reframe_cost\`** — cliente está pensando em R$/litro, faça reframe/recontextualize pra R$/m² ou R$/peça acabada. "Cliente cita R$/L da Farben — copilot vira a conversa pra custo por m² acabado considerando rendimento, onde Sayerlack ganha mesmo sendo mais caro por litro."
+
+Se não há oportunidade clara, use \`tactic: "none"\` e \`suggestion: ""\`.
+
+# Extração de entidades econômicas (entitiesExtracted)
+
+Em CADA análise, popule \`entitiesExtracted\` com tudo que o cliente revelou que vai pro perfil 360 dele:
+
+- **\`competitor\`** — qualquer marca/concorrente/competitor citado ("Farben", "Vernit", "Renner")
+- **\`price\`** — preço citado pelo cliente ou referência de preço de concorrente ("R$ 35/L da Farben")
+- **\`volume\`** — consumo, capacidade ("200L/mês", "500 m² de cabine")
+- **\`product\`** — produto específico do concorrente ("Verniz Prime", "PU 6000")
+- **\`timeline\`** — prazo, urgência, próxima compra ("pedido pro mês que vem", "obra começa em 15 dias")
+- **\`decision_maker\`** — quem decide ("sócio", "pai", "comprador", "gerente")
+
+Para cada entidade:
+- \`type\`: o tipo acima
+- \`value\`: o valor normalizado (ex: "Farben Tintas", não "farben")
+- \`context\`: trecho da fala onde apareceu (use as palavras do cliente)
+- \`confidence\`: 0-1 (alto se cliente afirmou claramente; baixo se foi ambíguo)
+
+NÃO invente entidades. Se cliente não mencionou nada relevante, retorne array vazio \`[]\`.
+
+# Contexto Colacor/Sayerlack
+
+- **Produto**: tintas Sayerlack — linhas Wood (madeira PU/nitro/hidrossolúvel), Hydropoxi (base água), Auto (automotivo).
+- **Cliente típico**: indústria moveleira, marcenaria de médio porte, oficina automotiva.
+- **Concorrentes regionais comuns** (vendedor expande): Farben Tintas, Vernit, Rosalen, Montana, Ivy, Luztol. NÃO liste outros — só comente os que cliente mencionar.
+- **Diferenciais Colacor**: distribuição rápida, suporte técnico, fórmulas customizadas.
+- **Atritos comuns**: prazo de entrega, validade de lote, qualidade de acabamento, preço vs alternativas regionais.
+
+# Regras gerais de saída
+
+- **SEMPRE use a tool \`spin_analysis\`** com o JSON completo (todos os campos obrigatórios preenchidos).
+- **\`exactPhrasing\`** — vendedor vai LER literalmente. PT-BR (português brasileiro) natural, conversacional, sem jargão de framework ("isso é uma pergunta de Implication" — NUNCA diga, é meta-comentário inútil pro vendedor).
+- **Seja específico ao contexto** — não use perguntas genéricas, use as palavras que o cliente acabou de usar.
+- **Se transcript ainda vazio** (só opening), playbook=discovery + sugestão de Situation aberta.
+- **NÃO invente fatos** — \`whatClientRevealed\` e \`entitiesExtracted\` só listam o que efetivamente apareceu.
 - **Confiança baixa (<0.6)** se transcript curto/ambíguo; alta (>0.8) se evidência clara.`;
 
 /**

--- a/src/lib/spin/types.ts
+++ b/src/lib/spin/types.ts
@@ -20,11 +20,30 @@ export type RiskType =
 
 export type RiskSeverity = 'low' | 'medium' | 'high';
 
+/** Qual playbook o copilot está executando agora */
+export type CopilotPlaybook = 'discovery' | 'teach' | 'close';
+
+/** Alavanca tática de aumento de ticket sugerida */
+export type TicketLeverage = 'anchor_premium' | 'bundle' | 'reframe_cost' | 'none';
+
+/** Tática específica quando playbook=close (JOLT) */
+export type DecisionPushTactic = 'recommendation' | 'risk_reversal' | 'simplification';
+
+/** Entidade econômica detectada na transcrição (concorrente, preço, etc) */
+export interface ExtractedEntity {
+  type: 'competitor' | 'price' | 'volume' | 'product' | 'timeline' | 'decision_maker';
+  value: string;
+  context: string;  // trecho original onde apareceu
+  confidence: number;  // 0-1
+}
+
 export interface SpinAnalysis {
   /** Estágio atual da conversa segundo SPIN */
   spinStage: SpinStage;
   /** Confiança da análise (0-1) */
   confidence: number;
+  /** NOVO: qual playbook o copilot escolheu acionar agora */
+  playbook: CopilotPlaybook;
   /** O que o cliente revelou até agora */
   whatClientRevealed: {
     situationFacts: string[];
@@ -41,6 +60,18 @@ export interface SpinAnalysis {
     exactPhrasing: string;
     /** Por que essa ação agora — uma frase curta */
     whyNow: string;
+    /** NOVO: insight comercial pronto pra falar (só preenche quando playbook=teach) */
+    commercialInsight?: {
+      dataPoint: string;
+      reframe: string;
+    };
+    /** NOVO: tática JOLT específica (só preenche quando playbook=close) */
+    decisionPushTactic?: DecisionPushTactic;
+  };
+  /** NOVO: alavanca de ticket sugerida (qualquer playbook, 'none' se sem oportunidade) */
+  ticketLeverage: {
+    tactic: TicketLeverage;
+    suggestion: string;
   };
   /** Riscos detectados na conversa */
   risks: Array<{
@@ -53,6 +84,8 @@ export interface SpinAnalysis {
     productHint: string;
     triggerPhrase: string;
   }>;
+  /** NOVO: entidades econômicas extraídas (PR4+ vai persistir no perfil 360) */
+  entitiesExtracted: ExtractedEntity[];
 }
 
 export type SpinAnalysisStatus = 'idle' | 'analyzing' | 'ready' | 'error';

--- a/supabase/functions/claude-spin-analyze/index.ts
+++ b/supabase/functions/claude-spin-analyze/index.ts
@@ -3,61 +3,120 @@ import { authorizeCronOrStaff, corsHeaders } from "../_shared/auth.ts";
 
 // System prompt INLINE (copiado de src/lib/spin/spin-prompts.ts pra evitar
 // dependência cross-package; manter sincronizado quando atualizar).
-const SYSTEM_PROMPT_SPIN = `Você é um copiloto de vendas SPIN ao vivo para vendedores da Colacor — distribuidora de tintas industriais Sayerlack para o segmento moveleiro brasileiro.
+const SYSTEM_PROMPT_SPIN = `Você é um copiloto de vendas ao vivo para vendedores da Colacor — distribuidora de tintas industriais Sayerlack para o segmento moveleiro brasileiro.
 
-Sua missão: durante uma chamada telefônica entre vendedor e cliente, analisar o transcript em tempo real e sugerir EXATAMENTE qual a próxima pergunta SPIN ideal pro vendedor fazer, baseado no estágio da conversa.
+Sua missão: durante uma chamada telefônica entre vendedor e cliente, analisar o transcript em tempo real e sugerir EXATAMENTE qual a próxima fala ideal pro vendedor, escolhendo o playbook certo pro momento da conversa.
 
-## Framework SPIN (Neil Rackham)
+# Os 3 playbooks que você escolhe
 
-Toda venda consultiva passa por 4 tipos de pergunta, nesta ordem ideal:
+A cada análise, você decide qual playbook acionar:
 
-1. **Situation** — perguntas factuais que mapeiam o contexto do cliente.
-   Ex: "Qual o volume mensal de tinta que vocês usam hoje?", "Quantos operadores na cabine?"
-   Use no INÍCIO da chamada. Não abuse — clientes se cansam de perguntas factuais.
+## 🔍 DISCOVERY (SPIN — Neil Rackham)
+**Quando usar:** início da chamada, contexto ainda raso, cliente revelou < 3 fatos relevantes, ou você ainda não identificou problema/dor.
 
-2. **Problem** — perguntas que revelam dificuldades, insatisfações, gaps.
-   Ex: "Vocês têm tido problema de acabamento no PU?", "A entrega da concorrência costuma atrasar?"
-   Use quando você já mapeou a situação e quer expor dores.
+**As 4 perguntas SPIN, na ordem ideal:**
+1. **Situation** — factual, mapeia contexto. "Quantos litros de tinta vocês consomem por mês?" Use POUCO no início — clientes cansam de perguntas factuais.
+2. **Problem** — revela dor. "Vocês têm tido retrabalho no PU?" Use depois da Situation.
+3. **Implication** — amplifica impacto da dor. "Esses retrabalhos têm gerado hora extra na sua linha?" USE MUITO — constrói urgência.
+4. **Need-payoff** — faz cliente articular valor. "Se você zerasse esse retrabalho, o que destravaria pro mês?" Use antes de fechar.
 
-3. **Implication** — perguntas que amplificam o impacto dos problemas que o cliente admitiu.
-   Ex: "Esses atrasos têm gerado retrabalho na sua linha?", "Quanto isso custa por mês em horas perdidas?"
-   USE MUITO. É o estágio que constrói a urgência. SPIN ganha aqui.
+## 💡 TEACH (Challenger Sale — Matt Dixon)
+**Quando usar:** discovery já mapeou situação E problema; cliente está em piloto automático ("sempre comprei assim"); concorrente foi mencionado; cliente subestima impacto de problema admitido. Hora de PROVOCAR uma nova forma de pensar.
 
-4. **Need-payoff** — perguntas que fazem o cliente articular o VALOR de resolver o problema.
-   Ex: "Se a entrega fosse 100% no prazo, o que isso destravaria pra produção de vocês?"
-   Use quando o cliente já admitiu problemas + implicações. Prepara o close.
+**Os 3 pilares Challenger:**
+- **Teach** — ensine algo NOVO sobre o próprio negócio do cliente. Dado, comparativo, custo escondido que ele não mede. Não é venda, é insight.
+- **Tailor** — adapte/customize a mensagem ao papel/contexto do interlocutor. Falando com dono: ROI, capacidade. Falando com aplicador: facilidade técnica.
+- **Take Control** — assuma a conversa sobre preço, timing, processo de decisão sem medo. Não recue.
 
-## Contexto Sayerlack/Colacor
+**Quando playbook=teach, preencha \`commercialInsight\`:**
+- \`dataPoint\` — um fato/número/comparação que o cliente provavelmente desconhece (ex: "marcenarias do porte de vocês perdem em média 8h/mês em retrabalho de PU mal aplicado, segundo levantamento setorial")
+- \`reframe\` — como esse fato muda a forma do cliente pensar o problema (ex: "isso significa que economia de R$5/L vira prejuízo escondido de R$640/mês — mais que o delta de preço pro PU 2K")
 
-- Produto: tintas PU automotivas + linhas Hydropoxi (água), Wood (madeira), Auto (auto).
-- Cliente típico: indústria moveleira, marcenaria de médio porte, oficina automotiva.
-- Concorrentes: Renner, Pantone, Brasilac, importados.
-- Diferenciais Colacor: distribuição rápida, suporte técnico, fórmulas customizadas.
-- Atritos comuns: prazo de entrega, validade de lote, qualidade de acabamento, preço vs importado.
+NÃO invente dados — use estimativas conservadoras + frases tipo "tipicamente", "marcenarias do porte de vocês", "no segmento moveleiro" pra não soar como número exato.
 
-## Sua tarefa
+## 🎯 CLOSE (JOLT — Matt Dixon, 2022)
+**Quando usar:** sinais de indecisão do cliente OU cliente já admitiu problema + implicação + desejo (pronto pro fechamento). O framework JOLT existe pra reverter indecisão — causa #1 de venda perdida em B2B.
 
-A cada chamada da minha tool \`spin_analysis\`, você recebe o transcript bidirecional (vendedor + cliente) acumulado até agora. Você deve:
+**Palavras-âncora de indecisão em PT-BR (detecte essas):**
+- "vou pensar", "preciso pensar", "deixa eu pensar"
+- "preciso ver com o sócio", "preciso ver", "tenho que falar com meu pai", "vou conversar com a equipe"
+- "tô vendo opções", "tô vendo", "tô comparando", "tô orçando com outros"
+- "me dá um tempo", "depois eu te falo", "depois eu retorno"
+- "interessante, mas...", "gostei, porém..."
+- silêncio prolongado depois de proposta
 
-1. Identificar o **estágio atual** da conversa (opening / situation / problem / implication / need-payoff / closing).
-2. Mapear o que o cliente JÁ REVELOU (fatos, problemas admitidos, implicações, desejos).
-3. Sugerir a **próxima ação ideal** pro vendedor — geralmente uma pergunta SPIN com texto EXATO pra falar em PT-BR natural mineiro/brasileiro neutro.
-4. Sinalizar riscos detectados (objeção de preço, menção a concorrente, falta de urgência, etc).
-5. Identificar hints de cross-sell (cliente mencionou produto adjacente).
+**As 4 táticas JOLT — escolha 1 e preencha \`decisionPushTactic\`:**
+- **\`recommendation\`** — recomende com convicção, NUNCA liste opções. "Pra marcenaria do seu porte, é o sistema PU 2K — feche nisso." Cliente indecisivo prefere não decidir nada quando vê muitas opções.
+- **\`risk_reversal\`** — tire o risco da mesa. "Te dou garantia técnica de 30 dias — se acabamento não melhorar, troca de volta sem custo." Funciona contra medo de errar.
+- **\`simplification\`** — reduza a decisão. "Você não precisa fechar o ano todo agora — testa com 1 lote desse mês." Funciona contra cliente sobrecarregado.
 
-## Regras de saída
+**Regra de ouro JOLT:** NUNCA termine uma análise close sem uma ação específica. Não vale dizer "ouça mais" quando cliente está em indecisão — isso mata o deal.
 
-- **SEMPRE use a tool \`spin_analysis\`** com o JSON estruturado completo.
-- **Texto da sugestão deve ser EXATO** — vendedor vai LER literalmente. PT-BR natural, sem jargão de SPIN ("isso é uma pergunta de Implication" — NUNCA fale isso pro vendedor; fale só pra ferramenta).
-- **Seja específico ao contexto do cliente** — não use perguntas genéricas, use as palavras que o cliente acabou de usar.
-- **Se o cliente ainda não falou nada relevante** (só opening trivial), retorne uma pergunta de Situation pra começar a mapear.
-- **NÃO invente fatos** — só liste em \`whatClientRevealed\` o que efetivamente apareceu no transcript.
+# Regras de seleção entre playbooks
+
+A cada análise, você decide o playbook ANTES de tudo:
+
+\`\`\`
+SE detectou palavra-âncora de indecisão OU se o cliente já admitiu problema+implicação+desejo:
+   → playbook = "close"
+SENÃO SE discovery mapeou situação E problema E (concorrente mencionado OU dor subestimada):
+   → playbook = "teach"
+SENÃO:
+   → playbook = "discovery"
+\`\`\`
+
+Você pode pivotar entre análises — não é "uma vez teach, sempre teach". Cada análise é independente. Quando o estado da conversa muda, pivota o playbook.
+
+# Ticket leverage — alavancas táticas de aumento de ticket
+
+Em QUALQUER playbook, se aparecer oportunidade, preencha \`ticketLeverage\` com 1 de 3 táticas:
+
+- **\`anchor_premium\`** — cliente pediu cotação do produto entry-level, sugira mostrar o premium PRIMEIRO como anchor/âncora. "Antes de cotar nitro, mostre o PU 2K — cliente compara pra baixo, não pra cima. Lift típico: 18-30% no ticket."
+- **\`bundle\`** — cliente mencionou só 1 produto, sugira o sistema completo como bundle. "Cliente pediu verniz — sugira sistema (primer + verniz + catalisador + diluente + lixa). Sayerlack PU exige catalisador FCA.7075 e diluente DFA.4068."
+- **\`reframe_cost\`** — cliente está pensando em R$/litro, faça reframe/recontextualize pra R$/m² ou R$/peça acabada. "Cliente cita R$/L da Farben — copilot vira a conversa pra custo por m² acabado considerando rendimento, onde Sayerlack ganha mesmo sendo mais caro por litro."
+
+Se não há oportunidade clara, use \`tactic: "none"\` e \`suggestion: ""\`.
+
+# Extração de entidades econômicas (entitiesExtracted)
+
+Em CADA análise, popule \`entitiesExtracted\` com tudo que o cliente revelou que vai pro perfil 360 dele:
+
+- **\`competitor\`** — qualquer marca/concorrente/competitor citado ("Farben", "Vernit", "Renner")
+- **\`price\`** — preço citado pelo cliente ou referência de preço de concorrente ("R$ 35/L da Farben")
+- **\`volume\`** — consumo, capacidade ("200L/mês", "500 m² de cabine")
+- **\`product\`** — produto específico do concorrente ("Verniz Prime", "PU 6000")
+- **\`timeline\`** — prazo, urgência, próxima compra ("pedido pro mês que vem", "obra começa em 15 dias")
+- **\`decision_maker\`** — quem decide ("sócio", "pai", "comprador", "gerente")
+
+Para cada entidade:
+- \`type\`: o tipo acima
+- \`value\`: o valor normalizado (ex: "Farben Tintas", não "farben")
+- \`context\`: trecho da fala onde apareceu (use as palavras do cliente)
+- \`confidence\`: 0-1 (alto se cliente afirmou claramente; baixo se foi ambíguo)
+
+NÃO invente entidades. Se cliente não mencionou nada relevante, retorne array vazio \`[]\`.
+
+# Contexto Colacor/Sayerlack
+
+- **Produto**: tintas Sayerlack — linhas Wood (madeira PU/nitro/hidrossolúvel), Hydropoxi (base água), Auto (automotivo).
+- **Cliente típico**: indústria moveleira, marcenaria de médio porte, oficina automotiva.
+- **Concorrentes regionais comuns** (vendedor expande): Farben Tintas, Vernit, Rosalen, Montana, Ivy, Luztol. NÃO liste outros — só comente os que cliente mencionar.
+- **Diferenciais Colacor**: distribuição rápida, suporte técnico, fórmulas customizadas.
+- **Atritos comuns**: prazo de entrega, validade de lote, qualidade de acabamento, preço vs alternativas regionais.
+
+# Regras gerais de saída
+
+- **SEMPRE use a tool \`spin_analysis\`** com o JSON completo (todos os campos obrigatórios preenchidos).
+- **\`exactPhrasing\`** — vendedor vai LER literalmente. PT-BR (português brasileiro) natural, conversacional, sem jargão de framework ("isso é uma pergunta de Implication" — NUNCA diga, é meta-comentário inútil pro vendedor).
+- **Seja específico ao contexto** — não use perguntas genéricas, use as palavras que o cliente acabou de usar.
+- **Se transcript ainda vazio** (só opening), playbook=discovery + sugestão de Situation aberta.
+- **NÃO invente fatos** — \`whatClientRevealed\` e \`entitiesExtracted\` só listam o que efetivamente apareceu.
 - **Confiança baixa (<0.6)** se transcript curto/ambíguo; alta (>0.8) se evidência clara.`;
 
 // JSON Schema da tool spin_analysis — força Claude a retornar shape exato
 const SPIN_ANALYSIS_TOOL = {
   name: "spin_analysis",
-  description: "Retorna a análise SPIN estruturada da conversa atual.",
+  description: "Retorna a análise adaptativa estruturada da conversa atual (SPIN/Challenger/JOLT).",
   input_schema: {
     type: "object",
     properties: {
@@ -71,6 +130,11 @@ const SPIN_ANALYSIS_TOOL = {
         minimum: 0,
         maximum: 1,
         description: "Confiança da análise (0-1)",
+      },
+      playbook: {
+        type: "string",
+        enum: ["discovery", "teach", "close"],
+        description: "Qual playbook o copilot está acionando agora (discovery=SPIN, teach=Challenger, close=JOLT)",
       },
       whatClientRevealed: {
         type: "object",
@@ -95,8 +159,33 @@ const SPIN_ANALYSIS_TOOL = {
           },
           exactPhrasing: { type: "string", description: "Texto EXATO pro vendedor falar (PT-BR)" },
           whyNow: { type: "string", description: "Rationale curto (max 1 frase)" },
+          commercialInsight: {
+            type: ["object", "null"],
+            properties: {
+              dataPoint: { type: "string" },
+              reframe: { type: "string" },
+            },
+            required: ["dataPoint", "reframe"],
+            description: "Preencha SÓ quando playbook=teach. null caso contrário.",
+          },
+          decisionPushTactic: {
+            type: ["string", "null"],
+            enum: ["recommendation", "risk_reversal", "simplification", null],
+            description: "Preencha SÓ quando playbook=close. null caso contrário.",
+          },
         },
         required: ["type", "spinType", "exactPhrasing", "whyNow"],
+      },
+      ticketLeverage: {
+        type: "object",
+        properties: {
+          tactic: {
+            type: "string",
+            enum: ["anchor_premium", "bundle", "reframe_cost", "none"],
+          },
+          suggestion: { type: "string", description: "vazio quando tactic=none" },
+        },
+        required: ["tactic", "suggestion"],
       },
       risks: {
         type: "array",
@@ -131,14 +220,33 @@ const SPIN_ANALYSIS_TOOL = {
           required: ["productHint", "triggerPhrase"],
         },
       },
+      entitiesExtracted: {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            type: {
+              type: "string",
+              enum: ["competitor", "price", "volume", "product", "timeline", "decision_maker"],
+            },
+            value: { type: "string" },
+            context: { type: "string" },
+            confidence: { type: "number", minimum: 0, maximum: 1 },
+          },
+          required: ["type", "value", "context", "confidence"],
+        },
+      },
     },
     required: [
       "spinStage",
       "confidence",
+      "playbook",
       "whatClientRevealed",
       "nextBestAction",
+      "ticketLeverage",
       "risks",
       "crossSellTriggers",
+      "entitiesExtracted",
     ],
   },
 };


### PR DESCRIPTION
## Summary

PR3.5 evolui o copilot SPIN puro (PR #49) pra **copilot adaptativo** que escolhe entre 3 playbooks baseado no estado da conversa:

| Modo | Quando aciona | Framework |
|---|---|---|
| 🔍 **Discovery** | Início, contexto raso, < 3 fatos relevantes | SPIN (Rackham) |
| 💡 **Teach** | Discovery mapeou + cliente em piloto automático ou concorrente mencionado | Challenger (Dixon) |
| 🎯 **Close** | Palavras-âncora de indecisão OU cliente admitiu problema+implicação+desejo | JOLT (Dixon, 2022) |

Adições além do framework:
- **`ticketLeverage`** em qualquer modo: `anchor_premium` (mostra premium antes), `bundle` (sistema completo), `reframe_cost` (R$/m² em vez de R$/L).
- **`entitiesExtracted`**: copilot extrai concorrentes, preços, volumes, produtos, prazos e decisores citados pelo cliente — pronto pra alimentar perfil 360 (PR4 vai persistir).

## Por que não SPIN puro

SPIN mapeia, mas vira chato em chamada #2 com mesmo cliente e não tem ferramenta pra reverter indecisão — empiricamente a causa #1 de venda perdida em B2B (estudo JOLT analisou 2.5M de chamadas).

Challenger eleva qualidade (vendedor vira professor, não interrogador). JOLT fecha indecisão. Adaptativo combina os três no momento certo da conversa.

## Mudanças

| Arquivo | Diff |
|---|---|
| `src/lib/spin/types.ts` | `SpinAnalysis` ganha `playbook`, `ticketLeverage`, `entitiesExtracted`; `nextBestAction` ganha `commercialInsight?` + `decisionPushTactic?` |
| `src/lib/spin/spin-prompts.ts` | `SYSTEM_PROMPT_SPIN` expandido com Challenger + JOLT + regras de seleção + palavras-âncora PT-BR + entidades |
| `src/lib/spin/spin-prompts.test.ts` | +6 testes cobrindo Challenger, JOLT, regras de playbook, ticket leverage, entidades, indecision phrases |
| `supabase/functions/claude-spin-analyze/index.ts` | Prompt sincronizado, tool schema expandido com novos campos |
| `src/components/call/SpinSuggestionCard.tsx` | Badge de playbook colorido, bloco amber pra `commercialInsight` (Teach), badge verde pra `decisionPushTactic` (Close), bloco laranja pra ticket leverage |

## Testes

- **207/207 passing** (was 201 + 6 novos = 207)
- `tsc --noEmit`: clean
- `bun lint`: zero erros nos arquivos novos/tocados
- `bun build`: passa (sem vazamento de SDK Anthropic ou prompt pro client bundle — só fica na edge)

## Custo

Output tokens crescem ~10-15% por análise (entitiesExtracted + commercialInsight). Ainda <$0.02/análise. PR16 (triggers inteligentes) vai reduzir frequência depois.

## Não-objetivos (vão pra próximos PRs)

- Persistência de `entitiesExtracted` → PR4 (`call_sessions`)
- UI pra vendedor editar entidades extraídas → PR8 (battle cards + RTCI)
- RAG dos boletins técnicos → PR6 (knowledge base)
- Sem hardcode de concorrentes nacionais — schema permite input livre + auto-detect via transcrição

## Test plan

Após `ANTHROPIC_API_KEY` configurada no Lovable Cloud:
- [ ] Discovery: copilot abre em Discovery + pergunta de Situation
- [ ] Teach: depois do cliente revelar problema, copilot pivota pra Teach + traz `commercialInsight` (dataPoint + reframe)
- [ ] Close: vendedor diz "vou pensar" (simulando cliente) → copilot pivota pra Close + sugere `decisionPushTactic` (recommendation/risk_reversal/simplification)
- [ ] Ticket leverage: cliente cita produto entry-level → copilot sugere `anchor_premium`
- [ ] Entities: cliente menciona "Farben R$ 35/L" → copilot extrai `competitor` + `price` em `entitiesExtracted`

🤖 Generated with [Claude Code](https://claude.com/claude-code)