### PR TITLE
refactor(reposicao): split AdminReposicaoSlaFornecedor (576→93) em hook + componentes

### DIFF
--- a/src/components/reposicao/slaFornecedor/ComplianceCardsGrid.tsx
+++ b/src/components/reposicao/slaFornecedor/ComplianceCardsGrid.tsx
@@ -1,0 +1,55 @@
+// Grid de cards de compliance global por fornecedor.
+// Extraído verbatim de src/pages/AdminReposicaoSlaFornecedor.tsx (god-component split).
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { cardTone, fmtNum } from "./config";
+import type { ForCompliance } from "./types";
+
+interface ComplianceCardsGridProps {
+  fornecedores: ForCompliance[] | undefined;
+  loading: boolean;
+}
+
+export function ComplianceCardsGrid({ fornecedores, loading: loadingFor }: ComplianceCardsGridProps) {
+  return (
+    <div className="grid gap-3 grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
+      {loadingFor &&
+        Array.from({ length: 3 }).map((_, i) => <Skeleton key={i} className="h-40 w-full" />)}
+      {!loadingFor &&
+        fornecedores?.map((f) => (
+          <Card key={f.fornecedor_nome} className={cardTone(f.perc_sla_compliance)}>
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm flex items-center justify-between gap-2">
+                <span className="truncate" title={f.fornecedor_nome}>{f.fornecedor_nome}</span>
+                <Badge variant="outline" className="shrink-0">{f.skus_total} SKUs</Badge>
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-2">
+              <div className="text-3xl font-bold">
+                {f.perc_sla_compliance != null ? `${f.perc_sla_compliance}%` : "—"}
+                <span className="text-xs font-normal text-muted-foreground ml-1">compliance</span>
+              </div>
+              <div className="text-xs text-muted-foreground">
+                LT teórico: <span className="font-mono">{fmtNum(f.lt_teorico_agregado)}d</span> · observado:{" "}
+                <span className="font-mono">{fmtNum(f.lt_medio_observado_agregado)}d</span>
+              </div>
+              <div className="flex flex-wrap gap-1.5 pt-1">
+                <Badge variant="success">{f.skus_cumprindo} ok</Badge>
+                <Badge variant="warning">{f.skus_limite} limite</Badge>
+                <Badge variant="warning">{f.skus_violando} viol.</Badge>
+                <Badge variant="destructive">{f.skus_criticos} crít.</Badge>
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      {!loadingFor && (fornecedores?.length ?? 0) === 0 && (
+        <Card className="md:col-span-3">
+          <CardContent className="py-8 text-center text-sm text-muted-foreground">
+            Nenhum fornecedor com dados de SLA disponíveis ainda.
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/src/components/reposicao/slaFornecedor/SkuComplianceTable.tsx
+++ b/src/components/reposicao/slaFornecedor/SkuComplianceTable.tsx
@@ -1,0 +1,99 @@
+// Tabela de compliance de SLA por SKU.
+// Extraída verbatim de src/pages/AdminReposicaoSlaFornecedor.tsx (god-component split).
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { STATUS_LABEL, STATUS_VARIANT, desvioColorClass, fmtData, fmtNum } from "./config";
+import { TendenciaIcon } from "./TendenciaIcon";
+import type { SkuCompliance } from "./types";
+
+interface SkuComplianceTableProps {
+  skus: SkuCompliance[];
+  loading: boolean;
+  onSelectSku: (s: SkuCompliance) => void;
+}
+
+export function SkuComplianceTable({ skus: skusFiltrados, loading: loadingSkus, onSelectSku }: SkuComplianceTableProps) {
+  return (
+    <div className="border rounded-md">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead className="w-[120px]">Status</TableHead>
+            <TableHead>SKU</TableHead>
+            <TableHead>Grupo</TableHead>
+            <TableHead className="text-right">LT teór.</TableHead>
+            <TableHead className="text-right">LT obs.</TableHead>
+            <TableHead className="text-right">Recente 5</TableHead>
+            <TableHead className="text-right">Desvio</TableHead>
+            <TableHead>Último receb.</TableHead>
+            <TableHead className="text-right">N obs.</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {loadingSkus &&
+            Array.from({ length: 6 }).map((_, i) => (
+              <TableRow key={i}>
+                <TableCell colSpan={9}><Skeleton className="h-6 w-full" /></TableCell>
+              </TableRow>
+            ))}
+          {!loadingSkus && skusFiltrados.length === 0 && (
+            <TableRow>
+              <TableCell colSpan={9} className="text-center text-sm text-muted-foreground py-8">
+                Nenhum SKU encontrado com os filtros atuais.
+              </TableCell>
+            </TableRow>
+          )}
+          {!loadingSkus &&
+            skusFiltrados.map((s) => {
+              const clicavel = (s.n_observacoes ?? 0) >= 3;
+              return (
+                <TableRow
+                  key={`${s.empresa}-${s.sku_codigo_omie}`}
+                  className={clicavel ? "cursor-pointer" : "opacity-90"}
+                  onClick={() => clicavel && onSelectSku(s)}
+                >
+                  <TableCell>
+                    <Badge variant={STATUS_VARIANT[s.status_sla]}>{STATUS_LABEL[s.status_sla]}</Badge>
+                  </TableCell>
+                  <TableCell className="align-top min-w-[280px]">
+                    <div className="font-mono text-xs text-muted-foreground">{s.sku_codigo_omie}</div>
+                    <div className="text-sm font-medium whitespace-normal break-words">
+                      {s.sku_descricao ?? "—"}
+                    </div>
+                  </TableCell>
+                  <TableCell>
+                    {s.grupo_codigo ? (
+                      <Badge variant="outline" className="text-xs">{s.grupo_codigo}</Badge>
+                    ) : (
+                      <span className="text-xs text-muted-foreground">—</span>
+                    )}
+                  </TableCell>
+                  <TableCell className="text-right font-mono text-xs">{fmtNum(s.lt_teorico, 1)}</TableCell>
+                  <TableCell className="text-right font-mono text-xs">{fmtNum(s.lt_observado_medio, 1)}</TableCell>
+                  <TableCell className="text-right">
+                    <div className="inline-flex items-center gap-1 font-mono text-xs">
+                      {fmtNum(s.lt_recente_medio, 1)}
+                      <TendenciaIcon t={s.tendencia} />
+                    </div>
+                  </TableCell>
+                  <TableCell className={`text-right font-mono text-xs ${desvioColorClass(s.desvio_perc)}`}>
+                    {s.desvio_perc == null ? "—" : `${s.desvio_perc > 0 ? "+" : ""}${s.desvio_perc}%`}
+                  </TableCell>
+                  <TableCell className="text-xs">{fmtData(s.ultimo_recebimento)}</TableCell>
+                  <TableCell className="text-right font-mono text-xs">{s.n_observacoes ?? 0}</TableCell>
+                </TableRow>
+              );
+            })}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/src/components/reposicao/slaFornecedor/SkuHistoricoDialog.tsx
+++ b/src/components/reposicao/slaFornecedor/SkuHistoricoDialog.tsx
@@ -1,0 +1,111 @@
+// Modal de histórico de lead time do SKU selecionado (gráfico de linhas).
+// Extraído verbatim de src/pages/AdminReposicaoSlaFornecedor.tsx (god-component split).
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import {
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  ReferenceLine,
+  ResponsiveContainer,
+  Tooltip as ReTooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { STATUS_LABEL, STATUS_VARIANT, fmtNum } from "./config";
+import type { HistPoint, SkuCompliance } from "./types";
+
+interface SkuHistoricoDialogProps {
+  skuDetalhe: SkuCompliance | null;
+  onOpenChange: (open: boolean) => void;
+  historico: HistPoint[] | undefined;
+  loadingHist: boolean;
+}
+
+export function SkuHistoricoDialog({ skuDetalhe, onOpenChange, historico, loadingHist }: SkuHistoricoDialogProps) {
+  return (
+    <Dialog open={!!skuDetalhe} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-3xl">
+        <DialogHeader>
+          <DialogTitle>
+            <div className="flex items-center gap-2">
+              <span className="font-mono text-sm">{skuDetalhe?.sku_codigo_omie}</span>
+              <span className="text-sm font-normal text-muted-foreground truncate">
+                {skuDetalhe?.sku_descricao}
+              </span>
+            </div>
+          </DialogTitle>
+        </DialogHeader>
+        {skuDetalhe && (
+          <div className="space-y-3">
+            <div className="flex flex-wrap gap-2 text-xs">
+              <Badge variant={STATUS_VARIANT[skuDetalhe.status_sla]}>{STATUS_LABEL[skuDetalhe.status_sla]}</Badge>
+              {skuDetalhe.fornecedor_nome && <Badge variant="outline">{skuDetalhe.fornecedor_nome}</Badge>}
+              {skuDetalhe.grupo_codigo && <Badge variant="outline">Grupo {skuDetalhe.grupo_codigo}</Badge>}
+              <Badge variant="outline">LT teórico: <span className="font-mono ml-1">{fmtNum(skuDetalhe.lt_teorico, 1)}d</span></Badge>
+              <Badge variant="outline">Médio observado: <span className="font-mono ml-1">{fmtNum(skuDetalhe.lt_observado_medio, 1)}d</span></Badge>
+            </div>
+            <div className="h-[280px]">
+              {loadingHist ? (
+                <Skeleton className="h-full w-full" />
+              ) : (
+                <ResponsiveContainer width="100%" height="100%">
+                  <LineChart data={historico ?? []}>
+                    <CartesianGrid strokeDasharray="3 3" />
+                    <XAxis dataKey="data" tick={{ fontSize: 11 }} />
+                    <YAxis tick={{ fontSize: 11 }} label={{ value: "dias úteis", angle: -90, position: "insideLeft", style: { fontSize: 11 } }} />
+                    <ReTooltip />
+                    <Legend wrapperStyle={{ fontSize: 11 }} />
+                    {skuDetalhe.lt_teorico != null && (
+                      <ReferenceLine
+                        y={skuDetalhe.lt_teorico}
+                        stroke="hsl(var(--muted-foreground))"
+                        strokeDasharray="4 4"
+                        label={{ value: `Teórico ${skuDetalhe.lt_teorico}d`, position: "right", fontSize: 10 }}
+                      />
+                    )}
+                    <Line
+                      type="monotone"
+                      dataKey="faturamento"
+                      name="Faturamento"
+                      stroke="hsl(217 91% 70%)"
+                      strokeWidth={1.5}
+                      strokeDasharray="4 3"
+                      dot={{ r: 2.5 }}
+                      connectNulls={false}
+                      isAnimationActive={false}
+                    />
+                    <Line
+                      type="monotone"
+                      dataKey="logistica"
+                      name="Logística"
+                      stroke="hsl(25 95% 65%)"
+                      strokeWidth={1.5}
+                      strokeDasharray="4 3"
+                      dot={{ r: 2.5 }}
+                      connectNulls={false}
+                      isAnimationActive={false}
+                    />
+                    <Line type="monotone" dataKey="lt" name="LT bruto" stroke="hsl(var(--primary))" strokeWidth={2.5} isAnimationActive={false} dot={(props: { cx?: number; cy?: number; payload?: { lt: number | null } }) => {
+                      const { cx, cy, payload } = props;
+                      const violou = skuDetalhe.lt_teorico != null && payload?.lt != null && payload.lt > skuDetalhe.lt_teorico * 1.25;
+                      return (
+                        <circle cx={cx} cy={cy} r={4} fill={violou ? "hsl(var(--destructive))" : "hsl(var(--primary))"} stroke="white" strokeWidth={1} />
+                      );
+                    }} />
+                  </LineChart>
+                </ResponsiveContainer>
+              )}
+            </div>
+            <p className="text-xs text-muted-foreground">
+              Pontos vermelhos indicam recebimentos que ultrapassaram 25% do LT teórico. As linhas pontilhadas
+              decompõem o LT em faturamento (fornecedor) e logística (transportadora) para diagnóstico.
+            </p>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/reposicao/slaFornecedor/SlaFiltros.tsx
+++ b/src/components/reposicao/slaFornecedor/SlaFiltros.tsx
@@ -1,0 +1,92 @@
+// Linha de filtros da tabela de SLA por SKU (fornecedor/tendência/grupo/busca).
+// Extraída verbatim de src/pages/AdminReposicaoSlaFornecedor.tsx (god-component split).
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Search } from "lucide-react";
+
+interface SlaFiltrosProps {
+  filtroFornecedor: string;
+  onFiltroFornecedorChange: (v: string) => void;
+  filtroTendencia: string;
+  onFiltroTendenciaChange: (v: string) => void;
+  filtroGrupo: string;
+  onFiltroGrupoChange: (v: string) => void;
+  busca: string;
+  onBuscaChange: (v: string) => void;
+  fornecedoresOptions: string[];
+  grupos: string[];
+}
+
+export function SlaFiltros({
+  filtroFornecedor,
+  onFiltroFornecedorChange,
+  filtroTendencia,
+  onFiltroTendenciaChange,
+  filtroGrupo,
+  onFiltroGrupoChange,
+  busca,
+  onBuscaChange,
+  fornecedoresOptions,
+  grupos,
+}: SlaFiltrosProps) {
+  return (
+    <div className="flex flex-wrap gap-3 items-end">
+      <div className="w-[220px]">
+        <Label className="text-xs">Fornecedor</Label>
+        <Select value={filtroFornecedor} onValueChange={onFiltroFornecedorChange}>
+          <SelectTrigger><SelectValue /></SelectTrigger>
+          <SelectContent>
+            <SelectItem value="__all__">Todos</SelectItem>
+            {fornecedoresOptions.map((f) => (
+              <SelectItem key={f} value={f}>{f}</SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+      <div className="w-[150px]">
+        <Label className="text-xs">Tendência</Label>
+        <Select value={filtroTendencia} onValueChange={onFiltroTendenciaChange}>
+          <SelectTrigger><SelectValue /></SelectTrigger>
+          <SelectContent>
+            <SelectItem value="__all__">Todas</SelectItem>
+            <SelectItem value="melhorando">Melhorando</SelectItem>
+            <SelectItem value="estavel">Estável</SelectItem>
+            <SelectItem value="piorando">Piorando</SelectItem>
+            <SelectItem value="sem_dados">Sem dados</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+      <div className="w-[180px]">
+        <Label className="text-xs">Grupo de produção</Label>
+        <Select value={filtroGrupo} onValueChange={onFiltroGrupoChange}>
+          <SelectTrigger><SelectValue /></SelectTrigger>
+          <SelectContent>
+            <SelectItem value="__all__">Todos</SelectItem>
+            {grupos.map((g) => (
+              <SelectItem key={g} value={g}>{g}</SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+      <div className="flex-1 min-w-[200px]">
+        <Label className="text-xs">Buscar SKU</Label>
+        <div className="relative">
+          <Search className="h-3.5 w-3.5 absolute left-2 top-1/2 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            className="pl-7"
+            placeholder="Código ou descrição"
+            value={busca}
+            onChange={(e) => onBuscaChange(e.target.value)}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/reposicao/slaFornecedor/StatusChips.tsx
+++ b/src/components/reposicao/slaFornecedor/StatusChips.tsx
@@ -1,0 +1,35 @@
+// Chips multi-select de status do SLA.
+// Extraído verbatim de src/pages/AdminReposicaoSlaFornecedor.tsx (god-component split).
+import { STATUS_LABEL } from "./config";
+import type { SlaStatus } from "./types";
+
+interface StatusChipsProps {
+  filtroStatus: SlaStatus[];
+  onToggle: (s: SlaStatus) => void;
+}
+
+export function StatusChips({ filtroStatus, onToggle }: StatusChipsProps) {
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      <span className="text-xs text-muted-foreground self-center mr-1">Status:</span>
+      {(["cumprindo", "limite", "violando", "critico", "poucos_dados", "sem_sla_teorico"] as SlaStatus[]).map(
+        (s) => {
+          const active = filtroStatus.includes(s);
+          return (
+            <button
+              key={s}
+              onClick={() => onToggle(s)}
+              className={`text-xs px-2 py-1 rounded-full border transition-colors ${
+                active
+                  ? "bg-primary text-primary-foreground border-primary"
+                  : "bg-background text-muted-foreground border-border hover:bg-muted"
+              }`}
+            >
+              {STATUS_LABEL[s]}
+            </button>
+          );
+        },
+      )}
+    </div>
+  );
+}

--- a/src/components/reposicao/slaFornecedor/TendenciaIcon.tsx
+++ b/src/components/reposicao/slaFornecedor/TendenciaIcon.tsx
@@ -1,0 +1,11 @@
+// Ícone de tendência do lead time (piorando/melhorando/estável/sem dados).
+// Extraído verbatim de src/pages/AdminReposicaoSlaFornecedor.tsx (god-component split).
+import { ArrowDown, ArrowRight, ArrowUp, Minus } from "lucide-react";
+import type { Tendencia } from "./types";
+
+export const TendenciaIcon = ({ t }: { t: Tendencia }) => {
+  if (t === "piorando") return <ArrowUp className="h-3.5 w-3.5 text-destructive" aria-label="piorando" />;
+  if (t === "melhorando") return <ArrowDown className="h-3.5 w-3.5 text-success" aria-label="melhorando" />;
+  if (t === "sem_dados") return <Minus className="h-3.5 w-3.5 text-muted-foreground/50" aria-label="sem dados de tendência" />;
+  return <ArrowRight className="h-3.5 w-3.5 text-muted-foreground" aria-label="estável" />;
+};

--- a/src/components/reposicao/slaFornecedor/__tests__/ComplianceCardsGrid.test.tsx
+++ b/src/components/reposicao/slaFornecedor/__tests__/ComplianceCardsGrid.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ComplianceCardsGrid } from "../ComplianceCardsGrid";
+import type { ForCompliance } from "../types";
+
+function makeFor(o: Partial<ForCompliance> = {}): ForCompliance {
+  return {
+    empresa: "colacor",
+    fornecedor_nome: "Forn A",
+    skus_total: 10,
+    skus_cumprindo: 6,
+    skus_limite: 2,
+    skus_violando: 1,
+    skus_criticos: 1,
+    perc_sla_compliance: 85,
+    lt_teorico_agregado: 10,
+    lt_medio_observado_agregado: 12,
+    ...o,
+  };
+}
+
+describe("ComplianceCardsGrid", () => {
+  it("renderiza card de fornecedor com compliance e badges", () => {
+    render(<ComplianceCardsGrid fornecedores={[makeFor()]} loading={false} />);
+    expect(screen.getByText("Forn A")).toBeTruthy();
+    expect(screen.getByText("10 SKUs")).toBeTruthy();
+    expect(screen.getByText("85%")).toBeTruthy();
+    expect(screen.getByText("6 ok")).toBeTruthy();
+    expect(screen.getByText("1 crít.")).toBeTruthy();
+  });
+
+  it("mostra empty state sem fornecedores", () => {
+    render(<ComplianceCardsGrid fornecedores={[]} loading={false} />);
+    expect(screen.getByText("Nenhum fornecedor com dados de SLA disponíveis ainda.")).toBeTruthy();
+  });
+
+  it("mostra 3 skeletons em loading", () => {
+    const { container } = render(<ComplianceCardsGrid fornecedores={undefined} loading={true} />);
+    expect(container.querySelectorAll(".animate-shimmer")).toHaveLength(3);
+  });
+});

--- a/src/components/reposicao/slaFornecedor/__tests__/SkuComplianceTable.test.tsx
+++ b/src/components/reposicao/slaFornecedor/__tests__/SkuComplianceTable.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { SkuComplianceTable } from "../SkuComplianceTable";
+import type { SkuCompliance } from "../types";
+
+function makeSku(o: Partial<SkuCompliance> = {}): SkuCompliance {
+  return {
+    empresa: "colacor",
+    sku_codigo_omie: "111",
+    sku_descricao: "Verniz",
+    fornecedor_nome: "Forn A",
+    grupo_codigo: "G1",
+    lt_teorico: 10,
+    lt_observado_medio: 12,
+    lt_recente_medio: 13,
+    n_observacoes: 5,
+    ultimo_recebimento: "2026-03-01",
+    desvio_perc: 12,
+    status_sla: "violando",
+    tendencia: "piorando",
+    ...o,
+  };
+}
+
+describe("SkuComplianceTable", () => {
+  it("mostra empty state sem SKUs", () => {
+    render(<SkuComplianceTable skus={[]} loading={false} onSelectSku={vi.fn()} />);
+    expect(screen.getByText("Nenhum SKU encontrado com os filtros atuais.")).toBeTruthy();
+  });
+
+  it("seleciona SKU clicável (n_observacoes >= 3)", () => {
+    const onSelect = vi.fn();
+    render(<SkuComplianceTable skus={[makeSku()]} loading={false} onSelectSku={onSelect} />);
+    fireEvent.click(screen.getByText("Verniz"));
+    expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({ sku_codigo_omie: "111" }));
+  });
+
+  it("não seleciona SKU com poucas observações", () => {
+    const onSelect = vi.fn();
+    render(<SkuComplianceTable skus={[makeSku({ n_observacoes: 2 })]} loading={false} onSelectSku={onSelect} />);
+    fireEvent.click(screen.getByText("Verniz"));
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("formata desvio com sinal", () => {
+    render(
+      <SkuComplianceTable
+        skus={[
+          makeSku({ desvio_perc: 12 }),
+          makeSku({ sku_codigo_omie: "222", sku_descricao: "Cola", desvio_perc: -5 }),
+        ]}
+        loading={false}
+        onSelectSku={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("+12%")).toBeTruthy();
+    expect(screen.getByText("-5%")).toBeTruthy();
+  });
+});

--- a/src/components/reposicao/slaFornecedor/__tests__/SkuHistoricoDialog.test.tsx
+++ b/src/components/reposicao/slaFornecedor/__tests__/SkuHistoricoDialog.test.tsx
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { SkuHistoricoDialog } from "../SkuHistoricoDialog";
+import type { SkuCompliance } from "../types";
+
+function makeSku(o: Partial<SkuCompliance> = {}): SkuCompliance {
+  return {
+    empresa: "colacor",
+    sku_codigo_omie: "111",
+    sku_descricao: "Verniz",
+    fornecedor_nome: "Forn A",
+    grupo_codigo: "G1",
+    lt_teorico: 10,
+    lt_observado_medio: 12,
+    lt_recente_medio: 13,
+    n_observacoes: 5,
+    ultimo_recebimento: "2026-03-01",
+    desvio_perc: 12,
+    status_sla: "violando",
+    tendencia: "piorando",
+    ...o,
+  };
+}
+
+describe("SkuHistoricoDialog", () => {
+  it("não renderiza conteúdo quando skuDetalhe é null", () => {
+    render(<SkuHistoricoDialog skuDetalhe={null} onOpenChange={vi.fn()} historico={[]} loadingHist={false} />);
+    expect(screen.queryByText("Verniz")).toBeNull();
+  });
+
+  it("renderiza título e badges (loadingHist evita o gráfico)", () => {
+    render(<SkuHistoricoDialog skuDetalhe={makeSku()} onOpenChange={vi.fn()} historico={undefined} loadingHist={true} />);
+    expect(screen.getByText("111")).toBeTruthy();
+    expect(screen.getByText("Verniz")).toBeTruthy();
+    expect(screen.getByText("Violando")).toBeTruthy();
+    expect(screen.getByText("Forn A")).toBeTruthy();
+  });
+});

--- a/src/components/reposicao/slaFornecedor/__tests__/StatusChips.test.tsx
+++ b/src/components/reposicao/slaFornecedor/__tests__/StatusChips.test.tsx
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { StatusChips } from "../StatusChips";
+import type { SlaStatus } from "../types";
+
+const ativos: SlaStatus[] = ["cumprindo", "limite", "violando", "critico"];
+
+describe("StatusChips", () => {
+  it("renderiza os 6 chips de status", () => {
+    render(<StatusChips filtroStatus={ativos} onToggle={vi.fn()} />);
+    expect(screen.getAllByRole("button")).toHaveLength(6);
+    expect(screen.getByText("Cumprindo")).toBeTruthy();
+    expect(screen.getByText("Poucos dados")).toBeTruthy();
+  });
+
+  it("dispara onToggle com o status clicado", () => {
+    const onToggle = vi.fn();
+    render(<StatusChips filtroStatus={ativos} onToggle={onToggle} />);
+    fireEvent.click(screen.getByText("Crítico"));
+    expect(onToggle).toHaveBeenCalledWith("critico");
+  });
+
+  it("aplica estilo ativo nos chips selecionados", () => {
+    render(<StatusChips filtroStatus={["cumprindo"]} onToggle={vi.fn()} />);
+    expect(screen.getByText("Cumprindo").className).toContain("bg-primary");
+    expect(screen.getByText("Violando").className).not.toContain("bg-primary");
+  });
+});

--- a/src/components/reposicao/slaFornecedor/__tests__/TendenciaIcon.test.tsx
+++ b/src/components/reposicao/slaFornecedor/__tests__/TendenciaIcon.test.tsx
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { TendenciaIcon } from "../TendenciaIcon";
+
+const label = (markup: HTMLElement) => markup.querySelector("svg")?.getAttribute("aria-label");
+
+describe("TendenciaIcon", () => {
+  it("piorando", () => {
+    const { container } = render(<TendenciaIcon t="piorando" />);
+    expect(label(container)).toBe("piorando");
+  });
+  it("melhorando", () => {
+    const { container } = render(<TendenciaIcon t="melhorando" />);
+    expect(label(container)).toBe("melhorando");
+  });
+  it("sem_dados", () => {
+    const { container } = render(<TendenciaIcon t="sem_dados" />);
+    expect(label(container)).toBe("sem dados de tendência");
+  });
+  it("estavel (default)", () => {
+    const { container } = render(<TendenciaIcon t="estavel" />);
+    expect(label(container)).toBe("estável");
+  });
+});

--- a/src/components/reposicao/slaFornecedor/__tests__/config.test.ts
+++ b/src/components/reposicao/slaFornecedor/__tests__/config.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { fmtNum, fmtData, desvioColorClass, cardTone } from "../config";
+
+describe("slaFornecedor/config", () => {
+  it("fmtNum trata null/undefined e arredonda", () => {
+    expect(fmtNum(null)).toBe("—");
+    expect(fmtNum(undefined)).toBe("—");
+    expect(fmtNum(3.456)).toBe("3.5");
+    expect(fmtNum(3.456, 2)).toBe("3.46");
+  });
+
+  it("fmtData trata null e formata DD/MM/AAAA", () => {
+    expect(fmtData(null)).toBe("—");
+    expect(fmtData("2026-03-15")).toMatch(/^\d{2}\/\d{2}\/\d{4}$/);
+  });
+
+  it("desvioColorClass por faixa", () => {
+    expect(desvioColorClass(null)).toBe("text-muted-foreground");
+    expect(desvioColorClass(5)).toBe("text-success font-medium");
+    expect(desvioColorClass(20)).toBe("text-warning font-medium");
+    expect(desvioColorClass(40)).toBe("text-warning font-semibold");
+    expect(desvioColorClass(60)).toBe("text-destructive font-semibold");
+  });
+
+  it("cardTone por faixa de compliance", () => {
+    expect(cardTone(null)).toBe("border-border");
+    expect(cardTone(95)).toBe("border-success/40 bg-success/5");
+    expect(cardTone(75)).toBe("border-warning/40 bg-warning/5");
+    expect(cardTone(50)).toBe("border-destructive/40 bg-destructive/5");
+  });
+});

--- a/src/components/reposicao/slaFornecedor/config.ts
+++ b/src/components/reposicao/slaFornecedor/config.ts
@@ -1,0 +1,51 @@
+// Labels, variantes, ranking e helpers de formatação/cores do SLA de fornecedor.
+// Extraídos verbatim de src/pages/AdminReposicaoSlaFornecedor.tsx (god-component split).
+import type { SlaStatus } from "./types";
+
+export const STATUS_LABEL: Record<SlaStatus, string> = {
+  cumprindo: "Cumprindo",
+  limite: "No limite",
+  violando: "Violando",
+  critico: "Crítico",
+  sem_sla_teorico: "Sem SLA",
+  poucos_dados: "Poucos dados",
+};
+
+export const STATUS_VARIANT: Record<SlaStatus, "success" | "warning" | "info" | "destructive" | "outline"> = {
+  cumprindo: "success",
+  limite: "warning",
+  violando: "warning",
+  critico: "destructive",
+  sem_sla_teorico: "outline",
+  poucos_dados: "outline",
+};
+
+export const STATUS_RANK: Record<SlaStatus, number> = {
+  critico: 0,
+  violando: 1,
+  limite: 2,
+  cumprindo: 3,
+  poucos_dados: 4,
+  sem_sla_teorico: 5,
+};
+
+export const fmtNum = (v: number | null | undefined, dec = 1) =>
+  v == null ? "—" : Number(v).toFixed(dec);
+
+export const fmtData = (v: string | null) =>
+  v ? new Date(v).toLocaleDateString("pt-BR") : "—";
+
+export const desvioColorClass = (pct: number | null) => {
+  if (pct == null) return "text-muted-foreground";
+  if (pct <= 10) return "text-success font-medium";
+  if (pct <= 25) return "text-warning font-medium";
+  if (pct <= 50) return "text-warning font-semibold";
+  return "text-destructive font-semibold";
+};
+
+export const cardTone = (pct: number | null) => {
+  if (pct == null) return "border-border";
+  if (pct >= 90) return "border-success/40 bg-success/5";
+  if (pct >= 70) return "border-warning/40 bg-warning/5";
+  return "border-destructive/40 bg-destructive/5";
+};

--- a/src/components/reposicao/slaFornecedor/types.ts
+++ b/src/components/reposicao/slaFornecedor/types.ts
@@ -1,0 +1,48 @@
+// Tipos do SLA de fornecedor.
+// Extraídos verbatim de src/pages/AdminReposicaoSlaFornecedor.tsx (god-component split).
+
+export type SlaStatus =
+  | "cumprindo"
+  | "limite"
+  | "violando"
+  | "critico"
+  | "sem_sla_teorico"
+  | "poucos_dados";
+
+export type Tendencia = "melhorando" | "estavel" | "piorando" | "sem_dados";
+
+export interface ForCompliance {
+  empresa: string;
+  fornecedor_nome: string;
+  skus_total: number;
+  skus_cumprindo: number;
+  skus_limite: number;
+  skus_violando: number;
+  skus_criticos: number;
+  perc_sla_compliance: number | null;
+  lt_teorico_agregado: number | null;
+  lt_medio_observado_agregado: number | null;
+}
+
+export interface SkuCompliance {
+  empresa: string;
+  sku_codigo_omie: string;
+  sku_descricao: string | null;
+  fornecedor_nome: string | null;
+  grupo_codigo: string | null;
+  lt_teorico: number | null;
+  lt_observado_medio: number | null;
+  lt_recente_medio: number | null;
+  n_observacoes: number | null;
+  ultimo_recebimento: string | null;
+  desvio_perc: number | null;
+  status_sla: SlaStatus;
+  tendencia: Tendencia;
+}
+
+export interface HistPoint {
+  data: string;
+  lt: number | null;
+  faturamento: number | null;
+  logistica: number | null;
+}

--- a/src/components/reposicao/slaFornecedor/useSlaFornecedor.ts
+++ b/src/components/reposicao/slaFornecedor/useSlaFornecedor.ts
@@ -1,0 +1,178 @@
+// Hook de dados/estado do SLA de fornecedor.
+// Extraído verbatim de src/pages/AdminReposicaoSlaFornecedor.tsx (god-component split):
+// 3 queries (compliance por fornecedor/SKU + histórico) + memos + exportCsv + toggleStatus.
+import { useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { supabase } from "@/integrations/supabase/client";
+import { useReposicaoEmpresa } from "@/contexts/ReposicaoEmpresaContext";
+import { STATUS_RANK } from "./config";
+import type { ForCompliance, SkuCompliance, SlaStatus } from "./types";
+
+export function useSlaFornecedor() {
+  const { empresa } = useReposicaoEmpresa();
+  const [filtroFornecedor, setFiltroFornecedor] = useState<string>("__all__");
+  const [filtroStatus, setFiltroStatus] = useState<SlaStatus[]>([
+    "cumprindo",
+    "limite",
+    "violando",
+    "critico",
+  ]);
+  const [filtroTendencia, setFiltroTendencia] = useState<string>("__all__");
+  const [filtroGrupo, setFiltroGrupo] = useState<string>("__all__");
+  const [busca, setBusca] = useState("");
+  const [skuDetalhe, setSkuDetalhe] = useState<SkuCompliance | null>(null);
+
+  // Compliance por fornecedor
+  const { data: fornecedores, isLoading: loadingFor } = useQuery({
+    queryKey: ["sla-fornecedor", empresa],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from("v_fornecedor_sla_compliance")
+        .select("*")
+        .eq("empresa", empresa)
+        .order("perc_sla_compliance", { ascending: true, nullsFirst: false });
+      if (error) throw error;
+      return (data ?? []) as ForCompliance[];
+    },
+  });
+
+  // Compliance por SKU
+  const { data: skus, isLoading: loadingSkus } = useQuery({
+    queryKey: ["sla-sku", empresa],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from("v_sku_sla_compliance")
+        .select("*")
+        .eq("empresa", empresa)
+        .limit(5000);
+      if (error) throw error;
+      return (data ?? []) as unknown as SkuCompliance[];
+    },
+  });
+
+  // Histórico do SKU selecionado
+  const { data: historico, isLoading: loadingHist } = useQuery({
+    enabled: !!skuDetalhe,
+    queryKey: ["sla-hist", skuDetalhe?.sku_codigo_omie],
+    queryFn: async () => {
+      if (!skuDetalhe) return [];
+      const { data, error } = await supabase
+        .from("sku_leadtime_history")
+        .select("t4_data_recebimento, lt_bruto_dias_uteis, lt_faturamento_dias_uteis, lt_logistica_dias_uteis")
+        .eq("sku_codigo_omie", Number(skuDetalhe.sku_codigo_omie))
+        .not("lt_bruto_dias_uteis", "is", null)
+        .order("t4_data_recebimento", { ascending: false })
+        .limit(15);
+      if (error) throw error;
+      type HistRow = {
+        t4_data_recebimento: string | null;
+        lt_bruto_dias_uteis: number | string | null;
+        lt_faturamento_dias_uteis: number | string | null;
+        lt_logistica_dias_uteis: number | string | null;
+      };
+      return ((data ?? []) as HistRow[])
+        .reverse()
+        .map((r) => ({
+          data: r.t4_data_recebimento
+            ? new Date(r.t4_data_recebimento).toLocaleDateString("pt-BR", { day: "2-digit", month: "2-digit" })
+            : "",
+          lt: r.lt_bruto_dias_uteis != null ? Number(r.lt_bruto_dias_uteis) : null,
+          faturamento: r.lt_faturamento_dias_uteis != null ? Number(r.lt_faturamento_dias_uteis) : null,
+          logistica: r.lt_logistica_dias_uteis != null ? Number(r.lt_logistica_dias_uteis) : null,
+        }));
+    },
+  });
+
+  const grupos = useMemo(
+    () => Array.from(new Set((skus ?? []).map((s) => s.grupo_codigo).filter(Boolean))).sort() as string[],
+    [skus],
+  );
+
+  const skusFiltrados = useMemo(() => {
+    const q = busca.trim().toLowerCase();
+    return (skus ?? [])
+      .filter((s) => filtroStatus.includes(s.status_sla))
+      .filter((s) => filtroFornecedor === "__all__" || s.fornecedor_nome === filtroFornecedor)
+      .filter((s) => filtroTendencia === "__all__" || s.tendencia === filtroTendencia)
+      .filter((s) => filtroGrupo === "__all__" || s.grupo_codigo === filtroGrupo)
+      .filter(
+        (s) =>
+          !q ||
+          s.sku_codigo_omie.toLowerCase().includes(q) ||
+          (s.sku_descricao ?? "").toLowerCase().includes(q),
+      )
+      .sort((a, b) => {
+        const r = STATUS_RANK[a.status_sla] - STATUS_RANK[b.status_sla];
+        if (r !== 0) return r;
+        return (b.desvio_perc ?? -Infinity) - (a.desvio_perc ?? -Infinity);
+      });
+  }, [skus, filtroStatus, filtroFornecedor, filtroTendencia, filtroGrupo, busca]);
+
+  const fornecedoresOptions = useMemo(
+    () => Array.from(new Set((skus ?? []).map((s) => s.fornecedor_nome).filter(Boolean))).sort() as string[],
+    [skus],
+  );
+
+  const exportCsv = () => {
+    if (!fornecedores?.length) return;
+    const head = [
+      "fornecedor",
+      "skus_total",
+      "perc_sla_compliance",
+      "skus_cumprindo",
+      "skus_limite",
+      "skus_violando",
+      "skus_criticos",
+      "lt_teorico_agregado",
+      "lt_medio_observado_agregado",
+    ];
+    const rows = fornecedores.map((f) =>
+      [
+        `"${f.fornecedor_nome.replace(/"/g, '""')}"`,
+        f.skus_total,
+        f.perc_sla_compliance ?? "",
+        f.skus_cumprindo,
+        f.skus_limite,
+        f.skus_violando,
+        f.skus_criticos,
+        f.lt_teorico_agregado ?? "",
+        f.lt_medio_observado_agregado ?? "",
+      ].join(","),
+    );
+    const blob = new Blob([head.join(",") + "\n" + rows.join("\n")], { type: "text/csv;charset=utf-8" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `sla-fornecedor-${new Date().toISOString().slice(0, 10)}.csv`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const toggleStatus = (s: SlaStatus) => {
+    setFiltroStatus((prev) => (prev.includes(s) ? prev.filter((x) => x !== s) : [...prev, s]));
+  };
+
+  return {
+    fornecedores,
+    loadingFor,
+    loadingSkus,
+    skusFiltrados,
+    historico,
+    loadingHist,
+    grupos,
+    fornecedoresOptions,
+    filtroFornecedor,
+    setFiltroFornecedor,
+    filtroTendencia,
+    setFiltroTendencia,
+    filtroGrupo,
+    setFiltroGrupo,
+    busca,
+    setBusca,
+    filtroStatus,
+    toggleStatus,
+    skuDetalhe,
+    setSkuDetalhe,
+    exportCsv,
+  };
+}

--- a/src/pages/AdminReposicaoSlaFornecedor.tsx
+++ b/src/pages/AdminReposicaoSlaFornecedor.tsx
@@ -1,280 +1,40 @@
-import { useMemo, useState } from "react";
-import { useQuery } from "@tanstack/react-query";
-import { supabase } from "@/integrations/supabase/client";
+// SLA de fornecedor — compliance de lead time por SKU e por fornecedor.
+// Composição: useSlaFornecedor (dados/filtros) + cards + filtros + tabela + modal de histórico.
+// God-component split de src/pages/AdminReposicaoSlaFornecedor.tsx (comportamento 1:1).
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
-import { Skeleton } from "@/components/ui/skeleton";
-import { ArrowDown, ArrowRight, ArrowUp, Download, Minus, Search } from "lucide-react";
-import {
-  CartesianGrid,
-  Legend,
-  Line,
-  LineChart,
-  ReferenceLine,
-  ResponsiveContainer,
-  Tooltip as ReTooltip,
-  XAxis,
-  YAxis,
-} from "recharts";
-
-import { useReposicaoEmpresa } from "@/contexts/ReposicaoEmpresaContext";
-
-type SlaStatus =
-  | "cumprindo"
-  | "limite"
-  | "violando"
-  | "critico"
-  | "sem_sla_teorico"
-  | "poucos_dados";
-
-type Tendencia = "melhorando" | "estavel" | "piorando" | "sem_dados";
-
-interface ForCompliance {
-  empresa: string;
-  fornecedor_nome: string;
-  skus_total: number;
-  skus_cumprindo: number;
-  skus_limite: number;
-  skus_violando: number;
-  skus_criticos: number;
-  perc_sla_compliance: number | null;
-  lt_teorico_agregado: number | null;
-  lt_medio_observado_agregado: number | null;
-}
-
-interface SkuCompliance {
-  empresa: string;
-  sku_codigo_omie: string;
-  sku_descricao: string | null;
-  fornecedor_nome: string | null;
-  grupo_codigo: string | null;
-  lt_teorico: number | null;
-  lt_observado_medio: number | null;
-  lt_recente_medio: number | null;
-  n_observacoes: number | null;
-  ultimo_recebimento: string | null;
-  desvio_perc: number | null;
-  status_sla: SlaStatus;
-  tendencia: Tendencia;
-}
-
-const STATUS_LABEL: Record<SlaStatus, string> = {
-  cumprindo: "Cumprindo",
-  limite: "No limite",
-  violando: "Violando",
-  critico: "Crítico",
-  sem_sla_teorico: "Sem SLA",
-  poucos_dados: "Poucos dados",
-};
-
-const STATUS_VARIANT: Record<SlaStatus, "success" | "warning" | "info" | "destructive" | "outline"> = {
-  cumprindo: "success",
-  limite: "warning",
-  violando: "warning",
-  critico: "destructive",
-  sem_sla_teorico: "outline",
-  poucos_dados: "outline",
-};
-
-const STATUS_RANK: Record<SlaStatus, number> = {
-  critico: 0,
-  violando: 1,
-  limite: 2,
-  cumprindo: 3,
-  poucos_dados: 4,
-  sem_sla_teorico: 5,
-};
-
-const fmtNum = (v: number | null | undefined, dec = 1) =>
-  v == null ? "—" : Number(v).toFixed(dec);
-
-const fmtData = (v: string | null) =>
-  v ? new Date(v).toLocaleDateString("pt-BR") : "—";
-
-const TendenciaIcon = ({ t }: { t: Tendencia }) => {
-  if (t === "piorando") return <ArrowUp className="h-3.5 w-3.5 text-destructive" aria-label="piorando" />;
-  if (t === "melhorando") return <ArrowDown className="h-3.5 w-3.5 text-success" aria-label="melhorando" />;
-  if (t === "sem_dados") return <Minus className="h-3.5 w-3.5 text-muted-foreground/50" aria-label="sem dados de tendência" />;
-  return <ArrowRight className="h-3.5 w-3.5 text-muted-foreground" aria-label="estável" />;
-};
-
-const desvioColorClass = (pct: number | null) => {
-  if (pct == null) return "text-muted-foreground";
-  if (pct <= 10) return "text-success font-medium";
-  if (pct <= 25) return "text-warning font-medium";
-  if (pct <= 50) return "text-warning font-semibold";
-  return "text-destructive font-semibold";
-};
-
-const cardTone = (pct: number | null) => {
-  if (pct == null) return "border-border";
-  if (pct >= 90) return "border-success/40 bg-success/5";
-  if (pct >= 70) return "border-warning/40 bg-warning/5";
-  return "border-destructive/40 bg-destructive/5";
-};
+import { Download } from "lucide-react";
+import { useSlaFornecedor } from "@/components/reposicao/slaFornecedor/useSlaFornecedor";
+import { ComplianceCardsGrid } from "@/components/reposicao/slaFornecedor/ComplianceCardsGrid";
+import { SlaFiltros } from "@/components/reposicao/slaFornecedor/SlaFiltros";
+import { StatusChips } from "@/components/reposicao/slaFornecedor/StatusChips";
+import { SkuComplianceTable } from "@/components/reposicao/slaFornecedor/SkuComplianceTable";
+import { SkuHistoricoDialog } from "@/components/reposicao/slaFornecedor/SkuHistoricoDialog";
 
 export default function AdminReposicaoSlaFornecedor() {
-  const { empresa } = useReposicaoEmpresa();
-  const [filtroFornecedor, setFiltroFornecedor] = useState<string>("__all__");
-  const [filtroStatus, setFiltroStatus] = useState<SlaStatus[]>([
-    "cumprindo",
-    "limite",
-    "violando",
-    "critico",
-  ]);
-  const [filtroTendencia, setFiltroTendencia] = useState<string>("__all__");
-  const [filtroGrupo, setFiltroGrupo] = useState<string>("__all__");
-  const [busca, setBusca] = useState("");
-  const [skuDetalhe, setSkuDetalhe] = useState<SkuCompliance | null>(null);
-
-  // Compliance por fornecedor
-  const { data: fornecedores, isLoading: loadingFor } = useQuery({
-    queryKey: ["sla-fornecedor", empresa],
-    queryFn: async () => {
-      const { data, error } = await supabase
-        .from("v_fornecedor_sla_compliance")
-        .select("*")
-        .eq("empresa", empresa)
-        .order("perc_sla_compliance", { ascending: true, nullsFirst: false });
-      if (error) throw error;
-      return (data ?? []) as ForCompliance[];
-    },
-  });
-
-  // Compliance por SKU
-  const { data: skus, isLoading: loadingSkus } = useQuery({
-    queryKey: ["sla-sku", empresa],
-    queryFn: async () => {
-      const { data, error } = await supabase
-        .from("v_sku_sla_compliance")
-        .select("*")
-        .eq("empresa", empresa)
-        .limit(5000);
-      if (error) throw error;
-      return (data ?? []) as unknown as SkuCompliance[];
-    },
-  });
-
-  // Histórico do SKU selecionado
-  const { data: historico, isLoading: loadingHist } = useQuery({
-    enabled: !!skuDetalhe,
-    queryKey: ["sla-hist", skuDetalhe?.sku_codigo_omie],
-    queryFn: async () => {
-      if (!skuDetalhe) return [];
-      const { data, error } = await supabase
-        .from("sku_leadtime_history")
-        .select("t4_data_recebimento, lt_bruto_dias_uteis, lt_faturamento_dias_uteis, lt_logistica_dias_uteis")
-        .eq("sku_codigo_omie", Number(skuDetalhe.sku_codigo_omie))
-        .not("lt_bruto_dias_uteis", "is", null)
-        .order("t4_data_recebimento", { ascending: false })
-        .limit(15);
-      if (error) throw error;
-      type HistRow = {
-        t4_data_recebimento: string | null;
-        lt_bruto_dias_uteis: number | string | null;
-        lt_faturamento_dias_uteis: number | string | null;
-        lt_logistica_dias_uteis: number | string | null;
-      };
-      return ((data ?? []) as HistRow[])
-        .reverse()
-        .map((r) => ({
-          data: r.t4_data_recebimento
-            ? new Date(r.t4_data_recebimento).toLocaleDateString("pt-BR", { day: "2-digit", month: "2-digit" })
-            : "",
-          lt: r.lt_bruto_dias_uteis != null ? Number(r.lt_bruto_dias_uteis) : null,
-          faturamento: r.lt_faturamento_dias_uteis != null ? Number(r.lt_faturamento_dias_uteis) : null,
-          logistica: r.lt_logistica_dias_uteis != null ? Number(r.lt_logistica_dias_uteis) : null,
-        }));
-    },
-  });
-
-  const grupos = useMemo(
-    () => Array.from(new Set((skus ?? []).map((s) => s.grupo_codigo).filter(Boolean))).sort() as string[],
-    [skus],
-  );
-
-  const skusFiltrados = useMemo(() => {
-    const q = busca.trim().toLowerCase();
-    return (skus ?? [])
-      .filter((s) => filtroStatus.includes(s.status_sla))
-      .filter((s) => filtroFornecedor === "__all__" || s.fornecedor_nome === filtroFornecedor)
-      .filter((s) => filtroTendencia === "__all__" || s.tendencia === filtroTendencia)
-      .filter((s) => filtroGrupo === "__all__" || s.grupo_codigo === filtroGrupo)
-      .filter(
-        (s) =>
-          !q ||
-          s.sku_codigo_omie.toLowerCase().includes(q) ||
-          (s.sku_descricao ?? "").toLowerCase().includes(q),
-      )
-      .sort((a, b) => {
-        const r = STATUS_RANK[a.status_sla] - STATUS_RANK[b.status_sla];
-        if (r !== 0) return r;
-        return (b.desvio_perc ?? -Infinity) - (a.desvio_perc ?? -Infinity);
-      });
-  }, [skus, filtroStatus, filtroFornecedor, filtroTendencia, filtroGrupo, busca]);
-
-  const fornecedoresOptions = useMemo(
-    () => Array.from(new Set((skus ?? []).map((s) => s.fornecedor_nome).filter(Boolean))).sort() as string[],
-    [skus],
-  );
-
-  const exportCsv = () => {
-    if (!fornecedores?.length) return;
-    const head = [
-      "fornecedor",
-      "skus_total",
-      "perc_sla_compliance",
-      "skus_cumprindo",
-      "skus_limite",
-      "skus_violando",
-      "skus_criticos",
-      "lt_teorico_agregado",
-      "lt_medio_observado_agregado",
-    ];
-    const rows = fornecedores.map((f) =>
-      [
-        `"${f.fornecedor_nome.replace(/"/g, '""')}"`,
-        f.skus_total,
-        f.perc_sla_compliance ?? "",
-        f.skus_cumprindo,
-        f.skus_limite,
-        f.skus_violando,
-        f.skus_criticos,
-        f.lt_teorico_agregado ?? "",
-        f.lt_medio_observado_agregado ?? "",
-      ].join(","),
-    );
-    const blob = new Blob([head.join(",") + "\n" + rows.join("\n")], { type: "text/csv;charset=utf-8" });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = `sla-fornecedor-${new Date().toISOString().slice(0, 10)}.csv`;
-    a.click();
-    URL.revokeObjectURL(url);
-  };
-
-  const toggleStatus = (s: SlaStatus) => {
-    setFiltroStatus((prev) => (prev.includes(s) ? prev.filter((x) => x !== s) : [...prev, s]));
-  };
+  const {
+    fornecedores,
+    loadingFor,
+    loadingSkus,
+    skusFiltrados,
+    historico,
+    loadingHist,
+    grupos,
+    fornecedoresOptions,
+    filtroFornecedor,
+    setFiltroFornecedor,
+    filtroTendencia,
+    setFiltroTendencia,
+    filtroGrupo,
+    setFiltroGrupo,
+    busca,
+    setBusca,
+    filtroStatus,
+    toggleStatus,
+    skuDetalhe,
+    setSkuDetalhe,
+    exportCsv,
+  } = useSlaFornecedor();
 
   return (
     <div className="space-y-6 p-4 md:p-6">
@@ -291,44 +51,7 @@ export default function AdminReposicaoSlaFornecedor() {
       </div>
 
       {/* Cards de compliance global */}
-      <div className="grid gap-3 grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
-        {loadingFor &&
-          Array.from({ length: 3 }).map((_, i) => <Skeleton key={i} className="h-40 w-full" />)}
-        {!loadingFor &&
-          fornecedores?.map((f) => (
-            <Card key={f.fornecedor_nome} className={cardTone(f.perc_sla_compliance)}>
-              <CardHeader className="pb-2">
-                <CardTitle className="text-sm flex items-center justify-between gap-2">
-                  <span className="truncate" title={f.fornecedor_nome}>{f.fornecedor_nome}</span>
-                  <Badge variant="outline" className="shrink-0">{f.skus_total} SKUs</Badge>
-                </CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-2">
-                <div className="text-3xl font-bold">
-                  {f.perc_sla_compliance != null ? `${f.perc_sla_compliance}%` : "—"}
-                  <span className="text-xs font-normal text-muted-foreground ml-1">compliance</span>
-                </div>
-                <div className="text-xs text-muted-foreground">
-                  LT teórico: <span className="font-mono">{fmtNum(f.lt_teorico_agregado)}d</span> · observado:{" "}
-                  <span className="font-mono">{fmtNum(f.lt_medio_observado_agregado)}d</span>
-                </div>
-                <div className="flex flex-wrap gap-1.5 pt-1">
-                  <Badge variant="success">{f.skus_cumprindo} ok</Badge>
-                  <Badge variant="warning">{f.skus_limite} limite</Badge>
-                  <Badge variant="warning">{f.skus_violando} viol.</Badge>
-                  <Badge variant="destructive">{f.skus_criticos} crít.</Badge>
-                </div>
-              </CardContent>
-            </Card>
-          ))}
-        {!loadingFor && (fornecedores?.length ?? 0) === 0 && (
-          <Card className="md:col-span-3">
-            <CardContent className="py-8 text-center text-sm text-muted-foreground">
-              Nenhum fornecedor com dados de SLA disponíveis ainda.
-            </CardContent>
-          </Card>
-        )}
-      </div>
+      <ComplianceCardsGrid fornecedores={fornecedores} loading={loadingFor} />
 
       {/* Tabela detalhada por SKU */}
       <Card>
@@ -337,240 +60,34 @@ export default function AdminReposicaoSlaFornecedor() {
         </CardHeader>
         <CardContent className="space-y-3">
           {/* Filtros */}
-          <div className="flex flex-wrap gap-3 items-end">
-            <div className="w-[220px]">
-              <Label className="text-xs">Fornecedor</Label>
-              <Select value={filtroFornecedor} onValueChange={setFiltroFornecedor}>
-                <SelectTrigger><SelectValue /></SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="__all__">Todos</SelectItem>
-                  {fornecedoresOptions.map((f) => (
-                    <SelectItem key={f} value={f}>{f}</SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-            <div className="w-[150px]">
-              <Label className="text-xs">Tendência</Label>
-              <Select value={filtroTendencia} onValueChange={setFiltroTendencia}>
-                <SelectTrigger><SelectValue /></SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="__all__">Todas</SelectItem>
-                  <SelectItem value="melhorando">Melhorando</SelectItem>
-                  <SelectItem value="estavel">Estável</SelectItem>
-                  <SelectItem value="piorando">Piorando</SelectItem>
-                  <SelectItem value="sem_dados">Sem dados</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-            <div className="w-[180px]">
-              <Label className="text-xs">Grupo de produção</Label>
-              <Select value={filtroGrupo} onValueChange={setFiltroGrupo}>
-                <SelectTrigger><SelectValue /></SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="__all__">Todos</SelectItem>
-                  {grupos.map((g) => (
-                    <SelectItem key={g} value={g}>{g}</SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-            <div className="flex-1 min-w-[200px]">
-              <Label className="text-xs">Buscar SKU</Label>
-              <div className="relative">
-                <Search className="h-3.5 w-3.5 absolute left-2 top-1/2 -translate-y-1/2 text-muted-foreground" />
-                <Input
-                  className="pl-7"
-                  placeholder="Código ou descrição"
-                  value={busca}
-                  onChange={(e) => setBusca(e.target.value)}
-                />
-              </div>
-            </div>
-          </div>
+          <SlaFiltros
+            filtroFornecedor={filtroFornecedor}
+            onFiltroFornecedorChange={setFiltroFornecedor}
+            filtroTendencia={filtroTendencia}
+            onFiltroTendenciaChange={setFiltroTendencia}
+            filtroGrupo={filtroGrupo}
+            onFiltroGrupoChange={setFiltroGrupo}
+            busca={busca}
+            onBuscaChange={setBusca}
+            fornecedoresOptions={fornecedoresOptions}
+            grupos={grupos}
+          />
 
           {/* Status multi-select como chips */}
-          <div className="flex flex-wrap gap-1.5">
-            <span className="text-xs text-muted-foreground self-center mr-1">Status:</span>
-            {(["cumprindo", "limite", "violando", "critico", "poucos_dados", "sem_sla_teorico"] as SlaStatus[]).map(
-              (s) => {
-                const active = filtroStatus.includes(s);
-                return (
-                  <button
-                    key={s}
-                    onClick={() => toggleStatus(s)}
-                    className={`text-xs px-2 py-1 rounded-full border transition-colors ${
-                      active
-                        ? "bg-primary text-primary-foreground border-primary"
-                        : "bg-background text-muted-foreground border-border hover:bg-muted"
-                    }`}
-                  >
-                    {STATUS_LABEL[s]}
-                  </button>
-                );
-              },
-            )}
-          </div>
+          <StatusChips filtroStatus={filtroStatus} onToggle={toggleStatus} />
 
           {/* Tabela */}
-          <div className="border rounded-md">
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead className="w-[120px]">Status</TableHead>
-                  <TableHead>SKU</TableHead>
-                  <TableHead>Grupo</TableHead>
-                  <TableHead className="text-right">LT teór.</TableHead>
-                  <TableHead className="text-right">LT obs.</TableHead>
-                  <TableHead className="text-right">Recente 5</TableHead>
-                  <TableHead className="text-right">Desvio</TableHead>
-                  <TableHead>Último receb.</TableHead>
-                  <TableHead className="text-right">N obs.</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {loadingSkus &&
-                  Array.from({ length: 6 }).map((_, i) => (
-                    <TableRow key={i}>
-                      <TableCell colSpan={9}><Skeleton className="h-6 w-full" /></TableCell>
-                    </TableRow>
-                  ))}
-                {!loadingSkus && skusFiltrados.length === 0 && (
-                  <TableRow>
-                    <TableCell colSpan={9} className="text-center text-sm text-muted-foreground py-8">
-                      Nenhum SKU encontrado com os filtros atuais.
-                    </TableCell>
-                  </TableRow>
-                )}
-                {!loadingSkus &&
-                  skusFiltrados.map((s) => {
-                    const clicavel = (s.n_observacoes ?? 0) >= 3;
-                    return (
-                      <TableRow
-                        key={`${s.empresa}-${s.sku_codigo_omie}`}
-                        className={clicavel ? "cursor-pointer" : "opacity-90"}
-                        onClick={() => clicavel && setSkuDetalhe(s)}
-                      >
-                        <TableCell>
-                          <Badge variant={STATUS_VARIANT[s.status_sla]}>{STATUS_LABEL[s.status_sla]}</Badge>
-                        </TableCell>
-                        <TableCell className="align-top min-w-[280px]">
-                          <div className="font-mono text-xs text-muted-foreground">{s.sku_codigo_omie}</div>
-                          <div className="text-sm font-medium whitespace-normal break-words">
-                            {s.sku_descricao ?? "—"}
-                          </div>
-                        </TableCell>
-                        <TableCell>
-                          {s.grupo_codigo ? (
-                            <Badge variant="outline" className="text-xs">{s.grupo_codigo}</Badge>
-                          ) : (
-                            <span className="text-xs text-muted-foreground">—</span>
-                          )}
-                        </TableCell>
-                        <TableCell className="text-right font-mono text-xs">{fmtNum(s.lt_teorico, 1)}</TableCell>
-                        <TableCell className="text-right font-mono text-xs">{fmtNum(s.lt_observado_medio, 1)}</TableCell>
-                        <TableCell className="text-right">
-                          <div className="inline-flex items-center gap-1 font-mono text-xs">
-                            {fmtNum(s.lt_recente_medio, 1)}
-                            <TendenciaIcon t={s.tendencia} />
-                          </div>
-                        </TableCell>
-                        <TableCell className={`text-right font-mono text-xs ${desvioColorClass(s.desvio_perc)}`}>
-                          {s.desvio_perc == null ? "—" : `${s.desvio_perc > 0 ? "+" : ""}${s.desvio_perc}%`}
-                        </TableCell>
-                        <TableCell className="text-xs">{fmtData(s.ultimo_recebimento)}</TableCell>
-                        <TableCell className="text-right font-mono text-xs">{s.n_observacoes ?? 0}</TableCell>
-                      </TableRow>
-                    );
-                  })}
-              </TableBody>
-            </Table>
-          </div>
+          <SkuComplianceTable skus={skusFiltrados} loading={loadingSkus} onSelectSku={setSkuDetalhe} />
         </CardContent>
       </Card>
 
       {/* Modal: histórico do SKU */}
-      <Dialog open={!!skuDetalhe} onOpenChange={(o) => !o && setSkuDetalhe(null)}>
-        <DialogContent className="max-w-3xl">
-          <DialogHeader>
-            <DialogTitle>
-              <div className="flex items-center gap-2">
-                <span className="font-mono text-sm">{skuDetalhe?.sku_codigo_omie}</span>
-                <span className="text-sm font-normal text-muted-foreground truncate">
-                  {skuDetalhe?.sku_descricao}
-                </span>
-              </div>
-            </DialogTitle>
-          </DialogHeader>
-          {skuDetalhe && (
-            <div className="space-y-3">
-              <div className="flex flex-wrap gap-2 text-xs">
-                <Badge variant={STATUS_VARIANT[skuDetalhe.status_sla]}>{STATUS_LABEL[skuDetalhe.status_sla]}</Badge>
-                {skuDetalhe.fornecedor_nome && <Badge variant="outline">{skuDetalhe.fornecedor_nome}</Badge>}
-                {skuDetalhe.grupo_codigo && <Badge variant="outline">Grupo {skuDetalhe.grupo_codigo}</Badge>}
-                <Badge variant="outline">LT teórico: <span className="font-mono ml-1">{fmtNum(skuDetalhe.lt_teorico, 1)}d</span></Badge>
-                <Badge variant="outline">Médio observado: <span className="font-mono ml-1">{fmtNum(skuDetalhe.lt_observado_medio, 1)}d</span></Badge>
-              </div>
-              <div className="h-[280px]">
-                {loadingHist ? (
-                  <Skeleton className="h-full w-full" />
-                ) : (
-                  <ResponsiveContainer width="100%" height="100%">
-                    <LineChart data={historico ?? []}>
-                      <CartesianGrid strokeDasharray="3 3" />
-                      <XAxis dataKey="data" tick={{ fontSize: 11 }} />
-                      <YAxis tick={{ fontSize: 11 }} label={{ value: "dias úteis", angle: -90, position: "insideLeft", style: { fontSize: 11 } }} />
-                      <ReTooltip />
-                      <Legend wrapperStyle={{ fontSize: 11 }} />
-                      {skuDetalhe.lt_teorico != null && (
-                        <ReferenceLine
-                          y={skuDetalhe.lt_teorico}
-                          stroke="hsl(var(--muted-foreground))"
-                          strokeDasharray="4 4"
-                          label={{ value: `Teórico ${skuDetalhe.lt_teorico}d`, position: "right", fontSize: 10 }}
-                        />
-                      )}
-                      <Line
-                        type="monotone"
-                        dataKey="faturamento"
-                        name="Faturamento"
-                        stroke="hsl(217 91% 70%)"
-                        strokeWidth={1.5}
-                        strokeDasharray="4 3"
-                        dot={{ r: 2.5 }}
-                        connectNulls={false}
-                        isAnimationActive={false}
-                      />
-                      <Line
-                        type="monotone"
-                        dataKey="logistica"
-                        name="Logística"
-                        stroke="hsl(25 95% 65%)"
-                        strokeWidth={1.5}
-                        strokeDasharray="4 3"
-                        dot={{ r: 2.5 }}
-                        connectNulls={false}
-                        isAnimationActive={false}
-                      />
-                      <Line type="monotone" dataKey="lt" name="LT bruto" stroke="hsl(var(--primary))" strokeWidth={2.5} isAnimationActive={false} dot={(props: { cx?: number; cy?: number; payload?: { lt: number | null } }) => {
-                        const { cx, cy, payload } = props;
-                        const violou = skuDetalhe.lt_teorico != null && payload?.lt != null && payload.lt > skuDetalhe.lt_teorico * 1.25;
-                        return (
-                          <circle cx={cx} cy={cy} r={4} fill={violou ? "hsl(var(--destructive))" : "hsl(var(--primary))"} stroke="white" strokeWidth={1} />
-                        );
-                      }} />
-                    </LineChart>
-                  </ResponsiveContainer>
-                )}
-              </div>
-              <p className="text-xs text-muted-foreground">
-                Pontos vermelhos indicam recebimentos que ultrapassaram 25% do LT teórico. As linhas pontilhadas
-                decompõem o LT em faturamento (fornecedor) e logística (transportadora) para diagnóstico.
-              </p>
-            </div>
-          )}
-        </DialogContent>
-      </Dialog>
+      <SkuHistoricoDialog
+        skuDetalhe={skuDetalhe}
+        onOpenChange={(o) => !o && setSkuDetalhe(null)}
+        historico={historico}
+        loadingHist={loadingHist}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Resumo
Quebra o god-component `src/pages/AdminReposicaoSlaFornecedor.tsx` (**576→93L**) em um hook de dados/estado + componentes presentacionais controlados, sob `src/components/reposicao/slaFornecedor/`. Extração **verbatim** — comportamento preservado 1:1.

## O que mudou
- **`useSlaFornecedor`** (hook): 3 queries (`v_fornecedor_sla_compliance`, `v_sku_sla_compliance`, `sku_leadtime_history` com `enabled: !!skuDetalhe`) + memos (`grupos`/`skusFiltrados`/`fornecedoresOptions`) + `exportCsv` + `toggleStatus`.
- **`ComplianceCardsGrid`** — grid de cards de compliance global por fornecedor.
- **`SlaFiltros`** — filtros (fornecedor/tendência/grupo/busca).
- **`StatusChips`** — chips multi-select de status.
- **`SkuComplianceTable`** — tabela detalhada por SKU.
- **`SkuHistoricoDialog`** — modal com gráfico de histórico de lead time.
- **`TendenciaIcon`** — ícone de tendência.
- **`types.ts`** / **`config.ts`** (`STATUS_LABEL/VARIANT/RANK` + `fmtNum`/`fmtData`/`desvioColorClass`/`cardTone`).
- **+20 testes** (helpers puros + presentacionais).

## Verificação
- `bunx tsc --noEmit` (baseline) = **0**
- `eslint` = **0 erros / 0 warnings**
- **20/20 testes** verdes (isolados)
- Revisão independente FIEL 1:1: **aprovada** (queries/memos/exportCsv/sort/ordem de hooks conferidos)

## Migrations
Nenhuma.

🤖 Generated with [Claude Code](https://claude.com/claude-code)