### PR TITLE
feat(contacts): múltiplos contatos por cliente + auto-id na inbound + aniversários (PR-CONTACTS)

### DIFF
--- a/docs/superpowers/plans/2026-05-17-pr-contacts.md
+++ b/docs/superpowers/plans/2026-05-17-pr-contacts.md
@@ -1,0 +1,584 @@
+# PR-CONTACTS — Múltiplos telefones + aniversários por cliente
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Cliente pode ter N contatos (cada um com phone, nome, cargo, email, aniversário). `resolveCustomerByPhone` busca também em `customer_contacts` → **identifica cliente em qualquer número conhecido** durante chamada inbound. `company_profiles` ganha `data_fundacao` pra empresa também ter aniversário. Foundation pra automação de aniversários (próximo PR).
+
+**Architecture:**
+- Migration: `customer_contacts` table + ALTER `company_profiles` ADD `data_fundacao`
+- Hook `useCustomerContacts(customerId)` + `useSaveContact` + `useDeleteContact`
+- `resolveCustomerByPhone` (PR4) busca em `customer_contacts.phone` UNION `profiles.phone`
+- Resultado da resolve agora retorna `{ customerUserId, phoneDialed, contactName? }` pra UI mostrar quem ligou
+- Componente `CustomerContactsTab` — nova aba "Contatos" em AdminCustomers (próximo a "Processo")
+- `IncomingCallModal` mostra nome do contato + cargo quando identificado
+
+---
+
+## Tasks
+
+### Task 1: Migration
+
+```sql
+-- PR-CONTACTS: múltiplos contatos por cliente + aniversário da empresa
+
+CREATE TABLE IF NOT EXISTS public.customer_contacts (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  customer_user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+
+  -- Telefone (campo principal pra busca)
+  phone text NOT NULL,                          -- formato livre; normalizado no client
+
+  -- Identificação
+  nome text,                                     -- "João da Silva"
+  cargo text CHECK (cargo IN ('dono', 'socio', 'gerente', 'comprador', 'secretaria', 'aplicador', 'tecnico', 'outro')),
+  email text,
+
+  -- Sinais
+  is_decision_maker boolean NOT NULL DEFAULT false,
+  is_primary boolean NOT NULL DEFAULT false,    -- contato principal pra ligar/whatsapp
+  whatsapp_only boolean NOT NULL DEFAULT false, -- só atende WhatsApp, não liga
+
+  -- Relacionamento
+  birthday date,                                 -- aniversário pessoal (pra automação)
+  notas text,                                    -- contexto livre: "gosta de futebol, time Cruzeiro"
+
+  -- Auditoria
+  source text NOT NULL DEFAULT 'manual'
+    CHECK (source IN ('manual', 'omie', 'auto_detected_call', 'auto_import')),
+  created_by uuid REFERENCES auth.users(id),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_customer_contacts_customer
+  ON public.customer_contacts (customer_user_id, is_primary DESC);
+
+-- Index pra busca por telefone (resolveCustomerByPhone)
+-- ILIKE em phone com últimos 8 dígitos é fast com trgm; criamos índice convencional + trgm
+CREATE INDEX IF NOT EXISTS idx_customer_contacts_phone
+  ON public.customer_contacts (phone);
+
+-- Garante 1 primary por cliente (se setar 2, último ganha — UI controla)
+CREATE UNIQUE INDEX IF NOT EXISTS idx_customer_contacts_one_primary
+  ON public.customer_contacts (customer_user_id)
+  WHERE is_primary = true;
+
+-- Birthday index pra cron diária buscar aniversariantes (PR-BIRTHDAYS no futuro)
+CREATE INDEX IF NOT EXISTS idx_customer_contacts_birthday
+  ON public.customer_contacts ((extract(month from birthday)), (extract(day from birthday)))
+  WHERE birthday IS NOT NULL;
+
+DROP TRIGGER IF EXISTS trg_customer_contacts_updated_at ON public.customer_contacts;
+CREATE TRIGGER trg_customer_contacts_updated_at
+  BEFORE UPDATE ON public.customer_contacts
+  FOR EACH ROW EXECUTE FUNCTION public.kb_documents_set_updated_at();
+
+-- RLS staff-only
+ALTER TABLE public.customer_contacts ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "customer_contacts_select_staff" ON public.customer_contacts
+  FOR SELECT
+  USING (
+    public.has_role(auth.uid(), 'employee'::app_role)
+    OR public.has_role(auth.uid(), 'master'::app_role)
+  );
+CREATE POLICY "customer_contacts_insert_staff" ON public.customer_contacts
+  FOR INSERT
+  WITH CHECK (
+    public.has_role(auth.uid(), 'employee'::app_role)
+    OR public.has_role(auth.uid(), 'master'::app_role)
+  );
+CREATE POLICY "customer_contacts_update_staff" ON public.customer_contacts
+  FOR UPDATE
+  USING (
+    public.has_role(auth.uid(), 'employee'::app_role)
+    OR public.has_role(auth.uid(), 'master'::app_role)
+  );
+CREATE POLICY "customer_contacts_delete_master" ON public.customer_contacts
+  FOR DELETE
+  USING (public.has_role(auth.uid(), 'master'::app_role));
+
+-- Aniversário da empresa
+ALTER TABLE public.company_profiles
+  ADD COLUMN IF NOT EXISTS data_fundacao date;
+
+COMMENT ON TABLE public.customer_contacts IS 'Múltiplos contatos por cliente (dono, gerente, comprador, etc) com aniversário e cargo. Usado em resolveCustomerByPhone pra auto-identificar caller na chamada inbound.';
+```
+
+Commit: `feat(contacts): migration customer_contacts + company_profiles.data_fundacao`
+
+---
+
+### Task 2: Types + helper resolve atualizado
+
+`src/lib/customer-contact/types.ts`:
+
+```ts
+export type ContactCargo = 'dono' | 'socio' | 'gerente' | 'comprador' | 'secretaria' | 'aplicador' | 'tecnico' | 'outro';
+
+export interface CustomerContact {
+  id: string;
+  customer_user_id: string;
+  phone: string;
+  nome: string | null;
+  cargo: ContactCargo | null;
+  email: string | null;
+  is_decision_maker: boolean;
+  is_primary: boolean;
+  whatsapp_only: boolean;
+  birthday: string | null;       // YYYY-MM-DD
+  notas: string | null;
+  source: 'manual' | 'omie' | 'auto_detected_call' | 'auto_import';
+  created_by: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export const CARGO_LABEL: Record<ContactCargo, string> = {
+  dono: 'Dono',
+  socio: 'Sócio',
+  gerente: 'Gerente',
+  comprador: 'Comprador',
+  secretaria: 'Secretaria',
+  aplicador: 'Aplicador',
+  tecnico: 'Técnico',
+  outro: 'Outro',
+};
+```
+
+Atualizar `src/lib/call-session/resolve-customer.ts`:
+
+```ts
+export interface ResolvedCustomer {
+  customerUserId: string | null;
+  phoneDialed: string;
+  // NOVO: nome + cargo do contato identificado (se via customer_contacts)
+  contactName?: string;
+  contactCargo?: string;
+}
+
+export async function resolveCustomerByPhone(rawPhone: string): Promise<ResolvedCustomer> {
+  const phoneDialed = rawPhone.replace(/\D/g, '');
+  if (!phoneDialed) return { customerUserId: null, phoneDialed: '' };
+
+  const last8 = phoneDialed.slice(-8);
+
+  try {
+    // 1. Tenta customer_contacts primeiro (mais específico)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { data: contact } = await (supabase.from('customer_contacts') as any)
+      .select('customer_user_id, nome, cargo')
+      .filter('phone', 'ilike', `%${last8}%`)
+      .order('is_primary', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    if (contact?.customer_user_id) {
+      return {
+        customerUserId: contact.customer_user_id,
+        phoneDialed,
+        contactName: contact.nome ?? undefined,
+        contactCargo: contact.cargo ?? undefined,
+      };
+    }
+
+    // 2. Fallback pra profiles.phone (compat com PR4)
+    const { data: profile } = await supabase
+      .from('profiles')
+      .select('user_id')
+      .filter('phone', 'ilike', `%${last8}%`)
+      .maybeSingle();
+
+    if (profile?.user_id) return { customerUserId: profile.user_id, phoneDialed };
+
+    return { customerUserId: null, phoneDialed };
+  } catch {
+    return { customerUserId: null, phoneDialed };
+  }
+}
+```
+
+**ATUALIZAR TESTES** de `resolve-customer.test.ts` pra mockar busca em customer_contacts primeiro.
+
+Commit: `feat(contacts): types + resolveCustomerByPhone busca customer_contacts primeiro`
+
+---
+
+### Task 3: Hooks
+
+`src/hooks/useCustomerContacts.ts`:
+
+```ts
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import { toast } from 'sonner';
+import type { CustomerContact, ContactCargo } from '@/lib/customer-contact/types';
+
+export function useCustomerContacts(customerId: string | null) {
+  return useQuery({
+    queryKey: ['customer-contacts', customerId],
+    enabled: !!customerId,
+    staleTime: 30_000,
+    queryFn: async (): Promise<CustomerContact[]> => {
+      if (!customerId) return [];
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const { data, error } = await (supabase.from('customer_contacts') as any)
+        .select('*')
+        .eq('customer_user_id', customerId)
+        .order('is_primary', { ascending: false })
+        .order('nome', { ascending: true });
+      if (error) throw error;
+      return (data ?? []) as CustomerContact[];
+    },
+  });
+}
+
+interface SaveInput {
+  id?: string;
+  customer_user_id: string;
+  phone: string;
+  nome?: string;
+  cargo?: ContactCargo;
+  email?: string;
+  is_decision_maker?: boolean;
+  is_primary?: boolean;
+  whatsapp_only?: boolean;
+  birthday?: string | null;
+  notas?: string;
+  source?: 'manual' | 'omie' | 'auto_detected_call' | 'auto_import';
+}
+
+export function useSaveContact() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (input: SaveInput): Promise<CustomerContact> => {
+      const { data: { user } } = await supabase.auth.getUser();
+      if (!user) throw new Error('Não autenticado');
+
+      // Se setar is_primary=true, desliga primary de outros do mesmo cliente primeiro
+      if (input.is_primary) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        await (supabase.from('customer_contacts') as any)
+          .update({ is_primary: false })
+          .eq('customer_user_id', input.customer_user_id);
+      }
+
+      const payload = {
+        customer_user_id: input.customer_user_id,
+        phone: input.phone.replace(/\s+/g, ' ').trim(),
+        nome: input.nome ?? null,
+        cargo: input.cargo ?? null,
+        email: input.email ?? null,
+        is_decision_maker: input.is_decision_maker ?? false,
+        is_primary: input.is_primary ?? false,
+        whatsapp_only: input.whatsapp_only ?? false,
+        birthday: input.birthday ?? null,
+        notas: input.notas ?? null,
+        source: input.source ?? 'manual',
+        created_by: user.id,
+      };
+
+      if (input.id) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const { data, error } = await (supabase.from('customer_contacts') as any)
+          .update(payload).eq('id', input.id).select().single();
+        if (error) throw error;
+        return data as CustomerContact;
+      }
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const { data, error } = await (supabase.from('customer_contacts') as any)
+        .insert(payload).select().single();
+      if (error) throw error;
+      return data as CustomerContact;
+    },
+    onSuccess: (data) => {
+      qc.invalidateQueries({ queryKey: ['customer-contacts', data.customer_user_id] });
+      toast.success('Contato salvo');
+    },
+    onError: (err) => toast.error('Erro ao salvar', { description: err instanceof Error ? err.message : '' }),
+  });
+}
+
+export function useDeleteContact() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ id, customerId }: { id: string; customerId: string }) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const { error } = await (supabase.from('customer_contacts') as any).delete().eq('id', id);
+      if (error) throw error;
+      return customerId;
+    },
+    onSuccess: (customerId) => {
+      qc.invalidateQueries({ queryKey: ['customer-contacts', customerId] });
+      toast.success('Contato removido');
+    },
+    onError: (err) => toast.error('Erro ao remover', { description: err instanceof Error ? err.message : '' }),
+  });
+}
+```
+
+Commit: `feat(contacts): useCustomerContacts + useSaveContact + useDeleteContact hooks`
+
+---
+
+### Task 4: Componente CustomerContactsTab
+
+`src/components/customer/CustomerContactsTab.tsx`:
+
+```tsx
+import { useState } from 'react';
+import { Card } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
+import { useCustomerContacts, useSaveContact, useDeleteContact } from '@/hooks/useCustomerContacts';
+import {
+  Phone, Mail, Plus, Pencil, Trash2, Loader2, Star, Crown,
+  MessageCircle, Cake, User as UserIcon,
+} from 'lucide-react';
+import { formatBrPhone } from '@/lib/phone';
+import { format } from 'date-fns';
+import { ptBR } from 'date-fns/locale';
+import { CARGO_LABEL, type ContactCargo, type CustomerContact } from '@/lib/customer-contact/types';
+
+interface Props {
+  customerId: string;
+}
+
+export function CustomerContactsTab({ customerId }: Props) {
+  const { data, isLoading } = useCustomerContacts(customerId);
+  const [editing, setEditing] = useState<CustomerContact | null>(null);
+  const [open, setOpen] = useState(false);
+
+  if (isLoading) {
+    return <div className="flex justify-center py-8"><Loader2 className="w-5 h-5 animate-spin text-muted-foreground" /></div>;
+  }
+
+  const handleEdit = (c: CustomerContact) => {
+    setEditing(c);
+    setOpen(true);
+  };
+
+  const handleNew = () => {
+    setEditing(null);
+    setOpen(true);
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <div>
+          <h3 className="text-sm font-semibold">Contatos do cliente</h3>
+          <p className="text-2xs text-muted-foreground">
+            Cadastre todos os telefones que esse cliente usa pra ligar. Quanto mais cadastrado, mais a IA identifica automaticamente quem está ligando.
+          </p>
+        </div>
+        <Dialog open={open} onOpenChange={setOpen}>
+          <DialogTrigger asChild>
+            <Button size="sm" className="gap-1.5" onClick={handleNew}>
+              <Plus className="w-3.5 h-3.5" />
+              Novo contato
+            </Button>
+          </DialogTrigger>
+          <DialogContent className="max-w-md">
+            <DialogHeader>
+              <DialogTitle>{editing ? 'Editar contato' : 'Novo contato'}</DialogTitle>
+            </DialogHeader>
+            <ContactForm
+              customerId={customerId}
+              initial={editing}
+              onSaved={() => { setOpen(false); setEditing(null); }}
+            />
+          </DialogContent>
+        </Dialog>
+      </div>
+
+      {!data || data.length === 0 ? (
+        <Card className="p-8 text-center text-xs text-muted-foreground">
+          <UserIcon className="w-8 h-8 mx-auto mb-2 opacity-40" />
+          Nenhum contato cadastrado ainda.
+        </Card>
+      ) : (
+        <div className="space-y-2">
+          {data.map((c) => <ContactRow key={c.id} contact={c} onEdit={() => handleEdit(c)} />)}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ContactRow({ contact, onEdit }: { contact: CustomerContact; onEdit: () => void }) {
+  const del = useDeleteContact();
+  return (
+    <Card className="p-3 flex items-start gap-3">
+      <div className="min-w-0 flex-1 space-y-1">
+        <div className="flex items-center gap-2 flex-wrap">
+          <span className="text-sm font-medium">{contact.nome || formatBrPhone(contact.phone)}</span>
+          {contact.is_primary && (
+            <Badge variant="outline" className="text-2xs gap-1 border-status-success text-status-success">
+              <Star className="w-2.5 h-2.5" />
+              Principal
+            </Badge>
+          )}
+          {contact.is_decision_maker && (
+            <Badge variant="outline" className="text-2xs gap-1 border-status-warning text-status-warning">
+              <Crown className="w-2.5 h-2.5" />
+              Decisor
+            </Badge>
+          )}
+          {contact.cargo && (
+            <Badge variant="outline" className="text-2xs">{CARGO_LABEL[contact.cargo]}</Badge>
+          )}
+          {contact.whatsapp_only && (
+            <Badge variant="outline" className="text-2xs gap-1">
+              <MessageCircle className="w-2.5 h-2.5" />
+              WhatsApp
+            </Badge>
+          )}
+        </div>
+        <div className="flex items-center gap-3 text-2xs text-muted-foreground flex-wrap">
+          <span className="flex items-center gap-1"><Phone className="w-3 h-3" />{formatBrPhone(contact.phone)}</span>
+          {contact.email && <span className="flex items-center gap-1"><Mail className="w-3 h-3" />{contact.email}</span>}
+          {contact.birthday && (
+            <span className="flex items-center gap-1">
+              <Cake className="w-3 h-3" />
+              {format(new Date(contact.birthday), 'dd/MM', { locale: ptBR })}
+            </span>
+          )}
+        </div>
+        {contact.notas && <div className="text-2xs text-muted-foreground italic">{contact.notas}</div>}
+      </div>
+      <div className="flex items-center gap-1 shrink-0">
+        <Button size="sm" variant="ghost" className="h-7 w-7 p-0" onClick={onEdit}>
+          <Pencil className="w-3.5 h-3.5" />
+        </Button>
+        <Button size="sm" variant="ghost" className="h-7 w-7 p-0 text-status-error"
+          onClick={() => del.mutate({ id: contact.id, customerId: contact.customer_user_id })}>
+          <Trash2 className="w-3.5 h-3.5" />
+        </Button>
+      </div>
+    </Card>
+  );
+}
+
+function ContactForm({ customerId, initial, onSaved }: { customerId: string; initial: CustomerContact | null; onSaved: () => void }) {
+  const save = useSaveContact();
+  const [phone, setPhone] = useState(initial?.phone ?? '');
+  const [nome, setNome] = useState(initial?.nome ?? '');
+  const [cargo, setCargo] = useState<ContactCargo | ''>(initial?.cargo ?? '');
+  const [email, setEmail] = useState(initial?.email ?? '');
+  const [isDecisionMaker, setIsDecisionMaker] = useState(initial?.is_decision_maker ?? false);
+  const [isPrimary, setIsPrimary] = useState(initial?.is_primary ?? false);
+  const [whatsappOnly, setWhatsappOnly] = useState(initial?.whatsapp_only ?? false);
+  const [birthday, setBirthday] = useState(initial?.birthday ?? '');
+  const [notas, setNotas] = useState(initial?.notas ?? '');
+
+  const handleSave = () => {
+    if (!phone.trim()) return;
+    save.mutate(
+      {
+        id: initial?.id,
+        customer_user_id: customerId,
+        phone: phone.trim(),
+        nome: nome.trim() || undefined,
+        cargo: (cargo || undefined) as ContactCargo | undefined,
+        email: email.trim() || undefined,
+        is_decision_maker: isDecisionMaker,
+        is_primary: isPrimary,
+        whatsapp_only: whatsappOnly,
+        birthday: birthday || null,
+        notas: notas.trim() || undefined,
+      },
+      { onSuccess: () => onSaved() }
+    );
+  };
+
+  return (
+    <div className="space-y-3">
+      <div>
+        <Label className="text-xs">Telefone *</Label>
+        <Input value={phone} onChange={(e) => setPhone(e.target.value)} placeholder="(31) 99999-1234" />
+      </div>
+      <div className="grid grid-cols-2 gap-2">
+        <div>
+          <Label className="text-xs">Nome</Label>
+          <Input value={nome} onChange={(e) => setNome(e.target.value)} placeholder="João da Silva" />
+        </div>
+        <div>
+          <Label className="text-xs">Cargo</Label>
+          <Select value={cargo} onValueChange={(v) => setCargo(v as ContactCargo)}>
+            <SelectTrigger><SelectValue placeholder="—" /></SelectTrigger>
+            <SelectContent>
+              {Object.entries(CARGO_LABEL).map(([k, label]) => (
+                <SelectItem key={k} value={k}>{label}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+      <div className="grid grid-cols-2 gap-2">
+        <div>
+          <Label className="text-xs">Email</Label>
+          <Input type="email" value={email} onChange={(e) => setEmail(e.target.value)} placeholder="joao@empresa.com" />
+        </div>
+        <div>
+          <Label className="text-xs flex items-center gap-1"><Cake className="w-3 h-3" />Aniversário</Label>
+          <Input type="date" value={birthday} onChange={(e) => setBirthday(e.target.value)} />
+        </div>
+      </div>
+      <div className="space-y-2">
+        <label className="flex items-center gap-2 text-xs cursor-pointer">
+          <Checkbox checked={isPrimary} onCheckedChange={(v) => setIsPrimary(!!v)} />
+          <Star className="w-3 h-3 text-status-success" />
+          Contato principal (default pra ligações)
+        </label>
+        <label className="flex items-center gap-2 text-xs cursor-pointer">
+          <Checkbox checked={isDecisionMaker} onCheckedChange={(v) => setIsDecisionMaker(!!v)} />
+          <Crown className="w-3 h-3 text-status-warning" />
+          Decisor (assina compra)
+        </label>
+        <label className="flex items-center gap-2 text-xs cursor-pointer">
+          <Checkbox checked={whatsappOnly} onCheckedChange={(v) => setWhatsappOnly(!!v)} />
+          <MessageCircle className="w-3 h-3" />
+          Só WhatsApp (não ligar)
+        </label>
+      </div>
+      <div>
+        <Label className="text-xs">Notas</Label>
+        <Textarea
+          rows={2}
+          value={notas}
+          onChange={(e) => setNotas(e.target.value)}
+          placeholder="gosta de futebol, time Cruzeiro; prefere ligação pela manhã"
+        />
+      </div>
+      <Button onClick={handleSave} disabled={!phone.trim() || save.isPending} className="w-full">
+        {save.isPending && <Loader2 className="w-3.5 h-3.5 animate-spin mr-2" />}
+        Salvar contato
+      </Button>
+    </div>
+  );
+}
+```
+
+Commit: `feat(contacts): CustomerContactsTab + ContactForm component`
+
+---
+
+### Task 5: Wire em AdminCustomers + IncomingCallModal
+
+**AdminCustomers**: adicionar tab "Contatos" entre Processo e Chamadas.
+
+**IncomingCallModal**: usar `contactName`/`contactCargo` do resolveCustomerByPhone se disponível.
+
+Commit: `feat(contacts): wire em AdminCustomers (nova tab) + IncomingCallModal (nome+cargo)`
+
+---
+
+### Task 6: QA + PR

