### PR TITLE
refactor(reposicao): split AdminReposicaoAumentos (544→119) em hook + componentes

### DIFF
--- a/src/components/reposicao/aumentos/AtivosAguardandoBanner.tsx
+++ b/src/components/reposicao/aumentos/AtivosAguardandoBanner.tsx
@@ -1,0 +1,40 @@
+// Banner de aumentos ativos aguardando vigência.
+// Extraído verbatim de src/pages/AdminReposicaoAumentos.tsx (god-component split).
+import { TrendingUp } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+
+interface AtivosAguardandoBannerProps {
+  count: number;
+  onVerAtivos: () => void;
+}
+
+export function AtivosAguardandoBanner({ count: ativosAguardando, onVerAtivos }: AtivosAguardandoBannerProps) {
+  return (
+    <Card className="border-status-info/40 bg-status-info/5">
+      <CardContent className="flex items-center justify-between gap-3 py-4">
+        <div className="flex items-center gap-3">
+          <TrendingUp className="h-5 w-5 text-status-info" />
+          <div>
+            <p className="font-medium">
+              {ativosAguardando}{" "}
+              {ativosAguardando === 1
+                ? "aumento ativo aguardando vigência"
+                : "aumentos ativos aguardando vigência"}
+            </p>
+            <p className="text-sm text-muted-foreground">
+              Confirmados, aguardando a data de início.
+            </p>
+          </div>
+        </div>
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={onVerAtivos}
+        >
+          Ver ativos
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/reposicao/aumentos/AumentosFiltros.tsx
+++ b/src/components/reposicao/aumentos/AumentosFiltros.tsx
@@ -1,0 +1,72 @@
+// Filtros dos aumentos (fornecedor + estado + busca).
+// Extraído verbatim de src/pages/AdminReposicaoAumentos.tsx (god-component split).
+import { Search } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { ALL, ESTADOS } from "./config";
+
+interface AumentosFiltrosProps {
+  filtroFornecedor: string;
+  onFiltroFornecedorChange: (v: string) => void;
+  filtroEstado: string;
+  onFiltroEstadoChange: (v: string) => void;
+  busca: string;
+  onBuscaChange: (v: string) => void;
+  fornecedores: string[];
+}
+
+export function AumentosFiltros({
+  filtroFornecedor,
+  onFiltroFornecedorChange,
+  filtroEstado,
+  onFiltroEstadoChange,
+  busca,
+  onBuscaChange,
+  fornecedores,
+}: AumentosFiltrosProps) {
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
+      <Select value={filtroFornecedor} onValueChange={onFiltroFornecedorChange}>
+        <SelectTrigger>
+          <SelectValue placeholder="Fornecedor" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value={ALL}>Todos os fornecedores</SelectItem>
+          {fornecedores.map((f) => (
+            <SelectItem key={f} value={f}>
+              {f}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <Select value={filtroEstado} onValueChange={onFiltroEstadoChange}>
+        <SelectTrigger>
+          <SelectValue placeholder="Estado" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value={ALL}>Ativos (exceto expirado)</SelectItem>
+          {ESTADOS.map((e) => (
+            <SelectItem key={e.value} value={e.value}>
+              {e.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <div className="md:col-span-2 relative">
+        <Search className="h-4 w-4 absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          placeholder="Buscar por nome…"
+          className="pl-9"
+          value={busca}
+          onChange={(e) => onBuscaChange(e.target.value)}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/reposicao/aumentos/AumentosGrupos.tsx
+++ b/src/components/reposicao/aumentos/AumentosGrupos.tsx
@@ -1,0 +1,147 @@
+// Lista de aumentos agrupada por mês (colapsável) + estados de loading/empty.
+// Extraído verbatim de src/pages/AdminReposicaoAumentos.tsx (god-component split).
+import { Loader2, Upload, ChevronDown, ChevronRight } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import type { GrupoMensal } from "@/lib/agruparPorMes";
+import { ESTADOS, estadoBadgeClass, formatDate } from "./config";
+import type { AumentoComAgg } from "./types";
+
+interface AumentosGruposProps {
+  isLoading: boolean;
+  grupos: GrupoMensal<AumentoComAgg>[];
+  isCollapsed: (chave: string) => boolean;
+  onToggleMes: (chave: string) => void;
+  onUploadClick: () => void;
+  onRowClick: (id: number) => void;
+}
+
+export function AumentosGrupos({
+  isLoading,
+  grupos,
+  isCollapsed,
+  onToggleMes,
+  onUploadClick,
+  onRowClick,
+}: AumentosGruposProps) {
+  if (isLoading) {
+    return (
+      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+        <Loader2 className="h-4 w-4 animate-spin" /> Carregando…
+      </div>
+    );
+  }
+
+  if (grupos.length === 0) {
+    return (
+      <div className="text-center text-muted-foreground py-12 text-sm">
+        Nenhum aumento cadastrado ainda.
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto space-y-4">
+      {grupos.map((grupo) => {
+        const collapsed = isCollapsed(grupo.chave);
+        return (
+          <div key={grupo.chave} className="rounded-md border">
+            <button
+              type="button"
+              onClick={() => onToggleMes(grupo.chave)}
+              className="w-full flex items-center justify-between gap-2 px-3 py-2 bg-muted/40 hover:bg-muted/60 transition-colors text-left"
+            >
+              <div className="flex items-center gap-2">
+                {collapsed ? (
+                  <ChevronRight className="h-4 w-4 text-muted-foreground" />
+                ) : (
+                  <ChevronDown className="h-4 w-4 text-muted-foreground" />
+                )}
+                <span className="font-semibold text-sm">{grupo.label}</span>
+                <Badge variant="outline" className="text-xs">
+                  {grupo.itens.length}{" "}
+                  {grupo.itens.length === 1 ? "aumento" : "aumentos"}
+                </Badge>
+              </div>
+            </button>
+
+            {!collapsed && (
+              grupo.vazio ? (
+                <div className="flex items-center justify-between gap-3 px-3 py-4 text-sm">
+                  <span className="text-muted-foreground">
+                    Nenhum aumento cadastrado neste mês.
+                  </span>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={onUploadClick}
+                  >
+                    <Upload className="h-3.5 w-3.5" /> Upload PDF
+                  </Button>
+                </div>
+              ) : (
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Nome</TableHead>
+                      <TableHead>Fornecedor</TableHead>
+                      <TableHead>Vigência</TableHead>
+                      <TableHead>Anúncio</TableHead>
+                      <TableHead className="text-right">Categorias</TableHead>
+                      <TableHead className="text-right">% médio</TableHead>
+                      <TableHead>Estado</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {grupo.itens.map((a) => (
+                      <TableRow
+                        key={a.id}
+                        className="cursor-pointer"
+                        onClick={() => onRowClick(a.id)}
+                      >
+                        <TableCell className="font-medium">{a.nome}</TableCell>
+                        <TableCell className="text-muted-foreground">
+                          {a.fornecedor_nome}
+                        </TableCell>
+                        <TableCell className="tabular-nums text-sm">
+                          {formatDate(a.data_vigencia)}
+                        </TableCell>
+                        <TableCell className="tabular-nums text-sm text-muted-foreground">
+                          {formatDate(a.data_anuncio)}
+                        </TableCell>
+                        <TableCell className="text-right tabular-nums font-medium">
+                          {a.num_categorias}
+                        </TableCell>
+                        <TableCell className="text-right tabular-nums">
+                          {a.perc_medio !== null
+                            ? `${a.perc_medio.toFixed(2)}%`
+                            : "—"}
+                        </TableCell>
+                        <TableCell>
+                          <Badge
+                            variant="outline"
+                            className={estadoBadgeClass(a.estado)}
+                          >
+                            {ESTADOS.find((e) => e.value === a.estado)?.label ?? a.estado}
+                          </Badge>
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              )
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/reposicao/aumentos/UploadDialog.tsx
+++ b/src/components/reposicao/aumentos/UploadDialog.tsx
@@ -1,0 +1,84 @@
+// Modal de upload/extração de anúncio de aumento (PDF/imagem → Gemini Vision).
+// Extraído verbatim de src/pages/AdminReposicaoAumentos.tsx (god-component split).
+import { Loader2, FileText } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+
+interface UploadDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  arquivo: File | null;
+  onFileChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onCancel: () => void;
+  onExtrair: () => void;
+  extraindo: boolean;
+  fileInputRef: React.RefObject<HTMLInputElement>;
+}
+
+export function UploadDialog({
+  open,
+  onOpenChange,
+  arquivo,
+  onFileChange,
+  onCancel,
+  onExtrair,
+  extraindo,
+  fileInputRef,
+}: UploadDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Upload de anúncio de aumento</DialogTitle>
+          <DialogDescription>
+            Selecione um PDF ou imagem do comunicado. A IA vai extrair nome,
+            data de vigência e categorias com percentual de aumento.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3">
+          <Input
+            ref={fileInputRef}
+            type="file"
+            accept=".pdf,.png,.jpg,.jpeg,application/pdf,image/png,image/jpeg"
+            onChange={onFileChange}
+            disabled={extraindo}
+          />
+          {arquivo && (
+            <div className="flex items-center gap-2 rounded-md border bg-muted/40 p-3 text-sm">
+              <FileText className="h-4 w-4 text-muted-foreground shrink-0" />
+              <div className="min-w-0 flex-1">
+                <p className="truncate font-medium">{arquivo.name}</p>
+                <p className="text-xs text-muted-foreground">
+                  {(arquivo.size / 1024).toFixed(1)} KB
+                </p>
+              </div>
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button
+            variant="ghost"
+            onClick={onCancel}
+            disabled={extraindo}
+          >
+            Cancelar
+          </Button>
+          <Button onClick={onExtrair} disabled={!arquivo || extraindo}>
+            {extraindo && <Loader2 className="h-4 w-4 animate-spin" />}
+            Extrair
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/reposicao/aumentos/__tests__/AtivosAguardandoBanner.test.tsx
+++ b/src/components/reposicao/aumentos/__tests__/AtivosAguardandoBanner.test.tsx
@@ -1,0 +1,22 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { AtivosAguardandoBanner } from "../AtivosAguardandoBanner";
+
+describe("AtivosAguardandoBanner", () => {
+  it("usa singular quando count é 1", () => {
+    render(<AtivosAguardandoBanner count={1} onVerAtivos={vi.fn()} />);
+    expect(screen.getByText("1 aumento ativo aguardando vigência")).toBeTruthy();
+  });
+
+  it("usa plural quando count > 1", () => {
+    render(<AtivosAguardandoBanner count={3} onVerAtivos={vi.fn()} />);
+    expect(screen.getByText("3 aumentos ativos aguardando vigência")).toBeTruthy();
+  });
+
+  it("dispara onVerAtivos ao clicar em Ver ativos", () => {
+    const onVerAtivos = vi.fn();
+    render(<AtivosAguardandoBanner count={2} onVerAtivos={onVerAtivos} />);
+    fireEvent.click(screen.getByRole("button", { name: "Ver ativos" }));
+    expect(onVerAtivos).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/reposicao/aumentos/__tests__/AumentosFiltros.test.tsx
+++ b/src/components/reposicao/aumentos/__tests__/AumentosFiltros.test.tsx
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { AumentosFiltros } from "../AumentosFiltros";
+
+function setup(overrides: Partial<React.ComponentProps<typeof AumentosFiltros>> = {}) {
+  const props: React.ComponentProps<typeof AumentosFiltros> = {
+    filtroFornecedor: "__all__",
+    onFiltroFornecedorChange: vi.fn(),
+    filtroEstado: "__all__",
+    onFiltroEstadoChange: vi.fn(),
+    busca: "",
+    onBuscaChange: vi.fn(),
+    fornecedores: ["RENNER SAYERLACK S/A", "Outro Forn"],
+    ...overrides,
+  };
+  render(<AumentosFiltros {...props} />);
+  return props;
+}
+
+describe("AumentosFiltros", () => {
+  it("renderiza o campo de busca", () => {
+    setup();
+    expect(screen.getByPlaceholderText("Buscar por nome…")).toBeTruthy();
+  });
+
+  it("dispara onBuscaChange ao digitar", () => {
+    const props = setup();
+    fireEvent.change(screen.getByPlaceholderText("Buscar por nome…"), { target: { value: "verniz" } });
+    expect(props.onBuscaChange).toHaveBeenCalledWith("verniz");
+  });
+});

--- a/src/components/reposicao/aumentos/__tests__/AumentosGrupos.test.tsx
+++ b/src/components/reposicao/aumentos/__tests__/AumentosGrupos.test.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { AumentosGrupos } from "../AumentosGrupos";
+import type { GrupoMensal } from "@/lib/agruparPorMes";
+import type { AumentoComAgg } from "../types";
+
+function makeAumento(o: Partial<AumentoComAgg> = {}): AumentoComAgg {
+  return {
+    id: 1,
+    nome: "Reajuste X",
+    fornecedor_nome: "RENNER",
+    data_vigencia: "2026-04-01",
+    data_anuncio: "2026-03-01",
+    estado: "vigente",
+    extracao_confianca: null,
+    criado_em: "2026-03-01",
+    num_categorias: 5,
+    perc_medio: 12.5,
+    ...o,
+  };
+}
+
+const grupoCheio: GrupoMensal<AumentoComAgg> = {
+  chave: "2026-04",
+  label: "Abril 2026",
+  itens: [makeAumento()],
+  vazio: false,
+};
+
+const grupoVazio: GrupoMensal<AumentoComAgg> = {
+  chave: "2026-03",
+  label: "Março 2026",
+  itens: [],
+  vazio: true,
+};
+
+function setup(overrides: Partial<React.ComponentProps<typeof AumentosGrupos>> = {}) {
+  const props: React.ComponentProps<typeof AumentosGrupos> = {
+    isLoading: false,
+    grupos: [grupoCheio],
+    isCollapsed: () => false,
+    onToggleMes: vi.fn(),
+    onUploadClick: vi.fn(),
+    onRowClick: vi.fn(),
+    ...overrides,
+  };
+  render(<AumentosGrupos {...props} />);
+  return props;
+}
+
+describe("AumentosGrupos", () => {
+  it("mostra loading", () => {
+    setup({ isLoading: true });
+    expect(screen.getByText("Carregando…")).toBeTruthy();
+  });
+
+  it("mostra empty state sem grupos", () => {
+    setup({ grupos: [] });
+    expect(screen.getByText("Nenhum aumento cadastrado ainda.")).toBeTruthy();
+  });
+
+  it("renderiza linha do aumento e % médio formatado", () => {
+    setup();
+    expect(screen.getByText("Reajuste X")).toBeTruthy();
+    expect(screen.getByText("12.50%")).toBeTruthy();
+    expect(screen.getByText("Vigente")).toBeTruthy();
+    expect(screen.getByText("1 aumento")).toBeTruthy();
+  });
+
+  it("dispara onRowClick ao clicar na linha", () => {
+    const props = setup();
+    fireEvent.click(screen.getByText("Reajuste X"));
+    expect(props.onRowClick).toHaveBeenCalledWith(1);
+  });
+
+  it("dispara onToggleMes ao clicar no header do mês", () => {
+    const props = setup();
+    fireEvent.click(screen.getByText("Abril 2026"));
+    expect(props.onToggleMes).toHaveBeenCalledWith("2026-04");
+  });
+
+  it("oculta a tabela quando o mês está colapsado", () => {
+    setup({ isCollapsed: () => true });
+    expect(screen.getByText("Abril 2026")).toBeTruthy();
+    expect(screen.queryByText("Reajuste X")).toBeNull();
+  });
+
+  it("mês vazio mostra CTA de upload", () => {
+    const props = setup({ grupos: [grupoVazio] });
+    expect(screen.getByText("Nenhum aumento cadastrado neste mês.")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: /Upload PDF/ }));
+    expect(props.onUploadClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/reposicao/aumentos/__tests__/UploadDialog.test.tsx
+++ b/src/components/reposicao/aumentos/__tests__/UploadDialog.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi } from "vitest";
+import { createRef } from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { UploadDialog } from "../UploadDialog";
+
+function setup(overrides: Partial<React.ComponentProps<typeof UploadDialog>> = {}) {
+  const props: React.ComponentProps<typeof UploadDialog> = {
+    open: true,
+    onOpenChange: vi.fn(),
+    arquivo: null,
+    onFileChange: vi.fn(),
+    onCancel: vi.fn(),
+    onExtrair: vi.fn(),
+    extraindo: false,
+    fileInputRef: createRef<HTMLInputElement>(),
+    ...overrides,
+  };
+  render(<UploadDialog {...props} />);
+  return props;
+}
+
+describe("UploadDialog", () => {
+  it("não renderiza conteúdo quando fechado", () => {
+    setup({ open: false });
+    expect(screen.queryByText("Upload de anúncio de aumento")).toBeNull();
+  });
+
+  it("Extrair desabilitado sem arquivo", () => {
+    setup();
+    expect(screen.getByRole("button", { name: /Extrair/ })).toHaveProperty("disabled", true);
+  });
+
+  it("mostra o arquivo selecionado e habilita Extrair", () => {
+    const arquivo = new File(["x".repeat(2048)], "anuncio.pdf", { type: "application/pdf" });
+    setup({ arquivo });
+    expect(screen.getByText("anuncio.pdf")).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Extrair/ })).toHaveProperty("disabled", false);
+  });
+
+  it("dispara onExtrair e onCancel", () => {
+    const arquivo = new File(["x".repeat(2048)], "anuncio.pdf", { type: "application/pdf" });
+    const props = setup({ arquivo });
+    fireEvent.click(screen.getByRole("button", { name: /Extrair/ }));
+    fireEvent.click(screen.getByRole("button", { name: "Cancelar" }));
+    expect(props.onExtrair).toHaveBeenCalledTimes(1);
+    expect(props.onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("desabilita botões durante extração", () => {
+    const arquivo = new File(["x".repeat(2048)], "anuncio.pdf", { type: "application/pdf" });
+    setup({ arquivo, extraindo: true });
+    expect(screen.getByRole("button", { name: /Extrair/ })).toHaveProperty("disabled", true);
+    expect(screen.getByRole("button", { name: "Cancelar" })).toHaveProperty("disabled", true);
+  });
+});

--- a/src/components/reposicao/aumentos/__tests__/config.test.ts
+++ b/src/components/reposicao/aumentos/__tests__/config.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from "vitest";
+import { estadoBadgeClass, formatDate } from "../config";
+
+describe("aumentos/config", () => {
+  it("formatDate trata null e formata DD/MM/AA", () => {
+    expect(formatDate(null)).toBe("—");
+    expect(formatDate("2026-04-15")).toBe("15/04/26");
+  });
+
+  it("estadoBadgeClass por estado", () => {
+    expect(estadoBadgeClass("ativo")).toContain("status-info");
+    expect(estadoBadgeClass("vigente")).toContain("status-success");
+    expect(estadoBadgeClass("rascunho")).toContain("status-warning");
+    expect(estadoBadgeClass("cancelado")).toContain("destructive");
+    expect(estadoBadgeClass("expirado")).toBe("bg-muted text-muted-foreground border-border");
+    expect(estadoBadgeClass("desconhecido")).toBe("");
+  });
+});

--- a/src/components/reposicao/aumentos/config.ts
+++ b/src/components/reposicao/aumentos/config.ts
@@ -1,0 +1,37 @@
+// Constantes e helpers dos aumentos anunciados.
+// Extraídos verbatim de src/pages/AdminReposicaoAumentos.tsx (god-component split).
+
+export const EMPRESA = "OBEN";
+export const FORNECEDOR_DEFAULT = "RENNER SAYERLACK S/A";
+export const ALL = "__all__";
+
+export const ESTADOS: Array<{ value: string; label: string }> = [
+  { value: "rascunho", label: "Rascunho" },
+  { value: "ativo", label: "Ativo" },
+  { value: "vigente", label: "Vigente" },
+  { value: "expirado", label: "Expirado" },
+  { value: "cancelado", label: "Cancelado" },
+];
+
+export function estadoBadgeClass(estado: string): string {
+  switch (estado) {
+    case "rascunho":
+      return "bg-status-warning/15 text-status-warning border-status-warning/30";
+    case "ativo":
+      return "bg-status-info/15 text-status-info border-status-info/30";
+    case "vigente":
+      return "bg-status-success/15 text-status-success border-status-success/30";
+    case "expirado":
+      return "bg-muted text-muted-foreground border-border";
+    case "cancelado":
+      return "bg-destructive/15 text-destructive border-destructive/30";
+    default:
+      return "";
+  }
+}
+
+export function formatDate(d: string | null): string {
+  if (!d) return "—";
+  const [y, m, day] = d.split("-");
+  return `${day}/${m}/${y.slice(2)}`;
+}

--- a/src/components/reposicao/aumentos/types.ts
+++ b/src/components/reposicao/aumentos/types.ts
@@ -1,0 +1,27 @@
+// Tipos dos aumentos anunciados.
+// Extraídos verbatim de src/pages/AdminReposicaoAumentos.tsx (god-component split).
+
+export type Aumento = {
+  id: number;
+  nome: string;
+  fornecedor_nome: string;
+  data_vigencia: string;
+  data_anuncio: string | null;
+  estado: string;
+  extracao_confianca: number | null;
+  criado_em: string;
+};
+
+export type AumentoComAgg = Aumento & {
+  num_categorias: number;
+  perc_medio: number | null;
+};
+
+export type FornecedorRow = { fornecedor_nome: string | null };
+
+export type AumentoItemAgg = {
+  aumento_id: number;
+  aumento_perc: number | null;
+  ativo: boolean | null;
+  confirmado: boolean | null;
+};

--- a/src/components/reposicao/aumentos/useAumentos.ts
+++ b/src/components/reposicao/aumentos/useAumentos.ts
@@ -1,0 +1,211 @@
+// Hook de dados/estado dos aumentos anunciados.
+// Extraído verbatim de src/pages/AdminReposicaoAumentos.tsx (god-component split):
+// 2 queries (fornecedores + aumentos com agregação de itens), memos de agrupamento
+// por mês e handlers do upload/extração via Gemini Vision.
+import { useState, useRef, useMemo, useCallback } from "react";
+import { useNavigate } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import { supabase } from "@/integrations/supabase/client";
+import { toast } from "sonner";
+import { agruparPorMes, chavesUltimosNMeses } from "@/lib/agruparPorMes";
+import { EMPRESA, FORNECEDOR_DEFAULT, ALL } from "./config";
+import type { Aumento, AumentoComAgg, FornecedorRow, AumentoItemAgg } from "./types";
+
+export function useAumentos() {
+  const navigate = useNavigate();
+
+  const [filtroFornecedor, setFiltroFornecedor] = useState<string>(ALL);
+  const [filtroEstado, setFiltroEstado] = useState<string>(ALL);
+  const [busca, setBusca] = useState("");
+
+  // Upload modal
+  const [uploadOpen, setUploadOpen] = useState(false);
+  const [arquivo, setArquivo] = useState<File | null>(null);
+  const [extraindo, setExtraindo] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // ============ QUERIES ============
+  const { data: fornecedores = [] } = useQuery({
+    queryKey: ["aumentos-fornecedores"],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from("fornecedor_aumento_anunciado")
+        .select("fornecedor_nome")
+        .eq("empresa", EMPRESA);
+      if (error) throw error;
+      const rows = (data || []) as unknown as FornecedorRow[];
+      const uniq = Array.from(
+        new Set(rows.map((r) => r.fornecedor_nome).filter((n): n is string => Boolean(n))),
+      );
+      return uniq.sort();
+    },
+  });
+
+  const { data: aumentos = [], isLoading } = useQuery({
+    queryKey: ["aumentos", filtroFornecedor, filtroEstado, busca],
+    queryFn: async () => {
+      let q = supabase
+        .from("fornecedor_aumento_anunciado")
+        .select(
+          "id, nome, fornecedor_nome, data_vigencia, data_anuncio, estado, extracao_confianca, criado_em",
+        )
+        .eq("empresa", EMPRESA)
+        .order("criado_em", { ascending: false });
+
+      if (filtroFornecedor !== ALL) q = q.eq("fornecedor_nome", filtroFornecedor);
+      if (filtroEstado !== ALL) {
+        q = q.eq("estado", filtroEstado);
+      } else {
+        // default: todos exceto expirado
+        q = q.neq("estado", "expirado");
+      }
+      if (busca.trim()) q = q.ilike("nome", `%${busca.trim()}%`);
+
+      const { data, error } = await q;
+      if (error) throw error;
+      const rows = (data || []) as unknown as Aumento[];
+
+      // Aggregate items: count + avg(perc) onde ativo=true e confirmado=true
+      const ids = rows.map((r) => r.id);
+      const counts: Record<number, number> = {};
+      const sums: Record<number, { sum: number; n: number }> = {};
+      if (ids.length > 0) {
+        const { data: itens } = await supabase
+          .from("fornecedor_aumento_item")
+          .select("aumento_id, aumento_perc, ativo, confirmado")
+          .in("aumento_id", ids)
+          .eq("ativo", true);
+        ((itens || []) as unknown as AumentoItemAgg[]).forEach((it) => {
+          counts[it.aumento_id] = (counts[it.aumento_id] || 0) + 1;
+          if (it.confirmado && typeof it.aumento_perc === "number") {
+            const s = sums[it.aumento_id] || { sum: 0, n: 0 };
+            s.sum += Number(it.aumento_perc);
+            s.n += 1;
+            sums[it.aumento_id] = s;
+          }
+        });
+      }
+
+      return rows.map<AumentoComAgg>((r) => ({
+        ...r,
+        num_categorias: counts[r.id] || 0,
+        perc_medio: sums[r.id] ? sums[r.id].sum / sums[r.id].n : null,
+      }));
+    },
+  });
+
+  const ativosAguardando = useMemo(
+    () => aumentos.filter((a) => a.estado === "ativo").length,
+    [aumentos],
+  );
+
+  // Agrupa aumentos por mês (data_vigencia)
+  const grupos = useMemo(
+    () => agruparPorMes(aumentos, (a) => a.data_vigencia),
+    [aumentos],
+  );
+
+  const [collapsedMeses, setCollapsedMeses] = useState<Record<string, boolean>>({});
+  const ultimos3 = useMemo(() => chavesUltimosNMeses(3), []);
+  const isCollapsed = useCallback(
+    (chave: string) =>
+      chave in collapsedMeses ? collapsedMeses[chave] : !ultimos3.has(chave),
+    [collapsedMeses, ultimos3],
+  );
+  const toggleMes = useCallback((chave: string) => {
+    setCollapsedMeses((prev) => ({ ...prev, [chave]: !(prev[chave] ?? false) }));
+  }, []);
+
+  // ============ HANDLERS ============
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0] ?? null;
+    setArquivo(file);
+  };
+
+  const resetUpload = () => {
+    setArquivo(null);
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  };
+
+  const handleExtrair = async () => {
+    if (!arquivo) return;
+    setExtraindo(true);
+    try {
+      const base64 = await new Promise<string>((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => {
+          const result = reader.result as string;
+          const idx = result.indexOf(",");
+          resolve(idx >= 0 ? result.slice(idx + 1) : result);
+        };
+        reader.onerror = () => reject(reader.error);
+        reader.readAsDataURL(arquivo);
+      });
+
+      const arquivo_tipo =
+        arquivo.type === "application/pdf" ? "pdf" : arquivo.type;
+
+      toast.info("Extraindo dados via Gemini Vision…");
+
+      const { data, error } = await supabase.functions.invoke(
+        "promocao-extrair-via-vision",
+        {
+          body: {
+            tipo_documento: "aumento",
+            empresa: EMPRESA,
+            fornecedor_nome: FORNECEDOR_DEFAULT,
+            arquivo_tipo,
+            arquivo_base64: base64,
+          },
+        },
+      );
+
+      if (error) throw error;
+      if (data?.error) throw new Error(data.error);
+
+      const cat = data?.extracao?.categorias_extraidas ?? 0;
+      const conf = data?.extracao?.confianca;
+      const confTxt =
+        typeof conf === "number" ? ` · confiança ${Math.round(conf * 100)}%` : "";
+      toast.success(
+        `${cat} ${cat === 1 ? "categoria extraída" : "categorias extraídas"}${confTxt}`,
+      );
+
+      setUploadOpen(false);
+      resetUpload();
+
+      if (data?.aumento_id) {
+        navigate(`/admin/reposicao/aumentos/${data.aumento_id}`);
+      }
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : "Erro ao extrair aumento";
+      toast.error(msg);
+    } finally {
+      setExtraindo(false);
+    }
+  };
+
+  return {
+    fornecedores,
+    aumentos,
+    isLoading,
+    ativosAguardando,
+    grupos,
+    isCollapsed,
+    toggleMes,
+    filtroFornecedor,
+    setFiltroFornecedor,
+    filtroEstado,
+    setFiltroEstado,
+    busca,
+    setBusca,
+    uploadOpen,
+    setUploadOpen,
+    arquivo,
+    extraindo,
+    fileInputRef,
+    handleFileChange,
+    resetUpload,
+    handleExtrair,
+  };
+}

--- a/src/pages/AdminReposicaoAumentos.tsx
+++ b/src/pages/AdminReposicaoAumentos.tsx
@@ -1,280 +1,41 @@
-import { useState, useRef, useMemo, useCallback } from "react";
+// Aumentos anunciados — reajustes de preços anunciados pelos fornecedores.
+// Composição: useAumentos (dados/filtros/upload) + banner + filtros + grupos + modal.
+// God-component split de src/pages/AdminReposicaoAumentos.tsx (comportamento 1:1).
 import { useNavigate } from "react-router-dom";
-import { useQuery } from "@tanstack/react-query";
-import { supabase } from "@/integrations/supabase/client";
-import { toast } from "sonner";
-import {
-  TrendingUp,
-  Search,
-  Loader2,
-  Upload,
-  FilePlus,
-  FileText,
-  ChevronDown,
-  ChevronRight,
-} from "lucide-react";
-import { agruparPorMes, chavesUltimosNMeses } from "@/lib/agruparPorMes";
+import { TrendingUp, Upload, FilePlus } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import { Input } from "@/components/ui/input";
-import {
-  Dialog,
-  DialogContent,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-  DialogDescription,
-} from "@/components/ui/dialog";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
-
-const EMPRESA = "OBEN";
-const FORNECEDOR_DEFAULT = "RENNER SAYERLACK S/A";
-const ALL = "__all__";
-
-type Aumento = {
-  id: number;
-  nome: string;
-  fornecedor_nome: string;
-  data_vigencia: string;
-  data_anuncio: string | null;
-  estado: string;
-  extracao_confianca: number | null;
-  criado_em: string;
-};
-
-type AumentoComAgg = Aumento & {
-  num_categorias: number;
-  perc_medio: number | null;
-};
-
-type FornecedorRow = { fornecedor_nome: string | null };
-
-type AumentoItemAgg = {
-  aumento_id: number;
-  aumento_perc: number | null;
-  ativo: boolean | null;
-  confirmado: boolean | null;
-};
-
-const ESTADOS: Array<{ value: string; label: string }> = [
-  { value: "rascunho", label: "Rascunho" },
-  { value: "ativo", label: "Ativo" },
-  { value: "vigente", label: "Vigente" },
-  { value: "expirado", label: "Expirado" },
-  { value: "cancelado", label: "Cancelado" },
-];
-
-function estadoBadgeClass(estado: string): string {
-  switch (estado) {
-    case "rascunho":
-      return "bg-status-warning/15 text-status-warning border-status-warning/30";
-    case "ativo":
-      return "bg-status-info/15 text-status-info border-status-info/30";
-    case "vigente":
-      return "bg-status-success/15 text-status-success border-status-success/30";
-    case "expirado":
-      return "bg-muted text-muted-foreground border-border";
-    case "cancelado":
-      return "bg-destructive/15 text-destructive border-destructive/30";
-    default:
-      return "";
-  }
-}
-
-function formatDate(d: string | null): string {
-  if (!d) return "—";
-  const [y, m, day] = d.split("-");
-  return `${day}/${m}/${y.slice(2)}`;
-}
+import { useAumentos } from "@/components/reposicao/aumentos/useAumentos";
+import { AtivosAguardandoBanner } from "@/components/reposicao/aumentos/AtivosAguardandoBanner";
+import { AumentosFiltros } from "@/components/reposicao/aumentos/AumentosFiltros";
+import { AumentosGrupos } from "@/components/reposicao/aumentos/AumentosGrupos";
+import { UploadDialog } from "@/components/reposicao/aumentos/UploadDialog";
 
 export default function AdminReposicaoAumentos() {
   const navigate = useNavigate();
 
-  const [filtroFornecedor, setFiltroFornecedor] = useState<string>(ALL);
-  const [filtroEstado, setFiltroEstado] = useState<string>(ALL);
-  const [busca, setBusca] = useState("");
-
-  // Upload modal
-  const [uploadOpen, setUploadOpen] = useState(false);
-  const [arquivo, setArquivo] = useState<File | null>(null);
-  const [extraindo, setExtraindo] = useState(false);
-  const fileInputRef = useRef<HTMLInputElement>(null);
-
-  // ============ QUERIES ============
-  const { data: fornecedores = [] } = useQuery({
-    queryKey: ["aumentos-fornecedores"],
-    queryFn: async () => {
-      const { data, error } = await supabase
-        .from("fornecedor_aumento_anunciado")
-        .select("fornecedor_nome")
-        .eq("empresa", EMPRESA);
-      if (error) throw error;
-      const rows = (data || []) as unknown as FornecedorRow[];
-      const uniq = Array.from(
-        new Set(rows.map((r) => r.fornecedor_nome).filter((n): n is string => Boolean(n))),
-      );
-      return uniq.sort();
-    },
-  });
-
-  const { data: aumentos = [], isLoading } = useQuery({
-    queryKey: ["aumentos", filtroFornecedor, filtroEstado, busca],
-    queryFn: async () => {
-      let q = supabase
-        .from("fornecedor_aumento_anunciado")
-        .select(
-          "id, nome, fornecedor_nome, data_vigencia, data_anuncio, estado, extracao_confianca, criado_em",
-        )
-        .eq("empresa", EMPRESA)
-        .order("criado_em", { ascending: false });
-
-      if (filtroFornecedor !== ALL) q = q.eq("fornecedor_nome", filtroFornecedor);
-      if (filtroEstado !== ALL) {
-        q = q.eq("estado", filtroEstado);
-      } else {
-        // default: todos exceto expirado
-        q = q.neq("estado", "expirado");
-      }
-      if (busca.trim()) q = q.ilike("nome", `%${busca.trim()}%`);
-
-      const { data, error } = await q;
-      if (error) throw error;
-      const rows = (data || []) as unknown as Aumento[];
-
-      // Aggregate items: count + avg(perc) onde ativo=true e confirmado=true
-      const ids = rows.map((r) => r.id);
-      const counts: Record<number, number> = {};
-      const sums: Record<number, { sum: number; n: number }> = {};
-      if (ids.length > 0) {
-        const { data: itens } = await supabase
-          .from("fornecedor_aumento_item")
-          .select("aumento_id, aumento_perc, ativo, confirmado")
-          .in("aumento_id", ids)
-          .eq("ativo", true);
-        ((itens || []) as unknown as AumentoItemAgg[]).forEach((it) => {
-          counts[it.aumento_id] = (counts[it.aumento_id] || 0) + 1;
-          if (it.confirmado && typeof it.aumento_perc === "number") {
-            const s = sums[it.aumento_id] || { sum: 0, n: 0 };
-            s.sum += Number(it.aumento_perc);
-            s.n += 1;
-            sums[it.aumento_id] = s;
-          }
-        });
-      }
-
-      return rows.map<AumentoComAgg>((r) => ({
-        ...r,
-        num_categorias: counts[r.id] || 0,
-        perc_medio: sums[r.id] ? sums[r.id].sum / sums[r.id].n : null,
-      }));
-    },
-  });
-
-  const ativosAguardando = useMemo(
-    () => aumentos.filter((a) => a.estado === "ativo").length,
-    [aumentos],
-  );
-
-  // Agrupa aumentos por mês (data_vigencia)
-  const grupos = useMemo(
-    () => agruparPorMes(aumentos, (a) => a.data_vigencia),
-    [aumentos],
-  );
-
-  const [collapsedMeses, setCollapsedMeses] = useState<Record<string, boolean>>({});
-  const ultimos3 = useMemo(() => chavesUltimosNMeses(3), []);
-  const isCollapsed = useCallback(
-    (chave: string) =>
-      chave in collapsedMeses ? collapsedMeses[chave] : !ultimos3.has(chave),
-    [collapsedMeses, ultimos3],
-  );
-  const toggleMes = useCallback((chave: string) => {
-    setCollapsedMeses((prev) => ({ ...prev, [chave]: !(prev[chave] ?? false) }));
-  }, []);
-
-  // ============ HANDLERS ============
-  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0] ?? null;
-    setArquivo(file);
-  };
-
-  const resetUpload = () => {
-    setArquivo(null);
-    if (fileInputRef.current) fileInputRef.current.value = "";
-  };
-
-  const handleExtrair = async () => {
-    if (!arquivo) return;
-    setExtraindo(true);
-    try {
-      const base64 = await new Promise<string>((resolve, reject) => {
-        const reader = new FileReader();
-        reader.onload = () => {
-          const result = reader.result as string;
-          const idx = result.indexOf(",");
-          resolve(idx >= 0 ? result.slice(idx + 1) : result);
-        };
-        reader.onerror = () => reject(reader.error);
-        reader.readAsDataURL(arquivo);
-      });
-
-      const arquivo_tipo =
-        arquivo.type === "application/pdf" ? "pdf" : arquivo.type;
-
-      toast.info("Extraindo dados via Gemini Vision…");
-
-      const { data, error } = await supabase.functions.invoke(
-        "promocao-extrair-via-vision",
-        {
-          body: {
-            tipo_documento: "aumento",
-            empresa: EMPRESA,
-            fornecedor_nome: FORNECEDOR_DEFAULT,
-            arquivo_tipo,
-            arquivo_base64: base64,
-          },
-        },
-      );
-
-      if (error) throw error;
-      if (data?.error) throw new Error(data.error);
-
-      const cat = data?.extracao?.categorias_extraidas ?? 0;
-      const conf = data?.extracao?.confianca;
-      const confTxt =
-        typeof conf === "number" ? ` · confiança ${Math.round(conf * 100)}%` : "";
-      toast.success(
-        `${cat} ${cat === 1 ? "categoria extraída" : "categorias extraídas"}${confTxt}`,
-      );
-
-      setUploadOpen(false);
-      resetUpload();
-
-      if (data?.aumento_id) {
-        navigate(`/admin/reposicao/aumentos/${data.aumento_id}`);
-      }
-    } catch (e: unknown) {
-      const msg = e instanceof Error ? e.message : "Erro ao extrair aumento";
-      toast.error(msg);
-    } finally {
-      setExtraindo(false);
-    }
-  };
+  const {
+    fornecedores,
+    isLoading,
+    ativosAguardando,
+    grupos,
+    isCollapsed,
+    toggleMes,
+    filtroFornecedor,
+    setFiltroFornecedor,
+    filtroEstado,
+    setFiltroEstado,
+    busca,
+    setBusca,
+    uploadOpen,
+    setUploadOpen,
+    arquivo,
+    extraindo,
+    fileInputRef,
+    handleFileChange,
+    resetUpload,
+    handleExtrair,
+  } = useAumentos();
 
   return (
     <div className="container mx-auto p-4 sm:p-6 space-y-6 max-w-7xl">
@@ -303,31 +64,10 @@ export default function AdminReposicaoAumentos() {
       </header>
 
       {ativosAguardando > 0 && filtroEstado !== "ativo" && (
-        <Card className="border-status-info/40 bg-status-info/5">
-          <CardContent className="flex items-center justify-between gap-3 py-4">
-            <div className="flex items-center gap-3">
-              <TrendingUp className="h-5 w-5 text-status-info" />
-              <div>
-                <p className="font-medium">
-                  {ativosAguardando}{" "}
-                  {ativosAguardando === 1
-                    ? "aumento ativo aguardando vigência"
-                    : "aumentos ativos aguardando vigência"}
-                </p>
-                <p className="text-sm text-muted-foreground">
-                  Confirmados, aguardando a data de início.
-                </p>
-              </div>
-            </div>
-            <Button
-              size="sm"
-              variant="outline"
-              onClick={() => setFiltroEstado("ativo")}
-            >
-              Ver ativos
-            </Button>
-          </CardContent>
-        </Card>
+        <AtivosAguardandoBanner
+          count={ativosAguardando}
+          onVerAtivos={() => setFiltroEstado("ativo")}
+        />
       )}
 
       <Card>
@@ -335,154 +75,28 @@ export default function AdminReposicaoAumentos() {
           <CardTitle className="text-base">Anúncios</CardTitle>
         </CardHeader>
         <CardContent className="space-y-4">
-          <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-            <Select value={filtroFornecedor} onValueChange={setFiltroFornecedor}>
-              <SelectTrigger>
-                <SelectValue placeholder="Fornecedor" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value={ALL}>Todos os fornecedores</SelectItem>
-                {fornecedores.map((f) => (
-                  <SelectItem key={f} value={f}>
-                    {f}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-            <Select value={filtroEstado} onValueChange={setFiltroEstado}>
-              <SelectTrigger>
-                <SelectValue placeholder="Estado" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value={ALL}>Ativos (exceto expirado)</SelectItem>
-                {ESTADOS.map((e) => (
-                  <SelectItem key={e.value} value={e.value}>
-                    {e.label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-            <div className="md:col-span-2 relative">
-              <Search className="h-4 w-4 absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground" />
-              <Input
-                placeholder="Buscar por nome…"
-                className="pl-9"
-                value={busca}
-                onChange={(e) => setBusca(e.target.value)}
-              />
-            </div>
-          </div>
+          <AumentosFiltros
+            filtroFornecedor={filtroFornecedor}
+            onFiltroFornecedorChange={setFiltroFornecedor}
+            filtroEstado={filtroEstado}
+            onFiltroEstadoChange={setFiltroEstado}
+            busca={busca}
+            onBuscaChange={setBusca}
+            fornecedores={fornecedores}
+          />
 
-          {isLoading ? (
-            <div className="flex items-center gap-2 text-sm text-muted-foreground">
-              <Loader2 className="h-4 w-4 animate-spin" /> Carregando…
-            </div>
-          ) : grupos.length === 0 ? (
-            <div className="text-center text-muted-foreground py-12 text-sm">
-              Nenhum aumento cadastrado ainda.
-            </div>
-          ) : (
-            <div className="overflow-x-auto space-y-4">
-              {grupos.map((grupo) => {
-                const collapsed = isCollapsed(grupo.chave);
-                return (
-                  <div key={grupo.chave} className="rounded-md border">
-                    <button
-                      type="button"
-                      onClick={() => toggleMes(grupo.chave)}
-                      className="w-full flex items-center justify-between gap-2 px-3 py-2 bg-muted/40 hover:bg-muted/60 transition-colors text-left"
-                    >
-                      <div className="flex items-center gap-2">
-                        {collapsed ? (
-                          <ChevronRight className="h-4 w-4 text-muted-foreground" />
-                        ) : (
-                          <ChevronDown className="h-4 w-4 text-muted-foreground" />
-                        )}
-                        <span className="font-semibold text-sm">{grupo.label}</span>
-                        <Badge variant="outline" className="text-xs">
-                          {grupo.itens.length}{" "}
-                          {grupo.itens.length === 1 ? "aumento" : "aumentos"}
-                        </Badge>
-                      </div>
-                    </button>
-
-                    {!collapsed && (
-                      grupo.vazio ? (
-                        <div className="flex items-center justify-between gap-3 px-3 py-4 text-sm">
-                          <span className="text-muted-foreground">
-                            Nenhum aumento cadastrado neste mês.
-                          </span>
-                          <Button
-                            size="sm"
-                            variant="outline"
-                            onClick={() => setUploadOpen(true)}
-                          >
-                            <Upload className="h-3.5 w-3.5" /> Upload PDF
-                          </Button>
-                        </div>
-                      ) : (
-                        <Table>
-                          <TableHeader>
-                            <TableRow>
-                              <TableHead>Nome</TableHead>
-                              <TableHead>Fornecedor</TableHead>
-                              <TableHead>Vigência</TableHead>
-                              <TableHead>Anúncio</TableHead>
-                              <TableHead className="text-right">Categorias</TableHead>
-                              <TableHead className="text-right">% médio</TableHead>
-                              <TableHead>Estado</TableHead>
-                            </TableRow>
-                          </TableHeader>
-                          <TableBody>
-                            {grupo.itens.map((a) => (
-                              <TableRow
-                                key={a.id}
-                                className="cursor-pointer"
-                                onClick={() =>
-                                  navigate(`/admin/reposicao/aumentos/${a.id}`)
-                                }
-                              >
-                                <TableCell className="font-medium">{a.nome}</TableCell>
-                                <TableCell className="text-muted-foreground">
-                                  {a.fornecedor_nome}
-                                </TableCell>
-                                <TableCell className="tabular-nums text-sm">
-                                  {formatDate(a.data_vigencia)}
-                                </TableCell>
-                                <TableCell className="tabular-nums text-sm text-muted-foreground">
-                                  {formatDate(a.data_anuncio)}
-                                </TableCell>
-                                <TableCell className="text-right tabular-nums font-medium">
-                                  {a.num_categorias}
-                                </TableCell>
-                                <TableCell className="text-right tabular-nums">
-                                  {a.perc_medio !== null
-                                    ? `${a.perc_medio.toFixed(2)}%`
-                                    : "—"}
-                                </TableCell>
-                                <TableCell>
-                                  <Badge
-                                    variant="outline"
-                                    className={estadoBadgeClass(a.estado)}
-                                  >
-                                    {ESTADOS.find((e) => e.value === a.estado)?.label ?? a.estado}
-                                  </Badge>
-                                </TableCell>
-                              </TableRow>
-                            ))}
-                          </TableBody>
-                        </Table>
-                      )
-                    )}
-                  </div>
-                );
-              })}
-            </div>
-          )}
+          <AumentosGrupos
+            isLoading={isLoading}
+            grupos={grupos}
+            isCollapsed={isCollapsed}
+            onToggleMes={toggleMes}
+            onUploadClick={() => setUploadOpen(true)}
+            onRowClick={(id) => navigate(`/admin/reposicao/aumentos/${id}`)}
+          />
         </CardContent>
       </Card>
 
-      <Dialog
+      <UploadDialog
         open={uploadOpen}
         onOpenChange={(o) => {
           if (!extraindo) {
@@ -490,55 +104,16 @@ export default function AdminReposicaoAumentos() {
             if (!o) resetUpload();
           }
         }}
-      >
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Upload de anúncio de aumento</DialogTitle>
-            <DialogDescription>
-              Selecione um PDF ou imagem do comunicado. A IA vai extrair nome,
-              data de vigência e categorias com percentual de aumento.
-            </DialogDescription>
-          </DialogHeader>
-
-          <div className="space-y-3">
-            <Input
-              ref={fileInputRef}
-              type="file"
-              accept=".pdf,.png,.jpg,.jpeg,application/pdf,image/png,image/jpeg"
-              onChange={handleFileChange}
-              disabled={extraindo}
-            />
-            {arquivo && (
-              <div className="flex items-center gap-2 rounded-md border bg-muted/40 p-3 text-sm">
-                <FileText className="h-4 w-4 text-muted-foreground shrink-0" />
-                <div className="min-w-0 flex-1">
-                  <p className="truncate font-medium">{arquivo.name}</p>
-                  <p className="text-xs text-muted-foreground">
-                    {(arquivo.size / 1024).toFixed(1)} KB
-                  </p>
-                </div>
-              </div>
-            )}
-          </div>
-
-          <DialogFooter>
-            <Button
-              variant="ghost"
-              onClick={() => {
-                setUploadOpen(false);
-                resetUpload();
-              }}
-              disabled={extraindo}
-            >
-              Cancelar
-            </Button>
-            <Button onClick={handleExtrair} disabled={!arquivo || extraindo}>
-              {extraindo && <Loader2 className="h-4 w-4 animate-spin" />}
-              Extrair
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+        arquivo={arquivo}
+        onFileChange={handleFileChange}
+        onCancel={() => {
+          setUploadOpen(false);
+          resetUpload();
+        }}
+        onExtrair={handleExtrair}
+        extraindo={extraindo}
+        fileInputRef={fileInputRef}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Resumo
Quebra o god-component `src/pages/AdminReposicaoAumentos.tsx` (**544→119L**) em um hook de dados/estado + componentes presentacionais controlados, sob `src/components/reposicao/aumentos/`. Extração **verbatim** — comportamento preservado 1:1.

## O que mudou
- **`useAumentos`** (hook): 2 queries (`fornecedor_aumento_anunciado` + agregação de `fornecedor_aumento_item`), memos de agrupamento por mês (`grupos`/`isCollapsed`/`toggleMes`) e handlers de upload/extração via Gemini Vision (`handleExtrair`).
- **`AtivosAguardandoBanner`** — banner de ativos aguardando vigência.
- **`AumentosFiltros`** — filtros (fornecedor/estado/busca).
- **`AumentosGrupos`** — lista agrupada por mês (colapsável) + loading/empty.
- **`UploadDialog`** — modal de upload/extração (PDF/imagem).
- **`types.ts`** / **`config.ts`** (`EMPRESA`/`FORNECEDOR_DEFAULT`/`ALL`/`ESTADOS`/`estadoBadgeClass`/`formatDate`).
- **+19 testes** (helpers puros + presentacionais).

## Verificação
- `bunx tsc --noEmit` (baseline) = **0**
- `eslint` = **0 erros / 0 warnings**
- **19/19 testes** verdes (isolados)
- Revisão independente FIEL 1:1: **aprovada** (queries/agregação/handlers/ordem de hooks conferidos)

## Migrations
Nenhuma.

🤖 Generated with [Claude Code](https://claude.com/claude-code)