### PR TITLE
chore: gitignore per-developer agent tooling artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,8 @@ dist-ssr
 *.sln
 *.sw?
 .gstack/
+
+# Agent tooling artifacts (per-developer, never commit)
+.codex/
+AGENTS.md
+


### PR DESCRIPTION
## Summary
- Adiciona `.codex/` (sessão/hooks do Codex CLI) e `AGENTS.md` (cópia local do CLAUDE.md mantida por agentes que usam convenção AGENTS.md em vez de CLAUDE.md) ao `.gitignore`
- São artefatos por-dev: aparecem como untracked em todo `git status` de quem rodou Codex localmente, sujando saída do /ship e podendo vazar pra commits acidentais via `git add .`

## Motivação
Detectado durante `/ship` no branch `claude/customer-360-contacts-section` (PR #109, já mergeado). Ambos os arquivos surgiam no `git status` mas não pertenciam ao PR.

## Test plan
- [x] `git status` agora ignora `.codex/` e `AGENTS.md` nos worktrees onde Codex foi rodado
- [x] Diff é só 5 linhas no `.gitignore`, sem efeito em runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)