### PR TITLE
test(phone): cobertura da normalização BR (Nvoip/WhatsApp)

### DIFF
--- a/docs/superpowers/specs/2026-05-25-phone-normalize-test-design.md
+++ b/docs/superpowers/specs/2026-05-25-phone-normalize-test-design.md
@@ -1,0 +1,45 @@
+# Cobertura de teste do `phone.ts` (normalização BR) — Design Spec
+
+> **Data:** 2026-05-25
+> **Status:** continuação autônoma (decidido com o Codex — #2 da fila por valor × baixo risco). `src/lib/phone.ts` (normaliza/forma telefone BR pro formato da Nvoip) sem teste. Impacto operacional real: número mal normalizado = **ligação/WhatsApp pro destino errado**. Função pura → teste durável.
+
+## Goal
+
+Travar `normalizeBrPhone` e `formatBrPhone`: matriz de DDD, 8/9/10/11 dígitos, prefixo +55 e entradas sujas. Sem mudança de código.
+
+## Regras (do código)
+
+- **`normalizeBrPhone(input, defaultDdd='37')`**:
+  - falsy (`null`/`undefined`/`''`) → `''`.
+  - tira tudo que não é dígito.
+  - se `length > 11` e começa com `55` → remove os 2 primeiros (código de país).
+  - se `length > 11` e começa com `0` → remove zeros à esquerda.
+  - se `length` é **8 ou 9** (sem DDD) → prefixa `defaultDdd`.
+  - devolve os dígitos (sem validar DDD; lixo curto passa).
+- **`formatBrPhone(input)`**: normaliza; `len 11` → `(DD) 9XXXX-XXXX`; `len 10` → `(DD) XXXX-XXXX`; senão devolve o **input original** (`input ?? ''`).
+
+## Cenários (saídas verificadas via node)
+
+`normalizeBrPhone`:
+1. `null`/`undefined`/`''` → `''`.
+2. `'(37) 99999-8888'` → `'37999998888'` (tira formatação).
+3. `'99999-8888'` (9 díg, celular sem DDD) → `'37999998888'` (DDD padrão).
+4. `'3333-4444'` (8 díg, fixo sem DDD) → `'3733334444'`.
+5. `'5537999998888'` e `'+55 (37) 99999-8888'` (+55) → `'37999998888'`.
+6. `'55999998888'` (11 díg começando com 55) → `'55999998888'` **inalterado** (regra do 55 só em `>11`; trata 55 como DDD).
+7. `defaultDdd` custom: `normalizeBrPhone('999998888','11')` → `'11999998888'`.
+8. `'123'` (lixo curto) → `'123'` (passa, não valida).
+
+`formatBrPhone`:
+9. `'99999-8888'` → `'(37) 99999-8888'` (11 díg).
+10. `'3733334444'` e `'(37) 3333-4444'` → `'(37) 3333-4444'` (10 díg; reformata consistente).
+11. `null` → `''`.
+12. `'123'` (não bate 10/11) → `'123'` (devolve o input original).
+
+## Testing
+
+`src/lib/__tests__/phone.test.ts` (vitest, sem mocks — funções puras). Suíte verde; lint limpo; sem tocar o módulo.
+
+## Out-of-scope
+
+- Validação de DDD real / discagem da Nvoip; o caso patológico `0055...` (prefixo duplo país+zero não é totalmente limpo — gap latente, não realista, deixado sem assert pra não travar comportamento bugado como esperado).

--- a/src/lib/__tests__/phone.test.ts
+++ b/src/lib/__tests__/phone.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeBrPhone, formatBrPhone } from '../phone';
+
+describe('normalizeBrPhone', () => {
+  it('falsy → string vazia', () => {
+    expect(normalizeBrPhone(null)).toBe('');
+    expect(normalizeBrPhone(undefined)).toBe('');
+    expect(normalizeBrPhone('')).toBe('');
+  });
+
+  it('tira a formatação de um celular com DDD', () => {
+    expect(normalizeBrPhone('(37) 99999-8888')).toBe('37999998888');
+  });
+
+  it('celular sem DDD (9 díg) → aplica o DDD padrão 37', () => {
+    expect(normalizeBrPhone('99999-8888')).toBe('37999998888');
+  });
+
+  it('fixo sem DDD (8 díg) → aplica o DDD padrão 37', () => {
+    expect(normalizeBrPhone('3333-4444')).toBe('3733334444');
+  });
+
+  it('remove o código de país +55 quando há mais de 11 dígitos', () => {
+    expect(normalizeBrPhone('5537999998888')).toBe('37999998888');
+    expect(normalizeBrPhone('+55 (37) 99999-8888')).toBe('37999998888');
+  });
+
+  it('11 dígitos começando com 55 NÃO tira o 55 (regra só em >11; 55 vira DDD)', () => {
+    expect(normalizeBrPhone('55999998888')).toBe('55999998888');
+  });
+
+  it('respeita um defaultDdd custom', () => {
+    expect(normalizeBrPhone('999998888', '11')).toBe('11999998888');
+  });
+
+  it('já normalizado (11/10 díg) passa inalterado', () => {
+    expect(normalizeBrPhone('37999998888')).toBe('37999998888');
+    expect(normalizeBrPhone('3733334444')).toBe('3733334444');
+  });
+
+  it('lixo curto passa sem validação de DDD', () => {
+    expect(normalizeBrPhone('123')).toBe('123');
+  });
+});
+
+describe('formatBrPhone', () => {
+  it('11 dígitos → (DD) 9XXXX-XXXX', () => {
+    expect(formatBrPhone('99999-8888')).toBe('(37) 99999-8888');
+    expect(formatBrPhone('37999998888')).toBe('(37) 99999-8888');
+  });
+
+  it('10 dígitos → (DD) XXXX-XXXX (reformata consistente)', () => {
+    expect(formatBrPhone('3733334444')).toBe('(37) 3333-4444');
+    expect(formatBrPhone('(37) 3333-4444')).toBe('(37) 3333-4444');
+  });
+
+  it('falsy → string vazia', () => {
+    expect(formatBrPhone(null)).toBe('');
+    expect(formatBrPhone('')).toBe('');
+  });
+
+  it('não bate 10/11 dígitos → devolve o input original', () => {
+    expect(formatBrPhone('123')).toBe('123');
+  });
+});


### PR DESCRIPTION
## Resumo
Cobertura de teste **aditiva** (test-only) para `src/lib/phone.ts`, decidido com o Codex (#2 da fila por valor × baixo risco). Normaliza/forma telefone BR pro formato da Nvoip — número mal normalizado = ligação/WhatsApp pro destino errado.

Trava:
- **`normalizeBrPhone`**: falsy → `''`; tira formatação; remove `+55` só quando `>11` díg; aplica **DDD padrão 37** em 8/9 díg; respeita `defaultDdd` custom; 11 díg começando com 55 fica inalterado (55 vira DDD); lixo curto passa
- **`formatBrPhone`**: 11 díg → `(DD) 9XXXX-XXXX`; 10 díg → `(DD) XXXX-XXXX` (reformata consistente); não-bate → devolve o **input original**; falsy → `''`

13 casos, sem mocks (saídas verificadas via `node` antes de escrever os asserts).

## Sem mudança de código
`phone.ts` não foi tocado. Só o teste + a spec. (A spec documenta um gap latente NÃO-realista — `0055...` prefixo duplo — deixado sem assert pra não travar comportamento bugado como esperado.)

## Test plan
- [x] `bun run test -- src/lib/__tests__/phone.test.ts` → 13/13 verde
- [x] `eslint` no arquivo novo → exit 0
- [ ] CI `validate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)