### PR TITLE
refactor: split AdminAnalyticsSync (694→124) em hook + componentes

### DIFF
--- a/src/components/analyticsSync/EngineCards.tsx
+++ b/src/components/analyticsSync/EngineCards.tsx
@@ -1,0 +1,88 @@
+// Cards do Motor de Custo (fallback inteligente) e Regras de Associação (Apriori).
+// Extraídos verbatim de src/pages/AdminAnalyticsSync.tsx (god-component split).
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { RefreshCw, Calculator, GitBranch } from "lucide-react";
+import { type RecConfigs } from "./useAnalyticsSync";
+
+export function CostEngineCard({
+  isRunning,
+  pending,
+  recConfigs,
+  onRecalcular,
+}: {
+  isRunning: boolean;
+  pending: boolean;
+  recConfigs: RecConfigs;
+  onRecalcular: () => void;
+}) {
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <Calculator className="h-5 w-5 text-muted-foreground" />
+            <CardTitle className="text-base">Motor de Custo (Fallback Inteligente)</CardTitle>
+          </div>
+          <Button variant="outline" size="sm" disabled={isRunning} onClick={onRecalcular}>
+            <RefreshCw className={`h-3 w-3 mr-2 ${pending ? "animate-spin" : ""}`} />
+            Recalcular Custos
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <p className="text-xs text-muted-foreground mb-3">
+          Hierarquia: Custo Produto → CMC (Estoque) → Proxy Família → Proxy Default.
+          Divergência {">"} {((recConfigs?.find(c => c.key === "divergence_threshold")?.value || 0.2) * 100).toFixed(0)}%
+          aplica heurística estoque vs encomenda.
+        </p>
+        <div className="grid grid-cols-4 gap-3 text-center text-xs">
+          {["PRODUCT_COST", "CMC", "FAMILY_MARGIN_PROXY", "DEFAULT_PROXY"].map((source) => (
+            <div key={source} className="p-2 rounded bg-muted">
+              <div className="font-medium">{source.replace(/_/g, " ")}</div>
+              <div className="text-muted-foreground mt-1">
+                Confiança: {source === "PRODUCT_COST" ? "95%" : source === "CMC" ? "80%" : source === "FAMILY_MARGIN_PROXY" ? "50%" : "25%"}
+              </div>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function AssociationRulesCard({
+  isRunning,
+  pending,
+  recConfigs,
+  onRecalcular,
+}: {
+  isRunning: boolean;
+  pending: boolean;
+  recConfigs: RecConfigs;
+  onRecalcular: () => void;
+}) {
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <GitBranch className="h-5 w-5 text-muted-foreground" />
+            <CardTitle className="text-base">Regras de Associação (Apriori)</CardTitle>
+          </div>
+          <Button variant="outline" size="sm" disabled={isRunning} onClick={onRecalcular}>
+            <RefreshCw className={`h-3 w-3 mr-2 ${pending ? "animate-spin" : ""}`} />
+            Recalcular Regras
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <p className="text-xs text-muted-foreground">
+          Analisa co-ocorrências em pedidos para gerar regras do tipo "quem comprou A também comprou B".
+          Filtros: lift ≥ {recConfigs?.find(c => c.key === "l_min")?.value ?? 1.2}, support ≥ {recConfigs?.find(c => c.key === "s_min")?.value ?? 0.01}.
+          As regras alimentam o score Assoc(j|B) do motor de recomendação.
+        </p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/analyticsSync/EngineConfigCard.tsx
+++ b/src/components/analyticsSync/EngineConfigCard.tsx
@@ -1,0 +1,67 @@
+// Card de parâmetros editáveis do motor de recomendação.
+// Extraído verbatim de src/pages/AdminAnalyticsSync.tsx (god-component split).
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Loader2, Save, Settings } from "lucide-react";
+import { type RecConfigs } from "./useAnalyticsSync";
+
+interface EngineConfigCardProps {
+  isLoading: boolean;
+  recConfigs: RecConfigs;
+  editingConfig: Record<string, string>;
+  setEditingConfig: React.Dispatch<React.SetStateAction<Record<string, string>>>;
+  onSave: (id: string) => void;
+}
+
+export function EngineConfigCard({
+  isLoading,
+  recConfigs,
+  editingConfig,
+  setEditingConfig,
+  onSave,
+}: EngineConfigCardProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center gap-2">
+          <Settings className="h-5 w-5 text-muted-foreground" />
+          <CardTitle className="text-base">Parâmetros do Motor</CardTitle>
+        </div>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <div className="flex items-center justify-center py-8">
+            <Loader2 className="h-6 w-6 animate-spin" />
+          </div>
+        ) : (
+          <div className="grid gap-3 md:grid-cols-2 lg:grid-cols-3">
+            {(recConfigs || []).map((config) => {
+              const isEditing = editingConfig[config.id] !== undefined;
+              return (
+                <div key={config.id} className="p-3 rounded border text-sm space-y-2">
+                  <div className="font-mono font-medium text-xs">{config.key}</div>
+                  <div className="text-xs text-muted-foreground">{config.description}</div>
+                  <div className="flex items-center gap-2">
+                    <Input
+                      type="number"
+                      step="0.01"
+                      className="h-8 text-sm font-semibold"
+                      value={isEditing ? editingConfig[config.id] : config.value}
+                      onChange={(e) => setEditingConfig(prev => ({ ...prev, [config.id]: e.target.value }))}
+                    />
+                    {isEditing && (
+                      <Button size="sm" className="h-8 w-8 p-0" onClick={() => onSave(config.id)}>
+                        <Save className="h-3.5 w-3.5" />
+                      </Button>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/analyticsSync/ImportCards.tsx
+++ b/src/components/analyticsSync/ImportCards.tsx
@@ -1,0 +1,156 @@
+// Cards de importação em massa: clientes, endereços e pedidos (Omie).
+// Extraídos verbatim de src/pages/AdminAnalyticsSync.tsx (god-component split).
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { RefreshCw, Loader2, Sparkles, ShoppingCart, Users, MapPin } from "lucide-react";
+
+export function ImportClientesCard({
+  isRunning,
+  pending,
+  progress,
+  onImport,
+}: {
+  isRunning: boolean;
+  pending: boolean;
+  progress: string | null;
+  onImport: () => void;
+}) {
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <Users className="h-5 w-5 text-muted-foreground" />
+            <CardTitle className="text-base">Importar Clientes (3 Contas Omie)</CardTitle>
+          </div>
+          <Button variant="outline" size="sm" disabled={isRunning} onClick={onImport}>
+            {pending ? (
+              <Loader2 className="h-3 w-3 mr-2 animate-spin" />
+            ) : (
+              <RefreshCw className="h-3 w-3 mr-2" />
+            )}
+            Importar Todos
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <p className="text-xs text-muted-foreground">
+          Importa todos os clientes das 3 contas Omie (Colacor Afiação, Oben Vendas, Colacor Vendas),
+          criando perfis placeholder e mapeamentos em <code className="font-mono">omie_clientes</code>.
+          Pré-requisito para rodar os motores de inteligência (calculate-scores, algorithm-a-audit).
+        </p>
+        {progress && (
+          <div className="mt-3 flex items-center gap-2 text-xs text-primary font-medium">
+            <Loader2 className="h-3 w-3 animate-spin" />
+            {progress}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+export function ImportEnderecosCard({
+  isRunning,
+  pending,
+  progress,
+  onSync,
+}: {
+  isRunning: boolean;
+  pending: boolean;
+  progress: string | null;
+  onSync: () => void;
+}) {
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <MapPin className="h-5 w-5 text-muted-foreground" />
+            <CardTitle className="text-base">Sincronizar Endereços do Omie</CardTitle>
+          </div>
+          <Button variant="outline" size="sm" disabled={isRunning} onClick={onSync}>
+            {pending ? (
+              <Loader2 className="h-3 w-3 mr-2 animate-spin" />
+            ) : (
+              <RefreshCw className="h-3 w-3 mr-2" />
+            )}
+            Sincronizar Endereços
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <p className="text-xs text-muted-foreground">
+          Busca endereços dos clientes no Omie e popula a tabela <code className="font-mono">addresses</code>.
+          Pré-requisito para o roteirizador e funcionalidades que dependem de localização.
+        </p>
+        {progress && (
+          <div className="mt-3 flex items-center gap-2 text-xs text-primary font-medium">
+            <Loader2 className="h-3 w-3 animate-spin" />
+            {progress}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+export function ImportPedidosCard({
+  isRunning,
+  recentPending,
+  bulkPending,
+  progress,
+  onImportRecent,
+  onImportAll,
+}: {
+  isRunning: boolean;
+  recentPending: boolean;
+  bulkPending: boolean;
+  progress: string | null;
+  onImportRecent: () => void;
+  onImportAll: () => void;
+}) {
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <ShoppingCart className="h-5 w-5 text-muted-foreground" />
+            <CardTitle className="text-base">Importar Pedidos (Oben + Colacor)</CardTitle>
+          </div>
+          <div className="flex gap-2">
+            <Button variant="default" size="sm" disabled={isRunning} onClick={onImportRecent}>
+              {recentPending ? (
+                <Loader2 className="h-3 w-3 mr-2 animate-spin" />
+              ) : (
+                <Sparkles className="h-3 w-3 mr-2" />
+              )}
+              Importar Recentes (180d)
+            </Button>
+            <Button variant="outline" size="sm" disabled={isRunning} onClick={onImportAll}>
+              {bulkPending ? (
+                <Loader2 className="h-3 w-3 mr-2 animate-spin" />
+              ) : (
+                <RefreshCw className="h-3 w-3 mr-2" />
+              )}
+              Importar Todos
+            </Button>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <p className="text-xs text-muted-foreground">
+          <strong>Importar Recentes:</strong> busca apenas pedidos dos últimos 180 dias (rápido, ~2 min).
+          <br />
+          <strong>Importar Todos:</strong> varre todo o histórico (~425 páginas, pode levar 30+ min).
+        </p>
+        {progress && (
+          <div className="mt-3 flex items-center gap-2 text-xs text-primary font-medium">
+            <Loader2 className="h-3 w-3 animate-spin" />
+            {progress}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/analyticsSync/SyncEntitiesGrid.tsx
+++ b/src/components/analyticsSync/SyncEntitiesGrid.tsx
@@ -1,0 +1,76 @@
+// Grade de cards de sincronização por entidade (clientes/produtos/pedidos/estoque).
+// Extraída verbatim de src/pages/AdminAnalyticsSync.tsx (god-component split).
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { RefreshCw, Clock } from "lucide-react";
+import { ENTITY_CONFIG, STATUS_MAP, type SyncEntity, type SyncState } from "./types";
+
+interface SyncEntitiesGridProps {
+  selectedAccount: string;
+  getStateFor: (entity: string, account: string) => SyncState | undefined;
+  formatDate: (d: string | null) => string;
+  isRunning: boolean;
+  onSync: (entity: SyncEntity) => void;
+}
+
+export function SyncEntitiesGrid({ selectedAccount, getStateFor, formatDate, isRunning, onSync }: SyncEntitiesGridProps) {
+  return (
+    <div className="grid gap-4 md:grid-cols-2">
+      {(Object.entries(ENTITY_CONFIG) as [SyncEntity, typeof ENTITY_CONFIG[SyncEntity]][]).map(
+        ([entity, config]) => {
+          const state = getStateFor(entity, selectedAccount);
+          const statusCfg = STATUS_MAP[state?.status || "idle"];
+          const StatusIcon = statusCfg?.icon || Clock;
+
+          return (
+            <Card key={entity}>
+              <CardHeader className="pb-3">
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    <config.icon className="h-5 w-5 text-muted-foreground" />
+                    <CardTitle className="text-base">{config.label}</CardTitle>
+                  </div>
+                  <Badge variant={statusCfg?.variant || "secondary"}>
+                    <StatusIcon className={`h-3 w-3 mr-1 ${state?.status === "running" ? "animate-spin" : ""}`} />
+                    {state?.status || "idle"}
+                  </Badge>
+                </div>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                <p className="text-xs text-muted-foreground">{config.description}</p>
+                <div className="grid grid-cols-2 gap-2 text-sm">
+                  <div>
+                    <span className="text-muted-foreground">Último sync:</span>
+                    <br />
+                    <span className="font-medium">{formatDate(state?.last_sync_at || null)}</span>
+                  </div>
+                  <div>
+                    <span className="text-muted-foreground">Registros:</span>
+                    <br />
+                    <span className="font-medium">{state?.total_synced || 0}</span>
+                  </div>
+                </div>
+                {state?.error_message && (
+                  <p className="text-xs text-destructive bg-destructive/10 p-2 rounded">
+                    {state.error_message.substring(0, 150)}
+                  </p>
+                )}
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="w-full"
+                  disabled={isRunning}
+                  onClick={() => onSync(entity)}
+                >
+                  <RefreshCw className={`h-3 w-3 mr-2 ${isRunning ? "animate-spin" : ""}`} />
+                  Sincronizar {config.label}
+                </Button>
+              </CardContent>
+            </Card>
+          );
+        }
+      )}
+    </div>
+  );
+}

--- a/src/components/analyticsSync/__tests__/EngineCards.test.tsx
+++ b/src/components/analyticsSync/__tests__/EngineCards.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { CostEngineCard, AssociationRulesCard } from "../EngineCards";
+import type { RecConfigs } from "../useAnalyticsSync";
+
+const recConfigs = [
+  { id: "1", key: "divergence_threshold", value: 0.25, description: "limiar" },
+  { id: "2", key: "l_min", value: 1.5, description: "lift mínimo" },
+  { id: "3", key: "s_min", value: 0.02, description: "support mínimo" },
+] as unknown as RecConfigs;
+
+describe("CostEngineCard", () => {
+  it("calcula a divergência a partir do recConfigs e mostra as 4 fontes", () => {
+    render(<CostEngineCard isRunning={false} pending={false} recConfigs={recConfigs} onRecalcular={() => {}} />);
+    expect(screen.getByText(/Divergência > 25%/)).toBeTruthy();
+    expect(screen.getByText("PRODUCT COST")).toBeTruthy();
+    expect(screen.getByText("DEFAULT PROXY")).toBeTruthy();
+  });
+
+  it("usa 20% como fallback quando não há config", () => {
+    render(<CostEngineCard isRunning={false} pending={false} recConfigs={undefined} onRecalcular={() => {}} />);
+    expect(screen.getByText(/Divergência > 20%/)).toBeTruthy();
+  });
+
+  it("dispara onRecalcular", () => {
+    const onRecalcular = vi.fn();
+    render(<CostEngineCard isRunning={false} pending={false} recConfigs={recConfigs} onRecalcular={onRecalcular} />);
+    fireEvent.click(screen.getByRole("button", { name: /Recalcular Custos/ }));
+    expect(onRecalcular).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("AssociationRulesCard", () => {
+  it("mostra lift e support do recConfigs", () => {
+    render(<AssociationRulesCard isRunning={false} pending={false} recConfigs={recConfigs} onRecalcular={() => {}} />);
+    expect(screen.getByText(/lift ≥ 1\.5/)).toBeTruthy();
+    expect(screen.getByText(/support ≥ 0\.02/)).toBeTruthy();
+  });
+
+  it("usa fallbacks (1.2 / 0.01) quando não há config", () => {
+    render(<AssociationRulesCard isRunning={false} pending={false} recConfigs={undefined} onRecalcular={() => {}} />);
+    expect(screen.getByText(/lift ≥ 1\.2/)).toBeTruthy();
+    expect(screen.getByText(/support ≥ 0\.01/)).toBeTruthy();
+  });
+});

--- a/src/components/analyticsSync/__tests__/EngineConfigCard.test.tsx
+++ b/src/components/analyticsSync/__tests__/EngineConfigCard.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { EngineConfigCard } from "../EngineConfigCard";
+import type { RecConfigs } from "../useAnalyticsSync";
+
+const recConfigs = [
+  { id: "1", key: "alpha", value: 0.5, description: "peso alpha" },
+  { id: "2", key: "beta", value: 0.3, description: "peso beta" },
+] as unknown as RecConfigs;
+
+describe("EngineConfigCard", () => {
+  it("mostra spinner quando isLoading", () => {
+    const { container } = render(
+      <EngineConfigCard isLoading recConfigs={recConfigs} editingConfig={{}} setEditingConfig={vi.fn()} onSave={vi.fn()} />,
+    );
+    expect(container.querySelector(".animate-spin")).toBeTruthy();
+  });
+
+  it("renderiza as chaves e descrições dos parâmetros", () => {
+    render(
+      <EngineConfigCard isLoading={false} recConfigs={recConfigs} editingConfig={{}} setEditingConfig={vi.fn()} onSave={vi.fn()} />,
+    );
+    expect(screen.getByText("alpha")).toBeTruthy();
+    expect(screen.getByText("peso beta")).toBeTruthy();
+  });
+
+  it("mostra o botão Salvar somente para o parâmetro em edição e dispara onSave", () => {
+    const onSave = vi.fn();
+    render(
+      <EngineConfigCard
+        isLoading={false}
+        recConfigs={recConfigs}
+        editingConfig={{ "1": "0.9" }}
+        setEditingConfig={vi.fn()}
+        onSave={onSave}
+      />,
+    );
+    const saveButtons = screen.getAllByRole("button");
+    expect(saveButtons).toHaveLength(1); // só o parâmetro id "1" está em edição
+    fireEvent.click(saveButtons[0]);
+    expect(onSave).toHaveBeenCalledWith("1");
+  });
+
+  it("dispara setEditingConfig ao digitar num parâmetro", () => {
+    const setEditingConfig = vi.fn();
+    render(
+      <EngineConfigCard
+        isLoading={false}
+        recConfigs={recConfigs}
+        editingConfig={{}}
+        setEditingConfig={setEditingConfig}
+        onSave={vi.fn()}
+      />,
+    );
+    const inputs = screen.getAllByRole("spinbutton");
+    fireEvent.change(inputs[0], { target: { value: "0.7" } });
+    expect(setEditingConfig).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/analyticsSync/__tests__/ImportCards.test.tsx
+++ b/src/components/analyticsSync/__tests__/ImportCards.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ImportClientesCard, ImportEnderecosCard, ImportPedidosCard } from "../ImportCards";
+
+describe("ImportClientesCard", () => {
+  it("renderiza título e dispara onImport", () => {
+    const onImport = vi.fn();
+    render(<ImportClientesCard isRunning={false} pending={false} progress={null} onImport={onImport} />);
+    expect(screen.getByText("Importar Clientes (3 Contas Omie)")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: /Importar Todos/ }));
+    expect(onImport).toHaveBeenCalledTimes(1);
+  });
+
+  it("mostra o progresso quando presente", () => {
+    render(<ImportClientesCard isRunning pending progress="Conta 1/3 — página 2..." onImport={() => {}} />);
+    expect(screen.getByText("Conta 1/3 — página 2...")).toBeTruthy();
+  });
+});
+
+describe("ImportEnderecosCard", () => {
+  it("renderiza título e dispara onSync", () => {
+    const onSync = vi.fn();
+    render(<ImportEnderecosCard isRunning={false} pending={false} progress={null} onSync={onSync} />);
+    expect(screen.getByText("Sincronizar Endereços do Omie")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: /Sincronizar Endereços/ }));
+    expect(onSync).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("ImportPedidosCard", () => {
+  it("dispara onImportRecent e onImportAll separadamente", () => {
+    const onImportRecent = vi.fn();
+    const onImportAll = vi.fn();
+    render(
+      <ImportPedidosCard
+        isRunning={false}
+        recentPending={false}
+        bulkPending={false}
+        progress={null}
+        onImportRecent={onImportRecent}
+        onImportAll={onImportAll}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Importar Recentes/ }));
+    fireEvent.click(screen.getByRole("button", { name: /Importar Todos/ }));
+    expect(onImportRecent).toHaveBeenCalledTimes(1);
+    expect(onImportAll).toHaveBeenCalledTimes(1);
+  });
+
+  it("desabilita os botões quando isRunning", () => {
+    render(
+      <ImportPedidosCard
+        isRunning
+        recentPending={false}
+        bulkPending={false}
+        progress={null}
+        onImportRecent={() => {}}
+        onImportAll={() => {}}
+      />,
+    );
+    expect(screen.getByRole("button", { name: /Importar Recentes/ })).toHaveProperty("disabled", true);
+    expect(screen.getByRole("button", { name: /Importar Todos/ })).toHaveProperty("disabled", true);
+  });
+});

--- a/src/components/analyticsSync/__tests__/SyncEntitiesGrid.test.tsx
+++ b/src/components/analyticsSync/__tests__/SyncEntitiesGrid.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { SyncEntitiesGrid } from "../SyncEntitiesGrid";
+import type { SyncState } from "../types";
+
+function setup(overrides: Partial<React.ComponentProps<typeof SyncEntitiesGrid>> = {}) {
+  const props: React.ComponentProps<typeof SyncEntitiesGrid> = {
+    selectedAccount: "vendas",
+    getStateFor: () => undefined,
+    formatDate: (d) => (d ? "20/05/2026" : "Nunca"),
+    isRunning: false,
+    onSync: vi.fn(),
+    ...overrides,
+  };
+  render(<SyncEntitiesGrid {...props} />);
+  return props;
+}
+
+describe("SyncEntitiesGrid", () => {
+  it("renderiza os 4 cards de entidade", () => {
+    setup();
+    expect(screen.getByText("Clientes")).toBeTruthy();
+    expect(screen.getByText("Produtos")).toBeTruthy();
+    expect(screen.getByText("Pedidos")).toBeTruthy();
+    expect(screen.getByText("Estoque")).toBeTruthy();
+  });
+
+  it("mostra status e registros do state quando presente", () => {
+    const state = { entity_type: "customers", account: "vendas", status: "running", total_synced: 42, last_sync_at: "2026-05-20T10:00:00Z", error_message: null } as unknown as SyncState;
+    setup({ getStateFor: (e) => (e === "customers" ? state : undefined) });
+    expect(screen.getByText("running")).toBeTruthy();
+    expect(screen.getByText("42")).toBeTruthy();
+  });
+
+  it("dispara onSync com a entidade ao clicar no botão", () => {
+    const props = setup();
+    fireEvent.click(screen.getByRole("button", { name: /Sincronizar Clientes/ }));
+    expect(props.onSync).toHaveBeenCalledWith("customers");
+  });
+
+  it("desabilita os botões quando isRunning", () => {
+    setup({ isRunning: true });
+    expect(screen.getByRole("button", { name: /Sincronizar Produtos/ })).toHaveProperty("disabled", true);
+  });
+});

--- a/src/components/analyticsSync/types.ts
+++ b/src/components/analyticsSync/types.ts
@@ -1,0 +1,31 @@
+// Tipos e constantes da tela de Sincronização & Analytics.
+// Extraídos verbatim de src/pages/AdminAnalyticsSync.tsx (god-component split).
+import { Database, Package, ShoppingCart, Warehouse, CheckCircle, AlertCircle, Clock, Loader2 } from "lucide-react";
+
+export type SyncEntity = "customers" | "products" | "orders" | "inventory";
+export type OmieAccount = "vendas" | "servicos";
+
+export interface SyncState {
+  id: string;
+  entity_type: string;
+  account: string;
+  last_sync_at: string | null;
+  total_synced: number;
+  status: string;
+  error_message: string | null;
+  updated_at: string;
+}
+
+export const ENTITY_CONFIG: Record<SyncEntity, { label: string; icon: typeof Database; description: string }> = {
+  customers: { label: "Clientes", icon: Database, description: "Sincronizar clientes e mapear com perfis locais" },
+  products: { label: "Produtos", icon: Package, description: "Catálogo de produtos com família e subfamília" },
+  orders: { label: "Pedidos", icon: ShoppingCart, description: "Sync incremental com janela de 24h" },
+  inventory: { label: "Estoque", icon: Warehouse, description: "Posição de estoque + CMC para custo" },
+};
+
+export const STATUS_MAP: Record<string, { variant: "default" | "secondary" | "destructive" | "outline"; icon: typeof Clock }> = {
+  idle: { variant: "secondary", icon: Clock },
+  running: { variant: "default", icon: Loader2 },
+  complete: { variant: "outline", icon: CheckCircle },
+  error: { variant: "destructive", icon: AlertCircle },
+};

--- a/src/components/analyticsSync/useAnalyticsSync.ts
+++ b/src/components/analyticsSync/useAnalyticsSync.ts
@@ -1,0 +1,361 @@
+// Lógica da tela de Sincronização & Analytics (queries, mutations, sync orquestrado).
+// Extraída verbatim de src/pages/AdminAnalyticsSync.tsx (god-component split).
+import { useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { supabase } from "@/integrations/supabase/client";
+import { useAuth } from "@/contexts/AuthContext";
+import { toast } from "sonner";
+import { OmieAccount, SyncState } from "./types";
+
+export type RecConfigs = ReturnType<typeof useAnalyticsSync>["recConfigs"];
+
+export function useAnalyticsSync() {
+  const [selectedAccount, setSelectedAccount] = useState<OmieAccount>("vendas");
+  const { user } = useAuth();
+  const queryClient = useQueryClient();
+
+  // Check if user has the master CPF for sync health access
+  const { data: profileData } = useQuery({
+    queryKey: ["profile-doc", user?.id],
+    queryFn: async () => {
+      if (!user?.id) return null;
+      const { data } = await supabase
+        .from("profiles")
+        .select("document")
+        .eq("user_id", user.id)
+        .maybeSingle();
+      return data;
+    },
+    enabled: !!user?.id,
+  });
+
+  const userDoc = (profileData?.document || "").replace(/\D/g, "");
+  const showSyncHealth = userDoc === "01363383647";
+
+  const { data: syncStates, isLoading } = useQuery({
+    queryKey: ["sync-state"],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from("sync_state")
+        .select("*")
+        .order("entity_type");
+      if (error) throw error;
+      return data as SyncState[];
+    },
+    refetchInterval: 5000,
+  });
+
+  const { data: recConfigs } = useQuery({
+    queryKey: ["recommendation-config"],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from("recommendation_config")
+        .select("*")
+        .order("key");
+      if (error) throw error;
+      return data;
+    },
+  });
+
+  const syncMutation = useMutation({
+    mutationFn: async ({ action, account }: { action: string; account: OmieAccount }) => {
+      const { data, error } = await supabase.functions.invoke("omie-analytics-sync", {
+        body: { action, account },
+      });
+      if (error) throw error;
+      return data;
+    },
+    onSuccess: (data, variables) => {
+      toast.success(`Sync ${variables.action} concluído`, {
+        description: JSON.stringify(data?.data || {}).substring(0, 100),
+      });
+      queryClient.invalidateQueries({ queryKey: ["sync-state"] });
+    },
+    onError: (error) => {
+      toast.error("Erro no sync", { description: String(error) });
+    },
+  });
+
+  const computeCostsMutation = useMutation({
+    mutationFn: async () => {
+      const { data, error } = await supabase.functions.invoke("omie-analytics-sync", {
+        body: { action: "compute_costs" },
+      });
+      if (error) throw error;
+      return data;
+    },
+    onSuccess: (data) => {
+      toast.success("Custos recalculados", {
+        description: `${data?.data?.updated || 0} produtos atualizados`,
+      });
+    },
+    onError: (error) => {
+      toast.error("Erro ao calcular custos", { description: String(error) });
+    },
+  });
+
+  const assocRulesMutation = useMutation({
+    mutationFn: async () => {
+      const { data, error } = await supabase.functions.invoke("omie-analytics-sync", {
+        body: { action: "compute_association_rules" },
+      });
+      if (error) throw error;
+      return data;
+    },
+    onSuccess: (data) => {
+      toast.success("Regras de associação geradas", {
+        description: `${data?.data?.rules_generated || 0} regras a partir de ${data?.data?.total_transactions || 0} transações`,
+      });
+    },
+    onError: (error) => {
+      toast.error("Erro ao gerar regras", { description: String(error) });
+    },
+  });
+
+  const updateConfigMutation = useMutation({
+    mutationFn: async ({ id, value }: { id: string; value: number }) => {
+      const { error } = await supabase
+        .from("recommendation_config")
+        .update({ value, updated_at: new Date().toISOString() })
+        .eq("id", id);
+      if (error) throw error;
+    },
+    onSuccess: () => {
+      toast.success("Parâmetro atualizado");
+      queryClient.invalidateQueries({ queryKey: ["recommendation-config"] });
+    },
+    onError: (error) => {
+      toast.error("Erro ao atualizar", { description: String(error) });
+    },
+  });
+
+  const [clientSyncProgress, setClientSyncProgress] = useState<string | null>(null);
+
+  const bulkClientSyncMutation = useMutation({
+    mutationFn: async () => {
+      let accountIndex = 0;
+      let startPage = 1;
+      let totalImported = 0;
+      let totalSkipped = 0;
+      let totalErrors = 0;
+
+      while (true) {
+        setClientSyncProgress(`Conta ${accountIndex + 1}/3 — página ${startPage}...`);
+        const { data, error } = await supabase.functions.invoke("omie-cliente", {
+          body: { action: "sync_all_clients", account_index: accountIndex, start_page: startPage },
+        });
+        if (error) throw error;
+
+        totalImported += data?.imported || 0;
+        totalSkipped += data?.skipped || 0;
+        totalErrors += data?.errors || 0;
+
+        if (data?.account) {
+          setClientSyncProgress(`${data.account}: +${data.imported} importados (pág ${data.lastPage}/${data.totalPages})`);
+        }
+
+        if (!data?.hasMore) break;
+        accountIndex = data.next.account_index;
+        startPage = data.next.start_page;
+      }
+
+      setClientSyncProgress(null);
+      return { totalImported, totalSkipped, totalErrors };
+    },
+    onSuccess: (data) => {
+      toast.success("Importação de clientes concluída", {
+        description: `${data.totalImported} importados, ${data.totalSkipped} já existiam, ${data.totalErrors} erros`,
+        duration: 10000,
+      });
+    },
+    onError: (error) => {
+      setClientSyncProgress(null);
+      toast.error("Erro na importação de clientes", { description: String(error) });
+    },
+  });
+
+  const addressSyncMutation = useMutation({
+    mutationFn: async () => {
+      let totalSynced = 0;
+      let totalSkipped = 0;
+      let totalErrors = 0;
+      let totalNeeding = 0;
+      let hasMore = true;
+      let iteration = 0;
+
+      while (hasMore) {
+        iteration++;
+        setAddressSyncProgress(`Sincronizando endereços... (lote ${iteration}, ${totalSynced} criados)`);
+        const { data, error } = await supabase.functions.invoke("omie-cliente", {
+          body: { action: "sync_addresses", batch_size: 30 },
+        });
+        if (error) throw error;
+
+        totalSynced += data?.synced || 0;
+        totalSkipped += data?.skipped || 0;
+        totalErrors += data?.errors || 0;
+        totalNeeding = data?.totalNeeding || 0;
+        hasMore = data?.hasMore || false;
+
+        // Safety: if batch produced 0 synced AND 0 skipped AND 0 errors, stop to avoid infinite loop
+        if ((data?.synced || 0) === 0 && (data?.skipped || 0) === 0 && (data?.errors || 0) === 0) {
+          hasMore = false;
+        }
+      }
+
+      setAddressSyncProgress(null);
+      return { synced: totalSynced, skipped: totalSkipped, errors: totalErrors, totalNeeding };
+    },
+    onSuccess: (data) => {
+      toast.success("Sincronização de endereços concluída", {
+        description: `${data?.synced || 0} endereços criados, ${data?.skipped || 0} ignorados, ${data?.errors || 0} erros (de ${data?.totalNeeding || 0} pendentes)`,
+        duration: 10000,
+      });
+    },
+    onError: (error) => {
+      setAddressSyncProgress(null);
+      toast.error("Erro na sincronização de endereços", { description: String(error) });
+    },
+  });
+
+  const [editingConfig, setEditingConfig] = useState<Record<string, string>>({});
+  const [addressSyncProgress, setAddressSyncProgress] = useState<string | null>(null);
+  const [ordersSyncProgress, setOrdersSyncProgress] = useState<string | null>(null);
+
+  // Helper to format date as DD/MM/YYYY
+  const formatOmieDate = (date: Date) => {
+    const dd = String(date.getDate()).padStart(2, '0');
+    const mm = String(date.getMonth() + 1).padStart(2, '0');
+    const yyyy = date.getFullYear();
+    return `${dd}/${mm}/${yyyy}`;
+  };
+
+  const runOrdersSync = async (dateFrom?: string, dateTo?: string) => {
+    const accounts: Array<{ name: string; account: string }> = [
+      { name: "Oben", account: "oben" },
+      { name: "Colacor", account: "colacor" },
+    ];
+    let grandTotalSynced = 0;
+    let grandTotalItems = 0;
+    let grandTotalSkipped = 0;
+
+    for (const acc of accounts) {
+      let startPage = 1;
+      let complete = false;
+
+      while (!complete) {
+        setOrdersSyncProgress(`${acc.name}: página ${startPage}...`);
+        const { data, error } = await supabase.functions.invoke("omie-vendas-sync", {
+          body: {
+            action: "sync_pedidos",
+            account: acc.account,
+            start_page: startPage,
+            max_pages: 10,
+            ...(dateFrom && { date_from: dateFrom }),
+            ...(dateTo && { date_to: dateTo }),
+          },
+        });
+        if (error) throw new Error(`${acc.name}: ${error.message}`);
+
+        grandTotalSynced += data?.totalSynced || 0;
+        grandTotalItems += data?.totalItems || 0;
+        grandTotalSkipped += data?.skippedNoClient || 0;
+
+        const lastPage = data?.lastPage || startPage;
+        const totalPages = data?.totalPaginas || 1;
+        setOrdersSyncProgress(`${acc.name}: pág ${lastPage}/${totalPages} — ${grandTotalSynced} pedidos importados`);
+
+        if (data?.complete || !data?.nextPage) {
+          complete = true;
+        } else {
+          startPage = data.nextPage;
+        }
+      }
+    }
+
+    // Refresh materialized view after import
+    setOrdersSyncProgress("Atualizando métricas de clientes...");
+    await supabase.rpc("refresh_customer_metrics");
+
+    setOrdersSyncProgress(null);
+    return { grandTotalSynced, grandTotalItems, grandTotalSkipped };
+  };
+
+  const bulkOrdersSyncMutation = useMutation({
+    mutationFn: () => runOrdersSync(),
+    onSuccess: (data) => {
+      toast.success("Importação de pedidos concluída", {
+        description: `${data.grandTotalSynced} pedidos, ${data.grandTotalItems} itens, ${data.grandTotalSkipped} sem cliente`,
+        duration: 10000,
+      });
+      queryClient.invalidateQueries({ queryKey: ["sync-state"] });
+    },
+    onError: (error) => {
+      setOrdersSyncProgress(null);
+      toast.error("Erro na importação de pedidos", { description: String(error) });
+    },
+  });
+
+  const recentOrdersSyncMutation = useMutation({
+    mutationFn: () => {
+      const now = new Date();
+      const from = new Date(now);
+      from.setDate(from.getDate() - 180);
+      return runOrdersSync(formatOmieDate(from), formatOmieDate(now));
+    },
+    onSuccess: (data) => {
+      toast.success("Importação recente concluída", {
+        description: `${data.grandTotalSynced} pedidos, ${data.grandTotalItems} itens`,
+        duration: 10000,
+      });
+      queryClient.invalidateQueries({ queryKey: ["sync-state"] });
+    },
+    onError: (error) => {
+      setOrdersSyncProgress(null);
+      toast.error("Erro na importação recente", { description: String(error) });
+    },
+  });
+
+  const getStateFor = (entity: string, account: string) =>
+    syncStates?.find((s) => s.entity_type === entity && s.account === account);
+
+  const formatDate = (d: string | null) => {
+    if (!d) return "Nunca";
+    return new Date(d).toLocaleString("pt-BR", { dateStyle: "short", timeStyle: "short" });
+  };
+
+  const isRunning = syncMutation.isPending || computeCostsMutation.isPending || assocRulesMutation.isPending || bulkClientSyncMutation.isPending || bulkOrdersSyncMutation.isPending || recentOrdersSyncMutation.isPending || addressSyncMutation.isPending;
+
+  const handleConfigSave = (id: string) => {
+    const val = parseFloat(editingConfig[id]);
+    if (!isNaN(val)) {
+      updateConfigMutation.mutate({ id, value: val });
+      setEditingConfig(prev => { const n = { ...prev }; delete n[id]; return n; });
+    }
+  };
+
+  return {
+    selectedAccount,
+    setSelectedAccount,
+    showSyncHealth,
+    syncStates,
+    isLoading,
+    recConfigs,
+    syncMutation,
+    computeCostsMutation,
+    assocRulesMutation,
+    bulkClientSyncMutation,
+    addressSyncMutation,
+    bulkOrdersSyncMutation,
+    recentOrdersSyncMutation,
+    clientSyncProgress,
+    addressSyncProgress,
+    ordersSyncProgress,
+    editingConfig,
+    setEditingConfig,
+    getStateFor,
+    formatDate,
+    isRunning,
+    handleConfigSave,
+  };
+}

--- a/src/pages/AdminAnalyticsSync.tsx
+++ b/src/pages/AdminAnalyticsSync.tsx
@@ -1,369 +1,36 @@
-import { useState } from "react";
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { supabase } from "@/integrations/supabase/client";
-import { useAuth } from "@/contexts/AuthContext";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
-import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { RefreshCw, Database, Package, ShoppingCart, Warehouse, Calculator, Play, CheckCircle, AlertCircle, Clock, Loader2, Save, GitBranch, Sparkles, FlaskConical, Settings, ShieldCheck, Users, MapPin } from "lucide-react";
-import { toast } from "sonner";
-
-
-type SyncEntity = "customers" | "products" | "orders" | "inventory";
-type OmieAccount = "vendas" | "servicos";
-
-interface SyncState {
-  id: string;
-  entity_type: string;
-  account: string;
-  last_sync_at: string | null;
-  total_synced: number;
-  status: string;
-  error_message: string | null;
-  updated_at: string;
-}
-
-const ENTITY_CONFIG: Record<SyncEntity, { label: string; icon: typeof Database; description: string }> = {
-  customers: { label: "Clientes", icon: Database, description: "Sincronizar clientes e mapear com perfis locais" },
-  products: { label: "Produtos", icon: Package, description: "Catálogo de produtos com família e subfamília" },
-  orders: { label: "Pedidos", icon: ShoppingCart, description: "Sync incremental com janela de 24h" },
-  inventory: { label: "Estoque", icon: Warehouse, description: "Posição de estoque + CMC para custo" },
-};
-
-const STATUS_MAP: Record<string, { variant: "default" | "secondary" | "destructive" | "outline"; icon: typeof Clock }> = {
-  idle: { variant: "secondary", icon: Clock },
-  running: { variant: "default", icon: Loader2 },
-  complete: { variant: "outline", icon: CheckCircle },
-  error: { variant: "destructive", icon: AlertCircle },
-};
+import { Play, Loader2 } from "lucide-react";
+import { type OmieAccount } from "@/components/analyticsSync/types";
+import { useAnalyticsSync } from "@/components/analyticsSync/useAnalyticsSync";
+import { SyncEntitiesGrid } from "@/components/analyticsSync/SyncEntitiesGrid";
+import { ImportClientesCard, ImportEnderecosCard, ImportPedidosCard } from "@/components/analyticsSync/ImportCards";
+import { CostEngineCard, AssociationRulesCard } from "@/components/analyticsSync/EngineCards";
+import { EngineConfigCard } from "@/components/analyticsSync/EngineConfigCard";
 
 export default function AdminAnalyticsSync() {
-  const [selectedAccount, setSelectedAccount] = useState<OmieAccount>("vendas");
-  const { user } = useAuth();
-  const queryClient = useQueryClient();
-
-  // Check if user has the master CPF for sync health access
-  const { data: profileData } = useQuery({
-    queryKey: ["profile-doc", user?.id],
-    queryFn: async () => {
-      if (!user?.id) return null;
-      const { data } = await supabase
-        .from("profiles")
-        .select("document")
-        .eq("user_id", user.id)
-        .maybeSingle();
-      return data;
-    },
-    enabled: !!user?.id,
-  });
-
-  const userDoc = (profileData?.document || "").replace(/\D/g, "");
-  const showSyncHealth = userDoc === "01363383647";
-
-  const { data: syncStates, isLoading } = useQuery({
-    queryKey: ["sync-state"],
-    queryFn: async () => {
-      const { data, error } = await supabase
-        .from("sync_state")
-        .select("*")
-        .order("entity_type");
-      if (error) throw error;
-      return data as SyncState[];
-    },
-    refetchInterval: 5000,
-  });
-
-  const { data: recConfigs } = useQuery({
-    queryKey: ["recommendation-config"],
-    queryFn: async () => {
-      const { data, error } = await supabase
-        .from("recommendation_config")
-        .select("*")
-        .order("key");
-      if (error) throw error;
-      return data;
-    },
-  });
-
-  const syncMutation = useMutation({
-    mutationFn: async ({ action, account }: { action: string; account: OmieAccount }) => {
-      const { data, error } = await supabase.functions.invoke("omie-analytics-sync", {
-        body: { action, account },
-      });
-      if (error) throw error;
-      return data;
-    },
-    onSuccess: (data, variables) => {
-      toast.success(`Sync ${variables.action} concluído`, {
-        description: JSON.stringify(data?.data || {}).substring(0, 100),
-      });
-      queryClient.invalidateQueries({ queryKey: ["sync-state"] });
-    },
-    onError: (error) => {
-      toast.error("Erro no sync", { description: String(error) });
-    },
-  });
-
-  const computeCostsMutation = useMutation({
-    mutationFn: async () => {
-      const { data, error } = await supabase.functions.invoke("omie-analytics-sync", {
-        body: { action: "compute_costs" },
-      });
-      if (error) throw error;
-      return data;
-    },
-    onSuccess: (data) => {
-      toast.success("Custos recalculados", {
-        description: `${data?.data?.updated || 0} produtos atualizados`,
-      });
-    },
-    onError: (error) => {
-      toast.error("Erro ao calcular custos", { description: String(error) });
-    },
-  });
-
-  const assocRulesMutation = useMutation({
-    mutationFn: async () => {
-      const { data, error } = await supabase.functions.invoke("omie-analytics-sync", {
-        body: { action: "compute_association_rules" },
-      });
-      if (error) throw error;
-      return data;
-    },
-    onSuccess: (data) => {
-      toast.success("Regras de associação geradas", {
-        description: `${data?.data?.rules_generated || 0} regras a partir de ${data?.data?.total_transactions || 0} transações`,
-      });
-    },
-    onError: (error) => {
-      toast.error("Erro ao gerar regras", { description: String(error) });
-    },
-  });
-
-  const updateConfigMutation = useMutation({
-    mutationFn: async ({ id, value }: { id: string; value: number }) => {
-      const { error } = await supabase
-        .from("recommendation_config")
-        .update({ value, updated_at: new Date().toISOString() })
-        .eq("id", id);
-      if (error) throw error;
-    },
-    onSuccess: () => {
-      toast.success("Parâmetro atualizado");
-      queryClient.invalidateQueries({ queryKey: ["recommendation-config"] });
-    },
-    onError: (error) => {
-      toast.error("Erro ao atualizar", { description: String(error) });
-    },
-  });
-
-  const [clientSyncProgress, setClientSyncProgress] = useState<string | null>(null);
-
-  const bulkClientSyncMutation = useMutation({
-    mutationFn: async () => {
-      let accountIndex = 0;
-      let startPage = 1;
-      let totalImported = 0;
-      let totalSkipped = 0;
-      let totalErrors = 0;
-
-      while (true) {
-        setClientSyncProgress(`Conta ${accountIndex + 1}/3 — página ${startPage}...`);
-        const { data, error } = await supabase.functions.invoke("omie-cliente", {
-          body: { action: "sync_all_clients", account_index: accountIndex, start_page: startPage },
-        });
-        if (error) throw error;
-
-        totalImported += data?.imported || 0;
-        totalSkipped += data?.skipped || 0;
-        totalErrors += data?.errors || 0;
-
-        if (data?.account) {
-          setClientSyncProgress(`${data.account}: +${data.imported} importados (pág ${data.lastPage}/${data.totalPages})`);
-        }
-
-        if (!data?.hasMore) break;
-        accountIndex = data.next.account_index;
-        startPage = data.next.start_page;
-      }
-
-      setClientSyncProgress(null);
-      return { totalImported, totalSkipped, totalErrors };
-    },
-    onSuccess: (data) => {
-      toast.success("Importação de clientes concluída", {
-        description: `${data.totalImported} importados, ${data.totalSkipped} já existiam, ${data.totalErrors} erros`,
-        duration: 10000,
-      });
-    },
-    onError: (error) => {
-      setClientSyncProgress(null);
-      toast.error("Erro na importação de clientes", { description: String(error) });
-    },
-  });
-
-  const addressSyncMutation = useMutation({
-    mutationFn: async () => {
-      let totalSynced = 0;
-      let totalSkipped = 0;
-      let totalErrors = 0;
-      let totalNeeding = 0;
-      let hasMore = true;
-      let iteration = 0;
-
-      while (hasMore) {
-        iteration++;
-        setAddressSyncProgress(`Sincronizando endereços... (lote ${iteration}, ${totalSynced} criados)`);
-        const { data, error } = await supabase.functions.invoke("omie-cliente", {
-          body: { action: "sync_addresses", batch_size: 30 },
-        });
-        if (error) throw error;
-
-        totalSynced += data?.synced || 0;
-        totalSkipped += data?.skipped || 0;
-        totalErrors += data?.errors || 0;
-        totalNeeding = data?.totalNeeding || 0;
-        hasMore = data?.hasMore || false;
-
-        // Safety: if batch produced 0 synced AND 0 skipped AND 0 errors, stop to avoid infinite loop
-        if ((data?.synced || 0) === 0 && (data?.skipped || 0) === 0 && (data?.errors || 0) === 0) {
-          hasMore = false;
-        }
-      }
-
-      setAddressSyncProgress(null);
-      return { synced: totalSynced, skipped: totalSkipped, errors: totalErrors, totalNeeding };
-    },
-    onSuccess: (data) => {
-      toast.success("Sincronização de endereços concluída", {
-        description: `${data?.synced || 0} endereços criados, ${data?.skipped || 0} ignorados, ${data?.errors || 0} erros (de ${data?.totalNeeding || 0} pendentes)`,
-        duration: 10000,
-      });
-    },
-    onError: (error) => {
-      setAddressSyncProgress(null);
-      toast.error("Erro na sincronização de endereços", { description: String(error) });
-    },
-  });
-
-  const [editingConfig, setEditingConfig] = useState<Record<string, string>>({});
-  const [addressSyncProgress, setAddressSyncProgress] = useState<string | null>(null);
-  const [ordersSyncProgress, setOrdersSyncProgress] = useState<string | null>(null);
-
-  // Helper to format date as DD/MM/YYYY
-  const formatOmieDate = (date: Date) => {
-    const dd = String(date.getDate()).padStart(2, '0');
-    const mm = String(date.getMonth() + 1).padStart(2, '0');
-    const yyyy = date.getFullYear();
-    return `${dd}/${mm}/${yyyy}`;
-  };
-
-  const runOrdersSync = async (dateFrom?: string, dateTo?: string) => {
-    const accounts: Array<{ name: string; account: string }> = [
-      { name: "Oben", account: "oben" },
-      { name: "Colacor", account: "colacor" },
-    ];
-    let grandTotalSynced = 0;
-    let grandTotalItems = 0;
-    let grandTotalSkipped = 0;
-
-    for (const acc of accounts) {
-      let startPage = 1;
-      let complete = false;
-
-      while (!complete) {
-        setOrdersSyncProgress(`${acc.name}: página ${startPage}...`);
-        const { data, error } = await supabase.functions.invoke("omie-vendas-sync", {
-          body: {
-            action: "sync_pedidos",
-            account: acc.account,
-            start_page: startPage,
-            max_pages: 10,
-            ...(dateFrom && { date_from: dateFrom }),
-            ...(dateTo && { date_to: dateTo }),
-          },
-        });
-        if (error) throw new Error(`${acc.name}: ${error.message}`);
-
-        grandTotalSynced += data?.totalSynced || 0;
-        grandTotalItems += data?.totalItems || 0;
-        grandTotalSkipped += data?.skippedNoClient || 0;
-
-        const lastPage = data?.lastPage || startPage;
-        const totalPages = data?.totalPaginas || 1;
-        setOrdersSyncProgress(`${acc.name}: pág ${lastPage}/${totalPages} — ${grandTotalSynced} pedidos importados`);
-
-        if (data?.complete || !data?.nextPage) {
-          complete = true;
-        } else {
-          startPage = data.nextPage;
-        }
-      }
-    }
-
-    // Refresh materialized view after import
-    setOrdersSyncProgress("Atualizando métricas de clientes...");
-    await supabase.rpc("refresh_customer_metrics");
-
-    setOrdersSyncProgress(null);
-    return { grandTotalSynced, grandTotalItems, grandTotalSkipped };
-  };
-
-  const bulkOrdersSyncMutation = useMutation({
-    mutationFn: () => runOrdersSync(),
-    onSuccess: (data) => {
-      toast.success("Importação de pedidos concluída", {
-        description: `${data.grandTotalSynced} pedidos, ${data.grandTotalItems} itens, ${data.grandTotalSkipped} sem cliente`,
-        duration: 10000,
-      });
-      queryClient.invalidateQueries({ queryKey: ["sync-state"] });
-    },
-    onError: (error) => {
-      setOrdersSyncProgress(null);
-      toast.error("Erro na importação de pedidos", { description: String(error) });
-    },
-  });
-
-  const recentOrdersSyncMutation = useMutation({
-    mutationFn: () => {
-      const now = new Date();
-      const from = new Date(now);
-      from.setDate(from.getDate() - 180);
-      return runOrdersSync(formatOmieDate(from), formatOmieDate(now));
-    },
-    onSuccess: (data) => {
-      toast.success("Importação recente concluída", {
-        description: `${data.grandTotalSynced} pedidos, ${data.grandTotalItems} itens`,
-        duration: 10000,
-      });
-      queryClient.invalidateQueries({ queryKey: ["sync-state"] });
-    },
-    onError: (error) => {
-      setOrdersSyncProgress(null);
-      toast.error("Erro na importação recente", { description: String(error) });
-    },
-  });
-
-  const getStateFor = (entity: string, account: string) =>
-    syncStates?.find((s) => s.entity_type === entity && s.account === account);
-
-  const formatDate = (d: string | null) => {
-    if (!d) return "Nunca";
-    return new Date(d).toLocaleString("pt-BR", { dateStyle: "short", timeStyle: "short" });
-  };
-
-  const isRunning = syncMutation.isPending || computeCostsMutation.isPending || assocRulesMutation.isPending || bulkClientSyncMutation.isPending || bulkOrdersSyncMutation.isPending || recentOrdersSyncMutation.isPending || addressSyncMutation.isPending;
-
-  const handleConfigSave = (id: string) => {
-    const val = parseFloat(editingConfig[id]);
-    if (!isNaN(val)) {
-      updateConfigMutation.mutate({ id, value: val });
-      setEditingConfig(prev => { const n = { ...prev }; delete n[id]; return n; });
-    }
-  };
+  const {
+    selectedAccount,
+    setSelectedAccount,
+    isLoading,
+    recConfigs,
+    syncMutation,
+    computeCostsMutation,
+    assocRulesMutation,
+    bulkClientSyncMutation,
+    addressSyncMutation,
+    bulkOrdersSyncMutation,
+    recentOrdersSyncMutation,
+    clientSyncProgress,
+    addressSyncProgress,
+    ordersSyncProgress,
+    editingConfig,
+    setEditingConfig,
+    getStateFor,
+    formatDate,
+    isRunning,
+    handleConfigSave,
+  } = useAnalyticsSync();
 
   return (
     <div className="space-y-6">
@@ -395,300 +62,63 @@ export default function AdminAnalyticsSync() {
       </div>
 
       {/* Sync Entities */}
-      <div className="grid gap-4 md:grid-cols-2">
-        {(Object.entries(ENTITY_CONFIG) as [SyncEntity, typeof ENTITY_CONFIG[SyncEntity]][]).map(
-          ([entity, config]) => {
-            const state = getStateFor(entity, selectedAccount);
-            const statusCfg = STATUS_MAP[state?.status || "idle"];
-            const StatusIcon = statusCfg?.icon || Clock;
-
-            return (
-              <Card key={entity}>
-                <CardHeader className="pb-3">
-                  <div className="flex items-center justify-between">
-                    <div className="flex items-center gap-2">
-                      <config.icon className="h-5 w-5 text-muted-foreground" />
-                      <CardTitle className="text-base">{config.label}</CardTitle>
-                    </div>
-                    <Badge variant={statusCfg?.variant || "secondary"}>
-                      <StatusIcon className={`h-3 w-3 mr-1 ${state?.status === "running" ? "animate-spin" : ""}`} />
-                      {state?.status || "idle"}
-                    </Badge>
-                  </div>
-                </CardHeader>
-                <CardContent className="space-y-3">
-                  <p className="text-xs text-muted-foreground">{config.description}</p>
-                  <div className="grid grid-cols-2 gap-2 text-sm">
-                    <div>
-                      <span className="text-muted-foreground">Último sync:</span>
-                      <br />
-                      <span className="font-medium">{formatDate(state?.last_sync_at || null)}</span>
-                    </div>
-                    <div>
-                      <span className="text-muted-foreground">Registros:</span>
-                      <br />
-                      <span className="font-medium">{state?.total_synced || 0}</span>
-                    </div>
-                  </div>
-                  {state?.error_message && (
-                    <p className="text-xs text-destructive bg-destructive/10 p-2 rounded">
-                      {state.error_message.substring(0, 150)}
-                    </p>
-                  )}
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    className="w-full"
-                    disabled={isRunning}
-                    onClick={() =>
-                      syncMutation.mutate({ action: `sync_${entity}`, account: selectedAccount })
-                    }
-                  >
-                    <RefreshCw className={`h-3 w-3 mr-2 ${isRunning ? "animate-spin" : ""}`} />
-                    Sincronizar {config.label}
-                  </Button>
-                </CardContent>
-              </Card>
-            );
-          }
-        )}
-      </div>
+      <SyncEntitiesGrid
+        selectedAccount={selectedAccount}
+        getStateFor={getStateFor}
+        formatDate={formatDate}
+        isRunning={isRunning}
+        onSync={(entity) => syncMutation.mutate({ action: `sync_${entity}`, account: selectedAccount })}
+      />
 
       {/* Bulk Client Import */}
-      <Card>
-        <CardHeader>
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-2">
-              <Users className="h-5 w-5 text-muted-foreground" />
-              <CardTitle className="text-base">Importar Clientes (3 Contas Omie)</CardTitle>
-            </div>
-            <Button
-              variant="outline"
-              size="sm"
-              disabled={isRunning}
-              onClick={() => bulkClientSyncMutation.mutate()}
-            >
-              {bulkClientSyncMutation.isPending ? (
-                <Loader2 className="h-3 w-3 mr-2 animate-spin" />
-              ) : (
-                <RefreshCw className="h-3 w-3 mr-2" />
-              )}
-              Importar Todos
-            </Button>
-          </div>
-        </CardHeader>
-        <CardContent>
-          <p className="text-xs text-muted-foreground">
-            Importa todos os clientes das 3 contas Omie (Colacor Afiação, Oben Vendas, Colacor Vendas), 
-            criando perfis placeholder e mapeamentos em <code className="font-mono">omie_clientes</code>. 
-            Pré-requisito para rodar os motores de inteligência (calculate-scores, algorithm-a-audit).
-          </p>
-          {clientSyncProgress && (
-            <div className="mt-3 flex items-center gap-2 text-xs text-primary font-medium">
-              <Loader2 className="h-3 w-3 animate-spin" />
-              {clientSyncProgress}
-            </div>
-          )}
-        </CardContent>
-      </Card>
+      <ImportClientesCard
+        isRunning={isRunning}
+        pending={bulkClientSyncMutation.isPending}
+        progress={clientSyncProgress}
+        onImport={() => bulkClientSyncMutation.mutate()}
+      />
 
       {/* Address Sync from Omie */}
-      <Card>
-        <CardHeader>
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-2">
-              <MapPin className="h-5 w-5 text-muted-foreground" />
-              <CardTitle className="text-base">Sincronizar Endereços do Omie</CardTitle>
-            </div>
-            <Button
-              variant="outline"
-              size="sm"
-              disabled={isRunning}
-              onClick={() => addressSyncMutation.mutate()}
-            >
-              {addressSyncMutation.isPending ? (
-                <Loader2 className="h-3 w-3 mr-2 animate-spin" />
-              ) : (
-                <RefreshCw className="h-3 w-3 mr-2" />
-              )}
-              Sincronizar Endereços
-            </Button>
-          </div>
-        </CardHeader>
-        <CardContent>
-          <p className="text-xs text-muted-foreground">
-            Busca endereços dos clientes no Omie e popula a tabela <code className="font-mono">addresses</code>. 
-            Pré-requisito para o roteirizador e funcionalidades que dependem de localização.
-          </p>
-          {addressSyncProgress && (
-            <div className="mt-3 flex items-center gap-2 text-xs text-primary font-medium">
-              <Loader2 className="h-3 w-3 animate-spin" />
-              {addressSyncProgress}
-            </div>
-          )}
-        </CardContent>
-      </Card>
+      <ImportEnderecosCard
+        isRunning={isRunning}
+        pending={addressSyncMutation.isPending}
+        progress={addressSyncProgress}
+        onSync={() => addressSyncMutation.mutate()}
+      />
 
-      <Card>
-        <CardHeader>
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-2">
-              <ShoppingCart className="h-5 w-5 text-muted-foreground" />
-              <CardTitle className="text-base">Importar Pedidos (Oben + Colacor)</CardTitle>
-            </div>
-            <div className="flex gap-2">
-              <Button
-                variant="default"
-                size="sm"
-                disabled={isRunning}
-                onClick={() => recentOrdersSyncMutation.mutate()}
-              >
-                {recentOrdersSyncMutation.isPending ? (
-                  <Loader2 className="h-3 w-3 mr-2 animate-spin" />
-                ) : (
-                  <Sparkles className="h-3 w-3 mr-2" />
-                )}
-                Importar Recentes (180d)
-              </Button>
-              <Button
-                variant="outline"
-                size="sm"
-                disabled={isRunning}
-                onClick={() => bulkOrdersSyncMutation.mutate()}
-              >
-                {bulkOrdersSyncMutation.isPending ? (
-                  <Loader2 className="h-3 w-3 mr-2 animate-spin" />
-                ) : (
-                  <RefreshCw className="h-3 w-3 mr-2" />
-                )}
-                Importar Todos
-              </Button>
-            </div>
-          </div>
-        </CardHeader>
-        <CardContent>
-          <p className="text-xs text-muted-foreground">
-            <strong>Importar Recentes:</strong> busca apenas pedidos dos últimos 180 dias (rápido, ~2 min).
-            <br />
-            <strong>Importar Todos:</strong> varre todo o histórico (~425 páginas, pode levar 30+ min).
-          </p>
-          {ordersSyncProgress && (
-            <div className="mt-3 flex items-center gap-2 text-xs text-primary font-medium">
-              <Loader2 className="h-3 w-3 animate-spin" />
-              {ordersSyncProgress}
-            </div>
-          )}
-        </CardContent>
-      </Card>
+      <ImportPedidosCard
+        isRunning={isRunning}
+        recentPending={recentOrdersSyncMutation.isPending}
+        bulkPending={bulkOrdersSyncMutation.isPending}
+        progress={ordersSyncProgress}
+        onImportRecent={() => recentOrdersSyncMutation.mutate()}
+        onImportAll={() => bulkOrdersSyncMutation.mutate()}
+      />
+
       {/* Cost Engine */}
-      <Card>
-        <CardHeader>
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-2">
-              <Calculator className="h-5 w-5 text-muted-foreground" />
-              <CardTitle className="text-base">Motor de Custo (Fallback Inteligente)</CardTitle>
-            </div>
-            <Button
-              variant="outline"
-              size="sm"
-              disabled={isRunning}
-              onClick={() => computeCostsMutation.mutate()}
-            >
-              <RefreshCw className={`h-3 w-3 mr-2 ${computeCostsMutation.isPending ? "animate-spin" : ""}`} />
-              Recalcular Custos
-            </Button>
-          </div>
-        </CardHeader>
-        <CardContent>
-          <p className="text-xs text-muted-foreground mb-3">
-            Hierarquia: Custo Produto → CMC (Estoque) → Proxy Família → Proxy Default.
-            Divergência {">"} {((recConfigs?.find(c => c.key === "divergence_threshold")?.value || 0.2) * 100).toFixed(0)}%
-            aplica heurística estoque vs encomenda.
-          </p>
-          <div className="grid grid-cols-4 gap-3 text-center text-xs">
-            {["PRODUCT_COST", "CMC", "FAMILY_MARGIN_PROXY", "DEFAULT_PROXY"].map((source) => (
-              <div key={source} className="p-2 rounded bg-muted">
-                <div className="font-medium">{source.replace(/_/g, " ")}</div>
-                <div className="text-muted-foreground mt-1">
-                  Confiança: {source === "PRODUCT_COST" ? "95%" : source === "CMC" ? "80%" : source === "FAMILY_MARGIN_PROXY" ? "50%" : "25%"}
-                </div>
-              </div>
-            ))}
-          </div>
-        </CardContent>
-      </Card>
+      <CostEngineCard
+        isRunning={isRunning}
+        pending={computeCostsMutation.isPending}
+        recConfigs={recConfigs}
+        onRecalcular={() => computeCostsMutation.mutate()}
+      />
 
       {/* Association Rules */}
-      <Card>
-        <CardHeader>
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-2">
-              <GitBranch className="h-5 w-5 text-muted-foreground" />
-              <CardTitle className="text-base">Regras de Associação (Apriori)</CardTitle>
-            </div>
-            <Button
-              variant="outline"
-              size="sm"
-              disabled={isRunning}
-              onClick={() => assocRulesMutation.mutate()}
-            >
-              <RefreshCw className={`h-3 w-3 mr-2 ${assocRulesMutation.isPending ? "animate-spin" : ""}`} />
-              Recalcular Regras
-            </Button>
-          </div>
-        </CardHeader>
-        <CardContent>
-          <p className="text-xs text-muted-foreground">
-            Analisa co-ocorrências em pedidos para gerar regras do tipo "quem comprou A também comprou B".
-            Filtros: lift ≥ {recConfigs?.find(c => c.key === "l_min")?.value ?? 1.2}, support ≥ {recConfigs?.find(c => c.key === "s_min")?.value ?? 0.01}.
-            As regras alimentam o score Assoc(j|B) do motor de recomendação.
-          </p>
-        </CardContent>
-      </Card>
+      <AssociationRulesCard
+        isRunning={isRunning}
+        pending={assocRulesMutation.isPending}
+        recConfigs={recConfigs}
+        onRecalcular={() => assocRulesMutation.mutate()}
+      />
 
       {/* Engine Config (Editable) */}
-      <Card>
-        <CardHeader>
-          <div className="flex items-center gap-2">
-            <Settings className="h-5 w-5 text-muted-foreground" />
-            <CardTitle className="text-base">Parâmetros do Motor</CardTitle>
-          </div>
-        </CardHeader>
-        <CardContent>
-          {isLoading ? (
-            <div className="flex items-center justify-center py-8">
-              <Loader2 className="h-6 w-6 animate-spin" />
-            </div>
-          ) : (
-            <div className="grid gap-3 md:grid-cols-2 lg:grid-cols-3">
-              {(recConfigs || []).map((config) => {
-                const isEditing = editingConfig[config.id] !== undefined;
-                return (
-                  <div key={config.id} className="p-3 rounded border text-sm space-y-2">
-                    <div className="font-mono font-medium text-xs">{config.key}</div>
-                    <div className="text-xs text-muted-foreground">{config.description}</div>
-                    <div className="flex items-center gap-2">
-                      <Input
-                        type="number"
-                        step="0.01"
-                        className="h-8 text-sm font-semibold"
-                        value={isEditing ? editingConfig[config.id] : config.value}
-                        onChange={(e) => setEditingConfig(prev => ({ ...prev, [config.id]: e.target.value }))}
-                      />
-                      {isEditing && (
-                        <Button size="sm" className="h-8 w-8 p-0" onClick={() => handleConfigSave(config.id)}>
-                          <Save className="h-3.5 w-3.5" />
-                        </Button>
-                      )}
-                    </div>
-                  </div>
-                );
-              })}
-            </div>
-          )}
-        </CardContent>
-      </Card>
-
+      <EngineConfigCard
+        isLoading={isLoading}
+        recConfigs={recConfigs}
+        editingConfig={editingConfig}
+        setEditingConfig={setEditingConfig}
+        onSave={handleConfigSave}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Resumo
- Split estrutural da página `AdminAnalyticsSync` (694→**124** linhas), preservando 100% do comportamento (move verbatim).
- Lógica isolada no hook **`useAnalyticsSync`** (3 queries, 8 mutations, `runOrdersSync` orquestrado p/ Oben+Colacor, helpers, `isRunning`).
- JSX em componentes presentacionais controlados: **`SyncEntitiesGrid`**, **`ImportCards`** (clientes/endereços/pedidos), **`EngineCards`** (custo + associação), **`EngineConfigCard`**.
- Tipos/constantes (`SyncEntity`/`OmieAccount`/`SyncState`/`ENTITY_CONFIG`/`STATUS_MAP`) em `analyticsSync/types.ts`.

## Verificação
- `bunx tsc --noEmit` = 0 erros
- `bunx eslint` nos arquivos tocados = 0
- Testes novos (+18) passam isolados (4/4 arquivos). ⚠️ Suíte completa local segue com flakiness por **contenção de CPU** (worktrees paralelos: timeouts de 5s estourando, durações 50×+). Gate autoritativo = CI `validate` em ambiente limpo.
- Revisão independente de fidelidade (subagente): **FIEL 1:1**, zero divergências.

## Test plan
- [x] tsc / eslint verdes; +18 testes novos verdes isolados
- [x] Revisão 1:1 confirmando comportamento idêntico
- [ ] CI `validate` verde (gate da suíte completa)

🤖 Generated with [Claude Code](https://claude.com/claude-code)