### PR TITLE
refactor(reposicao): split AdminReposicaoAplicacao (656→172)

### DIFF
--- a/src/components/reposicao/aplicacao/AplicacaoConfirmDialogs.tsx
+++ b/src/components/reposicao/aplicacao/AplicacaoConfirmDialogs.tsx
@@ -1,0 +1,89 @@
+// Dialogs de confirmação: aplicação em lote (delta > 50%) e individual.
+// Extraídos verbatim de src/pages/AdminReposicaoAplicacao.tsx (god-component split).
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { type FilaItem } from "./types";
+
+interface AplicacaoConfirmDialogsProps {
+  confirmLote: { ids: number[]; maxDelta: number } | null;
+  setConfirmLote: (v: { ids: number[]; maxDelta: number } | null) => void;
+  confirmIndividual: FilaItem | null;
+  setConfirmIndividual: (v: FilaItem | null) => void;
+  onAplicar: (ids: number[]) => void;
+}
+
+export function AplicacaoConfirmDialogs({
+  confirmLote,
+  setConfirmLote,
+  confirmIndividual,
+  setConfirmIndividual,
+  onAplicar,
+}: AplicacaoConfirmDialogsProps) {
+  return (
+    <>
+      {/* Confirmação lote com delta > 50% */}
+      <AlertDialog open={!!confirmLote} onOpenChange={(o) => !o && setConfirmLote(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delta elevado detectado</AlertDialogTitle>
+            <AlertDialogDescription>
+              Há SKUs com delta acima de 50% (máximo: {confirmLote?.maxDelta.toFixed(0)}%). Tem
+              certeza de que quer aplicar este lote no Omie?
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancelar</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                if (confirmLote) onAplicar(confirmLote.ids);
+                setConfirmLote(null);
+              }}
+            >
+              Confirmar aplicação
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* Confirmação individual */}
+      <AlertDialog
+        open={!!confirmIndividual}
+        onOpenChange={(o) => !o && setConfirmIndividual(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Aplicar parâmetros no Omie?</AlertDialogTitle>
+            <AlertDialogDescription>
+              SKU {confirmIndividual?.sku_codigo_omie} — {confirmIndividual?.sku_descricao}.
+              <br />
+              EM: {confirmIndividual?.estoque_minimo_omie_atual ?? "—"} →{" "}
+              {confirmIndividual?.estoque_minimo_novo}
+              <br />
+              PP: {confirmIndividual?.ponto_pedido_omie_atual ?? "—"} →{" "}
+              {confirmIndividual?.ponto_pedido_novo}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancelar</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                if (confirmIndividual) onAplicar([confirmIndividual.id]);
+                setConfirmIndividual(null);
+              }}
+            >
+              Aplicar agora
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/src/components/reposicao/aplicacao/AplicacaoHeader.tsx
+++ b/src/components/reposicao/aplicacao/AplicacaoHeader.tsx
@@ -1,0 +1,64 @@
+// Cabeçalho da tela de aplicação no Omie (última sync + ações).
+// Extraído verbatim de src/pages/AdminReposicaoAplicacao.tsx (god-component split).
+import { formatDistanceToNow } from "date-fns";
+import { ptBR } from "date-fns/locale";
+import { RefreshCw, PlayCircle } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+interface AplicacaoHeaderProps {
+  ultimoSync: string | null | undefined;
+  syncDesatualizado: boolean;
+  onSincronizar: () => void;
+  sincronizarPending: boolean;
+  onGerarFila: () => void;
+  gerarFilaPending: boolean;
+}
+
+export function AplicacaoHeader({
+  ultimoSync,
+  syncDesatualizado,
+  onSincronizar,
+  sincronizarPending,
+  onGerarFila,
+  gerarFilaPending,
+}: AplicacaoHeaderProps) {
+  return (
+    <header className="flex items-start justify-between gap-4 flex-wrap">
+      <div>
+        <h1 className="text-2xl font-bold">Aplicação no Omie</h1>
+        <p className="text-sm text-muted-foreground">
+          Gere e aplique parâmetros de reposição diretamente no ERP, com validação de prontidão.
+        </p>
+      </div>
+      <div className="flex items-center gap-2">
+        <div className="text-xs text-right">
+          <div className="text-muted-foreground">Última sync Omie</div>
+          <div
+            className={
+              syncDesatualizado ? "text-destructive font-medium" : "text-foreground font-medium"
+            }
+          >
+            {ultimoSync
+              ? formatDistanceToNow(new Date(ultimoSync), { addSuffix: true, locale: ptBR })
+              : "nunca"}
+          </div>
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={onSincronizar}
+          disabled={sincronizarPending}
+        >
+          <RefreshCw
+            className={`h-4 w-4 mr-2 ${sincronizarPending ? "animate-spin" : ""}`}
+          />
+          Sincronizar agora
+        </Button>
+        <Button onClick={onGerarFila} disabled={gerarFilaPending}>
+          <PlayCircle className="h-4 w-4 mr-2" />
+          Gerar fila
+        </Button>
+      </div>
+    </header>
+  );
+}

--- a/src/components/reposicao/aplicacao/AplicadosTab.tsx
+++ b/src/components/reposicao/aplicacao/AplicadosTab.tsx
@@ -1,0 +1,67 @@
+// Aba "Aplicados (30d)": tabela do histórico de aplicações.
+// Extraída verbatim de src/pages/AdminReposicaoAplicacao.tsx (god-component split).
+import { format } from "date-fns";
+import { ptBR } from "date-fns/locale";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { type FilaItem } from "./types";
+
+export function AplicadosTab({ filteredItens }: { filteredItens: FilaItem[] }) {
+  return (
+    <Card>
+      <CardContent className="pt-6">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Aplicado em</TableHead>
+              <TableHead>SKU</TableHead>
+              <TableHead>Descrição</TableHead>
+              <TableHead>EM</TableHead>
+              <TableHead>PP</TableHead>
+              <TableHead>Resultado</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {filteredItens.map((it) => (
+              <TableRow key={it.id}>
+                <TableCell className="text-xs">
+                  {it.aplicado_em
+                    ? format(new Date(it.aplicado_em), "dd/MM/yyyy HH:mm", { locale: ptBR })
+                    : "—"}
+                </TableCell>
+                <TableCell className="font-mono text-xs">{it.sku_codigo_omie}</TableCell>
+                <TableCell className="min-w-[280px] whitespace-normal break-words">{it.sku_descricao}</TableCell>
+                <TableCell>{it.estoque_minimo_novo}</TableCell>
+                <TableCell>{it.ponto_pedido_novo}</TableCell>
+                <TableCell>
+                  {it.erro_omie ? (
+                    <Badge variant="destructive" title={it.erro_omie}>
+                      Erro
+                    </Badge>
+                  ) : (
+                    <Badge className="bg-success/20 text-success">OK</Badge>
+                  )}
+                </TableCell>
+              </TableRow>
+            ))}
+            {filteredItens.length === 0 && (
+              <TableRow>
+                <TableCell colSpan={6} className="text-center py-6 text-muted-foreground">
+                  Sem aplicações nos últimos 30 dias.
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/reposicao/aplicacao/InativosTab.tsx
+++ b/src/components/reposicao/aplicacao/InativosTab.tsx
@@ -1,0 +1,66 @@
+// Aba "Item inativo": cards de SKUs bloqueados por inativação.
+// Extraída verbatim de src/pages/AdminReposicaoAplicacao.tsx (god-component split).
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { type FilaItem } from "./types";
+
+interface InativosTabProps {
+  filteredItens: FilaItem[];
+  isLoading: boolean;
+  onSubstituicao: (it: FilaItem) => void;
+  onDesativar: (sku: string) => void;
+}
+
+export function InativosTab({ filteredItens, isLoading, onSubstituicao, onDesativar }: InativosTabProps) {
+  return (
+    <>
+      {isLoading && <p className="text-sm text-muted-foreground">Carregando…</p>}
+      {!isLoading && (filteredItens?.length ?? 0) === 0 && (
+        <p className="text-sm text-muted-foreground py-6 text-center">
+          Nenhum SKU bloqueado por inativação. 🎉
+        </p>
+      )}
+      {filteredItens.map((it) => (
+        <Card key={it.id} className="border-destructive/30">
+          <CardContent className="py-4 space-y-3">
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <div className="font-mono text-sm">{it.sku_codigo_omie}</div>
+                <div className="font-medium">{it.sku_descricao}</div>
+                <div className="text-xs text-muted-foreground mt-1">
+                  Mensagem: {it.mensagem_bloqueio ?? "—"}
+                </div>
+              </div>
+              <Badge variant="destructive">Item inativo</Badge>
+            </div>
+            <div className="flex gap-2 flex-wrap">
+              <Button size="sm" onClick={() => onSubstituicao(it)}>
+                Registrar substituição
+              </Button>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => onDesativar(it.sku_codigo_omie)}
+              >
+                Descadastrar do módulo
+              </Button>
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={() =>
+                  toast.info(
+                    "Marcado como reativação manual — aguardando próximo sync para revalidar."
+                  )
+                }
+              >
+                Reativar manualmente
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      ))}
+    </>
+  );
+}

--- a/src/components/reposicao/aplicacao/ProntosTab.tsx
+++ b/src/components/reposicao/aplicacao/ProntosTab.tsx
@@ -1,0 +1,194 @@
+// Aba "Prontos para aplicar": filtros + tabela com seleção e ação por linha.
+// Extraída verbatim de src/pages/AdminReposicaoAplicacao.tsx (god-component split).
+import { Search } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { type FilaItem } from "./types";
+import { DeltaArrow } from "./DeltaArrow";
+
+interface ProntosTabProps {
+  filteredItens: FilaItem[];
+  isLoading: boolean;
+  search: string;
+  setSearch: (v: string) => void;
+  deltaFilter: string;
+  setDeltaFilter: (v: string) => void;
+  selected: Set<number>;
+  setSelected: (s: Set<number>) => void;
+  toggleAll: () => void;
+  hasBloqueados: boolean;
+  aplicarPending: boolean;
+  onAplicarLote: (ids: number[]) => void;
+  onConfirmIndividual: (it: FilaItem) => void;
+}
+
+export function ProntosTab({
+  filteredItens,
+  isLoading,
+  search,
+  setSearch,
+  deltaFilter,
+  setDeltaFilter,
+  selected,
+  setSelected,
+  toggleAll,
+  hasBloqueados,
+  aplicarPending,
+  onAplicarLote,
+  onConfirmIndividual,
+}: ProntosTabProps) {
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between gap-3 flex-wrap">
+        <div className="flex items-center gap-2 flex-wrap">
+          <div className="relative">
+            <Search className="absolute left-2 top-2.5 h-4 w-4 text-muted-foreground" />
+            <Input
+              className="pl-8 w-64"
+              placeholder="Buscar SKU ou descrição"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+            />
+          </div>
+          <Select value={deltaFilter} onValueChange={setDeltaFilter}>
+            <SelectTrigger className="w-44">
+              <SelectValue placeholder="Filtrar por delta" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">Todos os deltas</SelectItem>
+              <SelectItem value="<10">&lt; 10%</SelectItem>
+              <SelectItem value="10-25">10–25%</SelectItem>
+              <SelectItem value="25-50">25–50%</SelectItem>
+              <SelectItem value=">50">&gt; 50%</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+        <Button
+          disabled={selected.size === 0 || aplicarPending || hasBloqueados}
+          onClick={() => onAplicarLote(Array.from(selected))}
+        >
+          Aplicar selecionados ({selected.size})
+        </Button>
+      </CardHeader>
+      <CardContent>
+        {hasBloqueados && (
+          <div className="mb-3 rounded-md border border-warning bg-warning/5 px-3 py-2 text-xs">
+            Há SKUs bloqueados. Aplicação em lote desabilitada — triê-los primeiro.
+          </div>
+        )}
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="w-10">
+                <Checkbox
+                  checked={
+                    filteredItens.length > 0 && selected.size === filteredItens.length
+                  }
+                  onCheckedChange={toggleAll}
+                />
+              </TableHead>
+              <TableHead>SKU</TableHead>
+              <TableHead>Descrição</TableHead>
+              <TableHead>EM (atual → novo)</TableHead>
+              <TableHead>PP (atual → novo)</TableHead>
+              <TableHead>Emax (atual → novo)</TableHead>
+              <TableHead>Δ máx</TableHead>
+              <TableHead className="text-right">Ação</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {isLoading && (
+              <TableRow>
+                <TableCell colSpan={8} className="text-center py-6">
+                  Carregando…
+                </TableCell>
+              </TableRow>
+            )}
+            {!isLoading && filteredItens.length === 0 && (
+              <TableRow>
+                <TableCell colSpan={8} className="text-center py-6 text-muted-foreground">
+                  Nenhum SKU pronto. Clique em "Gerar fila".
+                </TableCell>
+              </TableRow>
+            )}
+            {filteredItens.map((it) => (
+              <TableRow key={it.id}>
+                <TableCell>
+                  <Checkbox
+                    checked={selected.has(it.id)}
+                    onCheckedChange={(v) => {
+                      const n = new Set(selected);
+                      if (v) n.add(it.id);
+                      else n.delete(it.id);
+                      setSelected(n);
+                    }}
+                  />
+                </TableCell>
+                <TableCell className="font-mono text-xs">{it.sku_codigo_omie}</TableCell>
+                <TableCell className="min-w-[280px] whitespace-normal break-words">{it.sku_descricao}</TableCell>
+                <TableCell>
+                  <DeltaArrow
+                    novo={it.estoque_minimo_novo}
+                    atual={it.estoque_minimo_omie_atual}
+                  />
+                </TableCell>
+                <TableCell>
+                  <DeltaArrow
+                    novo={it.ponto_pedido_novo}
+                    atual={it.ponto_pedido_omie_atual}
+                  />
+                </TableCell>
+                <TableCell>
+                  <DeltaArrow
+                    novo={it.estoque_maximo_novo}
+                    atual={it.estoque_maximo_omie_atual}
+                  />
+                </TableCell>
+                <TableCell>
+                  <Badge
+                    variant={
+                      (it.delta_max_perc ?? 0) > 50
+                        ? "destructive"
+                        : (it.delta_max_perc ?? 0) > 25
+                        ? "secondary"
+                        : "outline"
+                    }
+                  >
+                    {(it.delta_max_perc ?? 0).toFixed(0)}%
+                  </Badge>
+                </TableCell>
+                <TableCell className="text-right">
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => onConfirmIndividual(it)}
+                  >
+                    Aplicar
+                  </Button>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/reposicao/aplicacao/__tests__/AplicacaoConfirmDialogs.test.tsx
+++ b/src/components/reposicao/aplicacao/__tests__/AplicacaoConfirmDialogs.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { AplicacaoConfirmDialogs } from "../AplicacaoConfirmDialogs";
+import type { FilaItem } from "../types";
+
+const it1 = {
+  id: 5, empresa: "OBEN", sku_codigo_omie: "999", sku_descricao: "Diluente",
+  estoque_minimo_novo: 10, ponto_pedido_novo: 20, estoque_maximo_novo: 40,
+  estoque_minimo_omie_atual: 8, ponto_pedido_omie_atual: 15, estoque_maximo_omie_atual: 30,
+  status_validacao: "pronto", mensagem_bloqueio: null, delta_max_perc: 60,
+  aplicado_em: null, resposta_omie: null, erro_omie: null, criado_em: "2026-05-20T00:00:00Z",
+} as FilaItem;
+
+describe("AplicacaoConfirmDialogs", () => {
+  it("lote: mostra maxDelta e aplica os ids ao confirmar", () => {
+    const onAplicar = vi.fn();
+    const setConfirmLote = vi.fn();
+    render(
+      <AplicacaoConfirmDialogs
+        confirmLote={{ ids: [1, 2], maxDelta: 60 }}
+        setConfirmLote={setConfirmLote}
+        confirmIndividual={null}
+        setConfirmIndividual={vi.fn()}
+        onAplicar={onAplicar}
+      />,
+    );
+    expect(screen.getByText(/máximo: 60%/)).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: /Confirmar aplicação/ }));
+    expect(onAplicar).toHaveBeenCalledWith([1, 2]);
+    expect(setConfirmLote).toHaveBeenCalledWith(null);
+  });
+
+  it("individual: mostra SKU e aplica o id único ao confirmar", () => {
+    const onAplicar = vi.fn();
+    render(
+      <AplicacaoConfirmDialogs
+        confirmLote={null}
+        setConfirmLote={vi.fn()}
+        confirmIndividual={it1}
+        setConfirmIndividual={vi.fn()}
+        onAplicar={onAplicar}
+      />,
+    );
+    expect(screen.getByText("Aplicar parâmetros no Omie?")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: /Aplicar agora/ }));
+    expect(onAplicar).toHaveBeenCalledWith([5]);
+  });
+});

--- a/src/components/reposicao/aplicacao/__tests__/AplicacaoHeader.test.tsx
+++ b/src/components/reposicao/aplicacao/__tests__/AplicacaoHeader.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { AplicacaoHeader } from "../AplicacaoHeader";
+
+function setup(overrides: Partial<React.ComponentProps<typeof AplicacaoHeader>> = {}) {
+  const props: React.ComponentProps<typeof AplicacaoHeader> = {
+    ultimoSync: null,
+    syncDesatualizado: false,
+    onSincronizar: vi.fn(),
+    sincronizarPending: false,
+    onGerarFila: vi.fn(),
+    gerarFilaPending: false,
+    ...overrides,
+  };
+  render(<AplicacaoHeader {...props} />);
+  return props;
+}
+
+describe("AplicacaoHeader", () => {
+  it("mostra título e 'nunca' quando não há sync", () => {
+    setup();
+    expect(screen.getByText("Aplicação no Omie")).toBeTruthy();
+    expect(screen.getByText("nunca")).toBeTruthy();
+  });
+
+  it("dispara onSincronizar e onGerarFila", () => {
+    const props = setup();
+    fireEvent.click(screen.getByRole("button", { name: /Sincronizar agora/ }));
+    fireEvent.click(screen.getByRole("button", { name: /Gerar fila/ }));
+    expect(props.onSincronizar).toHaveBeenCalledTimes(1);
+    expect(props.onGerarFila).toHaveBeenCalledTimes(1);
+  });
+
+  it("desabilita botões quando pending", () => {
+    setup({ sincronizarPending: true, gerarFilaPending: true });
+    expect(screen.getByRole("button", { name: /Sincronizar agora/ })).toHaveProperty("disabled", true);
+    expect(screen.getByRole("button", { name: /Gerar fila/ })).toHaveProperty("disabled", true);
+  });
+});

--- a/src/components/reposicao/aplicacao/__tests__/AplicadosTab.test.tsx
+++ b/src/components/reposicao/aplicacao/__tests__/AplicadosTab.test.tsx
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { AplicadosTab } from "../AplicadosTab";
+import type { FilaItem } from "../types";
+
+function item(p: Partial<FilaItem>): FilaItem {
+  return {
+    id: 1, empresa: "OBEN", sku_codigo_omie: "555", sku_descricao: "Verniz",
+    estoque_minimo_novo: 10, ponto_pedido_novo: 20, estoque_maximo_novo: 40,
+    estoque_minimo_omie_atual: null, ponto_pedido_omie_atual: null, estoque_maximo_omie_atual: null,
+    status_validacao: "pronto", mensagem_bloqueio: null, delta_max_perc: null,
+    aplicado_em: "2026-05-20T13:45:00Z", resposta_omie: null, erro_omie: null, criado_em: "2026-05-20T00:00:00Z",
+    ...p,
+  };
+}
+
+describe("AplicadosTab", () => {
+  it("mostra estado vazio", () => {
+    render(<AplicadosTab filteredItens={[]} />);
+    expect(screen.getByText(/Sem aplicações nos últimos 30 dias/)).toBeTruthy();
+  });
+
+  it("renderiza linha com SKU e badge OK quando sem erro", () => {
+    render(<AplicadosTab filteredItens={[item({})]} />);
+    expect(screen.getByText("555")).toBeTruthy();
+    expect(screen.getByText("OK")).toBeTruthy();
+  });
+
+  it("mostra badge de Erro quando erro_omie presente", () => {
+    render(<AplicadosTab filteredItens={[item({ erro_omie: "falha 500" })]} />);
+    expect(screen.getByText("Erro")).toBeTruthy();
+  });
+});

--- a/src/components/reposicao/aplicacao/__tests__/InativosTab.test.tsx
+++ b/src/components/reposicao/aplicacao/__tests__/InativosTab.test.tsx
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { InativosTab } from "../InativosTab";
+import type { FilaItem } from "../types";
+
+const it1 = {
+  id: 1, empresa: "OBEN", sku_codigo_omie: "777", sku_descricao: "Catalisador",
+  estoque_minimo_novo: null, ponto_pedido_novo: null, estoque_maximo_novo: null,
+  estoque_minimo_omie_atual: null, ponto_pedido_omie_atual: null, estoque_maximo_omie_atual: null,
+  status_validacao: "bloqueado_inativo", mensagem_bloqueio: "Produto inativo no Omie",
+  delta_max_perc: null, aplicado_em: null, resposta_omie: null, erro_omie: null, criado_em: "2026-05-20T00:00:00Z",
+} as FilaItem;
+
+describe("InativosTab", () => {
+  it("mostra mensagem vazia quando não há itens", () => {
+    render(<InativosTab filteredItens={[]} isLoading={false} onSubstituicao={vi.fn()} onDesativar={vi.fn()} />);
+    expect(screen.getByText(/Nenhum SKU bloqueado por inativação/)).toBeTruthy();
+  });
+
+  it("renderiza card com SKU e mensagem de bloqueio", () => {
+    render(<InativosTab filteredItens={[it1]} isLoading={false} onSubstituicao={vi.fn()} onDesativar={vi.fn()} />);
+    expect(screen.getByText("777")).toBeTruthy();
+    expect(screen.getByText(/Produto inativo no Omie/)).toBeTruthy();
+  });
+
+  it("dispara onSubstituicao e onDesativar", () => {
+    const onSubstituicao = vi.fn();
+    const onDesativar = vi.fn();
+    render(<InativosTab filteredItens={[it1]} isLoading={false} onSubstituicao={onSubstituicao} onDesativar={onDesativar} />);
+    fireEvent.click(screen.getByRole("button", { name: /Registrar substituição/ }));
+    fireEvent.click(screen.getByRole("button", { name: /Descadastrar do módulo/ }));
+    expect(onSubstituicao).toHaveBeenCalledWith(it1);
+    expect(onDesativar).toHaveBeenCalledWith("777");
+  });
+});

--- a/src/components/reposicao/aplicacao/__tests__/ProntosTab.test.tsx
+++ b/src/components/reposicao/aplicacao/__tests__/ProntosTab.test.tsx
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ProntosTab } from "../ProntosTab";
+import type { FilaItem } from "../types";
+
+function item(p: Partial<FilaItem>): FilaItem {
+  return {
+    id: 1, empresa: "OBEN", sku_codigo_omie: "555", sku_descricao: "Verniz",
+    estoque_minimo_novo: 10, ponto_pedido_novo: 20, estoque_maximo_novo: 40,
+    estoque_minimo_omie_atual: 8, ponto_pedido_omie_atual: 15, estoque_maximo_omie_atual: 30,
+    status_validacao: "pronto", mensagem_bloqueio: null, delta_max_perc: 12,
+    aplicado_em: null, resposta_omie: null, erro_omie: null, criado_em: "2026-05-20T00:00:00Z",
+    ...p,
+  };
+}
+
+function setup(overrides: Partial<React.ComponentProps<typeof ProntosTab>> = {}) {
+  const props: React.ComponentProps<typeof ProntosTab> = {
+    filteredItens: [item({})],
+    isLoading: false,
+    search: "",
+    setSearch: vi.fn(),
+    deltaFilter: "all",
+    setDeltaFilter: vi.fn(),
+    selected: new Set<number>(),
+    setSelected: vi.fn(),
+    toggleAll: vi.fn(),
+    hasBloqueados: false,
+    aplicarPending: false,
+    onAplicarLote: vi.fn(),
+    onConfirmIndividual: vi.fn(),
+    ...overrides,
+  };
+  render(<ProntosTab {...props} />);
+  return props;
+}
+
+describe("ProntosTab", () => {
+  it("renderiza a linha do SKU e o delta", () => {
+    setup();
+    expect(screen.getByText("555")).toBeTruthy();
+    expect(screen.getByText("Verniz")).toBeTruthy();
+    expect(screen.getByText("12%")).toBeTruthy();
+  });
+
+  it("desabilita 'Aplicar selecionados' sem seleção", () => {
+    setup();
+    expect(screen.getByRole("button", { name: /Aplicar selecionados \(0\)/ })).toHaveProperty("disabled", true);
+  });
+
+  it("aplica lote com a seleção atual", () => {
+    const props = setup({ selected: new Set([1]) });
+    fireEvent.click(screen.getByRole("button", { name: /Aplicar selecionados \(1\)/ }));
+    expect(props.onAplicarLote).toHaveBeenCalledWith([1]);
+  });
+
+  it("dispara onConfirmIndividual no botão da linha", () => {
+    const props = setup();
+    fireEvent.click(screen.getByRole("button", { name: /^Aplicar$/ }));
+    expect(props.onConfirmIndividual).toHaveBeenCalledTimes(1);
+  });
+
+  it("mostra aviso quando há bloqueados", () => {
+    setup({ hasBloqueados: true });
+    expect(screen.getByText(/Aplicação em lote desabilitada/)).toBeTruthy();
+  });
+
+  it("mostra estado vazio", () => {
+    setup({ filteredItens: [] });
+    expect(screen.getByText(/Nenhum SKU pronto/)).toBeTruthy();
+  });
+});

--- a/src/components/reposicao/aplicacao/useAplicacaoFila.ts
+++ b/src/components/reposicao/aplicacao/useAplicacaoFila.ts
@@ -1,0 +1,242 @@
+// Lógica da tela de aplicação no Omie (fila, contadores, mutations).
+// Extraída verbatim de src/pages/AdminReposicaoAplicacao.tsx (god-component split).
+import { useState, useMemo } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { supabase } from "@/integrations/supabase/client";
+import { toast } from "sonner";
+import {
+  EMPRESA,
+  type FilaItem,
+  type FilaCounterRow,
+  type GerarFilaResult,
+} from "./types";
+
+export function useAplicacaoFila() {
+  const qc = useQueryClient();
+  const [tab, setTab] = useState("pronto");
+  const [selected, setSelected] = useState<Set<number>>(new Set());
+  const [deltaFilter, setDeltaFilter] = useState<string>("all");
+  const [search, setSearch] = useState("");
+  const [substituicaoOpen, setSubstituicaoOpen] = useState<FilaItem | null>(null);
+  const [confirmLote, setConfirmLote] = useState<{ ids: number[]; maxDelta: number } | null>(null);
+  const [confirmIndividual, setConfirmIndividual] = useState<FilaItem | null>(null);
+
+  // Última sincronização Omie
+  const { data: ultimoSync } = useQuery({
+    queryKey: ["sku-status-omie-ultimo-sync", EMPRESA],
+    queryFn: async () => {
+      const { data } = await supabase
+        .from("sku_status_omie")
+        .select("ultima_sincronizacao")
+        .eq("empresa", EMPRESA)
+        .order("ultima_sincronizacao", { ascending: false })
+        .limit(1)
+        .maybeSingle();
+      return data?.ultima_sincronizacao ?? null;
+    },
+    refetchInterval: 60000,
+  });
+
+  // Contadores de cada aba
+  const { data: contadores } = useQuery({
+    queryKey: ["fila-aplicacao-contadores", EMPRESA],
+    queryFn: async () => {
+      const result = await supabase
+        .from("fila_aplicacao_omie" as never)
+        .select("status_validacao, aplicado_em")
+        .eq("empresa", EMPRESA);
+      const rows = (result.data ?? []) as unknown as FilaCounterRow[];
+      const c = { pronto: 0, inativo: 0, substituicao: 0, aplicado: 0 };
+      rows.forEach((r) => {
+        if (r.aplicado_em) c.aplicado++;
+        else if (r.status_validacao === "pronto") c.pronto++;
+        else if (r.status_validacao === "bloqueado_inativo") c.inativo++;
+        else if (r.status_validacao === "bloqueado_substituicao") c.substituicao++;
+      });
+      return c;
+    },
+    refetchInterval: 30000,
+  });
+
+  // Listagens por aba
+  const { data: itens, isLoading } = useQuery({
+    queryKey: ["fila-aplicacao", EMPRESA, tab],
+    queryFn: async () => {
+      // Builder genérico — tabela ainda fora do Database type, cast de retorno.
+      let q = supabase
+        .from("fila_aplicacao_omie" as never)
+        .select("*")
+        .eq("empresa", EMPRESA);
+      if (tab === "pronto") q = q.eq("status_validacao", "pronto").is("aplicado_em", null);
+      else if (tab === "inativo")
+        q = q.eq("status_validacao", "bloqueado_inativo").is("aplicado_em", null);
+      else if (tab === "substituicao")
+        q = q.eq("status_validacao", "bloqueado_substituicao").is("aplicado_em", null);
+      else if (tab === "aplicado")
+        q = q
+          .not("aplicado_em", "is", null)
+          .gte("aplicado_em", new Date(Date.now() - 30 * 86400000).toISOString())
+          .order("aplicado_em", { ascending: false });
+      const { data, error } = await q;
+      if (error) throw error;
+      return (data ?? []) as unknown as FilaItem[];
+    },
+    refetchInterval: tab === "aplicado" ? 60000 : 15000,
+  });
+
+  // Filtros adicionais (delta + busca) somente na aba "pronto"
+  const filteredItens = useMemo(() => {
+    if (!itens) return [];
+    let arr = itens;
+    if (search.trim()) {
+      const s = search.toLowerCase();
+      arr = arr.filter(
+        (i) =>
+          i.sku_codigo_omie.toLowerCase().includes(s) ||
+          (i.sku_descricao ?? "").toLowerCase().includes(s)
+      );
+    }
+    if (tab === "pronto" && deltaFilter !== "all") {
+      arr = arr.filter((i) => {
+        const d = i.delta_max_perc ?? 0;
+        if (deltaFilter === "<10") return d < 10;
+        if (deltaFilter === "10-25") return d >= 10 && d < 25;
+        if (deltaFilter === "25-50") return d >= 25 && d < 50;
+        if (deltaFilter === ">50") return d >= 50;
+        return true;
+      });
+    }
+    return arr;
+  }, [itens, search, deltaFilter, tab]);
+
+  const hasBloqueados = (contadores?.inativo ?? 0) + (contadores?.substituicao ?? 0) > 0;
+  const syncDesatualizado =
+    !ultimoSync || Date.now() - new Date(ultimoSync).getTime() > 24 * 3600 * 1000;
+
+  // Mutations
+  const gerarFila = useMutation({
+    mutationFn: async () => {
+      const { data, error } = await supabase.rpc("gerar_fila_aplicacao_omie" as never, {
+        p_empresa: EMPRESA,
+      } as never);
+      if (error) throw error;
+      return data as unknown as GerarFilaResult | GerarFilaResult[];
+    },
+    onSuccess: (data) => {
+      const r = (Array.isArray(data) ? data[0] : data) as GerarFilaResult | undefined;
+      toast.success(
+        `Fila gerada: ${r?.prontos ?? 0} prontos, ${r?.bloqueados_inativos ?? 0} inativos, ${
+          r?.bloqueados_substituicao ?? 0
+        } com substituição`
+      );
+      qc.invalidateQueries({ queryKey: ["fila-aplicacao"] });
+      qc.invalidateQueries({ queryKey: ["fila-aplicacao-contadores"] });
+    },
+    onError: (e: Error) => toast.error("Falha ao gerar fila: " + e.message),
+  });
+
+  const sincronizarOmie = useMutation({
+    mutationFn: async () => {
+      const { data, error } = await supabase.functions.invoke("omie-sync-status-produtos", {
+        body: { empresa: EMPRESA },
+      });
+      if (error) throw error;
+      return data;
+    },
+    onSuccess: () => {
+      toast.success("Sincronização Omie disparada");
+      qc.invalidateQueries({ queryKey: ["sku-status-omie-ultimo-sync"] });
+    },
+    onError: (e: Error) => toast.error("Falha no sync: " + e.message),
+  });
+
+  const aplicarIds = useMutation({
+    mutationFn: async (ids: number[]) => {
+      const { data, error } = await supabase.functions.invoke("omie-aplicar-parametros", {
+        body: { empresa: EMPRESA, ids },
+      });
+      if (error) throw error;
+      return data as { sucessos: number; falhas: number };
+    },
+    onSuccess: (r) => {
+      toast.success(`Aplicados: ${r.sucessos} | Falhas: ${r.falhas}`);
+      setSelected(new Set());
+      qc.invalidateQueries({ queryKey: ["fila-aplicacao"] });
+      qc.invalidateQueries({ queryKey: ["fila-aplicacao-contadores"] });
+    },
+    onError: (e: Error) => toast.error("Falha ao aplicar: " + e.message),
+  });
+
+  const desativarSku = useMutation({
+    mutationFn: async (sku: string) => {
+      const { error } = await supabase
+        .from("sku_parametros")
+        .update({ aplicar_no_omie: false })
+        .eq("empresa", EMPRESA)
+        .eq("sku_codigo_omie", Number(sku));
+      if (error) throw error;
+    },
+    onSuccess: () => {
+      toast.success("SKU descadastrado do módulo");
+      qc.invalidateQueries({ queryKey: ["fila-aplicacao"] });
+      qc.invalidateQueries({ queryKey: ["fila-aplicacao-contadores"] });
+    },
+  });
+
+  const handleAplicarLote = (ids: number[]) => {
+    if (hasBloqueados) {
+      toast.error("Resolva primeiro os SKUs bloqueados antes de aplicar em lote.");
+      return;
+    }
+    const itensSel = (filteredItens ?? []).filter((i) => ids.includes(i.id));
+    const maxDelta = Math.max(0, ...itensSel.map((i) => i.delta_max_perc ?? 0));
+    if (maxDelta > 50) {
+      setConfirmLote({ ids, maxDelta });
+      return;
+    }
+    aplicarIds.mutate(ids);
+  };
+
+  const toggleAll = () => {
+    if (selected.size === filteredItens.length) setSelected(new Set());
+    else setSelected(new Set(filteredItens.map((i) => i.id)));
+  };
+
+  const invalidateFila = () => {
+    qc.invalidateQueries({ queryKey: ["fila-aplicacao"] });
+    qc.invalidateQueries({ queryKey: ["fila-aplicacao-contadores"] });
+  };
+
+  const invalidateAll = () => qc.invalidateQueries();
+
+  return {
+    tab,
+    setTab,
+    selected,
+    setSelected,
+    deltaFilter,
+    setDeltaFilter,
+    search,
+    setSearch,
+    substituicaoOpen,
+    setSubstituicaoOpen,
+    confirmLote,
+    setConfirmLote,
+    confirmIndividual,
+    setConfirmIndividual,
+    ultimoSync,
+    contadores,
+    isLoading,
+    filteredItens,
+    hasBloqueados,
+    syncDesatualizado,
+    gerarFila,
+    sincronizarOmie,
+    aplicarIds,
+    desativarSku,
+    handleAplicarLote,
+    toggleAll,
+    invalidateFila,
+    invalidateAll,
+  };
+}

--- a/src/pages/AdminReposicaoAplicacao.tsx
+++ b/src/pages/AdminReposicaoAplicacao.tsx
@@ -1,289 +1,58 @@
-import { useState, useMemo } from "react";
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { supabase } from "@/integrations/supabase/client";
-import { toast } from "sonner";
-import { format, formatDistanceToNow } from "date-fns";
-import { ptBR } from "date-fns/locale";
-import {
-  RefreshCw,
-  PlayCircle,
-  AlertTriangle,
-  CheckCircle2,
-  XCircle,
-  Clock,
-  Search,
-} from "lucide-react";
-import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Badge } from "@/components/ui/badge";
-import { Checkbox } from "@/components/ui/checkbox";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import { Input } from "@/components/ui/input";
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/components/ui/alert-dialog";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
-import {
-  EMPRESA,
-  type FilaItem,
-  type FilaCounterRow,
-  type GerarFilaResult,
-} from "@/components/reposicao/aplicacao/types";
-import { DeltaArrow } from "@/components/reposicao/aplicacao/DeltaArrow";
+import { AlertTriangle, CheckCircle2, XCircle, Clock } from "lucide-react";
 import { SubstituicaoPendenteCard } from "@/components/reposicao/aplicacao/SubstituicaoPendenteCard";
 import { SubstituicaoModal } from "@/components/reposicao/aplicacao/SubstituicaoModal";
