### PR TITLE
feat(carteira): Sub-PR E — saúde/observabilidade da carteira (semáforo)

### DIFF
--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,13 +21,13 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **60** custom migrations totais
-- **333** objetos esperados (criados por estas migrations)
+- **61** custom migrations totais
+- **334** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
   - `rls_policy`: 104
   - `index`: 95
   - `table`: 51
-  - `function`: 33
+  - `function`: 34
   - `trigger`: 31
   - `cron_job`: 15
   - `enum_value`: 4
@@ -657,6 +657,12 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | `table` | `public.carteira_positivacao_snapshot` | — |
 | `index` | `public.idx_sales_orders_kpi_date` | `sales_orders` |
 | `function` | `public.get_minha_positivacao` | — |
+
+### `20260525160000_carteira_saude_rpc.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `public.get_carteira_saude` | — |
 
 ## Próximos passos quando algo der `❌`
 

--- a/docs/superpowers/specs/2026-05-25-carteira-saude-observabilidade-design.md
+++ b/docs/superpowers/specs/2026-05-25-carteira-saude-observabilidade-design.md
@@ -1,0 +1,39 @@
+# Sub-PR E — Saúde da Carteira (observabilidade/confiabilidade) — Design
+
+> **Status:** decidido por mim + codex consult (2026-05-25). Direção: a próxima entrega é confiabilidade (Codex), não expansão de superfície. Net-new, zero-colisão (carteira é "minha", recém-entregue), backlog §10 drenado.
+> **Branch:** `feat/carteira-saude` (a partir de `main`).
+
+## Problema
+O programa Carteira-Omie (A+B+D) acabou de subir: cron-pesado, business-critical e **silenciosamente degradável** — nada na UI diz se está funcionando. Falhas invisíveis: crons (`carteira-rebuild-nightly`, `scoring-recalc-batch-nightly`, `visit-score-recalc-batch-nightly`, `carteira-positivacao-snapshot-mensal`) falhando calado; `carteira_assignments.last_synced_at` envelhecendo (o spec da carteira já queria um monitor ">48h"); score coverage derivando (deveria ser 1 linha/cliente = tamanho da carteira). Hoje só dá pra saber rodando SQL na mão.
+
+## Decisão (anti-over-build, Codex)
+**Um painel read-only de SEMÁFORO operacional** (verde/amarelo/vermelho + limiar + contagem afetada + próxima ação), **não** um dashboard de gráficos. Dentro da página existente `/admin/analytics-sync` (`AdminAnalyticsSync`), como um card no topo — não cria área nova.
+
+## Sinais MVP (rankeados pelo Codex)
+1. **Saúde dos crons** — pros 4 jobs da carteira: último run, status, idade, última mensagem de erro. Pega a maior classe de falha silenciosa. Fonte: `cron.job` × `cron.job_run_details`.
+2. **Frescor do sync** — `max(carteira_assignments.last_synced_at)`, idade, contagem stale/null; **vermelho se >48h**. (Deferido no spec da carteira — agora entregue.)
+3. **Cobertura de score** — `count(carteira_assignments)` vs `count(distinct customer_user_id)` em `farmer_client_scores` e `customer_visit_scores`. Pega "sugestões/positivação vazias ou tortas" antes do usuário ver.
+
+**Adiado de propósito:** `order_date_kpi` coverage (detalhe menor pós-backfill); positivação por dono (KPI já vive no fluxo do vendedor); **"clientes não-vinculados"** (semântica ambígua em `omie_clientes.user_id` — não shipar número errado; vira item futuro quando a definição estiver clara).
+
+## Arquitetura
+- **RPC `get_carteira_saude()`** `SECURITY DEFINER` (gate master/staff via `has_role`; sem param). Lê `cron.job`×`cron.job_run_details` (precisa de DEFINER — staff não lê schema `cron`; as views `v_cron_jobs_*` existentes são `security_invoker=on` e não servem pra UI), `carteira_assignments`, `farmer_client_scores`, `customer_visit_scores`. Retorna jsonb com os 3 sinais (dados crus — sem decisão de cor no SQL).
+- **Helper puro `src/lib/carteira-saude/status.ts` (TDD):** `statusFor*(...)` → `{ nivel: 'green'|'yellow'|'red', acao: string }` por sinal (a regra de limiar/cor vive aqui, testável; o SQL só dá os números).
+- **Hook `useCarteiraSaude()`** chama a RPC, aplica o helper.
+- **`CarteiraSaudePanel.tsx`** — card semáforo (dot colorido + label + detalhe + próxima ação por check). Montado no topo do `AdminAnalyticsSync`.
+
+## Limiares (no helper, testáveis)
+- **Cron:** `red` se último status = `failed`/`failure`, ou idade > 2× intervalo esperado (nightly→48h; mensal→sem alerta de idade no dia-a-dia); `yellow` se nunca rodou; `green` se sucesso recente. Ação no red: "ver logs / reinvocar no Lovable".
+- **Sync:** `red` se idade `>48h` OU `stale/null > 0`; `yellow` 24–48h; `green` `<24h`. Ação: "rodar carteira-rebuild".
+- **Score coverage:** `red` se `fcs_clientes != carteira` ou `cvs_clientes != carteira`; `green` se iguais. Ação: "rodar calculate-scores + drain de visit".
+
+## Risco (Codex) + mitigação
+Dashboard passivo que ninguém abre → **checklist operacional acionável**, não analytics. Sem tendências/gráficos/leaderboard. Próxima ação humana em cada check. (Alerta proativo no topo da área de sync se algo vermelho = follow-up; v1 entrega o painel.)
+
+## Rollout
+1. SQL Editor: migration com a RPC `get_carteira_saude()`.
+2. Frontend (helper+hook+painel+placement) via PR/CI.
+3. Validar no app `/admin/analytics-sync` (master).
+
+## TDD
+Helper `status.ts` 100% TDD (limiares). RPC validada via SQL (números batem com queries manuais).

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 60
+-- Total de custom migrations: 61
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -79,7 +79,8 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260525000000', 'fin_crons_por_entidade', '20260525000000_fin_crons_por_entidade.sql'),
   ('20260525010000', 'fin_audit_skip_service_role', '20260525010000_fin_audit_skip_service_role.sql'),
   ('20260525020000', 'fin_sync_cursor', '20260525020000_fin_sync_cursor.sql'),
