### PR TITLE
refactor(types): remove 5 casts (supabase as any).from('standard_processes')

### DIFF
--- a/src/hooks/useApproveStandardProcess.ts
+++ b/src/hooks/useApproveStandardProcess.ts
@@ -27,8 +27,8 @@ export function useApproveStandardProcess() {
         payload.reviewed_at = new Date().toISOString();
       }
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const { error } = await (supabase as any).from('standard_processes')
+       
+      const { error } = await supabase.from('standard_processes')
         .update(payload).eq('id', id);
       if (error) throw error;
     },

--- a/src/hooks/useSaveStandardProcess.ts
+++ b/src/hooks/useSaveStandardProcess.ts
@@ -4,6 +4,7 @@ import { toast } from 'sonner';
 import { slugify } from '@/lib/standard-process/types';
 import { useReindexRag } from './useReindexRag';
 import type { StandardProcess, StandardProcessEtapa, StandardProcessStatus } from '@/lib/standard-process/types';
+import type { Json } from '@/integrations/supabase/types';
 
 interface SaveInput {
   id?: string;  // se passar, UPDATE; senão INSERT
@@ -34,7 +35,7 @@ export function useSaveStandardProcess() {
         segmento: input.segmento,
         porte_alvo: input.porte_alvo,
         tags: input.tags,
-        etapas: input.etapas,
+        etapas: input.etapas as unknown as Json,
         expected_outcomes: input.expected_outcomes,
         target_audience: input.target_audience ?? null,
         prerequisites: input.prerequisites,
@@ -42,17 +43,17 @@ export function useSaveStandardProcess() {
       };
 
       if (input.id) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const { data, error } = await (supabase as any).from('standard_processes')
+         
+        const { data, error } = await supabase.from('standard_processes')
           .update(payload).eq('id', input.id).select().single();
         if (error) throw error;
-        return data as StandardProcess;
+        return data as unknown as StandardProcess;
       }
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const { data, error } = await (supabase as any).from('standard_processes')
+       
+      const { data, error } = await supabase.from('standard_processes')
         .insert({ ...payload, created_by: user.id }).select().single();
       if (error) throw error;
-      return data as StandardProcess;
+      return data as unknown as StandardProcess;
     },
     onSuccess: (data) => {
       qc.invalidateQueries({ queryKey: ['standard-processes'] });

--- a/src/hooks/useStandardProcess.ts
+++ b/src/hooks/useStandardProcess.ts
@@ -8,11 +8,11 @@ export function useStandardProcess(id: string | null) {
     enabled: !!id,
     queryFn: async (): Promise<StandardProcess | null> => {
       if (!id) return null;
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const { data, error } = await (supabase as any).from('standard_processes')
+       
+      const { data, error } = await supabase.from('standard_processes')
         .select('*').eq('id', id).maybeSingle();
       if (error) throw error;
-      return (data as StandardProcess) ?? null;
+      return (data as unknown as StandardProcess) ?? null;
     },
   });
 }

--- a/src/hooks/useStandardProcessesList.ts
+++ b/src/hooks/useStandardProcessesList.ts
@@ -12,15 +12,15 @@ export function useStandardProcessesList(filters: Filters = {}) {
     queryKey: ['standard-processes', filters],
     staleTime: 30_000,
     queryFn: async (): Promise<StandardProcess[]> => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      let q = (supabase as any).from('standard_processes').select('*');
+       
+      let q = supabase.from('standard_processes').select('*');
       const statusList = filters.status ?? ['draft', 'in_review', 'published'];
       q = q.in('status', statusList);
       if (filters.segmento) q = q.eq('segmento', filters.segmento);
       q = q.order('updated_at', { ascending: false }).limit(200);
       const { data, error } = await q;
       if (error) throw error;
-      return (data ?? []) as StandardProcess[];
+      return (data ?? []) as unknown as StandardProcess[];
     },
   });
 }


### PR DESCRIPTION
## Resumo
Wave standard_processes do Item 1. A tabela `standard_processes` **já existe** no `types.ts` — o padrão `(supabase as any).from(...)` era legado. Removo 5 casts + `eslint-disable` órfãos em: useApproveStandardProcess, useSaveStandardProcess (×2), useStandardProcess, useStandardProcessesList.

### Fallout do strict (corrigido antes do push)
`etapas` é jsonb (tipa como `Json`) mas o tipo de domínio é `StandardProcessEtapa[]`:
- payload `etapas` → `as unknown as Json` (insert/update)
- returns `data as StandardProcess` → `as unknown as StandardProcess` (×4) — `data` agora tipado com `etapas:Json` não sobrepõe `StandardProcessEtapa[]` num cast direto; runtime é a mesma shape

## Validação
- `bun run typecheck:strict`: **0** · `bunx tsc --noEmit`: 0 · `bun run build`: OK · eslint: 0
- Codex review: **No findings**

> Progresso §10 `no-explicit-any`: ~65 → ~60. **Item 1 (casts de tabela) essencialmente concluído.** Restam: alguns `as any` avulsos (kb_documents em useKnowledgeBaseList, AdminProductivity reviews, AdminReposicaoParametros) + Item 2 (JsSIP/deepgram/tesseract).

🤖 Generated with [Claude Code](https://claude.com/claude-code)