### PR TITLE
fix(dashboard): 3 queries com colunas inexistentes que zeravam KPIs/alertas

### DIFF
--- a/src/hooks/dashboard/useEstoqueZone.ts
+++ b/src/hooks/dashboard/useEstoqueZone.ts
@@ -72,24 +72,25 @@ export function useEstoqueZone() {
       try {
         const today = new Date();
         today.setDate(today.getDate() + 7);
+        // FEFO mora em picking_task_items (validade_fefo/product_descricao), não em picking_tasks.
         const { data: fefo } = await supabase
-          .from('picking_tasks')
-          .select('id, sku_descricao, validade')
-          .eq('status', 'pendente')
-          .not('validade', 'is', null)
-          .lt('validade', today.toISOString());
+          .from('picking_task_items')
+          .select('id, product_descricao, validade_fefo')
+          .in('status', ['pendente', 'em_andamento'])
+          .not('validade_fefo', 'is', null)
+          .lt('validade_fefo', today.toISOString());
         if (fefo) {
-          const rows = fefo as unknown as Array<{
+          const rows = fefo as Array<{
             id: string;
-            sku_descricao?: string | null;
-            validade?: string | null;
+            product_descricao: string | null;
+            validade_fefo: string | null;
           }>;
           pickingFefoVencendo = rows.length;
           for (const t of rows.slice(0, 1)) {
             topItems.push({
               id: t.id,
               icon: Package,
-              title: t.sku_descricao ?? 'Item',
+              title: t.product_descricao ?? 'Item',
               subtitle: 'Picking com validade próxima',
               path: `/admin/estoque/picking`,
               itemType: 'picking_fefo_vencendo',

--- a/src/hooks/dashboard/useReposicaoZone.ts
+++ b/src/hooks/dashboard/useReposicaoZone.ts
@@ -40,21 +40,21 @@ export function useReposicaoZone() {
       try {
         const { data: alerts, count } = await supabase
           .from('eventos_outlier')
-          .select('id, tipo, descricao, severidade', { count: 'exact' })
-          .order('created_at', { ascending: false })
+          .select('id, tipo, sku_descricao, severidade', { count: 'exact' })
+          .order('detectado_em', { ascending: false, nullsFirst: false })
           .limit(5);
         alertasAtivos = count ?? 0;
         if (alerts) {
-          const rows = alerts as unknown as Array<{
-            id: string;
-            tipo?: string | null;
-            descricao?: string | null;
-            severidade?: string | null;
+          const rows = alerts as Array<{
+            id: number;
+            tipo: string;
+            sku_descricao: string | null;
+            severidade: string;
           }>;
           topItems = rows.slice(0, 3).map((a) => ({
-            id: a.id,
+            id: String(a.id),
             icon: AlertTriangle,
-            title: a.descricao ?? a.tipo ?? 'Alerta',
+            title: a.sku_descricao ?? a.tipo ?? 'Alerta',
             subtitle: `Severidade ${a.severidade ?? 'média'}`,
             path: '/admin/reposicao/sessao',
             itemType: 'outlier_event',

--- a/src/pages/AdminReposicaoCadastros.tsx
+++ b/src/pages/AdminReposicaoCadastros.tsx
@@ -252,10 +252,10 @@ export default function AdminReposicaoCadastros() {
 /* ─── Histórico de Pedidos por Ciclo ─── */
 type CicloRow = {
   data_ciclo: string;
-  fornecedor_grupo: string | null;
+  fornecedor_nome: string | null;
   status: string | null;
   valor_total: number | null;
-  n_skus: number | null;
+  num_skus: number | null;
 };
 
 function statusVariant(status: string | null): "success" | "warning" | "destructive" | "secondary" {
@@ -283,14 +283,14 @@ function HistoricoPedidosCiclos() {
     queryFn: async (): Promise<CicloRow[]> => {
       const { data, error } = await supabase
         .from("pedido_compra_sugerido")
-        .select("data_ciclo, fornecedor_grupo, status, valor_total, n_skus")
+        .select("data_ciclo, fornecedor_nome, status, valor_total, num_skus")
         .eq("empresa", empresa)
         .gte("data_ciclo", de)
         .lte("data_ciclo", ate)
         .order("data_ciclo", { ascending: false })
         .limit(2000);
       if (error) return [];
-      return (data ?? []) as unknown as CicloRow[];
+      return (data ?? []) as CicloRow[];
     },
     staleTime: 30000,
   });
@@ -355,15 +355,15 @@ function HistoricoPedidosCiclos() {
                 </TableHeader>
                 <TableBody>
                   {pageRows.map((r, i) => (
-                    <TableRow key={`${r.data_ciclo}-${r.fornecedor_grupo}-${i}`}>
+                    <TableRow key={`${r.data_ciclo}-${r.fornecedor_nome}-${i}`}>
                       <TableCell className="font-mono text-xs">
                         {r.data_ciclo ? new Date(r.data_ciclo).toLocaleDateString("pt-BR") : "—"}
                       </TableCell>
-                      <TableCell>{r.fornecedor_grupo ?? "—"}</TableCell>
+                      <TableCell>{r.fornecedor_nome ?? "—"}</TableCell>
                       <TableCell>
                         <Badge variant={statusVariant(r.status)}>{r.status ?? "—"}</Badge>
                       </TableCell>
-                      <TableCell className="text-right">{r.n_skus ?? 0}</TableCell>
+                      <TableCell className="text-right">{r.num_skus ?? 0}</TableCell>
                       <TableCell className="text-right">
                         {(r.valor_total ?? 0).toLocaleString("pt-BR", {
                           style: "currency",


### PR DESCRIPTION
## Contexto

Auditoria retrospectiva (Codex) sobre casts `as unknown as` achou 3 queries Supabase que selecionavam **colunas que não existem no schema**. O PostgREST retornava `400 (42703 column does not exist)`, o `try/catch` engolia o erro, e os KPIs/alertas ficavam **permanentemente zerados**. O cast `as unknown as X` escondia o `SelectQueryError` do compilador.

Complementa o PR #141 (que corrigiu `nfe_recebimentos.razao_social_emitente` + o KPI "SKUs sem cadeia"). Estas são as 3 que **não** foram cobertas lá.

## Fixes

1. **`useEstoqueZone` (alerta FEFO vencendo, score 85)** — `picking_tasks` **não tem** `sku_descricao` nem `validade`. Os dados de validade do lote moram em **`picking_task_items`** (`validade_fefo`, `product_descricao`, FK `picking_task_id`). Repontado pra tabela certa; filtro de status `in ('pendente','em_andamento')` (itens ainda não separados). Sem migration — o feature simplesmente apontava pra tabela errada.

2. **`useReposicaoZone` (KPI "alertas ativos" + top outliers)** — `eventos_outlier` não tem `descricao` nem `created_at`. Mapeado `descricao`→`sku_descricao` (title) e `created_at`→`detectado_em`. `id` é `number` (não `string`) → `String(a.id)` pro `TopListItem.id`. **Codex catch:** `detectado_em` é nullable e `DESC` no Postgres é `NULLS FIRST` → adicionado `nullsFirst: false` pra não jogar nulls no topo.

3. **`AdminReposicaoCadastros` (histórico de ciclos)** — `pedido_compra_sugerido` não tem `fornecedor_grupo` nem `n_skus`. Mapeado `fornecedor_grupo`→`fornecedor_nome` (nome exibido na coluna "Fornecedor") e `n_skus`→`num_skus`. **`valor_total` mantido — a coluna existe** (a hipótese da auditoria de que não existia estava errada). Tipo `CicloRow` ajustado.

Em todos: cast tightened de `as unknown as X` → `as X` único, pra a checagem de tipos do client tipado do Supabase pegar reincidência.

## Validação

- `bun run typecheck:strict` → exit 0
- `bunx tsc --noEmit -p tsconfig.app.json` → exit 0
- `bun run test` (vitest) → **392/392**
- **Probe ao PostgREST de produção** (anon key, read-only): os `select` antigos retornam `400 42703 column does not exist`; os novos retornam `200`. Confirma o fix na camada de API (os `[]` são RLS de anon — sob JWT de staff os KPIs populam com dados reais).
- Codex review aplicado (`nullsFirst: false`).

## Test plan
- [ ] Logar como staff e abrir o dashboard home (`/`) — zona Estoque (alerta FEFO) e zona Reposição (alertas ativos + top outliers) populam quando há dados.
- [ ] `/admin/reposicao/cadastros` → tab histórico de ciclos lista linhas (fornecedor, N SKUs, valor total).

🤖 Generated with [Claude Code](https://claude.com/claude-code)