### PR TITLE
refactor(farmer): split god-component FarmerCalls (864→474)

### DIFF
--- a/src/components/farmer/calls/AgendaQueueCard.tsx
+++ b/src/components/farmer/calls/AgendaQueueCard.tsx
@@ -1,0 +1,93 @@
+// Fila de "Próximas ligações" (agenda priorizada) da página de Ligações.
+// Extraída de src/pages/FarmerCalls.tsx (god-component split).
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { PhoneCall, Loader2, CheckCircle, Phone, FileText } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { Dialer } from '@/components/call/Dialer';
+import type { AgendaItem, ClientScore } from '@/hooks/useFarmerScoring';
+import { AGENDA_TYPE_META } from './types';
+
+type DialerEndData = { duration: number; state: string; audioLink: string | null };
+
+export function AgendaQueueCard({
+  agenda, clientScores, agendaLoading, onCallEnd, onRegister,
+}: {
+  agenda: AgendaItem[];
+  clientScores: ClientScore[];
+  agendaLoading: boolean;
+  onCallEnd: (item: AgendaItem, phone: string, data: DialerEndData) => void;
+  onRegister: (item: AgendaItem, phone: string | null | undefined) => void;
+}) {
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-sm font-medium flex items-center gap-2">
+          <PhoneCall className="w-4 h-4 text-primary" />
+          Próximas ligações
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        {agendaLoading ? (
+          <div className="flex justify-center py-6"><Loader2 className="w-5 h-5 animate-spin text-muted-foreground" /></div>
+        ) : agenda.length === 0 ? (
+          <div className="text-center py-6">
+            <CheckCircle className="w-6 h-6 mx-auto mb-2 text-primary/60" />
+            <p className="text-sm text-muted-foreground">Nenhuma ligação pendente na agenda. Bom trabalho!</p>
+          </div>
+        ) : (
+          agenda.slice(0, 5).map(item => {
+            const meta = AGENDA_TYPE_META[item.agendaType] || AGENDA_TYPE_META.follow_up;
+            const Icon = meta.icon;
+            const score = clientScores.find(c => c.customer_user_id === item.customer_user_id);
+            const phone = score?.customer_phone;
+
+            return (
+              <div key={item.customer_user_id} className="flex items-center gap-3 rounded-lg border p-3">
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2 mb-0.5">
+                    <p className="text-sm font-medium truncate">{item.customer_name}</p>
+                    <Badge variant="outline" className={cn('text-[10px] shrink-0', meta.color)}>
+                      <Icon className="w-3 h-3 mr-0.5" /> {meta.label}
+                    </Badge>
+                  </div>
+                  <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                    <span>Prioridade: {item.priorityScore.toFixed(1)}</span>
+                    {phone && (
+                      <>
+                        <span>·</span>
+                        <span>{phone}</span>
+                      </>
+                    )}
+                  </div>
+                </div>
+                <div className="flex items-center gap-1.5 shrink-0">
+                  {phone ? (
+                    <Dialer
+                      phoneNumber={phone}
+                      customerName={item.customer_name}
+                      compact
+                      onCallEnd={(data) => onCallEnd(item, phone, data)}
+                    />
+                  ) : (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <span><Button size="icon" variant="ghost" className="h-8 w-8" disabled><Phone className="w-4 h-4" /></Button></span>
+                      </TooltipTrigger>
+                      <TooltipContent><p className="text-xs">Sem telefone cadastrado</p></TooltipContent>
+                    </Tooltip>
+                  )}
+                  <Button size="sm" variant="outline" className="h-8 text-xs gap-1" onClick={() => onRegister(item, phone)}>
+                    <FileText className="w-3 h-3" /> Registrar
+                  </Button>
+                </div>
+              </div>
+            );
+          })
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/farmer/calls/CallDetailPanel.tsx
+++ b/src/components/farmer/calls/CallDetailPanel.tsx
@@ -1,0 +1,109 @@
+// Painel de detalhe de ligação (inspirado no Gong).
+// Extraído de src/pages/FarmerCalls.tsx (god-component split).
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Separator } from '@/components/ui/separator';
+import { DollarSign, ArrowUpRight, FileText, Mic } from 'lucide-react';
+import { format } from 'date-fns';
+import { ptBR } from 'date-fns/locale';
+import { cn } from '@/lib/utils';
+import { CALL_TYPES, CALL_RESULTS, fmt, formatTimer, type CallLog } from './types';
+
+export function CallDetailPanel({ call }: { call: CallLog; onClose: () => void }) {
+  const typeInfo = CALL_TYPES.find(t => t.value === call.call_type);
+  const resultInfo = CALL_RESULTS.find(r => r.value === call.call_result);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h3 className="font-semibold text-foreground">{call.customer_name}</h3>
+        <span className="text-xs text-muted-foreground">
+          {format(new Date(call.created_at), "dd/MM/yy 'às' HH:mm", { locale: ptBR })}
+        </span>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <Badge variant="outline" className={cn('text-[10px]', typeInfo?.color)}>
+          {typeInfo?.label}
+        </Badge>
+        <Badge variant="outline" className="text-[10px]">
+          {resultInfo?.icon} {resultInfo?.label}
+        </Badge>
+        {call.attempt_number > 1 && (
+          <Badge variant="secondary" className="text-[10px]">#{call.attempt_number}</Badge>
+        )}
+      </div>
+
+      {/* Timeline / Player area (Gong-style) */}
+      <Card className="bg-muted/30">
+        <CardContent className="p-4">
+          <div className="flex items-center justify-center gap-6">
+            <div className="text-center">
+              <p className="text-2xl font-mono font-bold">{formatTimer(call.duration_seconds)}</p>
+              <p className="text-[10px] text-muted-foreground mt-0.5">Duração da ligação</p>
+            </div>
+            {call.follow_up_duration_seconds > 0 && (
+              <>
+                <Separator orientation="vertical" className="h-10" />
+                <div className="text-center">
+                  <p className="text-2xl font-mono font-bold">{formatTimer(call.follow_up_duration_seconds)}</p>
+                  <p className="text-[10px] text-muted-foreground mt-0.5">Follow-up</p>
+                </div>
+              </>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Metrics */}
+      {(call.revenue_generated > 0 || call.margin_generated > 0) && (
+        <div className="grid grid-cols-2 gap-3">
+          <Card>
+            <CardContent className="p-3 text-center">
+              <DollarSign className="w-4 h-4 mx-auto text-muted-foreground mb-1" />
+              <p className="text-sm font-bold">{fmt(call.revenue_generated)}</p>
+              <p className="text-[10px] text-muted-foreground">Receita gerada</p>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardContent className="p-3 text-center">
+              <ArrowUpRight className="w-4 h-4 mx-auto text-muted-foreground mb-1" />
+              <p className="text-sm font-bold">{fmt(call.margin_generated)}</p>
+              <p className="text-[10px] text-muted-foreground">Margem gerada</p>
+            </CardContent>
+          </Card>
+        </div>
+      )}
+
+      {/* Transcript placeholder */}
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-xs font-medium text-muted-foreground uppercase tracking-wider flex items-center gap-1.5">
+            <FileText className="w-3.5 h-3.5" /> Transcrição
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {call.notes ? (
+            <p className="text-sm text-foreground whitespace-pre-wrap">{call.notes}</p>
+          ) : (
+            <div className="text-center py-6">
+              <Mic className="w-6 h-6 mx-auto mb-2 text-muted-foreground/40" />
+              <p className="text-xs text-muted-foreground">Nenhuma transcrição disponível</p>
+              <p className="text-[10px] text-muted-foreground mt-0.5">Use o Copilot para transcrever em tempo real.</p>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Next steps placeholder */}
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-xs font-medium text-muted-foreground uppercase tracking-wider">Próximos passos</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-xs text-muted-foreground">Nenhum próximo passo registrado.</p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/farmer/calls/CallListPanel.tsx
+++ b/src/components/farmer/calls/CallListPanel.tsx
@@ -1,0 +1,104 @@
+// Lista de ligações + painel de detalhe (split estilo Gong) da página de Ligações.
+// Extraído de src/pages/FarmerCalls.tsx (god-component split).
+import { Card, CardContent } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Filter, Loader2, Phone, Clock, ChevronRight } from 'lucide-react';
+import { format } from 'date-fns';
+import { ptBR } from 'date-fns/locale';
+import { cn } from '@/lib/utils';
+import { CallDetailPanel } from './CallDetailPanel';
+import { CALL_TYPES, CALL_RESULTS, fmt, formatTimer, type CallLog } from './types';
+
+export function CallListPanel({
+  filterType, setFilterType, filteredLogs, loadingLogs, selectedCall, setSelectedCall,
+}: {
+  filterType: string;
+  setFilterType: (s: string) => void;
+  filteredLogs: CallLog[];
+  loadingLogs: boolean;
+  selectedCall: CallLog | null;
+  setSelectedCall: (c: CallLog | null) => void;
+}) {
+  return (
+    <div className="grid grid-cols-1 lg:grid-cols-5 gap-4">
+      {/* Call List */}
+      <div className={cn('space-y-2', selectedCall ? 'lg:col-span-2' : 'lg:col-span-5')}>
+        {/* Filters */}
+        <div className="flex items-center gap-2">
+          <Select value={filterType} onValueChange={setFilterType}>
+            <SelectTrigger className="h-8 w-auto text-xs">
+              <Filter className="w-3 h-3 mr-1" />
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">Todos os tipos</SelectItem>
+              {CALL_TYPES.map(t => <SelectItem key={t.value} value={t.value}>{t.label}</SelectItem>)}
+            </SelectContent>
+          </Select>
+          <span className="text-xs text-muted-foreground ml-auto">{filteredLogs.length} ligações</span>
+        </div>
+
+        {loadingLogs ? (
+          <div className="flex justify-center py-12"><Loader2 className="w-5 h-5 animate-spin text-muted-foreground" /></div>
+        ) : filteredLogs.length === 0 ? (
+          <Card><CardContent className="py-12 text-center">
+            <Phone className="w-8 h-8 mx-auto mb-2 text-muted-foreground/40" />
+            <p className="text-sm text-muted-foreground">Nenhuma ligação registrada</p>
+          </CardContent></Card>
+        ) : (
+          filteredLogs.map(log => {
+            const typeInfo = CALL_TYPES.find(t => t.value === log.call_type);
+            const resultInfo = CALL_RESULTS.find(r => r.value === log.call_result);
+            const isSelected = selectedCall?.id === log.id;
+
+            return (
+              <Card key={log.id} className={cn('cursor-pointer transition-colors hover:border-primary/30', isSelected && 'border-primary ring-1 ring-primary/20')}
+                onClick={() => setSelectedCall(isSelected ? null : log)}>
+                <CardContent className="p-3">
+                  <div className="flex items-start justify-between">
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2 mb-1">
+                        <p className="text-sm font-medium truncate">{log.customer_name}</p>
+                        <Badge variant="outline" className={cn('text-[10px] shrink-0', typeInfo?.color)}>
+                          {typeInfo?.label}
+                        </Badge>
+                      </div>
+                      <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                        <span>{resultInfo?.icon} {resultInfo?.label}</span>
+                        <span>·</span>
+                        <span><Clock className="w-3 h-3 inline mr-0.5" />{formatTimer(log.duration_seconds)}</span>
+                      </div>
+                      {Number(log.revenue_generated) > 0 && (
+                        <p className="text-xs font-medium mt-1 status-success inline-block px-1.5 py-0.5 rounded">
+                          {fmt(Number(log.revenue_generated))}
+                        </p>
+                      )}
+                    </div>
+                    <div className="flex items-center gap-1 shrink-0">
+                      <span className="text-xs text-muted-foreground">
+                        {format(new Date(log.created_at), 'dd/MM HH:mm', { locale: ptBR })}
+                      </span>
+                      <ChevronRight className="w-3.5 h-3.5 text-muted-foreground" />
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
+            );
+          })
+        )}
+      </div>
+
+      {/* Detail panel (Gong-style) */}
+      {selectedCall && (
+        <div className="lg:col-span-3">
+          <Card>
+            <CardContent className="p-4">
+              <CallDetailPanel call={selectedCall} onClose={() => setSelectedCall(null)} />
+            </CardContent>
+          </Card>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/farmer/calls/NewCallDialog.tsx
+++ b/src/components/farmer/calls/NewCallDialog.tsx
@@ -1,0 +1,190 @@
+// Diálogo de registro de ligação (formulário) da página de Ligações.
+// Extraído de src/pages/FarmerCalls.tsx (god-component split). Componente controlado:
+// todo o estado vive no pai e desce via props.
+import { Card, CardContent } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
+import {
+  Phone, PhoneOff, Play, Pause, Search, Timer, CheckCircle, XCircle,
+  Loader2, PhoneCall, PhoneIncoming,
+} from 'lucide-react';
+import { CALL_TYPES, CALL_RESULTS, formatTimer, type Customer } from './types';
+
+export function NewCallDialog({
+  open, onOpenChange,
+  selectedCustomer, setSelectedCustomer,
+  customerSearch, setCustomerSearch, customers, setCustomers, searchLoading,
+  callType, setCallType, callResult, setCallResult,
+  attemptNumber, setAttemptNumber, notes, setNotes, revenue, setRevenue, margin, setMargin,
+  callSeconds, followUpSeconds, isCallActive, isFollowUpActive,
+  nvoipIsConnecting, nvoipIsRinging, nvoipIsEstablished, nvoipIsActive, nvoipError, callBackend,
+  saving,
+  onStartCall, onStopCall, onStartFollowUp, onStopFollowUp, onSave,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  selectedCustomer: Customer | null;
+  setSelectedCustomer: (c: Customer | null) => void;
+  customerSearch: string;
+  setCustomerSearch: (s: string) => void;
+  customers: Customer[];
+  setCustomers: (c: Customer[]) => void;
+  searchLoading: boolean;
+  callType: string;
+  setCallType: (s: string) => void;
+  callResult: string;
+  setCallResult: (s: string) => void;
+  attemptNumber: number;
+  setAttemptNumber: (n: number) => void;
+  notes: string;
+  setNotes: (s: string) => void;
+  revenue: string;
+  setRevenue: (s: string) => void;
+  margin: string;
+  setMargin: (s: string) => void;
+  callSeconds: number;
+  followUpSeconds: number;
+  isCallActive: boolean;
+  isFollowUpActive: boolean;
+  nvoipIsConnecting: boolean;
+  nvoipIsRinging: boolean;
+  nvoipIsEstablished: boolean;
+  nvoipIsActive: boolean;
+  nvoipError: string | null;
+  callBackend: string;
+  saving: boolean;
+  onStartCall: () => void;
+  onStopCall: () => void;
+  onStartFollowUp: () => void;
+  onStopFollowUp: () => void;
+  onSave: () => void;
+}) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Phone className="w-5 h-5" /> Registrar ligação
+          </DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4">
+          {/* Customer Search */}
+          <div>
+            <label className="text-sm font-medium">Cliente</label>
+            {selectedCustomer ? (
+              <div className="flex items-center justify-between bg-muted/50 rounded-lg p-3 mt-1">
+                <div>
+                  <p className="text-sm font-medium">{selectedCustomer.name}</p>
+                  <p className="text-xs text-muted-foreground">{selectedCustomer.phone || selectedCustomer.email}</p>
+                </div>
+                <Button size="sm" variant="ghost" onClick={() => setSelectedCustomer(null)}>
+                  <XCircle className="w-4 h-4" />
+                </Button>
+              </div>
+            ) : (
+              <div className="mt-1">
+                <div className="relative">
+                  <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
+                  <Input placeholder="Buscar cliente..." value={customerSearch} onChange={e => setCustomerSearch(e.target.value)} className="pl-9 h-9" />
+                </div>
+                {searchLoading && <div className="flex justify-center py-2"><Loader2 className="w-4 h-4 animate-spin" /></div>}
+                {customers.length > 0 && (
+                  <div className="border rounded-lg mt-1 max-h-60 overflow-y-auto">
+                    {customers.map((c, idx) => (
+                      <button key={`${c.user_id || c.omie_codigo_cliente || c.document}-${idx}`}
+                        onClick={() => { setSelectedCustomer(c); setCustomerSearch(''); setCustomers([]); }}
+                        className="w-full text-left px-3 py-2 hover:bg-muted/50 text-sm border-b last:border-b-0">
+                        <div className="flex items-center justify-between gap-2">
+                          <p className="font-medium truncate">{c.name}</p>
+                          {c.omie_codigo_cliente && (
+                            <Badge variant="outline" className="text-[10px] shrink-0">Omie</Badge>
+                          )}
+                        </div>
+                        <p className="text-xs text-muted-foreground truncate">
+                          {[c.document, c.phone, c.email].filter(Boolean).join(' · ') || 'Sem contato'}
+                        </p>
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+
+          <Select value={callType} onValueChange={setCallType}>
+            <SelectTrigger className="h-9"><SelectValue /></SelectTrigger>
+            <SelectContent>{CALL_TYPES.map(t => <SelectItem key={t.value} value={t.value}>{t.label}</SelectItem>)}</SelectContent>
+          </Select>
+
+          {/* Timers */}
+          <Card className="bg-muted/30">
+            <CardContent className="p-3">
+              <div className="grid grid-cols-2 gap-3">
+                <div className="text-center">
+                  <p className="text-xs text-muted-foreground mb-1">Ligação</p>
+                  <p className="text-2xl font-mono font-bold">{formatTimer(callSeconds)}</p>
+                  {selectedCustomer?.phone ? (
+                    <Badge variant="outline" className="text-[10px] mt-1">
+                      {nvoipIsConnecting && <><Loader2 className="w-3 h-3 mr-1 animate-spin" /> Conectando...</>}
+                      {nvoipIsRinging && <><PhoneCall className="w-3 h-3 mr-1 animate-pulse" /> Tocando ramal/destino</>}
+                      {nvoipIsEstablished && <><PhoneIncoming className="w-3 h-3 mr-1 text-emerald-600" /> Em chamada</>}
+                      {!nvoipIsActive && !nvoipIsEstablished && (
+                        <>📞 Disca via {callBackend === 'webrtc' ? 'WebRTC' : 'Nvoip'} → {selectedCustomer.phone}</>
+                      )}
+                    </Badge>
+                  ) : (
+                    <Badge variant="outline" className="text-[10px] mt-1 text-amber-700">
+                      Sem telefone — cronômetro manual
+                    </Badge>
+                  )}
+                  <Button size="sm" variant={isCallActive ? 'destructive' : 'default'} className="mt-2 w-full h-8"
+                    onClick={isCallActive ? onStopCall : onStartCall}
+                    disabled={nvoipIsConnecting}>
+                    {isCallActive ? <><PhoneOff className="w-3 h-3 mr-1" /> Parar</> : <><Play className="w-3 h-3 mr-1" /> Iniciar</>}
+                  </Button>
+                  {nvoipError && (
+                    <p className="text-[10px] text-destructive mt-1">{nvoipError}</p>
+                  )}
+                </div>
+                <div className="text-center">
+                  <p className="text-xs text-muted-foreground mb-1">Follow-up</p>
+                  <p className="text-2xl font-mono font-bold">{formatTimer(followUpSeconds)}</p>
+                  <Button size="sm" variant={isFollowUpActive ? 'destructive' : 'outline'} className="mt-2 w-full h-8"
+                    onClick={isFollowUpActive ? onStopFollowUp : onStartFollowUp}>
+                    {isFollowUpActive ? <><Pause className="w-3 h-3 mr-1" /> Parar</> : <><Timer className="w-3 h-3 mr-1" /> Iniciar</>}
+                  </Button>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+
+          <Select value={callResult} onValueChange={setCallResult}>
+            <SelectTrigger className="h-9"><SelectValue /></SelectTrigger>
+            <SelectContent>{CALL_RESULTS.map(r => <SelectItem key={r.value} value={r.value}>{r.icon} {r.label}</SelectItem>)}</SelectContent>
+          </Select>
+
+          <Input type="number" min={1} value={attemptNumber} onChange={e => setAttemptNumber(parseInt(e.target.value) || 1)} className="h-9" placeholder="Nº da tentativa" />
+
+          {callResult === 'contato_sucesso' && (
+            <div className="grid grid-cols-2 gap-3">
+              <Input type="number" step="0.01" placeholder="Receita (R$)" value={revenue} onChange={e => setRevenue(e.target.value)} className="h-9" />
+              <Input type="number" step="0.01" placeholder="Margem (R$)" value={margin} onChange={e => setMargin(e.target.value)} className="h-9" />
+            </div>
+          )}
+
+          <Textarea placeholder="Observações da ligação..." value={notes} onChange={e => setNotes(e.target.value)} rows={2} />
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>Cancelar</Button>
+          <Button onClick={onSave} disabled={!selectedCustomer || saving} className="gap-1.5">
+            {saving ? <Loader2 className="w-4 h-4 animate-spin" /> : <CheckCircle className="w-4 h-4" />} Salvar
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/farmer/calls/TodayStatsCards.tsx
+++ b/src/components/farmer/calls/TodayStatsCards.tsx
@@ -1,0 +1,31 @@
+// KPIs do dia (ligações, receita, duração média) da página de Ligações.
+// Extraído de src/pages/FarmerCalls.tsx (god-component split).
+import { Card, CardContent } from '@/components/ui/card';
+import { Phone, DollarSign, Clock } from 'lucide-react';
+import { fmt, formatTimer } from './types';
+
+export function TodayStatsCards({ count, revenue, avgDuration }: {
+  count: number;
+  revenue: number;
+  avgDuration: number;
+}) {
+  return (
+    <div className="grid grid-cols-3 gap-3">
+      <Card><CardContent className="p-3 text-center">
+        <Phone className="w-4 h-4 mx-auto text-muted-foreground mb-1" />
+        <p className="text-lg font-bold">{count}</p>
+        <p className="text-[10px] text-muted-foreground">Ligações hoje</p>
+      </CardContent></Card>
+      <Card><CardContent className="p-3 text-center">
+        <DollarSign className="w-4 h-4 mx-auto text-muted-foreground mb-1" />
+        <p className="text-lg font-bold">{fmt(revenue)}</p>
+        <p className="text-[10px] text-muted-foreground">Receita hoje</p>
+      </CardContent></Card>
+      <Card><CardContent className="p-3 text-center">
+        <Clock className="w-4 h-4 mx-auto text-muted-foreground mb-1" />
+        <p className="text-lg font-bold">{formatTimer(avgDuration)}</p>
+        <p className="text-[10px] text-muted-foreground">Duração média</p>
+      </CardContent></Card>
+    </div>
+  );
+}

--- a/src/components/farmer/calls/__tests__/AgendaQueueCard.test.tsx
+++ b/src/components/farmer/calls/__tests__/AgendaQueueCard.test.tsx
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { TooltipProvider } from '@/components/ui/tooltip';
+import { AgendaQueueCard } from '../AgendaQueueCard';
+import type { AgendaItem, ClientScore } from '@/hooks/useFarmerScoring';
+
+// Mock do Dialer pra não puxar feature-flag / contexto de chamada nos testes.
+vi.mock('@/components/call/Dialer', () => ({
+  Dialer: ({ phoneNumber, onCallEnd }: { phoneNumber: string; onCallEnd: (d: { duration: number; state: string; audioLink: string | null }) => void }) => (
+    <button onClick={() => onCallEnd({ duration: 42, state: 'finished', audioLink: null })}>
+      dialer-{phoneNumber}
+    </button>
+  ),
+}));
+
+const item: AgendaItem = {
+  customer_user_id: 'u1',
+  customer_name: 'Cliente Alpha',
+  priorityScore: 87.4,
+  agendaType: 'risco',
+  healthClass: 'critico',
+};
+
+function noop() { /* */ }
+
+describe('AgendaQueueCard', () => {
+  it('agenda vazia → mensagem de "bom trabalho"', () => {
+    render(
+      <AgendaQueueCard
+        agenda={[]} clientScores={[]} agendaLoading={false}
+        onCallEnd={noop} onRegister={noop}
+      />,
+      { wrapper: TooltipProvider }
+    );
+    expect(screen.getByText(/Nenhuma ligação pendente na agenda/)).toBeTruthy();
+  });
+
+  it('título "Próximas ligações" sempre presente', () => {
+    render(
+      <AgendaQueueCard
+        agenda={[]} clientScores={[]} agendaLoading
+        onCallEnd={noop} onRegister={noop}
+      />,
+      { wrapper: TooltipProvider }
+    );
+    expect(screen.getByText('Próximas ligações')).toBeTruthy();
+  });
+
+  it('item sem telefone → mostra nome, badge de tipo e Registrar; clique chama onRegister', () => {
+    const onRegister = vi.fn();
+    render(
+      <AgendaQueueCard
+        agenda={[item]} clientScores={[]} agendaLoading={false}
+        onCallEnd={noop} onRegister={onRegister}
+      />,
+      { wrapper: TooltipProvider }
+    );
+    expect(screen.getByText('Cliente Alpha')).toBeTruthy();
+    expect(screen.getByText('Risco')).toBeTruthy();
+    expect(screen.getByText(/Prioridade: 87\.4/)).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: /Registrar/ }));
+    expect(onRegister).toHaveBeenCalledWith(item, undefined);
+  });
+
+  it('item com telefone → exibe telefone, renderiza Dialer e encaminha onCallEnd', () => {
+    const onCallEnd = vi.fn();
+    const score = { customer_user_id: 'u1', customer_phone: '11999990000' } as unknown as ClientScore;
+    render(
+      <AgendaQueueCard
+        agenda={[item]} clientScores={[score]} agendaLoading={false}
+        onCallEnd={onCallEnd} onRegister={noop}
+      />,
+      { wrapper: TooltipProvider }
+    );
+    expect(screen.getByText('11999990000')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: /dialer-11999990000/ }));
+    expect(onCallEnd).toHaveBeenCalledWith(item, '11999990000', { duration: 42, state: 'finished', audioLink: null });
+  });
+});

--- a/src/components/farmer/calls/__tests__/CallDetailPanel.test.tsx
+++ b/src/components/farmer/calls/__tests__/CallDetailPanel.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { CallDetailPanel } from '../CallDetailPanel';
+import type { CallLog } from '../types';
+
+const base: CallLog = {
+  id: 'c1',
+  customer_user_id: 'u1',
+  call_type: 'cross_sell',
+  call_result: 'contato_sucesso',
+  duration_seconds: 125,
+  follow_up_duration_seconds: 0,
+  attempt_number: 1,
+  revenue_generated: 0,
+  margin_generated: 0,
+  notes: null,
+  created_at: '2026-01-15T10:30:00Z',
+  customer_name: 'Cliente Alpha',
+};
+
+function noop() { /* */ }
+
+describe('CallDetailPanel', () => {
+  it('renderiza nome, tipo, duração e placeholders quando sem receita/notas', () => {
+    render(<CallDetailPanel call={base} onClose={noop} />);
+    expect(screen.getByText('Cliente Alpha')).toBeTruthy();
+    expect(screen.getByText('Cross-sell')).toBeTruthy();
+    expect(screen.getByText('02:05')).toBeTruthy();
+    expect(screen.getByText('Nenhuma transcrição disponível')).toBeTruthy();
+    expect(screen.getByText('Nenhum próximo passo registrado.')).toBeTruthy();
+    // sem cards de receita/margem
+    expect(screen.queryByText('Receita gerada')).toBeNull();
+  });
+
+  it('mostra métricas de receita/margem e transcrição quando presentes', () => {
+    render(<CallDetailPanel call={{ ...base, revenue_generated: 1000, margin_generated: 300, notes: 'Cliente pediu orçamento' }} onClose={noop} />);
+    expect(screen.getByText('Receita gerada')).toBeTruthy();
+    expect(screen.getByText('Margem gerada')).toBeTruthy();
+    expect(screen.getByText('Cliente pediu orçamento')).toBeTruthy();
+    expect(screen.queryByText('Nenhuma transcrição disponível')).toBeNull();
+  });
+
+  it('mostra bloco de follow-up quando follow_up_duration_seconds > 0', () => {
+    render(<CallDetailPanel call={{ ...base, follow_up_duration_seconds: 45 }} onClose={noop} />);
+    expect(screen.getByText('Follow-up')).toBeTruthy();
+    expect(screen.getByText('00:45')).toBeTruthy();
+  });
+});

--- a/src/components/farmer/calls/__tests__/CallListPanel.test.tsx
+++ b/src/components/farmer/calls/__tests__/CallListPanel.test.tsx
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { CallListPanel } from '../CallListPanel';
+import type { CallLog } from '../types';
+
+const log: CallLog = {
+  id: 'c1',
+  customer_user_id: 'u1',
+  call_type: 'cross_sell',
+  call_result: 'contato_sucesso',
+  duration_seconds: 60,
+  follow_up_duration_seconds: 0,
+  attempt_number: 1,
+  revenue_generated: 500,
+  margin_generated: 0,
+  notes: null,
+  created_at: '2026-01-15T10:30:00Z',
+  customer_name: 'Cliente Alpha',
+};
+
+function noop() { /* */ }
+
+describe('CallListPanel', () => {
+  it('lista vazia (não carregando) → mensagem e contador zerado', () => {
+    render(
+      <CallListPanel
+        filterType="all" setFilterType={noop}
+        filteredLogs={[]} loadingLogs={false}
+        selectedCall={null} setSelectedCall={noop}
+      />
+    );
+    expect(screen.getByText('Nenhuma ligação registrada')).toBeTruthy();
+    expect(screen.getByText('0 ligações')).toBeTruthy();
+  });
+
+  it('com logs → renderiza card e clique chama setSelectedCall', () => {
+    const setSelectedCall = vi.fn();
+    render(
+      <CallListPanel
+        filterType="all" setFilterType={noop}
+        filteredLogs={[log]} loadingLogs={false}
+        selectedCall={null} setSelectedCall={setSelectedCall}
+      />
+    );
+    expect(screen.getByText('Cliente Alpha')).toBeTruthy();
+    expect(screen.getByText('1 ligações')).toBeTruthy();
+    fireEvent.click(screen.getByText('Cliente Alpha'));
+    expect(setSelectedCall).toHaveBeenCalledWith(log);
+  });
+
+  it('com selectedCall → renderiza painel de detalhe (Gong)', () => {
+    render(
+      <CallListPanel
+        filterType="all" setFilterType={noop}
+        filteredLogs={[log]} loadingLogs={false}
+        selectedCall={log} setSelectedCall={noop}
+      />
+    );
+    // o painel de detalhe mostra placeholders próprios
+    expect(screen.getByText('Próximos passos')).toBeTruthy();
+    expect(screen.getByText('Receita gerada')).toBeTruthy();
+  });
+});

--- a/src/components/farmer/calls/__tests__/NewCallDialog.test.tsx
+++ b/src/components/farmer/calls/__tests__/NewCallDialog.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { NewCallDialog } from '../NewCallDialog';
+import type { Customer } from '../types';
+
+const customer: Customer = { user_id: 'u1', name: 'Cliente Alpha', email: null, phone: '11999990000' };
+
+function noop() { /* */ }
+
+function baseProps(over: Partial<React.ComponentProps<typeof NewCallDialog>> = {}): React.ComponentProps<typeof NewCallDialog> {
+  return {
+    open: true,
+    onOpenChange: noop,
+    selectedCustomer: null,
+    setSelectedCustomer: noop,
+    customerSearch: '',
+    setCustomerSearch: noop,
+    customers: [],
+    setCustomers: noop,
+    searchLoading: false,
+    callType: 'follow_up',
+    setCallType: noop,
+    callResult: 'contato_sucesso',
+    setCallResult: noop,
+    attemptNumber: 1,
+    setAttemptNumber: noop,
+    notes: '',
+    setNotes: noop,
+    revenue: '',
+    setRevenue: noop,
+    margin: '',
+    setMargin: noop,
+    callSeconds: 0,
+    followUpSeconds: 0,
+    isCallActive: false,
+    isFollowUpActive: false,
+    nvoipIsConnecting: false,
+    nvoipIsRinging: false,
+    nvoipIsEstablished: false,
+    nvoipIsActive: false,
+    nvoipError: null,
+    callBackend: 'nvoip',
+    saving: false,
+    onStartCall: noop,
+    onStopCall: noop,
+    onStartFollowUp: noop,
+    onStopFollowUp: noop,
+    onSave: noop,
+    ...over,
+  };
+}
+
+describe('NewCallDialog', () => {
+  it('fechado (open=false) → não renderiza o conteúdo', () => {
+    render(<NewCallDialog {...baseProps({ open: false })} />);
+    expect(screen.queryByText('Registrar ligação')).toBeNull();
+  });
+
+  it('aberto sem cliente → título, busca e Salvar desabilitado', () => {
+    render(<NewCallDialog {...baseProps()} />);
+    expect(screen.getByText('Registrar ligação')).toBeTruthy();
+    expect(screen.getByPlaceholderText('Buscar cliente...')).toBeTruthy();
+    const salvar = screen.getByRole('button', { name: /Salvar/ }) as HTMLButtonElement;
+    expect(salvar.disabled).toBe(true);
+  });
+
+  it('com cliente → mostra nome e habilita Salvar; clique chama onSave', () => {
+    const onSave = vi.fn();
+    render(<NewCallDialog {...baseProps({ selectedCustomer: customer, onSave })} />);
+    expect(screen.getByText('Cliente Alpha')).toBeTruthy();
+    const salvar = screen.getByRole('button', { name: /Salvar/ }) as HTMLButtonElement;
+    expect(salvar.disabled).toBe(false);
+    fireEvent.click(salvar);
+    expect(onSave).toHaveBeenCalled();
+  });
+
+  it('cliente com telefone → botão Iniciar chama onStartCall', () => {
+    const onStartCall = vi.fn();
+    render(<NewCallDialog {...baseProps({ selectedCustomer: customer, onStartCall })} />);
+    // "Iniciar" aparece em Ligação e Follow-up; o primeiro é o da chamada.
+    fireEvent.click(screen.getAllByRole('button', { name: /Iniciar/ })[0]);
+    expect(onStartCall).toHaveBeenCalled();
+  });
+});

--- a/src/components/farmer/calls/__tests__/TodayStatsCards.test.tsx
+++ b/src/components/farmer/calls/__tests__/TodayStatsCards.test.tsx
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { TodayStatsCards } from '../TodayStatsCards';
+
+describe('TodayStatsCards', () => {
+  it('renderiza contagem, receita formatada e duração média', () => {
+    render(<TodayStatsCards count={7} revenue={1500} avgDuration={125} />);
+    expect(screen.getByText('7')).toBeTruthy();
+    expect(screen.getByText('Ligações hoje')).toBeTruthy();
+    expect(screen.getByText(/1\.500,00/)).toBeTruthy();
+    expect(screen.getByText('02:05')).toBeTruthy();
+    expect(screen.getByText('Duração média')).toBeTruthy();
+  });
+});

--- a/src/components/farmer/calls/__tests__/types.test.ts
+++ b/src/components/farmer/calls/__tests__/types.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { fmt, formatTimer, CALL_TYPES, CALL_RESULTS, AGENDA_TYPE_META } from '../types';
+
+describe('formatTimer', () => {
+  it('formata segundos como MM:SS com zero-pad', () => {
+    expect(formatTimer(0)).toBe('00:00');
+    expect(formatTimer(9)).toBe('00:09');
+    expect(formatTimer(65)).toBe('01:05');
+    expect(formatTimer(600)).toBe('10:00');
+    expect(formatTimer(3661)).toBe('61:01');
+  });
+});
+
+describe('fmt', () => {
+  it('formata número como moeda BRL', () => {
+    expect(fmt(0)).toContain('0,00');
+    expect(fmt(1234.5)).toContain('1.234,50');
+    expect(fmt(1234.5)).toContain('R$');
+  });
+});
+
+describe('constantes', () => {
+  it('CALL_TYPES e CALL_RESULTS têm os valores esperados', () => {
+    expect(CALL_TYPES.map(t => t.value)).toEqual(['reativacao', 'cross_sell', 'up_sell', 'follow_up']);
+    expect(CALL_RESULTS.map(r => r.value)).toContain('contato_sucesso');
+    expect(CALL_RESULTS.map(r => r.value)).toContain('reagendado');
+  });
+
+  it('AGENDA_TYPE_META cobre risco/expansao/follow_up', () => {
+    expect(AGENDA_TYPE_META.risco.label).toBe('Risco');
+    expect(AGENDA_TYPE_META.expansao.label).toBe('Expansão');
+    expect(AGENDA_TYPE_META.follow_up.label).toBe('Follow-up');
+  });
+});

--- a/src/components/farmer/calls/types.ts
+++ b/src/components/farmer/calls/types.ts
@@ -1,0 +1,59 @@
+// Tipos, constantes e helpers da página de Ligações (FarmerCalls).
+// Extraídos de src/pages/FarmerCalls.tsx (god-component split).
+import { AlertTriangle, TrendingUp, RotateCcw } from 'lucide-react';
+
+export interface Customer {
+  user_id: string;
+  name: string;
+  email: string | null;
+  phone: string | null;
+  /** Omie codigo_cliente (Oben). Used to resolve/create local user_id when saving. */
+  omie_codigo_cliente?: number | null;
+  /** Omie cnpj_cpf used to resolve local profile by document. */
+  document?: string | null;
+}
+
+export interface CallLog {
+  id: string;
+  customer_user_id: string;
+  call_type: string;
+  call_result: string;
+  duration_seconds: number;
+  follow_up_duration_seconds: number;
+  attempt_number: number;
+  revenue_generated: number;
+  margin_generated: number;
+  notes: string | null;
+  created_at: string;
+  customer_name?: string;
+}
+
+export const CALL_TYPES = [
+  { value: 'reativacao', label: 'Reativação', color: 'status-danger' },
+  { value: 'cross_sell', label: 'Cross-sell', color: 'status-progress' },
+  { value: 'up_sell', label: 'Up-sell', color: 'bg-purple-50 text-purple-700 border-purple-200' },
+  { value: 'follow_up', label: 'Follow-up', color: 'status-pending' },
+];
+
+export const CALL_RESULTS = [
+  { value: 'contato_sucesso', label: 'Contato com Sucesso', icon: '✅' },
+  { value: 'sem_resposta', label: 'Sem Resposta', icon: '📵' },
+  { value: 'ocupado', label: 'Ocupado', icon: '🔴' },
+  { value: 'caixa_postal', label: 'Caixa Postal', icon: '📩' },
+  { value: 'numero_invalido', label: 'Número Inválido', icon: '❌' },
+  { value: 'reagendado', label: 'Reagendado', icon: '📅' },
+];
+
+export const AGENDA_TYPE_META: Record<string, { label: string; icon: typeof AlertTriangle; color: string }> = {
+  risco: { label: 'Risco', icon: AlertTriangle, color: 'text-destructive bg-destructive/10 border-destructive/20' },
+  expansao: { label: 'Expansão', icon: TrendingUp, color: 'text-primary bg-primary/10 border-primary/20' },
+  follow_up: { label: 'Follow-up', icon: RotateCcw, color: 'text-amber-600 bg-amber-50 border-amber-200' },
+};
+
+export const fmt = (v: number) => v.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
+
+export function formatTimer(secs: number) {
+  const m = Math.floor(secs / 60);
+  const s = secs % 60;
+  return `${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
+}

--- a/src/pages/FarmerCalls.tsx
+++ b/src/pages/FarmerCalls.tsx
@@ -1,193 +1,23 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Textarea } from '@/components/ui/textarea';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
-import { Separator } from '@/components/ui/separator';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
 import { toast } from 'sonner';
-import { useFarmerScoring } from '@/hooks/useFarmerScoring';
-import { cn } from '@/lib/utils';
-import { Dialer } from '@/components/call/Dialer';
+import { useFarmerScoring, type AgendaItem } from '@/hooks/useFarmerScoring';
 import { TranscriptionPanel } from '@/components/call/TranscriptionPanel';
 import type { NvoipCallState } from '@/hooks/useNvoipCall';
 import { useCallBackend } from '@/hooks/useCallBackend';
 import { useWebRTCCall } from '@/hooks/useWebRTCCall';
-import {
-  Phone, PhoneOff, Play, Pause, Clock, Search,
-  Plus, Timer, CheckCircle, XCircle, Loader2,
-  ArrowUpRight, DollarSign, Filter, FileText,
-  Mic, ChevronRight,
-  PhoneCall, PhoneIncoming, AlertTriangle, TrendingUp, RotateCcw,
-} from 'lucide-react';
-import { format } from 'date-fns';
-import { ptBR } from 'date-fns/locale';
-
-/* ─── Types ─── */
-interface Customer {
-  user_id: string;
-  name: string;
-  email: string | null;
-  phone: string | null;
-  /** Omie codigo_cliente (Oben). Used to resolve/create local user_id when saving. */
-  omie_codigo_cliente?: number | null;
-  /** Omie cnpj_cpf used to resolve local profile by document. */
-  document?: string | null;
-}
-
-interface CallLog {
-  id: string;
-  customer_user_id: string;
-  call_type: string;
-  call_result: string;
-  duration_seconds: number;
-  follow_up_duration_seconds: number;
-  attempt_number: number;
-  revenue_generated: number;
-  margin_generated: number;
-  notes: string | null;
-  created_at: string;
-  customer_name?: string;
-}
-
-const CALL_TYPES = [
-  { value: 'reativacao', label: 'Reativação', color: 'status-danger' },
-  { value: 'cross_sell', label: 'Cross-sell', color: 'status-progress' },
-  { value: 'up_sell', label: 'Up-sell', color: 'bg-purple-50 text-purple-700 border-purple-200' },
-  { value: 'follow_up', label: 'Follow-up', color: 'status-pending' },
-];
-
-const CALL_RESULTS = [
-  { value: 'contato_sucesso', label: 'Contato com Sucesso', icon: '✅' },
-  { value: 'sem_resposta', label: 'Sem Resposta', icon: '📵' },
-  { value: 'ocupado', label: 'Ocupado', icon: '🔴' },
-  { value: 'caixa_postal', label: 'Caixa Postal', icon: '📩' },
-  { value: 'numero_invalido', label: 'Número Inválido', icon: '❌' },
-  { value: 'reagendado', label: 'Reagendado', icon: '📅' },
-];
-
-const fmt = (v: number) => v.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
-
-/* ─── Call Detail Panel (Gong-inspired) ─── */
-function CallDetailPanel({ call }: { call: CallLog; onClose: () => void }) {
-  const typeInfo = CALL_TYPES.find(t => t.value === call.call_type);
-  const resultInfo = CALL_RESULTS.find(r => r.value === call.call_result);
-  
-  return (
-    <div className="space-y-4">
-      <div className="flex items-center justify-between">
-        <h3 className="font-semibold text-foreground">{call.customer_name}</h3>
-        <span className="text-xs text-muted-foreground">
-          {format(new Date(call.created_at), "dd/MM/yy 'às' HH:mm", { locale: ptBR })}
-        </span>
-      </div>
-
-      <div className="flex items-center gap-2">
-        <Badge variant="outline" className={cn('text-[10px]', typeInfo?.color)}>
-          {typeInfo?.label}
-        </Badge>
-        <Badge variant="outline" className="text-[10px]">
-          {resultInfo?.icon} {resultInfo?.label}
-        </Badge>
-        {call.attempt_number > 1 && (
-          <Badge variant="secondary" className="text-[10px]">#{call.attempt_number}</Badge>
-        )}
-      </div>
-
-      {/* Timeline / Player area (Gong-style) */}
-      <Card className="bg-muted/30">
-        <CardContent className="p-4">
-          <div className="flex items-center justify-center gap-6">
-            <div className="text-center">
-              <p className="text-2xl font-mono font-bold">{formatTimer(call.duration_seconds)}</p>
-              <p className="text-[10px] text-muted-foreground mt-0.5">Duração da ligação</p>
-            </div>
-            {call.follow_up_duration_seconds > 0 && (
-              <>
-                <Separator orientation="vertical" className="h-10" />
-                <div className="text-center">
-                  <p className="text-2xl font-mono font-bold">{formatTimer(call.follow_up_duration_seconds)}</p>
-                  <p className="text-[10px] text-muted-foreground mt-0.5">Follow-up</p>
-                </div>
-              </>
-            )}
-          </div>
-        </CardContent>
-      </Card>
-
-      {/* Metrics */}
-      {(call.revenue_generated > 0 || call.margin_generated > 0) && (
-        <div className="grid grid-cols-2 gap-3">
-          <Card>
-            <CardContent className="p-3 text-center">
-              <DollarSign className="w-4 h-4 mx-auto text-muted-foreground mb-1" />
-              <p className="text-sm font-bold">{fmt(call.revenue_generated)}</p>
-              <p className="text-[10px] text-muted-foreground">Receita gerada</p>
-            </CardContent>
-          </Card>
-          <Card>
-            <CardContent className="p-3 text-center">
-              <ArrowUpRight className="w-4 h-4 mx-auto text-muted-foreground mb-1" />
-              <p className="text-sm font-bold">{fmt(call.margin_generated)}</p>
-              <p className="text-[10px] text-muted-foreground">Margem gerada</p>
-            </CardContent>
-          </Card>
-        </div>
-      )}
-
-      {/* Transcript placeholder */}
-      <Card>
-        <CardHeader className="pb-2">
-          <CardTitle className="text-xs font-medium text-muted-foreground uppercase tracking-wider flex items-center gap-1.5">
-            <FileText className="w-3.5 h-3.5" /> Transcrição
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          {call.notes ? (
-            <p className="text-sm text-foreground whitespace-pre-wrap">{call.notes}</p>
-          ) : (
-            <div className="text-center py-6">
-              <Mic className="w-6 h-6 mx-auto mb-2 text-muted-foreground/40" />
-              <p className="text-xs text-muted-foreground">Nenhuma transcrição disponível</p>
-              <p className="text-[10px] text-muted-foreground mt-0.5">Use o Copilot para transcrever em tempo real.</p>
-            </div>
-          )}
-        </CardContent>
-      </Card>
-
-      {/* Next steps placeholder */}
-      <Card>
-        <CardHeader className="pb-2">
-          <CardTitle className="text-xs font-medium text-muted-foreground uppercase tracking-wider">Próximos passos</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <p className="text-xs text-muted-foreground">Nenhum próximo passo registrado.</p>
-        </CardContent>
-      </Card>
-    </div>
-  );
-}
-
-function formatTimer(secs: number) {
-  const m = Math.floor(secs / 60);
-  const s = secs % 60;
-  return `${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
-}
+import { Plus, Loader2 } from 'lucide-react';
+import { type Customer, type CallLog } from '@/components/farmer/calls/types';
+import { TodayStatsCards } from '@/components/farmer/calls/TodayStatsCards';
+import { AgendaQueueCard } from '@/components/farmer/calls/AgendaQueueCard';
+import { CallListPanel } from '@/components/farmer/calls/CallListPanel';
+import { NewCallDialog } from '@/components/farmer/calls/NewCallDialog';
 
 /* ─── Main Page ─── */
-const AGENDA_TYPE_META: Record<string, { label: string; icon: typeof AlertTriangle; color: string }> = {
-  risco: { label: 'Risco', icon: AlertTriangle, color: 'text-destructive bg-destructive/10 border-destructive/20' },
-  expansao: { label: 'Expansão', icon: TrendingUp, color: 'text-primary bg-primary/10 border-primary/20' },
-  follow_up: { label: 'Follow-up', icon: RotateCcw, color: 'text-amber-600 bg-amber-50 border-amber-200' },
-};
-
 const FarmerCalls = () => {
   const navigate = useNavigate();
   const { user, isStaff, loading: authLoading } = useAuth();
@@ -486,6 +316,39 @@ const FarmerCalls = () => {
     } finally { setSaving(false); }
   };
 
+  // Prefill the call form from an agenda item after a Dialer call ends
+  const handleAgendaCallEnd = (
+    item: AgendaItem,
+    phone: string,
+    data: { duration: number; state: string; audioLink: string | null },
+  ) => {
+    // Map Nvoip state to call_result
+    const resultMap: Record<string, string> = {
+      finished: 'contato_sucesso',
+      noanswer: 'sem_resposta',
+      busy: 'ocupado',
+      failed: 'sem_resposta',
+    };
+    // Pre-fill the call form with Nvoip data
+    const agendaCallType = item.agendaType === 'risco' ? 'reativacao' : item.agendaType === 'expansao' ? 'cross_sell' : 'follow_up';
+    resetForm();
+    setSelectedCustomer({ user_id: item.customer_user_id, name: item.customer_name, email: null, phone });
+    setCallType(agendaCallType);
+    setCallResult(resultMap[data.state] || 'contato_sucesso');
+    setCallSeconds(data.duration);
+    callStartRef.current = new Date(Date.now() - data.duration * 1000);
+    setShowNewCall(true);
+  };
+
+  // Open the call form for an agenda item ("Registrar" button)
+  const handleAgendaRegister = (item: AgendaItem, phone: string | null | undefined) => {
+    const agendaCallType = item.agendaType === 'risco' ? 'reativacao' : item.agendaType === 'expansao' ? 'cross_sell' : 'follow_up';
+    resetForm();
+    setSelectedCustomer({ user_id: item.customer_user_id, name: item.customer_name, email: null, phone: phone || null });
+    setCallType(agendaCallType);
+    setShowNewCall(true);
+  };
+
   // Stats
   const todayCalls = callLogs.filter(c => {
     const d = new Date(c.created_at);
@@ -516,321 +379,68 @@ const FarmerCalls = () => {
         </div>
 
         {/* Today's stats */}
-        <div className="grid grid-cols-3 gap-3">
-          <Card><CardContent className="p-3 text-center">
-            <Phone className="w-4 h-4 mx-auto text-muted-foreground mb-1" />
-            <p className="text-lg font-bold">{todayCalls.length}</p>
-            <p className="text-[10px] text-muted-foreground">Ligações hoje</p>
-          </CardContent></Card>
-          <Card><CardContent className="p-3 text-center">
-            <DollarSign className="w-4 h-4 mx-auto text-muted-foreground mb-1" />
-            <p className="text-lg font-bold">{fmt(todayRevenue)}</p>
-            <p className="text-[10px] text-muted-foreground">Receita hoje</p>
-          </CardContent></Card>
-          <Card><CardContent className="p-3 text-center">
-            <Clock className="w-4 h-4 mx-auto text-muted-foreground mb-1" />
-            <p className="text-lg font-bold">{formatTimer(avgDuration)}</p>
-            <p className="text-[10px] text-muted-foreground">Duração média</p>
-          </CardContent></Card>
-        </div>
+        <TodayStatsCards count={todayCalls.length} revenue={todayRevenue} avgDuration={avgDuration} />
 
         {/* ─── Agenda Queue ─── */}
-        <Card>
-          <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium flex items-center gap-2">
-              <PhoneCall className="w-4 h-4 text-primary" />
-              Próximas ligações
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-2">
-            {agendaLoading ? (
-              <div className="flex justify-center py-6"><Loader2 className="w-5 h-5 animate-spin text-muted-foreground" /></div>
-            ) : agenda.length === 0 ? (
-              <div className="text-center py-6">
-                <CheckCircle className="w-6 h-6 mx-auto mb-2 text-primary/60" />
-                <p className="text-sm text-muted-foreground">Nenhuma ligação pendente na agenda. Bom trabalho!</p>
-              </div>
-            ) : (
-              agenda.slice(0, 5).map(item => {
-                const meta = AGENDA_TYPE_META[item.agendaType] || AGENDA_TYPE_META.follow_up;
-                const Icon = meta.icon;
-                const score = clientScores.find(c => c.customer_user_id === item.customer_user_id);
-                const phone = score?.customer_phone;
-
-                return (
-                  <div key={item.customer_user_id} className="flex items-center gap-3 rounded-lg border p-3">
-                    <div className="flex-1 min-w-0">
-                      <div className="flex items-center gap-2 mb-0.5">
-                        <p className="text-sm font-medium truncate">{item.customer_name}</p>
-                        <Badge variant="outline" className={cn('text-[10px] shrink-0', meta.color)}>
-                          <Icon className="w-3 h-3 mr-0.5" /> {meta.label}
-                        </Badge>
-                      </div>
-                      <div className="flex items-center gap-2 text-xs text-muted-foreground">
-                        <span>Prioridade: {item.priorityScore.toFixed(1)}</span>
-                        {phone && (
-                          <>
-                            <span>·</span>
-                            <span>{phone}</span>
-                          </>
-                        )}
-                      </div>
-                    </div>
-                    <div className="flex items-center gap-1.5 shrink-0">
-                      {phone ? (
-                        <Dialer
-                          phoneNumber={phone}
-                          customerName={item.customer_name}
-                          compact
-                          onCallEnd={(data) => {
-                            // Map Nvoip state to call_result
-                            const resultMap: Record<string, string> = {
-                              finished: 'contato_sucesso',
-                              noanswer: 'sem_resposta',
-                              busy: 'ocupado',
-                              failed: 'sem_resposta',
-                            };
-                            // Pre-fill the call form with Nvoip data
-                            const agendaCallType = item.agendaType === 'risco' ? 'reativacao' : item.agendaType === 'expansao' ? 'cross_sell' : 'follow_up';
-                            resetForm();
-                            setSelectedCustomer({ user_id: item.customer_user_id, name: item.customer_name, email: null, phone });
-                            setCallType(agendaCallType);
-                            setCallResult(resultMap[data.state] || 'contato_sucesso');
-                            setCallSeconds(data.duration);
-                            callStartRef.current = new Date(Date.now() - data.duration * 1000);
-                            setShowNewCall(true);
-                          }}
-                        />
-                      ) : (
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <span><Button size="icon" variant="ghost" className="h-8 w-8" disabled><Phone className="w-4 h-4" /></Button></span>
-                          </TooltipTrigger>
-                          <TooltipContent><p className="text-xs">Sem telefone cadastrado</p></TooltipContent>
-                        </Tooltip>
-                      )}
-                      <Button size="sm" variant="outline" className="h-8 text-xs gap-1" onClick={() => {
-                        const agendaCallType = item.agendaType === 'risco' ? 'reativacao' : item.agendaType === 'expansao' ? 'cross_sell' : 'follow_up';
-                        resetForm();
-                        setSelectedCustomer({ user_id: item.customer_user_id, name: item.customer_name, email: null, phone: phone || null });
-                        setCallType(agendaCallType);
-                        setShowNewCall(true);
-                      }}>
-                        <FileText className="w-3 h-3" /> Registrar
-                      </Button>
-                    </div>
-                  </div>
-                );
-              })
-            )}
-          </CardContent>
-        </Card>
+        <AgendaQueueCard
+          agenda={agenda}
+          clientScores={clientScores}
+          agendaLoading={agendaLoading}
+          onCallEnd={handleAgendaCallEnd}
+          onRegister={handleAgendaRegister}
+        />
 
         {/* Call list + detail (Gong split) */}
-        <div className="grid grid-cols-1 lg:grid-cols-5 gap-4">
-          {/* Call List */}
-          <div className={cn('space-y-2', selectedCall ? 'lg:col-span-2' : 'lg:col-span-5')}>
-            {/* Filters */}
-            <div className="flex items-center gap-2">
-              <Select value={filterType} onValueChange={setFilterType}>
-                <SelectTrigger className="h-8 w-auto text-xs">
-                  <Filter className="w-3 h-3 mr-1" />
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="all">Todos os tipos</SelectItem>
-                  {CALL_TYPES.map(t => <SelectItem key={t.value} value={t.value}>{t.label}</SelectItem>)}
-                </SelectContent>
-              </Select>
-              <span className="text-xs text-muted-foreground ml-auto">{filteredLogs.length} ligações</span>
-            </div>
-
-            {loadingLogs ? (
-              <div className="flex justify-center py-12"><Loader2 className="w-5 h-5 animate-spin text-muted-foreground" /></div>
-            ) : filteredLogs.length === 0 ? (
-              <Card><CardContent className="py-12 text-center">
-                <Phone className="w-8 h-8 mx-auto mb-2 text-muted-foreground/40" />
-                <p className="text-sm text-muted-foreground">Nenhuma ligação registrada</p>
-              </CardContent></Card>
-            ) : (
-              filteredLogs.map(log => {
-                const typeInfo = CALL_TYPES.find(t => t.value === log.call_type);
-                const resultInfo = CALL_RESULTS.find(r => r.value === log.call_result);
-                const isSelected = selectedCall?.id === log.id;
-
-                return (
-                  <Card key={log.id} className={cn('cursor-pointer transition-colors hover:border-primary/30', isSelected && 'border-primary ring-1 ring-primary/20')}
-                    onClick={() => setSelectedCall(isSelected ? null : log)}>
-                    <CardContent className="p-3">
-                      <div className="flex items-start justify-between">
-                        <div className="flex-1 min-w-0">
-                          <div className="flex items-center gap-2 mb-1">
-                            <p className="text-sm font-medium truncate">{log.customer_name}</p>
-                            <Badge variant="outline" className={cn('text-[10px] shrink-0', typeInfo?.color)}>
-                              {typeInfo?.label}
-                            </Badge>
-                          </div>
-                          <div className="flex items-center gap-2 text-xs text-muted-foreground">
-                            <span>{resultInfo?.icon} {resultInfo?.label}</span>
-                            <span>·</span>
-                            <span><Clock className="w-3 h-3 inline mr-0.5" />{formatTimer(log.duration_seconds)}</span>
-                          </div>
-                          {Number(log.revenue_generated) > 0 && (
-                            <p className="text-xs font-medium mt-1 status-success inline-block px-1.5 py-0.5 rounded">
-                              {fmt(Number(log.revenue_generated))}
-                            </p>
-                          )}
-                        </div>
-                        <div className="flex items-center gap-1 shrink-0">
-                          <span className="text-xs text-muted-foreground">
-                            {format(new Date(log.created_at), 'dd/MM HH:mm', { locale: ptBR })}
-                          </span>
-                          <ChevronRight className="w-3.5 h-3.5 text-muted-foreground" />
-                        </div>
-                      </div>
-                    </CardContent>
-                  </Card>
-                );
-              })
-            )}
-          </div>
-
-          {/* Detail panel (Gong-style) */}
-          {selectedCall && (
-            <div className="lg:col-span-3">
-              <Card>
-                <CardContent className="p-4">
-                  <CallDetailPanel call={selectedCall} onClose={() => setSelectedCall(null)} />
-                </CardContent>
-              </Card>
-            </div>
-          )}
-        </div>
+        <CallListPanel
+          filterType={filterType}
+          setFilterType={setFilterType}
+          filteredLogs={filteredLogs}
+          loadingLogs={loadingLogs}
+          selectedCall={selectedCall}
+          setSelectedCall={setSelectedCall}
+        />
       </div>
 
       {/* New Call Dialog */}
-      <Dialog open={showNewCall} onOpenChange={setShowNewCall}>
-        <DialogContent className="max-w-md max-h-[90vh] overflow-y-auto">
-          <DialogHeader>
-            <DialogTitle className="flex items-center gap-2">
-              <Phone className="w-5 h-5" /> Registrar ligação
-            </DialogTitle>
-          </DialogHeader>
-          <div className="space-y-4">
-            {/* Customer Search */}
-            <div>
-              <label className="text-sm font-medium">Cliente</label>
-              {selectedCustomer ? (
-                <div className="flex items-center justify-between bg-muted/50 rounded-lg p-3 mt-1">
-                  <div>
-                    <p className="text-sm font-medium">{selectedCustomer.name}</p>
-                    <p className="text-xs text-muted-foreground">{selectedCustomer.phone || selectedCustomer.email}</p>
-                  </div>
-                  <Button size="sm" variant="ghost" onClick={() => setSelectedCustomer(null)}>
-                    <XCircle className="w-4 h-4" />
-                  </Button>
-                </div>
-              ) : (
-                <div className="mt-1">
-                  <div className="relative">
-                    <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
-                    <Input placeholder="Buscar cliente..." value={customerSearch} onChange={e => setCustomerSearch(e.target.value)} className="pl-9 h-9" />
-                  </div>
-                  {searchLoading && <div className="flex justify-center py-2"><Loader2 className="w-4 h-4 animate-spin" /></div>}
-                  {customers.length > 0 && (
-                    <div className="border rounded-lg mt-1 max-h-60 overflow-y-auto">
-                      {customers.map((c, idx) => (
-                        <button key={`${c.user_id || c.omie_codigo_cliente || c.document}-${idx}`}
-                          onClick={() => { setSelectedCustomer(c); setCustomerSearch(''); setCustomers([]); }}
-                          className="w-full text-left px-3 py-2 hover:bg-muted/50 text-sm border-b last:border-b-0">
-                          <div className="flex items-center justify-between gap-2">
-                            <p className="font-medium truncate">{c.name}</p>
-                            {c.omie_codigo_cliente && (
-                              <Badge variant="outline" className="text-[10px] shrink-0">Omie</Badge>
-                            )}
-                          </div>
-                          <p className="text-xs text-muted-foreground truncate">
-                            {[c.document, c.phone, c.email].filter(Boolean).join(' · ') || 'Sem contato'}
-                          </p>
-                        </button>
-                      ))}
-                    </div>
-                  )}
-                </div>
-              )}
-            </div>
-
-            <Select value={callType} onValueChange={setCallType}>
-              <SelectTrigger className="h-9"><SelectValue /></SelectTrigger>
-              <SelectContent>{CALL_TYPES.map(t => <SelectItem key={t.value} value={t.value}>{t.label}</SelectItem>)}</SelectContent>
-            </Select>
-
-            {/* Timers */}
-            <Card className="bg-muted/30">
-              <CardContent className="p-3">
-                <div className="grid grid-cols-2 gap-3">
-                  <div className="text-center">
-                    <p className="text-xs text-muted-foreground mb-1">Ligação</p>
-                    <p className="text-2xl font-mono font-bold">{formatTimer(callSeconds)}</p>
-                    {selectedCustomer?.phone ? (
-                      <Badge variant="outline" className="text-[10px] mt-1">
-                        {nvoipIsConnecting && <><Loader2 className="w-3 h-3 mr-1 animate-spin" /> Conectando...</>}
-                        {nvoipIsRinging && <><PhoneCall className="w-3 h-3 mr-1 animate-pulse" /> Tocando ramal/destino</>}
-                        {nvoipIsEstablished && <><PhoneIncoming className="w-3 h-3 mr-1 text-emerald-600" /> Em chamada</>}
-                        {!nvoipIsActive && !nvoipIsEstablished && (
-                          <>📞 Disca via {callBackend === 'webrtc' ? 'WebRTC' : 'Nvoip'} → {selectedCustomer.phone}</>
-                        )}
-                      </Badge>
-                    ) : (
-                      <Badge variant="outline" className="text-[10px] mt-1 text-amber-700">
-                        Sem telefone — cronômetro manual
-                      </Badge>
-                    )}
-                    <Button size="sm" variant={isCallActive ? 'destructive' : 'default'} className="mt-2 w-full h-8"
-                      onClick={isCallActive ? stopCallTimer : startCallTimer}
-                      disabled={nvoipIsConnecting}>
-                      {isCallActive ? <><PhoneOff className="w-3 h-3 mr-1" /> Parar</> : <><Play className="w-3 h-3 mr-1" /> Iniciar</>}
-                    </Button>
-                    {nvoipError && (
-                      <p className="text-[10px] text-destructive mt-1">{nvoipError}</p>
-                    )}
-                  </div>
-                  <div className="text-center">
-                    <p className="text-xs text-muted-foreground mb-1">Follow-up</p>
-                    <p className="text-2xl font-mono font-bold">{formatTimer(followUpSeconds)}</p>
-                    <Button size="sm" variant={isFollowUpActive ? 'destructive' : 'outline'} className="mt-2 w-full h-8"
-                      onClick={isFollowUpActive ? stopFollowUpTimer : startFollowUpTimer}>
-                      {isFollowUpActive ? <><Pause className="w-3 h-3 mr-1" /> Parar</> : <><Timer className="w-3 h-3 mr-1" /> Iniciar</>}
-                    </Button>
-                  </div>
-                </div>
-              </CardContent>
-            </Card>
-
-            <Select value={callResult} onValueChange={setCallResult}>
-              <SelectTrigger className="h-9"><SelectValue /></SelectTrigger>
-              <SelectContent>{CALL_RESULTS.map(r => <SelectItem key={r.value} value={r.value}>{r.icon} {r.label}</SelectItem>)}</SelectContent>
-            </Select>
-
-            <Input type="number" min={1} value={attemptNumber} onChange={e => setAttemptNumber(parseInt(e.target.value) || 1)} className="h-9" placeholder="Nº da tentativa" />
-
-            {callResult === 'contato_sucesso' && (
-              <div className="grid grid-cols-2 gap-3">
-                <Input type="number" step="0.01" placeholder="Receita (R$)" value={revenue} onChange={e => setRevenue(e.target.value)} className="h-9" />
-                <Input type="number" step="0.01" placeholder="Margem (R$)" value={margin} onChange={e => setMargin(e.target.value)} className="h-9" />
-              </div>
-            )}
-
-            <Textarea placeholder="Observações da ligação..." value={notes} onChange={e => setNotes(e.target.value)} rows={2} />
-          </div>
-          <DialogFooter>
-            <Button variant="outline" onClick={() => setShowNewCall(false)}>Cancelar</Button>
-            <Button onClick={handleSaveCall} disabled={!selectedCustomer || saving} className="gap-1.5">
-              {saving ? <Loader2 className="w-4 h-4 animate-spin" /> : <CheckCircle className="w-4 h-4" />} Salvar
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      <NewCallDialog
+        open={showNewCall}
+        onOpenChange={setShowNewCall}
+        selectedCustomer={selectedCustomer}
+        setSelectedCustomer={setSelectedCustomer}
+        customerSearch={customerSearch}
+        setCustomerSearch={setCustomerSearch}
+        customers={customers}
+        setCustomers={setCustomers}
+        searchLoading={searchLoading}
+        callType={callType}
+        setCallType={setCallType}
+        callResult={callResult}
+        setCallResult={setCallResult}
+        attemptNumber={attemptNumber}
+        setAttemptNumber={setAttemptNumber}
+        notes={notes}
+        setNotes={setNotes}
+        revenue={revenue}
+        setRevenue={setRevenue}
+        margin={margin}
+        setMargin={setMargin}
+        callSeconds={callSeconds}
+        followUpSeconds={followUpSeconds}
+        isCallActive={isCallActive}
+        isFollowUpActive={isFollowUpActive}
+        nvoipIsConnecting={nvoipIsConnecting}
+        nvoipIsRinging={nvoipIsRinging}
+        nvoipIsEstablished={nvoipIsEstablished}
+        nvoipIsActive={nvoipIsActive}
+        nvoipError={nvoipError}
+        callBackend={callBackend}
+        saving={saving}
+        onStartCall={startCallTimer}
+        onStopCall={stopCallTimer}
+        onStartFollowUp={startFollowUpTimer}
+        onStopFollowUp={stopFollowUpTimer}
+        onSave={handleSaveCall}
+      />
 
       {/* Painel lateral de transcrição ao vivo — só renderiza em chamadas WebRTC ativas */}
       {callBackend === 'webrtc' && webrtc.callState === 'established' && (


### PR DESCRIPTION
## Resumo

Quebra do god-component `src/pages/FarmerCalls.tsx` (página "Ligações") — **864 → 474 linhas**. Refactor **comportamento-preservante 1:1**, novos componentes em `src/components/farmer/calls/`.

- **`types.ts`** — `Customer`/`CallLog` + `CALL_TYPES`/`CALL_RESULTS`/`AGENDA_TYPE_META` + helpers `fmt`/`formatTimer` (movidos verbatim).
- **`CallDetailPanel.tsx`** — painel de detalhe estilo Gong (leaf puro).
- **`TodayStatsCards.tsx`** — KPIs do dia (ligações/receita/duração média).
- **`AgendaQueueCard.tsx`** — fila "Próximas ligações". A lógica de prefill que estava inline no `onCallEnd`/Registrar foi movida para handlers nomeados no pai (`handleAgendaCallEnd`/`handleAgendaRegister`), passados como props — o componente fica burro.
- **`CallListPanel.tsx`** — lista filtrada + detalhe (split Gong).
- **`NewCallDialog.tsx`** — diálogo de registro (componente controlado, ~30 props).

### Decisão de arquitetura

Todo o estado (`useState`/`useRef`), os 5 `useEffect`, os timers, `loadCallLogs`, `searchCustomers`, `resetForm` e `handleSaveCall` permanecem **no pai** e descem via props. Nenhuma mudança de timing de efeito ou data-fetch.

## Garantias

- ✅ `bunx tsc --noEmit` — 0 erros.
- ✅ `bun lint` — 0 erros (1 warning `exhaustive-deps` em `loadCallLogs`, **pré-existente**, herdado verbatim do original).
- ✅ Suíte: **494/494** passando.
- ✅ `bun run build` exit 0.
- ✅ +19 testes novos (6 arquivos): helpers, render, estados vazios, cliques de filtro/registrar/salvar, encaminhamento de callbacks.
- ✅ Revisão independente (subagente): veredito **FIEL 1:1** — `handleAgendaCallEnd`/`handleAgendaRegister` reproduzem fielmente a lógica inline; nenhum bloco perdido (painel de transcrição WebRTC, botão "Mostrar transcrição", early-return de authLoading intactos).

## Test plan

- [x] tsc 0 erros / lint 0 erros
- [x] 19 testes novos + suíte completa 494/494
- [x] build de produção exit 0
- [x] revisão independente confirma 1:1
- [ ] CI `validate` verde

🤖 Generated with [Claude Code](https://claude.com/claude-code)