### PR TITLE
test(print): hardening anti-flake no PrintFilters (findByText)

### DIFF
--- a/src/components/sales/print/__tests__/PrintFilters.test.tsx
+++ b/src/components/sales/print/__tests__/PrintFilters.test.tsx
@@ -5,7 +5,10 @@ import { PrintFilters } from '../PrintFilters';
 function noop() { /* */ }
 
 describe('PrintFilters', () => {
-  it('renderiza tabs de período e badges das empresas', () => {
+  // findByText (re-tenta ~1s) em vez de getByText (consulta imediata): tolera
+  // atraso de render/commit do React 18 sob carga paralela do suite completo —
+  // mitiga flake raro (~5%) observado só no `bun run test` inteiro.
+  it('renderiza tabs de período e badges das empresas', async () => {
     render(
       <PrintFilters
         selectedDate={new Date('2026-01-15T12:00:00')}
@@ -16,15 +19,15 @@ describe('PrintFilters', () => {
         toggleCompany={noop}
       />
     );
-    expect(screen.getByText('Todos')).toBeTruthy();
-    expect(screen.getByText('Manhã')).toBeTruthy();
-    expect(screen.getByText('Tarde')).toBeTruthy();
-    expect(screen.getByText('Oben')).toBeTruthy();
-    expect(screen.getByText('Colacor')).toBeTruthy();
-    expect(screen.getByText('Afiação')).toBeTruthy();
+    expect(await screen.findByText('Todos')).toBeTruthy();
+    expect(await screen.findByText('Manhã')).toBeTruthy();
+    expect(await screen.findByText('Tarde')).toBeTruthy();
+    expect(await screen.findByText('Oben')).toBeTruthy();
+    expect(await screen.findByText('Colacor')).toBeTruthy();
+    expect(await screen.findByText('Afiação')).toBeTruthy();
   });
 
-  it('clicar no badge de empresa chama toggleCompany', () => {
+  it('clicar no badge de empresa chama toggleCompany', async () => {
     const toggleCompany = vi.fn();
     render(
       <PrintFilters
@@ -36,7 +39,7 @@ describe('PrintFilters', () => {
         toggleCompany={toggleCompany}
       />
     );
-    fireEvent.click(screen.getByText('Colacor'));
+    fireEvent.click(await screen.findByText('Colacor'));
     expect(toggleCompany).toHaveBeenCalledWith('colacor');
   });
 });


### PR DESCRIPTION
## Summary
Hardening de resiliência contra um flake raro no `PrintFilters.test.tsx`, achado durante a verificação do flake WebRTC (#185).

## Investigação
- O flake apareceu **1 vez em ~21 runs do suite completo (~5%)**, só sob carga paralela do `bun run test` inteiro.
- `PrintFilters.test.tsx` passa **10/10 isolado** e **8/8 com `--no-isolate` + os testes suspeitos** juntos.
- Hipótese inicial (testes que stubam `ResizeObserver` sem cleanup) foi **refutada** pelo no-isolate.
- Não consegui capturar a mensagem de erro exata em 21 runs (`isolate:true` re-aplica o setup por arquivo, descartando poluição cross-file determinística).

## Mitigação
Troca `getByText` (consulta síncrona imediata) por `await findByText` (re-tenta ~1s) nos 2 testes. Isso tolera qualquer atraso de render/commit do React 18 sob contenção de CPU no suite completo. Se o elemento já está presente, resolve imediatamente — **nunca piora**.

**Transparência:** é hardening de resiliência, não fix de causa-raiz confirmada (o erro exato não foi capturável na frequência observada). Padrão recomendado do Testing Library pra flakes de timing de render.

## Validação
- `bunx eslint` ✅ 0
- Teste modificado: **10/10 isolado** pós-mudança
- **Codex review**: *"test change itself looks safe"*

## Test plan
- [ ] CI verde; observar se o flake do PrintFilters some das próximas rodadas do suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)