### PR TITLE
refactor(sales): split SalesOrders (654→144) em hook + componentes

### DIFF
--- a/src/components/salesOrders/SalesOrderCard.tsx
+++ b/src/components/salesOrders/SalesOrderCard.tsx
@@ -1,0 +1,148 @@
+// Card de um pedido (venda ou afiação) na listagem.
+// Extraído verbatim de src/pages/SalesOrders.tsx (god-component split).
+import { Card, CardContent } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Button } from '@/components/ui/button';
+import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, AlertDialogTrigger } from '@/components/ui/alert-dialog';
+import { Trash2, Share2, Pencil } from 'lucide-react';
+import { format } from 'date-fns';
+import { ptBR } from 'date-fns/locale';
+import { StatusBadgeSimple } from '@/components/StatusBadge';
+import type { OrderStatus } from '@/types';
+import { statusLabels, type SalesOrder } from './types';
+
+interface SalesOrderCardProps {
+  order: SalesOrder;
+  customerName: string;
+  checked: boolean;
+  onSelectChange: (checked: boolean) => void;
+  onShare: () => void;
+  onDelete: () => void;
+  onNavigate: (path: string) => void;
+}
+
+export function SalesOrderCard({
+  order,
+  customerName,
+  checked,
+  onSelectChange,
+  onShare,
+  onDelete,
+  onNavigate,
+}: SalesOrderCardProps) {
+  const isAfiacao = order._source === 'afiacao';
+  const status = statusLabels[order.status] || statusLabels.rascunho;
+  const totalItems = order.items?.reduce((s, i) => s + (i.quantidade || 0), 0) || 0;
+  // Afiação opera sob Colacor SC. Card sempre mostra a empresa (Oben/Colacor/SC)
+  // e, quando for pedido de afiação, um badge secundário "Afiação" pra distinguir
+  // serviço de pedido comercial. Antes mostrava só "Afiação" e perdia a empresa.
+  const orderAccount = isAfiacao ? 'colacor_sc' : (order.account || 'oben');
+  const accountLabel = orderAccount === 'colacor_sc'
+    ? 'Colacor SC'
+    : orderAccount === 'colacor'
+      ? 'Colacor'
+      : 'Oben';
+  const isSelectable = !isAfiacao; // só sales_orders são bulk-deletáveis
+
+  return (
+    <Card className={`cursor-pointer hover:bg-muted/30 transition-colors ${checked ? 'ring-2 ring-foreground/20' : ''}`} onClick={() => isAfiacao ? onNavigate(`/orders/${order.id}`) : undefined}>
+      <CardContent className="p-3">
+        <div className="flex items-start justify-between gap-2">
+          {isSelectable && (
+            <Checkbox
+              checked={checked}
+              onClick={(e) => e.stopPropagation()}
+              onCheckedChange={(v) => onSelectChange(!!v)}
+              className="mt-0.5"
+            />
+          )}
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-1.5 flex-wrap">
+              <p className="font-medium text-sm truncate">
+                {customerName}
+              </p>
+              <Badge variant="outline" className="text-[9px] px-1 py-0 shrink-0">
+                {accountLabel}
+              </Badge>
+              {/* Badge secundário pra distinguir serviço de afiação dentro de SC */}
+              {isAfiacao && (
+                <Badge variant="outline" className="text-[9px] px-1 py-0 shrink-0 bg-muted/50 text-muted-foreground border-dashed">
+                  Afiação
+                </Badge>
+              )}
+            </div>
+            <p className="text-xs text-muted-foreground mt-0.5">
+              {format(new Date(order.created_at), "dd/MM/yyyy 'às' HH:mm", { locale: ptBR })}
+            </p>
+            {order.omie_numero_pedido && (
+              <p className="text-xs text-muted-foreground">
+                PV: <span className="font-tabular text-foreground">{order.omie_numero_pedido.replace(/^0+/, '') || '0'}</span>
+              </p>
+            )}
+          </div>
+          <div className="text-right shrink-0 space-y-1">
+            {isAfiacao ? (
+              <StatusBadgeSimple status={order.status as OrderStatus} size="sm" />
+            ) : (
+              <Badge variant={status.variant}>{status.label}</Badge>
+            )}
+            <p className="text-sm font-bold">R$ {order.total.toFixed(2)}</p>
+            <p className="text-xs text-muted-foreground">{totalItems} itens</p>
+            <div className="flex gap-1 justify-end">
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-7 w-7"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onShare();
+                }}
+                title="Compartilhar via WhatsApp"
+              >
+                <Share2 className="w-3.5 h-3.5" />
+              </Button>
+              {!isAfiacao && !['cancelado', 'entregue', 'faturado'].includes(order.status) && (
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-7 w-7"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onNavigate(`/sales/edit/${order.id}`);
+                  }}
+                  title="Editar pedido"
+                >
+                  <Pencil className="w-3.5 h-3.5" />
+                </Button>
+              )}
+              {!isAfiacao && (
+                <AlertDialog>
+                  <AlertDialogTrigger asChild>
+                    <Button variant="ghost" size="icon" className="h-7 w-7 text-destructive hover:text-destructive" onClick={(e) => e.stopPropagation()}>
+                      <Trash2 className="w-3.5 h-3.5" />
+                    </Button>
+                  </AlertDialogTrigger>
+                  <AlertDialogContent>
+                    <AlertDialogHeader>
+                      <AlertDialogTitle>Excluir pedido?</AlertDialogTitle>
+                      <AlertDialogDescription>
+                        Esta ação não pode ser desfeita. O pedido será removido permanentemente do sistema.
+                      </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                      <AlertDialogCancel>Cancelar</AlertDialogCancel>
+                      <AlertDialogAction onClick={onDelete} className="bg-destructive text-destructive-foreground hover:bg-destructive/90">
+                        Excluir
+                      </AlertDialogAction>
+                    </AlertDialogFooter>
+                  </AlertDialogContent>
+                </AlertDialog>
+              )}
+            </div>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/salesOrders/SalesOrdersToolbar.tsx
+++ b/src/components/salesOrders/SalesOrdersToolbar.tsx
@@ -1,0 +1,73 @@
+// Toolbar da listagem de pedidos: ações + filtro de empresa + busca.
+// Extraída verbatim de src/pages/SalesOrders.tsx (god-component split).
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Plus, Package, Printer, Building2, Search } from 'lucide-react';
+import { type Account } from './types';
+
+interface SalesOrdersToolbarProps {
+  onNavigate: (path: string) => void;
+  accountFilter: Account;
+  setAccountFilter: (a: Account) => void;
+  search: string;
+  setSearch: (v: string) => void;
+}
+
+export function SalesOrdersToolbar({
+  onNavigate,
+  accountFilter,
+  setAccountFilter,
+  search,
+  setSearch,
+}: SalesOrdersToolbarProps) {
+  return (
+    <>
+      <div className="flex gap-2">
+        <Button onClick={() => onNavigate('/sales/new')} className="gap-2 flex-1">
+          <Plus className="w-4 h-4" />
+          Novo Pedido
+        </Button>
+        <Button variant="outline" onClick={() => onNavigate('/sales/products')} className="gap-2">
+          <Package className="w-4 h-4" />
+          Catálogo
+        </Button>
+        <Button variant="outline" onClick={() => onNavigate('/sales/print')} className="gap-2">
+          <Printer className="w-4 h-4" />
+          Imprimir
+        </Button>
+      </div>
+
+      {/* Account Filter — 3 empresas reais + Todos. Afiação foi unificada
+          em Colacor SC (módulo, não empresa). Cada card preserva o badge
+          "Afiação" quando _source='afiacao' pra distinção visual. */}
+      <Tabs value={accountFilter} onValueChange={(v) => setAccountFilter(v as Account)}>
+        <TabsList className="w-full grid grid-cols-4">
+          <TabsTrigger value="all">Todos</TabsTrigger>
+          <TabsTrigger value="oben" className="gap-1">
+            <Building2 className="w-3 h-3" />
+            Oben
+          </TabsTrigger>
+          <TabsTrigger value="colacor" className="gap-1">
+            <Building2 className="w-3 h-3" />
+            Colacor
+          </TabsTrigger>
+          <TabsTrigger value="colacor_sc" className="gap-1">
+            <Building2 className="w-3 h-3" />
+            Colacor SC
+          </TabsTrigger>
+        </TabsList>
+      </Tabs>
+
+      <div className="relative">
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
+        <Input
+          placeholder="Buscar por cliente, nº pedido ou item..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="pl-9"
+        />
+      </div>
+    </>
+  );
+}

