### PR TITLE
refactor(aiops): split AIops (506→108) em hook + componentes

### DIFF
--- a/src/components/aiOps/AiOpsHeader.tsx
+++ b/src/components/aiOps/AiOpsHeader.tsx
@@ -1,0 +1,50 @@
+// Header do AI Ops (título + filtro de confiança + botão Executar Agente).
+// Extraído verbatim de src/pages/AIops.tsx (god-component split).
+import { Button } from '@/components/ui/button';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Brain, RefreshCw } from 'lucide-react';
+
+interface AiOpsHeaderProps {
+  confidenceFilter: string;
+  onConfidenceChange: (v: string) => void;
+  onRunAgent: () => void;
+  isRunningAgent: boolean;
+}
+
+export function AiOpsHeader({ confidenceFilter, onConfidenceChange, onRunAgent, isRunningAgent }: AiOpsHeaderProps) {
+  return (
+    <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight flex items-center gap-2">
+          <Brain className="w-6 h-6 text-primary" />
+          AI Ops
+        </h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          Inteligência operacional — decisões e recomendações automatizadas
+        </p>
+      </div>
+      <div className="flex items-center gap-2">
+        <Select value={confidenceFilter} onValueChange={onConfidenceChange}>
+          <SelectTrigger className="w-[140px]">
+            <SelectValue placeholder="Confiança" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">Todas</SelectItem>
+            <SelectItem value="alta">Alta</SelectItem>
+            <SelectItem value="media">Média</SelectItem>
+            <SelectItem value="baixa">Baixa</SelectItem>
+          </SelectContent>
+        </Select>
+        <Button
+          onClick={onRunAgent}
+          disabled={isRunningAgent}
+          variant="outline"
+          className="gap-1.5"
+        >
+          <RefreshCw className={`w-4 h-4 ${isRunningAgent ? 'animate-spin' : ''}`} />
+          Executar Agente
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/aiOps/DecisionCard.tsx
+++ b/src/components/aiOps/DecisionCard.tsx
@@ -1,0 +1,129 @@
+// Card de decisão de IA (cliente, score, evidências, ações, métricas expandidas).
+// Extraído verbatim de src/pages/AIops.tsx (god-component split).
+import { useState } from 'react';
+import { Card, CardContent } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Phone, ChevronDown, ChevronUp, CheckCircle2, XCircle } from 'lucide-react';
+import { actionIcons, actionLabels, confidenceBadge } from './config';
+import { EvidenceItem } from './EvidenceItem';
+import type { AIDecision, Evidence } from './types';
+
+export function DecisionCard({
+  decision,
+  customerName,
+  customerPhone,
+  onAccept,
+  onDismiss,
+}: {
+  decision: AIDecision;
+  customerName: string;
+  customerPhone?: string | null;
+  onAccept: () => void;
+  onDismiss: () => void;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const ActionIcon = actionIcons[decision.suggested_action] || Phone;
+  const conf = confidenceBadge[decision.confidence] || confidenceBadge.baixa;
+
+  return (
+    <Card className="transition-shadow hover:shadow-md">
+      <CardContent className="p-4">
+        {/* Header row */}
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-2 mb-1">
+              <h3 className="font-semibold text-base truncate">{customerName}</h3>
+              <Badge variant={conf.variant} className="text-2xs shrink-0">
+                {conf.label}
+              </Badge>
+            </div>
+            <p className="text-sm text-muted-foreground leading-snug">{decision.primary_reason}</p>
+          </div>
+          <div className="flex items-center gap-2 shrink-0">
+            <div className="text-right">
+              <div className="text-lg font-bold text-primary">{decision.score_final.toFixed(0)}</div>
+              <div className="text-2xs text-muted-foreground">score</div>
+            </div>
+          </div>
+        </div>
+
+        {/* Evidences (first 2 always visible) */}
+        <div className="mt-3 space-y-1">
+          {(decision.evidences as Evidence[]).slice(0, expanded ? 4 : 2).map((ev, i) => (
+            <EvidenceItem key={i} evidence={ev} />
+          ))}
+        </div>
+
+        {/* Actions */}
+        <div className="mt-3 flex items-center justify-between gap-2">
+          <div className="flex items-center gap-2">
+            <Button
+              size="sm"
+              className="gap-1.5"
+              onClick={onAccept}
+              disabled={decision.status !== 'pending'}
+            >
+              <ActionIcon className="w-3.5 h-3.5" />
+              {actionLabels[decision.suggested_action]}
+            </Button>
+            {decision.status === 'pending' && (
+              <Button size="sm" variant="ghost" onClick={onDismiss}>
+                <XCircle className="w-3.5 h-3.5 mr-1" />
+                Dispensar
+              </Button>
+            )}
+            {decision.status === 'accepted' && (
+              <Badge variant="default" className="gap-1">
+                <CheckCircle2 className="w-3 h-3" /> Aceito
+              </Badge>
+            )}
+            {decision.status === 'dismissed' && (
+              <Badge variant="secondary" className="gap-1">
+                <XCircle className="w-3 h-3" /> Dispensado
+              </Badge>
+            )}
+          </div>
+          <Button
+            size="sm"
+            variant="ghost"
+            className="text-muted-foreground"
+            onClick={() => setExpanded(!expanded)}
+          >
+            {expanded ? <ChevronUp className="w-4 h-4" /> : <ChevronDown className="w-4 h-4" />}
+          </Button>
+        </div>
+
+        {/* Expanded metrics */}
+        {expanded && (
+          <div className="mt-3 pt-3 border-t border-border grid grid-cols-2 sm:grid-cols-4 gap-3 text-sm">
+            <div>
+              <div className="text-muted-foreground text-2xs">Pedidos 90d</div>
+              <div className="font-medium">{decision.customer_metrics?.pedidos_90d ?? 0}</div>
+            </div>
+            <div>
+              <div className="text-muted-foreground text-2xs">Faturamento 90d</div>
+              <div className="font-medium">
+                R$ {Number(decision.customer_metrics?.faturamento_90d ?? 0).toLocaleString('pt-BR', { minimumFractionDigits: 0 })}
+              </div>
+            </div>
+            <div>
+              <div className="text-muted-foreground text-2xs">Ticket médio</div>
+              <div className="font-medium">
+                R$ {Number(decision.customer_metrics?.ticket_medio_90d ?? 0).toLocaleString('pt-BR', { minimumFractionDigits: 0 })}
+              </div>
+            </div>
+            <div>
+              <div className="text-muted-foreground text-2xs">Intervalo médio</div>
+              <div className="font-medium">
+                {decision.customer_metrics?.intervalo_medio_dias
+                  ? `${Math.round(decision.customer_metrics.intervalo_medio_dias)} dias`
+                  : 'N/A'}
+              </div>
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/aiOps/DecisionList.tsx
+++ b/src/components/aiOps/DecisionList.tsx
@@ -1,0 +1,41 @@
+// Lista de decisões de uma aba (empty state + cards). Reutilizada nas 3 abas.
+// Extraída verbatim de src/pages/AIops.tsx (god-component split — as 3 abas eram idênticas exceto ícone/mensagem do empty state).
+import { Card, CardContent } from '@/components/ui/card';
+import type { LucideIcon } from 'lucide-react';
+import { DecisionCard } from './DecisionCard';
+import type { AIDecision, CustomerProfileLite } from './types';
+
+interface DecisionListProps {
+  decisions: AIDecision[];
+  profileMap: Map<string, CustomerProfileLite>;
+  emptyIcon: LucideIcon;
+  emptyMessage: string;
+  onAccept: (id: string) => void;
+  onDismiss: (id: string) => void;
+}
+
+export function DecisionList({ decisions, profileMap, emptyIcon: EmptyIcon, emptyMessage, onAccept, onDismiss }: DecisionListProps) {
+  return (
+    <div className="space-y-3">
+      {decisions.length === 0 ? (
+        <Card>
+          <CardContent className="p-8 text-center text-muted-foreground">
+            <EmptyIcon className="w-12 h-12 mx-auto mb-3 opacity-30" />
+            <p>{emptyMessage}</p>
+          </CardContent>
+        </Card>
+      ) : (
+        decisions.map((d) => (
+          <DecisionCard
+            key={d.id}
+            decision={d}
+            customerName={profileMap.get(d.customer_user_id)?.name || 'Cliente desconhecido'}
+            customerPhone={profileMap.get(d.customer_user_id)?.phone}
+            onAccept={() => onAccept(d.id)}
+            onDismiss={() => onDismiss(d.id)}
+          />
+        ))
+      )}
+    </div>
+  );
+}

--- a/src/components/aiOps/EvidenceItem.tsx
+++ b/src/components/aiOps/EvidenceItem.tsx
@@ -1,0 +1,28 @@
+// Item de evidência de uma decisão de IA.
+// Extraído verbatim de src/pages/AIops.tsx (god-component split).
+import { AlertTriangle, TrendingDown, Clock } from 'lucide-react';
+import type { Evidence } from './types';
+
+export function EvidenceItem({ evidence }: { evidence: Evidence }) {
+  const colorMap = {
+    critical: 'text-destructive',
+    warning: 'text-amber-600 dark:text-amber-400',
+    info: 'text-muted-foreground',
+  };
+  const iconMap = {
+    critical: AlertTriangle,
+    warning: TrendingDown,
+    info: Clock,
+  };
+  const Icon = iconMap[evidence.type];
+
+  return (
+    <div className="flex items-start gap-2 text-sm">
+      <Icon className={`w-3.5 h-3.5 mt-0.5 shrink-0 ${colorMap[evidence.type]}`} />
+      <div>
+        <span className="font-medium">{evidence.label}:</span>{' '}
+        <span className={colorMap[evidence.type]}>{evidence.value}</span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/aiOps/StatsCards.tsx
+++ b/src/components/aiOps/StatsCards.tsx
@@ -1,0 +1,49 @@
+// Cards de estatísticas do AI Ops (Prioridades / Oportunidades / Riscos).
+// Extraído verbatim de src/pages/AIops.tsx (god-component split).
+import { Card, CardContent } from '@/components/ui/card';
+import { Target, Zap, Shield } from 'lucide-react';
+
+interface StatsCardsProps {
+  prioridadesCount: number;
+  oportunidadesCount: number;
+  riscosCount: number;
+}
+
+export function StatsCards({ prioridadesCount, oportunidadesCount, riscosCount }: StatsCardsProps) {
+  const statsCards = [
+    {
+      icon: Target,
+      label: 'Prioridades',
+      value: prioridadesCount,
+      color: 'text-primary',
+    },
+    {
+      icon: Zap,
+      label: 'Oportunidades',
+      value: oportunidadesCount,
+      color: 'text-emerald-600 dark:text-emerald-400',
+    },
+    {
+      icon: Shield,
+      label: 'Riscos',
+      value: riscosCount,
+      color: 'text-destructive',
+    },
+  ];
+
+  return (
+    <div className="grid grid-cols-3 gap-4">
+      {statsCards.map((s) => (
+        <Card key={s.label}>
+          <CardContent className="p-4 flex items-center gap-3">
+            <s.icon className={`w-8 h-8 ${s.color}`} />
+            <div>
+              <div className="text-2xl font-bold">{s.value}</div>
+              <div className="text-sm text-muted-foreground">{s.label}</div>
+            </div>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/src/components/aiOps/__tests__/AiOpsHeader.test.tsx
+++ b/src/components/aiOps/__tests__/AiOpsHeader.test.tsx
@@ -1,0 +1,24 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { AiOpsHeader } from "../AiOpsHeader";
+
+describe("AiOpsHeader", () => {
+  it("renderiza título e botão; dispara onRunAgent", () => {
+    const onRunAgent = vi.fn();
+    render(
+      <AiOpsHeader confidenceFilter="all" onConfidenceChange={vi.fn()} onRunAgent={onRunAgent} isRunningAgent={false} />,
+    );
+    expect(screen.getByText("AI Ops")).toBeTruthy();
+    const btn = screen.getByRole("button", { name: /Executar Agente/ });
+    expect(btn).toHaveProperty("disabled", false);
+    fireEvent.click(btn);
+    expect(onRunAgent).toHaveBeenCalledTimes(1);
+  });
+
+  it("desabilita o botão durante execução", () => {
+    render(
+      <AiOpsHeader confidenceFilter="all" onConfidenceChange={vi.fn()} onRunAgent={vi.fn()} isRunningAgent />,
+    );
+    expect(screen.getByRole("button", { name: /Executar Agente/ })).toHaveProperty("disabled", true);
+  });
+});

--- a/src/components/aiOps/__tests__/DecisionCard.test.tsx
+++ b/src/components/aiOps/__tests__/DecisionCard.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { DecisionCard } from "../DecisionCard";
+import type { AIDecision } from "../types";
+
+function makeDecision(o: Partial<AIDecision> = {}): AIDecision {
+  return {
+    id: "d1",
+    decision_type: "churn",
+    customer_user_id: "c1",
+    farmer_id: null,
+    score_final: 87.4,
+    confidence: "alta",
+    confidence_value: 0.9,
+    suggested_action: "ligar",
+    primary_reason: "Cliente em risco de churn",
+    evidences: [
+      { label: "Atraso", value: "15 dias", type: "critical" },
+      { label: "Queda", value: "30%", type: "warning" },
+    ],
+    explanation: "x",
+    customer_metrics: { pedidos_90d: 5, faturamento_90d: 12000, ticket_medio_90d: 2400, intervalo_medio_dias: 22 },
+    status: "pending",
+    created_at: "2026-03-01T00:00:00Z",
+    updated_at: "2026-03-01T00:00:00Z",
+    ...o,
+  };
+}
+
+function setup(overrides: Partial<React.ComponentProps<typeof DecisionCard>> = {}) {
+  const props: React.ComponentProps<typeof DecisionCard> = {
+    decision: makeDecision(),
+    customerName: "Marcenaria Alfa",
+    customerPhone: "11999",
+    onAccept: vi.fn(),
+    onDismiss: vi.fn(),
+    ...overrides,
+  };
+  render(<DecisionCard {...props} />);
+  return props;
+}
+
+describe("DecisionCard", () => {
+  it("renderiza nome, score, motivo, confiança e ação", () => {
+    setup();
+    expect(screen.getByText("Marcenaria Alfa")).toBeTruthy();
+    expect(screen.getByText("87")).toBeTruthy(); // score_final.toFixed(0)
+    expect(screen.getByText("Cliente em risco de churn")).toBeTruthy();
+    expect(screen.getByText("Alta")).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Ligar/ })).toBeTruthy();
+  });
+
+  it("dispara onAccept e onDismiss", () => {
+    const props = setup();
+    fireEvent.click(screen.getByRole("button", { name: /Ligar/ }));
+    fireEvent.click(screen.getByRole("button", { name: /Dispensar/ }));
+    expect(props.onAccept).toHaveBeenCalledTimes(1);
+    expect(props.onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it("mostra badge Aceito e desabilita ação quando accepted", () => {
+    setup({ decision: makeDecision({ status: "accepted" }) });
+    expect(screen.getByText("Aceito")).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Ligar/ })).toHaveProperty("disabled", true);
+  });
+
+  it("expande para mostrar métricas", () => {
+    setup();
+    expect(screen.queryByText("Pedidos 90d")).toBeNull();
+    const buttons = screen.getAllByRole("button");
+    fireEvent.click(buttons[buttons.length - 1]); // chevron toggle
+    expect(screen.getByText("Pedidos 90d")).toBeTruthy();
+    expect(screen.getByText("5")).toBeTruthy();
+  });
+});

--- a/src/components/aiOps/__tests__/DecisionList.test.tsx
+++ b/src/components/aiOps/__tests__/DecisionList.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { Brain } from "lucide-react";
+import { DecisionList } from "../DecisionList";
+import type { AIDecision, CustomerProfileLite } from "../types";
+
+function makeDecision(o: Partial<AIDecision> = {}): AIDecision {
+  return {
+    id: "d1",
+    decision_type: "churn",
+    customer_user_id: "c1",
+    farmer_id: null,
+    score_final: 80,
+    confidence: "alta",
+    confidence_value: 0.9,
+    suggested_action: "ligar",
+    primary_reason: "motivo",
+    evidences: [],
+    explanation: "x",
+    customer_metrics: {},
+    status: "pending",
+    created_at: "2026-03-01T00:00:00Z",
+    updated_at: "2026-03-01T00:00:00Z",
+    ...o,
+  };
+}
+
+const profileMap = new Map<string, CustomerProfileLite>([
+  ["c1", { user_id: "c1", name: "Marcenaria Alfa", document: null, phone: "11999", email: null, customer_type: null }],
+]);
+
+describe("DecisionList", () => {
+  it("mostra empty state com ícone e mensagem", () => {
+    render(
+      <DecisionList decisions={[]} profileMap={profileMap} emptyIcon={Brain} emptyMessage="Nada aqui." onAccept={vi.fn()} onDismiss={vi.fn()} />,
+    );
+    expect(screen.getByText("Nada aqui.")).toBeTruthy();
+  });
+
+  it("renderiza cards e resolve nome via profileMap; onAccept recebe o id", () => {
+    const onAccept = vi.fn();
+    render(
+      <DecisionList
+        decisions={[makeDecision()]}
+        profileMap={profileMap}
+        emptyIcon={Brain}
+        emptyMessage="Nada aqui."
+        onAccept={onAccept}
+        onDismiss={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("Marcenaria Alfa")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: /Ligar/ }));
+    expect(onAccept).toHaveBeenCalledWith("d1");
+  });
+
+  it("usa fallback de nome quando não há perfil", () => {
+    render(
+      <DecisionList
+        decisions={[makeDecision({ customer_user_id: "desconhecido" })]}
+        profileMap={profileMap}
+        emptyIcon={Brain}
+        emptyMessage="Nada aqui."
+        onAccept={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("Cliente desconhecido")).toBeTruthy();
+  });
+});

--- a/src/components/aiOps/__tests__/EvidenceItem.test.tsx
+++ b/src/components/aiOps/__tests__/EvidenceItem.test.tsx
@@ -1,0 +1,11 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { EvidenceItem } from "../EvidenceItem";
+
+describe("EvidenceItem", () => {
+  it("renderiza label e value", () => {
+    render(<EvidenceItem evidence={{ label: "Atraso", value: "15 dias", type: "critical" }} />);
+    expect(screen.getByText("Atraso:")).toBeTruthy();
+    expect(screen.getByText("15 dias")).toBeTruthy();
+  });
+});

--- a/src/components/aiOps/__tests__/StatsCards.test.tsx
+++ b/src/components/aiOps/__tests__/StatsCards.test.tsx
@@ -1,0 +1,15 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { StatsCards } from "../StatsCards";
+
+describe("StatsCards", () => {
+  it("renderiza os 3 KPIs com valores e rótulos", () => {
+    render(<StatsCards prioridadesCount={7} oportunidadesCount={3} riscosCount={2} />);
+    expect(screen.getByText("Prioridades")).toBeTruthy();
+    expect(screen.getByText("Oportunidades")).toBeTruthy();
+    expect(screen.getByText("Riscos")).toBeTruthy();
+    expect(screen.getByText("7")).toBeTruthy();
+    expect(screen.getByText("3")).toBeTruthy();
+    expect(screen.getByText("2")).toBeTruthy();
+  });
+});

--- a/src/components/aiOps/__tests__/config.test.ts
+++ b/src/components/aiOps/__tests__/config.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from "vitest";
+import { actionLabels, confidenceBadge } from "../config";
+
+describe("aiOps/config", () => {
+  it("actionLabels mapeia ações", () => {
+    expect(actionLabels.ligar).toBe("Ligar");
+    expect(actionLabels.visitar).toBe("Visitar");
+    expect(actionLabels.mensagem).toBe("Enviar mensagem");
+  });
+
+  it("confidenceBadge mapeia níveis", () => {
+    expect(confidenceBadge.alta).toEqual({ variant: "default", label: "Alta" });
+    expect(confidenceBadge.media.label).toBe("Média");
+    expect(confidenceBadge.baixa.variant).toBe("outline");
+  });
+});

--- a/src/components/aiOps/config.ts
+++ b/src/components/aiOps/config.ts
@@ -1,0 +1,21 @@
+// Ícones, rótulos e badges de confiança do AI Ops.
+// Extraídos verbatim de src/pages/AIops.tsx (god-component split).
+import { Phone, MapPin, MessageSquare } from 'lucide-react';
+
+export const actionIcons: Record<string, React.ElementType> = {
+  ligar: Phone,
+  visitar: MapPin,
+  mensagem: MessageSquare,
+};
+
+export const actionLabels: Record<string, string> = {
+  ligar: 'Ligar',
+  visitar: 'Visitar',
+  mensagem: 'Enviar mensagem',
+};
+
+export const confidenceBadge: Record<string, { variant: 'default' | 'secondary' | 'outline' | 'destructive'; label: string }> = {
+  alta: { variant: 'default', label: 'Alta' },
+  media: { variant: 'secondary', label: 'Média' },
+  baixa: { variant: 'outline', label: 'Baixa' },
+};

--- a/src/components/aiOps/types.ts
+++ b/src/components/aiOps/types.ts
@@ -1,0 +1,35 @@
+// Tipos do AI Ops.
+// Extraídos verbatim de src/pages/AIops.tsx (god-component split).
+
+export interface Evidence {
+  label: string;
+  value: string;
+  type: 'warning' | 'info' | 'critical';
+}
+
+export interface AIDecision {
+  id: string;
+  decision_type: string;
+  customer_user_id: string;
+  farmer_id: string | null;
+  score_final: number;
+  confidence: string;
+  confidence_value: number;
+  suggested_action: string;
+  primary_reason: string;
+  evidences: Evidence[];
+  explanation: string;
+  customer_metrics: Record<string, number | null>;
+  status: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CustomerProfileLite {
+  user_id: string;
+  name: string | null;
+  document: string | null;
+  phone: string | null;
+  email: string | null;
+  customer_type: string | null;
+}

--- a/src/components/aiOps/useAiOps.ts
+++ b/src/components/aiOps/useAiOps.ts
@@ -1,0 +1,140 @@
+// Hooks de dados + composição de estado/derivados do AI Ops.
+// Extraído verbatim de src/pages/AIops.tsx (god-component split):
+// queries (decisões/perfis), mutations (rodar agente/atualizar status),
+// filtros e particionamento prioridades/oportunidades/riscos.
+import { useState, useMemo } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import { toast } from 'sonner';
+import type { AIDecision, CustomerProfileLite } from './types';
+
+function useAIDecisions() {
+  return useQuery({
+    queryKey: ['ai-decisions'],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from('ai_decisions')
+        .select('*')
+        .order('score_final', { ascending: false })
+        .limit(200);
+      if (error) throw error;
+      return (data || []) as unknown as AIDecision[];
+    },
+  });
+}
+
+function useCustomerProfiles(customerIds: string[]) {
+  return useQuery({
+    queryKey: ['ai-ops-profiles', customerIds.join(',')],
+    queryFn: async () => {
+      if (!customerIds.length) return [];
+      const { data, error } = await supabase
+        .from('profiles')
+        .select('user_id, name, document, phone, email, customer_type')
+        .in('user_id', customerIds);
+      if (error) throw error;
+      return (data || []) as unknown as CustomerProfileLite[];
+    },
+    enabled: customerIds.length > 0,
+  });
+}
+
+function useRunAgent() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async () => {
+      const { data, error } = await supabase.functions.invoke('ai-ops-agent');
+      if (error) throw error;
+      return data;
+    },
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ['ai-decisions'] });
+      toast.success(`Agente executado: ${data?.decisions_generated || 0} decisões geradas`);
+    },
+    onError: (error) => {
+      toast.error(`Erro ao executar agente: ${error.message}`);
+    },
+  });
+}
+
+function useUpdateDecisionStatus() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ id, status }: { id: string; status: string }) => {
+      const { error } = await supabase
+        .from('ai_decisions')
+        .update({ status, updated_at: new Date().toISOString() })
+        .eq('id', id);
+      if (error) throw error;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['ai-decisions'] });
+    },
+  });
+}
+
+export function useAiOps() {
+  const [confidenceFilter, setConfidenceFilter] = useState<string>('all');
+  const [activeTab, setActiveTab] = useState('prioridades');
+
+  const { data: decisions = [], isLoading } = useAIDecisions();
+  const runAgent = useRunAgent();
+  const updateStatus = useUpdateDecisionStatus();
+
+  const customerIds = useMemo(
+    () => [...new Set(decisions.map((d) => d.customer_user_id))],
+    [decisions]
+  );
+  const { data: profiles = [] } = useCustomerProfiles(customerIds);
+  const profileMap = useMemo(
+    () => new Map(profiles.map((p) => [p.user_id, p])),
+    [profiles]
+  );
+
+  // ─── Filtered lists ───
+  const filtered = useMemo(() => {
+    let list = decisions;
+    if (confidenceFilter !== 'all') {
+      list = list.filter((d) => d.confidence === confidenceFilter);
+    }
+    return list;
+  }, [decisions, confidenceFilter]);
+
+  // Prioridades: pending decisions sorted by score
+  const prioridades = filtered.filter((d) => d.status === 'pending');
+
+  // Oportunidades: customers with good metrics but could buy more (expansion)
+  const oportunidades = filtered.filter(
+    (d) =>
+      d.status === 'pending' &&
+      d.customer_metrics?.faturamento_90d > 0 &&
+      (d.customer_metrics?.atraso_relativo === null ||
+        d.customer_metrics?.atraso_relativo < 1.5)
+  );
+
+  // Riscos: high churn risk (atraso >= 2x or big revenue drop)
+  const riscos = filtered.filter(
+    (d) =>
+      d.status === 'pending' &&
+      (d.customer_metrics?.atraso_relativo >= 2.0 ||
+        (d.customer_metrics?.faturamento_prev_90d > 0 &&
+          d.customer_metrics?.faturamento_90d <
+            d.customer_metrics?.faturamento_prev_90d * 0.5))
+  );
+
+  return {
+    confidenceFilter,
+    setConfidenceFilter,
+    activeTab,
+    setActiveTab,
+    isLoading,
+    profileMap,
+    prioridades,
+    oportunidades,
+    riscos,
+    isRunningAgent: runAgent.isPending,
+    runAgent: () => runAgent.mutate(),
+    accept: (id: string) => updateStatus.mutate({ id, status: 'accepted' }),
+    dismiss: (id: string) => updateStatus.mutate({ id, status: 'dismissed' }),
+  };
+}

