### PR TITLE
fix: re-mergear PR6b (KB specs extraction) + PR6c (Calculadora) em main

### DIFF
--- a/docs/superpowers/plans/2026-05-17-pr6b-kb-extract-specs.md
+++ b/docs/superpowers/plans/2026-05-17-pr6b-kb-extract-specs.md
@@ -1,0 +1,661 @@
+# PR6b — KB: Extração Automática de Specs via Claude Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Dado um documento processado em `kb_documents` (status='ready' com texto extraído), permitir extração estruturada de specs técnicos via Claude tool use. Schema novo: `kb_product_specs` (rendimento, validade, pot life, densidade, sólidos, dureza, brilho, catalisador/diluente compatível, gramatura, compliance) + skeleton `kb_competitors` / `kb_competitor_products` (vazio — vendedor preenche via PR8). Edge function `kb-extract-specs` chama Claude, retorna proposta. UI no detail page: botão "Extrair specs" → form pré-preenchido pra admin revisar e aprovar → salva.
+
+**Architecture:**
+- Migration: 3 tabelas (`kb_product_specs`, `kb_competitors`, `kb_competitor_products`) + RLS (master CRUD, staff read)
+- Edge function `kb-extract-specs` (Deno + Anthropic SDK): recebe `documentId`, busca content_extracted, monta prompt SPIN-like com tool use forçada pra retornar shape estruturado, retorna `{ specs: {...}, confidence, gaps: [...] }`
+- Client: hook `useExtractSpecs` (mutation), hook `useKbProductSpecs(productCode)` (read), componente `KbSpecsForm` (form de revisão RHF+Zod), wire no `AdminKnowledgeBaseDetail`
+
+**Tech Stack:**
+- Anthropic SDK Deno (`npm:@anthropic-ai/sdk@^0.93.0`) — mesmo padrão de `claude-spin-analyze`
+- Claude Sonnet 4.6 (com adaptive thinking — extração técnica vale custo)
+- Tool use forçada (`tool_choice: { type: 'tool', name: 'extract_product_specs' }`)
+- Prompt caching no system prompt (compartilhado entre requests)
+- RHF + Zod no form
+
+**Não-objetivos (próximos PRs):**
+- Calculadora ao vivo no painel de chamada (PR6c)
+- RAG retrieval no copilot (PR6d)
+- UI de gestão de concorrentes + battle cards (PR8) — schema fica pronto aqui
+- Versionamento de specs (parent_id existe mas sem UI)
+- Histórico de revisões da spec (só guarda current)
+- OCR / fallback pra PDFs sem texto extraído
+
+---
+
+## File Structure
+
+**Criar:**
+- `supabase/migrations/{timestamp}_kb_specs_and_competitors.sql` — 3 tabelas + RLS
+- `supabase/functions/kb-extract-specs/index.ts` — edge function com Claude tool use
+- `src/lib/knowledge-base/specs-types.ts` — `KbProductSpec`, `KbCompetitor`, `KbCompetitorProduct` types
+- `src/hooks/useExtractSpecs.ts` — mutation: invoca edge function, retorna proposta sem salvar
+- `src/hooks/useSaveProductSpecs.ts` — mutation: salva specs aprovados
+- `src/hooks/useKbProductSpecs.ts` — query: busca specs por document_id ou product_code
+- `src/hooks/__tests__/useExtractSpecs.test.tsx`
+- `src/components/knowledge-base/KbSpecsForm.tsx` — form de revisão (RHF + Zod)
+- `src/components/knowledge-base/KbSpecsExtractButton.tsx` — botão + Dialog
+
+**Modificar:**
+- `src/integrations/supabase/types.ts` — 3 tabelas novas
+- `src/pages/AdminKnowledgeBaseDetail.tsx` — render do KbSpecsExtractButton + KbSpecsForm quando documento ready
+
+**Não modificar:**
+- `kb-ingest-document` edge function (PR6a — independente)
+- `claude-spin-analyze` (PR6d vai integrar)
+- `kb_documents` / `kb_chunks` schema (não muda)
+
+---
+
+## Pré-requisito do operador
+
+- `ANTHROPIC_API_KEY` já configurada (PR #55)
+- Rodar a nova migration SQL no Lovable Cloud
+- Regenerar types Supabase
+
+---
+
+## Task 1: Migration SQL
+
+**Files:** Create `supabase/migrations/{timestamp}_kb_specs_and_competitors.sql`
+
+```sql
+-- PR6b: KB specs + competitors skeleton
+
+-- 1. Tabela de specs estruturados (1 row por produto da Sayerlack/Colacor)
+CREATE TABLE IF NOT EXISTS public.kb_product_specs (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  document_id uuid REFERENCES public.kb_documents(id) ON DELETE SET NULL,
+  product_code text NOT NULL UNIQUE,        -- ex: 'FO20.6827.00'
+  product_name text NOT NULL,
+  supplier text NOT NULL DEFAULT 'sayerlack',
+  product_line text,                         -- 'wood_pu' | 'wood_nitro' | 'hydropoxi' | 'auto'
+  product_category text,                     -- 'primer' | 'verniz' | 'tinta' | 'catalisador' | 'diluente'
+
+  -- Propriedades físico-químicas
+  densidade_g_cm3 numeric,
+  solidos_pct numeric,
+  viscosidade_aplicacao_s numeric,
+  viscosidade_copo text,                     -- 'CF4' | 'CF6' | 'CF8'
+  brilho_ub numeric,                         -- unidades de brilho
+  dureza text,                               -- '3H', '2H' etc.
+
+  -- Aplicação
+  rendimento_m2_por_litro numeric,           -- calculado ou explícito
+  demaos_recomendadas integer,
+  gramatura_g_m2_min integer,
+  gramatura_g_m2_max integer,
+  pot_life_horas numeric,
+  temp_aplicacao_c_min numeric,
+  temp_aplicacao_c_max numeric,
+  umidade_aplicacao_pct_min numeric,
+  umidade_aplicacao_pct_max numeric,
+
+  -- Compatibilidade
+  catalisador_codigo text,                   -- ex: 'FC.6952'
+  catalisador_proporcao_pct numeric,
+  diluente_codigo text,                      -- ex: 'DF.4068'
+  equipamentos_aplicacao text[],             -- ['pistola_convencional', 'tanque_pressao']
+  lixa_recomendada text,
+  substrato text[],                          -- ['madeira', 'mdf']
+
+  -- Secagem
+  secagem_manuseio_h numeric,
+  secagem_empilhamento_h numeric,
+  secagem_total_h numeric,
+
+  -- Armazenamento
+  validade_dias integer,
+  temp_armazenamento_c_min integer,
+  temp_armazenamento_c_max integer,
+
+  -- Compliance
+  certificacoes_aplicaveis text[],           -- ['IKEA', 'LGA', 'Proposition_65']
+  isento_metais_pesados text[],              -- ['Cd', 'Pb', etc.]
+  isento_substancias text[],                 -- ['amianto', 'formaldeido']
+
+  -- Notas qualitativas
+  diferenciais_chave text[],                 -- ['resistencia_risco_superior', 'toque_sedoso']
+  uso_recomendado text,
+  publico_alvo text,
+
+  -- Metadata
+  extraction_confidence numeric,             -- 0-1 (Claude reporta)
+  extraction_gaps text[],                    -- campos que Claude não conseguiu extrair
+  extracted_by uuid REFERENCES auth.users(id),
+  approved_by uuid REFERENCES auth.users(id),
+  approved_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- 2. Concorrentes (vazio — populado por PR8)
+CREATE TABLE IF NOT EXISTS public.kb_competitors (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  name text NOT NULL UNIQUE,                 -- 'Farben Tintas', 'Vernit', 'Rosalen'
+  tipo text CHECK (tipo IN ('regional', 'nacional', 'importado')),
+  regiao_principal text,                     -- 'mg', 'sul', 'sp', 'nacional'
+  segmento_atuacao text[],                   -- ['moveleiro', 'industrial', 'automotivo']
+  notas_estrategicas text,
+  created_by uuid REFERENCES auth.users(id),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- 3. Produtos do concorrente (vazio — populado via UI ou auto-detect)
+CREATE TABLE IF NOT EXISTS public.kb_competitor_products (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  competitor_id uuid NOT NULL REFERENCES public.kb_competitors(id) ON DELETE CASCADE,
+  product_name text NOT NULL,
+  category text,                             -- mesmo enum de kb_product_specs.product_category
+  rendimento_m2_por_litro numeric,
+  solidos_pct numeric,
+  pot_life_horas numeric,
+  validade_dias integer,
+  preco_referencia_l numeric,
+  preco_atualizado_em timestamptz,
+  fonte_preco text CHECK (fonte_preco IN ('vendedor', 'cotacao', 'site', 'estimado', 'detectado_ia')),
+  pontos_fortes text[],
+  pontos_fracos text[],
+  nosso_equivalente_product_code text,       -- referência cruzada com nossos kb_product_specs.product_code
+  argumentos_comparativos jsonb,             -- estrutura aberta pra flexibilidade
+  created_by uuid REFERENCES auth.users(id),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- 4. Indexes
+CREATE INDEX IF NOT EXISTS idx_kb_product_specs_product_code ON public.kb_product_specs (product_code);
+CREATE INDEX IF NOT EXISTS idx_kb_product_specs_supplier_line ON public.kb_product_specs (supplier, product_line);
+CREATE INDEX IF NOT EXISTS idx_kb_competitor_products_competitor ON public.kb_competitor_products (competitor_id);
+CREATE INDEX IF NOT EXISTS idx_kb_competitor_products_equivalent ON public.kb_competitor_products (nosso_equivalente_product_code);
+
+-- 5. Triggers updated_at (reusa função do PR6a se existir; senão cria)
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_proc WHERE proname = 'kb_documents_set_updated_at') THEN
+    CREATE OR REPLACE FUNCTION public.kb_documents_set_updated_at()
+    RETURNS trigger AS $func$
+    BEGIN NEW.updated_at = now(); RETURN NEW; END;
+    $func$ LANGUAGE plpgsql;
+  END IF;
+END $$;
+
+DROP TRIGGER IF EXISTS trg_kb_product_specs_updated_at ON public.kb_product_specs;
+CREATE TRIGGER trg_kb_product_specs_updated_at
+  BEFORE UPDATE ON public.kb_product_specs
+  FOR EACH ROW EXECUTE FUNCTION public.kb_documents_set_updated_at();
+
+DROP TRIGGER IF EXISTS trg_kb_competitors_updated_at ON public.kb_competitors;
+CREATE TRIGGER trg_kb_competitors_updated_at
+  BEFORE UPDATE ON public.kb_competitors
+  FOR EACH ROW EXECUTE FUNCTION public.kb_documents_set_updated_at();
+
+DROP TRIGGER IF EXISTS trg_kb_competitor_products_updated_at ON public.kb_competitor_products;
+CREATE TRIGGER trg_kb_competitor_products_updated_at
+  BEFORE UPDATE ON public.kb_competitor_products
+  FOR EACH ROW EXECUTE FUNCTION public.kb_documents_set_updated_at();
+
+-- 6. RLS — staff lê, master CRUD
+ALTER TABLE public.kb_product_specs ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.kb_competitors ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.kb_competitor_products ENABLE ROW LEVEL SECURITY;
+
+-- kb_product_specs
+CREATE POLICY "kb_product_specs_select_staff" ON public.kb_product_specs
+  FOR SELECT
+  USING (
+    public.has_role(auth.uid(), 'employee'::app_role)
+    OR public.has_role(auth.uid(), 'master'::app_role)
+  );
+CREATE POLICY "kb_product_specs_insert_staff" ON public.kb_product_specs
+  FOR INSERT
+  WITH CHECK (
+    public.has_role(auth.uid(), 'employee'::app_role)
+    OR public.has_role(auth.uid(), 'master'::app_role)
+  );
+CREATE POLICY "kb_product_specs_update_master" ON public.kb_product_specs
+  FOR UPDATE
+  USING (
+    public.has_role(auth.uid(), 'master'::app_role)
+    OR extracted_by = auth.uid()
+  );
+CREATE POLICY "kb_product_specs_delete_master" ON public.kb_product_specs
+  FOR DELETE
+  USING (public.has_role(auth.uid(), 'master'::app_role));
+
+-- kb_competitors
+CREATE POLICY "kb_competitors_select_staff" ON public.kb_competitors
+  FOR SELECT
+  USING (
+    public.has_role(auth.uid(), 'employee'::app_role)
+    OR public.has_role(auth.uid(), 'master'::app_role)
+  );
+CREATE POLICY "kb_competitors_insert_staff" ON public.kb_competitors
+  FOR INSERT
+  WITH CHECK (
+    public.has_role(auth.uid(), 'employee'::app_role)
+    OR public.has_role(auth.uid(), 'master'::app_role)
+  );
+CREATE POLICY "kb_competitors_update_staff" ON public.kb_competitors
+  FOR UPDATE
+  USING (
+    public.has_role(auth.uid(), 'employee'::app_role)
+    OR public.has_role(auth.uid(), 'master'::app_role)
+  );
+CREATE POLICY "kb_competitors_delete_master" ON public.kb_competitors
+  FOR DELETE
+  USING (public.has_role(auth.uid(), 'master'::app_role));
+
+-- kb_competitor_products
+CREATE POLICY "kb_competitor_products_select_staff" ON public.kb_competitor_products
+  FOR SELECT
+  USING (
+    public.has_role(auth.uid(), 'employee'::app_role)
+    OR public.has_role(auth.uid(), 'master'::app_role)
+  );
+CREATE POLICY "kb_competitor_products_insert_staff" ON public.kb_competitor_products
+  FOR INSERT
+  WITH CHECK (
+    public.has_role(auth.uid(), 'employee'::app_role)
+    OR public.has_role(auth.uid(), 'master'::app_role)
+  );
+CREATE POLICY "kb_competitor_products_update_staff" ON public.kb_competitor_products
+  FOR UPDATE
+  USING (
+    public.has_role(auth.uid(), 'employee'::app_role)
+    OR public.has_role(auth.uid(), 'master'::app_role)
+  );
+CREATE POLICY "kb_competitor_products_delete_master" ON public.kb_competitor_products
+  FOR DELETE
+  USING (public.has_role(auth.uid(), 'master'::app_role));
+
+-- 7. Comentários
+COMMENT ON TABLE public.kb_product_specs IS 'Specs estruturados extraídos de kb_documents via Claude. 1 row por produto Sayerlack.';
+COMMENT ON TABLE public.kb_competitors IS 'Concorrentes regionais/nacionais. Populado por vendedores via UI ou auto-detect de transcripts.';
+COMMENT ON TABLE public.kb_competitor_products IS 'Produtos específicos dos concorrentes com specs comparáveis aos nossos.';
+```
+
+Commit: `feat(kb): migration — kb_product_specs + kb_competitors + kb_competitor_products + RLS`
+
+---
+
+## Task 2: Types Supabase + domain types
+
+**Files:**
+- Modify: `src/integrations/supabase/types.ts` — adicionar 3 tabelas
+- Create: `src/lib/knowledge-base/specs-types.ts`
+
+```ts
+// specs-types.ts
+export interface KbProductSpec {
+  id: string;
+  document_id: string | null;
+  product_code: string;
+  product_name: string;
+  supplier: string;
+  product_line: string | null;
+  product_category: string | null;
+
+  densidade_g_cm3: number | null;
+  solidos_pct: number | null;
+  viscosidade_aplicacao_s: number | null;
+  viscosidade_copo: string | null;
+  brilho_ub: number | null;
+  dureza: string | null;
+
+  rendimento_m2_por_litro: number | null;
+  demaos_recomendadas: number | null;
+  gramatura_g_m2_min: number | null;
+  gramatura_g_m2_max: number | null;
+  pot_life_horas: number | null;
+  temp_aplicacao_c_min: number | null;
+  temp_aplicacao_c_max: number | null;
+  umidade_aplicacao_pct_min: number | null;
+  umidade_aplicacao_pct_max: number | null;
+
+  catalisador_codigo: string | null;
+  catalisador_proporcao_pct: number | null;
+  diluente_codigo: string | null;
+  equipamentos_aplicacao: string[];
+  lixa_recomendada: string | null;
+  substrato: string[];
+
+  secagem_manuseio_h: number | null;
+  secagem_empilhamento_h: number | null;
+  secagem_total_h: number | null;
+
+  validade_dias: number | null;
+  temp_armazenamento_c_min: number | null;
+  temp_armazenamento_c_max: number | null;
+
+  certificacoes_aplicaveis: string[];
+  isento_metais_pesados: string[];
+  isento_substancias: string[];
+
+  diferenciais_chave: string[];
+  uso_recomendado: string | null;
+  publico_alvo: string | null;
+
+  extraction_confidence: number | null;
+  extraction_gaps: string[];
+  extracted_by: string | null;
+  approved_by: string | null;
+  approved_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+/** Resposta da edge fn kb-extract-specs (sem ids, sem timestamps — só os campos extraídos) */
+export type KbExtractedSpec = Omit<KbProductSpec,
+  'id' | 'document_id' | 'extracted_by' | 'approved_by' | 'approved_at' | 'created_at' | 'updated_at'
+>;
+
+export interface KbCompetitor {
+  id: string;
+  name: string;
+  tipo: 'regional' | 'nacional' | 'importado' | null;
+  regiao_principal: string | null;
+  segmento_atuacao: string[];
+  notas_estrategicas: string | null;
+  created_by: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface KbCompetitorProduct {
+  id: string;
+  competitor_id: string;
+  product_name: string;
+  category: string | null;
+  rendimento_m2_por_litro: number | null;
+  solidos_pct: number | null;
+  pot_life_horas: number | null;
+  validade_dias: number | null;
+  preco_referencia_l: number | null;
+  preco_atualizado_em: string | null;
+  fonte_preco: 'vendedor' | 'cotacao' | 'site' | 'estimado' | 'detectado_ia' | null;
+  pontos_fortes: string[];
+  pontos_fracos: string[];
+  nosso_equivalente_product_code: string | null;
+  argumentos_comparativos: unknown;
+  created_by: string | null;
+  created_at: string;
+  updated_at: string;
+}
+```
+
+Commit: `feat(kb): types — KbProductSpec + KbCompetitor + KbCompetitorProduct`
+
+---
+
+## Task 3: Edge Function `kb-extract-specs`
+
+**Files:** Create `supabase/functions/kb-extract-specs/index.ts`
+
+Recebe `{ documentId }`, busca o document (deve ter `content_extracted`), monta prompt SYSTEM_PROMPT_EXTRACT_SPECS, chama Claude com `tool_choice: { type: 'tool', name: 'extract_product_specs' }`, retorna tool input + metadata (confidence, gaps).
+
+```ts
+import Anthropic from "npm:@anthropic-ai/sdk@^0.93.0";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import { authorizeCronOrStaff, corsHeaders } from "../_shared/auth.ts";
+
+const SYSTEM_PROMPT_EXTRACT_SPECS = `Você extrai specs técnicos estruturados de boletins técnicos de tintas industriais para a base de conhecimento da Colacor (distribuidora Sayerlack).
+
+# Regras gerais
+- Use APENAS dados explícitos no texto. NÃO invente, NÃO estime.
+- Quando o boletim dá um range (ex: "viscosidade 42 ± 3s CF6 a 25°C"), use o valor central (42).
+- Para campos que o boletim NÃO menciona, deixe null.
+- Liste em \`extraction_gaps\` os campos importantes que estão ausentes.
+- \`extraction_confidence\` = 0.9+ se boletim claro, 0.6-0.8 se ambíguo, <0.6 se faltam muitos dados-chave.
+
+# Cálculos derivados permitidos
+- \`rendimento_m2_por_litro\` = (densidade_g_cm3 × 1000) / gramatura_g_m2_media. Use gramatura média entre min/max se houver range. Se boletim não tem gramatura nem densidade, deixe null.
+
+# Classificação semântica (vc preenche baseado no texto)
+- \`product_line\`: 'wood_pu' | 'wood_nitro' | 'hydropoxi' | 'auto' — Wood PU pra poliuretanos pra madeira (mais comum em boletins moveleiros)
+- \`product_category\`: 'primer' | 'verniz' | 'tinta' | 'catalisador' | 'diluente' | 'massa' | 'selador'
+- \`diferenciais_chave\`: extrai as 2-5 frases-chave do "Uso Recomendado" e "Características"
+
+# Compliance
+- Se boletim menciona "isento de" e lista substâncias/metais, capture nos arrays
+- \`certificacoes_aplicaveis\`: capture menções de IKEA, LGA, Proposition 65, JIS, CARB, etc.
+
+SEMPRE use a tool extract_product_specs. NÃO responda em texto fora dela.`;
+
+const EXTRACT_TOOL = {
+  name: "extract_product_specs",
+  description: "Retorna specs estruturados do produto extraídos do boletim técnico.",
+  input_schema: {
+    type: "object",
+    properties: {
+      product_code: { type: "string" },
+      product_name: { type: "string" },
+      supplier: { type: "string" },
+      product_line: { type: ["string", "null"], enum: ["wood_pu", "wood_nitro", "hydropoxi", "auto", null] },
+      product_category: { type: ["string", "null"] },
+      densidade_g_cm3: { type: ["number", "null"] },
+      solidos_pct: { type: ["number", "null"] },
+      viscosidade_aplicacao_s: { type: ["number", "null"] },
+      viscosidade_copo: { type: ["string", "null"] },
+      brilho_ub: { type: ["number", "null"] },
+      dureza: { type: ["string", "null"] },
+      rendimento_m2_por_litro: { type: ["number", "null"] },
+      demaos_recomendadas: { type: ["integer", "null"] },
+      gramatura_g_m2_min: { type: ["integer", "null"] },
+      gramatura_g_m2_max: { type: ["integer", "null"] },
+      pot_life_horas: { type: ["number", "null"] },
+      temp_aplicacao_c_min: { type: ["number", "null"] },
+      temp_aplicacao_c_max: { type: ["number", "null"] },
+      umidade_aplicacao_pct_min: { type: ["number", "null"] },
+      umidade_aplicacao_pct_max: { type: ["number", "null"] },
+      catalisador_codigo: { type: ["string", "null"] },
+      catalisador_proporcao_pct: { type: ["number", "null"] },
+      diluente_codigo: { type: ["string", "null"] },
+      equipamentos_aplicacao: { type: "array", items: { type: "string" } },
+      lixa_recomendada: { type: ["string", "null"] },
+      substrato: { type: "array", items: { type: "string" } },
+      secagem_manuseio_h: { type: ["number", "null"] },
+      secagem_empilhamento_h: { type: ["number", "null"] },
+      secagem_total_h: { type: ["number", "null"] },
+      validade_dias: { type: ["integer", "null"] },
+      temp_armazenamento_c_min: { type: ["integer", "null"] },
+      temp_armazenamento_c_max: { type: ["integer", "null"] },
+      certificacoes_aplicaveis: { type: "array", items: { type: "string" } },
+      isento_metais_pesados: { type: "array", items: { type: "string" } },
+      isento_substancias: { type: "array", items: { type: "string" } },
+      diferenciais_chave: { type: "array", items: { type: "string" } },
+      uso_recomendado: { type: ["string", "null"] },
+      publico_alvo: { type: ["string", "null"] },
+      extraction_confidence: { type: "number", minimum: 0, maximum: 1 },
+      extraction_gaps: { type: "array", items: { type: "string" } },
+    },
+    required: [
+      "product_code",
+      "product_name",
+      "supplier",
+      "extraction_confidence",
+      "extraction_gaps",
+      "equipamentos_aplicacao",
+      "substrato",
+      "certificacoes_aplicaveis",
+      "isento_metais_pesados",
+      "isento_substancias",
+      "diferenciais_chave",
+    ],
+  },
+};
+
+Deno.serve(async (req) => {
+  if (req.method === "OPTIONS") return new Response(null, { headers: corsHeaders });
+
+  const auth = await authorizeCronOrStaff(req);
+  if (!auth.ok) return auth.response;
+
+  const apiKey = Deno.env.get("ANTHROPIC_API_KEY");
+  if (!apiKey) {
+    return new Response(JSON.stringify({ error: "ANTHROPIC_API_KEY not configured" }), {
+      status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+
+  const supabase = createClient(
+    Deno.env.get("SUPABASE_URL")!,
+    Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!,
+  );
+
+  let body;
+  try { body = await req.json(); } catch {
+    return new Response(JSON.stringify({ error: "Invalid JSON" }), {
+      status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+  if (!body.documentId) {
+    return new Response(JSON.stringify({ error: "documentId required" }), {
+      status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+
+  try {
+    const { data: doc, error } = await supabase
+      .from("kb_documents")
+      .select("id, title, product_code, supplier, content_extracted, status")
+      .eq("id", body.documentId)
+      .single();
+
+    if (error || !doc) {
+      return new Response(JSON.stringify({ error: "Document not found" }), {
+        status: 404, headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    if (doc.status !== "ready" || !doc.content_extracted) {
+      return new Response(JSON.stringify({ error: "Document not ready or has no extracted content" }), {
+        status: 422, headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    const client = new Anthropic({ apiKey });
+
+    const userMsg = `Extraia os specs estruturados deste boletim técnico:
+
+# Metadata
+- Título: ${doc.title}
+- Código produto (hint): ${doc.product_code ?? "(não informado)"}
+- Fornecedor: ${doc.supplier ?? "sayerlack"}
+
+# Texto extraído
+${doc.content_extracted.slice(0, 50_000)}
+
+Use a tool extract_product_specs.`;
+
+    const response = await client.messages.create({
+      model: "claude-sonnet-4-6",
+      max_tokens: 4000,
+      system: [{
+        type: "text",
+        text: SYSTEM_PROMPT_EXTRACT_SPECS,
+        cache_control: { type: "ephemeral" },
+      }],
+      tools: [EXTRACT_TOOL],
+      tool_choice: { type: "tool", name: "extract_product_specs" },
+      messages: [{ role: "user", content: userMsg }],
+    });
+
+    const toolUse = response.content.find((b) => b.type === "tool_use");
+    if (!toolUse || toolUse.type !== "tool_use") {
+      return new Response(JSON.stringify({ error: "No tool_use in response", raw: response }), {
+        status: 502, headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    return new Response(JSON.stringify({
+      specs: toolUse.input,
+      usage: {
+        inputTokens: response.usage.input_tokens,
+        outputTokens: response.usage.output_tokens,
+        cacheCreationTokens: response.usage.cache_creation_input_tokens ?? 0,
+        cacheReadTokens: response.usage.cache_read_input_tokens ?? 0,
+      },
+    }), { headers: { ...corsHeaders, "Content-Type": "application/json" } });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "unknown error";
+    console.error("[kb-extract-specs]", msg);
+    return new Response(JSON.stringify({ error: msg }), {
+      status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+});
+```
+
+Commit: `feat(kb): edge function kb-extract-specs (Claude Sonnet 4.6 tool use)`
+
+---
+
+## Task 4: Hook `useExtractSpecs` (mutation + TDD)
+
+`useExtractSpecs.mutate(documentId)` → invoca edge, retorna `KbExtractedSpec` (não salva).
+
+Tests: mocka `invokeFunction`, valida que chama com payload correto, retorna data.specs.
+
+Commit: `feat(kb): useExtractSpecs mutation`
+
+---
+
+## Task 5: Hook `useSaveProductSpecs` + `useKbProductSpecs`
+
+- `useSaveProductSpecs`: upsert em `kb_product_specs` (por product_code unique). Set `approved_by = current_user`, `approved_at = now()`.
+- `useKbProductSpecs(productCode?)`: query buscando por product_code, retorna `KbProductSpec | null`.
+
+Commit: `feat(kb): useSaveProductSpecs + useKbProductSpecs hooks`
+
+---
+
+## Task 6: Componente `KbSpecsForm`
+
+Form RHF + Zod com TODOS os campos de `KbExtractedSpec`. Aceita `initialValues` (proposta do Claude). `onSubmit` chama `useSaveProductSpecs`.
+
+Visualmente agrupa em fieldsets: Identificação, Físico-químico, Aplicação, Compatibilidade, Secagem, Armazenamento, Compliance, Notas.
+
+Sub-componente `KbSpecField` (label + input + hint quando vier null/gap).
+
+Commit: `feat(kb): KbSpecsForm — revisar e aprovar specs propostos por Claude`
+
+---
+
+## Task 7: `KbSpecsExtractButton` + wire em `AdminKnowledgeBaseDetail`
+
+`KbSpecsExtractButton`: botão "Extrair specs com IA" → useExtractSpecs.mutate → abre Dialog com KbSpecsForm preenchido → user revisa → submit salva.
+
+No `AdminKnowledgeBaseDetail`, quando `status === 'ready'`:
+- Mostra section "Specs estruturados"
+- Se `useKbProductSpecs(doc.product_code).data` existe → mostra preview com `<KbSpecsPreview />` + botão "Editar"
+- Se não existe → mostra `<KbSpecsExtractButton />`
+
+Commit: `feat(kb): wire spec extraction in AdminKnowledgeBaseDetail`
+
+---
+
+## Task 8: QA + PR
+
+- vitest: espera ~+3 (useExtractSpecs)
+- tsc clean
+- build passa
+- Push + PR
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Extração automática via Claude → Task 3
+- UI de revisão e aprovação → Tasks 6, 7
+- Schema pra concorrentes (sem hardcode) → Task 1
+- Persistência aprovada → Task 5
+
+**Riscos:**
+- Schema de `kb_product_specs` tem ~45 campos. Form vai ficar grande mas é necessário (cada campo é dado real do boletim).
+- Claude pode "alucinar" campos quando boletim é vago — `extraction_gaps` mitigação parcial; user revisa.
+- Preço de chamada Claude com 50k chars de input: ~$0.05-0.15. Aceitável (rodado 1x por documento, depois cache).

--- a/docs/superpowers/plans/2026-05-17-pr6c-rendimento-calculator.md
+++ b/docs/superpowers/plans/2026-05-17-pr6c-rendimento-calculator.md
@@ -1,0 +1,333 @@
+# PR6c — Calculadora de Rendimento Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development.
+
+**Goal:** Calculadora standalone que vendedor abre antes/durante chamada pra calcular consumo (L) + estimativa de ticket baseado em `kb_product_specs` (extraídos no PR6b). Vendedor seleciona produto + informa área em m² → vê cálculo passo-a-passo. Página `/admin/calculadora` + botão no sidebar. **Integração ao vivo no painel de chamada fica pra PR6c.5** (precisa hook que escuta entitiesExtracted da transcrição — mais complexo, pode ir depois).
+
+**Architecture:**
+- Helper puro `calculate-rendimento.ts` (TDD): recebe specs + área + demãos override → retorna `{ litros, demãos, gramaturaMedia, calculoPasso }`
+- Hook `useKbProductSpecsList` — lista de specs aprovados pra select
+- Componente `RendimentoCalculator` — UI standalone
+- Página `/admin/calculadora` + rota + menu
+
+**Não-objetivos:**
+- Auto-detect de volume na transcrição da chamada (PR6c.5)
+- Preço real do produto (precisa de Omie sync — PR10). Por enquanto, placeholder de "ticket bruto" só com volume L
+- Comparativo com concorrente (PR8)
+- Histórico de cálculos salvos
+
+---
+
+## Tasks
+
+### Task 1: Helper `calculate-rendimento` (TDD)
+
+**Files:**
+- `src/lib/knowledge-base/calculate-rendimento.ts`
+- `src/lib/knowledge-base/calculate-rendimento.test.ts`
+
+```ts
+// calculate-rendimento.ts
+import type { KbProductSpec } from './specs-types';
+
+export interface RendimentoCalculation {
+  /** Área total a ser pintada (m²) */
+  areaM2: number;
+  /** Demãos aplicadas (override ou default do spec) */
+  demaos: number;
+  /** Rendimento usado (m²/L do spec ou recalculado pela gramatura) */
+  rendimentoM2PorLitro: number;
+  /** Litros necessários */
+  litrosNecessarios: number;
+  /** Memória de cálculo pra UI */
+  calculo: string;
+  /** Avisos se faltam dados pro cálculo */
+  warnings: string[];
+}
+
+export interface CalculateInput {
+  spec: Pick<KbProductSpec, 'rendimento_m2_por_litro' | 'densidade_g_cm3' | 'gramatura_g_m2_min' | 'gramatura_g_m2_max' | 'demaos_recomendadas' | 'product_name'>;
+  areaM2: number;
+  demaosOverride?: number;
+}
+
+/**
+ * Calcula litros necessários considerando rendimento + demãos.
+ * Se spec não tem rendimento explícito mas tem densidade + gramatura, deriva.
+ * Retorna warnings quando faltam dados ou cálculo é aproximação.
+ */
+export function calculateRendimento(input: CalculateInput): RendimentoCalculation {
+  const warnings: string[] = [];
+  const demaos = input.demaosOverride ?? input.spec.demaos_recomendadas ?? 1;
+
+  if (input.demaosOverride === undefined && !input.spec.demaos_recomendadas) {
+    warnings.push('Demãos não informadas no boletim — assumindo 1.');
+  }
+
+  let rendimento = input.spec.rendimento_m2_por_litro;
+  let calculo = '';
+
+  if (rendimento != null && rendimento > 0) {
+    calculo = `Rendimento do boletim: ${rendimento} m²/L`;
+  } else if (input.spec.densidade_g_cm3 && (input.spec.gramatura_g_m2_min || input.spec.gramatura_g_m2_max)) {
+    const min = input.spec.gramatura_g_m2_min ?? input.spec.gramatura_g_m2_max ?? 0;
+    const max = input.spec.gramatura_g_m2_max ?? input.spec.gramatura_g_m2_min ?? 0;
+    const gramaturaMedia = (min + max) / 2;
+    const densidadeGPorL = input.spec.densidade_g_cm3 * 1000;
+    rendimento = gramaturaMedia > 0 ? densidadeGPorL / gramaturaMedia : 0;
+    calculo = `Derivado: densidade ${input.spec.densidade_g_cm3} g/cm³ × 1000 ÷ gramatura média ${gramaturaMedia} g/m² = ${rendimento.toFixed(1)} m²/L`;
+    warnings.push('Rendimento derivado da densidade + gramatura (boletim não informa explicitamente).');
+  } else {
+    warnings.push('Spec sem rendimento, densidade ou gramatura — cálculo impossível.');
+    return {
+      areaM2: input.areaM2,
+      demaos,
+      rendimentoM2PorLitro: 0,
+      litrosNecessarios: 0,
+      calculo: 'Dados insuficientes',
+      warnings,
+    };
+  }
+
+  if (rendimento <= 0) {
+    warnings.push('Rendimento calculado é zero ou negativo.');
+    return {
+      areaM2: input.areaM2,
+      demaos,
+      rendimentoM2PorLitro: 0,
+      litrosNecessarios: 0,
+      calculo,
+      warnings,
+    };
+  }
+
+  const litros = (input.areaM2 / rendimento) * demaos;
+
+  return {
+    areaM2: input.areaM2,
+    demaos,
+    rendimentoM2PorLitro: rendimento,
+    litrosNecessarios: litros,
+    calculo,
+    warnings,
+  };
+}
+```
+
+**Testes** (6 mínimos):
+1. Spec com rendimento explícito → usa direto
+2. Spec sem rendimento mas com densidade + gramatura → deriva
+3. Spec sem nada → warning + litros=0
+4. Demãos override sobrescreve default
+5. Sem demãos no spec nem override → assume 1 + warning
+6. Cálculo final: 80m² × 2 demãos ÷ 8 m²/L = 20L
+
+Commit: `feat(kb): calculateRendimento — pure helper com derivação automática de densidade+gramatura`
+
+---
+
+### Task 2: Hook `useKbProductSpecsList`
+
+**File:** `src/hooks/useKbProductSpecsList.ts`
+
+Lista de todos os specs aprovados (status filtro: approved_by IS NOT NULL).
+
+```ts
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import type { KbProductSpec } from '@/lib/knowledge-base/specs-types';
+
+export function useKbProductSpecsList() {
+  return useQuery({
+    queryKey: ['kb-product-specs-list'],
+    staleTime: 60_000,
+    queryFn: async (): Promise<KbProductSpec[]> => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const { data, error } = await (supabase.from('kb_product_specs') as any)
+        .select('*')
+        .not('approved_at', 'is', null)
+        .order('product_name', { ascending: true })
+        .limit(500);
+      if (error) throw error;
+      return (data ?? []) as KbProductSpec[];
+    },
+  });
+}
+```
+
+Commit: `feat(kb): useKbProductSpecsList hook (specs aprovados pra select)`
+
+---
+
+### Task 3: Componente `RendimentoCalculator`
+
+**File:** `src/components/knowledge-base/RendimentoCalculator.tsx`
+
+Form simples:
+- Select produto (specs aprovados)
+- Input área (m²) com validação > 0
+- Input demãos (override, opcional — pré-preenchido com spec.demaos_recomendadas)
+- Output card com cálculo + memória + warnings
+
+```tsx
+import { useState, useMemo } from 'react';
+import { Card } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Badge } from '@/components/ui/badge';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Calculator, AlertTriangle, Loader2 } from 'lucide-react';
+import { useKbProductSpecsList } from '@/hooks/useKbProductSpecsList';
+import { calculateRendimento } from '@/lib/knowledge-base/calculate-rendimento';
+
+export function RendimentoCalculator() {
+  const { data: specs, isLoading } = useKbProductSpecsList();
+  const [productCode, setProductCode] = useState<string>('');
+  const [areaM2, setAreaM2] = useState<string>('');
+  const [demaosOverride, setDemaosOverride] = useState<string>('');
+
+  const selectedSpec = specs?.find((s) => s.product_code === productCode);
+  const area = parseFloat(areaM2) || 0;
+  const demaos = demaosOverride ? parseInt(demaosOverride, 10) : undefined;
+
+  const result = useMemo(() => {
+    if (!selectedSpec || area <= 0) return null;
+    return calculateRendimento({ spec: selectedSpec, areaM2: area, demaosOverride: demaos });
+  }, [selectedSpec, area, demaos]);
+
+  return (
+    <Card className="p-4 space-y-4">
+      <div className="flex items-center gap-2">
+        <Calculator className="w-4 h-4 text-status-warning" />
+        <h2 className="text-sm font-semibold">Calculadora de rendimento</h2>
+      </div>
+
+      <div className="space-y-3">
+        <div>
+          <Label htmlFor="product" className="text-xs">Produto</Label>
+          {isLoading ? (
+            <div className="flex items-center gap-2 text-xs text-muted-foreground py-2">
+              <Loader2 className="w-3 h-3 animate-spin" />
+              Carregando produtos…
+            </div>
+          ) : !specs || specs.length === 0 ? (
+            <div className="text-xs text-muted-foreground py-2">
+              Nenhum spec aprovado ainda. Suba boletins em /admin/knowledge-base e extraia os specs primeiro.
+            </div>
+          ) : (
+            <Select value={productCode} onValueChange={setProductCode}>
+              <SelectTrigger><SelectValue placeholder="Escolha o produto" /></SelectTrigger>
+              <SelectContent>
+                {specs.map((s) => (
+                  <SelectItem key={s.product_code} value={s.product_code}>
+                    {s.product_name} <span className="text-muted-foreground">({s.product_code})</span>
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          )}
+        </div>
+
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <Label htmlFor="area" className="text-xs">Área a pintar (m²)</Label>
+            <Input id="area" type="number" min="0" step="any" value={areaM2} onChange={(e) => setAreaM2(e.target.value)} />
+          </div>
+          <div>
+            <Label htmlFor="demaos" className="text-xs">
+              Demãos {selectedSpec?.demaos_recomendadas && <span className="text-muted-foreground">(default: {selectedSpec.demaos_recomendadas})</span>}
+            </Label>
+            <Input id="demaos" type="number" min="1" placeholder={String(selectedSpec?.demaos_recomendadas ?? 1)} value={demaosOverride} onChange={(e) => setDemaosOverride(e.target.value)} />
+          </div>
+        </div>
+      </div>
+
+      {result && (
+        <Card className="p-3 border-status-success bg-status-success-bg/30 space-y-2">
+          <div className="flex items-baseline justify-between">
+            <span className="text-xs text-muted-foreground">Consumo estimado</span>
+            <span className="text-2xl font-semibold tabular-nums text-status-success">{result.litrosNecessarios.toFixed(1)} L</span>
+          </div>
+          <div className="text-2xs text-muted-foreground space-y-0.5">
+            <div>Área: {result.areaM2} m² · Demãos: {result.demaos} · Rendimento: {result.rendimentoM2PorLitro.toFixed(1)} m²/L</div>
+            <div className="font-mono text-[10px]">{result.calculo}</div>
+            <div className="font-mono text-[10px]">{result.areaM2} ÷ {result.rendimentoM2PorLitro.toFixed(1)} × {result.demaos} = {result.litrosNecessarios.toFixed(1)} L</div>
+          </div>
+          {result.warnings.length > 0 && (
+            <div className="space-y-1 pt-2 border-t border-status-success/20">
+              {result.warnings.map((w, i) => (
+                <div key={i} className="flex items-start gap-1.5 text-2xs text-status-warning">
+                  <AlertTriangle className="w-2.5 h-2.5 mt-0.5 shrink-0" />
+                  {w}
+                </div>
+              ))}
+            </div>
+          )}
+          {selectedSpec && (
+            <div className="flex flex-wrap gap-1 pt-2 border-t border-status-success/20">
+              {selectedSpec.catalisador_codigo && <Badge variant="outline" className="text-[10px]">+ catalisador {selectedSpec.catalisador_codigo}{selectedSpec.catalisador_proporcao_pct && ` (${selectedSpec.catalisador_proporcao_pct}%)`}</Badge>}
+              {selectedSpec.diluente_codigo && <Badge variant="outline" className="text-[10px]">+ diluente {selectedSpec.diluente_codigo}</Badge>}
+              {selectedSpec.pot_life_horas && <Badge variant="outline" className="text-[10px]">pot life {selectedSpec.pot_life_horas}h</Badge>}
+            </div>
+          )}
+        </Card>
+      )}
+    </Card>
+  );
+}
+```
+
+Commit: `feat(kb): RendimentoCalculator component standalone`
+
+---
+
+### Task 4: Página + rota + menu
+
+**Files:**
+- `src/pages/AdminCalculadora.tsx` (default export)
+- `src/App.tsx` — lazy + rota `/admin/calculadora`
+- `src/components/AppShell.tsx` — item de menu na seção Gestão (icon `Calculator`)
+
+```tsx
+// AdminCalculadora.tsx
+import { RendimentoCalculator } from '@/components/knowledge-base/RendimentoCalculator';
+
+export default function AdminCalculadora() {
+  return (
+    <div className="container mx-auto p-4 space-y-3 max-w-2xl">
+      <div>
+        <h1 className="text-xl font-semibold">Calculadora de rendimento</h1>
+        <p className="text-xs text-muted-foreground">
+          Calcula consumo de tinta baseado em área a pintar + boletim técnico aprovado.
+        </p>
+      </div>
+      <RendimentoCalculator />
+    </div>
+  );
+}
+```
+
+Commit: `feat(kb): AdminCalculadora page + route + menu item`
+
+---
+
+### Task 5: QA + PR
+
+- tsc clean
+- tests passing (+6 do calculate-rendimento)
+- build passes
+- Push + PR stacked sobre PR6a (base = `claude/pr6a-knowledge-base-foundation`) OU stacked sobre PR6b (`claude/pr6b-kb-extract-specs` — mais correto porque depende dos types KbProductSpec)
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Cálculo automático com fallback de densidade+gramatura → Task 1
+- Select de produtos aprovados → Task 2
+- UI standalone → Task 3
+- Acessível via menu → Task 4
+
+**Riscos:**
+- Specs aprovados ainda zero — empty state vai aparecer sempre até user aprovar specs via PR6b. Documentado.
+- Sem preço (sem Omie sync) — não mostra ticket R$. Mostra só litros. PR10 traz preço.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -151,6 +151,7 @@ const AdminPortalSayerlack = lazy(() => import("./pages/AdminPortalSayerlack"));
 const AdminVendorSipCredentials = lazy(() => import("./pages/AdminVendorSipCredentials"));
 const AdminKnowledgeBase = lazy(() => import("./pages/AdminKnowledgeBase"));
 const AdminKnowledgeBaseDetail = lazy(() => import("./pages/AdminKnowledgeBaseDetail"));
+const AdminCalculadora = lazy(() => import("./pages/AdminCalculadora"));
 
 const PageLoader = () => <PageSkeleton variant="auto" />;
 
@@ -325,6 +326,7 @@ const App = () => (
               <Route path="admin/sip-credentials" element={<AdminVendorSipCredentials />} />
               <Route path="admin/knowledge-base" element={<AdminKnowledgeBase />} />
               <Route path="admin/knowledge-base/:id" element={<AdminKnowledgeBaseDetail />} />
+              <Route path="admin/calculadora" element={<AdminCalculadora />} />
             </Route>
 
             <Route path="*" element={<NotFound />} />

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -138,6 +138,7 @@ const unifiedNavSections: { title: string; items: NavItem[] }[] = [
       { icon: UserCheck, label: 'Liberar Acessos', path: '/admin/approvals', managerOnly: true },
       { icon: Users, label: 'Departamentos', path: '/admin/departments', managerOnly: true },
       { icon: Library, label: 'Base de conhecimento', path: '/admin/knowledge-base', managerOnly: true },
+      { icon: Calculator, label: 'Calculadora de rendimento', path: '/admin/calculadora' },
       { icon: Shield, label: 'Admin & Relatórios', path: '/gestao/admin', managerOnly: true },
       { icon: Lock, label: 'Governança', path: '/gestao/governanca', managerOnly: true },
     ],

--- a/src/components/knowledge-base/KbSpecsExtractButton.tsx
+++ b/src/components/knowledge-base/KbSpecsExtractButton.tsx
@@ -1,0 +1,84 @@
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog';
+import { useExtractSpecs } from '@/hooks/useExtractSpecs';
+import { KbSpecsForm } from './KbSpecsForm';
+import { Sparkles, Loader2 } from 'lucide-react';
+import type { KbExtractedSpec } from '@/lib/knowledge-base/specs-types';
+
+interface Props {
+  documentId: string;
+  documentTitle: string;
+  productCode?: string | null;
+  onSaved?: () => void;
+}
+
+/**
+ * Botão "Extrair specs com IA" → invoca Claude → abre Dialog com KbSpecsForm
+ * pré-preenchido pra admin revisar e aprovar.
+ */
+export function KbSpecsExtractButton({ documentId, documentTitle, productCode, onSaved }: Props) {
+  const [open, setOpen] = useState(false);
+  const [extracted, setExtracted] = useState<KbExtractedSpec | null>(null);
+  const extract = useExtractSpecs();
+
+  const handleExtract = () => {
+    extract.mutate(documentId, {
+      onSuccess: (data) => {
+        setExtracted(data.specs);
+        setOpen(true);
+      },
+    });
+  };
+
+  const handleSaved = () => {
+    setOpen(false);
+    setExtracted(null);
+    onSaved?.();
+  };
+
+  return (
+    <>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={handleExtract}
+        disabled={extract.isPending}
+        className="gap-1.5"
+      >
+        {extract.isPending ? (
+          <>
+            <Loader2 className="w-3.5 h-3.5 animate-spin" />
+            Extraindo…
+          </>
+        ) : (
+          <>
+            <Sparkles className="w-3.5 h-3.5" />
+            Extrair specs com IA
+          </>
+        )}
+      </Button>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="max-w-3xl max-h-[90vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>Revisar specs extraídos</DialogTitle>
+            <DialogDescription>
+              Claude analisou <strong>{documentTitle}</strong>
+              {productCode && <> ({productCode})</>} e propôs os valores abaixo. Revise antes de aprovar — campos com confiança baixa ou faltantes estão sinalizados.
+            </DialogDescription>
+          </DialogHeader>
+
+          {extracted && (
+            <KbSpecsForm
+              initialValues={extracted}
+              documentId={documentId}
+              onSaved={handleSaved}
+            />
+          )}
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/components/knowledge-base/KbSpecsForm.tsx
+++ b/src/components/knowledge-base/KbSpecsForm.tsx
@@ -1,0 +1,392 @@
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { Card } from '@/components/ui/card';
+import { Loader2, Save, AlertTriangle } from 'lucide-react';
+import { useSaveProductSpecs } from '@/hooks/useSaveProductSpecs';
+import type { KbExtractedSpec } from '@/lib/knowledge-base/specs-types';
+
+const nullableNumber = z
+  .preprocess((v) => {
+    if (v === '' || v === null || v === undefined) return null;
+    const n = typeof v === 'number' ? v : Number(v);
+    return Number.isFinite(n) ? n : null;
+  }, z.number().nullable());
+
+const nullableInt = z
+  .preprocess((v) => {
+    if (v === '' || v === null || v === undefined) return null;
+    const n = typeof v === 'number' ? v : Number(v);
+    return Number.isFinite(n) ? Math.trunc(n) : null;
+  }, z.number().int().nullable());
+
+const nullableString = z
+  .preprocess((v) => {
+    if (v === null || v === undefined) return null;
+    const s = String(v).trim();
+    return s === '' ? null : s;
+  }, z.string().nullable());
+
+const schema = z.object({
+  product_code: z.string().min(1, 'Obrigatório'),
+  product_name: z.string().min(1, 'Obrigatório'),
+  supplier: z.string().min(1, 'Obrigatório'),
+  product_line: nullableString,
+  product_category: nullableString,
+  densidade_g_cm3: nullableNumber,
+  solidos_pct: nullableNumber,
+  viscosidade_aplicacao_s: nullableNumber,
+  viscosidade_copo: nullableString,
+  brilho_ub: nullableNumber,
+  dureza: nullableString,
+  rendimento_m2_por_litro: nullableNumber,
+  demaos_recomendadas: nullableInt,
+  gramatura_g_m2_min: nullableInt,
+  gramatura_g_m2_max: nullableInt,
+  pot_life_horas: nullableNumber,
+  temp_aplicacao_c_min: nullableNumber,
+  temp_aplicacao_c_max: nullableNumber,
+  umidade_aplicacao_pct_min: nullableNumber,
+  umidade_aplicacao_pct_max: nullableNumber,
+  catalisador_codigo: nullableString,
+  catalisador_proporcao_pct: nullableNumber,
+  diluente_codigo: nullableString,
+  equipamentos_aplicacao: z.string().default(''),
+  lixa_recomendada: nullableString,
+  substrato: z.string().default(''),
+  secagem_manuseio_h: nullableNumber,
+  secagem_empilhamento_h: nullableNumber,
+  secagem_total_h: nullableNumber,
+  validade_dias: nullableInt,
+  temp_armazenamento_c_min: nullableInt,
+  temp_armazenamento_c_max: nullableInt,
+  certificacoes_aplicaveis: z.string().default(''),
+  isento_metais_pesados: z.string().default(''),
+  isento_substancias: z.string().default(''),
+  diferenciais_chave: z.string().default(''),
+  uso_recomendado: nullableString,
+  publico_alvo: nullableString,
+  extraction_confidence: nullableNumber,
+});
+
+type FormValues = z.infer<typeof schema>;
+
+interface Props {
+  initialValues: KbExtractedSpec;
+  documentId?: string;
+  onSaved?: () => void;
+}
+
+function splitTags(s: string | undefined | null): string[] {
+  if (!s) return [];
+  return s
+    .split(',')
+    .map((t) => t.trim())
+    .filter(Boolean);
+}
+
+function joinTags(arr: string[] | undefined | null): string {
+  return (arr ?? []).join(', ');
+}
+
+export function KbSpecsForm({ initialValues, documentId, onSaved }: Props) {
+  const save = useSaveProductSpecs();
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<FormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: {
+      product_code: initialValues.product_code ?? '',
+      product_name: initialValues.product_name ?? '',
+      supplier: initialValues.supplier ?? '',
+      product_line: initialValues.product_line,
+      product_category: initialValues.product_category,
+      densidade_g_cm3: initialValues.densidade_g_cm3,
+      solidos_pct: initialValues.solidos_pct,
+      viscosidade_aplicacao_s: initialValues.viscosidade_aplicacao_s,
+      viscosidade_copo: initialValues.viscosidade_copo,
+      brilho_ub: initialValues.brilho_ub,
+      dureza: initialValues.dureza,
+      rendimento_m2_por_litro: initialValues.rendimento_m2_por_litro,
+      demaos_recomendadas: initialValues.demaos_recomendadas,
+      gramatura_g_m2_min: initialValues.gramatura_g_m2_min,
+      gramatura_g_m2_max: initialValues.gramatura_g_m2_max,
+      pot_life_horas: initialValues.pot_life_horas,
+      temp_aplicacao_c_min: initialValues.temp_aplicacao_c_min,
+      temp_aplicacao_c_max: initialValues.temp_aplicacao_c_max,
+      umidade_aplicacao_pct_min: initialValues.umidade_aplicacao_pct_min,
+      umidade_aplicacao_pct_max: initialValues.umidade_aplicacao_pct_max,
+      catalisador_codigo: initialValues.catalisador_codigo,
+      catalisador_proporcao_pct: initialValues.catalisador_proporcao_pct,
+      diluente_codigo: initialValues.diluente_codigo,
+      equipamentos_aplicacao: joinTags(initialValues.equipamentos_aplicacao),
+      lixa_recomendada: initialValues.lixa_recomendada,
+      substrato: joinTags(initialValues.substrato),
+      secagem_manuseio_h: initialValues.secagem_manuseio_h,
+      secagem_empilhamento_h: initialValues.secagem_empilhamento_h,
+      secagem_total_h: initialValues.secagem_total_h,
+      validade_dias: initialValues.validade_dias,
+      temp_armazenamento_c_min: initialValues.temp_armazenamento_c_min,
+      temp_armazenamento_c_max: initialValues.temp_armazenamento_c_max,
+      certificacoes_aplicaveis: joinTags(initialValues.certificacoes_aplicaveis),
+      isento_metais_pesados: joinTags(initialValues.isento_metais_pesados),
+      isento_substancias: joinTags(initialValues.isento_substancias),
+      diferenciais_chave: joinTags(initialValues.diferenciais_chave),
+      uso_recomendado: initialValues.uso_recomendado,
+      publico_alvo: initialValues.publico_alvo,
+      extraction_confidence: initialValues.extraction_confidence,
+    },
+  });
+
+  const onSubmit = (values: FormValues) => {
+    const specs: KbExtractedSpec = {
+      product_code: values.product_code,
+      product_name: values.product_name,
+      supplier: values.supplier,
+      product_line: values.product_line,
+      product_category: values.product_category,
+      densidade_g_cm3: values.densidade_g_cm3,
+      solidos_pct: values.solidos_pct,
+      viscosidade_aplicacao_s: values.viscosidade_aplicacao_s,
+      viscosidade_copo: values.viscosidade_copo,
+      brilho_ub: values.brilho_ub,
+      dureza: values.dureza,
+      rendimento_m2_por_litro: values.rendimento_m2_por_litro,
+      demaos_recomendadas: values.demaos_recomendadas,
+      gramatura_g_m2_min: values.gramatura_g_m2_min,
+      gramatura_g_m2_max: values.gramatura_g_m2_max,
+      pot_life_horas: values.pot_life_horas,
+      temp_aplicacao_c_min: values.temp_aplicacao_c_min,
+      temp_aplicacao_c_max: values.temp_aplicacao_c_max,
+      umidade_aplicacao_pct_min: values.umidade_aplicacao_pct_min,
+      umidade_aplicacao_pct_max: values.umidade_aplicacao_pct_max,
+      catalisador_codigo: values.catalisador_codigo,
+      catalisador_proporcao_pct: values.catalisador_proporcao_pct,
+      diluente_codigo: values.diluente_codigo,
+      equipamentos_aplicacao: splitTags(values.equipamentos_aplicacao),
+      lixa_recomendada: values.lixa_recomendada,
+      substrato: splitTags(values.substrato),
+      secagem_manuseio_h: values.secagem_manuseio_h,
+      secagem_empilhamento_h: values.secagem_empilhamento_h,
+      secagem_total_h: values.secagem_total_h,
+      validade_dias: values.validade_dias,
+      temp_armazenamento_c_min: values.temp_armazenamento_c_min,
+      temp_armazenamento_c_max: values.temp_armazenamento_c_max,
+      certificacoes_aplicaveis: splitTags(values.certificacoes_aplicaveis),
+      isento_metais_pesados: splitTags(values.isento_metais_pesados),
+      isento_substancias: splitTags(values.isento_substancias),
+      diferenciais_chave: splitTags(values.diferenciais_chave),
+      uso_recomendado: values.uso_recomendado,
+      publico_alvo: values.publico_alvo,
+      extraction_confidence: values.extraction_confidence,
+      extraction_gaps: initialValues.extraction_gaps,
+    };
+    save.mutate(
+      { specs, documentId },
+      { onSuccess: () => onSaved?.() },
+    );
+  };
+
+  const Field = ({
+    name,
+    label,
+    type = 'text',
+    placeholder,
+  }: {
+    name: keyof FormValues;
+    label: string;
+    type?: string;
+    placeholder?: string;
+  }) => (
+    <div>
+      <Label htmlFor={name as string} className="text-xs">
+        {label}
+      </Label>
+      <Input
+        id={name as string}
+        type={type}
+        step={type === 'number' ? 'any' : undefined}
+        placeholder={placeholder}
+        {...register(name)}
+        className="text-xs h-8"
+      />
+      {errors[name] && (
+        <div className="text-[10px] text-status-error mt-0.5">
+          {String(errors[name]?.message ?? 'inválido')}
+        </div>
+      )}
+    </div>
+  );
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+      {initialValues.extraction_gaps.length > 0 && (
+        <Card className="p-2.5 bg-status-warning-bg border-status-warning">
+          <div className="flex items-center gap-1.5 text-xs text-status-warning">
+            <AlertTriangle className="w-3.5 h-3.5" />
+            <span>
+              Claude não conseguiu extrair: {initialValues.extraction_gaps.join(', ')}
+            </span>
+          </div>
+        </Card>
+      )}
+
+      <fieldset className="space-y-2">
+        <legend className="text-[10px] uppercase tracking-wide text-muted-foreground font-medium">
+          Identificação
+        </legend>
+        <div className="grid grid-cols-2 gap-2">
+          <Field name="product_code" label="Código *" />
+          <Field name="supplier" label="Fornecedor *" />
+        </div>
+        <Field name="product_name" label="Nome *" />
+        <div className="grid grid-cols-2 gap-2">
+          <Field name="product_line" label="Linha" placeholder="wood_pu, wood_nitro…" />
+          <Field
+            name="product_category"
+            label="Categoria"
+            placeholder="primer, verniz, tinta…"
+          />
+        </div>
+      </fieldset>
+
+      <fieldset className="space-y-2">
+        <legend className="text-[10px] uppercase tracking-wide text-muted-foreground font-medium">
+          Físico-químico
+        </legend>
+        <div className="grid grid-cols-2 gap-2">
+          <Field name="densidade_g_cm3" label="Densidade (g/cm³)" type="number" />
+          <Field name="solidos_pct" label="Sólidos (%)" type="number" />
+          <Field
+            name="viscosidade_aplicacao_s"
+            label="Viscosidade aplic. (s)"
+            type="number"
+          />
+          <Field name="viscosidade_copo" label="Copo (CF4/CF6/CF8)" />
+          <Field name="brilho_ub" label="Brilho (UB)" type="number" />
+          <Field name="dureza" label="Dureza (ex: 3H)" />
+        </div>
+      </fieldset>
+
+      <fieldset className="space-y-2">
+        <legend className="text-[10px] uppercase tracking-wide text-muted-foreground font-medium">
+          Aplicação
+        </legend>
+        <div className="grid grid-cols-2 gap-2">
+          <Field name="rendimento_m2_por_litro" label="Rendimento (m²/L)" type="number" />
+          <Field name="demaos_recomendadas" label="Demãos" type="number" />
+          <Field name="gramatura_g_m2_min" label="Gramatura min (g/m²)" type="number" />
+          <Field name="gramatura_g_m2_max" label="Gramatura max (g/m²)" type="number" />
+          <Field name="pot_life_horas" label="Pot life (h)" type="number" />
+          <Field name="temp_aplicacao_c_min" label="Temp min (°C)" type="number" />
+          <Field name="temp_aplicacao_c_max" label="Temp max (°C)" type="number" />
+          <Field name="umidade_aplicacao_pct_min" label="Umidade min (%)" type="number" />
+          <Field name="umidade_aplicacao_pct_max" label="Umidade max (%)" type="number" />
+        </div>
+      </fieldset>
+
+      <fieldset className="space-y-2">
+        <legend className="text-[10px] uppercase tracking-wide text-muted-foreground font-medium">
+          Compatibilidade
+        </legend>
+        <div className="grid grid-cols-2 gap-2">
+          <Field name="catalisador_codigo" label="Catalisador (código)" />
+          <Field
+            name="catalisador_proporcao_pct"
+            label="Catalisador (%)"
+            type="number"
+          />
+          <Field name="diluente_codigo" label="Diluente (código)" />
+          <Field name="lixa_recomendada" label="Lixa" />
+        </div>
+        <Field
+          name="equipamentos_aplicacao"
+          label="Equipamentos (vírgula)"
+          placeholder="pistola_convencional, tanque_pressao"
+        />
+        <Field name="substrato" label="Substrato (vírgula)" placeholder="madeira, mdf" />
+      </fieldset>
+
+      <fieldset className="space-y-2">
+        <legend className="text-[10px] uppercase tracking-wide text-muted-foreground font-medium">
+          Secagem & Armazenamento
+        </legend>
+        <div className="grid grid-cols-3 gap-2">
+          <Field name="secagem_manuseio_h" label="Manuseio (h)" type="number" />
+          <Field name="secagem_empilhamento_h" label="Empilhamento (h)" type="number" />
+          <Field name="secagem_total_h" label="Total (h)" type="number" />
+        </div>
+        <div className="grid grid-cols-3 gap-2">
+          <Field name="validade_dias" label="Validade (dias)" type="number" />
+          <Field name="temp_armazenamento_c_min" label="Temp armaz. min" type="number" />
+          <Field name="temp_armazenamento_c_max" label="Temp armaz. max" type="number" />
+        </div>
+      </fieldset>
+
+      <fieldset className="space-y-2">
+        <legend className="text-[10px] uppercase tracking-wide text-muted-foreground font-medium">
+          Compliance
+        </legend>
+        <Field
+          name="certificacoes_aplicaveis"
+          label="Certificações (vírgula)"
+          placeholder="IKEA, LGA, Proposition_65"
+        />
+        <Field
+          name="isento_metais_pesados"
+          label="Isento metais pesados (vírgula)"
+          placeholder="Cd, Pb, Hg"
+        />
+        <Field
+          name="isento_substancias"
+          label="Isento substâncias (vírgula)"
+          placeholder="amianto, formaldeido"
+        />
+      </fieldset>
+
+      <fieldset className="space-y-2">
+        <legend className="text-[10px] uppercase tracking-wide text-muted-foreground font-medium">
+          Notas qualitativas
+        </legend>
+        <Field
+          name="diferenciais_chave"
+          label="Diferenciais (vírgula)"
+          placeholder="resistencia_risco_superior, toque_sedoso"
+        />
+        <div>
+          <Label htmlFor="uso_recomendado" className="text-xs">
+            Uso recomendado
+          </Label>
+          <Textarea
+            id="uso_recomendado"
+            {...register('uso_recomendado')}
+            className="text-xs min-h-[60px]"
+          />
+        </div>
+        <Field name="publico_alvo" label="Público alvo" />
+      </fieldset>
+
+      <div className="flex items-center justify-between pt-2 border-t border-border">
+        <div className="text-[10px] text-muted-foreground">
+          Confiança da extração:{' '}
+          {Math.round((initialValues.extraction_confidence ?? 0) * 100)}%
+        </div>
+        <Button type="submit" disabled={save.isPending} size="sm">
+          {save.isPending ? (
+            <Loader2 className="w-3.5 h-3.5 animate-spin mr-2" />
+          ) : (
+            <Save className="w-3.5 h-3.5 mr-2" />
+          )}
+          Aprovar e salvar
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/src/components/knowledge-base/RendimentoCalculator.tsx
+++ b/src/components/knowledge-base/RendimentoCalculator.tsx
@@ -1,0 +1,167 @@
+import { useState, useMemo } from 'react';
+import { Card } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Badge } from '@/components/ui/badge';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Calculator, AlertTriangle, Loader2 } from 'lucide-react';
+import { useKbProductSpecsList } from '@/hooks/useKbProductSpecsList';
+import { calculateRendimento } from '@/lib/knowledge-base/calculate-rendimento';
+
+/**
+ * Calculadora standalone de consumo de tinta.
+ * Vendedor escolhe produto (de kb_product_specs aprovados), informa área em m²,
+ * vê cálculo de litros necessários + memória de cálculo + warnings.
+ *
+ * Usável tanto fora de chamada (planejamento, cotação) quanto embutida
+ * em painel de chamada futuramente (PR6c.5).
+ */
+export function RendimentoCalculator() {
+  const { data: specs, isLoading } = useKbProductSpecsList();
+  const [productCode, setProductCode] = useState<string>('');
+  const [areaM2, setAreaM2] = useState<string>('');
+  const [demaosOverride, setDemaosOverride] = useState<string>('');
+
+  const selectedSpec = specs?.find((s) => s.product_code === productCode);
+  const area = parseFloat(areaM2) || 0;
+  const demaos = demaosOverride ? parseInt(demaosOverride, 10) : undefined;
+
+  const result = useMemo(() => {
+    if (!selectedSpec || area <= 0) return null;
+    return calculateRendimento({ spec: selectedSpec, areaM2: area, demaosOverride: demaos });
+  }, [selectedSpec, area, demaos]);
+
+  return (
+    <Card className="p-4 space-y-4">
+      <div className="flex items-center gap-2">
+        <Calculator className="w-4 h-4 text-status-warning" />
+        <h2 className="text-sm font-semibold">Calculadora de rendimento</h2>
+      </div>
+
+      <div className="space-y-3">
+        <div>
+          <Label htmlFor="product" className="text-xs">Produto</Label>
+          {isLoading ? (
+            <div className="flex items-center gap-2 text-xs text-muted-foreground py-2">
+              <Loader2 className="w-3 h-3 animate-spin" />
+              Carregando produtos…
+            </div>
+          ) : !specs || specs.length === 0 ? (
+            <div className="text-xs text-muted-foreground py-2 px-2 rounded-md bg-muted/40">
+              Nenhum spec aprovado ainda. Suba boletins em <span className="font-mono">/admin/knowledge-base</span> e extraia os specs primeiro.
+            </div>
+          ) : (
+            <Select value={productCode} onValueChange={setProductCode}>
+              <SelectTrigger>
+                <SelectValue placeholder="Escolha o produto" />
+              </SelectTrigger>
+              <SelectContent>
+                {specs.map((s) => (
+                  <SelectItem key={s.product_code} value={s.product_code}>
+                    <span>{s.product_name}</span>
+                    <span className="text-muted-foreground ml-2 text-xs">({s.product_code})</span>
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          )}
+        </div>
+
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <Label htmlFor="area" className="text-xs">Área a pintar (m²)</Label>
+            <Input
+              id="area"
+              type="number"
+              min="0"
+              step="any"
+              value={areaM2}
+              onChange={(e) => setAreaM2(e.target.value)}
+              placeholder="Ex: 80"
+            />
+          </div>
+          <div>
+            <Label htmlFor="demaos" className="text-xs">
+              Demãos{' '}
+              {selectedSpec?.demaos_recomendadas != null && (
+                <span className="text-muted-foreground text-[10px]">(boletim: {selectedSpec.demaos_recomendadas})</span>
+              )}
+            </Label>
+            <Input
+              id="demaos"
+              type="number"
+              min="1"
+              step="1"
+              placeholder={String(selectedSpec?.demaos_recomendadas ?? 1)}
+              value={demaosOverride}
+              onChange={(e) => setDemaosOverride(e.target.value)}
+            />
+          </div>
+        </div>
+      </div>
+
+      {result && (
+        <Card className="p-3 border-status-success bg-status-success-bg/30 space-y-2">
+          <div className="flex items-baseline justify-between">
+            <span className="text-xs text-muted-foreground uppercase tracking-wide">Consumo estimado</span>
+            <span className="text-2xl font-semibold tabular-nums text-status-success">
+              {result.litrosNecessarios.toFixed(1)} L
+            </span>
+          </div>
+
+          <div className="text-2xs text-muted-foreground space-y-0.5 pt-1 border-t border-status-success/20">
+            <div>
+              Área: <span className="font-medium">{result.areaM2} m²</span> · Demãos:{' '}
+              <span className="font-medium">{result.demaos}</span> · Rendimento:{' '}
+              <span className="font-medium">{result.rendimentoM2PorLitro.toFixed(1)} m²/L</span>
+            </div>
+            {result.calculo && <div className="font-mono text-[10px] opacity-80">{result.calculo}</div>}
+            {result.rendimentoM2PorLitro > 0 && (
+              <div className="font-mono text-[10px] opacity-80">
+                {result.areaM2} ÷ {result.rendimentoM2PorLitro.toFixed(1)} × {result.demaos} ={' '}
+                <span className="font-bold">{result.litrosNecessarios.toFixed(1)} L</span>
+              </div>
+            )}
+          </div>
+
+          {result.warnings.length > 0 && (
+            <div className="space-y-1 pt-2 border-t border-status-success/20">
+              {result.warnings.map((w, i) => (
+                <div key={i} className="flex items-start gap-1.5 text-2xs text-status-warning">
+                  <AlertTriangle className="w-2.5 h-2.5 mt-0.5 shrink-0" />
+                  <span>{w}</span>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {selectedSpec && (
+            <div className="flex flex-wrap gap-1 pt-2 border-t border-status-success/20">
+              {selectedSpec.catalisador_codigo && (
+                <Badge variant="outline" className="text-[10px]">
+                  + catalisador {selectedSpec.catalisador_codigo}
+                  {selectedSpec.catalisador_proporcao_pct && ` (${selectedSpec.catalisador_proporcao_pct}%)`}
+                </Badge>
+              )}
+              {selectedSpec.diluente_codigo && (
+                <Badge variant="outline" className="text-[10px]">
+                  + diluente {selectedSpec.diluente_codigo}
+                </Badge>
+              )}
+              {selectedSpec.pot_life_horas && (
+                <Badge variant="outline" className="text-[10px]">
+                  pot life {selectedSpec.pot_life_horas}h
+                </Badge>
+              )}
+              {selectedSpec.validade_dias && (
+                <Badge variant="outline" className="text-[10px]">
+                  validade {selectedSpec.validade_dias} dias
+                </Badge>
+              )}
+            </div>
+          )}
+        </Card>
+      )}
+    </Card>
+  );
+}

--- a/src/hooks/__tests__/useExtractSpecs.test.tsx
+++ b/src/hooks/__tests__/useExtractSpecs.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+
+const { invokeMock } = vi.hoisted(() => ({ invokeMock: vi.fn() }));
+
+vi.mock('@/lib/invoke-function', () => ({
+  invokeFunction: invokeMock,
+}));
+
+import { useExtractSpecs } from '../useExtractSpecs';
+
+function wrapper({ children }: { children: ReactNode }) {
+  const qc = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+const fakeResponse = {
+  specs: {
+    product_code: 'FO20.6827.00',
+    product_name: 'Verniz20 PU 6827',
+    supplier: 'sayerlack',
+    extraction_confidence: 0.9,
+    extraction_gaps: [],
+    equipamentos_aplicacao: ['pistola_convencional'],
+    substrato: ['madeira'],
+    certificacoes_aplicaveis: [],
+    isento_metais_pesados: [],
+    isento_substancias: [],
+    diferenciais_chave: ['resistencia_quimica'],
+  },
+  usage: { inputTokens: 1500, outputTokens: 800, cacheCreationTokens: 0, cacheReadTokens: 0 },
+};
+
+describe('useExtractSpecs', () => {
+  it('estado inicial: idle', () => {
+    const { result } = renderHook(() => useExtractSpecs(), { wrapper });
+    expect(result.current.isPending).toBe(false);
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it('chama invokeFunction com documentId no payload', async () => {
+    invokeMock.mockResolvedValueOnce(fakeResponse);
+    const { result } = renderHook(() => useExtractSpecs(), { wrapper });
+    result.current.mutate('doc-1');
+    await waitFor(() => expect(result.current.data).toEqual(fakeResponse));
+    expect(invokeMock).toHaveBeenCalledWith('kb-extract-specs', { documentId: 'doc-1' });
+  });
+
+  it('propaga erro pra .error', async () => {
+    invokeMock.mockRejectedValueOnce(new Error('quota exceeded'));
+    const { result } = renderHook(() => useExtractSpecs(), { wrapper });
+    result.current.mutate('doc-1');
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toBeInstanceOf(Error);
+  });
+});

--- a/src/hooks/useExtractSpecs.ts
+++ b/src/hooks/useExtractSpecs.ts
@@ -1,0 +1,26 @@
+import { useMutation } from '@tanstack/react-query';
+import { invokeFunction } from '@/lib/invoke-function';
+import { toast } from 'sonner';
+import type { KbExtractedSpec } from '@/lib/knowledge-base/specs-types';
+
+interface ExtractResponse {
+  specs: KbExtractedSpec;
+  usage: {
+    inputTokens: number;
+    outputTokens: number;
+    cacheCreationTokens: number;
+    cacheReadTokens: number;
+  };
+}
+
+export function useExtractSpecs() {
+  return useMutation({
+    mutationFn: async (documentId: string): Promise<ExtractResponse> => {
+      const response = await invokeFunction<ExtractResponse>('kb-extract-specs', { documentId });
+      return response;
+    },
+    onError: (err) => {
+      toast.error('Erro na extração', { description: err instanceof Error ? err.message : '' });
+    },
+  });
+}

--- a/src/hooks/useKbProductSpecs.ts
+++ b/src/hooks/useKbProductSpecs.ts
@@ -1,0 +1,21 @@
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import type { KbProductSpec } from '@/lib/knowledge-base/specs-types';
+
+export function useKbProductSpecs(productCode: string | undefined | null) {
+  return useQuery({
+    queryKey: ['kb-product-spec', productCode],
+    enabled: !!productCode,
+    staleTime: 60_000,
+    queryFn: async (): Promise<KbProductSpec | null> => {
+      if (!productCode) return null;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const { data, error } = await (supabase.from('kb_product_specs') as any)
+        .select('*')
+        .eq('product_code', productCode)
+        .maybeSingle();
+      if (error) throw error;
+      return (data as KbProductSpec) ?? null;
+    },
+  });
+}

--- a/src/hooks/useKbProductSpecsList.ts
+++ b/src/hooks/useKbProductSpecsList.ts
@@ -1,0 +1,20 @@
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import type { KbProductSpec } from '@/lib/knowledge-base/specs-types';
+
+export function useKbProductSpecsList() {
+  return useQuery({
+    queryKey: ['kb-product-specs-list'],
+    staleTime: 60_000,
+    queryFn: async (): Promise<KbProductSpec[]> => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const { data, error } = await (supabase.from('kb_product_specs') as any)
+        .select('*')
+        .not('approved_at', 'is', null)
+        .order('product_name', { ascending: true })
+        .limit(500);
+      if (error) throw error;
+      return (data ?? []) as KbProductSpec[];
+    },
+  });
+}

--- a/src/hooks/useSaveProductSpecs.ts
+++ b/src/hooks/useSaveProductSpecs.ts
@@ -1,0 +1,44 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import { toast } from 'sonner';
+import type { KbExtractedSpec, KbProductSpec } from '@/lib/knowledge-base/specs-types';
+
+interface SaveInput {
+  specs: KbExtractedSpec;
+  documentId?: string;
+}
+
+export function useSaveProductSpecs() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (input: SaveInput): Promise<KbProductSpec> => {
+      const { data: { user } } = await supabase.auth.getUser();
+      if (!user) throw new Error('Não autenticado');
+
+      const payload = {
+        ...input.specs,
+        document_id: input.documentId ?? null,
+        extracted_by: user.id,
+        approved_by: user.id,
+        approved_at: new Date().toISOString(),
+      };
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const { data, error } = await (supabase.from('kb_product_specs') as any)
+        .upsert(payload, { onConflict: 'product_code' })
+        .select()
+        .single();
+
+      if (error) throw error;
+      return data as KbProductSpec;
+    },
+    onSuccess: (data) => {
+      qc.invalidateQueries({ queryKey: ['kb-product-specs'] });
+      qc.invalidateQueries({ queryKey: ['kb-product-spec', data.product_code] });
+      toast.success('Specs salvos', { description: `${data.product_name} (${data.product_code})` });
+    },
+    onError: (err) => {
+      toast.error('Erro ao salvar', { description: err instanceof Error ? err.message : '' });
+    },
+  });
+}

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -4520,6 +4520,263 @@ export type Database = {
           },
         ]
       }
+      kb_competitor_products: {
+        Row: {
+          argumentos_comparativos: Json | null
+          category: string | null
+          competitor_id: string
+          created_at: string
+          created_by: string | null
+          fonte_preco: string | null
+          id: string
+          nosso_equivalente_product_code: string | null
+          pontos_fortes: string[] | null
+          pontos_fracos: string[] | null
+          pot_life_horas: number | null
+          preco_atualizado_em: string | null
+          preco_referencia_l: number | null
+          product_name: string
+          rendimento_m2_por_litro: number | null
+          solidos_pct: number | null
+          updated_at: string
+          validade_dias: number | null
+        }
+        Insert: {
+          argumentos_comparativos?: Json | null
+          category?: string | null
+          competitor_id: string
+          created_at?: string
+          created_by?: string | null
+          fonte_preco?: string | null
+          id?: string
+          nosso_equivalente_product_code?: string | null
+          pontos_fortes?: string[] | null
+          pontos_fracos?: string[] | null
+          pot_life_horas?: number | null
+          preco_atualizado_em?: string | null
+          preco_referencia_l?: number | null
+          product_name: string
+          rendimento_m2_por_litro?: number | null
+          solidos_pct?: number | null
+          updated_at?: string
+          validade_dias?: number | null
+        }
+        Update: {
+          argumentos_comparativos?: Json | null
+          category?: string | null
+          competitor_id?: string
+          created_at?: string
+          created_by?: string | null
+          fonte_preco?: string | null
+          id?: string
+          nosso_equivalente_product_code?: string | null
+          pontos_fortes?: string[] | null
+          pontos_fracos?: string[] | null
+          pot_life_horas?: number | null
+          preco_atualizado_em?: string | null
+          preco_referencia_l?: number | null
+          product_name?: string
+          rendimento_m2_por_litro?: number | null
+          solidos_pct?: number | null
+          updated_at?: string
+          validade_dias?: number | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "kb_competitor_products_competitor_id_fkey"
+            columns: ["competitor_id"]
+            isOneToOne: false
+            referencedRelation: "kb_competitors"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      kb_competitors: {
+        Row: {
+          created_at: string
+          created_by: string | null
+          id: string
+          name: string
+          notas_estrategicas: string | null
+          regiao_principal: string | null
+          segmento_atuacao: string[] | null
+          tipo: string | null
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          created_by?: string | null
+          id?: string
+          name: string
+          notas_estrategicas?: string | null
+          regiao_principal?: string | null
+          segmento_atuacao?: string[] | null
+          tipo?: string | null
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          created_by?: string | null
+          id?: string
+          name?: string
+          notas_estrategicas?: string | null
+          regiao_principal?: string | null
+          segmento_atuacao?: string[] | null
+          tipo?: string | null
+          updated_at?: string
+        }
+        Relationships: []
+      }
+      kb_product_specs: {
+        Row: {
+          approved_at: string | null
+          approved_by: string | null
+          brilho_ub: number | null
+          catalisador_codigo: string | null
+          catalisador_proporcao_pct: number | null
+          certificacoes_aplicaveis: string[] | null
+          created_at: string
+          demaos_recomendadas: number | null
+          densidade_g_cm3: number | null
+          diferenciais_chave: string[] | null
+          diluente_codigo: string | null
+          document_id: string | null
+          dureza: string | null
+          equipamentos_aplicacao: string[] | null
+          extracted_by: string | null
+          extraction_confidence: number | null
+          extraction_gaps: string[] | null
+          gramatura_g_m2_max: number | null
+          gramatura_g_m2_min: number | null
+          id: string
+          isento_metais_pesados: string[] | null
+          isento_substancias: string[] | null
+          lixa_recomendada: string | null
+          pot_life_horas: number | null
+          product_category: string | null
+          product_code: string
+          product_line: string | null
+          product_name: string
+          publico_alvo: string | null
+          rendimento_m2_por_litro: number | null
+          secagem_empilhamento_h: number | null
+          secagem_manuseio_h: number | null
+          secagem_total_h: number | null
+          solidos_pct: number | null
+          substrato: string[] | null
+          supplier: string
+          temp_aplicacao_c_max: number | null
+          temp_aplicacao_c_min: number | null
+          temp_armazenamento_c_max: number | null
+          temp_armazenamento_c_min: number | null
+          umidade_aplicacao_pct_max: number | null
+          umidade_aplicacao_pct_min: number | null
+          updated_at: string
+          uso_recomendado: string | null
+          validade_dias: number | null
+          viscosidade_aplicacao_s: number | null
+          viscosidade_copo: string | null
+        }
+        Insert: {
+          approved_at?: string | null
+          approved_by?: string | null
+          brilho_ub?: number | null
+          catalisador_codigo?: string | null
+          catalisador_proporcao_pct?: number | null
+          certificacoes_aplicaveis?: string[] | null
+          created_at?: string
+          demaos_recomendadas?: number | null
+          densidade_g_cm3?: number | null
+          diferenciais_chave?: string[] | null
+          diluente_codigo?: string | null
+          document_id?: string | null
+          dureza?: string | null
+          equipamentos_aplicacao?: string[] | null
+          extracted_by?: string | null
+          extraction_confidence?: number | null
+          extraction_gaps?: string[] | null
+          gramatura_g_m2_max?: number | null
+          gramatura_g_m2_min?: number | null
+          id?: string
+          isento_metais_pesados?: string[] | null
+          isento_substancias?: string[] | null
+          lixa_recomendada?: string | null
+          pot_life_horas?: number | null
+          product_category?: string | null
+          product_code: string
+          product_line?: string | null
+          product_name: string
+          publico_alvo?: string | null
+          rendimento_m2_por_litro?: number | null
+          secagem_empilhamento_h?: number | null
+          secagem_manuseio_h?: number | null
+          secagem_total_h?: number | null
+          solidos_pct?: number | null
+          substrato?: string[] | null
+          supplier?: string
+          temp_aplicacao_c_max?: number | null
+          temp_aplicacao_c_min?: number | null
+          temp_armazenamento_c_max?: number | null
+          temp_armazenamento_c_min?: number | null
+          umidade_aplicacao_pct_max?: number | null
+          umidade_aplicacao_pct_min?: number | null
+          updated_at?: string
+          uso_recomendado?: string | null
+          validade_dias?: number | null
+          viscosidade_aplicacao_s?: number | null
+          viscosidade_copo?: string | null
+        }
+        Update: {
+          approved_at?: string | null
+          approved_by?: string | null
+          brilho_ub?: number | null
+          catalisador_codigo?: string | null
+          catalisador_proporcao_pct?: number | null
+          certificacoes_aplicaveis?: string[] | null
+          created_at?: string
+          demaos_recomendadas?: number | null
+          densidade_g_cm3?: number | null
+          diferenciais_chave?: string[] | null
+          diluente_codigo?: string | null
+          document_id?: string | null
+          dureza?: string | null
+          equipamentos_aplicacao?: string[] | null
+          extracted_by?: string | null
+          extraction_confidence?: number | null
+          extraction_gaps?: string[] | null
+          gramatura_g_m2_max?: number | null
+          gramatura_g_m2_min?: number | null
+          id?: string
+          isento_metais_pesados?: string[] | null
+          isento_substancias?: string[] | null
+          lixa_recomendada?: string | null
+          pot_life_horas?: number | null
+          product_category?: string | null
+          product_code?: string
+          product_line?: string | null
+          product_name?: string
+          publico_alvo?: string | null
+          rendimento_m2_por_litro?: number | null
+          secagem_empilhamento_h?: number | null
+          secagem_manuseio_h?: number | null
+          secagem_total_h?: number | null
+          solidos_pct?: number | null
+          substrato?: string[] | null
+          supplier?: string
+          temp_aplicacao_c_max?: number | null
+          temp_aplicacao_c_min?: number | null
+          temp_armazenamento_c_max?: number | null
+          temp_armazenamento_c_min?: number | null
+          umidade_aplicacao_pct_max?: number | null
+          umidade_aplicacao_pct_min?: number | null
+          updated_at?: string
+          uso_recomendado?: string | null
+          validade_dias?: number | null
+          viscosidade_aplicacao_s?: number | null
+          viscosidade_copo?: string | null
+        }
+        Relationships: []
+      }
       loyalty_points: {
         Row: {
           created_at: string

--- a/src/lib/knowledge-base/calculate-rendimento.test.ts
+++ b/src/lib/knowledge-base/calculate-rendimento.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest';
+import { calculateRendimento } from './calculate-rendimento';
+import type { KbProductSpec } from './specs-types';
+
+const spec = (overrides: Partial<KbProductSpec> = {}): KbProductSpec => ({
+  id: 's1',
+  document_id: null,
+  product_code: 'TEST.001',
+  product_name: 'Teste',
+  supplier: 'sayerlack',
+  product_line: null,
+  product_category: null,
+  densidade_g_cm3: null,
+  solidos_pct: null,
+  viscosidade_aplicacao_s: null,
+  viscosidade_copo: null,
+  brilho_ub: null,
+  dureza: null,
+  rendimento_m2_por_litro: null,
+  demaos_recomendadas: null,
+  gramatura_g_m2_min: null,
+  gramatura_g_m2_max: null,
+  pot_life_horas: null,
+  temp_aplicacao_c_min: null,
+  temp_aplicacao_c_max: null,
+  umidade_aplicacao_pct_min: null,
+  umidade_aplicacao_pct_max: null,
+  catalisador_codigo: null,
+  catalisador_proporcao_pct: null,
+  diluente_codigo: null,
+  equipamentos_aplicacao: [],
+  lixa_recomendada: null,
+  substrato: [],
+  secagem_manuseio_h: null,
+  secagem_empilhamento_h: null,
+  secagem_total_h: null,
+  validade_dias: null,
+  temp_armazenamento_c_min: null,
+  temp_armazenamento_c_max: null,
+  certificacoes_aplicaveis: [],
+  isento_metais_pesados: [],
+  isento_substancias: [],
+  diferenciais_chave: [],
+  uso_recomendado: null,
+  publico_alvo: null,
+  extraction_confidence: null,
+  extraction_gaps: [],
+  extracted_by: null,
+  approved_by: null,
+  approved_at: null,
+  created_at: '2026-05-17',
+  updated_at: '2026-05-17',
+  ...overrides,
+});
+
+describe('calculateRendimento', () => {
+  it('usa rendimento explícito do spec', () => {
+    const r = calculateRendimento({
+      spec: spec({ rendimento_m2_por_litro: 8, demaos_recomendadas: 2 }),
+      areaM2: 80,
+    });
+    expect(r.litrosNecessarios).toBeCloseTo(20, 1); // 80 / 8 * 2 = 20
+    expect(r.rendimentoM2PorLitro).toBe(8);
+    expect(r.demaos).toBe(2);
+    expect(r.warnings).toEqual([]);
+  });
+
+  it('deriva rendimento de densidade + gramatura quando explícito ausente', () => {
+    const r = calculateRendimento({
+      spec: spec({ densidade_g_cm3: 0.979, gramatura_g_m2_min: 100, gramatura_g_m2_max: 150, demaos_recomendadas: 1 }),
+      areaM2: 100,
+    });
+    // (0.979 * 1000) / 125 = ~7.83 m²/L
+    expect(r.rendimentoM2PorLitro).toBeCloseTo(7.83, 1);
+    expect(r.warnings).toContainEqual(expect.stringContaining('derivado'));
+  });
+
+  it('spec sem rendimento nem densidade/gramatura: warning + litros=0', () => {
+    const r = calculateRendimento({ spec: spec({ demaos_recomendadas: 2 }), areaM2: 50 });
+    expect(r.litrosNecessarios).toBe(0);
+    expect(r.warnings).toContainEqual(expect.stringContaining('insuficientes'));
+  });
+
+  it('demaosOverride sobrescreve default do spec', () => {
+    const r = calculateRendimento({
+      spec: spec({ rendimento_m2_por_litro: 10, demaos_recomendadas: 1 }),
+      areaM2: 100,
+      demaosOverride: 3,
+    });
+    expect(r.demaos).toBe(3);
+    expect(r.litrosNecessarios).toBeCloseTo(30, 1); // 100/10*3
+  });
+
+  it('sem demãos no spec nem override: assume 1 + warning', () => {
+    const r = calculateRendimento({
+      spec: spec({ rendimento_m2_por_litro: 8 }),
+      areaM2: 80,
+    });
+    expect(r.demaos).toBe(1);
+    expect(r.warnings).toContainEqual(expect.stringContaining('Demãos'));
+  });
+
+  it('cálculo realista: 80 m² × 2 demãos ÷ 8 m²/L = 20 L', () => {
+    const r = calculateRendimento({
+      spec: spec({ rendimento_m2_por_litro: 8, demaos_recomendadas: 2 }),
+      areaM2: 80,
+    });
+    expect(r.litrosNecessarios).toBeCloseTo(20, 1);
+  });
+});

--- a/src/lib/knowledge-base/calculate-rendimento.ts
+++ b/src/lib/knowledge-base/calculate-rendimento.ts
@@ -1,0 +1,84 @@
+import type { KbProductSpec } from './specs-types';
+
+export interface RendimentoCalculation {
+  /** Área total a ser pintada (m²) */
+  areaM2: number;
+  /** Demãos aplicadas (override ou default do spec) */
+  demaos: number;
+  /** Rendimento usado (m²/L do spec ou recalculado pela gramatura) */
+  rendimentoM2PorLitro: number;
+  /** Litros necessários */
+  litrosNecessarios: number;
+  /** Memória de cálculo pra UI */
+  calculo: string;
+  /** Avisos se faltam dados pro cálculo */
+  warnings: string[];
+}
+
+export interface CalculateInput {
+  spec: Pick<KbProductSpec, 'rendimento_m2_por_litro' | 'densidade_g_cm3' | 'gramatura_g_m2_min' | 'gramatura_g_m2_max' | 'demaos_recomendadas' | 'product_name'>;
+  areaM2: number;
+  demaosOverride?: number;
+}
+
+/**
+ * Calcula litros necessários considerando rendimento + demãos.
+ * Se spec não tem rendimento explícito mas tem densidade + gramatura, deriva.
+ * Retorna warnings quando faltam dados ou cálculo é aproximação.
+ */
+export function calculateRendimento(input: CalculateInput): RendimentoCalculation {
+  const warnings: string[] = [];
+  const demaos = input.demaosOverride ?? input.spec.demaos_recomendadas ?? 1;
+
+  if (input.demaosOverride === undefined && !input.spec.demaos_recomendadas) {
+    warnings.push('Demãos não informadas no boletim — assumindo 1.');
+  }
+
+  let rendimento = input.spec.rendimento_m2_por_litro;
+  let calculo = '';
+
+  if (rendimento != null && rendimento > 0) {
+    calculo = `Rendimento do boletim: ${rendimento} m²/L`;
+  } else if (input.spec.densidade_g_cm3 && (input.spec.gramatura_g_m2_min || input.spec.gramatura_g_m2_max)) {
+    const min = input.spec.gramatura_g_m2_min ?? input.spec.gramatura_g_m2_max ?? 0;
+    const max = input.spec.gramatura_g_m2_max ?? input.spec.gramatura_g_m2_min ?? 0;
+    const gramaturaMedia = (min + max) / 2;
+    const densidadeGPorL = input.spec.densidade_g_cm3 * 1000;
+    rendimento = gramaturaMedia > 0 ? densidadeGPorL / gramaturaMedia : 0;
+    calculo = `Derivado: densidade ${input.spec.densidade_g_cm3} g/cm³ × 1000 ÷ gramatura média ${gramaturaMedia} g/m² = ${rendimento.toFixed(1)} m²/L`;
+    warnings.push('Rendimento derivado da densidade + gramatura (boletim não informa explicitamente).');
+  } else {
+    warnings.push('Spec sem rendimento, densidade ou gramatura — dados insuficientes pro cálculo.');
+    return {
+      areaM2: input.areaM2,
+      demaos,
+      rendimentoM2PorLitro: 0,
+      litrosNecessarios: 0,
+      calculo: 'Dados insuficientes',
+      warnings,
+    };
+  }
+
+  if (rendimento <= 0) {
+    warnings.push('Rendimento calculado é zero ou negativo.');
+    return {
+      areaM2: input.areaM2,
+      demaos,
+      rendimentoM2PorLitro: 0,
+      litrosNecessarios: 0,
+      calculo,
+      warnings,
+    };
+  }
+
+  const litros = (input.areaM2 / rendimento) * demaos;
+
+  return {
+    areaM2: input.areaM2,
+    demaos,
+    rendimentoM2PorLitro: rendimento,
+    litrosNecessarios: litros,
+    calculo,
+    warnings,
+  };
+}

--- a/src/lib/knowledge-base/specs-types.ts
+++ b/src/lib/knowledge-base/specs-types.ts
@@ -1,0 +1,124 @@
+/**
+ * Domain types pra specs estruturados de produtos + concorrentes.
+ *
+ * KbProductSpec — 1 row por SKU Sayerlack/Colacor, extraído de boletim técnico
+ *   via Claude (edge function kb-extract-specs). Approved by master.
+ *
+ * KbCompetitor + KbCompetitorProduct — vazios no schema; populados via UI no PR8
+ *   (battle cards) ou auto-detect de transcripts (entitiesExtracted do copilot).
+ *   Sem hardcode — vendedor expande livremente.
+ */
+
+export interface KbProductSpec {
+  id: string;
+  document_id: string | null;
+  product_code: string;
+  product_name: string;
+  supplier: string;
+  product_line: string | null;
+  product_category: string | null;
+
+  // Físico-químico
+  densidade_g_cm3: number | null;
+  solidos_pct: number | null;
+  viscosidade_aplicacao_s: number | null;
+  viscosidade_copo: string | null;
+  brilho_ub: number | null;
+  dureza: string | null;
+
+  // Aplicação
+  rendimento_m2_por_litro: number | null;
+  demaos_recomendadas: number | null;
+  gramatura_g_m2_min: number | null;
+  gramatura_g_m2_max: number | null;
+  pot_life_horas: number | null;
+  temp_aplicacao_c_min: number | null;
+  temp_aplicacao_c_max: number | null;
+  umidade_aplicacao_pct_min: number | null;
+  umidade_aplicacao_pct_max: number | null;
+
+  // Compatibilidade
+  catalisador_codigo: string | null;
+  catalisador_proporcao_pct: number | null;
+  diluente_codigo: string | null;
+  equipamentos_aplicacao: string[];
+  lixa_recomendada: string | null;
+  substrato: string[];
+
+  // Secagem
+  secagem_manuseio_h: number | null;
+  secagem_empilhamento_h: number | null;
+  secagem_total_h: number | null;
+
+  // Armazenamento
+  validade_dias: number | null;
+  temp_armazenamento_c_min: number | null;
+  temp_armazenamento_c_max: number | null;
+
+  // Compliance
+  certificacoes_aplicaveis: string[];
+  isento_metais_pesados: string[];
+  isento_substancias: string[];
+
+  // Notas qualitativas
+  diferenciais_chave: string[];
+  uso_recomendado: string | null;
+  publico_alvo: string | null;
+
+  // Metadata da extração
+  extraction_confidence: number | null;
+  extraction_gaps: string[];
+  extracted_by: string | null;
+  approved_by: string | null;
+  approved_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+/**
+ * Shape retornado pela edge function kb-extract-specs.
+ * Sem ids/timestamps/metadata de auditoria — só os campos extraídos.
+ */
+export type KbExtractedSpec = Omit<
+  KbProductSpec,
+  | 'id'
+  | 'document_id'
+  | 'extracted_by'
+  | 'approved_by'
+  | 'approved_at'
+  | 'created_at'
+  | 'updated_at'
+>;
+
+export interface KbCompetitor {
+  id: string;
+  name: string;
+  tipo: 'regional' | 'nacional' | 'importado' | null;
+  regiao_principal: string | null;
+  segmento_atuacao: string[];
+  notas_estrategicas: string | null;
+  created_by: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface KbCompetitorProduct {
+  id: string;
+  competitor_id: string;
+  product_name: string;
+  category: string | null;
+  rendimento_m2_por_litro: number | null;
+  solidos_pct: number | null;
+  pot_life_horas: number | null;
+  validade_dias: number | null;
+  preco_referencia_l: number | null;
+  preco_atualizado_em: string | null;
+  fonte_preco: 'vendedor' | 'cotacao' | 'site' | 'estimado' | 'detectado_ia' | null;
+  pontos_fortes: string[];
+  pontos_fracos: string[];
+  nosso_equivalente_product_code: string | null;
+  argumentos_comparativos: unknown;
+  created_by: string | null;
+  created_at: string;
+  updated_at: string;
+}

--- a/src/pages/AdminCalculadora.tsx
+++ b/src/pages/AdminCalculadora.tsx
@@ -1,0 +1,16 @@
+import { RendimentoCalculator } from '@/components/knowledge-base/RendimentoCalculator';
+
+export default function AdminCalculadora() {
+  return (
+    <div className="container mx-auto p-4 space-y-3 max-w-2xl">
+      <div>
+        <h1 className="text-xl font-semibold">Calculadora de rendimento</h1>
+        <p className="text-xs text-muted-foreground">
+          Calcula consumo de tinta baseado em área a pintar + boletim técnico aprovado.
+          Use durante chamadas pra dar números precisos pro cliente.
+        </p>
+      </div>
+      <RendimentoCalculator />
+    </div>
+  );
+}

--- a/src/pages/AdminKnowledgeBaseDetail.tsx
+++ b/src/pages/AdminKnowledgeBaseDetail.tsx
@@ -3,11 +3,13 @@ import { useQuery } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
 import { Card } from '@/components/ui/card';
 import { KbStatusBadge } from '@/components/knowledge-base/KbStatusBadge';
+import { KbSpecsExtractButton } from '@/components/knowledge-base/KbSpecsExtractButton';
 import { Badge } from '@/components/ui/badge';
 import { format } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
-import { Loader2 } from 'lucide-react';
+import { Loader2, Database, Sparkles } from 'lucide-react';
 import type { KbDocument } from '@/lib/knowledge-base/types';
+import { useKbProductSpecs } from '@/hooks/useKbProductSpecs';
 
 export default function AdminKnowledgeBaseDetail() {
   const { id } = useParams<{ id: string }>();
@@ -55,6 +57,12 @@ export default function AdminKnowledgeBaseDetail() {
     );
   }
 
+  return <DetailContent data={data} chunkCount={chunkCount} />;
+}
+
+function DetailContent({ data, chunkCount }: { data: KbDocument; chunkCount: number | undefined }) {
+  const { data: existingSpecs, refetch: refetchSpecs } = useKbProductSpecs(data.product_code);
+
   return (
     <div className="container mx-auto p-4 space-y-3 max-w-4xl">
       <div className="flex items-center justify-between flex-wrap gap-2">
@@ -84,6 +92,64 @@ export default function AdminKnowledgeBaseDetail() {
         </Card>
       )}
 
+      {/* Specs estruturados — só quando documento está ready e tem product_code */}
+      {data.status === 'ready' && data.product_code && (
+        <Card className="p-3 space-y-2">
+          <div className="flex items-center justify-between flex-wrap gap-2">
+            <div className="flex items-center gap-2">
+              <Database className="w-4 h-4 text-muted-foreground" />
+              <span className="text-sm font-medium">Specs estruturados</span>
+              {existingSpecs && (
+                <Badge variant="outline" className="text-2xs gap-1">
+                  <Sparkles className="w-2.5 h-2.5" />
+                  Aprovado
+                </Badge>
+              )}
+            </div>
+            <KbSpecsExtractButton
+              documentId={data.id}
+              documentTitle={data.title}
+              productCode={data.product_code}
+              onSaved={() => refetchSpecs()}
+            />
+          </div>
+
+          {existingSpecs ? (
+            <div className="grid grid-cols-2 md:grid-cols-3 gap-2 text-2xs pt-2 border-t border-border">
+              {existingSpecs.rendimento_m2_por_litro != null && (
+                <KpiCell label="Rendimento" value={`${existingSpecs.rendimento_m2_por_litro} m²/L`} />
+              )}
+              {existingSpecs.densidade_g_cm3 != null && (
+                <KpiCell label="Densidade" value={`${existingSpecs.densidade_g_cm3} g/cm³`} />
+              )}
+              {existingSpecs.solidos_pct != null && (
+                <KpiCell label="Sólidos" value={`${existingSpecs.solidos_pct}%`} />
+              )}
+              {existingSpecs.pot_life_horas != null && (
+                <KpiCell label="Pot life" value={`${existingSpecs.pot_life_horas}h`} />
+              )}
+              {existingSpecs.validade_dias != null && (
+                <KpiCell label="Validade" value={`${existingSpecs.validade_dias} dias`} />
+              )}
+              {existingSpecs.dureza && <KpiCell label="Dureza" value={existingSpecs.dureza} />}
+              {existingSpecs.catalisador_codigo && (
+                <KpiCell label="Catalisador" value={`${existingSpecs.catalisador_codigo}${existingSpecs.catalisador_proporcao_pct ? ` (${existingSpecs.catalisador_proporcao_pct}%)` : ''}`} />
+              )}
+              {existingSpecs.diluente_codigo && (
+                <KpiCell label="Diluente" value={existingSpecs.diluente_codigo} />
+              )}
+              {existingSpecs.demaos_recomendadas != null && (
+                <KpiCell label="Demãos" value={String(existingSpecs.demaos_recomendadas)} />
+              )}
+            </div>
+          ) : (
+            <div className="text-2xs text-muted-foreground">
+              Clique acima pra extrair specs automaticamente do texto via Claude.
+            </div>
+          )}
+        </Card>
+      )}
+
       {data.content_extracted && (
         <Card className="p-3">
           <div className="text-2xs uppercase tracking-wide text-muted-foreground mb-2">
@@ -94,6 +160,15 @@ export default function AdminKnowledgeBaseDetail() {
           </pre>
         </Card>
       )}
+    </div>
+  );
+}
+
+function KpiCell({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <div className="text-muted-foreground">{label}</div>
+      <div className="font-medium tabular-nums">{value}</div>
     </div>
   );
 }

--- a/supabase/functions/kb-extract-specs/index.ts
+++ b/supabase/functions/kb-extract-specs/index.ts
@@ -1,0 +1,190 @@
+import Anthropic from "npm:@anthropic-ai/sdk@^0.93.0";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import { authorizeCronOrStaff, corsHeaders } from "../_shared/auth.ts";
+
+const SYSTEM_PROMPT_EXTRACT_SPECS = `Você extrai specs técnicos estruturados de boletins técnicos de tintas industriais para a base de conhecimento da Colacor (distribuidora Sayerlack).
+
+# Regras gerais
+- Use APENAS dados explícitos no texto. NÃO invente, NÃO estime.
+- Quando o boletim dá um range (ex: "viscosidade 42 ± 3s CF6 a 25°C"), use o valor central (42).
+- Para campos que o boletim NÃO menciona, deixe null.
+- Liste em \`extraction_gaps\` os campos importantes que estão ausentes.
+- \`extraction_confidence\` = 0.9+ se boletim claro, 0.6-0.8 se ambíguo, <0.6 se faltam muitos dados-chave.
+
+# Cálculos derivados permitidos
+- \`rendimento_m2_por_litro\` = (densidade_g_cm3 × 1000) / gramatura_g_m2_media. Use gramatura média entre min/max se houver range. Se boletim não tem gramatura nem densidade, deixe null.
+
+# Classificação semântica (vc preenche baseado no texto)
+- \`product_line\`: 'wood_pu' | 'wood_nitro' | 'hydropoxi' | 'auto' — Wood PU pra poliuretanos pra madeira (mais comum em boletins moveleiros)
+- \`product_category\`: 'primer' | 'verniz' | 'tinta' | 'catalisador' | 'diluente' | 'massa' | 'selador'
+- \`diferenciais_chave\`: extrai as 2-5 frases-chave do "Uso Recomendado" e "Características"
+
+# Compliance
+- Se boletim menciona "isento de" e lista substâncias/metais, capture nos arrays
+- \`certificacoes_aplicaveis\`: capture menções de IKEA, LGA, Proposition 65, JIS, CARB, etc.
+
+SEMPRE use a tool extract_product_specs. NÃO responda em texto fora dela.`;
+
+const EXTRACT_TOOL = {
+  name: "extract_product_specs",
+  description: "Retorna specs estruturados do produto extraídos do boletim técnico.",
+  input_schema: {
+    type: "object",
+    properties: {
+      product_code: { type: "string" },
+      product_name: { type: "string" },
+      supplier: { type: "string" },
+      product_line: { type: ["string", "null"], enum: ["wood_pu", "wood_nitro", "hydropoxi", "auto", null] },
+      product_category: { type: ["string", "null"] },
+      densidade_g_cm3: { type: ["number", "null"] },
+      solidos_pct: { type: ["number", "null"] },
+      viscosidade_aplicacao_s: { type: ["number", "null"] },
+      viscosidade_copo: { type: ["string", "null"] },
+      brilho_ub: { type: ["number", "null"] },
+      dureza: { type: ["string", "null"] },
+      rendimento_m2_por_litro: { type: ["number", "null"] },
+      demaos_recomendadas: { type: ["integer", "null"] },
+      gramatura_g_m2_min: { type: ["integer", "null"] },
+      gramatura_g_m2_max: { type: ["integer", "null"] },
+      pot_life_horas: { type: ["number", "null"] },
+      temp_aplicacao_c_min: { type: ["number", "null"] },
+      temp_aplicacao_c_max: { type: ["number", "null"] },
+      umidade_aplicacao_pct_min: { type: ["number", "null"] },
+      umidade_aplicacao_pct_max: { type: ["number", "null"] },
+      catalisador_codigo: { type: ["string", "null"] },
+      catalisador_proporcao_pct: { type: ["number", "null"] },
+      diluente_codigo: { type: ["string", "null"] },
+      equipamentos_aplicacao: { type: "array", items: { type: "string" } },
+      lixa_recomendada: { type: ["string", "null"] },
+      substrato: { type: "array", items: { type: "string" } },
+      secagem_manuseio_h: { type: ["number", "null"] },
+      secagem_empilhamento_h: { type: ["number", "null"] },
+      secagem_total_h: { type: ["number", "null"] },
+      validade_dias: { type: ["integer", "null"] },
+      temp_armazenamento_c_min: { type: ["integer", "null"] },
+      temp_armazenamento_c_max: { type: ["integer", "null"] },
+      certificacoes_aplicaveis: { type: "array", items: { type: "string" } },
+      isento_metais_pesados: { type: "array", items: { type: "string" } },
+      isento_substancias: { type: "array", items: { type: "string" } },
+      diferenciais_chave: { type: "array", items: { type: "string" } },
+      uso_recomendado: { type: ["string", "null"] },
+      publico_alvo: { type: ["string", "null"] },
+      extraction_confidence: { type: "number", minimum: 0, maximum: 1 },
+      extraction_gaps: { type: "array", items: { type: "string" } },
+    },
+    required: [
+      "product_code",
+      "product_name",
+      "supplier",
+      "extraction_confidence",
+      "extraction_gaps",
+      "equipamentos_aplicacao",
+      "substrato",
+      "certificacoes_aplicaveis",
+      "isento_metais_pesados",
+      "isento_substancias",
+      "diferenciais_chave",
+    ],
+  },
+};
+
+Deno.serve(async (req) => {
+  if (req.method === "OPTIONS") return new Response(null, { headers: corsHeaders });
+
+  const auth = await authorizeCronOrStaff(req);
+  if (!auth.ok) return auth.response;
+
+  const apiKey = Deno.env.get("ANTHROPIC_API_KEY");
+  if (!apiKey) {
+    return new Response(JSON.stringify({ error: "ANTHROPIC_API_KEY not configured" }), {
+      status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+
+  const supabase = createClient(
+    Deno.env.get("SUPABASE_URL")!,
+    Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!,
+  );
+
+  let body;
+  try { body = await req.json(); } catch {
+    return new Response(JSON.stringify({ error: "Invalid JSON" }), {
+      status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+  if (!body.documentId) {
+    return new Response(JSON.stringify({ error: "documentId required" }), {
+      status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+
+  try {
+    const { data: doc, error } = await supabase
+      .from("kb_documents")
+      .select("id, title, product_code, supplier, content_extracted, status")
+      .eq("id", body.documentId)
+      .single();
+
+    if (error || !doc) {
+      return new Response(JSON.stringify({ error: "Document not found" }), {
+        status: 404, headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    if (doc.status !== "ready" || !doc.content_extracted) {
+      return new Response(JSON.stringify({ error: "Document not ready or has no extracted content" }), {
+        status: 422, headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    const client = new Anthropic({ apiKey });
+
+    const userMsg = `Extraia os specs estruturados deste boletim técnico:
+
+# Metadata
+- Título: ${doc.title}
+- Código produto (hint): ${doc.product_code ?? "(não informado)"}
+- Fornecedor: ${doc.supplier ?? "sayerlack"}
+
+# Texto extraído
+${doc.content_extracted.slice(0, 50_000)}
+
+Use a tool extract_product_specs.`;
+
+    const response = await client.messages.create({
+      model: "claude-sonnet-4-6",
+      max_tokens: 4000,
+      system: [{
+        type: "text",
+        text: SYSTEM_PROMPT_EXTRACT_SPECS,
+        cache_control: { type: "ephemeral" },
+      }],
+      tools: [EXTRACT_TOOL],
+      tool_choice: { type: "tool", name: "extract_product_specs" },
+      messages: [{ role: "user", content: userMsg }],
+    });
+
+    const toolUse = response.content.find((b) => b.type === "tool_use");
+    if (!toolUse || toolUse.type !== "tool_use") {
+      return new Response(JSON.stringify({ error: "No tool_use in response", raw: response }), {
+        status: 502, headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    return new Response(JSON.stringify({
+      specs: toolUse.input,
+      usage: {
+        inputTokens: response.usage.input_tokens,
+        outputTokens: response.usage.output_tokens,
+        cacheCreationTokens: response.usage.cache_creation_input_tokens ?? 0,
+        cacheReadTokens: response.usage.cache_read_input_tokens ?? 0,
+      },
+    }), { headers: { ...corsHeaders, "Content-Type": "application/json" } });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "unknown error";
+    console.error("[kb-extract-specs]", msg);
+    return new Response(JSON.stringify({ error: msg }), {
+      status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+});

--- a/supabase/migrations/20260517180000_kb_specs_and_competitors.sql
+++ b/supabase/migrations/20260517180000_kb_specs_and_competitors.sql
@@ -1,0 +1,213 @@
+-- PR6b: KB specs + competitors skeleton
+
+-- 1. Tabela de specs estruturados (1 row por produto da Sayerlack/Colacor)
+CREATE TABLE IF NOT EXISTS public.kb_product_specs (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  document_id uuid REFERENCES public.kb_documents(id) ON DELETE SET NULL,
+  product_code text NOT NULL UNIQUE,        -- ex: 'FO20.6827.00'
+  product_name text NOT NULL,
+  supplier text NOT NULL DEFAULT 'sayerlack',
+  product_line text,                         -- 'wood_pu' | 'wood_nitro' | 'hydropoxi' | 'auto'
+  product_category text,                     -- 'primer' | 'verniz' | 'tinta' | 'catalisador' | 'diluente'
+
+  -- Propriedades físico-químicas
+  densidade_g_cm3 numeric,
+  solidos_pct numeric,
+  viscosidade_aplicacao_s numeric,
+  viscosidade_copo text,                     -- 'CF4' | 'CF6' | 'CF8'
+  brilho_ub numeric,                         -- unidades de brilho
+  dureza text,                               -- '3H', '2H' etc.
+
+  -- Aplicação
+  rendimento_m2_por_litro numeric,           -- calculado ou explícito
+  demaos_recomendadas integer,
+  gramatura_g_m2_min integer,
+  gramatura_g_m2_max integer,
+  pot_life_horas numeric,
+  temp_aplicacao_c_min numeric,
+  temp_aplicacao_c_max numeric,
+  umidade_aplicacao_pct_min numeric,
+  umidade_aplicacao_pct_max numeric,
+
+  -- Compatibilidade
+  catalisador_codigo text,                   -- ex: 'FC.6952'
+  catalisador_proporcao_pct numeric,
+  diluente_codigo text,                      -- ex: 'DF.4068'
+  equipamentos_aplicacao text[],             -- ['pistola_convencional', 'tanque_pressao']
+  lixa_recomendada text,
+  substrato text[],                          -- ['madeira', 'mdf']
+
+  -- Secagem
+  secagem_manuseio_h numeric,
+  secagem_empilhamento_h numeric,
+  secagem_total_h numeric,
+
+  -- Armazenamento
+  validade_dias integer,
+  temp_armazenamento_c_min integer,
+  temp_armazenamento_c_max integer,
+
+  -- Compliance
+  certificacoes_aplicaveis text[],           -- ['IKEA', 'LGA', 'Proposition_65']
+  isento_metais_pesados text[],              -- ['Cd', 'Pb', etc.]
+  isento_substancias text[],                 -- ['amianto', 'formaldeido']
+
+  -- Notas qualitativas
+  diferenciais_chave text[],                 -- ['resistencia_risco_superior', 'toque_sedoso']
+  uso_recomendado text,
+  publico_alvo text,
+
+  -- Metadata
+  extraction_confidence numeric,             -- 0-1 (Claude reporta)
+  extraction_gaps text[],                    -- campos que Claude não conseguiu extrair
+  extracted_by uuid REFERENCES auth.users(id),
+  approved_by uuid REFERENCES auth.users(id),
+  approved_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- 2. Concorrentes (vazio — populado por PR8)
+CREATE TABLE IF NOT EXISTS public.kb_competitors (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  name text NOT NULL UNIQUE,                 -- 'Farben Tintas', 'Vernit', 'Rosalen'
+  tipo text CHECK (tipo IN ('regional', 'nacional', 'importado')),
+  regiao_principal text,                     -- 'mg', 'sul', 'sp', 'nacional'
+  segmento_atuacao text[],                   -- ['moveleiro', 'industrial', 'automotivo']
+  notas_estrategicas text,
+  created_by uuid REFERENCES auth.users(id),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- 3. Produtos do concorrente (vazio — populado via UI ou auto-detect)
+CREATE TABLE IF NOT EXISTS public.kb_competitor_products (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  competitor_id uuid NOT NULL REFERENCES public.kb_competitors(id) ON DELETE CASCADE,
+  product_name text NOT NULL,
+  category text,                             -- mesmo enum de kb_product_specs.product_category
+  rendimento_m2_por_litro numeric,
+  solidos_pct numeric,
+  pot_life_horas numeric,
+  validade_dias integer,
+  preco_referencia_l numeric,
+  preco_atualizado_em timestamptz,
+  fonte_preco text CHECK (fonte_preco IN ('vendedor', 'cotacao', 'site', 'estimado', 'detectado_ia')),
+  pontos_fortes text[],
+  pontos_fracos text[],
+  nosso_equivalente_product_code text,       -- referência cruzada com nossos kb_product_specs.product_code
+  argumentos_comparativos jsonb,             -- estrutura aberta pra flexibilidade
+  created_by uuid REFERENCES auth.users(id),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- 4. Indexes
+CREATE INDEX IF NOT EXISTS idx_kb_product_specs_product_code ON public.kb_product_specs (product_code);
+CREATE INDEX IF NOT EXISTS idx_kb_product_specs_supplier_line ON public.kb_product_specs (supplier, product_line);
+CREATE INDEX IF NOT EXISTS idx_kb_competitor_products_competitor ON public.kb_competitor_products (competitor_id);
+CREATE INDEX IF NOT EXISTS idx_kb_competitor_products_equivalent ON public.kb_competitor_products (nosso_equivalente_product_code);
+
+-- 5. Triggers updated_at (reusa função do PR6a se existir; senão cria)
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_proc WHERE proname = 'kb_documents_set_updated_at') THEN
+    CREATE OR REPLACE FUNCTION public.kb_documents_set_updated_at()
+    RETURNS trigger AS $func$
+    BEGIN NEW.updated_at = now(); RETURN NEW; END;
+    $func$ LANGUAGE plpgsql;
+  END IF;
+END $$;
+
+DROP TRIGGER IF EXISTS trg_kb_product_specs_updated_at ON public.kb_product_specs;
+CREATE TRIGGER trg_kb_product_specs_updated_at
+  BEFORE UPDATE ON public.kb_product_specs
+  FOR EACH ROW EXECUTE FUNCTION public.kb_documents_set_updated_at();
+
+DROP TRIGGER IF EXISTS trg_kb_competitors_updated_at ON public.kb_competitors;
+CREATE TRIGGER trg_kb_competitors_updated_at
+  BEFORE UPDATE ON public.kb_competitors
+  FOR EACH ROW EXECUTE FUNCTION public.kb_documents_set_updated_at();
+
+DROP TRIGGER IF EXISTS trg_kb_competitor_products_updated_at ON public.kb_competitor_products;
+CREATE TRIGGER trg_kb_competitor_products_updated_at
+  BEFORE UPDATE ON public.kb_competitor_products
+  FOR EACH ROW EXECUTE FUNCTION public.kb_documents_set_updated_at();
+
+-- 6. RLS — staff lê, master CRUD
+ALTER TABLE public.kb_product_specs ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.kb_competitors ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.kb_competitor_products ENABLE ROW LEVEL SECURITY;
+
+-- kb_product_specs
+CREATE POLICY "kb_product_specs_select_staff" ON public.kb_product_specs
+  FOR SELECT
+  USING (
+    public.has_role(auth.uid(), 'employee'::app_role)
+    OR public.has_role(auth.uid(), 'master'::app_role)
+  );
+CREATE POLICY "kb_product_specs_insert_staff" ON public.kb_product_specs
+  FOR INSERT
+  WITH CHECK (
+    public.has_role(auth.uid(), 'employee'::app_role)
+    OR public.has_role(auth.uid(), 'master'::app_role)
+  );
+CREATE POLICY "kb_product_specs_update_master" ON public.kb_product_specs
+  FOR UPDATE
+  USING (
+    public.has_role(auth.uid(), 'master'::app_role)
+    OR extracted_by = auth.uid()
+  );
+CREATE POLICY "kb_product_specs_delete_master" ON public.kb_product_specs
+  FOR DELETE
+  USING (public.has_role(auth.uid(), 'master'::app_role));
+
+-- kb_competitors
+CREATE POLICY "kb_competitors_select_staff" ON public.kb_competitors
+  FOR SELECT
+  USING (
+    public.has_role(auth.uid(), 'employee'::app_role)
+    OR public.has_role(auth.uid(), 'master'::app_role)
+  );
+CREATE POLICY "kb_competitors_insert_staff" ON public.kb_competitors
+  FOR INSERT
+  WITH CHECK (
+    public.has_role(auth.uid(), 'employee'::app_role)
+    OR public.has_role(auth.uid(), 'master'::app_role)
+  );
+CREATE POLICY "kb_competitors_update_staff" ON public.kb_competitors
+  FOR UPDATE
+  USING (
+    public.has_role(auth.uid(), 'employee'::app_role)
+    OR public.has_role(auth.uid(), 'master'::app_role)
+  );
+CREATE POLICY "kb_competitors_delete_master" ON public.kb_competitors
+  FOR DELETE
+  USING (public.has_role(auth.uid(), 'master'::app_role));
+
+-- kb_competitor_products
+CREATE POLICY "kb_competitor_products_select_staff" ON public.kb_competitor_products
+  FOR SELECT
+  USING (
+    public.has_role(auth.uid(), 'employee'::app_role)
+    OR public.has_role(auth.uid(), 'master'::app_role)
+  );
+CREATE POLICY "kb_competitor_products_insert_staff" ON public.kb_competitor_products
+  FOR INSERT
+  WITH CHECK (
+    public.has_role(auth.uid(), 'employee'::app_role)
+    OR public.has_role(auth.uid(), 'master'::app_role)
+  );
+CREATE POLICY "kb_competitor_products_update_staff" ON public.kb_competitor_products
+  FOR UPDATE
+  USING (
+    public.has_role(auth.uid(), 'employee'::app_role)
+    OR public.has_role(auth.uid(), 'master'::app_role)
+  );
+CREATE POLICY "kb_competitor_products_delete_master" ON public.kb_competitor_products
+  FOR DELETE
+  USING (public.has_role(auth.uid(), 'master'::app_role));
+
+-- 7. Comentários
+COMMENT ON TABLE public.kb_product_specs IS 'Specs estruturados extraídos de kb_documents via Claude. 1 row por produto Sayerlack.';
+COMMENT ON TABLE public.kb_competitors IS 'Concorrentes regionais/nacionais. Populado por vendedores via UI ou auto-detect de transcripts.';
+COMMENT ON TABLE public.kb_competitor_products IS 'Produtos específicos dos concorrentes com specs comparáveis aos nossos.';


### PR DESCRIPTION
## Problema

**PR #65 (PR6b)** e **PR #66 (PR6c)** aparecem como MERGED no GitHub mas **não estão em main**. Foram mergeados em branches stacked (`claude/pr6a-knowledge-base-foundation` e `claude/pr6b-kb-extract-specs`) que viraram órfãs quando #63 (PR6a) foi mergeado direto em main.

Resultado: tabelas `kb_product_specs` + `kb_competitors` + `kb_competitor_products` existem **no banco** (você rodou o SQL), mas o **código TypeScript pra usá-las não chegou em main**:
- ❌ Edge function `kb-extract-specs` não deployada
- ❌ Página `/admin/calculadora` não existe na rota
- ❌ Item de menu "Calculadora" não aparece
- ❌ Botão "Extrair specs com IA" no detail do KB não existe

## Solução (esta PR)

Merge das branches `claude/pr6c-rendimento-calculator` (que herda transitivamente o PR6b) direto em main, com 3 conflitos resolvidos:

| Conflito | Resolução |
|---|---|
| `App.tsx` rotas | Mantém ambas — rotas PR-P2 (standard-processes) + PR6c (calculadora) |
| `AppShell.tsx` menu | Mantém ambos — itens "Processos padrão" + "Calculadora de rendimento" |
| `useKbProductSpecsList.ts` | Pega versão REAL do PR6c (não o stub do PR-P2) |

## Conteúdo (10 commits do PR6b + PR6c)

**PR6b:**
- Migration `kb_specs_and_competitors` (3 tabelas) — **já rodada no banco**
- Edge function `kb-extract-specs/index.ts` (Claude Sonnet 4.6 + tool use)
- `KbProductSpec`, `KbCompetitor`, `KbCompetitorProduct` types
- Hooks: `useExtractSpecs`, `useSaveProductSpecs`, `useKbProductSpecs`
- Components: `KbSpecsForm` (RHF + Zod, 8 fieldsets, ~45 campos), `KbSpecsExtractButton`
- Wire em `AdminKnowledgeBaseDetail.tsx` (botão "Extrair specs com IA" + preview de 9 KPIs)

**PR6c:**
- Helper `calculate-rendimento.ts` + 6 tests (fallback densidade+gramatura)
- Hook `useKbProductSpecsList`
- Component `RendimentoCalculator`
- Page `AdminCalculadora` + rota + item de menu

## Pré-requisito de deploy (já feito antes!)

Você já rodou:
- ✅ Migration do PR6b (3 tabelas + 12 RLS confirmadas)
- ✅ `OPENAI_API_KEY` configurada (não precisa pra este PR, mas pro KB ingest)
- ✅ `ANTHROPIC_API_KEY` configurada

**Nada novo precisa ser rodado**. Tabelas já existem, edge function vai ser deployada pelo Lovable automaticamente quando este PR mergear.

## Testes

- 241 → 250 (+9 do PR6c calculateRendimento)
- tsc clean ✅
- bun build passa ✅

## Como funciona depois do merge

1. Menu Gestão ganha 2 novos items: "Base de conhecimento" (já tinha) + "Calculadora de rendimento" + "Processos padrão" (do PR-P2)
2. Em `/admin/knowledge-base/:id`, documento `status='ready'` mostra seção "Specs estruturados" com botão "Extrair specs com IA"
3. Clica → Claude lê → propõe ~45 campos → admin revisa via `KbSpecsForm` → "Aprovar e salvar"
4. Em `/admin/calculadora`, vendedor escolhe produto aprovado + área m² → vê cálculo automático (rendimento, demãos, catalisador, diluente)

🤖 Generated with [Claude Code](https://claude.com/claude-code)