--- a/src/components/salesOrders/__tests__/SalesOrderCard.test.tsx
+++ b/src/components/salesOrders/__tests__/SalesOrderCard.test.tsx
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { SalesOrderCard } from '../SalesOrderCard';
+import type { SalesOrder } from '../types';
+
+function order(p: Partial<SalesOrder> = {}): SalesOrder {
+  return {
+    id: 'o1',
+    customer_user_id: 'u1',
+    items: [{ descricao: 'Verniz', quantidade: 2, valor_unitario: 50, valor_total: 100 }],
+    subtotal: 100,
+    total: 100,
+    status: 'enviado',
+    omie_numero_pedido: '000123',
+    omie_pedido_id: 9,
+    created_at: '2026-05-20T10:00:00Z',
+    notes: null,
+    account: 'oben',
+    _source: 'sales',
+    ...p,
+  };
+}
+
+function setup(o: SalesOrder, overrides: Partial<React.ComponentProps<typeof SalesOrderCard>> = {}) {
+  const props: React.ComponentProps<typeof SalesOrderCard> = {
+    order: o,
+    customerName: 'ACME Ltda',
+    checked: false,
+    onSelectChange: vi.fn(),
+    onShare: vi.fn(),
+    onDelete: vi.fn(),
+    onNavigate: vi.fn(),
+    ...overrides,
+  };
+  render(<SalesOrderCard {...props} />);
+  return props;
+}
+
+describe('SalesOrderCard (sales)', () => {
+  it('renderiza cliente, empresa, status, total, itens e PV', () => {
+    setup(order());
+    expect(screen.getByText('ACME Ltda')).toBeTruthy();
+    expect(screen.getByText('Oben')).toBeTruthy();
+    expect(screen.getByText('Enviado ao Omie')).toBeTruthy();
+    expect(screen.getByText('R$ 100.00')).toBeTruthy();
+    expect(screen.getByText('2 itens')).toBeTruthy();
+    expect(screen.getByText('123')).toBeTruthy(); // PV sem zeros à esquerda
+  });
+
+  it('checkbox dispara onSelectChange sem navegar', () => {
+    const props = setup(order());
+    fireEvent.click(screen.getByRole('checkbox'));
+    expect(props.onSelectChange).toHaveBeenCalledWith(true);
+    expect(props.onNavigate).not.toHaveBeenCalled();
+  });
+
+  it('botões de compartilhar e editar disparam os handlers', () => {
+    const props = setup(order());
+    fireEvent.click(screen.getByTitle('Compartilhar via WhatsApp'));
+    fireEvent.click(screen.getByTitle('Editar pedido'));
+    expect(props.onShare).toHaveBeenCalledTimes(1);
+    expect(props.onNavigate).toHaveBeenCalledWith('/sales/edit/o1');
+  });
+
+  it('confirmar exclusão dispara onDelete', () => {
+    const props = setup(order());
+    // abre o AlertDialog pelo botão de lixeira (último botão do card)
+    const buttons = screen.getAllByRole('button');
+    fireEvent.click(buttons[buttons.length - 1]);
+    fireEvent.click(screen.getByRole('button', { name: 'Excluir' }));
+    expect(props.onDelete).toHaveBeenCalledTimes(1);
+  });
+
+  it('não mostra editar quando status é faturado', () => {
+    setup(order({ status: 'faturado' }));
+    expect(screen.queryByTitle('Editar pedido')).toBeNull();
+  });
+});
+
+describe('SalesOrderCard (afiação)', () => {
+  it('mostra badges Colacor SC + Afiação e navega ao clicar no card', () => {
+    const props = setup(order({ _source: 'afiacao', account: 'afiacao', status: 'em_afiacao' }));
+    expect(screen.getByText('Colacor SC')).toBeTruthy();
+    expect(screen.getByText('Afiação')).toBeTruthy();
+    expect(screen.queryByRole('checkbox')).toBeNull(); // não selecionável
+    fireEvent.click(screen.getByText('ACME Ltda'));
+    expect(props.onNavigate).toHaveBeenCalledWith('/orders/o1');
+  });
+});

--- a/src/components/salesOrders/__tests__/SalesOrdersToolbar.test.tsx
+++ b/src/components/salesOrders/__tests__/SalesOrdersToolbar.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { SalesOrdersToolbar } from '../SalesOrdersToolbar';
+
+function setup(overrides: Partial<React.ComponentProps<typeof SalesOrdersToolbar>> = {}) {
+  const props: React.ComponentProps<typeof SalesOrdersToolbar> = {
+    onNavigate: vi.fn(),
+    accountFilter: 'all',
+    setAccountFilter: vi.fn(),
+    search: '',
+    setSearch: vi.fn(),
+    ...overrides,
+  };
+  render(<SalesOrdersToolbar {...props} />);
+  return props;
+}
+
+describe('SalesOrdersToolbar', () => {
+  it('navega para novo pedido, catálogo e imprimir', () => {
+    const props = setup();
+    fireEvent.click(screen.getByRole('button', { name: /Novo Pedido/ }));
+    fireEvent.click(screen.getByRole('button', { name: /Catálogo/ }));
+    fireEvent.click(screen.getByRole('button', { name: /Imprimir/ }));
+    expect(props.onNavigate).toHaveBeenCalledWith('/sales/new');
+    expect(props.onNavigate).toHaveBeenCalledWith('/sales/products');
+    expect(props.onNavigate).toHaveBeenCalledWith('/sales/print');
+  });
+
+  it('dispara setSearch ao digitar', () => {
+    const props = setup();
+    fireEvent.change(screen.getByPlaceholderText(/Buscar por cliente/), { target: { value: 'acme' } });
+    expect(props.setSearch).toHaveBeenCalledWith('acme');
+  });
+
+  it('renderiza as 4 abas de empresa', () => {
+    setup();
+    expect(screen.getByRole('tab', { name: 'Todos' })).toBeTruthy();
+    expect(screen.getByRole('tab', { name: /Oben/ })).toBeTruthy();
+    expect(screen.getByRole('tab', { name: /Colacor SC/ })).toBeTruthy();
+  });
+});

--- a/src/components/salesOrders/__tests__/types.test.ts
+++ b/src/components/salesOrders/__tests__/types.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { decodeHtml, statusLabels } from '../types';
+
+describe('decodeHtml', () => {
+  it('decodifica entidades HTML comuns', () => {
+    expect(decodeHtml('Tintas &amp; Vernizes')).toBe('Tintas & Vernizes');
+    expect(decodeHtml('&lt;b&gt;')).toBe('<b>');
+    expect(decodeHtml('O&apos;Brien')).toBe("O'Brien");
+    expect(decodeHtml('&quot;x&quot;')).toBe('"x"');
+  });
+  it('deixa texto sem entidades intacto', () => {
+    expect(decodeHtml('ACME Ltda')).toBe('ACME Ltda');
+  });
+});
+
+describe('statusLabels', () => {
+  it('mapeia status conhecidos', () => {
+    expect(statusLabels.enviado.label).toBe('Enviado ao Omie');
+    expect(statusLabels.cancelado.variant).toBe('destructive');
+  });
+});

