### PR TITLE
chore(ts-strict): promove 17 arquivos leaf a strict (lote 1 — types + lib)

### DIFF
--- a/tsconfig.strict.json
+++ b/tsconfig.strict.json
@@ -397,6 +397,23 @@
     "src/components/financeiro/dashboard/AgingCard.tsx",
     "src/components/financeiro/dashboard/FluxoCaixaTab.tsx",
     "src/components/financeiro/dashboard/DRETab.tsx",
-    "src/components/financeiro/dashboard/DREComparativo.tsx"
+    "src/components/financeiro/dashboard/DREComparativo.tsx",
+    "src/types/call-log.ts",
+    "src/types/index.ts",
+    "src/types/reposicao.ts",
+    "src/lib/analytics.ts",
+    "src/lib/offline-queue.ts",
+    "src/lib/call-log/build-insert.ts",
+    "src/lib/call-log/record.ts",
+    "src/lib/call-log/recording-policy.ts",
+    "src/lib/dashboard/persona-detect.ts",
+    "src/lib/dashboard/route-tracker.ts",
+    "src/lib/financeiro/aging-helpers.ts",
+    "src/lib/financeiro/dre-helpers.ts",
+    "src/lib/financeiro/dre-tabelas-tributarias.ts",
+    "src/lib/financeiro/ncg-helpers.ts",
+    "src/lib/knowledge-base/calculate-rendimento.ts",
+    "src/lib/knowledge-base/specs-types.ts",
+    "src/lib/reposicao/sku-param.ts"
   ]
 }


### PR DESCRIPTION
## Parte B — promoção (lote 1)

Feito na **janela de CPU calma** (load ~3) que permite validação `tsc` confiável — corrigindo a causa-raiz do que me queimou no #180 (validação local morta por contenção → falso-negativo).

Promove **17 arquivos folha já strict-clean** — **zero edição de source**, só append no `include`:

- `src/types/{call-log,index,reposicao}.ts`
- `src/lib/analytics.ts`, `offline-queue.ts`
- `src/lib/call-log/*` (3), `src/lib/dashboard/{persona-detect,route-tracker}.ts`
- `src/lib/financeiro/*` (4 helpers), `src/lib/knowledge-base/{calculate-rendimento,specs-types}.ts`
- `src/lib/reposicao/sku-param.ts`

## Garantias
- `typecheck:strict` = **0 erros** (run completo, validado localmente com CPU calma).
- Evitei **área farmer/scoring** (lane de outra sessão ativa) e **god-components/pages** (cascata transitiva).
- strict include: **379 → 396**.

## Test plan
- [ ] CI `validate` (typecheck:strict + lint + test). Auto-merge só com verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)