### PR TITLE
feat(typescript): wave 2 elimina any em 7 Edge Functions (-87 lint errors)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -494,3 +494,18 @@ Há muitas skills instaladas (gstack ~40 comandos, superpowers 14, catálogo de 
 **Colisão de nome conhecida:** existe `/review` do gstack e `review` do plugin oficial code-review. Tratamos o **`/review` do gstack como o canônico** para revisão de diff. Se o comando errado disparar, invocar explicitamente via gstack.
 
 Esta tabela é viva — ao instalar/remover skill, atualizar aqui.
+
+---
+
+## 13. Health Stack (usado por `/health`)
+
+Persistido em 2026-05-17 após primeira run completa do skill com sucesso.
+
+- **typecheck**: `bun run typecheck:strict` (incremental strict em `tsconfig.strict.json`) + `bunx tsc --noEmit` (baseline com `strict: false`)
+- **lint**: `bun lint` (eslint flat config)
+- **test**: `bun run test` (vitest run) — canônico, é o que CI executa. `bun test` (runner nativo) cobre só parte por causa de jsdom incompleto + `vi.hoisted/mocked/importActual` não suportados; bunfig.toml + src/test/bun-setup.ts polifillam localStorage/MediaStream/matchMedia mas alguns testes ainda falham. Sempre `bun run test` pra resultado oficial. Ver §2 pro detalhe.
+- **deadcode**: `bunx knip --reporter compact`. ⚠️ Ignorar a seção "Unlisted dependencies (38)" — são imports `npm:` das Edge Functions Deno, false-positive pro runtime Node.
+- **shell**: `shellcheck scripts/*.sh .claude/hooks/*.sh` (só 2 arquivos; `brew install shellcheck` se ainda não tiver).
+- **gbrain**: não configurado neste projeto.
+
+**Pre-flight**: worktrees novos precisam de `bun install` antes de `/health` (~3s pra extrair 955 packages).

--- a/supabase/functions/enviar-pedido-portal-sayerlack/index.ts
+++ b/supabase/functions/enviar-pedido-portal-sayerlack/index.ts
@@ -2,7 +2,7 @@
 // Automatiza envio de pedidos aprovados (OBEN -> Sayerlack) via Browserless.io
 // Modos: ECO (validacao), lote (cron), individual (manual)
 
-import { createClient } from "npm:@supabase/supabase-js@2.45.0";
+import { createClient, type SupabaseClient } from "npm:@supabase/supabase-js@2.45.0";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -1281,8 +1281,46 @@ interface ProcessResult {
   duracao_ms: number;
 }
 
+interface PostgrestErrorLike {
+  message: string;
+  code?: string;
+  details?: string;
+}
+
+interface PedidoItemDireto {
+  id: number;
+  sku_codigo_omie: string;
+  sku_descricao: string;
+  qtde_final: number | string;
+}
+
+interface SkuFornecedorExternoRow {
+  sku_omie: string;
+  sku_portal: string | null;
+  unidade_portal: string | null;
+  fator_conversao: number | string | null;
+  ativo: boolean | null;
+}
+
+interface BrowserlessEnvelope {
+  evidence?: Record<string, unknown>;
+  elapsedMs?: number;
+  preLoginScreenshotUrl?: string | null;
+  portal_data_entrega?: string;
+  [key: string]: unknown;
+}
+
+interface BrowserlessResponse {
+  data?: BrowserlessEnvelope;
+  type?: string;
+  screenshot?: string | null;
+  preLoginScreenshot?: string | null;
+  raw?: string;
+  [key: string]: unknown;
+}
+
 async function uploadScreenshot(
-  supabase: ReturnType<typeof createClient>,
+  supabase: SupabaseClient,
   pedidoId: number,
   base64: string,
   suffix: string = "",
@@ -1337,15 +1375,15 @@ async function registrarPedidoOmieAposPortal(pedido: PedidoCandidato) {
       return;
     }
     console.log(`[envio-portal] Pedido #${pedido.id}: Omie acionado apos portal [${resp.status}] ${text.slice(0, 300)}`);
-  } catch (e: any) {
-    console.error(`[envio-portal] Pedido #${pedido.id}: excecao ao registrar Omie apos portal`, e?.message ?? e);
+  } catch (e) {
+    console.error(`[envio-portal] Pedido #${pedido.id}: excecao ao registrar Omie apos portal`, e instanceof Error ? e.message : String(e));
   }
 }
 
 // PR1: grava uma linha de auditoria em pedidos_portal_tentativas.
 // Best-effort — uma falha aqui nunca aborta o processamento do pedido.
 async function gravarTentativa(
-  supabase: ReturnType<typeof createClient>,
+  supabase: SupabaseClient,
   pedidoId: number,
   params: {
     iniciadoEm: string;
@@ -1370,13 +1408,13 @@ async function gravarTentativa(
     if (error) {
       console.error(`[envio-portal] Pedido #${pedidoId}: falha ao gravar tentativa de auditoria:`, error.message);
     }
-  } catch (e: any) {
-    console.error(`[envio-portal] Pedido #${pedidoId}: excecao ao gravar tentativa de auditoria:`, e?.message ?? e);
+  } catch (e) {
+    console.error(`[envio-portal] Pedido #${pedidoId}: excecao ao gravar tentativa de auditoria:`, e instanceof Error ? e.message : String(e));
   }
 }
 
 async function processarPedido(
-  supabase: ReturnType<typeof createClient>,
+  supabase: SupabaseClient,
   pedido: PedidoCandidato,
 ): Promise<ProcessResult> {
   const t0 = Date.now();
@@ -1411,7 +1449,7 @@ async function processarPedido(
   console.log("[DEBUG_RPC] tentando RPC envio_portal_itens_mapeados, pedido_id=", pedido.id);
   const { data: itens, error: itensErr } = await supabase.rpc("envio_portal_itens_mapeados", {
     p_pedido_id: pedido.id,
-  }).select("*") as unknown as { data: ItemMapeado[] | null; error: any };
+  }).select("*") as unknown as { data: ItemMapeado[] | null; error: PostgrestErrorLike | null };
 
   let itensList: ItemMapeado[] | null = itens;
   console.log("[DEBUG_RPC_RESULT]", JSON.stringify({
@@ -1423,7 +1461,7 @@ async function processarPedido(
   }));
   // Fallback: query direta caso RPC nao exista
   if (itensErr || !itensList) {
-    const { data: itensDirect, error: e2 } = await supabase
+    const { data: itensDirectRaw, error: e2 } = await supabase
       .from("pedido_compra_item")
       .select(`
         id,
@@ -1433,7 +1471,8 @@ async function processarPedido(
       `)
       .eq("pedido_id", pedido.id)
       .order("id", { ascending: true });
-    if (e2 || !itensDirect) {
+    const itensDirect = (itensDirectRaw ?? []) as unknown as PedidoItemDireto[];
+    if (e2 || !itensDirectRaw) {
       // Erro de banco ao buscar itens — transiente, nenhum POST foi enviado.
       result.erro = `Erro ao buscar itens: ${e2?.message ?? "desconhecido"}`;
       result.tentativas += 1;
@@ -1456,31 +1495,32 @@ async function processarPedido(
       result.duracao_ms = Date.now() - t0;
       return result;
     }
-    const skus = itensDirect.map((i: any) => i.sku_codigo_omie);
+    const skus = itensDirect.map((i) => i.sku_codigo_omie);
     console.log("[DEBUG_FALLBACK_ITENS]", JSON.stringify({
       pedido_id: pedido.id,
       pedido_empresa: pedido.empresa,
       itensDirect_count: itensDirect?.length ?? 0,
       skus_extraidos: skus,
     }));
-    const { data: maps, error: mapsErr } = await supabase
+    const { data: mapsRaw, error: mapsErr } = await supabase
       .from("sku_fornecedor_externo")
       .select("sku_omie, sku_portal, unidade_portal, fator_conversao, ativo")
       .eq("empresa", pedido.empresa)
       .ilike("fornecedor_nome", "%SAYERLACK%")
       .in("sku_omie", skus);
+    const maps = (mapsRaw ?? []) as unknown as SkuFornecedorExternoRow[];
     console.log("[DEBUG_FALLBACK_MAPS]", JSON.stringify({
       pedido_id: pedido.id,
       filtro_empresa: pedido.empresa,
       filtro_fornecedor_pattern: '%SAYERLACK%',
       filtro_skus: skus,
-      maps_count: maps?.length ?? 0,
-      maps_amostra: (maps ?? []).slice(0, 3).map((m: any) => ({ sku_omie: m.sku_omie, sku_portal: m.sku_portal, ativo: m.ativo })),
+      maps_count: maps.length,
+      maps_amostra: maps.slice(0, 3).map((m) => ({ sku_omie: m.sku_omie, sku_portal: m.sku_portal, ativo: m.ativo })),
       mapsErr: mapsErr ? { message: mapsErr.message, code: mapsErr.code } : null,
     }));
-    const mapByOmie = new Map<string, any>();
-    (maps ?? []).forEach((m: any) => mapByOmie.set(m.sku_omie, m));
-    itensList = itensDirect.map((i: any) => {
+    const mapByOmie = new Map<string, SkuFornecedorExternoRow>();
+    maps.forEach((m) => mapByOmie.set(m.sku_omie, m));
+    itensList = itensDirect.map((i) => {
       const m = mapByOmie.get(i.sku_codigo_omie);
       return {
         item_id: i.id,
@@ -1576,7 +1616,7 @@ async function processarPedido(
   // 5. Invocar Browserless
   const tBrowserless = Date.now();
   let httpStatus = 0;
-  let bResp: any = null;
+  let bResp: BrowserlessResponse | null = null;
   let httpErr: string | null = null;
 
   try {
@@ -1606,12 +1646,12 @@ async function processarPedido(
     httpStatus = resp.status;
     const txt = await resp.text();
     try {
-      bResp = JSON.parse(txt);
+      bResp = JSON.parse(txt) as BrowserlessResponse;
     } catch {
       bResp = { raw: txt };
     }
-  } catch (e: any) {
-    httpErr = e?.message ?? String(e);
+  } catch (e) {
+    httpErr = e instanceof Error ? e.message : String(e);
   }
   const browserlessMs = Date.now() - tBrowserless;
   console.log(`[envio-portal] Pedido #${pedido.id}: Browserless retornou em ${browserlessMs}ms — status=${httpStatus}`);
@@ -1648,10 +1688,10 @@ async function processarPedido(
 
   // Extrair envelope estruturado (PR1): o script sempre devolve
   // { data: <envelope>, type, screenshot, preLoginScreenshot }.
-  const envelope = (bResp?.data ?? bResp ?? {}) as Record<string, any>;
+  const envelope: BrowserlessEnvelope = (bResp?.data ?? (bResp as BrowserlessEnvelope | null) ?? {}) as BrowserlessEnvelope;
   const screenshotB64: string | null = bResp?.screenshot ?? null;
   const preLoginScreenshotB64: string | null = bResp?.preLoginScreenshot ?? null;
-  const evidence = (envelope?.evidence ?? {}) as Record<string, any>;
+  const evidence: Record<string, unknown> = (envelope?.evidence ?? {}) as Record<string, unknown>;
   const requestSent = evidence?.requestSent === true;
 
   // Upload de screenshots (instrumentacao — comportamento inalterado)
@@ -1707,7 +1747,7 @@ async function processarPedido(
     // PR4: persiste a data_entrega devolvida pelo portal (formato ISO YYYY-MM-DD).
     // Só grava se veio um valor válido — não sobrescreve com null em re-tentativas
     // que não capturaram a data (ex.: caminho PR1.5 do recorder fallback).
-    const portalDataEntrega = (envelope as any)?.portal_data_entrega;
+    const portalDataEntrega = envelope?.portal_data_entrega;
     if (typeof portalDataEntrega === "string" && /^\d{4}-\d{2}-\d{2}$/.test(portalDataEntrega)) {
       update.portal_data_entrega = portalDataEntrega;
     }
@@ -1862,7 +1902,7 @@ async function authorizeCronOrStaff(req: Request): Promise<boolean> {
 // PR1: NUNCA reverte para pendente_envio_portal — um pedido travado em
 // enviando_portal pode ter submetido um POST antes de o task morrer. Sem
 // evidência, o destino seguro é conciliação manual.
-async function runWatchdog(supabase: any, minutos = 5) {
+async function runWatchdog(supabase: SupabaseClient, minutos = 5) {
   const cutoff = new Date(Date.now() - minutos * 60 * 1000).toISOString();
   const { data: stuck, error } = await supabase
     .from("pedido_compra_sugerido")
@@ -1901,7 +1941,7 @@ async function runWatchdog(supabase: any, minutos = 5) {
 // Processa lista de candidatos. Pode rodar em foreground (response síncrona)
 // ou em background via EdgeRuntime.waitUntil (modo async).
 async function processCandidatos(
-  supabase: any,
+  supabase: SupabaseClient,
   candidatos: PedidoCandidato[],
 ): Promise<{ detalhes: ProcessResult[]; sucesso: number; falhasDef: number; falhasTmp: number; indeterminados: number }> {
   const detalhes: ProcessResult[] = [];
@@ -1921,15 +1961,16 @@ async function processCandidatos(
       else if (r.status_final === "erro_retentavel" || r.status_final === "pendente_envio_portal") falhasTmp++;
       // aceito_portal_sem_protocolo/indeterminado = precisa conciliacao manual.
       else if (r.status_final === "aceito_portal_sem_protocolo" || r.status_final === "indeterminado_requer_conciliacao") indeterminados++;
-    } catch (e: any) {
-      console.error(`[envio-portal] Excecao no pedido #${p.id}:`, e?.message ?? e);
+    } catch (e) {
+      const errMsg = e instanceof Error ? e.message : String(e);
+      console.error(`[envio-portal] Excecao no pedido #${p.id}:`, errMsg);
       detalhes.push({
         pedido_id: p.id,
         status_inicial: p.status_envio_portal ?? "pendente_envio_portal",
         status_final: "erro_excecao",
         protocolo: null,
         tentativas: p.portal_tentativas ?? 0,
-        erro: e?.message ?? String(e),
+        erro: errMsg,
         screenshot_url: null,
         duracao_ms: 0,
       });
@@ -1953,11 +1994,11 @@ Deno.serve(async (req) => {
   const tStart = Date.now();
   console.log("[envio-portal] === Iniciando ===");
 
-  let body: any = {};
+  let body: Record<string, unknown> = {};
   try {
     if (req.method === "POST") {
       const txt = await req.text();
-      body = txt ? JSON.parse(txt) : {};
+      body = txt ? (JSON.parse(txt) as Record<string, unknown>) : {};
     }
   } catch {
     body = {};

--- a/supabase/functions/omie-analytics-sync/index.ts
+++ b/supabase/functions/omie-analytics-sync/index.ts
@@ -1,5 +1,5 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
-import { createClient } from "npm:@supabase/supabase-js@2";
+import { createClient, type SupabaseClient } from "npm:@supabase/supabase-js@2";
 import { authorizeCronOrStaff } from "../_shared/auth.ts";
 
 const corsHeaders = {
@@ -11,6 +11,107 @@ const corsHeaders = {
 const OMIE_API_URL = "https://app.omie.com.br/api/v1";
 
 type OmieAccount = "vendas" | "servicos" | "colacor_vendas";
+
+interface OmieClienteCadastro {
+  codigo_cliente_omie?: number;
+  codigo_cliente_integracao?: string | null;
+  codigo_vendedor?: number | null;
+  cnpj_cpf?: string;
+}
+
+interface OmieListarClientesResponse {
+  clientes_cadastro?: OmieClienteCadastro[];
+  total_de_paginas?: number;
+  faultstring?: string;
+}
+
+interface OmieImagemProduto {
+  url_imagem?: string;
+}
+
+interface OmieProdutoCadastro {
+  codigo_produto?: number;
+  codigo_produto_integracao?: string | null;
+  codigo?: string;
+  descricao?: string;
+  unidade?: string;
+  ncm?: string | null;
+  valor_unitario?: number;
+  quantidade_estoque?: number;
+  inativo?: string;
+  imagens?: OmieImagemProduto[];
+  descricao_familia?: string | null;
+  descricao_subfamilia?: string | null;
+  marca?: string;
+  modelo?: string;
+  peso_bruto?: number;
+  peso_liq?: number;
+  cfop?: string;
+}
+
+interface OmieListarProdutosResponse {
+  produto_servico_cadastro?: OmieProdutoCadastro[];
+  total_de_paginas?: number;
+  faultstring?: string;
+}
+
+interface OmiePedidoCabecalho {
+  codigo_cliente?: number;
+  numero_pedido?: string;
+  codigo_pedido?: number;
+}
+
+interface OmiePedidoProduto {
+  codigo_produto?: number;
+  quantidade?: number;
+  valor_unitario?: number;
+}
+
+interface OmiePedidoDet {
+  produto?: OmiePedidoProduto;
+}
+
+interface OmiePedidoVendaProduto {
+  cabecalho?: OmiePedidoCabecalho;
+  det?: OmiePedidoDet[];
+}
+
+interface OmieListarPedidosResponse {
+  pedido_venda_produto?: OmiePedidoVendaProduto[];
+  total_de_paginas?: number;
+  faultstring?: string;
+}
+
+interface OmieEstoqueProduto {
+  nCodProd?: number;
+  nSaldo?: number;
+  nCMC?: number;
+  nPrecoMedio?: number;
+}
+
+interface OmieListarPosEstoqueResponse {
+  produtos?: OmieEstoqueProduto[];
+  nTotPaginas?: number;
+  faultstring?: string;
+}
+
+interface OmieApiResponseBase {
+  faultstring?: string;
+  faultcode?: string;
+}
+
+interface ProductCostRow {
+  id: string;
+  product_id: string;
+  cost_price?: number;
+  cmc?: number;
+}
+
+interface InventoryPositionRow {
+  product_id: string | null;
+  cmc?: number;
+  saldo?: number;
+}
 
 function getCredentials(account: OmieAccount) {
   if (account === "vendas") {
@@ -32,7 +133,7 @@ function getCredentials(account: OmieAccount) {
   };
 }
 
-async function callOmie(account: OmieAccount, endpoint: string, call: string, params: Record<string, unknown>) {
+async function callOmie(account: OmieAccount, endpoint: string, call: string, params: Record<string, unknown>): Promise<OmieApiResponseBase> {
   const creds = getCredentials(account);
   if (!creds.key || !creds.secret) throw new Error(`Credenciais Omie (${account}) não configuradas`);
 
@@ -42,14 +143,14 @@ async function callOmie(account: OmieAccount, endpoint: string, call: string, pa
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
   });
-  const result = await res.json();
+  const result = (await res.json()) as OmieApiResponseBase;
   if (result.faultstring) throw new Error(`Omie (${account}): ${result.faultstring}`);
   return result;
 }
 
 // ======== SYNC STATE HELPERS ========
 
-async function getSyncState(db: any, entityType: string, account: string) {
+async function getSyncState(db: SupabaseClient, entityType: string, account: string) {
   const { data } = await db
     .from("sync_state")
     .select("*")
@@ -60,7 +161,7 @@ async function getSyncState(db: any, entityType: string, account: string) {
 }
 
 async function updateSyncState(
-  db: any,
+  db: SupabaseClient,
   entityType: string,
   account: string,
   updates: Record<string, unknown>
@@ -73,7 +174,7 @@ async function updateSyncState(
 
 // ======== SYNC CUSTOMERS ========
 
-async function syncCustomers(db: any, account: OmieAccount) {
+async function syncCustomers(db: SupabaseClient, account: OmieAccount) {
   await updateSyncState(db, "customers", account, { status: "running", error_message: null });
   let pagina = 1;
   let totalPaginas = 1;
@@ -81,11 +182,11 @@ async function syncCustomers(db: any, account: OmieAccount) {
 
   try {
     while (pagina <= totalPaginas) {
-      const result = await callOmie(account, "geral/clientes/", "ListarClientes", {
+      const result = (await callOmie(account, "geral/clientes/", "ListarClientes", {
         pagina,
         registros_por_pagina: 100,
         apenas_importado_api: "N",
-      }) as any;
+      })) as unknown as OmieListarClientesResponse;
 
       totalPaginas = result.total_de_paginas || 1;
       const clientes = result.clientes_cadastro || [];
@@ -148,7 +249,7 @@ async function syncCustomers(db: any, account: OmieAccount) {
 
 // ======== SYNC PRODUCTS ========
 
-async function syncProducts(db: any, account: OmieAccount, startPage = 1, maxPages = 10) {
+async function syncProducts(db: SupabaseClient, account: OmieAccount, startPage = 1, maxPages = 10) {
   await updateSyncState(db, "products", account, { status: "running", error_message: null });
   let pagina = startPage;
   let totalPaginas = startPage;
@@ -157,12 +258,12 @@ async function syncProducts(db: any, account: OmieAccount, startPage = 1, maxPag
 
   try {
     while (pagina <= totalPaginas && pagesProcessed < maxPages) {
-      const result = await callOmie(account, "geral/produtos/", "ListarProdutos", {
+      const result = (await callOmie(account, "geral/produtos/", "ListarProdutos", {
         pagina,
         registros_por_pagina: 100,
         apenas_importado_api: "N",
         filtrar_apenas_omiepdv: "N",
-      }) as any;
+      })) as unknown as OmieListarProdutosResponse;
 
       totalPaginas = result.total_de_paginas || 1;
       const produtos = result.produto_servico_cadastro || [];
@@ -170,7 +271,7 @@ async function syncProducts(db: any, account: OmieAccount, startPage = 1, maxPag
       if (account === "vendas" || account === "colacor_vendas") {
         // UPSERT — INCLUI inativos para refletir o flag `ativo` corretamente
         const acctValue = account === "colacor_vendas" ? "colacor" : "oben";
-        const rows = produtos.map((p: any) => ({
+        const rows = produtos.map((p) => ({
           omie_codigo_produto: p.codigo_produto,
           omie_codigo_produto_integracao: p.codigo_produto_integracao || null,
           codigo: p.codigo || `PROD-${p.codigo_produto}`,
@@ -232,7 +333,7 @@ async function syncProducts(db: any, account: OmieAccount, startPage = 1, maxPag
 
 // ======== SYNC ORDERS (INCREMENTAL) ========
 
-async function syncOrdersIncremental(db: any, account: OmieAccount) {
+async function syncOrdersIncremental(db: SupabaseClient, account: OmieAccount) {
   await updateSyncState(db, "orders", account, { status: "running", error_message: null });
 
   const state = await getSyncState(db, "orders", account);
@@ -262,7 +363,7 @@ async function syncOrdersIncremental(db: any, account: OmieAccount) {
         params.filtrar_por_data_ate = formatOmieDate(new Date());
       }
 
-      const result = await callOmie(account, "produtos/pedido/", "ListarPedidos", params) as any;
+      const result = (await callOmie(account, "produtos/pedido/", "ListarPedidos", params)) as unknown as OmieListarPedidosResponse;
       totalPaginas = result.total_de_paginas || 1;
       const pedidos = result.pedido_venda_produto || [];
 
@@ -350,7 +451,7 @@ async function syncOrdersIncremental(db: any, account: OmieAccount) {
 
 // ======== SYNC INVENTORY ========
 
-async function syncInventory(db: any, account: OmieAccount) {
+async function syncInventory(db: SupabaseClient, account: OmieAccount) {
   await updateSyncState(db, "inventory", account, { status: "running", error_message: null });
   let pagina = 1;
   let totalPaginas = 1;
@@ -358,11 +459,11 @@ async function syncInventory(db: any, account: OmieAccount) {
 
   try {
     while (pagina <= totalPaginas) {
-      const result = await callOmie(account, "estoque/consulta/", "ListarPosEstoque", {
+      const result = (await callOmie(account, "estoque/consulta/", "ListarPosEstoque", {
         nPagina: pagina,
         nRegPorPagina: 100,
         dDataPosicao: new Date().toLocaleDateString("pt-BR"),
-      }) as any;
+      })) as unknown as OmieListarPosEstoqueResponse;
 
       totalPaginas = result.nTotPaginas || 1;
       const produtos = result.produtos || [];
@@ -445,7 +546,7 @@ async function syncInventory(db: any, account: OmieAccount) {
 
 // ======== COMPUTE COSTS (Fallback Engine) ========
 
-async function computeCosts(db: any) {
+async function computeCosts(db: SupabaseClient) {
   // Load config
   const { data: configs } = await db.from("recommendation_config").select("key, value");
   const cfg: Record<string, number> = {};
@@ -461,14 +562,16 @@ async function computeCosts(db: any) {
   if (!products?.length) return { updated: 0 };
 
   // Get all product costs
-  const { data: costs } = await db.from("product_costs").select("*");
-  const costMap: Record<string, any> = {};
-  for (const c of costs || []) costMap[c.product_id] = c;
+  const { data: costsRaw } = await db.from("product_costs").select("*");
+  const costs = (costsRaw ?? []) as unknown as ProductCostRow[];
+  const costMap: Record<string, ProductCostRow> = {};
+  for (const c of costs) costMap[c.product_id] = c;
 
   // Get inventory for CMC
-  const { data: inventory } = await db.from("inventory_position").select("product_id, cmc, saldo");
-  const invMap: Record<string, any> = {};
-  for (const i of inventory || []) if (i.product_id) invMap[i.product_id] = i;
+  const { data: inventoryRaw } = await db.from("inventory_position").select("product_id, cmc, saldo");
+  const inventory = (inventoryRaw ?? []) as unknown as InventoryPositionRow[];
+  const invMap: Record<string, InventoryPositionRow> = {};
+  for (const i of inventory) if (i.product_id) invMap[i.product_id] = i;
 
   // Compute family average margins
   const familyMargins: Record<string, { totalMargin: number; count: number }> = {};
@@ -568,7 +671,7 @@ async function computeCosts(db: any) {
 
 // ======== COMPUTE ASSOCIATION RULES (Apriori-like) ========
 
-async function computeAssociationRules(db: any) {
+async function computeAssociationRules(db: SupabaseClient) {
   // Load config
   const { data: configs } = await db.from("recommendation_config").select("key, value");
   const cfg: Record<string, number> = {};

--- a/supabase/functions/omie-sync-vendas-items/index.ts
+++ b/supabase/functions/omie-sync-vendas-items/index.ts
@@ -7,6 +7,104 @@
 
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
 
+// ─── Type definitions ───
+
+/** Resposta genérica de uma chamada à API Omie nfconsultar */
+interface OmieNfResponseData {
+  faultstring?: string;
+  faultcode?: string;
+  total_de_paginas?: number;
+  nfCadastro?: OmieNfRecord[];
+  [k: string]: unknown;
+}
+
+/** Bloco prod (produto) dentro de det */
+interface OmieNfProd {
+  CFOP?: string | number;
+  cfop?: string | number;
+  cProd?: string;
+  xProd?: string;
+  NCM?: string;
+  uCom?: string;
+  qCom?: string | number;
+  vUnCom?: string | number;
+  vProd?: string | number;
+}
+
+/** Bloco nfProdInt (chaves internas Omie do produto) */
+interface OmieNfProdInt {
+  nCodProd?: number | string;
+  cCodProdInt?: string;
+}
+
+/** Item det (detalhe) de uma NF-e */
+interface OmieNfDetItem {
+  prod?: OmieNfProd;
+  nfProdInt?: OmieNfProdInt;
+  [k: string]: unknown;
+}
+
+/** Bloco ide (identificação) da NF-e */
+interface OmieNfIde {
+  nNF?: string | number;
+  serie?: string | number;
+  dEmi?: string;
+  [k: string]: unknown;
+}
+
+/** Bloco compl (complementares) da NF-e */
+interface OmieNfCompl {
+  cChaveNFe?: string;
+  [k: string]: unknown;
+}
+
+/** Bloco destinatário (nfDestInt ou dest) */
+interface OmieNfDest {
+  nCodCli?: number | string;
+  cRazao?: string;
+  cnpj_cpf?: string;
+  [k: string]: unknown;
+}
+
+/** Registro de NF-e retornado por ListarNF */
+interface OmieNfRecord {
+  ide?: OmieNfIde;
+  compl?: OmieNfCompl;
+  nfDestInt?: OmieNfDest;
+  dest?: OmieNfDest;
+  det?: OmieNfDetItem[];
+  [k: string]: unknown;
+}
+
+/** Linha pronta para inserir em venda_items_history */
+interface VendaItemHistoryRow {
+  empresa: string;
+  nfe_chave_acesso: string;
+  nfe_numero: string | null;
+  nfe_serie: string | null;
+  data_emissao: string;
+  cliente_codigo_omie: number | null;
+  cliente_razao_social: string | null;
+  cliente_cnpj_cpf: string | null;
+  cliente_uf: string | null;
+  cliente_cidade: string | null;
+  sku_codigo_omie: number;
+  sku_codigo: string | null;
+  sku_descricao: string | null;
+  sku_ncm: string | null;
+  sku_unidade: string | null;
+  quantidade: number;
+  valor_unitario: number | null;
+  valor_total: number | null;
+  cfop: string | null;
+  raw_data: unknown;
+}
+
+/** Linha já existente em venda_items_history (apenas chave usada no incremental) */
+interface VendaItemKeyRow {
+  nfe_chave_acesso: string | null;
+}
+
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
   "Access-Control-Allow-Headers":
@@ -70,7 +168,7 @@ function getOmieCreds(empresa: string): { app_key: string; app_secret: string } 
 interface OmieCallResult {
   ok: boolean;
   status: number;
-  data?: any;
+  data?: OmieNfResponseData;
   error?: string;
   apiBlocked?: boolean;
 }
@@ -79,7 +177,7 @@ async function omieCall(
   app_key: string,
   app_secret: string,
   call: string,
-  param: any,
+  param: Record<string, unknown>,
 ): Promise<OmieCallResult> {
   for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
     try {
@@ -111,9 +209,9 @@ async function omieCall(
       }
 
       const text = await res.text();
-      let data: any;
+      let data: OmieNfResponseData;
       try {
-        data = JSON.parse(text);
+        data = JSON.parse(text) as OmieNfResponseData;
       } catch {
         return { ok: false, status: res.status, error: `invalid JSON: ${text.slice(0, 200)}` };
       }
@@ -207,9 +305,9 @@ Deno.serve(async (req) => {
       console.error("Erro ao carregar chaves existentes:", existingErr);
     }
     const chavesExistentes = new Set<string>(
-      (existingRows ?? [])
-        .map((r: any) => r.nfe_chave_acesso)
-        .filter((k: string | null): k is string => !!k),
+      ((existingRows ?? []) as unknown as VendaItemKeyRow[])
+        .map((r) => r.nfe_chave_acesso)
+        .filter((k): k is string => !!k),
     );
     console.log(`[${empresa}] Chaves já processadas: ${chavesExistentes.size}`);
 
@@ -268,9 +366,9 @@ Deno.serve(async (req) => {
         continue;
       }
 
-      const data = result.data ?? {};
+      const data: OmieNfResponseData = result.data ?? {};
       totalPaginas = Number(data.total_de_paginas ?? 1);
-      const nfes = Array.isArray(data.nfCadastro) ? data.nfCadastro : [];
+      const nfes: OmieNfRecord[] = Array.isArray(data.nfCadastro) ? data.nfCadastro : [];
       nfes_listadas += nfes.length;
 
       // Diagnóstico do primeiro payload (apenas página 1)
@@ -308,10 +406,10 @@ Deno.serve(async (req) => {
         }
 
         try {
-          const ide = nf?.ide ?? {};
-          const compl = nf?.compl ?? {};
-          const dest = nf?.nfDestInt ?? nf?.dest ?? {};
-          const det: any[] = Array.isArray(nf?.det) ? nf.det : [];
+          const ide: OmieNfIde = nf?.ide ?? {};
+          const compl: OmieNfCompl = nf?.compl ?? {};
+          const dest: OmieNfDest = nf?.nfDestInt ?? nf?.dest ?? {};
+          const det: OmieNfDetItem[] = Array.isArray(nf?.det) ? nf.det : [];
 
           const chave: string = String(compl?.cChaveNFe ?? "").trim();
           const numero: string = String(ide?.nNF ?? "").trim();
@@ -343,7 +441,7 @@ Deno.serve(async (req) => {
 
           if (clienteCodigo) clientesDistintos.add(clienteCodigo);
 
-          const rows: any[] = [];
+          const rows: VendaItemHistoryRow[] = [];
           let itensValidosNesta = 0;
 
           for (const it of det) {
@@ -397,7 +495,7 @@ Deno.serve(async (req) => {
 
           if (rows.length > 0) {
             // Consolidar duplicatas (mesmo SKU 2x na mesma NF) somando qtd e valor_total
-            const dedup = new Map<number, any>();
+            const dedup = new Map<number, VendaItemHistoryRow>();
             for (const r of rows) {
               const key = r.sku_codigo_omie;
               const existing = dedup.get(key);
@@ -429,9 +527,10 @@ Deno.serve(async (req) => {
             nfes_processadas++;
             chavesExistentes.add(chave);
           }
-        } catch (err: any) {
+        } catch (err) {
           erros++;
-          console.error("Erro processando NF:", err?.message ?? err);
+          const msg = err instanceof Error ? err.message : String(err);
+          console.error("Erro processando NF:", msg);
         }
       }
 
@@ -462,10 +561,11 @@ Deno.serve(async (req) => {
       }),
       { status: 200, headers: { ...corsHeaders, "Content-Type": "application/json" } },
     );
-  } catch (err: any) {
+  } catch (err) {
     console.error("Fatal error:", err);
+    const msg = err instanceof Error ? err.message : String(err);
     return new Response(
-      JSON.stringify({ ok: false, error: err?.message ?? String(err) }),
+      JSON.stringify({ ok: false, error: msg }),
       { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } },
     );
   }

--- a/supabase/functions/omie-sync/index.ts
+++ b/supabase/functions/omie-sync/index.ts
@@ -1,5 +1,5 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
-import { createClient } from "npm:@supabase/supabase-js@2";
+import { createClient, type SupabaseClient } from "npm:@supabase/supabase-js@2";
 import { authorizeCronOrStaff } from "../_shared/auth.ts";
 // Resend usado via fetch direto à REST API (https://api.resend.com/emails) para evitar dep npm
 
@@ -20,6 +20,74 @@ interface OmieResponse {
   cCodIntCli?: string;
   nCodOS?: number;
   cNumOS?: string;
+}
+
+interface OmieClienteCadastro {
+  codigo_cliente_omie?: number;
+  codigo_cliente_integracao?: string | null;
+  razao_social?: string;
+  nome_fantasia?: string;
+  cnpj_cpf?: string;
+  email?: string;
+  telefone1_numero?: string;
+  codigo_vendedor?: number | null;
+  recomendacoes?: { codigo_vendedor?: number | null };
+}
+
+interface OmieListarClientesResponse {
+  clientes_cadastro?: OmieClienteCadastro[];
+  total_de_paginas?: number;
+  faultstring?: string;
+}
+
+interface OmieIncluirClienteResponse {
+  codigo_cliente_omie?: number;
+  nCodCli?: number;
+  faultstring?: string;
+}
+
+interface OmieServicoCadastro {
+  intListar?: { nCodServ?: number; cCodIntServ?: string };
+  descricao?: { cDescricao?: string; cDescrCompleta?: string };
+  cabecalho?: { cDescricao?: string; cIdTrib?: string; nValorUnit?: number; cUnidade?: string };
+  impostos?: { nCodServ?: string };
+  info?: { inativo?: string };
+}
+
+interface OmieListarServicosResponse {
+  cadastros?: OmieServicoCadastro[];
+  faultstring?: string;
+}
+
+interface OmieContaCorrente {
+  nCodCC?: number;
+  descricao?: string;
+  cDescricao?: string;
+  cCodCCInt?: string;
+  cNomeBanco?: string;
+  cAgencia?: string;
+  cNumeroConta?: string;
+  cTipo?: string;
+  tipo?: string;
+}
+
+interface OmieListarContasCorrentesResponse {
+  ListarContasCorrentes?: OmieContaCorrente[];
+  conta_corrente_lista?: OmieContaCorrente[];
+  faultstring?: string;
+}
+
+interface OmieConsultarOSResponse {
+  nCodOS?: number;
+  cNumOS?: string;
+  faultstring?: string;
+}
+
+interface ServicoLocalRow {
+  id: string;
+  omie_codigo_servico: number;
+  descricao: string;
+  inativo: boolean;
 }
 
 // Função para fazer chamadas à API do Omie
@@ -139,7 +207,7 @@ interface ClienteOmieResult {
 
 // Função para buscar cliente no Omie (apenas existentes)
 async function syncClienteOmie(
-  supabase: any,
+  supabase: SupabaseClient,
   userId: string,
   profile: {
     name: string;
@@ -185,15 +253,15 @@ async function syncClienteOmie(
   const searchResult = await callOmieApi(
     "geral/clientes/",
     "ListarClientes",
-    { 
-      pagina: 1, 
+    {
+      pagina: 1,
       registros_por_pagina: 1,
       clientesFiltro: {
         cnpj_cpf: documentClean
       }
     }
-  ) as any;
-  
+  ) as unknown as OmieListarClientesResponse;
+
   if (!searchResult.clientes_cadastro?.[0]?.codigo_cliente_omie) {
     // Cliente NÃO encontrado no Omie - não permitir criar pedido
     throw new Error(
@@ -226,7 +294,7 @@ async function syncClienteOmie(
 
 // Função para criar Ordem de Serviço no Omie
 async function criarOrdemServicoOmie(
-  supabase: any,
+  supabase: SupabaseClient,
   orderId: string,
   omieCodigoCliente: number,
   omieCodigoVendedor: number | undefined,
@@ -388,7 +456,7 @@ async function criarOrdemServicoOmie(
 
 // Função para alterar Ordem de Serviço no Omie
 async function alterarOrdemServicoOmie(
-  supabase: any,
+  supabase: SupabaseClient,
   orderId: string,
   order: {
     items: Array<{
@@ -598,7 +666,7 @@ serve(async (req) => {
                     codigo_cliente_omie: staffContext.customerOmieCode,
                   },
                 }
-              ) as any;
+              ) as unknown as OmieListarClientesResponse;
               const clienteOmie = searchResult.clientes_cadastro?.[0];
               omieCodigoVendedor = clienteOmie?.recomendacoes?.codigo_vendedor || clienteOmie?.codigo_vendedor || undefined;
             } catch (e) {
@@ -690,7 +758,7 @@ serve(async (req) => {
               registros_por_pagina: 1,
               clientesFiltro: { cnpj_cpf: documentClean },
             }
-          ) as any;
+          ) as unknown as OmieListarClientesResponse;
           const cliente = searchResult.clientes_cadastro?.[0];
           if (cliente) {
             result = {
@@ -724,7 +792,7 @@ serve(async (req) => {
             "geral/clientes/",
             "ListarClientes",
             { pagina: 1, registros_por_pagina: 1, clientesFiltro: { cnpj_cpf: docClean } }
-          ) as any;
+          ) as unknown as OmieListarClientesResponse;
           const existing = searchRes.clientes_cadastro?.[0];
           if (existing) {
             result = {
@@ -756,7 +824,7 @@ serve(async (req) => {
               "geral/clientes/",
               "IncluirCliente",
               clienteParams
-            ) as any;
+            ) as unknown as OmieIncluirClienteResponse;
             result = {
               success: true,
               codigo_cliente: createResult.codigo_cliente_omie || createResult.nCodCli,
@@ -764,9 +832,9 @@ serve(async (req) => {
               created: true,
             };
           }
-        } catch (e: any) {
+        } catch (e) {
           console.error("[Omie] Erro ao criar cliente na afiação:", e);
-          result = { success: false, error: e.message || "Erro ao criar cliente" };
+          result = { success: false, error: e instanceof Error ? e.message : "Erro ao criar cliente" };
         }
         break;
       }
@@ -793,17 +861,17 @@ serve(async (req) => {
           const omieResult = await callOmieApi(
             "servicos/servico/",
             "ListarCadastroServico",
-            { 
-              nPagina: 1, 
-              nRegPorPagina: 100 
+            {
+              nPagina: 1,
+              nRegPorPagina: 100
             }
-          ) as any;
+          ) as unknown as OmieListarServicosResponse;
 
           const servicos = omieResult.cadastros || [];
           console.log(`[Omie] ${servicos.length} serviços encontrados`);
 
           // Formatar para o app
-          const servicosFormatados = servicos.map((s: any) => ({
+          const servicosFormatados = servicos.map((s) => ({
             omie_codigo_servico: s.intListar?.nCodServ || 0,
             omie_codigo_integracao: s.intListar?.cCodIntServ || "",
             descricao: s.descricao?.cDescricao || s.cabecalho?.cDescricao || "Sem descrição",
@@ -836,18 +904,18 @@ serve(async (req) => {
           const omieResult = await callOmieApi(
             "geral/contacorrente/",
             "ListarContasCorrentes",
-            { 
-              pagina: 1, 
-              registros_por_pagina: 50 
+            {
+              pagina: 1,
+              registros_por_pagina: 50
             }
-          ) as any;
+          ) as unknown as OmieListarContasCorrentesResponse;
 
           const contas = omieResult.ListarContasCorrentes || omieResult.conta_corrente_lista || [];
           console.log(`[Omie] ${contas.length} contas correntes encontradas`);
           console.log("[Omie] Resposta completa:", JSON.stringify(omieResult, null, 2));
 
           // Formatar para o app
-          const contasFormatadas = contas.map((c: any) => ({
+          const contasFormatadas = contas.map((c) => ({
             nCodCC: c.nCodCC,
             cDescricao: c.descricao || c.cDescricao || "Sem descrição",
             cCodCCInt: c.cCodCCInt || "",
@@ -881,17 +949,17 @@ serve(async (req) => {
           const omieResult = await callOmieApi(
             "geral/clientes/",
             "ListarClientes",
-            { 
-              pagina: 1, 
-              registros_por_pagina: 20 
+            {
+              pagina: 1,
+              registros_por_pagina: 20
             }
-          ) as any;
+          ) as unknown as OmieListarClientesResponse;
 
           const clientes = omieResult.clientes_cadastro || [];
           console.log(`[Omie] ${clientes.length} clientes encontrados`);
 
           // Formatar para o app
-          const clientesFormatados = clientes.map((c: any) => ({
+          const clientesFormatados = clientes.map((c) => ({
             codigo_cliente_omie: c.codigo_cliente_omie,
             razao_social: c.razao_social,
             nome_fantasia: c.nome_fantasia,
@@ -961,22 +1029,24 @@ serve(async (req) => {
           const omieResult = await callOmieApi(
             "servicos/servico/",
             "ListarCadastroServico",
-            { 
-              nPagina: 1, 
+            {
+              nPagina: 1,
               nRegPorPagina: 500 // Buscar mais para garantir todos
             }
-          ) as any;
+          ) as unknown as OmieListarServicosResponse;
 
           const servicosOmie = omieResult.cadastros || [];
           console.log(`[Omie] ${servicosOmie.length} serviços encontrados no Omie`);
 
           // 2. Buscar serviços existentes no banco
-          const { data: servicosLocais } = await supabaseAdmin
+          const { data: servicosLocaisRaw } = await supabaseAdmin
             .from("omie_servicos")
             .select("id, omie_codigo_servico, descricao, inativo");
 
-          const servicosLocaisMap = new Map(
-            (servicosLocais || []).map((s: any) => [s.omie_codigo_servico, s])
+          const servicosLocais = (servicosLocaisRaw || []) as unknown as ServicoLocalRow[];
+
+          const servicosLocaisMap = new Map<number, ServicoLocalRow>(
+            servicosLocais.map((s) => [s.omie_codigo_servico, s])
           );
 
           let adicionados = 0;
@@ -1158,8 +1228,8 @@ serve(async (req) => {
         try {
           const consultaResult = await callOmieApi("servicos/os/", "ConsultarOS", {
             nCodOS: osCheck.omie_codigo_os,
-          }) as any;
-          
+          }) as unknown as OmieConsultarOSResponse;
+
           result = { exists: !consultaResult.faultstring };
         } catch {
           // If error contains "não encontrada" or similar, OS was deleted
@@ -1202,7 +1272,7 @@ serve(async (req) => {
             try {
               const consultaResult = await callOmieApi("servicos/os/", "ConsultarOS", {
                 nCodOS: os.omie_codigo_os,
-              }) as any;
+              }) as unknown as OmieConsultarOSResponse;
 
               if (consultaResult.faultstring) {
                 console.log(`[Omie] OS ${os.omie_numero_os} não existe mais no Omie, excluindo localmente...`);

--- a/supabase/functions/process-nfe/index.ts
+++ b/supabase/functions/process-nfe/index.ts
@@ -2,6 +2,59 @@ import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2";
 import { authorizeCronOrStaff } from "../_shared/auth.ts";
 
+// ── Omie NF-e (recebimento de NF-e) response types ──
+interface NfeCabec {
+  nIdReceb?: number;
+  cNumeroNFe?: string;
+  cChaveNfe?: string;
+  cNome?: string;
+  cRazaoSocial?: string;
+  cCodigoProduto?: string;
+  cIgnorarItem?: string;
+  nQtdeNFe?: number;
+  nFatorConversao?: number;
+  nFatorConv?: number;
+  nSequencia?: number;
+  nValorUnitario?: number;
+  nValorTotal?: number;
+  nIdProduto?: number;
+}
+
+interface NfeAjustes {
+  nFatorConversao?: number;
+  nFatorConv?: number;
+}
+
+interface NfeItemSubObj {
+  nFatorConversao?: number;
+}
+
+interface NfeItem {
+  itensCabec?: NfeCabec;
+  itensAjustes?: NfeAjustes;
+  itensConversao?: NfeItemSubObj;
+  itensNfe?: NfeItemSubObj;
+  [key: string]: unknown;
+}
+
+interface OmieListarRecebimentosResponse {
+  recebimentos?: Array<{ cabec?: NfeCabec }>;
+  nTotalRegistros?: number;
+}
+
+interface OmieConsultarRecebimentoResponse {
+  itensRecebimento?: NfeItem[];
+}
+
+interface OmieDepartamento {
+  codigo?: string;
+  descricao?: string;
+}
+
+interface OmieListarDepartamentosResponse {
+  departamentos?: OmieDepartamento[];
+}
+
 const ALLOWED_ORIGIN = Deno.env.get("ALLOWED_ORIGIN") || "*";
 
 const corsHeaders = {
@@ -32,7 +85,7 @@ function getCredentials(account: string): { key: string; secret: string } {
   }
 }
 
-async function callOmie(endpoint: string, call: string, params: Record<string, unknown>[], account = "oben") {
+async function callOmie(endpoint: string, call: string, params: Record<string, unknown>[], account = "oben"): Promise<Record<string, unknown>> {
   const creds = getCredentials(account);
   if (!creds.key || !creds.secret) throw new Error(`Credenciais Omie não configuradas para ${account}`);
 
@@ -52,14 +105,14 @@ async function callOmie(endpoint: string, call: string, params: Record<string, u
   });
 
   const text = await res.text();
-  let data;
+  let data: Record<string, unknown>;
   try {
     data = JSON.parse(text);
   } catch {
     throw new Error(`Resposta inválida da API Omie: ${text.substring(0, 300)}`);
   }
 
-  if (data.faultstring) {
+  if (typeof data.faultstring === "string") {
     throw new Error(`Omie: ${data.faultstring}`);
   }
 
@@ -117,10 +170,10 @@ serve(async (req) => {
 
       while (!found && pagina <= 30) {
         console.log(`[process-nfe] ListarRecebimentos página ${pagina}...`);
-        const listResult = await callOmie("produtos/recebimentonfe/", "ListarRecebimentos", [{
+        const listResult = (await callOmie("produtos/recebimentonfe/", "ListarRecebimentos", [{
           nPagina: pagina,
           nRegistrosPorPagina: 50,
-        }], account);
+        }], account)) as unknown as OmieListarRecebimentosResponse;
 
         const recebimentos = listResult.recebimentos || [];
         const totalRegistros = listResult.nTotalRegistros || 0;
@@ -128,7 +181,7 @@ serve(async (req) => {
 
         // Log sample for debugging
         if (pagina === 1 && recebimentos.length > 0) {
-          const samples = recebimentos.slice(0, 5).map((r: any) => ({
+          const samples = recebimentos.slice(0, 5).map((r) => ({
             nIdReceb: r.cabec?.nIdReceb,
             cNumeroNFe: r.cabec?.cNumeroNFe,
             cNome: r.cabec?.cNome,
@@ -167,21 +220,22 @@ serve(async (req) => {
       if (!found) {
         throw new Error(`NF ${nf_number} não encontrada no Omie (verificadas ${pagina} páginas, endpoint: produtos/recebimentonfe/)`);
       }
-    } catch (e: any) {
-      steps.push({ step: 1, description: `Buscar NF ${nf_number}`, status: "error", detail: e.message });
-      return new Response(JSON.stringify({ steps, error: e.message }), {
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      steps.push({ step: 1, description: `Buscar NF ${nf_number}`, status: "error", detail: message });
+      return new Response(JSON.stringify({ steps, error: message }), {
         status: 200,
         headers: { ...corsHeaders, "Content-Type": "application/json" },
       });
     }
 
     // STEP 2 - Get full details via ConsultarRecebimento
-    let itens: any[] = [];
+    let itens: NfeItem[] = [];
     try {
       const consultaParams: Record<string, unknown> = { nIdReceb };
       if (cChaveNfe) consultaParams.cChaveNfe = cChaveNfe;
-      
-      const detail = await callOmie("produtos/recebimentonfe/", "ConsultarRecebimento", [consultaParams], account);
+
+      const detail = (await callOmie("produtos/recebimentonfe/", "ConsultarRecebimento", [consultaParams], account)) as unknown as OmieConsultarRecebimentoResponse;
       itens = detail.itensRecebimento || [];
       
       console.log(`[process-nfe] ConsultarRecebimento: ${itens.length} itens`);
@@ -221,9 +275,10 @@ serve(async (req) => {
           status: "success",
         });
       }
-    } catch (e: any) {
-      steps.push({ step: 2, description: "Consultar detalhes da NF", status: "error", detail: e.message });
-      return new Response(JSON.stringify({ steps, error: e.message }), {
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      steps.push({ step: 2, description: "Consultar detalhes da NF", status: "error", detail: message });
+      return new Response(JSON.stringify({ steps, error: message }), {
         status: 200,
         headers: { ...corsHeaders, "Content-Type": "application/json" },
       });
@@ -231,7 +286,10 @@ serve(async (req) => {
 
     // STEP 3 - Update received quantities and departments via AlterarRecebimento
     try {
-      const itensEditar: any[] = [];
+      const itensEditar: Array<{
+        itensIde: { nSequencia: number; cAcao: string };
+        itensAjustes: { nQtdeRecebida: number };
+      }> = [];
       const itemResults: string[] = [];
 
       // Debug: log first item structure to find conversion factor field
@@ -291,22 +349,23 @@ serve(async (req) => {
       // Find department code
       let departmentCode = "";
       try {
-        const deptResult = await callOmie("geral/departamentos/", "ListarDepartamentos", [{
+        const deptResult = (await callOmie("geral/departamentos/", "ListarDepartamentos", [{
           pagina: 1,
           registros_por_pagina: 50,
-        }], account);
+        }], account)) as unknown as OmieListarDepartamentosResponse;
         const deptos = deptResult.departamentos || [];
-        console.log(`[process-nfe] Departamentos: ${deptos.map((d: any) => d.descricao || d.codigo).join(", ")}`);
-        const opsDept = deptos.find((d: any) => 
-          (d.descricao || "").toLowerCase().includes("opera") || 
+        console.log(`[process-nfe] Departamentos: ${deptos.map((d) => d.descricao || d.codigo).join(", ")}`);
+        const opsDept = deptos.find((d) =>
+          (d.descricao || "").toLowerCase().includes("opera") ||
           (d.codigo || "").toLowerCase().includes("opera")
         );
-        if (opsDept) {
+        if (opsDept && opsDept.codigo) {
           departmentCode = opsDept.codigo;
           console.log(`[process-nfe] Departamento Operações encontrado: ${departmentCode}`);
         }
-      } catch (e: any) {
-        console.log(`[process-nfe] Erro ao listar departamentos: ${e.message}`);
+      } catch (e) {
+        const message = e instanceof Error ? e.message : String(e);
+        console.log(`[process-nfe] Erro ao listar departamentos: ${message}`);
       }
 
       // Calculate total NF value for department distribution
@@ -350,10 +409,11 @@ serve(async (req) => {
         status: "success",
         detail: itemResults.join(" | ") + (departmentCode ? ` | Depto: ${departmentCode}` : ""),
       });
-    } catch (e: any) {
+    } catch (e) {
       // If alter fails, try step by step approach
-      steps.push({ step: 3, description: "Atualizar recebimento", status: "error", detail: e.message });
-      return new Response(JSON.stringify({ steps, error: e.message }), {
+      const message = e instanceof Error ? e.message : String(e);
+      steps.push({ step: 3, description: "Atualizar recebimento", status: "error", detail: message });
+      return new Response(JSON.stringify({ steps, error: message }), {
         status: 200,
         headers: { ...corsHeaders, "Content-Type": "application/json" },
       });
@@ -367,12 +427,13 @@ serve(async (req) => {
         cEtapa: "40", // Conferência / Pronto para concluir
       }], account);
       steps.push({ step: 4, description: "Etapa alterada para conferência", status: "success" });
-    } catch (e: any) {
-      if (e.message?.includes("já") || e.message?.includes("etapa")) {
-        steps.push({ step: 4, description: "Etapa já configurada", status: "warning", detail: e.message });
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      if (message.includes("já") || message.includes("etapa")) {
+        steps.push({ step: 4, description: "Etapa já configurada", status: "warning", detail: message });
       } else {
-        steps.push({ step: 4, description: "Alterar etapa", status: "error", detail: e.message });
-        return new Response(JSON.stringify({ steps, error: e.message }), {
+        steps.push({ step: 4, description: "Alterar etapa", status: "error", detail: message });
+        return new Response(JSON.stringify({ steps, error: message }), {
           status: 200,
           headers: { ...corsHeaders, "Content-Type": "application/json" },
         });
@@ -386,9 +447,10 @@ serve(async (req) => {
         cChaveNfe: cChaveNfe || "",
       }], account);
       steps.push({ step: 5, description: "Recebimento concluído com sucesso", status: "success" });
-    } catch (e: any) {
-      steps.push({ step: 5, description: "Concluir recebimento", status: "error", detail: e.message });
-      return new Response(JSON.stringify({ steps, error: e.message }), {
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      steps.push({ step: 5, description: "Concluir recebimento", status: "error", detail: message });
+      return new Response(JSON.stringify({ steps, error: message }), {
         status: 200,
         headers: { ...corsHeaders, "Content-Type": "application/json" },
       });
@@ -398,8 +460,9 @@ serve(async (req) => {
       status: 200,
       headers: { ...corsHeaders, "Content-Type": "application/json" },
     });
-  } catch (e: any) {
-    return new Response(JSON.stringify({ error: e.message }), {
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    return new Response(JSON.stringify({ error: message }), {
       status: 500,
       headers: { ...corsHeaders, "Content-Type": "application/json" },
     });

--- a/supabase/functions/sync-reprocess/index.ts
+++ b/supabase/functions/sync-reprocess/index.ts
@@ -1,10 +1,79 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
-import { createClient } from "npm:@supabase/supabase-js@2";
+import { createClient, type SupabaseClient } from "npm:@supabase/supabase-js@2";
 import { authorizeCron, corsHeaders } from "../_shared/auth.ts";
 
 const OMIE_API_URL = "https://app.omie.com.br/api/v1";
 
 type Account = "oben" | "colacor";
+
+// ── Omie response shapes ──
+interface OmieProdutoItem {
+  quantidade?: number;
+  valor_unitario?: number;
+  codigo_produto?: number | string;
+}
+
+interface OmiePedidoItem {
+  produto?: OmieProdutoItem;
+}
+
+interface OmiePedidoCabecalho {
+  codigo_cliente?: number;
+  numero_pedido?: string | number;
+  codigo_pedido?: string | number;
+  etapa?: string;
+}
+
+interface OmiePedidoVenda {
+  cabecalho?: OmiePedidoCabecalho;
+  det?: OmiePedidoItem[];
+}
+
+interface OmieListarPedidosResponse {
+  total_de_paginas?: number;
+  pedido_venda_produto?: OmiePedidoVenda[];
+}
+
+interface OmieProdutoImagem {
+  url_imagem?: string;
+}
+
+interface OmieProdutoCadastro {
+  codigo_produto?: number | string;
+  codigo_produto_integracao?: string | null;
+  codigo?: string;
+  descricao?: string;
+  unidade?: string;
+  ncm?: string | null;
+  valor_unitario?: number;
+  quantidade_estoque?: number;
+  descricao_familia?: string;
+  inativo?: string;
+  tipo?: string;
+  imagens?: OmieProdutoImagem[];
+  marca?: string;
+  modelo?: string;
+  peso_bruto?: number;
+  peso_liq?: number;
+  cfop?: string;
+}
+
+interface OmieListarProdutosResponse {
+  total_de_paginas?: number;
+  produto_servico_cadastro?: OmieProdutoCadastro[];
+}
+
+interface OmieEstoqueItem {
+  nCodProd?: number;
+  nSaldo?: number;
+  nCMC?: number;
+  nPrecoMedio?: number;
+}
+
+interface OmieListarPosEstoqueResponse {
+  nTotPaginas?: number;
+  produtos?: OmieEstoqueItem[];
+}
 
 function getVendasCredentials(account: Account) {
   if (account === "colacor") {
@@ -52,17 +121,18 @@ function formatOmieDate(d: Date): string {
 
 // ======== LOAD CONFIG ========
 
-async function loadReprocessConfig(db: any): Promise<Record<string, number>> {
+async function loadReprocessConfig(db: SupabaseClient): Promise<Record<string, number>> {
   const { data } = await db.from("sync_reprocess_config").select("key, value");
+  const rows = (data || []) as unknown as Array<{ key: string; value: number }>;
   const cfg: Record<string, number> = {};
-  for (const c of data || []) cfg[c.key] = c.value;
+  for (const c of rows) cfg[c.key] = c.value;
   return cfg;
 }
 
 // ======== LOG HELPERS ========
 
 async function createReprocessLog(
-  db: any,
+  db: SupabaseClient,
   entityType: string,
   account: string,
   reprocessType: string,
@@ -77,11 +147,11 @@ async function createReprocessLog(
     window_end: windowEnd.toISOString(),
     status: "running",
   }).select("id").single();
-  return data!.id;
+  return (data as unknown as { id: string }).id;
 }
 
 async function completeReprocessLog(
-  db: any,
+  db: SupabaseClient,
   logId: string,
   stats: {
     upserts_count: number;
@@ -107,7 +177,7 @@ async function completeReprocessLog(
 // ======== REPROCESS ORDERS ========
 
 async function reprocessOrders(
-  db: any,
+  db: SupabaseClient,
   account: Account,
   windowDays: number,
   reprocessType: string
@@ -126,13 +196,13 @@ async function reprocessOrders(
     let totalPaginas = 1;
 
     while (pagina <= totalPaginas) {
-      const result = await callOmie(account, "produtos/pedido/", "ListarPedidos", {
+      const result = (await callOmie(account, "produtos/pedido/", "ListarPedidos", {
         pagina,
         registros_por_pagina: 100,
         filtrar_apenas_inclusao: "N",
         filtrar_por_data_de: formatOmieDate(windowStart),
         filtrar_por_data_ate: formatOmieDate(windowEnd),
-      }) as any;
+      })) as unknown as OmieListarPedidosResponse;
 
       totalPaginas = result.total_de_paginas || 1;
       const pedidos = result.pedido_venda_produto || [];
@@ -173,7 +243,7 @@ async function reprocessOrders(
             "10": "rascunho", "20": "enviado", "50": "faturado", "60": "cancelado",
           };
 
-          const totalPedido = itens.reduce((sum: number, i: any) => {
+          const totalPedido = itens.reduce((sum: number, i: OmiePedidoItem) => {
             const prod = i.produto || {};
             return sum + (prod.quantidade || 1) * (prod.valor_unitario || 0);
           }, 0);
@@ -276,7 +346,7 @@ async function reprocessOrders(
 // ======== REPROCESS PRODUCTS ========
 
 async function reprocessProducts(
-  db: any,
+  db: SupabaseClient,
   account: Account,
   reprocessType: string
 ) {
@@ -294,12 +364,12 @@ async function reprocessProducts(
     let totalPaginas = 1;
 
     while (pagina <= totalPaginas) {
-      const result = await callOmie(account, "geral/produtos/", "ListarProdutos", {
+      const result = (await callOmie(account, "geral/produtos/", "ListarProdutos", {
         pagina,
         registros_por_pagina: 100,
         apenas_importado_api: "N",
         filtrar_apenas_omiepdv: "N",
-      }) as any;
+      })) as unknown as OmieListarProdutosResponse;
 
       totalPaginas = result.total_de_paginas || 1;
       const produtos = result.produto_servico_cadastro || [];
@@ -395,7 +465,7 @@ async function reprocessProducts(
 // ======== REPROCESS INVENTORY ========
 
 async function reprocessInventory(
-  db: any,
+  db: SupabaseClient,
   account: Account,
   reprocessType: string
 ) {
@@ -412,11 +482,11 @@ async function reprocessInventory(
     let totalPaginas = 1;
 
     while (pagina <= totalPaginas) {
-      const result = await callOmie(account, "estoque/consulta/", "ListarPosEstoque", {
+      const result = (await callOmie(account, "estoque/consulta/", "ListarPosEstoque", {
         nPagina: pagina,
         nRegPorPagina: 100,
         dDataPosicao: formatOmieDate(new Date()),
-      }) as any;
+      })) as unknown as OmieListarPosEstoqueResponse;
 
       totalPaginas = result.nTotPaginas || 1;
       const produtos = result.produtos || [];

--- a/supabase/functions/tint-sync-agent/index.ts
+++ b/supabase/functions/tint-sync-agent/index.ts
@@ -5,6 +5,74 @@ const corsHeaders = {
   "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type, x-sync-token, x-store-code, x-idempotency-key",
 };
 
+// ─── Type definitions ───
+
+/** Item bruto enviado pelo agente (catalogo: produtos, bases, embalagens, skus, corantes) */
+interface TintCatalogItem {
+  id?: string;
+  cod_produto?: string;
+  id_base?: string;
+  id_embalagem?: string;
+  id_base_sayersystem?: string;
+  id_embalagem_sayersystem?: string;
+  id_corante_sayersystem?: string;
+  descricao?: string;
+  volume_ml?: number;
+  preco_litro?: number;
+  [k: string]: unknown;
+}
+
+/** Item de fórmula (corante + ordem + qtd) */
+interface TintFormulaItem {
+  id_corante?: string;
+  ordem?: number;
+  qtd_ml?: number;
+}
+
+/** Fórmula bruta enviada pelo agente */
+interface TintFormulaPayload {
+  cor_id?: string;
+  nome_cor?: string;
+  cod_produto?: string;
+  id_base?: string;
+  id_embalagem?: string;
+  subcolecao?: string | null;
+  volume_final_ml?: number;
+  preco_final?: number;
+  personalizada?: boolean;
+  itens?: TintFormulaItem[];
+}
+
+/** Preparação (mistura de tinta concreta) bruta enviada pelo agente */
+interface TintPreparacaoPayload {
+  preparacao_id?: string;
+  cor_id?: string;
+  nome_cor?: string;
+  cod_produto?: string;
+  id_base?: string;
+  id_embalagem?: string;
+  volume_ml?: number;
+  preco?: number;
+  cliente?: string;
+  data_preparacao?: string;
+  personalizada?: boolean;
+  itens?: TintFormulaItem[];
+}
+
+/** Linha resultante do join tint_formulas + tint_produtos/bases/embalagens (modo simulate/real_data) */
+interface TintFormulaJoinRow {
+  cor_id: string;
+  nome_cor: string | null;
+  volume_final_ml: number | null;
+  preco_final_sayersystem: number | null;
+  produto_id: string;
+  base_id: string;
+  embalagem_id: string;
+  tint_produtos?: { cod_produto?: string } | null;
+  tint_bases?: { id_base_sayersystem?: string } | null;
+  tint_embalagens?: { id_embalagem_sayersystem?: string } | null;
+}
+
 function json(data: unknown, status = 200) {
   return new Response(JSON.stringify(data), { status, headers: { ...corsHeaders, "Content-Type": "application/json" } });
 }
@@ -206,7 +274,7 @@ Deno.serve(async (req) => {
 
       let received = 0;
       for (const [entityType, config] of Object.entries(stagingTables)) {
-        const items = body[entityType] || [];
+        const items: TintCatalogItem[] = (body[entityType] as TintCatalogItem[] | undefined) || [];
         received += items.length;
         for (const item of items) {
           try {
@@ -221,7 +289,8 @@ Deno.serve(async (req) => {
               if (k in row) continue;
               row[k] = v;
             }
-            row[config.keyField] = item[config.keyField] || item.id || "";
+            const entityKey = (item[config.keyField] as string | undefined) || item.id || "";
+            row[config.keyField] = entityKey;
             if (item.descricao) row.descricao = item.descricao;
             if (item.volume_ml !== undefined) row.volume_ml = item.volume_ml;
             if (item.preco_litro !== undefined) row.preco_litro = item.preco_litro;
@@ -231,15 +300,16 @@ Deno.serve(async (req) => {
             const { error } = await sb.from(config.table).insert(row);
             if (error) {
               errors++;
-              errorDetails.push({ entity_type: entityType, entity_id: item[config.keyField], message: error.message });
-              await logError(runId, entityType, item[config.keyField], error.message, error, item);
+              errorDetails.push({ entity_type: entityType, entity_id: entityKey, message: error.message });
+              await logError(runId, entityType, entityKey, error.message, error, item);
             } else {
               inserts++;
             }
-          } catch (e: any) {
+          } catch (e) {
             errors++;
-            errorDetails.push({ entity_type: entityType, entity_id: null, message: e.message });
-            await logError(runId, entityType, null, e.message, null, item);
+            const msg = e instanceof Error ? e.message : String(e);
+            errorDetails.push({ entity_type: entityType, entity_id: null, message: msg });
+            await logError(runId, entityType, null, msg, null, item);
           }
         }
       }
@@ -268,7 +338,7 @@ Deno.serve(async (req) => {
 
       let inserts = 0, errors = 0, ignored = 0;
       const errorDetails: { entity_type: string; entity_id: string | null; message: string }[] = [];
-      const formulas = body.formulas || [];
+      const formulas: TintFormulaPayload[] = (body.formulas as TintFormulaPayload[] | undefined) || [];
       const received = formulas.length;
 
       for (const f of formulas) {
@@ -305,7 +375,7 @@ Deno.serve(async (req) => {
             continue;
           }
 
-          const itens = f.itens || [];
+          const itens: TintFormulaItem[] = f.itens || [];
           for (const item of itens) {
             await sb.from("tint_staging_formula_itens").insert({
               sync_run_id: runId,
@@ -316,10 +386,11 @@ Deno.serve(async (req) => {
             });
           }
           inserts++;
-        } catch (e: any) {
+        } catch (e) {
           errors++;
-          errorDetails.push({ entity_type: "formula", entity_id: f.cor_id, message: e.message });
-          await logError(runId, "formula", f.cor_id, e.message, null, f);
+          const msg = e instanceof Error ? e.message : String(e);
+          errorDetails.push({ entity_type: "formula", entity_id: f.cor_id ?? null, message: msg });
+          await logError(runId, "formula", f.cor_id ?? null, msg, null, f);
         }
       }
 
@@ -347,7 +418,7 @@ Deno.serve(async (req) => {
 
       let inserts = 0, errors = 0, ignored = 0;
       const errorDetails: { entity_type: string; entity_id: string | null; message: string }[] = [];
-      const preps = body.preparacoes || [];
+      const preps: TintPreparacaoPayload[] = (body.preparacoes as TintPreparacaoPayload[] | undefined) || [];
       const received = preps.length;
 
       for (const p of preps) {
@@ -385,7 +456,7 @@ Deno.serve(async (req) => {
             continue;
           }
 
-          const itens = p.itens || [];
+          const itens: TintFormulaItem[] = p.itens || [];
           for (const item of itens) {
             await sb.from("tint_staging_preparacao_itens").insert({
               sync_run_id: runId,
@@ -396,10 +467,11 @@ Deno.serve(async (req) => {
             });
           }
           inserts++;
-        } catch (e: any) {
+        } catch (e) {
           errors++;
-          errorDetails.push({ entity_type: "preparacao", entity_id: p.preparacao_id, message: e.message });
-          await logError(runId, "preparacao", p.preparacao_id, e.message, null, p);
+          const msg = e instanceof Error ? e.message : String(e);
+          errorDetails.push({ entity_type: "preparacao", entity_id: p.preparacao_id ?? null, message: msg });
+          await logError(runId, "preparacao", p.preparacao_id ?? null, msg, null, p);
         }
       }
 
@@ -469,9 +541,9 @@ Deno.serve(async (req) => {
 
         debugLog.push(`Sampled ${realFormulas?.length || 0} formulas from official table`);
 
-        const formulaRows = realFormulas || [];
+        const formulaRows = (realFormulas || []) as unknown as TintFormulaJoinRow[];
         for (let i = 0; i < formulaRows.length; i++) {
-          const f = formulaRows[i] as any;
+          const f = formulaRows[i];
           const codProduto = f.tint_produtos?.cod_produto;
           const idBase = f.tint_bases?.id_base_sayersystem;
           const idEmbalagem = f.tint_embalagens?.id_embalagem_sayersystem;
@@ -574,8 +646,9 @@ Deno.serve(async (req) => {
     }
 
     return json({ ok: false, error: `Unknown endpoint: ${path}` }, 404);
-  } catch (e: any) {
+  } catch (e) {
     console.error("tint-sync-agent error:", e);
-    return json({ ok: false, error: e.message || "Internal error" }, 500);
+    const msg = e instanceof Error ? e.message : String(e);
+    return json({ ok: false, error: msg || "Internal error" }, 500);
   }
 });


### PR DESCRIPTION
## Summary

Wave 2 da onda TS strict. Migra 7 Edge Functions Deno do Supabase de `any` para tipos concretos, removendo **87 erros `@typescript-eslint/no-explicit-any`** do lint global. Continuação de #58 (infra), #62 (5 engines IA), #64 (4 Edge Functions Omie), #68 (9 pages top-offenders).

| File | Any antes | Any depois | LoC |
|---|---|---|---|
| `omie-sync` | 19 | 0 | 1244 |
| `enviar-pedido-portal-sayerlack` | 17 | 0 | 2161 |
| `omie-analytics-sync` | 15 | 0 | 759 |
| `process-nfe` | 12 | 0 | 407 |
| `sync-reprocess` | 10 | 0 | 652 |
| `omie-sync-vendas-items` | 9 | 0 | 472 |
| `tint-sync-agent` | 5 | 0 | 581 |
| **Total** | **87** | **0** | **6276** |

## Padrões aplicados (consistente com PR #64)

- `import { createClient, type SupabaseClient } from "npm:@supabase/supabase-js@2"`
- `supabase: any` / `db: any` → `SupabaseClient`
- `(await callOmie(...)) as any` → `as unknown as OmieXxxResponse` (double cast porque `fetch().json()` é unknown)
- `.map((x: any) => ...)` → callback inferido da array tipada
- `catch (e: any) { e.message }` → `catch (e) { e instanceof Error ? e.message : String(e) }`
- Supabase row arrays: `const rows = (rawData || []) as unknown as MyRow[]`

## ~70 interfaces locais novas

Inline por arquivo (Edge Functions bundlam independente; tipos não são compartilhados):

- **Omie REST**: `OmieClienteCadastro`, `OmieListarClientesResponse`, `OmieListarServicosResponse`, `OmieListarContasCorrentesResponse`, `OmieConsultarOSResponse`, `OmieIncluirClienteResponse`, `OmieListarRecebimentosResponse`, `OmieConsultarRecebimentoResponse`, `OmiePedidoVendaProduto`, `OmieListarPedidosResponse`, `OmieProdutoCadastro`, `OmieListarProdutosResponse`, `OmieListarPosEstoqueResponse`, `OmieDepartamento` etc
- **Sayerlack/Tint**: `SayerlackApiResponse`, `SayerlackPedidoResponse`, `TintCatalogItem`, `TintFormulaItem`, `TintFormulaPayload`, `TintFormulaJoinRow`, `BrowserlessEnvelope`, `BrowserlessResponse`, `PostgrestErrorLike`
- **NFe XML**: `NfeCabec`, `NfeAjustes`, `NfeItem` (com index signature pra debug `Object.keys`), `NfeItemSubObj`
- **Supabase rows locais**: `ServicoLocalRow`, `VendaItemHistoryRow`, `VendaItemKeyRow`, `ProductCostRow`, `InventoryPositionRow`

## Validação local

- ✅ `bun lint`: 851 → 766 problems (-85 net; -87 da wave + 2 errors introduzidos por features merged em paralelo)
- ✅ `no-explicit-any`: 729 → 644 (-85)
- ✅ `bun run build`: limpo, PWA gerado, 69 entries precache
- ✅ `bun run test`: 241/241 passam (34 test files)
- ✅ `bun run typecheck:strict`: passa (13 files no include)
- ⚠️ Edge Functions não testáveis localmente sem Deno + `supabase functions serve`

## Acumulado pós-Wave 1+2

- Lint: **1398 → 766 (-45%)** desde início da onda TS strict
- `no-explicit-any`: **1274 → 644 (-49%)**
- Edge Functions Omie/Sayerlack: **11 de 11 high-traffic 100% type-safe**

## Não-objetivo

- DOES NOT alterar comportamento runtime — pura migração de tipos
- DOES NOT entrar no `tsconfig.strict.json` include (Edge Functions bundlam separadas pelo Deno runtime do Supabase, fora do scope do tsc do projeto)
- DOES NOT migrar errors pré-existentes não-any (tint-sync-agent tem 9 de prefer-const/no-unused-expressions; sayerlack tem 2 de ban-ts-comment — deixados intactos)

## Próximos high-leverage candidates (Wave 3)

- **Pages**: AdminReposicaoAplicacao (18), FarmerCopilot (13), Recebimento (9)
- **God-components** (precisam refactor antes): FinanceiroDashboard (16, 1242L), AdminRoutePlanner (15, 1661L)
- **Hooks**: useFinanceiro (16), useCopilotEngine (16), useFarmerGovernance (11)
- **Edge Functions restantes**: omie-pedidos, calculate-scores, omie-nfe-recebimento

## Doc updates

`CLAUDE.md` §13 (Health Stack) atualizada com gotchas operacionais descobertos durante `/health`:
- `bun install` obrigatório em worktrees novos (deps não herdam)
- `bun test` ≠ `bun run test` (CI usa vitest; o nativo do Bun tem polyfills parciais via `bunfig.toml`)
- Knip "Unlisted dependencies" são false-positives das Edge Functions Deno (`npm:` imports)

## Test plan

- [x] `bun lint` confirma -85 problems
- [x] `bun run build` passa
- [x] `bun run test` passa (241/241)
- [x] `bun run typecheck:strict` passa
- [ ] (post-merge) Smoke test Edge Functions em produção via `supabase functions logs` após próximo deploy — confirmar que nenhuma estrutura de resposta Omie ficou narrowed demais

🤖 Generated with [Claude Code](https://claude.com/claude-code)