### PR TITLE
fix(test): destravar 19 test files no bun test runner via localStorage mock

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,9 +69,15 @@ bun dev       # vite dev server (porta 8080)
 bun build     # vite build (PWA gerado em production)
 bun build:dev # build em modo dev (sem PWA)
 bun lint      # eslint
-bun test      # vitest run
+bun run test  # vitest run — CANÔNICO, 241/241 passando, é o que roda em CI
+bun test      # bun runner nativo — fast path local (~280ms vs ~3.9s do vitest);
+              # cobertura parcial (não suporta vi.hoisted/vi.mocked/vi.importActual nem DOM completo).
+              # bunfig.toml + src/test/bun-setup.ts polifillam localStorage/MediaStream/matchMedia.
 bun preview   # vite preview
 ```
+
+> ⚠️ **`bun test` ≠ `bun run test`**. `bun test` invoca o runner nativo do bun (não usa vitest.config.ts).
+> Use pra loop rápido de TDD em tests que não dependem de DOM/React renderização. Resultado oficial é só do vitest.
 
 ---
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,2 @@
+[test]
+preload = "./src/test/bun-setup.ts"

--- a/src/test/bun-setup.ts
+++ b/src/test/bun-setup.ts
@@ -1,0 +1,69 @@
+// Preload para `bun test` (runner nativo do bun). Espelha o que `src/test/setup.ts`
+// faz pro vitest, já que o bun não usa vitest.config.ts e não roda em jsdom.
+//
+// Sem isso, qualquer test que importa (direta ou indiretamente) o supabase client
+// quebra porque `src/integrations/supabase/client.ts` referencia `localStorage`
+// no top-level.
+
+if (typeof globalThis.localStorage === "undefined") {
+  const store = new Map<string, string>();
+  const localStorageShim: Storage = {
+    get length() {
+      return store.size;
+    },
+    clear: () => store.clear(),
+    getItem: (key) => (store.has(key) ? store.get(key)! : null),
+    key: (index) => Array.from(store.keys())[index] ?? null,
+    removeItem: (key) => {
+      store.delete(key);
+    },
+    setItem: (key, value) => {
+      store.set(key, String(value));
+    },
+  };
+  Object.defineProperty(globalThis, "localStorage", {
+    value: localStorageShim,
+    writable: true,
+    configurable: true,
+  });
+}
+
+if (typeof globalThis.MediaStream === "undefined") {
+  class MediaStreamPolyfill {
+    private tracks: MediaStreamTrack[];
+    constructor(tracks: MediaStreamTrack[] = []) {
+      this.tracks = [...tracks];
+    }
+    getTracks() {
+      return this.tracks;
+    }
+    getAudioTracks() {
+      return this.tracks.filter((t) => t.kind === "audio");
+    }
+    getVideoTracks() {
+      return this.tracks.filter((t) => t.kind === "video");
+    }
+    addTrack(t: MediaStreamTrack) {
+      this.tracks.push(t);
+    }
+  }
+  // @ts-expect-error - shim
+  globalThis.MediaStream = MediaStreamPolyfill;
+}
+
+if (typeof globalThis.matchMedia === "undefined") {
+  Object.defineProperty(globalThis, "matchMedia", {
+    writable: true,
+    configurable: true,
+    value: (query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }),
+  });
+}


### PR DESCRIPTION
## Summary
- `bun test` (runner nativo) quebrava ~16 test files com `ReferenceError: localStorage is not defined` porque `src/integrations/supabase/client.ts:13` referencia `localStorage` no top-level e o bun não roda em jsdom nem usa `vitest.config.ts`
- Adicionado `bunfig.toml` + `src/test/bun-setup.ts` que polifillam `localStorage` / `MediaStream` / `matchMedia` globalmente antes de qualquer test rodar (espírito do `setupFiles` do vitest, adaptado pro runner certo)
- Corrigida documentação no CLAUDE.md que afirmava (erroneamente) que `bun test` → `vitest run`

## Resultado
| Runner | Antes | Depois |
|---|---|---|
| `bun run test` (vitest, CI) | 241/241 ✓ | 241/241 ✓ (não regrediu) |
| `bun test` (bun nativo, dev loop) | 108 pass / 21 errors | 163 pass / 14 errors |
| localStorage errors no `bun test` | 16 | 0 |

Zero mudança em código de produção. `bun run test` continua sendo o canônico (rodado em CI); `bun test` agora serve como loop rápido de TDD local (~280ms vs ~3.9s do vitest).

Os 14 erros restantes no `bun test` são gaps arquiteturais (DOM completo + `vi.hoisted`/`vi.mocked`/`vi.importActual` que são transformações de source do worker do vitest, não API de runtime). Não-polifilláveis sem virar gambiarra que silenciosamente quebra mocks. Documentado no CLAUDE.md.

## Test plan
- [x] `bun run test` segue passando 241/241
- [x] `bun test` sobe de 108 → 163 pass
- [x] Zero erros `localStorage is not defined` no `bun test`
- [x] Sem mudança em `src/integrations/supabase/client.ts` (zero risco em produção)

🤖 Generated with [Claude Code](https://claude.com/claude-code)