### PR TITLE
chore(ts-strict): promove 5 a strict (contexts + omieService)

### DIFF
--- a/docs/strict-migration-lanes.md
+++ b/docs/strict-migration-lanes.md
@@ -59,6 +59,10 @@ subgrafos sujos (`noUnusedLocals`/`strictNullChecks`) → cascata. **Promova lea
 - **Reposição**: god-components sendo decompostos.
 
 ### Reservas ativas (🔵 = em voo)
+- 🔵 **`feat/strict-promote-contexts`** (sessão determined-allen, 2026-05-23): fatia foundational —
+  `contexts/{AuthContext,CompanyContext,ConditionalWebRTCProvider,WebRTCCallContext}` + `services/omieService`.
+  **NÃO toco** `services/financeiroService` nem `financeiroV2Service` (colidem com `feat/financeiro-a2-impl` em voo).
+  Pages virá em fatia/branch separada depois (leaf-first). Append-only no `include`.
 - 🔵 **`feat/strict-promote-lib-leaf`** (sessão cranky-driscoll, 2026-05-23): lote leaf não-farmer —
   `lib/call-session/aggregate-customer-profile`, `lib/sip/sip-client`, `lib/transcription/{deepgram-client,transcription-engine}`,
   `components/customer360/format`, `components/financeiro/dashboard/format`, `components/portalSayerlack/types`,

--- a/tsconfig.strict.json
+++ b/tsconfig.strict.json
@@ -457,6 +457,11 @@
     "src/components/sales/print/types.ts",
     "src/components/unified-order/ServiceItemForm.tsx",
     "src/components/customer360/format.ts",
-    "src/components/reposicao/alertas/types.ts"
+    "src/components/reposicao/alertas/types.ts",
+    "src/contexts/WebRTCCallContext.tsx",
+    "src/contexts/CompanyContext.tsx",
+    "src/contexts/AuthContext.tsx",
+    "src/contexts/ConditionalWebRTCProvider.tsx",
+    "src/services/omieService.ts"
   ]
 }


### PR DESCRIPTION
## Resumo

Fatia foundational da migração TypeScript strict (fase de PROMOÇÃO). Adiciona 5 arquivos ao `include` do `tsconfig.strict.json`:

- `src/contexts/AuthContext.tsx`
- `src/contexts/CompanyContext.tsx`
- `src/contexts/WebRTCCallContext.tsx`
- `src/contexts/ConditionalWebRTCProvider.tsx`
- `src/services/omieService.ts`

**Promoção tsconfig-only** — os 5 arquivos já estavam strict-clean (zero `any`, bem tipados; todas as deps transitivas já estavam no programa strict). Nenhuma edição de source necessária.

Reserva registrada em `docs/strict-migration-lanes.md` (slice `feat/strict-promote-contexts`). `services/financeiroService` e `financeiroV2Service` ficaram **de fora** por colidirem com `feat/financeiro-a2-impl` em voo.

## Gate

- `bun run typecheck:strict` → exit 0 (limpo), com CPU calma.

## Test plan

- [x] `typecheck:strict` verde localmente
- [ ] CI `validate` verde