### PR TITLE
fix(security): valida período do DRE p/ fechar injeção PostgREST

### DIFF
--- a/docs/superpowers/specs/2026-05-25-dre-period-injection-fix-design.md
+++ b/docs/superpowers/specs/2026-05-25-dre-period-injection-fix-design.md
@@ -1,0 +1,57 @@
+# Fix: injeção PostgREST via período do DRE (omie-financeiro) — Design Spec
+
+> **Data:** 2026-05-25
+> **Status:** achado de segurança + integridade financeira, validado em revisão adversária com o Codex. Helper puro com TDD espelhado verbatim no Deno (disciplina §FinanceiroProgram).
+
+## Problema
+
+`supabase/functions/omie-financeiro/index.ts`, actions `calcular_dre`/`calcular_dre_year`:
+
+1. `ano`/`mes`/`meses` vêm do **body JSON** (linha ~1665) sem coerção numérica (`targetAno = ano || ...`, `targetMeses = meses ? meses : [mes]`). O tipo TS `ano: number` **não é enforced em runtime no Deno**.
+2. Viram `inicioMes`/`fimMes` por interpolação crua e entram no **`.or()`** do `calcularDRE` (linhas 1235/1249):
+   ```ts
+   .or(`and(data_recebimento.gte.${inicioMes},data_recebimento.lt.${fimMes}),...`)
+   ```
+3. Body `{"action":"calcular_dre","mes":"01),or(id.gte.0"}` quebra o `and(...)` e injeta filtro PostgREST.
+
+**Severidade: Média-Alta de integridade** (não crítica). Dimensionada com o Codex:
+- Client é **service_role** (RLS bypassed), mas exige **caller autenticado** (`validateCaller`: staff/master/service_role/cron).
+- `.eq("company", company)` ANDa por fora do `.or()` e o supabase-js encoda o valor → **isolamento de empresa se mantém**, sem cross-tenant nem escape pra outra tabela. Pior caso de leitura = alargar a janela de data dentro da própria empresa.
+- **O peso real:** `calcularDRE` faz **`upsert` em `fin_dre_snapshots`** (linha ~1400) e engole erros de query (`data ?? []`) → um período malformado pode **persistir DRE incorreta/zerada silenciosamente** em money-path.
+- Bônus: bug latente `ano + 1` (concat de string em dezembro se `ano` vier string).
+
+Viola o padrão §9b do próprio projeto (nunca interpolar input cru no `.or()`), do lado servidor onde a regra ESLint não alcança.
+
+## Solução
+
+Helper puro **`src/lib/financeiro/dre-period.ts`** (TDD em vitest), **espelhado verbatim no Deno**:
+- `validateAno`/`validateMes`: exigem **inteiro** (`Number.isInteger`, sem `Math.trunc` — `1.9` não vira janeiro silenciosamente) no intervalo (ano 2000-2100, mes 1-12).
+- `resolveDrePeriod`: campo **ausente** → default contratado (ano/mês corrente); campo **presente e inválido** → `DrePeriodError`.
+- `meses` (array) tem precedência sobre `mes`; vazio/não-array → throw.
+
+Contrato de erro (decisão do Codex — **THROW, não fallback silencioso**, porque em money-path errar ruidosamente é melhor que gravar período errado): `DrePeriodError` → **HTTP 400** no catch do handler.
+
+**Dois chokepoints** (também recomendação do Codex):
+1. **Boundary** (`calcular_dre`/`calcular_dre_year`): `resolveDrePeriod`/`validateAno` → 400 em input inválido.
+2. **`calcularDRE`** (entrada): re-assert `validateAno`/`validateMes` — ponto money-path reutilizável que compõe o `.or()` cru; protege qualquer caller futuro e fecha o bug de dezembro.
+
+## Validação
+
+- `src/lib/financeiro/__tests__/dre-period.test.ts` — 15 casos (válido, ausente→default, presente-inválido→throw incl. strings de injeção, float, fora de range, array com elemento ruim). Verde.
+- `deno check` no edge function: **mesmo erro-set antes/depois** (10 erros pré-existentes de tipagem frouxa em código não-tocado; zero introduzidos).
+- Lint do helper/test: exit 0.
+
+## Deploy (manual, §5)
+
+Edge function lê do repo na branch main → após o merge, **redeploy do `omie-financeiro` via chat do Lovable** (prompt no corpo do PR). Sem o redeploy, a validação não entra em produção.
+
+## Follow-ups (sweep do Codex — fora do escopo deste PR, documentados)
+
+- `company`/`companies` sem allow-list runtime contra `["oben","colacor","colacor_sc"]`.
+- `validateCaller` é role-scoped, não **tenant-scoped** (se staff devesse ser limitado por empresa, é mais sério que o `.or()`).
+- `maxPages`/`filtro_data_de`/`filtro_data_ate`/`requestedRegime` sem validação estrita.
+- Tratar `error` em **todas** as queries do DRE (não transformar falha de DB em DRE vazia silenciosa).
+
+## Out-of-scope
+
+- Os follow-ups acima; reescrever a tipagem frouxa pré-existente do arquivo.

