### PR TITLE
fix(customers): pagina loadScores (cap 1000 do PostgREST) + defesa CSS de scroll

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -377,6 +377,21 @@
     overscroll-behavior: contain;
   }
 
+  /* ── Body scroll guarantee ──
+     Defesa contra scroll-lock vazado por overlays Radix (Dialog/Sheet/etc.)
+     que setam `body { overflow: hidden }` inline e às vezes não limpam ao
+     fechar — sintoma: usuário não consegue rolar a página em /admin/customers
+     ou similares depois de abrir/fechar um modal. Esta regra GARANTE que body
+     fica scrollável sempre que NÃO houver Dialog/AlertDialog aberto, sobrepondo
+     qualquer overflow:hidden residual inline.
+
+     Quando uma Dialog está aberta o seletor :has() casa, a regra NÃO se aplica,
+     e o lock de Radix continua válido (background não rola enquanto modal está
+     em cima). :has() suportado em Chrome 105 / Safari 15.4 / FF 121 (fim 2023). */
+  body:not(:has([data-state="open"][role="dialog"], [data-state="open"][role="alertdialog"])) {
+    overflow: auto !important;
+  }
+
   /* ── Compact density ── */
   .density-compact {
     --table-row-height: 36px;

--- a/src/pages/AdminCustomers.tsx
+++ b/src/pages/AdminCustomers.tsx
@@ -851,12 +851,23 @@ const AdminCustomers = () => {
   const loadScores = async () => {
     if (!user?.id) return;
     try {
-      const { data } = await supabase
-        .from('farmer_client_scores')
-        .select('customer_user_id, health_score, health_class, churn_risk, expansion_score, priority_score, avg_monthly_spend_180d, days_since_last_purchase, category_count, gross_margin_pct, avg_repurchase_interval')
-        .eq('farmer_id', user.id);
-      if (data) {
-        const map = new Map<string, ClientScore>();
+      // farmer_client_scores tem ~1 linha por cliente da carteira (milhares).
+      // PostgREST capa em 1000 linhas/request, então paginamos com .range() até
+      // a página vir incompleta (ou bater um teto de segurança) — sem isso, os
+      // scores de clientes além dos 1000 primeiros ficavam silenciosamente vazios.
+      const SCORES_PAGE_SIZE = 1000;
+      const MAX_PAGES = 50; // teto de segurança = 50.000 scores
+      const map = new Map<string, ClientScore>();
+      for (let page = 0; page < MAX_PAGES; page++) {
+        const from = page * SCORES_PAGE_SIZE;
+        const to = from + SCORES_PAGE_SIZE - 1;
+        const { data, error } = await supabase
+          .from('farmer_client_scores')
+          .select('customer_user_id, health_score, health_class, churn_risk, expansion_score, priority_score, avg_monthly_spend_180d, days_since_last_purchase, category_count, gross_margin_pct, avg_repurchase_interval')
+          .eq('farmer_id', user.id)
+          .range(from, to);
+        if (error) throw error;
+        if (!data || data.length === 0) break;
         // Database row tem fields nullable; normaliza pra non-null com defaults
         data.forEach((s) => map.set(s.customer_user_id, {
           customer_user_id: s.customer_user_id,
@@ -870,8 +881,9 @@ const AdminCustomers = () => {
           category_count: s.category_count ?? 0,
           gross_margin_pct: s.gross_margin_pct ?? 0,
         }));
-        setScores(map);
+        if (data.length < SCORES_PAGE_SIZE) break;
       }
+      setScores(map);
     } catch (e) {
       console.error('Error loading scores:', e);
     }


### PR DESCRIPTION
## Resumo
Reaplica sobre a `main` atual a correção que estava parada na branch `claude/customers-entities-scroll-lock` (9 dias sem PR, 761 commits atrás — não mergeável crua). **É bugfix, não refactor.**

## O que mudou
- **`loadScores`** (`AdminCustomers.tsx`): paginação via `.range()` (1000/página, teto 50 páginas) na query de `farmer_client_scores`. Sem isso, a carteira (~6908 clientes) ficava **capada nos 1000 primeiros scores** — clientes além disso apareciam sem health/churn/etc. (`loadCustomers` já foi paginado na main via `useInfiniteQuery`; só faltava `loadScores`.)
- **`index.css`**: defesa `body:not(:has([data-state="open"][role="dialog"|"alertdialog"])) { overflow: auto !important }` contra scroll-lock vazado de overlays Radix que não limpam o `overflow:hidden` inline ao fechar.

A normalização dos scores (defaults non-null) foi preservada.

## Verificação
- `bunx tsc --noEmit` (baseline) = **0**
- `eslint` = **0 erros** (2 warnings `exhaustive-deps` pré-existentes em `AdminCustomers`)
- Mudança localizada e de baixo risco (1 função + 1 bloco CSS idempotente).

## Migrations
Nenhuma.

🤖 Generated with [Claude Code](https://claude.com/claude-code)