### PR TITLE
chore(dx): wrapper `heavy` pra não saturar CPU/RAM em sessões paralelas

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,15 @@ bun preview   # vite preview
 > ⚠️ **`bun test` ≠ `bun run test`**. `bun test` invoca o runner nativo do bun (não usa vitest.config.ts).
 > Use pra loop rápido de TDD em tests que não dependem de DOM/React renderização. Resultado oficial é só do vitest.
 
+> 🟢 **Prefixe comandos PESADOS com `heavy`** quando houver sessões/worktrees rodando em paralelo (máquina do Lucas é M2 8GB, satura fácil). `heavy` é um semáforo global (`~/.local/bin/heavy`, fonte em `scripts/heavy.sh`) que limita quantos test/build/typecheck rodam ao mesmo tempo entre TODOS os worktrees — os demais esperam a vez em vez de competir por CPU/RAM. Auto-dimensiona pelo HW (1 slot na M2 8GB; ~9 num M4 Pro 48GB). Use:
+> ```bash
+> heavy bun run test
+> heavy bun run typecheck:strict
+> heavy bun build
+> heavy --status   # slots em uso
+> ```
+> Override: `AFIACAO_MAX_HEAVY=2 heavy …`. Comandos leves (`bun lint`, `bun dev`) não precisam.
+
 ---
 
 ## 3. Estrutura de pastas

