### PR TITLE
chore(settings): allowlist read-only de bun test/typecheck/lint

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,13 @@
 {
+  "permissions": {
+    "allow": [
+      "Bash(bun run test*)",
+      "Bash(bun run typecheck:strict*)",
+      "Bash(bun run vitest*)",
+      "Bash(bun run tsc*)",
+      "Bash(bun lint)"
+    ]
+  },
   "hooks": {
     "PreToolUse": [
       {


### PR DESCRIPTION
## Resumo
- Adiciona um baseline **read-only seguro** ao `.claude/settings.json` compartilhado (antes vazio em `permissions`), reduzindo prompts de "sempre permitir" pro time.
- Só comandos sem efeito colateral: suíte vitest, `typecheck:strict`, `tsc --noEmit` e `bun lint`.

## Patterns adicionados
- `Bash(bun run test*)`
- `Bash(bun run typecheck:strict*)`
- `Bash(bun run vitest*)`
- `Bash(bun run tsc*)`
- `Bash(bun lint)`

## Fora de escopo (deliberadamente)
- Nada que muta estado (`git push`, `bun run build`), nada de execução arbitrária (`bunx`, `deno`, `codex`, `bash`), nada que o Claude Code já auto-aprova (`grep`, `ls`, `git status/log/diff`, `gh pr view/list`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)