### PR TITLE
docs: Lovable migrations workflow + publish checklist

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -255,6 +255,27 @@ Dois backends coexistem; o usuário escolhe via toggle em `/settings`:
 
 - `src/lib/logger.ts` — wrapper estruturado com níveis (info/error/critical), usado consistente em AuthContext
 
+### Migrations Supabase — ⚠️ aplicação manual obrigatória
+
+**Lovable Cloud NÃO aplica automaticamente** migrations que você commita em `supabase/migrations/`. Confirmado experimentalmente em 2026-05-17:
+
+- Migrations geradas pelo Lovable (formato `_UUID.sql`, ex: `_868822bb-e38c-4fcf-8879-c64e48bd7630.sql`) rodam quando você usa o builder visual dele
+- Migrations com nome custom (`_user_departments.sql`, `_dashboard_visits.sql`, `_enable_realtime_dashboard_v3.sql`) commitadas via PR **ficam só no repo** e não tocam o banco
+
+**Workflow obrigatório quando criar migration custom**:
+
+1. Cria o arquivo em `supabase/migrations/YYYYMMDDHHMMSS_<nome>.sql`
+2. Mergeia o PR normal (commit fica no histórico do código)
+3. **Aplica manualmente**: Supabase Dashboard (via Lovable Cloud) → SQL Editor → New query → cola conteúdo → Run
+4. Valida com query tipo `SELECT EXISTS(SELECT 1 FROM pg_tables WHERE tablename = '<nova_tabela>')`
+
+**Migrations já criadas e que precisaram aplicação manual** (referência):
+- `20260517100000_enable_realtime_dashboard_v3.sql` — Realtime publication pras 4 tabelas Dashboard V3
+- `20260517120000_user_departments.sql` — schema `user_departments`
+- `20260517140000_dashboard_visits.sql` — schema `dashboard_visits`
+
+**Sempre que adicionar migration nova**: avisar no PR description "**ATENÇÃO: migration manual necessária**" e idealmente colar o SQL no body do PR pra facilitar.
+
 ### Convenções de código
 
 - Pages em PascalCase (`AdminReposicaoCockpit.tsx`)


### PR DESCRIPTION
## Summary

2 docs operacionais que protegem futuras publicações + ajudam o user no fluxo pré/pós-deploy:

### 1. CLAUDE.md §5 — nota sobre Lovable migrations

Aprendizado experimental de 2026-05-17 ([issue #56](https://github.com/LucasSardenbergL/afiacao/issues/56)):

**Lovable Cloud NÃO aplica automaticamente** migrations commitadas em PRs quando têm nome custom. Só roda automaticamente as suas próprias (formato `_UUID.sql` gerado pelo builder).

Adiciona workflow obrigatório em 4 passos + lista as 3 migrations já aplicadas manualmente como referência. PRs futuros precisam avisar "MIGRATION MANUAL NECESSÁRIA".

### 2. Novo doc: `2026-05-17-publish-checklist.md`

Checklist completo cobrindo:

- **Pré-publicação** no Lovable preview:
  - Dashboard `/` (Brief + Cockpit + persona/empresa/atalhos)
  - `/admin/departments`
  - `/recebimento` offline-first (DevTools Network → Offline)
  - Sanity check com `NODE_ENV=production` local

- **Pós-publicação** no app publicado:
  - Verificar PostHog Live events recebendo
  - Atribuir departments pros 10-20 staff (~15min)
  - Smoke final

- **Acompanhamento** 2-4 dias

- **Volta pra Issue #56** quando dado acumular

- **Troubleshooting** comum (LiveBadge sumido, erro `relation does not exist`, PostHog vazio)

## Stats
- 2 docs novos / 1 doc atualizado
- Zero código
- Zero risco

## Bonus desta sessão (não nesta PR mas relacionado)

- ✅ Branch protection ativada em `main` (validate required) — protege PR vermelho
- ✅ Realtime publication completa (4 tabelas adicionadas manualmente hoje)

🤖 Generated with [Claude Code](https://claude.com/claude-code)