### PR TITLE
fix(fin): elimina h1 duplicado em /financeiro/gestao

### DIFF
--- a/src/pages/FinanceiroDashboard.tsx
+++ b/src/pages/FinanceiroDashboard.tsx
@@ -26,7 +26,7 @@ const threeMonthsAhead = new Date(today.getFullYear(), today.getMonth() + 3, 0);
 
 // ═══════════════ MAIN COMPONENT ═══════════════
 
-const FinanceiroDashboard = () => {
+const FinanceiroDashboard = ({ embedded = false }: { embedded?: boolean } = {}) => {
   const {
     view, setView, loading, syncing, error, lastSync,
     activeResumo, resumo,
@@ -105,22 +105,25 @@ const FinanceiroDashboard = () => {
     <div className="space-y-4 pb-24">
       {/* Header */}
       <div className="flex items-center justify-between flex-wrap gap-3">
-        <div>
-          <h1
-            className="font-display"
-            style={{ fontSize: "2rem", fontWeight: 500, letterSpacing: "-0.04em", lineHeight: 1.1 }}
-          >
-            Financeiro
-          </h1>
-          <p className="text-sm text-muted-foreground mt-1">
-            Controle financeiro integrado — Omie
-            {lastSync && (
-              <span className="ml-2 text-xs font-normal opacity-60">
-                · Sync {new Date(lastSync).toLocaleString('pt-BR', { day: '2-digit', month: '2-digit', hour: '2-digit', minute: '2-digit' })}
-              </span>
-            )}
-          </p>
-        </div>
+        {/* Título omitido quando embutido (ex: dentro de FinanceiroGestao, que já tem h1) */}
+        {!embedded && (
+          <div>
+            <h1
+              className="font-display"
+              style={{ fontSize: "2rem", fontWeight: 500, letterSpacing: "-0.04em", lineHeight: 1.1 }}
+            >
+              Financeiro
+            </h1>
+            <p className="text-sm text-muted-foreground mt-1">
+              Controle financeiro integrado — Omie
+              {lastSync && (
+                <span className="ml-2 text-xs font-normal opacity-60">
+                  · Sync {new Date(lastSync).toLocaleString('pt-BR', { day: '2-digit', month: '2-digit', hour: '2-digit', minute: '2-digit' })}
+                </span>
+              )}
+            </p>
+          </div>
+        )}
         <div className="flex items-center gap-2 flex-wrap">
           <RegimeToggle />
           <Select value={view} onValueChange={(v) => setView(v as FinanceiroView)}>

--- a/src/pages/FinanceiroGestao.tsx
+++ b/src/pages/FinanceiroGestao.tsx
@@ -164,7 +164,12 @@ export default function FinanceiroGestao() {
         <div className="flex items-center gap-3">
           <Wallet className="h-6 w-6 text-primary" />
           <div>
-            <h1 className="text-2xl font-bold">Gestão Financeira</h1>
+            <h1
+              className="font-display"
+              style={{ fontSize: "2rem", fontWeight: 500, letterSpacing: "-0.04em", lineHeight: 1.1 }}
+            >
+              Gestão Financeira
+            </h1>
             <p className="text-sm text-muted-foreground">
               Painel, capital de giro, conciliação, orçamento e fechamento.
             </p>
@@ -197,7 +202,7 @@ export default function FinanceiroGestao() {
 
         <TabsContent value="painel" className="m-0">
           <Suspense fallback={<TabFallback />}>
-            <FinanceiroDashboard />
+            <FinanceiroDashboard embedded />
           </Suspense>
         </TabsContent>
         <TabsContent value="capital" className="m-0">


### PR DESCRIPTION
## Resumo
Auditoria do tier-2 de telas (SalesOrders, AdminCustomers, Gestão Financeira, cards de picking — decisão eu+codex). **3 das 4 telas estão sólidas/DS-compliant** (sem fix). A única com achado real:

- **fix(fin) /financeiro/gestao** — tinha **2 `<h1>`** na mesma página: "Gestão Financeira" (Geist sans) do wrapper + "Financeiro" (serif) do `FinanceiroDashboard` embutido → problema de hierarquia/a11y + inconsistência de fonte. Agora: `FinanceiroDashboard` ganha prop `embedded` que omite só o bloco de título (controles Caixa/Competência/Sincronizar preservados); o h1 "Gestão Financeira" vira serif `font-display` (único h1). Standalone `/financeiro` inalterado.

## Verificação (gate local completo)
- `typecheck:strict`: ✅ (0 erros)
- `bun run test`: 1398/1398 ✅
- `bun run build`: ✅
- Browser: `/financeiro/gestao` = 1 h1 (Newsreader), controles do dashboard preservados; `/financeiro` standalone intacto ✅

## Observações (não corrigidas — deferidas)
- **Contador `updated` morto** em `useDirectTintImport` (corantes/PBE): investiguei o "quick fix" — distinguir insert/update exige lógica por-linha via cache (edge cases de cap/cross-batch) e não dá pra verificar ao vivo (import = escrita prod). Melhor um PR dedicado do que contagem meia-boca. Deferido.
- **AdminCustomers** "999d" (dias s/ compra) em vermelho: provável sentinela de cliente inativo (8/48); se for "nunca comprou", trocar por "—". Depende de dado do backend. Deferido.

🤖 Generated with [Claude Code](https://claude.com/claude-code)