--- a/src/pages/AIops.tsx
+++ b/src/pages/AIops.tsx
@@ -1,406 +1,47 @@
-import { useState, useMemo } from 'react';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { supabase } from '@/integrations/supabase/client';
+// AI Ops — inteligência operacional (decisões e recomendações automatizadas).
+// Composição: useAiOps (queries/mutations/filtros) + header + stats + tabs.
+// God-component split de src/pages/AIops.tsx (comportamento 1:1).
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
-import { Button } from '@/components/ui/button';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Skeleton } from '@/components/ui/skeleton';
-import { toast } from 'sonner';
-import {
-  Brain,
-  Phone,
-  MapPin,
-  MessageSquare,
-  AlertTriangle,
-  TrendingDown,
-  Clock,
-  RefreshCw,
-  ChevronDown,
-  ChevronUp,
-  CheckCircle2,
-  XCircle,
-  Zap,
-  Shield,
-  Target,
-} from 'lucide-react';
+import { Brain, Zap, Shield, Target } from 'lucide-react';
+import { useAiOps } from '@/components/aiOps/useAiOps';
+import { AiOpsHeader } from '@/components/aiOps/AiOpsHeader';
+import { StatsCards } from '@/components/aiOps/StatsCards';
+import { DecisionList } from '@/components/aiOps/DecisionList';
 