--- a/src/components/salesOrders/types.ts
+++ b/src/components/salesOrders/types.ts
@@ -1,0 +1,63 @@
+// Tipos + constantes + helpers da listagem de pedidos de venda.
+// Extraídos verbatim de src/pages/SalesOrders.tsx (god-component split).
+import type { InfiniteData } from '@tanstack/react-query';
+import type { Tables } from '@/integrations/supabase/types';
+
+export type SalesOrderRow = Tables<'sales_orders'>;
+export type AfiacaoOrderRow = Tables<'orders'>;
+export type ProfileRow = Tables<'profiles'>;
+
+// Shape de cada item dentro de orders.items (jsonb). Só os campos consumidos aqui.
+export interface AfiacaoItemRaw {
+  category?: string | null;
+  name?: string | null;
+  quantity?: number | null;
+  unitPrice?: number | null;
+}
+
+// 3 empresas reais (oben, colacor, colacor_sc) + 'all'. Afiação NÃO é empresa,
+// é um módulo operando sob Colacor SC — pedidos da tabela `orders` (afiação)
+// aparecem dentro da aba "Colacor SC" junto com os pedidos comerciais
+// `sales_orders WHERE account='colacor_sc'`. Cada card mantém badge "Afiação"
+// quando _source='afiacao' pra preservar a distinção visual.
+export type Account = 'oben' | 'colacor' | 'colacor_sc' | 'all';
+
+export const PAGE_SIZE = 50;
+
+export const decodeHtml = (s: string): string =>
+  s
+    .replace(/&amp;/g, '&')
+    .replace(/&apos;/g, "'")
+    .replace(/&quot;/g, '"')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>');
+
+export interface SalesOrder {
+  id: string;
+  customer_user_id: string;
+  items: Array<{ descricao: string; quantidade: number; valor_unitario: number; valor_total: number }>;
+  subtotal: number;
+  total: number;
+  status: string;
+  omie_numero_pedido: string | null;
+  omie_pedido_id: number | null;
+  created_at: string;
+  notes: string | null;
+  account?: string;
+  _source?: 'sales' | 'afiacao';
+}
+
+// Cache do useInfiniteQuery de sales_orders — usado nos rollbacks optimistic.
+export type SalesOrdersInfiniteCache = InfiniteData<SalesOrder[]>;
+
+export const statusLabels: Record<string, { label: string; variant: 'default' | 'secondary' | 'destructive' | 'outline' }> = {
+  rascunho: { label: 'Rascunho', variant: 'outline' },
+  enviado: { label: 'Enviado ao Omie', variant: 'default' },
+  faturado: { label: 'Faturado', variant: 'secondary' },
+  cancelado: { label: 'Cancelado', variant: 'destructive' },
+  recebido: { label: 'Recebido', variant: 'default' },
+  em_analise: { label: 'Em Análise', variant: 'default' },
+  em_producao: { label: 'Em Produção', variant: 'default' },
+  pronto: { label: 'Pronto', variant: 'secondary' },
+  entregue: { label: 'Entregue', variant: 'secondary' },
+};

