### PR TITLE
FAB header (recebimento) + memo formasPagamento + 11 fixes de lint

### DIFF
--- a/src/components/portalSayerlack/PortalDetailDrawer.tsx
+++ b/src/components/portalSayerlack/PortalDetailDrawer.tsx
@@ -73,7 +73,7 @@ export function PortalDetailDrawer({ pedidoId, open, onOpenChange, isAdmin }: Pr
       if (error) throw error;
 
       const skus = (rows ?? []).map((r) => r.sku_codigo_omie).filter(Boolean);
-      let mapping: Record<string, string> = {};
+      const mapping: Record<string, string> = {};
       if (skus.length) {
         const { data: maps } = await supabase
           .from('sku_fornecedor_externo')

--- a/src/components/reposicao/pedidos/__tests__/CondicaoPagamentoPanel.test.tsx
+++ b/src/components/reposicao/pedidos/__tests__/CondicaoPagamentoPanel.test.tsx
@@ -36,7 +36,7 @@ describe('CondicaoPagamentoPanel', () => {
   });
 
   it('em modo não editável: mostra a condição definida ou "não definida"', () => {
-    const { } = setup({
+    setup({
       podeEditarCondicao: false,
       pedido: ped({ status: 'disparado', condicao_pagamento_codigo: null, condicao_pagamento_descricao: null }),
     });

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ));
 Command.displayName = CommandPrimitive.displayName;
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps;
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
-export interface TextareaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(({ className, ...props }, ref) => {
   return (

--- a/src/hooks/useDirectTintImport.ts
+++ b/src/hooks/useDirectTintImport.ts
@@ -90,7 +90,8 @@ export function useDirectTintImport() {
 
   // ─── Process dados_corantes ───
   const processDadosCorantes = async (rows: string[][]): Promise<{ imported: number; updated: number; errors: number }> => {
-    let imported = 0, updated = 0, errors = 0;
+    let imported = 0, errors = 0;
+    const updated = 0;
     const totalBatches = Math.ceil(rows.length / BATCH_SIZE);
 
     for (let b = 0; b < totalBatches; b++) {
@@ -138,7 +139,8 @@ export function useDirectTintImport() {
 
   // ─── Process dados_produto_base_embalagem ───
   const processDadosPBE = async (rows: string[][]): Promise<{ imported: number; updated: number; errors: number }> => {
-    let imported = 0, updated = 0, errors = 0;
+    let imported = 0, errors = 0;
+    const updated = 0;
     const totalBatches = Math.ceil(rows.length / BATCH_SIZE);
 
     for (let b = 0; b < totalBatches; b++) {
@@ -224,7 +226,8 @@ export function useDirectTintImport() {
 
   // ─── Process formulas ───
   const processFormulas = async (rows: string[][], personalizada: boolean, importacaoId: string): Promise<{ imported: number; updated: number; errors: number }> => {
-    let imported = 0, updated = 0, errors = 0;
+    let imported = 0, errors = 0;
+    const updated = 0;
     const totalBatches = Math.ceil(rows.length / BATCH_SIZE);
     const offset = personalizada ? 0 : 2;
 
@@ -476,7 +479,8 @@ export function useDirectTintImport() {
 
   // ─── Process formulas via RPC (Postgres-native) ───
   const processFormulasRPC = async (rows: string[][], personalizada: boolean, _importacaoId: string): Promise<{ imported: number; updated: number; errors: number }> => {
-    let imported = 0, updated = 0, errors = 0;
+    let imported = 0, errors = 0;
+    const updated = 0;
     const offset = personalizada ? 0 : 2;
     const totalBatches = Math.ceil(rows.length / RPC_BATCH_SIZE);
 

--- a/src/hooks/useDirectTintImport.ts
+++ b/src/hooks/useDirectTintImport.ts
@@ -227,7 +227,7 @@ export function useDirectTintImport() {
   // ─── Process formulas ───
   const processFormulas = async (rows: string[][], personalizada: boolean, importacaoId: string): Promise<{ imported: number; updated: number; errors: number }> => {
     let imported = 0, errors = 0;
-    const updated = 0;
+    let updated = 0;
     const totalBatches = Math.ceil(rows.length / BATCH_SIZE);
     const offset = personalizada ? 0 : 2;
 
@@ -480,7 +480,7 @@ export function useDirectTintImport() {
   // ─── Process formulas via RPC (Postgres-native) ───
   const processFormulasRPC = async (rows: string[][], personalizada: boolean, _importacaoId: string): Promise<{ imported: number; updated: number; errors: number }> => {
     let imported = 0, errors = 0;
-    const updated = 0;
+    let updated = 0;
     const offset = personalizada ? 0 : 2;
     const totalBatches = Math.ceil(rows.length / RPC_BATCH_SIZE);
 

--- a/src/hooks/useTintPricing.ts
+++ b/src/hooks/useTintPricing.ts
@@ -44,7 +44,7 @@ export function useTintPricing(formulaId: string | null) {
 
       // Get omie products for cost
       const omieIds = corantes.filter(c => c.omie_product_id).map(c => c.omie_product_id!);
-      let omieProducts: Record<string, { valor_unitario: number }> = {};
+      const omieProducts: Record<string, { valor_unitario: number }> = {};
       if (omieIds.length > 0) {
         const { data: prods } = await supabase
           .from('omie_products')

--- a/src/hooks/useUnifiedOrder.ts
+++ b/src/hooks/useUnifiedOrder.ts
@@ -143,8 +143,10 @@ export function useUnifiedOrder() {
     staleTime: 10 * 60 * 1000,
     queryFn: formasQueryFn('colacor'),
   });
-  const formasPagamentoOben = obenFormasQuery.data || [];
-  const formasPagamentoColacor = colacorFormasQuery.data || [];
+  // useMemo estabiliza a referência: `|| []` criava um array novo a cada render,
+  // invalidando os useMemo/useCallback que dependem destes (sortedFormas*, submit).
+  const formasPagamentoOben = useMemo(() => obenFormasQuery.data || [], [obenFormasQuery.data]);
+  const formasPagamentoColacor = useMemo(() => colacorFormasQuery.data || [], [colacorFormasQuery.data]);
   const loadingFormas = obenFormasQuery.isLoading || colacorFormasQuery.isLoading;
 
   const [ordemCompra, setOrdemCompra] = useState<string>('');

--- a/src/hooks/useUploadKbDocument.ts
+++ b/src/hooks/useUploadKbDocument.ts
@@ -20,7 +20,7 @@ export function useUploadKbDocument() {
       const { data: { user } } = await supabase.auth.getUser();
       if (!user) throw new Error('Não autenticado');
 
-      const safeName = input.file.name.replace(/[^\w.\-]/g, '_');
+      const safeName = input.file.name.replace(/[^\w.-]/g, '_');
       const path = `${user.id}/${Date.now()}_${safeName}`;
 
       // 1. Upload pro Storage

--- a/src/lib/financeiro/__tests__/audit.test.ts
+++ b/src/lib/financeiro/__tests__/audit.test.ts
@@ -35,7 +35,7 @@ describe('formatAuditValue', () => {
   it('formats numeric BRL', () => {
     const formatted = formatAuditValue(1234.5);
     // Intl may use non-breaking space between R$ and number depending on ICU version
-    expect(formatted.replace(/ /g, ' ')).toBe('R$ 1.234,50');
+    expect(formatted.replace(/\u00A0/g, ' ')).toBe('R$ 1.234,50');
   });
   it('formats null as em-dash', () => {
     expect(formatAuditValue(null)).toBe('—');

--- a/src/pages/Recebimento.tsx
+++ b/src/pages/Recebimento.tsx
@@ -209,6 +209,16 @@ export default function Recebimento({ statusFilter }: { statusFilter?: string[] 
           <FileCheck className="h-6 w-6 text-primary" />
           <h1 className="text-xl font-bold text-foreground">Recebimento de NF-e</h1>
         </div>
+        <div className="flex items-center gap-2">
+        <Button
+          variant="outline"
+          size="sm"
+          className="hidden lg:inline-flex"
+          onClick={() => setImportOpen(true)}
+        >
+          <Plus className="h-4 w-4 mr-1" />
+          Importar NF-e
+        </Button>
         <Button
           variant="outline"
           size="sm"
@@ -232,6 +242,7 @@ export default function Recebimento({ statusFilter }: { statusFilter?: string[] 
           <RefreshCw className={cn('h-4 w-4 mr-1', syncing && 'animate-spin')} />
           Sincronizar Omie
         </Button>
+        </div>
       </div>
 
       {/* Warehouse selector */}
@@ -370,7 +381,7 @@ export default function Recebimento({ statusFilter }: { statusFilter?: string[] 
       {/* FAB - Import manual */}
       <button
         onClick={() => setImportOpen(true)}
-        className="fixed bottom-6 right-6 z-40 h-14 w-14 rounded-full bg-primary text-primary-foreground shadow-lg flex items-center justify-center hover:bg-primary/90 transition-colors"
+        className="fixed bottom-6 right-6 z-40 h-14 w-14 rounded-full bg-primary text-primary-foreground shadow-lg flex lg:hidden items-center justify-center hover:bg-primary/90 transition-colors"
         aria-label="Importar NF-e"
       >
         <Plus className="h-6 w-6" />

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,6 @@
 import type { Config } from "tailwindcss";
+import tailwindcssAnimate from "tailwindcss-animate";
+import typography from "@tailwindcss/typography";
 
 export default {
   darkMode: ["class"],
@@ -185,5 +187,5 @@ export default {
       },
     },
   },
-  plugins: [require("tailwindcss-animate"), require("@tailwindcss/typography")],
+  plugins: [tailwindcssAnimate, typography],
 } satisfies Config;


### PR DESCRIPTION
## Resumo
Continuação pós-#307. 3 commits (decisão tomada com Codex):

- **style(design)** — Recebimento: "Importar NF-e" no header (desktop) + FAB `lg:hidden` (mobile). Antes o FAB era o único gatilho de importar com a lista populada e flutuava solto no desktop. Verificado: desktop header + FAB `display:none`; mobile FAB `display:flex`.
- **perf(sales)** — `useUnifiedOrder`: memoiza `formasPagamentoOben/Colacor` (`|| []` criava array novo todo render, invalidando `sortedFormasPagamento*` e o submit). Resolve 2 warnings `exhaustive-deps`. Comportamento idêntico.
- **chore(lint)** — 11 erros triviais de eslint (prefer-const, no-empty-object-type em shadcn → type alias, no-empty-pattern, no-useless-escape, no-irregular-whitespace NBSP→` `, require()→import no tailwind.config). **Lint: 12 erros → 1** (o `@ts-nocheck` do FinanceiroOrcamento ficou de fora de propósito — é migração de tipos, não lint).

### Decisões (Codex)
- Chunk-size/`manualChunks`: **já implementado** em `vite.config.ts` — nada a fazer.
- Bulk `exhaustive-deps` (~85 warnings, incl. 4 do money-path em useUnifiedOrder): **pulado** — é trabalho de comportamento, merece PR com teste.

## Verificação
- `bun run build`: ✅ (23s, PWA) — confirma tailwind ESM
- `bun lint`: 12→1 erro; 0 erro novo (o unused-disable em WebRTCCallContext é pré-existente)
- Testes tocados (audit, CondicaoPagamento): 11/11 ✅
- Browser: FAB desktop/mobile ✅, sales/new renderiza ✅

## Nota (fora de escopo)
`useDirectTintImport.ts`: contador `updated` é **morto** (nunca incrementado — tudo conta como `imported`). Reporta sempre 0. Pré-existente; vale um fix futuro de reporting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)