### PR TITLE
refactor(typescript): tipa customer_metrics no AIops (elimina 1 any)

### DIFF
--- a/src/pages/AIops.tsx
+++ b/src/pages/AIops.tsx
@@ -45,7 +45,7 @@ interface AIDecision {
   primary_reason: string;
   evidences: Evidence[];
   explanation: string;
-  customer_metrics: Record<string, any>;
+  customer_metrics: Record<string, number | null>;
   status: string;
   created_at: string;
   updated_at: string;


### PR DESCRIPTION
## Summary
`AIops.tsx`: `customer_metrics: Record<string, any>` → `Record<string, number | null>`. Os campos consumidos (pedidos_90d, faturamento_90d, ticket_medio_90d, intervalo_medio_dias, atraso_relativo) são métricas numéricas nullable — o tipo preciso preserva o acesso por propriedade, comparações `=== null` e renderização no JSX.

## Validação
- `bunx tsc --noEmit -p tsconfig.app.json` ✅ 0
- `bunx eslint` ✅ 0
- `bun run test` → **527/527** ✅

## Contexto
Penúltimo `any` do repo. O último (`AdminReposicaoParametros` — `v_fornecedor_sla_compliance`) ficou **de fora de propósito**: dropar o `as any` revelou um conflito entre o types.ts gerado (`skus_violando`) e o código consumidor + migrations (`violando`) — preciso confirmar as colunas reais no banco antes de mexer, pra não quebrar uma query que talvez funcione (Codex flag P2). SQL de verificação entregue ao founder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)