### PR TITLE
fix(security): gate omie-financeiro a master + gestor comercial (BFLA)

### DIFF
--- a/docs/superpowers/specs/2026-05-25-omie-financeiro-auth-gate-design.md
+++ b/docs/superpowers/specs/2026-05-25-omie-financeiro-auth-gate-design.md
@@ -1,0 +1,45 @@
+# Gate de acesso do `omie-financeiro` (master + gestor) — Design Spec
+
+> **Data:** 2026-05-25
+> **Status:** follow-up #2 do sweep do Codex (PR #322/#324). Matriz de permissão **decidida pelo founder** (2026-05-25): master + gestor comercial. Disciplina §FinanceiroProgram (helper puro TDD espelhado no Deno).
+
+## Problema (gap de autorização server-side, BFLA/BOLA-ish)
+
+`validateCaller` do `omie-financeiro` aceitava **qualquer** `employee` ou `master` (via JWT). Mas a function expõe dados financeiros sensíveis (DRE, saldos, contas a pagar/receber das 3 empresas) e dispara sync com o ERP Omie. No frontend, os cockpits financeiros são gated master-only ou gestor+master — mas **UI gate não é controle de segurança**: um `employee` comum (ex.: separador) com JWT válido podia chamar a function direto (curl/fetch) e ler/sincronizar.
+
+Confirmado em revisão adversária com o Codex como gap real; a **matriz** (quem pode) foi reservada pro founder.
+
+## Decisão (founder)
+
+**master + gestor comercial.** Espelha o gate canônico do `fin-valor-cockpit`/`fin-next-best-action`:
+- `master` em `user_roles.role`, **OU**
+- `commercial_roles.commercial_role` ∈ `{gerencial, estrategico, super_admin}`.
+- **cron/service_role** seguem livres (inalterados — os crons rodam o sync).
+- `employee` comum e `vendedor` (commercial não-gestor) → **403**.
+
+## Solução
+
+Helper puro `hasFinanceiroAccess({ userRoles, commercialRoles })` em `src/lib/financeiro/omie-request.ts` (TDD, deny-by-default), espelhado verbatim no Deno. `validateCaller` passa a buscar `user_roles` + `commercial_roles` (via `db` service_role → sem esbarrar em RLS) e delega a decisão ao helper.
+
+Granularidade: **função inteira** (não por-action) — todas as actions do `omie-financeiro` são financeiras/sync (sync_*, calcular_dre[_year], resumo, debug_raw); nenhuma é operacional pra employee comum.
+
+## Validação
+
+- `src/lib/financeiro/__tests__/omie-request.test.ts` — +6 casos de `hasFinanceiroAccess` (master→true; gerencial/estrategico/super_admin→true; master vence; employee→false; vendedor→false; null/vazio→false). Suíte financeiro: **220/220**.
+- `deno check`: mesmo erro-set antes/depois (zero introduzidos).
+- Lint: exit 0.
+
+## Risco / breakage
+
+- Crons (cron-secret/service_role): **não afetados**.
+- UI financeira: usuários são master/gestor → ok.
+- O que pode quebrar: caller direto ou tela esquecida usando `employee` puro — que é exatamente o acesso indevido que se quer cortar (descoberta = feature).
+
+## Deploy (manual, §5)
+
+Após o merge, **redeploy do `omie-financeiro` via chat do Lovable** (verbatim do repo na main).
+
+## Out-of-scope
+
+- Tenant-scoping por empresa (org única, staff troca livremente → by-design, não é gap).
+- `maxPages`/`filtro_data_*` (operacionais, baixo valor; `requestedRegime` já seguro).

--- a/src/lib/financeiro/__tests__/omie-request.test.ts
+++ b/src/lib/financeiro/__tests__/omie-request.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { resolveCompanies, OmieRequestError } from '../omie-request';
+import { resolveCompanies, hasFinanceiroAccess, OmieRequestError } from '../omie-request';
 
 const ALLOWED = ['oben', 'colacor', 'colacor_sc'] as const;
 
