### PR TITLE
refactor(reposicao): split god-component AdminReposicaoAlertas (845→369)

### DIFF
--- a/src/components/reposicao/alertas/AlertaDrillSheet.tsx
+++ b/src/components/reposicao/alertas/AlertaDrillSheet.tsx
@@ -1,0 +1,237 @@
+// Sheet de drill-down (contexto, dados do SKU, histórico, impacto, decisão) dos Alertas de Outlier.
+// Extraído de src/pages/AdminReposicaoAlertas.tsx (god-component split). Componente controlado.
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
+import { Badge } from "@/components/ui/badge";
+import { CheckCircle2, XCircle, EyeOff, Loader2 } from "lucide-react";
+import {
+  ResponsiveContainer, BarChart, Bar, ScatterChart, Scatter,
+  XAxis, YAxis, CartesianGrid, Tooltip as ReTooltip, ReferenceLine, Cell,
+} from "recharts";
+import { sevBadge, statusBadge } from "./badges";
+import { tipoLabel, fmt, type EventoOutlier, type SkuInfo, type ImpactoData, type GrupoRow } from "./types";
+
+export function AlertaDrillSheet({
+  drillEvento, onClose, isSemGrupo, skuInfo, historico, impacto, gruposFornecedor,
+  grupoEscolhido, setGrupoEscolhido, atribuirGrupoPending, onAtribuirGrupo,
+  justificativa, setJustificativa, onAcao,
+}: {
+  drillEvento: EventoOutlier | null;
+  onClose: () => void;
+  isSemGrupo: boolean;
+  skuInfo?: SkuInfo | null;
+  historico: unknown;
+  impacto?: ImpactoData;
+  gruposFornecedor?: GrupoRow[];
+  grupoEscolhido: string;
+  setGrupoEscolhido: (s: string) => void;
+  atribuirGrupoPending: boolean;
+  onAtribuirGrupo: () => void;
+  justificativa: string;
+  setJustificativa: (s: string) => void;
+  onAcao: (tipo: "aceitar" | "excluir" | "ignorar") => void;
+}) {
+  return (
+    <Sheet open={!!drillEvento} onOpenChange={(o) => !o && onClose()}>
+      <SheetContent className="w-full sm:max-w-2xl overflow-y-auto">
+        {drillEvento && (
+          <>
+            <SheetHeader>
+              <SheetTitle className="flex items-center gap-2">
+                {sevBadge(drillEvento.severidade)}
+                <span>{tipoLabel(drillEvento.tipo)} — SKU {drillEvento.sku_codigo_omie}</span>
+              </SheetTitle>
+            </SheetHeader>
+
+            <div className="space-y-5 mt-4">
+              {/* Seção 1 */}
+              <Card>
+                <CardHeader className="pb-2"><CardTitle className="text-sm">1. Contexto</CardTitle></CardHeader>
+                <CardContent className="space-y-1 text-sm">
+                  <div><span className="text-muted-foreground">Data:</span> {new Date(drillEvento.data_evento).toLocaleDateString("pt-BR")}</div>
+                  <div><span className="text-muted-foreground">Detectado:</span> {drillEvento.detectado_em ? new Date(drillEvento.detectado_em).toLocaleString("pt-BR") : "—"}</div>
+                  <div className="pt-2 p-2 bg-muted/50 rounded text-xs">{drillEvento.detalhes?.mensagem ?? "Sem mensagem"}</div>
+                </CardContent>
+              </Card>
+
+              {/* Seção 2 */}
+              <Card>
+                <CardHeader className="pb-2"><CardTitle className="text-sm">2. Dados do SKU</CardTitle></CardHeader>
+                <CardContent className="space-y-1 text-sm">
+                  <div><span className="text-muted-foreground">Descrição:</span> {drillEvento.sku_descricao ?? "—"}</div>
+                  <div><span className="text-muted-foreground">Classe:</span> {skuInfo?.classe_consolidada ?? "—"}</div>
+                  <div><span className="text-muted-foreground">D (média/dia):</span> {fmt(skuInfo?.demanda_media_diaria, 2)}</div>
+                  <div><span className="text-muted-foreground">σ atual:</span> {fmt(skuInfo?.demanda_sigma_diario, 2)}</div>
+                  <div><span className="text-muted-foreground">LT médio:</span> {fmt(skuInfo?.lt_medio_dias_uteis, 1)} dias</div>
+                  <div><span className="text-muted-foreground">Preço compra:</span> R$ {fmt(skuInfo?.preco_compra_real, 2)}</div>
+                </CardContent>
+              </Card>
+
+              {/* Seção 3 - Gráfico (não aplicável a sku_sem_grupo) */}
+              {!isSemGrupo && (
+                <Card>
+                  <CardHeader className="pb-2"><CardTitle className="text-sm">3. Histórico</CardTitle></CardHeader>
+                  <CardContent>
+                    <div className="h-[220px]">
+                      <ResponsiveContainer width="100%" height="100%">
+                        {drillEvento.tipo === "venda_atipica" ? (
+                          <BarChart data={(historico as Array<{ dia: string; qtde: number; isOutlier: boolean }> | null) ?? []}>
+                            <CartesianGrid strokeDasharray="3 3" />
+                            <XAxis dataKey="dia" tick={{ fontSize: 10 }} />
+                            <YAxis tick={{ fontSize: 10 }} />
+                            <ReTooltip />
+                            <Bar dataKey="qtde">
+                              {((historico as Array<{ isOutlier: boolean }> | null) ?? []).map((d, i) => (
+                                <Cell key={i} fill={d.isOutlier ? "hsl(var(--destructive))" : "hsl(var(--primary))"} />
+                              ))}
+                            </Bar>
+                          </BarChart>
+                        ) : (
+                          <ScatterChart>
+                            <CartesianGrid strokeDasharray="3 3" />
+                            <XAxis dataKey="idx" tick={{ fontSize: 10 }} name="#" />
+                            <YAxis dataKey="lt" tick={{ fontSize: 10 }} name="LT (dias)" />
+                            <ReTooltip />
+                            {impacto?.media_atual != null && (
+                              <ReferenceLine y={impacto.media_atual} stroke="hsl(var(--muted-foreground))" strokeDasharray="3 3" />
+                            )}
+                            <Scatter data={(historico as Array<{ idx: number; lt: number; isOutlier: boolean }> | null) ?? []}>
+                              {((historico as Array<{ isOutlier: boolean }> | null) ?? []).map((d, i) => (
+                                <Cell key={i} fill={d.isOutlier ? "hsl(var(--destructive))" : "hsl(var(--primary))"} />
+                              ))}
+                            </Scatter>
+                          </ScatterChart>
+                        )}
+                      </ResponsiveContainer>
+                    </div>
+                  </CardContent>
+                </Card>
+              )}
+
+              {/* Seção 4 - Impacto (não aplicável a sku_sem_grupo) */}
+              {!isSemGrupo && (
+                <Card>
+                  <CardHeader className="pb-2"><CardTitle className="text-sm">4. Impacto se excluir</CardTitle></CardHeader>
+                  <CardContent className="text-sm space-y-1">
+                    {impacto && !impacto.error ? (
+                      <>
+                        <div>σ atual: <span className="font-mono">{fmt(impacto.sigma_atual)}</span> → sem outlier: <span className="font-mono">{fmt(impacto.sigma_sem)}</span></div>
+                        <div>Média atual: <span className="font-mono">{fmt(impacto.media_atual)}</span> → sem: <span className="font-mono">{fmt(impacto.media_sem)}</span></div>
+                        {impacto.em_atual !== undefined && (
+                          <div className="pt-2 p-2 bg-muted/50 rounded">
+                            Estoque mínimo sugerido: <span className="font-mono">{impacto.em_atual}</span> → <span className="font-mono">{impacto.em_sem}</span>{" "}
+                            <Badge variant={impacto.delta_em < 0 ? "success" : "warning"}>
+                              {impacto.delta_em > 0 ? "+" : ""}{impacto.delta_em} un
+                            </Badge>
+                          </div>
+                        )}
+                      </>
+                    ) : (
+                      <div className="text-muted-foreground">Calculando…</div>
+                    )}
+                  </CardContent>
+                </Card>
+              )}
+
+              {/* Seção 3 alternativa: atribuir grupo (sku_sem_grupo) */}
+              {isSemGrupo && drillEvento.status === "pendente" && (
+                <Card>
+                  <CardHeader className="pb-2">
+                    <CardTitle className="text-sm">3. Atribuir grupo de produção</CardTitle>
+                  </CardHeader>
+                  <CardContent className="space-y-3">
+                    <div className="text-sm">
+                      <span className="text-muted-foreground">Fornecedor:</span>{" "}
+                      <span className="font-medium">{drillEvento.detalhes?.fornecedor ?? "—"}</span>
+                    </div>
+                    <div>
+                      <Label className="text-xs">Grupo de produção</Label>
+                      <Select value={grupoEscolhido} onValueChange={setGrupoEscolhido}>
+                        <SelectTrigger>
+                          <SelectValue placeholder="Selecione o grupo" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {(gruposFornecedor ?? []).map((g) => (
+                            // SelectItem espera string, mas a lógica original passava o number — preservar via cast
+                            <SelectItem key={g.id} value={g.id as unknown as string}>
+                              {g.codigo_grupo} — {g.descricao} (LT {g.lt_producao_dias}d)
+                            </SelectItem>
+                          ))}
+                          {(gruposFornecedor ?? []).length === 0 && (
+                            <div className="px-2 py-1.5 text-xs text-muted-foreground">
+                              Nenhum grupo cadastrado para este fornecedor
+                            </div>
+                          )}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                    <Button
+                      className="w-full"
+                      disabled={!grupoEscolhido || atribuirGrupoPending}
+                      onClick={onAtribuirGrupo}
+                    >
+                      {atribuirGrupoPending && <Loader2 className="h-4 w-4 mr-1 animate-spin" />}
+                      <CheckCircle2 className="h-4 w-4 mr-1" /> Atribuir e marcar como aceito
+                    </Button>
+                    <p className="text-xs text-muted-foreground">
+                      Ao atribuir, o SKU é classificado, o alerta é fechado e os parâmetros de reposição
+                      são recalculados com o novo LT de produção.
+                    </p>
+                  </CardContent>
+                </Card>
+              )}
+
+              {/* Seção 5 - Decisão padrão (oculta para sku_sem_grupo) */}
+              {!isSemGrupo && drillEvento.status === "pendente" && (
+                <Card>
+                  <CardHeader className="pb-2"><CardTitle className="text-sm">5. Decisão</CardTitle></CardHeader>
+                  <CardContent className="space-y-3">
+                    <div>
+                      <Label className="text-xs">Justificativa (opcional)</Label>
+                      <Textarea
+                        rows={2}
+                        value={justificativa}
+                        onChange={(e) => setJustificativa(e.target.value)}
+                        placeholder="Ex: pedido excepcional cliente X, não se repete"
+                      />
+                    </div>
+                    <div className="grid grid-cols-3 gap-2">
+                      <Button variant="default" className="bg-success hover:bg-success/90 text-success-foreground" onClick={() => onAcao("aceitar")}>
+                        <CheckCircle2 className="h-4 w-4 mr-1" /> Aceitar
+                      </Button>
+                      <Button variant="destructive" onClick={() => onAcao("excluir")}>
+                        <XCircle className="h-4 w-4 mr-1" /> Excluir
+                      </Button>
+                      <Button variant="secondary" onClick={() => onAcao("ignorar")}>
+                        <EyeOff className="h-4 w-4 mr-1" /> Ignorar
+                      </Button>
+                    </div>
+                    <p className="text-xs text-muted-foreground">
+                      <strong>Aceitar:</strong> evento real, mantém no cálculo. <strong>Excluir:</strong> one-off, remove da estatística. <strong>Ignorar:</strong> não mexe no dado.
+                    </p>
+                  </CardContent>
+                </Card>
+              )}
+
+              {drillEvento.status !== "pendente" && (
+                <Card>
+                  <CardContent className="pt-4 text-sm space-y-1">
+                    <div>Status: {statusBadge(drillEvento.status)}</div>
+                    <div className="text-muted-foreground">Por: {drillEvento.decidido_por ?? "—"} em {drillEvento.decidido_em ? new Date(drillEvento.decidido_em).toLocaleString("pt-BR") : "—"}</div>
+                    {drillEvento.justificativa_decisao && (
+                      <div className="p-2 bg-muted/50 rounded text-xs">{drillEvento.justificativa_decisao}</div>
+                    )}
+                  </CardContent>
+                </Card>
+              )}
+            </div>
+          </>
+        )}
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/src/components/reposicao/alertas/AlertasFiltros.tsx
+++ b/src/components/reposicao/alertas/AlertasFiltros.tsx
@@ -1,0 +1,103 @@
+// Card de filtros + barra de ações em lote dos Alertas de Outlier.
+// Extraído de src/pages/AdminReposicaoAlertas.tsx (god-component split).
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Search, CheckCircle2, XCircle } from "lucide-react";
+
+export function AlertasFiltros({
+  busca, setBusca, filtroTipo, setFiltroTipo, filtroSev, setFiltroSev, filtroStatus, setFiltroStatus,
+  setPage, selecionadosCount, onAceitarLote, onExcluirLote, onLimparSelecao,
+}: {
+  busca: string;
+  setBusca: (s: string) => void;
+  filtroTipo: string;
+  setFiltroTipo: (s: string) => void;
+  filtroSev: string;
+  setFiltroSev: (s: string) => void;
+  filtroStatus: string;
+  setFiltroStatus: (s: string) => void;
+  setPage: (p: number) => void;
+  selecionadosCount: number;
+  onAceitarLote: () => void;
+  onExcluirLote: () => void;
+  onLimparSelecao: () => void;
+}) {
+  return (
+    <Card>
+      <CardContent className="pt-4">
+        <div className="flex flex-wrap gap-3 items-end">
+          <div className="flex-1 min-w-[200px]">
+            <Label className="text-xs">Buscar SKU</Label>
+            <div className="relative">
+              <Search className="h-4 w-4 absolute left-2 top-2.5 text-muted-foreground" />
+              <Input
+                placeholder="Código ou descrição"
+                className="pl-8"
+                value={busca}
+                onChange={(e) => {
+                  setBusca(e.target.value);
+                  setPage(1);
+                }}
+              />
+            </div>
+          </div>
+          <div className="w-[160px]">
+            <Label className="text-xs">Tipo</Label>
+            <Select value={filtroTipo} onValueChange={(v) => { setFiltroTipo(v); setPage(1); }}>
+              <SelectTrigger><SelectValue /></SelectTrigger>
+              <SelectContent>
+                <SelectItem value="__all__">Todos</SelectItem>
+                <SelectItem value="venda_atipica">Venda atípica</SelectItem>
+                <SelectItem value="lt_atipico">LT atípico</SelectItem>
+                <SelectItem value="sku_sem_grupo">SKU sem grupo</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="w-[140px]">
+            <Label className="text-xs">Severidade</Label>
+            <Select value={filtroSev} onValueChange={(v) => { setFiltroSev(v); setPage(1); }}>
+              <SelectTrigger><SelectValue /></SelectTrigger>
+              <SelectContent>
+                <SelectItem value="__all__">Todas</SelectItem>
+                <SelectItem value="critico">Crítico</SelectItem>
+                <SelectItem value="atencao">Atenção</SelectItem>
+                <SelectItem value="info">Info</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="w-[140px]">
+            <Label className="text-xs">Status</Label>
+            <Select value={filtroStatus} onValueChange={(v) => { setFiltroStatus(v); setPage(1); }}>
+              <SelectTrigger><SelectValue /></SelectTrigger>
+              <SelectContent>
+                <SelectItem value="__all__">Todos</SelectItem>
+                <SelectItem value="pendente">Pendente</SelectItem>
+                <SelectItem value="aceito">Aceito</SelectItem>
+                <SelectItem value="excluido">Excluído</SelectItem>
+                <SelectItem value="ignorado">Ignorado</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+
+        {selecionadosCount > 0 && (
+          <div className="mt-4 flex gap-2 items-center bg-muted/50 p-3 rounded-md">
+            <span className="text-sm font-medium">{selecionadosCount} selecionado(s)</span>
+            <Button size="sm" variant="default" onClick={onAceitarLote}>
+              <CheckCircle2 className="h-4 w-4 mr-1" /> Aceitar selecionados
+            </Button>
+            <Button size="sm" variant="destructive" onClick={onExcluirLote}>
+              <XCircle className="h-4 w-4 mr-1" /> Excluir selecionados
+            </Button>
+            <Button size="sm" variant="ghost" onClick={onLimparSelecao}>
+              Limpar seleção
+            </Button>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/reposicao/alertas/AlertasTable.tsx
+++ b/src/components/reposicao/alertas/AlertasTable.tsx
@@ -1,0 +1,103 @@
+// Tabela de alertas + paginação dos Alertas de Outlier.
+// Extraída de src/pages/AdminReposicaoAlertas.tsx (god-component split).
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Loader2, ChevronLeft, ChevronRight } from "lucide-react";
+import { sevBadge, statusBadge } from "./badges";
+import { tipoLabel, fmt, type EventoOutlier } from "./types";
+
+export function AlertasTable({
+  lista, isLoading, selecionados, todosMarcados, selecionavelCount,
+  toggleAll, toggleOne, onDrill, page, totalPages, setPage,
+}: {
+  lista?: { rows: EventoOutlier[]; total: number };
+  isLoading: boolean;
+  selecionados: Set<number>;
+  todosMarcados: boolean;
+  selecionavelCount: number;
+  toggleAll: () => void;
+  toggleOne: (id: number) => void;
+  onDrill: (e: EventoOutlier) => void;
+  page: number;
+  totalPages: number;
+  setPage: (value: number | ((prev: number) => number)) => void;
+}) {
+  return (
+    <Card>
+      <CardContent className="pt-4 overflow-x-auto">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="w-10">
+                <Checkbox checked={todosMarcados} onCheckedChange={toggleAll} disabled={selecionavelCount === 0} />
+              </TableHead>
+              <TableHead>Severidade</TableHead>
+              <TableHead>Data evento</TableHead>
+              <TableHead>SKU</TableHead>
+              <TableHead>Descrição</TableHead>
+              <TableHead>Tipo</TableHead>
+              <TableHead className="text-right">Observado</TableHead>
+              <TableHead className="text-right">Esperado</TableHead>
+              <TableHead className="text-right">σ</TableHead>
+              <TableHead>Mensagem</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead></TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {isLoading && (
+              <TableRow><TableCell colSpan={12} className="text-center py-8"><Loader2 className="h-5 w-5 animate-spin mx-auto" /></TableCell></TableRow>
+            )}
+            {!isLoading && (lista?.rows.length ?? 0) === 0 && (
+              <TableRow><TableCell colSpan={12} className="text-center py-8 text-muted-foreground">Nenhum alerta encontrado</TableCell></TableRow>
+            )}
+            {lista?.rows.map((r) => {
+              const podeSelecionar =
+                r.status === "pendente" && r.severidade !== "critico" && r.tipo !== "sku_sem_grupo";
+              return (
+                <TableRow key={r.id} className="hover:bg-muted/50">
+                  <TableCell>
+                    <Checkbox
+                      checked={selecionados.has(r.id)}
+                      onCheckedChange={() => toggleOne(r.id)}
+                      disabled={!podeSelecionar}
+                    />
+                  </TableCell>
+                  <TableCell>{sevBadge(r.severidade)}</TableCell>
+                  <TableCell className="text-sm">{new Date(r.data_evento).toLocaleDateString("pt-BR")}</TableCell>
+                  <TableCell className="font-mono text-xs whitespace-nowrap">{r.sku_codigo_omie}</TableCell>
+                  <TableCell className="text-sm min-w-[260px] max-w-[360px] whitespace-normal break-words" title={r.sku_descricao ?? undefined}>{r.sku_descricao ?? "—"}</TableCell>
+                  <TableCell><Badge variant="outline">{tipoLabel(r.tipo)}</Badge></TableCell>
+                  <TableCell className="text-right font-mono text-sm">{fmt(r.valor_observado, 0)}</TableCell>
+                  <TableCell className="text-right font-mono text-sm">{fmt(r.valor_esperado, 1)}</TableCell>
+                  <TableCell className="text-right font-mono text-sm">{fmt(r.desvios_padrao, 1)}</TableCell>
+                  <TableCell className="text-xs min-w-[280px] max-w-[420px] whitespace-normal break-words text-muted-foreground" title={r.detalhes?.mensagem ?? undefined}>{r.detalhes?.mensagem ?? "—"}</TableCell>
+                  <TableCell>{statusBadge(r.status)}</TableCell>
+                  <TableCell>
+                    <Button size="sm" variant="ghost" onClick={() => onDrill(r)}>Detalhes</Button>
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+
+        <div className="flex items-center justify-between mt-4">
+          <div className="text-sm text-muted-foreground">{lista?.total ?? 0} alerta(s)</div>
+          <div className="flex items-center gap-2">
+            <Button size="sm" variant="outline" disabled={page === 1} onClick={() => setPage((p) => p - 1)}>
+              <ChevronLeft className="h-4 w-4" />
+            </Button>
+            <span className="text-sm">{page} / {totalPages}</span>
+            <Button size="sm" variant="outline" disabled={page >= totalPages} onClick={() => setPage((p) => p + 1)}>
+              <ChevronRight className="h-4 w-4" />
+            </Button>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/reposicao/alertas/ConfirmacaoDialog.tsx
+++ b/src/components/reposicao/alertas/ConfirmacaoDialog.tsx
@@ -1,0 +1,57 @@
+// Dialog de confirmação de ação (aceitar/excluir/ignorar) dos Alertas de Outlier.
+// Extraído de src/pages/AdminReposicaoAlertas.tsx (god-component split).
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter, DialogDescription } from "@/components/ui/dialog";
+import { Loader2 } from "lucide-react";
+import type { AcaoConfirm } from "./types";
+
+export function ConfirmacaoDialog({
+  acaoConfirm, onClose, selecionadosCount, justificativa, setJustificativa, onConfirm, isPending,
+}: {
+  acaoConfirm: AcaoConfirm | null;
+  onClose: () => void;
+  selecionadosCount: number;
+  justificativa: string;
+  setJustificativa: (s: string) => void;
+  onConfirm: () => void;
+  isPending: boolean;
+}) {
+  return (
+    <Dialog open={!!acaoConfirm} onOpenChange={(o) => !o && onClose()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>
+            Confirmar {acaoConfirm?.tipo === "aceitar" ? "aceitação" : acaoConfirm?.tipo === "excluir" ? "exclusão" : "ignorar"}
+          </DialogTitle>
+          <DialogDescription>
+            {acaoConfirm?.lote
+              ? `Aplicar a ${selecionadosCount} alerta(s). Críticos não estão incluídos.`
+              : `Aplicar ao alerta selecionado.`}
+            {acaoConfirm?.tipo === "excluir" && (
+              <div className="mt-2 text-warning">⚠ Esta ação remove os eventos do cálculo estatístico e dispara recálculo automático dos parâmetros.</div>
+            )}
+          </DialogDescription>
+        </DialogHeader>
+        {acaoConfirm?.lote && (
+          <div>
+            <Label className="text-xs">Justificativa em lote (opcional)</Label>
+            <Textarea rows={2} value={justificativa} onChange={(e) => setJustificativa(e.target.value)} />
+          </div>
+        )}
+        <DialogFooter>
+          <Button variant="ghost" onClick={onClose}>Cancelar</Button>
+          <Button
+            variant={acaoConfirm?.tipo === "excluir" ? "destructive" : "default"}
+            onClick={onConfirm}
+            disabled={isPending}
+          >
+            {isPending && <Loader2 className="h-4 w-4 mr-1 animate-spin" />}
+            Confirmar
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/reposicao/alertas/StatsCards.tsx
+++ b/src/components/reposicao/alertas/StatsCards.tsx
@@ -1,0 +1,47 @@
+// Grid de estatísticas (6 KPIs) dos Alertas de Outlier.
+// Extraído de src/pages/AdminReposicaoAlertas.tsx (god-component split).
+import { Card, CardContent } from "@/components/ui/card";
+import type { OutlierStats } from "./types";
+
+export function StatsCards({ stats }: { stats?: OutlierStats }) {
+  return (
+    <div className="grid grid-cols-2 md:grid-cols-6 gap-3">
+      <Card>
+        <CardContent className="pt-4">
+          <div className="text-xs text-muted-foreground">Total pendentes</div>
+          <div className="text-2xl font-bold">{stats?.pendentes ?? 0}</div>
+        </CardContent>
+      </Card>
+      <Card className="border-destructive/40">
+        <CardContent className="pt-4">
+          <div className="text-xs text-destructive">Críticos</div>
+          <div className="text-2xl font-bold text-destructive">{stats?.criticos ?? 0}</div>
+        </CardContent>
+      </Card>
+      <Card className="border-warning/40">
+        <CardContent className="pt-4">
+          <div className="text-xs text-warning">Atenção</div>
+          <div className="text-2xl font-bold text-warning">{stats?.atencao ?? 0}</div>
+        </CardContent>
+      </Card>
+      <Card>
+        <CardContent className="pt-4">
+          <div className="text-xs text-muted-foreground">Informativos</div>
+          <div className="text-2xl font-bold">{stats?.info ?? 0}</div>
+        </CardContent>
+      </Card>
+      <Card>
+        <CardContent className="pt-4">
+          <div className="text-xs text-success">Aceitos hoje</div>
+          <div className="text-2xl font-bold">{stats?.aceitosHoje ?? 0}</div>
+        </CardContent>
+      </Card>
+      <Card>
+        <CardContent className="pt-4">
+          <div className="text-xs text-destructive">Excluídos hoje</div>
+          <div className="text-2xl font-bold">{stats?.excluidosHoje ?? 0}</div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/reposicao/alertas/__tests__/AlertaDrillSheet.test.tsx
+++ b/src/components/reposicao/alertas/__tests__/AlertaDrillSheet.test.tsx
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeAll } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { AlertaDrillSheet } from "../AlertaDrillSheet";
+import type { EventoOutlier } from "../types";
+
+// recharts (ResponsiveContainer) usa ResizeObserver, ausente no jsdom.
+beforeAll(() => {
+  vi.stubGlobal("ResizeObserver", class {
+    observe() { /* */ }
+    unobserve() { /* */ }
+    disconnect() { /* */ }
+  });
+});
+
+const evtVenda: EventoOutlier = {
+  id: 1, empresa: "oben", sku_codigo_omie: "12345", sku_descricao: "Produto X",
+  tipo: "venda_atipica", severidade: "atencao", data_evento: "2026-01-15T00:00:00",
+  valor_observado: 100, valor_esperado: 50, desvios_padrao: 3.2,
+  detalhes: { mensagem: "pico de venda" }, status: "pendente",
+  decidido_em: null, decidido_por: null, justificativa_decisao: null, detectado_em: "2026-01-16T08:00:00",
+};
+
+const evtSemGrupo: EventoOutlier = {
+  ...evtVenda, id: 2, tipo: "sku_sem_grupo",
+  detalhes: { fornecedor: "ACME" },
+};
+
+function noop() { /* */ }
+
+function baseProps(over: Partial<React.ComponentProps<typeof AlertaDrillSheet>> = {}): React.ComponentProps<typeof AlertaDrillSheet> {
+  return {
+    drillEvento: evtVenda,
+    onClose: noop,
+    isSemGrupo: false,
+    skuInfo: null,
+    historico: null,
+    impacto: null,
+    gruposFornecedor: [],
+    grupoEscolhido: "",
+    setGrupoEscolhido: noop,
+    atribuirGrupoPending: false,
+    onAtribuirGrupo: noop,
+    justificativa: "",
+    setJustificativa: noop,
+    onAcao: noop,
+    ...over,
+  };
+}
+
+describe("AlertaDrillSheet", () => {
+  it("venda atípica pendente → seções contexto/SKU/histórico/decisão; Aceitar dispara onAcao", () => {
+    const onAcao = vi.fn();
+    render(<AlertaDrillSheet {...baseProps({ onAcao })} />);
+    expect(screen.getByText("1. Contexto")).toBeTruthy();
+    expect(screen.getByText("2. Dados do SKU")).toBeTruthy();
+    expect(screen.getByText("3. Histórico")).toBeTruthy();
+    expect(screen.getByText("5. Decisão")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: /Aceitar/ }));
+    expect(onAcao).toHaveBeenCalledWith("aceitar");
+  });
+
+  it("sku_sem_grupo pendente → atribuição de grupo; botão dispara onAtribuirGrupo", () => {
+    const onAtribuirGrupo = vi.fn();
+    render(
+      <AlertaDrillSheet
+        {...baseProps({
+          drillEvento: evtSemGrupo,
+          isSemGrupo: true,
+          gruposFornecedor: [{ id: 1, codigo_grupo: "G1", descricao: "Grupo 1", lt_producao_dias: 5 }],
+          grupoEscolhido: "1",
+          onAtribuirGrupo,
+        })}
+      />
+    );
+    expect(screen.getByText("3. Atribuir grupo de produção")).toBeTruthy();
+    expect(screen.getByText("ACME")).toBeTruthy();
+    expect(screen.queryByText("3. Histórico")).toBeNull();
+    expect(screen.queryByText("5. Decisão")).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: /Atribuir e marcar como aceito/ }));
+    expect(onAtribuirGrupo).toHaveBeenCalled();
+  });
+
+  it("fechado (drillEvento=null) → conteúdo não aparece", () => {
+    render(<AlertaDrillSheet {...baseProps({ drillEvento: null })} />);
+    expect(screen.queryByText("1. Contexto")).toBeNull();
+  });
+});

--- a/src/components/reposicao/alertas/__tests__/AlertasFiltros.test.tsx
+++ b/src/components/reposicao/alertas/__tests__/AlertasFiltros.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { AlertasFiltros } from "../AlertasFiltros";
+
+function baseProps(over: Partial<React.ComponentProps<typeof AlertasFiltros>> = {}): React.ComponentProps<typeof AlertasFiltros> {
+  const noop = () => { /* */ };
+  return {
+    busca: "",
+    setBusca: noop,
+    filtroTipo: "__all__",
+    setFiltroTipo: noop,
+    filtroSev: "__all__",
+    setFiltroSev: noop,
+    filtroStatus: "pendente",
+    setFiltroStatus: noop,
+    setPage: noop,
+    selecionadosCount: 0,
+    onAceitarLote: noop,
+    onExcluirLote: noop,
+    onLimparSelecao: noop,
+    ...over,
+  };
+}
+
+describe("AlertasFiltros", () => {
+  it("renderiza busca e labels; sem barra de lote quando count=0", () => {
+    render(<AlertasFiltros {...baseProps()} />);
+    expect(screen.getByPlaceholderText("Código ou descrição")).toBeTruthy();
+    expect(screen.getByText("Buscar SKU")).toBeTruthy();
+    expect(screen.queryByText(/selecionado\(s\)/)).toBeNull();
+  });
+
+  it("digitar na busca chama setBusca e reseta page", () => {
+    const setBusca = vi.fn();
+    const setPage = vi.fn();
+    render(<AlertasFiltros {...baseProps({ setBusca, setPage })} />);
+    fireEvent.change(screen.getByPlaceholderText("Código ou descrição"), { target: { value: "abc" } });
+    expect(setBusca).toHaveBeenCalledWith("abc");
+    expect(setPage).toHaveBeenCalledWith(1);
+  });
+
+  it("barra de lote aparece com count>0 e botões disparam callbacks", () => {
+    const onAceitarLote = vi.fn();
+    const onExcluirLote = vi.fn();
+    const onLimparSelecao = vi.fn();
+    render(<AlertasFiltros {...baseProps({ selecionadosCount: 3, onAceitarLote, onExcluirLote, onLimparSelecao })} />);
+    expect(screen.getByText("3 selecionado(s)")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: /Aceitar selecionados/ }));
+    expect(onAceitarLote).toHaveBeenCalled();
+    fireEvent.click(screen.getByRole("button", { name: /Excluir selecionados/ }));
+    expect(onExcluirLote).toHaveBeenCalled();
+    fireEvent.click(screen.getByRole("button", { name: /Limpar seleção/ }));
+    expect(onLimparSelecao).toHaveBeenCalled();
+  });
+});

--- a/src/components/reposicao/alertas/__tests__/AlertasTable.test.tsx
+++ b/src/components/reposicao/alertas/__tests__/AlertasTable.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { AlertasTable } from "../AlertasTable";
+import type { EventoOutlier } from "../types";
+
+const evt: EventoOutlier = {
+  id: 1, empresa: "oben", sku_codigo_omie: "12345", sku_descricao: "Produto X",
+  tipo: "venda_atipica", severidade: "atencao", data_evento: "2026-01-15T00:00:00",
+  valor_observado: 100, valor_esperado: 50, desvios_padrao: 3.2,
+  detalhes: { mensagem: "pico de venda" }, status: "pendente",
+  decidido_em: null, decidido_por: null, justificativa_decisao: null, detectado_em: "2026-01-16T08:00:00",
+};
+
+function noop() { /* */ }
+
+function baseProps(over: Partial<React.ComponentProps<typeof AlertasTable>> = {}): React.ComponentProps<typeof AlertasTable> {
+  return {
+    lista: { rows: [evt], total: 1 },
+    isLoading: false,
+    selecionados: new Set<number>(),
+    todosMarcados: false,
+    selecionavelCount: 1,
+    toggleAll: noop,
+    toggleOne: noop,
+    onDrill: noop,
+    page: 1,
+    totalPages: 1,
+    setPage: noop,
+    ...over,
+  };
+}
+
+describe("AlertasTable", () => {
+  it("lista vazia → mensagem 'Nenhum alerta encontrado'", () => {
+    render(<AlertasTable {...baseProps({ lista: { rows: [], total: 0 } })} />);
+    expect(screen.getByText("Nenhum alerta encontrado")).toBeTruthy();
+  });
+
+  it("com alerta → SKU, descrição, tipo, severidade e status", () => {
+    render(<AlertasTable {...baseProps()} />);
+    expect(screen.getByText("12345")).toBeTruthy();
+    expect(screen.getByText("Produto X")).toBeTruthy();
+    expect(screen.getByText("Venda atípica")).toBeTruthy();
+    expect(screen.getByText("Atenção")).toBeTruthy();
+    expect(screen.getByText("Pendente")).toBeTruthy();
+    expect(screen.getByText("1 alerta(s)")).toBeTruthy();
+  });
+
+  it("clicar Detalhes chama onDrill com o evento", () => {
+    const onDrill = vi.fn();
+    render(<AlertasTable {...baseProps({ onDrill })} />);
+    fireEvent.click(screen.getByRole("button", { name: "Detalhes" }));
+    expect(onDrill).toHaveBeenCalledWith(evt);
+  });
+
+  it("checkbox da linha chama toggleOne; paginação avança quando há próxima página", () => {
+    const toggleOne = vi.fn();
+    const setPage = vi.fn();
+    render(<AlertasTable {...baseProps({ toggleOne, setPage, page: 1, totalPages: 2 })} />);
+    // checkbox[0] = header, [1] = linha
+    fireEvent.click(screen.getAllByRole("checkbox")[1]);
+    expect(toggleOne).toHaveBeenCalledWith(1);
+    // botão "próxima" (segundo botão de paginação) habilitado
+    const navButtons = screen.getAllByRole("button").filter(b => b.querySelector("svg"));
+    fireEvent.click(navButtons[navButtons.length - 1]);
+    expect(setPage).toHaveBeenCalled();
+  });
+});

--- a/src/components/reposicao/alertas/__tests__/ConfirmacaoDialog.test.tsx
+++ b/src/components/reposicao/alertas/__tests__/ConfirmacaoDialog.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ConfirmacaoDialog } from "../ConfirmacaoDialog";
+
+function noop() { /* */ }
+
+describe("ConfirmacaoDialog", () => {
+  it("fechado (acaoConfirm=null) → não renderiza", () => {
+    render(<ConfirmacaoDialog acaoConfirm={null} onClose={noop} selecionadosCount={0} justificativa="" setJustificativa={noop} onConfirm={noop} isPending={false} />);
+    expect(screen.queryByText(/Confirmar/)).toBeNull();
+  });
+
+  it("excluir em lote → título, contagem, aviso e Confirmar dispara onConfirm", () => {
+    const onConfirm = vi.fn();
+    render(
+      <ConfirmacaoDialog
+        acaoConfirm={{ tipo: "excluir", lote: true }}
+        onClose={noop}
+        selecionadosCount={4}
+        justificativa=""
+        setJustificativa={noop}
+        onConfirm={onConfirm}
+        isPending={false}
+      />
+    );
+    expect(screen.getByText(/Confirmar exclusão/)).toBeTruthy();
+    expect(screen.getByText(/Aplicar a 4 alerta\(s\)/)).toBeTruthy();
+    expect(screen.getByText(/remove os eventos do cálculo estatístico/)).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: /Confirmar/ }));
+    expect(onConfirm).toHaveBeenCalled();
+  });
+
+  it("aceitar individual → título de aceitação, sem aviso de exclusão", () => {
+    render(
+      <ConfirmacaoDialog
+        acaoConfirm={{ tipo: "aceitar", lote: false }}
+        onClose={noop}
+        selecionadosCount={0}
+        justificativa=""
+        setJustificativa={noop}
+        onConfirm={noop}
+        isPending={false}
+      />
+    );
+    expect(screen.getByText(/Confirmar aceitação/)).toBeTruthy();
+    expect(screen.getByText(/Aplicar ao alerta selecionado/)).toBeTruthy();
+    expect(screen.queryByText(/remove os eventos/)).toBeNull();
+  });
+});

--- a/src/components/reposicao/alertas/__tests__/StatsCards.test.tsx
+++ b/src/components/reposicao/alertas/__tests__/StatsCards.test.tsx
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { StatsCards } from "../StatsCards";
+
+describe("StatsCards", () => {
+  it("renderiza rótulos e zeros quando sem stats", () => {
+    render(<StatsCards />);
+    expect(screen.getByText("Total pendentes")).toBeTruthy();
+    expect(screen.getByText("Críticos")).toBeTruthy();
+    expect(screen.getByText("Excluídos hoje")).toBeTruthy();
+    expect(screen.getAllByText("0").length).toBeGreaterThanOrEqual(6);
+  });
+
+  it("renderiza os valores fornecidos", () => {
+    render(<StatsCards stats={{ pendentes: 12, criticos: 3, atencao: 5, info: 4, aceitosHoje: 7, excluidosHoje: 2 }} />);
+    expect(screen.getByText("12")).toBeTruthy();
+    expect(screen.getByText("3")).toBeTruthy();
+    expect(screen.getByText("7")).toBeTruthy();
+  });
+});

--- a/src/components/reposicao/alertas/__tests__/badges.test.tsx
+++ b/src/components/reposicao/alertas/__tests__/badges.test.tsx
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { sevBadge, statusBadge } from "../badges";
+
+describe("sevBadge", () => {
+  it("mapeia severidades conhecidas e passthrough", () => {
+    render(<div>{sevBadge("critico")}{sevBadge("atencao")}{sevBadge("info")}{sevBadge("xpto")}</div>);
+    expect(screen.getByText("Crítico")).toBeTruthy();
+    expect(screen.getByText("Atenção")).toBeTruthy();
+    expect(screen.getByText("Info")).toBeTruthy();
+    expect(screen.getByText("xpto")).toBeTruthy();
+  });
+});
+
+describe("statusBadge", () => {
+  it("mapeia status conhecidos e passthrough", () => {
+    render(<div>{statusBadge("pendente")}{statusBadge("aceito")}{statusBadge("excluido")}{statusBadge("ignorado")}{statusBadge("zzz")}</div>);
+    expect(screen.getByText("Pendente")).toBeTruthy();
+    expect(screen.getByText("Aceito")).toBeTruthy();
+    expect(screen.getByText("Excluído")).toBeTruthy();
+    expect(screen.getByText("Ignorado")).toBeTruthy();
+    expect(screen.getByText("zzz")).toBeTruthy();
+  });
+});

--- a/src/components/reposicao/alertas/__tests__/types.test.ts
+++ b/src/components/reposicao/alertas/__tests__/types.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { tipoLabel, fmt, PAGE_SIZE } from "../types";
+
+describe("tipoLabel", () => {
+  it("mapeia os tipos conhecidos e faz passthrough do desconhecido", () => {
+    expect(tipoLabel("venda_atipica")).toBe("Venda atípica");
+    expect(tipoLabel("lt_atipico")).toBe("LT atípico");
+    expect(tipoLabel("sku_sem_grupo")).toBe("SKU sem grupo");
+    expect(tipoLabel("outro")).toBe("outro");
+  });
+});
+
+describe("fmt", () => {
+  it("formata número com casas decimais e usa — para null/undefined", () => {
+    expect(fmt(null)).toBe("—");
+    expect(fmt(undefined)).toBe("—");
+    expect(fmt(1234.5, 1)).toBe("1.234,5");
+    expect(fmt(10, 0)).toBe("10");
+  });
+});
+
+describe("PAGE_SIZE", () => {
+  it("é 25", () => {
+    expect(PAGE_SIZE).toBe(25);
+  });
+});

--- a/src/components/reposicao/alertas/badges.tsx
+++ b/src/components/reposicao/alertas/badges.tsx
@@ -1,0 +1,25 @@
+// Helpers de badge (severidade/status) dos Alertas de Outlier.
+// Extraídos de src/pages/AdminReposicaoAlertas.tsx (god-component split).
+import { Badge } from "@/components/ui/badge";
+import type { BadgeVariant } from "./types";
+
+export const sevBadge = (sev: string) => {
+  const map: Record<string, { variant: BadgeVariant; label: string }> = {
+    critico: { variant: "destructive", label: "Crítico" },
+    atencao: { variant: "warning", label: "Atenção" },
+    info: { variant: "secondary", label: "Info" },
+  };
+  const cfg = map[sev] ?? { variant: "outline" as BadgeVariant, label: sev };
+  return <Badge variant={cfg.variant}>{cfg.label}</Badge>;
+};
+
+export const statusBadge = (status: string) => {
+  const map: Record<string, { variant: BadgeVariant; label: string }> = {
+    pendente: { variant: "warning", label: "Pendente" },
+    aceito: { variant: "success", label: "Aceito" },
+    excluido: { variant: "destructive", label: "Excluído" },
+    ignorado: { variant: "secondary", label: "Ignorado" },
+  };
+  const cfg = map[status] ?? { variant: "outline" as BadgeVariant, label: status };
+  return <Badge variant={cfg.variant}>{cfg.label}</Badge>;
+};

--- a/src/components/reposicao/alertas/types.ts
+++ b/src/components/reposicao/alertas/types.ts
@@ -1,0 +1,75 @@
+// Tipos e helpers puros dos Alertas de Outlier (AdminReposicaoAlertas).
+// Extraídos de src/pages/AdminReposicaoAlertas.tsx (god-component split).
+
+export const PAGE_SIZE = 25;
+
+export type BadgeVariant = "default" | "secondary" | "destructive" | "outline" | "success" | "warning" | "info" | "danger" | "purple" | "indigo";
+
+export interface OutlierDetalhes {
+  fornecedor?: string;
+  mensagem?: string;
+  [k: string]: unknown;
+}
+
+export type EventoOutlier = {
+  id: number;
+  empresa: string;
+  sku_codigo_omie: string;
+  sku_descricao: string | null;
+  tipo: string;
+  severidade: string;
+  data_evento: string;
+  valor_observado: number | null;
+  valor_esperado: number | null;
+  desvios_padrao: number | null;
+  detalhes: OutlierDetalhes | null;
+  status: string;
+  decidido_em: string | null;
+  decidido_por: string | null;
+  justificativa_decisao: string | null;
+  detectado_em: string | null;
+};
+
+export type OutlierStats = {
+  pendentes: number;
+  criticos: number;
+  atencao: number;
+  info: number;
+  aceitosHoje: number;
+  excluidosHoje: number;
+};
+
+export type SkuInfo = {
+  classe_consolidada: string | null;
+  demanda_media_diaria: number | null;
+  demanda_sigma_diario: number | null;
+  lt_medio_dias_uteis: number | null;
+  preco_compra_real: number | null;
+};
+
+export type ImpactoData = {
+  error?: string;
+  media_atual?: number | null;
+  media_sem?: number | null;
+  sigma_atual?: number | null;
+  sigma_sem?: number | null;
+  em_atual?: number | null;
+  em_sem?: number | null;
+  delta_em?: number;
+} | null;
+
+export type GrupoRow = { id: number; codigo_grupo: string; descricao: string | null; lt_producao_dias: number };
+
+export type AcaoConfirm = { tipo: "aceitar" | "excluir" | "ignorar"; lote: boolean };
+
+export const tipoLabel = (tipo: string) =>
+  tipo === "venda_atipica"
+    ? "Venda atípica"
+    : tipo === "lt_atipico"
+    ? "LT atípico"
+    : tipo === "sku_sem_grupo"
+    ? "SKU sem grupo"
+    : tipo;
+
+export const fmt = (n: number | null | undefined, dec = 2) =>
+  n === null || n === undefined ? "—" : Number(n).toLocaleString("pt-BR", { minimumFractionDigits: dec, maximumFractionDigits: dec });

--- a/src/pages/AdminReposicaoAlertas.tsx
+++ b/src/pages/AdminReposicaoAlertas.tsx
@@ -4,113 +4,16 @@ import { supabase } from "@/integrations/supabase/client";
 import { useAuth } from "@/contexts/AuthContext";
 import { useReposicaoEmpresa } from "@/contexts/ReposicaoEmpresaContext";
 import { toast } from "sonner";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Badge } from "@/components/ui/badge";
-import { Checkbox } from "@/components/ui/checkbox";
+import { AlertTriangle } from "lucide-react";
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogFooter,
-  DialogDescription,
-} from "@/components/ui/dialog";
-import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
-import { Textarea } from "@/components/ui/textarea";
-import { Label } from "@/components/ui/label";
-import { Search, AlertTriangle, CheckCircle2, XCircle, EyeOff, Loader2, ChevronLeft, ChevronRight } from "lucide-react";
-import {
-  ResponsiveContainer,
-  BarChart,
-  Bar,
-  ScatterChart,
-  Scatter,
-  XAxis,
-  YAxis,
-  CartesianGrid,
-  Tooltip as ReTooltip,
-  ReferenceLine,
-  Cell,
-} from "recharts";
-
-const PAGE_SIZE = 25;
-
-type BadgeVariant = "default" | "secondary" | "destructive" | "outline" | "success" | "warning" | "info" | "danger" | "purple" | "indigo";
-
-interface OutlierDetalhes {
-  fornecedor?: string;
-  mensagem?: string;
-  [k: string]: unknown;
-}
-
-type EventoOutlier = {
-  id: number;
-  empresa: string;
-  sku_codigo_omie: string;
-  sku_descricao: string | null;
-  tipo: string;
-  severidade: string;
-  data_evento: string;
-  valor_observado: number | null;
-  valor_esperado: number | null;
-  desvios_padrao: number | null;
-  detalhes: OutlierDetalhes | null;
-  status: string;
-  decidido_em: string | null;
-  decidido_por: string | null;
-  justificativa_decisao: string | null;
-  detectado_em: string | null;
-};
-
-const sevBadge = (sev: string) => {
-  const map: Record<string, { variant: BadgeVariant; label: string }> = {
-    critico: { variant: "destructive", label: "Crítico" },
-    atencao: { variant: "warning", label: "Atenção" },
-    info: { variant: "secondary", label: "Info" },
-  };
-  const cfg = map[sev] ?? { variant: "outline" as BadgeVariant, label: sev };
-  return <Badge variant={cfg.variant}>{cfg.label}</Badge>;
-};
-
-const statusBadge = (status: string) => {
-  const map: Record<string, { variant: BadgeVariant; label: string }> = {
-    pendente: { variant: "warning", label: "Pendente" },
-    aceito: { variant: "success", label: "Aceito" },
-    excluido: { variant: "destructive", label: "Excluído" },
-    ignorado: { variant: "secondary", label: "Ignorado" },
-  };
-  const cfg = map[status] ?? { variant: "outline" as BadgeVariant, label: status };
-  return <Badge variant={cfg.variant}>{cfg.label}</Badge>;
-};
-
-const tipoLabel = (tipo: string) =>
-  tipo === "venda_atipica"
-    ? "Venda atípica"
-    : tipo === "lt_atipico"
-    ? "LT atípico"
-    : tipo === "sku_sem_grupo"
-    ? "SKU sem grupo"
-    : tipo;
-
-const fmt = (n: number | null | undefined, dec = 2) =>
-  n === null || n === undefined ? "—" : Number(n).toLocaleString("pt-BR", { minimumFractionDigits: dec, maximumFractionDigits: dec });
+  PAGE_SIZE,
+  type EventoOutlier, type SkuInfo, type ImpactoData, type GrupoRow, type AcaoConfirm,
+} from "@/components/reposicao/alertas/types";
+import { StatsCards } from "@/components/reposicao/alertas/StatsCards";
+import { AlertasFiltros } from "@/components/reposicao/alertas/AlertasFiltros";
+import { AlertasTable } from "@/components/reposicao/alertas/AlertasTable";
+import { AlertaDrillSheet } from "@/components/reposicao/alertas/AlertaDrillSheet";
+import { ConfirmacaoDialog } from "@/components/reposicao/alertas/ConfirmacaoDialog";
 
 export default function AdminReposicaoAlertas() {
   const { user } = useAuth();
@@ -125,7 +28,7 @@ export default function AdminReposicaoAlertas() {
   const [selecionados, setSelecionados] = useState<Set<number>>(new Set());
 
   const [drillEvento, setDrillEvento] = useState<EventoOutlier | null>(null);
-  const [acaoConfirm, setAcaoConfirm] = useState<{ tipo: "aceitar" | "excluir" | "ignorar"; lote: boolean } | null>(null);
+  const [acaoConfirm, setAcaoConfirm] = useState<AcaoConfirm | null>(null);
   const [justificativa, setJustificativa] = useState("");
 
   // Stats do cabeçalho
@@ -230,13 +133,6 @@ export default function AdminReposicaoAlertas() {
   });
 
   // Dados do SKU (drill seção 2)
-  type SkuInfo = {
-    classe_consolidada: string | null;
-    demanda_media_diaria: number | null;
-    demanda_sigma_diario: number | null;
-    lt_medio_dias_uteis: number | null;
-    preco_compra_real: number | null;
-  };
   const { data: skuInfo } = useQuery<SkuInfo | null>({
     enabled: !!drillEvento,
     queryKey: ["outlier-sku", drillEvento?.sku_codigo_omie, drillEvento?.empresa],
@@ -254,16 +150,6 @@ export default function AdminReposicaoAlertas() {
   });
 
   // Impacto previsto
-  type ImpactoData = {
-    error?: string;
-    media_atual?: number | null;
-    media_sem?: number | null;
-    sigma_atual?: number | null;
-    sigma_sem?: number | null;
-    em_atual?: number | null;
-    em_sem?: number | null;
-    delta_em?: number;
-  } | null;
   const { data: impacto } = useQuery<ImpactoData>({
     enabled: !!drillEvento && !isSemGrupo,
     queryKey: ["outlier-impacto", drillEvento?.id],
@@ -284,7 +170,6 @@ export default function AdminReposicaoAlertas() {
     queryFn: async () => {
       if (!drillEvento) return [];
       // NOTE: `codigo_grupo` no schema gerado é `grupo_codigo`; cast pra row local.
-      type GrupoRow = { id: number; codigo_grupo: string; descricao: string | null; lt_producao_dias: number };
       const { data, error } = await supabase
         .from("fornecedor_grupo_producao")
         .select("id, codigo_grupo, descricao, lt_producao_dias" as never)
@@ -417,429 +302,68 @@ export default function AdminReposicaoAlertas() {
       </div>
 
       {/* Estatísticas */}
-      <div className="grid grid-cols-2 md:grid-cols-6 gap-3">
-        <Card>
-          <CardContent className="pt-4">
-            <div className="text-xs text-muted-foreground">Total pendentes</div>
-            <div className="text-2xl font-bold">{stats?.pendentes ?? 0}</div>
-          </CardContent>
-        </Card>
-        <Card className="border-destructive/40">
-          <CardContent className="pt-4">
-            <div className="text-xs text-destructive">Críticos</div>
-            <div className="text-2xl font-bold text-destructive">{stats?.criticos ?? 0}</div>
-          </CardContent>
-        </Card>
-        <Card className="border-warning/40">
-          <CardContent className="pt-4">
-            <div className="text-xs text-warning">Atenção</div>
-            <div className="text-2xl font-bold text-warning">{stats?.atencao ?? 0}</div>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardContent className="pt-4">
-            <div className="text-xs text-muted-foreground">Informativos</div>
-            <div className="text-2xl font-bold">{stats?.info ?? 0}</div>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardContent className="pt-4">
-            <div className="text-xs text-success">Aceitos hoje</div>
-            <div className="text-2xl font-bold">{stats?.aceitosHoje ?? 0}</div>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardContent className="pt-4">
-            <div className="text-xs text-destructive">Excluídos hoje</div>
-            <div className="text-2xl font-bold">{stats?.excluidosHoje ?? 0}</div>
-          </CardContent>
-        </Card>
-      </div>
+      <StatsCards stats={stats} />
 
       {/* Filtros */}
-      <Card>
-        <CardContent className="pt-4">
-          <div className="flex flex-wrap gap-3 items-end">
-            <div className="flex-1 min-w-[200px]">
-              <Label className="text-xs">Buscar SKU</Label>
-              <div className="relative">
-                <Search className="h-4 w-4 absolute left-2 top-2.5 text-muted-foreground" />
-                <Input
-                  placeholder="Código ou descrição"
-                  className="pl-8"
-                  value={busca}
-                  onChange={(e) => {
-                    setBusca(e.target.value);
-                    setPage(1);
-                  }}
-                />
-              </div>
-            </div>
-            <div className="w-[160px]">
-              <Label className="text-xs">Tipo</Label>
-              <Select value={filtroTipo} onValueChange={(v) => { setFiltroTipo(v); setPage(1); }}>
-                <SelectTrigger><SelectValue /></SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="__all__">Todos</SelectItem>
-                  <SelectItem value="venda_atipica">Venda atípica</SelectItem>
-                  <SelectItem value="lt_atipico">LT atípico</SelectItem>
-                  <SelectItem value="sku_sem_grupo">SKU sem grupo</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-            <div className="w-[140px]">
-              <Label className="text-xs">Severidade</Label>
-              <Select value={filtroSev} onValueChange={(v) => { setFiltroSev(v); setPage(1); }}>
-                <SelectTrigger><SelectValue /></SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="__all__">Todas</SelectItem>
-                  <SelectItem value="critico">Crítico</SelectItem>
-                  <SelectItem value="atencao">Atenção</SelectItem>
-                  <SelectItem value="info">Info</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-            <div className="w-[140px]">
-              <Label className="text-xs">Status</Label>
-              <Select value={filtroStatus} onValueChange={(v) => { setFiltroStatus(v); setPage(1); }}>
-                <SelectTrigger><SelectValue /></SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="__all__">Todos</SelectItem>
-                  <SelectItem value="pendente">Pendente</SelectItem>
-                  <SelectItem value="aceito">Aceito</SelectItem>
-                  <SelectItem value="excluido">Excluído</SelectItem>
-                  <SelectItem value="ignorado">Ignorado</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-          </div>
-
-          {selecionados.size > 0 && (
-            <div className="mt-4 flex gap-2 items-center bg-muted/50 p-3 rounded-md">
-              <span className="text-sm font-medium">{selecionados.size} selecionado(s)</span>
-              <Button size="sm" variant="default" onClick={() => setAcaoConfirm({ tipo: "aceitar", lote: true })}>
-                <CheckCircle2 className="h-4 w-4 mr-1" /> Aceitar selecionados
-              </Button>
-              <Button size="sm" variant="destructive" onClick={() => setAcaoConfirm({ tipo: "excluir", lote: true })}>
-                <XCircle className="h-4 w-4 mr-1" /> Excluir selecionados
-              </Button>
-              <Button size="sm" variant="ghost" onClick={() => setSelecionados(new Set())}>
-                Limpar seleção
-              </Button>
-            </div>
-          )}
-        </CardContent>
-      </Card>
+      <AlertasFiltros
+        busca={busca}
+        setBusca={setBusca}
+        filtroTipo={filtroTipo}
+        setFiltroTipo={setFiltroTipo}
+        filtroSev={filtroSev}
+        setFiltroSev={setFiltroSev}
+        filtroStatus={filtroStatus}
+        setFiltroStatus={setFiltroStatus}
+        setPage={setPage}
+        selecionadosCount={selecionados.size}
+        onAceitarLote={() => setAcaoConfirm({ tipo: "aceitar", lote: true })}
+        onExcluirLote={() => setAcaoConfirm({ tipo: "excluir", lote: true })}
+        onLimparSelecao={() => setSelecionados(new Set())}
+      />
 
       {/* Lista */}
-      <Card>
-        <CardContent className="pt-4 overflow-x-auto">
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead className="w-10">
-                  <Checkbox checked={todosMarcados} onCheckedChange={toggleAll} disabled={todosSelecionavel.length === 0} />
-                </TableHead>
-                <TableHead>Severidade</TableHead>
-                <TableHead>Data evento</TableHead>
-                <TableHead>SKU</TableHead>
-                <TableHead>Descrição</TableHead>
-                <TableHead>Tipo</TableHead>
-                <TableHead className="text-right">Observado</TableHead>
-                <TableHead className="text-right">Esperado</TableHead>
-                <TableHead className="text-right">σ</TableHead>
-                <TableHead>Mensagem</TableHead>
-                <TableHead>Status</TableHead>
-                <TableHead></TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {isLoading && (
-                <TableRow><TableCell colSpan={12} className="text-center py-8"><Loader2 className="h-5 w-5 animate-spin mx-auto" /></TableCell></TableRow>
-              )}
-              {!isLoading && (lista?.rows.length ?? 0) === 0 && (
-                <TableRow><TableCell colSpan={12} className="text-center py-8 text-muted-foreground">Nenhum alerta encontrado</TableCell></TableRow>
-              )}
-              {lista?.rows.map((r) => {
-                const podeSelecionar =
-                  r.status === "pendente" && r.severidade !== "critico" && r.tipo !== "sku_sem_grupo";
-                return (
-                  <TableRow key={r.id} className="hover:bg-muted/50">
-                    <TableCell>
-                      <Checkbox
-                        checked={selecionados.has(r.id)}
-                        onCheckedChange={() => toggleOne(r.id)}
-                        disabled={!podeSelecionar}
-                      />
-                    </TableCell>
-                    <TableCell>{sevBadge(r.severidade)}</TableCell>
-                    <TableCell className="text-sm">{new Date(r.data_evento).toLocaleDateString("pt-BR")}</TableCell>
-                    <TableCell className="font-mono text-xs whitespace-nowrap">{r.sku_codigo_omie}</TableCell>
-                    <TableCell className="text-sm min-w-[260px] max-w-[360px] whitespace-normal break-words" title={r.sku_descricao ?? undefined}>{r.sku_descricao ?? "—"}</TableCell>
-                    <TableCell><Badge variant="outline">{tipoLabel(r.tipo)}</Badge></TableCell>
-                    <TableCell className="text-right font-mono text-sm">{fmt(r.valor_observado, 0)}</TableCell>
-                    <TableCell className="text-right font-mono text-sm">{fmt(r.valor_esperado, 1)}</TableCell>
-                    <TableCell className="text-right font-mono text-sm">{fmt(r.desvios_padrao, 1)}</TableCell>
-                    <TableCell className="text-xs min-w-[280px] max-w-[420px] whitespace-normal break-words text-muted-foreground" title={r.detalhes?.mensagem ?? undefined}>{r.detalhes?.mensagem ?? "—"}</TableCell>
-                    <TableCell>{statusBadge(r.status)}</TableCell>
-                    <TableCell>
-                      <Button size="sm" variant="ghost" onClick={() => setDrillEvento(r)}>Detalhes</Button>
-                    </TableCell>
-                  </TableRow>
-                );
-              })}
-            </TableBody>
-          </Table>
-
-          <div className="flex items-center justify-between mt-4">
-            <div className="text-sm text-muted-foreground">{lista?.total ?? 0} alerta(s)</div>
-            <div className="flex items-center gap-2">
-              <Button size="sm" variant="outline" disabled={page === 1} onClick={() => setPage((p) => p - 1)}>
-                <ChevronLeft className="h-4 w-4" />
-              </Button>
-              <span className="text-sm">{page} / {totalPages}</span>
-              <Button size="sm" variant="outline" disabled={page >= totalPages} onClick={() => setPage((p) => p + 1)}>
-                <ChevronRight className="h-4 w-4" />
-              </Button>
-            </div>
-          </div>
-        </CardContent>
-      </Card>
+      <AlertasTable
+        lista={lista}
+        isLoading={isLoading}
+        selecionados={selecionados}
+        todosMarcados={todosMarcados}
+        selecionavelCount={todosSelecionavel.length}
+        toggleAll={toggleAll}
+        toggleOne={toggleOne}
+        onDrill={setDrillEvento}
+        page={page}
+        totalPages={totalPages}
+        setPage={setPage}
+      />
 
       {/* Drill-down */}
-      <Sheet open={!!drillEvento} onOpenChange={(o) => !o && setDrillEvento(null)}>
-        <SheetContent className="w-full sm:max-w-2xl overflow-y-auto">
-          {drillEvento && (
-            <>
-              <SheetHeader>
-                <SheetTitle className="flex items-center gap-2">
-                  {sevBadge(drillEvento.severidade)}
-                  <span>{tipoLabel(drillEvento.tipo)} — SKU {drillEvento.sku_codigo_omie}</span>
-                </SheetTitle>
-              </SheetHeader>
-
-              <div className="space-y-5 mt-4">
-                {/* Seção 1 */}
-                <Card>
-                  <CardHeader className="pb-2"><CardTitle className="text-sm">1. Contexto</CardTitle></CardHeader>
-                  <CardContent className="space-y-1 text-sm">
-                    <div><span className="text-muted-foreground">Data:</span> {new Date(drillEvento.data_evento).toLocaleDateString("pt-BR")}</div>
-                    <div><span className="text-muted-foreground">Detectado:</span> {drillEvento.detectado_em ? new Date(drillEvento.detectado_em).toLocaleString("pt-BR") : "—"}</div>
-                    <div className="pt-2 p-2 bg-muted/50 rounded text-xs">{drillEvento.detalhes?.mensagem ?? "Sem mensagem"}</div>
-                  </CardContent>
-                </Card>
-
-                {/* Seção 2 */}
-                <Card>
-                  <CardHeader className="pb-2"><CardTitle className="text-sm">2. Dados do SKU</CardTitle></CardHeader>
-                  <CardContent className="space-y-1 text-sm">
-                    <div><span className="text-muted-foreground">Descrição:</span> {drillEvento.sku_descricao ?? "—"}</div>
-                    <div><span className="text-muted-foreground">Classe:</span> {skuInfo?.classe_consolidada ?? "—"}</div>
-                    <div><span className="text-muted-foreground">D (média/dia):</span> {fmt(skuInfo?.demanda_media_diaria, 2)}</div>
-                    <div><span className="text-muted-foreground">σ atual:</span> {fmt(skuInfo?.demanda_sigma_diario, 2)}</div>
-                    <div><span className="text-muted-foreground">LT médio:</span> {fmt(skuInfo?.lt_medio_dias_uteis, 1)} dias</div>
-                    <div><span className="text-muted-foreground">Preço compra:</span> R$ {fmt(skuInfo?.preco_compra_real, 2)}</div>
-                  </CardContent>
-                </Card>
-
-                {/* Seção 3 - Gráfico (não aplicável a sku_sem_grupo) */}
-                {!isSemGrupo && (
-                  <Card>
-                    <CardHeader className="pb-2"><CardTitle className="text-sm">3. Histórico</CardTitle></CardHeader>
-                    <CardContent>
-                      <div className="h-[220px]">
-                        <ResponsiveContainer width="100%" height="100%">
-                          {drillEvento.tipo === "venda_atipica" ? (
-                            <BarChart data={(historico as Array<{ dia: string; qtde: number; isOutlier: boolean }> | null) ?? []}>
-                              <CartesianGrid strokeDasharray="3 3" />
-                              <XAxis dataKey="dia" tick={{ fontSize: 10 }} />
-                              <YAxis tick={{ fontSize: 10 }} />
-                              <ReTooltip />
-                              <Bar dataKey="qtde">
-                                {((historico as Array<{ isOutlier: boolean }> | null) ?? []).map((d, i) => (
-                                  <Cell key={i} fill={d.isOutlier ? "hsl(var(--destructive))" : "hsl(var(--primary))"} />
-                                ))}
-                              </Bar>
-                            </BarChart>
-                          ) : (
-                            <ScatterChart>
-                              <CartesianGrid strokeDasharray="3 3" />
-                              <XAxis dataKey="idx" tick={{ fontSize: 10 }} name="#" />
-                              <YAxis dataKey="lt" tick={{ fontSize: 10 }} name="LT (dias)" />
-                              <ReTooltip />
-                              {impacto?.media_atual != null && (
-                                <ReferenceLine y={impacto.media_atual} stroke="hsl(var(--muted-foreground))" strokeDasharray="3 3" />
-                              )}
-                              <Scatter data={(historico as Array<{ idx: number; lt: number; isOutlier: boolean }> | null) ?? []}>
-                                {((historico as Array<{ isOutlier: boolean }> | null) ?? []).map((d, i) => (
-                                  <Cell key={i} fill={d.isOutlier ? "hsl(var(--destructive))" : "hsl(var(--primary))"} />
-                                ))}
-                              </Scatter>
-                            </ScatterChart>
-                          )}
-                        </ResponsiveContainer>
-                      </div>
-                    </CardContent>
-                  </Card>
-                )}
-
-                {/* Seção 4 - Impacto (não aplicável a sku_sem_grupo) */}
-                {!isSemGrupo && (
-                  <Card>
-                    <CardHeader className="pb-2"><CardTitle className="text-sm">4. Impacto se excluir</CardTitle></CardHeader>
-                    <CardContent className="text-sm space-y-1">
-                      {impacto && !impacto.error ? (
-                        <>
-                          <div>σ atual: <span className="font-mono">{fmt(impacto.sigma_atual)}</span> → sem outlier: <span className="font-mono">{fmt(impacto.sigma_sem)}</span></div>
-                          <div>Média atual: <span className="font-mono">{fmt(impacto.media_atual)}</span> → sem: <span className="font-mono">{fmt(impacto.media_sem)}</span></div>
-                          {impacto.em_atual !== undefined && (
-                            <div className="pt-2 p-2 bg-muted/50 rounded">
-                              Estoque mínimo sugerido: <span className="font-mono">{impacto.em_atual}</span> → <span className="font-mono">{impacto.em_sem}</span>{" "}
-                              <Badge variant={impacto.delta_em < 0 ? "success" : "warning"}>
-                                {impacto.delta_em > 0 ? "+" : ""}{impacto.delta_em} un
-                              </Badge>
-                            </div>
-                          )}
-                        </>
-                      ) : (
-                        <div className="text-muted-foreground">Calculando…</div>
-                      )}
-                    </CardContent>
-                  </Card>
-                )}
-
-                {/* Seção 3 alternativa: atribuir grupo (sku_sem_grupo) */}
-                {isSemGrupo && drillEvento.status === "pendente" && (
-                  <Card>
-                    <CardHeader className="pb-2">
-                      <CardTitle className="text-sm">3. Atribuir grupo de produção</CardTitle>
-                    </CardHeader>
-                    <CardContent className="space-y-3">
-                      <div className="text-sm">
-                        <span className="text-muted-foreground">Fornecedor:</span>{" "}
-                        <span className="font-medium">{drillEvento.detalhes?.fornecedor ?? "—"}</span>
-                      </div>
-                      <div>
-                        <Label className="text-xs">Grupo de produção</Label>
-                        <Select value={grupoEscolhido} onValueChange={setGrupoEscolhido}>
-                          <SelectTrigger>
-                            <SelectValue placeholder="Selecione o grupo" />
-                          </SelectTrigger>
-                          <SelectContent>
-                            {(gruposFornecedor ?? []).map((g) => (
-                              // SelectItem espera string, mas a lógica original passava o number — preservar via cast
-                              <SelectItem key={g.id} value={g.id as unknown as string}>
-                                {g.codigo_grupo} — {g.descricao} (LT {g.lt_producao_dias}d)
-                              </SelectItem>
-                            ))}
-                            {(gruposFornecedor ?? []).length === 0 && (
-                              <div className="px-2 py-1.5 text-xs text-muted-foreground">
-                                Nenhum grupo cadastrado para este fornecedor
-                              </div>
-                            )}
-                          </SelectContent>
-                        </Select>
-                      </div>
-                      <Button
-                        className="w-full"
-                        disabled={!grupoEscolhido || atribuirGrupoMut.isPending}
-                        onClick={() => atribuirGrupoMut.mutate()}
-                      >
-                        {atribuirGrupoMut.isPending && <Loader2 className="h-4 w-4 mr-1 animate-spin" />}
-                        <CheckCircle2 className="h-4 w-4 mr-1" /> Atribuir e marcar como aceito
-                      </Button>
-                      <p className="text-xs text-muted-foreground">
-                        Ao atribuir, o SKU é classificado, o alerta é fechado e os parâmetros de reposição
-                        são recalculados com o novo LT de produção.
-                      </p>
-                    </CardContent>
-                  </Card>
-                )}
-
-                {/* Seção 5 - Decisão padrão (oculta para sku_sem_grupo) */}
-                {!isSemGrupo && drillEvento.status === "pendente" && (
-                  <Card>
-                    <CardHeader className="pb-2"><CardTitle className="text-sm">5. Decisão</CardTitle></CardHeader>
-                    <CardContent className="space-y-3">
-                      <div>
-                        <Label className="text-xs">Justificativa (opcional)</Label>
-                        <Textarea
-                          rows={2}
-                          value={justificativa}
-                          onChange={(e) => setJustificativa(e.target.value)}
-                          placeholder="Ex: pedido excepcional cliente X, não se repete"
-                        />
-                      </div>
-                      <div className="grid grid-cols-3 gap-2">
-                        <Button variant="default" className="bg-success hover:bg-success/90 text-success-foreground" onClick={() => setAcaoConfirm({ tipo: "aceitar", lote: false })}>
-                          <CheckCircle2 className="h-4 w-4 mr-1" /> Aceitar
-                        </Button>
-                        <Button variant="destructive" onClick={() => setAcaoConfirm({ tipo: "excluir", lote: false })}>
-                          <XCircle className="h-4 w-4 mr-1" /> Excluir
-                        </Button>
-                        <Button variant="secondary" onClick={() => setAcaoConfirm({ tipo: "ignorar", lote: false })}>
-                          <EyeOff className="h-4 w-4 mr-1" /> Ignorar
-                        </Button>
-                      </div>
-                      <p className="text-xs text-muted-foreground">
-                        <strong>Aceitar:</strong> evento real, mantém no cálculo. <strong>Excluir:</strong> one-off, remove da estatística. <strong>Ignorar:</strong> não mexe no dado.
-                      </p>
-                    </CardContent>
-                  </Card>
-                )}
-
-                {drillEvento.status !== "pendente" && (
-                  <Card>
-                    <CardContent className="pt-4 text-sm space-y-1">
-                      <div>Status: {statusBadge(drillEvento.status)}</div>
-                      <div className="text-muted-foreground">Por: {drillEvento.decidido_por ?? "—"} em {drillEvento.decidido_em ? new Date(drillEvento.decidido_em).toLocaleString("pt-BR") : "—"}</div>
-                      {drillEvento.justificativa_decisao && (
-                        <div className="p-2 bg-muted/50 rounded text-xs">{drillEvento.justificativa_decisao}</div>
-                      )}
-                    </CardContent>
-                  </Card>
-                )}
-              </div>
-            </>
-          )}
-        </SheetContent>
-      </Sheet>
+      <AlertaDrillSheet
+        drillEvento={drillEvento}
+        onClose={() => setDrillEvento(null)}
+        isSemGrupo={!!isSemGrupo}
+        skuInfo={skuInfo}
+        historico={historico}
+        impacto={impacto}
+        gruposFornecedor={gruposFornecedor}
+        grupoEscolhido={grupoEscolhido}
+        setGrupoEscolhido={setGrupoEscolhido}
+        atribuirGrupoPending={atribuirGrupoMut.isPending}
+        onAtribuirGrupo={() => atribuirGrupoMut.mutate()}
+        justificativa={justificativa}
+        setJustificativa={setJustificativa}
+        onAcao={(tipo) => setAcaoConfirm({ tipo, lote: false })}
+      />
 
       {/* Confirmação */}
-      <Dialog open={!!acaoConfirm} onOpenChange={(o) => !o && setAcaoConfirm(null)}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>
-              Confirmar {acaoConfirm?.tipo === "aceitar" ? "aceitação" : acaoConfirm?.tipo === "excluir" ? "exclusão" : "ignorar"}
-            </DialogTitle>
-            <DialogDescription>
-              {acaoConfirm?.lote
-                ? `Aplicar a ${selecionados.size} alerta(s). Críticos não estão incluídos.`
-                : `Aplicar ao alerta selecionado.`}
-              {acaoConfirm?.tipo === "excluir" && (
-                <div className="mt-2 text-warning">⚠ Esta ação remove os eventos do cálculo estatístico e dispara recálculo automático dos parâmetros.</div>
-              )}
-            </DialogDescription>
-          </DialogHeader>
-          {acaoConfirm?.lote && (
-            <div>
-              <Label className="text-xs">Justificativa em lote (opcional)</Label>
-              <Textarea rows={2} value={justificativa} onChange={(e) => setJustificativa(e.target.value)} />
-            </div>
-          )}
-          <DialogFooter>
-            <Button variant="ghost" onClick={() => setAcaoConfirm(null)}>Cancelar</Button>
-            <Button
-              variant={acaoConfirm?.tipo === "excluir" ? "destructive" : "default"}
-              onClick={executarAcao}
-              disabled={resolverMut.isPending}
-            >
-              {resolverMut.isPending && <Loader2 className="h-4 w-4 mr-1 animate-spin" />}
-              Confirmar
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      <ConfirmacaoDialog
+        acaoConfirm={acaoConfirm}
+        onClose={() => setAcaoConfirm(null)}
+        selecionadosCount={selecionados.size}
+        justificativa={justificativa}
+        setJustificativa={setJustificativa}
+        onConfirm={executarAcao}
+        isPending={resolverMut.isPending}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Resumo

Quebra do god-component `src/pages/AdminReposicaoAlertas.tsx` (cockpit de triagem de alertas de outlier) — **845 → 369 linhas**. Refactor **comportamento-preservante 1:1**, novos módulos em `src/components/reposicao/alertas/`.

- **`types.ts`** — `PAGE_SIZE`, tipos (`EventoOutlier`, `OutlierStats`, `SkuInfo`, `ImpactoData`, `GrupoRow`, `AcaoConfirm`, `BadgeVariant`, `OutlierDetalhes`) + helpers `tipoLabel`/`fmt`.
- **`badges.tsx`** — `sevBadge`/`statusBadge`.
- **`StatsCards.tsx`** — grid de 6 KPIs.
- **`AlertasFiltros.tsx`** — busca + 3 selects + barra de ações em lote.
- **`AlertasTable.tsx`** — tabela + paginação.
- **`AlertaDrillSheet.tsx`** — Sheet de drill-down (contexto/SKU/histórico/impacto/decisão/atribuir grupo) com recharts + condicionais.
- **`ConfirmacaoDialog.tsx`** — confirmação de ação.

### Decisão de arquitetura

As 6 `useQuery` (stats/lista/historico/skuInfo/impacto/gruposFornecedor), as 2 `useMutation` (atribuirGrupo/resolver), os `useMemo` e os handlers permanecem **no pai**. A lógica inline de botões virou callbacks (`onAcao`/`onAtribuirGrupo`/`onAceitarLote`/`onConfirm`/etc.). Nenhuma mudança de `enabled`/timing de fetch.

## Garantias

- ✅ `bunx tsc --noEmit` — 0 erros.
- ✅ `bun lint` — 0 problemas nos arquivos tocados.
- ✅ Suíte: **563/563** passando.
- ✅ `bun run build` exit 0.
- ✅ +20 testes novos (7 arquivos): helpers, badges, render, estados vazios, filtros+lote, tabela (drill/checkbox/paginação), drill sheet (venda/sem-grupo, com stub de ResizeObserver p/ recharts), confirmação.
- ✅ Revisão independente (subagente): veredito **FIEL 1:1** — mapas de badge, condicionais do sheet, casts, RPC names e invalidateQueries byte-idênticos; callbacks reproduzem a lógica inline original.

## Test plan

- [x] tsc 0 erros / lint 0 problemas
- [x] 20 testes novos + suíte completa 563/563
- [x] build de produção exit 0
- [x] revisão independente confirma 1:1
- [ ] CI `validate` verde

🤖 Generated with [Claude Code](https://claude.com/claude-code)