### PR TITLE
feat(typescript): wave 7 promove 5 files Wave 6 pra strict (23→28)

### DIFF
--- a/src/components/des/CheckinQualitativoTab.tsx
+++ b/src/components/des/CheckinQualitativoTab.tsx
@@ -166,7 +166,7 @@ export function CheckinQualitativoTab({ empresa, ano, trimestre }: Props) {
       const { data, error } = await supabase
         .from("des_criterio_percentual")
         .select("criterio_id, faixa_id, percentual")
-        .eq("faixa_id", faixaConservId);
+        .eq("faixa_id", faixaConservId as number);
       if (error) throw error;
       return (data ?? []) as CriterioPercentual[];
     },

--- a/src/pages/AdminReposicaoNegociacaoParalela.tsx
+++ b/src/pages/AdminReposicaoNegociacaoParalela.tsx
@@ -13,7 +13,6 @@ import {
   MoreVertical,
   Search,
   Info,
-  TrendingUp,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -147,12 +146,6 @@ function formatBRL(v: number | null | undefined): string {
 function formatPerc(v: number | null | undefined, digits = 1): string {
   if (v === null || v === undefined) return "—";
   return `${Number(v).toLocaleString("pt-BR", { minimumFractionDigits: digits, maximumFractionDigits: digits })}%`;
-}
-
-function formatDateBR(d: string | null | undefined): string {
-  if (!d) return "—";
-  const date = new Date(d);
-  return date.toLocaleDateString("pt-BR");
 }
 
 function categoriaBadgeClass(cat: Categoria | null | undefined): string {
@@ -384,7 +377,8 @@ export default function AdminReposicaoNegociacaoParalela() {
         p_limite: 10,
       } as never);
       if (error) throw error;
-      const count = Array.isArray(data) ? data.length : 0;
+      const arr = data as unknown as unknown[] | null;
+      const count = Array.isArray(arr) ? arr.length : 0;
       toast.success(`${count} sugest${count === 1 ? "ão criada" : "ões criadas"}.`);
       queryClient.invalidateQueries({ queryKey: ["negociacao-paralela-sugestoes"] });
       queryClient.invalidateQueries({ queryKey: ["negociacao-paralela-sugestoes-count"] });

--- a/src/pages/SalesOrders.tsx
+++ b/src/pages/SalesOrders.tsx
@@ -220,9 +220,10 @@ const SalesOrders = () => {
     });
 
     // 1. Soft-delete local primeiro (audit trail antes do Omie)
+    // `deleted_at` existe no DB mas ainda não no generated Database type — cast as never
     const { error: softErr } = await supabase
       .from('sales_orders')
-      .update({ deleted_at: new Date().toISOString() })
+      .update({ deleted_at: new Date().toISOString() } as never)
       .eq('id', order.id);
 
     if (softErr) {
@@ -248,7 +249,7 @@ const SalesOrders = () => {
       // Rollback do soft-delete (deleted_at = null) — pedido volta a ser ativo
       await supabase
         .from('sales_orders')
-        .update({ deleted_at: null })
+        .update({ deleted_at: null } as never)
         .eq('id', order.id);
       queryClient.setQueryData(['sales-orders-paginated'], snapshot);
       toast.error('Erro ao excluir pedido', {
@@ -276,7 +277,7 @@ const SalesOrders = () => {
     const nowIso = new Date().toISOString();
     const { error: softErr } = await supabase
       .from('sales_orders')
-      .update({ deleted_at: nowIso })
+      .update({ deleted_at: nowIso } as never)
       .in('id', Array.from(deleteIds));
 
     if (softErr) {
@@ -311,7 +312,7 @@ const SalesOrders = () => {
     if (failedIds.length > 0) {
       await supabase
         .from('sales_orders')
-        .update({ deleted_at: null })
+        .update({ deleted_at: null } as never)
         .in('id', failedIds);
     }
 

--- a/src/pages/TintMapping.tsx
+++ b/src/pages/TintMapping.tsx
@@ -1,7 +1,6 @@
 import { useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';

--- a/src/pages/TintReconciliation.tsx
+++ b/src/pages/TintReconciliation.tsx
@@ -294,11 +294,11 @@ export default function TintReconciliation() {
                 {csvVal && <ValueDisplay label="Tabela oficial (CSV)" value={csvVal} />}
                 {syncVal && <ValueDisplay label="Staging (Sync)" value={syncVal} />}
 
-                {detailItem.diff_fields?.length > 0 && (
+                {(detailItem.diff_fields?.length ?? 0) > 0 && (
                   <div>
                     <p className="text-xs text-muted-foreground mb-1 font-semibold">Campos divergentes</p>
                     <div className="space-y-1">
-                      {detailItem.diff_fields.map((field: string) => (
+                      {(detailItem.diff_fields ?? []).map((field: string) => (
                         <div key={field} className="text-sm bg-muted p-2 rounded">
                           <span className="font-semibold">{field}:</span>
                           <span className="ml-2 text-primary">CSV: {String(csvVal?.[field] ?? "—")}</span>

--- a/tsconfig.strict.json
+++ b/tsconfig.strict.json
@@ -41,6 +41,11 @@
     "src/pages/FinanceiroConciliacao.tsx",
     "src/components/financeiro/CockpitDrillDown.tsx",
     "src/pages/FinanceiroCockpit.tsx",
-    "src/pages/AdminReposicaoAplicacao.tsx"
+    "src/pages/AdminReposicaoAplicacao.tsx",
+    "src/pages/AdminReposicaoNegociacaoParalela.tsx",
+    "src/components/des/CheckinQualitativoTab.tsx",
+    "src/pages/SalesOrders.tsx",
+    "src/pages/TintReconciliation.tsx",
+    "src/pages/TintMapping.tsx"
   ]
 }


### PR DESCRIPTION
## Summary

Promove os 5 files da Wave 6 (PR #93) pro `tsconfig.strict.json` include, fixing os **11 strict errors** que apareceram. Pattern já provado nas Waves 5 e 7 (alternância lint-only → strict promotion).

## tsconfig.strict.json: 23 → 28 files

Novos no include:
- `src/pages/AdminReposicaoNegociacaoParalela.tsx`
- `src/components/des/CheckinQualitativoTab.tsx`
- `src/pages/SalesOrders.tsx`
- `src/pages/TintReconciliation.tsx`
- `src/pages/TintMapping.tsx`

## Categorias de fix (11 errors)

### Unused imports (3 fixes, `noUnusedLocals`)

| File | Removidos |
|---|---|
| AdminReposicaoNegociacaoParalela | `TrendingUp` import + `formatDateBR` helper (zero callsites) |
| TintMapping | Import inteiro de `Card/CardContent/CardHeader/CardTitle` (zero callsites) |

### Type narrowing (8 fixes)

| Site | Issue | Fix |
|---|---|---|
| CheckinQualitativoTab:169 | `faixaConservId: number \| null` em `.eq()` | `as number` (query é gated em `!!faixaConservId`) |
| AdminReposicaoNegociacaoParalela:387 | `.length` em `never` (RPC `as never` bleed) | `data as unknown as unknown[] \| null` antes do `Array.isArray()` |
| TintReconciliation:297 | `diff_fields?.length > 0` (possibly undefined) | `(detailItem.diff_fields?.length ?? 0) > 0` |
| TintReconciliation:301 | `diff_fields.map()` (possibly null) | `(detailItem.diff_fields ?? []).map(...)` |
| SalesOrders:225,251,279,314 (4×) | `deleted_at` não no Database type | `as never` cast no payload, comment inline |

### Observação: `deleted_at` em sales_orders

Coluna existe no DB (migration aplicada), mas o generated `Database` type ainda não tem. 4 sites afetados (soft-delete + rollback do optimistic delete pattern). Opções:

1. **`as never` no payload** (escolhido) — documenta o gap inline, zero side effect
2. Regenerar Database types via Lovable Cloud → Supabase types — fora do escopo desta wave

O comment inline em SalesOrders:223 sinaliza pra próxima vez que regenerar types resolver os 4 sites.

## Validação

```
$ bun run typecheck:strict
0 errors (28 files)

$ bunx tsc --noEmit
0 errors (baseline mantido)

$ bun run test
Test Files  41 passed (41)
Tests       269 passed (269)

$ bun lint
589 problems (498 errors, 91 warnings) — sem mudança
```

## Aggregate strict-mode progress

| Wave | tsconfig.strict.json | Trigger |
|---|---|---|
| Pre-Wave 1 | 6 (só libs) | — |
| Wave 1 | 9 | PRs #58/#62/#64/#68 |
| Wave 3 | 18 | PR #84 (4 engine hooks) |
| Wave 5 | 23 | PR #91 (5 pages financeiro/farmer) |
| **Wave 7** | **28** | _Este PR (5 pages reposição/des/sales/tint)_ |

~8% do src em strict (28 / ~350 files alvo). Convergência ainda longa, pattern provado.

## Próximas waves candidatas

- **Wave 8**: Edge Functions restantes — `omie-pedidos`, `calculate-scores`, `omie-nfe-recebimento` (~25 any). Pattern Wave 2.
- **Wave 9**: pages restantes com any (próximos top offenders pós-Wave 6 cleanup).
- **Wave 10+**: god-components refactor — FinanceiroDashboard (1242L), AdminRoutePlanner (1661L). Alto risco, sprint próprio.

## Test plan

- [x] `bun run typecheck:strict` 0 errors (28 files)
- [x] `bunx tsc --noEmit` 0 errors (baseline)
- [x] `bun run test` 269/269
- [x] `bun lint` ≤ 589 problems
- [ ] CI verde (validate workflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)