### PR TITLE
fix(test): localStorage shim no setup do vitest (baseline 344/344 verde)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ dist-ssr
 .codex/
 AGENTS.md
 
+
+# Serena MCP local project cache
+.serena/

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,5 +1,46 @@
 import "@testing-library/jest-dom";
 
+// Newer Node (22+) ships an experimental global `localStorage` that is
+// non-functional without `--localstorage-file`, and it can shadow jsdom's
+// implementation under vitest. The supabase client references `localStorage`
+// at module top-level, so any test importing it crashes. Install a working
+// in-memory Storage shim whenever the ambient storage is missing OR broken
+// (a `typeof === "undefined"` guard is insufficient: Node's is defined-but-broken).
+function installStorageShim(name: "localStorage" | "sessionStorage") {
+  try {
+    const existing = (globalThis as unknown as Record<string, Storage | undefined>)[name];
+    if (existing) {
+      existing.setItem("__probe__", "1");
+      existing.removeItem("__probe__");
+      return; // already functional — leave it alone
+    }
+  } catch {
+    // fall through and install the shim
+  }
+  const store = new Map<string, string>();
+  const shim: Storage = {
+    get length() {
+      return store.size;
+    },
+    clear: () => store.clear(),
+    getItem: (key) => (store.has(key) ? store.get(key)! : null),
+    key: (index) => Array.from(store.keys())[index] ?? null,
+    removeItem: (key) => {
+      store.delete(key);
+    },
+    setItem: (key, value) => {
+      store.set(key, String(value));
+    },
+  };
+  Object.defineProperty(globalThis, name, {
+    value: shim,
+    writable: true,
+    configurable: true,
+  });
+}
+installStorageShim("localStorage");
+installStorageShim("sessionStorage");
+
 // jsdom doesn't ship WebRTC primitives — polyfill bare-minimum constructors
 // so SipClient tests can `new MediaStream()` without pulling in a heavy mock lib.
 if (typeof globalThis.MediaStream === "undefined") {


### PR DESCRIPTION
## Summary
Conserta o baseline de testes que estava vermelho (13 falhas em 3 arquivos) por causa do `localStorage` experimental do Node 22+, que não funciona sem `--localstorage-file` e sombreia o do jsdom no vitest. Como o supabase client referencia `localStorage` no top-level, qualquer teste que o importa quebrava.

- `src/test/setup.ts`: instala um shim in-memory de `Storage` (localStorage + sessionStorage) quando o ambiente não tem storage funcional. Usa probe por `setItem`/`removeItem` em vez de `typeof === undefined` (o do Node é definido-porém-quebrado). Espelha o padrão já existente em `bun-setup.ts`.
- `.gitignore`: ignora `.serena/` (cache local do Serena MCP).

Arquivos afetados pelas falhas: `route-tracker.test.ts`, `useFinanceiroRegime.test.tsx`, `useLastVisit.test.tsx` — nenhum relacionado a feature, todos de localStorage.

## Test plan
- [x] `bun run test` → **344/344 verde** (antes: 13 failed | 331 passed)
- [x] No-op quando o localStorage já é funcional (CI em Node mais antigo) — só instala o shim se o probe falhar
- [x] Sem mudança de código de produto — apenas test setup + gitignore

🤖 Generated with [Claude Code](https://claude.com/claude-code)