### PR TITLE
refactor(reposicao): extrai 8 render helpers puros de AdminRoutePlanner (1541→1479)

### DIFF
--- a/src/components/reposicao/routePlanner/renderHelpers.tsx
+++ b/src/components/reposicao/routePlanner/renderHelpers.tsx
@@ -1,0 +1,82 @@
+// Helpers de apresentação puros do planejador de rotas.
+// Extraídos de src/pages/AdminRoutePlanner.tsx (god-component split).
+// Todos são puros (dependem só dos args + window/lucide), sem estado do componente.
+//
+// NOTA: formatDuration tem um bug pré-existente conhecido (`min % h` deveria ser
+// `min % 60`) — preservado verbatim aqui; correção rastreada em task separada.
+import { Truck, ShoppingBag, Layers, Users } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import type { StopType, RouteStop, ManualCustomer } from './types';
+
+export const formatTimer = (seconds: number) => {
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return `${m}:${String(s).padStart(2, '0')}`;
+};
+
+export const formatDuration = (min: number) => {
+  if (min < 60) return `${min}min`;
+  const h = Math.floor(min / 60);
+  const m = min % h;
+  return m > 0 ? `${h}h${String(m).padStart(2, '0')}` : `${h}h`;
+};
+
+export const openInWaze = (stop: RouteStop) => {
+  if (stop.lat && stop.lng) {
+    window.open(`https://waze.com/ul?ll=${stop.lat},${stop.lng}&navigate=yes`, '_blank');
+  } else {
+    const q = `${stop.address.street}, ${stop.address.number}, ${stop.address.city}, ${stop.address.state}`;
+    window.open(`https://waze.com/ul?q=${encodeURIComponent(q)}&navigate=yes`, '_blank');
+  }
+};
+
+export const openInGoogleMaps = (stop: RouteStop) => {
+  if (stop.lat && stop.lng) {
+    window.open(`https://www.google.com/maps/dir/?api=1&destination=${stop.lat},${stop.lng}`, '_blank');
+  } else {
+    const q = `${stop.address.street}, ${stop.address.number}, ${stop.address.city}, ${stop.address.state}`;
+    window.open(`https://www.google.com/maps/dir/?api=1&destination=${encodeURIComponent(q)}`, '_blank');
+  }
+};
+
+export const getStopIcon = (type: StopType) => {
+  switch (type) {
+    case 'pickup_tools': return <Truck className="w-3.5 h-3.5" />;
+    case 'deliver_tools': return <Truck className="w-3.5 h-3.5" />;
+    case 'sales_visit': return <ShoppingBag className="w-3.5 h-3.5" />;
+    case 'hybrid_visit': return <Layers className="w-3.5 h-3.5" />;
+    case 'manual_visit': return <Users className="w-3.5 h-3.5" />;
+  }
+};
+
+export const getCTALabel = (stop: RouteStop) => {
+  if (stop.orderId) return 'Ver pedido';
+  if (stop.visitReason.includes('afiação vencida')) return 'Criar pedido de afiação';
+  return 'Criar pedido';
+};
+
+export const getVisitBadge = (customer: ManualCustomer) => {
+  if (customer.daysSinceLastVisit === null) {
+    return <Badge variant="danger" className="text-xs">Nunca visitado</Badge>;
+  }
+  if (customer.daysSinceLastVisit > 30) {
+    return <Badge variant="warning" className="text-xs">Última visita há {customer.daysSinceLastVisit} dias</Badge>;
+  }
+  return null;
+};
+
+export const getOrderBadge = (customer: ManualCustomer) => {
+  if (customer.daysSinceLastOrder === null) {
+    return null;
+  }
+  if (customer.daysSinceLastOrder > 90) {
+    return <Badge variant="danger" className="text-xs">Sem compra há {customer.daysSinceLastOrder} dias</Badge>;
+  }
+  if (customer.daysSinceLastOrder > 30) {
+    return <Badge variant="warning" className="text-xs">Comprou há {customer.daysSinceLastOrder} dias</Badge>;
+  }
+  if (customer.daysSinceLastOrder <= 30) {
+    return <Badge variant="success" className="text-xs">Comprou recentemente</Badge>;
+  }
+  return null;
+};

--- a/src/pages/AdminRoutePlanner.tsx
+++ b/src/pages/AdminRoutePlanner.tsx
@@ -32,6 +32,16 @@ import {
   PRIORITY_CONFIG,
   STOP_CONFIG,
 } from '@/components/reposicao/routePlanner/constants';
+import {
+  formatTimer,
+  formatDuration,
+  openInWaze,
+  openInGoogleMaps,
+  getStopIcon,
+  getCTALabel,
+  getVisitBadge,
+  getOrderBadge,
+} from '@/components/reposicao/routePlanner/renderHelpers';
 
 // Fix default marker icons for Leaflet + bundlers
 delete (L.Icon.Default.prototype as any)._getIconUrl;
@@ -471,11 +481,6 @@ const AdminRoutePlanner = () => {
     }
   };
   