--- a/src/lib/financeiro/__tests__/dre-period.test.ts
+++ b/src/lib/financeiro/__tests__/dre-period.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import {
+  validateAno,
+  validateMes,
+  resolveDrePeriod,
+  DrePeriodError,
+} from '../dre-period';
+
+describe('validateAno', () => {
+  it('aceita ano inteiro no intervalo', () => {
+    expect(validateAno(2026)).toBe(2026);
+    expect(validateAno(2000)).toBe(2000);
+    expect(validateAno(2100)).toBe(2100);
+  });
+
+  it('aceita string só-dígitos e coage a número', () => {
+    expect(validateAno('2026')).toBe(2026);
+    expect(validateAno('  2026  ')).toBe(2026);
+  });
+
+  it('rejeita float (não silencia pra inteiro)', () => {
+    expect(() => validateAno(2026.5)).toThrow(DrePeriodError);
+  });
+
+  it('rejeita fora do intervalo 2000-2100', () => {
+    expect(() => validateAno(1999)).toThrow(DrePeriodError);
+    expect(() => validateAno(2101)).toThrow(DrePeriodError);
+    expect(() => validateAno(0)).toThrow(DrePeriodError);
+  });
+
+  it('rejeita injeção / não-numérico', () => {
+    expect(() => validateAno('2026),or(id.gte.0')).toThrow(DrePeriodError);
+    expect(() => validateAno('abc')).toThrow(DrePeriodError);
+    expect(() => validateAno(NaN)).toThrow(DrePeriodError);
+    expect(() => validateAno(null)).toThrow(DrePeriodError);
+    expect(() => validateAno(undefined)).toThrow(DrePeriodError);
+  });
+});
+
+describe('validateMes', () => {
+  it('aceita 1 a 12', () => {
+    expect(validateMes(1)).toBe(1);
+    expect(validateMes(12)).toBe(12);
+    expect(validateMes('6')).toBe(6);
+  });
+
+  it('rejeita fora de 1-12', () => {
+    expect(() => validateMes(0)).toThrow(DrePeriodError);
+    expect(() => validateMes(13)).toThrow(DrePeriodError);
+  });
+
+  it('rejeita float e injeção', () => {
+    expect(() => validateMes(6.5)).toThrow(DrePeriodError);
+    expect(() => validateMes('01),or(id.gte.0')).toThrow(DrePeriodError);
+    expect(() => validateMes('evil')).toThrow(DrePeriodError);
+  });
+});
+
+describe('resolveDrePeriod', () => {
+  const defaults = { defaultAno: 2026, defaultMes: 5 };
+
+  it('campos ausentes → usa os defaults contratados', () => {
+    expect(resolveDrePeriod({ ...defaults })).toEqual({ ano: 2026, meses: [5] });
+    expect(resolveDrePeriod({ ano: null, mes: undefined, ...defaults })).toEqual({ ano: 2026, meses: [5] });
+  });
+
+  it('ano/mes presentes e válidos → usa os validados', () => {
+    expect(resolveDrePeriod({ ano: 2025, mes: 3, ...defaults })).toEqual({ ano: 2025, meses: [3] });
+    expect(resolveDrePeriod({ ano: '2024', mes: '12', ...defaults })).toEqual({ ano: 2024, meses: [12] });
+  });
+
+  it('meses (array) tem precedência sobre mes', () => {
+    expect(resolveDrePeriod({ meses: [1, 2, 3], mes: 9, ...defaults })).toEqual({ ano: 2026, meses: [1, 2, 3] });
+  });
+
+  it('ano presente mas inválido → throw (não cai pro default)', () => {
+    expect(() => resolveDrePeriod({ ano: '2026),or(1.eq.1', ...defaults })).toThrow(DrePeriodError);
+    expect(() => resolveDrePeriod({ ano: 1800, ...defaults })).toThrow(DrePeriodError);
+  });
+
+  it('mes presente mas inválido → throw', () => {
+    expect(() => resolveDrePeriod({ mes: '01),or(1.eq.1', ...defaults })).toThrow(DrePeriodError);
+    expect(() => resolveDrePeriod({ mes: 99, ...defaults })).toThrow(DrePeriodError);
+  });
+
+  it('meses com elemento inválido → throw', () => {
+    expect(() => resolveDrePeriod({ meses: [1, '02),evil', 3], ...defaults })).toThrow(DrePeriodError);
+  });
+
+  it('meses não-array ou vazio → throw', () => {
+    expect(() => resolveDrePeriod({ meses: 5, ...defaults })).toThrow(DrePeriodError);
+    expect(() => resolveDrePeriod({ meses: [], ...defaults })).toThrow(DrePeriodError);
+  });
+});

