### PR TITLE
style(customer-360): aplica 11 fixes do /design-review

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+.gstack/

--- a/src/pages/Customer360.tsx
+++ b/src/pages/Customer360.tsx
@@ -19,7 +19,8 @@ import {
   Clock,
   AlertCircle,
   Heart,
-  Sparkles,
+  User,
+  Inbox,
 } from 'lucide-react';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
@@ -50,7 +51,6 @@ import { cn } from '@/lib/utils';
  */
 
 const BRL = new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL' });
-const PCT = (v: number) => `${(v * 100).toFixed(1)}%`;
 
 function formatBRL(v: number | null | undefined): string {
   if (v === null || v === undefined || Number.isNaN(v)) return '—';
@@ -60,7 +60,60 @@ function formatBRL(v: number | null | undefined): string {
 function formatPctMaybe(v: number | null | undefined): string {
   if (v === null || v === undefined || Number.isNaN(v)) return '—';
   // Schema: gross_margin_pct vem como número (ex: 0.32 ou 32 — normalizamos)
-  return v > 1 ? `${v.toFixed(1)}%` : PCT(v);
+  const pct = v > 1 ? v : v * 100;
+  // Zero sem decimal ("0%" em vez de "0.0%"); outros valores com 1 decimal só se houver fração.
+  if (pct === 0) return '0%';
+  const rounded = Math.round(pct);
+  return Math.abs(pct - rounded) < 0.05 ? `${rounded}%` : `${pct.toFixed(1)}%`;
+}
+
+/**
+ * Profiles tem campo `email` text livre. Sincronização do Omie costuma concatenar
+ * múltiplos emails com vírgula (ex: "compras@x.com,financeiro@x.com"). Quebra em
+ * lista pra renderizar separadamente.
+ */
+function splitEmails(raw: string | null | undefined): string[] {
+  if (!raw) return [];
+  return raw
+    .split(/[,;]/)
+    .map((e) => e.trim())
+    .filter((e) => e.length > 0 && e.includes('@'));
+}
+
+/**
+ * `profiles.customer_type` vem como enum-ish text do app/Omie. Mapeia pros rótulos
+ * que o usuário humano entende. Fallback: capitaliza o valor cru.
+ */
+function formatCustomerType(t: string | null | undefined): string {
+  if (!t) return '—';
+  const map: Record<string, string> = {
+    domestic: 'Doméstico',
+    residential: 'Residencial',
+    residencial: 'Residencial',
+    commercial: 'Comercial',
+    comercial: 'Comercial',
+    industrial: 'Industrial',
+    revenda: 'Revenda',
+    reseller: 'Revenda',
+    professional: 'Profissional',
+    profissional: 'Profissional',
+  };
+  return map[t.toLowerCase()] ?? (t.charAt(0).toUpperCase() + t.slice(1));
+}
+
+/** Tom semântico pro badge de status do pedido. Mapeia status string pra cor sutil. */
+function orderStatusTone(status: string): { className: string; label: string } {
+  const s = (status || '').toLowerCase();
+  if (['faturado', 'concluido', 'pago', 'entregue'].includes(s)) {
+    return { className: 'bg-status-success-bg text-status-success-bold border-status-success/20', label: status };
+  }
+  if (['cancelado', 'recusado', 'erro'].includes(s)) {
+    return { className: 'bg-status-error-bg text-status-error-bold border-status-error/20', label: status };
+  }
+  if (['pendente', 'aguardando', 'em_analise'].includes(s)) {
+    return { className: 'bg-status-warning-bg text-status-warning-bold border-status-warning/20', label: status };
+  }
+  return { className: 'text-muted-foreground', label: status };
 }
 
 function formatDateOrDash(d: string | null | undefined): string {
@@ -427,7 +480,7 @@ export default function Customer360() {
                   className="w-full h-full object-cover"
                 />
               ) : (
-                <span className="text-base font-medium tracking-tight text-muted-foreground">
+                <span className="text-xl font-semibold tracking-tight text-foreground">
                   {initials(customer.name)}
                 </span>
               )}
@@ -469,27 +522,48 @@ export default function Customer360() {
                 <span>·</span>
                 <span>Cliente desde {formatDateOrDash(customer.created_at)}</span>
               </div>
-              {/* Badges de saúde */}
-              <div className="mt-3 flex flex-wrap items-center gap-3 text-sm">
-                <span className={cn('inline-flex items-center gap-1.5', health.className)}>
-                  <span className={cn('inline-block w-2 h-2 rounded-full', health.dot)} />
-                  {health.label}
-                  {s?.health_score != null && (
-                    <span className="font-mono text-xs ml-1">({Math.round(s.health_score)})</span>
+              {/* Status chips — peso visual maior que texto solto, p/ o estado do cliente
+                  competir com o CTA "Novo pedido". Cliente crítico precisa puxar o olho. */}
+              <div className="mt-3 flex flex-wrap items-center gap-2 text-xs">
+                <span
+                  className={cn(
+                    'inline-flex items-center gap-1.5 px-2 py-1 rounded-md border',
+                    s?.health_class === 'critico' || s?.health_class === 'risco'
+                      ? 'bg-status-error-bg text-status-error-bold border-status-error/20'
+                      : s?.health_class === 'atencao'
+                        ? 'bg-status-warning-bg text-status-warning-bold border-status-warning/20'
+                        : s?.health_class === 'saudavel'
+                          ? 'bg-status-success-bg text-status-success-bold border-status-success/20'
+                          : 'bg-muted text-muted-foreground border-border',
                   )}
+                >
+                  <span className={cn('inline-block w-1.5 h-1.5 rounded-full', health.dot)} />
+                  {health.label}
                 </span>
-                <span className={cn('inline-flex items-center gap-1.5', churn.className)}>
-                  <AlertCircle className="w-3.5 h-3.5" />
-                  {churn.label}
-                </span>
+                {s?.churn_risk != null && (
+                  <span
+                    className={cn(
+                      'inline-flex items-center gap-1.5 px-2 py-1 rounded-md border',
+                      churn.className.replace('text-', 'border-').replace('-bold', '/20'),
+                      churn.className,
+                    )}
+                  >
+                    <AlertCircle className="w-3 h-3" />
+                    {churn.label}
+                  </span>
+                )}
                 {s?.gross_margin_pct != null && (
                   <span
                     className={cn(
-                      'inline-flex items-center gap-1.5',
-                      s.gross_margin_pct >= 0.3 ? 'text-status-success-bold' : s.gross_margin_pct >= 0.15 ? 'text-status-warning-bold' : 'text-status-error-bold',
+                      'inline-flex items-center gap-1.5 px-2 py-1 rounded-md border',
+                      s.gross_margin_pct >= 0.3
+                        ? 'bg-status-success-bg text-status-success-bold border-status-success/20'
+                        : s.gross_margin_pct >= 0.15
+                          ? 'bg-status-warning-bg text-status-warning-bold border-status-warning/20'
+                          : 'bg-status-error-bg text-status-error-bold border-status-error/20',
                     )}
                   >
-                    <Activity className="w-3.5 h-3.5" />
+                    <Activity className="w-3 h-3" />
                     {formatPctMaybe(s.gross_margin_pct)} margem
                   </span>
                 )}
@@ -584,22 +658,58 @@ export default function Customer360() {
                 </CardTitle>
               </CardHeader>
               <CardContent className="space-y-2.5 text-sm">
-                <DataRow
-                  icon={Mail}
-                  label="E-mail"
-                  value={customer.email}
-                  href={customer.email ? `mailto:${customer.email}` : undefined}
-                />
+                {/* F1: profile.email frequentemente vem concatenado por vírgula vindo do Omie.
+                    Split + render como lista. Cada email vira `mailto:` clicável. */}
+                {(() => {
+                  const emails = splitEmails(customer.email);
+                  if (emails.length === 0) {
+                    return <DataRow icon={Mail} label="E-mail" value={null} />;
+                  }
+                  if (emails.length === 1) {
+                    return (
+                      <DataRow
+                        icon={Mail}
+                        label="E-mail"
+                        value={emails[0]}
+                        href={`mailto:${emails[0]}`}
+                      />
+                    );
+                  }
+                  return (
+                    <div className="flex items-start gap-3">
+                      <Mail className="w-3.5 h-3.5 text-muted-foreground mt-0.5 shrink-0" />
+                      <div className="flex-1 min-w-0">
+                        <div className="text-xs text-muted-foreground">
+                          E-mails <span className="font-tabular">({emails.length})</span>
+                        </div>
+                        <ul className="space-y-0.5 mt-0.5">
+                          {emails.map((e) => (
+                            <li key={e}>
+                              <a
+                                href={`mailto:${e}`}
+                                className="text-sm text-foreground hover:underline truncate block"
+                              >
+                                {e}
+                              </a>
+                            </li>
+                          ))}
+                        </ul>
+                      </div>
+                    </div>
+                  );
+                })()}
                 <DataRow
                   icon={Phone}
                   label="Telefone"
                   value={customer.phone ? formatPhone(customer.phone) : null}
                   href={customer.phone ? `tel:${customer.phone}` : undefined}
                 />
+                {/* F9: icon contextual ao tipo (PJ vs PF) em vez de Sparkles decorativo.
+                    F3: customer_type traduzido pra rótulo humano. */}
                 <DataRow
-                  icon={Sparkles}
+                  icon={isPj ? Building2 : User}
                   label="Tipo"
-                  value={customer.customer_type ?? (isPj ? 'PJ' : 'PF')}
+                  value={formatCustomerType(customer.customer_type) || (isPj ? 'PJ' : 'PF')}
                 />
               </CardContent>
             </Card>
@@ -613,27 +723,39 @@ export default function Customer360() {
               </CardHeader>
               <CardContent className="space-y-3 text-sm">
                 {address.data && address.data.length > 0 ? (
-                  address.data.slice(0, 2).map((a, i) => (
-                    <div key={i} className="space-y-0.5">
-                      <div className="flex items-center gap-2">
-                        <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
-                          {a.label || (a.is_default ? 'Principal' : `Endereço ${i + 1}`)}
-                        </span>
-                        {a.is_default && (
-                          <Badge variant="outline" className="text-[9px] uppercase">
-                            Padrão
-                          </Badge>
-                        )}
+                  address.data.slice(0, 2).map((a, i) => {
+                    // F2: "OMIE" e "padrão" são labels técnicos do ERP. Pro usuário, o que
+                    // importa é se é o endereço padrão ou não. Se for padrão, mostra "Principal".
+                    // Caso contrário, usa label custom OU "Endereço N" como fallback.
+                    const isFirstShown = i === 0;
+                    const isOmieLabel = (a.label ?? '').toUpperCase() === 'OMIE';
+                    const displayLabel = a.is_default
+                      ? 'Principal'
+                      : isOmieLabel
+                        ? `Endereço ${i + 1}`
+                        : (a.label || `Endereço ${i + 1}`);
+                    return (
+                      <div key={i} className="space-y-0.5">
+                        <div className="flex items-center gap-2">
+                          <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                            {displayLabel}
+                          </span>
+                          {a.is_default && !isFirstShown && (
+                            <Badge variant="outline" className="text-[9px] uppercase">
+                              Padrão
+                            </Badge>
+                          )}
+                        </div>
+                        <div className="text-foreground leading-snug">
+                          {a.street}, {a.number}
+                          {a.complement && <span className="text-muted-foreground"> · {a.complement}</span>}
+                        </div>
+                        <div className="text-muted-foreground">
+                          {a.neighborhood} · {a.city}/{a.state} · {formatCep(a.zip_code)}
+                        </div>
                       </div>
-                      <div className="text-foreground leading-snug">
-                        {a.street}, {a.number}
-                        {a.complement && <span className="text-muted-foreground"> · {a.complement}</span>}
-                      </div>
-                      <div className="text-muted-foreground">
-                        {a.neighborhood} · {a.city}/{a.state} · {formatCep(a.zip_code)}
-                      </div>
-                    </div>
-                  ))
+                    );
+                  })
                 ) : (
                   <p className="text-sm text-muted-foreground">Nenhum endereço cadastrado.</p>
                 )}
@@ -648,27 +770,30 @@ export default function Customer360() {
                     Score comercial
                   </CardTitle>
                 </CardHeader>
-                <CardContent className="space-y-2 text-sm">
-                  <DataRow
+                <CardContent className="space-y-2.5 text-sm">
+                  {/* F8: layout label-esquerda / valor-direita em mono, p/ valores
+                      numéricos saltarem na varredura. Score é dado denso, não prosa. */}
+                  <ScoreRow
                     label="Prioridade"
-                    value={s.priority_score != null ? Math.round(s.priority_score).toString() : null}
-                    hint="0–100, quanto maior mais prioritário"
+                    value={s.priority_score != null ? Math.round(s.priority_score).toString() : '—'}
+                    hint="0–100"
                   />
-                  <DataRow
-                    label="Potencial de expansão"
-                    value={s.expansion_score != null ? Math.round(s.expansion_score).toString() : null}
+                  <ScoreRow
+                    label="Expansão"
+                    value={s.expansion_score != null ? Math.round(s.expansion_score).toString() : '—'}
+                    hint="potencial"
                   />
-                  <DataRow
+                  <ScoreRow
                     label="Receita potencial"
-                    value={s.revenue_potential != null ? formatBRL(s.revenue_potential) : null}
+                    value={s.revenue_potential != null ? formatBRL(s.revenue_potential) : '—'}
                   />
-                  <DataRow
-                    label="Gasto médio mensal (180d)"
-                    value={s.avg_monthly_spend_180d != null ? formatBRL(s.avg_monthly_spend_180d) : null}
+                  <ScoreRow
+                    label="Gasto mensal (180d)"
+                    value={s.avg_monthly_spend_180d != null ? formatBRL(s.avg_monthly_spend_180d) : '—'}
                   />
-                  <DataRow
+                  <ScoreRow
                     label="Categorias compradas"
-                    value={s.category_count != null ? String(s.category_count) : null}
+                    value={s.category_count != null ? String(s.category_count) : '—'}
                   />
                 </CardContent>
               </Card>
@@ -728,9 +853,12 @@ export default function Customer360() {
                     ))}
                   </ul>
                 ) : (
-                  <p className="text-sm text-muted-foreground py-2">
-                    Nenhum item preferido registrado ainda. Aparecerá depois das primeiras compras.
-                  </p>
+                  <EmptyState
+                    icon={Package}
+                    title="Sem itens preferidos ainda"
+                    description="Aparecerão depois das primeiras compras."
+                    tone="operational"
+                  />
                 )}
               </CardContent>
             </Card>
@@ -791,9 +919,12 @@ export default function Customer360() {
                     ))}
                   </ul>
                 ) : (
-                  <p className="text-sm text-muted-foreground py-2">
-                    Nenhum contato registrado nas últimas semanas.
-                  </p>
+                  <EmptyState
+                    icon={Inbox}
+                    title="Sem contatos recentes"
+                    description="Nenhuma ligação ou mensagem registrada nas últimas semanas."
+                    tone="operational"
+                  />
                 )}
               </CardContent>
             </Card>
