### PR TITLE
refactor(types): elimina 12 no-explicit-any do par RoutePlanner

### DIFF
--- a/src/hooks/useRoutePlanner.ts
+++ b/src/hooks/useRoutePlanner.ts
@@ -21,6 +21,27 @@ import type {
 } from '@/components/reposicao/routePlanner/types';
 import { enrichWithPriority } from '@/components/reposicao/routePlanner/priority';
 import { STOP_DURATION_MIN } from '@/components/reposicao/routePlanner/constants';
+import type { Tables } from '@/integrations/supabase/types';
+
+// Linha de route_visits enriquecida com o nome do cliente (resolvido via profiles).
+export type TodayVisitRow = Tables<'route_visits'> & { customerName: string };
+
+// Endereço cru vindo de orders.address (jsonb) — campos opcionais.
+type RawAddress = {
+  street?: string;
+  number?: string;
+  neighborhood?: string;
+  city?: string;
+  state?: string;
+  zip_code?: string;
+  complement?: string;
+};
+
+// Projeção de user_tools + embed tool_categories(name) usada em loadCommercialStops.
+type OverdueToolRow = {
+  user_id: string;
+  tool_categories: { name: string | null } | null;
+};
 
 export function useRoutePlanner() {
   const navigate = useNavigate();
@@ -42,7 +63,7 @@ export function useRoutePlanner() {
 
   // Visit tracking state
   const [visitStatuses, setVisitStatuses] = useState<Map<string, VisitStatus>>(new Map());
-  const [todayVisits, setTodayVisits] = useState<any[]>([]);
+  const [todayVisits, setTodayVisits] = useState<TodayVisitRow[]>([]);
   // Checkout dialog state
   const [checkoutOpen, setCheckoutOpen] = useState(false);
   const [checkoutTarget, setCheckoutTarget] = useState<{ userId: string; name: string } | null>(null);
@@ -127,7 +148,7 @@ export function useRoutePlanner() {
 
       const stops: RouteStop[] = orders.map(order => {
         const profile = profiles?.find(p => p.user_id === order.user_id);
-        const orderAddress = order.address as any;
+        const orderAddress = order.address as unknown as RawAddress | null;
         const defaultAddr = addresses?.find(a => a.user_id === order.user_id && a.is_default) || addresses?.find(a => a.user_id === order.user_id);
         const addr = orderAddress || defaultAddr;
 
@@ -274,19 +295,19 @@ export function useRoutePlanner() {
 
     if (data && data.length > 0) {
       // Fetch customer names
-      const ids = [...new Set(data.map((v: any) => v.customer_user_id))];
+      const ids = [...new Set(data.map(v => v.customer_user_id))];
       const { data: profs } = await supabase
         .from('profiles')
         .select('user_id, name')
         .in('user_id', ids);
-      const nameMap = new Map((profs || []).map((p: any) => [p.user_id, p.name]));
-      const enriched = data.map((v: any) => ({ ...v, customerName: nameMap.get(v.customer_user_id) || 'Cliente' }));
+      const nameMap = new Map((profs || []).map(p => [p.user_id, p.name]));
+      const enriched: TodayVisitRow[] = data.map(v => ({ ...v, customerName: nameMap.get(v.customer_user_id) || 'Cliente' }));
 
       setTodayVisits(enriched);
 
       // Build active check-in status map
       const statusMap = new Map<string, VisitStatus>();
-      enriched.forEach((visit: any) => {
+      enriched.forEach(visit => {
         if (visit.check_in_at && !visit.check_out_at) {
           statusMap.set(visit.customer_user_id, {
             stopId: visit.customer_user_id,
@@ -473,7 +494,7 @@ export function useRoutePlanner() {
 
       // Group overdue tools by user
       const overdueByUser = new Map<string, string[]>();
-      (overdueTools || []).forEach((t: any) => {
+      ((overdueTools || []) as unknown as OverdueToolRow[]).forEach((t) => {
         const toolName = t.tool_categories?.name || 'Ferramenta';
         if (!overdueByUser.has(t.user_id)) overdueByUser.set(t.user_id, []);
         overdueByUser.get(t.user_id)!.push(toolName);
@@ -501,7 +522,7 @@ export function useRoutePlanner() {
           map.set(addr.user_id, addr);
         }
         return map;
-      }, new Map<string, any>());
+      }, new Map<string, Tables<'addresses'>>());
 
       // Deduplicate: build one stop per customer
       const seen = new Set<string>();
@@ -669,8 +690,8 @@ export function useRoutePlanner() {
               s.id === stop.id ? { ...s, lat: coords.lat, lng: coords.lng } : s
             ));
           }
-        } catch (e: any) {
-          if (e?.name === 'AbortError') break;
+        } catch (e) {
+          if ((e as { name?: string })?.name === 'AbortError') break;
           console.warn('Geocode failed for', stop.address.street);
         }
         // Nominatim rate limit: max 1 req/sec

--- a/src/pages/AdminRoutePlanner.tsx
+++ b/src/pages/AdminRoutePlanner.tsx
@@ -17,7 +17,7 @@ import { ManualModeCard } from '@/components/reposicao/routePlanner/ManualModeCa
 import { useRoutePlanner } from '@/hooks/useRoutePlanner';
 
 // Fix default marker icons for Leaflet + bundlers
-delete (L.Icon.Default.prototype as any)._getIconUrl;
+delete (L.Icon.Default.prototype as { _getIconUrl?: unknown })._getIconUrl;
 L.Icon.Default.mergeOptions({
   iconRetinaUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-icon-2x.png',
   iconUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-icon.png',
@@ -254,11 +254,11 @@ const AdminRoutePlanner = () => {
               </CardContent>
             </Card>
           ) : (
-            [...todayVisits].sort((a: any, b: any) => {
+            [...todayVisits].sort((a, b) => {
               if (!a.check_out_at && b.check_out_at) return -1;
               if (a.check_out_at && !b.check_out_at) return 1;
               return 0;
-            }).map((visit: any) => (
+            }).map((visit) => (
               <TodayVisitCard key={visit.id} visit={visit} />
             ))
           )}


### PR DESCRIPTION
## Resumo
Primeira wave da limpeza de `no-explicit-any` (§10). Tipa o par RoutePlanner usando os tipos gerados do Supabase. **Type-only — runtime idêntico** (casts/anotações apagam no compile).

### useRoutePlanner.ts (9 anys)
- `todayVisits: any[]` → `TodayVisitRow[]` (`Tables<'route_visits'> & { customerName }`)
- `order.address as any` → `as unknown as RawAddress | null`
- callbacks `(v/p/visit)` → inferidos das rows tipadas
- `overdueTools (t: any)` → `OverdueToolRow[]` (projeção do embed `tool_categories(name)`)
- `new Map<string, any>` → `Map<string, Tables<'addresses'>>`
- `catch (e: any)` → `catch (e)` + narrow via `(e as { name?: string })?.name`

### AdminRoutePlanner.tsx (3 anys)
- Leaflet `as any` → `as { _getIconUrl?: unknown }`
- sort/map de `todayVisits` → inferidos do hook (`TodayVisitRow`)

## Validação
- `bunx tsc --noEmit`: 0 · `bun run build`: OK
- `bunx eslint` nos 2 files: **0 errors** (12 `no-explicit-any` eliminados; restam só 2 warnings `exhaustive-deps` pré-existentes)
- Mudança type-only → testes logicamente inalterados (CI roda no runner limpo)
- Codex review: **No findings** (tudo type-only e behavior-equivalent)

> Progresso §10 `no-explicit-any`: ~110 → ~98 restantes. Próximos clusters: `sip-client.ts` (8), `useCustomerContacts.ts` (5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)