### PR TITLE
test(security): cobertura do sanitizador anti-injeção do .or() (postgrest)

### DIFF
--- a/docs/superpowers/specs/2026-05-25-postgrest-sanitizer-test-design.md
+++ b/docs/superpowers/specs/2026-05-25-postgrest-sanitizer-test-design.md
@@ -1,0 +1,36 @@
+# Cobertura de teste dos helpers de `postgrest.ts` — Design Spec
+
+> **Data:** 2026-05-25
+> **Status:** continuação autônoma (decidido com o Codex — top da fila por **valor × baixo risco**). Sanitizador **security-critical** do `.or()` do PostgREST (`src/lib/postgrest.ts`) sem teste. A regra ESLint do projeto (CLAUDE.md §9b) obriga usar esses helpers pra evitar injeção de cláusula; uma regressão silenciosa aqui = brecha de injeção. Função pura → teste durável.
+
+## Goal
+
+Travar o invariante de segurança: depois de sanitizar, o termo do usuário **não pode** introduzir separador de cláusula (`,`), agrupamento (`()`), escape (`\`), aspas (`"`) nem wildcard de ILIKE (`%` `_`). Sem mudança de código.
+
+## Regras (do código)
+
+- **`sanitizeForPostgrestOr(input)`** → remove **todo** caractere em `%`, `_`, `,`, `(`, `)`, `\`, `"`. O resto (incluindo `.`, espaço, acento, hífen, `;`) permanece literal.
+- **`ilike(col, term)`** → `` `${col}.ilike.%${sanitize(term)}%` ``.
+- **`ilikeOr(cols, term)`** → `cols.map(c => \`${c}.ilike.%${safe}%\`).join(',')` (1 termo sanitizado, N colunas). `[]` → `''`.
+- **`eqInt(col, term)`** → `` `${col}.eq.${X}` `` onde `X` = `term.trim()` se for **só dígitos** (`/^\d+$/`), senão `'0'` (não casa nada — comportamento desejado). Mantém zeros à esquerda (`'007'`).
+- **`eqText(col, value)`** → `` `${col}.eq.${sanitize(value)}` ``.
+- **`orFilter(...clauses)`** → `clauses.join(',')`. Zero args → `''`.
+
+## Cenários
+
+1. **sanitize — texto limpo**: `'abrasivo 120'` inalterado (espaço e dígitos sobrevivem); acento/hífen/ponto sobrevivem (`'ção-1.5'`).
+2. **sanitize — remove cada metacaractere**: `%`, `_`, `,`, `(`, `)`, `\`, `"` somem; vetor de injeção `'%,id.gt.0,('` → `'id.gt.0'` (sem vírgula/paren pra quebrar a cláusula → vira termo literal inofensivo).
+3. **sanitize — string vazia** → `''`.
+4. **ilike**: estrutura `col.ilike.%termo%`; termo malicioso `'a,b'` → `'col.ilike.%ab%'` (vírgula sumiu, estrutura intacta).
+5. **ilikeOr**: N colunas, 1 termo → `c1.ilike.%t%,c2.ilike.%t%`; termo com vírgula NÃO injeta cláusula extra (conta de vírgulas = N-1); `[]` → `''`.
+6. **eqInt**: `'42'`→`.eq.42`; `'  42  '`→`.eq.42` (trim); `'abc'`/`'4.5'`/`'1;DROP'`/`''`→`.eq.0`; `'007'`→`.eq.007`.
+7. **eqText**: limpo passa; `'a,b)'`→`'col.eq.ab'`.
+8. **orFilter**: junta com vírgula; zero args → `''`; 1 arg → ele mesmo.
+
+## Testing
+
+`src/lib/__tests__/postgrest.test.ts` (vitest, sem mocks — funções puras). Asserts incluem a **propriedade de segurança** (nenhum metacaractere sobrevive; nº de vírgulas no `ilikeOr` = colunas-1). Suíte verde; lint limpo; sem tocar o módulo.
+
+## Out-of-scope
+
+- O comportamento real do PostgREST/supabase-js (integração); o espelho Deno do sanitizador nas Edge Functions (cópia à parte).

--- a/src/lib/__tests__/postgrest.test.ts
+++ b/src/lib/__tests__/postgrest.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest';
+import {
+  sanitizeForPostgrestOr,
+  ilike,
+  ilikeOr,
+  eqInt,
+  eqText,
+  orFilter,
+} from '../postgrest';
+
+// Os metacaracteres que o parser do .or() interpreta — nenhum pode sobreviver à sanitização.
+const META = ['%', '_', ',', '(', ')', '\\', '"'];
+
+describe('sanitizeForPostgrestOr', () => {
+  it('texto limpo passa inalterado (espaço, dígito, acento, hífen, ponto sobrevivem)', () => {
+    expect(sanitizeForPostgrestOr('abrasivo 120')).toBe('abrasivo 120');
+    expect(sanitizeForPostgrestOr('ção-1.5')).toBe('ção-1.5');
+  });
+
+  it('remove cada metacaractere do parser', () => {
+    expect(sanitizeForPostgrestOr('a%b')).toBe('ab');
+    expect(sanitizeForPostgrestOr('a_b')).toBe('ab');
+    expect(sanitizeForPostgrestOr('a,b')).toBe('ab');
+    expect(sanitizeForPostgrestOr('a(b)c')).toBe('abc');
+    expect(sanitizeForPostgrestOr('a\\b')).toBe('ab');
+    expect(sanitizeForPostgrestOr('a"b')).toBe('ab');
+  });
+
+  it('neutraliza o vetor de injeção (vírgula+paren somem → vira termo literal)', () => {
+    expect(sanitizeForPostgrestOr('%,id.gt.0,(')).toBe('id.gt.0');
+  });
+
+  it('propriedade de segurança: NENHUM metacaractere sobra, qualquer que seja a entrada', () => {
+    const sujo = 'x,id.gt.0,(nome.ilike.%a%),"\\_';
+    const limpo = sanitizeForPostgrestOr(sujo);
+    for (const ch of META) expect(limpo.includes(ch)).toBe(false);
+  });
+
+  it('string vazia → string vazia', () => {
+    expect(sanitizeForPostgrestOr('')).toBe('');
+  });
+});
+
+describe('ilike', () => {
+  it('monta col.ilike.%termo%', () => {
+    expect(ilike('nome', 'abc')).toBe('nome.ilike.%abc%');
+  });
+
+  it('sanitiza o termo sem quebrar a estrutura', () => {
+    expect(ilike('nome', 'a,b')).toBe('nome.ilike.%ab%');
+  });
+});
+
+describe('ilikeOr', () => {
+  it('N colunas, 1 termo → N cláusulas separadas por vírgula', () => {
+    expect(ilikeOr(['nome', 'codigo'], 'abc')).toBe('nome.ilike.%abc%,codigo.ilike.%abc%');
+  });
+
+  it('termo malicioso NÃO injeta cláusula extra (nº de vírgulas = colunas - 1)', () => {
+    const cols = ['nome', 'codigo'];
+    const out = ilikeOr(cols, 'x,id.gt.0,(');
+    expect((out.match(/,/g) || []).length).toBe(cols.length - 1);
+    expect(out).toBe('nome.ilike.%xid.gt.0%,codigo.ilike.%xid.gt.0%');
+  });
+
+  it('lista de colunas vazia → string vazia', () => {
+    expect(ilikeOr([], 'abc')).toBe('');
+  });
+});
+
+describe('eqInt', () => {
+  it('só dígitos → usa o número', () => {
+    expect(eqInt('id', '42')).toBe('id.eq.42');
+  });
+
+  it('faz trim antes de validar', () => {
+    expect(eqInt('id', '  42  ')).toBe('id.eq.42');
+  });
+
+  it('mantém zeros à esquerda (não converte pra Number)', () => {
+    expect(eqInt('id', '007')).toBe('id.eq.007');
+  });
+
+  it('não-dígito / decimal / injeção / vazio → eq.0 (não casa nada)', () => {
+    expect(eqInt('id', 'abc')).toBe('id.eq.0');
+    expect(eqInt('id', '4.5')).toBe('id.eq.0');
+    expect(eqInt('id', '1; DROP TABLE x')).toBe('id.eq.0');
+    expect(eqInt('id', '')).toBe('id.eq.0');
+    expect(eqInt('id', '-3')).toBe('id.eq.0');
+  });
+});
+
+describe('eqText', () => {
+  it('valor limpo → col.eq.valor', () => {
+    expect(eqText('status', 'ativo')).toBe('status.eq.ativo');
+  });
+
+  it('sanitiza o valor', () => {
+    expect(eqText('status', 'a,b)')).toBe('status.eq.ab');
+  });
+});
+
+describe('orFilter', () => {
+  it('junta cláusulas com vírgula', () => {
+    expect(orFilter('a.eq.1', 'b.ilike.%x%')).toBe('a.eq.1,b.ilike.%x%');
+  });
+
+  it('uma cláusula → ela mesma', () => {
+    expect(orFilter('a.eq.1')).toBe('a.eq.1');
+  });
+
+  it('zero cláusulas → string vazia', () => {
+    expect(orFilter()).toBe('');
+  });
+});


### PR DESCRIPTION
## Resumo
Cobertura de teste **aditiva** (test-only) para `src/lib/postgrest.ts` — o sanitizador **security-critical** do `.or()` do PostgREST que a regra ESLint do projeto (CLAUDE.md §9b) obriga usar pra evitar injeção de cláusula. Era a maior peça pura sem teste (decidido com o Codex: melhor combinação valor × baixo risco).

Trava:
- **Propriedade de segurança**: depois de `sanitizeForPostgrestOr`, **nenhum** metacaractere do parser (`,` `(` `)` `\` `"` `%` `_`) sobrevive — para qualquer entrada
- Vetor de injeção `'%,id.gt.0,('` → vira termo literal `'id.gt.0'` (sem vírgula/paren pra quebrar a cláusula)
- `ilikeOr`: nº de vírgulas no resultado = `colunas - 1` (termo malicioso não injeta cláusula extra)
- `eqInt`: coage a inteiro não-negativo; `'abc'`/`'4.5'`/`'1; DROP'`/`''`/`'-3'` → `eq.0`; mantém zeros à esquerda (`'007'`)
- `ilike` / `eqText` / `orFilter`: estrutura + sanitização + bordas (`[]`/zero args → `''`)

19 casos, sem mocks (funções puras).

## Sem mudança de código
`postgrest.ts` não foi tocado. Só o teste + a spec.

## Test plan
- [x] `bun run test -- src/lib/__tests__/postgrest.test.ts` → 19/19 verde
- [x] `eslint` no arquivo novo → exit 0
- [ ] CI `validate` (tsc + typecheck:strict + test + build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)