### PR TITLE
refactor(loyalty): split AdminLoyalty (526→124) em hook + componentes

### DIFF
--- a/src/components/loyalty/AdjustDialog.tsx
+++ b/src/components/loyalty/AdjustDialog.tsx
@@ -1,0 +1,63 @@
+// Dialog de ajuste de pontos (adicionar/aprovar resgate).
+// Extraído verbatim de src/pages/AdminLoyalty.tsx (god-component split).
+import { Loader2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+
+export function AdjustDialog({
+  open, onOpenChange, type, points, setPoints, description, setDescription, onSubmit, loading,
+}: {
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+  type: 'earn' | 'redeem';
+  points: string;
+  setPoints: (v: string) => void;
+  description: string;
+  setDescription: (v: string) => void;
+  onSubmit: () => void;
+  loading: boolean;
+}) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>
+            {type === 'earn' ? '➕ Adicionar Pontos' : '🎁 Aprovar Resgate'}
+          </DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4">
+          <div>
+            <label className="text-sm font-medium text-foreground">Pontos</label>
+            <Input
+              type="number"
+              min="1"
+              value={points}
+              onChange={e => setPoints(e.target.value)}
+              placeholder="Ex: 100"
+            />
+          </div>
+          <div>
+            <label className="text-sm font-medium text-foreground">Descrição</label>
+            <Textarea
+              value={description}
+              onChange={e => setDescription(e.target.value)}
+              placeholder={type === 'earn' ? 'Motivo do bônus...' : 'Recompensa resgatada...'}
+              rows={2}
+            />
+          </div>
+          <Button onClick={onSubmit} disabled={loading || !points} className="w-full">
+            {loading ? <Loader2 className="w-4 h-4 animate-spin mr-2" /> : null}
+            {type === 'earn' ? 'Adicionar Pontos' : 'Aprovar Resgate'}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/loyalty/CustomerDetail.tsx
+++ b/src/components/loyalty/CustomerDetail.tsx
@@ -1,0 +1,86 @@
+// Visão de detalhe de um cliente (saldo, ações, histórico).
+// Extraído verbatim de src/pages/AdminLoyalty.tsx (god-component split).
+import { Card, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Plus, Minus } from 'lucide-react';
+import { format } from 'date-fns';
+import { ptBR } from 'date-fns/locale';
+import { getTier } from './config';
+import type { CustomerPoints, PointRecord } from './types';
+
+interface CustomerDetailProps {
+  customer: CustomerPoints;
+  history: PointRecord[];
+  onAddPoints: () => void;
+  onRedeem: () => void;
+  onBack: () => void;
+}
+
+export function CustomerDetail({ customer: selectedCustomer, history: customerHistory, onAddPoints, onRedeem, onBack }: CustomerDetailProps) {
+  const tier = getTier(selectedCustomer.balance);
+  return (
+    <main className="pt-16 px-4 max-w-lg mx-auto space-y-4">
+      <Card>
+        <CardContent className="p-5">
+          <div className="flex items-center justify-between mb-3">
+            <div>
+              <p className="text-xs text-muted-foreground uppercase">Saldo</p>
+              <p className="text-3xl font-bold text-foreground">{selectedCustomer.balance} pts</p>
+            </div>
+            <div className="text-center">
+              <span className="text-3xl">{tier.icon}</span>
+              <p className="text-xs font-medium text-muted-foreground">{tier.name}</p>
+            </div>
+          </div>
+          <div className="flex gap-4 text-sm text-muted-foreground">
+            <span>Ganhos: <strong className="text-foreground">{selectedCustomer.total_earned}</strong></span>
+            <span>Resgatados: <strong className="text-foreground">{selectedCustomer.total_redeemed}</strong></span>
+          </div>
+        </CardContent>
+      </Card>
+
+      <div className="flex gap-2">
+        <Button
+          className="flex-1"
+          onClick={onAddPoints}
+        >
+          <Plus className="w-4 h-4 mr-1" /> Adicionar Pontos
+        </Button>
+        <Button
+          variant="outline"
+          className="flex-1"
+          onClick={onRedeem}
+        >
+          <Minus className="w-4 h-4 mr-1" /> Resgatar
+        </Button>
+      </div>
+
+      <h3 className="font-display font-bold text-foreground">Histórico</h3>
+      <div className="space-y-2">
+        {customerHistory.map(item => (
+          <Card key={item.id}>
+            <CardContent className="p-3 flex items-center justify-between">
+              <div>
+                <p className="text-sm font-medium text-foreground">{item.description || 'Pontos'}</p>
+                <p className="text-xs text-muted-foreground">
+                  {format(new Date(item.created_at), "dd/MM/yyyy 'às' HH:mm", { locale: ptBR })}
+                </p>
+              </div>
+              <Badge variant={item.type === 'earn' ? 'default' : 'destructive'}>
+                {item.type === 'earn' ? '+' : ''}{item.points} pts
+              </Badge>
+            </CardContent>
+          </Card>
+        ))}
+        {customerHistory.length === 0 && (
+          <p className="text-sm text-muted-foreground text-center py-4">Sem histórico</p>
+        )}
+      </div>
+
+      <Button variant="ghost" className="w-full" onClick={onBack}>
+        ← Voltar à lista
+      </Button>
+    </main>
+  );
+}

--- a/src/components/loyalty/CustomerList.tsx
+++ b/src/components/loyalty/CustomerList.tsx
@@ -1,0 +1,91 @@
+// Busca + lista de clientes com pontos.
+// Extraído verbatim de src/pages/AdminLoyalty.tsx (god-component split).
+import { Card, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Search, Users, Plus, Gift } from 'lucide-react';
+import { getTier } from './config';
+import type { CustomerPoints } from './types';
+
+interface CustomerListProps {
+  search: string;
+  onSearchChange: (v: string) => void;
+  filtered: CustomerPoints[];
+  onView: (customer: CustomerPoints) => void;
+  onQuickEarn: (userId: string) => void;
+  onQuickRedeem: (userId: string) => void;
+}
+
+export function CustomerList({ search, onSearchChange, filtered, onView, onQuickEarn, onQuickRedeem }: CustomerListProps) {
+  return (
+    <>
+      <div className="relative">
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
+        <Input
+          placeholder="Buscar cliente..."
+          value={search}
+          onChange={e => onSearchChange(e.target.value)}
+          className="pl-10"
+        />
+      </div>
+
+      {/* Customer list */}
+      <div className="space-y-2">
+        {filtered.length === 0 && (
+          <Card>
+            <CardContent className="p-6 text-center">
+              <Users className="w-8 h-8 text-muted-foreground mx-auto mb-2" />
+              <p className="text-sm text-muted-foreground">
+                {search ? 'Nenhum cliente encontrado' : 'Nenhum cliente com pontos ainda'}
+              </p>
+            </CardContent>
+          </Card>
+        )}
+        {filtered.map(customer => {
+          const tier = getTier(customer.balance);
+          return (
+            <Card
+              key={customer.user_id}
+              className="cursor-pointer hover:shadow-medium transition-shadow"
+              onClick={() => onView(customer)}
+            >
+              <CardContent className="p-4 flex items-center justify-between">
+                <div className="flex items-center gap-3">
+                  <span className="text-2xl">{tier.icon}</span>
+                  <div>
+                    <p className="font-semibold text-foreground">{customer.name}</p>
+                    <p className="text-xs text-muted-foreground">
+                      {tier.name} · {customer.balance} pontos
+                    </p>
+                  </div>
+                </div>
+                <div className="flex gap-1">
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    onClick={e => {
+                      e.stopPropagation();
+                      onQuickEarn(customer.user_id);
+                    }}
+                  >
+                    <Plus className="w-4 h-4" />
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    onClick={e => {
+                      e.stopPropagation();
+                      onQuickRedeem(customer.user_id);
+                    }}
+                  >
+                    <Gift className="w-4 h-4" />
+                  </Button>
+                </div>
+              </CardContent>
+            </Card>
+          );
+        })}
+      </div>
+    </>
+  );
+}

--- a/src/components/loyalty/EconomicInsights.tsx
+++ b/src/components/loyalty/EconomicInsights.tsx
@@ -1,0 +1,74 @@
+// Card "Visão Econômica" (passivo estimado, taxa de resgate, top recompensas/saldos).
+// Extraído verbatim de src/pages/AdminLoyalty.tsx (god-component split).
+import { Card, CardContent } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { DollarSign, BarChart3, Crown } from 'lucide-react';
+import type { CustomerPoints } from './types';
+
+interface EconomicInsightsProps {
+  estimatedLiability: number;
+  redemptionRate: string;
+  topRewards: [string, number][];
+  topBalanceUsers: CustomerPoints[];
+}
+
+export function EconomicInsights({ estimatedLiability, redemptionRate, topRewards, topBalanceUsers }: EconomicInsightsProps) {
+  return (
+    <Card>
+      <CardContent className="p-4 space-y-3">
+        <div className="flex items-center gap-2 mb-1">
+          <DollarSign className="w-4 h-4 text-primary" />
+          <h3 className="text-sm font-semibold text-foreground">Visão Econômica</h3>
+        </div>
+        <div className="grid grid-cols-2 gap-3">
+          <div className="rounded-lg bg-muted p-3">
+            <p className="text-[10px] text-muted-foreground uppercase tracking-wide">Passivo estimado</p>
+            <p className="text-lg font-bold text-foreground">
+              R$ {estimatedLiability.toFixed(2)}
+            </p>
+            <p className="text-[10px] text-muted-foreground">se todos resgatassem</p>
+          </div>
+          <div className="rounded-lg bg-muted p-3">
+            <p className="text-[10px] text-muted-foreground uppercase tracking-wide">Taxa de resgate</p>
+            <p className="text-lg font-bold text-foreground">{redemptionRate}%</p>
+            <p className="text-[10px] text-muted-foreground">resgatados / emitidos</p>
+          </div>
+        </div>
+
+        {topRewards.length > 0 && (
+          <div>
+            <div className="flex items-center gap-1.5 mb-1.5">
+              <BarChart3 className="w-3.5 h-3.5 text-muted-foreground" />
+              <p className="text-xs font-medium text-muted-foreground">Recompensas mais resgatadas</p>
+            </div>
+            <div className="space-y-1">
+              {topRewards.map(([name, count]) => (
+                <div key={name} className="flex items-center justify-between text-sm">
+                  <span className="text-foreground truncate">{name}</span>
+                  <Badge variant="secondary" className="text-xs">{count}x</Badge>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {topBalanceUsers.length > 0 && (
+          <div>
+            <div className="flex items-center gap-1.5 mb-1.5">
+              <Crown className="w-3.5 h-3.5 text-muted-foreground" />
+              <p className="text-xs font-medium text-muted-foreground">Maiores saldos</p>
+            </div>
+            <div className="space-y-1">
+              {topBalanceUsers.map(u => (
+                <div key={u.user_id} className="flex items-center justify-between text-sm">
+                  <span className="text-foreground truncate">{u.name}</span>
+                  <span className="font-medium text-foreground">{u.balance} pts</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/loyalty/LoyaltyStats.tsx
+++ b/src/components/loyalty/LoyaltyStats.tsx
@@ -1,0 +1,38 @@
+// Grid de KPIs do módulo de fidelidade (circulação/ganhos/resgatados).
+// Extraído verbatim de src/pages/AdminLoyalty.tsx (god-component split).
+import { Card, CardContent } from '@/components/ui/card';
+import { TrendingUp, Plus, Gift } from 'lucide-react';
+
+interface LoyaltyStatsProps {
+  totalPointsCirculating: number;
+  totalEarned: number;
+  totalRedeemed: number;
+}
+
+export function LoyaltyStats({ totalPointsCirculating, totalEarned, totalRedeemed }: LoyaltyStatsProps) {
+  return (
+    <div className="grid grid-cols-3 gap-3">
+      <Card className="text-center">
+        <CardContent className="pt-4 pb-3">
+          <TrendingUp className="w-5 h-5 mx-auto text-primary mb-1" />
+          <p className="text-xl font-bold text-foreground">{totalPointsCirculating}</p>
+          <p className="text-[10px] text-muted-foreground">Em circulação</p>
+        </CardContent>
+      </Card>
+      <Card className="text-center">
+        <CardContent className="pt-4 pb-3">
+          <Plus className="w-5 h-5 mx-auto text-emerald-500 mb-1" />
+          <p className="text-xl font-bold text-foreground">{totalEarned}</p>
+          <p className="text-[10px] text-muted-foreground">Total ganhos</p>
+        </CardContent>
+      </Card>
+      <Card className="text-center">
+        <CardContent className="pt-4 pb-3">
+          <Gift className="w-5 h-5 mx-auto text-amber-500 mb-1" />
+          <p className="text-xl font-bold text-foreground">{totalRedeemed}</p>
+          <p className="text-[10px] text-muted-foreground">Resgatados</p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/loyalty/__tests__/AdjustDialog.test.tsx
+++ b/src/components/loyalty/__tests__/AdjustDialog.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { AdjustDialog } from "../AdjustDialog";
+
+function setup(overrides: Partial<React.ComponentProps<typeof AdjustDialog>> = {}) {
+  const props: React.ComponentProps<typeof AdjustDialog> = {
+    open: true,
+    onOpenChange: vi.fn(),
+    type: "earn",
+    points: "",
+    setPoints: vi.fn(),
+    description: "",
+    setDescription: vi.fn(),
+    onSubmit: vi.fn(),
+    loading: false,
+    ...overrides,
+  };
+  render(<AdjustDialog {...props} />);
+  return props;
+}
+
+describe("AdjustDialog", () => {
+  it("título e botão de earn", () => {
+    setup({ type: "earn", points: "100" });
+    expect(screen.getByText("➕ Adicionar Pontos")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Adicionar Pontos" })).toHaveProperty("disabled", false);
+  });
+
+  it("título de redeem", () => {
+    setup({ type: "redeem" });
+    expect(screen.getByText("🎁 Aprovar Resgate")).toBeTruthy();
+  });
+
+  it("desabilita submit sem pontos", () => {
+    setup({ type: "earn", points: "" });
+    expect(screen.getByRole("button", { name: "Adicionar Pontos" })).toHaveProperty("disabled", true);
+  });
+
+  it("dispara onSubmit", () => {
+    const props = setup({ type: "earn", points: "50" });
+    fireEvent.click(screen.getByRole("button", { name: "Adicionar Pontos" }));
+    expect(props.onSubmit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/loyalty/__tests__/CustomerDetail.test.tsx
+++ b/src/components/loyalty/__tests__/CustomerDetail.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { CustomerDetail } from "../CustomerDetail";
+import type { CustomerPoints, PointRecord } from "../types";
+
+const customer: CustomerPoints = {
+  user_id: "u1",
+  name: "Cliente X",
+  total_earned: 600,
+  total_redeemed: 100,
+  balance: 500,
+};
+
+const history: PointRecord[] = [
+  {
+    id: "p1",
+    user_id: "u1",
+    points: 100,
+    type: "earn",
+    description: "Bônus de boas-vindas",
+    created_at: "2026-03-01T10:00:00Z",
+    order_id: null,
+  },
+];
+
+function setup(overrides: Partial<React.ComponentProps<typeof CustomerDetail>> = {}) {
+  const props: React.ComponentProps<typeof CustomerDetail> = {
+    customer,
+    history,
+    onAddPoints: vi.fn(),
+    onRedeem: vi.fn(),
+    onBack: vi.fn(),
+    ...overrides,
+  };
+  render(<CustomerDetail {...props} />);
+  return props;
+}
+
+describe("CustomerDetail", () => {
+  it("mostra saldo, tier e totais", () => {
+    setup();
+    expect(screen.getByText("500 pts")).toBeTruthy();
+    expect(screen.getByText("Ouro")).toBeTruthy();
+    expect(screen.getByText("600")).toBeTruthy();
+    expect(screen.getByText("100")).toBeTruthy();
+  });
+
+  it("renderiza o histórico com badge", () => {
+    setup();
+    expect(screen.getByText("Bônus de boas-vindas")).toBeTruthy();
+    expect(screen.getByText("+100 pts")).toBeTruthy();
+  });
+
+  it("empty state de histórico", () => {
+    setup({ history: [] });
+    expect(screen.getByText("Sem histórico")).toBeTruthy();
+  });
+
+  it("dispara onAddPoints/onRedeem/onBack", () => {
+    const props = setup();
+    fireEvent.click(screen.getByRole("button", { name: /Adicionar Pontos/ }));
+    fireEvent.click(screen.getByRole("button", { name: /Resgatar/ }));
+    fireEvent.click(screen.getByRole("button", { name: /Voltar à lista/ }));
+    expect(props.onAddPoints).toHaveBeenCalledTimes(1);
+    expect(props.onRedeem).toHaveBeenCalledTimes(1);
+    expect(props.onBack).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/loyalty/__tests__/CustomerList.test.tsx
+++ b/src/components/loyalty/__tests__/CustomerList.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { CustomerList } from "../CustomerList";
+import type { CustomerPoints } from "../types";
+
+const customer: CustomerPoints = {
+  user_id: "u1",
+  name: "Cliente X",
+  total_earned: 600,
+  total_redeemed: 100,
+  balance: 500,
+};
+
+function setup(overrides: Partial<React.ComponentProps<typeof CustomerList>> = {}) {
+  const props: React.ComponentProps<typeof CustomerList> = {
+    search: "",
+    onSearchChange: vi.fn(),
+    filtered: [customer],
+    onView: vi.fn(),
+    onQuickEarn: vi.fn(),
+    onQuickRedeem: vi.fn(),
+    ...overrides,
+  };
+  render(<CustomerList {...props} />);
+  return props;
+}
+
+describe("CustomerList", () => {
+  it("empty state sem busca", () => {
+    setup({ filtered: [] });
+    expect(screen.getByText("Nenhum cliente com pontos ainda")).toBeTruthy();
+  });
+
+  it("empty state com busca", () => {
+    setup({ filtered: [], search: "abc" });
+    expect(screen.getByText("Nenhum cliente encontrado")).toBeTruthy();
+  });
+
+  it("renderiza cliente com tier e saldo", () => {
+    setup();
+    expect(screen.getByText("Cliente X")).toBeTruthy();
+    expect(screen.getByText("Ouro · 500 pontos")).toBeTruthy();
+  });
+
+  it("dispara onView ao clicar no card", () => {
+    const props = setup();
+    fireEvent.click(screen.getByText("Cliente X"));
+    expect(props.onView).toHaveBeenCalledWith(customer);
+  });
+
+  it("quick earn/redeem param o propagation e disparam callbacks", () => {
+    const props = setup();
+    const buttons = screen.getAllByRole("button");
+    expect(buttons).toHaveLength(2);
+    fireEvent.click(buttons[0]);
+    fireEvent.click(buttons[1]);
+    expect(props.onQuickEarn).toHaveBeenCalledWith("u1");
+    expect(props.onQuickRedeem).toHaveBeenCalledWith("u1");
+    expect(props.onView).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/loyalty/__tests__/EconomicInsights.test.tsx
+++ b/src/components/loyalty/__tests__/EconomicInsights.test.tsx
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { EconomicInsights } from "../EconomicInsights";
+import type { CustomerPoints } from "../types";
+
+const topBalanceUsers: CustomerPoints[] = [
+  { user_id: "u1", name: "Cliente Z", total_earned: 600, total_redeemed: 100, balance: 500 },
+];
+
+describe("EconomicInsights", () => {
+  it("renderiza passivo, taxa de resgate, recompensas e saldos", () => {
+    render(
+      <EconomicInsights
+        estimatedLiability={12.5}
+        redemptionRate="40.0"
+        topRewards={[["Brinde A", 3]]}
+        topBalanceUsers={topBalanceUsers}
+      />,
+    );
+    expect(screen.getByText("R$ 12.50")).toBeTruthy();
+    expect(screen.getByText("40.0%")).toBeTruthy();
+    expect(screen.getByText("Brinde A")).toBeTruthy();
+    expect(screen.getByText("3x")).toBeTruthy();
+    expect(screen.getByText("Cliente Z")).toBeTruthy();
+    expect(screen.getByText("500 pts")).toBeTruthy();
+  });
+
+  it("oculta seções quando vazias", () => {
+    render(
+      <EconomicInsights estimatedLiability={0} redemptionRate="0" topRewards={[]} topBalanceUsers={[]} />,
+    );
+    expect(screen.queryByText("Recompensas mais resgatadas")).toBeNull();
+    expect(screen.queryByText("Maiores saldos")).toBeNull();
+  });
+});

--- a/src/components/loyalty/__tests__/LoyaltyStats.test.tsx
+++ b/src/components/loyalty/__tests__/LoyaltyStats.test.tsx
@@ -1,0 +1,15 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { LoyaltyStats } from "../LoyaltyStats";
+
+describe("LoyaltyStats", () => {
+  it("renderiza os três KPIs com rótulos", () => {
+    render(<LoyaltyStats totalPointsCirculating={150} totalEarned={300} totalRedeemed={120} />);
+    expect(screen.getByText("150")).toBeTruthy();
+    expect(screen.getByText("300")).toBeTruthy();
+    expect(screen.getByText("120")).toBeTruthy();
+    expect(screen.getByText("Em circulação")).toBeTruthy();
+    expect(screen.getByText("Total ganhos")).toBeTruthy();
+    expect(screen.getByText("Resgatados")).toBeTruthy();
+  });
+});

--- a/src/components/loyalty/__tests__/config.test.ts
+++ b/src/components/loyalty/__tests__/config.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from "vitest";
+import { getTier } from "../config";
+
+describe("loyalty/config getTier", () => {
+  it("classifica por faixa de saldo", () => {
+    expect(getTier(0).name).toBe("Bronze");
+    expect(getTier(199).name).toBe("Bronze");
+    expect(getTier(200).name).toBe("Prata");
+    expect(getTier(499).name).toBe("Prata");
+    expect(getTier(500).name).toBe("Ouro");
+    expect(getTier(999).name).toBe("Ouro");
+    expect(getTier(1000).name).toBe("Diamante");
+    expect(getTier(5000).name).toBe("Diamante");
+  });
+});

--- a/src/components/loyalty/config.ts
+++ b/src/components/loyalty/config.ts
@@ -1,0 +1,13 @@
+// Tiers e helper de classificação do módulo de fidelidade.
+// Extraídos verbatim de src/pages/AdminLoyalty.tsx (god-component split).
+
+export const TIERS = [
+  { name: 'Bronze', min: 0, icon: '🥉' },
+  { name: 'Prata', min: 200, icon: '🥈' },
+  { name: 'Ouro', min: 500, icon: '🥇' },
+  { name: 'Diamante', min: 1000, icon: '💎' },
+];
+
+export function getTier(balance: number) {
+  return [...TIERS].reverse().find(t => balance >= t.min) || TIERS[0];
+}

--- a/src/components/loyalty/types.ts
+++ b/src/components/loyalty/types.ts
@@ -1,0 +1,29 @@
+// Tipos do módulo de fidelidade (loyalty).
+// Extraídos verbatim de src/pages/AdminLoyalty.tsx (god-component split).
+
+export interface CustomerPoints {
+  user_id: string;
+  name: string;
+  total_earned: number;
+  total_redeemed: number;
+  balance: number;
+}
+
+export interface PointRecord {
+  id: string;
+  user_id: string;
+  points: number;
+  type: string;
+  description: string | null;
+  created_at: string;
+  order_id: string | null;
+}
+
+export interface RedemptionRecord {
+  id: string;
+  user_id: string;
+  reward_name: string;
+  points_spent: number;
+  status: string;
+  created_at: string;
+}

--- a/src/components/loyalty/useAdminLoyalty.ts
+++ b/src/components/loyalty/useAdminLoyalty.ts
@@ -1,0 +1,185 @@
+// Hook de dados/estado do AdminLoyalty.
+// Extraído verbatim de src/pages/AdminLoyalty.tsx (god-component split):
+// state, redirect/load effects, loadData (3 queries + agregação por usuário),
+// ajuste de pontos e derivados econômicos.
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { supabase } from '@/integrations/supabase/client';
+import { useAuth } from '@/contexts/AuthContext';
+import { toast } from 'sonner';
+import type { CustomerPoints, PointRecord, RedemptionRecord } from './types';
+
+export function useAdminLoyalty() {
+  const navigate = useNavigate();
+  const { user, isStaff, loading: authLoading } = useAuth();
+
+  const [customers, setCustomers] = useState<CustomerPoints[]>([]);
+  const [allPoints, setAllPoints] = useState<PointRecord[]>([]);
+  const [redemptions, setRedemptions] = useState<RedemptionRecord[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [search, setSearch] = useState('');
+  const [selectedCustomer, setSelectedCustomer] = useState<CustomerPoints | null>(null);
+  const [customerHistory, setCustomerHistory] = useState<PointRecord[]>([]);
+
+  // Adjust points dialog
+  const [adjustOpen, setAdjustOpen] = useState(false);
+  const [adjustUserId, setAdjustUserId] = useState('');
+  const [adjustType, setAdjustType] = useState<'earn' | 'redeem'>('earn');
+  const [adjustPoints, setAdjustPoints] = useState('');
+  const [adjustDescription, setAdjustDescription] = useState('');
+  const [adjusting, setAdjusting] = useState(false);
+
+  useEffect(() => {
+    if (!authLoading && !isStaff) {
+      navigate('/', { replace: true });
+    }
+  }, [authLoading, isStaff, navigate]);
+
+  useEffect(() => {
+    if (user && isStaff) {
+      loadData();
+    }
+  }, [user, isStaff]);
+
+  const loadData = async () => {
+    try {
+      const [pointsRes, profilesRes, redemptionsRes] = await Promise.all([
+        supabase.from('loyalty_points').select('*').order('created_at', { ascending: false }),
+        supabase.from('profiles').select('user_id, name'),
+        supabase.from('loyalty_redemptions').select('*').order('created_at', { ascending: false }),
+      ]);
+
+      const points = (pointsRes.data || []) as PointRecord[];
+      const profiles = profilesRes.data || [];
+      const redData = (redemptionsRes.data || []) as RedemptionRecord[];
+      setAllPoints(points);
+      setRedemptions(redData);
+
+      // Aggregate by user
+      const userMap = new Map<string, CustomerPoints>();
+      for (const p of points) {
+        if (!userMap.has(p.user_id)) {
+          const profile = profiles.find(pr => pr.user_id === p.user_id);
+          userMap.set(p.user_id, {
+            user_id: p.user_id,
+            name: profile?.name || 'Desconhecido',
+            total_earned: 0,
+            total_redeemed: 0,
+            balance: 0,
+          });
+        }
+        const c = userMap.get(p.user_id)!;
+        if (p.type === 'earn') {
+          c.total_earned += p.points;
+        } else {
+          c.total_redeemed += Math.abs(p.points);
+        }
+        c.balance = c.total_earned - c.total_redeemed;
+      }
+
+      setCustomers(Array.from(userMap.values()).sort((a, b) => b.balance - a.balance));
+    } catch (err) {
+      console.error('Error loading loyalty data:', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const viewCustomerHistory = (customer: CustomerPoints) => {
+    setSelectedCustomer(customer);
+    setCustomerHistory(allPoints.filter(p => p.user_id === customer.user_id));
+  };
+
+  const openAdjust = (userId: string, type: 'earn' | 'redeem') => {
+    setAdjustUserId(userId);
+    setAdjustType(type);
+    setAdjustOpen(true);
+  };
+
+  const handleAdjustPoints = async () => {
+    if (!adjustPoints || !adjustUserId) return;
+    setAdjusting(true);
+
+    try {
+      const pts = parseInt(adjustPoints);
+      if (isNaN(pts) || pts <= 0) {
+        toast.error('Pontos inválidos');
+        return;
+      }
+
+      const { error } = await supabase.from('loyalty_points').insert({
+        user_id: adjustUserId,
+        points: adjustType === 'redeem' ? -pts : pts,
+        type: adjustType,
+        description: adjustDescription || (adjustType === 'earn' ? 'Pontos adicionados pelo admin' : 'Resgate aprovado pelo admin'),
+      });
+
+      if (error) throw error;
+
+      toast.success(adjustType === 'earn' ? 'Pontos adicionados!' : 'Resgate aprovado!');
+      setAdjustOpen(false);
+      setAdjustPoints('');
+      setAdjustDescription('');
+      loadData();
+    } catch (err) {
+      console.error('Error adjusting points:', err);
+      toast.error('Erro ao ajustar pontos');
+    } finally {
+      setAdjusting(false);
+    }
+  };
+
+  const totalPointsCirculating = customers.reduce((s, c) => s + c.balance, 0);
+  const totalEarned = customers.reduce((s, c) => s + c.total_earned, 0);
+  const totalRedeemed = customers.reduce((s, c) => s + c.total_redeemed, 0);
+
+  // Estimated liability: 1 pt ≈ R$0.01 (conservative estimate based on typical reward catalog)
+  const estimatedLiability = totalPointsCirculating * 0.01;
+  const redemptionRate = totalEarned > 0 ? ((totalRedeemed / totalEarned) * 100).toFixed(1) : '0';
+
+  // Top redeemed rewards
+  const rewardCounts = new Map<string, number>();
+  for (const r of redemptions) {
+    rewardCounts.set(r.reward_name, (rewardCounts.get(r.reward_name) || 0) + 1);
+  }
+  const topRewards = Array.from(rewardCounts.entries())
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 3);
+
+  // Top balance users (already sorted)
+  const topBalanceUsers = customers.slice(0, 5);
+
+  const filtered = customers.filter(c =>
+    c.name.toLowerCase().includes(search.toLowerCase())
+  );
+
+  return {
+    authLoading,
+    loading,
+    search,
+    setSearch,
+    selectedCustomer,
+    setSelectedCustomer,
+    customerHistory,
+    viewCustomerHistory,
+    openAdjust,
+    totalPointsCirculating,
+    totalEarned,
+    totalRedeemed,
+    estimatedLiability,
+    redemptionRate,
+    topRewards,
+    topBalanceUsers,
+    filtered,
+    // adjust dialog
+    adjustOpen,
+    setAdjustOpen,
+    adjustType,
+    adjustPoints,
+    setAdjustPoints,
+    adjustDescription,
+    setAdjustDescription,
+    adjusting,
+    handleAdjustPoints,
+  };
+}

--- a/src/pages/AdminLoyalty.tsx
+++ b/src/pages/AdminLoyalty.tsx
@@ -1,198 +1,43 @@
-import { useState, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
-import { Card, CardContent } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
-import { Input } from '@/components/ui/input';
-import { Textarea } from '@/components/ui/textarea';
-import { supabase } from '@/integrations/supabase/client';
-import { useAuth } from '@/contexts/AuthContext';
-import { toast } from 'sonner';
-import { Loader2, Search, Plus, Minus, Gift, Users, TrendingUp, DollarSign, BarChart3, Crown } from 'lucide-react';
-import { format } from 'date-fns';
-import { ptBR } from 'date-fns/locale';
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog';
-
-interface CustomerPoints {
-  user_id: string;
-  name: string;
-  total_earned: number;
-  total_redeemed: number;
-  balance: number;
-}
-
-interface PointRecord {
-  id: string;
-  user_id: string;
-  points: number;
-  type: string;
-  description: string | null;
-  created_at: string;
-  order_id: string | null;
-}
-
-interface RedemptionRecord {
-  id: string;
-  user_id: string;
-  reward_name: string;
-  points_spent: number;
-  status: string;
-  created_at: string;
-}
-
-const TIERS = [
-  { name: 'Bronze', min: 0, icon: '🥉' },
-  { name: 'Prata', min: 200, icon: '🥈' },
-  { name: 'Ouro', min: 500, icon: '🥇' },
-  { name: 'Diamante', min: 1000, icon: '💎' },
-];
-
-function getTier(balance: number) {
-  return [...TIERS].reverse().find(t => balance >= t.min) || TIERS[0];
-}
+// Fidelidade (loyalty) — pontos, tiers, ajustes e visão econômica.
+// Composição: useAdminLoyalty (dados/estado) + stats + insights + lista/detalhe + dialog.
+// God-component split de src/pages/AdminLoyalty.tsx (comportamento 1:1).
+import { Loader2 } from 'lucide-react';
+import { useAdminLoyalty } from '@/components/loyalty/useAdminLoyalty';
+import { AdjustDialog } from '@/components/loyalty/AdjustDialog';
+import { CustomerDetail } from '@/components/loyalty/CustomerDetail';
+import { LoyaltyStats } from '@/components/loyalty/LoyaltyStats';
+import { EconomicInsights } from '@/components/loyalty/EconomicInsights';
+import { CustomerList } from '@/components/loyalty/CustomerList';
 
 export default function AdminLoyalty() {
-  const navigate = useNavigate();
-  const { user, isStaff, loading: authLoading } = useAuth();
-
-  const [customers, setCustomers] = useState<CustomerPoints[]>([]);
-  const [allPoints, setAllPoints] = useState<PointRecord[]>([]);
-  const [redemptions, setRedemptions] = useState<RedemptionRecord[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [search, setSearch] = useState('');
-  const [selectedCustomer, setSelectedCustomer] = useState<CustomerPoints | null>(null);
-  const [customerHistory, setCustomerHistory] = useState<PointRecord[]>([]);
-
-  // Adjust points dialog
-  const [adjustOpen, setAdjustOpen] = useState(false);
-  const [adjustUserId, setAdjustUserId] = useState('');
-  const [adjustType, setAdjustType] = useState<'earn' | 'redeem'>('earn');
-  const [adjustPoints, setAdjustPoints] = useState('');
-  const [adjustDescription, setAdjustDescription] = useState('');
-  const [adjusting, setAdjusting] = useState(false);
-
-  useEffect(() => {
-    if (!authLoading && !isStaff) {
-      navigate('/', { replace: true });
-    }
-  }, [authLoading, isStaff, navigate]);
-
-  useEffect(() => {
-    if (user && isStaff) {
-      loadData();
-    }
-  }, [user, isStaff]);
-
-  const loadData = async () => {
-    try {
-      const [pointsRes, profilesRes, redemptionsRes] = await Promise.all([
-        supabase.from('loyalty_points').select('*').order('created_at', { ascending: false }),
-        supabase.from('profiles').select('user_id, name'),
-        supabase.from('loyalty_redemptions').select('*').order('created_at', { ascending: false }),
-      ]);
-
-      const points = (pointsRes.data || []) as PointRecord[];
-      const profiles = profilesRes.data || [];
-      const redData = (redemptionsRes.data || []) as RedemptionRecord[];
-      setAllPoints(points);
-      setRedemptions(redData);
-
-      // Aggregate by user
-      const userMap = new Map<string, CustomerPoints>();
-      for (const p of points) {
-        if (!userMap.has(p.user_id)) {
-          const profile = profiles.find(pr => pr.user_id === p.user_id);
-          userMap.set(p.user_id, {
-            user_id: p.user_id,
-            name: profile?.name || 'Desconhecido',
-            total_earned: 0,
-            total_redeemed: 0,
-            balance: 0,
-          });
-        }
-        const c = userMap.get(p.user_id)!;
-        if (p.type === 'earn') {
-          c.total_earned += p.points;
-        } else {
-          c.total_redeemed += Math.abs(p.points);
-        }
-        c.balance = c.total_earned - c.total_redeemed;
-      }
-
-      setCustomers(Array.from(userMap.values()).sort((a, b) => b.balance - a.balance));
-    } catch (err) {
-      console.error('Error loading loyalty data:', err);
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const viewCustomerHistory = (customer: CustomerPoints) => {
-    setSelectedCustomer(customer);
-    setCustomerHistory(allPoints.filter(p => p.user_id === customer.user_id));
-  };
-
-  const handleAdjustPoints = async () => {
-    if (!adjustPoints || !adjustUserId) return;
-    setAdjusting(true);
-
-    try {
-      const pts = parseInt(adjustPoints);
-      if (isNaN(pts) || pts <= 0) {
-        toast.error('Pontos inválidos');
-        return;
-      }
-
-      const { error } = await supabase.from('loyalty_points').insert({
-        user_id: adjustUserId,
-        points: adjustType === 'redeem' ? -pts : pts,
-        type: adjustType,
-        description: adjustDescription || (adjustType === 'earn' ? 'Pontos adicionados pelo admin' : 'Resgate aprovado pelo admin'),
-      });
-
-      if (error) throw error;
-
-      toast.success(adjustType === 'earn' ? 'Pontos adicionados!' : 'Resgate aprovado!');
-      setAdjustOpen(false);
-      setAdjustPoints('');
-      setAdjustDescription('');
-      loadData();
-    } catch (err) {
-      console.error('Error adjusting points:', err);
-      toast.error('Erro ao ajustar pontos');
-    } finally {
-      setAdjusting(false);
-    }
-  };
-
-  const totalPointsCirculating = customers.reduce((s, c) => s + c.balance, 0);
-  const totalEarned = customers.reduce((s, c) => s + c.total_earned, 0);
-  const totalRedeemed = customers.reduce((s, c) => s + c.total_redeemed, 0);
-
-  // Estimated liability: 1 pt ≈ R$0.01 (conservative estimate based on typical reward catalog)
-  const estimatedLiability = totalPointsCirculating * 0.01;
-  const redemptionRate = totalEarned > 0 ? ((totalRedeemed / totalEarned) * 100).toFixed(1) : '0';
-
-  // Top redeemed rewards
-  const rewardCounts = new Map<string, number>();
-  for (const r of redemptions) {
-    rewardCounts.set(r.reward_name, (rewardCounts.get(r.reward_name) || 0) + 1);
-  }
-  const topRewards = Array.from(rewardCounts.entries())
-    .sort((a, b) => b[1] - a[1])
-    .slice(0, 3);
-
-  // Top balance users (already sorted)
-  const topBalanceUsers = customers.slice(0, 5);
-
-  const filtered = customers.filter(c =>
-    c.name.toLowerCase().includes(search.toLowerCase())
-  );
+  const {
+    authLoading,
+    loading,
+    search,
+    setSearch,
+    selectedCustomer,
+    setSelectedCustomer,
+    customerHistory,
+    viewCustomerHistory,
+    openAdjust,
+    totalPointsCirculating,
+    totalEarned,
+    totalRedeemed,
+    estimatedLiability,
+    redemptionRate,
+    topRewards,
+    topBalanceUsers,
+    filtered,
+    adjustOpen,
+    setAdjustOpen,
+    adjustType,
+    adjustPoints,
+    setAdjustPoints,
+    adjustDescription,
+    setAdjustDescription,
+    adjusting,
+    handleAdjustPoints,
+  } = useAdminLoyalty();
 
   if (authLoading || loading) {
     return (
@@ -206,79 +51,15 @@ export default function AdminLoyalty() {
 
   // Detail view
   if (selectedCustomer) {
-    const tier = getTier(selectedCustomer.balance);
     return (
       <div className="min-h-screen bg-background pb-24">
-        <main className="pt-16 px-4 max-w-lg mx-auto space-y-4">
-          <Card>
-            <CardContent className="p-5">
-              <div className="flex items-center justify-between mb-3">
-                <div>
-                  <p className="text-xs text-muted-foreground uppercase">Saldo</p>
-                  <p className="text-3xl font-bold text-foreground">{selectedCustomer.balance} pts</p>
-                </div>
-                <div className="text-center">
-                  <span className="text-3xl">{tier.icon}</span>
-                  <p className="text-xs font-medium text-muted-foreground">{tier.name}</p>
-                </div>
-              </div>
-              <div className="flex gap-4 text-sm text-muted-foreground">
-                <span>Ganhos: <strong className="text-foreground">{selectedCustomer.total_earned}</strong></span>
-                <span>Resgatados: <strong className="text-foreground">{selectedCustomer.total_redeemed}</strong></span>
-              </div>
-            </CardContent>
-          </Card>
-
-          <div className="flex gap-2">
-            <Button
-              className="flex-1"
-              onClick={() => {
-                setAdjustUserId(selectedCustomer.user_id);
-                setAdjustType('earn');
-                setAdjustOpen(true);
-              }}
-            >
-              <Plus className="w-4 h-4 mr-1" /> Adicionar Pontos
-            </Button>
-            <Button
-              variant="outline"
-              className="flex-1"
-              onClick={() => {
-                setAdjustUserId(selectedCustomer.user_id);
-                setAdjustType('redeem');
-                setAdjustOpen(true);
-              }}
-            >
-              <Minus className="w-4 h-4 mr-1" /> Resgatar
-            </Button>
-          </div>
-
-          <h3 className="font-display font-bold text-foreground">Histórico</h3>
-          <div className="space-y-2">
-            {customerHistory.map(item => (
-              <Card key={item.id}>
-                <CardContent className="p-3 flex items-center justify-between">
-                  <div>
-                    <p className="text-sm font-medium text-foreground">{item.description || 'Pontos'}</p>
-                    <p className="text-xs text-muted-foreground">
-                      {format(new Date(item.created_at), "dd/MM/yyyy 'às' HH:mm", { locale: ptBR })}
-                    </p>
-                  </div>
-                  <Badge variant={item.type === 'earn' ? 'default' : 'destructive'}>
-                    {item.type === 'earn' ? '+' : ''}{item.points} pts
-                  </Badge>
-                </CardContent>
-              </Card>
-            ))}
-            {customerHistory.length === 0 && (
-              <p className="text-sm text-muted-foreground text-center py-4">Sem histórico</p>
-            )}
-          </div>
-
-          <Button variant="ghost" className="w-full" onClick={() => setSelectedCustomer(null)}>
-            ← Voltar à lista
-          </Button>
-        </main>
+        <CustomerDetail
+          customer={selectedCustomer}
+          history={customerHistory}
+          onAddPoints={() => openAdjust(selectedCustomer.user_id, 'earn')}
+          onRedeem={() => openAdjust(selectedCustomer.user_id, 'redeem')}
+          onBack={() => setSelectedCustomer(null)}
+        />
 
         {/* Adjust Dialog */}
         <AdjustDialog
@@ -301,160 +82,28 @@ export default function AdminLoyalty() {
 
       <main className="pt-16 px-4 max-w-lg mx-auto space-y-4">
         {/* Stats */}
-        <div className="grid grid-cols-3 gap-3">
-          <Card className="text-center">
-            <CardContent className="pt-4 pb-3">
-              <TrendingUp className="w-5 h-5 mx-auto text-primary mb-1" />
-              <p className="text-xl font-bold text-foreground">{totalPointsCirculating}</p>
-              <p className="text-[10px] text-muted-foreground">Em circulação</p>
-            </CardContent>
-          </Card>
-          <Card className="text-center">
-            <CardContent className="pt-4 pb-3">
-              <Plus className="w-5 h-5 mx-auto text-emerald-500 mb-1" />
-              <p className="text-xl font-bold text-foreground">{totalEarned}</p>
-              <p className="text-[10px] text-muted-foreground">Total ganhos</p>
-            </CardContent>
-          </Card>
-          <Card className="text-center">
-            <CardContent className="pt-4 pb-3">
-              <Gift className="w-5 h-5 mx-auto text-amber-500 mb-1" />
-              <p className="text-xl font-bold text-foreground">{totalRedeemed}</p>
-              <p className="text-[10px] text-muted-foreground">Resgatados</p>
-            </CardContent>
-          </Card>
-        </div>
+        <LoyaltyStats
+          totalPointsCirculating={totalPointsCirculating}
+          totalEarned={totalEarned}
+          totalRedeemed={totalRedeemed}
+        />
 
         {/* Economic insights */}
-        <Card>
-          <CardContent className="p-4 space-y-3">
-            <div className="flex items-center gap-2 mb-1">
-              <DollarSign className="w-4 h-4 text-primary" />
-              <h3 className="text-sm font-semibold text-foreground">Visão Econômica</h3>
-            </div>
-            <div className="grid grid-cols-2 gap-3">
-              <div className="rounded-lg bg-muted p-3">
-                <p className="text-[10px] text-muted-foreground uppercase tracking-wide">Passivo estimado</p>
-                <p className="text-lg font-bold text-foreground">
-                  R$ {estimatedLiability.toFixed(2)}
-                </p>
-                <p className="text-[10px] text-muted-foreground">se todos resgatassem</p>
-              </div>
-              <div className="rounded-lg bg-muted p-3">
-                <p className="text-[10px] text-muted-foreground uppercase tracking-wide">Taxa de resgate</p>
-                <p className="text-lg font-bold text-foreground">{redemptionRate}%</p>
-                <p className="text-[10px] text-muted-foreground">resgatados / emitidos</p>
-              </div>
-            </div>
+        <EconomicInsights
+          estimatedLiability={estimatedLiability}
+          redemptionRate={redemptionRate}
+          topRewards={topRewards}
+          topBalanceUsers={topBalanceUsers}
+        />
 
-            {topRewards.length > 0 && (
-              <div>
-                <div className="flex items-center gap-1.5 mb-1.5">
-                  <BarChart3 className="w-3.5 h-3.5 text-muted-foreground" />
-                  <p className="text-xs font-medium text-muted-foreground">Recompensas mais resgatadas</p>
-                </div>
-                <div className="space-y-1">
-                  {topRewards.map(([name, count]) => (
-                    <div key={name} className="flex items-center justify-between text-sm">
-                      <span className="text-foreground truncate">{name}</span>
-                      <Badge variant="secondary" className="text-xs">{count}x</Badge>
-                    </div>
-                  ))}
-                </div>
-              </div>
-            )}
-
-            {topBalanceUsers.length > 0 && (
-              <div>
-                <div className="flex items-center gap-1.5 mb-1.5">
-                  <Crown className="w-3.5 h-3.5 text-muted-foreground" />
-                  <p className="text-xs font-medium text-muted-foreground">Maiores saldos</p>
-                </div>
-                <div className="space-y-1">
-                  {topBalanceUsers.map(u => (
-                    <div key={u.user_id} className="flex items-center justify-between text-sm">
-                      <span className="text-foreground truncate">{u.name}</span>
-                      <span className="font-medium text-foreground">{u.balance} pts</span>
-                    </div>
-                  ))}
-                </div>
-              </div>
-            )}
-          </CardContent>
-        </Card>
-
-
-        <div className="relative">
-          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
-          <Input
-            placeholder="Buscar cliente..."
-            value={search}
-            onChange={e => setSearch(e.target.value)}
-            className="pl-10"
-          />
-        </div>
-
-        {/* Customer list */}
-        <div className="space-y-2">
-          {filtered.length === 0 && (
-            <Card>
-              <CardContent className="p-6 text-center">
-                <Users className="w-8 h-8 text-muted-foreground mx-auto mb-2" />
-                <p className="text-sm text-muted-foreground">
-                  {search ? 'Nenhum cliente encontrado' : 'Nenhum cliente com pontos ainda'}
-                </p>
-              </CardContent>
-            </Card>
-          )}
-          {filtered.map(customer => {
-            const tier = getTier(customer.balance);
-            return (
-              <Card
-                key={customer.user_id}
-                className="cursor-pointer hover:shadow-medium transition-shadow"
-                onClick={() => viewCustomerHistory(customer)}
-              >
-                <CardContent className="p-4 flex items-center justify-between">
-                  <div className="flex items-center gap-3">
-                    <span className="text-2xl">{tier.icon}</span>
-                    <div>
-                      <p className="font-semibold text-foreground">{customer.name}</p>
-                      <p className="text-xs text-muted-foreground">
-                        {tier.name} · {customer.balance} pontos
-                      </p>
-                    </div>
-                  </div>
-                  <div className="flex gap-1">
-                    <Button
-                      size="sm"
-                      variant="ghost"
-                      onClick={e => {
-                        e.stopPropagation();
-                        setAdjustUserId(customer.user_id);
-                        setAdjustType('earn');
-                        setAdjustOpen(true);
-                      }}
-                    >
-                      <Plus className="w-4 h-4" />
-                    </Button>
-                    <Button
-                      size="sm"
-                      variant="ghost"
-                      onClick={e => {
-                        e.stopPropagation();
-                        setAdjustUserId(customer.user_id);
-                        setAdjustType('redeem');
-                        setAdjustOpen(true);
-                      }}
-                    >
-                      <Gift className="w-4 h-4" />
-                    </Button>
-                  </div>
-                </CardContent>
-              </Card>
-            );
-          })}
-        </div>
+        <CustomerList
+          search={search}
+          onSearchChange={setSearch}
+          filtered={filtered}
+          onView={viewCustomerHistory}
+          onQuickEarn={(userId) => openAdjust(userId, 'earn')}
+          onQuickRedeem={(userId) => openAdjust(userId, 'redeem')}
+        />
       </main>
 
 
@@ -471,56 +120,5 @@ export default function AdminLoyalty() {
         loading={adjusting}
       />
     </div>
-  );
-}
-
-function AdjustDialog({
-  open, onOpenChange, type, points, setPoints, description, setDescription, onSubmit, loading,
-}: {
-  open: boolean;
-  onOpenChange: (v: boolean) => void;
-  type: 'earn' | 'redeem';
-  points: string;
-  setPoints: (v: string) => void;
-  description: string;
-  setDescription: (v: string) => void;
-  onSubmit: () => void;
-  loading: boolean;
-}) {
-  return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>
-            {type === 'earn' ? '➕ Adicionar Pontos' : '🎁 Aprovar Resgate'}
-          </DialogTitle>
-        </DialogHeader>
-        <div className="space-y-4">
-          <div>
-            <label className="text-sm font-medium text-foreground">Pontos</label>
-            <Input
-              type="number"
-              min="1"
-              value={points}
-              onChange={e => setPoints(e.target.value)}
-              placeholder="Ex: 100"
-            />
-          </div>
-          <div>
-            <label className="text-sm font-medium text-foreground">Descrição</label>
-            <Textarea
-              value={description}
-              onChange={e => setDescription(e.target.value)}
-              placeholder={type === 'earn' ? 'Motivo do bônus...' : 'Recompensa resgatada...'}
-              rows={2}
-            />
-          </div>
-          <Button onClick={onSubmit} disabled={loading || !points} className="w-full">
-            {loading ? <Loader2 className="w-4 h-4 animate-spin mr-2" /> : null}
-            {type === 'earn' ? 'Adicionar Pontos' : 'Aprovar Resgate'}
-          </Button>
-        </div>
-      </DialogContent>
-    </Dialog>
   );
 }


### PR DESCRIPTION
## Resumo
Quebra o god-component `src/pages/AdminLoyalty.tsx` (**526→124L**) em um hook de dados/estado + componentes presentacionais controlados, sob `src/components/loyalty/`. Extração **verbatim** — comportamento preservado 1:1.

## O que mudou
- **`useAdminLoyalty`** (hook): state, effects (redirect non-staff + load), `loadData` (3 queries + agregação por usuário), ajuste de pontos e derivados econômicos (passivo/taxa de resgate/top recompensas/top saldos).
- **`AdjustDialog`** — dialog de ajuste de pontos (adicionar/aprovar resgate).
- **`CustomerDetail`** — visão de detalhe (saldo, tier, ações, histórico).
- **`LoyaltyStats`** — grid de KPIs.
- **`EconomicInsights`** — card "Visão Econômica".
- **`CustomerList`** — busca + lista de clientes.
- **`types.ts`** / **`config.ts`** (`TIERS`/`getTier`).
- **+17 testes** (helpers puros + presentacionais).

## Verificação
- `bunx tsc --noEmit` (baseline) = **0**
- `eslint` = **0 erros / 0 warnings**
- **17/17 testes** verdes (isolados)
- Revisão independente FIEL 1:1: **aprovada** (queries/agregação/derivados/3 views/dialog em ambos os branches conferidos)

## Migrations
Nenhuma.

🤖 Generated with [Claude Code](https://claude.com/claude-code)