### PR TITLE
fix(reposicao): corrige formatDuration que omitia minutos em rotas >1h

### DIFF
--- a/src/components/reposicao/routePlanner/__tests__/renderHelpers.test.ts
+++ b/src/components/reposicao/routePlanner/__tests__/renderHelpers.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { formatDuration } from "@/components/reposicao/routePlanner/renderHelpers";
+
+describe("formatDuration", () => {
+  it("formata minutos puros abaixo de 1h", () => {
+    expect(formatDuration(45)).toBe("45min");
+  });
+
+  it("formata exatamente 1h sem minutos", () => {
+    expect(formatDuration(60)).toBe("1h");
+  });
+
+  it("formata 1h30 (90min)", () => {
+    expect(formatDuration(90)).toBe("1h30");
+  });
+
+  it("formata 2h30 (150min)", () => {
+    expect(formatDuration(150)).toBe("2h30");
+  });
+});

--- a/src/components/reposicao/routePlanner/renderHelpers.tsx
+++ b/src/components/reposicao/routePlanner/renderHelpers.tsx
@@ -1,0 +1,9 @@
+// Helpers de apresentação das paradas de rota.
+// Extraído de src/pages/AdminRoutePlanner.tsx (god-component split).
+
+export const formatDuration = (min: number) => {
+  if (min < 60) return `${min}min`;
+  const h = Math.floor(min / 60);
+  const m = min % 60;
+  return m > 0 ? `${h}h${String(m).padStart(2, '0')}` : `${h}h`;
+};

--- a/src/pages/AdminRoutePlanner.tsx
+++ b/src/pages/AdminRoutePlanner.tsx
@@ -27,6 +27,7 @@ import type {
   RouteStop,
 } from '@/components/reposicao/routePlanner/types';
 import { enrichWithPriority } from '@/components/reposicao/routePlanner/priority';
+import { formatDuration } from '@/components/reposicao/routePlanner/renderHelpers';
 import {
   STOP_DURATION_MIN,
   PRIORITY_CONFIG,
@@ -978,13 +979,6 @@ const AdminRoutePlanner = () => {
     }
     return { stopMin, travelMin, totalMin: stopMin + travelMin };
   }, [optimizedRoute]);
-
-  const formatDuration = (min: number) => {
-    if (min < 60) return `${min}min`;
-    const h = Math.floor(min / 60);
-    const m = min % h;
-    return m > 0 ? `${h}h${String(m).padStart(2, '0')}` : `${h}h`;
-  };
 
   const isLoading = authLoading || loading;
 


### PR DESCRIPTION
## Summary
- Corrige bug pré-existente em `formatDuration` (route planner): usava `min % h` (resto pela quantidade de horas) em vez de `min % 60`, zerando os minutos sempre que o divisor virava 1 ou 2. Ex: `90min` exibia **"1h"** em vez de **"1h30"**; `150min` exibia **"2h"** em vez de **"2h30"**.
- Extrai a função, antes inline em `AdminRoutePlanner.tsx`, para `src/components/reposicao/routePlanner/renderHelpers.tsx` (testável), seguindo a quebra em andamento desse god-component (#147, #148).
- Adiciona teste unitário cobrindo os 4 casos: `45→45min`, `60→1h`, `90→1h30`, `150→2h30`.

## Test Coverage
Todos os ramos de `formatDuration` cobertos (`<60` puro, hora exata, hora+minutos). Teste novo em `routePlanner/__tests__/renderHelpers.test.ts` validado em red→green: com o bug, `90` e `150` falhavam; após o fix, 4/4 passam.

Suíte completa: **396/396** (`bun run test`). `typecheck:strict` limpo.

## Pre-Landing Review
Sem problemas. Bug fix puro + extração; sem SQL, LLM ou trust boundary. Único uso de `formatDuration` (linha 1276) permanece via import; sem refs órfãs. Lint dos arquivos tocados: 0 problemas (os 13 `no-explicit-any` restantes em `AdminRoutePlanner` são pré-existentes, fora de escopo).

## Test plan
- [x] `bun run test` — 396/396 passando
- [x] `bun run typecheck:strict` — limpo
- [x] Teste novo cobre 90→1h30, 150→2h30, 60→1h, 45→45min (red→green verificado)

🤖 Generated with [Claude Code](https://claude.com/claude-code)