### PR TITLE
chore(ts-strict): promove 4 pages a strict (lote 2 — fixes leaf)

### DIFF
--- a/src/components/CustomerDashboard.tsx
+++ b/src/components/CustomerDashboard.tsx
@@ -2,9 +2,9 @@ import { useNavigate } from 'react-router-dom';
 import { useEffect, useState } from 'react';
 import { Card, CardContent } from '@/components/ui/card';
 import { Progress } from '@/components/ui/progress';
-import { motion, AnimatePresence } from 'framer-motion';
+import { motion } from 'framer-motion';
 import {
-  PlusCircle, ClipboardList, ChevronRight, Wrench, Calendar, User,
+  PlusCircle, ChevronRight, Wrench, User,
   ArrowRight, TrendingUp, Package, Trophy, Gamepad2,
   Sparkles, AlertTriangle, Award, CheckCircle2, MapPin,
   LifeBuoy, FileText

--- a/src/components/intelligence/IntelligenceManagerialTab.tsx
+++ b/src/components/intelligence/IntelligenceManagerialTab.tsx
@@ -1,4 +1,4 @@
-import React, { memo } from 'react';
+import { memo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';

--- a/src/components/intelligence/IntelligenceOperationalTab.tsx
+++ b/src/components/intelligence/IntelligenceOperationalTab.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';

--- a/src/components/intelligence/IntelligenceStrategicTab.tsx
+++ b/src/components/intelligence/IntelligenceStrategicTab.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
@@ -91,9 +91,6 @@ export function IntelligenceStrategicTab() {
     ? nonDiscountedItems.reduce((a, i) => a + Number(i.quantity), 0) / nonDiscountedItems.length : 0;
   const priceElasticity = avgNonDiscountQty > 0 ? ((avgDiscountQty - avgNonDiscountQty) / avgNonDiscountQty * 100) : 0;
 
-  const avgDiscount = salesOrders?.length
-    ? salesOrders.reduce((a, o) => a + Number(o.discount || 0), 0) / salesOrders.length
-    : 0;
   const ordersWithDiscount = salesOrders?.filter(o => Number(o.discount || 0) > 0).length || 0;
   const discountSensitivity = salesOrders?.length ? (ordersWithDiscount / salesOrders.length * 100) : 0;
 

--- a/src/components/intelligence/IntelligenceUserSimulator.tsx
+++ b/src/components/intelligence/IntelligenceUserSimulator.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
 import { Badge } from '@/components/ui/badge';

--- a/src/hooks/useAdminOrderDetail.ts
+++ b/src/hooks/useAdminOrderDetail.ts
@@ -11,7 +11,7 @@ import type { Order, OrderItem, Profile } from '@/components/admin-order/types';
 
 export function useAdminOrderDetail(id: string | undefined) {
   const navigate = useNavigate();
-  const { user, isStaff, loading: authLoading, role } = useAuth();
+  const { isStaff, loading: authLoading, role } = useAuth();
 
   const [order, setOrder] = useState<Order | null>(null);
   const [profile, setProfile] = useState<Profile | null>(null);

--- a/src/hooks/useCallLog.ts
+++ b/src/hooks/useCallLog.ts
@@ -2,7 +2,7 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
 import { acknowledgeMissed } from '@/lib/call-log/record';
-import type { CallLogRow, CallDirection, CallStatus } from '@/types/call-log';
+import type { CallLogRow } from '@/types/call-log';
 
 export type CallLogTab = 'recentes' | 'recebidas' | 'perdidas' | 'feitas' | 'time';
 

--- a/src/pages/AdminOrderDetail.tsx
+++ b/src/pages/AdminOrderDetail.tsx
@@ -19,7 +19,6 @@ const AdminOrderDetail = () => {
     saving,
     syncingOmie,
     deleting,
-    isStaff,
     itemPrices,
     setItemPrices,
     selectedStatus,

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -37,7 +37,7 @@ const Index = () => {
   if (!isStaff) {
     return (
       <CustomerDashboard
-        profile={profile}
+        profile={profile ?? null}
         pendingOrders={pendingOrders}
         userTools={userTools}
         getGreeting={getGreeting}

--- a/src/pages/IntelligenceDashboard.tsx
+++ b/src/pages/IntelligenceDashboard.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
 import { useCommercialRole } from '@/hooks/useCommercialRole';
 import { supabase } from '@/integrations/supabase/client';

--- a/tsconfig.strict.json
+++ b/tsconfig.strict.json
@@ -474,6 +474,10 @@
     "src/pages/FinanceiroCapitalGiro.tsx",
     "src/pages/AdminKnowledgeBase.tsx",
     "src/pages/TintCorantes.tsx",
-    "src/pages/FinanceiroAnalise.tsx"
+    "src/pages/FinanceiroAnalise.tsx",
+    "src/pages/AdminOrderDetail.tsx",
+    "src/pages/Telefonia.tsx",
+    "src/pages/IntelligenceDashboard.tsx",
+    "src/pages/Index.tsx"
   ]
 }


### PR DESCRIPTION
## Resumo

Lote 2 da fatia de pages (migração TypeScript strict). Promove 4 pages que no batch inicial estavam "tainted" por dead-code em deps. Aplica fixes mínimos (todos confirmados unused pelo próprio compilador) e adiciona ao `include`:

- `src/pages/AdminOrderDetail.tsx`
- `src/pages/Telefonia.tsx`
- `src/pages/IntelligenceDashboard.tsx`
- `src/pages/Index.tsx`

### Fixes que destravaram (dead-code + 1 null-check)
- `CustomerDashboard`: remove imports não usados (`AnimatePresence`, `ClipboardList`, `Calendar`)
- `intelligence/{Managerial,Operational,Strategic,UserSimulator}Tab`: remove `import React` não usado (JSX runtime automático); `StrategicTab` remove `avgDiscount` morto
- `useAdminOrderDetail`: remove `user` não usado
- `useCallLog`: remove tipos `CallDirection`/`CallStatus` não usados
- `AdminOrderDetail`: remove `isStaff` não usado
- `Index`: `profile ?? null` (strictNullChecks: `undefined`→`null`)

Pages ainda deferidas: `AdminReposicaoSessaoPedidos` (cascata profunda via lazy + null-check em `CiclosAnteriores`) e `AdminStandardProcessNew` (typing de `zodResolver`).

## Gate

- `bun run typecheck:strict` → TSC_EXIT=0 (sem erros).

## Test plan

- [x] `typecheck:strict` verde localmente
- [ ] CI `validate` verde