### PR TITLE
chore(migrations): refresh audit pra 40 custom migrations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -301,7 +301,9 @@ Dois backends coexistem; o usuário escolhe via toggle em `/settings`:
 - Inventário completo em [`docs/migrations-audit.md`](docs/migrations-audit.md) (38 custom migrations, 262 objetos esperados — tables, indexes, functions, triggers, cron jobs, enum values, RLS policies)
 - Script SQL pronto pra colar no Supabase SQL Editor em [`scripts/audit-custom-migrations.sql`](scripts/audit-custom-migrations.sql) — read-only, retorna duas tabelas: (a) `supabase_migrations.schema_migrations` cross-reference, (b) existência objeto-a-objeto via `pg_catalog`/`information_schema`. Linha com `❌` = precisa apply manual
 - Regenerar quando adicionar migration nova: `bun run audit:migrations` (parser regex em `scripts/audit-custom-migrations.ts`, idempotente)
-- **Audit de 2026-05-19**: 262 objetos checados, 2 gaps (`standard_processes` nunca aplicada + `idx_customer_contacts_birthday` partial). Fechados via `scripts/apply-missing-migrations-2026-05-19.sql` (verificado ok=true). Histórico em `docs/migrations-audit.md`.
+- **Audit de 2026-05-19**: 262 objetos checados, 2 gaps (`standard_processes` nunca aplicada + `idx_customer_contacts_birthday` partial). Fechados via `scripts/apply-missing-migrations-2026-05-19.sql` (verificado ok=true).
+- **Audit de 2026-05-20**: 40 custom migrations / 274 objetos (re-gerado após PRs paralelos). Nova migration `20260520010000_scoring_visit_p1_fixes.sql` — **rodar `scripts/audit-custom-migrations.sql` no Studio pra confirmar apply**.
+- ⚠️ O histórico de auditorias vive aqui (não no `docs/migrations-audit.md`, que é auto-gerado e sobrescrito a cada `bun run audit:migrations`).
 
 ### Convenções de código
 

--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -2,16 +2,6 @@
 
 > Gerado por `scripts/audit-custom-migrations.ts`. Re-rodar quando custom migrations forem adicionadas: `bun scripts/audit-custom-migrations.ts`.
 
-## Histórico de auditorias
-
-| Data | Objetos checados | Gaps `❌` | Remediação |
-| --- | --- | --- | --- |
-| 2026-05-19 | 262 | 2 | `scripts/apply-missing-migrations-2026-05-19.sql` (aplicado, verificado ok=true) |
-
-**Gaps de 2026-05-19 (fechados):**
-1. `standard_processes` (migration `20260517200000`) — tabela inteira nunca aplicada (tabela + 3 índices + 4 RLS policies + 1 trigger).
-2. `idx_customer_contacts_birthday` (migration `20260517220000`) — único objeto faltando (partial-apply; resto da migration OK). App filtra aniversários client-side, então o índice estava sem uso — recriado pro roadmap PR-BIRTHDAYS.
-
 ## Contexto
 
 Per CLAUDE.md §5, **Lovable Cloud NÃO aplica automaticamente** migrations com nome custom (não-UUID) em `supabase/migrations/`. UUID-format (ex: `_868822bb-e38c-4fcf-8879-c64e48bd7630.sql`) são geradas pelo builder visual do Lovable e auto-rodam. Custom (ex: `_user_departments.sql`) ficam no repo mas precisam apply manual via Supabase SQL Editor.
@@ -31,14 +21,14 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **38** custom migrations totais
-- **262** objetos esperados (criados por estas migrations)
+- **40** custom migrations totais
+- **274** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
   - `rls_policy`: 98
-  - `index`: 76
-  - `table`: 41
-  - `trigger`: 27
-  - `function`: 16
+  - `index`: 80
+  - `table`: 43
+  - `trigger`: 29
+  - `function`: 20
   - `enum_value`: 4
 
 ## Inventário por migration
@@ -443,6 +433,21 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | `function` | `public.enqueue_score_recalc_from_call` | — |
 | `trigger` | `public.trg_farmer_calls_enqueue_recalc` | `farmer_calls` |
 
+### `20260518120000_visit_intelligence_v1.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `table` | `public.customer_visit_scores` | — |
+| `table` | `public.visit_score_recalc_queue` | — |
+| `index` | `public.idx_visit_scores_farmer_priority` | `customer_visit_scores` |
+| `index` | `public.idx_visit_scores_farmer_city` | `customer_visit_scores` |
+| `index` | `public.idx_visit_score_queue_pending` | `visit_score_recalc_queue` |
+| `index` | `public.uniq_visit_score_queue_pending` | `visit_score_recalc_queue` |
+| `function` | `public.enqueue_visit_score_recalc_from_visit` | — |
+| `function` | `public.enqueue_visit_score_recalc_from_client_score` | — |
+| `trigger` | `public.trg_route_visits_enqueue_visit_recalc` | `route_visits` |
+| `trigger` | `public.trg_farmer_client_scores_enqueue_visit_recalc` | `farmer_client_scores` |
+
 ### `20260519000000_fin_a1_eventos.sql`
 
 | Tipo | Objeto | Parent |
@@ -490,6 +495,13 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 ### `20260519010000_fin_a1_cron.sql`
 
 > _Nenhum objeto extraído via regex._ Migration provavelmente é `ALTER TABLE` / `UPDATE` / `INSERT` / RLS-only. Validar manualmente.