@@ -38,5 +38,35 @@ describe('resolveCompanies', () => {
   it('company de tipo inválido → throw', () => {
     expect(() => resolveCompanies({ company: 123, allowed: ALLOWED })).toThrow(OmieRequestError);
     expect(() => resolveCompanies({ companies: [1, 2], allowed: ALLOWED })).toThrow(OmieRequestError);
+  });
+});
+
+describe('hasFinanceiroAccess', () => {
+  it('master (user_roles) → true', () => {
+    expect(hasFinanceiroAccess({ userRoles: [{ role: 'master' }], commercialRoles: [] })).toBe(true);
+  });
+
+  it('gestor comercial (gerencial/estrategico/super_admin) → true', () => {
+    expect(hasFinanceiroAccess({ userRoles: [], commercialRoles: [{ commercial_role: 'gerencial' }] })).toBe(true);
+    expect(hasFinanceiroAccess({ userRoles: [], commercialRoles: [{ commercial_role: 'estrategico' }] })).toBe(true);
+    expect(hasFinanceiroAccess({ userRoles: [], commercialRoles: [{ commercial_role: 'super_admin' }] })).toBe(true);
+  });
+
+  it('master vence mesmo com commercial_role não-gestor', () => {
+    expect(hasFinanceiroAccess({ userRoles: [{ role: 'master' }], commercialRoles: [{ commercial_role: 'vendedor' }] })).toBe(true);
+  });
+
+  it('employee comum (sem master, sem gestor) → false', () => {
+    expect(hasFinanceiroAccess({ userRoles: [{ role: 'employee' }], commercialRoles: [] })).toBe(false);
+  });
+
+  it('vendedor (commercial_role não-gestor) → false', () => {
+    expect(hasFinanceiroAccess({ userRoles: [{ role: 'employee' }], commercialRoles: [{ commercial_role: 'vendedor' }] })).toBe(false);
+  });
+
+  it('null/undefined/vazio → false (deny by default)', () => {
+    expect(hasFinanceiroAccess({ userRoles: null, commercialRoles: null })).toBe(false);
+    expect(hasFinanceiroAccess({ userRoles: undefined, commercialRoles: undefined })).toBe(false);
+    expect(hasFinanceiroAccess({ userRoles: [], commercialRoles: [] })).toBe(false);
   });
 });

--- a/src/lib/financeiro/omie-request.ts
+++ b/src/lib/financeiro/omie-request.ts
@@ -60,3 +60,30 @@ export function resolveCompanies(input: ResolveCompaniesInput): string[] {
 
   return [...allowed];
 }
+
+/**
+ * Conjunto de `commercial_role` que contam como "gestor comercial" pra acesso
+ * financeiro. Espelha o gate canônico do `fin-valor-cockpit`/`fin-next-best-action`.
+ */
+export const GESTOR_COMMERCIAL_ROLES = ['gerencial', 'estrategico', 'super_admin'] as const;
+
+/**
+ * Gate de acesso ao engine financeiro (`omie-financeiro`): expõe DRE/saldos/CP-CR
+ * + sync com o ERP, então NÃO é pra employee comum. Autoriza se o usuário é
+ * `master` (user_roles) OU gestor comercial (commercial_roles em
+ * GESTOR_COMMERCIAL_ROLES). Deny-by-default (null/vazio → false).
+ *
+ * Decisão de matriz: founder (2026-05-25). Não confere RLS/tenant — a verdade do
+ * dado vem das queries `.eq("company", ...)`; isto é só o gate de quem-pode-chamar.
+ */
+export function hasFinanceiroAccess(input: {
+  userRoles: ReadonlyArray<{ role?: string | null }> | null | undefined;
+  commercialRoles: ReadonlyArray<{ commercial_role?: string | null }> | null | undefined;
+}): boolean {
+  const isMaster = (input.userRoles ?? []).some((r) => r?.role === 'master');
+  if (isMaster) return true;
+  const gestor = new Set<string>(GESTOR_COMMERCIAL_ROLES);
+  return (input.commercialRoles ?? []).some(
+    (c) => c?.commercial_role != null && gestor.has(c.commercial_role),
+  );
+}