-// ─── Types ───
-interface Evidence {
-  label: string;
-  value: string;
-  type: 'warning' | 'info' | 'critical';
-}
-
-interface AIDecision {
-  id: string;
-  decision_type: string;
-  customer_user_id: string;
-  farmer_id: string | null;
-  score_final: number;
-  confidence: string;
-  confidence_value: number;
-  suggested_action: string;
-  primary_reason: string;
-  evidences: Evidence[];
-  explanation: string;
-  customer_metrics: Record<string, number | null>;
-  status: string;
-  created_at: string;
-  updated_at: string;
-}
-
-// ─── Hooks ───
-function useAIDecisions() {
-  return useQuery({
-    queryKey: ['ai-decisions'],
-    queryFn: async () => {
-      const { data, error } = await supabase
-        .from('ai_decisions')
-        .select('*')
-        .order('score_final', { ascending: false })
-        .limit(200);
-      if (error) throw error;
-      return (data || []) as unknown as AIDecision[];
-    },
-  });
-}
-
-function useCustomerProfiles(customerIds: string[]) {
-  return useQuery({
-    queryKey: ['ai-ops-profiles', customerIds.join(',')],
-    queryFn: async () => {
-      if (!customerIds.length) return [];
-      const { data, error } = await supabase
-        .from('profiles')
-        .select('user_id, name, document, phone, email, customer_type')
-        .in('user_id', customerIds);
-      if (error) throw error;
-      return data || [];
-    },
-    enabled: customerIds.length > 0,
-  });
-}
-
-function useRunAgent() {
-  const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: async () => {
-      const { data, error } = await supabase.functions.invoke('ai-ops-agent');
-      if (error) throw error;
-      return data;
-    },
-    onSuccess: (data) => {
-      queryClient.invalidateQueries({ queryKey: ['ai-decisions'] });
-      toast.success(`Agente executado: ${data?.decisions_generated || 0} decisões geradas`);
-    },
-    onError: (error) => {
-      toast.error(`Erro ao executar agente: ${error.message}`);
-    },
-  });
-}
-
-function useUpdateDecisionStatus() {
-  const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: async ({ id, status }: { id: string; status: string }) => {
-      const { error } = await supabase
-        .from('ai_decisions')
-        .update({ status, updated_at: new Date().toISOString() })
-        .eq('id', id);
-      if (error) throw error;
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['ai-decisions'] });
-    },
-  });
-}
-
-// ─── Sub-components ───
-const actionIcons: Record<string, React.ElementType> = {
-  ligar: Phone,
-  visitar: MapPin,
-  mensagem: MessageSquare,
-};
-
-const actionLabels: Record<string, string> = {
-  ligar: 'Ligar',
-  visitar: 'Visitar',
-  mensagem: 'Enviar mensagem',
-};
-
-const confidenceBadge: Record<string, { variant: 'default' | 'secondary' | 'outline' | 'destructive'; label: string }> = {
-  alta: { variant: 'default', label: 'Alta' },
-  media: { variant: 'secondary', label: 'Média' },
-  baixa: { variant: 'outline', label: 'Baixa' },
-};
-
-function EvidenceItem({ evidence }: { evidence: Evidence }) {
-  const colorMap = {
-    critical: 'text-destructive',
-    warning: 'text-amber-600 dark:text-amber-400',
-    info: 'text-muted-foreground',
-  };
-  const iconMap = {
-    critical: AlertTriangle,
-    warning: TrendingDown,
-    info: Clock,
-  };
-  const Icon = iconMap[evidence.type];
-
-  return (
-    <div className="flex items-start gap-2 text-sm">
-      <Icon className={`w-3.5 h-3.5 mt-0.5 shrink-0 ${colorMap[evidence.type]}`} />
-      <div>
-        <span className="font-medium">{evidence.label}:</span>{' '}
-        <span className={colorMap[evidence.type]}>{evidence.value}</span>
-      </div>
-    </div>
-  );
-}
-
-function DecisionCard({
-  decision,
-  customerName,
-  customerPhone,
-  onAccept,
-  onDismiss,
-}: {
-  decision: AIDecision;
-  customerName: string;
-  customerPhone?: string | null;
-  onAccept: () => void;
-  onDismiss: () => void;
-}) {
-  const [expanded, setExpanded] = useState(false);
-  const ActionIcon = actionIcons[decision.suggested_action] || Phone;
-  const conf = confidenceBadge[decision.confidence] || confidenceBadge.baixa;
-
-  return (
-    <Card className="transition-shadow hover:shadow-md">
-      <CardContent className="p-4">
-        {/* Header row */}
-        <div className="flex items-start justify-between gap-3">
-          <div className="flex-1 min-w-0">
-            <div className="flex items-center gap-2 mb-1">
-              <h3 className="font-semibold text-base truncate">{customerName}</h3>
-              <Badge variant={conf.variant} className="text-2xs shrink-0">
-                {conf.label}
-              </Badge>
-            </div>
-            <p className="text-sm text-muted-foreground leading-snug">{decision.primary_reason}</p>
-          </div>
-          <div className="flex items-center gap-2 shrink-0">
-            <div className="text-right">
-              <div className="text-lg font-bold text-primary">{decision.score_final.toFixed(0)}</div>
-              <div className="text-2xs text-muted-foreground">score</div>
-            </div>
-          </div>
-        </div>
-
-        {/* Evidences (first 2 always visible) */}
-        <div className="mt-3 space-y-1">
-          {(decision.evidences as Evidence[]).slice(0, expanded ? 4 : 2).map((ev, i) => (
-            <EvidenceItem key={i} evidence={ev} />
-          ))}
-        </div>
-
-        {/* Actions */}
-        <div className="mt-3 flex items-center justify-between gap-2">
-          <div className="flex items-center gap-2">
-            <Button
-              size="sm"
-              className="gap-1.5"
-              onClick={onAccept}
-              disabled={decision.status !== 'pending'}
-            >
-              <ActionIcon className="w-3.5 h-3.5" />
-              {actionLabels[decision.suggested_action]}
-            </Button>
-            {decision.status === 'pending' && (
-              <Button size="sm" variant="ghost" onClick={onDismiss}>
-                <XCircle className="w-3.5 h-3.5 mr-1" />
-                Dispensar
-              </Button>
-            )}
-            {decision.status === 'accepted' && (
-              <Badge variant="default" className="gap-1">
-                <CheckCircle2 className="w-3 h-3" /> Aceito
-              </Badge>
-            )}
-            {decision.status === 'dismissed' && (
-              <Badge variant="secondary" className="gap-1">
-                <XCircle className="w-3 h-3" /> Dispensado
-              </Badge>
-            )}
-          </div>
-          <Button
-            size="sm"
-            variant="ghost"
-            className="text-muted-foreground"
-            onClick={() => setExpanded(!expanded)}
-          >
-            {expanded ? <ChevronUp className="w-4 h-4" /> : <ChevronDown className="w-4 h-4" />}
-          </Button>
-        </div>
-
-        {/* Expanded metrics */}
-        {expanded && (
-          <div className="mt-3 pt-3 border-t border-border grid grid-cols-2 sm:grid-cols-4 gap-3 text-sm">
-            <div>
-              <div className="text-muted-foreground text-2xs">Pedidos 90d</div>
-              <div className="font-medium">{decision.customer_metrics?.pedidos_90d ?? 0}</div>
-            </div>
-            <div>
-              <div className="text-muted-foreground text-2xs">Faturamento 90d</div>
-              <div className="font-medium">
-                R$ {Number(decision.customer_metrics?.faturamento_90d ?? 0).toLocaleString('pt-BR', { minimumFractionDigits: 0 })}
-              </div>
-            </div>
-            <div>
-              <div className="text-muted-foreground text-2xs">Ticket médio</div>
-              <div className="font-medium">
-                R$ {Number(decision.customer_metrics?.ticket_medio_90d ?? 0).toLocaleString('pt-BR', { minimumFractionDigits: 0 })}
-              </div>
-            </div>
-            <div>
-              <div className="text-muted-foreground text-2xs">Intervalo médio</div>
-              <div className="font-medium">
-                {decision.customer_metrics?.intervalo_medio_dias
-                  ? `${Math.round(decision.customer_metrics.intervalo_medio_dias)} dias`
-                  : 'N/A'}
-              </div>
-            </div>
-          </div>
-        )}
-      </CardContent>
-    </Card>
-  );
-}
-
-// ─── Main Page ───
 export default function AIops() {
-  const [confidenceFilter, setConfidenceFilter] = useState<string>('all');
-  const [activeTab, setActiveTab] = useState('prioridades');
-
-  const { data: decisions = [], isLoading } = useAIDecisions();
-  const runAgent = useRunAgent();
-  const updateStatus = useUpdateDecisionStatus();
-
-  const customerIds = useMemo(
-    () => [...new Set(decisions.map((d) => d.customer_user_id))],
-    [decisions]
-  );
-  const { data: profiles = [] } = useCustomerProfiles(customerIds);
-  const profileMap = useMemo(
-    () => new Map(profiles.map((p) => [p.user_id, p])),
-    [profiles]
-  );
-
-  // ─── Filtered lists ───
-  const filtered = useMemo(() => {
-    let list = decisions;
-    if (confidenceFilter !== 'all') {
-      list = list.filter((d) => d.confidence === confidenceFilter);
-    }
-    return list;
-  }, [decisions, confidenceFilter]);
-
-  // Prioridades: pending decisions sorted by score
-  const prioridades = filtered.filter((d) => d.status === 'pending');
-
-  // Oportunidades: customers with good metrics but could buy more (expansion)
-  const oportunidades = filtered.filter(
-    (d) =>
-      d.status === 'pending' &&
-      d.customer_metrics?.faturamento_90d > 0 &&
-      (d.customer_metrics?.atraso_relativo === null ||
-        d.customer_metrics?.atraso_relativo < 1.5)
-  );
-
-  // Riscos: high churn risk (atraso >= 2x or big revenue drop)
-  const riscos = filtered.filter(
-    (d) =>
-      d.status === 'pending' &&
-      (d.customer_metrics?.atraso_relativo >= 2.0 ||
-        (d.customer_metrics?.faturamento_prev_90d > 0 &&
-          d.customer_metrics?.faturamento_90d <
-            d.customer_metrics?.faturamento_prev_90d * 0.5))
-  );
-
-  const statsCards = [
-    {
-      icon: Target,
-      label: 'Prioridades',
-      value: prioridades.length,
-      color: 'text-primary',
-    },
-    {
-      icon: Zap,
-      label: 'Oportunidades',
-      value: oportunidades.length,
-      color: 'text-emerald-600 dark:text-emerald-400',
-    },
-    {
-      icon: Shield,
-      label: 'Riscos',
-      value: riscos.length,
-      color: 'text-destructive',
-    },
-  ];
+  const {
+    confidenceFilter,
+    setConfidenceFilter,
+    activeTab,
+    setActiveTab,
+    isLoading,
+    profileMap,
+    prioridades,
+    oportunidades,
+    riscos,
+    isRunningAgent,
+    runAgent,
+    accept,
+    dismiss,
+  } = useAiOps();
 
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
-        <div>
-          <h1 className="text-2xl font-bold tracking-tight flex items-center gap-2">
-            <Brain className="w-6 h-6 text-primary" />
-            AI Ops
-          </h1>
-          <p className="text-sm text-muted-foreground mt-1">
-            Inteligência operacional — decisões e recomendações automatizadas
-          </p>
-        </div>
-        <div className="flex items-center gap-2">
-          <Select value={confidenceFilter} onValueChange={setConfidenceFilter}>
-            <SelectTrigger className="w-[140px]">
-              <SelectValue placeholder="Confiança" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">Todas</SelectItem>
-              <SelectItem value="alta">Alta</SelectItem>
-              <SelectItem value="media">Média</SelectItem>
-              <SelectItem value="baixa">Baixa</SelectItem>
-            </SelectContent>
-          </Select>
-          <Button
-            onClick={() => runAgent.mutate()}
-            disabled={runAgent.isPending}
-            variant="outline"
-            className="gap-1.5"
-          >
-            <RefreshCw className={`w-4 h-4 ${runAgent.isPending ? 'animate-spin' : ''}`} />
-            Executar Agente
-          </Button>
-        </div>
-      </div>
+      <AiOpsHeader
+        confidenceFilter={confidenceFilter}
+        onConfidenceChange={setConfidenceFilter}
+        onRunAgent={runAgent}
+        isRunningAgent={isRunningAgent}
+      />
 
       {/* Stats */}
-      <div className="grid grid-cols-3 gap-4">
-        {statsCards.map((s) => (
-          <Card key={s.label}>
-            <CardContent className="p-4 flex items-center gap-3">
-              <s.icon className={`w-8 h-8 ${s.color}`} />
-              <div>
-                <div className="text-2xl font-bold">{s.value}</div>
-                <div className="text-sm text-muted-foreground">{s.label}</div>
-              </div>
-            </CardContent>
-          </Card>
-        ))}
-      </div>
+      <StatsCards
+        prioridadesCount={prioridades.length}
+        oportunidadesCount={oportunidades.length}
+        riscosCount={riscos.length}
+      />
 
       {/* Tabs */}
       <Tabs value={activeTab} onValueChange={setActiveTab}>
@@ -428,75 +69,36 @@ export default function AIops() {
         ) : (
           <>
             <TabsContent value="prioridades">
-              <div className="space-y-3">
-                {prioridades.length === 0 ? (
-                  <Card>
-                    <CardContent className="p-8 text-center text-muted-foreground">
-                      <Brain className="w-12 h-12 mx-auto mb-3 opacity-30" />
-                      <p>Nenhuma prioridade gerada. Execute o agente para gerar recomendações.</p>
-                    </CardContent>
-                  </Card>
-                ) : (
-                  prioridades.map((d) => (
-                    <DecisionCard
-                      key={d.id}
-                      decision={d}
-                      customerName={profileMap.get(d.customer_user_id)?.name || 'Cliente desconhecido'}
-                      customerPhone={profileMap.get(d.customer_user_id)?.phone}
-                      onAccept={() => updateStatus.mutate({ id: d.id, status: 'accepted' })}
-                      onDismiss={() => updateStatus.mutate({ id: d.id, status: 'dismissed' })}
-                    />
-                  ))
-                )}
-              </div>
+              <DecisionList
+                decisions={prioridades}
+                profileMap={profileMap}
+                emptyIcon={Brain}
+                emptyMessage="Nenhuma prioridade gerada. Execute o agente para gerar recomendações."
+                onAccept={accept}
+                onDismiss={dismiss}
+              />
             </TabsContent>
 
             <TabsContent value="oportunidades">
-              <div className="space-y-3">
-                {oportunidades.length === 0 ? (
-                  <Card>
-                    <CardContent className="p-8 text-center text-muted-foreground">
-                      <Zap className="w-12 h-12 mx-auto mb-3 opacity-30" />
-                      <p>Nenhuma oportunidade identificada no momento.</p>
-                    </CardContent>
-                  </Card>
-                ) : (
-                  oportunidades.map((d) => (
-                    <DecisionCard
-                      key={d.id}
-                      decision={d}
-                      customerName={profileMap.get(d.customer_user_id)?.name || 'Cliente desconhecido'}
-                      customerPhone={profileMap.get(d.customer_user_id)?.phone}
-                      onAccept={() => updateStatus.mutate({ id: d.id, status: 'accepted' })}
-                      onDismiss={() => updateStatus.mutate({ id: d.id, status: 'dismissed' })}
-                    />
-                  ))
-                )}
-              </div>
+              <DecisionList
+                decisions={oportunidades}
+                profileMap={profileMap}
+                emptyIcon={Zap}
+                emptyMessage="Nenhuma oportunidade identificada no momento."
+                onAccept={accept}
+                onDismiss={dismiss}
+              />
             </TabsContent>
 
             <TabsContent value="riscos">
-              <div className="space-y-3">
-                {riscos.length === 0 ? (
-                  <Card>
-                    <CardContent className="p-8 text-center text-muted-foreground">
-                      <Shield className="w-12 h-12 mx-auto mb-3 opacity-30" />
-                      <p>Nenhum cliente em risco identificado.</p>
-                    </CardContent>
-                  </Card>
-                ) : (
-                  riscos.map((d) => (
-                    <DecisionCard
-                      key={d.id}
-                      decision={d}
-                      customerName={profileMap.get(d.customer_user_id)?.name || 'Cliente desconhecido'}
-                      customerPhone={profileMap.get(d.customer_user_id)?.phone}
-                      onAccept={() => updateStatus.mutate({ id: d.id, status: 'accepted' })}
-                      onDismiss={() => updateStatus.mutate({ id: d.id, status: 'dismissed' })}
-                    />
-                  ))
-                )}
-              </div>
+              <DecisionList
+                decisions={riscos}
+                profileMap={profileMap}
+                emptyIcon={Shield}
+                emptyMessage="Nenhum cliente em risco identificado."
+                onAccept={accept}
+                onDismiss={dismiss}
+              />
             </TabsContent>
           </>
         )}


