### PR TITLE
refactor(farmer): split FarmerTacticalPlan (599→97) em hook + componentes

### DIFF
--- a/src/components/farmer/tacticalPlan/EfficiencyAlertDialog.tsx
+++ b/src/components/farmer/tacticalPlan/EfficiencyAlertDialog.tsx
@@ -1,0 +1,44 @@
+// Dialog de alerta de potencial baixo (lucro/hora abaixo do limiar).
+// Extraído verbatim de src/pages/FarmerTacticalPlan.tsx (god-component split).
+import { AlertCircle } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import type { PlanType } from '@/hooks/useTacticalPlan';
+import { fmt } from './config';
+
+interface EfficiencyAlertDialogProps {
+  alert: { customerId: string; profitPerHour: number; planType: PlanType } | null;
+  onClose: () => void;
+  onConfirm: () => void;
+}
+
+export function EfficiencyAlertDialog({ alert, onClose, onConfirm }: EfficiencyAlertDialogProps) {
+  return (
+    <Dialog open={!!alert} onOpenChange={onClose}>
+      <DialogContent className="max-w-xs">
+        <DialogHeader>
+          <DialogTitle className="text-sm flex items-center gap-2">
+            <AlertCircle className="w-4 h-4 text-status-warning" />
+            Potencial Baixo
+          </DialogTitle>
+        </DialogHeader>
+        <div className="space-y-3">
+          <p className="text-xs text-muted-foreground">
+            O lucro estimado por hora para este cliente é de{' '}
+            <strong className="text-foreground">{fmt(alert?.profitPerHour || 0)}/h</strong>,
+            abaixo do limiar recomendado de <strong className="text-foreground">{fmt(50)}/h</strong>.
+          </p>
+          <p className="text-xs text-muted-foreground">Deseja continuar mesmo assim?</p>
+          <div className="flex gap-2">
+            <Button variant="outline" size="sm" className="flex-1 text-xs" onClick={onClose}>
+              Cancelar
+            </Button>
+            <Button size="sm" className="flex-1 text-xs" onClick={onConfirm}>
+              Continuar
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/farmer/tacticalPlan/GerarPlanoCard.tsx
+++ b/src/components/farmer/tacticalPlan/GerarPlanoCard.tsx
@@ -1,0 +1,79 @@
+// Card "Gerar Plano para Qualquer Cliente" (busca + lista + botões essencial/estratégico).
+// Extraído verbatim de src/pages/FarmerTacticalPlan.tsx (god-component split).
+import { Plus, Loader2, Zap, Layers } from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import type { PlanType } from '@/hooks/useTacticalPlan';
+import type { CustomerLite } from './types';
+
+interface GerarPlanoCardProps {
+  searchTerm: string;
+  onSearchChange: (v: string) => void;
+  filteredCustomers: CustomerLite[];
+  generating: string | null;
+  onGenerate: (customerId: string, planType: PlanType) => void;
+}
+
+export function GerarPlanoCard({
+  searchTerm,
+  onSearchChange,
+  filteredCustomers,
+  generating,
+  onGenerate,
+}: GerarPlanoCardProps) {
+  return (
+    <Card>
+      <CardHeader className="p-3 pb-2">
+        <CardTitle className="text-xs flex items-center gap-2">
+          <Plus className="w-3 h-3" /> Gerar Plano para Qualquer Cliente
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="p-3 pt-0 space-y-2">
+        <Input
+          placeholder="Buscar cliente..."
+          value={searchTerm}
+          onChange={e => onSearchChange(e.target.value)}
+          className="h-8 text-xs"
+        />
+        <div className="space-y-1.5 max-h-60 overflow-y-auto">
+          {filteredCustomers.map(c => (
+            <div key={c.id} className="flex items-center justify-between p-2 rounded-lg border text-xs">
+              <div className="flex items-center gap-2 flex-1 min-w-0">
+                <div className={`w-2 h-2 rounded-full shrink-0 ${
+                  c.healthScore >= 70 ? 'bg-status-success' :
+                  c.healthScore >= 40 ? 'bg-status-warning' : 'bg-status-error'
+                }`} />
+                <span className="truncate font-medium">{c.name}</span>
+                <span className="text-[9px] text-muted-foreground shrink-0">HS:{Math.round(c.healthScore)}</span>
+              </div>
+              <div className="flex gap-1 shrink-0 ml-2">
+                <Button
+                  size="sm"
+                  variant="outline"
+                  className="h-6 text-[8px] px-2"
+                  disabled={generating === c.id}
+                  onClick={() => onGenerate(c.id, 'essencial')}
+                >
+                  {generating === c.id ? <Loader2 className="w-3 h-3 animate-spin" /> : <><Zap className="w-2.5 h-2.5 mr-0.5" />Essencial</>}
+                </Button>
+                <Button
+                  size="sm"
+                  variant="default"
+                  className="h-6 text-[8px] px-2"
+                  disabled={generating === c.id}
+                  onClick={() => onGenerate(c.id, 'estrategico')}
+                >
+                  {generating === c.id ? <Loader2 className="w-3 h-3 animate-spin" /> : <><Layers className="w-2.5 h-2.5 mr-0.5" />Estratégico</>}
+                </Button>
+              </div>
+            </div>
+          ))}
+          {filteredCustomers.length === 0 && (
+            <p className="text-[10px] text-muted-foreground text-center py-4">Nenhum cliente encontrado</p>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/farmer/tacticalPlan/PlanCard.tsx
+++ b/src/components/farmer/tacticalPlan/PlanCard.tsx
@@ -1,0 +1,228 @@
+// Card de plano tático (resumo + conteúdo expandido).
+// Extraído verbatim de src/pages/FarmerTacticalPlan.tsx (god-component split).
+import {
+  Target, Heart, AlertTriangle, TrendingUp, Package,
+  MessageSquare, Shield, ChevronDown, ChevronUp,
+  Brain, DollarSign, BarChart3, AlertCircle,
+} from 'lucide-react';
+import { Card, CardContent } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { getObjectiveLabel, type TacticalPlan } from '@/hooks/useTacticalPlan';
+import { fmt, objectiveColors, profileLabels } from './config';
+import { Section, MetricRow, CopyButton } from './PlanSection';
+import { RecordResultDialog } from './RecordResultDialog';
+import type { RecordResultPayload } from './types';
+
+export const PlanCard = ({
+  plan, expanded, onToggle, onCopy, copiedText, onRecordResult,
+}: {
+  plan: TacticalPlan;
+  expanded: boolean;
+  onToggle: () => void;
+  onCopy: (text: string) => void;
+  copiedText: string | null;
+  onRecordResult: (planId: string, result: RecordResultPayload) => Promise<void>;
+}) => {
+  return (
+    <Card className={plan.status === 'concluido' ? 'opacity-70' : ''}>
+      <CardContent className="p-3">
+        <div className="flex items-center justify-between mb-2" onClick={onToggle} role="button">
+          <div className="flex items-center gap-2 flex-1 min-w-0">
+            <Target className="w-4 h-4 text-primary shrink-0" />
+            <span className="text-xs font-bold truncate">{plan.customerName}</span>
+          </div>
+          <div className="flex items-center gap-1.5">
+            <Badge variant="outline" className={`text-[7px] ${plan.planType === 'estrategico' ? 'border-primary text-primary' : ''}`}>
+              {plan.planType === 'estrategico' ? '⚡ Estratégico' : '📋 Essencial'}
+            </Badge>
+            <Badge className={`text-[8px] ${objectiveColors[plan.strategicObjective] || ''}`}>
+              {getObjectiveLabel(plan.strategicObjective)}
+            </Badge>
+            {expanded ? <ChevronUp className="w-3 h-3" /> : <ChevronDown className="w-3 h-3" />}
+          </div>
+        </div>
+
+        {/* Quick metrics */}
+        <div className="grid grid-cols-4 gap-1 text-center text-[9px]">
+          <div className="bg-muted/50 rounded p-1">
+            <p className="font-bold">{Math.round(plan.healthScore)}</p>
+            <p className="text-muted-foreground">Health</p>
+          </div>
+          <div className="bg-muted/50 rounded p-1">
+            <p className="font-bold">{Math.round(plan.churnRisk)}%</p>
+            <p className="text-muted-foreground">Churn</p>
+          </div>
+          <div className="bg-muted/50 rounded p-1">
+            <p className="font-bold">{plan.mixGap}</p>
+            <p className="text-muted-foreground">Gap Mix</p>
+          </div>
+          <div className="bg-muted/50 rounded p-1">
+            <p className="font-bold">{fmt(plan.bundleLie)}</p>
+            <p className="text-muted-foreground">LIE</p>
+          </div>
+        </div>
+
+        {/* Efficiency indicator */}
+        {plan.estimatedProfitPerHour > 0 && (
+          <div className={`mt-1.5 flex items-center gap-1 text-[9px] ${
+            plan.estimatedProfitPerHour >= 50 ? 'text-status-success' : 'text-status-warning'
+          }`}>
+            <DollarSign className="w-3 h-3" />
+            <span>Lucro estimado: {fmt(plan.estimatedProfitPerHour)}/h</span>
+          </div>
+        )}
+
+        {/* Expanded content */}
+        {expanded && (
+          <div className="mt-3 space-y-3">
+            {/* Diagnosis */}
+            <Section title="Diagnóstico Resumido" icon={Heart}>
+              <MetricRow label="Margem atual" value={`${plan.currentMarginPct.toFixed(1)}%`} />
+              <MetricRow label="Média cluster" value={`${plan.clusterAvgMarginPct.toFixed(1)}%`} />
+              <MetricRow label="Potencial expansão" value={`${plan.expansionPotential.toFixed(0)}%`} />
+              <MetricRow label="Perfil" value={profileLabels[plan.customerProfile] || plan.customerProfile} />
+            </Section>
+
+            {/* LTV Projection (strategic only) */}
+            {plan.ltvProjection && (
+              <Section title="Projeção de LTV" icon={BarChart3}>
+                <MetricRow label="Faturamento atual/ano" value={fmt(plan.ltvProjection.current_annual)} />
+                <MetricRow label="Projetado/ano" value={fmt(plan.ltvProjection.projected_annual)} />
+                <MetricRow label="Crescimento" value={`+${plan.ltvProjection.growth_pct}%`} />
+              </Section>
+            )}
+
+            {/* Expected Result (strategic only) */}
+            {plan.expectedResult && (
+              <Section title="Simulação de Resultado" icon={TrendingUp}>
+                <MetricRow label="Melhor cenário" value={fmt(plan.expectedResult.best_case_margin)} />
+                <MetricRow label="Cenário provável" value={fmt(plan.expectedResult.likely_margin)} />
+                <MetricRow label="Pior cenário" value={fmt(plan.expectedResult.worst_case_margin)} />
+              </Section>
+            )}
+
+            {/* Strategy A */}
+            {plan.approachStrategy && (
+              <Section title="Estratégia de Abordagem A" icon={Brain}>
+                <p className="text-xs leading-relaxed">{plan.approachStrategy}</p>
+                <CopyButton text={plan.approachStrategy} copied={copiedText === plan.approachStrategy} onCopy={onCopy} />
+              </Section>
+            )}
+
+            {/* Strategy B (strategic only) */}
+            {plan.approachStrategyB && (
+              <Section title="Estratégia Alternativa B" icon={Shield}>
+                <p className="text-xs leading-relaxed">{plan.approachStrategyB}</p>
+                <CopyButton text={plan.approachStrategyB} copied={copiedText === plan.approachStrategyB} onCopy={onCopy} />
+              </Section>
+            )}
+
+            {/* Bundle */}
+            {plan.bundleLie > 0 && (
+              <Section title="Bundle Prioritário" icon={Package}>
+                <MetricRow label="LIE Bundle" value={fmt(plan.bundleLie)} />
+                <MetricRow label="Probabilidade" value={`${plan.bundleProbability.toFixed(1)}%`} />
+                <MetricRow label="Margem incremental" value={fmt(plan.bundleIncrementalMargin)} />
+                {plan.bestIndividualLie > 0 && (
+                  <MetricRow label="Melhor individual" value={fmt(plan.bestIndividualLie)} />
+                )}
+              </Section>
+            )}
+
+            {/* Diagnostic Questions */}
+            {plan.diagnosticQuestions.length > 0 && (
+              <Section title="Perguntas Diagnósticas" icon={MessageSquare}>
+                {plan.diagnosticQuestions.map((q, i) => (
+                  <div key={i} className="p-2 rounded bg-muted/30 space-y-0.5">
+                    <div className="flex items-start justify-between gap-1">
+                      <p className="text-xs font-medium">
+                        <span className="text-primary">{i + 1}.</span> {q.question}
+                      </p>
+                      <CopyButton text={q.question} copied={copiedText === q.question} onCopy={onCopy} />
+                    </div>
+                    <p className="text-[9px] text-muted-foreground">💡 {q.purpose}</p>
+                  </div>
+                ))}
+
+                {plan.implicationQuestion && (
+                  <div className="p-2 rounded bg-status-warning-bg border border-status-warning/30">
+                    <div className="flex items-start justify-between gap-1">
+                      <div>
+                        <p className="text-[9px] font-semibold text-status-warning">Pergunta de Implicação</p>
+                        <p className="text-xs">{plan.implicationQuestion}</p>
+                      </div>
+                      <CopyButton text={plan.implicationQuestion} copied={copiedText === plan.implicationQuestion} onCopy={onCopy} />
+                    </div>
+                  </div>
+                )}
+
+                {plan.offerTransition && (
+                  <div className="p-2 rounded bg-status-success-bg border border-status-success/30">
+                    <div className="flex items-start justify-between gap-1">
+                      <div>
+                        <p className="text-[9px] font-semibold text-status-success">Transição para Oferta</p>
+                        <p className="text-xs">{plan.offerTransition}</p>
+                      </div>
+                      <CopyButton text={plan.offerTransition} copied={copiedText === plan.offerTransition} onCopy={onCopy} />
+                    </div>
+                  </div>
+                )}
+              </Section>
+            )}
+
+            {/* Objections */}
+            {plan.probableObjections.length > 0 && (
+              <Section title="Mapa de Objeções" icon={Shield}>
+                {plan.probableObjections.map((obj, i) => (
+                  <div key={i} className="p-2 rounded bg-muted/30 space-y-1">
+                    <div className="flex items-center justify-between">
+                      <p className="text-xs font-medium text-status-error">⚠ {obj.objection}</p>
+                      <Badge variant="outline" className="text-[8px]">{obj.probability}%</Badge>
+                    </div>
+                    <div className="space-y-0.5">
+                      <div className="flex items-start gap-1">
+                        <span className="text-[9px] font-semibold text-status-info shrink-0">Técnica:</span>
+                        <p className="text-[10px]">{obj.technical_response}</p>
+                      </div>
+                      <div className="flex items-start gap-1">
+                        <span className="text-[9px] font-semibold text-status-success shrink-0">Econômica:</span>
+                        <p className="text-[10px]">{obj.economic_response}</p>
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </Section>
+            )}
+
+            {/* Operational Risks (strategic only) */}
+            {plan.operationalRisks.length > 0 && (
+              <Section title="Riscos Operacionais" icon={AlertTriangle}>
+                {plan.operationalRisks.map((risk, i) => (
+                  <div key={i} className="flex items-start gap-1.5 text-[10px]">
+                    <AlertCircle className="w-3 h-3 text-status-warning shrink-0 mt-0.5" />
+                    <span>{risk}</span>
+                  </div>
+                ))}
+              </Section>
+            )}
+
+            {/* Post-call registration */}
+            {plan.status !== 'concluido' && (
+              <RecordResultDialog planId={plan.id} onRecord={onRecordResult} />
+            )}
+
+            {plan.status === 'concluido' && (
+              <div className="p-2 rounded bg-muted/50 text-[10px] space-y-0.5">
+                <p className="font-semibold">Resultado registrado</p>
+                <p>Plano seguido: {plan.planFollowed ? 'Sim' : 'Não'}</p>
+                <p>Resultado: {plan.callResult}</p>
+                {plan.actualMargin !== undefined && <p>Margem: {fmt(plan.actualMargin)}</p>}
+                {plan.callDurationSeconds && <p>Duração: {Math.round(plan.callDurationSeconds / 60)}min</p>}
+              </div>
+            )}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+};

--- a/src/components/farmer/tacticalPlan/PlanSection.tsx
+++ b/src/components/farmer/tacticalPlan/PlanSection.tsx
@@ -1,0 +1,27 @@
+// Primitivos presentacionais do PlanCard (Section, MetricRow, CopyButton).
+// Extraídos verbatim de src/pages/FarmerTacticalPlan.tsx (god-component split).
+import { Copy, Check, type LucideIcon } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+export const Section = ({ title, icon: Icon, children }: { title: string; icon: LucideIcon; children: React.ReactNode }) => (
+  <div className="space-y-1.5">
+    <div className="flex items-center gap-1.5">
+      <Icon className="w-3 h-3 text-primary" />
+      <span className="text-[10px] font-semibold">{title}</span>
+    </div>
+    <div className="space-y-1.5 pl-4">{children}</div>
+  </div>
+);
+
+export const MetricRow = ({ label, value }: { label: string; value: string }) => (
+  <div className="flex items-center justify-between text-[10px]">
+    <span className="text-muted-foreground">{label}</span>
+    <span className="font-medium">{value}</span>
+  </div>
+);
+
+export const CopyButton = ({ text, copied, onCopy }: { text: string; copied: boolean; onCopy: (t: string) => void }) => (
+  <Button size="sm" variant="ghost" className="h-5 w-5 p-0 shrink-0" onClick={() => onCopy(text)}>
+    {copied ? <Check className="w-2.5 h-2.5 text-status-success" /> : <Copy className="w-2.5 h-2.5" />}
+  </Button>
+);

--- a/src/components/farmer/tacticalPlan/RecordResultDialog.tsx
+++ b/src/components/farmer/tacticalPlan/RecordResultDialog.tsx
@@ -1,0 +1,108 @@
+// Dialog de registro de resultado pós-ligação.
+// Extraído verbatim de src/pages/FarmerTacticalPlan.tsx (god-component split).
+import { useState } from 'react';
+import { Loader2, FileText } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Switch } from '@/components/ui/switch';
+import { Label } from '@/components/ui/label';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
+import type { RecordResultPayload } from './types';
+
+export const RecordResultDialog = ({
+  planId,
+  onRecord,
+}: {
+  planId: string;
+  onRecord: (planId: string, result: RecordResultPayload) => Promise<void>;
+}) => {
+  const [open, setOpen] = useState(false);
+  const [planFollowed, setPlanFollowed] = useState(true);
+  const [callResult, setCallResult] = useState('');
+  const [actualMargin, setActualMargin] = useState('');
+  const [duration, setDuration] = useState('');
+  const [objectionType, setObjectionType] = useState('');
+  const [notes, setNotes] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  const handleSave = async () => {
+    setSaving(true);
+    await onRecord(planId, {
+      planFollowed,
+      callResult,
+      actualMargin: parseFloat(actualMargin) || 0,
+      callDurationSeconds: (parseFloat(duration) || 0) * 60,
+      objectionType: objectionType || undefined,
+      notes: notes || undefined,
+    });
+    setSaving(false);
+    setOpen(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button variant="outline" size="sm" className="w-full text-[10px] gap-1">
+          <FileText className="w-3 h-3" /> Registrar Resultado
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle className="text-sm">Resultado da Ligação</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-3">
+          <div className="flex items-center gap-2">
+            <Switch checked={planFollowed} onCheckedChange={setPlanFollowed} />
+            <Label className="text-xs">Plano foi seguido</Label>
+          </div>
+
+          <Select value={callResult} onValueChange={setCallResult}>
+            <SelectTrigger className="h-8 text-xs">
+              <SelectValue placeholder="Resultado" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="venda_realizada" className="text-xs">Venda realizada</SelectItem>
+              <SelectItem value="interesse_futuro" className="text-xs">Interesse futuro</SelectItem>
+              <SelectItem value="sem_interesse" className="text-xs">Sem interesse</SelectItem>
+              <SelectItem value="nao_atendeu" className="text-xs">Não atendeu</SelectItem>
+              <SelectItem value="reagendado" className="text-xs">Reagendado</SelectItem>
+            </SelectContent>
+          </Select>
+
+          <div className="grid grid-cols-2 gap-2">
+            <div>
+              <Label className="text-[10px]">Margem (R$)</Label>
+              <Input type="number" value={actualMargin} onChange={e => setActualMargin(e.target.value)} className="h-8 text-xs" placeholder="0.00" />
+            </div>
+            <div>
+              <Label className="text-[10px]">Duração (min)</Label>
+              <Input type="number" value={duration} onChange={e => setDuration(e.target.value)} className="h-8 text-xs" placeholder="0" />
+            </div>
+          </div>
+
+          <Select value={objectionType} onValueChange={setObjectionType}>
+            <SelectTrigger className="h-8 text-xs">
+              <SelectValue placeholder="Tipo de objeção (opcional)" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="preco" className="text-xs">Preço</SelectItem>
+              <SelectItem value="tecnica" className="text-xs">Técnica</SelectItem>
+              <SelectItem value="urgencia" className="text-xs">Falta de urgência</SelectItem>
+              <SelectItem value="concorrente" className="text-xs">Concorrente</SelectItem>
+              <SelectItem value="nenhuma" className="text-xs">Nenhuma</SelectItem>
+            </SelectContent>
+          </Select>
+
+          <Textarea value={notes} onChange={e => setNotes(e.target.value)} placeholder="Observações..." className="text-xs min-h-[60px]" />
+
+          <Button onClick={handleSave} disabled={!callResult || saving} className="w-full text-xs">
+            {saving ? <Loader2 className="w-3 h-3 animate-spin mr-1" /> : null}
+            Salvar Resultado
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/components/farmer/tacticalPlan/__tests__/EfficiencyAlertDialog.test.tsx
+++ b/src/components/farmer/tacticalPlan/__tests__/EfficiencyAlertDialog.test.tsx
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { EfficiencyAlertDialog } from "../EfficiencyAlertDialog";
+
+describe("EfficiencyAlertDialog", () => {
+  it("não renderiza conteúdo quando alert é null", () => {
+    render(<EfficiencyAlertDialog alert={null} onClose={vi.fn()} onConfirm={vi.fn()} />);
+    expect(screen.queryByText("Potencial Baixo")).toBeNull();
+  });
+
+  it("mostra o lucro/hora quando há alerta", () => {
+    render(
+      <EfficiencyAlertDialog
+        alert={{ customerId: "c1", profitPerHour: 30, planType: "essencial" }}
+        onClose={vi.fn()}
+        onConfirm={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("Potencial Baixo")).toBeTruthy();
+    expect(screen.getByText(/30,00\/h/)).toBeTruthy();
+  });
+
+  it("dispara onClose e onConfirm", () => {
+    const onClose = vi.fn();
+    const onConfirm = vi.fn();
+    render(
+      <EfficiencyAlertDialog
+        alert={{ customerId: "c1", profitPerHour: 30, planType: "essencial" }}
+        onClose={onClose}
+        onConfirm={onConfirm}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Cancelar" }));
+    fireEvent.click(screen.getByRole("button", { name: "Continuar" }));
+    expect(onClose).toHaveBeenCalled();
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/farmer/tacticalPlan/__tests__/GerarPlanoCard.test.tsx
+++ b/src/components/farmer/tacticalPlan/__tests__/GerarPlanoCard.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { GerarPlanoCard } from "../GerarPlanoCard";
+import type { CustomerLite } from "../types";
+
+const customers: CustomerLite[] = [
+  { id: "c1", name: "Marcenaria Alfa", healthScore: 80, churnRisk: 10 },
+  { id: "c2", name: "Móveis Beta", healthScore: 30, churnRisk: 60 },
+];
+
+function setup(overrides: Partial<React.ComponentProps<typeof GerarPlanoCard>> = {}) {
+  const props: React.ComponentProps<typeof GerarPlanoCard> = {
+    searchTerm: "",
+    onSearchChange: vi.fn(),
+    filteredCustomers: customers,
+    generating: null,
+    onGenerate: vi.fn(),
+    ...overrides,
+  };
+  render(<GerarPlanoCard {...props} />);
+  return props;
+}
+
+describe("GerarPlanoCard", () => {
+  it("lista os clientes com health score", () => {
+    setup();
+    expect(screen.getByText("Marcenaria Alfa")).toBeTruthy();
+    expect(screen.getByText("HS:80")).toBeTruthy();
+  });
+
+  it("dispara onSearchChange ao digitar", () => {
+    const props = setup();
+    fireEvent.change(screen.getByPlaceholderText("Buscar cliente..."), { target: { value: "alfa" } });
+    expect(props.onSearchChange).toHaveBeenCalledWith("alfa");
+  });
+
+  it("gera plano essencial e estratégico", () => {
+    const props = setup({ filteredCustomers: [customers[0]] });
+    fireEvent.click(screen.getByRole("button", { name: /Essencial/ }));
+    fireEvent.click(screen.getByRole("button", { name: /Estratégico/ }));
+    expect(props.onGenerate).toHaveBeenNthCalledWith(1, "c1", "essencial");
+    expect(props.onGenerate).toHaveBeenNthCalledWith(2, "c1", "estrategico");
+  });
+
+  it("mostra empty state quando não há clientes", () => {
+    setup({ filteredCustomers: [] });
+    expect(screen.getByText("Nenhum cliente encontrado")).toBeTruthy();
+  });
+
+  it("desabilita os botões do cliente em geração", () => {
+    setup({ filteredCustomers: [customers[0]], generating: "c1" });
+    const buttons = screen.getAllByRole("button");
+    expect(buttons).toHaveLength(2);
+    buttons.forEach((b) => expect(b).toHaveProperty("disabled", true));
+  });
+});

--- a/src/components/farmer/tacticalPlan/__tests__/PlanCard.test.tsx
+++ b/src/components/farmer/tacticalPlan/__tests__/PlanCard.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { PlanCard } from "../PlanCard";
+import type { TacticalPlan } from "@/hooks/useTacticalPlan";
+
+function makePlan(overrides: Partial<TacticalPlan> = {}): TacticalPlan {
+  return {
+    id: "p1",
+    customerId: "c1",
+    customerName: "Marcenaria Alfa",
+    planType: "essencial",
+    healthScore: 72,
+    churnRisk: 18,
+    mixGap: 3,
+    currentMarginPct: 12.5,
+    clusterAvgMarginPct: 15,
+    expansionPotential: 40,
+    strategicObjective: "recuperacao",
+    customerProfile: "misto",
+    approachStrategy: "",
+    approachStrategyB: "",
+    topBundle: {},
+    secondBundle: {},
+    bundleLie: 0,
+    bundleProbability: 0,
+    bundleIncrementalMargin: 0,
+    bestIndividualLie: 0,
+    diagnosticQuestions: [],
+    implicationQuestion: "",
+    offerTransition: "",
+    probableObjections: [],
+    ltvProjection: null,
+    expectedResult: null,
+    operationalRisks: [],
+    estimatedProfitPerHour: 0,
+    status: "ativo",
+    ...overrides,
+  };
+}
+
+function setup(overrides: Partial<React.ComponentProps<typeof PlanCard>> = {}) {
+  const props: React.ComponentProps<typeof PlanCard> = {
+    plan: makePlan(),
+    expanded: false,
+    onToggle: vi.fn(),
+    onCopy: vi.fn(),
+    copiedText: null,
+    onRecordResult: vi.fn(async () => {}),
+    ...overrides,
+  };
+  render(<PlanCard {...props} />);
+  return props;
+}
+
+describe("PlanCard", () => {
+  it("mostra nome do cliente, objetivo, tipo e health", () => {
+    setup();
+    expect(screen.getByText("Marcenaria Alfa")).toBeTruthy();
+    expect(screen.getByText("🔴 Recuperação")).toBeTruthy();
+    expect(screen.getByText("📋 Essencial")).toBeTruthy();
+    expect(screen.getByText("72")).toBeTruthy();
+  });
+
+  it("dispara onToggle ao clicar no cabeçalho", () => {
+    const props = setup();
+    fireEvent.click(screen.getByText("Marcenaria Alfa"));
+    expect(props.onToggle).toHaveBeenCalledTimes(1);
+  });
+
+  it("ao expandir mostra diagnóstico e o botão de registrar resultado", () => {
+    setup({ expanded: true });
+    expect(screen.getByText("Diagnóstico Resumido")).toBeTruthy();
+    expect(screen.getByText("Registrar Resultado")).toBeTruthy();
+  });
+
+  it("quando concluído oculta registrar resultado e exibe o resumo", () => {
+    setup({
+      expanded: true,
+      plan: makePlan({ status: "concluido", planFollowed: true, callResult: "venda_realizada" }),
+    });
+    expect(screen.queryByText("Registrar Resultado")).toBeNull();
+    expect(screen.getByText("Resultado registrado")).toBeTruthy();
+  });
+});

--- a/src/components/farmer/tacticalPlan/__tests__/PlanSection.test.tsx
+++ b/src/components/farmer/tacticalPlan/__tests__/PlanSection.test.tsx
@@ -1,0 +1,25 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { Target } from "lucide-react";
+import { Section, MetricRow, CopyButton } from "../PlanSection";
+
+describe("PlanSection primitives", () => {
+  it("Section renderiza título e filhos", () => {
+    render(<Section title="Diagnóstico" icon={Target}><span>conteúdo</span></Section>);
+    expect(screen.getByText("Diagnóstico")).toBeTruthy();
+    expect(screen.getByText("conteúdo")).toBeTruthy();
+  });
+
+  it("MetricRow renderiza label e valor", () => {
+    render(<MetricRow label="Margem" value="12,5%" />);
+    expect(screen.getByText("Margem")).toBeTruthy();
+    expect(screen.getByText("12,5%")).toBeTruthy();
+  });
+
+  it("CopyButton dispara onCopy com o texto", () => {
+    const onCopy = vi.fn();
+    render(<CopyButton text="copiar isso" copied={false} onCopy={onCopy} />);
+    fireEvent.click(screen.getByRole("button"));
+    expect(onCopy).toHaveBeenCalledWith("copiar isso");
+  });
+});

--- a/src/components/farmer/tacticalPlan/config.ts
+++ b/src/components/farmer/tacticalPlan/config.ts
@@ -1,0 +1,19 @@
+// Helpers e mapas de rótulos do FarmerTacticalPlan.
+// Extraídos verbatim de src/pages/FarmerTacticalPlan.tsx (god-component split).
+
+export const fmt = (v: number) => v.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
+
+export const objectiveColors: Record<string, string> = {
+  recuperacao: 'bg-status-error-bg text-status-error-fg',
+  expansao_mix: 'bg-status-success-bg text-status-success-fg',
+  upsell_premium: 'bg-status-info-bg text-status-info-fg',
+  reativacao: 'bg-status-warning-bg text-status-warning-fg',
+  consolidacao_margem: 'bg-orange-100 text-orange-800',
+};
+
+export const profileLabels: Record<string, string> = {
+  sensivel_preco: '💰 Sensível a Preço',
+  orientado_qualidade: '⭐ Orientado a Qualidade',
+  orientado_produtividade: '⚡ Orientado a Produtividade',
+  misto: '🔄 Perfil Misto',
+};

--- a/src/components/farmer/tacticalPlan/types.ts
+++ b/src/components/farmer/tacticalPlan/types.ts
@@ -1,0 +1,29 @@
+// Tipos locais do FarmerTacticalPlan.
+// Extraídos verbatim de src/pages/FarmerTacticalPlan.tsx (god-component split).
+
+export interface FarmerClientScoreRow {
+  customer_user_id: string;
+  health_score: number | null;
+  churn_risk: number | null;
+}
+
+export interface ProfileRow {
+  user_id: string;
+  name: string | null;
+}
+
+export interface RecordResultPayload {
+  planFollowed: boolean;
+  callResult: string;
+  actualMargin: number;
+  callDurationSeconds: number;
+  objectionType?: string;
+  notes?: string;
+}
+
+export interface CustomerLite {
+  id: string;
+  name: string;
+  healthScore: number;
+  churnRisk: number;
+}

--- a/src/components/farmer/tacticalPlan/useFarmerTacticalPlan.ts
+++ b/src/components/farmer/tacticalPlan/useFarmerTacticalPlan.ts
@@ -1,0 +1,99 @@
+// Hook de dados/estado do FarmerTacticalPlan.
+// Extraído verbatim de src/pages/FarmerTacticalPlan.tsx (god-component split):
+// state, carregamento de clientes, geração com checagem de eficiência e handlers.
+import { useState, useEffect } from 'react';
+import { useAuth } from '@/contexts/AuthContext';
+import { useTacticalPlan, type PlanType } from '@/hooks/useTacticalPlan';
+import { supabase } from '@/integrations/supabase/client';
+import type { FarmerClientScoreRow, ProfileRow, CustomerLite } from './types';
+
+export function useFarmerTacticalPlan() {
+  const { user, isStaff } = useAuth();
+  const { plans, loading, generating, loadPlans, generatePlan, checkEfficiency, recordResult } = useTacticalPlan();
+  const [customers, setCustomers] = useState<CustomerLite[]>([]);
+  const [expandedPlan, setExpandedPlan] = useState<string | null>(null);
+  const [copiedText, setCopiedText] = useState<string | null>(null);
+  const [searchTerm, setSearchTerm] = useState('');
+  const [efficiencyAlert, setEfficiencyAlert] = useState<{ customerId: string; profitPerHour: number; planType: PlanType } | null>(null);
+
+  useEffect(() => {
+    if (user?.id && isStaff) {
+      loadPlans();
+      loadCustomers();
+    }
+  }, [user, isStaff]);
+
+  const loadCustomers = async () => {
+    if (!user?.id) return;
+    const { data: scoresData } = await supabase
+      .from('farmer_client_scores')
+      .select('customer_user_id, health_score, churn_risk')
+      .eq('farmer_id', user.id)
+      .order('priority_score', { ascending: false });
+    const scores = (scoresData ?? []) as FarmerClientScoreRow[];
+    if (!scores.length) return;
+
+    const ids = scores.map((s) => s.customer_user_id);
+    const { data: profilesData } = await supabase
+      .from('profiles')
+      .select('user_id, name')
+      .in('user_id', ids);
+    const profiles = (profilesData ?? []) as ProfileRow[];
+
+    const profileMap = new Map(profiles.map((p) => [p.user_id, p.name]));
+
+    setCustomers(scores.map((s) => ({
+      id: s.customer_user_id,
+      name: profileMap.get(s.customer_user_id) || 'Cliente',
+      healthScore: Number(s.health_score || 0),
+      churnRisk: Number(s.churn_risk || 0),
+    })));
+  };
+
+  const handleGenerateWithCheck = async (customerId: string, planType: PlanType) => {
+    const check = await checkEfficiency(customerId);
+    if (!check.isAboveThreshold) {
+      setEfficiencyAlert({ customerId, profitPerHour: check.estimatedProfitPerHour, planType });
+      return;
+    }
+    generatePlan(customerId, planType);
+  };
+
+  const confirmGenerate = () => {
+    if (efficiencyAlert) {
+      generatePlan(efficiencyAlert.customerId, efficiencyAlert.planType);
+      setEfficiencyAlert(null);
+    }
+  };
+
+  const handleCopy = (text: string) => {
+    navigator.clipboard.writeText(text);
+    setCopiedText(text);
+    setTimeout(() => setCopiedText(null), 2000);
+  };
+
+  const filteredCustomers = searchTerm
+    ? customers.filter(c => c.name.toLowerCase().includes(searchTerm.toLowerCase()))
+    : customers;
+
+  const toggleExpanded = (planId: string) =>
+    setExpandedPlan(expandedPlan === planId ? null : planId);
+
+  return {
+    plans,
+    loading,
+    generating,
+    searchTerm,
+    setSearchTerm,
+    filteredCustomers,
+    expandedPlan,
+    toggleExpanded,
+    copiedText,
+    handleCopy,
+    efficiencyAlert,
+    setEfficiencyAlert,
+    confirmGenerate,
+    handleGenerateWithCheck,
+    recordResult,
+  };
+}

--- a/src/pages/FarmerTacticalPlan.tsx
+++ b/src/pages/FarmerTacticalPlan.tsx
@@ -1,132 +1,32 @@
-import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Textarea } from '@/components/ui/textarea';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { Switch } from '@/components/ui/switch';
-import { Label } from '@/components/ui/label';
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
+import { Loader2, Target, FileText } from 'lucide-react';
+import { Card, CardContent } from '@/components/ui/card';
 import { useAuth } from '@/contexts/AuthContext';
-import { useTacticalPlan, getObjectiveLabel, type TacticalPlan, type PlanType } from '@/hooks/useTacticalPlan';
-import { supabase } from '@/integrations/supabase/client';
-import {
-  Loader2, Target, Heart, AlertTriangle, TrendingUp, Package,
-  MessageSquare, Shield, Copy, Check, ChevronDown, ChevronUp,
-  Plus, FileText, Brain, DollarSign, Zap, BarChart3,
-  AlertCircle, Layers, type LucideIcon
-} from 'lucide-react';
-
-// ─── Local types ───────────────────────────────────────────────────
-interface FarmerClientScoreRow {
-  customer_user_id: string;
-  health_score: number | null;
-  churn_risk: number | null;
-}
-
-interface ProfileRow {
-  user_id: string;
-  name: string | null;
-}
-
-interface RecordResultPayload {
-  planFollowed: boolean;
-  callResult: string;
-  actualMargin: number;
-  callDurationSeconds: number;
-  objectionType?: string;
-  notes?: string;
-}
-
-// ─── Helpers ───────────────────────────────────────────────────────
-const fmt = (v: number) => v.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
-
-const objectiveColors: Record<string, string> = {
-  recuperacao: 'bg-status-error-bg text-status-error-fg',
-  expansao_mix: 'bg-status-success-bg text-status-success-fg',
-  upsell_premium: 'bg-status-info-bg text-status-info-fg',
-  reativacao: 'bg-status-warning-bg text-status-warning-fg',
-  consolidacao_margem: 'bg-orange-100 text-orange-800',
-};
-
-const profileLabels: Record<string, string> = {
-  sensivel_preco: '💰 Sensível a Preço',
-  orientado_qualidade: '⭐ Orientado a Qualidade',
-  orientado_produtividade: '⚡ Orientado a Produtividade',
-  misto: '🔄 Perfil Misto',
-};
+import { useFarmerTacticalPlan } from '@/components/farmer/tacticalPlan/useFarmerTacticalPlan';
+import { GerarPlanoCard } from '@/components/farmer/tacticalPlan/GerarPlanoCard';
+import { EfficiencyAlertDialog } from '@/components/farmer/tacticalPlan/EfficiencyAlertDialog';
+import { PlanCard } from '@/components/farmer/tacticalPlan/PlanCard';
 
 const FarmerTacticalPlan = () => {
   const navigate = useNavigate();
-  const { user, isStaff } = useAuth();
-  const { plans, loading, generating, loadPlans, generatePlan, checkEfficiency, recordResult } = useTacticalPlan();
-  const [customers, setCustomers] = useState<{ id: string; name: string; healthScore: number; churnRisk: number }[]>([]);
-  const [expandedPlan, setExpandedPlan] = useState<string | null>(null);
-  const [copiedText, setCopiedText] = useState<string | null>(null);
-  const [searchTerm, setSearchTerm] = useState('');
-  const [efficiencyAlert, setEfficiencyAlert] = useState<{ customerId: string; profitPerHour: number; planType: PlanType } | null>(null);
-
-  useEffect(() => {
-    if (user?.id && isStaff) {
-      loadPlans();
-      loadCustomers();
-    }
-  }, [user, isStaff]);
-
-  const loadCustomers = async () => {
-    if (!user?.id) return;
-    const { data: scoresData } = await supabase
-      .from('farmer_client_scores')
-      .select('customer_user_id, health_score, churn_risk')
-      .eq('farmer_id', user.id)
-      .order('priority_score', { ascending: false });
-    const scores = (scoresData ?? []) as FarmerClientScoreRow[];
-    if (!scores.length) return;
-
-    const ids = scores.map((s) => s.customer_user_id);
-    const { data: profilesData } = await supabase
-      .from('profiles')
-      .select('user_id, name')
-      .in('user_id', ids);
-    const profiles = (profilesData ?? []) as ProfileRow[];
-
-    const profileMap = new Map(profiles.map((p) => [p.user_id, p.name]));
-
-    setCustomers(scores.map((s) => ({
-      id: s.customer_user_id,
-      name: profileMap.get(s.customer_user_id) || 'Cliente',
-      healthScore: Number(s.health_score || 0),
-      churnRisk: Number(s.churn_risk || 0),
-    })));
-  };
-
-  const handleGenerateWithCheck = async (customerId: string, planType: PlanType) => {
-    const check = await checkEfficiency(customerId);
-    if (!check.isAboveThreshold) {
-      setEfficiencyAlert({ customerId, profitPerHour: check.estimatedProfitPerHour, planType });
-      return;
-    }
-    generatePlan(customerId, planType);
-  };
-
-  const confirmGenerate = () => {
-    if (efficiencyAlert) {
-      generatePlan(efficiencyAlert.customerId, efficiencyAlert.planType);
-      setEfficiencyAlert(null);
-    }
-  };
-
-  const handleCopy = (text: string) => {
-    navigator.clipboard.writeText(text);
-    setCopiedText(text);
-    setTimeout(() => setCopiedText(null), 2000);
-  };
-
-  const filteredCustomers = searchTerm
-    ? customers.filter(c => c.name.toLowerCase().includes(searchTerm.toLowerCase()))
-    : customers;
+  const { isStaff } = useAuth();
+  const {
+    plans,
+    loading,
+    generating,
+    searchTerm,
+    setSearchTerm,
+    filteredCustomers,
+    expandedPlan,
+    toggleExpanded,
+    copiedText,
+    handleCopy,
+    efficiencyAlert,
+    setEfficiencyAlert,
+    confirmGenerate,
+    handleGenerateWithCheck,
+    recordResult,
+  } = useFarmerTacticalPlan();
 
   if (!isStaff) { navigate('/', { replace: true }); return null; }
 
@@ -148,86 +48,20 @@ const FarmerTacticalPlan = () => {
         </Card>
 
         {/* Generate for any customer */}
-        <Card>
-          <CardHeader className="p-3 pb-2">
-            <CardTitle className="text-xs flex items-center gap-2">
-              <Plus className="w-3 h-3" /> Gerar Plano para Qualquer Cliente
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="p-3 pt-0 space-y-2">
-            <Input
-              placeholder="Buscar cliente..."
-              value={searchTerm}
-              onChange={e => setSearchTerm(e.target.value)}
-              className="h-8 text-xs"
-            />
-            <div className="space-y-1.5 max-h-60 overflow-y-auto">
-              {filteredCustomers.map(c => (
-                <div key={c.id} className="flex items-center justify-between p-2 rounded-lg border text-xs">
-                  <div className="flex items-center gap-2 flex-1 min-w-0">
-                    <div className={`w-2 h-2 rounded-full shrink-0 ${
-                      c.healthScore >= 70 ? 'bg-status-success' :
-                      c.healthScore >= 40 ? 'bg-status-warning' : 'bg-status-error'
-                    }`} />
-                    <span className="truncate font-medium">{c.name}</span>
-                    <span className="text-[9px] text-muted-foreground shrink-0">HS:{Math.round(c.healthScore)}</span>
-                  </div>
-                  <div className="flex gap-1 shrink-0 ml-2">
-                    <Button
-                      size="sm"
-                      variant="outline"
-                      className="h-6 text-[8px] px-2"
-                      disabled={generating === c.id}
-                      onClick={() => handleGenerateWithCheck(c.id, 'essencial')}
-                    >
-                      {generating === c.id ? <Loader2 className="w-3 h-3 animate-spin" /> : <><Zap className="w-2.5 h-2.5 mr-0.5" />Essencial</>}
-                    </Button>
-                    <Button
-                      size="sm"
-                      variant="default"
-                      className="h-6 text-[8px] px-2"
-                      disabled={generating === c.id}
-                      onClick={() => handleGenerateWithCheck(c.id, 'estrategico')}
-                    >
-                      {generating === c.id ? <Loader2 className="w-3 h-3 animate-spin" /> : <><Layers className="w-2.5 h-2.5 mr-0.5" />Estratégico</>}
-                    </Button>
-                  </div>
-                </div>
-              ))}
-              {filteredCustomers.length === 0 && (
-                <p className="text-[10px] text-muted-foreground text-center py-4">Nenhum cliente encontrado</p>
-              )}
-            </div>
-          </CardContent>
-        </Card>
+        <GerarPlanoCard
+          searchTerm={searchTerm}
+          onSearchChange={setSearchTerm}
+          filteredCustomers={filteredCustomers}
+          generating={generating}
+          onGenerate={handleGenerateWithCheck}
+        />
 
         {/* Efficiency Alert Dialog */}
-        <Dialog open={!!efficiencyAlert} onOpenChange={() => setEfficiencyAlert(null)}>
-          <DialogContent className="max-w-xs">
-            <DialogHeader>
-              <DialogTitle className="text-sm flex items-center gap-2">
-                <AlertCircle className="w-4 h-4 text-status-warning" />
-                Potencial Baixo
-              </DialogTitle>
-            </DialogHeader>
-            <div className="space-y-3">
-              <p className="text-xs text-muted-foreground">
-                O lucro estimado por hora para este cliente é de{' '}
-                <strong className="text-foreground">{fmt(efficiencyAlert?.profitPerHour || 0)}/h</strong>,
-                abaixo do limiar recomendado de <strong className="text-foreground">{fmt(50)}/h</strong>.
-              </p>
-              <p className="text-xs text-muted-foreground">Deseja continuar mesmo assim?</p>
-              <div className="flex gap-2">
-                <Button variant="outline" size="sm" className="flex-1 text-xs" onClick={() => setEfficiencyAlert(null)}>
-                  Cancelar
-                </Button>
-                <Button size="sm" className="flex-1 text-xs" onClick={confirmGenerate}>
-                  Continuar
-                </Button>
-              </div>
-            </div>
-          </DialogContent>
-        </Dialog>
+        <EfficiencyAlertDialog
+          alert={efficiencyAlert}
+          onClose={() => setEfficiencyAlert(null)}
+          onConfirm={confirmGenerate}
+        />
 
         {/* Plans List */}
         {loading ? (
@@ -247,7 +81,7 @@ const FarmerTacticalPlan = () => {
               key={plan.id}
               plan={plan}
               expanded={expandedPlan === plan.id}
-              onToggle={() => setExpandedPlan(expandedPlan === plan.id ? null : plan.id)}
+              onToggle={() => toggleExpanded(plan.id)}
               onCopy={handleCopy}
               copiedText={copiedText}
               onRecordResult={recordResult}
@@ -257,342 +91,6 @@ const FarmerTacticalPlan = () => {
       </main>
 
     </div>
-  );
-};
-
-// ─── Plan Card Component ────────────────────────────────────────────
-const PlanCard = ({
-  plan, expanded, onToggle, onCopy, copiedText, onRecordResult,
-}: {
-  plan: TacticalPlan;
-  expanded: boolean;
-  onToggle: () => void;
-  onCopy: (text: string) => void;
-  copiedText: string | null;
-  onRecordResult: (planId: string, result: RecordResultPayload) => Promise<void>;
-}) => {
-  return (
-    <Card className={plan.status === 'concluido' ? 'opacity-70' : ''}>
-      <CardContent className="p-3">
-        <div className="flex items-center justify-between mb-2" onClick={onToggle} role="button">
-          <div className="flex items-center gap-2 flex-1 min-w-0">
-            <Target className="w-4 h-4 text-primary shrink-0" />
-            <span className="text-xs font-bold truncate">{plan.customerName}</span>
-          </div>
-          <div className="flex items-center gap-1.5">
-            <Badge variant="outline" className={`text-[7px] ${plan.planType === 'estrategico' ? 'border-primary text-primary' : ''}`}>
-              {plan.planType === 'estrategico' ? '⚡ Estratégico' : '📋 Essencial'}
-            </Badge>
-            <Badge className={`text-[8px] ${objectiveColors[plan.strategicObjective] || ''}`}>
-              {getObjectiveLabel(plan.strategicObjective)}
-            </Badge>
-            {expanded ? <ChevronUp className="w-3 h-3" /> : <ChevronDown className="w-3 h-3" />}
-          </div>
-        </div>
-
-        {/* Quick metrics */}
-        <div className="grid grid-cols-4 gap-1 text-center text-[9px]">
-          <div className="bg-muted/50 rounded p-1">
-            <p className="font-bold">{Math.round(plan.healthScore)}</p>
-            <p className="text-muted-foreground">Health</p>
-          </div>
-          <div className="bg-muted/50 rounded p-1">
-            <p className="font-bold">{Math.round(plan.churnRisk)}%</p>
-            <p className="text-muted-foreground">Churn</p>
-          </div>
-          <div className="bg-muted/50 rounded p-1">
-            <p className="font-bold">{plan.mixGap}</p>
-            <p className="text-muted-foreground">Gap Mix</p>
-          </div>
-          <div className="bg-muted/50 rounded p-1">
-            <p className="font-bold">{fmt(plan.bundleLie)}</p>
-            <p className="text-muted-foreground">LIE</p>
-          </div>
-        </div>
-
-        {/* Efficiency indicator */}
-        {plan.estimatedProfitPerHour > 0 && (
-          <div className={`mt-1.5 flex items-center gap-1 text-[9px] ${
-            plan.estimatedProfitPerHour >= 50 ? 'text-status-success' : 'text-status-warning'
-          }`}>
-            <DollarSign className="w-3 h-3" />
-            <span>Lucro estimado: {fmt(plan.estimatedProfitPerHour)}/h</span>
-          </div>
-        )}
-
-        {/* Expanded content */}
-        {expanded && (
-          <div className="mt-3 space-y-3">
-            {/* Diagnosis */}
-            <Section title="Diagnóstico Resumido" icon={Heart}>
-              <MetricRow label="Margem atual" value={`${plan.currentMarginPct.toFixed(1)}%`} />
-              <MetricRow label="Média cluster" value={`${plan.clusterAvgMarginPct.toFixed(1)}%`} />
-              <MetricRow label="Potencial expansão" value={`${plan.expansionPotential.toFixed(0)}%`} />
-              <MetricRow label="Perfil" value={profileLabels[plan.customerProfile] || plan.customerProfile} />
-            </Section>
-
-            {/* LTV Projection (strategic only) */}
-            {plan.ltvProjection && (
-              <Section title="Projeção de LTV" icon={BarChart3}>
-                <MetricRow label="Faturamento atual/ano" value={fmt(plan.ltvProjection.current_annual)} />
-                <MetricRow label="Projetado/ano" value={fmt(plan.ltvProjection.projected_annual)} />
-                <MetricRow label="Crescimento" value={`+${plan.ltvProjection.growth_pct}%`} />
-              </Section>
-            )}
-
-            {/* Expected Result (strategic only) */}
-            {plan.expectedResult && (
-              <Section title="Simulação de Resultado" icon={TrendingUp}>
-                <MetricRow label="Melhor cenário" value={fmt(plan.expectedResult.best_case_margin)} />
-                <MetricRow label="Cenário provável" value={fmt(plan.expectedResult.likely_margin)} />
-                <MetricRow label="Pior cenário" value={fmt(plan.expectedResult.worst_case_margin)} />
-              </Section>
-            )}
-
-            {/* Strategy A */}
-            {plan.approachStrategy && (
-              <Section title="Estratégia de Abordagem A" icon={Brain}>
-                <p className="text-xs leading-relaxed">{plan.approachStrategy}</p>
-                <CopyButton text={plan.approachStrategy} copied={copiedText === plan.approachStrategy} onCopy={onCopy} />
-              </Section>
-            )}
-
-            {/* Strategy B (strategic only) */}
-            {plan.approachStrategyB && (
-              <Section title="Estratégia Alternativa B" icon={Shield}>
-                <p className="text-xs leading-relaxed">{plan.approachStrategyB}</p>
-                <CopyButton text={plan.approachStrategyB} copied={copiedText === plan.approachStrategyB} onCopy={onCopy} />
-              </Section>
-            )}
-
-            {/* Bundle */}
-            {plan.bundleLie > 0 && (
-              <Section title="Bundle Prioritário" icon={Package}>
-                <MetricRow label="LIE Bundle" value={fmt(plan.bundleLie)} />
-                <MetricRow label="Probabilidade" value={`${plan.bundleProbability.toFixed(1)}%`} />
-                <MetricRow label="Margem incremental" value={fmt(plan.bundleIncrementalMargin)} />
-                {plan.bestIndividualLie > 0 && (
-                  <MetricRow label="Melhor individual" value={fmt(plan.bestIndividualLie)} />
-                )}
-              </Section>
-            )}
-
-            {/* Diagnostic Questions */}
-            {plan.diagnosticQuestions.length > 0 && (
-              <Section title="Perguntas Diagnósticas" icon={MessageSquare}>
-                {plan.diagnosticQuestions.map((q, i) => (
-                  <div key={i} className="p-2 rounded bg-muted/30 space-y-0.5">
-                    <div className="flex items-start justify-between gap-1">
-                      <p className="text-xs font-medium">
-                        <span className="text-primary">{i + 1}.</span> {q.question}
-                      </p>
-                      <CopyButton text={q.question} copied={copiedText === q.question} onCopy={onCopy} />
-                    </div>
-                    <p className="text-[9px] text-muted-foreground">💡 {q.purpose}</p>
-                  </div>
-                ))}
-
-                {plan.implicationQuestion && (
-                  <div className="p-2 rounded bg-status-warning-bg border border-status-warning/30">
-                    <div className="flex items-start justify-between gap-1">
-                      <div>
-                        <p className="text-[9px] font-semibold text-status-warning">Pergunta de Implicação</p>
-                        <p className="text-xs">{plan.implicationQuestion}</p>
-                      </div>
-                      <CopyButton text={plan.implicationQuestion} copied={copiedText === plan.implicationQuestion} onCopy={onCopy} />
-                    </div>
-                  </div>
-                )}
-
-                {plan.offerTransition && (
-                  <div className="p-2 rounded bg-status-success-bg border border-status-success/30">
-                    <div className="flex items-start justify-between gap-1">
-                      <div>
-                        <p className="text-[9px] font-semibold text-status-success">Transição para Oferta</p>
-                        <p className="text-xs">{plan.offerTransition}</p>
-                      </div>
-                      <CopyButton text={plan.offerTransition} copied={copiedText === plan.offerTransition} onCopy={onCopy} />
-                    </div>
-                  </div>
-                )}
-              </Section>
-            )}
-
-            {/* Objections */}
-            {plan.probableObjections.length > 0 && (
-              <Section title="Mapa de Objeções" icon={Shield}>
-                {plan.probableObjections.map((obj, i) => (
-                  <div key={i} className="p-2 rounded bg-muted/30 space-y-1">
-                    <div className="flex items-center justify-between">
-                      <p className="text-xs font-medium text-status-error">⚠ {obj.objection}</p>
-                      <Badge variant="outline" className="text-[8px]">{obj.probability}%</Badge>
-                    </div>
-                    <div className="space-y-0.5">
-                      <div className="flex items-start gap-1">
-                        <span className="text-[9px] font-semibold text-status-info shrink-0">Técnica:</span>
-                        <p className="text-[10px]">{obj.technical_response}</p>
-                      </div>
-                      <div className="flex items-start gap-1">
-                        <span className="text-[9px] font-semibold text-status-success shrink-0">Econômica:</span>
-                        <p className="text-[10px]">{obj.economic_response}</p>
-                      </div>
-                    </div>
-                  </div>
-                ))}
-              </Section>
-            )}
-
-            {/* Operational Risks (strategic only) */}
-            {plan.operationalRisks.length > 0 && (
-              <Section title="Riscos Operacionais" icon={AlertTriangle}>
-                {plan.operationalRisks.map((risk, i) => (
-                  <div key={i} className="flex items-start gap-1.5 text-[10px]">
-                    <AlertCircle className="w-3 h-3 text-status-warning shrink-0 mt-0.5" />
-                    <span>{risk}</span>
-                  </div>
-                ))}
-              </Section>
-            )}
-
-            {/* Post-call registration */}
-            {plan.status !== 'concluido' && (
-              <RecordResultDialog planId={plan.id} onRecord={onRecordResult} />
-            )}
-
-            {plan.status === 'concluido' && (
-              <div className="p-2 rounded bg-muted/50 text-[10px] space-y-0.5">
-                <p className="font-semibold">Resultado registrado</p>
-                <p>Plano seguido: {plan.planFollowed ? 'Sim' : 'Não'}</p>
-                <p>Resultado: {plan.callResult}</p>
-                {plan.actualMargin !== undefined && <p>Margem: {fmt(plan.actualMargin)}</p>}
-                {plan.callDurationSeconds && <p>Duração: {Math.round(plan.callDurationSeconds / 60)}min</p>}
-              </div>
-            )}
-          </div>
-        )}
-      </CardContent>
-    </Card>
-  );
-};
-
-// ─── Sub-components ─────────────────────────────────────────────────
-const Section = ({ title, icon: Icon, children }: { title: string; icon: LucideIcon; children: React.ReactNode }) => (
-  <div className="space-y-1.5">
-    <div className="flex items-center gap-1.5">
-      <Icon className="w-3 h-3 text-primary" />
-      <span className="text-[10px] font-semibold">{title}</span>
-    </div>
-    <div className="space-y-1.5 pl-4">{children}</div>
-  </div>
-);
-
-const MetricRow = ({ label, value }: { label: string; value: string }) => (
-  <div className="flex items-center justify-between text-[10px]">
-    <span className="text-muted-foreground">{label}</span>
-    <span className="font-medium">{value}</span>
-  </div>
-);
-
-const CopyButton = ({ text, copied, onCopy }: { text: string; copied: boolean; onCopy: (t: string) => void }) => (
-  <Button size="sm" variant="ghost" className="h-5 w-5 p-0 shrink-0" onClick={() => onCopy(text)}>
-    {copied ? <Check className="w-2.5 h-2.5 text-status-success" /> : <Copy className="w-2.5 h-2.5" />}
-  </Button>
-);
-
-// ─── Record Result Dialog ───────────────────────────────────────────
-const RecordResultDialog = ({
-  planId,
-  onRecord,
-}: {
-  planId: string;
-  onRecord: (planId: string, result: RecordResultPayload) => Promise<void>;
-}) => {
-  const [open, setOpen] = useState(false);
-  const [planFollowed, setPlanFollowed] = useState(true);
-  const [callResult, setCallResult] = useState('');
-  const [actualMargin, setActualMargin] = useState('');
-  const [duration, setDuration] = useState('');
-  const [objectionType, setObjectionType] = useState('');
-  const [notes, setNotes] = useState('');
-  const [saving, setSaving] = useState(false);
-
-  const handleSave = async () => {
-    setSaving(true);
-    await onRecord(planId, {
-      planFollowed,
-      callResult,
-      actualMargin: parseFloat(actualMargin) || 0,
-      callDurationSeconds: (parseFloat(duration) || 0) * 60,
-      objectionType: objectionType || undefined,
-      notes: notes || undefined,
-    });
-    setSaving(false);
-    setOpen(false);
-  };
-
-  return (
-    <Dialog open={open} onOpenChange={setOpen}>
-      <DialogTrigger asChild>
-        <Button variant="outline" size="sm" className="w-full text-[10px] gap-1">
-          <FileText className="w-3 h-3" /> Registrar Resultado
-        </Button>
-      </DialogTrigger>
-      <DialogContent className="max-w-sm">
-        <DialogHeader>
-          <DialogTitle className="text-sm">Resultado da Ligação</DialogTitle>
-        </DialogHeader>
-        <div className="space-y-3">
-          <div className="flex items-center gap-2">
-            <Switch checked={planFollowed} onCheckedChange={setPlanFollowed} />
-            <Label className="text-xs">Plano foi seguido</Label>
-          </div>
-
-          <Select value={callResult} onValueChange={setCallResult}>
-            <SelectTrigger className="h-8 text-xs">
-              <SelectValue placeholder="Resultado" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="venda_realizada" className="text-xs">Venda realizada</SelectItem>
-              <SelectItem value="interesse_futuro" className="text-xs">Interesse futuro</SelectItem>
-              <SelectItem value="sem_interesse" className="text-xs">Sem interesse</SelectItem>
-              <SelectItem value="nao_atendeu" className="text-xs">Não atendeu</SelectItem>
-              <SelectItem value="reagendado" className="text-xs">Reagendado</SelectItem>
-            </SelectContent>
-          </Select>
-
-          <div className="grid grid-cols-2 gap-2">
-            <div>
-              <Label className="text-[10px]">Margem (R$)</Label>
-              <Input type="number" value={actualMargin} onChange={e => setActualMargin(e.target.value)} className="h-8 text-xs" placeholder="0.00" />
-            </div>
-            <div>
-              <Label className="text-[10px]">Duração (min)</Label>
-              <Input type="number" value={duration} onChange={e => setDuration(e.target.value)} className="h-8 text-xs" placeholder="0" />
-            </div>
-          </div>
-
-          <Select value={objectionType} onValueChange={setObjectionType}>
-            <SelectTrigger className="h-8 text-xs">
-              <SelectValue placeholder="Tipo de objeção (opcional)" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="preco" className="text-xs">Preço</SelectItem>
-              <SelectItem value="tecnica" className="text-xs">Técnica</SelectItem>
-              <SelectItem value="urgencia" className="text-xs">Falta de urgência</SelectItem>
-              <SelectItem value="concorrente" className="text-xs">Concorrente</SelectItem>
-              <SelectItem value="nenhuma" className="text-xs">Nenhuma</SelectItem>
-            </SelectContent>
-          </Select>
-
-          <Textarea value={notes} onChange={e => setNotes(e.target.value)} placeholder="Observações..." className="text-xs min-h-[60px]" />
-
-          <Button onClick={handleSave} disabled={!callResult || saving} className="w-full text-xs">
-            {saving ? <Loader2 className="w-3 h-3 animate-spin mr-1" /> : null}
-            Salvar Resultado
-          </Button>
-        </div>
-      </DialogContent>
-    </Dialog>
   );
 };
 


### PR DESCRIPTION
## Resumo
Quebra o god-component `src/pages/FarmerTacticalPlan.tsx` (**599→97L**) em um hook de dados/estado + componentes presentacionais controlados, sob `src/components/farmer/tacticalPlan/`. Extração **verbatim** — comportamento preservado 1:1.

## O que mudou
- **`useFarmerTacticalPlan`** (hook): state, `loadCustomers` (queries Supabase intactas), `handleGenerateWithCheck`, `confirmGenerate`, `handleCopy`, `filteredCustomers`, `toggleExpanded`, `useEffect` `[user, isStaff]`.
- **`GerarPlanoCard`** — busca + lista de clientes + botões Essencial/Estratégico.
- **`EfficiencyAlertDialog`** — alerta de potencial baixo (lucro/hora).
- **`PlanCard`** — card de plano (resumo + conteúdo expandido).
- **`RecordResultDialog`** — registro de resultado pós-ligação.
- **`PlanSection`** — primitivos `Section`/`MetricRow`/`CopyButton`.
- **`types.ts`** / **`config.ts`** — tipos locais + `fmt`/`objectiveColors`/`profileLabels`.
- Página reescrita para composição; guard `isStaff` mantido após os hooks (ordem preservada).
- **+15 testes** dos pedaços presentacionais.

## Verificação
- `bunx tsc --noEmit` (baseline) = **0**
- `eslint` = **0 erros** (1 warning `exhaustive-deps` pré-existente, apenas relocado para o hook — confirmado na `origin/main`)
- **15/15 testes** verdes (isolados)
- Revisão independente FIEL 1:1: **aprovada**

## Migrations
Nenhuma.

🤖 Generated with [Claude Code](https://claude.com/claude-code)