### PR TITLE
refactor(typescript): wave 28 elimina any em 5 hooks (-10 lint)

### DIFF
--- a/src/hooks/useBiometricAuth.ts
+++ b/src/hooks/useBiometricAuth.ts
@@ -171,15 +171,18 @@ export const useBiometricAuth = (): BiometricAuthHook => {
       });
 
       return true;
-    } catch (error: any) {
-      logger.error('Biometric registration failed', { stage: 'register', errorName: error?.name, error });
-      if (error.name === 'NotAllowedError') {
+    } catch (error) {
+      // WebAuthn rejeita com DOMException, que nem sempre é instanceof Error —
+      // leitura estrutural preserva name/message (ex: NotAllowedError) sem usar any.
+      const err = error as { name?: string; message?: string };
+      logger.error('Biometric registration failed', { stage: 'register', errorName: err?.name, error });
+      if (err?.name === 'NotAllowedError') {
         toast.error('Acesso negado', {
           description: 'Você precisa permitir o uso de biometria',
         });
       } else {
         toast.error('Erro ao registrar biometria', {
-          description: error.message || 'Tente novamente mais tarde',
+          description: err?.message || 'Tente novamente mais tarde',
         });
       }
       return false;
@@ -235,9 +238,10 @@ export const useBiometricAuth = (): BiometricAuthHook => {
       return {
         email: data.email,
       };
-    } catch (error: any) {
-      logger.warn('Biometric authentication failed', { stage: 'authenticate', errorName: error?.name, error });
-      if (error.name === 'NotAllowedError') {
+    } catch (error) {
+      const err = error as { name?: string; message?: string };
+      logger.warn('Biometric authentication failed', { stage: 'authenticate', errorName: err?.name, error });
+      if (err?.name === 'NotAllowedError') {
         toast.error('Acesso negado', {
           description: 'Autenticação biométrica cancelada',
         });

--- a/src/hooks/useBundleArguments.ts
+++ b/src/hooks/useBundleArguments.ts
@@ -93,14 +93,14 @@ export const useBundleArguments = () => {
     profile: CustomerProfile,
     approachType: string
   ) => {
-    await supabase.from('farmer_bundle_recommendations' as any).update({
+    await supabase.from('farmer_bundle_recommendations').update({
       argument_phone: argument.versao_phone,
       argument_whatsapp: argument.versao_whatsapp,
       argument_technical: argument.versao_tecnica,
       customer_profile: profile,
       approach_type: approachType,
       updated_at: new Date().toISOString(),
-    } as any).eq('id', bundleId);
+    }).eq('id', bundleId);
   }, []);
 
   return {

--- a/src/hooks/useCustomerCalls.ts
+++ b/src/hooks/useCustomerCalls.ts
@@ -33,9 +33,8 @@ export function useCustomerCalls(customerId: string | null) {
     gcTime: 5 * 60_000,
     queryFn: async (): Promise<CustomerCallRow[]> => {
       if (!customerId) return [];
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const { data, error } = await (supabase
-        .from('farmer_calls') as any)
+      const { data, error } = await supabase
+        .from('farmer_calls')
         .select(`
           id, farmer_id, customer_user_id, phone_dialed, call_backend,
           started_at, ended_at, duration_seconds,

--- a/src/hooks/useNvoipCall.ts
+++ b/src/hooks/useNvoipCall.ts
@@ -131,11 +131,12 @@ export function useNvoipCall(): UseNvoipCallReturn {
         }, 2000);
 
         toast.success('📞 Chamada iniciada', { description: `Ligando para ${formatBrPhone(normalized)}...` });
-      } catch (err: any) {
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : '';
         setCallState('error');
-        setError(err.message || 'Erro ao realizar chamada');
+        setError(msg || 'Erro ao realizar chamada');
         toast.error('Erro na chamada', {
-          description: err.message || 'Não foi possível realizar a chamada',
+          description: msg || 'Não foi possível realizar a chamada',
         });
       }
     },
@@ -150,10 +151,10 @@ export function useNvoipCall(): UseNvoipCallReturn {
       setCallState('finished');
       stopPolling();
       toast.success('Chamada encerrada');
-    } catch (err: any) {
+    } catch (err) {
       console.error('Error ending call:', err);
       toast.error('Erro ao encerrar', {
-        description: err.message,
+        description: err instanceof Error ? err.message : undefined,
       });
     }
   }, [callId, stopPolling]);

--- a/src/hooks/useUnreadMessages.ts
+++ b/src/hooks/useUnreadMessages.ts
@@ -22,7 +22,7 @@ export function useUnreadMessages() {
           table: 'order_messages',
         },
         (payload) => {
-          const msg = payload.new as any;
+          const msg = payload.new as { sender_id?: string };
           // If the message is not from us, increment
           if (msg.sender_id !== user.id) {
             setUnreadCount(prev => prev + 1);
@@ -60,7 +60,7 @@ export function useUnreadMessages() {
       const orderIds = orders.map(o => o.id);
 
       // Count unread messages (not sent by us, not read)
-      const { count, error } = await (supabase as any)
+      const { count, error } = await supabase
         .from('order_messages')
         .select('*', { count: 'exact', head: true })
         .in('order_id', orderIds)


### PR DESCRIPTION
## Summary
Wave 28 da migração TypeScript strict — retomada da opção 3 (eliminação de `any`) após a série de god-components. Remove **10 `any`** em 5 hooks de app (no-explicit-any 103→93):

- **useBiometricAuth** — `catch (error: any)` → leitura estrutural `{ name?, message? }`. Preserva o `NotAllowedError` do WebAuthn (DOMException nem sempre é `instanceof Error`).
- **useNvoipCall** — `catch (err: any)` → `err instanceof Error ? err.message`
- **useBundleArguments** — `.from(... as any).update({} as any)` → chamada tipada (`farmer_bundle_recommendations` está no Database type)
- **useCustomerCalls** — `(supabase.from('farmer_calls') as any)` → chamada tipada
- **useUnreadMessages** — `payload.new as any` → shape tipado; `(supabase as any)` → tipado

## Catch do Codex review (P2, corrigido)
1ª rodada: o narrowing `instanceof Error` em useBiometricAuth descartaria o `name` do DOMException do WebAuthn em alguns browsers, pulando o tratamento de cancelamento/permissão. Corrigido com leitura estrutural. 2ª rodada limpa.

## Validação
- `tsc --noEmit -p tsconfig.app.json` — 0 erros
- `bun run typecheck:strict` — 0 erros
- `bun run test` — 423/423
- `codex review` — 2 rodadas (P2 corrigido)

🤖 Generated with [Claude Code](https://claude.com/claude-code)