### PR TITLE
test(reposicao): cobertura do calcApprovalSuggestion (auto-aprovação de compras)

### DIFF
--- a/docs/superpowers/specs/2026-05-25-approval-suggestion-test-design.md
+++ b/docs/superpowers/specs/2026-05-25-approval-suggestion-test-design.md
@@ -1,0 +1,30 @@
+# Cobertura de teste do `calcApprovalSuggestion` — Design Spec
+
+> **Data:** 2026-05-25
+> **Status:** continuação autônoma (Codex #2 na fila de cobertura). Função **pura** de auto-aprovação de compras (`src/lib/reposicao/approvalSuggestion.ts`) sem teste — purchasing é money-adjacent e lógica pura gera testes duráveis.
+
+## Goal
+
+Travar as regras de `calcApprovalSuggestion(item)`: quando o item de sugestão de compra pode ser **auto-aprovado** (`mode:'auto'`) vs precisa de **revisão manual** (`mode:'review'` + razões). Sem mudança de código.
+
+## Regras (do código)
+
+`auto` exige TODAS: `num_skus > 0`; `status` contém `'pendente_aprovacao'` E sem `aprovado_em`/`cancelado_em`; `pedido_anterior_valor > 0`; e variação `|valor_total - anterior|/anterior ≤ 0.3` (`VALUE_DELTA_REVIEW_THRESHOLD`). Qualquer violação → `review` com a razão correspondente; razões acumulam.
+
+## Cenários
+
+1. **Auto (caminho limpo)**: qtd 5, status `pendente_aprovacao`, sem aprovado/cancelado, anterior 100, atual 100 (delta 0) → `{mode:'auto', reasons:[]}`.
+2. **Qtd inválida** (0/null) → `review` + "Quantidade sugerida inválida".
+3. **Status não-pendente** (ex.: `aprovado_em` setado, ou status `aprovado`) → `review` + "Confiança baixa/média — verificar status".
+4. **Primeiro pedido** (anterior 0/null) → `review` + "Primeiro pedido — sem referência histórica".
+5. **Delta > 30%** (atual 200, anterior 100 → 100%) → `review` + razão "Valor varia 100.0%".
+6. **Boundary delta = 30%** (atual 130, anterior 100 → 0.3, NÃO > 0.3) com resto limpo → `auto` (não dispara a razão de variação).
+7. **Acúmulo** (qtd 0 + primeiro pedido) → `review` com ≥2 razões.
+
+## Testing
+
+`src/lib/reposicao/__tests__/approvalSuggestion.test.ts` (vitest, sem mocks — função pura). Suíte verde; lint limpo; sem tocar o módulo.
+
+## Out-of-scope
+
+- Quem consome a sugestão (UI/queries); só a regra pura.

--- a/src/lib/reposicao/__tests__/approvalSuggestion.test.ts
+++ b/src/lib/reposicao/__tests__/approvalSuggestion.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { calcApprovalSuggestion, type ApprovalInput } from '../approvalSuggestion';
+
+function base(over: Partial<ApprovalInput> = {}): ApprovalInput {
+  return {
+    num_skus: 5,
+    valor_total: 100,
+    pedido_anterior_valor: 100,
+    status: 'pendente_aprovacao',
+    aprovado_em: null,
+    cancelado_em: null,
+    ...over,
+  };
+}
+
+describe('calcApprovalSuggestion', () => {
+  it('caminho limpo → auto, sem razões', () => {
+    const r = calcApprovalSuggestion(base());
+    expect(r).toEqual({ mode: 'auto', reasons: [] });
+  });
+
+  it('quantidade inválida → review', () => {
+    const r = calcApprovalSuggestion(base({ num_skus: 0 }));
+    expect(r.mode).toBe('review');
+    expect(r.reasons).toContain('Quantidade sugerida inválida');
+  });
+
+  it('status não-pendente (aprovado_em setado) → review', () => {
+    const r = calcApprovalSuggestion(base({ aprovado_em: '2026-05-01T00:00:00Z' }));
+    expect(r.mode).toBe('review');
+    expect(r.reasons).toContain('Confiança baixa/média — verificar status');
+  });
+
+  it('primeiro pedido (sem valor anterior) → review', () => {
+    const r = calcApprovalSuggestion(base({ pedido_anterior_valor: 0 }));
+    expect(r.mode).toBe('review');
+    expect(r.reasons).toContain('Primeiro pedido — sem referência histórica');
+  });
+
+  it('variação > 30% → review com a razão de variação', () => {
+    const r = calcApprovalSuggestion(base({ valor_total: 200, pedido_anterior_valor: 100 }));
+    expect(r.mode).toBe('review');
+    expect(r.reasons.some((x) => x.includes('Valor varia 100.0%'))).toBe(true);
+  });
+
+  it('variação exatamente 30% (boundary, não > 0.3) → auto', () => {
+    const r = calcApprovalSuggestion(base({ valor_total: 130, pedido_anterior_valor: 100 }));
+    expect(r).toEqual({ mode: 'auto', reasons: [] });
+  });
+
+  it('acumula razões (qtd inválida + primeiro pedido)', () => {
+    const r = calcApprovalSuggestion(base({ num_skus: 0, pedido_anterior_valor: null }));
+    expect(r.mode).toBe('review');
+    expect(r.reasons).toContain('Quantidade sugerida inválida');
+    expect(r.reasons).toContain('Primeiro pedido — sem referência histórica');
+    expect(r.reasons.length).toBeGreaterThanOrEqual(2);
+  });
+});


### PR DESCRIPTION
## Contexto

Continuação autônoma da cobertura (Codex #2). `src/lib/reposicao/approvalSuggestion.ts` — função **pura** que decide se um item de sugestão de compra pode ser **auto-aprovado** ou precisa de **revisão** — não tinha teste. Purchasing é money-adjacent. Spec em `docs/superpowers/specs/2026-05-25-approval-suggestion-test-design.md`.

## O que muda (só teste)

`src/lib/reposicao/__tests__/approvalSuggestion.test.ts` — 7 cenários travando as regras: caminho limpo→auto, qtd inválida, status não-pendente, primeiro pedido, variação >30%, **boundary exato 30%→auto**, e acúmulo de razões. Sem tocar o módulo.

## Test plan

- [x] 7/7; lint limpo; função pura (sem mocks); aditivo (CI roda a suíte cheia como gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)