### PR TITLE
feat(access): controle de acesso por persona (matriz + resolver + menu + guards)

### DIFF
--- a/docs/superpowers/plans/2026-05-23-controle-acesso-persona.md
+++ b/docs/superpowers/plans/2026-05-23-controle-acesso-persona.md
@@ -1,0 +1,612 @@
+# Controle de Acesso por Persona — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Controle de acesso determinístico por persona — filtra o menu lateral e bloqueia rotas (guard) conforme `commercial_role` + `department` + `app_role`, com default = vendedor.
+
+**Architecture:** Camada `src/lib/access/` (resolver determinístico + matriz estática, libs puras testáveis), hook `useAccess()` que compõe os hooks de fonte existentes, componente `<RequireAccess>` pra guard de rota, e integração no `AppShell` (filtro de menu) + `App.tsx` (guards). Separada do `inferPersona` (dashboard).
+
+**Tech Stack:** React 18 + TS + Vite, `@tanstack/react-query`, react-router-dom 6, vitest. Spec: `docs/superpowers/specs/2026-05-23-controle-acesso-persona-design.md`.
+
+> **Convenção:** `bun run test` (vitest). Libs puras em `src/lib/access/__tests__/` ou `*.test.ts`. Branch: `claude/controle-acesso-persona`.
+
+---
+
+## File Structure
+
+**Criar:**
+- `src/lib/access/types.ts` — `AccessPersona`, `SectionId`, `GroupTag`.
+- `src/lib/access/resolve-access.ts` (+ `.test.ts`) — `resolveAccessPersona`, `resolveGroupTag`.
+- `src/lib/access/access-matrix.ts` (+ `.test.ts`) — `ACCESS`, `canAccess`, `isReadOnly`.
+- `src/hooks/useAccess.ts` — compõe os hooks de fonte → `{ persona, group, loading, can, isReadOnly }`.
+- `src/components/access/RequireAccess.tsx` — guard de rota.
+
+**Modificar:**
+- `src/hooks/useCommercialRole.ts` — estender o enum `CommercialRole` (falta farmer/hunter/closer/master).
+- `src/components/AppShell.tsx` — cada item ganha `section`; filtro via `useAccess().can`.
+- `src/App.tsx` — envolver grupos de rota com `<RequireAccess section=...>`.
+- `src/pages/Customer360.tsx` — gate da seção financeira do cliente.
+
+---
+
+## Task 1: Estender o enum `CommercialRole`
+
+**Files:**
+- Modify: `src/hooks/useCommercialRole.ts:5`
+
+- [ ] **Step 1: Atualizar o tipo pra refletir o enum real do banco**
+
+O tipo atual é `export type CommercialRole = 'operacional' | 'gerencial' | 'estrategico' | 'super_admin';`. O banco tem mais valores (adicionados em migration). Trocar por:
+```ts
+export type CommercialRole =
+  | 'operacional' | 'gerencial' | 'estrategico' | 'super_admin'
+  | 'farmer' | 'hunter' | 'closer' | 'master';
+```
+
+- [ ] **Step 2: Build não regride**
+
+Run: `bunx tsc --noEmit 2>&1 | grep -cE "error TS"`
+Expected: mesmo número de antes (0 novos). O `inferPersona` usa um `switch` sobre `commercialRole` sem `default` exaustivo — confirmar que ainda compila (os novos valores caem na heurística, comportamento ok).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/hooks/useCommercialRole.ts
+git commit -m "feat(access): estende enum CommercialRole (farmer/hunter/closer/master)"
+```
+
+---
+
+## Task 2: Tipos de acesso
+
+**Files:**
+- Create: `src/lib/access/types.ts`
+
+- [ ] **Step 1: Escrever os tipos**
+
+```ts
+// src/lib/access/types.ts
+export type AccessPersona =
+  | 'vendedor' | 'gestor_comercial' | 'operacao' | 'financeiro' | 'gestao' | 'cliente';
+
+export type GroupTag = 'hunter' | 'farmer' | 'closer';
+
+export type SectionId =
+  | 'principal'      // Dashboard + Meu dia
+  | 'clientes'       // Customer 360
+  | 'vendas'         // Pedidos / Novo / Ferramentas de venda / Telefonia / Chamadas
+  | 'operacao'       // Recebimento / Picking / Tintométrico balcão / Produção
+  | 'reposicao'
+  | 'performance'
+  | 'inteligencia'
+  | 'financeiro'             // módulo /financeiro
+  | 'tintometrico_cockpit'   // cockpit analítico de tintométrico
+  | 'gestao_admin'           // Liberar Acessos / Departamentos / Governança / etc.
+  | 'docs';                  // Ajuda / Design System / UX Rules
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/lib/access/types.ts
+git commit -m "feat(access): tipos AccessPersona/SectionId/GroupTag"
+```
+
+---
+
+## Task 3: Resolver determinístico (TDD)
+
+**Files:**
+- Create: `src/lib/access/resolve-access.test.ts`
+- Create: `src/lib/access/resolve-access.ts`
+
+- [ ] **Step 1: Escrever o teste que falha**
+
+```ts
+// src/lib/access/resolve-access.test.ts
+import { describe, it, expect } from 'vitest';
+import { resolveAccessPersona, resolveGroupTag } from './resolve-access';
+
+const base = { appRole: null, commercialRole: null, department: null, isSalesOnly: false } as const;
+
+describe('resolveAccessPersona', () => {
+  it('master (app_role) → gestao', () => {
+    expect(resolveAccessPersona({ ...base, appRole: 'master' })).toBe('gestao');
+  });
+  it('estrategico/super_admin → gestao', () => {
+    expect(resolveAccessPersona({ ...base, commercialRole: 'estrategico' })).toBe('gestao');
+    expect(resolveAccessPersona({ ...base, commercialRole: 'super_admin' })).toBe('gestao');
+  });
+  it('gerencial → gestor_comercial', () => {
+    expect(resolveAccessPersona({ ...base, commercialRole: 'gerencial' })).toBe('gestor_comercial');
+  });
+  it('department gestao → gestor_comercial', () => {
+    expect(resolveAccessPersona({ ...base, appRole: 'employee', department: 'gestao' })).toBe('gestor_comercial');
+  });
+  it('department financeiro → financeiro', () => {
+    expect(resolveAccessPersona({ ...base, appRole: 'employee', department: 'financeiro' })).toBe('financeiro');
+  });
+  it('department separador/conferente/tintometrico → operacao', () => {
+    for (const d of ['separador', 'conferente', 'tintometrico'] as const) {
+      expect(resolveAccessPersona({ ...base, appRole: 'employee', department: d })).toBe('operacao');
+    }
+  });
+  it('customer → cliente', () => {
+    expect(resolveAccessPersona({ ...base, appRole: 'customer' })).toBe('cliente');
+  });
+  it('vendas (operacional/farmer/hunter/closer) → vendedor', () => {
+    for (const r of ['operacional', 'farmer', 'hunter', 'closer'] as const) {
+      expect(resolveAccessPersona({ ...base, appRole: 'employee', commercialRole: r })).toBe('vendedor');
+    }
+  });
+  it('sales-only → vendedor', () => {
+    expect(resolveAccessPersona({ ...base, appRole: 'employee', isSalesOnly: true })).toBe('vendedor');
+  });
+  it('staff sem tag → vendedor (default)', () => {
+    expect(resolveAccessPersona({ ...base, appRole: 'employee' })).toBe('vendedor');
+  });
+});
+
+describe('resolveGroupTag', () => {
+  it('hunter/farmer/closer → o próprio', () => {
+    expect(resolveGroupTag('hunter')).toBe('hunter');
+    expect(resolveGroupTag('farmer')).toBe('farmer');
+    expect(resolveGroupTag('closer')).toBe('closer');
+  });
+  it('demais → null', () => {
+    expect(resolveGroupTag('operacional')).toBeNull();
+    expect(resolveGroupTag(null)).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Rodar pra ver falhar**
+
+Run: `bun run test src/lib/access/resolve-access.test.ts`
+Expected: FAIL — módulo não existe.
+
+- [ ] **Step 3: Implementar**
+
+```ts
+// src/lib/access/resolve-access.ts
+import type { AppRole } from '@/contexts/AuthContext';
+import type { CommercialRole } from '@/hooks/useCommercialRole';
+import type { Department } from '@/integrations/supabase/types-departments';
+import type { AccessPersona, GroupTag } from './types';
+
+export interface AccessSignals {
+  appRole: AppRole | null;
+  commercialRole: CommercialRole | null;
+  department: Department | null;
+  isSalesOnly: boolean;
+}
+
+/** Resolve a persona de acesso de forma DETERMINÍSTICA (sem heurística). */
+export function resolveAccessPersona(s: AccessSignals): AccessPersona {
+  if (s.appRole === 'master'
+    || s.commercialRole === 'estrategico'
+    || s.commercialRole === 'super_admin'
+    || s.commercialRole === 'master') return 'gestao';
+  if (s.commercialRole === 'gerencial' || s.department === 'gestao') return 'gestor_comercial';
+  if (s.department === 'financeiro') return 'financeiro';
+  if (s.department === 'separador' || s.department === 'conferente' || s.department === 'tintometrico') return 'operacao';
+  if (s.appRole === 'customer') return 'cliente';
+  // operacional/farmer/hunter/closer, dept vendas, sales-only, ou staff sem tag → vendedor (default)
+  return 'vendedor';
+}
+
+/** Tag de grupo comercial (não muda acesso; usada pela Performance e pela home). */
+export function resolveGroupTag(commercialRole: CommercialRole | null): GroupTag | null {
+  if (commercialRole === 'hunter' || commercialRole === 'farmer' || commercialRole === 'closer') {
+    return commercialRole;
+  }
+  return null;
+}
+```
+
+- [ ] **Step 4: Rodar pra ver passar**
+
+Run: `bun run test src/lib/access/resolve-access.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/access/resolve-access.ts src/lib/access/resolve-access.test.ts
+git commit -m "feat(access): resolveAccessPersona + resolveGroupTag (TDD)"
+```
+
+---
+
+## Task 4: Matriz de acesso (TDD)
+
+**Files:**
+- Create: `src/lib/access/access-matrix.test.ts`
+- Create: `src/lib/access/access-matrix.ts`
+
+- [ ] **Step 1: Escrever o teste que falha**
+
+```ts
+// src/lib/access/access-matrix.test.ts
+import { describe, it, expect } from 'vitest';
+import { canAccess, isReadOnly } from './access-matrix';
+
+describe('canAccess', () => {
+  it('vendedor: vendas/clientes/performance sim; financeiro/operacao/reposicao não', () => {
+    expect(canAccess('vendedor', 'vendas')).toBe(true);
+    expect(canAccess('vendedor', 'clientes')).toBe(true);
+    expect(canAccess('vendedor', 'performance')).toBe(true);
+    expect(canAccess('vendedor', 'financeiro')).toBe(false);
+    expect(canAccess('vendedor', 'operacao')).toBe(false);
+    expect(canAccess('vendedor', 'reposicao')).toBe(false);
+  });
+  it('gestor_comercial: inteligencia sim; financeiro/operacao não', () => {
+    expect(canAccess('gestor_comercial', 'inteligencia')).toBe(true);
+    expect(canAccess('gestor_comercial', 'clientes')).toBe(true);
+    expect(canAccess('gestor_comercial', 'financeiro')).toBe(false);
+    expect(canAccess('gestor_comercial', 'operacao')).toBe(false);
+  });
+  it('operacao: operacao sim; vendas/clientes não', () => {
+    expect(canAccess('operacao', 'operacao')).toBe(true);
+    expect(canAccess('operacao', 'vendas')).toBe(false);
+    expect(canAccess('operacao', 'clientes')).toBe(false);
+  });
+  it('financeiro: financeiro/clientes sim; vendas leitura', () => {
+    expect(canAccess('financeiro', 'financeiro')).toBe(true);
+    expect(canAccess('financeiro', 'clientes')).toBe(true);
+    expect(canAccess('financeiro', 'vendas')).toBe(true);
+    expect(isReadOnly('financeiro', 'vendas')).toBe(true);
+  });
+  it('gestao: acessa tudo', () => {
+    for (const s of ['principal','clientes','vendas','operacao','reposicao','performance','inteligencia','financeiro','tintometrico_cockpit','gestao_admin','docs'] as const) {
+      expect(canAccess('gestao', s)).toBe(true);
+    }
+  });
+  it('docs liberado pra todas as personas staff', () => {
+    for (const p of ['vendedor','gestor_comercial','operacao','financeiro','gestao'] as const) {
+      expect(canAccess(p, 'docs')).toBe(true);
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Rodar pra ver falhar**
+
+Run: `bun run test src/lib/access/access-matrix.test.ts`
+Expected: FAIL — módulo não existe.
+
+- [ ] **Step 3: Implementar**
+
+```ts
+// src/lib/access/access-matrix.ts
+import type { AccessPersona, SectionId } from './types';
+
+const ALL: SectionId[] = [
+  'principal', 'clientes', 'vendas', 'operacao', 'reposicao', 'performance',
+  'inteligencia', 'financeiro', 'tintometrico_cockpit', 'gestao_admin', 'docs',
+];
+
+export const ACCESS: Record<AccessPersona, { sections: SectionId[]; readOnly: SectionId[] }> = {
+  gestao:           { sections: ALL, readOnly: [] },
+  gestor_comercial: { sections: ['principal', 'clientes', 'vendas', 'performance', 'inteligencia', 'docs'], readOnly: [] },
+  vendedor:         { sections: ['principal', 'clientes', 'vendas', 'performance', 'docs'], readOnly: [] },
+  operacao:         { sections: ['principal', 'operacao', 'docs'], readOnly: [] },
+  financeiro:       { sections: ['principal', 'clientes', 'vendas', 'financeiro', 'docs'], readOnly: ['vendas'] },
+  cliente:          { sections: [], readOnly: [] }, // customer usa o portal próprio (nav de customer, fora desta matriz)
+};
+
+export function canAccess(persona: AccessPersona, section: SectionId): boolean {
+  return ACCESS[persona].sections.includes(section);
+}
+
+export function isReadOnly(persona: AccessPersona, section: SectionId): boolean {
+  return ACCESS[persona].readOnly.includes(section);
+}
+```
+
+- [ ] **Step 4: Rodar pra ver passar**
+
+Run: `bun run test src/lib/access/access-matrix.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/access/access-matrix.ts src/lib/access/access-matrix.test.ts
+git commit -m "feat(access): matriz de acesso estática (canAccess/isReadOnly)"
+```
+
+---
+
+## Task 5: Hook `useAccess`
+
+**Files:**
+- Create: `src/hooks/useAccess.ts`
+
+Compõe os hooks de fonte. `useAuth()` expõe `role` (AppRole|null), `isStaff`, `loading`. `useCommercialRole()` → `{ commercialRole, loading }`. `useUserDepartment()` → `{ department }` (react-query). `useSalesOnlyRestriction()` → boolean.
+
+- [ ] **Step 1: Implementar**
+
+```ts
+// src/hooks/useAccess.ts
+import { useMemo } from 'react';
+import { useAuth } from '@/contexts/AuthContext';
+import { useCommercialRole } from '@/hooks/useCommercialRole';
+import { useUserDepartment } from '@/hooks/useUserDepartment';
+import { useSalesOnlyRestriction } from '@/hooks/useSalesOnlyRestriction';
+import { resolveAccessPersona, resolveGroupTag } from '@/lib/access/resolve-access';
+import { canAccess, isReadOnly } from '@/lib/access/access-matrix';
+import type { AccessPersona, GroupTag, SectionId } from '@/lib/access/types';
+
+export interface UseAccessReturn {
+  persona: AccessPersona;
+  group: GroupTag | null;
+  loading: boolean;
+  can: (section: SectionId) => boolean;
+  isReadOnly: (section: SectionId) => boolean;
+}
+
+export function useAccess(): UseAccessReturn {
+  const { role, loading: authLoading } = useAuth();
+  const { commercialRole, loading: crLoading } = useCommercialRole();
+  const { department } = useUserDepartment();
+  const isSalesOnly = useSalesOnlyRestriction();
+
+  const persona = useMemo(
+    () => resolveAccessPersona({ appRole: role, commercialRole, department, isSalesOnly }),
+    [role, commercialRole, department, isSalesOnly],
+  );
+  const group = useMemo(() => resolveGroupTag(commercialRole), [commercialRole]);
+
+  return {
+    persona,
+    group,
+    loading: authLoading || crLoading,
+    can: (section) => canAccess(persona, section),
+    isReadOnly: (section) => isReadOnly(persona, section),
+  };
+}
+```
+
+> **Confira ao implementar:** os nomes reais de campos em `useAuth()` (`role`/`loading`) e `useCommercialRole()` (`commercialRole`/`loading`). Ajuste se diferirem. `useSalesOnlyRestriction()` retorna `boolean` direto.
+
+- [ ] **Step 2: Lint + build**
+
+Run: `bunx eslint src/hooks/useAccess.ts && bun run build 2>&1 | tail -3`
+Expected: 0 erros, build ok.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/hooks/useAccess.ts
+git commit -m "feat(access): hook useAccess (compõe fontes → persona/group/can)"
+```
+
+---
+
+## Task 6: Componente `RequireAccess` (TDD)
+
+**Files:**
+- Create: `src/components/access/__tests__/RequireAccess.test.tsx`
+- Create: `src/components/access/RequireAccess.tsx`
+
+- [ ] **Step 1: Escrever o teste que falha**
+
+```tsx
+// src/components/access/__tests__/RequireAccess.test.tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { RequireAccess } from '../RequireAccess';
+
+const mockAccess = vi.fn();
+vi.mock('@/hooks/useAccess', () => ({ useAccess: () => mockAccess() }));
+vi.mock('react-router-dom', () => ({
+  Navigate: ({ to }: { to: string }) => <div data-testid="redirect" data-to={to} />,
+  Outlet: () => <div data-testid="outlet" />,
+}));
+
+describe('RequireAccess', () => {
+  beforeEach(() => mockAccess.mockReset());
+
+  it('loading → não redireciona nem mostra conteúdo (placeholder null)', () => {
+    mockAccess.mockReturnValue({ loading: true, can: () => false });
+    const { container } = render(<RequireAccess section="financeiro"><div data-testid="kid" /></RequireAccess>);
+    expect(screen.queryByTestId('redirect')).toBeNull();
+    expect(screen.queryByTestId('kid')).toBeNull();
+    expect(container).toBeTruthy();
+  });
+
+  it('sem acesso → redireciona pra /', () => {
+    mockAccess.mockReturnValue({ loading: false, can: () => false });
+    render(<RequireAccess section="financeiro"><div data-testid="kid" /></RequireAccess>);
+    expect(screen.getByTestId('redirect').getAttribute('data-to')).toBe('/');
+  });
+
+  it('com acesso → renderiza os filhos', () => {
+    mockAccess.mockReturnValue({ loading: false, can: (s: string) => s === 'financeiro' });
+    render(<RequireAccess section="financeiro"><div data-testid="kid" /></RequireAccess>);
+    expect(screen.getByTestId('kid')).toBeInTheDocument();
+  });
+
+  it('sem children → renderiza <Outlet/> quando tem acesso', () => {
+    mockAccess.mockReturnValue({ loading: false, can: () => true });
+    render(<RequireAccess section="vendas" />);
+    expect(screen.getByTestId('outlet')).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Rodar pra ver falhar**
+
+Run: `bun run test src/components/access/__tests__/RequireAccess.test.tsx`
+Expected: FAIL — módulo não existe.
+
+- [ ] **Step 3: Implementar**
+
+```tsx
+// src/components/access/RequireAccess.tsx
+import type { ReactNode } from 'react';
+import { Navigate, Outlet } from 'react-router-dom';
+import { useAccess } from '@/hooks/useAccess';
+import type { SectionId } from '@/lib/access/types';
+
+interface Props {
+  section: SectionId;
+  children?: ReactNode;
+  /** Pra onde redirecionar quando sem acesso. Default '/'. */
+  redirectTo?: string;
+}
+
+/**
+ * Guard de rota por seção de acesso. Bloqueia URL digitada na mão (não só esconde menu).
+ * Enquanto carrega o acesso, não decide (evita flash de redirect). Use como wrapper de
+ * grupo de rotas (com <Outlet/>) ou de uma rota única (com children).
+ */
+export function RequireAccess({ section, children, redirectTo = '/' }: Props) {
+  const { loading, can } = useAccess();
+  if (loading) return null;
+  if (!can(section)) return <Navigate to={redirectTo} replace />;
+  return <>{children ?? <Outlet />}</>;
+}
+```
+
+- [ ] **Step 4: Rodar pra ver passar**
+
+Run: `bun run test src/components/access/__tests__/RequireAccess.test.tsx`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/access/RequireAccess.tsx src/components/access/__tests__/RequireAccess.test.tsx
+git commit -m "feat(access): RequireAccess (guard de rota por seção) — TDD"
+```
+
+---
+
+## Task 7: Filtro de menu no `AppShell`
+
+**Files:**
+- Modify: `src/components/AppShell.tsx`
+
+- [ ] **Step 1: Mapear cada item de nav pra uma `SectionId`**
+
+READ `src/components/AppShell.tsx` (arrays `unifiedNavSections` + `docNavSection`, ~linhas 55-160). Adicionar um campo `section: SectionId` a CADA item de nav, conforme a seção dona dele:
+- Principal (Dashboard, Meu dia) → `'principal'`; Clientes → `'clientes'`.
+- Afiação (Ferramentas, Gamificação) → `'principal'` (são base; ou criar nada — ficam com vendedor+). Use `'principal'`.
+- Vendas (Pedidos/Novo/Ferramentas de Venda/Telefonia/Chamadas) → `'vendas'`.
+- Estoque (Recebimento) + Produção (Ordens) + tintométrico balcão → `'operacao'`.
+- Reposição (Cockpit/Mercado/Parâmetros/Cadastros) → `'reposicao'`.
+- Performance → `'performance'`.
+- Inteligência (Dashboard Intel/AI Ops) → `'inteligencia'`.
+- Financeiro (Cockpit CFO/Gestão/Análise) → `'financeiro'`.
+- Tintométrico (Dashboard/Catálogo/Integração) → `'tintometrico_cockpit'`.
+- Automação (Notificações/Portal Sayerlack) + Gestão (Liberar Acessos/Departamentos/KB/Calculadora/Processos/Governança) → `'gestao_admin'`.
+- Documentação (Ajuda/Design System/UX Rules) → `'docs'`.
+
+- [ ] **Step 2: Trocar o gating binário pelo `useAccess`**
+
+No `AppSidebar`, adicionar `const { can } = useAccess();` (import `useAccess`). Onde hoje as seções/itens são filtradas por `managerOnly` + `isSalesOnly`, passar a filtrar por `can(item.section)`. Cada seção só aparece se tiver ≥1 item visível. Manter o `useSalesOnlyRestriction` SOMENTE como entrada do resolver (já é) — remover o uso direto dele pra esconder itens (o resolver+matriz já cobrem: sales-only→vendedor→só vê vendas/clientes/principal/performance/docs). Remover o flag `managerOnly` dos itens (substituído por `section`).
+
+> **Nota:** itens base de CLIENTE (quando `role === 'customer'`) continuam pelo caminho atual de customer-nav — a matriz é pra staff. Se o AppShell já separa customer vs staff nav, não mexer no ramo customer.
+
+- [ ] **Step 3: Build + lint + suíte**
+
+Run: `bun run build 2>&1 | tail -3 && bunx eslint src/components/AppShell.tsx && bun run test 2>&1 | grep -E "Tests "`
+Expected: build ok, lint 0, testes verdes (flaky reposicao ignorar).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/AppShell.tsx
+git commit -m "feat(access): menu lateral filtra por useAccess().can (substitui managerOnly/isSalesOnly)"
+```
+
+---
+
+## Task 8: Guards de rota no `App.tsx`
+
+**Files:**
+- Modify: `src/App.tsx`
+
+- [ ] **Step 1: Envolver os grupos de rota com `<RequireAccess>`**
+
+READ `src/App.tsx` (bloco `<Route element={<ProtectedRoute><AppShellLayout/></ProtectedRoute>}>`). Agrupar as rotas por seção e envolver cada grupo com um layout-route `<RequireAccess section=...>`. Padrão react-router v6 (rota-layout sem path, com `<Outlet/>` via RequireAccess):
+```tsx
+<Route element={<RequireAccess section="financeiro" />}>
+  <Route path="financeiro/cockpit" element={<FinanceiroCockpit />} />
+  <Route path="financeiro/gestao" element={<FinanceiroGestao />} />
+  <Route path="financeiro/analise" element={<FinanceiroAnalise />} />
+</Route>
+```
+Aplicar pros grupos sensíveis: `financeiro` (rotas /financeiro/*), `operacao` (/admin/estoque/*, /recebimento, /producao), `reposicao` (/admin/reposicao/*), `tintometrico_cockpit` (/tintometrico/*), `inteligencia` (/intelligence, /ai-ops), `gestao_admin` (/admin/approvals, /admin/departments, /gestao/*, /admin/notificacoes, /admin/portal-sayerlack), `vendas` (/sales/*, /telefonia, /vendas/*), `clientes` (/admin/customers + /admin/customers/:id). Rotas base (Dashboard /, /meu-dia, /tools, /profile, docs) ficam SEM guard (todos staff têm `principal`/`docs`).
+
+> Não precisa cobrir 100% das 119 rotas — priorizar os grupos da matriz. Rotas não envolvidas seguem acessíveis (degradação segura), e o MENU já as esconde. O guard é pra bloquear URL direta dos módulos sensíveis.
+
+- [ ] **Step 2: Build (valida rotas/JSX)**
+
+Run: `bun run build 2>&1 | tail -3`
+Expected: build ok.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/App.tsx
+git commit -m "feat(access): guards de rota <RequireAccess> nos módulos sensíveis"
+```
+
+---
+
+## Task 9: Gate da seção financeira no Customer 360
+
+**Files:**
+- Modify: `src/pages/Customer360.tsx`
+
+- [ ] **Step 1: Localizar a seção financeira do cliente**
+
+READ `src/pages/Customer360.tsx` e achar a seção/aba que mostra a situação financeira do cliente (aging/crédito/limite — buscar por termos como `financ`, `aging`, `credito`, `limite`, `inadimpl`). Se não houver uma seção financeira dedicada hoje, **registrar como DONE_WITH_CONCERNS** (não há o que gatear ainda) e pular — o gate entra quando a seção existir.
+
+- [ ] **Step 2: Gatear a renderização**
+
+Adicionar `const { persona } = useAccess();` (import) e envolver a seção financeira do cliente com:
+```tsx
+{(['vendedor','gestor_comercial','financeiro','gestao'] as const).includes(persona) && (
+  /* ...seção financeira do cliente... */
+)}
+```
+(Quem acessa Customer 360 já é uma dessas personas; o gate é defensivo pra não vazar se o acesso a `clientes` for ampliado.)
+
+- [ ] **Step 3: Build + commit**
+
+Run: `bun run build 2>&1 | tail -3`
+```bash
+git add src/pages/Customer360.tsx
+git commit -m "feat(access): gate da seção financeira do cliente no Customer 360"
+```
+
+---
+
+## Task 10: Validação final + PR
+
+- [ ] **Step 1: Suíte + build + lint**
+
+Run: `bun run test && bun run build && bunx eslint src/lib/access src/hooks/useAccess.ts src/components/access`
+Expected: testes verdes (inclui resolve-access + access-matrix + RequireAccess), build ok, lint 0.
+
+- [ ] **Step 2: typecheck:strict (CI roda isso — não regredir)**
+
+Run: `bun run typecheck:strict 2>&1 | grep -cE "error TS"`
+Expected: 0.
+
+- [ ] **Step 3: Abrir PR**
+
+```bash
+gh pr create --title "feat(access): controle de acesso por persona (matriz + resolver + menu + guards)" --body "Implementa o spec docs/superpowers/specs/2026-05-23-controle-acesso-persona-design.md. Sem migration (frontend-only). Default=vendedor."
+```
+
+---
+
+## Self-review / observações
+- **Sem migration** — é frontend-only; nenhum passo manual no Lovable.
+- **Default seguro:** staff sem tag → vendedor (vê só vendas/clientes/principal/performance/docs). Pra dar acesso a operação/financeiro/gestão, taggear `commercial_role`/`department` via "Liberar Acessos"/"Departamentos".
+- **Fora deste plano:** home por grupo (Sub-projeto B), filtro de dados da Performance por grupo (a tag fica pronta no `useAccess().group`), RLS de banco.

--- a/docs/superpowers/specs/2026-05-23-controle-acesso-persona-design.md
+++ b/docs/superpowers/specs/2026-05-23-controle-acesso-persona-design.md
@@ -1,0 +1,115 @@
+# Controle de Acesso por Persona — Design Spec
+
+> **Data:** 2026-05-23
+> **Status:** aprovado no brainstorming, pronto pra planejar
+> **Escopo:** Sub-projeto A (controle de acesso). O Sub-projeto B (home/agenda por grupo Hunter/farmer/inbound) é um brainstorm separado depois — depende da "tag de grupo" que este entrega.
+
+## Goal
+
+Controle de acesso "de verdade" por persona: cada papel (vendedor, gestor comercial, operação, financeiro, gestão/master, cliente) vê **só os módulos que pode** no menu lateral **e** não consegue abrir as rotas bloqueadas digitando a URL (guard de rota, não só esconder). Determinístico (sem heurística), baseado em `commercial_role` + `department` + `app_role`.
+
+## Contexto (estado atual)
+
+- **Detecção de persona já existe** (`src/lib/dashboard/persona-detect.ts` → `inferPersona`, `persona-config.ts` → `PERSONA_CONFIG`), mas serve pra **ordenar zonas do dashboard**, NÃO pra acesso. Mistura fontes (override, `user_departments`, sales_only, `commercial_role`, heurística de uso, default). **Não usar pra acesso** (heurística = acesso imprevisível).
+- **Navegação hoje** (`AppShell.tsx`): gating binário via flag `managerOnly` por item + `useSalesOnlyRestriction` (lockdown por CPF em `company_config.sales_only_cpfs`). Sem granularidade por persona, sem guard de rota.
+- **Fontes de dado determinísticas disponíveis:**
+  - `useAuth()` → `appRole` (`employee|customer|master`), `isMaster`, `isStaff`.
+  - `useCommercialRole()` → enum `commercial_role`: `operacional|gerencial|estrategico|super_admin|farmer|hunter|closer|master`.
+  - `useUserDepartment()` → `user_departments.primary_dept`: `vendas|gestao|comprador|separador|conferente|tintometrico|financeiro|outro`.
+  - `useSalesOnlyRestriction()` → boolean (CPF sales-only).
+- **Admin de tagging já existe** no menu: "Liberar Acessos" (`/admin/approvals`) e "Departamentos" (`/admin/departments`).
+- Rotas em `src/App.tsx` agrupadas sob `<ProtectedRoute><AppShellLayout/></ProtectedRoute>`.
+
+## Decisões do brainstorming
+
+1. **Camada de acesso dedicada e determinística** — separada do `inferPersona` (que continua só pro dashboard).
+2. **Fonte:** `commercial_role` + `department` + `app_role` (+ `isSalesOnly`). **Código estático** (matriz no código, não config dinâmica).
+3. **Frontend-first:** filtro de menu + guard de rota no front. (RLS de banco fica fora deste escopo — observação no roadmap.)
+4. **Default de quem não tem tag = Vendedor** (acesso a Vendas + Principal). Ninguém fica trancado fora do básico; ninguém ganha financeiro/admin sem ser taggeado.
+5. **Tag de grupo** (`hunter|farmer|closer`, do `commercial_role`) — NÃO muda acesso (todos = Vendedor), mas é exposta pra Performance (escopo) e pra home (Sub-projeto B).
+6. **Estoque + Tintométrico (balcão) + Produção = uma persona "Operação".** Sem persona separada de produção. Cockpit analítico de tintométrico fica com Gestão/Master.
+7. **Comprador = só o Lucas** → dobra em Master (Reposição + Inteligência = master).
+8. **Gestor comercial = puramente comercial:** sem /financeiro módulo, sem reposição/estoque/admin. A parte financeira que ele vê é a **do cliente** (Customer 360).
+9. **Vendedor + Gestor + Master veem a situação financeira do CLIENTE** (Customer 360) — distinto do módulo /financeiro.
+
+## Arquitetura
+
+### Personas de acesso + matriz
+
+Personas (de acesso): `vendedor`, `gestor_comercial`, `operacao`, `financeiro`, `gestao` (master tier), `cliente`.
+
+Seções de navegação (colunas): `principal` (Dashboard + Meu dia), `clientes` (Customer 360), `vendas` (Pedidos/Novo/Ferramentas/**Telefonia**/Chamadas), `operacao` (Recebimento/Picking/Tintométrico-balcão/Produção), `reposicao`, `performance`, `inteligencia`, `financeiro` (módulo), `tintometrico_cockpit`, `gestao_admin` (Liberar Acessos/Departamentos/Governança/etc.), `docs` (Ajuda/Design System/UX Rules — todos).
+
+| Persona (fonte) | principal | clientes | vendas+tel | operacao | reposicao | performance | inteligencia | financeiro | tinto_cockpit | gestao_admin |
+|---|---|---|---|---|---|---|---|---|---|---|
+| **vendedor** (operacional·farmer·hunter·closer / dept vendas / sales-only / default) | ✅ | ✅ | ✅ | ➖ | ➖ | ✅ (própria + grupo + empresa) | ➖ | ➖ | ➖ | ➖ |
+| **gestor_comercial** (gerencial / dept gestao) | ✅ | ✅ | ✅ | ➖ | ➖ | ✅ (equipe) | ✅ | ➖ | ➖ | ➖ |
+| **operacao** (dept separador·conferente·tintometrico) | ✅ | ➖ | ➖ | ✅ | ➖ | ➖ | ➖ | ➖ | ➖ | ➖ |
+| **financeiro** (dept financeiro) | ✅ | ✅ | 🟡 leitura | ➖ | ➖ | ➖ | ➖ | ✅ | ➖ | ➖ |
+| **gestao** (estrategico·super_admin·master / app master) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| **cliente** (app customer) | portal do cliente (pedidos/ferramentas próprios) | — | ➖ | ➖ | ➖ | ➖ | ➖ | ➖ | ➖ | ➖ |
+
+- ✅ acesso · 🟡 leitura · ➖ bloqueado.
+- **Situação financeira do cliente** (aging/crédito no Customer 360) = liberada pra `vendedor`, `gestor_comercial`, `financeiro`, `gestao` (quem tem `clientes`). É uma seção DENTRO do Customer 360, não o módulo /financeiro.
+- **Performance escopada por grupo:** `vendedor` vê própria + agregado do seu grupo (`farmer`→"Farmers Geral"; `hunter`→"Hunters Geral"; `closer`→"Closers Geral") + total da empresa. `gestor_comercial`/`gestao` veem todos os grupos.
+
+### Peça 1 — Resolver determinístico
+
+`src/lib/access/resolve-access.ts`:
+```
+resolveAccessPersona({ appRole, commercialRole, department, isSalesOnly }): AccessPersona
+```
+Ordem de precedência (primeira que casar vence):
+1. `appRole === 'master'` OU `commercialRole ∈ {estrategico, super_admin, master}` → `gestao`.
+2. `commercialRole === 'gerencial'` OU `department === 'gestao'` → `gestor_comercial`.
+3. `department === 'financeiro'` → `financeiro`.
+4. `department ∈ {separador, conferente, tintometrico}` → `operacao`.
+5. `appRole === 'customer'` → `cliente`.
+6. `commercialRole ∈ {operacional, farmer, hunter, closer}` OU `department === 'vendas'` OU `isSalesOnly` → `vendedor`.
+7. **default** (staff sem tag) → `vendedor`.
+
+`resolveGroupTag(commercialRole): 'hunter'|'farmer'|'closer'|null` — pra Performance/home.
+
+Composição via hook `useAccess()` que junta `useAuth`+`useCommercialRole`+`useUserDepartment`+`useSalesOnlyRestriction` → `{ persona, group, can(section) }`.
+
+### Peça 2 — Matriz como dado estático
+
+`src/lib/access/access-matrix.ts`:
+```
+ACCESS: Record<AccessPersona, { sections: Set<SectionId>; readOnly: Set<SectionId> }>
+```
+A matriz acima vira esse objeto. `can(section)` = `ACCESS[persona].sections.has(section)`. `isReadOnly(section)` p/ as células 🟡.
+
+### Peça 3 — Filtro de menu
+
+`AppShell.tsx`: cada item/seção do menu ganha um `section: SectionId`. O filtro passa a ser `useAccess().can(item.section)` em vez de `managerOnly`/`isSalesOnly` soltos. Remove o gating binário antigo (migra `managerOnly`→seção correspondente; mantém `isSalesOnly` só como uma das entradas do resolver).
+
+### Peça 4 — Guard de rota
+
+`src/components/access/RequireAccess.tsx`:
+```tsx
+<RequireAccess section="financeiro"><Outlet/></RequireAccess>
+```
+Envolve os grupos de rota no `App.tsx` por seção. Se `!can(section)` → `<Navigate to="/" replace />` (ou uma tela "sem acesso"). É o "de verdade": bloqueia URL digitada na mão.
+
+### Peça 5 — Customer 360: seção financeira do cliente
+
+Dentro do Customer 360, a seção/aba de situação financeira do cliente é renderizada só se `can('clientes')` E persona ∈ {vendedor, gestor_comercial, financeiro, gestao}. (Todos que têm `clientes` já satisfazem; o gate explícito evita vazar se o acesso a `clientes` for ampliado no futuro.)
+
+### Peça 6 — Tag de grupo na Performance
+
+A Performance lê `useAccess().group`: `vendedor` com grupo → filtra "minha + meu grupo + empresa". Sem mudar acesso, só escopo de dados exibidos. (Implementação do filtro de dados pode ser fase incremental — o spec garante a tag disponível.)
+
+## Fora de escopo (este spec)
+
+- **Sub-projeto B — home/agenda por grupo** (Hunter vs farmer vs inbound: o que aparece primeiro). Brainstorm próprio, com mockups. Usa a tag de grupo entregue aqui.
+- **RLS de banco por persona** (defesa server-side). Este spec é frontend-first; o gating de UI + rota não substitui RLS pra dados sensíveis — registrar como observação de roadmap (hoje a maior parte do gating sensível já tem RLS própria por tabela).
+- **Telas de admin pra criar/editar grupos comerciais** (Farmers/Hunters) — assume `commercial_role` já setado via "Liberar Acessos"/"Departamentos".
+- Implementação fina do filtro de dados da Performance por grupo (a tag fica pronta; o filtro pode vir em fase 2).
+
+## Touchpoints no código
+
+- Criar: `src/lib/access/{resolve-access.ts, access-matrix.ts}` (+ testes puros), `src/hooks/useAccess.ts`, `src/components/access/RequireAccess.tsx`.
+- Modificar: `src/components/AppShell.tsx` (itens ganham `section`; filtro via `useAccess`), `src/App.tsx` (envolver grupos de rota com `RequireAccess`), Customer 360 (gate da seção financeira do cliente).
+- Reusar: `useAuth`, `useCommercialRole`, `useUserDepartment`, `useSalesOnlyRestriction`.
+- NÃO tocar: `inferPersona`/`persona-config` (continuam pro dashboard).

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -273,7 +273,9 @@ const App = () => (
               <Route element={<RequireAccess section="inteligencia" />}>
                 <Route path="ai-ops" element={<AIops />} />
               </Route>
-              <Route path="nfe-receipt" element={<NfeReceipt />} />
+              <Route element={<RequireAccess section="operacao" />}>
+                <Route path="nfe-receipt" element={<NfeReceipt />} />
+              </Route>
               <Route element={<RequireAccess section="tintometrico_cockpit" />}>
                 <Route path="tintometrico" element={<TintDashboard />} />
                 <Route path="tintometrico/importar" element={<TintImport />} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import { ConditionalWebRTCProvider } from "@/contexts/ConditionalWebRTCProvider"
 import { ProtectedRoute } from "@/components/ProtectedRoute";
 import { NotificationPrompt } from "@/components/NotificationPrompt";
 import { AppShellLayout } from "@/components/AppShellLayout";
+import { RequireAccess } from "@/components/access/RequireAccess";
 import { PageSkeleton } from "@/components/ui/page-skeleton";
 
 // Lazy-loaded pages
@@ -206,11 +207,15 @@ const App = () => (
               <Route path="tools/:toolId/reports" element={<ToolReports />} />
               <Route path="support" element={<Support />} />
               <Route path="admin" element={<Admin />} />
-              <Route path="admin/approvals" element={<AdminApprovals />} />
-              <Route path="admin/departments" element={<AdminDepartments />} />
-              <Route path="admin/customers" element={<AdminCustomers />} />
-              <Route path="admin/customers/:customerId" element={<AdminCustomers />} />
-              <Route path="admin/customers/:customerId/360" element={<Customer360 />} />
+              <Route element={<RequireAccess section="gestao_admin" />}>
+                <Route path="admin/approvals" element={<AdminApprovals />} />
+                <Route path="admin/departments" element={<AdminDepartments />} />
+              </Route>
+              <Route element={<RequireAccess section="clientes" />}>
+                <Route path="admin/customers" element={<AdminCustomers />} />
+                <Route path="admin/customers/:customerId" element={<AdminCustomers />} />
+                <Route path="admin/customers/:customerId/360" element={<Customer360 />} />
+              </Route>
               <Route path="admin/orders/:id" element={<AdminOrderDetail />} />
               <Route path="admin/orders/:id/quality" element={<QualityChecklist />} />
               <Route path="admin/demand-forecast" element={<AdminDemandForecast />} />
@@ -252,40 +257,53 @@ const App = () => (
               <Route path="coaching" element={<CoachingSPIN />} />
               <Route path="settings" element={<SettingsConfig />} />
               <Route path="docs" element={<TechnicalDocs />} />
-              <Route path="intelligence" element={<IntelligenceDashboard />} />
-              <Route path="governance/users" element={<GovernanceUsers />} />
-              <Route path="governance/permissions" element={<GovernancePermissions />} />
-              <Route path="governance/math" element={<GovernanceMathParams />} />
-              <Route path="governance/audit" element={<GovernanceAudit />} />
-              <Route path="governance/settings" element={<GovernanceSettings />} />
-              <Route path="governance/companies" element={<GovernanceCompanies />} />
-              <Route path="ai-ops" element={<AIops />} />
+              <Route element={<RequireAccess section="inteligencia" />}>
+                <Route path="intelligence" element={<IntelligenceDashboard />} />
+              </Route>
+              <Route element={<RequireAccess section="gestao_admin" />}>
+                <Route path="governance/users" element={<GovernanceUsers />} />
+                <Route path="governance/permissions" element={<GovernancePermissions />} />
+                <Route path="governance/math" element={<GovernanceMathParams />} />
+                <Route path="governance/audit" element={<GovernanceAudit />} />
+                <Route path="governance/settings" element={<GovernanceSettings />} />
+                <Route path="governance/companies" element={<GovernanceCompanies />} />
+              </Route>
+              <Route element={<RequireAccess section="inteligencia" />}>
+                <Route path="ai-ops" element={<AIops />} />
+              </Route>
               <Route path="nfe-receipt" element={<NfeReceipt />} />
-              <Route path="tintometrico" element={<TintDashboard />} />
-              <Route path="tintometrico/importar" element={<TintImport />} />
-              <Route path="tintometrico/mapeamento" element={<TintMapping />} />
-              <Route path="tintometrico/precos" element={<TintPricing />} />
-              <Route path="tintometrico/formulas" element={<TintFormulas />} />
-              <Route path="tintometrico/corantes" element={<TintCorantes />} />
-              <Route path="tintometrico/integracoes" element={<TintIntegrations />} />
-              <Route path="tintometrico/reconciliacao" element={<TintReconciliation />} />
-              <Route path="tintometrico/sync-runs" element={<TintSyncRuns />} />
-              <Route path="tintometrico/api-contract" element={<TintApiContract />} />
-              <Route path="financeiro" element={<FinanceiroDashboard />} />
-              <Route path="financeiro/sync" element={<FinanceiroSync />} />
-              <Route path="financeiro/mapping" element={<FinanceiroMapping />} />
-              <Route path="financeiro/capital-giro" element={<FinanceiroCapitalGiro />} />
-              <Route path="financeiro/fechamento" element={<FinanceiroFechamento />} />
-              <Route path="financeiro/analytics" element={<FinanceiroAnalytics />} />
-              <Route path="financeiro/cockpit" element={<FinanceiroCockpit />} />
-              <Route path="financeiro/conciliacao" element={<FinanceiroConciliacao />} />
-              <Route path="financeiro/orcamento" element={<FinanceiroOrcamento />} />
-              <Route path="financeiro/intercompany" element={<FinanceiroIntercompany />} />
-              <Route path="financeiro/intercompany/fila" element={<FinanceiroIntercompanyFila />} />
-              <Route path="financeiro/tributario" element={<FinanceiroTributario />} />
-              <Route path="recebimento" element={<Recebimento />} />
-              <Route path="recebimento/:id" element={<RecebimentoConferencia />} />
-              <Route path="producao" element={<ProductionOrders />} />
+              <Route element={<RequireAccess section="tintometrico_cockpit" />}>
+                <Route path="tintometrico" element={<TintDashboard />} />
+                <Route path="tintometrico/importar" element={<TintImport />} />
+                <Route path="tintometrico/mapeamento" element={<TintMapping />} />
+                <Route path="tintometrico/precos" element={<TintPricing />} />
+                <Route path="tintometrico/formulas" element={<TintFormulas />} />
+                <Route path="tintometrico/corantes" element={<TintCorantes />} />
+                <Route path="tintometrico/integracoes" element={<TintIntegrations />} />
+                <Route path="tintometrico/reconciliacao" element={<TintReconciliation />} />
+                <Route path="tintometrico/sync-runs" element={<TintSyncRuns />} />
+                <Route path="tintometrico/api-contract" element={<TintApiContract />} />
+              </Route>
+              <Route element={<RequireAccess section="financeiro" />}>
+                <Route path="financeiro" element={<FinanceiroDashboard />} />
+                <Route path="financeiro/sync" element={<FinanceiroSync />} />
+                <Route path="financeiro/mapping" element={<FinanceiroMapping />} />
+                <Route path="financeiro/capital-giro" element={<FinanceiroCapitalGiro />} />
+                <Route path="financeiro/fechamento" element={<FinanceiroFechamento />} />
+                <Route path="financeiro/analytics" element={<FinanceiroAnalytics />} />
+                <Route path="financeiro/cockpit" element={<FinanceiroCockpit />} />
+                <Route path="financeiro/conciliacao" element={<FinanceiroConciliacao />} />
+                <Route path="financeiro/orcamento" element={<FinanceiroOrcamento />} />
+                <Route path="financeiro/intercompany" element={<FinanceiroIntercompany />} />
+                <Route path="financeiro/intercompany/fila" element={<FinanceiroIntercompanyFila />} />
+                <Route path="financeiro/tributario" element={<FinanceiroTributario />} />
+              </Route>
+              <Route element={<RequireAccess section="operacao" />}>
+                <Route path="recebimento" element={<Recebimento />} />
+                <Route path="recebimento/:id" element={<RecebimentoConferencia />} />
+                <Route path="producao" element={<ProductionOrders />} />
+              </Route>
+              <Route element={<RequireAccess section="reposicao" />}>
               <Route path="admin/reposicao/revisao" element={<AdminReposicaoRevisao />} />
               <Route path="admin/reposicao/historico" element={<AdminReposicaoHistorico />} />
               <Route path="admin/reposicao/alertas" element={<AdminReposicaoAlertas />} />
@@ -318,21 +336,34 @@ const App = () => (
               <Route path="admin/reposicao/mercado" element={<Navigate to="/admin/reposicao/sessao/mercado" replace />} />
               <Route path="admin/reposicao/parametros" element={<Navigate to="/admin/reposicao/sessao/parametros" replace />} />
               <Route path="admin/reposicao/cadastros" element={<AdminReposicaoCadastros />} />
-              <Route path="admin/estoque/recebimento" element={<AdminEstoqueRecebimento />} />
-              <Route path="admin/estoque/picking" element={<AdminEstoquePicking />} />
-              <Route path="admin/estoque/picking/mobile" element={<TouchPickingView />} />
-              <Route path="financeiro/gestao" element={<FinanceiroGestao />} />
-              <Route path="financeiro/analise" element={<FinanceiroAnalise />} />
-              <Route path="tintometrico/catalogo" element={<TintCatalogo />} />
-              <Route path="tintometrico/integracao" element={<TintIntegracao />} />
-              <Route path="performance" element={<PerformanceHub />} />
+              </Route>
+              <Route element={<RequireAccess section="operacao" />}>
+                <Route path="admin/estoque/recebimento" element={<AdminEstoqueRecebimento />} />
+                <Route path="admin/estoque/picking" element={<AdminEstoquePicking />} />
+                <Route path="admin/estoque/picking/mobile" element={<TouchPickingView />} />
+              </Route>
+              <Route element={<RequireAccess section="financeiro" />}>
+                <Route path="financeiro/gestao" element={<FinanceiroGestao />} />
+                <Route path="financeiro/analise" element={<FinanceiroAnalise />} />
+              </Route>
+              <Route element={<RequireAccess section="tintometrico_cockpit" />}>
+                <Route path="tintometrico/catalogo" element={<TintCatalogo />} />
+                <Route path="tintometrico/integracao" element={<TintIntegracao />} />
+              </Route>
+              <Route element={<RequireAccess section="performance" />}>
+                <Route path="performance" element={<PerformanceHub />} />
+              </Route>
               <Route path="vendas/ferramentas" element={<VendasFerramentas />} />
-              <Route path="gestao/admin" element={<GestaoAdmin />} />
-              <Route path="gestao/governanca" element={<GestaoGovernanca />} />
+              <Route element={<RequireAccess section="gestao_admin" />}>
+                <Route path="gestao/admin" element={<GestaoAdmin />} />
+                <Route path="gestao/governanca" element={<GestaoGovernanca />} />
+              </Route>
               <Route path="admin/ajuda" element={<AdminAjuda />} />
               <Route path="admin/des/trimestre-atual" element={<AdminDesTrimestreAtual />} />
-              <Route path="admin/notificacoes" element={<AdminNotificacoes />} />
-              <Route path="admin/portal-sayerlack" element={<AdminPortalSayerlack />} />
+              <Route element={<RequireAccess section="gestao_admin" />}>
+                <Route path="admin/notificacoes" element={<AdminNotificacoes />} />
+                <Route path="admin/portal-sayerlack" element={<AdminPortalSayerlack />} />
+              </Route>
               <Route path="admin/sip-credentials" element={<AdminVendorSipCredentials />} />
               <Route path="admin/knowledge-base" element={<AdminKnowledgeBase />} />
               <Route path="admin/knowledge-base/:id" element={<AdminKnowledgeBaseDetail />} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -364,13 +364,15 @@ const App = () => (
                 <Route path="admin/notificacoes" element={<AdminNotificacoes />} />
                 <Route path="admin/portal-sayerlack" element={<AdminPortalSayerlack />} />
               </Route>
-              <Route path="admin/sip-credentials" element={<AdminVendorSipCredentials />} />
-              <Route path="admin/knowledge-base" element={<AdminKnowledgeBase />} />
-              <Route path="admin/knowledge-base/:id" element={<AdminKnowledgeBaseDetail />} />
-              <Route path="admin/standard-processes" element={<AdminStandardProcesses />} />
-              <Route path="admin/standard-processes/new" element={<AdminStandardProcessNew />} />
-              <Route path="admin/standard-processes/:id" element={<AdminStandardProcessDetail />} />
-              <Route path="admin/calculadora" element={<AdminCalculadora />} />
+              <Route element={<RequireAccess section="gestao_admin" />}>
+                <Route path="admin/sip-credentials" element={<AdminVendorSipCredentials />} />
+                <Route path="admin/knowledge-base" element={<AdminKnowledgeBase />} />
+                <Route path="admin/knowledge-base/:id" element={<AdminKnowledgeBaseDetail />} />
+                <Route path="admin/standard-processes" element={<AdminStandardProcesses />} />
+                <Route path="admin/standard-processes/new" element={<AdminStandardProcessNew />} />
+                <Route path="admin/standard-processes/:id" element={<AdminStandardProcessDetail />} />
+                <Route path="admin/calculadora" element={<AdminCalculadora />} />
+              </Route>
               <Route path="telefonia" element={<Telefonia />} />
             </Route>
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -226,7 +226,9 @@ const App = () => (
               <Route path="admin/gamification" element={<AdminGamification />} />
               <Route path="admin/training" element={<AdminTraining />} />
               <Route path="admin/price-table" element={<AdminPriceTable />} />
-              <Route path="admin/analytics-sync" element={<AdminAnalyticsSync />} />
+              <Route element={<RequireAccess section="gestao_admin" />}>
+                <Route path="admin/analytics-sync" element={<AdminAnalyticsSync />} />
+              </Route>
               <Route path="recurring-schedules" element={<RecurringSchedules />} />
               <Route path="savings" element={<SavingsDashboard />} />
               <Route path="loyalty" element={<Loyalty />} />
@@ -359,7 +361,9 @@ const App = () => (
                 <Route path="gestao/governanca" element={<GestaoGovernanca />} />
               </Route>
               <Route path="admin/ajuda" element={<AdminAjuda />} />
-              <Route path="admin/des/trimestre-atual" element={<AdminDesTrimestreAtual />} />
+              <Route element={<RequireAccess section="performance" />}>
+                <Route path="admin/des/trimestre-atual" element={<AdminDesTrimestreAtual />} />
+              </Route>
               <Route element={<RequireAccess section="gestao_admin" />}>
                 <Route path="admin/notificacoes" element={<AdminNotificacoes />} />
                 <Route path="admin/portal-sayerlack" element={<AdminPortalSayerlack />} />

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -37,6 +37,8 @@ import { AnalyticsIdentify } from '@/components/shell/AnalyticsIdentify';
 import { useFeatureFlagBodyClass } from '@/hooks/useFeatureFlag';
 import { useSidebarFavorites } from '@/hooks/useSidebarFavorites';
 import { useSalesOnlyRestriction } from '@/hooks/useSalesOnlyRestriction';
+import { useAccess } from '@/hooks/useAccess';
+import type { SectionId } from '@/lib/access/types';
 import { useRouteTracker } from '@/lib/dashboard/route-tracker';
 import { useOfflineFlush } from '@/hooks/useOfflineFlush';
 import { useMissedCount } from '@/hooks/useCallLog';
@@ -49,103 +51,104 @@ interface NavItem {
   path: string;
   badge?: number;
   badgeVariant?: 'default' | 'destructive';
-  managerOnly?: boolean;
+  /** Seção de acesso dona deste item — filtra a visibilidade via useAccess().can */
+  section: SectionId;
 }
 
 const unifiedNavSections: { title: string; items: NavItem[] }[] = [
   {
     title: 'Principal',
     items: [
-      { icon: LayoutDashboard, label: 'Dashboard', path: '/' },
-      { icon: Target, label: 'Meu dia', path: '/meu-dia' },
-      { icon: Users, label: 'Clientes', path: '/admin/customers' },
+      { icon: LayoutDashboard, label: 'Dashboard', path: '/', section: 'principal' },
+      { icon: Target, label: 'Meu dia', path: '/meu-dia', section: 'principal' },
+      { icon: Users, label: 'Clientes', path: '/admin/customers', section: 'clientes' },
     ],
   },
   {
     title: 'Afiação',
     items: [
-      { icon: Wrench, label: 'Ferramentas', path: '/tools' },
-      { icon: Award, label: 'Gamificação', path: '/gamification' },
+      { icon: Wrench, label: 'Ferramentas', path: '/tools', section: 'principal' },
+      { icon: Award, label: 'Gamificação', path: '/gamification', section: 'principal' },
     ],
   },
   {
     title: 'Vendas',
     items: [
-      { icon: ShoppingCart, label: 'Pedidos', path: '/sales' },
-      { icon: PlusCircle, label: 'Novo Pedido', path: '/sales/new' },
-      { icon: Wrench, label: 'Ferramentas de Venda', path: '/vendas/ferramentas' },
-      { icon: Link2, label: 'Chamadas pendentes', path: '/farmer/calls/pending-link' },
-      { icon: Phone, label: 'Telefonia', path: '/telefonia' },
+      { icon: ShoppingCart, label: 'Pedidos', path: '/sales', section: 'vendas' },
+      { icon: PlusCircle, label: 'Novo Pedido', path: '/sales/new', section: 'vendas' },
+      { icon: Wrench, label: 'Ferramentas de Venda', path: '/vendas/ferramentas', section: 'vendas' },
+      { icon: Link2, label: 'Chamadas pendentes', path: '/farmer/calls/pending-link', section: 'vendas' },
+      { icon: Phone, label: 'Telefonia', path: '/telefonia', section: 'vendas' },
     ],
   },
   {
     title: 'Estoque',
     items: [
-      { icon: FileCheck, label: 'Recebimento', path: '/admin/estoque/recebimento' },
-      { icon: Package, label: 'Picking & Estoque', path: '/admin/estoque/picking' },
+      { icon: FileCheck, label: 'Recebimento', path: '/admin/estoque/recebimento', section: 'operacao' },
+      { icon: Package, label: 'Picking & Estoque', path: '/admin/estoque/picking', section: 'operacao' },
     ],
   },
   {
     title: 'Reposição',
     items: [
-      { icon: LayoutDashboard, label: 'Cockpit', path: '/admin/reposicao/sessao', managerOnly: true },
-      { icon: TrendingUp, label: 'Mercado', path: '/admin/reposicao/sessao/mercado', managerOnly: true },
-      { icon: Settings, label: 'Parâmetros', path: '/admin/reposicao/sessao/parametros', managerOnly: true },
-      { icon: Database, label: 'Cadastros', path: '/admin/reposicao/cadastros', managerOnly: true },
+      { icon: LayoutDashboard, label: 'Cockpit', path: '/admin/reposicao/sessao', section: 'reposicao' },
+      { icon: TrendingUp, label: 'Mercado', path: '/admin/reposicao/sessao/mercado', section: 'reposicao' },
+      { icon: Settings, label: 'Parâmetros', path: '/admin/reposicao/sessao/parametros', section: 'reposicao' },
+      { icon: Database, label: 'Cadastros', path: '/admin/reposicao/cadastros', section: 'reposicao' },
     ],
   },
   {
     title: 'Produção',
     items: [
-      { icon: Wrench, label: 'Ordens de Produção', path: '/producao' },
+      { icon: Wrench, label: 'Ordens de Produção', path: '/producao', section: 'operacao' },
     ],
   },
   {
     title: 'Performance',
     items: [
-      { icon: BarChart3, label: 'Performance', path: '/performance' },
+      { icon: BarChart3, label: 'Performance', path: '/performance', section: 'performance' },
     ],
   },
   {
     title: 'Inteligência',
     items: [
-      { icon: BarChart3, label: 'Dashboard Intel', path: '/intelligence' },
-      { icon: Target, label: 'AI Ops', path: '/ai-ops' },
+      { icon: BarChart3, label: 'Dashboard Intel', path: '/intelligence', section: 'inteligencia' },
+      { icon: Target, label: 'AI Ops', path: '/ai-ops', section: 'inteligencia' },
     ],
   },
   {
     title: 'Financeiro',
     items: [
-      { icon: Shield, label: 'Cockpit CFO', path: '/financeiro/cockpit', managerOnly: true },
-      { icon: DollarSign, label: 'Gestão Financeira', path: '/financeiro/gestao', managerOnly: true },
-      { icon: BarChart3, label: 'Análise e Config', path: '/financeiro/analise', managerOnly: true },
+      { icon: Shield, label: 'Cockpit CFO', path: '/financeiro/cockpit', section: 'financeiro' },
+      { icon: DollarSign, label: 'Gestão Financeira', path: '/financeiro/gestao', section: 'financeiro' },
+      { icon: BarChart3, label: 'Análise e Config', path: '/financeiro/analise', section: 'financeiro' },
     ],
   },
   {
     title: 'Tintométrico',
     items: [
-      { icon: BarChart3, label: 'Dashboard', path: '/tintometrico', managerOnly: true },
-      { icon: Palette, label: 'Catálogo e Preços', path: '/tintometrico/catalogo', managerOnly: true },
-      { icon: Settings, label: 'Integração e Sync', path: '/tintometrico/integracao', managerOnly: true },
+      { icon: BarChart3, label: 'Dashboard', path: '/tintometrico', section: 'tintometrico_cockpit' },
+      { icon: Palette, label: 'Catálogo e Preços', path: '/tintometrico/catalogo', section: 'tintometrico_cockpit' },
+      { icon: Settings, label: 'Integração e Sync', path: '/tintometrico/integracao', section: 'tintometrico_cockpit' },
     ],
   },
   {
     title: 'Automação',
     items: [
-      { icon: Bell, label: 'Notificações', path: '/admin/notificacoes', managerOnly: true },
-      { icon: Globe2, label: 'Portal Sayerlack', path: '/admin/portal-sayerlack', managerOnly: true },
+      { icon: Bell, label: 'Notificações', path: '/admin/notificacoes', section: 'gestao_admin' },
+      { icon: Globe2, label: 'Portal Sayerlack', path: '/admin/portal-sayerlack', section: 'gestao_admin' },
     ],
   },
   {
     title: 'Gestão',
     items: [
-      { icon: UserCheck, label: 'Liberar Acessos', path: '/admin/approvals', managerOnly: true },
-      { icon: Users, label: 'Departamentos', path: '/admin/departments', managerOnly: true },
-      { icon: Library, label: 'Base de conhecimento', path: '/admin/knowledge-base', managerOnly: true },
-      { icon: Calculator, label: 'Calculadora de rendimento', path: '/admin/calculadora' },
-      { icon: Factory, label: 'Processos padrão', path: '/admin/standard-processes' },
-      { icon: Shield, label: 'Admin & Relatórios', path: '/gestao/admin', managerOnly: true },
-      { icon: Lock, label: 'Governança', path: '/gestao/governanca', managerOnly: true },
+      { icon: UserCheck, label: 'Liberar Acessos', path: '/admin/approvals', section: 'gestao_admin' },
+      { icon: Users, label: 'Departamentos', path: '/admin/departments', section: 'gestao_admin' },
+      { icon: Library, label: 'Base de conhecimento', path: '/admin/knowledge-base', section: 'gestao_admin' },
+      { icon: Calculator, label: 'Calculadora de rendimento', path: '/admin/calculadora', section: 'gestao_admin' },
+      { icon: Factory, label: 'Processos padrão', path: '/admin/standard-processes', section: 'gestao_admin' },
+      { icon: Shield, label: 'Admin & Relatórios', path: '/gestao/admin', section: 'gestao_admin' },
+      { icon: Lock, label: 'Governança', path: '/gestao/governanca', section: 'gestao_admin' },
     ],
   },
 ];
@@ -153,9 +156,9 @@ const unifiedNavSections: { title: string; items: NavItem[] }[] = [
 const docNavSection: { title: string; items: NavItem[] } = {
   title: 'Documentação',
   items: [
-    { icon: BookOpen, label: 'Ajuda', path: '/admin/ajuda' },
-    { icon: BookOpen, label: 'Design System', path: '/design-system' },
-    { icon: BookOpen, label: 'UX Rules', path: '/ux-rules' },
+    { icon: BookOpen, label: 'Ajuda', path: '/admin/ajuda', section: 'docs' },
+    { icon: BookOpen, label: 'Design System', path: '/design-system', section: 'docs' },
+    { icon: BookOpen, label: 'UX Rules', path: '/ux-rules', section: 'docs' },
   ],
 };
 
@@ -332,6 +335,7 @@ function AppSidebar({ collapsed, onToggle }: { collapsed: boolean; onToggle: () 
   const location = useLocation();
   const navigate = useNavigate();
   const { isStaff, user } = useAuth();
+  const { can } = useAccess();
   const isSalesOnly = useSalesOnlyRestriction();
   const { favorites, isFavorite, toggle: toggleFavorite } = useSidebarFavorites();
 
@@ -541,8 +545,8 @@ function AppSidebar({ collapsed, onToggle }: { collapsed: boolean; onToggle: () 
 
       {/* Navigation — Favoritos no topo (se houver) + seções secundárias colapsadas por padrão */}
       <nav className="flex-1 min-h-0 overflow-y-auto py-2">
-        {/* Favoritos pinados — coletados de todas as seções pelo path */}
-        {!isSalesOnly && favorites.length > 0 && !collapsed && (
+        {/* Favoritos pinados — coletados de todas as seções pelo path (só os acessíveis) */}
+        {favorites.length > 0 && !collapsed && (
           <SidebarSection
             title="Favoritos"
             collapsed={false}
@@ -553,7 +557,7 @@ function AppSidebar({ collapsed, onToggle }: { collapsed: boolean; onToggle: () 
               sectionsWithBadges
                 .flatMap((s) => s.items)
                 .filter((item) => favorites.includes(item.path))
-                .filter((item) => !item.managerOnly || isStaff)
+                .filter((item) => can(item.section))
             }
             onToggleFavorite={toggleFavorite}
             isFavorite={isFavorite}
@@ -561,9 +565,9 @@ function AppSidebar({ collapsed, onToggle }: { collapsed: boolean; onToggle: () 
         )}
 
         {sectionsWithBadges.map((section) => {
-          if (isSalesOnly && section.title !== 'Vendas') return null;
-
-          const visibleItems = section.items.filter(item => !item.managerOnly || isStaff);
+          // Filtro de acesso por persona: cada item só aparece se a matriz liberar
+          // a seção dele. Uma seção (grupo) só renderiza se tiver ≥1 item visível.
+          const visibleItems = section.items.filter((item) => can(item.section));
           if (visibleItems.length === 0) return null;
 
           const isSecondary = SECONDARY_SECTIONS.includes(section.title);
@@ -659,8 +663,7 @@ function AppTopbar({ sidebarCollapsed, onMobileMenuToggle }: { sidebarCollapsed:
 function MobileNav({ open, onClose }: { open: boolean; onClose: () => void }) {
   const location = useLocation();
   const navigate = useNavigate();
-  const { isStaff } = useAuth();
-  const isSalesOnly = useSalesOnlyRestriction();
+  const { can } = useAccess();
 
   if (!open) return null;
 
@@ -687,8 +690,7 @@ function MobileNav({ open, onClose }: { open: boolean; onClose: () => void }) {
         </div>
         <nav className="flex-1 min-h-0 overflow-y-auto py-2">
           {[...unifiedNavSections, docNavSection].map((section) => {
-            if (isSalesOnly && section.title !== 'Vendas') return null;
-            const visibleItems = section.items.filter(item => !item.managerOnly || isStaff);
+            const visibleItems = section.items.filter((item) => can(item.section));
             if (visibleItems.length === 0) return null;
             return (
               <div key={section.title} className="mb-1">

--- a/src/components/access/RequireAccess.tsx
+++ b/src/components/access/RequireAccess.tsx
@@ -1,0 +1,23 @@
+import type { ReactNode } from 'react';
+import { Navigate, Outlet } from 'react-router-dom';
+import { useAccess } from '@/hooks/useAccess';
+import type { SectionId } from '@/lib/access/types';
+
+interface Props {
+  section: SectionId;
+  children?: ReactNode;
+  /** Pra onde redirecionar quando sem acesso. Default '/'. */
+  redirectTo?: string;
+}
+
+/**
+ * Guard de rota por seção de acesso. Bloqueia URL digitada na mão (não só esconde menu).
+ * Enquanto carrega o acesso, não decide (evita flash de redirect). Use como wrapper de
+ * grupo de rotas (com <Outlet/>) ou de uma rota única (com children).
+ */
+export function RequireAccess({ section, children, redirectTo = '/' }: Props) {
+  const { loading, can } = useAccess();
+  if (loading) return null;
+  if (!can(section)) return <Navigate to={redirectTo} replace />;
+  return <>{children ?? <Outlet />}</>;
+}

--- a/src/components/access/__tests__/RequireAccess.test.tsx
+++ b/src/components/access/__tests__/RequireAccess.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { RequireAccess } from '../RequireAccess';
+
+const mockAccess = vi.fn();
+vi.mock('@/hooks/useAccess', () => ({ useAccess: () => mockAccess() }));
+vi.mock('react-router-dom', () => ({
+  Navigate: ({ to }: { to: string }) => <div data-testid="redirect" data-to={to} />,
+  Outlet: () => <div data-testid="outlet" />,
+}));
+
+describe('RequireAccess', () => {
+  beforeEach(() => mockAccess.mockReset());
+
+  it('loading → não redireciona nem mostra conteúdo (placeholder null)', () => {
+    mockAccess.mockReturnValue({ loading: true, can: () => false });
+    const { container } = render(<RequireAccess section="financeiro"><div data-testid="kid" /></RequireAccess>);
+    expect(screen.queryByTestId('redirect')).toBeNull();
+    expect(screen.queryByTestId('kid')).toBeNull();
+    expect(container).toBeTruthy();
+  });
+
+  it('sem acesso → redireciona pra /', () => {
+    mockAccess.mockReturnValue({ loading: false, can: () => false });
+    render(<RequireAccess section="financeiro"><div data-testid="kid" /></RequireAccess>);
+    expect(screen.getByTestId('redirect').getAttribute('data-to')).toBe('/');
+  });
+
+  it('com acesso → renderiza os filhos', () => {
+    mockAccess.mockReturnValue({ loading: false, can: (s: string) => s === 'financeiro' });
+    render(<RequireAccess section="financeiro"><div data-testid="kid" /></RequireAccess>);
+    expect(screen.getByTestId('kid')).toBeInTheDocument();
+  });
+
+  it('sem children → renderiza <Outlet/> quando tem acesso', () => {
+    mockAccess.mockReturnValue({ loading: false, can: () => true });
+    render(<RequireAccess section="vendas" />);
+    expect(screen.getByTestId('outlet')).toBeInTheDocument();
+  });
+});

--- a/src/hooks/useAccess.ts
+++ b/src/hooks/useAccess.ts
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
 import { useCommercialRole } from '@/hooks/useCommercialRole';
 import { useUserDepartment } from '@/hooks/useUserDepartment';
-import { useSalesOnlyRestriction } from '@/hooks/useSalesOnlyRestriction';
+import { useSalesOnlyState } from '@/hooks/useSalesOnlyRestriction';
 import { resolveAccessPersona, resolveGroupTag } from '@/lib/access/resolve-access';
 import { canAccess, isReadOnly } from '@/lib/access/access-matrix';
 import type { AccessPersona, GroupTag, SectionId } from '@/lib/access/types';
@@ -20,7 +20,7 @@ export function useAccess(): UseAccessReturn {
   const { role, loading: authLoading } = useAuth();
   const { commercialRole, loading: crLoading } = useCommercialRole();
   const { department, isLoading: deptLoading } = useUserDepartment();
-  const isSalesOnly = useSalesOnlyRestriction();
+  const { isSalesOnly, loading: salesOnlyLoading } = useSalesOnlyState();
 
   const persona = useMemo(
     () => resolveAccessPersona({ appRole: role, commercialRole, department, isSalesOnly }),
@@ -31,7 +31,9 @@ export function useAccess(): UseAccessReturn {
   return {
     persona,
     group,
-    loading: authLoading || crLoading || deptLoading,
+    // fail-closed: espera TAMBÉM o sales-only resolver (senão um sales-only+dept
+    // privilegiado escalaria na janela de load — codex review).
+    loading: authLoading || crLoading || deptLoading || salesOnlyLoading,
     can: (section) => canAccess(persona, section),
     isReadOnly: (section) => isReadOnly(persona, section),
   };

--- a/src/hooks/useAccess.ts
+++ b/src/hooks/useAccess.ts
@@ -1,0 +1,38 @@
+import { useMemo } from 'react';
+import { useAuth } from '@/contexts/AuthContext';
+import { useCommercialRole } from '@/hooks/useCommercialRole';
+import { useUserDepartment } from '@/hooks/useUserDepartment';
+import { useSalesOnlyRestriction } from '@/hooks/useSalesOnlyRestriction';
+import { resolveAccessPersona, resolveGroupTag } from '@/lib/access/resolve-access';
+import { canAccess, isReadOnly } from '@/lib/access/access-matrix';
+import type { AccessPersona, GroupTag, SectionId } from '@/lib/access/types';
+
+export interface UseAccessReturn {
+  persona: AccessPersona;
+  group: GroupTag | null;
+  loading: boolean;
+  can: (section: SectionId) => boolean;
+  isReadOnly: (section: SectionId) => boolean;
+}
+
+export function useAccess(): UseAccessReturn {
+  // Note: useUserDepartment exposes `isLoading` (not `loading`) — adapt accordingly
+  const { role, loading: authLoading } = useAuth();
+  const { commercialRole, loading: crLoading } = useCommercialRole();
+  const { department, isLoading: deptLoading } = useUserDepartment();
+  const isSalesOnly = useSalesOnlyRestriction();
+
+  const persona = useMemo(
+    () => resolveAccessPersona({ appRole: role, commercialRole, department, isSalesOnly }),
+    [role, commercialRole, department, isSalesOnly],
+  );
+  const group = useMemo(() => resolveGroupTag(commercialRole), [commercialRole]);
+
+  return {
+    persona,
+    group,
+    loading: authLoading || crLoading || deptLoading,
+    can: (section) => canAccess(persona, section),
+    isReadOnly: (section) => isReadOnly(persona, section),
+  };
+}

--- a/src/hooks/useCommercialRole.ts
+++ b/src/hooks/useCommercialRole.ts
@@ -2,7 +2,9 @@ import { useState, useEffect } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
 import { supabase } from '@/integrations/supabase/client';
 
-export type CommercialRole = 'operacional' | 'gerencial' | 'estrategico' | 'super_admin';
+export type CommercialRole =
+  | 'operacional' | 'gerencial' | 'estrategico' | 'super_admin'
+  | 'farmer' | 'hunter' | 'closer' | 'master';
 
 interface UseCommercialRoleReturn {
   commercialRole: CommercialRole | null;

--- a/src/hooks/useSalesOnlyRestriction.ts
+++ b/src/hooks/useSalesOnlyRestriction.ts
@@ -3,13 +3,14 @@ import { useAuth } from '@/contexts/AuthContext';
 import { supabase } from '@/integrations/supabase/client';
 
 /**
- * Retorna true se o CPF do usuário está na lista `sales_only_cpfs` da company_config.
- * Extraído de AppShell.tsx pra ser reusado por usePersona e outros lugares.
+ * Estado completo do sales-only: o flag + se as queries ainda estão carregando.
+ * O `loading` é essencial pro controle de acesso fail-closed (não liberar rota
+ * privilegiada na janela em que o sales-only ainda não resolveu). Ver useAccess.
  */
-export function useSalesOnlyRestriction(): boolean {
+export function useSalesOnlyState(): { isSalesOnly: boolean; loading: boolean } {
   const { user } = useAuth();
 
-  const { data: salesOnlyCpfs } = useQuery({
+  const cpfsQuery = useQuery({
     queryKey: ['config', 'sales_only_cpfs'],
     queryFn: async () => {
       const { data } = await supabase
@@ -22,7 +23,7 @@ export function useSalesOnlyRestriction(): boolean {
     staleTime: 5 * 60 * 1000,
   });
 
-  const { data: userDoc } = useQuery({
+  const docQuery = useQuery({
     queryKey: ['profile', 'document', user?.id],
     queryFn: async () => {
       const { data } = await supabase
@@ -36,6 +37,19 @@ export function useSalesOnlyRestriction(): boolean {
     staleTime: 5 * 60 * 1000,
   });
 
-  if (!salesOnlyCpfs || !userDoc) return false;
-  return salesOnlyCpfs.includes(userDoc);
+  // Carregando enquanto qualquer query relevante não resolveu (docQuery só conta
+  // se há user — quando disabled, isLoading é false).
+  const loading = cpfsQuery.isLoading || (!!user?.id && docQuery.isLoading);
+  const salesOnlyCpfs = cpfsQuery.data;
+  const userDoc = docQuery.data;
+  const isSalesOnly = !salesOnlyCpfs || !userDoc ? false : salesOnlyCpfs.includes(userDoc);
+  return { isSalesOnly, loading };
+}
+
+/**
+ * Retorna true se o CPF do usuário está na lista `sales_only_cpfs` da company_config.
+ * Wrapper booleano (compat) sobre useSalesOnlyState — reusado por AppShell/usePersona.
+ */
+export function useSalesOnlyRestriction(): boolean {
+  return useSalesOnlyState().isSalesOnly;
 }

--- a/src/lib/access/access-matrix.test.ts
+++ b/src/lib/access/access-matrix.test.ts
@@ -38,4 +38,13 @@ describe('canAccess', () => {
       expect(canAccess(p, 'docs')).toBe(true);
     }
   });
+
+  it('cliente: principal/docs sim (Dashboard+tools); staff sections não', () => {
+    expect(canAccess('cliente', 'principal')).toBe(true);
+    expect(canAccess('cliente', 'docs')).toBe(true);
+    expect(canAccess('cliente', 'vendas')).toBe(false);
+    expect(canAccess('cliente', 'clientes')).toBe(false);
+    expect(canAccess('cliente', 'financeiro')).toBe(false);
+    expect(canAccess('cliente', 'gestao_admin')).toBe(false);
+  });
 });

--- a/src/lib/access/access-matrix.test.ts
+++ b/src/lib/access/access-matrix.test.ts
@@ -1,0 +1,41 @@
+// src/lib/access/access-matrix.test.ts
+import { describe, it, expect } from 'vitest';
+import { canAccess, isReadOnly } from './access-matrix';
+
+describe('canAccess', () => {
+  it('vendedor: vendas/clientes/performance sim; financeiro/operacao/reposicao não', () => {
+    expect(canAccess('vendedor', 'vendas')).toBe(true);
+    expect(canAccess('vendedor', 'clientes')).toBe(true);
+    expect(canAccess('vendedor', 'performance')).toBe(true);
+    expect(canAccess('vendedor', 'financeiro')).toBe(false);
+    expect(canAccess('vendedor', 'operacao')).toBe(false);
+    expect(canAccess('vendedor', 'reposicao')).toBe(false);
+  });
+  it('gestor_comercial: inteligencia sim; financeiro/operacao não', () => {
+    expect(canAccess('gestor_comercial', 'inteligencia')).toBe(true);
+    expect(canAccess('gestor_comercial', 'clientes')).toBe(true);
+    expect(canAccess('gestor_comercial', 'financeiro')).toBe(false);
+    expect(canAccess('gestor_comercial', 'operacao')).toBe(false);
+  });
+  it('operacao: operacao sim; vendas/clientes não', () => {
+    expect(canAccess('operacao', 'operacao')).toBe(true);
+    expect(canAccess('operacao', 'vendas')).toBe(false);
+    expect(canAccess('operacao', 'clientes')).toBe(false);
+  });
+  it('financeiro: financeiro/clientes sim; vendas leitura', () => {
+    expect(canAccess('financeiro', 'financeiro')).toBe(true);
+    expect(canAccess('financeiro', 'clientes')).toBe(true);
+    expect(canAccess('financeiro', 'vendas')).toBe(true);
+    expect(isReadOnly('financeiro', 'vendas')).toBe(true);
+  });
+  it('gestao: acessa tudo', () => {
+    for (const s of ['principal','clientes','vendas','operacao','reposicao','performance','inteligencia','financeiro','tintometrico_cockpit','gestao_admin','docs'] as const) {
+      expect(canAccess('gestao', s)).toBe(true);
+    }
+  });
+  it('docs liberado pra todas as personas staff', () => {
+    for (const p of ['vendedor','gestor_comercial','operacao','financeiro','gestao'] as const) {
+      expect(canAccess(p, 'docs')).toBe(true);
+    }
+  });
+});

--- a/src/lib/access/access-matrix.ts
+++ b/src/lib/access/access-matrix.ts
@@ -1,0 +1,24 @@
+// src/lib/access/access-matrix.ts
+import type { AccessPersona, SectionId } from './types';
+
+const ALL: SectionId[] = [
+  'principal', 'clientes', 'vendas', 'operacao', 'reposicao', 'performance',
+  'inteligencia', 'financeiro', 'tintometrico_cockpit', 'gestao_admin', 'docs',
+];
+
+export const ACCESS: Record<AccessPersona, { sections: SectionId[]; readOnly: SectionId[] }> = {
+  gestao:           { sections: ALL, readOnly: [] },
+  gestor_comercial: { sections: ['principal', 'clientes', 'vendas', 'performance', 'inteligencia', 'docs'], readOnly: [] },
+  vendedor:         { sections: ['principal', 'clientes', 'vendas', 'performance', 'docs'], readOnly: [] },
+  operacao:         { sections: ['principal', 'operacao', 'docs'], readOnly: [] },
+  financeiro:       { sections: ['principal', 'clientes', 'vendas', 'financeiro', 'docs'], readOnly: ['vendas'] },
+  cliente:          { sections: [], readOnly: [] }, // customer usa o portal próprio (nav de customer, fora desta matriz)
+};
+
+export function canAccess(persona: AccessPersona, section: SectionId): boolean {
+  return ACCESS[persona].sections.includes(section);
+}
+
+export function isReadOnly(persona: AccessPersona, section: SectionId): boolean {
+  return ACCESS[persona].readOnly.includes(section);
+}

--- a/src/lib/access/access-matrix.ts
+++ b/src/lib/access/access-matrix.ts
@@ -12,7 +12,10 @@ export const ACCESS: Record<AccessPersona, { sections: SectionId[]; readOnly: Se
   vendedor:         { sections: ['principal', 'clientes', 'vendas', 'performance', 'docs'], readOnly: [] },
   operacao:         { sections: ['principal', 'operacao', 'docs'], readOnly: [] },
   financeiro:       { sections: ['principal', 'clientes', 'vendas', 'financeiro', 'docs'], readOnly: ['vendas'] },
-  cliente:          { sections: [], readOnly: [] }, // customer usa o portal próprio (nav de customer, fora desta matriz)
+  // Customer renderiza o MESMO AppShell (rotas /orders /tools /profile vivem nele).
+  // Mantém Dashboard + Ferramentas/tools (principal) + docs; esconde tudo de staff
+  // (vendas/clientes-admin/financeiro/etc.) — mais correto que o menu permissivo antigo.
+  cliente:          { sections: ['principal', 'docs'], readOnly: [] },
 };
 
 export function canAccess(persona: AccessPersona, section: SectionId): boolean {

--- a/src/lib/access/resolve-access.test.ts
+++ b/src/lib/access/resolve-access.test.ts
@@ -1,0 +1,55 @@
+// src/lib/access/resolve-access.test.ts
+import { describe, it, expect } from 'vitest';
+import { resolveAccessPersona, resolveGroupTag } from './resolve-access';
+
+const base = { appRole: null, commercialRole: null, department: null, isSalesOnly: false } as const;
+
+describe('resolveAccessPersona', () => {
+  it('master (app_role) → gestao', () => {
+    expect(resolveAccessPersona({ ...base, appRole: 'master' })).toBe('gestao');
+  });
+  it('estrategico/super_admin → gestao', () => {
+    expect(resolveAccessPersona({ ...base, commercialRole: 'estrategico' })).toBe('gestao');
+    expect(resolveAccessPersona({ ...base, commercialRole: 'super_admin' })).toBe('gestao');
+  });
+  it('gerencial → gestor_comercial', () => {
+    expect(resolveAccessPersona({ ...base, commercialRole: 'gerencial' })).toBe('gestor_comercial');
+  });
+  it('department gestao → gestor_comercial', () => {
+    expect(resolveAccessPersona({ ...base, appRole: 'employee', department: 'gestao' })).toBe('gestor_comercial');
+  });
+  it('department financeiro → financeiro', () => {
+    expect(resolveAccessPersona({ ...base, appRole: 'employee', department: 'financeiro' })).toBe('financeiro');
+  });
+  it('department separador/conferente/tintometrico → operacao', () => {
+    for (const d of ['separador', 'conferente', 'tintometrico'] as const) {
+      expect(resolveAccessPersona({ ...base, appRole: 'employee', department: d })).toBe('operacao');
+    }
+  });
+  it('customer → cliente', () => {
+    expect(resolveAccessPersona({ ...base, appRole: 'customer' })).toBe('cliente');
+  });
+  it('vendas (operacional/farmer/hunter/closer) → vendedor', () => {
+    for (const r of ['operacional', 'farmer', 'hunter', 'closer'] as const) {
+      expect(resolveAccessPersona({ ...base, appRole: 'employee', commercialRole: r })).toBe('vendedor');
+    }
+  });
+  it('sales-only → vendedor', () => {
+    expect(resolveAccessPersona({ ...base, appRole: 'employee', isSalesOnly: true })).toBe('vendedor');
+  });
+  it('staff sem tag → vendedor (default)', () => {
+    expect(resolveAccessPersona({ ...base, appRole: 'employee' })).toBe('vendedor');
+  });
+});
+
+describe('resolveGroupTag', () => {
+  it('hunter/farmer/closer → o próprio', () => {
+    expect(resolveGroupTag('hunter')).toBe('hunter');
+    expect(resolveGroupTag('farmer')).toBe('farmer');
+    expect(resolveGroupTag('closer')).toBe('closer');
+  });
+  it('demais → null', () => {
+    expect(resolveGroupTag('operacional')).toBeNull();
+    expect(resolveGroupTag(null)).toBeNull();
+  });
+});

--- a/src/lib/access/resolve-access.test.ts
+++ b/src/lib/access/resolve-access.test.ts
@@ -40,6 +40,15 @@ describe('resolveAccessPersona', () => {
   it('staff sem tag → vendedor (default)', () => {
     expect(resolveAccessPersona({ ...base, appRole: 'employee' })).toBe('vendedor');
   });
+  // Anti-escalação (codex review): restrições vencem sinais de privilégio residuais.
+  it('customer com commercial_role residual NÃO escala — fica cliente', () => {
+    expect(resolveAccessPersona({ ...base, appRole: 'customer', commercialRole: 'super_admin' })).toBe('cliente');
+    expect(resolveAccessPersona({ ...base, appRole: 'customer', commercialRole: 'gerencial' })).toBe('cliente');
+  });
+  it('sales-only com department privilegiado NÃO escala — fica vendedor', () => {
+    expect(resolveAccessPersona({ ...base, appRole: 'employee', isSalesOnly: true, department: 'financeiro' })).toBe('vendedor');
+    expect(resolveAccessPersona({ ...base, appRole: 'employee', isSalesOnly: true, commercialRole: 'gerencial' })).toBe('vendedor');
+  });
 });
 
 describe('resolveGroupTag', () => {

--- a/src/lib/access/resolve-access.ts
+++ b/src/lib/access/resolve-access.ts
@@ -13,6 +13,11 @@ export interface AccessSignals {
 
 /** Resolve a persona de acesso de forma DETERMINÍSTICA (sem heurística). */
 export function resolveAccessPersona(s: AccessSignals): AccessPersona {
+  // RESTRIÇÕES PRIMEIRO — vencem qualquer sinal de privilégio "perdido"
+  // (ex: customer com commercial_role residual; sales-only com department).
+  if (s.appRole === 'customer') return 'cliente';
+  if (s.isSalesOnly) return 'vendedor';
+  // Escada de privilégio (do mais alto pro mais baixo).
   if (s.appRole === 'master'
     || s.commercialRole === 'estrategico'
     || s.commercialRole === 'super_admin'
@@ -20,8 +25,7 @@ export function resolveAccessPersona(s: AccessSignals): AccessPersona {
   if (s.commercialRole === 'gerencial' || s.department === 'gestao') return 'gestor_comercial';
   if (s.department === 'financeiro') return 'financeiro';
   if (s.department === 'separador' || s.department === 'conferente' || s.department === 'tintometrico') return 'operacao';
-  if (s.appRole === 'customer') return 'cliente';
-  // operacional/farmer/hunter/closer, dept vendas, sales-only, ou staff sem tag → vendedor (default)
+  // operacional/farmer/hunter/closer, dept vendas, ou staff sem tag → vendedor (default)
   return 'vendedor';
 }
 

--- a/src/lib/access/resolve-access.ts
+++ b/src/lib/access/resolve-access.ts
@@ -1,0 +1,34 @@
+// src/lib/access/resolve-access.ts
+import type { AppRole } from '@/contexts/AuthContext';
+import type { CommercialRole } from '@/hooks/useCommercialRole';
+import type { Department } from '@/integrations/supabase/types-departments';
+import type { AccessPersona, GroupTag } from './types';
+
+export interface AccessSignals {
+  appRole: AppRole | null;
+  commercialRole: CommercialRole | null;
+  department: Department | null;
+  isSalesOnly: boolean;
+}
+
+/** Resolve a persona de acesso de forma DETERMINÍSTICA (sem heurística). */
+export function resolveAccessPersona(s: AccessSignals): AccessPersona {
+  if (s.appRole === 'master'
+    || s.commercialRole === 'estrategico'
+    || s.commercialRole === 'super_admin'
+    || s.commercialRole === 'master') return 'gestao';
+  if (s.commercialRole === 'gerencial' || s.department === 'gestao') return 'gestor_comercial';
+  if (s.department === 'financeiro') return 'financeiro';
+  if (s.department === 'separador' || s.department === 'conferente' || s.department === 'tintometrico') return 'operacao';
+  if (s.appRole === 'customer') return 'cliente';
+  // operacional/farmer/hunter/closer, dept vendas, sales-only, ou staff sem tag → vendedor (default)
+  return 'vendedor';
+}
+
+/** Tag de grupo comercial (não muda acesso; usada pela Performance e pela home). */
+export function resolveGroupTag(commercialRole: CommercialRole | null): GroupTag | null {
+  if (commercialRole === 'hunter' || commercialRole === 'farmer' || commercialRole === 'closer') {
+    return commercialRole;
+  }
+  return null;
+}

--- a/src/lib/access/types.ts
+++ b/src/lib/access/types.ts
@@ -1,0 +1,18 @@
+// src/lib/access/types.ts
+export type AccessPersona =
+  | 'vendedor' | 'gestor_comercial' | 'operacao' | 'financeiro' | 'gestao' | 'cliente';
+
+export type GroupTag = 'hunter' | 'farmer' | 'closer';
+
+export type SectionId =
+  | 'principal'      // Dashboard + Meu dia
+  | 'clientes'       // Customer 360
+  | 'vendas'         // Pedidos / Novo / Ferramentas de venda / Telefonia / Chamadas
+  | 'operacao'       // Recebimento / Picking / Tintométrico balcão / Produção
+  | 'reposicao'
+  | 'performance'
+  | 'inteligencia'
+  | 'financeiro'             // módulo /financeiro
+  | 'tintometrico_cockpit'   // cockpit analítico de tintométrico
+  | 'gestao_admin'           // Liberar Acessos / Departamentos / Governança / etc.
+  | 'docs';                  // Ajuda / Design System / UX Rules


### PR DESCRIPTION
## O que é
Controle de acesso determinístico por persona, implementando o spec `docs/superpowers/specs/2026-05-23-controle-acesso-persona-design.md`. Filtra o menu lateral **e** bloqueia rotas por URL (guard) conforme `commercial_role` + `department` + `app_role`. **Frontend-only — sem migration, sem passos no Lovable.**

## Como funciona
- **Resolver determinístico** (`src/lib/access/resolve-access.ts`): restrições primeiro (customer→cliente, sales-only→vendedor) e depois escada de privilégio (gestao→gestor_comercial→financeiro→operacao→default **vendedor**). Sem heurística.
- **Matriz estática** (`access-matrix.ts`): persona → seções permitidas (+ readOnly).
- **Menu** (`AppShell`): filtra por `useAccess().can(section)` (substitui `managerOnly`/`isSalesOnly` solto). Item ganha `section`.
- **Guard de rota** (`<RequireAccess section>`): envolve os módulos sensíveis (financeiro, reposição, tintométrico-cockpit, gestão/admin, inteligência, operação, clientes, performance) — bloqueia URL direta. Fail-closed enquanto o acesso carrega.
- **Tag de grupo** (`useAccess().group`: hunter/farmer/closer) pronta pra Performance e pra home (Sub-projeto B).

## Personas → acesso (matriz)
| persona | principal | clientes | vendas | operação | reposição | performance | inteligência | financeiro | tinto-cockpit | gestão/admin |
|---|---|---|---|---|---|---|---|---|---|---|
| vendedor (incl. hunter/farmer/closer) | ✅ | ✅ | ✅ | ➖ | ➖ | ✅ | ➖ | ➖ | ➖ | ➖ |
| gestor_comercial | ✅ | ✅ | ✅ | ➖ | ➖ | ✅ | ✅ | ➖ | ➖ | ➖ |
| operação (estoque+tinto-balcão+produção) | ✅ | ➖ | ➖ | ✅ | ➖ | ➖ | ➖ | ➖ | ➖ | ➖ |
| financeiro | ✅ | ✅ | 🟡 | ➖ | ➖ | ➖ | ➖ | ✅ | ➖ | ➖ |
| gestão/master | ✅ tudo |
| cliente | principal+docs (Dashboard/tools) |

**Default = vendedor** (staff sem tag). Pra liberar operação/financeiro/gestão: taggear em "Liberar Acessos"/"Departamentos".

## Qualidade
- TDD nas libs puras (resolver + matriz): testes incluem anti-escalação.
- `bun run test` → 595/595 ✓ · `bun run build` ✓ · `bun run typecheck:strict` → 0 ✓ · lint 0.
- **Codex review (4 rodadas):** achou + corrigiu **5 P1 de bypass** (escalação do resolver, rotas gestao_admin/operação/performance sem guard, race do sales-only loading) → review final **CLEAN, zero bypass de matriz**. Também peguei uma regressão do cliente (menu vazio) e corrigi.

## Fora de escopo (follow-ups documentados)
- Home/agenda por grupo (Hunter vs farmer vs inbound) = **Sub-projeto B** (brainstorm próprio, com mockups; usa a tag de grupo daqui).
- Seção "situação financeira do cliente" no Customer 360 (não existe ainda — gate pronto pra quando for construída).
- Guard de rota pros admin/* órfãos não-no-menu (price-table, route-planner, etc.) + vendas — menu já não os expõe por persona; baixa criticidade.
- Filtro de dados da Performance por grupo (a tag fica pronta no `useAccess().group`).
- RLS de banco por persona (defesa server-side).

🤖 Generated with [Claude Code](https://claude.com/claude-code)