### PR TITLE
fix(fin): não auditar escritas do sync do ERP (service_role)

### DIFF
--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,13 +21,13 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **57** custom migrations totais
-- **324** objetos esperados (criados por estas migrations)
+- **58** custom migrations totais
+- **325** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
   - `rls_policy`: 102
   - `index`: 93
   - `table`: 49
-  - `function`: 31
+  - `function`: 32
   - `trigger`: 31
   - `cron_job`: 14
   - `enum_value`: 4
@@ -633,6 +633,12 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | `cron_job` | `cron.fin-sync-cp-2x` | — |
 | `cron_job` | `cron.fin-sync-cr-2x` | — |
 | `cron_job` | `cron.fin-sync-mov-2x` | — |
+
+### `20260525010000_fin_audit_skip_service_role.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `public.fin_audit_trigger` | — |
 
 ## Próximos passos quando algo der `❌`
 

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 57
+-- Total de custom migrations: 58
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -76,7 +76,8 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260524180000', 'carteira_scores_owner_e_filas', '20260524180000_carteira_scores_owner_e_filas.sql'),
   ('20260524202410', 'tuning_crons_estoque_freq_e_timeouts', '20260524202410_tuning_crons_estoque_freq_e_timeouts.sql'),
   ('20260524203000', 'rpc_staff_guard_permite_cron_backend', '20260524203000_rpc_staff_guard_permite_cron_backend.sql'),
-  ('20260525000000', 'fin_crons_por_entidade', '20260525000000_fin_crons_por_entidade.sql')
+  ('20260525000000', 'fin_crons_por_entidade', '20260525000000_fin_crons_por_entidade.sql'),
+  ('20260525010000', 'fin_audit_skip_service_role', '20260525010000_fin_audit_skip_service_role.sql')
 )
 SELECT
   e.version,
@@ -418,7 +419,8 @@ WITH expected_objects (migration, kind, schema_name, object_name, parent_name) A
   ('fin_crons_por_entidade', 'cron_job', 'cron', 'fin-sync-base-diario', ''),
   ('fin_crons_por_entidade', 'cron_job', 'cron', 'fin-sync-cp-2x', ''),
   ('fin_crons_por_entidade', 'cron_job', 'cron', 'fin-sync-cr-2x', ''),
-  ('fin_crons_por_entidade', 'cron_job', 'cron', 'fin-sync-mov-2x', '')
+  ('fin_crons_por_entidade', 'cron_job', 'cron', 'fin-sync-mov-2x', ''),
+  ('fin_audit_skip_service_role', 'function', 'public', 'fin_audit_trigger', '')
 )
 SELECT
   e.migration,