-  ('20260525120000', 'positivacao_kpis', '20260525120000_positivacao_kpis.sql')
+  ('20260525120000', 'positivacao_kpis', '20260525120000_positivacao_kpis.sql'),
+  ('20260525160000', 'carteira_saude_rpc', '20260525160000_carteira_saude_rpc.sql')
 )
 SELECT
   e.version,
@@ -430,7 +431,8 @@ WITH expected_objects (migration, kind, schema_name, object_name, parent_name) A
   ('fin_sync_cursor', 'rls_policy', 'public', 'fin_sync_cursor_service_all', 'fin_sync_cursor'),
   ('positivacao_kpis', 'table', 'public', 'carteira_positivacao_snapshot', ''),
   ('positivacao_kpis', 'index', 'public', 'idx_sales_orders_kpi_date', 'sales_orders'),
-  ('positivacao_kpis', 'function', 'public', 'get_minha_positivacao', '')
+  ('positivacao_kpis', 'function', 'public', 'get_minha_positivacao', ''),
+  ('carteira_saude_rpc', 'function', 'public', 'get_carteira_saude', '')
 )
 SELECT
   e.migration,

--- a/src/components/carteira/CarteiraSaudePanel.tsx
+++ b/src/components/carteira/CarteiraSaudePanel.tsx
@@ -1,0 +1,76 @@
+import { Card, CardHeader, CardTitle } from '@/components/ui/card';
+import { Loader2 } from 'lucide-react';
+import { useCarteiraSaude } from '@/hooks/useCarteiraSaude';
+import { statusCron, statusSync, statusCoverage, nivelAgregado } from '@/lib/carteira-saude/status';
+import type { SaudeNivel } from '@/lib/carteira-saude/types';
+
+const DOT: Record<SaudeNivel, string> = {
+  green: 'bg-status-success-bold',
+  yellow: 'bg-status-warning-bold',
+  red: 'bg-status-error-bold',
+};
+
+const NIGHTLY_MAX_AGE = 48;
+const MENSAL = 'carteira-positivacao-snapshot-mensal';
+
+function Row({ nivel, label, detail, acao }: { nivel: SaudeNivel; label: string; detail: string; acao: string }) {
+  return (
+    <div className="flex items-start gap-3 py-2">
+      <span className={`mt-1 h-2.5 w-2.5 rounded-full shrink-0 ${DOT[nivel]}`} />
+      <div className="min-w-0">
+        <div className="text-sm font-medium">
+          {label} <span className="text-2xs text-muted-foreground font-normal">{detail}</span>
+        </div>
+        {nivel !== 'green' && <div className="text-2xs text-muted-foreground">{acao}</div>}
+      </div>
+    </div>
+  );
+}
+
+export function CarteiraSaudePanel() {
+  const { data, isLoading } = useCarteiraSaude();
+
+  if (isLoading) {
+    return (
+      <Card className="p-6 flex justify-center">
+        <Loader2 className="w-5 h-5 animate-spin text-muted-foreground" />
+      </Card>
+    );
+  }
+  if (!data) return null;
+
+  const cronRows = data.crons.map((c) => {
+    const st = statusCron(c, c.jobname === MENSAL ? null : NIGHTLY_MAX_AGE);
+    const detail = c.last_run_at ? `${c.last_status ?? '?'} · há ${c.age_hours ?? '?'}h` : 'nunca rodou';
+    return { ...st, label: c.jobname, detail };
+  });
+  const syncSt = statusSync(data.sync);
+  const syncDetail = data.sync.age_hours == null
+    ? 'sem sync'
+    : `há ${data.sync.age_hours}h · ${data.sync.stale_count} stale`;
+  const covSt = statusCoverage(data.score_coverage);
+  const covDetail = `${data.score_coverage.fcs_clientes}/${data.score_coverage.carteira} score · ${data.score_coverage.cvs_clientes}/${data.score_coverage.carteira} visita`;
+
+  const agregado = nivelAgregado([...cronRows.map((r) => r.nivel), syncSt.nivel, covSt.nivel]);
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-sm flex items-center gap-2">
+          <span className={`h-2.5 w-2.5 rounded-full ${DOT[agregado]}`} />
+          Saúde da carteira
+        </CardTitle>
+        <p className="text-2xs text-muted-foreground">
+          Crons, frescor do sync Omie e cobertura de score. Semáforo operacional — vermelho = ação necessária.
+        </p>
+      </CardHeader>
+      <div className="px-6 pb-4 divide-y divide-border">
+        <Row nivel={syncSt.nivel} label="Sync da carteira" detail={syncDetail} acao={syncSt.acao} />
+        <Row nivel={covSt.nivel} label="Cobertura de score" detail={covDetail} acao={covSt.acao} />
+        {cronRows.map((r) => (
+          <Row key={r.label} nivel={r.nivel} label={r.label} detail={r.detail} acao={r.acao} />
+        ))}
+      </div>
+    </Card>
+  );
+}

