### PR TITLE
feat(offline): pedido offline-first (rascunho + CTA de reconexão)

### DIFF
--- a/docs/superpowers/plans/2026-05-24-offline-order-submit.md
+++ b/docs/superpowers/plans/2026-05-24-offline-order-submit.md
@@ -1,0 +1,412 @@
+# Pedido Offline (submitOrder rascunho-first) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Dar ao vendedor offline um envio de pedido sem erro: offline salva rascunho (já existe) e um CTA manual "Enviar agora" dispara o `submitOrder` online ao reconectar — sem nunca enfileirar (evita PV duplicado no Omie).
+
+**Architecture:** Hook fino `useOfflineSubmit` faz o gate em volta de `h.submitOrder` (offline → marca pendente + toast, não envia; online → envia). `UnifiedOrder` usa `useNetworkStatus` + o hook, passa estado `offline` pro `CartSummaryBar` (label do botão) e renderiza um banner com CTA quando reconecta com intent pendente. Sem migration, sem tocar `submitOrder`/Omie.
+
+**Tech Stack:** React 18 + TypeScript + @tanstack/react-query + sonner + vitest. Reusa `useNetworkStatus` e `useOrderDraft` existentes.
+
+**Spec base:** [docs/superpowers/specs/2026-05-24-offline-order-submit-design.md](../specs/2026-05-24-offline-order-submit-design.md)
+
+**Baseline:** vitest 847 passed / 162 files (pós-merge do #250). Não regredir.
+
+---
+
+## File Structure
+
+**Novos:**
+```
+src/hooks/useOfflineSubmit.ts                  # gate offline/online em volta do submit
+src/hooks/__tests__/useOfflineSubmit.test.tsx  # 5 cenários
+```
+
+**Editados:**
+```
+src/components/unified-order/CartSummaryBar.tsx  # + prop offline; label do botão
+src/pages/UnifiedOrder.tsx                       # useNetworkStatus + useOfflineSubmit + banner + props
+```
+
+---
+
+### Task 1: Hook `useOfflineSubmit` (TDD)
+
+**Files:**
+- Create: `src/hooks/useOfflineSubmit.ts`
+- Test: `src/hooks/__tests__/useOfflineSubmit.test.tsx`
+
+- [ ] **Step 1: Escrever o teste falhando**
+
+Create `src/hooks/__tests__/useOfflineSubmit.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+vi.mock('sonner', () => ({ toast: { info: vi.fn(), success: vi.fn(), error: vi.fn() } }));
+
+import { useOfflineSubmit } from '../useOfflineSubmit';
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('useOfflineSubmit', () => {
+  it('online: onSubmit chama submit', () => {
+    const submit = vi.fn();
+    const { result } = renderHook(() => useOfflineSubmit({ submit, online: true, hasContent: true }));
+    act(() => result.current.onSubmit());
+    expect(submit).toHaveBeenCalledTimes(1);
+    expect(result.current.offline).toBe(false);
+    expect(result.current.showReconnectCta).toBe(false);
+  });
+
+  it('offline: onSubmit NÃO chama submit e marca offline', () => {
+    const submit = vi.fn();
+    const { result } = renderHook(() => useOfflineSubmit({ submit, online: false, hasContent: true }));
+    act(() => result.current.onSubmit());
+    expect(submit).not.toHaveBeenCalled();
+    expect(result.current.offline).toBe(true);
+  });
+
+  it('offline→online com intent pendente + conteúdo → mostra CTA de reconexão', () => {
+    const submit = vi.fn();
+    const { result, rerender } = renderHook(
+      ({ online }: { online: boolean }) => useOfflineSubmit({ submit, online, hasContent: true }),
+      { initialProps: { online: false } },
+    );
+    act(() => result.current.onSubmit()); // clica offline → pendente
+    expect(result.current.showReconnectCta).toBe(false); // ainda offline
+    rerender({ online: true }); // reconecta
+    expect(result.current.showReconnectCta).toBe(true);
+  });
+
+  it('CTA de reconexão chama submit e some depois', () => {
+    const submit = vi.fn();
+    const { result, rerender } = renderHook(
+      ({ online }: { online: boolean }) => useOfflineSubmit({ submit, online, hasContent: true }),
+      { initialProps: { online: false } },
+    );
+    act(() => result.current.onSubmit());
+    rerender({ online: true });
+    expect(result.current.showReconnectCta).toBe(true);
+    act(() => result.current.onReconnectSubmit());
+    expect(submit).toHaveBeenCalledTimes(1);
+    expect(result.current.showReconnectCta).toBe(false);
+  });
+
+  it('sem conteúdo: nunca mostra CTA mesmo com intent pendente', () => {
+    const submit = vi.fn();
+    const { result, rerender } = renderHook(
+      ({ online, hasContent }: { online: boolean; hasContent: boolean }) =>
+        useOfflineSubmit({ submit, online, hasContent }),
+      { initialProps: { online: false, hasContent: true } },
+    );
+    act(() => result.current.onSubmit());
+    rerender({ online: true, hasContent: false });
+    expect(result.current.showReconnectCta).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Rodar → FAIL**
+
+Run: `bun run vitest run src/hooks/__tests__/useOfflineSubmit.test.tsx`
+Expected: FAIL — `Cannot find module '../useOfflineSubmit'`.
+
+- [ ] **Step 3: Implementar**
+
+Create `src/hooks/useOfflineSubmit.ts`:
+
+```ts
+import { useState, useCallback } from 'react';
+import { toast } from 'sonner';
+
+export interface UseOfflineSubmitOptions {
+  /** Envio online real (ex: h.submitOrder). */
+  submit: () => void | Promise<void>;
+  /** Estado de rede (de useNetworkStatus). */
+  online: boolean;
+  /** Há conteúdo a enviar (cart > 0)? Gate o CTA de reconexão. */
+  hasContent: boolean;
+}
+
+export interface UseOfflineSubmitReturn {
+  /** Handler do botão de envio: offline → marca pendente + toast; online → submit(). */
+  onSubmit: () => void;
+  /** True quando offline (pra UI do botão). */
+  offline: boolean;
+  /** Mostra o banner de reconexão (online + intent offline pendente + tem conteúdo). */
+  showReconnectCta: boolean;
+  /** Handler do CTA "Enviar agora": limpa pendente + submit(). */
+  onReconnectSubmit: () => void;
+}
+
+/**
+ * Gate offline-first para o envio de pedido. Não enfileira (submitOrder cria PV cobrado
+ * no Omie, não-idempotente). Offline: salva intent pendente + avisa (o rascunho já é
+ * auto-salvo pelo useOrderDraft). Online de novo: expõe CTA pra enviar de verdade.
+ */
+export function useOfflineSubmit({ submit, online, hasContent }: UseOfflineSubmitOptions): UseOfflineSubmitReturn {
+  const [pending, setPending] = useState(false);
+
+  const onSubmit = useCallback(() => {
+    if (!online) {
+      setPending(true);
+      toast.info('Sem conexão — salvo como rascunho. Enviaremos quando reconectar.');
+      return;
+    }
+    setPending(false);
+    void submit();
+  }, [online, submit]);
+
+  const onReconnectSubmit = useCallback(() => {
+    setPending(false);
+    void submit();
+  }, [submit]);
+
+  return {
+    onSubmit,
+    offline: !online,
+    showReconnectCta: online && pending && hasContent,
+    onReconnectSubmit,
+  };
+}
+```
+
+- [ ] **Step 4: Rodar → PASS**
+
+Run: `bun run vitest run src/hooks/__tests__/useOfflineSubmit.test.tsx`
+Expected: PASS (5/5).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hooks/useOfflineSubmit.ts src/hooks/__tests__/useOfflineSubmit.test.tsx
+git commit -m "feat(offline): useOfflineSubmit (gate rascunho-first p/ envio de pedido, 5 tests)"
+```
+
+---
+
+### Task 2: `CartSummaryBar` — prop `offline` + label do botão
+
+**Files:**
+- Modify: `src/components/unified-order/CartSummaryBar.tsx`
+
+- [ ] **Step 1: Adicionar `CloudOff` ao import de ícones**
+
+Trocar (linhas 10-12):
+```ts
+import {
+  Send, Loader2, AlertCircle, Check, ChevronsUpDown, FileText, Calendar,
+} from 'lucide-react';
+```
+por:
+```ts
+import {
+  Send, Loader2, AlertCircle, Check, ChevronsUpDown, FileText, Calendar, CloudOff,
+} from 'lucide-react';
+```
+
+- [ ] **Step 2: Adicionar a prop `offline` à interface**
+
+Na `interface CartSummaryBarProps`, dentro do bloco `// Actions` (perto de `onSubmit`):
+```ts
+  // Actions
+  onSubmit: () => void;
+  onSubmitQuote?: () => void;
+  /** Quando true, o botão vira "salvar rascunho" (vendedor offline). */
+  offline?: boolean;
+```
+
+- [ ] **Step 3: Receber a prop na desestruturação do componente**
+
+Trocar:
+```ts
+  onSubmit, onSubmitQuote,
+}: CartSummaryBarProps) {
+```
+por:
+```ts
+  onSubmit, onSubmitQuote, offline = false,
+}: CartSummaryBarProps) {
+```
+
+- [ ] **Step 4: Trocar o conteúdo do botão de envio por versão offline-aware**
+
+Trocar (botão "Enviar pedido", ~linha 240-246):
+```tsx
+          <Button className="w-full gap-2" onClick={onSubmit} disabled={disableSubmit}>
+            {submitting ? <Loader2 className="w-4 h-4 animate-spin" /> : <Send className="w-4 h-4" />}
+            Enviar pedido
+            {(() => {
+              const count = (obenProductItems.length > 0 ? 1 : 0) + (colacorProductItems.length > 0 ? 1 : 0) + (serviceItems.length > 0 ? 1 : 0);
+              return count > 1 ? <span className="text-[10px] opacity-70">({count} pedidos)</span> : null;
+            })()}
+          </Button>
+```
+por:
+```tsx
+          <Button className="w-full gap-2" onClick={onSubmit} disabled={disableSubmit}>
+            {submitting ? (
+              <Loader2 className="w-4 h-4 animate-spin" />
+            ) : offline ? (
+              <CloudOff className="w-4 h-4" />
+            ) : (
+              <Send className="w-4 h-4" />
+            )}
+            {offline ? 'Sem conexão — salvar rascunho' : 'Enviar pedido'}
+            {!offline && (() => {
+              const count = (obenProductItems.length > 0 ? 1 : 0) + (colacorProductItems.length > 0 ? 1 : 0) + (serviceItems.length > 0 ? 1 : 0);
+              return count > 1 ? <span className="text-[10px] opacity-70">({count} pedidos)</span> : null;
+            })()}
+          </Button>
+```
+
+> Nota: `disableSubmit` (submitting / serviço sem seleção / divergência de vendedor) continua valendo offline — são validações de negócio, não de rede. O botão de orçamento (`onSubmitQuote`) já depende de `submitting`; deixá-lo desabilitado offline fica fora do escopo (não é o fluxo principal).
+
+- [ ] **Step 5: Validar lint**
+
+Run: `bunx eslint src/components/unified-order/CartSummaryBar.tsx`
+Expected: zero erros.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/unified-order/CartSummaryBar.tsx
+git commit -m "feat(offline): CartSummaryBar mostra 'salvar rascunho' quando offline"
+```
+
+---
+
+### Task 3: Fiar no `UnifiedOrder` (hook + banner + props)
+
+**Files:**
+- Modify: `src/pages/UnifiedOrder.tsx`
+
+- [ ] **Step 1: Imports**
+
+Adicionar `Wifi` ao import de ícones (linha 2):
+```ts
+import { Loader2, ChevronLeft, CheckCircle, Building2, Scissors, Wifi } from 'lucide-react';
+```
+
+Adicionar (junto aos outros imports de hooks/components, ex. após a linha 15 `import { useAuth } ...`):
+```ts
+import { Button } from '@/components/ui/button';
+import { useNetworkStatus } from '@/hooks/useNetworkStatus';
+import { useOfflineSubmit } from '@/hooks/useOfflineSubmit';
+```
+
+> Se `Button` já estiver importado no arquivo, não duplicar (conferir com `grep -n "components/ui/button" src/pages/UnifiedOrder.tsx`; se já houver, pular essa linha).
+
+- [ ] **Step 2: Instanciar rede + gate (após o bloco do useOrderDraft, ~linha 78)**
+
+Logo após o `const { draft, clear: clearDraft, dismiss: dismissDraft } = useOrderDraft({...});`:
+```ts
+  const net = useNetworkStatus();
+  const offlineSubmit = useOfflineSubmit({
+    submit: h.submitOrder,
+    online: net.online,
+    hasContent: h.cart.length > 0,
+  });
+```
+
+- [ ] **Step 3: Banner de reconexão (logo após a abertura do container principal, antes do grid de conteúdo)**
+
+Inserir imediatamente antes da linha `<div className={cn('grid gap-4', ...`:
+```tsx
+      {offlineSubmit.showReconnectCta && (
+        <div className="rounded-md border border-status-info-bold/30 bg-status-info-bg px-4 py-3 mb-4 flex flex-col sm:flex-row sm:items-center justify-between gap-3">
+          <div className="flex items-center gap-2 text-sm text-status-info-bold">
+            <Wifi className="w-4 h-4 shrink-0" />
+            Conexão restabelecida. Seu pedido está salvo como rascunho.
+          </div>
+          <Button size="sm" onClick={offlineSubmit.onReconnectSubmit} disabled={h.submitting} className="shrink-0">
+            Enviar pedido agora
+          </Button>
+        </div>
+      )}
+```
+
+- [ ] **Step 4: Passar `onSubmit` (gate) + `offline` pro CartSummaryBar**
+
+Trocar (no `<CartSummaryBar ... />`):
+```tsx
+              onSubmit={h.submitOrder}
+              onSubmitQuote={h.submitQuote}
+```
+por:
+```tsx
+              onSubmit={offlineSubmit.onSubmit}
+              onSubmitQuote={h.submitQuote}
+              offline={offlineSubmit.offline}
+```
+
+- [ ] **Step 5: Validar lint + tipos + suíte**
+
+Run:
+```bash
+bunx eslint src/pages/UnifiedOrder.tsx
+bun run vitest run src/hooks/__tests__/useOfflineSubmit.test.tsx
+```
+Expected: zero erros de lint; 5/5 do hook.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/pages/UnifiedOrder.tsx
+git commit -m "feat(offline): UnifiedOrder usa useOfflineSubmit + banner de reconexão"
+```
+
+---
+
+### Task 4: Validação final + QA + design-review
+
+**Files:** nenhum (validação)
+
+- [ ] **Step 1: Suíte + build limpos**
+
+Run (sequencial, sem concorrência — CPU calma):
+```bash
+bun run test
+bun run build
+```
+Expected: vitest 847 + 5 novos verdes; build exit 0.
+
+- [ ] **Step 2: QA manual offline**
+
+`bun dev` → logar → UnifiedOrder com cliente + itens no cart → DevTools → Offline →
+1. Botão mostra "Sem conexão — salvar rascunho" (ícone CloudOff).
+2. Clicar → toast "Sem conexão — salvo como rascunho..." (NÃO abre success dialog, NÃO chama Omie).
+3. Network → Online → banner "Conexão restabelecida... Enviar pedido agora" aparece.
+4. Clicar "Enviar pedido agora" → pedido criado normal (success dialog + recibo).
+5. Online o tempo todo: botão "Enviar pedido" normal, envia direto (sem banner).
+
+- [ ] **Step 3: `/design-review` nos estados offline**
+
+Rodar `/design-review` (gstack) apontando pros estados: botão offline + banner de reconexão. Aplicar ajustes de espaçamento/hierarquia/contraste contra o design system v3 que ele apontar (commit separado se houver mudança).
+
+- [ ] **Step 4: Push + PR (só com ok do founder)**
+
+> Push/PR só com autorização explícita. Quando liberado:
+```bash
+git push -u origin claude/offline-order-submit
+```
+PR title: `feat(offline): pedido offline-first (rascunho + CTA de reconexão)`
+
+---
+
+## Critérios de "feito"
+
+- [ ] `useOfflineSubmit` testado (online envia; offline não envia + marca; reconnect mostra CTA; CTA envia e some; sem conteúdo não mostra CTA).
+- [ ] `CartSummaryBar` mostra "salvar rascunho" + ícone CloudOff quando offline.
+- [ ] `UnifiedOrder` renderiza banner de reconexão e usa o gate.
+- [ ] `submitOrder`/Omie inalterados; sem migration; sem enqueue.
+- [ ] vitest verde (847 + 5); build exit 0.
+- [ ] QA manual offline passou; `/design-review` aplicado.
+
+## Out-of-scope (follow-up)
+
+- Cross-sessão: persistir entrega/pagamento/volumes/ready-date no rascunho + restaurá-los (enviar após fechar/reabrir offline).
+- Detecção de rede por timeout/heartbeat além de `navigator.onLine`.
+- `submitQuote` offline; enqueue/idempotência de `submitOrder`.

--- a/docs/superpowers/specs/2026-05-24-offline-order-submit-design.md
+++ b/docs/superpowers/specs/2026-05-24-offline-order-submit-design.md
@@ -1,0 +1,153 @@
+# Pedido Offline (submitOrder rascunho-first) — Design Spec
+
+> **Data:** 2026-05-24
+> **Status:** aprovado no brainstorming, pronto pra planejar
+> **Autor:** brainstorming colaborativo (Lucas + Claude). Arquitetura (rascunho-first, NÃO enfileirar) validada pelo codex no PR1 (consult de 2026-05-24).
+> **Sequência:** PR2 do programa offline-first (PR1 = picking + optimistic + fix de loop, mergeado em #250).
+
+## Goal
+
+Dar ao **vendedor externo no carro** (persona do briefing, "frequente offline") uma experiência sã ao enviar pedido sem conexão: em vez de um erro de rede, o pedido fica **salvo como rascunho** e, quando a conexão volta, um **CTA "Enviar agora"** dispara o envio online real. O `submitOrder` continua estritamente online (sem fila), porque criar o pedido offline é perigoso.
+
+## Contexto técnico (estado atual)
+
+- **`submitOrder`** (`src/services/orderSubmission/submitOrder.ts`) orquestra inserts em `sales_orders` + criação de **PV cobrado no Omie** via edge function `omie-vendas-sync` (que monta `codigo_pedido_integracao = PV_${id}_${Date.now()}` — sem idempotência). Replay offline→online **duplicaria pedido/PV no ERP**. O recibo depende dos números de PV que o Omie devolve (não existem offline). → **NÃO enfileirar** (decisão herdada do PR1, codex-validada).
+- **Auto-save de rascunho já existe**: `useOrderDraft` (`src/hooks/useOrderDraft.ts`) salva `{ cart, customerCodigoCliente, customerName, notes, ordemCompra }` em localStorage enquanto o cart > 0 (scope = `user.id`), limpa quando `orderSuccessOpen` (sucesso), e oferece restauração via `RestoreDraftDialog` ao voltar à tela com cart vazio (`UnifiedOrder.tsx:59-113`).
+- **Botão de envio** vive em `CartSummaryBar.tsx` (`onSubmit={h.submitOrder}`, `submitting`, `disableSubmit = submitting || serviceItems.some(s=>!s.servico) || vendedorDivergencias.length>0`, label "Enviar pedido").
+- **Rede**: `useNetworkStatus()` (`src/hooks/useNetworkStatus.ts`) expõe `{ online, quality, ... }`; `NetworkStatusIndicator` já no shell. Workbox `NetworkFirst` (PR #40).
+- **`submitOrder` hoje não tem consciência de rede**: offline, ele chama o insert/Omie e estoura erro de rede → toast "Erro ao criar pedido". Nenhum estado "salvo como rascunho" nem CTA de reconexão.
+
+## Decisões do brainstorming
+
+1. **Não enfileirar `submitOrder`** — modelo rascunho-first (online-only commit). Motivo: PV cobrado + não-idempotente + recibo depende do Omie.
+2. **Reconexão = CTA manual** "Enviar agora" (não auto-enviar) — evita disparar PV no ERP num momento indesejado.
+3. **Alcance = mesma sessão (MVP)** — cobre o caso real (app aberto, sinal cai e volta; estado de entrega/pagamento/volumes segue em memória). O rascunho atual (cart/cliente/notes) é o backstop pra "fechou o app". **Cross-sessão** (persistir entrega/pagamento/volumes e enviar após reabrir offline) fica como **follow-up**.
+4. **Sem migration, sem mudança no `submitOrder`/Omie.** Só camada de UI/estado em volta do submit.
+5. **Vale pra staff e customer** (ambos usam `UnifiedOrder`); o alvo é o vendedor, mas o gate é genérico.
+
+## Arquitetura
+
+### 1. Hook `src/hooks/useOfflineSubmit.ts` (novo)
+
+Gate fino e testável em volta do submit:
+
+```ts
+import { useState, useCallback } from 'react';
+import { toast } from 'sonner';
+
+export interface UseOfflineSubmitOptions {
+  /** Função de envio online real (ex: h.submitOrder). */
+  submit: () => void | Promise<void>;
+  /** Estado de rede (de useNetworkStatus). */
+  online: boolean;
+  /** Há conteúdo a enviar (cart > 0)? Gate o CTA de reconexão. */
+  hasContent: boolean;
+}
+
+export interface UseOfflineSubmitReturn {
+  /** Handler do botão de envio: offline → marca pendente + toast; online → submit(). */
+  onSubmit: () => void;
+  /** True quando offline (pra UI do botão). */
+  offline: boolean;
+  /** Mostra o banner de reconexão (online + havia intent offline + tem conteúdo). */
+  showReconnectCta: boolean;
+  /** Handler do CTA "Enviar agora": limpa pendente + submit(). */
+  onReconnectSubmit: () => void;
+}
+
+export function useOfflineSubmit({ submit, online, hasContent }: UseOfflineSubmitOptions): UseOfflineSubmitReturn {
+  const [pending, setPending] = useState(false);
+
+  const onSubmit = useCallback(() => {
+    if (!online) {
+      setPending(true);
+      toast.info('Sem conexão — salvo como rascunho. Enviaremos quando reconectar.');
+      return;
+    }
+    setPending(false);
+    void submit();
+  }, [online, submit]);
+
+  const onReconnectSubmit = useCallback(() => {
+    setPending(false);
+    void submit();
+  }, [submit]);
+
+  return {
+    onSubmit,
+    offline: !online,
+    showReconnectCta: online && pending && hasContent,
+    onReconnectSubmit,
+  };
+}
+```
+
+> Observação de invariante: `pending` só vira `true` por clique offline. Quando `online` volta e ainda há `pending` + conteúdo, `showReconnectCta` acende. Após `submit()` (CTA ou clique online), `pending` zera. O sucesso do pedido limpa o rascunho pelo mecanismo existente (`clearTrigger: orderSuccessOpen`).
+
+### 2. `UnifiedOrder.tsx`
+
+- `const net = useNetworkStatus();`
+- `const offlineSubmit = useOfflineSubmit({ submit: h.submitOrder, online: net.online, hasContent: h.cart.length > 0 });`
+- Passar `onSubmit={offlineSubmit.onSubmit}` (no lugar de `h.submitOrder`) e `offline={offlineSubmit.offline}` pro `CartSummaryBar`.
+- Renderizar o **banner de reconexão** acima do conteúdo quando `offlineSubmit.showReconnectCta`:
+
+```tsx
+{offlineSubmit.showReconnectCta && (
+  <div className="rounded-md border border-status-info-bold/30 bg-status-info-bg px-4 py-3 flex items-center justify-between gap-3">
+    <div className="flex items-center gap-2 text-sm text-status-info-bold">
+      <Wifi className="w-4 h-4" />
+      Conexão restabelecida. Seu pedido está salvo como rascunho.
+    </div>
+    <Button size="sm" onClick={offlineSubmit.onReconnectSubmit} disabled={h.submitting}>
+      Enviar pedido agora
+    </Button>
+  </div>
+)}
+```
+
+### 3. `CartSummaryBar.tsx`
+
+- Nova prop opcional `offline?: boolean`.
+- Botão de envio: quando `offline`, **não desabilita** por causa da rede (o vendedor pode "salvar rascunho"); troca ícone/label:
+  - online: `<Send/> Enviar pedido` (atual).
+  - offline: `<CloudOff/> Sem conexão — salvar rascunho`.
+- `onClick={onSubmit}` em ambos (o gate decide o comportamento). `disableSubmit` mantém as validações de negócio (serviço sem seleção, divergência de vendedor) — essas valem offline também.
+- O botão de **orçamento** (`onSubmitQuote`) fica desabilitado offline (depende de rede; fora do escopo do gate).
+
+## Data flow
+
+```
+[vendedor offline clica "Enviar"]
+  → useOfflineSubmit.onSubmit: online=false → setPending(true) + toast "salvo como rascunho"
+  → (submitOrder NÃO é chamado; rascunho já auto-salvo via useOrderDraft)
+[sinal volta → useNetworkStatus.online = true]
+  → showReconnectCta = true → banner aparece
+[vendedor clica "Enviar pedido agora"]
+  → onReconnectSubmit: setPending(false) + submitOrder() (online normal, PV real, recibo real)
+  → sucesso → orderSuccessOpen → rascunho limpa (clearTrigger existente)
+```
+
+## Error handling
+
+- **Offline no clique**: interceptado pelo gate (não chama submit). Rascunho persiste.
+- **Rede cai NO MEIO do submit** (estava online ao clicar): o `submitOrder` atual já trata parcial (insert ok + Omie falha → "PV (pendente ERP)") e erros (try/catch → toast). O gate não muda isso — fora do escopo do MVP.
+- **`navigator.onLine` falso-positivo** (diz online mas request falha): cai no tratamento de erro existente do `submitOrder`. Aceitável no MVP (não tentamos detectar via timeout).
+
+## Testing
+
+- **`useOfflineSubmit` (TDD, vitest + renderHook):**
+  - offline + onSubmit → NÃO chama `submit`, marca pendente (e `offline === true`).
+  - online + onSubmit → chama `submit`.
+  - online + pendente + hasContent → `showReconnectCta === true`; sem conteúdo → false.
+  - onReconnectSubmit → chama `submit` e zera pendente (CTA some).
+  - (mock de `sonner`.)
+- Suíte completa verde (847+ baseline).
+- **QA manual offline:** `bun dev` → UnifiedOrder com cart → DevTools Offline → "Enviar" → ver toast "salvo como rascunho" + botão "Sem conexão — salvar rascunho" → reconectar → banner "Enviar pedido agora" → clicar → pedido criado normal.
+- **`/design-review`** nos estados offline (botão) e reconnect (banner) com screenshots, ajustando contra o design system v3.
+
+## Scope boundaries (fora desta PR)
+
+- **Cross-sessão**: persistir entrega/pagamento/volumes/ready-date no rascunho e restaurá-los pra permitir envio após fechar/reabrir offline. Follow-up.
+- **Detecção de rede por timeout/heartbeat** (além de `navigator.onLine`).
+- **Enfileirar/idempotência de `submitOrder`** (exigiria UUID de pedido + unique constraint + dedup no edge function antes do Omie) — explicitamente descartado.
+- `submitQuote` offline.

--- a/src/components/unified-order/CartSummaryBar.tsx
+++ b/src/components/unified-order/CartSummaryBar.tsx
@@ -8,7 +8,7 @@ import { Card, CardContent } from '@/components/ui/card';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from '@/components/ui/command';
 import {
-  Send, Loader2, AlertCircle, Check, ChevronsUpDown, FileText, Calendar,
+  Send, Loader2, AlertCircle, Check, ChevronsUpDown, FileText, Calendar, CloudOff,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { format, addDays, startOfWeek, isWeekend } from 'date-fns';
@@ -51,6 +51,8 @@ interface CartSummaryBarProps {
   // Actions
   onSubmit: () => void;
   onSubmitQuote?: () => void;
+  /** Quando true, o botão vira "salvar rascunho" (vendedor offline). */
+  offline?: boolean;
 }
 
 function PaymentCombobox({
@@ -154,7 +156,7 @@ export function CartSummaryBar({
   volumesOben, volumesColacor,
   ordemCompra, setOrdemCompra, isOrdemCompraCustomer,
   readyByDate, setReadyByDate,
-  onSubmit, onSubmitQuote,
+  onSubmit, onSubmitQuote, offline = false,
 }: CartSummaryBarProps) {
   const hasOnlyProducts = (obenProductItems.length > 0 || colacorProductItems.length > 0) && serviceItems.length === 0;
   const disableSubmit = submitting || serviceItems.some(s => !s.servico) || vendedorDivergencias.length > 0;
@@ -238,9 +240,15 @@ export function CartSummaryBar({
             </p>
           )}
           <Button className="w-full gap-2" onClick={onSubmit} disabled={disableSubmit}>
-            {submitting ? <Loader2 className="w-4 h-4 animate-spin" /> : <Send className="w-4 h-4" />}
-            Enviar pedido
-            {(() => {
+            {submitting ? (
+              <Loader2 className="w-4 h-4 animate-spin" />
+            ) : offline ? (
+              <CloudOff className="w-4 h-4" />
+            ) : (
+              <Send className="w-4 h-4" />
+            )}
+            {offline ? 'Sem conexão — salvar rascunho' : 'Enviar pedido'}
+            {!offline && (() => {
               const count = (obenProductItems.length > 0 ? 1 : 0) + (colacorProductItems.length > 0 ? 1 : 0) + (serviceItems.length > 0 ? 1 : 0);
               return count > 1 ? <span className="text-[10px] opacity-70">({count} pedidos)</span> : null;
             })()}

--- a/src/hooks/__tests__/useOfflineSubmit.test.tsx
+++ b/src/hooks/__tests__/useOfflineSubmit.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+vi.mock('sonner', () => ({ toast: { info: vi.fn(), success: vi.fn(), error: vi.fn() } }));
+
+import { useOfflineSubmit } from '../useOfflineSubmit';
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('useOfflineSubmit', () => {
+  it('online: onSubmit chama submit', () => {
+    const submit = vi.fn();
+    const { result } = renderHook(() => useOfflineSubmit({ submit, online: true, hasContent: true }));
+    act(() => result.current.onSubmit());
+    expect(submit).toHaveBeenCalledTimes(1);
+    expect(result.current.offline).toBe(false);
+    expect(result.current.showReconnectCta).toBe(false);
+  });
+
+  it('offline: onSubmit NÃO chama submit e marca offline', () => {
+    const submit = vi.fn();
+    const { result } = renderHook(() => useOfflineSubmit({ submit, online: false, hasContent: true }));
+    act(() => result.current.onSubmit());
+    expect(submit).not.toHaveBeenCalled();
+    expect(result.current.offline).toBe(true);
+  });
+
+  it('offline→online com intent pendente + conteúdo → mostra CTA de reconexão', () => {
+    const submit = vi.fn();
+    const { result, rerender } = renderHook(
+      ({ online }: { online: boolean }) => useOfflineSubmit({ submit, online, hasContent: true }),
+      { initialProps: { online: false } },
+    );
+    act(() => result.current.onSubmit()); // clica offline → pendente
+    expect(result.current.showReconnectCta).toBe(false); // ainda offline
+    rerender({ online: true }); // reconecta
+    expect(result.current.showReconnectCta).toBe(true);
+  });
+
+  it('CTA de reconexão chama submit e some depois', () => {
+    const submit = vi.fn();
+    const { result, rerender } = renderHook(
+      ({ online }: { online: boolean }) => useOfflineSubmit({ submit, online, hasContent: true }),
+      { initialProps: { online: false } },
+    );
+    act(() => result.current.onSubmit());
+    rerender({ online: true });
+    expect(result.current.showReconnectCta).toBe(true);
+    act(() => result.current.onReconnectSubmit());
+    expect(submit).toHaveBeenCalledTimes(1);
+    expect(result.current.showReconnectCta).toBe(false);
+  });
+
+  it('sem conteúdo: nunca mostra CTA mesmo com intent pendente', () => {
+    const submit = vi.fn();
+    const { result, rerender } = renderHook(
+      ({ online, hasContent }: { online: boolean; hasContent: boolean }) =>
+        useOfflineSubmit({ submit, online, hasContent }),
+      { initialProps: { online: false, hasContent: true } },
+    );
+    act(() => result.current.onSubmit());
+    rerender({ online: true, hasContent: false });
+    expect(result.current.showReconnectCta).toBe(false);
+  });
+});

--- a/src/hooks/useOfflineSubmit.ts
+++ b/src/hooks/useOfflineSubmit.ts
@@ -1,0 +1,53 @@
+import { useState, useCallback } from 'react';
+import { toast } from 'sonner';
+
+export interface UseOfflineSubmitOptions {
+  /** Envio online real (ex: h.submitOrder). */
+  submit: () => void | Promise<void>;
+  /** Estado de rede (de useNetworkStatus). */
+  online: boolean;
+  /** Há conteúdo a enviar (cart > 0)? Gate o CTA de reconexão. */
+  hasContent: boolean;
+}
+
+export interface UseOfflineSubmitReturn {
+  /** Handler do botão de envio: offline → marca pendente + toast; online → submit(). */
+  onSubmit: () => void;
+  /** True quando offline (pra UI do botão). */
+  offline: boolean;
+  /** Mostra o banner de reconexão (online + intent offline pendente + tem conteúdo). */
+  showReconnectCta: boolean;
+  /** Handler do CTA "Enviar agora": limpa pendente + submit(). */
+  onReconnectSubmit: () => void;
+}
+
+/**
+ * Gate offline-first para o envio de pedido. Não enfileira (submitOrder cria PV cobrado
+ * no Omie, não-idempotente). Offline: salva intent pendente + avisa (o rascunho já é
+ * auto-salvo pelo useOrderDraft). Online de novo: expõe CTA pra enviar de verdade.
+ */
+export function useOfflineSubmit({ submit, online, hasContent }: UseOfflineSubmitOptions): UseOfflineSubmitReturn {
+  const [pending, setPending] = useState(false);
+
+  const onSubmit = useCallback(() => {
+    if (!online) {
+      setPending(true);
+      toast.info('Sem conexão — salvo como rascunho. Enviaremos quando reconectar.');
+      return;
+    }
+    setPending(false);
+    void submit();
+  }, [online, submit]);
+
+  const onReconnectSubmit = useCallback(() => {
+    setPending(false);
+    void submit();
+  }, [submit]);
+
+  return {
+    onSubmit,
+    offline: !online,
+    showReconnectCta: online && pending && hasContent,
+    onReconnectSubmit,
+  };
+}

--- a/src/pages/UnifiedOrder.tsx
+++ b/src/pages/UnifiedOrder.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { Loader2, ChevronLeft, CheckCircle, Building2, Scissors } from 'lucide-react';
+import { Loader2, ChevronLeft, CheckCircle, Building2, Scissors, Wifi } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { track } from '@/lib/analytics';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -13,6 +13,9 @@ import { useUnifiedOrder } from '@/hooks/useUnifiedOrder';
 import { useOrderDeepLink } from '@/hooks/useOrderDeepLink';
 import { useOrderDraft } from '@/hooks/useOrderDraft';
 import { useAuth } from '@/contexts/AuthContext';
+import { Button } from '@/components/ui/button';
+import { useNetworkStatus } from '@/hooks/useNetworkStatus';
+import { useOfflineSubmit } from '@/hooks/useOfflineSubmit';
 import { RestoreDraftDialog } from '@/components/unified-order/RestoreDraftDialog';
 import { CustomerSearch } from '@/components/unified-order/CustomerSearch';
 import { ProductItemForm } from '@/components/unified-order/ProductItemForm';
@@ -75,6 +78,15 @@ const UnifiedOrder = () => {
     state: draftPayload,
     shouldSave: h.cart.length > 0,
     clearTrigger: h.orderSuccessOpen, // limpa quando o success dialog abrir = pedido enviado
+  });
+
+  // Gate offline-first do envio: offline salva rascunho (já auto-salvo acima) e expõe
+  // CTA de reconexão; nunca enfileira (submitOrder cria PV cobrado no Omie).
+  const net = useNetworkStatus();
+  const offlineSubmit = useOfflineSubmit({
+    submit: h.submitOrder,
+    online: net.online,
+    hasContent: h.cart.length > 0,
   });
 
   // Oferece restore se houver draft pendente E o cart atual estiver vazio (entrou novo na tela).
@@ -141,6 +153,18 @@ const UnifiedOrder = () => {
       </div>
 
       <OrderStepper step={h.currentStep} isCustomerMode={isCustomerMode} />
+
+      {offlineSubmit.showReconnectCta && (
+        <div className="rounded-md border border-status-info-bold/30 bg-status-info-bg px-4 py-3 mb-4 flex flex-col sm:flex-row sm:items-center justify-between gap-3">
+          <div className="flex items-center gap-2 text-sm text-status-info-bold">
+            <Wifi className="w-4 h-4 shrink-0" />
+            Conexão restabelecida. Seu pedido está salvo como rascunho.
+          </div>
+          <Button size="sm" onClick={offlineSubmit.onReconnectSubmit} disabled={h.submitting} className="shrink-0">
+            Enviar pedido agora
+          </Button>
+        </div>
+      )}
 
       <div className={cn('grid gap-4', showProductTabs ? 'grid-cols-1 lg:grid-cols-3' : 'grid-cols-1 lg:grid-cols-3')}>
         <div className={cn(showProductTabs ? 'lg:col-span-2' : 'lg:col-span-2', 'space-y-4')}>
@@ -277,8 +301,9 @@ const UnifiedOrder = () => {
               ordemCompra={h.ordemCompra} setOrdemCompra={h.setOrdemCompra}
               isOrdemCompraCustomer={h.isOrdemCompraCustomer}
               readyByDate={h.readyByDate} setReadyByDate={h.setReadyByDate}
-              onSubmit={h.submitOrder}
+              onSubmit={offlineSubmit.onSubmit}
               onSubmitQuote={h.submitQuote}
+              offline={offlineSubmit.offline}
             />
           )}
         </div>


### PR DESCRIPTION
## Contexto

PR2 do programa offline-first (PR1 = picking + optimistic + fix de loop, #250). Atende a persona "vendedor externo no carro, frequente offline" (briefing / CLAUDE.md §6 item 1). Spec/plan em `docs/superpowers/{specs,plans}/2026-05-24-offline-order-submit*`. Arquitetura validada pelo codex no PR1.

## O que muda

- **`src/hooks/useOfflineSubmit.ts` (novo, 5 testes)** — gate em volta de `h.submitOrder`:
  - **offline** → marca intent pendente + toast "Sem conexão — salvo como rascunho"; **NÃO** chama `submitOrder`.
  - **online** → envia normal.
  - reconectou + intent pendente + carrinho não-vazio → `showReconnectCta`.
  - `onReconnectSubmit` → envia e limpa o pendente.
- **`CartSummaryBar`** — prop `offline`: botão vira "Sem conexão — salvar rascunho" (ícone `CloudOff`) quando offline; validações de negócio (`disableSubmit`) mantidas.
- **`UnifiedOrder`** — `useNetworkStatus` + o hook; banner de reconexão `bg-status-info` com CTA "Enviar pedido agora"; passa `onSubmit`(gate) + `offline` pro `CartSummaryBar`.

## Por que NÃO enfileira

`submitOrder` cria **PV cobrado no Omie** via `omie-vendas-sync`, que monta `codigo_pedido_integracao = PV_${id}_${Date.now()}` (sem idempotência) — replay offline→online **duplicaria pedido/PV no ERP**. O recibo depende dos números de PV que o Omie devolve (não existem offline). Logo: rascunho-first, commit só online. `submitOrder`/Omie **inalterados**, **sem migration**.

## Fora de escopo (follow-up)

- Cross-sessão: persistir entrega/pagamento/volumes/ready-date no rascunho + restaurá-los (enviar após fechar/reabrir offline). Hoje cobre **mesma sessão** (app aberto, sinal cai e volta), que é o caso real; o rascunho atual (cart/cliente/notes) é o backstop pra "fechou o app".
- Detecção de rede por timeout/heartbeat; `submitQuote` offline.

## Test plan

- [x] vitest: `useOfflineSubmit` 5/5; suíte completa passa (as 12 falhas vistas num run foram flakes de CPU saturada — todas passam isoladas, 53/53)
- [x] `bun run build` exit 0 (compila UnifiedOrder/CartSummaryBar/hook); lint dos arquivos tocados limpo
- [x] `typecheck:strict` não aplicável (nenhum arquivo do PR2 está no `tsconfig.strict.json`; build cobre a corretude de tipos)
- [ ] **QA manual (founder):** UnifiedOrder com cliente + itens → DevTools Offline → botão "Sem conexão — salvar rascunho" → clicar → toast (não abre success, não chama Omie) → reconectar → banner "Enviar pedido agora" → clicar → pedido criado normal. + `/design-review` nos estados offline/banner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)