### PR TITLE
fix(financeiro regime): hook compila no postgrest-js do Lovable (TS2589/TS2352)

### DIFF
--- a/src/hooks/useRegimeTributario.ts
+++ b/src/hooks/useRegimeTributario.ts
@@ -1,7 +1,6 @@
 // src/hooks/useRegimeTributario.ts
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
-import type { Json } from '@/integrations/supabase/types';
 import type { RegimeTributarioResult, RegimeInputs } from '@/services/financeiroService';
 
 export function useRegimeTributario() {
@@ -19,12 +18,22 @@ export function useUpdateRegimeInputs() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: async ({ company, regime_inputs }: { company: string; regime_inputs: RegimeInputs }) => {
-      // Tabela master-only dedicada (RLS exige role 'master'). upsert cobre o caso de a linha
-      // de seed não existir. O form é pré-preenchido com os inputs atuais, então o replace é seguro.
-      // `fin_regime_inputs` ainda não está no types.ts gerado (tabela nova, migration pendente de
-      // apply), então usamos o cast pattern já adotado no repo para tabelas fora dos tipos gerados.
-      const { error } = await (supabase.from('fin_regime_inputs') as ReturnType<typeof supabase.from>).upsert(
-        { company, regime_inputs: regime_inputs as unknown as Json, updated_at: new Date().toISOString() },
+      // Tabela master-only dedicada (RLS exige role 'master'). upsert cobre o caso de a linha de seed
+      // não existir; o form é pré-preenchido com os inputs atuais, então o replace é seguro.
+      // `fin_regime_inputs` é nova e ainda não está no types.ts gerado — e a versão de postgrest-js do
+      // dev-server do Lovable difere da do repo. O cast `as ReturnType<typeof supabase.from>` estourava
+      // TS2589 (deep instantiation) / TS2352 no postgrest-js novo. Acessamos por um shape MÍNIMO do
+      // client (cast através de `unknown`, sem `any`): independe da versão e de a tabela estar nos tipos.
+      const client = supabase as unknown as {
+        from: (table: string) => {
+          upsert: (
+            values: Record<string, unknown>,
+            options: { onConflict: string },
+          ) => Promise<{ error: { message: string } | null }>;
+        };
+      };
+      const { error } = await client.from('fin_regime_inputs').upsert(
+        { company, regime_inputs, updated_at: new Date().toISOString() },
         { onConflict: 'company' },
       );
       if (error) throw error;


### PR DESCRIPTION
Hotfix de build: o cast `as ReturnType<typeof supabase.from>` no useUpdateRegimeInputs estourava no postgrest-js do dev-server do Lovable (14.1 vs 2.95.3 do repo — por isso passou local+CI). Troca por shape mínimo do client via `unknown`, sem `any`. tsc+lint limpos.