### PR TITLE
chore(ts-strict): promove 8 arquivos a strict (lote 2 — orderSubmission + contexts)

### DIFF
--- a/tsconfig.strict.json
+++ b/tsconfig.strict.json
@@ -414,6 +414,14 @@
     "src/lib/financeiro/ncg-helpers.ts",
     "src/lib/knowledge-base/calculate-rendimento.ts",
     "src/lib/knowledge-base/specs-types.ts",
-    "src/lib/reposicao/sku-param.ts"
+    "src/lib/reposicao/sku-param.ts",
+    "src/services/orderSubmission/types.ts",
+    "src/services/orderSubmission/buildPrintData.ts",
+    "src/services/orderSubmission/submitQuote.ts",
+    "src/services/orderSubmission/index.ts",
+    "src/contexts/AppShellContext.tsx",
+    "src/contexts/DashboardEditModeContext.tsx",
+    "src/contexts/DashboardPersonaContext.tsx",
+    "src/contexts/ReposicaoEmpresaContext.tsx"
   ]
 }


### PR DESCRIPTION
Parte B lote 2 (tsconfig-only, 0 edição de source). `typecheck:strict` = 0 erros (validado local). Promove orderSubmission/{types,buildPrintData,submitQuote,index} + 4 contexts pequenos (AppShell, DashboardEditMode, DashboardPersona, ReposicaoEmpresa). calendar.tsx podado (rest param não-usado — lote futuro). Evitei área farmer/scoring (lane ativa). include 396→404. Auto-merge só com CI verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)