--- a/src/hooks/useCarteiraSaude.ts
+++ b/src/hooks/useCarteiraSaude.ts
@@ -1,0 +1,25 @@
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import { useAuth } from '@/contexts/AuthContext';
+import type { CarteiraSaudeResumo } from '@/lib/carteira-saude/types';
+
+/**
+ * Saúde/observabilidade da carteira (crons, frescor do sync, cobertura de score).
+ * RPC SECURITY DEFINER get_carteira_saude() (gate staff via auth.uid()).
+ */
+export function useCarteiraSaude() {
+  const { isStaff } = useAuth();
+  return useQuery({
+    queryKey: ['carteira-saude'],
+    enabled: isStaff,
+    staleTime: 60_000,
+    queryFn: async (): Promise<CarteiraSaudeResumo | null> => {
+      // RPC ainda não nos tipos gerados — cast no boundary (preserva `this` do client).
+      const { data, error } = await (supabase as unknown as {
+        rpc(fn: string): Promise<{ data: unknown; error: { message: string } | null }>;
+      }).rpc('get_carteira_saude');
+      if (error) throw new Error(error.message);
+      return (data as CarteiraSaudeResumo) ?? null;
+    },
+  });
+}

--- a/src/lib/carteira-saude/__tests__/status.test.ts
+++ b/src/lib/carteira-saude/__tests__/status.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { statusCron, statusSync, statusCoverage, nivelAgregado } from '../status';
+
+describe('statusCron', () => {
+  it('nunca rodou → yellow', () => {
+    expect(statusCron({ last_status: null, age_hours: null }, 48).nivel).toBe('yellow');
+  });
+  it('última falhou → red', () => {
+    expect(statusCron({ last_status: 'failed', age_hours: 1 }, 48).nivel).toBe('red');
+    expect(statusCron({ last_status: 'failure', age_hours: 1 }, 48).nivel).toBe('red');
+  });
+  it('atrasado além do maxAge → red', () => {
+    expect(statusCron({ last_status: 'succeeded', age_hours: 60 }, 48).nivel).toBe('red');
+  });
+  it('sucesso recente → green', () => {
+    expect(statusCron({ last_status: 'succeeded', age_hours: 10 }, 48).nivel).toBe('green');
+  });
+  it('maxAge null (mensal) não alerta por idade → green', () => {
+    expect(statusCron({ last_status: 'succeeded', age_hours: 600 }, null).nivel).toBe('green');
+  });
+});
+
+describe('statusSync', () => {
+  it('sem sync → yellow', () => {
+    expect(statusSync({ age_hours: null, stale_count: 0 }).nivel).toBe('yellow');
+  });
+  it('>48h → red', () => {
+    expect(statusSync({ age_hours: 50, stale_count: 0 }).nivel).toBe('red');
+  });
+  it('stale_count > 0 → red', () => {
+    expect(statusSync({ age_hours: 2, stale_count: 5 }).nivel).toBe('red');
+  });
+  it('24-48h → yellow', () => {
+    expect(statusSync({ age_hours: 30, stale_count: 0 }).nivel).toBe('yellow');
+  });
+  it('<24h → green', () => {
+    expect(statusSync({ age_hours: 5, stale_count: 0 }).nivel).toBe('green');
+  });
+});
+
+describe('statusCoverage', () => {
+  it('carteira vazia → yellow', () => {
+    expect(statusCoverage({ carteira: 0, fcs_clientes: 0, cvs_clientes: 0 }).nivel).toBe('yellow');
+  });
+  it('mismatch → red', () => {
+    expect(statusCoverage({ carteira: 6908, fcs_clientes: 6900, cvs_clientes: 6908 }).nivel).toBe('red');
+  });
+  it('cobertura completa → green', () => {
+    expect(statusCoverage({ carteira: 6908, fcs_clientes: 6908, cvs_clientes: 6908 }).nivel).toBe('green');
+  });
+});
+
+describe('nivelAgregado', () => {
+  it('red ganha', () => {
+    expect(nivelAgregado(['green', 'yellow', 'red'])).toBe('red');
+  });
+  it('yellow sobre green', () => {
+    expect(nivelAgregado(['green', 'yellow', 'green'])).toBe('yellow');
+  });
+  it('tudo green → green', () => {
+    expect(nivelAgregado(['green', 'green'])).toBe('green');
+  });
+});

