### PR TITLE
refactor(edge-functions): elimina 20 no-explicit-any em 11 funções Deno

### DIFF
--- a/supabase/functions/biometric-auth/index.ts
+++ b/supabase/functions/biometric-auth/index.ts
@@ -163,6 +163,7 @@ serve(async (req) => {
               clientDataJSON,
               signature,
             },
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any -- shape exato do AuthenticationResponseJSON do @simplewebauthn varia por versão; cast no boundary da lib
           } as any,
           expectedChallenge: (c) => c === chalRec.challenge,
           expectedOrigin: allowedOrigins,

--- a/supabase/functions/generate-bundle-argument/index.ts
+++ b/supabase/functions/generate-bundle-argument/index.ts
@@ -93,7 +93,7 @@ Gasto médio mensal: R$ ${customer.avgMonthlySpend || 0}
 Categorias compradas: ${customer.categoryCount || 0}
 
 Bundle sugerido (${bundle.products.length} produtos):
-${bundle.products.map((p: any, i: number) => `${i + 1}. ${p.name} - Preço: R$ ${p.price.toFixed(2)} | Margem: R$ ${p.margin.toFixed(2)}`).join('\n')}
+${bundle.products.map((p: { name: string; price: number; margin: number }, i: number) => `${i + 1}. ${p.name} - Preço: R$ ${p.price.toFixed(2)} | Margem: R$ ${p.margin.toFixed(2)}`).join('\n')}
 
 LIE do Bundle: R$ ${bundle.lieBundle.toFixed(2)}
 Confidence: ${(bundle.confidence * 100).toFixed(1)}%
@@ -186,7 +186,7 @@ Gasto médio mensal: R$ ${customer.avgMonthlySpend || 0}
 Categorias compradas: ${customer.categoryCount || 0}
 
 Bundle sugerido (${bundle.products.length} produtos):
-${bundle.products.map((p: any, i: number) => `${i + 1}. ${p.name} - Preço: R$ ${p.price.toFixed(2)} | Margem: R$ ${p.margin.toFixed(2)}`).join('\n')}
+${bundle.products.map((p: { name: string; price: number; margin: number }, i: number) => `${i + 1}. ${p.name} - Preço: R$ ${p.price.toFixed(2)} | Margem: R$ ${p.margin.toFixed(2)}`).join('\n')}
 
 LIE do Bundle: R$ ${bundle.lieBundle.toFixed(2)}
 Confidence: ${(bundle.confidence * 100).toFixed(1)}%

