### PR TITLE
chore(ts-strict): promove 5 pages a strict (lote C — fixes próprios)

### DIFF
--- a/docs/strict-migration-lanes.md
+++ b/docs/strict-migration-lanes.md
@@ -84,6 +84,9 @@ subgrafos sujos (`noUnusedLocals`/`strictNullChecks`) → cascata. **Promova lea
   hubs (PerformanceHub, GestaoAdmin, TintIntegracao/Catalogo, VendasFerramentas, AdminReposicaoParametros)
   e pages com fix próprio (Auth, AdminAjuda, AdminPriceTable, Support, ToolPublicHistory,
   AdminReposicaoSessaoPedidos, AdminStandardProcessNew).
+- 🔵 **`feat/strict-promote-pages-fixes2`** (sessão determined-allen, 2026-05-24): lote de fixes próprios
+  (grupo C) — AdminAjuda, Support, ToolPublicHistory (dead-code), Auth, AdminPriceTable (typing de setState).
+  Defiro AdminStandardProcessNew (zodResolver) e os hubs. **NÃO toco** lanes farmer/financeiro.
 - 🔵 **`feat/strict-promote-lib-leaf`** (sessão cranky-driscoll, 2026-05-23): lote leaf não-farmer —
   `lib/call-session/aggregate-customer-profile`, `lib/sip/sip-client`, `lib/transcription/{deepgram-client,transcription-engine}`,
   `components/customer360/format`, `components/financeiro/dashboard/format`, `components/portalSayerlack/types`,

--- a/src/components/auth/SignupForm.tsx
+++ b/src/components/auth/SignupForm.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Loader2, FileText, User, Lock, Eye, EyeOff, MapPin, Phone, Mail, AlertCircle, Factory, ChevronLeft } from 'lucide-react';
+import { Loader2, FileText, User, Lock, Eye, EyeOff, MapPin, AlertCircle, Factory, ChevronLeft } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';

--- a/src/pages/AdminAjuda.tsx
+++ b/src/pages/AdminAjuda.tsx
@@ -7,7 +7,7 @@ import { ScrollArea } from '@/components/ui/scroll-area';
 import { cn } from '@/lib/utils';
 import { MarkdownContent } from '@/components/help/MarkdownContent';
 import { helpModules, getHelpModule, defaultHelpModule } from '@/content/help';
-import { extractToc, slugify } from '@/lib/help-utils';
+import { extractToc } from '@/lib/help-utils';
 
 export default function AdminAjuda() {
   const [searchParams, setSearchParams] = useSearchParams();

--- a/src/pages/AdminPriceTable.tsx
+++ b/src/pages/AdminPriceTable.tsx
@@ -69,6 +69,7 @@ const AdminPriceTable = () => {
       if (pricesRes.data) {
         setPrices(pricesRes.data.map(p => ({
           ...p,
+          tool_category_id: p.tool_category_id ?? '',
           spec_filter: (p.spec_filter as Record<string, string>) || {},
         })));
         // Initialize edited prices

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -26,7 +26,16 @@ const Auth = () => {
   useEffect(() => {
     const loadToolCategories = async () => {
       const { data } = await supabase.from('tool_categories').select('*').order('name');
-      if (data) setToolCategories(data);
+      if (data) {
+        setToolCategories(data.map((c) => ({
+          id: c.id,
+          name: c.name,
+          description: c.description ?? '',
+          icon: c.icon ?? '',
+          usage_type: c.usage_type,
+          suggested_interval_days: c.suggested_interval_days ?? 90,
+        })));
+      }
     };
     loadToolCategories();
   }, []);

--- a/src/pages/Support.tsx
+++ b/src/pages/Support.tsx
@@ -6,7 +6,6 @@ import { useAuth } from '@/contexts/AuthContext';
 import { supabase } from '@/integrations/supabase/client';
 import { useQuery } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
-import { cn } from '@/lib/utils';
 
 const WHATSAPP_NUMBER = '553732221035';
 

--- a/src/pages/ToolPublicHistory.tsx
+++ b/src/pages/ToolPublicHistory.tsx
@@ -2,13 +2,12 @@ import { useState, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
-import { Separator } from '@/components/ui/separator';
 import { supabase } from '@/integrations/supabase/client';
 import { 
   Loader2, Wrench, AlertTriangle, CheckCircle, 
   FileText, Settings, Clock, Hash 
 } from 'lucide-react';
-import { format, formatDistanceToNow } from 'date-fns';
+import { format } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
 import { cn } from '@/lib/utils';
 

--- a/tsconfig.strict.json
+++ b/tsconfig.strict.json
@@ -481,6 +481,11 @@
     "src/pages/Index.tsx",
     "src/pages/AdminReposicaoHistorico.tsx",
     "src/pages/AdminVendorSipCredentials.tsx",
-    "src/pages/Orders.tsx"
+    "src/pages/Orders.tsx",
+    "src/pages/AdminAjuda.tsx",
+    "src/pages/Support.tsx",
+    "src/pages/ToolPublicHistory.tsx",
+    "src/pages/Auth.tsx",
+    "src/pages/AdminPriceTable.tsx"
   ]
 }


### PR DESCRIPTION
## Resumo

Lote de fixes próprios (grupo C da migração strict). Conserta o dead-code/typing que bloqueava e promove 5 pages ao `include`:

- `src/pages/AdminAjuda.tsx` — remove `slugify` não usado
- `src/pages/Support.tsx` — remove `cn` não usado
- `src/pages/ToolPublicHistory.tsx` — remove `Separator` + `formatDistanceToNow` não usados
- `src/pages/Auth.tsx` — normaliza `tool_categories` no `.map()` (colunas `description`/`icon`/`suggested_interval_days` nuláveis no DB → defaults); + `SignupForm` (puxado por Auth) remove `Phone`/`Mail` não usados
- `src/pages/AdminPriceTable.tsx` — coage `tool_category_id ?? ''` no `.map()` (mantém comportamento: id vazio → "Desconhecido")

Fixes localizados nos próprios sítios — **sem mexer em tipos compartilhados** (`ToolCategory`/`DefaultPrice` inalterados → zero cascata).

Deferidos: `AdminStandardProcessNew` (zodResolver, fiddly) e os hubs com `lazy()`.

## Gate

- `bun run typecheck:strict` → TSC_EXIT=0 (sem erros).

## Test plan

- [x] `typecheck:strict` verde localmente
- [ ] CI `validate` verde