### PR TITLE
refactor(farmer): split FarmerCopilot (615→166) em hook + componentes

### DIFF
--- a/src/components/farmer/copilot/ActivePlanCard.tsx
+++ b/src/components/farmer/copilot/ActivePlanCard.tsx
@@ -1,0 +1,43 @@
+// Card do PTPL (plano tático) ativo durante a sessão.
+// Extraído verbatim de src/pages/FarmerCopilot.tsx (god-component split).
+import { FileText, ChevronDown, ChevronUp } from 'lucide-react';
+import { Card, CardContent } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { getObjectiveLabel, type TacticalPlan } from '@/hooks/useTacticalPlan';
+
+interface ActivePlanCardProps {
+  activePlan: TacticalPlan;
+  showPlan: boolean;
+  onToggle: () => void;
+}
+
+export function ActivePlanCard({ activePlan, showPlan, onToggle }: ActivePlanCardProps) {
+  return (
+    <Card className="border-dashed border-primary/30">
+      <CardContent className="p-3">
+        <div className="flex items-center justify-between" onClick={onToggle} role="button">
+          <div className="flex items-center gap-2">
+            <FileText className="w-3.5 h-3.5 text-primary" />
+            <span className="text-[10px] font-semibold">PTPL Ativo — {activePlan.planType === 'estrategico' ? 'Estratégico' : 'Essencial'}</span>
+          </div>
+          {showPlan ? <ChevronUp className="w-3 h-3" /> : <ChevronDown className="w-3 h-3" />}
+        </div>
+        {showPlan && (
+          <div className="mt-2 space-y-1.5 text-[9px]">
+            <div className="flex gap-1.5">
+              <Badge variant="outline" className="text-[7px]">{getObjectiveLabel(activePlan.strategicObjective)}</Badge>
+              <Badge variant="outline" className="text-[7px]">HS: {Math.round(activePlan.healthScore)}</Badge>
+              <Badge variant="outline" className="text-[7px]">Churn: {Math.round(activePlan.churnRisk)}%</Badge>
+            </div>
+            {activePlan.approachStrategy && (
+              <p className="text-muted-foreground">{activePlan.approachStrategy}</p>
+            )}
+            {activePlan.diagnosticQuestions.slice(0, 2).map((q, i) => (
+              <p key={i} className="text-muted-foreground">• {q.question}</p>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/farmer/copilot/AnalysisHistoryCard.tsx
+++ b/src/components/farmer/copilot/AnalysisHistoryCard.tsx
@@ -1,0 +1,39 @@
+// Card de histórico de análises da sessão.
+// Extraído verbatim de src/pages/FarmerCopilot.tsx (god-component split).
+import { Brain } from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import type { CopilotAnalysis } from '@/hooks/useCopilotEngine';
+import { intentLabels } from './config';
+
+interface AnalysisHistoryCardProps {
+  analysisHistory: CopilotAnalysis[];
+}
+
+export function AnalysisHistoryCard({ analysisHistory }: AnalysisHistoryCardProps) {
+  return (
+    <Card>
+      <CardHeader className="p-3 pb-2">
+        <CardTitle className="text-xs flex items-center gap-2">
+          <Brain className="w-3 h-3" /> Histórico de Análises ({analysisHistory.length})
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="p-3 pt-0">
+        <div className="space-y-1.5">
+          {analysisHistory.slice(-5).reverse().map((a, i) => {
+            return (
+              <div key={i} className="flex items-center gap-2 text-[9px]">
+                <div className={`w-2 h-2 rounded-full ${
+                  a.direction === 'positivo' ? 'bg-status-success' :
+                  a.direction === 'risco' ? 'bg-status-error' : 'bg-status-warning'
+                }`} />
+                <span className="font-medium">{intentLabels[a.intent]?.label}</span>
+                <span className="text-muted-foreground">→</span>
+                <span className="text-muted-foreground truncate flex-1">{a.suggestion.slice(0, 50)}...</span>
+              </div>
+            );
+          })}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/farmer/copilot/DirectionIndicator.tsx
+++ b/src/components/farmer/copilot/DirectionIndicator.tsx
@@ -1,0 +1,43 @@
+// Indicador de direção da conversa (positivo/neutro/risco) + intenção + fase.
+// Extraído verbatim de src/pages/FarmerCopilot.tsx (god-component split).
+import type { LucideIcon } from 'lucide-react';
+import { Card, CardContent } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import type { CopilotAnalysis } from '@/hooks/useCopilotEngine';
+import { intentLabels, phaseLabels } from './config';
+
+interface DirectionIndicatorProps {
+  analysis: CopilotAnalysis;
+  dir: { color: string; bg: string; icon: LucideIcon; label: string };
+  DirIcon: LucideIcon;
+}
+
+export function DirectionIndicator({ analysis, dir, DirIcon }: DirectionIndicatorProps) {
+  return (
+    <Card className={`border ${dir.bg}`}>
+      <CardContent className="p-3">
+        <div className="flex items-center justify-between mb-1">
+          <div className="flex items-center gap-2">
+            <DirIcon className={`w-5 h-5 ${dir.color}`} />
+            <span className={`text-sm font-bold ${dir.color}`}>{dir.label}</span>
+          </div>
+          <div className="flex gap-1">
+            <Badge className={intentLabels[analysis.intent]?.color || ''} variant="secondary">
+              {intentLabels[analysis.intent]?.label || analysis.intent}
+            </Badge>
+            <Badge variant="outline" className="text-[9px]">
+              {phaseLabels[analysis.phase] || analysis.phase}
+            </Badge>
+          </div>
+        </div>
+        {analysis.directionReasons.length > 0 && (
+          <div className="flex flex-wrap gap-1 mt-1">
+            {analysis.directionReasons.map((r, i) => (
+              <span key={i} className="text-[9px] text-muted-foreground">• {r}</span>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/farmer/copilot/ManualTextInput.tsx
+++ b/src/components/farmer/copilot/ManualTextInput.tsx
@@ -1,0 +1,45 @@
+// Entrada manual de texto (modo texto do copiloto).
+// Extraído verbatim de src/pages/FarmerCopilot.tsx (god-component split).
+import { Type, Send, Loader2 } from 'lucide-react';
+import { Card, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+
+interface ManualTextInputProps {
+  manualText: string;
+  setManualText: (v: string) => void;
+  isManualAnalyzing: boolean;
+  onAnalyze: () => void;
+}
+
+export function ManualTextInput({ manualText, setManualText, isManualAnalyzing, onAnalyze }: ManualTextInputProps) {
+  return (
+    <Card>
+      <CardContent className="p-3 space-y-2">
+        <div className="flex items-center gap-2">
+          <Type className="w-3.5 h-3.5 text-muted-foreground" />
+          <span className="text-[10px] font-semibold text-muted-foreground">Entrada de texto</span>
+        </div>
+        <Textarea
+          value={manualText}
+          onChange={(e) => setManualText(e.target.value)}
+          placeholder="Cole ou digite trechos da conversa aqui..."
+          className="text-xs min-h-[80px] resize-none"
+        />
+        <Button
+          size="sm"
+          className="w-full h-8 gap-1.5 text-xs"
+          disabled={isManualAnalyzing || !manualText.trim()}
+          onClick={onAnalyze}
+        >
+          {isManualAnalyzing ? (
+            <Loader2 className="w-3 h-3 animate-spin" />
+          ) : (
+            <Send className="w-3 h-3" />
+          )}
+          Analisar
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/farmer/copilot/SessionStartCard.tsx
+++ b/src/components/farmer/copilot/SessionStartCard.tsx
@@ -1,0 +1,103 @@
+// Card de início de sessão do copiloto (modo voz/texto + cliente + iniciar).
+// Extraído verbatim de src/pages/FarmerCopilot.tsx (god-component split).
+import { Mic, Radio, Type, AlertTriangle, Loader2 } from 'lucide-react';
+import { Card, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { cn } from '@/lib/utils';
+import type { InputMode } from './types';
+
+interface SessionStartCardProps {
+  inputMode: InputMode;
+  setInputMode: (m: InputMode) => void;
+  selectedCustomer: string;
+  setSelectedCustomer: (v: string) => void;
+  customers: { id: string; name: string }[];
+  isConnecting: boolean;
+  onStart: () => void;
+}
+
+export function SessionStartCard({
+  inputMode,
+  setInputMode,
+  selectedCustomer,
+  setSelectedCustomer,
+  customers,
+  isConnecting,
+  onStart,
+}: SessionStartCardProps) {
+  return (
+    <Card className="border-primary/20">
+      <CardContent className="p-4 space-y-3">
+        <div className="flex items-center gap-2 mb-1">
+          <Radio className="w-5 h-5 text-primary" />
+          <h2 className="text-sm font-bold">Iniciar Copiloto</h2>
+        </div>
+        <p className="text-[10px] text-muted-foreground">
+          O copiloto analisa a conversa, detecta intenções e sugere a melhor ação em cada momento.
+        </p>
+
+        {/* Mode Toggle */}
+        <div className="flex rounded-lg border overflow-hidden">
+          <button
+            onClick={() => setInputMode('voice')}
+            className={cn(
+              'flex-1 flex items-center justify-center gap-1.5 py-2 text-xs font-medium transition-colors',
+              inputMode === 'voice'
+                ? 'bg-primary text-primary-foreground'
+                : 'bg-muted/50 text-muted-foreground hover:bg-muted'
+            )}
+          >
+            <Mic className="w-3.5 h-3.5" /> Voz
+          </button>
+          <button
+            onClick={() => setInputMode('text')}
+            className={cn(
+              'flex-1 flex items-center justify-center gap-1.5 py-2 text-xs font-medium transition-colors',
+              inputMode === 'text'
+                ? 'bg-primary text-primary-foreground'
+                : 'bg-muted/50 text-muted-foreground hover:bg-muted'
+            )}
+          >
+            <Type className="w-3.5 h-3.5" /> Texto
+          </button>
+        </div>
+
+        {inputMode === 'text' && (
+          <div className="flex items-start gap-1.5 p-2 rounded-md bg-status-warning-bg border border-status-warning/30">
+            <AlertTriangle className="w-3.5 h-3.5 text-status-warning mt-0.5 shrink-0" />
+            <p className="text-[9px] text-status-warning">
+              No modo texto, cole ou digite trechos da conversa e clique em "Analisar" para receber sugestões.
+            </p>
+          </div>
+        )}
+
+        <Select value={selectedCustomer} onValueChange={setSelectedCustomer}>
+          <SelectTrigger className="h-9 text-xs">
+            <SelectValue placeholder="Selecionar cliente (opcional)" />
+          </SelectTrigger>
+          <SelectContent>
+            {customers.map(c => (
+              <SelectItem key={c.id} value={c.id} className="text-xs">{c.name}</SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <Button
+          onClick={onStart}
+          disabled={isConnecting}
+          className="w-full gap-2"
+        >
+          {isConnecting ? (
+            <Loader2 className="w-4 h-4 animate-spin" />
+          ) : inputMode === 'voice' ? (
+            <Mic className="w-4 h-4" />
+          ) : (
+            <Type className="w-4 h-4" />
+          )}
+          {isConnecting ? 'Conectando...' : inputMode === 'voice' ? 'Iniciar Transcrição' : 'Iniciar Modo Texto'}
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/farmer/copilot/SuggestionCard.tsx
+++ b/src/components/farmer/copilot/SuggestionCard.tsx
@@ -1,0 +1,67 @@
+// Card da sugestão da IA (com cópia e contadores).
+// Extraído verbatim de src/pages/FarmerCopilot.tsx (god-component split).
+import { Copy, Check, type LucideIcon } from 'lucide-react';
+import { Card, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import type { CopilotAnalysis } from '@/hooks/useCopilotEngine';
+
+interface SuggestionCardProps {
+  analysis: CopilotAnalysis;
+  SugIcon: LucideIcon;
+  riskFlash: boolean;
+  copied: boolean;
+  onCopy: (text: string) => void;
+  suggestionsShown: number;
+  suggestionsUsed: number;
+}
+
+export function SuggestionCard({
+  analysis,
+  SugIcon,
+  riskFlash,
+  copied,
+  onCopy,
+  suggestionsShown,
+  suggestionsUsed,
+}: SuggestionCardProps) {
+  return (
+    <Card className={cn(
+      'border-2 border-primary/30 bg-primary/5 transition-all duration-500',
+      riskFlash && analysis.direction === 'risco' && 'ring-2 ring-red-400 shadow-lg shadow-red-100'
+    )}>
+      <CardContent className="p-3">
+        <div className="flex items-start justify-between gap-2">
+          <div className="flex items-start gap-2 flex-1">
+            <SugIcon className="w-4 h-4 text-primary mt-0.5 shrink-0" />
+            <div>
+              <p className="text-[10px] font-semibold text-primary mb-0.5">
+                {analysis.suggestionType === 'pergunta_diagnostica' ? 'Pergunta Sugerida' :
+                 analysis.suggestionType === 'resposta_tecnica' ? 'Resposta Técnica' :
+                 analysis.suggestionType === 'argumento_economico' ? 'Argumento Econômico' :
+                 'Abordagem Alternativa'}
+              </p>
+              <p className="text-xs leading-relaxed">{analysis.suggestion}</p>
+            </div>
+          </div>
+          <Button
+            size="sm"
+            variant="ghost"
+            className="h-7 w-7 p-0 shrink-0"
+            onClick={() => onCopy(analysis.suggestion)}
+          >
+            {copied ? <Check className="w-3 h-3 text-status-success" /> : <Copy className="w-3 h-3" />}
+          </Button>
+        </div>
+        <div className="flex items-center justify-between mt-2">
+          <span className="text-[9px] text-muted-foreground">
+            Confiança: {analysis.confidence}%
+          </span>
+          <span className="text-[9px] text-muted-foreground">
+            {suggestionsShown} sugestões • {suggestionsUsed} usadas
+          </span>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/farmer/copilot/TranscriptCard.tsx
+++ b/src/components/farmer/copilot/TranscriptCard.tsx
@@ -1,0 +1,46 @@
+// Card de transcrição da conversa (voz ou texto).
+// Extraído verbatim de src/pages/FarmerCopilot.tsx (god-component split).
+import { MessageSquare } from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import type { TranscriptEntry } from '@/hooks/useCopilotEngine';
+import type { InputMode } from './types';
+
+interface TranscriptCardProps {
+  transcript: TranscriptEntry[];
+  inputMode: InputMode;
+  transcriptEndRef: React.RefObject<HTMLDivElement>;
+}
+
+export function TranscriptCard({ transcript, inputMode, transcriptEndRef }: TranscriptCardProps) {
+  return (
+    <Card>
+      <CardHeader className="p-3 pb-2">
+        <CardTitle className="text-xs flex items-center gap-2">
+          <MessageSquare className="w-3 h-3" /> Transcrição
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="p-0">
+        <ScrollArea className="h-48 px-3 pb-3">
+          {transcript.length === 0 ? (
+            <p className="text-[10px] text-muted-foreground text-center py-8">
+              {inputMode === 'voice' ? 'Aguardando fala...' : 'Nenhum texto analisado ainda.'}
+            </p>
+          ) : (
+            <div className="space-y-1">
+              {transcript.map(entry => (
+                <p
+                  key={entry.id}
+                  className={`text-xs leading-relaxed ${entry.isPartial ? 'text-muted-foreground italic' : ''}`}
+                >
+                  {entry.text}
+                </p>
+              ))}
+              <div ref={transcriptEndRef} />
+            </div>
+          )}
+        </ScrollArea>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/farmer/copilot/__tests__/DirectionIndicator.test.tsx
+++ b/src/components/farmer/copilot/__tests__/DirectionIndicator.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { TrendingUp } from 'lucide-react';
+import { DirectionIndicator } from '../DirectionIndicator';
+import { directionConfig } from '../config';
+import type { CopilotAnalysis } from '@/hooks/useCopilotEngine';
+
+function analysis(p: Partial<CopilotAnalysis>): CopilotAnalysis {
+  return {
+    direction: 'positivo',
+    directionReasons: ['cliente engajado', 'pediu preço'],
+    intent: 'interesse',
+    phase: 'diagnostico',
+    suggestionType: 'argumento_economico',
+    suggestion: 's',
+    confidence: 80,
+    ...p,
+  } as CopilotAnalysis;
+}
+
+describe('DirectionIndicator', () => {
+  it('mostra label da direção, intenção, fase e motivos', () => {
+    render(
+      <DirectionIndicator
+        analysis={analysis({})}
+        dir={directionConfig.positivo}
+        DirIcon={TrendingUp}
+      />,
+    );
+    expect(screen.getByText('Positivo')).toBeTruthy();
+    expect(screen.getByText('Interesse')).toBeTruthy();
+    expect(screen.getByText(/Diagnóstico/)).toBeTruthy();
+    expect(screen.getByText(/cliente engajado/)).toBeTruthy();
+  });
+
+  it('usa o label cru quando intent é desconhecido', () => {
+    render(
+      <DirectionIndicator
+        analysis={analysis({ intent: 'xpto' as CopilotAnalysis['intent'], directionReasons: [] })}
+        dir={directionConfig.positivo}
+        DirIcon={TrendingUp}
+      />,
+    );
+    expect(screen.getByText('xpto')).toBeTruthy();
+  });
+});

--- a/src/components/farmer/copilot/__tests__/ManualTextInput.test.tsx
+++ b/src/components/farmer/copilot/__tests__/ManualTextInput.test.tsx
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ManualTextInput } from '../ManualTextInput';
+
+function setup(overrides: Partial<React.ComponentProps<typeof ManualTextInput>> = {}) {
+  const props: React.ComponentProps<typeof ManualTextInput> = {
+    manualText: '',
+    setManualText: vi.fn(),
+    isManualAnalyzing: false,
+    onAnalyze: vi.fn(),
+    ...overrides,
+  };
+  render(<ManualTextInput {...props} />);
+  return props;
+}
+
+describe('ManualTextInput', () => {
+  it('dispara setManualText ao digitar', () => {
+    const props = setup();
+    fireEvent.change(screen.getByPlaceholderText(/Cole ou digite/), { target: { value: 'oi' } });
+    expect(props.setManualText).toHaveBeenCalledWith('oi');
+  });
+
+  it('botão Analisar desabilitado sem texto', () => {
+    setup({ manualText: '' });
+    expect(screen.getByRole('button', { name: /Analisar/ })).toHaveProperty('disabled', true);
+  });
+
+  it('dispara onAnalyze com texto presente', () => {
+    const props = setup({ manualText: 'conversa longa' });
+    fireEvent.click(screen.getByRole('button', { name: /Analisar/ }));
+    expect(props.onAnalyze).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/farmer/copilot/__tests__/SessionStartCard.test.tsx
+++ b/src/components/farmer/copilot/__tests__/SessionStartCard.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { SessionStartCard } from '../SessionStartCard';
+
+function setup(overrides: Partial<React.ComponentProps<typeof SessionStartCard>> = {}) {
+  const props: React.ComponentProps<typeof SessionStartCard> = {
+    inputMode: 'voice',
+    setInputMode: vi.fn(),
+    selectedCustomer: '',
+    setSelectedCustomer: vi.fn(),
+    customers: [{ id: 'c1', name: 'ACME' }],
+    isConnecting: false,
+    onStart: vi.fn(),
+    ...overrides,
+  };
+  render(<SessionStartCard {...props} />);
+  return props;
+}
+
+describe('SessionStartCard', () => {
+  it('modo voz: botão "Iniciar Transcrição"', () => {
+    setup({ inputMode: 'voice' });
+    expect(screen.getByRole('button', { name: /Iniciar Transcrição/ })).toBeTruthy();
+  });
+
+  it('modo texto: botão "Iniciar Modo Texto" + aviso', () => {
+    setup({ inputMode: 'text' });
+    expect(screen.getByRole('button', { name: /Iniciar Modo Texto/ })).toBeTruthy();
+    expect(screen.getByText(/No modo texto, cole ou digite/)).toBeTruthy();
+  });
+
+  it('alterna modo e dispara onStart', () => {
+    const props = setup({ inputMode: 'voice' });
+    fireEvent.click(screen.getByRole('button', { name: /^Texto$/ }));
+    expect(props.setInputMode).toHaveBeenCalledWith('text');
+    fireEvent.click(screen.getByRole('button', { name: /Iniciar Transcrição/ }));
+    expect(props.onStart).toHaveBeenCalledTimes(1);
+  });
+
+  it('conectando: mostra "Conectando..." e desabilita', () => {
+    setup({ isConnecting: true });
+    const btn = screen.getByRole('button', { name: /Conectando/ });
+    expect(btn).toHaveProperty('disabled', true);
+  });
+});

--- a/src/components/farmer/copilot/__tests__/SuggestionCard.test.tsx
+++ b/src/components/farmer/copilot/__tests__/SuggestionCard.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Lightbulb } from 'lucide-react';
+import { SuggestionCard } from '../SuggestionCard';
+import type { CopilotAnalysis } from '@/hooks/useCopilotEngine';
+
+function analysis(p: Partial<CopilotAnalysis>): CopilotAnalysis {
+  return {
+    direction: 'positivo',
+    directionReasons: [],
+    intent: 'interesse',
+    phase: 'abertura',
+    suggestionType: 'argumento_economico',
+    suggestion: 'Mostre o ROI do produto premium.',
+    confidence: 82,
+    ...p,
+  } as CopilotAnalysis;
+}
+
+describe('SuggestionCard', () => {
+  it('renderiza tipo da sugestão, texto e confiança', () => {
+    render(
+      <SuggestionCard
+        analysis={analysis({})}
+        SugIcon={Lightbulb}
+        riskFlash={false}
+        copied={false}
+        onCopy={vi.fn()}
+        suggestionsShown={3}
+        suggestionsUsed={1}
+      />,
+    );
+    expect(screen.getByText('Argumento Econômico')).toBeTruthy();
+    expect(screen.getByText('Mostre o ROI do produto premium.')).toBeTruthy();
+    expect(screen.getByText(/Confiança: 82%/)).toBeTruthy();
+    expect(screen.getByText(/3 sugestões • 1 usadas/)).toBeTruthy();
+  });
+
+  it('copia a sugestão ao clicar', () => {
+    const onCopy = vi.fn();
+    render(
+      <SuggestionCard
+        analysis={analysis({ suggestion: 'X' })}
+        SugIcon={Lightbulb}
+        riskFlash={false}
+        copied={false}
+        onCopy={onCopy}
+        suggestionsShown={0}
+        suggestionsUsed={0}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button'));
+    expect(onCopy).toHaveBeenCalledWith('X');
+  });
+
+  it('mostra rótulo de pergunta diagnóstica', () => {
+    render(
+      <SuggestionCard
+        analysis={analysis({ suggestionType: 'pergunta_diagnostica' })}
+        SugIcon={Lightbulb}
+        riskFlash={false}
+        copied={false}
+        onCopy={vi.fn()}
+        suggestionsShown={0}
+        suggestionsUsed={0}
+      />,
+    );
+    expect(screen.getByText('Pergunta Sugerida')).toBeTruthy();
+  });
+});

--- a/src/components/farmer/copilot/__tests__/TranscriptCard.test.tsx
+++ b/src/components/farmer/copilot/__tests__/TranscriptCard.test.tsx
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { createRef as reactCreateRef } from 'react';
+import { TranscriptCard } from '../TranscriptCard';
+import type { TranscriptEntry } from '@/hooks/useCopilotEngine';
+
+describe('TranscriptCard', () => {
+  it('mostra placeholder de voz quando vazio', () => {
+    render(<TranscriptCard transcript={[]} inputMode="voice" transcriptEndRef={reactCreateRef()} />);
+    expect(screen.getByText('Aguardando fala...')).toBeTruthy();
+  });
+
+  it('mostra placeholder de texto quando vazio', () => {
+    render(<TranscriptCard transcript={[]} inputMode="text" transcriptEndRef={reactCreateRef()} />);
+    expect(screen.getByText('Nenhum texto analisado ainda.')).toBeTruthy();
+  });
+
+  it('renderiza as entradas da transcrição', () => {
+    const transcript = [
+      { id: '1', text: 'olá', isPartial: false },
+      { id: '2', text: 'parcial', isPartial: true },
+    ] as unknown as TranscriptEntry[];
+    render(<TranscriptCard transcript={transcript} inputMode="voice" transcriptEndRef={reactCreateRef()} />);
+    expect(screen.getByText('olá')).toBeTruthy();
+    expect(screen.getByText('parcial')).toBeTruthy();
+  });
+});

--- a/src/components/farmer/copilot/config.ts
+++ b/src/components/farmer/copilot/config.ts
@@ -1,0 +1,44 @@
+// Constantes de apresentação do copiloto de vendas.
+// Extraídas verbatim de src/pages/FarmerCopilot.tsx (god-component split).
+import {
+  Lightbulb, MessageSquare, Brain, Target, Shield,
+  TrendingUp, TrendingDown, Minus, type LucideIcon,
+} from 'lucide-react';
+import type {
+  CopilotDirection,
+  CopilotPhase,
+  CopilotIntent,
+  SuggestionType,
+} from '@/hooks/useCopilotEngine';
+
+export const directionConfig: Record<CopilotDirection, { color: string; bg: string; icon: LucideIcon; label: string }> = {
+  positivo: { color: 'text-status-success', bg: 'bg-status-success-bg border-status-success/30', icon: TrendingUp, label: 'Positivo' },
+  neutro: { color: 'text-status-warning', bg: 'bg-status-warning-bg border-status-warning/30', icon: Minus, label: 'Neutro' },
+  risco: { color: 'text-status-error', bg: 'bg-status-error-bg border-status-error/30', icon: TrendingDown, label: 'Em Risco' },
+};
+
+export const phaseLabels: Record<CopilotPhase, string> = {
+  abertura: '🔵 Abertura',
+  diagnostico: '🔍 Diagnóstico',
+  exploracao: '🧭 Exploração',
+  proposta: '💼 Proposta',
+  fechamento: '🎯 Fechamento',
+};
+
+export const intentLabels: Record<CopilotIntent, { label: string; color: string }> = {
+  interesse: { label: 'Interesse', color: 'bg-status-success-bg text-status-success-fg' },
+  objecao_preco: { label: 'Objeção Preço', color: 'bg-status-error-bg text-status-error-fg' },
+  objecao_tecnica: { label: 'Objeção Técnica', color: 'bg-orange-100 text-orange-800' },
+  falta_urgencia: { label: 'Falta Urgência', color: 'bg-status-warning-bg text-status-warning-fg' },
+  comparacao_concorrente: { label: 'Concorrente', color: 'bg-purple-100 text-purple-800' },
+  indiferenca: { label: 'Indiferença', color: 'bg-muted text-muted-foreground' },
+};
+
+export const suggestionTypeIcons: Record<SuggestionType, LucideIcon> = {
+  pergunta_diagnostica: MessageSquare,
+  resposta_tecnica: Brain,
+  argumento_economico: Target,
+  alternativa_abordagem: Shield,
+};
+
+export const fallbackSuggestionIcon = Lightbulb;

--- a/src/components/farmer/copilot/types.ts
+++ b/src/components/farmer/copilot/types.ts
@@ -1,0 +1,4 @@
+// Tipos do copiloto de vendas.
+// Extraídos verbatim de src/pages/FarmerCopilot.tsx (god-component split).
+
+export type InputMode = 'voice' | 'text';

--- a/src/components/farmer/copilot/useFarmerCopilot.ts
+++ b/src/components/farmer/copilot/useFarmerCopilot.ts
@@ -1,0 +1,269 @@
+// Lógica do copiloto de vendas (sessão, transcrição ElevenLabs, análise, PTPL).
+// Extraída verbatim de src/pages/FarmerCopilot.tsx (god-component split).
+import { useState, useCallback, useEffect, useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useScribe, CommitStrategy } from '@elevenlabs/react';
+import { useAuth } from '@/contexts/AuthContext';
+import { useCopilotEngine, type CopilotContext } from '@/hooks/useCopilotEngine';
+import { useTacticalPlan, type TacticalPlan } from '@/hooks/useTacticalPlan';
+import { supabase } from '@/integrations/supabase/client';
+import { toast } from 'sonner';
+import { Minus } from 'lucide-react';
+import { directionConfig, suggestionTypeIcons, fallbackSuggestionIcon } from './config';
+import type { InputMode } from './types';
+
+export function useFarmerCopilot() {
+  const navigate = useNavigate();
+  const { user, isStaff } = useAuth();
+  const copilot = useCopilotEngine();
+  const { getActivePlan } = useTacticalPlan();
+  const [selectedCustomer, setSelectedCustomer] = useState<string>('');
+  const [customers, setCustomers] = useState<{ id: string; name: string }[]>([]);
+  const [isConnecting, setIsConnecting] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const [activePlan, setActivePlan] = useState<TacticalPlan | null>(null);
+  const [showPlan, setShowPlan] = useState(false);
+  const transcriptEndRef = useRef<HTMLDivElement>(null);
+
+  // Text mode state
+  const [inputMode, setInputMode] = useState<InputMode>('voice');
+  const [manualText, setManualText] = useState('');
+  const [isManualAnalyzing, setIsManualAnalyzing] = useState(false);
+  const [riskFlash, setRiskFlash] = useState(false);
+
+  // ElevenLabs realtime scribe
+  const scribe = useScribe({
+    modelId: 'scribe_v2_realtime',
+    commitStrategy: CommitStrategy.VAD,
+    onPartialTranscript: (data) => {
+      if (data.text) copilot.addTranscript(data.text, true);
+    },
+    onCommittedTranscript: (data) => {
+      if (data.text) copilot.addTranscript(data.text, false);
+    },
+  });
+
+  // Load customers
+  useEffect(() => {
+    if (!user?.id || !isStaff) return;
+    (async () => {
+      const { data: scores } = await supabase
+        .from('farmer_client_scores')
+        .select('customer_user_id')
+        .eq('farmer_id', user.id);
+      if (!scores?.length) return;
+      const ids = scores.map((s) => s.customer_user_id).filter((id): id is string => id !== null);
+      const { data: profiles } = await supabase
+        .from('profiles')
+        .select('user_id, name')
+        .in('user_id', ids);
+      if (profiles) {
+        setCustomers(profiles.map((p) => ({ id: p.user_id, name: p.name ?? '' })));
+      }
+    })();
+  }, [user, isStaff]);
+
+  // Auto-scroll transcript
+  useEffect(() => {
+    transcriptEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [copilot.transcript]);
+
+  // Flash risk highlight when direction changes to 'risco'
+  useEffect(() => {
+    if (copilot.currentAnalysis?.direction === 'risco') {
+      setRiskFlash(true);
+      const timer = setTimeout(() => setRiskFlash(false), 2500);
+      return () => clearTimeout(timer);
+    }
+  }, [copilot.currentAnalysis]);
+
+  // Shared session start logic (reused by both modes)
+  const prepareSessionContext = useCallback(async () => {
+    let customerContext: Record<string, unknown> | null = null;
+    let customerName = '';
+    let bundleContext: CopilotContext | undefined = undefined;
+
+    if (selectedCustomer) {
+      const { data: score } = await supabase
+        .from('farmer_client_scores')
+        .select('*')
+        .eq('customer_user_id', selectedCustomer)
+        .eq('farmer_id', user!.id)
+        .single();
+
+      const { data: profile } = await supabase
+        .from('profiles')
+        .select('name, customer_type, cnae')
+        .eq('user_id', selectedCustomer)
+        .single();
+
+      customerName = profile?.name || '';
+      customerContext = {
+        name: profile?.name,
+        cnae: profile?.cnae,
+        customerType: profile?.customer_type,
+        healthScore: score?.health_score,
+        avgMonthlySpend: score?.avg_monthly_spend_180d,
+        grossMarginPct: score?.gross_margin_pct,
+        categoryCount: score?.category_count,
+        daysSinceLastPurchase: score?.days_since_last_purchase,
+        churnRisk: score?.churn_risk,
+      };
+
+      const plan = await getActivePlan(selectedCustomer);
+      if (plan) {
+        setActivePlan(plan);
+        setShowPlan(true);
+        toast.success('PTPL carregado', { description: `Plano ${plan.planType} ativo para ${plan.customerName}` });
+        bundleContext = plan.topBundle;
+        if (customerContext) {
+          customerContext.activePlan = {
+            objective: plan.strategicObjective,
+            profile: plan.customerProfile,
+            approachStrategy: plan.approachStrategy,
+            diagnosticQuestions: plan.diagnosticQuestions,
+          };
+        }
+      } else {
+        setActivePlan(null);
+      }
+    }
+
+    return { customerContext, customerName, bundleContext };
+  }, [selectedCustomer, user, getActivePlan]);
+
+  // Start voice recording
+  const handleStartVoice = useCallback(async () => {
+    setIsConnecting(true);
+    try {
+      const { data: tokenData, error: tokenError } = await supabase.functions.invoke('elevenlabs-scribe-token');
+      if (tokenError || !tokenData?.token) throw new Error('Falha ao obter token de transcrição');
+
+      const { customerContext, customerName, bundleContext } = await prepareSessionContext();
+
+      await copilot.startSession({
+        customerId: selectedCustomer || undefined,
+        customerName: customerName || undefined,
+        customerContext: customerContext ?? undefined,
+        bundleContext,
+      });
+
+      await scribe.connect({
+        token: tokenData.token,
+        microphone: {
+          echoCancellation: true,
+          noiseSuppression: true,
+        },
+      });
+
+      toast.success('Copiloto ativado', { description: 'Transcrição em tempo real iniciada' });
+    } catch (err) {
+      console.error('Start error:', err);
+      // Auto-fallback to text mode
+      setInputMode('text');
+      toast.error('Voz indisponível', {
+        description: 'Transcrição por voz falhou. Modo texto ativado automaticamente.',
+      });
+    } finally {
+      setIsConnecting(false);
+    }
+  }, [selectedCustomer, user, copilot, scribe, prepareSessionContext]);
+
+  // Start text mode session
+  const handleStartText = useCallback(async () => {
+    setIsConnecting(true);
+    try {
+      const { customerContext, customerName, bundleContext } = await prepareSessionContext();
+
+      await copilot.startSession({
+        customerId: selectedCustomer || undefined,
+        customerName: customerName || undefined,
+        customerContext: customerContext ?? undefined,
+        bundleContext,
+      });
+
+      toast.success('Copiloto ativado', { description: 'Modo texto — cole ou digite trechos da conversa' });
+    } catch (err) {
+      console.error('Start error:', err);
+      const message = err instanceof Error ? err.message : 'Falha ao iniciar copiloto';
+      toast.error('Erro', { description: message });
+    } finally {
+      setIsConnecting(false);
+    }
+  }, [selectedCustomer, copilot, prepareSessionContext]);
+
+  // Unified start handler
+  const handleStart = useCallback(async () => {
+    if (inputMode === 'voice') {
+      await handleStartVoice();
+    } else {
+      await handleStartText();
+    }
+  }, [inputMode, handleStartVoice, handleStartText]);
+
+  // Analyze manual text — reuses same pipeline
+  const handleAnalyzeManualText = useCallback(async () => {
+    if (!manualText.trim() || manualText.trim().length < 10) {
+      toast.error('Texto curto', { description: 'Digite pelo menos 10 caracteres para análise.' });
+      return;
+    }
+    setIsManualAnalyzing(true);
+    // Feed text into the same transcript pipeline
+    copilot.addTranscript(manualText.trim(), false);
+    // Trigger analysis using the existing engine
+    await copilot.triggerAnalysis();
+    setManualText('');
+    setIsManualAnalyzing(false);
+  }, [manualText, copilot]);
+
+  // Stop recording
+  const handleStop = useCallback(async () => {
+    if (inputMode === 'voice') {
+      scribe.disconnect();
+    }
+    await copilot.endSession();
+    toast.success('Sessão encerrada');
+  }, [scribe, copilot, inputMode]);
+
+  // Copy suggestion
+  const handleCopySuggestion = useCallback((text: string) => {
+    navigator.clipboard.writeText(text);
+    copilot.markSuggestionUsed(text);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }, [copilot]);
+
+  const analysis = copilot.currentAnalysis;
+  const dir = analysis ? directionConfig[analysis.direction] : null;
+  const DirIcon = dir?.icon || Minus;
+  const SugIcon = analysis ? (suggestionTypeIcons[analysis.suggestionType] || fallbackSuggestionIcon) : fallbackSuggestionIcon;
+
+  return {
+    navigate,
+    isStaff,
+    copilot,
+    selectedCustomer,
+    setSelectedCustomer,
+    customers,
+    isConnecting,
+    copied,
+    activePlan,
+    showPlan,
+    setShowPlan,
+    inputMode,
+    setInputMode,
+    manualText,
+    setManualText,
+    isManualAnalyzing,
+    riskFlash,
+    transcriptEndRef,
+    handleStart,
+    handleStop,
+    handleAnalyzeManualText,
+    handleCopySuggestion,
+    analysis,
+    dir,
+    DirIcon,
+    SugIcon,
+  };
+}

--- a/src/pages/FarmerCopilot.tsx
+++ b/src/pages/FarmerCopilot.tsx
@@ -1,293 +1,47 @@
-import { useState, useCallback, useEffect, useRef } from 'react';
-import { useNavigate } from 'react-router-dom';
-import { useScribe, CommitStrategy } from '@elevenlabs/react';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { ScrollArea } from '@/components/ui/scroll-area';
-import { Textarea } from '@/components/ui/textarea';
-import { useAuth } from '@/contexts/AuthContext';
-import {
-  useCopilotEngine,
-  type CopilotDirection,
-  type CopilotPhase,
-  type CopilotIntent,
-  type SuggestionType,
-  type CopilotContext,
-} from '@/hooks/useCopilotEngine';
-import { useTacticalPlan, getObjectiveLabel, type TacticalPlan } from '@/hooks/useTacticalPlan';
-import { supabase } from '@/integrations/supabase/client';
-import {
-  Mic, Radio, StopCircle, Lightbulb, Copy, Check,
-  MessageSquare, Brain, Target, Shield, TrendingUp, TrendingDown,
-  Minus, AlertTriangle, Loader2, FileText,
-  ChevronDown, ChevronUp, Type, Send,
-  type LucideIcon,
-} from 'lucide-react';
-import { toast } from 'sonner';
-import { cn } from '@/lib/utils';
-
-// ─── Helpers ───────────────────────────────────────────────────────
-const directionConfig: Record<CopilotDirection, { color: string; bg: string; icon: LucideIcon; label: string }> = {
-  positivo: { color: 'text-status-success', bg: 'bg-status-success-bg border-status-success/30', icon: TrendingUp, label: 'Positivo' },
-  neutro: { color: 'text-status-warning', bg: 'bg-status-warning-bg border-status-warning/30', icon: Minus, label: 'Neutro' },
-  risco: { color: 'text-status-error', bg: 'bg-status-error-bg border-status-error/30', icon: TrendingDown, label: 'Em Risco' },
-};
-
-const phaseLabels: Record<CopilotPhase, string> = {
-  abertura: '🔵 Abertura',
-  diagnostico: '🔍 Diagnóstico',
-  exploracao: '🧭 Exploração',
-  proposta: '💼 Proposta',
-  fechamento: '🎯 Fechamento',
-};
-
-const intentLabels: Record<CopilotIntent, { label: string; color: string }> = {
-  interesse: { label: 'Interesse', color: 'bg-status-success-bg text-status-success-fg' },
-  objecao_preco: { label: 'Objeção Preço', color: 'bg-status-error-bg text-status-error-fg' },
-  objecao_tecnica: { label: 'Objeção Técnica', color: 'bg-orange-100 text-orange-800' },
-  falta_urgencia: { label: 'Falta Urgência', color: 'bg-status-warning-bg text-status-warning-fg' },
-  comparacao_concorrente: { label: 'Concorrente', color: 'bg-purple-100 text-purple-800' },
-  indiferenca: { label: 'Indiferença', color: 'bg-muted text-muted-foreground' },
-};
-
-const suggestionTypeIcons: Record<SuggestionType, LucideIcon> = {
-  pergunta_diagnostica: MessageSquare,
-  resposta_tecnica: Brain,
-  argumento_economico: Target,
-  alternativa_abordagem: Shield,
-};
-
-type InputMode = 'voice' | 'text';
+import { Type, StopCircle, Shield, Loader2 } from 'lucide-react';
+import { useFarmerCopilot } from '@/components/farmer/copilot/useFarmerCopilot';
+import { SessionStartCard } from '@/components/farmer/copilot/SessionStartCard';
+import { DirectionIndicator } from '@/components/farmer/copilot/DirectionIndicator';
+import { SuggestionCard } from '@/components/farmer/copilot/SuggestionCard';
+import { ActivePlanCard } from '@/components/farmer/copilot/ActivePlanCard';
+import { ManualTextInput } from '@/components/farmer/copilot/ManualTextInput';
+import { TranscriptCard } from '@/components/farmer/copilot/TranscriptCard';
+import { AnalysisHistoryCard } from '@/components/farmer/copilot/AnalysisHistoryCard';
 
 const FarmerCopilot = () => {
-  const navigate = useNavigate();
-  const { user, isStaff } = useAuth();
-  const copilot = useCopilotEngine();
-  const { getActivePlan } = useTacticalPlan();
-  const [selectedCustomer, setSelectedCustomer] = useState<string>('');
-  const [customers, setCustomers] = useState<{ id: string; name: string }[]>([]);
-  const [isConnecting, setIsConnecting] = useState(false);
-  const [copied, setCopied] = useState(false);
-  const [activePlan, setActivePlan] = useState<TacticalPlan | null>(null);
-  const [showPlan, setShowPlan] = useState(false);
-  const transcriptEndRef = useRef<HTMLDivElement>(null);
-
-  // Text mode state
-  const [inputMode, setInputMode] = useState<InputMode>('voice');
-  const [manualText, setManualText] = useState('');
-  const [isManualAnalyzing, setIsManualAnalyzing] = useState(false);
-  const [riskFlash, setRiskFlash] = useState(false);
-
-  // ElevenLabs realtime scribe
-  const scribe = useScribe({
-    modelId: 'scribe_v2_realtime',
-    commitStrategy: CommitStrategy.VAD,
-    onPartialTranscript: (data) => {
-      if (data.text) copilot.addTranscript(data.text, true);
-    },
-    onCommittedTranscript: (data) => {
-      if (data.text) copilot.addTranscript(data.text, false);
-    },
-  });
-
-  // Load customers
-  useEffect(() => {
-    if (!user?.id || !isStaff) return;
-    (async () => {
-      const { data: scores } = await supabase
-        .from('farmer_client_scores')
-        .select('customer_user_id')
-        .eq('farmer_id', user.id);
-      if (!scores?.length) return;
-      const ids = scores.map((s) => s.customer_user_id).filter((id): id is string => id !== null);
-      const { data: profiles } = await supabase
-        .from('profiles')
-        .select('user_id, name')
-        .in('user_id', ids);
-      if (profiles) {
-        setCustomers(profiles.map((p) => ({ id: p.user_id, name: p.name ?? '' })));
-      }
-    })();
-  }, [user, isStaff]);
-
-  // Auto-scroll transcript
-  useEffect(() => {
-    transcriptEndRef.current?.scrollIntoView({ behavior: 'smooth' });
-  }, [copilot.transcript]);
-
-  // Flash risk highlight when direction changes to 'risco'
-  useEffect(() => {
-    if (copilot.currentAnalysis?.direction === 'risco') {
-      setRiskFlash(true);
-      const timer = setTimeout(() => setRiskFlash(false), 2500);
-      return () => clearTimeout(timer);
-    }
-  }, [copilot.currentAnalysis]);
-
-  // Shared session start logic (reused by both modes)
-  const prepareSessionContext = useCallback(async () => {
-    let customerContext: Record<string, unknown> | null = null;
-    let customerName = '';
-    let bundleContext: CopilotContext | undefined = undefined;
-
-    if (selectedCustomer) {
-      const { data: score } = await supabase
-        .from('farmer_client_scores')
-        .select('*')
-        .eq('customer_user_id', selectedCustomer)
-        .eq('farmer_id', user!.id)
-        .single();
-
-      const { data: profile } = await supabase
-        .from('profiles')
-        .select('name, customer_type, cnae')
-        .eq('user_id', selectedCustomer)
-        .single();
-
-      customerName = profile?.name || '';
-      customerContext = {
-        name: profile?.name,
-        cnae: profile?.cnae,
-        customerType: profile?.customer_type,
-        healthScore: score?.health_score,
-        avgMonthlySpend: score?.avg_monthly_spend_180d,
-        grossMarginPct: score?.gross_margin_pct,
-        categoryCount: score?.category_count,
-        daysSinceLastPurchase: score?.days_since_last_purchase,
-        churnRisk: score?.churn_risk,
-      };
-
-      const plan = await getActivePlan(selectedCustomer);
-      if (plan) {
-        setActivePlan(plan);
-        setShowPlan(true);
-        toast.success('PTPL carregado', { description: `Plano ${plan.planType} ativo para ${plan.customerName}` });
-        bundleContext = plan.topBundle;
-        if (customerContext) {
-          customerContext.activePlan = {
-            objective: plan.strategicObjective,
-            profile: plan.customerProfile,
-            approachStrategy: plan.approachStrategy,
-            diagnosticQuestions: plan.diagnosticQuestions,
-          };
-        }
-      } else {
-        setActivePlan(null);
-      }
-    }
-
-    return { customerContext, customerName, bundleContext };
-  }, [selectedCustomer, user, getActivePlan]);
-
-  // Start voice recording
-  const handleStartVoice = useCallback(async () => {
-    setIsConnecting(true);
-    try {
-      const { data: tokenData, error: tokenError } = await supabase.functions.invoke('elevenlabs-scribe-token');
-      if (tokenError || !tokenData?.token) throw new Error('Falha ao obter token de transcrição');
-
-      const { customerContext, customerName, bundleContext } = await prepareSessionContext();
-
-      await copilot.startSession({
-        customerId: selectedCustomer || undefined,
-        customerName: customerName || undefined,
-        customerContext: customerContext ?? undefined,
-        bundleContext,
-      });
-
-      await scribe.connect({
-        token: tokenData.token,
-        microphone: {
-          echoCancellation: true,
-          noiseSuppression: true,
-        },
-      });
-
-      toast.success('Copiloto ativado', { description: 'Transcrição em tempo real iniciada' });
-    } catch (err) {
-      console.error('Start error:', err);
-      // Auto-fallback to text mode
-      setInputMode('text');
-      toast.error('Voz indisponível', {
-        description: 'Transcrição por voz falhou. Modo texto ativado automaticamente.',
-      });
-    } finally {
-      setIsConnecting(false);
-    }
-  }, [selectedCustomer, user, copilot, scribe, prepareSessionContext]);
-
-  // Start text mode session
-  const handleStartText = useCallback(async () => {
-    setIsConnecting(true);
-    try {
-      const { customerContext, customerName, bundleContext } = await prepareSessionContext();
-
-      await copilot.startSession({
-        customerId: selectedCustomer || undefined,
-        customerName: customerName || undefined,
-        customerContext: customerContext ?? undefined,
-        bundleContext,
-      });
-
-      toast.success('Copiloto ativado', { description: 'Modo texto — cole ou digite trechos da conversa' });
-    } catch (err) {
-      console.error('Start error:', err);
-      const message = err instanceof Error ? err.message : 'Falha ao iniciar copiloto';
-      toast.error('Erro', { description: message });
-    } finally {
-      setIsConnecting(false);
-    }
-  }, [selectedCustomer, copilot, prepareSessionContext]);
-
-  // Unified start handler
-  const handleStart = useCallback(async () => {
-    if (inputMode === 'voice') {
-      await handleStartVoice();
-    } else {
-      await handleStartText();
-    }
-  }, [inputMode, handleStartVoice, handleStartText]);
-
-  // Analyze manual text — reuses same pipeline
-  const handleAnalyzeManualText = useCallback(async () => {
-    if (!manualText.trim() || manualText.trim().length < 10) {
-      toast.error('Texto curto', { description: 'Digite pelo menos 10 caracteres para análise.' });
-      return;
-    }
-    setIsManualAnalyzing(true);
-    // Feed text into the same transcript pipeline
-    copilot.addTranscript(manualText.trim(), false);
-    // Trigger analysis using the existing engine
-    await copilot.triggerAnalysis();
-    setManualText('');
-    setIsManualAnalyzing(false);
-  }, [manualText, copilot]);
-
-  // Stop recording
-  const handleStop = useCallback(async () => {
-    if (inputMode === 'voice') {
-      scribe.disconnect();
-    }
-    await copilot.endSession();
-    toast.success('Sessão encerrada');
-  }, [scribe, copilot, inputMode]);
-
-  // Copy suggestion
-  const handleCopySuggestion = useCallback((text: string) => {
-    navigator.clipboard.writeText(text);
-    copilot.markSuggestionUsed(text);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
-  }, [copilot]);
+  const {
+    navigate,
+    isStaff,
+    copilot,
+    selectedCustomer,
+    setSelectedCustomer,
+    customers,
+    isConnecting,
+    copied,
+    activePlan,
+    showPlan,
+    setShowPlan,
+    inputMode,
+    setInputMode,
+    manualText,
+    setManualText,
+    isManualAnalyzing,
+    riskFlash,
+    transcriptEndRef,
+    handleStart,
+    handleStop,
+    handleAnalyzeManualText,
+    handleCopySuggestion,
+    analysis,
+    dir,
+    DirIcon,
+    SugIcon,
+  } = useFarmerCopilot();
 
   if (!isStaff) { navigate('/', { replace: true }); return null; }
-
-  const analysis = copilot.currentAnalysis;
-  const dir = analysis ? directionConfig[analysis.direction] : null;
-  const DirIcon = dir?.icon || Minus;
-  const SugIcon = analysis ? (suggestionTypeIcons[analysis.suggestionType] || Lightbulb) : Lightbulb;
 
   return (
     <div className="min-h-screen bg-background pb-24">
@@ -295,78 +49,15 @@ const FarmerCopilot = () => {
       <main className="px-4 py-4 space-y-3 max-w-lg mx-auto">
         {/* Session Controls */}
         {!copilot.isActive ? (
-          <Card className="border-primary/20">
-            <CardContent className="p-4 space-y-3">
-              <div className="flex items-center gap-2 mb-1">
-                <Radio className="w-5 h-5 text-primary" />
-                <h2 className="text-sm font-bold">Iniciar Copiloto</h2>
-              </div>
-              <p className="text-[10px] text-muted-foreground">
-                O copiloto analisa a conversa, detecta intenções e sugere a melhor ação em cada momento.
-              </p>
-
-              {/* Mode Toggle */}
-              <div className="flex rounded-lg border overflow-hidden">
-                <button
-                  onClick={() => setInputMode('voice')}
-                  className={cn(
-                    'flex-1 flex items-center justify-center gap-1.5 py-2 text-xs font-medium transition-colors',
-                    inputMode === 'voice'
-                      ? 'bg-primary text-primary-foreground'
-                      : 'bg-muted/50 text-muted-foreground hover:bg-muted'
-                  )}
-                >
-                  <Mic className="w-3.5 h-3.5" /> Voz
-                </button>
-                <button
-                  onClick={() => setInputMode('text')}
-                  className={cn(
-                    'flex-1 flex items-center justify-center gap-1.5 py-2 text-xs font-medium transition-colors',
-                    inputMode === 'text'
-                      ? 'bg-primary text-primary-foreground'
-                      : 'bg-muted/50 text-muted-foreground hover:bg-muted'
-                  )}
-                >
-                  <Type className="w-3.5 h-3.5" /> Texto
-                </button>
-              </div>
-
-              {inputMode === 'text' && (
-                <div className="flex items-start gap-1.5 p-2 rounded-md bg-status-warning-bg border border-status-warning/30">
-                  <AlertTriangle className="w-3.5 h-3.5 text-status-warning mt-0.5 shrink-0" />
-                  <p className="text-[9px] text-status-warning">
-                    No modo texto, cole ou digite trechos da conversa e clique em "Analisar" para receber sugestões.
-                  </p>
-                </div>
-              )}
-
-              <Select value={selectedCustomer} onValueChange={setSelectedCustomer}>
-                <SelectTrigger className="h-9 text-xs">
-                  <SelectValue placeholder="Selecionar cliente (opcional)" />
-                </SelectTrigger>
-                <SelectContent>
-                  {customers.map(c => (
-                    <SelectItem key={c.id} value={c.id} className="text-xs">{c.name}</SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-
-              <Button
-                onClick={handleStart}
-                disabled={isConnecting}
-                className="w-full gap-2"
-              >
-                {isConnecting ? (
-                  <Loader2 className="w-4 h-4 animate-spin" />
-                ) : inputMode === 'voice' ? (
-                  <Mic className="w-4 h-4" />
-                ) : (
-                  <Type className="w-4 h-4" />
-                )}
-                {isConnecting ? 'Conectando...' : inputMode === 'voice' ? 'Iniciar Transcrição' : 'Iniciar Modo Texto'}
-              </Button>
-            </CardContent>
-          </Card>
+          <SessionStartCard
+            inputMode={inputMode}
+            setInputMode={setInputMode}
+            selectedCustomer={selectedCustomer}
+            setSelectedCustomer={setSelectedCustomer}
+            customers={customers}
+            isConnecting={isConnecting}
+            onStart={handleStart}
+          />
         ) : (
           <>
             {/* Active Session Header */}
@@ -395,102 +86,29 @@ const FarmerCopilot = () => {
 
             {/* Direction Indicator */}
             {analysis && dir && (
-              <Card className={`border ${dir.bg}`}>
-                <CardContent className="p-3">
-                  <div className="flex items-center justify-between mb-1">
-                    <div className="flex items-center gap-2">
-                      <DirIcon className={`w-5 h-5 ${dir.color}`} />
-                      <span className={`text-sm font-bold ${dir.color}`}>{dir.label}</span>
-                    </div>
-                    <div className="flex gap-1">
-                      <Badge className={intentLabels[analysis.intent]?.color || ''} variant="secondary">
-                        {intentLabels[analysis.intent]?.label || analysis.intent}
-                      </Badge>
-                      <Badge variant="outline" className="text-[9px]">
-                        {phaseLabels[analysis.phase] || analysis.phase}
-                      </Badge>
-                    </div>
-                  </div>
-                  {analysis.directionReasons.length > 0 && (
-                    <div className="flex flex-wrap gap-1 mt-1">
-                      {analysis.directionReasons.map((r, i) => (
-                        <span key={i} className="text-[9px] text-muted-foreground">• {r}</span>
-                      ))}
-                    </div>
-                  )}
-                </CardContent>
-              </Card>
+              <DirectionIndicator analysis={analysis} dir={dir} DirIcon={DirIcon} />
             )}
 
             {/* AI Suggestion */}
             {analysis?.suggestion && (
-              <Card className={cn(
-                'border-2 border-primary/30 bg-primary/5 transition-all duration-500',
-                riskFlash && analysis.direction === 'risco' && 'ring-2 ring-red-400 shadow-lg shadow-red-100'
-              )}>
-                <CardContent className="p-3">
-                  <div className="flex items-start justify-between gap-2">
-                    <div className="flex items-start gap-2 flex-1">
-                      <SugIcon className="w-4 h-4 text-primary mt-0.5 shrink-0" />
-                      <div>
-                        <p className="text-[10px] font-semibold text-primary mb-0.5">
-                          {analysis.suggestionType === 'pergunta_diagnostica' ? 'Pergunta Sugerida' :
-                           analysis.suggestionType === 'resposta_tecnica' ? 'Resposta Técnica' :
-                           analysis.suggestionType === 'argumento_economico' ? 'Argumento Econômico' :
-                           'Abordagem Alternativa'}
-                        </p>
-                        <p className="text-xs leading-relaxed">{analysis.suggestion}</p>
-                      </div>
-                    </div>
-                    <Button
-                      size="sm"
-                      variant="ghost"
-                      className="h-7 w-7 p-0 shrink-0"
-                      onClick={() => handleCopySuggestion(analysis.suggestion)}
-                    >
-                      {copied ? <Check className="w-3 h-3 text-status-success" /> : <Copy className="w-3 h-3" />}
-                    </Button>
-                  </div>
-                  <div className="flex items-center justify-between mt-2">
-                    <span className="text-[9px] text-muted-foreground">
-                      Confiança: {analysis.confidence}%
-                    </span>
-                    <span className="text-[9px] text-muted-foreground">
-                      {copilot.suggestionsShown} sugestões • {copilot.suggestionsUsed} usadas
-                    </span>
-                  </div>
-                </CardContent>
-              </Card>
+              <SuggestionCard
+                analysis={analysis}
+                SugIcon={SugIcon}
+                riskFlash={riskFlash}
+                copied={copied}
+                onCopy={handleCopySuggestion}
+                suggestionsShown={copilot.suggestionsShown}
+                suggestionsUsed={copilot.suggestionsUsed}
+              />
             )}
 
             {/* Active PTPL */}
             {activePlan && (
-              <Card className="border-dashed border-primary/30">
-                <CardContent className="p-3">
-                  <div className="flex items-center justify-between" onClick={() => setShowPlan(!showPlan)} role="button">
-                    <div className="flex items-center gap-2">
-                      <FileText className="w-3.5 h-3.5 text-primary" />
-                      <span className="text-[10px] font-semibold">PTPL Ativo — {activePlan.planType === 'estrategico' ? 'Estratégico' : 'Essencial'}</span>
-                    </div>
-                    {showPlan ? <ChevronUp className="w-3 h-3" /> : <ChevronDown className="w-3 h-3" />}
-                  </div>
-                  {showPlan && (
-                    <div className="mt-2 space-y-1.5 text-[9px]">
-                      <div className="flex gap-1.5">
-                        <Badge variant="outline" className="text-[7px]">{getObjectiveLabel(activePlan.strategicObjective)}</Badge>
-                        <Badge variant="outline" className="text-[7px]">HS: {Math.round(activePlan.healthScore)}</Badge>
-                        <Badge variant="outline" className="text-[7px]">Churn: {Math.round(activePlan.churnRisk)}%</Badge>
-                      </div>
-                      {activePlan.approachStrategy && (
-                        <p className="text-muted-foreground">{activePlan.approachStrategy}</p>
-                      )}
-                      {activePlan.diagnosticQuestions.slice(0, 2).map((q, i) => (
-                        <p key={i} className="text-muted-foreground">• {q.question}</p>
-                      ))}
-                    </div>
-                  )}
-                </CardContent>
-              </Card>
+              <ActivePlanCard
+                activePlan={activePlan}
+                showPlan={showPlan}
+                onToggle={() => setShowPlan(!showPlan)}
+              />
             )}
 
             {copilot.isAnalyzing && (
@@ -502,91 +120,24 @@ const FarmerCopilot = () => {
 
             {/* Manual Text Input (text mode) */}
             {inputMode === 'text' && (
-              <Card>
-                <CardContent className="p-3 space-y-2">
-                  <div className="flex items-center gap-2">
-                    <Type className="w-3.5 h-3.5 text-muted-foreground" />
-                    <span className="text-[10px] font-semibold text-muted-foreground">Entrada de texto</span>
-                  </div>
-                  <Textarea
-                    value={manualText}
-                    onChange={(e) => setManualText(e.target.value)}
-                    placeholder="Cole ou digite trechos da conversa aqui..."
-                    className="text-xs min-h-[80px] resize-none"
-                  />
-                  <Button
-                    size="sm"
-                    className="w-full h-8 gap-1.5 text-xs"
-                    disabled={isManualAnalyzing || !manualText.trim()}
-                    onClick={handleAnalyzeManualText}
-                  >
-                    {isManualAnalyzing ? (
-                      <Loader2 className="w-3 h-3 animate-spin" />
-                    ) : (
-                      <Send className="w-3 h-3" />
-                    )}
-                    Analisar
-                  </Button>
-                </CardContent>
-              </Card>
+              <ManualTextInput
+                manualText={manualText}
+                setManualText={setManualText}
+                isManualAnalyzing={isManualAnalyzing}
+                onAnalyze={handleAnalyzeManualText}
+              />
             )}
 
             {/* Transcript */}
-            <Card>
-              <CardHeader className="p-3 pb-2">
-                <CardTitle className="text-xs flex items-center gap-2">
-                  <MessageSquare className="w-3 h-3" /> Transcrição
-                </CardTitle>
-              </CardHeader>
-              <CardContent className="p-0">
-                <ScrollArea className="h-48 px-3 pb-3">
-                  {copilot.transcript.length === 0 ? (
-                    <p className="text-[10px] text-muted-foreground text-center py-8">
-                      {inputMode === 'voice' ? 'Aguardando fala...' : 'Nenhum texto analisado ainda.'}
-                    </p>
-                  ) : (
-                    <div className="space-y-1">
-                      {copilot.transcript.map(entry => (
-                        <p
-                          key={entry.id}
-                          className={`text-xs leading-relaxed ${entry.isPartial ? 'text-muted-foreground italic' : ''}`}
-                        >
-                          {entry.text}
-                        </p>
-                      ))}
-                      <div ref={transcriptEndRef} />
-                    </div>
-                  )}
-                </ScrollArea>
-              </CardContent>
-            </Card>
+            <TranscriptCard
+              transcript={copilot.transcript}
+              inputMode={inputMode}
+              transcriptEndRef={transcriptEndRef}
+            />
 
             {/* Analysis History */}
             {copilot.analysisHistory.length > 1 && (
-              <Card>
-                <CardHeader className="p-3 pb-2">
-                  <CardTitle className="text-xs flex items-center gap-2">
-                    <Brain className="w-3 h-3" /> Histórico de Análises ({copilot.analysisHistory.length})
-                  </CardTitle>
-                </CardHeader>
-                <CardContent className="p-3 pt-0">
-                  <div className="space-y-1.5">
-                    {copilot.analysisHistory.slice(-5).reverse().map((a, i) => {
-                      return (
-                        <div key={i} className="flex items-center gap-2 text-[9px]">
-                          <div className={`w-2 h-2 rounded-full ${
-                            a.direction === 'positivo' ? 'bg-status-success' :
-                            a.direction === 'risco' ? 'bg-status-error' : 'bg-status-warning'
-                          }`} />
-                          <span className="font-medium">{intentLabels[a.intent]?.label}</span>
-                          <span className="text-muted-foreground">→</span>
-                          <span className="text-muted-foreground truncate flex-1">{a.suggestion.slice(0, 50)}...</span>
-                        </div>
-                      );
-                    })}
-                  </div>
-                </CardContent>
-              </Card>
+              <AnalysisHistoryCard analysisHistory={copilot.analysisHistory} />
             )}
           </>
         )}


### PR DESCRIPTION
## Resumo
- Split estrutural da página `FarmerCopilot` (615→**166** linhas), preservando 100% do comportamento (move verbatim).
- Lógica isolada no hook **`useFarmerCopilot`** (sessão, transcrição ElevenLabs scribe, `prepareSessionContext`, handlers voz/texto/análise/cópia, derivações).
- JSX em componentes controlados: **`SessionStartCard`**, **`DirectionIndicator`**, **`SuggestionCard`**, **`ActivePlanCard`**, **`ManualTextInput`**, **`TranscriptCard`**, **`AnalysisHistoryCard`**. Constantes em `config.ts`, `InputMode` em `types.ts`.

## Verificação
- `bunx tsc --noEmit` = 0 erros
- `bunx eslint` = 0 erros (1 warning `exhaustive-deps` no `handleStartVoice` é **baseline** — confirmado lintando o arquivo de origem)
- Testes novos (+15) passam isolados (5/5 arquivos). ⚠️ Suíte completa local com flakiness por contenção de CPU. Gate autoritativo = CI `validate`.
- Revisão independente de fidelidade (subagente): **FIEL 1:1**, zero divergências (deps de useCallback idênticas).

## Test plan
- [x] tsc / eslint verdes; +15 testes novos verdes isolados
- [x] Revisão 1:1 confirmando comportamento idêntico
- [ ] CI `validate` verde (gate da suíte completa)

🤖 Generated with [Claude Code](https://claude.com/claude-code)