### PR TITLE
fix(fin): hardening omie-financeiro — allow-list de empresa + error nas queries do DRE

### DIFF
--- a/docs/superpowers/specs/2026-05-25-omie-financeiro-hardening-design.md
+++ b/docs/superpowers/specs/2026-05-25-omie-financeiro-hardening-design.md
@@ -1,0 +1,39 @@
+# Hardening do `omie-financeiro` (follow-up do sweep do Codex) — Design Spec
+
+> **Data:** 2026-05-25
+> **Status:** follow-up do PR #322 (fix de injeção no DRE). Endereça 2 dos 4 itens do sweep adversário do Codex. Disciplina §FinanceiroProgram (helper puro TDD espelhado no Deno).
+
+## Goal
+
+Fechar mais dois gaps do sweep do Codex no `supabase/functions/omie-financeiro/index.ts`, sem mudar o comportamento legítimo:
+
+- **#1 — allow-list de empresa**: `company`/`companies` vêm do body sem validação. Não é injetável (`.eq()` encoda), mas garbage → resultado vazio / chave-lixo silenciosa, e fora do conjunto conhecido o upsert de snapshot grava numa empresa fantasma.
+- **#4 — `error` engolido nas queries do DRE**: `buscarCR`/`buscarCP` (e mappings/histReceita) faziam `const { data } = ...; return data ?? []`, ignorando `error`. Falha de DB (RLS, conexão) virava **DRE zerada/mis-categorizada persistida** no upsert — o ponto que o Codex classificou como integridade Média-Alta.
+
+## Solução
+
+**#1** — helper puro `src/lib/financeiro/omie-request.ts` (TDD), espelhado verbatim no Deno:
+- `resolveCompanies({ companies, company, allowed })`: `companies` (array) tem precedência, cada item no allow-list; senão `company` único validado; ambos ausentes → todas as permitidas. Inválido/vazio/não-array/tipo errado → `OmieRequestError` → **HTTP 400**.
+- Allow-list = `["oben","colacor","colacor_sc"]` (= `Company`). Aplicado no boundary (substitui `companies || (company ? [company] : [...])`).
+
+**#4** — em `calcularDRE`, capturar `error` e `throw` nas queries que alimentam a DRE: `buscarCR` (competência+caixa), `buscarCP` (competência+caixa), `fin_categoria_dre_mapping`, e o histórico p/ RBT12 (`fin_dre_snapshots`). Erro de DB nunca é "sem linhas" → não persistir DRE incompleta. **`cfgRes` (coluna opcional `dre_tributario`) fica como está** — degradação proposital documentada (`maybeSingle` → null).
+
+## Decisões (validadas com o Codex)
+
+- THROW, não fallback silencioso (money-path: errar ruidosamente > gravar errado). `calcularDRE` não é envolto em try/catch por-empresa → um throw 500a a action (correto: o cron/UI vê a falha e re-tenta).
+- `error` ≠ "sem linhas": throw em error não quebra o caso legítimo de tabela vazia (ex.: empresa nova sem histórico).
+
+## Fora do escopo (sweep do Codex — registrados, não feitos)
+
+- **#2 — `validateCaller` é role-scoped, não tenant-scoped**: é **decisão de PRODUTO** (o `CompanyContext` deixa staff trocar de empresa livremente → provavelmente não se quer escopar por empresa). Precisa do founder, não é hardening autônomo.
+- **#3 — `maxPages`/`filtro_data_de`/`filtro_data_ate`**: operacionais, baixo valor; `requestedRegime` **já é seguro** (comparado por `===` a literais com default). Deferido.
+
+## Validação
+
+- `src/lib/financeiro/__tests__/omie-request.test.ts` — 7 casos (ausente→todas, válido, fora-do-allow-list→throw, vazio/não-array/tipo errado→throw). Verde. Suíte financeiro: 214/214.
+- `deno check`: **mesmo erro-set antes/depois** (10 erros pré-existentes; zero introduzidos).
+- Lint do helper/test: exit 0.
+
+## Deploy (manual, §5)
+
+Após o merge, **redeploy do `omie-financeiro` via chat do Lovable** (verbatim do repo na main).

