### PR TITLE
refactor(reposicao): split AdminReposicaoNegociacaoParalela (702→280)

### DIFF
--- a/src/components/reposicao/negociacaoParalela/DistribuicaoCards.tsx
+++ b/src/components/reposicao/negociacaoParalela/DistribuicaoCards.tsx
@@ -1,0 +1,30 @@
+// Cards de distribuição por categoria do ranking (BLOCO 2).
+// Extraídos verbatim de src/pages/AdminReposicaoNegociacaoParalela.tsx (god-component split).
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+import { type Categoria } from "./types";
+import { categoriaBadgeClass, categoriaLabel } from "./helpers";
+
+interface DistribuicaoCardsProps {
+  distribuicao: Record<Categoria, number>;
+}
+
+export function DistribuicaoCards({ distribuicao }: DistribuicaoCardsProps) {
+  return (
+    <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+      {(["prioritario", "forte", "moderado", "fraco"] as Categoria[]).map((c) => (
+        <Card key={c}>
+          <CardContent className="py-3">
+            <div className="flex items-center justify-between gap-2">
+              <Badge variant="outline" className={cn("uppercase text-[10px]", categoriaBadgeClass(c))}>
+                {categoriaLabel(c)}
+              </Badge>
+              <span className="text-xl font-semibold">{distribuicao[c]}</span>
+            </div>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/src/components/reposicao/negociacaoParalela/RankingPaginacao.tsx
+++ b/src/components/reposicao/negociacaoParalela/RankingPaginacao.tsx
@@ -1,0 +1,46 @@
+// Rodapé de paginação do ranking completo (BLOCO 2).
+// Extraído verbatim de src/pages/AdminReposicaoNegociacaoParalela.tsx (god-component split).
+import { Button } from "@/components/ui/button";
+
+interface RankingPaginacaoProps {
+  paginaAtual: number;
+  totalPaginas: number;
+  pageSize: number;
+  totalFiltrado: number;
+  onAnterior: () => void;
+  onProxima: () => void;
+}
+
+export function RankingPaginacao({
+  paginaAtual,
+  totalPaginas,
+  pageSize,
+  totalFiltrado,
+  onAnterior,
+  onProxima,
+}: RankingPaginacaoProps) {
+  return (
+    <div className="flex items-center justify-between flex-wrap gap-3">
+      <p className="text-xs text-muted-foreground">
+        Mostrando {totalFiltrado === 0 ? 0 : (paginaAtual - 1) * pageSize + 1}–
+        {Math.min(paginaAtual * pageSize, totalFiltrado)} de {totalFiltrado} SKUs ranqueados
+      </p>
+      <div className="flex items-center gap-2">
+        <Button variant="outline" size="sm" disabled={paginaAtual === 1} onClick={onAnterior}>
+          Anterior
+        </Button>
+        <span className="text-xs text-muted-foreground">
+          {paginaAtual} / {totalPaginas}
+        </span>
+        <Button
+          variant="outline"
+          size="sm"
+          disabled={paginaAtual >= totalPaginas}
+          onClick={onProxima}
+        >
+          Próxima
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/reposicao/negociacaoParalela/RankingToolbar.tsx
+++ b/src/components/reposicao/negociacaoParalela/RankingToolbar.tsx
@@ -1,0 +1,87 @@
+// Barra de filtros do ranking completo (BLOCO 2).
+// Extraída verbatim de src/pages/AdminReposicaoNegociacaoParalela.tsx (god-component split).
+import { Search } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+  DropdownMenuCheckboxItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+} from "@/components/ui/dropdown-menu";
+import { CATEGORIAS, type Categoria } from "./types";
+
+interface RankingToolbarProps {
+  rankingCategoriaFiltro: Set<Categoria>;
+  onToggleCategoria: (v: Categoria) => void;
+  rankingComSugestao: "sim" | "nao" | "ambos";
+  onComSugestaoChange: (v: "sim" | "nao" | "ambos") => void;
+  rankingBusca: string;
+  onBuscaChange: (v: string) => void;
+}
+
+export function RankingToolbar({
+  rankingCategoriaFiltro,
+  onToggleCategoria,
+  rankingComSugestao,
+  onComSugestaoChange,
+  rankingBusca,
+  onBuscaChange,
+}: RankingToolbarProps) {
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="outline" size="sm">
+            Categoria ({rankingCategoriaFiltro.size})
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuLabel>Filtrar por categoria</DropdownMenuLabel>
+          <DropdownMenuSeparator />
+          {CATEGORIAS.map((c) => (
+            <DropdownMenuCheckboxItem
+              key={c.value}
+              checked={rankingCategoriaFiltro.has(c.value)}
+              onCheckedChange={() => onToggleCategoria(c.value)}
+              onSelect={(e) => e.preventDefault()}
+            >
+              {c.label}
+            </DropdownMenuCheckboxItem>
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <Select
+        value={rankingComSugestao}
+        onValueChange={(v) => onComSugestaoChange(v as "sim" | "nao" | "ambos")}
+      >
+        <SelectTrigger className="w-[180px] h-9">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="ambos">Com/sem sugestão</SelectItem>
+          <SelectItem value="sim">Com sugestão ativa</SelectItem>
+          <SelectItem value="nao">Sem sugestão ativa</SelectItem>
+        </SelectContent>
+      </Select>
+      <div className="relative flex-1 min-w-[220px] max-w-md">
+        <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+        <Input
+          placeholder="Buscar por SKU ou descrição..."
+          value={rankingBusca}
+          onChange={(e) => onBuscaChange(e.target.value)}
+          className="pl-8 h-9"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/reposicao/negociacaoParalela/SugestoesToolbar.tsx
+++ b/src/components/reposicao/negociacaoParalela/SugestoesToolbar.tsx
@@ -1,0 +1,103 @@
+// Barra de filtros das sugestões ativas (BLOCO 1).
+// Extraída verbatim de src/pages/AdminReposicaoNegociacaoParalela.tsx (god-component split).
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+  DropdownMenuCheckboxItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+} from "@/components/ui/dropdown-menu";
+import {
+  STATUS_LIST,
+  ORDENACOES,
+  type StatusSugestao,
+  type Categoria,
+  type OrdenacaoKey,
+} from "./types";
+import { categoriaLabel } from "./helpers";
+
+interface SugestoesToolbarProps {
+  statusFiltro: Set<StatusSugestao>;
+  onToggleStatus: (v: StatusSugestao) => void;
+  categoriaFiltro: Set<Categoria>;
+  onToggleCategoria: (v: Categoria) => void;
+  ordenacao: OrdenacaoKey;
+  onOrdenacaoChange: (v: OrdenacaoKey) => void;
+}
+
+export function SugestoesToolbar({
+  statusFiltro,
+  onToggleStatus,
+  categoriaFiltro,
+  onToggleCategoria,
+  ordenacao,
+  onOrdenacaoChange,
+}: SugestoesToolbarProps) {
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="outline" size="sm">
+            Status ({statusFiltro.size})
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuLabel>Filtrar por status</DropdownMenuLabel>
+          <DropdownMenuSeparator />
+          {STATUS_LIST.map((st) => (
+            <DropdownMenuCheckboxItem
+              key={st.value}
+              checked={statusFiltro.has(st.value)}
+              onCheckedChange={() => onToggleStatus(st.value)}
+              onSelect={(e) => e.preventDefault()}
+            >
+              {st.label}
+            </DropdownMenuCheckboxItem>
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="outline" size="sm">
+            Categoria ({categoriaFiltro.size})
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuLabel>Filtrar por categoria</DropdownMenuLabel>
+          <DropdownMenuSeparator />
+          {(["prioritario", "forte", "moderado"] as Categoria[]).map((c) => (
+            <DropdownMenuCheckboxItem
+              key={c}
+              checked={categoriaFiltro.has(c)}
+              onCheckedChange={() => onToggleCategoria(c)}
+              onSelect={(e) => e.preventDefault()}
+            >
+              {categoriaLabel(c)}
+            </DropdownMenuCheckboxItem>
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <Select value={ordenacao} onValueChange={(v) => onOrdenacaoChange(v as OrdenacaoKey)}>
+        <SelectTrigger className="w-[200px] h-9">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {ORDENACOES.map((o) => (
+            <SelectItem key={o.value} value={o.value}>
+              {o.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}

--- a/src/components/reposicao/negociacaoParalela/__tests__/DistribuicaoCards.test.tsx
+++ b/src/components/reposicao/negociacaoParalela/__tests__/DistribuicaoCards.test.tsx
@@ -1,0 +1,21 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { DistribuicaoCards } from "../DistribuicaoCards";
+
+describe("DistribuicaoCards", () => {
+  it("renderiza os 4 cards de categoria com seus rótulos e contagens", () => {
+    render(
+      <DistribuicaoCards
+        distribuicao={{ prioritario: 2, forte: 5, moderado: 1, fraco: 9 }}
+      />,
+    );
+    expect(screen.getByText("Prioritário")).toBeTruthy();
+    expect(screen.getByText("Forte")).toBeTruthy();
+    expect(screen.getByText("Moderado")).toBeTruthy();
+    expect(screen.getByText("Fraco")).toBeTruthy();
+    expect(screen.getByText("2")).toBeTruthy();
+    expect(screen.getByText("5")).toBeTruthy();
+    expect(screen.getByText("1")).toBeTruthy();
+    expect(screen.getByText("9")).toBeTruthy();
+  });
+});

--- a/src/components/reposicao/negociacaoParalela/__tests__/RankingPaginacao.test.tsx
+++ b/src/components/reposicao/negociacaoParalela/__tests__/RankingPaginacao.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { RankingPaginacao } from "../RankingPaginacao";
+
+describe("RankingPaginacao", () => {
+  it("mostra intervalo, total e indicador de página", () => {
+    render(
+      <RankingPaginacao
+        paginaAtual={1}
+        totalPaginas={3}
+        pageSize={20}
+        totalFiltrado={45}
+        onAnterior={() => {}}
+        onProxima={() => {}}
+      />,
+    );
+    expect(screen.getByText(/Mostrando 1–20 de 45 SKUs ranqueados/)).toBeTruthy();
+    expect(screen.getByText("1 / 3")).toBeTruthy();
+  });
+
+  it("desabilita Anterior na primeira página e Próxima na última", () => {
+    const { rerender } = render(
+      <RankingPaginacao
+        paginaAtual={1}
+        totalPaginas={3}
+        pageSize={20}
+        totalFiltrado={45}
+        onAnterior={() => {}}
+        onProxima={() => {}}
+      />,
+    );
+    expect(screen.getByRole("button", { name: "Anterior" })).toHaveProperty("disabled", true);
+    expect(screen.getByRole("button", { name: "Próxima" })).toHaveProperty("disabled", false);
+
+    rerender(
+      <RankingPaginacao
+        paginaAtual={3}
+        totalPaginas={3}
+        pageSize={20}
+        totalFiltrado={45}
+        onAnterior={() => {}}
+        onProxima={() => {}}
+      />,
+    );
+    expect(screen.getByRole("button", { name: "Próxima" })).toHaveProperty("disabled", true);
+  });
+
+  it("dispara callbacks ao clicar", () => {
+    const onAnterior = vi.fn();
+    const onProxima = vi.fn();
+    render(
+      <RankingPaginacao
+        paginaAtual={2}
+        totalPaginas={3}
+        pageSize={20}
+        totalFiltrado={45}
+        onAnterior={onAnterior}
+        onProxima={onProxima}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Anterior" }));
+    fireEvent.click(screen.getByRole("button", { name: "Próxima" }));
+    expect(onAnterior).toHaveBeenCalledTimes(1);
+    expect(onProxima).toHaveBeenCalledTimes(1);
+  });
+
+  it("trata lista vazia (0–0 de 0)", () => {
+    render(
+      <RankingPaginacao
+        paginaAtual={1}
+        totalPaginas={1}
+        pageSize={20}
+        totalFiltrado={0}
+        onAnterior={() => {}}
+        onProxima={() => {}}
+      />,
+    );
+    expect(screen.getByText(/Mostrando 0–0 de 0 SKUs ranqueados/)).toBeTruthy();
+  });
+});

--- a/src/components/reposicao/negociacaoParalela/__tests__/RankingToolbar.test.tsx
+++ b/src/components/reposicao/negociacaoParalela/__tests__/RankingToolbar.test.tsx
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { RankingToolbar } from "../RankingToolbar";
+
+function setup(overrides: Partial<React.ComponentProps<typeof RankingToolbar>> = {}) {
+  const props: React.ComponentProps<typeof RankingToolbar> = {
+    rankingCategoriaFiltro: new Set(["prioritario", "forte", "moderado", "fraco"]),
+    onToggleCategoria: vi.fn(),
+    rankingComSugestao: "ambos",
+    onComSugestaoChange: vi.fn(),
+    rankingBusca: "",
+    onBuscaChange: vi.fn(),
+    ...overrides,
+  };
+  render(<RankingToolbar {...props} />);
+  return props;
+}
+
+describe("RankingToolbar", () => {
+  it("mostra a contagem de categorias selecionadas no botão", () => {
+    setup();
+    expect(screen.getByRole("button", { name: /Categoria \(4\)/ })).toBeTruthy();
+  });
+
+  it("renderiza o campo de busca com o valor controlado", () => {
+    setup({ rankingBusca: "verniz" });
+    const input = screen.getByPlaceholderText("Buscar por SKU ou descrição...") as HTMLInputElement;
+    expect(input.value).toBe("verniz");
+  });
+
+  it("dispara onBuscaChange ao digitar", () => {
+    const props = setup();
+    const input = screen.getByPlaceholderText("Buscar por SKU ou descrição...");
+    fireEvent.change(input, { target: { value: "tinta" } });
+    expect(props.onBuscaChange).toHaveBeenCalledWith("tinta");
+  });
+});

--- a/src/components/reposicao/negociacaoParalela/__tests__/SugestoesToolbar.test.tsx
+++ b/src/components/reposicao/negociacaoParalela/__tests__/SugestoesToolbar.test.tsx
@@ -1,0 +1,20 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { SugestoesToolbar } from "../SugestoesToolbar";
+
+describe("SugestoesToolbar", () => {
+  it("mostra contagens de status e categoria selecionados nos botões", () => {
+    render(
+      <SugestoesToolbar
+        statusFiltro={new Set(["nova", "visualizada", "acao_tomada"])}
+        onToggleStatus={vi.fn()}
+        categoriaFiltro={new Set(["prioritario", "forte"])}
+        onToggleCategoria={vi.fn()}
+        ordenacao="score"
+        onOrdenacaoChange={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole("button", { name: /Status \(3\)/ })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Categoria \(2\)/ })).toBeTruthy();
+  });
+});

--- a/src/components/reposicao/negociacaoParalela/__tests__/helpers.test.ts
+++ b/src/components/reposicao/negociacaoParalela/__tests__/helpers.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import {
+  toggleSet,
+  categoriaLabel,
+  categoriaBadgeClass,
+  statusLabel,
+  lastDayOfNextMonth,
+} from "../helpers";
+
+describe("toggleSet", () => {
+  it("adiciona valor ausente sem mutar o original", () => {
+    const orig = new Set<string>(["a"]);
+    const next = toggleSet(orig, "b");
+    expect([...next].sort()).toEqual(["a", "b"]);
+    expect([...orig]).toEqual(["a"]); // imutável
+  });
+
+  it("remove valor presente", () => {
+    const next = toggleSet(new Set(["a", "b"]), "a");
+    expect([...next]).toEqual(["b"]);
+  });
+});
+
+describe("categoriaLabel", () => {
+  it("mapeia categorias conhecidas", () => {
+    expect(categoriaLabel("prioritario")).toBe("Prioritário");
+    expect(categoriaLabel("fraco")).toBe("Fraco");
+  });
+  it("retorna — para nulo/desconhecido", () => {
+    expect(categoriaLabel(null)).toBe("—");
+  });
+});
+
+describe("categoriaBadgeClass", () => {
+  it("retorna classe específica para prioritário e fallback para nulo", () => {
+    expect(categoriaBadgeClass("prioritario")).toContain("status-warning");
+    expect(categoriaBadgeClass(null)).toContain("muted");
+  });
+});
+
+describe("statusLabel", () => {
+  it("traduz status", () => {
+    expect(statusLabel("nova")).toBe("Nova");
+    expect(statusLabel("fechada_sem_acordo")).toBe("Fechada sem acordo");
+  });
+});
+
+describe("lastDayOfNextMonth", () => {
+  it("retorna data ISO (YYYY-MM-DD) do último dia do mês seguinte", () => {
+    const s = lastDayOfNextMonth();
+    expect(s).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+});

--- a/src/components/reposicao/negociacaoParalela/helpers.ts
+++ b/src/components/reposicao/negociacaoParalela/helpers.ts
@@ -76,3 +76,11 @@ export function lastDayOfNextMonth(): string {
   const d = new Date(now.getFullYear(), now.getMonth() + 2, 0);
   return d.toISOString().slice(0, 10);
 }
+
+// Toggle imutável de um valor num Set (helper genérico, puro).
+export function toggleSet<T>(set: Set<T>, value: T): Set<T> {
+  const next = new Set(set);
+  if (next.has(value)) next.delete(value);
+  else next.add(value);
+  return next;
+}

--- a/src/components/reposicao/negociacaoParalela/useNegociacaoParalela.ts
+++ b/src/components/reposicao/negociacaoParalela/useNegociacaoParalela.ts
@@ -1,0 +1,399 @@
+// Camada de dados/lógica da tela de negociação paralela.
+// Extraída verbatim de src/pages/AdminReposicaoNegociacaoParalela.tsx (god-component split).
+// Mantém estado, queries, memos derivados e handlers; a página vira composição de UI.
+import { useState, useMemo, useRef } from "react";
+import { useNavigate } from "react-router-dom";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { supabase } from "@/integrations/supabase/client";
+import { toast } from "sonner";
+import {
+  EMPRESA,
+  type StatusSugestao,
+  type Categoria,
+  type OrdenacaoKey,
+  type Sugestao,
+  type RankingRow,
+  type ConvertForm,
+} from "./types";
+import { lastDayOfNextMonth, toggleSet } from "./helpers";
+
+const PAGE_SIZE = 20;
+
+export function useNegociacaoParalela() {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const rankingRef = useRef<HTMLDivElement>(null);
+
+  // Bloco 1 filtros
+  const [statusFiltro, setStatusFiltro] = useState<Set<StatusSugestao>>(
+    new Set(["nova", "visualizada", "acao_tomada"]),
+  );
+  const [categoriaFiltro, setCategoriaFiltro] = useState<Set<Categoria>>(
+    new Set(["prioritario", "forte", "moderado"]),
+  );
+  const [ordenacao, setOrdenacao] = useState<OrdenacaoKey>("score");
+
+  // Bloco 2 filtros
+  const [rankingCategoriaFiltro, setRankingCategoriaFiltro] = useState<Set<Categoria>>(
+    new Set(["prioritario", "forte", "moderado", "fraco"]),
+  );
+  const [rankingComSugestao, setRankingComSugestao] = useState<"sim" | "nao" | "ambos">("ambos");
+  const [rankingBusca, setRankingBusca] = useState("");
+  const [rankingPagina, setRankingPagina] = useState(1);
+  const [highlightSku, setHighlightSku] = useState<string | null>(null);
+
+  // Action states
+  const [gerando, setGerando] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
+  const [ignoreTarget, setIgnoreTarget] = useState<Sugestao | null>(null);
+  const [fecharSemAcordoTarget, setFecharSemAcordoTarget] = useState<Sugestao | null>(null);
+  const [fecharObs, setFecharObs] = useState("");
+  const [convertTarget, setConvertTarget] = useState<Sugestao | null>(null);
+  const [convertForm, setConvertForm] = useState<ConvertForm>({
+    desconto_perc: 5,
+    volume_minimo: 1000,
+    volume_unidade: "reais",
+    data_fim: lastDayOfNextMonth(),
+    responsavel: "",
+    canal: "ligacao",
+    observacoes: "",
+  });
+  const [convertSubmitting, setConvertSubmitting] = useState(false);
+
+  // Queries
+  const { data: sugestoes = [], isLoading: loadingSugestoes } = useQuery({
+    queryKey: ["negociacao-paralela-sugestoes", EMPRESA],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from("v_sugestao_negociacao_ativa" as never)
+        .select("*")
+        .eq("empresa", EMPRESA);
+      if (error) throw error;
+      return (data ?? []) as unknown as Sugestao[];
+    },
+    staleTime: 30_000,
+  });
+
+  const { data: ranking = [], isLoading: loadingRanking } = useQuery({
+    queryKey: ["negociacao-paralela-ranking", EMPRESA],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from("mv_sku_ranking_negociacao_paralela" as never)
+        .select("*")
+        .eq("empresa", EMPRESA)
+        .order("score_final", { ascending: false });
+      if (error) throw error;
+      return (data ?? []) as unknown as RankingRow[];
+    },
+    staleTime: 30_000,
+  });
+
+  // SKUs com sugestão ativa (qualquer status considerado "ativo" pela view)
+  const skusComSugestao = useMemo(
+    () => new Set(sugestoes.map((s) => s.sku_codigo_omie)),
+    [sugestoes],
+  );
+
+  // Filtragem das sugestões
+  const sugestoesFiltradas = useMemo(() => {
+    let arr = sugestoes.filter((s) => statusFiltro.has(s.status as StatusSugestao));
+    if (categoriaFiltro.size > 0) {
+      arr = arr.filter((s) => !s.categoria || categoriaFiltro.has(s.categoria));
+    }
+    arr = [...arr].sort((a, b) => {
+      switch (ordenacao) {
+        case "volume":
+          return Number(b.volume_financeiro_12m ?? 0) - Number(a.volume_financeiro_12m ?? 0);
+        case "preco":
+          return Number(b.preco_medio_unitario ?? 0) - Number(a.preco_medio_unitario ?? 0);
+        case "expirando":
+          return (a.dias_ate_expirar ?? 999) - (b.dias_ate_expirar ?? 999);
+        case "score":
+        default:
+          return Number(b.score_final ?? 0) - Number(a.score_final ?? 0);
+      }
+    });
+    return arr;
+  }, [sugestoes, statusFiltro, categoriaFiltro, ordenacao]);
+
+  // Distribuição categorias do ranking
+  const distribuicao = useMemo(() => {
+    const acc: Record<Categoria, number> = { prioritario: 0, forte: 0, moderado: 0, fraco: 0 };
+    for (const r of ranking) {
+      if (r.categoria) acc[r.categoria] = (acc[r.categoria] ?? 0) + 1;
+    }
+    return acc;
+  }, [ranking]);
+
+  // Filtragem ranking
+  const rankingFiltrado = useMemo(() => {
+    let arr = ranking.filter((r) => !r.categoria || rankingCategoriaFiltro.has(r.categoria));
+    if (rankingComSugestao !== "ambos") {
+      arr = arr.filter((r) => {
+        const tem = skusComSugestao.has(r.sku_codigo_omie);
+        return rankingComSugestao === "sim" ? tem : !tem;
+      });
+    }
+    if (rankingBusca.trim()) {
+      const q = rankingBusca.trim().toLowerCase();
+      arr = arr.filter(
+        (r) =>
+          r.sku_codigo_omie.toLowerCase().includes(q) ||
+          (r.sku_descricao ?? "").toLowerCase().includes(q),
+      );
+    }
+    return arr;
+  }, [ranking, rankingCategoriaFiltro, rankingComSugestao, rankingBusca, skusComSugestao]);
+
+  const totalPaginas = Math.max(1, Math.ceil(rankingFiltrado.length / PAGE_SIZE));
+  const paginaAtual = Math.min(rankingPagina, totalPaginas);
+  const rankingPagina_ = useMemo(
+    () => rankingFiltrado.slice((paginaAtual - 1) * PAGE_SIZE, paginaAtual * PAGE_SIZE),
+    [rankingFiltrado, paginaAtual],
+  );
+
+  const ultimaAtualizacao = ranking[0]?.atualizado_em
+    ? new Date(ranking[0].atualizado_em).toLocaleString("pt-BR")
+    : null;
+
+  // Calcular "compras 12m" e "meses" lookup do ranking para enriquecer cards
+  const rankingMap = useMemo(() => {
+    const m = new Map<string, RankingRow>();
+    for (const r of ranking) m.set(r.sku_codigo_omie, r);
+    return m;
+  }, [ranking]);
+
+  // Actions
+  const handleGerarSugestoes = async () => {
+    setGerando(true);
+    try {
+      const { data, error } = await supabase.rpc("sugerir_negociacao_paralela_hoje" as never, {
+        p_empresa: EMPRESA,
+        p_limite: 10,
+      } as never);
+      if (error) throw error;
+      const arr = data as unknown as unknown[] | null;
+      const count = Array.isArray(arr) ? arr.length : 0;
+      toast.success(`${count} sugest${count === 1 ? "ão criada" : "ões criadas"}.`);
+      queryClient.invalidateQueries({ queryKey: ["negociacao-paralela-sugestoes"] });
+      queryClient.invalidateQueries({ queryKey: ["negociacao-paralela-sugestoes-count"] });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      toast.error("Erro ao gerar sugestões: " + message);
+    } finally {
+      setGerando(false);
+    }
+  };
+
+  const handleRefreshRanking = async () => {
+    setRefreshing(true);
+    try {
+      const { error } = await supabase.rpc("refresh_sku_ranking_negociacao" as never);
+      if (error) throw error;
+      toast.success("Ranking atualizado.");
+      queryClient.invalidateQueries({ queryKey: ["negociacao-paralela-ranking"] });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      toast.error("Erro ao atualizar ranking: " + message);
+    } finally {
+      setRefreshing(false);
+    }
+  };
+
+  const updateStatus = async (id: number, novoStatus: StatusSugestao, extra: Record<string, unknown> = {}) => {
+    const { error } = await supabase
+      .from("sugestao_negociacao_paralela")
+      .update({ status: novoStatus, ...extra } as never)
+      .eq("id", id);
+    if (error) {
+      toast.error("Erro ao atualizar status: " + error.message);
+      return false;
+    }
+    queryClient.invalidateQueries({ queryKey: ["negociacao-paralela-sugestoes"] });
+    queryClient.invalidateQueries({ queryKey: ["negociacao-paralela-sugestoes-count"] });
+    return true;
+  };
+
+  const handleMarcarVisualizada = async (s: Sugestao) => {
+    const ok = await updateStatus(s.id, "visualizada");
+    if (ok) toast.success("Marcada como visualizada.");
+  };
+
+  const handleMarcarEmAndamento = async (s: Sugestao) => {
+    const ok = await updateStatus(s.id, "acao_tomada", { data_acao: new Date().toISOString() });
+    if (ok) toast.success("Marcada como em andamento.");
+  };
+
+  const handleIgnorarConfirm = async () => {
+    if (!ignoreTarget) return;
+    const ok = await updateStatus(ignoreTarget.id, "ignorada");
+    if (ok) toast.success("Sugestão ignorada.");
+    setIgnoreTarget(null);
+  };
+
+  const handleFecharSemAcordoConfirm = async () => {
+    if (!fecharSemAcordoTarget) return;
+    const ok = await updateStatus(fecharSemAcordoTarget.id, "fechada_sem_acordo", {
+      observacoes: fecharObs || null,
+      data_acao: new Date().toISOString(),
+    });
+    if (ok) toast.success("Negociação encerrada sem acordo.");
+    setFecharSemAcordoTarget(null);
+    setFecharObs("");
+  };
+
+  const handleIrAoRanking = (s: Sugestao) => {
+    setHighlightSku(s.sku_codigo_omie);
+    rankingRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+    setTimeout(() => setHighlightSku(null), 3000);
+  };
+
+  const openConvertDialog = (s: Sugestao) => {
+    setConvertTarget(s);
+    setConvertForm({
+      desconto_perc: 5,
+      volume_minimo: Math.round(Number(s.volume_financeiro_12m ?? 0) / 12) || 1000,
+      volume_unidade: "reais",
+      data_fim: lastDayOfNextMonth(),
+      responsavel: "",
+      canal: "ligacao",
+      observacoes: "",
+    });
+  };
+
+  const handleConverterConfirm = async () => {
+    if (!convertTarget) return;
+    if (convertForm.desconto_perc < 1 || convertForm.desconto_perc > 50) {
+      toast.error("Desconto deve estar entre 1 e 50%.");
+      return;
+    }
+    if (convertForm.volume_minimo <= 0) {
+      toast.error("Volume mínimo deve ser maior que zero.");
+      return;
+    }
+    setConvertSubmitting(true);
+    try {
+      const { data, error } = await supabase.rpc("converter_sugestao_em_campanha_flat" as never, {
+        p_sugestao_id: convertTarget.id,
+        p_desconto_perc: convertForm.desconto_perc,
+        p_volume_minimo: convertForm.volume_minimo,
+        p_volume_unidade: convertForm.volume_unidade,
+        p_data_fim: convertForm.data_fim,
+        p_responsavel_nome: convertForm.responsavel || null,
+        p_canal: convertForm.canal,
+        p_observacoes: convertForm.observacoes || null,
+      } as never);
+      if (error) throw error;
+      toast.success("Sugestão convertida em campanha.");
+      queryClient.invalidateQueries({ queryKey: ["negociacao-paralela-sugestoes"] });
+      const campanhaId = typeof data === "number" || typeof data === "string" ? data : null;
+      if (campanhaId) navigate(`/admin/reposicao/promocoes/${campanhaId}`);
+      else navigate(`/admin/reposicao/promocoes`);
+      setConvertTarget(null);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      toast.error("Erro ao converter: " + message);
+    } finally {
+      setConvertSubmitting(false);
+    }
+  };
+
+  const handleCriarSugestaoDoRanking = async (r: RankingRow) => {
+    try {
+      const dataGeracao = new Date().toISOString().slice(0, 10);
+      const validoAte = new Date();
+      validoAte.setDate(validoAte.getDate() + 14);
+      const { error } = await supabase.from("sugestao_negociacao_paralela").insert({
+        empresa: r.empresa,
+        sku_codigo_omie: r.sku_codigo_omie,
+        sku_descricao: r.sku_descricao,
+        motivo: "score_alto_ciclo_semanal",
+        motivo_detalhes: { criado_via: "ui_ranking", categoria_ranking: r.categoria },
+        score_final: r.score_final,
+        volume_financeiro_12m: r.volume_financeiro_12m,
+        preco_medio_unitario: r.preco_medio_unitario,
+        promocoes_12m: r.promocoes_12m,
+        perc_meses_com_promo: r.perc_meses_com_promo,
+        status: "nova",
+        data_geracao: dataGeracao,
+        valido_ate: validoAte.toISOString().slice(0, 10),
+      });
+      if (error) throw error;
+      toast.success(`Sugestão criada para ${r.sku_codigo_omie}.`);
+      queryClient.invalidateQueries({ queryKey: ["negociacao-paralela-sugestoes"] });
+      queryClient.invalidateQueries({ queryKey: ["negociacao-paralela-sugestoes-count"] });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      toast.error("Erro ao criar sugestão: " + message);
+    }
+  };
+
+  // Callbacks de filtro (encapsulam os updaters imutáveis para a UI presentacional)
+  const toggleStatusFiltro = (v: StatusSugestao) => setStatusFiltro((prev) => toggleSet(prev, v));
+  const toggleCategoriaFiltro = (v: Categoria) => setCategoriaFiltro((prev) => toggleSet(prev, v));
+  const toggleRankingCategoria = (v: Categoria) =>
+    setRankingCategoriaFiltro((prev) => toggleSet(prev, v));
+  const onRankingBuscaChange = (v: string) => {
+    setRankingBusca(v);
+    setRankingPagina(1);
+  };
+
+  return {
+    PAGE_SIZE,
+    rankingRef,
+    // Bloco 1 filtros
+    statusFiltro,
+    categoriaFiltro,
+    ordenacao,
+    setOrdenacao,
+    toggleStatusFiltro,
+    toggleCategoriaFiltro,
+    // Bloco 2 filtros
+    rankingCategoriaFiltro,
+    toggleRankingCategoria,
+    rankingComSugestao,
+    setRankingComSugestao,
+    rankingBusca,
+    onRankingBuscaChange,
+    rankingPagina,
+    setRankingPagina,
+    highlightSku,
+    // Action states
+    gerando,
+    refreshing,
+    ignoreTarget,
+    setIgnoreTarget,
+    fecharSemAcordoTarget,
+    setFecharSemAcordoTarget,
+    fecharObs,
+    setFecharObs,
+    convertTarget,
+    setConvertTarget,
+    convertForm,
+    setConvertForm,
+    convertSubmitting,
+    // Derived
+    loadingSugestoes,
+    loadingRanking,
+    skusComSugestao,
+    sugestoesFiltradas,
+    distribuicao,
+    rankingFiltrado,
+    totalPaginas,
+    paginaAtual,
+    rankingPagina_,
+    ultimaAtualizacao,
+    rankingMap,
+    // Handlers
+    handleGerarSugestoes,
+    handleRefreshRanking,
+    handleMarcarVisualizada,
+    handleMarcarEmAndamento,
+    handleIgnorarConfirm,
+    handleFecharSemAcordoConfirm,
+    handleIrAoRanking,
+    openConvertDialog,
+    handleConverterConfirm,
+    handleCriarSugestaoDoRanking,
+  };
+}

--- a/src/pages/AdminReposicaoNegociacaoParalela.tsx
+++ b/src/pages/AdminReposicaoNegociacaoParalela.tsx
@@ -1,36 +1,13 @@
-import { useState, useMemo, useRef } from "react";
-import { useNavigate } from "react-router-dom";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { supabase } from "@/integrations/supabase/client";
-import { toast } from "sonner";
 import {
   Handshake,
   Loader2,
   RefreshCw,
   Sparkles,
   ClipboardList,
-  Search,
   Info,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
-import { Input } from "@/components/ui/input";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuTrigger,
-  DropdownMenuCheckboxItem,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-} from "@/components/ui/dropdown-menu";
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -39,25 +16,7 @@ import {
   BreadcrumbPage,
   BreadcrumbSeparator,
 } from "@/components/ui/breadcrumb";
-import { cn } from "@/lib/utils";
 import { HelpDrawer } from "@/components/help/HelpDrawer";
-import {
-  EMPRESA,
-  CATEGORIAS,
-  STATUS_LIST,
-  ORDENACOES,
-  type StatusSugestao,
-  type Categoria,
-  type OrdenacaoKey,
-  type Sugestao,
-  type RankingRow,
-  type ConvertForm,
-} from "@/components/reposicao/negociacaoParalela/types";
-import {
-  categoriaBadgeClass,
-  categoriaLabel,
-  lastDayOfNextMonth,
-} from "@/components/reposicao/negociacaoParalela/helpers";
 import { SugestaoCard } from "@/components/reposicao/negociacaoParalela/SugestaoCard";
 import { RankingTable } from "@/components/reposicao/negociacaoParalela/RankingTable";
 import {
@@ -65,323 +24,65 @@ import {
   FecharSemAcordoDialog,
   ConverterDialog,
 } from "@/components/reposicao/negociacaoParalela/dialogs";
+import { SugestoesToolbar } from "@/components/reposicao/negociacaoParalela/SugestoesToolbar";
+import { RankingToolbar } from "@/components/reposicao/negociacaoParalela/RankingToolbar";
+import { DistribuicaoCards } from "@/components/reposicao/negociacaoParalela/DistribuicaoCards";
+import { RankingPaginacao } from "@/components/reposicao/negociacaoParalela/RankingPaginacao";
+import { useNegociacaoParalela } from "@/components/reposicao/negociacaoParalela/useNegociacaoParalela";
 
 export default function AdminReposicaoNegociacaoParalela() {
-  const navigate = useNavigate();
-  const queryClient = useQueryClient();
-  const rankingRef = useRef<HTMLDivElement>(null);
-
-  // Bloco 1 filtros
-  const [statusFiltro, setStatusFiltro] = useState<Set<StatusSugestao>>(
-    new Set(["nova", "visualizada", "acao_tomada"]),
-  );
-  const [categoriaFiltro, setCategoriaFiltro] = useState<Set<Categoria>>(
-    new Set(["prioritario", "forte", "moderado"]),
-  );
-  const [ordenacao, setOrdenacao] = useState<OrdenacaoKey>("score");
-
-  // Bloco 2 filtros
-  const [rankingCategoriaFiltro, setRankingCategoriaFiltro] = useState<Set<Categoria>>(
-    new Set(["prioritario", "forte", "moderado", "fraco"]),
-  );
-  const [rankingComSugestao, setRankingComSugestao] = useState<"sim" | "nao" | "ambos">("ambos");
-  const [rankingBusca, setRankingBusca] = useState("");
-  const [rankingPagina, setRankingPagina] = useState(1);
-  const [highlightSku, setHighlightSku] = useState<string | null>(null);
-  const PAGE_SIZE = 20;
-
-  // Action states
-  const [gerando, setGerando] = useState(false);
-  const [refreshing, setRefreshing] = useState(false);
-  const [ignoreTarget, setIgnoreTarget] = useState<Sugestao | null>(null);
-  const [fecharSemAcordoTarget, setFecharSemAcordoTarget] = useState<Sugestao | null>(null);
-  const [fecharObs, setFecharObs] = useState("");
-  const [convertTarget, setConvertTarget] = useState<Sugestao | null>(null);
-  const [convertForm, setConvertForm] = useState<ConvertForm>({
-    desconto_perc: 5,
-    volume_minimo: 1000,
-    volume_unidade: "reais",
-    data_fim: lastDayOfNextMonth(),
-    responsavel: "",
-    canal: "ligacao",
-    observacoes: "",
-  });
-  const [convertSubmitting, setConvertSubmitting] = useState(false);
-
-  // Queries
-  const { data: sugestoes = [], isLoading: loadingSugestoes } = useQuery({
-    queryKey: ["negociacao-paralela-sugestoes", EMPRESA],
-    queryFn: async () => {
-      const { data, error } = await supabase
-        .from("v_sugestao_negociacao_ativa" as never)
-        .select("*")
-        .eq("empresa", EMPRESA);
-      if (error) throw error;
-      return (data ?? []) as unknown as Sugestao[];
-    },
-    staleTime: 30_000,
-  });
-
-  const { data: ranking = [], isLoading: loadingRanking } = useQuery({
-    queryKey: ["negociacao-paralela-ranking", EMPRESA],
-    queryFn: async () => {
-      const { data, error } = await supabase
-        .from("mv_sku_ranking_negociacao_paralela" as never)
-        .select("*")
-        .eq("empresa", EMPRESA)
-        .order("score_final", { ascending: false });
-      if (error) throw error;
-      return (data ?? []) as unknown as RankingRow[];
-    },
-    staleTime: 30_000,
-  });
-
-  // SKUs com sugestão ativa (qualquer status considerado "ativo" pela view)
-  const skusComSugestao = useMemo(
-    () => new Set(sugestoes.map((s) => s.sku_codigo_omie)),
-    [sugestoes],
-  );
-
-  // Filtragem das sugestões
-  const sugestoesFiltradas = useMemo(() => {
-    let arr = sugestoes.filter((s) => statusFiltro.has(s.status as StatusSugestao));
-    if (categoriaFiltro.size > 0) {
-      arr = arr.filter((s) => !s.categoria || categoriaFiltro.has(s.categoria));
-    }
-    arr = [...arr].sort((a, b) => {
-      switch (ordenacao) {
-        case "volume":
-          return Number(b.volume_financeiro_12m ?? 0) - Number(a.volume_financeiro_12m ?? 0);
-        case "preco":
-          return Number(b.preco_medio_unitario ?? 0) - Number(a.preco_medio_unitario ?? 0);
-        case "expirando":
-          return (a.dias_ate_expirar ?? 999) - (b.dias_ate_expirar ?? 999);
-        case "score":
-        default:
-          return Number(b.score_final ?? 0) - Number(a.score_final ?? 0);
-      }
-    });
-    return arr;
-  }, [sugestoes, statusFiltro, categoriaFiltro, ordenacao]);
-
-  // Distribuição categorias do ranking
-  const distribuicao = useMemo(() => {
-    const acc: Record<Categoria, number> = { prioritario: 0, forte: 0, moderado: 0, fraco: 0 };
-    for (const r of ranking) {
-      if (r.categoria) acc[r.categoria] = (acc[r.categoria] ?? 0) + 1;
-    }
-    return acc;
-  }, [ranking]);
-
-  // Filtragem ranking
-  const rankingFiltrado = useMemo(() => {
-    let arr = ranking.filter((r) => !r.categoria || rankingCategoriaFiltro.has(r.categoria));
-    if (rankingComSugestao !== "ambos") {
-      arr = arr.filter((r) => {
-        const tem = skusComSugestao.has(r.sku_codigo_omie);
-        return rankingComSugestao === "sim" ? tem : !tem;
-      });
-    }
-    if (rankingBusca.trim()) {
-      const q = rankingBusca.trim().toLowerCase();
-      arr = arr.filter(
-        (r) =>
-          r.sku_codigo_omie.toLowerCase().includes(q) ||
-          (r.sku_descricao ?? "").toLowerCase().includes(q),
-      );
-    }
-    return arr;
-  }, [ranking, rankingCategoriaFiltro, rankingComSugestao, rankingBusca, skusComSugestao]);
-
-  const totalPaginas = Math.max(1, Math.ceil(rankingFiltrado.length / PAGE_SIZE));
-  const paginaAtual = Math.min(rankingPagina, totalPaginas);
-  const rankingPagina_ = useMemo(
-    () => rankingFiltrado.slice((paginaAtual - 1) * PAGE_SIZE, paginaAtual * PAGE_SIZE),
-    [rankingFiltrado, paginaAtual],
-  );
-
-  const ultimaAtualizacao = ranking[0]?.atualizado_em
-    ? new Date(ranking[0].atualizado_em).toLocaleString("pt-BR")
-    : null;
-
-  // Calcular "compras 12m" e "meses" lookup do ranking para enriquecer cards
-  const rankingMap = useMemo(() => {
-    const m = new Map<string, RankingRow>();
-    for (const r of ranking) m.set(r.sku_codigo_omie, r);
-    return m;
-  }, [ranking]);
-
-  // Actions
-  const handleGerarSugestoes = async () => {
-    setGerando(true);
-    try {
-      const { data, error } = await supabase.rpc("sugerir_negociacao_paralela_hoje" as never, {
-        p_empresa: EMPRESA,
-        p_limite: 10,
-      } as never);
-      if (error) throw error;
-      const arr = data as unknown as unknown[] | null;
-      const count = Array.isArray(arr) ? arr.length : 0;
-      toast.success(`${count} sugest${count === 1 ? "ão criada" : "ões criadas"}.`);
-      queryClient.invalidateQueries({ queryKey: ["negociacao-paralela-sugestoes"] });
-      queryClient.invalidateQueries({ queryKey: ["negociacao-paralela-sugestoes-count"] });
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      toast.error("Erro ao gerar sugestões: " + message);
-    } finally {
-      setGerando(false);
-    }
-  };
-
-  const handleRefreshRanking = async () => {
-    setRefreshing(true);
-    try {
-      const { error } = await supabase.rpc("refresh_sku_ranking_negociacao" as never);
-      if (error) throw error;
-      toast.success("Ranking atualizado.");
-      queryClient.invalidateQueries({ queryKey: ["negociacao-paralela-ranking"] });
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      toast.error("Erro ao atualizar ranking: " + message);
-    } finally {
-      setRefreshing(false);
-    }
-  };
-
-  const updateStatus = async (id: number, novoStatus: StatusSugestao, extra: Record<string, unknown> = {}) => {
-    const { error } = await supabase
-      .from("sugestao_negociacao_paralela")
-      .update({ status: novoStatus, ...extra } as never)
-      .eq("id", id);
-    if (error) {
-      toast.error("Erro ao atualizar status: " + error.message);
-      return false;
-    }
-    queryClient.invalidateQueries({ queryKey: ["negociacao-paralela-sugestoes"] });
-    queryClient.invalidateQueries({ queryKey: ["negociacao-paralela-sugestoes-count"] });
-    return true;
-  };
-
-  const handleMarcarVisualizada = async (s: Sugestao) => {
-    const ok = await updateStatus(s.id, "visualizada");
-    if (ok) toast.success("Marcada como visualizada.");
-  };
-
-  const handleMarcarEmAndamento = async (s: Sugestao) => {
-    const ok = await updateStatus(s.id, "acao_tomada", { data_acao: new Date().toISOString() });
-    if (ok) toast.success("Marcada como em andamento.");
-  };
-
-  const handleIgnorarConfirm = async () => {
-    if (!ignoreTarget) return;
-    const ok = await updateStatus(ignoreTarget.id, "ignorada");
-    if (ok) toast.success("Sugestão ignorada.");
-    setIgnoreTarget(null);
-  };
-
-  const handleFecharSemAcordoConfirm = async () => {
-    if (!fecharSemAcordoTarget) return;
-    const ok = await updateStatus(fecharSemAcordoTarget.id, "fechada_sem_acordo", {
-      observacoes: fecharObs || null,
-      data_acao: new Date().toISOString(),
-    });
-    if (ok) toast.success("Negociação encerrada sem acordo.");
-    setFecharSemAcordoTarget(null);
-    setFecharObs("");
-  };
-
-  const handleIrAoRanking = (s: Sugestao) => {
-    setHighlightSku(s.sku_codigo_omie);
-    rankingRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
-    setTimeout(() => setHighlightSku(null), 3000);
-  };
-
-  const openConvertDialog = (s: Sugestao) => {
-    setConvertTarget(s);
-    setConvertForm({
-      desconto_perc: 5,
-      volume_minimo: Math.round(Number(s.volume_financeiro_12m ?? 0) / 12) || 1000,
-      volume_unidade: "reais",
-      data_fim: lastDayOfNextMonth(),
-      responsavel: "",
-      canal: "ligacao",
-      observacoes: "",
-    });
-  };
-
-  const handleConverterConfirm = async () => {
-    if (!convertTarget) return;
-    if (convertForm.desconto_perc < 1 || convertForm.desconto_perc > 50) {
-      toast.error("Desconto deve estar entre 1 e 50%.");
-      return;
-    }
-    if (convertForm.volume_minimo <= 0) {
-      toast.error("Volume mínimo deve ser maior que zero.");
-      return;
-    }
-    setConvertSubmitting(true);
-    try {
-      const { data, error } = await supabase.rpc("converter_sugestao_em_campanha_flat" as never, {
-        p_sugestao_id: convertTarget.id,
-        p_desconto_perc: convertForm.desconto_perc,
-        p_volume_minimo: convertForm.volume_minimo,
-        p_volume_unidade: convertForm.volume_unidade,
-        p_data_fim: convertForm.data_fim,
-        p_responsavel_nome: convertForm.responsavel || null,
-        p_canal: convertForm.canal,
-        p_observacoes: convertForm.observacoes || null,
-      } as never);
-      if (error) throw error;
-      toast.success("Sugestão convertida em campanha.");
-      queryClient.invalidateQueries({ queryKey: ["negociacao-paralela-sugestoes"] });
-      const campanhaId = typeof data === "number" || typeof data === "string" ? data : null;
-      if (campanhaId) navigate(`/admin/reposicao/promocoes/${campanhaId}`);
-      else navigate(`/admin/reposicao/promocoes`);
-      setConvertTarget(null);
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      toast.error("Erro ao converter: " + message);
-    } finally {
-      setConvertSubmitting(false);
-    }
-  };
-
-  const handleCriarSugestaoDoRanking = async (r: RankingRow) => {
-    try {
-      const dataGeracao = new Date().toISOString().slice(0, 10);
-      const validoAte = new Date();
-      validoAte.setDate(validoAte.getDate() + 14);
-      const { error } = await supabase.from("sugestao_negociacao_paralela").insert({
-        empresa: r.empresa,
-        sku_codigo_omie: r.sku_codigo_omie,
-        sku_descricao: r.sku_descricao,
-        motivo: "score_alto_ciclo_semanal",
-        motivo_detalhes: { criado_via: "ui_ranking", categoria_ranking: r.categoria },
-        score_final: r.score_final,
-        volume_financeiro_12m: r.volume_financeiro_12m,
-        preco_medio_unitario: r.preco_medio_unitario,
-        promocoes_12m: r.promocoes_12m,
-        perc_meses_com_promo: r.perc_meses_com_promo,
-        status: "nova",
-        data_geracao: dataGeracao,
-        valido_ate: validoAte.toISOString().slice(0, 10),
-      });
-      if (error) throw error;
-      toast.success(`Sugestão criada para ${r.sku_codigo_omie}.`);
-      queryClient.invalidateQueries({ queryKey: ["negociacao-paralela-sugestoes"] });
-      queryClient.invalidateQueries({ queryKey: ["negociacao-paralela-sugestoes-count"] });
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      toast.error("Erro ao criar sugestão: " + message);
-    }
-  };
-
-  const toggleSet = <T,>(set: Set<T>, value: T): Set<T> => {
-    const next = new Set(set);
-    if (next.has(value)) next.delete(value);
-    else next.add(value);
-    return next;
-  };
+  const {
+    PAGE_SIZE,
+    rankingRef,
+    statusFiltro,
+    categoriaFiltro,
+    ordenacao,
+    setOrdenacao,
+    toggleStatusFiltro,
+    toggleCategoriaFiltro,
+    rankingCategoriaFiltro,
+    toggleRankingCategoria,
+    rankingComSugestao,
+    setRankingComSugestao,
+    rankingBusca,
+    onRankingBuscaChange,
+    setRankingPagina,
+    highlightSku,
+    gerando,
+    refreshing,
+    ignoreTarget,
+    setIgnoreTarget,
+    fecharSemAcordoTarget,
+    setFecharSemAcordoTarget,
+    fecharObs,
+    setFecharObs,
+    convertTarget,
+    setConvertTarget,
+    convertForm,
+    setConvertForm,
+    convertSubmitting,
+    loadingSugestoes,
+    loadingRanking,
+    skusComSugestao,
+    sugestoesFiltradas,
+    distribuicao,
+    rankingFiltrado,
+    totalPaginas,
+    paginaAtual,
+    rankingPagina_,
+    ultimaAtualizacao,
+    rankingMap,
+    handleGerarSugestoes,
+    handleRefreshRanking,
+    handleMarcarVisualizada,
+    handleMarcarEmAndamento,
+    handleIgnorarConfirm,
+    handleFecharSemAcordoConfirm,
+    handleIrAoRanking,
+    openConvertDialog,
+    handleConverterConfirm,
+    handleCriarSugestaoDoRanking,
+  } = useNegociacaoParalela();
 
   return (
     <div className="container mx-auto py-6 space-y-6 max-w-screen-2xl">
@@ -439,62 +140,14 @@ export default function AdminReposicaoNegociacaoParalela() {
         </div>
 
         {/* Filtros */}
-        <div className="flex flex-wrap items-center gap-2">
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button variant="outline" size="sm">
-                Status ({statusFiltro.size})
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent>
-              <DropdownMenuLabel>Filtrar por status</DropdownMenuLabel>
-              <DropdownMenuSeparator />
-              {STATUS_LIST.map((st) => (
-                <DropdownMenuCheckboxItem
-                  key={st.value}
-                  checked={statusFiltro.has(st.value)}
-                  onCheckedChange={() => setStatusFiltro((prev) => toggleSet(prev, st.value))}
-                  onSelect={(e) => e.preventDefault()}
-                >
-                  {st.label}
-                </DropdownMenuCheckboxItem>
-              ))}
-            </DropdownMenuContent>
-          </DropdownMenu>
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button variant="outline" size="sm">
-                Categoria ({categoriaFiltro.size})
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent>
-              <DropdownMenuLabel>Filtrar por categoria</DropdownMenuLabel>
-              <DropdownMenuSeparator />
-              {(["prioritario", "forte", "moderado"] as Categoria[]).map((c) => (
-                <DropdownMenuCheckboxItem
-                  key={c}
-                  checked={categoriaFiltro.has(c)}
-                  onCheckedChange={() => setCategoriaFiltro((prev) => toggleSet(prev, c))}
-                  onSelect={(e) => e.preventDefault()}
-                >
-                  {categoriaLabel(c)}
-                </DropdownMenuCheckboxItem>
-              ))}
-            </DropdownMenuContent>
-          </DropdownMenu>
-          <Select value={ordenacao} onValueChange={(v) => setOrdenacao(v as OrdenacaoKey)}>
-            <SelectTrigger className="w-[200px] h-9">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {ORDENACOES.map((o) => (
-                <SelectItem key={o.value} value={o.value}>
-                  {o.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
+        <SugestoesToolbar
+          statusFiltro={statusFiltro}
+          onToggleStatus={toggleStatusFiltro}
+          categoriaFiltro={categoriaFiltro}
+          onToggleCategoria={toggleCategoriaFiltro}
+          ordenacao={ordenacao}
+          onOrdenacaoChange={setOrdenacao}
+        />
 
         {loadingSugestoes ? (
           <div className="flex items-center justify-center py-12 text-muted-foreground">
@@ -556,72 +209,17 @@ export default function AdminReposicaoNegociacaoParalela() {
         </div>
 
         {/* Distribuição */}
-        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
-          {(["prioritario", "forte", "moderado", "fraco"] as Categoria[]).map((c) => (
-            <Card key={c}>
-              <CardContent className="py-3">
-                <div className="flex items-center justify-between gap-2">
-                  <Badge variant="outline" className={cn("uppercase text-[10px]", categoriaBadgeClass(c))}>
-                    {categoriaLabel(c)}
-                  </Badge>
-                  <span className="text-xl font-semibold">{distribuicao[c]}</span>
-                </div>
-              </CardContent>
-            </Card>
-          ))}
-        </div>
+        <DistribuicaoCards distribuicao={distribuicao} />
 
         {/* Filtros ranking */}
-        <div className="flex flex-wrap items-center gap-2">
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button variant="outline" size="sm">
-                Categoria ({rankingCategoriaFiltro.size})
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent>
-              <DropdownMenuLabel>Filtrar por categoria</DropdownMenuLabel>
-              <DropdownMenuSeparator />
-              {CATEGORIAS.map((c) => (
-                <DropdownMenuCheckboxItem
-                  key={c.value}
-                  checked={rankingCategoriaFiltro.has(c.value)}
-                  onCheckedChange={() =>
-                    setRankingCategoriaFiltro((prev) => toggleSet(prev, c.value))
-                  }
-                  onSelect={(e) => e.preventDefault()}
-                >
-                  {c.label}
-                </DropdownMenuCheckboxItem>
-              ))}
-            </DropdownMenuContent>
-          </DropdownMenu>
-          <Select
-            value={rankingComSugestao}
-            onValueChange={(v) => setRankingComSugestao(v as "sim" | "nao" | "ambos")}
-          >
-            <SelectTrigger className="w-[180px] h-9">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="ambos">Com/sem sugestão</SelectItem>
-              <SelectItem value="sim">Com sugestão ativa</SelectItem>
-              <SelectItem value="nao">Sem sugestão ativa</SelectItem>
-            </SelectContent>
-          </Select>
-          <div className="relative flex-1 min-w-[220px] max-w-md">
-            <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-            <Input
-              placeholder="Buscar por SKU ou descrição..."
-              value={rankingBusca}
-              onChange={(e) => {
-                setRankingBusca(e.target.value);
-                setRankingPagina(1);
-              }}
-              className="pl-8 h-9"
-            />
-          </div>
-        </div>
+        <RankingToolbar
+          rankingCategoriaFiltro={rankingCategoriaFiltro}
+          onToggleCategoria={toggleRankingCategoria}
+          rankingComSugestao={rankingComSugestao}
+          onComSugestaoChange={setRankingComSugestao}
+          rankingBusca={rankingBusca}
+          onBuscaChange={onRankingBuscaChange}
+        />
 
         {/* Tabela */}
         <RankingTable
@@ -635,34 +233,14 @@ export default function AdminReposicaoNegociacaoParalela() {
         />
 
         {/* Paginação */}
-        <div className="flex items-center justify-between flex-wrap gap-3">
-          <p className="text-xs text-muted-foreground">
-            Mostrando {rankingFiltrado.length === 0 ? 0 : (paginaAtual - 1) * PAGE_SIZE + 1}–
-            {Math.min(paginaAtual * PAGE_SIZE, rankingFiltrado.length)} de {rankingFiltrado.length} SKUs
-            ranqueados
-          </p>
-          <div className="flex items-center gap-2">
-            <Button
-              variant="outline"
-              size="sm"
-              disabled={paginaAtual === 1}
-              onClick={() => setRankingPagina((p) => Math.max(1, p - 1))}
-            >
-              Anterior
-            </Button>
-            <span className="text-xs text-muted-foreground">
-              {paginaAtual} / {totalPaginas}
-            </span>
-            <Button
-              variant="outline"
-              size="sm"
-              disabled={paginaAtual >= totalPaginas}
-              onClick={() => setRankingPagina((p) => Math.min(totalPaginas, p + 1))}
-            >
-              Próxima
-            </Button>
-          </div>
-        </div>
+        <RankingPaginacao
+          paginaAtual={paginaAtual}
+          totalPaginas={totalPaginas}
+          pageSize={PAGE_SIZE}
+          totalFiltrado={rankingFiltrado.length}
+          onAnterior={() => setRankingPagina((p) => Math.max(1, p - 1))}
+          onProxima={() => setRankingPagina((p) => Math.min(totalPaginas, p + 1))}
+        />
       </section>
 
       {/* Dialog: ignorar */}


### PR DESCRIPTION
## Resumo
- Split estrutural do god-component `AdminReposicaoNegociacaoParalela` (702→**280** linhas), preservando 100% do comportamento (move verbatim).
- Camada de dados/lógica isolada no hook **`useNegociacaoParalela`** (estado, 2 queries, 6 memos derivados, ~12 handlers) — padrão `useRoutePlanner` do §10.
- JSX quebrado em componentes presentacionais controlados: **`SugestoesToolbar`**, **`RankingToolbar`**, **`DistribuicaoCards`**, **`RankingPaginacao`**.
- `toggleSet` (genérico, puro) movido para `helpers.ts`.
- Os leaf components (`SugestaoCard`, `RankingTable`, `dialogs`) já existiam (PR #157/#160) e recebem as mesmas props.

## Verificação
- `bunx tsc --noEmit` = 0 erros
- `bunx eslint` nos arquivos tocados = 0
- `bun run test` = **668 passed** (126 files); +16 testes novos (componentes puros + `toggleSet`)
- `bun run build` = exit 0
- Revisão independente de fidelidade (subagente): **FIEL 1:1**, zero divergências de comportamento.

## Test plan
- [x] tsc / eslint / vitest / build verdes
- [x] Revisão 1:1 confirmando comportamento idêntico

🤖 Generated with [Claude Code](https://claude.com/claude-code)