### PR TITLE
chore(db): pacote do snapshot de schema public

### DIFF
--- a/supabase/README-schema.md
+++ b/supabase/README-schema.md
@@ -37,13 +37,13 @@ Um `supabase db reset` a partir das migrations **quebra** (ex: `20260510235956` 
 
 ⚠️ O snapshot referencia `auth.uid()` (1119×), `auth.role()`, `auth.users` nas policies. Só restaura num **projeto Supabase** (que provê o schema `auth`). Em Postgres puro seria necessário stubar `auth.*` (ver branch `feat/baseline-squash-schema`).
 
-1. Rode **`schema-extensions-prelude.sql`** primeiro (cria schema `extensions` + uuid-ossp/pgcrypto/pg_trgm, `vector` em `public`, `pg_cron`).
-2. Rode **`schema-snapshot.sql`**.
+1. Rode **`schema-extensions-prelude.sql`** primeiro (cria schema `extensions` + uuid-ossp/pgcrypto/pg_trgm e `vector` em `public`; `pg_cron` fica comentado — ver abaixo).
+2. Rode **`schema-snapshot.sql`** com **`psql`** (é dump SQL plain; **não** use `pg_restore`, que serve só pra formatos custom/tar/directory).
 
 ### Armadilhas conhecidas
-- O dump tem **`CREATE SCHEMA public;`** sem `IF NOT EXISTS` (linha ~27). Num projeto novo o schema `public` já existe → o statement falha. Remova essa linha ou rode tolerando o erro.
-- O dump é do **pg_dump 17** e usa os meta-comandos `\restrict` / `\unrestrict` (primeira/última linha). Funcionam via `psql`/`pg_restore`; o SQL Editor do Lovable pode não reconhecê-los — remova-os se restaurar por lá.
-- Se `pg_cron` não puder ser habilitado, as views `v_cron_jobs_status` / `v_cron_jobs_falhas` falham no replay e podem ser puladas.
+- O dump tem **`CREATE SCHEMA public;`** sem `IF NOT EXISTS` (linha ~27). Num projeto novo o schema `public` já existe → o statement falha. **Remova essa linha** (caminho preferido); só tolere o erro se rodar **sem** `ON_ERROR_STOP` (com `ON_ERROR_STOP` o restore aborta aí).
+- O dump é do **pg_dump 17** e usa os meta-comandos `\restrict` / `\unrestrict` (primeira/última linha), reconhecidos pelo `psql`. O SQL Editor do Lovable pode não reconhecê-los — remova-os se restaurar por lá.
+- O prelude deixa **`pg_cron` comentado** de propósito (habilitá-lo pode abortar o restore sob `ON_ERROR_STOP`). Habilite-o antes pelo dashboard do Supabase se quiser as views `v_cron_jobs_status` / `v_cron_jobs_falhas`; senão elas falham no replay e devem ser puladas.
 
 > **Status: restore NUNCA foi testado.** Sem um teste de restore num projeto Supabase vazio, este arquivo é **inventário, não seguro de recuperação**. Validar o restore é follow-up (ver branch `feat/baseline-squash-schema`).
 

--- a/supabase/README-schema.md
+++ b/supabase/README-schema.md
@@ -1,0 +1,60 @@
+# Snapshot de schema — `schema-snapshot.sql`
+
+> Gerado em **2026-05-24** a partir do banco de produção (Supabase do Lovable, projeto `fzvklzpomgnyikkfkzai`, PostgreSQL 17.6) via `pg_dump --schema-only --schema=public --no-owner --no-privileges`.
+
+## O que é
+
+`schema-snapshot.sql` é um retrato **schema-only** (sem dados) do schema `public` de produção. É um **artefato de referência, DR e auditoria** — não um sistema de migrations.
+
+## Por que existe (leia antes de confiar nas migrations)
+
+As migrations em `supabase/migrations/` **NÃO são uma cadeia restaurável**. Há drift sistêmico: o Lovable cria muitos objetos direto em produção e não commita o `CREATE`. Diagnóstico de 2026-05-24 (set-difference catálogo de produção × `CREATE`s das migrations):
+
+| Tipo | Em produção | Sem `CREATE` no repo |
+|---|---:|---:|
+| Tabelas | 212 | ~60 |
+| Funções | 86 | ~41 |
+| Views | 37 | 25 |
+| Triggers | 76 | ~22 |
+| Enums | 14 | 5 |
+| Materialized views | 4 | 1 |
+| Policies (RLS) | 474 | ~56 |
+
+Um `supabase db reset` a partir das migrations **quebra** (ex: `20260510235956` faz `ALTER VIEW` em views que nenhuma migration cria; `sku_parametros` é ALTERada em 20 migrations mas nunca criada). Produção é a fonte da verdade e funciona; este snapshot é a forma versionada e auditável desse estado.
+
+## O que está coberto / o que NÃO está
+
+**Coberto** (schema `public`): tabelas, colunas, defaults, constraints, índices, sequences, tipos/enums, views (com `security_invoker`), materialized views, funções, triggers, RLS (`ENABLE` + policies).
+
+**NÃO coberto** (schema-only de `public`):
+- Dados, valores de sequences, registros.
+- Usuários **Auth**, objetos do **Storage**, **secrets do Vault**, **Edge Functions**.
+- Infra fora de `public`: **crons** (`cron.job`), **buckets** (`storage.buckets`), **realtime publications**, **extensions** (ver prelude).
+
+> A captura **funcional completa** (infra fora de `public` + archive das migrations + verificação de replay + runbook) está planejada como baseline-squash na branch **`feat/baseline-squash-schema`** — executar quando houver necessidade real de staging/DR funcional.
+
+## Como restaurar (em projeto Supabase, não Postgres puro)
+
+⚠️ O snapshot referencia `auth.uid()` (1119×), `auth.role()`, `auth.users` nas policies. Só restaura num **projeto Supabase** (que provê o schema `auth`). Em Postgres puro seria necessário stubar `auth.*` (ver branch `feat/baseline-squash-schema`).
+
+1. Rode **`schema-extensions-prelude.sql`** primeiro (cria schema `extensions` + uuid-ossp/pgcrypto/pg_trgm, `vector` em `public`, `pg_cron`).
+2. Rode **`schema-snapshot.sql`**.
+
+### Armadilhas conhecidas
+- O dump tem **`CREATE SCHEMA public;`** sem `IF NOT EXISTS` (linha ~27). Num projeto novo o schema `public` já existe → o statement falha. Remova essa linha ou rode tolerando o erro.
+- O dump é do **pg_dump 17** e usa os meta-comandos `\restrict` / `\unrestrict` (primeira/última linha). Funcionam via `psql`/`pg_restore`; o SQL Editor do Lovable pode não reconhecê-los — remova-os se restaurar por lá.
+- Se `pg_cron` não puder ser habilitado, as views `v_cron_jobs_status` / `v_cron_jobs_falhas` falham no replay e podem ser puladas.
+
+> **Status: restore NUNCA foi testado.** Sem um teste de restore num projeto Supabase vazio, este arquivo é **inventário, não seguro de recuperação**. Validar o restore é follow-up (ver branch `feat/baseline-squash-schema`).
+
+## Como re-gerar
+
+Cole no **chat do Lovable** (não no SQL Editor):
+
+> Gere um dump SQL literal do schema public deste banco Supabase usando pg_dump, com flags equivalentes a `pg_dump --schema-only --schema=public --no-owner --no-privileges`. Não inclua dados nem os schemas auth/storage/realtime/vault/extensions/cron/graphql/pgsodium/supabase_functions. Não resuma nem trunque. Entregue o conteúdo INTEGRAL como arquivo `supabase/schema-snapshot.sql` e faça commit. Confirme o número de linhas.
+
+Depois atualize **`schema-snapshot.manifest.md`** com as novas contagens — o diff do git é a revisão do drift.
+
+## Cadência
+
+Artefato periódico, não sincronização contínua. Re-gerar: após qualquer módulo/tabela/RPC nova criada pelo Lovable, antes de criar staging ou migrar projeto, no mínimo mensalmente se o banco muda, ou sob demanda quando suspeitar de drift.

--- a/supabase/schema-extensions-prelude.sql
+++ b/supabase/schema-extensions-prelude.sql
@@ -1,0 +1,36 @@
+-- ============================================================================
+-- PRELUDE — pré-requisitos de extensions/schemas para schema-snapshot.sql
+-- ============================================================================
+-- Rode ESTE arquivo ANTES de schema-snapshot.sql ao reconstruir o schema public
+-- num ambiente Supabase NOVO/vazio (staging, recuperação de desastre, projeto novo).
+--
+-- Por quê: schema-snapshot.sql é um pg_dump --schema-only de `public` e NÃO emite
+-- nenhum CREATE EXTENSION. Os objetos do dump referenciam extensions que precisam
+-- existir antes. Inventário extraído do snapshot (gerado 2026-05-24, PG 17.6):
+--   - extensions.uuid_generate_v4()             -> uuid-ossp em schema `extensions`
+--   - extensions.gen_random_bytes()             -> pgcrypto  em schema `extensions`
+--   - extensions.gin_trgm_ops                   -> pg_trgm   em schema `extensions`
+--   - public.vector(1536) / public.vector_cosine_ops -> vector em schema `public`
+--   - cron.job / cron.job_run_details (views v_cron_jobs_*) -> pg_cron (schema `cron`)
+--
+-- NÃO incluídas de propósito:
+--   - gen_random_uuid() (157 usos) é built-in do PostgreSQL 13+, não requer extension.
+--   - pg_net NÃO é referenciado pelo schema public (vive nos crons, fora deste snapshot).
+--   - supabase_vault / pg_stat_statements / plpgsql são geridas/builtin — não recriar.
+-- ============================================================================
+
+CREATE SCHEMA IF NOT EXISTS extensions;
+
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp" WITH SCHEMA extensions;
+CREATE EXTENSION IF NOT EXISTS pgcrypto    WITH SCHEMA extensions;
+CREATE EXTENSION IF NOT EXISTS pg_trgm     WITH SCHEMA extensions;
+
+-- O tipo vector é referenciado como public.vector(...) no snapshot.
+CREATE EXTENSION IF NOT EXISTS vector WITH SCHEMA public;
+
+-- pg_cron cria o schema `cron`; as views v_cron_jobs_status / v_cron_jobs_falhas
+-- leem cron.job e cron.job_run_details. Em Supabase, habilitar pg_cron normalmente
+-- é via dashboard (Database > Extensions); em Postgres puro exige pg_cron em
+-- shared_preload_libraries. Se não puder habilitar, as 2 views v_cron_jobs_*
+-- falham no replay e podem ser puladas (ver README-schema.md).
+CREATE EXTENSION IF NOT EXISTS pg_cron;

--- a/supabase/schema-extensions-prelude.sql
+++ b/supabase/schema-extensions-prelude.sql
@@ -19,6 +19,12 @@
 --   - supabase_vault / pg_stat_statements / plpgsql são geridas/builtin — não recriar.
 -- ============================================================================
 
+-- NOTA: estes comandos assumem ambiente NOVO/vazio. `IF NOT EXISTS` NÃO move uma
+-- extension que já exista em OUTRO schema — apenas emite notice e não faz nada.
+-- Como o snapshot usa nomes qualificados (extensions.*, public.vector), num alvo
+-- não-limpo valide `SELECT extname, extnamespace::regnamespace FROM pg_extension`
+-- depois, senão as referências quebram.
+
 CREATE SCHEMA IF NOT EXISTS extensions;
 
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp" WITH SCHEMA extensions;
@@ -28,9 +34,10 @@ CREATE EXTENSION IF NOT EXISTS pg_trgm     WITH SCHEMA extensions;
 -- O tipo vector é referenciado como public.vector(...) no snapshot.
 CREATE EXTENSION IF NOT EXISTS vector WITH SCHEMA public;
 
--- pg_cron cria o schema `cron`; as views v_cron_jobs_status / v_cron_jobs_falhas
--- leem cron.job e cron.job_run_details. Em Supabase, habilitar pg_cron normalmente
--- é via dashboard (Database > Extensions); em Postgres puro exige pg_cron em
--- shared_preload_libraries. Se não puder habilitar, as 2 views v_cron_jobs_*
--- falham no replay e podem ser puladas (ver README-schema.md).
-CREATE EXTENSION IF NOT EXISTS pg_cron;
+-- pg_cron: deixado COMENTADO de propósito. `CREATE EXTENSION pg_cron` pode falhar
+-- (permissão / shared_preload_libraries) e, sob ON_ERROR_STOP, abortaria o restore
+-- antes do snapshot. Habilite-o ANTES pelo dashboard do Supabase (Database >
+-- Extensions) se quiser as views v_cron_jobs_status / v_cron_jobs_falhas (que leem
+-- cron.job / cron.job_run_details). Sem ele, essas 2 views falham no replay do
+-- snapshot e devem ser puladas.
+-- CREATE EXTENSION IF NOT EXISTS pg_cron;

--- a/supabase/schema-snapshot.manifest.md
+++ b/supabase/schema-snapshot.manifest.md
@@ -1,0 +1,37 @@
+# Manifest — `schema-snapshot.sql`
+
+> Contagens do snapshot. Ao re-gerar o dump, atualize esta tabela: o **diff do git é a revisão do drift** de schema entre uma geração e a próxima.
+
+| Campo | Valor |
+|---|---|
+| Gerado em | 2026-05-24 |
+| Fonte | produção (Supabase Lovable, `fzvklzpomgnyikkfkzai`) |
+| Versão do banco | PostgreSQL 17.6 |
+| pg_dump | 17.9 |
+| Flags | `--schema-only --schema=public --no-owner --no-privileges` |
+| Linhas do arquivo | 23.745 |
+| Tamanho | ~838 KB |
+
+## Contagens por tipo (schema `public`)
+
+| Objeto | Quantidade |
+|---|---:|
+| `CREATE TABLE` | 212 |
+| `CREATE VIEW` | 37 |
+| `CREATE MATERIALIZED VIEW` | 4 |
+| `CREATE FUNCTION` | 86 |
+| `CREATE TRIGGER` | 76 |
+| `CREATE TYPE` | 14 |
+| `CREATE POLICY` | 474 |
+| `ENABLE ROW LEVEL SECURITY` | 212 |
+| views com `security_invoker` | 34 |
+
+## Extensions referenciadas pelo `public` (ver `schema-extensions-prelude.sql`)
+
+| Extension | Schema | Uso no snapshot |
+|---|---|---|
+| uuid-ossp | extensions | `extensions.uuid_generate_v4()` |
+| pgcrypto | extensions | `extensions.gen_random_bytes()` |
+| pg_trgm | extensions | `extensions.gin_trgm_ops` |
+| vector | public | `public.vector(1536)`, `public.vector_cosine_ops` |
+| pg_cron | cron | views `v_cron_jobs_*` leem `cron.job` |


### PR DESCRIPTION
## Resumo

Fecha a fase **snapshot** do tratamento de drift schema×migrations (decisão: híbrido em fases). Sobre o `supabase/schema-snapshot.sql` que **já está em `main`** (pg_dump --schema-only de `public`, 23.745 linhas, gerado pelo Lovable), adiciona os artefatos de apoio que faltavam:

- **`supabase/schema-extensions-prelude.sql`** — `CREATE EXTENSION` dos pré-requisitos que o `pg_dump --schema-only` não emite (uuid-ossp/pgcrypto/pg_trgm em `extensions`, `vector` em `public`; `pg_cron` comentado de propósito).
- **`supabase/README-schema.md`** — por que as migrations **não** são cadeia restaurável, o que o snapshot cobre/não cobre, como restaurar (só em projeto Supabase, por causa de `auth.*` nas policies), armadilhas e como re-gerar.
- **`supabase/schema-snapshot.manifest.md`** — contagens por tipo (212 tabelas / 37 views / 86 funções / 474 policies / …) pra revisar drift por diff a cada re-geração.

## Contexto

Diagnóstico de 2026-05-24 (set-difference catálogo de produção × CREATEs das migrations): ~210 objetos existem em produção sem `CREATE` commitado (60 tabelas, 41 funções, 25 views, ~22 triggers, 5 enums, ~56 policies). Validado por codex consult (metodologia) + codex review (diff). As contagens do dump batem exatamente com o catálogo de produção medido.

## Não requer apply em produção

Só toca o repo. Produção é a fonte da verdade e não é alterada. Nenhuma migration manual.

## Follow-up (fora deste PR)

O baseline-squash funcional completo (infra fora de `public` — crons/buckets/realtime/nomes de secrets — + archive das 222 migrations + verificação de replay + runbook) está planejado na branch `feat/baseline-squash-schema`, a executar quando houver necessidade real de staging/DR funcional. O restore do snapshot **ainda não foi testado** num projeto Supabase vazio (documentado no README como follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)