### PR TITLE
chore(ts-strict): promove 8 a strict (lote 3 — lib boundary + componentes leaf)

### DIFF
--- a/tsconfig.strict.json
+++ b/tsconfig.strict.json
@@ -427,6 +427,14 @@
     "src/components/ui/chart.tsx",
     "src/components/ui/sidebar.tsx",
     "src/lib/spin/types.ts",
-    "src/lib/spin/spin-prompts.ts"
+    "src/lib/spin/spin-prompts.ts",
+    "src/lib/sip/sip-client.ts",
+    "src/lib/transcription/deepgram-client.ts",
+    "src/lib/transcription/transcription-engine.ts",
+    "src/lib/call-session/aggregate-customer-profile.ts",
+    "src/components/AddToolDialog.tsx",
+    "src/components/OrderPrintLayout.tsx",
+    "src/components/SendingQualityChecklist.tsx",
+    "src/components/ToolImageIdentifier.tsx"
   ]
 }


### PR DESCRIPTION
Parte B lote 3 (tsconfig-only, 0 edição de source). `typecheck:strict` = 0 erros (validado local, run completo). Promove 4 lib de boundary externo (sip-client, transcription ×2, call-session) + 4 componentes leaf (AddToolDialog, OrderPrintLayout, SendingQualityChecklist, ToolImageIdentifier). SharpeningSuggestions podado (4× TS6133 — fix estrutural do forwardRef fica pra depois). include 409→417. Auto-merge só com CI verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)