### PR TITLE
refactor(typescript): tipa leaf components do dashboard financeiro (-13 any)

### DIFF
--- a/src/components/financeiro/dashboard/AgingCard.tsx
+++ b/src/components/financeiro/dashboard/AgingCard.tsx
@@ -1,10 +1,11 @@
 // Card de aging (faixas de vencimento) do dashboard financeiro.
 // Extraído de src/pages/FinanceiroDashboard.tsx (god-component split).
+import type { AgingData } from '@/services/financeiroService';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 import { fmt, fmtCompact } from '@/components/financeiro/dashboard/format';
 
-export function AgingCard({ title, data }: { title: string; data: any; type: 'receber' | 'pagar' }) {
+export function AgingCard({ title, data }: { title: string; data: AgingData | null; type: 'receber' | 'pagar' }) {
   if (!data) return (
     <Card>
       <CardHeader className="pb-3">

--- a/src/components/financeiro/dashboard/DREComparativo.tsx
+++ b/src/components/financeiro/dashboard/DREComparativo.tsx
@@ -5,14 +5,27 @@ import { Badge } from '@/components/ui/badge';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { PieChart } from 'lucide-react';
 import { COMPANIES, type Company } from '@/contexts/CompanyContext';
+import type { FinDRE } from '@/services/financeiroService';
 import { fmtCompact } from '@/components/financeiro/dashboard/format';
 
-export function DREComparativo({ data, ano }: { data: Record<string, any[]>; ano: number }) {
+type DRETotais = {
+  company: string;
+  receita_liquida: number;
+  lucro_bruto: number;
+  resultado_operacional: number;
+  resultado_liquido: number;
+  impostos: number;
+  margemBruta: number;
+  margemLiquida: number;
+};
+type DRETotaisField = Exclude<keyof DRETotais, 'company'>;
+
+export function DREComparativo({ data, ano }: { data: Record<string, FinDRE[]>; ano: number }) {
   const companies = Object.keys(data);
   if (companies.length < 2) return null;
 
   // Calculate annual totals per company
-  const annualTotals = companies.map(co => {
+  const annualTotals: DRETotais[] = companies.map(co => {
     const rows = data[co] || [];
     const total = rows.reduce(
       (acc, r) => ({
@@ -29,7 +42,7 @@ export function DREComparativo({ data, ano }: { data: Record<string, any[]>; ano
     return { company: co, ...total, margemBruta, margemLiquida };
   });
 
-  const lines: { label: string; field: string; format: 'currency' | 'pct' }[] = [
+  const lines: { label: string; field: DRETotaisField; format: 'currency' | 'pct' }[] = [
     { label: 'Receita Líquida', field: 'receita_liquida', format: 'currency' },
     { label: 'Lucro Bruto', field: 'lucro_bruto', format: 'currency' },
     { label: 'Margem Bruta', field: 'margemBruta', format: 'pct' },
@@ -72,7 +85,7 @@ export function DREComparativo({ data, ano }: { data: Record<string, any[]>; ano
                     {line.label}
                   </TableCell>
                   {annualTotals.map(t => {
-                    const val = (t as any)[line.field] || 0;
+                    const val = t[line.field] || 0;
                     const isResult = line.field.includes('resultado') || line.field === 'margemLiquida';
                     const colorClass = isResult
                       ? val >= 0 ? 'text-status-success' : 'text-status-error'

--- a/src/components/financeiro/dashboard/DRETab.tsx
+++ b/src/components/financeiro/dashboard/DRETab.tsx
@@ -5,9 +5,14 @@ import { Badge } from '@/components/ui/badge';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { AlertTriangle, FileText } from 'lucide-react';
 import { type FinanceiroView } from '@/hooks/useFinanceiro';
+import type { FinDRE } from '@/services/financeiroService';
 import { fmtCompact } from '@/components/financeiro/dashboard/format';
 
-export function DRETab({ data, view, ano }: { data: any[]; view: FinanceiroView; ano: number }) {
+type FinDRENumericField = {
+  [K in keyof FinDRE]: FinDRE[K] extends number ? K : never;
+}[keyof FinDRE];
+
+export function DRETab({ data, view, ano }: { data: FinDRE[]; view: FinanceiroView; ano: number }) {
   if (!data || data.length === 0) {
     return (
       <Card>
@@ -20,17 +25,17 @@ export function DRETab({ data, view, ano }: { data: any[]; view: FinanceiroView;
   }
 
   // Data already comes consolidated from hook (dreConsolidado) — no re-consolidation needed
-  const rows = [...data].sort((a: any, b: any) => a.mes - b.mes);
+  const rows = [...data].sort((a, b) => a.mes - b.mes);
 
   // Ponto 5: check for unmapped categories
-  const unmappedCats = rows.flatMap((r: any) =>
+  const unmappedCats = rows.flatMap((r) =>
     r.detalhamento?.categorias_nao_mapeadas || []
   );
   const uniqueUnmapped = [...new Set(unmappedCats)];
 
   const meses = ['Jan', 'Fev', 'Mar', 'Abr', 'Mai', 'Jun', 'Jul', 'Ago', 'Set', 'Out', 'Nov', 'Dez'];
 
-  const dreLines = [
+  const dreLines: { label: string; field: FinDRENumericField; bold: boolean; color: string }[] = [
     { label: 'Receita Bruta', field: 'receita_bruta', bold: true, color: '' },
     { label: '(-) Deduções', field: 'deducoes', bold: false, color: 'text-status-error' },
     { label: '= Receita Líquida', field: 'receita_liquida', bold: true, color: '' },
@@ -81,7 +86,7 @@ export function DRETab({ data, view, ano }: { data: any[]; view: FinanceiroView;
             <TableHeader>
               <TableRow>
                 <TableHead className="sticky left-0 bg-background min-w-[180px]">Linha</TableHead>
-                {rows.map((r: any) => (
+                {rows.map((r) => (
                   <TableHead key={r.mes} className="text-right min-w-[100px]">
                     {meses[r.mes - 1]}
                   </TableHead>
@@ -94,7 +99,7 @@ export function DRETab({ data, view, ano }: { data: any[]; view: FinanceiroView;
                   <TableCell className={`sticky left-0 bg-background text-sm ${line.bold ? 'font-bold' : ''}`}>
                     {line.label}
                   </TableCell>
-                  {rows.map((r: any) => {
+                  {rows.map((r) => {
                     const val = r[line.field] || 0;
                     const colorClass = line.color || (line.bold && line.field.includes('resultado')
                       ? (val >= 0 ? 'text-status-success' : 'text-status-error')
@@ -112,7 +117,7 @@ export function DRETab({ data, view, ano }: { data: any[]; view: FinanceiroView;
                 <TableCell className="sticky left-0 bg-background text-sm font-medium text-muted-foreground">
                   Margem Bruta %
                 </TableCell>
-                {rows.map((r: any) => {
+                {rows.map((r) => {
                   const pct = r.receita_liquida > 0 ? (r.lucro_bruto / r.receita_liquida) * 100 : 0;
                   return (
                     <TableCell key={r.mes} className="text-right text-sm text-muted-foreground">
@@ -126,7 +131,7 @@ export function DRETab({ data, view, ano }: { data: any[]; view: FinanceiroView;
                 <TableCell className="sticky left-0 bg-background text-sm font-medium text-muted-foreground">
                   Margem Líquida %
                 </TableCell>
-                {rows.map((r: any) => {
+                {rows.map((r) => {
                   const pct = r.receita_liquida > 0 ? (r.resultado_liquido / r.receita_liquida) * 100 : 0;
                   return (
                     <TableCell key={r.mes} className={`text-right text-sm font-medium ${pct >= 0 ? 'text-status-success' : 'text-status-error'}`}>

--- a/src/components/financeiro/dashboard/FluxoCaixaTab.tsx
+++ b/src/components/financeiro/dashboard/FluxoCaixaTab.tsx
@@ -1,11 +1,12 @@
 // Tab de Fluxo de Caixa (visão semanal) do dashboard financeiro.
 // Extraído de src/pages/FinanceiroDashboard.tsx (god-component split).
+import type { FluxoCaixaDiario } from '@/services/financeiroService';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 import { BarChart3 } from 'lucide-react';
 import { fmtCompact, getWeekLabel } from '@/components/financeiro/dashboard/format';
 
-export function FluxoCaixaTab({ data, loading, saldoCC }: { data: any[]; loading: boolean; saldoCC?: number }) {
+export function FluxoCaixaTab({ data, loading, saldoCC }: { data: FluxoCaixaDiario[]; loading: boolean; saldoCC?: number }) {
   if (loading) return <Skeleton className="h-60" />;
   if (!data || data.length === 0) {
     return (

--- a/src/components/financeiro/dashboard/KpiCard.tsx
+++ b/src/components/financeiro/dashboard/KpiCard.tsx
@@ -1,12 +1,13 @@
 // Card de KPI do dashboard financeiro.
 // Extraído de src/pages/FinanceiroDashboard.tsx (god-component split).
+import type { LucideIcon } from 'lucide-react';
 import { Card, CardContent } from '@/components/ui/card';
 import { fmtCompact } from '@/components/financeiro/dashboard/format';
 
 export function KpiCard({ title, value, icon: Icon, color, bgColor, subtitle, subtitleColor }: {
   title: string;
   value: number;
-  icon: any;
+  icon: LucideIcon;
   color: string;
   bgColor: string;
   subtitle?: string;

--- a/src/components/financeiro/dashboard/__tests__/DREComparativo.test.tsx
+++ b/src/components/financeiro/dashboard/__tests__/DREComparativo.test.tsx
@@ -1,11 +1,12 @@
 import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { DREComparativo } from '../DREComparativo';
+import { makeDRE } from './factories';
 
-const row = {
+const row = makeDRE({
   receita_liquida: 9000, lucro_bruto: 5000, resultado_operacional: 3000,
   resultado_liquido: 2500, impostos: 600,
-};
+});
 
 describe('DREComparativo', () => {
   it('menos de 2 empresas → não renderiza nada', () => {

--- a/src/components/financeiro/dashboard/__tests__/DRETab.test.tsx
+++ b/src/components/financeiro/dashboard/__tests__/DRETab.test.tsx
@@ -1,14 +1,15 @@
 import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { DRETab } from '../DRETab';
+import { makeDRE } from './factories';
 
-const row = {
+const row = makeDRE({
   mes: 1,
   receita_bruta: 10000, deducoes: 1000, receita_liquida: 9000, cmv: 4000, lucro_bruto: 5000,
   despesas_operacionais: 1000, despesas_administrativas: 500, despesas_comerciais: 300,
   despesas_financeiras: 100, receitas_financeiras: 50, resultado_operacional: 3150,
-  impostos: 600, resultado_liquido: 2550, detalhamento: {},
-};
+  impostos: 600, resultado_liquido: 2550,
+});
 
 describe('DRETab', () => {
   it('vazio → mensagem de recalcular', () => {
@@ -26,7 +27,7 @@ describe('DRETab', () => {
   });
 
   it('categorias não mapeadas → aviso de heurística', () => {
-    const unmapped = [{ ...row, detalhamento: { categorias_nao_mapeadas: ['CAT_X'] } }];
+    const unmapped = [{ ...row, detalhamento: { receitas: {}, despesas: {}, categorias_nao_mapeadas: ['CAT_X'] } }];
     render(<DRETab data={unmapped} view="all" ano={2026} />);
     expect(screen.getByText(/classificadas por heurística/)).toBeTruthy();
     expect(screen.getByText(/CAT_X/)).toBeTruthy();

--- a/src/components/financeiro/dashboard/__tests__/FluxoCaixaTab.test.tsx
+++ b/src/components/financeiro/dashboard/__tests__/FluxoCaixaTab.test.tsx
@@ -1,10 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { FluxoCaixaTab } from '../FluxoCaixaTab';
+import { makeFluxoDia } from './factories';
 
 const days = [
-  { data: '2026-01-05', entradas_realizadas: 1000, saidas_realizadas: 400, entradas_previstas: 0, saidas_previstas: 0 },
-  { data: '2099-01-05', entradas_realizadas: 0, saidas_realizadas: 0, entradas_previstas: 800, saidas_previstas: 300 },
+  makeFluxoDia({ data: '2026-01-05', entradas_realizadas: 1000, saidas_realizadas: 400 }),
+  makeFluxoDia({ data: '2099-01-05', entradas_previstas: 800, saidas_previstas: 300 }),
 ];
 
 describe('FluxoCaixaTab', () => {

--- a/src/components/financeiro/dashboard/__tests__/factories.ts
+++ b/src/components/financeiro/dashboard/__tests__/factories.ts
@@ -1,0 +1,41 @@
+import type { FinDRE, FluxoCaixaDiario } from '@/services/financeiroService';
+
+export function makeDRE(overrides: Partial<FinDRE> = {}): FinDRE {
+  return {
+    company: 'oben',
+    ano: 2026,
+    mes: 1,
+    regime: 'caixa',
+    receita_bruta: 0,
+    deducoes: 0,
+    receita_liquida: 0,
+    cmv: 0,
+    lucro_bruto: 0,
+    despesas_operacionais: 0,
+    despesas_administrativas: 0,
+    despesas_comerciais: 0,
+    despesas_financeiras: 0,
+    receitas_financeiras: 0,
+    resultado_operacional: 0,
+    outras_receitas: 0,
+    outras_despesas: 0,
+    resultado_antes_impostos: 0,
+    impostos: 0,
+    resultado_liquido: 0,
+    detalhamento: { receitas: {}, despesas: {} },
+    ...overrides,
+  };
+}
+
+export function makeFluxoDia(overrides: Partial<FluxoCaixaDiario> = {}): FluxoCaixaDiario {
+  return {
+    data: '2026-01-01',
+    entradas_previstas: 0,
+    entradas_realizadas: 0,
+    saidas_previstas: 0,
+    saidas_realizadas: 0,
+    saldo_previsto: 0,
+    saldo_realizado: 0,
+    ...overrides,
+  };
+}

--- a/src/pages/FarmerDashboard.tsx
+++ b/src/pages/FarmerDashboard.tsx
@@ -15,6 +15,7 @@ import {
   Eye, ShoppingCart,
 } from 'lucide-react';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { CallButton } from '@/components/call/CallButton';
 
 // ─── Helpers ─────────────────────────────────────────────────────────
 const healthColors: Record<string, { bg: string; text: string; border: string }> = {

--- a/src/services/financeiroService.ts
+++ b/src/services/financeiroService.ts
@@ -81,6 +81,7 @@ export interface FinDRE {
   detalhamento: {
     receitas: Record<string, number>;
     despesas: Record<string, number>;
+    categorias_nao_mapeadas?: string[];
   };
 }
 

--- a/tsconfig.strict.json
+++ b/tsconfig.strict.json
@@ -382,6 +382,12 @@
     "src/pages/AdminMonthlyReports.tsx",
     "src/pages/NfeReceipt.tsx",
     "src/pages/ResetPassword.tsx",
-    "src/components/portalSayerlack/PortalDetailDrawer.tsx"
+    "src/components/portalSayerlack/PortalDetailDrawer.tsx",
+    "src/components/financeiro/dashboard/format.ts",
+    "src/components/financeiro/dashboard/KpiCard.tsx",
+    "src/components/financeiro/dashboard/AgingCard.tsx",
+    "src/components/financeiro/dashboard/DREComparativo.tsx",
+    "src/components/financeiro/dashboard/DRETab.tsx",
+    "src/components/financeiro/dashboard/FluxoCaixaTab.tsx"
   ]
 }


### PR DESCRIPTION
## Resumo

Elimina os **13 erros `@typescript-eslint/no-explicit-any`** introduzidos pelo split do `FinanceiroDashboard` (#161) nos leaf components de `src/components/financeiro/dashboard/`, seguindo o padrão da Wave 26 (`financeiroAlerts.ts`).

- `KpiCard`: `icon: any` → `icon: LucideIcon`
- `AgingCard`: `data: any` → `data: AgingData | null`
- `DREComparativo`: `data: Record<string, any[]>` → `Record<string, FinDRE[]>`; `(t as any)[line.field]` → tipo derivado `DRETotaisField`
- `DRETab`: `data: any[]` → `FinDRE[]`; callbacks `(r: any)` tipadas; `dreLines` usa `FinDRENumericField` (mapped type das chaves numéricas de `FinDRE`)
- `FluxoCaixaTab`: `data: any[]` → `FluxoCaixaDiario[]`

Mudanças de apoio:
- `FinDRE.detalhamento` ganha `categorias_nao_mapeadas?: string[]` (campo já escrito pela edge function `omie-financeiro`, faltava no tipo)
- Mocks dos testes passam a usar factory tipada (`makeDRE`/`makeFluxoDia`) em `__tests__/factories.ts`
- Os 5 componentes + `format.ts` entram no `include` de `tsconfig.strict.json` (strict-clean)

### Fix secundário (build-break herdado de main)
- `fix(farmer)`: #163 deixou `<CallButton>` em `FarmerDashboard.tsx:160` **sem o import**, quebrando `tsc --noEmit -p tsconfig.app.json`. Adicionado o import (espelha `Customer360.tsx`).

## Validação
- `bunx eslint src/components/financeiro/dashboard/ src/pages/FinanceiroDashboard.tsx` → **0 erros** (2 warnings `exhaustive-deps` pré-existentes)
- `bun run typecheck:strict` → **exit 0** (com os 5 componentes + format.ts já no strict include)
- `bunx tsc --noEmit -p tsconfig.app.json` → **exit 0** (após o fix do import)
- `bun run test` → **455/455 passando**
- `codex review --uncommitted` → sem findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)