### PR TITLE
fix(customer-process): cast via unknown em etapas (corrige build do Lovable)

### DIFF
--- a/src/hooks/useCustomerProcess.ts
+++ b/src/hooks/useCustomerProcess.ts
@@ -20,7 +20,9 @@ export function useCustomerProcess(customerId: string | null) {
         .eq('is_current', true)
         .maybeSingle();
       if (error) throw error;
-      return (data as CustomerProcess) ?? null;
+      // etapas vem como Json do banco; CustomerProcess.etapas é ProcessEtapa[].
+      // Cast via unknown (mesmo padrão da linha do insert) — tipos não se sobrepõem.
+      return (data as unknown as CustomerProcess) ?? null;
     },
   });
 }
@@ -70,7 +72,7 @@ export function useSaveCustomerProcess() {
         .single();
 
       if (error) throw error;
-      return data as CustomerProcess;
+      return data as unknown as CustomerProcess;
     },
     onSuccess: (data, variables) => {
       qc.invalidateQueries({ queryKey: ['customer-process', variables.customerId] });


### PR DESCRIPTION
## Problema
Após a regeneração automática dos tipos do Supabase (disparada pela migration da Central de Telefonia), o build do Lovable quebrou com TS2352 em `useCustomerProcess.ts:23,73`:
`Conversion of type '{ ...; etapas: Json; ... }' to type 'CustomerProcess' may be a mistake` (`Json` não se sobrepõe a `ProcessEtapa[]`).

Causa: a PR #199 ("remove 12 casts as any das tabelas customer_*") removeu o `as any` que mascarava o mismatch de `etapas`. Com os tipos regenerados (`etapas: Json`), o cast direto `data as CustomerProcess` passou a falhar.

## Fix
Cast via `unknown` nas duas leituras (`data as unknown as CustomerProcess`) — mesmo padrão idiomático já usado no insert (linha 54, `as unknown as Json`). Não muda runtime; só satisfaz o typecheck contra os tipos regenerados.

## Validação
- `bunx tsc --noEmit` → 0 erros · `bun lint` (arquivo) → 0 erros
- Outros 3 arquivos do #199 (useCustomerContacts, useMyVisitSuggestions, resolve-customer) não erraram no build do Lovable — só este precisava.

🤖 Generated with [Claude Code](https://claude.com/claude-code)