@@ -812,23 +943,31 @@ export default function Customer360() {
                 </CardHeader>
                 <CardContent>
                   <ul className="divide-y divide-border -my-2">
-                    {orders.data.slice(0, 5).map((o) => (
-                      <li key={o.id} className="py-2 flex items-center gap-3 text-sm">
-                        <div className="flex-1 min-w-0">
-                          <div className="font-tabular text-foreground">
-                            PV {o.omie_numero_pedido ?? o.id.slice(0, 8)}
+                    {orders.data.slice(0, 5).map((o) => {
+                      // F11: badge de status com tom semântico (verde p/ faturado, vermelho
+                      // p/ cancelado, âmbar p/ pendente). Cinza só se status não mapeado.
+                      const tone = orderStatusTone(o.status);
+                      return (
+                        <li key={o.id} className="py-2 flex items-center gap-3 text-sm">
+                          <div className="flex-1 min-w-0">
+                            <div className="font-tabular text-foreground">
+                              PV {o.omie_numero_pedido ?? o.id.slice(0, 8)}
+                            </div>
+                            <div className="text-xs text-muted-foreground">
+                              {formatDateOrDash(o.created_at)} ·{' '}
+                              <span className="uppercase tracking-wide">{o.account}</span>
+                            </div>
                           </div>
-                          <div className="text-xs text-muted-foreground">
-                            {formatDateOrDash(o.created_at)} ·{' '}
-                            <span className="uppercase tracking-wide">{o.account}</span>
-                          </div>
-                        </div>
-                        <div className="text-sm font-mono">{formatBRL(o.total)}</div>
-                        <Badge variant="outline" className="text-[10px] uppercase">
-                          {o.status}
-                        </Badge>
-                      </li>
-                    ))}
+                          <div className="text-sm font-mono tabular-nums">{formatBRL(o.total)}</div>
+                          <Badge
+                            variant="outline"
+                            className={cn('text-[10px] uppercase font-tabular', tone.className)}
+                          >
+                            {tone.label}
+                          </Badge>
+                        </li>
+                      );
+                    })}
                   </ul>
                   {orders.data.length > 5 && (
                     <>
@@ -886,6 +1025,32 @@ function DataRow({
           <div className="text-sm text-foreground truncate">{display}</div>
         )}
         {hint && <div className="text-xs text-muted-foreground mt-0.5">{hint}</div>}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Linha de score (label esquerda, valor à direita em mono). Usada no card "Score
+ * comercial" pra densidade tabular — diferente de DataRow que é vertical (form-like).
+ */
+function ScoreRow({
+  label,
+  value,
+  hint,
+}: {
+  label: string;
+  value: string;
+  hint?: string;
+}) {
+  return (
+    <div className="flex items-baseline justify-between gap-2">
+      <div className="min-w-0">
+        <div className="text-xs text-muted-foreground truncate">{label}</div>
+        {hint && <div className="text-[10px] text-muted-foreground/70 mt-0.5">{hint}</div>}
+      </div>
+      <div className="font-mono text-sm font-medium text-foreground tabular-nums shrink-0">
+        {value}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

Polish do Cliente 360 baseado em 11 achados do `/design-review` com prints reais (cliente RAVENNA INDUSTRIA DE MOVEIS LTDA.). PR sequencial ao [#92](https://github.com/LucasSardenbergL/afiacao/pull/92).

## Achados corrigidos

### ALTOS (visuais que comprometiam leitura)

| # | Achado | Fix |
|---|---|---|
| F1 | E-mail concatenado por virgula no DB ficava truncado feio | `splitEmails()` helper quebra por `,;`, valida `@`, renderiza lista numerada quando >1 |
| F2 | Label "OMIE PADRAO" no card Enderecos era jargao tecnico | Mapeado p/ "Principal" quando `is_default`; fallback "Endereco N" |
| F3 | `customer_type` "domestic" cru do enum | `formatCustomerType()` mapeia domestic->Domestico, residential->Residencial, commercial->Comercial, etc |
| F4 | "Critico (0)" no badge confundia (o (0) era health_score) | Removido — badge so o label agora |
| F5 | Hero hierarchy fraca — botao "Novo pedido" preto dominava o status critico | Badges health/churn/margem viraram chips com `bg-status-*-bg` + border + padding |
| F6 | "0.0% margem" com decimal desnecessario | `formatPctMaybe` retorna "0%" sem decimal quando = 0; arredonda quando proximo de inteiro |

### MEDIOS (polish)

| # | Achado | Fix |
|---|---|---|
| F7 | Avatar fallback ("RI") muito pequeno em 64px | text-base->text-xl, font-medium->semibold, text-muted->text-foreground |
| F8 | Score comercial valores sem hierarquia | Novo `<ScoreRow>` com layout label-esquerda / valor-direita em `font-mono tabular-nums` |
| F9 | `Sparkles` icon decorativo na linha "Tipo" duplicava o do botao "Ver 360°" | Trocado por `User` (PF) ou `Building2` (PJ) baseado em `isPj` |
| F10 | Empty states ("Nenhum item preferido", "Nenhum contato") usavam `<p>` simples | Migrados pro `<EmptyState>` v3 com icon (`Package`/`Inbox`), title, description, padrao de pontos sutil |
| F11 | Badge de status de pedido (Faturado/Cancelado/Pendente) todo cinza outline | `orderStatusTone()` mapeia status->cores sutis (verde p/ faturado, vermelho p/ cancelado, ambar p/ pendente) |

## Cleanup

- Removido `const PCT` nao usado depois do refactor de `formatPctMaybe`
- `.gstack/` adicionado ao `.gitignore` (sessoes locais)

## Build

- `bun install` adicionou jssip + posthog-js + react-hook-form (deps que vieram da main desde o ultimo install local)
- `bun run build` exit 0 (~35s, 5287 KiB precache)

## Test plan

- [ ] Lovable redeploya
- [ ] Abrir Cliente 360 de cliente com email multiplo (RAVENNA tem 2): card Contato deve mostrar "E-mails (2)" + lista
- [ ] Abrir Cliente 360 de PJ: badge "PJ" no hero + icon Building2 no card Contato linha Tipo
- [ ] Abrir Cliente 360 de PF: badge "PF" + icon User
- [ ] Endereco principal: label "Principal" em vez de "OMIE PADRAO"
- [ ] Cliente critico (health_class=critico): badge no hero com bg vermelho sutil + border (chip estilo)
- [ ] Cliente com margem 0: mostra "0%" sem decimal
- [ ] Pedido faturado: badge com tom verde sutil em vez de cinza
- [ ] Cliente sem itens preferidos: EmptyState com icon Package + pattern de pontos
- [ ] Cliente sem contatos: EmptyState com icon Inbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)