--- a/src/components/salesOrders/useSalesOrders.ts
+++ b/src/components/salesOrders/useSalesOrders.ts
@@ -1,0 +1,369 @@
+// Lógica da listagem de pedidos de venda (queries paginadas, merge, optimistic delete).
+// Extraída verbatim de src/pages/SalesOrders.tsx (god-component split).
+import { useState, useEffect, useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useInfiniteQuery, useQuery, useQueryClient } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import { useAuth } from '@/contexts/AuthContext';
+import { toast } from 'sonner';
+import { shareOrderViaWhatsApp } from '@/utils/whatsappShare';
+import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
+import {
+  PAGE_SIZE,
+  decodeHtml,
+  type Account,
+  type SalesOrder,
+  type SalesOrderRow,
+  type AfiacaoOrderRow,
+  type ProfileRow,
+  type AfiacaoItemRaw,
+  type SalesOrdersInfiniteCache,
+} from './types';
+
+export function useSalesOrders() {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const { isStaff, loading: authLoading, role } = useAuth();
+  const [accountFilter, setAccountFilter] = useState<Account>('all');
+  const [search, setSearch] = useState('');
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    if (!authLoading && role !== null && !isStaff) navigate('/', { replace: true });
+  }, [authLoading, role, isStaff, navigate]);
+
+  /* ─── Sales orders: infinite query (50 por página) ─── */
+  const salesQuery = useInfiniteQuery({
+    queryKey: ['sales-orders-paginated'],
+    enabled: isStaff,
+    initialPageParam: 0,
+    queryFn: async ({ pageParam }) => {
+      const start = (pageParam as number) * PAGE_SIZE;
+      const { data, error } = await supabase
+        .from('sales_orders')
+        .select('*')
+        // Filtra soft-deletes (deleted_at IS NOT NULL = pedido excluído).
+        // Usa partial index idx_sales_orders_active em deleted_at IS NULL.
+        .is('deleted_at', null)
+        .order('created_at', { ascending: false })
+        .range(start, start + PAGE_SIZE - 1);
+      if (error) throw error;
+      return ((data || []) as SalesOrderRow[]).map((o) => ({
+        ...o,
+        _source: 'sales' as const,
+      })) as unknown as SalesOrder[];
+    },
+    getNextPageParam: (lastPage, allPages) =>
+      lastPage.length === PAGE_SIZE ? allPages.length : undefined,
+  });
+
+  /* ─── Afiação orders: infinite query (50 por página) ─── */
+  const afiacaoQuery = useInfiniteQuery({
+    queryKey: ['afiacao-orders-paginated'],
+    enabled: isStaff,
+    initialPageParam: 0,
+    queryFn: async ({ pageParam }) => {
+      const start = (pageParam as number) * PAGE_SIZE;
+      const { data, error } = await supabase
+        .from('orders')
+        .select('*')
+        .order('created_at', { ascending: false })
+        .range(start, start + PAGE_SIZE - 1);
+      if (error) throw error;
+      return ((data || []) as AfiacaoOrderRow[]).map((o) => {
+        const rawItems = Array.isArray(o.items) ? (o.items as unknown as AfiacaoItemRaw[]) : [];
+        return {
+          id: o.id,
+          customer_user_id: o.user_id,
+          items: rawItems.map((i) => ({
+            descricao: i.category || i.name || 'Afiação',
+            quantidade: i.quantity || 1,
+            valor_unitario: i.unitPrice || 0,
+            valor_total: (i.quantity || 1) * (i.unitPrice || 0),
+          })),
+          subtotal: o.subtotal || o.total || 0,
+          total: o.total || 0,
+          status: o.status,
+          omie_numero_pedido: null,
+          omie_pedido_id: null,
+          created_at: o.created_at,
+          notes: o.notes,
+          account: 'afiacao',
+          _source: 'afiacao' as const,
+        };
+      }) as SalesOrder[];
+    },
+    getNextPageParam: (lastPage, allPages) =>
+      lastPage.length === PAGE_SIZE ? allPages.length : undefined,
+  });
+
+  /* ─── Lista mergeada ─── */
+  const orders = useMemo<SalesOrder[]>(() => {
+    const sales = salesQuery.data?.pages.flat() || [];
+    const afiacao = afiacaoQuery.data?.pages.flat() || [];
+    return [...sales, ...afiacao].sort(
+      (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
+    );
+  }, [salesQuery.data, afiacaoQuery.data]);
+
+  /* ─── Profiles (nomes dos clientes) ─── */
+  const customerIds = useMemo(() => [...new Set(orders.map((o) => o.customer_user_id))], [orders]);
+  const profilesQuery = useQuery({
+    queryKey: ['sales-orders-profiles', customerIds.sort().join(',')],
+    enabled: isStaff && customerIds.length > 0,
+    staleTime: 60_000,
+    queryFn: async () => {
+      const { data } = await supabase
+        .from('profiles')
+        .select('user_id, name')
+        .in('user_id', customerIds);
+      const map: Record<string, string> = {};
+      ((data || []) as Pick<ProfileRow, 'user_id' | 'name'>[]).forEach((p) => {
+        map[p.user_id] = p.name ?? '';
+      });
+      return map;
+    },
+  });
+  const profiles = profilesQuery.data || {};
+
+  /* ─── Infinite scroll: dispara fetchNextPage de quem ainda tem páginas ─── */
+  const hasNext = !!salesQuery.hasNextPage || !!afiacaoQuery.hasNextPage;
+  const isFetching = salesQuery.isFetchingNextPage || afiacaoQuery.isFetchingNextPage;
+  const sentinelRef = useInfiniteScroll(
+    () => {
+      if (salesQuery.hasNextPage && !salesQuery.isFetchingNextPage) salesQuery.fetchNextPage();
+      if (afiacaoQuery.hasNextPage && !afiacaoQuery.isFetchingNextPage) afiacaoQuery.fetchNextPage();
+    },
+    hasNext && !isFetching,
+  );
+
+  const loadMore = () => {
+    if (salesQuery.hasNextPage) salesQuery.fetchNextPage();
+    if (afiacaoQuery.hasNextPage) afiacaoQuery.fetchNextPage();
+  };
+
+  const loading = salesQuery.isLoading || afiacaoQuery.isLoading;
+
+  // Soft-delete + Omie exclude. Fluxo:
+  // 1. Optimistic remove do cache (UI atualiza instantaneamente)
+  // 2. UPDATE sales_orders SET deleted_at = now() (audit trail compliance)
+  // 3. Call Omie excluir_pedido
+  // 4. Se Omie falhar: rollback do soft-delete + restaura cache
+  // 5. Se Supabase update falhar: rollback do cache, NÃO chama Omie
+  const deleteOrder = async (order: SalesOrder) => {
+    const snapshot = queryClient.getQueryData<SalesOrdersInfiniteCache>(['sales-orders-paginated']);
+    queryClient.setQueryData<SalesOrdersInfiniteCache>(['sales-orders-paginated'], (old) => {
+      if (!old) return old;
+      return {
+        ...old,
+        pages: old.pages.map((page) => page.filter((o) => o.id !== order.id)),
+      };
+    });
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      next.delete(order.id);
+      return next;
+    });
+
+    // 1. Soft-delete local primeiro (audit trail antes do Omie)
+    // `deleted_at` existe no DB mas ainda não no generated Database type — cast as never
+    const { error: softErr } = await supabase
+      .from('sales_orders')
+      .update({ deleted_at: new Date().toISOString() } as never)
+      .eq('id', order.id);
+
+    if (softErr) {
+      console.error(softErr);
+      queryClient.setQueryData(['sales-orders-paginated'], snapshot);
+      toast.error('Erro ao excluir pedido', { description: softErr.message });
+      return;
+    }
+
+    // 2. Omie exclude — se falhar, rollback do soft-delete
+    try {
+      const { error } = await supabase.functions.invoke('omie-vendas-sync', {
+        body: {
+          action: 'excluir_pedido',
+          sales_order_id: order.id,
+          omie_pedido_id: order.omie_pedido_id,
+        },
+      });
+      if (error) throw error;
+      toast.success('Pedido excluído');
+    } catch (e) {
+      console.error(e);
+      // Rollback do soft-delete (deleted_at = null) — pedido volta a ser ativo
+      await supabase
+        .from('sales_orders')
+        .update({ deleted_at: null } as never)
+        .eq('id', order.id);
+      queryClient.setQueryData(['sales-orders-paginated'], snapshot);
+      toast.error('Erro ao excluir pedido', {
+        description: e instanceof Error ? e.message : String(e),
+      });
+    }
+  };
+
+  // Bulk delete — sequencial pra não floodar o Omie. Mostra progresso.
+  const deleteSelected = async () => {
+    if (selectedIds.size === 0) return;
+    const toDelete = orders.filter((o) => selectedIds.has(o.id) && o._source === 'sales');
+    const snapshot = queryClient.getQueryData<SalesOrdersInfiniteCache>(['sales-orders-paginated']);
+    const deleteIds = new Set(toDelete.map((o) => o.id));
+    queryClient.setQueryData<SalesOrdersInfiniteCache>(['sales-orders-paginated'], (old) => {
+      if (!old) return old;
+      return {
+        ...old,
+        pages: old.pages.map((page) => page.filter((o) => !deleteIds.has(o.id))),
+      };
+    });
+    setSelectedIds(new Set());
+
+    // 1. Soft-delete em batch (1 UPDATE com .in('id', ...))
+    const nowIso = new Date().toISOString();
+    const { error: softErr } = await supabase
+      .from('sales_orders')
+      .update({ deleted_at: nowIso } as never)
+      .in('id', Array.from(deleteIds));
+
+    if (softErr) {
+      console.error(softErr);
+      queryClient.setQueryData(['sales-orders-paginated'], snapshot);
+      toast.error(`Erro ao excluir pedidos`, { description: softErr.message });
+      return;
+    }
+
+    // 2. Omie exclude sequencial (não floodar). Rollback do deleted_at em falhas.
+    const failedIds: string[] = [];
+    let success = 0;
+    for (const o of toDelete) {
+      try {
+        const { error } = await supabase.functions.invoke('omie-vendas-sync', {
+          body: {
+            action: 'excluir_pedido',
+            sales_order_id: o.id,
+            omie_pedido_id: o.omie_pedido_id,
+          },
+        });
+        if (error) throw error;
+        success++;
+      } catch (e) {
+        failedIds.push(o.id);
+        console.error(e);
+      }
+    }
+    const failed = failedIds.length;
+
+    // Rollback do soft-delete só pros que falharam no Omie
+    if (failedIds.length > 0) {
+      await supabase
+        .from('sales_orders')
+        .update({ deleted_at: null } as never)
+        .in('id', failedIds);
+    }
+
+    if (failed === 0) {
+      toast.success(`${success} pedido(s) excluído(s)`);
+    } else if (success === 0) {
+      queryClient.setQueryData(['sales-orders-paginated'], snapshot); // rollback completo
+      toast.error(`Falhou: ${failed} pedido(s) não puderam ser excluídos`);
+    } else {
+      // Parcial — restaura os que falharam no cache (já temos deleted_at=null no DB)
+      const failedSet = new Set(failedIds);
+      queryClient.setQueryData<SalesOrdersInfiniteCache>(['sales-orders-paginated'], (old) => {
+        if (!old || !snapshot) return old;
+        // Pega as rows que falharam do snapshot original e reinjeta na primeira página
+        const failedRows = snapshot.pages
+          .flat()
+          .filter((o) => failedSet.has(o.id));
+        return {
+          ...old,
+          pages: old.pages.map((page, i) =>
+            i === 0 ? [...failedRows, ...page] : page,
+          ),
+        };
+      });
+      toast.warning(`${success} excluído(s), ${failed} falharam`);
+    }
+  };
+
+  const handleShareOrder = (order: SalesOrder, customerName: string) => {
+    const items = (order.items || []).map(item => ({
+      description: item.descricao,
+      quantity: item.quantidade,
+      unitPrice: item.valor_unitario,
+    }));
+
+    const orderNumbers = order.omie_numero_pedido ? [order.omie_numero_pedido.replace(/^0+/, '') || '0'] : [];
+
+    shareOrderViaWhatsApp({
+      customerName,
+      items,
+      total: order.total,
+      orderNumbers,
+      date: new Date(order.created_at),
+    });
+  };
+
+  const filteredOrders = useMemo(() => {
+    // Colacor SC engloba: (a) pedidos comerciais com account='colacor_sc' E
+    // (b) pedidos de afiação (que operam sob a entidade SC). Afiação não é tab
+    // separada, é serviço da Colacor SC.
+    let result = accountFilter === 'all'
+      ? orders
+      : accountFilter === 'colacor_sc'
+        ? orders.filter(o => o._source === 'afiacao' || (o._source === 'sales' && o.account === 'colacor_sc'))
+        : orders.filter(o => o._source === 'sales' && (o.account || 'oben') === accountFilter);
+
+    if (search.trim()) {
+      const q = search.trim().toLowerCase();
+      result = result.filter(o => {
+        const customerName = decodeHtml(profiles[o.customer_user_id] || '');
+        const pvNumber = o.omie_numero_pedido || '';
+        const itemDescs = (o.items || []).map(i => i.descricao).join(' ');
+        return (
+          customerName.toLowerCase().includes(q) ||
+          pvNumber.toLowerCase().includes(q) ||
+          itemDescs.toLowerCase().includes(q) ||
+          o.total.toFixed(2).includes(q)
+        );
+      });
+    }
+
+    return result;
+  }, [orders, accountFilter, search, profiles]);
+
+  const toggleSelect = (id: string, checked: boolean) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (checked) next.add(id);
+      else next.delete(id);
+      return next;
+    });
+  };
+
+  const clearSelection = () => setSelectedIds(new Set());
+
+  return {
+    navigate,
+    authLoading,
+    loading,
+    accountFilter,
+    setAccountFilter,
+    search,
+    setSearch,
+    selectedIds,
+    toggleSelect,
+    clearSelection,
+    orders,
+    profiles,
+    filteredOrders,
+    hasNext,
+    isFetching,
+    sentinelRef,
+    loadMore,
+    deleteOrder,
+    deleteSelected,
+    handleShareOrder,
+  };
+}