--- a/src/lib/carteira-saude/status.ts
+++ b/src/lib/carteira-saude/status.ts
@@ -1,0 +1,45 @@
+import type { CronSaude, SyncSaude, CoverageSaude, SaudeStatus, SaudeNivel } from './types';
+
+const FALHA = new Set(['failed', 'failure', 'error']);
+
+/**
+ * Status de um cron. `maxAgeHours` = idade máxima tolerada antes de alertar
+ * (nightly = 48; mensal = null → não alerta por idade no dia-a-dia).
+ */
+export function statusCron(
+  c: Pick<CronSaude, 'last_status' | 'age_hours'>,
+  maxAgeHours: number | null,
+): SaudeStatus {
+  if (!c.last_status) return { nivel: 'yellow', acao: 'Nunca rodou — agendar/invocar no Lovable.' };
+  if (FALHA.has(c.last_status.toLowerCase())) {
+    return { nivel: 'red', acao: 'Última execução falhou — ver logs / reinvocar no Lovable.' };
+  }
+  if (maxAgeHours != null && c.age_hours != null && c.age_hours > maxAgeHours) {
+    return { nivel: 'red', acao: `Atrasado — não roda há ${Math.round(c.age_hours)}h.` };
+  }
+  return { nivel: 'green', acao: 'OK.' };
+}
+
+export function statusSync(s: Pick<SyncSaude, 'age_hours' | 'stale_count'>): SaudeStatus {
+  if (s.age_hours == null) return { nivel: 'yellow', acao: 'Sem sync registrado da carteira.' };
+  if (s.age_hours > 48 || s.stale_count > 0) {
+    return { nivel: 'red', acao: 'Sync da carteira velho (>48h) — rodar carteira-rebuild.' };
+  }
+  if (s.age_hours > 24) return { nivel: 'yellow', acao: 'Sync entre 24-48h — acompanhar.' };
+  return { nivel: 'green', acao: 'OK.' };
+}
+
+export function statusCoverage(c: CoverageSaude): SaudeStatus {
+  if (c.carteira === 0) return { nivel: 'yellow', acao: 'Carteira vazia — rodar carteira-rebuild.' };
+  if (c.fcs_clientes !== c.carteira || c.cvs_clientes !== c.carteira) {
+    return { nivel: 'red', acao: 'Cobertura de score incompleta — rodar calculate-scores + drain do visit.' };
+  }
+  return { nivel: 'green', acao: 'OK.' };
+}
+
+/** Pior nível entre os checks, pro indicador agregado do topo. */
+export function nivelAgregado(niveis: SaudeNivel[]): SaudeNivel {
+  if (niveis.includes('red')) return 'red';
+  if (niveis.includes('yellow')) return 'yellow';
+  return 'green';
+}

