### PR TITLE
refactor(des): split HistoricoTab (584→91) em hook + componentes

### DIFF
--- a/src/components/des/HistoricoTab.tsx
+++ b/src/components/des/HistoricoTab.tsx
@@ -1,289 +1,34 @@
-import { memo, useMemo, useState } from "react";
-import { useQuery } from "@tanstack/react-query";
+// Aba de histórico trimestral do DES (dashboard executivo).
+// Composição: useHistoricoData (dados/filtros) + filtros + gráfico + timeline + modal.
+// God-component split de src/components/des/HistoricoTab.tsx (comportamento 1:1).
+import { memo, useState } from "react";
 import { Link } from "react-router-dom";
-import {
-  Bar,
-  BarChart,
-  CartesianGrid,
-  Cell,
-  ReferenceLine,
-  ResponsiveContainer,
-  Tooltip as RTooltip,
-  XAxis,
-  YAxis,
-} from "recharts";
-import { CalendarDays, Star } from "lucide-react";
-import { supabase } from "@/integrations/supabase/client";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
-import { Skeleton } from "@/components/ui/skeleton";
+import { CalendarDays } from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
-import { cn } from "@/lib/utils";
-
-interface Props {
-  empresa: string;
-  ano: number;
-  trimestre: number;
-}
-
-interface MetaRow {
-  ano: number;
-  trimestre: number;
-  meta_faturamento: number;
-  faixa_des_objetivo: number | null;
-}
-
-interface SnapshotRow {
-  ano: number;
-  trimestre: number;
-  data_referencia: string;
-  fat_bruto_valor: number | null;
-  pedidos_abertos_valor: number | null;
-  objetivo_valor: number | null;
-}
-
-interface CheckinDescontoRow {
-  checkin_id: number;
-  ano: number;
-  trimestre: number;
-  data_avaliacao: string;
-  tipo: string;
-  faixa_numero: number | null;
-  estrelas: number | null;
-  desconto_padrao: number | null;
-  qualitativos_atingidos_perc: number | null;
-  bonus_atingido_perc: number | null;
-  desconto_total_projetado: number | null;
-  desconto_total_maximo: number | null;
-}
-
-interface PosicaoLiveRow {
-  ano: number;
-  trimestre: number;
-  posicao_ao_vivo_conservadora: number | null;
-  faixa_conservadora: { faixa_numero?: number; estrelas?: number } | null;
-  meta_pessoal: number | null;
-  inicio_trimestre: string | null;
-  fim_trimestre: string | null;
-}
-
-interface QuarterCard {
-  ano: number;
-  trimestre: number;
-  isAtual: boolean;
-  meta: number;
-  faturado: number;
-  faixaEstrelas: number;
-  inicio: string | null;
-  fim: string | null;
-  ultimoCheckin: CheckinDescontoRow | null;
-  snapshots: SnapshotRow[];
-}
-
-const fmtBRL = (v: number | null | undefined) =>
-  v == null
-    ? "—"
-    : new Intl.NumberFormat("pt-BR", { style: "currency", currency: "BRL" }).format(Number(v));
-
-const fmtPct = (v: number | null | undefined) =>
-  v == null ? "—" : `${Number(v).toFixed(2).replace(".", ",")}%`;
-
-const fmtDate = (d: string | null | undefined) =>
-  d ? new Date(d + "T00:00:00").toLocaleDateString("pt-BR") : "—";
-
-function StarsRow({ count, max = 6 }: { count: number; max?: number }) {
-  return (
-    <div className="flex items-center gap-0.5">
-      {Array.from({ length: max }).map((_, i) => (
-        <Star
-          key={i}
-          className={cn(
-            "h-3.5 w-3.5",
-            i < count ? "fill-amber-400 text-amber-400" : "text-muted-foreground/30",
-          )}
-        />
-      ))}
-    </div>
-  );
-}
-
-function quarterDates(ano: number, trimestre: number): { inicio: string; fim: string } {
-  const startMonth = (trimestre - 1) * 3;
-  const inicio = new Date(ano, startMonth, 1);
-  const fim = new Date(ano, startMonth + 3, 0);
-  const iso = (d: Date) => d.toISOString().slice(0, 10);
-  return { inicio: iso(inicio), fim: iso(fim) };
-}
+import { Skeleton } from "@/components/ui/skeleton";
+import { useHistoricoData } from "./historico/useHistoricoData";
+import { HistoricoFiltros } from "./historico/HistoricoFiltros";
+import { FaturamentoChart } from "./historico/FaturamentoChart";
+import { QuarterCardItem } from "./historico/QuarterCardItem";
+import { DetalhesDialog } from "./historico/DetalhesDialog";
+import type { Props, QuarterCard } from "./historico/types";
 
 function HistoricoTabImpl({ empresa, ano: anoAtual, trimestre: trimestreAtual }: Props) {
-  const [filtroAno, setFiltroAno] = useState<string>("__todos__");
-  const [filtroStatus, setFiltroStatus] = useState<string>("todos");
   const [detalhesOpen, setDetalhesOpen] = useState<QuarterCard | null>(null);
 
-  // Metas
-  const metasQuery = useQuery({
-    queryKey: ["des-historico-metas", empresa],
-    queryFn: async () => {
-      const { data, error } = await supabase
-        .from("des_meta_empresa")
-        .select("ano, trimestre, meta_faturamento, faixa_des_objetivo")
-        .eq("empresa", empresa)
-        .order("ano", { ascending: false })
-        .order("trimestre", { ascending: false });
-      if (error) throw error;
-      return (data ?? []) as MetaRow[];
-    },
-  });
-
-  // Snapshots (todos)
-  const snapshotsQuery = useQuery({
-    queryKey: ["des-historico-snapshots", empresa],
-    queryFn: async () => {
-      const { data, error } = await supabase
-        .from("des_trimestre_snapshot")
-        .select("ano, trimestre, data_referencia, fat_bruto_valor, pedidos_abertos_valor, objetivo_valor")
-        .eq("empresa", empresa)
-        .order("data_referencia", { ascending: false });
-      if (error) throw error;
-      return (data ?? []) as SnapshotRow[];
-    },
-  });
-
-  // Checkins (via view de desconto)
-  const checkinsQuery = useQuery({
-    queryKey: ["des-historico-checkins", empresa],
-    queryFn: async () => {
-      const { data, error } = await supabase
-        .from("v_des_desconto_por_checkin")
-        .select("*")
-        .eq("empresa", empresa)
-        .order("data_avaliacao", { ascending: false });
-      if (error) throw error;
-      return (data ?? []) as unknown as CheckinDescontoRow[];
-    },
-  });
-
-  // Posição ao vivo (apenas trimestre corrente)
-  const posLiveQuery = useQuery({
-    queryKey: ["des-historico-poslive", empresa, anoAtual, trimestreAtual],
-    queryFn: async () => {
-      const { data, error } = await supabase
-        .from("v_des_posicao_trimestre_ao_vivo")
-        .select("ano, trimestre, posicao_ao_vivo_conservadora, faixa_conservadora, meta_pessoal, inicio_trimestre, fim_trimestre")
-        .eq("empresa", empresa)
-        .eq("ano", anoAtual)
-        .eq("trimestre", trimestreAtual)
-        .maybeSingle();
-      if (error) throw error;
-      return data as unknown as PosicaoLiveRow | null;
-    },
-  });
-
-  const cards: QuarterCard[] = useMemo(() => {
-    const metas = metasQuery.data ?? [];
-    const snapshots = snapshotsQuery.data ?? [];
-    const checkins = checkinsQuery.data ?? [];
-    const live = posLiveQuery.data;
-
-    const keys = new Set<string>();
-    metas.forEach((m) => keys.add(`${m.ano}-${m.trimestre}`));
-    snapshots.forEach((s) => keys.add(`${s.ano}-${s.trimestre}`));
-    checkins.forEach((c) => keys.add(`${c.ano}-${c.trimestre}`));
-    keys.add(`${anoAtual}-${trimestreAtual}`);
-
-    const list: QuarterCard[] = Array.from(keys).map((k) => {
-      const [a, t] = k.split("-").map(Number);
-      const isAtual = a === anoAtual && t === trimestreAtual;
-      const meta = metas.find((m) => m.ano === a && m.trimestre === t);
-      const snapsTri = snapshots.filter((s) => s.ano === a && s.trimestre === t);
-      const ultimoSnap = snapsTri[0]; // já vem desc
-      // Para trimestre corrente, prioriza posicao ao vivo conservadora
-      const faturado = isAtual
-        ? Number(live?.posicao_ao_vivo_conservadora ?? ultimoSnap?.fat_bruto_valor ?? 0)
-        : Number(ultimoSnap?.fat_bruto_valor ?? 0);
-
-      // Último checkin: confirmacao_andre tem prioridade, senão projecao
-      const checkinsTri = checkins.filter((c) => c.ano === a && c.trimestre === t);
-      const ultimoCheckin =
-        checkinsTri.find((c) => c.tipo === "confirmacao_andre") ??
-        checkinsTri[0] ??
-        null;
-
-      const faixaEstrelas = isAtual
-        ? Number(live?.faixa_conservadora?.estrelas ?? ultimoCheckin?.estrelas ?? 0)
-        : Number(ultimoCheckin?.estrelas ?? 0);
-
-      const dates = quarterDates(a, t);
-      return {
-        ano: a,
-        trimestre: t,
-        isAtual,
-        meta: Number(meta?.meta_faturamento ?? live?.meta_pessoal ?? 0),
-        faturado,
-        faixaEstrelas,
-        inicio: isAtual ? (live?.inicio_trimestre ?? dates.inicio) : dates.inicio,
-        fim: isAtual ? (live?.fim_trimestre ?? dates.fim) : dates.fim,
-        ultimoCheckin,
-        snapshots: snapsTri,
-      };
-    });
-
-    // Ordena desc (ano, trimestre)
-    list.sort((a, b) => (b.ano - a.ano) || (b.trimestre - a.trimestre));
-    return list;
-  }, [metasQuery.data, snapshotsQuery.data, checkinsQuery.data, posLiveQuery.data, anoAtual, trimestreAtual]);
-
-  const anosDisponiveis = useMemo(() => {
-    const set = new Set<number>();
-    cards.forEach((c) => set.add(c.ano));
-    return Array.from(set).sort((a, b) => b - a);
-  }, [cards]);
-
-  const cardsFiltrados = useMemo(() => {
-    return cards.filter((c) => {
-      if (filtroAno !== "__todos__" && String(c.ano) !== filtroAno) return false;
-      if (filtroStatus === "andamento" && !c.isAtual) return false;
-      if (filtroStatus === "encerrados" && c.isAtual) return false;
-      return true;
-    });
-  }, [cards, filtroAno, filtroStatus]);
-
-  const chartData = useMemo(() => {
-    return [...cardsFiltrados]
-      .sort((a, b) => (a.ano - b.ano) || (a.trimestre - b.trimestre))
-      .map((c) => ({
-        label: `T${c.trimestre}/${String(c.ano).slice(2)}`,
-        faturado: c.faturado,
-        meta: c.meta,
-        isAtual: c.isAtual,
-      }));
-  }, [cardsFiltrados]);
-
-  const metaMedia = useMemo(() => {
-    const metas = chartData.map((d) => d.meta).filter((m) => m > 0);
-    if (!metas.length) return 0;
-    return metas.reduce((a, b) => a + b, 0) / metas.length;
-  }, [chartData]);
-
-  const isLoading =
-    metasQuery.isLoading ||
-    snapshotsQuery.isLoading ||
-    checkinsQuery.isLoading ||
-    posLiveQuery.isLoading;
+  const {
+    filtroAno,
+    setFiltroAno,
+    filtroStatus,
+    setFiltroStatus,
+    cards,
+    anosDisponiveis,
+    cardsFiltrados,
+    chartData,
+    metaMedia,
+    isLoading,
+  } = useHistoricoData(empresa, anoAtual, trimestreAtual);
 
   if (isLoading) {
     return <Skeleton className="h-96 w-full" />;
@@ -308,182 +53,24 @@ function HistoricoTabImpl({ empresa, ano: anoAtual, trimestre: trimestreAtual }:
   return (
     <div className="space-y-6">
       {/* Filtros */}
-      <div className="flex flex-wrap items-center gap-3">
-        <div className="flex items-center gap-2">
-          <span className="text-xs text-muted-foreground">Ano:</span>
-          <Select value={filtroAno} onValueChange={setFiltroAno}>
-            <SelectTrigger className="w-[120px] h-8 text-xs">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="__todos__">Todos</SelectItem>
-              {anosDisponiveis.map((a) => (
-                <SelectItem key={a} value={String(a)}>{a}</SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-        <ToggleGroup
-          type="single"
-          value={filtroStatus}
-          onValueChange={(v) => v && setFiltroStatus(v)}
-          size="sm"
-        >
-          <ToggleGroupItem value="todos" className="text-xs h-8">Todos</ToggleGroupItem>
-          <ToggleGroupItem value="andamento" className="text-xs h-8">Em andamento</ToggleGroupItem>
-          <ToggleGroupItem value="encerrados" className="text-xs h-8">Encerrados</ToggleGroupItem>
-        </ToggleGroup>
-      </div>
+      <HistoricoFiltros
+        filtroAno={filtroAno}
+        onFiltroAnoChange={setFiltroAno}
+        filtroStatus={filtroStatus}
+        onFiltroStatusChange={setFiltroStatus}
+        anosDisponiveis={anosDisponiveis}
+      />
 
       {/* Gráfico */}
       {chartData.length > 0 && (
-        <Card>
-          <CardHeader className="pb-2">
-            <CardTitle className="text-base">Faturamento por trimestre</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="h-64">
-              <ResponsiveContainer width="100%" height="100%">
-                <BarChart data={chartData}>
-                  <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" />
-                  <XAxis dataKey="label" tick={{ fontSize: 11 }} stroke="hsl(var(--muted-foreground))" />
-                  <YAxis
-                    tick={{ fontSize: 11 }}
-                    stroke="hsl(var(--muted-foreground))"
-                    tickFormatter={(v) => `R$ ${(v / 1000).toFixed(0)}k`}
-                  />
-                  <RTooltip
-                    formatter={(v: number) => fmtBRL(v)}
-                    contentStyle={{
-                      backgroundColor: "hsl(var(--background))",
-                      border: "1px solid hsl(var(--border))",
-                      borderRadius: 6,
-                      fontSize: 12,
-                    }}
-                  />
-                  <Bar dataKey="faturado" name="Faturado" radius={[4, 4, 0, 0]}>
-                    {chartData.map((d, i) => (
-                      <Cell
-                        key={i}
-                        fill={
-                          d.isAtual
-                            ? "hsl(217 91% 60%)"
-                            : d.faturado >= d.meta
-                              ? "hsl(142 71% 45%)"
-                              : "hsl(0 72% 51%)"
-                        }
-                      />
-                    ))}
-                  </Bar>
-                  {metaMedia > 0 && (
-                    <ReferenceLine
-                      y={metaMedia}
-                      stroke="hsl(var(--foreground))"
-                      strokeDasharray="4 4"
-                      label={{
-                        value: `Meta média: ${fmtBRL(metaMedia)}`,
-                        position: "right",
-                        fontSize: 10,
-                        fill: "hsl(var(--muted-foreground))",
-                      }}
-                    />
-                  )}
-                </BarChart>
-              </ResponsiveContainer>
-            </div>
-          </CardContent>
-        </Card>
+        <FaturamentoChart chartData={chartData} metaMedia={metaMedia} />
       )}
 
       {/* Timeline de cards */}
       <div className="space-y-4">
-        {cardsFiltrados.map((c) => {
-          const progress =
-            c.meta > 0 ? Math.min((c.faturado / c.meta) * 100, 100) : 0;
-          const atingiu = c.meta > 0 && c.faturado >= c.meta;
-          return (
-            <Card key={`${c.ano}-${c.trimestre}`} className={cn(c.isAtual && "border-status-info/40")}>
-              <CardHeader className="pb-3">
-                <div className="flex items-start justify-between gap-3 flex-wrap">
-                  <div>
-                    <CardTitle className="text-lg">T{c.trimestre} {c.ano}</CardTitle>
-                    <p className="text-xs text-muted-foreground mt-0.5">
-                      de {fmtDate(c.inicio)} a {fmtDate(c.fim)}
-                    </p>
-                  </div>
-                  <div className="flex items-center gap-2">
-                    {c.isAtual && (
-                      <Badge variant="outline" className="bg-status-info/10 border-status-info/40 text-status-info text-xs">
-                        Em andamento
-                      </Badge>
-                    )}
-                    {!c.isAtual && c.meta > 0 && (
-                      atingiu ? (
-                        <Badge variant="outline" className="bg-status-success/10 border-status-success/40 text-status-success text-xs">
-                          Meta atingida
-                        </Badge>
-                      ) : (
-                        <Badge variant="outline" className="bg-status-error/10 border-status-error/40 text-status-error text-xs">
-                          Meta não atingida
-                        </Badge>
-                      )
-                    )}
-                  </div>
-                </div>
-              </CardHeader>
-              <CardContent>
-                <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-                  <div>
-                    <p className="text-xs text-muted-foreground">Meta pessoal</p>
-                    <p className="text-sm font-medium mt-1">{fmtBRL(c.meta)}</p>
-                  </div>
-                  <div>
-                    <p className="text-xs text-muted-foreground">
-                      {c.isAtual ? "Faturado (ao vivo)" : "Faturado final"}
-                    </p>
-                    <p className={cn("text-sm font-medium mt-1", atingiu ? "text-status-success" : "text-foreground")}>
-                      {fmtBRL(c.faturado)}
-                    </p>
-                  </div>
-                  <div>
-                    <p className="text-xs text-muted-foreground">Faixa DES</p>
-                    <div className="mt-1 flex items-center gap-1.5">
-                      <span className="text-sm font-medium">{c.faixaEstrelas}★</span>
-                      <StarsRow count={c.faixaEstrelas} />
-                    </div>
-                  </div>
-                  <div>
-                    <p className="text-xs text-muted-foreground">Desc. próx. trimestre</p>
-                    <p className="text-sm font-medium mt-1">
-                      {fmtPct(c.ultimoCheckin?.desconto_total_projetado)}
-                    </p>
-                  </div>
-                </div>
-                {c.isAtual && c.meta > 0 && (
-                  <div className="mt-4 space-y-1">
-                    <div className="h-2 w-full bg-muted rounded-full overflow-hidden">
-                      <div
-                        className={cn(
-                          "h-full transition-all",
-                          progress >= 100 ? "bg-status-success" : progress >= 75 ? "bg-status-warning" : "bg-status-info",
-                        )}
-                        style={{ width: `${progress}%` }}
-                      />
-                    </div>
-                    <p className="text-xs text-muted-foreground">
-                      {progress.toFixed(1).replace(".", ",")}% da meta
-                    </p>
-                  </div>
-                )}
-                <div className="mt-4 pt-3 border-t border-border">
-                  <Button variant="link" size="sm" className="h-auto p-0 text-xs" onClick={() => setDetalhesOpen(c)}>
-                    Ver detalhes
-                  </Button>
-                </div>
-              </CardContent>
-            </Card>
-          );
-        })}
+        {cardsFiltrados.map((c) => (
+          <QuarterCardItem key={`${c.ano}-${c.trimestre}`} card={c} onVerDetalhes={setDetalhesOpen} />
+        ))}
         {cardsFiltrados.length === 0 && (
           <Card>
             <CardContent className="p-8 text-center">
@@ -496,87 +83,7 @@ function HistoricoTabImpl({ empresa, ano: anoAtual, trimestre: trimestreAtual }:
       </div>
 
       {/* Modal de detalhes */}
-      <Dialog open={!!detalhesOpen} onOpenChange={(o) => !o && setDetalhesOpen(null)}>
-        <DialogContent className="max-w-2xl max-h-[80vh] overflow-y-auto">
-          {detalhesOpen && (
-            <>
-              <DialogHeader>
-                <DialogTitle>
-                  Detalhes T{detalhesOpen.trimestre}/{detalhesOpen.ano}
-                </DialogTitle>
-              </DialogHeader>
-              <div className="space-y-4 mt-2">
-                <div className="grid grid-cols-2 gap-3 text-sm">
-                  <div>
-                    <p className="text-xs text-muted-foreground">Período</p>
-                    <p>{fmtDate(detalhesOpen.inicio)} a {fmtDate(detalhesOpen.fim)}</p>
-                  </div>
-                  <div>
-                    <p className="text-xs text-muted-foreground">Meta pessoal</p>
-                    <p>{fmtBRL(detalhesOpen.meta)}</p>
-                  </div>
-                  <div>
-                    <p className="text-xs text-muted-foreground">Faturado</p>
-                    <p>{fmtBRL(detalhesOpen.faturado)}</p>
-                  </div>
-                  <div>
-                    <p className="text-xs text-muted-foreground">Faixa DES</p>
-                    <p>{detalhesOpen.faixaEstrelas} estrelas</p>
-                  </div>
-                </div>
-
-                {detalhesOpen.ultimoCheckin && (
-                  <div className="border-t border-border pt-3">
-                    <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-2">
-                      Último checkin ({detalhesOpen.ultimoCheckin.tipo})
-                    </p>
-                    <div className="grid grid-cols-2 gap-3 text-xs">
-                      <div>
-                        <p className="text-muted-foreground">Data</p>
-                        <p>{fmtDate(detalhesOpen.ultimoCheckin.data_avaliacao)}</p>
-                      </div>
-                      <div>
-                        <p className="text-muted-foreground">Desconto padrão</p>
-                        <p>{fmtPct(detalhesOpen.ultimoCheckin.desconto_padrao)}</p>
-                      </div>
-                      <div>
-                        <p className="text-muted-foreground">Qualitativos atingidos</p>
-                        <p>{fmtPct(detalhesOpen.ultimoCheckin.qualitativos_atingidos_perc)}</p>
-                      </div>
-                      <div>
-                        <p className="text-muted-foreground">Bônus</p>
-                        <p>{fmtPct(detalhesOpen.ultimoCheckin.bonus_atingido_perc)}</p>
-                      </div>
-                      <div className="col-span-2">
-                        <p className="text-muted-foreground">Desconto total projetado</p>
-                        <p className="font-semibold text-base">
-                          {fmtPct(detalhesOpen.ultimoCheckin.desconto_total_projetado)}
-                        </p>
-                      </div>
-                    </div>
-                  </div>
-                )}
-
-                {detalhesOpen.snapshots.length > 0 && (
-                  <div className="border-t border-border pt-3">
-                    <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-2">
-                      Snapshots GoodData ({detalhesOpen.snapshots.length})
-                    </p>
-                    <div className="space-y-1 text-xs">
-                      {detalhesOpen.snapshots.slice(0, 5).map((s, i) => (
-                        <div key={i} className="flex items-center justify-between py-1 border-b border-border/40 last:border-0">
-                          <span>{fmtDate(s.data_referencia)}</span>
-                          <span className="font-medium">{fmtBRL(s.fat_bruto_valor)}</span>
-                        </div>
-                      ))}
-                    </div>
-                  </div>
-                )}
-              </div>
-            </>
-          )}
-        </DialogContent>
-      </Dialog>
+      <DetalhesDialog detalhes={detalhesOpen} onOpenChange={(o) => !o && setDetalhesOpen(null)} />
     </div>
   );
 }

--- a/src/components/des/historico/DetalhesDialog.tsx
+++ b/src/components/des/historico/DetalhesDialog.tsx
@@ -1,0 +1,101 @@
+// Modal de detalhes de um trimestre (checkin + snapshots).
+// Extraído verbatim de src/components/des/HistoricoTab.tsx (god-component split).
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { fmtBRL, fmtPct, fmtDate } from "./format";
+import type { QuarterCard } from "./types";
+
+interface DetalhesDialogProps {
+  detalhes: QuarterCard | null;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function DetalhesDialog({ detalhes: detalhesOpen, onOpenChange }: DetalhesDialogProps) {
+  return (
+    <Dialog open={!!detalhesOpen} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl max-h-[80vh] overflow-y-auto">
+        {detalhesOpen && (
+          <>
+            <DialogHeader>
+              <DialogTitle>
+                Detalhes T{detalhesOpen.trimestre}/{detalhesOpen.ano}
+              </DialogTitle>
+            </DialogHeader>
+            <div className="space-y-4 mt-2">
+              <div className="grid grid-cols-2 gap-3 text-sm">
+                <div>
+                  <p className="text-xs text-muted-foreground">Período</p>
+                  <p>{fmtDate(detalhesOpen.inicio)} a {fmtDate(detalhesOpen.fim)}</p>
+                </div>
+                <div>
+                  <p className="text-xs text-muted-foreground">Meta pessoal</p>
+                  <p>{fmtBRL(detalhesOpen.meta)}</p>
+                </div>
+                <div>
+                  <p className="text-xs text-muted-foreground">Faturado</p>
+                  <p>{fmtBRL(detalhesOpen.faturado)}</p>
+                </div>
+                <div>
+                  <p className="text-xs text-muted-foreground">Faixa DES</p>
+                  <p>{detalhesOpen.faixaEstrelas} estrelas</p>
+                </div>
+              </div>
+
+              {detalhesOpen.ultimoCheckin && (
+                <div className="border-t border-border pt-3">
+                  <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-2">
+                    Último checkin ({detalhesOpen.ultimoCheckin.tipo})
+                  </p>
+                  <div className="grid grid-cols-2 gap-3 text-xs">
+                    <div>
+                      <p className="text-muted-foreground">Data</p>
+                      <p>{fmtDate(detalhesOpen.ultimoCheckin.data_avaliacao)}</p>
+                    </div>
+                    <div>
+                      <p className="text-muted-foreground">Desconto padrão</p>
+                      <p>{fmtPct(detalhesOpen.ultimoCheckin.desconto_padrao)}</p>
+                    </div>
+                    <div>
+                      <p className="text-muted-foreground">Qualitativos atingidos</p>
+                      <p>{fmtPct(detalhesOpen.ultimoCheckin.qualitativos_atingidos_perc)}</p>
+                    </div>
+                    <div>
+                      <p className="text-muted-foreground">Bônus</p>
+                      <p>{fmtPct(detalhesOpen.ultimoCheckin.bonus_atingido_perc)}</p>
+                    </div>
+                    <div className="col-span-2">
+                      <p className="text-muted-foreground">Desconto total projetado</p>
+                      <p className="font-semibold text-base">
+                        {fmtPct(detalhesOpen.ultimoCheckin.desconto_total_projetado)}
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              )}
+
+              {detalhesOpen.snapshots.length > 0 && (
+                <div className="border-t border-border pt-3">
+                  <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-2">
+                    Snapshots GoodData ({detalhesOpen.snapshots.length})
+                  </p>
+                  <div className="space-y-1 text-xs">
+                    {detalhesOpen.snapshots.slice(0, 5).map((s, i) => (
+                      <div key={i} className="flex items-center justify-between py-1 border-b border-border/40 last:border-0">
+                        <span>{fmtDate(s.data_referencia)}</span>
+                        <span className="font-medium">{fmtBRL(s.fat_bruto_valor)}</span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </div>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/des/historico/FaturamentoChart.tsx
+++ b/src/components/des/historico/FaturamentoChart.tsx
@@ -1,0 +1,82 @@
+// Gráfico de faturamento por trimestre (BarChart + linha de meta média).
+// Extraído verbatim de src/components/des/HistoricoTab.tsx (god-component split).
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  ReferenceLine,
+  ResponsiveContainer,
+  Tooltip as RTooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { fmtBRL } from "./format";
+import type { ChartDatum } from "./types";
+
+interface FaturamentoChartProps {
+  chartData: ChartDatum[];
+  metaMedia: number;
+}
+
+export function FaturamentoChart({ chartData, metaMedia }: FaturamentoChartProps) {
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base">Faturamento por trimestre</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="h-64">
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart data={chartData}>
+              <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" />
+              <XAxis dataKey="label" tick={{ fontSize: 11 }} stroke="hsl(var(--muted-foreground))" />
+              <YAxis
+                tick={{ fontSize: 11 }}
+                stroke="hsl(var(--muted-foreground))"
+                tickFormatter={(v) => `R$ ${(v / 1000).toFixed(0)}k`}
+              />
+              <RTooltip
+                formatter={(v: number) => fmtBRL(v)}
+                contentStyle={{
+                  backgroundColor: "hsl(var(--background))",
+                  border: "1px solid hsl(var(--border))",
+                  borderRadius: 6,
+                  fontSize: 12,
+                }}
+              />
+              <Bar dataKey="faturado" name="Faturado" radius={[4, 4, 0, 0]}>
+                {chartData.map((d, i) => (
+                  <Cell
+                    key={i}
+                    fill={
+                      d.isAtual
+                        ? "hsl(217 91% 60%)"
+                        : d.faturado >= d.meta
+                          ? "hsl(142 71% 45%)"
+                          : "hsl(0 72% 51%)"
+                    }
+                  />
+                ))}
+              </Bar>
+              {metaMedia > 0 && (
+                <ReferenceLine
+                  y={metaMedia}
+                  stroke="hsl(var(--foreground))"
+                  strokeDasharray="4 4"
+                  label={{
+                    value: `Meta média: ${fmtBRL(metaMedia)}`,
+                    position: "right",
+                    fontSize: 10,
+                    fill: "hsl(var(--muted-foreground))",
+                  }}
+                />
+              )}
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/des/historico/HistoricoFiltros.tsx
+++ b/src/components/des/historico/HistoricoFiltros.tsx
@@ -1,0 +1,55 @@
+// Filtros do HistoricoTab (ano + status do trimestre).
+// Extraído verbatim de src/components/des/HistoricoTab.tsx (god-component split).
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+
+interface HistoricoFiltrosProps {
+  filtroAno: string;
+  onFiltroAnoChange: (v: string) => void;
+  filtroStatus: string;
+  onFiltroStatusChange: (v: string) => void;
+  anosDisponiveis: number[];
+}
+
+export function HistoricoFiltros({
+  filtroAno,
+  onFiltroAnoChange,
+  filtroStatus,
+  onFiltroStatusChange,
+  anosDisponiveis,
+}: HistoricoFiltrosProps) {
+  return (
+    <div className="flex flex-wrap items-center gap-3">
+      <div className="flex items-center gap-2">
+        <span className="text-xs text-muted-foreground">Ano:</span>
+        <Select value={filtroAno} onValueChange={onFiltroAnoChange}>
+          <SelectTrigger className="w-[120px] h-8 text-xs">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="__todos__">Todos</SelectItem>
+            {anosDisponiveis.map((a) => (
+              <SelectItem key={a} value={String(a)}>{a}</SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+      <ToggleGroup
+        type="single"
+        value={filtroStatus}
+        onValueChange={(v) => v && onFiltroStatusChange(v)}
+        size="sm"
+      >
+        <ToggleGroupItem value="todos" className="text-xs h-8">Todos</ToggleGroupItem>
+        <ToggleGroupItem value="andamento" className="text-xs h-8">Em andamento</ToggleGroupItem>
+        <ToggleGroupItem value="encerrados" className="text-xs h-8">Encerrados</ToggleGroupItem>
+      </ToggleGroup>
+    </div>
+  );
+}

--- a/src/components/des/historico/QuarterCardItem.tsx
+++ b/src/components/des/historico/QuarterCardItem.tsx
@@ -1,0 +1,101 @@
+// Card de um trimestre na timeline do HistoricoTab.
+// Extraído verbatim de src/components/des/HistoricoTab.tsx (god-component split).
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { fmtBRL, fmtPct, fmtDate } from "./format";
+import { StarsRow } from "./StarsRow";
+import type { QuarterCard } from "./types";
+
+interface QuarterCardItemProps {
+  card: QuarterCard;
+  onVerDetalhes: (c: QuarterCard) => void;
+}
+
+export function QuarterCardItem({ card: c, onVerDetalhes }: QuarterCardItemProps) {
+  const progress = c.meta > 0 ? Math.min((c.faturado / c.meta) * 100, 100) : 0;
+  const atingiu = c.meta > 0 && c.faturado >= c.meta;
+  return (
+    <Card className={cn(c.isAtual && "border-status-info/40")}>
+      <CardHeader className="pb-3">
+        <div className="flex items-start justify-between gap-3 flex-wrap">
+          <div>
+            <CardTitle className="text-lg">T{c.trimestre} {c.ano}</CardTitle>
+            <p className="text-xs text-muted-foreground mt-0.5">
+              de {fmtDate(c.inicio)} a {fmtDate(c.fim)}
+            </p>
+          </div>
+          <div className="flex items-center gap-2">
+            {c.isAtual && (
+              <Badge variant="outline" className="bg-status-info/10 border-status-info/40 text-status-info text-xs">
+                Em andamento
+              </Badge>
+            )}
+            {!c.isAtual && c.meta > 0 && (
+              atingiu ? (
+                <Badge variant="outline" className="bg-status-success/10 border-status-success/40 text-status-success text-xs">
+                  Meta atingida
+                </Badge>
+              ) : (
+                <Badge variant="outline" className="bg-status-error/10 border-status-error/40 text-status-error text-xs">
+                  Meta não atingida
+                </Badge>
+              )
+            )}
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+          <div>
+            <p className="text-xs text-muted-foreground">Meta pessoal</p>
+            <p className="text-sm font-medium mt-1">{fmtBRL(c.meta)}</p>
+          </div>
+          <div>
+            <p className="text-xs text-muted-foreground">
+              {c.isAtual ? "Faturado (ao vivo)" : "Faturado final"}
+            </p>
+            <p className={cn("text-sm font-medium mt-1", atingiu ? "text-status-success" : "text-foreground")}>
+              {fmtBRL(c.faturado)}
+            </p>
+          </div>
+          <div>
+            <p className="text-xs text-muted-foreground">Faixa DES</p>
+            <div className="mt-1 flex items-center gap-1.5">
+              <span className="text-sm font-medium">{c.faixaEstrelas}★</span>
+              <StarsRow count={c.faixaEstrelas} />
+            </div>
+          </div>
+          <div>
+            <p className="text-xs text-muted-foreground">Desc. próx. trimestre</p>
+            <p className="text-sm font-medium mt-1">
+              {fmtPct(c.ultimoCheckin?.desconto_total_projetado)}
+            </p>
+          </div>
+        </div>
+        {c.isAtual && c.meta > 0 && (
+          <div className="mt-4 space-y-1">
+            <div className="h-2 w-full bg-muted rounded-full overflow-hidden">
+              <div
+                className={cn(
+                  "h-full transition-all",
+                  progress >= 100 ? "bg-status-success" : progress >= 75 ? "bg-status-warning" : "bg-status-info",
+                )}
+                style={{ width: `${progress}%` }}
+              />
+            </div>
+            <p className="text-xs text-muted-foreground">
+              {progress.toFixed(1).replace(".", ",")}% da meta
+            </p>
+          </div>
+        )}
+        <div className="mt-4 pt-3 border-t border-border">
+          <Button variant="link" size="sm" className="h-auto p-0 text-xs" onClick={() => onVerDetalhes(c)}>
+            Ver detalhes
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/des/historico/StarsRow.tsx
+++ b/src/components/des/historico/StarsRow.tsx
@@ -1,0 +1,20 @@
+// Linha de estrelas da faixa DES.
+// Extraído verbatim de src/components/des/HistoricoTab.tsx (god-component split).
+import { Star } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export function StarsRow({ count, max = 6 }: { count: number; max?: number }) {
+  return (
+    <div className="flex items-center gap-0.5">
+      {Array.from({ length: max }).map((_, i) => (
+        <Star
+          key={i}
+          className={cn(
+            "h-3.5 w-3.5",
+            i < count ? "fill-amber-400 text-amber-400" : "text-muted-foreground/30",
+          )}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/components/des/historico/__tests__/DetalhesDialog.test.tsx
+++ b/src/components/des/historico/__tests__/DetalhesDialog.test.tsx
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { DetalhesDialog } from "../DetalhesDialog";
+import type { QuarterCard } from "../types";
+
+const card: QuarterCard = {
+  ano: 2026,
+  trimestre: 2,
+  isAtual: false,
+  meta: 100000,
+  faturado: 120000,
+  faixaEstrelas: 4,
+  inicio: "2026-04-01",
+  fim: "2026-06-30",
+  ultimoCheckin: null,
+  snapshots: [],
+};
+
+describe("DetalhesDialog", () => {
+  it("não renderiza conteúdo quando detalhes é null", () => {
+    render(<DetalhesDialog detalhes={null} onOpenChange={vi.fn()} />);
+    expect(screen.queryByText(/Detalhes T/)).toBeNull();
+  });
+
+  it("renderiza o título e a faixa quando há trimestre selecionado", () => {
+    render(<DetalhesDialog detalhes={card} onOpenChange={vi.fn()} />);
+    expect(screen.getByText("Detalhes T2/2026")).toBeTruthy();
+    expect(screen.getByText("4 estrelas")).toBeTruthy();
+  });
+});

--- a/src/components/des/historico/__tests__/HistoricoFiltros.test.tsx
+++ b/src/components/des/historico/__tests__/HistoricoFiltros.test.tsx
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { HistoricoFiltros } from "../HistoricoFiltros";
+
+function setup(overrides: Partial<React.ComponentProps<typeof HistoricoFiltros>> = {}) {
+  const props: React.ComponentProps<typeof HistoricoFiltros> = {
+    filtroAno: "__todos__",
+    onFiltroAnoChange: vi.fn(),
+    filtroStatus: "todos",
+    onFiltroStatusChange: vi.fn(),
+    anosDisponiveis: [2026, 2025],
+    ...overrides,
+  };
+  render(<HistoricoFiltros {...props} />);
+  return props;
+}
+
+describe("HistoricoFiltros", () => {
+  it("renderiza o rótulo de ano e os toggles de status", () => {
+    setup();
+    expect(screen.getByText("Ano:")).toBeTruthy();
+    expect(screen.getByText("Em andamento")).toBeTruthy();
+    expect(screen.getByText("Encerrados")).toBeTruthy();
+  });
+
+  it("dispara onFiltroStatusChange ao selecionar um status", () => {
+    const props = setup();
+    fireEvent.click(screen.getByText("Em andamento"));
+    expect(props.onFiltroStatusChange).toHaveBeenCalledWith("andamento");
+  });
+});

--- a/src/components/des/historico/__tests__/QuarterCardItem.test.tsx
+++ b/src/components/des/historico/__tests__/QuarterCardItem.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { QuarterCardItem } from "../QuarterCardItem";
+import type { QuarterCard } from "../types";
+
+function makeCard(overrides: Partial<QuarterCard> = {}): QuarterCard {
+  return {
+    ano: 2026,
+    trimestre: 2,
+    isAtual: false,
+    meta: 100000,
+    faturado: 120000,
+    faixaEstrelas: 4,
+    inicio: "2026-04-01",
+    fim: "2026-06-30",
+    ultimoCheckin: null,
+    snapshots: [],
+    ...overrides,
+  };
+}
+
+function setup(overrides: Partial<React.ComponentProps<typeof QuarterCardItem>> = {}) {
+  const props: React.ComponentProps<typeof QuarterCardItem> = {
+    card: makeCard(),
+    onVerDetalhes: vi.fn(),
+    ...overrides,
+  };
+  render(<QuarterCardItem {...props} />);
+  return props;
+}
+
+describe("QuarterCardItem", () => {
+  it("mostra título e badge de meta atingida (encerrado, acima da meta)", () => {
+    setup();
+    expect(screen.getByText("T2 2026")).toBeTruthy();
+    expect(screen.getByText("Meta atingida")).toBeTruthy();
+  });
+
+  it("badge de meta não atingida (encerrado, abaixo da meta)", () => {
+    setup({ card: makeCard({ faturado: 50000 }) });
+    expect(screen.getByText("Meta não atingida")).toBeTruthy();
+  });
+
+  it("badge em andamento + progresso quando trimestre atual", () => {
+    setup({ card: makeCard({ isAtual: true, faturado: 50000 }) });
+    expect(screen.getByText("Em andamento")).toBeTruthy();
+    expect(screen.getByText("50,0% da meta")).toBeTruthy();
+  });
+
+  it("dispara onVerDetalhes ao clicar em Ver detalhes", () => {
+    const props = setup();
+    fireEvent.click(screen.getByText("Ver detalhes"));
+    expect(props.onVerDetalhes).toHaveBeenCalledWith(props.card);
+  });
+});

--- a/src/components/des/historico/__tests__/StarsRow.test.tsx
+++ b/src/components/des/historico/__tests__/StarsRow.test.tsx
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { StarsRow } from "../StarsRow";
+
+describe("StarsRow", () => {
+  it("renderiza 6 estrelas (default) e preenche count", () => {
+    const { container } = render(<StarsRow count={3} />);
+    expect(container.querySelectorAll("svg")).toHaveLength(6);
+    expect(container.querySelectorAll(".fill-amber-400")).toHaveLength(3);
+  });
+
+  it("respeita max custom e sem preenchimento quando count 0", () => {
+    const { container } = render(<StarsRow count={0} max={4} />);
+    expect(container.querySelectorAll("svg")).toHaveLength(4);
+    expect(container.querySelectorAll(".fill-amber-400")).toHaveLength(0);
+  });
+});

--- a/src/components/des/historico/__tests__/format.test.ts
+++ b/src/components/des/historico/__tests__/format.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { fmtBRL, fmtPct, fmtDate, quarterDates } from "../format";
+
+describe("historico/format", () => {
+  it("fmtBRL trata null/undefined e formata em BRL", () => {
+    expect(fmtBRL(null)).toBe("—");
+    expect(fmtBRL(undefined)).toBe("—");
+    expect(fmtBRL(1000)).toContain("1.000,00");
+  });
+
+  it("fmtPct trata null e usa vírgula decimal", () => {
+    expect(fmtPct(null)).toBe("—");
+    expect(fmtPct(12.5)).toBe("12,50%");
+    expect(fmtPct(0)).toBe("0,00%");
+  });
+
+  it("fmtDate trata null e formata pt-BR", () => {
+    expect(fmtDate(null)).toBe("—");
+    expect(fmtDate("2026-03-15")).toBe("15/03/2026");
+  });
+
+  it("quarterDates retorna início/fim do trimestre", () => {
+    expect(quarterDates(2026, 1)).toEqual({ inicio: "2026-01-01", fim: "2026-03-31" });
+    expect(quarterDates(2026, 3)).toEqual({ inicio: "2026-07-01", fim: "2026-09-30" });
+  });
+});

--- a/src/components/des/historico/format.ts
+++ b/src/components/des/historico/format.ts
@@ -1,0 +1,21 @@
+// Helpers puros de formatação e datas do HistoricoTab.
+// Extraídos verbatim de src/components/des/HistoricoTab.tsx (god-component split).
+
+export const fmtBRL = (v: number | null | undefined) =>
+  v == null
+    ? "—"
+    : new Intl.NumberFormat("pt-BR", { style: "currency", currency: "BRL" }).format(Number(v));
+
+export const fmtPct = (v: number | null | undefined) =>
+  v == null ? "—" : `${Number(v).toFixed(2).replace(".", ",")}%`;
+
+export const fmtDate = (d: string | null | undefined) =>
+  d ? new Date(d + "T00:00:00").toLocaleDateString("pt-BR") : "—";
+
+export function quarterDates(ano: number, trimestre: number): { inicio: string; fim: string } {
+  const startMonth = (trimestre - 1) * 3;
+  const inicio = new Date(ano, startMonth, 1);
+  const fim = new Date(ano, startMonth + 3, 0);
+  const iso = (d: Date) => d.toISOString().slice(0, 10);
+  return { inicio: iso(inicio), fim: iso(fim) };
+}

--- a/src/components/des/historico/types.ts
+++ b/src/components/des/historico/types.ts
@@ -1,0 +1,69 @@
+// Tipos do HistoricoTab (DES — dashboard executivo).
+// Extraídos verbatim de src/components/des/HistoricoTab.tsx (god-component split).
+
+export interface Props {
+  empresa: string;
+  ano: number;
+  trimestre: number;
+}
+
+export interface MetaRow {
+  ano: number;
+  trimestre: number;
+  meta_faturamento: number;
+  faixa_des_objetivo: number | null;
+}
+
+export interface SnapshotRow {
+  ano: number;
+  trimestre: number;
+  data_referencia: string;
+  fat_bruto_valor: number | null;
+  pedidos_abertos_valor: number | null;
+  objetivo_valor: number | null;
+}
+
+export interface CheckinDescontoRow {
+  checkin_id: number;
+  ano: number;
+  trimestre: number;
+  data_avaliacao: string;
+  tipo: string;
+  faixa_numero: number | null;
+  estrelas: number | null;
+  desconto_padrao: number | null;
+  qualitativos_atingidos_perc: number | null;
+  bonus_atingido_perc: number | null;
+  desconto_total_projetado: number | null;
+  desconto_total_maximo: number | null;
+}
+
+export interface PosicaoLiveRow {
+  ano: number;
+  trimestre: number;
+  posicao_ao_vivo_conservadora: number | null;
+  faixa_conservadora: { faixa_numero?: number; estrelas?: number } | null;
+  meta_pessoal: number | null;
+  inicio_trimestre: string | null;
+  fim_trimestre: string | null;
+}
+
+export interface QuarterCard {
+  ano: number;
+  trimestre: number;
+  isAtual: boolean;
+  meta: number;
+  faturado: number;
+  faixaEstrelas: number;
+  inicio: string | null;
+  fim: string | null;
+  ultimoCheckin: CheckinDescontoRow | null;
+  snapshots: SnapshotRow[];
+}
+
+export interface ChartDatum {
+  label: string;
+  faturado: number;
+  meta: number;
+  isAtual: boolean;
+}

--- a/src/components/des/historico/useHistoricoData.ts
+++ b/src/components/des/historico/useHistoricoData.ts
@@ -1,0 +1,183 @@
+// Hook de dados/estado do HistoricoTab.
+// Extraído verbatim de src/components/des/HistoricoTab.tsx (god-component split):
+// 4 queries (metas/snapshots/checkins/posição ao vivo) + memos derivados + filtros.
+import { useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { supabase } from "@/integrations/supabase/client";
+import { quarterDates } from "./format";
+import type {
+  MetaRow,
+  SnapshotRow,
+  CheckinDescontoRow,
+  PosicaoLiveRow,
+  QuarterCard,
+} from "./types";
+
+export function useHistoricoData(empresa: string, anoAtual: number, trimestreAtual: number) {
+  const [filtroAno, setFiltroAno] = useState<string>("__todos__");
+  const [filtroStatus, setFiltroStatus] = useState<string>("todos");
+
+  // Metas
+  const metasQuery = useQuery({
+    queryKey: ["des-historico-metas", empresa],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from("des_meta_empresa")
+        .select("ano, trimestre, meta_faturamento, faixa_des_objetivo")
+        .eq("empresa", empresa)
+        .order("ano", { ascending: false })
+        .order("trimestre", { ascending: false });
+      if (error) throw error;
+      return (data ?? []) as MetaRow[];
+    },
+  });
+
+  // Snapshots (todos)
+  const snapshotsQuery = useQuery({
+    queryKey: ["des-historico-snapshots", empresa],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from("des_trimestre_snapshot")
+        .select("ano, trimestre, data_referencia, fat_bruto_valor, pedidos_abertos_valor, objetivo_valor")
+        .eq("empresa", empresa)
+        .order("data_referencia", { ascending: false });
+      if (error) throw error;
+      return (data ?? []) as SnapshotRow[];
+    },
+  });
+
+  // Checkins (via view de desconto)
+  const checkinsQuery = useQuery({
+    queryKey: ["des-historico-checkins", empresa],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from("v_des_desconto_por_checkin")
+        .select("*")
+        .eq("empresa", empresa)
+        .order("data_avaliacao", { ascending: false });
+      if (error) throw error;
+      return (data ?? []) as unknown as CheckinDescontoRow[];
+    },
+  });
+
+  // Posição ao vivo (apenas trimestre corrente)
+  const posLiveQuery = useQuery({
+    queryKey: ["des-historico-poslive", empresa, anoAtual, trimestreAtual],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from("v_des_posicao_trimestre_ao_vivo")
+        .select("ano, trimestre, posicao_ao_vivo_conservadora, faixa_conservadora, meta_pessoal, inicio_trimestre, fim_trimestre")
+        .eq("empresa", empresa)
+        .eq("ano", anoAtual)
+        .eq("trimestre", trimestreAtual)
+        .maybeSingle();
+      if (error) throw error;
+      return data as unknown as PosicaoLiveRow | null;
+    },
+  });
+
+  const cards: QuarterCard[] = useMemo(() => {
+    const metas = metasQuery.data ?? [];
+    const snapshots = snapshotsQuery.data ?? [];
+    const checkins = checkinsQuery.data ?? [];
+    const live = posLiveQuery.data;
+
+    const keys = new Set<string>();
+    metas.forEach((m) => keys.add(`${m.ano}-${m.trimestre}`));
+    snapshots.forEach((s) => keys.add(`${s.ano}-${s.trimestre}`));
+    checkins.forEach((c) => keys.add(`${c.ano}-${c.trimestre}`));
+    keys.add(`${anoAtual}-${trimestreAtual}`);
+
+    const list: QuarterCard[] = Array.from(keys).map((k) => {
+      const [a, t] = k.split("-").map(Number);
+      const isAtual = a === anoAtual && t === trimestreAtual;
+      const meta = metas.find((m) => m.ano === a && m.trimestre === t);
+      const snapsTri = snapshots.filter((s) => s.ano === a && s.trimestre === t);
+      const ultimoSnap = snapsTri[0]; // já vem desc
+      // Para trimestre corrente, prioriza posicao ao vivo conservadora
+      const faturado = isAtual
+        ? Number(live?.posicao_ao_vivo_conservadora ?? ultimoSnap?.fat_bruto_valor ?? 0)
+        : Number(ultimoSnap?.fat_bruto_valor ?? 0);
+
+      // Último checkin: confirmacao_andre tem prioridade, senão projecao
+      const checkinsTri = checkins.filter((c) => c.ano === a && c.trimestre === t);
+      const ultimoCheckin =
+        checkinsTri.find((c) => c.tipo === "confirmacao_andre") ??
+        checkinsTri[0] ??
+        null;
+
+      const faixaEstrelas = isAtual
+        ? Number(live?.faixa_conservadora?.estrelas ?? ultimoCheckin?.estrelas ?? 0)
+        : Number(ultimoCheckin?.estrelas ?? 0);
+
+      const dates = quarterDates(a, t);
+      return {
+        ano: a,
+        trimestre: t,
+        isAtual,
+        meta: Number(meta?.meta_faturamento ?? live?.meta_pessoal ?? 0),
+        faturado,
+        faixaEstrelas,
+        inicio: isAtual ? (live?.inicio_trimestre ?? dates.inicio) : dates.inicio,
+        fim: isAtual ? (live?.fim_trimestre ?? dates.fim) : dates.fim,
+        ultimoCheckin,
+        snapshots: snapsTri,
+      };
+    });
+
+    // Ordena desc (ano, trimestre)
+    list.sort((a, b) => (b.ano - a.ano) || (b.trimestre - a.trimestre));
+    return list;
+  }, [metasQuery.data, snapshotsQuery.data, checkinsQuery.data, posLiveQuery.data, anoAtual, trimestreAtual]);
+
+  const anosDisponiveis = useMemo(() => {
+    const set = new Set<number>();
+    cards.forEach((c) => set.add(c.ano));
+    return Array.from(set).sort((a, b) => b - a);
+  }, [cards]);
+
+  const cardsFiltrados = useMemo(() => {
+    return cards.filter((c) => {
+      if (filtroAno !== "__todos__" && String(c.ano) !== filtroAno) return false;
+      if (filtroStatus === "andamento" && !c.isAtual) return false;
+      if (filtroStatus === "encerrados" && c.isAtual) return false;
+      return true;
+    });
+  }, [cards, filtroAno, filtroStatus]);
+
+  const chartData = useMemo(() => {
+    return [...cardsFiltrados]
+      .sort((a, b) => (a.ano - b.ano) || (a.trimestre - b.trimestre))
+      .map((c) => ({
+        label: `T${c.trimestre}/${String(c.ano).slice(2)}`,
+        faturado: c.faturado,
+        meta: c.meta,
+        isAtual: c.isAtual,
+      }));
+  }, [cardsFiltrados]);
+
+  const metaMedia = useMemo(() => {
+    const metas = chartData.map((d) => d.meta).filter((m) => m > 0);
+    if (!metas.length) return 0;
+    return metas.reduce((a, b) => a + b, 0) / metas.length;
+  }, [chartData]);
+
+  const isLoading =
+    metasQuery.isLoading ||
+    snapshotsQuery.isLoading ||
+    checkinsQuery.isLoading ||
+    posLiveQuery.isLoading;
+
+  return {
+    filtroAno,
+    setFiltroAno,
+    filtroStatus,
+    setFiltroStatus,
+    cards,
+    anosDisponiveis,
+    cardsFiltrados,
+    chartData,
+    metaMedia,
+    isLoading,
+  };
+}


### PR DESCRIPTION
## Resumo
Quebra o god-component `src/components/des/HistoricoTab.tsx` (**584→91L**) em um hook de dados/estado + componentes presentacionais controlados, sob `src/components/des/historico/`. Extração **verbatim** — comportamento preservado 1:1.

## O que mudou
- **`useHistoricoData`** (hook): 4 queries (`des_meta_empresa`, `des_trimestre_snapshot`, `v_des_desconto_por_checkin`, `v_des_posicao_trimestre_ao_vivo`) + memos derivados (`cards`/`anosDisponiveis`/`cardsFiltrados`/`chartData`/`metaMedia`) + estado de filtros + `isLoading`.
- **`HistoricoFiltros`** — Select de ano + ToggleGroup de status.
- **`FaturamentoChart`** — BarChart com linha de meta média (Recharts).
- **`QuarterCardItem`** — card de um trimestre na timeline.
- **`DetalhesDialog`** — modal de detalhes (checkin + snapshots).
- **`StarsRow`** — linha de estrelas da faixa DES.
- **`types.ts`** / **`format.ts`** (`fmtBRL`/`fmtPct`/`fmtDate`/`quarterDates`).
- Componente reescrito para composição; `memo(HistoricoTabImpl)` mantido; early returns (loading/empty) preservados após os hooks.
- **+14 testes** (helpers puros + presentacionais).

## Verificação
- `bunx tsc --noEmit` (baseline) = **0**
- `eslint` = **0 erros / 0 warnings**
- **14/14 testes** verdes (isolados)
- Revisão independente FIEL 1:1: **aprovada** (queries, memos, ordem de hooks estável, JSX e cores do gráfico conferidos)

## Migrations
Nenhuma.

🤖 Generated with [Claude Code](https://claude.com/claude-code)