### PR TITLE
refactor(edge-functions): zera lint errors restantes (Deno, lane isolada)

### DIFF
--- a/supabase/functions/analyze-unified-order/index.ts
+++ b/supabase/functions/analyze-unified-order/index.ts
@@ -457,7 +457,7 @@ serve(async (req) => {
               }
             }
           }
-        } catch (e) {}
+        } catch (_e) { /* erro ignorado de propósito */ }
       }
     }
 
@@ -1227,7 +1227,7 @@ Responda SEMPRE usando a função identify_order_items.`;
             ].filter(Boolean);
 
             // Get omie_codigo_produto mapping for identified products
-            let omieCodeMap: Record<number, string> = {}; // omie_codigo_produto → product_id
+            const omieCodeMap: Record<number, string> = {}; // omie_codigo_produto → product_id
             if (allProductIds.length > 0) {
               const { data: productMappings } = await supabase
                 .from("omie_products")

--- a/supabase/functions/enviar-pedido-portal-sayerlack/index.ts
+++ b/supabase/functions/enviar-pedido-portal-sayerlack/index.ts
@@ -2151,8 +2151,10 @@ Deno.serve(async (req) => {
       .catch((e) => {
         console.error("[envio-portal][async] Excecao geral:", e?.message ?? e);
       });
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment -- @ts-ignore intencional: EdgeRuntime é global do Deno/Supabase Edge (pode não estar tipado); @ts-expect-error quebraria o deploy se estivesse
     // @ts-ignore - EdgeRuntime existe no runtime do Supabase Edge
     if (typeof EdgeRuntime !== "undefined" && typeof EdgeRuntime.waitUntil === "function") {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment -- idem acima
       // @ts-ignore
       EdgeRuntime.waitUntil(bgTask);
     }

--- a/supabase/functions/omie-aplicar-parametros/index.ts
+++ b/supabase/functions/omie-aplicar-parametros/index.ts
@@ -106,7 +106,7 @@ Deno.serve(async (req) => {
     const body = await req.json();
     if (body?.empresa) empresa = String(body.empresa).toUpperCase();
     if (Array.isArray(body?.ids)) ids = body.ids.map((x: unknown) => Number(x)).filter(Boolean);
-  } catch (_) {}
+  } catch (_) { /* parse de body opcional */ }
 
   if (ids.length === 0) {
     return new Response(JSON.stringify({ error: "ids vazio" }), {

--- a/supabase/functions/omie-sync-status-produtos/index.ts
+++ b/supabase/functions/omie-sync-status-produtos/index.ts
@@ -94,7 +94,7 @@ Deno.serve(async (req) => {
       const body = await req.json().catch(() => ({}));
       if (body?.empresa) empresa = String(body.empresa).toUpperCase();
     }
-  } catch (_) {}
+  } catch (_) { /* parse de body opcional */ }
 
   const empresasPermitidas = new Set(["OBEN", "COLACOR"]);
   if (!empresasPermitidas.has(empresa)) {

--- a/supabase/functions/omie-webhook/index.ts
+++ b/supabase/functions/omie-webhook/index.ts
@@ -213,8 +213,10 @@ serve(async (req: Request) => {
     const { novo, id } = await registrarEvento(empresa, payload, eventId);
 
     if (novo && id) {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment -- @ts-ignore intencional: EdgeRuntime é global do Deno/Supabase Edge (pode não estar tipado); @ts-expect-error quebraria o deploy se estivesse
       // @ts-ignore EdgeRuntime existe no Supabase Edge Runtime
       if (typeof EdgeRuntime !== "undefined" && EdgeRuntime.waitUntil) {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment -- idem acima
         // @ts-ignore
         EdgeRuntime.waitUntil(processarEvento(empresa, payload, id));
       } else {

--- a/supabase/functions/tint-import/index.ts
+++ b/supabase/functions/tint-import/index.ts
@@ -150,7 +150,8 @@ async function processDadosCorantes(supabase: Supabase, rows: string[][], accoun
 
 // ─── Process dados_produto_base_embalagem ───
 async function processDadosProdutoBaseEmbalagem(supabase: Supabase, rows: string[][], account: string) {
-  let imported = 0, updated = 0, errors = 0;
+  let imported = 0, errors = 0;
+  const updated = 0;
   const errosDetalhe: Array<{ linha: number; motivo: string }> = [];
 
   for (let i = 0; i < rows.length; i++) {

--- a/supabase/functions/tint-sync-agent/index.ts
+++ b/supabase/functions/tint-sync-agent/index.ts
@@ -261,7 +261,8 @@ Deno.serve(async (req) => {
       const runId = await createSyncRun(agent, "catalogs");
       if (!runId) return json({ ok: false, error: "Failed to create sync run" }, 500);
 
-      let inserts = 0, updates = 0, ignored = 0, errors = 0;
+      let inserts = 0, errors = 0;
+      const updates = 0, ignored = 0;
       const errorDetails: { entity_type: string; entity_id: string | null; message: string }[] = [];
 
       const stagingTables: Record<string, { table: string; keyField: string }> = {
@@ -336,7 +337,8 @@ Deno.serve(async (req) => {
       const runId = await createSyncRun(agent, "formulas");
       if (!runId) return json({ ok: false, error: "Failed to create sync run" }, 500);
 
-      let inserts = 0, errors = 0, ignored = 0;
+      let inserts = 0, errors = 0;
+      const ignored = 0;
       const errorDetails: { entity_type: string; entity_id: string | null; message: string }[] = [];
       const formulas: TintFormulaPayload[] = (body.formulas as TintFormulaPayload[] | undefined) || [];
       const received = formulas.length;
@@ -416,7 +418,8 @@ Deno.serve(async (req) => {
       const runId = await createSyncRun(agent, "preparations");
       if (!runId) return json({ ok: false, error: "Failed to create sync run" }, 500);
 
-      let inserts = 0, errors = 0, ignored = 0;
+      let inserts = 0, errors = 0;
+      const ignored = 0;
       const errorDetails: { entity_type: string; entity_id: string | null; message: string }[] = [];
       const preps: TintPreparacaoPayload[] = (body.preparacoes as TintPreparacaoPayload[] | undefined) || [];
       const received = preps.length;
@@ -527,7 +530,7 @@ Deno.serve(async (req) => {
             descricao: c.descricao, preco_litro: c.preco_litro,
             raw_data: c, staging_status: "pending",
           });
-          error ? errors++ : inserts++;
+          if (error) { errors++; } else { inserts++; }
         }
 
         const { data: realFormulas } = await sb.from("tint_formulas")
@@ -565,7 +568,7 @@ Deno.serve(async (req) => {
             personalizada: false, raw_data: { ...f, _sim_index: i },
             staging_status: "pending",
           }).select("id").single();
-          fErr ? errors++ : inserts++;
+          if (fErr) { errors++; } else { inserts++; }
           if (fErr) debugLog.push(`ERROR staging formula ${f.cor_id}: ${fErr.message}`);
         }
 
@@ -580,7 +583,7 @@ Deno.serve(async (req) => {
             volume_final_ml: synth.volume_final_ml, preco_final: synth.preco_final,
             personalizada: false, raw_data: synth, staging_status: "pending",
           });
-          error ? errors++ : inserts++;
+          if (error) { errors++; } else { inserts++; }
           debugLog.push(`Synthetic formula ${synth.cor_id}: only_sync test`);
         }
 
@@ -597,7 +600,7 @@ Deno.serve(async (req) => {
             id_corante_sayersystem: c.id_corante_sayersystem, descricao: c.descricao,
             preco_litro: c.preco_litro, raw_data: c, staging_status: "pending",
           });
-          error ? errors++ : inserts++;
+          if (error) { errors++; } else { inserts++; }
         }
         const seedFormulas = [
           { cor_id: "SIM-COR-001", nome_cor: "Amarelo Sol", cod_produto: "SIM-CORAL", id_base: "BASE-A", id_embalagem: "EMB-900", volume_final_ml: 900, preco_final: 89.90, personalizada: false },
@@ -611,7 +614,7 @@ Deno.serve(async (req) => {
             volume_final_ml: f.volume_final_ml, preco_final: f.preco_final,
             personalizada: f.personalizada, raw_data: f, staging_status: "pending",
           }).select("id").single();
-          error ? errors++ : inserts++;
+          if (error) { errors++; } else { inserts++; }
         }
       }
 


### PR DESCRIPTION
## Lane isolada — zero colisão (parte A do plano)

Continuação da limpeza em `supabase/functions/` (Deno). **17→0 lint errors**, todos behavior-preserving:

- **prefer-const**: split de `let` multi-var onde só alguns contadores são reatribuídos (tint-import, tint-sync-agent ×3) + `omieCodeMap` (via `--fix`).
- **no-empty**: comentário em `catch` vazios (analyze-unified-order, omie-aplicar-parametros, omie-sync-status-produtos).
- **no-unused-expressions**: ternários-statement (`cond ? errors++ : inserts++`) → `if/else` (idêntico em runtime) no tint-sync-agent.
- **ban-ts-comment**: os `@ts-ignore` do `EdgeRuntime` (global do Deno/Supabase Edge) ficam com **eslint-disable justificado** — deliberadamente **não** trocados pra `@ts-expect-error`, que quebraria o typecheck do Deno no deploy se `EdgeRuntime` estiver tipado. Diretivas eslint são ignoradas pelo Deno → zero efeito em runtime/deploy.

## Garantias

- **Zero mudança de runtime** (splits de declaração, comentários, ternário→if/else idêntico, supressões de comment).
- **Lane não colide** com nenhuma sessão ativa (Deno, fora do `tsconfig.strict.json`, não importada por testes).
- `eslint supabase/functions` = **0 problemas**.

## Test plan

- [ ] CI `validate` — type-only/lint-only em arquivos Deno fora do typecheck:strict e dos testes. Auto-merge só com CI verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)