### PR TITLE
fix(financeiro-a2): cast valor_inputs como Json no upsert (TS2769)

### DIFF
--- a/src/hooks/useValor.ts
+++ b/src/hooks/useValor.ts
@@ -1,6 +1,7 @@
 // src/hooks/useValor.ts
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
+import type { Json } from '@/integrations/supabase/types';
 import type { ValorEmpresaResult, ValorInputs } from '@/services/financeiroService';
 
 export function useValor(company: string) {
@@ -24,7 +25,7 @@ export function useUpdateValorInputs() {
       const { error } = await supabase
         .from('fin_valor_inputs')
         .upsert(
-          { company, valor_inputs: valor_inputs as unknown as Record<string, unknown>, updated_at: new Date().toISOString() },
+          { company, valor_inputs: valor_inputs as unknown as Json, updated_at: new Date().toISOString() },
           { onConflict: 'company' },
         );
       if (error) throw error;


### PR DESCRIPTION
## Resumo
- `useUpdateValorInputs` (`src/hooks/useValor.ts`) fazia `.upsert({ ... valor_inputs: ... as unknown as Record<string, unknown> })`, mas a coluna `fin_valor_inputs.valor_inputs` é tipada como `Json` no schema gerado do Supabase. `Record<string, unknown>` não casa com `Json`, gerando `TS2769: No overload matches this call` em `bunx tsc --noEmit -p tsconfig.app.json`.
- Troquei o cast para `as unknown as Json` (com import de `@/integrations/supabase/types`), seguindo o padrão idiomático já usado em `useTacticalPlan`, `useBundleEngine`, `useCustomerProcess` e `useSaveStandardProcess`.

## Escopo
- 1 arquivo, +2/-1. Sem mudança de comportamento em runtime (puro cast de tipo).
- Não toca carteira nem outros módulos.

## Test plan
- [x] `bunx tsc --noEmit -p tsconfig.app.json` não reporta mais erro em `useValor.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)