### PR TITLE
feat(typescript): wave 5 promove 5 pages pra strict mode (18→23 files)

### DIFF
--- a/src/pages/AdminReposicaoAplicacao.tsx
+++ b/src/pages/AdminReposicaoAplicacao.tsx
@@ -15,7 +15,7 @@ import {
   Search,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Badge } from "@/components/ui/badge";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -240,7 +240,7 @@ export default function AdminReposicaoAplicacao() {
     mutationFn: async () => {
       const { data, error } = await supabase.rpc("gerar_fila_aplicacao_omie" as never, {
         p_empresa: EMPRESA,
-      });
+      } as never);
       if (error) throw error;
       return data as unknown as GerarFilaResult | GerarFilaResult[];
     },
@@ -869,7 +869,7 @@ function SubstituicaoModal({
         p_acao_parametros: acao,
         p_motivo: motivo,
         p_usuario: user?.email ?? "sistema",
-      });
+      } as never);
       if (error) throw error;
       const result = data as unknown as RegistrarSubstResult | null;
       if (result?.error) throw new Error(result.error);

--- a/src/pages/FarmerCopilot.tsx
+++ b/src/pages/FarmerCopilot.tsx
@@ -19,9 +19,9 @@ import {
 import { useTacticalPlan, getObjectiveLabel, type TacticalPlan } from '@/hooks/useTacticalPlan';
 import { supabase } from '@/integrations/supabase/client';
 import {
-  Mic, MicOff, Radio, StopCircle, Lightbulb, Copy, Check,
+  Mic, Radio, StopCircle, Lightbulb, Copy, Check,
   MessageSquare, Brain, Target, Shield, TrendingUp, TrendingDown,
-  Minus, AlertTriangle, Loader2, ChevronRight, Phone, FileText,
+  Minus, AlertTriangle, Loader2, FileText,
   ChevronDown, ChevronUp, Type, Send,
   type LucideIcon,
 } from 'lucide-react';
@@ -193,7 +193,7 @@ const FarmerCopilot = () => {
       await copilot.startSession({
         customerId: selectedCustomer || undefined,
         customerName: customerName || undefined,
-        customerContext,
+        customerContext: customerContext ?? undefined,
         bundleContext,
       });
 
@@ -227,7 +227,7 @@ const FarmerCopilot = () => {
       await copilot.startSession({
         customerId: selectedCustomer || undefined,
         customerName: customerName || undefined,
-        customerContext,
+        customerContext: customerContext ?? undefined,
         bundleContext,
       });
 

--- a/src/pages/FinanceiroCockpit.tsx
+++ b/src/pages/FinanceiroCockpit.tsx
@@ -1,18 +1,15 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
-import { Button } from '@/components/ui/button';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
-import { Progress } from '@/components/ui/progress';
 import { Skeleton } from '@/components/ui/skeleton';
-import { COMPANIES, ALL_COMPANIES, type Company } from '@/contexts/CompanyContext';
+import { COMPANIES, type Company } from '@/contexts/CompanyContext';
 import { supabase } from '@/integrations/supabase/client';
 import { getResumoFinanceiro, getAgingReceber, getDRE, getTopInadimplentes, type FinResumo, type AgingData, type FinDRE } from '@/services/financeiroService';
 import {
-  Building2, TrendingUp, TrendingDown, AlertTriangle, Wallet,
-  ShieldCheck, Shield, BarChart3, Target, Clock, Eye, Lock,
-  CheckCircle2, Info, XCircle
+  TrendingUp, TrendingDown, AlertTriangle, Wallet,
+  BarChart3, Target, Clock, Eye, Lock,
+  Info,
 } from 'lucide-react';
 import { CockpitDrillDown, type DrillDownType } from '@/components/financeiro/CockpitDrillDown';
 import { logger } from '@/lib/logger';
@@ -282,7 +279,6 @@ const FinanceiroCockpit = () => {
             <div className="space-y-3">
               {dreConsolidado.map(d => {
                 const mg = d.receita_liquida > 0 ? (d.lucro_bruto / d.receita_liquida) * 100 : 0;
-                const mo = d.receita_liquida > 0 ? (d.resultado_operacional / d.receita_liquida) * 100 : 0;
                 const conf = confiabilidade.find(c => c.company === d.company);
                 return (
                   <div key={d.company} className="flex items-center justify-between p-3 rounded-lg bg-muted/40">

--- a/src/pages/FinanceiroConciliacao.tsx
+++ b/src/pages/FinanceiroConciliacao.tsx
@@ -233,7 +233,7 @@ const FinanceiroConciliacao = () => {
           const Icon = cfg.icon;
           const count = stats[key as keyof typeof stats] || 0;
           return (
-            <button key={key} onClick={() => setStatusFilter(key)}
+            <button key={key} onClick={() => setStatusFilter(key as ConciliacaoStatus)}
               className={`p-3 rounded-lg text-center transition-all ${statusFilter === key ? 'ring-2 ring-primary' : ''} ${cfg.color.replace('text-', 'bg-').split(' ')[0]}/30`}>
               <p className="text-xs text-muted-foreground flex items-center justify-center gap-1">
                 <Icon className="w-3 h-3" />{cfg.label}
@@ -295,7 +295,7 @@ const FinanceiroConciliacao = () => {
                 </TableHeader>
                 <TableBody>
                   {filtered.slice(0, 200).map(item => {
-                    const cfg = statusConfig[item.status] || statusConfig.pendente;
+                    const cfg = statusConfig[item.status as ConciliacaoStatus] || statusConfig.pendente;
                     const Icon = cfg.icon;
                     return (
                       <TableRow key={item.id} className={item.status === 'divergencia' ? 'bg-status-error-bg/50' : ''}>

--- a/tsconfig.strict.json
+++ b/tsconfig.strict.json
@@ -36,6 +36,11 @@
     "src/hooks/useFinanceiro.ts",
     "src/hooks/useCopilotEngine.ts",
     "src/hooks/useFarmerGovernance.ts",
-    "src/hooks/useFarmerScoring.ts"
+    "src/hooks/useFarmerScoring.ts",
+    "src/pages/FarmerCopilot.tsx",
+    "src/pages/FinanceiroConciliacao.tsx",
+    "src/components/financeiro/CockpitDrillDown.tsx",
+    "src/pages/FinanceiroCockpit.tsx",
+    "src/pages/AdminReposicaoAplicacao.tsx"
   ]
 }


### PR DESCRIPTION
## Summary

Promove os 5 files da Wave 4 (PR #87) pro `tsconfig.strict.json` include, fixing os **21 strict errors** que apareceram quando rodei `bun run typecheck:strict` com eles na lista.

**Padrão**: promote-then-fix. Esse loop pega bugs que sub-agents passam (ex: na Wave 3 peguei `useFinanceiro` unused `useEffect` import e `useFarmerScoring` null `cid` lookup latente). Aqui não rolaram bugs latentes, só strict-flag housekeeping.

## tsconfig.strict.json: 18 → 23 files

Novos no include:
- `src/pages/FarmerCopilot.tsx`
- `src/pages/FinanceiroConciliacao.tsx`
- `src/components/financeiro/CockpitDrillDown.tsx` _(zero erros, só include)_
- `src/pages/FinanceiroCockpit.tsx`
- `src/pages/AdminReposicaoAplicacao.tsx`

## Categorias de fix (21 errors)

### Unused imports (12 fixes, `noUnusedLocals/Parameters`)

| File | Removidos |
|---|---|
| FinanceiroCockpit | `useCallback`, `Button`, `Progress`, `Select*`, `ALL_COMPANIES`, `Building2`, `ShieldCheck`, `Shield`, `CheckCircle2`, `XCircle`, `const mo = ...` |
| FarmerCopilot | `MicOff`, `ChevronRight`, `Phone` |
| AdminReposicaoAplicacao | `CardTitle` |

### Type narrowing (9 fixes)

| Site | Fix |
|---|---|
| FarmerCopilot:196,230 — `customerContext: Record<string,unknown> \| null` → `CopilotContext \| undefined` | `customerContext ?? undefined` |
| AdminReposicaoAplicacao:241,865 — `supabase.rpc("name" as never, args)` narrowing arg pra `undefined` | second cast `args as never` |
| FinanceiroConciliacao:236 — `setStatusFilter(key)` onde `key: string` | `key as ConciliacaoStatus` |
| FinanceiroConciliacao:298 — `statusConfig[item.status]` index com string | `item.status as ConciliacaoStatus` |

## Validação

```
$ bun run typecheck:strict
0 errors (23 files)

$ bunx tsc --noEmit
0 errors (baseline mantido)

$ bun run test
Test Files  39 passed (39)
Tests       265 passed (265)

$ bun lint
645 problems (era 644, +1 unused-disable directive irrelevante)
```

## Aggregate strict-mode progress

| Wave | tsconfig.strict.json files | Trigger |
|---|---|---|
| Pre-Wave 1 | 6 (só libs) | — |
| Wave 1 | 9 | PRs #58/#62/#64/#68 |
| Wave 3 | 18 | PR #84 (4 engine hooks) |
| **Wave 5** | **23** | _Este PR (5 pages)_ |

5/119 pages no strict mode. Convergência ainda longa, mas pattern provado.

## Próximas waves candidatas

- **Wave 6**: pages restantes com mais lint errors — AdminReposicaoNegociacaoParalela (14), CheckinQualitativoTab (12), SalesOrders (11), TintReconciliation (10), TintMapping (10)
- **Wave 7**: Edge Functions restantes — omie-pedidos, calculate-scores, omie-nfe-recebimento
- **Wave 8 (alto risco)**: god-components refactor — FinanceiroDashboard (1242L), AdminRoutePlanner (1661L)

## Test plan

- [x] `bun run typecheck:strict` passa (23 files)
- [x] `bunx tsc --noEmit` passa (baseline)
- [x] `bun run test` 265/265
- [x] `bun lint` ≤ 645 problems
- [ ] CI verde (validate workflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)