### PR TITLE
feat(typescript): wave 32 catch type-safe em 8 files + promove 4 pra strict (-10 lint)

### DIFF
--- a/src/components/intelligence/IntelligenceStrategicTab.tsx
+++ b/src/components/intelligence/IntelligenceStrategicTab.tsx
@@ -112,8 +112,8 @@ export function IntelligenceStrategicTab() {
       const { error } = await supabase.functions.invoke('algorithm-a-audit');
       if (error) throw error;
       toast.success('Algoritmo A executado com sucesso');
-    } catch (e: any) {
-      toast.error('Erro: ' + e.message);
+    } catch (e) {
+      toast.error('Erro: ' + (e instanceof Error ? e.message : String(e)));
     } finally {
       setRunningAlgoA(false);
     }

--- a/src/components/portalSayerlack/PortalDetailDrawer.tsx
+++ b/src/components/portalSayerlack/PortalDetailDrawer.tsx
@@ -127,8 +127,8 @@ export function PortalDetailDrawer({ pedidoId, open, onOpenChange, isAdmin }: Pr
       setConciliarOpen(false);
       setConciliarProtocolo('');
       refetchAll();
-    } catch (err: any) {
-      const msg = err?.message ?? String(err);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
       toast.error(`Falha ao conciliar: ${msg}`);
     } finally {
       setConciliando(false);
@@ -153,8 +153,8 @@ export function PortalDetailDrawer({ pedidoId, open, onOpenChange, isAdmin }: Pr
       if (error) throw error;
       toast.success(`Pedido #${pedidoId} resetado. Use 'Disparar agora' para reenviar.`);
       refetchAll();
-    } catch (err: any) {
-      toast.error(`Falha: ${err.message}`);
+    } catch (err) {
+      toast.error(`Falha: ${err instanceof Error ? err.message : String(err)}`);
     } finally {
       setResetting(false);
     }

--- a/src/hooks/useBiometricAuth.ts
+++ b/src/hooks/useBiometricAuth.ts
@@ -171,15 +171,16 @@ export const useBiometricAuth = (): BiometricAuthHook => {
       });
 
       return true;