### PR DESCRIPTION
## Resumo
Quebra o god-component `src/pages/AIops.tsx` (**506→108L**) em um hook de dados/estado + componentes presentacionais controlados, sob `src/components/aiOps/`. Extração **verbatim** — comportamento preservado 1:1.

## O que mudou
- **`useAiOps`** (hook): 4 hooks de dados (`ai_decisions`, perfis, rodar agente `ai-ops-agent`, atualizar status) + filtros + particionamento `prioridades`/`oportunidades`/`riscos`.
- **`AiOpsHeader`** — título + filtro de confiança + botão Executar Agente.
- **`StatsCards`** — KPIs (Prioridades/Oportunidades/Riscos).
- **`DecisionList`** — lista reutilizada nas 3 abas (eram idênticas exceto ícone/mensagem do empty state).
- **`DecisionCard`** — card de decisão (score, evidências, ações, métricas expandidas).
- **`EvidenceItem`** — item de evidência.
- **`types.ts`** / **`config.ts`** (`actionIcons`/`actionLabels`/`confidenceBadge`).
- **+13 testes** (config + presentacionais).

## Verificação
- `bunx tsc --noEmit` (baseline) = **0**
- `eslint` = **0 erros / 0 warnings**
- **13/13 testes** verdes (isolados)
- Revisão independente FIEL 1:1: **aprovada** (ordem de hooks/queries/predicados de filtro/dedup das 3 abas conferidos)

## Migrations
Nenhuma.

🤖 Generated with [Claude Code](https://claude.com/claude-code)