--- a/src/lib/financeiro/__tests__/omie-request.test.ts
+++ b/src/lib/financeiro/__tests__/omie-request.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { resolveCompanies, OmieRequestError } from '../omie-request';
+
+const ALLOWED = ['oben', 'colacor', 'colacor_sc'] as const;
+
+describe('resolveCompanies', () => {
+  it('ausente (sem companies nem company) → todas as permitidas', () => {
+    expect(resolveCompanies({ allowed: ALLOWED })).toEqual(['oben', 'colacor', 'colacor_sc']);
+    expect(resolveCompanies({ companies: null, company: undefined, allowed: ALLOWED })).toEqual([
+      'oben', 'colacor', 'colacor_sc',
+    ]);
+  });
+
+  it('companies (array) válido → exatamente essas', () => {
+    expect(resolveCompanies({ companies: ['oben', 'colacor'], allowed: ALLOWED })).toEqual(['oben', 'colacor']);
+    expect(resolveCompanies({ companies: ['colacor_sc'], allowed: ALLOWED })).toEqual(['colacor_sc']);
+  });
+
+  it('company único válido → [company]', () => {
+    expect(resolveCompanies({ company: 'colacor_sc', allowed: ALLOWED })).toEqual(['colacor_sc']);
+  });
+
+  it('companies (array) tem precedência sobre company', () => {
+    expect(resolveCompanies({ companies: ['oben'], company: 'colacor', allowed: ALLOWED })).toEqual(['oben']);
+  });
+
+  it('empresa fora do allow-list → throw', () => {
+    expect(() => resolveCompanies({ companies: ['oben', 'evil'], allowed: ALLOWED })).toThrow(OmieRequestError);
+    expect(() => resolveCompanies({ company: 'dropTable', allowed: ALLOWED })).toThrow(OmieRequestError);
+    expect(() => resolveCompanies({ company: 'colacor),or(1.eq.1', allowed: ALLOWED })).toThrow(OmieRequestError);
+  });
+
+  it('companies vazio ou não-array → throw', () => {
+    expect(() => resolveCompanies({ companies: [], allowed: ALLOWED })).toThrow(OmieRequestError);
+    expect(() => resolveCompanies({ companies: 'oben', allowed: ALLOWED })).toThrow(OmieRequestError);
+  });
+
+  it('company de tipo inválido → throw', () => {
+    expect(() => resolveCompanies({ company: 123, allowed: ALLOWED })).toThrow(OmieRequestError);
+    expect(() => resolveCompanies({ companies: [1, 2], allowed: ALLOWED })).toThrow(OmieRequestError);
+  });
+});

--- a/src/lib/financeiro/omie-request.ts
+++ b/src/lib/financeiro/omie-request.ts
@@ -1,0 +1,62 @@
+/**
+ * Validação de parâmetros de request do engine `omie-financeiro`.
+ *
+ * SEGURANÇA/INTEGRIDADE: `company`/`companies` vêm do body JSON e são usados em
+ * `.eq("company", ...)`, como chave do upsert de snapshot e como chave do objeto
+ * de resultado. Embora o supabase-js encode o valor do `.eq()` (não há injeção
+ * estrutural como no `.or()`), uma empresa fora do conjunto conhecido produz
+ * resultado vazio / chave-lixo silenciosa. Aqui validamos contra o allow-list e
+ * fazemos THROW no input inválido (mapeado pra HTTP 400 no handler).
+ *
+ * ⚠️ Espelhado VERBATIM no Deno em `supabase/functions/omie-financeiro/index.ts`
+ * (mesma disciplina do §FinanceiroProgram). Ao editar aqui, edite lá também.
+ */
+
+export class OmieRequestError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'OmieRequestError';
+  }
+}
+
+function validateCompany(value: unknown, allowed: readonly string[]): string {
+  if (typeof value === 'string' && allowed.includes(value)) {
+    return value;
+  }
+  throw new OmieRequestError(`company inválida (recebido: ${JSON.stringify(value)})`);
+}
+
+export interface ResolveCompaniesInput {
+  companies?: unknown;
+  company?: unknown;
+  /** Conjunto permitido (ex.: ["oben","colacor","colacor_sc"]). */
+  allowed: readonly string[];
+}
+
+/**
+ * Resolve a lista-alvo de empresas validando contra o allow-list.
+ * - `companies` (array) tem precedência; cada item deve estar no allow-list.
+ * - senão `company` único validado.
+ * - ambos ausentes → todas as permitidas.
+ * Qualquer valor presente e inválido (fora do allow-list, vazio, não-array,
+ * tipo errado) → `OmieRequestError`.
+ */
+export function resolveCompanies(input: ResolveCompaniesInput): string[] {
+  const { companies, company, allowed } = input;
+
+  if (companies != null) {
+    if (!Array.isArray(companies)) {
+      throw new OmieRequestError('companies deve ser um array');
+    }
+    if (companies.length === 0) {
+      throw new OmieRequestError('companies não pode ser vazio');
+    }
+    return companies.map((c) => validateCompany(c, allowed));
+  }
+
+  if (company != null) {
+    return [validateCompany(company, allowed)];
+  }
+
+  return [...allowed];
+}

