### PR TITLE
feat(typescript): wave 16 desbloqueia 4 deferidos + fix deps (44→48 strict)

### DIFF
--- a/src/components/TintColorSelectDialog.tsx
+++ b/src/components/TintColorSelectDialog.tsx
@@ -164,9 +164,7 @@ export function TintColorSelectDialog({ product, open, onClose, onConfirm, custo
             .map(b => b.id)
         );
         
-        // Remove SKUs with non-matching bases
-        const filteredSkuIds = new Set(skus.filter(s => validBaseIds.has(s.base_id)).map(s => s.id));
-        // Also filter the skus array in-place for later use
+        // Remove SKUs with non-matching bases — filtra skus in-place
         const filteredSkus = skus.filter(s => validBaseIds.has(s.base_id));
         if (filteredSkus.length === 0) return [];
         // Replace skus reference
@@ -210,7 +208,7 @@ export function TintColorSelectDialog({ product, open, onClose, onConfirm, custo
   });
 
   // Pricing breakdown for selected formula (for informational display)
-  const { data: pricing, isLoading: loadingPricing } = useTintPricing(selectedFormula?.id || null);
+  const { data: pricing } = useTintPricing(selectedFormula?.id || null);
 
   // Last practiced price for this color+base for the customer
   const { data: lastPracticedPrice, isLoading: loadingLastPrice } = useQuery({

--- a/src/hooks/unifiedOrder/useProductCatalog.ts
+++ b/src/hooks/unifiedOrder/useProductCatalog.ts
@@ -55,11 +55,11 @@ export function useProductCatalog({
         try {
           let nextPage: number | null = 1;
           while (nextPage) {
-            const { data, error } = await supabase.functions.invoke('omie-vendas-sync', {
+            const result: { data: unknown; error: unknown } = await supabase.functions.invoke('omie-vendas-sync', {
               body: { action: 'sync_estoque', start_page: nextPage, account },
             });
-            if (error) break;
-            nextPage = data?.nextPage || null;
+            if (result.error) break;
+            nextPage = (result.data as { nextPage?: number | null } | null)?.nextPage ?? null;
           }
           const refreshed = await fetchProductsForAccount(account);
           if (refreshed.length > 0) setProds(refreshed);
@@ -88,12 +88,12 @@ export function useProductCatalog({
           try {
             let nextPage: number | null = 1;
             while (nextPage) {
-              const { data: syncResult, error: syncError } = await supabase.functions.invoke(
+              const syncRes: { data: unknown; error: unknown } = await supabase.functions.invoke(
                 'omie-vendas-sync',
                 { body: { action: 'sync_products', start_page: nextPage, account } },
               );
-              if (syncError) throw syncError;
-              nextPage = syncResult?.nextPage || null;
+              if (syncRes.error) throw syncRes.error;
+              nextPage = (syncRes.data as { nextPage?: number | null } | null)?.nextPage ?? null;
             }
             products = await fetchProductsForAccount(account);
           } catch (syncErr) {

--- a/src/hooks/useAuditTrail.ts
+++ b/src/hooks/useAuditTrail.ts
@@ -21,15 +21,16 @@ export function useAuditTrail(params: { tableName: string; rowId: string; limit?
     queryKey: ['fin_audit_log', tableName, rowId, limit],
     enabled: Boolean(tableName) && Boolean(rowId),
     queryFn: async (): Promise<AuditEntry[]> => {
+      // `fin_audit_log` existe no DB (migration 20260518) mas ainda não no generated Database type
       const { data, error } = await supabase
-        .from('fin_audit_log')
+        .from('fin_audit_log' as never)
         .select('*')
-        .eq('table_name', tableName)
-        .eq('row_id', rowId)
+        .eq('table_name' as never, tableName as never)
+        .eq('row_id' as never, rowId as never)
         .order('changed_at', { ascending: false })
         .limit(limit);
       if (error) throw error;
-      return (data ?? []) as AuditEntry[];
+      return (data ?? []) as unknown as AuditEntry[];
     },
   });
 }

--- a/src/hooks/useIcMatches.ts
+++ b/src/hooks/useIcMatches.ts
@@ -27,15 +27,16 @@ export function useIcMatches(filterStatus?: IcMatch['status']) {
   return useQuery({
     queryKey: ['fin_ic_matches', filterStatus ?? 'all'],
     queryFn: async (): Promise<IcMatch[]> => {
+      // `fin_ic_matches` existe no DB (migration 20260518) mas ainda não no generated Database type
       let q = supabase
-        .from('fin_ic_matches')
+        .from('fin_ic_matches' as never)
         .select('*')
         .order('matched_at', { ascending: false })
         .limit(500);
-      if (filterStatus) q = q.eq('status', filterStatus);
+      if (filterStatus) q = q.eq('status' as never, filterStatus as never);
       const { data, error } = await q;
       if (error) throw error;
-      return (data ?? []) as IcMatch[];
+      return (data ?? []) as unknown as IcMatch[];
     },
   });
 }
@@ -50,14 +51,14 @@ export function useResolveIcMatch() {
     }) => {
       const user = await supabase.auth.getUser();
       const { error } = await supabase
-        .from('fin_ic_matches')
+        .from('fin_ic_matches' as never)
         .update({
           status: input.status,
           observacao: input.observacao ?? null,
           resolvido_por: user.data.user?.id,
           resolvido_em: new Date().toISOString(),
-        })
-        .eq('id', input.id);
+        } as never)
+        .eq('id' as never, input.id as never);
       if (error) throw error;
     },
     onSuccess: () => qc.invalidateQueries({ queryKey: ['fin_ic_matches'] }),

--- a/src/hooks/usePriceHistory.ts
+++ b/src/hooks/usePriceHistory.ts
@@ -2,12 +2,6 @@ import { useState, useCallback } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import { logger } from '@/lib/logger';
 
-interface PriceHistoryEntry {
-  user_tool_id: string;
-  service_type: string;
-  unit_price: number;
-}
-
 interface PriceHistory {
   [key: string]: number; // key = `${userToolId}_${serviceType}` or `${serviceType}`
 }

--- a/src/hooks/usePricingEngine.ts
+++ b/src/hooks/usePricingEngine.ts
@@ -3,7 +3,7 @@ import { supabase } from '@/integrations/supabase/client';
 
 interface DefaultPrice {
   id: string;
-  tool_category_id: string;
+  tool_category_id: string | null;
   spec_filter: Record<string, string>;
   price: number;
   description: string | null;

--- a/src/hooks/useUnifiedOrder.ts
+++ b/src/hooks/useUnifiedOrder.ts
@@ -44,7 +44,6 @@ import type {
   OmieCustomer,
   FormaPagamento,
   CompanyProfile,
-  AddressData,
   ToolCategory,
   UserTool,
 } from '@/hooks/unifiedOrder/types';
@@ -193,8 +192,8 @@ export function useUnifiedOrder() {
     loadingCustomer,
     customerUserId, setCustomerUserId,
     requiresPo,
-    customerPricesOben, setCustomerPricesOben,
-    customerPricesColacor, setCustomerPricesColacor,
+    customerPricesOben,
+    customerPricesColacor,
     selectedParcelaOben, setSelectedParcelaOben,
     selectedParcelaColacor, setSelectedParcelaColacor,
     customerParcelaRankingOben,
@@ -272,7 +271,6 @@ export function useUnifiedOrder() {
     loadingObenProducts, loadingColacorProducts,
     productSearch, setProductSearch,
     filteredObenProducts, filteredColacorProducts,
-    isProductPreviouslyPurchased, getProductLastOrderDate,
   } = catalog;
 
   // Wrap clearCustomer to also clear cart + ordem de compra

--- a/src/pages/AdminReposicaoCadeiaLogistica.tsx
+++ b/src/pages/AdminReposicaoCadeiaLogistica.tsx
@@ -179,7 +179,7 @@ export default function AdminReposicaoCadeiaLogistica() {
       const ltDepois = await ltTotalAtualForn(args.fornecedor);
       const delta = ltDepois - args.ltAntes;
 
-      // log histórico
+      // log histórico — coluna `empresa` existe no DB mas ainda não no generated type
       await supabase.from("fornecedor_cadeia_logistica_historico").insert({
         empresa: EMPRESA,
         fornecedor_nome: args.fornecedor,
@@ -188,7 +188,7 @@ export default function AdminReposicaoCadeiaLogistica() {
         descricao_mudanca: args.descricao,
         valores_anteriores: args.valoresAnt ?? null,
         valores_novos: args.valoresNov ?? null,
-      });
+      } as never);
 
       // chamar recálculo (best-effort)
       const { error: rpcErr } = await supabase.rpc(
@@ -231,6 +231,7 @@ export default function AdminReposicaoCadeiaLogistica() {
         const proxOrdem = ordensExist.length > 0 ? Math.max(...ordensExist) + 1 : 1;
         const codigo = `${payload.fornecedor.slice(0, 4).toUpperCase().replace(/\s/g, "")}_E${proxOrdem}_${Date.now().toString(36)}`;
 
+        // `empresa` field existe no DB mas ainda não no generated type
         const { error } = await supabase
           .from("fornecedor_cadeia_logistica")
           .insert({
@@ -246,7 +247,7 @@ export default function AdminReposicaoCadeiaLogistica() {
             parceiro_contato: payload.etapa.parceiro_contato ?? null,
             observacoes: payload.etapa.observacoes ?? null,
             ativo: true,
-          });
+          } as never);
         if (error) throw error;
 
         await recalcularComImpacto({

--- a/src/pages/AdminReposicaoGruposProducao.tsx
+++ b/src/pages/AdminReposicaoGruposProducao.tsx
@@ -233,8 +233,8 @@ export default function AdminReposicaoGruposProducao() {
       if (g.id) {
         const { error } = await supabase
           .from("fornecedor_grupo_producao" as never)
-          .update(payload)
-          .eq("id", g.id);
+          .update(payload as never)
+          .eq("id" as never, g.id as never);
         if (error) throw error;
       } else {
         const { error } = await supabase

--- a/src/pages/AdminSkuMapeamento.tsx
+++ b/src/pages/AdminSkuMapeamento.tsx
@@ -4,7 +4,7 @@ import { supabase } from '@/integrations/supabase/client';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
-import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle, DialogTrigger, DialogDescription } from '@/components/ui/dialog';
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';

--- a/src/pages/FinanceiroFechamento.tsx
+++ b/src/pages/FinanceiroFechamento.tsx
@@ -3,7 +3,6 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { Input } from '@/components/ui/input';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from '@/components/ui/dialog';
 import { COMPANIES, ALL_COMPANIES, type Company } from '@/contexts/CompanyContext';
 import {
@@ -17,8 +16,8 @@ import { parsePostgresFinanceiroError } from '@/lib/financeiro/error-handler';
 import { useNavigate, Link } from 'react-router-dom';
 import { useIcMatches } from '@/hooks/useIcMatches';
 import {
-  Loader2, Building2, Lock, Unlock, CheckCircle2, Clock,
-  FileText, Eye, RotateCcw, Plus, History, ShieldCheck, AlertTriangle,
+  Loader2, Building2, Lock, Unlock, Clock,
+  Eye, RotateCcw, Plus, History, ShieldCheck, AlertTriangle,
   type LucideIcon,
 } from 'lucide-react';
 
@@ -44,10 +43,10 @@ const FinanceiroFechamento = () => {
   const [company, setCompany] = useState<Company | 'all'>('all');
   const [ano, setAno] = useState(new Date().getFullYear());
   const [fechamentos, setFechamentos] = useState<Fechamento[]>([]);
-  const [loading, setLoading] = useState(true);
+  const [, setLoading] = useState(true);
   const [acting, setActing] = useState(false);
   const [selectedLog, setSelectedLog] = useState<{ id: string; logs: FechamentoLog[] } | null>(null);
-  const [motivoReabertura, setMotivoReabertura] = useState('');
+  const [motivoReabertura] = useState('');
   const [auditTarget, setAuditTarget] = useState<{ table: string; id: string; title: string } | null>(null);
   const [mappingPendentes, setMappingPendentes] = useState<Array<{id: string; nome: string}>>([]);
   const { data: icDiv } = useIcMatches('divergencia_valor');

--- a/src/pages/FinanceiroIntercompany.tsx
+++ b/src/pages/FinanceiroIntercompany.tsx
@@ -9,7 +9,7 @@ import { COMPANIES, ALL_COMPANIES, type Company } from '@/contexts/CompanyContex
 import { getEliminacoes, upsertEliminacao, deleteEliminacao, type EliminacaoRegra } from '@/services/financeiroV2Service';
 import { supabase } from '@/integrations/supabase/client';
 import { toast } from 'sonner';
-import { Loader2, Plus, Trash2, ArrowRight, Building2, Save, BarChart3, AlertTriangle } from 'lucide-react';
+import { Plus, Trash2, ArrowRight, BarChart3, AlertTriangle } from 'lucide-react';
 import { useIcMatches } from '@/hooks/useIcMatches';
 import { Link } from 'react-router-dom';
 

--- a/src/pages/SalesOrderEdit.tsx
+++ b/src/pages/SalesOrderEdit.tsx
@@ -128,7 +128,7 @@ function PaymentComboboxEdit({
 const SalesOrderEdit = () => {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
-  const { isStaff } = useAuth();
+  useAuth(); // mantém o hook montado pra refresh de token; isStaff não é usado
 
   const [order, setOrder] = useState<SalesOrder | null>(null);
   const [customerName, setCustomerName] = useState('');
@@ -143,7 +143,6 @@ const SalesOrderEdit = () => {
   const [showAddProduct, setShowAddProduct] = useState(false);
   const [productSearch, setProductSearch] = useState('');
   const [catalogProducts, setCatalogProducts] = useState<OmieProduct[]>([]);
-  const [loadingProducts, setLoadingProducts] = useState(false);
   // Tint color dialog
   const [tintPendingProduct, setTintPendingProduct] = useState<OmieProduct | null>(null);
   const [customerUserId, setCustomerUserId] = useState<string | null>(null);
@@ -153,6 +152,7 @@ const SalesOrderEdit = () => {
   }, [id]);
 
   const loadOrder = async () => {
+    if (!id) return;
     try {
       const { data, error } = await supabase
         .from('sales_orders')
@@ -261,7 +261,7 @@ const SalesOrderEdit = () => {
     toast.success(`"${product.descricao}" adicionado`);
   };
 
-  const handleTintConfirm = (formulaId: string, corId: string, nomeCor: string, precoFinal: number, custoCorantes: number, alternativeProduct?: Product) => {
+  const handleTintConfirm = (_formulaId: string, corId: string, nomeCor: string, precoFinal: number, _custoCorantes: number, alternativeProduct?: Product) => {
     const product = alternativeProduct
       ? catalogProducts.find(p => p.id === alternativeProduct.id) || tintPendingProduct!
       : tintPendingProduct!;

--- a/tsconfig.strict.json
+++ b/tsconfig.strict.json
@@ -62,6 +62,10 @@
     "src/pages/QualityChecklist.tsx",
     "src/pages/FarmerLOCC.tsx",
     "src/pages/AdminReposicaoAumentos.tsx",
-    "src/pages/TintPricing.tsx"
+    "src/pages/TintPricing.tsx",
+    "src/pages/FinanceiroIntercompany.tsx",
+    "src/pages/FinanceiroFechamento.tsx",
+    "src/pages/SalesOrderEdit.tsx",
+    "src/pages/AdminReposicaoCadastros.tsx"
   ]
 }


### PR DESCRIPTION
## Summary

Desbloqueia os **4 files deferidos** em Wave 15 (PR #107) fixando suas cross-file dep chains. Pattern provado: incremental strict mode tem teto natural quando arquivo A importa B com strict errors. Solução = fix B primeiro, depois promover A.

## tsconfig.strict.json: 44 → 48 files

### Promovidos (antes deferidos)

- `src/pages/FinanceiroIntercompany.tsx`
- `src/pages/FinanceiroFechamento.tsx`
- `src/pages/SalesOrderEdit.tsx`
- `src/pages/AdminReposicaoCadastros.tsx`

## Fixes em cross-file deps (8 files)

| File | Issue | Fix |
|---|---|---|
| `useAuditTrail.ts` | `fin_audit_log` não no Database type (2 sites) | `from("fin_audit_log" as never)` + eq args/result cast |
| `useIcMatches.ts` | `fin_ic_matches` mesmo pattern (3 sites: query/update/eq) | `as never` pattern + payload cast |
| `useProductCatalog.ts` | TS7022 circular ref em `supabase.functions.invoke` destructure (2 sites) | Variável explicit `: { data: unknown; error: unknown }` + cast pra shape |
| `useUnifiedOrder.ts` | 5 unused (AddressData import + 4 destructured) | Remove imports + destructures obsoletos |
| `usePriceHistory.ts` | `PriceHistoryEntry` type unused | Removed |
| `usePricingEngine.ts` | `DefaultPrice.tool_category_id: string` vs row `string \| null` | Aligned to `string \| null` |
| `AdminReposicaoCadeiaLogistica.tsx` | 2 inserts com `empresa` field não no type | Payload cast `as never` |
| `AdminReposicaoGruposProducao.tsx` | Update em `fornecedor_grupo_producao` não no type | `as never` eq + payload |
| `AdminSkuMapeamento.tsx` | `DialogTrigger` import unused | Removed |

## Fixes em files promovidos (15 errors)

**FinanceiroFechamento.tsx** (5 unused) — Input, CheckCircle2, FileText, loading/setLoading split, motivoReabertura setter
**FinanceiroIntercompany.tsx** (3 unused) — Loader2, Building2, Save
**SalesOrderEdit.tsx** (6) — isStaff (preserva useAuth() mount), loadingProducts state, 2 params `_`-prefix, `id` narrowing via early guard

## Validação

```
$ bun run typecheck:strict
0 errors (48 files)

$ bunx tsc --noEmit
0 errors (baseline)

$ bun run test
Tests       315 passed (315)

$ bun lint
371 problems (sem mudança — wave 16 é promote-only)
```

## Aggregate strict-mode progress

| Wave | strict files | Trigger |
|---|---|---|
| Pre-Wave 1 | 6 | — |
| Wave 5 | 23 | PR #91 |
| Wave 9 | 33 | PR #99 |
| Wave 15 | 44 | PR #107 |
| **Wave 16** | **48** | _Este PR_ |

**~14% do src em strict** (48 / ~350 files alvo). **0 deferidos restantes**.

## Pattern documented

`as never` em tables não-Database é compile-time only, behavior intocado. Quando Lovable Cloud regenerar Database types, esses casts podem ser removidos batch. Em particular:

- `fin_audit_log` (migration 20260518 já aplicada)
- `fin_ic_matches` (migration 20260518 já aplicada)
- `fornecedor_cadeia_logistica_historico` (campo `empresa` adicionado depois)
- `fornecedor_cadeia_logistica` (campo `empresa` adicionado depois)
- `fornecedor_grupo_producao` (tabela depois)

## Próximas waves

- **Wave 17**: continuar top offenders restantes
- **Wave 18+**: god-components refactor (FinanceiroDashboard 1242L, AdminRoutePlanner 1661L) — sprint próprio, alto risco

## Test plan

- [x] `bun run typecheck:strict` 0 errors (48 files)
- [x] `bunx tsc --noEmit` 0 errors
- [x] `bun run test` 315/315
- [x] `bun lint` ≤ 371 problems
- [x] 0 deferidos restantes da Wave 15
- [ ] CI verde (validate workflow)
- [ ] Auto-merge habilitado

🤖 Generated with [Claude Code](https://claude.com/claude-code)