### PR TITLE
refactor(reposicao): split god-component AdminReposicaoOportunidades (745→347)

### DIFF
--- a/src/components/reposicao/oportunidades/GerarCicloDialog.tsx
+++ b/src/components/reposicao/oportunidades/GerarCicloDialog.tsx
@@ -1,0 +1,53 @@
+// Dialog de confirmação "Gerar ciclo de oportunidade do dia".
+// Extraído de src/pages/AdminReposicaoOportunidades.tsx (god-component split).
+import {
+  AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent,
+  AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Loader2 } from "lucide-react";
+import { formatBRL } from "./shared";
+
+export function GerarCicloDialog({
+  open, onOpenChange, oportunidadesCount, totalEconomia, executando, onConfirm,
+}: {
+  open: boolean;
+  onOpenChange: (o: boolean) => void;
+  oportunidadesCount: number;
+  totalEconomia: number;
+  executando: boolean;
+  onConfirm: () => void;
+}) {
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Gerar ciclo de oportunidade do dia</AlertDialogTitle>
+          <AlertDialogDescription>
+            Vai gerar pedidos de oportunidade para{" "}
+            <strong>{oportunidadesCount} SKUs</strong>, com economia total
+            estimada de{" "}
+            <strong className="text-status-success">
+              {formatBRL(totalEconomia)}
+            </strong>
+            . Continuar?
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={executando}>
+            Cancelar
+          </AlertDialogCancel>
+          <AlertDialogAction
+            onClick={(e) => {
+              e.preventDefault();
+              onConfirm();
+            }}
+            disabled={executando}
+          >
+            {executando && <Loader2 className="h-4 w-4 animate-spin mr-2" />}
+            Confirmar e gerar
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/components/reposicao/oportunidades/KpiCards.tsx
+++ b/src/components/reposicao/oportunidades/KpiCards.tsx
@@ -1,0 +1,120 @@
+// Grid de 4 KPIs da página de Oportunidades.
+// Extraído de src/pages/AdminReposicaoOportunidades.tsx (god-component split).
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { PlayCircle } from "lucide-react";
+import { formatBRL, formatDateLong, diasBadge } from "./shared";
+
+export function KpiCards({
+  totalEconomia, oportunidadesCount, totalSkusAtivos, dataLimiteMaisProxima, diasAteLimite, cicloHoje, onGerarCiclo,
+}: {
+  totalEconomia: number;
+  oportunidadesCount: number;
+  totalSkusAtivos: number;
+  dataLimiteMaisProxima: string | null;
+  diasAteLimite: number | null;
+  cicloHoje: number;
+  onGerarCiclo: () => void;
+}) {
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-xs font-medium text-muted-foreground">
+            Economia total potencial hoje
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="text-2xl font-bold text-status-success tabular-nums">
+            {formatBRL(totalEconomia)}
+          </div>
+          <p className="text-xs text-muted-foreground mt-1">
+            considerando promoções e aumentos vigentes
+          </p>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-xs font-medium text-muted-foreground">
+            SKUs com oportunidade
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="text-2xl font-bold tabular-nums">
+            {oportunidadesCount}
+          </div>
+          <p className="text-xs text-muted-foreground mt-1">
+            de {totalSkusAtivos} SKUs ativos
+          </p>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-xs font-medium text-muted-foreground">
+            Data limite mais próxima
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {dataLimiteMaisProxima ? (
+            <>
+              <div className="text-lg font-bold tabular-nums">
+                {formatDateLong(dataLimiteMaisProxima)}
+              </div>
+              <div className="mt-1">
+                <Badge variant="outline" className={diasBadge(diasAteLimite)}>
+                  em {diasAteLimite} {diasAteLimite === 1 ? "dia" : "dias"}
+                </Badge>
+              </div>
+              <p className="text-xs text-muted-foreground mt-2">
+                Próxima janela crítica
+              </p>
+            </>
+          ) : (
+            <>
+              <div className="text-lg font-bold text-muted-foreground">—</div>
+              <p className="text-xs text-muted-foreground mt-1">
+                Sem janelas ativas
+              </p>
+            </>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-xs font-medium text-muted-foreground">
+            Ciclo oportunidade do dia
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {cicloHoje > 0 ? (
+            <>
+              <Badge
+                className="bg-status-success/15 text-status-success border-status-success/30 cursor-pointer hover:bg-status-success/25"
+                variant="outline"
+                onClick={onGerarCiclo}
+              >
+                <PlayCircle className="h-3 w-3 mr-1" />
+                Gerar ciclo oportunidade
+              </Badge>
+              <p className="text-xs text-muted-foreground mt-2">
+                {cicloHoje} {cicloHoje === 1 ? "evento" : "eventos"} encerra(m) hoje
+              </p>
+            </>
+          ) : (
+            <>
+              <Badge variant="outline" className="text-muted-foreground">
+                Sem ciclo hoje
+              </Badge>
+              <p className="text-xs text-muted-foreground mt-2">
+                Próxima janela crítica ainda não chegou
+              </p>
+            </>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/reposicao/oportunidades/NegociacaoBanner.tsx
+++ b/src/components/reposicao/oportunidades/NegociacaoBanner.tsx
@@ -1,0 +1,38 @@
+// Banner de sugestões de negociação paralela (Oportunidades).
+// Extraído de src/pages/AdminReposicaoOportunidades.tsx (god-component split).
+import { Button } from "@/components/ui/button";
+import { Handshake, X } from "lucide-react";
+
+export function NegociacaoBanner({
+  count, onVerSugestoes, onFechar,
+}: {
+  count: number;
+  onVerSugestoes: () => void;
+  onFechar: () => void;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-3 rounded-lg border border-status-info/30 bg-status-info/10 px-4 py-3 text-sm">
+      <div className="flex items-center gap-2 flex-1">
+        <Handshake className="h-4 w-4 text-status-info dark:text-status-info shrink-0" />
+        <span>
+          <strong>{count}</strong> SKU{count === 1 ? '' : 's'}{' '}
+          {count === 1 ? 'foi sugerido' : 'foram sugeridos'} para negociação paralela.
+        </span>
+      </div>
+      <div className="flex items-center gap-2 shrink-0">
+        <Button size="sm" variant="outline" onClick={onVerSugestoes}>
+          Ver sugestões
+        </Button>
+        <Button
+          size="icon"
+          variant="ghost"
+          className="h-7 w-7"
+          onClick={onFechar}
+          aria-label="Fechar"
+        >
+          <X className="h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/reposicao/oportunidades/OportunidadesFiltros.tsx
+++ b/src/components/reposicao/oportunidades/OportunidadesFiltros.tsx
@@ -1,0 +1,94 @@
+// Filtros da tabela de oportunidades (cenários/fornecedor/ordenação/switch).
+// Extraído de src/pages/AdminReposicaoOportunidades.tsx (god-component split).
+import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import {
+  DropdownMenu, DropdownMenuContent, DropdownMenuTrigger, DropdownMenuCheckboxItem,
+} from "@/components/ui/dropdown-menu";
+import { ChevronRight } from "lucide-react";
+import { ALL, CENARIOS, cenarioIcon } from "./shared";
+import type { Cenario, OrdemKey } from "./types";
+
+export function OportunidadesFiltros({
+  cenariosSelecionados, cenariosLabel, toggleCenario,
+  filtroFornecedor, setFiltroFornecedor, fornecedoresUnicos,
+  ordenacao, setOrdenacao, apenasComEconomia, setApenasComEconomia,
+}: {
+  cenariosSelecionados: Set<Cenario>;
+  cenariosLabel: string;
+  toggleCenario: (c: Cenario, checked: boolean) => void;
+  filtroFornecedor: string;
+  setFiltroFornecedor: (v: string) => void;
+  fornecedoresUnicos: string[];
+  ordenacao: OrdemKey;
+  setOrdenacao: (v: OrdemKey) => void;
+  apenasComEconomia: boolean;
+  setApenasComEconomia: (v: boolean) => void;
+}) {
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="outline" className="justify-between">
+            {cenariosLabel}
+            <ChevronRight className="h-4 w-4 rotate-90 opacity-50" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent className="w-56" align="start">
+          {CENARIOS.map((c) => (
+            <DropdownMenuCheckboxItem
+              key={c.value}
+              checked={cenariosSelecionados.has(c.value)}
+              onCheckedChange={(checked) => toggleCenario(c.value, !!checked)}
+              onSelect={(e) => e.preventDefault()}
+            >
+              <span className="flex items-center gap-2">
+                {cenarioIcon(c.value)}
+                {c.label}
+              </span>
+            </DropdownMenuCheckboxItem>
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <Select value={filtroFornecedor} onValueChange={setFiltroFornecedor}>
+        <SelectTrigger>
+          <SelectValue placeholder="Fornecedor" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value={ALL}>Todos os fornecedores</SelectItem>
+          {fornecedoresUnicos.map((f) => (
+            <SelectItem key={f} value={f}>
+              {f}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      <Select value={ordenacao} onValueChange={(v) => setOrdenacao(v as OrdemKey)}>
+        <SelectTrigger>
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="economia">Maior economia</SelectItem>
+          <SelectItem value="data_limite">Data limite mais próxima</SelectItem>
+          <SelectItem value="desconto">Maior % desconto</SelectItem>
+          <SelectItem value="sku">SKU alfabético</SelectItem>
+        </SelectContent>
+      </Select>
+
+      <div className="flex items-center justify-end gap-2 px-2">
+        <Switch
+          id="apenas-economia"
+          checked={apenasComEconomia}
+          onCheckedChange={setApenasComEconomia}
+        />
+        <Label htmlFor="apenas-economia" className="text-sm cursor-pointer">
+          Apenas com economia &gt; 0
+        </Label>
+      </div>
+    </div>
+  );
+}

--- a/src/components/reposicao/oportunidades/OportunidadesTable.tsx
+++ b/src/components/reposicao/oportunidades/OportunidadesTable.tsx
@@ -1,0 +1,186 @@
+// Tabela de oportunidades ativas (loading/vazio/linhas).
+// Extraída de src/pages/AdminReposicaoOportunidades.tsx (god-component split).
+import type { useNavigate } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
+import { Loader2, ChevronRight, MoreVertical, EyeOff, ArrowRight } from "lucide-react";
+import { EstadoVazio } from "./components";
+import {
+  formatBRL, formatNumber, formatDate, cenarioIcon, cenarioLabel, descontoBadgeClass,
+} from "./shared";
+import type { Oportunidade } from "./types";
+
+export function OportunidadesTable({
+  isLoading, totalCount, rows, navigate, onOpenDrawer, onIgnorar,
+}: {
+  isLoading: boolean;
+  totalCount: number;
+  rows: Oportunidade[];
+  navigate: ReturnType<typeof useNavigate>;
+  onOpenDrawer: (o: Oportunidade) => void;
+  onIgnorar: (sku: number) => void;
+}) {
+  if (isLoading) {
+    return (
+      <div className="flex items-center gap-2 text-sm text-muted-foreground py-12 justify-center">
+        <Loader2 className="h-4 w-4 animate-spin" /> Carregando…
+      </div>
+    );
+  }
+  if (totalCount === 0) {
+    return <EstadoVazio navigate={navigate} />;
+  }
+  return (
+    <div className="overflow-x-auto">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead className="w-10"></TableHead>
+            <TableHead>SKU / Descrição</TableHead>
+            <TableHead>Fornecedor</TableHead>
+            <TableHead className="text-right">Desconto total</TableHead>
+            <TableHead className="text-right">Qtde sugerida</TableHead>
+            <TableHead>Data limite</TableHead>
+            <TableHead className="text-right">Economia bruta</TableHead>
+            <TableHead className="w-20 text-right">Ações</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {rows.length === 0 && (
+            <TableRow>
+              <TableCell colSpan={8} className="text-center text-muted-foreground py-12">
+                Nenhum SKU bate os filtros atuais.
+              </TableCell>
+            </TableRow>
+          )}
+          {rows.map((o) => (
+            <TableRow key={`${o.sku_codigo_omie}-${o.cenario}`}>
+              <TableCell>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span className="inline-flex">{cenarioIcon(o.cenario)}</span>
+                  </TooltipTrigger>
+                  <TooltipContent>{cenarioLabel(o.cenario)}</TooltipContent>
+                </Tooltip>
+              </TableCell>
+              <TableCell>
+                <div className="font-medium tabular-nums text-xs text-muted-foreground">
+                  {o.sku_codigo_omie}
+                </div>
+                <div className="text-sm">{o.sku_descricao ?? "—"}</div>
+              </TableCell>
+              <TableCell className="text-sm text-muted-foreground">
+                {o.fornecedor_nome ?? "—"}
+              </TableCell>
+              <TableCell className="text-right">
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Badge
+                      variant="outline"
+                      className={descontoBadgeClass(o.desconto_total_perc)}
+                    >
+                      {formatNumber(o.desconto_total_perc, 1)}%
+                    </Badge>
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-xs">
+                    <div className="space-y-1 text-xs">
+                      <div>
+                        Base promo: {formatNumber(o.desconto_promo_perc, 2)}%
+                      </div>
+                      {o.tem_negociacao_extra && (
+                        <div>+ Extra negociado</div>
+                      )}
+                      {o.aumento_evitado_perc !== null &&
+                        Number(o.aumento_evitado_perc) > 0 && (
+                          <div>
+                            + Aumento evitado:{" "}
+                            {formatNumber(o.aumento_evitado_perc, 2)}%
+                          </div>
+                        )}
+                    </div>
+                  </TooltipContent>
+                </Tooltip>
+              </TableCell>
+              <TableCell className="text-right tabular-nums">
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span className="font-medium">
+                      {formatNumber(o.qtde_oportunidade, 0)}
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <div className="text-xs space-y-1">
+                      <div>
+                        Demanda diária: {formatNumber(o.demanda_diaria, 2)}
+                      </div>
+                      <div>
+                        Quantidade base EOQ: {formatNumber(o.qtde_base, 0)}
+                      </div>
+                    </div>
+                  </TooltipContent>
+                </Tooltip>
+              </TableCell>
+              <TableCell className="text-sm">
+                <div className="tabular-nums">{formatDate(o.data_limite_acao)}</div>
+                <div className="text-xs text-muted-foreground">
+                  {o.dias_ate_limite !== null
+                    ? `em ${o.dias_ate_limite} ${o.dias_ate_limite === 1 ? "dia" : "dias"}`
+                    : ""}
+                </div>
+              </TableCell>
+              <TableCell
+                className={`text-right tabular-nums font-medium ${
+                  Number(o.economia_bruta_estimada ?? 0) > 0
+                    ? "text-status-success"
+                    : "text-muted-foreground"
+                }`}
+              >
+                {formatBRL(o.economia_bruta_estimada)}
+              </TableCell>
+              <TableCell className="text-right">
+                <div className="flex items-center justify-end gap-1">
+                  <Button
+                    size="icon"
+                    variant="ghost"
+                    className="h-8 w-8"
+                    onClick={() => onOpenDrawer(o)}
+                  >
+                    <ChevronRight className="h-4 w-4" />
+                  </Button>
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button size="icon" variant="ghost" className="h-8 w-8">
+                        <MoreVertical className="h-4 w-4" />
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end">
+                      <DropdownMenuItem
+                        onClick={() =>
+                          navigate(
+                            `/admin/reposicao/skus/${o.sku_codigo_omie}`,
+                          )
+                        }
+                      >
+                        <ArrowRight className="h-4 w-4 mr-2" />
+                        Ir para SKU em reposição
+                      </DropdownMenuItem>
+                      <DropdownMenuItem
+                        onClick={() => onIgnorar(o.sku_codigo_omie)}
+                      >
+                        <EyeOff className="h-4 w-4 mr-2" />
+                        Ignorar hoje
+                      </DropdownMenuItem>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                </div>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/src/components/reposicao/oportunidades/__tests__/GerarCicloDialog.test.tsx
+++ b/src/components/reposicao/oportunidades/__tests__/GerarCicloDialog.test.tsx
@@ -1,0 +1,22 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { GerarCicloDialog } from "../GerarCicloDialog";
+
+function noop() { /* */ }
+
+describe("GerarCicloDialog", () => {
+  it("fechado → não renderiza", () => {
+    render(<GerarCicloDialog open={false} onOpenChange={noop} oportunidadesCount={5} totalEconomia={1000} executando={false} onConfirm={noop} />);
+    expect(screen.queryByText("Gerar ciclo de oportunidade do dia")).toBeNull();
+  });
+
+  it("aberto → título, contagem, economia; Confirmar dispara onConfirm", () => {
+    const onConfirm = vi.fn();
+    render(<GerarCicloDialog open onOpenChange={noop} oportunidadesCount={5} totalEconomia={1000} executando={false} onConfirm={onConfirm} />);
+    expect(screen.getByText("Gerar ciclo de oportunidade do dia")).toBeTruthy();
+    expect(screen.getByText(/5 SKUs/)).toBeTruthy();
+    expect(screen.getByText(/1\.000,00/)).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: /Confirmar e gerar/ }));
+    expect(onConfirm).toHaveBeenCalled();
+  });
+});

--- a/src/components/reposicao/oportunidades/__tests__/KpiCards.test.tsx
+++ b/src/components/reposicao/oportunidades/__tests__/KpiCards.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { KpiCards } from "../KpiCards";
+
+function noop() { /* */ }
+
+describe("KpiCards", () => {
+  it("renderiza economia, contagem e ciclo; clicar no badge dispara onGerarCiclo", () => {
+    const onGerarCiclo = vi.fn();
+    render(
+      <KpiCards
+        totalEconomia={1000}
+        oportunidadesCount={5}
+        totalSkusAtivos={50}
+        dataLimiteMaisProxima="2026-01-20"
+        diasAteLimite={3}
+        cicloHoje={2}
+        onGerarCiclo={onGerarCiclo}
+      />
+    );
+    expect(screen.getByText("SKUs com oportunidade")).toBeTruthy();
+    expect(screen.getByText("5")).toBeTruthy();
+    expect(screen.getByText("de 50 SKUs ativos")).toBeTruthy();
+    expect(screen.getByText(/1\.000,00/)).toBeTruthy();
+    expect(screen.getByText(/em 3 dias/)).toBeTruthy();
+    expect(screen.getByText(/2 eventos encerra/)).toBeTruthy();
+    fireEvent.click(screen.getByText("Gerar ciclo oportunidade"));
+    expect(onGerarCiclo).toHaveBeenCalled();
+  });
+
+  it("sem data limite e sem ciclo → estados vazios", () => {
+    render(
+      <KpiCards
+        totalEconomia={0}
+        oportunidadesCount={0}
+        totalSkusAtivos={0}
+        dataLimiteMaisProxima={null}
+        diasAteLimite={null}
+        cicloHoje={0}
+        onGerarCiclo={noop}
+      />
+    );
+    expect(screen.getByText("Sem janelas ativas")).toBeTruthy();
+    expect(screen.getByText("Sem ciclo hoje")).toBeTruthy();
+  });
+});

--- a/src/components/reposicao/oportunidades/__tests__/NegociacaoBanner.test.tsx
+++ b/src/components/reposicao/oportunidades/__tests__/NegociacaoBanner.test.tsx
@@ -1,0 +1,22 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { NegociacaoBanner } from "../NegociacaoBanner";
+
+describe("NegociacaoBanner", () => {
+  it("plural → texto e botões disparam callbacks", () => {
+    const onVerSugestoes = vi.fn();
+    const onFechar = vi.fn();
+    render(<NegociacaoBanner count={3} onVerSugestoes={onVerSugestoes} onFechar={onFechar} />);
+    expect(screen.getByText(/foram sugeridos/)).toBeTruthy();
+    expect(screen.getByText("3")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Ver sugestões" }));
+    expect(onVerSugestoes).toHaveBeenCalled();
+    fireEvent.click(screen.getByRole("button", { name: "Fechar" }));
+    expect(onFechar).toHaveBeenCalled();
+  });
+
+  it("singular → 'foi sugerido'", () => {
+    render(<NegociacaoBanner count={1} onVerSugestoes={() => {}} onFechar={() => {}} />);
+    expect(screen.getByText(/foi sugerido/)).toBeTruthy();
+  });
+});

--- a/src/components/reposicao/oportunidades/__tests__/OportunidadesFiltros.test.tsx
+++ b/src/components/reposicao/oportunidades/__tests__/OportunidadesFiltros.test.tsx
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { OportunidadesFiltros } from "../OportunidadesFiltros";
+import { CENARIOS } from "../shared";
+import type { Cenario } from "../types";
+
+function noop() { /* */ }
+
+function baseProps(over: Partial<React.ComponentProps<typeof OportunidadesFiltros>> = {}): React.ComponentProps<typeof OportunidadesFiltros> {
+  return {
+    cenariosSelecionados: new Set<Cenario>(CENARIOS.map((c) => c.value)),
+    cenariosLabel: "Todos os cenários",
+    toggleCenario: noop,
+    filtroFornecedor: "__all__",
+    setFiltroFornecedor: noop,
+    fornecedoresUnicos: ["ACME", "SAYERLACK"],
+    ordenacao: "economia",
+    setOrdenacao: noop,
+    apenasComEconomia: true,
+    setApenasComEconomia: noop,
+    ...over,
+  };
+}
+
+describe("OportunidadesFiltros", () => {
+  it("renderiza o label de cenários e o switch de economia", () => {
+    render(<OportunidadesFiltros {...baseProps()} />);
+    expect(screen.getByText("Todos os cenários")).toBeTruthy();
+    expect(screen.getByText(/Apenas com economia/)).toBeTruthy();
+  });
+
+  it("alternar o switch dispara setApenasComEconomia", () => {
+    const setApenasComEconomia = vi.fn();
+    render(<OportunidadesFiltros {...baseProps({ setApenasComEconomia })} />);
+    fireEvent.click(screen.getByRole("switch"));
+    expect(setApenasComEconomia).toHaveBeenCalled();
+  });
+});

--- a/src/components/reposicao/oportunidades/__tests__/OportunidadesTable.test.tsx
+++ b/src/components/reposicao/oportunidades/__tests__/OportunidadesTable.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { OportunidadesTable } from "../OportunidadesTable";
+import type { Oportunidade } from "../types";
+import type { useNavigate } from "react-router-dom";
+
+const navigate = vi.fn() as unknown as ReturnType<typeof useNavigate>;
+
+const op = {
+  empresa: "OBEN",
+  sku_codigo_omie: 999,
+  sku_descricao: "Verniz Premium",
+  fornecedor_nome: "SAYERLACK",
+  cenario: "promo_flat",
+  desconto_total_perc: 12.5,
+  desconto_promo_perc: 10,
+  aumento_evitado_perc: 0,
+  tem_negociacao_extra: false,
+  data_limite_acao: "2026-01-20",
+  dias_ate_limite: 3,
+  demanda_diaria: 2,
+  qtde_base: 10,
+  qtde_oportunidade: 30,
+  economia_bruta_estimada: 500,
+} as unknown as Oportunidade;
+
+function noop() { /* */ }
+const renderTab = (ui: React.ReactElement) => render(<TooltipProvider>{ui}</TooltipProvider>);
+
+describe("OportunidadesTable", () => {
+  it("loading → Carregando…", () => {
+    renderTab(<OportunidadesTable isLoading totalCount={0} rows={[]} navigate={navigate} onOpenDrawer={noop} onIgnorar={noop} />);
+    expect(screen.getByText("Carregando…")).toBeTruthy();
+  });
+
+  it("totalCount=0 → estado vazio (sem cabeçalho da tabela)", () => {
+    renderTab(<OportunidadesTable isLoading={false} totalCount={0} rows={[]} navigate={navigate} onOpenDrawer={noop} onIgnorar={noop} />);
+    expect(screen.queryByText("SKU / Descrição")).toBeNull();
+  });
+
+  it("filtros sem match → mensagem; com linha → dados e clique abre drawer", () => {
+    const onOpenDrawer = vi.fn();
+    const { rerender } = renderTab(
+      <OportunidadesTable isLoading={false} totalCount={1} rows={[]} navigate={navigate} onOpenDrawer={onOpenDrawer} onIgnorar={noop} />
+    );
+    expect(screen.getByText("Nenhum SKU bate os filtros atuais.")).toBeTruthy();
+
+    rerender(
+      <TooltipProvider>
+        <OportunidadesTable isLoading={false} totalCount={1} rows={[op]} navigate={navigate} onOpenDrawer={onOpenDrawer} onIgnorar={noop} />
+      </TooltipProvider>
+    );
+    expect(screen.getByText("Verniz Premium")).toBeTruthy();
+    expect(screen.getByText("999")).toBeTruthy();
+    expect(screen.getByText(/500,00/)).toBeTruthy();
+    // primeiro botão da linha (ChevronRight) abre o drawer
+    const chevronBtn = screen.getAllByRole("button")[0];
+    fireEvent.click(chevronBtn);
+    expect(onOpenDrawer).toHaveBeenCalledWith(op);
+  });
+});

--- a/src/pages/AdminReposicaoOportunidades.tsx
+++ b/src/pages/AdminReposicaoOportunidades.tsx
@@ -3,84 +3,20 @@ import { useNavigate } from "react-router-dom";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
 import { toast } from "sonner";
-import {
-  Sparkles,
-  Loader2,
-  RefreshCw,
-  PlayCircle,
-  ChevronRight,
-  MoreVertical,
-  EyeOff,
-  ArrowRight,
-  Handshake,
-  X,
-} from "lucide-react";
+import { Sparkles, RefreshCw, PlayCircle } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
-import { Switch } from "@/components/ui/switch";
-import { Label } from "@/components/ui/label";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-  TooltipProvider,
-} from "@/components/ui/tooltip";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import {
-  Sheet,
-  SheetContent,
-} from "@/components/ui/sheet";
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/components/ui/alert-dialog";
-import {
-  DropdownMenuCheckboxItem,
-} from "@/components/ui/dropdown-menu";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { Sheet, SheetContent } from "@/components/ui/sheet";
 
 import { Cenario, Oportunidade, OrdemKey } from "@/components/reposicao/oportunidades/types";
-import {
-  EMPRESA,
-  ALL,
-  CENARIOS,
-  formatBRL,
-  formatNumber,
-  formatDate,
-  formatDateLong,
-  diasEntre,
-  cenarioIcon,
-  cenarioLabel,
-  descontoBadgeClass,
-  diasBadge,
-} from "@/components/reposicao/oportunidades/shared";
-import { EstadoVazio, DrawerConteudo } from "@/components/reposicao/oportunidades/components";
+import { EMPRESA, ALL, CENARIOS, formatBRL, diasEntre } from "@/components/reposicao/oportunidades/shared";
+import { DrawerConteudo } from "@/components/reposicao/oportunidades/components";
+import { KpiCards } from "@/components/reposicao/oportunidades/KpiCards";
+import { NegociacaoBanner } from "@/components/reposicao/oportunidades/NegociacaoBanner";
+import { OportunidadesFiltros } from "@/components/reposicao/oportunidades/OportunidadesFiltros";
+import { OportunidadesTable } from "@/components/reposicao/oportunidades/OportunidadesTable";
+import { GerarCicloDialog } from "@/components/reposicao/oportunidades/GerarCicloDialog";
 
 export default function AdminReposicaoOportunidades() {
   const navigate = useNavigate();
@@ -322,36 +258,14 @@ export default function AdminReposicaoOportunidades() {
         </header>
 
         {!bannerNegociacaoFechado && negociacaoNovasCount > 0 && (
-          <div className="flex items-center justify-between gap-3 rounded-lg border border-status-info/30 bg-status-info/10 px-4 py-3 text-sm">
-            <div className="flex items-center gap-2 flex-1">
-              <Handshake className="h-4 w-4 text-status-info dark:text-status-info shrink-0" />
-              <span>
-                <strong>{negociacaoNovasCount}</strong> SKU{negociacaoNovasCount === 1 ? '' : 's'}{' '}
-                {negociacaoNovasCount === 1 ? 'foi sugerido' : 'foram sugeridos'} para negociação paralela.
-              </span>
-            </div>
-            <div className="flex items-center gap-2 shrink-0">
-              <Button
-                size="sm"
-                variant="outline"
-                onClick={() => navigate('/admin/reposicao/negociacao-paralela')}
-              >
-                Ver sugestões
-              </Button>
-              <Button
-                size="icon"
-                variant="ghost"
-                className="h-7 w-7"
-                onClick={() => {
-                  sessionStorage.setItem('banner-negociacao-fechado', '1');
-                  setBannerNegociacaoFechado(true);
-                }}
-                aria-label="Fechar"
-              >
-                <X className="h-4 w-4" />
-              </Button>
-            </div>
-          </div>
+          <NegociacaoBanner
+            count={negociacaoNovasCount}
+            onVerSugestoes={() => navigate('/admin/reposicao/negociacao-paralela')}
+            onFechar={() => {
+              sessionStorage.setItem('banner-negociacao-fechado', '1');
+              setBannerNegociacaoFechado(true);
+            }}
+          />
         )}
 
         {historicoPromocoes && historicoPromocoes.campanhas > 0 && (
@@ -371,105 +285,15 @@ export default function AdminReposicaoOportunidades() {
         )}
 
         {/* KPI Cards */}
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
-          <Card>
-            <CardHeader className="pb-2">
-              <CardTitle className="text-xs font-medium text-muted-foreground">
-                Economia total potencial hoje
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="text-2xl font-bold text-status-success tabular-nums">
-                {formatBRL(totalEconomia)}
-              </div>
-              <p className="text-xs text-muted-foreground mt-1">
-                considerando promoções e aumentos vigentes
-              </p>
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader className="pb-2">
-              <CardTitle className="text-xs font-medium text-muted-foreground">
-                SKUs com oportunidade
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="text-2xl font-bold tabular-nums">
-                {oportunidades.length}
-              </div>
-              <p className="text-xs text-muted-foreground mt-1">
-                de {totalSkusAtivos} SKUs ativos
-              </p>
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader className="pb-2">
-              <CardTitle className="text-xs font-medium text-muted-foreground">
-                Data limite mais próxima
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              {dataLimiteMaisProxima ? (
-                <>
-                  <div className="text-lg font-bold tabular-nums">
-                    {formatDateLong(dataLimiteMaisProxima)}
-                  </div>
-                  <div className="mt-1">
-                    <Badge variant="outline" className={diasBadge(diasAteLimite)}>
-                      em {diasAteLimite} {diasAteLimite === 1 ? "dia" : "dias"}
-                    </Badge>
-                  </div>
-                  <p className="text-xs text-muted-foreground mt-2">
-                    Próxima janela crítica
-                  </p>
-                </>
-              ) : (
-                <>
-                  <div className="text-lg font-bold text-muted-foreground">—</div>
-                  <p className="text-xs text-muted-foreground mt-1">
-                    Sem janelas ativas
-                  </p>
-                </>
-              )}
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader className="pb-2">
-              <CardTitle className="text-xs font-medium text-muted-foreground">
-                Ciclo oportunidade do dia
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              {cicloHoje > 0 ? (
-                <>
-                  <Badge
-                    className="bg-status-success/15 text-status-success border-status-success/30 cursor-pointer hover:bg-status-success/25"
-                    variant="outline"
-                    onClick={() => setConfirmCicloOpen(true)}
-                  >
-                    <PlayCircle className="h-3 w-3 mr-1" />
-                    Gerar ciclo oportunidade
-                  </Badge>
-                  <p className="text-xs text-muted-foreground mt-2">
-                    {cicloHoje} {cicloHoje === 1 ? "evento" : "eventos"} encerra(m) hoje
-                  </p>
-                </>
-              ) : (
-                <>
-                  <Badge variant="outline" className="text-muted-foreground">
-                    Sem ciclo hoje
-                  </Badge>
-                  <p className="text-xs text-muted-foreground mt-2">
-                    Próxima janela crítica ainda não chegou
-                  </p>
-                </>
-              )}
-            </CardContent>
-          </Card>
-        </div>
+        <KpiCards
+          totalEconomia={totalEconomia}
+          oportunidadesCount={oportunidades.length}
+          totalSkusAtivos={totalSkusAtivos}
+          dataLimiteMaisProxima={dataLimiteMaisProxima}
+          diasAteLimite={diasAteLimite}
+          cicloHoje={cicloHoje}
+          onGerarCiclo={() => setConfirmCicloOpen(true)}
+        />
 
         {/* Filtros + Tabela */}
         <Card>
@@ -477,226 +301,27 @@ export default function AdminReposicaoOportunidades() {
             <CardTitle className="text-base">Oportunidades ativas</CardTitle>
           </CardHeader>
           <CardContent className="space-y-4">
-            <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button variant="outline" className="justify-between">
-                    {cenariosLabel}
-                    <ChevronRight className="h-4 w-4 rotate-90 opacity-50" />
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent className="w-56" align="start">
-                  {CENARIOS.map((c) => (
-                    <DropdownMenuCheckboxItem
-                      key={c.value}
-                      checked={cenariosSelecionados.has(c.value)}
-                      onCheckedChange={(checked) => toggleCenario(c.value, !!checked)}
-                      onSelect={(e) => e.preventDefault()}
-                    >
-                      <span className="flex items-center gap-2">
-                        {cenarioIcon(c.value)}
-                        {c.label}
-                      </span>
-                    </DropdownMenuCheckboxItem>
-                  ))}
-                </DropdownMenuContent>
-              </DropdownMenu>
+            <OportunidadesFiltros
+              cenariosSelecionados={cenariosSelecionados}
+              cenariosLabel={cenariosLabel}
+              toggleCenario={toggleCenario}
+              filtroFornecedor={filtroFornecedor}
+              setFiltroFornecedor={setFiltroFornecedor}
+              fornecedoresUnicos={fornecedoresUnicos}
+              ordenacao={ordenacao}
+              setOrdenacao={setOrdenacao}
+              apenasComEconomia={apenasComEconomia}
+              setApenasComEconomia={setApenasComEconomia}
+            />
 
-              <Select value={filtroFornecedor} onValueChange={setFiltroFornecedor}>
-                <SelectTrigger>
-                  <SelectValue placeholder="Fornecedor" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value={ALL}>Todos os fornecedores</SelectItem>
-                  {fornecedoresUnicos.map((f) => (
-                    <SelectItem key={f} value={f}>
-                      {f}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-
-              <Select value={ordenacao} onValueChange={(v) => setOrdenacao(v as OrdemKey)}>
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="economia">Maior economia</SelectItem>
-                  <SelectItem value="data_limite">Data limite mais próxima</SelectItem>
-                  <SelectItem value="desconto">Maior % desconto</SelectItem>
-                  <SelectItem value="sku">SKU alfabético</SelectItem>
-                </SelectContent>
-              </Select>
-
-              <div className="flex items-center justify-end gap-2 px-2">
-                <Switch
-                  id="apenas-economia"
-                  checked={apenasComEconomia}
-                  onCheckedChange={setApenasComEconomia}
-                />
-                <Label htmlFor="apenas-economia" className="text-sm cursor-pointer">
-                  Apenas com economia &gt; 0
-                </Label>
-              </div>
-            </div>
-
-            {/* Tabela */}
-            {isLoading ? (
-              <div className="flex items-center gap-2 text-sm text-muted-foreground py-12 justify-center">
-                <Loader2 className="h-4 w-4 animate-spin" /> Carregando…
-              </div>
-            ) : oportunidades.length === 0 ? (
-              <EstadoVazio navigate={navigate} />
-            ) : (
-              <div className="overflow-x-auto">
-                <Table>
-                  <TableHeader>
-                    <TableRow>
-                      <TableHead className="w-10"></TableHead>
-                      <TableHead>SKU / Descrição</TableHead>
-                      <TableHead>Fornecedor</TableHead>
-                      <TableHead className="text-right">Desconto total</TableHead>
-                      <TableHead className="text-right">Qtde sugerida</TableHead>
-                      <TableHead>Data limite</TableHead>
-                      <TableHead className="text-right">Economia bruta</TableHead>
-                      <TableHead className="w-20 text-right">Ações</TableHead>
-                    </TableRow>
-                  </TableHeader>
-                  <TableBody>
-                    {oportunidadesFiltradas.length === 0 && (
-                      <TableRow>
-                        <TableCell colSpan={8} className="text-center text-muted-foreground py-12">
-                          Nenhum SKU bate os filtros atuais.
-                        </TableCell>
-                      </TableRow>
-                    )}
-                    {oportunidadesFiltradas.map((o) => (
-                      <TableRow key={`${o.sku_codigo_omie}-${o.cenario}`}>
-                        <TableCell>
-                          <Tooltip>
-                            <TooltipTrigger asChild>
-                              <span className="inline-flex">{cenarioIcon(o.cenario)}</span>
-                            </TooltipTrigger>
-                            <TooltipContent>{cenarioLabel(o.cenario)}</TooltipContent>
-                          </Tooltip>
-                        </TableCell>
-                        <TableCell>
-                          <div className="font-medium tabular-nums text-xs text-muted-foreground">
-                            {o.sku_codigo_omie}
-                          </div>
-                          <div className="text-sm">{o.sku_descricao ?? "—"}</div>
-                        </TableCell>
-                        <TableCell className="text-sm text-muted-foreground">
-                          {o.fornecedor_nome ?? "—"}
-                        </TableCell>
-                        <TableCell className="text-right">
-                          <Tooltip>
-                            <TooltipTrigger asChild>
-                              <Badge
-                                variant="outline"
-                                className={descontoBadgeClass(o.desconto_total_perc)}
-                              >
-                                {formatNumber(o.desconto_total_perc, 1)}%
-                              </Badge>
-                            </TooltipTrigger>
-                            <TooltipContent className="max-w-xs">
-                              <div className="space-y-1 text-xs">
-                                <div>
-                                  Base promo: {formatNumber(o.desconto_promo_perc, 2)}%
-                                </div>
-                                {o.tem_negociacao_extra && (
-                                  <div>+ Extra negociado</div>
-                                )}
-                                {o.aumento_evitado_perc !== null &&
-                                  Number(o.aumento_evitado_perc) > 0 && (
-                                    <div>
-                                      + Aumento evitado:{" "}
-                                      {formatNumber(o.aumento_evitado_perc, 2)}%
-                                    </div>
-                                  )}
-                              </div>
-                            </TooltipContent>
-                          </Tooltip>
-                        </TableCell>
-                        <TableCell className="text-right tabular-nums">
-                          <Tooltip>
-                            <TooltipTrigger asChild>
-                              <span className="font-medium">
-                                {formatNumber(o.qtde_oportunidade, 0)}
-                              </span>
-                            </TooltipTrigger>
-                            <TooltipContent>
-                              <div className="text-xs space-y-1">
-                                <div>
-                                  Demanda diária: {formatNumber(o.demanda_diaria, 2)}
-                                </div>
-                                <div>
-                                  Quantidade base EOQ: {formatNumber(o.qtde_base, 0)}
-                                </div>
-                              </div>
-                            </TooltipContent>
-                          </Tooltip>
-                        </TableCell>
-                        <TableCell className="text-sm">
-                          <div className="tabular-nums">{formatDate(o.data_limite_acao)}</div>
-                          <div className="text-xs text-muted-foreground">
-                            {o.dias_ate_limite !== null
-                              ? `em ${o.dias_ate_limite} ${o.dias_ate_limite === 1 ? "dia" : "dias"}`
-                              : ""}
-                          </div>
-                        </TableCell>
-                        <TableCell
-                          className={`text-right tabular-nums font-medium ${
-                            Number(o.economia_bruta_estimada ?? 0) > 0
-                              ? "text-status-success"
-                              : "text-muted-foreground"
-                          }`}
-                        >
-                          {formatBRL(o.economia_bruta_estimada)}
-                        </TableCell>
-                        <TableCell className="text-right">
-                          <div className="flex items-center justify-end gap-1">
-                            <Button
-                              size="icon"
-                              variant="ghost"
-                              className="h-8 w-8"
-                              onClick={() => setDrawerSku(o)}
-                            >
-                              <ChevronRight className="h-4 w-4" />
-                            </Button>
-                            <DropdownMenu>
-                              <DropdownMenuTrigger asChild>
-                                <Button size="icon" variant="ghost" className="h-8 w-8">
-                                  <MoreVertical className="h-4 w-4" />
-                                </Button>
-                              </DropdownMenuTrigger>
-                              <DropdownMenuContent align="end">
-                                <DropdownMenuItem
-                                  onClick={() =>
-                                    navigate(
-                                      `/admin/reposicao/skus/${o.sku_codigo_omie}`,
-                                    )
-                                  }
-                                >
-                                  <ArrowRight className="h-4 w-4 mr-2" />
-                                  Ir para SKU em reposição
-                                </DropdownMenuItem>
-                                <DropdownMenuItem
-                                  onClick={() => handleIgnorar(o.sku_codigo_omie)}
-                                >
-                                  <EyeOff className="h-4 w-4 mr-2" />
-                                  Ignorar hoje
-                                </DropdownMenuItem>
-                              </DropdownMenuContent>
-                            </DropdownMenu>
-                          </div>
-                        </TableCell>
-                      </TableRow>
-                    ))}
-                  </TableBody>
-                </Table>
-              </div>
-            )}
+            <OportunidadesTable
+              isLoading={isLoading}
+              totalCount={oportunidades.length}
+              rows={oportunidadesFiltradas}
+              navigate={navigate}
+              onOpenDrawer={setDrawerSku}
+              onIgnorar={handleIgnorar}
+            />
           </CardContent>
         </Card>
 
@@ -708,37 +333,14 @@ export default function AdminReposicaoOportunidades() {
         </Sheet>
 
         {/* Confirmação ciclo */}
-        <AlertDialog open={confirmCicloOpen} onOpenChange={setConfirmCicloOpen}>
-          <AlertDialogContent>
-            <AlertDialogHeader>
-              <AlertDialogTitle>Gerar ciclo de oportunidade do dia</AlertDialogTitle>
-              <AlertDialogDescription>
-                Vai gerar pedidos de oportunidade para{" "}
-                <strong>{oportunidades.length} SKUs</strong>, com economia total
-                estimada de{" "}
-                <strong className="text-status-success">
-                  {formatBRL(totalEconomia)}
-                </strong>
-                . Continuar?
-              </AlertDialogDescription>
-            </AlertDialogHeader>
-            <AlertDialogFooter>
-              <AlertDialogCancel disabled={executandoCiclo}>
-                Cancelar
-              </AlertDialogCancel>
-              <AlertDialogAction
-                onClick={(e) => {
-                  e.preventDefault();
-                  handleGerarCiclo();
-                }}
-                disabled={executandoCiclo}
-              >
-                {executandoCiclo && <Loader2 className="h-4 w-4 animate-spin mr-2" />}
-                Confirmar e gerar
-              </AlertDialogAction>
-            </AlertDialogFooter>
-          </AlertDialogContent>
-        </AlertDialog>
+        <GerarCicloDialog
+          open={confirmCicloOpen}
+          onOpenChange={setConfirmCicloOpen}
+          oportunidadesCount={oportunidades.length}
+          totalEconomia={totalEconomia}
+          executando={executandoCiclo}
+          onConfirm={handleGerarCiclo}
+        />
       </div>
     </TooltipProvider>
   );


### PR DESCRIPTION
## Resumo

Continua o split do god-component `src/pages/AdminReposicaoOportunidades.tsx` (já tinha `types`/`shared`/`components` extraídos): tira o restante do render inline para 5 componentes em `src/components/reposicao/oportunidades/`. **745 → 347 linhas**. Refactor **comportamento-preservante 1:1**.

- **`KpiCards.tsx`** — os 4 KPIs (economia / SKUs / data limite / ciclo do dia).
- **`NegociacaoBanner.tsx`** — banner de sugestões de negociação paralela.
- **`OportunidadesFiltros.tsx`** — cenários (DropdownMenu multi) + fornecedor + ordenação + switch.
- **`OportunidadesTable.tsx`** — tabela (loading/vazio→EstadoVazio/linhas com tooltips e ações).
- **`GerarCicloDialog.tsx`** — AlertDialog de confirmação do ciclo.

### Decisão de arquitetura

As 5 `useQuery`, os useMemo derivados (`oportunidadesFiltradas` com sort de 4 chaves, `totalEconomia`, `dataLimiteMaisProxima`, `diasAteLimite`, `fornecedoresUnicos`) e os handlers permanecem **no pai** (que segue dentro de `<TooltipProvider>`).

## Garantias

- ✅ `bunx tsc --noEmit` — 0 erros.
- ✅ `bun lint` — 0 problemas nos arquivos tocados.
- ✅ Suíte: **618/618** passando.
- ✅ +11 testes novos (5 arquivos): KPIs, banner, filtros, tabela (loading/vazio/linha/drawer) e dialog.
- ✅ Revisão independente (subagente): veredito **FIEL 1:1** — as 5 queries, o sort de `oportunidadesFiltradas`, `handleGerarCiclo` e os tooltips da tabela byte-a-byte idênticos.

## Test plan

- [x] tsc 0 erros / lint 0 problemas
- [x] 11 testes novos + suíte completa 618/618
- [x] revisão independente confirma 1:1
- [ ] CI `validate` verde (inclui build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)