### PR TITLE
refactor(typescript): elimina 5 any avulsos (catch tipado + casts obsoletos)

### DIFF
--- a/src/components/ForgotPasswordDialog.tsx
+++ b/src/components/ForgotPasswordDialog.tsx
@@ -54,10 +54,10 @@ export const ForgotPasswordDialog = ({ open, onOpenChange }: ForgotPasswordDialo
       toast.success('E-mail enviado!', {
         description: 'Verifique sua caixa de entrada',
       });
-    } catch (error: any) {
+    } catch (error) {
       console.error('Error sending reset email:', error);
       toast.error('Erro ao enviar e-mail', {
-        description: error.message || 'Tente novamente mais tarde',
+        description: error instanceof Error ? error.message : 'Tente novamente mais tarde',
       });
     } finally {
       setIsLoading(false);

--- a/src/components/TintColorSelectDialog.tsx
+++ b/src/components/TintColorSelectDialog.tsx
@@ -229,7 +229,7 @@ export function TintColorSelectDialog({ product, open, onClose, onConfirm, custo
       if (!orders) return null;
 
       for (const order of orders) {
-        const items = order.items as any[];
+        const items = order.items as Array<{ product_id?: string; tint_cor_id?: string; valor_unitario?: number }>;
         if (!Array.isArray(items)) continue;
         for (const item of items) {
           if (

--- a/src/components/portalSayerlack/DispararAgoraButton.tsx
+++ b/src/components/portalSayerlack/DispararAgoraButton.tsx
@@ -79,8 +79,8 @@ export function DispararAgoraButton({
         }
         onSuccess?.();
       }
-    } catch (err: any) {
-      toast.error(`Falha ao disparar: ${err?.message ?? err}`);
+    } catch (err) {
+      toast.error(`Falha ao disparar: ${err instanceof Error ? err.message : String(err)}`);
     } finally {
       setLoading(false);
     }

--- a/src/components/unified-order/ProductItemForm.tsx
+++ b/src/components/unified-order/ProductItemForm.tsx
@@ -74,7 +74,7 @@ export function ProductItemForm({
                       <div className="flex items-center gap-1 mt-0.5 flex-wrap">
                         <span className="text-[10px] text-muted-foreground font-mono">{product.codigo}</span>
                         {!product.ativo && <Badge variant="destructive" className="text-[9px] px-1 py-0">Inativo</Badge>}
-                        {(product as any).is_tintometric && (
+                        {product.is_tintometric && (
                           <Badge variant="outline" className="text-[9px] px-1 py-0 border-primary/40 text-primary">🎨 Tintométrico</Badge>
                         )}
                         {customerPrice && customerPrice !== product.valor_unitario && (

--- a/src/hooks/unifiedOrder/types.ts
+++ b/src/hooks/unifiedOrder/types.ts
@@ -44,7 +44,7 @@ export interface Product {
   account?: string;
   is_tintometric?: boolean;
   tint_type?: string;
-  metadata?: Record<string, any> | null;
+  metadata?: Record<string, unknown> | null;
 }
 
 export interface ProductCartItem {


### PR DESCRIPTION
## Summary
Wave final de limpeza dos `any` espalhados (baixo risco, 5 sites em 5 arquivos):

- **ForgotPasswordDialog** / **DispararAgoraButton**: `catch (e: any)` → `catch (e)` + narrowing (`e instanceof Error ? e.message : ...`)
- **unifiedOrder/types.ts**: `metadata: Record<string, any>` → `Record<string, unknown>`
- **ProductItemForm**: `(product as any).is_tintometric` → `product.is_tintometric` (o tipo `Product` já declara `is_tintometric?: boolean` — cast obsoleto)
- **TintColorSelectDialog**: `order.items as any[]` → array tipado com o shape realmente usado (`product_id`/`tint_cor_id`/`valor_unitario`)

## Validação
- `bunx tsc --noEmit -p tsconfig.app.json` ✅ (0 erros nos arquivos tocados)
- `bunx eslint` 5 arquivos ✅ 0
- **Codex review**: *"staged source edits look behavior-preserving"*

## Contexto
Fecha a varredura dos avulsos não-gated. O que resta de `any` no repo é majoritariamente: `AdminRoutePlanner` (gated/Leaflet, alto-risco), `financeiro/dashboard` (#161, já flaggado em follow-up), `useRoutePlanner` (vai junto do AdminRoutePlanner), `useSharpeningSuggestions` (deferido — precisa investigação de shape), e os `(supabase.from('X') as any)` de tabelas tipadas que estão com `eslint-disable` (débito aceito, hygiene futura).

## Test plan
- [ ] Reset de senha (erro mostra mensagem)
- [ ] Disparo portal Sayerlack (erro mostra mensagem)
- [ ] Catálogo de produtos no pedido (badge tintométrico aparece)
- [ ] Seleção de cor tintométrica (preço da última compra)

🤖 Generated with [Claude Code](https://claude.com/claude-code)