### PR TITLE
test(financeiro): cobertura de format.ts + componentes de FinanceiroDashboard

### DIFF
--- a/src/components/financeiro/dashboard/__tests__/AgingCard.test.tsx
+++ b/src/components/financeiro/dashboard/__tests__/AgingCard.test.tsx
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { AgingCard } from '../AgingCard';
+
+const data = {
+  a_vencer_valor: 1000, a_vencer_qtd: 2,
+  vencido_1_30_valor: 500, vencido_1_30_qtd: 1,
+  vencido_31_60_valor: 0, vencido_31_60_qtd: 0,
+  vencido_61_90_valor: 0, vencido_61_90_qtd: 0,
+  vencido_90_plus_valor: 250, vencido_90_plus_qtd: 1,
+};
+
+describe('AgingCard', () => {
+  it('sem data → título + skeleton, sem faixas', () => {
+    render(<AgingCard title="Aging Recebíveis" data={null} type="receber" />);
+    expect(screen.getByText('Aging Recebíveis')).toBeTruthy();
+    expect(screen.queryByText('A vencer (2)')).toBeNull();
+  });
+
+  it('com data → 5 faixas e total', () => {
+    render(<AgingCard title="Aging Recebíveis" data={data} type="receber" />);
+    expect(screen.getByText('A vencer (2)')).toBeTruthy();
+    expect(screen.getByText('1-30 dias (1)')).toBeTruthy();
+    expect(screen.getByText('31-60 dias (0)')).toBeTruthy();
+    expect(screen.getByText('61-90 dias (0)')).toBeTruthy();
+    expect(screen.getByText('+90 dias (1)')).toBeTruthy();
+    expect(screen.getByText(/Total:/)).toBeTruthy();
+  });
+});

