### PR TITLE
refactor(reposicao): split DetalhesModal (707→168) em hook + componentes

### DIFF
--- a/src/components/reposicao/pedidos/CondicaoPagamentoPanel.tsx
+++ b/src/components/reposicao/pedidos/CondicaoPagamentoPanel.tsx
@@ -1,0 +1,87 @@
+// Painel: seleção/edição da condição de pagamento Omie (obrigatória p/ disparo).
+// Extraído verbatim de src/components/reposicao/pedidos/DetalhesModal.tsx (god-component split).
+import { Loader2 } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { PedidoSugerido, CondicaoPagamento } from './types';
+
+interface CondicaoPagamentoPanelProps {
+  pedido: PedidoSugerido;
+  podeEditarCondicao: boolean;
+  condicaoCodigo: string;
+  onCondicaoChange: (codigo: string) => void;
+  condicoes: CondicaoPagamento[];
+  condicaoSelecionada: CondicaoPagamento | null;
+  condicaoMudou: boolean;
+  salvarCondicaoPending: boolean;
+  onSalvarCondicao: () => void;
+}
+
+export function CondicaoPagamentoPanel({
+  pedido,
+  podeEditarCondicao,
+  condicaoCodigo,
+  onCondicaoChange,
+  condicoes,
+  condicaoSelecionada,
+  condicaoMudou,
+  salvarCondicaoPending,
+  onSalvarCondicao,
+}: CondicaoPagamentoPanelProps) {
+  return (
+    <div className="rounded-md border bg-muted/30 p-3 space-y-2">
+      <div className="flex items-center justify-between">
+        <label className="text-sm font-medium">
+          Condição de pagamento Omie
+          {!condicaoSelecionada && <span className="text-destructive ml-1">*</span>}
+        </label>
+        {pedido.condicao_origem && (
+          <Badge variant="outline" className="text-[10px] h-4">
+            origem: {pedido.condicao_origem}
+          </Badge>
+        )}
+      </div>
+      {podeEditarCondicao ? (
+        <div className="flex gap-2">
+          <Select value={condicaoCodigo || undefined} onValueChange={onCondicaoChange}>
+            <SelectTrigger className="flex-1">
+              <SelectValue placeholder="Selecione a condição (obrigatório p/ disparar ao Omie)" />
+            </SelectTrigger>
+            <SelectContent className="max-h-[300px]">
+              {condicoes.map((c) => (
+                <SelectItem key={c.codigo} value={c.codigo}>
+                  <span className="font-mono text-xs mr-2">{c.codigo}</span>
+                  {c.descricao}
+                  {c.num_parcelas ? <span className="text-muted-foreground ml-2">({c.num_parcelas}x)</span> : null}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          {pedido.status === 'aprovado_aguardando_disparo' && condicaoMudou && condicaoSelecionada && (
+            <Button
+              size="sm"
+              variant="secondary"
+              disabled={salvarCondicaoPending}
+              onClick={onSalvarCondicao}
+            >
+              {salvarCondicaoPending && <Loader2 className="w-4 h-4 mr-1 animate-spin" />}
+              Salvar
+            </Button>
+          )}
+        </div>
+      ) : (
+        <div className="text-sm">
+          {pedido.condicao_pagamento_codigo
+            ? <><span className="font-mono text-xs mr-2">{pedido.condicao_pagamento_codigo}</span>{pedido.condicao_pagamento_descricao}</>
+            : <span className="text-muted-foreground italic">não definida</span>}
+        </div>
+      )}
+      {!condicaoSelecionada && podeEditarCondicao && (
+        <p className="text-xs text-destructive">
+          Sem condição selecionada o disparo ao Omie falhará.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/reposicao/pedidos/ConfirmacaoDialogs.tsx
+++ b/src/components/reposicao/pedidos/ConfirmacaoDialogs.tsx
@@ -1,0 +1,86 @@
+// Dialogs de confirmação: remover linha e remover + descontinuar SKU.
+// Extraídos verbatim de src/components/reposicao/pedidos/DetalhesModal.tsx (god-component split).
+import { Loader2 } from 'lucide-react';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { PedidoItem } from './types';
+
+export function RemoverItemDialog({
+  item,
+  onOpenChange,
+  pending,
+  onConfirm,
+}: {
+  item: PedidoItem | null;
+  onOpenChange: (v: boolean) => void;
+  pending: boolean;
+  onConfirm: () => void;
+}) {
+  return (
+    <AlertDialog open={!!item} onOpenChange={(v) => !v && onOpenChange(false)}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Remover este item do pedido?</AlertDialogTitle>
+          <AlertDialogDescription>
+            SKU <span className="font-mono">{item?.sku_codigo_omie}</span> — {item?.sku_descricao ?? '—'}.
+            <br />O valor total do pedido será recalculado. Se for o último item, o pedido será cancelado automaticamente.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={pending}>Cancelar</AlertDialogCancel>
+          <AlertDialogAction disabled={pending} onClick={onConfirm}>
+            {pending && <Loader2 className="w-4 h-4 mr-1 animate-spin" />}
+            Remover
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}
+
+export function DescontinuarItemDialog({
+  item,
+  onOpenChange,
+  pending,
+  onConfirm,
+}: {
+  item: PedidoItem | null;
+  onOpenChange: (v: boolean) => void;
+  pending: boolean;
+  onConfirm: () => void;
+}) {
+  return (
+    <AlertDialog open={!!item} onOpenChange={(v) => !v && onOpenChange(false)}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Descontinuar SKU permanentemente?</AlertDialogTitle>
+          <AlertDialogDescription>
+            SKU <span className="font-mono">{item?.sku_codigo_omie}</span> — {item?.sku_descricao ?? '—'}.
+            <br />
+            <strong className="text-destructive">Tem certeza?</strong> Este SKU não será mais incluído em ciclos futuros de reposição automática.
+            A linha também será removida deste pedido.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={pending}>Voltar</AlertDialogCancel>
+          <AlertDialogAction
+            disabled={pending}
+            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            onClick={onConfirm}
+          >
+            {pending && <Loader2 className="w-4 h-4 mr-1 animate-spin" />}
+            Descontinuar e remover
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/components/reposicao/pedidos/DetalhesModal.tsx
+++ b/src/components/reposicao/pedidos/DetalhesModal.tsx
@@ -1,146 +1,17 @@
-import { useEffect, useMemo, useState } from 'react';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { supabase } from '@/integrations/supabase/client';
-import { useAuth } from '@/contexts/AuthContext';
 import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
-import { Input } from '@/components/ui/input';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from '@/components/ui/alert-dialog';
-import { AlertTriangle, Ban, Loader2, Trash2 } from 'lucide-react';
-import { toast } from 'sonner';
-import { format } from 'date-fns';
-import { ptBR } from 'date-fns/locale';
-import { logger } from '@/lib/logger';
-import { cn } from '@/lib/utils';
-import { PedidoSugerido, PedidoItem, CondicaoPagamento, StatusEnvioPortal } from './types';
-import { getEstoqueZoneClass, formatBRL, formatTime, portalStatusMeta } from './shared';
+import { AlertTriangle, Loader2 } from 'lucide-react';
+import { PedidoSugerido } from './types';
+import { formatBRL, formatTime } from './shared';
 import { StatusBadge, SplitInfo } from './badges';
-
-/* ─── Painel: Status de envio ao portal ─── */
-function PortalStatusPanel({ pedido }: { pedido: PedidoSugerido | null }) {
-  if (!pedido) return null;
-  const status = (pedido.status_envio_portal ?? 'nao_aplicavel') as StatusEnvioPortal;
-  const meta = portalStatusMeta[status] ?? portalStatusMeta.nao_aplicavel;
-  const tentativas = pedido.portal_tentativas ?? 0;
-  const fmt = (iso: string | null | undefined) => {
-    if (!iso) return '—';
-    try { return format(new Date(iso), "dd/MM/yyyy HH:mm", { locale: ptBR }); } catch { return '—'; }
-  };
-  return (
-    <div className="rounded-md border bg-muted/20 p-3 space-y-2">
-      <div className="flex items-center justify-between">
-        <div className="text-sm font-medium">Status de envio ao portal</div>
-        <span className={cn(
-          'inline-flex items-center rounded-full border px-2 py-0.5 text-[11px] font-semibold',
-          meta.className,
-        )}>{meta.label}</span>
-      </div>
-      <dl className="grid grid-cols-2 gap-x-3 gap-y-1.5 text-xs">
-        <dt className="text-muted-foreground">Enviado em</dt>
-        <dd className="text-right tabular-nums">{fmt(pedido.enviado_portal_em)}</dd>
-        <dt className="text-muted-foreground">Protocolo</dt>
-        <dd className="text-right font-mono">{pedido.portal_protocolo ?? '—'}</dd>
-        <dt className="text-muted-foreground">Tentativas</dt>
-        <dd className="text-right tabular-nums">{tentativas}</dd>
-        <dt className="text-muted-foreground">Próx. retry</dt>
-        <dd className="text-right tabular-nums">{fmt(pedido.portal_proximo_retry_em)}</dd>
-      </dl>
-      {pedido.portal_erro && (
-        <div className="text-xs text-destructive whitespace-pre-wrap break-words border-t pt-2">
-          {pedido.portal_erro}
-        </div>
-      )}
-    </div>
-  );
-}
-
-/* ─── Painel: Histórico de ações ─── */
-function HistoricoAcoesPanel({ pedido }: { pedido: PedidoSugerido | null }) {
-  if (!pedido) return null;
-  type Evt = { ts: string; label: string; by?: string | null; detail?: string | null; tone: 'default' | 'success' | 'warn' | 'danger' };
-  const evts: Evt[] = [];
-  if (pedido.criado_em) evts.push({ ts: pedido.criado_em, label: 'Pedido gerado', tone: 'default' });
-  if (pedido.aprovado_em) evts.push({ ts: pedido.aprovado_em, label: 'Aprovado', by: pedido.aprovado_por, tone: 'success' });
-  if (pedido.enviado_portal_em) {
-    evts.push({
-      ts: pedido.enviado_portal_em,
-      label: 'Enviado ao portal',
-      detail: pedido.portal_protocolo ? `Protocolo ${pedido.portal_protocolo}` : null,
-      tone: pedido.status_envio_portal === 'falha_envio_portal' ? 'danger' : 'success',
-    });
-  }
-  if (pedido.horario_disparo_real) evts.push({ ts: pedido.horario_disparo_real, label: 'Disparado', tone: 'success' });
-  if (pedido.omie_registrado_em) evts.push({
-    ts: pedido.omie_registrado_em,
-    label: 'Registrado no Omie',
-    detail: pedido.omie_pedido_compra_numero ? `Nº ${pedido.omie_pedido_compra_numero}` : null,
-    tone: 'success',
-  });
-  if (pedido.cancelado_em) evts.push({
-    ts: pedido.cancelado_em,
-    label: 'Cancelado',
-    by: pedido.cancelado_por,
-    detail: pedido.justificativa_cancelamento,
-    tone: 'danger',
-  });
-  evts.sort((a, b) => new Date(b.ts).getTime() - new Date(a.ts).getTime());
-
-  const fmt = (iso: string) => {
-    try { return format(new Date(iso), "dd/MM/yyyy HH:mm", { locale: ptBR }); } catch { return iso; }
-  };
-  const dotCls: Record<Evt['tone'], string> = {
-    default: 'bg-muted-foreground',
-    success: 'bg-status-success',
-    warn: 'bg-status-warning',
-    danger: 'bg-destructive',
-  };
-  return (
-    <div className="rounded-md border bg-muted/20 p-3">
-      <div className="text-sm font-medium mb-2">Histórico de ações</div>
-      {evts.length === 0 ? (
-        <div className="text-xs text-muted-foreground py-2">Sem eventos registrados.</div>
-      ) : (
-        <ol className="space-y-2.5">
-          {evts.map((e, i) => (
-            <li key={i} className="flex gap-2.5 text-xs">
-              <div className="flex flex-col items-center pt-0.5">
-                <span className={cn('h-2 w-2 rounded-full', dotCls[e.tone])} />
-                {i < evts.length - 1 && <span className="flex-1 w-px bg-border mt-1" />}
-              </div>
-              <div className="flex-1 pb-1">
-                <div className="flex items-center justify-between gap-2">
-                  <span className="font-medium">{e.label}</span>
-                  <span className="tabular-nums text-muted-foreground">{fmt(e.ts)}</span>
-                </div>
-                {(e.by || e.detail) && (
-                  <div className="text-muted-foreground mt-0.5 break-words">
-                    {e.by && <span>por {e.by}</span>}
-                    {e.by && e.detail && <span> · </span>}
-                    {e.detail && <span>{e.detail}</span>}
-                  </div>
-                )}
-              </div>
-            </li>
-          ))}
-        </ol>
-      )}
-    </div>
-  );
-}
+import { useDetalhesModal } from './useDetalhesModal';
+import { PortalStatusPanel } from './PortalStatusPanel';
+import { HistoricoAcoesPanel } from './HistoricoAcoesPanel';
+import { CondicaoPagamentoPanel } from './CondicaoPagamentoPanel';
+import { ItensTable } from './ItensTable';
+import { RemoverItemDialog, DescontinuarItemDialog } from './ConfirmacaoDialogs';
 
 /* ─── Detalhes Modal ─── */
 export function DetalhesModal({
@@ -154,278 +25,33 @@ export function DetalhesModal({
   onOpenChange: (v: boolean) => void;
   onApproved: () => void;
 }) {
-  const { user } = useAuth();
-  const queryClient = useQueryClient();
-  const [edits, setEdits] = useState<Record<number, number>>({});
-  const [obs, setObs] = useState('');
-  const [condicaoCodigo, setCondicaoCodigo] = useState<string>('');
-  const [removerItem, setRemoverItem] = useState<PedidoItem | null>(null);
-  const [descontinuarItem, setDescontinuarItem] = useState<PedidoItem | null>(null);
-
-  // Catálogo de condições de pagamento Omie (carregado uma vez)
-  const { data: condicoes = [] } = useQuery({
-    queryKey: ['condicoes-pagamento', pedido?.empresa],
-    queryFn: async () => {
-      if (!pedido) return [] as CondicaoPagamento[];
-      const { data, error } = await supabase
-        .from('omie_condicao_pagamento_catalogo')
-        .select('codigo, descricao, num_parcelas, dias_parcelas')
-        .eq('empresa', pedido.empresa)
-        .eq('ativo', true)
-        .order('descricao');
-      if (error) throw error;
-      return (data ?? []) as CondicaoPagamento[];
-    },
-    enabled: !!pedido && open,
-  });
-
-  const { data: itens, isLoading } = useQuery({
-    queryKey: ['pedido-itens', pedido?.id],
-    queryFn: async () => {
-      if (!pedido) return [] as PedidoItem[];
-      const { data, error } = await supabase
-        .from('pedido_compra_item')
-        .select('*')
-        .eq('pedido_id', pedido.id)
-        .order('id', { ascending: true });
-      if (error) throw error;
-      const baseItens = data ?? [];
-      if (baseItens.length === 0) return [] as PedidoItem[];
-
-      // Buscar estoque_minimo de sku_parametros (JOIN manual)
-      const skuCodigos = baseItens.map((it) => Number(it.sku_codigo_omie)).filter((n) => !isNaN(n));
-      const { data: params } = await supabase
-        .from('sku_parametros')
-        .select('sku_codigo_omie, estoque_minimo')
-        .eq('empresa', pedido.empresa)
-        .in('sku_codigo_omie', skuCodigos);
-      const minMap = new Map<string, number>();
-      (params ?? []).forEach((p) => {
-        minMap.set(String(p.sku_codigo_omie), Number(p.estoque_minimo ?? 0));
-      });
-
-      return baseItens.map((it) => ({
-        ...it,
-        estoque_minimo: minMap.get(String(it.sku_codigo_omie)) ?? 0,
-      })) as PedidoItem[];
-    },
-    enabled: !!pedido && open,
-  });
-
-  useEffect(() => {
-    if (!open) {
-      setEdits({});
-      setObs('');
-      setCondicaoCodigo('');
-    } else if (pedido) {
-      setCondicaoCodigo(pedido.condicao_pagamento_codigo ?? '');
-    }
-  }, [open, pedido]);
-
-  const linhas = useMemo(() => {
-    return (itens ?? []).map((it) => {
-      const qtd = edits[it.id] ?? Number(it.qtde_final ?? it.qtde_sugerida);
-      const preco = Number(it.preco_unitario ?? 0);
-      return { ...it, _qtd: qtd, _valor: qtd * preco };
-    });
-  }, [itens, edits]);
-
-  const totalAtual = useMemo(
-    () => linhas.reduce((acc, l) => acc + l._valor, 0),
-    [linhas],
-  );
-
-  const salvarMutation = useMutation({
-    mutationFn: async () => {
-      if (!pedido) return;
-      const updates = Object.entries(edits);
-      for (const [itemId, qtd] of updates) {
-        const item = (itens ?? []).find((i) => i.id === Number(itemId));
-        const preco = Number(item?.preco_unitario ?? 0);
-        const { error } = await supabase
-          .from('pedido_compra_item')
-          .update({
-            qtde_final: qtd,
-            valor_linha: qtd * preco,
-            ajustado_humano: true,
-          })
-          .eq('id', Number(itemId));
-        if (error) throw error;
-      }
-      const novoTotal = linhas.reduce((acc, l) => acc + l._valor, 0);
-      const { error: errPed } = await supabase
-        .from('pedido_compra_sugerido')
-        .update({ valor_total: novoTotal, atualizado_em: new Date().toISOString() })
-        .eq('id', pedido.id);
-      if (errPed) throw errPed;
-    },
-    onSuccess: () => {
-      toast.success('Ajustes salvos');
-      queryClient.invalidateQueries({ queryKey: ['pedido-itens', pedido?.id] });
-      queryClient.invalidateQueries({ queryKey: ['pedidos-ciclo'] });
-      setEdits({});
-    },
-    onError: (e: Error) => {
-      logger.error('Erro ao salvar ajustes', { error: e });
-      toast.error(`Erro ao salvar: ${e.message}`);
-    },
-  });
-
-  const condicaoSelecionada = useMemo(
-    () => condicoes.find((c) => c.codigo === condicaoCodigo) ?? null,
-    [condicoes, condicaoCodigo],
-  );
-
-  const condicaoMudou = condicaoCodigo !== (pedido?.condicao_pagamento_codigo ?? '');
-
-  const salvarCondicaoMutation = useMutation({
-    mutationFn: async () => {
-      if (!pedido || !condicaoSelecionada) return;
-      const { error } = await supabase
-        .from('pedido_compra_sugerido')
-        .update({
-          condicao_pagamento_codigo: condicaoSelecionada.codigo,
-          condicao_pagamento_descricao: condicaoSelecionada.descricao,
-          num_parcelas: condicaoSelecionada.num_parcelas,
-          condicao_origem: 'manual_humano',
-          atualizado_em: new Date().toISOString(),
-        })
-        .eq('id', pedido.id);
-      if (error) throw error;
-    },
-    onSuccess: () => {
-      toast.success('Condição de pagamento salva');
-      queryClient.invalidateQueries({ queryKey: ['pedidos-ciclo'] });
-    },
-    onError: (e: Error) => {
-      logger.error('Erro ao salvar condição', { error: e });
-      toast.error(`Erro ao salvar condição: ${e.message}`);
-    },
-  });
-
-  const aprovarMutation = useMutation({
-    mutationFn: async () => {
-      if (!pedido) return;
-      if (!condicaoSelecionada) {
-        throw new Error('Selecione uma condição de pagamento antes de aprovar');
-      }
-      // salvar ajustes primeiro se houver
-      if (Object.keys(edits).length > 0) {
-        await salvarMutation.mutateAsync();
-      }
-      // salvar condição se mudou ou se ainda não havia
-      if (condicaoMudou) {
-        await salvarCondicaoMutation.mutateAsync();
-      }
-      const { data, error } = await supabase.rpc('aprovar_pedido_sugerido', {
-        p_pedido_id: pedido.id,
-        p_usuario: user?.email ?? 'sistema',
-      });
-      if (error) throw error;
-      return data;
-    },
-    onSuccess: () => {
-      const horario = pedido?.horario_corte_planejado ? formatTime(pedido.horario_corte_planejado) : 'horário planejado';
-      toast.success(`Pedido aprovado. Será disparado às ${horario}.`);
-      queryClient.invalidateQueries({ queryKey: ['pedidos-ciclo'] });
-      onApproved();
-      onOpenChange(false);
-    },
-    onError: (e: Error) => {
-      logger.error('Erro ao aprovar pedido', { error: e });
-      toast.error(`Erro ao aprovar: ${e.message}`);
-    },
-  });
-
-  // Recalcula valor total e status do pedido após remoção de item
-  const recalcularPedido = async () => {
-    if (!pedido) return;
-    const { data: restantes, error } = await supabase
-      .from('pedido_compra_item')
-      .select('id, qtde_final, qtde_sugerida, preco_unitario')
-      .eq('pedido_id', pedido.id);
-    if (error) throw error;
-
-    const itensRest = restantes ?? [];
-    const novoTotal = itensRest.reduce((acc, it) => {
-      const q = Number(it.qtde_final ?? it.qtde_sugerida ?? 0);
-      const p = Number(it.preco_unitario ?? 0);
-      return acc + q * p;
-    }, 0);
-
-    const updates: Record<string, unknown> = {
-      valor_total: novoTotal,
-      num_skus: itensRest.length,
-      atualizado_em: new Date().toISOString(),
-    };
-    if (itensRest.length === 0) {
-      updates.status = 'cancelado_humano';
-      updates.cancelado_por = user?.email ?? 'sistema';
-      updates.cancelado_em = new Date().toISOString();
-      updates.justificativa_cancelamento = 'Todos os itens foram removidos manualmente';
-    }
-    const { error: errPed } = await supabase
-      .from('pedido_compra_sugerido')
-      .update(updates)
-      .eq('id', pedido.id);
-    if (errPed) throw errPed;
-    return { vazio: itensRest.length === 0 };
-  };
-
-  const removerItemMutation = useMutation({
-    mutationFn: async (itemId: number) => {
-      const { error } = await supabase.from('pedido_compra_item').delete().eq('id', itemId);
-      if (error) throw error;
-      return await recalcularPedido();
-    },
-    onSuccess: (res) => {
-      toast.success(res?.vazio ? 'Item removido. Pedido cancelado (sem itens restantes).' : 'Item removido');
-      queryClient.invalidateQueries({ queryKey: ['pedido-itens', pedido?.id] });
-      queryClient.invalidateQueries({ queryKey: ['pedidos-ciclo'] });
-      setRemoverItem(null);
-      if (res?.vazio) onOpenChange(false);
-    },
-    onError: (e: Error) => {
-      toast.error(`Erro ao remover item: ${e.message}`);
-    },
-  });
-
-  const descontinuarMutation = useMutation({
-    mutationFn: async (item: PedidoItem) => {
-      // 1. descontinua o SKU
-      const { error: errSku } = await supabase
-        .from('sku_parametros')
-        .update({
-          tipo_reposicao: 'descontinuado',
-          habilitado_reposicao_automatica: false,
-        })
-        .eq('empresa', pedido!.empresa)
-        .eq('sku_codigo_omie', Number(item.sku_codigo_omie));
-      if (errSku) throw errSku;
-      // 2. remove a linha
-      const { error: errDel } = await supabase.from('pedido_compra_item').delete().eq('id', item.id);
-      if (errDel) throw errDel;
-      return await recalcularPedido();
-    },
-    onSuccess: (res) => {
-      toast.success(
-        res?.vazio
-          ? 'SKU descontinuado e item removido. Pedido cancelado (sem itens restantes).'
-          : 'SKU descontinuado. Não será mais incluído em ciclos futuros.'
-      );
-      queryClient.invalidateQueries({ queryKey: ['pedido-itens', pedido?.id] });
-      queryClient.invalidateQueries({ queryKey: ['pedidos-ciclo'] });
-      setDescontinuarItem(null);
-      if (res?.vazio) onOpenChange(false);
-    },
-    onError: (e: Error) => {
-      toast.error(`Erro ao descontinuar SKU: ${e.message}`);
-    },
-  });
+  const {
+    condicoes,
+    isLoading,
+    edits,
+    onEditQty,
+    obs,
+    setObs,
+    condicaoCodigo,
+    setCondicaoCodigo,
+    removerItem,
+    setRemoverItem,
+    descontinuarItem,
+    setDescontinuarItem,
+    linhas,
+    totalAtual,
+    condicaoSelecionada,
+    condicaoMudou,
+    salvarMutation,
+    salvarCondicaoMutation,
+    aprovarMutation,
+    removerItemMutation,
+    descontinuarMutation,
+    podeEditar,
+    podeEditarCondicao,
+  } = useDetalhesModal({ pedido, open, onOpenChange, onApproved });
 
   if (!pedido) return null;
-  const podeEditar = pedido.status === 'pendente_aprovacao' || pedido.status === 'bloqueado_guardrail';
-  const podeEditarCondicao = podeEditar || pedido.status === 'aprovado_aguardando_disparo';
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -446,59 +72,17 @@ export function DetalhesModal({
         </div>
 
         {/* Condição de pagamento Omie (obrigatório p/ disparo) */}
-        <div className="rounded-md border bg-muted/30 p-3 space-y-2">
-          <div className="flex items-center justify-between">
-            <label className="text-sm font-medium">
-              Condição de pagamento Omie
-              {!condicaoSelecionada && <span className="text-destructive ml-1">*</span>}
-            </label>
-            {pedido.condicao_origem && (
-              <Badge variant="outline" className="text-[10px] h-4">
-                origem: {pedido.condicao_origem}
-              </Badge>
-            )}
-          </div>
-          {podeEditarCondicao ? (
-            <div className="flex gap-2">
-              <Select value={condicaoCodigo || undefined} onValueChange={setCondicaoCodigo}>
-                <SelectTrigger className="flex-1">
-                  <SelectValue placeholder="Selecione a condição (obrigatório p/ disparar ao Omie)" />
-                </SelectTrigger>
-                <SelectContent className="max-h-[300px]">
-                  {condicoes.map((c) => (
-                    <SelectItem key={c.codigo} value={c.codigo}>
-                      <span className="font-mono text-xs mr-2">{c.codigo}</span>
-                      {c.descricao}
-                      {c.num_parcelas ? <span className="text-muted-foreground ml-2">({c.num_parcelas}x)</span> : null}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-              {pedido.status === 'aprovado_aguardando_disparo' && condicaoMudou && condicaoSelecionada && (
-                <Button
-                  size="sm"
-                  variant="secondary"
-                  disabled={salvarCondicaoMutation.isPending}
-                  onClick={() => salvarCondicaoMutation.mutate()}
-                >
-                  {salvarCondicaoMutation.isPending && <Loader2 className="w-4 h-4 mr-1 animate-spin" />}
-                  Salvar
-                </Button>
-              )}
-            </div>
-          ) : (
-            <div className="text-sm">
-              {pedido.condicao_pagamento_codigo
-                ? <><span className="font-mono text-xs mr-2">{pedido.condicao_pagamento_codigo}</span>{pedido.condicao_pagamento_descricao}</>
-                : <span className="text-muted-foreground italic">não definida</span>}
-            </div>
-          )}
-          {!condicaoSelecionada && podeEditarCondicao && (
-            <p className="text-xs text-destructive">
-              Sem condição selecionada o disparo ao Omie falhará.
-            </p>
-          )}
-        </div>
+        <CondicaoPagamentoPanel
+          pedido={pedido}
+          podeEditarCondicao={podeEditarCondicao}
+          condicaoCodigo={condicaoCodigo}
+          onCondicaoChange={setCondicaoCodigo}
+          condicoes={condicoes}
+          condicaoSelecionada={condicaoSelecionada}
+          condicaoMudou={condicaoMudou}
+          salvarCondicaoPending={salvarCondicaoMutation.isPending}
+          onSalvarCondicao={() => salvarCondicaoMutation.mutate()}
+        />
 
         {pedido.status === 'bloqueado_guardrail' && pedido.mensagem_bloqueio && (
           <Alert variant="destructive">
@@ -513,106 +97,16 @@ export function DetalhesModal({
             <Loader2 className="w-6 h-6 animate-spin text-muted-foreground" />
           </div>
         ) : (
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead className="w-[34%] min-w-[300px]">SKU / Descrição</TableHead>
-                <TableHead className="text-right">Estoque atual</TableHead>
-                <TableHead className="text-right">EM</TableHead>
-                <TableHead className="text-right">PP</TableHead>
-                <TableHead className="text-right">Emax</TableHead>
-                <TableHead className="text-right">Qtde sugerida</TableHead>
-                <TableHead className="text-right">Qtde final</TableHead>
-                <TableHead className="text-right">Preço</TableHead>
-                <TableHead className="text-right">Valor linha</TableHead>
-                {podeEditar && <TableHead className="text-right">Ações</TableHead>}
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {linhas.map((l) => {
-                const estoque = Number(l.estoque_atual ?? 0);
-                const minimo = Number(l.estoque_minimo ?? 0);
-                const pp = Number(l.ponto_pedido ?? 0);
-                const zoneClass = getEstoqueZoneClass(estoque, minimo, pp);
-                const sugerida = Number(l.qtde_sugerida ?? 0);
-                return (
-                <TableRow key={l.id}>
-                  <TableCell className="align-top whitespace-normal">
-                    <div className="font-mono text-xs text-muted-foreground">{l.sku_codigo_omie}</div>
-                    <div className="text-sm font-medium whitespace-normal break-words leading-snug">
-                      {l.sku_descricao ?? '—'}
-                    </div>
-                    <div className="flex gap-1 mt-1">
-                      {l.primeira_compra && (
-                        <Badge variant="destructive" className="text-[10px] h-4">primeira compra</Badge>
-                      )}
-                      {l.ajustado_humano && (
-                        <Badge variant="outline" className="text-[10px] h-4">ajustado</Badge>
-                      )}
-                    </div>
-                  </TableCell>
-                  <TableCell className={`text-right tabular-nums ${zoneClass}`}>{estoque.toFixed(0)}</TableCell>
-                  <TableCell className="text-right tabular-nums text-muted-foreground">{minimo.toFixed(0)}</TableCell>
-                  <TableCell className="text-right tabular-nums">{pp.toFixed(0)}</TableCell>
-                  <TableCell className="text-right tabular-nums">{Number(l.estoque_maximo ?? 0).toFixed(0)}</TableCell>
-                  <TableCell className="text-right tabular-nums text-muted-foreground">{sugerida.toFixed(0)}</TableCell>
-                  <TableCell className="text-right">
-                    {podeEditar ? (
-                      <Input
-                        type="number"
-                        min={0}
-                        step="1"
-                        className="h-8 w-24 ml-auto text-right tabular-nums"
-                        value={l._qtd}
-                        onChange={(e) => {
-                          const v = Number(e.target.value);
-                          setEdits((prev) => ({ ...prev, [l.id]: isNaN(v) ? 0 : v }));
-                        }}
-                      />
-                    ) : (
-                      <span className={cn(
-                        "tabular-nums",
-                        l._qtd !== sugerida && "font-semibold text-status-warning",
-                      )}>{l._qtd.toFixed(0)}</span>
-                    )}
-                  </TableCell>
-                  <TableCell className="text-right tabular-nums">{formatBRL(l.preco_unitario)}</TableCell>
-                  <TableCell className="text-right tabular-nums font-medium">{formatBRL(l._valor)}</TableCell>
-                  {podeEditar && (
-                    <TableCell className="text-right">
-                      <div className="flex justify-end gap-1">
-                        <Button
-                          size="sm"
-                          variant="ghost"
-                          title="Remover linha deste pedido"
-                          onClick={() => setRemoverItem(l)}
-                          disabled={removerItemMutation.isPending || descontinuarMutation.isPending}
-                        >
-                          <Trash2 className="w-4 h-4" />
-                        </Button>
-                        <Button
-                          size="sm"
-                          variant="ghost"
-                          title="Remover linha + descontinuar SKU"
-                          className="text-destructive hover:text-destructive"
-                          onClick={() => setDescontinuarItem(l)}
-                          disabled={removerItemMutation.isPending || descontinuarMutation.isPending}
-                        >
-                          <Ban className="w-4 h-4" />
-                        </Button>
-                      </div>
-                    </TableCell>
-                  )}
-                </TableRow>
-                );
-              })}
-              <TableRow>
-                <TableCell colSpan={8} className="text-right font-medium">Total</TableCell>
-                <TableCell className="text-right font-bold tabular-nums">{formatBRL(totalAtual)}</TableCell>
-                {podeEditar && <TableCell />}
-              </TableRow>
-            </TableBody>
-          </Table>
+          <ItensTable
+            linhas={linhas}
+            podeEditar={podeEditar}
+            totalAtual={totalAtual}
+            onEditQty={onEditQty}
+            onRemover={(l) => setRemoverItem(l)}
+            onDescontinuar={(l) => setDescontinuarItem(l)}
+            removerPending={removerItemMutation.isPending}
+            descontinuarPending={descontinuarMutation.isPending}
+          />
         )}
 
         {/* Status de envio ao portal + Histórico de ações */}
@@ -655,53 +149,20 @@ export function DetalhesModal({
       </DialogContent>
 
       {/* Confirmação: remover linha */}
-      <AlertDialog open={!!removerItem} onOpenChange={(v) => !v && setRemoverItem(null)}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Remover este item do pedido?</AlertDialogTitle>
-            <AlertDialogDescription>
-              SKU <span className="font-mono">{removerItem?.sku_codigo_omie}</span> — {removerItem?.sku_descricao ?? '—'}.
-              <br />O valor total do pedido será recalculado. Se for o último item, o pedido será cancelado automaticamente.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={removerItemMutation.isPending}>Cancelar</AlertDialogCancel>
-            <AlertDialogAction
-              disabled={removerItemMutation.isPending}
-              onClick={() => removerItem && removerItemMutation.mutate(removerItem.id)}
-            >
-              {removerItemMutation.isPending && <Loader2 className="w-4 h-4 mr-1 animate-spin" />}
-              Remover
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+      <RemoverItemDialog
+        item={removerItem}
+        onOpenChange={() => setRemoverItem(null)}
+        pending={removerItemMutation.isPending}
+        onConfirm={() => removerItem && removerItemMutation.mutate(removerItem.id)}
+      />
 
       {/* Confirmação: remover + descontinuar */}
-      <AlertDialog open={!!descontinuarItem} onOpenChange={(v) => !v && setDescontinuarItem(null)}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Descontinuar SKU permanentemente?</AlertDialogTitle>
-            <AlertDialogDescription>
-              SKU <span className="font-mono">{descontinuarItem?.sku_codigo_omie}</span> — {descontinuarItem?.sku_descricao ?? '—'}.
-              <br />
-              <strong className="text-destructive">Tem certeza?</strong> Este SKU não será mais incluído em ciclos futuros de reposição automática.
-              A linha também será removida deste pedido.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={descontinuarMutation.isPending}>Voltar</AlertDialogCancel>
-            <AlertDialogAction
-              disabled={descontinuarMutation.isPending}
-              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-              onClick={() => descontinuarItem && descontinuarMutation.mutate(descontinuarItem)}
-            >
-              {descontinuarMutation.isPending && <Loader2 className="w-4 h-4 mr-1 animate-spin" />}
-              Descontinuar e remover
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+      <DescontinuarItemDialog
+        item={descontinuarItem}
+        onOpenChange={() => setDescontinuarItem(null)}
+        pending={descontinuarMutation.isPending}
+        onConfirm={() => descontinuarItem && descontinuarMutation.mutate(descontinuarItem)}
+      />
     </Dialog>
   );
 }

--- a/src/components/reposicao/pedidos/HistoricoAcoesPanel.tsx
+++ b/src/components/reposicao/pedidos/HistoricoAcoesPanel.tsx
@@ -1,0 +1,79 @@
+// Painel: histórico de ações do pedido (timeline).
+// Extraído verbatim de src/components/reposicao/pedidos/DetalhesModal.tsx (god-component split).
+import { format } from 'date-fns';
+import { ptBR } from 'date-fns/locale';
+import { cn } from '@/lib/utils';
+import { PedidoSugerido } from './types';
+
+export function HistoricoAcoesPanel({ pedido }: { pedido: PedidoSugerido | null }) {
+  if (!pedido) return null;
+  type Evt = { ts: string; label: string; by?: string | null; detail?: string | null; tone: 'default' | 'success' | 'warn' | 'danger' };
+  const evts: Evt[] = [];
+  if (pedido.criado_em) evts.push({ ts: pedido.criado_em, label: 'Pedido gerado', tone: 'default' });
+  if (pedido.aprovado_em) evts.push({ ts: pedido.aprovado_em, label: 'Aprovado', by: pedido.aprovado_por, tone: 'success' });
+  if (pedido.enviado_portal_em) {
+    evts.push({
+      ts: pedido.enviado_portal_em,
+      label: 'Enviado ao portal',
+      detail: pedido.portal_protocolo ? `Protocolo ${pedido.portal_protocolo}` : null,
+      tone: pedido.status_envio_portal === 'falha_envio_portal' ? 'danger' : 'success',
+    });
+  }
+  if (pedido.horario_disparo_real) evts.push({ ts: pedido.horario_disparo_real, label: 'Disparado', tone: 'success' });
+  if (pedido.omie_registrado_em) evts.push({
+    ts: pedido.omie_registrado_em,
+    label: 'Registrado no Omie',
+    detail: pedido.omie_pedido_compra_numero ? `Nº ${pedido.omie_pedido_compra_numero}` : null,
+    tone: 'success',
+  });
+  if (pedido.cancelado_em) evts.push({
+    ts: pedido.cancelado_em,
+    label: 'Cancelado',
+    by: pedido.cancelado_por,
+    detail: pedido.justificativa_cancelamento,
+    tone: 'danger',
+  });
+  evts.sort((a, b) => new Date(b.ts).getTime() - new Date(a.ts).getTime());
+
+  const fmt = (iso: string) => {
+    try { return format(new Date(iso), "dd/MM/yyyy HH:mm", { locale: ptBR }); } catch { return iso; }
+  };
+  const dotCls: Record<Evt['tone'], string> = {
+    default: 'bg-muted-foreground',
+    success: 'bg-status-success',
+    warn: 'bg-status-warning',
+    danger: 'bg-destructive',
+  };
+  return (
+    <div className="rounded-md border bg-muted/20 p-3">
+      <div className="text-sm font-medium mb-2">Histórico de ações</div>
+      {evts.length === 0 ? (
+        <div className="text-xs text-muted-foreground py-2">Sem eventos registrados.</div>
+      ) : (
+        <ol className="space-y-2.5">
+          {evts.map((e, i) => (
+            <li key={i} className="flex gap-2.5 text-xs">
+              <div className="flex flex-col items-center pt-0.5">
+                <span className={cn('h-2 w-2 rounded-full', dotCls[e.tone])} />
+                {i < evts.length - 1 && <span className="flex-1 w-px bg-border mt-1" />}
+              </div>
+              <div className="flex-1 pb-1">
+                <div className="flex items-center justify-between gap-2">
+                  <span className="font-medium">{e.label}</span>
+                  <span className="tabular-nums text-muted-foreground">{fmt(e.ts)}</span>
+                </div>
+                {(e.by || e.detail) && (
+                  <div className="text-muted-foreground mt-0.5 break-words">
+                    {e.by && <span>por {e.by}</span>}
+                    {e.by && e.detail && <span> · </span>}
+                    {e.detail && <span>{e.detail}</span>}
+                  </div>
+                )}
+              </div>
+            </li>
+          ))}
+        </ol>
+      )}
+    </div>
+  );
+}

--- a/src/components/reposicao/pedidos/ItensTable.tsx
+++ b/src/components/reposicao/pedidos/ItensTable.tsx
@@ -1,0 +1,132 @@
+// Tabela de itens do pedido (com edição de quantidade e ações de remover/descontinuar).
+// Extraída verbatim de src/components/reposicao/pedidos/DetalhesModal.tsx (god-component split).
+import { Ban, Trash2 } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { cn } from '@/lib/utils';
+import { getEstoqueZoneClass, formatBRL } from './shared';
+import { type Linha } from './useDetalhesModal';
+
+interface ItensTableProps {
+  linhas: Linha[];
+  podeEditar: boolean;
+  totalAtual: number;
+  onEditQty: (id: number, raw: string) => void;
+  onRemover: (l: Linha) => void;
+  onDescontinuar: (l: Linha) => void;
+  removerPending: boolean;
+  descontinuarPending: boolean;
+}
+
+export function ItensTable({
+  linhas,
+  podeEditar,
+  totalAtual,
+  onEditQty,
+  onRemover,
+  onDescontinuar,
+  removerPending,
+  descontinuarPending,
+}: ItensTableProps) {
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead className="w-[34%] min-w-[300px]">SKU / Descrição</TableHead>
+          <TableHead className="text-right">Estoque atual</TableHead>
+          <TableHead className="text-right">EM</TableHead>
+          <TableHead className="text-right">PP</TableHead>
+          <TableHead className="text-right">Emax</TableHead>
+          <TableHead className="text-right">Qtde sugerida</TableHead>
+          <TableHead className="text-right">Qtde final</TableHead>
+          <TableHead className="text-right">Preço</TableHead>
+          <TableHead className="text-right">Valor linha</TableHead>
+          {podeEditar && <TableHead className="text-right">Ações</TableHead>}
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {linhas.map((l) => {
+          const estoque = Number(l.estoque_atual ?? 0);
+          const minimo = Number(l.estoque_minimo ?? 0);
+          const pp = Number(l.ponto_pedido ?? 0);
+          const zoneClass = getEstoqueZoneClass(estoque, minimo, pp);
+          const sugerida = Number(l.qtde_sugerida ?? 0);
+          return (
+          <TableRow key={l.id}>
+            <TableCell className="align-top whitespace-normal">
+              <div className="font-mono text-xs text-muted-foreground">{l.sku_codigo_omie}</div>
+              <div className="text-sm font-medium whitespace-normal break-words leading-snug">
+                {l.sku_descricao ?? '—'}
+              </div>
+              <div className="flex gap-1 mt-1">
+                {l.primeira_compra && (
+                  <Badge variant="destructive" className="text-[10px] h-4">primeira compra</Badge>
+                )}
+                {l.ajustado_humano && (
+                  <Badge variant="outline" className="text-[10px] h-4">ajustado</Badge>
+                )}
+              </div>
+            </TableCell>
+            <TableCell className={`text-right tabular-nums ${zoneClass}`}>{estoque.toFixed(0)}</TableCell>
+            <TableCell className="text-right tabular-nums text-muted-foreground">{minimo.toFixed(0)}</TableCell>
+            <TableCell className="text-right tabular-nums">{pp.toFixed(0)}</TableCell>
+            <TableCell className="text-right tabular-nums">{Number(l.estoque_maximo ?? 0).toFixed(0)}</TableCell>
+            <TableCell className="text-right tabular-nums text-muted-foreground">{sugerida.toFixed(0)}</TableCell>
+            <TableCell className="text-right">
+              {podeEditar ? (
+                <Input
+                  type="number"
+                  min={0}
+                  step="1"
+                  className="h-8 w-24 ml-auto text-right tabular-nums"
+                  value={l._qtd}
+                  onChange={(e) => onEditQty(l.id, e.target.value)}
+                />
+              ) : (
+                <span className={cn(
+                  "tabular-nums",
+                  l._qtd !== sugerida && "font-semibold text-status-warning",
+                )}>{l._qtd.toFixed(0)}</span>
+              )}
+            </TableCell>
+            <TableCell className="text-right tabular-nums">{formatBRL(l.preco_unitario)}</TableCell>
+            <TableCell className="text-right tabular-nums font-medium">{formatBRL(l._valor)}</TableCell>
+            {podeEditar && (
+              <TableCell className="text-right">
+                <div className="flex justify-end gap-1">
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    title="Remover linha deste pedido"
+                    onClick={() => onRemover(l)}
+                    disabled={removerPending || descontinuarPending}
+                  >
+                    <Trash2 className="w-4 h-4" />
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    title="Remover linha + descontinuar SKU"
+                    className="text-destructive hover:text-destructive"
+                    onClick={() => onDescontinuar(l)}
+                    disabled={removerPending || descontinuarPending}
+                  >
+                    <Ban className="w-4 h-4" />
+                  </Button>
+                </div>
+              </TableCell>
+            )}
+          </TableRow>
+          );
+        })}
+        <TableRow>
+          <TableCell colSpan={8} className="text-right font-medium">Total</TableCell>
+          <TableCell className="text-right font-bold tabular-nums">{formatBRL(totalAtual)}</TableCell>
+          {podeEditar && <TableCell />}
+        </TableRow>
+      </TableBody>
+    </Table>
+  );
+}

--- a/src/components/reposicao/pedidos/PortalStatusPanel.tsx
+++ b/src/components/reposicao/pedidos/PortalStatusPanel.tsx
@@ -1,0 +1,44 @@
+// Painel: status de envio ao portal.
+// Extraído verbatim de src/components/reposicao/pedidos/DetalhesModal.tsx (god-component split).
+import { format } from 'date-fns';
+import { ptBR } from 'date-fns/locale';
+import { cn } from '@/lib/utils';
+import { PedidoSugerido, StatusEnvioPortal } from './types';
+import { portalStatusMeta } from './shared';
+
+export function PortalStatusPanel({ pedido }: { pedido: PedidoSugerido | null }) {
+  if (!pedido) return null;
+  const status = (pedido.status_envio_portal ?? 'nao_aplicavel') as StatusEnvioPortal;
+  const meta = portalStatusMeta[status] ?? portalStatusMeta.nao_aplicavel;
+  const tentativas = pedido.portal_tentativas ?? 0;
+  const fmt = (iso: string | null | undefined) => {
+    if (!iso) return '—';
+    try { return format(new Date(iso), "dd/MM/yyyy HH:mm", { locale: ptBR }); } catch { return '—'; }
+  };
+  return (
+    <div className="rounded-md border bg-muted/20 p-3 space-y-2">
+      <div className="flex items-center justify-between">
+        <div className="text-sm font-medium">Status de envio ao portal</div>
+        <span className={cn(
+          'inline-flex items-center rounded-full border px-2 py-0.5 text-[11px] font-semibold',
+          meta.className,
+        )}>{meta.label}</span>
+      </div>
+      <dl className="grid grid-cols-2 gap-x-3 gap-y-1.5 text-xs">
+        <dt className="text-muted-foreground">Enviado em</dt>
+        <dd className="text-right tabular-nums">{fmt(pedido.enviado_portal_em)}</dd>
+        <dt className="text-muted-foreground">Protocolo</dt>
+        <dd className="text-right font-mono">{pedido.portal_protocolo ?? '—'}</dd>
+        <dt className="text-muted-foreground">Tentativas</dt>
+        <dd className="text-right tabular-nums">{tentativas}</dd>
+        <dt className="text-muted-foreground">Próx. retry</dt>
+        <dd className="text-right tabular-nums">{fmt(pedido.portal_proximo_retry_em)}</dd>
+      </dl>
+      {pedido.portal_erro && (
+        <div className="text-xs text-destructive whitespace-pre-wrap break-words border-t pt-2">
+          {pedido.portal_erro}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/reposicao/pedidos/__tests__/CondicaoPagamentoPanel.test.tsx
+++ b/src/components/reposicao/pedidos/__tests__/CondicaoPagamentoPanel.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { CondicaoPagamentoPanel } from '../CondicaoPagamentoPanel';
+import type { PedidoSugerido, CondicaoPagamento } from '../types';
+
+const condicoes: CondicaoPagamento[] = [
+  { codigo: '000', descricao: 'À vista', num_parcelas: 1, dias_parcelas: '0' },
+  { codigo: '030', descricao: '30 dias', num_parcelas: 1, dias_parcelas: '30' },
+];
+
+function ped(partial: Partial<PedidoSugerido>): PedidoSugerido {
+  return partial as unknown as PedidoSugerido;
+}
+
+function setup(overrides: Partial<React.ComponentProps<typeof CondicaoPagamentoPanel>> = {}) {
+  const props: React.ComponentProps<typeof CondicaoPagamentoPanel> = {
+    pedido: ped({ status: 'pendente_aprovacao', condicao_origem: null, condicao_pagamento_codigo: null, condicao_pagamento_descricao: null }),
+    podeEditarCondicao: true,
+    condicaoCodigo: '',
+    onCondicaoChange: vi.fn(),
+    condicoes,
+    condicaoSelecionada: null,
+    condicaoMudou: false,
+    salvarCondicaoPending: false,
+    onSalvarCondicao: vi.fn(),
+    ...overrides,
+  };
+  render(<CondicaoPagamentoPanel {...props} />);
+  return props;
+}
+
+describe('CondicaoPagamentoPanel', () => {
+  it('em modo editável sem condição: mostra o aviso de disparo', () => {
+    setup();
+    expect(screen.getByText(/Sem condição selecionada o disparo ao Omie falhará/)).toBeTruthy();
+  });
+
+  it('em modo não editável: mostra a condição definida ou "não definida"', () => {
+    const { } = setup({
+      podeEditarCondicao: false,
+      pedido: ped({ status: 'disparado', condicao_pagamento_codigo: null, condicao_pagamento_descricao: null }),
+    });
+    expect(screen.getByText('não definida')).toBeTruthy();
+  });
+
+  it('mostra o botão Salvar quando aprovado, condição mudou e selecionada; dispara onSalvarCondicao', () => {
+    const props = setup({
+      pedido: ped({ status: 'aprovado_aguardando_disparo', condicao_origem: null }),
+      condicaoCodigo: '030',
+      condicaoSelecionada: condicoes[1],
+      condicaoMudou: true,
+    });
+    const btn = screen.getByRole('button', { name: /Salvar/ });
+    fireEvent.click(btn);
+    expect(props.onSalvarCondicao).toHaveBeenCalledTimes(1);
+  });
+
+  it('mostra a origem como badge quando presente', () => {
+    setup({ pedido: ped({ status: 'pendente_aprovacao', condicao_origem: 'ia_sugerida' }) });
+    expect(screen.getByText(/origem: ia_sugerida/)).toBeTruthy();
+  });
+});

--- a/src/components/reposicao/pedidos/__tests__/ConfirmacaoDialogs.test.tsx
+++ b/src/components/reposicao/pedidos/__tests__/ConfirmacaoDialogs.test.tsx
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { RemoverItemDialog, DescontinuarItemDialog } from '../ConfirmacaoDialogs';
+import type { PedidoItem } from '../types';
+
+const item = { id: 3, sku_codigo_omie: '777', sku_descricao: 'Catalisador' } as unknown as PedidoItem;
+
+describe('RemoverItemDialog', () => {
+  it('fechado (item null) não renderiza título', () => {
+    render(<RemoverItemDialog item={null} onOpenChange={() => {}} pending={false} onConfirm={() => {}} />);
+    expect(screen.queryByText('Remover este item do pedido?')).toBeNull();
+  });
+
+  it('aberto: mostra SKU e dispara onConfirm', () => {
+    const onConfirm = vi.fn();
+    render(<RemoverItemDialog item={item} onOpenChange={() => {}} pending={false} onConfirm={onConfirm} />);
+    expect(screen.getByText('Remover este item do pedido?')).toBeTruthy();
+    expect(screen.getByText('777')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: /^Remover$/ }));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('DescontinuarItemDialog', () => {
+  it('aberto: mostra título de descontinuação e dispara onConfirm', () => {
+    const onConfirm = vi.fn();
+    render(<DescontinuarItemDialog item={item} onOpenChange={() => {}} pending={false} onConfirm={onConfirm} />);
+    expect(screen.getByText('Descontinuar SKU permanentemente?')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: /Descontinuar e remover/ }));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('desabilita ações quando pending', () => {
+    render(<DescontinuarItemDialog item={item} onOpenChange={() => {}} pending onConfirm={() => {}} />);
+    expect(screen.getByRole('button', { name: /Descontinuar e remover/ })).toHaveProperty('disabled', true);
+  });
+});

--- a/src/components/reposicao/pedidos/__tests__/HistoricoAcoesPanel.test.tsx
+++ b/src/components/reposicao/pedidos/__tests__/HistoricoAcoesPanel.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { HistoricoAcoesPanel } from '../HistoricoAcoesPanel';
+import type { PedidoSugerido } from '../types';
+
+function ped(partial: Partial<PedidoSugerido>): PedidoSugerido {
+  return partial as unknown as PedidoSugerido;
+}
+
+describe('HistoricoAcoesPanel', () => {
+  it('retorna null quando pedido é null', () => {
+    const { container } = render(<HistoricoAcoesPanel pedido={null} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('mostra "Sem eventos registrados" quando não há datas', () => {
+    render(<HistoricoAcoesPanel pedido={ped({})} />);
+    expect(screen.getByText('Sem eventos registrados.')).toBeTruthy();
+  });
+
+  it('lista eventos de geração e aprovação com o responsável', () => {
+    render(
+      <HistoricoAcoesPanel
+        pedido={ped({
+          criado_em: '2026-05-20T08:00:00Z',
+          aprovado_em: '2026-05-20T09:00:00Z',
+          aprovado_por: 'joao@empresa.com',
+        })}
+      />,
+    );
+    expect(screen.getByText('Pedido gerado')).toBeTruthy();
+    expect(screen.getByText('Aprovado')).toBeTruthy();
+    expect(screen.getByText(/por joao@empresa\.com/)).toBeTruthy();
+  });
+
+  it('mostra o protocolo no evento de envio ao portal', () => {
+    render(
+      <HistoricoAcoesPanel
+        pedido={ped({
+          enviado_portal_em: '2026-05-20T10:00:00Z',
+          portal_protocolo: 'P-999',
+          status_envio_portal: 'enviado_portal',
+        })}
+      />,
+    );
+    expect(screen.getByText('Enviado ao portal')).toBeTruthy();
+    expect(screen.getByText('Protocolo P-999')).toBeTruthy();
+  });
+});

--- a/src/components/reposicao/pedidos/__tests__/ItensTable.test.tsx
+++ b/src/components/reposicao/pedidos/__tests__/ItensTable.test.tsx
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ItensTable } from '../ItensTable';
+import type { Linha } from '../useDetalhesModal';
+
+function linha(partial: Partial<Linha>): Linha {
+  return {
+    id: 1,
+    pedido_id: 10,
+    sku_codigo_omie: '555',
+    sku_descricao: 'Verniz X',
+    estoque_atual: 5,
+    estoque_minimo: 2,
+    ponto_pedido: 8,
+    estoque_maximo: 20,
+    qtde_sugerida: 10,
+    qtde_final: null,
+    preco_unitario: 3,
+    valor_linha: null,
+    primeira_compra: null,
+    ajustado_humano: null,
+    _qtd: 10,
+    _valor: 30,
+    ...partial,
+  } as Linha;
+}
+
+function setup(overrides: Partial<React.ComponentProps<typeof ItensTable>> = {}) {
+  const props: React.ComponentProps<typeof ItensTable> = {
+    linhas: [linha({})],
+    podeEditar: true,
+    totalAtual: 30,
+    onEditQty: vi.fn(),
+    onRemover: vi.fn(),
+    onDescontinuar: vi.fn(),
+    removerPending: false,
+    descontinuarPending: false,
+    ...overrides,
+  };
+  render(<ItensTable {...props} />);
+  return props;
+}
+
+describe('ItensTable', () => {
+  it('renderiza SKU, descrição e total', () => {
+    setup();
+    expect(screen.getByText('555')).toBeTruthy();
+    expect(screen.getByText('Verniz X')).toBeTruthy();
+    expect(screen.getByText('Total')).toBeTruthy();
+  });
+
+  it('em modo editável: input dispara onEditQty e botões disparam ações', () => {
+    const props = setup();
+    const input = screen.getByRole('spinbutton') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '7' } });
+    expect(props.onEditQty).toHaveBeenCalledWith(1, '7');
+
+    const buttons = screen.getAllByRole('button');
+    fireEvent.click(buttons[0]); // remover
+    fireEvent.click(buttons[1]); // descontinuar
+    expect(props.onRemover).toHaveBeenCalledTimes(1);
+    expect(props.onDescontinuar).toHaveBeenCalledTimes(1);
+  });
+
+  it('sem permissão de edição: não há coluna Ações nem input', () => {
+    setup({ podeEditar: false });
+    expect(screen.queryByText('Ações')).toBeNull();
+    expect(screen.queryByRole('spinbutton')).toBeNull();
+  });
+
+  it('em modo leitura, destaca qtde final divergente da sugerida', () => {
+    setup({ podeEditar: false, linhas: [linha({ _qtd: 4, qtde_sugerida: 10 })] });
+    // 4 (qtd final divergente) é renderizado como span destacado
+    expect(screen.getByText('4')).toBeTruthy();
+  });
+});

--- a/src/components/reposicao/pedidos/__tests__/PortalStatusPanel.test.tsx
+++ b/src/components/reposicao/pedidos/__tests__/PortalStatusPanel.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { PortalStatusPanel } from '../PortalStatusPanel';
+import type { PedidoSugerido } from '../types';
+
+function ped(partial: Partial<PedidoSugerido>): PedidoSugerido {
+  return partial as unknown as PedidoSugerido;
+}
+
+describe('PortalStatusPanel', () => {
+  it('retorna null quando pedido é null', () => {
+    const { container } = render(<PortalStatusPanel pedido={null} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('mostra label do status, protocolo e tentativas', () => {
+    render(
+      <PortalStatusPanel
+        pedido={ped({
+          status_envio_portal: 'enviado_portal',
+          portal_protocolo: 'ABC123',
+          portal_tentativas: 2,
+          enviado_portal_em: '2026-05-20T10:30:00Z',
+          portal_proximo_retry_em: null,
+          portal_erro: null,
+        })}
+      />,
+    );
+    expect(screen.getByText('✓ Enviado')).toBeTruthy();
+    expect(screen.getByText('ABC123')).toBeTruthy();
+    expect(screen.getByText('2')).toBeTruthy();
+  });
+
+  it('mostra o erro do portal quando presente', () => {
+    render(
+      <PortalStatusPanel
+        pedido={ped({ status_envio_portal: 'falha_envio_portal', portal_erro: 'Timeout no portal', portal_tentativas: 1 })}
+      />,
+    );
+    expect(screen.getByText('Falha')).toBeTruthy();
+    expect(screen.getByText('Timeout no portal')).toBeTruthy();
+  });
+});

--- a/src/components/reposicao/pedidos/useDetalhesModal.ts
+++ b/src/components/reposicao/pedidos/useDetalhesModal.ts
@@ -1,0 +1,326 @@
+// Lógica do modal de detalhes do pedido (queries, mutations, edição de itens, aprovação).
+// Extraída verbatim de src/components/reposicao/pedidos/DetalhesModal.tsx (god-component split).
+import { useEffect, useMemo, useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import { useAuth } from '@/contexts/AuthContext';
+import { toast } from 'sonner';
+import { logger } from '@/lib/logger';
+import { PedidoSugerido, PedidoItem, CondicaoPagamento } from './types';
+import { formatTime } from './shared';
+
+export type Linha = PedidoItem & { _qtd: number; _valor: number };
+
+interface UseDetalhesModalArgs {
+  pedido: PedidoSugerido | null;
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+  onApproved: () => void;
+}
+
+export function useDetalhesModal({ pedido, open, onOpenChange, onApproved }: UseDetalhesModalArgs) {
+  const { user } = useAuth();
+  const queryClient = useQueryClient();
+  const [edits, setEdits] = useState<Record<number, number>>({});
+  const [obs, setObs] = useState('');
+  const [condicaoCodigo, setCondicaoCodigo] = useState<string>('');
+  const [removerItem, setRemoverItem] = useState<PedidoItem | null>(null);
+  const [descontinuarItem, setDescontinuarItem] = useState<PedidoItem | null>(null);
+
+  // Catálogo de condições de pagamento Omie (carregado uma vez)
+  const { data: condicoes = [] } = useQuery({
+    queryKey: ['condicoes-pagamento', pedido?.empresa],
+    queryFn: async () => {
+      if (!pedido) return [] as CondicaoPagamento[];
+      const { data, error } = await supabase
+        .from('omie_condicao_pagamento_catalogo')
+        .select('codigo, descricao, num_parcelas, dias_parcelas')
+        .eq('empresa', pedido.empresa)
+        .eq('ativo', true)
+        .order('descricao');
+      if (error) throw error;
+      return (data ?? []) as CondicaoPagamento[];
+    },
+    enabled: !!pedido && open,
+  });
+
+  const { data: itens, isLoading } = useQuery({
+    queryKey: ['pedido-itens', pedido?.id],
+    queryFn: async () => {
+      if (!pedido) return [] as PedidoItem[];
+      const { data, error } = await supabase
+        .from('pedido_compra_item')
+        .select('*')
+        .eq('pedido_id', pedido.id)
+        .order('id', { ascending: true });
+      if (error) throw error;
+      const baseItens = data ?? [];
+      if (baseItens.length === 0) return [] as PedidoItem[];
+
+      // Buscar estoque_minimo de sku_parametros (JOIN manual)
+      const skuCodigos = baseItens.map((it) => Number(it.sku_codigo_omie)).filter((n) => !isNaN(n));
+      const { data: params } = await supabase
+        .from('sku_parametros')
+        .select('sku_codigo_omie, estoque_minimo')
+        .eq('empresa', pedido.empresa)
+        .in('sku_codigo_omie', skuCodigos);
+      const minMap = new Map<string, number>();
+      (params ?? []).forEach((p) => {
+        minMap.set(String(p.sku_codigo_omie), Number(p.estoque_minimo ?? 0));
+      });
+
+      return baseItens.map((it) => ({
+        ...it,
+        estoque_minimo: minMap.get(String(it.sku_codigo_omie)) ?? 0,
+      })) as PedidoItem[];
+    },
+    enabled: !!pedido && open,
+  });
+
+  useEffect(() => {
+    if (!open) {
+      setEdits({});
+      setObs('');
+      setCondicaoCodigo('');
+    } else if (pedido) {
+      setCondicaoCodigo(pedido.condicao_pagamento_codigo ?? '');
+    }
+  }, [open, pedido]);
+
+  const linhas = useMemo<Linha[]>(() => {
+    return (itens ?? []).map((it) => {
+      const qtd = edits[it.id] ?? Number(it.qtde_final ?? it.qtde_sugerida);
+      const preco = Number(it.preco_unitario ?? 0);
+      return { ...it, _qtd: qtd, _valor: qtd * preco };
+    });
+  }, [itens, edits]);
+
+  const totalAtual = useMemo(
+    () => linhas.reduce((acc, l) => acc + l._valor, 0),
+    [linhas],
+  );
+
+  const salvarMutation = useMutation({
+    mutationFn: async () => {
+      if (!pedido) return;
+      const updates = Object.entries(edits);
+      for (const [itemId, qtd] of updates) {
+        const item = (itens ?? []).find((i) => i.id === Number(itemId));
+        const preco = Number(item?.preco_unitario ?? 0);
+        const { error } = await supabase
+          .from('pedido_compra_item')
+          .update({
+            qtde_final: qtd,
+            valor_linha: qtd * preco,
+            ajustado_humano: true,
+          })
+          .eq('id', Number(itemId));
+        if (error) throw error;
+      }
+      const novoTotal = linhas.reduce((acc, l) => acc + l._valor, 0);
+      const { error: errPed } = await supabase
+        .from('pedido_compra_sugerido')
+        .update({ valor_total: novoTotal, atualizado_em: new Date().toISOString() })
+        .eq('id', pedido.id);
+      if (errPed) throw errPed;
+    },
+    onSuccess: () => {
+      toast.success('Ajustes salvos');
+      queryClient.invalidateQueries({ queryKey: ['pedido-itens', pedido?.id] });
+      queryClient.invalidateQueries({ queryKey: ['pedidos-ciclo'] });
+      setEdits({});
+    },
+    onError: (e: Error) => {
+      logger.error('Erro ao salvar ajustes', { error: e });
+      toast.error(`Erro ao salvar: ${e.message}`);
+    },
+  });
+
+  const condicaoSelecionada = useMemo(
+    () => condicoes.find((c) => c.codigo === condicaoCodigo) ?? null,
+    [condicoes, condicaoCodigo],
+  );
+
+  const condicaoMudou = condicaoCodigo !== (pedido?.condicao_pagamento_codigo ?? '');
+
+  const salvarCondicaoMutation = useMutation({
+    mutationFn: async () => {
+      if (!pedido || !condicaoSelecionada) return;
+      const { error } = await supabase
+        .from('pedido_compra_sugerido')
+        .update({
+          condicao_pagamento_codigo: condicaoSelecionada.codigo,
+          condicao_pagamento_descricao: condicaoSelecionada.descricao,
+          num_parcelas: condicaoSelecionada.num_parcelas,
+          condicao_origem: 'manual_humano',
+          atualizado_em: new Date().toISOString(),
+        })
+        .eq('id', pedido.id);
+      if (error) throw error;
+    },
+    onSuccess: () => {
+      toast.success('Condição de pagamento salva');
+      queryClient.invalidateQueries({ queryKey: ['pedidos-ciclo'] });
+    },
+    onError: (e: Error) => {
+      logger.error('Erro ao salvar condição', { error: e });
+      toast.error(`Erro ao salvar condição: ${e.message}`);
+    },
+  });
+
+  const aprovarMutation = useMutation({
+    mutationFn: async () => {
+      if (!pedido) return;
+      if (!condicaoSelecionada) {
+        throw new Error('Selecione uma condição de pagamento antes de aprovar');
+      }
+      // salvar ajustes primeiro se houver
+      if (Object.keys(edits).length > 0) {
+        await salvarMutation.mutateAsync();
+      }
+      // salvar condição se mudou ou se ainda não havia
+      if (condicaoMudou) {
+        await salvarCondicaoMutation.mutateAsync();
+      }
+      const { data, error } = await supabase.rpc('aprovar_pedido_sugerido', {
+        p_pedido_id: pedido.id,
+        p_usuario: user?.email ?? 'sistema',
+      });
+      if (error) throw error;
+      return data;
+    },
+    onSuccess: () => {
+      const horario = pedido?.horario_corte_planejado ? formatTime(pedido.horario_corte_planejado) : 'horário planejado';
+      toast.success(`Pedido aprovado. Será disparado às ${horario}.`);
+      queryClient.invalidateQueries({ queryKey: ['pedidos-ciclo'] });
+      onApproved();
+      onOpenChange(false);
+    },
+    onError: (e: Error) => {
+      logger.error('Erro ao aprovar pedido', { error: e });
+      toast.error(`Erro ao aprovar: ${e.message}`);
+    },
+  });
+
+  // Recalcula valor total e status do pedido após remoção de item
+  const recalcularPedido = async () => {
+    if (!pedido) return;
+    const { data: restantes, error } = await supabase
+      .from('pedido_compra_item')
+      .select('id, qtde_final, qtde_sugerida, preco_unitario')
+      .eq('pedido_id', pedido.id);
+    if (error) throw error;
+
+    const itensRest = restantes ?? [];
+    const novoTotal = itensRest.reduce((acc, it) => {
+      const q = Number(it.qtde_final ?? it.qtde_sugerida ?? 0);
+      const p = Number(it.preco_unitario ?? 0);
+      return acc + q * p;
+    }, 0);
+
+    const updates: Record<string, unknown> = {
+      valor_total: novoTotal,
+      num_skus: itensRest.length,
+      atualizado_em: new Date().toISOString(),
+    };
+    if (itensRest.length === 0) {
+      updates.status = 'cancelado_humano';
+      updates.cancelado_por = user?.email ?? 'sistema';
+      updates.cancelado_em = new Date().toISOString();
+      updates.justificativa_cancelamento = 'Todos os itens foram removidos manualmente';
+    }
+    const { error: errPed } = await supabase
+      .from('pedido_compra_sugerido')
+      .update(updates)
+      .eq('id', pedido.id);
+    if (errPed) throw errPed;
+    return { vazio: itensRest.length === 0 };
+  };
+
+  const removerItemMutation = useMutation({
+    mutationFn: async (itemId: number) => {
+      const { error } = await supabase.from('pedido_compra_item').delete().eq('id', itemId);
+      if (error) throw error;
+      return await recalcularPedido();
+    },
+    onSuccess: (res) => {
+      toast.success(res?.vazio ? 'Item removido. Pedido cancelado (sem itens restantes).' : 'Item removido');
+      queryClient.invalidateQueries({ queryKey: ['pedido-itens', pedido?.id] });
+      queryClient.invalidateQueries({ queryKey: ['pedidos-ciclo'] });
+      setRemoverItem(null);
+      if (res?.vazio) onOpenChange(false);
+    },
+    onError: (e: Error) => {
+      toast.error(`Erro ao remover item: ${e.message}`);
+    },
+  });
+
+  const descontinuarMutation = useMutation({
+    mutationFn: async (item: PedidoItem) => {
+      // 1. descontinua o SKU
+      const { error: errSku } = await supabase
+        .from('sku_parametros')
+        .update({
+          tipo_reposicao: 'descontinuado',
+          habilitado_reposicao_automatica: false,
+        })
+        .eq('empresa', pedido!.empresa)
+        .eq('sku_codigo_omie', Number(item.sku_codigo_omie));
+      if (errSku) throw errSku;
+      // 2. remove a linha
+      const { error: errDel } = await supabase.from('pedido_compra_item').delete().eq('id', item.id);
+      if (errDel) throw errDel;
+      return await recalcularPedido();
+    },
+    onSuccess: (res) => {
+      toast.success(
+        res?.vazio
+          ? 'SKU descontinuado e item removido. Pedido cancelado (sem itens restantes).'
+          : 'SKU descontinuado. Não será mais incluído em ciclos futuros.'
+      );
+      queryClient.invalidateQueries({ queryKey: ['pedido-itens', pedido?.id] });
+      queryClient.invalidateQueries({ queryKey: ['pedidos-ciclo'] });
+      setDescontinuarItem(null);
+      if (res?.vazio) onOpenChange(false);
+    },
+    onError: (e: Error) => {
+      toast.error(`Erro ao descontinuar SKU: ${e.message}`);
+    },
+  });
+
+  const onEditQty = (id: number, raw: string) => {
+    const v = Number(raw);
+    setEdits((prev) => ({ ...prev, [id]: isNaN(v) ? 0 : v }));
+  };
+
+  const podeEditar =
+    pedido?.status === 'pendente_aprovacao' || pedido?.status === 'bloqueado_guardrail';
+  const podeEditarCondicao = podeEditar || pedido?.status === 'aprovado_aguardando_disparo';
+
+  return {
+    condicoes,
+    itens,
+    isLoading,
+    edits,
+    onEditQty,
+    obs,
+    setObs,
+    condicaoCodigo,
+    setCondicaoCodigo,
+    removerItem,
+    setRemoverItem,
+    descontinuarItem,
+    setDescontinuarItem,
+    linhas,
+    totalAtual,
+    condicaoSelecionada,
+    condicaoMudou,
+    salvarMutation,
+    salvarCondicaoMutation,
+    aprovarMutation,
+    removerItemMutation,
+    descontinuarMutation,
+    podeEditar,
+    podeEditarCondicao,
+  };
+}


### PR DESCRIPTION
## Resumo
- Split estrutural de `DetalhesModal` (707→**168** linhas), preservando 100% do comportamento (move verbatim).
- Lógica isolada no hook **`useDetalhesModal`** (2 queries, 5 mutations, `recalcularPedido`, memos, flags de edição).
- JSX em componentes presentacionais controlados: **`PortalStatusPanel`**, **`HistoricoAcoesPanel`**, **`CondicaoPagamentoPanel`**, **`ItensTable`** e **`ConfirmacaoDialogs`** (Remover/Descontinuar).
- Named export `DetalhesModal` preservado (consumidor: `AdminReposicaoPedidos`).

## Verificação
- `bunx tsc --noEmit` = 0 erros
- `bunx eslint` nos arquivos tocados = 0
- Testes novos (+19) passam isolados (5/5 arquivos). ⚠️ A suíte completa local apresentou flakiness por **contenção de CPU** (vários worktrees paralelos: durações 50–150× o normal, conjunto de falhas variando entre runs, em módulos não tocados). O gate autoritativo é o CI `validate` em ambiente limpo.
- Revisão independente de fidelidade (subagente): **FIEL 1:1**, zero divergências.

## Test plan
- [x] tsc / eslint verdes; +19 testes novos verdes isolados
- [x] Revisão 1:1 confirmando comportamento idêntico
- [ ] CI `validate` verde (gate da suíte completa)

🤖 Generated with [Claude Code](https://claude.com/claude-code)