### PR TITLE
refactor(types): adiciona tabelas kb_* aos tipos + remove 6 casts as any

### DIFF
--- a/src/hooks/useKbProductSpecs.ts
+++ b/src/hooks/useKbProductSpecs.ts
@@ -9,8 +9,7 @@ export function useKbProductSpecs(productCode: string | undefined | null) {
     staleTime: 60_000,
     queryFn: async (): Promise<KbProductSpec | null> => {
       if (!productCode) return null;
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const { data, error } = await (supabase.from('kb_product_specs') as any)
+      const { data, error } = await supabase.from('kb_product_specs')
         .select('*')
         .eq('product_code', productCode)
         .maybeSingle();

--- a/src/hooks/useKbProductSpecsList.ts
+++ b/src/hooks/useKbProductSpecsList.ts
@@ -7,8 +7,7 @@ export function useKbProductSpecsList() {
     queryKey: ['kb-product-specs-list'],
     staleTime: 60_000,
     queryFn: async (): Promise<KbProductSpec[]> => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const { data, error } = await (supabase.from('kb_product_specs') as any)
+      const { data, error } = await supabase.from('kb_product_specs')
         .select('*')
         .not('approved_at', 'is', null)
         .order('product_name', { ascending: true })

--- a/src/hooks/useSaveProductSpecs.ts
+++ b/src/hooks/useSaveProductSpecs.ts
@@ -23,8 +23,7 @@ export function useSaveProductSpecs() {
         approved_at: new Date().toISOString(),
       };
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const { data, error } = await (supabase.from('kb_product_specs') as any)
+      const { data, error } = await supabase.from('kb_product_specs')
         .upsert(payload, { onConflict: 'product_code' })
         .select()
         .single();

--- a/src/hooks/useUploadKbDocument.ts
+++ b/src/hooks/useUploadKbDocument.ts
@@ -30,8 +30,7 @@ export function useUploadKbDocument() {
       if (upErr) throw upErr;
 
       // 2. Insert document
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const { data: doc, error: insErr } = await (supabase.from('kb_documents') as any)
+      const { data: doc, error: insErr } = await supabase.from('kb_documents')
         .insert({
           title: input.title,
           type: input.type,

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -14,273 +14,6 @@ export type Database = {
   }
   public: {
     Tables: {
-      kb_chunks: {
-        Row: {
-          id: string
-          document_id: string
-          chunk_index: number
-          content: string
-          embedding: string | null
-          token_count: number | null
-          char_start: number | null
-          char_end: number | null
-          created_at: string
-        }
-        Insert: {
-          id?: string
-          document_id: string
-          chunk_index: number
-          content: string
-          embedding?: string | null
-          token_count?: number | null
-          char_start?: number | null
-          char_end?: number | null
-          created_at?: string
-        }
-        Update: {
-          id?: string
-          document_id?: string
-          chunk_index?: number
-          content?: string
-          embedding?: string | null
-          token_count?: number | null
-          char_start?: number | null
-          char_end?: number | null
-          created_at?: string
-        }
-        Relationships: [
-          {
-            foreignKeyName: "kb_chunks_document_id_fkey"
-            columns: ["document_id"]
-            isOneToOne: false
-            referencedRelation: "kb_documents"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-      kb_documents: {
-        Row: {
-          id: string
-          title: string
-          type: string
-          supplier: string | null
-          product_code: string | null
-          file_url: string
-          file_size_bytes: number | null
-          content_extracted: string | null
-          tags: string[] | null
-          status: string
-          status_error: string | null
-          version: number
-          parent_id: string | null
-          created_by: string
-          created_at: string
-          updated_at: string
-        }
-        Insert: {
-          id?: string
-          title: string
-          type: string
-          supplier?: string | null
-          product_code?: string | null
-          file_url: string
-          file_size_bytes?: number | null
-          content_extracted?: string | null
-          tags?: string[] | null
-          status?: string
-          status_error?: string | null
-          version?: number
-          parent_id?: string | null
-          created_by: string
-          created_at?: string
-          updated_at?: string
-        }
-        Update: {
-          id?: string
-          title?: string
-          type?: string
-          supplier?: string | null
-          product_code?: string | null
-          file_url?: string
-          file_size_bytes?: number | null
-          content_extracted?: string | null
-          tags?: string[] | null
-          status?: string
-          status_error?: string | null
-          version?: number
-          parent_id?: string | null
-          created_by?: string
-          created_at?: string
-          updated_at?: string
-        }
-        Relationships: [
-          {
-            foreignKeyName: "kb_documents_parent_id_fkey"
-            columns: ["parent_id"]
-            isOneToOne: false
-            referencedRelation: "kb_documents"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-      kb_product_specs: {
-        Row: {
-          id: string
-          document_id: string | null
-          product_code: string
-          product_name: string
-          supplier: string
-          product_line: string | null
-          product_category: string | null
-          densidade_g_cm3: number | null
-          solidos_pct: number | null
-          viscosidade_aplicacao_s: number | null
-          viscosidade_copo: string | null
-          brilho_ub: number | null
-          dureza: string | null
-          rendimento_m2_por_litro: number | null
-          demaos_recomendadas: number | null
-          gramatura_g_m2_min: number | null
-          gramatura_g_m2_max: number | null
-          pot_life_horas: number | null
-          temp_aplicacao_c_min: number | null
-          temp_aplicacao_c_max: number | null
-          umidade_aplicacao_pct_min: number | null
-          umidade_aplicacao_pct_max: number | null
-          catalisador_codigo: string | null
-          catalisador_proporcao_pct: number | null
-          diluente_codigo: string | null
-          equipamentos_aplicacao: string[] | null
-          lixa_recomendada: string | null
-          substrato: string[] | null
-          secagem_manuseio_h: number | null
-          secagem_empilhamento_h: number | null
-          secagem_total_h: number | null
-          validade_dias: number | null
-          temp_armazenamento_c_min: number | null
-          temp_armazenamento_c_max: number | null
-          certificacoes_aplicaveis: string[] | null
-          isento_metais_pesados: string[] | null
-          isento_substancias: string[] | null
-          diferenciais_chave: string[] | null
-          uso_recomendado: string | null
-          publico_alvo: string | null
-          extraction_confidence: number | null
-          extraction_gaps: string[] | null
-          extracted_by: string | null
-          approved_by: string | null
-          approved_at: string | null
-          created_at: string
-          updated_at: string
-        }
-        Insert: {
-          id?: string
-          document_id?: string | null
-          product_code: string
-          product_name: string
-          supplier?: string
-          product_line?: string | null
-          product_category?: string | null
-          densidade_g_cm3?: number | null
-          solidos_pct?: number | null
-          viscosidade_aplicacao_s?: number | null
-          viscosidade_copo?: string | null
-          brilho_ub?: number | null
-          dureza?: string | null
-          rendimento_m2_por_litro?: number | null
-          demaos_recomendadas?: number | null
-          gramatura_g_m2_min?: number | null
-          gramatura_g_m2_max?: number | null
-          pot_life_horas?: number | null
-          temp_aplicacao_c_min?: number | null
-          temp_aplicacao_c_max?: number | null
-          umidade_aplicacao_pct_min?: number | null
-          umidade_aplicacao_pct_max?: number | null
-          catalisador_codigo?: string | null
-          catalisador_proporcao_pct?: number | null
-          diluente_codigo?: string | null
-          equipamentos_aplicacao?: string[] | null
-          lixa_recomendada?: string | null
-          substrato?: string[] | null
-          secagem_manuseio_h?: number | null
-          secagem_empilhamento_h?: number | null
-          secagem_total_h?: number | null
-          validade_dias?: number | null
-          temp_armazenamento_c_min?: number | null
-          temp_armazenamento_c_max?: number | null
-          certificacoes_aplicaveis?: string[] | null
-          isento_metais_pesados?: string[] | null
-          isento_substancias?: string[] | null
-          diferenciais_chave?: string[] | null
-          uso_recomendado?: string | null
-          publico_alvo?: string | null
-          extraction_confidence?: number | null
-          extraction_gaps?: string[] | null
-          extracted_by?: string | null
-          approved_by?: string | null
-          approved_at?: string | null
-          created_at?: string
-          updated_at?: string
-        }
-        Update: {
-          id?: string
-          document_id?: string | null
-          product_code?: string
-          product_name?: string
-          supplier?: string
-          product_line?: string | null
-          product_category?: string | null
-          densidade_g_cm3?: number | null
-          solidos_pct?: number | null
-          viscosidade_aplicacao_s?: number | null
-          viscosidade_copo?: string | null
-          brilho_ub?: number | null
-          dureza?: string | null
-          rendimento_m2_por_litro?: number | null
-          demaos_recomendadas?: number | null
-          gramatura_g_m2_min?: number | null
-          gramatura_g_m2_max?: number | null
-          pot_life_horas?: number | null
-          temp_aplicacao_c_min?: number | null
-          temp_aplicacao_c_max?: number | null
-          umidade_aplicacao_pct_min?: number | null
-          umidade_aplicacao_pct_max?: number | null
-          catalisador_codigo?: string | null
-          catalisador_proporcao_pct?: number | null
-          diluente_codigo?: string | null
-          equipamentos_aplicacao?: string[] | null
-          lixa_recomendada?: string | null
-          substrato?: string[] | null
-          secagem_manuseio_h?: number | null
-          secagem_empilhamento_h?: number | null
-          secagem_total_h?: number | null
-          validade_dias?: number | null
-          temp_armazenamento_c_min?: number | null
-          temp_armazenamento_c_max?: number | null
-          certificacoes_aplicaveis?: string[] | null
-          isento_metais_pesados?: string[] | null
-          isento_substancias?: string[] | null
-          diferenciais_chave?: string[] | null
-          uso_recomendado?: string | null
-          publico_alvo?: string | null
-          extraction_confidence?: number | null
-          extraction_gaps?: string[] | null
-          extracted_by?: string | null
-          approved_by?: string | null
-          approved_at?: string | null
-          created_at?: string
-          updated_at?: string
-        }
-        Relationships: [
-          {
-            foreignKeyName: "kb_product_specs_document_id_fkey"
-            columns: ["document_id"]
-            isOneToOne: false
-            referencedRelation: "kb_documents"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
       abc_xyz_classification: {
         Row: {
           classe_abc: Database["public"]["Enums"]["classe_abc"] | null
@@ -3174,6 +2907,7 @@ export type Database = {
         Row: {
           adiantamento_categorias_codigos: string[]
           company: string
+          dre_tributario: Json
           folha_categorias_codigos: string[]
           overrides_cenario: Json
           thresholds: Json
@@ -3183,6 +2917,7 @@ export type Database = {
         Insert: {
           adiantamento_categorias_codigos?: string[]
           company: string
+          dre_tributario?: Json
           folha_categorias_codigos?: string[]
           overrides_cenario?: Json
           thresholds?: Json
@@ -3192,6 +2927,7 @@ export type Database = {
         Update: {
           adiantamento_categorias_codigos?: string[]
           company?: string
+          dre_tributario?: Json
           folha_categorias_codigos?: string[]
           overrides_cenario?: Json
           thresholds?: Json

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -14,6 +14,273 @@ export type Database = {
   }
   public: {
     Tables: {
+      kb_chunks: {
+        Row: {
+          id: string
+          document_id: string
+          chunk_index: number
+          content: string
+          embedding: string | null
+          token_count: number | null
+          char_start: number | null
+          char_end: number | null
+          created_at: string
+        }
+        Insert: {
+          id?: string
+          document_id: string
+          chunk_index: number
+          content: string
+          embedding?: string | null
+          token_count?: number | null
+          char_start?: number | null
+          char_end?: number | null
+          created_at?: string
+        }
+        Update: {
+          id?: string
+          document_id?: string
+          chunk_index?: number
+          content?: string
+          embedding?: string | null
+          token_count?: number | null
+          char_start?: number | null
+          char_end?: number | null
+          created_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "kb_chunks_document_id_fkey"
+            columns: ["document_id"]
+            isOneToOne: false
+            referencedRelation: "kb_documents"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      kb_documents: {
+        Row: {
+          id: string
+          title: string
+          type: string
+          supplier: string | null
+          product_code: string | null
+          file_url: string
+          file_size_bytes: number | null
+          content_extracted: string | null
+          tags: string[] | null
+          status: string
+          status_error: string | null
+          version: number
+          parent_id: string | null
+          created_by: string
+          created_at: string
+          updated_at: string
+        }
+        Insert: {
+          id?: string
+          title: string
+          type: string
+          supplier?: string | null
+          product_code?: string | null
+          file_url: string
+          file_size_bytes?: number | null
+          content_extracted?: string | null
+          tags?: string[] | null
+          status?: string
+          status_error?: string | null
+          version?: number
+          parent_id?: string | null
+          created_by: string
+          created_at?: string
+          updated_at?: string
+        }
+        Update: {
+          id?: string
+          title?: string
+          type?: string
+          supplier?: string | null
+          product_code?: string | null
+          file_url?: string
+          file_size_bytes?: number | null
+          content_extracted?: string | null
+          tags?: string[] | null
+          status?: string
+          status_error?: string | null
+          version?: number
+          parent_id?: string | null
+          created_by?: string
+          created_at?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "kb_documents_parent_id_fkey"
+            columns: ["parent_id"]
+            isOneToOne: false
+            referencedRelation: "kb_documents"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      kb_product_specs: {
+        Row: {
+          id: string
+          document_id: string | null
+          product_code: string
+          product_name: string
+          supplier: string
+          product_line: string | null
+          product_category: string | null
+          densidade_g_cm3: number | null
+          solidos_pct: number | null
+          viscosidade_aplicacao_s: number | null
+          viscosidade_copo: string | null
+          brilho_ub: number | null
+          dureza: string | null
+          rendimento_m2_por_litro: number | null
+          demaos_recomendadas: number | null
+          gramatura_g_m2_min: number | null
+          gramatura_g_m2_max: number | null
+          pot_life_horas: number | null
+          temp_aplicacao_c_min: number | null
+          temp_aplicacao_c_max: number | null
+          umidade_aplicacao_pct_min: number | null
+          umidade_aplicacao_pct_max: number | null
+          catalisador_codigo: string | null
+          catalisador_proporcao_pct: number | null
+          diluente_codigo: string | null
+          equipamentos_aplicacao: string[] | null
+          lixa_recomendada: string | null
+          substrato: string[] | null
+          secagem_manuseio_h: number | null
+          secagem_empilhamento_h: number | null
+          secagem_total_h: number | null
+          validade_dias: number | null
+          temp_armazenamento_c_min: number | null
+          temp_armazenamento_c_max: number | null
+          certificacoes_aplicaveis: string[] | null
+          isento_metais_pesados: string[] | null
+          isento_substancias: string[] | null
+          diferenciais_chave: string[] | null
+          uso_recomendado: string | null
+          publico_alvo: string | null
+          extraction_confidence: number | null
+          extraction_gaps: string[] | null
+          extracted_by: string | null
+          approved_by: string | null
+          approved_at: string | null
+          created_at: string
+          updated_at: string
+        }
+        Insert: {
+          id?: string
+          document_id?: string | null
+          product_code: string
+          product_name: string
+          supplier?: string
+          product_line?: string | null
+          product_category?: string | null
+          densidade_g_cm3?: number | null
+          solidos_pct?: number | null
+          viscosidade_aplicacao_s?: number | null
+          viscosidade_copo?: string | null
+          brilho_ub?: number | null
+          dureza?: string | null
+          rendimento_m2_por_litro?: number | null
+          demaos_recomendadas?: number | null
+          gramatura_g_m2_min?: number | null
+          gramatura_g_m2_max?: number | null
+          pot_life_horas?: number | null
+          temp_aplicacao_c_min?: number | null
+          temp_aplicacao_c_max?: number | null
+          umidade_aplicacao_pct_min?: number | null
+          umidade_aplicacao_pct_max?: number | null
+          catalisador_codigo?: string | null
+          catalisador_proporcao_pct?: number | null
+          diluente_codigo?: string | null
+          equipamentos_aplicacao?: string[] | null
+          lixa_recomendada?: string | null
+          substrato?: string[] | null
+          secagem_manuseio_h?: number | null
+          secagem_empilhamento_h?: number | null
+          secagem_total_h?: number | null
+          validade_dias?: number | null
+          temp_armazenamento_c_min?: number | null
+          temp_armazenamento_c_max?: number | null
+          certificacoes_aplicaveis?: string[] | null
+          isento_metais_pesados?: string[] | null
+          isento_substancias?: string[] | null
+          diferenciais_chave?: string[] | null
+          uso_recomendado?: string | null
+          publico_alvo?: string | null
+          extraction_confidence?: number | null
+          extraction_gaps?: string[] | null
+          extracted_by?: string | null
+          approved_by?: string | null
+          approved_at?: string | null
+          created_at?: string
+          updated_at?: string
+        }
+        Update: {
+          id?: string
+          document_id?: string | null
+          product_code?: string
+          product_name?: string
+          supplier?: string
+          product_line?: string | null
+          product_category?: string | null
+          densidade_g_cm3?: number | null
+          solidos_pct?: number | null
+          viscosidade_aplicacao_s?: number | null
+          viscosidade_copo?: string | null
+          brilho_ub?: number | null
+          dureza?: string | null
+          rendimento_m2_por_litro?: number | null
+          demaos_recomendadas?: number | null
+          gramatura_g_m2_min?: number | null
+          gramatura_g_m2_max?: number | null
+          pot_life_horas?: number | null
+          temp_aplicacao_c_min?: number | null
+          temp_aplicacao_c_max?: number | null
+          umidade_aplicacao_pct_min?: number | null
+          umidade_aplicacao_pct_max?: number | null
+          catalisador_codigo?: string | null
+          catalisador_proporcao_pct?: number | null
+          diluente_codigo?: string | null
+          equipamentos_aplicacao?: string[] | null
+          lixa_recomendada?: string | null
+          substrato?: string[] | null
+          secagem_manuseio_h?: number | null
+          secagem_empilhamento_h?: number | null
+          secagem_total_h?: number | null
+          validade_dias?: number | null
+          temp_armazenamento_c_min?: number | null
+          temp_armazenamento_c_max?: number | null
+          certificacoes_aplicaveis?: string[] | null
+          isento_metais_pesados?: string[] | null
+          isento_substancias?: string[] | null
+          diferenciais_chave?: string[] | null
+          uso_recomendado?: string | null
+          publico_alvo?: string | null
+          extraction_confidence?: number | null
+          extraction_gaps?: string[] | null
+          extracted_by?: string | null
+          approved_by?: string | null
+          approved_at?: string | null
+          created_at?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "kb_product_specs_document_id_fkey"
+            columns: ["document_id"]
+            isOneToOne: false
+            referencedRelation: "kb_documents"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       abc_xyz_classification: {
         Row: {
           classe_abc: Database["public"]["Enums"]["classe_abc"] | null

--- a/src/pages/AdminKnowledgeBaseDetail.tsx
+++ b/src/pages/AdminKnowledgeBaseDetail.tsx
@@ -18,8 +18,7 @@ export default function AdminKnowledgeBaseDetail() {
     queryKey: ['kb-document', id],
     enabled: !!id,
     queryFn: async (): Promise<KbDocument | null> => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const { data, error } = await (supabase.from('kb_documents') as any)
+      const { data, error } = await supabase.from('kb_documents')
         .select('*')
         .eq('id', id!)
         .single();
@@ -34,8 +33,7 @@ export default function AdminKnowledgeBaseDetail() {
     queryKey: ['kb-chunks-count', id],
     enabled: !!id,
     queryFn: async () => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const { count } = await (supabase.from('kb_chunks') as any)
+      const { count } = await supabase.from('kb_chunks')
         .select('*', { count: 'exact', head: true })
         .eq('document_id', id);
       return count ?? 0;


### PR DESCRIPTION
## Resumo
**Item 1 / Wave kb_*** do plano de tipagem. Causa-raiz dos casts `as any` era o `types.ts` **desatualizado** — as tabelas `kb_documents`/`kb_chunks`/`kb_product_specs` nunca foram geradas nos tipos do Supabase.

Adiciono `Row/Insert/Update/Relationships` das 3 tabelas (escritos a partir dos `CREATE TABLE` das migrations `kb_foundation` + `kb_specs_and_competitors`) e removo os 6 `(supabase.from('kb_*') as any)`:
- `useKbProductSpecsList`, `useKbProductSpecs`, `useSaveProductSpecs` → `kb_product_specs`
- `useUploadKbDocument`, `AdminKnowledgeBaseDetail` → `kb_documents` + `kb_chunks`

Agora essas queries são **type-safe de verdade** — o `TechnicalDocs.tsx` listava "as any extensivo → erros de schema passam silenciosamente" como risco; isso fecha o risco para o módulo KB.

## Validação
- `bunx tsc --noEmit`: **0** (upsert/insert/select tipados batem com o schema — sem fallout)
- `bun run build`: OK · eslint: **0 `no-explicit-any`** nos files
- Codex review: **No findings** (tipos internamente consistentes com o schema, casts runtime-idênticos, Relationships válidos)

> Nota: 1 `no-useless-escape` pré-existente em useUploadKbDocument.ts:23 (regex `\-`) fica fora de escopo (não é `no-explicit-any`).
>
> Progresso §10 `no-explicit-any`: ~93 → ~87. Próximas waves: customer_* (11), farmer_* + commercial_roles (6), standard_processes + profiles.razao_social.

🤖 Generated with [Claude Code](https://claude.com/claude-code)