### PR TITLE
style(customer-360): permite quebra do nome em 2 linhas no hero

### DIFF
--- a/src/pages/Customer360.tsx
+++ b/src/pages/Customer360.tsx
@@ -487,7 +487,10 @@ export default function Customer360() {
             </div>
             <div className="flex-1 min-w-0">
               <div className="flex items-center gap-2 flex-wrap">
-                <h1 className="font-display text-3xl font-medium tracking-[-0.04em] leading-tight truncate">
+                {/* Nome do cliente: line-clamp-2 em vez de truncate, p/ acomodar razao
+                    social longa em viewport estreito (Lovable preview split, mobile).
+                    Em viewport wide cabe em 1 linha; em estreito quebra sem truncar. */}
+                <h1 className="font-display text-3xl font-medium tracking-[-0.04em] leading-tight line-clamp-2 break-words min-w-0">
                   {customer.name}
                 </h1>
                 {isPj && (


### PR DESCRIPTION
## Summary

Customer com razao social longa (ex: RAVENNA INDUSTRIA DE MOVEIS LTDA.) ficava truncado no hero quando viewport estava estreito (preview Lovable com chat aberto, mobile). Trocado `truncate` por `line-clamp-2 break-words min-w-0` no h1.

## Comportamento

- **Viewport wide**: nome cabe em 1 linha (igual antes)
- **Viewport estreito** (~1200px ou menor): nome quebra em 2 linhas sem truncar
- **Nome absurdamente longo**: ainda trunca com ellipsis depois de 2 linhas (raro)

## Test plan

- [ ] Cliente com nome longo: ver completo no Cliente 360 em viewport estreito
- [ ] Cliente com nome curto: continua 1 linha
- [ ] Layout do hero (avatar + nome + badges + botoes) nao quebra

🤖 Generated with [Claude Code](https://claude.com/claude-code)