### PR TITLE
feat(typescript): wave 31 elimina any em 2 financeiro pages + promove 3 pra strict (-3 lint)

### DIFF
--- a/src/pages/FinanceiroAnalytics.tsx
+++ b/src/pages/FinanceiroAnalytics.tsx
@@ -1,16 +1,15 @@
 import { useState, useEffect, useCallback } from 'react';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
+import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { Progress } from '@/components/ui/progress';
 import { COMPANIES, ALL_COMPANIES, type Company } from '@/contexts/CompanyContext';
 import { getAnaliseDimensional, type Dimensao, type AnaliseDimensional } from '@/services/financeiroV2Service';
-import { downloadCSV, exportContasPagarCSV, exportContasReceberCSV } from '@/services/financeiroService';
+import { downloadCSV } from '@/services/financeiroService';
 import {
-  Loader2, Building2, BarChart3, PieChart, Download, Filter,
-  ArrowDownCircle, ArrowUpCircle, TrendingUp
+  Loader2, Building2, BarChart3, PieChart, Download,
+  ArrowDownCircle, ArrowUpCircle
 } from 'lucide-react';
 
 const fmt = (v: number) => v.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
@@ -99,7 +98,7 @@ const FinanceiroAnalytics = () => {
       <Card>
         <CardContent className="p-4">
           <div className="flex flex-wrap items-center gap-3">
-            <Select value={tipo} onValueChange={v => setTipo(v as any)}>
+            <Select value={tipo} onValueChange={v => setTipo(v as 'cr' | 'cp')}>
               <SelectTrigger className="w-[140px]">
                 {tipo === 'cr' ? <ArrowDownCircle className="w-4 h-4 mr-2" /> : <ArrowUpCircle className="w-4 h-4 mr-2" />}
                 <SelectValue />
@@ -122,7 +121,7 @@ const FinanceiroAnalytics = () => {
               </SelectContent>
             </Select>
 
-            <Select value={company} onValueChange={v => setCompany(v as any)}>
+            <Select value={company} onValueChange={v => setCompany(v as Company | 'all')}>
               <SelectTrigger className="w-[150px]">
                 <Building2 className="w-4 h-4 mr-2" />
                 <SelectValue />

--- a/src/pages/FinanceiroTributario.tsx
+++ b/src/pages/FinanceiroTributario.tsx
@@ -1,15 +1,13 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
-import { Button } from '@/components/ui/button';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { Progress } from '@/components/ui/progress';
-import { COMPANIES, ALL_COMPANIES, type Company } from '@/contexts/CompanyContext';
+import { COMPANIES, ALL_COMPANIES } from '@/contexts/CompanyContext';
 import { getDRE, type FinDRE } from '@/services/financeiroService';
-import { supabase } from '@/integrations/supabase/client';
 import {
-  Loader2, Building2, Calendar, BarChart3, TrendingUp, AlertTriangle, Receipt
+  Loader2, Calendar, AlertTriangle, Receipt
 } from 'lucide-react';
 
 const fmt = (v: number) => v.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
@@ -100,7 +98,7 @@ const FinanceiroTributario = () => {
 
         // Regime-specific analysis
         let snInfo: { aliquota: number; faixa: string } | null = null;
-        let lpBreakdown: any = null;
+        let lpBreakdown: { irpj: number; adicionalIRPJ: number; csll: number; pis: number; cofins: number; total: number } | null = null;
 
         if (regime === 'simples') {
           snInfo = calcAliquotaEfetivaSN(receitaAnual);

--- a/tsconfig.strict.json
+++ b/tsconfig.strict.json
@@ -366,6 +366,9 @@
     "src/components/reposicao/routePlanner/priority.ts",
     "src/components/reposicao/routePlanner/constants.ts",
     "src/components/des/PosicaoAtualTab.tsx",
-    "src/components/des/HistoricoTab.tsx"
+    "src/components/des/HistoricoTab.tsx",
+    "src/pages/FinanceiroAnalytics.tsx",
+    "src/pages/FinanceiroTributario.tsx",
+    "src/pages/FinanceiroSync.tsx"
   ]
 }


### PR DESCRIPTION
## Resumo

Wave 31 da migração TypeScript strict (CLAUDE.md §10) — **páginas do módulo Financeiro** (estende a cobertura já alta do módulo).

**Elimina 3 `any`:**
- `FinanceiroAnalytics.tsx` — `Select onValueChange` tipado (`v as 'cr' | 'cp'` e `v as Company | 'all'`) em vez de `as any`, seguindo o padrão já usado no `setDimensao(v as Dimensao)` do mesmo arquivo
- `FinanceiroTributario.tsx` — `lpBreakdown` tipado com o objeto de impostos do Lucro Presumido (`irpj/adicionalIRPJ/csll/pis/cofins/total`) em vez de `any`

**Promove 3 files pro `tsconfig.strict.json`:** os 2 acima + `FinanceiroSync.tsx` (0 any, promoção pura). Dead-code removido pelo `noUnusedLocals` (imports não usados + `useCallback`/`supabase` órfãos).

## Validação

- `bun run typecheck:strict` → **0 erros**
- `bun lint` → `no-explicit-any` 106 → **103** (−3); cluster Financeiro limpo, zero erro novo
- `bun run test` → **396/396** verdes

Sem mudança de runtime — só tipos + dead-code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)