### PR TITLE
test(sales): cobertura do submitQuote (orçamento)

### DIFF
--- a/docs/superpowers/specs/2026-05-25-submitquote-test-coverage-design.md
+++ b/docs/superpowers/specs/2026-05-25-submitquote-test-coverage-design.md
@@ -1,0 +1,33 @@
+# Cobertura de teste do `submitQuote` — Design Spec
+
+> **Data:** 2026-05-25
+> **Status:** aprovado (continuação autônoma decidida com o Codex — irmão do `submitOrder`, próximo na fila de cobertura).
+> **Contexto:** `src/services/orderSubmission/submitQuote.ts` (salva carrinho como orçamento — insere `sales_orders` status `orcamento`, **sem sync Omie**) não tem teste. Money-adjacent. Mesma estratégia de mock do `submitOrder` (já coberto em #306).
+
+## Goal
+
+Travar o comportamento do `submitQuote`: validação, sucesso por conta, abort do Oben em falha, não-abort do Colacor em falha, e o invariante de que **orçamento nunca chama o Omie**. Sem mudança de código.
+
+## Comportamentos a travar
+
+1. **Carrinho vazio** (oben+colacor vazios) → `{ success:false, errors:[{step:'validate'}] }`; nenhum insert.
+2. **Oben ok** → `success:true`, `results` inclui `'Orçamento Oben salvo'`; insert chamado com `account:'oben'`, `status:'orcamento'`.
+3. **Oben insert FALHA → aborta** (`success:false`, `step:'insert_oben_quote'`); se houver Colacor, **o insert do Colacor NÃO é tentado** (early return).
+4. **Oben + Colacor ok** → `success:true`, 2 results, 2 inserts.
+5. **Colacor FALHA (Oben ok) → NÃO aborta**: `success:true` (Oben salvou), `errors` tem `step:'insert_colacor_quote'`, `results` só o Oben.
+6. **Nunca chama `supabase.functions.invoke`** (orçamento não sincroniza com o ERP).
+
+## Mock
+
+- `vi.mock('../helpers')` → `formatCustomerAddress`→`'Rua X'`, `resolveCustomerPhone`→`async '11999'`.
+- `vi.mock('@/lib/logger')` → logger no-op.
+- **supabase** (injetado): `from('sales_orders').insert(payload)` resolve `{ error }` controlado por `payload.account` (permite Oben-ok + Colacor-falha). `functions.invoke` presente mas **assert never called**.
+- Fixtures: reuso do padrão do `submitOrder.test` (OmieCustomer, User, ProductCartItem por `as`).
+
+## Testing
+
+`src/services/orderSubmission/__tests__/submitQuote.test.ts` (vitest). Sem rede. Suíte verde; lint limpo; sem tocar `submitQuote.ts`.
+
+## Out-of-scope
+
+- Refactor; testar helpers (mockados).

--- a/src/services/orderSubmission/__tests__/submitQuote.test.ts
+++ b/src/services/orderSubmission/__tests__/submitQuote.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { User } from '@supabase/supabase-js';
+
+vi.mock('../helpers', () => ({
+  formatCustomerAddress: vi.fn().mockReturnValue('Rua X, 1'),
+  resolveCustomerPhone: vi.fn().mockResolvedValue('11999999999'),
+}));
+vi.mock('@/lib/logger', () => ({
+  logger: { info: vi.fn(), error: vi.fn(), critical: vi.fn(), warn: vi.fn() },
+}));
+
+import { submitQuote } from '../submitQuote';
+import type { SubmitQuoteParams, SubmitClient } from '../types';
+import type { OmieCustomer, ProductCartItem } from '@/hooks/unifiedOrder/types';
+
+interface MakeSupabaseOpts {
+  obenError?: unknown;
+  colacorError?: unknown;
+}
+function makeSupabase(opts: MakeSupabaseOpts = {}) {
+  const insert = vi.fn().mockImplementation((payload: { account?: string }) =>
+    Promise.resolve({ error: payload.account === 'colacor' ? (opts.colacorError ?? null) : (opts.obenError ?? null) }),
+  );
+  const from = vi.fn().mockReturnValue({ insert });
+  const invoke = vi.fn();
+  const client = { from, functions: { invoke } } as unknown as SubmitClient;
+  return { client, from, insert, invoke };
+}
+
+const customer = {
+  codigo_cliente: 100,
+  codigo_cliente_colacor: 200,
+  codigo_vendedor: 5,
+  razao_social: 'ACME LTDA',
+  nome_fantasia: 'ACME',
+  cnpj_cpf: '12345678000199',
+} as OmieCustomer;
+
+const user = { id: 'user-1' } as User;
+
+function obenItem(): ProductCartItem {
+  return {
+    type: 'product', account: 'oben', quantity: 2, unit_price: 10,
+    product: { id: 'p1', omie_codigo_produto: 'OBEN1', codigo: 'C1', descricao: 'Lixa', unidade: 'UN' },
+  } as unknown as ProductCartItem;
+}
+function colacorItem(): ProductCartItem {
+  return {
+    type: 'product', account: 'colacor', quantity: 1, unit_price: 50,
+    product: { id: 'p2', omie_codigo_produto: 'COL1', codigo: 'C2', descricao: 'Disco', unidade: 'UN' },
+  } as unknown as ProductCartItem;
+}
+
+function makeParams(over: Partial<SubmitQuoteParams> & { supabase: SubmitClient }): SubmitQuoteParams {
+  return {
+    customer, customerUserId: 'cu-1', user,
+    cart: { obenProductItems: [], colacorProductItems: [] },
+    subtotals: { oben: 0, colacor: 0 },
+    delivery: { option: 'balcao', selectedAddress: undefined },
+    meta: { notes: '' },
+    ...over,
+  } as SubmitQuoteParams;
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('submitQuote', () => {
+  it('carrinho vazio → erro de validação, sem insert', async () => {
+    const { client, insert } = makeSupabase();
+    const r = await submitQuote(makeParams({ supabase: client }));
+    expect(r.success).toBe(false);
+    expect(r.errors[0]).toEqual({ step: 'validate', message: 'Carrinho vazio' });
+    expect(insert).not.toHaveBeenCalled();
+  });
+
+  it('Oben ok → success + insert status orcamento', async () => {
+    const { client, insert } = makeSupabase();
+    const r = await submitQuote(makeParams({
+      supabase: client,
+      cart: { obenProductItems: [obenItem()], colacorProductItems: [] },
+      subtotals: { oben: 20, colacor: 0 },
+    }));
+    expect(r.success).toBe(true);
+    expect(r.results).toContain('Orçamento Oben salvo');
+    expect(insert).toHaveBeenCalledWith(expect.objectContaining({ account: 'oben', status: 'orcamento' }));
+  });
+
+  it('Oben FALHA → aborta e NÃO tenta o Colacor', async () => {
+    const { client, insert } = makeSupabase({ obenError: { message: 'rls' } });
+    const r = await submitQuote(makeParams({
+      supabase: client,
+      cart: { obenProductItems: [obenItem()], colacorProductItems: [colacorItem()] },
+      subtotals: { oben: 20, colacor: 50 },
+    }));
+    expect(r.success).toBe(false);
+    expect(r.errors.some((e) => e.step === 'insert_oben_quote')).toBe(true);
+    expect(insert).toHaveBeenCalledTimes(1); // só o Oben; aborta antes do Colacor
+  });
+
+  it('Oben + Colacor ok → 2 inserts, 2 results, sem Omie', async () => {
+    const { client, insert, invoke } = makeSupabase();
+    const r = await submitQuote(makeParams({
+      supabase: client,
+      cart: { obenProductItems: [obenItem()], colacorProductItems: [colacorItem()] },
+      subtotals: { oben: 20, colacor: 50 },
+    }));
+    expect(r.success).toBe(true);
+    expect(r.results).toHaveLength(2);
+    expect(insert).toHaveBeenCalledTimes(2);
+    expect(invoke).not.toHaveBeenCalled(); // orçamento nunca sincroniza com o Omie
+  });
+
+  it('Colacor FALHA (Oben ok) → NÃO aborta: success true + erro registrado', async () => {
+    const { client } = makeSupabase({ colacorError: { message: 'fk' } });
+    const r = await submitQuote(makeParams({
+      supabase: client,
+      cart: { obenProductItems: [obenItem()], colacorProductItems: [colacorItem()] },
+      subtotals: { oben: 20, colacor: 50 },
+    }));
+    expect(r.success).toBe(true); // Oben salvou
+    expect(r.results).toEqual(['Orçamento Oben salvo']);
+    expect(r.errors.some((e) => e.step === 'insert_colacor_quote')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Contexto

Continuação autônoma da cobertura do caminho de pedido (decidido com o Codex: irmão do `submitOrder` coberto em #306). `submitQuote.ts` (salva carrinho como **orçamento** — insere `sales_orders` status `orcamento`, **sem sync Omie**) não tinha teste. Spec em `docs/superpowers/specs/2026-05-25-submitquote-test-coverage-design.md`.

## O que muda (só teste)

`src/services/orderSubmission/__tests__/submitQuote.test.ts` — 5 cenários (sem tocar `submitQuote.ts`):
1. Carrinho vazio → validação, sem insert.
2. Oben ok → success + insert `status:'orcamento'`.
3. **Oben FALHA → aborta e NÃO tenta o Colacor** (early return).
4. Oben+Colacor ok → 2 inserts, 2 results, e **nunca chama `functions.invoke`** (orçamento não sincroniza com o ERP).
5. **Colacor falha (Oben ok) → NÃO aborta**: success true, erro `insert_colacor_quote` registrado.

## Test plan

- [x] submitQuote 5/5; lint limpo; sem mudança de produção (aditivo → CI roda a suíte cheia como gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)