### PR TITLE
refactor(reposicao): extrai ItensTab de AdminReposicaoPromocaoDetail (1205→914)

### DIFF
--- a/src/components/reposicao/promocaoDetail/ItensTab.tsx
+++ b/src/components/reposicao/promocaoDetail/ItensTab.tsx
@@ -1,0 +1,325 @@
+// Aba "Itens da campanha": tabela de itens (com edição inline + células de
+// mapeamento/desconto extra) + formulário de adicionar item.
+// Extraída de src/pages/AdminReposicaoPromocaoDetail.tsx (god-component split).
+//
+// O estado de adicionar-item (novo*) e o handleAddItem são 100% locais a esta
+// aba, então vivem aqui. As mutations de linha (update/delete) ficam no parent
+// e chegam via callbacks onUpdateItem/onDeleteItem — comportamento idêntico ao
+// original.
+import { useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { supabase } from "@/integrations/supabase/client";
+import { toast } from "sonner";
+import { Loader2, Plus, Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { MapeamentoStatusCell } from "./MapeamentoStatusCell";
+import { DescontoExtraCell } from "./DescontoExtraCell";
+import type { ItemRow } from "./types";
+
+export function ItensTab({
+  campanhaId,
+  itens,
+  efetivoMap,
+  loadingItens,
+  userEmail,
+  onUpdateItem,
+  onDeleteItem,
+}: {
+  campanhaId: string;
+  itens: ItemRow[];
+  efetivoMap: Record<number, number>;
+  loadingItens: boolean;
+  userEmail: string;
+  onUpdateItem: (itemId: number, changes: Partial<ItemRow>) => void;
+  onDeleteItem: (itemId: number) => void;
+}) {
+  const qc = useQueryClient();
+  const [addingItem, setAddingItem] = useState(false);
+  const [novoCodFornecedor, setNovoCodFornecedor] = useState("");
+  const [novoDesconto, setNovoDesconto] = useState("");
+  const [novoVolume, setNovoVolume] = useState("");
+  const [savingNovoItem, setSavingNovoItem] = useState(false);
+
+  const handleAddItem = async () => {
+    if (!novoCodFornecedor.trim() || !novoDesconto.trim()) {
+      toast.error("Código e desconto obrigatórios");
+      return;
+    }
+    const desc = parseFloat(novoDesconto);
+    if (isNaN(desc) || desc <= 0 || desc > 100) {
+      toast.error("Desconto deve ser entre 0 e 100%");
+      return;
+    }
+    const vol = novoVolume.trim() ? parseFloat(novoVolume) : null;
+
+    setSavingNovoItem(true);
+    try {
+      const { data: inserted, error: insertErr } = await supabase
+        .from("promocao_item")
+        .insert({
+          campanha_id: Number(campanhaId),
+          sku_codigo_fornecedor: novoCodFornecedor.trim(),
+          desconto_perc: desc,
+          volume_minimo: vol,
+          ativo: true,
+          confirmado: false,
+        })
+        .select("id")
+        .single();
+      if (insertErr) throw insertErr;
+
+      const novoId = (inserted as { id: number }).id;
+      // Chama RPC de expansão
+      const { error: rpcErr } = await supabase.rpc(
+        "expandir_promocao_item" as never,
+        { p_item_id: novoId } as never,
+      );
+      if (rpcErr) throw rpcErr;
+
+      toast.success("Item adicionado");
+      setAddingItem(false);
+      setNovoCodFornecedor("");
+      setNovoDesconto("");
+      setNovoVolume("");
+      qc.invalidateQueries({ queryKey: ["promocao-itens", campanhaId] });
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Erro ao adicionar item");
+    } finally {
+      setSavingNovoItem(false);
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between">
+        <CardTitle className="text-base">
+          Itens da campanha
+        </CardTitle>
+        <Button
+          size="sm"
+          onClick={() => setAddingItem(true)}
+          disabled={addingItem}
+        >
+          <Plus className="h-4 w-4" /> Adicionar item
+        </Button>
+      </CardHeader>
+      <CardContent>
+        {loadingItens ? (
+          <div className="flex items-center gap-2 text-sm text-muted-foreground py-6">
+            <Loader2 className="h-4 w-4 animate-spin" /> Carregando…
+          </div>
+        ) : (
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Cód. fornecedor</TableHead>
+                  <TableHead>Descrição</TableHead>
+                  <TableHead className="text-right">Desc.%</TableHead>
+                  <TableHead>Extra</TableHead>
+                  <TableHead className="text-right">
+                    Vol. mín.
+                  </TableHead>
+                  <TableHead>SKU Omie</TableHead>
+                  <TableHead className="w-12"></TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {itens.length === 0 && !addingItem && (
+                  <TableRow>
+                    <TableCell
+                      colSpan={7}
+                      className="text-center text-muted-foreground py-8"
+                    >
+                      Nenhum item nesta campanha.
+                    </TableCell>
+                  </TableRow>
+                )}
+                {itens.map((item) => {
+                  const efetivo = efetivoMap[item.id];
+                  return (
+                    <TableRow key={item.id}>
+                      <TableCell>
+                        {item.confirmado ? (
+                          <span className="font-mono text-sm">
+                            {item.sku_codigo_fornecedor}
+                          </span>
+                        ) : (
+                          <Input
+                            className="h-8 font-mono text-sm"
+                            defaultValue={item.sku_codigo_fornecedor}
+                            onBlur={(e) => {
+                              if (
+                                e.target.value !==
+                                item.sku_codigo_fornecedor
+                              ) {
+                                onUpdateItem(item.id, {
+                                  sku_codigo_fornecedor: e.target.value,
+                                });
+                              }
+                            }}
+                          />
+                        )}
+                      </TableCell>
+                      <TableCell className="text-sm text-muted-foreground max-w-xs truncate">
+                        {item.descricao_produto_fornecedor || "—"}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        <Input
+                          type="number"
+                          step="0.1"
+                          className="h-8 w-20 text-right tabular-nums"
+                          defaultValue={item.desconto_perc}
+                          onBlur={(e) => {
+                            const v = parseFloat(e.target.value);
+                            if (!isNaN(v) && v !== item.desconto_perc) {
+                              onUpdateItem(item.id, { desconto_perc: v });
+                            }
+                          }}
+                        />
+                      </TableCell>
+                      <TableCell>
+                        <div className="flex flex-col gap-0.5">
+                          <DescontoExtraCell
+                            item={item}
+                            userEmail={userEmail}
+                            onSave={(changes) =>
+                              onUpdateItem(item.id, changes)
+                            }
+                          />
+                          {efetivo !== undefined && (
+                            <span className="text-[10px] text-muted-foreground">
+                              Efetivo: {efetivo}%
+                            </span>
+                          )}
+                        </div>
+                      </TableCell>
+                      <TableCell className="text-right">
+                        <Input
+                          type="number"
+                          step="1"
+                          className="h-8 w-20 text-right tabular-nums"
+                          defaultValue={item.volume_minimo ?? ""}
+                          placeholder="—"
+                          onBlur={(e) => {
+                            const v = e.target.value.trim()
+                              ? parseFloat(e.target.value)
+                              : null;
+                            if (v !== item.volume_minimo) {
+                              onUpdateItem(item.id, { volume_minimo: v });
+                            }
+                          }}
+                        />
+                      </TableCell>
+                      <TableCell>
+                        <MapeamentoStatusCell
+                          item={item}
+                          onUpdate={(changes) =>
+                            onUpdateItem(item.id, changes)
+                          }
+                        />
+                      </TableCell>
+                      <TableCell>
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          onClick={() => {
+                            if (confirm("Remover este item?")) {
+                              onDeleteItem(item.id);
+                            }
+                          }}
+                        >
+                          <Trash2 className="h-4 w-4 text-destructive" />
+                        </Button>
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+                {addingItem && (
+                  <TableRow className="bg-accent/30">
+                    <TableCell>
+                      <Input
+                        className="h-8 font-mono text-sm"
+                        placeholder="DR.4403"
+                        value={novoCodFornecedor}
+                        onChange={(e) =>
+                          setNovoCodFornecedor(e.target.value)
+                        }
+                        autoFocus
+                      />
+                    </TableCell>
+                    <TableCell className="text-xs text-muted-foreground">
+                      (auto)
+                    </TableCell>
+                    <TableCell>
+                      <Input
+                        type="number"
+                        step="0.1"
+                        className="h-8 w-20 text-right"
+                        placeholder="20"
+                        value={novoDesconto}
+                        onChange={(e) =>
+                          setNovoDesconto(e.target.value)
+                        }
+                      />
+                    </TableCell>
+                    <TableCell></TableCell>
+                    <TableCell>
+                      <Input
+                        type="number"
+                        step="1"
+                        className="h-8 w-20 text-right"
+                        placeholder="—"
+                        value={novoVolume}
+                        onChange={(e) =>
+                          setNovoVolume(e.target.value)
+                        }
+                      />
+                    </TableCell>
+                    <TableCell colSpan={2}>
+                      <div className="flex gap-1 justify-end">
+                        <Button
+                          size="sm"
+                          onClick={handleAddItem}
+                          disabled={savingNovoItem}
+                        >
+                          {savingNovoItem && (
+                            <Loader2 className="h-3 w-3 animate-spin" />
+                          )}
+                          Salvar
+                        </Button>
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          onClick={() => {
+                            setAddingItem(false);
+                            setNovoCodFornecedor("");
+                            setNovoDesconto("");
+                            setNovoVolume("");
+                          }}
+                          disabled={savingNovoItem}
+                        >
+                          Cancelar
+                        </Button>
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/reposicao/promocaoDetail/ItensTab.tsx
+++ b/src/components/reposicao/promocaoDetail/ItensTab.tsx
@@ -35,7 +35,7 @@ export function ItensTab({
   onUpdateItem,
   onDeleteItem,
 }: {
-  campanhaId: string;
+  campanhaId: string | undefined;
   itens: ItemRow[];
   efetivoMap: Record<number, number>;
   loadingItens: boolean;

--- a/src/pages/AdminReposicaoPromocaoDetail.tsx
+++ b/src/pages/AdminReposicaoPromocaoDetail.tsx
@@ -12,7 +12,6 @@ import {
   ExternalLink,
   Mail,
   Plus,
-  Trash2,
   Check,
   X,
   Sparkles,
@@ -29,14 +28,6 @@ import {
   TabsList,
   TabsTrigger,
 } from "@/components/ui/tabs";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
 import {
   Select,
   SelectContent,
@@ -85,8 +76,7 @@ import {
   formatDateTimeBR,
   formatRelative,
 } from "@/components/reposicao/promocaoDetail/helpers";
-import { MapeamentoStatusCell } from "@/components/reposicao/promocaoDetail/MapeamentoStatusCell";
-import { DescontoExtraCell } from "@/components/reposicao/promocaoDetail/DescontoExtraCell";
+import { ItensTab } from "@/components/reposicao/promocaoDetail/ItensTab";
 
 // ========== PÁGINA PRINCIPAL ==========
 export default function AdminReposicaoPromocaoDetail() {
@@ -325,61 +315,6 @@ export default function AdminReposicaoPromocaoDetail() {
   });
 
   // ============ ADD ITEM (inline row) ============
-  const [addingItem, setAddingItem] = useState(false);
-  const [novoCodFornecedor, setNovoCodFornecedor] = useState("");
-  const [novoDesconto, setNovoDesconto] = useState("");
-  const [novoVolume, setNovoVolume] = useState("");
-  const [savingNovoItem, setSavingNovoItem] = useState(false);
-
-  const handleAddItem = async () => {
-    if (!novoCodFornecedor.trim() || !novoDesconto.trim()) {
-      toast.error("Código e desconto obrigatórios");
-      return;
-    }
-    const desc = parseFloat(novoDesconto);
-    if (isNaN(desc) || desc <= 0 || desc > 100) {
-      toast.error("Desconto deve ser entre 0 e 100%");
-      return;
-    }
-    const vol = novoVolume.trim() ? parseFloat(novoVolume) : null;
-
-    setSavingNovoItem(true);
-    try {
-      const { data: inserted, error: insertErr } = await supabase
-        .from("promocao_item")
-        .insert({
-          campanha_id: Number(id),
-          sku_codigo_fornecedor: novoCodFornecedor.trim(),
-          desconto_perc: desc,
-          volume_minimo: vol,
-          ativo: true,
-          confirmado: false,
-        })
-        .select("id")
-        .single();
-      if (insertErr) throw insertErr;
-
-      const novoId = (inserted as { id: number }).id;
-      // Chama RPC de expansão
-      const { error: rpcErr } = await supabase.rpc(
-        "expandir_promocao_item" as never,
-        { p_item_id: novoId } as never,
-      );
-      if (rpcErr) throw rpcErr;
-
-      toast.success("Item adicionado");
-      setAddingItem(false);
-      setNovoCodFornecedor("");
-      setNovoDesconto("");
-      setNovoVolume("");
-      qc.invalidateQueries({ queryKey: ["promocao-itens", id] });
-    } catch (e) {
-      toast.error(e instanceof Error ? e.message : "Erro ao adicionar item");
-    } finally {
-      setSavingNovoItem(false);
-    }
-  };
-
   // ============ EVENTO MODAL ============
   const [eventoOpen, setEventoOpen] = useState(false);
   const [novoEvento, setNovoEvento] = useState({
@@ -647,243 +582,17 @@ export default function AdminReposicaoPromocaoDetail() {
 
             {/* ========== TAB ITENS ========== */}
             <TabsContent value="itens" className="space-y-4">
-              <Card>
-                <CardHeader className="flex flex-row items-center justify-between">
-                  <CardTitle className="text-base">
-                    Itens da campanha
-                  </CardTitle>
-                  <Button
-                    size="sm"
-                    onClick={() => setAddingItem(true)}
-                    disabled={addingItem}
-                  >
-                    <Plus className="h-4 w-4" /> Adicionar item
-                  </Button>
-                </CardHeader>
-                <CardContent>
-                  {loadingItens ? (
-                    <div className="flex items-center gap-2 text-sm text-muted-foreground py-6">
-                      <Loader2 className="h-4 w-4 animate-spin" /> Carregando…
-                    </div>
-                  ) : (
-                    <div className="overflow-x-auto">
-                      <Table>
-                        <TableHeader>
-                          <TableRow>
-                            <TableHead>Cód. fornecedor</TableHead>
-                            <TableHead>Descrição</TableHead>
-                            <TableHead className="text-right">Desc.%</TableHead>
-                            <TableHead>Extra</TableHead>
-                            <TableHead className="text-right">
-                              Vol. mín.
-                            </TableHead>
-                            <TableHead>SKU Omie</TableHead>
-                            <TableHead className="w-12"></TableHead>
-                          </TableRow>
-                        </TableHeader>
-                        <TableBody>
-                          {itens.length === 0 && !addingItem && (
-                            <TableRow>
-                              <TableCell
-                                colSpan={7}
-                                className="text-center text-muted-foreground py-8"
-                              >
-                                Nenhum item nesta campanha.
-                              </TableCell>
-                            </TableRow>
-                          )}
-                          {itens.map((item) => {
-                            const efetivo = efetivoMap[item.id];
-                            return (
-                              <TableRow key={item.id}>
-                                <TableCell>
-                                  {item.confirmado ? (
-                                    <span className="font-mono text-sm">
-                                      {item.sku_codigo_fornecedor}
-                                    </span>
-                                  ) : (
-                                    <Input
-                                      className="h-8 font-mono text-sm"
-                                      defaultValue={item.sku_codigo_fornecedor}
-                                      onBlur={(e) => {
-                                        if (
-                                          e.target.value !==
-                                          item.sku_codigo_fornecedor
-                                        ) {
-                                          updateItemMut.mutate({
-                                            itemId: item.id,
-                                            changes: {
-                                              sku_codigo_fornecedor:
-                                                e.target.value,
-                                            },
-                                          });
-                                        }
-                                      }}
-                                    />
-                                  )}
-                                </TableCell>
-                                <TableCell className="text-sm text-muted-foreground max-w-xs truncate">
-                                  {item.descricao_produto_fornecedor || "—"}
-                                </TableCell>
-                                <TableCell className="text-right">
-                                  <Input
-                                    type="number"
-                                    step="0.1"
-                                    className="h-8 w-20 text-right tabular-nums"
-                                    defaultValue={item.desconto_perc}
-                                    onBlur={(e) => {
-                                      const v = parseFloat(e.target.value);
-                                      if (!isNaN(v) && v !== item.desconto_perc) {
-                                        updateItemMut.mutate({
-                                          itemId: item.id,
-                                          changes: { desconto_perc: v },
-                                        });
-                                      }
-                                    }}
-                                  />
-                                </TableCell>
-                                <TableCell>
-                                  <div className="flex flex-col gap-0.5">
-                                    <DescontoExtraCell
-                                      item={item}
-                                      userEmail={userEmail}
-                                      onSave={(changes) =>
-                                        updateItemMut.mutate({
-                                          itemId: item.id,
-                                          changes,
-                                        })
-                                      }
-                                    />
-                                    {efetivo !== undefined && (
-                                      <span className="text-[10px] text-muted-foreground">
-                                        Efetivo: {efetivo}%
-                                      </span>
-                                    )}
-                                  </div>
-                                </TableCell>
-                                <TableCell className="text-right">
-                                  <Input
-                                    type="number"
-                                    step="1"
-                                    className="h-8 w-20 text-right tabular-nums"
-                                    defaultValue={item.volume_minimo ?? ""}
-                                    placeholder="—"
-                                    onBlur={(e) => {
-                                      const v = e.target.value.trim()
-                                        ? parseFloat(e.target.value)
-                                        : null;
-                                      if (v !== item.volume_minimo) {
-                                        updateItemMut.mutate({
-                                          itemId: item.id,
-                                          changes: { volume_minimo: v },
-                                        });
-                                      }
-                                    }}
-                                  />
-                                </TableCell>
-                                <TableCell>
-                                  <MapeamentoStatusCell
-                                    item={item}
-                                    onUpdate={(changes) =>
-                                      updateItemMut.mutate({
-                                        itemId: item.id,
-                                        changes,
-                                      })
-                                    }
-                                  />
-                                </TableCell>
-                                <TableCell>
-                                  <Button
-                                    size="sm"
-                                    variant="ghost"
-                                    onClick={() => {
-                                      if (confirm("Remover este item?")) {
-                                        deleteItemMut.mutate(item.id);
-                                      }
-                                    }}
-                                  >
-                                    <Trash2 className="h-4 w-4 text-destructive" />
-                                  </Button>
-                                </TableCell>
-                              </TableRow>
-                            );
-                          })}
-                          {addingItem && (
-                            <TableRow className="bg-accent/30">
-                              <TableCell>
-                                <Input
-                                  className="h-8 font-mono text-sm"
-                                  placeholder="DR.4403"
-                                  value={novoCodFornecedor}
-                                  onChange={(e) =>
-                                    setNovoCodFornecedor(e.target.value)
-                                  }
-                                  autoFocus
-                                />
-                              </TableCell>
-                              <TableCell className="text-xs text-muted-foreground">
-                                (auto)
-                              </TableCell>
-                              <TableCell>
-                                <Input
-                                  type="number"
-                                  step="0.1"
-                                  className="h-8 w-20 text-right"
-                                  placeholder="20"
-                                  value={novoDesconto}
-                                  onChange={(e) =>
-                                    setNovoDesconto(e.target.value)
-                                  }
-                                />
-                              </TableCell>
-                              <TableCell></TableCell>
-                              <TableCell>
-                                <Input
-                                  type="number"
-                                  step="1"
-                                  className="h-8 w-20 text-right"
-                                  placeholder="—"
-                                  value={novoVolume}
-                                  onChange={(e) =>
-                                    setNovoVolume(e.target.value)
-                                  }
-                                />
-                              </TableCell>
-                              <TableCell colSpan={2}>
-                                <div className="flex gap-1 justify-end">
-                                  <Button
-                                    size="sm"
-                                    onClick={handleAddItem}
-                                    disabled={savingNovoItem}
-                                  >
-                                    {savingNovoItem && (
-                                      <Loader2 className="h-3 w-3 animate-spin" />
-                                    )}
-                                    Salvar
-                                  </Button>
-                                  <Button
-                                    size="sm"
-                                    variant="ghost"
-                                    onClick={() => {
-                                      setAddingItem(false);
-                                      setNovoCodFornecedor("");
-                                      setNovoDesconto("");
-                                      setNovoVolume("");
-                                    }}
-                                    disabled={savingNovoItem}
-                                  >
-                                    Cancelar
-                                  </Button>
-                                </div>
-                              </TableCell>
-                            </TableRow>
-                          )}
-                        </TableBody>
-                      </Table>
-                    </div>
-                  )}
-                </CardContent>
-              </Card>
+              <ItensTab
+                campanhaId={id ?? ""}
+                itens={itens}
+                efetivoMap={efetivoMap}
+                loadingItens={loadingItens}
+                userEmail={userEmail}
+                onUpdateItem={(itemId, changes) =>
+                  updateItemMut.mutate({ itemId, changes })
+                }
+                onDeleteItem={(itemId) => deleteItemMut.mutate(itemId)}
+              />
             </TabsContent>
 
             {/* ========== TAB NEGOCIAÇÃO ========== */}

--- a/src/pages/AdminReposicaoPromocaoDetail.tsx
+++ b/src/pages/AdminReposicaoPromocaoDetail.tsx
@@ -583,7 +583,7 @@ export default function AdminReposicaoPromocaoDetail() {
             {/* ========== TAB ITENS ========== */}
             <TabsContent value="itens" className="space-y-4">
               <ItensTab
-                campanhaId={id ?? ""}
+                campanhaId={id}
                 itens={itens}
                 efetivoMap={efetivoMap}
                 loadingItens={loadingItens}

--- a/tsconfig.strict.json
+++ b/tsconfig.strict.json
@@ -349,6 +349,7 @@
     "src/hooks/useUnreadMessages.ts",
     "src/hooks/useUploadKbDocument.ts",
     "src/hooks/useUrlState.ts",
-    "src/queries/useUserTools.ts"
+    "src/queries/useUserTools.ts",
+    "src/components/reposicao/promocaoDetail/ItensTab.tsx"
   ]
 }


### PR DESCRIPTION
## Summary

Segundo corte do god-component #1 da Reposição. Extrai a aba **"Itens da campanha"** (tabela com edição inline + add-item form) pra `ItensTab.tsx`. Página: **1205 → 914 LoC (-291)**, aproximando do alvo 500-800 do Codex.

## Boundary (zero mudança de comportamento)

- Estado de adicionar-item (`addingItem`, `novo*`, `savingNovoItem`) + `handleAddItem` são 100% locais à aba → movidos pra dentro do `ItensTab`. Mesma lógica (insert + RPC `expandir_promocao_item` + invalidate com a **mesma query key** `["promocao-itens", campanhaId]`).
- Mutations de linha (update/delete) ficam no parent (compartilhadas com a query) e chegam via callbacks `onUpdateItem`/`onDeleteItem` — zero mudança de data-flow.
- Parent limpa 8 imports órfãos (Table*, Trash2, células que agora só o ItensTab usa).
- `ItensTab` entra no `tsconfig.strict.json` (332).

## Codex review (gate de refactor)

Rodado `codex review` no diff. Pegou **1 [P2]**: `campanhaId={id ?? ""}` mudava o edge-case de `id` undefined (`Number("")=0` vs `NaN`; key `["...",""]` vs `[...,undefined]`). **Corrigido** (commit `6a152aa`): `campanhaId` agora é `string | undefined`, parent passa `id` direto → edge-case idêntico ao original. Codex confirmou que update/delete handlers, callbacks das células e add-item state estão equivalentes.

## Test plan

- [x] `bun run typecheck:strict` — 0 erros
- [x] `bunx tsc --noEmit` — 0 erros
- [x] `bunx eslint` — 0 unused / 0 errors
- [x] `bun run build` — OK
- [x] `bun run test` — 358/358 passando
- [x] **codex review** — 1 P2 endereçado, sem P1

🤖 Generated with [Claude Code](https://claude.com/claude-code)