### PR TITLE
chore(migrations): audit script + report pras 38 custom migrations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -282,6 +282,12 @@ Dois backends coexistem; o usuário escolhe via toggle em `/settings`:
 
 **Sempre que adicionar migration nova**: avisar no PR description "**ATENÇÃO: migration manual necessária**" e idealmente colar o SQL no body do PR pra facilitar.
 
+**Auditoria de quais custom migrations estão aplicadas no banco**:
+
+- Inventário completo em [`docs/migrations-audit.md`](docs/migrations-audit.md) (38 custom migrations, 262 objetos esperados — tables, indexes, functions, triggers, cron jobs, enum values, RLS policies)
+- Script SQL pronto pra colar no Supabase SQL Editor em [`scripts/audit-custom-migrations.sql`](scripts/audit-custom-migrations.sql) — read-only, retorna duas tabelas: (a) `supabase_migrations.schema_migrations` cross-reference, (b) existência objeto-a-objeto via `pg_catalog`/`information_schema`. Linha com `❌` = precisa apply manual
+- Regenerar quando adicionar migration nova: `bun run audit:migrations` (parser regex em `scripts/audit-custom-migrations.ts`, idempotente)
+
 ### Convenções de código
 
 - Pages em PascalCase (`AdminReposicaoCockpit.tsx`)