--- a/supabase/functions/omie-financeiro/index.ts
+++ b/supabase/functions/omie-financeiro/index.ts
@@ -111,6 +111,25 @@ function resolveCompanies(input: {
   return [...allowed];
 }
 
+// ═══════════════ GATE DE ACESSO FINANCEIRO ═══════════════
+// ⚠️ ESPELHO VERBATIM de src/lib/financeiro/omie-request.ts (testado em vitest).
+// Autoriza master (user_roles) OU gestor comercial (commercial_roles em
+// GESTOR_COMMERCIAL_ROLES). Espelha o gate do fin-valor-cockpit. Editou aqui?
+// Edite lá também.
+const GESTOR_COMMERCIAL_ROLES = ["gerencial", "estrategico", "super_admin"] as const;
+
+function hasFinanceiroAccess(input: {
+  userRoles: ReadonlyArray<{ role?: string | null }> | null | undefined;
+  commercialRoles: ReadonlyArray<{ commercial_role?: string | null }> | null | undefined;
+}): boolean {
+  const isMaster = (input.userRoles ?? []).some((r) => r?.role === "master");
+  if (isMaster) return true;
+  const gestor = new Set<string>(GESTOR_COMMERCIAL_ROLES);
+  return (input.commercialRoles ?? []).some(
+    (c) => c?.commercial_role != null && gestor.has(c.commercial_role),
+  );
+}
+
 type OmieGenericResponse = Record<string, unknown> & { faultstring?: string };
 
 interface OmieListResponse<T> {
@@ -1643,16 +1662,21 @@ async function validateCaller(
     return { authorized: false, error: "Token inválido" };
   }
 
-  // Check staff role (admin, manager, employee, master)
-  const { data: roles } = await db
+  // Gate financeiro: master (user_roles) OU gestor comercial (commercial_roles).
+  // omie-financeiro expõe DRE/saldos/CP-CR + sync ERP — não é p/ employee comum.
+  // Matriz decidida pelo founder (2026-05-25); espelha o gate do fin-valor-cockpit.
+  // `db` é service_role → lê as roles sem esbarrar em RLS.
+  const { data: userRoles } = await db
     .from("user_roles")
     .select("role")
-    .eq("user_id", user.id)
-    .in("role", ["employee", "master"])
-    .limit(1);
+    .eq("user_id", user.id);
+  const { data: commercialRoles } = await db
+    .from("commercial_roles")
+    .select("commercial_role")
+    .eq("user_id", user.id);
 
-  if (!roles || roles.length === 0) {
-    return { authorized: false, error: "Permissão negada: requer perfil de funcionário" };
+  if (!hasFinanceiroAccess({ userRoles, commercialRoles })) {
+    return { authorized: false, error: "Permissão negada: requer master ou gestor comercial" };
   }
 
   return { authorized: true, userId: user.id };


### PR DESCRIPTION
## Achado (autorização server-side, BFLA/BOLA-ish)
`validateCaller` aceitava **qualquer** `employee`/`master` via JWT, mas o `omie-financeiro` expõe DRE/saldos/CP-CR das 3 empresas + dispara sync com o ERP. **UI gate ≠ controle de segurança**: um `employee` comum (ex.: separador) com JWT válido podia chamar a function direto (curl/fetch) e ler/sincronizar financeiro. Confirmado com o Codex.

## Decisão (founder, 2026-05-25)
**master + gestor comercial** — espelha o gate canônico do `fin-valor-cockpit`:
- `master` (`user_roles.role`) **OU** `commercial_roles.commercial_role` ∈ `{gerencial, estrategico, super_admin}`
- **cron/service_role** inalterados (crons rodam o sync)
- `employee` puro e `vendedor` → **403**

## Implementação
Helper puro `hasFinanceiroAccess` (TDD, deny-by-default) espelhado verbatim no Deno; `validateCaller` busca `user_roles` + `commercial_roles` (via `db` service_role → sem RLS) e delega. Gate na **função inteira** (todas as actions são financeiras/sync; nenhuma é operacional pra employee).

## Validação
- `bun run test -- src/lib/financeiro/` → **220/220** (+6 casos de hasFinanceiroAccess)
- `deno check` → **mesmo erro-set antes/depois** (zero introduzidos)
- `eslint` → exit 0

## Risco / breakage
- Crons (cron-secret/service_role): **não afetados**.
- UI financeira: usuários são master/gestor → ok.
- Pode quebrar: caller direto / tela esquecida usando `employee` puro — que é exatamente o acesso indevido a cortar.

## ⚠️ ATENÇÃO: deploy manual
Após o merge, **redeploy do `omie-financeiro` via chat do Lovable** (verbatim do repo na main).

> Edit the existing Supabase edge function `omie-financeiro`: read `supabase/functions/omie-financeiro/index.ts` from the repo (branch `main`) and deploy it **verbatim** — do NOT modify the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)