### PR TITLE
fix(test): polyfill localStorage no setup do vitest (main vermelho)

### DIFF
--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,5 +1,33 @@
 import "@testing-library/jest-dom";
 
+// jsdom com origin opaca (about:blank) não expõe localStorage de forma confiável.
+// Testes de hooks/libs que dependem de localStorage (useLastVisit, route-tracker,
+// useFinanceiroRegime) quebram com "Cannot read properties of undefined (reading
+// 'clear')" no beforeEach. Espelha o shim do bun-setup.ts pra garantir localStorage
+// sempre presente, independente de ordem de execução dos arquivos de teste.
+if (typeof globalThis.localStorage === "undefined") {
+  const store = new Map<string, string>();
+  const localStorageShim: Storage = {
+    get length() {
+      return store.size;
+    },
+    clear: () => store.clear(),
+    getItem: (key) => (store.has(key) ? store.get(key)! : null),
+    key: (index) => Array.from(store.keys())[index] ?? null,
+    removeItem: (key) => {
+      store.delete(key);
+    },
+    setItem: (key, value) => {
+      store.set(key, String(value));
+    },
+  };
+  Object.defineProperty(globalThis, "localStorage", {
+    value: localStorageShim,
+    writable: true,
+    configurable: true,
+  });
+}
+
 // jsdom doesn't ship WebRTC primitives — polyfill bare-minimum constructors
 // so SipClient tests can `new MediaStream()` without pulling in a heavy mock lib.
 if (typeof globalThis.MediaStream === "undefined") {


### PR DESCRIPTION
## P0 — main estava vermelho

`bun run test` no main (d490644) tinha **13 testes falhando** em 3 arquivos (`useLastVisit`, `route-tracker`, `useFinanceiroRegime`), todos com:
```
TypeError: Cannot read properties of undefined (reading 'clear')
  → localStorage.clear() no beforeEach
```

Como `bun run test` é gate **bloqueante** no CI, isso travava o auto-merge de **todos os PRs**.

## Root cause

`src/test/setup.ts` (setup do vitest) polifillava MediaStream e matchMedia, mas **não localStorage**. O `bun-setup.ts` (runner nativo bun) tem o polyfill; o do vitest não.

Os PRs paralelos que adicionaram esses testes (`51d6c36` useLastVisit, `8b00e74` route-tracker) passaram no CI isoladamente — na ordem de execução do suite deles, outro arquivo populava `localStorage` global antes. Juntos no main, a ordem mudou e `localStorage` ficou `undefined` no `beforeEach`. **Conflito semântico de merge paralelo** que nenhum CI de PR individual pegou (cada um verde sozinho, vermelho juntos).

## Fix

Espelha o shim de localStorage do `bun-setup.ts` no `setup.ts` do vitest (mesma origem opaca `about:blank` do jsdom não expõe localStorage de forma confiável — mesmo motivo dos polyfills de MediaStream/matchMedia que já existem ali). Garante `localStorage` sempre presente, independente de ordem de execução.

## Test plan

- [x] Antes: `13 failed | 331 passed`
- [x] Depois: `bun run test` → **358 passed (50 files)**
- [x] `bunx tsc --noEmit` — 0 erros
- [x] Diff: +28 linhas, 1 arquivo (test infra apenas)

🤖 Generated with [Claude Code](https://claude.com/claude-code)