+
+### `20260520010000_scoring_visit_p1_fixes.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `public.enqueue_visit_score_recalc_from_visit` | — |
+| `function` | `public.enqueue_visit_score_recalc_from_client_score` | — |
 
 ## Próximos passos quando algo der `❌`
 

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 38
+-- Total de custom migrations: 40
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -54,10 +54,12 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260518004300', 'fin_consolidado_v2', '20260518004300_fin_consolidado_v2.sql'),
   ('20260518100000', 'commercial_role_add_values', '20260518100000_commercial_role_add_values.sql'),
   ('20260518110000', 'scoring_v2_signal_modifiers', '20260518110000_scoring_v2_signal_modifiers.sql'),
+  ('20260518120000', 'visit_intelligence_v1', '20260518120000_visit_intelligence_v1.sql'),
   ('20260519000000', 'fin_a1_eventos', '20260519000000_fin_a1_eventos.sql'),
   ('20260519000100', 'fin_a1_snapshots_alertas_config', '20260519000100_fin_a1_snapshots_alertas_config.sql'),
   ('20260519000200', 'fin_a1_audit_lock_attach', '20260519000200_fin_a1_audit_lock_attach.sql'),
-  ('20260519010000', 'fin_a1_cron', '20260519010000_fin_a1_cron.sql')
+  ('20260519010000', 'fin_a1_cron', '20260519010000_fin_a1_cron.sql'),
+  ('20260520010000', 'scoring_visit_p1_fixes', '20260520010000_scoring_visit_p1_fixes.sql')
 )
 SELECT
   e.version,
@@ -309,6 +311,16 @@ WITH expected_objects (migration, kind, schema_name, object_name, parent_name) A
   ('scoring_v2_signal_modifiers', 'index', 'public', 'uniq_score_recalc_queue_pending', 'score_recalc_queue'),
   ('scoring_v2_signal_modifiers', 'function', 'public', 'enqueue_score_recalc_from_call', ''),
   ('scoring_v2_signal_modifiers', 'trigger', 'public', 'trg_farmer_calls_enqueue_recalc', 'farmer_calls'),
+  ('visit_intelligence_v1', 'table', 'public', 'customer_visit_scores', ''),
+  ('visit_intelligence_v1', 'table', 'public', 'visit_score_recalc_queue', ''),
+  ('visit_intelligence_v1', 'index', 'public', 'idx_visit_scores_farmer_priority', 'customer_visit_scores'),
+  ('visit_intelligence_v1', 'index', 'public', 'idx_visit_scores_farmer_city', 'customer_visit_scores'),
+  ('visit_intelligence_v1', 'index', 'public', 'idx_visit_score_queue_pending', 'visit_score_recalc_queue'),
+  ('visit_intelligence_v1', 'index', 'public', 'uniq_visit_score_queue_pending', 'visit_score_recalc_queue'),
+  ('visit_intelligence_v1', 'function', 'public', 'enqueue_visit_score_recalc_from_visit', ''),
+  ('visit_intelligence_v1', 'function', 'public', 'enqueue_visit_score_recalc_from_client_score', ''),
+  ('visit_intelligence_v1', 'trigger', 'public', 'trg_route_visits_enqueue_visit_recalc', 'route_visits'),
+  ('visit_intelligence_v1', 'trigger', 'public', 'trg_farmer_client_scores_enqueue_visit_recalc', 'farmer_client_scores'),
   ('fin_a1_eventos', 'table', 'public', 'fin_eventos_recorrentes', ''),
   ('fin_a1_eventos', 'table', 'public', 'fin_eventos_eventuais', ''),
   ('fin_a1_eventos', 'index', 'public', 'fin_eventos_rec_company_ativo_idx', 'fin_eventos_recorrentes'),
@@ -337,7 +349,9 @@ WITH expected_objects (migration, kind, schema_name, object_name, parent_name) A
   ('fin_a1_audit_lock_attach', 'trigger', 'public', 'trg_audit', 'fin_alertas'),
   ('fin_a1_audit_lock_attach', 'trigger', 'public', 'trg_audit', 'fin_config_cashflow'),
   ('fin_a1_audit_lock_attach', 'trigger', 'public', 'trg_period_lock', 'fin_eventos_recorrentes'),
-  ('fin_a1_audit_lock_attach', 'trigger', 'public', 'trg_period_lock', 'fin_eventos_eventuais')
+  ('fin_a1_audit_lock_attach', 'trigger', 'public', 'trg_period_lock', 'fin_eventos_eventuais'),
+  ('scoring_visit_p1_fixes', 'function', 'public', 'enqueue_visit_score_recalc_from_visit', ''),
+  ('scoring_visit_p1_fixes', 'function', 'public', 'enqueue_visit_score_recalc_from_client_score', '')
 )
 SELECT
   e.migration,


### PR DESCRIPTION
## Summary

Re-gera os artefatos de audit de migrations após PRs paralelos adicionarem novas custom migrations (38 → **40 migrations, 274 objetos**).

- `scripts/audit-custom-migrations.sql` + `docs/migrations-audit.md` regenerados (`bun run audit:migrations`)
- Inclui a nova `20260520010000_scoring_visit_p1_fixes.sql`
- `CLAUDE.md §5`: entrada de audit 2026-05-20 + nota de que o histórico vive no CLAUDE.md (o `docs/migrations-audit.md` é auto-gerado e sobrescrito a cada run — não editar à mão)

## Ação manual pendente (você)

Rodar `scripts/audit-custom-migrations.sql` no Supabase Studio (via Lovable → Backend → Open Supabase) pra confirmar que `scoring_visit_p1_fixes` foi aplicada. Linhas `❌` = precisa apply manual.

## Test plan

- [x] `bun run audit:migrations` gera os 2 artefatos (40 migrations, 274 objetos)
- [x] Doc-only + script de verificação (read-only), sem mudança de runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)