--- a/src/pages/SalesOrders.tsx
+++ b/src/pages/SalesOrders.tsx
@@ -1,393 +1,35 @@
-import { useState, useEffect, useMemo } from 'react';
-import { useNavigate } from 'react-router-dom';
-import { useInfiniteQuery, useQuery, useQueryClient, type InfiniteData } from '@tanstack/react-query';
 import { Button } from '@/components/ui/button';
-import { Card, CardContent } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
-import { Input } from '@/components/ui/input';
-import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, AlertDialogTrigger } from '@/components/ui/alert-dialog';
-import { supabase } from '@/integrations/supabase/client';
-import type { Tables } from '@/integrations/supabase/types';
-import { useAuth } from '@/contexts/AuthContext';
-import { Loader2, ShoppingCart, Plus, Package, Trash2, Building2, Share2, Printer, Pencil, Search, ChevronLeft } from 'lucide-react';
+import { Loader2, ShoppingCart, Trash2, ChevronLeft } from 'lucide-react';
 import { EmptyState } from '@/components/EmptyState';
-import { Checkbox } from '@/components/ui/checkbox';
 import { BulkActionsBar } from '@/components/ui/bulk-actions-bar';
-import { format } from 'date-fns';
-import { ptBR } from 'date-fns/locale';
-import { toast } from 'sonner';
-import { StatusBadgeSimple } from '@/components/StatusBadge';
-import type { OrderStatus } from '@/types';
-import { shareOrderViaWhatsApp } from '@/utils/whatsappShare';
-import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
-
-type SalesOrderRow = Tables<'sales_orders'>;
-type AfiacaoOrderRow = Tables<'orders'>;
-type ProfileRow = Tables<'profiles'>;
-
-// Shape de cada item dentro de orders.items (jsonb). Só os campos consumidos aqui.
-interface AfiacaoItemRaw {
-  category?: string | null;
-  name?: string | null;
-  quantity?: number | null;
-  unitPrice?: number | null;
-}
-
-// Cache do useInfiniteQuery de sales_orders — usado nos rollbacks optimistic.
-type SalesOrdersInfiniteCache = InfiniteData<SalesOrder[]>;
-
-// 3 empresas reais (oben, colacor, colacor_sc) + 'all'. Afiação NÃO é empresa,
-// é um módulo operando sob Colacor SC — pedidos da tabela `orders` (afiação)
-// aparecem dentro da aba "Colacor SC" junto com os pedidos comerciais
-// `sales_orders WHERE account='colacor_sc'`. Cada card mantém badge "Afiação"
-// quando _source='afiacao' pra preservar a distinção visual.
-type Account = 'oben' | 'colacor' | 'colacor_sc' | 'all';
-
-const PAGE_SIZE = 50;
-
-const decodeHtml = (s: string): string =>
-  s
-    .replace(/&amp;/g, '&')
-    .replace(/&apos;/g, "'")
-    .replace(/&quot;/g, '"')
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>');
-
-interface SalesOrder {
-  id: string;
-  customer_user_id: string;
-  items: Array<{ descricao: string; quantidade: number; valor_unitario: number; valor_total: number }>;
-  subtotal: number;
-  total: number;
-  status: string;
-  omie_numero_pedido: string | null;
-  omie_pedido_id: number | null;
-  created_at: string;
-  notes: string | null;
-  account?: string;
-  _source?: 'sales' | 'afiacao';
-}
-
-const statusLabels: Record<string, { label: string; variant: 'default' | 'secondary' | 'destructive' | 'outline' }> = {
-  rascunho: { label: 'Rascunho', variant: 'outline' },
-  enviado: { label: 'Enviado ao Omie', variant: 'default' },
-  faturado: { label: 'Faturado', variant: 'secondary' },
-  cancelado: { label: 'Cancelado', variant: 'destructive' },
-  recebido: { label: 'Recebido', variant: 'default' },
-  em_analise: { label: 'Em Análise', variant: 'default' },
-  em_producao: { label: 'Em Produção', variant: 'default' },
-  pronto: { label: 'Pronto', variant: 'secondary' },
-  entregue: { label: 'Entregue', variant: 'secondary' },
-};
+import { decodeHtml, PAGE_SIZE } from '@/components/salesOrders/types';
+import { useSalesOrders } from '@/components/salesOrders/useSalesOrders';
+import { SalesOrdersToolbar } from '@/components/salesOrders/SalesOrdersToolbar';
+import { SalesOrderCard } from '@/components/salesOrders/SalesOrderCard';
 
 const SalesOrders = () => {
-  const navigate = useNavigate();
-  const queryClient = useQueryClient();
-  const { isStaff, loading: authLoading, role } = useAuth();
-  const [accountFilter, setAccountFilter] = useState<Account>('all');
-  const [search, setSearch] = useState('');
-  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
-
-  useEffect(() => {
-    if (!authLoading && role !== null && !isStaff) navigate('/', { replace: true });
-  }, [authLoading, role, isStaff, navigate]);
-
-  /* ─── Sales orders: infinite query (50 por página) ─── */
-  const salesQuery = useInfiniteQuery({
-    queryKey: ['sales-orders-paginated'],
-    enabled: isStaff,
-    initialPageParam: 0,
-    queryFn: async ({ pageParam }) => {
-      const start = (pageParam as number) * PAGE_SIZE;
-      const { data, error } = await supabase
-        .from('sales_orders')
-        .select('*')
-        // Filtra soft-deletes (deleted_at IS NOT NULL = pedido excluído).
-        // Usa partial index idx_sales_orders_active em deleted_at IS NULL.
-        .is('deleted_at', null)
-        .order('created_at', { ascending: false })
-        .range(start, start + PAGE_SIZE - 1);
-      if (error) throw error;
-      return ((data || []) as SalesOrderRow[]).map((o) => ({
-        ...o,
-        _source: 'sales' as const,
-      })) as unknown as SalesOrder[];
-    },
-    getNextPageParam: (lastPage, allPages) =>
-      lastPage.length === PAGE_SIZE ? allPages.length : undefined,
-  });
-
-  /* ─── Afiação orders: infinite query (50 por página) ─── */
-  const afiacaoQuery = useInfiniteQuery({
-    queryKey: ['afiacao-orders-paginated'],
-    enabled: isStaff,
-    initialPageParam: 0,
-    queryFn: async ({ pageParam }) => {
-      const start = (pageParam as number) * PAGE_SIZE;
-      const { data, error } = await supabase
-        .from('orders')
-        .select('*')
-        .order('created_at', { ascending: false })
-        .range(start, start + PAGE_SIZE - 1);
-      if (error) throw error;
-      return ((data || []) as AfiacaoOrderRow[]).map((o) => {
-        const rawItems = Array.isArray(o.items) ? (o.items as unknown as AfiacaoItemRaw[]) : [];
-        return {
-          id: o.id,
-          customer_user_id: o.user_id,
-          items: rawItems.map((i) => ({
-            descricao: i.category || i.name || 'Afiação',
-            quantidade: i.quantity || 1,
-            valor_unitario: i.unitPrice || 0,
-            valor_total: (i.quantity || 1) * (i.unitPrice || 0),
-          })),
-          subtotal: o.subtotal || o.total || 0,
-          total: o.total || 0,
-          status: o.status,
-          omie_numero_pedido: null,
-          omie_pedido_id: null,
-          created_at: o.created_at,
-          notes: o.notes,
-          account: 'afiacao',
-          _source: 'afiacao' as const,
-        };
-      }) as SalesOrder[];
-    },
-    getNextPageParam: (lastPage, allPages) =>
-      lastPage.length === PAGE_SIZE ? allPages.length : undefined,
-  });
-
-  /* ─── Lista mergeada ─── */
-  const orders = useMemo<SalesOrder[]>(() => {
-    const sales = salesQuery.data?.pages.flat() || [];
-    const afiacao = afiacaoQuery.data?.pages.flat() || [];
-    return [...sales, ...afiacao].sort(
-      (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
-    );
-  }, [salesQuery.data, afiacaoQuery.data]);
-
-  /* ─── Profiles (nomes dos clientes) ─── */
-  const customerIds = useMemo(() => [...new Set(orders.map((o) => o.customer_user_id))], [orders]);
-  const profilesQuery = useQuery({
-    queryKey: ['sales-orders-profiles', customerIds.sort().join(',')],
-    enabled: isStaff && customerIds.length > 0,
-    staleTime: 60_000,
-    queryFn: async () => {
-      const { data } = await supabase
-        .from('profiles')
-        .select('user_id, name')
-        .in('user_id', customerIds);
-      const map: Record<string, string> = {};
-      ((data || []) as Pick<ProfileRow, 'user_id' | 'name'>[]).forEach((p) => {
-        map[p.user_id] = p.name ?? '';
-      });
-      return map;
-    },
-  });
-  const profiles = profilesQuery.data || {};
-
-  /* ─── Infinite scroll: dispara fetchNextPage de quem ainda tem páginas ─── */
-  const hasNext = !!salesQuery.hasNextPage || !!afiacaoQuery.hasNextPage;
-  const isFetching = salesQuery.isFetchingNextPage || afiacaoQuery.isFetchingNextPage;
-  const sentinelRef = useInfiniteScroll(
-    () => {
-      if (salesQuery.hasNextPage && !salesQuery.isFetchingNextPage) salesQuery.fetchNextPage();
-      if (afiacaoQuery.hasNextPage && !afiacaoQuery.isFetchingNextPage) afiacaoQuery.fetchNextPage();
-    },
-    hasNext && !isFetching,
-  );
-
-  const loading = salesQuery.isLoading || afiacaoQuery.isLoading;
-
-  // Soft-delete + Omie exclude. Fluxo:
-  // 1. Optimistic remove do cache (UI atualiza instantaneamente)
-  // 2. UPDATE sales_orders SET deleted_at = now() (audit trail compliance)
-  // 3. Call Omie excluir_pedido
-  // 4. Se Omie falhar: rollback do soft-delete + restaura cache
-  // 5. Se Supabase update falhar: rollback do cache, NÃO chama Omie
-  const deleteOrder = async (order: SalesOrder) => {
-    const snapshot = queryClient.getQueryData<SalesOrdersInfiniteCache>(['sales-orders-paginated']);
-    queryClient.setQueryData<SalesOrdersInfiniteCache>(['sales-orders-paginated'], (old) => {
-      if (!old) return old;
-      return {
-        ...old,
-        pages: old.pages.map((page) => page.filter((o) => o.id !== order.id)),
-      };
-    });
-    setSelectedIds((prev) => {
-      const next = new Set(prev);
-      next.delete(order.id);
-      return next;
-    });
-
-    // 1. Soft-delete local primeiro (audit trail antes do Omie)
-    // `deleted_at` existe no DB mas ainda não no generated Database type — cast as never
-    const { error: softErr } = await supabase
-      .from('sales_orders')
-      .update({ deleted_at: new Date().toISOString() } as never)
-      .eq('id', order.id);
-
-    if (softErr) {
-      console.error(softErr);
-      queryClient.setQueryData(['sales-orders-paginated'], snapshot);
-      toast.error('Erro ao excluir pedido', { description: softErr.message });
-      return;
-    }
-
-    // 2. Omie exclude — se falhar, rollback do soft-delete
-    try {
-      const { error } = await supabase.functions.invoke('omie-vendas-sync', {
-        body: {
-          action: 'excluir_pedido',
-          sales_order_id: order.id,
-          omie_pedido_id: order.omie_pedido_id,
-        },
-      });
-      if (error) throw error;
-      toast.success('Pedido excluído');
-    } catch (e) {
-      console.error(e);
-      // Rollback do soft-delete (deleted_at = null) — pedido volta a ser ativo
-      await supabase
-        .from('sales_orders')
-        .update({ deleted_at: null } as never)
-        .eq('id', order.id);
-      queryClient.setQueryData(['sales-orders-paginated'], snapshot);
-      toast.error('Erro ao excluir pedido', {
-        description: e instanceof Error ? e.message : String(e),
-      });
-    }
-  };
-
-  // Bulk delete — sequencial pra não floodar o Omie. Mostra progresso.
-  const deleteSelected = async () => {
-    if (selectedIds.size === 0) return;
-    const toDelete = orders.filter((o) => selectedIds.has(o.id) && o._source === 'sales');
-    const snapshot = queryClient.getQueryData<SalesOrdersInfiniteCache>(['sales-orders-paginated']);
-    const deleteIds = new Set(toDelete.map((o) => o.id));
-    queryClient.setQueryData<SalesOrdersInfiniteCache>(['sales-orders-paginated'], (old) => {
-      if (!old) return old;
-      return {
-        ...old,
-        pages: old.pages.map((page) => page.filter((o) => !deleteIds.has(o.id))),
-      };
-    });
-    setSelectedIds(new Set());
-
-    // 1. Soft-delete em batch (1 UPDATE com .in('id', ...))
-    const nowIso = new Date().toISOString();
-    const { error: softErr } = await supabase
-      .from('sales_orders')
-      .update({ deleted_at: nowIso } as never)
-      .in('id', Array.from(deleteIds));
-
-    if (softErr) {
-      console.error(softErr);
-      queryClient.setQueryData(['sales-orders-paginated'], snapshot);
-      toast.error(`Erro ao excluir pedidos`, { description: softErr.message });
-      return;
-    }
-
-    // 2. Omie exclude sequencial (não floodar). Rollback do deleted_at em falhas.
-    const failedIds: string[] = [];
-    let success = 0;
-    for (const o of toDelete) {
-      try {
-        const { error } = await supabase.functions.invoke('omie-vendas-sync', {
-          body: {
-            action: 'excluir_pedido',
-            sales_order_id: o.id,
-            omie_pedido_id: o.omie_pedido_id,
-          },
-        });
-        if (error) throw error;
-        success++;
-      } catch (e) {
-        failedIds.push(o.id);
-        console.error(e);
-      }
-    }
-    const failed = failedIds.length;
-
-    // Rollback do soft-delete só pros que falharam no Omie
-    if (failedIds.length > 0) {
-      await supabase
-        .from('sales_orders')
-        .update({ deleted_at: null } as never)
-        .in('id', failedIds);
-    }
-
-    if (failed === 0) {
-      toast.success(`${success} pedido(s) excluído(s)`);
-    } else if (success === 0) {
-      queryClient.setQueryData(['sales-orders-paginated'], snapshot); // rollback completo
-      toast.error(`Falhou: ${failed} pedido(s) não puderam ser excluídos`);
-    } else {
-      // Parcial — restaura os que falharam no cache (já temos deleted_at=null no DB)
-      const failedSet = new Set(failedIds);
-      queryClient.setQueryData<SalesOrdersInfiniteCache>(['sales-orders-paginated'], (old) => {
-        if (!old || !snapshot) return old;
-        // Pega as rows que falharam do snapshot original e reinjeta na primeira página
-        const failedRows = snapshot.pages
-          .flat()
-          .filter((o) => failedSet.has(o.id));
-        return {
-          ...old,
-          pages: old.pages.map((page, i) =>
-            i === 0 ? [...failedRows, ...page] : page,
-          ),
-        };
-      });
-      toast.warning(`${success} excluído(s), ${failed} falharam`);
-    }
-  };
-
-  const handleShareOrder = (order: SalesOrder, customerName: string) => {
-    const items = (order.items || []).map(item => ({
-      description: item.descricao,
-      quantity: item.quantidade,
-      unitPrice: item.valor_unitario,
-    }));
-
-    const orderNumbers = order.omie_numero_pedido ? [order.omie_numero_pedido.replace(/^0+/, '') || '0'] : [];
-
-    shareOrderViaWhatsApp({
-      customerName,
-      items,
-      total: order.total,
-      orderNumbers,
-      date: new Date(order.created_at),
-    });
-  };
-
-  const filteredOrders = useMemo(() => {
-    // Colacor SC engloba: (a) pedidos comerciais com account='colacor_sc' E
-    // (b) pedidos de afiação (que operam sob a entidade SC). Afiação não é tab
-    // separada, é serviço da Colacor SC.
-    let result = accountFilter === 'all'
-      ? orders
-      : accountFilter === 'colacor_sc'
-        ? orders.filter(o => o._source === 'afiacao' || (o._source === 'sales' && o.account === 'colacor_sc'))
-        : orders.filter(o => o._source === 'sales' && (o.account || 'oben') === accountFilter);
-
-    if (search.trim()) {
-      const q = search.trim().toLowerCase();
-      result = result.filter(o => {
-        const customerName = decodeHtml(profiles[o.customer_user_id] || '');
-        const pvNumber = o.omie_numero_pedido || '';
-        const itemDescs = (o.items || []).map(i => i.descricao).join(' ');
-        return (
-          customerName.toLowerCase().includes(q) ||
-          pvNumber.toLowerCase().includes(q) ||
-          itemDescs.toLowerCase().includes(q) ||
-          o.total.toFixed(2).includes(q)
-        );
-      });
-    }
-
-    return result;
-  }, [orders, accountFilter, search, profiles]);
+  const {
+    navigate,
+    authLoading,
+    loading,
+    accountFilter,
+    setAccountFilter,
+    search,
+    setSearch,
+    selectedIds,
+    toggleSelect,
+    clearSelection,
+    orders,
+    profiles,
+    filteredOrders,
+    hasNext,
+    isFetching,
+    sentinelRef,
+    loadMore,
+    deleteOrder,
+    deleteSelected,
+    handleShareOrder,
+  } = useSalesOrders();
 
   if (authLoading || loading) {
     return (
@@ -409,51 +51,13 @@ const SalesOrders = () => {
         </div>
       </div>
 
-      <div className="flex gap-2">
-        <Button onClick={() => navigate('/sales/new')} className="gap-2 flex-1">
-          <Plus className="w-4 h-4" />
-          Novo Pedido
-        </Button>
-        <Button variant="outline" onClick={() => navigate('/sales/products')} className="gap-2">
-          <Package className="w-4 h-4" />
-          Catálogo
-        </Button>
-        <Button variant="outline" onClick={() => navigate('/sales/print')} className="gap-2">
-          <Printer className="w-4 h-4" />
-          Imprimir
-        </Button>
-      </div>
-
-      {/* Account Filter — 3 empresas reais + Todos. Afiação foi unificada
-          em Colacor SC (módulo, não empresa). Cada card preserva o badge
-          "Afiação" quando _source='afiacao' pra distinção visual. */}
-      <Tabs value={accountFilter} onValueChange={(v) => setAccountFilter(v as Account)}>
-        <TabsList className="w-full grid grid-cols-4">
-          <TabsTrigger value="all">Todos</TabsTrigger>
-          <TabsTrigger value="oben" className="gap-1">
-            <Building2 className="w-3 h-3" />
-            Oben
-          </TabsTrigger>
-          <TabsTrigger value="colacor" className="gap-1">
-            <Building2 className="w-3 h-3" />
-            Colacor
-          </TabsTrigger>
-          <TabsTrigger value="colacor_sc" className="gap-1">
-            <Building2 className="w-3 h-3" />
-            Colacor SC
-          </TabsTrigger>
-        </TabsList>
-      </Tabs>
-
-      <div className="relative">
-        <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
-        <Input
-          placeholder="Buscar por cliente, nº pedido ou item..."
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-          className="pl-9"
-        />
-      </div>
+      <SalesOrdersToolbar
+        onNavigate={navigate}
+        accountFilter={accountFilter}
+        setAccountFilter={setAccountFilter}
+        search={search}
+        setSearch={setSearch}
+      />
 
       {filteredOrders.length === 0 ? (
         <EmptyState
@@ -476,129 +80,18 @@ const SalesOrders = () => {
         />
       ) : (
         <div className="space-y-2">
-          {filteredOrders.map((order) => {
-            const isAfiacao = order._source === 'afiacao';
-            const status = statusLabels[order.status] || statusLabels.rascunho;
-            const totalItems = order.items?.reduce((s, i) => s + (i.quantidade || 0), 0) || 0;
-            // Afiação opera sob Colacor SC. Card sempre mostra a empresa (Oben/Colacor/SC)
-            // e, quando for pedido de afiação, um badge secundário "Afiação" pra distinguir
-            // serviço de pedido comercial. Antes mostrava só "Afiação" e perdia a empresa.
-            const orderAccount = isAfiacao ? 'colacor_sc' : (order.account || 'oben');
-            const accountLabel = orderAccount === 'colacor_sc'
-              ? 'Colacor SC'
-              : orderAccount === 'colacor'
-                ? 'Colacor'
-                : 'Oben';
-            const isSelectable = !isAfiacao; // só sales_orders são bulk-deletáveis
-            const checked = selectedIds.has(order.id);
-            return (
-              <Card key={`${order._source}-${order.id}`} className={`cursor-pointer hover:bg-muted/30 transition-colors ${checked ? 'ring-2 ring-foreground/20' : ''}`} onClick={() => isAfiacao ? navigate(`/orders/${order.id}`) : undefined}>
-                <CardContent className="p-3">
-                  <div className="flex items-start justify-between gap-2">
-                    {isSelectable && (
-                      <Checkbox
-                        checked={checked}
-                        onClick={(e) => e.stopPropagation()}
-                        onCheckedChange={(v) => {
-                          setSelectedIds((prev) => {
-                            const next = new Set(prev);
-                            if (v) next.add(order.id);
-                            else next.delete(order.id);
-                            return next;
-                          });
-                        }}
-                        className="mt-0.5"
-                      />
-                    )}
-                    <div className="flex-1 min-w-0">
-                      <div className="flex items-center gap-1.5 flex-wrap">
-                        <p className="font-medium text-sm truncate">
-                          {decodeHtml(profiles[order.customer_user_id] || 'Cliente')}
-                        </p>
-                        <Badge variant="outline" className="text-[9px] px-1 py-0 shrink-0">
-                          {accountLabel}
-                        </Badge>
-                        {/* Badge secundário pra distinguir serviço de afiação dentro de SC */}
-                        {isAfiacao && (
-                          <Badge variant="outline" className="text-[9px] px-1 py-0 shrink-0 bg-muted/50 text-muted-foreground border-dashed">
-                            Afiação
-                          </Badge>
-                        )}
-                      </div>
-                      <p className="text-xs text-muted-foreground mt-0.5">
-                        {format(new Date(order.created_at), "dd/MM/yyyy 'às' HH:mm", { locale: ptBR })}
-                      </p>
-                      {order.omie_numero_pedido && (
-                        <p className="text-xs text-muted-foreground">
-                          PV: <span className="font-tabular text-foreground">{order.omie_numero_pedido.replace(/^0+/, '') || '0'}</span>
-                        </p>
-                      )}
-                    </div>
-                    <div className="text-right shrink-0 space-y-1">
-                      {isAfiacao ? (
-                        <StatusBadgeSimple status={order.status as OrderStatus} size="sm" />
-                      ) : (
-                        <Badge variant={status.variant}>{status.label}</Badge>
-                      )}
-                      <p className="text-sm font-bold">R$ {order.total.toFixed(2)}</p>
-                      <p className="text-xs text-muted-foreground">{totalItems} itens</p>
-                      <div className="flex gap-1 justify-end">
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          className="h-7 w-7"
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            handleShareOrder(order, decodeHtml(profiles[order.customer_user_id] || 'Cliente'));
-                          }}
-                          title="Compartilhar via WhatsApp"
-                        >
-                          <Share2 className="w-3.5 h-3.5" />
-                        </Button>
-                        {!isAfiacao && !['cancelado', 'entregue', 'faturado'].includes(order.status) && (
-                          <Button
-                            variant="ghost"
-                            size="icon"
-                            className="h-7 w-7"
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              navigate(`/sales/edit/${order.id}`);
-                            }}
-                            title="Editar pedido"
-                          >
-                            <Pencil className="w-3.5 h-3.5" />
-                          </Button>
-                        )}
-                        {!isAfiacao && (
-                          <AlertDialog>
-                            <AlertDialogTrigger asChild>
-                              <Button variant="ghost" size="icon" className="h-7 w-7 text-destructive hover:text-destructive" onClick={(e) => e.stopPropagation()}>
-                                <Trash2 className="w-3.5 h-3.5" />
-                              </Button>
-                            </AlertDialogTrigger>
-                            <AlertDialogContent>
-                              <AlertDialogHeader>
-                                <AlertDialogTitle>Excluir pedido?</AlertDialogTitle>
-                                <AlertDialogDescription>
-                                  Esta ação não pode ser desfeita. O pedido será removido permanentemente do sistema.
-                                </AlertDialogDescription>
-                              </AlertDialogHeader>
-                              <AlertDialogFooter>
-                                <AlertDialogCancel>Cancelar</AlertDialogCancel>
-                                <AlertDialogAction onClick={() => deleteOrder(order)} className="bg-destructive text-destructive-foreground hover:bg-destructive/90">
-                                  Excluir
-                                </AlertDialogAction>
-                              </AlertDialogFooter>
-                            </AlertDialogContent>
-                          </AlertDialog>
-                        )}
-                      </div>
-                    </div>
-                  </div>
-                </CardContent>
-              </Card>
-            );
-          })}
+          {filteredOrders.map((order) => (
+            <SalesOrderCard
+              key={`${order._source}-${order.id}`}
+              order={order}
+              customerName={decodeHtml(profiles[order.customer_user_id] || 'Cliente')}
+              checked={selectedIds.has(order.id)}
+              onSelectChange={(v) => toggleSelect(order.id, v)}
+              onShare={() => handleShareOrder(order, decodeHtml(profiles[order.customer_user_id] || 'Cliente'))}
+              onDelete={() => deleteOrder(order)}
+              onNavigate={navigate}
+            />
+          ))}
 
           {/* Infinite scroll sentinel + carregar mais fallback */}
           {hasNext && (
@@ -609,10 +102,7 @@ const SalesOrders = () => {
                 <Button
                   variant="outline"
                   size="sm"
-                  onClick={() => {
-                    if (salesQuery.hasNextPage) salesQuery.fetchNextPage();
-                    if (afiacaoQuery.hasNextPage) afiacaoQuery.fetchNextPage();
-                  }}
+                  onClick={loadMore}
                 >
                   Carregar mais
                 </Button>
@@ -630,7 +120,7 @@ const SalesOrders = () => {
       {/* Barra flutuante quando há seleção múltipla */}
       <BulkActionsBar
         count={selectedIds.size}
-        onClear={() => setSelectedIds(new Set())}
+        onClear={clearSelection}
         itemSingular="pedido"
         itemPlural="pedidos"
         actions={[


### PR DESCRIPTION
## Resumo
- Split estrutural da página `SalesOrders` (654→**144** linhas), preservando 100% do comportamento (move verbatim).
- Lógica isolada no hook **`useSalesOrders`** (2 infinite queries sales+afiação, merge, profiles, infinite scroll, `deleteOrder`/`deleteSelected` optimistic com rollback, `filteredOrders`).
- JSX em componentes controlados: **`SalesOrdersToolbar`** (ações + tabs + busca) e **`SalesOrderCard`**. Tipos/helpers (`decodeHtml`, `statusLabels`, `PAGE_SIZE`) em `types.ts`.
- ⭐ `deleteOrder`/`deleteSelected` (referência viva de optimistic UI do CLAUDE.md) movidos **byte-a-byte** — snapshot/rollback/early-returns idênticos.

## Verificação
- `bunx tsc --noEmit` = 0 erros
- `bunx eslint` = 0 erros (1 warning `exhaustive-deps` de `profiles` é **baseline** — confirmado lintando o arquivo de origem)
- Testes novos (+12) passam isolados (3/3 arquivos). ⚠️ Suíte completa local com flakiness por contenção de CPU. Gate autoritativo = CI `validate`.
- Revisão independente de fidelidade (subagente): **FIEL 1:1**, zero divergências (optimistic delete/rollback byte-a-byte).

## Test plan
- [x] tsc / eslint verdes; +12 testes novos verdes isolados
- [x] Revisão 1:1 confirmando comportamento idêntico
- [ ] CI `validate` verde (gate da suíte completa)

🤖 Generated with [Claude Code](https://claude.com/claude-code)