### PR TITLE
refactor(tint): split god-component TintImport (726→387)

### DIFF
--- a/src/components/tintImport/HistoryTable.tsx
+++ b/src/components/tintImport/HistoryTable.tsx
@@ -1,0 +1,69 @@
+// Tabela "Histórico de Importações" da Importação Tintométrica.
+// Extraída de src/pages/TintImport.tsx (god-component split).
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { RotateCcw, Loader2 } from 'lucide-react';
+import { statusColor, type TintImportacaoRow } from './types';
+
+export function HistoryTable({
+  history, histLoading, importing, resumingId, onResume,
+}: {
+  history: TintImportacaoRow[];
+  histLoading: boolean;
+  importing: boolean;
+  resumingId: string | null;
+  onResume: (imp: TintImportacaoRow) => void;
+}) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Histórico de Importações</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Data</TableHead>
+              <TableHead>Tipo</TableHead>
+              <TableHead>Arquivo</TableHead>
+              <TableHead>Registros</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead></TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {histLoading ? (
+              <TableRow><TableCell colSpan={6}><Skeleton className="h-6 w-full" /></TableCell></TableRow>
+            ) : history.map((imp) => (
+              <TableRow key={imp.id}>
+                <TableCell className="text-sm">{new Date(imp.created_at).toLocaleDateString('pt-BR')}</TableCell>
+                <TableCell className="text-sm">{imp.tipo}</TableCell>
+                <TableCell className="text-sm max-w-[200px] truncate">{imp.arquivo_nome}</TableCell>
+                <TableCell className="text-sm">{(imp.registros_importados ?? 0) + (imp.registros_atualizados ?? 0)} / {imp.total_registros ?? 0}</TableCell>
+                <TableCell>
+                  <Badge variant="outline" className={statusColor[imp.status] || ''}>{imp.status}</Badge>
+                </TableCell>
+                <TableCell>
+                  {(imp.status === 'processando' || imp.status === 'concluido_parcial') && (
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      disabled={importing || resumingId === imp.id}
+                      onClick={() => onResume(imp)}
+                    >
+                      {resumingId === imp.id ? <Loader2 className="w-3 h-3 mr-1 animate-spin" /> : <RotateCcw className="w-3 h-3 mr-1" />}
+                      Retomar
+                    </Button>
+                  )}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/tintImport/ImportCard.tsx
+++ b/src/components/tintImport/ImportCard.tsx
@@ -1,0 +1,205 @@
+// Card "Importar CSV do SAYERSYSTEM" da Importação Tintométrica.
+// Extraído de src/pages/TintImport.tsx (god-component split).
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Progress } from '@/components/ui/progress';
+import { Upload, FileText, CheckCircle, AlertTriangle, Loader2, Zap, Cloud } from 'lucide-react';
+import Papa from 'papaparse';
+import { TIPO_OPTIONS, type FileWithPreview, type TintImportFileResult } from './types';
+
+type DirectProgress = {
+  phase: string;
+  currentBatch: number;
+  totalBatches: number;
+  recordsProcessed: number;
+  totalRecords: number;
+  imported: number;
+  updated: number;
+  errors: number;
+};
+
+type ChunkProgress = {
+  currentFile: number;
+  totalFiles: number;
+  fileName: string;
+  currentChunk: number;
+  totalChunks: number;
+};
+
+export function ImportCard({
+  tipo, setTipo, importMode, setImportMode, files, onFiles,
+  importing, directRunning, directProgress, chunkProgress, progressPct, results,
+  onImport, onCancelDirect,
+}: {
+  tipo: string;
+  setTipo: (v: string) => void;
+  importMode: 'auto' | 'edge' | 'direct' | 'rpc';
+  setImportMode: (v: 'auto' | 'edge' | 'direct' | 'rpc') => void;
+  files: FileWithPreview[];
+  onFiles: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  importing: boolean;
+  directRunning: boolean;
+  directProgress?: DirectProgress | null;
+  chunkProgress: ChunkProgress;
+  progressPct: number;
+  results: TintImportFileResult[];
+  onImport: () => void;
+  onCancelDirect: () => void;
+}) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Importar CSV do SAYERSYSTEM</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="flex gap-4 flex-wrap">
+          <div className="max-w-sm flex-1">
+            <label className="text-sm font-medium mb-1 block">Tipo de importação</label>
+            <Select value={tipo} onValueChange={setTipo}>
+              <SelectTrigger><SelectValue placeholder="Selecione o tipo" /></SelectTrigger>
+              <SelectContent>
+                {TIPO_OPTIONS.map(o => <SelectItem key={o.value} value={o.value}>{o.label}</SelectItem>)}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="max-w-xs">
+            <label className="text-sm font-medium mb-1 block">Modo de importação</label>
+            <Select value={importMode} onValueChange={(v) => setImportMode(v as 'auto' | 'edge' | 'direct' | 'rpc')}>
+              <SelectTrigger><SelectValue /></SelectTrigger>
+              <SelectContent>
+                <SelectItem value="auto">Automático (recomendado)</SelectItem>
+                <SelectItem value="rpc">⚡ RPC Postgres (mais rápido)</SelectItem>
+                <SelectItem value="direct">Importação Direta (SQL)</SelectItem>
+                <SelectItem value="edge">Edge Function (legacy)</SelectItem>
+              </SelectContent>
+            </Select>
+            <p className="text-xs text-muted-foreground mt-1">
+              {importMode === 'auto' && 'Fórmulas grandes: RPC Postgres | Auxiliares: Direto | < 500 linhas: Edge'}
+              {importMode === 'rpc' && '2.000 linhas por lote, processado nativamente no Postgres (~45s para 29k linhas)'}
+              {importMode === 'direct' && 'Sem edge function. 200 linhas por lote via JS client'}
+              {importMode === 'edge' && 'Usa edge function com chunks. Pode dar timeout em arquivos grandes'}
+            </p>
+          </div>
+        </div>
+
+        <div>
+          <label className="text-sm font-medium mb-1 block">Arquivos CSV</label>
+          <div className="border-2 border-dashed rounded-lg p-6 text-center hover:border-primary/50 transition-colors">
+            <Upload className="w-8 h-8 mx-auto text-muted-foreground mb-2" />
+            <p className="text-sm text-muted-foreground mb-2">Arraste arquivos ou clique para selecionar</p>
+            <input
+              type="file"
+              accept=".csv,.txt"
+              multiple
+              onChange={onFiles}
+              className="block w-full text-sm file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-medium file:bg-primary file:text-primary-foreground hover:file:bg-primary/90 cursor-pointer"
+            />
+          </div>
+        </div>
+
+        {/* Preview */}
+        {files.length > 0 && (
+          <div className="space-y-3">
+            {files.map((f, idx) => {
+              const lineCount = Papa.parse(f.rawText, { delimiter: ';', skipEmptyLines: true }).data.length - 1;
+              const useDirectMode = importMode === 'direct' || importMode === 'rpc' || (importMode === 'auto' && lineCount >= 500);
+              return (
+                <div key={idx} className="border rounded-md p-3">
+                  <div className="flex items-center gap-2 mb-2">
+                    <FileText className="w-4 h-4" />
+                    <span className="text-sm font-medium">{f.name}</span>
+                    <Badge variant="outline">{lineCount} linhas</Badge>
+                    {useDirectMode ? (
+                      <Badge variant="secondary" className="gap-1">
+                        <Zap className="w-3 h-3" /> {importMode === 'rpc' || (importMode === 'auto' && (tipo === 'formulas_padrao' || tipo === 'formulas_personalizadas')) ? 'RPC Postgres' : 'Direto'}
+                      </Badge>
+                    ) : (
+                      <Badge variant="outline" className="gap-1"><Cloud className="w-3 h-3" /> Edge Function</Badge>
+                    )}
+                  </div>
+                  <div className="overflow-x-auto">
+                    <table className="text-xs">
+                      <tbody>
+                        {f.preview.map((row, ri) => (
+                          <tr key={ri} className={ri === 0 ? 'font-semibold bg-muted/50' : ''}>
+                            {row.map((cell, ci) => (
+                              <td key={ci} className="px-2 py-0.5 border-b whitespace-nowrap max-w-[200px] truncate">{cell}</td>
+                            ))}
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+
+        {/* Progress — Edge Function mode */}
+        {importing && !directRunning && (
+          <div className="space-y-2">
+            <p className="text-sm">
+              <Cloud className="w-4 h-4 inline mr-1" />
+              Importando <span className="font-medium">{chunkProgress.fileName}</span>
+              {' '}(arquivo {chunkProgress.currentFile}/{chunkProgress.totalFiles})
+              {chunkProgress.totalChunks > 1 && (
+                <> — chunk {chunkProgress.currentChunk}/{chunkProgress.totalChunks}</>
+              )}
+            </p>
+            <Progress value={progressPct} />
+          </div>
+        )}
+
+        {/* Progress — Direct mode */}
+        {directRunning && directProgress && (
+          <div className="space-y-2">
+            <p className="text-sm">
+              <Zap className="w-4 h-4 inline mr-1" />
+              {directProgress.phase} — Lote {directProgress.currentBatch}/{directProgress.totalBatches}
+              {' '}({directProgress.recordsProcessed.toLocaleString()} / {directProgress.totalRecords.toLocaleString()} registros)
+            </p>
+            <Progress value={(directProgress.recordsProcessed / directProgress.totalRecords) * 100} />
+            <p className="text-xs text-muted-foreground">
+              {directProgress.imported} importados, {directProgress.updated} atualizados, {directProgress.errors} erros
+            </p>
+            <Button size="sm" variant="outline" onClick={onCancelDirect}>Cancelar</Button>
+          </div>
+        )}
+
+        {/* Results */}
+        {results.length > 0 && (
+          <div className="space-y-2">
+            <h3 className="text-sm font-semibold">Resultado</h3>
+            {results.map((r, i) => (
+              <div key={i} className="border rounded-md p-3 flex items-start gap-3">
+                {r.status === 'concluido' ? <CheckCircle className="w-4 h-4 text-green-500 mt-0.5" /> : <AlertTriangle className="w-4 h-4 text-yellow-500 mt-0.5" />}
+                <div className="text-sm">
+                  <p className="font-medium">{r.name}</p>
+                  <p className="text-muted-foreground">
+                    {r.registros_importados ?? r.imported ?? 0} importados, {r.registros_atualizados ?? r.updated ?? 0} atualizados, {r.registros_erro ?? r.errors ?? 0} erros
+                    {r.failed_chunks > 0 && <span className="text-destructive"> ({r.failed_chunks} chunks falharam)</span>}
+                  </p>
+                  {r.erros && r.erros.length > 0 && (
+                    <ul className="text-xs text-destructive mt-1">
+                      {r.erros.slice(0, 5).map((e, j: number) => <li key={j}>Linha {e.linha}: {e.motivo}</li>)}
+                    </ul>
+                  )}
+                  {r.error && <p className="text-xs text-destructive">{r.error}</p>}
+                  {r.status === 'duplicado' && <p className="text-xs text-muted-foreground">{r.message || 'Arquivo já importado anteriormente'}</p>}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+
+        <Button onClick={onImport} disabled={importing || directRunning || !tipo || files.length === 0}>
+          {(importing || directRunning) ? <Loader2 className="w-4 h-4 mr-2 animate-spin" /> : <Upload className="w-4 h-4 mr-2" />}
+          Importar
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/tintImport/SyncCard.tsx
+++ b/src/components/tintImport/SyncCard.tsx
@@ -1,0 +1,36 @@
+// Card "Sincronizar Produtos Omie" da Importação Tintométrica.
+// Extraído de src/pages/TintImport.tsx (god-component split).
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { RefreshCw, Loader2 } from 'lucide-react';
+
+export function SyncCard({
+  syncing, onSync, tintCounts,
+}: {
+  syncing: boolean;
+  onSync: () => void;
+  tintCounts?: { bases: number; concentrados: number };
+}) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Sincronizar Produtos Omie</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <p className="text-sm text-muted-foreground mb-3">
+          Importa bases e concentrados tintométricos do Omie para o sistema.
+        </p>
+        <Button onClick={onSync} disabled={syncing}>
+          {syncing ? <Loader2 className="w-4 h-4 mr-2 animate-spin" /> : <RefreshCw className="w-4 h-4 mr-2" />}
+          Sincronizar Produtos Omie
+        </Button>
+        {tintCounts && (tintCounts.bases > 0 || tintCounts.concentrados > 0) && (
+          <p className="text-sm text-muted-foreground mt-3">
+            <span className="font-medium text-foreground">{tintCounts.bases}</span> bases e{' '}
+            <span className="font-medium text-foreground">{tintCounts.concentrados}</span> concentrados encontrados no Omie
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/tintImport/__tests__/HistoryTable.test.tsx
+++ b/src/components/tintImport/__tests__/HistoryTable.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { HistoryTable } from '../HistoryTable';
+import type { TintImportacaoRow } from '../types';
+
+const row = (over: Partial<TintImportacaoRow> = {}): TintImportacaoRow => ({
+  id: 'imp-1',
+  tipo: 'dados_corantes',
+  arquivo_nome: 'corantes.csv',
+  status: 'concluido',
+  total_registros: 100,
+  registros_importados: 80,
+  registros_atualizados: 20,
+  registros_erro: 0,
+  created_at: '2026-01-10T10:00:00',
+  ...over,
+});
+
+function noop() { /* */ }
+
+describe('HistoryTable', () => {
+  it('renderiza linha com arquivo, registros e status', () => {
+    render(<HistoryTable history={[row()]} histLoading={false} importing={false} resumingId={null} onResume={noop} />);
+    expect(screen.getByText('corantes.csv')).toBeTruthy();
+    expect(screen.getByText('100 / 100')).toBeTruthy();
+    expect(screen.getByText('concluido')).toBeTruthy();
+  });
+
+  it('status concluido → sem botão Retomar', () => {
+    render(<HistoryTable history={[row()]} histLoading={false} importing={false} resumingId={null} onResume={noop} />);
+    expect(screen.queryByRole('button', { name: /Retomar/ })).toBeNull();
+  });
+
+  it('status concluido_parcial → botão Retomar dispara onResume', () => {
+    const onResume = vi.fn();
+    const r = row({ status: 'concluido_parcial' });
+    render(<HistoryTable history={[r]} histLoading={false} importing={false} resumingId={null} onResume={onResume} />);
+    fireEvent.click(screen.getByRole('button', { name: /Retomar/ }));
+    expect(onResume).toHaveBeenCalledWith(r);
+  });
+});

--- a/src/components/tintImport/__tests__/ImportCard.test.tsx
+++ b/src/components/tintImport/__tests__/ImportCard.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ImportCard } from '../ImportCard';
+import type { FileWithPreview, TintImportFileResult } from '../types';
+
+const fileFix: FileWithPreview = {
+  file: new File(['a;b\n1;2'], 'teste.csv', { type: 'text/csv' }),
+  preview: [['Col A', 'Col B'], ['1', '2']],
+  name: 'teste.csv',
+  rawText: 'a;b\n1;2',
+};
+
+function noop() { /* */ }
+
+function baseProps(over: Partial<React.ComponentProps<typeof ImportCard>> = {}): React.ComponentProps<typeof ImportCard> {
+  return {
+    tipo: '',
+    setTipo: noop,
+    importMode: 'auto',
+    setImportMode: noop,
+    files: [],
+    onFiles: noop,
+    importing: false,
+    directRunning: false,
+    directProgress: null,
+    chunkProgress: { currentFile: 0, totalFiles: 0, fileName: '', currentChunk: 0, totalChunks: 0 },
+    progressPct: 0,
+    results: [],
+    onImport: noop,
+    onCancelDirect: noop,
+    ...over,
+  };
+}
+
+describe('ImportCard', () => {
+  it('sem tipo/arquivos → botão Importar desabilitado', () => {
+    render(<ImportCard {...baseProps()} />);
+    expect((screen.getByRole('button', { name: /Importar/ }) as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('com tipo e arquivo → preview, contador de linhas e Importar habilitado dispara onImport', () => {
+    const onImport = vi.fn();
+    render(<ImportCard {...baseProps({ tipo: 'dados_corantes', files: [fileFix], onImport })} />);
+    expect(screen.getByText('teste.csv')).toBeTruthy();
+    expect(screen.getByText('Col A')).toBeTruthy();
+    expect(screen.getByText(/1 linhas/)).toBeTruthy();
+    const btn = screen.getByRole('button', { name: /Importar/ }) as HTMLButtonElement;
+    expect(btn.disabled).toBe(false);
+    fireEvent.click(btn);
+    expect(onImport).toHaveBeenCalled();
+  });
+
+  it('mostra resultados de importação', () => {
+    const results: TintImportFileResult[] = [
+      { name: 'teste.csv', status: 'concluido', registros_importados: 10, registros_atualizados: 3, registros_erro: 0 },
+    ];
+    render(<ImportCard {...baseProps({ results })} />);
+    expect(screen.getByText('Resultado')).toBeTruthy();
+    expect(screen.getByText(/10 importados, 3 atualizados, 0 erros/)).toBeTruthy();
+  });
+});

--- a/src/components/tintImport/__tests__/SyncCard.test.tsx
+++ b/src/components/tintImport/__tests__/SyncCard.test.tsx
@@ -1,0 +1,23 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { SyncCard } from '../SyncCard';
+
+describe('SyncCard', () => {
+  it('renderiza e o botão dispara onSync', () => {
+    const onSync = vi.fn();
+    render(<SyncCard syncing={false} onSync={onSync} />);
+    fireEvent.click(screen.getByRole('button', { name: /Sincronizar Produtos Omie/ }));
+    expect(onSync).toHaveBeenCalled();
+  });
+
+  it('mostra contagens quando há produtos', () => {
+    render(<SyncCard syncing={false} onSync={() => {}} tintCounts={{ bases: 4, concentrados: 9 }} />);
+    expect(screen.getByText('4')).toBeTruthy();
+    expect(screen.getByText('9')).toBeTruthy();
+  });
+
+  it('botão desabilitado quando syncing', () => {
+    render(<SyncCard syncing onSync={() => {}} />);
+    expect((screen.getByRole('button', { name: /Sincronizar/ }) as HTMLButtonElement).disabled).toBe(true);
+  });
+});

--- a/src/components/tintImport/__tests__/types.test.ts
+++ b/src/components/tintImport/__tests__/types.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@/lib/invoke-function', () => ({ invokeFunction: vi.fn() }));
+
+import { invokeFunction } from '@/lib/invoke-function';
+import {
+  getChunkSize, sha256, sleep, sendChunkWithRetry,
+  TIPO_OPTIONS, statusColor, CHUNK_SIZE_DEFAULT, CHUNK_SIZE_FORMULAS,
+} from '../types';
+
+describe('getChunkSize', () => {
+  it('fórmulas → 50; demais → 200', () => {
+    expect(getChunkSize('formulas_padrao')).toBe(CHUNK_SIZE_FORMULAS);
+    expect(getChunkSize('formulas_personalizadas')).toBe(CHUNK_SIZE_FORMULAS);
+    expect(getChunkSize('dados_corantes')).toBe(CHUNK_SIZE_DEFAULT);
+    expect(getChunkSize('qualquer')).toBe(200);
+  });
+});
+
+describe('sha256', () => {
+  it('hash determinístico de "abc"', async () => {
+    expect(await sha256('abc')).toBe('ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad');
+  });
+});
+
+describe('sleep', () => {
+  it('resolve', async () => {
+    await expect(sleep(0)).resolves.toBeUndefined();
+  });
+});
+
+describe('constantes', () => {
+  it('TIPO_OPTIONS e statusColor', () => {
+    expect(TIPO_OPTIONS.map(o => o.value)).toEqual([
+      'dados_corantes', 'dados_produto_base_embalagem', 'formulas_padrao', 'formulas_personalizadas',
+    ]);
+    expect(statusColor.concluido).toContain('green');
+    expect(statusColor.erro).toContain('red');
+  });
+});
+
+describe('sendChunkWithRetry', () => {
+  it('sucesso na primeira tentativa retorna o resultado', async () => {
+    const mocked = vi.mocked(invokeFunction);
+    mocked.mockResolvedValueOnce({ registros_importados: 5, registros_atualizados: 2 });
+    const res = await sendChunkWithRetry({ foo: 1 }, 0, 3);
+    expect(res.registros_importados).toBe(5);
+    expect(mocked).toHaveBeenCalledWith('tint-import', { foo: 1 });
+  });
+});

--- a/src/components/tintImport/queries.ts
+++ b/src/components/tintImport/queries.ts
@@ -1,0 +1,37 @@
+// Query hooks da Importação Tintométrica (histórico + contagem de produtos).
+// Extraídos de src/pages/TintImport.tsx (god-component split).
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import { ACCOUNT } from './types';
+
+export function useImportHistory() {
+  return useQuery({
+    queryKey: ['tint-import-history'],
+    queryFn: async () => {
+      const { data } = await supabase
+        .from('tint_importacoes')
+        .select('*')
+        .eq('account', ACCOUNT)
+        .order('created_at', { ascending: false })
+        .limit(20);
+      return data ?? [];
+    },
+  });
+}
+
+export function useTintProductCounts() {
+  return useQuery({
+    queryKey: ['tint-product-counts'],
+    queryFn: async () => {
+      const { data } = await supabase
+        .from('omie_products')
+        .select('tint_type')
+        .eq('is_tintometric', true)
+        .eq('account', ACCOUNT);
+      const bases = (data ?? []).filter(p => p.tint_type === 'base').length;
+      const concentrados = (data ?? []).filter(p => p.tint_type === 'concentrado').length;
+      return { bases, concentrados };
+    },
+    staleTime: 5 * 60 * 1000,
+  });
+}

--- a/src/components/tintImport/types.ts
+++ b/src/components/tintImport/types.ts
@@ -1,0 +1,112 @@
+// Constantes, tipos e helpers puros da Importação Tintométrica (TintImport).
+// Extraídos de src/pages/TintImport.tsx (god-component split).
+import { invokeFunction } from '@/lib/invoke-function';
+
+export const ACCOUNT = 'oben';
+export const CHUNK_SIZE_DEFAULT = 200;
+export const CHUNK_SIZE_FORMULAS = 50; // Formulas are heavy (~10 DB ops per row)
+export const MAX_RETRIES = 3;
+export const RETRY_DELAY_MS = 2000;
+
+export function getChunkSize(tipo: string): number {
+  if (tipo === 'formulas_padrao' || tipo === 'formulas_personalizadas') return CHUNK_SIZE_FORMULAS;
+  return CHUNK_SIZE_DEFAULT;
+}
+
+export interface TintImportChunkResult {
+  registros_importados?: number;
+  registros_atualizados?: number;
+  registros_erro?: number;
+  status?: string;
+  message?: string;
+  importacao_id?: string;
+  erros?: Array<{ linha: number | string; motivo: string }>;
+  [k: string]: unknown;
+}
+
+export interface TintSyncResult {
+  total_sincronizado?: number;
+  totalSynced?: number;
+  [k: string]: unknown;
+}
+
+export interface TintImportacaoRow {
+  id: string;
+  tipo: string;
+  arquivo_nome: string;
+  status: string;
+  total_registros: number | null;
+  registros_importados: number | null;
+  registros_atualizados: number | null;
+  registros_erro: number | null;
+  created_at: string;
+  [k: string]: unknown;
+}
+
+export interface TintImportFileResult extends TintImportChunkResult {
+  name: string;
+  imported?: number;
+  updated?: number;
+  errors?: number;
+  total_registros?: number;
+  failed_chunks?: number;
+  error?: string | null;
+}
+
+export interface FileWithPreview {
+  file: File;
+  preview: string[][];
+  name: string;
+  rawText: string;
+}
+
+export const TIPO_OPTIONS = [
+  { value: 'dados_corantes', label: 'Dados auxiliares — Corantes' },
+  { value: 'dados_produto_base_embalagem', label: 'Dados auxiliares — Produto/Base/Embalagem' },
+  { value: 'formulas_padrao', label: 'Fórmulas — Cores Padrões' },
+  { value: 'formulas_personalizadas', label: 'Fórmulas — Personalizadas' },
+];
+
+export const statusColor: Record<string, string> = {
+  concluido: 'bg-green-500/10 text-green-700',
+  concluido_parcial: 'bg-yellow-500/10 text-yellow-700',
+  parcial: 'bg-yellow-500/10 text-yellow-700',
+  erro: 'bg-red-500/10 text-red-700',
+  processando: 'bg-blue-500/10 text-blue-700',
+  duplicado: 'bg-gray-500/10 text-gray-700',
+};
+
+export async function sha256(content: string): Promise<string> {
+  const data = new TextEncoder().encode(content);
+  const hash = await crypto.subtle.digest('SHA-256', data);
+  return Array.from(new Uint8Array(hash))
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+export function sleep(ms: number) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+export async function sendChunkWithRetry(
+  body: Record<string, unknown>,
+  chunkIndex: number,
+  totalChunks: number,
+): Promise<TintImportChunkResult> {
+  for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+    try {
+      console.log(`Chunk ${chunkIndex + 1}/${totalChunks}: enviando... (tentativa ${attempt}/${MAX_RETRIES})`);
+      const res = await invokeFunction<TintImportChunkResult>('tint-import', body);
+      console.log(`Chunk ${chunkIndex + 1}/${totalChunks}: sucesso, ${res.registros_importados ?? 0} importados, ${res.registros_atualizados ?? 0} atualizados`);
+      return res;
+    } catch (err) {
+      console.error(`Chunk ${chunkIndex + 1}/${totalChunks}: falhou tentativa ${attempt}/${MAX_RETRIES}`, err);
+      if (attempt < MAX_RETRIES) {
+        await sleep(RETRY_DELAY_MS);
+      } else {
+        throw err;
+      }
+    }
+  }
+  throw new Error(`sendChunkWithRetry exhausted retries for chunk ${chunkIndex + 1}`);
+}

--- a/src/pages/TintImport.tsx
+++ b/src/pages/TintImport.tsx
@@ -1,150 +1,18 @@
 import { useState, useCallback } from 'react';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { supabase } from '@/integrations/supabase/client';
+import { useQueryClient } from '@tanstack/react-query';
 import { invokeFunction } from '@/lib/invoke-function';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { Progress } from '@/components/ui/progress';
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
-import { Skeleton } from '@/components/ui/skeleton';
-import { Upload, RefreshCw, FileText, CheckCircle, AlertTriangle, Loader2, RotateCcw, Zap, Cloud } from 'lucide-react';
 import { toast } from 'sonner';
 import Papa from 'papaparse';
 import { useDirectTintImport } from '@/hooks/useDirectTintImport';
-
-const ACCOUNT = 'oben';
-const CHUNK_SIZE_DEFAULT = 200;
-const CHUNK_SIZE_FORMULAS = 50; // Formulas are heavy (~10 DB ops per row)
-const MAX_RETRIES = 3;
-const RETRY_DELAY_MS = 2000;
-
-function getChunkSize(tipo: string): number {
-  if (tipo === 'formulas_padrao' || tipo === 'formulas_personalizadas') return CHUNK_SIZE_FORMULAS;
-  return CHUNK_SIZE_DEFAULT;
-}
-
-interface TintImportChunkResult {
-  registros_importados?: number;
-  registros_atualizados?: number;
-  registros_erro?: number;
-  status?: string;
-  message?: string;
-  importacao_id?: string;
-  erros?: Array<{ linha: number | string; motivo: string }>;
-  [k: string]: unknown;
-}
-
-interface TintSyncResult {
-  total_sincronizado?: number;
-  totalSynced?: number;
-  [k: string]: unknown;
-}
-
-interface TintImportacaoRow {
-  id: string;
-  tipo: string;
-  arquivo_nome: string;
-  status: string;
-  total_registros: number | null;
-  registros_importados: number | null;
-  registros_atualizados: number | null;
-  registros_erro: number | null;
-  created_at: string;
-  [k: string]: unknown;
-}
-
-interface TintImportFileResult extends TintImportChunkResult {
-  name: string;
-  imported?: number;
-  updated?: number;
-  errors?: number;
-  total_registros?: number;
-  failed_chunks?: number;
-  error?: string | null;
-}
-
-const TIPO_OPTIONS = [
-  { value: 'dados_corantes', label: 'Dados auxiliares — Corantes' },
-  { value: 'dados_produto_base_embalagem', label: 'Dados auxiliares — Produto/Base/Embalagem' },
-  { value: 'formulas_padrao', label: 'Fórmulas — Cores Padrões' },
-  { value: 'formulas_personalizadas', label: 'Fórmulas — Personalizadas' },
-];
-
-function useImportHistory() {
-  return useQuery({
-    queryKey: ['tint-import-history'],
-    queryFn: async () => {
-      const { data } = await supabase
-        .from('tint_importacoes')
-        .select('*')
-        .eq('account', ACCOUNT)
-        .order('created_at', { ascending: false })
-        .limit(20);
-      return data ?? [];
-    },
-  });
-}
-
-function useTintProductCounts() {
-  return useQuery({
-    queryKey: ['tint-product-counts'],
-    queryFn: async () => {
-      const { data } = await supabase
-        .from('omie_products')
-        .select('tint_type')
-        .eq('is_tintometric', true)
-        .eq('account', ACCOUNT);
-      const bases = (data ?? []).filter(p => p.tint_type === 'base').length;
-      const concentrados = (data ?? []).filter(p => p.tint_type === 'concentrado').length;
-      return { bases, concentrados };
-    },
-    staleTime: 5 * 60 * 1000,
-  });
-}
-
-interface FileWithPreview {
-  file: File;
-  preview: string[][];
-  name: string;
-  rawText: string;
-}
-
-async function sha256(content: string): Promise<string> {
-  const data = new TextEncoder().encode(content);
-  const hash = await crypto.subtle.digest('SHA-256', data);
-  return Array.from(new Uint8Array(hash))
-    .map(b => b.toString(16).padStart(2, '0'))
-    .join('');
-}
-
-function sleep(ms: number) {
-  return new Promise(resolve => setTimeout(resolve, ms));
-}
-
-async function sendChunkWithRetry(
-  body: Record<string, unknown>,
-  chunkIndex: number,
-  totalChunks: number,
-): Promise<TintImportChunkResult> {
-  for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
-    try {
-      console.log(`Chunk ${chunkIndex + 1}/${totalChunks}: enviando... (tentativa ${attempt}/${MAX_RETRIES})`);
-      const res = await invokeFunction<TintImportChunkResult>('tint-import', body);
-      console.log(`Chunk ${chunkIndex + 1}/${totalChunks}: sucesso, ${res.registros_importados ?? 0} importados, ${res.registros_atualizados ?? 0} atualizados`);
-      return res;
-    } catch (err) {
-      console.error(`Chunk ${chunkIndex + 1}/${totalChunks}: falhou tentativa ${attempt}/${MAX_RETRIES}`, err);
-      if (attempt < MAX_RETRIES) {
-        await sleep(RETRY_DELAY_MS);
-      } else {
-        throw err;
-      }
-    }
-  }
-  throw new Error(`sendChunkWithRetry exhausted retries for chunk ${chunkIndex + 1}`);
-}
+import {
+  ACCOUNT, MAX_RETRIES, getChunkSize, sha256, sendChunkWithRetry,
+  type TintImportChunkResult, type TintSyncResult, type TintImportacaoRow,
+  type TintImportFileResult, type FileWithPreview,
+} from '@/components/tintImport/types';
+import { useImportHistory, useTintProductCounts } from '@/components/tintImport/queries';
+import { SyncCard } from '@/components/tintImport/SyncCard';
+import { ImportCard } from '@/components/tintImport/ImportCard';
+import { HistoryTable } from '@/components/tintImport/HistoryTable';
 
 export default function TintImport() {
   const [tipo, setTipo] = useState('');
@@ -480,15 +348,6 @@ export default function TintImport() {
     toast.success('Retomada finalizada');
   };
 
-  const statusColor: Record<string, string> = {
-    concluido: 'bg-green-500/10 text-green-700',
-    concluido_parcial: 'bg-yellow-500/10 text-yellow-700',
-    parcial: 'bg-yellow-500/10 text-yellow-700',
-    erro: 'bg-red-500/10 text-red-700',
-    processando: 'bg-blue-500/10 text-blue-700',
-    duplicado: 'bg-gray-500/10 text-gray-700',
-  };
-
   const progressPct = chunkProgress.totalChunks > 0
     ? ((chunkProgress.currentChunk / chunkProgress.totalChunks) * 100)
     : 0;
@@ -497,230 +356,32 @@ export default function TintImport() {
     <div className="space-y-6">
       <h1 className="text-2xl font-bold">Tintométrico — Importação</h1>
 
-      {/* Sync Omie */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-base">Sincronizar Produtos Omie</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <p className="text-sm text-muted-foreground mb-3">
-            Importa bases e concentrados tintométricos do Omie para o sistema.
-          </p>
-          <Button onClick={handleSync} disabled={syncing}>
-            {syncing ? <Loader2 className="w-4 h-4 mr-2 animate-spin" /> : <RefreshCw className="w-4 h-4 mr-2" />}
-            Sincronizar Produtos Omie
-          </Button>
-          {tintCounts && (tintCounts.bases > 0 || tintCounts.concentrados > 0) && (
-            <p className="text-sm text-muted-foreground mt-3">
-              <span className="font-medium text-foreground">{tintCounts.bases}</span> bases e{' '}
-              <span className="font-medium text-foreground">{tintCounts.concentrados}</span> concentrados encontrados no Omie
-            </p>
-          )}
-        </CardContent>
-      </Card>
+      <SyncCard syncing={syncing} onSync={handleSync} tintCounts={tintCounts} />
 
-      {/* Import CSV */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-base">Importar CSV do SAYERSYSTEM</CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          <div className="flex gap-4 flex-wrap">
-            <div className="max-w-sm flex-1">
-              <label className="text-sm font-medium mb-1 block">Tipo de importação</label>
-              <Select value={tipo} onValueChange={setTipo}>
-                <SelectTrigger><SelectValue placeholder="Selecione o tipo" /></SelectTrigger>
-                <SelectContent>
-                  {TIPO_OPTIONS.map(o => <SelectItem key={o.value} value={o.value}>{o.label}</SelectItem>)}
-                </SelectContent>
-              </Select>
-            </div>
-            <div className="max-w-xs">
-              <label className="text-sm font-medium mb-1 block">Modo de importação</label>
-              <Select value={importMode} onValueChange={(v) => setImportMode(v as 'auto' | 'edge' | 'direct' | 'rpc')}>
-                <SelectTrigger><SelectValue /></SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="auto">Automático (recomendado)</SelectItem>
-                  <SelectItem value="rpc">⚡ RPC Postgres (mais rápido)</SelectItem>
-                  <SelectItem value="direct">Importação Direta (SQL)</SelectItem>
-                  <SelectItem value="edge">Edge Function (legacy)</SelectItem>
-                </SelectContent>
-              </Select>
-              <p className="text-xs text-muted-foreground mt-1">
-                {importMode === 'auto' && 'Fórmulas grandes: RPC Postgres | Auxiliares: Direto | < 500 linhas: Edge'}
-                {importMode === 'rpc' && '2.000 linhas por lote, processado nativamente no Postgres (~45s para 29k linhas)'}
-                {importMode === 'direct' && 'Sem edge function. 200 linhas por lote via JS client'}
-                {importMode === 'edge' && 'Usa edge function com chunks. Pode dar timeout em arquivos grandes'}
-              </p>
-            </div>
-          </div>
+      <ImportCard
+        tipo={tipo}
+        setTipo={setTipo}
+        importMode={importMode}
+        setImportMode={setImportMode}
+        files={files}
+        onFiles={handleFiles}
+        importing={importing}
+        directRunning={directRunning}
+        directProgress={directProgress}
+        chunkProgress={chunkProgress}
+        progressPct={progressPct}
+        results={results}
+        onImport={handleImportWithMode}
+        onCancelDirect={cancelDirect}
+      />
 
-          <div>
-            <label className="text-sm font-medium mb-1 block">Arquivos CSV</label>
-            <div className="border-2 border-dashed rounded-lg p-6 text-center hover:border-primary/50 transition-colors">
-              <Upload className="w-8 h-8 mx-auto text-muted-foreground mb-2" />
-              <p className="text-sm text-muted-foreground mb-2">Arraste arquivos ou clique para selecionar</p>
-              <input
-                type="file"
-                accept=".csv,.txt"
-                multiple
-                onChange={handleFiles}
-                className="block w-full text-sm file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-medium file:bg-primary file:text-primary-foreground hover:file:bg-primary/90 cursor-pointer"
-              />
-            </div>
-          </div>
-
-          {/* Preview */}
-          {files.length > 0 && (
-            <div className="space-y-3">
-              {files.map((f, idx) => {
-                const lineCount = Papa.parse(f.rawText, { delimiter: ';', skipEmptyLines: true }).data.length - 1;
-                const useDirectMode = importMode === 'direct' || importMode === 'rpc' || (importMode === 'auto' && lineCount >= 500);
-                return (
-                  <div key={idx} className="border rounded-md p-3">
-                    <div className="flex items-center gap-2 mb-2">
-                      <FileText className="w-4 h-4" />
-                      <span className="text-sm font-medium">{f.name}</span>
-                      <Badge variant="outline">{lineCount} linhas</Badge>
-                      {useDirectMode ? (
-                        <Badge variant="secondary" className="gap-1">
-                          <Zap className="w-3 h-3" /> {importMode === 'rpc' || (importMode === 'auto' && (tipo === 'formulas_padrao' || tipo === 'formulas_personalizadas')) ? 'RPC Postgres' : 'Direto'}
-                        </Badge>
-                      ) : (
-                        <Badge variant="outline" className="gap-1"><Cloud className="w-3 h-3" /> Edge Function</Badge>
-                      )}
-                    </div>
-                    <div className="overflow-x-auto">
-                      <table className="text-xs">
-                        <tbody>
-                          {f.preview.map((row, ri) => (
-                            <tr key={ri} className={ri === 0 ? 'font-semibold bg-muted/50' : ''}>
-                              {row.map((cell, ci) => (
-                                <td key={ci} className="px-2 py-0.5 border-b whitespace-nowrap max-w-[200px] truncate">{cell}</td>
-                              ))}
-                            </tr>
-                          ))}
-                        </tbody>
-                      </table>
-                    </div>
-                  </div>
-                );
-              })}
-            </div>
-          )}
-
-          {/* Progress — Edge Function mode */}
-          {importing && !directRunning && (
-            <div className="space-y-2">
-              <p className="text-sm">
-                <Cloud className="w-4 h-4 inline mr-1" />
-                Importando <span className="font-medium">{chunkProgress.fileName}</span>
-                {' '}(arquivo {chunkProgress.currentFile}/{chunkProgress.totalFiles})
-                {chunkProgress.totalChunks > 1 && (
-                  <> — chunk {chunkProgress.currentChunk}/{chunkProgress.totalChunks}</>
-                )}
-              </p>
-              <Progress value={progressPct} />
-            </div>
-          )}
-
-          {/* Progress — Direct mode */}
-          {directRunning && directProgress && (
-            <div className="space-y-2">
-              <p className="text-sm">
-                <Zap className="w-4 h-4 inline mr-1" />
-                {directProgress.phase} — Lote {directProgress.currentBatch}/{directProgress.totalBatches}
-                {' '}({directProgress.recordsProcessed.toLocaleString()} / {directProgress.totalRecords.toLocaleString()} registros)
-              </p>
-              <Progress value={(directProgress.recordsProcessed / directProgress.totalRecords) * 100} />
-              <p className="text-xs text-muted-foreground">
-                {directProgress.imported} importados, {directProgress.updated} atualizados, {directProgress.errors} erros
-              </p>
-              <Button size="sm" variant="outline" onClick={cancelDirect}>Cancelar</Button>
-            </div>
-          )}
-
-          {/* Results */}
-          {results.length > 0 && (
-            <div className="space-y-2">
-              <h3 className="text-sm font-semibold">Resultado</h3>
-              {results.map((r, i) => (
-                <div key={i} className="border rounded-md p-3 flex items-start gap-3">
-                  {r.status === 'concluido' ? <CheckCircle className="w-4 h-4 text-green-500 mt-0.5" /> : <AlertTriangle className="w-4 h-4 text-yellow-500 mt-0.5" />}
-                  <div className="text-sm">
-                    <p className="font-medium">{r.name}</p>
-                    <p className="text-muted-foreground">
-                      {r.registros_importados ?? r.imported ?? 0} importados, {r.registros_atualizados ?? r.updated ?? 0} atualizados, {r.registros_erro ?? r.errors ?? 0} erros
-                      {r.failed_chunks > 0 && <span className="text-destructive"> ({r.failed_chunks} chunks falharam)</span>}
-                    </p>
-                    {r.erros && r.erros.length > 0 && (
-                      <ul className="text-xs text-destructive mt-1">
-                        {r.erros.slice(0, 5).map((e, j: number) => <li key={j}>Linha {e.linha}: {e.motivo}</li>)}
-                      </ul>
-                    )}
-                    {r.error && <p className="text-xs text-destructive">{r.error}</p>}
-                    {r.status === 'duplicado' && <p className="text-xs text-muted-foreground">{r.message || 'Arquivo já importado anteriormente'}</p>}
-                  </div>
-                </div>
-              ))}
-            </div>
-          )}
-
-          <Button onClick={handleImportWithMode} disabled={importing || directRunning || !tipo || files.length === 0}>
-            {(importing || directRunning) ? <Loader2 className="w-4 h-4 mr-2 animate-spin" /> : <Upload className="w-4 h-4 mr-2" />}
-            Importar
-          </Button>
-        </CardContent>
-      </Card>
-
-      {/* History */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-base">Histórico de Importações</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>Data</TableHead>
-                <TableHead>Tipo</TableHead>
-                <TableHead>Arquivo</TableHead>
-                <TableHead>Registros</TableHead>
-                <TableHead>Status</TableHead>
-                <TableHead></TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {histLoading ? (
-                <TableRow><TableCell colSpan={6}><Skeleton className="h-6 w-full" /></TableCell></TableRow>
-              ) : (history ?? []).map((imp) => (
-                <TableRow key={imp.id}>
-                  <TableCell className="text-sm">{new Date(imp.created_at).toLocaleDateString('pt-BR')}</TableCell>
-                  <TableCell className="text-sm">{imp.tipo}</TableCell>
-                  <TableCell className="text-sm max-w-[200px] truncate">{imp.arquivo_nome}</TableCell>
-                  <TableCell className="text-sm">{(imp.registros_importados ?? 0) + (imp.registros_atualizados ?? 0)} / {imp.total_registros ?? 0}</TableCell>
-                  <TableCell>
-                    <Badge variant="outline" className={statusColor[imp.status] || ''}>{imp.status}</Badge>
-                  </TableCell>
-                  <TableCell>
-                    {(imp.status === 'processando' || imp.status === 'concluido_parcial') && (
-                      <Button
-                        size="sm"
-                        variant="outline"
-                        disabled={importing || resumingId === imp.id}
-                        onClick={() => handleResume(imp)}
-                      >
-                        {resumingId === imp.id ? <Loader2 className="w-3 h-3 mr-1 animate-spin" /> : <RotateCcw className="w-3 h-3 mr-1" />}
-                        Retomar
-                      </Button>
-                    )}
-                  </TableCell>
-                </TableRow>
-              ))}
-            </TableBody>
-          </Table>
-        </CardContent>
-      </Card>
+      <HistoryTable
+        history={(history ?? []) as TintImportacaoRow[]}
+        histLoading={histLoading}
+        importing={importing}
+        resumingId={resumingId}
+        onResume={handleResume}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Resumo

Quebra do god-component `src/pages/TintImport.tsx` (Importação Tintométrica via CSV) — **726 → 387 linhas**. Refactor **comportamento-preservante 1:1**, novos módulos em `src/components/tintImport/`.

- **`types.ts`** — constantes (ACCOUNT/CHUNK_SIZE_*/MAX_RETRIES/RETRY_DELAY_MS), tipos, helpers **puros** (`getChunkSize`, `sha256`, `sleep`, `sendChunkWithRetry`), `TIPO_OPTIONS`, `statusColor`.
- **`queries.ts`** — `useImportHistory` + `useTintProductCounts`.
- **`SyncCard.tsx`** — card de sincronização Omie.
- **`ImportCard.tsx`** — selects tipo/modo, dropzone, preview, progresso (edge/direct), resultados, botão.
- **`HistoryTable.tsx`** — histórico com botão Retomar.

### Decisão de arquitetura

Toda a orquestração de import — `handleImport` (chunking de arquivos grandes), `handleResume` (retomada pulando linhas já processadas), `handleImportWithMode`, `shouldUseDirect`, `finalizeImport`, `handleSync` — permanece **verbatim no pai** (lógica delicada de chunk index/retry; risco zero). Os 3 cards são presentacionais.

## Garantias

- ✅ `bunx tsc --noEmit` — 0 erros.
- ✅ `bun lint` — 0 problemas nos arquivos tocados.
- ✅ Suíte: **632/632** passando.
- ✅ `bun run build` exit 0.
- ✅ +14 testes novos (4 arquivos): helpers (`getChunkSize`/`sha256`/`sendChunkWithRetry`), SyncCard, ImportCard (preview/resultados/disabled), HistoryTable (Retomar).
- ✅ Revisão independente (subagente): veredito **FIEL 1:1** — `sendChunkWithRetry`/`sha256`/`getChunkSize` byte-a-byte; `handleImport`/`handleResume` idênticos (incluindo `baseChunkIndex`/`absoluteChunkIndex`/`total_chunks`).

## Test plan

- [x] tsc 0 erros / lint 0 problemas
- [x] 14 testes novos + suíte completa 632/632
- [x] build de produção exit 0
- [x] revisão independente confirma 1:1
- [ ] CI `validate` verde

🤖 Generated with [Claude Code](https://claude.com/claude-code)