### PR TITLE
refactor(financeiro): split PosicaoAgora (502→94) em hook + lógica + componentes

### DIFF
--- a/src/components/financeiro/cashflow/PosicaoAgora.tsx
+++ b/src/components/financeiro/cashflow/PosicaoAgora.tsx
@@ -1,83 +1,21 @@
-import { useState, useEffect } from 'react';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
+// Posição de caixa "agora" — liquidez, ciclo financeiro, projeção 30d e stress test.
+// Composição: usePosicaoAgora (dados/consolidação) + filtro + cards de seção.
+// God-component split de src/components/financeiro/cashflow/PosicaoAgora.tsx (comportamento 1:1).
+import { Card, CardContent } from '@/components/ui/card';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
-import { Progress } from '@/components/ui/progress';
 import { Skeleton } from '@/components/ui/skeleton';
 import { COMPANIES, ALL_COMPANIES, type Company } from '@/contexts/CompanyContext';
-import { getCapitalDeGiro, type CapitalDeGiro } from '@/services/financeiroService';
-import {
-  Building2, TrendingUp, TrendingDown, Clock,
-  AlertTriangle, Wallet,
-  BarChart3, Target, ShieldCheck
-} from 'lucide-react';
-
-const fmt = (v: number) =>
-  v.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
-
-const fmtCompact = (v: number) => {
-  if (Math.abs(v) >= 1_000_000) return `R$ ${(v / 1_000_000).toFixed(1)}M`;
-  if (Math.abs(v) >= 1_000) return `R$ ${(v / 1_000).toFixed(1)}k`;
-  return fmt(v);
-};
+import { Building2 } from 'lucide-react';
+import { usePosicaoAgora } from './posicaoAgora/usePosicaoAgora';
+import { KpiCards } from './posicaoAgora/KpiCards';
+import { CicloFinanceiroCard } from './posicaoAgora/CicloFinanceiroCard';
+import { Projecao30dCard } from './posicaoAgora/Projecao30dCard';
+import { ComparativoEmpresasCard } from './posicaoAgora/ComparativoEmpresasCard';
+import { ConcentracaoRiscoCard } from './posicaoAgora/ConcentracaoRiscoCard';
+import { StressTest } from './posicaoAgora/StressTest';
 
 export function PosicaoAgora() {
-  const [data, setData] = useState<CapitalDeGiro[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [view, setView] = useState<'all' | Company>('all');
-
-  useEffect(() => {
-    loadData();
-  }, [view]);
-
-  const loadData = async () => {
-    setLoading(true);
-    try {
-      const result = await getCapitalDeGiro(view);
-      setData(result);
-    } catch (e) {
-      console.error(e);
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  // Consolidado — médias ponderadas por volume (Ponto 10)
-  const consolidated: CapitalDeGiro | null = data.length > 0
-    ? (() => {
-        const totalCR = data.reduce((s, d) => s + d.total_cr_aberto, 0);
-        const totalCP = data.reduce((s, d) => s + d.total_cp_aberto, 0);
-
-        // PMR ponderado pelo volume de CR de cada empresa
-        const pmrWeighted = totalCR > 0
-          ? Math.round(data.reduce((s, d) => s + d.pmr * d.total_cr_aberto, 0) / totalCR)
-          : 0;
-        // PMP ponderado pelo volume de CP de cada empresa
-        const pmpWeighted = totalCP > 0
-          ? Math.round(data.reduce((s, d) => s + d.pmp * d.total_cp_aberto, 0) / totalCP)
-          : 0;
-
-        return {
-          company: 'consolidado',
-          total_cr_aberto: totalCR,
-          total_cp_aberto: totalCP,
-          saldo_cc: data.reduce((s, d) => s + d.saldo_cc, 0),
-          capital_giro: data.reduce((s, d) => s + d.capital_giro, 0),
-          capital_giro_liquido: data.reduce((s, d) => s + d.capital_giro_liquido, 0),
-          pmr: pmrWeighted,
-          pmp: pmpWeighted,
-          ciclo_financeiro: pmrWeighted - pmpWeighted,
-          top5_cr_pct: 0, // Não faz sentido consolidar % de concentração
-          top5_cp_pct: 0,
-          entradas_30d: data.reduce((s, d) => s + d.entradas_30d, 0),
-          saidas_30d: data.reduce((s, d) => s + d.saidas_30d, 0),
-          saldo_projetado_30d: data.reduce((s, d) => s + d.saldo_projetado_30d, 0),
-        };
-      })()
-    : null;
-
-  const active = view === 'all' ? consolidated : data[0] || null;
+  const { data, loading, view, setView, active } = usePosicaoAgora();
 
   if (loading) {
     return (
@@ -121,253 +59,22 @@ export function PosicaoAgora() {
       ) : (
         <>
           {/* KPI Cards */}
-          <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
-            <MetricCard
-              title="Capital de Giro"
-              value={active.capital_giro}
-              subtitle="CR - CP abertos"
-              positive={active.capital_giro >= 0}
-              icon={active.capital_giro >= 0 ? TrendingUp : TrendingDown}
-            />
-            <MetricCard
-              title="CG Líquido"
-              value={active.capital_giro_liquido}
-              subtitle="CR + CC - CP"
-              positive={active.capital_giro_liquido >= 0}
-              icon={Wallet}
-            />
-            <MetricCard
-              title="Projeção 30 dias"
-              value={active.saldo_projetado_30d}
-              subtitle={`+${fmtCompact(active.entradas_30d)} / -${fmtCompact(active.saidas_30d)}`}
-              positive={active.saldo_projetado_30d >= 0}
-              icon={Target}
-            />
-            <div className="p-4 rounded-lg border bg-card">
-              <p className="text-xs text-muted-foreground font-medium">Ciclo Financeiro</p>
-              <p className={`text-2xl font-bold mt-1 ${active.ciclo_financeiro > 0 ? 'text-status-warning' : 'text-status-success'}`}>
-                {active.ciclo_financeiro} dias
-              </p>
-              <p className="text-xs text-muted-foreground mt-1">
-                PMR {active.pmr}d − PMP {active.pmp}d
-              </p>
-            </div>
-          </div>
+          <KpiCards active={active} />
 
           {/* Ciclo Financeiro Visual */}
-          <Card>
-            <CardHeader className="pb-3">
-              <CardTitle className="text-base flex items-center gap-2">
-                <Clock className="w-4 h-4" />
-                Ciclo Financeiro
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-6">
-              <div className="space-y-3">
-                {/* PMR Bar */}
-                <div>
-                  <div className="flex justify-between text-sm mb-1">
-                    <span className="text-muted-foreground">Prazo Médio de Recebimento</span>
-                    <span className="font-bold">{active.pmr} dias</span>
-                  </div>
-                  <div className="h-4 rounded-full bg-muted overflow-hidden">
-                    <div
-                      className="h-full rounded-full bg-status-info transition-all"
-                      style={{ width: `${Math.min((active.pmr / Math.max(active.pmr, active.pmp, 1)) * 100, 100)}%` }}
-                    />
-                  </div>
-                </div>
-                {/* PMP Bar */}
-                <div>
-                  <div className="flex justify-between text-sm mb-1">
-                    <span className="text-muted-foreground">Prazo Médio de Pagamento</span>
-                    <span className="font-bold">{active.pmp} dias</span>
-                  </div>
-                  <div className="h-4 rounded-full bg-muted overflow-hidden">
-                    <div
-                      className="h-full rounded-full bg-status-success transition-all"
-                      style={{ width: `${Math.min((active.pmp / Math.max(active.pmr, active.pmp, 1)) * 100, 100)}%` }}
-                    />
-                  </div>
-                </div>
-              </div>
-
-              <div className={`p-4 rounded-lg ${active.ciclo_financeiro > 0 ? 'bg-status-warning-bg border-status-warning/30' : 'bg-status-success-bg border-status-success/30'} border`}>
-                <p className={`text-sm font-medium ${active.ciclo_financeiro > 0 ? 'text-status-warning-fg' : 'text-status-success-fg'}`}>
-                  {active.ciclo_financeiro > 0
-                    ? `Ciclo positivo de ${active.ciclo_financeiro} dias — você financia seus clientes por ${active.ciclo_financeiro} dias antes de receber.`
-                    : active.ciclo_financeiro < 0
-                      ? `Ciclo negativo de ${Math.abs(active.ciclo_financeiro)} dias — você recebe antes de pagar, gerando caixa livre.`
-                      : 'Ciclo neutro — recebimento e pagamento estão alinhados.'
-                  }
-                </p>
-                {active.ciclo_financeiro > 15 && (
-                  <p className="text-xs mt-2 text-status-warning">
-                    Considere: renegociar prazos com fornecedores, antecipar recebíveis, ou reduzir prazos de vendas.
-                  </p>
-                )}
-              </div>
-            </CardContent>
-          </Card>
+          <CicloFinanceiroCard active={active} />
 
           {/* Projeção 30 dias */}
-          <Card>
-            <CardHeader className="pb-3">
-              <CardTitle className="text-base flex items-center gap-2">
-                <Target className="w-4 h-4" />
-                Projeção de Caixa — Próximos 30 dias
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="space-y-4">
-                <div className="grid grid-cols-3 gap-4 text-center">
-                  <div className="p-3 rounded-lg bg-status-info-bg">
-                    <p className="text-xs text-muted-foreground">Saldo Atual CC</p>
-                    <p className="text-lg font-bold text-status-info">{fmtCompact(active.saldo_cc)}</p>
-                  </div>
-                  <div className="p-3 rounded-lg bg-muted/50">
-                    <p className="text-xs text-muted-foreground">Fluxo Líquido 30d</p>
-                    <p className={`text-lg font-bold ${active.entradas_30d - active.saidas_30d >= 0 ? 'text-status-success' : 'text-status-error'}`}>
-                      {fmtCompact(active.entradas_30d - active.saidas_30d)}
-                    </p>
-                  </div>
-                  <div className={`p-3 rounded-lg ${active.saldo_projetado_30d >= 0 ? 'bg-status-success-bg' : 'bg-status-error-bg'}`}>
-                    <p className="text-xs text-muted-foreground">Saldo Projetado</p>
-                    <p className={`text-lg font-bold ${active.saldo_projetado_30d >= 0 ? 'text-status-success' : 'text-status-error'}`}>
-                      {fmtCompact(active.saldo_projetado_30d)}
-                    </p>
-                  </div>
-                </div>
-
-                {/* Waterfall visual */}
-                <div className="flex items-end justify-center gap-2 h-32">
-                  <WaterfallBar label="CC Atual" value={active.saldo_cc} max={Math.max(active.saldo_cc, active.saldo_projetado_30d, active.entradas_30d)} color="bg-status-info" />
-                  <WaterfallBar label="Entradas" value={active.entradas_30d} max={Math.max(active.saldo_cc, active.saldo_projetado_30d, active.entradas_30d)} color="bg-status-success" />
-                  <WaterfallBar label="Saídas" value={active.saidas_30d} max={Math.max(active.saldo_cc, active.saldo_projetado_30d, active.entradas_30d)} color="bg-status-error" />
-                  <WaterfallBar label="Projetado" value={active.saldo_projetado_30d} max={Math.max(active.saldo_cc, active.saldo_projetado_30d, active.entradas_30d)} color={active.saldo_projetado_30d >= 0 ? 'bg-status-success' : 'bg-status-error'} />
-                </div>
-
-                {active.saldo_projetado_30d < 0 && (
-                  <div className="flex items-start gap-2 p-3 rounded-lg bg-status-error-bg border border-status-error/30">
-                    <AlertTriangle className="w-4 h-4 text-status-error mt-0.5" />
-                    <div>
-                      <p className="text-sm font-medium text-status-error-fg">Projeção negativa</p>
-                      <p className="text-xs text-status-error mt-1">
-                        Déficit projetado de {fmtCompact(Math.abs(active.saldo_projetado_30d))} nos próximos 30 dias.
-                        Ação necessária: antecipar recebíveis, renegociar prazos de CP, ou injetar capital.
-                      </p>
-                    </div>
-                  </div>
-                )}
-              </div>
-            </CardContent>
-          </Card>
+          <Projecao30dCard active={active} />
 
           {/* Comparativo por empresa */}
           {view === 'all' && data.length > 1 && (
-            <Card>
-              <CardHeader className="pb-3">
-                <CardTitle className="text-base flex items-center gap-2">
-                  <BarChart3 className="w-4 h-4" />
-                  Comparativo por Empresa
-                </CardTitle>
-              </CardHeader>
-              <CardContent className="p-0">
-                <div className="overflow-x-auto">
-                  <Table>
-                    <TableHeader>
-                      <TableRow>
-                        <TableHead className="sticky left-0 bg-background">Indicador</TableHead>
-                        {data.map(d => (
-                          <TableHead key={d.company} className="text-right min-w-[120px]">
-                            <div className="flex flex-col items-end">
-                              <span>{COMPANIES[d.company as Company]?.shortName}</span>
-                              <Badge variant="outline" className="text-[10px] mt-0.5">
-                                {COMPANIES[d.company as Company]?.regime === 'simples' ? 'SN' : 'LP'}
-                              </Badge>
-                            </div>
-                          </TableHead>
-                        ))}
-                      </TableRow>
-                    </TableHeader>
-                    <TableBody>
-                      {[
-                        { label: 'CR Aberto', field: 'total_cr_aberto', fmt: 'currency' },
-                        { label: 'CP Aberto', field: 'total_cp_aberto', fmt: 'currency' },
-                        { label: 'Saldo CC', field: 'saldo_cc', fmt: 'currency' },
-                        { label: 'Capital de Giro', field: 'capital_giro', fmt: 'currency' },
-                        { label: 'CG Líquido', field: 'capital_giro_liquido', fmt: 'currency' },
-                        { label: 'PMR', field: 'pmr', fmt: 'days' },
-                        { label: 'PMP', field: 'pmp', fmt: 'days' },
-                        { label: 'Ciclo Financeiro', field: 'ciclo_financeiro', fmt: 'days' },
-                        { label: 'Concentração CR (Top 5)', field: 'top5_cr_pct', fmt: 'pct' },
-                        { label: 'Concentração CP (Top 5)', field: 'top5_cp_pct', fmt: 'pct' },
-                        { label: 'Projeção 30d', field: 'saldo_projetado_30d', fmt: 'currency' },
-                      ].map(line => (
-                        <TableRow key={line.field}>
-                          <TableCell className="sticky left-0 bg-background text-sm font-medium">
-                            {line.label}
-                          </TableCell>
-                          {data.map(d => {
-                            const val = (d as unknown as Record<string, unknown>)[line.field] as number || 0;
-                            const isResult = ['capital_giro', 'capital_giro_liquido', 'saldo_projetado_30d'].includes(line.field);
-                            const color = isResult ? (val >= 0 ? 'text-status-success' : 'text-status-error') : '';
-                            let display = '';
-                            if (line.fmt === 'currency') display = fmtCompact(val);
-                            else if (line.fmt === 'days') display = `${val}d`;
-                            else if (line.fmt === 'pct') display = `${val.toFixed(0)}%`;
-                            return (
-                              <TableCell key={d.company} className={`text-right text-sm font-medium ${color}`}>
-                                {display}
-                              </TableCell>
-                            );
-                          })}
-                        </TableRow>
-                      ))}
-                    </TableBody>
-                  </Table>
-                </div>
-              </CardContent>
-            </Card>
+            <ComparativoEmpresasCard data={data} />
           )}
 
           {/* Concentração de risco */}
           {active.top5_cr_pct > 0 && (
-            <Card>
-              <CardHeader className="pb-3">
-                <CardTitle className="text-base flex items-center gap-2">
-                  <ShieldCheck className="w-4 h-4" />
-                  Concentração de Risco
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <div className="grid grid-cols-2 gap-6">
-                  <div>
-                    <p className="text-sm text-muted-foreground mb-2">Recebíveis — Top 5 clientes</p>
-                    <div className="flex items-center gap-3">
-                      <Progress
-                        value={active.top5_cr_pct}
-                        className={`h-3 ${active.top5_cr_pct > 70 ? '[&>div]:bg-status-error' : active.top5_cr_pct > 50 ? '[&>div]:bg-status-warning' : '[&>div]:bg-status-success'}`}
-                      />
-                      <span className="text-sm font-bold">{active.top5_cr_pct.toFixed(0)}%</span>
-                    </div>
-                    {active.top5_cr_pct > 60 && (
-                      <p className="text-xs text-status-warning mt-1">Alta concentração — diversifique a base de clientes</p>
-                    )}
-                  </div>
-                  <div>
-                    <p className="text-sm text-muted-foreground mb-2">Payables — Top 5 fornecedores</p>
-                    <div className="flex items-center gap-3">
-                      <Progress
-                        value={active.top5_cp_pct}
-                        className={`h-3 ${active.top5_cp_pct > 70 ? '[&>div]:bg-status-warning' : '[&>div]:bg-status-info'}`}
-                      />
-                      <span className="text-sm font-bold">{active.top5_cp_pct.toFixed(0)}%</span>
-                    </div>
-                  </div>
-                </div>
-              </CardContent>
-            </Card>
+            <ConcentracaoRiscoCard active={active} />
           )}
 
           {/* Stress Test */}
@@ -383,120 +90,5 @@ export function PosicaoAgora() {
         </>
       )}
     </div>
-  );
-}
-
-// ═══════════════ SUB-COMPONENTS ═══════════════
-
-function MetricCard({ title, value, subtitle, positive, icon: Icon }: {
-  title: string; value: number; subtitle: string; positive: boolean; icon: React.ElementType;
-}) {
-  return (
-    <Card>
-      <CardContent className="p-4">
-        <div className="flex items-start justify-between">
-          <div>
-            <p className="text-xs text-muted-foreground font-medium">{title}</p>
-            <p className={`text-lg font-bold mt-1 ${positive ? 'text-status-success' : 'text-status-error'}`}>
-              {fmtCompact(value)}
-            </p>
-            <p className="text-xs text-muted-foreground mt-1">{subtitle}</p>
-          </div>
-          <div className={`p-2 rounded-lg ${positive ? 'bg-status-success-bg' : 'bg-status-error-bg'}`}>
-            <Icon className={`w-4 h-4 ${positive ? 'text-status-success' : 'text-status-error'}`} />
-          </div>
-        </div>
-      </CardContent>
-    </Card>
-  );
-}
-
-function WaterfallBar({ label, value, max, color }: {
-  label: string; value: number; max: number; color: string;
-}) {
-  const pct = max > 0 ? Math.min((Math.abs(value) / max) * 100, 100) : 0;
-  return (
-    <div className="flex flex-col items-center gap-1 flex-1">
-      <div className="w-full flex items-end justify-center h-24">
-        <div
-          className={`w-full max-w-[48px] rounded-t ${color} transition-all`}
-          style={{ height: `${Math.max(pct, 5)}%` }}
-        />
-      </div>
-      <span className="text-[10px] text-muted-foreground text-center">{label}</span>
-      <span className="text-xs font-bold">{fmtCompact(value)}</span>
-    </div>
-  );
-}
-
-function StressTest({ saldoCC, entradas30, saidas30, pmr }: {
-  saldoCC: number; entradas30: number; saidas30: number; totalCR: number; pmr: number;
-}) {
-  const scenarios = [
-    { label: 'Base', delayDays: 0, defaultPct: 0, desc: 'Cenário atual sem alterações' },
-    { label: 'Atraso 15d', delayDays: 15, defaultPct: 0, desc: 'Clientes atrasam 15 dias em média' },
-    { label: 'Atraso 30d', delayDays: 30, defaultPct: 0, desc: 'Clientes atrasam 30 dias em média' },
-    { label: '10% inadimplência', delayDays: 0, defaultPct: 10, desc: '10% dos recebíveis viram perda' },
-    { label: '25% inadimplência', delayDays: 0, defaultPct: 25, desc: '25% dos recebíveis viram perda' },
-    { label: 'Combinado severo', delayDays: 30, defaultPct: 15, desc: 'Atraso 30d + 15% inadimplência' },
-  ];
-
-  return (
-    <Card>
-      <CardHeader className="pb-3">
-        <CardTitle className="text-base flex items-center gap-2">
-          <AlertTriangle className="w-4 h-4" />
-          Teste de Estresse — Sensibilidade do Caixa
-        </CardTitle>
-      </CardHeader>
-      <CardContent>
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead className="min-w-[150px]">Cenário</TableHead>
-              <TableHead className="text-right">Entradas Ajust.</TableHead>
-              <TableHead className="text-right">Saldo 30d</TableHead>
-              <TableHead className="text-right">Impacto</TableHead>
-              <TableHead className="w-20">Risco</TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {scenarios.map(s => {
-              // Se delay > 0, parte das entradas dos próx 30d escorrega pra fora
-              const pctDelayed = s.delayDays > 0
-                ? Math.min(s.delayDays / Math.max(pmr + s.delayDays, 1), 0.8)
-                : 0;
-              const entradasAjust = entradas30 * (1 - pctDelayed) * (1 - s.defaultPct / 100);
-              const saldo = saldoCC + entradasAjust - saidas30;
-              const impacto = saldo - (saldoCC + entradas30 - saidas30);
-              const risco = saldo < 0 ? 'Crítico' : saldo < saldoCC * 0.3 ? 'Alto' : saldo < saldoCC * 0.6 ? 'Médio' : 'Baixo';
-              const riskColor = risco === 'Crítico' ? 'text-status-error bg-status-error-bg'
-                : risco === 'Alto' ? 'text-status-error bg-status-error-bg'
-                : risco === 'Médio' ? 'text-status-warning bg-status-warning-bg'
-                : 'text-status-success bg-status-success-bg';
-
-              return (
-                <TableRow key={s.label} className={saldo < 0 ? 'bg-status-error-bg/50' : ''}>
-                  <TableCell>
-                    <p className="text-sm font-medium">{s.label}</p>
-                    <p className="text-[10px] text-muted-foreground">{s.desc}</p>
-                  </TableCell>
-                  <TableCell className="text-right text-sm">{fmtCompact(entradasAjust)}</TableCell>
-                  <TableCell className={`text-right text-sm font-bold ${saldo >= 0 ? 'text-status-success' : 'text-status-error'}`}>
-                    {fmtCompact(saldo)}
-                  </TableCell>
-                  <TableCell className={`text-right text-sm ${impacto < 0 ? 'text-status-error' : ''}`}>
-                    {fmtCompact(impacto)}
-                  </TableCell>
-                  <TableCell>
-                    <Badge className={`text-[10px] ${riskColor}`}>{risco}</Badge>
-                  </TableCell>
-                </TableRow>
-              );
-            })}
-          </TableBody>
-        </Table>
-      </CardContent>
-    </Card>
   );
 }

--- a/src/components/financeiro/cashflow/posicaoAgora/CicloFinanceiroCard.tsx
+++ b/src/components/financeiro/cashflow/posicaoAgora/CicloFinanceiroCard.tsx
@@ -1,0 +1,64 @@
+// Card visual do ciclo financeiro (PMR/PMP + interpretação).
+// Extraído verbatim de src/components/financeiro/cashflow/PosicaoAgora.tsx (god-component split).
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Clock } from 'lucide-react';
+import type { CapitalDeGiro } from '@/services/financeiroService';
+
+export function CicloFinanceiroCard({ active }: { active: CapitalDeGiro }) {
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base flex items-center gap-2">
+          <Clock className="w-4 h-4" />
+          Ciclo Financeiro
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <div className="space-y-3">
+          {/* PMR Bar */}
+          <div>
+            <div className="flex justify-between text-sm mb-1">
+              <span className="text-muted-foreground">Prazo Médio de Recebimento</span>
+              <span className="font-bold">{active.pmr} dias</span>
+            </div>
+            <div className="h-4 rounded-full bg-muted overflow-hidden">
+              <div
+                className="h-full rounded-full bg-status-info transition-all"
+                style={{ width: `${Math.min((active.pmr / Math.max(active.pmr, active.pmp, 1)) * 100, 100)}%` }}
+              />
+            </div>
+          </div>
+          {/* PMP Bar */}
+          <div>
+            <div className="flex justify-between text-sm mb-1">
+              <span className="text-muted-foreground">Prazo Médio de Pagamento</span>
+              <span className="font-bold">{active.pmp} dias</span>
+            </div>
+            <div className="h-4 rounded-full bg-muted overflow-hidden">
+              <div
+                className="h-full rounded-full bg-status-success transition-all"
+                style={{ width: `${Math.min((active.pmp / Math.max(active.pmr, active.pmp, 1)) * 100, 100)}%` }}
+              />
+            </div>
+          </div>
+        </div>
+
+        <div className={`p-4 rounded-lg ${active.ciclo_financeiro > 0 ? 'bg-status-warning-bg border-status-warning/30' : 'bg-status-success-bg border-status-success/30'} border`}>
+          <p className={`text-sm font-medium ${active.ciclo_financeiro > 0 ? 'text-status-warning-fg' : 'text-status-success-fg'}`}>
+            {active.ciclo_financeiro > 0
+              ? `Ciclo positivo de ${active.ciclo_financeiro} dias — você financia seus clientes por ${active.ciclo_financeiro} dias antes de receber.`
+              : active.ciclo_financeiro < 0
+                ? `Ciclo negativo de ${Math.abs(active.ciclo_financeiro)} dias — você recebe antes de pagar, gerando caixa livre.`
+                : 'Ciclo neutro — recebimento e pagamento estão alinhados.'
+            }
+          </p>
+          {active.ciclo_financeiro > 15 && (
+            <p className="text-xs mt-2 text-status-warning">
+              Considere: renegociar prazos com fornecedores, antecipar recebíveis, ou reduzir prazos de vendas.
+            </p>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/financeiro/cashflow/posicaoAgora/ComparativoEmpresasCard.tsx
+++ b/src/components/financeiro/cashflow/posicaoAgora/ComparativoEmpresasCard.tsx
@@ -1,0 +1,78 @@
+// Tabela comparativa de indicadores por empresa.
+// Extraída verbatim de src/components/financeiro/cashflow/PosicaoAgora.tsx (god-component split).
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { BarChart3 } from 'lucide-react';
+import { COMPANIES, type Company } from '@/contexts/CompanyContext';
+import type { CapitalDeGiro } from '@/services/financeiroService';
+import { fmtCompact } from './format';
+
+export function ComparativoEmpresasCard({ data }: { data: CapitalDeGiro[] }) {
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base flex items-center gap-2">
+          <BarChart3 className="w-4 h-4" />
+          Comparativo por Empresa
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="p-0">
+        <div className="overflow-x-auto">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="sticky left-0 bg-background">Indicador</TableHead>
+                {data.map(d => (
+                  <TableHead key={d.company} className="text-right min-w-[120px]">
+                    <div className="flex flex-col items-end">
+                      <span>{COMPANIES[d.company as Company]?.shortName}</span>
+                      <Badge variant="outline" className="text-[10px] mt-0.5">
+                        {COMPANIES[d.company as Company]?.regime === 'simples' ? 'SN' : 'LP'}
+                      </Badge>
+                    </div>
+                  </TableHead>
+                ))}
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {[
+                { label: 'CR Aberto', field: 'total_cr_aberto', fmt: 'currency' },
+                { label: 'CP Aberto', field: 'total_cp_aberto', fmt: 'currency' },
+                { label: 'Saldo CC', field: 'saldo_cc', fmt: 'currency' },
+                { label: 'Capital de Giro', field: 'capital_giro', fmt: 'currency' },
+                { label: 'CG Líquido', field: 'capital_giro_liquido', fmt: 'currency' },
+                { label: 'PMR', field: 'pmr', fmt: 'days' },
+                { label: 'PMP', field: 'pmp', fmt: 'days' },
+                { label: 'Ciclo Financeiro', field: 'ciclo_financeiro', fmt: 'days' },
+                { label: 'Concentração CR (Top 5)', field: 'top5_cr_pct', fmt: 'pct' },
+                { label: 'Concentração CP (Top 5)', field: 'top5_cp_pct', fmt: 'pct' },
+                { label: 'Projeção 30d', field: 'saldo_projetado_30d', fmt: 'currency' },
+              ].map(line => (
+                <TableRow key={line.field}>
+                  <TableCell className="sticky left-0 bg-background text-sm font-medium">
+                    {line.label}
+                  </TableCell>
+                  {data.map(d => {
+                    const val = (d as unknown as Record<string, unknown>)[line.field] as number || 0;
+                    const isResult = ['capital_giro', 'capital_giro_liquido', 'saldo_projetado_30d'].includes(line.field);
+                    const color = isResult ? (val >= 0 ? 'text-status-success' : 'text-status-error') : '';
+                    let display = '';
+                    if (line.fmt === 'currency') display = fmtCompact(val);
+                    else if (line.fmt === 'days') display = `${val}d`;
+                    else if (line.fmt === 'pct') display = `${val.toFixed(0)}%`;
+                    return (
+                      <TableCell key={d.company} className={`text-right text-sm font-medium ${color}`}>
+                        {display}
+                      </TableCell>
+                    );
+                  })}
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/financeiro/cashflow/posicaoAgora/ConcentracaoRiscoCard.tsx
+++ b/src/components/financeiro/cashflow/posicaoAgora/ConcentracaoRiscoCard.tsx
@@ -1,0 +1,46 @@
+// Card de concentração de risco (Top 5 clientes/fornecedores).
+// Extraído verbatim de src/components/financeiro/cashflow/PosicaoAgora.tsx (god-component split).
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Progress } from '@/components/ui/progress';
+import { ShieldCheck } from 'lucide-react';
+import type { CapitalDeGiro } from '@/services/financeiroService';
+
+export function ConcentracaoRiscoCard({ active }: { active: CapitalDeGiro }) {
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base flex items-center gap-2">
+          <ShieldCheck className="w-4 h-4" />
+          Concentração de Risco
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="grid grid-cols-2 gap-6">
+          <div>
+            <p className="text-sm text-muted-foreground mb-2">Recebíveis — Top 5 clientes</p>
+            <div className="flex items-center gap-3">
+              <Progress
+                value={active.top5_cr_pct}
+                className={`h-3 ${active.top5_cr_pct > 70 ? '[&>div]:bg-status-error' : active.top5_cr_pct > 50 ? '[&>div]:bg-status-warning' : '[&>div]:bg-status-success'}`}
+              />
+              <span className="text-sm font-bold">{active.top5_cr_pct.toFixed(0)}%</span>
+            </div>
+            {active.top5_cr_pct > 60 && (
+              <p className="text-xs text-status-warning mt-1">Alta concentração — diversifique a base de clientes</p>
+            )}
+          </div>
+          <div>
+            <p className="text-sm text-muted-foreground mb-2">Payables — Top 5 fornecedores</p>
+            <div className="flex items-center gap-3">
+              <Progress
+                value={active.top5_cp_pct}
+                className={`h-3 ${active.top5_cp_pct > 70 ? '[&>div]:bg-status-warning' : '[&>div]:bg-status-info'}`}
+              />
+              <span className="text-sm font-bold">{active.top5_cp_pct.toFixed(0)}%</span>
+            </div>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/financeiro/cashflow/posicaoAgora/KpiCards.tsx
+++ b/src/components/financeiro/cashflow/posicaoAgora/KpiCards.tsx
@@ -1,0 +1,43 @@
+// Linha de KPIs do PosicaoAgora (Capital de Giro / CG Líquido / Projeção 30d / Ciclo).
+// Extraída verbatim de src/components/financeiro/cashflow/PosicaoAgora.tsx (god-component split).
+import { TrendingUp, TrendingDown, Wallet, Target } from 'lucide-react';
+import type { CapitalDeGiro } from '@/services/financeiroService';
+import { fmtCompact } from './format';
+import { MetricCard } from './MetricCard';
+
+export function KpiCards({ active }: { active: CapitalDeGiro }) {
+  return (
+    <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
+      <MetricCard
+        title="Capital de Giro"
+        value={active.capital_giro}
+        subtitle="CR - CP abertos"
+        positive={active.capital_giro >= 0}
+        icon={active.capital_giro >= 0 ? TrendingUp : TrendingDown}
+      />
+      <MetricCard
+        title="CG Líquido"
+        value={active.capital_giro_liquido}
+        subtitle="CR + CC - CP"
+        positive={active.capital_giro_liquido >= 0}
+        icon={Wallet}
+      />
+      <MetricCard
+        title="Projeção 30 dias"
+        value={active.saldo_projetado_30d}
+        subtitle={`+${fmtCompact(active.entradas_30d)} / -${fmtCompact(active.saidas_30d)}`}
+        positive={active.saldo_projetado_30d >= 0}
+        icon={Target}
+      />
+      <div className="p-4 rounded-lg border bg-card">
+        <p className="text-xs text-muted-foreground font-medium">Ciclo Financeiro</p>
+        <p className={`text-2xl font-bold mt-1 ${active.ciclo_financeiro > 0 ? 'text-status-warning' : 'text-status-success'}`}>
+          {active.ciclo_financeiro} dias
+        </p>
+        <p className="text-xs text-muted-foreground mt-1">
+          PMR {active.pmr}d − PMP {active.pmp}d
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/financeiro/cashflow/posicaoAgora/MetricCard.tsx
+++ b/src/components/financeiro/cashflow/posicaoAgora/MetricCard.tsx
@@ -1,0 +1,27 @@
+// Card de KPI do PosicaoAgora.
+// Extraído verbatim de src/components/financeiro/cashflow/PosicaoAgora.tsx (god-component split).
+import { Card, CardContent } from '@/components/ui/card';
+import { fmtCompact } from './format';
+
+export function MetricCard({ title, value, subtitle, positive, icon: Icon }: {
+  title: string; value: number; subtitle: string; positive: boolean; icon: React.ElementType;
+}) {
+  return (
+    <Card>
+      <CardContent className="p-4">
+        <div className="flex items-start justify-between">
+          <div>
+            <p className="text-xs text-muted-foreground font-medium">{title}</p>
+            <p className={`text-lg font-bold mt-1 ${positive ? 'text-status-success' : 'text-status-error'}`}>
+              {fmtCompact(value)}
+            </p>
+            <p className="text-xs text-muted-foreground mt-1">{subtitle}</p>
+          </div>
+          <div className={`p-2 rounded-lg ${positive ? 'bg-status-success-bg' : 'bg-status-error-bg'}`}>
+            <Icon className={`w-4 h-4 ${positive ? 'text-status-success' : 'text-status-error'}`} />
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/financeiro/cashflow/posicaoAgora/Projecao30dCard.tsx
+++ b/src/components/financeiro/cashflow/posicaoAgora/Projecao30dCard.tsx
@@ -1,0 +1,63 @@
+// Card de projeção de caixa de 30 dias (KPIs + waterfall + alerta).
+// Extraído verbatim de src/components/financeiro/cashflow/PosicaoAgora.tsx (god-component split).
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Target, AlertTriangle } from 'lucide-react';
+import type { CapitalDeGiro } from '@/services/financeiroService';
+import { fmtCompact } from './format';
+import { WaterfallBar } from './WaterfallBar';
+
+export function Projecao30dCard({ active }: { active: CapitalDeGiro }) {
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base flex items-center gap-2">
+          <Target className="w-4 h-4" />
+          Projeção de Caixa — Próximos 30 dias
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-4">
+          <div className="grid grid-cols-3 gap-4 text-center">
+            <div className="p-3 rounded-lg bg-status-info-bg">
+              <p className="text-xs text-muted-foreground">Saldo Atual CC</p>
+              <p className="text-lg font-bold text-status-info">{fmtCompact(active.saldo_cc)}</p>
+            </div>
+            <div className="p-3 rounded-lg bg-muted/50">
+              <p className="text-xs text-muted-foreground">Fluxo Líquido 30d</p>
+              <p className={`text-lg font-bold ${active.entradas_30d - active.saidas_30d >= 0 ? 'text-status-success' : 'text-status-error'}`}>
+                {fmtCompact(active.entradas_30d - active.saidas_30d)}
+              </p>
+            </div>
+            <div className={`p-3 rounded-lg ${active.saldo_projetado_30d >= 0 ? 'bg-status-success-bg' : 'bg-status-error-bg'}`}>
+              <p className="text-xs text-muted-foreground">Saldo Projetado</p>
+              <p className={`text-lg font-bold ${active.saldo_projetado_30d >= 0 ? 'text-status-success' : 'text-status-error'}`}>
+                {fmtCompact(active.saldo_projetado_30d)}
+              </p>
+            </div>
+          </div>
+
+          {/* Waterfall visual */}
+          <div className="flex items-end justify-center gap-2 h-32">
+            <WaterfallBar label="CC Atual" value={active.saldo_cc} max={Math.max(active.saldo_cc, active.saldo_projetado_30d, active.entradas_30d)} color="bg-status-info" />
+            <WaterfallBar label="Entradas" value={active.entradas_30d} max={Math.max(active.saldo_cc, active.saldo_projetado_30d, active.entradas_30d)} color="bg-status-success" />
+            <WaterfallBar label="Saídas" value={active.saidas_30d} max={Math.max(active.saldo_cc, active.saldo_projetado_30d, active.entradas_30d)} color="bg-status-error" />
+            <WaterfallBar label="Projetado" value={active.saldo_projetado_30d} max={Math.max(active.saldo_cc, active.saldo_projetado_30d, active.entradas_30d)} color={active.saldo_projetado_30d >= 0 ? 'bg-status-success' : 'bg-status-error'} />
+          </div>
+
+          {active.saldo_projetado_30d < 0 && (
+            <div className="flex items-start gap-2 p-3 rounded-lg bg-status-error-bg border border-status-error/30">
+              <AlertTriangle className="w-4 h-4 text-status-error mt-0.5" />
+              <div>
+                <p className="text-sm font-medium text-status-error-fg">Projeção negativa</p>
+                <p className="text-xs text-status-error mt-1">
+                  Déficit projetado de {fmtCompact(Math.abs(active.saldo_projetado_30d))} nos próximos 30 dias.
+                  Ação necessária: antecipar recebíveis, renegociar prazos de CP, ou injetar capital.
+                </p>
+              </div>
+            </div>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/financeiro/cashflow/posicaoAgora/StressTest.tsx
+++ b/src/components/financeiro/cashflow/posicaoAgora/StressTest.tsx
@@ -1,0 +1,60 @@
+// Teste de estresse — sensibilidade do caixa a atrasos/inadimplência.
+// Extraído verbatim de src/components/financeiro/cashflow/PosicaoAgora.tsx (god-component split).
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { AlertTriangle } from 'lucide-react';
+import { fmtCompact } from './format';
+import { SCENARIOS, computeStressRow } from './stress';
+
+export function StressTest({ saldoCC, entradas30, saidas30, pmr }: {
+  saldoCC: number; entradas30: number; saidas30: number; totalCR: number; pmr: number;
+}) {
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base flex items-center gap-2">
+          <AlertTriangle className="w-4 h-4" />
+          Teste de Estresse — Sensibilidade do Caixa
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="min-w-[150px]">Cenário</TableHead>
+              <TableHead className="text-right">Entradas Ajust.</TableHead>
+              <TableHead className="text-right">Saldo 30d</TableHead>
+              <TableHead className="text-right">Impacto</TableHead>
+              <TableHead className="w-20">Risco</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {SCENARIOS.map(s => {
+              const { entradasAjust, saldo, impacto, risco, riskColor } = computeStressRow(s, { saldoCC, entradas30, saidas30, pmr });
+
+              return (
+                <TableRow key={s.label} className={saldo < 0 ? 'bg-status-error-bg/50' : ''}>
+                  <TableCell>
+                    <p className="text-sm font-medium">{s.label}</p>
+                    <p className="text-[10px] text-muted-foreground">{s.desc}</p>
+                  </TableCell>
+                  <TableCell className="text-right text-sm">{fmtCompact(entradasAjust)}</TableCell>
+                  <TableCell className={`text-right text-sm font-bold ${saldo >= 0 ? 'text-status-success' : 'text-status-error'}`}>
+                    {fmtCompact(saldo)}
+                  </TableCell>
+                  <TableCell className={`text-right text-sm ${impacto < 0 ? 'text-status-error' : ''}`}>
+                    {fmtCompact(impacto)}
+                  </TableCell>
+                  <TableCell>
+                    <Badge className={`text-[10px] ${riskColor}`}>{risco}</Badge>
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/financeiro/cashflow/posicaoAgora/WaterfallBar.tsx
+++ b/src/components/financeiro/cashflow/posicaoAgora/WaterfallBar.tsx
@@ -1,0 +1,21 @@
+// Barra do waterfall de projeção de caixa do PosicaoAgora.
+// Extraído verbatim de src/components/financeiro/cashflow/PosicaoAgora.tsx (god-component split).
+import { fmtCompact } from './format';
+
+export function WaterfallBar({ label, value, max, color }: {
+  label: string; value: number; max: number; color: string;
+}) {
+  const pct = max > 0 ? Math.min((Math.abs(value) / max) * 100, 100) : 0;
+  return (
+    <div className="flex flex-col items-center gap-1 flex-1">
+      <div className="w-full flex items-end justify-center h-24">
+        <div
+          className={`w-full max-w-[48px] rounded-t ${color} transition-all`}
+          style={{ height: `${Math.max(pct, 5)}%` }}
+        />
+      </div>
+      <span className="text-[10px] text-muted-foreground text-center">{label}</span>
+      <span className="text-xs font-bold">{fmtCompact(value)}</span>
+    </div>
+  );
+}

--- a/src/components/financeiro/cashflow/posicaoAgora/__tests__/cards.test.tsx
+++ b/src/components/financeiro/cashflow/posicaoAgora/__tests__/cards.test.tsx
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { TrendingUp } from "lucide-react";
+import { MetricCard } from "../MetricCard";
+import { WaterfallBar } from "../WaterfallBar";
+
+describe("posicaoAgora cards", () => {
+  it("MetricCard renderiza título, valor compacto e subtítulo", () => {
+    render(<MetricCard title="Capital de Giro" value={2_500_000} subtitle="CR - CP abertos" positive icon={TrendingUp} />);
+    expect(screen.getByText("Capital de Giro")).toBeTruthy();
+    expect(screen.getByText("R$ 2.5M")).toBeTruthy();
+    expect(screen.getByText("CR - CP abertos")).toBeTruthy();
+  });
+
+  it("WaterfallBar renderiza label e valor", () => {
+    render(<WaterfallBar label="Entradas" value={100_000} max={200_000} color="bg-status-success" />);
+    expect(screen.getByText("Entradas")).toBeTruthy();
+    expect(screen.getByText("R$ 100.0k")).toBeTruthy();
+  });
+});

--- a/src/components/financeiro/cashflow/posicaoAgora/__tests__/consolidate.test.ts
+++ b/src/components/financeiro/cashflow/posicaoAgora/__tests__/consolidate.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { buildConsolidated } from "../consolidate";
+import type { CapitalDeGiro } from "@/services/financeiroService";
+
+function mk(o: Partial<CapitalDeGiro>): CapitalDeGiro {
+  return {
+    company: "x",
+    total_cr_aberto: 0,
+    total_cp_aberto: 0,
+    saldo_cc: 0,
+    capital_giro: 0,
+    capital_giro_liquido: 0,
+    pmr: 0,
+    pmp: 0,
+    ciclo_financeiro: 0,
+    top5_cr_pct: 0,
+    top5_cp_pct: 0,
+    entradas_30d: 0,
+    saidas_30d: 0,
+    saldo_projetado_30d: 0,
+    ...o,
+  };
+}
+
+describe("buildConsolidated", () => {
+  it("retorna null para lista vazia", () => {
+    expect(buildConsolidated([])).toBeNull();
+  });
+
+  it("pondera PMR/PMP por volume e soma o resto", () => {
+    const c = buildConsolidated([
+      mk({ total_cr_aberto: 100, pmr: 10, total_cp_aberto: 50, pmp: 20, saldo_cc: 1000, capital_giro: 50 }),
+      mk({ total_cr_aberto: 300, pmr: 30, total_cp_aberto: 150, pmp: 40, saldo_cc: 2000, capital_giro: 150 }),
+    ])!;
+    expect(c.company).toBe("consolidado");
+    expect(c.total_cr_aberto).toBe(400);
+    expect(c.total_cp_aberto).toBe(200);
+    expect(c.pmr).toBe(25); // round((10*100 + 30*300)/400)
+    expect(c.pmp).toBe(35); // round((20*50 + 40*150)/200)
+    expect(c.ciclo_financeiro).toBe(-10);
+    expect(c.saldo_cc).toBe(3000);
+    expect(c.capital_giro).toBe(200);
+    expect(c.top5_cr_pct).toBe(0); // concentração não consolida
+  });
+
+  it("PMR/PMP = 0 quando volume zero (evita divisão por zero)", () => {
+    const c = buildConsolidated([mk({ total_cr_aberto: 0, pmr: 99, total_cp_aberto: 0, pmp: 99 })])!;
+    expect(c.pmr).toBe(0);
+    expect(c.pmp).toBe(0);
+  });
+});

--- a/src/components/financeiro/cashflow/posicaoAgora/__tests__/format.test.ts
+++ b/src/components/financeiro/cashflow/posicaoAgora/__tests__/format.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from "vitest";
+import { fmt, fmtCompact } from "../format";
+
+describe("posicaoAgora/format", () => {
+  it("fmt em BRL", () => {
+    expect(fmt(1000)).toContain("1.000,00");
+  });
+
+  it("fmtCompact usa M/k/valor cheio", () => {
+    expect(fmtCompact(2_500_000)).toBe("R$ 2.5M");
+    expect(fmtCompact(100_000)).toBe("R$ 100.0k");
+    expect(fmtCompact(500)).toContain("500,00");
+  });
+});

--- a/src/components/financeiro/cashflow/posicaoAgora/__tests__/stress.test.ts
+++ b/src/components/financeiro/cashflow/posicaoAgora/__tests__/stress.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { computeStressRow, SCENARIOS } from "../stress";
+
+const inputs = { saldoCC: 1000, entradas30: 500, saidas30: 300, pmr: 30 };
+
+describe("posicaoAgora/stress", () => {
+  it("SCENARIOS tem 6 cenários", () => {
+    expect(SCENARIOS).toHaveLength(6);
+  });
+
+  it("base: sem ajuste, impacto zero, risco Baixo", () => {
+    const r = computeStressRow({ label: "Base", delayDays: 0, defaultPct: 0, desc: "" }, inputs);
+    expect(r.entradasAjust).toBe(500);
+    expect(r.saldo).toBe(1200);
+    expect(r.impacto).toBe(0);
+    expect(r.risco).toBe("Baixo");
+  });
+
+  it("inadimplência reduz entradas e gera impacto negativo", () => {
+    const r = computeStressRow({ label: "", delayDays: 0, defaultPct: 10, desc: "" }, inputs);
+    expect(r.entradasAjust).toBeCloseTo(450);
+    expect(r.impacto).toBeCloseTo(-50);
+  });
+
+  it("atraso aplica pctDelayed", () => {
+    // pctDelayed = min(15 / (30+15), 0.8) = 0.3333; entradasAjust = 500*(1-0.3333) ≈ 333.3
+    const r = computeStressRow({ label: "", delayDays: 15, defaultPct: 0, desc: "" }, inputs);
+    expect(r.entradasAjust).toBeCloseTo(333.33, 1);
+  });
+
+  it("saldo negativo classifica como Crítico", () => {
+    const r = computeStressRow(
+      { label: "", delayDays: 0, defaultPct: 0, desc: "" },
+      { saldoCC: 100, entradas30: 100, saidas30: 300, pmr: 30 },
+    );
+    expect(r.saldo).toBe(-100);
+    expect(r.risco).toBe("Crítico");
+  });
+});

--- a/src/components/financeiro/cashflow/posicaoAgora/consolidate.ts
+++ b/src/components/financeiro/cashflow/posicaoAgora/consolidate.ts
@@ -1,0 +1,37 @@
+// Consolidação de capital de giro — médias ponderadas por volume.
+// Extraída verbatim de src/components/financeiro/cashflow/PosicaoAgora.tsx (god-component split).
+import type { CapitalDeGiro } from '@/services/financeiroService';
+
+// Consolidado — médias ponderadas por volume (Ponto 10)
+export function buildConsolidated(data: CapitalDeGiro[]): CapitalDeGiro | null {
+  if (data.length === 0) return null;
+
+  const totalCR = data.reduce((s, d) => s + d.total_cr_aberto, 0);
+  const totalCP = data.reduce((s, d) => s + d.total_cp_aberto, 0);
+
+  // PMR ponderado pelo volume de CR de cada empresa
+  const pmrWeighted = totalCR > 0
+    ? Math.round(data.reduce((s, d) => s + d.pmr * d.total_cr_aberto, 0) / totalCR)
+    : 0;
+  // PMP ponderado pelo volume de CP de cada empresa
+  const pmpWeighted = totalCP > 0
+    ? Math.round(data.reduce((s, d) => s + d.pmp * d.total_cp_aberto, 0) / totalCP)
+    : 0;
+
+  return {
+    company: 'consolidado',
+    total_cr_aberto: totalCR,
+    total_cp_aberto: totalCP,
+    saldo_cc: data.reduce((s, d) => s + d.saldo_cc, 0),
+    capital_giro: data.reduce((s, d) => s + d.capital_giro, 0),
+    capital_giro_liquido: data.reduce((s, d) => s + d.capital_giro_liquido, 0),
+    pmr: pmrWeighted,
+    pmp: pmpWeighted,
+    ciclo_financeiro: pmrWeighted - pmpWeighted,
+    top5_cr_pct: 0, // Não faz sentido consolidar % de concentração
+    top5_cp_pct: 0,
+    entradas_30d: data.reduce((s, d) => s + d.entradas_30d, 0),
+    saidas_30d: data.reduce((s, d) => s + d.saidas_30d, 0),
+    saldo_projetado_30d: data.reduce((s, d) => s + d.saldo_projetado_30d, 0),
+  };
+}

--- a/src/components/financeiro/cashflow/posicaoAgora/format.ts
+++ b/src/components/financeiro/cashflow/posicaoAgora/format.ts
@@ -1,0 +1,11 @@
+// Helpers de formatação do PosicaoAgora.
+// Extraídos verbatim de src/components/financeiro/cashflow/PosicaoAgora.tsx (god-component split).
+
+export const fmt = (v: number) =>
+  v.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
+
+export const fmtCompact = (v: number) => {
+  if (Math.abs(v) >= 1_000_000) return `R$ ${(v / 1_000_000).toFixed(1)}M`;
+  if (Math.abs(v) >= 1_000) return `R$ ${(v / 1_000).toFixed(1)}k`;
+  return fmt(v);
+};

--- a/src/components/financeiro/cashflow/posicaoAgora/stress.ts
+++ b/src/components/financeiro/cashflow/posicaoAgora/stress.ts
@@ -1,0 +1,49 @@
+// Cenários e cálculo do Teste de Estresse de caixa.
+// Extraídos verbatim de src/components/financeiro/cashflow/PosicaoAgora.tsx (god-component split).
+
+export interface StressScenario {
+  label: string;
+  delayDays: number;
+  defaultPct: number;
+  desc: string;
+}
+
+export const SCENARIOS: StressScenario[] = [
+  { label: 'Base', delayDays: 0, defaultPct: 0, desc: 'Cenário atual sem alterações' },
+  { label: 'Atraso 15d', delayDays: 15, defaultPct: 0, desc: 'Clientes atrasam 15 dias em média' },
+  { label: 'Atraso 30d', delayDays: 30, defaultPct: 0, desc: 'Clientes atrasam 30 dias em média' },
+  { label: '10% inadimplência', delayDays: 0, defaultPct: 10, desc: '10% dos recebíveis viram perda' },
+  { label: '25% inadimplência', delayDays: 0, defaultPct: 25, desc: '25% dos recebíveis viram perda' },
+  { label: 'Combinado severo', delayDays: 30, defaultPct: 15, desc: 'Atraso 30d + 15% inadimplência' },
+];
+
+export interface StressInputs {
+  saldoCC: number;
+  entradas30: number;
+  saidas30: number;
+  pmr: number;
+}
+
+export interface StressRow {
+  entradasAjust: number;
+  saldo: number;
+  impacto: number;
+  risco: string;
+  riskColor: string;
+}
+
+export function computeStressRow(s: StressScenario, { saldoCC, entradas30, saidas30, pmr }: StressInputs): StressRow {
+  // Se delay > 0, parte das entradas dos próx 30d escorrega pra fora
+  const pctDelayed = s.delayDays > 0
+    ? Math.min(s.delayDays / Math.max(pmr + s.delayDays, 1), 0.8)
+    : 0;
+  const entradasAjust = entradas30 * (1 - pctDelayed) * (1 - s.defaultPct / 100);
+  const saldo = saldoCC + entradasAjust - saidas30;
+  const impacto = saldo - (saldoCC + entradas30 - saidas30);
+  const risco = saldo < 0 ? 'Crítico' : saldo < saldoCC * 0.3 ? 'Alto' : saldo < saldoCC * 0.6 ? 'Médio' : 'Baixo';
+  const riskColor = risco === 'Crítico' ? 'text-status-error bg-status-error-bg'
+    : risco === 'Alto' ? 'text-status-error bg-status-error-bg'
+    : risco === 'Médio' ? 'text-status-warning bg-status-warning-bg'
+    : 'text-status-success bg-status-success-bg';
+  return { entradasAjust, saldo, impacto, risco, riskColor };
+}

--- a/src/components/financeiro/cashflow/posicaoAgora/usePosicaoAgora.ts
+++ b/src/components/financeiro/cashflow/posicaoAgora/usePosicaoAgora.ts
@@ -1,0 +1,34 @@
+// Hook de dados/estado do PosicaoAgora.
+// Extraído verbatim de src/components/financeiro/cashflow/PosicaoAgora.tsx (god-component split):
+// carrega capital de giro por empresa/consolidado e expõe a posição ativa.
+import { useState, useEffect } from 'react';
+import { type Company } from '@/contexts/CompanyContext';
+import { getCapitalDeGiro, type CapitalDeGiro } from '@/services/financeiroService';
+import { buildConsolidated } from './consolidate';
+
+export function usePosicaoAgora() {
+  const [data, setData] = useState<CapitalDeGiro[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [view, setView] = useState<'all' | Company>('all');
+
+  useEffect(() => {
+    loadData();
+  }, [view]);
+
+  const loadData = async () => {
+    setLoading(true);
+    try {
+      const result = await getCapitalDeGiro(view);
+      setData(result);
+    } catch (e) {
+      console.error(e);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const consolidated = buildConsolidated(data);
+  const active = view === 'all' ? consolidated : data[0] || null;
+
+  return { data, loading, view, setView, active };
+}


### PR DESCRIPTION
## Resumo
Quebra o god-component `src/components/financeiro/cashflow/PosicaoAgora.tsx` (**502→94L**) em hook + **lógica pura testável** + componentes presentacionais, sob `src/components/financeiro/cashflow/posicaoAgora/`. Extração **verbatim** — comportamento preservado 1:1.

## O que mudou
- **`usePosicaoAgora`** (hook): carrega capital de giro (`getCapitalDeGiro`) + posição ativa (consolidado/empresa).
- **`consolidate.ts`** (`buildConsolidated`) — médias ponderadas de PMR/PMP por volume de CR/CP + somas. **Pura, testada.**
- **`stress.ts`** (`SCENARIOS` + `computeStressRow`) — sensibilidade do caixa a atraso/inadimplência. **Pura, testada.**
- **`KpiCards`** / **`CicloFinanceiroCard`** / **`Projecao30dCard`** / **`ComparativoEmpresasCard`** / **`ConcentracaoRiscoCard`** / **`StressTest`** — seções.
- **`MetricCard`** / **`WaterfallBar`** / **`format.ts`** — primitivos.
- **+12 testes** (consolidação ponderada + cenários de stress + format + presentacionais).

## Verificação
- `bunx tsc --noEmit` (baseline) = **0**
- `eslint` = **0 erros** (1 warning `exhaustive-deps` pré-existente, relocado pro hook — confirmado na `origin/main`)
- **12/12 testes** verdes (isolados)
- Revisão independente FIEL 1:1: **aprovada** (buildConsolidated/computeStressRow campo-a-campo + gates de render conferidos)

## Migrations
Nenhuma.

🤖 Generated with [Claude Code](https://claude.com/claude-code)