### PR TITLE
feat(fin): esconder contas zeradas + touch no scanner OCR + nav dedup

### DIFF
--- a/src/components/financeiro/dashboard/VisaoGeralTab.tsx
+++ b/src/components/financeiro/dashboard/VisaoGeralTab.tsx
@@ -1,7 +1,9 @@
 // Conteúdo da aba "Visão Geral" do dashboard financeiro.
 // Extraído de src/pages/FinanceiroDashboard.tsx (god-component split).
+import { useState } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
 import {
   TrendingUp, TrendingDown, AlertTriangle, Wallet,
   ArrowDownCircle, ArrowUpCircle, BarChart3,
@@ -25,6 +27,15 @@ export function VisaoGeralTab({
   agingPagar: AgingData | null;
   inadimplentes: { nome: string; cnpj: string; total_vencido: number; qtd_titulos: number }[];
 }) {
+  const [showContasZeradas, setShowContasZeradas] = useState(false);
+  // Esconde contas com saldo zerado por padrão (ruído numa lista de ~40 contas).
+  // Se TODAS estiverem zeradas, mostra mesmo assim (senão o card ficaria vazio).
+  const contasCorrentes = activeResumo?.contas_correntes ?? [];
+  const contasComSaldo = contasCorrentes.filter((cc) => cc.saldo_atual !== 0);
+  const qtdZeradas = contasCorrentes.length - contasComSaldo.length;
+  const contasVisiveis =
+    showContasZeradas || contasComSaldo.length === 0 ? contasCorrentes : contasComSaldo;
+
   return (
     <>
       {/* Alerts */}
@@ -263,7 +274,7 @@ export function VisaoGeralTab({
           </CardHeader>
           <CardContent>
             <div className="space-y-2">
-              {activeResumo.contas_correntes.map((cc, idx) => (
+              {contasVisiveis.map((cc, idx) => (
                 <div key={idx} className="flex items-center justify-between py-2 border-b last:border-0">
                   <div>
                     <p className="font-medium text-sm">{cc.descricao}</p>
@@ -275,6 +286,18 @@ export function VisaoGeralTab({
                 </div>
               ))}
             </div>
+            {qtdZeradas > 0 && contasComSaldo.length > 0 && (
+              <Button
+                variant="ghost"
+                size="sm"
+                className="mt-2 h-auto px-1 py-1 text-xs text-muted-foreground hover:text-foreground"
+                onClick={() => setShowContasZeradas((v) => !v)}
+              >
+                {showContasZeradas
+                  ? 'Ocultar contas zeradas'
+                  : `Mostrar ${qtdZeradas} ${qtdZeradas === 1 ? 'conta zerada' : 'contas zeradas'}`}
+              </Button>
+            )}
           </CardContent>
         </Card>
       )}

--- a/src/components/recebimento/LoteScannerOCR.tsx
+++ b/src/components/recebimento/LoteScannerOCR.tsx
@@ -196,7 +196,7 @@ export default function LoteScannerOCR({ onLoteCapturado, onCancelar }: LoteScan
           onClick={capture}
           disabled={!cameraReady || processing}
           className="gap-2"
-          size="lg"
+          size="balcao"
         >
           <Camera className="h-5 w-5" />
           Capturar
@@ -264,10 +264,10 @@ export default function LoteScannerOCR({ onLoteCapturado, onCancelar }: LoteScan
 
       {/* Footer actions */}
       <div className="flex gap-3 px-4 py-4 bg-card border-t border-border">
-        <Button variant="outline" className="flex-1" onClick={onCancelar}>
+        <Button variant="outline" size="touch" className="flex-1" onClick={onCancelar}>
           Cancelar
         </Button>
-        <Button className="flex-1" disabled={!lote.trim()} onClick={handleConfirmar}>
+        <Button size="touch" className="flex-1" disabled={!lote.trim()} onClick={handleConfirmar}>
           Confirmar Lote
         </Button>
       </div>

--- a/src/pages/UnifiedOrder.tsx
+++ b/src/pages/UnifiedOrder.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { Loader2, ChevronLeft, CheckCircle, Building2, Scissors, Wifi } from 'lucide-react';
+import { Loader2, CheckCircle, Building2, Scissors, Wifi } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { track } from '@/lib/analytics';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -137,9 +137,6 @@ const UnifiedOrder = () => {
   return (
     <div className="max-w-5xl mx-auto space-y-4 pb-6">
       <div className="flex items-center gap-3">
-        <button onClick={() => h.navigate(-1)} className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground">
-          <ChevronLeft className="w-4 h-4" />
-        </button>
         <div>
           <h1 className="text-lg font-semibold">
             {isCustomerMode ? 'Nova Ordem de Serviço' : 'Novo Pedido'}


### PR DESCRIPTION
## Resumo
Continuação do design review, sobre a `main` pós-#296. 3 mudanças:

- **feat(fin)** — Contas Correntes (financeiro): esconde contas com saldo R$ 0,00 por padrão + toggle "Mostrar N contas zeradas". Agora viável porque o saldo passou a sincronizar de verdade (fix do `ListarExtrato`). Verificado: Colacor mostra 9 contas com saldo real + 30 zeradas escondidas.
- **style(design)** — `LoteScannerOCR` (recebimento/conferência, chão de fábrica/luva): captura `lg`→`balcao` (56px), footer Cancelar/Confirmar →`touch` (44px). WCAG.
- **style(design)** — `UnifiedOrder`: remove chevron de voltar redundante (shell já tem breadcrumb + link). 3→2 affordances de navegação.

## Verificação
- Browser: toggle de contas zeradas (expande/recolhe) ✅; saldos reais aparecem (Saldo Bancário R$ 55.4k) ✅; nav do Novo Pedido limpa ✅
- `bun lint`: 0 problemas novos nos arquivos tocados
- LoteScannerOCR: verificado por compilação + variantes `touch`/`balcao` confirmadas no Button (não dá pra abrir o scanner ao vivo sem processar NF-e)

🤖 Generated with [Claude Code](https://claude.com/claude-code)