### PR TITLE
feat(capture): IA extrai dados cadastrais durante chamada + wizard pós-call (PR-CAPTURE-A)

### DIFF
--- a/src/components/AppShellLayout.tsx
+++ b/src/components/AppShellLayout.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import { Outlet, useLocation } from 'react-router-dom';
 import { AppShell } from './AppShell';
 import { IncomingCallModal } from './call/IncomingCallModal';
+import { PostCallProspectWizard } from './call/PostCallProspectWizard';
 
 /**
  * Limpa scroll-locks e pointer-events deixados por overlays Radix
@@ -58,6 +59,8 @@ export function AppShellLayout() {
       <Outlet />
       {/* PR-INBOUND-CALLS: modal global pra chamadas inbound em qualquer tela autenticada */}
       <IncomingCallModal />
+      {/* PR-CAPTURE-A: wizard pós-chamada quando IA capturou dados de cliente novo */}
+      <PostCallProspectWizard />
     </AppShell>
   );
 }

--- a/src/components/call/CustomerCaptureSidebar.tsx
+++ b/src/components/call/CustomerCaptureSidebar.tsx
@@ -1,0 +1,134 @@
+import { useWebRTCCallContext } from '@/contexts/WebRTCCallContext';
+import { Card } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Sparkles, Building2, User, Mail, MapPin, Phone, FileText, Tag, Factory, Loader2 } from 'lucide-react';
+import { captureFilledCount } from '@/lib/customer-capture/merge';
+
+/**
+ * Sidebar exibida durante chamada ativa. Mostra dados cadastrais que a IA
+ * está capturando em tempo real do que o cliente fala. Vendedor pode editar
+ * cada campo inline.
+ *
+ * Compact mode: aparece como Card no painel lateral da chamada.
+ */
+export function CustomerCaptureSidebar() {
+  const {
+    isEstablished,
+    customerCaptureBuffer: c,
+    updateCustomerCaptureBuffer: update,
+    spinAnalysisStatus,
+  } = useWebRTCCallContext();
+
+  if (!isEstablished) return null;
+
+  const filled = captureFilledCount(c);
+  const isAnalyzing = spinAnalysisStatus === 'analyzing';
+
+  return (
+    <Card className="p-3 space-y-3 max-w-md">
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <Sparkles className="w-4 h-4 text-status-warning" />
+          <h3 className="text-sm font-semibold">Capturando cliente</h3>
+        </div>
+        <div className="flex items-center gap-2">
+          {isAnalyzing && <Loader2 className="w-3 h-3 animate-spin text-muted-foreground" />}
+          <Badge variant="outline" className="text-2xs">{filled} dados</Badge>
+        </div>
+      </div>
+
+      {filled === 0 && (
+        <div className="text-2xs text-muted-foreground italic">
+          Aguardando cliente revelar dados cadastrais (nome da empresa, CNPJ, endereço, email, segmento, volume mensal...)
+        </div>
+      )}
+
+      <div className="space-y-2 text-xs">
+        <FieldRow icon={Building2} label="Razão social" value={c.razao_social} onChange={(v) => update({ razao_social: v || null })} />
+        <FieldRow icon={User} label="Contato" value={c.nome_contato} onChange={(v) => update({ nome_contato: v || null })} />
+        <FieldRow icon={FileText} label="CNPJ" value={c.cnpj} onChange={(v) => update({ cnpj: v || null })} />
+        <FieldRow icon={Mail} label="Email" value={c.email} onChange={(v) => update({ email: v || null })} />
+        <FieldRow icon={Phone} label="Telefone alt." value={c.telefone_alternativo} onChange={(v) => update({ telefone_alternativo: v || null })} />
+
+        <div className="grid grid-cols-2 gap-2">
+          <FieldRow icon={MapPin} label="Cidade" value={c.cidade} onChange={(v) => update({ cidade: v || null })} compact />
+          <FieldRow icon={null} label="UF" value={c.estado} onChange={(v) => update({ estado: (v || null) as string | null })} compact />
+        </div>
+
+        <div className="grid grid-cols-2 gap-2">
+          <FieldRow icon={Factory} label="Segmento" value={c.segmento} onChange={(v) => update({ segmento: v || null })} compact />
+          <div>
+            <Label className="text-[10px] flex items-center gap-1 text-muted-foreground">Volume mensal</Label>
+            <Input
+              type="number"
+              className="h-7 text-xs"
+              value={c.volume_mensal_litros ?? ''}
+              onChange={(e) => update({ volume_mensal_litros: e.target.value ? Number(e.target.value) : null })}
+              placeholder="L/mês"
+            />
+          </div>
+        </div>
+
+        {c.produtos_interesse.length > 0 && (
+          <div>
+            <Label className="text-[10px] text-muted-foreground flex items-center gap-1">
+              <Tag className="w-2.5 h-2.5" /> Interesse
+            </Label>
+            <div className="flex flex-wrap gap-1 mt-0.5">
+              {c.produtos_interesse.map((p) => (
+                <Badge key={p} variant="outline" className="text-2xs">{p}</Badge>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {c.tags_detectadas.length > 0 && (
+          <div>
+            <Label className="text-[10px] text-muted-foreground">Tags</Label>
+            <div className="flex flex-wrap gap-1 mt-0.5">
+              {c.tags_detectadas.map((t) => (
+                <Badge key={t} variant="outline" className="text-[10px]">{t}</Badge>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+
+      <div className="text-2xs text-muted-foreground border-t border-border pt-2">
+        💡 IA detecta automaticamente conforme cliente fala. Você pode editar qualquer campo.
+        Após encerrar a chamada, abrirá wizard pra cadastrar (se cliente for novo).
+      </div>
+    </Card>
+  );
+}
+
+function FieldRow({
+  icon: Icon,
+  label,
+  value,
+  onChange,
+  compact,
+}: {
+  icon: typeof Building2 | null;
+  label: string;
+  value: string | null;
+  onChange: (v: string) => void;
+  compact?: boolean;
+}) {
+  return (
+    <div className={compact ? '' : 'space-y-0.5'}>
+      <Label className="text-[10px] text-muted-foreground flex items-center gap-1">
+        {Icon && <Icon className="w-2.5 h-2.5" />}
+        {label}
+      </Label>
+      <Input
+        className="h-7 text-xs"
+        value={value ?? ''}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder="—"
+      />
+    </div>
+  );
+}

--- a/src/components/call/PostCallProspectWizard.tsx
+++ b/src/components/call/PostCallProspectWizard.tsx
@@ -1,0 +1,202 @@
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useWebRTCCallContext } from '@/contexts/WebRTCCallContext';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Badge } from '@/components/ui/badge';
+import { Sparkles, Loader2, UserPlus, X } from 'lucide-react';
+import { useCreateProspect } from '@/hooks/useCreateProspect';
+import { formatBrPhone } from '@/lib/phone';
+
+/**
+ * Wizard que aparece após encerrar chamada inbound de cliente NÃO identificado,
+ * QUANDO a IA capturou >=2 campos cadastrais durante a conversa.
+ *
+ * Pré-preenche form com tudo que IA extraiu. Vendedor confirma e cria prospect.
+ * Próxima chamada do mesmo número será auto-identificada.
+ *
+ * PR-CAPTURE-B (próximo): adiciona sync automático nos 3 Omies aqui.
+ */
+export function PostCallProspectWizard() {
+  const { lastCallCapture, dismissLastCallCapture } = useWebRTCCallContext();
+  const navigate = useNavigate();
+  const create = useCreateProspect();
+
+  const [razaoSocial, setRazaoSocial] = useState('');
+  const [nomeContato, setNomeContato] = useState('');
+  const [email, setEmail] = useState('');
+  const [cnpj, setCnpj] = useState('');
+  const [cidade, setCidade] = useState('');
+  const [estado, setEstado] = useState('');
+  const [segmento, setSegmento] = useState('');
+
+  // Pré-preenche quando captura abre
+  useEffect(() => {
+    if (!lastCallCapture) return;
+    const c = lastCallCapture.capture;
+    setRazaoSocial(c.razao_social ?? '');
+    setNomeContato(c.nome_contato ?? '');
+    setEmail(c.email ?? '');
+    setCnpj(c.cnpj ?? '');
+    setCidade(c.cidade ?? '');
+    setEstado(c.estado ?? '');
+    setSegmento(c.segmento ?? '');
+  }, [lastCallCapture]);
+
+  if (!lastCallCapture) return null;
+
+  const handleCreate = () => {
+    if (!razaoSocial.trim()) return;
+    create.mutate(
+      {
+        razao_social: razaoSocial.trim(),
+        phone: lastCallCapture.phoneDialed,
+        nome_contato: nomeContato.trim() || undefined,
+        email: email.trim() || undefined,
+        cnpj: cnpj.trim() || undefined,
+        segmento: segmento.trim() || undefined,
+        tags: lastCallCapture.capture.tags_detectadas,
+        origin_call_id: lastCallCapture.callId ?? undefined,
+        source: 'chamada_inbound',
+      },
+      {
+        onSuccess: (data) => {
+          dismissLastCallCapture();
+          navigate(`/admin/customers/${data.user_id}`);
+        },
+      },
+    );
+  };
+
+  const c = lastCallCapture.capture;
+
+  return (
+    <Dialog open={true} onOpenChange={(open) => !open && dismissLastCallCapture()}>
+      <DialogContent className="max-w-lg max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Sparkles className="w-4 h-4 text-status-warning" />
+            Cliente novo detectado
+          </DialogTitle>
+          <DialogDescription>
+            A IA capturou estes dados durante a chamada. Revise e confirme pra cadastrar como prospect. Telefone: <strong>{formatBrPhone(lastCallCapture.phoneDialed)}</strong>
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3">
+          <div>
+            <Label className="text-xs">Razão social *</Label>
+            <Input
+              value={razaoSocial}
+              onChange={(e) => setRazaoSocial(e.target.value)}
+              placeholder="Marcenaria São Pedro Ltda"
+              autoFocus
+            />
+            {c.razao_social && (
+              <p className="text-2xs text-status-success mt-0.5">✓ Capturado da conversa</p>
+            )}
+          </div>
+
+          <div className="grid grid-cols-2 gap-2">
+            <div>
+              <Label className="text-xs">Nome do contato</Label>
+              <Input value={nomeContato} onChange={(e) => setNomeContato(e.target.value)} />
+              {c.nome_contato && <p className="text-2xs text-status-success mt-0.5">✓</p>}
+            </div>
+            <div>
+              <Label className="text-xs">CNPJ</Label>
+              <Input value={cnpj} onChange={(e) => setCnpj(e.target.value)} placeholder="00.000.000/0001-00" />
+              {c.cnpj && <p className="text-2xs text-status-success mt-0.5">✓</p>}
+            </div>
+          </div>
+
+          <div>
+            <Label className="text-xs">Email</Label>
+            <Input type="email" value={email} onChange={(e) => setEmail(e.target.value)} placeholder="contato@empresa.com" />
+            {c.email && <p className="text-2xs text-status-success mt-0.5">✓</p>}
+          </div>
+
+          <div className="grid grid-cols-3 gap-2">
+            <div className="col-span-2">
+              <Label className="text-xs">Cidade</Label>
+              <Input value={cidade} onChange={(e) => setCidade(e.target.value)} />
+              {c.cidade && <p className="text-2xs text-status-success mt-0.5">✓</p>}
+            </div>
+            <div>
+              <Label className="text-xs">UF</Label>
+              <Input value={estado} onChange={(e) => setEstado(e.target.value)} maxLength={2} />
+              {c.estado && <p className="text-2xs text-status-success mt-0.5">✓</p>}
+            </div>
+          </div>
+
+          <div>
+            <Label className="text-xs">Segmento</Label>
+            <Input value={segmento} onChange={(e) => setSegmento(e.target.value)} placeholder="marcenaria, indústria moveleira..." />
+            {c.segmento && <p className="text-2xs text-status-success mt-0.5">✓</p>}
+          </div>
+
+          {c.produtos_interesse.length > 0 && (
+            <div>
+              <Label className="text-xs">Produtos de interesse detectados</Label>
+              <div className="flex flex-wrap gap-1 mt-1">
+                {c.produtos_interesse.map((p) => (
+                  <Badge key={p} variant="outline" className="text-2xs">{p}</Badge>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {c.tags_detectadas.length > 0 && (
+            <div>
+              <Label className="text-xs">Tags detectadas (serão salvas)</Label>
+              <div className="flex flex-wrap gap-1 mt-1">
+                {c.tags_detectadas.map((t) => (
+                  <Badge key={t} variant="outline" className="text-[10px]">{t}</Badge>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {c.volume_mensal_litros && (
+            <div className="text-2xs text-muted-foreground">
+              Volume mencionado: <strong>{c.volume_mensal_litros}L/mês</strong>
+            </div>
+          )}
+
+          {c.observacoes && (
+            <div className="text-2xs text-muted-foreground italic border-l-2 border-status-warning pl-2">
+              {c.observacoes}
+            </div>
+          )}
+
+          <div className="flex items-center gap-2 pt-2 border-t border-border">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={dismissLastCallCapture}
+              disabled={create.isPending}
+              className="gap-1.5"
+            >
+              <X className="w-3.5 h-3.5" />
+              Descartar
+            </Button>
+            <Button
+              onClick={handleCreate}
+              disabled={!razaoSocial.trim() || create.isPending}
+              className="gap-1.5 flex-1"
+            >
+              {create.isPending ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <UserPlus className="w-3.5 h-3.5" />}
+              Cadastrar prospect
+            </Button>
+          </div>
+
+          <p className="text-2xs text-muted-foreground text-center">
+            Próxima chamada deste número será auto-identificada.
+          </p>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/contexts/WebRTCCallContext.tsx
+++ b/src/contexts/WebRTCCallContext.tsx
@@ -9,9 +9,10 @@ import { mixPrerollWithMic } from '@/lib/sip/audio-preroll';
 import { useTranscription } from '@/hooks/useTranscription';
 import type { TranscriptTurn, TranscriptionStatus } from '@/lib/transcription/types';
 import { useSpinAnalysis } from '@/hooks/useSpinAnalysis';
-import type { SpinAnalysis, SpinAnalysisStatus } from '@/lib/spin/types';
+import type { SpinAnalysis, SpinAnalysisStatus, CustomerCapture } from '@/lib/spin/types';
 import { resolveCustomerByPhone } from '@/lib/call-session/resolve-customer';
 import { buildSessionPayload } from '@/lib/call-session/build-session-payload';
+import { emptyCapture, mergeCustomerCapture, captureFilledCount } from '@/lib/customer-capture/merge';
 
 export type WebRTCCallState =
   | 'idle' | 'connecting' | 'calling_origin' | 'calling_destination'
@@ -69,6 +70,15 @@ export interface WebRTCCallContextValue {
   incomingCall: IncomingCallInfo | null;
   acceptIncoming: () => Promise<void>;
   rejectIncoming: () => void;
+  /** PR-CAPTURE-A: dados cadastrais acumulados durante a chamada (Claude extrai) */
+  customerCaptureBuffer: CustomerCapture;
+  /** PR-CAPTURE-A: quantos campos significativos foram capturados (usado pra decidir wizard) */
+  customerCaptureFilledCount: number;
+  /** PR-CAPTURE-A: dados capturados da última chamada encerrada, pra wizard pós-call */
+  lastCallCapture: { capture: CustomerCapture; phoneDialed: string; callId: string | null } | null;
+  dismissLastCallCapture: () => void;
+  /** PR-CAPTURE-A: vendedor pode editar buffer durante a chamada (sidebar) */
+  updateCustomerCaptureBuffer: (patch: Partial<CustomerCapture>) => void;
 }
 
 const WebRTCCallContext = createContext<WebRTCCallContextValue | null>(null);
@@ -126,6 +136,13 @@ export function WebRTCCallProvider({ children }: ProviderProps) {
   const [prerollPlaying, setPrerollPlaying] = useState(false);
   const [prerollEndsAt, setPrerollEndsAt] = useState<number | null>(null);
   const [vendorMicStream, setVendorMicStream] = useState<MediaStream | null>(null);
+  // PR-CAPTURE-A: buffer acumulador de dados cadastrais durante chamada
+  const [customerCaptureBuffer, setCustomerCaptureBuffer] = useState<CustomerCapture>(emptyCapture);
+  const [lastCallCapture, setLastCallCapture] = useState<{
+    capture: CustomerCapture;
+    phoneDialed: string;
+    callId: string | null;
+  } | null>(null);
   // PR-INBOUND-CALLS
   const [incomingCall, setIncomingCall] = useState<IncomingCallInfo | null>(null);
 
@@ -264,6 +281,7 @@ export function WebRTCCallProvider({ children }: ProviderProps) {
 
     // PR4 — Reset refs de sessão antes de iniciar nova chamada
     analysisHistoryRef.current = [];
+    setCustomerCaptureBuffer(emptyCapture()); // PR-CAPTURE-A: reset buffer
     dialedPhoneRef.current = normalized;
     callStartedAtRef.current = new Date();
 
@@ -301,6 +319,8 @@ export function WebRTCCallProvider({ children }: ProviderProps) {
     const turnsSnapshot = [...turnsRef.current];
     const analysesSnapshot = [...analysisHistoryRef.current];
     const dialedPhone = dialedPhoneRef.current;
+    // PR-CAPTURE-A: snapshot do buffer pra wizard pós-call
+    const captureSnapshot = customerCaptureBuffer;
 
     clientRef.current?.hangUp();
     cleanupAudioResources();
@@ -317,7 +337,22 @@ export function WebRTCCallProvider({ children }: ProviderProps) {
         dialedPhone,
       });
     }
-  }, []);
+
+    // PR-CAPTURE-A: dispara wizard se cliente é novo (resolveCustomerByPhone retorna null)
+    // E houve captura significativa (>=2 campos preenchidos)
+    if (dialedPhone && captureFilledCount(captureSnapshot) >= 2) {
+      void (async () => {
+        const { customerUserId } = await resolveCustomerByPhone(dialedPhone);
+        if (!customerUserId) {
+          setLastCallCapture({
+            capture: captureSnapshot,
+            phoneDialed: dialedPhone,
+            callId: null, // farmer_calls.id ainda não temos (persist é fire-and-forget); UI sem callId vinculará via phone match na criação
+          });
+        }
+      })();
+    }
+  }, [customerCaptureBuffer]);
 
   const toggleMute = useCallback(() => {
     if (!clientRef.current) return;
@@ -396,6 +431,10 @@ export function WebRTCCallProvider({ children }: ProviderProps) {
   useEffect(() => {
     if (spin.analysis && !analysisHistoryRef.current.includes(spin.analysis)) {
       analysisHistoryRef.current.push(spin.analysis);
+      // PR-CAPTURE-A: merge customerCapture da nova análise no buffer
+      if (spin.analysis.customerCapture) {
+        setCustomerCaptureBuffer((prev) => mergeCustomerCapture(prev, spin.analysis!.customerCapture));
+      }
     }
   }, [spin.analysis]);
 
@@ -403,6 +442,13 @@ export function WebRTCCallProvider({ children }: ProviderProps) {
   useEffect(() => {
     turnsRef.current = transcription.turns;
   }, [transcription.turns]);
+
+  // PR-CAPTURE-A: vendedor edita campo manual no sidebar
+  const updateCustomerCaptureBuffer = useCallback((patch: Partial<CustomerCapture>) => {
+    setCustomerCaptureBuffer((prev) => ({ ...prev, ...patch }));
+  }, []);
+
+  const dismissLastCallCapture = useCallback(() => setLastCallCapture(null), []);
 
   const value: WebRTCCallContextValue = {
     callState,
@@ -429,6 +475,11 @@ export function WebRTCCallProvider({ children }: ProviderProps) {
     incomingCall,
     acceptIncoming,
     rejectIncoming,
+    customerCaptureBuffer,
+    customerCaptureFilledCount: captureFilledCount(customerCaptureBuffer),
+    lastCallCapture,
+    dismissLastCallCapture,
+    updateCustomerCaptureBuffer,
   };
 
   return <WebRTCCallContext.Provider value={value}>{children}</WebRTCCallContext.Provider>;

--- a/src/lib/customer-capture/merge.test.ts
+++ b/src/lib/customer-capture/merge.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { emptyCapture, mergeCustomerCapture, captureFilledCount } from './merge';
+import type { CustomerCapture } from '@/lib/spin/types';
+
+describe('mergeCustomerCapture', () => {
+  it('incoming null retorna buffer inalterado', () => {
+    const buf = emptyCapture();
+    buf.razao_social = 'Marcenaria X';
+    const result = mergeCustomerCapture(buf, null);
+    expect(result).toEqual(buf);
+  });
+
+  it('preenche campos vazios do buffer com valores do incoming', () => {
+    const buf = emptyCapture();
+    const incoming: CustomerCapture = { ...emptyCapture(), razao_social: 'Marcenaria X', cnpj: '12345' };
+    const result = mergeCustomerCapture(buf, incoming);
+    expect(result.razao_social).toBe('Marcenaria X');
+    expect(result.cnpj).toBe('12345');
+  });
+
+  it('incoming sobrescreve scalar não-null do buffer (versão nova ganha)', () => {
+    const buf = emptyCapture();
+    buf.razao_social = 'Velho';
+    buf.email = 'velho@x.com';
+    const incoming: CustomerCapture = { ...emptyCapture(), razao_social: 'Novo' };
+    const result = mergeCustomerCapture(buf, incoming);
+    expect(result.razao_social).toBe('Novo'); // sobrescrito
+    expect(result.email).toBe('velho@x.com'); // mantido (incoming era null)
+  });
+
+  it('arrays fazem union deduplicado case-insensitive', () => {
+    const buf = emptyCapture();
+    buf.produtos_interesse = ['PU 2K', 'verniz'];
+    buf.tags_detectadas = ['alto_padrao'];
+    const incoming: CustomerCapture = {
+      ...emptyCapture(),
+      produtos_interesse: ['pu 2k', 'primer'], // 'pu 2k' duplica com 'PU 2K'
+      tags_detectadas: ['alto_padrao', 'cabine_pressurizada'],
+    };
+    const result = mergeCustomerCapture(buf, incoming);
+    expect(result.produtos_interesse).toEqual(['PU 2K', 'verniz', 'primer']);
+    expect(result.tags_detectadas).toEqual(['alto_padrao', 'cabine_pressurizada']);
+  });
+
+  it('string vazia em incoming NÃO sobrescreve buffer', () => {
+    const buf = emptyCapture();
+    buf.cidade = 'BH';
+    const incoming: CustomerCapture = { ...emptyCapture(), cidade: '' };
+    const result = mergeCustomerCapture(buf, incoming);
+    expect(result.cidade).toBe('BH');
+  });
+});
+
+describe('captureFilledCount', () => {
+  it('empty retorna 0', () => {
+    expect(captureFilledCount(emptyCapture())).toBe(0);
+  });
+
+  it('conta campos preenchidos', () => {
+    const c = emptyCapture();
+    c.razao_social = 'X';
+    c.cnpj = '123';
+    c.email = 'a@b.c';
+    c.produtos_interesse = ['PU'];
+    expect(captureFilledCount(c)).toBe(4);
+  });
+
+  it('array vazio não conta', () => {
+    const c = emptyCapture();
+    c.razao_social = 'X';
+    c.produtos_interesse = [];
+    expect(captureFilledCount(c)).toBe(1);
+  });
+});

--- a/src/lib/customer-capture/merge.ts
+++ b/src/lib/customer-capture/merge.ts
@@ -1,0 +1,97 @@
+import type { CustomerCapture } from '@/lib/spin/types';
+
+const EMPTY_CAPTURE: CustomerCapture = {
+  razao_social: null,
+  nome_contato: null,
+  cnpj: null,
+  email: null,
+  telefone_alternativo: null,
+  cidade: null,
+  estado: null,
+  endereco: null,
+  segmento: null,
+  porte_estimado: null,
+  volume_mensal_litros: null,
+  produtos_interesse: [],
+  tags_detectadas: [],
+  observacoes: null,
+};
+
+export function emptyCapture(): CustomerCapture {
+  return { ...EMPTY_CAPTURE, produtos_interesse: [], tags_detectadas: [] };
+}
+
+/**
+ * Faz merge incremental de capture do Claude com o buffer acumulado.
+ * Para cada campo:
+ * - Scalar (string/number): se incoming.field != null, sobrescreve (versão mais nova ganha)
+ * - Array: faz union deduplicado (case-insensitive)
+ *
+ * Pattern: análises subsequentes refinam dados sem perder o que já foi capturado.
+ */
+export function mergeCustomerCapture(
+  buffer: CustomerCapture,
+  incoming: CustomerCapture | null | undefined
+): CustomerCapture {
+  if (!incoming) return buffer;
+
+  const merged: CustomerCapture = { ...buffer };
+
+  // Scalar fields: incoming sobrescreve se != null
+  const scalarFields: (keyof CustomerCapture)[] = [
+    'razao_social',
+    'nome_contato',
+    'cnpj',
+    'email',
+    'telefone_alternativo',
+    'cidade',
+    'estado',
+    'endereco',
+    'segmento',
+    'porte_estimado',
+    'volume_mensal_litros',
+    'observacoes',
+  ];
+  for (const f of scalarFields) {
+    const v = incoming[f];
+    if (v !== null && v !== undefined && v !== '') {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (merged[f] as any) = v;
+    }
+  }
+
+  // Arrays: union deduplicado case-insensitive
+  merged.produtos_interesse = unionDedupe(buffer.produtos_interesse, incoming.produtos_interesse);
+  merged.tags_detectadas = unionDedupe(buffer.tags_detectadas, incoming.tags_detectadas);
+
+  return merged;
+}
+
+function unionDedupe(a: string[], b: string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const v of [...a, ...b]) {
+    const key = v.trim().toLowerCase();
+    if (!key || seen.has(key)) continue;
+    seen.add(key);
+    out.push(v.trim());
+  }
+  return out;
+}
+
+/**
+ * Conta quantos campos significativos estão preenchidos.
+ * Usado pra decidir se vale a pena abrir wizard pós-call.
+ */
+export function captureFilledCount(c: CustomerCapture): number {
+  let count = 0;
+  if (c.razao_social) count++;
+  if (c.nome_contato) count++;
+  if (c.cnpj) count++;
+  if (c.email) count++;
+  if (c.cidade) count++;
+  if (c.segmento) count++;
+  if (c.volume_mensal_litros) count++;
+  if (c.produtos_interesse.length > 0) count++;
+  return count;
+}

--- a/src/lib/spin/types.ts
+++ b/src/lib/spin/types.ts
@@ -37,6 +37,28 @@ export interface ExtractedEntity {
   confidence: number;  // 0-1
 }
 
+/**
+ * Dados cadastrais do cliente extraídos da conversa (PR-CAPTURE-A).
+ * Acumula progressivamente ao longo das análises da chamada.
+ * Vendedor revisa no wizard pós-call antes de cadastrar.
+ */
+export interface CustomerCapture {
+  razao_social: string | null;
+  nome_contato: string | null;
+  cnpj: string | null;
+  email: string | null;
+  telefone_alternativo: string | null;
+  cidade: string | null;
+  estado: string | null;
+  endereco: string | null;
+  segmento: string | null;
+  porte_estimado: 'pequeno' | 'medio' | 'grande' | null;
+  volume_mensal_litros: number | null;
+  produtos_interesse: string[];
+  tags_detectadas: string[];
+  observacoes: string | null;
+}
+
 export interface SpinAnalysis {
   /** Estágio atual da conversa segundo SPIN */
   spinStage: SpinStage;
@@ -86,6 +108,8 @@ export interface SpinAnalysis {
   }>;
   /** NOVO: entidades econômicas extraídas (PR4+ vai persistir no perfil 360) */
   entitiesExtracted: ExtractedEntity[];
+  /** PR-CAPTURE-A: dados cadastrais do cliente (acumula progressivamente). null se nada relevante foi falado. */
+  customerCapture?: CustomerCapture | null;
 }
 
 export type SpinAnalysisStatus = 'idle' | 'analyzing' | 'ready' | 'error';

--- a/src/pages/FarmerCalls.tsx
+++ b/src/pages/FarmerCalls.tsx
@@ -18,6 +18,7 @@ import { useFarmerScoring } from '@/hooks/useFarmerScoring';
 import { cn } from '@/lib/utils';
 import { Dialer } from '@/components/call/Dialer';
 import { TranscriptionPanel } from '@/components/call/TranscriptionPanel';
+import { CustomerCaptureSidebar } from '@/components/call/CustomerCaptureSidebar';
 import type { NvoipCallState } from '@/hooks/useNvoipCall';
 import { useCallBackend } from '@/hooks/useCallBackend';
 import { useWebRTCCall } from '@/hooks/useWebRTCCall';
@@ -843,6 +844,13 @@ const FarmerCalls = () => {
           spinAnalysis={webrtc.spinAnalysis}
           spinError={webrtc.spinAnalysisError}
         />
+      )}
+
+      {/* PR-CAPTURE-A: Sidebar de captura de dados cadastrais durante chamada WebRTC */}
+      {callBackend === 'webrtc' && webrtc.callState === 'established' && (
+        <div className="fixed left-4 bottom-4 z-30">
+          <CustomerCaptureSidebar />
+        </div>
       )}
 
       {/* Botão pra reabrir o painel se vendedor fechou acidentalmente */}

--- a/supabase/functions/claude-spin-analyze/index.ts
+++ b/supabase/functions/claude-spin-analyze/index.ts
@@ -77,6 +77,30 @@ Em QUALQUER playbook, se aparecer oportunidade, preencha \`ticketLeverage\` com 
 
 Se não há oportunidade clara, use \`tactic: "none"\` e \`suggestion: ""\`.
 
+# Customer Capture — Dados cadastrais do cliente novo (customerCapture)
+
+Quando o cliente fala dados que servem pra CADASTRAR ele na base (ex: cliente novo que ligou pela primeira vez), preencha \`customerCapture\` com TUDO que foi explicitamente revelado:
+
+- **razao_social**: nome da empresa ("Marcenaria São Pedro", "São Pedro Móveis Planejados")
+- **nome_contato**: nome da pessoa que falou ("aqui é o João", "fala com a Maria")
+- **cnpj**: se mencionado, formato XX.XXX.XXX/XXXX-XX
+- **email**: se ditado ou soletrado
+- **telefone_alternativo**: outro telefone além do que está sendo usado na chamada
+- **cidade / estado**: localização mencionada ("aqui em Belo Horizonte", "fica em Minas")
+- **endereco**: se cliente passou endereço completo
+- **segmento**: detecte pelo contexto — "marcenaria", "indústria moveleira", "oficina automotiva", "marcenaria pequena", "industrial"
+- **porte_estimado**: pelo volume mencionado — pequeno (<50L/mês), médio (50-500L), grande (>500L)
+- **volume_mensal_litros**: se citado consumo mensal
+- **produtos_interesse**: array dos tipos de tinta/produto que cliente mencionou ("PU 2K", "hidrossolúvel", "verniz fosco")
+- **tags_detectadas**: palavras-chave técnicas relevantes ("alto_padrão", "cabine_pressurizada", "lixamento_manual")
+- **observacoes**: contexto livre relevante pro cadastro futuro
+
+REGRAS:
+- Se cliente JÁ é conhecido (não é primeiro contato), preenche mesmo assim — pode atualizar dados existentes
+- Se cliente NÃO mencionou um dado, deixe null. NUNCA invente
+- Se nada relevante foi falado, retorne customerCapture com produtos_interesse=[] e tags_detectadas=[] (mas pode retornar null como objeto inteiro também se 0 dados)
+- Acumule progressivamente — primeira análise pode ter só razão social; análise posterior pode adicionar email + cidade
+
 # Extração de entidades econômicas (entitiesExtracted)
 
 Em CADA análise, popule \`entitiesExtracted\` com tudo que o cliente revelou que vai pro perfil 360 dele:
@@ -235,6 +259,27 @@ const SPIN_ANALYSIS_TOOL = {
           },
           required: ["type", "value", "context", "confidence"],
         },
+      },
+      customerCapture: {
+        type: ["object", "null"],
+        description: "Dados cadastrais do cliente extraídos da conversa (PR-CAPTURE-A). Preenche SÓ se cliente revelou explicitamente. Vendedor revisa antes de cadastrar.",
+        properties: {
+          razao_social: { type: ["string", "null"], description: "Razão social ou nome fantasia da empresa" },
+          nome_contato: { type: ["string", "null"], description: "Nome da pessoa que está falando" },
+          cnpj: { type: ["string", "null"], description: "CNPJ no formato XX.XXX.XXX/XXXX-XX se mencionado" },
+          email: { type: ["string", "null"], description: "Email do contato ou empresa" },
+          telefone_alternativo: { type: ["string", "null"], description: "Outro telefone mencionado (alternativo ao da chamada)" },
+          cidade: { type: ["string", "null"] },
+          estado: { type: ["string", "null"], description: "Sigla UF (ex: MG)" },
+          endereco: { type: ["string", "null"], description: "Endereço completo se mencionado" },
+          segmento: { type: ["string", "null"], description: "marcenaria, indústria moveleira, oficina automotiva, etc" },
+          porte_estimado: { type: ["string", "null"], enum: ["pequeno", "medio", "grande", null], description: "Baseado em volume mencionado" },
+          volume_mensal_litros: { type: ["number", "null"], description: "Consumo mensal de tinta mencionado em L" },
+          produtos_interesse: { type: "array", items: { type: "string" }, description: "Produtos/categorias que o cliente mencionou interesse" },
+          tags_detectadas: { type: "array", items: { type: "string" }, description: "Tags relevantes: pu_2k, hidrossolúvel, alto_padrão, etc" },
+          observacoes: { type: ["string", "null"], description: "Notas livres relevantes pro cadastro (preferências, peculiaridades)" },
+        },
+        required: ["produtos_interesse", "tags_detectadas"],
       },
     },
     required: [


### PR DESCRIPTION
## Summary

**PR-CAPTURE-A** — Quando cliente novo liga, a IA **extrai dados cadastrais em tempo real** do que ele fala (razão social, CNPJ, email, cidade, segmento, volume mensal, produtos de interesse). Vendedor vê tudo sendo capturado num sidebar lateral. Ao encerrar a chamada (se cliente é novo), **wizard pré-preenchido** abre automaticamente — vendedor confirma e cliente é cadastrado com tudo pronto.

**Stacked sobre PR #85** (PR-CUSTOMERS-MGMT) — reusa `useCreateProspect`.

**PR-CAPTURE-B (próximo)** vai adicionar sync automático nos 3 Omies (Colacor + Oben + Colacor SC).

## Como funciona

```
1. Cliente novo (31) 99999-1234 liga (PR-INBOUND-CALLS)
   → IncomingCallModal: "Cliente não identificado"
   → Vendedor atende

2. Cliente: "Aqui é o João da Marcenaria São Pedro,
              CNPJ 12.345.678/0001-90, fica em Belo Horizonte.
              Compramos 200L de PU por mês,
              email contato@saopedro.com.br"

3. Copilot Claude analisa transcript (PR3.5) com tool schema expandido:
   → customerCapture: {
       razao_social: "Marcenaria São Pedro",
       cnpj: "12.345.678/0001-90",
       cidade: "Belo Horizonte",
       nome_contato: "João",
       email: "contato@saopedro.com.br",
       volume_mensal_litros: 200,
       segmento: "marcenaria",
       produtos_interesse: ["PU"],
       tags_detectadas: []
     }

4. Sidebar lateral (CustomerCaptureSidebar) mostra em tempo real:
   ✓ Marcenaria São Pedro
   ✓ CNPJ 12.345.678/0001-90 [editar]
   ✓ João (contato)
   ✓ Belo Horizonte
   ✓ contato@saopedro.com.br
   ✓ 200L/mês — marcenaria

5. Vendedor encerra chamada
   → endCall snapshota customerCaptureBuffer
   → SE cliente novo (resolveCustomerByPhone retorna null) E filledCount >= 2
   → PostCallProspectWizard abre automaticamente

6. Wizard pré-preenchido com tudo capturado
   → Vendedor revisa (campos com ✓ = vieram da IA), pode editar
   → Submit → useCreateProspect (PR-CUSTOMERS-MGMT) → cria profile + customer_contact primary
   → Redirect pra /admin/customers/:newId

7. Próxima chamada do mesmo número → IncomingCallModal mostra
   "João (Contato) — Marcenaria São Pedro" — fluxo perfeito
```

## Arquitetura

| Camada | Mudança |
|---|---|
| Edge fn `claude-spin-analyze` | SYSTEM_PROMPT expandido com instruções de extração cadastral + tool schema ganha `customerCapture` opcional (15 campos) |
| Types `SpinAnalysis` | + `customerCapture?: CustomerCapture \| null` (interface nova com 15 fields) |
| Helper TDD | `src/lib/customer-capture/merge.ts` (+8 testes) — merge incremental que combina N análises num buffer (scalars sobrescrevem se !=null; arrays fazem union deduplicado) |
| Context `WebRTCCallContext` | Buffer `customerCaptureBuffer` + effect que faz merge a cada nova análise + snapshot no endCall + state `lastCallCapture` pra wizard |
| Componente `CustomerCaptureSidebar` | Painel fixed bottom-left durante chamada — mostra dados capturados live, vendedor edita inline |
| Componente `PostCallProspectWizard` | Modal pós-call (auto) com form pré-preenchido + badge ✓ nos campos vindos da IA |
| Wire | `AppShellLayout` renderiza wizard globalmente; `FarmerCalls` renderiza sidebar |

## Custo

Output do Claude cresce ~5-10% (campos novos no schema), mas só se cliente revelar dados. ~$0.001-0.005 adicional por análise. Mais que pago pelo valor (cliente cadastrado em segundos vs 10min de digitação manual).

## Testes

- **251 → 259** (+8 testes do merge helper)
- tsc clean ✅
- bun build passa ✅

## Edge cases

- **Cliente não revela nada**: filledCount=0, wizard não abre. Vendedor pode criar manual via PR-CUSTOMERS-MGMT.
- **Cliente ID via phone match** (já é customer): wizard NÃO abre. Buffer é descartado.
- **Múltiplas análises mencionam mesma empresa**: merge mantém versão mais recente (scalar) ou union (arrays).
- **Vendedor edita sidebar durante chamada**: edits sobrevivem ao snapshot final.
- **Cliente diz CNPJ errado e corrige depois**: análise posterior sobrescreve. Vendedor revisa no wizard.

## Não incluso (PR-CAPTURE-B, próximo)

- **Sync automático nos 3 Omies** (Colacor / Oben / Colacor SC) — quando wizard submete, cria cliente nos 3 ERPs com API Omie + grava `omie_clientes` mapping
- Edge fn `omie-create-customer` por empresa (3 secrets: `OMIE_API_KEY_COLACOR/OBEN/COLACOR_SC`)
- Confirmação de criação por empresa (toast: "Criado em Colacor + Oben + Colacor SC")

## Test plan

Após merge + Copilot ANTHROPIC_API_KEY já configurada:
- [ ] Discar pra número novo (não cadastrado) e atender com WebRTC ativo
- [ ] Mencionar verbalmente: razão social + CNPJ + cidade + email + volume + segmento
- [ ] Ver sidebar capturando em ~3s (após primeiro turno final do cliente)
- [ ] Editar manualmente qualquer campo — persiste
- [ ] Encerrar chamada → wizard abre auto
- [ ] Confirmar → redirect pra ficha do prospect

🤖 Generated with [Claude Code](https://claude.com/claude-code)