### PR TITLE
test(reposicao): cobertura dos helpers de sku-param

### DIFF
--- a/docs/superpowers/specs/2026-05-25-sku-param-test-design.md
+++ b/docs/superpowers/specs/2026-05-25-sku-param-test-design.md
@@ -1,0 +1,32 @@
+# Cobertura de teste dos helpers de `sku-param.ts` — Design Spec
+
+> **Data:** 2026-05-25
+> **Status:** continuação autônoma (Codex #3 na fila de cobertura). Helpers **puros** de apresentação extraídos do god-component da Reposição (`src/lib/reposicao/sku-param.ts`) sem teste. Dirigem o que o **comprador** lê na tela (badge de fonte de preço, classe ABC, valores BRL) — barato de travar, regressão silenciosa se mudar.
+
+## Goal
+
+Travar o comportamento dos 5 helpers puros de `sku-param.ts`. Sem mudança de código.
+
+## Regras (do código)
+
+- **`fonteBadgeVariant(fonte)`** → `'success'|'warning'|'danger'|'outline'`. Ordem importa: null/vazio → `danger`; contém `'compra'` **E** `'real'` → `success`; senão contém `'estim'` → `warning`; senão contém `'sem'` → `danger`; senão → `outline`. Case-insensitive.
+- **`fonteBadgeLabel(fonte)`** → string. null/vazio → `'Sem preço'`; `compra`+`real` → `'Compra real'`; `estim` → `'Estimado'`; `sem` → `'Sem preço'`; **fallback devolve o `fonte` original (NÃO lowercased)**.
+- **`classBadge(classe)`** → string. null → `'secondary'`; 1º char `'A'` → `'destructive'`; `'B'` → `'default'`; qualquer outro → `'secondary'`.
+- **`fmt(v, dec=2)`** → string pt-BR. null/undefined → `'—'`; `0` formata (`'0,00'`, **não** `'—'` — guarda contra bug de falsy); respeita `dec`; separador de milhar `.` e decimal `,`.
+- **`fmtBRL(v)`** → string pt-BR moeda. null/undefined → `'—'`; senão `'R$ …'` com **espaço não-quebrável (U+00A0)** após `R$`.
+
+## Cenários
+
+1. **`fonteBadgeVariant`**: `null`/`''` → danger; `'compra real'`/`'Compra Real'` → success; `'compra estimada'` (tem `compra` mas não `real`, tem `estim`) → warning; `'estimado'` → warning; `'sem preço'` → danger; `'qualquer'` → outline.
+2. **`fonteBadgeLabel`**: `null` → 'Sem preço'; `'compra real'` → 'Compra real'; `'estim...'` → 'Estimado'; `'sem...'` → 'Sem preço'; fallback `'XPTO'` devolve `'XPTO'` verbatim.
+3. **`classBadge`**: `null` → secondary; `'A'`/`'A2'` → destructive; `'B'` → default; `'C'`/`'X'` → secondary.
+4. **`fmt`**: `null`/`undefined` → '—'; `0` → '0,00'; `1234.5` → '1.234,50'; `2.5` com `dec=1` → '2,5'; `1200` com `dec=0` → '1.200'.
+5. **`fmtBRL`**: `null` → '—'; `0` → contém `'R$'` e `'0,00'`; `1234.5` → contém `'R$'` e `'1.234,50'` (asserts por `toContain` pra não acoplar ao NBSP).
+
+## Testing
+
+`src/lib/reposicao/__tests__/skuParam.test.ts` (vitest, sem mocks — funções puras). Suíte verde; lint limpo; sem tocar o módulo.
+
+## Out-of-scope
+
+- Os `type`s (sem runtime); quem consome os helpers (page/sheet). Só a regra pura.

--- a/src/lib/reposicao/__tests__/skuParam.test.ts
+++ b/src/lib/reposicao/__tests__/skuParam.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from 'vitest';
+import {
+  fonteBadgeVariant,
+  fonteBadgeLabel,
+  classBadge,
+  fmt,
+  fmtBRL,
+} from '../sku-param';
+
+describe('fonteBadgeVariant', () => {
+  it('null/undefined/vazio → danger', () => {
+    expect(fonteBadgeVariant(null)).toBe('danger');
+    expect(fonteBadgeVariant(undefined)).toBe('danger');
+    expect(fonteBadgeVariant('')).toBe('danger');
+  });
+
+  it('compra + real → success (case-insensitive)', () => {
+    expect(fonteBadgeVariant('compra real')).toBe('success');
+    expect(fonteBadgeVariant('Compra Real')).toBe('success');
+    expect(fonteBadgeVariant('preço de compra (real)')).toBe('success');
+  });
+
+  it('compra sem real cai pra estim → warning', () => {
+    // tem 'compra' mas não 'real'; tem 'estim' → warning (ordem dos ifs)
+    expect(fonteBadgeVariant('compra estimada')).toBe('warning');
+  });
+
+  it('estim → warning', () => {
+    expect(fonteBadgeVariant('estimado')).toBe('warning');
+    expect(fonteBadgeVariant('ESTIMATIVA')).toBe('warning');
+  });
+
+  it('sem → danger', () => {
+    expect(fonteBadgeVariant('sem preço')).toBe('danger');
+  });
+
+  it('desconhecido → outline', () => {
+    expect(fonteBadgeVariant('qualquer coisa')).toBe('outline');
+  });
+});
+
+describe('fonteBadgeLabel', () => {
+  it('null/vazio → Sem preço', () => {
+    expect(fonteBadgeLabel(null)).toBe('Sem preço');
+    expect(fonteBadgeLabel(undefined)).toBe('Sem preço');
+    expect(fonteBadgeLabel('')).toBe('Sem preço');
+  });
+
+  it('compra + real → Compra real', () => {
+    expect(fonteBadgeLabel('compra real')).toBe('Compra real');
+    expect(fonteBadgeLabel('Compra Real')).toBe('Compra real');
+  });
+
+  it('estim → Estimado', () => {
+    expect(fonteBadgeLabel('estimado')).toBe('Estimado');
+  });
+
+  it('sem → Sem preço', () => {
+    expect(fonteBadgeLabel('sem dados')).toBe('Sem preço');
+  });
+
+  it('fallback devolve o fonte original (NÃO lowercased)', () => {
+    expect(fonteBadgeLabel('XPTO')).toBe('XPTO');
+    expect(fonteBadgeLabel('Tabela Manual')).toBe('Tabela Manual');
+  });
+});
+
+describe('classBadge', () => {
+  it('null → secondary', () => {
+    expect(classBadge(null)).toBe('secondary');
+  });
+
+  it('classe A → destructive (olha só o 1º char)', () => {
+    expect(classBadge('A')).toBe('destructive');
+    expect(classBadge('AX')).toBe('destructive');
+  });
+
+  it('classe B → default', () => {
+    expect(classBadge('B')).toBe('default');
+    expect(classBadge('BY')).toBe('default');
+  });
+
+  it('classe C / outras → secondary', () => {
+    expect(classBadge('C')).toBe('secondary');
+    expect(classBadge('CZ')).toBe('secondary');
+    expect(classBadge('X')).toBe('secondary');
+  });
+});
+
+describe('fmt', () => {
+  it('null/undefined → travessão', () => {
+    expect(fmt(null)).toBe('—');
+    expect(fmt(undefined)).toBe('—');
+  });
+
+  it('zero formata (não é tratado como vazio)', () => {
+    expect(fmt(0)).toBe('0,00');
+  });
+
+  it('milhar + 2 casas por padrão (pt-BR)', () => {
+    expect(fmt(1234.5)).toBe('1.234,50');
+    expect(fmt(1000000)).toBe('1.000.000,00');
+  });
+
+  it('respeita o parâmetro de casas decimais', () => {
+    expect(fmt(2.5, 1)).toBe('2,5');
+    expect(fmt(1200, 0)).toBe('1.200');
+  });
+});
+
+describe('fmtBRL', () => {
+  it('null/undefined → travessão', () => {
+    expect(fmtBRL(null)).toBe('—');
+    expect(fmtBRL(undefined)).toBe('—');
+  });
+
+  it('zero formata como moeda (não vira travessão)', () => {
+    const out = fmtBRL(0);
+    expect(out).toContain('R$');
+    expect(out).toContain('0,00');
+  });
+
+  it('valor em BRL pt-BR (milhar + 2 casas)', () => {
+    const out = fmtBRL(1234.5);
+    expect(out).toContain('R$');
+    expect(out).toContain('1.234,50');
+  });
+});


### PR DESCRIPTION
## Resumo
Cobertura de teste **aditiva** (test-only) para os 5 helpers puros de `src/lib/reposicao/sku-param.ts`, extraídos do god-component da Reposição e até agora sem teste. Eles dirigem o que o **comprador** lê na tela (badge da fonte de preço, classe ABC, valores BRL) — regressão silenciosa se mudarem.

- `fonteBadgeVariant` / `fonteBadgeLabel` — ordem dos ifs (`compra+real` → `estim` → `sem`), case-insensitive, fallback que devolve o `fonte` verbatim
- `classBadge` — cor por 1º char da classe ABC
- `fmt` / `fmtBRL` — formatação pt-BR; trava o **zero formatando** (guarda contra bug de falsy) e milhar/decimais

22 casos, sem mocks (funções puras). Asserts de moeda por `toContain` pra **não acoplar ao espaço não-quebrável (U+00A0)** do locale BRL.

## Sem mudança de código
`sku-param.ts` não foi tocado. Só `__tests__/skuParam.test.ts` + a spec.

## Test plan
- [x] `bun run test -- src/lib/reposicao/__tests__/skuParam.test.ts` → 22/22 verde
- [x] `eslint` no arquivo novo → exit 0
- [ ] CI `validate` (tsc + typecheck:strict + test + build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)