### PR TITLE
feat(omie): sync automático nos 3 Omies ao criar prospect (PR-CAPTURE-B)

### DIFF
--- a/src/components/call/PostCallProspectWizard.tsx
+++ b/src/components/call/PostCallProspectWizard.tsx
@@ -60,6 +60,11 @@ export function PostCallProspectWizard() {
         tags: lastCallCapture.capture.tags_detectadas,
         origin_call_id: lastCallCapture.callId ?? undefined,
         source: 'chamada_inbound',
+        // PR-CAPTURE-B: passa pros sync Omie
+        cidade: cidade.trim() || undefined,
+        estado: estado.trim() || undefined,
+        endereco: lastCallCapture.capture.endereco ?? undefined,
+        sync_omie: true,
       },
       {
         onSuccess: (data) => {

--- a/src/hooks/useCopilotEngine.ts
+++ b/src/hooks/useCopilotEngine.ts
@@ -26,13 +26,25 @@ export interface TranscriptEntry {
   isPartial?: boolean;
 }
 
+export type CopilotContext = Record<string, unknown>;
+
 export interface CopilotSession {
   id: string;
   customerId?: string;
   customerName?: string;
   startedAt: Date;
-  bundleContext?: any;
-  customerContext?: any;
+  bundleContext?: CopilotContext;
+  customerContext?: CopilotContext;
+}
+
+interface CopilotAnalyzeResponse {
+  intent?: CopilotIntent;
+  phase?: CopilotPhase;
+  direction?: CopilotDirection;
+  direction_reasons?: string[];
+  suggestion?: string;
+  suggestion_type?: SuggestionType;
+  confidence?: number;
 }
 
 interface CopilotState {
@@ -70,21 +82,21 @@ export const useCopilotEngine = () => {
   const startSession = useCallback(async (params: {
     customerId?: string;
     customerName?: string;
-    bundleContext?: any;
-    customerContext?: any;
+    bundleContext?: CopilotContext;
+    customerContext?: CopilotContext;
   }) => {
     if (!user?.id) return;
 
     const { data } = await supabase
-      .from('farmer_copilot_sessions' as any)
+      .from('farmer_copilot_sessions')
       .insert({
         farmer_id: user.id,
         customer_user_id: params.customerId || null,
-      } as any)
+      })
       .select('id')
       .single();
 
-    const sessionId = (data as any)?.id || crypto.randomUUID();
+    const sessionId = data?.id || crypto.randomUUID();
     sessionIdRef.current = sessionId;
 
     const session: CopilotSession = {
@@ -125,7 +137,7 @@ export const useCopilotEngine = () => {
       const durationSeconds = Math.round((Date.now() - startTime.getTime()) / 1000);
 
       await supabase
-        .from('farmer_copilot_sessions' as any)
+        .from('farmer_copilot_sessions')
         .update({
           ended_at: new Date().toISOString(),
           duration_seconds: durationSeconds,
@@ -135,7 +147,7 @@ export const useCopilotEngine = () => {
           suggestions_shown: state.suggestionsShown,
           suggestions_used: state.suggestionsUsed,
           result: 'finalizado',
-        } as any)
+        })
         .eq('id', sessionIdRef.current);
     }
 
@@ -206,14 +218,15 @@ export const useCopilotEngine = () => {
 
           if (error || !data) throw error || new Error('No data');
 
+          const payload = data as CopilotAnalyzeResponse;
           const analysis: CopilotAnalysis = {
-            intent: data.intent || 'indiferenca',
-            phase: data.phase || 'abertura',
-            direction: data.direction || 'neutro',
-            directionReasons: data.direction_reasons || [],
-            suggestion: data.suggestion || '',
-            suggestionType: data.suggestion_type || 'pergunta_diagnostica',
-            confidence: data.confidence || 0,
+            intent: payload.intent || 'indiferenca',
+            phase: payload.phase || 'abertura',
+            direction: payload.direction || 'neutro',
+            directionReasons: payload.direction_reasons || [],
+            suggestion: payload.suggestion || '',
+            suggestionType: payload.suggestion_type || 'pergunta_diagnostica',
+            confidence: payload.confidence || 0,
           };
 
           setState(s => ({
@@ -226,7 +239,7 @@ export const useCopilotEngine = () => {
 
           // Log event
           if (sessionIdRef.current) {
-            await supabase.from('farmer_copilot_events' as any).insert({
+            await supabase.from('farmer_copilot_events').insert({
               session_id: sessionIdRef.current,
               event_type: 'suggestion',
               event_data: {
@@ -238,7 +251,7 @@ export const useCopilotEngine = () => {
               },
               transcript_snippet: fullText.slice(-200),
               suggestion_text: analysis.suggestion,
-            } as any);
+            });
           }
         } catch (err) {
           console.error('Analysis error:', err);
@@ -255,12 +268,12 @@ export const useCopilotEngine = () => {
     setState(prev => ({ ...prev, suggestionsUsed: prev.suggestionsUsed + 1 }));
 
     if (sessionIdRef.current) {
-      await supabase.from('farmer_copilot_events' as any).insert({
+      await supabase.from('farmer_copilot_events').insert({
         session_id: sessionIdRef.current,
         event_type: 'suggestion_used',
         suggestion_text: suggestionText,
         suggestion_used: true,
-      } as any);
+      });
     }
   }, []);
 
@@ -269,12 +282,12 @@ export const useCopilotEngine = () => {
     if (!sessionIdRef.current) return;
 
     await supabase
-      .from('farmer_copilot_sessions' as any)
+      .from('farmer_copilot_sessions')
       .update({
         result,
         revenue_generated: revenue,
         margin_generated: margin,
-      } as any)
+      })
       .eq('id', sessionIdRef.current);
   }, []);
 

--- a/src/hooks/useCreateProspect.ts
+++ b/src/hooks/useCreateProspect.ts
@@ -12,6 +12,12 @@ export interface CreateProspectInput {
   tags?: string[];
   origin_call_id?: string;
   source?: 'chamada_inbound' | 'chamada_outbound' | 'walk_in' | 'manual';
+  /** PR-CAPTURE-B: campos opcionais pra sync Omie multi-empresa */
+  cidade?: string;
+  estado?: string;
+  endereco?: string;
+  /** Default true: dispara sync nos 3 Omies em fire-and-forget após criar profile. */
+  sync_omie?: boolean;
 }
 
 export interface CreateProspectResponse {
@@ -25,19 +31,78 @@ export interface CreateProspectResponse {
   };
 }
 
+export interface OmieMultiResult {
+  ok: boolean;
+  summary: { created: number; errors: number; skipped: number; total: number };
+  results: Array<{
+    empresa: 'colacor' | 'oben' | 'colacor_sc';
+    empresa_label: string;
+    status: 'created' | 'skipped_no_secret' | 'error';
+    codigo_cliente_omie?: number;
+    error?: string;
+  }>;
+}
+
 /**
  * Cria prospect (cliente novo cadastrado pelo vendedor). Edge fn usa service
  * role pra criar auth.users dummy + profile com is_prospect=true. Se passar
  * origin_call_id, retroativa farmer_calls.customer_user_id.
  *
- * Quando cliente real fizer signup no futuro (se você abrir app pra clientes),
- * basta flipar is_prospect=false e setar email/password real.
+ * PR-CAPTURE-B: dispara `omie-create-customer-multi` fire-and-forget pra
+ * sincronizar nas 3 contas Omie em paralelo (toast com summary depois).
+ * Falhas no Omie NÃO bloqueiam o sucesso do prospect (graceful degradation).
  */
 export function useCreateProspect() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: async (input: CreateProspectInput): Promise<CreateProspectResponse> => {
-      return await invokeFunction<CreateProspectResponse>('create-prospect-customer', input);
+      const resp = await invokeFunction<CreateProspectResponse>('create-prospect-customer', input);
+
+      // PR-CAPTURE-B: sync Omie multi-empresa fire-and-forget
+      const shouldSyncOmie = input.sync_omie !== false && resp.user_id;
+      if (shouldSyncOmie) {
+        invokeFunction<OmieMultiResult>('omie-create-customer-multi', {
+          user_id: resp.user_id,
+          razao_social: input.razao_social,
+          cnpj: input.cnpj ?? null,
+          email: input.email ?? null,
+          phone: input.phone,
+          nome_contato: input.nome_contato ?? null,
+          cidade: input.cidade ?? null,
+          estado: input.estado ?? null,
+          endereco: input.endereco ?? null,
+          tags: input.tags ?? [],
+        })
+          .then((omieResult) => {
+            const { summary } = omieResult;
+            if (summary.created > 0) {
+              const empresasOk = omieResult.results
+                .filter((r) => r.status === 'created')
+                .map((r) => r.empresa_label)
+                .join(' + ');
+              toast.success(`Sincronizado no Omie: ${empresasOk}`, {
+                description: summary.errors > 0 || summary.skipped > 0
+                  ? `${summary.errors} erro(s), ${summary.skipped} skipped`
+                  : undefined,
+              });
+            } else if (summary.skipped === summary.total) {
+              toast.info('Sync Omie skipped — secrets não configuradas');
+            } else {
+              const firstError = omieResult.results.find((r) => r.error)?.error;
+              toast.warning('Sync Omie falhou em todas as empresas', {
+                description: firstError,
+              });
+            }
+          })
+          .catch((err) => {
+            console.error('[useCreateProspect] omie sync failed:', err);
+            toast.warning('Sync Omie falhou', {
+              description: err instanceof Error ? err.message : 'Erro desconhecido',
+            });
+          });
+      }
+
+      return resp;
     },
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ['farmer-pending-link'] });

--- a/src/hooks/useFarmerGovernance.ts
+++ b/src/hooks/useFarmerGovernance.ts
@@ -2,6 +2,11 @@ import { useState, useEffect } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
 import { toast } from 'sonner';
+import type { Tables, TablesInsert } from '@/integrations/supabase/types';
+
+type GovernanceProposalRow = Tables<'farmer_governance_proposals'>;
+type AuditLogRow = Tables<'farmer_audit_log'>;
+type ProfileRow = Pick<Tables<'profiles'>, 'user_id' | 'name'>;
 
 export interface GovernanceProposal {
   id: string;
@@ -27,7 +32,7 @@ export interface GovernanceProposal {
 export const useFarmerGovernance = () => {
   const { user } = useAuth();
   const [proposals, setProposals] = useState<GovernanceProposal[]>([]);
-  const [auditLogs, setAuditLogs] = useState<any[]>([]);
+  const [auditLogs, setAuditLogs] = useState<AuditLogRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [isGovernor, setIsGovernor] = useState(false);
 
@@ -50,22 +55,42 @@ export const useFarmerGovernance = () => {
     try {
       const [proposalsRes, logsRes] = await Promise.all([
         supabase.from('farmer_governance_proposals')
-          .select('*').order('created_at', { ascending: false }) as any,
+          .select('*').order('created_at', { ascending: false }),
         supabase.from('farmer_audit_log')
-          .select('*').order('created_at', { ascending: false }).limit(50) as any,
+          .select('*').order('created_at', { ascending: false }).limit(50),
       ]);
 
       if (proposalsRes.data) {
+        const rows = proposalsRes.data as GovernanceProposalRow[];
         // Load proposer names
-        const proposerIds = [...new Set(proposalsRes.data.map((p: any) => p.proposed_by))] as string[];
+        const proposerIds = [...new Set(rows.map((p) => p.proposed_by))];
         const { data: profiles } = await supabase
           .from('profiles').select('user_id, name').in('user_id', proposerIds);
-        const nameMap = new Map((profiles || []).map((p: any) => [p.user_id, p.name]));
-        setProposals(proposalsRes.data.map((p: any) => ({
-          ...p, proposer_name: nameMap.get(p.proposed_by) || 'Desconhecido',
+        const nameMap = new Map(
+          ((profiles || []) as ProfileRow[]).map((p) => [p.user_id, p.name])
+        );
+        setProposals(rows.map((p) => ({
+          id: p.id,
+          proposed_by: p.proposed_by,
+          proposal_type: p.proposal_type,
+          title: p.title,
+          description: p.description,
+          current_params: (p.current_params ?? {}) as Record<string, number>,
+          proposed_params: (p.proposed_params ?? {}) as Record<string, number>,
+          impact_revenue_pct: p.impact_revenue_pct,
+          impact_margin_pct: p.impact_margin_pct,
+          impact_churn_pct: p.impact_churn_pct,
+          impact_margin_per_hour: p.impact_margin_per_hour,
+          status: p.status ?? 'pendente',
+          approved_by: p.approved_by,
+          approved_at: p.approved_at,
+          rejection_reason: p.rejection_reason,
+          algorithm_version: p.algorithm_version ?? 'v1.0',
+          created_at: p.created_at ?? '',
+          proposer_name: nameMap.get(p.proposed_by) || 'Desconhecido',
         })));
       }
-      if (logsRes.data) setAuditLogs(logsRes.data);
+      if (logsRes.data) setAuditLogs(logsRes.data as AuditLogRow[]);
     } catch (error) {
       console.error('Error loading governance data:', error);
     } finally {
@@ -85,11 +110,14 @@ export const useFarmerGovernance = () => {
     impact_margin_per_hour?: number;
   }) => {
     if (!user) return;
-    const { error } = await supabase.from('farmer_governance_proposals').insert({
+    const proposalInsert: TablesInsert<'farmer_governance_proposals'> = {
       ...proposal,
       proposed_by: user.id,
       algorithm_version: 'v1.0',
-    } as any);
+    };
+    const { error } = await supabase
+      .from('farmer_governance_proposals')
+      .insert(proposalInsert);
 
     if (error) {
       toast.error('Erro ao criar proposta');
@@ -97,7 +125,7 @@ export const useFarmerGovernance = () => {
     }
 
     // Audit log
-    await supabase.from('farmer_audit_log').insert({
+    const auditInsert: TablesInsert<'farmer_audit_log'> = {
       action: 'proposal_created',
       entity_type: 'governance_proposal',
       performed_by: user.id,
@@ -105,11 +133,12 @@ export const useFarmerGovernance = () => {
       previous_params: proposal.current_params,
       new_params: proposal.proposed_params,
       projection: {
-        revenue_pct: proposal.impact_revenue_pct,
-        margin_pct: proposal.impact_margin_pct,
-        churn_pct: proposal.impact_churn_pct,
+        revenue_pct: proposal.impact_revenue_pct ?? null,
+        margin_pct: proposal.impact_margin_pct ?? null,
+        churn_pct: proposal.impact_churn_pct ?? null,
       },
-    } as any);
+    };
+    await supabase.from('farmer_audit_log').insert(auditInsert);
 
     toast.success('Proposta criada com sucesso');
     loadData();
@@ -141,7 +170,7 @@ export const useFarmerGovernance = () => {
       }).eq('id', proposalId);
 
     // Audit log
-    await supabase.from('farmer_audit_log').insert({
+    const approveAudit: TablesInsert<'farmer_audit_log'> = {
       action: 'proposal_approved',
       entity_type: 'governance_proposal',
       entity_id: proposalId,
@@ -150,11 +179,12 @@ export const useFarmerGovernance = () => {
       previous_params: proposal.current_params,
       new_params: proposal.proposed_params,
       projection: {
-        revenue_pct: proposal.impact_revenue_pct,
-        margin_pct: proposal.impact_margin_pct,
-        churn_pct: proposal.impact_churn_pct,
+        revenue_pct: proposal.impact_revenue_pct ?? null,
+        margin_pct: proposal.impact_margin_pct ?? null,
+        churn_pct: proposal.impact_churn_pct ?? null,
       },
-    } as any);
+    };
+    await supabase.from('farmer_audit_log').insert(approveAudit);
 
     toast.success('Proposta aprovada e aplicada');
     loadData();
@@ -173,13 +203,14 @@ export const useFarmerGovernance = () => {
         updated_at: new Date().toISOString(),
       }).eq('id', proposalId);
 
-    await supabase.from('farmer_audit_log').insert({
+    const rejectAudit: TablesInsert<'farmer_audit_log'> = {
       action: 'proposal_rejected',
       entity_type: 'governance_proposal',
       entity_id: proposalId,
       performed_by: user.id,
       notes: reason,
-    } as any);
+    };
+    await supabase.from('farmer_audit_log').insert(rejectAudit);
 
     toast.success('Proposta rejeitada');
     loadData();

--- a/src/hooks/useFarmerScoring.ts
+++ b/src/hooks/useFarmerScoring.ts
@@ -1,6 +1,25 @@
 import { useState, useEffect, useMemo, useCallback } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
+import type { Tables, TablesInsert } from '@/integrations/supabase/types';
+
+type AlgorithmConfigRow = Pick<Tables<'farmer_algorithm_config'>, 'key' | 'value'>;
+type ProductCostRow = Pick<Tables<'product_costs'>, 'product_id' | 'cost_price'>;
+type FarmerCallRow = Pick<
+  Tables<'farmer_calls'>,
+  'customer_user_id' | 'call_result' | 'is_whatsapp' | 'whatsapp_replied' | 'created_at'
+>;
+type ProfileRow = Pick<Tables<'profiles'>, 'user_id' | 'name' | 'phone'>;
+type SalesOrderRow = Pick<
+  Tables<'sales_orders'>,
+  'id' | 'customer_user_id' | 'items' | 'total' | 'created_at' | 'status'
+>;
+
+interface SalesOrderItem {
+  product_id?: string;
+  quantity?: number | string;
+  unit_price?: number | string;
+}
 
 // ─── Types ───────────────────────────────────────────────────────────
 export interface AlgorithmConfig {
@@ -88,10 +107,11 @@ export const useFarmerScoring = (farmerId?: string) => {
   // Load algorithm config
   useEffect(() => {
     (async () => {
-      const { data } = await supabase.from('farmer_algorithm_config').select('key, value') as any;
-      if (data && data.length > 0) {
+      const { data } = await supabase.from('farmer_algorithm_config').select('key, value');
+      const rows = (data ?? []) as AlgorithmConfigRow[];
+      if (rows.length > 0) {
         const map: Record<string, number> = {};
-        data.forEach((r: any) => { map[r.key] = Number(r.value); });
+        rows.forEach((r) => { map[r.key] = Number(r.value); });
         setConfig(prev => ({ ...prev, ...map } as AlgorithmConfig));
       }
     })();
@@ -108,12 +128,13 @@ export const useFarmerScoring = (farmerId?: string) => {
 
     try {
       // 1. Load all customers with sales orders
-      const { data: salesOrders } = await supabase
+      const { data: salesOrdersData } = await supabase
         .from('sales_orders')
         .select('id, customer_user_id, items, total, created_at, status')
-        .in('status', ['confirmado', 'faturado', 'entregue']) as any;
+        .in('status', ['confirmado', 'faturado', 'entregue']);
+      const salesOrders = (salesOrdersData ?? []) as SalesOrderRow[];
 
-      if (!salesOrders || salesOrders.length === 0) {
+      if (salesOrders.length === 0) {
         setClientScores([]);
         setAgenda([]);
         setCalculating(false);
@@ -122,26 +143,29 @@ export const useFarmerScoring = (farmerId?: string) => {
       }
 
       // 2. Load product costs for margin calculation
-      const { data: productCosts } = await supabase
+      const { data: productCostsData } = await supabase
         .from('product_costs')
-        .select('product_id, cost_price') as any;
+        .select('product_id, cost_price');
+      const productCosts = (productCostsData ?? []) as ProductCostRow[];
       const costMap = new Map<string, number>();
-      (productCosts || []).forEach((pc: any) => costMap.set(pc.product_id, Number(pc.cost_price)));
+      productCosts.forEach((pc) => costMap.set(pc.product_id, Number(pc.cost_price)));
 
       // 3. Load farmer calls for contact rates
-      const { data: calls } = await supabase
+      const { data: callsData } = await supabase
         .from('farmer_calls')
         .select('customer_user_id, call_result, is_whatsapp, whatsapp_replied, created_at')
-        .eq('farmer_id', targetFarmerId) as any;
+        .eq('farmer_id', targetFarmerId);
+      const calls = (callsData ?? []) as FarmerCallRow[];
 
       // 4. Load customer profiles
-      const customerIds = [...new Set(salesOrders.map((o: any) => o.customer_user_id))] as string[];
-      const { data: profiles } = await supabase
+      const customerIds = [...new Set(salesOrders.map((o) => o.customer_user_id))];
+      const { data: profilesData } = await supabase
         .from('profiles')
         .select('user_id, name, phone')
         .in('user_id', customerIds);
+      const profiles = (profilesData ?? []) as ProfileRow[];
       const profileMap = new Map<string, { name: string; phone: string | null }>();
-      (profiles || []).forEach((p: any) => profileMap.set(p.user_id, { name: p.name, phone: p.phone }));
+      profiles.forEach((p) => profileMap.set(p.user_id, { name: p.name, phone: p.phone }));
 
       // 5. Aggregate per-customer data
       const now = Date.now();
@@ -182,7 +206,9 @@ export const useFarmerScoring = (farmerId?: string) => {
         if (orderTime >= sixMonthsAgo) cd.spend180d += Number(order.total || 0);
 
         // Parse items for categories and margin
-        const items = Array.isArray(order.items) ? order.items : [];
+        const items: SalesOrderItem[] = Array.isArray(order.items)
+          ? (order.items as unknown as SalesOrderItem[])
+          : [];
         for (const item of items) {
           if (item.product_id) {
             cd.categories.add(item.product_id);
@@ -196,8 +222,9 @@ export const useFarmerScoring = (farmerId?: string) => {
       }
 
       // Aggregate call data
-      for (const call of (calls || [])) {
+      for (const call of calls) {
         const cid = call.customer_user_id;
+        if (!cid) continue;
         const cd = customerMap.get(cid);
         if (!cd) continue;
         const callTime = new Date(call.created_at).getTime();
@@ -389,7 +416,7 @@ export const useFarmerScoring = (farmerId?: string) => {
 
       // 9. Persist scores to DB
       for (const s of scores) {
-        await supabase.from('farmer_client_scores').upsert({
+        const scoreUpsert: TablesInsert<'farmer_client_scores'> = {
           customer_user_id: s.customer_user_id,
           farmer_id: targetFarmerId,
           rf_score: s.rf, m_score: s.m, g_score: s.g, x_score: s.x, s_score: s.s,
@@ -410,7 +437,10 @@ export const useFarmerScoring = (farmerId?: string) => {
           revenue_potential: s.revenuePotential,
           calculated_at: new Date().toISOString(),
           updated_at: new Date().toISOString(),
-        } as any, { onConflict: 'customer_user_id,farmer_id' });
+        };
+        await supabase
+          .from('farmer_client_scores')
+          .upsert(scoreUpsert, { onConflict: 'customer_user_id,farmer_id' });
       }
 
     } catch (error) {

--- a/src/hooks/useFinanceiro.ts
+++ b/src/hooks/useFinanceiro.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, useMemo } from 'react';
+import { useState, useCallback, useMemo } from 'react';
 import type { Company } from '@/contexts/CompanyContext';
 import {
   triggerFinanceiroSync,
@@ -70,8 +70,8 @@ export function useFinanceiro(defaultCompany: FinanceiroView = 'all') {
       ]);
       setResumo(prev => ({ ...prev, ...data }));
       setLastSync(syncTime);
-    } catch (e: any) {
-      setError(e.message);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
     } finally {
       setLoading(false);
     }
@@ -87,8 +87,8 @@ export function useFinanceiro(defaultCompany: FinanceiroView = 'all') {
       setLoading(true);
       const data = await getContasPagar(view === 'all' ? 'all' : view as Company, filtros);
       setContasPagar(data);
-    } catch (e: any) {
-      setError(e.message);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
     } finally {
       setLoading(false);
     }
@@ -104,8 +104,8 @@ export function useFinanceiro(defaultCompany: FinanceiroView = 'all') {
       setLoading(true);
       const data = await getContasReceber(view === 'all' ? 'all' : view as Company, filtros);
       setContasReceber(data);
-    } catch (e: any) {
-      setError(e.message);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
     } finally {
       setLoading(false);
     }
@@ -120,8 +120,8 @@ export function useFinanceiro(defaultCompany: FinanceiroView = 'all') {
       ]);
       setAgingReceber(ar);
       setAgingPagar(ap);
-    } catch (e: any) {
-      setError(e.message);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
     }
   }, [view]);
 
@@ -140,8 +140,8 @@ export function useFinanceiro(defaultCompany: FinanceiroView = 'all') {
         const data = await getDRE(view as Company, ano, meses);
         setDre(data);
       }
-    } catch (e: any) {
-      setError(e.message);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
     } finally {
       setLoading(false);
     }
@@ -153,8 +153,8 @@ export function useFinanceiro(defaultCompany: FinanceiroView = 'all') {
       const company = view === 'all' ? 'all' : view as Company;
       const data = await getFluxoCaixa(company, dataInicio, dataFim);
       setFluxoCaixa(data);
-    } catch (e: any) {
-      setError(e.message);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
     } finally {
       setLoading(false);
     }
@@ -165,8 +165,8 @@ export function useFinanceiro(defaultCompany: FinanceiroView = 'all') {
       const company = view === 'all' ? 'all' : view as Company;
       const data = await getTopInadimplentes(company, 15);
       setInadimplentes(data);
-    } catch (e: any) {
-      setError(e.message);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
     }
   }, [view]);
 
@@ -181,8 +181,8 @@ export function useFinanceiro(defaultCompany: FinanceiroView = 'all') {
       await triggerFinanceiroSync('sync_all', companies);
       // Reload local data after sync
       await loadResumo();
-    } catch (e: any) {
-      setError(e.message);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
     } finally {
       setSyncing(false);
     }
@@ -196,8 +196,8 @@ export function useFinanceiro(defaultCompany: FinanceiroView = 'all') {
         : [view as Company];
       await triggerFinanceiroSync('calcular_dre', companies, { ano, meses: [mes] });
       await loadDRE(ano, [mes]);
-    } catch (e: any) {
-      setError(e.message);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
     } finally {
       setSyncing(false);
     }
@@ -211,8 +211,8 @@ export function useFinanceiro(defaultCompany: FinanceiroView = 'all') {
         : [view as Company];
       await triggerFinanceiroSync('calcular_dre_year', companies, { ano });
       await loadDRE(ano);
-    } catch (e: any) {
-      setError(e.message);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
     } finally {
       setSyncing(false);
     }
@@ -229,24 +229,24 @@ export function useFinanceiro(defaultCompany: FinanceiroView = 'all') {
       // Heavy sync actions: call one company at a time to avoid 150s timeout
       const heavyActions = ['sync_contas_pagar', 'sync_contas_receber', 'sync_movimentacoes', 'sync_all', 'calcular_dre', 'calcular_dre_year'];
       if (heavyActions.includes(action)) {
-        const allResults: Record<string, any> = {};
+        const allResults: Record<string, unknown> = {};
         for (const co of companies) {
           try {
-            const result = await triggerFinanceiroSync(action, [co], options);
+            const result = (await triggerFinanceiroSync(action, [co], options)) as Record<string, unknown> | null | undefined;
             // Edge function returns { success, action, oben: {...} } — extract company key
             if (result?.[co]) {
               allResults[co] = result[co];
             }
-          } catch (e: any) {
-            allResults[co] = { error: e.message };
+          } catch (e) {
+            allResults[co] = { error: e instanceof Error ? e.message : String(e) };
           }
         }
         return { results: allResults };
       }
 
-      const result = await triggerFinanceiroSync(action, companies, options);
+      const result = (await triggerFinanceiroSync(action, companies, options)) as Record<string, unknown> | null | undefined;
       // Normalize: wrap company-keyed response into { results: {...} }
-      const allResults: Record<string, any> = {};
+      const allResults: Record<string, unknown> = {};
       for (const co of companies) {
         if (result?.[co]) {
           allResults[co] = result[co];
@@ -256,31 +256,31 @@ export function useFinanceiro(defaultCompany: FinanceiroView = 'all') {
         return { results: allResults };
       }
       return result;
-    } catch (e: any) {
-      setError(e.message);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
     } finally {
       setSyncing(false);
     }
   }, [view]);
 
   // Computed: DRE consolidado por mês (soma empresas quando view === 'all')
-  const dreConsolidado = useMemo(() => {
+  const dreConsolidado = useMemo<FinDRE[]>(() => {
     if (view !== 'all' || dre.length === 0) return dre;
-    const byMonth = new Map<number, any>();
+    const byMonth = new Map<number, FinDRE>();
     const numFields = [
       'receita_bruta', 'deducoes', 'receita_liquida', 'cmv', 'lucro_bruto',
       'despesas_operacionais', 'despesas_administrativas', 'despesas_comerciais',
       'despesas_financeiras', 'receitas_financeiras', 'resultado_operacional',
       'outras_receitas', 'outras_despesas', 'resultado_antes_impostos',
       'impostos', 'resultado_liquido'
-    ];
+    ] as const satisfies readonly (keyof FinDRE)[];
     for (const row of dre) {
       if (!byMonth.has(row.mes)) {
         byMonth.set(row.mes, { ...row, company: 'consolidado' });
       } else {
-        const c = byMonth.get(row.mes);
+        const c = byMonth.get(row.mes)!;
         for (const f of numFields) {
-          c[f] = (c[f] || 0) + ((row as any)[f] || 0);
+          (c[f] as number) = ((c[f] as number) || 0) + ((row[f] as number) || 0);
         }
       }
     }

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -584,6 +584,71 @@ export type Database = {
         }
         Relationships: []
       }
+      customer_processes: {
+        Row: {
+          created_at: string
+          created_by: string
+          customer_user_id: string
+          descricao_livre: string
+          etapas: Json | null
+          ia_confidence: number | null
+          ia_gaps: string[] | null
+          ia_structured_at: string | null
+          id: string
+          is_current: boolean
+          parent_id: string | null
+          porte: string | null
+          segmento: string | null
+          tags: string[] | null
+          updated_at: string
+          version: number
+        }
+        Insert: {
+          created_at?: string
+          created_by: string
+          customer_user_id: string
+          descricao_livre: string
+          etapas?: Json | null
+          ia_confidence?: number | null
+          ia_gaps?: string[] | null
+          ia_structured_at?: string | null
+          id?: string
+          is_current?: boolean
+          parent_id?: string | null
+          porte?: string | null
+          segmento?: string | null
+          tags?: string[] | null
+          updated_at?: string
+          version?: number
+        }
+        Update: {
+          created_at?: string
+          created_by?: string
+          customer_user_id?: string
+          descricao_livre?: string
+          etapas?: Json | null
+          ia_confidence?: number | null
+          ia_gaps?: string[] | null
+          ia_structured_at?: string | null
+          id?: string
+          is_current?: boolean
+          parent_id?: string | null
+          porte?: string | null
+          segmento?: string | null
+          tags?: string[] | null
+          updated_at?: string
+          version?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "customer_processes_parent_id_fkey"
+            columns: ["parent_id"]
+            isOneToOne: false
+            referencedRelation: "customer_processes"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       customer_segments: {
         Row: {
           account: string
@@ -614,6 +679,33 @@ export type Database = {
           segment?: string | null
           tags?: string[] | null
           updated_at?: string
+        }
+        Relationships: []
+      }
+      dashboard_visits: {
+        Row: {
+          company_selection: string | null
+          id: number
+          persona: string | null
+          session_minutes: number | null
+          user_id: string
+          visited_at: string
+        }
+        Insert: {
+          company_selection?: string | null
+          id?: number
+          persona?: string | null
+          session_minutes?: number | null
+          user_id: string
+          visited_at?: string
+        }
+        Update: {
+          company_selection?: string | null
+          id?: number
+          persona?: string | null
+          session_minutes?: number | null
+          user_id?: string
+          visited_at?: string
         }
         Relationships: []
       }
@@ -4520,6 +4612,50 @@ export type Database = {
           },
         ]
       }
+      kb_chunks: {
+        Row: {
+          char_end: number | null
+          char_start: number | null
+          chunk_index: number
+          content: string
+          created_at: string
+          document_id: string
+          embedding: string | null
+          id: string
+          token_count: number | null
+        }
+        Insert: {
+          char_end?: number | null
+          char_start?: number | null
+          chunk_index: number
+          content: string
+          created_at?: string
+          document_id: string
+          embedding?: string | null
+          id?: string
+          token_count?: number | null
+        }
+        Update: {
+          char_end?: number | null
+          char_start?: number | null
+          chunk_index?: number
+          content?: string
+          created_at?: string
+          document_id?: string
+          embedding?: string | null
+          id?: string
+          token_count?: number | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "kb_chunks_document_id_fkey"
+            columns: ["document_id"]
+            isOneToOne: false
+            referencedRelation: "kb_documents"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       kb_competitor_products: {
         Row: {
           argumentos_comparativos: Json | null
@@ -4626,6 +4762,71 @@ export type Database = {
           updated_at?: string
         }
         Relationships: []
+      }
+      kb_documents: {
+        Row: {
+          content_extracted: string | null
+          created_at: string
+          created_by: string
+          file_size_bytes: number | null
+          file_url: string
+          id: string
+          parent_id: string | null
+          product_code: string | null
+          status: string
+          status_error: string | null
+          supplier: string | null
+          tags: string[] | null
+          title: string
+          type: string
+          updated_at: string
+          version: number
+        }
+        Insert: {
+          content_extracted?: string | null
+          created_at?: string
+          created_by: string
+          file_size_bytes?: number | null
+          file_url: string
+          id?: string
+          parent_id?: string | null
+          product_code?: string | null
+          status?: string
+          status_error?: string | null
+          supplier?: string | null
+          tags?: string[] | null
+          title: string
+          type: string
+          updated_at?: string
+          version?: number
+        }
+        Update: {
+          content_extracted?: string | null
+          created_at?: string
+          created_by?: string
+          file_size_bytes?: number | null
+          file_url?: string
+          id?: string
+          parent_id?: string | null
+          product_code?: string | null
+          status?: string
+          status_error?: string | null
+          supplier?: string | null
+          tags?: string[] | null
+          title?: string
+          type?: string
+          updated_at?: string
+          version?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "kb_documents_parent_id_fkey"
+            columns: ["parent_id"]
+            isOneToOne: false
+            referencedRelation: "kb_documents"
+            referencedColumns: ["id"]
+          },
+        ]
       }
       kb_product_specs: {
         Row: {
@@ -4775,7 +4976,15 @@ export type Database = {
           viscosidade_aplicacao_s?: number | null
           viscosidade_copo?: string | null
         }
-        Relationships: []
+        Relationships: [
+          {
+            foreignKeyName: "kb_product_specs_document_id_fkey"
+            columns: ["document_id"]
+            isOneToOne: false
+            referencedRelation: "kb_documents"
+            referencedColumns: ["id"]
+          },
+        ]
       }
       loyalty_points: {
         Row: {
@@ -6788,6 +6997,39 @@ export type Database = {
           transportadora_cnpj?: string | null
           transportadora_nome?: string | null
           updated_at?: string
+        }
+        Relationships: []
+      }
+      rag_chunks: {
+        Row: {
+          chunk_index: number
+          content: string
+          created_at: string
+          embedding: string | null
+          id: string
+          metadata: Json | null
+          source_id: string
+          source_table: string
+        }
+        Insert: {
+          chunk_index: number
+          content: string
+          created_at?: string
+          embedding?: string | null
+          id?: string
+          metadata?: Json | null
+          source_id: string
+          source_table: string
+        }
+        Update: {
+          chunk_index?: number
+          content?: string
+          created_at?: string
+          embedding?: string | null
+          id?: string
+          metadata?: Json | null
+          source_id?: string
+          source_table?: string
         }
         Relationships: []
       }
@@ -9717,6 +9959,33 @@ export type Database = {
         }
         Relationships: []
       }
+      user_departments: {
+        Row: {
+          created_at: string
+          created_by: string | null
+          department: Database["public"]["Enums"]["department"]
+          id: string
+          primary_dept: boolean
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          created_by?: string | null
+          department: Database["public"]["Enums"]["department"]
+          id?: string
+          primary_dept?: boolean
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          created_by?: string | null
+          department?: Database["public"]["Enums"]["department"]
+          id?: string
+          primary_dept?: boolean
+          user_id?: string
+        }
+        Relationships: []
+      }
       user_roles: {
         Row: {
           created_at: string
@@ -9869,6 +10138,39 @@ export type Database = {
           sku_unidade?: string | null
           valor_total?: number | null
           valor_unitario?: number | null
+        }
+        Relationships: []
+      }
+      vendor_sip_credentials: {
+        Row: {
+          created_at: string
+          id: string
+          notes: string | null
+          sip_caller_id: string | null
+          sip_pass: string
+          sip_user: string
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          notes?: string | null
+          sip_caller_id?: string | null
+          sip_pass: string
+          sip_user: string
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          notes?: string | null
+          sip_caller_id?: string | null
+          sip_pass?: string
+          sip_user?: string
+          updated_at?: string
+          user_id?: string
         }
         Relationships: []
       }
@@ -11425,6 +11727,15 @@ export type Database = {
         | "gerencial"
         | "estrategico"
         | "super_admin"
+      department:
+        | "separador"
+        | "conferente"
+        | "comprador"
+        | "tintometrico"
+        | "financeiro"
+        | "vendas"
+        | "gestao"
+        | "outro"
       empresa_reposicao: "OBEN" | "COLACOR"
       farmer_call_result:
         | "contato_sucesso"
@@ -11584,6 +11895,16 @@ export const Constants = {
         "gerencial",
         "estrategico",
         "super_admin",
+      ],
+      department: [
+        "separador",
+        "conferente",
+        "comprador",
+        "tintometrico",
+        "financeiro",
+        "vendas",
+        "gestao",
+        "outro",
       ],
       empresa_reposicao: ["OBEN", "COLACOR"],
       farmer_call_result: [

--- a/supabase/functions/omie-create-customer-multi/index.ts
+++ b/supabase/functions/omie-create-customer-multi/index.ts
@@ -1,0 +1,274 @@
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import { authorizeCronOrStaff, corsHeaders } from "../_shared/auth.ts";
+
+/**
+ * PR-CAPTURE-B — Cria cliente nas 3 contas Omie em paralelo (Colacor / Oben / Colacor SC)
+ * e grava o mapping em `omie_clientes` pra cada empresa.
+ *
+ * Padrão de secrets: OMIE_{EMPRESA}_APP_KEY + OMIE_{EMPRESA}_APP_SECRET
+ *   - OMIE_COLACOR_APP_KEY/SECRET
+ *   - OMIE_OBEN_APP_KEY/SECRET
+ *   - OMIE_COLACOR_SC_APP_KEY/SECRET
+ *
+ * Se uma empresa não tem secret configurada, é skipped (graceful degradation).
+ * Retorna { results: [{ empresa, status, codigo_cliente_omie? error? }] } pra UI mostrar.
+ */
+
+const OMIE_API_URL = "https://app.omie.com.br/api/v1";
+
+type EmpresaKey = 'colacor' | 'oben' | 'colacor_sc';
+const EMPRESAS: EmpresaKey[] = ['colacor', 'oben', 'colacor_sc'];
+const EMPRESA_LABEL: Record<EmpresaKey, string> = {
+  colacor: 'Colacor',
+  oben: 'Oben',
+  colacor_sc: 'Colacor SC',
+};
+const EMPRESA_SECRET_PREFIX: Record<EmpresaKey, string> = {
+  colacor: 'OMIE_COLACOR',
+  oben: 'OMIE_OBEN',
+  colacor_sc: 'OMIE_COLACOR_SC',
+};
+
+interface ReqBody {
+  user_id: string;
+  razao_social: string;
+  cnpj?: string | null;
+  email?: string | null;
+  phone?: string | null;
+  nome_contato?: string | null;
+  cidade?: string | null;
+  estado?: string | null;
+  endereco?: string | null;
+  target_empresas?: EmpresaKey[]; // default: todas
+  tags?: string[];
+}
+
+interface EmpresaResult {
+  empresa: EmpresaKey;
+  empresa_label: string;
+  status: 'created' | 'skipped_no_secret' | 'error';
+  codigo_cliente_omie?: number;
+  error?: string;
+}
+
+interface OmieClientePayload {
+  codigo_cliente_integracao: string;
+  razao_social: string;
+  cnpj_cpf: string;
+  pessoa_fisica?: string;
+  nome_fantasia?: string;
+  email?: string;
+  telefone1_numero?: string;
+  cidade?: string;
+  estado?: string;
+  endereco?: string;
+  tags?: Array<{ tag: string }>;
+}
+
+function digitsOnly(s: string | null | undefined): string {
+  return (s ?? '').replace(/\D/g, '');
+}
+
+async function createClienteInOmie(
+  empresa: EmpresaKey,
+  body: ReqBody,
+): Promise<EmpresaResult> {
+  const prefix = EMPRESA_SECRET_PREFIX[empresa];
+  const appKey = Deno.env.get(`${prefix}_APP_KEY`);
+  const appSecret = Deno.env.get(`${prefix}_APP_SECRET`);
+
+  if (!appKey || !appSecret) {
+    return {
+      empresa,
+      empresa_label: EMPRESA_LABEL[empresa],
+      status: 'skipped_no_secret',
+      error: `Secrets ${prefix}_APP_KEY/SECRET não configuradas`,
+    };
+  }
+
+  // Determina pessoa física ou jurídica pelo CNPJ
+  const cnpjDigits = digitsOnly(body.cnpj);
+  const isPF = cnpjDigits.length === 11;
+  const isPJ = cnpjDigits.length === 14;
+
+  if (!cnpjDigits) {
+    // Sem CNPJ, gera placeholder de PF com sufixo do user_id (pra Omie aceitar)
+    // Mas isso pode dar erro no Omie. Melhor retornar error se não tem doc.
+    return {
+      empresa,
+      empresa_label: EMPRESA_LABEL[empresa],
+      status: 'error',
+      error: 'CNPJ/CPF é obrigatório pra criar cliente no Omie',
+    };
+  }
+
+  const payload: OmieClientePayload = {
+    codigo_cliente_integracao: `prospect-${body.user_id.slice(0, 18)}`,
+    razao_social: body.razao_social,
+    cnpj_cpf: cnpjDigits,
+    pessoa_fisica: isPF ? 'S' : 'N',
+    nome_fantasia: body.nome_contato || body.razao_social,
+    email: body.email || undefined,
+    telefone1_numero: digitsOnly(body.phone) || undefined,
+    cidade: body.cidade || undefined,
+    estado: body.estado || undefined,
+    endereco: body.endereco || undefined,
+    tags: body.tags && body.tags.length > 0 ? body.tags.map((t) => ({ tag: t })) : undefined,
+  };
+
+  // Remove undefined pra Omie não reclamar
+  Object.keys(payload).forEach((k) => {
+    if ((payload as Record<string, unknown>)[k] === undefined) delete (payload as Record<string, unknown>)[k];
+  });
+
+  try {
+    const resp = await fetch(`${OMIE_API_URL}/geral/clientes/`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        call: 'IncluirCliente',
+        app_key: appKey,
+        app_secret: appSecret,
+        param: [payload],
+      }),
+    });
+
+    const data = await resp.json();
+
+    // Omie retorna codigo_cliente_omie em sucesso; faultcode/faultstring em erro (SOAP-like)
+    if (data.faultstring || !resp.ok) {
+      // Cliente já existe? Tenta upsert via UpsertCliente
+      if (typeof data.faultstring === 'string' && data.faultstring.includes('já cadastrado')) {
+        // Faz UpsertCliente como retry
+        const respUpsert = await fetch(`${OMIE_API_URL}/geral/clientes/`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            call: 'UpsertCliente',
+            app_key: appKey,
+            app_secret: appSecret,
+            param: [payload],
+          }),
+        });
+        const dataUpsert = await respUpsert.json();
+        if (dataUpsert.codigo_cliente_omie) {
+          return {
+            empresa,
+            empresa_label: EMPRESA_LABEL[empresa],
+            status: 'created',
+            codigo_cliente_omie: dataUpsert.codigo_cliente_omie,
+          };
+        }
+        return {
+          empresa,
+          empresa_label: EMPRESA_LABEL[empresa],
+          status: 'error',
+          error: dataUpsert.faultstring ?? 'Upsert failed',
+        };
+      }
+      return {
+        empresa,
+        empresa_label: EMPRESA_LABEL[empresa],
+        status: 'error',
+        error: data.faultstring ?? `HTTP ${resp.status}`,
+      };
+    }
+
+    return {
+      empresa,
+      empresa_label: EMPRESA_LABEL[empresa],
+      status: 'created',
+      codigo_cliente_omie: data.codigo_cliente_omie,
+    };
+  } catch (err) {
+    return {
+      empresa,
+      empresa_label: EMPRESA_LABEL[empresa],
+      status: 'error',
+      error: err instanceof Error ? err.message : 'unknown error',
+    };
+  }
+}
+
+Deno.serve(async (req) => {
+  if (req.method === "OPTIONS") return new Response(null, { headers: corsHeaders });
+
+  const auth = await authorizeCronOrStaff(req);
+  if (!auth.ok) return auth.response;
+
+  let body: ReqBody;
+  try {
+    body = await req.json();
+  } catch {
+    return new Response(JSON.stringify({ error: "Invalid JSON" }), {
+      status: 400,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+
+  if (!body.user_id || !body.razao_social) {
+    return new Response(JSON.stringify({ error: "user_id + razao_social required" }), {
+      status: 400,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+
+  const targets = body.target_empresas && body.target_empresas.length > 0
+    ? body.target_empresas
+    : EMPRESAS;
+
+  try {
+    // Executa nas N empresas em paralelo
+    const results = await Promise.all(
+      targets.map((empresa) => createClienteInOmie(empresa, body)),
+    );
+
+    // Persiste mapping em omie_clientes pra cada sucesso
+    const supabase = createClient(
+      Deno.env.get("SUPABASE_URL")!,
+      Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!,
+    );
+
+    const successfulRows = results
+      .filter((r) => r.status === 'created' && r.codigo_cliente_omie)
+      .map((r) => ({
+        user_id: body.user_id,
+        omie_codigo_cliente: r.codigo_cliente_omie!,
+        empresa_omie: r.empresa, // assume coluna empresa_omie em omie_clientes; ajusta se nome diferente
+      }));
+
+    if (successfulRows.length > 0) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const { error: insErr } = await (supabase.from('omie_clientes') as any).upsert(
+        successfulRows,
+        { onConflict: 'user_id,empresa_omie' }
+      );
+      if (insErr) {
+        console.warn('[omie-create-customer-multi] mapping upsert failed:', insErr);
+        // não bloqueia — sucesso parcial é melhor que rollback completo
+      }
+    }
+
+    const createdCount = results.filter((r) => r.status === 'created').length;
+    const errorCount = results.filter((r) => r.status === 'error').length;
+    const skippedCount = results.filter((r) => r.status === 'skipped_no_secret').length;
+
+    return new Response(JSON.stringify({
+      ok: createdCount > 0,
+      summary: {
+        created: createdCount,
+        errors: errorCount,
+        skipped: skippedCount,
+        total: results.length,
+      },
+      results,
+    }), { headers: { ...corsHeaders, "Content-Type": "application/json" } });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "unknown error";
+    console.error("[omie-create-customer-multi]", msg);
+    return new Response(JSON.stringify({ error: msg }), {
+      status: 500,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+});

--- a/supabase/migrations/20260517240000_omie_clientes_multi_empresa.sql
+++ b/supabase/migrations/20260517240000_omie_clientes_multi_empresa.sql
@@ -1,0 +1,30 @@
+-- PR-CAPTURE-B: suporte multi-empresa em omie_clientes
+-- Cada cliente pode ter N códigos Omie (1 por empresa do grupo Colacor: colacor / oben / colacor_sc).
+-- Coluna default 'colacor' pra backward compat de rows antigas (presumidas Colacor).
+
+ALTER TABLE public.omie_clientes
+  ADD COLUMN IF NOT EXISTS empresa_omie text NOT NULL DEFAULT 'colacor'
+    CHECK (empresa_omie IN ('colacor', 'oben', 'colacor_sc'));
+
+-- Constraint composta: 1 código por (cliente, empresa)
+-- Drop unique antiga em omie_codigo_cliente se existir (era global)
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'omie_clientes_omie_codigo_cliente_key'
+  ) THEN
+    ALTER TABLE public.omie_clientes DROP CONSTRAINT omie_clientes_omie_codigo_cliente_key;
+  END IF;
+END $$;
+
+-- Nova unique: (omie_codigo_cliente, empresa_omie) — códigos podem repetir entre empresas
+CREATE UNIQUE INDEX IF NOT EXISTS idx_omie_clientes_codigo_empresa
+  ON public.omie_clientes (omie_codigo_cliente, empresa_omie);
+
+-- Index pra lookup rápido por (user, empresa)
+CREATE UNIQUE INDEX IF NOT EXISTS idx_omie_clientes_user_empresa
+  ON public.omie_clientes (user_id, empresa_omie);
+
+COMMENT ON COLUMN public.omie_clientes.empresa_omie IS
+  'Qual empresa do grupo Colacor: colacor (principal) | oben (distribuição) | colacor_sc (serviços). Cada user_id pode ter 1 código por empresa.';

--- a/tsconfig.strict.json
+++ b/tsconfig.strict.json
@@ -32,6 +32,10 @@
     "src/hooks/useFarmerExperiments.ts",
     "src/hooks/useTacticalPlan.ts",
     "src/hooks/useCrossSellEngine.ts",
-    "src/hooks/useBundleEngine.ts"
+    "src/hooks/useBundleEngine.ts",
+    "src/hooks/useFinanceiro.ts",
+    "src/hooks/useCopilotEngine.ts",
+    "src/hooks/useFarmerGovernance.ts",
+    "src/hooks/useFarmerScoring.ts"
   ]
 }


### PR DESCRIPTION
## Summary

**PR-CAPTURE-B** — Completa o fluxo "chamada vira cliente cadastrado": quando o wizard pós-call (PR-CAPTURE-A) cria o prospect, dispara automaticamente sync nas **3 contas Omie** em paralelo (Colacor / Oben / Colacor SC) via `IncluirCliente` → grava códigos retornados em `omie_clientes` (uma row por empresa).

**Stacked sobre PR #86** (PR-CAPTURE-A).

## Como funciona

```
Vendedor confirma wizard pós-call (PR-CAPTURE-A)
  → useCreateProspect.mutate(...)
  → 1. Edge fn create-prospect-customer cria profile + customer_contact (PR-CUSTOMERS-MGMT)
  → 2. Fire-and-forget: invokeFunction('omie-create-customer-multi', {user_id, razao_social, cnpj, ...})
       → Promise.all em paralelo nas 3 contas:
          → Colacor: POST /geral/clientes/ {call:IncluirCliente, app_key:COLACOR, app_secret:COLACOR}
          → Oben:    POST /geral/clientes/ {call:IncluirCliente, app_key:OBEN, app_secret:OBEN}
          → ColacorSC: POST /geral/clientes/ {call:IncluirCliente, app_key:COLACOR_SC, ...}
       → Pra cada sucesso: upsert omie_clientes(user_id, omie_codigo_cliente, empresa_omie)
       → Retorna {summary: {created:3, errors:0, skipped:0, total:3}, results: [...]}
  → Toast: "Sincronizado no Omie: Colacor + Oben + Colacor SC"

Edge cases tratados:
  → Cliente já existe no Omie ("já cadastrado") → retry com UpsertCliente
  → Secret de uma empresa não configurada → status=skipped_no_secret, NÃO bloqueia outras
  → CNPJ ausente → status=error pra essa empresa (Omie exige)
  → Falha em 1 das 3 → toast warning mas profile já criado (graceful degradation)
```

## Pré-requisito de deploy

1. **Rodar migration SQL** no Lovable Cloud (ALTER `omie_clientes` add `empresa_omie` + unique compound)
2. **Confirmar 3 pares de secrets** já configuradas (você disse que sim):
   - `OMIE_COLACOR_APP_KEY` + `OMIE_COLACOR_APP_SECRET`
   - `OMIE_OBEN_APP_KEY` + `OMIE_OBEN_APP_SECRET`
   - `OMIE_COLACOR_SC_APP_KEY` + `OMIE_COLACOR_SC_APP_SECRET`
3. Regenerar types Supabase

Se alguma secret faltar → edge fn retorna `status=skipped_no_secret` pra aquela empresa, segue com as outras.

## Arquitetura

| Camada | Mudança |
|---|---|
| Migration | `omie_clientes` ganha coluna `empresa_omie` (default 'colacor' pra backward compat) + unique(user_id, empresa_omie) |
| Edge fn | `omie-create-customer-multi` — Promise.all nas 3 contas, retry com UpsertCliente se "já cadastrado", grava omie_clientes mapping |
| Hook `useCreateProspect` | Após criar profile, dispara `omie-create-customer-multi` fire-and-forget com cidade/estado/endereço |
| `PostCallProspectWizard` | Passa cidade/estado/endereço pro hook (já existiam mas não eram propagados) |

## Por que multi-empresa em `omie_clientes`

Antes: 1 código Omie por user_id (constraint UNIQUE em omie_codigo_cliente).
Depois: N códigos por user_id (1 por empresa do grupo). Pattern necessário pra distribuidor multi-empresa.

Backward compat: rows antigas ficam `empresa_omie='colacor'` (default). Nada quebra.

## Retry inteligente UpsertCliente

Se cliente já existe no Omie (caso comum quando vendedor cadastra mesmo CNPJ na 2ª chamada), `IncluirCliente` retorna erro "já cadastrado". Edge fn detecta a string + faz retry automático com `UpsertCliente` (que aceita upsert) — recupera o codigo_cliente_omie sem dar erro pro vendedor.

## Testes

- 259/259 tests still passing ✅
- tsc clean ✅
- bun build OK ✅

## Não incluso (próximos)

- **Sync ASYNC já gravado** — se prospect já existe e quer re-sincronizar manualmente, falta botão "Re-sync Omie" no detail page
- **Schema de vendedor Omie** — `codigo_vendedor` por empresa (vendedor existe nas 3 contas com códigos diferentes). Fica pra PR posterior quando configurar pra cada vendedor
- **Detecção semântica de empresa** — IA poderia decidir "só cria em Colacor se cliente menciona apenas tinta" (decidido com user: criar em todas é mais simples)

🤖 Generated with [Claude Code](https://claude.com/claude-code)