### PR TITLE
refactor(des): split CheckinQualitativoTab (640→104) em hook + componentes

### DIFF
--- a/src/components/des/CheckinQualitativoTab.tsx
+++ b/src/components/des/CheckinQualitativoTab.tsx
@@ -1,430 +1,48 @@
-import { useEffect, useMemo, useState } from "react";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { toast } from "sonner";
-import { ChevronDown, Save, Loader2, Sparkles } from "lucide-react";
-import { supabase } from "@/integrations/supabase/client";
-import { useAuth } from "@/contexts/AuthContext";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
-import { Switch } from "@/components/ui/switch";
-import { Textarea } from "@/components/ui/textarea";
-import { Badge } from "@/components/ui/badge";
+import { Sparkles } from "lucide-react";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Separator } from "@/components/ui/separator";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/components/ui/alert-dialog";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
-import { cn } from "@/lib/utils";
-
-interface Props {
-  empresa: string;
-  ano: number;
-  trimestre: number;
-}
-
-interface Criterio {
-  id: number;
-  codigo: string;
-  nome: string;
-  descricao: string | null;
-  ordem: number;
-  tipo: "qualitativo" | "bonus" | string;
-}
-
-interface CriterioPercentual {
-  criterio_id: number;
-  faixa_id: number;
-  percentual: number;
-}
-
-interface DescontoCheckin {
-  checkin_id: number;
-  data_avaliacao: string;
-  tipo: string;
-  faixa_numero: number | null;
-  estrelas: number | null;
-  desconto_padrao: number | null;
-  qualitativos_atingidos_perc: number | null;
-  bonus_atingido_perc: number | null;
-  desconto_total_projetado: number | null;
-  desconto_total_maximo: number | null;
-  avaliado_por?: string | null;
-}
-
-interface CheckinAtualRow {
-  checkin_id: number;
-  data_avaliacao: string;
-  tipo: string;
-  avaliado_com: string | null;
-  avaliado_por: string | null;
-  codigo: string;
-  nome: string;
-  criterio_tipo: string;
-  atingido: boolean;
-  observacao_criterio: string | null;
-}
-
-interface FaixaInfo {
-  faixa_id: number | null;
-  [key: string]: unknown;
-}
-
-interface PosicaoTrimestreRow {
-  faixa_conservadora: FaixaInfo | null;
-  faixa_otimista: FaixaInfo | null;
-}
-
-interface DescontoCheckinRow {
-  checkin_id: number;
-  data_avaliacao: string;
-  tipo: string;
-  faixa_numero: number | null;
-  estrelas: number | null;
-  desconto_padrao: number | null;
-  qualitativos_atingidos_perc: number | null;
-  bonus_atingido_perc: number | null;
-  desconto_total_projetado: number | null;
-  desconto_total_maximo: number | null;
-}
-
-interface CheckinQualitativoRow {
-  id: number;
-  avaliado_por: string | null;
-}
-
-const fmtPct = (v: number | null | undefined) =>
-  v == null ? "—" : `${Number(v).toFixed(2).replace(".", ",")}%`;
-
-const fmtDate = (d: string | null | undefined) =>
-  d ? new Date(d + "T00:00:00").toLocaleDateString("pt-BR") : "—";
+import { type Props } from "./checkinQualitativo/types";
+import { useCheckinQualitativo } from "./checkinQualitativo/useCheckinQualitativo";
+import { DescontoProjetadoCard } from "./checkinQualitativo/DescontoProjetadoCard";
+import { CriterioCard } from "./checkinQualitativo/CriterioCard";
+import { HistoricoCheckins } from "./checkinQualitativo/HistoricoCheckins";
+import { ConfirmacaoAndreDialog } from "./checkinQualitativo/ConfirmacaoAndreDialog";
 
 export function CheckinQualitativoTab({ empresa, ano, trimestre }: Props) {
-  const { user } = useAuth();
-  const qc = useQueryClient();
-
-  const [respostas, setRespostas] = useState<Record<number, { atingido: boolean; observacao: string }>>({});
-  const [saving, setSaving] = useState(false);
-  const [confirmAndreOpen, setConfirmAndreOpen] = useState(false);
-
-  // Critérios cadastrados
-  const criteriosQuery = useQuery({
-    queryKey: ["des-criterios"],
-    queryFn: async () => {
-      const { data, error } = await supabase
-        .from("des_criterio_qualitativo")
-        .select("id, codigo, nome, descricao, ordem, tipo")
-        .order("ordem", { ascending: true });
-      if (error) throw error;
-      return (data ?? []) as Criterio[];
-    },
-  });
-
-  // Posição ao vivo (para descobrir faixa atual e percentuais)
-  const posicaoQuery = useQuery({
-    queryKey: ["des-posicao-checkin", empresa, ano, trimestre],
-    queryFn: async () => {
-      const { data, error } = await supabase
-        .from("v_des_posicao_trimestre_ao_vivo" as never)
-        .select("faixa_conservadora, faixa_otimista")
-        .eq("empresa", empresa)
-        .eq("ano", ano)
-        .eq("trimestre", trimestre)
-        .maybeSingle();
-      if (error) throw error;
-      return data as unknown as PosicaoTrimestreRow | null;
-    },
-  });
-
-  // Percentuais por critério para a faixa atual
-  const faixaConservId = posicaoQuery.data?.faixa_conservadora?.faixa_id ?? null;
-
-  const percentuaisQuery = useQuery({
-    queryKey: ["des-percentuais", faixaConservId],
-    enabled: !!faixaConservId,
-    queryFn: async () => {
-      const { data, error } = await supabase
-        .from("des_criterio_percentual")
-        .select("criterio_id, faixa_id, percentual")
-        .eq("faixa_id", faixaConservId as number);
-      if (error) throw error;
-      return (data ?? []) as CriterioPercentual[];
-    },
-  });
-
-  // Checkin atual (mais recente do trimestre)
-  const checkinAtualQuery = useQuery({
-    queryKey: ["des-checkin-atual", empresa, ano, trimestre],
-    queryFn: async () => {
-      const { data, error } = await supabase
-        .from("v_des_checkin_atual" as never)
-        .select("*")
-        .eq("empresa", empresa)
-        .eq("ano", ano)
-        .eq("trimestre", trimestre);
-      if (error) throw error;
-      return (data ?? []) as unknown as CheckinAtualRow[];
-    },
-  });
-
-  // Desconto projetado para o checkin atual
-  const descontoQuery = useQuery({
-    queryKey: ["des-desconto", empresa, ano, trimestre],
-    queryFn: async () => {
-      const { data, error } = await supabase
-        .from("v_des_desconto_por_checkin" as never)
-        .select("*")
-        .eq("empresa", empresa)
-        .eq("ano", ano)
-        .eq("trimestre", trimestre)
-        .order("data_avaliacao", { ascending: false })
-        .limit(1)
-        .maybeSingle();
-      if (error) throw error;
-      return data as unknown as DescontoCheckin | null;
-    },
-  });
-
-  // Histórico de checkins do trimestre
-  const historicoQuery = useQuery({
-    queryKey: ["des-checkin-historico", empresa, ano, trimestre],
-    queryFn: async () => {
-      const { data, error } = await supabase
-        .from("v_des_desconto_por_checkin" as never)
-        .select("*")
-        .eq("empresa", empresa)
-        .eq("ano", ano)
-        .eq("trimestre", trimestre)
-        .order("data_avaliacao", { ascending: false });
-      if (error) throw error;
-      const rows = (data ?? []) as unknown as DescontoCheckinRow[];
-      // join avaliado_por via des_checkin_qualitativo
-      const ids = rows.map((d) => d.checkin_id).filter(Boolean);
-      const porMap: Record<number, string | null> = {};
-      if (ids.length) {
-        const { data: chs } = await supabase
-          .from("des_checkin_qualitativo")
-          .select("id, avaliado_por")
-          .in("id", ids);
-        const chsRows = (chs ?? []) as unknown as CheckinQualitativoRow[];
-        chsRows.forEach((c) => { porMap[c.id] = c.avaliado_por; });
-      }
-      return rows.map((d) => ({
-        ...d,
-        avaliado_por: porMap[d.checkin_id] ?? null,
-      })) as DescontoCheckin[];
-    },
-  });
-
-  // Inicializa respostas a partir do checkin atual
-  useEffect(() => {
-    const criterios = criteriosQuery.data ?? [];
-    const rows = checkinAtualQuery.data ?? [];
-    if (!criterios.length) return;
-
-    const next: Record<number, { atingido: boolean; observacao: string }> = {};
-    criterios.forEach((c) => {
-      const row = rows.find((r) => r.codigo === c.codigo);
-      next[c.id] = {
-        atingido: row?.atingido ?? false,
-        observacao: row?.observacao_criterio ?? "",
-      };
-    });
-    setRespostas(next);
-  }, [criteriosQuery.data, checkinAtualQuery.data]);
-
-  const percentualPorCriterio = useMemo(() => {
-    const map: Record<number, number> = {};
-    (percentuaisQuery.data ?? []).forEach((p) => {
-      map[p.criterio_id] = Number(p.percentual);
-    });
-    return map;
-  }, [percentuaisQuery.data]);
-
-  const desconto = descontoQuery.data;
-  const max = Number(desconto?.desconto_total_maximo ?? 0);
-  const total = Number(desconto?.desconto_total_projetado ?? 0);
-  const ratio = max > 0 ? total / max : 0;
-  const cardColor =
-    ratio >= 1
-      ? "bg-green-500/5 border-green-500/30"
-      : ratio >= 0.5
-        ? "bg-amber-500/5 border-amber-500/30"
-        : "bg-red-500/5 border-red-500/30";
-  const totalColor =
-    ratio >= 1 ? "text-green-700" : ratio >= 0.5 ? "text-amber-700" : "text-red-700";
-
-  async function salvarCheckin(tipo: "projecao" | "confirmacao_andre") {
-    if (!user) {
-      toast.error("Sessão expirada. Faça login novamente.");
-      return;
-    }
-    setSaving(true);
-    try {
-      const hoje = new Date().toISOString().slice(0, 10);
-      const avaliadoCom = tipo === "confirmacao_andre" ? "André (Sayerlack)" : null;
-      const avaliadoPor = user.email ?? user.id;
-
-      // 1. Procura checkin existente do mesmo tipo
-      const { data: existentes, error: errFind } = await supabase
-        .from("des_checkin_qualitativo")
-        .select("id")
-        .eq("empresa", empresa)
-        .eq("ano", ano)
-        .eq("trimestre", trimestre)
-        .eq("tipo", tipo)
-        .order("criado_em", { ascending: false })
-        .limit(1);
-      if (errFind) throw errFind;
-
-      let checkinId: number;
-      if (existentes && existentes.length > 0) {
-        checkinId = existentes[0].id;
-        const { error: errUpd } = await supabase
-          .from("des_checkin_qualitativo")
-          .update({
-            data_avaliacao: hoje,
-            avaliado_por: avaliadoPor,
-            avaliado_com: avaliadoCom,
-            atualizado_em: new Date().toISOString(),
-          })
-          .eq("id", checkinId);
-        if (errUpd) throw errUpd;
-      } else {
-        const { data: novo, error: errIns } = await supabase
-          .from("des_checkin_qualitativo")
-          .insert({
-            empresa,
-            ano,
-            trimestre,
-            data_avaliacao: hoje,
-            tipo,
-            avaliado_por: avaliadoPor,
-            avaliado_com: avaliadoCom,
-          })
-          .select("id")
-          .single();
-        if (errIns) throw errIns;
-        checkinId = novo.id;
-      }
-
-      // 2. Apaga respostas antigas e insere novas
-      const { error: errDel } = await supabase
-        .from("des_checkin_qualitativo_resposta")
-        .delete()
-        .eq("checkin_id", checkinId);
-      if (errDel) throw errDel;
-
-      const novasRespostas = Object.entries(respostas).map(([critId, val]) => ({
-        checkin_id: checkinId,
-        criterio_id: Number(critId),
-        atingido: val.atingido,
-        observacao: val.observacao || null,
-      }));
-
-      if (novasRespostas.length) {
-        const { error: errInsR } = await supabase
-          .from("des_checkin_qualitativo_resposta")
-          .insert(novasRespostas);
-        if (errInsR) throw errInsR;
-      }
-
-      toast.success(
-        tipo === "projecao"
-          ? "Projeção atualizada."
-          : "Confirmação com André registrada."
-      );
-
-      // Refetch
-      qc.invalidateQueries({ queryKey: ["des-checkin-atual", empresa, ano, trimestre] });
-      qc.invalidateQueries({ queryKey: ["des-desconto", empresa, ano, trimestre] });
-      qc.invalidateQueries({ queryKey: ["des-checkin-historico", empresa, ano, trimestre] });
-    } catch (err) {
-      console.error(err);
-      const msg = err instanceof Error ? err.message : "desconhecido";
-      toast.error("Erro ao salvar checkin: " + msg);
-    } finally {
-      setSaving(false);
-      setConfirmAndreOpen(false);
-    }
-  }
-
-  const isLoading = criteriosQuery.isLoading || checkinAtualQuery.isLoading;
-  const criterios = criteriosQuery.data ?? [];
-  const qualitativos = criterios.filter((c) => c.tipo === "qualitativo");
-  const bonusItems = criterios.filter((c) => c.tipo === "bonus");
+  const {
+    respostas,
+    setResposta,
+    saving,
+    confirmAndreOpen,
+    setConfirmAndreOpen,
+    percentualPorCriterio,
+    desconto,
+    max,
+    total,
+    cardColor,
+    totalColor,
+    salvarCheckin,
+    isLoading,
+    qualitativos,
+    bonusItems,
+    historicoLoading,
+    historico,
+  } = useCheckinQualitativo({ empresa, ano, trimestre });
 
   return (
     <div className="space-y-6">
       {/* Topo: card de desconto projetado */}
-      <Card className={cn("border-2", cardColor)}>
-        <CardContent className="pt-6">
-          <div className="flex items-start justify-between gap-4 flex-wrap">
-            <div className="flex-1 min-w-[280px]">
-              <p className="text-xs text-muted-foreground uppercase tracking-wide font-medium">
-                Desconto projetado para o próximo trimestre
-              </p>
-              <p className={cn("text-3xl font-bold mt-2", totalColor)}>
-                Se confirmar os critérios, será {fmtPct(total)}
-              </p>
-              <p className="text-xs text-muted-foreground mt-2">
-                Padrão da faixa: <strong>{fmtPct(desconto?.desconto_padrao)}</strong> + Qualitativos atingidos:{" "}
-                <strong>{fmtPct(desconto?.qualitativos_atingidos_perc)}</strong> + Bônus:{" "}
-                <strong>{fmtPct(desconto?.bonus_atingido_perc)}</strong>
-              </p>
-              {max > 0 && (
-                <p className="text-xs text-muted-foreground mt-1">
-                  Máximo possível desta faixa: {fmtPct(max)}
-                </p>
-              )}
-            </div>
-
-            <div className="flex items-center gap-2">
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button disabled={saving || isLoading}>
-                    {saving ? (
-                      <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                    ) : (
-                      <Save className="h-4 w-4 mr-2" />
-                    )}
-                    Salvar
-                    <ChevronDown className="h-4 w-4 ml-2" />
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end">
-                  <DropdownMenuItem onClick={() => salvarCheckin("projecao")}>
-                    Salvar como Projeção
-                  </DropdownMenuItem>
-                  <DropdownMenuItem onClick={() => setConfirmAndreOpen(true)}>
-                    Salvar como Confirmação (com André)
-                  </DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
-            </div>
-          </div>
-        </CardContent>
-      </Card>
+      <DescontoProjetadoCard
+        desconto={desconto}
+        max={max}
+        total={total}
+        cardColor={cardColor}
+        totalColor={totalColor}
+        saving={saving}
+        isLoading={isLoading}
+        onSalvarProjecao={() => salvarCheckin("projecao")}
+        onSalvarConfirmacao={() => setConfirmAndreOpen(true)}
+      />
 
       {/* Critérios */}
       {isLoading ? (
@@ -436,61 +54,15 @@ export function CheckinQualitativoTab({ empresa, ano, trimestre }: Props) {
       ) : (
         <>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            {qualitativos.map((c) => {
-              const r = respostas[c.id] ?? { atingido: false, observacao: "" };
-              const pct = percentualPorCriterio[c.id] ?? 0;
-              return (
-                <Card
-                  key={c.id}
-                  className={cn(
-                    "transition-colors",
-                    r.atingido && "bg-green-500/5 border-green-500/30"
-                  )}
-                >
-                  <CardHeader className="pb-3">
-                    <div className="flex items-start justify-between gap-2">
-                      <div className="flex-1 min-w-0">
-                        <CardTitle className="text-sm leading-tight">{c.nome}</CardTitle>
-                        {c.descricao && (
-                          <p className="text-xs text-muted-foreground mt-1.5 leading-relaxed">
-                            {c.descricao}
-                          </p>
-                        )}
-                      </div>
-                      <Badge variant="outline" className="shrink-0 text-xs">
-                        Vale {fmtPct(pct)}
-                      </Badge>
-                    </div>
-                  </CardHeader>
-                  <CardContent className="space-y-3">
-                    <div className="flex items-center gap-2">
-                      <Switch
-                        checked={r.atingido}
-                        onCheckedChange={(v) =>
-                          setRespostas((prev) => ({ ...prev, [c.id]: { ...r, atingido: v } }))
-                        }
-                      />
-                      <label className="text-sm font-medium cursor-pointer">
-                        {r.atingido ? "Atingido" : "Não atingido"}
-                      </label>
-                    </div>
-                    {r.atingido && (
-                      <Textarea
-                        placeholder="Observação (opcional)..."
-                        value={r.observacao}
-                        onChange={(e) =>
-                          setRespostas((prev) => ({
-                            ...prev,
-                            [c.id]: { ...r, observacao: e.target.value },
-                          }))
-                        }
-                        className="text-xs min-h-[60px]"
-                      />
-                    )}
-                  </CardContent>
-                </Card>
-              );
-            })}
+            {qualitativos.map((c) => (
+              <CriterioCard
+                key={c.id}
+                criterio={c}
+                resposta={respostas[c.id] ?? { atingido: false, observacao: "" }}
+                percentual={percentualPorCriterio[c.id] ?? 0}
+                onChange={(resp) => setResposta(c.id, resp)}
+              />
+            ))}
           </div>
 
           {bonusItems.length > 0 && (
@@ -501,61 +73,16 @@ export function CheckinQualitativoTab({ empresa, ano, trimestre }: Props) {
                 <Separator className="flex-1" />
               </div>
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                {bonusItems.map((c) => {
-                  const r = respostas[c.id] ?? { atingido: false, observacao: "" };
-                  const pct = percentualPorCriterio[c.id] ?? 0;
-                  return (
-                    <Card
-                      key={c.id}
-                      className={cn(
-                        "transition-colors border-amber-500/30",
-                        r.atingido && "bg-amber-500/10"
-                      )}
-                    >
-                      <CardHeader className="pb-3">
-                        <div className="flex items-start justify-between gap-2">
-                          <div className="flex-1 min-w-0">
-                            <CardTitle className="text-sm leading-tight">{c.nome}</CardTitle>
-                            {c.descricao && (
-                              <p className="text-xs text-muted-foreground mt-1.5 leading-relaxed">
-                                {c.descricao}
-                              </p>
-                            )}
-                          </div>
-                          <Badge variant="outline" className="shrink-0 text-xs bg-amber-500/10 border-amber-500/40 text-amber-700">
-                            Vale {fmtPct(pct)}
-                          </Badge>
-                        </div>
-                      </CardHeader>
-                      <CardContent className="space-y-3">
-                        <div className="flex items-center gap-2">
-                          <Switch
-                            checked={r.atingido}
-                            onCheckedChange={(v) =>
-                              setRespostas((prev) => ({ ...prev, [c.id]: { ...r, atingido: v } }))
-                            }
-                          />
-                          <label className="text-sm font-medium cursor-pointer">
-                            {r.atingido ? "Atingido" : "Não atingido"}
-                          </label>
-                        </div>
-                        {r.atingido && (
-                          <Textarea
-                            placeholder="Observação (opcional)..."
-                            value={r.observacao}
-                            onChange={(e) =>
-                              setRespostas((prev) => ({
-                                ...prev,
-                                [c.id]: { ...r, observacao: e.target.value },
-                              }))
-                            }
-                            className="text-xs min-h-[60px]"
-                          />
-                        )}
-                      </CardContent>
-                    </Card>
-                  );
-                })}
+                {bonusItems.map((c) => (
+                  <CriterioCard
+                    key={c.id}
+                    criterio={c}
+                    resposta={respostas[c.id] ?? { atingido: false, observacao: "" }}
+                    percentual={percentualPorCriterio[c.id] ?? 0}
+                    bonus
+                    onChange={(resp) => setResposta(c.id, resp)}
+                  />
+                ))}
               </div>
             </>
           )}
@@ -563,78 +90,15 @@ export function CheckinQualitativoTab({ empresa, ano, trimestre }: Props) {
       )}
 
       {/* Histórico do trimestre */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-base">Checkins anteriores neste trimestre</CardTitle>
-        </CardHeader>
-        <CardContent>
-          {historicoQuery.isLoading ? (
-            <Skeleton className="h-32 w-full" />
-          ) : (historicoQuery.data ?? []).length === 0 ? (
-            <p className="text-sm text-muted-foreground text-center py-6">
-              Nenhum checkin registrado ainda neste trimestre.
-            </p>
-          ) : (
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Data</TableHead>
-                  <TableHead>Tipo</TableHead>
-                  <TableHead>Avaliado por</TableHead>
-                  <TableHead className="text-right">Qualitativos</TableHead>
-                  <TableHead className="text-right">Desconto projetado</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {historicoQuery.data!.map((h) => (
-                  <TableRow key={h.checkin_id}>
-                    <TableCell className="text-xs">{fmtDate(h.data_avaliacao)}</TableCell>
-                    <TableCell>
-                      <Badge variant={h.tipo === "confirmacao_andre" ? "default" : "secondary"} className="text-xs">
-                        {h.tipo === "confirmacao_andre" ? "Confirmação" : "Projeção"}
-                      </Badge>
-                    </TableCell>
-                    <TableCell className="text-xs text-muted-foreground">
-                      {h.avaliado_por ?? "—"}
-                    </TableCell>
-                    <TableCell className="text-right text-xs">
-                      {fmtPct(h.qualitativos_atingidos_perc)}
-                    </TableCell>
-                    <TableCell className="text-right text-xs font-medium">
-                      {fmtPct(h.desconto_total_projetado)}
-                    </TableCell>
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          )}
-        </CardContent>
-      </Card>
+      <HistoricoCheckins loading={historicoLoading} historico={historico} />
 
       {/* Dialog confirmação com André */}
-      <AlertDialog open={confirmAndreOpen} onOpenChange={setConfirmAndreOpen}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Confirmação final com André</AlertDialogTitle>
-            <AlertDialogDescription>
-              Esta é a avaliação final do trimestre feita com André. Substituirá a projeção atual. Confirmar?
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={saving}>Cancelar</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={(e) => {
-                e.preventDefault();
-                salvarCheckin("confirmacao_andre");
-              }}
-              disabled={saving}
-            >
-              {saving ? <Loader2 className="h-4 w-4 mr-2 animate-spin" /> : null}
-              Confirmar
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+      <ConfirmacaoAndreDialog
+        open={confirmAndreOpen}
+        onOpenChange={setConfirmAndreOpen}
+        saving={saving}
+        onConfirm={() => salvarCheckin("confirmacao_andre")}
+      />
     </div>
   );
 }

--- a/src/components/des/checkinQualitativo/ConfirmacaoAndreDialog.tsx
+++ b/src/components/des/checkinQualitativo/ConfirmacaoAndreDialog.tsx
@@ -1,0 +1,48 @@
+// Dialog de confirmação final com André.
+// Extraído verbatim de src/components/des/CheckinQualitativoTab.tsx (god-component split).
+import { Loader2 } from "lucide-react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+
+interface ConfirmacaoAndreDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  saving: boolean;
+  onConfirm: () => void;
+}
+
+export function ConfirmacaoAndreDialog({ open, onOpenChange, saving, onConfirm }: ConfirmacaoAndreDialogProps) {
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Confirmação final com André</AlertDialogTitle>
+          <AlertDialogDescription>
+            Esta é a avaliação final do trimestre feita com André. Substituirá a projeção atual. Confirmar?
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={saving}>Cancelar</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={(e) => {
+              e.preventDefault();
+              onConfirm();
+            }}
+            disabled={saving}
+          >
+            {saving ? <Loader2 className="h-4 w-4 mr-2 animate-spin" /> : null}
+            Confirmar
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/components/des/checkinQualitativo/CriterioCard.tsx
+++ b/src/components/des/checkinQualitativo/CriterioCard.tsx
@@ -1,0 +1,69 @@
+// Card de um critério qualitativo (ou de bônus) do check-in DES.
+// Extraído verbatim de src/components/des/CheckinQualitativoTab.tsx (god-component split).
+// Unifica os dois cards (qualitativo/bônus) que eram idênticos exceto pelas classes.
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Switch } from "@/components/ui/switch";
+import { Textarea } from "@/components/ui/textarea";
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+import { type Criterio, type Resposta } from "./types";
+import { fmtPct } from "./format";
+
+interface CriterioCardProps {
+  criterio: Criterio;
+  resposta: Resposta;
+  percentual: number;
+  bonus?: boolean;
+  onChange: (resposta: Resposta) => void;
+}
+
+export function CriterioCard({ criterio: c, resposta: r, percentual: pct, bonus, onChange }: CriterioCardProps) {
+  return (
+    <Card
+      className={cn(
+        "transition-colors",
+        bonus
+          ? cn("border-amber-500/30", r.atingido && "bg-amber-500/10")
+          : r.atingido && "bg-green-500/5 border-green-500/30",
+      )}
+    >
+      <CardHeader className="pb-3">
+        <div className="flex items-start justify-between gap-2">
+          <div className="flex-1 min-w-0">
+            <CardTitle className="text-sm leading-tight">{c.nome}</CardTitle>
+            {c.descricao && (
+              <p className="text-xs text-muted-foreground mt-1.5 leading-relaxed">
+                {c.descricao}
+              </p>
+            )}
+          </div>
+          <Badge
+            variant="outline"
+            className={cn("shrink-0 text-xs", bonus && "bg-amber-500/10 border-amber-500/40 text-amber-700")}
+          >
+            Vale {fmtPct(pct)}
+          </Badge>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <div className="flex items-center gap-2">
+          <Switch
+            checked={r.atingido}
+            onCheckedChange={(v) => onChange({ ...r, atingido: v })}
+          />
+          <label className="text-sm font-medium cursor-pointer">
+            {r.atingido ? "Atingido" : "Não atingido"}
+          </label>
+        </div>
+        {r.atingido && (
+          <Textarea
+            placeholder="Observação (opcional)..."
+            value={r.observacao}
+            onChange={(e) => onChange({ ...r, observacao: e.target.value })}
+            className="text-xs min-h-[60px]"
+          />
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/des/checkinQualitativo/DescontoProjetadoCard.tsx
+++ b/src/components/des/checkinQualitativo/DescontoProjetadoCard.tsx
@@ -1,0 +1,89 @@
+// Card de topo: desconto projetado para o próximo trimestre + ação Salvar.
+// Extraído verbatim de src/components/des/CheckinQualitativoTab.tsx (god-component split).
+import { ChevronDown, Save, Loader2 } from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { cn } from "@/lib/utils";
+import { type DescontoCheckin } from "./types";
+import { fmtPct } from "./format";
+
+interface DescontoProjetadoCardProps {
+  desconto: DescontoCheckin | null | undefined;
+  max: number;
+  total: number;
+  cardColor: string;
+  totalColor: string;
+  saving: boolean;
+  isLoading: boolean;
+  onSalvarProjecao: () => void;
+  onSalvarConfirmacao: () => void;
+}
+
+export function DescontoProjetadoCard({
+  desconto,
+  max,
+  total,
+  cardColor,
+  totalColor,
+  saving,
+  isLoading,
+  onSalvarProjecao,
+  onSalvarConfirmacao,
+}: DescontoProjetadoCardProps) {
+  return (
+    <Card className={cn("border-2", cardColor)}>
+      <CardContent className="pt-6">
+        <div className="flex items-start justify-between gap-4 flex-wrap">
+          <div className="flex-1 min-w-[280px]">
+            <p className="text-xs text-muted-foreground uppercase tracking-wide font-medium">
+              Desconto projetado para o próximo trimestre
+            </p>
+            <p className={cn("text-3xl font-bold mt-2", totalColor)}>
+              Se confirmar os critérios, será {fmtPct(total)}
+            </p>
+            <p className="text-xs text-muted-foreground mt-2">
+              Padrão da faixa: <strong>{fmtPct(desconto?.desconto_padrao)}</strong> + Qualitativos atingidos:{" "}
+              <strong>{fmtPct(desconto?.qualitativos_atingidos_perc)}</strong> + Bônus:{" "}
+              <strong>{fmtPct(desconto?.bonus_atingido_perc)}</strong>
+            </p>
+            {max > 0 && (
+              <p className="text-xs text-muted-foreground mt-1">
+                Máximo possível desta faixa: {fmtPct(max)}
+              </p>
+            )}
+          </div>
+
+          <div className="flex items-center gap-2">
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button disabled={saving || isLoading}>
+                  {saving ? (
+                    <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                  ) : (
+                    <Save className="h-4 w-4 mr-2" />
+                  )}
+                  Salvar
+                  <ChevronDown className="h-4 w-4 ml-2" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem onClick={onSalvarProjecao}>
+                  Salvar como Projeção
+                </DropdownMenuItem>
+                <DropdownMenuItem onClick={onSalvarConfirmacao}>
+                  Salvar como Confirmação (com André)
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/des/checkinQualitativo/HistoricoCheckins.tsx
+++ b/src/components/des/checkinQualitativo/HistoricoCheckins.tsx
@@ -1,0 +1,72 @@
+// Card de histórico de check-ins do trimestre.
+// Extraído verbatim de src/components/des/CheckinQualitativoTab.tsx (god-component split).
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { type DescontoCheckin } from "./types";
+import { fmtPct, fmtDate } from "./format";
+
+interface HistoricoCheckinsProps {
+  loading: boolean;
+  historico: DescontoCheckin[] | undefined;
+}
+
+export function HistoricoCheckins({ loading, historico }: HistoricoCheckinsProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Checkins anteriores neste trimestre</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {loading ? (
+          <Skeleton className="h-32 w-full" />
+        ) : (historico ?? []).length === 0 ? (
+          <p className="text-sm text-muted-foreground text-center py-6">
+            Nenhum checkin registrado ainda neste trimestre.
+          </p>
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Data</TableHead>
+                <TableHead>Tipo</TableHead>
+                <TableHead>Avaliado por</TableHead>
+                <TableHead className="text-right">Qualitativos</TableHead>
+                <TableHead className="text-right">Desconto projetado</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {historico!.map((h) => (
+                <TableRow key={h.checkin_id}>
+                  <TableCell className="text-xs">{fmtDate(h.data_avaliacao)}</TableCell>
+                  <TableCell>
+                    <Badge variant={h.tipo === "confirmacao_andre" ? "default" : "secondary"} className="text-xs">
+                      {h.tipo === "confirmacao_andre" ? "Confirmação" : "Projeção"}
+                    </Badge>
+                  </TableCell>
+                  <TableCell className="text-xs text-muted-foreground">
+                    {h.avaliado_por ?? "—"}
+                  </TableCell>
+                  <TableCell className="text-right text-xs">
+                    {fmtPct(h.qualitativos_atingidos_perc)}
+                  </TableCell>
+                  <TableCell className="text-right text-xs font-medium">
+                    {fmtPct(h.desconto_total_projetado)}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/des/checkinQualitativo/__tests__/CriterioCard.test.tsx
+++ b/src/components/des/checkinQualitativo/__tests__/CriterioCard.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { CriterioCard } from "../CriterioCard";
+import type { Criterio, Resposta } from "../types";
+
+const criterio: Criterio = {
+  id: 1, codigo: "Q1", nome: "Atende metas de mix", descricao: "Comprou todas as linhas", ordem: 1, tipo: "qualitativo",
+};
+
+function setup(overrides: Partial<React.ComponentProps<typeof CriterioCard>> = {}) {
+  const props: React.ComponentProps<typeof CriterioCard> = {
+    criterio,
+    resposta: { atingido: false, observacao: "" } as Resposta,
+    percentual: 2.5,
+    onChange: vi.fn(),
+    ...overrides,
+  };
+  render(<CriterioCard {...props} />);
+  return props;
+}
+
+describe("CriterioCard", () => {
+  it("renderiza nome, descrição e percentual", () => {
+    setup();
+    expect(screen.getByText("Atende metas de mix")).toBeTruthy();
+    expect(screen.getByText("Comprou todas as linhas")).toBeTruthy();
+    expect(screen.getByText("Vale 2,50%")).toBeTruthy();
+    expect(screen.getByText("Não atingido")).toBeTruthy();
+  });
+
+  it("alterna o switch chamando onChange com atingido=true", () => {
+    const props = setup();
+    fireEvent.click(screen.getByRole("switch"));
+    expect(props.onChange).toHaveBeenCalledWith({ atingido: true, observacao: "" });
+  });
+
+  it("mostra observação só quando atingido e dispara onChange ao digitar", () => {
+    const props = setup({ resposta: { atingido: true, observacao: "" } });
+    expect(screen.getByText("Atingido")).toBeTruthy();
+    const textarea = screen.getByPlaceholderText(/Observação/);
+    fireEvent.change(textarea, { target: { value: "ok" } });
+    expect(props.onChange).toHaveBeenCalledWith({ atingido: true, observacao: "ok" });
+  });
+
+  it("não renderiza textarea quando não atingido", () => {
+    setup({ resposta: { atingido: false, observacao: "" } });
+    expect(screen.queryByPlaceholderText(/Observação/)).toBeNull();
+  });
+});

--- a/src/components/des/checkinQualitativo/__tests__/DescontoProjetadoCard.test.tsx
+++ b/src/components/des/checkinQualitativo/__tests__/DescontoProjetadoCard.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { DescontoProjetadoCard } from "../DescontoProjetadoCard";
+import type { DescontoCheckin } from "../types";
+
+const desconto = {
+  checkin_id: 1, data_avaliacao: "2026-05-20", tipo: "projecao", faixa_numero: 2, estrelas: 3,
+  desconto_padrao: 5, qualitativos_atingidos_perc: 2.5, bonus_atingido_perc: 0,
+  desconto_total_projetado: 7.5, desconto_total_maximo: 10,
+} as DescontoCheckin;
+
+describe("DescontoProjetadoCard", () => {
+  it("mostra o total projetado e o máximo da faixa", () => {
+    render(
+      <DescontoProjetadoCard
+        desconto={desconto}
+        max={10}
+        total={7.5}
+        cardColor="bg-amber-500/5 border-amber-500/30"
+        totalColor="text-amber-700"
+        saving={false}
+        isLoading={false}
+        onSalvarProjecao={vi.fn()}
+        onSalvarConfirmacao={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/Se confirmar os critérios, será 7,50%/)).toBeTruthy();
+    expect(screen.getByText(/Máximo possível desta faixa: 10,00%/)).toBeTruthy();
+  });
+
+  it("desabilita o botão Salvar quando saving", () => {
+    render(
+      <DescontoProjetadoCard
+        desconto={desconto} max={10} total={7.5}
+        cardColor="" totalColor="" saving isLoading={false}
+        onSalvarProjecao={vi.fn()} onSalvarConfirmacao={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole("button", { name: /Salvar/ })).toHaveProperty("disabled", true);
+  });
+});

--- a/src/components/des/checkinQualitativo/__tests__/HistoricoCheckins.test.tsx
+++ b/src/components/des/checkinQualitativo/__tests__/HistoricoCheckins.test.tsx
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { HistoricoCheckins } from "../HistoricoCheckins";
+import type { DescontoCheckin } from "../types";
+
+function row(p: Partial<DescontoCheckin>): DescontoCheckin {
+  return {
+    checkin_id: 1, data_avaliacao: "2026-05-20", tipo: "projecao",
+    faixa_numero: 2, estrelas: 3, desconto_padrao: 5,
+    qualitativos_atingidos_perc: 2.5, bonus_atingido_perc: 0,
+    desconto_total_projetado: 7.5, desconto_total_maximo: 10, avaliado_por: "joao",
+    ...p,
+  };
+}
+
+describe("HistoricoCheckins", () => {
+  it("mostra mensagem vazia", () => {
+    render(<HistoricoCheckins loading={false} historico={[]} />);
+    expect(screen.getByText(/Nenhum checkin registrado/)).toBeTruthy();
+  });
+
+  it("renderiza linha de projeção com data e percentuais", () => {
+    render(<HistoricoCheckins loading={false} historico={[row({})]} />);
+    expect(screen.getByText("20/05/2026")).toBeTruthy();
+    expect(screen.getByText("Projeção")).toBeTruthy();
+    expect(screen.getByText("joao")).toBeTruthy();
+    expect(screen.getByText("7,50%")).toBeTruthy();
+  });
+
+  it("rotula confirmacao_andre como Confirmação", () => {
+    render(<HistoricoCheckins loading={false} historico={[row({ tipo: "confirmacao_andre" })]} />);
+    expect(screen.getByText("Confirmação")).toBeTruthy();
+  });
+});

--- a/src/components/des/checkinQualitativo/__tests__/format.test.ts
+++ b/src/components/des/checkinQualitativo/__tests__/format.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { fmtPct, fmtDate } from "../format";
+
+describe("fmtPct", () => {
+  it("retorna — para null/undefined", () => {
+    expect(fmtPct(null)).toBe("—");
+    expect(fmtPct(undefined)).toBe("—");
+  });
+  it("formata com 2 casas e vírgula", () => {
+    expect(fmtPct(12.5)).toBe("12,50%");
+    expect(fmtPct(0)).toBe("0,00%");
+  });
+});
+
+describe("fmtDate", () => {
+  it("retorna — para vazio", () => {
+    expect(fmtDate(null)).toBe("—");
+    expect(fmtDate(undefined)).toBe("—");
+  });
+  it("formata data ISO (yyyy-mm-dd) para pt-BR", () => {
+    expect(fmtDate("2026-05-20")).toBe("20/05/2026");
+  });
+});

--- a/src/components/des/checkinQualitativo/format.ts
+++ b/src/components/des/checkinQualitativo/format.ts
@@ -1,0 +1,8 @@
+// Helpers de formatação do check-in qualitativo (puros).
+// Extraídos verbatim de src/components/des/CheckinQualitativoTab.tsx (god-component split).
+
+export const fmtPct = (v: number | null | undefined) =>
+  v == null ? "—" : `${Number(v).toFixed(2).replace(".", ",")}%`;
+
+export const fmtDate = (d: string | null | undefined) =>
+  d ? new Date(d + "T00:00:00").toLocaleDateString("pt-BR") : "—";

--- a/src/components/des/checkinQualitativo/types.ts
+++ b/src/components/des/checkinQualitativo/types.ts
@@ -1,0 +1,83 @@
+// Tipos do check-in qualitativo DES.
+// Extraídos verbatim de src/components/des/CheckinQualitativoTab.tsx (god-component split).
+
+export interface Props {
+  empresa: string;
+  ano: number;
+  trimestre: number;
+}
+
+export interface Criterio {
+  id: number;
+  codigo: string;
+  nome: string;
+  descricao: string | null;
+  ordem: number;
+  tipo: "qualitativo" | "bonus" | string;
+}
+
+export interface CriterioPercentual {
+  criterio_id: number;
+  faixa_id: number;
+  percentual: number;
+}
+
+export interface DescontoCheckin {
+  checkin_id: number;
+  data_avaliacao: string;
+  tipo: string;
+  faixa_numero: number | null;
+  estrelas: number | null;
+  desconto_padrao: number | null;
+  qualitativos_atingidos_perc: number | null;
+  bonus_atingido_perc: number | null;
+  desconto_total_projetado: number | null;
+  desconto_total_maximo: number | null;
+  avaliado_por?: string | null;
+}
+
+export interface CheckinAtualRow {
+  checkin_id: number;
+  data_avaliacao: string;
+  tipo: string;
+  avaliado_com: string | null;
+  avaliado_por: string | null;
+  codigo: string;
+  nome: string;
+  criterio_tipo: string;
+  atingido: boolean;
+  observacao_criterio: string | null;
+}
+
+export interface FaixaInfo {
+  faixa_id: number | null;
+  [key: string]: unknown;
+}
+
+export interface PosicaoTrimestreRow {
+  faixa_conservadora: FaixaInfo | null;
+  faixa_otimista: FaixaInfo | null;
+}
+
+export interface DescontoCheckinRow {
+  checkin_id: number;
+  data_avaliacao: string;
+  tipo: string;
+  faixa_numero: number | null;
+  estrelas: number | null;
+  desconto_padrao: number | null;
+  qualitativos_atingidos_perc: number | null;
+  bonus_atingido_perc: number | null;
+  desconto_total_projetado: number | null;
+  desconto_total_maximo: number | null;
+}
+
+export interface CheckinQualitativoRow {
+  id: number;
+  avaliado_por: string | null;
+}
+
+export interface Resposta {
+  atingido: boolean;
+  observacao: string;
+}

--- a/src/components/des/checkinQualitativo/useCheckinQualitativo.ts
+++ b/src/components/des/checkinQualitativo/useCheckinQualitativo.ts
@@ -1,0 +1,297 @@
+// Lógica do check-in qualitativo DES (queries, respostas, salvar projeção/confirmação).
+// Extraída verbatim de src/components/des/CheckinQualitativoTab.tsx (god-component split).
+import { useEffect, useMemo, useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { supabase } from "@/integrations/supabase/client";
+import { useAuth } from "@/contexts/AuthContext";
+import {
+  type Props,
+  type Criterio,
+  type CriterioPercentual,
+  type DescontoCheckin,
+  type CheckinAtualRow,
+  type PosicaoTrimestreRow,
+  type DescontoCheckinRow,
+  type CheckinQualitativoRow,
+  type Resposta,
+} from "./types";
+
+export function useCheckinQualitativo({ empresa, ano, trimestre }: Props) {
+  const { user } = useAuth();
+  const qc = useQueryClient();
+
+  const [respostas, setRespostas] = useState<Record<number, Resposta>>({});
+  const [saving, setSaving] = useState(false);
+  const [confirmAndreOpen, setConfirmAndreOpen] = useState(false);
+
+  // Critérios cadastrados
+  const criteriosQuery = useQuery({
+    queryKey: ["des-criterios"],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from("des_criterio_qualitativo")
+        .select("id, codigo, nome, descricao, ordem, tipo")
+        .order("ordem", { ascending: true });
+      if (error) throw error;
+      return (data ?? []) as Criterio[];
+    },
+  });
+
+  // Posição ao vivo (para descobrir faixa atual e percentuais)
+  const posicaoQuery = useQuery({
+    queryKey: ["des-posicao-checkin", empresa, ano, trimestre],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from("v_des_posicao_trimestre_ao_vivo" as never)
+        .select("faixa_conservadora, faixa_otimista")
+        .eq("empresa", empresa)
+        .eq("ano", ano)
+        .eq("trimestre", trimestre)
+        .maybeSingle();
+      if (error) throw error;
+      return data as unknown as PosicaoTrimestreRow | null;
+    },
+  });
+
+  // Percentuais por critério para a faixa atual
+  const faixaConservId = posicaoQuery.data?.faixa_conservadora?.faixa_id ?? null;
+
+  const percentuaisQuery = useQuery({
+    queryKey: ["des-percentuais", faixaConservId],
+    enabled: !!faixaConservId,
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from("des_criterio_percentual")
+        .select("criterio_id, faixa_id, percentual")
+        .eq("faixa_id", faixaConservId as number);
+      if (error) throw error;
+      return (data ?? []) as CriterioPercentual[];
+    },
+  });
+
+  // Checkin atual (mais recente do trimestre)
+  const checkinAtualQuery = useQuery({
+    queryKey: ["des-checkin-atual", empresa, ano, trimestre],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from("v_des_checkin_atual" as never)
+        .select("*")
+        .eq("empresa", empresa)
+        .eq("ano", ano)
+        .eq("trimestre", trimestre);
+      if (error) throw error;
+      return (data ?? []) as unknown as CheckinAtualRow[];
+    },
+  });
+
+  // Desconto projetado para o checkin atual
+  const descontoQuery = useQuery({
+    queryKey: ["des-desconto", empresa, ano, trimestre],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from("v_des_desconto_por_checkin" as never)
+        .select("*")
+        .eq("empresa", empresa)
+        .eq("ano", ano)
+        .eq("trimestre", trimestre)
+        .order("data_avaliacao", { ascending: false })
+        .limit(1)
+        .maybeSingle();
+      if (error) throw error;
+      return data as unknown as DescontoCheckin | null;
+    },
+  });
+
+  // Histórico de checkins do trimestre
+  const historicoQuery = useQuery({
+    queryKey: ["des-checkin-historico", empresa, ano, trimestre],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from("v_des_desconto_por_checkin" as never)
+        .select("*")
+        .eq("empresa", empresa)
+        .eq("ano", ano)
+        .eq("trimestre", trimestre)
+        .order("data_avaliacao", { ascending: false });
+      if (error) throw error;
+      const rows = (data ?? []) as unknown as DescontoCheckinRow[];
+      // join avaliado_por via des_checkin_qualitativo
+      const ids = rows.map((d) => d.checkin_id).filter(Boolean);
+      const porMap: Record<number, string | null> = {};
+      if (ids.length) {
+        const { data: chs } = await supabase
+          .from("des_checkin_qualitativo")
+          .select("id, avaliado_por")
+          .in("id", ids);
+        const chsRows = (chs ?? []) as unknown as CheckinQualitativoRow[];
+        chsRows.forEach((c) => { porMap[c.id] = c.avaliado_por; });
+      }
+      return rows.map((d) => ({
+        ...d,
+        avaliado_por: porMap[d.checkin_id] ?? null,
+      })) as DescontoCheckin[];
+    },
+  });
+
+  // Inicializa respostas a partir do checkin atual
+  useEffect(() => {
+    const criterios = criteriosQuery.data ?? [];
+    const rows = checkinAtualQuery.data ?? [];
+    if (!criterios.length) return;
+
+    const next: Record<number, Resposta> = {};
+    criterios.forEach((c) => {
+      const row = rows.find((r) => r.codigo === c.codigo);
+      next[c.id] = {
+        atingido: row?.atingido ?? false,
+        observacao: row?.observacao_criterio ?? "",
+      };
+    });
+    setRespostas(next);
+  }, [criteriosQuery.data, checkinAtualQuery.data]);
+
+  const percentualPorCriterio = useMemo(() => {
+    const map: Record<number, number> = {};
+    (percentuaisQuery.data ?? []).forEach((p) => {
+      map[p.criterio_id] = Number(p.percentual);
+    });
+    return map;
+  }, [percentuaisQuery.data]);
+
+  const desconto = descontoQuery.data;
+  const max = Number(desconto?.desconto_total_maximo ?? 0);
+  const total = Number(desconto?.desconto_total_projetado ?? 0);
+  const ratio = max > 0 ? total / max : 0;
+  const cardColor =
+    ratio >= 1
+      ? "bg-green-500/5 border-green-500/30"
+      : ratio >= 0.5
+        ? "bg-amber-500/5 border-amber-500/30"
+        : "bg-red-500/5 border-red-500/30";
+  const totalColor =
+    ratio >= 1 ? "text-green-700" : ratio >= 0.5 ? "text-amber-700" : "text-red-700";
+
+  async function salvarCheckin(tipo: "projecao" | "confirmacao_andre") {
+    if (!user) {
+      toast.error("Sessão expirada. Faça login novamente.");
+      return;
+    }
+    setSaving(true);
+    try {
+      const hoje = new Date().toISOString().slice(0, 10);
+      const avaliadoCom = tipo === "confirmacao_andre" ? "André (Sayerlack)" : null;
+      const avaliadoPor = user.email ?? user.id;
+
+      // 1. Procura checkin existente do mesmo tipo
+      const { data: existentes, error: errFind } = await supabase
+        .from("des_checkin_qualitativo")
+        .select("id")
+        .eq("empresa", empresa)
+        .eq("ano", ano)
+        .eq("trimestre", trimestre)
+        .eq("tipo", tipo)
+        .order("criado_em", { ascending: false })
+        .limit(1);
+      if (errFind) throw errFind;
+
+      let checkinId: number;
+      if (existentes && existentes.length > 0) {
+        checkinId = existentes[0].id;
+        const { error: errUpd } = await supabase
+          .from("des_checkin_qualitativo")
+          .update({
+            data_avaliacao: hoje,
+            avaliado_por: avaliadoPor,
+            avaliado_com: avaliadoCom,
+            atualizado_em: new Date().toISOString(),
+          })
+          .eq("id", checkinId);
+        if (errUpd) throw errUpd;
+      } else {
+        const { data: novo, error: errIns } = await supabase
+          .from("des_checkin_qualitativo")
+          .insert({
+            empresa,
+            ano,
+            trimestre,
+            data_avaliacao: hoje,
+            tipo,
+            avaliado_por: avaliadoPor,
+            avaliado_com: avaliadoCom,
+          })
+          .select("id")
+          .single();
+        if (errIns) throw errIns;
+        checkinId = novo.id;
+      }
+
+      // 2. Apaga respostas antigas e insere novas
+      const { error: errDel } = await supabase
+        .from("des_checkin_qualitativo_resposta")
+        .delete()
+        .eq("checkin_id", checkinId);
+      if (errDel) throw errDel;
+
+      const novasRespostas = Object.entries(respostas).map(([critId, val]) => ({
+        checkin_id: checkinId,
+        criterio_id: Number(critId),
+        atingido: val.atingido,
+        observacao: val.observacao || null,
+      }));
+
+      if (novasRespostas.length) {
+        const { error: errInsR } = await supabase
+          .from("des_checkin_qualitativo_resposta")
+          .insert(novasRespostas);
+        if (errInsR) throw errInsR;
+      }
+
+      toast.success(
+        tipo === "projecao"
+          ? "Projeção atualizada."
+          : "Confirmação com André registrada."
+      );
+
+      // Refetch
+      qc.invalidateQueries({ queryKey: ["des-checkin-atual", empresa, ano, trimestre] });
+      qc.invalidateQueries({ queryKey: ["des-desconto", empresa, ano, trimestre] });
+      qc.invalidateQueries({ queryKey: ["des-checkin-historico", empresa, ano, trimestre] });
+    } catch (err) {
+      console.error(err);
+      const msg = err instanceof Error ? err.message : "desconhecido";
+      toast.error("Erro ao salvar checkin: " + msg);
+    } finally {
+      setSaving(false);
+      setConfirmAndreOpen(false);
+    }
+  }
+
+  const isLoading = criteriosQuery.isLoading || checkinAtualQuery.isLoading;
+  const criterios = criteriosQuery.data ?? [];
+  const qualitativos = criterios.filter((c) => c.tipo === "qualitativo");
+  const bonusItems = criterios.filter((c) => c.tipo === "bonus");
+
+  const setResposta = (id: number, resposta: Resposta) =>
+    setRespostas((prev) => ({ ...prev, [id]: resposta }));
+
+  return {
+    respostas,
+    setResposta,
+    saving,
+    confirmAndreOpen,
+    setConfirmAndreOpen,
+    percentualPorCriterio,
+    desconto,
+    max,
+    total,
+    cardColor,
+    totalColor,
+    salvarCheckin,
+    isLoading,
+    qualitativos,
+    bonusItems,
+    historicoLoading: historicoQuery.isLoading,
+    historico: historicoQuery.data,
+  };
+}


### PR DESCRIPTION
## Resumo
- Split estrutural de `CheckinQualitativoTab` (640→**104** linhas), preservando 100% do comportamento (move verbatim).
- Lógica isolada no hook **`useCheckinQualitativo`** (6 queries DES, init de respostas, derivações de desconto, `salvarCheckin` projeção/confirmação).
- JSX em componentes controlados: **`DescontoProjetadoCard`**, **`CriterioCard`** (unifica os cards qualitativo/bônus que eram idênticos exceto classes), **`HistoricoCheckins`**, **`ConfirmacaoAndreDialog`**. Tipos + `format` (`fmtPct`/`fmtDate`) extraídos.

## Verificação
- `bunx tsc --noEmit` = 0 erros
- `bunx eslint` nos arquivos tocados = 0
- Testes novos (+13) passam isolados (4/4 arquivos). ⚠️ Suíte completa local com flakiness por contenção de CPU. Gate autoritativo = CI `validate`.
- Revisão independente de fidelidade (subagente): **FIEL 1:1**, zero divergências (unificação dos cards = classes idênticas; `salvarCheckin` byte-a-byte).

## Test plan
- [x] tsc / eslint verdes; +13 testes novos verdes isolados
- [x] Revisão 1:1 confirmando comportamento idêntico
- [ ] CI `validate` verde (gate da suíte completa)

🤖 Generated with [Claude Code](https://claude.com/claude-code)