### PR TITLE
refactor(typescript): wave 27 remove ~27 `as never` obsoletos

### DIFF
--- a/src/hooks/useAuditTrail.ts
+++ b/src/hooks/useAuditTrail.ts
@@ -21,12 +21,11 @@ export function useAuditTrail(params: { tableName: string; rowId: string; limit?
     queryKey: ['fin_audit_log', tableName, rowId, limit],
     enabled: Boolean(tableName) && Boolean(rowId),
     queryFn: async (): Promise<AuditEntry[]> => {
-      // `fin_audit_log` existe no DB (migration 20260518) mas ainda não no generated Database type
       const { data, error } = await supabase
-        .from('fin_audit_log' as never)
+        .from('fin_audit_log')
         .select('*')
-        .eq('table_name' as never, tableName as never)
-        .eq('row_id' as never, rowId as never)
+        .eq('table_name', tableName)
+        .eq('row_id', rowId)
         .order('changed_at', { ascending: false })
         .limit(limit);
       if (error) throw error;

--- a/src/hooks/useDiagnosticQuestions.ts
+++ b/src/hooks/useDiagnosticQuestions.ts
@@ -118,7 +118,7 @@ export const useDiagnosticQuestions = () => {
 
     try {
       for (const q of qs) {
-        await supabase.from('farmer_diagnostic_questions' as never).insert({
+        await supabase.from('farmer_diagnostic_questions').insert({
           bundle_recommendation_id: bundleRecommendationId || null,
           farmer_id: user.id,
           customer_user_id: customerId,
@@ -132,7 +132,7 @@ export const useDiagnosticQuestions = () => {
           bundle_result: bundleResult || null,
           margin_generated: marginGenerated || 0,
           time_spent_seconds: timeSpentSeconds || 0,
-        } as never);
+        });
       }
       toast.success('Respostas salvas com sucesso');
     } catch (error) {
@@ -145,9 +145,9 @@ export const useDiagnosticQuestions = () => {
     if (!user?.id) return null;
 
     const { data } = await supabase
-      .from('farmer_diagnostic_questions' as never)
+      .from('farmer_diagnostic_questions')
       .select('question_type, response_type, was_bundle_offered, bundle_result, margin_generated')
-      .eq('farmer_id' as never, user.id as never);
+      .eq('farmer_id', user.id);
 
     const rows = (data ?? []) as unknown as Array<{
       question_type: string;

--- a/src/hooks/useIcMatches.ts
+++ b/src/hooks/useIcMatches.ts
@@ -27,13 +27,12 @@ export function useIcMatches(filterStatus?: IcMatch['status']) {
   return useQuery({
     queryKey: ['fin_ic_matches', filterStatus ?? 'all'],
     queryFn: async (): Promise<IcMatch[]> => {
-      // `fin_ic_matches` existe no DB (migration 20260518) mas ainda não no generated Database type
       let q = supabase
-        .from('fin_ic_matches' as never)
+        .from('fin_ic_matches')
         .select('*')
         .order('matched_at', { ascending: false })
         .limit(500);
-      if (filterStatus) q = q.eq('status' as never, filterStatus as never);
+      if (filterStatus) q = q.eq('status', filterStatus);
       const { data, error } = await q;
       if (error) throw error;
       return (data ?? []) as unknown as IcMatch[];
@@ -51,14 +50,14 @@ export function useResolveIcMatch() {
     }) => {
       const user = await supabase.auth.getUser();
       const { error } = await supabase
-        .from('fin_ic_matches' as never)
+        .from('fin_ic_matches')
         .update({
           status: input.status,
           observacao: input.observacao ?? null,
           resolvido_por: user.data.user?.id,
           resolvido_em: new Date().toISOString(),
-        } as never)
-        .eq('id' as never, input.id as never);
+        })
+        .eq('id', input.id);
       if (error) throw error;
     },
     onSuccess: () => qc.invalidateQueries({ queryKey: ['fin_ic_matches'] }),

--- a/src/pages/AdminReposicaoAumentos.tsx
+++ b/src/pages/AdminReposicaoAumentos.tsx
@@ -120,7 +120,7 @@ export default function AdminReposicaoAumentos() {
     queryKey: ["aumentos-fornecedores"],
     queryFn: async () => {
       const { data, error } = await supabase
-        .from("fornecedor_aumento_anunciado" as never)
+        .from("fornecedor_aumento_anunciado")
         .select("fornecedor_nome")
         .eq("empresa", EMPRESA);
       if (error) throw error;
@@ -136,7 +136,7 @@ export default function AdminReposicaoAumentos() {
     queryKey: ["aumentos", filtroFornecedor, filtroEstado, busca],
     queryFn: async () => {
       let q = supabase
-        .from("fornecedor_aumento_anunciado" as never)
+        .from("fornecedor_aumento_anunciado")
         .select(
           "id, nome, fornecedor_nome, data_vigencia, data_anuncio, estado, extracao_confianca, criado_em",
         )
@@ -162,7 +162,7 @@ export default function AdminReposicaoAumentos() {
       const sums: Record<number, { sum: number; n: number }> = {};
       if (ids.length > 0) {
         const { data: itens } = await supabase
-          .from("fornecedor_aumento_item" as never)
+          .from("fornecedor_aumento_item")
           .select("aumento_id, aumento_perc, ativo, confirmado")
           .in("aumento_id", ids)
           .eq("ativo", true);

--- a/src/pages/AdminReposicaoCadastros.tsx
+++ b/src/pages/AdminReposicaoCadastros.tsx
@@ -57,14 +57,14 @@ function KpiCards() {
     queryKey: ["cadastros-skus-sem-cadeia", empresa],
     queryFn: async () => {
       const { data: comGrupo, error: e1 } = await supabase
-        .from("sku_grupo_producao" as never)
+        .from("sku_grupo_producao")
         .select("sku_codigo");
       if (e1) return 0;
       const grupoRows = (comGrupo ?? []) as unknown as Array<{ sku_codigo: string | null }>;
       const setComGrupo = new Set(grupoRows.map((r) => r.sku_codigo));
 
       const { data: ativos, error: e2 } = await supabase
-        .from("sku_parametros" as never)
+        .from("sku_parametros")
         .select("sku_codigo")
         .eq("empresa", empresa)
         .eq("ativo", true);
@@ -281,7 +281,7 @@ function HistoricoPedidosCiclos() {
     queryKey: ["historico-ciclos", empresa, de, ate],
     queryFn: async (): Promise<CicloRow[]> => {
       const { data, error } = await supabase
-        .from("pedido_compra_sugerido" as never)
+        .from("pedido_compra_sugerido")
         .select("data_ciclo, fornecedor_grupo, status, valor_total, n_skus")
         .eq("empresa", empresa)
         .gte("data_ciclo", de)

--- a/src/pages/AdminReposicaoGruposProducao.tsx
+++ b/src/pages/AdminReposicaoGruposProducao.tsx
@@ -102,7 +102,7 @@ export default function AdminReposicaoGruposProducao() {
     queryKey: ["fornecedor-grupos", EMPRESA],
     queryFn: async () => {
       const { data, error } = await supabase
-        .from("fornecedor_grupo_producao" as never)
+        .from("fornecedor_grupo_producao")
         .select("*")
         .eq("empresa", EMPRESA)
         .order("fornecedor_nome")
@@ -116,7 +116,7 @@ export default function AdminReposicaoGruposProducao() {
     queryKey: ["sku-grupo-contagens", EMPRESA],
     queryFn: async () => {
       const { data, error } = await supabase
-        .from("sku_grupo_producao" as never)
+        .from("sku_grupo_producao")
         .select("grupo_codigo")
         .eq("empresa", EMPRESA);
       if (error) throw error;
@@ -154,7 +154,7 @@ export default function AdminReposicaoGruposProducao() {
       const assocMap: Record<string, string> = {};
       if (skuCodes.length > 0) {
         const { data: assoc } = await supabase
-          .from("sku_grupo_producao" as never)
+          .from("sku_grupo_producao")
           .select("sku_codigo_omie, grupo_codigo")
           .eq("empresa", EMPRESA)
           .in("sku_codigo_omie", skuCodes);
@@ -232,14 +232,14 @@ export default function AdminReposicaoGruposProducao() {
       }
       if (g.id) {
         const { error } = await supabase
-          .from("fornecedor_grupo_producao" as never)
-          .update(payload as never)
-          .eq("id" as never, g.id as never);
+          .from("fornecedor_grupo_producao")
+          .update(payload)
+          .eq("id", g.id);
         if (error) throw error;
       } else {
         const { error } = await supabase
-          .from("fornecedor_grupo_producao" as never)
-          .insert(payload as never);
+          .from("fornecedor_grupo_producao")
+          .insert(payload);
         if (error) throw error;
       }
     },
@@ -256,21 +256,21 @@ export default function AdminReposicaoGruposProducao() {
       const { sku, novoGrupo } = params;
       if (!novoGrupo) {
         const { error } = await supabase
-          .from("sku_grupo_producao" as never)
+          .from("sku_grupo_producao")
           .delete()
           .eq("empresa", EMPRESA)
           .eq("sku_codigo_omie", String(sku));
         if (error) throw error;
       } else {
         const { error } = await supabase
-          .from("sku_grupo_producao" as never)
+          .from("sku_grupo_producao")
           .upsert(
             {
               empresa: EMPRESA,
               sku_codigo_omie: String(sku),
               grupo_codigo: novoGrupo,
               atualizado_em: new Date().toISOString(),
-            } as never,
+            },
             { onConflict: "empresa,sku_codigo_omie" },
           );
         if (error) throw error;
@@ -294,8 +294,8 @@ export default function AdminReposicaoGruposProducao() {
         atualizado_em: new Date().toISOString(),
       }));
       const { error } = await supabase
-        .from("sku_grupo_producao" as never)
-        .upsert(rows as never, { onConflict: "empresa,sku_codigo_omie" });
+        .from("sku_grupo_producao")
+        .upsert(rows, { onConflict: "empresa,sku_codigo_omie" });
       if (error) throw error;
     },
     onSuccess: async (_, vars) => {

--- a/src/pages/AdminReposicaoNegociacaoParalela.tsx
+++ b/src/pages/AdminReposicaoNegociacaoParalela.tsx
@@ -407,7 +407,7 @@ export default function AdminReposicaoNegociacaoParalela() {
 
   const updateStatus = async (id: number, novoStatus: StatusSugestao, extra: Record<string, unknown> = {}) => {
     const { error } = await supabase
-      .from("sugestao_negociacao_paralela" as never)
+      .from("sugestao_negociacao_paralela")
       .update({ status: novoStatus, ...extra } as never)
       .eq("id", id);
     if (error) {
@@ -508,7 +508,7 @@ export default function AdminReposicaoNegociacaoParalela() {
       const dataGeracao = new Date().toISOString().slice(0, 10);
       const validoAte = new Date();
       validoAte.setDate(validoAte.getDate() + 14);
-      const { error } = await supabase.from("sugestao_negociacao_paralela" as never).insert({
+      const { error } = await supabase.from("sugestao_negociacao_paralela").insert({
         empresa: r.empresa,
         sku_codigo_omie: r.sku_codigo_omie,
         sku_descricao: r.sku_descricao,
@@ -522,7 +522,7 @@ export default function AdminReposicaoNegociacaoParalela() {
         status: "nova",
         data_geracao: dataGeracao,
         valido_ate: validoAte.toISOString().slice(0, 10),
-      } as never);
+      });
       if (error) throw error;
       toast.success(`Sugestão criada para ${r.sku_codigo_omie}.`);
       queryClient.invalidateQueries({ queryKey: ["negociacao-paralela-sugestoes"] });

--- a/src/pages/AdminReposicaoOportunidades.tsx
+++ b/src/pages/AdminReposicaoOportunidades.tsx
@@ -254,7 +254,7 @@ export default function AdminReposicaoOportunidades() {
     queryKey: ["sku-parametros-count", EMPRESA],
     queryFn: async () => {
       const { count, error } = await supabase
-        .from("sku_parametros" as never)
+        .from("sku_parametros")
         .select("*", { count: "exact", head: true })
         .eq("empresa", EMPRESA)
         .eq("ativo", true);
@@ -271,13 +271,13 @@ export default function AdminReposicaoOportunidades() {
 
       const [promo, aumento] = await Promise.all([
         supabase
-          .from("promocao_campanha" as never)
+          .from("promocao_campanha")
           .select("id", { count: "exact", head: true })
           .eq("empresa", EMPRESA)
           .eq("estado", "ativa")
           .eq("data_corte_pedido", today),
         supabase
-          .from("fornecedor_aumento_anunciado" as never)
+          .from("fornecedor_aumento_anunciado")
           .select("id", { count: "exact", head: true })
           .eq("empresa", EMPRESA)
           .in("estado", ["ativo", "vigente"])
@@ -293,7 +293,7 @@ export default function AdminReposicaoOportunidades() {
     queryKey: ["historico-promocoes-count", EMPRESA],
     queryFn: async () => {
       const { data, error } = await supabase
-        .from("promocao_campanha" as never)
+        .from("promocao_campanha")
         .select("data_inicio")
         .eq("empresa", EMPRESA);
       if (error) throw error;


### PR DESCRIPTION
## Summary
Resultado da **auditoria retrospectiva do Codex** sobre os casts `as never` em chamadas Supabase. O Codex achou ~30 `.from('X' as never)` cuja tabela `X` **já existe** no Database type gerado (regenerado após as waves originais) — o cast virou obsoleto e silenciava o type-check real do payload/colunas.

Removidos os casts `as never` de **8 arquivos**, restaurando type-checking real (insert/update/upsert/eq/select agora validados contra o schema):
- `fin_ic_matches` (useIcMatches), `fin_audit_log` (useAuditTrail), `farmer_diagnostic_questions` (useDiagnosticQuestions)
- `fornecedor_grupo_producao`, `sku_grupo_producao` (AdminReposicaoGruposProducao)
- `sku_parametros`, `pedido_compra_sugerido` (AdminReposicaoCadastros)
- `promocao_campanha`, `fornecedor_aumento_anunciado` (AdminReposicaoOportunidades)
- `fornecedor_aumento_anunciado`, `fornecedor_aumento_item` (AdminReposicaoAumentos)
- `sugestao_negociacao_paralela` (AdminReposicaoNegociacaoParalela)

**Mantidos os casts legítimos** (não estão no Database type): RPCs (`.rpc`), views (`v_`/`mv_`/`fila_aplicacao_omie`), e payload dinâmico (`...extra: Record<string,unknown>`).

## Achado real (revertido, tratado à parte)
`RecurringSchedules.Schedule` declara campo `notes` que **não existe** na tabela `recurring_schedules` — campo morto (nunca lido) que o cast mascarava. Arquivo revertido deste PR; correção em tarefa separada.

## Segunda opinião (Codex)
`codex review --uncommitted` (rodou typecheck:strict ele mesmo): *"changes remove unnecessary Supabase `as never` casts now that the tables exist in the generated Database types. The affected strict typecheck passes, and I did not find a runtime regression in the diff."*

## Validação
- `bun run typecheck:strict` — 0 erros
- `bunx tsc --noEmit -p tsconfig.app.json` — 0 erros
- `bun run test` — 13 falhas **pré-existentes** de localStorage (route-tracker/useFinanceiroRegime/useLastVisit), provadas independentes deste diff (idênticas com `git stash`). Nenhum arquivo deste PR é tocado por esses testes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)