### PR TITLE
fix(scoring): RLS policies usam 'master' em vez de 'admin'

### DIFF
--- a/supabase/migrations/20260518110000_scoring_v2_signal_modifiers.sql
+++ b/supabase/migrations/20260518110000_scoring_v2_signal_modifiers.sql
@@ -36,11 +36,12 @@ CREATE UNIQUE INDEX IF NOT EXISTS uniq_score_recalc_queue_pending
 
 ALTER TABLE public.score_recalc_queue ENABLE ROW LEVEL SECURITY;
 
+-- Roles canônicos do projeto: employee | customer | master (NÃO existe 'admin' no enum app_role).
 CREATE POLICY "Staff can view recalc queue" ON public.score_recalc_queue FOR SELECT
-  USING (has_role(auth.uid(), 'admin'::app_role) OR has_role(auth.uid(), 'employee'::app_role));
+  USING (has_role(auth.uid(), 'master'::app_role) OR has_role(auth.uid(), 'employee'::app_role));
 
 CREATE POLICY "Staff can insert recalc queue" ON public.score_recalc_queue FOR INSERT
-  WITH CHECK (has_role(auth.uid(), 'admin'::app_role) OR has_role(auth.uid(), 'employee'::app_role));
+  WITH CHECK (has_role(auth.uid(), 'master'::app_role) OR has_role(auth.uid(), 'employee'::app_role));
 
 -- Service role (edge functions) bypass via service_role usage; sem policy update/delete pra users.
 


### PR DESCRIPTION
## Bug

Migration \`20260518110000_scoring_v2_signal_modifiers.sql\` (do PR #94 mergeado) usa \`has_role(auth.uid(), 'admin'::app_role)\` em 2 policies RLS. O enum \`app_role\` do projeto só tem \`employee | customer | master\` — \`admin\` não existe. Resultado: SQL Editor retorna **\`ERROR: 22P02: invalid input value for enum app_role: \"admin\"\`** e roda rollback completo. Migration não foi aplicada.

Bug do plano original — copiei pattern de uma migration antiga (\`20260223024009\`) que ainda tinha \`admin\` no enum antes de algum rename. Não validei contra o estado atual do schema.

## Fix

Troca \`'admin'::app_role\` por \`'master'::app_role\` nas 2 policies. Master é o role de maior privilégio no projeto, então é o equivalente semântico do que \`admin\` deveria ser.

## Impacto

- **Usuários que ainda não aplicaram a migration**: depois desse merge, podem re-pastar o arquivo corrigido direto. Tudo idempotente (IF NOT EXISTS / OR REPLACE / DROP IF EXISTS).
- **Usuários que já aplicaram (impossível agora, todo mundo recebeu o erro)**: N/A.

## Test plan

- [ ] Mergear
- [ ] Re-aplicar migration manual no Supabase Dashboard → deve rodar sem erro
- [ ] Validar com query: \`SELECT polname FROM pg_policy WHERE polrelid = 'public.score_recalc_queue'::regclass;\` — esperado 2 linhas

🤖 Generated with [Claude Code](https://claude.com/claude-code)