--- a/src/lib/carteira-saude/types.ts
+++ b/src/lib/carteira-saude/types.ts
@@ -1,0 +1,32 @@
+export type SaudeNivel = 'green' | 'yellow' | 'red';
+
+export interface SaudeStatus {
+  nivel: SaudeNivel;
+  acao: string;
+}
+
+export interface CronSaude {
+  jobname: string;
+  last_status: string | null;
+  last_run_at: string | null;
+  age_hours: number | null;
+  last_error: string | null;
+}
+
+export interface SyncSaude {
+  max_last_synced_at: string | null;
+  age_hours: number | null;
+  stale_count: number;
+}
+
+export interface CoverageSaude {
+  carteira: number;
+  fcs_clientes: number;
+  cvs_clientes: number;
+}
+
+export interface CarteiraSaudeResumo {
+  crons: CronSaude[];
+  sync: SyncSaude;
+  score_coverage: CoverageSaude;
+}

--- a/src/pages/AdminAnalyticsSync.tsx
+++ b/src/pages/AdminAnalyticsSync.tsx
@@ -7,6 +7,7 @@ import { SyncEntitiesGrid } from "@/components/analyticsSync/SyncEntitiesGrid";
 import { ImportClientesCard, ImportEnderecosCard, ImportPedidosCard } from "@/components/analyticsSync/ImportCards";
 import { CostEngineCard, AssociationRulesCard } from "@/components/analyticsSync/EngineCards";
 import { EngineConfigCard } from "@/components/analyticsSync/EngineConfigCard";