--- a/src/lib/financeiro/dre-period.ts
+++ b/src/lib/financeiro/dre-period.ts
@@ -1,0 +1,96 @@
+/**
+ * Validação/coerção do período (ano/mes/meses) do DRE.
+ *
+ * SEGURANÇA: o engine `omie-financeiro` interpola `ano`/`mes` cru num predicado
+ * `.or()` do PostgREST pra montar `data.gte.${inicioMes}` (calcularDRE). Como o
+ * body JSON do Deno não valida o tipo em runtime, um `mes` string tipo
+ * `"01),or(id.gte.0"` quebraria o `and(...)` e injetaria filtro — e como o
+ * calcularDRE faz UPSERT em `fin_dre_snapshots`, um período malformado também
+ * persistiria DRE incorreta. Estes helpers fecham os dois: exigem inteiro no
+ * intervalo válido e fazem THROW no input presente-mas-inválido (degradação
+ * honesta — em money-path, errar ruidosamente é melhor que cair num default
+ * silencioso e gravar o período errado).
+ *
+ * Contrato: campo AUSENTE → usa o default contratado; campo PRESENTE e inválido
+ * → `DrePeriodError` (o handler mapeia pra HTTP 400).
+ *
+ * ⚠️ Espelhado VERBATIM no Deno em `supabase/functions/omie-financeiro/index.ts`
+ * (mesma disciplina do §FinanceiroProgram). Ao editar aqui, edite lá também.
+ */
+
+export class DrePeriodError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'DrePeriodError';
+  }
+}
+
+function asInteger(value: unknown, field: string): number {
+  if (typeof value === 'number') {
+    if (!Number.isInteger(value)) {
+      throw new DrePeriodError(`${field} deve ser inteiro (recebido: ${value})`);
+    }
+    return value;
+  }
+  if (typeof value === 'string') {
+    const t = value.trim();
+    if (!/^\d+$/.test(t)) {
+      throw new DrePeriodError(`${field} inválido (recebido: "${value}")`);
+    }
+    return Number(t);
+  }
+  throw new DrePeriodError(`${field} inválido (recebido: ${String(value)})`);
+}
+
+export function validateAno(ano: unknown): number {
+  const n = asInteger(ano, 'ano');
+  if (n < 2000 || n > 2100) {
+    throw new DrePeriodError(`ano fora do intervalo 2000-2100 (recebido: ${n})`);
+  }
+  return n;
+}
+
+export function validateMes(mes: unknown): number {
+  const n = asInteger(mes, 'mes');
+  if (n < 1 || n > 12) {
+    throw new DrePeriodError(`mes fora do intervalo 1-12 (recebido: ${n})`);
+  }
+  return n;
+}
+
+export interface DrePeriodInput {
+  ano?: unknown;
+  mes?: unknown;
+  meses?: unknown;
+  /** Default contratado quando `ano` está ausente (ex.: ano corrente). */
+  defaultAno: number;
+  /** Default contratado quando `mes` e `meses` estão ausentes (ex.: mês corrente). */
+  defaultMes: number;
+}
+
+/**
+ * Resolve o período do DRE a partir do input do request.
+ * - `ano` ausente → `defaultAno`; presente → validado.
+ * - `meses` (array) tem precedência sobre `mes`; ambos ausentes → `[defaultMes]`.
+ * - Qualquer valor presente e inválido → `DrePeriodError`.
+ */
+export function resolveDrePeriod(input: DrePeriodInput): { ano: number; meses: number[] } {
+  const ano = input.ano == null ? input.defaultAno : validateAno(input.ano);
+
+  let meses: number[];
+  if (input.meses != null) {
+    if (!Array.isArray(input.meses)) {
+      throw new DrePeriodError('meses deve ser um array de inteiros');
+    }
+    if (input.meses.length === 0) {
+      throw new DrePeriodError('meses não pode ser vazio');
+    }
+    meses = input.meses.map((m) => validateMes(m));
+  } else if (input.mes != null) {
+    meses = [validateMes(input.mes)];
+  } else {
+    meses = [input.defaultMes];
+  }
+
+  return { ano, meses };
+}

