### PR TITLE
refactor(sales): split god-component SalesPrintDashboard (827→435)

### DIFF
--- a/src/components/sales/print/OrderGroup.tsx
+++ b/src/components/sales/print/OrderGroup.tsx
@@ -1,0 +1,66 @@
+// Grupo de pedidos por período (manhã/tarde) na Impressão de Pedidos.
+// Extraído de src/pages/SalesPrintDashboard.tsx (god-component split).
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Sun, Sunset, Printer } from 'lucide-react';
+import { format } from 'date-fns';
+import type { CompanyFilter, EnrichedOrder } from './types';
+
+export function OrderGroup({ company, period, orders, selectedOrders, onToggleOrder, onPrintSingle }: {
+  company: CompanyFilter;
+  period: 'manha' | 'tarde';
+  orders: EnrichedOrder[];
+  selectedOrders: Set<string>;
+  onToggleOrder: (id: string) => void;
+  onPrintSingle: (order: EnrichedOrder) => void;
+}) {
+  if (orders.length === 0) return null;
+  const periodLabel = period === 'manha' ? 'Manhã' : 'Tarde';
+  const PeriodIcon = period === 'manha' ? Sun : Sunset;
+
+  return (
+    <div key={`${company}-${period}`} className="space-y-2">
+      <div className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
+        <PeriodIcon className="h-4 w-4" />
+        <span>{periodLabel}</span>
+        <Badge variant="secondary" className="text-xs">{orders.length}</Badge>
+      </div>
+      <div className="space-y-1.5">
+        {orders.map(order => (
+          <div
+            key={order.id}
+            className="flex items-center gap-3 p-3 rounded-lg border bg-card hover:bg-accent/50 transition-colors cursor-pointer"
+            onClick={() => onToggleOrder(order.id)}
+          >
+            <Checkbox
+              checked={selectedOrders.has(order.id)}
+              onCheckedChange={() => onToggleOrder(order.id)}
+              onClick={e => e.stopPropagation()}
+            />
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center gap-2">
+                <span className="font-mono text-sm font-medium">
+                  {order.omie_numero_pedido ? `#${order.omie_numero_pedido.replace(/^0+/, '')}` : order.id.slice(0, 8).toUpperCase()}
+                </span>
+                <span className="text-xs text-muted-foreground">
+                  {format(new Date(order.created_at), 'HH:mm')}
+                </span>
+              </div>
+              <div className="text-sm text-muted-foreground truncate">{order.customer_name}</div>
+            </div>
+            <div className="text-right">
+              <div className="text-sm font-medium">
+                {order.total.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' })}
+              </div>
+              <div className="text-xs text-muted-foreground">{(order.items || []).length} itens</div>
+            </div>
+            <Button size="sm" variant="ghost" className="h-8 w-8 p-0" onClick={e => { e.stopPropagation(); onPrintSingle(order); }}>
+              <Printer className="h-4 w-4" />
+            </Button>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/sales/print/PrintFilters.tsx
+++ b/src/components/sales/print/PrintFilters.tsx
@@ -1,0 +1,79 @@
+// Card de filtros (data, período, empresas) da Impressão de Pedidos.
+// Extraído de src/pages/SalesPrintDashboard.tsx (god-component split).
+import { Card, CardContent } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Calendar } from '@/components/ui/calendar';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { CalendarIcon, Sun, Sunset, Building2 } from 'lucide-react';
+import { format } from 'date-fns';
+import { ptBR } from 'date-fns/locale';
+import { cn } from '@/lib/utils';
+import { COMPANY_LABELS, COMPANY_COLORS, type CompanyFilter } from './types';
+
+export function PrintFilters({
+  selectedDate, setSelectedDate, selectedPeriod, setSelectedPeriod, selectedCompanies, toggleCompany,
+}: {
+  selectedDate: Date;
+  setSelectedDate: (d: Date) => void;
+  selectedPeriod: 'all' | 'manha' | 'tarde';
+  setSelectedPeriod: (p: 'all' | 'manha' | 'tarde') => void;
+  selectedCompanies: CompanyFilter[];
+  toggleCompany: (c: CompanyFilter) => void;
+}) {
+  return (
+    <Card>
+      <CardContent className="pt-4 space-y-4">
+        {/* Date picker */}
+        <div className="flex items-center gap-3 flex-wrap">
+          <Popover>
+            <PopoverTrigger asChild>
+              <Button variant="outline" className={cn("w-[200px] justify-start text-left font-normal")}>
+                <CalendarIcon className="mr-2 h-4 w-4" />
+                {format(selectedDate, "dd 'de' MMMM, yyyy", { locale: ptBR })}
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent className="w-auto p-0" align="start">
+              <Calendar
+                mode="single"
+                selected={selectedDate}
+                onSelect={d => d && setSelectedDate(d)}
+                initialFocus
+                className="p-3 pointer-events-auto"
+                locale={ptBR}
+              />
+            </PopoverContent>
+          </Popover>
+
+          {/* Period filter */}
+          <Tabs value={selectedPeriod} onValueChange={v => setSelectedPeriod(v as 'all' | 'manha' | 'tarde')}>
+            <TabsList>
+              <TabsTrigger value="all">Todos</TabsTrigger>
+              <TabsTrigger value="manha" className="gap-1"><Sun className="h-3 w-3" />Manhã</TabsTrigger>
+              <TabsTrigger value="tarde" className="gap-1"><Sunset className="h-3 w-3" />Tarde</TabsTrigger>
+            </TabsList>
+          </Tabs>
+        </div>
+
+        {/* Company toggles */}
+        <div className="flex items-center gap-2 flex-wrap">
+          <Building2 className="h-4 w-4 text-muted-foreground" />
+          {(['oben', 'colacor', 'afiacao'] as CompanyFilter[]).map(c => (
+            <Badge
+              key={c}
+              variant="outline"
+              className={cn(
+                'cursor-pointer transition-all',
+                selectedCompanies.includes(c) ? COMPANY_COLORS[c] : 'opacity-40'
+              )}
+              onClick={() => toggleCompany(c)}
+            >
+              {COMPANY_LABELS[c]}
+            </Badge>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/sales/print/__tests__/OrderGroup.test.tsx
+++ b/src/components/sales/print/__tests__/OrderGroup.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { OrderGroup } from '../OrderGroup';
+import type { EnrichedOrder } from '../types';
+
+const order: EnrichedOrder = {
+  id: 'ord-1',
+  _company: 'oben',
+  customer_user_id: 'u1',
+  items: [{ codigo: 'P1', descricao: 'X', quantidade: 1 }, { codigo: 'P2', descricao: 'Y', quantidade: 1 }],
+  subtotal: 100,
+  total: 100,
+  status: 'aprovado',
+  omie_numero_pedido: '000045',
+  created_at: '2026-01-15T09:30:00',
+  notes: null,
+  customer_name: 'Cliente Alpha',
+};
+
+function noop() { /* */ }
+
+describe('OrderGroup', () => {
+  it('lista vazia → não renderiza nada (null)', () => {
+    const { container } = render(
+      <OrderGroup company="oben" period="manha" orders={[]} selectedOrders={new Set()} onToggleOrder={noop} onPrintSingle={noop} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renderiza período, número do pedido, cliente, total e contagem de itens', () => {
+    render(
+      <OrderGroup company="oben" period="manha" orders={[order]} selectedOrders={new Set()} onToggleOrder={noop} onPrintSingle={noop} />
+    );
+    expect(screen.getByText('Manhã')).toBeTruthy();
+    expect(screen.getByText('#45')).toBeTruthy();
+    expect(screen.getByText('Cliente Alpha')).toBeTruthy();
+    expect(screen.getByText('2 itens')).toBeTruthy();
+    expect(screen.getByText(/100,00/)).toBeTruthy();
+  });
+
+  it('clique na linha chama onToggleOrder; botão imprimir chama onPrintSingle', () => {
+    const onToggleOrder = vi.fn();
+    const onPrintSingle = vi.fn();
+    render(
+      <OrderGroup company="oben" period="manha" orders={[order]} selectedOrders={new Set()} onToggleOrder={onToggleOrder} onPrintSingle={onPrintSingle} />
+    );
+    fireEvent.click(screen.getByText('Cliente Alpha'));
+    expect(onToggleOrder).toHaveBeenCalledWith('ord-1');
+
+    // O botão de imprimir é o único <button> da linha (Checkbox tem role checkbox)
+    fireEvent.click(screen.getByRole('button'));
+    expect(onPrintSingle).toHaveBeenCalledWith(order);
+  });
+});

--- a/src/components/sales/print/__tests__/PrintFilters.test.tsx
+++ b/src/components/sales/print/__tests__/PrintFilters.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { PrintFilters } from '../PrintFilters';
+
+function noop() { /* */ }
+
+describe('PrintFilters', () => {
+  it('renderiza tabs de período e badges das empresas', () => {
+    render(
+      <PrintFilters
+        selectedDate={new Date('2026-01-15T12:00:00')}
+        setSelectedDate={noop}
+        selectedPeriod="all"
+        setSelectedPeriod={noop}
+        selectedCompanies={['oben', 'colacor', 'afiacao']}
+        toggleCompany={noop}
+      />
+    );
+    expect(screen.getByText('Todos')).toBeTruthy();
+    expect(screen.getByText('Manhã')).toBeTruthy();
+    expect(screen.getByText('Tarde')).toBeTruthy();
+    expect(screen.getByText('Oben')).toBeTruthy();
+    expect(screen.getByText('Colacor')).toBeTruthy();
+    expect(screen.getByText('Afiação')).toBeTruthy();
+  });
+
+  it('clicar no badge de empresa chama toggleCompany', () => {
+    const toggleCompany = vi.fn();
+    render(
+      <PrintFilters
+        selectedDate={new Date('2026-01-15T12:00:00')}
+        setSelectedDate={noop}
+        selectedPeriod="all"
+        setSelectedPeriod={noop}
+        selectedCompanies={['oben', 'colacor', 'afiacao']}
+        toggleCompany={toggleCompany}
+      />
+    );
+    fireEvent.click(screen.getByText('Colacor'));
+    expect(toggleCompany).toHaveBeenCalledWith('colacor');
+  });
+});

--- a/src/components/sales/print/__tests__/buildPrintHtml.test.ts
+++ b/src/components/sales/print/__tests__/buildPrintHtml.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import { buildPrintData, escapeHtml, buildSingleOrderHtml, buildPrintDocument } from '../buildPrintHtml';
+import type { SalesOrderRow } from '../types';
+
+const order: SalesOrderRow = {
+  id: 'abc12345-9999',
+  customer_user_id: 'u1',
+  items: [
+    { codigo: 'P1', descricao: 'Produto Alpha', quantidade: 2, unidade: 'UN', valor_unitario: 10, valor_total: 20 },
+  ],
+  subtotal: 20,
+  total: 20,
+  status: 'aprovado',
+  omie_numero_pedido: '000123',
+  created_at: '2026-01-15T10:00:00',
+  notes: null,
+  customer_name: 'João Cliente',
+  customer_document: '123',
+};
+
+describe('escapeHtml', () => {
+  it('escapa caracteres especiais HTML', () => {
+    expect(escapeHtml('<b>"a" & \'b\'>')).toBe('&lt;b&gt;&quot;a&quot; &amp; &#39;b&#39;&gt;');
+    expect(escapeHtml(null)).toBe('');
+    expect(escapeHtml(undefined)).toBe('');
+  });
+});
+
+describe('buildPrintData', () => {
+  it('mapeia pedido para PrintOrderData (oben) com número sem zeros à esquerda', () => {
+    const data = buildPrintData(order, 'oben');
+    expect(data.companyName).toBe('OBEN COMÉRCIO LTDA');
+    expect(data.isOben).toBe(true);
+    expect(data.orderNumber).toBe('123');
+    expect(data.customerName).toBe('João Cliente');
+    expect(data.items).toHaveLength(1);
+    expect(data.items[0].descricao).toBe('Produto Alpha');
+    expect(data.total).toBe(20);
+  });
+
+  it('usa fallback de nome e logo por empresa', () => {
+    const data = buildPrintData({ ...order, customer_name: undefined }, 'colacor', { colacor: 'http://logo' });
+    expect(data.companyName).toBe('COLACOR COMERCIAL LTDA');
+    expect(data.isOben).toBe(false);
+    expect(data.customerName).toBe('Cliente');
+    expect(data.companyLogoUrl).toBe('http://logo');
+  });
+
+  it('orderNumber cai para id quando sem omie_numero_pedido', () => {
+    const data = buildPrintData({ ...order, omie_numero_pedido: null }, 'oben');
+    expect(data.orderNumber).toBe('ABC12345');
+  });
+});
+
+describe('buildSingleOrderHtml', () => {
+  it('inclui cabeçalho, cliente, item e total', () => {
+    const html = buildSingleOrderHtml(buildPrintData(order, 'colacor'));
+    expect(html).toContain('COLACOR COMERCIAL LTDA');
+    expect(html).toContain('João Cliente');
+    expect(html).toContain('Produto Alpha');
+    expect(html).toContain('Nº 123');
+  });
+
+  it('inclui o recibo LGPD quando isOben', () => {
+    const html = buildSingleOrderHtml(buildPrintData(order, 'oben'));
+    expect(html).toContain('RECIBO DE ENTREGA DE VENDA NÃO PRESENCIAL');
+  });
+
+  it('gera parcelas a partir de condPagamento "28/42"', () => {
+    const html = buildSingleOrderHtml(buildPrintData({ ...order, cond_pagamento: '28/42' }, 'colacor'));
+    expect(html).toContain('1ª parcela');
+    expect(html).toContain('2ª parcela');
+    expect(html).toContain('CONDIÇÃO DE PAGAMENTO');
+  });
+
+  it('à vista (000) não gera parcelas', () => {
+    const html = buildSingleOrderHtml(buildPrintData({ ...order, cond_pagamento: '000' }, 'colacor'));
+    expect(html).not.toContain('1ª parcela');
+  });
+});
+
+describe('buildPrintDocument', () => {
+  it('envolve páginas com DOCTYPE, título com data, page-break e script de impressão', () => {
+    const html = buildPrintDocument(['<div>A</div>', '<div>B</div>'], '15/01/2026');
+    expect(html.startsWith('<!DOCTYPE html>')).toBe(true);
+    expect(html).toContain('Impressão de Pedidos - 15/01/2026');
+    expect(html).toContain('<div>A</div>');
+    expect(html).toContain('<div class="page-break"></div>');
+    expect(html).toContain('window.print()');
+  });
+});

--- a/src/components/sales/print/__tests__/types.test.ts
+++ b/src/components/sales/print/__tests__/types.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { getPeriod, COMPANY_LABELS, COMPANY_COLORS } from '../types';
+
+describe('getPeriod', () => {
+  it('antes do meio-dia → manha; meio-dia ou depois → tarde', () => {
+    expect(getPeriod('2026-01-15T08:00:00')).toBe('manha');
+    expect(getPeriod('2026-01-15T11:59:00')).toBe('manha');
+    expect(getPeriod('2026-01-15T12:00:00')).toBe('tarde');
+    expect(getPeriod('2026-01-15T18:30:00')).toBe('tarde');
+  });
+});
+
+describe('constantes de empresa', () => {
+  it('rótulos e cores cobrem as 3 empresas', () => {
+    expect(COMPANY_LABELS).toEqual({ oben: 'Oben', colacor: 'Colacor', afiacao: 'Afiação' });
+    expect(Object.keys(COMPANY_COLORS)).toEqual(['oben', 'colacor', 'afiacao']);
+  });
+});

--- a/src/components/sales/print/buildPrintHtml.ts
+++ b/src/components/sales/print/buildPrintHtml.ts
@@ -1,0 +1,220 @@
+// Geração pura de HTML para impressão de pedidos.
+// Extraído de src/pages/SalesPrintDashboard.tsx (god-component split).
+import { addDays, format } from 'date-fns';
+import { ptBR } from 'date-fns/locale';
+import { type PrintOrderData } from '@/components/OrderPrintLayout';
+import type { CompanyFilter, SalesOrderRow } from './types';
+
+export function buildPrintData(order: SalesOrderRow, company: CompanyFilter, logoUrls?: Record<string, string | null>): PrintOrderData {
+  const isOben = company === 'oben';
+  const companyMap: Record<CompanyFilter, { name: string; cnpj: string; phone: string; address: string }> = {
+    oben: {
+      name: 'OBEN COMÉRCIO LTDA',
+      cnpj: '51.027.034/0001-00',
+      phone: '(37) 9987-8190',
+      address: 'Av. Primeiro de Junho, 70 – Centro, Divinópolis/MG – CEP: 35.500-002',
+    },
+    colacor: {
+      name: 'COLACOR COMERCIAL LTDA',
+      cnpj: '15.422.799/0001-81',
+      phone: '(37) 3222-1035',
+      address: 'Av. Primeiro de Junho, 48 – Centro, Divinópolis/MG – CEP: 35.500-002',
+    },
+    afiacao: {
+      name: 'COLACOR S.C LTDA',
+      cnpj: '55.555.305/0001-51',
+      phone: '(37) 9987-8190',
+      address: 'Av. Primeiro de Junho, 50 – Centro, Divinópolis/MG – CEP: 35.500-002',
+    },
+  };
+
+  const c = companyMap[company];
+
+  // Extract parcelaCode from omie_payload
+  const payload = order.omie_payload;
+  const parcelaCode = payload?.cabecalho?.codigo_parcela || undefined;
+
+  return {
+    companyName: c.name,
+    companyCnpj: c.cnpj,
+    companyPhone: c.phone,
+    companyAddress: c.address,
+    companyLogoUrl: logoUrls?.[company] || undefined,
+    orderNumber: order.omie_numero_pedido?.replace(/^0+/, '') || order.id.slice(0, 8).toUpperCase(),
+    date: format(new Date(order.created_at), "dd/MM/yyyy HH:mm", { locale: ptBR }),
+    customerName: order.customer_name || 'Cliente',
+    customerDocument: order.customer_document || '',
+    customerPhone: order.customer_phone,
+    customerAddress: order.customer_address,
+    vendedorName: order.vendedor_name,
+    condPagamento: order.cond_pagamento,
+    parcelaCode,
+    items: (order.items || []).map((it) => ({
+      codigo: it.codigo || it.omie_codigo || '-',
+      descricao: it.descricao || it.nome || '',
+      quantidade: it.quantidade || 1,
+      unidade: it.unidade || 'UN',
+      valorUnitario: it.valor_unitario || 0,
+      valorTotal: it.valor_total || 0,
+      tintCorId: it.tint_cor_id,
+      tintNomeCor: it.tint_nome_cor,
+    })),
+    subtotal: order.subtotal || 0,
+    desconto: order.desconto || 0,
+    frete: order.frete || 0,
+    total: order.total || 0,
+    observacoes: order.notes || undefined,
+    isOben: isOben,
+  };
+}
+
+export function escapeHtml(s: string | undefined | null): string {
+  if (!s) return '';
+  return s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;');
+}
+
+// Build HTML for a single order page (without <html>/<body> wrappers)
+export function buildSingleOrderHtml(data: PrintOrderData): string {
+  const fmt = (v: number) => v.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
+
+  // Build installment dates
+  const parseParcelaDays = (codeOrDesc?: string): number[] => {
+    if (!codeOrDesc) return [];
+    const clean = codeOrDesc.trim();
+    if (clean === '000' || clean === '999' || /vista/i.test(clean)) return [];
+    // Extract all numeric groups — handles codes like "S37", "A28", "028/042", "28/42 DDL"
+    const matches = clean.match(/(\d{1,3})/g);
+    if (!matches) return [];
+    return matches.map(s => parseInt(s, 10)).filter(n => n > 0 && n <= 365);
+  };
+
+  let days = parseParcelaDays(data.condPagamento);
+  if (days.length === 0) days = parseParcelaDays(data.parcelaCode);
+  let installmentText = '';
+  if (days.length > 0) {
+    const today = new Date();
+    const parcValue = data.total && days.length > 0 ? data.total / days.length : 0;
+    installmentText = days.map((d, i) => {
+      const dueDate = addDays(today, d);
+      const dateStr = `${String(dueDate.getDate()).padStart(2, '0')}/${String(dueDate.getMonth() + 1).padStart(2, '0')}/${dueDate.getFullYear()}`;
+      const valStr = parcValue > 0 ? ` – ${fmt(parcValue)}` : '';
+      return `${i + 1}ª parcela: ${dateStr}${valStr}`;
+    }).join(' | ');
+  }
+
+  const itemsRows = data.items.map((item, i) => {
+    const descLines = [escapeHtml(item.descricao)];
+    if (item.tintCorId && item.tintNomeCor) {
+      const corParts = item.tintNomeCor.split(' - ');
+      const simplified = corParts.length > 2 ? corParts.slice(0, -1).join(' - ') : item.tintNomeCor;
+      const embMatch = item.descricao.match(/\b(QT|GL|LT|BD|BH|5L)\b/i);
+      const embalagem = embMatch ? embMatch[1].toUpperCase() : '';
+      descLines.push(`Cor: ${escapeHtml(item.tintCorId)} - ${escapeHtml(simplified)}${embalagem ? ' - ' + escapeHtml(embalagem) : ''}`);
+    }
+    return `<tr style="background:${i % 2 === 1 ? '#f5f5f5' : '#fff'}">
+      <td style="padding:6px 4px;border:1px solid #ddd;text-align:center;font-size:11px">${i + 1}</td>
+      <td style="padding:6px 4px;border:1px solid #ddd;font-size:11px">${escapeHtml(item.codigo)}</td>
+      <td style="padding:6px 4px;border:1px solid #ddd;font-size:11px">${descLines.join('<br/>')}</td>
+      <td style="padding:6px 4px;border:1px solid #ddd;text-align:center;font-size:11px">${item.quantidade}</td>
+      <td style="padding:6px 4px;border:1px solid #ddd;text-align:center;font-size:11px">${escapeHtml(item.unidade)}</td>
+      <td style="padding:6px 4px;border:1px solid #ddd;text-align:right;font-size:11px">${fmt(item.valorUnitario)}</td>
+      <td style="padding:6px 4px;border:1px solid #ddd;text-align:right;font-size:11px">${fmt(item.valorTotal)}</td>
+    </tr>`;
+  }).join('');
+
+  const cnpjsComDesconto = ['03.422.099/0001-08', '07.311.465/0001-02', '24.521.946/0001-61'];
+  const showDesconto = data.desconto > 0 && cnpjsComDesconto.includes(data.customerDocument || '');
+
+  const obs = data.isOben
+    ? 'RECIBO DE ENTREGA DE VENDA NÃO PRESENCIAL E-PTA-RE Nº: 45.000035717-51 / OBEN COMÉRCIO LTDA. TRANSPORTADORA: Transporte próprio: Oben Comercio Declaro que recebi as mercadorias constantes dessa Nota Fiscal, e que as mercadorias se destinam a uso e consumo, e que estão em perfeito estado e conferem com pedido feito no âmbito do comércio de telemarketing ou eletrônico e que foram recebidas no local por mim no local indicado acima.\n\nCPF/CNPJ:___________________________________ DATA DA ENTREGA:___/___/____\n\nNome/ASSINATURA:_________________________________________________' + (data.observacoes ? '\n\n' + escapeHtml(data.observacoes) : '')
+    : escapeHtml(data.observacoes) || '';
+
+  return `<div>
+<div class="header">
+  <div class="header-left">
+    ${data.companyLogoUrl ? `<img src="${escapeHtml(data.companyLogoUrl)}" class="company-logo" crossorigin="anonymous" />` : ''}
+    <div>
+      <div class="company-name">${escapeHtml(data.companyName)}</div>
+      <div class="company-info">CNPJ: ${escapeHtml(data.companyCnpj)} • Tel: ${escapeHtml(data.companyPhone)}</div>
+      <div class="company-info">${escapeHtml(data.companyAddress)}</div>
+    </div>
+  </div>
+  <div class="order-box">
+    <div class="label">PEDIDO DE VENDA</div>
+    <div class="number">Nº ${escapeHtml(data.orderNumber)}</div>
+    <div class="date">${data.date}</div>
+  </div>
+</div>
+<div class="section-title">DADOS DO CLIENTE</div>
+<div style="display:flex;justify-content:space-between">
+  <div>
+    <div class="customer-name">${escapeHtml(data.customerName)}</div>
+    <div class="customer-info">CPF/CNPJ: ${escapeHtml(data.customerDocument) || 'N/A'}${data.customerPhone ? ' • Tel: ' + escapeHtml(data.customerPhone) : ''}</div>
+    ${data.customerAddress ? `<div class="customer-info" style="margin-top:4px"><strong>Endereço:</strong> ${escapeHtml(data.customerAddress)}</div>` : ''}
+  </div>
+  <div class="right-info">
+    ${data.vendedorName ? `Vendedor: ${escapeHtml(data.vendedorName)}` : ''}
+  </div>
+</div>
+<div class="section-title">ITENS DO PEDIDO</div>
+<table><thead><tr>
+  <th style="width:30px;text-align:center">#</th>
+  <th style="width:70px">Código</th>
+  <th>Descrição</th>
+  <th style="width:40px;text-align:center">Qtd</th>
+  <th style="width:35px;text-align:center">Un</th>
+  <th style="width:80px;text-align:right">Vlr Unit.</th>
+  <th style="width:80px;text-align:right">Vlr Total</th>
+</tr></thead><tbody>${itemsRows}</tbody></table>
+<div class="totals">
+  <div class="row"><span>Subtotal:</span><span>${fmt(data.subtotal)}</span></div>
+  ${showDesconto ? `<div class="row"><span>Desconto:</span><span>- ${fmt(data.desconto)}</span></div>` : ''}
+  
+  <div class="row total-row"><span>TOTAL:</span><span>${fmt(data.total)}</span></div>
+</div>
+${data.condPagamento || installmentText ? `
+<div class="section-title">CONDIÇÃO DE PAGAMENTO</div>
+<div style="font-size:11px;margin-bottom:4px">${data.condPagamento ? `<strong>Prazo:</strong> ${escapeHtml(data.condPagamento)}` : ''}</div>
+${installmentText ? `<div style="font-size:10px;color:#333;background:#f8f8f8;padding:6px 10px;border-radius:2px;border-left:3px solid #e91e63"><strong>Vencimentos:</strong><br/>${installmentText}</div>` : ''}
+` : ''}
+${obs ? `<div class="section-title">OBSERVAÇÕES</div><div class="obs-box">${obs.replace(/\n/g, '<br/>')}</div>` : ''}
+<div class="footer">Documento gerado automaticamente pelo sistema • ${data.date}</div>
+</div>`;
+}
+
+// Build the full printable HTML document (wrappers + CSS) for a set of order pages.
+export function buildPrintDocument(pages: string[], dateLabel: string): string {
+  return `<!DOCTYPE html>
+<html><head><meta charset="utf-8"><title>Impressão de Pedidos - ${dateLabel}</title>
+<style>
+  @media print {
+    @page { margin: 0; size: A4; }
+    body { -webkit-print-color-adjust: exact; print-color-adjust: exact; padding: 1.5cm; }
+    .page-break { page-break-after: always; }
+  }
+  body { font-family: Helvetica, Arial, sans-serif; color: #1a1a1a; margin: 0; padding: 20px; }
+  .header { display: flex; justify-content: space-between; align-items: flex-start; margin-bottom: 16px; border-bottom: 1px solid #ccc; padding-bottom: 12px; }
+  .header-left { display: flex; align-items: center; gap: 12px; }
+  .company-logo { max-height: 50px; max-width: 120px; object-fit: contain; }
+  .company-name { font-size: 22px; font-weight: bold; }
+  .company-info { font-size: 10px; color: #666; margin-top: 2px; }
+  .order-box { background: #e91e63; color: white; border-radius: 4px; padding: 8px 20px; text-align: center; }
+  .order-box .label { font-size: 9px; }
+  .order-box .number { font-size: 18px; font-weight: bold; }
+  .order-box .date { font-size: 9px; }
+  .section-title { font-size: 11px; font-weight: bold; color: #e91e63; margin: 14px 0 6px; }
+  .customer-name { font-size: 14px; font-weight: bold; }
+  .customer-info { font-size: 11px; color: #333; margin-top: 2px; }
+  .right-info { font-size: 11px; color: #666; text-align: right; }
+  table { width: 100%; border-collapse: collapse; }
+  th { background: #2d2d2d; color: white; padding: 6px 4px; font-size: 10px; text-align: left; }
+  .totals { display: flex; flex-direction: column; align-items: flex-end; margin-top: 12px; }
+  .totals .row { display: flex; gap: 30px; font-size: 12px; padding: 3px 0; }
+  .totals .total-row { border-top: 2px solid #2d2d2d; font-size: 15px; font-weight: bold; padding-top: 6px; margin-top: 4px; }
+  .obs-box { background: #fafafa; border: 1px solid #ccc; border-radius: 2px; padding: 10px; font-size: 10px; white-space: pre-wrap; line-height: 1.5; }
+  .footer { text-align: center; font-size: 8px; color: #999; margin-top: 30px; }
+</style></head><body>
+${pages.join('\n<div class="page-break"></div>\n')}
+<script>window.onload = function() { window.print(); }</script>
+</body></html>`;
+}

--- a/src/components/sales/print/types.ts
+++ b/src/components/sales/print/types.ts
@@ -1,0 +1,94 @@
+// Tipos, constantes e helpers da Impressão de Pedidos (SalesPrintDashboard).
+// Extraídos de src/pages/SalesPrintDashboard.tsx (god-component split).
+
+export type CompanyFilter = 'oben' | 'colacor' | 'afiacao';
+
+export const COMPANY_LABELS: Record<CompanyFilter, string> = {
+  oben: 'Oben',
+  colacor: 'Colacor',
+  afiacao: 'Afiação',
+};
+
+export const COMPANY_COLORS: Record<CompanyFilter, string> = {
+  oben: 'bg-blue-100 text-blue-800 border-blue-300',
+  colacor: 'bg-rose-100 text-rose-800 border-rose-300',
+  afiacao: 'bg-amber-100 text-amber-800 border-amber-300',
+};
+
+export interface OrderItem {
+  codigo?: string;
+  omie_codigo?: string;
+  descricao?: string;
+  nome?: string;
+  quantidade?: number;
+  unidade?: string;
+  valor_unitario?: number;
+  valor_total?: number;
+  tint_cor_id?: string;
+  tint_nome_cor?: string;
+  [k: string]: unknown;
+}
+
+export interface OmiePayload {
+  cabecalho?: {
+    codigo_parcela?: string;
+    codigo_cliente?: number;
+    [k: string]: unknown;
+  };
+  [k: string]: unknown;
+}
+
+export interface SalesOrderRow {
+  id: string;
+  customer_user_id: string;
+  items: OrderItem[];
+  subtotal: number;
+  total: number;
+  desconto?: number;
+  frete?: number;
+  status: string;
+  omie_numero_pedido: string | null;
+  created_at: string;
+  notes: string | null;
+  account?: string;
+  customer_name?: string;
+  customer_document?: string;
+  customer_phone?: string;
+  customer_address?: string;
+  vendedor_name?: string;
+  cond_pagamento?: string;
+  user_id?: string;
+  omie_payload?: OmiePayload;
+}
+
+export interface ProfileLite {
+  user_id: string;
+  name: string | null;
+  document: string | null;
+  phone: string | null;
+}
+
+export interface AddressLite {
+  user_id: string;
+  street: string;
+  number: string;
+  complement: string | null;
+  neighborhood: string;
+  city: string;
+  state: string;
+  zip_code: string;
+  is_default: boolean | null;
+}
+
+export interface FormaPagamento {
+  codigo: string;
+  descricao: string;
+}
+
+/** Pedido após enriquecimento (perfil/endereço) + a empresa resolvida. */
+export type EnrichedOrder = SalesOrderRow & { _company: CompanyFilter };
+
+export function getPeriod(dateStr: string): 'manha' | 'tarde' {
+  const h = new Date(dateStr).getHours();
+  return h < 12 ? 'manha' : 'tarde';
+}

--- a/src/pages/SalesPrintDashboard.tsx
+++ b/src/pages/SalesPrintDashboard.tsx
@@ -1,173 +1,22 @@
 import { useState, useMemo } from 'react';
-import { addDays } from 'date-fns';
 import { useNavigate } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
-import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { Calendar } from '@/components/ui/calendar';
-import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
-import { Checkbox } from '@/components/ui/checkbox';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
 import { useQuery } from '@tanstack/react-query';
-import { Loader2, Printer, CalendarIcon, Sun, Sunset, ArrowLeft, Building2 } from 'lucide-react';
+import { Loader2, Printer, ArrowLeft } from 'lucide-react';
 import { format, startOfDay, endOfDay } from 'date-fns';
-import { ptBR } from 'date-fns/locale';
-import { cn } from '@/lib/utils';
-import { openPrintOrder, type PrintOrderData } from '@/components/OrderPrintLayout';
-
-type CompanyFilter = 'oben' | 'colacor' | 'afiacao';
-
-const COMPANY_LABELS: Record<CompanyFilter, string> = {
-  oben: 'Oben',
-  colacor: 'Colacor',
-  afiacao: 'Afiação',
-};
-
-const COMPANY_COLORS: Record<CompanyFilter, string> = {
-  oben: 'bg-blue-100 text-blue-800 border-blue-300',
-  colacor: 'bg-rose-100 text-rose-800 border-rose-300',
-  afiacao: 'bg-amber-100 text-amber-800 border-amber-300',
-};
-
-interface OrderItem {
-  codigo?: string;
-  omie_codigo?: string;
-  descricao?: string;
-  nome?: string;
-  quantidade?: number;
-  unidade?: string;
-  valor_unitario?: number;
-  valor_total?: number;
-  tint_cor_id?: string;
-  tint_nome_cor?: string;
-  [k: string]: unknown;
-}
-
-interface OmiePayload {
-  cabecalho?: {
-    codigo_parcela?: string;
-    codigo_cliente?: number;
-    [k: string]: unknown;
-  };
-  [k: string]: unknown;
-}
-
-interface SalesOrderRow {
-  id: string;
-  customer_user_id: string;
-  items: OrderItem[];
-  subtotal: number;
-  total: number;
-  desconto?: number;
-  frete?: number;
-  status: string;
-  omie_numero_pedido: string | null;
-  created_at: string;
-  notes: string | null;
-  account?: string;
-  customer_name?: string;
-  customer_document?: string;
-  customer_phone?: string;
-  customer_address?: string;
-  vendedor_name?: string;
-  cond_pagamento?: string;
-  user_id?: string;
-  omie_payload?: OmiePayload;
-}
-
-interface ProfileLite {
-  user_id: string;
-  name: string | null;
-  document: string | null;
-  phone: string | null;
-}
-
-interface AddressLite {
-  user_id: string;
-  street: string;
-  number: string;
-  complement: string | null;
-  neighborhood: string;
-  city: string;
-  state: string;
-  zip_code: string;
-  is_default: boolean | null;
-}
-
-interface FormaPagamento {
-  codigo: string;
-  descricao: string;
-}
-
-function getPeriod(dateStr: string): 'manha' | 'tarde' {
-  const h = new Date(dateStr).getHours();
-  return h < 12 ? 'manha' : 'tarde';
-}
-
-function buildPrintData(order: SalesOrderRow, company: CompanyFilter, logoUrls?: Record<string, string | null>): PrintOrderData {
-  const isOben = company === 'oben';
-  const companyMap: Record<CompanyFilter, { name: string; cnpj: string; phone: string; address: string }> = {
-    oben: {
-      name: 'OBEN COMÉRCIO LTDA',
-      cnpj: '51.027.034/0001-00',
-      phone: '(37) 9987-8190',
-      address: 'Av. Primeiro de Junho, 70 – Centro, Divinópolis/MG – CEP: 35.500-002',
-    },
-    colacor: {
-      name: 'COLACOR COMERCIAL LTDA',
-      cnpj: '15.422.799/0001-81',
-      phone: '(37) 3222-1035',
-      address: 'Av. Primeiro de Junho, 48 – Centro, Divinópolis/MG – CEP: 35.500-002',
-    },
-    afiacao: {
-      name: 'COLACOR S.C LTDA',
-      cnpj: '55.555.305/0001-51',
-      phone: '(37) 9987-8190',
-      address: 'Av. Primeiro de Junho, 50 – Centro, Divinópolis/MG – CEP: 35.500-002',
-    },
-  };
-
-  const c = companyMap[company];
-
-  // Extract parcelaCode from omie_payload
-  const payload = order.omie_payload;
-  const parcelaCode = payload?.cabecalho?.codigo_parcela || undefined;
-
-  return {
-    companyName: c.name,
-    companyCnpj: c.cnpj,
-    companyPhone: c.phone,
-    companyAddress: c.address,
-    companyLogoUrl: logoUrls?.[company] || undefined,
-    orderNumber: order.omie_numero_pedido?.replace(/^0+/, '') || order.id.slice(0, 8).toUpperCase(),
-    date: format(new Date(order.created_at), "dd/MM/yyyy HH:mm", { locale: ptBR }),
-    customerName: order.customer_name || 'Cliente',
-    customerDocument: order.customer_document || '',
-    customerPhone: order.customer_phone,
-    customerAddress: order.customer_address,
-    vendedorName: order.vendedor_name,
-    condPagamento: order.cond_pagamento,
-    parcelaCode,
-    items: (order.items || []).map((it) => ({
-      codigo: it.codigo || it.omie_codigo || '-',
-      descricao: it.descricao || it.nome || '',
-      quantidade: it.quantidade || 1,
-      unidade: it.unidade || 'UN',
-      valorUnitario: it.valor_unitario || 0,
-      valorTotal: it.valor_total || 0,
-      tintCorId: it.tint_cor_id,
-      tintNomeCor: it.tint_nome_cor,
-    })),
-    subtotal: order.subtotal || 0,
-    desconto: order.desconto || 0,
-    frete: order.frete || 0,
-    total: order.total || 0,
-    observacoes: order.notes || undefined,
-    isOben: isOben,
-  };
-}
+import { openPrintOrder } from '@/components/OrderPrintLayout';
+import {
+  COMPANY_LABELS, COMPANY_COLORS, getPeriod,
+  type CompanyFilter, type SalesOrderRow, type ProfileLite, type AddressLite,
+  type FormaPagamento, type EnrichedOrder,
+} from '@/components/sales/print/types';
+import { buildPrintData, buildSingleOrderHtml, buildPrintDocument } from '@/components/sales/print/buildPrintHtml';
+import { PrintFilters } from '@/components/sales/print/PrintFilters';
+import { OrderGroup } from '@/components/sales/print/OrderGroup';
 
 const SalesPrintDashboard = () => {
   const navigate = useNavigate();
@@ -358,7 +207,7 @@ const SalesPrintDashboard = () => {
       const result: Record<string, string> = {};
       for (const userId of customersMissingAddress) {
         let codigoCliente = omieClienteMap.get(userId);
-        
+
         // If no codigo_cliente, try searching by document (CNPJ/CPF)
         if (!codigoCliente) {
           const profile = profileMap.get(userId);
@@ -494,39 +343,7 @@ const SalesPrintDashboard = () => {
       return buildSingleOrderHtml(printData);
     });
 
-    const html = `<!DOCTYPE html>
-<html><head><meta charset="utf-8"><title>Impressão de Pedidos - ${format(selectedDate, 'dd/MM/yyyy')}</title>
-<style>
-  @media print {
-    @page { margin: 0; size: A4; }
-    body { -webkit-print-color-adjust: exact; print-color-adjust: exact; padding: 1.5cm; }
-    .page-break { page-break-after: always; }
-  }
-  body { font-family: Helvetica, Arial, sans-serif; color: #1a1a1a; margin: 0; padding: 20px; }
-  .header { display: flex; justify-content: space-between; align-items: flex-start; margin-bottom: 16px; border-bottom: 1px solid #ccc; padding-bottom: 12px; }
-  .header-left { display: flex; align-items: center; gap: 12px; }
-  .company-logo { max-height: 50px; max-width: 120px; object-fit: contain; }
-  .company-name { font-size: 22px; font-weight: bold; }
-  .company-info { font-size: 10px; color: #666; margin-top: 2px; }
-  .order-box { background: #e91e63; color: white; border-radius: 4px; padding: 8px 20px; text-align: center; }
-  .order-box .label { font-size: 9px; }
-  .order-box .number { font-size: 18px; font-weight: bold; }
-  .order-box .date { font-size: 9px; }
-  .section-title { font-size: 11px; font-weight: bold; color: #e91e63; margin: 14px 0 6px; }
-  .customer-name { font-size: 14px; font-weight: bold; }
-  .customer-info { font-size: 11px; color: #333; margin-top: 2px; }
-  .right-info { font-size: 11px; color: #666; text-align: right; }
-  table { width: 100%; border-collapse: collapse; }
-  th { background: #2d2d2d; color: white; padding: 6px 4px; font-size: 10px; text-align: left; }
-  .totals { display: flex; flex-direction: column; align-items: flex-end; margin-top: 12px; }
-  .totals .row { display: flex; gap: 30px; font-size: 12px; padding: 3px 0; }
-  .totals .total-row { border-top: 2px solid #2d2d2d; font-size: 15px; font-weight: bold; padding-top: 6px; margin-top: 4px; }
-  .obs-box { background: #fafafa; border: 1px solid #ccc; border-radius: 2px; padding: 10px; font-size: 10px; white-space: pre-wrap; line-height: 1.5; }
-  .footer { text-align: center; font-size: 8px; color: #999; margin-top: 30px; }
-</style></head><body>
-${allPages.join('\n<div class="page-break"></div>\n')}
-<script>window.onload = function() { window.print(); }</script>
-</body></html>`;
+    const html = buildPrintDocument(allPages, format(selectedDate, 'dd/MM/yyyy'));
 
     const printWindow = window.open('', '_blank');
     if (printWindow) {
@@ -535,62 +352,11 @@ ${allPages.join('\n<div class="page-break"></div>\n')}
     }
   };
 
-  const printSingle = (order: typeof filteredOrders[0]) => {
+  const printSingle = (order: EnrichedOrder) => {
     openPrintOrder(buildPrintData(order, order._company, companyLogos));
   };
 
   const isLoading = loadingSales || loadingAfiacao;
-
-  const renderOrderGroup = (company: CompanyFilter, period: 'manha' | 'tarde', orders: typeof filteredOrders) => {
-    if (orders.length === 0) return null;
-    const periodLabel = period === 'manha' ? 'Manhã' : 'Tarde';
-    const PeriodIcon = period === 'manha' ? Sun : Sunset;
-
-    return (
-      <div key={`${company}-${period}`} className="space-y-2">
-        <div className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
-          <PeriodIcon className="h-4 w-4" />
-          <span>{periodLabel}</span>
-          <Badge variant="secondary" className="text-xs">{orders.length}</Badge>
-        </div>
-        <div className="space-y-1.5">
-          {orders.map(order => (
-            <div
-              key={order.id}
-              className="flex items-center gap-3 p-3 rounded-lg border bg-card hover:bg-accent/50 transition-colors cursor-pointer"
-              onClick={() => toggleOrder(order.id)}
-            >
-              <Checkbox
-                checked={selectedOrders.has(order.id)}
-                onCheckedChange={() => toggleOrder(order.id)}
-                onClick={e => e.stopPropagation()}
-              />
-              <div className="flex-1 min-w-0">
-                <div className="flex items-center gap-2">
-                  <span className="font-mono text-sm font-medium">
-                    {order.omie_numero_pedido ? `#${order.omie_numero_pedido.replace(/^0+/, '')}` : order.id.slice(0, 8).toUpperCase()}
-                  </span>
-                  <span className="text-xs text-muted-foreground">
-                    {format(new Date(order.created_at), 'HH:mm')}
-                  </span>
-                </div>
-                <div className="text-sm text-muted-foreground truncate">{order.customer_name}</div>
-              </div>
-              <div className="text-right">
-                <div className="text-sm font-medium">
-                  {order.total.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' })}
-                </div>
-                <div className="text-xs text-muted-foreground">{(order.items || []).length} itens</div>
-              </div>
-              <Button size="sm" variant="ghost" className="h-8 w-8 p-0" onClick={e => { e.stopPropagation(); printSingle(order); }}>
-                <Printer className="h-4 w-4" />
-              </Button>
-            </div>
-          ))}
-        </div>
-      </div>
-    );
-  };
 
   return (
     <div className="max-w-4xl mx-auto space-y-6 pb-6">
@@ -607,58 +373,14 @@ ${allPages.join('\n<div class="page-break"></div>\n')}
         </div>
 
         {/* Filters */}
-        <Card>
-          <CardContent className="pt-4 space-y-4">
-            {/* Date picker */}
-            <div className="flex items-center gap-3 flex-wrap">
-              <Popover>
-                <PopoverTrigger asChild>
-                  <Button variant="outline" className={cn("w-[200px] justify-start text-left font-normal")}>
-                    <CalendarIcon className="mr-2 h-4 w-4" />
-                    {format(selectedDate, "dd 'de' MMMM, yyyy", { locale: ptBR })}
-                  </Button>
-                </PopoverTrigger>
-                <PopoverContent className="w-auto p-0" align="start">
-                  <Calendar
-                    mode="single"
-                    selected={selectedDate}
-                    onSelect={d => d && setSelectedDate(d)}
-                    initialFocus
-                    className="p-3 pointer-events-auto"
-                    locale={ptBR}
-                  />
-                </PopoverContent>
-              </Popover>
-
-              {/* Period filter */}
-              <Tabs value={selectedPeriod} onValueChange={v => setSelectedPeriod(v as 'all' | 'manha' | 'tarde')}>
-                <TabsList>
-                  <TabsTrigger value="all">Todos</TabsTrigger>
-                  <TabsTrigger value="manha" className="gap-1"><Sun className="h-3 w-3" />Manhã</TabsTrigger>
-                  <TabsTrigger value="tarde" className="gap-1"><Sunset className="h-3 w-3" />Tarde</TabsTrigger>
-                </TabsList>
-              </Tabs>
-            </div>
-
-            {/* Company toggles */}
-            <div className="flex items-center gap-2 flex-wrap">
-              <Building2 className="h-4 w-4 text-muted-foreground" />
-              {(['oben', 'colacor', 'afiacao'] as CompanyFilter[]).map(c => (
-                <Badge
-                  key={c}
-                  variant="outline"
-                  className={cn(
-                    'cursor-pointer transition-all',
-                    selectedCompanies.includes(c) ? COMPANY_COLORS[c] : 'opacity-40'
-                  )}
-                  onClick={() => toggleCompany(c)}
-                >
-                  {COMPANY_LABELS[c]}
-                </Badge>
-              ))}
-            </div>
-          </CardContent>
-        </Card>
+        <PrintFilters
+          selectedDate={selectedDate}
+          setSelectedDate={setSelectedDate}
+          selectedPeriod={selectedPeriod}
+          setSelectedPeriod={setSelectedPeriod}
+          selectedCompanies={selectedCompanies}
+          toggleCompany={toggleCompany}
+        />
 
         {/* Actions bar */}
         <div className="flex items-center justify-between">
@@ -698,8 +420,8 @@ ${allPages.join('\n<div class="page-break"></div>\n')}
                   </CardTitle>
                 </CardHeader>
                 <CardContent className="space-y-4">
-                  {renderOrderGroup(company, 'manha', grouped[company].manha)}
-                  {renderOrderGroup(company, 'tarde', grouped[company].tarde)}
+                  <OrderGroup company={company} period="manha" orders={grouped[company].manha} selectedOrders={selectedOrders} onToggleOrder={toggleOrder} onPrintSingle={printSingle} />
+                  <OrderGroup company={company} period="tarde" orders={grouped[company].tarde} selectedOrders={selectedOrders} onToggleOrder={toggleOrder} onPrintSingle={printSingle} />
                 </CardContent>
               </Card>
             );
@@ -709,119 +431,5 @@ ${allPages.join('\n<div class="page-break"></div>\n')}
     </div>
   );
 };
-
-function escapeHtml(s: string | undefined | null): string {
-  if (!s) return '';
-  return s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;');
-}
-
-// Build HTML for a single order page (without <html>/<body> wrappers)
-function buildSingleOrderHtml(data: PrintOrderData): string {
-  const fmt = (v: number) => v.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
-
-  // Build installment dates
-  const parseParcelaDays = (codeOrDesc?: string): number[] => {
-    if (!codeOrDesc) return [];
-    const clean = codeOrDesc.trim();
-    if (clean === '000' || clean === '999' || /vista/i.test(clean)) return [];
-    // Extract all numeric groups — handles codes like "S37", "A28", "028/042", "28/42 DDL"
-    const matches = clean.match(/(\d{1,3})/g);
-    if (!matches) return [];
-    return matches.map(s => parseInt(s, 10)).filter(n => n > 0 && n <= 365);
-  };
-
-  let days = parseParcelaDays(data.condPagamento);
-  if (days.length === 0) days = parseParcelaDays(data.parcelaCode);
-  let installmentText = '';
-  if (days.length > 0) {
-    const today = new Date();
-    const parcValue = data.total && days.length > 0 ? data.total / days.length : 0;
-    installmentText = days.map((d, i) => {
-      const dueDate = addDays(today, d);
-      const dateStr = `${String(dueDate.getDate()).padStart(2, '0')}/${String(dueDate.getMonth() + 1).padStart(2, '0')}/${dueDate.getFullYear()}`;
-      const valStr = parcValue > 0 ? ` – ${fmt(parcValue)}` : '';
-      return `${i + 1}ª parcela: ${dateStr}${valStr}`;
-    }).join(' | ');
-  }
-
-  const itemsRows = data.items.map((item, i) => {
-    const descLines = [escapeHtml(item.descricao)];
-    if (item.tintCorId && item.tintNomeCor) {
-      const corParts = item.tintNomeCor.split(' - ');
-      const simplified = corParts.length > 2 ? corParts.slice(0, -1).join(' - ') : item.tintNomeCor;
-      const embMatch = item.descricao.match(/\b(QT|GL|LT|BD|BH|5L)\b/i);
-      const embalagem = embMatch ? embMatch[1].toUpperCase() : '';
-      descLines.push(`Cor: ${escapeHtml(item.tintCorId)} - ${escapeHtml(simplified)}${embalagem ? ' - ' + escapeHtml(embalagem) : ''}`);
-    }
-    return `<tr style="background:${i % 2 === 1 ? '#f5f5f5' : '#fff'}">
-      <td style="padding:6px 4px;border:1px solid #ddd;text-align:center;font-size:11px">${i + 1}</td>
-      <td style="padding:6px 4px;border:1px solid #ddd;font-size:11px">${escapeHtml(item.codigo)}</td>
-      <td style="padding:6px 4px;border:1px solid #ddd;font-size:11px">${descLines.join('<br/>')}</td>
-      <td style="padding:6px 4px;border:1px solid #ddd;text-align:center;font-size:11px">${item.quantidade}</td>
-      <td style="padding:6px 4px;border:1px solid #ddd;text-align:center;font-size:11px">${escapeHtml(item.unidade)}</td>
-      <td style="padding:6px 4px;border:1px solid #ddd;text-align:right;font-size:11px">${fmt(item.valorUnitario)}</td>
-      <td style="padding:6px 4px;border:1px solid #ddd;text-align:right;font-size:11px">${fmt(item.valorTotal)}</td>
-    </tr>`;
-  }).join('');
-
-  const cnpjsComDesconto = ['03.422.099/0001-08', '07.311.465/0001-02', '24.521.946/0001-61'];
-  const showDesconto = data.desconto > 0 && cnpjsComDesconto.includes(data.customerDocument || '');
-
-  const obs = data.isOben
-    ? 'RECIBO DE ENTREGA DE VENDA NÃO PRESENCIAL E-PTA-RE Nº: 45.000035717-51 / OBEN COMÉRCIO LTDA. TRANSPORTADORA: Transporte próprio: Oben Comercio Declaro que recebi as mercadorias constantes dessa Nota Fiscal, e que as mercadorias se destinam a uso e consumo, e que estão em perfeito estado e conferem com pedido feito no âmbito do comércio de telemarketing ou eletrônico e que foram recebidas no local por mim no local indicado acima.\n\nCPF/CNPJ:___________________________________ DATA DA ENTREGA:___/___/____\n\nNome/ASSINATURA:_________________________________________________' + (data.observacoes ? '\n\n' + escapeHtml(data.observacoes) : '')
-    : escapeHtml(data.observacoes) || '';
-
-  return `<div>
-<div class="header">
-  <div class="header-left">
-    ${data.companyLogoUrl ? `<img src="${escapeHtml(data.companyLogoUrl)}" class="company-logo" crossorigin="anonymous" />` : ''}
-    <div>
-      <div class="company-name">${escapeHtml(data.companyName)}</div>
-      <div class="company-info">CNPJ: ${escapeHtml(data.companyCnpj)} • Tel: ${escapeHtml(data.companyPhone)}</div>
-      <div class="company-info">${escapeHtml(data.companyAddress)}</div>
-    </div>
-  </div>
-  <div class="order-box">
-    <div class="label">PEDIDO DE VENDA</div>
-    <div class="number">Nº ${escapeHtml(data.orderNumber)}</div>
-    <div class="date">${data.date}</div>
-  </div>
-</div>
-<div class="section-title">DADOS DO CLIENTE</div>
-<div style="display:flex;justify-content:space-between">
-  <div>
-    <div class="customer-name">${escapeHtml(data.customerName)}</div>
-    <div class="customer-info">CPF/CNPJ: ${escapeHtml(data.customerDocument) || 'N/A'}${data.customerPhone ? ' • Tel: ' + escapeHtml(data.customerPhone) : ''}</div>
-    ${data.customerAddress ? `<div class="customer-info" style="margin-top:4px"><strong>Endereço:</strong> ${escapeHtml(data.customerAddress)}</div>` : ''}
-  </div>
-  <div class="right-info">
-    ${data.vendedorName ? `Vendedor: ${escapeHtml(data.vendedorName)}` : ''}
-  </div>
-</div>
-<div class="section-title">ITENS DO PEDIDO</div>
-<table><thead><tr>
-  <th style="width:30px;text-align:center">#</th>
-  <th style="width:70px">Código</th>
-  <th>Descrição</th>
-  <th style="width:40px;text-align:center">Qtd</th>
-  <th style="width:35px;text-align:center">Un</th>
-  <th style="width:80px;text-align:right">Vlr Unit.</th>
-  <th style="width:80px;text-align:right">Vlr Total</th>
-</tr></thead><tbody>${itemsRows}</tbody></table>
-<div class="totals">
-  <div class="row"><span>Subtotal:</span><span>${fmt(data.subtotal)}</span></div>
-  ${showDesconto ? `<div class="row"><span>Desconto:</span><span>- ${fmt(data.desconto)}</span></div>` : ''}
-  
-  <div class="row total-row"><span>TOTAL:</span><span>${fmt(data.total)}</span></div>
-</div>
-${data.condPagamento || installmentText ? `
-<div class="section-title">CONDIÇÃO DE PAGAMENTO</div>
-<div style="font-size:11px;margin-bottom:4px">${data.condPagamento ? `<strong>Prazo:</strong> ${escapeHtml(data.condPagamento)}` : ''}</div>
-${installmentText ? `<div style="font-size:10px;color:#333;background:#f8f8f8;padding:6px 10px;border-radius:2px;border-left:3px solid #e91e63"><strong>Vencimentos:</strong><br/>${installmentText}</div>` : ''}
-` : ''}
-${obs ? `<div class="section-title">OBSERVAÇÕES</div><div class="obs-box">${obs.replace(/\n/g, '<br/>')}</div>` : ''}
-<div class="footer">Documento gerado automaticamente pelo sistema • ${data.date}</div>
-</div>`;
-}
 
 export default SalesPrintDashboard;


### PR DESCRIPTION
## Resumo

Quebra do god-component `src/pages/SalesPrintDashboard.tsx` (Impressão de Pedidos) — **827 → 435 linhas**. Refactor **comportamento-preservante 1:1**, novos módulos em `src/components/sales/print/`.

- **`types.ts`** — tipos (CompanyFilter, OrderItem, OmiePayload, SalesOrderRow, ProfileLite, AddressLite, FormaPagamento, `EnrichedOrder`) + `COMPANY_LABELS`/`COMPANY_COLORS` + `getPeriod`.
- **`buildPrintHtml.ts`** — funções **puras**: `buildPrintData`, `escapeHtml`, `buildSingleOrderHtml` + nova `buildPrintDocument(pages, dateLabel)` (template do documento + CSS, extraído do `printSelected`).
- **`OrderGroup.tsx`** — o antigo `renderOrderGroup` como componente controlado.
- **`PrintFilters.tsx`** — Card de filtros (data/período/empresas) controlado.

### Decisão de arquitetura

As 8 `useQuery`, todas as `useMemo` (enrich/endereços/agrupamento) e os handlers (`toggleCompany`, `toggleOrder`, `selectAll`, `printSelected`, `printSingle`) permanecem **no pai**. A lógica de geração de HTML virou funções puras (testáveis isoladamente). `printSelected` agora chama `buildPrintDocument(...)` e mantém `window.open`/`document.write`.

## Garantias

- ✅ `bunx tsc --noEmit` — 0 erros.
- ✅ `bun lint` — 0 problemas nos arquivos tocados.
- ✅ Suíte: **543/543** passando.
- ✅ `bun run build` exit 0.
- ✅ +16 testes novos (4 arquivos): helpers de HTML (parcelas `28/42`, à vista `000`, escape, recibo OBEN, wrapper do documento), `getPeriod`, render + cliques de `OrderGroup`/`PrintFilters`.
- ✅ Revisão independente (subagente): veredito **FIEL 1:1** — HTML/CSS de impressão byte-a-byte idêntico (CNPJs, regex de parcela/embalagem, recibo OBEN, bloco `<style>`), `buildPrintDocument` reproduz o template inline exatamente.

## Test plan

- [x] tsc 0 erros / lint 0 problemas
- [x] 16 testes novos + suíte completa 543/543
- [x] build de produção exit 0
- [x] revisão independente confirma 1:1
- [ ] CI `validate` verde

🤖 Generated with [Claude Code](https://claude.com/claude-code)