### PR TITLE
feat(typescript): wave 33 tipa 12 any dos componentes do FinanceiroDashboard + promove 5 pra strict (-12 lint)

### DIFF
--- a/src/components/financeiro/dashboard/AgingCard.tsx
+++ b/src/components/financeiro/dashboard/AgingCard.tsx
@@ -3,8 +3,9 @@
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 import { fmt, fmtCompact } from '@/components/financeiro/dashboard/format';
+import type { AgingData } from '@/services/financeiroService';
 
-export function AgingCard({ title, data }: { title: string; data: any; type: 'receber' | 'pagar' }) {
+export function AgingCard({ title, data }: { title: string; data: AgingData | null; type: 'receber' | 'pagar' }) {
   if (!data) return (
     <Card>
       <CardHeader className="pb-3">

--- a/src/components/financeiro/dashboard/DREComparativo.tsx
+++ b/src/components/financeiro/dashboard/DREComparativo.tsx
@@ -6,8 +6,9 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@
 import { PieChart } from 'lucide-react';
 import { COMPANIES, type Company } from '@/contexts/CompanyContext';
 import { fmtCompact } from '@/components/financeiro/dashboard/format';
+import type { FinDRE } from '@/services/financeiroService';
 
-export function DREComparativo({ data, ano }: { data: Record<string, any[]>; ano: number }) {
+export function DREComparativo({ data, ano }: { data: Record<string, FinDRE[]>; ano: number }) {
   const companies = Object.keys(data);
   if (companies.length < 2) return null;
 
@@ -29,7 +30,7 @@ export function DREComparativo({ data, ano }: { data: Record<string, any[]>; ano
     return { company: co, ...total, margemBruta, margemLiquida };
   });
 
-  const lines: { label: string; field: string; format: 'currency' | 'pct' }[] = [
+  const lines: { label: string; field: 'receita_liquida' | 'lucro_bruto' | 'margemBruta' | 'resultado_operacional' | 'impostos' | 'resultado_liquido' | 'margemLiquida'; format: 'currency' | 'pct' }[] = [
     { label: 'Receita Líquida', field: 'receita_liquida', format: 'currency' },
     { label: 'Lucro Bruto', field: 'lucro_bruto', format: 'currency' },
     { label: 'Margem Bruta', field: 'margemBruta', format: 'pct' },
@@ -72,7 +73,7 @@ export function DREComparativo({ data, ano }: { data: Record<string, any[]>; ano
                     {line.label}
                   </TableCell>
                   {annualTotals.map(t => {
-                    const val = (t as any)[line.field] || 0;
+                    const val = t[line.field] || 0;
                     const isResult = line.field.includes('resultado') || line.field === 'margemLiquida';
                     const colorClass = isResult
                       ? val >= 0 ? 'text-status-success' : 'text-status-error'

--- a/src/components/financeiro/dashboard/DRETab.tsx
+++ b/src/components/financeiro/dashboard/DRETab.tsx
@@ -6,8 +6,9 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@
 import { AlertTriangle, FileText } from 'lucide-react';
 import { type FinanceiroView } from '@/hooks/useFinanceiro';
 import { fmtCompact } from '@/components/financeiro/dashboard/format';
+import type { FinDRE } from '@/services/financeiroService';
 
-export function DRETab({ data, view, ano }: { data: any[]; view: FinanceiroView; ano: number }) {
+export function DRETab({ data, view, ano }: { data: FinDRE[]; view: FinanceiroView; ano: number }) {
   if (!data || data.length === 0) {
     return (
       <Card>
@@ -20,17 +21,17 @@ export function DRETab({ data, view, ano }: { data: any[]; view: FinanceiroView;
   }
 
   // Data already comes consolidated from hook (dreConsolidado) — no re-consolidation needed
-  const rows = [...data].sort((a: any, b: any) => a.mes - b.mes);
+  const rows = [...data].sort((a, b) => a.mes - b.mes);
 
   // Ponto 5: check for unmapped categories
-  const unmappedCats = rows.flatMap((r: any) =>
+  const unmappedCats = rows.flatMap((r) =>
     r.detalhamento?.categorias_nao_mapeadas || []
   );
   const uniqueUnmapped = [...new Set(unmappedCats)];
 
   const meses = ['Jan', 'Fev', 'Mar', 'Abr', 'Mai', 'Jun', 'Jul', 'Ago', 'Set', 'Out', 'Nov', 'Dez'];
 
-  const dreLines = [
+  const dreLines: { label: string; field: keyof FinDRE & ('receita_bruta' | 'deducoes' | 'receita_liquida' | 'cmv' | 'lucro_bruto' | 'despesas_operacionais' | 'despesas_administrativas' | 'despesas_comerciais' | 'despesas_financeiras' | 'receitas_financeiras' | 'resultado_operacional' | 'impostos' | 'resultado_liquido'); bold: boolean; color: string }[] = [
     { label: 'Receita Bruta', field: 'receita_bruta', bold: true, color: '' },
     { label: '(-) Deduções', field: 'deducoes', bold: false, color: 'text-status-error' },
     { label: '= Receita Líquida', field: 'receita_liquida', bold: true, color: '' },
@@ -81,7 +82,7 @@ export function DRETab({ data, view, ano }: { data: any[]; view: FinanceiroView;
             <TableHeader>
               <TableRow>
                 <TableHead className="sticky left-0 bg-background min-w-[180px]">Linha</TableHead>
-                {rows.map((r: any) => (
+                {rows.map((r) => (
                   <TableHead key={r.mes} className="text-right min-w-[100px]">
                     {meses[r.mes - 1]}
                   </TableHead>
@@ -94,7 +95,7 @@ export function DRETab({ data, view, ano }: { data: any[]; view: FinanceiroView;
                   <TableCell className={`sticky left-0 bg-background text-sm ${line.bold ? 'font-bold' : ''}`}>
                     {line.label}
                   </TableCell>
-                  {rows.map((r: any) => {
+                  {rows.map((r) => {
                     const val = r[line.field] || 0;
                     const colorClass = line.color || (line.bold && line.field.includes('resultado')
                       ? (val >= 0 ? 'text-status-success' : 'text-status-error')
@@ -112,7 +113,7 @@ export function DRETab({ data, view, ano }: { data: any[]; view: FinanceiroView;
                 <TableCell className="sticky left-0 bg-background text-sm font-medium text-muted-foreground">
                   Margem Bruta %
                 </TableCell>
-                {rows.map((r: any) => {
+                {rows.map((r) => {
                   const pct = r.receita_liquida > 0 ? (r.lucro_bruto / r.receita_liquida) * 100 : 0;
                   return (
                     <TableCell key={r.mes} className="text-right text-sm text-muted-foreground">
@@ -126,7 +127,7 @@ export function DRETab({ data, view, ano }: { data: any[]; view: FinanceiroView;
                 <TableCell className="sticky left-0 bg-background text-sm font-medium text-muted-foreground">
                   Margem Líquida %
                 </TableCell>
-                {rows.map((r: any) => {
+                {rows.map((r) => {
                   const pct = r.receita_liquida > 0 ? (r.resultado_liquido / r.receita_liquida) * 100 : 0;
                   return (
                     <TableCell key={r.mes} className={`text-right text-sm font-medium ${pct >= 0 ? 'text-status-success' : 'text-status-error'}`}>

--- a/src/components/financeiro/dashboard/FluxoCaixaTab.tsx
+++ b/src/components/financeiro/dashboard/FluxoCaixaTab.tsx
@@ -4,8 +4,9 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 import { BarChart3 } from 'lucide-react';
 import { fmtCompact, getWeekLabel } from '@/components/financeiro/dashboard/format';
+import type { FluxoCaixaDiario } from '@/services/financeiroService';
 
-export function FluxoCaixaTab({ data, loading, saldoCC }: { data: any[]; loading: boolean; saldoCC?: number }) {
+export function FluxoCaixaTab({ data, loading, saldoCC }: { data: FluxoCaixaDiario[]; loading: boolean; saldoCC?: number }) {
   if (loading) return <Skeleton className="h-60" />;
   if (!data || data.length === 0) {
     return (

--- a/src/components/financeiro/dashboard/KpiCard.tsx
+++ b/src/components/financeiro/dashboard/KpiCard.tsx
@@ -1,12 +1,13 @@
 // Card de KPI do dashboard financeiro.
 // Extraído de src/pages/FinanceiroDashboard.tsx (god-component split).
 import { Card, CardContent } from '@/components/ui/card';
+import type { LucideIcon } from 'lucide-react';
 import { fmtCompact } from '@/components/financeiro/dashboard/format';
 
 export function KpiCard({ title, value, icon: Icon, color, bgColor, subtitle, subtitleColor }: {
   title: string;
   value: number;
-  icon: any;
+  icon: LucideIcon;
   color: string;
   bgColor: string;
   subtitle?: string;

--- a/src/services/financeiroService.ts
+++ b/src/services/financeiroService.ts
@@ -81,6 +81,7 @@ export interface FinDRE {
   detalhamento: {
     receitas: Record<string, number>;
     despesas: Record<string, number>;
+    categorias_nao_mapeadas?: string[];
   };
 }
 

--- a/tsconfig.strict.json
+++ b/tsconfig.strict.json
@@ -380,6 +380,11 @@
     "src/pages/AdminMonthlyReports.tsx",
     "src/pages/NfeReceipt.tsx",
     "src/pages/ResetPassword.tsx",
-    "src/components/portalSayerlack/PortalDetailDrawer.tsx"
+    "src/components/portalSayerlack/PortalDetailDrawer.tsx",
+    "src/components/financeiro/dashboard/KpiCard.tsx",
+    "src/components/financeiro/dashboard/AgingCard.tsx",
+    "src/components/financeiro/dashboard/FluxoCaixaTab.tsx",
+    "src/components/financeiro/dashboard/DRETab.tsx",
+    "src/components/financeiro/dashboard/DREComparativo.tsx"
   ]
 }


### PR DESCRIPTION
## Resumo

Re-execução da wave 33 sobre a **nova estrutura** pós-#161 (que decompôs o `FinanceiroDashboard`). Os 12 `any` migraram pros componentes extraídos em `src/components/financeiro/dashboard/*` — esta wave tipa todos. **Só tipos, zero runtime.**

- `KpiCard`: `icon: LucideIcon`
- `AgingCard`: `data: AgingData | null`
- `FluxoCaixaTab`: `data: FluxoCaixaDiario[]`
- `DRETab`: `data: FinDRE[]`; `sort`/`map`/`flatMap` inferidos; `dreLines.field` tipado (união das chaves numéricas) → `r[line.field]` vira `number` sem cast
- `DREComparativo`: `data: Record<string, FinDRE[]>`; `lines.field` tipado → `t[line.field]` sem `as any`
- `financeiroService`: `FinDRE.detalhamento` ganha `categorias_nao_mapeadas?: string[]` (campo do backend, antes mascarado) — additive/opcional

**Bônus:** como o #161 deixou esses como small files, os 5 **passam strict limpos** e foram **promovidos pro `tsconfig.strict.json`** (não só lint).

## Validação
- `bun run typecheck:strict` → **0 erros** (com os 5 promovidos)
- `bun lint` → `no-explicit-any` −12; componentes limpos
- `bun run test` → **455/455** verdes

> Substitui o #165 (fechado), que tinha tipado a versão in-file antiga antes do #161.

🤖 Generated with [Claude Code](https://claude.com/claude-code)