### PR TITLE
refactor: split TintColorSelectDialog (664→112) em hook + componentes

### DIFF
--- a/src/components/TintColorSelectDialog.tsx
+++ b/src/components/TintColorSelectDialog.tsx
@@ -1,350 +1,42 @@
-import { useState, useEffect, useMemo } from 'react';
-import { useQuery } from '@tanstack/react-query';
-import { supabase } from '@/integrations/supabase/client';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
-import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
-import { Card, CardContent } from '@/components/ui/card';
-import { Search, Palette, Loader2, AlertTriangle, History, Package } from 'lucide-react';
-import { Checkbox } from '@/components/ui/checkbox';
-import { useTintPricing } from '@/hooks/useTintPricing';
-import type { Product } from '@/hooks/useUnifiedOrder';
-import { fmt } from '@/hooks/useUnifiedOrder';
-
-interface TintColorSelectDialogProps {
-  product: Product;
-  open: boolean;
-  onClose: () => void;
-  onConfirm: (formulaId: string, corId: string, nomeCor: string, precoFinal: number, custoCorantes: number, alternativeProduct?: Product) => void;
-  customerUserId?: string | null;
-}
-
-interface FormulaResult {
-  id: string;
-  cor_id: string;
-  nome_cor: string;
-  preco_final_sayersystem: number | null;
-}
-
-interface AlternativePackaging {
-  formulaId: string;
-  skuId: string;
-  omieProductId: string;
-  productDescricao: string;
-  productCodigo: string;
-  precoFinalCsv: number | null;
-  product: Product;
-  sameAcabamento: boolean;
-  corId?: string;
-  nomeCor?: string;
-}
+import { Search, Palette, Loader2, AlertTriangle } from 'lucide-react';
+import type { TintColorSelectDialogProps } from './tintColorSelect/types';
+import { useTintColorSelect } from './tintColorSelect/useTintColorSelect';
+import { FormulaSearchResults } from './tintColorSelect/FormulaSearchResults';
+import { GlobalColorMatches } from './tintColorSelect/GlobalColorMatches';
+import { SelectedFormulaCard } from './tintColorSelect/SelectedFormulaCard';
 
 export function TintColorSelectDialog({ product, open, onClose, onConfirm, customerUserId }: TintColorSelectDialogProps) {
-  const [search, setSearch] = useState('');
-  const [debouncedSearch, setDebouncedSearch] = useState('');
-  const [selectedFormula, setSelectedFormula] = useState<FormulaResult | null>(null);
-  const [discountPct, setDiscountPct] = useState<number>(0);
-  const [altDiscounts, setAltDiscounts] = useState<Record<string, number>>({});
-  const [syncDiscount, setSyncDiscount] = useState(false);
-  useEffect(() => {
-    if (!open) {
-      setSearch('');
-      setDebouncedSearch('');
-      setSelectedFormula(null);
-      setPriceSourceOverride(null);
-    }
-  }, [open]);
-
-  useEffect(() => {
-    const t = setTimeout(() => setDebouncedSearch(search), 300);
-    return () => clearTimeout(t);
-  }, [search]);
-
-  // Find SKU id + produto_id + base_id for this omie product
-  const { data: skuInfo, isLoading: loadingSku } = useQuery({
-    queryKey: ['tint-sku-for-product', product.id],
-    staleTime: 5 * 60 * 1000,
-    enabled: open,
-    queryFn: async () => {
-      const { data } = await supabase
-        .from('tint_skus')
-        .select('id, produto_id, base_id')
-        .eq('omie_product_id', product.id)
-        .eq('account', 'oben')
-        .limit(1)
-        .maybeSingle();
-      return data || null;
-    },
-  });
-  const skuId = skuInfo?.id || null;
-
-  // Get base description to extract the numeric suffix (e.g. ".7666" from "WFOB.7666 BASE BRANCA...")
-  const { data: currentBaseInfo } = useQuery({
-    queryKey: ['tint-base-info', skuInfo?.base_id],
-    staleTime: 10 * 60 * 1000,
-    enabled: !!skuInfo?.base_id,
-    queryFn: async () => {
-      const { data } = await supabase
-        .from('tint_bases')
-        .select('id, descricao, id_base_sayersystem')
-        .eq('id', skuInfo!.base_id)
-        .maybeSingle();
-      return data || null;
-    },
-  });
-
-  // Extract numeric suffix like "6736" from "WFOB.6736 BASE BRANCA..."
-  const currentBaseSuffix = useMemo(() => {
-    if (!currentBaseInfo?.descricao) return null;
-    const match = currentBaseInfo.descricao.match(/\.(\d+)/);
-    return match ? match[1] : null;
-  }, [currentBaseInfo?.descricao]);
-
-  // Search formulas in current SKU
-  const { data: formulas, isLoading: loadingFormulas } = useQuery({
-    queryKey: ['tint-formula-search', skuId, debouncedSearch],
-    staleTime: 5 * 60 * 1000,
-    enabled: !!skuId && debouncedSearch.length >= 2,
-    queryFn: async () => {
-      const { data } = await supabase
-        .from('tint_formulas')
-        .select('id, cor_id, nome_cor, preco_final_sayersystem')
-        .eq('account', 'oben')
-        .eq('sku_id', skuId!)
-        .or(`cor_id.ilike.%${debouncedSearch}%,nome_cor.ilike.%${debouncedSearch}%`)
-        .limit(20);
-      return (data || []) as FormulaResult[];
-    },
-  });
-
-  // When color not found in current base, search ALL bases for it
-  const colorNotFoundInBase = debouncedSearch.length >= 2 && !loadingFormulas && formulas && formulas.length === 0;
-
-  const { data: globalColorMatches, isLoading: loadingGlobalColors } = useQuery({
-    queryKey: ['tint-global-color-search', debouncedSearch, currentBaseSuffix],
-    staleTime: 5 * 60 * 1000,
-    enabled: !!colorNotFoundInBase && !!currentBaseSuffix,
-    queryFn: async (): Promise<AlternativePackaging[]> => {
-      // Search formulas across all SKUs
-      const { data: globalFormulas } = await supabase
-        .from('tint_formulas')
-        .select('id, cor_id, nome_cor, sku_id, preco_final_sayersystem')
-        .eq('account', 'oben')
-        .or(`cor_id.ilike.%${debouncedSearch}%,nome_cor.ilike.%${debouncedSearch}%`)
-        .not('sku_id', 'is', null)
-        .limit(50);
-
-      if (!globalFormulas || globalFormulas.length === 0) return [];
-
-      // Get SKU details
-      const skuIds = [...new Set(globalFormulas.map(f => f.sku_id!))];
-      const { data: skus } = await supabase
-        .from('tint_skus')
-        .select('id, omie_product_id, produto_id, base_id')
-        .in('id', skuIds)
-        .not('omie_product_id', 'is', null);
-
-      if (!skus || skus.length === 0) return [];
-
-      // Filter SKUs to only those with the same base suffix (e.g. ".7666")
-      if (currentBaseSuffix) {
-        const baseIds = [...new Set(skus.map(s => s.base_id))];
-        const { data: bases } = await supabase
-          .from('tint_bases')
-          .select('id, descricao')
-          .in('id', baseIds);
-        
-        const validBaseIds = new Set(
-          (bases || [])
-            .filter(b => {
-              const match = b.descricao?.match(/\.(\d+)/);
-              return match && match[1] === currentBaseSuffix;
-            })
-            .map(b => b.id)
-        );
-        
-        // Remove SKUs with non-matching bases — filtra skus in-place
-        const filteredSkus = skus.filter(s => validBaseIds.has(s.base_id));
-        if (filteredSkus.length === 0) return [];
-        // Replace skus reference
-        skus.length = 0;
-        skus.push(...filteredSkus);
-      }
-
-      // Get product details
-      const productIds = skus.map(s => s.omie_product_id!).filter(Boolean);
-      const { data: products } = await supabase
-        .from('omie_products')
-        .select('id, codigo, descricao, unidade, valor_unitario, estoque, ativo, omie_codigo_produto, account, is_tintometric, tint_type')
-        .in('id', productIds);
-
-      if (!products) return [];
-
-      const result: AlternativePackaging[] = [];
-      for (const gf of globalFormulas) {
-        const sku = skus.find(s => s.id === gf.sku_id);
-        if (!sku?.omie_product_id) continue;
-        const prod = products.find(p => p.id === sku.omie_product_id);
-        if (!prod) continue;
-
-        result.push({
-          formulaId: gf.id,
-          skuId: gf.sku_id!,
-          omieProductId: sku.omie_product_id,
-          productDescricao: prod.descricao,
-          productCodigo: prod.codigo,
-          precoFinalCsv: gf.preco_final_sayersystem ? Math.ceil(gf.preco_final_sayersystem * 10) / 10 : gf.preco_final_sayersystem,
-          product: prod as Product,
-          sameAcabamento: false,
-          corId: gf.cor_id,
-          nomeCor: gf.nome_cor,
-        });
-      }
-
-      result.sort((a, b) => a.productDescricao.localeCompare(b.productDescricao));
-      return result;
-    },
-  });
-
-  // Pricing breakdown for selected formula (for informational display)
-  const { data: pricing } = useTintPricing(selectedFormula?.id || null);
-
-  // Last practiced price for this color+base for the customer
-  const { data: lastPracticedPrice, isLoading: loadingLastPrice } = useQuery({
-    queryKey: ['tint-last-price', customerUserId, product.id, selectedFormula?.cor_id],
-    staleTime: 30 * 1000,
-    enabled: !!customerUserId && !!selectedFormula?.cor_id && !!product.id,
-    queryFn: async () => {
-      if (!customerUserId || !selectedFormula?.cor_id || !product.id) return null;
-
-      const { data: orders } = await supabase
-        .from('sales_orders')
-        .select('items, created_at')
-        .eq('customer_user_id', customerUserId)
-        .eq('account', 'oben')
-        .order('created_at', { ascending: false })
-        .limit(50);
-
-      if (!orders) return null;
-
-      for (const order of orders) {
-        const items = order.items as Array<{ product_id?: string; tint_cor_id?: string; valor_unitario?: number }>;
-        if (!Array.isArray(items)) continue;
-        for (const item of items) {
-          if (
-            item.product_id === product.id &&
-            item.tint_cor_id === selectedFormula.cor_id
-          ) {
-            return {
-              price: item.valor_unitario as number,
-              date: order.created_at as string,
-            };
-          }
-        }
-      }
-      return null;
-    },
-  });
-
-  // Alternative packagings: same color, different SKUs
-  const { data: alternatives, isLoading: loadingAlternatives } = useQuery({
-    queryKey: ['tint-alternatives', selectedFormula?.cor_id, skuId],
-    staleTime: 5 * 60 * 1000,
-    enabled: !!selectedFormula?.cor_id && !!skuId,
-    queryFn: async (): Promise<AlternativePackaging[]> => {
-      if (!selectedFormula?.cor_id || !skuId) return [];
-
-      // Get all formulas with the same cor_id but different sku_id
-      const { data: altFormulas } = await supabase
-        .from('tint_formulas')
-        .select('id, sku_id, preco_final_sayersystem')
-        .eq('account', 'oben')
-        .eq('cor_id', selectedFormula.cor_id)
-        .neq('sku_id', skuId)
-        .not('sku_id', 'is', null);
-
-      if (!altFormulas || altFormulas.length === 0) return [];
-
-      // Get SKU details with omie_product_id, produto_id, base_id
-      const skuIds = [...new Set(altFormulas.map(f => f.sku_id!))];
-      const { data: skus } = await supabase
-        .from('tint_skus')
-        .select('id, omie_product_id, produto_id, base_id')
-        .in('id', skuIds)
-        .not('omie_product_id', 'is', null);
-
-      if (!skus || skus.length === 0) return [];
-
-      // Get product details
-      const productIds = skus.map(s => s.omie_product_id!).filter(Boolean);
-      const { data: products } = await supabase
-        .from('omie_products')
-        .select('id, codigo, descricao, unidade, valor_unitario, estoque, ativo, omie_codigo_produto, account, is_tintometric, tint_type')
-        .in('id', productIds);
-
-      if (!products) return [];
-
-      const currentProdutoId = skuInfo?.produto_id;
-      const currentBaseId = skuInfo?.base_id;
-
-      const result: AlternativePackaging[] = [];
-      for (const af of altFormulas) {
-        const sku = skus.find(s => s.id === af.sku_id);
-        if (!sku?.omie_product_id) continue;
-        const prod = products.find(p => p.id === sku.omie_product_id);
-        if (!prod) continue;
-
-        result.push({
-          formulaId: af.id,
-          skuId: af.sku_id!,
-          omieProductId: sku.omie_product_id,
-          productDescricao: prod.descricao,
-          productCodigo: prod.codigo,
-          precoFinalCsv: af.preco_final_sayersystem ? Math.ceil(af.preco_final_sayersystem * 10) / 10 : af.preco_final_sayersystem,
-          product: prod as Product,
-          sameAcabamento: sku.produto_id === currentProdutoId && sku.base_id === currentBaseId,
-        });
-      }
-
-      // Sort: same acabamento first, then by description
-      result.sort((a, b) => {
-        if (a.sameAcabamento && !b.sameAcabamento) return -1;
-        if (!a.sameAcabamento && b.sameAcabamento) return 1;
-        return a.productDescricao.localeCompare(b.productDescricao);
-      });
-
-      return result;
-    },
-  });
-
-  // Use CSV price rounded up to the nearest R$0.10
-  const rawCsv = selectedFormula?.preco_final_sayersystem ?? 0;
-  const precoCsv = rawCsv > 0 ? Math.ceil(rawCsv * 10) / 10 : 0;
-  const custoCorantes = pricing?.custoCorantes || 0;
-
-  // Price source selection: user can choose between historical, CSV, or calculated
-  const [priceSourceOverride, setPriceSourceOverride] = useState<'cliente' | 'tabela' | 'calculado' | null>(null);
-
-  const precoBase = product.valor_unitario;
-  const precoCalculado = precoBase + custoCorantes;
-
-  // Auto-detect best price source
-  const precoCsvValido = precoCsv > 0 && precoCsv >= precoBase ? precoCsv : 0;
-  const autoSource = lastPracticedPrice
-    ? 'cliente'
-    : precoCsvValido > 0
-      ? 'tabela'
-      : 'calculado';
-  const priceSource = priceSourceOverride || autoSource;
-
-  // Se o preço CSV for menor que o preço da base, usar o calculado (base + corantes) como piso
-  const precoSemDesconto = priceSource === 'cliente' && lastPracticedPrice
-    ? lastPracticedPrice.price
-    : priceSource === 'tabela' && precoCsvValido > 0
-      ? precoCsvValido
-      : precoCalculado;
-  const precoFinal = discountPct > 0 ? Math.round(precoSemDesconto * (1 - discountPct / 100) * 100) / 100 : precoSemDesconto;
+  const {
+    search,
+    onSearchChange,
+    loadingSku,
+    skuId,
+    formulas,
+    loadingFormulas,
+    colorNotFoundInBase,
+    globalColorMatches,
+    loadingGlobalColors,
+    selectedFormula,
+    setSelectedFormula,
+    lastPracticedPrice,
+    loadingLastPrice,
+    alternatives,
+    loadingAlternatives,
+    discountPct,
+    setDiscountPct,
+    altDiscounts,
+    setAltDiscounts,
+    syncDiscount,
+    setSyncDiscount,
+    priceSource,
+    setPriceSourceOverride,
+    precoCsv,
+    custoCorantes,
+    precoSemDesconto,
+    precoFinal,
+  } = useTintColorSelect({ product, open, customerUserId });
 
   return (
     <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
@@ -369,7 +61,7 @@ export function TintColorSelectDialog({ product, open, onClose, onConfirm, custo
               <Input
                 placeholder="Buscar por código ou nome da cor..."
                 value={search}
-                onChange={e => { setSearch(e.target.value); setSelectedFormula(null); setPriceSourceOverride(null); }}
+                onChange={e => onSearchChange(e.target.value)}
                 className="pl-9 h-9"
                 autoFocus
               />
@@ -378,283 +70,39 @@ export function TintColorSelectDialog({ product, open, onClose, onConfirm, custo
             {loadingFormulas && <Loader2 className="w-4 h-4 animate-spin mx-auto my-4" />}
 
             {formulas && formulas.length > 0 && !selectedFormula && (
-              <div className="max-h-48 overflow-y-auto border rounded-md divide-y">
-                {formulas.map(f => (
-                  <button
-                    key={f.id}
-                    onClick={() => setSelectedFormula(f)}
-                    className="w-full text-left px-3 py-2 hover:bg-muted/50 transition-colors text-xs flex items-center gap-2"
-                  >
-                    <Palette className="w-3 h-3 text-primary shrink-0" />
-                    <span className="font-mono font-medium">{f.cor_id}</span>
-                    <span className="text-muted-foreground">—</span>
-                    <span className="truncate">{f.nome_cor}</span>
-                  </button>
-                ))}
-              </div>
+              <FormulaSearchResults formulas={formulas} onSelect={setSelectedFormula} />
             )}
 
             {colorNotFoundInBase && !loadingGlobalColors && (
-              <>
-                {globalColorMatches && globalColorMatches.length > 0 ? (
-                  <div className="space-y-3">
-                    <div className="flex items-start gap-2 p-3 rounded-md bg-status-warning-bg border border-status-warning/30">
-                      <AlertTriangle className="w-5 h-5 text-status-warning shrink-0 mt-0.5" />
-                      <div>
-                        <p className="text-sm font-semibold text-status-warning-foreground">
-                          Esta cor não pode ser feita nesta base
-                        </p>
-                        <p className="text-xs text-status-warning mt-1">
-                          A cor pesquisada não está disponível em <strong>{product.descricao}</strong>. Veja abaixo as embalagens onde ela pode ser produzida:
-                        </p>
-                      </div>
-                    </div>
-
-                    <div className="space-y-1.5">
-                      <div className="flex items-center gap-1.5 text-[10px] uppercase font-semibold text-muted-foreground tracking-wider">
-                        <Package className="w-3 h-3" />
-                        Bases disponíveis para esta cor
-                      </div>
-                      <div className="max-h-60 overflow-y-auto space-y-1.5">
-                        {globalColorMatches.map((alt) => {
-                          const altBasePrice = alt.precoFinalCsv && alt.precoFinalCsv > 0
-                            ? alt.precoFinalCsv
-                            : alt.product.valor_unitario;
-                          return (
-                            <div key={alt.formulaId} className="rounded-md border border-border hover:border-primary/50 transition-all text-xs">
-                              <button
-                                onClick={() => onConfirm(
-                                  alt.formulaId,
-                                  alt.corId || '',
-                                  alt.nomeCor || '',
-                                  altBasePrice,
-                                  0,
-                                  alt.product,
-                                )}
-                                className="w-full flex items-center justify-between gap-2 p-2.5 hover:bg-primary/5"
-                              >
-                                <div className="flex-1 text-left min-w-0">
-                                  <p className="font-medium break-words whitespace-normal">
-                                    {alt.productDescricao}
-                                  </p>
-                                  <div className="flex items-center gap-1.5 mt-0.5">
-                                    <span className="text-[10px] text-muted-foreground font-mono">{alt.productCodigo}</span>
-                                    {alt.corId && (
-                                      <Badge variant="outline" className="text-[8px] px-1 py-0">{alt.corId}</Badge>
-                                    )}
-                                  </div>
-                                </div>
-                                <div className="text-right shrink-0">
-                                  <span className="font-bold text-primary">{fmt(altBasePrice)}</span>
-                                  {alt.precoFinalCsv && alt.precoFinalCsv > 0 ? (
-                                    <Badge variant="secondary" className="text-[8px] px-1 py-0 ml-1">Tabela</Badge>
-                                  ) : (
-                                    <Badge variant="outline" className="text-[8px] px-1 py-0 ml-1">Base</Badge>
-                                  )}
-                                </div>
-                              </button>
-                            </div>
-                          );
-                        })}
-                      </div>
-                    </div>
-                  </div>
-                ) : (
-                  <p className="text-xs text-muted-foreground text-center py-4">Nenhuma cor encontrada em nenhuma base.</p>
-                )}
-              </>
+              <GlobalColorMatches
+                product={product}
+                matches={globalColorMatches ?? []}
+                onConfirm={onConfirm}
+              />
             )}
             {loadingGlobalColors && <Loader2 className="w-4 h-4 animate-spin mx-auto my-4" />}
 
             {selectedFormula && (
-              <Card className="border-primary/30">
-                <CardContent className="pt-4 space-y-3">
-                  <div className="flex items-center gap-2">
-                    <Badge variant="outline" className="text-xs font-mono">{selectedFormula.cor_id}</Badge>
-                    <span className="text-sm font-medium">{selectedFormula.nome_cor}</span>
-                  </div>
-
-                  {/* Last practiced price for this customer */}
-                  {loadingLastPrice ? (
-                    <Loader2 className="w-3 h-3 animate-spin" />
-                  ) : lastPracticedPrice ? (
-                    <div className="flex items-center gap-2 p-2 rounded-md bg-primary/5 border border-primary/20">
-                      <History className="w-3.5 h-3.5 text-primary shrink-0" />
-                      <div className="text-xs">
-                        <span className="font-medium text-primary">Último preço cliente: {fmt(lastPracticedPrice.price)}</span>
-                        {precoCsv > 0 && lastPracticedPrice.price < precoCsv && (
-                          <Badge variant="secondary" className="ml-1.5 text-[9px] px-1.5 py-0 text-status-warning-bold bg-status-warning-bg border-status-warning/30">
-                            -{Math.round((1 - lastPracticedPrice.price / precoCsv) * 100)}% da tabela
-                          </Badge>
-                        )}
-                        <span className="text-muted-foreground ml-1">
-                          ({new Date(lastPracticedPrice.date).toLocaleDateString('pt-BR')})
-                        </span>
-                      </div>
-                    </div>
-                  ) : null}
-
-                  {/* Price source selection when multiple options available */}
-                  {lastPracticedPrice && precoCsv > 0 ? (
-                    <div className="space-y-1.5">
-                      <p className="text-[10px] uppercase font-semibold text-muted-foreground tracking-wider">Selecionar preço</p>
-                      <div className="flex flex-wrap gap-1.5">
-                        <button
-                          onClick={() => setPriceSourceOverride('cliente')}
-                          className={`flex items-center gap-1 px-2 py-1 rounded-md border text-xs transition-all ${priceSource === 'cliente' ? 'border-primary bg-primary/10 text-primary font-semibold' : 'border-border hover:border-primary/50'}`}
-                        >
-                          <History className="w-3 h-3" />
-                          Cliente {fmt(lastPracticedPrice.price)}
-                        </button>
-                        <button
-                          onClick={() => setPriceSourceOverride('tabela')}
-                          className={`flex items-center gap-1 px-2 py-1 rounded-md border text-xs transition-all ${priceSource === 'tabela' ? 'border-primary bg-primary/10 text-primary font-semibold' : 'border-border hover:border-primary/50'}`}
-                        >
-                          Tabela {fmt(precoCsv)}
-                        </button>
-                      </div>
-                    </div>
-                  ) : null}
-
-                  {/* Price breakdown */}
-                  <div className="space-y-2">
-                    {/* Main price */}
-                    <div className="flex justify-between text-sm font-bold border-b pb-2">
-                      <span className="flex items-center gap-1.5">
-                        Preço Final
-                        <Badge variant="secondary" className="text-[9px] px-1.5 py-0">
-                          {priceSource === 'cliente' ? 'Preço cliente' : 'Tabela'}
-                        </Badge>
-                      </span>
-                      <span className="text-primary">{fmt(precoFinal)}</span>
-                    </div>
-
-                    {/* Discount field */}
-                    <div className="flex items-center gap-2 pt-1">
-                      <label className="text-xs text-muted-foreground whitespace-nowrap">Desconto %</label>
-                      <Input
-                        type="number"
-                        min={0}
-                        max={100}
-                        step={1}
-                        value={discountPct || ''}
-                        onChange={(e) => setDiscountPct(Math.min(100, Math.max(0, Number(e.target.value) || 0)))}
-                        className="h-7 w-20 text-xs text-right"
-                        placeholder="0"
-                      />
-                      {discountPct > 0 && (
-                        <span className="text-[10px] text-muted-foreground line-through">{fmt(precoSemDesconto)}</span>
-                      )}
-                    </div>
-                    {alternatives && alternatives.length > 0 && (
-                      <div className="flex items-center gap-2 pt-1">
-                        <Checkbox
-                          id="sync-discount"
-                          checked={syncDiscount}
-                          onCheckedChange={(v) => setSyncDiscount(!!v)}
-                          className="h-3.5 w-3.5"
-                        />
-                        <label htmlFor="sync-discount" className="text-[10px] text-muted-foreground cursor-pointer">
-                          Aplicar mesmo desconto nas outras embalagens
-                        </label>
-                      </div>
-                    )}
-                  </div>
-
-                  <Button
-                    size="sm"
-                    onClick={() => onConfirm(
-                      selectedFormula.id,
-                      selectedFormula.cor_id,
-                      selectedFormula.nome_cor,
-                      precoFinal,
-                      custoCorantes,
-                    )}
-                  >
-                    <Palette className="w-3.5 h-3.5 mr-1.5" />
-                    Adicionar ao Pedido — {fmt(precoFinal)}
-                  </Button>
-
-                  {/* Alternative packagings */}
-                  {loadingAlternatives ? (
-                    <div className="flex items-center gap-2 text-xs text-muted-foreground pt-1">
-                      <Loader2 className="w-3 h-3 animate-spin" />
-                      Buscando outras embalagens...
-                    </div>
-                  ) : alternatives && alternatives.length > 0 ? (
-                    <div className="space-y-2 pt-1">
-                      <div className="flex items-center gap-1.5 text-[10px] uppercase font-semibold text-muted-foreground tracking-wider">
-                        <Package className="w-3 h-3" />
-                        Mesma cor em outras embalagens
-                      </div>
-                      <div className="space-y-1.5">
-                        {alternatives.map((alt, idx) => {
-                          const prevAlt = idx > 0 ? alternatives[idx - 1] : null;
-                          const showDivider = prevAlt && prevAlt.sameAcabamento && !alt.sameAcabamento;
-                          const altBasePrice = alt.precoFinalCsv && alt.precoFinalCsv > 0
-                            ? alt.precoFinalCsv
-                            : alt.product.valor_unitario + custoCorantes;
-                          const altDisc = syncDiscount ? discountPct : (altDiscounts[alt.formulaId] || 0);
-                          const altPrice = altDisc > 0 ? Math.round(altBasePrice * (1 - altDisc / 100) * 100) / 100 : altBasePrice;
-                          return (
-                            <>
-                              {showDivider && (
-                                <div className="flex items-center gap-2 pt-1 pb-0.5">
-                                  <div className="flex-1 border-t border-border" />
-                                  <span className="text-[9px] text-muted-foreground uppercase tracking-wider">Outros acabamentos</span>
-                                  <div className="flex-1 border-t border-border" />
-                                </div>
-                              )}
-                              <div className={`rounded-md border transition-all text-xs group ${alt.sameAcabamento ? 'border-primary/30 bg-primary/5' : 'border-border hover:border-primary/50'}`}>
-                              <button
-                                onClick={() => onConfirm(
-                                  alt.formulaId,
-                                  selectedFormula.cor_id,
-                                  selectedFormula.nome_cor,
-                                  altPrice,
-                                  custoCorantes,
-                                  alt.product,
-                                )}
-                                className="w-full flex items-center justify-between gap-2 p-2 hover:bg-primary/5"
-                              >
-                                <div className="flex-1 text-left min-w-0">
-                                  <p className="font-medium group-hover:text-primary transition-colors break-words whitespace-normal">
-                                    {alt.productDescricao}
-                                  </p>
-                                  <p className="text-[10px] text-muted-foreground font-mono">{alt.productCodigo}</p>
-                                </div>
-                                <div className="text-right shrink-0">
-                                  <span className="font-bold text-primary">{fmt(altPrice)}</span>
-                                  {altDisc > 0 && <span className="text-[10px] text-muted-foreground line-through ml-1">{fmt(altBasePrice)}</span>}
-                                  {alt.precoFinalCsv && alt.precoFinalCsv > 0 ? (
-                                    <Badge variant="secondary" className="text-[8px] px-1 py-0 ml-1">Tabela</Badge>
-                                  ) : (
-                                    <Badge variant="outline" className="text-[8px] px-1 py-0 ml-1">Calc.</Badge>
-                                  )}
-                                </div>
-                              </button>
-                              <div className="flex items-center gap-2 px-2 pb-2" onClick={(e) => e.stopPropagation()}>
-                                <label className="text-[10px] text-muted-foreground whitespace-nowrap">Desconto %</label>
-                                <Input
-                                  type="number"
-                                  min={0}
-                                  max={100}
-                                  step={1}
-                                  value={altDisc || ''}
-                                  onChange={(e) => setAltDiscounts(prev => ({ ...prev, [alt.formulaId]: Math.min(100, Math.max(0, Number(e.target.value) || 0)) }))}
-                                  className="h-6 w-16 text-[10px] text-right"
-                                  placeholder="0"
-                                />
-                              </div>
-                            </div>
-                            </>
-                          );
-                        })}
-                      </div>
-                    </div>
-                  ) : null}
-                </CardContent>
-              </Card>
+              <SelectedFormulaCard
+                selectedFormula={selectedFormula}
+                loadingLastPrice={loadingLastPrice}
+                lastPracticedPrice={lastPracticedPrice}
+                precoCsv={precoCsv}
+                priceSource={priceSource}
+                setPriceSourceOverride={setPriceSourceOverride}
+                precoFinal={precoFinal}
+                precoSemDesconto={precoSemDesconto}
+                discountPct={discountPct}
+                setDiscountPct={setDiscountPct}
+                syncDiscount={syncDiscount}
+                setSyncDiscount={setSyncDiscount}
+                alternatives={alternatives}
+                loadingAlternatives={loadingAlternatives}
+                altDiscounts={altDiscounts}
+                setAltDiscounts={setAltDiscounts}
+                custoCorantes={custoCorantes}
+                onConfirm={onConfirm}
+              />
             )}
           </>
         )}

--- a/src/components/tintColorSelect/FormulaSearchResults.tsx
+++ b/src/components/tintColorSelect/FormulaSearchResults.tsx
@@ -1,0 +1,28 @@
+// Lista de resultados de busca de cor (fórmulas na base atual).
+// Extraída verbatim de src/components/TintColorSelectDialog.tsx (god-component split).
+import { Palette } from 'lucide-react';
+import type { FormulaResult } from './types';
+
+interface FormulaSearchResultsProps {
+  formulas: FormulaResult[];
+  onSelect: (f: FormulaResult) => void;
+}
+
+export function FormulaSearchResults({ formulas, onSelect }: FormulaSearchResultsProps) {
+  return (
+    <div className="max-h-48 overflow-y-auto border rounded-md divide-y">
+      {formulas.map(f => (
+        <button
+          key={f.id}
+          onClick={() => onSelect(f)}
+          className="w-full text-left px-3 py-2 hover:bg-muted/50 transition-colors text-xs flex items-center gap-2"
+        >
+          <Palette className="w-3 h-3 text-primary shrink-0" />
+          <span className="font-mono font-medium">{f.cor_id}</span>
+          <span className="text-muted-foreground">—</span>
+          <span className="truncate">{f.nome_cor}</span>
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/components/tintColorSelect/GlobalColorMatches.tsx
+++ b/src/components/tintColorSelect/GlobalColorMatches.tsx
@@ -1,0 +1,84 @@
+// Lista de bases alternativas quando a cor não existe na base atual.
+// Extraída verbatim de src/components/TintColorSelectDialog.tsx (god-component split).
+import { AlertTriangle, Package } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import type { Product } from '@/hooks/useUnifiedOrder';
+import { fmt } from '@/hooks/useUnifiedOrder';
+import type { AlternativePackaging } from './types';
+
+interface GlobalColorMatchesProps {
+  product: Product;
+  matches: AlternativePackaging[];
+  onConfirm: (formulaId: string, corId: string, nomeCor: string, precoFinal: number, custoCorantes: number, alternativeProduct?: Product) => void;
+}
+
+export function GlobalColorMatches({ product, matches, onConfirm }: GlobalColorMatchesProps) {
+  if (matches.length === 0) {
+    return <p className="text-xs text-muted-foreground text-center py-4">Nenhuma cor encontrada em nenhuma base.</p>;
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-start gap-2 p-3 rounded-md bg-status-warning-bg border border-status-warning/30">
+        <AlertTriangle className="w-5 h-5 text-status-warning shrink-0 mt-0.5" />
+        <div>
+          <p className="text-sm font-semibold text-status-warning-foreground">
+            Esta cor não pode ser feita nesta base
+          </p>
+          <p className="text-xs text-status-warning mt-1">
+            A cor pesquisada não está disponível em <strong>{product.descricao}</strong>. Veja abaixo as embalagens onde ela pode ser produzida:
+          </p>
+        </div>
+      </div>
+
+      <div className="space-y-1.5">
+        <div className="flex items-center gap-1.5 text-[10px] uppercase font-semibold text-muted-foreground tracking-wider">
+          <Package className="w-3 h-3" />
+          Bases disponíveis para esta cor
+        </div>
+        <div className="max-h-60 overflow-y-auto space-y-1.5">
+          {matches.map((alt) => {
+            const altBasePrice = alt.precoFinalCsv && alt.precoFinalCsv > 0
+              ? alt.precoFinalCsv
+              : alt.product.valor_unitario;
+            return (
+              <div key={alt.formulaId} className="rounded-md border border-border hover:border-primary/50 transition-all text-xs">
+                <button
+                  onClick={() => onConfirm(
+                    alt.formulaId,
+                    alt.corId || '',
+                    alt.nomeCor || '',
+                    altBasePrice,
+                    0,
+                    alt.product,
+                  )}
+                  className="w-full flex items-center justify-between gap-2 p-2.5 hover:bg-primary/5"
+                >
+                  <div className="flex-1 text-left min-w-0">
+                    <p className="font-medium break-words whitespace-normal">
+                      {alt.productDescricao}
+                    </p>
+                    <div className="flex items-center gap-1.5 mt-0.5">
+                      <span className="text-[10px] text-muted-foreground font-mono">{alt.productCodigo}</span>
+                      {alt.corId && (
+                        <Badge variant="outline" className="text-[8px] px-1 py-0">{alt.corId}</Badge>
+                      )}
+                    </div>
+                  </div>
+                  <div className="text-right shrink-0">
+                    <span className="font-bold text-primary">{fmt(altBasePrice)}</span>
+                    {alt.precoFinalCsv && alt.precoFinalCsv > 0 ? (
+                      <Badge variant="secondary" className="text-[8px] px-1 py-0 ml-1">Tabela</Badge>
+                    ) : (
+                      <Badge variant="outline" className="text-[8px] px-1 py-0 ml-1">Base</Badge>
+                    )}
+                  </div>
+                </button>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/tintColorSelect/SelectedFormulaCard.tsx
+++ b/src/components/tintColorSelect/SelectedFormulaCard.tsx
@@ -1,0 +1,246 @@
+// Card de detalhe da cor selecionada: preço, fonte, desconto e embalagens alternativas.
+// Extraído verbatim de src/components/TintColorSelectDialog.tsx (god-component split).
+import { Loader2, History, Package, Palette } from 'lucide-react';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent } from '@/components/ui/card';
+import { Checkbox } from '@/components/ui/checkbox';
+import type { Product } from '@/hooks/useUnifiedOrder';
+import { fmt } from '@/hooks/useUnifiedOrder';
+import type { FormulaResult, AlternativePackaging } from './types';
+
+type PriceSource = 'cliente' | 'tabela' | 'calculado';
+
+interface SelectedFormulaCardProps {
+  selectedFormula: FormulaResult;
+  loadingLastPrice: boolean;
+  lastPracticedPrice: { price: number; date: string } | null | undefined;
+  precoCsv: number;
+  priceSource: string;
+  setPriceSourceOverride: (s: PriceSource | null) => void;
+  precoFinal: number;
+  precoSemDesconto: number;
+  discountPct: number;
+  setDiscountPct: (n: number) => void;
+  syncDiscount: boolean;
+  setSyncDiscount: (v: boolean) => void;
+  alternatives: AlternativePackaging[] | undefined;
+  loadingAlternatives: boolean;
+  altDiscounts: Record<string, number>;
+  setAltDiscounts: React.Dispatch<React.SetStateAction<Record<string, number>>>;
+  custoCorantes: number;
+  onConfirm: (formulaId: string, corId: string, nomeCor: string, precoFinal: number, custoCorantes: number, alternativeProduct?: Product) => void;
+}
+
+export function SelectedFormulaCard({
+  selectedFormula,
+  loadingLastPrice,
+  lastPracticedPrice,
+  precoCsv,
+  priceSource,
+  setPriceSourceOverride,
+  precoFinal,
+  precoSemDesconto,
+  discountPct,
+  setDiscountPct,
+  syncDiscount,
+  setSyncDiscount,
+  alternatives,
+  loadingAlternatives,
+  altDiscounts,
+  setAltDiscounts,
+  custoCorantes,
+  onConfirm,
+}: SelectedFormulaCardProps) {
+  return (
+    <Card className="border-primary/30">
+      <CardContent className="pt-4 space-y-3">
+        <div className="flex items-center gap-2">
+          <Badge variant="outline" className="text-xs font-mono">{selectedFormula.cor_id}</Badge>
+          <span className="text-sm font-medium">{selectedFormula.nome_cor}</span>
+        </div>
+
+        {/* Last practiced price for this customer */}
+        {loadingLastPrice ? (
+          <Loader2 className="w-3 h-3 animate-spin" />
+        ) : lastPracticedPrice ? (
+          <div className="flex items-center gap-2 p-2 rounded-md bg-primary/5 border border-primary/20">
+            <History className="w-3.5 h-3.5 text-primary shrink-0" />
+            <div className="text-xs">
+              <span className="font-medium text-primary">Último preço cliente: {fmt(lastPracticedPrice.price)}</span>
+              {precoCsv > 0 && lastPracticedPrice.price < precoCsv && (
+                <Badge variant="secondary" className="ml-1.5 text-[9px] px-1.5 py-0 text-status-warning-bold bg-status-warning-bg border-status-warning/30">
+                  -{Math.round((1 - lastPracticedPrice.price / precoCsv) * 100)}% da tabela
+                </Badge>
+              )}
+              <span className="text-muted-foreground ml-1">
+                ({new Date(lastPracticedPrice.date).toLocaleDateString('pt-BR')})
+              </span>
+            </div>
+          </div>
+        ) : null}
+
+        {/* Price source selection when multiple options available */}
+        {lastPracticedPrice && precoCsv > 0 ? (
+          <div className="space-y-1.5">
+            <p className="text-[10px] uppercase font-semibold text-muted-foreground tracking-wider">Selecionar preço</p>
+            <div className="flex flex-wrap gap-1.5">
+              <button
+                onClick={() => setPriceSourceOverride('cliente')}
+                className={`flex items-center gap-1 px-2 py-1 rounded-md border text-xs transition-all ${priceSource === 'cliente' ? 'border-primary bg-primary/10 text-primary font-semibold' : 'border-border hover:border-primary/50'}`}
+              >
+                <History className="w-3 h-3" />
+                Cliente {fmt(lastPracticedPrice.price)}
+              </button>
+              <button
+                onClick={() => setPriceSourceOverride('tabela')}
+                className={`flex items-center gap-1 px-2 py-1 rounded-md border text-xs transition-all ${priceSource === 'tabela' ? 'border-primary bg-primary/10 text-primary font-semibold' : 'border-border hover:border-primary/50'}`}
+              >
+                Tabela {fmt(precoCsv)}
+              </button>
+            </div>
+          </div>
+        ) : null}
+
+        {/* Price breakdown */}
+        <div className="space-y-2">
+          {/* Main price */}
+          <div className="flex justify-between text-sm font-bold border-b pb-2">
+            <span className="flex items-center gap-1.5">
+              Preço Final
+              <Badge variant="secondary" className="text-[9px] px-1.5 py-0">
+                {priceSource === 'cliente' ? 'Preço cliente' : 'Tabela'}
+              </Badge>
+            </span>
+            <span className="text-primary">{fmt(precoFinal)}</span>
+          </div>
+
+          {/* Discount field */}
+          <div className="flex items-center gap-2 pt-1">
+            <label className="text-xs text-muted-foreground whitespace-nowrap">Desconto %</label>
+            <Input
+              type="number"
+              min={0}
+              max={100}
+              step={1}
+              value={discountPct || ''}
+              onChange={(e) => setDiscountPct(Math.min(100, Math.max(0, Number(e.target.value) || 0)))}
+              className="h-7 w-20 text-xs text-right"
+              placeholder="0"
+            />
+            {discountPct > 0 && (
+              <span className="text-[10px] text-muted-foreground line-through">{fmt(precoSemDesconto)}</span>
+            )}
+          </div>
+          {alternatives && alternatives.length > 0 && (
+            <div className="flex items-center gap-2 pt-1">
+              <Checkbox
+                id="sync-discount"
+                checked={syncDiscount}
+                onCheckedChange={(v) => setSyncDiscount(!!v)}
+                className="h-3.5 w-3.5"
+              />
+              <label htmlFor="sync-discount" className="text-[10px] text-muted-foreground cursor-pointer">
+                Aplicar mesmo desconto nas outras embalagens
+              </label>
+            </div>
+          )}
+        </div>
+
+        <Button
+          size="sm"
+          onClick={() => onConfirm(
+            selectedFormula.id,
+            selectedFormula.cor_id,
+            selectedFormula.nome_cor,
+            precoFinal,
+            custoCorantes,
+          )}
+        >
+          <Palette className="w-3.5 h-3.5 mr-1.5" />
+          Adicionar ao Pedido — {fmt(precoFinal)}
+        </Button>
+
+        {/* Alternative packagings */}
+        {loadingAlternatives ? (
+          <div className="flex items-center gap-2 text-xs text-muted-foreground pt-1">
+            <Loader2 className="w-3 h-3 animate-spin" />
+            Buscando outras embalagens...
+          </div>
+        ) : alternatives && alternatives.length > 0 ? (
+          <div className="space-y-2 pt-1">
+            <div className="flex items-center gap-1.5 text-[10px] uppercase font-semibold text-muted-foreground tracking-wider">
+              <Package className="w-3 h-3" />
+              Mesma cor em outras embalagens
+            </div>
+            <div className="space-y-1.5">
+              {alternatives.map((alt, idx) => {
+                const prevAlt = idx > 0 ? alternatives[idx - 1] : null;
+                const showDivider = prevAlt && prevAlt.sameAcabamento && !alt.sameAcabamento;
+                const altBasePrice = alt.precoFinalCsv && alt.precoFinalCsv > 0
+                  ? alt.precoFinalCsv
+                  : alt.product.valor_unitario + custoCorantes;
+                const altDisc = syncDiscount ? discountPct : (altDiscounts[alt.formulaId] || 0);
+                const altPrice = altDisc > 0 ? Math.round(altBasePrice * (1 - altDisc / 100) * 100) / 100 : altBasePrice;
+                return (
+                  <>
+                    {showDivider && (
+                      <div className="flex items-center gap-2 pt-1 pb-0.5">
+                        <div className="flex-1 border-t border-border" />
+                        <span className="text-[9px] text-muted-foreground uppercase tracking-wider">Outros acabamentos</span>
+                        <div className="flex-1 border-t border-border" />
+                      </div>
+                    )}
+                    <div className={`rounded-md border transition-all text-xs group ${alt.sameAcabamento ? 'border-primary/30 bg-primary/5' : 'border-border hover:border-primary/50'}`}>
+                    <button
+                      onClick={() => onConfirm(
+                        alt.formulaId,
+                        selectedFormula.cor_id,
+                        selectedFormula.nome_cor,
+                        altPrice,
+                        custoCorantes,
+                        alt.product,
+                      )}
+                      className="w-full flex items-center justify-between gap-2 p-2 hover:bg-primary/5"
+                    >
+                      <div className="flex-1 text-left min-w-0">
+                        <p className="font-medium group-hover:text-primary transition-colors break-words whitespace-normal">
+                          {alt.productDescricao}
+                        </p>
+                        <p className="text-[10px] text-muted-foreground font-mono">{alt.productCodigo}</p>
+                      </div>
+                      <div className="text-right shrink-0">
+                        <span className="font-bold text-primary">{fmt(altPrice)}</span>
+                        {altDisc > 0 && <span className="text-[10px] text-muted-foreground line-through ml-1">{fmt(altBasePrice)}</span>}
+                        {alt.precoFinalCsv && alt.precoFinalCsv > 0 ? (
+                          <Badge variant="secondary" className="text-[8px] px-1 py-0 ml-1">Tabela</Badge>
+                        ) : (
+                          <Badge variant="outline" className="text-[8px] px-1 py-0 ml-1">Calc.</Badge>
+                        )}
+                      </div>
+                    </button>
+                    <div className="flex items-center gap-2 px-2 pb-2" onClick={(e) => e.stopPropagation()}>
+                      <label className="text-[10px] text-muted-foreground whitespace-nowrap">Desconto %</label>
+                      <Input
+                        type="number"
+                        min={0}
+                        max={100}
+                        step={1}
+                        value={altDisc || ''}
+                        onChange={(e) => setAltDiscounts(prev => ({ ...prev, [alt.formulaId]: Math.min(100, Math.max(0, Number(e.target.value) || 0)) }))}
+                        className="h-6 w-16 text-[10px] text-right"
+                        placeholder="0"
+                      />
+                    </div>
+                  </div>
+                  </>
+                );
+              })}
+            </div>
+          </div>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/tintColorSelect/__tests__/FormulaSearchResults.test.tsx
+++ b/src/components/tintColorSelect/__tests__/FormulaSearchResults.test.tsx
@@ -1,0 +1,25 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { FormulaSearchResults } from '../FormulaSearchResults';
+import type { FormulaResult } from '../types';
+
+const formulas: FormulaResult[] = [
+  { id: 'f1', cor_id: 'RAL9010', nome_cor: 'Branco Puro', preco_final_sayersystem: 120 },
+  { id: 'f2', cor_id: 'RAL5005', nome_cor: 'Azul Sinal', preco_final_sayersystem: 140 },
+];
+
+describe('FormulaSearchResults', () => {
+  it('renderiza cada fórmula com cor_id e nome', () => {
+    render(<FormulaSearchResults formulas={formulas} onSelect={() => {}} />);
+    expect(screen.getByText('RAL9010')).toBeTruthy();
+    expect(screen.getByText('Branco Puro')).toBeTruthy();
+    expect(screen.getByText('RAL5005')).toBeTruthy();
+  });
+
+  it('dispara onSelect com a fórmula clicada', () => {
+    const onSelect = vi.fn();
+    render(<FormulaSearchResults formulas={formulas} onSelect={onSelect} />);
+    fireEvent.click(screen.getByText('Azul Sinal'));
+    expect(onSelect).toHaveBeenCalledWith(formulas[1]);
+  });
+});

--- a/src/components/tintColorSelect/__tests__/GlobalColorMatches.test.tsx
+++ b/src/components/tintColorSelect/__tests__/GlobalColorMatches.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { GlobalColorMatches } from '../GlobalColorMatches';
+import type { AlternativePackaging } from '../types';
+import type { Product } from '@/hooks/useUnifiedOrder';
+
+const product = { id: 'p1', descricao: 'Base Branca 900ml', valor_unitario: 50 } as unknown as Product;
+
+function alt(partial: Partial<AlternativePackaging>): AlternativePackaging {
+  return {
+    formulaId: 'f1',
+    skuId: 's1',
+    omieProductId: 'op1',
+    productDescricao: 'Base Branca 3.6L',
+    productCodigo: 'WFOB36',
+    precoFinalCsv: 200,
+    product: { id: 'op1', valor_unitario: 180 } as unknown as Product,
+    sameAcabamento: false,
+    corId: 'RAL9010',
+    nomeCor: 'Branco',
+    ...partial,
+  };
+}
+
+describe('GlobalColorMatches', () => {
+  it('mostra mensagem vazia quando não há matches', () => {
+    render(<GlobalColorMatches product={product} matches={[]} onConfirm={() => {}} />);
+    expect(screen.getByText('Nenhuma cor encontrada em nenhuma base.')).toBeTruthy();
+  });
+
+  it('mostra aviso e lista de embalagens alternativas', () => {
+    render(<GlobalColorMatches product={product} matches={[alt({})]} onConfirm={() => {}} />);
+    expect(screen.getByText('Esta cor não pode ser feita nesta base')).toBeTruthy();
+    expect(screen.getByText('Base Branca 3.6L')).toBeTruthy();
+  });
+
+  it('confirma com preço CSV quando presente', () => {
+    const onConfirm = vi.fn();
+    render(<GlobalColorMatches product={product} matches={[alt({ precoFinalCsv: 200 })]} onConfirm={onConfirm} />);
+    fireEvent.click(screen.getByText('Base Branca 3.6L'));
+    expect(onConfirm).toHaveBeenCalledWith('f1', 'RAL9010', 'Branco', 200, 0, expect.objectContaining({ id: 'op1' }));
+  });
+
+  it('usa valor_unitario da base quando não há preço CSV', () => {
+    const onConfirm = vi.fn();
+    render(<GlobalColorMatches product={product} matches={[alt({ precoFinalCsv: null })]} onConfirm={onConfirm} />);
+    fireEvent.click(screen.getByText('Base Branca 3.6L'));
+    expect(onConfirm).toHaveBeenCalledWith('f1', 'RAL9010', 'Branco', 180, 0, expect.objectContaining({ id: 'op1' }));
+  });
+});

--- a/src/components/tintColorSelect/__tests__/SelectedFormulaCard.test.tsx
+++ b/src/components/tintColorSelect/__tests__/SelectedFormulaCard.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { SelectedFormulaCard } from '../SelectedFormulaCard';
+import type { FormulaResult, AlternativePackaging } from '../types';
+import type { Product } from '@/hooks/useUnifiedOrder';
+
+const selectedFormula: FormulaResult = { id: 'f1', cor_id: 'RAL5005', nome_cor: 'Azul Sinal', preco_final_sayersystem: 50 };
+
+function setup(overrides: Partial<React.ComponentProps<typeof SelectedFormulaCard>> = {}) {
+  const props: React.ComponentProps<typeof SelectedFormulaCard> = {
+    selectedFormula,
+    loadingLastPrice: false,
+    lastPracticedPrice: null,
+    precoCsv: 50,
+    priceSource: 'tabela',
+    setPriceSourceOverride: vi.fn(),
+    precoFinal: 50,
+    precoSemDesconto: 50,
+    discountPct: 0,
+    setDiscountPct: vi.fn(),
+    syncDiscount: false,
+    setSyncDiscount: vi.fn(),
+    alternatives: undefined,
+    loadingAlternatives: false,
+    altDiscounts: {},
+    setAltDiscounts: vi.fn(),
+    custoCorantes: 5,
+    onConfirm: vi.fn(),
+    ...overrides,
+  };
+  render(<SelectedFormulaCard {...props} />);
+  return props;
+}
+
+describe('SelectedFormulaCard', () => {
+  it('renderiza cor e nome da fórmula selecionada', () => {
+    setup();
+    expect(screen.getByText('RAL5005')).toBeTruthy();
+    expect(screen.getByText('Azul Sinal')).toBeTruthy();
+  });
+
+  it('confirma com os dados da fórmula e preço final', () => {
+    const props = setup({ precoFinal: 50, custoCorantes: 5 });
+    fireEvent.click(screen.getByRole('button', { name: /Adicionar ao Pedido/ }));
+    expect(props.onConfirm).toHaveBeenCalledWith('f1', 'RAL5005', 'Azul Sinal', 50, 5);
+  });
+
+  it('clampa o desconto entre 0 e 100', () => {
+    const props = setup();
+    const input = screen.getByPlaceholderText('0') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '150' } });
+    expect(props.setDiscountPct).toHaveBeenCalledWith(100);
+  });
+
+  it('mostra seletor de preço quando há último preço cliente e tabela; dispara override', () => {
+    const props = setup({ lastPracticedPrice: { price: 40, date: '2026-05-01T00:00:00Z' }, precoCsv: 50, priceSource: 'cliente' });
+    fireEvent.click(screen.getByRole('button', { name: /Tabela/ }));
+    expect(props.setPriceSourceOverride).toHaveBeenCalledWith('tabela');
+  });
+
+  it('lista embalagens alternativas e confirma com o produto alternativo', () => {
+    const altProduct = { id: 'op2', valor_unitario: 80 } as unknown as Product;
+    const alternatives: AlternativePackaging[] = [
+      {
+        formulaId: 'fa', skuId: 's2', omieProductId: 'op2',
+        productDescricao: 'Base 3.6L', productCodigo: 'B36', precoFinalCsv: 200,
+        product: altProduct, sameAcabamento: false,
+      },
+    ];
+    const props = setup({ alternatives });
+    expect(screen.getByText('Mesma cor em outras embalagens')).toBeTruthy();
+    fireEvent.click(screen.getByText('Base 3.6L'));
+    expect(props.onConfirm).toHaveBeenCalledWith('fa', 'RAL5005', 'Azul Sinal', 200, 5, altProduct);
+  });
+});

--- a/src/components/tintColorSelect/types.ts
+++ b/src/components/tintColorSelect/types.ts
@@ -1,0 +1,31 @@
+// Tipos do diálogo de seleção de cor tintométrica.
+// Extraídos verbatim de src/components/TintColorSelectDialog.tsx (god-component split).
+import type { Product } from '@/hooks/useUnifiedOrder';
+
+export interface TintColorSelectDialogProps {
+  product: Product;
+  open: boolean;
+  onClose: () => void;
+  onConfirm: (formulaId: string, corId: string, nomeCor: string, precoFinal: number, custoCorantes: number, alternativeProduct?: Product) => void;
+  customerUserId?: string | null;
+}
+
+export interface FormulaResult {
+  id: string;
+  cor_id: string;
+  nome_cor: string;
+  preco_final_sayersystem: number | null;
+}
+
+export interface AlternativePackaging {
+  formulaId: string;
+  skuId: string;
+  omieProductId: string;
+  productDescricao: string;
+  productCodigo: string;
+  precoFinalCsv: number | null;
+  product: Product;
+  sameAcabamento: boolean;
+  corId?: string;
+  nomeCor?: string;
+}

--- a/src/components/tintColorSelect/useTintColorSelect.ts
+++ b/src/components/tintColorSelect/useTintColorSelect.ts
@@ -1,0 +1,357 @@
+// Lógica do diálogo de seleção de cor tintométrica (queries, preços, alternativas).
+// Extraída verbatim de src/components/TintColorSelectDialog.tsx (god-component split).
+import { useState, useEffect, useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import { useTintPricing } from '@/hooks/useTintPricing';
+import type { Product } from '@/hooks/useUnifiedOrder';
+import type { FormulaResult, AlternativePackaging } from './types';
+
+interface UseTintColorSelectArgs {
+  product: Product;
+  open: boolean;
+  customerUserId?: string | null;
+}
+
+export function useTintColorSelect({ product, open, customerUserId }: UseTintColorSelectArgs) {
+  const [search, setSearch] = useState('');
+  const [debouncedSearch, setDebouncedSearch] = useState('');
+  const [selectedFormula, setSelectedFormula] = useState<FormulaResult | null>(null);
+  const [discountPct, setDiscountPct] = useState<number>(0);
+  const [altDiscounts, setAltDiscounts] = useState<Record<string, number>>({});
+  const [syncDiscount, setSyncDiscount] = useState(false);
+  useEffect(() => {
+    if (!open) {
+      setSearch('');
+      setDebouncedSearch('');
+      setSelectedFormula(null);
+      setPriceSourceOverride(null);
+    }
+  }, [open]);
+
+  useEffect(() => {
+    const t = setTimeout(() => setDebouncedSearch(search), 300);
+    return () => clearTimeout(t);
+  }, [search]);
+
+  // Find SKU id + produto_id + base_id for this omie product
+  const { data: skuInfo, isLoading: loadingSku } = useQuery({
+    queryKey: ['tint-sku-for-product', product.id],
+    staleTime: 5 * 60 * 1000,
+    enabled: open,
+    queryFn: async () => {
+      const { data } = await supabase
+        .from('tint_skus')
+        .select('id, produto_id, base_id')
+        .eq('omie_product_id', product.id)
+        .eq('account', 'oben')
+        .limit(1)
+        .maybeSingle();
+      return data || null;
+    },
+  });
+  const skuId = skuInfo?.id || null;
+
+  // Get base description to extract the numeric suffix (e.g. ".7666" from "WFOB.7666 BASE BRANCA...")
+  const { data: currentBaseInfo } = useQuery({
+    queryKey: ['tint-base-info', skuInfo?.base_id],
+    staleTime: 10 * 60 * 1000,
+    enabled: !!skuInfo?.base_id,
+    queryFn: async () => {
+      const { data } = await supabase
+        .from('tint_bases')
+        .select('id, descricao, id_base_sayersystem')
+        .eq('id', skuInfo!.base_id)
+        .maybeSingle();
+      return data || null;
+    },
+  });
+
+  // Extract numeric suffix like "6736" from "WFOB.6736 BASE BRANCA..."
+  const currentBaseSuffix = useMemo(() => {
+    if (!currentBaseInfo?.descricao) return null;
+    const match = currentBaseInfo.descricao.match(/\.(\d+)/);
+    return match ? match[1] : null;
+  }, [currentBaseInfo?.descricao]);
+
+  // Search formulas in current SKU
+  const { data: formulas, isLoading: loadingFormulas } = useQuery({
+    queryKey: ['tint-formula-search', skuId, debouncedSearch],
+    staleTime: 5 * 60 * 1000,
+    enabled: !!skuId && debouncedSearch.length >= 2,
+    queryFn: async () => {
+      const { data } = await supabase
+        .from('tint_formulas')
+        .select('id, cor_id, nome_cor, preco_final_sayersystem')
+        .eq('account', 'oben')
+        .eq('sku_id', skuId!)
+        .or(`cor_id.ilike.%${debouncedSearch}%,nome_cor.ilike.%${debouncedSearch}%`)
+        .limit(20);
+      return (data || []) as FormulaResult[];
+    },
+  });
+
+  // When color not found in current base, search ALL bases for it
+  const colorNotFoundInBase = debouncedSearch.length >= 2 && !loadingFormulas && formulas && formulas.length === 0;
+
+  const { data: globalColorMatches, isLoading: loadingGlobalColors } = useQuery({
+    queryKey: ['tint-global-color-search', debouncedSearch, currentBaseSuffix],
+    staleTime: 5 * 60 * 1000,
+    enabled: !!colorNotFoundInBase && !!currentBaseSuffix,
+    queryFn: async (): Promise<AlternativePackaging[]> => {
+      // Search formulas across all SKUs
+      const { data: globalFormulas } = await supabase
+        .from('tint_formulas')
+        .select('id, cor_id, nome_cor, sku_id, preco_final_sayersystem')
+        .eq('account', 'oben')
+        .or(`cor_id.ilike.%${debouncedSearch}%,nome_cor.ilike.%${debouncedSearch}%`)
+        .not('sku_id', 'is', null)
+        .limit(50);
+
+      if (!globalFormulas || globalFormulas.length === 0) return [];
+
+      // Get SKU details
+      const skuIds = [...new Set(globalFormulas.map(f => f.sku_id!))];
+      const { data: skus } = await supabase
+        .from('tint_skus')
+        .select('id, omie_product_id, produto_id, base_id')
+        .in('id', skuIds)
+        .not('omie_product_id', 'is', null);
+
+      if (!skus || skus.length === 0) return [];
+
+      // Filter SKUs to only those with the same base suffix (e.g. ".7666")
+      if (currentBaseSuffix) {
+        const baseIds = [...new Set(skus.map(s => s.base_id))];
+        const { data: bases } = await supabase
+          .from('tint_bases')
+          .select('id, descricao')
+          .in('id', baseIds);
+
+        const validBaseIds = new Set(
+          (bases || [])
+            .filter(b => {
+              const match = b.descricao?.match(/\.(\d+)/);
+              return match && match[1] === currentBaseSuffix;
+            })
+            .map(b => b.id)
+        );
+
+        // Remove SKUs with non-matching bases — filtra skus in-place
+        const filteredSkus = skus.filter(s => validBaseIds.has(s.base_id));
+        if (filteredSkus.length === 0) return [];
+        // Replace skus reference
+        skus.length = 0;
+        skus.push(...filteredSkus);
+      }
+
+      // Get product details
+      const productIds = skus.map(s => s.omie_product_id!).filter(Boolean);
+      const { data: products } = await supabase
+        .from('omie_products')
+        .select('id, codigo, descricao, unidade, valor_unitario, estoque, ativo, omie_codigo_produto, account, is_tintometric, tint_type')
+        .in('id', productIds);
+
+      if (!products) return [];
+
+      const result: AlternativePackaging[] = [];
+      for (const gf of globalFormulas) {
+        const sku = skus.find(s => s.id === gf.sku_id);
+        if (!sku?.omie_product_id) continue;
+        const prod = products.find(p => p.id === sku.omie_product_id);
+        if (!prod) continue;
+
+        result.push({
+          formulaId: gf.id,
+          skuId: gf.sku_id!,
+          omieProductId: sku.omie_product_id,
+          productDescricao: prod.descricao,
+          productCodigo: prod.codigo,
+          precoFinalCsv: gf.preco_final_sayersystem ? Math.ceil(gf.preco_final_sayersystem * 10) / 10 : gf.preco_final_sayersystem,
+          product: prod as Product,
+          sameAcabamento: false,
+          corId: gf.cor_id,
+          nomeCor: gf.nome_cor,
+        });
+      }
+
+      result.sort((a, b) => a.productDescricao.localeCompare(b.productDescricao));
+      return result;
+    },
+  });
+
+  // Pricing breakdown for selected formula (for informational display)
+  const { data: pricing } = useTintPricing(selectedFormula?.id || null);
+
+  // Last practiced price for this color+base for the customer
+  const { data: lastPracticedPrice, isLoading: loadingLastPrice } = useQuery({
+    queryKey: ['tint-last-price', customerUserId, product.id, selectedFormula?.cor_id],
+    staleTime: 30 * 1000,
+    enabled: !!customerUserId && !!selectedFormula?.cor_id && !!product.id,
+    queryFn: async () => {
+      if (!customerUserId || !selectedFormula?.cor_id || !product.id) return null;
+
+      const { data: orders } = await supabase
+        .from('sales_orders')
+        .select('items, created_at')
+        .eq('customer_user_id', customerUserId)
+        .eq('account', 'oben')
+        .order('created_at', { ascending: false })
+        .limit(50);
+
+      if (!orders) return null;
+
+      for (const order of orders) {
+        const items = order.items as Array<{ product_id?: string; tint_cor_id?: string; valor_unitario?: number }>;
+        if (!Array.isArray(items)) continue;
+        for (const item of items) {
+          if (
+            item.product_id === product.id &&
+            item.tint_cor_id === selectedFormula.cor_id
+          ) {
+            return {
+              price: item.valor_unitario as number,
+              date: order.created_at as string,
+            };
+          }
+        }
+      }
+      return null;
+    },
+  });
+
+  // Alternative packagings: same color, different SKUs
+  const { data: alternatives, isLoading: loadingAlternatives } = useQuery({
+    queryKey: ['tint-alternatives', selectedFormula?.cor_id, skuId],
+    staleTime: 5 * 60 * 1000,
+    enabled: !!selectedFormula?.cor_id && !!skuId,
+    queryFn: async (): Promise<AlternativePackaging[]> => {
+      if (!selectedFormula?.cor_id || !skuId) return [];
+
+      // Get all formulas with the same cor_id but different sku_id
+      const { data: altFormulas } = await supabase
+        .from('tint_formulas')
+        .select('id, sku_id, preco_final_sayersystem')
+        .eq('account', 'oben')
+        .eq('cor_id', selectedFormula.cor_id)
+        .neq('sku_id', skuId)
+        .not('sku_id', 'is', null);
+
+      if (!altFormulas || altFormulas.length === 0) return [];
+
+      // Get SKU details with omie_product_id, produto_id, base_id
+      const skuIds = [...new Set(altFormulas.map(f => f.sku_id!))];
+      const { data: skus } = await supabase
+        .from('tint_skus')
+        .select('id, omie_product_id, produto_id, base_id')
+        .in('id', skuIds)
+        .not('omie_product_id', 'is', null);
+
+      if (!skus || skus.length === 0) return [];
+
+      // Get product details
+      const productIds = skus.map(s => s.omie_product_id!).filter(Boolean);
+      const { data: products } = await supabase
+        .from('omie_products')
+        .select('id, codigo, descricao, unidade, valor_unitario, estoque, ativo, omie_codigo_produto, account, is_tintometric, tint_type')
+        .in('id', productIds);
+
+      if (!products) return [];
+
+      const currentProdutoId = skuInfo?.produto_id;
+      const currentBaseId = skuInfo?.base_id;
+
+      const result: AlternativePackaging[] = [];
+      for (const af of altFormulas) {
+        const sku = skus.find(s => s.id === af.sku_id);
+        if (!sku?.omie_product_id) continue;
+        const prod = products.find(p => p.id === sku.omie_product_id);
+        if (!prod) continue;
+
+        result.push({
+          formulaId: af.id,
+          skuId: af.sku_id!,
+          omieProductId: sku.omie_product_id,
+          productDescricao: prod.descricao,
+          productCodigo: prod.codigo,
+          precoFinalCsv: af.preco_final_sayersystem ? Math.ceil(af.preco_final_sayersystem * 10) / 10 : af.preco_final_sayersystem,
+          product: prod as Product,
+          sameAcabamento: sku.produto_id === currentProdutoId && sku.base_id === currentBaseId,
+        });
+      }
+
+      // Sort: same acabamento first, then by description
+      result.sort((a, b) => {
+        if (a.sameAcabamento && !b.sameAcabamento) return -1;
+        if (!a.sameAcabamento && b.sameAcabamento) return 1;
+        return a.productDescricao.localeCompare(b.productDescricao);
+      });
+
+      return result;
+    },
+  });
+
+  // Use CSV price rounded up to the nearest R$0.10
+  const rawCsv = selectedFormula?.preco_final_sayersystem ?? 0;
+  const precoCsv = rawCsv > 0 ? Math.ceil(rawCsv * 10) / 10 : 0;
+  const custoCorantes = pricing?.custoCorantes || 0;
+
+  // Price source selection: user can choose between historical, CSV, or calculated
+  const [priceSourceOverride, setPriceSourceOverride] = useState<'cliente' | 'tabela' | 'calculado' | null>(null);
+
+  const precoBase = product.valor_unitario;
+  const precoCalculado = precoBase + custoCorantes;
+
+  // Auto-detect best price source
+  const precoCsvValido = precoCsv > 0 && precoCsv >= precoBase ? precoCsv : 0;
+  const autoSource = lastPracticedPrice
+    ? 'cliente'
+    : precoCsvValido > 0
+      ? 'tabela'
+      : 'calculado';
+  const priceSource = priceSourceOverride || autoSource;
+
+  // Se o preço CSV for menor que o preço da base, usar o calculado (base + corantes) como piso
+  const precoSemDesconto = priceSource === 'cliente' && lastPracticedPrice
+    ? lastPracticedPrice.price
+    : priceSource === 'tabela' && precoCsvValido > 0
+      ? precoCsvValido
+      : precoCalculado;
+  const precoFinal = discountPct > 0 ? Math.round(precoSemDesconto * (1 - discountPct / 100) * 100) / 100 : precoSemDesconto;
+
+  const onSearchChange = (value: string) => {
+    setSearch(value);
+    setSelectedFormula(null);
+    setPriceSourceOverride(null);
+  };
+
+  return {
+    search,
+    onSearchChange,
+    loadingSku,
+    skuId,
+    formulas,
+    loadingFormulas,
+    colorNotFoundInBase,
+    globalColorMatches,
+    loadingGlobalColors,
+    selectedFormula,
+    setSelectedFormula,
+    lastPracticedPrice,
+    loadingLastPrice,
+    alternatives,
+    loadingAlternatives,
+    discountPct,
+    setDiscountPct,
+    altDiscounts,
+    setAltDiscounts,
+    syncDiscount,
+    setSyncDiscount,
+    priceSource,
+    setPriceSourceOverride,
+    precoCsv,
+    custoCorantes,
+    precoSemDesconto,
+    precoFinal,
+  };
+}


### PR DESCRIPTION
## Resumo
- Split estrutural de `TintColorSelectDialog` (664→**112** linhas), preservando 100% do comportamento (move verbatim).
- Lógica isolada no hook **`useTintColorSelect`** (6 queries Supabase + `useTintPricing` + cálculos de preço/fonte/desconto/alternativas).
- JSX em componentes presentacionais controlados: **`FormulaSearchResults`**, **`GlobalColorMatches`** (bases alternativas), **`SelectedFormulaCard`** (detalhe da cor + descontos + embalagens).
- Tipos em `tintColorSelect/types.ts`. Named export `TintColorSelectDialog` preservado (consumidores: `SalesOrderEdit`, `UnifiedOrder`).

## Verificação
- `bunx tsc --noEmit` = 0 erros
- `bunx eslint` nos arquivos tocados = 0
- Testes novos (+11) passam isolados (3/3 arquivos). ⚠️ Suíte completa local com flakiness por contenção de CPU. Gate autoritativo = CI `validate`.
- Revisão independente de fidelidade (subagente): **FIEL 1:1**, zero divergências (warning de `key` no map de alternativas é baseline, já existia no original).

## Test plan
- [x] tsc / eslint verdes; +11 testes novos verdes isolados
- [x] Revisão 1:1 confirmando comportamento idêntico
- [ ] CI `validate` verde (gate da suíte completa)

🤖 Generated with [Claude Code](https://claude.com/claude-code)