--- a/supabase/migrations/20260525010000_fin_audit_skip_service_role.sql
+++ b/supabase/migrations/20260525010000_fin_audit_skip_service_role.sql
@@ -1,0 +1,72 @@
+-- ============================================================
+-- fin_audit_trigger: não auditar escritas do sync do ERP (service_role).
+--
+-- O sync (omie-financeiro, service_role) é um MIRROR de alto volume: cada run
+-- faz ~12k upserts em fin_contas_*/movimentacoes → ~12k inserts em fin_audit_log
+-- por run, várias vezes/dia. Isso incha o audit-log e adiciona overhead. A
+-- auditoria existe pra rastrear EDIÇÃO HUMANA via app, não o espelho do ERP.
+--
+-- Fix: pular o audit quando auth.role()='service_role' (mesmo critério do bypass
+-- do period-lock). Edição humana (anon/authenticated) continua auditada.
+--
+-- Mantém o resto idêntico ao 20260524102500 (acesso JSON via v_rec).
+-- Idempotente (CREATE OR REPLACE).
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.fin_audit_trigger() RETURNS trigger
+LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_changed jsonb := '{}'::jsonb;
+  v_origem  text := COALESCE(current_setting('fin.origem', true), 'manual');
+  v_justif  text := current_setting('fin.override_justificativa', true);
+  v_period  date;
+  v_row_id  text;
+  v_company text;
+  v_rec     jsonb := CASE TG_OP WHEN 'DELETE' THEN to_jsonb(OLD) ELSE to_jsonb(NEW) END;
+BEGIN
+  -- Sync do ERP (service_role) é mirror de alto volume: não auditar.
+  IF auth.role() = 'service_role' THEN
+    RETURN COALESCE(NEW, OLD);
+  END IF;
+
+  IF TG_OP = 'UPDATE' THEN
+    SELECT jsonb_object_agg(key, jsonb_build_object('before', o_val, 'after', n_val))
+      INTO v_changed
+      FROM (
+        SELECT o.key, o.value AS o_val, n.value AS n_val
+          FROM jsonb_each(to_jsonb(OLD)) o
+          JOIN jsonb_each(to_jsonb(NEW)) n USING (key)
+         WHERE o.value IS DISTINCT FROM n.value
+      ) diffs;
+    IF v_changed IS NULL THEN RETURN NEW; END IF;
+  ELSIF TG_OP = 'INSERT' THEN
+    v_changed := to_jsonb(NEW);
+  ELSE
+    v_changed := to_jsonb(OLD);
+  END IF;
+
+  v_row_id  := COALESCE(v_rec->>'id', 'unknown');
+  v_company := COALESCE(v_rec->>'company', v_rec->>'empresa_origem');
+
+  v_period := CASE TG_TABLE_NAME
+    WHEN 'fin_contas_receber'           THEN (v_rec->>'data_emissao')::date
+    WHEN 'fin_contas_pagar'             THEN (v_rec->>'data_emissao')::date
+    WHEN 'fin_movimentacoes'            THEN (v_rec->>'data_movimento')::date
+    WHEN 'fin_categoria_dre_mapping'    THEN current_date
+    WHEN 'fin_orcamento'                THEN make_date((v_rec->>'ano')::int, (v_rec->>'mes')::int, 1)
+    WHEN 'fin_fechamentos'              THEN make_date((v_rec->>'ano')::int, (v_rec->>'mes')::int, 1)
+    WHEN 'fin_eliminacoes_intercompany' THEN current_date
+    ELSE current_date
+  END;
+
+  INSERT INTO fin_audit_log (
+    table_name, row_id, op, changed_fields,
+    changed_by, company, origem, period_ref, override_justificativa
+  ) VALUES (
+    TG_TABLE_NAME, v_row_id, TG_OP, v_changed,
+    auth.uid(), v_company, v_origem, v_period, v_justif
+  );
+
+  RETURN COALESCE(NEW, OLD);
+END $function$;


### PR DESCRIPTION
## Resumo

`fin_audit_trigger` logava **~12k inserts por run** do mirror `omie-financeiro` em `fin_audit_log` (várias vezes/dia) → inchaço do audit-log + overhead. A auditoria existe pra rastrear **edição humana via app**, não o espelho do ERP.

Fix: pular o audit quando `auth.role()='service_role'` (mesmo critério do bypass do period-lock já em prod). Edição humana (anon/authenticated) continua auditada.

Descoberto durante o follow-up de paginação do financeiro: testamos isso pra acelerar a colacor CR, mas o ganho foi marginal (115→126 págs/130s) — **o gargalo é a latência da API do Omie (~1s/página), não as escritas no banco**. O audit-skip fica pelo valor próprio (menos inchaço no audit-log), e a cobertura total da colacor CR vai precisar de **cursor de continuação** (próximo passo).

## ⚠️ Migration manual (Lovable)
`20260525010000_fin_audit_skip_service_role.sql` — **já aplicado em prod** via SQL Editor.

## Test plan
- [x] `bun run audit:migrations` (58 migrations / 325 objetos)
- [x] Aplicado em prod; sync segue gravando (CP/CR/mov), sem entradas de service_role no fin_audit_log
- [ ] CI: `bun lint && bun run test`