### PR TITLE
refactor(reposicao): split god-component AdminReposicaoPromocoes (774→227)

### DIFF
--- a/src/components/reposicao/promocoes/CampanhasFiltros.tsx
+++ b/src/components/reposicao/promocoes/CampanhasFiltros.tsx
@@ -1,0 +1,58 @@
+// Filtros (estado/fornecedor/busca) da lista de campanhas (Promoções).
+// Extraído de src/pages/AdminReposicaoPromocoes.tsx (god-component split).
+import { Input } from "@/components/ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Search } from "lucide-react";
+import { ESTADOS, ALL } from "./types";
+
+export function CampanhasFiltros({
+  filtroEstado, setFiltroEstado, filtroFornecedor, setFiltroFornecedor, busca, setBusca, fornecedores,
+}: {
+  filtroEstado: string;
+  setFiltroEstado: (v: string) => void;
+  filtroFornecedor: string;
+  setFiltroFornecedor: (v: string) => void;
+  busca: string;
+  setBusca: (v: string) => void;
+  fornecedores: string[];
+}) {
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
+      <Select value={filtroEstado} onValueChange={setFiltroEstado}>
+        <SelectTrigger>
+          <SelectValue placeholder="Estado" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value={ALL}>Todos os estados</SelectItem>
+          {ESTADOS.map((e) => (
+            <SelectItem key={e.value} value={e.value}>
+              {e.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <Select value={filtroFornecedor} onValueChange={setFiltroFornecedor}>
+        <SelectTrigger>
+          <SelectValue placeholder="Fornecedor" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value={ALL}>Todos os fornecedores</SelectItem>
+          {fornecedores.map((f) => (
+            <SelectItem key={f} value={f}>
+              {f}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <div className="md:col-span-2 relative">
+        <Search className="h-4 w-4 absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          placeholder="Buscar por nome…"
+          className="pl-9"
+          value={busca}
+          onChange={(e) => setBusca(e.target.value)}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/reposicao/promocoes/CampanhasTable.tsx
+++ b/src/components/reposicao/promocoes/CampanhasTable.tsx
@@ -1,0 +1,130 @@
+// Tabela de campanhas agrupada por mês (com colapso) da página de Promoções.
+// Extraída de src/pages/AdminReposicaoPromocoes.tsx (god-component split).
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Loader2, Upload, ChevronDown, ChevronRight } from "lucide-react";
+import type { GrupoMensal } from "@/lib/agruparPorMes";
+import { confiancaBadge } from "./badges";
+import { ESTADOS, estadoBadgeClass, formatPeriodo, type CampanhaComContagem } from "./types";
+
+export function CampanhasTable({
+  isLoading, grupos, isCollapsed, toggleMes, onOpenUpload, onNavigate,
+}: {
+  isLoading: boolean;
+  grupos: GrupoMensal<CampanhaComContagem>[];
+  isCollapsed: (chave: string) => boolean;
+  toggleMes: (chave: string) => void;
+  onOpenUpload: () => void;
+  onNavigate: (id: number) => void;
+}) {
+  if (isLoading) {
+    return (
+      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+        <Loader2 className="h-4 w-4 animate-spin" /> Carregando…
+      </div>
+    );
+  }
+  if (grupos.length === 0) {
+    return (
+      <div className="text-center text-muted-foreground py-12 text-sm">
+        Nenhuma campanha cadastrada ainda.
+      </div>
+    );
+  }
+  return (
+    <div className="overflow-x-auto space-y-4">
+      {grupos.map((grupo) => {
+        const collapsed = isCollapsed(grupo.chave);
+        return (
+          <div key={grupo.chave} className="rounded-md border">
+            <button
+              type="button"
+              onClick={() => toggleMes(grupo.chave)}
+              className="w-full flex items-center justify-between gap-2 px-3 py-2 bg-muted/40 hover:bg-muted/60 transition-colors text-left"
+            >
+              <div className="flex items-center gap-2">
+                {collapsed ? (
+                  <ChevronRight className="h-4 w-4 text-muted-foreground" />
+                ) : (
+                  <ChevronDown className="h-4 w-4 text-muted-foreground" />
+                )}
+                <span className="font-semibold text-sm">{grupo.label}</span>
+                <Badge variant="outline" className="text-xs">
+                  {grupo.itens.length}{" "}
+                  {grupo.itens.length === 1 ? "campanha" : "campanhas"}
+                </Badge>
+              </div>
+            </button>
+
+            {!collapsed && (
+              grupo.vazio ? (
+                <div className="flex items-center justify-between gap-3 px-3 py-4 text-sm">
+                  <span className="text-muted-foreground">
+                    Nenhuma campanha cadastrada neste mês.
+                  </span>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={onOpenUpload}
+                  >
+                    <Upload className="h-3.5 w-3.5" /> Upload PDF
+                  </Button>
+                </div>
+              ) : (
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Nome</TableHead>
+                      <TableHead>Fornecedor</TableHead>
+                      <TableHead>Tipo</TableHead>
+                      <TableHead>Período</TableHead>
+                      <TableHead>Estado</TableHead>
+                      <TableHead className="text-right">Itens</TableHead>
+                      <TableHead>Confiança</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {grupo.itens.map((c) => (
+                      <TableRow
+                        key={c.id}
+                        className="cursor-pointer"
+                        onClick={() => onNavigate(c.id)}
+                      >
+                        <TableCell className="font-medium">{c.nome}</TableCell>
+                        <TableCell className="text-muted-foreground">
+                          {c.fornecedor_nome}
+                        </TableCell>
+                        <TableCell>
+                          {c.tipo_origem === "negociacao_cliente" ? (
+                            <Badge variant="outline" className="bg-status-info/15 text-status-info border-status-info/30">
+                              Negociação
+                            </Badge>
+                          ) : (
+                            <Badge variant="outline">Fornecedor</Badge>
+                          )}
+                        </TableCell>
+                        <TableCell className="tabular-nums text-sm">
+                          {formatPeriodo(c.data_inicio, c.data_fim)}
+                        </TableCell>
+                        <TableCell>
+                          <Badge variant="outline" className={estadoBadgeClass(c.estado)}>
+                            {ESTADOS.find((e) => e.value === c.estado)?.label ?? c.estado}
+                          </Badge>
+                        </TableCell>
+                        <TableCell className="text-right tabular-nums font-medium">
+                          {c.num_itens}
+                        </TableCell>
+                        <TableCell>{confiancaBadge(c.extracao_confianca)}</TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              )
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/reposicao/promocoes/UploadDialog.tsx
+++ b/src/components/reposicao/promocoes/UploadDialog.tsx
@@ -1,0 +1,188 @@
+// Modal de upload em lote de promoções (PDF/imagem → IA).
+// Extraído de src/pages/AdminReposicaoPromocoes.tsx (god-component split).
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Badge } from "@/components/ui/badge";
+import { Progress } from "@/components/ui/progress";
+import {
+  Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle, DialogDescription,
+} from "@/components/ui/dialog";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { Loader2, FileText, CheckCircle2, XCircle, Clock, RotateCw, X } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { useUploadPromocoes } from "./useUploadPromocoes";
+
+type UploadState = ReturnType<typeof useUploadPromocoes>;
+
+export function UploadDialog({
+  open, onOpenChange, upload, onIrParaLista, onCancelar,
+}: {
+  open: boolean;
+  onOpenChange: (o: boolean) => void;
+  upload: UploadState;
+  onIrParaLista: () => void;
+  onCancelar: () => void;
+}) {
+  const {
+    items, processando, fileInputRef, handleFileChange, removerItem, tentarNovamente, iniciarProcessamento,
+    totalItens, concluidos, comErro, aguardando, emProcesso, finalizados, progresso, todosFinalizados, podeIniciar,
+  } = upload;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Upload de promoções (lote)</DialogTitle>
+          <DialogDescription>
+            Selecione um ou mais PDFs/imagens da promoção do fornecedor. A IA extrai
+            nome, datas e itens automaticamente. Cada arquivo gera uma campanha em rascunho.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3">
+          <Input
+            ref={fileInputRef}
+            type="file"
+            multiple
+            accept=".pdf,.png,.jpg,.jpeg,application/pdf,image/png,image/jpeg"
+            onChange={handleFileChange}
+            disabled={processando}
+          />
+
+          {totalItens > 0 && (
+            <div className="space-y-2">
+              <div className="flex items-center justify-between text-xs">
+                <span className="text-muted-foreground">
+                  {finalizados} de {totalItens} processados
+                  {emProcesso > 0 && ` · ${emProcesso} em andamento`}
+                </span>
+                <span className="font-medium tabular-nums">{progresso}%</span>
+              </div>
+              <Progress value={progresso} className="h-2" />
+            </div>
+          )}
+
+          {totalItens > 0 && (
+            <TooltipProvider>
+              <div className="max-h-72 overflow-y-auto rounded-md border divide-y">
+                {items.map((it) => (
+                  <div key={it.id} className="flex items-center gap-2 p-2 text-sm">
+                    <FileText className="h-4 w-4 text-muted-foreground shrink-0" />
+                    <div className="min-w-0 flex-1">
+                      <p className="truncate font-medium">{it.file.name}</p>
+                      <p className="text-xs text-muted-foreground">
+                        {(it.file.size / 1024).toFixed(1)} KB
+                        {it.status === "concluido" && it.nomeCampanha && (
+                          <> · {it.nomeCampanha} · {it.itensExtraidos} {it.itensExtraidos === 1 ? "item" : "itens"}</>
+                        )}
+                        {it.status === "erro" && it.erro && (
+                          <span className="text-destructive"> · Extração falhou: {it.erro}</span>
+                        )}
+                      </p>
+                    </div>
+
+                    {it.status === "aguardando" && (
+                      <Badge variant="outline" className="gap-1">
+                        <Clock className="h-3 w-3" /> Aguardando
+                      </Badge>
+                    )}
+                    {it.status === "processando" && (
+                      <Badge variant="outline" className="gap-1 bg-status-info/15 text-status-info border-status-info/30">
+                        <Loader2 className="h-3 w-3 animate-spin" /> Processando
+                      </Badge>
+                    )}
+                    {it.status === "concluido" && (
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Badge
+                            variant="outline"
+                            className={cn(
+                              "gap-1 cursor-help",
+                              "bg-status-success/15 text-status-success border-status-success/30",
+                            )}
+                          >
+                            <CheckCircle2 className="h-3 w-3" /> Concluído
+                          </Badge>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          {it.confianca !== null && it.confianca !== undefined
+                            ? `Confiança Gemini: ${Math.round(it.confianca * 100)}%`
+                            : "Confiança não informada"}
+                        </TooltipContent>
+                      </Tooltip>
+                    )}
+                    {it.status === "erro" && (
+                      <Badge variant="outline" className="gap-1 bg-destructive/15 text-destructive border-destructive/30">
+                        <XCircle className="h-3 w-3" /> Erro
+                      </Badge>
+                    )}
+
+                    {it.status === "erro" && !processando && (
+                      <Button
+                        size="icon"
+                        variant="ghost"
+                        className="h-7 w-7"
+                        onClick={() => tentarNovamente(it.id)}
+                        title="Tentar novamente"
+                      >
+                        <RotateCw className="h-3.5 w-3.5" />
+                      </Button>
+                    )}
+                    {(it.status === "aguardando" || it.status === "erro") && !processando && (
+                      <Button
+                        size="icon"
+                        variant="ghost"
+                        className="h-7 w-7"
+                        onClick={() => removerItem(it.id)}
+                        title="Remover"
+                      >
+                        <X className="h-3.5 w-3.5" />
+                      </Button>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </TooltipProvider>
+          )}
+
+          {todosFinalizados && (
+            <div className="rounded-md border bg-muted/40 p-3 text-sm">
+              <p className="font-medium">
+                {concluidos} de {totalItens}{" "}
+                {totalItens === 1 ? "campanha criada" : "campanhas criadas"} com sucesso.
+                {comErro > 0 && (
+                  <span className="text-destructive">
+                    {" "}{comErro} {comErro === 1 ? "campanha" : "campanhas"} com erro.
+                  </span>
+                )}
+              </p>
+              <p className="mt-1 text-xs text-muted-foreground">
+                As campanhas ficam em rascunho. Acesse a lista para revisar e ativar.
+              </p>
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          {todosFinalizados ? (
+            <Button onClick={onIrParaLista}>
+              Ir para lista
+            </Button>
+          ) : (
+            <>
+              <Button variant="ghost" onClick={onCancelar} disabled={processando}>
+                {processando ? "Processando…" : "Cancelar"}
+              </Button>
+              <Button onClick={iniciarProcessamento} disabled={!podeIniciar}>
+                {processando && <Loader2 className="h-4 w-4 animate-spin" />}
+                {comErro > 0 && aguardando === 0
+                  ? `Tentar novamente (${comErro})`
+                  : `Processar ${aguardando + comErro} ${aguardando + comErro === 1 ? "arquivo" : "arquivos"}`}
+              </Button>
+            </>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/reposicao/promocoes/__tests__/CampanhasFiltros.test.tsx
+++ b/src/components/reposicao/promocoes/__tests__/CampanhasFiltros.test.tsx
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { CampanhasFiltros } from "../CampanhasFiltros";
+
+function noop() { /* */ }
+
+describe("CampanhasFiltros", () => {
+  it("renderiza a busca e os fornecedores fornecidos", () => {
+    render(
+      <CampanhasFiltros
+        filtroEstado="__all__" setFiltroEstado={noop}
+        filtroFornecedor="__all__" setFiltroFornecedor={noop}
+        busca="" setBusca={noop}
+        fornecedores={["ACME", "RENNER SAYERLACK S/A"]}
+      />
+    );
+    expect(screen.getByPlaceholderText("Buscar por nome…")).toBeTruthy();
+  });
+
+  it("digitar na busca chama setBusca", () => {
+    const setBusca = vi.fn();
+    render(
+      <CampanhasFiltros
+        filtroEstado="__all__" setFiltroEstado={noop}
+        filtroFornecedor="__all__" setFiltroFornecedor={noop}
+        busca="" setBusca={setBusca}
+        fornecedores={[]}
+      />
+    );
+    fireEvent.change(screen.getByPlaceholderText("Buscar por nome…"), { target: { value: "promo" } });
+    expect(setBusca).toHaveBeenCalledWith("promo");
+  });
+});

--- a/src/components/reposicao/promocoes/__tests__/CampanhasTable.test.tsx
+++ b/src/components/reposicao/promocoes/__tests__/CampanhasTable.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { CampanhasTable } from "../CampanhasTable";
+import type { GrupoMensal } from "@/lib/agruparPorMes";
+import type { CampanhaComContagem } from "../types";
+
+const campanha: CampanhaComContagem = {
+  id: 7, nome: "Promo Verão", fornecedor_nome: "ACME", tipo_origem: "fornecedor_impoe",
+  data_inicio: "2026-01-05", data_fim: "2026-01-20", estado: "rascunho",
+  extracao_confianca: 0.9, criado_em: "2026-01-01", num_itens: 3,
+};
+
+const grupos: GrupoMensal<CampanhaComContagem>[] = [
+  { chave: "2026-01", label: "Janeiro 2026", itens: [campanha], vazio: false },
+  { chave: "2026-02", label: "Fevereiro 2026", itens: [], vazio: true },
+];
+
+function noop() { /* */ }
+
+describe("CampanhasTable", () => {
+  it("loading → Carregando…", () => {
+    render(<CampanhasTable isLoading grupos={[]} isCollapsed={() => false} toggleMes={noop} onOpenUpload={noop} onNavigate={noop} />);
+    expect(screen.getByText("Carregando…")).toBeTruthy();
+  });
+
+  it("sem grupos → mensagem de vazio", () => {
+    render(<CampanhasTable isLoading={false} grupos={[]} isCollapsed={() => false} toggleMes={noop} onOpenUpload={noop} onNavigate={noop} />);
+    expect(screen.getByText("Nenhuma campanha cadastrada ainda.")).toBeTruthy();
+  });
+
+  it("grupos expandidos → campanha, estado, itens, confiança; clique navega", () => {
+    const onNavigate = vi.fn();
+    render(<CampanhasTable isLoading={false} grupos={grupos} isCollapsed={() => false} toggleMes={noop} onOpenUpload={noop} onNavigate={onNavigate} />);
+    expect(screen.getByText("Janeiro 2026")).toBeTruthy();
+    expect(screen.getByText("Promo Verão")).toBeTruthy();
+    expect(screen.getByText("ACME")).toBeTruthy();
+    expect(screen.getByText("Rascunho")).toBeTruthy();
+    expect(screen.getByText("3")).toBeTruthy();
+    expect(screen.getByText("90%")).toBeTruthy();
+    // mês vazio expandido
+    expect(screen.getByText("Nenhuma campanha cadastrada neste mês.")).toBeTruthy();
+    fireEvent.click(screen.getByText("Promo Verão"));
+    expect(onNavigate).toHaveBeenCalledWith(7);
+  });
+
+  it("clicar cabeçalho do mês chama toggleMes; upload no mês vazio chama onOpenUpload", () => {
+    const toggleMes = vi.fn();
+    const onOpenUpload = vi.fn();
+    render(<CampanhasTable isLoading={false} grupos={grupos} isCollapsed={() => false} toggleMes={toggleMes} onOpenUpload={onOpenUpload} onNavigate={noop} />);
+    fireEvent.click(screen.getByText("Janeiro 2026"));
+    expect(toggleMes).toHaveBeenCalledWith("2026-01");
+    fireEvent.click(screen.getByRole("button", { name: /Upload PDF/ }));
+    expect(onOpenUpload).toHaveBeenCalled();
+  });
+});

--- a/src/components/reposicao/promocoes/__tests__/UploadDialog.test.tsx
+++ b/src/components/reposicao/promocoes/__tests__/UploadDialog.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi } from "vitest";
+import { createRef } from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { UploadDialog } from "../UploadDialog";
+import type { useUploadPromocoes } from "../useUploadPromocoes";
+import type { UploadItem } from "../types";
+
+type UploadState = ReturnType<typeof useUploadPromocoes>;
+
+function mkUpload(over: Partial<UploadState> = {}): UploadState {
+  return {
+    items: [],
+    processando: false,
+    fileInputRef: createRef<HTMLInputElement>(),
+    handleFileChange: vi.fn(),
+    removerItem: vi.fn(),
+    resetUpload: vi.fn(),
+    iniciarProcessamento: vi.fn(),
+    tentarNovamente: vi.fn(),
+    totalItens: 0,
+    concluidos: 0,
+    comErro: 0,
+    aguardando: 0,
+    emProcesso: 0,
+    finalizados: 0,
+    progresso: 0,
+    todosFinalizados: false,
+    podeIniciar: false,
+    ...over,
+  } as unknown as UploadState;
+}
+
+const aguardandoItem: UploadItem = {
+  id: "i1",
+  file: new File(["x"], "promo.pdf", { type: "application/pdf" }),
+  status: "aguardando",
+};
+
+function noop() { /* */ }
+
+describe("UploadDialog", () => {
+  it("vazio → input de arquivo e botão Processar (desabilitado)", () => {
+    render(<UploadDialog open onOpenChange={noop} upload={mkUpload()} onIrParaLista={noop} onCancelar={noop} />);
+    expect(screen.getByText("Upload de promoções (lote)")).toBeTruthy();
+    expect(screen.getByText("Cancelar")).toBeTruthy();
+  });
+
+  it("com 1 aguardando → Processar habilita e dispara iniciarProcessamento; Cancelar chama onCancelar", () => {
+    const iniciarProcessamento = vi.fn();
+    const onCancelar = vi.fn();
+    const upload = mkUpload({ items: [aguardandoItem], totalItens: 1, aguardando: 1, podeIniciar: true, iniciarProcessamento });
+    render(<UploadDialog open onOpenChange={noop} upload={upload} onIrParaLista={noop} onCancelar={onCancelar} />);
+    expect(screen.getByText("promo.pdf")).toBeTruthy();
+    expect(screen.getByText("Aguardando")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: /Processar 1 arquivo/ }));
+    expect(iniciarProcessamento).toHaveBeenCalled();
+    fireEvent.click(screen.getByRole("button", { name: "Cancelar" }));
+    expect(onCancelar).toHaveBeenCalled();
+  });
+
+  it("todos finalizados → resumo e botão 'Ir para lista' dispara onIrParaLista", () => {
+    const onIrParaLista = vi.fn();
+    const upload = mkUpload({
+      items: [{ ...aguardandoItem, status: "concluido", nomeCampanha: "Promo X", itensExtraidos: 4, confianca: 0.9 }],
+      totalItens: 1, concluidos: 1, finalizados: 1, progresso: 100, todosFinalizados: true,
+    });
+    render(<UploadDialog open onOpenChange={noop} upload={upload} onIrParaLista={onIrParaLista} onCancelar={noop} />);
+    expect(screen.getByText("Concluído")).toBeTruthy();
+    expect(screen.getByText(/1 de 1 campanha criada com sucesso/)).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Ir para lista" }));
+    expect(onIrParaLista).toHaveBeenCalled();
+  });
+});

--- a/src/components/reposicao/promocoes/__tests__/badges.test.tsx
+++ b/src/components/reposicao/promocoes/__tests__/badges.test.tsx
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { confiancaBadge } from "../badges";
+
+describe("confiancaBadge", () => {
+  it("null/undefined → não renderiza", () => {
+    expect(confiancaBadge(null)).toBeNull();
+    expect(confiancaBadge(undefined as unknown as number)).toBeNull();
+  });
+
+  it("renderiza percentual arredondado", () => {
+    render(<div>{confiancaBadge(0.876)}</div>);
+    expect(screen.getByText("88%")).toBeTruthy();
+  });
+
+  it("faixas de confiança mudam a classe", () => {
+    const { container: low } = render(<div>{confiancaBadge(0.3)}</div>);
+    expect(low.querySelector(".text-destructive")).toBeTruthy();
+    const { container: mid } = render(<div>{confiancaBadge(0.7)}</div>);
+    expect(mid.querySelector(".text-status-warning")).toBeTruthy();
+    const { container: high } = render(<div>{confiancaBadge(0.95)}</div>);
+    expect(high.querySelector(".text-status-success")).toBeTruthy();
+  });
+});

--- a/src/components/reposicao/promocoes/__tests__/types.test.ts
+++ b/src/components/reposicao/promocoes/__tests__/types.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { estadoBadgeClass, formatPeriodo, ESTADOS, EMPRESA, ALL } from "../types";
+
+describe("estadoBadgeClass", () => {
+  it("retorna classes por estado e vazio para desconhecido", () => {
+    expect(estadoBadgeClass("rascunho")).toContain("status-warning");
+    expect(estadoBadgeClass("negociando")).toContain("status-info");
+    expect(estadoBadgeClass("ativa")).toContain("status-success");
+    expect(estadoBadgeClass("encerrada")).toContain("muted");
+    expect(estadoBadgeClass("cancelada")).toContain("destructive");
+    expect(estadoBadgeClass("zzz")).toBe("");
+  });
+});
+
+describe("formatPeriodo", () => {
+  it("formata dd/mm/aa – dd/mm/aa", () => {
+    expect(formatPeriodo("2026-01-05", "2026-01-20")).toBe("05/01/26 – 20/01/26");
+  });
+});
+
+describe("constantes", () => {
+  it("EMPRESA, ALL e ESTADOS", () => {
+    expect(EMPRESA).toBe("OBEN");
+    expect(ALL).toBe("__all__");
+    expect(ESTADOS.map((e) => e.value)).toEqual(["rascunho", "negociando", "ativa", "encerrada", "cancelada"]);
+  });
+});

--- a/src/components/reposicao/promocoes/__tests__/useUploadPromocoes.test.ts
+++ b/src/components/reposicao/promocoes/__tests__/useUploadPromocoes.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useUploadPromocoes } from "../useUploadPromocoes";
+
+function fileEvent(files: File[]) {
+  return { target: { files } } as unknown as React.ChangeEvent<HTMLInputElement>;
+}
+
+describe("useUploadPromocoes", () => {
+  it("estado inicial vazio e podeIniciar=false", () => {
+    const { result } = renderHook(() => useUploadPromocoes(vi.fn()));
+    expect(result.current.items).toEqual([]);
+    expect(result.current.totalItens).toBe(0);
+    expect(result.current.podeIniciar).toBe(false);
+    expect(result.current.todosFinalizados).toBe(false);
+  });
+
+  it("handleFileChange adiciona itens aguardando e habilita podeIniciar", () => {
+    const { result } = renderHook(() => useUploadPromocoes(vi.fn()));
+    const f = new File(["x"], "promo.pdf", { type: "application/pdf" });
+    act(() => result.current.handleFileChange(fileEvent([f])));
+    expect(result.current.totalItens).toBe(1);
+    expect(result.current.aguardando).toBe(1);
+    expect(result.current.items[0].status).toBe("aguardando");
+    expect(result.current.podeIniciar).toBe(true);
+  });
+
+  it("removerItem e resetUpload limpam a fila", () => {
+    const { result } = renderHook(() => useUploadPromocoes(vi.fn()));
+    const f1 = new File(["a"], "a.pdf", { type: "application/pdf" });
+    const f2 = new File(["b"], "b.pdf", { type: "application/pdf" });
+    act(() => result.current.handleFileChange(fileEvent([f1, f2])));
+    expect(result.current.totalItens).toBe(2);
+    const id0 = result.current.items[0].id;
+    act(() => result.current.removerItem(id0));
+    expect(result.current.totalItens).toBe(1);
+    act(() => result.current.resetUpload());
+    expect(result.current.totalItens).toBe(0);
+  });
+});

--- a/src/components/reposicao/promocoes/badges.tsx
+++ b/src/components/reposicao/promocoes/badges.tsx
@@ -1,0 +1,15 @@
+// Badge de confiança da extração (Promoções).
+// Extraído de src/pages/AdminReposicaoPromocoes.tsx (god-component split).
+import { Badge } from "@/components/ui/badge";
+
+export function confiancaBadge(c: number | null) {
+  if (c === null || c === undefined) return null;
+  let cls = "bg-status-success/15 text-status-success border-status-success/30";
+  if (c < 0.5) cls = "bg-destructive/15 text-destructive border-destructive/30";
+  else if (c <= 0.8) cls = "bg-status-warning/15 text-status-warning border-status-warning/30";
+  return (
+    <Badge variant="outline" className={cls}>
+      {Math.round(c * 100)}%
+    </Badge>
+  );
+}

--- a/src/components/reposicao/promocoes/types.ts
+++ b/src/components/reposicao/promocoes/types.ts
@@ -1,0 +1,67 @@
+// Tipos, constantes e helpers puros da página de Promoções (AdminReposicaoPromocoes).
+// Extraídos de src/pages/AdminReposicaoPromocoes.tsx (god-component split).
+
+export const MAX_CONCURRENT = 3;
+export const EMPRESA = "OBEN";
+export const FORNECEDOR_DEFAULT = "RENNER SAYERLACK S/A";
+export const ALL = "__all__";
+
+export type UploadStatus = "aguardando" | "processando" | "concluido" | "erro";
+
+export type UploadItem = {
+  id: string;
+  file: File;
+  status: UploadStatus;
+  campanhaId?: number;
+  nomeCampanha?: string;
+  itensExtraidos?: number;
+  confianca?: number | null;
+  erro?: string;
+};
+
+export type Campanha = {
+  id: number;
+  nome: string;
+  fornecedor_nome: string;
+  tipo_origem: string;
+  data_inicio: string;
+  data_fim: string;
+  estado: string;
+  extracao_confianca: number | null;
+  criado_em: string;
+};
+
+export type CampanhaComContagem = Campanha & { num_itens: number };
+
+export const ESTADOS: Array<{ value: string; label: string }> = [
+  { value: "rascunho", label: "Rascunho" },
+  { value: "negociando", label: "Negociando" },
+  { value: "ativa", label: "Ativa" },
+  { value: "encerrada", label: "Encerrada" },
+  { value: "cancelada", label: "Cancelada" },
+];
+
+export function estadoBadgeClass(estado: string): string {
+  switch (estado) {
+    case "rascunho":
+      return "bg-status-warning/15 text-status-warning border-status-warning/30";
+    case "negociando":
+      return "bg-status-info/15 text-status-info border-status-info/30";
+    case "ativa":
+      return "bg-status-success/15 text-status-success border-status-success/30";
+    case "encerrada":
+      return "bg-muted text-muted-foreground border-border";
+    case "cancelada":
+      return "bg-destructive/15 text-destructive border-destructive/30";
+    default:
+      return "";
+  }
+}
+
+export function formatPeriodo(inicio: string, fim: string): string {
+  const fmt = (d: string) => {
+    const [y, m, day] = d.split("-");
+    return `${day}/${m}/${y.slice(2)}`;
+  };
+  return `${fmt(inicio)} – ${fmt(fim)}`;
+}

--- a/src/components/reposicao/promocoes/useUploadPromocoes.ts
+++ b/src/components/reposicao/promocoes/useUploadPromocoes.ts
@@ -1,0 +1,164 @@
+// Hook com a lógica de upload em lote de promoções (FileReader + pool de
+// concorrência + retry + contadores). Extraído de src/pages/AdminReposicaoPromocoes.tsx.
+import { useState, useRef, useCallback } from "react";
+import { supabase } from "@/integrations/supabase/client";
+import { MAX_CONCURRENT, EMPRESA, FORNECEDOR_DEFAULT, type UploadItem } from "./types";
+
+/** `onProcessed` é chamado após cada rodada de processamento (para invalidar a lista). */
+export function useUploadPromocoes(onProcessed: () => void) {
+  const [items, setItems] = useState<UploadItem[]>([]);
+  const [processando, setProcessando] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(e.target.files ?? []);
+    if (files.length === 0) return;
+    const novos: UploadItem[] = files.map((f) => ({
+      id: `${f.name}-${f.size}-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+      file: f,
+      status: "aguardando",
+    }));
+    setItems((prev) => [...prev, ...novos]);
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  };
+
+  const removerItem = (id: string) => {
+    setItems((prev) => prev.filter((i) => i.id !== id));
+  };
+
+  const resetUpload = () => {
+    setItems([]);
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  };
+
+  const updateItem = useCallback((id: string, patch: Partial<UploadItem>) => {
+    setItems((prev) => prev.map((i) => (i.id === id ? { ...i, ...patch } : i)));
+  }, []);
+
+  const processarArquivo = useCallback(
+    async (item: UploadItem): Promise<void> => {
+      updateItem(item.id, { status: "processando", erro: undefined });
+      try {
+        const base64 = await new Promise<string>((resolve, reject) => {
+          const reader = new FileReader();
+          reader.onload = () => {
+            const result = reader.result as string;
+            const idx = result.indexOf(",");
+            resolve(idx >= 0 ? result.slice(idx + 1) : result);
+          };
+          reader.onerror = () => reject(reader.error);
+          reader.readAsDataURL(item.file);
+        });
+
+        const arquivo_tipo =
+          item.file.type === "application/pdf" ? "pdf" : item.file.type;
+
+        const { data, error } = await supabase.functions.invoke(
+          "promocao-extrair-via-vision",
+          {
+            body: {
+              empresa: EMPRESA,
+              fornecedor_nome: FORNECEDOR_DEFAULT,
+              arquivo_tipo,
+              arquivo_base64: base64,
+            },
+          },
+        );
+
+        if (error) throw error;
+        if (data?.error) throw new Error(data.error);
+
+        const campanhaId: number | undefined = data?.campanha_id;
+        const itensExtraidos =
+          data?.extracao?.items_extraidos ?? data?.items?.length ?? 0;
+        const confianca: number | null =
+          data?.extracao?.confianca ?? data?.confianca ?? null;
+
+        // Confirma propagação para evitar race com a lista
+        let nomeCampanha = "Campanha";
+        if (campanhaId) {
+          for (let i = 0; i < 6; i++) {
+            const { data: row } = await supabase
+              .from("promocao_campanha")
+              .select("nome")
+              .eq("id", campanhaId)
+              .maybeSingle();
+            const typedRow = row as { nome: string | null } | null;
+            if (typedRow && typedRow.nome) {
+              nomeCampanha = typedRow.nome;
+              break;
+            }
+            await new Promise((r) => setTimeout(r, 250));
+          }
+        }
+
+        updateItem(item.id, {
+          status: "concluido",
+          campanhaId,
+          nomeCampanha,
+          itensExtraidos,
+          confianca,
+        });
+      } catch (e) {
+        updateItem(item.id, {
+          status: "erro",
+          erro: e instanceof Error ? e.message : String(e),
+        });
+      }
+    },
+    [updateItem],
+  );
+
+  const iniciarProcessamento = async () => {
+    const fila = items.filter((i) => i.status === "aguardando" || i.status === "erro");
+    if (fila.length === 0) return;
+    setProcessando(true);
+
+    // Marca toda a fila como aguardando (caso haja "erro" sendo retentado)
+    fila.forEach((it) => {
+      if (it.status === "erro") updateItem(it.id, { status: "aguardando", erro: undefined });
+    });
+
+    // Pool de concorrência simples (até MAX_CONCURRENT em paralelo)
+    let cursor = 0;
+    const next = async (): Promise<void> => {
+      const idx = cursor++;
+      if (idx >= fila.length) return;
+      await processarArquivo(fila[idx]);
+      return next();
+    };
+    const workers = Array.from(
+      { length: Math.min(MAX_CONCURRENT, fila.length) },
+      () => next(),
+    );
+    await Promise.all(workers);
+
+    setProcessando(false);
+    onProcessed();
+  };
+
+  const tentarNovamente = async (id: string) => {
+    const it = items.find((x) => x.id === id);
+    if (!it) return;
+    setProcessando(true);
+    await processarArquivo(it);
+    setProcessando(false);
+    onProcessed();
+  };
+
+  const totalItens = items.length;
+  const concluidos = items.filter((i) => i.status === "concluido").length;
+  const comErro = items.filter((i) => i.status === "erro").length;
+  const aguardando = items.filter((i) => i.status === "aguardando").length;
+  const emProcesso = items.filter((i) => i.status === "processando").length;
+  const finalizados = concluidos + comErro;
+  const progresso = totalItens > 0 ? Math.round((finalizados / totalItens) * 100) : 0;
+  const todosFinalizados = totalItens > 0 && finalizados === totalItens && !processando;
+  const podeIniciar = !processando && (aguardando > 0 || (comErro > 0 && emProcesso === 0));
+
+  return {
+    items, processando, fileInputRef,
+    handleFileChange, removerItem, resetUpload, iniciarProcessamento, tentarNovamente,
+    totalItens, concluidos, comErro, aguardando, emProcesso, finalizados, progresso, todosFinalizados, podeIniciar,
+  };
+}

--- a/src/pages/AdminReposicaoPromocoes.tsx
+++ b/src/pages/AdminReposicaoPromocoes.tsx
@@ -1,139 +1,17 @@
-import { useState, useRef, useMemo, useCallback } from "react";
+import { useState, useMemo, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
 import { toast } from "sonner";
-import {
-  Percent,
-  Search,
-  Loader2,
-  Upload,
-  FilePlus,
-  Handshake,
-  AlertTriangle,
-  FileText,
-  CheckCircle2,
-  XCircle,
-  Clock,
-  RotateCw,
-  X,
-  ChevronDown,
-  ChevronRight,
-} from "lucide-react";
+import { Percent, Upload, FilePlus, Handshake, AlertTriangle } from "lucide-react";
 import { agruparPorMes, chavesUltimosNMeses } from "@/lib/agruparPorMes";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import { Input } from "@/components/ui/input";
-import {
-  Dialog,
-  DialogContent,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-  DialogDescription,
-} from "@/components/ui/dialog";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
-import { Progress } from "@/components/ui/progress";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
-import { cn } from "@/lib/utils";
-
-const MAX_CONCURRENT = 3;
-
-type UploadStatus = "aguardando" | "processando" | "concluido" | "erro";
-
-type UploadItem = {
-  id: string;
-  file: File;
-  status: UploadStatus;
-  campanhaId?: number;
-  nomeCampanha?: string;
-  itensExtraidos?: number;
-  confianca?: number | null;
-  erro?: string;
-};
-
-const EMPRESA = "OBEN";
-const FORNECEDOR_DEFAULT = "RENNER SAYERLACK S/A";
-const ALL = "__all__";
-
-type Campanha = {
-  id: number;
-  nome: string;
-  fornecedor_nome: string;
-  tipo_origem: string;
-  data_inicio: string;
-  data_fim: string;
-  estado: string;
-  extracao_confianca: number | null;
-  criado_em: string;
-};
-
-type CampanhaComContagem = Campanha & { num_itens: number };
-
-const ESTADOS: Array<{ value: string; label: string }> = [
-  { value: "rascunho", label: "Rascunho" },
-  { value: "negociando", label: "Negociando" },
-  { value: "ativa", label: "Ativa" },
-  { value: "encerrada", label: "Encerrada" },
-  { value: "cancelada", label: "Cancelada" },
-];
-
-function estadoBadgeClass(estado: string): string {
-  switch (estado) {
-    case "rascunho":
-      return "bg-status-warning/15 text-status-warning border-status-warning/30";
-    case "negociando":
-      return "bg-status-info/15 text-status-info border-status-info/30";
-    case "ativa":
-      return "bg-status-success/15 text-status-success border-status-success/30";
-    case "encerrada":
-      return "bg-muted text-muted-foreground border-border";
-    case "cancelada":
-      return "bg-destructive/15 text-destructive border-destructive/30";
-    default:
-      return "";
-  }
-}
-
-function confiancaBadge(c: number | null) {
-  if (c === null || c === undefined) return null;
-  let cls = "bg-status-success/15 text-status-success border-status-success/30";
-  if (c < 0.5) cls = "bg-destructive/15 text-destructive border-destructive/30";
-  else if (c <= 0.8) cls = "bg-status-warning/15 text-status-warning border-status-warning/30";
-  return (
-    <Badge variant="outline" className={cls}>
-      {Math.round(c * 100)}%
-    </Badge>
-  );
-}
-
-function formatPeriodo(inicio: string, fim: string): string {
-  const fmt = (d: string) => {
-    const [y, m, day] = d.split("-");
-    return `${day}/${m}/${y.slice(2)}`;
-  };
-  return `${fmt(inicio)} – ${fmt(fim)}`;
-}
+import { EMPRESA, ALL, type Campanha, type CampanhaComContagem } from "@/components/reposicao/promocoes/types";
+import { useUploadPromocoes } from "@/components/reposicao/promocoes/useUploadPromocoes";
+import { CampanhasFiltros } from "@/components/reposicao/promocoes/CampanhasFiltros";
+import { CampanhasTable } from "@/components/reposicao/promocoes/CampanhasTable";
+import { UploadDialog } from "@/components/reposicao/promocoes/UploadDialog";
 
 export default function AdminReposicaoPromocoes() {
   const navigate = useNavigate();
@@ -143,13 +21,7 @@ export default function AdminReposicaoPromocoes() {
   const [filtroFornecedor, setFiltroFornecedor] = useState<string>(ALL);
   const [busca, setBusca] = useState("");
 
-
-
-  // Upload modal — múltiplos arquivos
   const [uploadOpen, setUploadOpen] = useState(false);
-  const [items, setItems] = useState<UploadItem[]>([]);
-  const [processando, setProcessando] = useState(false);
-  const fileInputRef = useRef<HTMLInputElement>(null);
 
   // ============ QUERIES ============
   const { data: campanhas = [], isLoading } = useQuery({
@@ -231,156 +103,23 @@ export default function AdminReposicaoPromocoes() {
   }, []);
 
   // ============ UPLOAD MULTIPLO ============
-  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const files = Array.from(e.target.files ?? []);
-    if (files.length === 0) return;
-    const novos: UploadItem[] = files.map((f) => ({
-      id: `${f.name}-${f.size}-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
-      file: f,
-      status: "aguardando",
-    }));
-    setItems((prev) => [...prev, ...novos]);
-    if (fileInputRef.current) fileInputRef.current.value = "";
-  };
-
-  const removerItem = (id: string) => {
-    setItems((prev) => prev.filter((i) => i.id !== id));
-  };
-
-  const resetUpload = () => {
-    setItems([]);
-    if (fileInputRef.current) fileInputRef.current.value = "";
-  };
-
-  const updateItem = useCallback((id: string, patch: Partial<UploadItem>) => {
-    setItems((prev) => prev.map((i) => (i.id === id ? { ...i, ...patch } : i)));
-  }, []);
-
-  const processarArquivo = useCallback(
-    async (item: UploadItem): Promise<void> => {
-      updateItem(item.id, { status: "processando", erro: undefined });
-      try {
-        const base64 = await new Promise<string>((resolve, reject) => {
-          const reader = new FileReader();
-          reader.onload = () => {
-            const result = reader.result as string;
-            const idx = result.indexOf(",");
-            resolve(idx >= 0 ? result.slice(idx + 1) : result);
-          };
-          reader.onerror = () => reject(reader.error);
-          reader.readAsDataURL(item.file);
-        });
-
-        const arquivo_tipo =
-          item.file.type === "application/pdf" ? "pdf" : item.file.type;
-
-        const { data, error } = await supabase.functions.invoke(
-          "promocao-extrair-via-vision",
-          {
-            body: {
-              empresa: EMPRESA,
-              fornecedor_nome: FORNECEDOR_DEFAULT,
-              arquivo_tipo,
-              arquivo_base64: base64,
-            },
-          },
-        );
-
-        if (error) throw error;
-        if (data?.error) throw new Error(data.error);
-
-        const campanhaId: number | undefined = data?.campanha_id;
-        const itensExtraidos =
-          data?.extracao?.items_extraidos ?? data?.items?.length ?? 0;
-        const confianca: number | null =
-          data?.extracao?.confianca ?? data?.confianca ?? null;
-
-        // Confirma propagação para evitar race com a lista
-        let nomeCampanha = "Campanha";
-        if (campanhaId) {
-          for (let i = 0; i < 6; i++) {
-            const { data: row } = await supabase
-              .from("promocao_campanha")
-              .select("nome")
-              .eq("id", campanhaId)
-              .maybeSingle();
-            const typedRow = row as { nome: string | null } | null;
-            if (typedRow && typedRow.nome) {
-              nomeCampanha = typedRow.nome;
-              break;
-            }
-            await new Promise((r) => setTimeout(r, 250));
-          }
-        }
-
-        updateItem(item.id, {
-          status: "concluido",
-          campanhaId,
-          nomeCampanha,
-          itensExtraidos,
-          confianca,
-        });
-      } catch (e) {
-        updateItem(item.id, {
-          status: "erro",
-          erro: e instanceof Error ? e.message : String(e),
-        });
-      }
-    },
-    [updateItem],
-  );
-
-  const iniciarProcessamento = async () => {
-    const fila = items.filter((i) => i.status === "aguardando" || i.status === "erro");
-    if (fila.length === 0) return;
-    setProcessando(true);
-
-    // Marca toda a fila como aguardando (caso haja "erro" sendo retentado)
-    fila.forEach((it) => {
-      if (it.status === "erro") updateItem(it.id, { status: "aguardando", erro: undefined });
-    });
-
-    // Pool de concorrência simples (até MAX_CONCURRENT em paralelo)
-    let cursor = 0;
-    const next = async (): Promise<void> => {
-      const idx = cursor++;
-      if (idx >= fila.length) return;
-      await processarArquivo(fila[idx]);
-      return next();
-    };
-    const workers = Array.from(
-      { length: Math.min(MAX_CONCURRENT, fila.length) },
-      () => next(),
-    );
-    await Promise.all(workers);
-
-    setProcessando(false);
-    qc.invalidateQueries({ queryKey: ["promocao-campanhas"] });
-  };
-
-  const tentarNovamente = async (id: string) => {
-    const it = items.find((x) => x.id === id);
-    if (!it) return;
-    setProcessando(true);
-    await processarArquivo(it);
-    setProcessando(false);
-    qc.invalidateQueries({ queryKey: ["promocao-campanhas"] });
-  };
-
-  const totalItens = items.length;
-  const concluidos = items.filter((i) => i.status === "concluido").length;
-  const comErro = items.filter((i) => i.status === "erro").length;
-  const aguardando = items.filter((i) => i.status === "aguardando").length;
-  const emProcesso = items.filter((i) => i.status === "processando").length;
-  const finalizados = concluidos + comErro;
-  const progresso = totalItens > 0 ? Math.round((finalizados / totalItens) * 100) : 0;
-  const todosFinalizados = totalItens > 0 && finalizados === totalItens && !processando;
-  const podeIniciar = !processando && (aguardando > 0 || (comErro > 0 && emProcesso === 0));
+  const upload = useUploadPromocoes(() => qc.invalidateQueries({ queryKey: ["promocao-campanhas"] }));
 
   const fecharModal = () => {
-    if (processando) return;
+    if (upload.processando) return;
     setUploadOpen(false);
-    resetUpload();
+    upload.resetUpload();
+  };
+
+  const irParaLista = () => {
+    if (upload.concluidos > 0) {
+      toast.success(
+        `${upload.concluidos} ${upload.concluidos === 1 ? "campanha criada" : "campanhas criadas"}`,
+      );
+    }
+    setUploadOpen(false);
+    upload.resetUpload();
+    qc.invalidateQueries({ queryKey: ["promocao-campanhas"] });
   };
 
   return (
@@ -454,321 +193,35 @@ export default function AdminReposicaoPromocoes() {
           <CardTitle className="text-base">Campanhas</CardTitle>
         </CardHeader>
         <CardContent className="space-y-4">
-          {/* Filtros */}
-          <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-            <Select value={filtroEstado} onValueChange={setFiltroEstado}>
-              <SelectTrigger>
-                <SelectValue placeholder="Estado" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value={ALL}>Todos os estados</SelectItem>
-                {ESTADOS.map((e) => (
-                  <SelectItem key={e.value} value={e.value}>
-                    {e.label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-            <Select value={filtroFornecedor} onValueChange={setFiltroFornecedor}>
-              <SelectTrigger>
-                <SelectValue placeholder="Fornecedor" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value={ALL}>Todos os fornecedores</SelectItem>
-                {fornecedores.map((f) => (
-                  <SelectItem key={f} value={f}>
-                    {f}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-            <div className="md:col-span-2 relative">
-              <Search className="h-4 w-4 absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground" />
-              <Input
-                placeholder="Buscar por nome…"
-                className="pl-9"
-                value={busca}
-                onChange={(e) => setBusca(e.target.value)}
-              />
-            </div>
-          </div>
+          <CampanhasFiltros
+            filtroEstado={filtroEstado}
+            setFiltroEstado={setFiltroEstado}
+            filtroFornecedor={filtroFornecedor}
+            setFiltroFornecedor={setFiltroFornecedor}
+            busca={busca}
+            setBusca={setBusca}
+            fornecedores={fornecedores}
+          />
 
-          {/* Tabela agrupada por mês */}
-          {isLoading ? (
-            <div className="flex items-center gap-2 text-sm text-muted-foreground">
-              <Loader2 className="h-4 w-4 animate-spin" /> Carregando…
-            </div>
-          ) : grupos.length === 0 ? (
-            <div className="text-center text-muted-foreground py-12 text-sm">
-              Nenhuma campanha cadastrada ainda.
-            </div>
-          ) : (
-            <div className="overflow-x-auto space-y-4">
-              {grupos.map((grupo) => {
-                const collapsed = isCollapsed(grupo.chave);
-                return (
-                  <div key={grupo.chave} className="rounded-md border">
-                    <button
-                      type="button"
-                      onClick={() => toggleMes(grupo.chave)}
-                      className="w-full flex items-center justify-between gap-2 px-3 py-2 bg-muted/40 hover:bg-muted/60 transition-colors text-left"
-                    >
-                      <div className="flex items-center gap-2">
-                        {collapsed ? (
-                          <ChevronRight className="h-4 w-4 text-muted-foreground" />
-                        ) : (
-                          <ChevronDown className="h-4 w-4 text-muted-foreground" />
-                        )}
-                        <span className="font-semibold text-sm">{grupo.label}</span>
-                        <Badge variant="outline" className="text-xs">
-                          {grupo.itens.length}{" "}
-                          {grupo.itens.length === 1 ? "campanha" : "campanhas"}
-                        </Badge>
-                      </div>
-                    </button>
-
-                    {!collapsed && (
-                      grupo.vazio ? (
-                        <div className="flex items-center justify-between gap-3 px-3 py-4 text-sm">
-                          <span className="text-muted-foreground">
-                            Nenhuma campanha cadastrada neste mês.
-                          </span>
-                          <Button
-                            size="sm"
-                            variant="outline"
-                            onClick={() => setUploadOpen(true)}
-                          >
-                            <Upload className="h-3.5 w-3.5" /> Upload PDF
-                          </Button>
-                        </div>
-                      ) : (
-                        <Table>
-                          <TableHeader>
-                            <TableRow>
-                              <TableHead>Nome</TableHead>
-                              <TableHead>Fornecedor</TableHead>
-                              <TableHead>Tipo</TableHead>
-                              <TableHead>Período</TableHead>
-                              <TableHead>Estado</TableHead>
-                              <TableHead className="text-right">Itens</TableHead>
-                              <TableHead>Confiança</TableHead>
-                            </TableRow>
-                          </TableHeader>
-                          <TableBody>
-                            {grupo.itens.map((c) => (
-                              <TableRow
-                                key={c.id}
-                                className="cursor-pointer"
-                                onClick={() =>
-                                  navigate(`/admin/reposicao/promocoes/${c.id}`)
-                                }
-                              >
-                                <TableCell className="font-medium">{c.nome}</TableCell>
-                                <TableCell className="text-muted-foreground">
-                                  {c.fornecedor_nome}
-                                </TableCell>
-                                <TableCell>
-                                  {c.tipo_origem === "negociacao_cliente" ? (
-                                    <Badge variant="outline" className="bg-status-info/15 text-status-info border-status-info/30">
-                                      Negociação
-                                    </Badge>
-                                  ) : (
-                                    <Badge variant="outline">Fornecedor</Badge>
-                                  )}
-                                </TableCell>
-                                <TableCell className="tabular-nums text-sm">
-                                  {formatPeriodo(c.data_inicio, c.data_fim)}
-                                </TableCell>
-                                <TableCell>
-                                  <Badge variant="outline" className={estadoBadgeClass(c.estado)}>
-                                    {ESTADOS.find((e) => e.value === c.estado)?.label ?? c.estado}
-                                  </Badge>
-                                </TableCell>
-                                <TableCell className="text-right tabular-nums font-medium">
-                                  {c.num_itens}
-                                </TableCell>
-                                <TableCell>{confiancaBadge(c.extracao_confianca)}</TableCell>
-                              </TableRow>
-                            ))}
-                          </TableBody>
-                        </Table>
-                      )
-                    )}
-                  </div>
-                );
-              })}
-            </div>
-          )}
+          <CampanhasTable
+            isLoading={isLoading}
+            grupos={grupos}
+            isCollapsed={isCollapsed}
+            toggleMes={toggleMes}
+            onOpenUpload={() => setUploadOpen(true)}
+            onNavigate={(id) => navigate(`/admin/reposicao/promocoes/${id}`)}
+          />
         </CardContent>
       </Card>
 
       {/* Modal de Upload — múltiplos arquivos */}
-      <Dialog open={uploadOpen} onOpenChange={(o) => (o ? setUploadOpen(true) : fecharModal())}>
-        <DialogContent className="max-w-2xl">
-          <DialogHeader>
-            <DialogTitle>Upload de promoções (lote)</DialogTitle>
-            <DialogDescription>
-              Selecione um ou mais PDFs/imagens da promoção do fornecedor. A IA extrai
-              nome, datas e itens automaticamente. Cada arquivo gera uma campanha em rascunho.
-            </DialogDescription>
-          </DialogHeader>
-
-          <div className="space-y-3">
-            <Input
-              ref={fileInputRef}
-              type="file"
-              multiple
-              accept=".pdf,.png,.jpg,.jpeg,application/pdf,image/png,image/jpeg"
-              onChange={handleFileChange}
-              disabled={processando}
-            />
-
-            {totalItens > 0 && (
-              <div className="space-y-2">
-                <div className="flex items-center justify-between text-xs">
-                  <span className="text-muted-foreground">
-                    {finalizados} de {totalItens} processados
-                    {emProcesso > 0 && ` · ${emProcesso} em andamento`}
-                  </span>
-                  <span className="font-medium tabular-nums">{progresso}%</span>
-                </div>
-                <Progress value={progresso} className="h-2" />
-              </div>
-            )}
-
-            {totalItens > 0 && (
-              <TooltipProvider>
-                <div className="max-h-72 overflow-y-auto rounded-md border divide-y">
-                  {items.map((it) => (
-                    <div key={it.id} className="flex items-center gap-2 p-2 text-sm">
-                      <FileText className="h-4 w-4 text-muted-foreground shrink-0" />
-                      <div className="min-w-0 flex-1">
-                        <p className="truncate font-medium">{it.file.name}</p>
-                        <p className="text-xs text-muted-foreground">
-                          {(it.file.size / 1024).toFixed(1)} KB
-                          {it.status === "concluido" && it.nomeCampanha && (
-                            <> · {it.nomeCampanha} · {it.itensExtraidos} {it.itensExtraidos === 1 ? "item" : "itens"}</>
-                          )}
-                          {it.status === "erro" && it.erro && (
-                            <span className="text-destructive"> · Extração falhou: {it.erro}</span>
-                          )}
-                        </p>
-                      </div>
-
-                      {it.status === "aguardando" && (
-                        <Badge variant="outline" className="gap-1">
-                          <Clock className="h-3 w-3" /> Aguardando
-                        </Badge>
-                      )}
-                      {it.status === "processando" && (
-                        <Badge variant="outline" className="gap-1 bg-status-info/15 text-status-info border-status-info/30">
-                          <Loader2 className="h-3 w-3 animate-spin" /> Processando
-                        </Badge>
-                      )}
-                      {it.status === "concluido" && (
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <Badge
-                              variant="outline"
-                              className={cn(
-                                "gap-1 cursor-help",
-                                "bg-status-success/15 text-status-success border-status-success/30",
-                              )}
-                            >
-                              <CheckCircle2 className="h-3 w-3" /> Concluído
-                            </Badge>
-                          </TooltipTrigger>
-                          <TooltipContent>
-                            {it.confianca !== null && it.confianca !== undefined
-                              ? `Confiança Gemini: ${Math.round(it.confianca * 100)}%`
-                              : "Confiança não informada"}
-                          </TooltipContent>
-                        </Tooltip>
-                      )}
-                      {it.status === "erro" && (
-                        <Badge variant="outline" className="gap-1 bg-destructive/15 text-destructive border-destructive/30">
-                          <XCircle className="h-3 w-3" /> Erro
-                        </Badge>
-                      )}
-
-                      {it.status === "erro" && !processando && (
-                        <Button
-                          size="icon"
-                          variant="ghost"
-                          className="h-7 w-7"
-                          onClick={() => tentarNovamente(it.id)}
-                          title="Tentar novamente"
-                        >
-                          <RotateCw className="h-3.5 w-3.5" />
-                        </Button>
-                      )}
-                      {(it.status === "aguardando" || it.status === "erro") && !processando && (
-                        <Button
-                          size="icon"
-                          variant="ghost"
-                          className="h-7 w-7"
-                          onClick={() => removerItem(it.id)}
-                          title="Remover"
-                        >
-                          <X className="h-3.5 w-3.5" />
-                        </Button>
-                      )}
-                    </div>
-                  ))}
-                </div>
-              </TooltipProvider>
-            )}
-
-            {todosFinalizados && (
-              <div className="rounded-md border bg-muted/40 p-3 text-sm">
-                <p className="font-medium">
-                  {concluidos} de {totalItens}{" "}
-                  {totalItens === 1 ? "campanha criada" : "campanhas criadas"} com sucesso.
-                  {comErro > 0 && (
-                    <span className="text-destructive">
-                      {" "}{comErro} {comErro === 1 ? "campanha" : "campanhas"} com erro.
-                    </span>
-                  )}
-                </p>
-                <p className="mt-1 text-xs text-muted-foreground">
-                  As campanhas ficam em rascunho. Acesse a lista para revisar e ativar.
-                </p>
-              </div>
-            )}
-          </div>
-
-          <DialogFooter>
-            {todosFinalizados ? (
-              <Button
-                onClick={() => {
-                  if (concluidos > 0) {
-                    toast.success(
-                      `${concluidos} ${concluidos === 1 ? "campanha criada" : "campanhas criadas"}`,
-                    );
-                  }
-                  setUploadOpen(false);
-                  resetUpload();
-                  qc.invalidateQueries({ queryKey: ["promocao-campanhas"] });
-                }}
-              >
-                Ir para lista
-              </Button>
-            ) : (
-              <>
-                <Button variant="ghost" onClick={fecharModal} disabled={processando}>
-                  {processando ? "Processando…" : "Cancelar"}
-                </Button>
-                <Button onClick={iniciarProcessamento} disabled={!podeIniciar}>
-                  {processando && <Loader2 className="h-4 w-4 animate-spin" />}
-                  {comErro > 0 && aguardando === 0
-                    ? `Tentar novamente (${comErro})`
-                    : `Processar ${aguardando + comErro} ${aguardando + comErro === 1 ? "arquivo" : "arquivos"}`}
-                </Button>
-              </>
-            )}
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      <UploadDialog
+        open={uploadOpen}
+        onOpenChange={(o) => (o ? setUploadOpen(true) : fecharModal())}
+        upload={upload}
+        onIrParaLista={irParaLista}
+        onCancelar={fecharModal}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Resumo

Quebra do god-component `src/pages/AdminReposicaoPromocoes.tsx` (página de Promoções) — **774 → 227 linhas**. Refactor **comportamento-preservante 1:1**, novos módulos em `src/components/reposicao/promocoes/`.

- **`types.ts`** — constantes (EMPRESA/FORNECEDOR_DEFAULT/MAX_CONCURRENT/ALL/ESTADOS), tipos (UploadItem/Campanha/CampanhaComContagem) + helpers `estadoBadgeClass`/`formatPeriodo`.
- **`badges.tsx`** — `confiancaBadge`.
- **`useUploadPromocoes.ts`** — hook com toda a lógica de upload em lote: FileReader → base64, invoke `promocao-extrair-via-vision`, polling de nome, **pool de concorrência** (MAX_CONCURRENT), retry, e contadores derivados. Recebe `onProcessed` (substitui o `invalidateQueries` ao fim de iniciar/retry).
- **`CampanhasFiltros.tsx`** — filtros (estado/fornecedor/busca).
- **`CampanhasTable.tsx`** — tabela agrupada por mês (colapso/vazio/loading).
- **`UploadDialog.tsx`** — modal de upload (presentacional, consome o hook).

### Decisão de arquitetura

As 2 `useQuery` (campanhas+contagem em batch / fornecedores) e os `useMemo` de agrupamento por mês permanecem **no pai**. A lógica de upload (coesa e independente) foi isolada num hook testável. `fecharModal`/`irParaLista` ficam no pai (precisam de `setUploadOpen`/`toast`/`qc`).

## Garantias

- ✅ `bunx tsc --noEmit` — 0 erros.
- ✅ `bun lint` — 0 problemas nos arquivos tocados.
- ✅ Suíte: **588/588** passando.
- ✅ `bun run build` exit 0.
- ✅ +18 testes novos (6 arquivos): helpers, badges, filtros, tabela (loading/empty/grupos/navegação/colapso), hook (add/remove/reset/contadores) e dialog (status/progresso/footer dinâmico).
- ✅ Revisão independente (subagente): veredito **FIEL 1:1** — lógica de upload (concorrência/contadores/parsing/polling) byte-a-byte idêntica; `onProcessed` substitui o `invalidateQueries` exatamente nos 2 pontos corretos.

## Test plan

- [x] tsc 0 erros / lint 0 problemas
- [x] 18 testes novos + suíte completa 588/588
- [x] build de produção exit 0
- [x] revisão independente confirma 1:1
- [ ] CI `validate` verde

🤖 Generated with [Claude Code](https://claude.com/claude-code)