-    } catch (error: any) {
-      logger.error('Biometric registration failed', { stage: 'register', errorName: error?.name, error });
-      if (error.name === 'NotAllowedError') {
+    } catch (error) {
+      const name = error instanceof Error ? error.name : undefined;
+      logger.error('Biometric registration failed', { stage: 'register', errorName: name, error });
+      if (name === 'NotAllowedError') {
         toast.error('Acesso negado', {
           description: 'Você precisa permitir o uso de biometria',
         });
       } else {
         toast.error('Erro ao registrar biometria', {
-          description: error.message || 'Tente novamente mais tarde',
+          description: error instanceof Error ? error.message : 'Tente novamente mais tarde',
         });
       }
       return false;
@@ -235,9 +236,10 @@ export const useBiometricAuth = (): BiometricAuthHook => {
       return {
         email: data.email,
       };
-    } catch (error: any) {
-      logger.warn('Biometric authentication failed', { stage: 'authenticate', errorName: error?.name, error });
-      if (error.name === 'NotAllowedError') {
+    } catch (error) {
+      const name = error instanceof Error ? error.name : undefined;
+      logger.warn('Biometric authentication failed', { stage: 'authenticate', errorName: name, error });
+      if (name === 'NotAllowedError') {
         toast.error('Acesso negado', {
           description: 'Autenticação biométrica cancelada',
         });

--- a/src/hooks/useDirectTintImport.ts
+++ b/src/hooks/useDirectTintImport.ts
@@ -411,7 +411,7 @@ export function useDirectTintImport() {
             newFormulas.push({ row: formulaRow, items: coranteItems });
             imported++;
           }
-        } catch (e: any) {
+        } catch (e) {
           errors++;
           logger.warn('Tint formula row processing failed (skipping row)', {
             stage: 'upload_formulas',

--- a/src/pages/AdminMonthlyReports.tsx
+++ b/src/pages/AdminMonthlyReports.tsx
@@ -1,15 +1,15 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Separator } from '@/components/ui/separator';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
 import { toast } from 'sonner';
 import { 
-  Loader2, Send, MessageCircle, Mail, Users, 
-  AlertTriangle, CheckCircle, Wrench, Eye, ExternalLink 
+  Loader2, Send, MessageCircle, Mail, Users,
+  AlertTriangle, CheckCircle, Wrench, Eye
 } from 'lucide-react';
 
 interface ToolSummary {
@@ -71,10 +71,10 @@ const AdminMonthlyReports = () => {
           description: `Relatórios enviados para ${data.reports_count} cliente(s)`,
         });
       }
-    } catch (error: any) {
+    } catch (error) {
       console.error('Error:', error);
       toast.error('Erro', {
-        description: error.message || 'Falha ao gerar relatórios',
+        description: error instanceof Error ? error.message : 'Falha ao gerar relatórios',
       });
     } finally {
       setLoading(false);

--- a/src/pages/IntelligenceDashboard.tsx
+++ b/src/pages/IntelligenceDashboard.tsx
@@ -29,8 +29,8 @@ export default function IntelligenceDashboard() {
       const { error } = await supabase.functions.invoke('calculate-scores');
       if (error) throw error;
       toast.success('Scores recalculados com sucesso');
-    } catch (e: any) {
-      toast.error('Erro: ' + e.message);
+    } catch (e) {
+      toast.error('Erro: ' + (e instanceof Error ? e.message : String(e)));
     } finally {
       setRunningScores(false);
     }

--- a/src/pages/NfeReceipt.tsx
+++ b/src/pages/NfeReceipt.tsx
@@ -97,8 +97,8 @@ export default function NfeReceipt() {
           steps_count: resultSteps.length,
         }),
       );
-    } catch (e: any) {
-      const resultSteps = [{ step: 0, description: "Erro inesperado", status: "error" as const, detail: e.message }];
+    } catch (e) {
+      const resultSteps = [{ step: 0, description: "Erro inesperado", status: "error" as const, detail: e instanceof Error ? e.message : String(e) }];
       setSteps(resultSteps);
       setFinalStatus("error");
       setHistory(

--- a/src/pages/ResetPassword.tsx
+++ b/src/pages/ResetPassword.tsx
@@ -95,10 +95,10 @@ const ResetPassword = () => {
       setTimeout(() => {
         navigate('/', { replace: true });
       }, 2000);
-    } catch (error: any) {
+    } catch (error) {
       console.error('Error resetting password:', error);
       toast.error('Erro ao redefinir senha', {
-        description: error.message || 'Tente novamente mais tarde',
+        description: error instanceof Error ? error.message : 'Tente novamente mais tarde',
       });
     } finally {
       setIsLoading(false);

--- a/tsconfig.strict.json
+++ b/tsconfig.strict.json
@@ -369,6 +369,10 @@
     "src/components/des/HistoricoTab.tsx",
     "src/pages/FinanceiroAnalytics.tsx",
     "src/pages/FinanceiroTributario.tsx",
-    "src/pages/FinanceiroSync.tsx"
+    "src/pages/FinanceiroSync.tsx",
+    "src/pages/AdminMonthlyReports.tsx",
+    "src/pages/NfeReceipt.tsx",
+    "src/pages/ResetPassword.tsx",
+    "src/components/portalSayerlack/PortalDetailDrawer.tsx"
   ]
 }


### PR DESCRIPTION
## Resumo

Wave 32 — **error handling type-safe**. Troca 10 `catch (e: any)` por `catch (e)` + narrowing `instanceof Error` em 8 files (segue o padrão já usado no repo):

- **pages:** AdminMonthlyReports, NfeReceipt, ResetPassword, IntelligenceDashboard
- **components:** portalSayerlack/PortalDetailDrawer (×2), intelligence/IntelligenceStrategicTab
- **hooks:** useDirectTintImport (`e` só é logado), useBiometricAuth (×2 — usa `error.name` de `DOMException`, subclasse de `Error`, acessado via `instanceof`)

**Promove 4 desses pro `tsconfig.strict.json`** (AdminMonthlyReports, NfeReceipt, ResetPassword, PortalDetailDrawer) — strict-clean após limpar dead imports.

**Por que só 4 dos 8 promovidos:** os outros 4 ficam fora do `include` por ora — `useDirectTintImport` tem 2 erros de `strictNullChecks` (`string | null`) que merecem fix dedicado, e o cluster Intelligence (`IntelligenceDashboard`/`StrategicTab`) puxa tabs irmãs transitivamente (cascata maior). O ganho de lint (`any` eliminado) já vale, e a promoção fica pra wave focada.

## Validação

- `bun run typecheck:strict` → **0 erros**
- `bun lint` → `no-explicit-any` 103 → **93** (−10); os 8 files limpos, zero erro novo
- `bun run test` → **423/423** verdes

Comportamento de runtime preservado (narrowing equivale ao acesso anterior para Error/DOMException reais; fallback `String(e)` no caso não-Error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)