+import { useAplicacaoFila } from "@/components/reposicao/aplicacao/useAplicacaoFila";
+import { AplicacaoHeader } from "@/components/reposicao/aplicacao/AplicacaoHeader";
+import { ProntosTab } from "@/components/reposicao/aplicacao/ProntosTab";
+import { InativosTab } from "@/components/reposicao/aplicacao/InativosTab";
+import { AplicadosTab } from "@/components/reposicao/aplicacao/AplicadosTab";
+import { AplicacaoConfirmDialogs } from "@/components/reposicao/aplicacao/AplicacaoConfirmDialogs";
 
 export default function AdminReposicaoAplicacao() {
-  const qc = useQueryClient();
-  const [tab, setTab] = useState("pronto");
-  const [selected, setSelected] = useState<Set<number>>(new Set());
-  const [deltaFilter, setDeltaFilter] = useState<string>("all");
-  const [search, setSearch] = useState("");
-  const [substituicaoOpen, setSubstituicaoOpen] = useState<FilaItem | null>(null);
-  const [confirmLote, setConfirmLote] = useState<{ ids: number[]; maxDelta: number } | null>(null);
-  const [confirmIndividual, setConfirmIndividual] = useState<FilaItem | null>(null);
-
-  // Última sincronização Omie
-  const { data: ultimoSync } = useQuery({
-    queryKey: ["sku-status-omie-ultimo-sync", EMPRESA],
-    queryFn: async () => {
-      const { data } = await supabase
-        .from("sku_status_omie")
-        .select("ultima_sincronizacao")
-        .eq("empresa", EMPRESA)
-        .order("ultima_sincronizacao", { ascending: false })
-        .limit(1)
-        .maybeSingle();
-      return data?.ultima_sincronizacao ?? null;
-    },
-    refetchInterval: 60000,
-  });
-
-  // Contadores de cada aba
-  const { data: contadores } = useQuery({
-    queryKey: ["fila-aplicacao-contadores", EMPRESA],
-    queryFn: async () => {
-      const result = await supabase
-        .from("fila_aplicacao_omie" as never)
-        .select("status_validacao, aplicado_em")
-        .eq("empresa", EMPRESA);
-      const rows = (result.data ?? []) as unknown as FilaCounterRow[];
-      const c = { pronto: 0, inativo: 0, substituicao: 0, aplicado: 0 };
-      rows.forEach((r) => {
-        if (r.aplicado_em) c.aplicado++;
-        else if (r.status_validacao === "pronto") c.pronto++;
-        else if (r.status_validacao === "bloqueado_inativo") c.inativo++;
-        else if (r.status_validacao === "bloqueado_substituicao") c.substituicao++;
-      });
-      return c;
-    },
-    refetchInterval: 30000,
-  });
-
-  // Listagens por aba
-  const { data: itens, isLoading } = useQuery({
-    queryKey: ["fila-aplicacao", EMPRESA, tab],
-    queryFn: async () => {
-      // Builder genérico — tabela ainda fora do Database type, cast de retorno.
-      let q = supabase
-        .from("fila_aplicacao_omie" as never)
-        .select("*")
-        .eq("empresa", EMPRESA);
-      if (tab === "pronto") q = q.eq("status_validacao", "pronto").is("aplicado_em", null);
-      else if (tab === "inativo")
-        q = q.eq("status_validacao", "bloqueado_inativo").is("aplicado_em", null);
-      else if (tab === "substituicao")
-        q = q.eq("status_validacao", "bloqueado_substituicao").is("aplicado_em", null);
-      else if (tab === "aplicado")
-        q = q
-          .not("aplicado_em", "is", null)
-          .gte("aplicado_em", new Date(Date.now() - 30 * 86400000).toISOString())
-          .order("aplicado_em", { ascending: false });
-      const { data, error } = await q;
-      if (error) throw error;
-      return (data ?? []) as unknown as FilaItem[];
-    },
-    refetchInterval: tab === "aplicado" ? 60000 : 15000,
-  });
-
-  // Filtros adicionais (delta + busca) somente na aba "pronto"
-  const filteredItens = useMemo(() => {
-    if (!itens) return [];
-    let arr = itens;
-    if (search.trim()) {
-      const s = search.toLowerCase();
-      arr = arr.filter(
-        (i) =>
-          i.sku_codigo_omie.toLowerCase().includes(s) ||
-          (i.sku_descricao ?? "").toLowerCase().includes(s)
-      );
-    }
-    if (tab === "pronto" && deltaFilter !== "all") {
-      arr = arr.filter((i) => {
-        const d = i.delta_max_perc ?? 0;
-        if (deltaFilter === "<10") return d < 10;
-        if (deltaFilter === "10-25") return d >= 10 && d < 25;
-        if (deltaFilter === "25-50") return d >= 25 && d < 50;
-        if (deltaFilter === ">50") return d >= 50;
-        return true;
-      });
-    }
-    return arr;
-  }, [itens, search, deltaFilter, tab]);
-
-  const hasBloqueados = (contadores?.inativo ?? 0) + (contadores?.substituicao ?? 0) > 0;
-  const syncDesatualizado =
-    !ultimoSync || Date.now() - new Date(ultimoSync).getTime() > 24 * 3600 * 1000;
-
-  // Mutations
-  const gerarFila = useMutation({
-    mutationFn: async () => {
-      const { data, error } = await supabase.rpc("gerar_fila_aplicacao_omie" as never, {
-        p_empresa: EMPRESA,
-      } as never);
-      if (error) throw error;
-      return data as unknown as GerarFilaResult | GerarFilaResult[];
-    },
-    onSuccess: (data) => {
-      const r = (Array.isArray(data) ? data[0] : data) as GerarFilaResult | undefined;
-      toast.success(
-        `Fila gerada: ${r?.prontos ?? 0} prontos, ${r?.bloqueados_inativos ?? 0} inativos, ${
-          r?.bloqueados_substituicao ?? 0
-        } com substituição`
-      );
-      qc.invalidateQueries({ queryKey: ["fila-aplicacao"] });
-      qc.invalidateQueries({ queryKey: ["fila-aplicacao-contadores"] });
-    },
-    onError: (e: Error) => toast.error("Falha ao gerar fila: " + e.message),
-  });
-
-  const sincronizarOmie = useMutation({
-    mutationFn: async () => {
-      const { data, error } = await supabase.functions.invoke("omie-sync-status-produtos", {
-        body: { empresa: EMPRESA },
-      });
-      if (error) throw error;
-      return data;
-    },
-    onSuccess: () => {
-      toast.success("Sincronização Omie disparada");
-      qc.invalidateQueries({ queryKey: ["sku-status-omie-ultimo-sync"] });
-    },
-    onError: (e: Error) => toast.error("Falha no sync: " + e.message),
-  });
-
-  const aplicarIds = useMutation({
-    mutationFn: async (ids: number[]) => {
-      const { data, error } = await supabase.functions.invoke("omie-aplicar-parametros", {
-        body: { empresa: EMPRESA, ids },
-      });
-      if (error) throw error;
-      return data as { sucessos: number; falhas: number };
-    },
-    onSuccess: (r) => {
-      toast.success(`Aplicados: ${r.sucessos} | Falhas: ${r.falhas}`);
-      setSelected(new Set());
-      qc.invalidateQueries({ queryKey: ["fila-aplicacao"] });
-      qc.invalidateQueries({ queryKey: ["fila-aplicacao-contadores"] });
-    },
-    onError: (e: Error) => toast.error("Falha ao aplicar: " + e.message),
-  });
-
-  const desativarSku = useMutation({
-    mutationFn: async (sku: string) => {
-      const { error } = await supabase
-        .from("sku_parametros")
-        .update({ aplicar_no_omie: false })
-        .eq("empresa", EMPRESA)
-        .eq("sku_codigo_omie", Number(sku));
-      if (error) throw error;
-    },
-    onSuccess: () => {
-      toast.success("SKU descadastrado do módulo");
-      qc.invalidateQueries({ queryKey: ["fila-aplicacao"] });
-      qc.invalidateQueries({ queryKey: ["fila-aplicacao-contadores"] });
-    },
-  });
-
-  const handleAplicarLote = (ids: number[]) => {
-    if (hasBloqueados) {
-      toast.error("Resolva primeiro os SKUs bloqueados antes de aplicar em lote.");
-      return;
-    }
-    const itensSel = (filteredItens ?? []).filter((i) => ids.includes(i.id));
-    const maxDelta = Math.max(0, ...itensSel.map((i) => i.delta_max_perc ?? 0));
-    if (maxDelta > 50) {
-      setConfirmLote({ ids, maxDelta });
-      return;
-    }
-    aplicarIds.mutate(ids);
-  };
-
-  const toggleAll = () => {
-    if (selected.size === filteredItens.length) setSelected(new Set());
-    else setSelected(new Set(filteredItens.map((i) => i.id)));
-  };
+  const {
+    tab,
+    setTab,
+    selected,
+    setSelected,
+    deltaFilter,
+    setDeltaFilter,
+    search,
+    setSearch,
+    substituicaoOpen,
+    setSubstituicaoOpen,
+    confirmLote,
+    setConfirmLote,
+    confirmIndividual,
+    setConfirmIndividual,
+    ultimoSync,
+    contadores,
+    isLoading,
+    filteredItens,
+    hasBloqueados,
+    syncDesatualizado,
+    gerarFila,
+    sincronizarOmie,
+    aplicarIds,
+    desativarSku,
+    handleAplicarLote,
+    toggleAll,
+    invalidateFila,
+    invalidateAll,
+  } = useAplicacaoFila();
 
   return (
     <div className="container mx-auto py-6 space-y-6">
-      <header className="flex items-start justify-between gap-4 flex-wrap">
-        <div>
-          <h1 className="text-2xl font-bold">Aplicação no Omie</h1>
-          <p className="text-sm text-muted-foreground">
-            Gere e aplique parâmetros de reposição diretamente no ERP, com validação de prontidão.
-          </p>
-        </div>
-        <div className="flex items-center gap-2">
-          <div className="text-xs text-right">
-            <div className="text-muted-foreground">Última sync Omie</div>
-            <div
-              className={
-                syncDesatualizado ? "text-destructive font-medium" : "text-foreground font-medium"
-              }
-            >
-              {ultimoSync
-                ? formatDistanceToNow(new Date(ultimoSync), { addSuffix: true, locale: ptBR })
-                : "nunca"}
-            </div>
-          </div>
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => sincronizarOmie.mutate()}
-            disabled={sincronizarOmie.isPending}
-          >
-            <RefreshCw
-              className={`h-4 w-4 mr-2 ${sincronizarOmie.isPending ? "animate-spin" : ""}`}
-            />
-            Sincronizar agora
-          </Button>
-          <Button onClick={() => gerarFila.mutate()} disabled={gerarFila.isPending}>
-            <PlayCircle className="h-4 w-4 mr-2" />
-            Gerar fila
-          </Button>
-        </div>
-      </header>
+      <AplicacaoHeader
+        ultimoSync={ultimoSync}
+        syncDesatualizado={syncDesatualizado}
+        onSincronizar={() => sincronizarOmie.mutate()}
+        sincronizarPending={sincronizarOmie.isPending}
+        onGerarFila={() => gerarFila.mutate()}
+        gerarFilaPending={gerarFila.isPending}
+      />
 
       {syncDesatualizado && (
         <Card className="border-warning bg-warning/5">
@@ -333,189 +102,31 @@ export default function AdminReposicaoAplicacao() {
 
         {/* ABA 1: PRONTOS */}
         <TabsContent value="pronto" className="space-y-3">
-          <Card>
-            <CardHeader className="flex flex-row items-center justify-between gap-3 flex-wrap">
-              <div className="flex items-center gap-2 flex-wrap">
-                <div className="relative">
-                  <Search className="absolute left-2 top-2.5 h-4 w-4 text-muted-foreground" />
-                  <Input
-                    className="pl-8 w-64"
-                    placeholder="Buscar SKU ou descrição"
-                    value={search}
-                    onChange={(e) => setSearch(e.target.value)}
-                  />
-                </div>
-                <Select value={deltaFilter} onValueChange={setDeltaFilter}>
-                  <SelectTrigger className="w-44">
-                    <SelectValue placeholder="Filtrar por delta" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="all">Todos os deltas</SelectItem>
-                    <SelectItem value="<10">&lt; 10%</SelectItem>
-                    <SelectItem value="10-25">10–25%</SelectItem>
-                    <SelectItem value="25-50">25–50%</SelectItem>
-                    <SelectItem value=">50">&gt; 50%</SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
-              <Button
-                disabled={selected.size === 0 || aplicarIds.isPending || hasBloqueados}
-                onClick={() => handleAplicarLote(Array.from(selected))}
-              >
-                Aplicar selecionados ({selected.size})
-              </Button>
-            </CardHeader>
-            <CardContent>
-              {hasBloqueados && (
-                <div className="mb-3 rounded-md border border-warning bg-warning/5 px-3 py-2 text-xs">
-                  Há SKUs bloqueados. Aplicação em lote desabilitada — triê-los primeiro.
-                </div>
-              )}
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead className="w-10">
-                      <Checkbox
-                        checked={
-                          filteredItens.length > 0 && selected.size === filteredItens.length
-                        }
-                        onCheckedChange={toggleAll}
-                      />
-                    </TableHead>
-                    <TableHead>SKU</TableHead>
-                    <TableHead>Descrição</TableHead>
-                    <TableHead>EM (atual → novo)</TableHead>
-                    <TableHead>PP (atual → novo)</TableHead>
-                    <TableHead>Emax (atual → novo)</TableHead>
-                    <TableHead>Δ máx</TableHead>
-                    <TableHead className="text-right">Ação</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {isLoading && (
-                    <TableRow>
-                      <TableCell colSpan={8} className="text-center py-6">
-                        Carregando…
-                      </TableCell>
-                    </TableRow>
-                  )}
-                  {!isLoading && filteredItens.length === 0 && (
-                    <TableRow>
-                      <TableCell colSpan={8} className="text-center py-6 text-muted-foreground">
-                        Nenhum SKU pronto. Clique em "Gerar fila".
-                      </TableCell>
-                    </TableRow>
-                  )}
-                  {filteredItens.map((it) => (
-                    <TableRow key={it.id}>
-                      <TableCell>
-                        <Checkbox
-                          checked={selected.has(it.id)}
-                          onCheckedChange={(v) => {
-                            const n = new Set(selected);
-                            if (v) n.add(it.id);
-                            else n.delete(it.id);
-                            setSelected(n);
-                          }}
-                        />
-                      </TableCell>
-                      <TableCell className="font-mono text-xs">{it.sku_codigo_omie}</TableCell>
-                      <TableCell className="min-w-[280px] whitespace-normal break-words">{it.sku_descricao}</TableCell>
-                      <TableCell>
-                        <DeltaArrow
-                          novo={it.estoque_minimo_novo}
-                          atual={it.estoque_minimo_omie_atual}
-                        />
-                      </TableCell>
-                      <TableCell>
-                        <DeltaArrow
-                          novo={it.ponto_pedido_novo}
-                          atual={it.ponto_pedido_omie_atual}
-                        />
-                      </TableCell>
-                      <TableCell>
-                        <DeltaArrow
-                          novo={it.estoque_maximo_novo}
-                          atual={it.estoque_maximo_omie_atual}
-                        />
-                      </TableCell>
-                      <TableCell>
-                        <Badge
-                          variant={
-                            (it.delta_max_perc ?? 0) > 50
-                              ? "destructive"
-                              : (it.delta_max_perc ?? 0) > 25
-                              ? "secondary"
-                              : "outline"
-                          }
-                        >
-                          {(it.delta_max_perc ?? 0).toFixed(0)}%
-                        </Badge>
-                      </TableCell>
-                      <TableCell className="text-right">
-                        <Button
-                          size="sm"
-                          variant="outline"
-                          onClick={() => setConfirmIndividual(it)}
-                        >
-                          Aplicar
-                        </Button>
-                      </TableCell>
-                    </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
-            </CardContent>
-          </Card>
+          <ProntosTab
+            filteredItens={filteredItens}
+            isLoading={isLoading}
+            search={search}
+            setSearch={setSearch}
+            deltaFilter={deltaFilter}
+            setDeltaFilter={setDeltaFilter}
+            selected={selected}
+            setSelected={setSelected}
+            toggleAll={toggleAll}
+            hasBloqueados={hasBloqueados}
+            aplicarPending={aplicarIds.isPending}
+            onAplicarLote={handleAplicarLote}
+            onConfirmIndividual={setConfirmIndividual}
+          />
         </TabsContent>
 
         {/* ABA 2: INATIVOS */}
         <TabsContent value="inativo" className="space-y-3">
-          {isLoading && <p className="text-sm text-muted-foreground">Carregando…</p>}
-          {!isLoading && (filteredItens?.length ?? 0) === 0 && (
-            <p className="text-sm text-muted-foreground py-6 text-center">
-              Nenhum SKU bloqueado por inativação. 🎉
-            </p>
-          )}
-          {filteredItens.map((it) => (
-            <Card key={it.id} className="border-destructive/30">
-              <CardContent className="py-4 space-y-3">
-                <div className="flex items-start justify-between gap-3">
-                  <div>
-                    <div className="font-mono text-sm">{it.sku_codigo_omie}</div>
-                    <div className="font-medium">{it.sku_descricao}</div>
-                    <div className="text-xs text-muted-foreground mt-1">
-                      Mensagem: {it.mensagem_bloqueio ?? "—"}
-                    </div>
-                  </div>
-                  <Badge variant="destructive">Item inativo</Badge>
-                </div>
-                <div className="flex gap-2 flex-wrap">
-                  <Button size="sm" onClick={() => setSubstituicaoOpen(it)}>
-                    Registrar substituição
-                  </Button>
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    onClick={() => desativarSku.mutate(it.sku_codigo_omie)}
-                  >
-                    Descadastrar do módulo
-                  </Button>
-                  <Button
-                    size="sm"
-                    variant="ghost"
-                    onClick={() =>
-                      toast.info(
-                        "Marcado como reativação manual — aguardando próximo sync para revalidar."
-                      )
-                    }
-                  >
-                    Reativar manualmente
-                  </Button>
-                </div>
-              </CardContent>
-            </Card>
-          ))}
+          <InativosTab
+            filteredItens={filteredItens}
+            isLoading={isLoading}
+            onSubstituicao={setSubstituicaoOpen}
+            onDesativar={(sku) => desativarSku.mutate(sku)}
+          />
         </TabsContent>
 
         {/* ABA 3: SUBSTITUIÇÃO */}
@@ -527,59 +138,13 @@ export default function AdminReposicaoAplicacao() {
             </p>
           )}
           {filteredItens.map((it) => (
-            <SubstituicaoPendenteCard key={it.id} item={it} onChange={() => qc.invalidateQueries()} />
+            <SubstituicaoPendenteCard key={it.id} item={it} onChange={() => invalidateAll()} />
           ))}
         </TabsContent>
 
         {/* ABA 4: APLICADOS */}
         <TabsContent value="aplicado">
-          <Card>
-            <CardContent className="pt-6">
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>Aplicado em</TableHead>
-                    <TableHead>SKU</TableHead>
-                    <TableHead>Descrição</TableHead>
-                    <TableHead>EM</TableHead>
-                    <TableHead>PP</TableHead>
-                    <TableHead>Resultado</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {filteredItens.map((it) => (
-                    <TableRow key={it.id}>
-                      <TableCell className="text-xs">
-                        {it.aplicado_em
-                          ? format(new Date(it.aplicado_em), "dd/MM/yyyy HH:mm", { locale: ptBR })
-                          : "—"}
-                      </TableCell>
-                      <TableCell className="font-mono text-xs">{it.sku_codigo_omie}</TableCell>
-                      <TableCell className="min-w-[280px] whitespace-normal break-words">{it.sku_descricao}</TableCell>
-                      <TableCell>{it.estoque_minimo_novo}</TableCell>
-                      <TableCell>{it.ponto_pedido_novo}</TableCell>
-                      <TableCell>
-                        {it.erro_omie ? (
-                          <Badge variant="destructive" title={it.erro_omie}>
-                            Erro
-                          </Badge>
-                        ) : (
-                          <Badge className="bg-success/20 text-success">OK</Badge>
-                        )}
-                      </TableCell>
-                    </TableRow>
-                  ))}
-                  {filteredItens.length === 0 && (
-                    <TableRow>
-                      <TableCell colSpan={6} className="text-center py-6 text-muted-foreground">
-                        Sem aplicações nos últimos 30 dias.
-                      </TableCell>
-                    </TableRow>
-                  )}
-                </TableBody>
-              </Table>
-            </CardContent>
-          </Card>
+          <AplicadosTab filteredItens={filteredItens} />
         </TabsContent>
       </Tabs>
 
@@ -590,67 +155,18 @@ export default function AdminReposicaoAplicacao() {
           onClose={() => setSubstituicaoOpen(null)}
           onDone={() => {
             setSubstituicaoOpen(null);
-            qc.invalidateQueries({ queryKey: ["fila-aplicacao"] });
-            qc.invalidateQueries({ queryKey: ["fila-aplicacao-contadores"] });
+            invalidateFila();
           }}
         />
       )}
 
-      {/* Confirmação lote com delta > 50% */}
-      <AlertDialog open={!!confirmLote} onOpenChange={(o) => !o && setConfirmLote(null)}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Delta elevado detectado</AlertDialogTitle>
-            <AlertDialogDescription>
-              Há SKUs com delta acima de 50% (máximo: {confirmLote?.maxDelta.toFixed(0)}%). Tem
-              certeza de que quer aplicar este lote no Omie?
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>Cancelar</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={() => {
-                if (confirmLote) aplicarIds.mutate(confirmLote.ids);
-                setConfirmLote(null);
-              }}
-            >
-              Confirmar aplicação
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
-
-      {/* Confirmação individual */}
-      <AlertDialog
-        open={!!confirmIndividual}
-        onOpenChange={(o) => !o && setConfirmIndividual(null)}
-      >
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Aplicar parâmetros no Omie?</AlertDialogTitle>
-            <AlertDialogDescription>
-              SKU {confirmIndividual?.sku_codigo_omie} — {confirmIndividual?.sku_descricao}.
-              <br />
-              EM: {confirmIndividual?.estoque_minimo_omie_atual ?? "—"} →{" "}
-              {confirmIndividual?.estoque_minimo_novo}
-              <br />
-              PP: {confirmIndividual?.ponto_pedido_omie_atual ?? "—"} →{" "}
-              {confirmIndividual?.ponto_pedido_novo}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>Cancelar</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={() => {
-                if (confirmIndividual) aplicarIds.mutate([confirmIndividual.id]);
-                setConfirmIndividual(null);
-              }}
-            >
-              Aplicar agora
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+      <AplicacaoConfirmDialogs
+        confirmLote={confirmLote}
+        setConfirmLote={setConfirmLote}
+        confirmIndividual={confirmIndividual}
+        setConfirmIndividual={setConfirmIndividual}
+        onAplicar={(ids) => aplicarIds.mutate(ids)}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Resumo
- Split estrutural da página `AdminReposicaoAplicacao` (656→**172** linhas), preservando 100% do comportamento (move verbatim). Continua o split parcial anterior (DeltaArrow/Substituicao* já extraídos).
- Lógica isolada no hook **`useAplicacaoFila`** (3 queries + `filteredItens` + 4 mutations + `handleAplicarLote`/`toggleAll`).
- JSX em componentes controlados: **`AplicacaoHeader`**, **`ProntosTab`**, **`InativosTab`**, **`AplicadosTab`**, **`AplicacaoConfirmDialogs`** (lote + individual). TabsList fica inline.

## Verificação
- `bunx tsc --noEmit` = 0 erros
- `bunx eslint` nos arquivos tocados = 0
- Testes novos (+17) passam isolados (5/5 arquivos). ⚠️ Suíte completa local com flakiness por contenção de CPU (Radix Select/Checkbox estourando timeout de 5s — o teste que falha varia entre runs; passam ao re-rodar). Gate autoritativo = CI `validate`.
- Revisão independente de fidelidade (subagente): **FIEL 1:1**, zero divergências.

## Test plan
- [x] tsc / eslint verdes; +17 testes novos verdes isolados
- [x] Revisão 1:1 confirmando comportamento idêntico
- [ ] CI `validate` verde (gate da suíte completa)

🤖 Generated with [Claude Code](https://claude.com/claude-code)