### PR TITLE
feat: KB extração estruturada de specs via Claude (PR6b)

### DIFF
--- a/docs/superpowers/plans/2026-05-17-pr6b-kb-extract-specs.md
+++ b/docs/superpowers/plans/2026-05-17-pr6b-kb-extract-specs.md
@@ -1,0 +1,661 @@
+# PR6b — KB: Extração Automática de Specs via Claude Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Dado um documento processado em `kb_documents` (status='ready' com texto extraído), permitir extração estruturada de specs técnicos via Claude tool use. Schema novo: `kb_product_specs` (rendimento, validade, pot life, densidade, sólidos, dureza, brilho, catalisador/diluente compatível, gramatura, compliance) + skeleton `kb_competitors` / `kb_competitor_products` (vazio — vendedor preenche via PR8). Edge function `kb-extract-specs` chama Claude, retorna proposta. UI no detail page: botão "Extrair specs" → form pré-preenchido pra admin revisar e aprovar → salva.
+
+**Architecture:**
+- Migration: 3 tabelas (`kb_product_specs`, `kb_competitors`, `kb_competitor_products`) + RLS (master CRUD, staff read)
+- Edge function `kb-extract-specs` (Deno + Anthropic SDK): recebe `documentId`, busca content_extracted, monta prompt SPIN-like com tool use forçada pra retornar shape estruturado, retorna `{ specs: {...}, confidence, gaps: [...] }`
+- Client: hook `useExtractSpecs` (mutation), hook `useKbProductSpecs(productCode)` (read), componente `KbSpecsForm` (form de revisão RHF+Zod), wire no `AdminKnowledgeBaseDetail`
+
+**Tech Stack:**
+- Anthropic SDK Deno (`npm:@anthropic-ai/sdk@^0.93.0`) — mesmo padrão de `claude-spin-analyze`
+- Claude Sonnet 4.6 (com adaptive thinking — extração técnica vale custo)
+- Tool use forçada (`tool_choice: { type: 'tool', name: 'extract_product_specs' }`)
+- Prompt caching no system prompt (compartilhado entre requests)
+- RHF + Zod no form
+
+**Não-objetivos (próximos PRs):**
+- Calculadora ao vivo no painel de chamada (PR6c)
+- RAG retrieval no copilot (PR6d)
+- UI de gestão de concorrentes + battle cards (PR8) — schema fica pronto aqui
+- Versionamento de specs (parent_id existe mas sem UI)
+- Histórico de revisões da spec (só guarda current)
+- OCR / fallback pra PDFs sem texto extraído
+
+---
+
+## File Structure
+
+**Criar:**
+- `supabase/migrations/{timestamp}_kb_specs_and_competitors.sql` — 3 tabelas + RLS
+- `supabase/functions/kb-extract-specs/index.ts` — edge function com Claude tool use
+- `src/lib/knowledge-base/specs-types.ts` — `KbProductSpec`, `KbCompetitor`, `KbCompetitorProduct` types
+- `src/hooks/useExtractSpecs.ts` — mutation: invoca edge function, retorna proposta sem salvar
+- `src/hooks/useSaveProductSpecs.ts` — mutation: salva specs aprovados
+- `src/hooks/useKbProductSpecs.ts` — query: busca specs por document_id ou product_code
+- `src/hooks/__tests__/useExtractSpecs.test.tsx`
+- `src/components/knowledge-base/KbSpecsForm.tsx` — form de revisão (RHF + Zod)
+- `src/components/knowledge-base/KbSpecsExtractButton.tsx` — botão + Dialog
+
+**Modificar:**
+- `src/integrations/supabase/types.ts` — 3 tabelas novas
+- `src/pages/AdminKnowledgeBaseDetail.tsx` — render do KbSpecsExtractButton + KbSpecsForm quando documento ready
+
+**Não modificar:**
+- `kb-ingest-document` edge function (PR6a — independente)
+- `claude-spin-analyze` (PR6d vai integrar)
+- `kb_documents` / `kb_chunks` schema (não muda)
+
+---
+
+## Pré-requisito do operador
+
+- `ANTHROPIC_API_KEY` já configurada (PR #55)
+- Rodar a nova migration SQL no Lovable Cloud
+- Regenerar types Supabase
+
+---
+
+## Task 1: Migration SQL
+
+**Files:** Create `supabase/migrations/{timestamp}_kb_specs_and_competitors.sql`
+
+```sql
+-- PR6b: KB specs + competitors skeleton
+
+-- 1. Tabela de specs estruturados (1 row por produto da Sayerlack/Colacor)
+CREATE TABLE IF NOT EXISTS public.kb_product_specs (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  document_id uuid REFERENCES public.kb_documents(id) ON DELETE SET NULL,
+  product_code text NOT NULL UNIQUE,        -- ex: 'FO20.6827.00'
+  product_name text NOT NULL,
+  supplier text NOT NULL DEFAULT 'sayerlack',
+  product_line text,                         -- 'wood_pu' | 'wood_nitro' | 'hydropoxi' | 'auto'
+  product_category text,                     -- 'primer' | 'verniz' | 'tinta' | 'catalisador' | 'diluente'
+
+  -- Propriedades físico-químicas
+  densidade_g_cm3 numeric,
+  solidos_pct numeric,
+  viscosidade_aplicacao_s numeric,
+  viscosidade_copo text,                     -- 'CF4' | 'CF6' | 'CF8'
+  brilho_ub numeric,                         -- unidades de brilho
+  dureza text,                               -- '3H', '2H' etc.
+
+  -- Aplicação
+  rendimento_m2_por_litro numeric,           -- calculado ou explícito
+  demaos_recomendadas integer,
+  gramatura_g_m2_min integer,
+  gramatura_g_m2_max integer,
+  pot_life_horas numeric,
+  temp_aplicacao_c_min numeric,
+  temp_aplicacao_c_max numeric,
+  umidade_aplicacao_pct_min numeric,
+  umidade_aplicacao_pct_max numeric,
+
+  -- Compatibilidade
+  catalisador_codigo text,                   -- ex: 'FC.6952'
+  catalisador_proporcao_pct numeric,
+  diluente_codigo text,                      -- ex: 'DF.4068'
+  equipamentos_aplicacao text[],             -- ['pistola_convencional', 'tanque_pressao']
+  lixa_recomendada text,
+  substrato text[],                          -- ['madeira', 'mdf']
+
+  -- Secagem
+  secagem_manuseio_h numeric,
+  secagem_empilhamento_h numeric,
+  secagem_total_h numeric,
+
+  -- Armazenamento
+  validade_dias integer,
+  temp_armazenamento_c_min integer,
+  temp_armazenamento_c_max integer,
+
+  -- Compliance
+  certificacoes_aplicaveis text[],           -- ['IKEA', 'LGA', 'Proposition_65']
+  isento_metais_pesados text[],              -- ['Cd', 'Pb', etc.]
+  isento_substancias text[],                 -- ['amianto', 'formaldeido']
+
+  -- Notas qualitativas
+  diferenciais_chave text[],                 -- ['resistencia_risco_superior', 'toque_sedoso']
+  uso_recomendado text,
+  publico_alvo text,
+
+  -- Metadata
+  extraction_confidence numeric,             -- 0-1 (Claude reporta)
+  extraction_gaps text[],                    -- campos que Claude não conseguiu extrair
+  extracted_by uuid REFERENCES auth.users(id),
+  approved_by uuid REFERENCES auth.users(id),
+  approved_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- 2. Concorrentes (vazio — populado por PR8)
+CREATE TABLE IF NOT EXISTS public.kb_competitors (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  name text NOT NULL UNIQUE,                 -- 'Farben Tintas', 'Vernit', 'Rosalen'
+  tipo text CHECK (tipo IN ('regional', 'nacional', 'importado')),
+  regiao_principal text,                     -- 'mg', 'sul', 'sp', 'nacional'
+  segmento_atuacao text[],                   -- ['moveleiro', 'industrial', 'automotivo']
+  notas_estrategicas text,
+  created_by uuid REFERENCES auth.users(id),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- 3. Produtos do concorrente (vazio — populado via UI ou auto-detect)
+CREATE TABLE IF NOT EXISTS public.kb_competitor_products (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  competitor_id uuid NOT NULL REFERENCES public.kb_competitors(id) ON DELETE CASCADE,
+  product_name text NOT NULL,
+  category text,                             -- mesmo enum de kb_product_specs.product_category
+  rendimento_m2_por_litro numeric,
+  solidos_pct numeric,
+  pot_life_horas numeric,
+  validade_dias integer,
+  preco_referencia_l numeric,
+  preco_atualizado_em timestamptz,
+  fonte_preco text CHECK (fonte_preco IN ('vendedor', 'cotacao', 'site', 'estimado', 'detectado_ia')),
+  pontos_fortes text[],
+  pontos_fracos text[],
+  nosso_equivalente_product_code text,       -- referência cruzada com nossos kb_product_specs.product_code
+  argumentos_comparativos jsonb,             -- estrutura aberta pra flexibilidade
+  created_by uuid REFERENCES auth.users(id),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- 4. Indexes
+CREATE INDEX IF NOT EXISTS idx_kb_product_specs_product_code ON public.kb_product_specs (product_code);
+CREATE INDEX IF NOT EXISTS idx_kb_product_specs_supplier_line ON public.kb_product_specs (supplier, product_line);
+CREATE INDEX IF NOT EXISTS idx_kb_competitor_products_competitor ON public.kb_competitor_products (competitor_id);
+CREATE INDEX IF NOT EXISTS idx_kb_competitor_products_equivalent ON public.kb_competitor_products (nosso_equivalente_product_code);
+
+-- 5. Triggers updated_at (reusa função do PR6a se existir; senão cria)
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_proc WHERE proname = 'kb_documents_set_updated_at') THEN
+    CREATE OR REPLACE FUNCTION public.kb_documents_set_updated_at()
+    RETURNS trigger AS $func$
+    BEGIN NEW.updated_at = now(); RETURN NEW; END;
+    $func$ LANGUAGE plpgsql;
+  END IF;
+END $$;
+
+DROP TRIGGER IF EXISTS trg_kb_product_specs_updated_at ON public.kb_product_specs;
+CREATE TRIGGER trg_kb_product_specs_updated_at
+  BEFORE UPDATE ON public.kb_product_specs
+  FOR EACH ROW EXECUTE FUNCTION public.kb_documents_set_updated_at();
+
+DROP TRIGGER IF EXISTS trg_kb_competitors_updated_at ON public.kb_competitors;
+CREATE TRIGGER trg_kb_competitors_updated_at
+  BEFORE UPDATE ON public.kb_competitors
+  FOR EACH ROW EXECUTE FUNCTION public.kb_documents_set_updated_at();
+
+DROP TRIGGER IF EXISTS trg_kb_competitor_products_updated_at ON public.kb_competitor_products;
+CREATE TRIGGER trg_kb_competitor_products_updated_at
+  BEFORE UPDATE ON public.kb_competitor_products
+  FOR EACH ROW EXECUTE FUNCTION public.kb_documents_set_updated_at();
+
+-- 6. RLS — staff lê, master CRUD
+ALTER TABLE public.kb_product_specs ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.kb_competitors ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.kb_competitor_products ENABLE ROW LEVEL SECURITY;
+
+-- kb_product_specs
+CREATE POLICY "kb_product_specs_select_staff" ON public.kb_product_specs
+  FOR SELECT
+  USING (
+    public.has_role(auth.uid(), 'employee'::app_role)
+    OR public.has_role(auth.uid(), 'master'::app_role)
+  );
+CREATE POLICY "kb_product_specs_insert_staff" ON public.kb_product_specs
+  FOR INSERT
+  WITH CHECK (
+    public.has_role(auth.uid(), 'employee'::app_role)
+    OR public.has_role(auth.uid(), 'master'::app_role)
+  );
+CREATE POLICY "kb_product_specs_update_master" ON public.kb_product_specs
+  FOR UPDATE
+  USING (
+    public.has_role(auth.uid(), 'master'::app_role)
+    OR extracted_by = auth.uid()
+  );
+CREATE POLICY "kb_product_specs_delete_master" ON public.kb_product_specs
+  FOR DELETE
+  USING (public.has_role(auth.uid(), 'master'::app_role));
+
+-- kb_competitors
+CREATE POLICY "kb_competitors_select_staff" ON public.kb_competitors
+  FOR SELECT
+  USING (
+    public.has_role(auth.uid(), 'employee'::app_role)
+    OR public.has_role(auth.uid(), 'master'::app_role)
+  );
+CREATE POLICY "kb_competitors_insert_staff" ON public.kb_competitors
+  FOR INSERT
+  WITH CHECK (
+    public.has_role(auth.uid(), 'employee'::app_role)
+    OR public.has_role(auth.uid(), 'master'::app_role)
+  );
+CREATE POLICY "kb_competitors_update_staff" ON public.kb_competitors
+  FOR UPDATE
+  USING (
+    public.has_role(auth.uid(), 'employee'::app_role)
+    OR public.has_role(auth.uid(), 'master'::app_role)
+  );
+CREATE POLICY "kb_competitors_delete_master" ON public.kb_competitors
+  FOR DELETE
+  USING (public.has_role(auth.uid(), 'master'::app_role));
+
+-- kb_competitor_products
+CREATE POLICY "kb_competitor_products_select_staff" ON public.kb_competitor_products
+  FOR SELECT
+  USING (
+    public.has_role(auth.uid(), 'employee'::app_role)
+    OR public.has_role(auth.uid(), 'master'::app_role)
+  );
+CREATE POLICY "kb_competitor_products_insert_staff" ON public.kb_competitor_products
+  FOR INSERT
+  WITH CHECK (
+    public.has_role(auth.uid(), 'employee'::app_role)
+    OR public.has_role(auth.uid(), 'master'::app_role)
+  );
+CREATE POLICY "kb_competitor_products_update_staff" ON public.kb_competitor_products
+  FOR UPDATE
+  USING (
+    public.has_role(auth.uid(), 'employee'::app_role)
+    OR public.has_role(auth.uid(), 'master'::app_role)
+  );
+CREATE POLICY "kb_competitor_products_delete_master" ON public.kb_competitor_products
+  FOR DELETE
+  USING (public.has_role(auth.uid(), 'master'::app_role));
+
+-- 7. Comentários
+COMMENT ON TABLE public.kb_product_specs IS 'Specs estruturados extraídos de kb_documents via Claude. 1 row por produto Sayerlack.';
+COMMENT ON TABLE public.kb_competitors IS 'Concorrentes regionais/nacionais. Populado por vendedores via UI ou auto-detect de transcripts.';
+COMMENT ON TABLE public.kb_competitor_products IS 'Produtos específicos dos concorrentes com specs comparáveis aos nossos.';
+```
+
+Commit: `feat(kb): migration — kb_product_specs + kb_competitors + kb_competitor_products + RLS`
+
+---
+
+## Task 2: Types Supabase + domain types
+
+**Files:**
+- Modify: `src/integrations/supabase/types.ts` — adicionar 3 tabelas
+- Create: `src/lib/knowledge-base/specs-types.ts`
+
+```ts
+// specs-types.ts
+export interface KbProductSpec {
+  id: string;
+  document_id: string | null;
+  product_code: string;
+  product_name: string;
+  supplier: string;
+  product_line: string | null;
+  product_category: string | null;
+
+  densidade_g_cm3: number | null;
+  solidos_pct: number | null;
+  viscosidade_aplicacao_s: number | null;
+  viscosidade_copo: string | null;
+  brilho_ub: number | null;
+  dureza: string | null;
+
+  rendimento_m2_por_litro: number | null;
+  demaos_recomendadas: number | null;
+  gramatura_g_m2_min: number | null;
+  gramatura_g_m2_max: number | null;
+  pot_life_horas: number | null;
+  temp_aplicacao_c_min: number | null;
+  temp_aplicacao_c_max: number | null;
+  umidade_aplicacao_pct_min: number | null;
+  umidade_aplicacao_pct_max: number | null;
+
+  catalisador_codigo: string | null;
+  catalisador_proporcao_pct: number | null;
+  diluente_codigo: string | null;
+  equipamentos_aplicacao: string[];
+  lixa_recomendada: string | null;
+  substrato: string[];
+
+  secagem_manuseio_h: number | null;
+  secagem_empilhamento_h: number | null;
+  secagem_total_h: number | null;
+
+  validade_dias: number | null;
+  temp_armazenamento_c_min: number | null;
+  temp_armazenamento_c_max: number | null;
+
+  certificacoes_aplicaveis: string[];
+  isento_metais_pesados: string[];
+  isento_substancias: string[];
+
+  diferenciais_chave: string[];
+  uso_recomendado: string | null;
+  publico_alvo: string | null;
+
+  extraction_confidence: number | null;
+  extraction_gaps: string[];
+  extracted_by: string | null;
+  approved_by: string | null;
+  approved_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+/** Resposta da edge fn kb-extract-specs (sem ids, sem timestamps — só os campos extraídos) */
+export type KbExtractedSpec = Omit<KbProductSpec,
+  'id' | 'document_id' | 'extracted_by' | 'approved_by' | 'approved_at' | 'created_at' | 'updated_at'
+>;
+
+export interface KbCompetitor {
+  id: string;
+  name: string;
+  tipo: 'regional' | 'nacional' | 'importado' | null;
+  regiao_principal: string | null;
+  segmento_atuacao: string[];
+  notas_estrategicas: string | null;
+  created_by: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface KbCompetitorProduct {
+  id: string;
+  competitor_id: string;
+  product_name: string;
+  category: string | null;
+  rendimento_m2_por_litro: number | null;
+  solidos_pct: number | null;
+  pot_life_horas: number | null;
+  validade_dias: number | null;
+  preco_referencia_l: number | null;
+  preco_atualizado_em: string | null;
+  fonte_preco: 'vendedor' | 'cotacao' | 'site' | 'estimado' | 'detectado_ia' | null;
+  pontos_fortes: string[];
+  pontos_fracos: string[];
+  nosso_equivalente_product_code: string | null;
+  argumentos_comparativos: unknown;
+  created_by: string | null;
+  created_at: string;
+  updated_at: string;
+}
+```
+
+Commit: `feat(kb): types — KbProductSpec + KbCompetitor + KbCompetitorProduct`
+
+---
+
+## Task 3: Edge Function `kb-extract-specs`
+
+**Files:** Create `supabase/functions/kb-extract-specs/index.ts`
+
+Recebe `{ documentId }`, busca o document (deve ter `content_extracted`), monta prompt SYSTEM_PROMPT_EXTRACT_SPECS, chama Claude com `tool_choice: { type: 'tool', name: 'extract_product_specs' }`, retorna tool input + metadata (confidence, gaps).
+
+```ts
+import Anthropic from "npm:@anthropic-ai/sdk@^0.93.0";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import { authorizeCronOrStaff, corsHeaders } from "../_shared/auth.ts";
+
+const SYSTEM_PROMPT_EXTRACT_SPECS = `Você extrai specs técnicos estruturados de boletins técnicos de tintas industriais para a base de conhecimento da Colacor (distribuidora Sayerlack).
+
+# Regras gerais
+- Use APENAS dados explícitos no texto. NÃO invente, NÃO estime.
+- Quando o boletim dá um range (ex: "viscosidade 42 ± 3s CF6 a 25°C"), use o valor central (42).
+- Para campos que o boletim NÃO menciona, deixe null.
+- Liste em \`extraction_gaps\` os campos importantes que estão ausentes.
+- \`extraction_confidence\` = 0.9+ se boletim claro, 0.6-0.8 se ambíguo, <0.6 se faltam muitos dados-chave.
+
+# Cálculos derivados permitidos
+- \`rendimento_m2_por_litro\` = (densidade_g_cm3 × 1000) / gramatura_g_m2_media. Use gramatura média entre min/max se houver range. Se boletim não tem gramatura nem densidade, deixe null.
+
+# Classificação semântica (vc preenche baseado no texto)
+- \`product_line\`: 'wood_pu' | 'wood_nitro' | 'hydropoxi' | 'auto' — Wood PU pra poliuretanos pra madeira (mais comum em boletins moveleiros)
+- \`product_category\`: 'primer' | 'verniz' | 'tinta' | 'catalisador' | 'diluente' | 'massa' | 'selador'
+- \`diferenciais_chave\`: extrai as 2-5 frases-chave do "Uso Recomendado" e "Características"
+
+# Compliance
+- Se boletim menciona "isento de" e lista substâncias/metais, capture nos arrays
+- \`certificacoes_aplicaveis\`: capture menções de IKEA, LGA, Proposition 65, JIS, CARB, etc.
+
+SEMPRE use a tool extract_product_specs. NÃO responda em texto fora dela.`;
+
+const EXTRACT_TOOL = {
+  name: "extract_product_specs",
+  description: "Retorna specs estruturados do produto extraídos do boletim técnico.",
+  input_schema: {
+    type: "object",
+    properties: {
+      product_code: { type: "string" },
+      product_name: { type: "string" },
+      supplier: { type: "string" },
+      product_line: { type: ["string", "null"], enum: ["wood_pu", "wood_nitro", "hydropoxi", "auto", null] },
+      product_category: { type: ["string", "null"] },
+      densidade_g_cm3: { type: ["number", "null"] },
+      solidos_pct: { type: ["number", "null"] },
+      viscosidade_aplicacao_s: { type: ["number", "null"] },
+      viscosidade_copo: { type: ["string", "null"] },
+      brilho_ub: { type: ["number", "null"] },
+      dureza: { type: ["string", "null"] },
+      rendimento_m2_por_litro: { type: ["number", "null"] },
+      demaos_recomendadas: { type: ["integer", "null"] },
+      gramatura_g_m2_min: { type: ["integer", "null"] },
+      gramatura_g_m2_max: { type: ["integer", "null"] },
+      pot_life_horas: { type: ["number", "null"] },
+      temp_aplicacao_c_min: { type: ["number", "null"] },
+      temp_aplicacao_c_max: { type: ["number", "null"] },
+      umidade_aplicacao_pct_min: { type: ["number", "null"] },
+      umidade_aplicacao_pct_max: { type: ["number", "null"] },
+      catalisador_codigo: { type: ["string", "null"] },
+      catalisador_proporcao_pct: { type: ["number", "null"] },
+      diluente_codigo: { type: ["string", "null"] },
+      equipamentos_aplicacao: { type: "array", items: { type: "string" } },
+      lixa_recomendada: { type: ["string", "null"] },
+      substrato: { type: "array", items: { type: "string" } },
+      secagem_manuseio_h: { type: ["number", "null"] },
+      secagem_empilhamento_h: { type: ["number", "null"] },
+      secagem_total_h: { type: ["number", "null"] },
+      validade_dias: { type: ["integer", "null"] },
+      temp_armazenamento_c_min: { type: ["integer", "null"] },
+      temp_armazenamento_c_max: { type: ["integer", "null"] },
+      certificacoes_aplicaveis: { type: "array", items: { type: "string" } },
+      isento_metais_pesados: { type: "array", items: { type: "string" } },
+      isento_substancias: { type: "array", items: { type: "string" } },
+      diferenciais_chave: { type: "array", items: { type: "string" } },
+      uso_recomendado: { type: ["string", "null"] },
+      publico_alvo: { type: ["string", "null"] },
+      extraction_confidence: { type: "number", minimum: 0, maximum: 1 },
+      extraction_gaps: { type: "array", items: { type: "string" } },
+    },
+    required: [
+      "product_code",
+      "product_name",
+      "supplier",
+      "extraction_confidence",
+      "extraction_gaps",
+      "equipamentos_aplicacao",
+      "substrato",
+      "certificacoes_aplicaveis",
+      "isento_metais_pesados",
+      "isento_substancias",
+      "diferenciais_chave",
+    ],
+  },
+};
+
+Deno.serve(async (req) => {
+  if (req.method === "OPTIONS") return new Response(null, { headers: corsHeaders });
+
+  const auth = await authorizeCronOrStaff(req);
+  if (!auth.ok) return auth.response;
+
+  const apiKey = Deno.env.get("ANTHROPIC_API_KEY");
+  if (!apiKey) {
+    return new Response(JSON.stringify({ error: "ANTHROPIC_API_KEY not configured" }), {
+      status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+
+  const supabase = createClient(
+    Deno.env.get("SUPABASE_URL")!,
+    Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!,
+  );
+
+  let body;
+  try { body = await req.json(); } catch {
+    return new Response(JSON.stringify({ error: "Invalid JSON" }), {
+      status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+  if (!body.documentId) {
+    return new Response(JSON.stringify({ error: "documentId required" }), {
+      status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+
+  try {
+    const { data: doc, error } = await supabase
+      .from("kb_documents")
+      .select("id, title, product_code, supplier, content_extracted, status")
+      .eq("id", body.documentId)
+      .single();
+
+    if (error || !doc) {
+      return new Response(JSON.stringify({ error: "Document not found" }), {
+        status: 404, headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    if (doc.status !== "ready" || !doc.content_extracted) {
+      return new Response(JSON.stringify({ error: "Document not ready or has no extracted content" }), {
+        status: 422, headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    const client = new Anthropic({ apiKey });
+
+    const userMsg = `Extraia os specs estruturados deste boletim técnico:
+
+# Metadata
+- Título: ${doc.title}
+- Código produto (hint): ${doc.product_code ?? "(não informado)"}
+- Fornecedor: ${doc.supplier ?? "sayerlack"}
+
+# Texto extraído
+${doc.content_extracted.slice(0, 50_000)}
+
+Use a tool extract_product_specs.`;
+
+    const response = await client.messages.create({
+      model: "claude-sonnet-4-6",
+      max_tokens: 4000,
+      system: [{
+        type: "text",
+        text: SYSTEM_PROMPT_EXTRACT_SPECS,
+        cache_control: { type: "ephemeral" },
+      }],
+      tools: [EXTRACT_TOOL],
+      tool_choice: { type: "tool", name: "extract_product_specs" },
+      messages: [{ role: "user", content: userMsg }],
+    });
+
+    const toolUse = response.content.find((b) => b.type === "tool_use");
+    if (!toolUse || toolUse.type !== "tool_use") {
+      return new Response(JSON.stringify({ error: "No tool_use in response", raw: response }), {
+        status: 502, headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    return new Response(JSON.stringify({
+      specs: toolUse.input,
+      usage: {
+        inputTokens: response.usage.input_tokens,
+        outputTokens: response.usage.output_tokens,
+        cacheCreationTokens: response.usage.cache_creation_input_tokens ?? 0,
+        cacheReadTokens: response.usage.cache_read_input_tokens ?? 0,
+      },
+    }), { headers: { ...corsHeaders, "Content-Type": "application/json" } });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "unknown error";
+    console.error("[kb-extract-specs]", msg);
+    return new Response(JSON.stringify({ error: msg }), {
+      status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+});
+```
+
+Commit: `feat(kb): edge function kb-extract-specs (Claude Sonnet 4.6 tool use)`
+
+---
+
+## Task 4: Hook `useExtractSpecs` (mutation + TDD)
+
+`useExtractSpecs.mutate(documentId)` → invoca edge, retorna `KbExtractedSpec` (não salva).
+
+Tests: mocka `invokeFunction`, valida que chama com payload correto, retorna data.specs.
+
+Commit: `feat(kb): useExtractSpecs mutation`
+
+---
+
+## Task 5: Hook `useSaveProductSpecs` + `useKbProductSpecs`
+
+- `useSaveProductSpecs`: upsert em `kb_product_specs` (por product_code unique). Set `approved_by = current_user`, `approved_at = now()`.
+- `useKbProductSpecs(productCode?)`: query buscando por product_code, retorna `KbProductSpec | null`.
+
+Commit: `feat(kb): useSaveProductSpecs + useKbProductSpecs hooks`
+
+---
+
+## Task 6: Componente `KbSpecsForm`
+
+Form RHF + Zod com TODOS os campos de `KbExtractedSpec`. Aceita `initialValues` (proposta do Claude). `onSubmit` chama `useSaveProductSpecs`.
+
+Visualmente agrupa em fieldsets: Identificação, Físico-químico, Aplicação, Compatibilidade, Secagem, Armazenamento, Compliance, Notas.
+
+Sub-componente `KbSpecField` (label + input + hint quando vier null/gap).
+
+Commit: `feat(kb): KbSpecsForm — revisar e aprovar specs propostos por Claude`
+
+---
+
+## Task 7: `KbSpecsExtractButton` + wire em `AdminKnowledgeBaseDetail`
+
+`KbSpecsExtractButton`: botão "Extrair specs com IA" → useExtractSpecs.mutate → abre Dialog com KbSpecsForm preenchido → user revisa → submit salva.
+
+No `AdminKnowledgeBaseDetail`, quando `status === 'ready'`:
+- Mostra section "Specs estruturados"
+- Se `useKbProductSpecs(doc.product_code).data` existe → mostra preview com `<KbSpecsPreview />` + botão "Editar"
+- Se não existe → mostra `<KbSpecsExtractButton />`
+
+Commit: `feat(kb): wire spec extraction in AdminKnowledgeBaseDetail`
+
+---
+
+## Task 8: QA + PR
+
+- vitest: espera ~+3 (useExtractSpecs)
+- tsc clean
+- build passa
+- Push + PR
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Extração automática via Claude → Task 3
+- UI de revisão e aprovação → Tasks 6, 7
+- Schema pra concorrentes (sem hardcode) → Task 1
+- Persistência aprovada → Task 5
+
+**Riscos:**
+- Schema de `kb_product_specs` tem ~45 campos. Form vai ficar grande mas é necessário (cada campo é dado real do boletim).
+- Claude pode "alucinar" campos quando boletim é vago — `extraction_gaps` mitigação parcial; user revisa.
+- Preço de chamada Claude com 50k chars de input: ~$0.05-0.15. Aceitável (rodado 1x por documento, depois cache).

--- a/src/components/knowledge-base/KbSpecsExtractButton.tsx
+++ b/src/components/knowledge-base/KbSpecsExtractButton.tsx
@@ -1,0 +1,84 @@
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog';
+import { useExtractSpecs } from '@/hooks/useExtractSpecs';
+import { KbSpecsForm } from './KbSpecsForm';
+import { Sparkles, Loader2 } from 'lucide-react';
+import type { KbExtractedSpec } from '@/lib/knowledge-base/specs-types';
+
+interface Props {
+  documentId: string;
+  documentTitle: string;
+  productCode?: string | null;
+  onSaved?: () => void;
+}
+
+/**
+ * Botão "Extrair specs com IA" → invoca Claude → abre Dialog com KbSpecsForm
+ * pré-preenchido pra admin revisar e aprovar.
+ */
+export function KbSpecsExtractButton({ documentId, documentTitle, productCode, onSaved }: Props) {
+  const [open, setOpen] = useState(false);
+  const [extracted, setExtracted] = useState<KbExtractedSpec | null>(null);
+  const extract = useExtractSpecs();
+
+  const handleExtract = () => {
+    extract.mutate(documentId, {
+      onSuccess: (data) => {
+        setExtracted(data.specs);
+        setOpen(true);
+      },
+    });
+  };
+
+  const handleSaved = () => {
+    setOpen(false);
+    setExtracted(null);
+    onSaved?.();
+  };
+
+  return (
+    <>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={handleExtract}
+        disabled={extract.isPending}
+        className="gap-1.5"
+      >
+        {extract.isPending ? (
+          <>
+            <Loader2 className="w-3.5 h-3.5 animate-spin" />
+            Extraindo…
+          </>
+        ) : (
+          <>
+            <Sparkles className="w-3.5 h-3.5" />
+            Extrair specs com IA
+          </>
+        )}
+      </Button>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="max-w-3xl max-h-[90vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>Revisar specs extraídos</DialogTitle>
+            <DialogDescription>
+              Claude analisou <strong>{documentTitle}</strong>
+              {productCode && <> ({productCode})</>} e propôs os valores abaixo. Revise antes de aprovar — campos com confiança baixa ou faltantes estão sinalizados.
+            </DialogDescription>
+          </DialogHeader>
+
+          {extracted && (
+            <KbSpecsForm
+              initialValues={extracted}
+              documentId={documentId}
+              onSaved={handleSaved}
+            />
+          )}
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/components/knowledge-base/KbSpecsForm.tsx
+++ b/src/components/knowledge-base/KbSpecsForm.tsx
@@ -1,0 +1,392 @@
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { Card } from '@/components/ui/card';
+import { Loader2, Save, AlertTriangle } from 'lucide-react';
+import { useSaveProductSpecs } from '@/hooks/useSaveProductSpecs';
+import type { KbExtractedSpec } from '@/lib/knowledge-base/specs-types';
+
+const nullableNumber = z
+  .preprocess((v) => {
+    if (v === '' || v === null || v === undefined) return null;
+    const n = typeof v === 'number' ? v : Number(v);
+    return Number.isFinite(n) ? n : null;
+  }, z.number().nullable());
+
+const nullableInt = z
+  .preprocess((v) => {
+    if (v === '' || v === null || v === undefined) return null;
+    const n = typeof v === 'number' ? v : Number(v);
+    return Number.isFinite(n) ? Math.trunc(n) : null;
+  }, z.number().int().nullable());
+
+const nullableString = z
+  .preprocess((v) => {
+    if (v === null || v === undefined) return null;
+    const s = String(v).trim();
+    return s === '' ? null : s;
+  }, z.string().nullable());
+
+const schema = z.object({
+  product_code: z.string().min(1, 'Obrigatório'),
+  product_name: z.string().min(1, 'Obrigatório'),
+  supplier: z.string().min(1, 'Obrigatório'),
+  product_line: nullableString,
+  product_category: nullableString,
+  densidade_g_cm3: nullableNumber,
+  solidos_pct: nullableNumber,
+  viscosidade_aplicacao_s: nullableNumber,
+  viscosidade_copo: nullableString,
+  brilho_ub: nullableNumber,
+  dureza: nullableString,
+  rendimento_m2_por_litro: nullableNumber,
+  demaos_recomendadas: nullableInt,
+  gramatura_g_m2_min: nullableInt,
+  gramatura_g_m2_max: nullableInt,
+  pot_life_horas: nullableNumber,
+  temp_aplicacao_c_min: nullableNumber,
+  temp_aplicacao_c_max: nullableNumber,
+  umidade_aplicacao_pct_min: nullableNumber,
+  umidade_aplicacao_pct_max: nullableNumber,
+  catalisador_codigo: nullableString,
+  catalisador_proporcao_pct: nullableNumber,
+  diluente_codigo: nullableString,
+  equipamentos_aplicacao: z.string().default(''),
+  lixa_recomendada: nullableString,
+  substrato: z.string().default(''),
+  secagem_manuseio_h: nullableNumber,
+  secagem_empilhamento_h: nullableNumber,
+  secagem_total_h: nullableNumber,
+  validade_dias: nullableInt,
+  temp_armazenamento_c_min: nullableInt,
+  temp_armazenamento_c_max: nullableInt,
+  certificacoes_aplicaveis: z.string().default(''),
+  isento_metais_pesados: z.string().default(''),
+  isento_substancias: z.string().default(''),
+  diferenciais_chave: z.string().default(''),
+  uso_recomendado: nullableString,
+  publico_alvo: nullableString,
+  extraction_confidence: nullableNumber,
+});
+
+type FormValues = z.infer<typeof schema>;
+
+interface Props {
+  initialValues: KbExtractedSpec;
+  documentId?: string;
+  onSaved?: () => void;
+}
+
+function splitTags(s: string | undefined | null): string[] {
+  if (!s) return [];
+  return s
+    .split(',')
+    .map((t) => t.trim())
+    .filter(Boolean);
+}
+
+function joinTags(arr: string[] | undefined | null): string {
+  return (arr ?? []).join(', ');
+}
+
+export function KbSpecsForm({ initialValues, documentId, onSaved }: Props) {
+  const save = useSaveProductSpecs();
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<FormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: {
+      product_code: initialValues.product_code ?? '',
+      product_name: initialValues.product_name ?? '',
+      supplier: initialValues.supplier ?? '',
+      product_line: initialValues.product_line,
+      product_category: initialValues.product_category,
+      densidade_g_cm3: initialValues.densidade_g_cm3,
+      solidos_pct: initialValues.solidos_pct,
+      viscosidade_aplicacao_s: initialValues.viscosidade_aplicacao_s,
+      viscosidade_copo: initialValues.viscosidade_copo,
+      brilho_ub: initialValues.brilho_ub,
+      dureza: initialValues.dureza,
+      rendimento_m2_por_litro: initialValues.rendimento_m2_por_litro,
+      demaos_recomendadas: initialValues.demaos_recomendadas,
+      gramatura_g_m2_min: initialValues.gramatura_g_m2_min,
+      gramatura_g_m2_max: initialValues.gramatura_g_m2_max,
+      pot_life_horas: initialValues.pot_life_horas,
+      temp_aplicacao_c_min: initialValues.temp_aplicacao_c_min,
+      temp_aplicacao_c_max: initialValues.temp_aplicacao_c_max,
+      umidade_aplicacao_pct_min: initialValues.umidade_aplicacao_pct_min,
+      umidade_aplicacao_pct_max: initialValues.umidade_aplicacao_pct_max,
+      catalisador_codigo: initialValues.catalisador_codigo,
+      catalisador_proporcao_pct: initialValues.catalisador_proporcao_pct,
+      diluente_codigo: initialValues.diluente_codigo,
+      equipamentos_aplicacao: joinTags(initialValues.equipamentos_aplicacao),
+      lixa_recomendada: initialValues.lixa_recomendada,
+      substrato: joinTags(initialValues.substrato),
+      secagem_manuseio_h: initialValues.secagem_manuseio_h,
+      secagem_empilhamento_h: initialValues.secagem_empilhamento_h,
+      secagem_total_h: initialValues.secagem_total_h,
+      validade_dias: initialValues.validade_dias,
+      temp_armazenamento_c_min: initialValues.temp_armazenamento_c_min,
+      temp_armazenamento_c_max: initialValues.temp_armazenamento_c_max,
+      certificacoes_aplicaveis: joinTags(initialValues.certificacoes_aplicaveis),
+      isento_metais_pesados: joinTags(initialValues.isento_metais_pesados),
+      isento_substancias: joinTags(initialValues.isento_substancias),
+      diferenciais_chave: joinTags(initialValues.diferenciais_chave),
+      uso_recomendado: initialValues.uso_recomendado,
+      publico_alvo: initialValues.publico_alvo,
+      extraction_confidence: initialValues.extraction_confidence,
+    },
+  });
+
+  const onSubmit = (values: FormValues) => {
+    const specs: KbExtractedSpec = {
+      product_code: values.product_code,
+      product_name: values.product_name,
+      supplier: values.supplier,
+      product_line: values.product_line,
+      product_category: values.product_category,
+      densidade_g_cm3: values.densidade_g_cm3,
+      solidos_pct: values.solidos_pct,
+      viscosidade_aplicacao_s: values.viscosidade_aplicacao_s,
+      viscosidade_copo: values.viscosidade_copo,
+      brilho_ub: values.brilho_ub,
+      dureza: values.dureza,
+      rendimento_m2_por_litro: values.rendimento_m2_por_litro,
+      demaos_recomendadas: values.demaos_recomendadas,
+      gramatura_g_m2_min: values.gramatura_g_m2_min,
+      gramatura_g_m2_max: values.gramatura_g_m2_max,
+      pot_life_horas: values.pot_life_horas,
+      temp_aplicacao_c_min: values.temp_aplicacao_c_min,
+      temp_aplicacao_c_max: values.temp_aplicacao_c_max,
+      umidade_aplicacao_pct_min: values.umidade_aplicacao_pct_min,
+      umidade_aplicacao_pct_max: values.umidade_aplicacao_pct_max,
+      catalisador_codigo: values.catalisador_codigo,
+      catalisador_proporcao_pct: values.catalisador_proporcao_pct,
+      diluente_codigo: values.diluente_codigo,
+      equipamentos_aplicacao: splitTags(values.equipamentos_aplicacao),
+      lixa_recomendada: values.lixa_recomendada,
+      substrato: splitTags(values.substrato),
+      secagem_manuseio_h: values.secagem_manuseio_h,
+      secagem_empilhamento_h: values.secagem_empilhamento_h,
+      secagem_total_h: values.secagem_total_h,
+      validade_dias: values.validade_dias,
+      temp_armazenamento_c_min: values.temp_armazenamento_c_min,
+      temp_armazenamento_c_max: values.temp_armazenamento_c_max,
+      certificacoes_aplicaveis: splitTags(values.certificacoes_aplicaveis),
+      isento_metais_pesados: splitTags(values.isento_metais_pesados),
+      isento_substancias: splitTags(values.isento_substancias),
+      diferenciais_chave: splitTags(values.diferenciais_chave),
+      uso_recomendado: values.uso_recomendado,
+      publico_alvo: values.publico_alvo,
+      extraction_confidence: values.extraction_confidence,
+      extraction_gaps: initialValues.extraction_gaps,
+    };
+    save.mutate(
+      { specs, documentId },
+      { onSuccess: () => onSaved?.() },
+    );
+  };
+
+  const Field = ({
+    name,
+    label,
+    type = 'text',
+    placeholder,
+  }: {
+    name: keyof FormValues;
+    label: string;
+    type?: string;
+    placeholder?: string;
+  }) => (
+    <div>
+      <Label htmlFor={name as string} className="text-xs">
+        {label}
+      </Label>
+      <Input
+        id={name as string}
+        type={type}
+        step={type === 'number' ? 'any' : undefined}
+        placeholder={placeholder}
+        {...register(name)}
+        className="text-xs h-8"
+      />
+      {errors[name] && (
+        <div className="text-[10px] text-status-error mt-0.5">
+          {String(errors[name]?.message ?? 'inválido')}
+        </div>
+      )}
+    </div>
+  );
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+      {initialValues.extraction_gaps.length > 0 && (
+        <Card className="p-2.5 bg-status-warning-bg border-status-warning">
+          <div className="flex items-center gap-1.5 text-xs text-status-warning">
+            <AlertTriangle className="w-3.5 h-3.5" />
+            <span>
+              Claude não conseguiu extrair: {initialValues.extraction_gaps.join(', ')}
+            </span>
+          </div>
+        </Card>
+      )}
+
+      <fieldset className="space-y-2">
+        <legend className="text-[10px] uppercase tracking-wide text-muted-foreground font-medium">
+          Identificação
+        </legend>
+        <div className="grid grid-cols-2 gap-2">
+          <Field name="product_code" label="Código *" />
+          <Field name="supplier" label="Fornecedor *" />
+        </div>
+        <Field name="product_name" label="Nome *" />
+        <div className="grid grid-cols-2 gap-2">
+          <Field name="product_line" label="Linha" placeholder="wood_pu, wood_nitro…" />
+          <Field
+            name="product_category"
+            label="Categoria"
+            placeholder="primer, verniz, tinta…"
+          />
+        </div>
+      </fieldset>
+
+      <fieldset className="space-y-2">
+        <legend className="text-[10px] uppercase tracking-wide text-muted-foreground font-medium">
+          Físico-químico
+        </legend>
+        <div className="grid grid-cols-2 gap-2">
+          <Field name="densidade_g_cm3" label="Densidade (g/cm³)" type="number" />
+          <Field name="solidos_pct" label="Sólidos (%)" type="number" />
+          <Field
+            name="viscosidade_aplicacao_s"
+            label="Viscosidade aplic. (s)"
+            type="number"
+          />
+          <Field name="viscosidade_copo" label="Copo (CF4/CF6/CF8)" />
+          <Field name="brilho_ub" label="Brilho (UB)" type="number" />
+          <Field name="dureza" label="Dureza (ex: 3H)" />
+        </div>
+      </fieldset>
+
+      <fieldset className="space-y-2">
+        <legend className="text-[10px] uppercase tracking-wide text-muted-foreground font-medium">
+          Aplicação
+        </legend>
+        <div className="grid grid-cols-2 gap-2">
+          <Field name="rendimento_m2_por_litro" label="Rendimento (m²/L)" type="number" />
+          <Field name="demaos_recomendadas" label="Demãos" type="number" />
+          <Field name="gramatura_g_m2_min" label="Gramatura min (g/m²)" type="number" />
+          <Field name="gramatura_g_m2_max" label="Gramatura max (g/m²)" type="number" />
+          <Field name="pot_life_horas" label="Pot life (h)" type="number" />
+          <Field name="temp_aplicacao_c_min" label="Temp min (°C)" type="number" />
+          <Field name="temp_aplicacao_c_max" label="Temp max (°C)" type="number" />
+          <Field name="umidade_aplicacao_pct_min" label="Umidade min (%)" type="number" />
+          <Field name="umidade_aplicacao_pct_max" label="Umidade max (%)" type="number" />
+        </div>
+      </fieldset>
+
+      <fieldset className="space-y-2">
+        <legend className="text-[10px] uppercase tracking-wide text-muted-foreground font-medium">
+          Compatibilidade
+        </legend>
+        <div className="grid grid-cols-2 gap-2">
+          <Field name="catalisador_codigo" label="Catalisador (código)" />
+          <Field
+            name="catalisador_proporcao_pct"
+            label="Catalisador (%)"
+            type="number"
+          />
+          <Field name="diluente_codigo" label="Diluente (código)" />
+          <Field name="lixa_recomendada" label="Lixa" />
+        </div>
+        <Field
+          name="equipamentos_aplicacao"
+          label="Equipamentos (vírgula)"
+          placeholder="pistola_convencional, tanque_pressao"
+        />
+        <Field name="substrato" label="Substrato (vírgula)" placeholder="madeira, mdf" />
+      </fieldset>
+
+      <fieldset className="space-y-2">
+        <legend className="text-[10px] uppercase tracking-wide text-muted-foreground font-medium">
+          Secagem & Armazenamento
+        </legend>
+        <div className="grid grid-cols-3 gap-2">
+          <Field name="secagem_manuseio_h" label="Manuseio (h)" type="number" />
+          <Field name="secagem_empilhamento_h" label="Empilhamento (h)" type="number" />
+          <Field name="secagem_total_h" label="Total (h)" type="number" />
+        </div>
+        <div className="grid grid-cols-3 gap-2">
+          <Field name="validade_dias" label="Validade (dias)" type="number" />
+          <Field name="temp_armazenamento_c_min" label="Temp armaz. min" type="number" />
+          <Field name="temp_armazenamento_c_max" label="Temp armaz. max" type="number" />
+        </div>
+      </fieldset>
+
+      <fieldset className="space-y-2">
+        <legend className="text-[10px] uppercase tracking-wide text-muted-foreground font-medium">
+          Compliance
+        </legend>
+        <Field
+          name="certificacoes_aplicaveis"
+          label="Certificações (vírgula)"
+          placeholder="IKEA, LGA, Proposition_65"
+        />
+        <Field
+          name="isento_metais_pesados"
+          label="Isento metais pesados (vírgula)"
+          placeholder="Cd, Pb, Hg"
+        />
+        <Field
+          name="isento_substancias"
+          label="Isento substâncias (vírgula)"
+          placeholder="amianto, formaldeido"
+        />
+      </fieldset>
+
+      <fieldset className="space-y-2">
+        <legend className="text-[10px] uppercase tracking-wide text-muted-foreground font-medium">
+          Notas qualitativas
+        </legend>
+        <Field
+          name="diferenciais_chave"
+          label="Diferenciais (vírgula)"
+          placeholder="resistencia_risco_superior, toque_sedoso"
+        />
+        <div>
+          <Label htmlFor="uso_recomendado" className="text-xs">
+            Uso recomendado
+          </Label>
+          <Textarea
+            id="uso_recomendado"
+            {...register('uso_recomendado')}
+            className="text-xs min-h-[60px]"
+          />
+        </div>
+        <Field name="publico_alvo" label="Público alvo" />
+      </fieldset>
+
+      <div className="flex items-center justify-between pt-2 border-t border-border">
+        <div className="text-[10px] text-muted-foreground">
+          Confiança da extração:{' '}
+          {Math.round((initialValues.extraction_confidence ?? 0) * 100)}%
+        </div>
+        <Button type="submit" disabled={save.isPending} size="sm">
+          {save.isPending ? (
+            <Loader2 className="w-3.5 h-3.5 animate-spin mr-2" />
+          ) : (
+            <Save className="w-3.5 h-3.5 mr-2" />
+          )}
+          Aprovar e salvar
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/src/hooks/__tests__/useExtractSpecs.test.tsx
+++ b/src/hooks/__tests__/useExtractSpecs.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+
+const { invokeMock } = vi.hoisted(() => ({ invokeMock: vi.fn() }));
+
+vi.mock('@/lib/invoke-function', () => ({
+  invokeFunction: invokeMock,
+}));
+
+import { useExtractSpecs } from '../useExtractSpecs';
+
+function wrapper({ children }: { children: ReactNode }) {
+  const qc = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+const fakeResponse = {
+  specs: {
+    product_code: 'FO20.6827.00',
+    product_name: 'Verniz20 PU 6827',
+    supplier: 'sayerlack',
+    extraction_confidence: 0.9,
+    extraction_gaps: [],
+    equipamentos_aplicacao: ['pistola_convencional'],
+    substrato: ['madeira'],
+    certificacoes_aplicaveis: [],
+    isento_metais_pesados: [],
+    isento_substancias: [],
+    diferenciais_chave: ['resistencia_quimica'],
+  },
+  usage: { inputTokens: 1500, outputTokens: 800, cacheCreationTokens: 0, cacheReadTokens: 0 },
+};
+
+describe('useExtractSpecs', () => {
+  it('estado inicial: idle', () => {
+    const { result } = renderHook(() => useExtractSpecs(), { wrapper });
+    expect(result.current.isPending).toBe(false);
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it('chama invokeFunction com documentId no payload', async () => {
+    invokeMock.mockResolvedValueOnce(fakeResponse);
+    const { result } = renderHook(() => useExtractSpecs(), { wrapper });
+    result.current.mutate('doc-1');
+    await waitFor(() => expect(result.current.data).toEqual(fakeResponse));
+    expect(invokeMock).toHaveBeenCalledWith('kb-extract-specs', { documentId: 'doc-1' });
+  });
+
+  it('propaga erro pra .error', async () => {
+    invokeMock.mockRejectedValueOnce(new Error('quota exceeded'));
+    const { result } = renderHook(() => useExtractSpecs(), { wrapper });
+    result.current.mutate('doc-1');
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toBeInstanceOf(Error);
+  });
+});

--- a/src/hooks/useBundleEngine.ts
+++ b/src/hooks/useBundleEngine.ts
@@ -1,5 +1,6 @@
 import { useState, useCallback } from 'react';
 import { supabase } from '@/integrations/supabase/client';
+import type { Json } from '@/integrations/supabase/types';
 import { useAuth } from '@/contexts/AuthContext';
 import { toast } from 'sonner';
 
@@ -52,6 +53,82 @@ export interface CustomerBundles {
   recentProducts: string[];
 }
 
+// ─── Row types ─────────────────────────────────────────────────────
+interface ClientScoreRow {
+  customer_user_id: string;
+  health_score: number | string | null;
+  answer_rate_60d: number | string | null;
+  whatsapp_reply_rate_60d: number | string | null;
+  avg_monthly_spend_180d: number | string | null;
+  gross_margin_pct: number | string | null;
+  category_count: number | string | null;
+  days_since_last_purchase: number | string | null;
+}
+
+interface ProductRow {
+  id: string;
+  codigo: string | null;
+  descricao: string;
+  valor_unitario: number | string | null;
+  metadata: unknown;
+  ativo: boolean | null;
+  omie_codigo_produto: number | string | null;
+}
+
+interface ProductCostRow {
+  product_id: string;
+  cost_price: number | string | null;
+}
+
+interface ProfileRow {
+  user_id: string;
+  name: string | null;
+  customer_type: string | null;
+  cnae: string | null;
+}
+
+interface ConversionRow {
+  category_id: string;
+  complexity_factor: number | string | null;
+}
+
+interface SalesOrderItem {
+  product_id?: string;
+  omie_codigo_produto?: number | string;
+}
+
+interface SalesOrderRow {
+  customer_user_id: string;
+  items: SalesOrderItem[] | unknown;
+  total: number | string | null;
+  created_at: string;
+}
+
+interface ExistingRecRow {
+  product_id: string;
+  lie: number | string | null;
+  recommendation_type: 'cross_sell' | 'up_sell';
+}
+
+interface StatsRecRow {
+  status: string;
+  actual_margin: number | string | null;
+  time_spent_seconds: number | null;
+}
+
+interface BundleStatsRow extends StatsRecRow {
+  bundle_products: { id: string }[] | unknown;
+}
+
+interface BundleAcceptUpdate {
+  status: 'aceito_total' | 'aceito_parcial';
+  accepted_at: string;
+  updated_at: string;
+  accepted_products?: string[];
+  actual_margin?: number;
+  time_spent_seconds?: number;
+}
+
 const clamp = (v: number, lo: number, hi: number) => Math.max(lo, Math.min(hi, v));
 
 // ─── Configuration ──────────────────────────────────────────────────
@@ -78,15 +155,15 @@ export const useBundleEngine = () => {
 
     try {
       // 1. Load data with fallback for super_admin
-      const fetchAllScores = async (filterFarmerId?: string) => {
-        const all: any[] = [];
+      const fetchAllScores = async (filterFarmerId?: string): Promise<ClientScoreRow[]> => {
+        const all: ClientScoreRow[] = [];
         let page = 0;
         const sz = 1000;
         let hasMore = true;
         while (hasMore) {
           let q = supabase.from('farmer_client_scores').select('*').range(page * sz, (page + 1) * sz - 1);
           if (filterFarmerId) q = q.eq('farmer_id', filterFarmerId);
-          const { data } = await q as any;
+          const { data } = (await q) as unknown as { data: ClientScoreRow[] | null };
           if (!data || data.length === 0) hasMore = false;
           else { all.push(...data); if (data.length < sz) hasMore = false; page++; }
         }
@@ -102,26 +179,26 @@ export const useBundleEngine = () => {
         { data: profiles },
         { data: conversionData },
       ] = await Promise.all([
-        supabase.from('omie_products').select('id, codigo, descricao, valor_unitario, metadata, ativo, omie_codigo_produto').eq('ativo', true) as any,
-        supabase.from('product_costs').select('product_id, cost_price') as any,
-        supabase.from('profiles').select('user_id, name, customer_type, cnae') as any,
-        supabase.from('farmer_category_conversion').select('*') as any,
+        supabase.from('omie_products').select('id, codigo, descricao, valor_unitario, metadata, ativo, omie_codigo_produto').eq('ativo', true) as unknown as Promise<{ data: ProductRow[] | null }>,
+        supabase.from('product_costs').select('product_id, cost_price') as unknown as Promise<{ data: ProductCostRow[] | null }>,
+        supabase.from('profiles').select('user_id, name, customer_type, cnae') as unknown as Promise<{ data: ProfileRow[] | null }>,
+        supabase.from('farmer_category_conversion').select('*') as unknown as Promise<{ data: ConversionRow[] | null }>,
       ]);
 
       if (!clientScores?.length) { setCustomerBundles([]); return; }
 
       // Load ALL sales orders (avoid huge .in() URL)
-      const fetchAllSalesOrders = async () => {
-        const all: any[] = [];
+      const fetchAllSalesOrders = async (): Promise<SalesOrderRow[]> => {
+        const all: SalesOrderRow[] = [];
         let page = 0;
         const sz = 1000;
         let hasMore = true;
         while (hasMore) {
-          const { data } = await supabase
+          const { data } = (await supabase
             .from('sales_orders')
             .select('customer_user_id, items, total, created_at')
             .in('status', ['confirmado', 'faturado', 'entregue'])
-            .range(page * sz, (page + 1) * sz - 1) as any;
+            .range(page * sz, (page + 1) * sz - 1)) as unknown as { data: SalesOrderRow[] | null };
           if (!data || data.length === 0) hasMore = false;
           else { all.push(...data); if (data.length < sz) hasMore = false; page++; }
         }
@@ -131,38 +208,38 @@ export const useBundleEngine = () => {
 
       // Build maps
       const costMap = new Map<string, number>();
-      (productCosts || []).forEach((pc: any) => costMap.set(pc.product_id, Number(pc.cost_price)));
-      const productMap = new Map<string, any>();
-      (products || []).forEach((p: any) => productMap.set(p.id, p));
+      (productCosts || []).forEach((pc) => costMap.set(pc.product_id, Number(pc.cost_price)));
+      const productMap = new Map<string, ProductRow>();
+      (products || []).forEach((p) => productMap.set(p.id, p));
       const omieToProductId = new Map<number, string>();
-      (products || []).forEach((p: any) => {
+      (products || []).forEach((p) => {
         if (p.omie_codigo_produto) omieToProductId.set(Number(p.omie_codigo_produto), p.id);
       });
-      const profileMap = new Map<string, any>();
-      (profiles || []).forEach((p: any) => profileMap.set(p.user_id, p));
-      const conversionMap = new Map<string, any>();
-      (conversionData || []).forEach((c: any) => conversionMap.set(c.category_id, c));
+      const profileMap = new Map<string, ProfileRow>();
+      (profiles || []).forEach((p) => profileMap.set(p.user_id, p));
+      const conversionMap = new Map<string, ConversionRow>();
+      (conversionData || []).forEach((c) => conversionMap.set(c.category_id, c));
 
       // 2. Build transaction baskets per customer
       const baskets: string[][] = [];
       const customerBaskets = new Map<string, Set<string>>();
       const sequentialPurchases = new Map<string, { productId: string; date: Date }[]>();
 
-      for (const order of (salesOrders || [])) {
-        const items = Array.isArray(order.items) ? order.items : [];
-        const productIds = items.map((i: any) => {
+      for (const order of salesOrders || []) {
+        const items: SalesOrderItem[] = Array.isArray(order.items) ? (order.items as SalesOrderItem[]) : [];
+        const productIds = items.map((i) => {
           if (i.product_id) return i.product_id;
           if (i.omie_codigo_produto) return omieToProductId.get(Number(i.omie_codigo_produto));
           return null;
-        }).filter(Boolean) as string[];
+        }).filter((id): id is string => Boolean(id));
         if (productIds.length > 0) {
           baskets.push(productIds);
           if (!customerBaskets.has(order.customer_user_id)) customerBaskets.set(order.customer_user_id, new Set());
-          productIds.forEach((pid: string) => customerBaskets.get(order.customer_user_id)!.add(pid));
-          
+          productIds.forEach((pid) => customerBaskets.get(order.customer_user_id)!.add(pid));
+
           // Sequential tracking
           if (!sequentialPurchases.has(order.customer_user_id)) sequentialPurchases.set(order.customer_user_id, []);
-          productIds.forEach((pid: string) => {
+          productIds.forEach((pid) => {
             sequentialPurchases.get(order.customer_user_id)!.push({
               productId: pid,
               date: new Date(order.created_at),
@@ -259,7 +336,6 @@ export const useBundleEngine = () => {
             const daysDiff = (sorted[j].date.getTime() - sorted[i].date.getTime()) / (1000 * 60 * 60 * 24);
             if (daysDiff > config.sequentialWindowDays) break;
             if (sorted[i].productId === sorted[j].productId) continue;
-            const key = `${sorted[i].productId}→${sorted[j].productId}`;
             // Count in a temp map (simplified: we already have pair data)
             const existingRule = discoveredRules.find(
               r => r.antecedent[0] === sorted[i].productId && r.consequent[0] === sorted[j].productId
@@ -277,7 +353,7 @@ export const useBundleEngine = () => {
       setRules(discoveredRules.slice(0, 50)); // Keep top 50
 
       // Persist top rules
-      await supabase.from('farmer_association_rules' as any).delete().neq('id', '00000000-0000-0000-0000-000000000000');
+      await supabase.from('farmer_association_rules').delete().neq('id', '00000000-0000-0000-0000-000000000000');
       if (discoveredRules.length > 0) {
         const rulesToInsert = discoveredRules.slice(0, 50).map(r => ({
           antecedent_product_ids: r.antecedent,
@@ -288,7 +364,7 @@ export const useBundleEngine = () => {
           rule_type: r.type,
           sample_size: totalBaskets,
         }));
-        await supabase.from('farmer_association_rules' as any).insert(rulesToInsert as any);
+        await supabase.from('farmer_association_rules').insert(rulesToInsert);
       }
 
       // 5. Generate bundles per customer
@@ -369,7 +445,7 @@ export const useBundleEngine = () => {
                 if (lieBundle > 0) {
                   bundles.push({
                     customerId: cid,
-                    customerName: profile.name,
+                    customerName: profile.name ?? '',
                     products: [
                       { id: pid, name: product.descricao, price, cost, margin },
                       { id: relatedPid, name: relatedProduct.descricao, price: relatedPrice, cost: relatedCost, margin: relatedMargin },
@@ -395,14 +471,14 @@ export const useBundleEngine = () => {
 
         // Best individual product (from cross-sell engine data)
         let bestIndividual: IndividualComparison | null = null;
-        const { data: existingRecs } = await supabase
-          .from('farmer_recommendations' as any)
+        const { data: existingRecs } = (await supabase
+          .from('farmer_recommendations')
           .select('product_id, lie, recommendation_type')
           .eq('farmer_id', user.id)
           .eq('customer_user_id', cid)
           .eq('status', 'pendente')
           .order('lie', { ascending: false })
-          .limit(1) as any;
+          .limit(1)) as unknown as { data: ExistingRecRow[] | null };
 
         if (existingRecs?.length) {
           const rec = existingRecs[0];
@@ -416,10 +492,12 @@ export const useBundleEngine = () => {
         }
 
         if (topBundles.length > 0 || bestIndividual) {
-          const purchasedProducts = [...purchased].map(pid => productMap.get(pid)?.descricao).filter(Boolean);
+          const purchasedProducts = [...purchased]
+            .map((pid) => productMap.get(pid)?.descricao)
+            .filter((d): d is string => Boolean(d));
           allCustomerBundles.push({
             customerId: cid,
-            customerName: profile.name,
+            customerName: profile.name ?? '',
             healthScore,
             bundles: topBundles,
             bestIndividual,
@@ -446,10 +524,10 @@ export const useBundleEngine = () => {
       // Persist bundle recommendations
       for (const cb of allCustomerBundles) {
         for (const bundle of cb.bundles) {
-          await supabase.from('farmer_bundle_recommendations' as any).insert({
+          await supabase.from('farmer_bundle_recommendations').insert({
             farmer_id: user.id,
             customer_user_id: bundle.customerId,
-            bundle_products: bundle.products,
+            bundle_products: bundle.products as unknown as Json,
             support: bundle.support,
             confidence: bundle.confidence,
             lift: bundle.lift,
@@ -458,7 +536,7 @@ export const useBundleEngine = () => {
             lie_bundle: bundle.lieBundle,
             complexity_factor: bundle.complexityFactor,
             status: 'pendente',
-          } as any);
+          });
         }
       }
 
@@ -474,8 +552,8 @@ export const useBundleEngine = () => {
 
   // ─── Actions ─────────────────────────────────────────────────────────
   const markBundleOffered = useCallback(async (bundleId: string) => {
-    await supabase.from('farmer_bundle_recommendations' as any)
-      .update({ status: 'ofertado', offered_at: new Date().toISOString() } as any)
+    await supabase.from('farmer_bundle_recommendations')
+      .update({ status: 'ofertado', offered_at: new Date().toISOString() })
       .eq('id', bundleId);
   }, []);
 
@@ -486,7 +564,7 @@ export const useBundleEngine = () => {
     actualMargin?: number,
     timeSpent?: number
   ) => {
-    const update: any = {
+    const update: BundleAcceptUpdate = {
       status: acceptType === 'total' ? 'aceito_total' : 'aceito_parcial',
       accepted_at: new Date().toISOString(),
       updated_at: new Date().toISOString(),
@@ -495,7 +573,7 @@ export const useBundleEngine = () => {
     if (actualMargin !== undefined) update.actual_margin = actualMargin;
     if (timeSpent !== undefined) update.time_spent_seconds = timeSpent;
 
-    await supabase.from('farmer_bundle_recommendations' as any).update(update).eq('id', bundleId);
+    await supabase.from('farmer_bundle_recommendations').update(update).eq('id', bundleId);
 
     // Update conversion stats for each product
     if (acceptedProducts && actualMargin !== undefined) {
@@ -507,51 +585,51 @@ export const useBundleEngine = () => {
   }, []);
 
   const markBundleRejected = useCallback(async (bundleId: string) => {
-    await supabase.from('farmer_bundle_recommendations' as any)
-      .update({ status: 'rejeitado', rejected_at: new Date().toISOString() } as any)
+    await supabase.from('farmer_bundle_recommendations')
+      .update({ status: 'rejeitado', rejected_at: new Date().toISOString() })
       .eq('id', bundleId);
   }, []);
 
   const updateConversionStats = async (productId: string) => {
-    const { data: recs } = await supabase.from('farmer_recommendations' as any)
+    const { data: recs } = (await supabase.from('farmer_recommendations')
       .select('status, actual_margin, time_spent_seconds')
       .eq('product_id', productId)
-      .in('status', ['aceito', 'rejeitado', 'ofertado']) as any;
+      .in('status', ['aceito', 'rejeitado', 'ofertado'])) as unknown as { data: StatsRecRow[] | null };
 
-    const { data: bundleRecs } = await supabase.from('farmer_bundle_recommendations' as any)
+    const { data: bundleRecs } = (await supabase.from('farmer_bundle_recommendations')
       .select('status, actual_margin, time_spent_seconds, bundle_products')
-      .in('status', ['aceito_total', 'aceito_parcial', 'rejeitado', 'ofertado']) as any;
+      .in('status', ['aceito_total', 'aceito_parcial', 'rejeitado', 'ofertado'])) as unknown as { data: BundleStatsRow[] | null };
 
-    const allRecs = [
-      ...(recs || []).map((r: any) => ({ ...r, source: 'individual' })),
-      ...(bundleRecs || []).filter((b: any) => {
-        const prods = Array.isArray(b.bundle_products) ? b.bundle_products : [];
-        return prods.some((p: any) => p.id === productId);
-      }).map((r: any) => ({ ...r, source: 'bundle' })),
+    const allRecs: StatsRecRow[] = [
+      ...(recs || []),
+      ...(bundleRecs || []).filter((b) => {
+        const prods = Array.isArray(b.bundle_products) ? (b.bundle_products as { id: string }[]) : [];
+        return prods.some((p) => p.id === productId);
+      }),
     ];
 
     if (!allRecs.length) return;
 
     const offered = allRecs.length;
-    const accepted = allRecs.filter((r: any) =>
+    const accepted = allRecs.filter((r) =>
       ['aceito', 'aceito_total', 'aceito_parcial'].includes(r.status)
     ).length;
     const rate = offered > 0 ? accepted / offered : 0;
 
-    const withMargin = allRecs.filter((r: any) => r.actual_margin != null);
+    const withMargin = allRecs.filter((r) => r.actual_margin != null);
     const avgMargin = withMargin.length > 0
-      ? withMargin.reduce((s: number, r: any) => s + Number(r.actual_margin), 0) / withMargin.length
+      ? withMargin.reduce((s, r) => s + Number(r.actual_margin), 0) / withMargin.length
       : 0;
 
-    const withTime = allRecs.filter((r: any) => r.time_spent_seconds != null);
+    const withTime = allRecs.filter((r): r is StatsRecRow & { time_spent_seconds: number } => r.time_spent_seconds != null);
     const avgTime = withTime.length > 0
-      ? Math.round(withTime.reduce((s: number, r: any) => s + r.time_spent_seconds, 0) / withTime.length)
+      ? Math.round(withTime.reduce((s, r) => s + r.time_spent_seconds, 0) / withTime.length)
       : 0;
 
     const profitPerHour = avgTime > 0 ? (avgMargin / (avgTime / 3600)) : 0;
     const complexity = profitPerHour > 0 ? clamp(1.0 / (1 + Math.log(1 + profitPerHour / 100)), 0.5, 1.5) : 1.0;
 
-    await supabase.from('farmer_category_conversion' as any).upsert({
+    await supabase.from('farmer_category_conversion').upsert({
       category_id: productId,
       total_offers: offered,
       total_accepts: accepted,
@@ -561,7 +639,7 @@ export const useBundleEngine = () => {
       profit_per_hour: Math.round(profitPerHour * 100) / 100,
       complexity_factor: Math.round(complexity * 1000) / 1000,
       updated_at: new Date().toISOString(),
-    } as any);
+    });
   };
 
   return {

--- a/src/hooks/useCrossSellEngine.ts
+++ b/src/hooks/useCrossSellEngine.ts
@@ -29,6 +29,80 @@ export interface CustomerRecommendations {
   upSell: Recommendation[];
 }
 
+// ─── Row types ─────────────────────────────────────────────────────
+interface ClientScoreRow {
+  customer_user_id: string;
+  health_score: number | string | null;
+  answer_rate_60d: number | string | null;
+  whatsapp_reply_rate_60d: number | string | null;
+}
+
+interface ProductRow {
+  id: string;
+  codigo: string | null;
+  descricao: string;
+  valor_unitario: number | string | null;
+  metadata: unknown;
+  ativo: boolean | null;
+  omie_codigo_produto: number | string | null;
+  estoque: number | null;
+}
+
+interface ProductCostRow {
+  product_id: string;
+  cost_price: number | string | null;
+}
+
+interface SalesOrderItem {
+  product_id?: string;
+  omie_codigo_produto?: number | string;
+  quantity?: number | string;
+  quantidade?: number | string;
+  unit_price?: number | string;
+  valor_unitario?: number | string;
+}
+
+interface SalesOrderRow {
+  customer_user_id: string;
+  items: SalesOrderItem[] | unknown;
+  total: number | string | null;
+  created_at: string;
+}
+
+interface ConversionRow {
+  category_id: string;
+  conversion_rate: number | string | null;
+  complexity_factor: number | string | null;
+}
+
+interface AssocRuleRow {
+  antecedent_product_ids: string[] | null;
+  consequent_product_ids: string[] | null;
+  confidence: number | string | null;
+  lift: number | string | null;
+  support: number | string | null;
+}
+
+interface ProfileRow {
+  user_id: string;
+  name: string | null;
+  customer_type: string | null;
+  cnae: string | null;
+}
+
+interface RecommendationStatsRow {
+  status: string;
+  actual_margin: number | string | null;
+  time_spent_seconds: number | null;
+}
+
+interface RecommendationUpdate {
+  status: 'aceito';
+  accepted_at: string;
+  actual_margin?: number;
+  time_spent_seconds?: number;
+}
+
 const clamp = (v: number, lo: number, hi: number) => Math.max(lo, Math.min(hi, v));
 
 // ─── Main Hook ───────────────────────────────────────────────────────
@@ -45,15 +119,15 @@ export const useCrossSellEngine = () => {
 
     try {
       // 1. Load client scores with pagination
-      const fetchAllScores = async (filterFarmerId?: string) => {
-        const all: any[] = [];
+      const fetchAllScores = async (filterFarmerId?: string): Promise<ClientScoreRow[]> => {
+        const all: ClientScoreRow[] = [];
         let page = 0;
         const sz = 1000;
         let hasMore = true;
         while (hasMore) {
           let q = supabase.from('farmer_client_scores').select('*').range(page * sz, (page + 1) * sz - 1);
           if (filterFarmerId) q = q.eq('farmer_id', filterFarmerId);
-          const { data } = await q as any;
+          const { data } = (await q) as unknown as { data: ClientScoreRow[] | null };
           if (!data || data.length === 0) hasMore = false;
           else { all.push(...data); if (data.length < sz) hasMore = false; page++; }
         }
@@ -72,30 +146,30 @@ export const useCrossSellEngine = () => {
       }
 
       // 2. Load all products with costs
-      const { data: products } = await supabase
+      const { data: products } = (await supabase
         .from('omie_products')
         .select('id, codigo, descricao, valor_unitario, metadata, ativo, omie_codigo_produto, estoque')
-        .eq('ativo', true) as any;
+        .eq('ativo', true)) as unknown as { data: ProductRow[] | null };
 
-      const { data: productCosts } = await supabase
+      const { data: productCosts } = (await supabase
         .from('product_costs')
-        .select('product_id, cost_price') as any;
+        .select('product_id, cost_price')) as unknown as { data: ProductCostRow[] | null };
 
       const costMap = new Map<string, number>();
-      (productCosts || []).forEach((pc: any) => costMap.set(pc.product_id, Number(pc.cost_price)));
+      (productCosts || []).forEach((pc) => costMap.set(pc.product_id, Number(pc.cost_price)));
 
       // 3. Load ALL sales history (avoid huge .in() URL with 3598 IDs)
-      const fetchAllSalesOrders = async () => {
-        const all: any[] = [];
+      const fetchAllSalesOrders = async (): Promise<SalesOrderRow[]> => {
+        const all: SalesOrderRow[] = [];
         let page = 0;
         const sz = 1000;
         let hasMore = true;
         while (hasMore) {
-          const { data } = await supabase
+          const { data } = (await supabase
             .from('sales_orders')
             .select('customer_user_id, items, total, created_at')
             .in('status', ['confirmado', 'faturado', 'entregue'])
-            .range(page * sz, (page + 1) * sz - 1) as any;
+            .range(page * sz, (page + 1) * sz - 1)) as unknown as { data: SalesOrderRow[] | null };
           if (!data || data.length === 0) hasMore = false;
           else { all.push(...data); if (data.length < sz) hasMore = false; page++; }
         }
@@ -105,11 +179,11 @@ export const useCrossSellEngine = () => {
 
       // Build set of customer IDs that have orders
       const customerIdsWithOrders = new Set<string>();
-      (salesOrders || []).forEach((o: any) => customerIdsWithOrders.add(o.customer_user_id));
+      (salesOrders || []).forEach((o) => customerIdsWithOrders.add(o.customer_user_id));
 
       // Filter clientScores to only those with orders (avoid processing 3598 empty clients)
-      const activeClientScores = clientScores.filter((c: any) => customerIdsWithOrders.has(c.customer_user_id));
-      const customerIds = activeClientScores.map((c: any) => c.customer_user_id);
+      const activeClientScores = clientScores.filter((c) => customerIdsWithOrders.has(c.customer_user_id));
+      const customerIds = activeClientScores.map((c) => c.customer_user_id);
 
       if (!customerIds.length) {
         setRecommendations([]);
@@ -117,25 +191,25 @@ export const useCrossSellEngine = () => {
       }
 
       // 4. Load category conversion rates (learning data)
-      const { data: conversionData } = await supabase
+      const { data: conversionData } = (await supabase
         .from('farmer_category_conversion')
-        .select('*') as any;
-      const conversionMap = new Map<string, any>();
-      (conversionData || []).forEach((c: any) => conversionMap.set(c.category_id, c));
+        .select('*')) as unknown as { data: ConversionRow[] | null };
+      const conversionMap = new Map<string, ConversionRow>();
+      (conversionData || []).forEach((c) => conversionMap.set(c.category_id, c));
 
       // 4b. Load association rules for personalized recommendations
-      const { data: assocRules } = await supabase
+      const { data: assocRules } = (await supabase
         .from('farmer_association_rules')
         .select('antecedent_product_ids, consequent_product_ids, confidence, lift, support')
         .gte('confidence', 0.05)
-        .gte('lift', 1.0) as any;
+        .gte('lift', 1.0)) as unknown as { data: AssocRuleRow[] | null };
 
       // Build map: antecedent product -> consequent products with scores
       const assocMap = new Map<string, { productId: string; confidence: number; lift: number; support: number }[]>();
-      for (const rule of (assocRules || [])) {
-        for (const ant of (rule.antecedent_product_ids || [])) {
+      for (const rule of assocRules || []) {
+        for (const ant of rule.antecedent_product_ids || []) {
           if (!assocMap.has(ant)) assocMap.set(ant, []);
-          for (const cons of (rule.consequent_product_ids || [])) {
+          for (const cons of rule.consequent_product_ids || []) {
             assocMap.get(ant)!.push({
               productId: cons,
               confidence: Number(rule.confidence),
@@ -148,21 +222,21 @@ export const useCrossSellEngine = () => {
 
       // 5. Load customer profiles for active clients only
       // Split into batches of 100 to avoid URL limits
-      const allProfiles: any[] = [];
+      const allProfiles: ProfileRow[] = [];
       for (let i = 0; i < customerIds.length; i += 100) {
         const batch = customerIds.slice(i, i + 100);
-        const { data: batchProfiles } = await supabase
+        const { data: batchProfiles } = (await supabase
           .from('profiles')
           .select('user_id, name, customer_type, cnae')
-          .in('user_id', batch);
+          .in('user_id', batch)) as unknown as { data: ProfileRow[] | null };
         if (batchProfiles) allProfiles.push(...batchProfiles);
       }
-      const profileMap = new Map<string, any>();
-      allProfiles.forEach((p: any) => profileMap.set(p.user_id, p));
+      const profileMap = new Map<string, ProfileRow>();
+      allProfiles.forEach((p) => profileMap.set(p.user_id, p));
 
       // 6. Build omie_codigo_produto -> product UUID map
       const omieToProductId = new Map<number, string>();
-      (products || []).forEach((p: any) => {
+      (products || []).forEach((p) => {
         if (p.omie_codigo_produto) omieToProductId.set(Number(p.omie_codigo_produto), p.id);
       });
 
@@ -170,12 +244,12 @@ export const useCrossSellEngine = () => {
       const customerProducts = new Map<string, Map<string, { qty: number; price: number; cost: number }>>();
       const allProductPurchases = new Map<string, number>(); // product_id -> total customers who bought
 
-      for (const order of (salesOrders || [])) {
+      for (const order of salesOrders || []) {
         const cid = order.customer_user_id;
         if (!customerProducts.has(cid)) customerProducts.set(cid, new Map());
         const cp = customerProducts.get(cid)!;
 
-        const items = Array.isArray(order.items) ? order.items : [];
+        const items: SalesOrderItem[] = Array.isArray(order.items) ? (order.items as SalesOrderItem[]) : [];
         for (const item of items) {
           // Resolve product_id: use direct product_id or map from omie_codigo_produto
           let productId = item.product_id;
@@ -272,7 +346,7 @@ export const useCrossSellEngine = () => {
           if (lie > 0) {
             crossSellRecs.push({
               customerId: cid,
-              customerName: profile.name,
+              customerName: profile.name ?? '',
               type: 'cross_sell',
               productId: product.id,
               productName: product.descricao,
@@ -320,10 +394,10 @@ export const useCrossSellEngine = () => {
             const lie = pij * mij * complexityFactor;
 
             if (lie > 0) {
-              const currentProduct = productList.find((p: any) => p.id === purchasedId);
+              const currentProduct = productList.find((p) => p.id === purchasedId);
               upSellRecs.push({
                 customerId: cid,
-                customerName: profile.name,
+                customerName: profile.name ?? '',
                 type: 'up_sell',
                 productId: product.id,
                 productName: product.descricao,
@@ -351,7 +425,7 @@ export const useCrossSellEngine = () => {
         if (topCross.length > 0 || topUp.length > 0) {
           allRecs.push({
             customerId: cid,
-            customerName: profile.name,
+            customerName: profile.name ?? '',
             healthScore,
             crossSell: topCross,
             upSell: topUp,
@@ -386,7 +460,7 @@ export const useCrossSellEngine = () => {
         })),
       );
       if (recRows.length > 0) {
-        await supabase.from('farmer_recommendations' as any).upsert(recRows as any);
+        await supabase.from('farmer_recommendations').upsert(recRows);
       }
     } catch (error) {
       console.error('Error calculating recommendations:', error);
@@ -398,58 +472,58 @@ export const useCrossSellEngine = () => {
 
   // ─── Actions ─────────────────────────────────────────────────────────
   const markAsOffered = useCallback(async (recId: string) => {
-    await supabase.from('farmer_recommendations' as any)
-      .update({ status: 'ofertado', offered_at: new Date().toISOString() } as any)
+    await supabase.from('farmer_recommendations')
+      .update({ status: 'ofertado', offered_at: new Date().toISOString() })
       .eq('id', recId);
   }, []);
 
   const markAsAccepted = useCallback(async (recId: string, actualMargin?: number, timeSpent?: number) => {
-    const update: any = {
+    const update: RecommendationUpdate = {
       status: 'aceito',
       accepted_at: new Date().toISOString(),
     };
     if (actualMargin !== undefined) update.actual_margin = actualMargin;
     if (timeSpent !== undefined) update.time_spent_seconds = timeSpent;
 
-    await supabase.from('farmer_recommendations' as any).update(update).eq('id', recId);
+    await supabase.from('farmer_recommendations').update(update).eq('id', recId);
 
     // Update category conversion rates (learning)
     if (actualMargin !== undefined) {
-      const { data: rec } = await supabase.from('farmer_recommendations' as any)
-        .select('product_id').eq('id', recId).single();
+      const { data: rec } = (await supabase.from('farmer_recommendations')
+        .select('product_id').eq('id', recId).single()) as unknown as { data: { product_id: string } | null };
       if (rec) {
-        await updateConversionStats((rec as any).product_id);
+        await updateConversionStats(rec.product_id);
       }
     }
   }, []);
 
   const markAsRejected = useCallback(async (recId: string) => {
-    await supabase.from('farmer_recommendations' as any)
-      .update({ status: 'rejeitado', rejected_at: new Date().toISOString() } as any)
+    await supabase.from('farmer_recommendations')
+      .update({ status: 'rejeitado', rejected_at: new Date().toISOString() })
       .eq('id', recId);
   }, []);
 
   // Recalculate conversion stats from historical data
   const updateConversionStats = async (productId: string) => {
-    const { data: recs } = await supabase.from('farmer_recommendations' as any)
+    const { data: recs } = (await supabase.from('farmer_recommendations')
       .select('status, actual_margin, time_spent_seconds')
       .eq('product_id', productId)
-      .in('status', ['aceito', 'rejeitado', 'ofertado']) as any;
+      .in('status', ['aceito', 'rejeitado', 'ofertado'])) as unknown as { data: RecommendationStatsRow[] | null };
 
     if (!recs?.length) return;
 
-    const offered = recs.filter((r: any) => ['aceito', 'rejeitado', 'ofertado'].includes(r.status)).length;
-    const accepted = recs.filter((r: any) => r.status === 'aceito').length;
+    const offered = recs.filter((r) => ['aceito', 'rejeitado', 'ofertado'].includes(r.status)).length;
+    const accepted = recs.filter((r) => r.status === 'aceito').length;
     const rate = offered > 0 ? accepted / offered : 0;
 
-    const acceptedRecs = recs.filter((r: any) => r.status === 'aceito' && r.actual_margin != null);
+    const acceptedRecs = recs.filter((r) => r.status === 'aceito' && r.actual_margin != null);
     const avgMargin = acceptedRecs.length > 0
-      ? acceptedRecs.reduce((s: number, r: any) => s + Number(r.actual_margin), 0) / acceptedRecs.length
+      ? acceptedRecs.reduce((s, r) => s + Number(r.actual_margin), 0) / acceptedRecs.length
       : 0;
 
-    const withTime = acceptedRecs.filter((r: any) => r.time_spent_seconds != null);
+    const withTime = acceptedRecs.filter((r): r is RecommendationStatsRow & { time_spent_seconds: number } => r.time_spent_seconds != null);
     const avgTime = withTime.length > 0
-      ? Math.round(withTime.reduce((s: number, r: any) => s + r.time_spent_seconds, 0) / withTime.length)
+      ? Math.round(withTime.reduce((s, r) => s + r.time_spent_seconds, 0) / withTime.length)
       : 0;
 
     const profitPerHour = avgTime > 0 ? (avgMargin / (avgTime / 3600)) : 0;
@@ -457,7 +531,7 @@ export const useCrossSellEngine = () => {
     // Complexity factor: higher profit/hour = lower complexity (easier to sell)
     const complexity = profitPerHour > 0 ? clamp(1.0 / (1 + Math.log(1 + profitPerHour / 100)), 0.5, 1.5) : 1.0;
 
-    await supabase.from('farmer_category_conversion' as any).upsert({
+    await supabase.from('farmer_category_conversion').upsert({
       category_id: productId,
       total_offers: offered,
       total_accepts: accepted,
@@ -467,7 +541,7 @@ export const useCrossSellEngine = () => {
       profit_per_hour: Math.round(profitPerHour * 100) / 100,
       complexity_factor: Math.round(complexity * 1000) / 1000,
       updated_at: new Date().toISOString(),
-    } as any);
+    });
   };
 
   return {

--- a/src/hooks/useExtractSpecs.ts
+++ b/src/hooks/useExtractSpecs.ts
@@ -1,0 +1,26 @@
+import { useMutation } from '@tanstack/react-query';
+import { invokeFunction } from '@/lib/invoke-function';
+import { toast } from 'sonner';
+import type { KbExtractedSpec } from '@/lib/knowledge-base/specs-types';
+
+interface ExtractResponse {
+  specs: KbExtractedSpec;
+  usage: {
+    inputTokens: number;
+    outputTokens: number;
+    cacheCreationTokens: number;
+    cacheReadTokens: number;
+  };
+}
+
+export function useExtractSpecs() {
+  return useMutation({
+    mutationFn: async (documentId: string): Promise<ExtractResponse> => {
+      const response = await invokeFunction<ExtractResponse>('kb-extract-specs', { documentId });
+      return response;
+    },
+    onError: (err) => {
+      toast.error('Erro na extração', { description: err instanceof Error ? err.message : '' });
+    },
+  });
+}

--- a/src/hooks/useFarmerExperiments.ts
+++ b/src/hooks/useFarmerExperiments.ts
@@ -47,6 +47,55 @@ const METRIC_LABELS: Record<string, string> = {
   receita_incremental: 'Receita Incremental',
 };
 
+// ─── Row types ─────────────────────────────────────────────────────
+interface ExperimentRow {
+  id: string;
+  farmer_id: string;
+  title: string;
+  hypothesis: string;
+  primary_metric: Experiment['primary_metric'];
+  min_duration_days: number;
+  min_sample_size: number;
+  min_significance: number;
+  status: Experiment['status'];
+  winner: Experiment['winner'];
+  control_description: string | null;
+  test_description: string | null;
+  control_metric_value: number;
+  test_metric_value: number;
+  lift_pct: number;
+  p_value: number | null;
+  started_at: string | null;
+  ended_at: string | null;
+  created_at: string;
+}
+
+interface ExperimentClientRow {
+  id: string;
+  experiment_id: string;
+  customer_user_id: string;
+  group_type: 'controle' | 'teste';
+  metric_value: number;
+  revenue_generated: number;
+  margin_generated: number;
+  calls_count: number;
+  total_time_seconds: number;
+}
+
+interface ClientScoreLite {
+  customer_user_id: string;
+  health_score: number | string | null;
+  priority_score: number | string | null;
+}
+
+interface FarmerCallLite {
+  customer_user_id: string;
+  revenue_generated: number | string | null;
+  margin_generated: number | string | null;
+  duration_seconds: number | string | null;
+  follow_up_duration_seconds: number | string | null;
+}
+
 export const useFarmerExperiments = () => {
   const { user } = useAuth();
   const [experiments, setExperiments] = useState<Experiment[]>([]);
@@ -56,32 +105,32 @@ export const useFarmerExperiments = () => {
     if (!user?.id) return;
     setLoading(true);
     try {
-      const { data } = await supabase
-        .from('farmer_experiments' as any)
+      const { data } = (await supabase
+        .from('farmer_experiments')
         .select('*')
         .eq('farmer_id', user.id)
-        .order('created_at', { ascending: false }) as any;
+        .order('created_at', { ascending: false })) as unknown as { data: ExperimentRow[] | null };
 
       if (data) {
         // Load client counts em 1 query (antes era N+1: 1 select por experimento)
-        const expIds = data.map((e: any) => e.id);
+        const expIds = data.map((e) => e.id);
         const { data: allClients } = expIds.length > 0
-          ? await supabase
-              .from('farmer_experiment_clients' as any)
+          ? ((await supabase
+              .from('farmer_experiment_clients')
               .select('experiment_id, group_type')
-              .in('experiment_id', expIds) as any
-          : { data: [] };
+              .in('experiment_id', expIds)) as unknown as { data: Array<{ experiment_id: string; group_type: string }> | null })
+          : { data: [] as Array<{ experiment_id: string; group_type: string }> };
 
         // Agrupa client-side: experiment_id → { controle, teste }
         const counts = new Map<string, { controle: number; teste: number }>();
-        for (const c of (allClients || []) as Array<{ experiment_id: string; group_type: string }>) {
+        for (const c of allClients || []) {
           const existing = counts.get(c.experiment_id) || { controle: 0, teste: 0 };
           if (c.group_type === 'controle') existing.controle++;
           else if (c.group_type === 'teste') existing.teste++;
           counts.set(c.experiment_id, existing);
         }
 
-        const enriched = data.map((exp: any) => {
+        const enriched: Experiment[] = data.map((exp) => {
           const c = counts.get(exp.id) || { controle: 0, teste: 0 };
           return { ...exp, control_count: c.controle, test_count: c.teste };
         });
@@ -107,10 +156,10 @@ export const useFarmerExperiments = () => {
     test_description: string;
   }) => {
     if (!user?.id) return;
-    const { error } = await supabase.from('farmer_experiments' as any).insert({
+    const { error } = await supabase.from('farmer_experiments').insert({
       farmer_id: user.id,
       ...input,
-    } as any);
+    });
     if (error) {
       toast.error('Erro ao criar experimento');
       return;
@@ -123,10 +172,10 @@ export const useFarmerExperiments = () => {
     if (!user?.id) return;
 
     // Load eligible clients from farmer_client_scores
-    const { data: clients } = await supabase
+    const { data: clients } = (await supabase
       .from('farmer_client_scores')
       .select('customer_user_id, health_score, priority_score')
-      .eq('farmer_id', user.id) as any;
+      .eq('farmer_id', user.id)) as unknown as { data: ClientScoreLite[] | null };
 
     if (!clients || clients.length < 2) {
       toast.error('Não há clientes suficientes para o experimento');
@@ -134,17 +183,17 @@ export const useFarmerExperiments = () => {
     }
 
     // Stratified random assignment: sort by health_score, alternate
-    const sorted = [...clients].sort((a: any, b: any) => Number(b.health_score) - Number(a.health_score));
-    const assignments = sorted.map((c: any, i: number) => ({
+    const sorted = [...clients].sort((a, b) => Number(b.health_score) - Number(a.health_score));
+    const assignments = sorted.map((c, i) => ({
       experiment_id: experimentId,
       customer_user_id: c.customer_user_id,
-      group_type: i % 2 === 0 ? 'controle' : 'teste',
+      group_type: (i % 2 === 0 ? 'controle' : 'teste') as 'controle' | 'teste',
     }));
 
     // Insert assignments
     const { error: assignError } = await supabase
-      .from('farmer_experiment_clients' as any)
-      .insert(assignments as any);
+      .from('farmer_experiment_clients')
+      .insert(assignments);
 
     if (assignError) {
       console.error('Assignment error:', assignError);
@@ -153,8 +202,8 @@ export const useFarmerExperiments = () => {
     }
 
     // Start experiment
-    await supabase.from('farmer_experiments' as any)
-      .update({ status: 'ativo', started_at: new Date().toISOString() } as any)
+    await supabase.from('farmer_experiments')
+      .update({ status: 'ativo', started_at: new Date().toISOString() })
       .eq('id', experimentId);
 
     toast.success('Experimento iniciado com ' + assignments.length + ' clientes');
@@ -163,34 +212,34 @@ export const useFarmerExperiments = () => {
 
   const measureExperiment = useCallback(async (experimentId: string) => {
     // Load experiment
-    const { data: exp } = await supabase
-      .from('farmer_experiments' as any)
+    const { data: exp } = (await supabase
+      .from('farmer_experiments')
       .select('*')
       .eq('id', experimentId)
-      .single() as any;
-    if (!exp) return;
+      .single()) as unknown as { data: ExperimentRow | null };
+    if (!exp || !exp.started_at) return;
 
     // Load experiment clients with their call data
-    const { data: expClients } = await supabase
-      .from('farmer_experiment_clients' as any)
+    const { data: expClients } = (await supabase
+      .from('farmer_experiment_clients')
       .select('*')
-      .eq('experiment_id', experimentId) as any;
+      .eq('experiment_id', experimentId)) as unknown as { data: ExperimentClientRow[] | null };
 
     if (!expClients?.length) return;
 
     const startDate = exp.started_at;
-    const clientIds = expClients.map((c: any) => c.customer_user_id);
+    const clientIds = expClients.map((c) => c.customer_user_id);
 
     // Load calls since experiment start
-    const { data: calls } = await supabase
+    const { data: calls } = (await supabase
       .from('farmer_calls')
       .select('*')
       .in('customer_user_id', clientIds)
-      .gte('created_at', startDate) as any;
+      .gte('created_at', startDate)) as unknown as { data: FarmerCallLite[] | null };
 
     // Aggregate per client
     const clientMetrics = new Map<string, { revenue: number; margin: number; calls: number; time: number }>();
-    for (const call of (calls || [])) {
+    for (const call of calls || []) {
       const existing = clientMetrics.get(call.customer_user_id) || { revenue: 0, margin: 0, calls: 0, time: 0 };
       existing.revenue += Number(call.revenue_generated || 0);
       existing.margin += Number(call.margin_generated || 0);
@@ -201,11 +250,14 @@ export const useFarmerExperiments = () => {
 
     // Update experiment clients (batch upsert único — antes era N updates sequenciais)
     const updateRows = expClients
-      .map((ec: any) => {
+      .map((ec) => {
         const m = clientMetrics.get(ec.customer_user_id);
         if (!m) return null;
         return {
           id: ec.id,
+          experiment_id: ec.experiment_id,
+          customer_user_id: ec.customer_user_id,
+          group_type: ec.group_type,
           revenue_generated: m.revenue,
           margin_generated: m.margin,
           calls_count: m.calls,
@@ -217,32 +269,32 @@ export const useFarmerExperiments = () => {
       .filter((r): r is NonNullable<typeof r> => r !== null);
 
     if (updateRows.length > 0) {
-      await supabase.from('farmer_experiment_clients' as any).upsert(updateRows as any);
+      await supabase.from('farmer_experiment_clients').upsert(updateRows);
     }
 
     // Reload clients after update
-    const { data: updatedClients } = await supabase
-      .from('farmer_experiment_clients' as any)
+    const { data: updatedClients } = (await supabase
+      .from('farmer_experiment_clients')
       .select('*')
-      .eq('experiment_id', experimentId) as any;
+      .eq('experiment_id', experimentId)) as unknown as { data: ExperimentClientRow[] | null };
 
     if (!updatedClients?.length) return;
 
-    const controlGroup = updatedClients.filter((c: any) => c.group_type === 'controle');
-    const testGroup = updatedClients.filter((c: any) => c.group_type === 'teste');
+    const controlGroup = updatedClients.filter((c) => c.group_type === 'controle');
+    const testGroup = updatedClients.filter((c) => c.group_type === 'teste');
 
     const controlAvg = controlGroup.length > 0
-      ? controlGroup.reduce((s: number, c: any) => s + Number(c.metric_value), 0) / controlGroup.length
+      ? controlGroup.reduce((s, c) => s + Number(c.metric_value), 0) / controlGroup.length
       : 0;
     const testAvg = testGroup.length > 0
-      ? testGroup.reduce((s: number, c: any) => s + Number(c.metric_value), 0) / testGroup.length
+      ? testGroup.reduce((s, c) => s + Number(c.metric_value), 0) / testGroup.length
       : 0;
 
     const liftPct = controlAvg > 0 ? ((testAvg - controlAvg) / controlAvg) * 100 : 0;
 
     // Simple Z-test for significance
-    const pValue = calculatePValue(controlGroup.map((c: any) => Number(c.metric_value)),
-      testGroup.map((c: any) => Number(c.metric_value)));
+    const pValue = calculatePValue(controlGroup.map((c) => Number(c.metric_value)),
+      testGroup.map((c) => Number(c.metric_value)));
 
     // Check completion criteria
     const daysSinceStart = Math.floor((Date.now() - new Date(startDate).getTime()) / (1000 * 60 * 60 * 24));
@@ -250,8 +302,8 @@ export const useFarmerExperiments = () => {
     const hasMinSample = controlGroup.length >= exp.min_sample_size && testGroup.length >= exp.min_sample_size;
     const isSignificant = pValue !== null && (1 - pValue) >= exp.min_significance;
 
-    let winner: string | null = null;
-    let newStatus = exp.status;
+    let winner: Experiment['winner'] = null;
+    let newStatus: Experiment['status'] = exp.status;
 
     if (hasMinDuration && hasMinSample) {
       if (isSignificant) {
@@ -264,7 +316,7 @@ export const useFarmerExperiments = () => {
       }
     }
 
-    await supabase.from('farmer_experiments' as any)
+    await supabase.from('farmer_experiments')
       .update({
         control_metric_value: Math.round(controlAvg * 100) / 100,
         test_metric_value: Math.round(testAvg * 100) / 100,
@@ -274,7 +326,7 @@ export const useFarmerExperiments = () => {
         status: newStatus,
         ended_at: newStatus === 'concluido' ? new Date().toISOString() : null,
         updated_at: new Date().toISOString(),
-      } as any)
+      })
       .eq('id', experimentId);
 
     toast.success(newStatus === 'concluido' ? `Experimento concluído: ${winner}` : 'Métricas atualizadas');
@@ -282,29 +334,29 @@ export const useFarmerExperiments = () => {
   }, [loadExperiments]);
 
   const cancelExperiment = useCallback(async (experimentId: string) => {
-    await supabase.from('farmer_experiments' as any)
-      .update({ status: 'cancelado', ended_at: new Date().toISOString() } as any)
+    await supabase.from('farmer_experiments')
+      .update({ status: 'cancelado', ended_at: new Date().toISOString() })
       .eq('id', experimentId);
     toast.success('Experimento cancelado');
     loadExperiments();
   }, [loadExperiments]);
 
   const loadExperimentClients = useCallback(async (experimentId: string): Promise<ExperimentClient[]> => {
-    const { data } = await supabase
-      .from('farmer_experiment_clients' as any)
+    const { data } = (await supabase
+      .from('farmer_experiment_clients')
       .select('*')
-      .eq('experiment_id', experimentId) as any;
+      .eq('experiment_id', experimentId)) as unknown as { data: ExperimentClientRow[] | null };
 
     if (!data) return [];
 
-    const clientIds = data.map((c: any) => c.customer_user_id);
+    const clientIds = data.map((c) => c.customer_user_id);
     const { data: profiles } = await supabase
       .from('profiles')
       .select('user_id, name')
       .in('user_id', clientIds);
-    const nameMap = new Map((profiles || []).map(p => [p.user_id, p.name]));
+    const nameMap = new Map<string, string | null>((profiles || []).map(p => [p.user_id, p.name]));
 
-    return data.map((c: any) => ({
+    return data.map((c) => ({
       ...c,
       customer_name: nameMap.get(c.customer_user_id) || 'Desconhecido',
     }));

--- a/src/hooks/useFarmerPerformance.ts
+++ b/src/hooks/useFarmerPerformance.ts
@@ -34,13 +34,67 @@ export interface PerformanceScore {
   totalTimeSeconds: number;
 }
 
+interface PerformanceScoreRow {
+  id: string;
+  farmer_id: string;
+  calculated_at: string;
+  period_start: string;
+  period_end: string;
+  iee_ptpl_usage: number | string | null;
+  iee_objective_adherence: number | string | null;
+  iee_questions_usage: number | string | null;
+  iee_bundle_offered: number | string | null;
+  iee_post_call_registration: number | string | null;
+  iee_total: number | string | null;
+  ipf_incremental_margin: number | string | null;
+  ipf_margin_per_hour: number | string | null;
+  ipf_mix_expansion: number | string | null;
+  ipf_ltv_evolution: number | string | null;
+  ipf_churn_reduction: number | string | null;
+  ipf_total: number | string | null;
+  total_calls: number | string | null;
+  total_plans: number | string | null;
+  total_margin: number | string | null;
+  total_time_seconds: number | string | null;
+}
+
+interface ProfileNameRow {
+  user_id: string;
+  name: string | null;
+}
+
+interface TacticalPlanRow {
+  status: string | null;
+  plan_followed: boolean | null;
+  bundle_recommendation_id: string | null;
+  actual_margin: number | string | null;
+  call_duration_seconds: number | string | null;
+}
+
+interface FarmerCallRow {
+  margin_generated: number | string | null;
+  duration_seconds: number | string | null;
+}
+
+interface ClientScoreRow {
+  churn_risk: number | string | null;
+  category_count: number | string | null;
+  avg_monthly_spend_180d: number | string | null;
+  health_score: number | string | null;
+}
+
+interface CopilotSessionRow {
+  suggestions_shown: number | string | null;
+  suggestions_used: number | string | null;
+}
+
 export const useFarmerPerformance = () => {
   const { user } = useAuth();
   const [scores, setScores] = useState<PerformanceScore[]>([]);
   const [loading, setLoading] = useState(false);
   const [calculating, setCalculating] = useState(false);
 
-  const parseScore = (d: any, nameMap: Map<string, string>): PerformanceScore => ({
+  const parseScore = (d: PerformanceScoreRow, nameMap: Map<string, string>): PerformanceScore => ({
     id: d.id,
     farmerId: d.farmer_id,
     farmerName: nameMap.get(d.farmer_id) || 'Farmer',
@@ -71,7 +125,7 @@ export const useFarmerPerformance = () => {
     setLoading(true);
     try {
       let query = supabase
-        .from('farmer_performance_scores' as any)
+        .from('farmer_performance_scores')
         .select('*')
         .order('calculated_at', { ascending: false })
         .limit(100);
@@ -80,17 +134,17 @@ export const useFarmerPerformance = () => {
         query = query.eq('farmer_id', farmerId);
       }
 
-      const { data } = await query as any;
+      const { data } = (await query) as unknown as { data: PerformanceScoreRow[] | null };
       if (!data) { setScores([]); return; }
 
-      const farmerIds = [...new Set(data.map((d: any) => d.farmer_id))] as string[];
-      const { data: profiles } = await supabase
+      const farmerIds = [...new Set(data.map((d) => d.farmer_id))];
+      const { data: profiles } = (await supabase
         .from('profiles')
         .select('user_id, name')
-        .in('user_id', farmerIds) as any;
+        .in('user_id', farmerIds)) as unknown as { data: ProfileNameRow[] | null };
 
-      const nameMap = new Map<string, string>((profiles || []).map((p: any) => [p.user_id, p.name]));
-      setScores(data.map((d: any) => parseScore(d, nameMap)));
+      const nameMap = new Map<string, string>((profiles || []).map((p) => [p.user_id, p.name ?? 'Farmer']));
+      setScores(data.map((d) => parseScore(d, nameMap)));
     } catch (err) {
       console.error('Error loading scores:', err);
     } finally {
@@ -110,41 +164,41 @@ export const useFarmerPerformance = () => {
       const startStr = periodStart.toISOString();
 
       // Fetch tactical plans for the period
-      const { data: plans } = await supabase
-        .from('farmer_tactical_plans' as any)
+      const { data: plans } = (await supabase
+        .from('farmer_tactical_plans')
         .select('*')
         .eq('farmer_id', farmerId)
-        .gte('created_at', startStr) as any;
+        .gte('created_at', startStr)) as unknown as { data: TacticalPlanRow[] | null };
 
       // Fetch calls for the period
-      const { data: calls } = await supabase
+      const { data: calls } = (await supabase
         .from('farmer_calls')
         .select('*')
         .eq('farmer_id', farmerId)
-        .gte('created_at', startStr) as any;
+        .gte('created_at', startStr)) as unknown as { data: FarmerCallRow[] | null };
 
       // Fetch client scores (current snapshot)
-      const { data: clientScores } = await supabase
+      const { data: clientScores } = (await supabase
         .from('farmer_client_scores')
         .select('churn_risk, category_count, avg_monthly_spend_180d, health_score')
-        .eq('farmer_id', farmerId) as any;
+        .eq('farmer_id', farmerId)) as unknown as { data: ClientScoreRow[] | null };
 
       // Fetch copilot sessions
-      const { data: copilotSessions } = await supabase
-        .from('farmer_copilot_sessions' as any)
+      const { data: copilotSessions } = (await supabase
+        .from('farmer_copilot_sessions')
         .select('suggestions_shown, suggestions_used')
         .eq('farmer_id', farmerId)
-        .gte('created_at', startStr) as any;
+        .gte('created_at', startStr)) as unknown as { data: CopilotSessionRow[] | null };
 
-      const plansArr = plans || [];
-      const callsArr = calls || [];
-      const clientArr = clientScores || [];
-      const copilotArr = copilotSessions || [];
+      const plansArr: TacticalPlanRow[] = plans || [];
+      const callsArr: FarmerCallRow[] = calls || [];
+      const clientArr: ClientScoreRow[] = clientScores || [];
+      const copilotArr: CopilotSessionRow[] = copilotSessions || [];
 
       const totalCalls = callsArr.length;
       const totalPlans = plansArr.length;
-      const completedPlans = plansArr.filter((p: any) => p.status === 'concluido');
-      const plansFollowed = completedPlans.filter((p: any) => p.plan_followed === true);
+      const completedPlans = plansArr.filter((p) => p.status === 'concluido');
+      const plansFollowed = completedPlans.filter((p) => p.plan_followed === true);
 
       // ── IEE Calculation ──────────────────────────────────────
       // 1. PTPL Usage: % of calls that had a plan generated before
@@ -157,14 +211,14 @@ export const useFarmerPerformance = () => {
         : 0;
 
       // 3. Questions usage: based on copilot suggestions used ratio
-      const totalSugShown = copilotArr.reduce((s: number, c: any) => s + Number(c.suggestions_shown || 0), 0);
-      const totalSugUsed = copilotArr.reduce((s: number, c: any) => s + Number(c.suggestions_used || 0), 0);
+      const totalSugShown = copilotArr.reduce((s, c) => s + Number(c.suggestions_shown || 0), 0);
+      const totalSugUsed = copilotArr.reduce((s, c) => s + Number(c.suggestions_used || 0), 0);
       const ieeQuestionsUsage = totalSugShown > 0
         ? Math.round(Math.min(100, (totalSugUsed / totalSugShown) * 100))
         : 50; // neutral if no data
 
       // 4. Bundle offered: % of plans with bundle_recommendation_id
-      const plansWithBundle = plansArr.filter((p: any) => p.bundle_recommendation_id).length;
+      const plansWithBundle = plansArr.filter((p) => p.bundle_recommendation_id).length;
       const ieeBundleOffered = totalPlans > 0
         ? Math.round((plansWithBundle / totalPlans) * 100)
         : 0;
@@ -184,10 +238,10 @@ export const useFarmerPerformance = () => {
       );
 
       // ── IPF Calculation ──────────────────────────────────────
-      const totalMargin = completedPlans.reduce((s: number, p: any) => s + Number(p.actual_margin || 0), 0);
-      const totalTimeSeconds = completedPlans.reduce((s: number, p: any) => s + Number(p.call_duration_seconds || 0), 0);
-      const totalCallMargin = callsArr.reduce((s: number, c: any) => s + Number(c.margin_generated || 0), 0);
-      const totalCallTime = callsArr.reduce((s: number, c: any) => s + Number(c.duration_seconds || 0), 0);
+      const totalMargin = completedPlans.reduce((s, p) => s + Number(p.actual_margin || 0), 0);
+      const totalTimeSeconds = completedPlans.reduce((s, p) => s + Number(p.call_duration_seconds || 0), 0);
+      const totalCallMargin = callsArr.reduce((s, c) => s + Number(c.margin_generated || 0), 0);
+      const totalCallTime = callsArr.reduce((s, c) => s + Number(c.duration_seconds || 0), 0);
 
       const combinedMargin = totalMargin + totalCallMargin;
       const combinedTime = totalTimeSeconds + totalCallTime;
@@ -202,18 +256,18 @@ export const useFarmerPerformance = () => {
 
       // 3. Mix expansion: avg categories across clients (target 6+)
       const avgCategories = clientArr.length > 0
-        ? clientArr.reduce((s: number, c: any) => s + Number(c.category_count || 0), 0) / clientArr.length
+        ? clientArr.reduce((s, c) => s + Number(c.category_count || 0), 0) / clientArr.length
         : 0;
       const ipfMixExpansion = Math.round(Math.min(100, (avgCategories / 6) * 100));
 
       // 4. LTV evolution: avg monthly spend (target R$2000)
       const avgSpend = clientArr.length > 0
-        ? clientArr.reduce((s: number, c: any) => s + Number(c.avg_monthly_spend_180d || 0), 0) / clientArr.length
+        ? clientArr.reduce((s, c) => s + Number(c.avg_monthly_spend_180d || 0), 0) / clientArr.length
         : 0;
       const ipfLtvEvolution = Math.round(Math.min(100, (avgSpend / 2000) * 100));
 
       // 5. Churn reduction: % of clients with low churn risk (<30%)
-      const lowChurnClients = clientArr.filter((c: any) => Number(c.churn_risk || 100) < 30).length;
+      const lowChurnClients = clientArr.filter((c) => Number(c.churn_risk || 100) < 30).length;
       const ipfChurnReduction = clientArr.length > 0
         ? Math.round((lowChurnClients / clientArr.length) * 100)
         : 0;
@@ -251,14 +305,15 @@ export const useFarmerPerformance = () => {
       };
 
       await supabase
-        .from('farmer_performance_scores' as any)
-        .insert(scoreData as any);
+        .from('farmer_performance_scores')
+        .insert(scoreData);
 
       toast.success('Índices calculados com sucesso');
       await loadScores(farmerId);
-    } catch (err: any) {
+    } catch (err) {
       console.error('Error calculating scores:', err);
-      toast.error('Erro ao calcular índices', { description: err.message });
+      const message = err instanceof Error ? err.message : String(err);
+      toast.error('Erro ao calcular índices', { description: message });
     } finally {
       setCalculating(false);
     }

--- a/src/hooks/useKbProductSpecs.ts
+++ b/src/hooks/useKbProductSpecs.ts
@@ -1,0 +1,21 @@
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import type { KbProductSpec } from '@/lib/knowledge-base/specs-types';
+
+export function useKbProductSpecs(productCode: string | undefined | null) {
+  return useQuery({
+    queryKey: ['kb-product-spec', productCode],
+    enabled: !!productCode,
+    staleTime: 60_000,
+    queryFn: async (): Promise<KbProductSpec | null> => {
+      if (!productCode) return null;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const { data, error } = await (supabase.from('kb_product_specs') as any)
+        .select('*')
+        .eq('product_code', productCode)
+        .maybeSingle();
+      if (error) throw error;
+      return (data as KbProductSpec) ?? null;
+    },
+  });
+}

--- a/src/hooks/useSaveProductSpecs.ts
+++ b/src/hooks/useSaveProductSpecs.ts
@@ -1,0 +1,44 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import { toast } from 'sonner';
+import type { KbExtractedSpec, KbProductSpec } from '@/lib/knowledge-base/specs-types';
+
+interface SaveInput {
+  specs: KbExtractedSpec;
+  documentId?: string;
+}
+
+export function useSaveProductSpecs() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (input: SaveInput): Promise<KbProductSpec> => {
+      const { data: { user } } = await supabase.auth.getUser();
+      if (!user) throw new Error('Não autenticado');
+
+      const payload = {
+        ...input.specs,
+        document_id: input.documentId ?? null,
+        extracted_by: user.id,
+        approved_by: user.id,
+        approved_at: new Date().toISOString(),
+      };
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const { data, error } = await (supabase.from('kb_product_specs') as any)
+        .upsert(payload, { onConflict: 'product_code' })
+        .select()
+        .single();
+
+      if (error) throw error;
+      return data as KbProductSpec;
+    },
+    onSuccess: (data) => {
+      qc.invalidateQueries({ queryKey: ['kb-product-specs'] });
+      qc.invalidateQueries({ queryKey: ['kb-product-spec', data.product_code] });
+      toast.success('Specs salvos', { description: `${data.product_name} (${data.product_code})` });
+    },
+    onError: (err) => {
+      toast.error('Erro ao salvar', { description: err instanceof Error ? err.message : '' });
+    },
+  });
+}

--- a/src/hooks/useTacticalPlan.ts
+++ b/src/hooks/useTacticalPlan.ts
@@ -1,17 +1,22 @@
 import { useState, useCallback } from 'react';
 import { supabase } from '@/integrations/supabase/client';
+import type { Json } from '@/integrations/supabase/types';
 import { useAuth } from '@/contexts/AuthContext';
 import { toast } from 'sonner';
 
 // ─── Types ───────────────────────────────────────────────────────────
 export type PlanType = 'essencial' | 'estrategico';
 
+// JSON shape stored in top_bundle / second_bundle columns — schema is dynamic
+// (varies by bundle engine version), so kept as Record.
+export type BundleSnapshot = Record<string, unknown>;
+
 export interface TacticalPlan {
   id: string;
   customerId: string;
   customerName: string;
   planType: PlanType;
-  
+
   // Diagnosis
   healthScore: number;
   churnRisk: number;
@@ -19,35 +24,35 @@ export interface TacticalPlan {
   currentMarginPct: number;
   clusterAvgMarginPct: number;
   expansionPotential: number;
-  
+
   // Strategy
   strategicObjective: string;
   customerProfile: string;
   approachStrategy: string;
   approachStrategyB: string;
-  
+
   // Bundle
-  topBundle: any;
-  secondBundle: any;
+  topBundle: BundleSnapshot;
+  secondBundle: BundleSnapshot;
   bundleLie: number;
   bundleProbability: number;
   bundleIncrementalMargin: number;
   bestIndividualLie: number;
-  
+
   // AI-generated content
   diagnosticQuestions: { question: string; purpose: string; expected_insight: string }[];
   implicationQuestion: string;
   offerTransition: string;
   probableObjections: { objection: string; technical_response: string; economic_response: string; probability: number }[];
-  
+
   // Strategic-only fields
   ltvProjection: { current_annual: number; projected_annual: number; growth_pct: number } | null;
   expectedResult: { best_case_margin: number; likely_margin: number; worst_case_margin: number } | null;
   operationalRisks: string[];
-  
+
   // Efficiency
   estimatedProfitPerHour: number;
-  
+
   // Tracking
   status: string;
   planFollowed?: boolean;
@@ -57,6 +62,105 @@ export interface TacticalPlan {
   objectionType?: string;
   notes?: string;
   generatedAt: string;
+}
+
+// ─── Row + helper types ────────────────────────────────────────────
+interface TacticalPlanRow {
+  id: string;
+  customer_user_id: string;
+  plan_type: PlanType | null;
+  health_score: number | string | null;
+  churn_risk: number | string | null;
+  mix_gap: number | string | null;
+  current_margin_pct: number | string | null;
+  cluster_avg_margin_pct: number | string | null;
+  expansion_potential: number | string | null;
+  strategic_objective: string;
+  customer_profile: string;
+  approach_strategy: string | null;
+  approach_strategy_b: string | null;
+  top_bundle: BundleSnapshot | null;
+  second_bundle: BundleSnapshot | null;
+  bundle_lie: number | string | null;
+  bundle_probability: number | string | null;
+  bundle_incremental_margin: number | string | null;
+  best_individual_lie: number | string | null;
+  diagnostic_questions: TacticalPlan['diagnosticQuestions'] | unknown;
+  implication_question: string | null;
+  offer_transition: string | null;
+  probable_objections: TacticalPlan['probableObjections'] | unknown;
+  ltv_projection: TacticalPlan['ltvProjection'] | unknown;
+  expected_result: TacticalPlan['expectedResult'] | unknown;
+  operational_risks: string[] | unknown;
+  status: string;
+  plan_followed?: boolean | null;
+  call_result?: string | null;
+  actual_margin?: number | string | null;
+  call_duration_seconds?: number | null;
+  objection_type?: string | null;
+  notes?: string | null;
+  generated_at: string;
+}
+
+interface ClientScoreFull {
+  health_score: number | string | null;
+  churn_risk: number | string | null;
+  avg_monthly_spend_180d: number | string | null;
+  gross_margin_pct: number | string | null;
+  category_count: number | string | null;
+  days_since_last_purchase: number | string | null;
+  expansion_score: number | string | null;
+  revenue_potential: number | string | null;
+}
+
+interface ProfileLite {
+  user_id?: string;
+  name: string | null;
+  customer_type?: string | null;
+  cnae?: string | null;
+}
+
+interface BundleRow {
+  id: string;
+  bundle_products: BundleSnapshot;
+  lie_bundle: number | string | null;
+  p_bundle: number | string | null;
+  m_bundle: number | string | null;
+}
+
+interface CopilotEventRow {
+  event_data: { intent?: string } | Record<string, unknown> | null;
+}
+
+interface EffectivenessRow {
+  strategic_objective: string;
+  plan_followed: boolean | null;
+  actual_margin: number | string | null;
+  call_duration_seconds: number | string | null;
+  plan_type: PlanType | null;
+}
+
+interface AiPlanResponse {
+  strategic_objective?: string;
+  diagnostic_questions?: TacticalPlan['diagnosticQuestions'];
+  implication_question?: string;
+  offer_transition?: string;
+  probable_objections?: TacticalPlan['probableObjections'];
+  approach_strategy?: string;
+  approach_strategy_b?: string;
+  ltv_projection?: TacticalPlan['ltvProjection'];
+  expected_result?: TacticalPlan['expectedResult'];
+  operational_risks?: string[];
+}
+
+interface DiagnosticData {
+  strategicObjective: string;
+  secondBundle?: {
+    products: BundleSnapshot;
+    lie: number | string | null;
+    probability: number | string | null;
+    margin: number | string | null;
+  };
 }
 
 export interface EfficiencyCheck {
@@ -98,11 +202,11 @@ export const useTacticalPlan = () => {
   const [loading, setLoading] = useState(false);
   const [generating, setGenerating] = useState<string | null>(null);
 
-  const parsePlan = (d: any, profileMap: Map<string, string>): TacticalPlan => {
-    const topBundle = d.top_bundle || {};
-    const secondBundle = d.second_bundle || {};
-    const ltvProjection = d.ltv_projection || null;
-    const expectedResult = d.expected_result || null;
+  const parsePlan = (d: TacticalPlanRow, profileMap: Map<string, string>): TacticalPlan => {
+    const topBundle: BundleSnapshot = d.top_bundle || {};
+    const secondBundle: BundleSnapshot = d.second_bundle || {};
+    const ltvProjection = d.ltv_projection;
+    const expectedResult = d.expected_result;
     const avgCallMinutes = 15;
     const bundleLie = Number(d.bundle_lie || 0);
     const estimatedProfitPerHour = bundleLie > 0 ? (bundleLie / (avgCallMinutes / 60)) : 0;
@@ -128,21 +232,29 @@ export const useTacticalPlan = () => {
       bundleProbability: Number(d.bundle_probability || 0),
       bundleIncrementalMargin: Number(d.bundle_incremental_margin || 0),
       bestIndividualLie: Number(d.best_individual_lie || 0),
-      diagnosticQuestions: Array.isArray(d.diagnostic_questions) ? d.diagnostic_questions : [],
+      diagnosticQuestions: Array.isArray(d.diagnostic_questions)
+        ? (d.diagnostic_questions as TacticalPlan['diagnosticQuestions'])
+        : [],
       implicationQuestion: d.implication_question || '',
       offerTransition: d.offer_transition || '',
-      probableObjections: Array.isArray(d.probable_objections) ? d.probable_objections : [],
-      ltvProjection: ltvProjection && typeof ltvProjection === 'object' ? ltvProjection : null,
-      expectedResult: expectedResult && typeof expectedResult === 'object' ? expectedResult : null,
-      operationalRisks: Array.isArray(d.operational_risks) ? d.operational_risks : [],
+      probableObjections: Array.isArray(d.probable_objections)
+        ? (d.probable_objections as TacticalPlan['probableObjections'])
+        : [],
+      ltvProjection: ltvProjection && typeof ltvProjection === 'object'
+        ? (ltvProjection as TacticalPlan['ltvProjection'])
+        : null,
+      expectedResult: expectedResult && typeof expectedResult === 'object'
+        ? (expectedResult as TacticalPlan['expectedResult'])
+        : null,
+      operationalRisks: Array.isArray(d.operational_risks) ? (d.operational_risks as string[]) : [],
       estimatedProfitPerHour,
       status: d.status,
-      planFollowed: d.plan_followed,
-      callResult: d.call_result,
+      planFollowed: d.plan_followed ?? undefined,
+      callResult: d.call_result ?? undefined,
       actualMargin: d.actual_margin ? Number(d.actual_margin) : undefined,
-      callDurationSeconds: d.call_duration_seconds,
-      objectionType: d.objection_type,
-      notes: d.notes,
+      callDurationSeconds: d.call_duration_seconds ?? undefined,
+      objectionType: d.objection_type ?? undefined,
+      notes: d.notes ?? undefined,
       generatedAt: d.generated_at,
     };
   };
@@ -152,25 +264,27 @@ export const useTacticalPlan = () => {
     if (!user?.id) return;
     setLoading(true);
     try {
-      const { data } = await supabase
-        .from('farmer_tactical_plans' as any)
+      const { data } = (await supabase
+        .from('farmer_tactical_plans')
         .select('*')
         .eq('farmer_id', user.id)
         .order('created_at', { ascending: false })
-        .limit(50) as any;
+        .limit(50)) as unknown as { data: TacticalPlanRow[] | null };
 
       if (!data) { setPlans([]); return; }
 
       const customerIdsSet = new Set<string>();
-      data.forEach((d: any) => customerIdsSet.add(String(d.customer_user_id)));
+      data.forEach((d) => customerIdsSet.add(String(d.customer_user_id)));
       const customerIds: string[] = Array.from(customerIdsSet);
-      const { data: profiles } = await supabase
+      const { data: profiles } = (await supabase
         .from('profiles')
         .select('user_id, name')
-        .in('user_id', customerIds) as any;
+        .in('user_id', customerIds)) as unknown as { data: ProfileLite[] | null };
 
-      const profileMap = new Map<string, string>((profiles || []).map((p: any) => [p.user_id, p.name]));
-      setPlans(data.map((d: any) => parsePlan(d, profileMap)));
+      const profileMap = new Map<string, string>(
+        (profiles || []).map((p) => [p.user_id ?? '', p.name ?? 'Cliente'])
+      );
+      setPlans(data.map((d) => parsePlan(d, profileMap)));
     } catch (err) {
       console.error('Error loading plans:', err);
     } finally {
@@ -182,12 +296,12 @@ export const useTacticalPlan = () => {
   const checkEfficiency = useCallback(async (customerId: string): Promise<EfficiencyCheck> => {
     if (!user?.id) return { estimatedProfitPerHour: 0, threshold: PROFIT_PER_HOUR_THRESHOLD, isAboveThreshold: false };
 
-    const { data: score } = await supabase
+    const { data: score } = (await supabase
       .from('farmer_client_scores')
       .select('revenue_potential, avg_monthly_spend_180d, gross_margin_pct')
       .eq('customer_user_id', customerId)
       .eq('farmer_id', user.id)
-      .single() as any;
+      .single()) as unknown as { data: Pick<ClientScoreFull, 'revenue_potential' | 'avg_monthly_spend_180d' | 'gross_margin_pct'> | null };
 
     const revPotential = Number(score?.revenue_potential || 0);
     const avgSpend = Number(score?.avg_monthly_spend_180d || 0);
@@ -214,9 +328,9 @@ export const useTacticalPlan = () => {
         { data: profile },
         { data: bundles },
       ] = await Promise.all([
-        supabase.from('farmer_client_scores').select('*').eq('customer_user_id', customerId).eq('farmer_id', user.id).single() as any,
-        supabase.from('profiles').select('name, customer_type, cnae').eq('user_id', customerId).single() as any,
-        supabase.from('farmer_bundle_recommendations' as any).select('*').eq('customer_user_id', customerId).eq('farmer_id', user.id).eq('status', 'pendente').order('lie_bundle', { ascending: false }).limit(2) as any,
+        supabase.from('farmer_client_scores').select('*').eq('customer_user_id', customerId).eq('farmer_id', user.id).single() as unknown as Promise<{ data: ClientScoreFull | null }>,
+        supabase.from('profiles').select('name, customer_type, cnae').eq('user_id', customerId).single() as unknown as Promise<{ data: ProfileLite | null }>,
+        supabase.from('farmer_bundle_recommendations').select('*').eq('customer_user_id', customerId).eq('farmer_id', user.id).eq('status', 'pendente').order('lie_bundle', { ascending: false }).limit(2) as unknown as Promise<{ data: BundleRow[] | null }>,
       ]);
 
       if (!score) {
@@ -233,13 +347,13 @@ export const useTacticalPlan = () => {
       const expansionPotential = Number(score.expansion_score || 0);
       const revenuePotential = Number(score.revenue_potential || 0);
 
-      const { data: allScores } = await supabase
+      const { data: allScores } = (await supabase
         .from('farmer_client_scores')
         .select('gross_margin_pct')
-        .eq('farmer_id', user.id) as any;
-      
+        .eq('farmer_id', user.id)) as unknown as { data: Pick<ClientScoreFull, 'gross_margin_pct'>[] | null };
+
       const clusterMargin = allScores?.length
-        ? allScores.reduce((s: number, r: any) => s + Number(r.gross_margin_pct || 0), 0) / allScores.length
+        ? allScores.reduce((s, r) => s + Number(r.gross_margin_pct || 0), 0) / allScores.length
         : 25;
 
       const mixGap = Math.max(0, 8 - categoryCount);
@@ -249,15 +363,18 @@ export const useTacticalPlan = () => {
       const topBundle = bundles?.[0] || null;
       const secondBundle = bundles?.[1] || null;
 
-      const { data: objectionEvents } = await supabase
-        .from('farmer_copilot_events' as any)
+      const { data: objectionEvents } = (await supabase
+        .from('farmer_copilot_events')
         .select('event_data')
         .eq('event_type', 'suggestion')
-        .limit(20) as any;
+        .limit(20)) as unknown as { data: CopilotEventRow[] | null };
 
       const historicalObjections = (objectionEvents || [])
-        .filter((e: any) => e.event_data?.intent?.startsWith('objecao'))
-        .map((e: any) => e.event_data.intent)
+        .filter((e): e is CopilotEventRow & { event_data: { intent: string } } => {
+          const intent = (e.event_data as { intent?: unknown } | null)?.intent;
+          return typeof intent === 'string' && intent.startsWith('objecao');
+        })
+        .map((e) => e.event_data.intent)
         .slice(0, 5);
 
       const bundleCtx = topBundle ? {
@@ -268,7 +385,7 @@ export const useTacticalPlan = () => {
       } : null;
 
       // For strategic plans, include second bundle for comparison
-      const diagnosticData: any = { strategicObjective };
+      const diagnosticData: DiagnosticData = { strategicObjective };
       if (planType === 'estrategico' && secondBundle) {
         diagnosticData.secondBundle = {
           products: secondBundle.bundle_products,
@@ -278,7 +395,7 @@ export const useTacticalPlan = () => {
         };
       }
 
-      const { data: aiPlan, error: aiError } = await supabase.functions.invoke('generate-tactical-plan', {
+      const { data: aiPlan, error: aiError } = await supabase.functions.invoke<AiPlanResponse>('generate-tactical-plan', {
         body: {
           customerContext: {
             name: profile?.name,
@@ -318,35 +435,36 @@ export const useTacticalPlan = () => {
         strategic_objective: aiPlan?.strategic_objective || strategicObjective,
         customer_profile: customerProfile,
         plan_type: planType,
-        top_bundle: topBundle ? topBundle.bundle_products : {},
-        second_bundle: secondBundle ? secondBundle.bundle_products : {},
+        top_bundle: (topBundle ? topBundle.bundle_products : {}) as Json,
+        second_bundle: (secondBundle ? secondBundle.bundle_products : {}) as Json,
         bundle_lie: topBundle ? Number(topBundle.lie_bundle) : 0,
         bundle_probability: topBundle ? Number(topBundle.p_bundle) : 0,
         bundle_incremental_margin: topBundle ? Number(topBundle.m_bundle) : 0,
         best_individual_lie: 0,
-        diagnostic_questions: aiPlan?.diagnostic_questions || [],
+        diagnostic_questions: (aiPlan?.diagnostic_questions || []) as unknown as Json,
         implication_question: aiPlan?.implication_question || '',
         offer_transition: aiPlan?.offer_transition || '',
-        probable_objections: aiPlan?.probable_objections || [],
+        probable_objections: (aiPlan?.probable_objections || []) as unknown as Json,
         approach_strategy: aiPlan?.approach_strategy || '',
         approach_strategy_b: aiPlan?.approach_strategy_b || '',
-        ltv_projection: aiPlan?.ltv_projection || null,
-        expected_result: aiPlan?.expected_result || null,
+        ltv_projection: (aiPlan?.ltv_projection || null) as unknown as Json,
+        expected_result: (aiPlan?.expected_result || null) as unknown as Json,
         operational_risks: aiPlan?.operational_risks || [],
         status: 'gerado',
       };
 
       await supabase
-        .from('farmer_tactical_plans' as any)
-        .insert(planData as any)
+        .from('farmer_tactical_plans')
+        .insert(planData)
         .select('id')
-        .single() as any;
+        .single();
 
       toast.success(`Plano ${planType === 'estrategico' ? 'estratégico' : 'essencial'} gerado com sucesso`);
       await loadPlans();
-    } catch (err: any) {
+    } catch (err) {
       console.error('Error generating plan:', err);
-      toast.error('Erro ao gerar plano', { description: err.message });
+      const message = err instanceof Error ? err.message : String(err);
+      toast.error('Erro ao gerar plano', { description: message });
     } finally {
       setGenerating(null);
     }
@@ -356,22 +474,22 @@ export const useTacticalPlan = () => {
   const getActivePlan = useCallback(async (customerId: string): Promise<TacticalPlan | null> => {
     if (!user?.id) return null;
 
-    const { data } = await supabase
-      .from('farmer_tactical_plans' as any)
+    const { data } = (await supabase
+      .from('farmer_tactical_plans')
       .select('*')
       .eq('farmer_id', user.id)
       .eq('customer_user_id', customerId)
       .eq('status', 'gerado')
       .order('created_at', { ascending: false })
-      .limit(1) as any;
+      .limit(1)) as unknown as { data: TacticalPlanRow[] | null };
 
     if (!data?.[0]) return null;
 
-    const { data: profile } = await supabase
+    const { data: profile } = (await supabase
       .from('profiles')
       .select('user_id, name')
       .eq('user_id', customerId)
-      .single() as any;
+      .single()) as unknown as { data: ProfileLite | null };
 
     const profileMap = new Map<string, string>([[customerId, profile?.name || 'Cliente']]);
     return parsePlan(data[0], profileMap);
@@ -388,7 +506,7 @@ export const useTacticalPlan = () => {
   }) => {
     try {
       await supabase
-        .from('farmer_tactical_plans' as any)
+        .from('farmer_tactical_plans')
         .update({
           plan_followed: result.planFollowed,
           call_result: result.callResult,
@@ -398,7 +516,7 @@ export const useTacticalPlan = () => {
           notes: result.notes || null,
           status: 'concluido',
           completed_at: new Date().toISOString(),
-        } as any)
+        })
         .eq('id', planId);
 
       toast.success('Resultado registrado');
@@ -412,11 +530,11 @@ export const useTacticalPlan = () => {
   const getEffectivenessStats = useCallback(async () => {
     if (!user?.id) return null;
 
-    const { data } = await supabase
-      .from('farmer_tactical_plans' as any)
+    const { data } = (await supabase
+      .from('farmer_tactical_plans')
       .select('strategic_objective, plan_followed, actual_margin, call_duration_seconds, plan_type')
       .eq('farmer_id', user.id)
-      .eq('status', 'concluido') as any;
+      .eq('status', 'concluido')) as unknown as { data: EffectivenessRow[] | null };
 
     if (!data?.length) return null;
 
@@ -427,7 +545,7 @@ export const useTacticalPlan = () => {
       const obj = d.strategic_objective;
       const pt = d.plan_type || 'essencial';
 
-      for (const [key, map] of [['obj_' + obj, byObjective], ['type_' + pt, byType]] as const) {
+      for (const [key] of [['obj_' + obj, byObjective], ['type_' + pt, byType]] as const) {
         const target = key.startsWith('obj_') ? byObjective : byType;
         const k = key.replace(/^(obj_|type_)/, '');
         if (!target[k]) target[k] = { count: 0, followed: 0, totalMargin: 0, totalTime: 0 };

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -4520,6 +4520,263 @@ export type Database = {
           },
         ]
       }
+      kb_competitor_products: {
+        Row: {
+          argumentos_comparativos: Json | null
+          category: string | null
+          competitor_id: string
+          created_at: string
+          created_by: string | null
+          fonte_preco: string | null
+          id: string
+          nosso_equivalente_product_code: string | null
+          pontos_fortes: string[] | null
+          pontos_fracos: string[] | null
+          pot_life_horas: number | null
+          preco_atualizado_em: string | null
+          preco_referencia_l: number | null
+          product_name: string
+          rendimento_m2_por_litro: number | null
+          solidos_pct: number | null
+          updated_at: string
+          validade_dias: number | null
+        }
+        Insert: {
+          argumentos_comparativos?: Json | null
+          category?: string | null
+          competitor_id: string
+          created_at?: string
+          created_by?: string | null
+          fonte_preco?: string | null
+          id?: string
+          nosso_equivalente_product_code?: string | null
+          pontos_fortes?: string[] | null
+          pontos_fracos?: string[] | null
+          pot_life_horas?: number | null
+          preco_atualizado_em?: string | null
+          preco_referencia_l?: number | null
+          product_name: string
+          rendimento_m2_por_litro?: number | null
+          solidos_pct?: number | null
+          updated_at?: string
+          validade_dias?: number | null
+        }
+        Update: {
+          argumentos_comparativos?: Json | null
+          category?: string | null
+          competitor_id?: string
+          created_at?: string
+          created_by?: string | null
+          fonte_preco?: string | null
+          id?: string
+          nosso_equivalente_product_code?: string | null
+          pontos_fortes?: string[] | null
+          pontos_fracos?: string[] | null
+          pot_life_horas?: number | null
+          preco_atualizado_em?: string | null
+          preco_referencia_l?: number | null
+          product_name?: string
+          rendimento_m2_por_litro?: number | null
+          solidos_pct?: number | null
+          updated_at?: string
+          validade_dias?: number | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "kb_competitor_products_competitor_id_fkey"
+            columns: ["competitor_id"]
+            isOneToOne: false
+            referencedRelation: "kb_competitors"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      kb_competitors: {
+        Row: {
+          created_at: string
+          created_by: string | null
+          id: string
+          name: string
+          notas_estrategicas: string | null
+          regiao_principal: string | null
+          segmento_atuacao: string[] | null
+          tipo: string | null
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          created_by?: string | null
+          id?: string
+          name: string
+          notas_estrategicas?: string | null
+          regiao_principal?: string | null
+          segmento_atuacao?: string[] | null
+          tipo?: string | null
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          created_by?: string | null
+          id?: string
+          name?: string
+          notas_estrategicas?: string | null
+          regiao_principal?: string | null
+          segmento_atuacao?: string[] | null
+          tipo?: string | null
+          updated_at?: string
+        }
+        Relationships: []
+      }
+      kb_product_specs: {
+        Row: {
+          approved_at: string | null
+          approved_by: string | null
+          brilho_ub: number | null
+          catalisador_codigo: string | null
+          catalisador_proporcao_pct: number | null
+          certificacoes_aplicaveis: string[] | null
+          created_at: string
+          demaos_recomendadas: number | null
+          densidade_g_cm3: number | null
+          diferenciais_chave: string[] | null
+          diluente_codigo: string | null
+          document_id: string | null
+          dureza: string | null
+          equipamentos_aplicacao: string[] | null
+          extracted_by: string | null
+          extraction_confidence: number | null
+          extraction_gaps: string[] | null
+          gramatura_g_m2_max: number | null
+          gramatura_g_m2_min: number | null
+          id: string
+          isento_metais_pesados: string[] | null
+          isento_substancias: string[] | null
+          lixa_recomendada: string | null
+          pot_life_horas: number | null
+          product_category: string | null
+          product_code: string
+          product_line: string | null
+          product_name: string
+          publico_alvo: string | null
+          rendimento_m2_por_litro: number | null
+          secagem_empilhamento_h: number | null
+          secagem_manuseio_h: number | null
+          secagem_total_h: number | null
+          solidos_pct: number | null
+          substrato: string[] | null
+          supplier: string
+          temp_aplicacao_c_max: number | null
+          temp_aplicacao_c_min: number | null
+          temp_armazenamento_c_max: number | null
+          temp_armazenamento_c_min: number | null
+          umidade_aplicacao_pct_max: number | null
+          umidade_aplicacao_pct_min: number | null
+          updated_at: string
+          uso_recomendado: string | null
+          validade_dias: number | null
+          viscosidade_aplicacao_s: number | null
+          viscosidade_copo: string | null
+        }
+        Insert: {
+          approved_at?: string | null
+          approved_by?: string | null
+          brilho_ub?: number | null
+          catalisador_codigo?: string | null
+          catalisador_proporcao_pct?: number | null
+          certificacoes_aplicaveis?: string[] | null
+          created_at?: string
+          demaos_recomendadas?: number | null
+          densidade_g_cm3?: number | null
+          diferenciais_chave?: string[] | null
+          diluente_codigo?: string | null
+          document_id?: string | null
+          dureza?: string | null
+          equipamentos_aplicacao?: string[] | null
+          extracted_by?: string | null
+          extraction_confidence?: number | null
+          extraction_gaps?: string[] | null
+          gramatura_g_m2_max?: number | null
+          gramatura_g_m2_min?: number | null
+          id?: string
+          isento_metais_pesados?: string[] | null
+          isento_substancias?: string[] | null
+          lixa_recomendada?: string | null
+          pot_life_horas?: number | null
+          product_category?: string | null
+          product_code: string
+          product_line?: string | null
+          product_name: string
+          publico_alvo?: string | null
+          rendimento_m2_por_litro?: number | null
+          secagem_empilhamento_h?: number | null
+          secagem_manuseio_h?: number | null
+          secagem_total_h?: number | null
+          solidos_pct?: number | null
+          substrato?: string[] | null
+          supplier?: string
+          temp_aplicacao_c_max?: number | null
+          temp_aplicacao_c_min?: number | null
+          temp_armazenamento_c_max?: number | null
+          temp_armazenamento_c_min?: number | null
+          umidade_aplicacao_pct_max?: number | null
+          umidade_aplicacao_pct_min?: number | null
+          updated_at?: string
+          uso_recomendado?: string | null
+          validade_dias?: number | null
+          viscosidade_aplicacao_s?: number | null
+          viscosidade_copo?: string | null
+        }
+        Update: {
+          approved_at?: string | null
+          approved_by?: string | null
+          brilho_ub?: number | null
+          catalisador_codigo?: string | null
+          catalisador_proporcao_pct?: number | null
+          certificacoes_aplicaveis?: string[] | null
+          created_at?: string
+          demaos_recomendadas?: number | null
+          densidade_g_cm3?: number | null
+          diferenciais_chave?: string[] | null
+          diluente_codigo?: string | null
+          document_id?: string | null
+          dureza?: string | null
+          equipamentos_aplicacao?: string[] | null
+          extracted_by?: string | null
+          extraction_confidence?: number | null
+          extraction_gaps?: string[] | null
+          gramatura_g_m2_max?: number | null
+          gramatura_g_m2_min?: number | null
+          id?: string
+          isento_metais_pesados?: string[] | null
+          isento_substancias?: string[] | null
+          lixa_recomendada?: string | null
+          pot_life_horas?: number | null
+          product_category?: string | null
+          product_code?: string
+          product_line?: string | null
+          product_name?: string
+          publico_alvo?: string | null
+          rendimento_m2_por_litro?: number | null
+          secagem_empilhamento_h?: number | null
+          secagem_manuseio_h?: number | null
+          secagem_total_h?: number | null
+          solidos_pct?: number | null
+          substrato?: string[] | null
+          supplier?: string
+          temp_aplicacao_c_max?: number | null
+          temp_aplicacao_c_min?: number | null
+          temp_armazenamento_c_max?: number | null
+          temp_armazenamento_c_min?: number | null
+          umidade_aplicacao_pct_max?: number | null
+          umidade_aplicacao_pct_min?: number | null
+          updated_at?: string
+          uso_recomendado?: string | null
+          validade_dias?: number | null
+          viscosidade_aplicacao_s?: number | null
+          viscosidade_copo?: string | null
+        }
+        Relationships: []
+      }
       loyalty_points: {
         Row: {
           created_at: string

--- a/src/lib/knowledge-base/specs-types.ts
+++ b/src/lib/knowledge-base/specs-types.ts
@@ -1,0 +1,124 @@
+/**
+ * Domain types pra specs estruturados de produtos + concorrentes.
+ *
+ * KbProductSpec — 1 row por SKU Sayerlack/Colacor, extraído de boletim técnico
+ *   via Claude (edge function kb-extract-specs). Approved by master.
+ *
+ * KbCompetitor + KbCompetitorProduct — vazios no schema; populados via UI no PR8
+ *   (battle cards) ou auto-detect de transcripts (entitiesExtracted do copilot).
+ *   Sem hardcode — vendedor expande livremente.
+ */
+
+export interface KbProductSpec {
+  id: string;
+  document_id: string | null;
+  product_code: string;
+  product_name: string;
+  supplier: string;
+  product_line: string | null;
+  product_category: string | null;
+
+  // Físico-químico
+  densidade_g_cm3: number | null;
+  solidos_pct: number | null;
+  viscosidade_aplicacao_s: number | null;
+  viscosidade_copo: string | null;
+  brilho_ub: number | null;
+  dureza: string | null;
+
+  // Aplicação
+  rendimento_m2_por_litro: number | null;
+  demaos_recomendadas: number | null;
+  gramatura_g_m2_min: number | null;
+  gramatura_g_m2_max: number | null;
+  pot_life_horas: number | null;
+  temp_aplicacao_c_min: number | null;
+  temp_aplicacao_c_max: number | null;
+  umidade_aplicacao_pct_min: number | null;
+  umidade_aplicacao_pct_max: number | null;
+
+  // Compatibilidade
+  catalisador_codigo: string | null;
+  catalisador_proporcao_pct: number | null;
+  diluente_codigo: string | null;
+  equipamentos_aplicacao: string[];
+  lixa_recomendada: string | null;
+  substrato: string[];
+
+  // Secagem
+  secagem_manuseio_h: number | null;
+  secagem_empilhamento_h: number | null;
+  secagem_total_h: number | null;
+
+  // Armazenamento
+  validade_dias: number | null;
+  temp_armazenamento_c_min: number | null;
+  temp_armazenamento_c_max: number | null;
+
+  // Compliance
+  certificacoes_aplicaveis: string[];
+  isento_metais_pesados: string[];
+  isento_substancias: string[];
+
+  // Notas qualitativas
+  diferenciais_chave: string[];
+  uso_recomendado: string | null;
+  publico_alvo: string | null;
+
+  // Metadata da extração
+  extraction_confidence: number | null;
+  extraction_gaps: string[];
+  extracted_by: string | null;
+  approved_by: string | null;
+  approved_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+/**
+ * Shape retornado pela edge function kb-extract-specs.
+ * Sem ids/timestamps/metadata de auditoria — só os campos extraídos.
+ */
+export type KbExtractedSpec = Omit<
+  KbProductSpec,
+  | 'id'
+  | 'document_id'
+  | 'extracted_by'
+  | 'approved_by'
+  | 'approved_at'
+  | 'created_at'
+  | 'updated_at'
+>;
+
+export interface KbCompetitor {
+  id: string;
+  name: string;
+  tipo: 'regional' | 'nacional' | 'importado' | null;
+  regiao_principal: string | null;
+  segmento_atuacao: string[];
+  notas_estrategicas: string | null;
+  created_by: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface KbCompetitorProduct {
+  id: string;
+  competitor_id: string;
+  product_name: string;
+  category: string | null;
+  rendimento_m2_por_litro: number | null;
+  solidos_pct: number | null;
+  pot_life_horas: number | null;
+  validade_dias: number | null;
+  preco_referencia_l: number | null;
+  preco_atualizado_em: string | null;
+  fonte_preco: 'vendedor' | 'cotacao' | 'site' | 'estimado' | 'detectado_ia' | null;
+  pontos_fortes: string[];
+  pontos_fracos: string[];
+  nosso_equivalente_product_code: string | null;
+  argumentos_comparativos: unknown;
+  created_by: string | null;
+  created_at: string;
+  updated_at: string;
+}

--- a/src/pages/AdminKnowledgeBaseDetail.tsx
+++ b/src/pages/AdminKnowledgeBaseDetail.tsx
@@ -3,11 +3,13 @@ import { useQuery } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
 import { Card } from '@/components/ui/card';
 import { KbStatusBadge } from '@/components/knowledge-base/KbStatusBadge';
+import { KbSpecsExtractButton } from '@/components/knowledge-base/KbSpecsExtractButton';
 import { Badge } from '@/components/ui/badge';
 import { format } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
-import { Loader2 } from 'lucide-react';
+import { Loader2, Database, Sparkles } from 'lucide-react';
 import type { KbDocument } from '@/lib/knowledge-base/types';
+import { useKbProductSpecs } from '@/hooks/useKbProductSpecs';
 
 export default function AdminKnowledgeBaseDetail() {
   const { id } = useParams<{ id: string }>();
@@ -55,6 +57,12 @@ export default function AdminKnowledgeBaseDetail() {
     );
   }
 
+  return <DetailContent data={data} chunkCount={chunkCount} />;
+}
+
+function DetailContent({ data, chunkCount }: { data: KbDocument; chunkCount: number | undefined }) {
+  const { data: existingSpecs, refetch: refetchSpecs } = useKbProductSpecs(data.product_code);
+
   return (
     <div className="container mx-auto p-4 space-y-3 max-w-4xl">
       <div className="flex items-center justify-between flex-wrap gap-2">
@@ -84,6 +92,64 @@ export default function AdminKnowledgeBaseDetail() {
         </Card>
       )}
 
+      {/* Specs estruturados — só quando documento está ready e tem product_code */}
+      {data.status === 'ready' && data.product_code && (
+        <Card className="p-3 space-y-2">
+          <div className="flex items-center justify-between flex-wrap gap-2">
+            <div className="flex items-center gap-2">
+              <Database className="w-4 h-4 text-muted-foreground" />
+              <span className="text-sm font-medium">Specs estruturados</span>
+              {existingSpecs && (
+                <Badge variant="outline" className="text-2xs gap-1">
+                  <Sparkles className="w-2.5 h-2.5" />
+                  Aprovado
+                </Badge>
+              )}
+            </div>
+            <KbSpecsExtractButton
+              documentId={data.id}
+              documentTitle={data.title}
+              productCode={data.product_code}
+              onSaved={() => refetchSpecs()}
+            />
+          </div>
+
+          {existingSpecs ? (
+            <div className="grid grid-cols-2 md:grid-cols-3 gap-2 text-2xs pt-2 border-t border-border">
+              {existingSpecs.rendimento_m2_por_litro != null && (
+                <KpiCell label="Rendimento" value={`${existingSpecs.rendimento_m2_por_litro} m²/L`} />
+              )}
+              {existingSpecs.densidade_g_cm3 != null && (
+                <KpiCell label="Densidade" value={`${existingSpecs.densidade_g_cm3} g/cm³`} />
+              )}
+              {existingSpecs.solidos_pct != null && (
+                <KpiCell label="Sólidos" value={`${existingSpecs.solidos_pct}%`} />
+              )}
+              {existingSpecs.pot_life_horas != null && (
+                <KpiCell label="Pot life" value={`${existingSpecs.pot_life_horas}h`} />
+              )}
+              {existingSpecs.validade_dias != null && (
+                <KpiCell label="Validade" value={`${existingSpecs.validade_dias} dias`} />
+              )}
+              {existingSpecs.dureza && <KpiCell label="Dureza" value={existingSpecs.dureza} />}
+              {existingSpecs.catalisador_codigo && (
+                <KpiCell label="Catalisador" value={`${existingSpecs.catalisador_codigo}${existingSpecs.catalisador_proporcao_pct ? ` (${existingSpecs.catalisador_proporcao_pct}%)` : ''}`} />
+              )}
+              {existingSpecs.diluente_codigo && (
+                <KpiCell label="Diluente" value={existingSpecs.diluente_codigo} />
+              )}
+              {existingSpecs.demaos_recomendadas != null && (
+                <KpiCell label="Demãos" value={String(existingSpecs.demaos_recomendadas)} />
+              )}
+            </div>
+          ) : (
+            <div className="text-2xs text-muted-foreground">
+              Clique acima pra extrair specs automaticamente do texto via Claude.
+            </div>
+          )}
+        </Card>
+      )}
+
       {data.content_extracted && (
         <Card className="p-3">
           <div className="text-2xs uppercase tracking-wide text-muted-foreground mb-2">
@@ -94,6 +160,15 @@ export default function AdminKnowledgeBaseDetail() {
           </pre>
         </Card>
       )}
+    </div>
+  );
+}
+
+function KpiCell({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <div className="text-muted-foreground">{label}</div>
+      <div className="font-medium tabular-nums">{value}</div>
     </div>
   );
 }

--- a/supabase/functions/kb-extract-specs/index.ts
+++ b/supabase/functions/kb-extract-specs/index.ts
@@ -1,0 +1,190 @@
+import Anthropic from "npm:@anthropic-ai/sdk@^0.93.0";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import { authorizeCronOrStaff, corsHeaders } from "../_shared/auth.ts";
+
+const SYSTEM_PROMPT_EXTRACT_SPECS = `Você extrai specs técnicos estruturados de boletins técnicos de tintas industriais para a base de conhecimento da Colacor (distribuidora Sayerlack).
+
+# Regras gerais
+- Use APENAS dados explícitos no texto. NÃO invente, NÃO estime.
+- Quando o boletim dá um range (ex: "viscosidade 42 ± 3s CF6 a 25°C"), use o valor central (42).
+- Para campos que o boletim NÃO menciona, deixe null.
+- Liste em \`extraction_gaps\` os campos importantes que estão ausentes.
+- \`extraction_confidence\` = 0.9+ se boletim claro, 0.6-0.8 se ambíguo, <0.6 se faltam muitos dados-chave.
+
+# Cálculos derivados permitidos
+- \`rendimento_m2_por_litro\` = (densidade_g_cm3 × 1000) / gramatura_g_m2_media. Use gramatura média entre min/max se houver range. Se boletim não tem gramatura nem densidade, deixe null.
+
+# Classificação semântica (vc preenche baseado no texto)
+- \`product_line\`: 'wood_pu' | 'wood_nitro' | 'hydropoxi' | 'auto' — Wood PU pra poliuretanos pra madeira (mais comum em boletins moveleiros)
+- \`product_category\`: 'primer' | 'verniz' | 'tinta' | 'catalisador' | 'diluente' | 'massa' | 'selador'
+- \`diferenciais_chave\`: extrai as 2-5 frases-chave do "Uso Recomendado" e "Características"
+
+# Compliance
+- Se boletim menciona "isento de" e lista substâncias/metais, capture nos arrays
+- \`certificacoes_aplicaveis\`: capture menções de IKEA, LGA, Proposition 65, JIS, CARB, etc.
+
+SEMPRE use a tool extract_product_specs. NÃO responda em texto fora dela.`;
+
+const EXTRACT_TOOL = {
+  name: "extract_product_specs",
+  description: "Retorna specs estruturados do produto extraídos do boletim técnico.",
+  input_schema: {
+    type: "object",
+    properties: {
+      product_code: { type: "string" },
+      product_name: { type: "string" },
+      supplier: { type: "string" },
+      product_line: { type: ["string", "null"], enum: ["wood_pu", "wood_nitro", "hydropoxi", "auto", null] },
+      product_category: { type: ["string", "null"] },
+      densidade_g_cm3: { type: ["number", "null"] },
+      solidos_pct: { type: ["number", "null"] },
+      viscosidade_aplicacao_s: { type: ["number", "null"] },
+      viscosidade_copo: { type: ["string", "null"] },
+      brilho_ub: { type: ["number", "null"] },
+      dureza: { type: ["string", "null"] },
+      rendimento_m2_por_litro: { type: ["number", "null"] },
+      demaos_recomendadas: { type: ["integer", "null"] },
+      gramatura_g_m2_min: { type: ["integer", "null"] },
+      gramatura_g_m2_max: { type: ["integer", "null"] },
+      pot_life_horas: { type: ["number", "null"] },
+      temp_aplicacao_c_min: { type: ["number", "null"] },
+      temp_aplicacao_c_max: { type: ["number", "null"] },
+      umidade_aplicacao_pct_min: { type: ["number", "null"] },
+      umidade_aplicacao_pct_max: { type: ["number", "null"] },
+      catalisador_codigo: { type: ["string", "null"] },
+      catalisador_proporcao_pct: { type: ["number", "null"] },
+      diluente_codigo: { type: ["string", "null"] },
+      equipamentos_aplicacao: { type: "array", items: { type: "string" } },
+      lixa_recomendada: { type: ["string", "null"] },
+      substrato: { type: "array", items: { type: "string" } },
+      secagem_manuseio_h: { type: ["number", "null"] },
+      secagem_empilhamento_h: { type: ["number", "null"] },
+      secagem_total_h: { type: ["number", "null"] },
+      validade_dias: { type: ["integer", "null"] },
+      temp_armazenamento_c_min: { type: ["integer", "null"] },
+      temp_armazenamento_c_max: { type: ["integer", "null"] },
+      certificacoes_aplicaveis: { type: "array", items: { type: "string" } },
+      isento_metais_pesados: { type: "array", items: { type: "string" } },
+      isento_substancias: { type: "array", items: { type: "string" } },
+      diferenciais_chave: { type: "array", items: { type: "string" } },
+      uso_recomendado: { type: ["string", "null"] },
+      publico_alvo: { type: ["string", "null"] },
+      extraction_confidence: { type: "number", minimum: 0, maximum: 1 },
+      extraction_gaps: { type: "array", items: { type: "string" } },
+    },
+    required: [
+      "product_code",
+      "product_name",
+      "supplier",
+      "extraction_confidence",
+      "extraction_gaps",
+      "equipamentos_aplicacao",
+      "substrato",
+      "certificacoes_aplicaveis",
+      "isento_metais_pesados",
+      "isento_substancias",
+      "diferenciais_chave",
+    ],
+  },
+};
+
+Deno.serve(async (req) => {
+  if (req.method === "OPTIONS") return new Response(null, { headers: corsHeaders });
+
+  const auth = await authorizeCronOrStaff(req);
+  if (!auth.ok) return auth.response;
+
+  const apiKey = Deno.env.get("ANTHROPIC_API_KEY");
+  if (!apiKey) {
+    return new Response(JSON.stringify({ error: "ANTHROPIC_API_KEY not configured" }), {
+      status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+
+  const supabase = createClient(
+    Deno.env.get("SUPABASE_URL")!,
+    Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!,
+  );
+
+  let body;
+  try { body = await req.json(); } catch {
+    return new Response(JSON.stringify({ error: "Invalid JSON" }), {
+      status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+  if (!body.documentId) {
+    return new Response(JSON.stringify({ error: "documentId required" }), {
+      status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+
+  try {
+    const { data: doc, error } = await supabase
+      .from("kb_documents")
+      .select("id, title, product_code, supplier, content_extracted, status")
+      .eq("id", body.documentId)
+      .single();
+
+    if (error || !doc) {
+      return new Response(JSON.stringify({ error: "Document not found" }), {
+        status: 404, headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    if (doc.status !== "ready" || !doc.content_extracted) {
+      return new Response(JSON.stringify({ error: "Document not ready or has no extracted content" }), {
+        status: 422, headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    const client = new Anthropic({ apiKey });
+
+    const userMsg = `Extraia os specs estruturados deste boletim técnico:
+
+# Metadata
+- Título: ${doc.title}
+- Código produto (hint): ${doc.product_code ?? "(não informado)"}
+- Fornecedor: ${doc.supplier ?? "sayerlack"}
+
+# Texto extraído
+${doc.content_extracted.slice(0, 50_000)}
+
+Use a tool extract_product_specs.`;
+
+    const response = await client.messages.create({
+      model: "claude-sonnet-4-6",
+      max_tokens: 4000,
+      system: [{
+        type: "text",
+        text: SYSTEM_PROMPT_EXTRACT_SPECS,
+        cache_control: { type: "ephemeral" },
+      }],
+      tools: [EXTRACT_TOOL],
+      tool_choice: { type: "tool", name: "extract_product_specs" },
+      messages: [{ role: "user", content: userMsg }],
+    });
+
+    const toolUse = response.content.find((b) => b.type === "tool_use");
+    if (!toolUse || toolUse.type !== "tool_use") {
+      return new Response(JSON.stringify({ error: "No tool_use in response", raw: response }), {
+        status: 502, headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    return new Response(JSON.stringify({
+      specs: toolUse.input,
+      usage: {
+        inputTokens: response.usage.input_tokens,
+        outputTokens: response.usage.output_tokens,
+        cacheCreationTokens: response.usage.cache_creation_input_tokens ?? 0,
+        cacheReadTokens: response.usage.cache_read_input_tokens ?? 0,
+      },
+    }), { headers: { ...corsHeaders, "Content-Type": "application/json" } });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "unknown error";
+    console.error("[kb-extract-specs]", msg);
+    return new Response(JSON.stringify({ error: msg }), {
+      status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+});

--- a/supabase/migrations/20260517180000_kb_specs_and_competitors.sql
+++ b/supabase/migrations/20260517180000_kb_specs_and_competitors.sql
@@ -1,0 +1,213 @@
+-- PR6b: KB specs + competitors skeleton
+
+-- 1. Tabela de specs estruturados (1 row por produto da Sayerlack/Colacor)
+CREATE TABLE IF NOT EXISTS public.kb_product_specs (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  document_id uuid REFERENCES public.kb_documents(id) ON DELETE SET NULL,
+  product_code text NOT NULL UNIQUE,        -- ex: 'FO20.6827.00'
+  product_name text NOT NULL,
+  supplier text NOT NULL DEFAULT 'sayerlack',
+  product_line text,                         -- 'wood_pu' | 'wood_nitro' | 'hydropoxi' | 'auto'
+  product_category text,                     -- 'primer' | 'verniz' | 'tinta' | 'catalisador' | 'diluente'
+
+  -- Propriedades físico-químicas
+  densidade_g_cm3 numeric,
+  solidos_pct numeric,
+  viscosidade_aplicacao_s numeric,
+  viscosidade_copo text,                     -- 'CF4' | 'CF6' | 'CF8'
+  brilho_ub numeric,                         -- unidades de brilho
+  dureza text,                               -- '3H', '2H' etc.
+
+  -- Aplicação
+  rendimento_m2_por_litro numeric,           -- calculado ou explícito
+  demaos_recomendadas integer,
+  gramatura_g_m2_min integer,
+  gramatura_g_m2_max integer,
+  pot_life_horas numeric,
+  temp_aplicacao_c_min numeric,
+  temp_aplicacao_c_max numeric,
+  umidade_aplicacao_pct_min numeric,
+  umidade_aplicacao_pct_max numeric,
+
+  -- Compatibilidade
+  catalisador_codigo text,                   -- ex: 'FC.6952'
+  catalisador_proporcao_pct numeric,
+  diluente_codigo text,                      -- ex: 'DF.4068'
+  equipamentos_aplicacao text[],             -- ['pistola_convencional', 'tanque_pressao']
+  lixa_recomendada text,
+  substrato text[],                          -- ['madeira', 'mdf']
+
+  -- Secagem
+  secagem_manuseio_h numeric,
+  secagem_empilhamento_h numeric,
+  secagem_total_h numeric,
+
+  -- Armazenamento
+  validade_dias integer,
+  temp_armazenamento_c_min integer,
+  temp_armazenamento_c_max integer,
+
+  -- Compliance
+  certificacoes_aplicaveis text[],           -- ['IKEA', 'LGA', 'Proposition_65']
+  isento_metais_pesados text[],              -- ['Cd', 'Pb', etc.]
+  isento_substancias text[],                 -- ['amianto', 'formaldeido']
+
+  -- Notas qualitativas
+  diferenciais_chave text[],                 -- ['resistencia_risco_superior', 'toque_sedoso']
+  uso_recomendado text,
+  publico_alvo text,
+
+  -- Metadata
+  extraction_confidence numeric,             -- 0-1 (Claude reporta)
+  extraction_gaps text[],                    -- campos que Claude não conseguiu extrair
+  extracted_by uuid REFERENCES auth.users(id),
+  approved_by uuid REFERENCES auth.users(id),
+  approved_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- 2. Concorrentes (vazio — populado por PR8)
+CREATE TABLE IF NOT EXISTS public.kb_competitors (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  name text NOT NULL UNIQUE,                 -- 'Farben Tintas', 'Vernit', 'Rosalen'
+  tipo text CHECK (tipo IN ('regional', 'nacional', 'importado')),
+  regiao_principal text,                     -- 'mg', 'sul', 'sp', 'nacional'
+  segmento_atuacao text[],                   -- ['moveleiro', 'industrial', 'automotivo']
+  notas_estrategicas text,
+  created_by uuid REFERENCES auth.users(id),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- 3. Produtos do concorrente (vazio — populado via UI ou auto-detect)
+CREATE TABLE IF NOT EXISTS public.kb_competitor_products (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  competitor_id uuid NOT NULL REFERENCES public.kb_competitors(id) ON DELETE CASCADE,
+  product_name text NOT NULL,
+  category text,                             -- mesmo enum de kb_product_specs.product_category
+  rendimento_m2_por_litro numeric,
+  solidos_pct numeric,
+  pot_life_horas numeric,
+  validade_dias integer,
+  preco_referencia_l numeric,
+  preco_atualizado_em timestamptz,
+  fonte_preco text CHECK (fonte_preco IN ('vendedor', 'cotacao', 'site', 'estimado', 'detectado_ia')),
+  pontos_fortes text[],
+  pontos_fracos text[],
+  nosso_equivalente_product_code text,       -- referência cruzada com nossos kb_product_specs.product_code
+  argumentos_comparativos jsonb,             -- estrutura aberta pra flexibilidade
+  created_by uuid REFERENCES auth.users(id),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- 4. Indexes
+CREATE INDEX IF NOT EXISTS idx_kb_product_specs_product_code ON public.kb_product_specs (product_code);
+CREATE INDEX IF NOT EXISTS idx_kb_product_specs_supplier_line ON public.kb_product_specs (supplier, product_line);
+CREATE INDEX IF NOT EXISTS idx_kb_competitor_products_competitor ON public.kb_competitor_products (competitor_id);
+CREATE INDEX IF NOT EXISTS idx_kb_competitor_products_equivalent ON public.kb_competitor_products (nosso_equivalente_product_code);
+
+-- 5. Triggers updated_at (reusa função do PR6a se existir; senão cria)
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_proc WHERE proname = 'kb_documents_set_updated_at') THEN
+    CREATE OR REPLACE FUNCTION public.kb_documents_set_updated_at()
+    RETURNS trigger AS $func$
+    BEGIN NEW.updated_at = now(); RETURN NEW; END;
+    $func$ LANGUAGE plpgsql;
+  END IF;
+END $$;
+
+DROP TRIGGER IF EXISTS trg_kb_product_specs_updated_at ON public.kb_product_specs;
+CREATE TRIGGER trg_kb_product_specs_updated_at
+  BEFORE UPDATE ON public.kb_product_specs
+  FOR EACH ROW EXECUTE FUNCTION public.kb_documents_set_updated_at();
+
+DROP TRIGGER IF EXISTS trg_kb_competitors_updated_at ON public.kb_competitors;
+CREATE TRIGGER trg_kb_competitors_updated_at
+  BEFORE UPDATE ON public.kb_competitors
+  FOR EACH ROW EXECUTE FUNCTION public.kb_documents_set_updated_at();
+
+DROP TRIGGER IF EXISTS trg_kb_competitor_products_updated_at ON public.kb_competitor_products;
+CREATE TRIGGER trg_kb_competitor_products_updated_at
+  BEFORE UPDATE ON public.kb_competitor_products
+  FOR EACH ROW EXECUTE FUNCTION public.kb_documents_set_updated_at();
+
+-- 6. RLS — staff lê, master CRUD
+ALTER TABLE public.kb_product_specs ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.kb_competitors ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.kb_competitor_products ENABLE ROW LEVEL SECURITY;
+
+-- kb_product_specs
+CREATE POLICY "kb_product_specs_select_staff" ON public.kb_product_specs
+  FOR SELECT
+  USING (
+    public.has_role(auth.uid(), 'employee'::app_role)
+    OR public.has_role(auth.uid(), 'master'::app_role)
+  );
+CREATE POLICY "kb_product_specs_insert_staff" ON public.kb_product_specs
+  FOR INSERT
+  WITH CHECK (
+    public.has_role(auth.uid(), 'employee'::app_role)
+    OR public.has_role(auth.uid(), 'master'::app_role)
+  );
+CREATE POLICY "kb_product_specs_update_master" ON public.kb_product_specs
+  FOR UPDATE
+  USING (
+    public.has_role(auth.uid(), 'master'::app_role)
+    OR extracted_by = auth.uid()
+  );
+CREATE POLICY "kb_product_specs_delete_master" ON public.kb_product_specs
+  FOR DELETE
+  USING (public.has_role(auth.uid(), 'master'::app_role));
+
+-- kb_competitors
+CREATE POLICY "kb_competitors_select_staff" ON public.kb_competitors
+  FOR SELECT
+  USING (
+    public.has_role(auth.uid(), 'employee'::app_role)
+    OR public.has_role(auth.uid(), 'master'::app_role)
+  );
+CREATE POLICY "kb_competitors_insert_staff" ON public.kb_competitors
+  FOR INSERT
+  WITH CHECK (
+    public.has_role(auth.uid(), 'employee'::app_role)
+    OR public.has_role(auth.uid(), 'master'::app_role)
+  );
+CREATE POLICY "kb_competitors_update_staff" ON public.kb_competitors
+  FOR UPDATE
+  USING (
+    public.has_role(auth.uid(), 'employee'::app_role)
+    OR public.has_role(auth.uid(), 'master'::app_role)
+  );
+CREATE POLICY "kb_competitors_delete_master" ON public.kb_competitors
+  FOR DELETE
+  USING (public.has_role(auth.uid(), 'master'::app_role));
+
+-- kb_competitor_products
+CREATE POLICY "kb_competitor_products_select_staff" ON public.kb_competitor_products
+  FOR SELECT
+  USING (
+    public.has_role(auth.uid(), 'employee'::app_role)
+    OR public.has_role(auth.uid(), 'master'::app_role)
+  );
+CREATE POLICY "kb_competitor_products_insert_staff" ON public.kb_competitor_products
+  FOR INSERT
+  WITH CHECK (
+    public.has_role(auth.uid(), 'employee'::app_role)
+    OR public.has_role(auth.uid(), 'master'::app_role)
+  );
+CREATE POLICY "kb_competitor_products_update_staff" ON public.kb_competitor_products
+  FOR UPDATE
+  USING (
+    public.has_role(auth.uid(), 'employee'::app_role)
+    OR public.has_role(auth.uid(), 'master'::app_role)
+  );
+CREATE POLICY "kb_competitor_products_delete_master" ON public.kb_competitor_products
+  FOR DELETE
+  USING (public.has_role(auth.uid(), 'master'::app_role));
+
+-- 7. Comentários
+COMMENT ON TABLE public.kb_product_specs IS 'Specs estruturados extraídos de kb_documents via Claude. 1 row por produto Sayerlack.';
+COMMENT ON TABLE public.kb_competitors IS 'Concorrentes regionais/nacionais. Populado por vendedores via UI ou auto-detect de transcripts.';
+COMMENT ON TABLE public.kb_competitor_products IS 'Produtos específicos dos concorrentes com specs comparáveis aos nossos.';

--- a/tsconfig.strict.json
+++ b/tsconfig.strict.json
@@ -27,6 +27,11 @@
     "src/lib/help-utils.ts",
     "src/hooks/useNetworkStatus.ts",
     "src/hooks/useInfiniteScroll.ts",
-    "src/hooks/useBarcodeDetector.ts"
+    "src/hooks/useBarcodeDetector.ts",
+    "src/hooks/useFarmerPerformance.ts",
+    "src/hooks/useFarmerExperiments.ts",
+    "src/hooks/useTacticalPlan.ts",
+    "src/hooks/useCrossSellEngine.ts",
+    "src/hooks/useBundleEngine.ts"
   ]
 }


### PR DESCRIPTION
## Summary

PR6b — Dado um documento processado em `kb_documents` (status='ready'), permite extração estruturada de specs técnicos via **Claude Sonnet 4.6 + tool use**.

**Stacked sobre PR #63 (PR6a)** — base = `claude/pr6a-knowledge-base-foundation`. Quando #63 mergear em main, GitHub auto-rebasea este PR.

## Entrega

- **Schema novo**: `kb_product_specs` (~45 colunas de specs físico-químicos, aplicação, secagem, compliance) + skeleton vazio `kb_competitors` + `kb_competitor_products` (vendedor preenche no PR8 — sem hardcode)
- **Edge function `kb-extract-specs`**: recebe documentId, monta system prompt com regras de extração + cache_control ephemeral, força tool use, retorna proposta estruturada com `extraction_confidence` + `extraction_gaps`
- **3 hooks**: `useExtractSpecs` (mutation), `useSaveProductSpecs` (upsert por product_code), `useKbProductSpecs` (read)
- **Componente `KbSpecsForm`**: form RHF + Zod com 45+ campos agrupados em 8 fieldsets (Identificação, Físico-químico, Aplicação, Compatibilidade, Secagem & Armazenamento, Compliance, Notas)
- **Componente `KbSpecsExtractButton`**: botão "Extrair specs com IA" → invoca Claude → abre Dialog com KbSpecsForm pré-preenchido → user revisa → "Aprovar e salvar"
- **Wire em `/admin/knowledge-base/:id`**: nova seção "Specs estruturados" entre status e texto extraído. Mostra preview de 9 KPIs (rendimento, densidade, sólidos, pot life, validade, dureza, catalisador, diluente, demãos) quando specs já aprovados; senão mostra botão de extração

## Pré-requisito de deploy

1. **Rodar a nova migration SQL** no Lovable Cloud (3 tabelas + RLS usando `has_role()`)
2. **Regenerar types Supabase** (Lovable Cloud → Database → Generate Types)
3. ANTHROPIC_API_KEY já configurada (PR #55)

## Testes

- 241 → 244 (+3 do useExtractSpecs)
- tsc clean ✅
- build passa ✅

## Como funciona em runtime

```
1. Admin abre /admin/knowledge-base/:id (documento status='ready' com texto extraído + product_code)
2. Vê seção "Specs estruturados" → clica "Extrair specs com IA"
3. Backend: edge function kb-extract-specs
   → busca content_extracted (até 50k chars)
   → Claude Sonnet 4.6 lê o boletim
   → retorna ~45 campos preenchidos via tool_use forçada
4. Frontend abre Dialog com KbSpecsForm pré-preenchido
5. Admin revisa (campos com gaps sinalizados em warning), edita se necessário, clica "Aprovar e salvar"
6. Backend: upsert em kb_product_specs por product_code
7. Card atualizado mostra preview dos 9 KPIs principais
```

## Custo Anthropic

- Prompt cached (~80% hit rate em chamadas subsequentes do mesmo modelo)
- 1 extração típica: ~$0.05-0.15 (depende do tamanho do boletim)
- Roda 1× por documento (depois aprovado, ficou salvo — chamada futura é gratuita via useKbProductSpecs)

## Não-objetivos (próximos sub-PRs)

- **PR6c**: Calculadora de rendimento embutida no painel de chamada (consome kb_product_specs)
- **PR6d**: RAG — copilot consulta KB + specs antes de gerar análise SPIN
- **PR8**: UI de gestão de concorrentes (kb_competitors + kb_competitor_products já têm schema pronto)

## Test plan

Após PR #63 + esta PR mergeados + migration rodada:

- [ ] Subir um boletim Sayerlack (FLA_6264_02 ou FO20_6827_00) via /admin/knowledge-base
- [ ] Aguardar processing → ready
- [ ] Entrar no detail page
- [ ] Clicar "Extrair specs com IA"
- [ ] Confirmar que Dialog abre em 5-15s com campos pré-preenchidos
- [ ] Confirmar que campos como densidade (0.979 ou 1.425), sólidos (38.4% ou 72.3%), pot life, catalisador (FC.6952 ou FCA.7075) estão corretos
- [ ] Revisar gaps (campos vazios), preencher manualmente se quiser
- [ ] Clicar "Aprovar e salvar" → ver preview com 9 KPIs no detail page

🤖 Generated with [Claude Code](https://claude.com/claude-code)