### PR TITLE
refactor(financeiro): split FinanceiroCockpit (509→130) em hook + componentes

### DIFF
--- a/src/components/financeiro/cockpit/CockpitCard.tsx
+++ b/src/components/financeiro/cockpit/CockpitCard.tsx
@@ -1,0 +1,32 @@
+// Card grande de KPI do Cockpit (Caixa/Projetado/NCG).
+// Extraído verbatim de src/pages/FinanceiroCockpit.tsx (god-component split).
+import { Card, CardContent } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import type { LucideIcon } from 'lucide-react';
+
+export function CockpitCard({ title, value, positive, icon: Icon, detail, detailColor, badge, onClick }: {
+  title: string; value: string; positive: boolean; icon: LucideIcon;
+  detail?: string; detailColor?: string; badge?: string; onClick?: () => void;
+}) {
+  return (
+    <Card className={onClick ? 'cursor-pointer hover:bg-muted/30 transition-colors' : ''} onClick={onClick}>
+      <CardContent className="p-5">
+        <div className="flex items-start justify-between">
+          <div>
+            <p className="text-xs text-muted-foreground font-medium uppercase tracking-wider">{title}</p>
+            <p className={`kpi-value text-3xl mt-2 ${positive ? 'text-status-success' : 'text-status-error'}`}>{value}</p>
+            {detail && (
+              <p className={`text-xs mt-2 ${detailColor || 'text-muted-foreground'}`}>{detail}</p>
+            )}
+            {badge && (
+              <Badge variant="outline" className="mt-2 text-[9px]">{badge}</Badge>
+            )}
+          </div>
+          <div className={`p-2.5 rounded-md ${positive ? 'bg-status-success-bg' : 'bg-status-error-bg'}`}>
+            <Icon className={`w-4 h-4 ${positive ? 'text-status-success' : 'text-status-error'}`} />
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/financeiro/cockpit/CockpitHeader.tsx
+++ b/src/components/financeiro/cockpit/CockpitHeader.tsx
@@ -1,0 +1,42 @@
+// Header do Cockpit financeiro (título + regime toggle + badges de confiabilidade).
+// Extraído verbatim de src/pages/FinanceiroCockpit.tsx (god-component split).
+import { COMPANIES, type Company } from '@/contexts/CompanyContext';
+import { RegimeToggle } from '@/components/financeiro/RegimeToggle';
+import { TransparencyBadge } from './TransparencyBadge';
+import type { FinConfiabilidadeRow } from './types';
+
+interface CockpitHeaderProps {
+  confiabilidade: FinConfiabilidadeRow[];
+}
+
+export function CockpitHeader({ confiabilidade }: CockpitHeaderProps) {
+  return (
+    <div className="relative bg-cockpit-hero noise rounded-lg border border-border px-6 py-8 flex items-center justify-between flex-wrap gap-3 overflow-hidden">
+      <div className="relative">
+        <p className="text-[10px] uppercase tracking-[0.18em] text-muted-foreground font-medium mb-1.5">
+          Financeiro · Cockpit
+        </p>
+        <h1 className="font-display" style={{ fontSize: '2.25rem', fontWeight: 500, letterSpacing: '-0.04em', lineHeight: 1.1 }}>
+          Visão consolidada
+        </h1>
+        <p className="text-sm text-muted-foreground mt-1.5 tabular-nums">
+          {new Date().toLocaleDateString('pt-BR', { month: 'long', year: 'numeric' })}
+        </p>
+      </div>
+      {/* Global transparency + regime toggle */}
+      <div className="relative flex flex-col items-end gap-3">
+        <RegimeToggle />
+        {confiabilidade.length > 0 && (
+          <div className="flex flex-col items-end gap-1">
+            {confiabilidade.map(c => (
+              <div key={c.company} className="flex items-center gap-2">
+                <span className="text-xs font-medium">{COMPANIES[c.company as Company]?.shortName}</span>
+                <TransparencyBadge conf={c} />
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/financeiro/cockpit/DataBasisFooter.tsx
+++ b/src/components/financeiro/cockpit/DataBasisFooter.tsx
@@ -1,0 +1,13 @@
+// Rodapé "Base dos números" do Cockpit financeiro.
+// Extraído verbatim de src/pages/FinanceiroCockpit.tsx (god-component split).
+import { Info } from 'lucide-react';
+
+export function DataBasisFooter() {
+  return (
+    <div className="text-xs text-muted-foreground bg-muted/30 p-3 rounded-lg space-y-1">
+      <p className="font-medium flex items-center gap-1"><Info className="w-3 h-3" /> Base dos números</p>
+      <p>Saldo bancário: consulta direta Omie (ResumirContaCorrente). CR/CP: títulos sincronizados (últimos 6 meses). DRE: regime de caixa (pagamento/recebimento efetivo). Projeção 13 semanas: baseada em vencimentos de títulos abertos.</p>
+      <p>Para números de controller, verifique: % mapeado ≥ 80%, conciliação ≥ 70%, mês fechado.</p>
+    </div>
+  );
+}

--- a/src/components/financeiro/cockpit/MiniCard.tsx
+++ b/src/components/financeiro/cockpit/MiniCard.tsx
@@ -1,0 +1,14 @@
+// Mini-card de KPI do Cockpit (margens/inadimplência/aging).
+// Extraído verbatim de src/pages/FinanceiroCockpit.tsx (god-component split).
+
+export function MiniCard({ label, value, color, subtitle, onClick }: {
+  label: string; value: string; color: string; subtitle?: string; onClick?: () => void;
+}) {
+  return (
+    <div className={`p-3 rounded-md border bg-card text-center ${onClick ? 'cursor-pointer hover:bg-muted/30 transition-colors' : ''}`} onClick={onClick}>
+      <p className="text-[10px] text-muted-foreground font-medium uppercase tracking-wider">{label}</p>
+      <p className={`kpi-value text-xl mt-1 ${color}`}>{value}</p>
+      {subtitle && <p className="text-xs text-muted-foreground mt-0.5 tabular-nums">{subtitle}</p>}
+    </div>
+  );
+}

--- a/src/components/financeiro/cockpit/Projecao13Card.tsx
+++ b/src/components/financeiro/cockpit/Projecao13Card.tsx
@@ -1,0 +1,66 @@
+// Card de projeção de caixa — 13 semanas.
+// Extraído verbatim de src/pages/FinanceiroCockpit.tsx (god-component split).
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { Target, AlertTriangle } from 'lucide-react';
+import { fmtCompact } from './format';
+import type { FinProjecaoSemana } from './types';
+
+interface Projecao13CardProps {
+  projecao13: FinProjecaoSemana[];
+}
+
+export function Projecao13Card({ projecao13 }: Projecao13CardProps) {
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base flex items-center gap-2">
+          <Target className="w-4 h-4" />
+          Projeção de Caixa — 13 Semanas
+          <Badge variant="outline" className="text-[10px]">Consolidado · Baseado em CR/CP abertos</Badge>
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="overflow-x-auto">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="min-w-[90px]">Semana</TableHead>
+                <TableHead className="text-right">Entradas</TableHead>
+                <TableHead className="text-right">Saídas</TableHead>
+                <TableHead className="text-right">Fluxo</TableHead>
+                <TableHead className="text-right">Saldo</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {projecao13.map((w, i) => (
+                <TableRow key={i} className={w.saldo_projetado < 0 ? 'bg-status-error-bg' : ''}>
+                  <TableCell className="text-xs">{w.semana_label}</TableCell>
+                  <TableCell className="text-right text-sm text-status-success">{fmtCompact(w.entradas_previstas)}</TableCell>
+                  <TableCell className="text-right text-sm text-status-error">{fmtCompact(w.saidas_previstas)}</TableCell>
+                  <TableCell className={`text-right text-sm font-medium ${w.fluxo_liquido >= 0 ? 'text-status-success' : 'text-status-error'}`}>
+                    {fmtCompact(w.fluxo_liquido)}
+                  </TableCell>
+                  <TableCell className={`text-right text-sm font-bold ${w.saldo_projetado >= 0 ? 'text-status-info' : 'text-status-error'}`}>
+                    {fmtCompact(w.saldo_projetado)}
+                    {w.saldo_projetado < 0 && <AlertTriangle className="inline w-3 h-3 ml-1 text-status-error" />}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+        {projecao13.some((w) => w.saldo_projetado < 0) && (
+          <div className="mt-3 p-3 rounded-lg bg-status-error-bg border border-status-error/20 flex items-start gap-2">
+            <AlertTriangle className="w-4 h-4 text-status-error mt-0.5 shrink-0" />
+            <p className="text-sm text-status-error-fg">
+              Projeção indica saldo negativo em {projecao13.filter((w) => w.saldo_projetado < 0).length} semana(s).
+              Ação necessária antes de {projecao13.find((w) => w.saldo_projetado < 0)?.semana_label}.
+            </p>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/financeiro/cockpit/ResultadoPorEmpresa.tsx
+++ b/src/components/financeiro/cockpit/ResultadoPorEmpresa.tsx
@@ -1,0 +1,114 @@
+// Card "Resultado por Empresa (último mês)" — DRE consolidado regime-aware.
+// Extraído verbatim de src/pages/FinanceiroCockpit.tsx (god-component split).
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { BarChart3 } from 'lucide-react';
+import { COMPANIES, type Company } from '@/contexts/CompanyContext';
+import type { FinDRE } from '@/services/financeiroService';
+import { fmt, fmtCompact, IMPOSTO_LABEL } from './format';
+import type { FinConfiabilidadeRow } from './types';
+
+interface ResultadoPorEmpresaProps {
+  dreConsolidado: FinDRE[];
+  confiabilidade: FinConfiabilidadeRow[];
+}
+
+export function ResultadoPorEmpresa({ dreConsolidado, confiabilidade }: ResultadoPorEmpresaProps) {
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base flex items-center gap-2">
+          <BarChart3 className="w-4 h-4" />
+          Resultado por Empresa (último mês)
+          <Badge variant="outline" className="text-[10px]">Regime de Caixa</Badge>
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {dreConsolidado.length === 0 ? (
+          <p className="text-sm text-muted-foreground">Sem DRE calculado. Recalcule na aba DRE.</p>
+        ) : (
+          <div className="space-y-3">
+            {dreConsolidado.map(d => {
+              const mg = d.receita_liquida > 0 ? (d.lucro_bruto / d.receita_liquida) * 100 : 0;
+              const conf = confiabilidade.find(c => c.company === d.company);
+              const impostos = Object.entries(d.detalhamento?.impostos ?? {});
+              return (
+                <div key={d.company} className="p-3 rounded-lg bg-muted/40 space-y-2">
+                  <div className="flex items-center justify-between">
+                    <div className="flex items-center gap-3">
+                      <Badge variant="outline">{COMPANIES[d.company as Company]?.shortName}</Badge>
+                      <span className="text-xs text-muted-foreground">
+                        {['Jan','Fev','Mar','Abr','Mai','Jun','Jul','Ago','Set','Out','Nov','Dez'][d.mes - 1]}
+                      </span>
+                      {d.detalhamento?.regime_tributario && (
+                        <Badge variant="outline" className="text-[9px] capitalize">{d.detalhamento.regime_tributario}</Badge>
+                      )}
+                      {d.detalhamento?.caixa_estimado && (
+                        <span className="text-xs text-status-warning">caixa estimado</span>
+                      )}
+                    </div>
+                    <div className="flex items-center gap-4 text-sm">
+                      <div className="text-right">
+                        <p className="text-[10px] text-muted-foreground">Receita</p>
+                        <p className="font-medium">{fmtCompact(d.receita_liquida)}</p>
+                      </div>
+                      <div className="text-right">
+                        <p className="text-[10px] text-muted-foreground">MB</p>
+                        <p className={`font-bold ${mg >= 30 ? 'text-status-success' : 'text-status-warning'}`}>{mg.toFixed(1)}%</p>
+                      </div>
+                      <div className="text-right">
+                        <p className="text-[10px] text-muted-foreground">Resultado</p>
+                        <p className={`font-bold ${d.resultado_liquido >= 0 ? 'text-status-success' : 'text-status-error'}`}>
+                          {fmtCompact(d.resultado_liquido)}
+                        </p>
+                      </div>
+                      {conf && (
+                        <div className="text-right">
+                          <p className="text-[10px] text-muted-foreground">Mapeado</p>
+                          <p className={`text-xs font-medium ${(conf.pct_valor_mapeado || 0) >= 80 ? 'text-status-success' : 'text-status-warning'}`}>
+                            {(conf.pct_valor_mapeado || 0).toFixed(0)}%
+                          </p>
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                  {/* Confiança banner quando confiança não é 'alta' */}
+                  {d.detalhamento?.confianca && d.detalhamento.confianca.nivel !== 'alta' && (
+                    <div className="rounded-md border p-2 text-xs text-status-warning">
+                      Confiança <strong>{d.detalhamento.confianca.nivel}</strong>:
+                      <ul className="list-disc ml-4">
+                        {d.detalhamento.confianca.motivos.map((m, i) => <li key={i}>{m}</li>)}
+                      </ul>
+                    </div>
+                  )}
+                  {/* Deduções de impostos regime-aware */}
+                  {impostos.length > 0 && (
+                    <div className="border-t pt-2 space-y-0.5">
+                      <p className="text-[10px] text-muted-foreground uppercase tracking-wider">Deduções / Impostos</p>
+                      {impostos.map(([k, v]) => (
+                        <div key={k} className="flex justify-between text-sm">
+                          <span className="text-muted-foreground">{IMPOSTO_LABEL[k] ?? k}</span>
+                          <span className="tabular-nums">{fmt(v as number)}</span>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                  {d.detalhamento?.imposto_teorico && (
+                    <div className="text-xs text-muted-foreground mt-1">
+                      Imposto teórico esperado: {fmt(Object.values(d.detalhamento.imposto_teorico).reduce((s: number, v) => s + (v ?? 0), 0))}
+                      {d.detalhamento.delta_imposto_pct != null && (
+                        <span className={Math.abs(d.detalhamento.delta_imposto_pct) > 0.25 ? 'text-status-warning ml-1' : 'ml-1'}>
+                          (Δ {(d.detalhamento.delta_imposto_pct * 100).toFixed(0)}% vs realizado)
+                        </span>
+                      )}
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/financeiro/cockpit/TopInadimplentes.tsx
+++ b/src/components/financeiro/cockpit/TopInadimplentes.tsx
@@ -1,0 +1,36 @@
+// Card "Inadimplência Crítica — Top 5".
+// Extraído verbatim de src/pages/FinanceiroCockpit.tsx (god-component split).
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { AlertTriangle } from 'lucide-react';
+import { fmt } from './format';
+import type { InadimplenteRow } from './types';
+
+interface TopInadimplentesProps {
+  inadimplentes: InadimplenteRow[];
+}
+
+export function TopInadimplentes({ inadimplentes }: TopInadimplentesProps) {
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base flex items-center gap-2">
+          <AlertTriangle className="w-4 h-4 text-status-error" />
+          Inadimplência Crítica — Top 5
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-2">
+          {inadimplentes.map((i, idx) => (
+            <div key={idx} className="flex items-center justify-between py-2 border-b last:border-0">
+              <div>
+                <p className="font-medium text-sm">{i.nome || (i.cnpj ? `CNPJ: ${i.cnpj}` : 'Cliente não identificado')}</p>
+                <p className="text-xs text-muted-foreground">{i.qtd_titulos} título(s)</p>
+              </div>
+              <span className="font-bold text-status-error">{fmt(i.total_vencido)}</span>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/financeiro/cockpit/TransparencyBadge.tsx
+++ b/src/components/financeiro/cockpit/TransparencyBadge.tsx
@@ -1,0 +1,46 @@
+// Badge de transparência/confiabilidade + ícone de status de fechamento.
+// Extraídos verbatim de src/pages/FinanceiroCockpit.tsx (god-component split).
+import { AlertTriangle, Clock, Eye, Lock } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import type { FinConfiabilidadeRow } from './types';
+
+export function TransparencyBadge({ conf }: { conf: FinConfiabilidadeRow | null }) {
+  if (!conf) return <Badge variant="outline" className="text-[9px]">Sem dados de confiabilidade</Badge>;
+
+  const pctMap = conf.pct_valor_mapeado || 0;
+  const pctConc = conf.pct_mov_conciliado || 0;
+  const fech = conf.fechamento_status || 'sem_fechamento';
+  const catHeur = conf.dre_categorias_heuristica || 0;
+
+  const score = Math.round((pctMap * 0.4) + (pctConc * 0.3) + (fech === 'fechado' ? 30 : 0));
+  const color = score >= 70 ? 'text-status-success' : score >= 40 ? 'text-status-warning' : 'text-status-error';
+  const bg = score >= 70 ? 'bg-status-success-bg border-status-success/20' : score >= 40 ? 'bg-status-warning-bg border-status-warning/20' : 'bg-status-error-bg border-status-error/20';
+
+  return (
+    <div className={`inline-flex items-center gap-2 px-2 py-1 rounded border text-xs ${bg}`}>
+      <span className={`font-semibold tabular-nums ${color}`}>{score}%</span>
+      <span className="text-muted-foreground">confiável</span>
+      <span className="text-muted-foreground">·</span>
+      <span className="tabular-nums">{pctMap.toFixed(0)}% mapeado</span>
+      <span className="text-muted-foreground">·</span>
+      <span className="tabular-nums">{pctConc.toFixed(0)}% conciliado</span>
+      {catHeur > 0 && (
+        <>
+          <span className="text-muted-foreground">·</span>
+          <span className="text-status-warning">{catHeur} cat. heurísticas</span>
+        </>
+      )}
+      <span className="text-muted-foreground">·</span>
+      <FechamentoIcon status={fech} />
+    </div>
+  );
+}
+
+function FechamentoIcon({ status }: { status: string }) {
+  switch (status) {
+    case 'fechado': return <span className="flex items-center gap-0.5 text-status-success"><Lock className="w-3 h-3" /> Fechado</span>;
+    case 'em_revisao': return <span className="flex items-center gap-0.5 text-status-warning"><Eye className="w-3 h-3" /> Revisão</span>;
+    case 'reaberto': return <span className="flex items-center gap-0.5 text-status-error"><AlertTriangle className="w-3 h-3" /> Reaberto</span>;
+    default: return <span className="flex items-center gap-0.5 text-muted-foreground"><Clock className="w-3 h-3" /> Aberto</span>;
+  }
+}

--- a/src/components/financeiro/cockpit/__tests__/Projecao13Card.test.tsx
+++ b/src/components/financeiro/cockpit/__tests__/Projecao13Card.test.tsx
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { Projecao13Card } from "../Projecao13Card";
+import type { FinProjecaoSemana } from "../types";
+
+function makeWeek(o: Partial<FinProjecaoSemana> = {}): FinProjecaoSemana {
+  return {
+    semana_label: "S1",
+    entradas_previstas: 1000,
+    saidas_previstas: 500,
+    fluxo_liquido: 500,
+    saldo_projetado: 500,
+    ...o,
+  } as unknown as FinProjecaoSemana;
+}
+
+describe("Projecao13Card", () => {
+  it("renderiza semanas", () => {
+    render(<Projecao13Card projecao13={[makeWeek(), makeWeek({ semana_label: "S2" })]} />);
+    expect(screen.getByText("S1")).toBeTruthy();
+    expect(screen.getByText("S2")).toBeTruthy();
+  });
+
+  it("mostra alerta quando há saldo negativo", () => {
+    render(
+      <Projecao13Card
+        projecao13={[makeWeek({ semana_label: "S3", fluxo_liquido: -1000, saldo_projetado: -500 })]}
+      />,
+    );
+    expect(screen.getByText(/saldo negativo em 1 semana/)).toBeTruthy();
+  });
+});

--- a/src/components/financeiro/cockpit/__tests__/ResultadoPorEmpresa.test.tsx
+++ b/src/components/financeiro/cockpit/__tests__/ResultadoPorEmpresa.test.tsx
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ResultadoPorEmpresa } from "../ResultadoPorEmpresa";
+import type { FinDRE } from "@/services/financeiroService";
+
+const dre = {
+  company: "oben",
+  mes: 3,
+  receita_liquida: 100000,
+  lucro_bruto: 40000,
+  resultado_operacional: 20000,
+  resultado_liquido: 15000,
+  detalhamento: {
+    impostos: { ded_icms: 1800 },
+    regime_tributario: "presumido",
+  },
+} as unknown as FinDRE;
+
+describe("ResultadoPorEmpresa", () => {
+  it("mostra placeholder sem DRE", () => {
+    render(<ResultadoPorEmpresa dreConsolidado={[]} confiabilidade={[]} />);
+    expect(screen.getByText("Sem DRE calculado. Recalcule na aba DRE.")).toBeTruthy();
+  });
+
+  it("renderiza linha de DRE com MB, mês, receita e dedução", () => {
+    render(<ResultadoPorEmpresa dreConsolidado={[dre]} confiabilidade={[]} />);
+    expect(screen.getByText("40.0%")).toBeTruthy(); // margem bruta
+    expect(screen.getByText("Mar")).toBeTruthy();
+    expect(screen.getByText("R$ 100.0k")).toBeTruthy(); // receita
+    expect(screen.getByText("ICMS")).toBeTruthy(); // dedução
+  });
+});

--- a/src/components/financeiro/cockpit/__tests__/TopInadimplentes.test.tsx
+++ b/src/components/financeiro/cockpit/__tests__/TopInadimplentes.test.tsx
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { TopInadimplentes } from "../TopInadimplentes";
+import type { InadimplenteRow } from "../types";
+
+describe("TopInadimplentes", () => {
+  it("renderiza nome, qtd de títulos e valor", () => {
+    const rows: InadimplenteRow[] = [
+      { nome: "Cliente A", cnpj: "123", total_vencido: 5000, qtd_titulos: 3 },
+    ];
+    render(<TopInadimplentes inadimplentes={rows} />);
+    expect(screen.getByText("Cliente A")).toBeTruthy();
+    expect(screen.getByText("3 título(s)")).toBeTruthy();
+    expect(screen.getByText(/5\.000,00/)).toBeTruthy();
+  });
+
+  it("usa fallback de CNPJ e 'não identificado'", () => {
+    const rows: InadimplenteRow[] = [
+      { nome: "", cnpj: "999", total_vencido: 100, qtd_titulos: 1 },
+      { nome: "", cnpj: "", total_vencido: 50, qtd_titulos: 1 },
+    ];
+    render(<TopInadimplentes inadimplentes={rows} />);
+    expect(screen.getByText("CNPJ: 999")).toBeTruthy();
+    expect(screen.getByText("Cliente não identificado")).toBeTruthy();
+  });
+});

--- a/src/components/financeiro/cockpit/__tests__/TransparencyBadge.test.tsx
+++ b/src/components/financeiro/cockpit/__tests__/TransparencyBadge.test.tsx
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { TransparencyBadge } from "../TransparencyBadge";
+import type { FinConfiabilidadeRow } from "../types";
+
+describe("TransparencyBadge", () => {
+  it("mostra placeholder quando conf é null", () => {
+    render(<TransparencyBadge conf={null} />);
+    expect(screen.getByText("Sem dados de confiabilidade")).toBeTruthy();
+  });
+
+  it("calcula score e mostra mapeado/conciliado/fechamento", () => {
+    const conf = {
+      company: "oben",
+      pct_valor_mapeado: 80,
+      pct_mov_conciliado: 70,
+      fechamento_status: "fechado",
+      dre_categorias_heuristica: 0,
+    } as unknown as FinConfiabilidadeRow;
+    render(<TransparencyBadge conf={conf} />);
+    // score = round(80*0.4 + 70*0.3 + 30) = 83
+    expect(screen.getByText("83%")).toBeTruthy();
+    expect(screen.getByText("80% mapeado")).toBeTruthy();
+    expect(screen.getByText("70% conciliado")).toBeTruthy();
+    expect(screen.getByText("Fechado")).toBeTruthy();
+  });
+});

--- a/src/components/financeiro/cockpit/__tests__/cards.test.tsx
+++ b/src/components/financeiro/cockpit/__tests__/cards.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { Wallet } from "lucide-react";
+import { CockpitCard } from "../CockpitCard";
+import { MiniCard } from "../MiniCard";
+
+describe("CockpitCard", () => {
+  it("renderiza título, valor, detalhe e badge", () => {
+    render(
+      <CockpitCard
+        title="Caixa Disponível"
+        value="R$ 10.0k"
+        positive
+        icon={Wallet}
+        detail="Risco de liquidez: Baixo"
+        badge="Saldo bancário real"
+      />,
+    );
+    expect(screen.getByText("Caixa Disponível")).toBeTruthy();
+    expect(screen.getByText("R$ 10.0k")).toBeTruthy();
+    expect(screen.getByText("Risco de liquidez: Baixo")).toBeTruthy();
+    expect(screen.getByText("Saldo bancário real")).toBeTruthy();
+  });
+
+  it("dispara onClick", () => {
+    const onClick = vi.fn();
+    render(<CockpitCard title="Caixa" value="R$ 1" positive icon={Wallet} onClick={onClick} />);
+    fireEvent.click(screen.getByText("Caixa"));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("MiniCard", () => {
+  it("renderiza label, valor e subtitle", () => {
+    render(<MiniCard label="Inadimplência" value="12.0%" color="text-status-warning" subtitle="R$ 5.0k" />);
+    expect(screen.getByText("Inadimplência")).toBeTruthy();
+    expect(screen.getByText("12.0%")).toBeTruthy();
+    expect(screen.getByText("R$ 5.0k")).toBeTruthy();
+  });
+
+  it("dispara onClick", () => {
+    const onClick = vi.fn();
+    render(<MiniCard label="Aging" value="3.0%" color="text-status-success" onClick={onClick} />);
+    fireEvent.click(screen.getByText("Aging"));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/financeiro/cockpit/__tests__/format.test.ts
+++ b/src/components/financeiro/cockpit/__tests__/format.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { fmt, fmtCompact, IMPOSTO_LABEL } from "../format";
+
+describe("cockpit/format", () => {
+  it("fmt formata em BRL", () => {
+    expect(fmt(1000)).toContain("1.000,00");
+  });
+
+  it("fmtCompact usa M/k/valor cheio", () => {
+    expect(fmtCompact(2_500_000)).toBe("R$ 2.5M");
+    expect(fmtCompact(100_000)).toBe("R$ 100.0k");
+    expect(fmtCompact(500)).toContain("500,00");
+  });
+
+  it("IMPOSTO_LABEL mapeia chaves conhecidas", () => {
+    expect(IMPOSTO_LABEL.ded_icms).toBe("ICMS");
+    expect(IMPOSTO_LABEL.das).toBe("DAS (Simples)");
+    expect(IMPOSTO_LABEL.irpj).toBe("IRPJ");
+  });
+});

--- a/src/components/financeiro/cockpit/format.ts
+++ b/src/components/financeiro/cockpit/format.ts
@@ -1,0 +1,15 @@
+// Helpers de formatação e rótulos de impostos do Cockpit financeiro.
+// Extraídos verbatim de src/pages/FinanceiroCockpit.tsx (god-component split).
+
+export const fmt = (v: number) => v.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
+
+export const fmtCompact = (v: number) => {
+  if (Math.abs(v) >= 1_000_000) return `R$ ${(v / 1_000_000).toFixed(1)}M`;
+  if (Math.abs(v) >= 1_000) return `R$ ${(v / 1_000).toFixed(1)}k`;
+  return fmt(v);
+};
+
+export const IMPOSTO_LABEL: Record<string, string> = {
+  ded_icms: 'ICMS', ded_iss: 'ISS', ded_pis: 'PIS', ded_cofins: 'COFINS', ded_ipi: 'IPI',
+  das: 'DAS (Simples)', irpj: 'IRPJ', csll: 'CSLL',
+};

--- a/src/components/financeiro/cockpit/types.ts
+++ b/src/components/financeiro/cockpit/types.ts
@@ -1,0 +1,7 @@
+// Tipos do Cockpit financeiro.
+// Extraídos verbatim de src/pages/FinanceiroCockpit.tsx (god-component split).
+import type { Database } from '@/integrations/supabase/types';
+
+export type FinConfiabilidadeRow = Database['public']['Tables']['fin_confiabilidade']['Row'];
+export type FinProjecaoSemana = Database['public']['Functions']['fin_projecao_13_semanas']['Returns'][number];
+export type InadimplenteRow = { nome: string; cnpj: string; total_vencido: number; qtd_titulos: number };

--- a/src/components/financeiro/cockpit/useFinanceiroCockpit.ts
+++ b/src/components/financeiro/cockpit/useFinanceiroCockpit.ts
@@ -1,0 +1,143 @@
+// Hook de dados/estado do Cockpit financeiro.
+// Extraído verbatim de src/pages/FinanceiroCockpit.tsx (god-component split):
+// state, loadAll (resumo/aging/DRE/inadimplentes/projeção 13s/confiabilidade) e
+// todos os derivados consolidados.
+import { useState, useEffect } from 'react';
+import { type Company } from '@/contexts/CompanyContext';
+import { supabase } from '@/integrations/supabase/client';
+import { getResumoFinanceiro, getAgingReceber, getDRE, getTopInadimplentes, type FinResumo, type AgingData, type FinDRE } from '@/services/financeiroService';
+import { useFinanceiroRegime } from '@/hooks/useFinanceiroRegime';
+import { logger } from '@/lib/logger';
+import type { DrillDownType } from '@/components/financeiro/CockpitDrillDown';
+import type { FinConfiabilidadeRow, FinProjecaoSemana, InadimplenteRow } from './types';
+
+export function useFinanceiroCockpit() {
+  const [loading, setLoading] = useState(true);
+  const [resumo, setResumo] = useState<Record<string, FinResumo>>({});
+  const [aging, setAging] = useState<AgingData | null>(null);
+  const [dre, setDre] = useState<FinDRE[]>([]);
+  const [inadimplentes, setInadimplentes] = useState<InadimplenteRow[]>([]);
+  const [projecao13, setProjecao13] = useState<FinProjecaoSemana[]>([]);
+  const [confiabilidade, setConfiabilidade] = useState<FinConfiabilidadeRow[]>([]);
+  const [drillDown, setDrillDown] = useState<DrillDownType>(null);
+
+  const { regime } = useFinanceiroRegime();
+  const ano = new Date().getFullYear();
+  const mes = new Date().getMonth() + 1;
+
+  useEffect(() => { loadAll(); }, [regime]);
+
+  const loadAll = async () => {
+    setLoading(true);
+    try {
+      const [res, ag, dr, inad] = await Promise.all([
+        getResumoFinanceiro(['oben', 'colacor', 'colacor_sc']),
+        getAgingReceber('all'),
+        Promise.all(['oben', 'colacor', 'colacor_sc'].map(co => getDRE(co as Company, ano, undefined, regime))).then(r => r.flat()),
+        getTopInadimplentes('all', 5),
+      ]);
+      setResumo(res);
+      setAging(ag);
+      setDre(dr);
+      setInadimplentes(inad);
+
+      // 13-week projection via RPC
+      try {
+        const { data: proj } = await supabase.rpc('fin_projecao_13_semanas', {});
+        setProjecao13(proj ?? []);
+      } catch (e) {
+        // RPC pode não existir ainda — registra para visibilidade em vez de falhar silencioso
+        logger.warn('RPC fin_projecao_13_semanas indisponível', {
+          error: e instanceof Error ? e.message : String(e),
+        });
+      }
+
+      // Confiabilidade for current month per company
+      const confResults: FinConfiabilidadeRow[] = [];
+      for (const co of ['oben', 'colacor', 'colacor_sc']) {
+        try {
+          const { data: conf } = await supabase
+            .from('fin_confiabilidade')
+            .select('*')
+            .eq('company', co)
+            .eq('ano', ano)
+            .eq('mes', mes)
+            .maybeSingle();
+          if (conf) confResults.push(conf);
+        } catch (e) {
+          logger.warn('Tabela fin_confiabilidade indisponível', {
+            company: co,
+            error: e instanceof Error ? e.message : String(e),
+          });
+        }
+      }
+      setConfiabilidade(confResults);
+    } catch (e) {
+      console.error(e);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // Computed
+  const totalCC = Object.values(resumo).reduce((s, r) => s + r.saldo_total_cc, 0);
+  const totalCR = Object.values(resumo).reduce((s, r) => s + r.total_a_receber, 0);
+  const totalCP = Object.values(resumo).reduce((s, r) => s + r.total_a_pagar, 0);
+  const totalVencidoCR = Object.values(resumo).reduce((s, r) => s + r.total_vencido_receber, 0);
+  const ncg = totalCR - totalCP; // Necessidade de capital de giro
+  const pctInadimplencia = totalCR > 0 ? (totalVencidoCR / totalCR) * 100 : 0;
+
+  // DRE do mês mais recente
+  const dreUltimo = new Map<string, FinDRE>();
+  for (const d of dre) {
+    const key = d.company;
+    if (!dreUltimo.has(key) || d.mes > (dreUltimo.get(key)?.mes || 0)) {
+      dreUltimo.set(key, d);
+    }
+  }
+  const dreConsolidado = Array.from(dreUltimo.values());
+  const totalReceita = dreConsolidado.reduce((s, d) => s + d.receita_liquida, 0);
+  const totalLucroBruto = dreConsolidado.reduce((s, d) => s + d.lucro_bruto, 0);
+  const totalResultadoOp = dreConsolidado.reduce((s, d) => s + d.resultado_operacional, 0);
+  const margemBruta = totalReceita > 0 ? (totalLucroBruto / totalReceita) * 100 : 0;
+  const margemOp = totalReceita > 0 ? (totalResultadoOp / totalReceita) * 100 : 0;
+
+  // Risco de liquidez
+  const riscoLiquidez = totalCP > 0 && totalCC > 0
+    ? totalCC / totalCP
+    : 0;
+  const riscoLabel = riscoLiquidez >= 1 ? 'Baixo' : riscoLiquidez >= 0.5 ? 'Médio' : 'Alto';
+  const riscoColor = riscoLiquidez >= 1 ? 'text-status-success' : riscoLiquidez >= 0.5 ? 'text-status-warning' : 'text-status-error';
+
+  // Concentração (do aging)
+  const totalAgingCR = aging
+    ? aging.a_vencer_valor + aging.vencido_1_30_valor + aging.vencido_31_60_valor + aging.vencido_61_90_valor + aging.vencido_90_plus_valor
+    : 0;
+  const pctCritico = totalAgingCR > 0
+    ? ((aging?.vencido_61_90_valor || 0) + (aging?.vencido_90_plus_valor || 0)) / totalAgingCR * 100
+    : 0;
+  const agingCriticoValor = (aging?.vencido_61_90_valor || 0) + (aging?.vencido_90_plus_valor || 0);
+
+  return {
+    loading,
+    confiabilidade,
+    dreConsolidado,
+    projecao13,
+    inadimplentes,
+    drillDown,
+    setDrillDown,
+    totalCC,
+    totalCR,
+    totalCP,
+    totalVencidoCR,
+    ncg,
+    pctInadimplencia,
+    margemBruta,
+    margemOp,
+    riscoLiquidez,
+    riscoLabel,
+    riscoColor,
+    pctCritico,
+    agingCriticoValor,
+  };
+}

--- a/src/pages/FinanceiroCockpit.tsx
+++ b/src/pages/FinanceiroCockpit.tsx
@@ -1,189 +1,43 @@
-import { useState, useEffect } from 'react';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+// Cockpit financeiro — visão consolidada (caixa, margens, DRE, projeção, inadimplência).
+// Composição: useFinanceiroCockpit (dados/derivados) + header + KPIs + cards de seção.
+// God-component split de src/pages/FinanceiroCockpit.tsx (comportamento 1:1).
 import { Skeleton } from '@/components/ui/skeleton';
-import { COMPANIES, type Company } from '@/contexts/CompanyContext';
-import { supabase } from '@/integrations/supabase/client';
-import { getResumoFinanceiro, getAgingReceber, getDRE, getTopInadimplentes, type FinResumo, type AgingData, type FinDRE } from '@/services/financeiroService';
-import { useFinanceiroRegime } from '@/hooks/useFinanceiroRegime';
-import { RegimeToggle } from '@/components/financeiro/RegimeToggle';
-import {
-  TrendingUp, TrendingDown, AlertTriangle, Wallet,
-  BarChart3, Target, Clock, Eye, Lock,
-  Info,
-} from 'lucide-react';
-import { CockpitDrillDown, type DrillDownType } from '@/components/financeiro/CockpitDrillDown';
+import { TrendingUp, TrendingDown, Wallet, Target } from 'lucide-react';
+import { CockpitDrillDown } from '@/components/financeiro/CockpitDrillDown';
 import { PeriodOverrideHistory } from '@/components/financeiro/PeriodOverrideHistory';
-import { logger } from '@/lib/logger';
-import type { LucideIcon } from 'lucide-react';
-import type { Database } from '@/integrations/supabase/types';
-
-type FinConfiabilidadeRow = Database['public']['Tables']['fin_confiabilidade']['Row'];
-type FinProjecaoSemana = Database['public']['Functions']['fin_projecao_13_semanas']['Returns'][number];
-type InadimplenteRow = { nome: string; cnpj: string; total_vencido: number; qtd_titulos: number };
-
-const fmt = (v: number) => v.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
-const fmtCompact = (v: number) => {
-  if (Math.abs(v) >= 1_000_000) return `R$ ${(v / 1_000_000).toFixed(1)}M`;
-  if (Math.abs(v) >= 1_000) return `R$ ${(v / 1_000).toFixed(1)}k`;
-  return fmt(v);
-};
-
-const IMPOSTO_LABEL: Record<string, string> = {
-  ded_icms: 'ICMS', ded_iss: 'ISS', ded_pis: 'PIS', ded_cofins: 'COFINS', ded_ipi: 'IPI',
-  das: 'DAS (Simples)', irpj: 'IRPJ', csll: 'CSLL',
-};
-
-// ═══════════════ TRANSPARENCY BADGE ═══════════════
-function TransparencyBadge({ conf }: { conf: FinConfiabilidadeRow | null }) {
-  if (!conf) return <Badge variant="outline" className="text-[9px]">Sem dados de confiabilidade</Badge>;
-
-  const pctMap = conf.pct_valor_mapeado || 0;
-  const pctConc = conf.pct_mov_conciliado || 0;
-  const fech = conf.fechamento_status || 'sem_fechamento';
-  const catHeur = conf.dre_categorias_heuristica || 0;
-
-  const score = Math.round((pctMap * 0.4) + (pctConc * 0.3) + (fech === 'fechado' ? 30 : 0));
-  const color = score >= 70 ? 'text-status-success' : score >= 40 ? 'text-status-warning' : 'text-status-error';
-  const bg = score >= 70 ? 'bg-status-success-bg border-status-success/20' : score >= 40 ? 'bg-status-warning-bg border-status-warning/20' : 'bg-status-error-bg border-status-error/20';
-
-  return (
-    <div className={`inline-flex items-center gap-2 px-2 py-1 rounded border text-xs ${bg}`}>
-      <span className={`font-semibold tabular-nums ${color}`}>{score}%</span>
-      <span className="text-muted-foreground">confiável</span>
-      <span className="text-muted-foreground">·</span>
-      <span className="tabular-nums">{pctMap.toFixed(0)}% mapeado</span>
-      <span className="text-muted-foreground">·</span>
-      <span className="tabular-nums">{pctConc.toFixed(0)}% conciliado</span>
-      {catHeur > 0 && (
-        <>
-          <span className="text-muted-foreground">·</span>
-          <span className="text-status-warning">{catHeur} cat. heurísticas</span>
-        </>
-      )}
-      <span className="text-muted-foreground">·</span>
-      <FechamentoIcon status={fech} />
-    </div>
-  );
-}
-
-function FechamentoIcon({ status }: { status: string }) {
-  switch (status) {
-    case 'fechado': return <span className="flex items-center gap-0.5 text-status-success"><Lock className="w-3 h-3" /> Fechado</span>;
-    case 'em_revisao': return <span className="flex items-center gap-0.5 text-status-warning"><Eye className="w-3 h-3" /> Revisão</span>;
-    case 'reaberto': return <span className="flex items-center gap-0.5 text-status-error"><AlertTriangle className="w-3 h-3" /> Reaberto</span>;
-    default: return <span className="flex items-center gap-0.5 text-muted-foreground"><Clock className="w-3 h-3" /> Aberto</span>;
-  }
-}
-
-// ═══════════════ MAIN COMPONENT ═══════════════
+import { useFinanceiroCockpit } from '@/components/financeiro/cockpit/useFinanceiroCockpit';
+import { fmtCompact } from '@/components/financeiro/cockpit/format';
+import { CockpitHeader } from '@/components/financeiro/cockpit/CockpitHeader';
+import { CockpitCard } from '@/components/financeiro/cockpit/CockpitCard';
+import { MiniCard } from '@/components/financeiro/cockpit/MiniCard';
+import { ResultadoPorEmpresa } from '@/components/financeiro/cockpit/ResultadoPorEmpresa';
+import { Projecao13Card } from '@/components/financeiro/cockpit/Projecao13Card';
+import { TopInadimplentes } from '@/components/financeiro/cockpit/TopInadimplentes';
+import { DataBasisFooter } from '@/components/financeiro/cockpit/DataBasisFooter';
 
 const FinanceiroCockpit = () => {
-  const [loading, setLoading] = useState(true);
-  const [resumo, setResumo] = useState<Record<string, FinResumo>>({});
-  const [aging, setAging] = useState<AgingData | null>(null);
-  const [dre, setDre] = useState<FinDRE[]>([]);
-  const [inadimplentes, setInadimplentes] = useState<InadimplenteRow[]>([]);
-  const [projecao13, setProjecao13] = useState<FinProjecaoSemana[]>([]);
-  const [confiabilidade, setConfiabilidade] = useState<FinConfiabilidadeRow[]>([]);
-  const [drillDown, setDrillDown] = useState<DrillDownType>(null);
-
-  const { regime } = useFinanceiroRegime();
-  const ano = new Date().getFullYear();
-  const mes = new Date().getMonth() + 1;
-
-  useEffect(() => { loadAll(); }, [regime]);
-
-  const loadAll = async () => {
-    setLoading(true);
-    try {
-      const [res, ag, dr, inad] = await Promise.all([
-        getResumoFinanceiro(['oben', 'colacor', 'colacor_sc']),
-        getAgingReceber('all'),
-        Promise.all(['oben', 'colacor', 'colacor_sc'].map(co => getDRE(co as Company, ano, undefined, regime))).then(r => r.flat()),
-        getTopInadimplentes('all', 5),
-      ]);
-      setResumo(res);
-      setAging(ag);
-      setDre(dr);
-      setInadimplentes(inad);
-
-      // 13-week projection via RPC
-      try {
-        const { data: proj } = await supabase.rpc('fin_projecao_13_semanas', {});
-        setProjecao13(proj ?? []);
-      } catch (e) {
-        // RPC pode não existir ainda — registra para visibilidade em vez de falhar silencioso
-        logger.warn('RPC fin_projecao_13_semanas indisponível', {
-          error: e instanceof Error ? e.message : String(e),
-        });
-      }
-
-      // Confiabilidade for current month per company
-      const confResults: FinConfiabilidadeRow[] = [];
-      for (const co of ['oben', 'colacor', 'colacor_sc']) {
-        try {
-          const { data: conf } = await supabase
-            .from('fin_confiabilidade')
-            .select('*')
-            .eq('company', co)
-            .eq('ano', ano)
-            .eq('mes', mes)
-            .maybeSingle();
-          if (conf) confResults.push(conf);
-        } catch (e) {
-          logger.warn('Tabela fin_confiabilidade indisponível', {
-            company: co,
-            error: e instanceof Error ? e.message : String(e),
-          });
-        }
-      }
-      setConfiabilidade(confResults);
-    } catch (e) {
-      console.error(e);
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  // Computed
-  const totalCC = Object.values(resumo).reduce((s, r) => s + r.saldo_total_cc, 0);
-  const totalCR = Object.values(resumo).reduce((s, r) => s + r.total_a_receber, 0);
-  const totalCP = Object.values(resumo).reduce((s, r) => s + r.total_a_pagar, 0);
-  const totalVencidoCR = Object.values(resumo).reduce((s, r) => s + r.total_vencido_receber, 0);
-  const ncg = totalCR - totalCP; // Necessidade de capital de giro
-  const pctInadimplencia = totalCR > 0 ? (totalVencidoCR / totalCR) * 100 : 0;
-
-  // DRE do mês mais recente
-  const dreUltimo = new Map<string, FinDRE>();
-  for (const d of dre) {
-    const key = d.company;
-    if (!dreUltimo.has(key) || d.mes > (dreUltimo.get(key)?.mes || 0)) {
-      dreUltimo.set(key, d);
-    }
-  }
-  const dreConsolidado = Array.from(dreUltimo.values());
-  const totalReceita = dreConsolidado.reduce((s, d) => s + d.receita_liquida, 0);
-  const totalLucroBruto = dreConsolidado.reduce((s, d) => s + d.lucro_bruto, 0);
-  const totalResultadoOp = dreConsolidado.reduce((s, d) => s + d.resultado_operacional, 0);
-  const margemBruta = totalReceita > 0 ? (totalLucroBruto / totalReceita) * 100 : 0;
-  const margemOp = totalReceita > 0 ? (totalResultadoOp / totalReceita) * 100 : 0;
-
-  // Risco de liquidez
-  const riscoLiquidez = totalCP > 0 && totalCC > 0
-    ? totalCC / totalCP
-    : 0;
-  const riscoLabel = riscoLiquidez >= 1 ? 'Baixo' : riscoLiquidez >= 0.5 ? 'Médio' : 'Alto';
-  const riscoColor = riscoLiquidez >= 1 ? 'text-status-success' : riscoLiquidez >= 0.5 ? 'text-status-warning' : 'text-status-error';
-
-  // Concentração (do aging)
-  const totalAgingCR = aging
-    ? aging.a_vencer_valor + aging.vencido_1_30_valor + aging.vencido_31_60_valor + aging.vencido_61_90_valor + aging.vencido_90_plus_valor
-    : 0;
-  const pctCritico = totalAgingCR > 0
-    ? ((aging?.vencido_61_90_valor || 0) + (aging?.vencido_90_plus_valor || 0)) / totalAgingCR * 100
-    : 0;
+  const {
+    loading,
+    confiabilidade,
+    dreConsolidado,
+    projecao13,
+    inadimplentes,
+    drillDown,
+    setDrillDown,
+    totalCC,
+    totalCR,
+    totalCP,
+    totalVencidoCR,
+    ncg,
+    pctInadimplencia,
+    margemBruta,
+    margemOp,
+    riscoLiquidez,
+    riscoLabel,
+    riscoColor,
+    pctCritico,
+    agingCriticoValor,
+  } = useFinanceiroCockpit();
 
   if (loading) {
     return (
@@ -198,33 +52,7 @@ const FinanceiroCockpit = () => {
   return (
     <div className="space-y-4 pb-24">
       {/* Header — display serif Newsreader em h1 + atmosphere gradient sutil + noise */}
-      <div className="relative bg-cockpit-hero noise rounded-lg border border-border px-6 py-8 flex items-center justify-between flex-wrap gap-3 overflow-hidden">
-        <div className="relative">
-          <p className="text-[10px] uppercase tracking-[0.18em] text-muted-foreground font-medium mb-1.5">
-            Financeiro · Cockpit
-          </p>
-          <h1 className="font-display" style={{ fontSize: '2.25rem', fontWeight: 500, letterSpacing: '-0.04em', lineHeight: 1.1 }}>
-            Visão consolidada
-          </h1>
-          <p className="text-sm text-muted-foreground mt-1.5 tabular-nums">
-            {new Date().toLocaleDateString('pt-BR', { month: 'long', year: 'numeric' })}
-          </p>
-        </div>
-        {/* Global transparency + regime toggle */}
-        <div className="relative flex flex-col items-end gap-3">
-          <RegimeToggle />
-          {confiabilidade.length > 0 && (
-            <div className="flex flex-col items-end gap-1">
-              {confiabilidade.map(c => (
-                <div key={c.company} className="flex items-center gap-2">
-                  <span className="text-xs font-medium">{COMPANIES[c.company as Company]?.shortName}</span>
-                  <TransparencyBadge conf={c} />
-                </div>
-              ))}
-            </div>
-          )}
-        </div>
-      </div>
+      <CockpitHeader confiabilidade={confiabilidade} />
 
       {/* Row 1: Big 3 — staggered reveal pra page load orquestrado */}
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4 stagger-children">
@@ -271,239 +99,32 @@ const FinanceiroCockpit = () => {
           onClick={() => setDrillDown('inadimplencia')} />
         <MiniCard label="Aging Crítico (+60d)" value={`${pctCritico.toFixed(1)}%`}
           color={pctCritico <= 5 ? 'text-status-success' : pctCritico <= 15 ? 'text-status-warning' : 'text-status-error'}
-          subtitle={fmtCompact((aging?.vencido_61_90_valor || 0) + (aging?.vencido_90_plus_valor || 0))}
+          subtitle={fmtCompact(agingCriticoValor)}
           onClick={() => setDrillDown('aging_critico')} />
       </div>
 
       {/* Row 3: Resultado por empresa */}
-      <Card>
-        <CardHeader className="pb-3">
-          <CardTitle className="text-base flex items-center gap-2">
-            <BarChart3 className="w-4 h-4" />
-            Resultado por Empresa (último mês)
-            <Badge variant="outline" className="text-[10px]">Regime de Caixa</Badge>
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          {dreConsolidado.length === 0 ? (
-            <p className="text-sm text-muted-foreground">Sem DRE calculado. Recalcule na aba DRE.</p>
-          ) : (
-            <div className="space-y-3">
-              {dreConsolidado.map(d => {
-                const mg = d.receita_liquida > 0 ? (d.lucro_bruto / d.receita_liquida) * 100 : 0;
-                const conf = confiabilidade.find(c => c.company === d.company);
-                const impostos = Object.entries(d.detalhamento?.impostos ?? {});
-                return (
-                  <div key={d.company} className="p-3 rounded-lg bg-muted/40 space-y-2">
-                    <div className="flex items-center justify-between">
-                      <div className="flex items-center gap-3">
-                        <Badge variant="outline">{COMPANIES[d.company as Company]?.shortName}</Badge>
-                        <span className="text-xs text-muted-foreground">
-                          {['Jan','Fev','Mar','Abr','Mai','Jun','Jul','Ago','Set','Out','Nov','Dez'][d.mes - 1]}
-                        </span>
-                        {d.detalhamento?.regime_tributario && (
-                          <Badge variant="outline" className="text-[9px] capitalize">{d.detalhamento.regime_tributario}</Badge>
-                        )}
-                        {d.detalhamento?.caixa_estimado && (
-                          <span className="text-xs text-status-warning">caixa estimado</span>
-                        )}
-                      </div>
-                      <div className="flex items-center gap-4 text-sm">
-                        <div className="text-right">
-                          <p className="text-[10px] text-muted-foreground">Receita</p>
-                          <p className="font-medium">{fmtCompact(d.receita_liquida)}</p>
-                        </div>
-                        <div className="text-right">
-                          <p className="text-[10px] text-muted-foreground">MB</p>
-                          <p className={`font-bold ${mg >= 30 ? 'text-status-success' : 'text-status-warning'}`}>{mg.toFixed(1)}%</p>
-                        </div>
-                        <div className="text-right">
-                          <p className="text-[10px] text-muted-foreground">Resultado</p>
-                          <p className={`font-bold ${d.resultado_liquido >= 0 ? 'text-status-success' : 'text-status-error'}`}>
-                            {fmtCompact(d.resultado_liquido)}
-                          </p>
-                        </div>
-                        {conf && (
-                          <div className="text-right">
-                            <p className="text-[10px] text-muted-foreground">Mapeado</p>
-                            <p className={`text-xs font-medium ${(conf.pct_valor_mapeado || 0) >= 80 ? 'text-status-success' : 'text-status-warning'}`}>
-                              {(conf.pct_valor_mapeado || 0).toFixed(0)}%
-                            </p>
-                          </div>
-                        )}
-                      </div>
-                    </div>
-                    {/* Confiança banner quando confiança não é 'alta' */}
-                    {d.detalhamento?.confianca && d.detalhamento.confianca.nivel !== 'alta' && (
-                      <div className="rounded-md border p-2 text-xs text-status-warning">
-                        Confiança <strong>{d.detalhamento.confianca.nivel}</strong>:
-                        <ul className="list-disc ml-4">
-                          {d.detalhamento.confianca.motivos.map((m, i) => <li key={i}>{m}</li>)}
-                        </ul>
-                      </div>
-                    )}
-                    {/* Deduções de impostos regime-aware */}
-                    {impostos.length > 0 && (
-                      <div className="border-t pt-2 space-y-0.5">
-                        <p className="text-[10px] text-muted-foreground uppercase tracking-wider">Deduções / Impostos</p>
-                        {impostos.map(([k, v]) => (
-                          <div key={k} className="flex justify-between text-sm">
-                            <span className="text-muted-foreground">{IMPOSTO_LABEL[k] ?? k}</span>
-                            <span className="tabular-nums">{fmt(v as number)}</span>
-                          </div>
-                        ))}
-                      </div>
-                    )}
-                    {d.detalhamento?.imposto_teorico && (
-                      <div className="text-xs text-muted-foreground mt-1">
-                        Imposto teórico esperado: {fmt(Object.values(d.detalhamento.imposto_teorico).reduce((s: number, v) => s + (v ?? 0), 0))}
-                        {d.detalhamento.delta_imposto_pct != null && (
-                          <span className={Math.abs(d.detalhamento.delta_imposto_pct) > 0.25 ? 'text-status-warning ml-1' : 'ml-1'}>
-                            (Δ {(d.detalhamento.delta_imposto_pct * 100).toFixed(0)}% vs realizado)
-                          </span>
-                        )}
-                      </div>
-                    )}
-                  </div>
-                );
-              })}
-            </div>
-          )}
-        </CardContent>
-      </Card>
+      <ResultadoPorEmpresa dreConsolidado={dreConsolidado} confiabilidade={confiabilidade} />
 
       {/* Row 4: Projeção 13 semanas */}
       {projecao13.length > 0 && (
-        <Card>
-          <CardHeader className="pb-3">
-            <CardTitle className="text-base flex items-center gap-2">
-              <Target className="w-4 h-4" />
-              Projeção de Caixa — 13 Semanas
-              <Badge variant="outline" className="text-[10px]">Consolidado · Baseado em CR/CP abertos</Badge>
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="overflow-x-auto">
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead className="min-w-[90px]">Semana</TableHead>
-                    <TableHead className="text-right">Entradas</TableHead>
-                    <TableHead className="text-right">Saídas</TableHead>
-                    <TableHead className="text-right">Fluxo</TableHead>
-                    <TableHead className="text-right">Saldo</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {projecao13.map((w, i) => (
-                    <TableRow key={i} className={w.saldo_projetado < 0 ? 'bg-status-error-bg' : ''}>
-                      <TableCell className="text-xs">{w.semana_label}</TableCell>
-                      <TableCell className="text-right text-sm text-status-success">{fmtCompact(w.entradas_previstas)}</TableCell>
-                      <TableCell className="text-right text-sm text-status-error">{fmtCompact(w.saidas_previstas)}</TableCell>
-                      <TableCell className={`text-right text-sm font-medium ${w.fluxo_liquido >= 0 ? 'text-status-success' : 'text-status-error'}`}>
-                        {fmtCompact(w.fluxo_liquido)}
-                      </TableCell>
-                      <TableCell className={`text-right text-sm font-bold ${w.saldo_projetado >= 0 ? 'text-status-info' : 'text-status-error'}`}>
-                        {fmtCompact(w.saldo_projetado)}
-                        {w.saldo_projetado < 0 && <AlertTriangle className="inline w-3 h-3 ml-1 text-status-error" />}
-                      </TableCell>
-                    </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
-            </div>
-            {projecao13.some((w) => w.saldo_projetado < 0) && (
-              <div className="mt-3 p-3 rounded-lg bg-status-error-bg border border-status-error/20 flex items-start gap-2">
-                <AlertTriangle className="w-4 h-4 text-status-error mt-0.5 shrink-0" />
-                <p className="text-sm text-status-error-fg">
-                  Projeção indica saldo negativo em {projecao13.filter((w) => w.saldo_projetado < 0).length} semana(s).
-                  Ação necessária antes de {projecao13.find((w) => w.saldo_projetado < 0)?.semana_label}.
-                </p>
-              </div>
-            )}
-          </CardContent>
-        </Card>
+        <Projecao13Card projecao13={projecao13} />
       )}
 
       {/* Row 5: Top inadimplentes */}
       {inadimplentes.length > 0 && (
-        <Card>
-          <CardHeader className="pb-3">
-            <CardTitle className="text-base flex items-center gap-2">
-              <AlertTriangle className="w-4 h-4 text-status-error" />
-              Inadimplência Crítica — Top 5
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="space-y-2">
-              {inadimplentes.map((i, idx) => (
-                <div key={idx} className="flex items-center justify-between py-2 border-b last:border-0">
-                  <div>
-                    <p className="font-medium text-sm">{i.nome || (i.cnpj ? `CNPJ: ${i.cnpj}` : 'Cliente não identificado')}</p>
-                    <p className="text-xs text-muted-foreground">{i.qtd_titulos} título(s)</p>
-                  </div>
-                  <span className="font-bold text-status-error">{fmt(i.total_vencido)}</span>
-                </div>
-              ))}
-            </div>
-          </CardContent>
-        </Card>
+        <TopInadimplentes inadimplentes={inadimplentes} />
       )}
 
       {/* Period override history */}
       <PeriodOverrideHistory />
 
       {/* Data basis footer */}
-      <div className="text-xs text-muted-foreground bg-muted/30 p-3 rounded-lg space-y-1">
-        <p className="font-medium flex items-center gap-1"><Info className="w-3 h-3" /> Base dos números</p>
-        <p>Saldo bancário: consulta direta Omie (ResumirContaCorrente). CR/CP: títulos sincronizados (últimos 6 meses). DRE: regime de caixa (pagamento/recebimento efetivo). Projeção 13 semanas: baseada em vencimentos de títulos abertos.</p>
-        <p>Para números de controller, verifique: % mapeado ≥ 80%, conciliação ≥ 70%, mês fechado.</p>
-      </div>
+      <DataBasisFooter />
 
       <CockpitDrillDown type={drillDown} onClose={() => setDrillDown(null)} />
     </div>
   );
 };
-
-// ═══════════════ SUB-COMPONENTS ═══════════════
-
-function CockpitCard({ title, value, positive, icon: Icon, detail, detailColor, badge, onClick }: {
-  title: string; value: string; positive: boolean; icon: LucideIcon;
-  detail?: string; detailColor?: string; badge?: string; onClick?: () => void;
-}) {
-  return (
-    <Card className={onClick ? 'cursor-pointer hover:bg-muted/30 transition-colors' : ''} onClick={onClick}>
-      <CardContent className="p-5">
-        <div className="flex items-start justify-between">
-          <div>
-            <p className="text-xs text-muted-foreground font-medium uppercase tracking-wider">{title}</p>
-            <p className={`kpi-value text-3xl mt-2 ${positive ? 'text-status-success' : 'text-status-error'}`}>{value}</p>
-            {detail && (
-              <p className={`text-xs mt-2 ${detailColor || 'text-muted-foreground'}`}>{detail}</p>
-            )}
-            {badge && (
-              <Badge variant="outline" className="mt-2 text-[9px]">{badge}</Badge>
-            )}
-          </div>
-          <div className={`p-2.5 rounded-md ${positive ? 'bg-status-success-bg' : 'bg-status-error-bg'}`}>
-            <Icon className={`w-4 h-4 ${positive ? 'text-status-success' : 'text-status-error'}`} />
-          </div>
-        </div>
-      </CardContent>
-    </Card>
-  );
-}
-
-function MiniCard({ label, value, color, subtitle, onClick }: {
-  label: string; value: string; color: string; subtitle?: string; onClick?: () => void;
-}) {
-  return (
-    <div className={`p-3 rounded-md border bg-card text-center ${onClick ? 'cursor-pointer hover:bg-muted/30 transition-colors' : ''}`} onClick={onClick}>
-      <p className="text-[10px] text-muted-foreground font-medium uppercase tracking-wider">{label}</p>
-      <p className={`kpi-value text-xl mt-1 ${color}`}>{value}</p>
-      {subtitle && <p className="text-xs text-muted-foreground mt-0.5 tabular-nums">{subtitle}</p>}
-    </div>
-  );
-}
 
 export default FinanceiroCockpit;


### PR DESCRIPTION
## Resumo
Quebra o god-component `src/pages/FinanceiroCockpit.tsx` (**509→130L**) em um hook de dados/derivados + componentes presentacionais controlados, sob `src/components/financeiro/cockpit/`. Extração **verbatim** — comportamento preservado 1:1.

## O que mudou
- **`useFinanceiroCockpit`** (hook): state, `loadAll` (resumo/aging/DRE/inadimplentes/projeção 13s via RPC/confiabilidade por empresa) e todos os derivados consolidados (caixa/NCG/margens/risco de liquidez/inadimplência/aging).
- **`CockpitHeader`** — título + RegimeToggle + badges de confiabilidade.
- **`CockpitCard`** / **`MiniCard`** — primitivos de KPI.
- **`TransparencyBadge`** — badge de confiabilidade + ícone de fechamento.
- **`ResultadoPorEmpresa`** — DRE consolidado regime-aware.
- **`Projecao13Card`** — projeção de caixa de 13 semanas.
- **`TopInadimplentes`** — inadimplência crítica top 5.
- **`DataBasisFooter`** — rodapé "base dos números".
- **`types.ts`** / **`format.ts`** (`fmt`/`fmtCompact`/`IMPOSTO_LABEL`).
- **+15 testes** (helpers puros + presentacionais).

## Verificação
- `bunx tsc --noEmit` (baseline) = **0**
- `eslint` = **0 erros** (1 warning `exhaustive-deps` pré-existente, apenas relocado para o hook — confirmado na `origin/main`)
- **15/15 testes** verdes (isolados)
- Revisão independente FIEL 1:1: **aprovada** (loadAll/derivados/ordem de hooks/DRE/projeção conferidos)

## Migrations
Nenhuma.

🤖 Generated with [Claude Code](https://claude.com/claude-code)