### PR TITLE
refactor(reposicao): split god-component AdminReposicaoGruposProducao (710→352)

### DIFF
--- a/src/components/reposicao/gruposProducao/GrupoDialog.tsx
+++ b/src/components/reposicao/gruposProducao/GrupoDialog.tsx
@@ -1,0 +1,118 @@
+// Modal de criação/edição de grupo de produção.
+// Extraído de src/pages/AdminReposicaoGruposProducao.tsx (god-component split).
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import {
+  Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle, DialogDescription,
+} from "@/components/ui/dialog";
+import { Loader2 } from "lucide-react";
+import type { Grupo } from "./types";
+
+export function GrupoDialog({
+  editing, setEditing, isNew, onSalvar, salvarPending,
+}: {
+  editing: Partial<Grupo> | null;
+  setEditing: (g: Partial<Grupo> | null) => void;
+  isNew: boolean;
+  onSalvar: (g: Partial<Grupo>) => void;
+  salvarPending: boolean;
+}) {
+  return (
+    <Dialog open={!!editing} onOpenChange={(o) => !o && setEditing(null)}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{isNew ? "Novo grupo" : "Editar grupo"}</DialogTitle>
+          <DialogDescription>
+            Define o lead time de produção e janela de corte do fornecedor.
+          </DialogDescription>
+        </DialogHeader>
+        {editing && (
+          <div className="space-y-3">
+            <div>
+              <Label>Fornecedor *</Label>
+              <Input
+                value={editing.fornecedor_nome || ""}
+                onChange={(e) => setEditing({ ...editing, fornecedor_nome: e.target.value })}
+                placeholder="Ex.: RENNER SAYERLACK S/A"
+              />
+            </div>
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <Label>Código do grupo *</Label>
+                <Input
+                  value={editing.grupo_codigo || ""}
+                  onChange={(e) => setEditing({ ...editing, grupo_codigo: e.target.value })}
+                  placeholder="ex.: sayerlack_rapido"
+                />
+              </div>
+              <div>
+                <Label>LT produção (dias) *</Label>
+                <Input
+                  type="number"
+                  min={1}
+                  value={editing.lt_producao_dias ?? 5}
+                  onChange={(e) =>
+                    setEditing({ ...editing, lt_producao_dias: Number(e.target.value) })
+                  }
+                />
+              </div>
+            </div>
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <Label>Unidade</Label>
+                <Select
+                  value={editing.lt_producao_unidade || "uteis"}
+                  onValueChange={(v) => setEditing({ ...editing, lt_producao_unidade: v })}
+                >
+                  <SelectTrigger><SelectValue /></SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="uteis">Dias úteis</SelectItem>
+                    <SelectItem value="corridos">Dias corridos</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div>
+                <Label>Horário de corte</Label>
+                <Input
+                  type="time"
+                  value={editing.horario_corte?.slice(0, 5) || ""}
+                  onChange={(e) =>
+                    setEditing({ ...editing, horario_corte: e.target.value || null })
+                  }
+                />
+              </div>
+            </div>
+            <div>
+              <Label>Descrição</Label>
+              <Input
+                value={editing.descricao || ""}
+                onChange={(e) => setEditing({ ...editing, descricao: e.target.value })}
+              />
+            </div>
+            <div>
+              <Label>Observações</Label>
+              <Textarea
+                rows={2}
+                value={editing.observacoes || ""}
+                onChange={(e) => setEditing({ ...editing, observacoes: e.target.value })}
+              />
+            </div>
+          </div>
+        )}
+        <DialogFooter>
+          <Button variant="outline" onClick={() => setEditing(null)}>Cancelar</Button>
+          <Button
+            onClick={() => editing && onSalvar(editing)}
+            disabled={salvarPending}
+          >
+            {salvarPending && <Loader2 className="h-4 w-4 animate-spin" />}
+            Salvar
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/reposicao/gruposProducao/GruposTable.tsx
+++ b/src/components/reposicao/gruposProducao/GruposTable.tsx
@@ -1,0 +1,85 @@
+// Tabela de grupos de produção cadastrados (Seção 1).
+// Extraída de src/pages/AdminReposicaoGruposProducao.tsx (god-component split).
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Loader2, Pencil } from "lucide-react";
+import type { Grupo } from "./types";
+
+export function GruposTable({
+  grupos, loading, contagensSku, onEdit,
+}: {
+  grupos: Grupo[];
+  loading: boolean;
+  contagensSku: Record<string, number>;
+  onEdit: (g: Grupo) => void;
+}) {
+  if (loading) {
+    return (
+      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+        <Loader2 className="h-4 w-4 animate-spin" /> Carregando…
+      </div>
+    );
+  }
+  return (
+    <div className="overflow-x-auto">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Fornecedor</TableHead>
+            <TableHead>Código</TableHead>
+            <TableHead>Descrição</TableHead>
+            <TableHead className="text-right">LT (dias)</TableHead>
+            <TableHead>Unidade</TableHead>
+            <TableHead>Corte</TableHead>
+            <TableHead className="text-right">SKUs</TableHead>
+            <TableHead className="w-[80px]"></TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {grupos.length === 0 && (
+            <TableRow>
+              <TableCell colSpan={8} className="text-center text-muted-foreground py-8">
+                Nenhum grupo cadastrado.
+              </TableCell>
+            </TableRow>
+          )}
+          {grupos.map((g) => (
+            <TableRow key={g.id}>
+              <TableCell className="font-medium">{g.fornecedor_nome}</TableCell>
+              <TableCell>
+                <Badge variant="outline">{g.grupo_codigo}</Badge>
+              </TableCell>
+              <TableCell className="text-muted-foreground">
+                {g.descricao || "—"}
+              </TableCell>
+              <TableCell className="text-right tabular-nums">
+                {g.lt_producao_dias}
+              </TableCell>
+              <TableCell>
+                <Badge variant="secondary" className="text-xs">
+                  {g.lt_producao_unidade === "uteis" ? "úteis" : "corridos"}
+                </Badge>
+              </TableCell>
+              <TableCell className="text-muted-foreground">
+                {g.horario_corte ? g.horario_corte.slice(0, 5) : "—"}
+              </TableCell>
+              <TableCell className="text-right tabular-nums font-medium">
+                {contagensSku[g.grupo_codigo] || 0}
+              </TableCell>
+              <TableCell>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => onEdit(g)}
+                >
+                  <Pencil className="h-3.5 w-3.5" />
+                </Button>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/src/components/reposicao/gruposProducao/SkuFilters.tsx
+++ b/src/components/reposicao/gruposProducao/SkuFilters.tsx
@@ -1,0 +1,105 @@
+// Filtros (fornecedor/grupo/busca) + barra de ação em lote da associação SKU→Grupo.
+// Extraído de src/pages/AdminReposicaoGruposProducao.tsx (god-component split).
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Search, Loader2 } from "lucide-react";
+import { ALL, SEM_GRUPO, type Grupo } from "./types";
+
+export function SkuFilters({
+  filtroFornecedor, setFiltroFornecedor, filtroGrupo, setFiltroGrupo, busca, setBusca, setPage,
+  fornecedoresDisponiveis, grupos, selecionadosCount, bulkGrupo, setBulkGrupo,
+  onAplicarLote, onLimparSelecao, moverLotePending,
+}: {
+  filtroFornecedor: string;
+  setFiltroFornecedor: (v: string) => void;
+  filtroGrupo: string;
+  setFiltroGrupo: (v: string) => void;
+  busca: string;
+  setBusca: (v: string) => void;
+  setPage: (p: number) => void;
+  fornecedoresDisponiveis: string[];
+  grupos: Grupo[];
+  selecionadosCount: number;
+  bulkGrupo: string;
+  setBulkGrupo: (v: string) => void;
+  onAplicarLote: () => void;
+  onLimparSelecao: () => void;
+  moverLotePending: boolean;
+}) {
+  return (
+    <>
+      {/* Filtros */}
+      <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
+        <Select value={filtroFornecedor} onValueChange={(v) => { setFiltroFornecedor(v); setPage(0); }}>
+          <SelectTrigger>
+            <SelectValue placeholder="Fornecedor" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={ALL}>Todos os fornecedores</SelectItem>
+            {fornecedoresDisponiveis.map((f) => (
+              <SelectItem key={f} value={f}>{f}</SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Select value={filtroGrupo} onValueChange={(v) => { setFiltroGrupo(v); setPage(0); }}>
+          <SelectTrigger>
+            <SelectValue placeholder="Grupo" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={ALL}>Todos os grupos</SelectItem>
+            <SelectItem value={SEM_GRUPO}>Sem grupo</SelectItem>
+            {grupos.map((g) => (
+              <SelectItem key={g.id} value={g.grupo_codigo}>
+                {g.grupo_codigo} ({g.fornecedor_nome})
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <div className="md:col-span-2 relative">
+          <Search className="h-4 w-4 absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            placeholder="Buscar por SKU ou descrição…"
+            className="pl-9"
+            value={busca}
+            onChange={(e) => { setBusca(e.target.value); setPage(0); }}
+          />
+        </div>
+      </div>
+
+      {/* Ação em lote */}
+      {selecionadosCount > 0 && (
+        <div className="flex items-center gap-3 rounded-md border bg-muted/40 p-3">
+          <span className="text-sm font-medium">{selecionadosCount} selecionado(s)</span>
+          <Select value={bulkGrupo} onValueChange={setBulkGrupo}>
+            <SelectTrigger className="max-w-xs">
+              <SelectValue placeholder="Mover para grupo…" />
+            </SelectTrigger>
+            <SelectContent>
+              {grupos.map((g) => (
+                <SelectItem key={g.id} value={g.grupo_codigo}>
+                  {g.grupo_codigo} — {g.fornecedor_nome}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Button
+            size="sm"
+            onClick={onAplicarLote}
+            disabled={!bulkGrupo || moverLotePending}
+          >
+            {moverLotePending && <Loader2 className="h-4 w-4 animate-spin" />}
+            Aplicar
+          </Button>
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={onLimparSelecao}
+          >
+            Cancelar
+          </Button>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/reposicao/gruposProducao/SkuTable.tsx
+++ b/src/components/reposicao/gruposProducao/SkuTable.tsx
@@ -1,0 +1,131 @@
+// Tabela de associação SKU→Grupo + paginação.
+// Extraída de src/pages/AdminReposicaoGruposProducao.tsx (god-component split).
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Loader2 } from "lucide-react";
+import { PAGE_SIZE, SEM_GRUPO, type Grupo, type SkuRow } from "./types";
+
+export function SkuTable({
+  skus, loadingSkus, selecionados, toggleSel, toggleAll, gruposParaSku,
+  onMoverSku, moverSkuPending, page, setPage, totalSkus,
+}: {
+  skus: SkuRow[];
+  loadingSkus: boolean;
+  selecionados: Set<string>;
+  toggleSel: (sku: number) => void;
+  toggleAll: () => void;
+  gruposParaSku: (fornecedor: string | null) => Grupo[];
+  onMoverSku: (sku: number, novoGrupo: string | null) => void;
+  moverSkuPending: boolean;
+  page: number;
+  setPage: (value: number | ((prev: number) => number)) => void;
+  totalSkus: number;
+}) {
+  return (
+    <>
+      {/* Tabela SKUs */}
+      <div className="overflow-x-auto">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="w-[40px]">
+                <Checkbox
+                  checked={skus.length > 0 && selecionados.size === skus.length}
+                  onCheckedChange={toggleAll}
+                />
+              </TableHead>
+              <TableHead>SKU</TableHead>
+              <TableHead>Descrição</TableHead>
+              <TableHead>Fornecedor</TableHead>
+              <TableHead className="w-[260px]">Grupo</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {loadingSkus && (
+              <TableRow>
+                <TableCell colSpan={5} className="text-center py-8 text-muted-foreground">
+                  <Loader2 className="h-4 w-4 animate-spin inline mr-2" /> Carregando…
+                </TableCell>
+              </TableRow>
+            )}
+            {!loadingSkus && skus.length === 0 && (
+              <TableRow>
+                <TableCell colSpan={5} className="text-center py-8 text-muted-foreground">
+                  Nenhum SKU encontrado.
+                </TableCell>
+              </TableRow>
+            )}
+            {!loadingSkus && skus.map((r) => {
+              const opts = gruposParaSku(r.fornecedor_nome);
+              const k = String(r.sku_codigo_omie);
+              return (
+                <TableRow key={k}>
+                  <TableCell>
+                    <Checkbox
+                      checked={selecionados.has(k)}
+                      onCheckedChange={() => toggleSel(r.sku_codigo_omie)}
+                    />
+                  </TableCell>
+                  <TableCell className="font-mono text-xs">{r.sku_codigo_omie}</TableCell>
+                  <TableCell className="max-w-[320px] truncate">{r.sku_descricao || "—"}</TableCell>
+                  <TableCell className="text-xs text-muted-foreground">
+                    {r.fornecedor_nome || "—"}
+                  </TableCell>
+                  <TableCell>
+                    <Select
+                      value={r.grupo_codigo || SEM_GRUPO}
+                      onValueChange={(v) =>
+                        onMoverSku(r.sku_codigo_omie, v === SEM_GRUPO ? null : v)
+                      }
+                      disabled={opts.length === 0 || moverSkuPending}
+                    >
+                      <SelectTrigger className="h-8 text-xs">
+                        <SelectValue placeholder={opts.length === 0 ? "Sem grupos do fornecedor" : "Selecionar…"} />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value={SEM_GRUPO}>— Sem grupo —</SelectItem>
+                        {opts.map((g) => (
+                          <SelectItem key={g.id} value={g.grupo_codigo}>
+                            {g.grupo_codigo} ({g.lt_producao_dias}d)
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      </div>
+
+      {/* Paginação */}
+      <div className="flex items-center justify-between text-sm text-muted-foreground">
+        <span>
+          Mostrando {skus.length} de {totalSkus} SKUs
+        </span>
+        <div className="flex items-center gap-2">
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={page === 0}
+            onClick={() => setPage((p) => Math.max(0, p - 1))}
+          >
+            Anterior
+          </Button>
+          <span>Página {page + 1}</span>
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={(page + 1) * PAGE_SIZE >= totalSkus}
+            onClick={() => setPage((p) => p + 1)}
+          >
+            Próxima
+          </Button>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/components/reposicao/gruposProducao/__tests__/GrupoDialog.test.tsx
+++ b/src/components/reposicao/gruposProducao/__tests__/GrupoDialog.test.tsx
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { GrupoDialog } from "../GrupoDialog";
+import { emptyGrupo, type Grupo } from "../types";
+
+function noop() { /* */ }
+
+describe("GrupoDialog", () => {
+  it("fechado (editing=null) → não renderiza", () => {
+    render(<GrupoDialog editing={null} setEditing={noop} isNew={false} onSalvar={noop} salvarPending={false} />);
+    expect(screen.queryByText("Novo grupo")).toBeNull();
+    expect(screen.queryByText("Editar grupo")).toBeNull();
+  });
+
+  it("novo (isNew) → título Novo grupo e campos", () => {
+    render(<GrupoDialog editing={emptyGrupo()} setEditing={noop} isNew onSalvar={noop} salvarPending={false} />);
+    expect(screen.getByText("Novo grupo")).toBeTruthy();
+    expect(screen.getByText("Fornecedor *")).toBeTruthy();
+    expect(screen.getByText("Código do grupo *")).toBeTruthy();
+  });
+
+  it("editar → título Editar grupo; Salvar dispara onSalvar com o grupo", () => {
+    const onSalvar = vi.fn();
+    const g: Partial<Grupo> = { ...emptyGrupo(), id: 9, fornecedor_nome: "ACME", grupo_codigo: "g1" };
+    render(<GrupoDialog editing={g} setEditing={noop} isNew={false} onSalvar={onSalvar} salvarPending={false} />);
+    expect(screen.getByText("Editar grupo")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: /Salvar/ }));
+    expect(onSalvar).toHaveBeenCalledWith(g);
+  });
+});

--- a/src/components/reposicao/gruposProducao/__tests__/GruposTable.test.tsx
+++ b/src/components/reposicao/gruposProducao/__tests__/GruposTable.test.tsx
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { GruposTable } from "../GruposTable";
+import type { Grupo } from "../types";
+
+const grupo: Grupo = {
+  id: 1, empresa: "OBEN", fornecedor_nome: "ACME", grupo_codigo: "g_rapido",
+  descricao: "Rápido", lt_producao_dias: 5, lt_producao_unidade: "uteis",
+  horario_corte: "14:00:00", observacoes: null,
+};
+
+function noop() { /* */ }
+
+describe("GruposTable", () => {
+  it("loading → Carregando…", () => {
+    render(<GruposTable grupos={[]} loading contagensSku={{}} onEdit={noop} />);
+    expect(screen.getByText("Carregando…")).toBeTruthy();
+  });
+
+  it("vazio → mensagem", () => {
+    render(<GruposTable grupos={[]} loading={false} contagensSku={{}} onEdit={noop} />);
+    expect(screen.getByText("Nenhum grupo cadastrado.")).toBeTruthy();
+  });
+
+  it("com grupo → dados, contagem de SKUs e edição dispara onEdit", () => {
+    const onEdit = vi.fn();
+    render(<GruposTable grupos={[grupo]} loading={false} contagensSku={{ g_rapido: 7 }} onEdit={onEdit} />);
+    expect(screen.getByText("ACME")).toBeTruthy();
+    expect(screen.getByText("g_rapido")).toBeTruthy();
+    expect(screen.getByText("Rápido")).toBeTruthy();
+    expect(screen.getByText("7")).toBeTruthy();
+    expect(screen.getByText("14:00")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button"));
+    expect(onEdit).toHaveBeenCalledWith(grupo);
+  });
+});

--- a/src/components/reposicao/gruposProducao/__tests__/SkuFilters.test.tsx
+++ b/src/components/reposicao/gruposProducao/__tests__/SkuFilters.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { SkuFilters } from "../SkuFilters";
+import type { Grupo } from "../types";
+
+const grupo: Grupo = {
+  id: 1, empresa: "OBEN", fornecedor_nome: "ACME", grupo_codigo: "g_rapido",
+  descricao: null, lt_producao_dias: 5, lt_producao_unidade: "uteis",
+  horario_corte: null, observacoes: null,
+};
+
+function noop() { /* */ }
+
+function baseProps(over: Partial<React.ComponentProps<typeof SkuFilters>> = {}): React.ComponentProps<typeof SkuFilters> {
+  return {
+    filtroFornecedor: "__all__",
+    setFiltroFornecedor: noop,
+    filtroGrupo: "__all__",
+    setFiltroGrupo: noop,
+    busca: "",
+    setBusca: noop,
+    setPage: noop,
+    fornecedoresDisponiveis: ["ACME"],
+    grupos: [grupo],
+    selecionadosCount: 0,
+    bulkGrupo: "",
+    setBulkGrupo: noop,
+    onAplicarLote: noop,
+    onLimparSelecao: noop,
+    moverLotePending: false,
+    ...over,
+  };
+}
+
+describe("SkuFilters", () => {
+  it("renderiza busca; sem barra de lote quando count=0", () => {
+    render(<SkuFilters {...baseProps()} />);
+    expect(screen.getByPlaceholderText(/Buscar por SKU/)).toBeTruthy();
+    expect(screen.queryByText(/selecionado\(s\)/)).toBeNull();
+  });
+
+  it("digitar busca chama setBusca e reseta page", () => {
+    const setBusca = vi.fn();
+    const setPage = vi.fn();
+    render(<SkuFilters {...baseProps({ setBusca, setPage })} />);
+    fireEvent.change(screen.getByPlaceholderText(/Buscar por SKU/), { target: { value: "999" } });
+    expect(setBusca).toHaveBeenCalledWith("999");
+    expect(setPage).toHaveBeenCalledWith(0);
+  });
+
+  it("barra de lote com count>0 → Aplicar/Cancelar disparam callbacks", () => {
+    const onAplicarLote = vi.fn();
+    const onLimparSelecao = vi.fn();
+    render(<SkuFilters {...baseProps({ selecionadosCount: 3, bulkGrupo: "g_rapido", onAplicarLote, onLimparSelecao })} />);
+    expect(screen.getByText("3 selecionado(s)")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: /Aplicar/ }));
+    expect(onAplicarLote).toHaveBeenCalled();
+    fireEvent.click(screen.getByRole("button", { name: /Cancelar/ }));
+    expect(onLimparSelecao).toHaveBeenCalled();
+  });
+});

--- a/src/components/reposicao/gruposProducao/__tests__/SkuTable.test.tsx
+++ b/src/components/reposicao/gruposProducao/__tests__/SkuTable.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { SkuTable } from "../SkuTable";
+import type { SkuRow } from "../types";
+
+const sku: SkuRow = {
+  empresa: "OBEN", sku_codigo_omie: 999, sku_descricao: "Produto X",
+  fornecedor_nome: "ACME", grupo_codigo: null,
+};
+
+function noop() { /* */ }
+
+function baseProps(over: Partial<React.ComponentProps<typeof SkuTable>> = {}): React.ComponentProps<typeof SkuTable> {
+  return {
+    skus: [sku],
+    loadingSkus: false,
+    selecionados: new Set<string>(),
+    toggleSel: noop,
+    toggleAll: noop,
+    gruposParaSku: () => [],
+    onMoverSku: noop,
+    moverSkuPending: false,
+    page: 0,
+    setPage: noop,
+    totalSkus: 1,
+    ...over,
+  };
+}
+
+describe("SkuTable", () => {
+  it("loading → Carregando…", () => {
+    render(<SkuTable {...baseProps({ skus: [], loadingSkus: true })} />);
+    expect(screen.getByText("Carregando…")).toBeTruthy();
+  });
+
+  it("vazio → Nenhum SKU encontrado", () => {
+    render(<SkuTable {...baseProps({ skus: [], totalSkus: 0 })} />);
+    expect(screen.getByText("Nenhum SKU encontrado.")).toBeTruthy();
+  });
+
+  it("com SKU → código, descrição e contador de paginação; Anterior desabilitado na página 0", () => {
+    render(<SkuTable {...baseProps()} />);
+    expect(screen.getByText("999")).toBeTruthy();
+    expect(screen.getByText("Produto X")).toBeTruthy();
+    expect(screen.getByText("Mostrando 1 de 1 SKUs")).toBeTruthy();
+    expect((screen.getByRole("button", { name: "Anterior" }) as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("clique no checkbox da linha chama toggleSel", () => {
+    const toggleSel = vi.fn();
+    render(<SkuTable {...baseProps({ toggleSel })} />);
+    // checkbox[0] = header (toggleAll), [1] = linha
+    fireEvent.click(screen.getAllByRole("checkbox")[1]);
+    expect(toggleSel).toHaveBeenCalledWith(999);
+  });
+});

--- a/src/components/reposicao/gruposProducao/types.ts
+++ b/src/components/reposicao/gruposProducao/types.ts
@@ -1,0 +1,50 @@
+// Constantes, tipos e helpers dos Grupos de Produção (AdminReposicaoGruposProducao).
+// Extraídos de src/pages/AdminReposicaoGruposProducao.tsx (god-component split).
+
+export const EMPRESA = "OBEN";
+export const ALL = "__all__";
+export const SEM_GRUPO = "__sem_grupo__";
+export const PAGE_SIZE = 50;
+
+export type Grupo = {
+  id: number;
+  empresa: string;
+  fornecedor_nome: string;
+  grupo_codigo: string;
+  descricao: string | null;
+  lt_producao_dias: number;
+  lt_producao_unidade: string;
+  horario_corte: string | null;
+  observacoes: string | null;
+};
+
+export type SkuRow = {
+  empresa: string;
+  sku_codigo_omie: number;
+  sku_descricao: string | null;
+  fornecedor_nome: string | null;
+  grupo_codigo: string | null;
+};
+
+export type SkuGrupoRow = {
+  sku_codigo_omie: string | number;
+  grupo_codigo: string;
+};
+
+export type SkuParametroRow = {
+  empresa: string;
+  sku_codigo_omie: string | number;
+  sku_descricao: string | null;
+  fornecedor_nome: string | null;
+};
+
+export const emptyGrupo = (): Partial<Grupo> => ({
+  empresa: EMPRESA,
+  fornecedor_nome: "",
+  grupo_codigo: "",
+  descricao: "",
+  lt_producao_dias: 5,
+  lt_producao_unidade: "uteis",
+  horario_corte: null,
+  observacoes: "",
+});

--- a/src/pages/AdminReposicaoGruposProducao.tsx
+++ b/src/pages/AdminReposicaoGruposProducao.tsx
@@ -2,85 +2,17 @@ import { useState, useMemo } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
 import { toast } from "sonner";
-import { Plus, Pencil, Search, Loader2, Factory } from "lucide-react";
+import { Plus, Factory } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
-import { Checkbox } from "@/components/ui/checkbox";
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import { Input } from "@/components/ui/input";
-import { Textarea } from "@/components/ui/textarea";
-import { Label } from "@/components/ui/label";
-import {
-  Dialog,
-  DialogContent,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-  DialogDescription,
-} from "@/components/ui/dialog";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
-
-const EMPRESA = "OBEN";
-const ALL = "__all__";
-const SEM_GRUPO = "__sem_grupo__";
-const PAGE_SIZE = 50;
-
-type Grupo = {
-  id: number;
-  empresa: string;
-  fornecedor_nome: string;
-  grupo_codigo: string;
-  descricao: string | null;
-  lt_producao_dias: number;
-  lt_producao_unidade: string;
-  horario_corte: string | null;
-  observacoes: string | null;
-};
-
-type SkuRow = {
-  empresa: string;
-  sku_codigo_omie: number;
-  sku_descricao: string | null;
-  fornecedor_nome: string | null;
-  grupo_codigo: string | null;
-};
-
-type SkuGrupoRow = {
-  sku_codigo_omie: string | number;
-  grupo_codigo: string;
-};
-
-type SkuParametroRow = {
-  empresa: string;
-  sku_codigo_omie: string | number;
-  sku_descricao: string | null;
-  fornecedor_nome: string | null;
-};
-
-const emptyGrupo = (): Partial<Grupo> => ({
-  empresa: EMPRESA,
-  fornecedor_nome: "",
-  grupo_codigo: "",
-  descricao: "",
-  lt_producao_dias: 5,
-  lt_producao_unidade: "uteis",
-  horario_corte: null,
-  observacoes: "",
-});
+  EMPRESA, ALL, SEM_GRUPO, PAGE_SIZE, emptyGrupo,
+  type Grupo, type SkuRow, type SkuGrupoRow, type SkuParametroRow,
+} from "@/components/reposicao/gruposProducao/types";
+import { GruposTable } from "@/components/reposicao/gruposProducao/GruposTable";
+import { SkuFilters } from "@/components/reposicao/gruposProducao/SkuFilters";
+import { SkuTable } from "@/components/reposicao/gruposProducao/SkuTable";
+import { GrupoDialog } from "@/components/reposicao/gruposProducao/GrupoDialog";
 
 export default function AdminReposicaoGruposProducao() {
   const qc = useQueryClient();
@@ -358,71 +290,12 @@ export default function AdminReposicaoGruposProducao() {
           </Button>
         </CardHeader>
         <CardContent>
-          {loadingGrupos ? (
-            <div className="flex items-center gap-2 text-sm text-muted-foreground">
-              <Loader2 className="h-4 w-4 animate-spin" /> Carregando…
-            </div>
-          ) : (
-            <div className="overflow-x-auto">
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>Fornecedor</TableHead>
-                    <TableHead>Código</TableHead>
-                    <TableHead>Descrição</TableHead>
-                    <TableHead className="text-right">LT (dias)</TableHead>
-                    <TableHead>Unidade</TableHead>
-                    <TableHead>Corte</TableHead>
-                    <TableHead className="text-right">SKUs</TableHead>
-                    <TableHead className="w-[80px]"></TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {grupos.length === 0 && (
-                    <TableRow>
-                      <TableCell colSpan={8} className="text-center text-muted-foreground py-8">
-                        Nenhum grupo cadastrado.
-                      </TableCell>
-                    </TableRow>
-                  )}
-                  {grupos.map((g) => (
-                    <TableRow key={g.id}>
-                      <TableCell className="font-medium">{g.fornecedor_nome}</TableCell>
-                      <TableCell>
-                        <Badge variant="outline">{g.grupo_codigo}</Badge>
-                      </TableCell>
-                      <TableCell className="text-muted-foreground">
-                        {g.descricao || "—"}
-                      </TableCell>
-                      <TableCell className="text-right tabular-nums">
-                        {g.lt_producao_dias}
-                      </TableCell>
-                      <TableCell>
-                        <Badge variant="secondary" className="text-xs">
-                          {g.lt_producao_unidade === "uteis" ? "úteis" : "corridos"}
-                        </Badge>
-                      </TableCell>
-                      <TableCell className="text-muted-foreground">
-                        {g.horario_corte ? g.horario_corte.slice(0, 5) : "—"}
-                      </TableCell>
-                      <TableCell className="text-right tabular-nums font-medium">
-                        {contagensSku[g.grupo_codigo] || 0}
-                      </TableCell>
-                      <TableCell>
-                        <Button
-                          size="sm"
-                          variant="ghost"
-                          onClick={() => setEditing(g)}
-                        >
-                          <Pencil className="h-3.5 w-3.5" />
-                        </Button>
-                      </TableCell>
-                    </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
-            </div>
-          )}
+          <GruposTable
+            grupos={grupos}
+            loading={loadingGrupos}
+            contagensSku={contagensSku}
+            onEdit={setEditing}
+          />
         </CardContent>
       </Card>
 
@@ -432,279 +305,48 @@ export default function AdminReposicaoGruposProducao() {
           <CardTitle className="text-base">Associação SKU → Grupo</CardTitle>
         </CardHeader>
         <CardContent className="space-y-4">
-          {/* Filtros */}
-          <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-            <Select value={filtroFornecedor} onValueChange={(v) => { setFiltroFornecedor(v); setPage(0); }}>
-              <SelectTrigger>
-                <SelectValue placeholder="Fornecedor" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value={ALL}>Todos os fornecedores</SelectItem>
-                {fornecedoresDisponiveis.map((f) => (
-                  <SelectItem key={f} value={f}>{f}</SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-            <Select value={filtroGrupo} onValueChange={(v) => { setFiltroGrupo(v); setPage(0); }}>
-              <SelectTrigger>
-                <SelectValue placeholder="Grupo" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value={ALL}>Todos os grupos</SelectItem>
-                <SelectItem value={SEM_GRUPO}>Sem grupo</SelectItem>
-                {grupos.map((g) => (
-                  <SelectItem key={g.id} value={g.grupo_codigo}>
-                    {g.grupo_codigo} ({g.fornecedor_nome})
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-            <div className="md:col-span-2 relative">
-              <Search className="h-4 w-4 absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground" />
-              <Input
-                placeholder="Buscar por SKU ou descrição…"
-                className="pl-9"
-                value={busca}
-                onChange={(e) => { setBusca(e.target.value); setPage(0); }}
-              />
-            </div>
-          </div>
+          <SkuFilters
+            filtroFornecedor={filtroFornecedor}
+            setFiltroFornecedor={setFiltroFornecedor}
+            filtroGrupo={filtroGrupo}
+            setFiltroGrupo={setFiltroGrupo}
+            busca={busca}
+            setBusca={setBusca}
+            setPage={setPage}
+            fornecedoresDisponiveis={fornecedoresDisponiveis}
+            grupos={grupos}
+            selecionadosCount={selecionados.size}
+            bulkGrupo={bulkGrupo}
+            setBulkGrupo={setBulkGrupo}
+            onAplicarLote={aplicarLote}
+            onLimparSelecao={() => { setSelecionados(new Set()); setBulkGrupo(""); }}
+            moverLotePending={moverLote.isPending}
+          />
 
-          {/* Ação em lote */}
-          {selecionados.size > 0 && (
-            <div className="flex items-center gap-3 rounded-md border bg-muted/40 p-3">
-              <span className="text-sm font-medium">{selecionados.size} selecionado(s)</span>
-              <Select value={bulkGrupo} onValueChange={setBulkGrupo}>
-                <SelectTrigger className="max-w-xs">
-                  <SelectValue placeholder="Mover para grupo…" />
-                </SelectTrigger>
-                <SelectContent>
-                  {grupos.map((g) => (
-                    <SelectItem key={g.id} value={g.grupo_codigo}>
-                      {g.grupo_codigo} — {g.fornecedor_nome}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-              <Button
-                size="sm"
-                onClick={aplicarLote}
-                disabled={!bulkGrupo || moverLote.isPending}
-              >
-                {moverLote.isPending && <Loader2 className="h-4 w-4 animate-spin" />}
-                Aplicar
-              </Button>
-              <Button
-                size="sm"
-                variant="ghost"
-                onClick={() => { setSelecionados(new Set()); setBulkGrupo(""); }}
-              >
-                Cancelar
-              </Button>
-            </div>
-          )}
-
-          {/* Tabela SKUs */}
-          <div className="overflow-x-auto">
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead className="w-[40px]">
-                    <Checkbox
-                      checked={skus.length > 0 && selecionados.size === skus.length}
-                      onCheckedChange={toggleAll}
-                    />
-                  </TableHead>
-                  <TableHead>SKU</TableHead>
-                  <TableHead>Descrição</TableHead>
-                  <TableHead>Fornecedor</TableHead>
-                  <TableHead className="w-[260px]">Grupo</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {loadingSkus && (
-                  <TableRow>
-                    <TableCell colSpan={5} className="text-center py-8 text-muted-foreground">
-                      <Loader2 className="h-4 w-4 animate-spin inline mr-2" /> Carregando…
-                    </TableCell>
-                  </TableRow>
-                )}
-                {!loadingSkus && skus.length === 0 && (
-                  <TableRow>
-                    <TableCell colSpan={5} className="text-center py-8 text-muted-foreground">
-                      Nenhum SKU encontrado.
-                    </TableCell>
-                  </TableRow>
-                )}
-                {!loadingSkus && skus.map((r) => {
-                  const opts = gruposParaSku(r.fornecedor_nome);
-                  const k = String(r.sku_codigo_omie);
-                  return (
-                    <TableRow key={k}>
-                      <TableCell>
-                        <Checkbox
-                          checked={selecionados.has(k)}
-                          onCheckedChange={() => toggleSel(r.sku_codigo_omie)}
-                        />
-                      </TableCell>
-                      <TableCell className="font-mono text-xs">{r.sku_codigo_omie}</TableCell>
-                      <TableCell className="max-w-[320px] truncate">{r.sku_descricao || "—"}</TableCell>
-                      <TableCell className="text-xs text-muted-foreground">
-                        {r.fornecedor_nome || "—"}
-                      </TableCell>
-                      <TableCell>
-                        <Select
-                          value={r.grupo_codigo || SEM_GRUPO}
-                          onValueChange={(v) =>
-                            moverSku.mutate({
-                              sku: r.sku_codigo_omie,
-                              novoGrupo: v === SEM_GRUPO ? null : v,
-                            })
-                          }
-                          disabled={opts.length === 0 || moverSku.isPending}
-                        >
-                          <SelectTrigger className="h-8 text-xs">
-                            <SelectValue placeholder={opts.length === 0 ? "Sem grupos do fornecedor" : "Selecionar…"} />
-                          </SelectTrigger>
-                          <SelectContent>
-                            <SelectItem value={SEM_GRUPO}>— Sem grupo —</SelectItem>
-                            {opts.map((g) => (
-                              <SelectItem key={g.id} value={g.grupo_codigo}>
-                                {g.grupo_codigo} ({g.lt_producao_dias}d)
-                              </SelectItem>
-                            ))}
-                          </SelectContent>
-                        </Select>
-                      </TableCell>
-                    </TableRow>
-                  );
-                })}
-              </TableBody>
-            </Table>
-          </div>
-
-          {/* Paginação */}
-          <div className="flex items-center justify-between text-sm text-muted-foreground">
-            <span>
-              Mostrando {skus.length} de {totalSkus} SKUs
-            </span>
-            <div className="flex items-center gap-2">
-              <Button
-                size="sm"
-                variant="outline"
-                disabled={page === 0}
-                onClick={() => setPage((p) => Math.max(0, p - 1))}
-              >
-                Anterior
-              </Button>
-              <span>Página {page + 1}</span>
-              <Button
-                size="sm"
-                variant="outline"
-                disabled={(page + 1) * PAGE_SIZE >= totalSkus}
-                onClick={() => setPage((p) => p + 1)}
-              >
-                Próxima
-              </Button>
-            </div>
-          </div>
+          <SkuTable
+            skus={skus}
+            loadingSkus={loadingSkus}
+            selecionados={selecionados}
+            toggleSel={toggleSel}
+            toggleAll={toggleAll}
+            gruposParaSku={gruposParaSku}
+            onMoverSku={(sku, novoGrupo) => moverSku.mutate({ sku, novoGrupo })}
+            moverSkuPending={moverSku.isPending}
+            page={page}
+            setPage={setPage}
+            totalSkus={totalSkus}
+          />
         </CardContent>
       </Card>
 
       {/* MODAL */}
-      <Dialog open={!!editing} onOpenChange={(o) => !o && setEditing(null)}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>{isNew ? "Novo grupo" : "Editar grupo"}</DialogTitle>
-            <DialogDescription>
-              Define o lead time de produção e janela de corte do fornecedor.
-            </DialogDescription>
-          </DialogHeader>
-          {editing && (
-            <div className="space-y-3">
-              <div>
-                <Label>Fornecedor *</Label>
-                <Input
-                  value={editing.fornecedor_nome || ""}
-                  onChange={(e) => setEditing({ ...editing, fornecedor_nome: e.target.value })}
-                  placeholder="Ex.: RENNER SAYERLACK S/A"
-                />
-              </div>
-              <div className="grid grid-cols-2 gap-3">
-                <div>
-                  <Label>Código do grupo *</Label>
-                  <Input
-                    value={editing.grupo_codigo || ""}
-                    onChange={(e) => setEditing({ ...editing, grupo_codigo: e.target.value })}
-                    placeholder="ex.: sayerlack_rapido"
-                  />
-                </div>
-                <div>
-                  <Label>LT produção (dias) *</Label>
-                  <Input
-                    type="number"
-                    min={1}
-                    value={editing.lt_producao_dias ?? 5}
-                    onChange={(e) =>
-                      setEditing({ ...editing, lt_producao_dias: Number(e.target.value) })
-                    }
-                  />
-                </div>
-              </div>
-              <div className="grid grid-cols-2 gap-3">
-                <div>
-                  <Label>Unidade</Label>
-                  <Select
-                    value={editing.lt_producao_unidade || "uteis"}
-                    onValueChange={(v) => setEditing({ ...editing, lt_producao_unidade: v })}
-                  >
-                    <SelectTrigger><SelectValue /></SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="uteis">Dias úteis</SelectItem>
-                      <SelectItem value="corridos">Dias corridos</SelectItem>
-                    </SelectContent>
-                  </Select>
-                </div>
-                <div>
-                  <Label>Horário de corte</Label>
-                  <Input
-                    type="time"
-                    value={editing.horario_corte?.slice(0, 5) || ""}
-                    onChange={(e) =>
-                      setEditing({ ...editing, horario_corte: e.target.value || null })
-                    }
-                  />
-                </div>
-              </div>
-              <div>
-                <Label>Descrição</Label>
-                <Input
-                  value={editing.descricao || ""}
-                  onChange={(e) => setEditing({ ...editing, descricao: e.target.value })}
-                />
-              </div>
-              <div>
-                <Label>Observações</Label>
-                <Textarea
-                  rows={2}
-                  value={editing.observacoes || ""}
-                  onChange={(e) => setEditing({ ...editing, observacoes: e.target.value })}
-                />
-              </div>
-            </div>
-          )}
-          <DialogFooter>
-            <Button variant="outline" onClick={() => setEditing(null)}>Cancelar</Button>
-            <Button
-              onClick={() => editing && salvarGrupo.mutate(editing)}
-              disabled={salvarGrupo.isPending}
-            >
-              {salvarGrupo.isPending && <Loader2 className="h-4 w-4 animate-spin" />}
-              Salvar
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      <GrupoDialog
+        editing={editing}
+        setEditing={setEditing}
+        isNew={isNew}
+        onSalvar={(g) => salvarGrupo.mutate(g)}
+        salvarPending={salvarGrupo.isPending}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Resumo

Quebra do god-component `src/pages/AdminReposicaoGruposProducao.tsx` (gestão de grupos de produção) — **710 → 352 linhas**. Refactor **comportamento-preservante 1:1**, novos módulos em `src/components/reposicao/gruposProducao/`.

- **`types.ts`** — constantes (EMPRESA/ALL/SEM_GRUPO/PAGE_SIZE) + tipos (`Grupo`/`SkuRow`/`SkuGrupoRow`/`SkuParametroRow`) + `emptyGrupo`.
- **`GruposTable.tsx`** — tabela de grupos cadastrados (Seção 1).
- **`SkuFilters.tsx`** — filtros (fornecedor/grupo/busca) + barra de ação em lote.
- **`SkuTable.tsx`** — tabela de associação SKU→grupo + paginação.
- **`GrupoDialog.tsx`** — modal de criação/edição.

### Decisão de arquitetura

As 3 `useQuery` (incluindo o `skusData` com fetch de associações + filtro client-side por grupo), as 3 `useMutation` (salvar/moverSku/moverLote), o `recalcular` (RPC) e os `useMemo`/handlers permanecem **no pai**. Os componentes são presentacionais.

## Garantias

- ✅ `bunx tsc --noEmit` — 0 erros.
- ✅ `bun lint` — 0 problemas nos arquivos tocados.
- ✅ Suíte: **652/652** passando.
- ✅ +13 testes novos (4 arquivos): tabela de grupos, filtros+lote, tabela SKU (checkbox/paginação) e dialog.
- ✅ Revisão independente (subagente): veredito **FIEL 1:1** — `skusData` (`.or` da busca, assocMap, filtro client-side), `salvarGrupo`/`moverSku`/`moverLote` (onConflict) e `recalcular` byte-a-byte.

## Test plan

- [x] tsc 0 erros / lint 0 problemas
- [x] 13 testes novos + suíte completa 652/652
- [x] revisão independente confirma 1:1
- [ ] CI `validate` verde (inclui build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)