### PR TITLE
refactor(sku): split AdminSkuMapeamento (503→100) em hook + componentes

### DIFF
--- a/src/components/skuMapeamento/MapeamentoFiltros.tsx
+++ b/src/components/skuMapeamento/MapeamentoFiltros.tsx
@@ -1,0 +1,73 @@
+// Card de filtros do Mapeamento SKU (empresa/fornecedor/status/busca).
+// Extraído verbatim de src/pages/AdminSkuMapeamento.tsx (god-component split).
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Search } from 'lucide-react';
+
+interface MapeamentoFiltrosProps {
+  filtroEmpresa: string;
+  onFiltroEmpresaChange: (v: string) => void;
+  filtroFornecedor: string;
+  onFiltroFornecedorChange: (v: string) => void;
+  filtroAtivo: string;
+  onFiltroAtivoChange: (v: string) => void;
+  busca: string;
+  onBuscaChange: (v: string) => void;
+  empresas: string[];
+  fornecedores: string[];
+}
+
+export function MapeamentoFiltros({
+  filtroEmpresa,
+  onFiltroEmpresaChange,
+  filtroFornecedor,
+  onFiltroFornecedorChange,
+  filtroAtivo,
+  onFiltroAtivoChange,
+  busca,
+  onBuscaChange,
+  empresas,
+  fornecedores,
+}: MapeamentoFiltrosProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Filtros</CardTitle>
+      </CardHeader>
+      <CardContent className="grid grid-cols-1 md:grid-cols-4 gap-3">
+        <Select value={filtroEmpresa} onValueChange={onFiltroEmpresaChange}>
+          <SelectTrigger><SelectValue placeholder="Empresa" /></SelectTrigger>
+          <SelectContent>
+            <SelectItem value="__all__">Todas as empresas</SelectItem>
+            {empresas.map((e) => <SelectItem key={e} value={e}>{e}</SelectItem>)}
+          </SelectContent>
+        </Select>
+        <Select value={filtroFornecedor} onValueChange={onFiltroFornecedorChange}>
+          <SelectTrigger><SelectValue placeholder="Fornecedor" /></SelectTrigger>
+          <SelectContent>
+            <SelectItem value="__all__">Todos os fornecedores</SelectItem>
+            {fornecedores.map((f) => <SelectItem key={f} value={f}>{f}</SelectItem>)}
+          </SelectContent>
+        </Select>
+        <Select value={filtroAtivo} onValueChange={onFiltroAtivoChange}>
+          <SelectTrigger><SelectValue placeholder="Status" /></SelectTrigger>
+          <SelectContent>
+            <SelectItem value="__all__">Todos</SelectItem>
+            <SelectItem value="ativos">Apenas ativos</SelectItem>
+            <SelectItem value="inativos">Apenas inativos</SelectItem>
+          </SelectContent>
+        </Select>
+        <div className="relative">
+          <Search className="h-4 w-4 absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            placeholder="Buscar SKU ou descrição"
+            value={busca}
+            onChange={(e) => onBuscaChange(e.target.value)}
+            className="pl-9"
+          />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/skuMapeamento/MapeamentoFormDialog.tsx
+++ b/src/components/skuMapeamento/MapeamentoFormDialog.tsx
@@ -1,0 +1,94 @@
+// Dialog de adicionar/editar mapeamento SKU.
+// Extraído verbatim de src/pages/AdminSkuMapeamento.tsx (god-component split).
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { Switch } from '@/components/ui/switch';
+import { Loader2 } from 'lucide-react';
+import type { SkuMapForm } from './config';
+
+interface MapeamentoFormDialogProps {
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+  isEditing: boolean;
+  form: SkuMapForm;
+  setForm: React.Dispatch<React.SetStateAction<SkuMapForm>>;
+  onCancel: () => void;
+  onSave: () => void;
+  isSaving: boolean;
+}
+
+export function MapeamentoFormDialog({
+  open,
+  onOpenChange,
+  isEditing,
+  form,
+  setForm,
+  onCancel,
+  onSave,
+  isSaving,
+}: MapeamentoFormDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>{isEditing ? 'Editar mapeamento' : 'Novo mapeamento'}</DialogTitle>
+          <DialogDescription>
+            Liga um código Omie ao código equivalente no portal do fornecedor.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <Label>Empresa</Label>
+            <Input value={form.empresa} onChange={(e) => setForm({ ...form, empresa: e.target.value.toUpperCase() })} />
+          </div>
+          <div>
+            <Label>Fornecedor</Label>
+            <Input value={form.fornecedor_nome} onChange={(e) => setForm({ ...form, fornecedor_nome: e.target.value })} />
+          </div>
+          <div>
+            <Label>SKU Omie</Label>
+            <Input value={form.sku_omie} onChange={(e) => setForm({ ...form, sku_omie: e.target.value })} disabled={isEditing} />
+          </div>
+          <div>
+            <Label>SKU Portal</Label>
+            <Input value={form.sku_portal} onChange={(e) => setForm({ ...form, sku_portal: e.target.value })} />
+          </div>
+          <div>
+            <Label>Unidade Portal</Label>
+            <Input value={form.unidade_portal} onChange={(e) => setForm({ ...form, unidade_portal: e.target.value.toUpperCase() })} />
+          </div>
+          <div>
+            <Label>Fator de conversão</Label>
+            <Input
+              type="number"
+              step="0.0001"
+              value={form.fator_conversao}
+              onChange={(e) => setForm({ ...form, fator_conversao: Number(e.target.value) })}
+            />
+          </div>
+          <div className="col-span-2 flex items-center gap-2">
+            <Switch checked={form.ativo} onCheckedChange={(v) => setForm({ ...form, ativo: v })} />
+            <Label>Ativo</Label>
+          </div>
+          <div className="col-span-2">
+            <Label>Observações</Label>
+            <Textarea value={form.observacoes} onChange={(e) => setForm({ ...form, observacoes: e.target.value })} rows={2} />
+          </div>
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={onCancel}>Cancelar</Button>
+          <Button
+            onClick={onSave}
+            disabled={isSaving || !form.empresa || !form.fornecedor_nome || !form.sku_omie}
+          >
+            {isSaving && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
+            Salvar
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/skuMapeamento/MapeamentosTable.tsx
+++ b/src/components/skuMapeamento/MapeamentosTable.tsx
@@ -1,0 +1,91 @@
+// Card + tabela de mapeamentos SKU.
+// Extraído verbatim de src/pages/AdminSkuMapeamento.tsx (god-component split).
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { Loader2 } from 'lucide-react';
+import type { Mapeamento } from './types';
+
+interface MapeamentosTableProps {
+  isLoading: boolean;
+  filtrados: Mapeamento[];
+  totalCount: number;
+  descricoes: Map<string, string> | undefined;
+  onEdit: (m: Mapeamento) => void;
+}
+
+export function MapeamentosTable({ isLoading, filtrados, totalCount, descricoes, onEdit }: MapeamentosTableProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Mapeamentos</CardTitle>
+        <CardDescription>{filtrados.length} de {totalCount} registros</CardDescription>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <div className="flex items-center justify-center py-10">
+            <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+          </div>
+        ) : (
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Empresa</TableHead>
+                  <TableHead>Fornecedor</TableHead>
+                  <TableHead>SKU Omie</TableHead>
+                  <TableHead>Descrição</TableHead>
+                  <TableHead>SKU Portal</TableHead>
+                  <TableHead>Unid.</TableHead>
+                  <TableHead>Fator</TableHead>
+                  <TableHead>Ativo</TableHead>
+                  <TableHead>Observações</TableHead>
+                  <TableHead></TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {filtrados.map((m) => {
+                  const desc = descricoes?.get(m.sku_omie);
+                  return (
+                    <TableRow key={m.id}>
+                      <TableCell><Badge variant="outline">{m.empresa}</Badge></TableCell>
+                      <TableCell className="text-xs">{m.fornecedor_nome}</TableCell>
+                      <TableCell className="font-mono text-xs">{m.sku_omie}</TableCell>
+                      <TableCell className="text-xs max-w-[260px] truncate" title={desc ?? ''}>{desc ?? '—'}</TableCell>
+                      <TableCell className="font-mono text-xs">
+                        {m.sku_portal
+                          ? <span>{m.sku_portal}</span>
+                          : <Badge variant="destructive">vazio</Badge>}
+                      </TableCell>
+                      <TableCell>{m.unidade_portal}</TableCell>
+                      <TableCell>{Number(m.fator_conversao)}</TableCell>
+                      <TableCell>
+                        {m.ativo
+                          ? <Badge className="bg-status-success">Ativo</Badge>
+                          : <Badge variant="secondary">Inativo</Badge>}
+                      </TableCell>
+                      <TableCell className="text-xs max-w-[220px] truncate" title={m.observacoes ?? ''}>
+                        {m.observacoes ?? '—'}
+                      </TableCell>
+                      <TableCell>
+                        <Button size="sm" variant="ghost" onClick={() => onEdit(m)}>Editar</Button>
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+                {filtrados.length === 0 && (
+                  <TableRow>
+                    <TableCell colSpan={10} className="text-center text-muted-foreground py-10">
+                      Nenhum mapeamento encontrado.
+                    </TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/skuMapeamento/ValidacaoDialog.tsx
+++ b/src/components/skuMapeamento/ValidacaoDialog.tsx
@@ -1,0 +1,88 @@
+// Dialog de validação dos mapeamentos SKU.
+// Extraído verbatim de src/pages/AdminSkuMapeamento.tsx (god-component split).
+import { Card, CardContent } from '@/components/ui/card';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { AlertTriangle, CheckCircle2, Loader2 } from 'lucide-react';
+import type { ValidacaoResult } from './types';
+
+interface ValidacaoDialogProps {
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+  validando: boolean;
+  validacao: ValidacaoResult | null;
+}
+
+export function ValidacaoDialog({ open, onOpenChange, validando, validacao }: ValidacaoDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Validação dos mapeamentos</DialogTitle>
+          <DialogDescription>
+            Confere se todos os SKUs usados em pedidos Sayerlack OBEN têm correspondência no portal.
+          </DialogDescription>
+        </DialogHeader>
+        {validando || !validacao ? (
+          <div className="flex items-center justify-center py-10">
+            <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+          </div>
+        ) : (
+          <div className="space-y-4">
+            <div className="grid grid-cols-3 gap-3">
+              <Card><CardContent className="pt-4">
+                <div className="text-xs text-muted-foreground">Total</div>
+                <div className="text-2xl font-bold">{validacao.total}</div>
+              </CardContent></Card>
+              <Card><CardContent className="pt-4">
+                <div className="text-xs text-muted-foreground">Auto</div>
+                <div className="text-2xl font-bold">{validacao.automaticos}</div>
+              </CardContent></Card>
+              <Card><CardContent className="pt-4">
+                <div className="text-xs text-muted-foreground">Manual</div>
+                <div className="text-2xl font-bold">{validacao.manuais}</div>
+              </CardContent></Card>
+            </div>
+
+            {validacao.faltantes.length > 0 ? (
+              <Alert variant="destructive">
+                <AlertTriangle className="h-4 w-4" />
+                <AlertTitle>{validacao.faltantes.length} SKU(s) sem mapeamento</AlertTitle>
+                <AlertDescription>
+                  <div className="max-h-48 overflow-y-auto mt-2 space-y-1 text-xs">
+                    {validacao.faltantes.map((f) => (
+                      <div key={f.sku_codigo_omie} className="font-mono">
+                        {f.sku_codigo_omie} — {f.sku_descricao}
+                      </div>
+                    ))}
+                  </div>
+                </AlertDescription>
+              </Alert>
+            ) : (
+              <Alert>
+                <CheckCircle2 className="h-4 w-4" />
+                <AlertTitle>Todos os SKUs do histórico estão mapeados</AlertTitle>
+              </Alert>
+            )}
+
+            {validacao.suspeitos.length > 0 && (
+              <Alert>
+                <AlertTriangle className="h-4 w-4" />
+                <AlertTitle>{validacao.suspeitos.length} mapeamento(s) com SKU portal suspeito</AlertTitle>
+                <AlertDescription>
+                  <div className="max-h-32 overflow-y-auto mt-2 space-y-1 text-xs">
+                    {validacao.suspeitos.map((s) => (
+                      <div key={s.id} className="font-mono">
+                        {s.sku_omie} → {s.sku_portal ?? '(vazio)'}
+                      </div>
+                    ))}
+                  </div>
+                </AlertDescription>
+              </Alert>
+            )}
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/skuMapeamento/__tests__/MapeamentoFiltros.test.tsx
+++ b/src/components/skuMapeamento/__tests__/MapeamentoFiltros.test.tsx
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MapeamentoFiltros } from "../MapeamentoFiltros";
+
+function setup(overrides: Partial<React.ComponentProps<typeof MapeamentoFiltros>> = {}) {
+  const props: React.ComponentProps<typeof MapeamentoFiltros> = {
+    filtroEmpresa: "__all__",
+    onFiltroEmpresaChange: vi.fn(),
+    filtroFornecedor: "__all__",
+    onFiltroFornecedorChange: vi.fn(),
+    filtroAtivo: "__all__",
+    onFiltroAtivoChange: vi.fn(),
+    busca: "",
+    onBuscaChange: vi.fn(),
+    empresas: ["OBEN"],
+    fornecedores: ["RENNER SAYERLACK S/A"],
+    ...overrides,
+  };
+  render(<MapeamentoFiltros {...props} />);
+  return props;
+}
+
+describe("MapeamentoFiltros", () => {
+  it("renderiza o card e o campo de busca", () => {
+    setup();
+    expect(screen.getByText("Filtros")).toBeTruthy();
+    expect(screen.getByPlaceholderText("Buscar SKU ou descrição")).toBeTruthy();
+  });
+
+  it("dispara onBuscaChange ao digitar", () => {
+    const props = setup();
+    fireEvent.change(screen.getByPlaceholderText("Buscar SKU ou descrição"), { target: { value: "verniz" } });
+    expect(props.onBuscaChange).toHaveBeenCalledWith("verniz");
+  });
+});

--- a/src/components/skuMapeamento/__tests__/MapeamentoFormDialog.test.tsx
+++ b/src/components/skuMapeamento/__tests__/MapeamentoFormDialog.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MapeamentoFormDialog } from "../MapeamentoFormDialog";
+import { EMPTY_FORM } from "../config";
+
+function setup(overrides: Partial<React.ComponentProps<typeof MapeamentoFormDialog>> = {}) {
+  const props: React.ComponentProps<typeof MapeamentoFormDialog> = {
+    open: true,
+    onOpenChange: vi.fn(),
+    isEditing: false,
+    form: EMPTY_FORM,
+    setForm: vi.fn(),
+    onCancel: vi.fn(),
+    onSave: vi.fn(),
+    isSaving: false,
+    ...overrides,
+  };
+  render(<MapeamentoFormDialog {...props} />);
+  return props;
+}
+
+describe("MapeamentoFormDialog", () => {
+  it("título Novo quando não editando; SKU Omie habilitado", () => {
+    setup();
+    expect(screen.getByText("Novo mapeamento")).toBeTruthy();
+  });
+
+  it("título Editar quando editando", () => {
+    setup({ isEditing: true });
+    expect(screen.getByText("Editar mapeamento")).toBeTruthy();
+  });
+
+  it("Salvar desabilitado sem sku_omie (EMPTY_FORM)", () => {
+    setup();
+    expect(screen.getByRole("button", { name: "Salvar" })).toHaveProperty("disabled", true);
+  });
+
+  it("Salvar habilitado e dispara onSave quando form completo", () => {
+    const props = setup({ form: { ...EMPTY_FORM, sku_omie: "111" } });
+    const btn = screen.getByRole("button", { name: "Salvar" });
+    expect(btn).toHaveProperty("disabled", false);
+    fireEvent.click(btn);
+    expect(props.onSave).toHaveBeenCalledTimes(1);
+  });
+
+  it("dispara onCancel e atualiza setForm ao digitar empresa", () => {
+    const props = setup();
+    fireEvent.click(screen.getByRole("button", { name: "Cancelar" }));
+    expect(props.onCancel).toHaveBeenCalledTimes(1);
+    const empresaInput = screen.getByDisplayValue("OBEN");
+    fireEvent.change(empresaInput, { target: { value: "colacor" } });
+    expect(props.setForm).toHaveBeenCalledWith(expect.objectContaining({ empresa: "COLACOR" }));
+  });
+});

--- a/src/components/skuMapeamento/__tests__/MapeamentosTable.test.tsx
+++ b/src/components/skuMapeamento/__tests__/MapeamentosTable.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MapeamentosTable } from "../MapeamentosTable";
+import type { Mapeamento } from "../types";
+
+function makeMap(o: Partial<Mapeamento> = {}): Mapeamento {
+  return {
+    id: 1,
+    empresa: "OBEN",
+    fornecedor_nome: "RENNER SAYERLACK S/A",
+    sku_omie: "111",
+    sku_portal: "ABC123",
+    unidade_portal: "UN",
+    fator_conversao: 1,
+    ativo: true,
+    observacoes: null,
+    criado_em: "",
+    atualizado_em: "",
+    ...o,
+  };
+}
+
+const descricoes = new Map<string, string>([["111", "Verniz"]]);
+
+describe("MapeamentosTable", () => {
+  it("mostra loader durante carregamento", () => {
+    const { container } = render(
+      <MapeamentosTable isLoading filtrados={[]} totalCount={0} descricoes={descricoes} onEdit={vi.fn()} />,
+    );
+    expect(container.querySelector(".animate-spin")).toBeTruthy();
+  });
+
+  it("renderiza linha com descrição e dispara onEdit", () => {
+    const onEdit = vi.fn();
+    render(
+      <MapeamentosTable isLoading={false} filtrados={[makeMap()]} totalCount={5} descricoes={descricoes} onEdit={onEdit} />,
+    );
+    expect(screen.getByText("111")).toBeTruthy();
+    expect(screen.getByText("Verniz")).toBeTruthy();
+    expect(screen.getByText("ABC123")).toBeTruthy();
+    expect(screen.getAllByText("Ativo").length).toBeGreaterThanOrEqual(2); // header da coluna + badge da linha
+    expect(screen.getByText("1 de 5 registros")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Editar" }));
+    expect(onEdit).toHaveBeenCalledWith(expect.objectContaining({ id: 1 }));
+  });
+
+  it("mostra badge vazio quando sku_portal é null", () => {
+    render(
+      <MapeamentosTable isLoading={false} filtrados={[makeMap({ sku_portal: null })]} totalCount={1} descricoes={descricoes} onEdit={vi.fn()} />,
+    );
+    expect(screen.getByText("vazio")).toBeTruthy();
+  });
+
+  it("mostra empty state sem mapeamentos", () => {
+    render(
+      <MapeamentosTable isLoading={false} filtrados={[]} totalCount={0} descricoes={descricoes} onEdit={vi.fn()} />,
+    );
+    expect(screen.getByText("Nenhum mapeamento encontrado.")).toBeTruthy();
+  });
+});

--- a/src/components/skuMapeamento/__tests__/ValidacaoDialog.test.tsx
+++ b/src/components/skuMapeamento/__tests__/ValidacaoDialog.test.tsx
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ValidacaoDialog } from "../ValidacaoDialog";
+import type { ValidacaoResult } from "../types";
+
+describe("ValidacaoDialog", () => {
+  it("mostra loader enquanto valida", () => {
+    // O conteúdo do Dialog (Radix) é renderizado em portal no document.body.
+    render(<ValidacaoDialog open onOpenChange={vi.fn()} validando validacao={null} />);
+    expect(document.querySelector(".animate-spin")).toBeTruthy();
+  });
+
+  it("mostra faltantes e KPIs", () => {
+    const validacao: ValidacaoResult = {
+      faltantes: [{ empresa: "OBEN", fornecedor_nome: "RENNER", sku_codigo_omie: "999", sku_descricao: "Cola" }],
+      suspeitos: [],
+      total: 5,
+      automaticos: 2,
+      manuais: 3,
+    };
+    render(<ValidacaoDialog open onOpenChange={vi.fn()} validando={false} validacao={validacao} />);
+    expect(screen.getByText("1 SKU(s) sem mapeamento")).toBeTruthy();
+    expect(screen.getByText(/999 — Cola/)).toBeTruthy();
+    expect(screen.getByText("5")).toBeTruthy();
+  });
+
+  it("mostra sucesso quando não há faltantes", () => {
+    const validacao: ValidacaoResult = { faltantes: [], suspeitos: [], total: 5, automaticos: 5, manuais: 0 };
+    render(<ValidacaoDialog open onOpenChange={vi.fn()} validando={false} validacao={validacao} />);
+    expect(screen.getByText("Todos os SKUs do histórico estão mapeados")).toBeTruthy();
+  });
+});

--- a/src/components/skuMapeamento/config.ts
+++ b/src/components/skuMapeamento/config.ts
@@ -1,0 +1,15 @@
+// Estado inicial do formulário de mapeamento SKU.
+// Extraído verbatim de src/pages/AdminSkuMapeamento.tsx (god-component split).
+
+export const EMPTY_FORM = {
+  empresa: 'OBEN',
+  fornecedor_nome: 'RENNER SAYERLACK S/A',
+  sku_omie: '',
+  sku_portal: '',
+  unidade_portal: 'UN',
+  fator_conversao: 1,
+  ativo: true,
+  observacoes: '',
+};
+
+export type SkuMapForm = typeof EMPTY_FORM;

--- a/src/components/skuMapeamento/types.ts
+++ b/src/components/skuMapeamento/types.ts
@@ -1,0 +1,29 @@
+// Tipos do Mapeamento SKU.
+// Extraídos verbatim de src/pages/AdminSkuMapeamento.tsx (god-component split).
+
+export interface Mapeamento {
+  id: number;
+  empresa: string;
+  fornecedor_nome: string;
+  sku_omie: string;
+  sku_portal: string | null;
+  unidade_portal: string;
+  fator_conversao: number;
+  ativo: boolean;
+  observacoes: string | null;
+  criado_em: string;
+  atualizado_em: string;
+}
+
+export interface DescricaoLookup {
+  sku_codigo_omie: string;
+  sku_descricao: string;
+}
+
+export interface ValidacaoResult {
+  faltantes: { empresa: string; fornecedor_nome: string; sku_codigo_omie: string; sku_descricao: string }[];
+  suspeitos: Mapeamento[];
+  total: number;
+  automaticos: number;
+  manuais: number;
+}

--- a/src/components/skuMapeamento/useSkuMapeamento.ts
+++ b/src/components/skuMapeamento/useSkuMapeamento.ts
@@ -1,0 +1,226 @@
+// Hook de dados/estado do Mapeamento SKU.
+// Extraído verbatim de src/pages/AdminSkuMapeamento.tsx (god-component split):
+// 2 queries (mapeamentos + descrições), memos de filtro, upsert e validação.
+import { useMemo, useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import { toast } from 'sonner';
+import { EMPTY_FORM } from './config';
+import type { Mapeamento, DescricaoLookup, ValidacaoResult } from './types';
+
+export function useSkuMapeamento() {
+  const qc = useQueryClient();
+  const [filtroEmpresa, setFiltroEmpresa] = useState<string>('__all__');
+  const [filtroFornecedor, setFiltroFornecedor] = useState<string>('__all__');
+  const [filtroAtivo, setFiltroAtivo] = useState<string>('__all__');
+  const [busca, setBusca] = useState('');
+  const [openAdd, setOpenAdd] = useState(false);
+  const [openValidar, setOpenValidar] = useState(false);
+  const [editing, setEditing] = useState<Mapeamento | null>(null);
+  const [form, setForm] = useState(EMPTY_FORM);
+  const [validacao, setValidacao] = useState<ValidacaoResult | null>(null);
+  const [validando, setValidando] = useState(false);
+
+  const { data: mapeamentos, isLoading } = useQuery({
+    queryKey: ['sku-mapeamento'],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from('sku_fornecedor_externo')
+        .select('*')
+        .order('empresa')
+        .order('fornecedor_nome')
+        .order('sku_omie');
+      if (error) throw error;
+      return data as Mapeamento[];
+    },
+  });
+
+  // Lookup de descrições do Omie a partir de pedido_compra_item (último valor visto)
+  const skusOmie = useMemo(() => (mapeamentos ?? []).map((m) => m.sku_omie), [mapeamentos]);
+
+  const { data: descricoes } = useQuery({
+    queryKey: ['sku-descricoes', skusOmie],
+    enabled: skusOmie.length > 0,
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from('pedido_compra_item')
+        .select('sku_codigo_omie, sku_descricao')
+        .in('sku_codigo_omie', skusOmie);
+      if (error) throw error;
+      const map = new Map<string, string>();
+      (data as DescricaoLookup[]).forEach((d) => {
+        if (!map.has(d.sku_codigo_omie) && d.sku_descricao) {
+          map.set(d.sku_codigo_omie, d.sku_descricao);
+        }
+      });
+      return map;
+    },
+  });
+
+  const empresas = useMemo(
+    () => Array.from(new Set((mapeamentos ?? []).map((m) => m.empresa))).sort(),
+    [mapeamentos],
+  );
+  const fornecedores = useMemo(
+    () => Array.from(new Set((mapeamentos ?? []).map((m) => m.fornecedor_nome))).sort(),
+    [mapeamentos],
+  );
+
+  const filtrados = useMemo(() => {
+    return (mapeamentos ?? []).filter((m) => {
+      if (filtroEmpresa !== '__all__' && m.empresa !== filtroEmpresa) return false;
+      if (filtroFornecedor !== '__all__' && m.fornecedor_nome !== filtroFornecedor) return false;
+      if (filtroAtivo === 'ativos' && !m.ativo) return false;
+      if (filtroAtivo === 'inativos' && m.ativo) return false;
+      if (busca.trim()) {
+        const t = busca.trim().toLowerCase();
+        const desc = descricoes?.get(m.sku_omie) ?? '';
+        return (
+          m.sku_omie.toLowerCase().includes(t) ||
+          (m.sku_portal ?? '').toLowerCase().includes(t) ||
+          desc.toLowerCase().includes(t)
+        );
+      }
+      return true;
+    });
+  }, [mapeamentos, filtroEmpresa, filtroFornecedor, filtroAtivo, busca, descricoes]);
+
+  const upsertMut = useMutation({
+    mutationFn: async (payload: typeof EMPTY_FORM & { id?: number }) => {
+      const { id, ...rest } = payload;
+      if (id) {
+        const { error } = await supabase
+          .from('sku_fornecedor_externo')
+          .update({ ...rest, atualizado_em: new Date().toISOString() })
+          .eq('id', id);
+        if (error) throw error;
+      } else {
+        const { error } = await supabase.from('sku_fornecedor_externo').insert(rest);
+        if (error) throw error;
+      }
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['sku-mapeamento'] });
+      toast.success(editing ? 'Mapeamento atualizado' : 'Mapeamento criado');
+      setOpenAdd(false);
+      setEditing(null);
+      setForm(EMPTY_FORM);
+    },
+    onError: (e: Error) => toast.error(e.message ?? 'Erro ao salvar'),
+  });
+
+  const handleEdit = (m: Mapeamento) => {
+    setEditing(m);
+    setForm({
+      empresa: m.empresa,
+      fornecedor_nome: m.fornecedor_nome,
+      sku_omie: m.sku_omie,
+      sku_portal: m.sku_portal ?? '',
+      unidade_portal: m.unidade_portal,
+      fator_conversao: Number(m.fator_conversao),
+      ativo: m.ativo,
+      observacoes: m.observacoes ?? '',
+    });
+    setOpenAdd(true);
+  };
+
+  const handleNovo = () => {
+    setEditing(null);
+    setForm(EMPTY_FORM);
+    setOpenAdd(true);
+  };
+
+  const handleValidar = async () => {
+    setValidando(true);
+    setOpenValidar(true);
+    try {
+      // SKUs em pedidos Sayerlack OBEN sem mapeamento ativo
+      const { data: itens, error: e1 } = await supabase
+        .from('pedido_compra_item')
+        .select('sku_codigo_omie, sku_descricao, pedido_id, pedido_compra_sugerido!inner(empresa, fornecedor_nome)')
+        .ilike('pedido_compra_sugerido.fornecedor_nome', '%SAYERLACK%')
+        .eq('pedido_compra_sugerido.empresa', 'OBEN');
+      if (e1) throw e1;
+
+      const skusUnicos = new Map<string, string>();
+      (itens as Array<{ sku_codigo_omie: string; sku_descricao: string }> | null)?.forEach((i) => {
+        if (!skusUnicos.has(i.sku_codigo_omie)) skusUnicos.set(i.sku_codigo_omie, i.sku_descricao);
+      });
+
+      const mapAtivos = new Set(
+        (mapeamentos ?? [])
+          .filter((m) => m.ativo && m.empresa === 'OBEN' && /SAYERLACK/i.test(m.fornecedor_nome))
+          .map((m) => m.sku_omie),
+      );
+
+      const faltantes: ValidacaoResult['faltantes'] = [];
+      skusUnicos.forEach((desc, sku) => {
+        if (!mapAtivos.has(sku)) {
+          faltantes.push({
+            empresa: 'OBEN',
+            fornecedor_nome: 'RENNER SAYERLACK S/A',
+            sku_codigo_omie: sku,
+            sku_descricao: desc,
+          });
+        }
+      });
+
+      const suspeitos = (mapeamentos ?? []).filter(
+        (m) =>
+          (m.sku_portal ?? '').trim() === '' ||
+          (m.sku_portal ?? '').length < 4 ||
+          !/[A-Z]/i.test(m.sku_portal ?? ''),
+      );
+
+      const automaticos = (mapeamentos ?? []).filter((m) =>
+        (m.observacoes ?? '').toLowerCase().includes('extraído automaticamente'),
+      ).length;
+      const manuais = (mapeamentos ?? []).length - automaticos;
+
+      setValidacao({
+        faltantes,
+        suspeitos,
+        total: mapeamentos?.length ?? 0,
+        automaticos,
+        manuais,
+      });
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'Erro ao validar');
+    } finally {
+      setValidando(false);
+    }
+  };
+
+  const handleOpenAddChange = (v: boolean) => {
+    setOpenAdd(v);
+    if (!v) { setEditing(null); setForm(EMPTY_FORM); }
+  };
+
+  return {
+    // filtros
+    filtroEmpresa, setFiltroEmpresa,
+    filtroFornecedor, setFiltroFornecedor,
+    filtroAtivo, setFiltroAtivo,
+    busca, setBusca,
+    empresas, fornecedores,
+    // dados
+    mapeamentos,
+    isLoading,
+    descricoes,
+    filtrados,
+    // add/edit
+    openAdd,
+    handleOpenAddChange,
+    closeAdd: () => setOpenAdd(false),
+    isEditing: !!editing,
+    form, setForm,
+    save: () => upsertMut.mutate({ ...form, id: editing?.id }),
+    isSaving: upsertMut.isPending,
+    handleEdit,
+    handleNovo,
+    // validar
+    openValidar, setOpenValidar,
+    validando, validacao,
+    handleValidar,
+  };
+}

--- a/src/pages/AdminSkuMapeamento.tsx
+++ b/src/pages/AdminSkuMapeamento.tsx
@@ -1,240 +1,38 @@
-import { useMemo, useState } from 'react';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { supabase } from '@/integrations/supabase/client';
+// Mapeamento SKU — liga código interno (Omie) ao código comercial dos portais.
+// Composição: useSkuMapeamento (queries/upsert/validação) + filtros + tabela + dialogs.
+// God-component split de src/pages/AdminSkuMapeamento.tsx (comportamento 1:1).
 import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
-import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import { Textarea } from '@/components/ui/textarea';
-import { Switch } from '@/components/ui/switch';
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
-import { AlertTriangle, CheckCircle2, Loader2, Plus, Search, ShieldQuestion } from 'lucide-react';
-import { toast } from 'sonner';
-
-interface Mapeamento {
-  id: number;
-  empresa: string;
-  fornecedor_nome: string;
-  sku_omie: string;
-  sku_portal: string | null;
-  unidade_portal: string;
-  fator_conversao: number;
-  ativo: boolean;
-  observacoes: string | null;
-  criado_em: string;
-  atualizado_em: string;
-}
-
-interface DescricaoLookup {
-  sku_codigo_omie: string;
-  sku_descricao: string;
-}
-
-interface ValidacaoResult {
-  faltantes: { empresa: string; fornecedor_nome: string; sku_codigo_omie: string; sku_descricao: string }[];
-  suspeitos: Mapeamento[];
-  total: number;
-  automaticos: number;
-  manuais: number;
-}
-
-const EMPTY_FORM = {
-  empresa: 'OBEN',
-  fornecedor_nome: 'RENNER SAYERLACK S/A',
-  sku_omie: '',
-  sku_portal: '',
-  unidade_portal: 'UN',
-  fator_conversao: 1,
-  ativo: true,
-  observacoes: '',
-};
+import { Plus, ShieldQuestion } from 'lucide-react';
+import { useSkuMapeamento } from '@/components/skuMapeamento/useSkuMapeamento';
+import { MapeamentoFiltros } from '@/components/skuMapeamento/MapeamentoFiltros';
+import { MapeamentosTable } from '@/components/skuMapeamento/MapeamentosTable';
+import { MapeamentoFormDialog } from '@/components/skuMapeamento/MapeamentoFormDialog';
+import { ValidacaoDialog } from '@/components/skuMapeamento/ValidacaoDialog';
 
 export default function AdminSkuMapeamento() {
-  const qc = useQueryClient();
-  const [filtroEmpresa, setFiltroEmpresa] = useState<string>('__all__');
-  const [filtroFornecedor, setFiltroFornecedor] = useState<string>('__all__');
-  const [filtroAtivo, setFiltroAtivo] = useState<string>('__all__');
-  const [busca, setBusca] = useState('');
-  const [openAdd, setOpenAdd] = useState(false);
-  const [openValidar, setOpenValidar] = useState(false);
-  const [editing, setEditing] = useState<Mapeamento | null>(null);
-  const [form, setForm] = useState(EMPTY_FORM);
-  const [validacao, setValidacao] = useState<ValidacaoResult | null>(null);
-  const [validando, setValidando] = useState(false);
-
-  const { data: mapeamentos, isLoading } = useQuery({
-    queryKey: ['sku-mapeamento'],
-    queryFn: async () => {
-      const { data, error } = await supabase
-        .from('sku_fornecedor_externo')
-        .select('*')
-        .order('empresa')
-        .order('fornecedor_nome')
-        .order('sku_omie');
-      if (error) throw error;
-      return data as Mapeamento[];
-    },
-  });
-
-  // Lookup de descrições do Omie a partir de pedido_compra_item (último valor visto)
-  const skusOmie = useMemo(() => (mapeamentos ?? []).map((m) => m.sku_omie), [mapeamentos]);
-
-  const { data: descricoes } = useQuery({
-    queryKey: ['sku-descricoes', skusOmie],
-    enabled: skusOmie.length > 0,
-    queryFn: async () => {
-      const { data, error } = await supabase
-        .from('pedido_compra_item')
-        .select('sku_codigo_omie, sku_descricao')
-        .in('sku_codigo_omie', skusOmie);
-      if (error) throw error;
-      const map = new Map<string, string>();
-      (data as DescricaoLookup[]).forEach((d) => {
-        if (!map.has(d.sku_codigo_omie) && d.sku_descricao) {
-          map.set(d.sku_codigo_omie, d.sku_descricao);
-        }
-      });
-      return map;
-    },
-  });
-
-  const empresas = useMemo(
-    () => Array.from(new Set((mapeamentos ?? []).map((m) => m.empresa))).sort(),
-    [mapeamentos],
-  );
-  const fornecedores = useMemo(
-    () => Array.from(new Set((mapeamentos ?? []).map((m) => m.fornecedor_nome))).sort(),
-    [mapeamentos],
-  );
-
-  const filtrados = useMemo(() => {
-    return (mapeamentos ?? []).filter((m) => {
-      if (filtroEmpresa !== '__all__' && m.empresa !== filtroEmpresa) return false;
-      if (filtroFornecedor !== '__all__' && m.fornecedor_nome !== filtroFornecedor) return false;
-      if (filtroAtivo === 'ativos' && !m.ativo) return false;
-      if (filtroAtivo === 'inativos' && m.ativo) return false;
-      if (busca.trim()) {
-        const t = busca.trim().toLowerCase();
-        const desc = descricoes?.get(m.sku_omie) ?? '';
-        return (
-          m.sku_omie.toLowerCase().includes(t) ||
-          (m.sku_portal ?? '').toLowerCase().includes(t) ||
-          desc.toLowerCase().includes(t)
-        );
-      }
-      return true;
-    });
-  }, [mapeamentos, filtroEmpresa, filtroFornecedor, filtroAtivo, busca, descricoes]);
-
-  const upsertMut = useMutation({
-    mutationFn: async (payload: typeof EMPTY_FORM & { id?: number }) => {
-      const { id, ...rest } = payload;
-      if (id) {
-        const { error } = await supabase
-          .from('sku_fornecedor_externo')
-          .update({ ...rest, atualizado_em: new Date().toISOString() })
-          .eq('id', id);
-        if (error) throw error;
-      } else {
-        const { error } = await supabase.from('sku_fornecedor_externo').insert(rest);
-        if (error) throw error;
-      }
-    },
-    onSuccess: () => {
-      qc.invalidateQueries({ queryKey: ['sku-mapeamento'] });
-      toast.success(editing ? 'Mapeamento atualizado' : 'Mapeamento criado');
-      setOpenAdd(false);
-      setEditing(null);
-      setForm(EMPTY_FORM);
-    },
-    onError: (e: Error) => toast.error(e.message ?? 'Erro ao salvar'),
-  });
-
-  const handleEdit = (m: Mapeamento) => {
-    setEditing(m);
-    setForm({
-      empresa: m.empresa,
-      fornecedor_nome: m.fornecedor_nome,
-      sku_omie: m.sku_omie,
-      sku_portal: m.sku_portal ?? '',
-      unidade_portal: m.unidade_portal,
-      fator_conversao: Number(m.fator_conversao),
-      ativo: m.ativo,
-      observacoes: m.observacoes ?? '',
-    });
-    setOpenAdd(true);
-  };
-
-  const handleNovo = () => {
-    setEditing(null);
-    setForm(EMPTY_FORM);
-    setOpenAdd(true);
-  };
-
-  const handleValidar = async () => {
-    setValidando(true);
-    setOpenValidar(true);
-    try {
-      // SKUs em pedidos Sayerlack OBEN sem mapeamento ativo
-      const { data: itens, error: e1 } = await supabase
-        .from('pedido_compra_item')
-        .select('sku_codigo_omie, sku_descricao, pedido_id, pedido_compra_sugerido!inner(empresa, fornecedor_nome)')
-        .ilike('pedido_compra_sugerido.fornecedor_nome', '%SAYERLACK%')
-        .eq('pedido_compra_sugerido.empresa', 'OBEN');
-      if (e1) throw e1;
-
-      const skusUnicos = new Map<string, string>();
-      (itens as Array<{ sku_codigo_omie: string; sku_descricao: string }> | null)?.forEach((i) => {
-        if (!skusUnicos.has(i.sku_codigo_omie)) skusUnicos.set(i.sku_codigo_omie, i.sku_descricao);
-      });
-
-      const mapAtivos = new Set(
-        (mapeamentos ?? [])
-          .filter((m) => m.ativo && m.empresa === 'OBEN' && /SAYERLACK/i.test(m.fornecedor_nome))
-          .map((m) => m.sku_omie),
-      );
-
-      const faltantes: ValidacaoResult['faltantes'] = [];
-      skusUnicos.forEach((desc, sku) => {
-        if (!mapAtivos.has(sku)) {
-          faltantes.push({
-            empresa: 'OBEN',
-            fornecedor_nome: 'RENNER SAYERLACK S/A',
-            sku_codigo_omie: sku,
-            sku_descricao: desc,
-          });
-        }
-      });
-
-      const suspeitos = (mapeamentos ?? []).filter(
-        (m) =>
-          (m.sku_portal ?? '').trim() === '' ||
-          (m.sku_portal ?? '').length < 4 ||
-          !/[A-Z]/i.test(m.sku_portal ?? ''),
-      );
-
-      const automaticos = (mapeamentos ?? []).filter((m) =>
-        (m.observacoes ?? '').toLowerCase().includes('extraído automaticamente'),
-      ).length;
-      const manuais = (mapeamentos ?? []).length - automaticos;
-
-      setValidacao({
-        faltantes,
-        suspeitos,
-        total: mapeamentos?.length ?? 0,
-        automaticos,
-        manuais,
-      });
-    } catch (e) {
-      toast.error(e instanceof Error ? e.message : 'Erro ao validar');
-    } finally {
-      setValidando(false);
-    }
-  };
+  const {
+    filtroEmpresa, setFiltroEmpresa,
+    filtroFornecedor, setFiltroFornecedor,
+    filtroAtivo, setFiltroAtivo,
+    busca, setBusca,
+    empresas, fornecedores,
+    mapeamentos,
+    isLoading,
+    descricoes,
+    filtrados,
+    openAdd,
+    handleOpenAddChange,
+    closeAdd,
+    isEditing,
+    form, setForm,
+    save,
+    isSaving,
+    handleEdit,
+    handleNovo,
+    openValidar, setOpenValidar,
+    validando, validacao,
+    handleValidar,
+  } = useSkuMapeamento();
 
   return (
     <div className="container mx-auto py-6 space-y-6">
@@ -257,247 +55,46 @@ export default function AdminSkuMapeamento() {
         </div>
       </div>
 
-      <Card>
-        <CardHeader>
-          <CardTitle>Filtros</CardTitle>
-        </CardHeader>
-        <CardContent className="grid grid-cols-1 md:grid-cols-4 gap-3">
-          <Select value={filtroEmpresa} onValueChange={setFiltroEmpresa}>
-            <SelectTrigger><SelectValue placeholder="Empresa" /></SelectTrigger>
-            <SelectContent>
-              <SelectItem value="__all__">Todas as empresas</SelectItem>
-              {empresas.map((e) => <SelectItem key={e} value={e}>{e}</SelectItem>)}
-            </SelectContent>
-          </Select>
-          <Select value={filtroFornecedor} onValueChange={setFiltroFornecedor}>
-            <SelectTrigger><SelectValue placeholder="Fornecedor" /></SelectTrigger>
-            <SelectContent>
-              <SelectItem value="__all__">Todos os fornecedores</SelectItem>
-              {fornecedores.map((f) => <SelectItem key={f} value={f}>{f}</SelectItem>)}
-            </SelectContent>
-          </Select>
-          <Select value={filtroAtivo} onValueChange={setFiltroAtivo}>
-            <SelectTrigger><SelectValue placeholder="Status" /></SelectTrigger>
-            <SelectContent>
-              <SelectItem value="__all__">Todos</SelectItem>
-              <SelectItem value="ativos">Apenas ativos</SelectItem>
-              <SelectItem value="inativos">Apenas inativos</SelectItem>
-            </SelectContent>
-          </Select>
-          <div className="relative">
-            <Search className="h-4 w-4 absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground" />
-            <Input
-              placeholder="Buscar SKU ou descrição"
-              value={busca}
-              onChange={(e) => setBusca(e.target.value)}
-              className="pl-9"
-            />
-          </div>
-        </CardContent>
-      </Card>
+      <MapeamentoFiltros
+        filtroEmpresa={filtroEmpresa}
+        onFiltroEmpresaChange={setFiltroEmpresa}
+        filtroFornecedor={filtroFornecedor}
+        onFiltroFornecedorChange={setFiltroFornecedor}
+        filtroAtivo={filtroAtivo}
+        onFiltroAtivoChange={setFiltroAtivo}
+        busca={busca}
+        onBuscaChange={setBusca}
+        empresas={empresas}
+        fornecedores={fornecedores}
+      />
 
-      <Card>
-        <CardHeader>
-          <CardTitle>Mapeamentos</CardTitle>
-          <CardDescription>{filtrados.length} de {mapeamentos?.length ?? 0} registros</CardDescription>
-        </CardHeader>
-        <CardContent>
-          {isLoading ? (
-            <div className="flex items-center justify-center py-10">
-              <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
-            </div>
-          ) : (
-            <div className="overflow-x-auto">
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>Empresa</TableHead>
-                    <TableHead>Fornecedor</TableHead>
-                    <TableHead>SKU Omie</TableHead>
-                    <TableHead>Descrição</TableHead>
-                    <TableHead>SKU Portal</TableHead>
-                    <TableHead>Unid.</TableHead>
-                    <TableHead>Fator</TableHead>
-                    <TableHead>Ativo</TableHead>
-                    <TableHead>Observações</TableHead>
-                    <TableHead></TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {filtrados.map((m) => {
-                    const desc = descricoes?.get(m.sku_omie);
-                    return (
-                      <TableRow key={m.id}>
-                        <TableCell><Badge variant="outline">{m.empresa}</Badge></TableCell>
-                        <TableCell className="text-xs">{m.fornecedor_nome}</TableCell>
-                        <TableCell className="font-mono text-xs">{m.sku_omie}</TableCell>
-                        <TableCell className="text-xs max-w-[260px] truncate" title={desc ?? ''}>{desc ?? '—'}</TableCell>
-                        <TableCell className="font-mono text-xs">
-                          {m.sku_portal
-                            ? <span>{m.sku_portal}</span>
-                            : <Badge variant="destructive">vazio</Badge>}
-                        </TableCell>
-                        <TableCell>{m.unidade_portal}</TableCell>
-                        <TableCell>{Number(m.fator_conversao)}</TableCell>
-                        <TableCell>
-                          {m.ativo
-                            ? <Badge className="bg-status-success">Ativo</Badge>
-                            : <Badge variant="secondary">Inativo</Badge>}
-                        </TableCell>
-                        <TableCell className="text-xs max-w-[220px] truncate" title={m.observacoes ?? ''}>
-                          {m.observacoes ?? '—'}
-                        </TableCell>
-                        <TableCell>
-                          <Button size="sm" variant="ghost" onClick={() => handleEdit(m)}>Editar</Button>
-                        </TableCell>
-                      </TableRow>
-                    );
-                  })}
-                  {filtrados.length === 0 && (
-                    <TableRow>
-                      <TableCell colSpan={10} className="text-center text-muted-foreground py-10">
-                        Nenhum mapeamento encontrado.
-                      </TableCell>
-                    </TableRow>
-                  )}
-                </TableBody>
-              </Table>
-            </div>
-          )}
-        </CardContent>
-      </Card>
+      <MapeamentosTable
+        isLoading={isLoading}
+        filtrados={filtrados}
+        totalCount={mapeamentos?.length ?? 0}
+        descricoes={descricoes}
+        onEdit={handleEdit}
+      />
 
       {/* Add/Edit dialog */}
-      <Dialog open={openAdd} onOpenChange={(v) => { setOpenAdd(v); if (!v) { setEditing(null); setForm(EMPTY_FORM); } }}>
-        <DialogContent className="max-w-lg">
-          <DialogHeader>
-            <DialogTitle>{editing ? 'Editar mapeamento' : 'Novo mapeamento'}</DialogTitle>
-            <DialogDescription>
-              Liga um código Omie ao código equivalente no portal do fornecedor.
-            </DialogDescription>
-          </DialogHeader>
-          <div className="grid grid-cols-2 gap-3">
-            <div>
-              <Label>Empresa</Label>
-              <Input value={form.empresa} onChange={(e) => setForm({ ...form, empresa: e.target.value.toUpperCase() })} />
-            </div>
-            <div>
-              <Label>Fornecedor</Label>
-              <Input value={form.fornecedor_nome} onChange={(e) => setForm({ ...form, fornecedor_nome: e.target.value })} />
-            </div>
-            <div>
-              <Label>SKU Omie</Label>
-              <Input value={form.sku_omie} onChange={(e) => setForm({ ...form, sku_omie: e.target.value })} disabled={!!editing} />
-            </div>
-            <div>
-              <Label>SKU Portal</Label>
-              <Input value={form.sku_portal} onChange={(e) => setForm({ ...form, sku_portal: e.target.value })} />
-            </div>
-            <div>
-              <Label>Unidade Portal</Label>
-              <Input value={form.unidade_portal} onChange={(e) => setForm({ ...form, unidade_portal: e.target.value.toUpperCase() })} />
-            </div>
-            <div>
-              <Label>Fator de conversão</Label>
-              <Input
-                type="number"
-                step="0.0001"
-                value={form.fator_conversao}
-                onChange={(e) => setForm({ ...form, fator_conversao: Number(e.target.value) })}
-              />
-            </div>
-            <div className="col-span-2 flex items-center gap-2">
-              <Switch checked={form.ativo} onCheckedChange={(v) => setForm({ ...form, ativo: v })} />
-              <Label>Ativo</Label>
-            </div>
-            <div className="col-span-2">
-              <Label>Observações</Label>
-              <Textarea value={form.observacoes} onChange={(e) => setForm({ ...form, observacoes: e.target.value })} rows={2} />
-            </div>
-          </div>
-          <DialogFooter>
-            <Button variant="outline" onClick={() => setOpenAdd(false)}>Cancelar</Button>
-            <Button
-              onClick={() => upsertMut.mutate({ ...form, id: editing?.id })}
-              disabled={upsertMut.isPending || !form.empresa || !form.fornecedor_nome || !form.sku_omie}
-            >
-              {upsertMut.isPending && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
-              Salvar
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      <MapeamentoFormDialog
+        open={openAdd}
+        onOpenChange={handleOpenAddChange}
+        isEditing={isEditing}
+        form={form}
+        setForm={setForm}
+        onCancel={closeAdd}
+        onSave={save}
+        isSaving={isSaving}
+      />
 
       {/* Validar dialog */}
-      <Dialog open={openValidar} onOpenChange={setOpenValidar}>
-        <DialogContent className="max-w-2xl">
-          <DialogHeader>
-            <DialogTitle>Validação dos mapeamentos</DialogTitle>
-            <DialogDescription>
-              Confere se todos os SKUs usados em pedidos Sayerlack OBEN têm correspondência no portal.
-            </DialogDescription>
-          </DialogHeader>
-          {validando || !validacao ? (
-            <div className="flex items-center justify-center py-10">
-              <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
-            </div>
-          ) : (
-            <div className="space-y-4">
-              <div className="grid grid-cols-3 gap-3">
-                <Card><CardContent className="pt-4">
-                  <div className="text-xs text-muted-foreground">Total</div>
-                  <div className="text-2xl font-bold">{validacao.total}</div>
-                </CardContent></Card>
-                <Card><CardContent className="pt-4">
-                  <div className="text-xs text-muted-foreground">Auto</div>
-                  <div className="text-2xl font-bold">{validacao.automaticos}</div>
-                </CardContent></Card>
-                <Card><CardContent className="pt-4">
-                  <div className="text-xs text-muted-foreground">Manual</div>
-                  <div className="text-2xl font-bold">{validacao.manuais}</div>
-                </CardContent></Card>
-              </div>
-
-              {validacao.faltantes.length > 0 ? (
-                <Alert variant="destructive">
-                  <AlertTriangle className="h-4 w-4" />
-                  <AlertTitle>{validacao.faltantes.length} SKU(s) sem mapeamento</AlertTitle>
-                  <AlertDescription>
-                    <div className="max-h-48 overflow-y-auto mt-2 space-y-1 text-xs">
-                      {validacao.faltantes.map((f) => (
-                        <div key={f.sku_codigo_omie} className="font-mono">
-                          {f.sku_codigo_omie} — {f.sku_descricao}
-                        </div>
-                      ))}
-                    </div>
-                  </AlertDescription>
-                </Alert>
-              ) : (
-                <Alert>
-                  <CheckCircle2 className="h-4 w-4" />
-                  <AlertTitle>Todos os SKUs do histórico estão mapeados</AlertTitle>
-                </Alert>
-              )}
-
-              {validacao.suspeitos.length > 0 && (
-                <Alert>
-                  <AlertTriangle className="h-4 w-4" />
-                  <AlertTitle>{validacao.suspeitos.length} mapeamento(s) com SKU portal suspeito</AlertTitle>
-                  <AlertDescription>
-                    <div className="max-h-32 overflow-y-auto mt-2 space-y-1 text-xs">
-                      {validacao.suspeitos.map((s) => (
-                        <div key={s.id} className="font-mono">
-                          {s.sku_omie} → {s.sku_portal ?? '(vazio)'}
-                        </div>
-                      ))}
-                    </div>
-                  </AlertDescription>
-                </Alert>
-              )}
-            </div>
-          )}
-        </DialogContent>
-      </Dialog>
+      <ValidacaoDialog
+        open={openValidar}
+        onOpenChange={setOpenValidar}
+        validando={validando}
+        validacao={validacao}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Resumo
Quebra o god-component `src/pages/AdminSkuMapeamento.tsx` (**503→100L**) em um hook de dados/estado + componentes presentacionais controlados, sob `src/components/skuMapeamento/`. Extração **verbatim** — comportamento preservado 1:1.

## O que mudou
- **`useSkuMapeamento`** (hook): 2 queries (`sku_fornecedor_externo` + descrições de `pedido_compra_item`), memos de filtro, `upsertMut` e validação (faltantes/suspeitos Sayerlack OBEN).
- **`MapeamentoFiltros`** — filtros (empresa/fornecedor/status/busca).
- **`MapeamentosTable`** — card + tabela de mapeamentos.
- **`MapeamentoFormDialog`** — dialog adicionar/editar.
- **`ValidacaoDialog`** — dialog de validação.
- **`types.ts`** / **`config.ts`** (`EMPTY_FORM`/`SkuMapForm`).
- **+14 testes** (presentacionais).

> Preservado o comportamento sutil: "Cancelar" chama `setOpenAdd(false)` direto (sem resetar form/editing), enquanto o `onOpenChange` do Dialog reseta — idêntico ao original.

## Verificação
- `bunx tsc --noEmit` (baseline) = **0**
- `eslint` = **0 erros / 0 warnings**
- **14/14 testes** verdes (isolados)
- Revisão independente FIEL 1:1: **aprovada**

## Migrations
Nenhuma.

🤖 Generated with [Claude Code](https://claude.com/claude-code)