--- a/scripts/heavy.sh
+++ b/scripts/heavy.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+#
+# heavy — semáforo GLOBAL pra tarefas pesadas (test/build/typecheck) rodando
+# em paralelo entre vários worktrees/sessões, pra não saturar CPU+RAM.
+#
+# Por que existe: nesta máquina (M2 8GB) rodar `bun run test` / `typecheck:strict`
+# em N worktrees ao mesmo tempo estoura a RAM (vira swap) e o load dispara pra 40+.
+# Este wrapper garante que no máximo SLOTS comandos pesados rodem simultaneamente;
+# os demais ESPERAM a vez (bloqueante), sem você precisar coordenar na mão.
+#
+# Uso:
+#   heavy bun run test
+#   heavy bun run typecheck:strict
+#   heavy bun build
+#   heavy --status        # mostra slots em uso e a config calculada
+#
+# Tuning (env, opcional):
+#   AFIACAO_MAX_HEAVY=2        força nº de slots (default = calculado por HW)
+#   AFIACAO_HEAVY_TIMEOUT=1800 segundos máx esperando uma vaga (default 30min)
+#   AFIACAO_HEAVY_LOCKDIR=...  dir dos locks (default /tmp/afiacao-heavy-slots)
+#
+set -euo pipefail
+
+LOCK_ROOT="${AFIACAO_HEAVY_LOCKDIR:-/tmp/afiacao-heavy-slots}"
+POLL=2
+MAX_WAIT="${AFIACAO_HEAVY_TIMEOUT:-1800}"
+
+# nº de slots = min(P-cores-1, RAM-folga). Calcula sozinho — funciona igual
+# numa M2 8GB (=1) e num MacBook Pro M4 Pro 48GB (~9).
+compute_slots() {
+  local pcores ram_gb cpu_lim ram_lim n
+  pcores=$(sysctl -n hw.perflevel0.physicalcpu 2>/dev/null || sysctl -n hw.physicalcpu 2>/dev/null || echo 4)
+  ram_gb=$(( $(sysctl -n hw.memsize 2>/dev/null || echo 8589934592) / 1073741824 ))
+  cpu_lim=$(( pcores > 1 ? pcores - 1 : 1 ))
+  ram_lim=$(( (ram_gb - 4) / 3 )); [ "$ram_lim" -lt 1 ] && ram_lim=1
+  n=$(( cpu_lim < ram_lim ? cpu_lim : ram_lim ))
+  [ "$n" -lt 1 ] && n=1
+  echo "$n"
+}
+SLOTS="${AFIACAO_MAX_HEAVY:-$(compute_slots)}"
+mkdir -p "$LOCK_ROOT"
+
+if [ "${1:-}" = "--status" ]; then
+  echo "heavy: $SLOTS slot(s) no total (lockdir: $LOCK_ROOT)"
+  busy=0
+  for slot in "$LOCK_ROOT"/slot-*; do
+    [ -d "$slot" ] || continue
+    pid=$(cat "$slot/pid" 2>/dev/null || echo "?")
+    cmd=$(cat "$slot/cmd" 2>/dev/null || echo "?")
+    if [ "$pid" != "?" ] && kill -0 "$pid" 2>/dev/null; then
+      busy=$((busy+1)); echo "  • $(basename "$slot"): pid $pid — $cmd"
+    fi
+  done
+  echo "heavy: $busy em uso, $((SLOTS - busy)) livre(s)"
+  exit 0
+fi
+
+[ $# -eq 0 ] && { echo "uso: heavy <comando...>   (ou: heavy --status)" >&2; exit 2; }
+
+ACQUIRED=""
+release() { [ -n "$ACQUIRED" ] && rm -rf "$ACQUIRED" 2>/dev/null || true; }
+trap release EXIT INT TERM
+
+acquire() {
+  local waited=0 i slot pid
+  while :; do
+    # recupera slots órfãos (dono morreu sem liberar)
+    for slot in "$LOCK_ROOT"/slot-*; do
+      [ -d "$slot" ] || continue
+      pid=$(cat "$slot/pid" 2>/dev/null || echo "")
+      [ -n "$pid" ] && ! kill -0 "$pid" 2>/dev/null && rm -rf "$slot" 2>/dev/null || true
+    done
+    # tenta pegar uma vaga (mkdir é atômico)
+    for i in $(seq 1 "$SLOTS"); do
+      slot="$LOCK_ROOT/slot-$i"
+      if mkdir "$slot" 2>/dev/null; then
+        echo "$$" > "$slot/pid"
+        echo "$*" > "$slot/cmd"
+        ACQUIRED="$slot"
+        return 0
+      fi
+    done
+    if [ "$waited" -ge "$MAX_WAIT" ]; then
+      echo "heavy: timeout (${MAX_WAIT}s) esperando vaga — abortando." >&2
+      return 1
+    fi
+    [ "$waited" -eq 0 ] && echo "heavy: $SLOTS slot(s) ocupado(s), aguardando vez… ($*)" >&2
+    sleep "$POLL"; waited=$((waited + POLL))
+  done
+}
+
+acquire "$@" || exit 1
+echo "heavy: ► rodando ($(basename "$ACQUIRED")/$SLOTS): $*" >&2
+"$@"


### PR DESCRIPTION
## Resumo
- Adiciona `scripts/heavy.sh` (instalado em `~/.local/bin/heavy`): semáforo **global** que limita quantos comandos pesados (`bun run test`, `typecheck:strict`, `build`) rodam ao mesmo tempo entre **todos os worktrees/sessões**, pra não estourar CPU/RAM. Na M2 8GB do Lucas, N sessões rodando teste em paralelo viravam swap e o load batia 40-50.
- **Auto-dimensiona pelo hardware**: `min(P-cores−1, folga de RAM)` → 1 slot na M2 8GB, ~9 num M4 Pro 48GB. Sem config manual.
- **Bloqueante** (comandos extras esperam a vez) + **recupera slots órfãos** se uma sessão morre sem liberar. Usa `mkdir` atômico porque `flock` não existe no macOS.
- Documenta o uso na §2 do `CLAUDE.md` pras próximas sessões.

## Como usar
```bash
heavy bun run test
heavy bun run typecheck:strict
heavy bun build
heavy --status        # slots em uso
```

## Test plan
- [x] `heavy --status` mostra config calculada (1 slot na M2 8GB)
- [x] Dois `heavy` concorrentes serializam (B só entra após A sair)
- [x] Recuperação de slot órfão (processo morto não trava a fila)
- [ ] Validar nº de slots num MacBook com mais RAM/cores quando disponível

🤖 Generated with [Claude Code](https://claude.com/claude-code)