### PR TITLE
feat(typescript): wave 3 elimina any em 4 hooks client-side (-50 lint errors)

### DIFF
--- a/src/hooks/useCopilotEngine.ts
+++ b/src/hooks/useCopilotEngine.ts
@@ -26,13 +26,25 @@ export interface TranscriptEntry {
   isPartial?: boolean;
 }
 
+export type CopilotContext = Record<string, unknown>;
+
 export interface CopilotSession {
   id: string;
   customerId?: string;
   customerName?: string;
   startedAt: Date;
-  bundleContext?: any;
-  customerContext?: any;
+  bundleContext?: CopilotContext;
+  customerContext?: CopilotContext;
+}
+
+interface CopilotAnalyzeResponse {
+  intent?: CopilotIntent;
+  phase?: CopilotPhase;
+  direction?: CopilotDirection;
+  direction_reasons?: string[];
+  suggestion?: string;
+  suggestion_type?: SuggestionType;
+  confidence?: number;
 }
 
 interface CopilotState {
@@ -70,21 +82,21 @@ export const useCopilotEngine = () => {
   const startSession = useCallback(async (params: {
     customerId?: string;
     customerName?: string;
-    bundleContext?: any;
-    customerContext?: any;
+    bundleContext?: CopilotContext;
+    customerContext?: CopilotContext;
   }) => {
     if (!user?.id) return;
 
     const { data } = await supabase
-      .from('farmer_copilot_sessions' as any)
+      .from('farmer_copilot_sessions')
       .insert({
         farmer_id: user.id,
         customer_user_id: params.customerId || null,
-      } as any)
+      })
       .select('id')
       .single();
 
-    const sessionId = (data as any)?.id || crypto.randomUUID();
+    const sessionId = data?.id || crypto.randomUUID();
     sessionIdRef.current = sessionId;
 
     const session: CopilotSession = {
@@ -125,7 +137,7 @@ export const useCopilotEngine = () => {
       const durationSeconds = Math.round((Date.now() - startTime.getTime()) / 1000);
 
       await supabase
-        .from('farmer_copilot_sessions' as any)
+        .from('farmer_copilot_sessions')
         .update({
           ended_at: new Date().toISOString(),
           duration_seconds: durationSeconds,
@@ -135,7 +147,7 @@ export const useCopilotEngine = () => {
           suggestions_shown: state.suggestionsShown,
           suggestions_used: state.suggestionsUsed,
           result: 'finalizado',
-        } as any)
+        })
         .eq('id', sessionIdRef.current);
     }
 
@@ -206,14 +218,15 @@ export const useCopilotEngine = () => {
 
           if (error || !data) throw error || new Error('No data');
 
+          const payload = data as CopilotAnalyzeResponse;
           const analysis: CopilotAnalysis = {
-            intent: data.intent || 'indiferenca',
-            phase: data.phase || 'abertura',
-            direction: data.direction || 'neutro',
-            directionReasons: data.direction_reasons || [],
-            suggestion: data.suggestion || '',
-            suggestionType: data.suggestion_type || 'pergunta_diagnostica',
-            confidence: data.confidence || 0,
+            intent: payload.intent || 'indiferenca',
+            phase: payload.phase || 'abertura',
+            direction: payload.direction || 'neutro',
+            directionReasons: payload.direction_reasons || [],
+            suggestion: payload.suggestion || '',
+            suggestionType: payload.suggestion_type || 'pergunta_diagnostica',
+            confidence: payload.confidence || 0,
           };
 
           setState(s => ({
@@ -226,7 +239,7 @@ export const useCopilotEngine = () => {
 
           // Log event
           if (sessionIdRef.current) {
-            await supabase.from('farmer_copilot_events' as any).insert({
+            await supabase.from('farmer_copilot_events').insert({
               session_id: sessionIdRef.current,
               event_type: 'suggestion',
               event_data: {
@@ -238,7 +251,7 @@ export const useCopilotEngine = () => {
               },
               transcript_snippet: fullText.slice(-200),
               suggestion_text: analysis.suggestion,
-            } as any);
+            });
           }
         } catch (err) {
           console.error('Analysis error:', err);
@@ -255,12 +268,12 @@ export const useCopilotEngine = () => {
     setState(prev => ({ ...prev, suggestionsUsed: prev.suggestionsUsed + 1 }));
 
     if (sessionIdRef.current) {
-      await supabase.from('farmer_copilot_events' as any).insert({
+      await supabase.from('farmer_copilot_events').insert({
         session_id: sessionIdRef.current,
         event_type: 'suggestion_used',
         suggestion_text: suggestionText,
         suggestion_used: true,
-      } as any);
+      });
     }
   }, []);
 
@@ -269,12 +282,12 @@ export const useCopilotEngine = () => {
     if (!sessionIdRef.current) return;
 
     await supabase
-      .from('farmer_copilot_sessions' as any)
+      .from('farmer_copilot_sessions')
       .update({
         result,
         revenue_generated: revenue,
         margin_generated: margin,
-      } as any)
+      })
       .eq('id', sessionIdRef.current);
   }, []);
 

--- a/src/hooks/useFarmerGovernance.ts
+++ b/src/hooks/useFarmerGovernance.ts
@@ -2,6 +2,11 @@ import { useState, useEffect } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
 import { toast } from 'sonner';
+import type { Tables, TablesInsert } from '@/integrations/supabase/types';
+
+type GovernanceProposalRow = Tables<'farmer_governance_proposals'>;
+type AuditLogRow = Tables<'farmer_audit_log'>;
+type ProfileRow = Pick<Tables<'profiles'>, 'user_id' | 'name'>;
 
 export interface GovernanceProposal {
   id: string;
@@ -27,7 +32,7 @@ export interface GovernanceProposal {
 export const useFarmerGovernance = () => {
   const { user } = useAuth();
   const [proposals, setProposals] = useState<GovernanceProposal[]>([]);
-  const [auditLogs, setAuditLogs] = useState<any[]>([]);
+  const [auditLogs, setAuditLogs] = useState<AuditLogRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [isGovernor, setIsGovernor] = useState(false);
 
@@ -50,22 +55,42 @@ export const useFarmerGovernance = () => {
     try {
       const [proposalsRes, logsRes] = await Promise.all([
         supabase.from('farmer_governance_proposals')
-          .select('*').order('created_at', { ascending: false }) as any,
+          .select('*').order('created_at', { ascending: false }),
         supabase.from('farmer_audit_log')
-          .select('*').order('created_at', { ascending: false }).limit(50) as any,
+          .select('*').order('created_at', { ascending: false }).limit(50),
       ]);
 
       if (proposalsRes.data) {
+        const rows = proposalsRes.data as GovernanceProposalRow[];
         // Load proposer names
-        const proposerIds = [...new Set(proposalsRes.data.map((p: any) => p.proposed_by))] as string[];
+        const proposerIds = [...new Set(rows.map((p) => p.proposed_by))];
         const { data: profiles } = await supabase
           .from('profiles').select('user_id, name').in('user_id', proposerIds);
-        const nameMap = new Map((profiles || []).map((p: any) => [p.user_id, p.name]));
-        setProposals(proposalsRes.data.map((p: any) => ({
-          ...p, proposer_name: nameMap.get(p.proposed_by) || 'Desconhecido',
+        const nameMap = new Map(
+          ((profiles || []) as ProfileRow[]).map((p) => [p.user_id, p.name])
+        );
+        setProposals(rows.map((p) => ({
+          id: p.id,
+          proposed_by: p.proposed_by,
+          proposal_type: p.proposal_type,
+          title: p.title,
+          description: p.description,
+          current_params: (p.current_params ?? {}) as Record<string, number>,
+          proposed_params: (p.proposed_params ?? {}) as Record<string, number>,
+          impact_revenue_pct: p.impact_revenue_pct,
+          impact_margin_pct: p.impact_margin_pct,
+          impact_churn_pct: p.impact_churn_pct,
+          impact_margin_per_hour: p.impact_margin_per_hour,
+          status: p.status ?? 'pendente',
+          approved_by: p.approved_by,
+          approved_at: p.approved_at,
+          rejection_reason: p.rejection_reason,
+          algorithm_version: p.algorithm_version ?? 'v1.0',
+          created_at: p.created_at ?? '',
+          proposer_name: nameMap.get(p.proposed_by) || 'Desconhecido',
         })));
       }
-      if (logsRes.data) setAuditLogs(logsRes.data);
+      if (logsRes.data) setAuditLogs(logsRes.data as AuditLogRow[]);
     } catch (error) {
       console.error('Error loading governance data:', error);
     } finally {
@@ -85,11 +110,14 @@ export const useFarmerGovernance = () => {
     impact_margin_per_hour?: number;
   }) => {
     if (!user) return;
-    const { error } = await supabase.from('farmer_governance_proposals').insert({
+    const proposalInsert: TablesInsert<'farmer_governance_proposals'> = {
       ...proposal,
       proposed_by: user.id,
       algorithm_version: 'v1.0',
-    } as any);
+    };
+    const { error } = await supabase
+      .from('farmer_governance_proposals')
+      .insert(proposalInsert);
 
     if (error) {
       toast.error('Erro ao criar proposta');
@@ -97,7 +125,7 @@ export const useFarmerGovernance = () => {
     }
 
     // Audit log
-    await supabase.from('farmer_audit_log').insert({
+    const auditInsert: TablesInsert<'farmer_audit_log'> = {
       action: 'proposal_created',
       entity_type: 'governance_proposal',
       performed_by: user.id,
@@ -105,11 +133,12 @@ export const useFarmerGovernance = () => {
       previous_params: proposal.current_params,
       new_params: proposal.proposed_params,
       projection: {
-        revenue_pct: proposal.impact_revenue_pct,
-        margin_pct: proposal.impact_margin_pct,
-        churn_pct: proposal.impact_churn_pct,
+        revenue_pct: proposal.impact_revenue_pct ?? null,
+        margin_pct: proposal.impact_margin_pct ?? null,
+        churn_pct: proposal.impact_churn_pct ?? null,
       },
-    } as any);
+    };
+    await supabase.from('farmer_audit_log').insert(auditInsert);
 
     toast.success('Proposta criada com sucesso');
     loadData();
@@ -141,7 +170,7 @@ export const useFarmerGovernance = () => {
       }).eq('id', proposalId);
 
     // Audit log
-    await supabase.from('farmer_audit_log').insert({
+    const approveAudit: TablesInsert<'farmer_audit_log'> = {
       action: 'proposal_approved',
       entity_type: 'governance_proposal',
       entity_id: proposalId,
@@ -150,11 +179,12 @@ export const useFarmerGovernance = () => {
       previous_params: proposal.current_params,
       new_params: proposal.proposed_params,
       projection: {
-        revenue_pct: proposal.impact_revenue_pct,
-        margin_pct: proposal.impact_margin_pct,
-        churn_pct: proposal.impact_churn_pct,
+        revenue_pct: proposal.impact_revenue_pct ?? null,
+        margin_pct: proposal.impact_margin_pct ?? null,
+        churn_pct: proposal.impact_churn_pct ?? null,
       },
-    } as any);
+    };
+    await supabase.from('farmer_audit_log').insert(approveAudit);
 
     toast.success('Proposta aprovada e aplicada');
     loadData();
@@ -173,13 +203,14 @@ export const useFarmerGovernance = () => {
         updated_at: new Date().toISOString(),
       }).eq('id', proposalId);
 
-    await supabase.from('farmer_audit_log').insert({
+    const rejectAudit: TablesInsert<'farmer_audit_log'> = {
       action: 'proposal_rejected',
       entity_type: 'governance_proposal',
       entity_id: proposalId,
       performed_by: user.id,
       notes: reason,
-    } as any);
+    };
+    await supabase.from('farmer_audit_log').insert(rejectAudit);
 
     toast.success('Proposta rejeitada');
     loadData();

--- a/src/hooks/useFarmerScoring.ts
+++ b/src/hooks/useFarmerScoring.ts
@@ -1,6 +1,25 @@
 import { useState, useEffect, useMemo, useCallback } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
+import type { Tables, TablesInsert } from '@/integrations/supabase/types';
+
+type AlgorithmConfigRow = Pick<Tables<'farmer_algorithm_config'>, 'key' | 'value'>;
+type ProductCostRow = Pick<Tables<'product_costs'>, 'product_id' | 'cost_price'>;
+type FarmerCallRow = Pick<
+  Tables<'farmer_calls'>,
+  'customer_user_id' | 'call_result' | 'is_whatsapp' | 'whatsapp_replied' | 'created_at'
+>;
+type ProfileRow = Pick<Tables<'profiles'>, 'user_id' | 'name' | 'phone'>;
+type SalesOrderRow = Pick<
+  Tables<'sales_orders'>,
+  'id' | 'customer_user_id' | 'items' | 'total' | 'created_at' | 'status'
+>;
+
+interface SalesOrderItem {
+  product_id?: string;
+  quantity?: number | string;
+  unit_price?: number | string;
+}
 
 // ─── Types ───────────────────────────────────────────────────────────
 export interface AlgorithmConfig {
@@ -88,10 +107,11 @@ export const useFarmerScoring = (farmerId?: string) => {
   // Load algorithm config
   useEffect(() => {
     (async () => {
-      const { data } = await supabase.from('farmer_algorithm_config').select('key, value') as any;
-      if (data && data.length > 0) {
+      const { data } = await supabase.from('farmer_algorithm_config').select('key, value');
+      const rows = (data ?? []) as AlgorithmConfigRow[];
+      if (rows.length > 0) {
         const map: Record<string, number> = {};
-        data.forEach((r: any) => { map[r.key] = Number(r.value); });
+        rows.forEach((r) => { map[r.key] = Number(r.value); });
         setConfig(prev => ({ ...prev, ...map } as AlgorithmConfig));
       }
     })();
@@ -108,12 +128,13 @@ export const useFarmerScoring = (farmerId?: string) => {
 
     try {
       // 1. Load all customers with sales orders
-      const { data: salesOrders } = await supabase
+      const { data: salesOrdersData } = await supabase
         .from('sales_orders')
         .select('id, customer_user_id, items, total, created_at, status')
-        .in('status', ['confirmado', 'faturado', 'entregue']) as any;
+        .in('status', ['confirmado', 'faturado', 'entregue']);
+      const salesOrders = (salesOrdersData ?? []) as SalesOrderRow[];
 
-      if (!salesOrders || salesOrders.length === 0) {
+      if (salesOrders.length === 0) {
         setClientScores([]);
         setAgenda([]);
         setCalculating(false);
@@ -122,26 +143,29 @@ export const useFarmerScoring = (farmerId?: string) => {
       }
 
       // 2. Load product costs for margin calculation
-      const { data: productCosts } = await supabase
+      const { data: productCostsData } = await supabase
         .from('product_costs')
-        .select('product_id, cost_price') as any;
+        .select('product_id, cost_price');
+      const productCosts = (productCostsData ?? []) as ProductCostRow[];
       const costMap = new Map<string, number>();
-      (productCosts || []).forEach((pc: any) => costMap.set(pc.product_id, Number(pc.cost_price)));
+      productCosts.forEach((pc) => costMap.set(pc.product_id, Number(pc.cost_price)));
 
       // 3. Load farmer calls for contact rates
-      const { data: calls } = await supabase
+      const { data: callsData } = await supabase
         .from('farmer_calls')
         .select('customer_user_id, call_result, is_whatsapp, whatsapp_replied, created_at')
-        .eq('farmer_id', targetFarmerId) as any;
+        .eq('farmer_id', targetFarmerId);
+      const calls = (callsData ?? []) as FarmerCallRow[];
 
       // 4. Load customer profiles
-      const customerIds = [...new Set(salesOrders.map((o: any) => o.customer_user_id))] as string[];
-      const { data: profiles } = await supabase
+      const customerIds = [...new Set(salesOrders.map((o) => o.customer_user_id))];
+      const { data: profilesData } = await supabase
         .from('profiles')
         .select('user_id, name, phone')
         .in('user_id', customerIds);
+      const profiles = (profilesData ?? []) as ProfileRow[];
       const profileMap = new Map<string, { name: string; phone: string | null }>();
-      (profiles || []).forEach((p: any) => profileMap.set(p.user_id, { name: p.name, phone: p.phone }));
+      profiles.forEach((p) => profileMap.set(p.user_id, { name: p.name, phone: p.phone }));
 
       // 5. Aggregate per-customer data
       const now = Date.now();
@@ -182,7 +206,9 @@ export const useFarmerScoring = (farmerId?: string) => {
         if (orderTime >= sixMonthsAgo) cd.spend180d += Number(order.total || 0);
 
         // Parse items for categories and margin
-        const items = Array.isArray(order.items) ? order.items : [];
+        const items: SalesOrderItem[] = Array.isArray(order.items)
+          ? (order.items as unknown as SalesOrderItem[])
+          : [];
         for (const item of items) {
           if (item.product_id) {
             cd.categories.add(item.product_id);
@@ -196,8 +222,9 @@ export const useFarmerScoring = (farmerId?: string) => {
       }
 
       // Aggregate call data
-      for (const call of (calls || [])) {
+      for (const call of calls) {
         const cid = call.customer_user_id;
+        if (!cid) continue;
         const cd = customerMap.get(cid);
         if (!cd) continue;
         const callTime = new Date(call.created_at).getTime();
@@ -389,7 +416,7 @@ export const useFarmerScoring = (farmerId?: string) => {
 
       // 9. Persist scores to DB
       for (const s of scores) {
-        await supabase.from('farmer_client_scores').upsert({
+        const scoreUpsert: TablesInsert<'farmer_client_scores'> = {
           customer_user_id: s.customer_user_id,
           farmer_id: targetFarmerId,
           rf_score: s.rf, m_score: s.m, g_score: s.g, x_score: s.x, s_score: s.s,
@@ -410,7 +437,10 @@ export const useFarmerScoring = (farmerId?: string) => {
           revenue_potential: s.revenuePotential,
           calculated_at: new Date().toISOString(),
           updated_at: new Date().toISOString(),
-        } as any, { onConflict: 'customer_user_id,farmer_id' });
+        };
+        await supabase
+          .from('farmer_client_scores')
+          .upsert(scoreUpsert, { onConflict: 'customer_user_id,farmer_id' });
       }
 
     } catch (error) {

--- a/src/hooks/useFinanceiro.ts
+++ b/src/hooks/useFinanceiro.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, useMemo } from 'react';
+import { useState, useCallback, useMemo } from 'react';
 import type { Company } from '@/contexts/CompanyContext';
 import {
   triggerFinanceiroSync,
@@ -70,8 +70,8 @@ export function useFinanceiro(defaultCompany: FinanceiroView = 'all') {
       ]);
       setResumo(prev => ({ ...prev, ...data }));
       setLastSync(syncTime);
-    } catch (e: any) {
-      setError(e.message);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
     } finally {
       setLoading(false);
     }
@@ -87,8 +87,8 @@ export function useFinanceiro(defaultCompany: FinanceiroView = 'all') {
       setLoading(true);
       const data = await getContasPagar(view === 'all' ? 'all' : view as Company, filtros);
       setContasPagar(data);
-    } catch (e: any) {
-      setError(e.message);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
     } finally {
       setLoading(false);
     }
@@ -104,8 +104,8 @@ export function useFinanceiro(defaultCompany: FinanceiroView = 'all') {
       setLoading(true);
       const data = await getContasReceber(view === 'all' ? 'all' : view as Company, filtros);
       setContasReceber(data);
-    } catch (e: any) {
-      setError(e.message);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
     } finally {
       setLoading(false);
     }
@@ -120,8 +120,8 @@ export function useFinanceiro(defaultCompany: FinanceiroView = 'all') {
       ]);
       setAgingReceber(ar);
       setAgingPagar(ap);
-    } catch (e: any) {
-      setError(e.message);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
     }
   }, [view]);
 
@@ -140,8 +140,8 @@ export function useFinanceiro(defaultCompany: FinanceiroView = 'all') {
         const data = await getDRE(view as Company, ano, meses);
         setDre(data);
       }
-    } catch (e: any) {
-      setError(e.message);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
     } finally {
       setLoading(false);
     }
@@ -153,8 +153,8 @@ export function useFinanceiro(defaultCompany: FinanceiroView = 'all') {
       const company = view === 'all' ? 'all' : view as Company;
       const data = await getFluxoCaixa(company, dataInicio, dataFim);
       setFluxoCaixa(data);
-    } catch (e: any) {
-      setError(e.message);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
     } finally {
       setLoading(false);
     }
@@ -165,8 +165,8 @@ export function useFinanceiro(defaultCompany: FinanceiroView = 'all') {
       const company = view === 'all' ? 'all' : view as Company;
       const data = await getTopInadimplentes(company, 15);
       setInadimplentes(data);
-    } catch (e: any) {
-      setError(e.message);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
     }
   }, [view]);
 
@@ -181,8 +181,8 @@ export function useFinanceiro(defaultCompany: FinanceiroView = 'all') {
       await triggerFinanceiroSync('sync_all', companies);
       // Reload local data after sync
       await loadResumo();
-    } catch (e: any) {
-      setError(e.message);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
     } finally {
       setSyncing(false);
     }
@@ -196,8 +196,8 @@ export function useFinanceiro(defaultCompany: FinanceiroView = 'all') {
         : [view as Company];
       await triggerFinanceiroSync('calcular_dre', companies, { ano, meses: [mes] });
       await loadDRE(ano, [mes]);
-    } catch (e: any) {
-      setError(e.message);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
     } finally {
       setSyncing(false);
     }
@@ -211,8 +211,8 @@ export function useFinanceiro(defaultCompany: FinanceiroView = 'all') {
         : [view as Company];
       await triggerFinanceiroSync('calcular_dre_year', companies, { ano });
       await loadDRE(ano);
-    } catch (e: any) {
-      setError(e.message);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
     } finally {
       setSyncing(false);
     }
@@ -229,24 +229,24 @@ export function useFinanceiro(defaultCompany: FinanceiroView = 'all') {
       // Heavy sync actions: call one company at a time to avoid 150s timeout
       const heavyActions = ['sync_contas_pagar', 'sync_contas_receber', 'sync_movimentacoes', 'sync_all', 'calcular_dre', 'calcular_dre_year'];
       if (heavyActions.includes(action)) {
-        const allResults: Record<string, any> = {};
+        const allResults: Record<string, unknown> = {};
         for (const co of companies) {
           try {
-            const result = await triggerFinanceiroSync(action, [co], options);
+            const result = (await triggerFinanceiroSync(action, [co], options)) as Record<string, unknown> | null | undefined;
             // Edge function returns { success, action, oben: {...} } — extract company key
             if (result?.[co]) {
               allResults[co] = result[co];
             }
-          } catch (e: any) {
-            allResults[co] = { error: e.message };
+          } catch (e) {
+            allResults[co] = { error: e instanceof Error ? e.message : String(e) };
           }
         }
         return { results: allResults };
       }
 
-      const result = await triggerFinanceiroSync(action, companies, options);
+      const result = (await triggerFinanceiroSync(action, companies, options)) as Record<string, unknown> | null | undefined;
       // Normalize: wrap company-keyed response into { results: {...} }
-      const allResults: Record<string, any> = {};
+      const allResults: Record<string, unknown> = {};
       for (const co of companies) {
         if (result?.[co]) {
           allResults[co] = result[co];
@@ -256,31 +256,31 @@ export function useFinanceiro(defaultCompany: FinanceiroView = 'all') {
         return { results: allResults };
       }
       return result;
-    } catch (e: any) {
-      setError(e.message);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
     } finally {
       setSyncing(false);
     }
   }, [view]);
 
   // Computed: DRE consolidado por mês (soma empresas quando view === 'all')
-  const dreConsolidado = useMemo(() => {
+  const dreConsolidado = useMemo<FinDRE[]>(() => {
     if (view !== 'all' || dre.length === 0) return dre;
-    const byMonth = new Map<number, any>();
+    const byMonth = new Map<number, FinDRE>();
     const numFields = [
       'receita_bruta', 'deducoes', 'receita_liquida', 'cmv', 'lucro_bruto',
       'despesas_operacionais', 'despesas_administrativas', 'despesas_comerciais',
       'despesas_financeiras', 'receitas_financeiras', 'resultado_operacional',
       'outras_receitas', 'outras_despesas', 'resultado_antes_impostos',
       'impostos', 'resultado_liquido'
-    ];
+    ] as const satisfies readonly (keyof FinDRE)[];
     for (const row of dre) {
       if (!byMonth.has(row.mes)) {
         byMonth.set(row.mes, { ...row, company: 'consolidado' });
       } else {
-        const c = byMonth.get(row.mes);
+        const c = byMonth.get(row.mes)!;
         for (const f of numFields) {
-          c[f] = (c[f] || 0) + ((row as any)[f] || 0);
+          (c[f] as number) = ((c[f] as number) || 0) + ((row[f] as number) || 0);
         }
       }
     }

--- a/tsconfig.strict.json
+++ b/tsconfig.strict.json
@@ -32,6 +32,10 @@
     "src/hooks/useFarmerExperiments.ts",
     "src/hooks/useTacticalPlan.ts",
     "src/hooks/useCrossSellEngine.ts",
-    "src/hooks/useBundleEngine.ts"
+    "src/hooks/useBundleEngine.ts",
+    "src/hooks/useFinanceiro.ts",
+    "src/hooks/useCopilotEngine.ts",
+    "src/hooks/useFarmerGovernance.ts",
+    "src/hooks/useFarmerScoring.ts"
   ]
 }


### PR DESCRIPTION
## Summary

Wave 3 da onda TS strict. Migra 4 hooks React Query high-traffic de `any` para tipos concretos, removendo **50 erros `@typescript-eslint/no-explicit-any`** do lint. **Promove os 4 hooks pro `tsconfig.strict.json` include** (anti-regressão futura via CI). Continuação de #58 (infra), #62 (5 engines IA), #64 (4 Edge Functions Omie), #68 (9 pages), #76 (7 Edge Functions wave 2).

| Hook | Any antes | Any depois | LoC |
|---|---|---|---|
| `useFinanceiro` | 16 | 0 | 336 |
| `useCopilotEngine` | 15 | 0 | 290 |
| `useFarmerGovernance` | 11 | 0 | 192 |
| `useFarmerScoring` | 10 | 0 | 452 |
| **Total** | **52** | **0** | **1270** |

Lint net dropou 50 (2 directives `eslint-disable` ficaram virando "unused" warnings — esperado pós-cleanup, não bloqueia).

## Padrões aplicados (diferente de Edge Functions)

Diferença do PR #76: hooks client-side reusam tipos gerados do Supabase:
- **`Database` types do `@/integrations/supabase/types`** reutilizados via `Tables<>`, `TablesInsert<>`, `Pick<Tables<>, '...'>` — preferência sobre inline interfaces.
- `supabase.functions.invoke(...)`: cast `data` pra `CopilotAnalyzeResponse` etc.
- `useMutation<TData, any, TVars>` → `useMutation<TData, Error, TVars>`
- `catch (e: any) { e.message }` → `catch (e) { e instanceof Error ? e.message : String(e) }`
- `.from('tabela' as any).select(...)` → cast removido (Database type cobre) ou `Row` local + `as unknown as` quando schema profundo (ex: `Json → SalesOrderItem[]` em useFarmerScoring)

## tsconfig.strict.json include +4

```json
// Antes: 14 files cobertos por strict
+ "src/hooks/useFinanceiro.ts",
+ "src/hooks/useCopilotEngine.ts",
+ "src/hooks/useFarmerGovernance.ts",
+ "src/hooks/useFarmerScoring.ts"
// Agora: 18 files
```

Strict descobriu 2 bugs latentes que os sub-agents (rodando só eslint) não pegaram:
- **`useFinanceiro.ts:1`** — `useEffect` importado mas não usado (cleanup do refactor). Removido.
- **`useFarmerScoring.ts:227`** — `call.customer_user_id: string | null` passado pra `Map<string, CustomerData>` esperando `string`. Bug latente: chamadas sem `customer_user_id` válido teriam sido pesquisadas com `null` no Map (silent `undefined` → continue). Agora explícito: `if (!cid) continue;` antes do lookup.

## Validação local

- ✅ `bun lint`: 766 → 716 (-50 problems)
- ✅ `no-explicit-any`: 644 → 594 (-50)
- ✅ `bun run build`: limpo
- ✅ `bun run test`: 241/241 passam
- ✅ `bun run typecheck:strict`: passa com 18 files no include
- ✅ Consumidores das hooks (FinanceiroDashboard, FarmerCopilot, FarmerGovernance, FarmerLOCC, FarmerCalls, AdminRoutePlanner) não quebraram — verificado por sub-agents via análise de call sites + tsc full pass

## Acumulado pós-Wave 1+2+3

- Lint: **1398 → 716 (-49%)** desde início da onda TS strict
- `no-explicit-any`: **1274 → 594 (-53%)**
- Engines IA + hooks high-value: **9 de 9 migrados** (5 engines do PR #62 + 4 hooks aqui)
- Edge Functions Omie/Sayerlack: **11 de 11 migrados**
- `tsconfig.strict.json`: **18 files protegidos contra regressão**

## Não-objetivo

- DOES NOT alterar comportamento runtime (exceto correção do bug latente em useFarmerScoring documentado acima)
- DOES NOT migrar consumidores dos hooks (pages) — isso vira Wave 4
- DOES NOT remover diretivas `eslint-disable` que ficaram "unused" — outro PR de cleanup pode varrer

## Próximos high-leverage candidates (Wave 4)

- **Pages mid-size**: AdminReposicaoAplicacao (18), FarmerCopilot (13), Recebimento (9)
- **God-components** (precisam refactor antes de tipar): FinanceiroDashboard (16, 1242L), AdminRoutePlanner (15, 1661L)
- **Edge Functions restantes**: omie-pedidos, calculate-scores, omie-nfe-recebimento

## Test plan

- [x] `bun lint` confirma -50 problems
- [x] `bun run build` passa
- [x] `bun run test` passa (241/241)
- [x] `bun run typecheck:strict` passa com 18 files (+ 4 hooks novos)
- [ ] (post-merge) Smoke test no app: abrir `/financeiro/*` (DRE, fluxo caixa, sync), `/farmer/governance`, `/farmer/scoring`/`LOCC`, e `/farmer/copilot` — confirmar que nada quebrou na UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)