### PR TITLE
feat(reposicao): trata tendencia 'sem_dados' no SLA fornecedor

### DIFF
--- a/src/pages/AdminReposicaoSlaFornecedor.tsx
+++ b/src/pages/AdminReposicaoSlaFornecedor.tsx
@@ -23,7 +23,7 @@ import {
 } from "@/components/ui/table";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Skeleton } from "@/components/ui/skeleton";
-import { ArrowDown, ArrowRight, ArrowUp, Download, Search } from "lucide-react";
+import { ArrowDown, ArrowRight, ArrowUp, Download, Minus, Search } from "lucide-react";
 import {
   CartesianGrid,
   Legend,
@@ -46,7 +46,7 @@ type SlaStatus =
   | "sem_sla_teorico"
   | "poucos_dados";
 
-type Tendencia = "melhorando" | "estavel" | "piorando";
+type Tendencia = "melhorando" | "estavel" | "piorando" | "sem_dados";
 
 interface ForCompliance {
   empresa: string;
@@ -113,6 +113,7 @@ const fmtData = (v: string | null) =>
 const TendenciaIcon = ({ t }: { t: Tendencia }) => {
   if (t === "piorando") return <ArrowUp className="h-3.5 w-3.5 text-destructive" aria-label="piorando" />;
   if (t === "melhorando") return <ArrowDown className="h-3.5 w-3.5 text-success" aria-label="melhorando" />;
+  if (t === "sem_dados") return <Minus className="h-3.5 w-3.5 text-muted-foreground/50" aria-label="sem dados de tendência" />;
   return <ArrowRight className="h-3.5 w-3.5 text-muted-foreground" aria-label="estável" />;
 };
 
@@ -358,6 +359,7 @@ export default function AdminReposicaoSlaFornecedor() {
                   <SelectItem value="melhorando">Melhorando</SelectItem>
                   <SelectItem value="estavel">Estável</SelectItem>
                   <SelectItem value="piorando">Piorando</SelectItem>
+                  <SelectItem value="sem_dados">Sem dados</SelectItem>
                 </SelectContent>
               </Select>
             </div>


### PR DESCRIPTION
## Contexto

Polish achado durante o QA visual do #203. A view `v_sku_sla_compliance` de produção retorna `tendencia = 'sem_dados'` (SKU com LT teórico mas sem observações recentes), valor que **não estava** no type `Tendencia` do front. O cast `as unknown` absorvia, mas em runtime essas linhas caíam no ícone neutro de "estável" (seta →) — semanticamente errado.

## Mudanças
- `Tendencia` += `'sem_dados'`
- `TendenciaIcon`: ícone `Minus` (–) cinza-claro com `aria-label="sem dados de tendência"` (em vez da seta de estável)
- Filtro de Tendência: nova opção **"Sem dados"**

Diff de 1 arquivo, UI-only.

## Validação
- `bunx tsc --noEmit -p tsconfig.app.json` → 0
- `bunx eslint` → 0
- `bun run test` → 632/632
- `codex review --uncommitted` → limpo
- **QA visual confirmado** pelo founder (filtro "Sem dados" + traço cinza nas linhas sem tendência)

> Obs (fora do escopo): linhas `sem_dados` aparecem como **Crítico** com **N obs 0** — vem da lógica da view de produção (SKU com LT teórico e 0 observações cai no `ELSE 'critico'` por comparação com NULL). Anotado pra task de sync da stack de views SLA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)