--- a/supabase/functions/omie-financeiro/index.ts
+++ b/supabase/functions/omie-financeiro/index.ts
@@ -1,6 +1,75 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient, type SupabaseClient } from "npm:@supabase/supabase-js@2";
 
+// ═══════════════ VALIDAÇÃO DE PERÍODO DO DRE (anti-injeção) ═══════════════
+// ⚠️ ESPELHO VERBATIM de src/lib/financeiro/dre-period.ts (testado em vitest).
+// Fecha injeção PostgREST via ano/mes crus no .or() do calcularDRE + evita
+// persistir DRE de período inválido. Editou aqui? Edite lá também.
+class DrePeriodError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "DrePeriodError";
+  }
+}
+
+function asInteger(value: unknown, field: string): number {
+  if (typeof value === "number") {
+    if (!Number.isInteger(value)) {
+      throw new DrePeriodError(`${field} deve ser inteiro (recebido: ${value})`);
+    }
+    return value;
+  }
+  if (typeof value === "string") {
+    const t = value.trim();
+    if (!/^\d+$/.test(t)) {
+      throw new DrePeriodError(`${field} inválido (recebido: "${value}")`);
+    }
+    return Number(t);
+  }
+  throw new DrePeriodError(`${field} inválido (recebido: ${String(value)})`);
+}
+
+function validateAno(ano: unknown): number {
+  const n = asInteger(ano, "ano");
+  if (n < 2000 || n > 2100) {
+    throw new DrePeriodError(`ano fora do intervalo 2000-2100 (recebido: ${n})`);
+  }
+  return n;
+}
+
+function validateMes(mes: unknown): number {
+  const n = asInteger(mes, "mes");
+  if (n < 1 || n > 12) {
+    throw new DrePeriodError(`mes fora do intervalo 1-12 (recebido: ${n})`);
+  }
+  return n;
+}
+
+function resolveDrePeriod(input: {
+  ano?: unknown;
+  mes?: unknown;
+  meses?: unknown;
+  defaultAno: number;
+  defaultMes: number;
+}): { ano: number; meses: number[] } {
+  const ano = input.ano == null ? input.defaultAno : validateAno(input.ano);
+  let meses: number[];
+  if (input.meses != null) {
+    if (!Array.isArray(input.meses)) {
+      throw new DrePeriodError("meses deve ser um array de inteiros");
+    }
+    if (input.meses.length === 0) {
+      throw new DrePeriodError("meses não pode ser vazio");
+    }
+    meses = input.meses.map((m) => validateMes(m));
+  } else if (input.mes != null) {
+    meses = [validateMes(input.mes)];
+  } else {
+    meses = [input.defaultMes];
+  }
+  return { ano, meses };
+}
+
 type OmieGenericResponse = Record<string, unknown> & { faultstring?: string };
 
 interface OmieListResponse<T> {
@@ -1210,6 +1279,12 @@ async function calcularDRE(
   mes: number,
   regime: Regime = "caixa"
 ) {
+  // Defense-in-depth: este é o ponto money-path que compõe o filtro .or() cru
+  // (1235/1249) e faz upsert em fin_dre_snapshots. Re-valida mesmo que o boundary
+  // já valide — qualquer caller futuro fica protegido. Reatribui pra normalizar
+  // o tipo (boundary pode entregar string "2026") e fechar o bug de dezembro.
+  ano = validateAno(ano);
+  mes = validateMes(mes);
   const inicioMes = `${ano}-${String(mes).padStart(2, "0")}-01`;
   const fimMes =
     mes === 12
@@ -1770,12 +1845,14 @@ serve(async (req) => {
       // Phase 3 (Fundação): calcula ambos regimes (caixa + competência) por padrão.
       // Aceita `regime` opcional ('caixa' | 'competencia' | 'ambos'). Default 'ambos'.
       case "calcular_dre": {
-        const targetAno = ano || new Date().getFullYear();
-        const targetMeses: number[] = meses
-          ? meses
-          : mes
-            ? [mes]
-            : [new Date().getMonth() + 1];
+        const nowDre = new Date();
+        const { ano: targetAno, meses: targetMeses } = resolveDrePeriod({
+          ano,
+          mes,
+          meses,
+          defaultAno: nowDre.getFullYear(),
+          defaultMes: nowDre.getMonth() + 1,
+        });
         const regimesToRun: Regime[] = requestedRegime === "caixa"
           ? ["caixa"]
           : requestedRegime === "competencia"
@@ -1796,7 +1873,7 @@ serve(async (req) => {
 
       // Ponto 8: calcular_dre_year = todos os meses até o mês atual
       case "calcular_dre_year": {
-        const targetAno = ano || new Date().getFullYear();
+        const targetAno = ano == null ? new Date().getFullYear() : validateAno(ano);
         const currentMonth = new Date().getFullYear() === targetAno ? new Date().getMonth() + 1 : 12;
         const regimesYear: Regime[] = ["caixa", "competencia"];
         for (const co of targetCompanies) {
@@ -1878,10 +1955,12 @@ serve(async (req) => {
     });
   } catch (error) {
     console.error("[Fin] Erro:", error);
+    // Período inválido = erro de contrato do cliente → 400 (não 500).
+    const status = error instanceof DrePeriodError ? 400 : 500;
     return new Response(
       JSON.stringify({ success: false, error: String(error) }),
       {
-        status: 500,
+        status,
         headers: { ...corsHeaders, "Content-Type": "application/json" },
       }
     );


### PR DESCRIPTION
## Achado
`omie-financeiro` interpolava `ano`/`mes` **crus** (do body JSON, sem coerção em runtime no Deno) num predicado `.or()` do `calcularDRE` (linhas 1235/1249). Body tipo `{"action":"calcular_dre","mes":"01),or(id.gte.0"}` quebra o `and(...)` e injeta filtro PostgREST.

**Severidade: Média-Alta de integridade** (validada em revisão adversária com o Codex — não é crítica):
- Client é **service_role** (RLS bypassed), mas exige **caller autenticado** (`validateCaller`).
- `.eq("company")` ANDa por fora do `.or()` + supabase-js encoda → **isolamento de empresa se mantém** (sem cross-tenant).
- **Peso real:** `calcularDRE` faz `upsert` em `fin_dre_snapshots` e engole erros (`data ?? []`) → período malformado **persiste DRE incorreta/zerada silenciosamente** (money-path).
- Bônus: bug latente `ano + 1` (concat de string em dezembro).
- Viola o padrão §9b do projeto, do lado servidor (fora do alcance da regra ESLint).

## Fix
Helper puro **`src/lib/financeiro/dre-period.ts`** (TDD, 15 casos) **espelhado verbatim no Deno**:
- Exige **inteiro** (`Number.isInteger` — `1.9` não vira janeiro) no range (ano 2000-2100, mes 1-12).
- Ausente → default contratado; **presente e inválido → `DrePeriodError` → HTTP 400** (THROW, não fallback silencioso — decisão do Codex: em money-path, errar ruidosamente > gravar período errado).
- **Dois chokepoints:** boundary (`calcular_dre`/`calcular_dre_year`) + re-assert na entrada do `calcularDRE`. Fecha também o bug de dezembro.

## Validação
- `bun run test -- src/lib/financeiro/__tests__/dre-period.test.ts` → 15/15 verde
- `deno check supabase/functions/omie-financeiro/index.ts` → **mesmo erro-set antes/depois** (10 erros pré-existentes de tipagem frouxa em código não-tocado; **zero introduzidos**)
- `eslint` no helper/test → exit 0

## ⚠️ ATENÇÃO: deploy manual necessário
Após o merge, **redeploy do `omie-financeiro` via chat do Lovable** (a function lê o arquivo do repo na main). Prompt pronto:

> Edit the existing Supabase edge function `omie-financeiro`: read the file `supabase/functions/omie-financeiro/index.ts` from the repo (branch main) and deploy it **verbatim** — do NOT modify or reinterpret the code.

## Follow-ups (sweep do Codex — não inclusos, propositalmente)
- `company`/`companies` sem allow-list runtime.
- `validateCaller` é role-scoped, não tenant-scoped.
- `maxPages`/`filtro_data_*`/`requestedRegime` sem validação estrita.
- Tratar `error` em todas as queries do DRE (não virar DRE vazia silenciosa).

🤖 Generated with [Claude Code](https://claude.com/claude-code)