### PR TITLE
refactor(notificacoes): split AdminNotificacoes (510→101) em hook + componentes

### DIFF
--- a/src/components/notificacoes/AlertaDrawer.tsx
+++ b/src/components/notificacoes/AlertaDrawer.tsx
@@ -1,0 +1,111 @@
+// Drawer (Sheet) com detalhes de um alerta de notificação.
+// Extraído verbatim de src/pages/AdminNotificacoes.tsx (god-component split).
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import {
+  Sheet, SheetContent, SheetHeader, SheetTitle,
+} from '@/components/ui/sheet';
+import { Mail, Calendar as CalendarIcon, ExternalLink, AlertCircle } from 'lucide-react';
+import { SeveridadeBadge, StatusBadge } from './badges';
+import { fmtDate } from './format';
+import type { AlertaRow } from './types';
+
+interface AlertaDrawerProps {
+  alerta: AlertaRow | null;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function AlertaDrawer({ alerta: drawerAlerta, onOpenChange }: AlertaDrawerProps) {
+  return (
+    <Sheet open={!!drawerAlerta} onOpenChange={onOpenChange}>
+      <SheetContent className="overflow-y-auto sm:max-w-lg">
+        {drawerAlerta && (
+          <>
+            <SheetHeader>
+              <SheetTitle className="flex items-center gap-2">
+                <SeveridadeBadge s={drawerAlerta.severidade} />
+                <span className="truncate">{drawerAlerta.titulo}</span>
+              </SheetTitle>
+            </SheetHeader>
+
+            <div className="space-y-4 mt-4 text-sm">
+              <div className="flex flex-wrap gap-2">
+                <Badge variant="outline">{drawerAlerta.empresa}</Badge>
+                <Badge variant="secondary">{drawerAlerta.tipo}</Badge>
+                <StatusBadge s={drawerAlerta.status} />
+              </div>
+
+              {drawerAlerta.fornecedor_nome && (
+                <div><span className="font-medium">Fornecedor: </span>{drawerAlerta.fornecedor_nome}</div>
+              )}
+
+              <div>
+                <div className="font-medium mb-1">Mensagem</div>
+                <div className="whitespace-pre-wrap text-muted-foreground">
+                  {drawerAlerta.mensagem || '(sem mensagem)'}
+                </div>
+              </div>
+
+              {drawerAlerta.data_evento && (
+                <div>
+                  <span className="font-medium">Evento agendado: </span>
+                  {fmtDate(drawerAlerta.data_evento)}
+                </div>
+              )}
+
+              {drawerAlerta.metadata && Object.keys(drawerAlerta.metadata).length > 0 && (
+                <div>
+                  <div className="font-medium mb-1">Metadata</div>
+                  <pre className="bg-muted rounded p-2 text-xs overflow-x-auto">
+                    {JSON.stringify(drawerAlerta.metadata, null, 2)}
+                  </pre>
+                </div>
+              )}
+
+              <div className="grid grid-cols-2 gap-3 text-xs text-muted-foreground">
+                <div><div className="font-medium text-foreground">Criado</div>{fmtDate(drawerAlerta.criado_em)}</div>
+                <div><div className="font-medium text-foreground">Notificado</div>{fmtDate(drawerAlerta.notificado_em)}</div>
+                <div><div className="font-medium text-foreground">Tentativas</div>{drawerAlerta.tentativas ?? 0}/3</div>
+                <div><div className="font-medium text-foreground">Alerta ID</div>{drawerAlerta.id}</div>
+              </div>
+
+              <div className="flex flex-wrap gap-2 pt-2">
+                {drawerAlerta.gmail_message_id && (
+                  <Button asChild variant="outline" size="sm">
+                    <a
+                      href={`https://mail.google.com/mail/u/0/#all/${drawerAlerta.gmail_message_id}`}
+                      target="_blank" rel="noreferrer"
+                    >
+                      <Mail className="w-3 h-3 mr-1" /> Abrir no Gmail <ExternalLink className="w-3 h-3 ml-1" />
+                    </a>
+                  </Button>
+                )}
+                {drawerAlerta.calendar_evento_id && (
+                  <Button asChild variant="outline" size="sm">
+                    <a
+                      href={`https://calendar.google.com/calendar/u/0/r/eventedit/${drawerAlerta.calendar_evento_id}`}
+                      target="_blank" rel="noreferrer"
+                    >
+                      <CalendarIcon className="w-3 h-3 mr-1" /> Abrir no Calendar <ExternalLink className="w-3 h-3 ml-1" />
+                    </a>
+                  </Button>
+                )}
+              </div>
+
+              {drawerAlerta.erro_notificacao && (
+                <div className="border border-destructive/30 bg-destructive/5 rounded p-3">
+                  <div className="flex items-center gap-2 font-medium text-destructive mb-1">
+                    <AlertCircle className="w-4 h-4" /> Erro de notificação
+                  </div>
+                  <div className="text-xs text-destructive/80 whitespace-pre-wrap">
+                    {drawerAlerta.erro_notificacao}
+                  </div>
+                </div>
+              )}
+            </div>
+          </>
+        )}
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/src/components/notificacoes/DispatchButton.tsx
+++ b/src/components/notificacoes/DispatchButton.tsx
@@ -1,0 +1,39 @@
+// Botão "Disparar agora" com confirmação (AlertDialog).
+// Extraído verbatim de src/pages/AdminNotificacoes.tsx (god-component split).
+import { Zap } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+  AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent,
+  AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog';
+
+interface DispatchButtonProps {
+  isPending: boolean;
+  onDispatch: () => void;
+}
+
+export function DispatchButton({ isPending, onDispatch }: DispatchButtonProps) {
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>
+        <Button disabled={isPending}>
+          <Zap className="w-4 h-4 mr-2" />
+          {isPending ? 'Disparando...' : 'Disparar agora'}
+        </Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Disparar notificações</AlertDialogTitle>
+          <AlertDialogDescription>
+            Isso vai processar todos os alertas pendentes imediatamente. Confirma?
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancelar</AlertDialogCancel>
+          <AlertDialogAction onClick={onDispatch}>Disparar</AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/components/notificacoes/HistoricoTab.tsx
+++ b/src/components/notificacoes/HistoricoTab.tsx
@@ -1,0 +1,66 @@
+// Aba de histórico de notificações (últimos 30 dias).
+// Extraída verbatim de src/pages/AdminNotificacoes.tsx (god-component split).
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import {
+  Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
+} from '@/components/ui/table';
+import { SeveridadeBadge, StatusBadge } from './badges';
+import { fmtDate } from './format';
+import type { AlertaRow } from './types';
+
+interface HistoricoTabProps {
+  loading: boolean;
+  historico: AlertaRow[] | undefined;
+  onSelectAlerta: (a: AlertaRow) => void;
+}
+
+export function HistoricoTab({ loading, historico, onSelectAlerta }: HistoricoTabProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Histórico (últimos 30 dias)</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {loading ? (
+          <Skeleton className="h-40 w-full" />
+        ) : (historico ?? []).length === 0 ? (
+          <p className="text-sm text-muted-foreground py-6 text-center">Sem histórico no período.</p>
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Status</TableHead>
+                <TableHead>Severidade</TableHead>
+                <TableHead>Empresa</TableHead>
+                <TableHead>Tipo</TableHead>
+                <TableHead>Título</TableHead>
+                <TableHead>Notificado em</TableHead>
+                <TableHead className="text-right">Ações</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {(historico ?? []).map((a) => (
+                <TableRow key={a.id}>
+                  <TableCell><StatusBadge s={a.status} /></TableCell>
+                  <TableCell><SeveridadeBadge s={a.severidade} /></TableCell>
+                  <TableCell><Badge variant="outline">{a.empresa}</Badge></TableCell>
+                  <TableCell className="text-xs">{a.tipo}</TableCell>
+                  <TableCell className="max-w-[320px] truncate">{a.titulo}</TableCell>
+                  <TableCell className="text-xs">{fmtDate(a.notificado_em)}</TableCell>
+                  <TableCell className="text-right">
+                    <Button size="sm" variant="ghost" onClick={() => onSelectAlerta(a)}>
+                      Ver detalhes
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/notificacoes/PendentesTab.tsx
+++ b/src/components/notificacoes/PendentesTab.tsx
@@ -1,0 +1,113 @@
+// Aba de alertas pendentes (filtros + tabela).
+// Extraída verbatim de src/pages/AdminNotificacoes.tsx (god-component split).
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Skeleton } from '@/components/ui/skeleton';
+import {
+  Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
+} from '@/components/ui/table';
+import {
+  Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
+} from '@/components/ui/select';
+import { SeveridadeBadge } from './badges';
+import { relTime } from './format';
+import type { AlertaRow } from './types';
+
+interface PendentesTabProps {
+  loading: boolean;
+  pendentesFiltrados: AlertaRow[];
+  filtroSev: string;
+  onFiltroSevChange: (v: string) => void;
+  filtroEmpresa: string;
+  onFiltroEmpresaChange: (v: string) => void;
+  filtroTipo: string;
+  onFiltroTipoChange: (v: string) => void;
+  empresasOpts: string[];
+  tiposOpts: string[];
+  onSelectAlerta: (a: AlertaRow) => void;
+}
+
+export function PendentesTab({
+  loading,
+  pendentesFiltrados,
+  filtroSev,
+  onFiltroSevChange,
+  filtroEmpresa,
+  onFiltroEmpresaChange,
+  filtroTipo,
+  onFiltroTipoChange,
+  empresasOpts,
+  tiposOpts,
+  onSelectAlerta,
+}: PendentesTabProps) {
+  return (
+    <Card>
+      <CardHeader className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+        <CardTitle className="text-base">Alertas pendentes</CardTitle>
+        <div className="flex flex-wrap gap-2">
+          <Select value={filtroSev} onValueChange={onFiltroSevChange}>
+            <SelectTrigger className="w-[150px]"><SelectValue placeholder="Severidade" /></SelectTrigger>
+            <SelectContent>
+              <SelectItem value="__all__">Todas severidades</SelectItem>
+              <SelectItem value="info">info</SelectItem>
+              <SelectItem value="atencao">atenção</SelectItem>
+              <SelectItem value="urgente">urgente</SelectItem>
+            </SelectContent>
+          </Select>
+          <Select value={filtroEmpresa} onValueChange={onFiltroEmpresaChange}>
+            <SelectTrigger className="w-[150px]"><SelectValue placeholder="Empresa" /></SelectTrigger>
+            <SelectContent>
+              <SelectItem value="__all__">Todas empresas</SelectItem>
+              {empresasOpts.map((e) => <SelectItem key={e} value={e}>{e}</SelectItem>)}
+            </SelectContent>
+          </Select>
+          <Select value={filtroTipo} onValueChange={onFiltroTipoChange}>
+            <SelectTrigger className="w-[180px]"><SelectValue placeholder="Tipo" /></SelectTrigger>
+            <SelectContent>
+              <SelectItem value="__all__">Todos tipos</SelectItem>
+              {tiposOpts.map((t) => <SelectItem key={t} value={t}>{t}</SelectItem>)}
+            </SelectContent>
+          </Select>
+        </div>
+      </CardHeader>
+      <CardContent>
+        {loading ? (
+          <Skeleton className="h-40 w-full" />
+        ) : pendentesFiltrados.length === 0 ? (
+          <p className="text-sm text-muted-foreground py-6 text-center">Nenhum alerta pendente.</p>
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Severidade</TableHead>
+                <TableHead>Empresa</TableHead>
+                <TableHead>Tipo</TableHead>
+                <TableHead>Título</TableHead>
+                <TableHead>Fornecedor</TableHead>
+                <TableHead>Criado</TableHead>
+                <TableHead className="text-right">Tentativas</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {pendentesFiltrados.map((a) => (
+                <TableRow
+                  key={a.id}
+                  className="cursor-pointer"
+                  onClick={() => onSelectAlerta(a)}
+                >
+                  <TableCell><SeveridadeBadge s={a.severidade} /></TableCell>
+                  <TableCell><Badge variant="outline">{a.empresa}</Badge></TableCell>
+                  <TableCell className="text-xs">{a.tipo}</TableCell>
+                  <TableCell className="max-w-[320px] truncate">{a.titulo}</TableCell>
+                  <TableCell className="text-xs">{a.fornecedor_nome ?? '—'}</TableCell>
+                  <TableCell className="text-xs text-muted-foreground">{relTime(a.criado_em)}</TableCell>
+                  <TableCell className="text-right">{a.tentativas ?? 0}/3</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/notificacoes/StatsTab.tsx
+++ b/src/components/notificacoes/StatsTab.tsx
@@ -1,0 +1,61 @@
+// Aba de estatísticas (KPIs + gráfico de distribuição diária).
+// Extraída verbatim de src/pages/AdminNotificacoes.tsx (god-component split).
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import {
+  BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Legend,
+} from 'recharts';
+import type { ChartDatum } from './types';
+
+interface StatsTabProps {
+  loading: boolean;
+  total7d: number;
+  taxaSucesso: number;
+  esgotados: number;
+  chartData: ChartDatum[];
+}
+
+export function StatsTab({ loading, total7d, taxaSucesso, esgotados, chartData }: StatsTabProps) {
+  return (
+    <>
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <Card>
+          <CardHeader><CardTitle className="text-sm">Total últimos 7 dias</CardTitle></CardHeader>
+          <CardContent>
+            {loading ? <Skeleton className="h-8 w-20" /> : <div className="text-3xl font-bold">{total7d}</div>}
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader><CardTitle className="text-sm">Taxa de sucesso</CardTitle></CardHeader>
+          <CardContent>
+            {loading ? <Skeleton className="h-8 w-20" /> : <div className="text-3xl font-bold">{taxaSucesso}%</div>}
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader><CardTitle className="text-sm">Alertas esgotados (3 tentativas)</CardTitle></CardHeader>
+          <CardContent>
+            {loading ? <Skeleton className="h-8 w-20" /> : <div className="text-3xl font-bold">{esgotados}</div>}
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader><CardTitle className="text-base">Distribuição diária (30 dias)</CardTitle></CardHeader>
+        <CardContent style={{ height: 320 }}>
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart data={chartData}>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis dataKey="dia" />
+              <YAxis />
+              <Tooltip />
+              <Legend />
+              <Bar dataKey="notificado" stackId="a" fill="hsl(142 71% 45%)" name="notificado" />
+              <Bar dataKey="pendente" stackId="a" fill="hsl(45 93% 47%)" name="pendente" />
+              <Bar dataKey="falha" stackId="a" fill="hsl(0 84% 60%)" name="falha" />
+            </BarChart>
+          </ResponsiveContainer>
+        </CardContent>
+      </Card>
+    </>
+  );
+}

--- a/src/components/notificacoes/__tests__/AlertaDrawer.test.tsx
+++ b/src/components/notificacoes/__tests__/AlertaDrawer.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { AlertaDrawer } from "../AlertaDrawer";
+import type { AlertaRow } from "../types";
+
+function makeAlerta(o: Partial<AlertaRow> = {}): AlertaRow {
+  return {
+    id: 7,
+    empresa: "OBEN",
+    fornecedor_nome: "Forn A",
+    tipo: "aumento",
+    severidade: "urgente",
+    titulo: "Reajuste X",
+    mensagem: "corpo da mensagem",
+    status: "notificado",
+    tentativas: 2,
+    criado_em: "2026-03-01T10:00:00Z",
+    notificado_em: "2026-03-01T11:00:00Z",
+    gmail_message_id: "gmid123",
+    calendar_evento_id: null,
+    erro_notificacao: null,
+    metadata: null,
+    data_evento: null,
+    ...o,
+  };
+}
+
+describe("AlertaDrawer", () => {
+  it("não renderiza conteúdo quando alerta é null", () => {
+    render(<AlertaDrawer alerta={null} onOpenChange={vi.fn()} />);
+    expect(screen.queryByText("Reajuste X")).toBeNull();
+  });
+
+  it("renderiza detalhes e link do Gmail", () => {
+    render(<AlertaDrawer alerta={makeAlerta()} onOpenChange={vi.fn()} />);
+    expect(screen.getByText("Reajuste X")).toBeTruthy();
+    expect(screen.getByText("corpo da mensagem")).toBeTruthy();
+    expect(screen.getByText("Forn A")).toBeTruthy();
+    expect(screen.getByText(/Abrir no Gmail/)).toBeTruthy();
+  });
+
+  it("mostra a seção de erro quando há erro_notificacao", () => {
+    render(<AlertaDrawer alerta={makeAlerta({ erro_notificacao: "timeout SMTP" })} onOpenChange={vi.fn()} />);
+    expect(screen.getByText("Erro de notificação")).toBeTruthy();
+    expect(screen.getByText("timeout SMTP")).toBeTruthy();
+  });
+});

--- a/src/components/notificacoes/__tests__/DispatchButton.test.tsx
+++ b/src/components/notificacoes/__tests__/DispatchButton.test.tsx
@@ -1,0 +1,24 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { DispatchButton } from "../DispatchButton";
+
+describe("DispatchButton", () => {
+  it("estado normal: label e habilitado", () => {
+    render(<DispatchButton isPending={false} onDispatch={vi.fn()} />);
+    expect(screen.getByRole("button", { name: /Disparar agora/ })).toHaveProperty("disabled", false);
+  });
+
+  it("estado pendente: label e desabilitado", () => {
+    render(<DispatchButton isPending onDispatch={vi.fn()} />);
+    const btn = screen.getByRole("button", { name: /Disparando/ });
+    expect(btn).toHaveProperty("disabled", true);
+  });
+
+  it("confirma o disparo via AlertDialog", () => {
+    const onDispatch = vi.fn();
+    render(<DispatchButton isPending={false} onDispatch={onDispatch} />);
+    fireEvent.click(screen.getByRole("button", { name: /Disparar agora/ }));
+    fireEvent.click(screen.getByRole("button", { name: /^Disparar$/ }));
+    expect(onDispatch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/notificacoes/__tests__/HistoricoTab.test.tsx
+++ b/src/components/notificacoes/__tests__/HistoricoTab.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { HistoricoTab } from "../HistoricoTab";
+import type { AlertaRow } from "../types";
+
+function makeAlerta(o: Partial<AlertaRow> = {}): AlertaRow {
+  return {
+    id: 1,
+    empresa: "OBEN",
+    fornecedor_nome: "Forn A",
+    tipo: "aumento",
+    severidade: "info",
+    titulo: "Aviso Y",
+    mensagem: "msg",
+    status: "notificado",
+    tentativas: 1,
+    criado_em: new Date().toISOString(),
+    notificado_em: "2026-03-01T10:00:00Z",
+    gmail_message_id: null,
+    calendar_evento_id: null,
+    erro_notificacao: null,
+    metadata: null,
+    data_evento: null,
+    ...o,
+  };
+}
+
+describe("HistoricoTab", () => {
+  it("mostra empty state sem histórico", () => {
+    render(<HistoricoTab loading={false} historico={[]} onSelectAlerta={vi.fn()} />);
+    expect(screen.getByText("Sem histórico no período.")).toBeTruthy();
+  });
+
+  it("renderiza linha e dispara onSelectAlerta no Ver detalhes", () => {
+    const onSelectAlerta = vi.fn();
+    render(<HistoricoTab loading={false} historico={[makeAlerta()]} onSelectAlerta={onSelectAlerta} />);
+    expect(screen.getByText("Aviso Y")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Ver detalhes" }));
+    expect(onSelectAlerta).toHaveBeenCalledWith(expect.objectContaining({ id: 1 }));
+  });
+});

--- a/src/components/notificacoes/__tests__/PendentesTab.test.tsx
+++ b/src/components/notificacoes/__tests__/PendentesTab.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { PendentesTab } from "../PendentesTab";
+import type { AlertaRow } from "../types";
+
+function makeAlerta(o: Partial<AlertaRow> = {}): AlertaRow {
+  return {
+    id: 1,
+    empresa: "OBEN",
+    fornecedor_nome: "Forn A",
+    tipo: "aumento",
+    severidade: "urgente",
+    titulo: "Reajuste X",
+    mensagem: "msg",
+    status: "pendente_notificacao",
+    tentativas: 1,
+    criado_em: new Date().toISOString(),
+    notificado_em: null,
+    gmail_message_id: null,
+    calendar_evento_id: null,
+    erro_notificacao: null,
+    metadata: null,
+    data_evento: null,
+    ...o,
+  };
+}
+
+function setup(overrides: Partial<React.ComponentProps<typeof PendentesTab>> = {}) {
+  const props: React.ComponentProps<typeof PendentesTab> = {
+    loading: false,
+    pendentesFiltrados: [makeAlerta()],
+    filtroSev: "__all__",
+    onFiltroSevChange: vi.fn(),
+    filtroEmpresa: "__all__",
+    onFiltroEmpresaChange: vi.fn(),
+    filtroTipo: "__all__",
+    onFiltroTipoChange: vi.fn(),
+    empresasOpts: ["OBEN"],
+    tiposOpts: ["aumento"],
+    onSelectAlerta: vi.fn(),
+    ...overrides,
+  };
+  render(<PendentesTab {...props} />);
+  return props;
+}
+
+describe("PendentesTab", () => {
+  it("mostra skeleton em loading", () => {
+    const { container } = render(
+      <PendentesTab
+        loading
+        pendentesFiltrados={[]}
+        filtroSev="__all__"
+        onFiltroSevChange={vi.fn()}
+        filtroEmpresa="__all__"
+        onFiltroEmpresaChange={vi.fn()}
+        filtroTipo="__all__"
+        onFiltroTipoChange={vi.fn()}
+        empresasOpts={[]}
+        tiposOpts={[]}
+        onSelectAlerta={vi.fn()}
+      />,
+    );
+    expect(container.querySelectorAll(".animate-shimmer").length).toBeGreaterThan(0);
+  });
+
+  it("empty state sem pendentes", () => {
+    setup({ pendentesFiltrados: [] });
+    expect(screen.getByText("Nenhum alerta pendente.")).toBeTruthy();
+  });
+
+  it("renderiza linha e dispara onSelectAlerta", () => {
+    const props = setup();
+    expect(screen.getByText("Reajuste X")).toBeTruthy();
+    fireEvent.click(screen.getByText("Reajuste X"));
+    expect(props.onSelectAlerta).toHaveBeenCalledWith(expect.objectContaining({ id: 1 }));
+  });
+});

--- a/src/components/notificacoes/__tests__/StatsTab.test.tsx
+++ b/src/components/notificacoes/__tests__/StatsTab.test.tsx
@@ -1,0 +1,33 @@
+import { describe, it, expect, beforeAll, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { StatsTab } from "../StatsTab";
+
+beforeAll(() => {
+  // Recharts ResponsiveContainer usa ResizeObserver, ausente no jsdom.
+  vi.stubGlobal(
+    "ResizeObserver",
+    class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    },
+  );
+});
+
+describe("StatsTab", () => {
+  it("renderiza KPIs quando não está carregando", () => {
+    render(<StatsTab loading={false} total7d={42} taxaSucesso={87} esgotados={3} chartData={[]} />);
+    expect(screen.getByText("42")).toBeTruthy();
+    expect(screen.getByText("87%")).toBeTruthy();
+    expect(screen.getByText("3")).toBeTruthy();
+    expect(screen.getByText("Total últimos 7 dias")).toBeTruthy();
+    expect(screen.getByText("Distribuição diária (30 dias)")).toBeTruthy();
+  });
+
+  it("mostra 3 skeletons em loading", () => {
+    const { container } = render(
+      <StatsTab loading total7d={0} taxaSucesso={0} esgotados={0} chartData={[]} />,
+    );
+    expect(container.querySelectorAll(".animate-shimmer")).toHaveLength(3);
+  });
+});

--- a/src/components/notificacoes/__tests__/badges.test.tsx
+++ b/src/components/notificacoes/__tests__/badges.test.tsx
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { SeveridadeBadge, StatusBadge } from "../badges";
+
+describe("notificacoes/badges", () => {
+  it("SeveridadeBadge por nível", () => {
+    const { rerender } = render(<SeveridadeBadge s="urgente" />);
+    expect(screen.getByText("urgente")).toBeTruthy();
+    rerender(<SeveridadeBadge s="atencao" />);
+    expect(screen.getByText("atenção")).toBeTruthy();
+    rerender(<SeveridadeBadge s="info" />);
+    expect(screen.getByText("info")).toBeTruthy();
+  });
+
+  it("StatusBadge por status", () => {
+    const { rerender } = render(<StatusBadge s="notificado" />);
+    expect(screen.getByText("notificado")).toBeTruthy();
+    rerender(<StatusBadge s="falha_notificacao" />);
+    expect(screen.getByText("falha")).toBeTruthy();
+    rerender(<StatusBadge s="pendente_notificacao" />);
+    expect(screen.getByText("pendente_notificacao")).toBeTruthy();
+    rerender(<StatusBadge s={null} />);
+    expect(screen.getByText("—")).toBeTruthy();
+  });
+});

--- a/src/components/notificacoes/__tests__/format.test.ts
+++ b/src/components/notificacoes/__tests__/format.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from "vitest";
+import { relTime, fmtDate } from "../format";
+
+describe("notificacoes/format", () => {
+  it("relTime formata deltas relativos", () => {
+    expect(relTime(new Date().toISOString())).toBe("agora");
+    expect(relTime(new Date(Date.now() - 5 * 60000).toISOString())).toBe("há 5m");
+    expect(relTime(new Date(Date.now() - 2 * 3600000).toISOString())).toBe("há 2h");
+    expect(relTime(new Date(Date.now() - 3 * 86400000).toISOString())).toBe("há 3d");
+  });
+
+  it("fmtDate trata null e formata data válida", () => {
+    expect(fmtDate(null)).toBe("—");
+    expect(fmtDate("2026-03-01T10:00:00Z")).toMatch(/2026/);
+  });
+});

--- a/src/components/notificacoes/badges.tsx
+++ b/src/components/notificacoes/badges.tsx
@@ -1,0 +1,16 @@
+// Badges de severidade e status do módulo de notificações.
+// Extraídos verbatim de src/pages/AdminNotificacoes.tsx (god-component split).
+import { Badge } from '@/components/ui/badge';
+import type { Severidade } from './types';
+
+export function SeveridadeBadge({ s }: { s: Severidade }) {
+  if (s === 'urgente') return <Badge className="bg-destructive text-destructive-foreground">urgente</Badge>;
+  if (s === 'atencao') return <Badge className="bg-status-warning text-white">atenção</Badge>;
+  return <Badge variant="secondary">info</Badge>;
+}
+
+export function StatusBadge({ s }: { s: string | null }) {
+  if (s === 'notificado') return <Badge className="bg-status-success text-white">notificado</Badge>;
+  if (s === 'falha_notificacao') return <Badge variant="destructive">falha</Badge>;
+  return <Badge variant="outline">{s ?? '—'}</Badge>;
+}

--- a/src/components/notificacoes/format.ts
+++ b/src/components/notificacoes/format.ts
@@ -1,0 +1,21 @@
+// Colunas de seleção e helpers de tempo/data do módulo de notificações.
+// Extraídos verbatim de src/pages/AdminNotificacoes.tsx (god-component split).
+
+export const SELECT_COLUMNS =
+  'id, empresa, fornecedor_nome, tipo, severidade, titulo, mensagem, status, tentativas, criado_em, notificado_em, gmail_message_id, calendar_evento_id, erro_notificacao, metadata, data_evento';
+
+export function relTime(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const min = Math.round(diff / 60000);
+  if (min < 1) return 'agora';
+  if (min < 60) return `há ${min}m`;
+  const h = Math.round(min / 60);
+  if (h < 24) return `há ${h}h`;
+  const d = Math.round(h / 24);
+  return `há ${d}d`;
+}
+
+export function fmtDate(iso: string | null): string {
+  if (!iso) return '—';
+  return new Date(iso).toLocaleString('pt-BR', { timeZone: 'America/Sao_Paulo' });
+}

--- a/src/components/notificacoes/types.ts
+++ b/src/components/notificacoes/types.ts
@@ -1,0 +1,30 @@
+// Tipos do módulo de notificações.
+// Extraídos verbatim de src/pages/AdminNotificacoes.tsx (god-component split).
+
+export type Severidade = 'info' | 'atencao' | 'urgente';
+
+export type AlertaRow = {
+  id: number;
+  empresa: string;
+  fornecedor_nome: string | null;
+  tipo: string;
+  severidade: Severidade;
+  titulo: string;
+  mensagem: string | null;
+  status: string | null;
+  tentativas: number | null;
+  criado_em: string;
+  notificado_em: string | null;
+  gmail_message_id: string | null;
+  calendar_evento_id: string | null;
+  erro_notificacao: string | null;
+  metadata: Record<string, unknown> | null;
+  data_evento: string | null;
+};
+
+export interface ChartDatum {
+  dia: string;
+  notificado: number;
+  pendente: number;
+  falha: number;
+}

--- a/src/components/notificacoes/useNotificacoes.ts
+++ b/src/components/notificacoes/useNotificacoes.ts
@@ -1,0 +1,170 @@
+// Hook de dados/estado do AdminNotificacoes.
+// Extraído verbatim de src/pages/AdminNotificacoes.tsx (god-component split):
+// 3 queries (pendentes/histórico/stats30) + mutation de disparo + memos de
+// filtros, estatísticas e dados do gráfico.
+import { useState, useMemo } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import { toast } from 'sonner';
+import { SELECT_COLUMNS } from './format';
+import type { AlertaRow } from './types';
+
+export function useNotificacoes() {
+  const qc = useQueryClient();
+  const [drawerAlerta, setDrawerAlerta] = useState<AlertaRow | null>(null);
+
+  const [filtroSev, setFiltroSev] = useState<string>('__all__');
+  const [filtroEmpresa, setFiltroEmpresa] = useState<string>('__all__');
+  const [filtroTipo, setFiltroTipo] = useState<string>('__all__');
+
+  // Pendentes
+  const { data: pendentes, isLoading: loadingPend } = useQuery({
+    queryKey: ['notificacoes', 'pendentes'],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from('fornecedor_alerta')
+        .select(SELECT_COLUMNS)
+        .eq('status', 'pendente_notificacao')
+        .order('criado_em', { ascending: false })
+        .limit(200);
+      if (error) throw error;
+      return data as unknown as AlertaRow[];
+    },
+    refetchInterval: 30_000,
+  });
+
+  // Histórico (30 dias)
+  const { data: historico, isLoading: loadingHist } = useQuery({
+    queryKey: ['notificacoes', 'historico'],
+    queryFn: async () => {
+      const since = new Date(Date.now() - 30 * 24 * 3600_000).toISOString();
+      const { data, error } = await supabase
+        .from('fornecedor_alerta')
+        .select(SELECT_COLUMNS)
+        .in('status', ['notificado', 'falha_notificacao'])
+        .gte('criado_em', since)
+        .order('notificado_em', { ascending: false, nullsFirst: false })
+        .limit(500);
+      if (error) throw error;
+      return data as unknown as AlertaRow[];
+    },
+    refetchInterval: 60_000,
+  });
+
+  // Estatísticas (30 dias completos para gráfico)
+  const { data: stats30, isLoading: loadingStats } = useQuery({
+    queryKey: ['notificacoes', 'stats30'],
+    queryFn: async () => {
+      const since = new Date(Date.now() - 30 * 24 * 3600_000).toISOString();
+      const { data, error } = await supabase
+        .from('fornecedor_alerta')
+        .select('id, status, criado_em, tentativas')
+        .gte('criado_em', since)
+        .limit(5000);
+      if (error) throw error;
+      return data as Array<{ id: number; status: string | null; criado_em: string; tentativas: number | null }>;
+    },
+    refetchInterval: 60_000,
+  });
+
+  const dispatchMut = useMutation({
+    mutationFn: async () => {
+      const { data, error } = await supabase.functions.invoke('dispatch-notifications', {
+        body: {},
+      });
+      if (error) throw error;
+      return data as { processados: number; sucesso?: number; falhas?: number };
+    },
+    onSuccess: (data) => {
+      const proc = data?.processados ?? 0;
+      const ok = data?.sucesso ?? 0;
+      const fail = data?.falhas ?? 0;
+      toast.success(`${proc} processados, ${ok} sucesso, ${fail} falhas`);
+      qc.invalidateQueries({ queryKey: ['notificacoes'] });
+    },
+    onError: (err: unknown) => {
+      const msg = err instanceof Error ? err.message : String(err);
+      toast.error(`Falha ao disparar: ${msg}`);
+    },
+  });
+
+  // Opções dos filtros (derivadas de pendentes)
+  const empresasOpts = useMemo(
+    () => Array.from(new Set((pendentes ?? []).map((a) => a.empresa).filter(Boolean))),
+    [pendentes],
+  );
+  const tiposOpts = useMemo(
+    () => Array.from(new Set((pendentes ?? []).map((a) => a.tipo).filter(Boolean))),
+    [pendentes],
+  );
+
+  const pendentesFiltrados = useMemo(() => {
+    return (pendentes ?? []).filter((a) => {
+      if (filtroSev !== '__all__' && a.severidade !== filtroSev) return false;
+      if (filtroEmpresa !== '__all__' && a.empresa !== filtroEmpresa) return false;
+      if (filtroTipo !== '__all__' && a.tipo !== filtroTipo) return false;
+      return true;
+    });
+  }, [pendentes, filtroSev, filtroEmpresa, filtroTipo]);
+
+  // Stats
+  const total7d = useMemo(() => {
+    const cutoff = Date.now() - 7 * 24 * 3600_000;
+    return (stats30 ?? []).filter((a) => new Date(a.criado_em).getTime() >= cutoff).length;
+  }, [stats30]);
+
+  const taxaSucesso = useMemo(() => {
+    const finais = (stats30 ?? []).filter((a) => a.status === 'notificado' || a.status === 'falha_notificacao');
+    if (finais.length === 0) return 0;
+    const ok = finais.filter((a) => a.status === 'notificado').length;
+    return Math.round((ok / finais.length) * 100);
+  }, [stats30]);
+
+  const esgotados = useMemo(() => {
+    return (stats30 ?? []).filter((a) => a.status === 'falha_notificacao' && (a.tentativas ?? 0) >= 3).length;
+  }, [stats30]);
+
+  // Stack chart data por dia
+  const chartData = useMemo(() => {
+    const buckets: Record<string, { dia: string; notificado: number; pendente: number; falha: number }> = {};
+    for (let i = 29; i >= 0; i--) {
+      const d = new Date(Date.now() - i * 24 * 3600_000);
+      const key = d.toISOString().slice(0, 10);
+      buckets[key] = { dia: key.slice(5), notificado: 0, pendente: 0, falha: 0 };
+    }
+    for (const a of stats30 ?? []) {
+      const key = a.criado_em.slice(0, 10);
+      const b = buckets[key];
+      if (!b) continue;
+      if (a.status === 'notificado') b.notificado++;
+      else if (a.status === 'falha_notificacao') b.falha++;
+      else b.pendente++;
+    }
+    return Object.values(buckets);
+  }, [stats30]);
+
+  return {
+    drawerAlerta,
+    setDrawerAlerta,
+    filtroSev,
+    setFiltroSev,
+    filtroEmpresa,
+    setFiltroEmpresa,
+    filtroTipo,
+    setFiltroTipo,
+    pendentes,
+    loadingPend,
+    historico,
+    loadingHist,
+    loadingStats,
+    dispatchPending: dispatchMut.isPending,
+    dispatch: () => dispatchMut.mutate(),
+    empresasOpts,
+    tiposOpts,
+    pendentesFiltrados,
+    total7d,
+    taxaSucesso,
+    esgotados,
+    chartData,
+  };
+}

--- a/src/pages/AdminNotificacoes.tsx
+++ b/src/pages/AdminNotificacoes.tsx
@@ -1,216 +1,39 @@
-import { useState, useMemo } from 'react';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { supabase } from '@/integrations/supabase/client';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+// Notificações — disparo de alertas via Gmail + Google Calendar (fornecedor_alerta).
+// Composição: useNotificacoes (queries/mutation/memos) + tabs + drawer.
+// God-component split de src/pages/AdminNotificacoes.tsx (comportamento 1:1).
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { Badge } from '@/components/ui/badge';
-import { Button } from '@/components/ui/button';
-import {
-  Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
-} from '@/components/ui/table';
-import {
-  Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
-} from '@/components/ui/select';
-import {
-  AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent,
-  AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle,
-  AlertDialogTrigger,
-} from '@/components/ui/alert-dialog';
-import {
-  Sheet, SheetContent, SheetHeader, SheetTitle,
-} from '@/components/ui/sheet';
-import { Skeleton } from '@/components/ui/skeleton';
-import { Zap, Mail, Calendar as CalendarIcon, ExternalLink, AlertCircle } from 'lucide-react';
-import { toast } from 'sonner';
-import {
-  BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Legend,
-} from 'recharts';
-
-type Severidade = 'info' | 'atencao' | 'urgente';
-
-type AlertaRow = {
-  id: number;
-  empresa: string;
-  fornecedor_nome: string | null;
-  tipo: string;
-  severidade: Severidade;
-  titulo: string;
-  mensagem: string | null;
-  status: string | null;
-  tentativas: number | null;
-  criado_em: string;
-  notificado_em: string | null;
-  gmail_message_id: string | null;
-  calendar_evento_id: string | null;
-  erro_notificacao: string | null;
-  metadata: Record<string, unknown> | null;
-  data_evento: string | null;
-};
-
-const SELECT_COLUMNS =
-  'id, empresa, fornecedor_nome, tipo, severidade, titulo, mensagem, status, tentativas, criado_em, notificado_em, gmail_message_id, calendar_evento_id, erro_notificacao, metadata, data_evento';
-
-function relTime(iso: string): string {
-  const diff = Date.now() - new Date(iso).getTime();
-  const min = Math.round(diff / 60000);
-  if (min < 1) return 'agora';
-  if (min < 60) return `há ${min}m`;
-  const h = Math.round(min / 60);
-  if (h < 24) return `há ${h}h`;
-  const d = Math.round(h / 24);
-  return `há ${d}d`;
-}
-
-function fmtDate(iso: string | null): string {
-  if (!iso) return '—';
-  return new Date(iso).toLocaleString('pt-BR', { timeZone: 'America/Sao_Paulo' });
-}
-
-function SeveridadeBadge({ s }: { s: Severidade }) {
-  if (s === 'urgente') return <Badge className="bg-destructive text-destructive-foreground">urgente</Badge>;
-  if (s === 'atencao') return <Badge className="bg-status-warning text-white">atenção</Badge>;
-  return <Badge variant="secondary">info</Badge>;
-}
-
-function StatusBadge({ s }: { s: string | null }) {
-  if (s === 'notificado') return <Badge className="bg-status-success text-white">notificado</Badge>;
-  if (s === 'falha_notificacao') return <Badge variant="destructive">falha</Badge>;
-  return <Badge variant="outline">{s ?? '—'}</Badge>;
-}
+import { useNotificacoes } from '@/components/notificacoes/useNotificacoes';
+import { DispatchButton } from '@/components/notificacoes/DispatchButton';
+import { PendentesTab } from '@/components/notificacoes/PendentesTab';
+import { HistoricoTab } from '@/components/notificacoes/HistoricoTab';
+import { StatsTab } from '@/components/notificacoes/StatsTab';
+import { AlertaDrawer } from '@/components/notificacoes/AlertaDrawer';
 
 export default function AdminNotificacoes() {
-  const qc = useQueryClient();
-  const [drawerAlerta, setDrawerAlerta] = useState<AlertaRow | null>(null);
-
-  const [filtroSev, setFiltroSev] = useState<string>('__all__');
-  const [filtroEmpresa, setFiltroEmpresa] = useState<string>('__all__');
-  const [filtroTipo, setFiltroTipo] = useState<string>('__all__');
-
-  // Pendentes
-  const { data: pendentes, isLoading: loadingPend } = useQuery({
-    queryKey: ['notificacoes', 'pendentes'],
-    queryFn: async () => {
-      const { data, error } = await supabase
-        .from('fornecedor_alerta')
-        .select(SELECT_COLUMNS)
-        .eq('status', 'pendente_notificacao')
-        .order('criado_em', { ascending: false })
-        .limit(200);
-      if (error) throw error;
-      return data as unknown as AlertaRow[];
-    },
-    refetchInterval: 30_000,
-  });
-
-  // Histórico (30 dias)
-  const { data: historico, isLoading: loadingHist } = useQuery({
-    queryKey: ['notificacoes', 'historico'],
-    queryFn: async () => {
-      const since = new Date(Date.now() - 30 * 24 * 3600_000).toISOString();
-      const { data, error } = await supabase
-        .from('fornecedor_alerta')
-        .select(SELECT_COLUMNS)
-        .in('status', ['notificado', 'falha_notificacao'])
-        .gte('criado_em', since)
-        .order('notificado_em', { ascending: false, nullsFirst: false })
-        .limit(500);
-      if (error) throw error;
-      return data as unknown as AlertaRow[];
-    },
-    refetchInterval: 60_000,
-  });
-
-  // Estatísticas (30 dias completos para gráfico)
-  const { data: stats30, isLoading: loadingStats } = useQuery({
-    queryKey: ['notificacoes', 'stats30'],
-    queryFn: async () => {
-      const since = new Date(Date.now() - 30 * 24 * 3600_000).toISOString();
-      const { data, error } = await supabase
-        .from('fornecedor_alerta')
-        .select('id, status, criado_em, tentativas')
-        .gte('criado_em', since)
-        .limit(5000);
-      if (error) throw error;
-      return data as Array<{ id: number; status: string | null; criado_em: string; tentativas: number | null }>;
-    },
-    refetchInterval: 60_000,
-  });
-
-  const dispatchMut = useMutation({
-    mutationFn: async () => {
-      const { data, error } = await supabase.functions.invoke('dispatch-notifications', {
-        body: {},
-      });
-      if (error) throw error;
-      return data as { processados: number; sucesso?: number; falhas?: number };
-    },
-    onSuccess: (data) => {
-      const proc = data?.processados ?? 0;
-      const ok = data?.sucesso ?? 0;
-      const fail = data?.falhas ?? 0;
-      toast.success(`${proc} processados, ${ok} sucesso, ${fail} falhas`);
-      qc.invalidateQueries({ queryKey: ['notificacoes'] });
-    },
-    onError: (err: unknown) => {
-      const msg = err instanceof Error ? err.message : String(err);
-      toast.error(`Falha ao disparar: ${msg}`);
-    },
-  });
-
-  // Opções dos filtros (derivadas de pendentes)
-  const empresasOpts = useMemo(
-    () => Array.from(new Set((pendentes ?? []).map((a) => a.empresa).filter(Boolean))),
-    [pendentes],
-  );
-  const tiposOpts = useMemo(
-    () => Array.from(new Set((pendentes ?? []).map((a) => a.tipo).filter(Boolean))),
-    [pendentes],
-  );
-
-  const pendentesFiltrados = useMemo(() => {
-    return (pendentes ?? []).filter((a) => {
-      if (filtroSev !== '__all__' && a.severidade !== filtroSev) return false;
-      if (filtroEmpresa !== '__all__' && a.empresa !== filtroEmpresa) return false;
-      if (filtroTipo !== '__all__' && a.tipo !== filtroTipo) return false;
-      return true;
-    });
-  }, [pendentes, filtroSev, filtroEmpresa, filtroTipo]);
-
-  // Stats
-  const total7d = useMemo(() => {
-    const cutoff = Date.now() - 7 * 24 * 3600_000;
-    return (stats30 ?? []).filter((a) => new Date(a.criado_em).getTime() >= cutoff).length;
-  }, [stats30]);
-
-  const taxaSucesso = useMemo(() => {
-    const finais = (stats30 ?? []).filter((a) => a.status === 'notificado' || a.status === 'falha_notificacao');
-    if (finais.length === 0) return 0;
-    const ok = finais.filter((a) => a.status === 'notificado').length;
-    return Math.round((ok / finais.length) * 100);
-  }, [stats30]);
-
-  const esgotados = useMemo(() => {
-    return (stats30 ?? []).filter((a) => a.status === 'falha_notificacao' && (a.tentativas ?? 0) >= 3).length;
-  }, [stats30]);
-
-  // Stack chart data por dia
-  const chartData = useMemo(() => {
-    const buckets: Record<string, { dia: string; notificado: number; pendente: number; falha: number }> = {};
-    for (let i = 29; i >= 0; i--) {
-      const d = new Date(Date.now() - i * 24 * 3600_000);
-      const key = d.toISOString().slice(0, 10);
-      buckets[key] = { dia: key.slice(5), notificado: 0, pendente: 0, falha: 0 };
-    }
-    for (const a of stats30 ?? []) {
-      const key = a.criado_em.slice(0, 10);
-      const b = buckets[key];
-      if (!b) continue;
-      if (a.status === 'notificado') b.notificado++;
-      else if (a.status === 'falha_notificacao') b.falha++;
-      else b.pendente++;
-    }
-    return Object.values(buckets);
-  }, [stats30]);
+  const {
+    drawerAlerta,
+    setDrawerAlerta,
+    filtroSev,
+    setFiltroSev,
+    filtroEmpresa,
+    setFiltroEmpresa,
+    filtroTipo,
+    setFiltroTipo,
+    pendentes,
+    loadingPend,
+    historico,
+    loadingHist,
+    loadingStats,
+    dispatchPending,
+    dispatch,
+    empresasOpts,
+    tiposOpts,
+    pendentesFiltrados,
+    total7d,
+    taxaSucesso,
+    esgotados,
+    chartData,
+  } = useNotificacoes();
 
   return (
     <div className="container mx-auto p-4 lg:p-6 space-y-6">
@@ -221,26 +44,7 @@ export default function AdminNotificacoes() {
             Disparo de alertas via Gmail + Google Calendar (sobre fornecedor_alerta).
           </p>
         </div>
-        <AlertDialog>
-          <AlertDialogTrigger asChild>
-            <Button disabled={dispatchMut.isPending}>
-              <Zap className="w-4 h-4 mr-2" />
-              {dispatchMut.isPending ? 'Disparando...' : 'Disparar agora'}
-            </Button>
-          </AlertDialogTrigger>
-          <AlertDialogContent>
-            <AlertDialogHeader>
-              <AlertDialogTitle>Disparar notificações</AlertDialogTitle>
-              <AlertDialogDescription>
-                Isso vai processar todos os alertas pendentes imediatamente. Confirma?
-              </AlertDialogDescription>
-            </AlertDialogHeader>
-            <AlertDialogFooter>
-              <AlertDialogCancel>Cancelar</AlertDialogCancel>
-              <AlertDialogAction onClick={() => dispatchMut.mutate()}>Disparar</AlertDialogAction>
-            </AlertDialogFooter>
-          </AlertDialogContent>
-        </AlertDialog>
+        <DispatchButton isPending={dispatchPending} onDispatch={dispatch} />
       </div>
 
       <Tabs defaultValue="pendentes">
@@ -254,257 +58,44 @@ export default function AdminNotificacoes() {
 
         {/* PENDENTES */}
         <TabsContent value="pendentes" className="space-y-4">
-          <Card>
-            <CardHeader className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
-              <CardTitle className="text-base">Alertas pendentes</CardTitle>
-              <div className="flex flex-wrap gap-2">
-                <Select value={filtroSev} onValueChange={setFiltroSev}>
-                  <SelectTrigger className="w-[150px]"><SelectValue placeholder="Severidade" /></SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="__all__">Todas severidades</SelectItem>
-                    <SelectItem value="info">info</SelectItem>
-                    <SelectItem value="atencao">atenção</SelectItem>
-                    <SelectItem value="urgente">urgente</SelectItem>
-                  </SelectContent>
-                </Select>
-                <Select value={filtroEmpresa} onValueChange={setFiltroEmpresa}>
-                  <SelectTrigger className="w-[150px]"><SelectValue placeholder="Empresa" /></SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="__all__">Todas empresas</SelectItem>
-                    {empresasOpts.map((e) => <SelectItem key={e} value={e}>{e}</SelectItem>)}
-                  </SelectContent>
-                </Select>
-                <Select value={filtroTipo} onValueChange={setFiltroTipo}>
-                  <SelectTrigger className="w-[180px]"><SelectValue placeholder="Tipo" /></SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="__all__">Todos tipos</SelectItem>
-                    {tiposOpts.map((t) => <SelectItem key={t} value={t}>{t}</SelectItem>)}
-                  </SelectContent>
-                </Select>
-              </div>
-            </CardHeader>
-            <CardContent>
-              {loadingPend ? (
-                <Skeleton className="h-40 w-full" />
-              ) : pendentesFiltrados.length === 0 ? (
-                <p className="text-sm text-muted-foreground py-6 text-center">Nenhum alerta pendente.</p>
-              ) : (
-                <Table>
-                  <TableHeader>
-                    <TableRow>
-                      <TableHead>Severidade</TableHead>
-                      <TableHead>Empresa</TableHead>
-                      <TableHead>Tipo</TableHead>
-                      <TableHead>Título</TableHead>
-                      <TableHead>Fornecedor</TableHead>
-                      <TableHead>Criado</TableHead>
-                      <TableHead className="text-right">Tentativas</TableHead>
-                    </TableRow>
-                  </TableHeader>
-                  <TableBody>
-                    {pendentesFiltrados.map((a) => (
-                      <TableRow
-                        key={a.id}
-                        className="cursor-pointer"
-                        onClick={() => setDrawerAlerta(a)}
-                      >
-                        <TableCell><SeveridadeBadge s={a.severidade} /></TableCell>
-                        <TableCell><Badge variant="outline">{a.empresa}</Badge></TableCell>
-                        <TableCell className="text-xs">{a.tipo}</TableCell>
-                        <TableCell className="max-w-[320px] truncate">{a.titulo}</TableCell>
-                        <TableCell className="text-xs">{a.fornecedor_nome ?? '—'}</TableCell>
-                        <TableCell className="text-xs text-muted-foreground">{relTime(a.criado_em)}</TableCell>
-                        <TableCell className="text-right">{a.tentativas ?? 0}/3</TableCell>
-                      </TableRow>
-                    ))}
-                  </TableBody>
-                </Table>
-              )}
-            </CardContent>
-          </Card>
+          <PendentesTab
+            loading={loadingPend}
+            pendentesFiltrados={pendentesFiltrados}
+            filtroSev={filtroSev}
+            onFiltroSevChange={setFiltroSev}
+            filtroEmpresa={filtroEmpresa}
+            onFiltroEmpresaChange={setFiltroEmpresa}
+            filtroTipo={filtroTipo}
+            onFiltroTipoChange={setFiltroTipo}
+            empresasOpts={empresasOpts}
+            tiposOpts={tiposOpts}
+            onSelectAlerta={setDrawerAlerta}
+          />
         </TabsContent>
 
         {/* HISTÓRICO */}
         <TabsContent value="historico" className="space-y-4">
-          <Card>
-            <CardHeader>
-              <CardTitle className="text-base">Histórico (últimos 30 dias)</CardTitle>
-            </CardHeader>
-            <CardContent>
-              {loadingHist ? (
-                <Skeleton className="h-40 w-full" />
-              ) : (historico ?? []).length === 0 ? (
-                <p className="text-sm text-muted-foreground py-6 text-center">Sem histórico no período.</p>
-              ) : (
-                <Table>
-                  <TableHeader>
-                    <TableRow>
-                      <TableHead>Status</TableHead>
-                      <TableHead>Severidade</TableHead>
-                      <TableHead>Empresa</TableHead>
-                      <TableHead>Tipo</TableHead>
-                      <TableHead>Título</TableHead>
-                      <TableHead>Notificado em</TableHead>
-                      <TableHead className="text-right">Ações</TableHead>
-                    </TableRow>
-                  </TableHeader>
-                  <TableBody>
-                    {(historico ?? []).map((a) => (
-                      <TableRow key={a.id}>
-                        <TableCell><StatusBadge s={a.status} /></TableCell>
-                        <TableCell><SeveridadeBadge s={a.severidade} /></TableCell>
-                        <TableCell><Badge variant="outline">{a.empresa}</Badge></TableCell>
-                        <TableCell className="text-xs">{a.tipo}</TableCell>
-                        <TableCell className="max-w-[320px] truncate">{a.titulo}</TableCell>
-                        <TableCell className="text-xs">{fmtDate(a.notificado_em)}</TableCell>
-                        <TableCell className="text-right">
-                          <Button size="sm" variant="ghost" onClick={() => setDrawerAlerta(a)}>
-                            Ver detalhes
-                          </Button>
-                        </TableCell>
-                      </TableRow>
-                    ))}
-                  </TableBody>
-                </Table>
-              )}
-            </CardContent>
-          </Card>
+          <HistoricoTab
+            loading={loadingHist}
+            historico={historico}
+            onSelectAlerta={setDrawerAlerta}
+          />
         </TabsContent>
 
         {/* STATS */}
         <TabsContent value="stats" className="space-y-4">
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-            <Card>
-              <CardHeader><CardTitle className="text-sm">Total últimos 7 dias</CardTitle></CardHeader>
-              <CardContent>
-                {loadingStats ? <Skeleton className="h-8 w-20" /> : <div className="text-3xl font-bold">{total7d}</div>}
-              </CardContent>
-            </Card>
-            <Card>
-              <CardHeader><CardTitle className="text-sm">Taxa de sucesso</CardTitle></CardHeader>
-              <CardContent>
-                {loadingStats ? <Skeleton className="h-8 w-20" /> : <div className="text-3xl font-bold">{taxaSucesso}%</div>}
-              </CardContent>
-            </Card>
-            <Card>
-              <CardHeader><CardTitle className="text-sm">Alertas esgotados (3 tentativas)</CardTitle></CardHeader>
-              <CardContent>
-                {loadingStats ? <Skeleton className="h-8 w-20" /> : <div className="text-3xl font-bold">{esgotados}</div>}
-              </CardContent>
-            </Card>
-          </div>
-
-          <Card>
-            <CardHeader><CardTitle className="text-base">Distribuição diária (30 dias)</CardTitle></CardHeader>
-            <CardContent style={{ height: 320 }}>
-              <ResponsiveContainer width="100%" height="100%">
-                <BarChart data={chartData}>
-                  <CartesianGrid strokeDasharray="3 3" />
-                  <XAxis dataKey="dia" />
-                  <YAxis />
-                  <Tooltip />
-                  <Legend />
-                  <Bar dataKey="notificado" stackId="a" fill="hsl(142 71% 45%)" name="notificado" />
-                  <Bar dataKey="pendente" stackId="a" fill="hsl(45 93% 47%)" name="pendente" />
-                  <Bar dataKey="falha" stackId="a" fill="hsl(0 84% 60%)" name="falha" />
-                </BarChart>
-              </ResponsiveContainer>
-            </CardContent>
-          </Card>
+          <StatsTab
+            loading={loadingStats}
+            total7d={total7d}
+            taxaSucesso={taxaSucesso}
+            esgotados={esgotados}
+            chartData={chartData}
+          />
         </TabsContent>
       </Tabs>
 
       {/* DRAWER */}
-      <Sheet open={!!drawerAlerta} onOpenChange={(o) => !o && setDrawerAlerta(null)}>
-        <SheetContent className="overflow-y-auto sm:max-w-lg">
-          {drawerAlerta && (
-            <>
-              <SheetHeader>
-                <SheetTitle className="flex items-center gap-2">
-                  <SeveridadeBadge s={drawerAlerta.severidade} />
-                  <span className="truncate">{drawerAlerta.titulo}</span>
-                </SheetTitle>
-              </SheetHeader>
-
-              <div className="space-y-4 mt-4 text-sm">
-                <div className="flex flex-wrap gap-2">
-                  <Badge variant="outline">{drawerAlerta.empresa}</Badge>
-                  <Badge variant="secondary">{drawerAlerta.tipo}</Badge>
-                  <StatusBadge s={drawerAlerta.status} />
-                </div>
-
-                {drawerAlerta.fornecedor_nome && (
-                  <div><span className="font-medium">Fornecedor: </span>{drawerAlerta.fornecedor_nome}</div>
-                )}
-
-                <div>
-                  <div className="font-medium mb-1">Mensagem</div>
-                  <div className="whitespace-pre-wrap text-muted-foreground">
-                    {drawerAlerta.mensagem || '(sem mensagem)'}
-                  </div>
-                </div>
-
-                {drawerAlerta.data_evento && (
-                  <div>
-                    <span className="font-medium">Evento agendado: </span>
-                    {fmtDate(drawerAlerta.data_evento)}
-                  </div>
-                )}
-
-                {drawerAlerta.metadata && Object.keys(drawerAlerta.metadata).length > 0 && (
-                  <div>
-                    <div className="font-medium mb-1">Metadata</div>
-                    <pre className="bg-muted rounded p-2 text-xs overflow-x-auto">
-                      {JSON.stringify(drawerAlerta.metadata, null, 2)}
-                    </pre>
-                  </div>
-                )}
-
-                <div className="grid grid-cols-2 gap-3 text-xs text-muted-foreground">
-                  <div><div className="font-medium text-foreground">Criado</div>{fmtDate(drawerAlerta.criado_em)}</div>
-                  <div><div className="font-medium text-foreground">Notificado</div>{fmtDate(drawerAlerta.notificado_em)}</div>
-                  <div><div className="font-medium text-foreground">Tentativas</div>{drawerAlerta.tentativas ?? 0}/3</div>
-                  <div><div className="font-medium text-foreground">Alerta ID</div>{drawerAlerta.id}</div>
-                </div>
-
-                <div className="flex flex-wrap gap-2 pt-2">
-                  {drawerAlerta.gmail_message_id && (
-                    <Button asChild variant="outline" size="sm">
-                      <a
-                        href={`https://mail.google.com/mail/u/0/#all/${drawerAlerta.gmail_message_id}`}
-                        target="_blank" rel="noreferrer"
-                      >
-                        <Mail className="w-3 h-3 mr-1" /> Abrir no Gmail <ExternalLink className="w-3 h-3 ml-1" />
-                      </a>
-                    </Button>
-                  )}
-                  {drawerAlerta.calendar_evento_id && (
-                    <Button asChild variant="outline" size="sm">
-                      <a
-                        href={`https://calendar.google.com/calendar/u/0/r/eventedit/${drawerAlerta.calendar_evento_id}`}
-                        target="_blank" rel="noreferrer"
-                      >
-                        <CalendarIcon className="w-3 h-3 mr-1" /> Abrir no Calendar <ExternalLink className="w-3 h-3 ml-1" />
-                      </a>
-                    </Button>
-                  )}
-                </div>
-
-                {drawerAlerta.erro_notificacao && (
-                  <div className="border border-destructive/30 bg-destructive/5 rounded p-3">
-                    <div className="flex items-center gap-2 font-medium text-destructive mb-1">
-                      <AlertCircle className="w-4 h-4" /> Erro de notificação
-                    </div>
-                    <div className="text-xs text-destructive/80 whitespace-pre-wrap">
-                      {drawerAlerta.erro_notificacao}
-                    </div>
-                  </div>
-                )}
-              </div>
-            </>
-          )}
-        </SheetContent>
-      </Sheet>
+      <AlertaDrawer alerta={drawerAlerta} onOpenChange={(o) => !o && setDrawerAlerta(null)} />
     </div>
   );
 }


### PR DESCRIPTION
## Resumo
Quebra o god-component `src/pages/AdminNotificacoes.tsx` (**510→101L**) em um hook de dados/estado + componentes presentacionais controlados, sob `src/components/notificacoes/`. Extração **verbatim** — comportamento preservado 1:1.

## O que mudou
- **`useNotificacoes`** (hook): 3 queries (`pendentes`/`historico`/`stats30` com `refetchInterval`) + mutation de disparo (`dispatch-notifications`) + memos (filtros/estatísticas/chartData).
- **`DispatchButton`** — botão "Disparar agora" com confirmação (AlertDialog).
- **`PendentesTab`** — filtros + tabela de pendentes.
- **`HistoricoTab`** — histórico (30 dias).
- **`StatsTab`** — KPIs + gráfico de distribuição diária.
- **`AlertaDrawer`** — drawer (Sheet) com detalhes do alerta.
- **`badges.tsx`** (`SeveridadeBadge`/`StatusBadge`), **`types.ts`**, **`format.ts`** (`SELECT_COLUMNS`/`relTime`/`fmtDate`).
- **+17 testes** (helpers puros + presentacionais).

## Verificação
- `bunx tsc --noEmit` (baseline) = **0**
- `eslint` = **0 erros / 0 warnings**
- **17/17 testes** verdes (isolados)
- Revisão independente FIEL 1:1: **aprovada** (queries/refetch/mutation/memos/drawer conferidos)

## Migrations
Nenhuma.

🤖 Generated with [Claude Code](https://claude.com/claude-code)