--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -1,0 +1,490 @@
+# Migrations Audit — Custom (não-UUID)
+
+> Gerado por `scripts/audit-custom-migrations.ts`. Re-rodar quando custom migrations forem adicionadas: `bun scripts/audit-custom-migrations.ts`.
+
+## Contexto
+
+Per CLAUDE.md §5, **Lovable Cloud NÃO aplica automaticamente** migrations com nome custom (não-UUID) em `supabase/migrations/`. UUID-format (ex: `_868822bb-e38c-4fcf-8879-c64e48bd7630.sql`) são geradas pelo builder visual do Lovable e auto-rodam. Custom (ex: `_user_departments.sql`) ficam no repo mas precisam apply manual via Supabase SQL Editor.
+
+Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
+
+## Como rodar
+
+1. Abra **Supabase Dashboard** (via Lovable Cloud → Backend → Open Supabase, ou direto via `https://supabase.com/dashboard/project/fzvklzpomgnyikkfkzai`)
+2. **SQL Editor** → **New query**
+3. Cole TODO o conteúdo de `scripts/audit-custom-migrations.sql`
+4. **Run** (read-only, não altera nada)
+5. Você verá DUAS tabelas:
+   - **Section 1** — timestamps em `supabase_migrations.schema_migrations` (source of truth do Supabase)
+   - **Section 2** — existência objeto-a-objeto via `pg_catalog`/`information_schema`
+6. Filtre linhas com `❌` → essas são as migrations que precisam apply manual
+
+## Resumo
+
+- **38** custom migrations totais
+- **262** objetos esperados (criados por estas migrations)
+- Quebra por tipo:
+  - `rls_policy`: 98
+  - `index`: 76
+  - `table`: 41
+  - `trigger`: 27
+  - `function`: 16
+  - `enum_value`: 4
+
+## Inventário por migration
+
+Lista canônica do que cada migration *deveria* criar (extraído via regex de `CREATE TABLE`/`CREATE INDEX`/etc — não é parser SQL completo). Use junto com Section 2 do SQL pra cruzar com a realidade.
+
+### `20260328200000_financial_module.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `table` | `public.fin_categorias` | — |
+| `table` | `public.fin_contas_correntes` | — |
+| `table` | `public.fin_contas_pagar` | — |
+| `table` | `public.fin_contas_receber` | — |
+| `table` | `public.fin_movimentacoes` | — |
+| `table` | `public.fin_dre_snapshots` | — |
+| `index` | `public.idx_fin_categorias_company` | `fin_categorias` |
+| `index` | `public.idx_fin_categorias_tipo` | `fin_categorias` |
+| `index` | `public.idx_fin_cc_company` | `fin_contas_correntes` |
+| `index` | `public.idx_fin_cp_company` | `fin_contas_pagar` |
+| `index` | `public.idx_fin_cp_status` | `fin_contas_pagar` |
+| `index` | `public.idx_fin_cp_vencimento` | `fin_contas_pagar` |
+| `index` | `public.idx_fin_cp_fornecedor` | `fin_contas_pagar` |
+| `index` | `public.idx_fin_cp_categoria` | `fin_contas_pagar` |
+| `index` | `public.idx_fin_cr_company` | `fin_contas_receber` |
+| `index` | `public.idx_fin_cr_status` | `fin_contas_receber` |
+| `index` | `public.idx_fin_cr_vencimento` | `fin_contas_receber` |
+| `index` | `public.idx_fin_cr_cliente` | `fin_contas_receber` |
+| `index` | `public.idx_fin_cr_categoria` | `fin_contas_receber` |
+| `index` | `public.idx_fin_mov_company` | `fin_movimentacoes` |
+| `index` | `public.idx_fin_mov_data` | `fin_movimentacoes` |
+| `index` | `public.idx_fin_mov_cc` | `fin_movimentacoes` |
+| `index` | `public.idx_fin_dre_company_periodo` | `fin_dre_snapshots` |
+| `rls_policy` | `public.fin_categorias_select` | `fin_categorias` |
+| `rls_policy` | `public.fin_cc_select` | `fin_contas_correntes` |
+| `rls_policy` | `public.fin_cp_select` | `fin_contas_pagar` |
+| `rls_policy` | `public.fin_cr_select` | `fin_contas_receber` |
+| `rls_policy` | `public.fin_mov_select` | `fin_movimentacoes` |
+| `rls_policy` | `public.fin_dre_select` | `fin_dre_snapshots` |
+| `rls_policy` | `public.fin_categorias_service` | `fin_categorias` |
+| `rls_policy` | `public.fin_cc_service` | `fin_contas_correntes` |
+| `rls_policy` | `public.fin_cp_service` | `fin_contas_pagar` |
+| `rls_policy` | `public.fin_cr_service` | `fin_contas_receber` |
+| `rls_policy` | `public.fin_mov_service` | `fin_movimentacoes` |
+| `rls_policy` | `public.fin_dre_service` | `fin_dre_snapshots` |
+
+### `20260328200100_fin_categoria_dre_mapping.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `table` | `public.fin_categoria_dre_mapping` | — |
+| `index` | `public.idx_fin_cat_dre_company` | `fin_categoria_dre_mapping` |
+| `rls_policy` | `public.fin_cat_dre_select` | `fin_categoria_dre_mapping` |
+| `rls_policy` | `public.fin_cat_dre_all_service` | `fin_categoria_dre_mapping` |
+| `rls_policy` | `public.fin_cat_dre_admin_modify` | `fin_categoria_dre_mapping` |
+
+### `20260328200300_fix_fluxo_caixa_dre_regime.sql`
+
+> _Nenhum objeto extraído via regex._ Migration provavelmente é `ALTER TABLE` / `UPDATE` / `INSERT` / RLS-only. Validar manualmente.
+
+### `20260328200400_fix_cron_sync.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `table` | `public.fin_sync_log` | — |
+| `index` | `public.idx_fin_sync_log_started` | `fin_sync_log` |
+
+### `20260328200500_financeiro_v2.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `table` | `public.fin_fechamentos` | — |
+| `table` | `public.fin_fechamento_log` | — |
+| `table` | `public.fin_conciliacao` | — |
+| `table` | `public.fin_eliminacoes_intercompany` | — |
+| `table` | `public.fin_eliminacoes_log` | — |
+| `table` | `public.fin_orcamento` | — |
+| `table` | `public.fin_forecast` | — |
+| `table` | `public.fin_permissoes` | — |
+| `table` | `public.fin_kpi_tributario` | — |
+| `index` | `public.idx_fin_fech_company_periodo` | `fin_fechamentos` |
+| `index` | `public.idx_fin_fech_status` | `fin_fechamentos` |
+| `index` | `public.idx_fin_fech_log_fech` | `fin_fechamento_log` |
+| `index` | `public.idx_fin_conc_company` | `fin_conciliacao` |
+| `index` | `public.idx_fin_conc_status` | `fin_conciliacao` |
+| `index` | `public.idx_fin_conc_mov` | `fin_conciliacao` |
+| `index` | `public.idx_fin_elim_log_periodo` | `fin_eliminacoes_log` |
+| `index` | `public.idx_fin_orc_periodo` | `fin_orcamento` |
+| `index` | `public.idx_fin_analise_cr_unique` | `fin_analise_cr_dimensoes` |
+| `index` | `public.idx_fin_analise_cp_unique` | `fin_analise_cp_dimensoes` |
+| `index` | `public.idx_fin_kpi_trib_periodo` | `fin_kpi_tributario` |
+| `function` | `public.fin_refresh_analise_dimensoes` | — |
+| `function` | `public.fin_user_can_access` | — |
+| `rls_policy` | `public.fin_fechamentos_service` | `fin_fechamentos` |
+| `rls_policy` | `public.fin_fechamento_log_service` | `fin_fechamento_log` |
+| `rls_policy` | `public.fin_conciliacao_service` | `fin_conciliacao` |
+| `rls_policy` | `public.fin_elim_service` | `fin_eliminacoes_intercompany` |
+| `rls_policy` | `public.fin_elim_log_service` | `fin_eliminacoes_log` |
+| `rls_policy` | `public.fin_orc_service` | `fin_orcamento` |
+| `rls_policy` | `public.fin_forecast_service` | `fin_forecast` |
+| `rls_policy` | `public.fin_perm_service` | `fin_permissoes` |
+| `rls_policy` | `public.fin_kpi_trib_service` | `fin_kpi_tributario` |
+| `rls_policy` | `public.fin_fechamentos_user` | `fin_fechamentos` |
+| `rls_policy` | `public.fin_fechamento_log_user` | `fin_fechamento_log` |
+| `rls_policy` | `public.fin_conciliacao_user` | `fin_conciliacao` |
+| `rls_policy` | `public.fin_elim_user` | `fin_eliminacoes_intercompany` |
+| `rls_policy` | `public.fin_elim_log_user` | `fin_eliminacoes_log` |
+| `rls_policy` | `public.fin_orc_user` | `fin_orcamento` |
+| `rls_policy` | `public.fin_forecast_user` | `fin_forecast` |
+| `rls_policy` | `public.fin_perm_user` | `fin_permissoes` |
+| `rls_policy` | `public.fin_kpi_trib_user` | `fin_kpi_tributario` |
+| `rls_policy` | `public.fin_orc_write` | `fin_orcamento` |
+| `rls_policy` | `public.fin_conc_write` | `fin_conciliacao` |
+| `rls_policy` | `public.fin_elim_write` | `fin_eliminacoes_intercompany` |
+| `rls_policy` | `public.fin_fech_write` | `fin_fechamentos` |
+
+### `20260328200600_financeiro_v3_backend.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `table` | `public.fin_sync_checkpoint` | — |
+| `table` | `public.fin_confiabilidade` | — |
+| `index` | `public.idx_fin_conf_periodo` | `fin_confiabilidade` |
+| `function` | `public.fin_calcular_confiabilidade` | — |
+| `function` | `public.fin_projecao_13_semanas` | — |
+| `function` | `public.fin_consolidado_intercompany` | — |
+| `rls_policy` | `public.fin_sync_ckpt_service` | `fin_sync_checkpoint` |
+| `rls_policy` | `public.fin_sync_ckpt_user` | `fin_sync_checkpoint` |
+| `rls_policy` | `public.fin_conf_service` | `fin_confiabilidade` |
+| `rls_policy` | `public.fin_conf_user` | `fin_confiabilidade` |
+
+### `20260516120000_vendor_sip_credentials.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `table` | `public.vendor_sip_credentials` | — |
+| `index` | `public.idx_vendor_sip_credentials_user_id` | `vendor_sip_credentials` |
+| `function` | `public.update_vendor_sip_credentials_updated_at` | — |
+| `trigger` | `public.vendor_sip_credentials_updated_at_trigger` | `vendor_sip_credentials` |
+
+### `20260517100000_enable_realtime_dashboard_v3.sql`
+
+> _Nenhum objeto extraído via regex._ Migration provavelmente é `ALTER TABLE` / `UPDATE` / `INSERT` / RLS-only. Validar manualmente.
+
+### `20260517120000_user_departments.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `table` | `public.user_departments` | — |
+| `index` | `public.idx_user_departments_user` | `user_departments` |
+| `index` | `public.idx_user_departments_dept` | `user_departments` |
+| `rls_policy` | `public.user_departments_read_own` | `user_departments` |
+| `rls_policy` | `public.user_departments_master_all` | `user_departments` |
+| `rls_policy` | `public.user_departments_service_all` | `user_departments` |
+
+### `20260517140000_dashboard_visits.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `table` | `public.dashboard_visits` | — |
+| `index` | `public.idx_dashboard_visits_user_recent` | `dashboard_visits` |
+| `rls_policy` | `public.dashboard_visits_user_insert` | `dashboard_visits` |
+| `rls_policy` | `public.dashboard_visits_user_read` | `dashboard_visits` |
+| `rls_policy` | `public.dashboard_visits_master_read` | `dashboard_visits` |
+| `rls_policy` | `public.dashboard_visits_service_all` | `dashboard_visits` |
+
+### `20260517160000_farmer_calls_persist_session.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `index` | `public.idx_farmer_calls_has_transcript` | `farmer_calls` |
+
+### `20260517170000_kb_foundation.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `table` | `public.kb_documents` | — |
+| `table` | `public.kb_chunks` | — |
+| `index` | `public.idx_kb_chunks_embedding` | `kb_chunks` |
+| `index` | `public.idx_kb_documents_status_type` | `kb_documents` |
+| `index` | `public.idx_kb_chunks_document` | `kb_chunks` |
+| `function` | `public.kb_documents_set_updated_at` | — |
+| `trigger` | `public.trg_kb_documents_updated_at` | `kb_documents` |
+| `rls_policy` | `public.kb_documents_select_staff` | `kb_documents` |
+| `rls_policy` | `public.kb_documents_insert_staff` | `kb_documents` |
+| `rls_policy` | `public.kb_documents_update_master` | `kb_documents` |
+| `rls_policy` | `public.kb_documents_delete_master` | `kb_documents` |
+| `rls_policy` | `public.kb_chunks_select_staff` | `kb_chunks` |
+| `rls_policy` | `storage.kb_bucket_select_staff` | `objects` |
+| `rls_policy` | `storage.kb_bucket_insert_staff` | `objects` |
+| `rls_policy` | `storage.kb_bucket_delete_master` | `objects` |
+
+### `20260517180000_kb_specs_and_competitors.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `table` | `public.kb_product_specs` | — |
+| `table` | `public.kb_competitors` | — |
+| `table` | `public.kb_competitor_products` | — |
+| `index` | `public.idx_kb_product_specs_product_code` | `kb_product_specs` |
+| `index` | `public.idx_kb_product_specs_supplier_line` | `kb_product_specs` |
+| `index` | `public.idx_kb_competitor_products_competitor` | `kb_competitor_products` |
+| `index` | `public.idx_kb_competitor_products_equivalent` | `kb_competitor_products` |
+| `function` | `public.kb_documents_set_updated_at` | — |
+| `trigger` | `public.trg_kb_product_specs_updated_at` | `kb_product_specs` |
+| `trigger` | `public.trg_kb_competitors_updated_at` | `kb_competitors` |
+| `trigger` | `public.trg_kb_competitor_products_updated_at` | `kb_competitor_products` |
+| `rls_policy` | `public.kb_product_specs_select_staff` | `kb_product_specs` |
+| `rls_policy` | `public.kb_product_specs_insert_staff` | `kb_product_specs` |
+| `rls_policy` | `public.kb_product_specs_update_master` | `kb_product_specs` |
+| `rls_policy` | `public.kb_product_specs_delete_master` | `kb_product_specs` |
+| `rls_policy` | `public.kb_competitors_select_staff` | `kb_competitors` |
+| `rls_policy` | `public.kb_competitors_insert_staff` | `kb_competitors` |
+| `rls_policy` | `public.kb_competitors_update_staff` | `kb_competitors` |
+| `rls_policy` | `public.kb_competitors_delete_master` | `kb_competitors` |
+| `rls_policy` | `public.kb_competitor_products_select_staff` | `kb_competitor_products` |
+| `rls_policy` | `public.kb_competitor_products_insert_staff` | `kb_competitor_products` |
+| `rls_policy` | `public.kb_competitor_products_update_staff` | `kb_competitor_products` |
+| `rls_policy` | `public.kb_competitor_products_delete_master` | `kb_competitor_products` |
+
+### `20260517190000_customer_processes.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `table` | `public.customer_processes` | — |
+| `index` | `public.idx_customer_processes_one_current` | `customer_processes` |
+| `index` | `public.idx_customer_processes_customer` | `customer_processes` |
+| `index` | `public.idx_customer_processes_segmento` | `customer_processes` |
+| `trigger` | `public.trg_customer_processes_updated_at` | `customer_processes` |
+| `rls_policy` | `public.customer_processes_select_staff` | `customer_processes` |
+| `rls_policy` | `public.customer_processes_insert_staff` | `customer_processes` |
+| `rls_policy` | `public.customer_processes_update_staff` | `customer_processes` |
+| `rls_policy` | `public.customer_processes_delete_master` | `customer_processes` |
+
+### `20260517200000_standard_processes.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `table` | `public.standard_processes` | — |
+| `index` | `public.idx_standard_processes_status_segmento` | `standard_processes` |
+| `index` | `public.idx_standard_processes_published_segmento` | `standard_processes` |
+| `index` | `public.idx_standard_processes_slug` | `standard_processes` |
+| `trigger` | `public.trg_standard_processes_updated_at` | `standard_processes` |
+| `rls_policy` | `public.standard_processes_select_visible` | `standard_processes` |
+| `rls_policy` | `public.standard_processes_insert_staff` | `standard_processes` |
+| `rls_policy` | `public.standard_processes_update_owner_or_master` | `standard_processes` |
+| `rls_policy` | `public.standard_processes_delete_master` | `standard_processes` |
+
+### `20260517210000_rag_chunks.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `table` | `public.rag_chunks` | — |
+| `index` | `public.idx_rag_chunks_embedding` | `rag_chunks` |
+| `index` | `public.idx_rag_chunks_source` | `rag_chunks` |
+| `index` | `public.idx_rag_chunks_metadata_segmento` | `rag_chunks` |
+| `rls_policy` | `public.rag_chunks_select_staff` | `rag_chunks` |
+
+### `20260517220000_customer_contacts.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `table` | `public.customer_contacts` | — |
+| `index` | `public.idx_customer_contacts_customer` | `customer_contacts` |
+| `index` | `public.idx_customer_contacts_phone` | `customer_contacts` |
+| `index` | `public.idx_customer_contacts_one_primary` | `customer_contacts` |
+| `index` | `public.idx_customer_contacts_birthday` | `customer_contacts` |
+| `trigger` | `public.trg_customer_contacts_updated_at` | `customer_contacts` |
+| `rls_policy` | `public.customer_contacts_select_staff` | `customer_contacts` |
+| `rls_policy` | `public.customer_contacts_insert_staff` | `customer_contacts` |
+| `rls_policy` | `public.customer_contacts_update_staff` | `customer_contacts` |
+| `rls_policy` | `public.customer_contacts_delete_master` | `customer_contacts` |
+
+### `20260518000000_fin_audit_log.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `table` | `public.fin_audit_log` | — |
+| `index` | `public.fin_audit_log_table_row_idx` | `fin_audit_log` |
+| `index` | `public.fin_audit_log_company_period_idx` | `fin_audit_log` |
+| `index` | `public.fin_audit_log_user_idx` | `fin_audit_log` |
+| `rls_policy` | `public.fin_audit_log_select_staff` | `fin_audit_log` |
+
+### `20260518000100_fin_audit_trigger.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `public.fin_audit_trigger` | — |
+
+### `20260518000200_fin_audit_attach.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `trigger` | `public.trg_audit` | `fin_contas_receber` |
+| `trigger` | `public.trg_audit` | `fin_contas_pagar` |
+| `trigger` | `public.trg_audit` | `fin_categoria_dre_mapping` |
+| `trigger` | `public.trg_audit` | `fin_orcamento` |
+| `trigger` | `public.trg_audit` | `fin_fechamentos` |
+| `trigger` | `public.trg_audit` | `fin_eliminacoes_intercompany` |
+
+### `20260518000300_set_config_rpc.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `public.set_config` | — |
+
+### `20260518001000_fin_period_overrides.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `table` | `public.fin_period_overrides` | — |
+| `index` | `public.fin_period_overrides_active_idx` | `fin_period_overrides` |
+| `rls_policy` | `public.fin_period_overrides_select_staff` | `fin_period_overrides` |
+| `rls_policy` | `public.fin_period_overrides_insert_master` | `fin_period_overrides` |
+| `rls_policy` | `public.fin_period_overrides_update_self` | `fin_period_overrides` |
+
+### `20260518001100_fin_period_lock_trigger.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `public.fin_period_lock_trigger` | — |
+
+### `20260518001200_fin_period_lock_attach.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `trigger` | `public.trg_period_lock` | `fin_contas_receber` |
+| `trigger` | `public.trg_period_lock` | `fin_contas_pagar` |
+| `trigger` | `public.trg_period_lock` | `fin_movimentacoes` |
+| `trigger` | `public.trg_period_lock` | `fin_categoria_dre_mapping` |
+| `trigger` | `public.trg_period_lock` | `fin_orcamento` |
+
+### `20260518002000_dre_unique_with_regime.sql`
+
+> _Nenhum objeto extraído via regex._ Migration provavelmente é `ALTER TABLE` / `UPDATE` / `INSERT` / RLS-only. Validar manualmente.
+
+### `20260518002100_fechamento_dual_snapshots.sql`
+
+> _Nenhum objeto extraído via regex._ Migration provavelmente é `ALTER TABLE` / `UPDATE` / `INSERT` / RLS-only. Validar manualmente.
+
+### `20260518003000_fin_mapping_gate_trigger.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `public.fin_check_mapping_complete_trigger` | — |
+| `trigger` | `public.trg_mapping_gate` | `fin_fechamentos` |
+
+### `20260518003100_rpc_categorias_sem_mapping.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `public.fin_categorias_sem_mapping` | — |
+
+### `20260518004000_fin_ic_matches.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `table` | `public.fin_ic_matches` | — |
+| `index` | `public.fin_ic_matches_status_idx` | `fin_ic_matches` |
+| `index` | `public.fin_ic_matches_cr_idx` | `fin_ic_matches` |
+| `index` | `public.fin_ic_matches_cp_idx` | `fin_ic_matches` |
+| `index` | `public.fin_ic_matches_cr_unique` | `fin_ic_matches` |
+| `index` | `public.fin_ic_matches_cp_unique` | `fin_ic_matches` |
+| `rls_policy` | `public.fin_ic_matches_select_staff` | `fin_ic_matches` |
+| `rls_policy` | `public.fin_ic_matches_update_staff` | `fin_ic_matches` |
+
+### `20260518004100_company_cnpjs.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `table` | `public.company_cnpjs` | — |
+| `index` | `public.company_cnpjs_normalized_idx` | `company_cnpjs` |
+| `rls_policy` | `public.company_cnpjs_select_authenticated` | `company_cnpjs` |
+| `rls_policy` | `public.company_cnpjs_master_write` | `company_cnpjs` |
+
+### `20260518004200_fin_ic_cron.sql`
+
+> _Nenhum objeto extraído via regex._ Migration provavelmente é `ALTER TABLE` / `UPDATE` / `INSERT` / RLS-only. Validar manualmente.
+
+### `20260518004300_fin_consolidado_v2.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `public.fin_consolidado_intercompany` | — |
+
+### `20260518100000_commercial_role_add_values.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `enum_value` | `public.farmer` | `commercial_role` |
+| `enum_value` | `public.hunter` | `commercial_role` |
+| `enum_value` | `public.closer` | `commercial_role` |
+| `enum_value` | `public.master` | `commercial_role` |
+
+### `20260518110000_scoring_v2_signal_modifiers.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `table` | `public.score_recalc_queue` | — |
+| `index` | `public.idx_score_recalc_queue_pending` | `score_recalc_queue` |
+| `index` | `public.uniq_score_recalc_queue_pending` | `score_recalc_queue` |
+| `function` | `public.enqueue_score_recalc_from_call` | — |
+| `trigger` | `public.trg_farmer_calls_enqueue_recalc` | `farmer_calls` |
+
+### `20260519000000_fin_a1_eventos.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `table` | `public.fin_eventos_recorrentes` | — |
+| `table` | `public.fin_eventos_eventuais` | — |
+| `index` | `public.fin_eventos_rec_company_ativo_idx` | `fin_eventos_recorrentes` |
+| `index` | `public.fin_eventos_rec_categoria_idx` | `fin_eventos_recorrentes` |
+| `index` | `public.fin_eventos_ev_company_data_idx` | `fin_eventos_eventuais` |
+| `index` | `public.fin_eventos_ev_status_idx` | `fin_eventos_eventuais` |
+| `rls_policy` | `public.fin_eventos_rec_select_staff` | `fin_eventos_recorrentes` |
+| `rls_policy` | `public.fin_eventos_rec_write_staff` | `fin_eventos_recorrentes` |
+| `rls_policy` | `public.fin_eventos_ev_select_staff` | `fin_eventos_eventuais` |
+| `rls_policy` | `public.fin_eventos_ev_write_staff` | `fin_eventos_eventuais` |
+
+### `20260519000100_fin_a1_snapshots_alertas_config.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `table` | `public.fin_projecao_snapshots` | — |
+| `table` | `public.fin_alertas` | — |
+| `table` | `public.fin_config_cashflow` | — |
+| `index` | `public.fin_proj_company_snap_idx` | `fin_projecao_snapshots` |
+| `index` | `public.fin_proj_cenario_idx` | `fin_projecao_snapshots` |
+| `index` | `public.fin_alertas_company_criado_idx` | `fin_alertas` |
+| `index` | `public.fin_alertas_unique_ativo` | `fin_alertas` |
+| `rls_policy` | `public.fin_proj_select_staff` | `fin_projecao_snapshots` |
+| `rls_policy` | `public.fin_alertas_select_staff` | `fin_alertas` |
+| `rls_policy` | `public.fin_alertas_update_staff` | `fin_alertas` |
+| `rls_policy` | `public.fin_config_select_staff` | `fin_config_cashflow` |
+| `rls_policy` | `public.fin_config_write_master` | `fin_config_cashflow` |
+
+### `20260519000200_fin_a1_audit_lock_attach.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `public.fin_period_lock_trigger` | — |
+| `trigger` | `public.trg_audit` | `fin_eventos_recorrentes` |
+| `trigger` | `public.trg_audit` | `fin_eventos_eventuais` |
+| `trigger` | `public.trg_audit` | `fin_alertas` |
+| `trigger` | `public.trg_audit` | `fin_config_cashflow` |
+| `trigger` | `public.trg_period_lock` | `fin_eventos_recorrentes` |
+| `trigger` | `public.trg_period_lock` | `fin_eventos_eventuais` |
+
+### `20260519010000_fin_a1_cron.sql`
+
+> _Nenhum objeto extraído via regex._ Migration provavelmente é `ALTER TABLE` / `UPDATE` / `INSERT` / RLS-only. Validar manualmente.
+
+## Próximos passos quando algo der `❌`
+
+1. Abra a migration correspondente em `supabase/migrations/<arquivo>.sql`
+2. Copie o SQL inteiro
+3. Supabase SQL Editor → cole → Run
+4. Re-rode `scripts/audit-custom-migrations.sql` pra confirmar que virou `✅`
+5. (Opcional) `INSERT INTO supabase_migrations.schema_migrations (version, statements) VALUES ('<timestamp>', ARRAY['<sql>']);` pra registrar como aplicada (evita re-apply futura)

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "vitest run",
-    "typecheck:strict": "tsc --noEmit -p tsconfig.strict.json"
+    "typecheck:strict": "tsc --noEmit -p tsconfig.strict.json",
+    "audit:migrations": "bun scripts/audit-custom-migrations.ts"
   },
   "dependencies": {
     "@elevenlabs/react": "^0.14.0",

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -1,0 +1,387 @@
+-- ========================================================================
+-- AUDIT — Custom Migrations
+-- ========================================================================
+--
+-- Gerado por: scripts/audit-custom-migrations.ts
+-- Total de custom migrations: 38
+--
+-- Como usar:
+--   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
+--   2. Cole TODO este arquivo numa query
+--   3. Run
+--   4. Olhe as duas tabelas de resultado: (A) timestamps aplicados, (B) objetos existentes
+--
+-- Read-only — não altera nada no banco.
+-- ========================================================================
+
+-- =====================================================
+-- SECTION 1: Timestamps aplicados (canonical check)
+-- =====================================================
+-- Source of truth do Supabase. Se a row existe aqui, a migration rodou.
+
+WITH expected (version, slug, filename) AS (VALUES
+  ('20260328200000', 'financial_module', '20260328200000_financial_module.sql'),
+  ('20260328200100', 'fin_categoria_dre_mapping', '20260328200100_fin_categoria_dre_mapping.sql'),
+  ('20260328200300', 'fix_fluxo_caixa_dre_regime', '20260328200300_fix_fluxo_caixa_dre_regime.sql'),
+  ('20260328200400', 'fix_cron_sync', '20260328200400_fix_cron_sync.sql'),
+  ('20260328200500', 'financeiro_v2', '20260328200500_financeiro_v2.sql'),
+  ('20260328200600', 'financeiro_v3_backend', '20260328200600_financeiro_v3_backend.sql'),
+  ('20260516120000', 'vendor_sip_credentials', '20260516120000_vendor_sip_credentials.sql'),
+  ('20260517100000', 'enable_realtime_dashboard_v3', '20260517100000_enable_realtime_dashboard_v3.sql'),
+  ('20260517120000', 'user_departments', '20260517120000_user_departments.sql'),
+  ('20260517140000', 'dashboard_visits', '20260517140000_dashboard_visits.sql'),
+  ('20260517160000', 'farmer_calls_persist_session', '20260517160000_farmer_calls_persist_session.sql'),
+  ('20260517170000', 'kb_foundation', '20260517170000_kb_foundation.sql'),
+  ('20260517180000', 'kb_specs_and_competitors', '20260517180000_kb_specs_and_competitors.sql'),
+  ('20260517190000', 'customer_processes', '20260517190000_customer_processes.sql'),
+  ('20260517200000', 'standard_processes', '20260517200000_standard_processes.sql'),
+  ('20260517210000', 'rag_chunks', '20260517210000_rag_chunks.sql'),
+  ('20260517220000', 'customer_contacts', '20260517220000_customer_contacts.sql'),
+  ('20260518000000', 'fin_audit_log', '20260518000000_fin_audit_log.sql'),
+  ('20260518000100', 'fin_audit_trigger', '20260518000100_fin_audit_trigger.sql'),
+  ('20260518000200', 'fin_audit_attach', '20260518000200_fin_audit_attach.sql'),
+  ('20260518000300', 'set_config_rpc', '20260518000300_set_config_rpc.sql'),
+  ('20260518001000', 'fin_period_overrides', '20260518001000_fin_period_overrides.sql'),
+  ('20260518001100', 'fin_period_lock_trigger', '20260518001100_fin_period_lock_trigger.sql'),
+  ('20260518001200', 'fin_period_lock_attach', '20260518001200_fin_period_lock_attach.sql'),
+  ('20260518002000', 'dre_unique_with_regime', '20260518002000_dre_unique_with_regime.sql'),
+  ('20260518002100', 'fechamento_dual_snapshots', '20260518002100_fechamento_dual_snapshots.sql'),
+  ('20260518003000', 'fin_mapping_gate_trigger', '20260518003000_fin_mapping_gate_trigger.sql'),
+  ('20260518003100', 'rpc_categorias_sem_mapping', '20260518003100_rpc_categorias_sem_mapping.sql'),
+  ('20260518004000', 'fin_ic_matches', '20260518004000_fin_ic_matches.sql'),
+  ('20260518004100', 'company_cnpjs', '20260518004100_company_cnpjs.sql'),
+  ('20260518004200', 'fin_ic_cron', '20260518004200_fin_ic_cron.sql'),
+  ('20260518004300', 'fin_consolidado_v2', '20260518004300_fin_consolidado_v2.sql'),
+  ('20260518100000', 'commercial_role_add_values', '20260518100000_commercial_role_add_values.sql'),
+  ('20260518110000', 'scoring_v2_signal_modifiers', '20260518110000_scoring_v2_signal_modifiers.sql'),
+  ('20260519000000', 'fin_a1_eventos', '20260519000000_fin_a1_eventos.sql'),
+  ('20260519000100', 'fin_a1_snapshots_alertas_config', '20260519000100_fin_a1_snapshots_alertas_config.sql'),
+  ('20260519000200', 'fin_a1_audit_lock_attach', '20260519000200_fin_a1_audit_lock_attach.sql'),
+  ('20260519010000', 'fin_a1_cron', '20260519010000_fin_a1_cron.sql')
+)
+SELECT
+  e.version,
+  e.slug,
+  CASE WHEN sm.version IS NOT NULL THEN '✅ applied' ELSE '❌ MISSING — apply manually' END AS status,
+  e.filename
+FROM expected e
+LEFT JOIN supabase_migrations.schema_migrations sm ON sm.version = e.version
+ORDER BY e.version;
+
+
+-- =====================================================
+-- SECTION 2: Object existence (cross-check)
+-- =====================================================
+-- Caso schema_migrations diga ✅ mas o objeto não exista (rollback manual,
+-- partial apply), esta query captura. Para cada objeto esperado, checa pg_catalog.
+
+WITH expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VALUES
+  ('financial_module', 'table', 'public', 'fin_categorias', ''),
+  ('financial_module', 'table', 'public', 'fin_contas_correntes', ''),
+  ('financial_module', 'table', 'public', 'fin_contas_pagar', ''),
+  ('financial_module', 'table', 'public', 'fin_contas_receber', ''),
+  ('financial_module', 'table', 'public', 'fin_movimentacoes', ''),
+  ('financial_module', 'table', 'public', 'fin_dre_snapshots', ''),
+  ('financial_module', 'index', 'public', 'idx_fin_categorias_company', 'fin_categorias'),
+  ('financial_module', 'index', 'public', 'idx_fin_categorias_tipo', 'fin_categorias'),
+  ('financial_module', 'index', 'public', 'idx_fin_cc_company', 'fin_contas_correntes'),
+  ('financial_module', 'index', 'public', 'idx_fin_cp_company', 'fin_contas_pagar'),
+  ('financial_module', 'index', 'public', 'idx_fin_cp_status', 'fin_contas_pagar'),
+  ('financial_module', 'index', 'public', 'idx_fin_cp_vencimento', 'fin_contas_pagar'),
+  ('financial_module', 'index', 'public', 'idx_fin_cp_fornecedor', 'fin_contas_pagar'),
+  ('financial_module', 'index', 'public', 'idx_fin_cp_categoria', 'fin_contas_pagar'),
+  ('financial_module', 'index', 'public', 'idx_fin_cr_company', 'fin_contas_receber'),
+  ('financial_module', 'index', 'public', 'idx_fin_cr_status', 'fin_contas_receber'),
+  ('financial_module', 'index', 'public', 'idx_fin_cr_vencimento', 'fin_contas_receber'),
+  ('financial_module', 'index', 'public', 'idx_fin_cr_cliente', 'fin_contas_receber'),
+  ('financial_module', 'index', 'public', 'idx_fin_cr_categoria', 'fin_contas_receber'),
+  ('financial_module', 'index', 'public', 'idx_fin_mov_company', 'fin_movimentacoes'),
+  ('financial_module', 'index', 'public', 'idx_fin_mov_data', 'fin_movimentacoes'),
+  ('financial_module', 'index', 'public', 'idx_fin_mov_cc', 'fin_movimentacoes'),
+  ('financial_module', 'index', 'public', 'idx_fin_dre_company_periodo', 'fin_dre_snapshots'),
+  ('financial_module', 'rls_policy', 'public', 'fin_categorias_select', 'fin_categorias'),
+  ('financial_module', 'rls_policy', 'public', 'fin_cc_select', 'fin_contas_correntes'),
+  ('financial_module', 'rls_policy', 'public', 'fin_cp_select', 'fin_contas_pagar'),
+  ('financial_module', 'rls_policy', 'public', 'fin_cr_select', 'fin_contas_receber'),
+  ('financial_module', 'rls_policy', 'public', 'fin_mov_select', 'fin_movimentacoes'),
+  ('financial_module', 'rls_policy', 'public', 'fin_dre_select', 'fin_dre_snapshots'),
+  ('financial_module', 'rls_policy', 'public', 'fin_categorias_service', 'fin_categorias'),
+  ('financial_module', 'rls_policy', 'public', 'fin_cc_service', 'fin_contas_correntes'),
+  ('financial_module', 'rls_policy', 'public', 'fin_cp_service', 'fin_contas_pagar'),
+  ('financial_module', 'rls_policy', 'public', 'fin_cr_service', 'fin_contas_receber'),
+  ('financial_module', 'rls_policy', 'public', 'fin_mov_service', 'fin_movimentacoes'),
+  ('financial_module', 'rls_policy', 'public', 'fin_dre_service', 'fin_dre_snapshots'),
+  ('fin_categoria_dre_mapping', 'table', 'public', 'fin_categoria_dre_mapping', ''),
+  ('fin_categoria_dre_mapping', 'index', 'public', 'idx_fin_cat_dre_company', 'fin_categoria_dre_mapping'),
+  ('fin_categoria_dre_mapping', 'rls_policy', 'public', 'fin_cat_dre_select', 'fin_categoria_dre_mapping'),
+  ('fin_categoria_dre_mapping', 'rls_policy', 'public', 'fin_cat_dre_all_service', 'fin_categoria_dre_mapping'),
+  ('fin_categoria_dre_mapping', 'rls_policy', 'public', 'fin_cat_dre_admin_modify', 'fin_categoria_dre_mapping'),
+  ('fix_cron_sync', 'table', 'public', 'fin_sync_log', ''),
+  ('fix_cron_sync', 'index', 'public', 'idx_fin_sync_log_started', 'fin_sync_log'),
+  ('financeiro_v2', 'table', 'public', 'fin_fechamentos', ''),
+  ('financeiro_v2', 'table', 'public', 'fin_fechamento_log', ''),
+  ('financeiro_v2', 'table', 'public', 'fin_conciliacao', ''),
+  ('financeiro_v2', 'table', 'public', 'fin_eliminacoes_intercompany', ''),
+  ('financeiro_v2', 'table', 'public', 'fin_eliminacoes_log', ''),
+  ('financeiro_v2', 'table', 'public', 'fin_orcamento', ''),
+  ('financeiro_v2', 'table', 'public', 'fin_forecast', ''),
+  ('financeiro_v2', 'table', 'public', 'fin_permissoes', ''),
+  ('financeiro_v2', 'table', 'public', 'fin_kpi_tributario', ''),
+  ('financeiro_v2', 'index', 'public', 'idx_fin_fech_company_periodo', 'fin_fechamentos'),
+  ('financeiro_v2', 'index', 'public', 'idx_fin_fech_status', 'fin_fechamentos'),
+  ('financeiro_v2', 'index', 'public', 'idx_fin_fech_log_fech', 'fin_fechamento_log'),
+  ('financeiro_v2', 'index', 'public', 'idx_fin_conc_company', 'fin_conciliacao'),
+  ('financeiro_v2', 'index', 'public', 'idx_fin_conc_status', 'fin_conciliacao'),
+  ('financeiro_v2', 'index', 'public', 'idx_fin_conc_mov', 'fin_conciliacao'),
+  ('financeiro_v2', 'index', 'public', 'idx_fin_elim_log_periodo', 'fin_eliminacoes_log'),
+  ('financeiro_v2', 'index', 'public', 'idx_fin_orc_periodo', 'fin_orcamento'),
+  ('financeiro_v2', 'index', 'public', 'idx_fin_analise_cr_unique', 'fin_analise_cr_dimensoes'),
+  ('financeiro_v2', 'index', 'public', 'idx_fin_analise_cp_unique', 'fin_analise_cp_dimensoes'),
+  ('financeiro_v2', 'index', 'public', 'idx_fin_kpi_trib_periodo', 'fin_kpi_tributario'),
+  ('financeiro_v2', 'function', 'public', 'fin_refresh_analise_dimensoes', ''),
+  ('financeiro_v2', 'function', 'public', 'fin_user_can_access', ''),
+  ('financeiro_v2', 'rls_policy', 'public', 'fin_fechamentos_service', 'fin_fechamentos'),
+  ('financeiro_v2', 'rls_policy', 'public', 'fin_fechamento_log_service', 'fin_fechamento_log'),
+  ('financeiro_v2', 'rls_policy', 'public', 'fin_conciliacao_service', 'fin_conciliacao'),
+  ('financeiro_v2', 'rls_policy', 'public', 'fin_elim_service', 'fin_eliminacoes_intercompany'),
+  ('financeiro_v2', 'rls_policy', 'public', 'fin_elim_log_service', 'fin_eliminacoes_log'),
+  ('financeiro_v2', 'rls_policy', 'public', 'fin_orc_service', 'fin_orcamento'),
+  ('financeiro_v2', 'rls_policy', 'public', 'fin_forecast_service', 'fin_forecast'),
+  ('financeiro_v2', 'rls_policy', 'public', 'fin_perm_service', 'fin_permissoes'),
+  ('financeiro_v2', 'rls_policy', 'public', 'fin_kpi_trib_service', 'fin_kpi_tributario'),
+  ('financeiro_v2', 'rls_policy', 'public', 'fin_fechamentos_user', 'fin_fechamentos'),
+  ('financeiro_v2', 'rls_policy', 'public', 'fin_fechamento_log_user', 'fin_fechamento_log'),
+  ('financeiro_v2', 'rls_policy', 'public', 'fin_conciliacao_user', 'fin_conciliacao'),
+  ('financeiro_v2', 'rls_policy', 'public', 'fin_elim_user', 'fin_eliminacoes_intercompany'),
+  ('financeiro_v2', 'rls_policy', 'public', 'fin_elim_log_user', 'fin_eliminacoes_log'),
+  ('financeiro_v2', 'rls_policy', 'public', 'fin_orc_user', 'fin_orcamento'),
+  ('financeiro_v2', 'rls_policy', 'public', 'fin_forecast_user', 'fin_forecast'),
+  ('financeiro_v2', 'rls_policy', 'public', 'fin_perm_user', 'fin_permissoes'),
+  ('financeiro_v2', 'rls_policy', 'public', 'fin_kpi_trib_user', 'fin_kpi_tributario'),
+  ('financeiro_v2', 'rls_policy', 'public', 'fin_orc_write', 'fin_orcamento'),
+  ('financeiro_v2', 'rls_policy', 'public', 'fin_conc_write', 'fin_conciliacao'),
+  ('financeiro_v2', 'rls_policy', 'public', 'fin_elim_write', 'fin_eliminacoes_intercompany'),
+  ('financeiro_v2', 'rls_policy', 'public', 'fin_fech_write', 'fin_fechamentos'),
+  ('financeiro_v3_backend', 'table', 'public', 'fin_sync_checkpoint', ''),
+  ('financeiro_v3_backend', 'table', 'public', 'fin_confiabilidade', ''),
+  ('financeiro_v3_backend', 'index', 'public', 'idx_fin_conf_periodo', 'fin_confiabilidade'),
+  ('financeiro_v3_backend', 'function', 'public', 'fin_calcular_confiabilidade', ''),
+  ('financeiro_v3_backend', 'function', 'public', 'fin_projecao_13_semanas', ''),
+  ('financeiro_v3_backend', 'function', 'public', 'fin_consolidado_intercompany', ''),
+  ('financeiro_v3_backend', 'rls_policy', 'public', 'fin_sync_ckpt_service', 'fin_sync_checkpoint'),
+  ('financeiro_v3_backend', 'rls_policy', 'public', 'fin_sync_ckpt_user', 'fin_sync_checkpoint'),
+  ('financeiro_v3_backend', 'rls_policy', 'public', 'fin_conf_service', 'fin_confiabilidade'),
+  ('financeiro_v3_backend', 'rls_policy', 'public', 'fin_conf_user', 'fin_confiabilidade'),
+  ('vendor_sip_credentials', 'table', 'public', 'vendor_sip_credentials', ''),
+  ('vendor_sip_credentials', 'index', 'public', 'idx_vendor_sip_credentials_user_id', 'vendor_sip_credentials'),
+  ('vendor_sip_credentials', 'function', 'public', 'update_vendor_sip_credentials_updated_at', ''),
+  ('vendor_sip_credentials', 'trigger', 'public', 'vendor_sip_credentials_updated_at_trigger', 'vendor_sip_credentials'),
+  ('user_departments', 'table', 'public', 'user_departments', ''),
+  ('user_departments', 'index', 'public', 'idx_user_departments_user', 'user_departments'),
+  ('user_departments', 'index', 'public', 'idx_user_departments_dept', 'user_departments'),
+  ('user_departments', 'rls_policy', 'public', 'user_departments_read_own', 'user_departments'),
+  ('user_departments', 'rls_policy', 'public', 'user_departments_master_all', 'user_departments'),
+  ('user_departments', 'rls_policy', 'public', 'user_departments_service_all', 'user_departments'),
+  ('dashboard_visits', 'table', 'public', 'dashboard_visits', ''),
+  ('dashboard_visits', 'index', 'public', 'idx_dashboard_visits_user_recent', 'dashboard_visits'),
+  ('dashboard_visits', 'rls_policy', 'public', 'dashboard_visits_user_insert', 'dashboard_visits'),
+  ('dashboard_visits', 'rls_policy', 'public', 'dashboard_visits_user_read', 'dashboard_visits'),
+  ('dashboard_visits', 'rls_policy', 'public', 'dashboard_visits_master_read', 'dashboard_visits'),
+  ('dashboard_visits', 'rls_policy', 'public', 'dashboard_visits_service_all', 'dashboard_visits'),
+  ('farmer_calls_persist_session', 'index', 'public', 'idx_farmer_calls_has_transcript', 'farmer_calls'),
+  ('kb_foundation', 'table', 'public', 'kb_documents', ''),
+  ('kb_foundation', 'table', 'public', 'kb_chunks', ''),
+  ('kb_foundation', 'index', 'public', 'idx_kb_chunks_embedding', 'kb_chunks'),
+  ('kb_foundation', 'index', 'public', 'idx_kb_documents_status_type', 'kb_documents'),
+  ('kb_foundation', 'index', 'public', 'idx_kb_chunks_document', 'kb_chunks'),
+  ('kb_foundation', 'function', 'public', 'kb_documents_set_updated_at', ''),
+  ('kb_foundation', 'trigger', 'public', 'trg_kb_documents_updated_at', 'kb_documents'),
+  ('kb_foundation', 'rls_policy', 'public', 'kb_documents_select_staff', 'kb_documents'),
+  ('kb_foundation', 'rls_policy', 'public', 'kb_documents_insert_staff', 'kb_documents'),
+  ('kb_foundation', 'rls_policy', 'public', 'kb_documents_update_master', 'kb_documents'),
+  ('kb_foundation', 'rls_policy', 'public', 'kb_documents_delete_master', 'kb_documents'),
+  ('kb_foundation', 'rls_policy', 'public', 'kb_chunks_select_staff', 'kb_chunks'),
+  ('kb_foundation', 'rls_policy', 'storage', 'kb_bucket_select_staff', 'objects'),
+  ('kb_foundation', 'rls_policy', 'storage', 'kb_bucket_insert_staff', 'objects'),
+  ('kb_foundation', 'rls_policy', 'storage', 'kb_bucket_delete_master', 'objects'),
+  ('kb_specs_and_competitors', 'table', 'public', 'kb_product_specs', ''),
+  ('kb_specs_and_competitors', 'table', 'public', 'kb_competitors', ''),
+  ('kb_specs_and_competitors', 'table', 'public', 'kb_competitor_products', ''),
+  ('kb_specs_and_competitors', 'index', 'public', 'idx_kb_product_specs_product_code', 'kb_product_specs'),
+  ('kb_specs_and_competitors', 'index', 'public', 'idx_kb_product_specs_supplier_line', 'kb_product_specs'),
+  ('kb_specs_and_competitors', 'index', 'public', 'idx_kb_competitor_products_competitor', 'kb_competitor_products'),
+  ('kb_specs_and_competitors', 'index', 'public', 'idx_kb_competitor_products_equivalent', 'kb_competitor_products'),
+  ('kb_specs_and_competitors', 'function', 'public', 'kb_documents_set_updated_at', ''),
+  ('kb_specs_and_competitors', 'trigger', 'public', 'trg_kb_product_specs_updated_at', 'kb_product_specs'),
+  ('kb_specs_and_competitors', 'trigger', 'public', 'trg_kb_competitors_updated_at', 'kb_competitors'),
+  ('kb_specs_and_competitors', 'trigger', 'public', 'trg_kb_competitor_products_updated_at', 'kb_competitor_products'),
+  ('kb_specs_and_competitors', 'rls_policy', 'public', 'kb_product_specs_select_staff', 'kb_product_specs'),
+  ('kb_specs_and_competitors', 'rls_policy', 'public', 'kb_product_specs_insert_staff', 'kb_product_specs'),
+  ('kb_specs_and_competitors', 'rls_policy', 'public', 'kb_product_specs_update_master', 'kb_product_specs'),
+  ('kb_specs_and_competitors', 'rls_policy', 'public', 'kb_product_specs_delete_master', 'kb_product_specs'),
+  ('kb_specs_and_competitors', 'rls_policy', 'public', 'kb_competitors_select_staff', 'kb_competitors'),
+  ('kb_specs_and_competitors', 'rls_policy', 'public', 'kb_competitors_insert_staff', 'kb_competitors'),
+  ('kb_specs_and_competitors', 'rls_policy', 'public', 'kb_competitors_update_staff', 'kb_competitors'),
+  ('kb_specs_and_competitors', 'rls_policy', 'public', 'kb_competitors_delete_master', 'kb_competitors'),
+  ('kb_specs_and_competitors', 'rls_policy', 'public', 'kb_competitor_products_select_staff', 'kb_competitor_products'),
+  ('kb_specs_and_competitors', 'rls_policy', 'public', 'kb_competitor_products_insert_staff', 'kb_competitor_products'),
+  ('kb_specs_and_competitors', 'rls_policy', 'public', 'kb_competitor_products_update_staff', 'kb_competitor_products'),
+  ('kb_specs_and_competitors', 'rls_policy', 'public', 'kb_competitor_products_delete_master', 'kb_competitor_products'),
+  ('customer_processes', 'table', 'public', 'customer_processes', ''),
+  ('customer_processes', 'index', 'public', 'idx_customer_processes_one_current', 'customer_processes'),
+  ('customer_processes', 'index', 'public', 'idx_customer_processes_customer', 'customer_processes'),
+  ('customer_processes', 'index', 'public', 'idx_customer_processes_segmento', 'customer_processes'),
+  ('customer_processes', 'trigger', 'public', 'trg_customer_processes_updated_at', 'customer_processes'),
+  ('customer_processes', 'rls_policy', 'public', 'customer_processes_select_staff', 'customer_processes'),
+  ('customer_processes', 'rls_policy', 'public', 'customer_processes_insert_staff', 'customer_processes'),
+  ('customer_processes', 'rls_policy', 'public', 'customer_processes_update_staff', 'customer_processes'),
+  ('customer_processes', 'rls_policy', 'public', 'customer_processes_delete_master', 'customer_processes'),
+  ('standard_processes', 'table', 'public', 'standard_processes', ''),
+  ('standard_processes', 'index', 'public', 'idx_standard_processes_status_segmento', 'standard_processes'),
+  ('standard_processes', 'index', 'public', 'idx_standard_processes_published_segmento', 'standard_processes'),
+  ('standard_processes', 'index', 'public', 'idx_standard_processes_slug', 'standard_processes'),
+  ('standard_processes', 'trigger', 'public', 'trg_standard_processes_updated_at', 'standard_processes'),
+  ('standard_processes', 'rls_policy', 'public', 'standard_processes_select_visible', 'standard_processes'),
+  ('standard_processes', 'rls_policy', 'public', 'standard_processes_insert_staff', 'standard_processes'),
+  ('standard_processes', 'rls_policy', 'public', 'standard_processes_update_owner_or_master', 'standard_processes'),
+  ('standard_processes', 'rls_policy', 'public', 'standard_processes_delete_master', 'standard_processes'),
+  ('rag_chunks', 'table', 'public', 'rag_chunks', ''),
+  ('rag_chunks', 'index', 'public', 'idx_rag_chunks_embedding', 'rag_chunks'),
+  ('rag_chunks', 'index', 'public', 'idx_rag_chunks_source', 'rag_chunks'),
+  ('rag_chunks', 'index', 'public', 'idx_rag_chunks_metadata_segmento', 'rag_chunks'),
+  ('rag_chunks', 'rls_policy', 'public', 'rag_chunks_select_staff', 'rag_chunks'),
+  ('customer_contacts', 'table', 'public', 'customer_contacts', ''),
+  ('customer_contacts', 'index', 'public', 'idx_customer_contacts_customer', 'customer_contacts'),
+  ('customer_contacts', 'index', 'public', 'idx_customer_contacts_phone', 'customer_contacts'),
+  ('customer_contacts', 'index', 'public', 'idx_customer_contacts_one_primary', 'customer_contacts'),
+  ('customer_contacts', 'index', 'public', 'idx_customer_contacts_birthday', 'customer_contacts'),
+  ('customer_contacts', 'trigger', 'public', 'trg_customer_contacts_updated_at', 'customer_contacts'),
+  ('customer_contacts', 'rls_policy', 'public', 'customer_contacts_select_staff', 'customer_contacts'),
+  ('customer_contacts', 'rls_policy', 'public', 'customer_contacts_insert_staff', 'customer_contacts'),
+  ('customer_contacts', 'rls_policy', 'public', 'customer_contacts_update_staff', 'customer_contacts'),
+  ('customer_contacts', 'rls_policy', 'public', 'customer_contacts_delete_master', 'customer_contacts'),
+  ('fin_audit_log', 'table', 'public', 'fin_audit_log', ''),
+  ('fin_audit_log', 'index', 'public', 'fin_audit_log_table_row_idx', 'fin_audit_log'),
+  ('fin_audit_log', 'index', 'public', 'fin_audit_log_company_period_idx', 'fin_audit_log'),
+  ('fin_audit_log', 'index', 'public', 'fin_audit_log_user_idx', 'fin_audit_log'),
+  ('fin_audit_log', 'rls_policy', 'public', 'fin_audit_log_select_staff', 'fin_audit_log'),
+  ('fin_audit_trigger', 'function', 'public', 'fin_audit_trigger', ''),
+  ('fin_audit_attach', 'trigger', 'public', 'trg_audit', 'fin_contas_receber'),
+  ('fin_audit_attach', 'trigger', 'public', 'trg_audit', 'fin_contas_pagar'),
+  ('fin_audit_attach', 'trigger', 'public', 'trg_audit', 'fin_categoria_dre_mapping'),
+  ('fin_audit_attach', 'trigger', 'public', 'trg_audit', 'fin_orcamento'),
+  ('fin_audit_attach', 'trigger', 'public', 'trg_audit', 'fin_fechamentos'),
+  ('fin_audit_attach', 'trigger', 'public', 'trg_audit', 'fin_eliminacoes_intercompany'),
+  ('set_config_rpc', 'function', 'public', 'set_config', ''),
+  ('fin_period_overrides', 'table', 'public', 'fin_period_overrides', ''),
+  ('fin_period_overrides', 'index', 'public', 'fin_period_overrides_active_idx', 'fin_period_overrides'),
+  ('fin_period_overrides', 'rls_policy', 'public', 'fin_period_overrides_select_staff', 'fin_period_overrides'),
+  ('fin_period_overrides', 'rls_policy', 'public', 'fin_period_overrides_insert_master', 'fin_period_overrides'),
+  ('fin_period_overrides', 'rls_policy', 'public', 'fin_period_overrides_update_self', 'fin_period_overrides'),
+  ('fin_period_lock_trigger', 'function', 'public', 'fin_period_lock_trigger', ''),
+  ('fin_period_lock_attach', 'trigger', 'public', 'trg_period_lock', 'fin_contas_receber'),
+  ('fin_period_lock_attach', 'trigger', 'public', 'trg_period_lock', 'fin_contas_pagar'),
+  ('fin_period_lock_attach', 'trigger', 'public', 'trg_period_lock', 'fin_movimentacoes'),
+  ('fin_period_lock_attach', 'trigger', 'public', 'trg_period_lock', 'fin_categoria_dre_mapping'),
+  ('fin_period_lock_attach', 'trigger', 'public', 'trg_period_lock', 'fin_orcamento'),
+  ('fin_mapping_gate_trigger', 'function', 'public', 'fin_check_mapping_complete_trigger', ''),
+  ('fin_mapping_gate_trigger', 'trigger', 'public', 'trg_mapping_gate', 'fin_fechamentos'),
+  ('rpc_categorias_sem_mapping', 'function', 'public', 'fin_categorias_sem_mapping', ''),
+  ('fin_ic_matches', 'table', 'public', 'fin_ic_matches', ''),
+  ('fin_ic_matches', 'index', 'public', 'fin_ic_matches_status_idx', 'fin_ic_matches'),
+  ('fin_ic_matches', 'index', 'public', 'fin_ic_matches_cr_idx', 'fin_ic_matches'),
+  ('fin_ic_matches', 'index', 'public', 'fin_ic_matches_cp_idx', 'fin_ic_matches'),
+  ('fin_ic_matches', 'index', 'public', 'fin_ic_matches_cr_unique', 'fin_ic_matches'),
+  ('fin_ic_matches', 'index', 'public', 'fin_ic_matches_cp_unique', 'fin_ic_matches'),
+  ('fin_ic_matches', 'rls_policy', 'public', 'fin_ic_matches_select_staff', 'fin_ic_matches'),
+  ('fin_ic_matches', 'rls_policy', 'public', 'fin_ic_matches_update_staff', 'fin_ic_matches'),
+  ('company_cnpjs', 'table', 'public', 'company_cnpjs', ''),
+  ('company_cnpjs', 'index', 'public', 'company_cnpjs_normalized_idx', 'company_cnpjs'),
+  ('company_cnpjs', 'rls_policy', 'public', 'company_cnpjs_select_authenticated', 'company_cnpjs'),
+  ('company_cnpjs', 'rls_policy', 'public', 'company_cnpjs_master_write', 'company_cnpjs'),
+  ('fin_consolidado_v2', 'function', 'public', 'fin_consolidado_intercompany', ''),
+  ('commercial_role_add_values', 'enum_value', 'public', 'farmer', 'commercial_role'),
+  ('commercial_role_add_values', 'enum_value', 'public', 'hunter', 'commercial_role'),
+  ('commercial_role_add_values', 'enum_value', 'public', 'closer', 'commercial_role'),
+  ('commercial_role_add_values', 'enum_value', 'public', 'master', 'commercial_role'),
+  ('scoring_v2_signal_modifiers', 'table', 'public', 'score_recalc_queue', ''),
+  ('scoring_v2_signal_modifiers', 'index', 'public', 'idx_score_recalc_queue_pending', 'score_recalc_queue'),
+  ('scoring_v2_signal_modifiers', 'index', 'public', 'uniq_score_recalc_queue_pending', 'score_recalc_queue'),
+  ('scoring_v2_signal_modifiers', 'function', 'public', 'enqueue_score_recalc_from_call', ''),
+  ('scoring_v2_signal_modifiers', 'trigger', 'public', 'trg_farmer_calls_enqueue_recalc', 'farmer_calls'),
+  ('fin_a1_eventos', 'table', 'public', 'fin_eventos_recorrentes', ''),
+  ('fin_a1_eventos', 'table', 'public', 'fin_eventos_eventuais', ''),
+  ('fin_a1_eventos', 'index', 'public', 'fin_eventos_rec_company_ativo_idx', 'fin_eventos_recorrentes'),
+  ('fin_a1_eventos', 'index', 'public', 'fin_eventos_rec_categoria_idx', 'fin_eventos_recorrentes'),
+  ('fin_a1_eventos', 'index', 'public', 'fin_eventos_ev_company_data_idx', 'fin_eventos_eventuais'),
+  ('fin_a1_eventos', 'index', 'public', 'fin_eventos_ev_status_idx', 'fin_eventos_eventuais'),
+  ('fin_a1_eventos', 'rls_policy', 'public', 'fin_eventos_rec_select_staff', 'fin_eventos_recorrentes'),
+  ('fin_a1_eventos', 'rls_policy', 'public', 'fin_eventos_rec_write_staff', 'fin_eventos_recorrentes'),
+  ('fin_a1_eventos', 'rls_policy', 'public', 'fin_eventos_ev_select_staff', 'fin_eventos_eventuais'),
+  ('fin_a1_eventos', 'rls_policy', 'public', 'fin_eventos_ev_write_staff', 'fin_eventos_eventuais'),
+  ('fin_a1_snapshots_alertas_config', 'table', 'public', 'fin_projecao_snapshots', ''),
+  ('fin_a1_snapshots_alertas_config', 'table', 'public', 'fin_alertas', ''),
+  ('fin_a1_snapshots_alertas_config', 'table', 'public', 'fin_config_cashflow', ''),
+  ('fin_a1_snapshots_alertas_config', 'index', 'public', 'fin_proj_company_snap_idx', 'fin_projecao_snapshots'),
+  ('fin_a1_snapshots_alertas_config', 'index', 'public', 'fin_proj_cenario_idx', 'fin_projecao_snapshots'),
+  ('fin_a1_snapshots_alertas_config', 'index', 'public', 'fin_alertas_company_criado_idx', 'fin_alertas'),
+  ('fin_a1_snapshots_alertas_config', 'index', 'public', 'fin_alertas_unique_ativo', 'fin_alertas'),
+  ('fin_a1_snapshots_alertas_config', 'rls_policy', 'public', 'fin_proj_select_staff', 'fin_projecao_snapshots'),
+  ('fin_a1_snapshots_alertas_config', 'rls_policy', 'public', 'fin_alertas_select_staff', 'fin_alertas'),
+  ('fin_a1_snapshots_alertas_config', 'rls_policy', 'public', 'fin_alertas_update_staff', 'fin_alertas'),
+  ('fin_a1_snapshots_alertas_config', 'rls_policy', 'public', 'fin_config_select_staff', 'fin_config_cashflow'),
+  ('fin_a1_snapshots_alertas_config', 'rls_policy', 'public', 'fin_config_write_master', 'fin_config_cashflow'),
+  ('fin_a1_audit_lock_attach', 'function', 'public', 'fin_period_lock_trigger', ''),
+  ('fin_a1_audit_lock_attach', 'trigger', 'public', 'trg_audit', 'fin_eventos_recorrentes'),
+  ('fin_a1_audit_lock_attach', 'trigger', 'public', 'trg_audit', 'fin_eventos_eventuais'),
+  ('fin_a1_audit_lock_attach', 'trigger', 'public', 'trg_audit', 'fin_alertas'),
+  ('fin_a1_audit_lock_attach', 'trigger', 'public', 'trg_audit', 'fin_config_cashflow'),
+  ('fin_a1_audit_lock_attach', 'trigger', 'public', 'trg_period_lock', 'fin_eventos_recorrentes'),
+  ('fin_a1_audit_lock_attach', 'trigger', 'public', 'trg_period_lock', 'fin_eventos_eventuais')
+)
+SELECT
+  e.migration,
+  e.kind,
+  e.schema_name || '.' || e.object_name AS object,
+  CASE
+    WHEN e.kind = 'table' AND EXISTS (
+      SELECT 1 FROM information_schema.tables t
+      WHERE t.table_schema = e.schema_name AND t.table_name = e.object_name
+    ) THEN '✅'
+    WHEN e.kind = 'index' AND EXISTS (
+      SELECT 1 FROM pg_indexes i
+      WHERE i.schemaname = e.schema_name AND i.indexname = e.object_name
+    ) THEN '✅'
+    WHEN e.kind = 'function' AND EXISTS (
+      SELECT 1 FROM pg_proc p
+      JOIN pg_namespace n ON n.oid = p.pronamespace
+      WHERE n.nspname = e.schema_name AND p.proname = e.object_name
+    ) THEN '✅'
+    WHEN e.kind = 'trigger' AND EXISTS (
+      SELECT 1 FROM pg_trigger tr
+      JOIN pg_class c ON c.oid = tr.tgrelid
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+      WHERE n.nspname = e.schema_name AND tr.tgname = e.object_name AND c.relname = e.parent_name
+    ) THEN '✅'
+    WHEN e.kind = 'cron_job' AND EXISTS (
+      SELECT 1 FROM cron.job WHERE jobname = e.object_name
+    ) THEN '✅'
+    WHEN e.kind = 'enum_value' AND EXISTS (
+      SELECT 1 FROM pg_enum en
+      JOIN pg_type ty ON ty.oid = en.enumtypid
+      JOIN pg_namespace n ON n.oid = ty.typnamespace
+      WHERE n.nspname = e.schema_name AND ty.typname = e.parent_name AND en.enumlabel = e.object_name
+    ) THEN '✅'
+    WHEN e.kind = 'rls_policy' AND EXISTS (
+      SELECT 1 FROM pg_policies p
+      WHERE p.schemaname = e.schema_name AND p.tablename = e.parent_name AND p.policyname = e.object_name
+    ) THEN '✅'
+    ELSE '❌'
+  END AS status,
+  NULLIF(e.parent_name, '') AS parent
+FROM expected_objects e
+ORDER BY status DESC, e.migration, e.kind, e.object_name;
+
+-- ========================================================================
+-- FIM
+-- ========================================================================