--- a/supabase/functions/monthly-report/index.ts
+++ b/supabase/functions/monthly-report/index.ts
@@ -299,9 +299,9 @@ serve(async (req) => {
           : null;
 
         toolSummaries.push({
-          name: tool.generated_name || tool.custom_name || (tool.tool_categories as any)?.name || 'Ferramenta',
+          name: tool.generated_name || tool.custom_name || (tool.tool_categories as { name?: string } | null)?.name || 'Ferramenta',
           internal_code: tool.internal_code,
-          category: (tool.tool_categories as any)?.name || '',
+          category: (tool.tool_categories as { name?: string } | null)?.name || '',
           last_sharpened_at: tool.last_sharpened_at,
           next_sharpening_due: tool.next_sharpening_due,
           sharpening_count: sharpeningCount || 0,
@@ -378,7 +378,7 @@ serve(async (req) => {
       status: 200,
       headers: { ...corsHeaders, 'Content-Type': 'application/json' },
     });
-  } catch (error: any) {
+  } catch (error) {
     console.error('Error in monthly-report:', error);
     return new Response(JSON.stringify({ error: 'Erro ao gerar relatório' }), {
       status: 500,

--- a/supabase/functions/nvoip-calls/index.ts
+++ b/supabase/functions/nvoip-calls/index.ts
@@ -143,7 +143,7 @@ Deno.serve(async (req) => {
       return data.access_token;
     }
 
-    async function saveTokens(sb: any, tokenResp: any) {
+    async function saveTokens(sb: ReturnType<typeof createClient>, tokenResp: { expires_in?: number; access_token: string; refresh_token?: string }) {
       const expiresAt = Date.now() + (tokenResp.expires_in || 86400) * 1000;
 
       const upsert = async (key: string, value: string) => {

--- a/supabase/functions/omie-nfe-webhook/index.ts
+++ b/supabase/functions/omie-nfe-webhook/index.ts
@@ -103,12 +103,12 @@ Deno.serve(async (req) => {
     }
 
     // Parse items — NO conversion table, smart rounding only
-    const rawItems: any[] =
+    const rawItems: Record<string, unknown>[] =
       nfe.itens ?? nfe.items ?? nfe.det ?? nfe.produtos ?? [];
 
     const cnpjEmClean = cnpjEmitente.replace(/\D/g, "");
 
-    const itensToInsert = rawItems.map((item: any, idx: number) => {
+    const itensToInsert = rawItems.map((item: Record<string, unknown>, idx: number) => {
       const codigoProduto = item.codigo_produto ?? item.cProd ?? item.codigo ?? null;
       const descricao = item.descricao ?? item.xProd ?? item.desc ?? "Item sem descrição";
       const ncm = item.ncm ?? item.NCM ?? null;

--- a/supabase/functions/omie-sync-metadados/index.ts
+++ b/supabase/functions/omie-sync-metadados/index.ts
@@ -44,7 +44,7 @@ async function callOmie(
 }
 
 async function syncMetadadosAccount(
-  db: any,
+  db: ReturnType<typeof createClient>,
   account: OmieAccount,
 ) {
   const acctValue = getCredentials(account).label;

--- a/supabase/functions/omie-sync-status-produtos/index.ts
+++ b/supabase/functions/omie-sync-status-produtos/index.ts
@@ -36,7 +36,7 @@ async function omieCall(
   call: string,
   param: Record<string, unknown>,
   attempt = 1
-): Promise<any> {
+): Promise<Record<string, unknown>> {
   try {
     const res = await fetch(OMIE_URL, {
       method: "POST",
@@ -183,7 +183,7 @@ Deno.serve(async (req) => {
     let falhas = 0;
     let encontradosNaListagem = 0;
     const encontrados = new Set<string>();
-    const upserts: any[] = [];
+    const upserts: Record<string, unknown>[] = [];
 
     do {
       const resp = await omieCall(appKey, appSecret, "ListarProdutos", {
@@ -194,7 +194,7 @@ Deno.serve(async (req) => {
       });
 
       totalPages = resp?.total_de_paginas ?? 1;
-      const produtos: OmieProduto[] = resp?.produto_servico_cadastro ?? [];
+      const produtos: OmieProduto[] = (resp as { produto_servico_cadastro?: OmieProduto[] })?.produto_servico_cadastro ?? [];
 
       for (const p of produtos) {
         const codStr = String(p.codigo_produto ?? "");

--- a/supabase/functions/process-recurring-orders/index.ts
+++ b/supabase/functions/process-recurring-orders/index.ts
@@ -44,9 +44,9 @@ serve(async (req) => {
           .select('*')
           .eq('inativo', false);
 
-        const orderItems = tools.map((tool: any) => {
+        const orderItems = tools.map((tool: { id: string; generated_name?: string | null; custom_name?: string | null; tool_categories?: { name?: string } | null }) => {
           const categoryName = tool.tool_categories?.name?.toLowerCase() || '';
-          const matchingService = (servicos || []).find((s: any) => 
+          const matchingService = (servicos || []).find((s: { descricao: string; omie_codigo_servico?: string }) => 
             s.descricao.toLowerCase().includes(categoryName)
           );
 

--- a/supabase/functions/promocao-extrair-via-vision/index.ts
+++ b/supabase/functions/promocao-extrair-via-vision/index.ts
@@ -116,7 +116,7 @@ interface ExtractedAumento {
 // para o nome canônico (razão social) usado no resto do sistema.
 // Fallback hardcoded para Sayerlack/Renner caso a tabela esteja indisponível.
 async function normalizarFornecedor(
-  supabase: any,
+  supabase: ReturnType<typeof createClient>,
   extraido: string | null | undefined,
   _tipoDocumento: string,
 ): Promise<string> {

--- a/supabase/functions/rag-search/index.ts
+++ b/supabase/functions/rag-search/index.ts
@@ -78,9 +78,9 @@ Deno.serve(async (req) => {
 
     const sources = body.sources ?? ['customer_processes', 'standard_processes', 'kb_documents'];
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let q = supabase
       .from('rag_chunks')
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- filtros JSON-path (metadata->>x) não existem nos tipos gerados; cast no boundary do PostgREST
       .select('source_table, source_id, chunk_index, content, metadata, embedding') as any;
 
     q = q.in('source_table', sources);

--- a/supabase/functions/recommend/index.ts
+++ b/supabase/functions/recommend/index.ts
@@ -54,7 +54,7 @@ interface Candidate {
 }
 
 async function recommend(
-  db: any,
+  db: ReturnType<typeof createClient>,
   customerId: string,
   basketProductIds: string[],
   farmerId: string
@@ -290,7 +290,7 @@ async function recommend(
 // ======== LOG EVENT ========
 
 async function logEvent(
-  db: any,
+  db: ReturnType<typeof createClient>,
   farmerId: string,
   customerId: string,
   productId: string,


### PR DESCRIPTION
## Lane isolada — zero colisão

`supabase/functions/` (Deno) **não é tocada** por nenhuma sessão de migração strict do frontend e **não encosta no `tsconfig.strict.json`**. Escolhida exatamente por ser disjunta enquanto outras sessões trabalham `src/`.

## O que muda (type-only, zero runtime)

20 `no-explicit-any` eliminados em 11 funções:
- Params de client (`db`/`sb`/`supabase`) → `ReturnType<typeof createClient>` (sem novo import).
- `catch (error: any)` → `catch (error)`.
- `(tool_categories as any)` → `as { name?: string } | null`.
- Shapes claras → interfaces inline (bundle products, tokenResp do nvoip).
- Payloads externos (itens NFe, resposta Omie, upserts) → `Record<string, unknown>`.
- `.map`/`.find` params (process-recurring) → tipos inline dos campos usados.
- **2 mantidos com `eslint-disable` justificado**: `biometric-auth` (boundary do `@simplewebauthn`) e `rag-search` (filtro JSON-path `metadata->>x` que os tipos gerados do PostgREST não conhecem). No rag-search, a directiva estava mal-posicionada ("unused" na linha 81) — corrigida pra cobrir o cast.

eslint: **20→0** no-explicit-any nas 11 funções; **zero erro novo** (os erros pré-existentes em `tint-import`/`tint-sync-agent` não foram tocados).

## Caveat honesto

Edge functions ficam **fora do escopo** do `tsconfig.strict.json` (Deno, sem gate de `tsc`) e **deployam via chat do Lovable, não pelo repo** — então é melhoria de qualidade/tipo no repositório, sem efeito em produção até alguém re-deployar. Type-only, então mesmo no re-deploy o comportamento é idêntico.

## Test plan

- [ ] CI `validate` — edge functions não entram no typecheck:strict nem são importadas por testes (Deno). Mudança type-only. Auto-merge só com CI verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)