### PR TITLE
refactor(sales): split SalesOrderEdit (655→205) em hook + componentes

### DIFF
--- a/src/components/salesOrderEdit/AddProductSearch.tsx
+++ b/src/components/salesOrderEdit/AddProductSearch.tsx
@@ -1,0 +1,54 @@
+// Busca de produto para adicionar ao pedido.
+// Extraída verbatim de src/pages/SalesOrderEdit.tsx (god-component split).
+import { Input } from '@/components/ui/input';
+import { Search } from 'lucide-react';
+import { type OmieProduct } from './types';
+
+interface AddProductSearchProps {
+  productSearch: string;
+  setProductSearch: (v: string) => void;
+  filteredProducts: OmieProduct[];
+  onAddProduct: (p: OmieProduct) => void;
+}
+
+export function AddProductSearch({ productSearch, setProductSearch, filteredProducts, onAddProduct }: AddProductSearchProps) {
+  return (
+    <div className="border rounded-lg p-3 bg-muted/30 space-y-2">
+      <div className="relative">
+        <Search className="absolute left-2.5 top-2 w-4 h-4 text-muted-foreground" />
+        <Input
+          placeholder="Buscar produto por nome ou código..."
+          value={productSearch}
+          onChange={(e) => setProductSearch(e.target.value)}
+          className="pl-8 h-8 text-sm"
+          autoFocus
+        />
+      </div>
+      {filteredProducts.length > 0 && (
+        <div className="max-h-48 overflow-y-auto space-y-1">
+          {filteredProducts.map((p) => (
+            <button
+              key={p.id}
+              onClick={() => onAddProduct(p)}
+              className="w-full text-left px-2 py-1.5 rounded hover:bg-accent text-sm flex items-center justify-between gap-2"
+            >
+              <div className="min-w-0 flex-1">
+                <p className="font-medium text-wrap break-words">{p.descricao}</p>
+                <p className="text-xs text-muted-foreground">{p.codigo} • {p.unidade} • Estoque: <span className={p.estoque > 0 ? 'text-green-600 font-medium' : 'text-red-500 font-medium'}>{p.estoque ?? 0}</span></p>
+              </div>
+              <span className="text-xs font-medium shrink-0">
+                R$ {(p.valor_unitario || 0).toFixed(2)}
+              </span>
+            </button>
+          ))}
+        </div>
+      )}
+      {productSearch.length >= 2 && filteredProducts.length === 0 && (
+        <p className="text-xs text-muted-foreground text-center py-2">Nenhum produto encontrado</p>
+      )}
+      {productSearch.length < 2 && (
+        <p className="text-xs text-muted-foreground text-center py-1">Digite pelo menos 2 caracteres</p>
+      )}
+    </div>
+  );
+}