--- a/scripts/audit-custom-migrations.ts
+++ b/scripts/audit-custom-migrations.ts
@@ -1,0 +1,365 @@
+#!/usr/bin/env bun
+/**
+ * Audit de custom migrations
+ * ===========================
+ *
+ * Per CLAUDE.md §5: Lovable Cloud NÃO aplica automaticamente migrations com
+ * nome custom (não-UUID). Ficam no repo mas não tocam o banco. Este script:
+ *
+ *  1. Lista todas as migrations em supabase/migrations/
+ *  2. Separa UUID-format (auto-aplicadas) de custom (precisam validação)
+ *  3. Parseia cada custom migration extraindo objetos criados
+ *     (tables, indexes, functions, triggers, cron jobs, enum values)
+ *  4. Emite dois artefatos:
+ *      - scripts/audit-custom-migrations.sql  → cola no Supabase SQL Editor
+ *      - docs/migrations-audit.md             → inventário + instruções
+ *
+ * Rodar: `bun scripts/audit-custom-migrations.ts`
+ *
+ * Re-rodar sempre que migrations custom forem adicionadas — é idempotente.
+ */
+
+import { readdirSync, readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import { join, basename, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const MIGRATIONS_DIR = join(REPO_ROOT, 'supabase', 'migrations');
+const SQL_OUT = join(REPO_ROOT, 'scripts', 'audit-custom-migrations.sql');
+const MD_OUT = join(REPO_ROOT, 'docs', 'migrations-audit.md');
+
+const UUID_PATTERN = /_[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}\.sql$/;
+const TIMESTAMP_PATTERN = /^(\d{14})_(.+)\.sql$/;
+
+type ObjectKind = 'table' | 'index' | 'function' | 'trigger' | 'cron_job' | 'enum_value' | 'rls_policy' | 'rpc';
+
+interface ExtractedObject {
+  kind: ObjectKind;
+  schema: string;
+  name: string;
+  /** for enum_value: the enum type name. for trigger: the table. for rls_policy: the table. */
+  parent?: string;
+}
+
+interface MigrationAudit {
+  filename: string;
+  version: string;
+  slug: string;
+  objects: ExtractedObject[];
+  rawSize: number;
+}
+
+function isCustom(filename: string): boolean {
+  return !UUID_PATTERN.test(filename);
+}
+
+/**
+ * Extrai objetos criados por uma migration via regex.
+ * Não é parser SQL completo — heurístico mas suficiente pro audit.
+ * Cobre os patterns que aparecem nas migrations do projeto.
+ */
+function extractObjects(sql: string): ExtractedObject[] {
+  const objects: ExtractedObject[] = [];
+  // Strip line comments (-- ...) para evitar falsos positivos em exemplos comentados
+  const stripped = sql.replace(/--.*$/gm, '');
+
+  // CREATE TABLE [IF NOT EXISTS] [schema.]name (...)
+  const tableRe = /CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?(?:(\w+)\.)?(\w+)\s*\(/gi;
+  for (const m of stripped.matchAll(tableRe)) {
+    objects.push({ kind: 'table', schema: m[1] || 'public', name: m[2] });
+  }
+
+  // CREATE [UNIQUE] INDEX [CONCURRENTLY] [IF NOT EXISTS] name ON [schema.]table
+  const indexRe = /CREATE\s+(?:UNIQUE\s+)?INDEX\s+(?:CONCURRENTLY\s+)?(?:IF\s+NOT\s+EXISTS\s+)?(\w+)\s+ON\s+(?:(\w+)\.)?(\w+)/gi;
+  for (const m of stripped.matchAll(indexRe)) {
+    objects.push({ kind: 'index', schema: m[2] || 'public', name: m[1], parent: m[3] });
+  }
+
+  // CREATE [OR REPLACE] FUNCTION [schema.]name(
+  const fnRe = /CREATE\s+(?:OR\s+REPLACE\s+)?FUNCTION\s+(?:(\w+)\.)?(\w+)\s*\(/gi;
+  for (const m of stripped.matchAll(fnRe)) {
+    objects.push({ kind: 'function', schema: m[1] || 'public', name: m[2] });
+  }
+
+  // CREATE TRIGGER name ... ON [schema.]table
+  const trigRe = /CREATE\s+TRIGGER\s+(\w+)[\s\S]*?ON\s+(?:(\w+)\.)?(\w+)/gi;
+  for (const m of stripped.matchAll(trigRe)) {
+    objects.push({ kind: 'trigger', schema: m[2] || 'public', name: m[1], parent: m[3] });
+  }
+
+  // SELECT cron.schedule('jobname', ...)
+  const cronRe = /cron\.schedule\s*\(\s*'([^']+)'/gi;
+  for (const m of stripped.matchAll(cronRe)) {
+    objects.push({ kind: 'cron_job', schema: 'cron', name: m[1] });
+  }
+
+  // ALTER TYPE schema.enum ADD VALUE 'value'  (idempotência via DO block ou IF NOT EXISTS)
+  const enumRe = /ALTER\s+TYPE\s+(?:(\w+)\.)?(\w+)\s+ADD\s+VALUE\s+(?:IF\s+NOT\s+EXISTS\s+)?'([^']+)'/gi;
+  for (const m of stripped.matchAll(enumRe)) {
+    objects.push({ kind: 'enum_value', schema: m[1] || 'public', name: m[3], parent: m[2] });
+  }
+
+  // CREATE POLICY name ON [schema.]table
+  const policyRe = /CREATE\s+POLICY\s+"?([^\s"]+)"?\s+ON\s+(?:(\w+)\.)?(\w+)/gi;
+  for (const m of stripped.matchAll(policyRe)) {
+    objects.push({ kind: 'rls_policy', schema: m[2] || 'public', name: m[1], parent: m[3] });
+  }
+
+  // Dedupe — IF NOT EXISTS pode aparecer múltiplas vezes pro mesmo objeto
+  const seen = new Set<string>();
+  return objects.filter((o) => {
+    const key = `${o.kind}:${o.schema}.${o.name}:${o.parent || ''}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function loadMigrations(): MigrationAudit[] {
+  const files = readdirSync(MIGRATIONS_DIR).filter((f) => f.endsWith('.sql') && isCustom(f)).sort();
+  return files.map((filename) => {
+    const content = readFileSync(join(MIGRATIONS_DIR, filename), 'utf8');
+    const m = filename.match(TIMESTAMP_PATTERN);
+    return {
+      filename,
+      version: m?.[1] ?? filename,
+      slug: m?.[2] ?? filename,
+      objects: extractObjects(content),
+      rawSize: content.length,
+    };
+  });
+}
+
+function emitSql(audits: MigrationAudit[]): string {
+  const lines: string[] = [];
+
+  lines.push('-- ========================================================================');
+  lines.push('-- AUDIT — Custom Migrations');
+  lines.push('-- ========================================================================');
+  lines.push('--');
+  lines.push('-- Gerado por: scripts/audit-custom-migrations.ts');
+  lines.push(`-- Total de custom migrations: ${audits.length}`);
+  lines.push('--');
+  lines.push('-- Como usar:');
+  lines.push('--   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)');
+  lines.push('--   2. Cole TODO este arquivo numa query');
+  lines.push('--   3. Run');
+  lines.push('--   4. Olhe as duas tabelas de resultado: (A) timestamps aplicados, (B) objetos existentes');
+  lines.push('--');
+  lines.push('-- Read-only — não altera nada no banco.');
+  lines.push('-- ========================================================================');
+  lines.push('');
+
+  // Section 1: timestamp existence in supabase_migrations.schema_migrations
+  lines.push('-- =====================================================');
+  lines.push('-- SECTION 1: Timestamps aplicados (canonical check)');
+  lines.push('-- =====================================================');
+  lines.push('-- Source of truth do Supabase. Se a row existe aqui, a migration rodou.');
+  lines.push('');
+  lines.push('WITH expected (version, slug, filename) AS (VALUES');
+  audits.forEach((a, i) => {
+    const sep = i === audits.length - 1 ? '' : ',';
+    lines.push(`  ('${a.version}', ${sqlString(a.slug)}, ${sqlString(a.filename)})${sep}`);
+  });
+  lines.push(')');
+  lines.push('SELECT');
+  lines.push('  e.version,');
+  lines.push('  e.slug,');
+  lines.push('  CASE WHEN sm.version IS NOT NULL THEN \'✅ applied\' ELSE \'❌ MISSING — apply manually\' END AS status,');
+  lines.push('  e.filename');
+  lines.push('FROM expected e');
+  lines.push('LEFT JOIN supabase_migrations.schema_migrations sm ON sm.version = e.version');
+  lines.push('ORDER BY e.version;');
+  lines.push('');
+  lines.push('');
+
+  // Section 2: object existence per migration
+  lines.push('-- =====================================================');
+  lines.push('-- SECTION 2: Object existence (cross-check)');
+  lines.push('-- =====================================================');
+  lines.push('-- Caso schema_migrations diga ✅ mas o objeto não exista (rollback manual,');
+  lines.push('-- partial apply), esta query captura. Para cada objeto esperado, checa pg_catalog.');
+  lines.push('');
+
+  // Coletar TODOS os objetos de TODAS as migrations num único VALUES
+  type Row = { migration: string; kind: ObjectKind; schema: string; name: string; parent: string };
+  const rows: Row[] = [];
+  for (const a of audits) {
+    for (const o of a.objects) {
+      rows.push({
+        migration: a.slug,
+        kind: o.kind,
+        schema: o.schema,
+        name: o.name,
+        parent: o.parent || '',
+      });
+    }
+  }
+
+  if (rows.length === 0) {
+    lines.push('-- Nenhum objeto extraído. (Migrations só tiveram ALTER/UPDATE, não CREATE.)');
+  } else {
+    lines.push('WITH expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VALUES');
+    rows.forEach((r, i) => {
+      const sep = i === rows.length - 1 ? '' : ',';
+      lines.push(
+        `  (${sqlString(r.migration)}, ${sqlString(r.kind)}, ${sqlString(r.schema)}, ${sqlString(r.name)}, ${sqlString(r.parent)})${sep}`,
+      );
+    });
+    lines.push(')');
+    lines.push('SELECT');
+    lines.push('  e.migration,');
+    lines.push('  e.kind,');
+    lines.push('  e.schema_name || \'.\' || e.object_name AS object,');
+    lines.push('  CASE');
+
+    // Per-kind existence check via pg_catalog / information_schema
+    lines.push("    WHEN e.kind = 'table' AND EXISTS (");
+    lines.push('      SELECT 1 FROM information_schema.tables t');
+    lines.push('      WHERE t.table_schema = e.schema_name AND t.table_name = e.object_name');
+    lines.push("    ) THEN '✅'");
+    lines.push("    WHEN e.kind = 'index' AND EXISTS (");
+    lines.push('      SELECT 1 FROM pg_indexes i');
+    lines.push('      WHERE i.schemaname = e.schema_name AND i.indexname = e.object_name');
+    lines.push("    ) THEN '✅'");
+    lines.push("    WHEN e.kind = 'function' AND EXISTS (");
+    lines.push('      SELECT 1 FROM pg_proc p');
+    lines.push('      JOIN pg_namespace n ON n.oid = p.pronamespace');
+    lines.push('      WHERE n.nspname = e.schema_name AND p.proname = e.object_name');
+    lines.push("    ) THEN '✅'");
+    lines.push("    WHEN e.kind = 'trigger' AND EXISTS (");
+    lines.push('      SELECT 1 FROM pg_trigger tr');
+    lines.push('      JOIN pg_class c ON c.oid = tr.tgrelid');
+    lines.push('      JOIN pg_namespace n ON n.oid = c.relnamespace');
+    lines.push('      WHERE n.nspname = e.schema_name AND tr.tgname = e.object_name AND c.relname = e.parent_name');
+    lines.push("    ) THEN '✅'");
+    lines.push("    WHEN e.kind = 'cron_job' AND EXISTS (");
+    lines.push("      SELECT 1 FROM cron.job WHERE jobname = e.object_name");
+    lines.push("    ) THEN '✅'");
+    lines.push("    WHEN e.kind = 'enum_value' AND EXISTS (");
+    lines.push('      SELECT 1 FROM pg_enum en');
+    lines.push('      JOIN pg_type ty ON ty.oid = en.enumtypid');
+    lines.push('      JOIN pg_namespace n ON n.oid = ty.typnamespace');
+    lines.push('      WHERE n.nspname = e.schema_name AND ty.typname = e.parent_name AND en.enumlabel = e.object_name');
+    lines.push("    ) THEN '✅'");
+    lines.push("    WHEN e.kind = 'rls_policy' AND EXISTS (");
+    lines.push('      SELECT 1 FROM pg_policies p');
+    lines.push('      WHERE p.schemaname = e.schema_name AND p.tablename = e.parent_name AND p.policyname = e.object_name');
+    lines.push("    ) THEN '✅'");
+    lines.push("    ELSE '❌'");
+    lines.push('  END AS status,');
+    lines.push("  NULLIF(e.parent_name, '') AS parent");
+    lines.push('FROM expected_objects e');
+    lines.push("ORDER BY status DESC, e.migration, e.kind, e.object_name;");
+  }
+  lines.push('');
+  lines.push('-- ========================================================================');
+  lines.push('-- FIM');
+  lines.push('-- ========================================================================');
+  lines.push('');
+
+  return lines.join('\n');
+}
+
+function sqlString(s: string): string {
+  return `'${s.replace(/'/g, "''")}'`;
+}
+
+function emitMarkdown(audits: MigrationAudit[]): string {
+  const lines: string[] = [];
+  const total = audits.length;
+  const totalObjects = audits.reduce((sum, a) => sum + a.objects.length, 0);
+  const byKind = audits
+    .flatMap((a) => a.objects.map((o) => o.kind))
+    .reduce<Record<string, number>>((acc, k) => ((acc[k] = (acc[k] ?? 0) + 1), acc), {});
+
+  lines.push('# Migrations Audit — Custom (não-UUID)');
+  lines.push('');
+  lines.push(`> Gerado por \`scripts/audit-custom-migrations.ts\`. Re-rodar quando custom migrations forem adicionadas: \`bun scripts/audit-custom-migrations.ts\`.`);
+  lines.push('');
+  lines.push('## Contexto');
+  lines.push('');
+  lines.push('Per CLAUDE.md §5, **Lovable Cloud NÃO aplica automaticamente** migrations com nome custom (não-UUID) em `supabase/migrations/`. UUID-format (ex: `_868822bb-e38c-4fcf-8879-c64e48bd7630.sql`) são geradas pelo builder visual do Lovable e auto-rodam. Custom (ex: `_user_departments.sql`) ficam no repo mas precisam apply manual via Supabase SQL Editor.');
+  lines.push('');
+  lines.push('Este audit valida **quais custom migrations estão de fato aplicadas no banco**.');
+  lines.push('');
+  lines.push('## Como rodar');
+  lines.push('');
+  lines.push('1. Abra **Supabase Dashboard** (via Lovable Cloud → Backend → Open Supabase, ou direto via `https://supabase.com/dashboard/project/fzvklzpomgnyikkfkzai`)');
+  lines.push('2. **SQL Editor** → **New query**');
+  lines.push('3. Cole TODO o conteúdo de `scripts/audit-custom-migrations.sql`');
+  lines.push('4. **Run** (read-only, não altera nada)');
+  lines.push('5. Você verá DUAS tabelas:');
+  lines.push('   - **Section 1** — timestamps em `supabase_migrations.schema_migrations` (source of truth do Supabase)');
+  lines.push('   - **Section 2** — existência objeto-a-objeto via `pg_catalog`/`information_schema`');
+  lines.push('6. Filtre linhas com `❌` → essas são as migrations que precisam apply manual');
+  lines.push('');
+  lines.push('## Resumo');
+  lines.push('');
+  lines.push(`- **${total}** custom migrations totais`);
+  lines.push(`- **${totalObjects}** objetos esperados (criados por estas migrations)`);
+  lines.push('- Quebra por tipo:');
+  for (const [k, c] of Object.entries(byKind).sort((a, b) => b[1] - a[1])) {
+    lines.push(`  - \`${k}\`: ${c}`);
+  }
+  lines.push('');
+  lines.push('## Inventário por migration');
+  lines.push('');
+  lines.push('Lista canônica do que cada migration *deveria* criar (extraído via regex de `CREATE TABLE`/`CREATE INDEX`/etc — não é parser SQL completo). Use junto com Section 2 do SQL pra cruzar com a realidade.');
+  lines.push('');
+
+  for (const a of audits) {
+    lines.push(`### \`${a.filename}\``);
+    lines.push('');
+    if (a.objects.length === 0) {
+      lines.push('> _Nenhum objeto extraído via regex._ Migration provavelmente é `ALTER TABLE` / `UPDATE` / `INSERT` / RLS-only. Validar manualmente.');
+      lines.push('');
+      continue;
+    }
+    lines.push('| Tipo | Objeto | Parent |');
+    lines.push('| --- | --- | --- |');
+    for (const o of a.objects) {
+      lines.push(`| \`${o.kind}\` | \`${o.schema}.${o.name}\` | ${o.parent ? '`' + o.parent + '`' : '—'} |`);
+    }
+    lines.push('');
+  }
+
+  lines.push('## Próximos passos quando algo der `❌`');
+  lines.push('');
+  lines.push('1. Abra a migration correspondente em `supabase/migrations/<arquivo>.sql`');
+  lines.push('2. Copie o SQL inteiro');
+  lines.push('3. Supabase SQL Editor → cole → Run');
+  lines.push('4. Re-rode `scripts/audit-custom-migrations.sql` pra confirmar que virou `✅`');
+  lines.push('5. (Opcional) `INSERT INTO supabase_migrations.schema_migrations (version, statements) VALUES (\'<timestamp>\', ARRAY[\'<sql>\']);` pra registrar como aplicada (evita re-apply futura)');
+  lines.push('');
+
+  return lines.join('\n');
+}
+
+function main() {
+  if (!existsSync(MIGRATIONS_DIR)) {
+    console.error(`Migrations dir não encontrado: ${MIGRATIONS_DIR}`);
+    process.exit(1);
+  }
+
+  const audits = loadMigrations();
+  console.log(`Lidas ${audits.length} custom migrations.`);
+
+  for (const dir of [dirname(SQL_OUT), dirname(MD_OUT)]) {
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  }
+
+  const sql = emitSql(audits);
+  writeFileSync(SQL_OUT, sql);
+  console.log(`✓ Escrito ${SQL_OUT} (${sql.length} bytes)`);
+
+  const md = emitMarkdown(audits);
+  writeFileSync(MD_OUT, md);
+  console.log(`✓ Escrito ${MD_OUT} (${md.length} bytes)`);
+
+  const totalObjects = audits.reduce((sum, a) => sum + a.objects.length, 0);
+  console.log(`\nResumo: ${audits.length} migrations, ${totalObjects} objetos esperados.`);
+  console.log(`Próximo passo: abra ${basename(SQL_OUT)} no Supabase SQL Editor e rode.`);
+}
+
+main();


