### PR TITLE
test(sales): cobertura do submitOrder (caminho do dinheiro)

### DIFF
--- a/docs/superpowers/specs/2026-05-25-submitorder-test-coverage-design.md
+++ b/docs/superpowers/specs/2026-05-25-submitorder-test-coverage-design.md
@@ -1,0 +1,46 @@
+# Cobertura de teste do `submitOrder` (caminho do dinheiro) — Design Spec
+
+> **Data:** 2026-05-25
+> **Status:** aprovado no brainstorming
+> **Contexto:** audit de cobertura achou que `src/services/orderSubmission/submitOrder.ts` — a orquestração que cria PVs **cobrados** no Omie (Oben + Colacor + ordens de produção + OS de afiação) — **não tem nenhum teste**. É o código mais crítico do app (caminho do dinheiro) e tem lógica de sucesso-parcial/erro não-trivial. Esta PR adiciona cobertura; **não muda comportamento**.
+
+## Goal
+
+Travar o comportamento atual do `submitOrder` com testes, pra que mudanças futuras nessa orquestração sensível sejam pegas. Foco nos caminhos de erro/sucesso-parcial (onde bugs custam dinheiro).
+
+## Por que é testável
+
+`submitOrder(params)` é uma função pura-de-orquestração (sem React): recebe `supabase` por **injeção de dependência** (`params.supabase`) + `getServicePrice`, e importa `syncOrderToOmie` (omieService), `buildPrintData`, helpers. Tudo mockável.
+
+## Estratégia de mock
+
+- `vi.mock('@/services/omieService')` → `syncOrderToOmie` controlável (success/fail).
+- `vi.mock('../buildPrintData')` → `buildPrintData` → `[]` (isola; já é testável à parte no futuro).
+- `vi.mock('../helpers')` → `formatCustomerAddress` → `'Rua X, 1'`, `resolveCustomerPhone` → `async '11999'`, `buildToolInfo` → `''`, `getToolName` → `'Tool'`, `findParcelaDesc`/`getToolName` conforme uso.
+- **`supabase` mock** (objeto passado em params, sem mock de módulo):
+  - `from('sales_orders').insert(payload).select('id').single()` → `{ data: { id }, error }` (controlável por teste).
+  - `functions.invoke('omie-vendas-sync', { body })` → `{ data: { omie_numero_pedido }, error }` (controlável; usado p/ `criar_pedido` e `criar_ordem_producao`).
+- Fixtures mínimos (`as` cast pros tipos completos): `OmieCustomer`, `User` (`{ id }`), `ProductCartItem` (`product.{id,omie_codigo_produto,codigo,descricao,unidade,metadata?}`).
+
+## Comportamentos a travar (cenários)
+
+1. **Carrinho vazio** → `{ success:false, errors:[{step:'validate', message:'Carrinho vazio'}] }`; nenhum insert.
+2. **Oben: insert ok + Omie ok** → `success:true`, `results` inclui `PV Oben <numero>`; insert chamado com `account:'oben'`, `status:'rascunho'`.
+3. **Oben: insert FALHA** → aborta (`success:false`, `step:'insert_oben'`); **`functions.invoke` NÃO é chamado** (não cria PV no ERP sem o registro local).
+4. **Oben: insert ok + Omie FALHA** → `success:true` (não aborta), `results` inclui `PV Oben (pendente ERP)`, `errors` tem `step:'sync_oben_omie'`.
+5. **Colacor: produto acabado (tipo_produto '04') + sync ok + `defaultProductionAssigneeId` setado** → chama `invoke` com `action:'criar_ordem_producao'`.
+6. **Colacor: produto acabado SEM `defaultProductionAssigneeId`** → NÃO cria OP, adiciona `errors` `step:'create_production_order'` (responsável não configurado), mas `success:true`.
+
+> Os cenários cobrem o invariante crítico (#3: nunca chamar o Omie se o insert local falhou) e a degradação honesta (#4/#6).
+
+## Testing
+
+`src/services/orderSubmission/__tests__/submitOrder.test.ts` (vitest). Sem rede real. Cada cenário monta o mock supabase + params e asserta `result` + chamadas.
+
+Suíte completa verde; lint limpo; sem mudança no `submitOrder.ts`.
+
+## Out-of-scope
+
+- Testar `buildPrintData`/`syncOrderToOmie` (mockados aqui; merecem testes próprios depois).
+- Caminho de afiação/serviço em detalhe (coberto superficialmente; foco é produto + Omie).
+- Qualquer refactor do `submitOrder` (só cobertura).

--- a/src/services/orderSubmission/__tests__/submitOrder.test.ts
+++ b/src/services/orderSubmission/__tests__/submitOrder.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { User } from '@supabase/supabase-js';
+
+// ─── Mocks de módulo (isolam submitOrder da rede/print) ───
+vi.mock('@/services/omieService', () => ({
+  syncOrderToOmie: vi.fn().mockResolvedValue({ success: true, omie_os: { cNumOS: 'OS1' } }),
+}));
+vi.mock('../buildPrintData', () => ({ buildPrintData: vi.fn().mockReturnValue([]) }));
+vi.mock('../helpers', () => ({
+  formatCustomerAddress: vi.fn().mockReturnValue('Rua X, 1'),
+  resolveCustomerPhone: vi.fn().mockResolvedValue('11999999999'),
+  buildToolInfo: vi.fn().mockReturnValue(''),
+  getToolName: vi.fn().mockReturnValue('Tool'),
+  findParcelaDesc: vi.fn().mockReturnValue(''),
+}));
+vi.mock('@/lib/logger', () => ({
+  logger: { info: vi.fn(), error: vi.fn(), critical: vi.fn(), warn: vi.fn() },
+}));
+
+import { submitOrder } from '../submitOrder';
+import type { SubmitOrderParams, SubmitClient } from '../types';
+import type { OmieCustomer, ProductCartItem } from '@/hooks/unifiedOrder/types';
+
+// ─── Mock supabase (injetado via params) ───
+interface MakeSupabaseOpts {
+  insertError?: unknown;
+  insertId?: string;
+  invokeImpl?: (body: { action?: string }) => { data?: unknown; error?: unknown };
+}
+function makeSupabase(opts: MakeSupabaseOpts = {}) {
+  const single = vi.fn().mockResolvedValue({
+    data: opts.insertError ? null : { id: opts.insertId ?? 'so-1' },
+    error: opts.insertError ?? null,
+  });
+  const select = vi.fn().mockReturnValue({ single });
+  const insert = vi.fn().mockReturnValue({ select });
+  const from = vi.fn().mockReturnValue({ insert });
+  const invoke = vi.fn().mockImplementation(async (_name: string, arg: { body: { action?: string } }) =>
+    opts.invokeImpl ? opts.invokeImpl(arg.body) : { data: { omie_numero_pedido: '999' }, error: null },
+  );
+  const client = { from, functions: { invoke } } as unknown as SubmitClient;
+  return { client, from, insert, invoke };
+}
+
+const customer = {
+  codigo_cliente: 100,
+  codigo_cliente_colacor: 200,
+  codigo_vendedor: 5,
+  codigo_vendedor_colacor: 6,
+  razao_social: 'ACME LTDA',
+  nome_fantasia: 'ACME',
+  cnpj_cpf: '12345678000199',
+} as OmieCustomer;
+
+const user = { id: 'user-1' } as User;
+
+function obenItem(): ProductCartItem {
+  return {
+    type: 'product', account: 'oben', quantity: 2, unit_price: 10,
+    product: { id: 'p1', omie_codigo_produto: 'OBEN1', codigo: 'C1', descricao: 'Lixa', unidade: 'UN' },
+  } as unknown as ProductCartItem;
+}
+function colacorAcabado(): ProductCartItem {
+  return {
+    type: 'product', account: 'colacor', quantity: 1, unit_price: 50,
+    product: { id: 'p2', omie_codigo_produto: 'COL1', codigo: 'C2', descricao: 'Disco acabado', unidade: 'UN', metadata: { tipo_produto: '04' } },
+  } as unknown as ProductCartItem;
+}
+
+function makeParams(over: Partial<SubmitOrderParams> & { supabase: SubmitClient }): SubmitOrderParams {
+  return {
+    customer, customerUserId: 'cu-1', user,
+    cart: { obenProductItems: [], colacorProductItems: [], serviceItems: [] },
+    subtotals: { oben: 0, colacor: 0, service: 0 },
+    volumes: { oben: 0, colacor: 0 },
+    payment: { parcelaOben: '1', parcelaColacor: '1', afiacaoMethod: 'pix', formasPagamentoOben: [], formasPagamentoColacor: [] },
+    delivery: { option: 'balcao', selectedAddress: undefined },
+    meta: { notes: '', readyByDate: '', ordemCompra: '' },
+    companyProfiles: {},
+    defaultProductionAssigneeId: null,
+    getServicePrice: () => 0,
+    ...over,
+  } as SubmitOrderParams;
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('submitOrder', () => {
+  it('carrinho vazio → erro de validação, sem insert', async () => {
+    const { client, insert } = makeSupabase();
+    const r = await submitOrder(makeParams({ supabase: client }));
+    expect(r.success).toBe(false);
+    expect(r.errors[0]).toEqual({ step: 'validate', message: 'Carrinho vazio' });
+    expect(insert).not.toHaveBeenCalled();
+  });
+
+  it('Oben: insert ok + Omie ok → success + PV no results', async () => {
+    const { client, insert, invoke } = makeSupabase({ insertId: 'so-oben' });
+    const r = await submitOrder(makeParams({
+      supabase: client,
+      cart: { obenProductItems: [obenItem()], colacorProductItems: [], serviceItems: [] },
+      subtotals: { oben: 20, colacor: 0, service: 0 },
+    }));
+    expect(r.success).toBe(true);
+    expect(insert).toHaveBeenCalledWith(expect.objectContaining({ account: 'oben', status: 'rascunho' }));
+    expect(invoke).toHaveBeenCalledWith('omie-vendas-sync', expect.objectContaining({
+      body: expect.objectContaining({ action: 'criar_pedido', account: 'oben' }),
+    }));
+    expect(r.results.some((s) => s.includes('PV Oben'))).toBe(true);
+  });
+
+  it('Oben: insert FALHA → aborta e NÃO chama o Omie', async () => {
+    const { client, invoke } = makeSupabase({ insertError: { message: 'rls denied' } });
+    const r = await submitOrder(makeParams({
+      supabase: client,
+      cart: { obenProductItems: [obenItem()], colacorProductItems: [], serviceItems: [] },
+      subtotals: { oben: 20, colacor: 0, service: 0 },
+    }));
+    expect(r.success).toBe(false);
+    expect(r.errors.some((e) => e.step === 'insert_oben')).toBe(true);
+    expect(invoke).not.toHaveBeenCalled(); // invariante: sem registro local, não cria PV no ERP
+  });
+
+  it('Oben: insert ok + Omie FALHA → não aborta, marca pendente ERP', async () => {
+    const { client } = makeSupabase({
+      insertId: 'so-oben',
+      invokeImpl: () => ({ data: null, error: { message: 'omie timeout' } }),
+    });
+    const r = await submitOrder(makeParams({
+      supabase: client,
+      cart: { obenProductItems: [obenItem()], colacorProductItems: [], serviceItems: [] },
+      subtotals: { oben: 20, colacor: 0, service: 0 },
+    }));
+    expect(r.success).toBe(true);
+    expect(r.results.some((s) => s.includes('pendente ERP'))).toBe(true);
+    expect(r.errors.some((e) => e.step === 'sync_oben_omie')).toBe(true);
+  });
+
+  it('Colacor produto acabado + responsável setado → cria ordem de produção', async () => {
+    const { client, invoke } = makeSupabase({
+      insertId: 'so-col',
+      invokeImpl: (body) => body.action === 'criar_pedido'
+        ? { data: { omie_numero_pedido: '777' }, error: null }
+        : { data: { ok: true }, error: null },
+    });
+    const r = await submitOrder(makeParams({
+      supabase: client,
+      cart: { obenProductItems: [], colacorProductItems: [colacorAcabado()], serviceItems: [] },
+      subtotals: { oben: 0, colacor: 50, service: 0 },
+      defaultProductionAssigneeId: 'assignee-1',
+    }));
+    expect(r.success).toBe(true);
+    expect(invoke).toHaveBeenCalledWith('omie-vendas-sync', expect.objectContaining({
+      body: expect.objectContaining({ action: 'criar_ordem_producao', account: 'colacor' }),
+    }));
+  });
+
+  it('Colacor produto acabado SEM responsável → não cria OP, erro registrado, success ainda true', async () => {
+    const { client, invoke } = makeSupabase({
+      insertId: 'so-col',
+      invokeImpl: (body) => ({ data: { omie_numero_pedido: '888' }, error: body.action === 'criar_ordem_producao' ? { message: 'x' } : null }),
+    });
+    const r = await submitOrder(makeParams({
+      supabase: client,
+      cart: { obenProductItems: [], colacorProductItems: [colacorAcabado()], serviceItems: [] },
+      subtotals: { oben: 0, colacor: 50, service: 0 },
+      defaultProductionAssigneeId: null,
+    }));
+    expect(r.success).toBe(true);
+    expect(r.errors.some((e) => e.step === 'create_production_order')).toBe(true);
+    // nunca chamou criar_ordem_producao (sem responsável)
+    const opCalls = invoke.mock.calls.filter((c) => (c[1] as { body: { action?: string } }).body.action === 'criar_ordem_producao');
+    expect(opCalls).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Contexto

Audit de cobertura achou que `src/services/orderSubmission/submitOrder.ts` — a orquestração que cria PVs **cobrados** no Omie (Oben + Colacor + ordens de produção + OS de afiação) — **não tinha nenhum teste**. É o código mais crítico do app. Spec em `docs/superpowers/specs/2026-05-25-submitorder-test-coverage-design.md`.

## O que muda (só teste)

`src/services/orderSubmission/__tests__/submitOrder.test.ts` — 6 cenários travando o comportamento atual (sem tocar o `submitOrder.ts`):

1. **Carrinho vazio** → erro de validação, nenhum insert.
2. **Oben insert ok + Omie ok** → success + `PV Oben` nos results.
3. **Oben insert FALHA → aborta e NÃO chama o Omie** (invariante crítico: sem registro local, não cria PV cobrado no ERP).
4. **Oben insert ok + Omie FALHA** → não aborta, marca "pendente ERP" + erro.
5. **Colacor produto acabado + responsável setado** → cria ordem de produção.
6. **Produto acabado SEM responsável** → não cria OP, erro registrado, success ainda true.

Testável porque `submitOrder` recebe `supabase` por injeção; mocko `omieService`/`buildPrintData`/`helpers` + supabase.

## Test plan

- [x] `submitOrder` 6/6; suíte completa verde (1277, a única falha foi flake de CPU saturada no `SubstituicaoPendenteCard` — passa isolado, não relacionado); lint limpo

🤖 Generated with [Claude Code](https://claude.com/claude-code)