### PR TITLE
fix(security): sanitiza input em filtros .or() do PostgREST (injeção MEDIUM)

### DIFF
--- a/src/components/reposicao/aplicacao/SubstituicaoModal.tsx
+++ b/src/components/reposicao/aplicacao/SubstituicaoModal.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { useQuery, useMutation } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
+import { sanitizeForPostgrestOr } from "@/lib/postgrest";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -42,11 +43,13 @@ export function SubstituicaoModal({
     queryKey: ["sku-busca", busca],
     queryFn: async () => {
       if (!busca || busca.length < 2) return [];
+      // Só a parte ilike vem de texto livre; o .eq é coagido a número (seguro).
+      const descSafe = sanitizeForPostgrestOr(busca);
       const { data } = await supabase
         .from("sku_parametros")
         .select("sku_codigo_omie, sku_descricao")
         .eq("empresa", EMPRESA)
-        .or(`sku_codigo_omie.eq.${Number(busca) || 0},sku_descricao.ilike.%${busca}%`)
+        .or(`sku_codigo_omie.eq.${Number(busca) || 0},sku_descricao.ilike.%${descSafe}%`)
         .limit(20);
       return data ?? [];
     },

--- a/src/components/tintColorSelect/useTintColorSelect.ts
+++ b/src/components/tintColorSelect/useTintColorSelect.ts
@@ -3,6 +3,7 @@
 import { useState, useEffect, useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
+import { sanitizeForPostgrestOr } from '@/lib/postgrest';
 import { useTintPricing } from '@/hooks/useTintPricing';
 import type { Product } from '@/hooks/useUnifiedOrder';
 import type { FormulaResult, AlternativePackaging } from './types';
@@ -80,12 +81,13 @@ export function useTintColorSelect({ product, open, customerUserId }: UseTintCol
     staleTime: 5 * 60 * 1000,
     enabled: !!skuId && debouncedSearch.length >= 2,
     queryFn: async () => {
+      const q = sanitizeForPostgrestOr(debouncedSearch);
       const { data } = await supabase
         .from('tint_formulas')
         .select('id, cor_id, nome_cor, preco_final_sayersystem')
         .eq('account', 'oben')
         .eq('sku_id', skuId!)
-        .or(`cor_id.ilike.%${debouncedSearch}%,nome_cor.ilike.%${debouncedSearch}%`)
+        .or(`cor_id.ilike.%${q}%,nome_cor.ilike.%${q}%`)
         .limit(20);
       return (data || []) as FormulaResult[];
     },
@@ -99,12 +101,13 @@ export function useTintColorSelect({ product, open, customerUserId }: UseTintCol
     staleTime: 5 * 60 * 1000,
     enabled: !!colorNotFoundInBase && !!currentBaseSuffix,
     queryFn: async (): Promise<AlternativePackaging[]> => {
+      const q = sanitizeForPostgrestOr(debouncedSearch);
       // Search formulas across all SKUs
       const { data: globalFormulas } = await supabase
         .from('tint_formulas')
         .select('id, cor_id, nome_cor, sku_id, preco_final_sayersystem')
         .eq('account', 'oben')
-        .or(`cor_id.ilike.%${debouncedSearch}%,nome_cor.ilike.%${debouncedSearch}%`)
+        .or(`cor_id.ilike.%${q}%,nome_cor.ilike.%${q}%`)
         .not('sku_id', 'is', null)
         .limit(50);
 

--- a/src/hooks/useGlobalSearch.ts
+++ b/src/hooks/useGlobalSearch.ts
@@ -2,17 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
-
-/**
- * Sanitiza input pra uso em `.or()` do PostgREST.
- * Além dos wildcards do ILIKE (% _), remove caracteres que quebram o parser
- * do PostgREST e permitem injetar cláusulas extras: vírgula (separador),
- * parênteses (agrupamento), barra invertida (escape), aspas duplas (delimitador).
- * Sem isso, input tipo `foo,role.eq.master` quebra de uma .ilike e injeta filtro.
- */
-function sanitizeForPostgrestOr(input: string): string {
-  return input.replace(/[%_,()\\"]/g, '');
-}
+import { sanitizeForPostgrestOr } from '@/lib/postgrest';
 
 /**
  * Busca global pra Cmd-K — pesquisa simultânea em 3 entidades:

--- a/src/lib/postgrest.test.ts
+++ b/src/lib/postgrest.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { sanitizeForPostgrestOr } from '@/lib/postgrest';
+
+describe('sanitizeForPostgrestOr', () => {
+  it('remove a vírgula (separador de filtros do .or())', () => {
+    // Sem isso, o usuário injeta uma cláusula extra: `x,id.gt.0` viraria
+    // dois predicados (ilike + id>0), alargando o resultado da query.
+    expect(sanitizeForPostgrestOr('x,id.gt.0')).toBe('xid.gt.0');
+  });
+
+  it('remove parênteses (agrupamento de cláusulas)', () => {
+    expect(sanitizeForPostgrestOr('a(b)c')).toBe('abc');
+  });
+
+  it('remove os wildcards do ILIKE (% e _)', () => {
+    expect(sanitizeForPostgrestOr('50%_off')).toBe('50off');
+  });
+
+  it('remove barra invertida (escape do parser)', () => {
+    expect(sanitizeForPostgrestOr('a\\b')).toBe('ab');
+  });
+
+  it('remove aspas duplas (delimitador de valor)', () => {
+    expect(sanitizeForPostgrestOr('a"b"c')).toBe('abc');
+  });
+
+  it('remove todos os caracteres especiais combinados', () => {
+    expect(sanitizeForPostgrestOr('%_,()\\"')).toBe('');
+  });
+
+  it('neutraliza um payload de injeção real mantendo só texto inerte', () => {
+    expect(sanitizeForPostgrestOr('foo,role.eq.master')).toBe('foorole.eq.master');
+  });
+
+  it('preserva texto comum: letras, números, espaços, acentos, ponto e hífen', () => {
+    expect(sanitizeForPostgrestOr('Tinta Azul-Céu 2.5L')).toBe('Tinta Azul-Céu 2.5L');
+  });
+
+  it('retorna string vazia para entrada vazia', () => {
+    expect(sanitizeForPostgrestOr('')).toBe('');
+  });
+
+  it('é idempotente (aplicar duas vezes não muda o resultado)', () => {
+    const once = sanitizeForPostgrestOr('a,b(c)%_\\"d');
+    expect(sanitizeForPostgrestOr(once)).toBe(once);
+  });
+});

--- a/src/lib/postgrest.ts
+++ b/src/lib/postgrest.ts
@@ -1,0 +1,21 @@
+/**
+ * Sanitiza input do usuário pra interpolar com segurança numa string de `.or()`
+ * do PostgREST (supabase-js).
+ *
+ * O `.or('col.ilike.%termo%,outra.ilike.%termo%')` recebe uma string crua onde a
+ * vírgula separa cláusulas, os parênteses agrupam, e `% _` são wildcards do ILIKE.
+ * Se o `termo` vier do usuário sem escape, digitar algo como `x,id.gt.0` quebra a
+ * `.ilike` e injeta um predicado extra — alargando o resultado / permitindo
+ * enumerar dentro do que a RLS já libera.
+ *
+ * Remove os caracteres que têm significado especial no parser: vírgula (separador),
+ * parênteses (agrupamento), barra invertida (escape), aspas duplas (delimitador de
+ * valor) e os wildcards do ILIKE (`%` `_`). O texto restante vira filtro literal.
+ *
+ * Aplique SÓ na parte que vem de input do usuário, preservando a sintaxe do `.or()`:
+ *   const q = sanitizeForPostgrestOr(busca);
+ *   .or(`nome.ilike.%${q}%,doc.ilike.%${q}%`)
+ */
+export function sanitizeForPostgrestOr(input: string): string {
+  return input.replace(/[%_,()\\"]/g, '');
+}

--- a/src/pages/AdminReposicaoAlertas.tsx
+++ b/src/pages/AdminReposicaoAlertas.tsx
@@ -1,6 +1,7 @@
 import { useState, useMemo } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
+import { sanitizeForPostgrestOr } from "@/lib/postgrest";
 import { useAuth } from "@/contexts/AuthContext";
 import { useReposicaoEmpresa } from "@/contexts/ReposicaoEmpresaContext";
 import { toast } from "sonner";
@@ -68,7 +69,8 @@ export default function AdminReposicaoAlertas() {
       if (filtroSev !== "__all__") q = q.eq("severidade", filtroSev);
       if (filtroStatus !== "__all__") q = q.eq("status", filtroStatus);
       if (busca.trim()) {
-        q = q.or(`sku_codigo_omie.ilike.%${busca.trim()}%,sku_descricao.ilike.%${busca.trim()}%`);
+        const b = sanitizeForPostgrestOr(busca.trim());
+        q = q.or(`sku_codigo_omie.ilike.%${b}%,sku_descricao.ilike.%${b}%`);
       }
 
       const { data, error, count } = await q;

--- a/src/pages/AdminReposicaoGruposProducao.tsx
+++ b/src/pages/AdminReposicaoGruposProducao.tsx
@@ -1,6 +1,7 @@
 import { useState, useMemo } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
+import { sanitizeForPostgrestOr } from "@/lib/postgrest";
 import { toast } from "sonner";
 import { Plus, Factory } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -72,7 +73,9 @@ export default function AdminReposicaoGruposProducao() {
       if (filtroFornecedor !== ALL) q = q.eq("fornecedor_nome", filtroFornecedor);
       if (busca.trim()) {
         const t = busca.trim();
-        q = q.or(`sku_descricao.ilike.%${t}%,sku_codigo_omie.eq.${/^\d+$/.test(t) ? t : 0}`);
+        // Só a parte ilike é texto livre; o .eq só usa `t` quando é puramente numérico.
+        const descSafe = sanitizeForPostgrestOr(t);
+        q = q.or(`sku_descricao.ilike.%${descSafe}%,sku_codigo_omie.eq.${/^\d+$/.test(t) ? t : 0}`);
       }
 
       const { data, error, count } = await q

--- a/src/pages/FarmerCallsPendingLink.tsx
+++ b/src/pages/FarmerCallsPendingLink.tsx
@@ -3,6 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
 import { useLinkCallToCustomer } from '@/hooks/useLinkCallToCustomer';
+import { sanitizeForPostgrestOr } from '@/lib/postgrest';
 import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import {
@@ -92,10 +93,10 @@ function PendingRow({
     queryKey: ['profiles-search', search],
     enabled: open && search.length >= 2,
     queryFn: async (): Promise<ProfileMatch[]> => {
-      // PostgREST .or() takes user-controlled `search`; escape commas and parens
-      // to avoid breaking the filter syntax.
-      const safe = search.replace(/[,()]/g, ' ');
-       
+      // PostgREST .or() recebe `search` controlado pelo usuário; sanitiza pra não
+      // quebrar a sintaxe do filtro e injetar cláusulas extras.
+      const safe = sanitizeForPostgrestOr(search);
+
       const { data } = await supabase.from('profiles')
         .select('user_id, name, phone')
         .or(`name.ilike.%${safe}%,phone.ilike.%${safe}%`)

--- a/src/pages/TintFormulas.tsx
+++ b/src/pages/TintFormulas.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
+import { sanitizeForPostgrestOr } from '@/lib/postgrest';
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
@@ -108,7 +109,10 @@ export default function TintFormulas() {
         .order('cor_id')
         .range(page * PAGE_SIZE, (page + 1) * PAGE_SIZE - 1);
 
-      if (search) q = q.or(`cor_id.ilike.%${search}%,nome_cor.ilike.%${search}%`);
+      if (search) {
+        const s = sanitizeForPostgrestOr(search);
+        q = q.or(`cor_id.ilike.%${s}%,nome_cor.ilike.%${s}%`);
+      }
       if (produtoFilter) q = q.eq('produto_id', produtoFilter);
       if (baseFilter) q = q.eq('base_id', baseFilter);
       if (onlyPersonalizada) q = q.eq('personalizada', true);

--- a/tsconfig.strict.json
+++ b/tsconfig.strict.json
@@ -493,6 +493,7 @@
     "src/hooks/useEstoqueValor.ts",
     "src/hooks/useDirectTintImport.ts",
     "src/hooks/unifiedOrder/useCart.ts",
-    "src/hooks/unifiedOrder/useProductCatalog.ts"
+    "src/hooks/unifiedOrder/useProductCatalog.ts",
+    "src/lib/postgrest.ts"
   ]
 }


### PR DESCRIPTION
## Resumo

Corrige uma **injeção de filtro PostgREST (severidade MEDIUM)** encontrada em varredura SAST: vários callsites interpolavam input do usuário direto na string do `.or()` do supabase-js sem escapar os caracteres especiais do parser (`,` `(` `)` `%` `_` `\` `"`). Digitar algo como `x,id.gt.0` no campo de busca quebrava a `.ilike` e injetava um predicado extra — alargando o resultado / permitindo enumerar dentro do que a RLS já libera. Mitigado por RLS + `.eq(empresa/account)` e por serem tabelas de catálogo (não o caminho do dinheiro), mas real e replicável.

## Mudanças

- **Util compartilhado** [`src/lib/postgrest.ts`](src/lib/postgrest.ts) — `sanitizeForPostgrestOr` extraído (mesma regex do original, sem mudança de comportamento) + teste vitest [`src/lib/postgrest.test.ts`](src/lib/postgrest.test.ts) com 10 casos cobrindo cada caractere especial, payload de injeção e idempotência (ciclo TDD RED→GREEN). Adicionado ao `include` do `tsconfig.strict.json` (no fim, sem reordenar).
- **2 consumidores re-apontados** pro util: `useGlobalSearch.ts` (tinha a cópia local) e `FarmerCallsPendingLink.tsx` (tinha um escape inline **mais fraco** — só `,()`, sem `% _ \ "`).
- **6 callsites vulneráveis sanitizados** (escapando só a parte de input livre, mantendo a sintaxe do `.or()`):
  - `useTintColorSelect.ts` (2×)
  - `TintFormulas.tsx`
  - `AdminReposicaoAlertas.tsx`
  - `SubstituicaoModal.tsx` — só `sku_descricao.ilike`; o `.eq` é coagido a número
  - `AdminReposicaoGruposProducao.tsx` — só `sku_descricao.ilike`; o `.eq` é gated por `/^\d+$/`

## Validação

- `heavy bun run typecheck:strict` ✅
- `bunx tsc --noEmit` (baseline) ✅
- `eslint` nos 9 arquivos tocados → exit 0 ✅
- `heavy bun run test` → **1069/1069** (209 arquivos) ✅
- Varredura final: zero `.or(...ilike.%${...})` com input cru restante

Mudança **100% frontend** — sem migration, sem necessidade de tocar no banco.

🤖 Generated with [Claude Code](https://claude.com/claude-code)