### PR DESCRIPTION
## Summary

Resolve a task **#7 — Sweep validação de 33 migrations custom** (são 38 hoje, não 33).

Per `CLAUDE.md §5`, Lovable Cloud **não aplica automaticamente** migrations com nome custom (não-UUID) em `supabase/migrations/`. Ficam só no repo. Até hoje, nenhuma forma sistêmica de saber quais foram realmente aplicadas no banco. Esta PR fecha esse gap com artefatos que rodam manualmente via Lovable Cloud → Backend → Open Supabase.

## O que entra

- **`scripts/audit-custom-migrations.ts`** — parser bun (regex heurístico, não SQL parser completo) que lê todas as custom migrations e extrai 262 objetos esperados (tables, indexes, functions, triggers, cron jobs, enum values, RLS policies). Idempotente — re-rodar com `bun run audit:migrations` quando adicionar migration nova.

- **`scripts/audit-custom-migrations.sql`** — SQL de **31 KB**, read-only, pronto pra colar no Supabase SQL Editor. Retorna duas tabelas:
  - **Section 1** — cross-reference com `supabase_migrations.schema_migrations` (source of truth do Supabase). Linha `❌ MISSING` = nunca rodou.
  - **Section 2** — existência objeto-a-objeto via `pg_catalog`/`information_schema`. Captura partial-apply (Section 1 ✅ + Section 2 ❌ no mesmo objeto = aplicou metade).

