### PR TITLE
refactor(types): remove 10 casts as any (farmer_*/commercial_roles/profiles)

### DIFF
--- a/src/components/call/IncomingCallModal.tsx
+++ b/src/components/call/IncomingCallModal.tsx
@@ -62,8 +62,8 @@ export function IncomingCallModal() {
         if (resolved.contactName) setContactName(resolved.contactName);
         if (resolved.contactCargo) setContactCargo(resolved.contactCargo);
         if (!resolved.customerUserId) return;
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const { data } = await (supabase.from('profiles') as any)
+         
+        const { data } = await supabase.from('profiles')
           .select('name, razao_social')
           .eq('user_id', resolved.customerUserId)
           .maybeSingle();

--- a/src/components/dashboard/AgendaTodayList.tsx
+++ b/src/components/dashboard/AgendaTodayList.tsx
@@ -31,8 +31,8 @@ export function AgendaTodayList() {
     enabled: agenda.length > 0,
     staleTime: 60_000,
     queryFn: async (): Promise<Record<string, { name: string; phone: string | null }>> => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const { data } = await (supabase.from('profiles') as any)
+       
+      const { data } = await supabase.from('profiles')
         .select('user_id, name, razao_social, phone')
         .in('user_id', agenda.map((a) => a.customer_user_id));
       const map: Record<string, { name: string; phone: string | null }> = {};

--- a/src/hooks/useIsTelefoniaManager.ts
+++ b/src/hooks/useIsTelefoniaManager.ts
@@ -8,8 +8,8 @@ export function useIsTelefoniaManager(): boolean {
   const { data } = useQuery({
     queryKey: ['commercial_role', user?.id], enabled: !!user?.id,
     queryFn: async () => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const { data } = await (supabase.from('commercial_roles') as any)
+       
+      const { data } = await supabase.from('commercial_roles')
         .select('commercial_role').eq('user_id', user!.id).maybeSingle();
       return data?.commercial_role as string | undefined;
     },

--- a/src/hooks/useLinkCallToCustomer.ts
+++ b/src/hooks/useLinkCallToCustomer.ts
@@ -6,8 +6,8 @@ export function useLinkCallToCustomer() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: async ({ callId, customerUserId }: { callId: string; customerUserId: string }) => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const { error } = await (supabase.from('farmer_calls') as any)
+       
+      const { error } = await supabase.from('farmer_calls')
         .update({ customer_user_id: customerUserId })
         .eq('id', callId);
       if (error) throw error;

--- a/src/hooks/useMyCarteiraScores.ts
+++ b/src/hooks/useMyCarteiraScores.ts
@@ -30,8 +30,8 @@ export function useMyCarteiraScores() {
     staleTime: 60_000,
     queryFn: async (): Promise<CarteiraScoreRow[]> => {
       if (!user) return [];
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const { data, error } = await (supabase.from('farmer_client_scores') as any)
+       
+      const { data, error } = await supabase.from('farmer_client_scores')
         .select('customer_user_id, health_score, health_class, priority_score, churn_risk, expansion_score, recover_score, revenue_potential, days_since_last_purchase, avg_monthly_spend_180d, signal_modifiers, last_signal_recalc_at')
         .eq('farmer_id', user.id)
         .order('priority_score', { ascending: false })

--- a/src/hooks/useMyCommercialRole.ts
+++ b/src/hooks/useMyCommercialRole.ts
@@ -29,8 +29,8 @@ export function useMyCommercialRole() {
     staleTime: 60_000,
     queryFn: async (): Promise<MyCommercialRole> => {
       if (!user) return null;
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const { data } = await (supabase.from('commercial_roles') as any)
+       
+      const { data } = await supabase.from('commercial_roles')
         .select('commercial_role')
         .eq('user_id', user.id)
         .maybeSingle();

--- a/src/hooks/useMyKpis.ts
+++ b/src/hooks/useMyKpis.ts
@@ -25,8 +25,8 @@ export function useMyKpis() {
       }
       const todayIso = new Date().toISOString().slice(0, 10);
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const { data: calls } = await (supabase.from('farmer_calls') as any)
+       
+      const { data: calls } = await supabase.from('farmer_calls')
         .select('revenue_generated, margin_generated')
         .eq('farmer_id', user.id)
         .gte('started_at', todayIso);
@@ -36,8 +36,8 @@ export function useMyKpis() {
       const margin = callsArr.reduce((s, c) => s + Number(c.margin_generated ?? 0), 0);
       const withRevenue = callsArr.filter((c) => Number(c.revenue_generated ?? 0) > 0);
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const { count: pending } = await (supabase.from('farmer_calls') as any)
+       
+      const { count: pending } = await supabase.from('farmer_calls')
         .select('id', { count: 'exact', head: true })
         .eq('farmer_id', user.id)
         .is('customer_user_id', null)

--- a/src/pages/FarmerCallsPendingLink.tsx
+++ b/src/pages/FarmerCallsPendingLink.tsx
@@ -41,8 +41,8 @@ export default function FarmerCallsPendingLink() {
     queryKey: ['farmer-pending-link', user?.id],
     enabled: !!user,
     queryFn: async (): Promise<Pending[]> => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const { data, error } = await (supabase.from('farmer_calls') as any)
+       
+      const { data, error } = await supabase.from('farmer_calls')
         .select('id, phone_dialed, started_at, duration_seconds')
         .eq('farmer_id', user!.id)
         .is('customer_user_id', null)
@@ -95,8 +95,8 @@ function PendingRow({
       // PostgREST .or() takes user-controlled `search`; escape commas and parens
       // to avoid breaking the filter syntax.
       const safe = search.replace(/[,()]/g, ' ');
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const { data } = await (supabase.from('profiles') as any)
+       
+      const { data } = await supabase.from('profiles')
         .select('user_id, name, phone')
         .or(`name.ilike.%${safe}%,phone.ilike.%${safe}%`)
         .limit(10);


### PR DESCRIPTION
## Resumo
Wave farmer_* do Item 1. Tabelas `farmer_calls`/`farmer_client_scores`/`commercial_roles` e `profiles` **já existem** no `types.ts` gerado — casts `(supabase.from('X') as any)` eram legado desnecessário. Removo 10 casts + `eslint-disable` órfãos:
- `farmer_calls`: useLinkCallToCustomer, useMyKpis (×2), FarmerCallsPendingLink
- `farmer_client_scores`: useMyCarteiraScores
- `commercial_roles`: useIsTelefoniaManager, useMyCommercialRole
- `profiles`: IncomingCallModal, AgendaTodayList, FarmerCallsPendingLink

**Sem fallout de strict** desta vez (queries não tinham issues de strictNullChecks).

## Validação
- `bun run typecheck:strict`: **0** · `bunx tsc --noEmit`: 0 · `bun run build`: OK · eslint: 0
- Codex review: **No findings** (cast removals runtime-idênticos, sem disables órfãos, nenhuma mudança de query/payload/fluxo)

> Progresso §10 `no-explicit-any`: ~75 → ~65. Próxima wave: standard_processes (padrão `(supabase as any).from`, 5 casts). Depois: Item 2 (JsSIP/deepgram).

🤖 Generated with [Claude Code](https://claude.com/claude-code)