-  const formatTimer = (seconds: number) => {
-    const m = Math.floor(seconds / 60);
-    const s = seconds % 60;
-    return `${m}:${String(s).padStart(2, '0')}`;
-  };
 
   const loadCommercialStops = async () => {
     try {
@@ -843,60 +848,6 @@ const AdminRoutePlanner = () => {
     leafletMap.current.fitBounds(bounds, { padding: [40, 40] });
   }, [optimizedRoute]);
 
-  const openInWaze = (stop: RouteStop) => {
-    if (stop.lat && stop.lng) {
-      window.open(`https://waze.com/ul?ll=${stop.lat},${stop.lng}&navigate=yes`, '_blank');
-    } else {
-      const q = `${stop.address.street}, ${stop.address.number}, ${stop.address.city}, ${stop.address.state}`;
-      window.open(`https://waze.com/ul?q=${encodeURIComponent(q)}&navigate=yes`, '_blank');
-    }
-  };
-
-  const openInGoogleMaps = (stop: RouteStop) => {
-    if (stop.lat && stop.lng) {
-      window.open(`https://www.google.com/maps/dir/?api=1&destination=${stop.lat},${stop.lng}`, '_blank');
-    } else {
-      const q = `${stop.address.street}, ${stop.address.number}, ${stop.address.city}, ${stop.address.state}`;
-      window.open(`https://www.google.com/maps/dir/?api=1&destination=${encodeURIComponent(q)}`, '_blank');
-    }
-  };
-
-  const getStopIcon = (type: StopType) => {
-    switch (type) {
-      case 'pickup_tools': return <Truck className="w-3.5 h-3.5" />;
-      case 'deliver_tools': return <Truck className="w-3.5 h-3.5" />;
-      case 'sales_visit': return <ShoppingBag className="w-3.5 h-3.5" />;
-      case 'hybrid_visit': return <Layers className="w-3.5 h-3.5" />;
-      case 'manual_visit': return <Users className="w-3.5 h-3.5" />;
-    }
-  };
-  
-  const getVisitBadge = (customer: ManualCustomer) => {
-    if (customer.daysSinceLastVisit === null) {
-      return <Badge variant="danger" className="text-xs">Nunca visitado</Badge>;
-    }
-    if (customer.daysSinceLastVisit > 30) {
-      return <Badge variant="warning" className="text-xs">Última visita há {customer.daysSinceLastVisit} dias</Badge>;
-    }
-    return null;
-  };
-  
-  const getOrderBadge = (customer: ManualCustomer) => {
-    if (customer.daysSinceLastOrder === null) {
-      return null;
-    }
-    if (customer.daysSinceLastOrder > 90) {
-      return <Badge variant="danger" className="text-xs">Sem compra há {customer.daysSinceLastOrder} dias</Badge>;
-    }
-    if (customer.daysSinceLastOrder > 30) {
-      return <Badge variant="warning" className="text-xs">Comprou há {customer.daysSinceLastOrder} dias</Badge>;
-    }
-    if (customer.daysSinceLastOrder <= 30) {
-      return <Badge variant="success" className="text-xs">Comprou recentemente</Badge>;
-    }
-    return null;
-  };
-  
   const filteredManualCustomers = useMemo(() => {
     let filtered = manualCustomers;
     
@@ -946,12 +897,6 @@ const AdminRoutePlanner = () => {
     }
   };
 
-  const getCTALabel = (stop: RouteStop) => {
-    if (stop.orderId) return 'Ver pedido';
-    if (stop.visitReason.includes('afiação vencida')) return 'Criar pedido de afiação';
-    return 'Criar pedido';
-  };
-
   // Stats
   const stopCounts = useMemo(() => {
     const counts = { pickup_tools: 0, deliver_tools: 0, sales_visit: 0, hybrid_visit: 0 };
@@ -978,13 +923,6 @@ const AdminRoutePlanner = () => {
     }
     return { stopMin, travelMin, totalMin: stopMin + travelMin };
   }, [optimizedRoute]);
-
-  const formatDuration = (min: number) => {
-    if (min < 60) return `${min}min`;
-    const h = Math.floor(min / 60);
-    const m = min % h;
-    return m > 0 ? `${h}h${String(m).padStart(2, '0')}` : `${h}h`;
-  };
 
   const isLoading = authLoading || loading;
 

--- a/tsconfig.strict.json
+++ b/tsconfig.strict.json
@@ -364,6 +364,7 @@
     "src/components/GamificationCertificate.tsx",
     "src/components/reposicao/routePlanner/types.ts",
     "src/components/reposicao/routePlanner/priority.ts",
-    "src/components/reposicao/routePlanner/constants.ts"
+    "src/components/reposicao/routePlanner/constants.ts",
+    "src/components/reposicao/routePlanner/renderHelpers.tsx"
   ]
 }


### PR DESCRIPTION
## Summary

Segundo corte do RoutePlanner. Move pra `routePlanner/renderHelpers.tsx` as **8 funções de apresentação puras** (nenhuma fecha sobre estado): `formatTimer`, `formatDuration`, `openInWaze`, `openInGoogleMaps`, `getStopIcon`, `getCTALabel`, `getVisitBadge`, `getOrderBadge`.

Verbatim — zero mudança de comportamento. Página: **1541 → 1479 LoC**. `renderHelpers.tsx` entra no strict (347).

## Bug pré-existente preservado (flaggado separado)

`formatDuration` tem `min % h` onde deveria ser `min % 60` (mostra "1h" no lugar de "1h30"). **Preservado verbatim** pra manter o corte como puro move; correção rastreada em task separada (chip criado).

## Codex review (gate)

Rodado no diff (`origin/main...HEAD`). **"No findings in the requested scope"** — confirmou que os corpos movidos batem com os removidos, exports/imports OK, strict inclui o novo arquivo.

## Test plan

- [x] `bunx tsc --noEmit` 0 · `typecheck:strict` 0 · `eslint-unused` 0
- [x] `bun run build` OK · `bun run test` 392/392
- [x] codex review — sem findings
- [x] Nenhum import lucide/Badge órfão criado (todos seguem usados no corpo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)