### PR TITLE
feat(typescript): wave 9 promove 5 files Wave 8 pra strict (28→33)

### DIFF
--- a/src/components/UnifiedAIAssistant.tsx
+++ b/src/components/UnifiedAIAssistant.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useCallback, useEffect } from 'react';
-import { Mic, Send, Loader2, Sparkles, X, Square, Camera, Package, Wrench, Image, Check, Lightbulb, Plus, Paperclip, FileAudio, User, MapPin } from 'lucide-react';
+import { Mic, Loader2, Sparkles, X, Square, Camera, Package, Wrench, Check, Lightbulb, Plus, Paperclip, User, MapPin } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { cn, decodeHtmlEntities } from '@/lib/utils';

--- a/src/pages/AdminReposicaoOportunidades.tsx
+++ b/src/pages/AdminReposicaoOportunidades.tsx
@@ -146,7 +146,7 @@ function formatDate(d: string | null | undefined): string {
 
 function formatDateLong(d: string | null | undefined): string {
   if (!d) return "—";
-  const [y, m, day] = d.split("-");
+  const [, m, day] = d.split("-");
   const meses = [
     "janeiro",
     "fevereiro",

--- a/src/pages/FarmerTacticalPlan.tsx
+++ b/src/pages/FarmerTacticalPlan.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
@@ -8,7 +8,6 @@ import { Textarea } from '@/components/ui/textarea';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Switch } from '@/components/ui/switch';
 import { Label } from '@/components/ui/label';
-import { ScrollArea } from '@/components/ui/scroll-area';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
 import { useAuth } from '@/contexts/AuthContext';
 import { useTacticalPlan, getObjectiveLabel, type TacticalPlan, type PlanType } from '@/hooks/useTacticalPlan';
@@ -16,10 +15,9 @@ import { supabase } from '@/integrations/supabase/client';
 import {
   Loader2, Target, Heart, AlertTriangle, TrendingUp, Package,
   MessageSquare, Shield, Copy, Check, ChevronDown, ChevronUp,
-  Plus, FileText, Brain, DollarSign, Clock, Zap, BarChart3,
+  Plus, FileText, Brain, DollarSign, Zap, BarChart3,
   AlertCircle, Layers, type LucideIcon
 } from 'lucide-react';
-import { toast } from 'sonner';
 
 // ─── Local types ───────────────────────────────────────────────────
 interface FarmerClientScoreRow {

--- a/src/pages/Recebimento.tsx
+++ b/src/pages/Recebimento.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { decodeHtmlEntities } from '@/lib/utils';
 import { useNavigate } from 'react-router-dom';
 import { useQuery, useQueryClient } from '@tanstack/react-query';

--- a/tsconfig.strict.json
+++ b/tsconfig.strict.json
@@ -46,6 +46,11 @@
     "src/components/des/CheckinQualitativoTab.tsx",
     "src/pages/SalesOrders.tsx",
     "src/pages/TintReconciliation.tsx",
-    "src/pages/TintMapping.tsx"
+    "src/pages/TintMapping.tsx",
+    "src/pages/Recebimento.tsx",
+    "src/pages/AdminReposicaoPromocoes.tsx",
+    "src/pages/FarmerTacticalPlan.tsx",
+    "src/pages/AdminReposicaoOportunidades.tsx",
+    "src/components/UnifiedAIAssistant.tsx"
   ]
 }


### PR DESCRIPTION
## Summary

Promove os 5 files da Wave 8 (PR #98) pro `tsconfig.strict.json` include. **Todos os 9 strict errors residuais foram unused imports** — sub-agents da Wave 8 fizeram limpeza mais cuidadosa que waves anteriores, sem bugs latentes nem narrowing residual.

## tsconfig.strict.json: 28 → 33 files

Novos no include:
- `src/pages/Recebimento.tsx`
- `src/pages/AdminReposicaoPromocoes.tsx`
- `src/pages/FarmerTacticalPlan.tsx`
- `src/pages/AdminReposicaoOportunidades.tsx`
- `src/components/UnifiedAIAssistant.tsx`

## Correções (9 unused imports/vars)

| File | Removidos |
|---|---|
| UnifiedAIAssistant | `Send`, `Image`, `FileAudio` (lucide-react) |
| AdminReposicaoOportunidades | `y` em `formatDateLong` (destructure unused — só usa `m` e `day`) |
| FarmerTacticalPlan | `useCallback`, `ScrollArea`, `Clock`, `toast` |
| Recebimento | `React` import default legado (não usado com JSX transform moderno) |

## Validação

```
$ bun run typecheck:strict
0 errors (33 files)

$ bunx tsc --noEmit
0 errors (baseline mantido)

$ bun run test
Test Files  44 passed (44)
Tests       295 passed (295)

$ bun lint
547 problems (sem mudança — wave 9 só promove, não muda any count)
```

## Aggregate strict-mode progress

| Wave | tsconfig.strict.json | Trigger |
|---|---|---|
| Pre-Wave 1 | 6 (só libs) | — |
| Wave 1 | 9 | PRs #58/#62/#64/#68 |
| Wave 3 | 18 | PR #84 (4 engine hooks) |
| Wave 5 | 23 | PR #91 (5 pages financeiro/farmer) |
| Wave 7 | 28 | PR #95 (5 pages reposição/sales/tint/des) |
| **Wave 9** | **33** | _Este PR (5 pages receb/promo/farmer/opp/AI)_ |

~9% do src em strict (33 / ~350 files alvo). Convergência gradual mas estável.

## Próximas waves candidatas

- **Wave 10**: Edge Functions (omie-pedidos, calculate-scores, omie-nfe-recebimento)
- **Wave 11**: pages restantes com 6-7 any (SalesQuotes, SalesOrderEdit, FinanceiroIntercompany, AdminReposicaoRevisao, AdminReposicaoCadastros)
- **Wave 12+**: god-components refactor (FinanceiroDashboard 1242L, AdminRoutePlanner 1661L) — alto risco, sprint próprio

## Test plan

- [x] `bun run typecheck:strict` 0 errors (33 files)
- [x] `bunx tsc --noEmit` 0 errors (baseline)
- [x] `bun run test` 295/295
- [x] `bun lint` ≤ 547 problems
- [ ] CI verde (validate workflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)