### PR TITLE
fix(dashboard): corrige queries com coluna inexistente (KPIs mortos)

### DIFF
--- a/src/hooks/dashboard/useEstoqueZone.ts
+++ b/src/hooks/dashboard/useEstoqueZone.ts
@@ -36,12 +36,12 @@ export function useEstoqueZone() {
       try {
         const { data: nf } = await supabase
           .from('nfe_recebimentos')
-          .select('id, fornecedor_nome, created_at, status')
+          .select('id, razao_social_emitente, created_at, status')
           .eq('status', 'pendente');
         if (nf) {
           const rows = nf as unknown as Array<{
             id: string;
-            fornecedor_nome?: string | null;
+            razao_social_emitente?: string | null;
             created_at: string;
             status?: string | null;
           }>;
@@ -51,7 +51,7 @@ export function useEstoqueZone() {
             topItems.push({
               id: r.id,
               icon: FileCheck,
-              title: r.fornecedor_nome ?? 'Fornecedor',
+              title: r.razao_social_emitente ?? 'Fornecedor',
               subtitle: 'NF aguardando conferência',
               path: `/admin/estoque/recebimento`,
               itemType: 'nfe_pendente',

--- a/src/pages/AdminReposicaoCadastros.tsx
+++ b/src/pages/AdminReposicaoCadastros.tsx
@@ -58,20 +58,21 @@ function KpiCards() {
     queryFn: async () => {
       const { data: comGrupo, error: e1 } = await supabase
         .from("sku_grupo_producao")
-        .select("sku_codigo");
+        .select("sku_codigo_omie")
+        .eq("empresa", empresa);
       if (e1) return 0;
-      const grupoRows = (comGrupo ?? []) as unknown as Array<{ sku_codigo: string | null }>;
-      const setComGrupo = new Set(grupoRows.map((r) => r.sku_codigo));
+      const grupoRows = (comGrupo ?? []) as unknown as Array<{ sku_codigo_omie: string | number | null }>;
+      const setComGrupo = new Set(grupoRows.map((r) => String(r.sku_codigo_omie)));
 
       const { data: ativos, error: e2 } = await supabase
         .from("sku_parametros")
-        .select("sku_codigo")
+        .select("sku_codigo_omie")
         .eq("empresa", empresa)
         .eq("ativo", true);
       if (e2) return 0;
 
-      const ativosRows = (ativos ?? []) as unknown as Array<{ sku_codigo: string | null }>;
-      return ativosRows.filter((r) => !setComGrupo.has(r.sku_codigo)).length;
+      const ativosRows = (ativos ?? []) as unknown as Array<{ sku_codigo_omie: string | number | null }>;
+      return ativosRows.filter((r) => !setComGrupo.has(String(r.sku_codigo_omie))).length;
     },
     refetchInterval: 60000,
     staleTime: 30000,


### PR DESCRIPTION
## Summary
A **auditoria retrospectiva do Codex** sobre os casts `as unknown as` revelou que vários cockpits faziam `.select('coluna')` de **colunas que não existem no schema** — o PostgREST retorna 400, o código ignora o `error`, e os KPIs/alertas ficavam **permanentemente zerados**. O `as unknown as` no resultado escondia o `SelectQueryError` do compilador.

### Fixes de alta confiança (este PR)
- **useEstoqueZone**: `nfe_recebimentos.fornecedor_nome` → `razao_social_emitente`. Restaura o KPI "NF pendentes" e o alerta ">24h" (priority score 92) — que **nunca disparavam** (query 400 → `nf` null → contadores 0).
- **AdminReposicaoCadastros** (count "SKUs sem cadeia"): `sku_codigo` → `sku_codigo_omie` em `sku_grupo_producao` e `sku_parametros`. Normaliza comparação com `String()` (robusto a string/number) e adiciona `.eq("empresa", empresa)` no `setComGrupo`.

### Catch do Codex review (P2, corrigido antes do merge)
Sem o `.eq("empresa")` no `setComGrupo`, SKUs mapeados em **outra empresa** contavam como mapeados na empresa atual → subcontava "SKUs sem cadeia". 1ª rodada do codex review pegou; corrigido; 2ª rodada limpa.

### Flagged p/ decisão de schema (NÃO neste PR — já estavam mortos, sem regressão)
Tarefa separada criada para:
1. `picking_tasks` FEFO (useEstoqueZone) — tabela sem `validade`/`sku_descricao` (tabela errada? schema faltando?)
2. `eventos_outlier` (useReposicaoZone) — `descricao`→`sku_descricao`?, `created_at`→`detectado_em`
3. `pedido_compra_sugerido` (AdminReposicaoCadastros) — `fornecedor_grupo`/`valor_total`/`n_skus` (3 colunas erradas)

## Validação
- `bun run typecheck:strict` — 0 erros
- `bunx tsc --noEmit -p tsconfig.app.json` — 0 erros
- `bun run test` — 392/392
- `codex review` — 2 rodadas (P2 corrigido, 2ª limpa)

> ⚠️ **QA recomendado em produção**: estes KPIs voltam a buscar dados reais — confirmar que o cockpit de Estoque mostra NF pendentes/>24h e o count "SKUs sem cadeia" da Reposição reflete a realidade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)