- **`docs/migrations-audit.md`** — inventário markdown canônico do que cada migration deveria criar, com tabela por migration + instruções de uso.

- **`package.json`** — script `audit:migrations` pra rodar o gerador.

- **`CLAUDE.md §5`** — referência aos novos artefatos na seção de migrations Supabase.

## Como usar (manual, via Lovable)

1. Lovable Cloud → Backend → Open Supabase
2. SQL Editor → New query
3. Cola conteúdo de `scripts/audit-custom-migrations.sql`
4. Run
5. Filtra linhas com `❌` → essas precisam apply manual (abrir migration → copiar SQL → SQL Editor → Run)

## Breakdown dos objetos extraídos

- `rls_policy`: 98
- `index`: 76
- `table`: 41
- `trigger`: 27
- `function`: 16
- `enum_value`: 4

## Decisões

- **Por que regex e não SQL parser real**: 262 objetos extraídos com cobertura suficiente. Adicionar `pgsql-parser` ou similar = dependência pesada por marginal benefit. Migrations futuras com sintaxe exótica podem ser revisadas manualmente.
- **Por que read-only no SQL**: zero risco de o user rodar e quebrar nada.
- **Por que CLAUDE.md update**: futuras sessões precisam descobrir o workflow.

## Test plan

- [x] `bun run audit:migrations` roda e gera os 2 outputs (38 migrations, 262 objetos)
- [x] SQL output sintaticamente bem-formado (CTEs fecham, CASE/WHEN/EXISTS válidos)
- [x] Markdown renderiza inventário completo
- [x] Lint pre-existente não regrede (343 problemas antes, 343 depois)
- [ ] **Manual (você)**: colar `scripts/audit-custom-migrations.sql` no Supabase SQL Editor, confirmar que retorna as duas tabelas sem erro, identificar o que vier `❌`

🤖 Generated with [Claude Code](https://claude.com/claude-code)