--- a/src/components/financeiro/dashboard/__tests__/DREComparativo.test.tsx
+++ b/src/components/financeiro/dashboard/__tests__/DREComparativo.test.tsx
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { DREComparativo } from '../DREComparativo';
+
+const row = {
+  receita_liquida: 9000, lucro_bruto: 5000, resultado_operacional: 3000,
+  resultado_liquido: 2500, impostos: 600,
+};
+
+describe('DREComparativo', () => {
+  it('menos de 2 empresas → não renderiza nada', () => {
+    const { container } = render(<DREComparativo data={{ oben: [row] }} ano={2026} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('2+ empresas → tabela comparativa com indicadores', () => {
+    render(<DREComparativo data={{ oben: [row], colacor_sc: [row] }} ano={2026} />);
+    expect(screen.getByText(/Comparativo por Empresa/)).toBeTruthy();
+    expect(screen.getByText('Receita Líquida')).toBeTruthy();
+    expect(screen.getByText('Margem Bruta')).toBeTruthy();
+    expect(screen.getByText('% da Receita Total')).toBeTruthy();
+  });
+});

--- a/src/components/financeiro/dashboard/__tests__/DRETab.test.tsx
+++ b/src/components/financeiro/dashboard/__tests__/DRETab.test.tsx
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { DRETab } from '../DRETab';
+
+const row = {
+  mes: 1,
+  receita_bruta: 10000, deducoes: 1000, receita_liquida: 9000, cmv: 4000, lucro_bruto: 5000,
+  despesas_operacionais: 1000, despesas_administrativas: 500, despesas_comerciais: 300,
+  despesas_financeiras: 100, receitas_financeiras: 50, resultado_operacional: 3150,
+  impostos: 600, resultado_liquido: 2550, detalhamento: {},
+};
+
+describe('DRETab', () => {
+  it('vazio → mensagem de recalcular', () => {
+    render(<DRETab data={[]} view="all" ano={2026} />);
+    expect(screen.getByText(/Nenhum DRE calculado para 2026/)).toBeTruthy();
+  });
+
+  it('com dados → cabeçalho, linhas do DRE, mês e badge consolidado', () => {
+    render(<DRETab data={[row]} view="all" ano={2026} />);
+    expect(screen.getByText(/DRE Regime de Caixa/)).toBeTruthy();
+    expect(screen.getByText('Receita Bruta')).toBeTruthy();
+    expect(screen.getByText('= RESULTADO LÍQUIDO')).toBeTruthy();
+    expect(screen.getByText('Jan')).toBeTruthy();
+    expect(screen.getByText('Consolidado')).toBeTruthy();
+  });
+
+  it('categorias não mapeadas → aviso de heurística', () => {
+    const unmapped = [{ ...row, detalhamento: { categorias_nao_mapeadas: ['CAT_X'] } }];
+    render(<DRETab data={unmapped} view="all" ano={2026} />);
+    expect(screen.getByText(/classificadas por heurística/)).toBeTruthy();
+    expect(screen.getByText(/CAT_X/)).toBeTruthy();
+  });
+});

--- a/src/components/financeiro/dashboard/__tests__/FluxoCaixaTab.test.tsx
+++ b/src/components/financeiro/dashboard/__tests__/FluxoCaixaTab.test.tsx
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { FluxoCaixaTab } from '../FluxoCaixaTab';
+
+const days = [
+  { data: '2026-01-05', entradas_realizadas: 1000, saidas_realizadas: 400, entradas_previstas: 0, saidas_previstas: 0 },
+  { data: '2099-01-05', entradas_realizadas: 0, saidas_realizadas: 0, entradas_previstas: 800, saidas_previstas: 300 },
+];
+
+describe('FluxoCaixaTab', () => {
+  it('loading → skeleton (sem título do gráfico)', () => {
+    render(<FluxoCaixaTab data={[]} loading={true} />);
+    expect(screen.queryByText('Fluxo de Caixa Semanal')).toBeNull();
+  });
+
+  it('vazio → mensagem de sincronizar', () => {
+    render(<FluxoCaixaTab data={[]} loading={false} />);
+    expect(screen.getByText(/Nenhum dado de fluxo de caixa/)).toBeTruthy();
+  });
+
+  it('com dados → KPIs e gráfico semanal', () => {
+    render(<FluxoCaixaTab data={days} loading={false} saldoCC={5000} />);
+    expect(screen.getByText('Fluxo de Caixa Semanal')).toBeTruthy();
+    expect(screen.getByText('Recebido')).toBeTruthy();
+    expect(screen.getByText('Pago')).toBeTruthy();
+    expect(screen.getByText('Saldo CC Atual')).toBeTruthy();
+  });
+});

--- a/src/components/financeiro/dashboard/__tests__/KpiCard.test.tsx
+++ b/src/components/financeiro/dashboard/__tests__/KpiCard.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Wallet } from 'lucide-react';
+import { KpiCard } from '../KpiCard';
+
+describe('KpiCard', () => {
+  it('renderiza título e valor compacto', () => {
+    render(
+      <KpiCard
+        title="A Receber"
+        value={1_500_000}
+        icon={Wallet}
+        color="text-status-success"
+        bgColor="bg-status-success-bg"
+      />,
+    );
+    expect(screen.getByText('A Receber')).toBeTruthy();
+    expect(screen.getByText('R$ 1.5M')).toBeTruthy();
+  });
+
+  it('mostra subtitle quando fornecido', () => {
+    render(
+      <KpiCard
+        title="A Pagar"
+        value={0}
+        icon={Wallet}
+        color=""
+        bgColor=""
+        subtitle="R$ 100,00 vencido"
+      />,
+    );
+    expect(screen.getByText('R$ 100,00 vencido')).toBeTruthy();
+  });
+
+  it('sem subtitle não renderiza linha extra', () => {
+    render(<KpiCard title="X" value={0} icon={Wallet} color="" bgColor="" />);
+    expect(screen.queryByText(/vencido/)).toBeNull();
+  });
+});

--- a/src/components/financeiro/dashboard/__tests__/format.test.ts
+++ b/src/components/financeiro/dashboard/__tests__/format.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import {
+  fmt, fmtCompact, fmtDate, statusColor, getWeekLabel, formatCnpj,
+} from '../format';
+
+describe('fmt', () => {
+  it('formata em BRL com 2 casas', () => {
+    const out = fmt(1234.5);
+    expect(out).toContain('R$');
+    expect(out).toMatch(/1\.234,50/);
+  });
+  it('zero', () => {
+    expect(fmt(0)).toMatch(/0,00/);
+  });
+});
+
+describe('fmtCompact', () => {
+  it('milhões → M com 1 casa', () => {
+    expect(fmtCompact(1_500_000)).toBe('R$ 1.5M');
+  });
+  it('milhares → k com 1 casa', () => {
+    expect(fmtCompact(2_300)).toBe('R$ 2.3k');
+  });
+  it('abaixo de mil cai no fmt completo', () => {
+    expect(fmtCompact(500)).toMatch(/500,00/);
+  });
+  it('negativos usam |v| para escolher a faixa', () => {
+    expect(fmtCompact(-2_000_000)).toBe('R$ -2.0M');
+  });
+});
+
+describe('fmtDate', () => {
+  it('null → travessão', () => {
+    expect(fmtDate(null)).toBe('—');
+  });
+  it('ISO date → dd/mm/aaaa pt-BR', () => {
+    expect(fmtDate('2026-04-15')).toBe('15/04/2026');
+  });
+});
+
+describe('statusColor', () => {
+  it('estados liquidados → success', () => {
+    expect(statusColor('PAGO')).toBe('bg-status-success-bg text-status-success');
+    expect(statusColor('RECEBIDO')).toBe('bg-status-success-bg text-status-success');
+    expect(statusColor('LIQUIDADO')).toBe('bg-status-success-bg text-status-success');
+  });
+  it('VENCIDO → error, PARCIAL → warning, CANCELADO → cinza', () => {
+    expect(statusColor('VENCIDO')).toBe('bg-status-error-bg text-status-error');
+    expect(statusColor('PARCIAL')).toBe('bg-status-warning-bg text-status-warning');
+    expect(statusColor('CANCELADO')).toBe('bg-gray-100 text-gray-500');
+  });
+  it('desconhecido → info (default)', () => {
+    expect(statusColor('QUALQUER')).toBe('bg-status-info-bg text-status-info');
+  });
+});
+
+describe('getWeekLabel', () => {
+  it('formato DD/MM', () => {
+    expect(getWeekLabel(new Date('2026-01-07T00:00:00'))).toMatch(/^\d{2}\/\d{2}$/);
+  });
+  it('dias da mesma semana (dom-sáb) caem no mesmo rótulo (início de semana)', () => {
+    // 2026-01-04 é domingo; 05 (seg) e 10 (sáb) caem na mesma semana
+    const seg = getWeekLabel(new Date('2026-01-05T00:00:00'));
+    const sab = getWeekLabel(new Date('2026-01-10T00:00:00'));
+    expect(seg).toBe(sab);
+    expect(seg).toBe('04/01');
+  });
+});
+
+describe('formatCnpj', () => {
+  it('14 dígitos → CNPJ mascarado', () => {
+    expect(formatCnpj('12345678000190')).toBe('12.345.678/0001-90');
+  });
+  it('11 dígitos → CPF mascarado', () => {
+    expect(formatCnpj('12345678901')).toBe('123.456.789-01');
+  });
+  it('comprimento inesperado → retorna sem máscara', () => {
+    expect(formatCnpj('123')).toBe('123');
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up do #161 (split de `FinanceiroDashboard`). O #161 fez o move 1:1 sem testes; este PR fecha a lacuna ao mesmo padrão do PromocaoDetail (#154), priorizando a **formatação de dinheiro** e a apresentação dos números financeiros.

**+29 testes** (suite **423 → 452**):

- **format.ts (16)** — `fmt`/`fmtCompact` (faixas M/k/negativo), `fmtDate` (null/ISO pt-BR), `statusColor` (todos os estados + default), `getWeekLabel` (início de semana dom-sáb), `formatCnpj` (CNPJ/CPF/comprimento inesperado).
- **KpiCard (3)** — título, valor compacto, subtitle opcional.
- **AgingCard (2)** — skeleton sem dados; 5 faixas + total com dados.
- **FluxoCaixaTab (3)** — loading, estado vazio, KPIs + gráfico semanal.
- **DRETab (3)** — vazio, cabeçalho/linhas/mês/badge consolidado, aviso de categorias não mapeadas.
- **DREComparativo (2)** — `<2` empresas → null; tabela comparativa com 2+.

## Verification

- `bun run test` → **452/452**.
- `bun lint` → arquivos novos limpos.
- Sem mudança de código de produção — só testes.

## Test plan
- [x] `bun run test` — 452/452
- [x] `bun lint` — limpo

🤖 Generated with [Claude Code](https://claude.com/claude-code)