### PR TITLE
test(kb): cobertura do calculateRendimento (litros de tinta)

### DIFF
--- a/docs/superpowers/specs/2026-05-25-rendimento-test-design.md
+++ b/docs/superpowers/specs/2026-05-25-rendimento-test-design.md
@@ -1,0 +1,36 @@
+# Cobertura de teste do `calculateRendimento` — Design Spec
+
+> **Data:** 2026-05-25
+> **Status:** continuação autônoma (decidido com o Codex — #3 da fila). `src/lib/knowledge-base/calculate-rendimento.ts` calcula litros de tinta necessários (rendimento + demãos) — money/spec-adjacent, sem teste. Fórmula transparente e auto-consistente (cobertura de tinta padrão) → travo o comportamento observável com confiança.
+
+## Goal
+
+Travar `calculateRendimento(input)`: escolha de demãos, rendimento explícito vs. derivado de densidade+gramatura, caminhos de dados insuficientes, e o cálculo de litros. Sem mudança de código.
+
+## Regras (do código)
+
+- `demaos = demaosOverride ?? spec.demaos_recomendadas ?? 1`. Sem override **e** sem `demaos_recomendadas` → warning `'Demãos não informadas no boletim — assumindo 1.'`.
+- **Rendimento explícito**: `rendimento_m2_por_litro != null && > 0` → usa direto; `calculo` = `'Rendimento do boletim: X m²/L'`.
+- **Derivado**: senão, se `densidade_g_cm3` truthy **e** (`gramatura_min` ou `gramatura_max`) → `gramaturaMedia = (min+max)/2` (faltando uma ponta, usa a outra), `rendimento = densidade*1000 / gramaturaMedia`; warning `'Rendimento derivado da densidade + gramatura (boletim não informa explicitamente).'`.
+- **Insuficiente**: senão → warning `'Spec sem rendimento, densidade ou gramatura — dados insuficientes pro cálculo.'`, retorna `rendimento=0, litros=0, calculo='Dados insuficientes'`.
+- Após derivar, se `rendimento <= 0` → retorna zeros (mantém `calculo`).
+- `litros = (areaM2 / rendimento) * demaos`.
+
+## Cenários (valores verificados via node)
+
+1. **Explícito**: `{rendimento:10, demaos_recomendadas:2}`, area 100 → demaos 2, rendimento 10, litros **20**, `warnings:[]`, calculo contém `'Rendimento do boletim: 10'`.
+2. **Override** sobrepõe spec: demaosOverride 3 → demaos 3, litros **30**, sem warning de demãos.
+3. **Sem demãos**: `{rendimento:10}` (sem demaos_recomendadas, sem override) → demaos 1, warning de demãos presente.
+4. **Derivado**: `{densidade:1.2, gramatura_min:100, gramatura_max:200, demaos_recomendadas:1}`, area 80 → média 150, rendimento **8**, litros **10**, warning de derivação, calculo contém `'Derivado'`.
+5. **Derivado só com min**: `{densidade:1.2, gramatura_min:120}` → média 120, rendimento **10**.
+6. **Rendimento explícito 0 → cai pra derivação**: `{rendimento:0, densidade:1.2, gramatura_min:150}` → rendimento **8** (não trata 0 como válido).
+7. **Insuficiente**: `{rendimento:null}` sem densidade/gramatura → rendimento 0, litros 0, calculo `'Dados insuficientes'`, warning de insuficiência.
+8. **Área 0**: rendimento 10, area 0 → litros **0**, sem warning.
+
+## Testing
+
+`src/lib/knowledge-base/__tests__/calculate-rendimento.test.ts` (vitest, sem mocks — função pura). `toContain` na memória de cálculo (string longa); igualdade nos números. Suíte verde; lint limpo; sem tocar o módulo.
+
+## Out-of-scope
+
+- Correção contábil/química da fórmula (assumida correta — cobertura de tinta padrão); o guard `rendimento <= 0` pós-derivação é praticamente inalcançável com input realista (não forçado).

--- a/src/lib/knowledge-base/__tests__/calculate-rendimento.test.ts
+++ b/src/lib/knowledge-base/__tests__/calculate-rendimento.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import { calculateRendimento, type CalculateInput } from '../calculate-rendimento';
+
+type Spec = CalculateInput['spec'];
+
+function spec(over: Partial<Spec> = {}): Spec {
+  return {
+    product_name: 'Verniz X',
+    rendimento_m2_por_litro: null,
+    densidade_g_cm3: null,
+    gramatura_g_m2_min: null,
+    gramatura_g_m2_max: null,
+    demaos_recomendadas: null,
+    ...over,
+  };
+}
+
+const DEMAOS_WARN = 'Demãos não informadas no boletim — assumindo 1.';
+const DERIVADO_WARN = 'Rendimento derivado da densidade + gramatura (boletim não informa explicitamente).';
+const INSUF_WARN = 'Spec sem rendimento, densidade ou gramatura — dados insuficientes pro cálculo.';
+
+describe('calculateRendimento', () => {
+  it('rendimento explícito: litros = area/rendimento × demãos', () => {
+    const r = calculateRendimento({ spec: spec({ rendimento_m2_por_litro: 10, demaos_recomendadas: 2 }), areaM2: 100 });
+    expect(r.demaos).toBe(2);
+    expect(r.rendimentoM2PorLitro).toBe(10);
+    expect(r.litrosNecessarios).toBe(20);
+    expect(r.warnings).toEqual([]);
+    expect(r.calculo).toContain('Rendimento do boletim: 10');
+  });
+
+  it('demaosOverride sobrepõe o spec (sem warning de demãos)', () => {
+    const r = calculateRendimento({
+      spec: spec({ rendimento_m2_por_litro: 10, demaos_recomendadas: 2 }),
+      areaM2: 100,
+      demaosOverride: 3,
+    });
+    expect(r.demaos).toBe(3);
+    expect(r.litrosNecessarios).toBe(30);
+    expect(r.warnings).not.toContain(DEMAOS_WARN);
+  });
+
+  it('sem demãos informadas → assume 1 e avisa', () => {
+    const r = calculateRendimento({ spec: spec({ rendimento_m2_por_litro: 10 }), areaM2: 100 });
+    expect(r.demaos).toBe(1);
+    expect(r.litrosNecessarios).toBe(10);
+    expect(r.warnings).toContain(DEMAOS_WARN);
+  });
+
+  it('deriva o rendimento de densidade + gramatura (média das pontas)', () => {
+    const r = calculateRendimento({
+      spec: spec({ densidade_g_cm3: 1.2, gramatura_g_m2_min: 100, gramatura_g_m2_max: 200, demaos_recomendadas: 1 }),
+      areaM2: 80,
+    });
+    // média 150 g/m²; 1.2*1000 / 150 = 8 m²/L; litros = 80/8 * 1 = 10
+    expect(r.rendimentoM2PorLitro).toBe(8);
+    expect(r.litrosNecessarios).toBe(10);
+    expect(r.warnings).toContain(DERIVADO_WARN);
+    expect(r.calculo).toContain('Derivado');
+  });
+
+  it('deriva mesmo com só uma ponta de gramatura (usa a presente como média)', () => {
+    const r = calculateRendimento({
+      spec: spec({ densidade_g_cm3: 1.2, gramatura_g_m2_min: 120, demaos_recomendadas: 1 }),
+      areaM2: 120,
+    });
+    expect(r.rendimentoM2PorLitro).toBe(10); // 1200/120
+    expect(r.litrosNecessarios).toBe(12);
+    expect(r.warnings).toContain(DERIVADO_WARN);
+  });
+
+  it('rendimento explícito 0/inválido cai pra derivação (não trata 0 como válido)', () => {
+    const r = calculateRendimento({
+      spec: spec({ rendimento_m2_por_litro: 0, densidade_g_cm3: 1.2, gramatura_g_m2_min: 150, demaos_recomendadas: 1 }),
+      areaM2: 100,
+    });
+    expect(r.rendimentoM2PorLitro).toBe(8); // 1200/150
+    expect(r.litrosNecessarios).toBeCloseTo(12.5, 5);
+    expect(r.warnings).toContain(DERIVADO_WARN);
+  });
+
+  it('dados insuficientes → zeros + memória "Dados insuficientes"', () => {
+    const r = calculateRendimento({ spec: spec({ demaos_recomendadas: 1 }), areaM2: 100 });
+    expect(r.rendimentoM2PorLitro).toBe(0);
+    expect(r.litrosNecessarios).toBe(0);
+    expect(r.calculo).toBe('Dados insuficientes');
+    expect(r.warnings).toContain(INSUF_WARN);
+  });
+
+  it('área 0 → 0 litros, sem warning, rendimento preservado', () => {
+    const r = calculateRendimento({ spec: spec({ rendimento_m2_por_litro: 10, demaos_recomendadas: 1 }), areaM2: 0 });
+    expect(r.litrosNecessarios).toBe(0);
+    expect(r.rendimentoM2PorLitro).toBe(10);
+    expect(r.warnings).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Resumo
Cobertura de teste **aditiva** (test-only) para `src/lib/knowledge-base/calculate-rendimento.ts` — calcula litros de tinta necessários (rendimento + demãos), money/spec-adjacent. Codex #3 da fila.

Trava:
- **Demãos**: `demaosOverride ?? demaos_recomendadas ?? 1`; sem nenhum → assume 1 + warning
- **Rendimento explícito** (`>0`) vs. **derivado** de `densidade × 1000 / gramatura média` (com média das duas pontas, ou a única ponta presente) + warning de derivação
- **Rendimento explícito 0** cai pra derivação (não trata 0 como válido)
- **Dados insuficientes** → zeros + `calculo:'Dados insuficientes'` + warning
- `litros = area / rendimento × demãos`; área 0 → 0 litros

8 casos, sem mocks (valores verificados via `node`).

## Sem mudança de código
`calculate-rendimento.ts` não foi tocado. Só o teste + a spec.

## Test plan
- [x] `bun run test -- src/lib/knowledge-base/__tests__/calculate-rendimento.test.ts` → 8/8 verde
- [x] `eslint` no arquivo novo → exit 0
- [ ] CI `validate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)