### PR TITLE
fix(fin): saldo das contas correntes (Omie ListarExtrato) + 5 fixes de design DS v3

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -713,7 +713,7 @@ function MobileNav({ open, onClose }: { open: boolean; onClose: () => void }) {
                       key={item.path}
                       onClick={() => { navigate(item.path); onClose(); }}
                       className={cn(
-                        'flex items-center gap-2.5 w-full px-3 py-1.5 mx-2 rounded-md text-sm font-medium transition-colors',
+                        'flex min-h-11 items-center gap-2.5 w-full px-3 py-2.5 mx-2 rounded-md text-sm font-medium transition-colors',
                         active
                           ? 'bg-sidebar-accent text-sidebar-accent-foreground'
                           : 'text-sidebar-foreground hover:bg-sidebar-accent/60'

--- a/src/components/financeiro/dashboard/KpiCard.tsx
+++ b/src/components/financeiro/dashboard/KpiCard.tsx
@@ -19,7 +19,7 @@ export function KpiCard({ title, value, icon: Icon, color, bgColor, subtitle, su
         <div className="flex items-start justify-between">
           <div>
             <p className="text-xs text-muted-foreground font-medium">{title}</p>
-            <p className={`text-lg font-bold mt-1 ${color}`}>{fmtCompact(value)}</p>
+            <p className={`text-lg kpi-value mt-1 ${color}`}>{fmtCompact(value)}</p>
             {subtitle && (
               <p className={`text-xs mt-1 ${subtitleColor || 'text-muted-foreground'}`}>{subtitle}</p>
             )}

--- a/src/components/financeiro/dashboard/VisaoGeralTab.tsx
+++ b/src/components/financeiro/dashboard/VisaoGeralTab.tsx
@@ -155,7 +155,7 @@ export function VisaoGeralTab({
               {/* Capital de Giro */}
               <div className="text-center p-3 rounded-lg bg-muted/40">
                 <p className="text-xs text-muted-foreground">Capital de Giro</p>
-                <p className={`text-lg font-bold mt-1 ${
+                <p className={`text-lg kpi-value mt-1 ${
                   (activeResumo.total_a_receber - activeResumo.total_a_pagar) >= 0
                     ? 'text-status-success' : 'text-status-error'
                 }`}>
@@ -166,7 +166,7 @@ export function VisaoGeralTab({
               {/* Inadimplência % */}
               <div className="text-center p-3 rounded-lg bg-muted/40">
                 <p className="text-xs text-muted-foreground">Inadimplência</p>
-                <p className={`text-lg font-bold mt-1 ${
+                <p className={`text-lg kpi-value mt-1 ${
                   activeResumo.total_a_receber > 0 && (activeResumo.total_vencido_receber / activeResumo.total_a_receber) > 0.15
                     ? 'text-status-error' : 'text-status-warning'
                 }`}>
@@ -179,7 +179,7 @@ export function VisaoGeralTab({
               {/* Cobertura de Caixa */}
               <div className="text-center p-3 rounded-lg bg-muted/40">
                 <p className="text-xs text-muted-foreground">Cobertura de Caixa</p>
-                <p className={`text-lg font-bold mt-1 ${
+                <p className={`text-lg kpi-value mt-1 ${
                   activeResumo.total_a_pagar > 0 && (activeResumo.saldo_total_cc / activeResumo.total_a_pagar) >= 0.5
                     ? 'text-status-success' : 'text-status-error'
                 }`}>
@@ -192,7 +192,7 @@ export function VisaoGeralTab({
               {/* Exposure > 90 dias */}
               <div className="text-center p-3 rounded-lg bg-muted/40">
                 <p className="text-xs text-muted-foreground">Risco +90 dias</p>
-                <p className={`text-lg font-bold mt-1 ${
+                <p className={`text-lg kpi-value mt-1 ${
                   agingReceber.vencido_90_plus_valor > 0 ? 'text-status-error' : 'text-status-success'
                 }`}>
                   {fmtCompact(agingReceber.vencido_90_plus_valor)}

--- a/src/components/financeiro/dashboard/VisaoGeralTab.tsx
+++ b/src/components/financeiro/dashboard/VisaoGeralTab.tsx
@@ -138,7 +138,7 @@ export function VisaoGeralTab({
       {/* Aging */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
         <AgingCard title="Aging Recebíveis" data={agingReceber} type="receber" />
-        <AgingCard title="Aging Payables" data={agingPagar} type="pagar" />
+        <AgingCard title="Aging Pagáveis" data={agingPagar} type="pagar" />
       </div>
 
       {/* CFO Indicators */}

--- a/src/components/reposicao/MetricsStrip.tsx
+++ b/src/components/reposicao/MetricsStrip.tsx
@@ -24,7 +24,7 @@ function MetricCard({
           <I className="h-3.5 w-3.5" />
           {label}
         </div>
-        <div className="text-lg font-semibold">{value}</div>
+        <div className="text-lg kpi-value">{value}</div>
         {extra}
       </CardContent>
     </Card>

--- a/src/pages/FinanceiroDashboard.tsx
+++ b/src/pages/FinanceiroDashboard.tsx
@@ -106,7 +106,12 @@ const FinanceiroDashboard = () => {
       {/* Header */}
       <div className="flex items-center justify-between flex-wrap gap-3">
         <div>
-          <h1 className="text-2xl font-bold tracking-tight">Financeiro</h1>
+          <h1
+            className="font-display"
+            style={{ fontSize: "2rem", fontWeight: 500, letterSpacing: "-0.04em", lineHeight: 1.1 }}
+          >
+            Financeiro
+          </h1>
           <p className="text-sm text-muted-foreground mt-1">
             Controle financeiro integrado — Omie
             {lastSync && (

--- a/src/pages/Recebimento.tsx
+++ b/src/pages/Recebimento.tsx
@@ -5,6 +5,7 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
 import { FileCheck, Truck, Plus, Loader2, PackageCheck, RefreshCw } from 'lucide-react';
 import { EmptyState } from '@/components/EmptyState';
+import { PageSkeleton } from '@/components/ui/page-skeleton';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent } from '@/components/ui/card';
@@ -265,9 +266,7 @@ export default function Recebimento({ statusFilter }: { statusFilter?: string[] 
 
       {/* NF-e list */}
       {isLoading ? (
-        <div className="flex justify-center py-12">
-          <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
-        </div>
+        <PageSkeleton variant="list" />
       ) : !nfes || nfes.length === 0 ? (
         <Card>
           <CardContent className="p-0">

--- a/src/pages/picking/TouchPickingView.tsx
+++ b/src/pages/picking/TouchPickingView.tsx
@@ -6,7 +6,8 @@ import type { Tables } from '@/integrations/supabase/types';
 import { Button } from '@/components/ui/button';
 import { Progress } from '@/components/ui/progress';
 import { ScanBar, type ScanResult } from '@/components/picking/ScanBar';
-import { Loader2, ChevronRight, Package, Monitor } from 'lucide-react';
+import { ChevronRight, Package, Monitor } from 'lucide-react';
+import { PageSkeleton } from '@/components/ui/page-skeleton';
 import { toast } from 'sonner';
 import { cn } from '@/lib/utils';
 import { setForceFull } from '@/lib/picking/view-pref';
@@ -71,9 +72,7 @@ export default function TouchPickingView() {
 
   if (isLoading) {
     return (
-      <div className="flex justify-center py-20 text-muted-foreground">
-        <Loader2 className="h-6 w-6 animate-spin" />
-      </div>
+      <PageSkeleton variant="list" />
     );
   }
 
@@ -222,9 +221,7 @@ function ActiveTaskView({
 
   if (isLoading) {
     return (
-      <div className="flex justify-center py-20 text-muted-foreground">
-        <Loader2 className="h-6 w-6 animate-spin" />
-      </div>
+      <PageSkeleton variant="list" />
     );
   }
 

--- a/supabase/functions/omie-financeiro/index.ts
+++ b/supabase/functions/omie-financeiro/index.ts
@@ -40,9 +40,10 @@ interface OmieContaCorrente {
   cInativa?: string;
 }
 
-interface OmieResumirContaCorrenteResponse {
-  nSaldo?: number;
-  nSaldoAtual?: number;
+// Resposta de financas/extrato/ ListarExtrato — saldos no top-level.
+interface OmieExtratoResponse {
+  nSaldoAtual?: number;        // saldo realizado disponível hoje
+  nSaldoDisponivel?: number;   // saldo disponível hoje (fallback)
 }
 
 interface OmieContaPagar {
@@ -363,26 +364,39 @@ async function syncContasCorrentes(
       || (result.conta_corrente_lista as OmieContaCorrente[] | undefined)
       || [];
 
+    // Saldo atual vem de financas/extrato/ (ListarExtrato), NÃO de geral/contacorrente/.
+    // dPeriodoInicial/Final são obrigatórios (DD/MM/AAAA); pra saldo "hoje" usamos a data atual nos dois.
+    const hoje = new Date();
+    const dataBR = `${String(hoje.getDate()).padStart(2, "0")}/${String(hoje.getMonth() + 1).padStart(2, "0")}/${hoje.getFullYear()}`;
+
     for (const c of contas) {
-      // Buscar saldo real via ResumirContaCorrente
-      let saldoAtual = 0;
+      // Busca saldo real via ListarExtrato (cExibirApenasSaldo=S => só os saldos, sem movimentos).
+      let saldoAtual: number | null = null;
       let saldoData: string | null = null;
+      let saldoOk = false;
       try {
         const saldoResult = (await callOmie(
           company,
-          "geral/contacorrente/",
-          "ResumirContaCorrente",
-          { nCodCC: c.nCodCC }
-        )) as OmieResumirContaCorrenteResponse | null;
-        if (saldoResult) {
-          saldoAtual = saldoResult.nSaldo ?? saldoResult.nSaldoAtual ?? 0;
+          "financas/extrato/",
+          "ListarExtrato",
+          {
+            nCodCC: c.nCodCC,
+            dPeriodoInicial: dataBR,
+            dPeriodoFinal: dataBR,
+            cExibirApenasSaldo: "S",
+          }
+        )) as OmieExtratoResponse | null;
+        if (saldoResult && (saldoResult.nSaldoAtual != null || saldoResult.nSaldoDisponivel != null)) {
+          saldoAtual = saldoResult.nSaldoAtual ?? saldoResult.nSaldoDisponivel ?? null;
           saldoData = new Date().toISOString().split("T")[0];
+          saldoOk = true;
         }
       } catch (e) {
-        console.log(`[Fin][${company}] Saldo CC ${c.nCodCC} falhou, usando 0: ${e}`);
+        // NÃO zera em falha: preserva o saldo anterior (não inclui saldo_atual no upsert).
+        console.log(`[Fin][${company}] Saldo CC ${c.nCodCC} falhou, preservando saldo anterior: ${e}`);
       }
 
-      const row = {
+      const row: Record<string, unknown> = {
         company,
         omie_ncodcc: c.nCodCC,
         descricao: c.descricao || c.cDescricao,
@@ -390,11 +404,14 @@ async function syncContasCorrentes(
         agencia: c.codigo_agencia || c.cAgencia || c.agencia,
         numero_conta: c.numero_conta_corrente || c.cNumeroConta || c.numero_conta,
         tipo: c.tipo_conta_corrente || c.tipo || c.cTipo || "CC",
-        saldo_atual: saldoAtual,
-        saldo_data: saldoData,
         ativo: c.inativo !== "S" && c.cInativa !== "S",
         updated_at: new Date().toISOString(),
       };
+      // Só grava saldo quando o extrato respondeu; em falha, o upsert não mexe em saldo_atual/saldo_data.
+      if (saldoOk) {
+        row.saldo_atual = saldoAtual;
+        row.saldo_data = saldoData;
+      }
 
       const { error } = await db
         .from("fin_contas_correntes")
@@ -1801,13 +1818,16 @@ serve(async (req) => {
 
       // Debug: retorna JSON raw do Omie sem transformação (para validação Onda 1)
       case "debug_raw": {
+        const _hoje = new Date();
+        const _hojeBR = `${String(_hoje.getDate()).padStart(2, "0")}/${String(_hoje.getMonth() + 1).padStart(2, "0")}/${_hoje.getFullYear()}`;
         const endpoints: Record<string, { endpoint: string; call: string; params: Record<string, unknown> }> = {
           categorias: { endpoint: "geral/categorias/", call: "ListarCategorias", params: { pagina: 1, registros_por_pagina: 2 } },
           contas_correntes: { endpoint: "geral/contacorrente/", call: "ListarContasCorrentes", params: { pagina: 1, registros_por_pagina: 2 } },
           contas_pagar: { endpoint: "financas/contapagar/", call: "ListarContasPagar", params: { pagina: 1, registros_por_pagina: 2 } },
           contas_receber: { endpoint: "financas/contareceber/", call: "ListarContasReceber", params: { pagina: 1, registros_por_pagina: 2 } },
           movimentacoes: { endpoint: "financas/mf/", call: "ListarMovimentos", params: { nPagina: 1, nRegPorPagina: 2 } },
-          resumir_cc: { endpoint: "geral/contacorrente/", call: "ResumirContaCorrente", params: { nCodCC: Number(ncodcc) || 0 } },
+          // Saldo atual real de uma conta (passe ncodcc). Use pra validar o fix de saldo.
+          extrato_cc: { endpoint: "financas/extrato/", call: "ListarExtrato", params: { nCodCC: Number(ncodcc) || 0, dPeriodoInicial: _hojeBR, dPeriodoFinal: _hojeBR, cExibirApenasSaldo: "S" } },
         };
         const ep = endpoints[entidade || "contas_pagar"];
         if (!ep) {


### PR DESCRIPTION
## Resumo

Resultado de um `/design-review` das 5 telas top por persona (financeiro, venda, picking, recebimento, reposição) + investigação de root cause do "saldo zerado" das contas correntes.

### Fixes de design (DS v3, CSS/texto, verificados no browser)
- **FINDING-001** — "Aging Payables" → "Aging Pagáveis" (idioma pt-BR no cockpit financeiro)
- **FINDING-002** — h1 do cockpit financeiro em `font-display` (Newsreader serif), igual ao Reposição
- **FINDING-007** — itens do drawer de nav mobile com touch target 44px (WCAG; sidebar desktop densa preservada a 32px)
- **FINDING-006** — `PageSkeleton` no lugar de `Loader2` de página inteira (picking + recebimento)
- **FINDING-003** — KPIs em `.kpi-value` (Geist Mono + tabular) no financeiro e reposição

### Fix de backend (root cause)
- **`fix(fin)`** — as contas correntes apareciam zeradas porque `syncContasCorrentes` chamava `geral/contacorrente/ResumirContaCorrente`, **método inexistente na API do Omie** → fault → catch → `saldo_atual=0` em todas as contas. Trocado por **`financas/extrato/ListarExtrato`** (`nSaldoAtual`/`nSaldoDisponivel`). Em falha **não zera mais** (preserva saldo anterior). `debug_raw` ganhou `entidade: "extrato_cc"` pra validação.

## ⚠️ Deploy manual necessário (edge function)
`omie-financeiro` é edge function — **NÃO entra com o merge**. Após mergear, deployar via chat do Lovable (lê `supabase/functions/omie-financeiro/index.ts` da `main`) e **validar com 1 conta** (`debug_raw`/`extrato_cc`) antes de confiar no cron `sync_contas_correntes`.

## Verificação
- `bun run test`: 1030/1030 ✅
- `bun run build`: ✅ (PWA gerado)
- `bun lint`: 0 problemas novos nos arquivos tocados
- `deno check` (edge function): 0 erros novos (10 pré-existentes em `debug_raw`)
- Browser: h1 serif, "Aging Pagáveis", touch 44px mobile / 32px desktop, KPIs Geist Mono — todos confirmados via computed style

🤖 Generated with [Claude Code](https://claude.com/claude-code)