### PR TITLE
refactor(reposicao): split AdminReposicaoRevisao (615→115) em hook + componentes

### DIFF
--- a/src/components/reposicao/revisao/AprovarLoteDialog.tsx
+++ b/src/components/reposicao/revisao/AprovarLoteDialog.tsx
@@ -1,0 +1,111 @@
+// Dialog de confirmação de aprovação em lote de SKUs.
+// Extraído verbatim de src/pages/AdminReposicaoRevisao.tsx (god-component split).
+import { Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { type RowWithPrice, fmt } from "@/lib/reposicao/sku-param";
+
+interface AprovarLoteDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  aggregateImpact: { count: number; capUnits: number };
+  selectedRows: RowWithPrice[];
+  batchJustificativa: string;
+  setBatchJustificativa: (v: string) => void;
+  onConfirm: () => void;
+  isApproving: boolean;
+}
+
+export function AprovarLoteDialog({
+  open,
+  onOpenChange,
+  aggregateImpact,
+  selectedRows,
+  batchJustificativa,
+  setBatchJustificativa,
+  onConfirm,
+  isApproving,
+}: AprovarLoteDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Aprovar {aggregateImpact.count} SKU(s)</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4">
+          <div className="grid grid-cols-2 gap-4 text-sm">
+            <div className="rounded-md border p-3">
+              <div className="text-muted-foreground">Total de SKUs</div>
+              <div className="text-2xl font-semibold">{aggregateImpact.count}</div>
+            </div>
+            <div className="rounded-md border p-3">
+              <div className="text-muted-foreground">Estoque máx. agregado (un)</div>
+              <div className="text-2xl font-semibold">
+                {fmt(aggregateImpact.capUnits, 0)}
+              </div>
+            </div>
+          </div>
+
+          <div className="max-h-48 overflow-y-auto rounded-md border">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>SKU</TableHead>
+                  <TableHead>Descrição</TableHead>
+                  <TableHead>Classe</TableHead>
+                  <TableHead className="text-right">Emax</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {selectedRows.map((r) => (
+                  <TableRow key={r.id}>
+                    <TableCell className="font-mono text-xs align-top">{r.sku_codigo_omie}</TableCell>
+                    <TableCell className="text-xs min-w-[260px] whitespace-normal break-words leading-snug align-top">
+                      {r.sku_descricao}
+                    </TableCell>
+                    <TableCell className="align-top">{r.classe_consolidada}</TableCell>
+                    <TableCell className="text-right align-top">{fmt(r.estoque_maximo, 0)}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+
+          <div>
+            <Label>Justificativa (opcional, aplicada a todos)</Label>
+            <Textarea
+              value={batchJustificativa}
+              onChange={(e) => setBatchJustificativa(e.target.value)}
+              placeholder="Ex: Revisão trimestral aprovada pela operação."
+            />
+          </div>
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancelar
+          </Button>
+          <Button onClick={onConfirm} disabled={isApproving}>
+            {isApproving && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            Confirmar aprovação
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/reposicao/revisao/FiltrosCard.tsx
+++ b/src/components/reposicao/revisao/FiltrosCard.tsx
@@ -1,0 +1,114 @@
+// Card de filtros da revisão (empresa, status, busca, classe consolidada).
+// Extraído verbatim de src/pages/AdminReposicaoRevisao.tsx (god-component split).
+import { Search } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Badge } from "@/components/ui/badge";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { type StatusFilterValue } from "@/lib/reposicao/sku-param";
+import { CLASSE_OPTIONS } from "./types";
+
+interface FiltrosCardProps {
+  empresa: string;
+  statusFilter: StatusFilterValue;
+  onStatusChange: (v: StatusFilterValue) => void;
+  search: string;
+  onSearchChange: (v: string) => void;
+  classes: string[];
+  toggleClasse: (c: string) => void;
+  clearClasses: () => void;
+}
+
+export function FiltrosCard({
+  empresa,
+  statusFilter,
+  onStatusChange,
+  search,
+  onSearchChange,
+  classes,
+  toggleClasse,
+  clearClasses,
+}: FiltrosCardProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Filtros</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+          <div>
+            <Label className="text-xs">Empresa</Label>
+            <Select value={empresa} disabled>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="OBEN">OBEN</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div>
+            <Label className="text-xs">Status</Label>
+            <Select
+              value={statusFilter}
+              onValueChange={(v: StatusFilterValue) => onStatusChange(v)}
+            >
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="pendente">Pendentes</SelectItem>
+                <SelectItem value="aprovado">Aprovados</SelectItem>
+                <SelectItem value="aguardando_fornecedor">
+                  Aguardando habilitação de fornecedor
+                </SelectItem>
+                <SelectItem value="todos">Todos</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="md:col-span-2">
+            <Label className="text-xs">Busca (código ou descrição)</Label>
+            <div className="relative">
+              <Search className="absolute left-2 top-2.5 h-4 w-4 text-muted-foreground" />
+              <Input
+                className="pl-8"
+                value={search}
+                placeholder="Ex: 12345 ou TINTA BASE"
+                onChange={(e) => onSearchChange(e.target.value)}
+              />
+            </div>
+          </div>
+        </div>
+
+        <div>
+          <Label className="text-xs">Classe consolidada</Label>
+          <div className="flex flex-wrap gap-2 mt-1">
+            {CLASSE_OPTIONS.map((c) => (
+              <Badge
+                key={c}
+                variant={classes.includes(c) ? "default" : "outline"}
+                className="cursor-pointer"
+                onClick={() => toggleClasse(c)}
+              >
+                {c}
+              </Badge>
+            ))}
+            {classes.length > 0 && (
+              <Button variant="ghost" size="sm" onClick={clearClasses}>
+                Limpar
+              </Button>
+            )}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/reposicao/revisao/RevisaoTable.tsx
+++ b/src/components/reposicao/revisao/RevisaoTable.tsx
@@ -1,0 +1,142 @@
+// Card da tabela de revisão (cabeçalho + aprovar selecionados + tabela + paginação).
+// Extraído verbatim de src/pages/AdminReposicaoRevisao.tsx (god-component split).
+import { ChevronLeft, ChevronRight, CheckCircle2, Loader2 } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { type RowWithPrice } from "@/lib/reposicao/sku-param";
+import { SkuRow } from "./SkuRow";
+
+interface RevisaoTableProps {
+  total: number;
+  page: number;
+  totalPages: number;
+  isLoading: boolean;
+  rows: RowWithPrice[];
+  selected: Record<string, boolean>;
+  allChecked: boolean;
+  toggleAll: () => void;
+  onToggleSelect: (id: string, checked: boolean) => void;
+  onOpenDetail: (row: RowWithPrice) => void;
+  selectedCount: number;
+  onAprovarSelecionados: () => void;
+  onPrevPage: () => void;
+  onNextPage: () => void;
+}
+
+export function RevisaoTable({
+  total,
+  page,
+  totalPages,
+  isLoading,
+  rows,
+  selected,
+  allChecked,
+  toggleAll,
+  onToggleSelect,
+  onOpenDetail,
+  selectedCount,
+  onAprovarSelecionados,
+  onPrevPage,
+  onNextPage,
+}: RevisaoTableProps) {
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between">
+        <CardTitle className="text-base">
+          {total} SKU(s) encontrados — página {page + 1} de {totalPages}
+        </CardTitle>
+        <div className="flex gap-2">
+          <Button
+            size="sm"
+            disabled={selectedCount === 0}
+            onClick={onAprovarSelecionados}
+          >
+            <CheckCircle2 className="mr-2 h-4 w-4" />
+            Aprovar selecionados ({selectedCount})
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <div className="flex justify-center py-8">
+            <Loader2 className="h-6 w-6 animate-spin" />
+          </div>
+        ) : (
+          <div className="overflow-x-auto -mx-6 px-6">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="w-8">
+                  <Checkbox checked={allChecked} onCheckedChange={toggleAll} />
+                </TableHead>
+                <TableHead>SKU</TableHead>
+                <TableHead>Descrição</TableHead>
+                <TableHead>Classe</TableHead>
+                <TableHead className="text-right">D/dia</TableHead>
+                <TableHead className="text-right">R$ compra</TableHead>
+                <TableHead className="text-right">R$ venda</TableHead>
+                <TableHead>Fonte</TableHead>
+                <TableHead className="text-right">LT (du)</TableHead>
+                <TableHead className="text-right">EM</TableHead>
+                <TableHead className="text-right">PP</TableHead>
+                <TableHead className="text-right">Emax</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead></TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {rows.map((r) => (
+                <SkuRow
+                  key={r.id}
+                  row={r}
+                  checked={!!selected[r.id]}
+                  onToggleSelect={onToggleSelect}
+                  onOpenDetail={onOpenDetail}
+                />
+              ))}
+              {rows.length === 0 && (
+                <TableRow>
+                  <TableCell colSpan={14} className="text-center text-muted-foreground py-8">
+                    Nenhum SKU encontrado para os filtros atuais.
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+          </div>
+        )}
+
+        <div className="flex items-center justify-end gap-2 pt-4">
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={page === 0}
+            onClick={onPrevPage}
+          >
+            <ChevronLeft className="h-4 w-4" />
+          </Button>
+          <span className="text-sm text-muted-foreground">
+            {page + 1}/{totalPages}
+          </span>
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={page + 1 >= totalPages}
+            onClick={onNextPage}
+          >
+            <ChevronRight className="h-4 w-4" />
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/reposicao/revisao/SkuRow.tsx
+++ b/src/components/reposicao/revisao/SkuRow.tsx
@@ -1,0 +1,89 @@
+// Linha da tabela de revisão de um SKU.
+// Extraída verbatim de src/pages/AdminReposicaoRevisao.tsx (god-component split).
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { TableCell, TableRow } from "@/components/ui/table";
+import {
+  type RowWithPrice,
+  fonteBadgeVariant,
+  fonteBadgeLabel,
+  classBadge,
+  fmt,
+  fmtBRL,
+} from "@/lib/reposicao/sku-param";
+import { type BadgeVariant } from "./types";
+
+interface SkuRowProps {
+  row: RowWithPrice;
+  checked: boolean;
+  onToggleSelect: (id: string, checked: boolean) => void;
+  onOpenDetail: (row: RowWithPrice) => void;
+}
+
+export function SkuRow({ row: r, checked, onToggleSelect, onOpenDetail }: SkuRowProps) {
+  return (
+    <TableRow className={r.read_only ? "bg-muted/30" : undefined}>
+      <TableCell>
+        {r.read_only ? (
+          <span className="inline-block h-4 w-4" aria-hidden />
+        ) : (
+          <Checkbox
+            checked={!!checked}
+            onCheckedChange={(v) => onToggleSelect(r.id, !!v)}
+          />
+        )}
+      </TableCell>
+      <TableCell className="font-mono text-xs align-top">{r.sku_codigo_omie}</TableCell>
+      <TableCell className="min-w-[280px] align-top">
+        <div className="whitespace-normal break-words leading-snug">{r.sku_descricao}</div>
+        {r.read_only && r.fornecedor_nome && (
+          <Badge
+            variant="warning"
+            className="mt-1 text-[10px] font-medium"
+            title="Fornecedor pendente de habilitação para reposição"
+          >
+            🏭 {r.fornecedor_nome}
+          </Badge>
+        )}
+      </TableCell>
+      <TableCell>
+        <Badge variant={classBadge(r.classe_consolidada) as BadgeVariant}>
+          {r.classe_consolidada}
+        </Badge>
+      </TableCell>
+      <TableCell className="text-right">{fmt(r.demanda_media_diaria)}</TableCell>
+      <TableCell className="text-right">{fmtBRL(r.preco_compra_real)}</TableCell>
+      <TableCell className="text-right">{fmtBRL(r.preco_venda_medio)}</TableCell>
+      <TableCell>
+        <Badge variant={fonteBadgeVariant(r.fonte_preco) as BadgeVariant}>
+          {fonteBadgeLabel(r.fonte_preco)}
+        </Badge>
+      </TableCell>
+      <TableCell className="text-right">{fmt(r.lt_medio_dias_uteis, 1)}</TableCell>
+      <TableCell className="text-right">{fmt(r.estoque_minimo, 0)}</TableCell>
+      <TableCell className="text-right">{fmt(r.ponto_pedido, 0)}</TableCell>
+      <TableCell className="text-right">{fmt(r.estoque_maximo, 0)}</TableCell>
+      <TableCell>
+        {r.read_only ? (
+          <Badge
+            variant="secondary"
+            className="bg-muted text-muted-foreground border-muted-foreground/20"
+            title="SKU bloqueado: fornecedor ainda não habilitado para reposição automática"
+          >
+            Aguardando fornecedor
+          </Badge>
+        ) : r.aprovado_em ? (
+          <Badge variant="default">Aprovado</Badge>
+        ) : (
+          <Badge variant="outline">Pendente</Badge>
+        )}
+      </TableCell>
+      <TableCell>
+        <Button size="sm" variant="ghost" onClick={() => onOpenDetail(r)}>
+          Detalhes
+        </Button>
+      </TableCell>
+    </TableRow>
+  );
+}

--- a/src/components/reposicao/revisao/__tests__/AprovarLoteDialog.test.tsx
+++ b/src/components/reposicao/revisao/__tests__/AprovarLoteDialog.test.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { AprovarLoteDialog } from "../AprovarLoteDialog";
+import type { RowWithPrice } from "@/lib/reposicao/sku-param";
+
+const selectedRows = [
+  { id: "r1", sku_codigo_omie: 111, sku_descricao: "Verniz", classe_consolidada: "AX", estoque_maximo: 40 } as unknown as RowWithPrice,
+];
+
+function setup(overrides: Partial<React.ComponentProps<typeof AprovarLoteDialog>> = {}) {
+  const props: React.ComponentProps<typeof AprovarLoteDialog> = {
+    open: true,
+    onOpenChange: vi.fn(),
+    aggregateImpact: { count: 1, capUnits: 40 },
+    selectedRows,
+    batchJustificativa: "",
+    setBatchJustificativa: vi.fn(),
+    onConfirm: vi.fn(),
+    isApproving: false,
+    ...overrides,
+  };
+  render(<AprovarLoteDialog {...props} />);
+  return props;
+}
+
+describe("AprovarLoteDialog", () => {
+  it("mostra contagem e os SKUs selecionados", () => {
+    setup();
+    expect(screen.getByText("Aprovar 1 SKU(s)")).toBeTruthy();
+    expect(screen.getByText("111")).toBeTruthy();
+    expect(screen.getByText("Verniz")).toBeTruthy();
+  });
+
+  it("dispara setBatchJustificativa ao digitar", () => {
+    const props = setup();
+    fireEvent.change(screen.getByPlaceholderText(/Revisão trimestral/), { target: { value: "ok" } });
+    expect(props.setBatchJustificativa).toHaveBeenCalledWith("ok");
+  });
+
+  it("confirma e cancela", () => {
+    const props = setup();
+    fireEvent.click(screen.getByRole("button", { name: /Confirmar aprovação/ }));
+    fireEvent.click(screen.getByRole("button", { name: "Cancelar" }));
+    expect(props.onConfirm).toHaveBeenCalledTimes(1);
+    expect(props.onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("desabilita Confirmar quando isApproving", () => {
+    setup({ isApproving: true });
+    expect(screen.getByRole("button", { name: /Confirmar aprovação/ })).toHaveProperty("disabled", true);
+  });
+});

--- a/src/components/reposicao/revisao/__tests__/FiltrosCard.test.tsx
+++ b/src/components/reposicao/revisao/__tests__/FiltrosCard.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { FiltrosCard } from "../FiltrosCard";
+
+function setup(overrides: Partial<React.ComponentProps<typeof FiltrosCard>> = {}) {
+  const props: React.ComponentProps<typeof FiltrosCard> = {
+    empresa: "OBEN",
+    statusFilter: "pendente",
+    onStatusChange: vi.fn(),
+    search: "",
+    onSearchChange: vi.fn(),
+    classes: [],
+    toggleClasse: vi.fn(),
+    clearClasses: vi.fn(),
+    ...overrides,
+  };
+  render(<FiltrosCard {...props} />);
+  return props;
+}
+
+describe("FiltrosCard", () => {
+  it("renderiza as opções de classe consolidada", () => {
+    setup();
+    expect(screen.getByText("AX")).toBeTruthy();
+    expect(screen.getByText("CZ")).toBeTruthy();
+  });
+
+  it("dispara toggleClasse ao clicar numa classe", () => {
+    const props = setup();
+    fireEvent.click(screen.getByText("BY"));
+    expect(props.toggleClasse).toHaveBeenCalledWith("BY");
+  });
+
+  it("mostra 'Limpar' só quando há classes e dispara clearClasses", () => {
+    const props = setup({ classes: ["AX"] });
+    const btn = screen.getByRole("button", { name: "Limpar" });
+    fireEvent.click(btn);
+    expect(props.clearClasses).toHaveBeenCalledTimes(1);
+  });
+
+  it("não mostra 'Limpar' sem classes", () => {
+    setup({ classes: [] });
+    expect(screen.queryByRole("button", { name: "Limpar" })).toBeNull();
+  });
+
+  it("dispara onSearchChange ao digitar", () => {
+    const props = setup();
+    fireEvent.change(screen.getByPlaceholderText(/Ex: 12345/), { target: { value: "tinta" } });
+    expect(props.onSearchChange).toHaveBeenCalledWith("tinta");
+  });
+});

--- a/src/components/reposicao/revisao/__tests__/SkuRow.test.tsx
+++ b/src/components/reposicao/revisao/__tests__/SkuRow.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { SkuRow } from "../SkuRow";
+import type { RowWithPrice } from "@/lib/reposicao/sku-param";
+
+function row(p: Partial<RowWithPrice>): RowWithPrice {
+  return {
+    id: "row-1",
+    empresa: "OBEN",
+    sku_codigo_omie: 12345,
+    sku_descricao: "TINTA BASE BRANCA",
+    fornecedor_nome: "Sayerlack",
+    classe_consolidada: "AX",
+    classe_abc: "A", classe_xyz: "X",
+    demanda_media_diaria: 3, demanda_desvio_padrao: 1, demanda_coef_variacao: 0.3,
+    demanda_dias_com_movimento: 40, demanda_total_90d: 270, valor_vendido_90d: 9000,
+    lt_medio_dias_uteis: 7, lt_desvio_padrao_dias: 2, lt_p95_dias: 12, lt_n_observacoes: 8,
+    fonte_leadtime: "historico", estoque_minimo: 10, ponto_pedido: 20, estoque_maximo: 40,
+    estoque_seguranca: 5, z_score: 1.65, cobertura_alvo_dias: 30, aplicar_no_omie: false,
+    aprovado_em: null, aprovado_por: null, justificativa_aprovacao: null, ultima_atualizacao_calculo: null,
+    preco_compra_real: 18.5, preco_venda_medio: 30, fonte_preco: "omie", read_only: false,
+    ...p,
+  };
+}
+
+function renderRow(r: RowWithPrice, overrides: Partial<React.ComponentProps<typeof SkuRow>> = {}) {
+  const props: React.ComponentProps<typeof SkuRow> = {
+    row: r, checked: false, onToggleSelect: vi.fn(), onOpenDetail: vi.fn(), ...overrides,
+  };
+  render(<table><tbody><SkuRow {...props} /></tbody></table>);
+  return props;
+}
+
+describe("SkuRow", () => {
+  it("renderiza código, descrição, classe e status Pendente", () => {
+    renderRow(row({}));
+    expect(screen.getByText("12345")).toBeTruthy();
+    expect(screen.getByText("TINTA BASE BRANCA")).toBeTruthy();
+    expect(screen.getByText("AX")).toBeTruthy();
+    expect(screen.getByText("Pendente")).toBeTruthy();
+  });
+
+  it("checkbox dispara onToggleSelect com o id", () => {
+    const props = renderRow(row({}));
+    fireEvent.click(screen.getByRole("checkbox"));
+    expect(props.onToggleSelect).toHaveBeenCalledWith("row-1", true);
+  });
+
+  it("status Aprovado quando aprovado_em presente", () => {
+    renderRow(row({ aprovado_em: "2026-05-20T00:00:00Z" }));
+    expect(screen.getByText("Aprovado")).toBeTruthy();
+  });
+
+  it("read_only: sem checkbox, badge de fornecedor e status Aguardando", () => {
+    renderRow(row({ read_only: true }));
+    expect(screen.queryByRole("checkbox")).toBeNull();
+    expect(screen.getByText(/Sayerlack/)).toBeTruthy();
+    expect(screen.getByText("Aguardando fornecedor")).toBeTruthy();
+  });
+
+  it("Detalhes dispara onOpenDetail com a linha", () => {
+    const r = row({});
+    const props = renderRow(r);
+    fireEvent.click(screen.getByRole("button", { name: "Detalhes" }));
+    expect(props.onOpenDetail).toHaveBeenCalledWith(r);
+  });
+});

--- a/src/components/reposicao/revisao/types.ts
+++ b/src/components/reposicao/revisao/types.ts
@@ -1,0 +1,12 @@
+// Tipos + constantes da tela de revisão de parâmetros de reposição.
+// Extraídos verbatim de src/pages/AdminReposicaoRevisao.tsx (god-component split).
+import type { Database } from "@/integrations/supabase/types";
+import type { VariantProps } from "class-variance-authority";
+import type { badgeVariants } from "@/components/ui/badge";
+
+export type SkuSugeridoView = Database["public"]["Views"]["v_sku_parametros_sugeridos"]["Row"];
+export type BadgeVariant = NonNullable<VariantProps<typeof badgeVariants>["variant"]>;
+
+export const PAGE_SIZE = 25;
+
+export const CLASSE_OPTIONS = ["AX", "AY", "AZ", "BX", "BY", "BZ", "CX", "CY", "CZ"];

--- a/src/components/reposicao/revisao/useRevisaoParametros.ts
+++ b/src/components/reposicao/revisao/useRevisaoParametros.ts
@@ -1,0 +1,280 @@
+// Lógica da revisão de parâmetros de reposição (query paginada, aprovação, edição).
+// Extraída verbatim de src/pages/AdminReposicaoRevisao.tsx (god-component split).
+import { useState, useMemo } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { supabase } from "@/integrations/supabase/client";
+import { useAuth } from "@/contexts/AuthContext";
+import { useReposicaoEmpresa } from "@/contexts/ReposicaoEmpresaContext";
+import { toast } from "sonner";
+import { type SkuParam, type RowWithPrice, type StatusFilterValue } from "@/lib/reposicao/sku-param";
+import { PAGE_SIZE, type SkuSugeridoView } from "./types";
+
+export function useRevisaoParametros() {
+  const { user } = useAuth();
+  const queryClient = useQueryClient();
+
+  const { empresa } = useReposicaoEmpresa();
+  const [classes, setClasses] = useState<string[]>([]);
+  const [statusFilter, setStatusFilter] = useState<StatusFilterValue>("pendente");
+  const [search, setSearch] = useState("");
+  const [page, setPage] = useState(0);
+  const [selected, setSelected] = useState<Record<string, boolean>>({});
+  const [openSku, setOpenSku] = useState<RowWithPrice | null>(null);
+  const [confirmBatch, setConfirmBatch] = useState(false);
+  const [batchJustificativa, setBatchJustificativa] = useState("");
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["sku_parametros_revisao", empresa, classes, statusFilter, search, page],
+    queryFn: async () => {
+      // Caso especial: SKUs aguardando habilitação de fornecedor vêm da view
+      if (statusFilter === "aguardando_fornecedor") {
+        let q = supabase
+          .from("v_sku_parametros_sugeridos")
+          .select("*", { count: "exact" })
+          .eq("empresa", empresa)
+          .eq("status_sugestao", "AGUARDANDO_HABILITACAO_FORNECEDOR");
+
+        if (classes.length > 0) q = q.in("classe_consolidada", classes);
+        if (search.trim()) {
+          const s = search.trim();
+          if (/^\d+$/.test(s)) {
+            q = q.eq("sku_codigo_omie", Number(s));
+          } else {
+            q = q.ilike("sku_descricao", `%${s}%`);
+          }
+        }
+
+        q = q.order("valor_total_90d", { ascending: false, nullsFirst: false });
+        q = q.range(page * PAGE_SIZE, (page + 1) * PAGE_SIZE - 1);
+
+        const { data: vdata, error, count } = await q;
+        if (error) throw error;
+
+        const priced: RowWithPrice[] = ((vdata ?? []) as SkuSugeridoView[]).map((v) => ({
+          id: `view-${v.sku_codigo_omie}`,
+          empresa: v.empresa ?? empresa,
+          sku_codigo_omie: Number(v.sku_codigo_omie),
+          sku_descricao: v.sku_descricao,
+          fornecedor_nome: v.fornecedor_nome,
+          classe_consolidada: v.classe_consolidada,
+          classe_abc: v.classe_abc_proposta,
+          classe_xyz: v.classe_xyz_proposta,
+          demanda_media_diaria: v.demanda_media_diaria,
+          demanda_desvio_padrao: v.demanda_sigma_diario,
+          demanda_coef_variacao: v.coef_variacao_ordem,
+          demanda_dias_com_movimento: v.dias_com_movimento,
+          demanda_total_90d: null,
+          valor_vendido_90d: v.valor_total_90d,
+          lt_medio_dias_uteis: v.lead_time_medio,
+          lt_desvio_padrao_dias: v.lead_time_desvio,
+          lt_p95_dias: v.lt_p95_dias,
+          lt_n_observacoes: null,
+          fonte_leadtime: v.fonte_leadtime,
+          estoque_minimo: v.estoque_minimo_sugerido,
+          ponto_pedido: v.ponto_pedido_sugerido,
+          estoque_maximo: v.estoque_maximo_sugerido,
+          estoque_seguranca: null,
+          z_score: v.z_aplicado,
+          cobertura_alvo_dias: v.cobertura_alvo_dias,
+          aplicar_no_omie: false,
+          aprovado_em: null,
+          aprovado_por: null,
+          justificativa_aprovacao: null,
+          ultima_atualizacao_calculo: v.calculado_em,
+          preco_compra_real: v.preco_compra_real,
+          preco_venda_medio: v.preco_venda_medio,
+          fonte_preco: v.fonte_preco,
+          status_sugestao: v.status_sugestao,
+          fornecedor_habilitado: v.fornecedor_habilitado,
+          read_only: true,
+        }));
+
+        return { rows: priced, total: count ?? 0 };
+      }
+
+      let q = supabase
+        .from("sku_parametros")
+        .select("*", { count: "exact" })
+        .eq("empresa", empresa)
+        .eq("ativo", true)
+        .not("estoque_minimo", "is", null);
+
+      if (classes.length > 0) q = q.in("classe_consolidada", classes);
+      if (statusFilter === "pendente") q = q.is("aprovado_em", null);
+      if (statusFilter === "aprovado") q = q.not("aprovado_em", "is", null);
+      if (search.trim()) {
+        const s = search.trim();
+        if (/^\d+$/.test(s)) {
+          q = q.eq("sku_codigo_omie", Number(s));
+        } else {
+          q = q.ilike("sku_descricao", `%${s}%`);
+        }
+      }
+
+      q = q.order("valor_vendido_90d", { ascending: false, nullsFirst: false });
+      q = q.range(page * PAGE_SIZE, (page + 1) * PAGE_SIZE - 1);
+
+      const { data, error, count } = await q;
+      if (error) throw error;
+
+      const baseRows = (data ?? []) as SkuParam[];
+
+      // Buscar preços/fonte da view para todos os SKUs da página em uma chamada
+      let priced: RowWithPrice[] = baseRows.map((r) => ({
+        ...r,
+        preco_compra_real: null,
+        preco_venda_medio: null,
+        fonte_preco: null,
+      }));
+
+      if (baseRows.length > 0) {
+        const codes = baseRows.map((r) => r.sku_codigo_omie);
+        const { data: vrows } = await supabase
+          .from("v_sku_parametros_sugeridos")
+          .select("sku_codigo_omie, preco_compra_real, preco_venda_medio, fonte_preco, fornecedor_habilitado, status_sugestao")
+          .eq("empresa", empresa)
+          .in("sku_codigo_omie", codes);
+
+        type SkuPriceRow = Pick<
+          SkuSugeridoView,
+          "sku_codigo_omie" | "preco_compra_real" | "preco_venda_medio" | "fonte_preco" | "fornecedor_habilitado" | "status_sugestao"
+        >;
+        const map = new Map<number, SkuPriceRow>();
+        ((vrows ?? []) as SkuPriceRow[]).forEach((row) => map.set(Number(row.sku_codigo_omie), row));
+        priced = baseRows.map((r) => {
+          const v = map.get(Number(r.sku_codigo_omie));
+          return {
+            ...r,
+            preco_compra_real: v?.preco_compra_real ?? null,
+            preco_venda_medio: v?.preco_venda_medio ?? null,
+            fonte_preco: v?.fonte_preco ?? null,
+            status_sugestao: v?.status_sugestao ?? null,
+            fornecedor_habilitado: v?.fornecedor_habilitado ?? null,
+            read_only: false,
+          };
+        });
+      }
+
+      return { rows: priced, total: count ?? 0 };
+    },
+  });
+
+  const rows = data?.rows ?? [];
+  const total = data?.total ?? 0;
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+
+  const selectedIds = useMemo(() => Object.keys(selected).filter((k) => selected[k]), [selected]);
+  const selectedRows = useMemo(() => rows.filter((r) => selected[r.id]), [rows, selected]);
+
+  const aggregateImpact = useMemo(() => {
+    const cap = selectedRows.reduce((acc, r) => acc + (r.estoque_maximo ?? 0) * 1, 0);
+    return { count: selectedRows.length, capUnits: cap };
+  }, [selectedRows]);
+
+  const approveMutation = useMutation({
+    mutationFn: async (payload: { ids: string[]; justificativa?: string }) => {
+      const { error } = await supabase
+        .from("sku_parametros")
+        .update({
+          aplicar_no_omie: true,
+          aprovado_em: new Date().toISOString(),
+          aprovado_por: user?.email ?? "desconhecido",
+          justificativa_aprovacao: payload.justificativa || null,
+        })
+        .in("id", payload.ids);
+      if (error) throw error;
+    },
+    onSuccess: (_d, vars) => {
+      toast.success(`${vars.ids.length} SKU(s) aprovado(s)`);
+      setSelected({});
+      setConfirmBatch(false);
+      setBatchJustificativa("");
+      setOpenSku(null);
+      queryClient.invalidateQueries({ queryKey: ["sku_parametros_revisao"] });
+    },
+    onError: (e: Error) => toast.error("Falha ao aprovar: " + e.message),
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: async (payload: { id: string; values: Partial<SkuParam> }) => {
+      const { error } = await supabase
+        .from("sku_parametros")
+        .update(payload.values)
+        .eq("id", payload.id);
+      if (error) throw error;
+    },
+    onSuccess: () => {
+      toast.success("Valores atualizados");
+      queryClient.invalidateQueries({ queryKey: ["sku_parametros_revisao"] });
+    },
+    onError: (e: Error) => toast.error("Falha ao atualizar: " + e.message),
+  });
+
+  const toggleClasse = (c: string) => {
+    setPage(0);
+    setClasses((prev) => (prev.includes(c) ? prev.filter((x) => x !== c) : [...prev, c]));
+  };
+
+  const selectableRows = useMemo(() => rows.filter((r) => !r.read_only), [rows]);
+  const allChecked = selectableRows.length > 0 && selectableRows.every((r) => selected[r.id]);
+  const toggleAll = () => {
+    if (allChecked) {
+      const next = { ...selected };
+      selectableRows.forEach((r) => delete next[r.id]);
+      setSelected(next);
+    } else {
+      const next = { ...selected };
+      selectableRows.forEach((r) => (next[r.id] = true));
+      setSelected(next);
+    }
+  };
+
+  // Handlers compostos (encapsulam os resets de página/seleção inline do JSX original)
+  const onStatusChange = (v: StatusFilterValue) => {
+    setPage(0);
+    setStatusFilter(v);
+    setSelected({});
+  };
+  const onSearchChange = (v: string) => {
+    setPage(0);
+    setSearch(v);
+  };
+  const clearClasses = () => setClasses([]);
+  const onToggleSelect = (id: string, checked: boolean) =>
+    setSelected((s) => ({ ...s, [id]: checked }));
+  const prevPage = () => setPage((p) => Math.max(0, p - 1));
+  const nextPage = () => setPage((p) => p + 1);
+
+  return {
+    empresa,
+    classes,
+    statusFilter,
+    search,
+    page,
+    selected,
+    openSku,
+    setOpenSku,
+    confirmBatch,
+    setConfirmBatch,
+    batchJustificativa,
+    setBatchJustificativa,
+    isLoading,
+    rows,
+    total,
+    totalPages,
+    selectedIds,
+    selectedRows,
+    aggregateImpact,
+    allChecked,
+    toggleAll,
+    toggleClasse,
+    clearClasses,
+    onStatusChange,
+    onSearchChange,
+    onToggleSelect,
+    prevPage,
+    nextPage,
+    approveMutation,
+    updateMutation,
+  };
+}

--- a/src/pages/AdminReposicaoRevisao.tsx
+++ b/src/pages/AdminReposicaoRevisao.tsx
@@ -1,289 +1,45 @@
-import { useState, useMemo } from "react";
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Link } from "react-router-dom";
-import { supabase } from "@/integrations/supabase/client";
-import type { Database } from "@/integrations/supabase/types";
-import type { VariantProps } from "class-variance-authority";
-import { badgeVariants } from "@/components/ui/badge";
-
-type SkuSugeridoView = Database["public"]["Views"]["v_sku_parametros_sugeridos"]["Row"];
-type BadgeVariant = NonNullable<VariantProps<typeof badgeVariants>["variant"]>;
-import { useAuth } from "@/contexts/AuthContext";
-import { useReposicaoEmpresa } from "@/contexts/ReposicaoEmpresaContext";
-import { toast } from "sonner";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Badge } from "@/components/ui/badge";
-import { Checkbox } from "@/components/ui/checkbox";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogFooter,
-} from "@/components/ui/dialog";
-import { Textarea } from "@/components/ui/textarea";
-import { Label } from "@/components/ui/label";
+import { History } from "lucide-react";
 import { SkuDetailSheet } from "@/components/reposicao/SkuDetailSheet";
-import {
-  type SkuParam,
-  type RowWithPrice,
-  type StatusFilterValue,
-  fonteBadgeVariant,
-  fonteBadgeLabel,
-  classBadge,
-  fmt,
-  fmtBRL,
-} from "@/lib/reposicao/sku-param";
-import {
-  ChevronLeft,
-  ChevronRight,
-  History,
-  Search,
-  CheckCircle2,
-  Loader2,
-} from "lucide-react";
-const PAGE_SIZE = 25;
-
-const CLASSE_OPTIONS = ["AX", "AY", "AZ", "BX", "BY", "BZ", "CX", "CY", "CZ"];
-
-// Tipos + helpers moved pra @/lib/reposicao/sku-param
+import { useRevisaoParametros } from "@/components/reposicao/revisao/useRevisaoParametros";
+import { FiltrosCard } from "@/components/reposicao/revisao/FiltrosCard";
+import { RevisaoTable } from "@/components/reposicao/revisao/RevisaoTable";
+import { AprovarLoteDialog } from "@/components/reposicao/revisao/AprovarLoteDialog";
 
 export default function AdminReposicaoRevisao() {
-  const { user } = useAuth();
-  const queryClient = useQueryClient();
-
-  const { empresa } = useReposicaoEmpresa();
-  const [classes, setClasses] = useState<string[]>([]);
-  const [statusFilter, setStatusFilter] = useState<StatusFilterValue>("pendente");
-  const [search, setSearch] = useState("");
-  const [page, setPage] = useState(0);
-  const [selected, setSelected] = useState<Record<string, boolean>>({});
-  const [openSku, setOpenSku] = useState<RowWithPrice | null>(null);
-  const [confirmBatch, setConfirmBatch] = useState(false);
-  const [batchJustificativa, setBatchJustificativa] = useState("");
-
-  const { data, isLoading } = useQuery({
-    queryKey: ["sku_parametros_revisao", empresa, classes, statusFilter, search, page],
-    queryFn: async () => {
-      // Caso especial: SKUs aguardando habilitação de fornecedor vêm da view
-      if (statusFilter === "aguardando_fornecedor") {
-        let q = supabase
-          .from("v_sku_parametros_sugeridos")
-          .select("*", { count: "exact" })
-          .eq("empresa", empresa)
-          .eq("status_sugestao", "AGUARDANDO_HABILITACAO_FORNECEDOR");
-
-        if (classes.length > 0) q = q.in("classe_consolidada", classes);
-        if (search.trim()) {
-          const s = search.trim();
-          if (/^\d+$/.test(s)) {
-            q = q.eq("sku_codigo_omie", Number(s));
-          } else {
-            q = q.ilike("sku_descricao", `%${s}%`);
-          }
-        }
-
-        q = q.order("valor_total_90d", { ascending: false, nullsFirst: false });
-        q = q.range(page * PAGE_SIZE, (page + 1) * PAGE_SIZE - 1);
-
-        const { data: vdata, error, count } = await q;
-        if (error) throw error;
-
-        const priced: RowWithPrice[] = ((vdata ?? []) as SkuSugeridoView[]).map((v) => ({
-          id: `view-${v.sku_codigo_omie}`,
-          empresa: v.empresa ?? empresa,
-          sku_codigo_omie: Number(v.sku_codigo_omie),
-          sku_descricao: v.sku_descricao,
-          fornecedor_nome: v.fornecedor_nome,
-          classe_consolidada: v.classe_consolidada,
-          classe_abc: v.classe_abc_proposta,
-          classe_xyz: v.classe_xyz_proposta,
-          demanda_media_diaria: v.demanda_media_diaria,
-          demanda_desvio_padrao: v.demanda_sigma_diario,
-          demanda_coef_variacao: v.coef_variacao_ordem,
-          demanda_dias_com_movimento: v.dias_com_movimento,
-          demanda_total_90d: null,
-          valor_vendido_90d: v.valor_total_90d,
-          lt_medio_dias_uteis: v.lead_time_medio,
-          lt_desvio_padrao_dias: v.lead_time_desvio,
-          lt_p95_dias: v.lt_p95_dias,
-          lt_n_observacoes: null,
-          fonte_leadtime: v.fonte_leadtime,
-          estoque_minimo: v.estoque_minimo_sugerido,
-          ponto_pedido: v.ponto_pedido_sugerido,
-          estoque_maximo: v.estoque_maximo_sugerido,
-          estoque_seguranca: null,
-          z_score: v.z_aplicado,
-          cobertura_alvo_dias: v.cobertura_alvo_dias,
-          aplicar_no_omie: false,
-          aprovado_em: null,
-          aprovado_por: null,
-          justificativa_aprovacao: null,
-          ultima_atualizacao_calculo: v.calculado_em,
-          preco_compra_real: v.preco_compra_real,
-          preco_venda_medio: v.preco_venda_medio,
-          fonte_preco: v.fonte_preco,
-          status_sugestao: v.status_sugestao,
-          fornecedor_habilitado: v.fornecedor_habilitado,
-          read_only: true,
-        }));
-
-        return { rows: priced, total: count ?? 0 };
-      }
-
-      let q = supabase
-        .from("sku_parametros")
-        .select("*", { count: "exact" })
-        .eq("empresa", empresa)
-        .eq("ativo", true)
-        .not("estoque_minimo", "is", null);
-
-      if (classes.length > 0) q = q.in("classe_consolidada", classes);
-      if (statusFilter === "pendente") q = q.is("aprovado_em", null);
-      if (statusFilter === "aprovado") q = q.not("aprovado_em", "is", null);
-      if (search.trim()) {
-        const s = search.trim();
-        if (/^\d+$/.test(s)) {
-          q = q.eq("sku_codigo_omie", Number(s));
-        } else {
-          q = q.ilike("sku_descricao", `%${s}%`);
-        }
-      }
-
-      q = q.order("valor_vendido_90d", { ascending: false, nullsFirst: false });
-      q = q.range(page * PAGE_SIZE, (page + 1) * PAGE_SIZE - 1);
-
-      const { data, error, count } = await q;
-      if (error) throw error;
-
-      const baseRows = (data ?? []) as SkuParam[];
-
-      // Buscar preços/fonte da view para todos os SKUs da página em uma chamada
-      let priced: RowWithPrice[] = baseRows.map((r) => ({
-        ...r,
-        preco_compra_real: null,
-        preco_venda_medio: null,
-        fonte_preco: null,
-      }));
-
-      if (baseRows.length > 0) {
-        const codes = baseRows.map((r) => r.sku_codigo_omie);
-        const { data: vrows } = await supabase
-          .from("v_sku_parametros_sugeridos")
-          .select("sku_codigo_omie, preco_compra_real, preco_venda_medio, fonte_preco, fornecedor_habilitado, status_sugestao")
-          .eq("empresa", empresa)
-          .in("sku_codigo_omie", codes);
-
-        type SkuPriceRow = Pick<
-          SkuSugeridoView,
-          "sku_codigo_omie" | "preco_compra_real" | "preco_venda_medio" | "fonte_preco" | "fornecedor_habilitado" | "status_sugestao"
-        >;
-        const map = new Map<number, SkuPriceRow>();
-        ((vrows ?? []) as SkuPriceRow[]).forEach((row) => map.set(Number(row.sku_codigo_omie), row));
-        priced = baseRows.map((r) => {
-          const v = map.get(Number(r.sku_codigo_omie));
-          return {
-            ...r,
-            preco_compra_real: v?.preco_compra_real ?? null,
-            preco_venda_medio: v?.preco_venda_medio ?? null,
-            fonte_preco: v?.fonte_preco ?? null,
-            status_sugestao: v?.status_sugestao ?? null,
-            fornecedor_habilitado: v?.fornecedor_habilitado ?? null,
-            read_only: false,
-          };
-        });
-      }
-
-      return { rows: priced, total: count ?? 0 };
-    },
-  });
-
-  const rows = data?.rows ?? [];
-  const total = data?.total ?? 0;
-  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
-
-  const selectedIds = useMemo(() => Object.keys(selected).filter((k) => selected[k]), [selected]);
-  const selectedRows = useMemo(() => rows.filter((r) => selected[r.id]), [rows, selected]);
-
-  const aggregateImpact = useMemo(() => {
-    const cap = selectedRows.reduce((acc, r) => acc + (r.estoque_maximo ?? 0) * 1, 0);
-    return { count: selectedRows.length, capUnits: cap };
-  }, [selectedRows]);
-
-  const approveMutation = useMutation({
-    mutationFn: async (payload: { ids: string[]; justificativa?: string }) => {
-      const { error } = await supabase
-        .from("sku_parametros")
-        .update({
-          aplicar_no_omie: true,
-          aprovado_em: new Date().toISOString(),
-          aprovado_por: user?.email ?? "desconhecido",
-          justificativa_aprovacao: payload.justificativa || null,
-        })
-        .in("id", payload.ids);
-      if (error) throw error;
-    },
-    onSuccess: (_d, vars) => {
-      toast.success(`${vars.ids.length} SKU(s) aprovado(s)`);
-      setSelected({});
-      setConfirmBatch(false);
-      setBatchJustificativa("");
-      setOpenSku(null);
-      queryClient.invalidateQueries({ queryKey: ["sku_parametros_revisao"] });
-    },
-    onError: (e: Error) => toast.error("Falha ao aprovar: " + e.message),
-  });
-
-  const updateMutation = useMutation({
-    mutationFn: async (payload: { id: string; values: Partial<SkuParam> }) => {
-      const { error } = await supabase
-        .from("sku_parametros")
-        .update(payload.values)
-        .eq("id", payload.id);
-      if (error) throw error;
-    },
-    onSuccess: () => {
-      toast.success("Valores atualizados");
-      queryClient.invalidateQueries({ queryKey: ["sku_parametros_revisao"] });
-    },
-    onError: (e: Error) => toast.error("Falha ao atualizar: " + e.message),
-  });
-
-  const toggleClasse = (c: string) => {
-    setPage(0);
-    setClasses((prev) => (prev.includes(c) ? prev.filter((x) => x !== c) : [...prev, c]));
-  };
-
-  const selectableRows = useMemo(() => rows.filter((r) => !r.read_only), [rows]);
-  const allChecked = selectableRows.length > 0 && selectableRows.every((r) => selected[r.id]);
-  const toggleAll = () => {
-    if (allChecked) {
-      const next = { ...selected };
-      selectableRows.forEach((r) => delete next[r.id]);
-      setSelected(next);
-    } else {
-      const next = { ...selected };
-      selectableRows.forEach((r) => (next[r.id] = true));
-      setSelected(next);
-    }
-  };
+  const {
+    empresa,
+    classes,
+    statusFilter,
+    search,
+    page,
+    selected,
+    openSku,
+    setOpenSku,
+    confirmBatch,
+    setConfirmBatch,
+    batchJustificativa,
+    setBatchJustificativa,
+    isLoading,
+    rows,
+    total,
+    totalPages,
+    selectedIds,
+    selectedRows,
+    aggregateImpact,
+    allChecked,
+    toggleAll,
+    toggleClasse,
+    clearClasses,
+    onStatusChange,
+    onSearchChange,
+    onToggleSelect,
+    prevPage,
+    nextPage,
+    approveMutation,
+    updateMutation,
+  } = useRevisaoParametros();
 
   return (
     <div className="container mx-auto p-6 space-y-6">
@@ -301,232 +57,33 @@ export default function AdminReposicaoRevisao() {
         </Button>
       </div>
 
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-base">Filtros</CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-            <div>
-              <Label className="text-xs">Empresa</Label>
-              <Select value={empresa} disabled>
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="OBEN">OBEN</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-            <div>
-              <Label className="text-xs">Status</Label>
-              <Select
-                value={statusFilter}
-                onValueChange={(v: StatusFilterValue) => {
-                  setPage(0);
-                  setStatusFilter(v);
-                  setSelected({});
-                }}
-              >
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="pendente">Pendentes</SelectItem>
-                  <SelectItem value="aprovado">Aprovados</SelectItem>
-                  <SelectItem value="aguardando_fornecedor">
-                    Aguardando habilitação de fornecedor
-                  </SelectItem>
-                  <SelectItem value="todos">Todos</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-            <div className="md:col-span-2">
-              <Label className="text-xs">Busca (código ou descrição)</Label>
-              <div className="relative">
-                <Search className="absolute left-2 top-2.5 h-4 w-4 text-muted-foreground" />
-                <Input
-                  className="pl-8"
-                  value={search}
-                  placeholder="Ex: 12345 ou TINTA BASE"
-                  onChange={(e) => {
-                    setPage(0);
-                    setSearch(e.target.value);
-                  }}
-                />
-              </div>
-            </div>
-          </div>
+      <FiltrosCard
+        empresa={empresa}
+        statusFilter={statusFilter}
+        onStatusChange={onStatusChange}
+        search={search}
+        onSearchChange={onSearchChange}
+        classes={classes}
+        toggleClasse={toggleClasse}
+        clearClasses={clearClasses}
+      />
 
-          <div>
-            <Label className="text-xs">Classe consolidada</Label>
-            <div className="flex flex-wrap gap-2 mt-1">
-              {CLASSE_OPTIONS.map((c) => (
-                <Badge
-                  key={c}
-                  variant={classes.includes(c) ? "default" : "outline"}
-                  className="cursor-pointer"
-                  onClick={() => toggleClasse(c)}
-                >
-                  {c}
-                </Badge>
-              ))}
-              {classes.length > 0 && (
-                <Button variant="ghost" size="sm" onClick={() => setClasses([])}>
-                  Limpar
-                </Button>
-              )}
-            </div>
-          </div>
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardHeader className="flex flex-row items-center justify-between">
-          <CardTitle className="text-base">
-            {total} SKU(s) encontrados — página {page + 1} de {totalPages}
-          </CardTitle>
-          <div className="flex gap-2">
-            <Button
-              size="sm"
-              disabled={selectedIds.length === 0}
-              onClick={() => setConfirmBatch(true)}
-            >
-              <CheckCircle2 className="mr-2 h-4 w-4" />
-              Aprovar selecionados ({selectedIds.length})
-            </Button>
-          </div>
-        </CardHeader>
-        <CardContent>
-          {isLoading ? (
-            <div className="flex justify-center py-8">
-              <Loader2 className="h-6 w-6 animate-spin" />
-            </div>
-          ) : (
-            <div className="overflow-x-auto -mx-6 px-6">
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead className="w-8">
-                    <Checkbox checked={allChecked} onCheckedChange={toggleAll} />
-                  </TableHead>
-                  <TableHead>SKU</TableHead>
-                  <TableHead>Descrição</TableHead>
-                  <TableHead>Classe</TableHead>
-                  <TableHead className="text-right">D/dia</TableHead>
-                  <TableHead className="text-right">R$ compra</TableHead>
-                  <TableHead className="text-right">R$ venda</TableHead>
-                  <TableHead>Fonte</TableHead>
-                  <TableHead className="text-right">LT (du)</TableHead>
-                  <TableHead className="text-right">EM</TableHead>
-                  <TableHead className="text-right">PP</TableHead>
-                  <TableHead className="text-right">Emax</TableHead>
-                  <TableHead>Status</TableHead>
-                  <TableHead></TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {rows.map((r) => (
-                  <TableRow key={r.id} className={r.read_only ? "bg-muted/30" : undefined}>
-                    <TableCell>
-                      {r.read_only ? (
-                        <span className="inline-block h-4 w-4" aria-hidden />
-                      ) : (
-                        <Checkbox
-                          checked={!!selected[r.id]}
-                          onCheckedChange={(v) =>
-                            setSelected((s) => ({ ...s, [r.id]: !!v }))
-                          }
-                        />
-                      )}
-                    </TableCell>
-                    <TableCell className="font-mono text-xs align-top">{r.sku_codigo_omie}</TableCell>
-                    <TableCell className="min-w-[280px] align-top">
-                      <div className="whitespace-normal break-words leading-snug">{r.sku_descricao}</div>
-                      {r.read_only && r.fornecedor_nome && (
-                        <Badge
-                          variant="warning"
-                          className="mt-1 text-[10px] font-medium"
-                          title="Fornecedor pendente de habilitação para reposição"
-                        >
-                          🏭 {r.fornecedor_nome}
-                        </Badge>
-                      )}
-                    </TableCell>
-                    <TableCell>
-                      <Badge variant={classBadge(r.classe_consolidada) as BadgeVariant}>
-                        {r.classe_consolidada}
-                      </Badge>
-                    </TableCell>
-                    <TableCell className="text-right">{fmt(r.demanda_media_diaria)}</TableCell>
-                    <TableCell className="text-right">{fmtBRL(r.preco_compra_real)}</TableCell>
-                    <TableCell className="text-right">{fmtBRL(r.preco_venda_medio)}</TableCell>
-                    <TableCell>
-                      <Badge variant={fonteBadgeVariant(r.fonte_preco) as BadgeVariant}>
-                        {fonteBadgeLabel(r.fonte_preco)}
-                      </Badge>
-                    </TableCell>
-                    <TableCell className="text-right">{fmt(r.lt_medio_dias_uteis, 1)}</TableCell>
-                    <TableCell className="text-right">{fmt(r.estoque_minimo, 0)}</TableCell>
-                    <TableCell className="text-right">{fmt(r.ponto_pedido, 0)}</TableCell>
-                    <TableCell className="text-right">{fmt(r.estoque_maximo, 0)}</TableCell>
-                    <TableCell>
-                      {r.read_only ? (
-                        <Badge
-                          variant="secondary"
-                          className="bg-muted text-muted-foreground border-muted-foreground/20"
-                          title="SKU bloqueado: fornecedor ainda não habilitado para reposição automática"
-                        >
-                          Aguardando fornecedor
-                        </Badge>
-                      ) : r.aprovado_em ? (
-                        <Badge variant="default">Aprovado</Badge>
-                      ) : (
-                        <Badge variant="outline">Pendente</Badge>
-                      )}
-                    </TableCell>
-                    <TableCell>
-                      <Button size="sm" variant="ghost" onClick={() => setOpenSku(r)}>
-                        Detalhes
-                      </Button>
-                    </TableCell>
-                  </TableRow>
-                ))}
-                {rows.length === 0 && (
-                  <TableRow>
-                    <TableCell colSpan={14} className="text-center text-muted-foreground py-8">
-                      Nenhum SKU encontrado para os filtros atuais.
-                    </TableCell>
-                  </TableRow>
-                )}
-              </TableBody>
-            </Table>
-            </div>
-          )}
-
-          <div className="flex items-center justify-end gap-2 pt-4">
-            <Button
-              size="sm"
-              variant="outline"
-              disabled={page === 0}
-              onClick={() => setPage((p) => Math.max(0, p - 1))}
-            >
-              <ChevronLeft className="h-4 w-4" />
-            </Button>
-            <span className="text-sm text-muted-foreground">
-              {page + 1}/{totalPages}
-            </span>
-            <Button
-              size="sm"
-              variant="outline"
-              disabled={page + 1 >= totalPages}
-              onClick={() => setPage((p) => p + 1)}
-            >
-              <ChevronRight className="h-4 w-4" />
-            </Button>
-          </div>
-        </CardContent>
-      </Card>
+      <RevisaoTable
+        total={total}
+        page={page}
+        totalPages={totalPages}
+        isLoading={isLoading}
+        rows={rows}
+        selected={selected}
+        allChecked={allChecked}
+        toggleAll={toggleAll}
+        onToggleSelect={onToggleSelect}
+        onOpenDetail={setOpenSku}
+        selectedCount={selectedIds.length}
+        onAprovarSelecionados={() => setConfirmBatch(true)}
+        onPrevPage={prevPage}
+        onNextPage={nextPage}
+      />
 
       <SkuDetailSheet
         sku={openSku}
@@ -541,75 +98,18 @@ export default function AdminReposicaoRevisao() {
         isSaving={updateMutation.isPending}
       />
 
-      <Dialog open={confirmBatch} onOpenChange={setConfirmBatch}>
-        <DialogContent className="max-w-2xl">
-          <DialogHeader>
-            <DialogTitle>Aprovar {aggregateImpact.count} SKU(s)</DialogTitle>
-          </DialogHeader>
-          <div className="space-y-4">
-            <div className="grid grid-cols-2 gap-4 text-sm">
-              <div className="rounded-md border p-3">
-                <div className="text-muted-foreground">Total de SKUs</div>
-                <div className="text-2xl font-semibold">{aggregateImpact.count}</div>
-              </div>
-              <div className="rounded-md border p-3">
-                <div className="text-muted-foreground">Estoque máx. agregado (un)</div>
-                <div className="text-2xl font-semibold">
-                  {fmt(aggregateImpact.capUnits, 0)}
-                </div>
-              </div>
-            </div>
-
-            <div className="max-h-48 overflow-y-auto rounded-md border">
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>SKU</TableHead>
-                    <TableHead>Descrição</TableHead>
-                    <TableHead>Classe</TableHead>
-                    <TableHead className="text-right">Emax</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {selectedRows.map((r) => (
-                    <TableRow key={r.id}>
-                      <TableCell className="font-mono text-xs align-top">{r.sku_codigo_omie}</TableCell>
-                      <TableCell className="text-xs min-w-[260px] whitespace-normal break-words leading-snug align-top">
-                        {r.sku_descricao}
-                      </TableCell>
-                      <TableCell className="align-top">{r.classe_consolidada}</TableCell>
-                      <TableCell className="text-right align-top">{fmt(r.estoque_maximo, 0)}</TableCell>
-                    </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
-            </div>
-
-            <div>
-              <Label>Justificativa (opcional, aplicada a todos)</Label>
-              <Textarea
-                value={batchJustificativa}
-                onChange={(e) => setBatchJustificativa(e.target.value)}
-                placeholder="Ex: Revisão trimestral aprovada pela operação."
-              />
-            </div>
-          </div>
-          <DialogFooter>
-            <Button variant="outline" onClick={() => setConfirmBatch(false)}>
-              Cancelar
-            </Button>
-            <Button
-              onClick={() =>
-                approveMutation.mutate({ ids: selectedIds, justificativa: batchJustificativa })
-              }
-              disabled={approveMutation.isPending}
-            >
-              {approveMutation.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-              Confirmar aprovação
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      <AprovarLoteDialog
+        open={confirmBatch}
+        onOpenChange={setConfirmBatch}
+        aggregateImpact={aggregateImpact}
+        selectedRows={selectedRows}
+        batchJustificativa={batchJustificativa}
+        setBatchJustificativa={setBatchJustificativa}
+        onConfirm={() =>
+          approveMutation.mutate({ ids: selectedIds, justificativa: batchJustificativa })
+        }
+        isApproving={approveMutation.isPending}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Resumo
- Split estrutural da página `AdminReposicaoRevisao` (615→**115** linhas), preservando 100% do comportamento (move verbatim).
- Lógica isolada no hook **`useRevisaoParametros`** (query paginada com caso especial `aguardando_fornecedor`, memos de seleção/impacto, mutations approve/update, handlers).
- JSX em componentes controlados: **`FiltrosCard`**, **`RevisaoTable`** + **`SkuRow`**, **`AprovarLoteDialog`**. Tipos/constantes em `types.ts`; reusa helpers de `@/lib/reposicao/sku-param` e o `SkuDetailSheet`.

## Verificação
- `bunx tsc --noEmit` = 0 erros
- `bunx eslint` = 0 erros (2 warnings `exhaustive-deps` de `rows` são **baseline** — confirmado lintando o arquivo de origem)
- Testes novos (+14) passam isolados (3/3 arquivos). ⚠️ Suíte completa local com flakiness por contenção de CPU. Gate autoritativo = CI `validate`.
- Revisão independente de fidelidade (subagente): **FIEL 1:1**, zero divergências (mapeamento da view byte-a-byte).

## Test plan
- [x] tsc / eslint verdes; +14 testes novos verdes isolados
- [x] Revisão 1:1 confirmando comportamento idêntico
- [ ] CI `validate` verde (gate da suíte completa)

🤖 Generated with [Claude Code](https://claude.com/claude-code)