### PR TITLE
chore(ts-strict): promove 20 a strict (lote 4 — docs/financeiro/portalSayerlack/sales)

### DIFF
--- a/tsconfig.strict.json
+++ b/tsconfig.strict.json
@@ -435,6 +435,26 @@
     "src/components/AddToolDialog.tsx",
     "src/components/OrderPrintLayout.tsx",
     "src/components/SendingQualityChecklist.tsx",
-    "src/components/ToolImageIdentifier.tsx"
+    "src/components/ToolImageIdentifier.tsx",
+    "src/components/docs/SecaoAlgoritmos.tsx",
+    "src/components/docs/SecaoFuncionalidades.tsx",
+    "src/components/docs/primitives.tsx",
+    "src/components/financeiro/cashflow/EventosManager.tsx",
+    "src/components/financeiro/cashflow/PosicaoAgora.tsx",
+    "src/components/financeiro/dashboard/ContasPagarTab.tsx",
+    "src/components/financeiro/dashboard/ContasReceberTab.tsx",
+    "src/components/financeiro/dashboard/VisaoGeralTab.tsx",
+    "src/components/financeiro/dashboard/format.ts",
+    "src/components/portalSayerlack/ConciliarTab.tsx",
+    "src/components/portalSayerlack/EstatisticasTab.tsx",
+    "src/components/portalSayerlack/HistoricoTab.tsx",
+    "src/components/portalSayerlack/KpiCards.tsx",
+    "src/components/portalSayerlack/PendentesTab.tsx",
+    "src/components/portalSayerlack/types.ts",
+    "src/components/sales/print/OrderGroup.tsx",
+    "src/components/sales/print/PrintFilters.tsx",
+    "src/components/sales/print/buildPrintHtml.ts",
+    "src/components/sales/print/types.ts",
+    "src/components/unified-order/ServiceItemForm.tsx"
   ]
 }


### PR DESCRIPTION
Parte B lote 4 (tsconfig-only). `typecheck:strict` = 0 erros (validado local, run completo). 20 arquivos: docs (3), financeiro cashflow+dashboard (6), portalSayerlack (6), sales/print (4), unified-order/ServiceItemForm. Podados: 4 intelligence tabs + CartSummaryBar/ProductItemForm (TS6133, fix de source pra depois). include 417→437. Auto-merge só com CI verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)