### PR TITLE
chore: regra de uma-sessão-por-worktree (helper + doc §14)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -635,3 +635,15 @@ Persistido em 2026-05-17 após primeira run completa do skill com sucesso.
 - **gbrain**: não configurado neste projeto.
 
 **Pre-flight**: worktrees novos precisam de `bun install` antes de `/health` (~3s pra extrair 955 packages).
+
+---
+
+## 14. Sessões paralelas — uma sessão por working tree (regra)
+
+> Registrado 2026-05-24 após duas sessões Claude rodarem no MESMO diretório principal e trocarem de branch uma da outra (uma quase perdeu commits; só um guard por SHA salvou). Esta máquina roda MUITAS sessões em paralelo (rode `git worktree list` — costuma ter ~10 worktrees ativas em `.claude/worktrees/`).
+
+**Regra:** cada sessão Claude trabalha no **seu próprio working tree**. NUNCA rode duas sessões ao mesmo tempo no diretório principal (`/Users/lucassardenberg/Projetos/afiacao`) — elas compartilham o mesmo checkout, e o `git checkout`/troca de branch de uma vaza pra outra (causa: branch-flip silencioso entre comandos → commit no lugar errado, risco de perda).
+
+- **Worktrees são o padrão seguro** — cada uma tem checkout + branch próprios. As de `.claude/worktrees/*` que o Claude Code cria já isolam automaticamente. O problema só aparece quando uma sessão roda **direto na raiz** junto com outra.
+- **Helper:** `bun run wt <branch> [base]` (`scripts/new-worktree.sh`) cria uma worktree isolada como sibling do repo (`../afiacao-<branch>`) a partir de `origin/main` (ou base custom) e imprime os próximos passos (`cd` + `bun install` + abrir a sessão lá).
+- **Rede de segurança (hook global):** `~/.claude/hooks/concurrent-session-guard.sh`, registrado em `SessionStart` no `~/.claude/settings.json`, **avisa** (via `systemMessage`) quando uma 2ª sessão inicia no mesmo working tree principal. Worktrees ficam **isentas** (são o caso bom). É aviso, não bloqueio — mas pega o lapso de "abri sem perceber". É global (vale em qualquer repo), validado com shellcheck + pipe-test. Pra revisar/desligar: `/hooks` ou editar o `settings.json`.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "preview": "vite preview",
     "test": "vitest run",
     "typecheck:strict": "tsc --noEmit -p tsconfig.strict.json",
-    "audit:migrations": "bun scripts/audit-custom-migrations.ts"
+    "audit:migrations": "bun scripts/audit-custom-migrations.ts",
+    "wt": "bash scripts/new-worktree.sh"
   },
   "dependencies": {
     "@elevenlabs/react": "^0.14.0",

--- a/scripts/new-worktree.sh
+++ b/scripts/new-worktree.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# new-worktree.sh — cria uma worktree ISOLADA pra rodar uma sessão Claude sem
+# colidir com outras. Cada sessão num working tree próprio = branches nunca se
+# cruzam (ver CLAUDE.md §14 + o hook concurrent-session-guard).
+#
+# Uso:  bun run wt <nome-da-branch> [base-ref]
+#   bun run wt feat/minha-feature                  # base = origin/main (limpo)
+#   bun run wt fix/x feat/carteira-omie-...         # base = branch existente
+#
+# A worktree é criada como SIBLING do repo principal: ../<repo>-<slug>.
+
+set -euo pipefail
+
+name="${1:-}"
+if [ -z "$name" ]; then
+  echo "uso: bun run wt <nome-da-branch> [base-ref]" >&2
+  echo "  ex.: bun run wt feat/minha-feature        # base origin/main" >&2
+  echo "       bun run wt fix/x feat/outra-branch    # base custom" >&2
+  exit 1
+fi
+base="${2:-origin/main}"
+
+# Ancora SEMPRE no repo principal (não no worktree atual): o git-common-dir
+# aponta pro .git principal, mesmo quando invocado de dentro de uma worktree.
+common_git=$(git rev-parse --git-common-dir)
+case "$common_git" in
+  /*) ;;
+  *) common_git="$(pwd)/$common_git" ;;
+esac
+main_root=$(cd "$(dirname "$common_git")" && pwd)
+repo_name=$(basename "$main_root")
+slug=$(printf '%s' "$name" | tr '/' '-')
+dir="$(dirname "$main_root")/$repo_name-$slug"
+
+git fetch origin --quiet
+git worktree add -b "$name" "$dir" "$base"
+
+cat <<EOF
+
+✅ worktree criada
+   pasta:  $dir
+   branch: $name (a partir de $base)
+
+Próximos passos:
+   cd "$dir"
+   bun install        # worktree nova precisa instalar deps
+   claude             # abra a sessão AQUI (isolada, sem colidir com outras)
+EOF


### PR DESCRIPTION
## Contexto

Hoje (2026-05-24) duas sessões Claude rodaram no **mesmo diretório principal** e ficaram trocando de branch uma da outra entre comandos. Um commit foi parar na branch errada e só um guard por SHA evitou que um `git reset --hard` apagasse o trabalho em voo da outra sessão. Esta máquina roda ~10 worktrees em paralelo — o risco é real e recorrente ("me pego fazendo isso sem perceber").

## O que entra (escolha do dono: "os dois" — rede + cura)

1. **Helper `bun run wt <branch> [base]`** (`scripts/new-worktree.sh`) — cria uma worktree isolada como sibling (`../afiacao-<branch>`) a partir de `origin/main` (ou base custom) e imprime os próximos passos (`cd` + `bun install` + abrir a sessão lá). Ancora sempre no repo principal via `git-common-dir`, então funciona mesmo invocado de dentro de outra worktree.
2. **CLAUDE.md §14** — documenta a regra (uma sessão por working tree), o helper e o hook de aviso.

## O que NÃO entra neste PR (é global, fora do repo)

- O hook em si: `~/.claude/hooks/concurrent-session-guard.sh` + entrada `SessionStart` no `~/.claude/settings.json`. É **global** (vale em qualquer repo do dono), então não pertence ao versionamento deste projeto. Avisa via `systemMessage` quando uma 2ª sessão inicia no mesmo working tree principal; **isenta worktrees** (o padrão bom). Validado com shellcheck + pipe-test JSON.

## Validação

- `shellcheck scripts/new-worktree.sh` ✅ limpo (entra no health stack `shellcheck scripts/*.sh`)
- `package.json` JSON válido, script `wt` registrado ✅
- Helper sem args mostra uso e sai 1 ✅
- Sem mudança de runtime/app — só tooling + doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)