### PR TITLE
refactor(customer): split CustomerDashboard (509→132) em hook + componentes

### DIFF
--- a/src/components/CustomerDashboard.tsx
+++ b/src/components/CustomerDashboard.tsx
@@ -1,44 +1,21 @@
+// Dashboard do cliente (afiação) — hero, ação prioritária, gamificação, pedidos,
+// ferramentas, ações rápidas. Composição com useCustomerDashboard + seções.
+// God-component split de src/components/CustomerDashboard.tsx (comportamento 1:1).
 import { useNavigate } from 'react-router-dom';
-import { useEffect, useState } from 'react';
 import { Card, CardContent } from '@/components/ui/card';
-import { Progress } from '@/components/ui/progress';
-import { motion } from 'framer-motion';
-import {
-  PlusCircle, ChevronRight, Wrench, User,
-  ArrowRight, TrendingUp, Package, Trophy, Gamepad2,
-  Sparkles, AlertTriangle, Award, CheckCircle2, MapPin,
-  LifeBuoy, FileText
-} from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
+import { motion } from 'framer-motion';
+import { PlusCircle, TrendingUp, Sparkles } from 'lucide-react';
 import { OnboardingWizard } from '@/components/OnboardingWizard';
-import { useGamificationScore, getLevelInfo } from '@/hooks/useGamificationScore';
-import { differenceInDays, format } from 'date-fns';
-import { ptBR } from 'date-fns/locale';
-import { cn } from '@/lib/utils';
-import { supabase } from '@/integrations/supabase/client';
-
-/* ─── Types ─── */
-interface Profile {
-  name: string;
-  customer_type: string | null;
-  document: string | null;
-}
-
-interface Order {
-  id: string;
-  status: string;
-  created_at: string;
-  service_type: string;
-}
-
-interface UserTool {
-  id: string;
-  tool_category_id: string;
-  next_sharpening_due: string | null;
-  sharpening_interval_days: number | null;
-  tool_categories: { name: string };
-}
+import { useCustomerDashboard } from '@/components/customerDashboard/useCustomerDashboard';
+import { stagger, fadeUp } from '@/components/customerDashboard/config';
+import { DashboardHero } from '@/components/customerDashboard/DashboardHero';
+import { PriorityCard } from '@/components/customerDashboard/PriorityCard';
+import { GamificationMini } from '@/components/customerDashboard/GamificationMini';
+import { PedidosAndamento } from '@/components/customerDashboard/PedidosAndamento';
+import { FerramentasAtencao } from '@/components/customerDashboard/FerramentasAtencao';
+import { AcoesRapidas } from '@/components/customerDashboard/AcoesRapidas';
+import type { Profile, Order, UserTool } from '@/components/customerDashboard/types';
 
 interface CustomerDashboardProps {
   profile: Profile | null;
@@ -47,202 +24,30 @@ interface CustomerDashboardProps {
   getGreeting: () => string;
 }
 
-/* ─── Status config ─── */
-const statusConfig: Record<string, { label: string; statusClass: string }> = {
-  'pedido_recebido': { label: 'Recebido', statusClass: 'status-progress' },
-  'aguardando_coleta': { label: 'Aguardando Coleta', statusClass: 'status-pending' },
-  'em_triagem': { label: 'Em Triagem', statusClass: 'status-purple' },
-  'orcamento_enviado': { label: 'Orçamento', statusClass: 'status-pending' },
-  'aprovado': { label: 'Aprovado', statusClass: 'status-success' },
-  'em_afiacao': { label: 'Em Afiação', statusClass: 'status-progress' },
-  'controle_qualidade': { label: 'Qualidade', statusClass: 'status-indigo' },
-  'pronto_entrega': { label: 'Pronto!', statusClass: 'status-success' },
-  'em_rota': { label: 'Em Rota', statusClass: 'status-indigo' },
-  'entregue': { label: 'Entregue', statusClass: 'bg-muted text-muted-foreground' },
-};
-
-/* ─── Animations ─── */
-const stagger = {
-  hidden: {},
-  show: { transition: { staggerChildren: 0.06 } },
-};
-const fadeUp = {
-  hidden: { opacity: 0, y: 14 },
-  show: { opacity: 1, y: 0, transition: { duration: 0.4, ease: [0.25, 0.1, 0.25, 1] as const } },
-};
-
-/* ─── Priority Action Logic ─── */
-interface PriorityAction {
-  type: 'quote' | 'order_issue' | 'tools_overdue' | 'no_tools' | 'no_address' | 'all_good';
-  title: string;
-  description: string;
-  buttonLabel?: string;
-  path?: string;
-  variant: 'warning' | 'destructive' | 'default' | 'success';
-  icon: typeof AlertTriangle;
-  orderId?: string;
-}
-
-function computePriority(
-  pendingOrders: Order[],
-  toolsOverdue: UserTool[],
-  userTools: UserTool[],
-  hasAddresses: boolean,
-): PriorityAction {
-  // 1. Pending quote
-  const quoteOrder = pendingOrders.find(o => o.status === 'orcamento_enviado');
-  if (quoteOrder) {
-    return {
-      type: 'quote', variant: 'warning', icon: FileText,
-      title: 'Orçamento pendente de aprovação',
-      description: 'Revise e aprove para que a afiação seja iniciada.',
-      buttonLabel: 'Ver orçamento', path: `/orders/${quoteOrder.id}`,
-      orderId: quoteOrder.id,
-    };
-  }
-
-  // 2. Tools overdue
-  if (toolsOverdue.length > 0) {
-    return {
-      type: 'tools_overdue', variant: 'destructive', icon: AlertTriangle,
-      title: `${toolsOverdue.length} ferramenta(s) com afiação vencida`,
-      description: 'Ferramentas fora do prazo podem perder o fio e danificar peças.',
-      buttonLabel: 'Agendar afiação', path: '/new-order',
-    };
-  }
-
-  // 3. No tools registered
-  if (userTools.length === 0) {
-    return {
-      type: 'no_tools', variant: 'default', icon: Wrench,
-      title: 'Cadastre suas ferramentas',
-      description: 'Facilite seus pedidos e receba alertas de manutenção.',
-      buttonLabel: 'Cadastrar', path: '/tools',
-    };
-  }
-
-  // 4. No address
-  if (!hasAddresses) {
-    return {
-      type: 'no_address', variant: 'default', icon: MapPin,
-      title: 'Cadastre um endereço para agilizar coletas',
-      description: 'Com um endereço salvo, seus pedidos ficam mais rápidos.',
-      buttonLabel: 'Adicionar', path: '/addresses',
-    };
-  }
-
-  // 5. All good
-  return {
-    type: 'all_good', variant: 'success', icon: CheckCircle2,
-    title: 'Tudo em dia!',
-    description: 'Suas ferramentas estão bem cuidadas.',
-  };
-}
-
-/* ─── Component ─── */
 export function CustomerDashboard({ profile, pendingOrders, userTools, getGreeting }: CustomerDashboardProps) {
   const navigate = useNavigate();
-  const { data: gamScore } = useGamificationScore();
-
-  const [hasAddresses, setHasAddresses] = useState(true); // optimistic default
-
-  // Lightweight address check
-  useEffect(() => {
-    (async () => {
-      const { count } = await supabase
-        .from('addresses')
-        .select('id', { count: 'exact', head: true });
-      setHasAddresses((count ?? 0) > 0);
-    })();
-  }, []);
-
-  const isCNPJ = profile?.document && profile.document.replace(/\D/g, '').length === 14;
-  const displayName = isCNPJ ? profile?.name || 'Cliente' : profile?.name?.split(' ')[0] || 'Cliente';
-
-  const toolsOverdue = userTools.filter(t => {
-    if (!t.next_sharpening_due) return false;
-    return differenceInDays(new Date(t.next_sharpening_due), new Date()) < 0;
-  });
-  const toolsSoon = userTools.filter(t => {
-    if (!t.next_sharpening_due) return false;
-    const d = differenceInDays(new Date(t.next_sharpening_due), new Date());
-    return d >= 0 && d <= 7;
-  });
-  const urgentTools = [...toolsOverdue, ...toolsSoon];
-  const levelInfo = gamScore ? getLevelInfo(gamScore.total_score) : null;
-
-  const priority = computePriority(pendingOrders, toolsOverdue, userTools, hasAddresses);
-
-  const ordersNeedingAction = pendingOrders.filter(o => o.status === 'orcamento_enviado');
-  const otherActiveOrders = pendingOrders.filter(o => o.status !== 'orcamento_enviado');
-
-  const quickActions = [
-    { icon: PlusCircle, label: 'Novo Pedido', path: '/new-order' },
-    { icon: Wrench, label: 'Ferramentas', path: '/tools' },
-    { icon: Gamepad2, label: 'Gamificação', path: '/gamification' },
-    { icon: LifeBuoy, label: 'Suporte', path: '/support' },
-  ];
+  const {
+    gamScore,
+    displayName,
+    urgentTools,
+    levelInfo,
+    priority,
+    ordersNeedingAction,
+    otherActiveOrders,
+  } = useCustomerDashboard(profile, pendingOrders, userTools);
 
   return (
     <div className="space-y-6">
       {/* ─── Hero Header ─── */}
-      <header className="bg-gradient-dark text-secondary-foreground px-4 pt-12 pb-10 relative overflow-hidden">
-        <div className="absolute top-0 right-0 w-72 h-72 bg-primary/8 rounded-full blur-3xl -translate-y-1/2 translate-x-1/2" />
-        <div className="absolute bottom-0 left-0 w-48 h-48 bg-primary/5 rounded-full blur-2xl translate-y-1/2 -translate-x-1/2" />
-        <motion.div
-          className="max-w-lg mx-auto relative z-10"
-          initial={{ opacity: 0, y: -10 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.5 }}
-        >
-          <div className="flex items-start justify-between mb-6">
-            <div className="space-y-1">
-              <p className="text-sm text-secondary-foreground/60 font-medium">{getGreeting()},</p>
-              <h1 className="text-2xl font-display font-bold tracking-tight">{displayName}</h1>
-              {profile?.customer_type && (
-                <span className={cn(
-                  'inline-flex items-center gap-1.5 text-[11px] px-2.5 py-1 rounded-full font-semibold uppercase tracking-wider',
-                  profile.customer_type === 'industrial'
-                    ? 'bg-status-warning/20 text-status-warning-bg'
-                    : 'bg-status-info/20 text-status-info-bg'
-                )}>
-                  {profile.customer_type === 'industrial' ? (
-                    <><TrendingUp className="w-3 h-3" /> Industrial</>
-                  ) : 'Doméstico'}
-                </span>
-              )}
-            </div>
-            <motion.button
-              onClick={() => navigate('/profile')}
-              className="w-12 h-12 rounded-2xl bg-secondary-foreground/10 hover:bg-secondary-foreground/20 flex items-center justify-center transition-colors border border-secondary-foreground/10"
-              whileTap={{ scale: 0.92 }}
-            >
-              <User className="w-5 h-5 text-secondary-foreground/80" />
-            </motion.button>
-          </div>
-
-          {/* Stats Row */}
-          <motion.div className="grid grid-cols-3 gap-2" variants={stagger} initial="hidden" animate="show">
-            {[
-              { icon: Package, value: pendingOrders.length, label: 'Pedidos', path: '/orders' },
-              { icon: Wrench, value: userTools.length, label: 'Ferramentas', path: '/tools' },
-              { icon: Trophy, value: gamScore?.total_score || 0, label: 'Score', path: '/gamification' },
-            ].map(stat => (
-              <motion.button
-                key={stat.label}
-                variants={fadeUp}
-                onClick={() => navigate(stat.path)}
-                className="bg-secondary-foreground/8 hover:bg-secondary-foreground/14 rounded-2xl p-3 backdrop-blur-sm border border-secondary-foreground/5 transition-colors text-left group"
-                whileTap={{ scale: 0.96 }}
-              >
-                <stat.icon className="w-4 h-4 text-secondary-foreground/50 mb-1" />
-                <p className="text-2xl font-bold tracking-tight">{stat.value}</p>
-                <p className="text-[10px] text-secondary-foreground/50 font-medium">{stat.label}</p>
-              </motion.button>
-            ))}
-          </motion.div>
-        </motion.div>
-      </header>
+      <DashboardHero
+        getGreeting={getGreeting}
+        displayName={displayName}
+        customerType={profile?.customer_type}
+        pendingOrdersCount={pendingOrders.length}
+        userToolsCount={userTools.length}
+        gamScoreTotal={gamScore?.total_score || 0}
+        navigate={navigate}
+      />
 
       <motion.main
         className="px-4 -mt-5 max-w-lg mx-auto relative z-20 space-y-5"
@@ -261,119 +66,31 @@ export function CustomerDashboard({ profile, pendingOrders, userTools, getGreeti
         {/* Gamification Mini */}
         {gamScore && levelInfo && (
           <motion.div variants={fadeUp}>
-            <Card
-              className="shadow-medium border-0 overflow-hidden cursor-pointer hover:shadow-strong transition-shadow"
-              onClick={() => navigate('/gamification')}
-            >
-              <CardContent className="p-4">
-                <div className="flex items-center gap-3">
-                  <div className="w-11 h-11 rounded-xl bg-status-warning-bg flex items-center justify-center flex-shrink-0">
-                    <Award className="w-6 h-6 text-status-warning" />
-                  </div>
-                  <div className="flex-1 min-w-0">
-                    <div className="flex items-center justify-between mb-1">
-                      <span className="font-semibold text-sm text-foreground">
-                        Nível {gamScore.level} — {gamScore.level_name}
-                      </span>
-                      <ChevronRight className="w-4 h-4 text-muted-foreground" />
-                    </div>
-                    <Progress value={gamScore.total_score} className="h-1.5" />
-                    <div className="flex justify-between mt-1">
-                      <span className="text-[10px] text-muted-foreground">{gamScore.total_score}/100 pts</span>
-                      {levelInfo.nextLevel && (
-                        <span className="text-[10px] text-muted-foreground">
-                          Faltam {Math.ceil(levelInfo.nextLevel.min - gamScore.total_score)} para {levelInfo.nextLevel.name}
-                        </span>
-                      )}
-                    </div>
-                  </div>
-                </div>
-              </CardContent>
-            </Card>
+            <GamificationMini gamScore={gamScore} levelInfo={levelInfo} navigate={navigate} />
           </motion.div>
         )}
 
         {/* ─── SEÇÃO 2: Pedidos em Andamento ─── */}
         {pendingOrders.length > 0 && (
           <motion.section variants={fadeUp}>
-            <div className="flex items-center justify-between mb-3">
-              <h2 className="font-display font-bold text-lg text-foreground">Pedidos em Andamento</h2>
-              <button onClick={() => navigate('/orders')} className="text-sm font-medium text-primary flex items-center gap-1 hover:gap-2 transition-all">
-                Ver todos <ChevronRight className="w-4 h-4" />
-              </button>
-            </div>
-            <div className="space-y-2.5">
-              {/* Orders needing action first */}
-              {ordersNeedingAction.map((order, i) => (
-                <OrderRow key={order.id} order={order} index={i} navigate={navigate} needsAction />
-              ))}
-              {otherActiveOrders.slice(0, 3).map((order, i) => (
-                <OrderRow key={order.id} order={order} index={ordersNeedingAction.length + i} navigate={navigate} />
-              ))}
-            </div>
+            <PedidosAndamento
+              ordersNeedingAction={ordersNeedingAction}
+              otherActiveOrders={otherActiveOrders}
+              navigate={navigate}
+            />
           </motion.section>
         )}
 
         {/* ─── SEÇÃO 3: Ferramentas que Exigem Atenção ─── */}
         {urgentTools.length > 0 && (
           <motion.section variants={fadeUp}>
-            <div className="flex items-center justify-between mb-3">
-              <h2 className="font-display font-bold text-lg text-foreground">Ferramentas com Atenção</h2>
-              <button onClick={() => navigate('/tools')} className="text-sm font-medium text-primary flex items-center gap-1 hover:gap-2 transition-all">
-                Gerenciar <ChevronRight className="w-4 h-4" />
-              </button>
-            </div>
-            <Card className="border-status-warning/20 bg-status-warning-bg/50">
-              <CardContent className="p-4 space-y-3">
-                {urgentTools.slice(0, 4).map(tool => {
-                  const days = differenceInDays(new Date(tool.next_sharpening_due!), new Date());
-                  return (
-                    <div key={tool.id} className="flex items-center justify-between">
-                      <div className="flex items-center gap-2">
-                        <div className={cn('w-8 h-8 rounded-lg flex items-center justify-center',
-                          days < 0 ? 'bg-destructive/10' : 'bg-status-warning-bg'
-                        )}>
-                          <Wrench className={cn('w-4 h-4', days < 0 ? 'text-destructive' : 'text-status-warning')} />
-                        </div>
-                        <span className="text-sm font-medium text-foreground">{tool.tool_categories?.name}</span>
-                      </div>
-                      <span className={cn(
-                        'text-xs font-semibold px-2 py-0.5 rounded-full',
-                        days < 0 ? 'bg-destructive/10 text-destructive' : 'bg-status-warning-bg text-status-warning-foreground'
-                      )}>
-                        {days < 0 ? `${Math.abs(days)}d atrasado` : days === 0 ? 'Hoje' : `Em ${days}d`}
-                      </span>
-                    </div>
-                  );
-                })}
-                <Button size="sm" className="w-full rounded-xl mt-1" onClick={() => navigate('/new-order')}>
-                  <PlusCircle className="w-4 h-4 mr-1.5" />
-                  Criar pedido
-                </Button>
-              </CardContent>
-            </Card>
+            <FerramentasAtencao urgentTools={urgentTools} navigate={navigate} />
           </motion.section>
         )}
 
         {/* ─── SEÇÃO 4: Ações Rápidas ─── */}
         <motion.section variants={fadeUp}>
-          <h2 className="font-display font-bold text-lg text-foreground mb-3">Ações Rápidas</h2>
-          <div className="grid grid-cols-4 gap-2">
-            {quickActions.map((item) => (
-              <motion.button
-                key={item.path}
-                onClick={() => navigate(item.path)}
-                className="bg-card rounded-2xl p-3 shadow-soft border border-border/80 hover:shadow-medium hover:border-primary/20 transition-all flex flex-col items-center gap-2 group"
-                whileTap={{ scale: 0.95 }}
-                whileHover={{ y: -2 }}
-              >
-                <div className="w-10 h-10 rounded-xl bg-muted flex items-center justify-center group-hover:bg-primary/10 transition-colors">
-                  <item.icon className="w-5 h-5 text-muted-foreground group-hover:text-primary transition-colors" />
-                </div>
-                <span className="text-[11px] font-semibold text-foreground text-center leading-tight">{item.label}</span>
-              </motion.button>
-            ))}
-          </div>
+          <AcoesRapidas navigate={navigate} />
         </motion.section>
 
         {/* Empty state for brand-new users */}
@@ -411,99 +128,5 @@ export function CustomerDashboard({ profile, pendingOrders, userTools, getGreeti
         )}
       </motion.main>
     </div>
-  );
-}
-
-/* ─── Sub-components ─── */
-
-function PriorityCard({ priority, navigate }: { priority: PriorityAction; navigate: ReturnType<typeof useNavigate> }) {
-  const bgMap: Record<PriorityAction['variant'], string> = {
-    warning: 'border-status-warning/30 bg-status-warning-bg/60',
-    destructive: 'border-destructive/30 bg-destructive/5',
-    default: 'border-border bg-card',
-    success: 'border-primary/20 bg-primary/5',
-  };
-  const iconBgMap: Record<PriorityAction['variant'], string> = {
-    warning: 'bg-status-warning-bg text-status-warning',
-    destructive: 'bg-destructive/10 text-destructive',
-    default: 'bg-muted text-muted-foreground',
-    success: 'bg-primary/10 text-primary',
-  };
-
-  return (
-    <Card className={cn('shadow-medium overflow-hidden', bgMap[priority.variant])}>
-      <CardContent className="p-4">
-        <div className="flex items-start gap-3">
-          <div className={cn('w-10 h-10 rounded-xl flex items-center justify-center flex-shrink-0', iconBgMap[priority.variant])}>
-            <priority.icon className="w-5 h-5" />
-          </div>
-          <div className="flex-1 min-w-0">
-            <h3 className="font-semibold text-sm text-foreground mb-0.5">{priority.title}</h3>
-            <p className="text-xs text-muted-foreground">{priority.description}</p>
-          </div>
-        </div>
-        {priority.buttonLabel && priority.path && (
-          <Button
-            size="sm"
-            className="w-full rounded-xl mt-3"
-            variant={priority.variant === 'success' ? 'outline' : 'default'}
-            onClick={() => navigate(priority.path!)}
-          >
-            {priority.buttonLabel}
-            <ArrowRight className="w-4 h-4 ml-1.5" />
-          </Button>
-        )}
-      </CardContent>
-    </Card>
-  );
-}
-
-function OrderRow({ order, index, navigate, needsAction }: {
-  order: Order; index: number; navigate: ReturnType<typeof useNavigate>; needsAction?: boolean;
-}) {
-  const config = statusConfig[order.status] || statusConfig['pedido_recebido'];
-  return (
-    <motion.div
-      initial={{ opacity: 0, x: -10 }}
-      animate={{ opacity: 1, x: 0 }}
-      transition={{ delay: index * 0.05 }}
-    >
-      <Card
-        className={cn(
-          'overflow-hidden hover:shadow-medium transition-all cursor-pointer group border-border/60',
-          needsAction && 'ring-1 ring-status-warning/40'
-        )}
-        onClick={() => navigate(`/orders/${order.id}`)}
-      >
-        <CardContent className="p-4">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-3">
-              <div className={cn('w-10 h-10 rounded-xl flex items-center justify-center',
-                needsAction ? 'bg-status-warning-bg' : 'bg-muted'
-              )}>
-                <Package className={cn('w-5 h-5', needsAction ? 'text-status-warning' : 'text-muted-foreground')} />
-              </div>
-              <div>
-                <p className="font-semibold text-sm text-foreground">
-                  {format(new Date(order.created_at), "dd 'de' MMM", { locale: ptBR })}
-                </p>
-                <p className="text-xs text-muted-foreground capitalize">{order.service_type}</p>
-              </div>
-            </div>
-            <div className="flex items-center gap-2">
-              {needsAction && (
-                <Badge variant="outline" className="text-[10px] border-status-warning text-status-warning bg-status-warning-bg font-semibold">
-                  Ação necessária
-                </Badge>
-              )}
-              <span className={cn('text-[11px] px-2.5 py-1 rounded-full font-semibold border', config.statusClass)}>
-                {config.label}
-              </span>
-              <ChevronRight className="w-4 h-4 text-muted-foreground group-hover:translate-x-1 transition-transform" />
-            </div>
-          </div>
-        </CardContent>
-      </Card>
-    </motion.div>
   );
 }

--- a/src/components/customerDashboard/AcoesRapidas.tsx
+++ b/src/components/customerDashboard/AcoesRapidas.tsx
@@ -1,0 +1,33 @@
+// Seção "Ações Rápidas" do CustomerDashboard.
+// Extraída verbatim de src/components/CustomerDashboard.tsx (god-component split).
+import { useNavigate } from 'react-router-dom';
+import { motion } from 'framer-motion';
+import { QUICK_ACTIONS } from './config';
+
+interface AcoesRapidasProps {
+  navigate: ReturnType<typeof useNavigate>;
+}
+
+export function AcoesRapidas({ navigate }: AcoesRapidasProps) {
+  return (
+    <>
+      <h2 className="font-display font-bold text-lg text-foreground mb-3">Ações Rápidas</h2>
+      <div className="grid grid-cols-4 gap-2">
+        {QUICK_ACTIONS.map((item) => (
+          <motion.button
+            key={item.path}
+            onClick={() => navigate(item.path)}
+            className="bg-card rounded-2xl p-3 shadow-soft border border-border/80 hover:shadow-medium hover:border-primary/20 transition-all flex flex-col items-center gap-2 group"
+            whileTap={{ scale: 0.95 }}
+            whileHover={{ y: -2 }}
+          >
+            <div className="w-10 h-10 rounded-xl bg-muted flex items-center justify-center group-hover:bg-primary/10 transition-colors">
+              <item.icon className="w-5 h-5 text-muted-foreground group-hover:text-primary transition-colors" />
+            </div>
+            <span className="text-[11px] font-semibold text-foreground text-center leading-tight">{item.label}</span>
+          </motion.button>
+        ))}
+      </div>
+    </>
+  );
+}

--- a/src/components/customerDashboard/DashboardHero.tsx
+++ b/src/components/customerDashboard/DashboardHero.tsx
@@ -1,0 +1,87 @@
+// Hero/header do CustomerDashboard (saudação, badge de tipo, stats row).
+// Extraído verbatim de src/components/CustomerDashboard.tsx (god-component split).
+import { useNavigate } from 'react-router-dom';
+import { motion } from 'framer-motion';
+import { User, TrendingUp, Package, Wrench, Trophy } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { stagger, fadeUp } from './config';
+
+interface DashboardHeroProps {
+  getGreeting: () => string;
+  displayName: string;
+  customerType: string | null | undefined;
+  pendingOrdersCount: number;
+  userToolsCount: number;
+  gamScoreTotal: number;
+  navigate: ReturnType<typeof useNavigate>;
+}
+
+export function DashboardHero({
+  getGreeting,
+  displayName,
+  customerType,
+  pendingOrdersCount,
+  userToolsCount,
+  gamScoreTotal,
+  navigate,
+}: DashboardHeroProps) {
+  return (
+    <header className="bg-gradient-dark text-secondary-foreground px-4 pt-12 pb-10 relative overflow-hidden">
+      <div className="absolute top-0 right-0 w-72 h-72 bg-primary/8 rounded-full blur-3xl -translate-y-1/2 translate-x-1/2" />
+      <div className="absolute bottom-0 left-0 w-48 h-48 bg-primary/5 rounded-full blur-2xl translate-y-1/2 -translate-x-1/2" />
+      <motion.div
+        className="max-w-lg mx-auto relative z-10"
+        initial={{ opacity: 0, y: -10 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.5 }}
+      >
+        <div className="flex items-start justify-between mb-6">
+          <div className="space-y-1">
+            <p className="text-sm text-secondary-foreground/60 font-medium">{getGreeting()},</p>
+            <h1 className="text-2xl font-display font-bold tracking-tight">{displayName}</h1>
+            {customerType && (
+              <span className={cn(
+                'inline-flex items-center gap-1.5 text-[11px] px-2.5 py-1 rounded-full font-semibold uppercase tracking-wider',
+                customerType === 'industrial'
+                  ? 'bg-status-warning/20 text-status-warning-bg'
+                  : 'bg-status-info/20 text-status-info-bg'
+              )}>
+                {customerType === 'industrial' ? (
+                  <><TrendingUp className="w-3 h-3" /> Industrial</>
+                ) : 'Doméstico'}
+              </span>
+            )}
+          </div>
+          <motion.button
+            onClick={() => navigate('/profile')}
+            className="w-12 h-12 rounded-2xl bg-secondary-foreground/10 hover:bg-secondary-foreground/20 flex items-center justify-center transition-colors border border-secondary-foreground/10"
+            whileTap={{ scale: 0.92 }}
+          >
+            <User className="w-5 h-5 text-secondary-foreground/80" />
+          </motion.button>
+        </div>
+
+        {/* Stats Row */}
+        <motion.div className="grid grid-cols-3 gap-2" variants={stagger} initial="hidden" animate="show">
+          {[
+            { icon: Package, value: pendingOrdersCount, label: 'Pedidos', path: '/orders' },
+            { icon: Wrench, value: userToolsCount, label: 'Ferramentas', path: '/tools' },
+            { icon: Trophy, value: gamScoreTotal, label: 'Score', path: '/gamification' },
+          ].map(stat => (
+            <motion.button
+              key={stat.label}
+              variants={fadeUp}
+              onClick={() => navigate(stat.path)}
+              className="bg-secondary-foreground/8 hover:bg-secondary-foreground/14 rounded-2xl p-3 backdrop-blur-sm border border-secondary-foreground/5 transition-colors text-left group"
+              whileTap={{ scale: 0.96 }}
+            >
+              <stat.icon className="w-4 h-4 text-secondary-foreground/50 mb-1" />
+              <p className="text-2xl font-bold tracking-tight">{stat.value}</p>
+              <p className="text-[10px] text-secondary-foreground/50 font-medium">{stat.label}</p>
+            </motion.button>
+          ))}
+        </motion.div>
+      </motion.div>
+    </header>
+  );
+}

--- a/src/components/customerDashboard/FerramentasAtencao.tsx
+++ b/src/components/customerDashboard/FerramentasAtencao.tsx
@@ -1,0 +1,56 @@
+// Seção "Ferramentas que Exigem Atenção" do CustomerDashboard.
+// Extraída verbatim de src/components/CustomerDashboard.tsx (god-component split).
+import { useNavigate } from 'react-router-dom';
+import { Card, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Wrench, PlusCircle, ChevronRight } from 'lucide-react';
+import { differenceInDays } from 'date-fns';
+import { cn } from '@/lib/utils';
+import type { UserTool } from './types';
+
+interface FerramentasAtencaoProps {
+  urgentTools: UserTool[];
+  navigate: ReturnType<typeof useNavigate>;
+}
+
+export function FerramentasAtencao({ urgentTools, navigate }: FerramentasAtencaoProps) {
+  return (
+    <>
+      <div className="flex items-center justify-between mb-3">
+        <h2 className="font-display font-bold text-lg text-foreground">Ferramentas com Atenção</h2>
+        <button onClick={() => navigate('/tools')} className="text-sm font-medium text-primary flex items-center gap-1 hover:gap-2 transition-all">
+          Gerenciar <ChevronRight className="w-4 h-4" />
+        </button>
+      </div>
+      <Card className="border-status-warning/20 bg-status-warning-bg/50">
+        <CardContent className="p-4 space-y-3">
+          {urgentTools.slice(0, 4).map(tool => {
+            const days = differenceInDays(new Date(tool.next_sharpening_due!), new Date());
+            return (
+              <div key={tool.id} className="flex items-center justify-between">
+                <div className="flex items-center gap-2">
+                  <div className={cn('w-8 h-8 rounded-lg flex items-center justify-center',
+                    days < 0 ? 'bg-destructive/10' : 'bg-status-warning-bg'
+                  )}>
+                    <Wrench className={cn('w-4 h-4', days < 0 ? 'text-destructive' : 'text-status-warning')} />
+                  </div>
+                  <span className="text-sm font-medium text-foreground">{tool.tool_categories?.name}</span>
+                </div>
+                <span className={cn(
+                  'text-xs font-semibold px-2 py-0.5 rounded-full',
+                  days < 0 ? 'bg-destructive/10 text-destructive' : 'bg-status-warning-bg text-status-warning-foreground'
+                )}>
+                  {days < 0 ? `${Math.abs(days)}d atrasado` : days === 0 ? 'Hoje' : `Em ${days}d`}
+                </span>
+              </div>
+            );
+          })}
+          <Button size="sm" className="w-full rounded-xl mt-1" onClick={() => navigate('/new-order')}>
+            <PlusCircle className="w-4 h-4 mr-1.5" />
+            Criar pedido
+          </Button>
+        </CardContent>
+      </Card>
+    </>
+  );
+}

--- a/src/components/customerDashboard/GamificationMini.tsx
+++ b/src/components/customerDashboard/GamificationMini.tsx
@@ -1,0 +1,47 @@
+// Card mini de gamificação do CustomerDashboard.
+// Extraído verbatim de src/components/CustomerDashboard.tsx (god-component split).
+import { useNavigate } from 'react-router-dom';
+import { Card, CardContent } from '@/components/ui/card';
+import { Progress } from '@/components/ui/progress';
+import { Award, ChevronRight } from 'lucide-react';
+import { useGamificationScore, getLevelInfo } from '@/hooks/useGamificationScore';
+
+interface GamificationMiniProps {
+  gamScore: NonNullable<ReturnType<typeof useGamificationScore>['data']>;
+  levelInfo: ReturnType<typeof getLevelInfo>;
+  navigate: ReturnType<typeof useNavigate>;
+}
+
+export function GamificationMini({ gamScore, levelInfo, navigate }: GamificationMiniProps) {
+  return (
+    <Card
+      className="shadow-medium border-0 overflow-hidden cursor-pointer hover:shadow-strong transition-shadow"
+      onClick={() => navigate('/gamification')}
+    >
+      <CardContent className="p-4">
+        <div className="flex items-center gap-3">
+          <div className="w-11 h-11 rounded-xl bg-status-warning-bg flex items-center justify-center flex-shrink-0">
+            <Award className="w-6 h-6 text-status-warning" />
+          </div>
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center justify-between mb-1">
+              <span className="font-semibold text-sm text-foreground">
+                Nível {gamScore.level} — {gamScore.level_name}
+              </span>
+              <ChevronRight className="w-4 h-4 text-muted-foreground" />
+            </div>
+            <Progress value={gamScore.total_score} className="h-1.5" />
+            <div className="flex justify-between mt-1">
+              <span className="text-[10px] text-muted-foreground">{gamScore.total_score}/100 pts</span>
+              {levelInfo.nextLevel && (
+                <span className="text-[10px] text-muted-foreground">
+                  Faltam {Math.ceil(levelInfo.nextLevel.min - gamScore.total_score)} para {levelInfo.nextLevel.name}
+                </span>
+              )}
+            </div>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/customerDashboard/OrderRow.tsx
+++ b/src/components/customerDashboard/OrderRow.tsx
@@ -1,0 +1,62 @@
+// Linha de pedido em andamento do CustomerDashboard.
+// Extraído verbatim de src/components/CustomerDashboard.tsx (god-component split).
+import { useNavigate } from 'react-router-dom';
+import { Card, CardContent } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { motion } from 'framer-motion';
+import { Package, ChevronRight } from 'lucide-react';
+import { format } from 'date-fns';
+import { ptBR } from 'date-fns/locale';
+import { cn } from '@/lib/utils';
+import { statusConfig } from './config';
+import type { Order } from './types';
+
+export function OrderRow({ order, index, navigate, needsAction }: {
+  order: Order; index: number; navigate: ReturnType<typeof useNavigate>; needsAction?: boolean;
+}) {
+  const config = statusConfig[order.status] || statusConfig['pedido_recebido'];
+  return (
+    <motion.div
+      initial={{ opacity: 0, x: -10 }}
+      animate={{ opacity: 1, x: 0 }}
+      transition={{ delay: index * 0.05 }}
+    >
+      <Card
+        className={cn(
+          'overflow-hidden hover:shadow-medium transition-all cursor-pointer group border-border/60',
+          needsAction && 'ring-1 ring-status-warning/40'
+        )}
+        onClick={() => navigate(`/orders/${order.id}`)}
+      >
+        <CardContent className="p-4">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-3">
+              <div className={cn('w-10 h-10 rounded-xl flex items-center justify-center',
+                needsAction ? 'bg-status-warning-bg' : 'bg-muted'
+              )}>
+                <Package className={cn('w-5 h-5', needsAction ? 'text-status-warning' : 'text-muted-foreground')} />
+              </div>
+              <div>
+                <p className="font-semibold text-sm text-foreground">
+                  {format(new Date(order.created_at), "dd 'de' MMM", { locale: ptBR })}
+                </p>
+                <p className="text-xs text-muted-foreground capitalize">{order.service_type}</p>
+              </div>
+            </div>
+            <div className="flex items-center gap-2">
+              {needsAction && (
+                <Badge variant="outline" className="text-[10px] border-status-warning text-status-warning bg-status-warning-bg font-semibold">
+                  Ação necessária
+                </Badge>
+              )}
+              <span className={cn('text-[11px] px-2.5 py-1 rounded-full font-semibold border', config.statusClass)}>
+                {config.label}
+              </span>
+              <ChevronRight className="w-4 h-4 text-muted-foreground group-hover:translate-x-1 transition-transform" />
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </motion.div>
+  );
+}

--- a/src/components/customerDashboard/PedidosAndamento.tsx
+++ b/src/components/customerDashboard/PedidosAndamento.tsx
@@ -1,0 +1,34 @@
+// Seção "Pedidos em Andamento" do CustomerDashboard.
+// Extraída verbatim de src/components/CustomerDashboard.tsx (god-component split).
+import { useNavigate } from 'react-router-dom';
+import { ChevronRight } from 'lucide-react';
+import { OrderRow } from './OrderRow';
+import type { Order } from './types';
+
+interface PedidosAndamentoProps {
+  ordersNeedingAction: Order[];
+  otherActiveOrders: Order[];
+  navigate: ReturnType<typeof useNavigate>;
+}
+
+export function PedidosAndamento({ ordersNeedingAction, otherActiveOrders, navigate }: PedidosAndamentoProps) {
+  return (
+    <>
+      <div className="flex items-center justify-between mb-3">
+        <h2 className="font-display font-bold text-lg text-foreground">Pedidos em Andamento</h2>
+        <button onClick={() => navigate('/orders')} className="text-sm font-medium text-primary flex items-center gap-1 hover:gap-2 transition-all">
+          Ver todos <ChevronRight className="w-4 h-4" />
+        </button>
+      </div>
+      <div className="space-y-2.5">
+        {/* Orders needing action first */}
+        {ordersNeedingAction.map((order, i) => (
+          <OrderRow key={order.id} order={order} index={i} navigate={navigate} needsAction />
+        ))}
+        {otherActiveOrders.slice(0, 3).map((order, i) => (
+          <OrderRow key={order.id} order={order} index={ordersNeedingAction.length + i} navigate={navigate} />
+        ))}
+      </div>
+    </>
+  );
+}

--- a/src/components/customerDashboard/PriorityCard.tsx
+++ b/src/components/customerDashboard/PriorityCard.tsx
@@ -1,0 +1,50 @@
+// Card de ação recomendada (prioridade) do CustomerDashboard.
+// Extraído verbatim de src/components/CustomerDashboard.tsx (god-component split).
+import { useNavigate } from 'react-router-dom';
+import { Card, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { ArrowRight } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import type { PriorityAction } from './types';
+
+export function PriorityCard({ priority, navigate }: { priority: PriorityAction; navigate: ReturnType<typeof useNavigate> }) {
+  const bgMap: Record<PriorityAction['variant'], string> = {
+    warning: 'border-status-warning/30 bg-status-warning-bg/60',
+    destructive: 'border-destructive/30 bg-destructive/5',
+    default: 'border-border bg-card',
+    success: 'border-primary/20 bg-primary/5',
+  };
+  const iconBgMap: Record<PriorityAction['variant'], string> = {
+    warning: 'bg-status-warning-bg text-status-warning',
+    destructive: 'bg-destructive/10 text-destructive',
+    default: 'bg-muted text-muted-foreground',
+    success: 'bg-primary/10 text-primary',
+  };
+
+  return (
+    <Card className={cn('shadow-medium overflow-hidden', bgMap[priority.variant])}>
+      <CardContent className="p-4">
+        <div className="flex items-start gap-3">
+          <div className={cn('w-10 h-10 rounded-xl flex items-center justify-center flex-shrink-0', iconBgMap[priority.variant])}>
+            <priority.icon className="w-5 h-5" />
+          </div>
+          <div className="flex-1 min-w-0">
+            <h3 className="font-semibold text-sm text-foreground mb-0.5">{priority.title}</h3>
+            <p className="text-xs text-muted-foreground">{priority.description}</p>
+          </div>
+        </div>
+        {priority.buttonLabel && priority.path && (
+          <Button
+            size="sm"
+            className="w-full rounded-xl mt-3"
+            variant={priority.variant === 'success' ? 'outline' : 'default'}
+            onClick={() => navigate(priority.path!)}
+          >
+            {priority.buttonLabel}
+            <ArrowRight className="w-4 h-4 ml-1.5" />
+          </Button>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/customerDashboard/__tests__/AcoesRapidas.test.tsx
+++ b/src/components/customerDashboard/__tests__/AcoesRapidas.test.tsx
@@ -1,0 +1,22 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import type { NavigateFunction } from "react-router-dom";
+import { AcoesRapidas } from "../AcoesRapidas";
+
+describe("AcoesRapidas", () => {
+  it("renderiza as 4 ações rápidas", () => {
+    const navigate = vi.fn();
+    render(<AcoesRapidas navigate={navigate as unknown as NavigateFunction} />);
+    expect(screen.getByText("Novo Pedido")).toBeTruthy();
+    expect(screen.getByText("Ferramentas")).toBeTruthy();
+    expect(screen.getByText("Gamificação")).toBeTruthy();
+    expect(screen.getByText("Suporte")).toBeTruthy();
+  });
+
+  it("navega ao clicar em uma ação", () => {
+    const navigate = vi.fn();
+    render(<AcoesRapidas navigate={navigate as unknown as NavigateFunction} />);
+    fireEvent.click(screen.getByText("Novo Pedido"));
+    expect(navigate).toHaveBeenCalledWith("/new-order");
+  });
+});

--- a/src/components/customerDashboard/__tests__/DashboardHero.test.tsx
+++ b/src/components/customerDashboard/__tests__/DashboardHero.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import type { NavigateFunction } from "react-router-dom";
+import { DashboardHero } from "../DashboardHero";
+
+function setup(overrides: Partial<React.ComponentProps<typeof DashboardHero>> = {}) {
+  const navigate = vi.fn();
+  const props: React.ComponentProps<typeof DashboardHero> = {
+    getGreeting: () => "Bom dia",
+    displayName: "Lucas",
+    customerType: "industrial",
+    pendingOrdersCount: 2,
+    userToolsCount: 5,
+    gamScoreTotal: 30,
+    navigate: navigate as unknown as NavigateFunction,
+    ...overrides,
+  };
+  render(<DashboardHero {...props} />);
+  return { navigate };
+}
+
+describe("DashboardHero", () => {
+  it("renderiza saudação, nome, badge industrial e stats", () => {
+    setup();
+    expect(screen.getByText("Bom dia,")).toBeTruthy();
+    expect(screen.getByText("Lucas")).toBeTruthy();
+    expect(screen.getByText("Industrial")).toBeTruthy();
+    expect(screen.getByText("2")).toBeTruthy();
+    expect(screen.getByText("5")).toBeTruthy();
+    expect(screen.getByText("30")).toBeTruthy();
+  });
+
+  it("mostra Doméstico quando não industrial", () => {
+    setup({ customerType: "domestico" });
+    expect(screen.getByText("Doméstico")).toBeTruthy();
+  });
+
+  it("navega ao clicar na stat de pedidos", () => {
+    const { navigate } = setup();
+    fireEvent.click(screen.getByText("Pedidos"));
+    expect(navigate).toHaveBeenCalledWith("/orders");
+  });
+});

--- a/src/components/customerDashboard/__tests__/FerramentasAtencao.test.tsx
+++ b/src/components/customerDashboard/__tests__/FerramentasAtencao.test.tsx
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import type { NavigateFunction } from "react-router-dom";
+import { FerramentasAtencao } from "../FerramentasAtencao";
+import type { UserTool } from "../types";
+
+function makeTool(o: Partial<UserTool> = {}): UserTool {
+  return {
+    id: "t1",
+    tool_category_id: "c1",
+    next_sharpening_due: new Date(Date.now() - 5 * 86400000).toISOString(),
+    sharpening_interval_days: 30,
+    tool_categories: { name: "Faca de corte" },
+    ...o,
+  };
+}
+
+describe("FerramentasAtencao", () => {
+  it("renderiza ferramenta com rótulo de atraso", () => {
+    const navigate = vi.fn();
+    render(<FerramentasAtencao urgentTools={[makeTool()]} navigate={navigate as unknown as NavigateFunction} />);
+    expect(screen.getByText("Faca de corte")).toBeTruthy();
+    expect(screen.getByText(/atrasado/)).toBeTruthy();
+  });
+
+  it("dispara navigate no botão Criar pedido", () => {
+    const navigate = vi.fn();
+    render(<FerramentasAtencao urgentTools={[makeTool()]} navigate={navigate as unknown as NavigateFunction} />);
+    fireEvent.click(screen.getByRole("button", { name: /Criar pedido/ }));
+    expect(navigate).toHaveBeenCalledWith("/new-order");
+  });
+});

--- a/src/components/customerDashboard/__tests__/GamificationMini.test.tsx
+++ b/src/components/customerDashboard/__tests__/GamificationMini.test.tsx
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import type { NavigateFunction } from "react-router-dom";
+import { GamificationMini } from "../GamificationMini";
+import type { useGamificationScore, getLevelInfo } from "@/hooks/useGamificationScore";
+
+const gamScore = {
+  total_score: 42,
+  level: 3,
+  level_name: "Profissional",
+} as unknown as NonNullable<ReturnType<typeof useGamificationScore>["data"]>;
+
+const levelInfo = {
+  nextLevel: { min: 65, name: "Elite Técnica" },
+} as unknown as ReturnType<typeof getLevelInfo>;
+
+describe("GamificationMini", () => {
+  it("renderiza nível, score e quanto falta", () => {
+    const navigate = vi.fn();
+    render(<GamificationMini gamScore={gamScore} levelInfo={levelInfo} navigate={navigate as unknown as NavigateFunction} />);
+    expect(screen.getByText("Nível 3 — Profissional")).toBeTruthy();
+    expect(screen.getByText("42/100 pts")).toBeTruthy();
+    expect(screen.getByText("Faltam 23 para Elite Técnica")).toBeTruthy();
+  });
+
+  it("navega para gamificação ao clicar", () => {
+    const navigate = vi.fn();
+    render(<GamificationMini gamScore={gamScore} levelInfo={levelInfo} navigate={navigate as unknown as NavigateFunction} />);
+    fireEvent.click(screen.getByText("Nível 3 — Profissional"));
+    expect(navigate).toHaveBeenCalledWith("/gamification");
+  });
+});

--- a/src/components/customerDashboard/__tests__/OrderRow.test.tsx
+++ b/src/components/customerDashboard/__tests__/OrderRow.test.tsx
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import type { NavigateFunction } from "react-router-dom";
+import { OrderRow } from "../OrderRow";
+import type { Order } from "../types";
+
+const order: Order = {
+  id: "o1",
+  status: "orcamento_enviado",
+  created_at: "2026-03-15T12:00:00",
+  service_type: "afiação",
+};
+
+describe("OrderRow", () => {
+  it("renderiza status, service_type e dispara navigate ao clicar", () => {
+    const navigate = vi.fn();
+    render(<OrderRow order={order} index={0} navigate={navigate as unknown as NavigateFunction} />);
+    expect(screen.getByText("Orçamento")).toBeTruthy(); // statusConfig label
+    expect(screen.getByText("afiação")).toBeTruthy();
+    fireEvent.click(screen.getByText("Orçamento"));
+    expect(navigate).toHaveBeenCalledWith("/orders/o1");
+  });
+
+  it("mostra badge de ação necessária quando needsAction", () => {
+    const navigate = vi.fn();
+    render(<OrderRow order={order} index={0} navigate={navigate as unknown as NavigateFunction} needsAction />);
+    expect(screen.getByText("Ação necessária")).toBeTruthy();
+  });
+});

--- a/src/components/customerDashboard/__tests__/PedidosAndamento.test.tsx
+++ b/src/components/customerDashboard/__tests__/PedidosAndamento.test.tsx
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import type { NavigateFunction } from "react-router-dom";
+import { PedidosAndamento } from "../PedidosAndamento";
+import type { Order } from "../types";
+
+const quote: Order = { id: "q1", status: "orcamento_enviado", created_at: "2026-03-15T12:00:00", service_type: "afiação" };
+const active: Order = { id: "a1", status: "em_afiacao", created_at: "2026-03-10T12:00:00", service_type: "recuperação" };
+
+describe("PedidosAndamento", () => {
+  it("renderiza pedidos com ação e ativos", () => {
+    const navigate = vi.fn();
+    render(
+      <PedidosAndamento
+        ordersNeedingAction={[quote]}
+        otherActiveOrders={[active]}
+        navigate={navigate as unknown as NavigateFunction}
+      />,
+    );
+    expect(screen.getByText("Ação necessária")).toBeTruthy();
+    expect(screen.getByText("Orçamento")).toBeTruthy();
+    expect(screen.getByText("Em Afiação")).toBeTruthy();
+  });
+
+  it("navega em Ver todos", () => {
+    const navigate = vi.fn();
+    render(
+      <PedidosAndamento ordersNeedingAction={[]} otherActiveOrders={[active]} navigate={navigate as unknown as NavigateFunction} />,
+    );
+    fireEvent.click(screen.getByText(/Ver todos/));
+    expect(navigate).toHaveBeenCalledWith("/orders");
+  });
+});

--- a/src/components/customerDashboard/__tests__/PriorityCard.test.tsx
+++ b/src/components/customerDashboard/__tests__/PriorityCard.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import type { NavigateFunction } from "react-router-dom";
+import { FileText } from "lucide-react";
+import { PriorityCard } from "../PriorityCard";
+import type { PriorityAction } from "../types";
+
+const priority: PriorityAction = {
+  type: "quote",
+  variant: "warning",
+  icon: FileText,
+  title: "Orçamento pendente de aprovação",
+  description: "Revise e aprove.",
+  buttonLabel: "Ver orçamento",
+  path: "/orders/q1",
+};
+
+describe("PriorityCard", () => {
+  it("renderiza título, descrição e botão", () => {
+    const navigate = vi.fn();
+    render(<PriorityCard priority={priority} navigate={navigate as unknown as NavigateFunction} />);
+    expect(screen.getByText("Orçamento pendente de aprovação")).toBeTruthy();
+    expect(screen.getByText("Revise e aprove.")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: /Ver orçamento/ }));
+    expect(navigate).toHaveBeenCalledWith("/orders/q1");
+  });
+
+  it("não renderiza botão quando não há buttonLabel/path", () => {
+    const navigate = vi.fn();
+    render(
+      <PriorityCard
+        priority={{ type: "all_good", variant: "success", icon: FileText, title: "Tudo em dia!", description: "ok" }}
+        navigate={navigate as unknown as NavigateFunction}
+      />,
+    );
+    expect(screen.getByText("Tudo em dia!")).toBeTruthy();
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+});

--- a/src/components/customerDashboard/__tests__/priority.test.ts
+++ b/src/components/customerDashboard/__tests__/priority.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { computePriority } from "../priority";
+import type { Order, UserTool } from "../types";
+
+function makeOrder(o: Partial<Order> = {}): Order {
+  return { id: "o1", status: "aprovado", created_at: "2026-03-01T12:00:00", service_type: "afiação", ...o };
+}
+function makeTool(o: Partial<UserTool> = {}): UserTool {
+  return {
+    id: "t1",
+    tool_category_id: "c1",
+    next_sharpening_due: null,
+    sharpening_interval_days: 30,
+    tool_categories: { name: "Faca" },
+    ...o,
+  };
+}
+
+describe("computePriority", () => {
+  it("orçamento pendente tem prioridade máxima", () => {
+    const p = computePriority([makeOrder({ id: "q1", status: "orcamento_enviado" })], [], [makeTool()], true);
+    expect(p.type).toBe("quote");
+    expect(p.path).toBe("/orders/q1");
+    expect(p.orderId).toBe("q1");
+  });
+
+  it("ferramentas vencidas em segundo", () => {
+    const overdue = [makeTool()];
+    const p = computePriority([], overdue, [makeTool()], true);
+    expect(p.type).toBe("tools_overdue");
+    expect(p.variant).toBe("destructive");
+  });
+
+  it("sem ferramentas cadastradas", () => {
+    const p = computePriority([], [], [], true);
+    expect(p.type).toBe("no_tools");
+  });
+
+  it("sem endereço quando há ferramentas e tudo ok", () => {
+    const p = computePriority([], [], [makeTool()], false);
+    expect(p.type).toBe("no_address");
+  });
+
+  it("tudo em dia", () => {
+    const p = computePriority([], [], [makeTool()], true);
+    expect(p.type).toBe("all_good");
+    expect(p.variant).toBe("success");
+  });
+});

--- a/src/components/customerDashboard/config.ts
+++ b/src/components/customerDashboard/config.ts
@@ -1,0 +1,32 @@
+// Configs do CustomerDashboard: status, animações e ações rápidas.
+// Extraídos verbatim de src/components/CustomerDashboard.tsx (god-component split).
+import { PlusCircle, Wrench, Gamepad2, LifeBuoy } from 'lucide-react';
+
+export const statusConfig: Record<string, { label: string; statusClass: string }> = {
+  'pedido_recebido': { label: 'Recebido', statusClass: 'status-progress' },
+  'aguardando_coleta': { label: 'Aguardando Coleta', statusClass: 'status-pending' },
+  'em_triagem': { label: 'Em Triagem', statusClass: 'status-purple' },
+  'orcamento_enviado': { label: 'Orçamento', statusClass: 'status-pending' },
+  'aprovado': { label: 'Aprovado', statusClass: 'status-success' },
+  'em_afiacao': { label: 'Em Afiação', statusClass: 'status-progress' },
+  'controle_qualidade': { label: 'Qualidade', statusClass: 'status-indigo' },
+  'pronto_entrega': { label: 'Pronto!', statusClass: 'status-success' },
+  'em_rota': { label: 'Em Rota', statusClass: 'status-indigo' },
+  'entregue': { label: 'Entregue', statusClass: 'bg-muted text-muted-foreground' },
+};
+
+export const stagger = {
+  hidden: {},
+  show: { transition: { staggerChildren: 0.06 } },
+};
+export const fadeUp = {
+  hidden: { opacity: 0, y: 14 },
+  show: { opacity: 1, y: 0, transition: { duration: 0.4, ease: [0.25, 0.1, 0.25, 1] as const } },
+};
+
+export const QUICK_ACTIONS = [
+  { icon: PlusCircle, label: 'Novo Pedido', path: '/new-order' },
+  { icon: Wrench, label: 'Ferramentas', path: '/tools' },
+  { icon: Gamepad2, label: 'Gamificação', path: '/gamification' },
+  { icon: LifeBuoy, label: 'Suporte', path: '/support' },
+];

--- a/src/components/customerDashboard/priority.ts
+++ b/src/components/customerDashboard/priority.ts
@@ -1,0 +1,60 @@
+// Lógica de ação prioritária do CustomerDashboard.
+// Extraída verbatim de src/components/CustomerDashboard.tsx (god-component split).
+import { AlertTriangle, Wrench, MapPin, CheckCircle2, FileText } from 'lucide-react';
+import type { Order, UserTool, PriorityAction } from './types';
+
+export function computePriority(
+  pendingOrders: Order[],
+  toolsOverdue: UserTool[],
+  userTools: UserTool[],
+  hasAddresses: boolean,
+): PriorityAction {
+  // 1. Pending quote
+  const quoteOrder = pendingOrders.find(o => o.status === 'orcamento_enviado');
+  if (quoteOrder) {
+    return {
+      type: 'quote', variant: 'warning', icon: FileText,
+      title: 'Orçamento pendente de aprovação',
+      description: 'Revise e aprove para que a afiação seja iniciada.',
+      buttonLabel: 'Ver orçamento', path: `/orders/${quoteOrder.id}`,
+      orderId: quoteOrder.id,
+    };
+  }
+
+  // 2. Tools overdue
+  if (toolsOverdue.length > 0) {
+    return {
+      type: 'tools_overdue', variant: 'destructive', icon: AlertTriangle,
+      title: `${toolsOverdue.length} ferramenta(s) com afiação vencida`,
+      description: 'Ferramentas fora do prazo podem perder o fio e danificar peças.',
+      buttonLabel: 'Agendar afiação', path: '/new-order',
+    };
+  }
+
+  // 3. No tools registered
+  if (userTools.length === 0) {
+    return {
+      type: 'no_tools', variant: 'default', icon: Wrench,
+      title: 'Cadastre suas ferramentas',
+      description: 'Facilite seus pedidos e receba alertas de manutenção.',
+      buttonLabel: 'Cadastrar', path: '/tools',
+    };
+  }
+
+  // 4. No address
+  if (!hasAddresses) {
+    return {
+      type: 'no_address', variant: 'default', icon: MapPin,
+      title: 'Cadastre um endereço para agilizar coletas',
+      description: 'Com um endereço salvo, seus pedidos ficam mais rápidos.',
+      buttonLabel: 'Adicionar', path: '/addresses',
+    };
+  }
+
+  // 5. All good
+  return {
+    type: 'all_good', variant: 'success', icon: CheckCircle2,
+    title: 'Tudo em dia!',
+    description: 'Suas ferramentas estão bem cuidadas.',
+  };
+}

--- a/src/components/customerDashboard/types.ts
+++ b/src/components/customerDashboard/types.ts
@@ -1,0 +1,35 @@
+// Tipos do CustomerDashboard.
+// Extraídos verbatim de src/components/CustomerDashboard.tsx (god-component split).
+import type { LucideIcon } from 'lucide-react';
+
+export interface Profile {
+  name: string;
+  customer_type: string | null;
+  document: string | null;
+}
+
+export interface Order {
+  id: string;
+  status: string;
+  created_at: string;
+  service_type: string;
+}
+
+export interface UserTool {
+  id: string;
+  tool_category_id: string;
+  next_sharpening_due: string | null;
+  sharpening_interval_days: number | null;
+  tool_categories: { name: string };
+}
+
+export interface PriorityAction {
+  type: 'quote' | 'order_issue' | 'tools_overdue' | 'no_tools' | 'no_address' | 'all_good';
+  title: string;
+  description: string;
+  buttonLabel?: string;
+  path?: string;
+  variant: 'warning' | 'destructive' | 'default' | 'success';
+  icon: LucideIcon;
+  orderId?: string;
+}

--- a/src/components/customerDashboard/useCustomerDashboard.ts
+++ b/src/components/customerDashboard/useCustomerDashboard.ts
@@ -1,0 +1,56 @@
+// Hook de dados/estado do CustomerDashboard.
+// Extraído verbatim de src/components/CustomerDashboard.tsx (god-component split):
+// gamification score, checagem de endereços e derivados (nome, ferramentas
+// urgentes, ação prioritária, particionamento de pedidos).
+import { useEffect, useState } from 'react';
+import { useGamificationScore, getLevelInfo } from '@/hooks/useGamificationScore';
+import { differenceInDays } from 'date-fns';
+import { supabase } from '@/integrations/supabase/client';
+import { computePriority } from './priority';
+import type { Profile, Order, UserTool } from './types';
+
+export function useCustomerDashboard(profile: Profile | null, pendingOrders: Order[], userTools: UserTool[]) {
+  const { data: gamScore } = useGamificationScore();
+
+  const [hasAddresses, setHasAddresses] = useState(true); // optimistic default
+
+  // Lightweight address check
+  useEffect(() => {
+    (async () => {
+      const { count } = await supabase
+        .from('addresses')
+        .select('id', { count: 'exact', head: true });
+      setHasAddresses((count ?? 0) > 0);
+    })();
+  }, []);
+
+  const isCNPJ = profile?.document && profile.document.replace(/\D/g, '').length === 14;
+  const displayName = isCNPJ ? profile?.name || 'Cliente' : profile?.name?.split(' ')[0] || 'Cliente';
+
+  const toolsOverdue = userTools.filter(t => {
+    if (!t.next_sharpening_due) return false;
+    return differenceInDays(new Date(t.next_sharpening_due), new Date()) < 0;
+  });
+  const toolsSoon = userTools.filter(t => {
+    if (!t.next_sharpening_due) return false;
+    const d = differenceInDays(new Date(t.next_sharpening_due), new Date());
+    return d >= 0 && d <= 7;
+  });
+  const urgentTools = [...toolsOverdue, ...toolsSoon];
+  const levelInfo = gamScore ? getLevelInfo(gamScore.total_score) : null;
+
+  const priority = computePriority(pendingOrders, toolsOverdue, userTools, hasAddresses);
+
+  const ordersNeedingAction = pendingOrders.filter(o => o.status === 'orcamento_enviado');
+  const otherActiveOrders = pendingOrders.filter(o => o.status !== 'orcamento_enviado');
+
+  return {
+    gamScore,
+    displayName,
+    urgentTools,
+    levelInfo,
+    priority,
+    ordersNeedingAction,
+    otherActiveOrders,
+  };
+}


### PR DESCRIPTION
## Resumo
Quebra o god-component `src/components/CustomerDashboard.tsx` (**509→132L**) em um hook de dados/estado + componentes presentacionais controlados, sob `src/components/customerDashboard/`. Extração **verbatim** — comportamento preservado 1:1.

## O que mudou
- **`useCustomerDashboard`** (hook): gamification score, checagem de endereços e derivados (`displayName`, ferramentas urgentes, ação prioritária, partição de pedidos).
- **`priority.ts`** (`computePriority`) — lógica pura de ação recomendada.
- **`DashboardHero`** — hero/header (saudação, badge, stats).
- **`PriorityCard`** / **`GamificationMini`** / **`PedidosAndamento`** / **`FerramentasAtencao`** / **`AcoesRapidas`** / **`OrderRow`** — seções/primitivos.
- **`types.ts`** / **`config.ts`** (`statusConfig`/`stagger`/`fadeUp`/`QUICK_ACTIONS`).
- **+20 testes** (lógica de prioridade + presentacionais).

> Os wrappers `framer-motion` (`motion.div/section variants={fadeUp}`) permaneceram como filhos diretos do `motion.main` no componente pai — a orquestração do `stagger` é preservada byte-a-byte.

## Verificação
- `bunx tsc --noEmit` (baseline) = **0**
- `eslint` = **0 erros / 0 warnings**
- **20/20 testes** verdes (isolados)
- Revisão independente FIEL 1:1: **aprovada** (hook/computePriority/árvore de motion conferidos)

## Migrations
Nenhuma.

🤖 Generated with [Claude Code](https://claude.com/claude-code)