### PR TITLE
test(sales): cobertura do buildPrintData (dados de impressão)

### DIFF
--- a/docs/superpowers/specs/2026-05-25-build-print-data-test-design.md
+++ b/docs/superpowers/specs/2026-05-25-build-print-data-test-design.md
@@ -1,0 +1,43 @@
+# Cobertura de teste do `buildPrintData` — Design Spec
+
+> **Data:** 2026-05-25
+> **Status:** continuação autônoma (Codex #4 na fila de cobertura). Função **pura** que monta os dados de impressão do pedido (`src/services/orderSubmission/buildPrintData.ts`) sem teste. Money-adjacent — é o que o cliente lê no comprovante (itens, totais, frete, condição de pagamento). Lógica pura → teste durável.
+
+## Goal
+
+Travar o mapeamento carrinho → `PrintOrderData[]`: quais blocos são gerados (Oben/Colacor/Serviço), em que ordem, com que totais, fallbacks de perfil de empresa e parsing do nº do pedido. Sem mudança de código.
+
+## Regras (do código)
+
+- Gera **um bloco por conta com itens** (`length > 0`), na ordem fixa **Oben → Colacor → Serviço**. Carrinho vazio → `[]`.
+- **Oben**: `isOben:true`; `orderNumber` = `results.find(startsWith 'PV Oben')` sem o prefixo (ou `''`); itens mapeados com `valorTotal = quantity * unit_price` + campos de tinta (`tintCorId`/`tintNomeCor`); `subtotal === total === obenSubtotal`; `frete:0`, `desconto:0`; `observacoes = notes || undefined`; `condPagamento = findParcelaDesc(parcelaOben, formasPagamentoOben)`.
+- **Colacor**: `isOben:false`; `orderNumber` de `'PV Colacor '`; itens sem campos de tinta; demais iguais ao Oben.
+- **Serviço**: `isOben:false`; `orderNumber` de `'OS '`; itens via `getServicePrice(c)` (`valorTotal = price * quantity`, `codigo = omie_codigo_servico.toString() || '-'`, `descricao = servico.descricao || getToolName(userTool)`, `unidade 'SV'`); `frete = DELIVERY_FEES[deliveryOption]`; `total = serviceSubtotal + frete`; `condPagamento = afiacaoMethod==='a_vista' ? 'À Vista' : afiacaoMethod`.
+- **Perfil da empresa** (`companyProfiles.{oben,colacor,afiacao}`) sobrescreve nome/CNPJ/telefone/endereço; ausente → fallback hardcoded.
+- `customerDocument = customer.cnpj_cpf || ''`.
+
+## Cenários
+
+1. **Carrinho vazio** → `[]`.
+2. **Só Oben** → 1 bloco; `isOben:true`; orderNumber `'12345'`; item `valorTotal = 2*10 = 20`; subtotal=total; observacoes=notes; fallback `'OBEN COMÉRCIO LTDA'` sem perfil.
+3. **Só Colacor** → 1 bloco; `isOben:false`; orderNumber de `'PV Colacor '`; fallback `'COLACOR COMERCIAL LTDA'`.
+4. **Só Serviço** → 1 bloco; `frete === DELIVERY_FEES[deliveryOption]`; `total === serviceSubtotal + frete`; `condPagamento 'À Vista'` quando `a_vista`; preço via `getServicePrice`.
+5. **Os três** → 3 blocos na ordem Oben, Colacor, Serviço.
+6. **Perfis presentes** → sobrescrevem companyName/cnpj/phone/address.
+7. **`results` sem prefixo** → `orderNumber === ''`.
+8. **notes vazio** → `observacoes === undefined`; **cnpj_cpf null** → `customerDocument === ''`.
+9. **condPagamento de serviço passthrough** quando `afiacaoMethod !== 'a_vista'`.
+
+## Mock
+
+- `vi.mock('../helpers')` → `findParcelaDesc` retorna `desc:<codigo>`; `getToolName` retorna `'FerramentaMock'` (isola o mapeamento da lógica dos helpers, já cobertos à parte).
+- `DELIVERY_FEES` **real** de `@/types` (assert por referência à constante, não valor hardcoded — robusto a mudança de tabela de frete).
+- Fixtures por `as unknown as` (padrão dos testes de submitOrder/submitQuote).
+
+## Testing
+
+`src/services/orderSubmission/__tests__/buildPrintData.test.ts` (vitest). Sem rede. Suíte verde; lint limpo; sem tocar `buildPrintData.ts`.
+
+## Out-of-scope
+
+- O componente `OrderPrintLayout` (render); helpers (mockados/cobertos à parte).

--- a/src/services/orderSubmission/__tests__/buildPrintData.test.ts
+++ b/src/services/orderSubmission/__tests__/buildPrintData.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../helpers', () => ({
+  findParcelaDesc: vi.fn((codigo: string) => `desc:${codigo}`),
+  getToolName: vi.fn(() => 'FerramentaMock'),
+}));
+
+import { buildPrintData } from '../buildPrintData';
+import { DELIVERY_FEES } from '@/types';
+import type { DeliveryOption } from '@/types';
+import type {
+  CompanyProfile,
+  FormaPagamento,
+  OmieCustomer,
+  ProductCartItem,
+  ServiceCartItem,
+} from '@/hooks/unifiedOrder/types';
+
+type Params = Parameters<typeof buildPrintData>[0];
+
+const customer = {
+  razao_social: 'ACME LTDA',
+  cnpj_cpf: '12345678000199',
+} as OmieCustomer;
+
+function obenItem(over: Partial<ProductCartItem> = {}): ProductCartItem {
+  return {
+    type: 'product', account: 'oben', quantity: 2, unit_price: 10,
+    tint_cor_id: 'cor-1', tint_nome_cor: 'Azul',
+    product: { id: 'p1', codigo: 'C1', descricao: 'Lixa', unidade: 'UN', omie_codigo_produto: 'OBEN1' },
+    ...over,
+  } as unknown as ProductCartItem;
+}
+function colacorItem(): ProductCartItem {
+  return {
+    type: 'product', account: 'colacor', quantity: 1, unit_price: 50,
+    product: { id: 'p2', codigo: 'C2', descricao: 'Disco', unidade: 'UN', omie_codigo_produto: 'COL1' },
+  } as unknown as ProductCartItem;
+}
+function svcItem(): ServiceCartItem {
+  return {
+    type: 'service', quantity: 3,
+    servico: { omie_codigo_servico: 999, descricao: 'Afiação' },
+    userTool: {},
+  } as unknown as ServiceCartItem;
+}
+
+function makeParams(over: Partial<Params> = {}): Params {
+  return {
+    customer,
+    customerAddress: 'Rua X, 1',
+    customerPhone: '11999999999',
+    obenProductItems: [],
+    colacorProductItems: [],
+    serviceItems: [],
+    obenSubtotal: 0,
+    colacorSubtotal: 0,
+    serviceSubtotal: 0,
+    parcelaOben: '000',
+    parcelaColacor: '000',
+    formasPagamentoOben: [] as FormaPagamento[],
+    formasPagamentoColacor: [] as FormaPagamento[],
+    afiacaoMethod: 'a_vista',
+    deliveryOption: 'balcao' as DeliveryOption,
+    notes: '',
+    results: [],
+    companyProfiles: {} as Record<string, CompanyProfile>,
+    getServicePrice: () => 25,
+    ...over,
+  };
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('buildPrintData', () => {
+  it('carrinho vazio → array vazio', () => {
+    expect(buildPrintData(makeParams())).toEqual([]);
+  });
+
+  it('só Oben → 1 bloco isOben, valorTotal = qtd × preço, tinta mapeada', () => {
+    const [bloco, ...rest] = buildPrintData(makeParams({
+      obenProductItems: [obenItem()],
+      obenSubtotal: 20,
+      results: ['PV Oben 12345'],
+      notes: 'entregar amanhã',
+    }));
+    expect(rest).toHaveLength(0);
+    expect(bloco.isOben).toBe(true);
+    expect(bloco.orderNumber).toBe('12345');
+    expect(bloco.subtotal).toBe(20);
+    expect(bloco.total).toBe(20);
+    expect(bloco.frete).toBe(0);
+    expect(bloco.desconto).toBe(0);
+    expect(bloco.observacoes).toBe('entregar amanhã');
+    expect(bloco.condPagamento).toBe('desc:000'); // findParcelaDesc mockado
+    expect(bloco.companyName).toBe('OBEN COMÉRCIO LTDA'); // fallback sem perfil
+    expect(bloco.items).toHaveLength(1);
+    expect(bloco.items[0]).toMatchObject({
+      codigo: 'C1', descricao: 'Lixa', quantidade: 2, unidade: 'UN',
+      valorUnitario: 10, valorTotal: 20, tintCorId: 'cor-1', tintNomeCor: 'Azul',
+    });
+  });
+
+  it('só Colacor → 1 bloco não-Oben, orderNumber de "PV Colacor", sem campos de tinta', () => {
+    const [bloco] = buildPrintData(makeParams({
+      colacorProductItems: [colacorItem()],
+      colacorSubtotal: 50,
+      results: ['PV Colacor 67890'],
+    }));
+    expect(bloco.isOben).toBe(false);
+    expect(bloco.orderNumber).toBe('67890');
+    expect(bloco.total).toBe(50);
+    expect(bloco.companyName).toBe('COLACOR COMERCIAL LTDA');
+    expect(bloco.items[0]).toMatchObject({ codigo: 'C2', valorTotal: 50 });
+    expect('tintCorId' in bloco.items[0]).toBe(false);
+  });
+
+  it('só Serviço → frete = DELIVERY_FEES[opção], total = subtotal + frete, preço via callback', () => {
+    const opt: DeliveryOption = 'somente_entrega';
+    const [bloco] = buildPrintData(makeParams({
+      serviceItems: [svcItem()],
+      serviceSubtotal: 75,
+      results: ['OS 555'],
+      deliveryOption: opt,
+      getServicePrice: () => 25,
+    }));
+    expect(bloco.isOben).toBe(false);
+    expect(bloco.orderNumber).toBe('555');
+    expect(bloco.frete).toBe(DELIVERY_FEES[opt]);
+    expect(bloco.total).toBe(75 + DELIVERY_FEES[opt]);
+    expect(bloco.condPagamento).toBe('À Vista'); // afiacaoMethod a_vista
+    expect(bloco.companyName).toBe('COLACOR S.C LTDA');
+    expect(bloco.items[0]).toMatchObject({
+      codigo: '999', descricao: 'Afiação', quantidade: 3, unidade: 'SV',
+      valorUnitario: 25, valorTotal: 75,
+    });
+  });
+
+  it('os três → 3 blocos na ordem Oben, Colacor, Serviço', () => {
+    const blocos = buildPrintData(makeParams({
+      obenProductItems: [obenItem()], obenSubtotal: 20,
+      colacorProductItems: [colacorItem()], colacorSubtotal: 50,
+      serviceItems: [svcItem()], serviceSubtotal: 75,
+      results: ['PV Oben 1', 'PV Colacor 2', 'OS 3'],
+    }));
+    expect(blocos).toHaveLength(3);
+    expect(blocos[0].isOben).toBe(true);
+    expect(blocos[0].orderNumber).toBe('1');
+    expect(blocos[1].orderNumber).toBe('2');
+    expect(blocos[2].orderNumber).toBe('3');
+  });
+
+  it('perfis presentes sobrescrevem o fallback hardcoded', () => {
+    const companyProfiles = {
+      oben: { legal_name: 'OBEN CUSTOM', cnpj: '00.000.000/0001-00', phone: '(00) 0000', address: 'Rua Custom' },
+    } as unknown as Record<string, CompanyProfile>;
+    const [bloco] = buildPrintData(makeParams({
+      obenProductItems: [obenItem()], obenSubtotal: 20,
+      companyProfiles,
+    }));
+    expect(bloco.companyName).toBe('OBEN CUSTOM');
+    expect(bloco.companyCnpj).toBe('00.000.000/0001-00');
+    expect(bloco.companyPhone).toBe('(00) 0000');
+    expect(bloco.companyAddress).toBe('Rua Custom');
+  });
+
+  it('results sem o prefixo correspondente → orderNumber vazio', () => {
+    const [bloco] = buildPrintData(makeParams({
+      obenProductItems: [obenItem()], obenSubtotal: 20,
+      results: ['OS 999'], // nada de "PV Oben"
+    }));
+    expect(bloco.orderNumber).toBe('');
+  });
+
+  it('notes vazio → observacoes undefined; cnpj_cpf null → customerDocument vazio', () => {
+    const [bloco] = buildPrintData(makeParams({
+      customer: { razao_social: 'SEM DOC', cnpj_cpf: null } as unknown as OmieCustomer,
+      obenProductItems: [obenItem()], obenSubtotal: 20,
+      notes: '',
+    }));
+    expect(bloco.observacoes).toBeUndefined();
+    expect(bloco.customerDocument).toBe('');
+  });
+
+  it('condPagamento de serviço faz passthrough quando não é a_vista', () => {
+    const [bloco] = buildPrintData(makeParams({
+      serviceItems: [svcItem()], serviceSubtotal: 75,
+      afiacaoMethod: 'parcelado_3x',
+    }));
+    expect(bloco.condPagamento).toBe('parcelado_3x');
+  });
+
+  it('descricao de serviço cai pra getToolName quando servico.descricao ausente', () => {
+    const semDesc = { type: 'service', quantity: 1, servico: { omie_codigo_servico: 7 }, userTool: {} } as unknown as ServiceCartItem;
+    const [bloco] = buildPrintData(makeParams({
+      serviceItems: [semDesc], serviceSubtotal: 10,
+    }));
+    expect(bloco.items[0].descricao).toBe('FerramentaMock');
+    expect(bloco.items[0].codigo).toBe('7');
+  });
+});


### PR DESCRIPTION
## Resumo
Cobertura de teste **aditiva** (test-only) para `buildPrintData` (`src/services/orderSubmission/buildPrintData.ts`), até agora sem teste. É a função pura que monta o que o cliente lê no comprovante impresso — money-adjacent.

Trava:
- **Blocos por conta** (Oben/Colacor/Serviço) gerados só quando há itens, na ordem fixa Oben → Colacor → Serviço; carrinho vazio → `[]`
- `valorTotal = quantidade × preço`; campos de tinta só no Oben
- **Frete** via `DELIVERY_FEES[deliveryOption]` e `total = subtotal + frete` no bloco de serviço (assert por **referência à constante**, robusto a mudança da tabela de frete)
- `orderNumber` parseado de `results` (`'PV Oben 123'` → `'123'`; sem match → `''`)
- Fallback de **perfil de empresa** (hardcoded) vs. perfil presente (override)
- `condPagamento` de serviço (`'a_vista'` → `'À Vista'`; senão passthrough)
- `observacoes = notes || undefined`; `customerDocument = cnpj_cpf || ''`

10 casos. `../helpers` mockado (findParcelaDesc/getToolName — cobertos à parte).

## Sem mudança de código
`buildPrintData.ts` não foi tocado. Só o teste + a spec.

## Test plan
- [x] `bun run test -- src/services/orderSubmission/__tests__/buildPrintData.test.ts` → 10/10 verde
- [x] `eslint` no arquivo novo → exit 0
- [ ] CI `validate` (tsc + typecheck:strict + test + build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)