--- a/src/components/salesOrderEdit/OrderItemCard.tsx
+++ b/src/components/salesOrderEdit/OrderItemCard.tsx
@@ -1,0 +1,80 @@
+// Card de um item do pedido (qtd/valor editáveis + remover).
+// Extraído verbatim de src/pages/SalesOrderEdit.tsx (god-component split).
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Trash2 } from 'lucide-react';
+import { type OrderItem } from './types';
+
+interface OrderItemCardProps {
+  item: OrderItem;
+  index: number;
+  isBlocked: boolean;
+  onUpdate: (index: number, field: 'quantidade' | 'valor_unitario', value: number) => void;
+  onRemove: (index: number) => void;
+}
+
+export function OrderItemCard({ item, index, isBlocked, onUpdate, onRemove }: OrderItemCardProps) {
+  return (
+    <div className="border rounded-lg p-3 space-y-2">
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex-1 min-w-0">
+          <p className="text-sm font-medium truncate">{item.descricao}</p>
+          {item.codigo && <p className="text-xs text-muted-foreground">Cód: {item.codigo}</p>}
+          {item.tint_nome_cor && (
+            <p className="text-xs text-muted-foreground">
+              🎨 {item.tint_cor_id} - {item.tint_nome_cor}
+            </p>
+          )}
+        </div>
+        {!isBlocked && (
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7 text-destructive"
+            onClick={() => onRemove(index)}
+          >
+            <Trash2 className="w-3.5 h-3.5" />
+          </Button>
+        )}
+      </div>
+
+      <div className="grid grid-cols-3 gap-2">
+        <div>
+          <label className="text-xs text-muted-foreground">Qtd</label>
+          <Input
+            type="text"
+            inputMode="numeric"
+            pattern="[0-9]*"
+            min={1}
+            value={item.quantidade}
+            onFocus={(e) => e.target.select()}
+            onChange={(e) => onUpdate(index, 'quantidade', Number(e.target.value) || 1)}
+            disabled={isBlocked}
+            className="h-8 text-sm"
+          />
+        </div>
+        <div>
+          <label className="text-xs text-muted-foreground">Valor Unit.</label>
+          <Input
+            type="text"
+            inputMode="decimal"
+            pattern="[0-9]*\.?[0-9]*"
+            step="0.01"
+            min={0}
+            value={item.valor_unitario}
+            onFocus={(e) => e.target.select()}
+            onChange={(e) => onUpdate(index, 'valor_unitario', Number(e.target.value) || 0)}
+            disabled={isBlocked}
+            className="h-8 text-sm"
+          />
+        </div>
+        <div>
+          <label className="text-xs text-muted-foreground">Total</label>
+          <p className="h-8 flex items-center text-sm font-medium">
+            R$ {item.valor_total.toFixed(2)}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/salesOrderEdit/PaymentComboboxEdit.tsx
+++ b/src/components/salesOrderEdit/PaymentComboboxEdit.tsx
@@ -1,0 +1,61 @@
+// Combobox de forma de pagamento (parcela Omie).
+// Extraído verbatim de src/pages/SalesOrderEdit.tsx (god-component split).
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { ChevronsUpDown, Check } from 'lucide-react';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from '@/components/ui/command';
+import { cn } from '@/lib/utils';
+
+export function PaymentComboboxEdit({
+  formas,
+  selected,
+  onSelect,
+  disabled,
+}: {
+  formas: Array<{ codigo: string; descricao: string }>;
+  selected: string;
+  onSelect: (v: string) => void;
+  disabled?: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  const selectedLabel = formas.find(f => f.codigo === selected)?.descricao || '';
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          disabled={disabled}
+          className="w-full justify-between text-sm h-9 font-normal"
+        >
+          <span className="truncate">{selected ? selectedLabel : 'Selecionar parcela'}</span>
+          <ChevronsUpDown className="ml-2 h-3.5 w-3.5 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-[--radix-popover-trigger-width] p-0" align="start">
+        <Command>
+          <CommandInput placeholder="Buscar... ex: 30, 60, vista" className="h-8 text-sm" />
+          <CommandList>
+            <CommandEmpty className="py-2 text-center text-xs text-muted-foreground">Nenhuma condição encontrada.</CommandEmpty>
+            <CommandGroup>
+              {formas.map(f => (
+                <CommandItem
+                  key={f.codigo}
+                  value={f.descricao}
+                  onSelect={() => { onSelect(f.codigo); setOpen(false); }}
+                  className="text-sm"
+                >
+                  <Check className={cn('mr-2 h-3.5 w-3.5', selected === f.codigo ? 'opacity-100' : 'opacity-0')} />
+                  {f.descricao}
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/components/salesOrderEdit/__tests__/AddProductSearch.test.tsx
+++ b/src/components/salesOrderEdit/__tests__/AddProductSearch.test.tsx
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { AddProductSearch } from '../AddProductSearch';
+import type { OmieProduct } from '../types';
+
+const prod: OmieProduct = {
+  id: 'p1', omie_codigo_produto: 100, codigo: 'C1', descricao: 'Verniz incolor',
+  unidade: 'UN', valor_unitario: 25, estoque: 8, ativo: true,
+};
+
+describe('AddProductSearch', () => {
+  it('dispara setProductSearch ao digitar', () => {
+    const setProductSearch = vi.fn();
+    render(<AddProductSearch productSearch="" setProductSearch={setProductSearch} filteredProducts={[]} onAddProduct={vi.fn()} />);
+    fireEvent.change(screen.getByPlaceholderText(/Buscar produto/), { target: { value: 'ver' } });
+    expect(setProductSearch).toHaveBeenCalledWith('ver');
+  });
+
+  it('mostra dica quando < 2 caracteres', () => {
+    render(<AddProductSearch productSearch="v" setProductSearch={vi.fn()} filteredProducts={[]} onAddProduct={vi.fn()} />);
+    expect(screen.getByText('Digite pelo menos 2 caracteres')).toBeTruthy();
+  });
+
+  it('mostra "nenhum produto" quando >=2 e lista vazia', () => {
+    render(<AddProductSearch productSearch="xyz" setProductSearch={vi.fn()} filteredProducts={[]} onAddProduct={vi.fn()} />);
+    expect(screen.getByText('Nenhum produto encontrado')).toBeTruthy();
+  });
+
+  it('lista produtos e dispara onAddProduct ao clicar', () => {
+    const onAddProduct = vi.fn();
+    render(<AddProductSearch productSearch="ver" setProductSearch={vi.fn()} filteredProducts={[prod]} onAddProduct={onAddProduct} />);
+    expect(screen.getByText('Verniz incolor')).toBeTruthy();
+    fireEvent.click(screen.getByText('Verniz incolor'));
+    expect(onAddProduct).toHaveBeenCalledWith(prod);
+  });
+});

--- a/src/components/salesOrderEdit/__tests__/OrderItemCard.test.tsx
+++ b/src/components/salesOrderEdit/__tests__/OrderItemCard.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { OrderItemCard } from '../OrderItemCard';
+import type { OrderItem } from '../types';
+
+function item(p: Partial<OrderItem> = {}): OrderItem {
+  return {
+    omie_codigo_produto: 100,
+    codigo: 'C1',
+    descricao: 'Verniz incolor',
+    unidade: 'UN',
+    quantidade: 2,
+    valor_unitario: 25,
+    valor_total: 50,
+    ...p,
+  };
+}
+
+describe('OrderItemCard', () => {
+  it('renderiza descrição, código e total', () => {
+    render(<OrderItemCard item={item()} index={0} isBlocked={false} onUpdate={vi.fn()} onRemove={vi.fn()} />);
+    expect(screen.getByText('Verniz incolor')).toBeTruthy();
+    expect(screen.getByText('Cód: C1')).toBeTruthy();
+    expect(screen.getByText('R$ 50.00')).toBeTruthy();
+  });
+
+  it('mostra a cor tintométrica quando presente', () => {
+    render(
+      <OrderItemCard
+        item={item({ tint_cor_id: 'RAL5005', tint_nome_cor: 'Azul' })}
+        index={0}
+        isBlocked={false}
+        onUpdate={vi.fn()}
+        onRemove={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/RAL5005 - Azul/)).toBeTruthy();
+  });
+
+  it('dispara onUpdate de quantidade e valor', () => {
+    const onUpdate = vi.fn();
+    render(<OrderItemCard item={item()} index={3} isBlocked={false} onUpdate={onUpdate} onRemove={vi.fn()} />);
+    const inputs = screen.getAllByRole('textbox');
+    fireEvent.change(inputs[0], { target: { value: '5' } }); // qtd
+    fireEvent.change(inputs[1], { target: { value: '30' } }); // valor
+    expect(onUpdate).toHaveBeenCalledWith(3, 'quantidade', 5);
+    expect(onUpdate).toHaveBeenCalledWith(3, 'valor_unitario', 30);
+  });
+
+  it('dispara onRemove com o índice', () => {
+    const onRemove = vi.fn();
+    render(<OrderItemCard item={item()} index={2} isBlocked={false} onUpdate={vi.fn()} onRemove={onRemove} />);
+    fireEvent.click(screen.getByRole('button'));
+    expect(onRemove).toHaveBeenCalledWith(2);
+  });
+
+  it('quando bloqueado: sem botão remover e inputs desabilitados', () => {
+    render(<OrderItemCard item={item()} index={0} isBlocked onUpdate={vi.fn()} onRemove={vi.fn()} />);
+    expect(screen.queryByRole('button')).toBeNull();
+    expect((screen.getAllByRole('textbox')[0] as HTMLInputElement).disabled).toBe(true);
+  });
+});

--- a/src/components/salesOrderEdit/__tests__/PaymentComboboxEdit.test.tsx
+++ b/src/components/salesOrderEdit/__tests__/PaymentComboboxEdit.test.tsx
@@ -1,0 +1,25 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { PaymentComboboxEdit } from '../PaymentComboboxEdit';
+
+const formas = [
+  { codigo: '000', descricao: 'À vista' },
+  { codigo: '030', descricao: '30 dias' },
+];
+
+describe('PaymentComboboxEdit', () => {
+  it('mostra placeholder quando nada selecionado', () => {
+    render(<PaymentComboboxEdit formas={formas} selected="" onSelect={vi.fn()} />);
+    expect(screen.getByText('Selecionar parcela')).toBeTruthy();
+  });
+
+  it('mostra a descrição da forma selecionada', () => {
+    render(<PaymentComboboxEdit formas={formas} selected="030" onSelect={vi.fn()} />);
+    expect(screen.getByText('30 dias')).toBeTruthy();
+  });
+
+  it('respeita o disabled', () => {
+    render(<PaymentComboboxEdit formas={formas} selected="" onSelect={vi.fn()} disabled />);
+    expect(screen.getByRole('combobox')).toHaveProperty('disabled', true);
+  });
+});

--- a/src/components/salesOrderEdit/types.ts
+++ b/src/components/salesOrderEdit/types.ts
@@ -1,0 +1,58 @@
+// Tipos da tela de edição de pedido de venda.
+// Extraídos verbatim de src/pages/SalesOrderEdit.tsx (god-component split).
+
+export interface OrderItem {
+  product_id?: string;
+  omie_codigo_produto: number;
+  codigo?: string;
+  descricao: string;
+  unidade?: string;
+  quantidade: number;
+  valor_unitario: number;
+  valor_total: number;
+  tint_cor_id?: string;
+  tint_nome_cor?: string;
+}
+
+export interface OmiePayload {
+  cabecalho?: {
+    codigo_parcela?: string;
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+}
+
+export interface SalesOrder {
+  id: string;
+  customer_user_id: string;
+  items: OrderItem[];
+  subtotal: number;
+  total: number;
+  status: string;
+  notes: string | null;
+  account: string;
+  omie_pedido_id: number | null;
+  omie_numero_pedido: string | null;
+  omie_payload: OmiePayload | null;
+  created_at: string;
+}
+
+export interface FormasPagamentoResponse {
+  formas?: Array<{ codigo: string; descricao: string }>;
+}
+
+export interface OmieProduct {
+  id: string;
+  omie_codigo_produto: number;
+  codigo: string;
+  descricao: string;
+  unidade: string;
+  valor_unitario: number;
+  estoque: number;
+  ativo: boolean;
+  account?: string;
+  is_tintometric?: boolean;
+  tint_type?: string;
+}
+
+export const BLOCKED_STATUSES = ['cancelado', 'entregue', 'faturado'];

--- a/src/components/salesOrderEdit/useSalesOrderEdit.ts
+++ b/src/components/salesOrderEdit/useSalesOrderEdit.ts
@@ -1,0 +1,326 @@
+// Lógica da tela de edição de pedido de venda (load, edição de itens, save no Omie).
+// Extraída verbatim de src/pages/SalesOrderEdit.tsx (god-component split).
+import { useState, useEffect, useMemo } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { supabase } from '@/integrations/supabase/client';
+import type { Tables, Json } from '@/integrations/supabase/types';
+import { useAuth } from '@/contexts/AuthContext';
+import { toast } from 'sonner';
+import type { Product } from '@/hooks/useUnifiedOrder';
+import {
+  BLOCKED_STATUSES,
+  type OrderItem,
+  type OmiePayload,
+  type SalesOrder,
+  type FormasPagamentoResponse,
+  type OmieProduct,
+} from './types';
+
+export function useSalesOrderEdit() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  useAuth(); // mantém o hook montado pra refresh de token; isStaff não é usado
+
+  const [order, setOrder] = useState<SalesOrder | null>(null);
+  const [customerName, setCustomerName] = useState('');
+  const [items, setItems] = useState<OrderItem[]>([]);
+  const [notes, setNotes] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [formas, setFormas] = useState<Array<{ codigo: string; descricao: string }>>([]);
+  const [selectedParcela, setSelectedParcela] = useState('');
+
+  // Add product state
+  const [showAddProduct, setShowAddProduct] = useState(false);
+  const [productSearch, setProductSearch] = useState('');
+  const [catalogProducts, setCatalogProducts] = useState<OmieProduct[]>([]);
+  // Tint color dialog
+  const [tintPendingProduct, setTintPendingProduct] = useState<OmieProduct | null>(null);
+  const [customerUserId, setCustomerUserId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (id) loadOrder();
+  }, [id]);
+
+  const loadOrder = async () => {
+    if (!id) return;
+    try {
+      const { data, error } = await supabase
+        .from('sales_orders')
+        .select('*')
+        .eq('id', id)
+        .single();
+      if (error) throw error;
+      const row = data as Tables<'sales_orders'>;
+      const o: SalesOrder = {
+        id: row.id,
+        customer_user_id: row.customer_user_id,
+        items: (row.items as unknown as OrderItem[]) || [],
+        subtotal: row.subtotal,
+        total: row.total,
+        status: row.status,
+        notes: row.notes,
+        account: row.account,
+        omie_pedido_id: row.omie_pedido_id,
+        omie_numero_pedido: row.omie_numero_pedido,
+        omie_payload: (row.omie_payload as unknown as OmiePayload | null) ?? null,
+        created_at: row.created_at,
+      };
+      setOrder(o);
+      setItems(o.items || []);
+      setNotes(o.notes || '');
+      const parcela = o.omie_payload?.cabecalho?.codigo_parcela;
+      if (parcela) setSelectedParcela(parcela);
+
+      const { data: profile } = await supabase
+        .from('profiles')
+        .select('name')
+        .eq('user_id', o.customer_user_id)
+        .single();
+      if (profile) setCustomerName(profile.name || '');
+      setCustomerUserId(o.customer_user_id);
+
+      const account = o.account === 'colacor' ? 'colacor' : 'oben';
+
+      // Load formas + products in parallel
+      const [formasRes, productsRes] = await Promise.all([
+        supabase.functions.invoke('omie-vendas-sync', {
+          body: { action: 'listar_formas_pagamento', account },
+        }),
+        supabase.from('omie_products')
+          .select('id, omie_codigo_produto, codigo, descricao, unidade, valor_unitario, estoque, ativo, account, is_tintometric, tint_type')
+          .eq('account', account === 'colacor' ? 'colacor_vendas' : 'oben')
+          .eq('ativo', true)
+          .order('descricao')
+          .limit(1000),
+      ]);
+
+      const formasData = formasRes.data as FormasPagamentoResponse | null;
+      if (formasData?.formas) setFormas(formasData.formas);
+      if (productsRes.data) setCatalogProducts(productsRes.data as unknown as OmieProduct[]);
+    } catch (e) {
+      console.error(e);
+      toast.error('Erro ao carregar pedido');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const updateItem = (index: number, field: 'quantidade' | 'valor_unitario', value: number) => {
+    setItems(prev => prev.map((item, i) => {
+      if (i !== index) return item;
+      const updated = { ...item, [field]: value };
+      updated.valor_total = updated.quantidade * updated.valor_unitario;
+      return updated;
+    }));
+  };
+
+  const removeItem = (index: number) => {
+    if (items.length <= 1) {
+      toast.error('O pedido precisa ter pelo menos 1 item');
+      return;
+    }
+    setItems(prev => prev.filter((_, i) => i !== index));
+  };
+
+  const addProduct = (product: OmieProduct) => {
+    // If tintometric base, open color dialog
+    if (product.is_tintometric && product.tint_type === 'base') {
+      setTintPendingProduct(product);
+      setShowAddProduct(false);
+      setProductSearch('');
+      return;
+    }
+    const exists = items.some(i => i.omie_codigo_produto === product.omie_codigo_produto && !i.tint_cor_id);
+    if (exists) {
+      toast.error('Este produto já está no pedido');
+      return;
+    }
+    const newItem: OrderItem = {
+      product_id: product.id,
+      omie_codigo_produto: product.omie_codigo_produto,
+      codigo: product.codigo,
+      descricao: product.descricao,
+      unidade: product.unidade || 'UN',
+      quantidade: 1,
+      valor_unitario: product.valor_unitario || 0,
+      valor_total: product.valor_unitario || 0,
+    };
+    setItems(prev => [...prev, newItem]);
+    setShowAddProduct(false);
+    setProductSearch('');
+    toast.success(`"${product.descricao}" adicionado`);
+  };
+
+  const handleTintConfirm = (_formulaId: string, corId: string, nomeCor: string, precoFinal: number, _custoCorantes: number, alternativeProduct?: Product) => {
+    const product = alternativeProduct
+      ? catalogProducts.find(p => p.id === alternativeProduct.id) || tintPendingProduct!
+      : tintPendingProduct!;
+    const newItem: OrderItem = {
+      product_id: product.id,
+      omie_codigo_produto: product.omie_codigo_produto,
+      codigo: product.codigo,
+      descricao: product.descricao,
+      unidade: product.unidade || 'UN',
+      quantidade: 1,
+      valor_unitario: precoFinal,
+      valor_total: precoFinal,
+      tint_cor_id: corId,
+      tint_nome_cor: nomeCor,
+    };
+    setItems(prev => [...prev, newItem]);
+    setTintPendingProduct(null);
+    toast.success(`"${product.descricao}" com cor ${corId} adicionado`);
+  };
+
+  const tintProductAsProduct = useMemo((): Product | null => {
+    if (!tintPendingProduct) return null;
+    return {
+      id: tintPendingProduct.id,
+      codigo: tintPendingProduct.codigo,
+      descricao: tintPendingProduct.descricao,
+      unidade: tintPendingProduct.unidade,
+      valor_unitario: tintPendingProduct.valor_unitario,
+      estoque: tintPendingProduct.estoque ?? 0,
+      ativo: tintPendingProduct.ativo ?? true,
+      omie_codigo_produto: tintPendingProduct.omie_codigo_produto,
+      account: tintPendingProduct.account,
+      is_tintometric: tintPendingProduct.is_tintometric,
+      tint_type: tintPendingProduct.tint_type,
+    };
+  }, [tintPendingProduct]);
+
+  const filteredProducts = useMemo(() => {
+    if (!productSearch || productSearch.length < 2) return [];
+    const q = productSearch.toLowerCase();
+    return catalogProducts.filter(p =>
+      p.descricao?.toLowerCase().includes(q) || p.codigo?.toLowerCase().includes(q)
+    ).slice(0, 20);
+  }, [productSearch, catalogProducts]);
+
+  const subtotal = items.reduce((s, i) => s + i.valor_total, 0);
+
+  const handleSave = async () => {
+    if (!order) return;
+    if (items.length === 0) {
+      toast.error('O pedido precisa ter pelo menos 1 item');
+      return;
+    }
+    setSaving(true);
+    try {
+      const account = order.account === 'colacor' ? 'colacor' : 'oben';
+
+      if (order.omie_pedido_id) {
+        // Save locally first
+        const updatedPayload = {
+          ...(order.omie_payload || {}),
+          cabecalho: {
+            ...(order.omie_payload?.cabecalho || {}),
+            ...(selectedParcela ? { codigo_parcela: selectedParcela } : {}),
+          },
+        };
+        const { error: localErr } = await supabase
+          .from('sales_orders')
+          .update({
+            items: items as unknown as Json,
+            subtotal,
+            total: subtotal,
+            notes: notes || null,
+            omie_payload: updatedPayload as unknown as Json,
+          })
+          .eq('id', order.id);
+        if (localErr) throw localErr;
+
+        // Navigate immediately and sync in background
+        toast.info('Pedido salvo! Sincronizando com o Omie em segundo plano...');
+        navigate('/sales');
+
+        // Fire-and-forget sync
+        supabase.functions.invoke('omie-vendas-sync', {
+          body: {
+            action: 'alterar_pedido',
+            account,
+            sales_order_id: order.id,
+            items: items.map(i => ({
+              product_id: i.product_id,
+              omie_codigo_produto: i.omie_codigo_produto,
+              codigo: i.codigo,
+              descricao: i.descricao,
+              unidade: i.unidade,
+              quantidade: i.quantidade,
+              valor_unitario: i.valor_unitario,
+              ...(i.tint_cor_id ? { tint_cor_id: i.tint_cor_id, tint_nome_cor: i.tint_nome_cor } : {}),
+            })),
+            observacao: notes,
+            codigo_parcela: selectedParcela || undefined,
+          },
+        }).then(({ error }) => {
+          if (error) {
+            toast.error('Erro ao sincronizar com Omie: ' + (error.message || 'Erro desconhecido'));
+          } else {
+            toast.success('Pedido sincronizado com o Omie com sucesso!');
+          }
+        }).catch((err) => {
+          toast.error('Erro ao sincronizar com Omie: ' + (err.message || 'Erro desconhecido'));
+        });
+      } else {
+        const updatedPayloadLocal = {
+          ...(order.omie_payload || {}),
+          cabecalho: {
+            ...(order.omie_payload?.cabecalho || {}),
+            ...(selectedParcela ? { codigo_parcela: selectedParcela } : {}),
+          },
+        };
+        const { error } = await supabase
+          .from('sales_orders')
+          .update({
+            items: items as unknown as Json,
+            subtotal,
+            total: subtotal,
+            notes: notes || null,
+            omie_payload: updatedPayloadLocal as unknown as Json,
+          })
+          .eq('id', order.id);
+        if (error) throw error;
+        toast.success('Pedido atualizado localmente');
+        navigate('/sales');
+      }
+    } catch (e) {
+      console.error(e);
+      const message = e instanceof Error ? e.message : 'Erro ao salvar pedido';
+      toast.error(message);
+      setSaving(false);
+    }
+  };
+
+  const isBlocked = order ? BLOCKED_STATUSES.includes(order.status) : false;
+
+  return {
+    order,
+    customerName,
+    items,
+    notes,
+    setNotes,
+    loading,
+    saving,
+    formas,
+    selectedParcela,
+    setSelectedParcela,
+    showAddProduct,
+    setShowAddProduct,
+    productSearch,
+    setProductSearch,
+    tintPendingProduct,
+    setTintPendingProduct,
+    customerUserId,
+    updateItem,
+    removeItem,
+    addProduct,
+    handleTintConfirm,
+    tintProductAsProduct,
+    filteredProducts,
+    subtotal,
+    handleSave,
+    isBlocked,
+  };
+}

--- a/src/pages/SalesOrderEdit.tsx
+++ b/src/pages/SalesOrderEdit.tsx
@@ -1,408 +1,43 @@
-import { useState, useEffect, useMemo } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
 import { TintColorSelectDialog } from '@/components/TintColorSelectDialog';
-import type { Product } from '@/hooks/useUnifiedOrder';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { Badge } from '@/components/ui/badge';
-import { supabase } from '@/integrations/supabase/client';
-import type { Tables, Json } from '@/integrations/supabase/types';
-import { useAuth } from '@/contexts/AuthContext';
-import { Loader2, Save, Trash2, Plus, AlertCircle, Search, X, ChevronsUpDown, Check } from 'lucide-react';
-import { toast } from 'sonner';
-import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
-import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from '@/components/ui/command';
-import { cn } from '@/lib/utils';
-
-interface OrderItem {
-  product_id?: string;
-  omie_codigo_produto: number;
-  codigo?: string;
-  descricao: string;
-  unidade?: string;
-  quantidade: number;
-  valor_unitario: number;
-  valor_total: number;
-  tint_cor_id?: string;
-  tint_nome_cor?: string;
-}
-
-interface OmiePayload {
-  cabecalho?: {
-    codigo_parcela?: string;
-    [key: string]: unknown;
-  };
-  [key: string]: unknown;
-}
-
-interface SalesOrder {
-  id: string;
-  customer_user_id: string;
-  items: OrderItem[];
-  subtotal: number;
-  total: number;
-  status: string;
-  notes: string | null;
-  account: string;
-  omie_pedido_id: number | null;
-  omie_numero_pedido: string | null;
-  omie_payload: OmiePayload | null;
-  created_at: string;
-}
-
-interface FormasPagamentoResponse {
-  formas?: Array<{ codigo: string; descricao: string }>;
-}
-
-interface OmieProduct {
-  id: string;
-  omie_codigo_produto: number;
-  codigo: string;
-  descricao: string;
-  unidade: string;
-  valor_unitario: number;
-  estoque: number;
-  ativo: boolean;
-  account?: string;
-  is_tintometric?: boolean;
-  tint_type?: string;
-}
-
-const BLOCKED_STATUSES = ['cancelado', 'entregue', 'faturado'];
-
-function PaymentComboboxEdit({
-  formas,
-  selected,
-  onSelect,
-  disabled,
-}: {
-  formas: Array<{ codigo: string; descricao: string }>;
-  selected: string;
-  onSelect: (v: string) => void;
-  disabled?: boolean;
-}) {
-  const [open, setOpen] = useState(false);
-  const selectedLabel = formas.find(f => f.codigo === selected)?.descricao || '';
-
-  return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
-        <Button
-          variant="outline"
-          role="combobox"
-          aria-expanded={open}
-          disabled={disabled}
-          className="w-full justify-between text-sm h-9 font-normal"
-        >
-          <span className="truncate">{selected ? selectedLabel : 'Selecionar parcela'}</span>
-          <ChevronsUpDown className="ml-2 h-3.5 w-3.5 shrink-0 opacity-50" />
-        </Button>
-      </PopoverTrigger>
-      <PopoverContent className="w-[--radix-popover-trigger-width] p-0" align="start">
-        <Command>
-          <CommandInput placeholder="Buscar... ex: 30, 60, vista" className="h-8 text-sm" />
-          <CommandList>
-            <CommandEmpty className="py-2 text-center text-xs text-muted-foreground">Nenhuma condição encontrada.</CommandEmpty>
-            <CommandGroup>
-              {formas.map(f => (
-                <CommandItem
-                  key={f.codigo}
-                  value={f.descricao}
-                  onSelect={() => { onSelect(f.codigo); setOpen(false); }}
-                  className="text-sm"
-                >
-                  <Check className={cn('mr-2 h-3.5 w-3.5', selected === f.codigo ? 'opacity-100' : 'opacity-0')} />
-                  {f.descricao}
-                </CommandItem>
-              ))}
-            </CommandGroup>
-          </CommandList>
-        </Command>
-      </PopoverContent>
-    </Popover>
-  );
-}
+import { Loader2, Save, Plus, AlertCircle, X } from 'lucide-react';
+import { useSalesOrderEdit } from '@/components/salesOrderEdit/useSalesOrderEdit';
+import { PaymentComboboxEdit } from '@/components/salesOrderEdit/PaymentComboboxEdit';
+import { AddProductSearch } from '@/components/salesOrderEdit/AddProductSearch';
+import { OrderItemCard } from '@/components/salesOrderEdit/OrderItemCard';
 
 const SalesOrderEdit = () => {
-  const { id } = useParams<{ id: string }>();
-  const navigate = useNavigate();
-  useAuth(); // mantém o hook montado pra refresh de token; isStaff não é usado
-
-  const [order, setOrder] = useState<SalesOrder | null>(null);
-  const [customerName, setCustomerName] = useState('');
-  const [items, setItems] = useState<OrderItem[]>([]);
-  const [notes, setNotes] = useState('');
-  const [loading, setLoading] = useState(true);
-  const [saving, setSaving] = useState(false);
-  const [formas, setFormas] = useState<Array<{ codigo: string; descricao: string }>>([]);
-  const [selectedParcela, setSelectedParcela] = useState('');
-
-  // Add product state
-  const [showAddProduct, setShowAddProduct] = useState(false);
-  const [productSearch, setProductSearch] = useState('');
-  const [catalogProducts, setCatalogProducts] = useState<OmieProduct[]>([]);
-  // Tint color dialog
-  const [tintPendingProduct, setTintPendingProduct] = useState<OmieProduct | null>(null);
-  const [customerUserId, setCustomerUserId] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (id) loadOrder();
-  }, [id]);
-
-  const loadOrder = async () => {
-    if (!id) return;
-    try {
-      const { data, error } = await supabase
-        .from('sales_orders')
-        .select('*')
-        .eq('id', id)
-        .single();
-      if (error) throw error;
-      const row = data as Tables<'sales_orders'>;
-      const o: SalesOrder = {
-        id: row.id,
-        customer_user_id: row.customer_user_id,
-        items: (row.items as unknown as OrderItem[]) || [],
-        subtotal: row.subtotal,
-        total: row.total,
-        status: row.status,
-        notes: row.notes,
-        account: row.account,
-        omie_pedido_id: row.omie_pedido_id,
-        omie_numero_pedido: row.omie_numero_pedido,
-        omie_payload: (row.omie_payload as unknown as OmiePayload | null) ?? null,
-        created_at: row.created_at,
-      };
-      setOrder(o);
-      setItems(o.items || []);
-      setNotes(o.notes || '');
-      const parcela = o.omie_payload?.cabecalho?.codigo_parcela;
-      if (parcela) setSelectedParcela(parcela);
-
-      const { data: profile } = await supabase
-        .from('profiles')
-        .select('name')
-        .eq('user_id', o.customer_user_id)
-        .single();
-      if (profile) setCustomerName(profile.name || '');
-      setCustomerUserId(o.customer_user_id);
-
-      const account = o.account === 'colacor' ? 'colacor' : 'oben';
-      
-      // Load formas + products in parallel
-      const [formasRes, productsRes] = await Promise.all([
-        supabase.functions.invoke('omie-vendas-sync', {
-          body: { action: 'listar_formas_pagamento', account },
-        }),
-        supabase.from('omie_products')
-          .select('id, omie_codigo_produto, codigo, descricao, unidade, valor_unitario, estoque, ativo, account, is_tintometric, tint_type')
-          .eq('account', account === 'colacor' ? 'colacor_vendas' : 'oben')
-          .eq('ativo', true)
-          .order('descricao')
-          .limit(1000),
-      ]);
-
-      const formasData = formasRes.data as FormasPagamentoResponse | null;
-      if (formasData?.formas) setFormas(formasData.formas);
-      if (productsRes.data) setCatalogProducts(productsRes.data as unknown as OmieProduct[]);
-    } catch (e) {
-      console.error(e);
-      toast.error('Erro ao carregar pedido');
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const updateItem = (index: number, field: 'quantidade' | 'valor_unitario', value: number) => {
-    setItems(prev => prev.map((item, i) => {
-      if (i !== index) return item;
-      const updated = { ...item, [field]: value };
-      updated.valor_total = updated.quantidade * updated.valor_unitario;
-      return updated;
-    }));
-  };
-
-  const removeItem = (index: number) => {
-    if (items.length <= 1) {
-      toast.error('O pedido precisa ter pelo menos 1 item');
-      return;
-    }
-    setItems(prev => prev.filter((_, i) => i !== index));
-  };
-
-  const addProduct = (product: OmieProduct) => {
-    // If tintometric base, open color dialog
-    if (product.is_tintometric && product.tint_type === 'base') {
-      setTintPendingProduct(product);
-      setShowAddProduct(false);
-      setProductSearch('');
-      return;
-    }
-    const exists = items.some(i => i.omie_codigo_produto === product.omie_codigo_produto && !i.tint_cor_id);
-    if (exists) {
-      toast.error('Este produto já está no pedido');
-      return;
-    }
-    const newItem: OrderItem = {
-      product_id: product.id,
-      omie_codigo_produto: product.omie_codigo_produto,
-      codigo: product.codigo,
-      descricao: product.descricao,
-      unidade: product.unidade || 'UN',
-      quantidade: 1,
-      valor_unitario: product.valor_unitario || 0,
-      valor_total: product.valor_unitario || 0,
-    };
-    setItems(prev => [...prev, newItem]);
-    setShowAddProduct(false);
-    setProductSearch('');
-    toast.success(`"${product.descricao}" adicionado`);
-  };
-
-  const handleTintConfirm = (_formulaId: string, corId: string, nomeCor: string, precoFinal: number, _custoCorantes: number, alternativeProduct?: Product) => {
-    const product = alternativeProduct
-      ? catalogProducts.find(p => p.id === alternativeProduct.id) || tintPendingProduct!
-      : tintPendingProduct!;
-    const newItem: OrderItem = {
-      product_id: product.id,
-      omie_codigo_produto: product.omie_codigo_produto,
-      codigo: product.codigo,
-      descricao: product.descricao,
-      unidade: product.unidade || 'UN',
-      quantidade: 1,
-      valor_unitario: precoFinal,
-      valor_total: precoFinal,
-      tint_cor_id: corId,
-      tint_nome_cor: nomeCor,
-    };
-    setItems(prev => [...prev, newItem]);
-    setTintPendingProduct(null);
-    toast.success(`"${product.descricao}" com cor ${corId} adicionado`);
-  };
-
-  const tintProductAsProduct = useMemo((): Product | null => {
-    if (!tintPendingProduct) return null;
-    return {
-      id: tintPendingProduct.id,
-      codigo: tintPendingProduct.codigo,
-      descricao: tintPendingProduct.descricao,
-      unidade: tintPendingProduct.unidade,
-      valor_unitario: tintPendingProduct.valor_unitario,
-      estoque: tintPendingProduct.estoque ?? 0,
-      ativo: tintPendingProduct.ativo ?? true,
-      omie_codigo_produto: tintPendingProduct.omie_codigo_produto,
-      account: tintPendingProduct.account,
-      is_tintometric: tintPendingProduct.is_tintometric,
-      tint_type: tintPendingProduct.tint_type,
-    };
-  }, [tintPendingProduct]);
-
-  const filteredProducts = useMemo(() => {
-    if (!productSearch || productSearch.length < 2) return [];
-    const q = productSearch.toLowerCase();
-    return catalogProducts.filter(p =>
-      p.descricao?.toLowerCase().includes(q) || p.codigo?.toLowerCase().includes(q)
-    ).slice(0, 20);
-  }, [productSearch, catalogProducts]);
-
-  const subtotal = items.reduce((s, i) => s + i.valor_total, 0);
-
-  const handleSave = async () => {
-    if (!order) return;
-    if (items.length === 0) {
-      toast.error('O pedido precisa ter pelo menos 1 item');
-      return;
-    }
-    setSaving(true);
-    try {
-      const account = order.account === 'colacor' ? 'colacor' : 'oben';
-
-      if (order.omie_pedido_id) {
-        // Save locally first
-        const updatedPayload = {
-          ...(order.omie_payload || {}),
-          cabecalho: {
-            ...(order.omie_payload?.cabecalho || {}),
-            ...(selectedParcela ? { codigo_parcela: selectedParcela } : {}),
-          },
-        };
-        const { error: localErr } = await supabase
-          .from('sales_orders')
-          .update({
-            items: items as unknown as Json,
-            subtotal,
-            total: subtotal,
-            notes: notes || null,
-            omie_payload: updatedPayload as unknown as Json,
-          })
-          .eq('id', order.id);
-        if (localErr) throw localErr;
-
-        // Navigate immediately and sync in background
-        toast.info('Pedido salvo! Sincronizando com o Omie em segundo plano...');
-        navigate('/sales');
-
-        // Fire-and-forget sync
-        supabase.functions.invoke('omie-vendas-sync', {
-          body: {
-            action: 'alterar_pedido',
-            account,
-            sales_order_id: order.id,
-            items: items.map(i => ({
-              product_id: i.product_id,
-              omie_codigo_produto: i.omie_codigo_produto,
-              codigo: i.codigo,
-              descricao: i.descricao,
-              unidade: i.unidade,
-              quantidade: i.quantidade,
-              valor_unitario: i.valor_unitario,
-              ...(i.tint_cor_id ? { tint_cor_id: i.tint_cor_id, tint_nome_cor: i.tint_nome_cor } : {}),
-            })),
-            observacao: notes,
-            codigo_parcela: selectedParcela || undefined,
-          },
-        }).then(({ error }) => {
-          if (error) {
-            toast.error('Erro ao sincronizar com Omie: ' + (error.message || 'Erro desconhecido'));
-          } else {
-            toast.success('Pedido sincronizado com o Omie com sucesso!');
-          }
-        }).catch((err) => {
-          toast.error('Erro ao sincronizar com Omie: ' + (err.message || 'Erro desconhecido'));
-        });
-      } else {
-        const updatedPayloadLocal = {
-          ...(order.omie_payload || {}),
-          cabecalho: {
-            ...(order.omie_payload?.cabecalho || {}),
-            ...(selectedParcela ? { codigo_parcela: selectedParcela } : {}),
-          },
-        };
-        const { error } = await supabase
-          .from('sales_orders')
-          .update({
-            items: items as unknown as Json,
-            subtotal,
-            total: subtotal,
-            notes: notes || null,
-            omie_payload: updatedPayloadLocal as unknown as Json,
-          })
-          .eq('id', order.id);
-        if (error) throw error;
-        toast.success('Pedido atualizado localmente');
-        navigate('/sales');
-      }
-    } catch (e) {
-      console.error(e);
-      const message = e instanceof Error ? e.message : 'Erro ao salvar pedido';
-      toast.error(message);
-      setSaving(false);
-    }
-  };
-
-  const isBlocked = order ? BLOCKED_STATUSES.includes(order.status) : false;
+  const {
+    order,
+    customerName,
+    items,
+    notes,
+    setNotes,
+    loading,
+    saving,
+    formas,
+    selectedParcela,
+    setSelectedParcela,
+    showAddProduct,
+    setShowAddProduct,
+    productSearch,
+    setProductSearch,
+    tintPendingProduct,
+    setTintPendingProduct,
+    customerUserId,
+    updateItem,
+    removeItem,
+    addProduct,
+    handleTintConfirm,
+    tintProductAsProduct,
+    filteredProducts,
+    subtotal,
+    handleSave,
+    isBlocked,
+  } = useSalesOrderEdit();
 
   if (loading) {
     return (
@@ -474,107 +109,23 @@ const SalesOrderEdit = () => {
           <CardContent className="space-y-3">
             {/* Add product search */}
             {showAddProduct && !isBlocked && (
-              <div className="border rounded-lg p-3 bg-muted/30 space-y-2">
-                <div className="relative">
-                  <Search className="absolute left-2.5 top-2 w-4 h-4 text-muted-foreground" />
-                  <Input
-                    placeholder="Buscar produto por nome ou código..."
-                    value={productSearch}
-                    onChange={(e) => setProductSearch(e.target.value)}
-                    className="pl-8 h-8 text-sm"
-                    autoFocus
-                  />
-                </div>
-                {filteredProducts.length > 0 && (
-                  <div className="max-h-48 overflow-y-auto space-y-1">
-                    {filteredProducts.map((p) => (
-                      <button
-                        key={p.id}
-                        onClick={() => addProduct(p)}
-                        className="w-full text-left px-2 py-1.5 rounded hover:bg-accent text-sm flex items-center justify-between gap-2"
-                      >
-                        <div className="min-w-0 flex-1">
-                          <p className="font-medium text-wrap break-words">{p.descricao}</p>
-                          <p className="text-xs text-muted-foreground">{p.codigo} • {p.unidade} • Estoque: <span className={p.estoque > 0 ? 'text-green-600 font-medium' : 'text-red-500 font-medium'}>{p.estoque ?? 0}</span></p>
-                        </div>
-                        <span className="text-xs font-medium shrink-0">
-                          R$ {(p.valor_unitario || 0).toFixed(2)}
-                        </span>
-                      </button>
-                    ))}
-                  </div>
-                )}
-                {productSearch.length >= 2 && filteredProducts.length === 0 && (
-                  <p className="text-xs text-muted-foreground text-center py-2">Nenhum produto encontrado</p>
-                )}
-                {productSearch.length < 2 && (
-                  <p className="text-xs text-muted-foreground text-center py-1">Digite pelo menos 2 caracteres</p>
-                )}
-              </div>
+              <AddProductSearch
+                productSearch={productSearch}
+                setProductSearch={setProductSearch}
+                filteredProducts={filteredProducts}
+                onAddProduct={addProduct}
+              />
             )}
 
             {items.map((item, index) => (
-              <div key={index} className="border rounded-lg p-3 space-y-2">
-                <div className="flex items-start justify-between gap-2">
-                  <div className="flex-1 min-w-0">
-                    <p className="text-sm font-medium truncate">{item.descricao}</p>
-                    {item.codigo && <p className="text-xs text-muted-foreground">Cód: {item.codigo}</p>}
-                    {item.tint_nome_cor && (
-                      <p className="text-xs text-muted-foreground">
-                        🎨 {item.tint_cor_id} - {item.tint_nome_cor}
-                      </p>
-                    )}
-                  </div>
-                  {!isBlocked && (
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      className="h-7 w-7 text-destructive"
-                      onClick={() => removeItem(index)}
-                    >
-                      <Trash2 className="w-3.5 h-3.5" />
-                    </Button>
-                  )}
-                </div>
-
-                <div className="grid grid-cols-3 gap-2">
-                  <div>
-                    <label className="text-xs text-muted-foreground">Qtd</label>
-                    <Input
-                      type="text"
-                      inputMode="numeric"
-                      pattern="[0-9]*"
-                      min={1}
-                      value={item.quantidade}
-                      onFocus={(e) => e.target.select()}
-                      onChange={(e) => updateItem(index, 'quantidade', Number(e.target.value) || 1)}
-                      disabled={isBlocked}
-                      className="h-8 text-sm"
-                    />
-                  </div>
-                  <div>
-                    <label className="text-xs text-muted-foreground">Valor Unit.</label>
-                    <Input
-                      type="text"
-                      inputMode="decimal"
-                      pattern="[0-9]*\.?[0-9]*"
-                      step="0.01"
-                      min={0}
-                      value={item.valor_unitario}
-                      onFocus={(e) => e.target.select()}
-                      onChange={(e) => updateItem(index, 'valor_unitario', Number(e.target.value) || 0)}
-                      disabled={isBlocked}
-                      className="h-8 text-sm"
-                    />
-                  </div>
-                  <div>
-                    <label className="text-xs text-muted-foreground">Total</label>
-                    <p className="h-8 flex items-center text-sm font-medium">
-                      R$ {item.valor_total.toFixed(2)}
-                    </p>
-                  </div>
-                </div>
-              </div>
+              <OrderItemCard
+                key={index}
+                item={item}
+                index={index}
+                isBlocked={isBlocked}
+                onUpdate={updateItem}
+                onRemove={removeItem}
+              />
             ))}
           </CardContent>
         </Card>
@@ -652,4 +203,3 @@ const SalesOrderEdit = () => {
 };
 
 export default SalesOrderEdit;
-


### PR DESCRIPTION
## Resumo
- Split estrutural da página `SalesOrderEdit` (655→**205** linhas), preservando 100% do comportamento (move verbatim).
- Lógica isolada no hook **`useSalesOrderEdit`** (load do pedido, edição de itens, `addProduct`, `handleTintConfirm`, memos, `handleSave` com sync Omie fire-and-forget).
- JSX em componentes controlados: **`PaymentComboboxEdit`**, **`AddProductSearch`**, **`OrderItemCard`**. Tipos em `salesOrderEdit/types.ts`.

## Verificação
- `bunx tsc --noEmit` = 0 erros
- `bunx eslint` = 0 erros (1 warning `exhaustive-deps` de `loadOrder` é **baseline** — confirmado lintando o arquivo de origem)
- Testes novos (+12) passam isolados (3/3 arquivos). ⚠️ Suíte completa local com flakiness por contenção de CPU. Gate autoritativo = CI `validate`.
- Revisão independente de fidelidade (subagente): **FIEL 1:1**, zero divergências.

## Test plan
- [x] tsc / eslint verdes; +12 testes novos verdes isolados
- [x] Revisão 1:1 confirmando comportamento idêntico
- [ ] CI `validate` verde (gate da suíte completa)

🤖 Generated with [Claude Code](https://claude.com/claude-code)