### PR TITLE
docs(ts-strict): cleanup do claim — lote 3 mergeado + progresso 463/668

### DIFF
--- a/docs/strict-migration-lanes.md
+++ b/docs/strict-migration-lanes.md
@@ -11,7 +11,7 @@
 - **`no-explicit-any` no repo: 0.** A fase de eliminação de `any` está **concluída**
   (src + edge functions + tests). Convergência de várias sessões + lotes deste claim.
 - **Fase atual: PROMOÇÃO** — adicionar arquivos strict-clean ao `include` do
-  `tsconfig.strict.json`. Progresso: **~409 / 629** arquivos src (~65%).
+  `tsconfig.strict.json`. Progresso: **~463 / 668** arquivos src (~69%).
 - Edge functions (`supabase/functions/`): lint zerado também (any + prefer-const +
   no-empty + no-unused-expressions). Restam só 4 `ban-ts-comment` com eslint-disable
   **justificado** (`@ts-ignore` do `EdgeRuntime` — NÃO trocar pra `@ts-expect-error`,
@@ -77,9 +77,13 @@ subgrafos sujos (`noUnusedLocals`/`strictNullChecks`) → cascata. **Promova lea
   AdminReposicaoSessao{Aplicacao,Historico,Confirmacao}, AdminDesTrimestreAtual, AdminStandardProcesses,
   FinanceiroCapitalGiro, AdminKnowledgeBase, TintCorantes, FinanceiroAnalise, AdminOrderDetail, Telefonia,
   IntelligenceDashboard, Index).
-- 🔵 **`feat/strict-promote-pages-lote3`** (sessão determined-allen, 2026-05-24): mais pages leaf por
-  lote empírico. **NÃO toco** Customer360 (lane refactor/customer360-split), pages farmer (lane farmer),
-  nem `services/financeiro*`. Append-only no `include`.
+- ✅ **`feat/strict-promote-pages-lote3`** (sessão determined-allen, 2026-05-24, #232 MERGEADO):
+  3 pages leaf de verdade (Orders, AdminVendorSipCredentials, AdminReposicaoHistorico). Triagem do
+  batch revelou que a maioria das pages "pequenas" restantes são **hubs com `lazy(() => import())`**
+  (não-leaf — ver lição acima) ou têm dead-code/typing próprios. Deferidas p/ próximos lotes:
+  hubs (PerformanceHub, GestaoAdmin, TintIntegracao/Catalogo, VendasFerramentas, AdminReposicaoParametros)
+  e pages com fix próprio (Auth, AdminAjuda, AdminPriceTable, Support, ToolPublicHistory,
+  AdminReposicaoSessaoPedidos, AdminStandardProcessNew).
 - 🔵 **`feat/strict-promote-lib-leaf`** (sessão cranky-driscoll, 2026-05-23): lote leaf não-farmer —
   `lib/call-session/aggregate-customer-profile`, `lib/sip/sip-client`, `lib/transcription/{deepgram-client,transcription-engine}`,
   `components/customer360/format`, `components/financeiro/dashboard/format`, `components/portalSayerlack/types`,


### PR DESCRIPTION
## Resumo

Cleanup de coordenação no `docs/strict-migration-lanes.md` (docs-only, sem código):

- Flip do marcador **🔵 → ✅** do `feat/strict-promote-pages-lote3` (já MERGEADO no #232) — evita que próximas sessões pensem que a lane de pages está em voo.
- Atualiza a contagem de progresso da fase de promoção: **~463 / 668 (~69%)** (era ~409/629).
- Registra as pages deferidas (hubs com `lazy()` + pages com fix próprio) para os próximos lotes.

## Test plan

- [x] docs-only — sem impacto em tipos/build/test
- [ ] CI `validate` verde