### PR TITLE
fix(qa): KPI Fornecedores violando SLA (colunas erradas) + último any do repo

### DIFF
--- a/src/pages/AdminReposicaoParametros.tsx
+++ b/src/pages/AdminReposicaoParametros.tsx
@@ -72,13 +72,13 @@ function KpiCards() {
   const { data: fornViolando } = useQuery({
     queryKey: ["parametros-sla-violando", empresa],
     queryFn: async () => {
-      const { data, error } = await (supabase as any)
+      const { data, error } = await supabase
         .from("v_fornecedor_sla_compliance")
-        .select("violando,critico")
+        .select("skus_violando,skus_criticos")
         .eq("empresa", empresa);
       if (error) throw error;
-      const rows = (data ?? []) as { violando: number; critico: number }[];
-      return rows.filter((r) => (r.violando ?? 0) > 0 || (r.critico ?? 0) > 0).length;
+      const rows = (data ?? []) as { skus_violando: number | null; skus_criticos: number | null }[];
+      return rows.filter((r) => (r.skus_violando ?? 0) > 0 || (r.skus_criticos ?? 0) > 0).length;
     },
     refetchInterval: 60000,
     staleTime: 30000,


### PR DESCRIPTION
## Summary
A query do KPI "Fornecedores violando SLA" (`AdminReposicaoParametros`) usava `(supabase as any).select("violando,critico")`, mas a view `v_fornecedor_sla_compliance` **não tem** essas colunas. Confirmado via `information_schema` no banco de produção: as colunas reais são **`skus_violando`** / **`skus_criticos`**. O `as any` mascarava o **400 Bad Request** → o KPI sempre caía no `catch` (mostrava 0/erro).

Fix: usa as colunas reais + dropa o `as any`. **Era o último `no-explicit-any` do `src/` → repo agora 0 any.**

## Como foi confirmado
Dropar o `as any` fez o tsc revelar `SelectQueryError<"column 'violando' does not exist">`. Codex inicialmente sugeriu que as migrations tinham `violando` — mas o founder rodou `information_schema.columns` no banco e confirmou: só existem `skus_violando`/`skus_criticos`. types.ts estava certo; o código consumidor estava com nome de coluna errado.

## ⚠️ Bug irmão flaggado (follow-up dedicado)
`AdminReposicaoSlaFornecedor` tem o MESMO problema em escala maior: o type `ForCompliance` declara `skus_avaliados/cumprindo/limite/violando/critico/...` mas a view tem `skus_total/skus_cumprindo/skus_limite/skus_violando/skus_criticos/...`. Lê tudo como `undefined` via `as unknown as` cast. Precisa rename de ~9 campos + QA visual → chip de follow-up.

## Validação
- `bunx tsc --noEmit -p tsconfig.app.json` ✅ 0
- `bunx eslint` ✅ 0
- **Codex review**: *"consistent with the typed Supabase view columns"*

## Test plan
- [ ] Página Parâmetros: card "Fornecedores violando SLA" mostra contagem real (não 0 fixo)
- [ ] Console sem 400 em v_fornecedor_sla_compliance

🤖 Generated with [Claude Code](https://claude.com/claude-code)