--- a/supabase/functions/omie-financeiro/index.ts
+++ b/supabase/functions/omie-financeiro/index.ts
@@ -70,6 +70,47 @@ function resolveDrePeriod(input: {
   return { ano, meses };
 }
 
+// ═══════════════ VALIDAÇÃO DE EMPRESA (allow-list) ═══════════════
+// ⚠️ ESPELHO VERBATIM de src/lib/financeiro/omie-request.ts (testado em vitest).
+// Valida company/companies do body contra o allow-list (evita resultado vazio /
+// chave-lixo silenciosa). Editou aqui? Edite lá também.
+const ALLOWED_COMPANIES = ["oben", "colacor", "colacor_sc"] as const;
+
+class OmieRequestError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "OmieRequestError";
+  }
+}
+
+function validateCompany(value: unknown, allowed: readonly string[]): string {
+  if (typeof value === "string" && allowed.includes(value)) {
+    return value;
+  }
+  throw new OmieRequestError(`company inválida (recebido: ${JSON.stringify(value)})`);
+}
+
+function resolveCompanies(input: {
+  companies?: unknown;
+  company?: unknown;
+  allowed: readonly string[];
+}): string[] {
+  const { companies, company, allowed } = input;
+  if (companies != null) {
+    if (!Array.isArray(companies)) {
+      throw new OmieRequestError("companies deve ser um array");
+    }
+    if (companies.length === 0) {
+      throw new OmieRequestError("companies não pode ser vazio");
+    }
+    return companies.map((c) => validateCompany(c, allowed));
+  }
+  if (company != null) {
+    return [validateCompany(company, allowed)];
+  }
+  return [...allowed];
+}
+
 type OmieGenericResponse = Record<string, unknown> & { faultstring?: string };
 
 interface OmieListResponse<T> {
@@ -1298,38 +1339,43 @@ async function calcularDRE(
   // vencimento na janela) e bucketiza client-side via resolverDataCaixa.
   async function buscarCR() {
     if (regime === "competencia") {
-      const { data } = await db.from("fin_contas_receber")
+      const { data, error } = await db.from("fin_contas_receber")
         .select("valor_documento, valor_recebido, data_recebimento, data_vencimento, categoria_codigo, categoria_descricao")
         .eq("company", company).neq("status_titulo", "CANCELADO")
         .gte("data_emissao", inicioMes).lt("data_emissao", fimMes);
+      if (error) throw error; // não silenciar falha de DB como DRE vazia
       return data ?? [];
     }
-    const { data } = await db.from("fin_contas_receber")
+    const { data, error } = await db.from("fin_contas_receber")
       .select("valor_documento, valor_recebido, data_recebimento, data_vencimento, categoria_codigo, categoria_descricao")
       .eq("company", company).in("status_titulo", ["RECEBIDO", "PARCIAL", "LIQUIDADO"])
       .or(`and(data_recebimento.gte.${inicioMes},data_recebimento.lt.${fimMes}),and(data_recebimento.is.null,data_vencimento.gte.${inicioMes},data_vencimento.lt.${fimMes})`);
+    if (error) throw error; // não silenciar falha de DB como DRE vazia
     return data ?? [];
   }
   async function buscarCP() {
     if (regime === "competencia") {
-      const { data } = await db.from("fin_contas_pagar")
+      const { data, error } = await db.from("fin_contas_pagar")
         .select("valor_documento, valor_pago, data_pagamento, data_vencimento, categoria_codigo, categoria_descricao")
         .eq("company", company).neq("status_titulo", "CANCELADO")
         .gte("data_emissao", inicioMes).lt("data_emissao", fimMes);
+      if (error) throw error; // não silenciar falha de DB como DRE vazia
       return data ?? [];
     }
-    const { data } = await db.from("fin_contas_pagar")
+    const { data, error } = await db.from("fin_contas_pagar")
       .select("valor_documento, valor_pago, data_pagamento, data_vencimento, categoria_codigo, categoria_descricao")
       .eq("company", company).in("status_titulo", ["PAGO", "PARCIAL", "LIQUIDADO"])
       .or(`and(data_pagamento.gte.${inicioMes},data_pagamento.lt.${fimMes}),and(data_pagamento.is.null,data_vencimento.gte.${inicioMes},data_vencimento.lt.${fimMes})`);
+    if (error) throw error; // não silenciar falha de DB como DRE vazia
     return data ?? [];
   }
   const receitas = await buscarCR();
   const despesas = await buscarCP();
 
   // ── Mapping ──
-  const { data: mappings } = await db.from("fin_categoria_dre_mapping")
+  const { data: mappings, error: mappingsError } = await db.from("fin_categoria_dre_mapping")
     .select("omie_codigo, dre_linha, company").in("company", [company, "_default"]);
+  if (mappingsError) throw mappingsError; // categorização incompleta não deve persistir DRE
   const mapping = new Map<string, string>();
   const sorted = ((mappings ?? []) as Array<{ omie_codigo: string; dre_linha: string; company: string }>)
     .slice().sort((a, b) => (a.company === "_default" ? -1 : 1));
@@ -1339,6 +1385,7 @@ async function calcularDRE(
   const cfgRes = await db.from("fin_config_cashflow").select("dre_tributario").eq("company", company).maybeSingle();
   const configTrib = normalizarConfigTributario(company, (cfgRes.data as { dre_tributario?: Record<string, unknown> } | null)?.dre_tributario ?? null);
   const histRes = await db.from("fin_dre_snapshots").select("ano, mes, receita_bruta").eq("company", company).eq("regime", "competencia");
+  if (histRes.error) throw histRes.error; // histórico p/ RBT12: falha de DB não vira histórico vazio
   const histReceita = ((histRes.data ?? []) as Array<{ ano: number; mes: number; receita_bruta: number }>);
 
   // ── Classificar + bucketizar (caixa por data efetiva) ──
@@ -1740,7 +1787,7 @@ serve(async (req) => {
     const { action, company, companies, filtro_data_de, filtro_data_ate, ano, mes, meses, maxPages, entidade, ncodcc, regime: requestedRegime } =
       await req.json();
 
-    const targetCompanies: Company[] = companies || (company ? [company] : ["oben", "colacor", "colacor_sc"]);
+    const targetCompanies = resolveCompanies({ companies, company, allowed: ALLOWED_COMPANIES }) as Company[];
 
     // Reset global counters per invocation
     globalStartTime = Date.now();
@@ -1955,8 +2002,8 @@ serve(async (req) => {
     });
   } catch (error) {
     console.error("[Fin] Erro:", error);
-    // Período inválido = erro de contrato do cliente → 400 (não 500).
-    const status = error instanceof DrePeriodError ? 400 : 500;
+    // Erro de contrato do cliente (período/empresa inválidos) → 400 (não 500).
+    const status = error instanceof DrePeriodError || error instanceof OmieRequestError ? 400 : 500;
     return new Response(
       JSON.stringify({ success: false, error: String(error) }),
       {


### PR DESCRIPTION
## Resumo
Follow-up do #322 (sweep adversário do Codex). Endereça **2 dos 4** itens.

### #1 — allow-list de empresa
`company`/`companies` vinham do body sem validação. Não é injetável (`.eq` encoda), mas garbage → resultado vazio / **upsert de snapshot em empresa fantasma**. Helper puro `resolveCompanies` (TDD, 7 casos) espelhado verbatim no Deno → `OmieRequestError` → **HTTP 400** fora de `["oben","colacor","colacor_sc"]`.

### #4 — `error` engolido nas queries do DRE (integridade)
`buscarCR`/`buscarCP`/mappings/histReceita faziam `const { data } = ...; return data ?? []`, transformando **falha de DB em DRE zerada/mis-categorizada PERSISTIDA** no upsert (o ponto que o Codex classificou como integridade Média-Alta). Agora `if (error) throw error` — erro de DB nunca é "sem linhas", e não quebra o caso legítimo de tabela vazia (ex.: empresa nova sem histórico). `cfgRes` (coluna opcional `dre_tributario`) fica como está — degradação **proposital** documentada.

## Fora do escopo (registrados, não feitos)
- **#2 — `validateCaller` role-scoped, não tenant-scoped**: **decisão de PRODUTO** (o CompanyContext deixa staff trocar de empresa livremente → provavelmente não se quer escopar). Precisa do founder.
- **#3 — `maxPages`/`filtro_data_*`**: operacionais, baixo valor; `requestedRegime` **já é seguro** (`===` a literais com default). Deferido.

## Validação
- `bun run test -- src/lib/financeiro/` → **214/214** (incl. 7 novos do omie-request)
- `deno check` → **mesmo erro-set antes/depois** (10 pré-existentes; **zero introduzidos**)
- `eslint` no helper/test → exit 0

## ⚠️ ATENÇÃO: deploy manual necessário
Após o merge, **redeploy do `omie-financeiro` via chat do Lovable** (verbatim do repo na main):

> Edit the existing Supabase edge function `omie-financeiro`: read `supabase/functions/omie-financeiro/index.ts` from the repo (branch `main`) and deploy it **verbatim** — do NOT modify the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)