### PR TITLE
refactor(reposicao): split CicloHojePanel (728→159) em hook + componentes

### DIFF
--- a/src/components/reposicao/CicloHojePanel.tsx
+++ b/src/components/reposicao/CicloHojePanel.tsx
@@ -1,331 +1,26 @@
-import { lazy, Suspense, useEffect, useMemo, useState } from "react";
-import { useQueryClient } from "@tanstack/react-query";
-import { toast } from "sonner";
-import {
-  AlertTriangle,
-  Check,
-  CheckCircle2,
-  Info,
-  ListChecks,
-  Loader2,
-  Pencil,
-  Search,
-  X,
-  XCircle,
-  Zap,
-} from "lucide-react";
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
+import { lazy, Suspense } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
-import { Input } from "@/components/ui/input";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import {
   Table,
   TableBody,
-  TableCell,
   TableHead,
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-import { supabase } from "@/integrations/supabase/client";
-import { formatBRL, logAudit } from "@/lib/reposicao";
-import { calcApprovalSuggestion } from "@/lib/reposicao/approvalSuggestion";
 import type { ColKey, PedidoItem } from "@/types/reposicao";
-import { ColumnConfigPopover } from "./ColumnConfig";
 import { TabFallback } from "./TabFallback";
+import { type CicloFilters } from "./cicloHoje/types";
+import { useCicloHoje } from "./cicloHoje/useCicloHoje";
+import { PedidoRow } from "./cicloHoje/PedidoRow";
+import { FiltersToolbar } from "./cicloHoje/FiltersToolbar";
+import { AutoApproveDialog } from "./cicloHoje/AutoApproveDialog";
+import { BatchActionsBar } from "./cicloHoje/BatchActionsBar";
+
+// Re-exporta ALL para preservar o import existente (AdminReposicaoSessaoPedidos).
+export { ALL } from "./cicloHoje/types";
 
 const AdminReposicaoPedidos = lazy(() => import("@/pages/AdminReposicaoPedidos"));
-
-export const ALL = "__all__";
-
-type ConfLevel = "alta" | "media" | "baixa";
-
-function inferConfianca(r: PedidoItem): { level: ConfLevel; reason: string } {
-  const s = (r.status ?? "").toLowerCase();
-  if (s.includes("pendente_aprovacao")) {
-    return { level: "alta", reason: "Pedido pendente gerado pelos guardrails do ciclo." };
-  }
-  if (s.includes("disparado") || s.includes("aprovado")) {
-    return { level: "alta", reason: "Pedido já aprovado/disparado." };
-  }
-  if (s.includes("cancel")) {
-    return { level: "baixa", reason: "Pedido cancelado — comprar geraria sobrestoque." };
-  }
-  if (s.includes("bloque")) {
-    return { level: "baixa", reason: "Bloqueado por guardrail." };
-  }
-  return {
-    level: "media",
-    reason: "Sem dados de cobertura no registro; confiança média por padrão (status pendente).",
-  };
-}
-
-function PrecoCell({ row }: { row: PedidoItem }) {
-  const atual = Number(row.valor_total ?? 0);
-  const anterior = Number(row.pedido_anterior_valor ?? NaN);
-  if (!Number.isFinite(anterior) || anterior === 0) {
-    return <span className="font-medium">{formatBRL(atual)}</span>;
-  }
-  const deltaPct = ((atual - anterior) / anterior) * 100;
-  const tone =
-    Math.abs(deltaPct) < 0.5
-      ? "text-muted-foreground"
-      : deltaPct < 0
-        ? "text-status-success"
-        : "text-destructive";
-  return (
-    <div className="flex flex-col items-end">
-      <span className="font-medium">{formatBRL(atual)}</span>
-      <span className={`text-[11px] ${tone}`}>
-        {deltaPct > 0 ? "+" : ""}
-        {deltaPct.toFixed(1)}%
-      </span>
-    </div>
-  );
-}
-
-function ConfiancaBadge({ row }: { row: PedidoItem }) {
-  const { level, reason } = inferConfianca(row);
-  const map = {
-    alta: { label: "Alta", cls: "bg-status-success-bg text-status-success border-status-success/40" },
-    media: { label: "Média", cls: "bg-status-warning-bg text-status-warning border-status-warning/40" },
-    baixa: { label: "Baixa", cls: "bg-muted text-muted-foreground border-border" },
-  } as const;
-  const m = map[level];
-  return (
-    <TooltipProvider delayDuration={200}>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <span
-            className={`inline-flex items-center gap-1 rounded-md border px-2 py-0.5 text-[11px] font-medium ${m.cls}`}
-          >
-            <Info className="h-3 w-3" /> {m.label}
-          </span>
-        </TooltipTrigger>
-        <TooltipContent className="max-w-[240px] text-xs">{reason}</TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
-  );
-}
-
-function PedidoRow({
-  row,
-  reviewMode,
-  selected,
-  onToggle,
-  cols,
-  user,
-  onChanged,
-}: {
-  row: PedidoItem;
-  reviewMode: boolean;
-  selected: boolean;
-  onToggle: () => void;
-  cols: Record<ColKey, boolean>;
-  user: { id?: string; email?: string | null } | null;
-  onChanged: () => void;
-}) {
-  const [qty, setQty] = useState<number>(Number(row.num_skus ?? 0));
-  const [busy, setBusy] = useState<null | "approve" | "reject">(null);
-  const [editingAuto, setEditingAuto] = useState(false);
-  const suggestion = calcApprovalSuggestion(row);
-  const showInlineEditor = suggestion.mode === "review" || editingAuto;
-
-  useEffect(() => {
-    setQty(Number(row.num_skus ?? 0));
-  }, [row.num_skus]);
-
-  const isApproved = !!row.aprovado_em;
-  const isRejected = !!row.cancelado_em;
-
-  const rowBg = isApproved
-    ? "bg-status-success-bg/40 hover:bg-status-success-bg"
-    : isRejected
-      ? "bg-destructive/5 hover:bg-destructive/10"
-      : "";
-
-  const act = async (kind: "approve" | "reject") => {
-    if (busy) return;
-    setBusy(kind);
-    const nowIso = new Date().toISOString();
-    const who = user?.email ?? user?.id ?? "cockpit";
-    try {
-      const patch =
-        kind === "approve"
-          ? {
-              aprovado_em: nowIso,
-              aprovado_por: who,
-              status: "aprovado_aguardando_disparo" as const,
-              num_skus: qty,
-            }
-          : {
-              cancelado_em: nowIso,
-              cancelado_por: who,
-              status: "cancelado" as const,
-              justificativa_cancelamento: "Rejeitado inline no Cockpit",
-            };
-      const { error } = await supabase
-        .from("pedido_compra_sugerido")
-        .update(patch)
-        .eq("id", row.id);
-      if (error) throw error;
-      await logAudit({
-        userId: user?.id ?? null,
-        action: kind === "approve" ? "Aprovação inline" : "Rejeição inline",
-        result: "Sucesso",
-        metadata: { id: row.id, qty },
-      });
-      toast.success(kind === "approve" ? "Pedido aprovado" : "Pedido rejeitado");
-      onChanged();
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      await logAudit({
-        userId: user?.id ?? null,
-        action: kind === "approve" ? "Aprovação inline" : "Rejeição inline",
-        result: `Erro: ${msg}`,
-        metadata: { id: row.id },
-      });
-      toast.error("Falha na operação");
-    } finally {
-      setBusy(null);
-    }
-  };
-
-  return (
-    <TableRow data-state={selected ? "selected" : undefined} className={rowBg}>
-      {reviewMode && (
-        <TableCell>
-          <Checkbox checked={selected} onCheckedChange={onToggle} />
-        </TableCell>
-      )}
-      {cols.fornecedor && (
-        <TableCell className="text-sm">{row.fornecedor_nome ?? "—"}</TableCell>
-      )}
-      {cols.grupo && (
-        <TableCell className="text-xs text-muted-foreground">
-          {row.grupo_codigo ?? "—"}
-        </TableCell>
-      )}
-      {cols.skus && <TableCell className="text-right">{row.num_skus ?? 0}</TableCell>}
-      {cols.valor && (
-        <TableCell className="text-right font-medium">{formatBRL(row.valor_total)}</TableCell>
-      )}
-      {cols.preco && (
-        <TableCell className="text-right">
-          <PrecoCell row={row} />
-        </TableCell>
-      )}
-      {cols.confianca && (
-        <TableCell>
-          <ConfiancaBadge row={row} />
-        </TableCell>
-      )}
-      {cols.status && (
-        <TableCell>
-          <Badge variant="secondary">{row.status ?? "—"}</Badge>
-        </TableCell>
-      )}
-      {cols.qtdAprovada && (
-        <TableCell>
-          <div className="flex items-center gap-1.5 justify-end">
-            {suggestion.mode === "auto" && !showInlineEditor ? (
-              <>
-                <Badge
-                  variant="secondary"
-                  className="gap-1 bg-primary/10 text-primary border-primary/20"
-                >
-                  <Zap className="h-3 w-3" /> Auto
-                </Badge>
-                <span className="w-10 text-right tabular-nums font-medium">{qty}</span>
-                <Button
-                  size="icon"
-                  variant="outline"
-                  className="h-8 w-8"
-                  onClick={() => setEditingAuto(true)}
-                  title="Editar quantidade antes de aprovar"
-                >
-                  <Pencil className="h-3.5 w-3.5" />
-                </Button>
-              </>
-            ) : (
-              <>
-                {suggestion.mode === "review" && (
-                  <TooltipProvider delayDuration={200}>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <Badge
-                          variant="outline"
-                          className="gap-1 border-status-warning/40 text-status-warning bg-status-warning-bg"
-                        >
-                          <AlertTriangle className="h-3 w-3" /> Revisar
-                        </Badge>
-                      </TooltipTrigger>
-                      <TooltipContent className="max-w-[260px] text-xs">
-                        {suggestion.reasons.join(" · ")}
-                      </TooltipContent>
-                    </Tooltip>
-                  </TooltipProvider>
-                )}
-                <Input
-                  type="number"
-                  min={0}
-                  value={qty}
-                  disabled={isApproved || isRejected || busy !== null}
-                  onChange={(e) => setQty(Number(e.target.value) || 0)}
-                  onFocus={(e) => e.currentTarget.select()}
-                  className="h-8 w-20 text-right"
-                />
-                <Button
-                  size="icon"
-                  variant="ghost"
-                  className="h-8 w-8 text-status-success hover:text-status-success hover:bg-status-success-bg"
-                  disabled={isApproved || busy !== null}
-                  onClick={() => act("approve")}
-                  title="Aprovar"
-                >
-                  {busy === "approve" ? (
-                    <Loader2 className="h-4 w-4 animate-spin" />
-                  ) : (
-                    <Check className="h-4 w-4" />
-                  )}
-                </Button>
-                <Button
-                  size="icon"
-                  variant="ghost"
-                  className="h-8 w-8 text-destructive hover:bg-destructive/10"
-                  disabled={isRejected || busy !== null}
-                  onClick={() => act("reject")}
-                  title="Rejeitar"
-                >
-                  {busy === "reject" ? (
-                    <Loader2 className="h-4 w-4 animate-spin" />
-                  ) : (
-                    <X className="h-4 w-4" />
-                  )}
-                </Button>
-              </>
-            )}
-          </div>
-        </TableCell>
-      )}
-    </TableRow>
-  );
-}
 
 export function CicloHojePanel({
   user,
@@ -343,8 +38,8 @@ export function CicloHojePanel({
   user: { id?: string; email?: string | null } | null;
   reviewMode: boolean;
   setReviewMode: (b: boolean) => void;
-  filters: { search: string; fornecedor: string; status: string };
-  setFilters: (f: { search: string; fornecedor: string; status: string }) => void;
+  filters: CicloFilters;
+  setFilters: (f: CicloFilters) => void;
   filteredItems: PedidoItem[];
   fornecedores: string[];
   statuses: string[];
@@ -352,223 +47,40 @@ export function CicloHojePanel({
   cols: Record<ColKey, boolean>;
   onColChange: (k: ColKey, v: boolean) => void;
 }) {
-  const queryClient = useQueryClient();
-  const [selected, setSelected] = useState<Set<number>>(new Set());
-  const [busy, setBusy] = useState(false);
-  const [confirmAuto, setConfirmAuto] = useState(false);
-
-  useEffect(() => {
-    if (!reviewMode) setSelected(new Set());
-  }, [reviewMode]);
-
-  const allChecked = filteredItems.length > 0 && filteredItems.every((i) => selected.has(i.id));
-  const toggleAll = () => {
-    if (allChecked) setSelected(new Set());
-    else setSelected(new Set(filteredItems.map((i) => i.id)));
-  };
-  const toggleOne = (id: number) => {
-    const next = new Set(selected);
-    if (next.has(id)) next.delete(id);
-    else next.add(id);
-    setSelected(next);
-  };
-
-  const totalSelectedValue = filteredItems
-    .filter((i) => selected.has(i.id))
-    .reduce((s, r) => s + Number(r.valor_total ?? 0), 0);
-
-  const eligibleAutoItems = useMemo(
-    () =>
-      filteredItems.filter(
-        (item) =>
-          calcApprovalSuggestion(item).mode === "auto" && !item.aprovado_em && !item.cancelado_em,
-      ),
-    [filteredItems],
-  );
-
-  const autoApprovalGroups = useMemo(() => {
-    const map = new Map<string, number>();
-    eligibleAutoItems.forEach((item) => {
-      const fornecedor = item.fornecedor_nome ?? "Sem fornecedor";
-      map.set(fornecedor, (map.get(fornecedor) ?? 0) + Number(item.num_skus ?? 0));
-    });
-    return Array.from(map.entries()).map(([fornecedor, qtd]) => ({ fornecedor, qtd }));
-  }, [eligibleAutoItems]);
-
-  const manualReviewItems = useMemo(
-    () =>
-      filteredItems
-        .filter((item) => !item.aprovado_em && !item.cancelado_em)
-        .map((item) => ({ item, suggestion: calcApprovalSuggestion(item) }))
-        .filter(({ suggestion }) => suggestion.mode === "review"),
-    [filteredItems],
-  );
-
-  const invalidate = () => {
-    queryClient.invalidateQueries({ queryKey: ["cockpit-itens-dia"] });
-    queryClient.invalidateQueries({ queryKey: ["cockpit-current-step"] });
-    queryClient.invalidateQueries({ queryKey: ["reposicao-pedidos"] });
-  };
-
-  const runBatch = async (kind: "approve" | "reject") => {
-    if (selected.size === 0 || busy) return;
-    setBusy(true);
-    const ids = Array.from(selected);
-    const nowIso = new Date().toISOString();
-    const who = user?.email ?? user?.id ?? "cockpit";
-    try {
-      const patch =
-        kind === "approve"
-          ? {
-              aprovado_em: nowIso,
-              aprovado_por: who,
-              status: "aprovado_aguardando_disparo" as const,
-            }
-          : {
-              cancelado_em: nowIso,
-              cancelado_por: who,
-              status: "cancelado" as const,
-              justificativa_cancelamento: "Rejeitado em lote no Cockpit",
-            };
-      const { error } = await supabase
-        .from("pedido_compra_sugerido")
-        .update(patch)
-        .in("id", ids);
-      if (error) throw error;
-
-      await logAudit({
-        userId: user?.id ?? null,
-        action: kind === "approve" ? "Aprovação em lote" : "Rejeição em lote",
-        result: "Sucesso",
-        metadata: { ids, count: ids.length },
-      });
-      toast.success(
-        `${ids.length} pedido(s) ${kind === "approve" ? "aprovado(s)" : "rejeitado(s)"}`,
-      );
-      setSelected(new Set());
-      invalidate();
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      await logAudit({
-        userId: user?.id ?? null,
-        action: kind === "approve" ? "Aprovação em lote" : "Rejeição em lote",
-        result: `Erro: ${msg}`,
-        metadata: { ids },
-      });
-      toast.error("Falha na operação em lote");
-    } finally {
-      setBusy(false);
-    }
-  };
-
-  const runAutoApprove = async () => {
-    if (eligibleAutoItems.length === 0 || busy) return;
-    setBusy(true);
-    const ids = eligibleAutoItems.map((item) => item.id);
-    const nowIso = new Date().toISOString();
-    const who = user?.email ?? user?.id ?? "cockpit";
-    try {
-      const { error } = await supabase
-        .from("pedido_compra_sugerido")
-        .update({
-          aprovado_em: nowIso,
-          aprovado_por: who,
-          status: "aprovado_aguardando_disparo",
-        })
-        .in("id", ids);
-      if (error) throw error;
-      await logAudit({
-        userId: user?.id ?? null,
-        action: "Aprovação automática — critérios atingidos",
-        result: "Sucesso",
-        metadata: { ids, count: ids.length },
-      });
-      toast.success(`${ids.length} pedido(s) aprovado(s) automaticamente`);
-      setConfirmAuto(false);
-      invalidate();
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      await logAudit({
-        userId: user?.id ?? null,
-        action: "Aprovação automática — critérios atingidos",
-        result: `Erro: ${msg}`,
-        metadata: { ids },
-      });
-      toast.error("Falha ao aprovar elegíveis");
-    } finally {
-      setBusy(false);
-    }
-  };
-
-  const clearFilters = () => setFilters({ search: "", fornecedor: ALL, status: ALL });
+  const {
+    selected,
+    busy,
+    confirmAuto,
+    setConfirmAuto,
+    allChecked,
+    toggleAll,
+    toggleOne,
+    totalSelectedValue,
+    eligibleAutoItems,
+    autoApprovalGroups,
+    manualReviewItems,
+    invalidate,
+    runBatch,
+    runAutoApprove,
+    clearFilters,
+  } = useCicloHoje({ user, reviewMode, filteredItems, setFilters });
 
   return (
     <div className="space-y-4">
-      <div className="flex flex-wrap items-center gap-2 rounded-md border p-2 bg-card">
-        <div className="relative flex-1 min-w-[200px]">
-          <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-          <Input
-            value={filters.search}
-            onChange={(e) => setFilters({ ...filters, search: e.target.value })}
-            placeholder="Buscar SKU, descrição ou fornecedor..."
-            className="pl-8 h-9"
-          />
-        </div>
-        <Select
-          value={filters.fornecedor}
-          onValueChange={(v) => setFilters({ ...filters, fornecedor: v })}
-        >
-          <SelectTrigger className="w-[180px] h-9">
-            <SelectValue placeholder="Fornecedor" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value={ALL}>Todos os fornecedores</SelectItem>
-            {fornecedores.map((f) => (
-              <SelectItem key={f} value={f}>
-                {f}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-        <Select value={filters.status} onValueChange={(v) => setFilters({ ...filters, status: v })}>
-          <SelectTrigger className="w-[180px] h-9">
-            <SelectValue placeholder="Status" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value={ALL}>Todos os status</SelectItem>
-            {statuses.map((s) => (
-              <SelectItem key={s} value={s}>
-                {s}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-        <Button size="sm" variant="ghost" onClick={clearFilters}>
-          Limpar filtros
-        </Button>
-        <Button
-          size="sm"
-          onClick={() => setConfirmAuto(true)}
-          disabled={eligibleAutoItems.length === 0 || busy}
-          title={
-            eligibleAutoItems.length === 0
-              ? "Nenhum item elegível para aprovação automática"
-              : "Aprovar automaticamente apenas os itens classificados como Auto"
-          }
-        >
-          <Zap className="h-4 w-4 mr-1.5" />
-          Aprovar elegíveis ({eligibleAutoItems.length})
-        </Button>
-        <Button
-          size="sm"
-          variant={reviewMode ? "default" : "outline"}
-          onClick={() => setReviewMode(!reviewMode)}
-        >
-          <ListChecks className="h-4 w-4 mr-1.5" />
-          Modo revisão
-        </Button>
-        <ColumnConfigPopover cols={cols} onChange={onColChange} />
-      </div>
+      <FiltersToolbar
+        filters={filters}
+        setFilters={setFilters}
+        fornecedores={fornecedores}
+        statuses={statuses}
+        eligibleAutoCount={eligibleAutoItems.length}
+        busy={busy}
+        onOpenAuto={() => setConfirmAuto(true)}
+        reviewMode={reviewMode}
+        setReviewMode={setReviewMode}
+        cols={cols}
+        onColChange={onColChange}
+        onClearFilters={clearFilters}
+      />
 
       <Card>
         <CardHeader className="py-3">
@@ -619,110 +131,29 @@ export function CicloHojePanel({
         </CardContent>
       </Card>
 
-      <Dialog open={confirmAuto} onOpenChange={setConfirmAuto}>
-        <DialogContent className="max-w-lg">
-          <DialogHeader>
-            <DialogTitle className="flex items-center gap-2">
-              <Zap className="h-5 w-5 text-primary" /> Aprovar elegíveis automaticamente
-            </DialogTitle>
-            <DialogDescription>
-              {eligibleAutoItems.length} pedido(s) serão aprovados automaticamente.
-            </DialogDescription>
-          </DialogHeader>
-          <div className="max-h-56 overflow-y-auto rounded-md border">
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Fornecedor</TableHead>
-                  <TableHead className="text-right">Qtd</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {autoApprovalGroups.map((group) => (
-                  <TableRow key={group.fornecedor}>
-                    <TableCell>{group.fornecedor}</TableCell>
-                    <TableCell className="text-right tabular-nums">{group.qtd}</TableCell>
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          </div>
-
-          {manualReviewItems.length > 0 && (
-            <div className="space-y-2 pt-2">
-              <div className="flex items-center gap-2 text-sm font-medium">
-                <AlertTriangle className="h-4 w-4 text-status-warning" />
-                {manualReviewItems.length} pedido(s) ficarão para aprovação manual
-              </div>
-              <div className="max-h-40 overflow-y-auto rounded-md border">
-                <Table>
-                  <TableHeader>
-                    <TableRow>
-                      <TableHead>Fornecedor</TableHead>
-                      <TableHead>Motivo</TableHead>
-                    </TableRow>
-                  </TableHeader>
-                  <TableBody>
-                    {manualReviewItems.map(({ item, suggestion }) => (
-                      <TableRow key={item.id}>
-                        <TableCell className="text-xs">
-                          {item.fornecedor_nome ?? "Sem fornecedor"}
-                        </TableCell>
-                        <TableCell className="text-xs text-muted-foreground">
-                          {suggestion.reasons.join("; ")}
-                        </TableCell>
-                      </TableRow>
-                    ))}
-                  </TableBody>
-                </Table>
-              </div>
-            </div>
-          )}
-          <div className="flex justify-end gap-2 pt-2">
-            <Button variant="outline" onClick={() => setConfirmAuto(false)} disabled={busy}>
-              Cancelar
-            </Button>
-            <Button onClick={runAutoApprove} disabled={busy || eligibleAutoItems.length === 0}>
-              {busy && <Loader2 className="h-4 w-4 mr-1.5 animate-spin" />}
-              Confirmar aprovação automática
-            </Button>
-          </div>
-        </DialogContent>
-      </Dialog>
+      <AutoApproveDialog
+        open={confirmAuto}
+        onOpenChange={setConfirmAuto}
+        eligibleCount={eligibleAutoItems.length}
+        autoApprovalGroups={autoApprovalGroups}
+        manualReviewItems={manualReviewItems}
+        busy={busy}
+        onConfirm={runAutoApprove}
+      />
 
       <Suspense fallback={<TabFallback />}>
         <AdminReposicaoPedidos />
       </Suspense>
 
       {reviewMode && selected.size > 0 && (
-        <div className="fixed bottom-0 left-0 right-0 z-40 border-t bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/80 shadow-lg">
-          <div className="container max-w-7xl mx-auto px-4 py-3 flex flex-wrap items-center justify-between gap-3">
-            <div className="text-sm">
-              <span className="font-semibold">{selected.size}</span> itens selecionados |{" "}
-              <span className="font-semibold">Total: {formatBRL(totalSelectedValue)}</span>
-            </div>
-            <div className="flex gap-2">
-              <Button
-                size="sm"
-                variant="outline"
-                onClick={() => runBatch("reject")}
-                disabled={busy}
-              >
-                <XCircle className="h-4 w-4 mr-1.5" /> Rejeitar selecionados
-              </Button>
-              <Button size="sm" onClick={() => runBatch("approve")} disabled={busy}>
-                {busy ? (
-                  <Loader2 className="h-4 w-4 mr-1.5 animate-spin" />
-                ) : (
-                  <CheckCircle2 className="h-4 w-4 mr-1.5" />
-                )}
-                Aprovar selecionados
-              </Button>
-            </div>
-          </div>
-        </div>
+        <BatchActionsBar
+          count={selected.size}
+          totalValue={totalSelectedValue}
+          busy={busy}
+          onReject={() => runBatch("reject")}
+          onApprove={() => runBatch("approve")}
+        />
       )}
     </div>
   );
 }
-

--- a/src/components/reposicao/cicloHoje/AutoApproveDialog.tsx
+++ b/src/components/reposicao/cicloHoje/AutoApproveDialog.tsx
@@ -1,0 +1,113 @@
+// Dialog de confirmação de aprovação automática (elegíveis + itens que ficam para revisão manual).
+// Extraído verbatim de src/components/reposicao/CicloHojePanel.tsx (god-component split).
+import { AlertTriangle, Loader2, Zap } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import type { AutoApprovalGroup, ManualReviewItem } from "./useCicloHoje";
+
+interface AutoApproveDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  eligibleCount: number;
+  autoApprovalGroups: AutoApprovalGroup[];
+  manualReviewItems: ManualReviewItem[];
+  busy: boolean;
+  onConfirm: () => void;
+}
+
+export function AutoApproveDialog({
+  open,
+  onOpenChange,
+  eligibleCount,
+  autoApprovalGroups,
+  manualReviewItems,
+  busy,
+  onConfirm,
+}: AutoApproveDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Zap className="h-5 w-5 text-primary" /> Aprovar elegíveis automaticamente
+          </DialogTitle>
+          <DialogDescription>
+            {eligibleCount} pedido(s) serão aprovados automaticamente.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="max-h-56 overflow-y-auto rounded-md border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Fornecedor</TableHead>
+                <TableHead className="text-right">Qtd</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {autoApprovalGroups.map((group) => (
+                <TableRow key={group.fornecedor}>
+                  <TableCell>{group.fornecedor}</TableCell>
+                  <TableCell className="text-right tabular-nums">{group.qtd}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+
+        {manualReviewItems.length > 0 && (
+          <div className="space-y-2 pt-2">
+            <div className="flex items-center gap-2 text-sm font-medium">
+              <AlertTriangle className="h-4 w-4 text-status-warning" />
+              {manualReviewItems.length} pedido(s) ficarão para aprovação manual
+            </div>
+            <div className="max-h-40 overflow-y-auto rounded-md border">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Fornecedor</TableHead>
+                    <TableHead>Motivo</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {manualReviewItems.map(({ item, suggestion }) => (
+                    <TableRow key={item.id}>
+                      <TableCell className="text-xs">
+                        {item.fornecedor_nome ?? "Sem fornecedor"}
+                      </TableCell>
+                      <TableCell className="text-xs text-muted-foreground">
+                        {suggestion.reasons.join("; ")}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          </div>
+        )}
+        <div className="flex justify-end gap-2 pt-2">
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={busy}>
+            Cancelar
+          </Button>
+          <Button onClick={onConfirm} disabled={busy || eligibleCount === 0}>
+            {busy && <Loader2 className="h-4 w-4 mr-1.5 animate-spin" />}
+            Confirmar aprovação automática
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/reposicao/cicloHoje/BatchActionsBar.tsx
+++ b/src/components/reposicao/cicloHoje/BatchActionsBar.tsx
@@ -1,0 +1,39 @@
+// Barra fixa de ações em lote (aparece no modo revisão com itens selecionados).
+// Extraída verbatim de src/components/reposicao/CicloHojePanel.tsx (god-component split).
+import { CheckCircle2, Loader2, XCircle } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { formatBRL } from "@/lib/reposicao";
+
+interface BatchActionsBarProps {
+  count: number;
+  totalValue: number;
+  busy: boolean;
+  onReject: () => void;
+  onApprove: () => void;
+}
+
+export function BatchActionsBar({ count, totalValue, busy, onReject, onApprove }: BatchActionsBarProps) {
+  return (
+    <div className="fixed bottom-0 left-0 right-0 z-40 border-t bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/80 shadow-lg">
+      <div className="container max-w-7xl mx-auto px-4 py-3 flex flex-wrap items-center justify-between gap-3">
+        <div className="text-sm">
+          <span className="font-semibold">{count}</span> itens selecionados |{" "}
+          <span className="font-semibold">Total: {formatBRL(totalValue)}</span>
+        </div>
+        <div className="flex gap-2">
+          <Button size="sm" variant="outline" onClick={onReject} disabled={busy}>
+            <XCircle className="h-4 w-4 mr-1.5" /> Rejeitar selecionados
+          </Button>
+          <Button size="sm" onClick={onApprove} disabled={busy}>
+            {busy ? (
+              <Loader2 className="h-4 w-4 mr-1.5 animate-spin" />
+            ) : (
+              <CheckCircle2 className="h-4 w-4 mr-1.5" />
+            )}
+            Aprovar selecionados
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/reposicao/cicloHoje/FiltersToolbar.tsx
+++ b/src/components/reposicao/cicloHoje/FiltersToolbar.tsx
@@ -1,0 +1,113 @@
+// Barra de filtros + ações do painel "Ciclo de hoje".
+// Extraída verbatim de src/components/reposicao/CicloHojePanel.tsx (god-component split).
+import { ListChecks, Search, Zap } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import type { ColKey } from "@/types/reposicao";
+import { ColumnConfigPopover } from "../ColumnConfig";
+import { ALL, type CicloFilters } from "./types";
+
+interface FiltersToolbarProps {
+  filters: CicloFilters;
+  setFilters: (f: CicloFilters) => void;
+  fornecedores: string[];
+  statuses: string[];
+  eligibleAutoCount: number;
+  busy: boolean;
+  onOpenAuto: () => void;
+  reviewMode: boolean;
+  setReviewMode: (b: boolean) => void;
+  cols: Record<ColKey, boolean>;
+  onColChange: (k: ColKey, v: boolean) => void;
+  onClearFilters: () => void;
+}
+
+export function FiltersToolbar({
+  filters,
+  setFilters,
+  fornecedores,
+  statuses,
+  eligibleAutoCount,
+  busy,
+  onOpenAuto,
+  reviewMode,
+  setReviewMode,
+  cols,
+  onColChange,
+  onClearFilters,
+}: FiltersToolbarProps) {
+  return (
+    <div className="flex flex-wrap items-center gap-2 rounded-md border p-2 bg-card">
+      <div className="relative flex-1 min-w-[200px]">
+        <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+        <Input
+          value={filters.search}
+          onChange={(e) => setFilters({ ...filters, search: e.target.value })}
+          placeholder="Buscar SKU, descrição ou fornecedor..."
+          className="pl-8 h-9"
+        />
+      </div>
+      <Select
+        value={filters.fornecedor}
+        onValueChange={(v) => setFilters({ ...filters, fornecedor: v })}
+      >
+        <SelectTrigger className="w-[180px] h-9">
+          <SelectValue placeholder="Fornecedor" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value={ALL}>Todos os fornecedores</SelectItem>
+          {fornecedores.map((f) => (
+            <SelectItem key={f} value={f}>
+              {f}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <Select value={filters.status} onValueChange={(v) => setFilters({ ...filters, status: v })}>
+        <SelectTrigger className="w-[180px] h-9">
+          <SelectValue placeholder="Status" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value={ALL}>Todos os status</SelectItem>
+          {statuses.map((s) => (
+            <SelectItem key={s} value={s}>
+              {s}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <Button size="sm" variant="ghost" onClick={onClearFilters}>
+        Limpar filtros
+      </Button>
+      <Button
+        size="sm"
+        onClick={onOpenAuto}
+        disabled={eligibleAutoCount === 0 || busy}
+        title={
+          eligibleAutoCount === 0
+            ? "Nenhum item elegível para aprovação automática"
+            : "Aprovar automaticamente apenas os itens classificados como Auto"
+        }
+      >
+        <Zap className="h-4 w-4 mr-1.5" />
+        Aprovar elegíveis ({eligibleAutoCount})
+      </Button>
+      <Button
+        size="sm"
+        variant={reviewMode ? "default" : "outline"}
+        onClick={() => setReviewMode(!reviewMode)}
+      >
+        <ListChecks className="h-4 w-4 mr-1.5" />
+        Modo revisão
+      </Button>
+      <ColumnConfigPopover cols={cols} onChange={onColChange} />
+    </div>
+  );
+}

--- a/src/components/reposicao/cicloHoje/PedidoRow.tsx
+++ b/src/components/reposicao/cicloHoje/PedidoRow.tsx
@@ -1,0 +1,220 @@
+// Linha de pedido do ciclo (estado local de quantidade + aprovação/rejeição inline).
+// Extraída verbatim de src/components/reposicao/CicloHojePanel.tsx (god-component split).
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+import { AlertTriangle, Check, Loader2, Pencil, X, Zap } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+import { TableCell, TableRow } from "@/components/ui/table";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { supabase } from "@/integrations/supabase/client";
+import { formatBRL, logAudit } from "@/lib/reposicao";
+import { calcApprovalSuggestion } from "@/lib/reposicao/approvalSuggestion";
+import type { ColKey, PedidoItem } from "@/types/reposicao";
+import { PrecoCell, ConfiancaBadge } from "./PedidoRowCells";
+
+export function PedidoRow({
+  row,
+  reviewMode,
+  selected,
+  onToggle,
+  cols,
+  user,
+  onChanged,
+}: {
+  row: PedidoItem;
+  reviewMode: boolean;
+  selected: boolean;
+  onToggle: () => void;
+  cols: Record<ColKey, boolean>;
+  user: { id?: string; email?: string | null } | null;
+  onChanged: () => void;
+}) {
+  const [qty, setQty] = useState<number>(Number(row.num_skus ?? 0));
+  const [busy, setBusy] = useState<null | "approve" | "reject">(null);
+  const [editingAuto, setEditingAuto] = useState(false);
+  const suggestion = calcApprovalSuggestion(row);
+  const showInlineEditor = suggestion.mode === "review" || editingAuto;
+
+  useEffect(() => {
+    setQty(Number(row.num_skus ?? 0));
+  }, [row.num_skus]);
+
+  const isApproved = !!row.aprovado_em;
+  const isRejected = !!row.cancelado_em;
+
+  const rowBg = isApproved
+    ? "bg-status-success-bg/40 hover:bg-status-success-bg"
+    : isRejected
+      ? "bg-destructive/5 hover:bg-destructive/10"
+      : "";
+
+  const act = async (kind: "approve" | "reject") => {
+    if (busy) return;
+    setBusy(kind);
+    const nowIso = new Date().toISOString();
+    const who = user?.email ?? user?.id ?? "cockpit";
+    try {
+      const patch =
+        kind === "approve"
+          ? {
+              aprovado_em: nowIso,
+              aprovado_por: who,
+              status: "aprovado_aguardando_disparo" as const,
+              num_skus: qty,
+            }
+          : {
+              cancelado_em: nowIso,
+              cancelado_por: who,
+              status: "cancelado" as const,
+              justificativa_cancelamento: "Rejeitado inline no Cockpit",
+            };
+      const { error } = await supabase
+        .from("pedido_compra_sugerido")
+        .update(patch)
+        .eq("id", row.id);
+      if (error) throw error;
+      await logAudit({
+        userId: user?.id ?? null,
+        action: kind === "approve" ? "Aprovação inline" : "Rejeição inline",
+        result: "Sucesso",
+        metadata: { id: row.id, qty },
+      });
+      toast.success(kind === "approve" ? "Pedido aprovado" : "Pedido rejeitado");
+      onChanged();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      await logAudit({
+        userId: user?.id ?? null,
+        action: kind === "approve" ? "Aprovação inline" : "Rejeição inline",
+        result: `Erro: ${msg}`,
+        metadata: { id: row.id },
+      });
+      toast.error("Falha na operação");
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  return (
+    <TableRow data-state={selected ? "selected" : undefined} className={rowBg}>
+      {reviewMode && (
+        <TableCell>
+          <Checkbox checked={selected} onCheckedChange={onToggle} />
+        </TableCell>
+      )}
+      {cols.fornecedor && (
+        <TableCell className="text-sm">{row.fornecedor_nome ?? "—"}</TableCell>
+      )}
+      {cols.grupo && (
+        <TableCell className="text-xs text-muted-foreground">
+          {row.grupo_codigo ?? "—"}
+        </TableCell>
+      )}
+      {cols.skus && <TableCell className="text-right">{row.num_skus ?? 0}</TableCell>}
+      {cols.valor && (
+        <TableCell className="text-right font-medium">{formatBRL(row.valor_total)}</TableCell>
+      )}
+      {cols.preco && (
+        <TableCell className="text-right">
+          <PrecoCell row={row} />
+        </TableCell>
+      )}
+      {cols.confianca && (
+        <TableCell>
+          <ConfiancaBadge row={row} />
+        </TableCell>
+      )}
+      {cols.status && (
+        <TableCell>
+          <Badge variant="secondary">{row.status ?? "—"}</Badge>
+        </TableCell>
+      )}
+      {cols.qtdAprovada && (
+        <TableCell>
+          <div className="flex items-center gap-1.5 justify-end">
+            {suggestion.mode === "auto" && !showInlineEditor ? (
+              <>
+                <Badge
+                  variant="secondary"
+                  className="gap-1 bg-primary/10 text-primary border-primary/20"
+                >
+                  <Zap className="h-3 w-3" /> Auto
+                </Badge>
+                <span className="w-10 text-right tabular-nums font-medium">{qty}</span>
+                <Button
+                  size="icon"
+                  variant="outline"
+                  className="h-8 w-8"
+                  onClick={() => setEditingAuto(true)}
+                  title="Editar quantidade antes de aprovar"
+                >
+                  <Pencil className="h-3.5 w-3.5" />
+                </Button>
+              </>
+            ) : (
+              <>
+                {suggestion.mode === "review" && (
+                  <TooltipProvider delayDuration={200}>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Badge
+                          variant="outline"
+                          className="gap-1 border-status-warning/40 text-status-warning bg-status-warning-bg"
+                        >
+                          <AlertTriangle className="h-3 w-3" /> Revisar
+                        </Badge>
+                      </TooltipTrigger>
+                      <TooltipContent className="max-w-[260px] text-xs">
+                        {suggestion.reasons.join(" · ")}
+                      </TooltipContent>
+                    </Tooltip>
+                  </TooltipProvider>
+                )}
+                <Input
+                  type="number"
+                  min={0}
+                  value={qty}
+                  disabled={isApproved || isRejected || busy !== null}
+                  onChange={(e) => setQty(Number(e.target.value) || 0)}
+                  onFocus={(e) => e.currentTarget.select()}
+                  className="h-8 w-20 text-right"
+                />
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  className="h-8 w-8 text-status-success hover:text-status-success hover:bg-status-success-bg"
+                  disabled={isApproved || busy !== null}
+                  onClick={() => act("approve")}
+                  title="Aprovar"
+                >
+                  {busy === "approve" ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : (
+                    <Check className="h-4 w-4" />
+                  )}
+                </Button>
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  className="h-8 w-8 text-destructive hover:bg-destructive/10"
+                  disabled={isRejected || busy !== null}
+                  onClick={() => act("reject")}
+                  title="Rejeitar"
+                >
+                  {busy === "reject" ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : (
+                    <X className="h-4 w-4" />
+                  )}
+                </Button>
+              </>
+            )}
+          </div>
+        </TableCell>
+      )}
+    </TableRow>
+  );
+}

--- a/src/components/reposicao/cicloHoje/PedidoRowCells.tsx
+++ b/src/components/reposicao/cicloHoje/PedidoRowCells.tsx
@@ -1,0 +1,55 @@
+// Células de apresentação da linha de pedido (preço com delta + badge de confiança).
+// Extraídas verbatim de src/components/reposicao/CicloHojePanel.tsx (god-component split).
+import { Info } from "lucide-react";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { formatBRL } from "@/lib/reposicao";
+import type { PedidoItem } from "@/types/reposicao";
+import { inferConfianca } from "./confianca";
+
+export function PrecoCell({ row }: { row: PedidoItem }) {
+  const atual = Number(row.valor_total ?? 0);
+  const anterior = Number(row.pedido_anterior_valor ?? NaN);
+  if (!Number.isFinite(anterior) || anterior === 0) {
+    return <span className="font-medium">{formatBRL(atual)}</span>;
+  }
+  const deltaPct = ((atual - anterior) / anterior) * 100;
+  const tone =
+    Math.abs(deltaPct) < 0.5
+      ? "text-muted-foreground"
+      : deltaPct < 0
+        ? "text-status-success"
+        : "text-destructive";
+  return (
+    <div className="flex flex-col items-end">
+      <span className="font-medium">{formatBRL(atual)}</span>
+      <span className={`text-[11px] ${tone}`}>
+        {deltaPct > 0 ? "+" : ""}
+        {deltaPct.toFixed(1)}%
+      </span>
+    </div>
+  );
+}
+
+export function ConfiancaBadge({ row }: { row: PedidoItem }) {
+  const { level, reason } = inferConfianca(row);
+  const map = {
+    alta: { label: "Alta", cls: "bg-status-success-bg text-status-success border-status-success/40" },
+    media: { label: "Média", cls: "bg-status-warning-bg text-status-warning border-status-warning/40" },
+    baixa: { label: "Baixa", cls: "bg-muted text-muted-foreground border-border" },
+  } as const;
+  const m = map[level];
+  return (
+    <TooltipProvider delayDuration={200}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span
+            className={`inline-flex items-center gap-1 rounded-md border px-2 py-0.5 text-[11px] font-medium ${m.cls}`}
+          >
+            <Info className="h-3 w-3" /> {m.label}
+          </span>
+        </TooltipTrigger>
+        <TooltipContent className="max-w-[240px] text-xs">{reason}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}

--- a/src/components/reposicao/cicloHoje/__tests__/AutoApproveDialog.test.tsx
+++ b/src/components/reposicao/cicloHoje/__tests__/AutoApproveDialog.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { AutoApproveDialog } from "../AutoApproveDialog";
+import type { ManualReviewItem } from "../useCicloHoje";
+import type { PedidoItem } from "@/types/reposicao";
+
+const manual: ManualReviewItem[] = [
+  {
+    item: { id: 7, fornecedor_nome: "ACME" } as unknown as PedidoItem,
+    suggestion: { mode: "review", reasons: ["Aumento de preço", "Cobertura alta"] } as ManualReviewItem["suggestion"],
+  },
+];
+
+function setup(overrides: Partial<React.ComponentProps<typeof AutoApproveDialog>> = {}) {
+  const props: React.ComponentProps<typeof AutoApproveDialog> = {
+    open: true,
+    onOpenChange: vi.fn(),
+    eligibleCount: 5,
+    autoApprovalGroups: [{ fornecedor: "ACME", qtd: 12 }],
+    manualReviewItems: [],
+    busy: false,
+    onConfirm: vi.fn(),
+    ...overrides,
+  };
+  render(<AutoApproveDialog {...props} />);
+  return props;
+}
+
+describe("AutoApproveDialog", () => {
+  it("mostra a contagem de elegíveis e os grupos por fornecedor", () => {
+    setup();
+    expect(screen.getByText(/5 pedido\(s\) serão aprovados automaticamente/)).toBeTruthy();
+    expect(screen.getByText("ACME")).toBeTruthy();
+    expect(screen.getByText("12")).toBeTruthy();
+  });
+
+  it("lista itens que ficam para revisão manual com o motivo", () => {
+    setup({ manualReviewItems: manual });
+    expect(screen.getByText(/1 pedido\(s\) ficarão para aprovação manual/)).toBeTruthy();
+    expect(screen.getByText("Aumento de preço; Cobertura alta")).toBeTruthy();
+  });
+
+  it("dispara onConfirm e onOpenChange(false) ao cancelar", () => {
+    const props = setup();
+    fireEvent.click(screen.getByRole("button", { name: /Confirmar aprovação automática/ }));
+    fireEvent.click(screen.getByRole("button", { name: /Cancelar/ }));
+    expect(props.onConfirm).toHaveBeenCalledTimes(1);
+    expect(props.onOpenChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/src/components/reposicao/cicloHoje/__tests__/BatchActionsBar.test.tsx
+++ b/src/components/reposicao/cicloHoje/__tests__/BatchActionsBar.test.tsx
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { BatchActionsBar } from "../BatchActionsBar";
+
+describe("BatchActionsBar", () => {
+  it("mostra contagem e total selecionado", () => {
+    render(<BatchActionsBar count={3} totalValue={1500} busy={false} onReject={() => {}} onApprove={() => {}} />);
+    expect(screen.getByText("3")).toBeTruthy();
+    expect(screen.getByText(/Total:/)).toBeTruthy();
+    expect(screen.getByText(/1\.500,00/)).toBeTruthy();
+  });
+
+  it("dispara onReject e onApprove", () => {
+    const onReject = vi.fn();
+    const onApprove = vi.fn();
+    render(<BatchActionsBar count={2} totalValue={10} busy={false} onReject={onReject} onApprove={onApprove} />);
+    fireEvent.click(screen.getByRole("button", { name: /Rejeitar selecionados/ }));
+    fireEvent.click(screen.getByRole("button", { name: /Aprovar selecionados/ }));
+    expect(onReject).toHaveBeenCalledTimes(1);
+    expect(onApprove).toHaveBeenCalledTimes(1);
+  });
+
+  it("desabilita os botões quando busy", () => {
+    render(<BatchActionsBar count={2} totalValue={10} busy onReject={() => {}} onApprove={() => {}} />);
+    expect(screen.getByRole("button", { name: /Rejeitar selecionados/ })).toHaveProperty("disabled", true);
+    expect(screen.getByRole("button", { name: /Aprovar selecionados/ })).toHaveProperty("disabled", true);
+  });
+});

--- a/src/components/reposicao/cicloHoje/__tests__/FiltersToolbar.test.tsx
+++ b/src/components/reposicao/cicloHoje/__tests__/FiltersToolbar.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { FiltersToolbar } from "../FiltersToolbar";
+import { ALL } from "../types";
+import type { ColKey } from "@/types/reposicao";
+
+const cols = {
+  fornecedor: true, grupo: true, skus: true, valor: true,
+  preco: true, confianca: true, status: true, qtdAprovada: true,
+} as Record<ColKey, boolean>;
+
+function setup(overrides: Partial<React.ComponentProps<typeof FiltersToolbar>> = {}) {
+  const props: React.ComponentProps<typeof FiltersToolbar> = {
+    filters: { search: "", fornecedor: ALL, status: ALL },
+    setFilters: vi.fn(),
+    fornecedores: ["ACME"],
+    statuses: ["pendente_aprovacao"],
+    eligibleAutoCount: 4,
+    busy: false,
+    onOpenAuto: vi.fn(),
+    reviewMode: false,
+    setReviewMode: vi.fn(),
+    cols,
+    onColChange: vi.fn(),
+    onClearFilters: vi.fn(),
+    ...overrides,
+  };
+  render(<FiltersToolbar {...props} />);
+  return props;
+}
+
+describe("FiltersToolbar", () => {
+  it("mostra a contagem de elegíveis no botão", () => {
+    setup();
+    expect(screen.getByRole("button", { name: /Aprovar elegíveis \(4\)/ })).toBeTruthy();
+  });
+
+  it("dispara setFilters ao digitar na busca", () => {
+    const props = setup();
+    fireEvent.change(screen.getByPlaceholderText(/Buscar SKU/), { target: { value: "disco" } });
+    expect(props.setFilters).toHaveBeenCalledWith({ search: "disco", fornecedor: ALL, status: ALL });
+  });
+
+  it("dispara onOpenAuto e onClearFilters", () => {
+    const props = setup();
+    fireEvent.click(screen.getByRole("button", { name: /Aprovar elegíveis/ }));
+    fireEvent.click(screen.getByRole("button", { name: /Limpar filtros/ }));
+    expect(props.onOpenAuto).toHaveBeenCalledTimes(1);
+    expect(props.onClearFilters).toHaveBeenCalledTimes(1);
+  });
+
+  it("desabilita 'Aprovar elegíveis' quando não há elegíveis", () => {
+    setup({ eligibleAutoCount: 0 });
+    expect(screen.getByRole("button", { name: /Aprovar elegíveis \(0\)/ })).toHaveProperty("disabled", true);
+  });
+
+  it("alterna o modo revisão", () => {
+    const props = setup({ reviewMode: false });
+    fireEvent.click(screen.getByRole("button", { name: /Modo revisão/ }));
+    expect(props.setReviewMode).toHaveBeenCalledWith(true);
+  });
+});

--- a/src/components/reposicao/cicloHoje/__tests__/PedidoRow.test.tsx
+++ b/src/components/reposicao/cicloHoje/__tests__/PedidoRow.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { PedidoRow } from "../PedidoRow";
+import type { ColKey, PedidoItem } from "@/types/reposicao";
+
+function renderRow(opts: { reviewMode?: boolean; cols?: Partial<Record<ColKey, boolean>>; onToggle?: () => void } = {}) {
+  const cols = {
+    fornecedor: true, grupo: false, skus: true, valor: true,
+    preco: false, confianca: false, status: true, qtdAprovada: false,
+    ...opts.cols,
+  } as Record<ColKey, boolean>;
+  const row = {
+    id: 1,
+    fornecedor_nome: "ACME Ltda",
+    grupo_codigo: "G1",
+    num_skus: 7,
+    valor_total: 250,
+    status: "pendente_aprovacao",
+    aprovado_em: null,
+    cancelado_em: null,
+    pedido_anterior_valor: null,
+  } as unknown as PedidoItem;
+  return render(
+    <table>
+      <tbody>
+        <PedidoRow
+          row={row}
+          reviewMode={opts.reviewMode ?? false}
+          selected={false}
+          onToggle={opts.onToggle ?? (() => {})}
+          cols={cols}
+          user={{ id: "u1", email: "a@b.c" }}
+          onChanged={() => {}}
+        />
+      </tbody>
+    </table>,
+  );
+}
+
+describe("PedidoRow", () => {
+  it("renderiza fornecedor, skus, valor e status", () => {
+    renderRow();
+    expect(screen.getByText("ACME Ltda")).toBeTruthy();
+    expect(screen.getByText("7")).toBeTruthy();
+    expect(screen.getByText(/250,00/)).toBeTruthy();
+    expect(screen.getByText("pendente_aprovacao")).toBeTruthy();
+  });
+
+  it("no modo revisão, mostra o checkbox e dispara onToggle", () => {
+    const onToggle = vi.fn();
+    renderRow({ reviewMode: true, onToggle });
+    const checkbox = screen.getByRole("checkbox");
+    fireEvent.click(checkbox);
+    expect(onToggle).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/reposicao/cicloHoje/__tests__/PedidoRowCells.test.tsx
+++ b/src/components/reposicao/cicloHoje/__tests__/PedidoRowCells.test.tsx
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { PrecoCell, ConfiancaBadge } from "../PedidoRowCells";
+import type { PedidoItem } from "@/types/reposicao";
+
+function row(partial: Partial<PedidoItem>): PedidoItem {
+  return partial as unknown as PedidoItem;
+}
+
+describe("PrecoCell", () => {
+  it("sem valor anterior: mostra só o valor atual (sem delta)", () => {
+    render(<PrecoCell row={row({ valor_total: 100, pedido_anterior_valor: null })} />);
+    expect(screen.getByText(/100,00/)).toBeTruthy();
+    expect(screen.queryByText(/%/)).toBeNull();
+  });
+
+  it("com valor anterior: mostra delta percentual positivo", () => {
+    render(<PrecoCell row={row({ valor_total: 110, pedido_anterior_valor: 100 })} />);
+    expect(screen.getByText("+10.0%")).toBeTruthy();
+  });
+
+  it("com queda de preço: delta negativo", () => {
+    render(<PrecoCell row={row({ valor_total: 90, pedido_anterior_valor: 100 })} />);
+    expect(screen.getByText("-10.0%")).toBeTruthy();
+  });
+});
+
+describe("ConfiancaBadge", () => {
+  it("renderiza o rótulo conforme o status", () => {
+    render(<ConfiancaBadge row={row({ status: "pendente_aprovacao" })} />);
+    expect(screen.getByText("Alta")).toBeTruthy();
+  });
+
+  it("status cancelado → Baixa", () => {
+    render(<ConfiancaBadge row={row({ status: "cancelado" })} />);
+    expect(screen.getByText("Baixa")).toBeTruthy();
+  });
+});

--- a/src/components/reposicao/cicloHoje/__tests__/confianca.test.ts
+++ b/src/components/reposicao/cicloHoje/__tests__/confianca.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { inferConfianca } from "../confianca";
+import type { PedidoItem } from "@/types/reposicao";
+
+function row(status: string | null): PedidoItem {
+  return { status } as unknown as PedidoItem;
+}
+
+describe("inferConfianca", () => {
+  it("pendente_aprovacao → alta", () => {
+    expect(inferConfianca(row("pendente_aprovacao")).level).toBe("alta");
+  });
+  it("disparado → alta", () => {
+    expect(inferConfianca(row("disparado")).level).toBe("alta");
+  });
+  it("aprovado → alta", () => {
+    expect(inferConfianca(row("aprovado_aguardando_disparo")).level).toBe("alta");
+  });
+  it("cancelado → baixa", () => {
+    expect(inferConfianca(row("cancelado")).level).toBe("baixa");
+  });
+  it("bloqueado → baixa", () => {
+    expect(inferConfianca(row("bloqueado_guardrail")).level).toBe("baixa");
+  });
+  it("status desconhecido → media", () => {
+    expect(inferConfianca(row("qualquer_coisa")).level).toBe("media");
+  });
+  it("status nulo → media", () => {
+    expect(inferConfianca(row(null)).level).toBe("media");
+  });
+});

--- a/src/components/reposicao/cicloHoje/confianca.ts
+++ b/src/components/reposicao/cicloHoje/confianca.ts
@@ -1,0 +1,24 @@
+// Inferência de confiança de um pedido sugerido (pura).
+// Extraída verbatim de src/components/reposicao/CicloHojePanel.tsx (god-component split).
+import type { PedidoItem } from "@/types/reposicao";
+import type { ConfLevel } from "./types";
+
+export function inferConfianca(r: PedidoItem): { level: ConfLevel; reason: string } {
+  const s = (r.status ?? "").toLowerCase();
+  if (s.includes("pendente_aprovacao")) {
+    return { level: "alta", reason: "Pedido pendente gerado pelos guardrails do ciclo." };
+  }
+  if (s.includes("disparado") || s.includes("aprovado")) {
+    return { level: "alta", reason: "Pedido já aprovado/disparado." };
+  }
+  if (s.includes("cancel")) {
+    return { level: "baixa", reason: "Pedido cancelado — comprar geraria sobrestoque." };
+  }
+  if (s.includes("bloque")) {
+    return { level: "baixa", reason: "Bloqueado por guardrail." };
+  }
+  return {
+    level: "media",
+    reason: "Sem dados de cobertura no registro; confiança média por padrão (status pendente).",
+  };
+}

--- a/src/components/reposicao/cicloHoje/types.ts
+++ b/src/components/reposicao/cicloHoje/types.ts
@@ -1,0 +1,13 @@
+// Constantes e tipos do painel "Ciclo de hoje".
+// Extraídos verbatim de src/components/reposicao/CicloHojePanel.tsx (god-component split).
+// ALL é re-exportado pelo arquivo principal (consumidor: AdminReposicaoSessaoPedidos).
+
+export const ALL = "__all__";
+
+export type ConfLevel = "alta" | "media" | "baixa";
+
+export interface CicloFilters {
+  search: string;
+  fornecedor: string;
+  status: string;
+}

--- a/src/components/reposicao/cicloHoje/useCicloHoje.ts
+++ b/src/components/reposicao/cicloHoje/useCicloHoje.ts
@@ -1,0 +1,197 @@
+// Lógica do painel "Ciclo de hoje" (seleção, aprovação em lote/automática, memos derivados).
+// Extraída verbatim de src/components/reposicao/CicloHojePanel.tsx (god-component split).
+import { useEffect, useMemo, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { supabase } from "@/integrations/supabase/client";
+import { logAudit } from "@/lib/reposicao";
+import { calcApprovalSuggestion } from "@/lib/reposicao/approvalSuggestion";
+import type { PedidoItem } from "@/types/reposicao";
+import { ALL, type CicloFilters } from "./types";
+
+export interface AutoApprovalGroup {
+  fornecedor: string;
+  qtd: number;
+}
+
+export type ManualReviewItem = {
+  item: PedidoItem;
+  suggestion: ReturnType<typeof calcApprovalSuggestion>;
+};
+
+interface UseCicloHojeArgs {
+  user: { id?: string; email?: string | null } | null;
+  reviewMode: boolean;
+  filteredItems: PedidoItem[];
+  setFilters: (f: CicloFilters) => void;
+}
+
+export function useCicloHoje({ user, reviewMode, filteredItems, setFilters }: UseCicloHojeArgs) {
+  const queryClient = useQueryClient();
+  const [selected, setSelected] = useState<Set<number>>(new Set());
+  const [busy, setBusy] = useState(false);
+  const [confirmAuto, setConfirmAuto] = useState(false);
+
+  useEffect(() => {
+    if (!reviewMode) setSelected(new Set());
+  }, [reviewMode]);
+
+  const allChecked = filteredItems.length > 0 && filteredItems.every((i) => selected.has(i.id));
+  const toggleAll = () => {
+    if (allChecked) setSelected(new Set());
+    else setSelected(new Set(filteredItems.map((i) => i.id)));
+  };
+  const toggleOne = (id: number) => {
+    const next = new Set(selected);
+    if (next.has(id)) next.delete(id);
+    else next.add(id);
+    setSelected(next);
+  };
+
+  const totalSelectedValue = filteredItems
+    .filter((i) => selected.has(i.id))
+    .reduce((s, r) => s + Number(r.valor_total ?? 0), 0);
+
+  const eligibleAutoItems = useMemo(
+    () =>
+      filteredItems.filter(
+        (item) =>
+          calcApprovalSuggestion(item).mode === "auto" && !item.aprovado_em && !item.cancelado_em,
+      ),
+    [filteredItems],
+  );
+
+  const autoApprovalGroups = useMemo<AutoApprovalGroup[]>(() => {
+    const map = new Map<string, number>();
+    eligibleAutoItems.forEach((item) => {
+      const fornecedor = item.fornecedor_nome ?? "Sem fornecedor";
+      map.set(fornecedor, (map.get(fornecedor) ?? 0) + Number(item.num_skus ?? 0));
+    });
+    return Array.from(map.entries()).map(([fornecedor, qtd]) => ({ fornecedor, qtd }));
+  }, [eligibleAutoItems]);
+
+  const manualReviewItems = useMemo<ManualReviewItem[]>(
+    () =>
+      filteredItems
+        .filter((item) => !item.aprovado_em && !item.cancelado_em)
+        .map((item) => ({ item, suggestion: calcApprovalSuggestion(item) }))
+        .filter(({ suggestion }) => suggestion.mode === "review"),
+    [filteredItems],
+  );
+
+  const invalidate = () => {
+    queryClient.invalidateQueries({ queryKey: ["cockpit-itens-dia"] });
+    queryClient.invalidateQueries({ queryKey: ["cockpit-current-step"] });
+    queryClient.invalidateQueries({ queryKey: ["reposicao-pedidos"] });
+  };
+
+  const runBatch = async (kind: "approve" | "reject") => {
+    if (selected.size === 0 || busy) return;
+    setBusy(true);
+    const ids = Array.from(selected);
+    const nowIso = new Date().toISOString();
+    const who = user?.email ?? user?.id ?? "cockpit";
+    try {
+      const patch =
+        kind === "approve"
+          ? {
+              aprovado_em: nowIso,
+              aprovado_por: who,
+              status: "aprovado_aguardando_disparo" as const,
+            }
+          : {
+              cancelado_em: nowIso,
+              cancelado_por: who,
+              status: "cancelado" as const,
+              justificativa_cancelamento: "Rejeitado em lote no Cockpit",
+            };
+      const { error } = await supabase
+        .from("pedido_compra_sugerido")
+        .update(patch)
+        .in("id", ids);
+      if (error) throw error;
+
+      await logAudit({
+        userId: user?.id ?? null,
+        action: kind === "approve" ? "Aprovação em lote" : "Rejeição em lote",
+        result: "Sucesso",
+        metadata: { ids, count: ids.length },
+      });
+      toast.success(
+        `${ids.length} pedido(s) ${kind === "approve" ? "aprovado(s)" : "rejeitado(s)"}`,
+      );
+      setSelected(new Set());
+      invalidate();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      await logAudit({
+        userId: user?.id ?? null,
+        action: kind === "approve" ? "Aprovação em lote" : "Rejeição em lote",
+        result: `Erro: ${msg}`,
+        metadata: { ids },
+      });
+      toast.error("Falha na operação em lote");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const runAutoApprove = async () => {
+    if (eligibleAutoItems.length === 0 || busy) return;
+    setBusy(true);
+    const ids = eligibleAutoItems.map((item) => item.id);
+    const nowIso = new Date().toISOString();
+    const who = user?.email ?? user?.id ?? "cockpit";
+    try {
+      const { error } = await supabase
+        .from("pedido_compra_sugerido")
+        .update({
+          aprovado_em: nowIso,
+          aprovado_por: who,
+          status: "aprovado_aguardando_disparo",
+        })
+        .in("id", ids);
+      if (error) throw error;
+      await logAudit({
+        userId: user?.id ?? null,
+        action: "Aprovação automática — critérios atingidos",
+        result: "Sucesso",
+        metadata: { ids, count: ids.length },
+      });
+      toast.success(`${ids.length} pedido(s) aprovado(s) automaticamente`);
+      setConfirmAuto(false);
+      invalidate();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      await logAudit({
+        userId: user?.id ?? null,
+        action: "Aprovação automática — critérios atingidos",
+        result: `Erro: ${msg}`,
+        metadata: { ids },
+      });
+      toast.error("Falha ao aprovar elegíveis");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const clearFilters = () => setFilters({ search: "", fornecedor: ALL, status: ALL });
+
+  return {
+    selected,
+    busy,
+    confirmAuto,
+    setConfirmAuto,
+    allChecked,
+    toggleAll,
+    toggleOne,
+    totalSelectedValue,
+    eligibleAutoItems,
+    autoApprovalGroups,
+    manualReviewItems,
+    invalidate,
+    runBatch,
+    runAutoApprove,
+    clearFilters,
+  };
+}


### PR DESCRIPTION
## Resumo
- Split estrutural de `CicloHojePanel` (728→**159** linhas), preservando 100% do comportamento (move verbatim).
- Lógica do painel isolada no hook **`useCicloHoje`** (seleção, aprovação em lote/automática, memos de elegíveis/grupos/revisão manual, invalidate).
- JSX em componentes presentacionais controlados: **`PedidoRow`** (+`PedidoRowCells`), **`FiltersToolbar`**, **`AutoApproveDialog`**, **`BatchActionsBar`**.
- `inferConfianca` isolada em `cicloHoje/confianca.ts` (pura, testável).
- **`ALL`** re-exportado pelo arquivo principal — `AdminReposicaoSessaoPedidos` continua importando do mesmo módulo, sem churn.

## Verificação
- `bunx tsc --noEmit` = 0 erros
- `bunx eslint` nos arquivos tocados = 0
- `bun run test` = **758 passed** (139 files); +25 testes novos (helper puro + 5 componentes presentacionais)
- `bun run build` = exit 0
- Revisão independente de fidelidade (subagente): **FIEL 1:1**, zero divergências.

## Test plan
- [x] tsc / eslint / vitest / build verdes
- [x] Re-export de ALL preserva consumidor externo
- [x] Revisão 1:1 confirmando comportamento idêntico

🤖 Generated with [Claude Code](https://claude.com/claude-code)