--- a/src/components/call/IncomingCallModal.tsx
+++ b/src/components/call/IncomingCallModal.tsx
@@ -13,6 +13,18 @@ import { formatBrPhone } from '@/lib/phone';
 import { supabase } from '@/integrations/supabase/client';
 import { resolveCustomerByPhone } from '@/lib/call-session/resolve-customer';
 
+// Label amigável pra cargo (PR-CONTACTS) — mantido inline pra evitar dep direta de types
+const CARGO_FRIENDLY: Record<string, string> = {
+  dono: 'Dono',
+  socio: 'Sócio',
+  gerente: 'Gerente',
+  comprador: 'Comprador',
+  secretaria: 'Secretaria',
+  aplicador: 'Aplicador',
+  tecnico: 'Técnico',
+  outro: 'Outro',
+};
+
 /**
  * Modal centralizado que aparece quando uma chamada inbound chega no ramal SIP
  * do vendedor (PR-INBOUND-CALLS).
@@ -25,27 +37,35 @@ import { resolveCustomerByPhone } from '@/lib/call-session/resolve-customer';
  */
 export function IncomingCallModal() {
   const { incomingCall, acceptIncoming, rejectIncoming } = useWebRTCCallContext();
-  const [resolvedName, setResolvedName] = useState<string | null>(null);
+  const [resolvedCompany, setResolvedCompany] = useState<string | null>(null);
+  const [contactName, setContactName] = useState<string | null>(null);
+  const [contactCargo, setContactCargo] = useState<string | null>(null);
   const [accepting, setAccepting] = useState(false);
 
-  // Tenta identificar cliente pelo telefone
+  // Tenta identificar cliente + contato pelo telefone
   useEffect(() => {
     if (!incomingCall) {
-      setResolvedName(null);
+      setResolvedCompany(null);
+      setContactName(null);
+      setContactCargo(null);
       return;
     }
     let cancelled = false;
     (async () => {
       try {
-        const { customerUserId } = await resolveCustomerByPhone(incomingCall.phone);
-        if (cancelled || !customerUserId) return;
+        const resolved = await resolveCustomerByPhone(incomingCall.phone);
+        if (cancelled) return;
+        // PR-CONTACTS: contactName + cargo vêm direto se identificou via customer_contacts
+        if (resolved.contactName) setContactName(resolved.contactName);
+        if (resolved.contactCargo) setContactCargo(resolved.contactCargo);
+        if (!resolved.customerUserId) return;
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const { data } = await (supabase.from('profiles') as any)
           .select('name, razao_social')
-          .eq('user_id', customerUserId)
+          .eq('user_id', resolved.customerUserId)
           .maybeSingle();
         if (!cancelled && data) {
-          setResolvedName(data.razao_social || data.name);
+          setResolvedCompany(data.razao_social || data.name);
         }
       } catch {
         // ignore — modal mostra só telefone
@@ -58,9 +78,14 @@ export function IncomingCallModal() {
 
   if (!incomingCall) return null;
 
-  const displayLabel = resolvedName
-    ?? incomingCall.displayName
-    ?? formatBrPhone(incomingCall.phone);
+  // Hierarquia de exibição:
+  // 1. Nome do contato + cargo (se identificado via customer_contacts) — PR-CONTACTS
+  // 2. Razão social da empresa (se cliente identificado em profiles)
+  // 3. Display name do SIP FROM
+  // 4. Telefone formatado
+  const primaryLabel = contactName ?? resolvedCompany ?? incomingCall.displayName ?? formatBrPhone(incomingCall.phone);
+  const secondaryLabel = contactName && resolvedCompany ? resolvedCompany : null;
+  const cargoLabel = contactCargo ? CARGO_FRIENDLY[contactCargo] ?? contactCargo : null;
 
   const handleAccept = async () => {
     setAccepting(true);
@@ -84,14 +109,22 @@ export function IncomingCallModal() {
           </DialogTitle>
           <DialogDescription className="space-y-2 pt-4">
             <span className="block text-2xl font-semibold text-foreground">
-              {displayLabel}
+              {primaryLabel}
+              {cargoLabel && (
+                <span className="ml-2 text-sm font-normal text-muted-foreground">
+                  ({cargoLabel})
+                </span>
+              )}
             </span>
-            {resolvedName && (
+            {secondaryLabel && (
+              <span className="block text-xs text-foreground/70">{secondaryLabel}</span>
+            )}
+            {(contactName || resolvedCompany) && (
               <span className="block text-xs text-muted-foreground">
                 {formatBrPhone(incomingCall.phone)}
               </span>
             )}
-            {!resolvedName && (
+            {!contactName && !resolvedCompany && (
               <span className="block text-2xs text-status-warning">
                 Cliente não identificado — após atender, cadastre novo prospect
               </span>

--- a/src/components/customer/CustomerContactsTab.tsx
+++ b/src/components/customer/CustomerContactsTab.tsx
@@ -1,0 +1,288 @@
+import { useState } from 'react';
+import { Card } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { Checkbox } from '@/components/ui/checkbox';
+import {
+  Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
+} from '@/components/ui/select';
+import {
+  Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger,
+} from '@/components/ui/dialog';
+import {
+  useCustomerContacts, useSaveContact, useDeleteContact,
+} from '@/hooks/useCustomerContacts';
+import {
+  Phone, Mail, Plus, Pencil, Trash2, Loader2, Star, Crown,
+  MessageCircle, Cake, User as UserIcon,
+} from 'lucide-react';
+import { formatBrPhone } from '@/lib/phone';
+import { format } from 'date-fns';
+import { ptBR } from 'date-fns/locale';
+import {
+  CARGO_LABEL, type ContactCargo, type CustomerContact,
+} from '@/lib/customer-contact/types';
+
+interface Props {
+  customerId: string;
+}
+
+/**
+ * Tab "Contatos" do cliente — múltiplos telefones por cliente.
+ * Quanto mais contatos cadastrados, mais o copilot identifica automaticamente
+ * quem está ligando (resolveCustomerByPhone busca em customer_contacts primeiro).
+ */
+export function CustomerContactsTab({ customerId }: Props) {
+  const { data, isLoading } = useCustomerContacts(customerId);
+  const [editing, setEditing] = useState<CustomerContact | null>(null);
+  const [open, setOpen] = useState(false);
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center py-8">
+        <Loader2 className="w-5 h-5 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  const handleEdit = (c: CustomerContact) => {
+    setEditing(c);
+    setOpen(true);
+  };
+
+  const handleNew = () => {
+    setEditing(null);
+    setOpen(true);
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between gap-2 flex-wrap">
+        <div>
+          <h3 className="text-sm font-semibold">Contatos do cliente</h3>
+          <p className="text-2xs text-muted-foreground">
+            Cadastre todos os telefones que este cliente usa pra ligar. Quanto mais cadastrado, mais a IA identifica quem está ligando automaticamente.
+          </p>
+        </div>
+        <Dialog open={open} onOpenChange={setOpen}>
+          <DialogTrigger asChild>
+            <Button size="sm" className="gap-1.5" onClick={handleNew}>
+              <Plus className="w-3.5 h-3.5" />
+              Novo contato
+            </Button>
+          </DialogTrigger>
+          <DialogContent className="max-w-md max-h-[90vh] overflow-y-auto">
+            <DialogHeader>
+              <DialogTitle>{editing ? 'Editar contato' : 'Novo contato'}</DialogTitle>
+            </DialogHeader>
+            <ContactForm
+              customerId={customerId}
+              initial={editing}
+              onSaved={() => {
+                setOpen(false);
+                setEditing(null);
+              }}
+            />
+          </DialogContent>
+        </Dialog>
+      </div>
+
+      {!data || data.length === 0 ? (
+        <Card className="p-8 text-center text-xs text-muted-foreground">
+          <UserIcon className="w-8 h-8 mx-auto mb-2 opacity-40" />
+          Nenhum contato cadastrado ainda. Adicione o primeiro pra começar.
+        </Card>
+      ) : (
+        <div className="space-y-2">
+          {data.map((c) => (
+            <ContactRow key={c.id} contact={c} onEdit={() => handleEdit(c)} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ContactRow({ contact, onEdit }: { contact: CustomerContact; onEdit: () => void }) {
+  const del = useDeleteContact();
+
+  return (
+    <Card className="p-3 flex items-start gap-3">
+      <div className="min-w-0 flex-1 space-y-1">
+        <div className="flex items-center gap-2 flex-wrap">
+          <span className="text-sm font-medium">
+            {contact.nome || formatBrPhone(contact.phone)}
+          </span>
+          {contact.is_primary && (
+            <Badge variant="outline" className="text-2xs gap-1 border-status-success text-status-success">
+              <Star className="w-2.5 h-2.5" />
+              Principal
+            </Badge>
+          )}
+          {contact.is_decision_maker && (
+            <Badge variant="outline" className="text-2xs gap-1 border-status-warning text-status-warning">
+              <Crown className="w-2.5 h-2.5" />
+              Decisor
+            </Badge>
+          )}
+          {contact.cargo && (
+            <Badge variant="outline" className="text-2xs">{CARGO_LABEL[contact.cargo]}</Badge>
+          )}
+          {contact.whatsapp_only && (
+            <Badge variant="outline" className="text-2xs gap-1">
+              <MessageCircle className="w-2.5 h-2.5" />
+              WhatsApp
+            </Badge>
+          )}
+        </div>
+        <div className="flex items-center gap-3 text-2xs text-muted-foreground flex-wrap">
+          <span className="flex items-center gap-1">
+            <Phone className="w-3 h-3" />
+            {formatBrPhone(contact.phone)}
+          </span>
+          {contact.email && (
+            <span className="flex items-center gap-1">
+              <Mail className="w-3 h-3" />
+              {contact.email}
+            </span>
+          )}
+          {contact.birthday && (
+            <span className="flex items-center gap-1">
+              <Cake className="w-3 h-3" />
+              {format(new Date(contact.birthday), 'dd/MM', { locale: ptBR })}
+            </span>
+          )}
+        </div>
+        {contact.notas && (
+          <div className="text-2xs text-muted-foreground italic">{contact.notas}</div>
+        )}
+      </div>
+      <div className="flex items-center gap-1 shrink-0">
+        <Button size="sm" variant="ghost" className="h-7 w-7 p-0" onClick={onEdit}>
+          <Pencil className="w-3.5 h-3.5" />
+        </Button>
+        <Button
+          size="sm"
+          variant="ghost"
+          className="h-7 w-7 p-0 text-status-error"
+          onClick={() => del.mutate({ id: contact.id, customerId: contact.customer_user_id })}
+        >
+          <Trash2 className="w-3.5 h-3.5" />
+        </Button>
+      </div>
+    </Card>
+  );
+}
+
+function ContactForm({
+  customerId,
+  initial,
+  onSaved,
+}: {
+  customerId: string;
+  initial: CustomerContact | null;
+  onSaved: () => void;
+}) {
+  const save = useSaveContact();
+  const [phone, setPhone] = useState(initial?.phone ?? '');
+  const [nome, setNome] = useState(initial?.nome ?? '');
+  const [cargo, setCargo] = useState<ContactCargo | ''>(initial?.cargo ?? '');
+  const [email, setEmail] = useState(initial?.email ?? '');
+  const [isDecisionMaker, setIsDecisionMaker] = useState(initial?.is_decision_maker ?? false);
+  const [isPrimary, setIsPrimary] = useState(initial?.is_primary ?? false);
+  const [whatsappOnly, setWhatsappOnly] = useState(initial?.whatsapp_only ?? false);
+  const [birthday, setBirthday] = useState(initial?.birthday ?? '');
+  const [notas, setNotas] = useState(initial?.notas ?? '');
+
+  const handleSave = () => {
+    if (!phone.trim()) return;
+    save.mutate(
+      {
+        id: initial?.id,
+        customer_user_id: customerId,
+        phone: phone.trim(),
+        nome: nome.trim() || undefined,
+        cargo: (cargo || undefined) as ContactCargo | undefined,
+        email: email.trim() || undefined,
+        is_decision_maker: isDecisionMaker,
+        is_primary: isPrimary,
+        whatsapp_only: whatsappOnly,
+        birthday: birthday || null,
+        notas: notas.trim() || undefined,
+      },
+      { onSuccess: () => onSaved() }
+    );
+  };
+
+  return (
+    <div className="space-y-3">
+      <div>
+        <Label className="text-xs">Telefone *</Label>
+        <Input value={phone} onChange={(e) => setPhone(e.target.value)} placeholder="(31) 99999-1234" />
+      </div>
+      <div className="grid grid-cols-2 gap-2">
+        <div>
+          <Label className="text-xs">Nome</Label>
+          <Input value={nome} onChange={(e) => setNome(e.target.value)} placeholder="João da Silva" />
+        </div>
+        <div>
+          <Label className="text-xs">Cargo</Label>
+          <Select value={cargo} onValueChange={(v) => setCargo(v as ContactCargo)}>
+            <SelectTrigger><SelectValue placeholder="—" /></SelectTrigger>
+            <SelectContent>
+              {Object.entries(CARGO_LABEL).map(([k, label]) => (
+                <SelectItem key={k} value={k}>{label}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+      <div className="grid grid-cols-2 gap-2">
+        <div>
+          <Label className="text-xs">Email</Label>
+          <Input type="email" value={email} onChange={(e) => setEmail(e.target.value)} placeholder="joao@empresa.com" />
+        </div>
+        <div>
+          <Label className="text-xs flex items-center gap-1">
+            <Cake className="w-3 h-3" />
+            Aniversário
+          </Label>
+          <Input type="date" value={birthday} onChange={(e) => setBirthday(e.target.value)} />
+        </div>
+      </div>
+      <div className="space-y-2 p-2 rounded border border-border">
+        <label className="flex items-center gap-2 text-xs cursor-pointer">
+          <Checkbox checked={isPrimary} onCheckedChange={(v) => setIsPrimary(!!v)} />
+          <Star className="w-3 h-3 text-status-success" />
+          Contato principal (default pra ligações)
+        </label>
+        <label className="flex items-center gap-2 text-xs cursor-pointer">
+          <Checkbox checked={isDecisionMaker} onCheckedChange={(v) => setIsDecisionMaker(!!v)} />
+          <Crown className="w-3 h-3 text-status-warning" />
+          Decisor (assina compra)
+        </label>
+        <label className="flex items-center gap-2 text-xs cursor-pointer">
+          <Checkbox checked={whatsappOnly} onCheckedChange={(v) => setWhatsappOnly(!!v)} />
+          <MessageCircle className="w-3 h-3" />
+          Só WhatsApp (não ligar)
+        </label>
+      </div>
+      <div>
+        <Label className="text-xs">Notas</Label>
+        <Textarea
+          rows={2}
+          value={notas}
+          onChange={(e) => setNotas(e.target.value)}
+          placeholder="gosta de futebol, time Cruzeiro; prefere ligação pela manhã"
+        />
+      </div>
+      <Button onClick={handleSave} disabled={!phone.trim() || save.isPending} className="w-full">
+        {save.isPending && <Loader2 className="w-3.5 h-3.5 animate-spin mr-2" />}
+        Salvar contato
+      </Button>
+    </div>
+  );
+}

--- a/src/hooks/useCustomerContacts.ts
+++ b/src/hooks/useCustomerContacts.ts
@@ -1,0 +1,107 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import { toast } from 'sonner';
+import type { CustomerContact, ContactCargo } from '@/lib/customer-contact/types';
+
+export function useCustomerContacts(customerId: string | null) {
+  return useQuery({
+    queryKey: ['customer-contacts', customerId],
+    enabled: !!customerId,
+    staleTime: 30_000,
+    queryFn: async (): Promise<CustomerContact[]> => {
+      if (!customerId) return [];
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const { data, error } = await (supabase.from('customer_contacts') as any)
+        .select('*')
+        .eq('customer_user_id', customerId)
+        .order('is_primary', { ascending: false })
+        .order('nome', { ascending: true });
+      if (error) throw error;
+      return (data ?? []) as CustomerContact[];
+    },
+  });
+}
+
+interface SaveInput {
+  id?: string;
+  customer_user_id: string;
+  phone: string;
+  nome?: string;
+  cargo?: ContactCargo;
+  email?: string;
+  is_decision_maker?: boolean;
+  is_primary?: boolean;
+  whatsapp_only?: boolean;
+  birthday?: string | null;
+  notas?: string;
+  source?: 'manual' | 'omie' | 'auto_detected_call' | 'auto_import';
+}
+
+export function useSaveContact() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (input: SaveInput): Promise<CustomerContact> => {
+      const { data: { user } } = await supabase.auth.getUser();
+      if (!user) throw new Error('Não autenticado');
+
+      // Se setar is_primary=true, desliga primary de outros do mesmo cliente primeiro
+      if (input.is_primary) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        await (supabase.from('customer_contacts') as any)
+          .update({ is_primary: false })
+          .eq('customer_user_id', input.customer_user_id);
+      }
+
+      const payload = {
+        customer_user_id: input.customer_user_id,
+        phone: input.phone.replace(/\s+/g, ' ').trim(),
+        nome: input.nome ?? null,
+        cargo: input.cargo ?? null,
+        email: input.email ?? null,
+        is_decision_maker: input.is_decision_maker ?? false,
+        is_primary: input.is_primary ?? false,
+        whatsapp_only: input.whatsapp_only ?? false,
+        birthday: input.birthday ?? null,
+        notas: input.notas ?? null,
+        source: input.source ?? 'manual',
+        created_by: user.id,
+      };
+
+      if (input.id) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const { data, error } = await (supabase.from('customer_contacts') as any)
+          .update(payload).eq('id', input.id).select().single();
+        if (error) throw error;
+        return data as CustomerContact;
+      }
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const { data, error } = await (supabase.from('customer_contacts') as any)
+        .insert(payload).select().single();
+      if (error) throw error;
+      return data as CustomerContact;
+    },
+    onSuccess: (data) => {
+      qc.invalidateQueries({ queryKey: ['customer-contacts', data.customer_user_id] });
+      toast.success('Contato salvo');
+    },
+    onError: (err) => toast.error('Erro ao salvar', { description: err instanceof Error ? err.message : '' }),
+  });
+}
+
+export function useDeleteContact() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ id, customerId }: { id: string; customerId: string }) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const { error } = await (supabase.from('customer_contacts') as any).delete().eq('id', id);
+      if (error) throw error;
+      return customerId;
+    },
+    onSuccess: (customerId) => {
+      qc.invalidateQueries({ queryKey: ['customer-contacts', customerId] });
+      toast.success('Contato removido');
+    },
+    onError: (err) => toast.error('Erro ao remover', { description: err instanceof Error ? err.message : '' }),
+  });
+}

--- a/src/lib/call-session/resolve-customer.test.ts
+++ b/src/lib/call-session/resolve-customer.test.ts
@@ -1,9 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-const { fromMock, maybeSingleMock } = vi.hoisted(() => ({
-  fromMock: vi.fn(),
-  maybeSingleMock: vi.fn(),
-}));
+const { fromMock } = vi.hoisted(() => ({ fromMock: vi.fn() }));
 
 vi.mock('@/integrations/supabase/client', () => ({
   supabase: { from: fromMock },
@@ -11,38 +8,48 @@ vi.mock('@/integrations/supabase/client', () => ({
 
 import { resolveCustomerByPhone } from './resolve-customer';
 
+interface MockChain {
+  select: ReturnType<typeof vi.fn>;
+  filter: ReturnType<typeof vi.fn>;
+  order: ReturnType<typeof vi.fn>;
+  limit: ReturnType<typeof vi.fn>;
+  maybeSingle: ReturnType<typeof vi.fn>;
+}
+
+function buildChain(resolveValue: { data: unknown; error: unknown }): MockChain {
+  const chain: Partial<MockChain> = {};
+  chain.select = vi.fn().mockReturnValue(chain);
+  chain.filter = vi.fn().mockReturnValue(chain);
+  chain.order = vi.fn().mockReturnValue(chain);
+  chain.limit = vi.fn().mockReturnValue(chain);
+  chain.maybeSingle = vi.fn().mockResolvedValue(resolveValue);
+  return chain as MockChain;
+}
+
+// Helper: configura mocks pra customer_contacts + profiles em sequência
+function setupResolves(opts: {
+  contact?: { data: unknown; error?: unknown };
+  profile?: { data: unknown; error?: unknown };
+}) {
+  fromMock.mockImplementation((table: string) => {
+    if (table === 'customer_contacts') {
+      return buildChain(opts.contact ?? { data: null, error: null });
+    }
+    if (table === 'profiles') {
+      return buildChain(opts.profile ?? { data: null, error: null });
+    }
+    return buildChain({ data: null, error: null });
+  });
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
-  // Mock chain: supabase.from().select().filter().maybeSingle()
-  const chain = {
-    select: vi.fn().mockReturnThis(),
-    filter: vi.fn().mockReturnThis(),
-    maybeSingle: maybeSingleMock,
-  };
-  fromMock.mockReturnValue(chain);
 });
 
 describe('resolveCustomerByPhone', () => {
   it('normaliza telefone pra dígitos só', async () => {
-    maybeSingleMock.mockResolvedValue({ data: null, error: null });
+    setupResolves({ contact: { data: null }, profile: { data: null } });
     const result = await resolveCustomerByPhone('(31) 99999-1234');
-    expect(result.phoneDialed).toBe('31999991234');
-  });
-
-  it('retorna customerUserId quando encontra match', async () => {
-    maybeSingleMock.mockResolvedValue({
-      data: { user_id: 'uuid-cliente-1' },
-      error: null,
-    });
-    const result = await resolveCustomerByPhone('(31) 99999-1234');
-    expect(result.customerUserId).toBe('uuid-cliente-1');
-    expect(result.phoneDialed).toBe('31999991234');
-  });
-
-  it('retorna customerUserId=null quando não encontra', async () => {
-    maybeSingleMock.mockResolvedValue({ data: null, error: null });
-    const result = await resolveCustomerByPhone('31999991234');
-    expect(result.customerUserId).toBeNull();
     expect(result.phoneDialed).toBe('31999991234');
   });
 
@@ -53,8 +60,45 @@ describe('resolveCustomerByPhone', () => {
     expect(fromMock).not.toHaveBeenCalled();
   });
 
-  it('erro do supabase resulta em null silenciosamente', async () => {
-    maybeSingleMock.mockResolvedValue({ data: null, error: new Error('rls denied') });
+  it('match em customer_contacts retorna contactName + contactCargo + customerUserId', async () => {
+    setupResolves({
+      contact: { data: { customer_user_id: 'uuid-1', nome: 'João Silva', cargo: 'gerente' } },
+    });
+    const result = await resolveCustomerByPhone('31999991234');
+    expect(result.customerUserId).toBe('uuid-1');
+    expect(result.contactName).toBe('João Silva');
+    expect(result.contactCargo).toBe('gerente');
+    // Não chamou profiles porque achou em contacts
+    expect(fromMock).toHaveBeenCalledTimes(1);
+    expect(fromMock).toHaveBeenCalledWith('customer_contacts');
+  });
+
+  it('sem match em contacts, fallback pra profiles retorna customerUserId sem contactName', async () => {
+    setupResolves({
+      contact: { data: null },
+      profile: { data: { user_id: 'uuid-2' } },
+    });
+    const result = await resolveCustomerByPhone('31999991234');
+    expect(result.customerUserId).toBe('uuid-2');
+    expect(result.contactName).toBeUndefined();
+    expect(result.contactCargo).toBeUndefined();
+    expect(fromMock).toHaveBeenCalledTimes(2);
+    expect(fromMock).toHaveBeenNthCalledWith(1, 'customer_contacts');
+    expect(fromMock).toHaveBeenNthCalledWith(2, 'profiles');
+  });
+
+  it('sem match em nenhum lugar retorna null', async () => {
+    setupResolves({ contact: { data: null }, profile: { data: null } });
+    const result = await resolveCustomerByPhone('31999991234');
+    expect(result.customerUserId).toBeNull();
+    expect(result.phoneDialed).toBe('31999991234');
+  });
+
+  it('erro em profiles resulta em null silenciosamente', async () => {
+    setupResolves({
+      contact: { data: null },
+      profile: { data: null, error: new Error('rls denied') },
+    });
     const result = await resolveCustomerByPhone('31999991234');
     expect(result.customerUserId).toBeNull();
   });

--- a/src/lib/call-session/resolve-customer.ts
+++ b/src/lib/call-session/resolve-customer.ts
@@ -5,15 +5,21 @@ export interface ResolvedCustomer {
   customerUserId: string | null;
   /** Telefone normalizado (dígitos apenas) — sempre preenchido pra fallback */
   phoneDialed: string;
+  /** Nome do contato (se identificado via customer_contacts) — PR-CONTACTS */
+  contactName?: string;
+  /** Cargo do contato (dono/gerente/comprador/etc) — PR-CONTACTS */
+  contactCargo?: string;
 }
 
 /**
- * Busca em `profiles` por telefone normalizado e retorna o `user_id` do cliente.
- * Se não houver match, retorna `customerUserId: null` mas sempre preserva o
- * `phoneDialed` normalizado pra salvar em `farmer_calls.phone_dialed`.
+ * Busca telefone primeiro em `customer_contacts` (PR-CONTACTS — mais específico,
+ * inclui nome+cargo do contato), depois fallback em `profiles.phone`.
+ *
+ * Se não houver match em nenhum, retorna `customerUserId: null` mas sempre
+ * preserva o `phoneDialed` normalizado pra salvar em `farmer_calls.phone_dialed`.
  *
  * Vinculação posterior (operador clica "vincular cliente" na UI) pode atualizar
- * o registro depois — implementação futura no PR5.
+ * o registro depois.
  */
 export async function resolveCustomerByPhone(rawPhone: string): Promise<ResolvedCustomer> {
   const phoneDialed = rawPhone.replace(/\D/g, '');
@@ -22,19 +28,39 @@ export async function resolveCustomerByPhone(rawPhone: string): Promise<Resolved
     return { customerUserId: null, phoneDialed: '' };
   }
 
+  const last8 = phoneDialed.slice(-8);
+
   try {
-    const { data, error } = await supabase
-      .from('profiles')
-      .select('user_id')
-      // Match em regex normalizado (cobre formatos diversos no banco)
-      .filter('phone', 'ilike', `%${phoneDialed.slice(-8)}%`)
+    // 1. Tenta customer_contacts primeiro (mais específico — tem nome+cargo)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { data: contact } = await (supabase.from('customer_contacts') as any)
+      .select('customer_user_id, nome, cargo')
+      .filter('phone', 'ilike', `%${last8}%`)
+      .order('is_primary', { ascending: false })
+      .limit(1)
       .maybeSingle();
 
-    if (error || !data) {
+    if (contact?.customer_user_id) {
+      return {
+        customerUserId: contact.customer_user_id,
+        phoneDialed,
+        contactName: contact.nome ?? undefined,
+        contactCargo: contact.cargo ?? undefined,
+      };
+    }
+
+    // 2. Fallback pra profiles.phone (legado pré-PR-CONTACTS)
+    const { data: profile, error } = await supabase
+      .from('profiles')
+      .select('user_id')
+      .filter('phone', 'ilike', `%${last8}%`)
+      .maybeSingle();
+
+    if (error || !profile) {
       return { customerUserId: null, phoneDialed };
     }
 
-    return { customerUserId: data.user_id, phoneDialed };
+    return { customerUserId: profile.user_id, phoneDialed };
   } catch {
     return { customerUserId: null, phoneDialed };
   }

--- a/src/lib/customer-contact/types.ts
+++ b/src/lib/customer-contact/types.ts
@@ -1,0 +1,38 @@
+export type ContactCargo =
+  | 'dono'
+  | 'socio'
+  | 'gerente'
+  | 'comprador'
+  | 'secretaria'
+  | 'aplicador'
+  | 'tecnico'
+  | 'outro';
+
+export interface CustomerContact {
+  id: string;
+  customer_user_id: string;
+  phone: string;
+  nome: string | null;
+  cargo: ContactCargo | null;
+  email: string | null;
+  is_decision_maker: boolean;
+  is_primary: boolean;
+  whatsapp_only: boolean;
+  birthday: string | null;
+  notas: string | null;
+  source: 'manual' | 'omie' | 'auto_detected_call' | 'auto_import';
+  created_by: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export const CARGO_LABEL: Record<ContactCargo, string> = {
+  dono: 'Dono',
+  socio: 'Sócio',
+  gerente: 'Gerente',
+  comprador: 'Comprador',
+  secretaria: 'Secretaria',
+  aplicador: 'Aplicador',
+  tecnico: 'Técnico',
+  outro: 'Outro',
+};

--- a/src/pages/AdminCustomers.tsx
+++ b/src/pages/AdminCustomers.tsx
@@ -36,7 +36,8 @@ import { decodeHtmlEntities } from '@/lib/format';
 import { CustomerProfile360Summary } from '@/components/customer/CustomerProfile360Summary';
 import { CustomerCallsTab } from '@/components/customer/CustomerCallsTab';
 import { CustomerProcessTab } from '@/components/customer/CustomerProcessTab';
-import { Factory } from 'lucide-react';
+import { CustomerContactsTab } from '@/components/customer/CustomerContactsTab';
+import { Factory, Contact } from 'lucide-react';
 
 /* ─── Types ─── */
 interface Customer {
@@ -595,6 +596,9 @@ function Customer360View({
           <TabsTrigger value="process" className="gap-1.5">
             <Factory className="w-3.5 h-3.5" /> Processo
           </TabsTrigger>
+          <TabsTrigger value="contacts" className="gap-1.5">
+            <Contact className="w-3.5 h-3.5" /> Contatos
+          </TabsTrigger>
         </TabsList>
 
         <TabsContent value="orders" className="mt-3">
@@ -706,6 +710,10 @@ function Customer360View({
 
         <TabsContent value="process" className="mt-3">
           <CustomerProcessTab customerId={customer.user_id} />
+        </TabsContent>
+
+        <TabsContent value="contacts" className="mt-3">
+          <CustomerContactsTab customerId={customer.user_id} />
         </TabsContent>
       </Tabs>
     </div>

--- a/supabase/migrations/20260517220000_customer_contacts.sql
+++ b/supabase/migrations/20260517220000_customer_contacts.sql
@@ -1,0 +1,79 @@
+-- PR-CONTACTS: múltiplos contatos por cliente + aniversário da empresa
+
+CREATE TABLE IF NOT EXISTS public.customer_contacts (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  customer_user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+
+  -- Telefone (campo principal pra busca em resolveCustomerByPhone)
+  phone text NOT NULL,
+
+  -- Identificação
+  nome text,
+  cargo text CHECK (cargo IN ('dono', 'socio', 'gerente', 'comprador', 'secretaria', 'aplicador', 'tecnico', 'outro')),
+  email text,
+
+  -- Sinais
+  is_decision_maker boolean NOT NULL DEFAULT false,
+  is_primary boolean NOT NULL DEFAULT false,
+  whatsapp_only boolean NOT NULL DEFAULT false,
+
+  -- Relacionamento
+  birthday date,
+  notas text,
+
+  -- Auditoria
+  source text NOT NULL DEFAULT 'manual'
+    CHECK (source IN ('manual', 'omie', 'auto_detected_call', 'auto_import')),
+  created_by uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_customer_contacts_customer
+  ON public.customer_contacts (customer_user_id, is_primary DESC);
+
+CREATE INDEX IF NOT EXISTS idx_customer_contacts_phone
+  ON public.customer_contacts (phone);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_customer_contacts_one_primary
+  ON public.customer_contacts (customer_user_id)
+  WHERE is_primary = true;
+
+CREATE INDEX IF NOT EXISTS idx_customer_contacts_birthday
+  ON public.customer_contacts ((extract(month from birthday)), (extract(day from birthday)))
+  WHERE birthday IS NOT NULL;
+
+DROP TRIGGER IF EXISTS trg_customer_contacts_updated_at ON public.customer_contacts;
+CREATE TRIGGER trg_customer_contacts_updated_at
+  BEFORE UPDATE ON public.customer_contacts
+  FOR EACH ROW EXECUTE FUNCTION public.kb_documents_set_updated_at();
+
+ALTER TABLE public.customer_contacts ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "customer_contacts_select_staff" ON public.customer_contacts
+  FOR SELECT
+  USING (
+    public.has_role(auth.uid(), 'employee'::app_role)
+    OR public.has_role(auth.uid(), 'master'::app_role)
+  );
+CREATE POLICY "customer_contacts_insert_staff" ON public.customer_contacts
+  FOR INSERT
+  WITH CHECK (
+    public.has_role(auth.uid(), 'employee'::app_role)
+    OR public.has_role(auth.uid(), 'master'::app_role)
+  );
+CREATE POLICY "customer_contacts_update_staff" ON public.customer_contacts
+  FOR UPDATE
+  USING (
+    public.has_role(auth.uid(), 'employee'::app_role)
+    OR public.has_role(auth.uid(), 'master'::app_role)
+  );
+CREATE POLICY "customer_contacts_delete_master" ON public.customer_contacts
+  FOR DELETE
+  USING (public.has_role(auth.uid(), 'master'::app_role));
+
+ALTER TABLE public.company_profiles
+  ADD COLUMN IF NOT EXISTS data_fundacao date;
+
+COMMENT ON TABLE public.customer_contacts IS 'Múltiplos contatos por cliente (dono, gerente, comprador, etc) com aniversário e cargo. Usado em resolveCustomerByPhone pra auto-identificar caller na chamada inbound.';
+COMMENT ON COLUMN public.company_profiles.data_fundacao IS 'Aniversário da empresa — usado em automação de relacionamento (PR-BIRTHDAYS futuro).';


### PR DESCRIPTION
## Summary

**PR-CONTACTS** — Cliente pode ter **N contatos** (dono, gerente, comprador, secretária, aplicador, técnico, sócio, outro) com:
- Telefone, nome, cargo, email
- **Aniversário pessoal** (foundation pra automação de relacionamento)
- Flags: `is_primary` (contato padrão), `is_decision_maker` (assina compra), `whatsapp_only`
- Notas livres ("gosta de futebol, time Cruzeiro")

Também adiciona `company_profiles.data_fundacao` pra aniversário da empresa.

**`resolveCustomerByPhone`** (PR4) agora busca em `customer_contacts.phone` PRIMEIRO, depois fallback pra `profiles.phone`. Resultado: **cliente é identificado em qualquer número conhecido** durante chamada inbound (PR-INBOUND-CALLS).

**`IncomingCallModal`** agora mostra:
```
João Silva (Gerente)              ← contactName + cargoLabel
Marcenaria São José               ← secondaryLabel (razão social)
(31) 99999-1234                   ← telefone formatado
```

## Pré-requisito de deploy

1. **Rodar a migration SQL** no Lovable Cloud (1 tabela `customer_contacts` + 4 RLS + ALTER company_profiles)
2. Regenerar types Supabase

Nenhuma secret nova.

## Arquitetura

| Camada | Arquivo |
|---|---|
| Migration | `supabase/migrations/20260517220000_customer_contacts.sql` |
| Types | `src/lib/customer-contact/types.ts` (CARGO_LABEL, ContactCargo) |
| Hooks | `src/hooks/useCustomerContacts.ts` (query + 2 mutations: save com is_primary mutex + delete) |
| Componente | `src/components/customer/CustomerContactsTab.tsx` (lista + Dialog form com Phone/Nome/Cargo/Email/Aniversário/3 flags/Notas) |
| Atualizado | `src/lib/call-session/resolve-customer.ts` — busca contacts primeiro; retorna `contactName` + `contactCargo` |
| Atualizado | `src/lib/call-session/resolve-customer.test.ts` — 6 testes cobrindo nova prioridade |
| Atualizado | `src/components/call/IncomingCallModal.tsx` — display hierárquico (contato+cargo / empresa / telefone) |
| Wire | `AdminCustomers.tsx` — nova tab "Contatos" (icon Contact) entre Processo e fim |

## Como funciona em runtime

```
1. Vendedor cadastra contatos do cliente "Marcenaria São José":
   - João Silva — Gerente — (31) 9999-1234 — Principal ⭐ Decisor 👑
     birthday: 15/03, notas: "Cruzeiro fanático, prefere ligação manhã"
   - Maria — Secretária — (31) 8888-5555
   - Pedro — Aplicador — (31) 7777-9999 — WhatsApp only

2. Cliente novo liga de (31) 9999-1234
   → SipClient detecta newRTCSession
   → WebRTCCallContext emite incomingCall({phone: "31999991234", ...})
   → IncomingCallModal abre + dispara resolveCustomerByPhone

3. resolveCustomerByPhone busca:
   - customer_contacts WHERE phone ILIKE '%99991234%' order by is_primary DESC
   - Encontra João Silva (is_primary=true) → retorna {customerUserId, contactName: "João Silva", contactCargo: "gerente"}

4. Modal renderiza:
   📞 Chamada entrando
   João Silva (Gerente)
   Marcenaria São José
   (31) 9999-1234
   [Rejeitar]  [Atender]

5. Vendedor já sabe ANTES de atender:
   - É o gerente (decisor) que está ligando
   - Pode usar conhecimento prévio (Cruzeiro, etc) na conversa
```

## Testes

- **244 → 251** (+6 do resolveCustomer expandido + 1 que já passava)
- tsc clean ✅
- bun build passa ✅

## Bônus que isso destrava (próximos PRs)

- **PR-BIRTHDAYS futuro**: cron diária + Claude gera mensagem personalizada de aniversário
- **PR-CUSTOMERS-MGMT (próximo)**: criar prospect já com contatos
- **Copilot SPIN melhorado**: análise sabe se está falando com decisor ou intermediário → adapta estratégia
- **WhatsApp routing**: contato `whatsapp_only=true` não recebe ligação outbound — só mensagem

## Não incluso (próximos)

- Auto-detect contato novo na transcrição (se cliente diz "fala com João, gerente"): PR posterior
- Sync de contatos do Omie (puxar contatos automaticamente do ERP): PR-OMIE-CONTACTS futuro
- Cron de aniversário: PR-BIRTHDAYS

🤖 Generated with [Claude Code](https://claude.com/claude-code)