### PR TITLE
feat(typescript): elimina any em 4 Edge Functions Omie (-164 lint errors)

### DIFF
--- a/supabase/functions/analyze-unified-order/index.ts
+++ b/supabase/functions/analyze-unified-order/index.ts
@@ -11,6 +11,104 @@ const corsHeaders = {
   "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type, x-supabase-client-platform, x-supabase-client-platform-version, x-supabase-client-runtime, x-supabase-client-runtime-version",
 };
 
+interface CustomerCandidate {
+  user_id?: string;
+  nome?: string;
+  nome_fantasia?: string;
+  razao_social?: string;
+  cnpj_cpf?: string;
+  documento?: string;
+  cidade?: string;
+  estado?: string;
+  codigo_cliente?: number | null;
+}
+
+interface ProdutoCatalogo {
+  id: string;
+  codigo: string;
+  descricao: string;
+  account?: string | null;
+  valor_unitario?: number | null;
+  estoque?: number | null;
+}
+
+interface UserToolRow {
+  id: string;
+  generated_name?: string | null;
+  custom_name?: string | null;
+  quantity?: number | null;
+  tool_categories?: { name?: string | null } | null;
+}
+
+interface AIProduct {
+  product_id?: string;
+  codigo?: string;
+  descricao?: string;
+  quantity?: number;
+  account?: string;
+  unit_price?: number;
+  notes?: string;
+}
+
+interface AIService {
+  userToolId: string;
+  omie_codigo_servico: number;
+  servico_descricao: string;
+  quantity: number;
+  notes?: string;
+}
+
+interface AISuggestion {
+  type: "product" | "service";
+  product_id?: string;
+  codigo?: string;
+  descricao: string;
+  quantity?: number;
+  account?: string;
+  unit_price?: number;
+  reason: string;
+  userToolId?: string;
+  omie_codigo_servico?: number;
+  servico_descricao?: string;
+}
+
+interface AIChatMessage {
+  role: "system" | "user" | "assistant";
+  content: string | Array<{ type: string; text?: string; image_url?: { url: string } }>;
+}
+
+interface ToolPropertySchema {
+  type: string | string[];
+  description?: string;
+  items?: unknown;
+  properties?: Record<string, unknown>;
+  required?: string[];
+  enum?: string[];
+}
+
+interface OmieProdutoPedidoItem {
+  produto?: { codigo_produto?: number; valor_unitario?: number };
+}
+
+interface OmiePedidoVendaProduto {
+  det?: OmieProdutoPedidoItem[];
+}
+
+interface OmieListarPedidosResponse {
+  pedido_venda_produto?: OmiePedidoVendaProduto[];
+}
+
+interface OmieClienteCadastroResponse {
+  clientes_cadastro?: Array<{
+    codigo_cliente_omie?: number;
+    nome_fantasia?: string;
+    razao_social?: string;
+    cnpj_cpf?: string;
+    cidade?: string;
+    estado?: string;
+  }>;
+}
+
 serve(async (req) => {
   if (req.method === "OPTIONS") {
     return new Response(null, { headers: corsHeaders });
@@ -37,7 +135,7 @@ serve(async (req) => {
         status: 401, headers: { ...corsHeaders, "Content-Type": "application/json" },
       });
     }
-    const loggedInUserId = (data.claims as any).sub || "";
+    const loggedInUserId = (data.claims as { sub?: string }).sub || "";
 
     // SECURITY: staff-only — prevents customer PII enumeration via
     // searchCustomer + service_role profile bulk-fetch.
@@ -80,7 +178,7 @@ serve(async (req) => {
 
     // ─── Customer search ───
     let customerSection = "";
-    let customerCandidates: any[] = [];
+    const customerCandidates: CustomerCandidate[] = [];
 
     if (searchCustomer && (text || allImages.length > 0)) {
       // Extract potential customer names/cities from text
@@ -183,7 +281,7 @@ serve(async (req) => {
               }),
             });
             if (omieRes.ok) {
-              const omieData = await omieRes.json();
+              const omieData = (await omieRes.json()) as OmieClienteCadastroResponse;
               if (omieData.clientes_cadastro) {
                 for (const c of omieData.clientes_cadastro) {
                   const key = `omie_${c.codigo_cliente_omie}`;
@@ -209,7 +307,7 @@ serve(async (req) => {
 
       if (customerCandidates.length > 0) {
         customerSection = "\n\nCLIENTES ENCONTRADOS NA BASE (para identificação):\n" +
-          customerCandidates.map((c: any, i: number) => {
+          customerCandidates.map((c, i) => {
             if (c.nome_fantasia !== undefined) {
               return `- [${i}] NomeFantasia:${c.nome_fantasia} | RazãoSocial:${c.razao_social} | CNPJ/CPF:${c.cnpj_cpf} | Cidade:${c.cidade || 'N/A'} | Estado:${c.estado || 'N/A'} | CódigoCliente:${c.codigo_cliente}`;
             }
@@ -228,7 +326,7 @@ serve(async (req) => {
     const servicosLista = (servicos || []).map(s => `- CódigoServiço:${s.omie_codigo_servico} | ${s.descricao}`).join("\n");
 
     // Build product list
-    let prodList: any[] = [];
+    let prodList: ProdutoCatalogo[] = [];
     const prodIds = new Set<string>();
 
     if (allImages.length > 0 && !text) {
@@ -391,14 +489,14 @@ serve(async (req) => {
 
     console.log(`[analyze-unified-order] Total products: ${prodList.length}, customer candidates: ${customerCandidates.length}, searchCustomer: ${searchCustomer}`);
 
-    const produtosLista = prodList.map((p: any) =>
+    const produtosLista = prodList.map((p) =>
       `- ID:${p.id} | Código:${p.codigo} | ${p.descricao} | Conta:${p.account || 'oben'} | Preço:${p.valor_unitario} | Estoque:${p.estoque ?? 0}`
     ).join("\n");
 
     // Format user tools
-    const tools = (userTools || []);
+    const tools: UserToolRow[] = (userTools || []);
     const ferramentasLista = tools.length > 0
-      ? tools.map((t: any) => {
+      ? tools.map((t) => {
           const nome = t.generated_name || t.custom_name || t.tool_categories?.name || "Ferramenta";
           return `- ToolID:${t.id} | Nome:${nome} | Categoria:${t.tool_categories?.name || ''} | Qtd:${t.quantity || 1}`;
         }).join("\n")
@@ -425,11 +523,11 @@ serve(async (req) => {
         if (recentItems && recentItems.length > 0) {
           const productCounts: Record<string, { descricao: string; codigo: string; account: string; totalQty: number; count: number }> = {};
           for (const item of recentItems) {
-            const prod = item.omie_products as any;
+            const prod = item.omie_products as { descricao?: string; codigo?: string; account?: string } | null;
             if (!prod) continue;
-            const key = item.product_id || prod.codigo;
+            const key = item.product_id || prod.codigo || '';
             if (!productCounts[key]) {
-              productCounts[key] = { descricao: prod.descricao, codigo: prod.codigo, account: prod.account || 'oben', totalQty: 0, count: 0 };
+              productCounts[key] = { descricao: prod.descricao ?? '', codigo: prod.codigo ?? '', account: prod.account || 'oben', totalQty: 0, count: 0 };
             }
             productCounts[key].totalQty += item.quantity;
             productCounts[key].count += 1;
@@ -444,7 +542,7 @@ serve(async (req) => {
           for (const order of recentOrders) {
             if (order.service_type) serviceTypes.add(order.service_type);
             if (order.items && Array.isArray(order.items)) {
-              for (const item of order.items as any[]) {
+              for (const item of order.items as Array<{ category?: string }>) {
                 if (item.category) serviceTypes.add(item.category);
               }
             }
@@ -556,12 +654,12 @@ REGRAS DE IDENTIFICAÇÃO DE CLIENTE (CRÍTICAS):
 ` : ""}
 Responda SEMPRE usando a função identify_order_items.`;
 
-    const messages: any[] = [
+    const messages: AIChatMessage[] = [
       { role: "system", content: systemPrompt },
     ];
 
     if (allImages.length > 0) {
-      const content: any[] = [
+      const content: Array<{ type: string; text?: string; image_url?: { url: string } }> = [
         { type: "text", text: text || "Identifique os produtos, ferramentas e cliente nestas imagens e sugira os itens para o pedido:" },
       ];
       for (const img of allImages) {
@@ -573,7 +671,7 @@ Responda SEMPRE usando a função identify_order_items.`;
     }
 
     // Build tool schema
-    const toolProperties: any = {
+    const toolProperties: Record<string, ToolPropertySchema> = {
       products: {
         type: "array",
         description: "Produtos do catálogo identificados com certeza",
@@ -706,9 +804,9 @@ Responda SEMPRE usando a função identify_order_items.`;
     const result = JSON.parse(toolCall.function.arguments);
 
     // Validate product IDs - rescue invalid ones by fuzzy matching
-    const validProductIds = new Set(prodList.map((p: any) => p.id));
-    const aiProducts = result.products || [];
-    let validProducts: any[] = [];
+    const validProductIds = new Set(prodList.map((p) => p.id));
+    const aiProducts: AIProduct[] = result.products || [];
+    let validProducts: AIProduct[] = [];
     
     for (const ap of aiProducts) {
       if (validProductIds.has(ap.product_id)) {
@@ -745,7 +843,7 @@ Responda SEMPRE usando a função identify_order_items.`;
 
         // 1. Exact codigo match (stripped)
         if (apCodigo) {
-          const match = prodList.find((p: any) => {
+          const match = prodList.find((p) => {
             const pDesc = p.descricao.replace(/[.\-\s]/g, '').toLowerCase();
             const pCodigo = p.codigo.replace(/[.\-\s]/g, '').toLowerCase();
             return pCodigo === apCodigo || pDesc.includes(apCodigo);
@@ -761,12 +859,12 @@ Responda SEMPRE usando a função identify_order_items.`;
         if (!rescued && allNumericCodes.size > 0) {
           for (const nc of allNumericCodes) {
             // Find all products containing this numeric code
-            const candidates = prodList.filter((p: any) => p.descricao.includes(nc));
+            const candidates = prodList.filter((p) => p.descricao.includes(nc));
             if (candidates.length === 0) continue;
-            
+
             // If we have prefix and suffix, find best match
             if (alphaPrefix && packSuffix) {
-              const bestMatch = candidates.find((p: any) => {
+              const bestMatch = candidates.find((p) => {
                 const desc = p.descricao.toUpperCase();
                 return desc.includes(alphaPrefix) && desc.includes(packSuffix);
               });
@@ -779,7 +877,7 @@ Responda SEMPRE usando a função identify_order_items.`;
             }
             // Try prefix only
             if (!rescued && alphaPrefix) {
-              const prefixMatch = candidates.find((p: any) => p.descricao.toUpperCase().includes(alphaPrefix));
+              const prefixMatch = candidates.find((p) => p.descricao.toUpperCase().includes(alphaPrefix));
               if (prefixMatch) {
                 console.log(`[analyze-unified-order] Rescued by prefix+numeric: ${ap.codigo}/${ap.descricao} → ${prefixMatch.descricao}`);
                 validProducts.push({ ...ap, product_id: prefixMatch.id, codigo: prefixMatch.codigo, descricao: prefixMatch.descricao, account: prefixMatch.account, unit_price: ap.unit_price || prefixMatch.valor_unitario });
@@ -789,7 +887,7 @@ Responda SEMPRE usando a função identify_order_items.`;
             }
             // Try suffix only
             if (!rescued && packSuffix) {
-              const suffMatch = candidates.find((p: any) => p.descricao.toUpperCase().includes(packSuffix));
+              const suffMatch = candidates.find((p) => p.descricao.toUpperCase().includes(packSuffix));
               if (suffMatch) {
                 console.log(`[analyze-unified-order] Rescued by numeric+suffix: ${ap.codigo}/${ap.descricao} → ${suffMatch.descricao}`);
                 validProducts.push({ ...ap, product_id: suffMatch.id, codigo: suffMatch.codigo, descricao: suffMatch.descricao, account: suffMatch.account, unit_price: ap.unit_price || suffMatch.valor_unitario });
@@ -861,9 +959,9 @@ Responda SEMPRE usando a função identify_order_items.`;
     const inputContext = (text || '').toUpperCase() + ' ' + (result.message || '').toUpperCase();
     
     // Group validProducts by their base numeric code (e.g., "6673")
-    const variantGroups = new Map<string, any[]>();
+    const variantGroups = new Map<string, Array<{ vp: AIProduct; prod: ProdutoCatalogo }>>();
     for (const vp of validProducts) {
-      const prod = prodList.find((p: any) => p.id === vp.product_id);
+      const prod = prodList.find((p) => p.id === vp.product_id);
       if (!prod) { continue; }
       // Extract numeric code from descricao (e.g., "6673" from "FL.6673.00LT")
       const numMatch = prod.descricao.match(/(\d{4,})/);
@@ -882,7 +980,7 @@ Responda SEMPRE usando a função identify_order_items.`;
     for (const [baseNum, group] of variantGroups) {
       if (group.length <= 1) continue;
       
-      console.log(`[analyze-unified-order] Variant dedup: ${baseNum} has ${group.length} variants: ${group.map((g: any) => g.prod.descricao).join(', ')}`);
+      console.log(`[analyze-unified-order] Variant dedup: ${baseNum} has ${group.length} variants: ${group.map((g) => g.prod.descricao).join(', ')}`);
       
       // Score each variant by context clues
       let bestIdx = 0;
@@ -913,13 +1011,13 @@ Responda SEMPRE usando a função identify_order_items.`;
     }
     
     if (removedProductIds.size > 0) {
-      validProducts = validProducts.filter((vp: any) => !removedProductIds.has(vp.product_id));
+      validProducts = validProducts.filter((vp) => !removedProductIds.has(vp.product_id ?? ''));
     }
 
     // ─── Multi-account optimization: for each product, find equivalent in both accounts ───
     // Pick the account with LESS stock (to clear smaller batches first)
-    const prodMap = new Map(prodList.map((p: any) => [p.id, p]));
-    const optimizedProducts: any[] = [];
+    const prodMap = new Map<string, ProdutoCatalogo>(prodList.map((p) => [p.id, p]));
+    const optimizedProducts: AIProduct[] = [];
     const processedCodes = new Set<string>();
 
     for (const vp of validProducts) {
@@ -934,7 +1032,7 @@ Responda SEMPRE usando a função identify_order_items.`;
 
       // Find equivalent product in the other account by matching codigo
       const otherAccount = prod.account === 'oben' ? 'colacor' : 'oben';
-      const equivalent = prodList.find((p: any) => 
+      const equivalent = prodList.find((p) =>
         p.codigo === baseCode && p.account === otherAccount
       );
 
@@ -962,12 +1060,12 @@ Responda SEMPRE usando a função identify_order_items.`;
     validProducts = optimizedProducts;
 
     // Validate tool IDs
-    const validToolIds = new Set(tools.map((t: any) => t.id));
-    const validServices = (result.services || []).filter((s: any) => validToolIds.has(s.userToolId));
+    const validToolIds = new Set(tools.map((t) => t.id));
+    const validServices = ((result.services || []) as AIService[]).filter((s) => validToolIds.has(s.userToolId));
 
     // Validate suggestions — also DEDUP: remove suggestions that are already in validProducts
-    const validProductIdSet = new Set(validProducts.map((vp: any) => vp.product_id));
-    const validSuggestions = (result.suggestions || []).filter((s: any) => {
+    const validProductIdSet = new Set(validProducts.map((vp) => vp.product_id));
+    const validSuggestions = ((result.suggestions || []) as AISuggestion[]).filter((s) => {
       if (s.type === 'product') {
         // Remove if this product is already in the confirmed products list
         if (s.product_id && s.product_id !== '' && validProductIdSet.has(s.product_id)) return false;
@@ -1018,7 +1116,7 @@ Responda SEMPRE usando a função identify_order_items.`;
 
       // Check if this customer actually exists in our candidates
       // IMPORTANT: Do NOT trust AI's user_id — only match by name, document, or codigo_cliente
-      const matchedCandidate = customerCandidates.find((c: any) => {
+      const matchedCandidate = customerCandidates.find((c) => {
         // Match by codigo_cliente
         if (c.codigo_cliente && result.customer.codigo_cliente && c.codigo_cliente === result.customer.codigo_cliente) return true;
         // Match by document
@@ -1057,7 +1155,7 @@ Responda SEMPRE usando a função identify_order_items.`;
           console.log(`[analyze-unified-order] Candidate: "${cn}"`);
         }
         
-        const bestMatch = customerCandidates.find((c: any) => {
+        const bestMatch = customerCandidates.find((c) => {
           const name = stripAccents((c.nome_fantasia || c.nome || '').toLowerCase());
           const aiName = stripAccents((result.customer.nome_fantasia || '').toLowerCase());
           if (!name || !aiName) return false;
@@ -1124,8 +1222,8 @@ Responda SEMPRE usando a função identify_order_items.`;
           try {
             // Collect all product IDs we need prices for
             const allProductIds = [
-              ...validProducts.map((vp: any) => vp.product_id),
-              ...validSuggestions.filter((vs: any) => vs.product_id).map((vs: any) => vs.product_id),
+              ...validProducts.map((vp) => vp.product_id),
+              ...validSuggestions.filter((vs) => vs.product_id).map((vs) => vs.product_id),
             ].filter(Boolean);
 
             // Get omie_codigo_produto mapping for identified products

--- a/supabase/functions/omie-financeiro/index.ts
+++ b/supabase/functions/omie-financeiro/index.ts
@@ -1,5 +1,194 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
-import { createClient } from "npm:@supabase/supabase-js@2";
+import { createClient, type SupabaseClient } from "npm:@supabase/supabase-js@2";
+
+type OmieGenericResponse = Record<string, unknown> & { faultstring?: string };
+
+interface OmieListResponse<T> {
+  total_de_paginas?: number;
+  nTotPaginas?: number;
+  faultstring?: string;
+  [key: string]: T[] | number | string | undefined;
+}
+
+interface OmieCategoria {
+  codigo?: string;
+  descricao?: string;
+  tipo_categoria?: string;
+  codigo_conta_pai?: string | null;
+  nivel?: number;
+  conta_totalizadora?: string;
+  conta_inativa?: string;
+}
+
+interface OmieContaCorrente {
+  nCodCC?: number;
+  descricao?: string;
+  cDescricao?: string;
+  codigo_banco?: string;
+  cNomeBanco?: string;
+  banco?: string;
+  codigo_agencia?: string;
+  cAgencia?: string;
+  agencia?: string;
+  numero_conta_corrente?: string;
+  cNumeroConta?: string;
+  numero_conta?: string;
+  tipo_conta_corrente?: string;
+  tipo?: string;
+  cTipo?: string;
+  inativo?: string;
+  cInativa?: string;
+}
+
+interface OmieResumirContaCorrenteResponse {
+  nSaldo?: number;
+  nSaldoAtual?: number;
+}
+
+interface OmieContaPagar {
+  codigo_lancamento_omie?: number;
+  nCodTitulo?: number;
+  codigo_lancamento?: number;
+  codigo_cliente_fornecedor_integracao?: string | null;
+  codigo_cliente_fornecedor?: number;
+  nome_cliente_fornecedor?: string;
+  nome_fornecedor?: string;
+  cnpj_cpf?: string;
+  numero_documento?: string;
+  cNumDocumento?: string;
+  numero_documento_fiscal?: string | null;
+  data_emissao?: string;
+  dDtEmissao?: string;
+  data_vencimento?: string;
+  dDtVenc?: string;
+  data_pagamento?: string;
+  dDtPagamento?: string;
+  data_previsao?: string;
+  dDtPreworst?: string;
+  valor_documento?: number;
+  nValorTitulo?: number;
+  valor_pago?: number;
+  nValorPago?: number;
+  valor_desconto?: number;
+  valor_juros?: number;
+  valor_multa?: number;
+  status_titulo?: string;
+  codigo_categoria?: string;
+  cCodCateg?: string;
+  descricao_categoria?: string;
+  departamento?: string | null;
+  centro_custo?: string | null;
+  observacao?: string | null;
+  nCodCC?: number | null;
+  codigo_barras?: string | null;
+  tipo_documento?: string | null;
+  id_origem?: string | null;
+  parcela?: number;
+  total_parcelas?: number;
+  baixa_obs?: string;
+}
+
+interface OmieContaReceber {
+  codigo_lancamento_omie?: number;
+  nCodTitulo?: number;
+  codigo_lancamento?: number;
+  codigo_cliente_fornecedor?: number;
+  codigo_cliente_fornecedor_integracao?: string | null;
+  nome_cliente_fornecedor?: string;
+  nome_cliente?: string;
+  cnpj_cpf?: string;
+  numero_documento?: string;
+  numero_documento_fiscal?: string | null;
+  numero_pedido?: string | null;
+  data_emissao?: string;
+  dDtEmissao?: string;
+  data_vencimento?: string;
+  dDtVenc?: string;
+  data_recebimento?: string;
+  dDtPagamento?: string;
+  data_previsao?: string;
+  valor_documento?: number;
+  nValorTitulo?: number;
+  valor_recebido?: number;
+  nValorPago?: number;
+  valor_desconto?: number;
+  valor_juros?: number;
+  valor_multa?: number;
+  status_titulo?: string;
+  codigo_categoria?: string;
+  cCodCateg?: string;
+  descricao_categoria?: string;
+  departamento?: string | null;
+  centro_custo?: string | null;
+  observacao?: string | null;
+  nCodCC?: number | null;
+  nCodVend?: number | null;
+  tipo_documento?: string | null;
+  id_origem?: string | null;
+  parcela?: number;
+  total_parcelas?: number;
+}
+
+interface OmieMovimentoDetalhes {
+  nCodTitulo?: number;
+  nCodCC?: number | null;
+  cGrupo?: string;
+  cNatureza?: string;
+  cOrigem?: string;
+  cStatus?: string;
+  cNumDocFiscal?: string;
+  cNumTitulo?: string;
+  cNumOS?: string;
+  cNumParcela?: string;
+  cCodCateg?: string;
+  dDtPagamento?: string;
+  dDtRegistro?: string;
+  dDtPrevisao?: string;
+  dDtVenc?: string;
+  dDtEmissao?: string;
+  nValorTitulo?: number;
+}
+
+interface OmieMovimentoResumo {
+  nValPago?: number;
+  nValLiquido?: number;
+  nDesconto?: number;
+  nJuros?: number;
+  nMulta?: number;
+}
+
+interface OmieMovimento {
+  detalhes?: OmieMovimentoDetalhes;
+  resumo?: OmieMovimentoResumo;
+}
+
+interface MovimentoRow {
+  company: Company;
+  omie_ncodmov: string;
+  omie_ncodcc: number | null;
+  data_movimento: string;
+  tipo: string;
+  valor: number;
+  descricao: string;
+  categoria_codigo: string;
+  categoria_descricao: string;
+  conciliado: boolean;
+  omie_codigo_lancamento: number | null;
+  natureza: string | null;
+  metadata: { detalhes: OmieMovimentoDetalhes; resumo: OmieMovimentoResumo };
+  updated_at: string;
+}
+
+interface ContaSaldoRow {
+  saldo?: number | null;
+  saldo_atual?: number | null;
+}
+
+interface CategoriaDreMappingRow {
+  omie_codigo: string;
+  dre_linha: string;
+  company: string;
+}
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -46,7 +235,7 @@ async function callOmie(
   endpoint: string,
   call: string,
   params: Record<string, unknown>
-) {
+): Promise<OmieGenericResponse | null> {
   const creds = getCredentials(company);
   if (!creds.key || !creds.secret)
     throw new Error(`Credenciais Omie (${company}) não configuradas`);
@@ -66,7 +255,7 @@ async function callOmie(
       body: JSON.stringify(body),
     });
     apiCallCount++;
-    const result = await res.json();
+    const result = (await res.json()) as OmieGenericResponse;
 
     if (result.faultstring) {
       const fs = String(result.faultstring);
@@ -93,7 +282,7 @@ async function callOmie(
 
 // ═══════════════ SYNC CATEGORIAS ═══════════════
 async function syncCategorias(
-  db: any,
+  db: SupabaseClient,
   company: Company
 ) {
   let pagina = 1;
@@ -101,18 +290,18 @@ async function syncCategorias(
   let totalSynced = 0;
 
   while (pagina <= totalPaginas) {
-    const result = (await callOmie(
+    const result = await callOmie(
       company,
       "geral/categorias/",
       "ListarCategorias",
       { pagina, registros_por_pagina: 500 }
-    )) as any;
+    );
     if (!result) break;
 
-    totalPaginas = result.total_de_paginas || 1;
-    const categorias = result.categoria_cadastro || [];
+    totalPaginas = (result.total_de_paginas as number) || 1;
+    const categorias = (result.categoria_cadastro as OmieCategoria[] | undefined) || [];
 
-    const rows = categorias.map((c: any) => ({
+    const rows = categorias.map((c) => ({
       company,
       omie_codigo: c.codigo,
       descricao: c.descricao,
@@ -140,7 +329,7 @@ async function syncCategorias(
 
 // ═══════════════ SYNC CONTAS CORRENTES ═══════════════
 async function syncContasCorrentes(
-  db: any,
+  db: SupabaseClient,
   company: Company
 ) {
   let pagina = 1;
@@ -148,16 +337,18 @@ async function syncContasCorrentes(
   let totalSynced = 0;
 
   while (pagina <= totalPaginas) {
-    const result = (await callOmie(
+    const result = await callOmie(
       company,
       "geral/contacorrente/",
       "ListarContasCorrentes",
       { pagina, registros_por_pagina: 50 }
-    )) as any;
+    );
     if (!result) break;
 
-    totalPaginas = result.nTotPaginas || 1;
-    const contas = result.ListarContasCorrentes || result.conta_corrente_lista || [];
+    totalPaginas = (result.nTotPaginas as number) || 1;
+    const contas = (result.ListarContasCorrentes as OmieContaCorrente[] | undefined)
+      || (result.conta_corrente_lista as OmieContaCorrente[] | undefined)
+      || [];
 
     for (const c of contas) {
       // Buscar saldo real via ResumirContaCorrente
@@ -169,7 +360,7 @@ async function syncContasCorrentes(
           "geral/contacorrente/",
           "ResumirContaCorrente",
           { nCodCC: c.nCodCC }
-        )) as any;
+        )) as OmieResumirContaCorrenteResponse | null;
         if (saldoResult) {
           saldoAtual = saldoResult.nSaldo ?? saldoResult.nSaldoAtual ?? 0;
           saldoData = new Date().toISOString().split("T")[0];
@@ -207,7 +398,7 @@ async function syncContasCorrentes(
 
 // ═══════════════ SYNC CONTAS A PAGAR ═══════════════
 async function syncContasPagar(
-  db: any,
+  db: SupabaseClient,
   company: Company,
   filtroDataDe?: string,
   filtroDataAte?: string,
@@ -226,19 +417,21 @@ async function syncContasPagar(
     };
     // Omie lcpListarRequest não aceita filtros de data
 
-    const result = (await callOmie(
+    const result = await callOmie(
       company,
       "financas/contapagar/",
       "ListarContasPagar",
       params
-    )) as any;
+    );
     if (!result) break;
 
-    totalPaginas = result.total_de_paginas || 1;
-    const titulos =
-      result.conta_pagar_cadastro || result.titulosEncontrados || [];
+    totalPaginas = (result.total_de_paginas as number) || 1;
+    const titulos: OmieContaPagar[] =
+      (result.conta_pagar_cadastro as OmieContaPagar[] | undefined)
+      || (result.titulosEncontrados as OmieContaPagar[] | undefined)
+      || [];
 
-    const rows = titulos.map((t: any) => {
+    const rows = titulos.map((t) => {
       const statusMap: Record<string, string> = {
         LIQUIDADO: "PAGO",
         CANCELADO: "CANCELADO",
@@ -301,7 +494,7 @@ async function syncContasPagar(
     });
 
     // Filter out rows with null primary key (prevents upsert failure)
-    const validRows = rows.filter((r: any) => r.omie_codigo_lancamento != null);
+    const validRows = rows.filter((r) => r.omie_codigo_lancamento != null);
     const skipped = rows.length - validRows.length;
     if (skipped > 0) console.log(`[Fin][${company}] CP p${pagina}: ${skipped} títulos sem código, ignorados`);
 
@@ -336,7 +529,7 @@ async function syncContasPagar(
 
 // ═══════════════ SYNC CONTAS A RECEBER ═══════════════
 async function syncContasReceber(
-  db: any,
+  db: SupabaseClient,
   company: Company,
   filtroDataDe?: string,
   filtroDataAte?: string,
@@ -355,19 +548,21 @@ async function syncContasReceber(
     };
     // Omie lcrListarRequest não aceita filtros de data
 
-    const result = (await callOmie(
+    const result = await callOmie(
       company,
       "financas/contareceber/",
       "ListarContasReceber",
       params
-    )) as any;
+    );
     if (!result) break;
 
-    totalPaginas = result.total_de_paginas || 1;
-    const titulos =
-      result.conta_receber_cadastro || result.titulosEncontrados || [];
+    totalPaginas = (result.total_de_paginas as number) || 1;
+    const titulos: OmieContaReceber[] =
+      (result.conta_receber_cadastro as OmieContaReceber[] | undefined)
+      || (result.titulosEncontrados as OmieContaReceber[] | undefined)
+      || [];
 
-    const rows = titulos.map((t: any) => {
+    const rows = titulos.map((t) => {
       let status = t.status_titulo || "ABERTO";
       if (status === "LIQUIDADO") status = "RECEBIDO";
       if (
@@ -418,7 +613,7 @@ async function syncContasReceber(
       };
     });
 
-    const validRows = rows.filter((r: any) => r.omie_codigo_lancamento != null);
+    const validRows = rows.filter((r) => r.omie_codigo_lancamento != null);
     const skipped = rows.length - validRows.length;
     if (skipped > 0) console.log(`[Fin][${company}] CR p${pagina}: ${skipped} títulos sem código, ignorados`);
 
@@ -452,7 +647,7 @@ async function syncContasReceber(
 }
 
 // ═══════════════ SYNC MOVIMENTAÇÕES FINANCEIRAS ═══════════════
-function buildSyntheticMovementId(company: Company, detalhes: Record<string, any>, resumo: Record<string, any>) {
+function buildSyntheticMovementId(company: Company, detalhes: OmieMovimentoDetalhes, resumo: OmieMovimentoResumo) {
   const source = [
     company,
     detalhes.nCodTitulo ?? "",
@@ -490,7 +685,7 @@ function buildSyntheticMovementId(company: Company, detalhes: Record<string, any
   return hash.toString();
 }
 
-function resolveMovementDate(detalhes: Record<string, any>) {
+function resolveMovementDate(detalhes: OmieMovimentoDetalhes) {
   return parseOmieDate(
     detalhes.dDtPagamento ||
       detalhes.dDtRegistro ||
@@ -500,7 +695,7 @@ function resolveMovementDate(detalhes: Record<string, any>) {
   );
 }
 
-function resolveMovementType(detalhes: Record<string, any>) {
+function resolveMovementType(detalhes: OmieMovimentoDetalhes) {
   const natureza = String(detalhes.cNatureza || "").toUpperCase();
   const grupo = String(detalhes.cGrupo || "").toUpperCase();
 
@@ -516,7 +711,7 @@ function resolveMovementType(detalhes: Record<string, any>) {
   return "S";
 }
 
-function resolveMovementDescription(detalhes: Record<string, any>) {
+function resolveMovementDescription(detalhes: OmieMovimentoDetalhes) {
   const parts = [
     detalhes.cGrupo,
     detalhes.cNumDocFiscal || detalhes.cNumTitulo || detalhes.cNumOS,
@@ -527,7 +722,7 @@ function resolveMovementDescription(detalhes: Record<string, any>) {
 }
 
 async function syncMovimentacoes(
-  db: any,
+  db: SupabaseClient,
   company: Company,
   filtroDataDe?: string,
   filtroDataAte?: string,
@@ -542,34 +737,34 @@ async function syncMovimentacoes(
   let pagesProcessed = 0;
   let consecutiveEmptyPages = 0;
 
-  const firstPage = (await callOmie(
+  const firstPage = await callOmie(
     company,
     "financas/mf/",
     "ListarMovimentos",
     { nPagina: 1, nRegPorPagina: 100 }
-  )) as any;
+  );
 
   if (!firstPage) {
     return { totalSynced: 0, complete: true, nextPage: null, timedOut: false };
   }
 
-  totalPaginas = firstPage.nTotPaginas || 1;
+  totalPaginas = (firstPage.nTotPaginas as number) || 1;
   // Start from the last page (most recent data) and go backwards
   pagina = totalPaginas;
 
   while (pagina >= 1 && pagesProcessed < maxPages && !isTimeBudgetExhausted()) {
-    const result = (await callOmie(
+    const result = await callOmie(
       company,
       "financas/mf/",
       "ListarMovimentos",
       { nPagina: pagina, nRegPorPagina: 100 }
-    )) as any;
+    );
     if (!result) break;
 
-    const movs = result.movimentos || [];
+    const movs: OmieMovimento[] = (result.movimentos as OmieMovimento[] | undefined) || [];
 
     const rows = movs
-      .map((mov: any) => {
+      .map((mov): MovimentoRow | null => {
         const detalhes = mov?.detalhes || {};
         const resumo = mov?.resumo || {};
         const dataMovimento = resolveMovementDate(detalhes);
@@ -600,7 +795,7 @@ async function syncMovimentacoes(
           updated_at: new Date().toISOString(),
         };
       })
-      .filter(Boolean) as Array<Record<string, any>>;
+      .filter((r): r is MovimentoRow => r !== null);
 
     const filteredRows = rows.filter((row) => {
       if (dataInicioIso && row.data_movimento < dataInicioIso) return false;
@@ -653,7 +848,7 @@ async function syncMovimentacoes(
 
 // ═══════════════ CALCULAR DRE SNAPSHOT ═══════════════
 async function calcularDRE(
-  db: any,
+  db: SupabaseClient,
   company: Company,
   ano: number,
   mes: number
@@ -691,9 +886,10 @@ async function calcularDRE(
 
   // Montar mapa de categorias → linha DRE (empresa-específico ganha)
   const catToDre = new Map<string, string>();
-  for (const m of (mappings || []).sort((a: any, b: any) =>
+  const sortedMappings = ((mappings ?? []) as CategoriaDreMappingRow[]).slice().sort((a, b) =>
     a.company === "_default" ? -1 : 1
-  )) {
+  );
+  for (const m of sortedMappings) {
     catToDre.set(m.omie_codigo, m.dre_linha);
   }
 
@@ -840,10 +1036,10 @@ async function calcularDRE(
 
 // ═══════════════ RESUMO RÁPIDO (sem sync, direto do DB) ═══════════════
 async function getResumoFinanceiro(
-  db: any,
+  db: SupabaseClient,
   companies: Company[]
 ) {
-  const resumo: Record<string, any> = {};
+  const resumo: Record<string, unknown> = {};
 
   for (const company of companies) {
     // Saldo total de contas correntes
@@ -881,13 +1077,13 @@ async function getResumoFinanceiro(
       .eq("company", company)
       .eq("status_titulo", "VENCIDO");
 
-    const sum = (arr: any[] | null) =>
-      (arr || []).reduce((s: number, r: any) => s + (r.saldo || 0), 0);
+    const sum = (arr: ContaSaldoRow[] | null) =>
+      (arr || []).reduce((s: number, r) => s + (r.saldo || 0), 0);
 
     resumo[company] = {
       contas_correntes: contas || [],
-      saldo_total_cc: (contas || []).reduce(
-        (s: number, c: any) => s + (c.saldo_atual || 0),
+      saldo_total_cc: ((contas as Array<{ saldo_atual?: number | null }> | null) || []).reduce(
+        (s: number, c) => s + (c.saldo_atual || 0),
         0
       ),
       total_a_receber: sum(crAberto),
@@ -923,7 +1119,7 @@ function formatOmieDate(d: Date): string {
 // ═══════════════ AUTH HELPER ═══════════════
 async function validateCaller(
   req: Request,
-  db: any
+  db: SupabaseClient
 ): Promise<{ authorized: boolean; userId?: string; error?: string }> {
   const authHeader = req.headers.get("authorization");
   if (!authHeader?.startsWith("Bearer ")) {
@@ -966,7 +1162,7 @@ async function validateCaller(
 // ═══════════════ SYNC LOG ═══════════════
 
 async function logSync(
-  db: any,
+  db: SupabaseClient,
   action: string,
   companies: string[],
   triggeredBy: string
@@ -986,9 +1182,9 @@ async function logSync(
 }
 
 async function completeSync(
-  db: any,
+  db: SupabaseClient,
   logId: string,
-  results: any,
+  results: Record<string, unknown> | null,
   errorMsg?: string,
   startTime?: number
 ) {
@@ -1056,7 +1252,7 @@ serve(async (req) => {
     rateLimitHits = 0;
     const logId = await logSync(supabase, action, targetCompanies, auth.userId || "unknown");
 
-    let result: any = {};
+    let result: Record<string, unknown> = {};
 
     switch (action) {
       case "sync_all": {
@@ -1176,7 +1372,7 @@ serve(async (req) => {
 
       // Debug: retorna JSON raw do Omie sem transformação (para validação Onda 1)
       case "debug_raw": {
-        const endpoints: Record<string, { endpoint: string; call: string; params: any }> = {
+        const endpoints: Record<string, { endpoint: string; call: string; params: Record<string, unknown> }> = {
           categorias: { endpoint: "geral/categorias/", call: "ListarCategorias", params: { pagina: 1, registros_por_pagina: 2 } },
           contas_correntes: { endpoint: "geral/contacorrente/", call: "ListarContasCorrentes", params: { pagina: 1, registros_por_pagina: 2 } },
           contas_pagar: { endpoint: "financas/contapagar/", call: "ListarContasPagar", params: { pagina: 1, registros_por_pagina: 2 } },

--- a/supabase/functions/omie-sync-nfes-recebidas/index.ts
+++ b/supabase/functions/omie-sync-nfes-recebidas/index.ts
@@ -21,7 +21,7 @@
 // Body opcional:
 //   { "empresa": "OBEN" | "COLACOR" | "ALL", "dias": 30, "fornecedor_codigo_omie": 8689681266 }
 
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import { createClient, type SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -70,6 +70,76 @@ interface EmpresaSummary {
 
 const TIMEOUT_GUARD_MS = 130_000;
 
+// Tipos minimos pra responses da Omie (campos opcionais — Omie nem sempre devolve tudo)
+interface OmieNFeCabec {
+  nIdReceb?: number;
+  cChaveNFe?: string;
+  cChaveNfe?: string;
+  nIdFornecedor?: number;
+  cRazaoSocial?: string;
+  cNome?: string;
+  cCNPJ_CPF?: string;
+  cNumeroNFe?: string;
+  cSerieNFe?: string;
+  dEmissaoNFe?: string;
+  transporte?: OmieNFeTransporte;
+}
+
+interface OmieNFeInfoCadastro {
+  cCancelada?: string;
+  cRecebido?: string;
+  cFaturado?: string;
+  dRec?: string;
+  hRec?: string;
+}
+
+interface OmieNFeTransporte {
+  cCnpjCpfTransp?: string;
+  cRazaoTransp?: string;
+  cNomeTransp?: string;
+}
+
+interface OmieNFeListItem {
+  cabec?: OmieNFeCabec;
+  infoCadastro?: OmieNFeInfoCadastro;
+  transporte?: OmieNFeTransporte;
+}
+
+interface OmieListRecebimentosResponse {
+  nTotalPaginas?: number;
+  recebimentos?: OmieNFeListItem[];
+  faultstring?: string;
+}
+
+interface OmieItensInfoAdic {
+  nNumPedCompra?: string | number;
+}
+
+interface OmieItemRecebimento {
+  itensInfoAdic?: OmieItensInfoAdic;
+}
+
+interface OmieConsultarRecebimentoResponse extends OmieNFeListItem {
+  itensRecebimento?: OmieItemRecebimento[];
+  faultstring?: string;
+}
+
+type OmieGenericResponse =
+  | OmieListRecebimentosResponse
+  | OmieConsultarRecebimentoResponse
+  | { faultstring?: string; raw?: string };
+
+interface PurchaseOrderTrackingRow {
+  id: string;
+  status?: string | null;
+  t2_data_faturamento?: string | null;
+  t4_data_recebimento?: string | null;
+  nfe_chave_acesso?: string | null;
+  raw_data?: Record<string, unknown> | null;
+  transportadora_nome?: string | null;
+  transportadora_cnpj?: string | null;
+}
+
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
 function formatDateBR(d: Date): string {
@@ -108,7 +178,7 @@ async function callOmie(
   app_secret: string,
   call: "ListarRecebimentos" | "ConsultarRecebimento",
   param: Record<string, unknown>,
-): Promise<any> {
+): Promise<OmieGenericResponse> {
   const body = { call, app_key, app_secret, param: [param] };
 
   let attempt = 0;
@@ -120,8 +190,8 @@ async function callOmie(
       body: JSON.stringify(body),
     });
     const text = await res.text();
-    let json: any;
-    try { json = JSON.parse(text); } catch { json = { raw: text }; }
+    let json: OmieGenericResponse;
+    try { json = JSON.parse(text) as OmieGenericResponse; } catch { json = { raw: text }; }
 
     if (res.status === 429 || (json?.faultstring && /rate limit/i.test(json.faultstring))) {
       console.warn(`[sync-nfes] ${call} rate limit (try ${attempt}/${MAX_RETRIES}) wait ${RETRY_DELAY_MS}ms`);
@@ -153,10 +223,10 @@ interface MappedNFe {
   transp_nome: string | null;
 }
 
-function mapNFe(nfe: any): MappedNFe {
-  const cab = nfe?.cabec ?? {};
-  const info = nfe?.infoCadastro ?? {};
-  const transp = cab?.transporte ?? nfe?.transporte ?? {};
+function mapNFe(nfe: OmieNFeListItem | OmieConsultarRecebimentoResponse): MappedNFe {
+  const cab: OmieNFeCabec = nfe?.cabec ?? {};
+  const info: OmieNFeInfoCadastro = nfe?.infoCadastro ?? {};
+  const transp: OmieNFeTransporte = cab?.transporte ?? nfe?.transporte ?? {};
 
   const cancelada = String(info?.cCancelada ?? "N").toUpperCase() === "S";
   const recebida = String(info?.cRecebido ?? "N").toUpperCase() === "S";
@@ -191,11 +261,11 @@ function mapNFe(nfe: any): MappedNFe {
  * Extrai a lista deduplicada de nNumPedCompra (CNUMERO do pedido de compra)
  * a partir de itensRecebimento[].itensInfoAdic.nNumPedCompra do detalhe da NFe.
  */
-function extractPedidosFromDetalhe(detalhe: any): string[] {
-  const itens: any[] = Array.isArray(detalhe?.itensRecebimento) ? detalhe.itensRecebimento : [];
+function extractPedidosFromDetalhe(detalhe: OmieConsultarRecebimentoResponse | null): string[] {
+  const itens: OmieItemRecebimento[] = Array.isArray(detalhe?.itensRecebimento) ? detalhe.itensRecebimento : [];
   const set = new Set<string>();
   for (const it of itens) {
-    const adic = it?.itensInfoAdic ?? {};
+    const adic: OmieItensInfoAdic = it?.itensInfoAdic ?? {};
     const num = adic?.nNumPedCompra;
     if (num !== undefined && num !== null && String(num).trim() !== "" && String(num).trim() !== "0") {
       set.add(String(num).trim());
@@ -209,7 +279,7 @@ function extractPedidosFromDetalhe(detalhe: any): string[] {
  * com os dados da NFe. Retorna quantas linhas foram atualizadas.
  */
 async function updateLinhasDoPedido(
-  supabase: any,
+  supabase: SupabaseClient,
   empresa: Empresa,
   numeroContrato: string,
   fornecedorCodigo: number | null,
@@ -223,19 +293,20 @@ async function updateLinhasDoPedido(
   if (fornecedorCodigo) {
     q = q.eq("fornecedor_codigo_omie", fornecedorCodigo);
   }
-  const { data: linhas, error: selErr } = await q;
+  const { data, error: selErr } = await q;
   if (selErr) throw selErr;
-  if (!linhas || linhas.length === 0) return 0;
+  const linhas = (data ?? []) as PurchaseOrderTrackingRow[];
+  if (linhas.length === 0) return 0;
 
   let atualizadas = 0;
   for (const linha of linhas) {
-    const currentStatus = String((linha as any).status ?? "");
+    const currentStatus = String(linha.status ?? "");
     let finalStatus: "FATURADO" | "RECEBIDO" | "CANCELADO" = m.status;
     if (currentStatus === "CANCELADO") finalStatus = "CANCELADO";
     else if (currentStatus === "RECEBIDO" && m.status === "FATURADO") finalStatus = "RECEBIDO";
 
     const updateRow: Record<string, unknown> = {
-      t2_data_faturamento: (linha as any).t2_data_faturamento ?? m.data_emissao_iso,
+      t2_data_faturamento: linha.t2_data_faturamento ?? m.data_emissao_iso,
       nfe_chave_acesso: m.chave,
       nfe_numero: m.numero,
       nfe_serie: m.serie,
@@ -243,7 +314,7 @@ async function updateLinhasDoPedido(
       updated_at: new Date().toISOString(),
     };
     if (m.recebida && m.data_recebimento_iso) {
-      updateRow.t4_data_recebimento = (linha as any).t4_data_recebimento ?? m.data_recebimento_iso;
+      updateRow.t4_data_recebimento = linha.t4_data_recebimento ?? m.data_recebimento_iso;
     }
     if (m.transp_cnpj) updateRow.transportadora_cnpj = m.transp_cnpj;
     if (m.transp_nome) updateRow.transportadora_nome = m.transp_nome;
@@ -253,7 +324,7 @@ async function updateLinhasDoPedido(
     const { error: updErr } = await supabase
       .from("purchase_orders_tracking")
       .update(updateRow)
-      .eq("id", (linha as any).id);
+      .eq("id", linha.id);
     if (updErr) throw updErr;
     atualizadas++;
   }
@@ -261,9 +332,9 @@ async function updateLinhasDoPedido(
 }
 
 async function insertOrfa(
-  supabase: any,
+  supabase: SupabaseClient,
   empresa: Empresa,
-  nfe: any,
+  nfe: OmieNFeListItem,
   m: MappedNFe,
   nIdReceb: number,
 ): Promise<void> {
@@ -311,7 +382,7 @@ async function insertOrfa(
 }
 
 async function syncEmpresa(
-  supabase: any,
+  supabase: SupabaseClient,
   empresa: Empresa,
   dias: number,
   fornecedorCodigo: number | undefined,
@@ -352,7 +423,7 @@ async function syncEmpresa(
   let totalPaginas = 1;
 
   while (pagina <= totalPaginas) {
-    let resp: any;
+    let resp: OmieListRecebimentosResponse;
     try {
       const param: Record<string, unknown> = {
         nPagina: pagina,
@@ -364,7 +435,7 @@ async function syncEmpresa(
         cEtapa: "",
       };
       if (fornecedorCodigo) param.nIdFornecedor = fornecedorCodigo;
-      resp = await callOmie(app_key, app_secret, "ListarRecebimentos", param);
+      resp = (await callOmie(app_key, app_secret, "ListarRecebimentos", param)) as OmieListRecebimentosResponse;
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       console.error(`[sync-nfes] ${empresa} pag=${pagina} ListarRecebimentos erro: ${msg}`);
@@ -384,7 +455,7 @@ async function syncEmpresa(
     }
 
     totalPaginas = Number(resp?.nTotalPaginas ?? 1);
-    const nfes: any[] = Array.isArray(resp?.recebimentos) ? resp.recebimentos : [];
+    const nfes: OmieNFeListItem[] = Array.isArray(resp?.recebimentos) ? resp.recebimentos : [];
     console.log(`[sync-nfes] ${empresa} pag=${pagina}/${totalPaginas} nfes=${nfes.length}`);
 
     for (const nfe of nfes) {
@@ -404,9 +475,9 @@ async function syncEmpresa(
 
         // ConsultarRecebimento → busca itens e nNumPedCompra
         await sleep(RATE_LIMIT_DELAY_MS);
-        let detalhe: any;
+        let detalhe: OmieConsultarRecebimentoResponse | null;
         try {
-          detalhe = await callOmie(app_key, app_secret, "ConsultarRecebimento", { nIdReceb });
+          detalhe = (await callOmie(app_key, app_secret, "ConsultarRecebimento", { nIdReceb })) as OmieConsultarRecebimentoResponse;
           summary.consultas_detalhadas++;
         } catch (errDet) {
           const msgDet = errDet instanceof Error ? errDet.message : String(errDet);
@@ -471,7 +542,7 @@ async function syncEmpresa(
  * chama ConsultarRecebimento(cChaveNFe) e atualiza raw_data + campos NULL.
  */
 async function backfillRawData(
-  supabase: any,
+  supabase: SupabaseClient,
   empresa: Empresa,
   fornecedorCodigo: number | undefined,
   t0: number,
@@ -499,8 +570,9 @@ async function backfillRawData(
     return out;
   }
 
-  const incompletos = (linhas ?? []).filter((l: any) => {
-    const rd = l.raw_data;
+  const linhasTyped = (linhas ?? []) as PurchaseOrderTrackingRow[];
+  const incompletos = linhasTyped.filter((l) => {
+    const rd = l.raw_data as { cabec?: { nIdReceb?: number } } | null | undefined;
     if (!rd || typeof rd !== "object") return true;
     const cab = rd.cabec;
     if (!cab || typeof cab !== "object") return true;
@@ -517,7 +589,7 @@ async function backfillRawData(
       break;
     }
 
-    const chave = String((linha as any).nfe_chave_acesso ?? "").replace(/\D/g, "").slice(0, 44);
+    const chave = String(linha.nfe_chave_acesso ?? "").replace(/\D/g, "").slice(0, 44);
     if (chave.length !== 44) {
       out.erros++;
       continue;
@@ -525,7 +597,7 @@ async function backfillRawData(
 
     try {
       await sleep(RATE_LIMIT_DELAY_MS);
-      const detalhe = await callOmie(app_key, app_secret, "ConsultarRecebimento", { cChaveNFe: chave });
+      const detalhe = (await callOmie(app_key, app_secret, "ConsultarRecebimento", { cChaveNFe: chave })) as OmieConsultarRecebimentoResponse;
 
       if (!detalhe || detalhe?.faultstring) {
         const fs = String(detalhe?.faultstring ?? "vazio");
@@ -539,23 +611,23 @@ async function backfillRawData(
         raw_data: detalhe,
         updated_at: new Date().toISOString(),
       };
-      if (!(linha as any).t2_data_faturamento && m.data_emissao_iso) {
+      if (!linha.t2_data_faturamento && m.data_emissao_iso) {
         updateRow.t2_data_faturamento = m.data_emissao_iso;
       }
-      if (!(linha as any).t4_data_recebimento && m.recebida && m.data_recebimento_iso) {
+      if (!linha.t4_data_recebimento && m.recebida && m.data_recebimento_iso) {
         updateRow.t4_data_recebimento = m.data_recebimento_iso;
       }
-      if (!(linha as any).transportadora_nome && m.transp_nome) {
+      if (!linha.transportadora_nome && m.transp_nome) {
         updateRow.transportadora_nome = m.transp_nome;
       }
-      if (!(linha as any).transportadora_cnpj && m.transp_cnpj) {
+      if (!linha.transportadora_cnpj && m.transp_cnpj) {
         updateRow.transportadora_cnpj = m.transp_cnpj;
       }
 
       const { error: updErr } = await supabase
         .from("purchase_orders_tracking")
         .update(updateRow)
-        .eq("id", (linha as any).id);
+        .eq("id", linha.id);
       if (updErr) {
         console.error(`[backfill] ${empresa} chave=${chave} update erro: ${updErr.message}`);
         out.erros++;

--- a/supabase/functions/omie-vendas-sync/index.ts
+++ b/supabase/functions/omie-vendas-sync/index.ts
@@ -1,6 +1,174 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
-import { createClient } from "npm:@supabase/supabase-js@2";
+import { createClient, type SupabaseClient } from "npm:@supabase/supabase-js@2";
 import { authorizeCronOrStaff } from "../_shared/auth.ts";
+
+type OmieGenericResponse = Record<string, unknown> & { faultstring?: string; codigo_status?: number | string; descricao_status?: string };
+
+interface OmieProdutoCadastro {
+  codigo_produto?: number;
+  codigo_produto_integracao?: string | null;
+  codigo?: string;
+  descricao?: string;
+  unidade?: string;
+  ncm?: string | null;
+  valor_unitario?: number;
+  quantidade_estoque?: number;
+  inativo?: string;
+  tipo?: string;
+  descricao_familia?: string;
+  imagens?: Array<{ url_imagem?: string }>;
+  marca?: string;
+  modelo?: string;
+  peso_bruto?: number;
+  peso_liq?: number;
+  cfop?: string;
+  recomendacoes_fiscais?: { tipo_produto?: string };
+}
+
+interface OmiePosEstoque {
+  nCodProd?: number;
+  nSaldo?: number;
+}
+
+interface OmieClienteCadastro {
+  codigo_cliente_omie?: number;
+  razao_social?: string;
+  nome_fantasia?: string;
+  cnpj_cpf?: string;
+  codigo_vendedor?: number | null;
+  recomendacoes?: { codigo_vendedor?: number | null };
+  endereco?: string;
+  endereco_numero?: string;
+  complemento?: string;
+  bairro?: string;
+  cidade?: string;
+  estado?: string;
+  cep?: string;
+  telefone1_ddd?: string;
+  telefone1_numero?: string;
+  contato?: string;
+  tags?: Array<{ tag?: string } | string>;
+  atividade?: string;
+  codigo_transportadora?: number | string;
+}
+
+interface OmieParcela {
+  cInativo?: string;
+  cCodigo?: string;
+  nCodigo?: number;
+  cDescricao?: string;
+  cDescParcela?: string;
+}
+
+interface OmieDetalheItem {
+  ide?: { codigo_item?: number; codigo_item_integracao?: number };
+  produto?: {
+    codigo_produto?: number;
+    descricao?: string;
+    quantidade?: number;
+    valor_unitario?: number;
+    desconto?: number;
+    cfop?: string;
+  };
+  imposto?: { cfop?: string };
+}
+
+interface OmiePedidoCabecalho {
+  codigo_cliente?: number;
+  codigo_pedido?: number;
+  numero_pedido?: number | string;
+  etapa?: string;
+  data_previsao?: string;
+  observacoes_pedido?: string;
+  codigo_parcela?: string;
+}
+
+interface OmiePedidoVendaProduto {
+  cabecalho?: OmiePedidoCabecalho;
+  det?: OmieDetalheItem[];
+  infoCadastro?: { dInc?: string };
+}
+
+interface OmieListarPedidosResponse {
+  pedido_venda_produto?: OmiePedidoVendaProduto[];
+  total_de_paginas?: number;
+}
+
+interface ProfileRow { user_id: string; document?: string | null }
+interface SalesOrderHashRow { hash_payload?: string | null }
+interface OmieClienteMapRow { omie_codigo_cliente: number; user_id: string | null }
+interface OmieProductMapRow { id: string; omie_codigo_produto: number }
+interface AdminProfileRow { user_id?: string }
+
+interface OrderItemPayload {
+  omie_codigo_produto?: number;
+  descricao?: string;
+  quantidade: number;
+  valor_unitario: number;
+  desconto?: number;
+}
+
+interface OrderBatchRow {
+  customer_user_id: string;
+  created_by: string;
+  items: OrderItemPayload[];
+  subtotal: number;
+  discount: number;
+  total: number;
+  status: string;
+  omie_pedido_id: number;
+  omie_numero_pedido: string;
+  account: Account;
+  hash_payload: string;
+  created_at: string;
+  notes: string | null;
+  customer_address: string | null;
+  customer_phone: string | null;
+}
+
+interface OrderItemBatchRow {
+  sales_order_id: string;
+  customer_user_id: string;
+  product_id: string | null;
+  omie_codigo_produto: number | null;
+  quantity: number;
+  unit_price: number;
+  discount: number;
+  hash_payload: string;
+}
+
+interface PriceHistoryBatchRow {
+  customer_user_id: string;
+  product_id: string;
+  unit_price: number;
+  sales_order_id: string;
+  created_at: string;
+}
+
+interface EditItemInput {
+  product_id?: string | null;
+  omie_codigo_produto?: number;
+  codigo?: string;
+  descricao?: string;
+  unidade?: string;
+  quantidade: number;
+  valor_unitario: number;
+  tint_cor_id?: string;
+  tint_nome_cor?: string;
+}
+
+interface OpItemInput {
+  product_id?: string | null;
+  omie_codigo_produto?: number;
+  codigo?: string;
+  descricao?: string;
+  quantidade: number;
+  unidade?: string;
+  assigned_to?: string | null;
+  ready_by_date?: string | null;
+}
+
+interface CreatedOP { id?: string; omie_ordem_id: number | null; omie_ordem_numero: string | null; descricao?: string }
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -30,7 +198,7 @@ async function callOmieVendasApi(
   call: string,
   params: Record<string, unknown>,
   account: Account = "oben"
-) {
+): Promise<OmieGenericResponse | null> {
   const { APP_KEY, APP_SECRET } = getCredentials(account);
 
   const body = {
@@ -50,7 +218,7 @@ async function callOmieVendasApi(
       body: JSON.stringify(body),
     });
 
-    const result = await response.json();
+    const result = (await response.json()) as OmieGenericResponse;
 
     if (result.faultstring) {
       const fs = String(result.faultstring);
@@ -100,6 +268,7 @@ async function callOmieVendasApi(
 
     return result;
   }
+  return null;
 }
 
 function getOmieItemIntegrationCode(index: number): number {
@@ -115,7 +284,7 @@ function getOmieItemIntegrationCode(index: number): number {
 }
 
 // Sincronizar todos os produtos da empresa de vendas
-async function syncProducts(supabase: any, startPage = 1, maxPages = 12, account: Account = "oben") {
+async function syncProducts(supabase: SupabaseClient, startPage = 1, maxPages = 12, account: Account = "oben") {
   let pagina = startPage;
   let totalPaginas = 1;
   let totalSynced = 0;
@@ -132,20 +301,20 @@ async function syncProducts(supabase: any, startPage = 1, maxPages = 12, account
         filtrar_apenas_omiepdv: "N",
       },
       account
-    ) as any;
+    );
 
     if (!result) {
       console.log(`[Omie Vendas][${account}] Products sync interrupted by rate limit at page ${pagina}`);
       break;
     }
 
-    totalPaginas = result.total_de_paginas || 1;
-    const produtos = result.produto_servico_cadastro || [];
+    totalPaginas = (result.total_de_paginas as number) || 1;
+    const produtos: OmieProdutoCadastro[] = (result.produto_servico_cadastro as OmieProdutoCadastro[] | undefined) || [];
 
     const EXCLUDED_FAMILIES = ['imobilizado', 'uso e consumo', 'matérias primas para conversão de cintas', 'jumbos de lixa para discos', 'material para tingimix'];
 
     const rows = produtos
-      .filter((prod: any) => {
+      .filter((prod) => {
         // Excluir produtos do tipo Kit (apenas Simples)
         if (prod.tipo && prod.tipo.toUpperCase() === "K") return false;
         const familia = (prod.descricao_familia || '').toLowerCase().trim();
@@ -154,7 +323,7 @@ async function syncProducts(supabase: any, startPage = 1, maxPages = 12, account
         if (desc.includes('810ml') || desc.includes('810 ml')) return false;
         return true;
       })
-      .map((prod: any) => ({
+      .map((prod) => ({
         omie_codigo_produto: prod.codigo_produto,
         omie_codigo_produto_integracao: prod.codigo_produto_integracao || null,
         codigo: prod.codigo || `PROD-${prod.codigo_produto}`,
@@ -198,7 +367,7 @@ async function syncProducts(supabase: any, startPage = 1, maxPages = 12, account
 }
 
 // Sincronizar estoque real dos produtos via ListarPosEstoque (paginado)
-async function syncEstoque(supabase: any, startPage = 1, maxPages = 3, account: Account = "oben") {
+async function syncEstoque(supabase: SupabaseClient, startPage = 1, maxPages = 3, account: Account = "oben") {
   let pagina = startPage;
   let totalPaginas = 1;
   let totalUpdated = 0;
@@ -214,19 +383,19 @@ async function syncEstoque(supabase: any, startPage = 1, maxPages = 3, account: 
         dDataPosicao: new Date().toLocaleDateString("pt-BR"),
       },
       account
-    ) as any;
+    );
 
     if (!result) {
       console.log(`[Omie Vendas][${account}] Estoque sync interrupted by rate limit at page ${pagina}`);
       break;
     }
 
-    totalPaginas = result.nTotPaginas || 1;
-    const produtos = Array.isArray(result.produtos) ? result.produtos : [];
+    totalPaginas = (result.nTotPaginas as number) || 1;
+    const produtos: OmiePosEstoque[] = Array.isArray(result.produtos) ? (result.produtos as OmiePosEstoque[]) : [];
     const updatedAt = new Date().toISOString();
 
     const productCodes = produtos
-      .map((prod: any) => Number(prod.nCodProd))
+      .map((prod) => Number(prod.nCodProd))
       .filter((code: number) => Number.isFinite(code));
 
     if (productCodes.length > 0) {
@@ -239,11 +408,12 @@ async function syncEstoque(supabase: any, startPage = 1, maxPages = 3, account: 
       if (existingError) {
         console.error(`[Omie Vendas][${account}] Erro buscando produtos para atualizar estoque na página ${pagina}:`, existingError);
       } else {
-        const existingMap = new Map(
-          ((existingProducts ?? []) as any[]).map((product: any) => [Number(product.omie_codigo_produto), product.id])
+        const existingMap = new Map<number, string>(
+          ((existingProducts ?? []) as OmieProductMapRow[]).map((product) => [Number(product.omie_codigo_produto), product.id])
         );
 
-        const stockRows = (produtos as any[]).reduce<Array<{ id: string; omie_codigo_produto: number; account: Account; estoque: number; updated_at: string }>>((rows: Array<{ id: string; omie_codigo_produto: number; account: Account; estoque: number; updated_at: string }>, prod: any) => {
+        type StockRow = { id: string; omie_codigo_produto: number; account: Account; estoque: number; updated_at: string };
+        const stockRows = produtos.reduce<StockRow[]>((rows, prod) => {
           const omieCodigoProduto = Number(prod.nCodProd);
           const existingId = existingMap.get(omieCodigoProduto);
 
@@ -330,12 +500,13 @@ async function listarClientesVendas(searchTerm: string, account: Account = "oben
         },
       },
       account
-    ) as any;
+    );
 
-    if (result.clientes_cadastro) {
-      for (const c of result.clientes_cadastro) {
+    const clientes = result?.clientes_cadastro as OmieClienteCadastro[] | undefined;
+    if (clientes) {
+      for (const c of clientes) {
             results.push({
-              codigo_cliente: c.codigo_cliente_omie,
+              codigo_cliente: c.codigo_cliente_omie ?? 0,
               razao_social: c.razao_social || "",
               nome_fantasia: c.nome_fantasia || "",
               cnpj_cpf: c.cnpj_cpf || "",
@@ -349,7 +520,7 @@ async function listarClientesVendas(searchTerm: string, account: Account = "oben
               cep: c.cep || "",
               telefone: c.telefone1_ddd && c.telefone1_numero ? `(${c.telefone1_ddd}) ${c.telefone1_numero}` : "",
               contato: c.contato || "",
-              tags: (c.tags || []).map((t: any) => t.tag || t),
+              tags: (c.tags || []).map((t) => typeof t === 'string' ? t : (t.tag ?? '')),
               atividade: c.atividade || "",
             });
       }
@@ -373,13 +544,14 @@ async function listarClientesVendas(searchTerm: string, account: Account = "oben
           },
         },
         account
-      ) as any;
+      );
 
-      if (result.clientes_cadastro) {
-        for (const c of result.clientes_cadastro) {
+      const clientes2 = result?.clientes_cadastro as OmieClienteCadastro[] | undefined;
+      if (clientes2) {
+        for (const c of clientes2) {
           if (!results.find(r => r.codigo_cliente === c.codigo_cliente_omie)) {
             results.push({
-              codigo_cliente: c.codigo_cliente_omie,
+              codigo_cliente: c.codigo_cliente_omie ?? 0,
               razao_social: c.razao_social || "",
               nome_fantasia: c.nome_fantasia || "",
               cnpj_cpf: c.cnpj_cpf || "",
@@ -393,7 +565,7 @@ async function listarClientesVendas(searchTerm: string, account: Account = "oben
               cep: c.cep || "",
               telefone: c.telefone1_ddd && c.telefone1_numero ? `(${c.telefone1_ddd}) ${c.telefone1_numero}` : "",
               contato: c.contato || "",
-              tags: (c.tags || []).map((t: any) => t.tag || t),
+              tags: (c.tags || []).map((t) => typeof t === 'string' ? t : (t.tag ?? '')),
               atividade: c.atividade || "",
             });
           }
@@ -420,13 +592,14 @@ async function buscarClienteVendas(document: string, account: Account = "oben") 
       clientesFiltro: { cnpj_cpf: documentClean },
     },
     account
-  ) as any;
+  );
 
-  if (!result || !result.clientes_cadastro?.[0]?.codigo_cliente_omie) {
+  const clientesArr = result?.clientes_cadastro as OmieClienteCadastro[] | undefined;
+  if (!result || !clientesArr?.[0]?.codigo_cliente_omie) {
     return null;
   }
 
-  const cliente = result.clientes_cadastro[0];
+  const cliente = clientesArr[0];
   const codigoVendedor = cliente.recomendacoes?.codigo_vendedor || cliente.codigo_vendedor || null;
   console.log(`[Omie Vendas][${account}] Cliente ${cliente.codigo_cliente_omie} vendedor: recomendacoes=${cliente.recomendacoes?.codigo_vendedor}, root=${cliente.codigo_vendedor}, resolved=${codigoVendedor}`);
   return {
@@ -449,10 +622,10 @@ async function buscarHistoricoPrecosOmie(codigoCliente: number, account: Account
         filtrar_apenas_inclusao: "N",
       },
       account
-    ) as any;
+    );
 
     const precos: Record<number, number> = {};
-    const pedidos = result?.pedido_venda_produto || [];
+    const pedidos: OmiePedidoVendaProduto[] = (result?.pedido_venda_produto as OmiePedidoVendaProduto[] | undefined) || [];
 
     // Percorrer pedidos do mais recente ao mais antigo
     for (const pedido of pedidos) {
@@ -488,7 +661,7 @@ async function listarFormasPagamento(account: Account = "oben") {
   ];
 
   try {
-    const allParcelas: any[] = [];
+    const allParcelas: OmieParcela[] = [];
     let pagina = 1;
     let totalPaginas = 1;
 
@@ -498,10 +671,14 @@ async function listarFormasPagamento(account: Account = "oben") {
         "ListarParcelas",
         { pagina, registros_por_pagina: 500 },
         account
-      ) as any;
+      );
 
-      const parcelas = result.cadastros || result.parcela_cadastro || result.lista_parcelas || [];
-      totalPaginas = result.total_de_paginas || 1;
+      const parcelas: OmieParcela[] =
+        (result?.cadastros as OmieParcela[] | undefined)
+        || (result?.parcela_cadastro as OmieParcela[] | undefined)
+        || (result?.lista_parcelas as OmieParcela[] | undefined)
+        || [];
+      totalPaginas = (result?.total_de_paginas as number) || 1;
       console.log(`[Omie Vendas][${account}] ListarParcelas página ${pagina}/${totalPaginas} retornou ${parcelas.length} parcelas.`);
       allParcelas.push(...parcelas);
       pagina++;
@@ -509,12 +686,12 @@ async function listarFormasPagamento(account: Account = "oben") {
 
     if (allParcelas.length > 0) {
       return allParcelas
-        .filter((f: any) => f.cInativo !== "S")
-        .map((f: any) => ({
+        .filter((f) => f.cInativo !== "S")
+        .map((f) => ({
           codigo: f.cCodigo || f.nCodigo?.toString() || '',
           descricao: f.cDescricao || f.cDescParcela || '',
         }))
-        .filter((f: any) => f.codigo && f.descricao);
+        .filter((f) => f.codigo && f.descricao);
     }
   } catch (error) {
     console.error(`[Omie Vendas][${account}] Erro ao buscar parcelas:`, error);
@@ -538,9 +715,9 @@ async function buscarUltimaParcela(codigoCliente: number, account: Account = "ob
         filtrar_apenas_inclusao: "N",
       },
       account
-    ) as any;
+    );
 
-    const pedidos = result?.pedido_venda_produto || [];
+    const pedidos: OmiePedidoVendaProduto[] = (result?.pedido_venda_produto as OmiePedidoVendaProduto[] | undefined) || [];
     const parcelaCount: Record<string, number> = {};
     let ultimaParcela: string | null = null;
 
@@ -566,7 +743,7 @@ async function buscarUltimaParcela(codigoCliente: number, account: Account = "ob
 
 // Sincronizar pedidos de venda do Omie para o banco local (OPTIMIZED)
 async function syncPedidos(
-  supabase: any,
+  supabase: SupabaseClient,
   startPage = 1,
   maxPages = 10,
   account: Account = "oben",
@@ -683,12 +860,16 @@ async function syncPedidos(
     if (clientCache.has(codigoCliente)) return clientCache.get(codigoCliente) || null;
     // Fallback: call Omie API only for clients NOT in omie_clientes table
     try {
-      const result = await callOmieVendasApi(
+      const result = (await callOmieVendasApi(
         "geral/clientes/",
         "ConsultarCliente",
         { codigo_cliente_omie: codigoCliente },
         account
-      ) as any;
+      )) as OmieClienteCadastro | null;
+      if (!result) {
+        clientCache.set(codigoCliente, null);
+        return null;
+      }
       const doc = (result.cnpj_cpf || '').replace(/\D/g, '');
       // Cache address/phone from ConsultarCliente result
       const addrParts = [result.endereco, result.endereco_numero, result.complemento, result.bairro, result.cidade, result.estado, result.cep].filter(Boolean);
@@ -711,12 +892,12 @@ async function syncPedidos(
   async function getClientAddressPhone(codigoCliente: number): Promise<{ address: string; phone: string }> {
     if (clientAddressCache.has(codigoCliente)) return clientAddressCache.get(codigoCliente)!;
     try {
-      const result = await callOmieVendasApi(
+      const result = (await callOmieVendasApi(
         "geral/clientes/",
         "ConsultarCliente",
         { codigo_cliente_omie: codigoCliente },
         account
-      ) as any;
+      )) as OmieClienteCadastro | null;
       if (result) {
         const addrParts = [
           result.endereco,
@@ -747,18 +928,18 @@ async function syncPedidos(
       "ListarPedidos",
       listParams,
       account
-    ) as any;
+    );
 
     if (!result) {
       console.log(`[sync_pedidos][${account}] Pedidos sync interrupted by rate limit at page ${pagina}`);
       break;
     }
 
-    totalPaginas = result.total_de_paginas || 1;
-    const pedidos = result.pedido_venda_produto || [];
+    totalPaginas = (result.total_de_paginas as number) || 1;
+    const pedidos: OmiePedidoVendaProduto[] = (result.pedido_venda_produto as OmiePedidoVendaProduto[] | undefined) || [];
 
     // Resolve only unknown client codes (most should be in cache from omie_clientes)
-    const uniqueClientCodes = [...new Set(pedidos.map((p: any) => p.cabecalho?.codigo_cliente).filter(Boolean))] as number[];
+    const uniqueClientCodes = [...new Set(pedidos.map((p) => p.cabecalho?.codigo_cliente).filter((c): c is number => Boolean(c)))];
     const unknownCodes = uniqueClientCodes.filter(c => !clientCache.has(c));
     if (unknownCodes.length > 0) {
       console.log(`[sync_pedidos][${account}] Resolving ${unknownCodes.length} unknown clients via API (concurrency=5)`);
@@ -781,8 +962,8 @@ async function syncPedidos(
     }
 
     // ── Prepare batch arrays ──
-    const orderBatch: any[] = [];
-    const orderMeta: Array<{ hashPayload: string; detalhes: any[]; customerUserId: string; createdAt: string }> = [];
+    const orderBatch: OrderBatchRow[] = [];
+    const orderMeta: Array<{ hashPayload: string; detalhes: OmieDetalheItem[]; customerUserId: string; createdAt: string }> = [];
 
     for (const pedido of pedidos) {
       const cab = pedido.cabecalho || {};
@@ -800,8 +981,8 @@ async function syncPedidos(
       if (existingHashes.has(hashPayload)) { skippedExisting++; continue; }
       existingHashes.add(hashPayload); // prevent duplicates within same run
 
-      const detalhes = pedido.det || [];
-      const itemsJson: any[] = [];
+      const detalhes: OmieDetalheItem[] = pedido.det || [];
+      const itemsJson: OrderItemPayload[] = [];
       let subtotal = 0;
 
       for (const det of detalhes) {
@@ -875,19 +1056,19 @@ async function syncPedidos(
             totalSynced++;
             // Insert items + prices for this order
             const meta = orderMeta[idx];
-            const itemRows = meta.detalhes.map((det: any) => {
+            const itemRows = meta.detalhes.map((det) => {
               const prod = det.produto || {};
               return {
                 sales_order_id: single.id,
                 customer_user_id: meta.customerUserId,
-                product_id: productMap.get(prod.codigo_produto) || null,
+                product_id: (prod.codigo_produto ? productMap.get(prod.codigo_produto) : null) || null,
                 omie_codigo_produto: prod.codigo_produto || null,
                 quantity: prod.quantidade || 1,
                 unit_price: prod.valor_unitario || 0,
                 discount: prod.desconto || 0,
                 hash_payload: `${meta.hashPayload}_${prod.codigo_produto}`,
               };
-            }).filter((i: any) => i.omie_codigo_produto);
+            }).filter((i) => i.omie_codigo_produto);
             if (itemRows.length > 0) {
               await supabase.from('order_items').insert(itemRows);
               totalItems += itemRows.length;
@@ -902,8 +1083,8 @@ async function syncPedidos(
         for (const o of insertedOrders) if (o.hash_payload) hashToId.set(o.hash_payload, o.id);
 
         // ── Batch insert order_items ──
-        const allItemRows: any[] = [];
-        const allPriceRows: any[] = [];
+        const allItemRows: OrderItemBatchRow[] = [];
+        const allPriceRows: PriceHistoryBatchRow[] = [];
 
         for (const meta of orderMeta) {
           const orderId = hashToId.get(meta.hashPayload);
@@ -974,10 +1155,10 @@ async function buscarTransportadoraPorNome(nomeTransportadora: string, account: 
         clientesFiltro: { razao_social: nomeTransportadora },
       },
       account
-    ) as any;
-    const clientes = result?.clientes_cadastro || [];
+    );
+    const clientes: OmieClienteCadastro[] = (result?.clientes_cadastro as OmieClienteCadastro[] | undefined) || [];
     if (clientes.length > 0) {
-      const codigo = clientes[0].codigo_cliente_omie;
+      const codigo = clientes[0].codigo_cliente_omie ?? null;
       console.log(`[Omie Vendas][${account}] Transportadora '${nomeTransportadora}' encontrada: ${codigo}`);
       return codigo;
     }
@@ -990,12 +1171,12 @@ async function buscarTransportadoraPorNome(nomeTransportadora: string, account: 
 // Buscar transportadora do cadastro do cliente
 async function buscarTransportadoraCliente(codigoCliente: number, account: Account): Promise<number | null> {
   try {
-    const result = await callOmieVendasApi(
+    const result = (await callOmieVendasApi(
       "geral/clientes/",
       "ConsultarCliente",
       { codigo_cliente_omie: codigoCliente },
       account
-    ) as any;
+    )) as OmieClienteCadastro | null;
     const codTransp = result?.codigo_transportadora;
     if (codTransp && Number(codTransp) > 0) {
       console.log(`[Omie Vendas][${account}] Cliente ${codigoCliente} tem transportadora: ${codTransp}`);
@@ -1036,7 +1217,7 @@ function getAccountConfig(account: Account) {
 
 // Criar pedido de venda no Omie
 async function criarPedidoVenda(
-  supabase: any,
+  supabase: SupabaseClient,
   salesOrderId: string,
   codigoCliente: number,
   codigoVendedor: number | null,
@@ -1069,7 +1250,7 @@ async function criarPedidoVenda(
     };
     // Add tint color info or ordem de compra to item observations + NF-e
     if (ordemCompra) {
-      (entry as any).inf_adic = {
+      entry.inf_adic = {
         dados_adicionais_item: ordemCompra,
         numero_pedido_compra: ordemCompra,
       };
@@ -1088,10 +1269,10 @@ async function criarPedidoVenda(
         if (embMatch) embTag = embMatch[1].replace(',', '.') + 'ML';
       }
       const corInfo = `Cor: ${corLabel}${embTag ? ` - ${embTag}` : ''}`;
-      (entry as any).inf_adic = {
+      entry.inf_adic = {
         dados_adicionais_item: corInfo,
       };
-      (entry as any).observacao = {
+      entry.observacao = {
         obs_item: corInfo,
       };
     }
@@ -1149,7 +1330,7 @@ async function criarPedidoVenda(
     "IncluirPedido",
     payload,
     account
-  ) as any;
+  );
 
   if (!result) {
     throw new Error(
@@ -1157,8 +1338,8 @@ async function criarPedidoVenda(
     );
   }
 
-  const omie_pedido_id = result.codigo_pedido || null;
-  const omie_numero_pedido = result.numero_pedido || cCodIntPed;
+  const omie_pedido_id = (result.codigo_pedido as number | undefined) || null;
+  const omie_numero_pedido = (result.numero_pedido as string | number | undefined) || cCodIntPed;
 
   // Atualizar sales_order com dados do Omie
   await supabase
@@ -1268,10 +1449,11 @@ serve(async (req) => {
         if (telefone) clienteParams.telefone1_numero = telefone;
         if (contato) clienteParams.contato = contato;
         console.log(`[Omie Vendas][${account}] Criando cliente: ${razao_social} (${docClean})`);
-        const createRes = await callOmieVendasApi("geral/clientes/", "IncluirCliente", clienteParams, account) as any;
+        const createRes = await callOmieVendasApi("geral/clientes/", "IncluirCliente", clienteParams, account);
+        const createResTyped = createRes as { codigo_cliente_omie?: number; nCodCli?: number } | null;
         result = {
           success: true,
-          codigo_cliente: createRes.codigo_cliente_omie || createRes.nCodCli,
+          codigo_cliente: createResTyped?.codigo_cliente_omie ?? createResTyped?.nCodCli ?? null,
           razao_social,
           codigo_vendedor: null,
           created: true,
@@ -1346,7 +1528,8 @@ serve(async (req) => {
         const editConfig = getAccountConfig(editAccount);
 
         // Build updated items payload for local DB
-        const updatedItemsPayload = editItems.map((item: any) => ({
+        const editItemsTyped: EditItemInput[] = editItems;
+        const updatedItemsPayload = editItemsTyped.map((item) => ({
           product_id: item.product_id,
           omie_codigo_produto: item.omie_codigo_produto,
           codigo: item.codigo,
@@ -1357,16 +1540,19 @@ serve(async (req) => {
           valor_total: item.quantidade * item.valor_unitario,
           ...(item.tint_cor_id ? { tint_cor_id: item.tint_cor_id, tint_nome_cor: item.tint_nome_cor } : {}),
         }));
-        const updatedSubtotal = updatedItemsPayload.reduce((s: number, i: any) => s + i.valor_total, 0);
+        const updatedSubtotal = updatedItemsPayload.reduce((s: number, i) => s + i.valor_total, 0);
 
         // Build Omie payload
-        const origPayload = existingOrder.omie_payload as any;
+        const origPayload = existingOrder.omie_payload as {
+          informacoes_adicionais?: { codVend?: number };
+          frete?: { codigo_transportadora?: number };
+        } | null;
         const codigoPedido = Number(existingOrder.omie_pedido_id);
-        const buildExpectedSignature = (items: any[]) => items
+        const buildExpectedSignature = (items: EditItemInput[]) => items
           .map((item) => `${Number(item.omie_codigo_produto)}:${Number(item.quantidade)}:${Number(item.valor_unitario).toFixed(4)}`)
           .sort()
           .join("|");
-        const buildOmieSignature = (items: any[]) => items
+        const buildOmieSignature = (items: OmieDetalheItem[]) => items
           .map((item) => {
             const prod = item?.produto || {};
             return `${Number(prod.codigo_produto)}:${Number(prod.quantidade)}:${Number(prod.valor_unitario).toFixed(4)}`;
@@ -1375,21 +1561,22 @@ serve(async (req) => {
           .join("|");
 
         // Step 1: Consult the real order in Omie to get actual item codes
-        let omieCurrentItems: any[] = [];
+        let omieCurrentItems: OmieDetalheItem[] = [];
         try {
-          const consultResult = await callOmieVendasApi(
+          const consultResult = (await callOmieVendasApi(
             "produtos/pedido/",
             "ConsultarPedido",
             { codigo_pedido: codigoPedido },
             editAccount
-          ) as any;
+          )) as { pedido_venda_produto?: { det?: OmieDetalheItem[] }; det?: OmieDetalheItem[] } | null;
           // Omie returns items under pedido_venda_produto.det
           omieCurrentItems = consultResult?.pedido_venda_produto?.det
             || consultResult?.det
             || [];
           console.log(`[Omie Vendas][${editAccount}] Pedido consultado: ${omieCurrentItems.length} itens no Omie`);
-        } catch (consultErr: any) {
-          console.warn(`[Omie Vendas][${editAccount}] Erro ao consultar pedido: ${consultErr.message}`);
+        } catch (consultErr) {
+          const msg = consultErr instanceof Error ? consultErr.message : String(consultErr);
+          console.warn(`[Omie Vendas][${editAccount}] Erro ao consultar pedido: ${msg}`);
         }
 
         // Step 2: Delete all existing items
@@ -1409,14 +1596,15 @@ serve(async (req) => {
                 editAccount
               );
               console.log(`[Omie Vendas][${editAccount}] Item ${codItemInt || codItem} excluído`);
-            } catch (delErr: any) {
-              throw new Error(`Falha ao excluir item existente do pedido no Omie: ${delErr.message}`);
+            } catch (delErr) {
+              const msg = delErr instanceof Error ? delErr.message : String(delErr);
+              throw new Error(`Falha ao excluir item existente do pedido no Omie: ${msg}`);
             }
           }
         }
 
         // Step 3: Add each new item individually
-        const newDetForPayload: any[] = [];
+        const newDetForPayload: Array<{ ide: { codigo_item_integracao: number }; produto: { codigo_produto: number; quantidade: number; valor_unitario: number } }> = [];
 
         // Extract default CFOP from existing items (before deletion)
         const defaultCfop = (() => {
@@ -1459,8 +1647,9 @@ serve(async (req) => {
           try {
             await callOmieVendasApi("produtos/pedidovenda/", "IncluirItemPedido", inclPayload, editAccount);
             console.log(`[Omie Vendas][${editAccount}] Item ${index + 1} incluído: ${item.descricao}`);
-          } catch (inclErr: any) {
-            throw new Error(`Falha ao incluir item ${index + 1} no Omie: ${inclErr.message}`);
+          } catch (inclErr) {
+            const msg = inclErr instanceof Error ? inclErr.message : String(inclErr);
+            throw new Error(`Falha ao incluir item ${index + 1} no Omie: ${msg}`);
           }
 
           newDetForPayload.push({
@@ -1497,8 +1686,9 @@ serve(async (req) => {
           await callOmieVendasApi("produtos/pedido/", "AlterarPedidoVenda",
             { cabecalho: editCabecalho, frete: editFrete, observacoes: { obs_venda: editObs || editConfig.obs_prefix }, informacoes_adicionais: editInfoAdic },
             editAccount);
-        } catch (headerErr: any) {
-          throw new Error(`Falha ao atualizar cabeçalho do pedido no Omie: ${headerErr.message}`);
+        } catch (headerErr) {
+          const msg = headerErr instanceof Error ? headerErr.message : String(headerErr);
+          throw new Error(`Falha ao atualizar cabeçalho do pedido no Omie: ${msg}`);
         }
 
         await callOmieVendasApi(
@@ -1508,13 +1698,13 @@ serve(async (req) => {
           editAccount,
         );
 
-        const finalConsultResult = await callOmieVendasApi(
+        const finalConsultResult = (await callOmieVendasApi(
           "produtos/pedido/",
           "ConsultarPedido",
           { codigo_pedido: codigoPedido },
           editAccount,
-        ) as any;
-        const finalOmieItems = finalConsultResult?.pedido_venda_produto?.det
+        )) as { pedido_venda_produto?: { det?: OmieDetalheItem[] }; det?: OmieDetalheItem[] } | null;
+        const finalOmieItems: OmieDetalheItem[] = finalConsultResult?.pedido_venda_produto?.det
           || finalConsultResult?.det
           || [];
         const expectedSignature = buildExpectedSignature(editItems);
@@ -1585,8 +1775,9 @@ serve(async (req) => {
               orderAccount
             );
             console.log(`[Omie Vendas][${orderAccount}] Pedido ${pedidoId} cancelado no Omie`);
-          } catch (omieErr: any) {
-            console.warn(`[Omie Vendas][${orderAccount}] Erro ao cancelar no Omie (continuando exclusão local):`, omieErr.message);
+          } catch (omieErr) {
+            const msg = omieErr instanceof Error ? omieErr.message : String(omieErr);
+            console.warn(`[Omie Vendas][${orderAccount}] Erro ao cancelar no Omie (continuando exclusão local):`, msg);
           }
         }
 
@@ -1726,8 +1917,9 @@ serve(async (req) => {
         const { sales_order_id: opSalesId, items: opItems } = params;
         if (!opSalesId || !opItems?.length) throw new Error("Dados insuficientes para criar ordem de produção");
 
-        const createdOPs: any[] = [];
-        for (const opItem of opItems) {
+        const opItemsTyped: OpItemInput[] = opItems;
+        const createdOPs: CreatedOP[] = [];
+        for (const opItem of opItemsTyped) {
           // Create production order in Omie
           const opPayload = {
             cCodIntOP: `OP_${opSalesId.substring(0, 8)}_${opItem.omie_codigo_produto}_${Date.now()}`,
@@ -1740,17 +1932,18 @@ serve(async (req) => {
           let omieOrdemId: number | null = null;
           let omieOrdemNumero: string | null = null;
           try {
-            const opResult = await callOmieVendasApi(
+            const opResult = (await callOmieVendasApi(
               "manufatura/ordemproducao/",
               "IncluirOrdemProducao",
               opPayload,
               account
-            ) as any;
+            )) as { nCodOP?: number; cNumOP?: string } | null;
             omieOrdemId = opResult?.nCodOP || null;
             omieOrdemNumero = opResult?.cNumOP || String(omieOrdemId);
             console.log(`[Omie Vendas][${account}] OP criada: ${omieOrdemNumero}`);
-          } catch (opErr: any) {
-            console.error(`[Omie Vendas][${account}] Erro ao criar OP:`, opErr.message);
+          } catch (opErr) {
+            const msg = opErr instanceof Error ? opErr.message : String(opErr);
+            console.error(`[Omie Vendas][${account}] Erro ao criar OP:`, msg);
           }
 
           // Save to local DB
@@ -1768,7 +1961,7 @@ serve(async (req) => {
             ready_by_date: opItem.ready_by_date || null,
             account,
             created_by: userId,
-          } as any).select('id').single();
+          }).select('id').single();
 
           createdOPs.push({ id: insertedOP?.id, omie_ordem_id: omieOrdemId, omie_ordem_numero: omieOrdemNumero, descricao: opItem.descricao });
         }
@@ -1781,36 +1974,38 @@ serve(async (req) => {
         const { production_order_id } = params;
         if (!production_order_id) throw new Error("ID da ordem de produção é obrigatório");
 
-        const { data: po } = await supabaseAdmin
+        const { data: poData } = await supabaseAdmin
           .from("production_orders")
           .select("*")
           .eq("id", production_order_id)
           .single();
-        if (!po) throw new Error("Ordem de produção não encontrada");
+        if (!poData) throw new Error("Ordem de produção não encontrada");
 
-        const poAccount: Account = (po as any).account === "colacor" ? "colacor" : "oben";
+        const po = poData as { account?: string; omie_ordem_producao_id?: number | null; omie_ordem_numero?: string | null };
+        const poAccount: Account = po.account === "colacor" ? "colacor" : "oben";
 
         // Finalize in Omie if it has an Omie ID
-        if ((po as any).omie_ordem_producao_id) {
+        if (po.omie_ordem_producao_id) {
           try {
             await callOmieVendasApi(
               "manufatura/ordemproducao/",
               "AlterarOrdemProducao",
               {
-                nCodOP: (po as any).omie_ordem_producao_id,
+                nCodOP: po.omie_ordem_producao_id,
                 cEtapa: "50", // Encerrada
               },
               poAccount
             );
-            console.log(`[Omie Vendas][${poAccount}] OP ${(po as any).omie_ordem_numero} finalizada no Omie`);
-          } catch (omieErr: any) {
-            console.warn(`[Omie Vendas][${poAccount}] Erro ao finalizar OP no Omie:`, omieErr.message);
+            console.log(`[Omie Vendas][${poAccount}] OP ${po.omie_ordem_numero} finalizada no Omie`);
+          } catch (omieErr) {
+            const msg = omieErr instanceof Error ? omieErr.message : String(omieErr);
+            console.warn(`[Omie Vendas][${poAccount}] Erro ao finalizar OP no Omie:`, msg);
           }
         }
 
         await supabaseAdmin
           .from("production_orders")
-          .update({ status: "completed", completed_at: new Date().toISOString() } as any)
+          .update({ status: "completed", completed_at: new Date().toISOString() })
           .eq("id", production_order_id);
 
         result = { success: true };


### PR DESCRIPTION
## Sumário

Continuação do trabalho de TS strict. PR #58 estabeleceu infra. PR #62 fez **5 engines IA client-side (-185)**. Esta PR ataca os **4 Edge Functions Deno** com mais `any` errors no lint global.

## Migração: 4 Edge Functions, 163 → 0 any errors

| File | Errors antes | Errors depois |
|---|---|---|
| `omie-sync-nfes-recebidas` | 24 | 0 |
| `analyze-unified-order` | 34 | 0 |
| `omie-financeiro` | 38 | 0 |
| `omie-vendas-sync` | 67 | 0 |
| **Total** | **163** | **0** |

## Diferenças vs PR #62 (engines client)

Edge Functions são **Deno runtime** (server-side), processadas pelo Supabase edge runtime, NÃO pelo `tsc` do Vite. Por isso:

- **NÃO entram no `tsconfig.strict.json`** (fora do scope do tsc do projeto)
- ESLint do projeto ainda processa eles → remover `any` reduz lint count
- Imports Deno (`https://deno.land/...`, `npm:@supabase/supabase-js@2`) preservados
- `db: any` em parâmetros → `db: SupabaseClient` (import do dep Deno)

## ~50 interfaces locais novas

Cada Edge Function define tipos pra:
- **Omie REST API responses** (shapes dinâmicos: `OmieListResponse<T>`, `OmieClienteCadastro`, `OmiePedidoVendaProduto`, `OmieCategoria`, `OmieMovimento`, `OmieContaCorrente` etc.)
- **Supabase row types** (`PurchaseOrderTrackingRow`, `OmieClienteMapRow`, `MovimentoRow`, `CategoriaDreMappingRow` etc.)
- **Edge-specific shapes** (`AISuggestion`, `CustomerCandidate`, `OrderItemPayload`, `EditItemInput`, `OpItemInput` etc.)

## Padrões aplicados

```ts
// Omie API response
(await callOmie(...)) as any  →  as OmieXResponse | null

// Callbacks
.map((x: any) => ...)  →  callbacks tipados por inferência (após tipar array origem)

// Reducers
.reduce((acc: any, item: any) => ..., {} as any)
→ .reduce<TipoAcc>((acc, item) => ..., initial)

// Catch blocks
catch (e: any) { e.message }
→ catch (e) { e instanceof Error ? e.message : String(e) }

// Inline narrow
(data.claims as any).sub  →  (data.claims as { sub?: string }).sub
```

## Validação

- [x] `bun lint`: **1236 problemas** (era 1400; -164 — engines do PR #62 ainda não em main)
- [x] `bun run build`: limpa em 28s, PWA gerado, 69 entries precache
- [x] `bun run test`: **232/232** passam (32 test files)
- ⚠️ Edge Functions não testáveis localmente sem Deno + supabase functions serve

## Acumulado pós-PRs #62 + #63

Se **ambos mergeados** (são independentes, sem conflito):
- Lint: 1398 → 1213 (PR #62) → **~1050** (PR #63 sobre #62 base) ≈ **-348 errors total**
- `no-explicit-any`: 1274 → 1089 → **~925**

**Próximos candidates** (após esses mergeados):
- `omie-sync` (~30 errors estimados)
- `AdminReposicaoPromocaoDetail` (page god-component, 28 errors)
- Outros files Reposição

## Net diff
4 files changed, 806 insertions(+), 245 deletions(-)

🤖 Generated with [Claude Code](https://claude.com/claude-code)