### PR TITLE
chore(ts-strict): promove 12 pages leaf a strict (lote 1)

### DIFF
--- a/docs/strict-migration-lanes.md
+++ b/docs/strict-migration-lanes.md
@@ -59,10 +59,14 @@ subgrafos sujos (`noUnusedLocals`/`strictNullChecks`) → cascata. **Promova lea
 - **Reposição**: god-components sendo decompostos.
 
 ### Reservas ativas (🔵 = em voo)
-- 🔵 **`feat/strict-promote-contexts`** (sessão determined-allen, 2026-05-23): fatia foundational —
+- ✅ **`feat/strict-promote-contexts`** (sessão determined-allen, 2026-05-23): fatia foundational —
   `contexts/{AuthContext,CompanyContext,ConditionalWebRTCProvider,WebRTCCallContext}` + `services/omieService`.
-  **NÃO toco** `services/financeiroService` nem `financeiroV2Service` (colidem com `feat/financeiro-a2-impl` em voo).
-  Pages virá em fatia/branch separada depois (leaf-first). Append-only no `include`.
+  **MERGEADA** (#220). `services/financeiroService`/`financeiroV2Service` ficaram fora (colidem com `feat/financeiro-a2-impl`).
+- 🔵 **`feat/strict-promote-pages`** (sessão determined-allen, 2026-05-23): fatia pages leaf-first.
+  Promovo pages pequenas cujas deps já estão no programa strict (MeuDia, AdminCalculadora, NotFound,
+  AdminReposicaoSessao*, AdminDesTrimestreAtual e demais leaf por lotes empíricos; lote 2 em
+  `feat/strict-promote-pages-fixes` com fixes triviais de dead-code). **NÃO toco** pages
+  reservadas por outras sessões nem `services/financeiro*`. Append-only no `include`.
 - 🔵 **`feat/strict-promote-lib-leaf`** (sessão cranky-driscoll, 2026-05-23): lote leaf não-farmer —
   `lib/call-session/aggregate-customer-profile`, `lib/sip/sip-client`, `lib/transcription/{deepgram-client,transcription-engine}`,
   `components/customer360/format`, `components/financeiro/dashboard/format`, `components/portalSayerlack/types`,

--- a/tsconfig.strict.json
+++ b/tsconfig.strict.json
@@ -462,6 +462,18 @@
     "src/contexts/CompanyContext.tsx",
     "src/contexts/AuthContext.tsx",
     "src/contexts/ConditionalWebRTCProvider.tsx",
-    "src/services/omieService.ts"
+    "src/services/omieService.ts",
+    "src/pages/MeuDia.tsx",
+    "src/pages/AdminCalculadora.tsx",
+    "src/pages/NotFound.tsx",
+    "src/pages/AdminReposicaoSessaoAplicacao.tsx",
+    "src/pages/AdminDesTrimestreAtual.tsx",
+    "src/pages/AdminReposicaoSessaoHistorico.tsx",
+    "src/pages/AdminReposicaoSessaoConfirmacao.tsx",
+    "src/pages/AdminStandardProcesses.tsx",
+    "src/pages/FinanceiroCapitalGiro.tsx",
+    "src/pages/AdminKnowledgeBase.tsx",
+    "src/pages/TintCorantes.tsx",
+    "src/pages/FinanceiroAnalise.tsx"
   ]
 }


### PR DESCRIPTION
## Resumo

Lote 1 da fatia de pages leaf-first (fase de PROMOÇÃO da migração TypeScript strict). Adiciona 12 pages ao `include` do `tsconfig.strict.json`:

`MeuDia`, `AdminCalculadora`, `NotFound`, `AdminReposicaoSessaoAplicacao`, `AdminReposicaoSessaoHistorico`, `AdminReposicaoSessaoConfirmacao`, `AdminDesTrimestreAtual`, `AdminStandardProcesses`, `FinanceiroCapitalGiro`, `AdminKnowledgeBase`, `TintCorantes`, `FinanceiroAnalise`.

**Promoção tsconfig-only** — todas têm grafo transitivo já strict-clean. Zero edição de source.

Um batch inicial maior (18 pages) foi triado pelo gate: 6 pages "tainted" (`Index`, `IntelligenceDashboard`, `Telefonia`, `AdminOrderDetail`, `AdminReposicaoSessaoPedidos`, `AdminStandardProcessNew`) foram removidas porque puxam deps com erros strict (unused imports / typing de zodResolver / null-check). Elas virão num lote de fixes separado.

Reserva registrada em `docs/strict-migration-lanes.md` (slice `feat/strict-promote-pages`).

## Gate

- `bun run typecheck:strict` → exit 0 (TSC_EXIT=0, sem erros).

## Test plan

- [x] `typecheck:strict` verde localmente
- [ ] CI `validate` verde