+import { CarteiraSaudePanel } from "@/components/carteira/CarteiraSaudePanel";
 
 export default function AdminAnalyticsSync() {
   const {
@@ -60,6 +61,9 @@ export default function AdminAnalyticsSync() {
           </Button>
         </div>
       </div>
+
+      {/* Saúde da carteira (observabilidade — semáforo) */}
+      <CarteiraSaudePanel />
 
       {/* Sync Entities */}
       <SyncEntitiesGrid

--- a/supabase/migrations/20260525160000_carteira_saude_rpc.sql
+++ b/supabase/migrations/20260525160000_carteira_saude_rpc.sql
@@ -1,0 +1,81 @@
+-- 20260525160000_carteira_saude_rpc.sql
+-- Sub-PR E: RPC de saúde/observabilidade da carteira (semáforo no /admin/analytics-sync).
+-- SECURITY DEFINER (lê cron.* que staff não acessa); gate master/staff. Read-only.
+
+CREATE OR REPLACE FUNCTION public.get_carteira_saude()
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  uid uuid := auth.uid();
+  result jsonb;
+BEGIN
+  IF uid IS NULL THEN RETURN NULL; END IF;
+  IF NOT (has_role(uid, 'master'::app_role) OR has_role(uid, 'employee'::app_role)) THEN
+    RETURN NULL;
+  END IF;
+
+  SELECT jsonb_build_object(
+    -- 1. Saúde dos 4 crons da carteira (último run via cron.job × job_run_details)
+    'crons', COALESCE((
+      SELECT jsonb_agg(jsonb_build_object(
+        'jobname', j.jobname,
+        'last_status', r.status,
+        'last_run_at', r.start_time,
+        'age_hours', CASE WHEN r.start_time IS NULL THEN NULL
+                          ELSE round(extract(epoch FROM (now() - r.start_time)) / 3600.0, 1) END,
+        'last_error', CASE WHEN lower(coalesce(r.status, '')) IN ('failed','failure','error')
+                           THEN r.return_message ELSE NULL END
+      ) ORDER BY j.jobname)
+      FROM cron.job j
+      LEFT JOIN LATERAL (
+        SELECT d.status, d.start_time, d.return_message
+        FROM cron.job_run_details d
+        WHERE d.jobid = j.jobid
+        ORDER BY d.start_time DESC NULLS LAST
+        LIMIT 1
+      ) r ON true
+      WHERE j.jobname IN (
+        'carteira-rebuild-nightly',
+        'scoring-recalc-batch-nightly',
+        'visit-score-recalc-batch-nightly',
+        'carteira-positivacao-snapshot-mensal'
+      )
+    ), '[]'::jsonb),
+
+    -- 2. Frescor do sync da carteira
+    'sync', (
+      SELECT jsonb_build_object(
+        'max_last_synced_at', max(last_synced_at),
+        'age_hours', CASE WHEN max(last_synced_at) IS NULL THEN NULL
+                          ELSE round(extract(epoch FROM (now() - max(last_synced_at))) / 3600.0, 1) END,
+        'stale_count', count(*) FILTER (
+          WHERE last_synced_at IS NULL OR last_synced_at < now() - interval '48 hours')
+      )
+      FROM public.carteira_assignments
+    ),
+
+    -- 3. Cobertura de score: clientes da carteira COM linha de score (EXISTS evita falso-alarme de órfãos)
+    'score_coverage', jsonb_build_object(
+      'carteira', (SELECT count(*) FROM public.carteira_assignments),
+      'fcs_clientes', (
+        SELECT count(*) FROM public.carteira_assignments ca
+        WHERE EXISTS (SELECT 1 FROM public.farmer_client_scores f WHERE f.customer_user_id = ca.customer_user_id)
+      ),
+      'cvs_clientes', (
+        SELECT count(*) FROM public.carteira_assignments ca
+        WHERE EXISTS (SELECT 1 FROM public.customer_visit_scores c WHERE c.customer_user_id = ca.customer_user_id)
+      )
+    )
+  ) INTO result;
+
+  RETURN result;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_carteira_saude() TO authenticated;
+
+SELECT 'BLOCO CARTEIRA SAUDE OK' AS status,
+  (SELECT count(*) FROM pg_proc WHERE proname = 'get_carteira_saude') AS rpc;


### PR DESCRIPTION
## Sub-PR E — Saúde da Carteira (observabilidade/confiabilidade)

Decisão **mim + Codex** (com o backlog §10 drenado e o founder querendo motor ligado): a próxima entrega é **confiabilidade** do que acabou de subir, não expansão de superfície. O programa Carteira-Omie (A+B+D) é cron-pesado e silenciosamente degradável — hoje só dá pra saber se está funcionando rodando SQL na mão.

Spec: `docs/superpowers/specs/2026-05-25-carteira-saude-observabilidade-design.md`

### O que entrega
Um **painel semáforo read-only** (verde/amarelo/vermelho + próxima ação, **sem gráficos**) no topo de `/admin/analytics-sync`, com 3 sinais:
1. **Saúde dos 4 crons** da carteira (`carteira-rebuild-nightly`, `scoring-recalc-batch-nightly`, `visit-score-recalc-batch-nightly`, `carteira-positivacao-snapshot-mensal`) — último run/status/idade/erro.
2. **Frescor do sync** — `max(carteira_assignments.last_synced_at)`, vermelho se >48h ou stale>0 (monitor que o spec da carteira já pedia).
3. **Cobertura de score** — clientes da carteira COM linha em `farmer_client_scores`/`customer_visit_scores` (EXISTS, evita falso-alarme de órfãos); vermelho se != tamanho da carteira.

### Mudanças
- **Helper puro TDD** `src/lib/carteira-saude/status.ts` (limiares/cores testáveis) — 16 testes.
- **Migration `20260525160000`**: RPC `get_carteira_saude()` `SECURITY DEFINER` (gate staff; lê `cron.job`×`cron.job_run_details` que staff não acessa).
- `useCarteiraSaude` hook + `CarteiraSaudePanel` (semáforo) montado no `AdminAnalyticsSync`.

Adiado de propósito (anti-over-build): `order_date_kpi` coverage, positivação por dono (gráfico), "clientes não-vinculados" (semântica ambígua — não shipar número errado).

### ⚠️ Rollout (manual no Lovable)
1. 🟣 SQL Editor: **BLOCO A** = `supabase/migrations/20260525160000_carteira_saude_rpc.sql` → esperado `rpc=1`.
2. Validar: `/admin/analytics-sync` (master) mostra o painel "Saúde da carteira" com os 3 sinais. (Se `cron.job_run_details` não existir nessa versão do pg_cron, a RPC erra no bloco de crons — me avisa que ajusto pra degradar gracioso.)

Sem deploy de edge function. Só a RPC.

## Test plan
- [x] `bun run test` (helper carteira-saude TDD, 16 testes) + baseline tsc + typecheck:strict + eslint verdes
- [ ] Rollout (RPC) aplicado + painel valida no app

🤖 Generated with [Claude Code](https://claude.com/claude-code)
