### PR TITLE
fix(security): endurece RLS de score por carteira (farmer/visit)

### DIFF
--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,13 +21,13 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **71** custom migrations totais
-- **360** objetos esperados (criados por estas migrations)
+- **72** custom migrations totais
+- **369** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
-  - `rls_policy`: 106
+  - `rls_policy`: 114
   - `index`: 95
+  - `function`: 54
   - `table`: 53
-  - `function`: 53
   - `trigger`: 31
   - `cron_job`: 18
   - `enum_value`: 4
@@ -738,6 +738,20 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | `table` | `public.impersonation_audit` | — |
 | `function` | `public.log_impersonation_start` | — |
 | `function` | `public.end_impersonation` | — |
+
+### `20260526020000_rls_score_carteira_hardening.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `public.pode_ver_carteira_completa` | — |
+| `rls_policy` | `public.fcs_select_carteira` | `farmer_client_scores` |
+| `rls_policy` | `public.fcs_insert_own_or_gestor` | `farmer_client_scores` |
+| `rls_policy` | `public.fcs_update_own_or_gestor` | `farmer_client_scores` |
+| `rls_policy` | `public.fcs_delete_own_or_gestor` | `farmer_client_scores` |
+| `rls_policy` | `public.cvs_select_carteira` | `customer_visit_scores` |
+| `rls_policy` | `public.cvs_insert_own_or_gestor` | `customer_visit_scores` |
+| `rls_policy` | `public.cvs_update_own_or_gestor` | `customer_visit_scores` |
+| `rls_policy` | `public.cvs_delete_own_or_gestor` | `customer_visit_scores` |
 
 ## Próximos passos quando algo der `❌`
 

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 71
+-- Total de custom migrations: 72
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -90,7 +90,8 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260525200000', 'fin_sync_watchdog', '20260525200000_fin_sync_watchdog.sql'),
   ('20260525210000', 'viewas_rpcs_for', '20260525210000_viewas_rpcs_for.sql'),
   ('20260525220000', 'viewas_access_targets', '20260525220000_viewas_access_targets.sql'),
-  ('20260525230000', 'impersonation_audit', '20260525230000_impersonation_audit.sql')
+  ('20260525230000', 'impersonation_audit', '20260525230000_impersonation_audit.sql'),
+  ('20260526020000', 'rls_score_carteira_hardening', '20260526020000_rls_score_carteira_hardening.sql')
 )
 SELECT
   e.version,
@@ -468,7 +469,16 @@ WITH expected_objects (migration, kind, schema_name, object_name, parent_name) A
   ('viewas_access_targets', 'function', 'public', 'list_impersonation_targets', ''),
   ('impersonation_audit', 'table', 'public', 'impersonation_audit', ''),
   ('impersonation_audit', 'function', 'public', 'log_impersonation_start', ''),
-  ('impersonation_audit', 'function', 'public', 'end_impersonation', '')
+  ('impersonation_audit', 'function', 'public', 'end_impersonation', ''),
+  ('rls_score_carteira_hardening', 'function', 'public', 'pode_ver_carteira_completa', ''),
+  ('rls_score_carteira_hardening', 'rls_policy', 'public', 'fcs_select_carteira', 'farmer_client_scores'),
+  ('rls_score_carteira_hardening', 'rls_policy', 'public', 'fcs_insert_own_or_gestor', 'farmer_client_scores'),
+  ('rls_score_carteira_hardening', 'rls_policy', 'public', 'fcs_update_own_or_gestor', 'farmer_client_scores'),
+  ('rls_score_carteira_hardening', 'rls_policy', 'public', 'fcs_delete_own_or_gestor', 'farmer_client_scores'),
+  ('rls_score_carteira_hardening', 'rls_policy', 'public', 'cvs_select_carteira', 'customer_visit_scores'),
+  ('rls_score_carteira_hardening', 'rls_policy', 'public', 'cvs_insert_own_or_gestor', 'customer_visit_scores'),
+  ('rls_score_carteira_hardening', 'rls_policy', 'public', 'cvs_update_own_or_gestor', 'customer_visit_scores'),
+  ('rls_score_carteira_hardening', 'rls_policy', 'public', 'cvs_delete_own_or_gestor', 'customer_visit_scores')
 )
 SELECT
   e.migration,

--- a/supabase/migrations/20260526020000_rls_score_carteira_hardening.sql
+++ b/supabase/migrations/20260526020000_rls_score_carteira_hardening.sql
@@ -1,0 +1,175 @@
+-- 20260526020000_rls_score_carteira_hardening.sql
+-- (timestamp realocado de 20260525220000 → colisão com 20260525220000_viewas_access_targets.sql na main)
+-- ============================================================
+-- Hardening de RLS nas tabelas de score de carteira.
+-- ============================================================
+-- Achado (security review 2026-05-25, confirmado por codex):
+--   farmer_client_scores tinha UMA policy FOR ALL ampla ("Staff can manage
+--   client scores": master OR employee) → QUALQUER employee lia E gerenciava
+--   (UPDATE/DELETE/roubo de posse via onConflict) os scores de TODOS os
+--   vendedores via PostgREST. O filtro por farmer_id no cliente é só display.
+--   customer_visit_scores já era farmer-scoped, mas a RLS BLOQUEAVA cobertura
+--   (useMyVisitSuggestions lê .in('farmer_id',[me,...covered]) e as linhas de
+--   covered eram barradas) e não previa gestor.
+--
+-- Fronteira de verdade = posse/cobertura por customer_user_id (não farmer_id):
+--   reusa o helper já existente carteira_visivel_para(customer_user_id, uid)
+--   = master OR dono OR cobertura ativa. Adiciona leitura de gestor comercial.
+--
+-- Decisões (validadas por codex consult):
+--   1. Split do FOR ALL: SELECT restrito + INSERT/UPDATE/DELETE por carteira.
+--      Escrita legítima é só na própria carteira (vendedor auto-scorando) +
+--      gestor + master; engines de scoring rodam via service_role (bypassa RLS).
+--   2. Helper de gestor EXIGE app_role employee (defesa contra customer com
+--      commercial_role sujo ganhar leitura global).
+--   3. Chamadas de função embrulhadas em (select ...) → initPlan, avaliadas 1x
+--      (padrão de performance de RLS no Supabase) em vez de por linha.
+--
+-- Idempotente: CREATE OR REPLACE FUNCTION + DROP POLICY IF EXISTS antes de CREATE.
+
+-- ============================================================
+-- 1. Helper: quem enxerga a carteira INTEIRA (gestor comercial ou master)
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.pode_ver_carteira_completa(_uid uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT
+    has_role(_uid, 'master'::app_role)
+    OR (
+      has_role(_uid, 'employee'::app_role)
+      AND get_commercial_role(_uid) IN (
+        'gerencial'::commercial_role,
+        'estrategico'::commercial_role,
+        'super_admin'::commercial_role
+      )
+    );
+$$;
+
+GRANT EXECUTE ON FUNCTION public.pode_ver_carteira_completa(uuid) TO authenticated;
+
+-- ============================================================
+-- 2. farmer_client_scores — remove a FOR ALL ampla, split por comando
+-- ============================================================
+ALTER TABLE public.farmer_client_scores ENABLE ROW LEVEL SECURITY;
+
+-- Remove a policy ampla (porta aberta)
+DROP POLICY IF EXISTS "Staff can manage client scores" ON public.farmer_client_scores;
+
+-- Limpa nomes novos (re-run seguro)
+DROP POLICY IF EXISTS "fcs_select_carteira"     ON public.farmer_client_scores;
+DROP POLICY IF EXISTS "fcs_insert_own_or_gestor" ON public.farmer_client_scores;
+DROP POLICY IF EXISTS "fcs_update_own_or_gestor" ON public.farmer_client_scores;
+DROP POLICY IF EXISTS "fcs_delete_own_or_gestor" ON public.farmer_client_scores;
+
+-- SELECT: gestor/master (carteira inteira) OU própria carteira + cobertura ativa
+CREATE POLICY "fcs_select_carteira" ON public.farmer_client_scores
+  FOR SELECT
+  USING (
+    (SELECT public.pode_ver_carteira_completa((SELECT auth.uid())))
+    OR public.carteira_visivel_para(customer_user_id, (SELECT auth.uid()))
+  );
+
+-- INSERT: própria carteira (farmer_id = eu) OU gestor/master
+CREATE POLICY "fcs_insert_own_or_gestor" ON public.farmer_client_scores
+  FOR INSERT
+  WITH CHECK (
+    (SELECT public.pode_ver_carteira_completa((SELECT auth.uid())))
+    OR farmer_id = (SELECT auth.uid())
+  );
+
+-- UPDATE: linha existente E nova ambas precisam ser própria carteira (impede
+-- roubo de posse: setar farmer_id pra si numa linha alheia) OU gestor/master
+CREATE POLICY "fcs_update_own_or_gestor" ON public.farmer_client_scores
+  FOR UPDATE
+  USING (
+    (SELECT public.pode_ver_carteira_completa((SELECT auth.uid())))
+    OR farmer_id = (SELECT auth.uid())
+  )
+  WITH CHECK (
+    (SELECT public.pode_ver_carteira_completa((SELECT auth.uid())))
+    OR farmer_id = (SELECT auth.uid())
+  );
+
+-- DELETE: própria carteira OU gestor/master
+CREATE POLICY "fcs_delete_own_or_gestor" ON public.farmer_client_scores
+  FOR DELETE
+  USING (
+    (SELECT public.pode_ver_carteira_completa((SELECT auth.uid())))
+    OR farmer_id = (SELECT auth.uid())
+  );
+
+-- ============================================================
+-- 3. customer_visit_scores — SELECT ganha cobertura + gestor; write por carteira
+-- ============================================================
+ALTER TABLE public.customer_visit_scores ENABLE ROW LEVEL SECURITY;
+
+-- Remove as 2 policies antigas (own-scoped, sem cobertura/gestor)
+DROP POLICY IF EXISTS "Staff can manage their visit scores" ON public.customer_visit_scores;
+DROP POLICY IF EXISTS "Staff can view their visit scores"   ON public.customer_visit_scores;
+
+-- Limpa nomes novos (re-run seguro)
+DROP POLICY IF EXISTS "cvs_select_carteira"     ON public.customer_visit_scores;
+DROP POLICY IF EXISTS "cvs_insert_own_or_gestor" ON public.customer_visit_scores;
+DROP POLICY IF EXISTS "cvs_update_own_or_gestor" ON public.customer_visit_scores;
+DROP POLICY IF EXISTS "cvs_delete_own_or_gestor" ON public.customer_visit_scores;
+
+-- SELECT: gestor/master OU própria carteira + cobertura ativa (corrige cobertura)
+CREATE POLICY "cvs_select_carteira" ON public.customer_visit_scores
+  FOR SELECT
+  USING (
+    (SELECT public.pode_ver_carteira_completa((SELECT auth.uid())))
+    OR public.carteira_visivel_para(customer_user_id, (SELECT auth.uid()))
+  );
+
+-- INSERT/UPDATE/DELETE: própria carteira OU gestor/master
+-- (sem escrita client-side hoje; só service_role escreve, que bypassa RLS)
+CREATE POLICY "cvs_insert_own_or_gestor" ON public.customer_visit_scores
+  FOR INSERT
+  WITH CHECK (
+    (SELECT public.pode_ver_carteira_completa((SELECT auth.uid())))
+    OR farmer_id = (SELECT auth.uid())
+  );
+
+CREATE POLICY "cvs_update_own_or_gestor" ON public.customer_visit_scores
+  FOR UPDATE
+  USING (
+    (SELECT public.pode_ver_carteira_completa((SELECT auth.uid())))
+    OR farmer_id = (SELECT auth.uid())
+  )
+  WITH CHECK (
+    (SELECT public.pode_ver_carteira_completa((SELECT auth.uid())))
+    OR farmer_id = (SELECT auth.uid())
+  );
+
+CREATE POLICY "cvs_delete_own_or_gestor" ON public.customer_visit_scores
+  FOR DELETE
+  USING (
+    (SELECT public.pode_ver_carteira_completa((SELECT auth.uid())))
+    OR farmer_id = (SELECT auth.uid())
+  );
+
+-- ============================================================
+-- 4. Validação
+-- ============================================================
+WITH p AS (
+  SELECT tablename, policyname, cmd
+  FROM pg_policies
+  WHERE schemaname = 'public'
+    AND tablename IN ('farmer_client_scores', 'customer_visit_scores')
+)
+SELECT
+  CASE WHEN
+        (SELECT count(*) FROM pg_proc WHERE proname = 'pode_ver_carteira_completa') = 1
+    AND NOT EXISTS (SELECT 1 FROM p WHERE cmd = 'ALL')
+    AND NOT EXISTS (SELECT 1 FROM p WHERE policyname = 'Staff can manage client scores')
+    AND NOT EXISTS (SELECT 1 FROM p WHERE policyname IN ('Staff can manage their visit scores','Staff can view their visit scores'))
+    AND (SELECT count(*) FROM p WHERE tablename='farmer_client_scores'  AND cmd='SELECT') = 1
+    AND (SELECT count(*) FROM p WHERE tablename='farmer_client_scores'  AND cmd IN ('INSERT','UPDATE','DELETE')) = 3
+    AND (SELECT count(*) FROM p WHERE tablename='customer_visit_scores' AND cmd='SELECT') = 1
+    AND (SELECT count(*) FROM p WHERE tablename='customer_visit_scores' AND cmd IN ('INSERT','UPDATE','DELETE')) = 3
+       THEN '✅ RLS endurecida: helper criado, policies amplas/FOR ALL removidas, SELECT+escrita por carteira nas 2 tabelas'
+       ELSE '❌ FALTANDO — confira o dump de pg_policies abaixo' END AS status;


### PR DESCRIPTION
## Resumo

Endurece a RLS de duas tabelas de score de carteira que vazavam dados entre vendedores.

**Furo:** `farmer_client_scores` tinha uma única policy `FOR ALL` ampla (`master OR employee`) — **qualquer vendedor (`employee`) lia E gerenciava** (UPDATE/DELETE/roubo de posse via `onConflict`) os scores de **toda a carteira de outros vendedores** via PostgREST direto. O filtro por `farmer_id` no frontend era só display, não fronteira. `customer_visit_scores` já era own-scoped, mas a RLS **bloqueava cobertura** (quebra silenciosa de `useMyVisitSuggestions` p/ carteiras cobertas) e não previa gestor.

## O que muda
- **novo helper** `pode_ver_carteira_completa(uid)` = `master OR (employee AND commercial_role IN gerencial/estrategico/super_admin)` — exige `employee` p/ evitar `customer` com `commercial_role` sujo ganhar leitura global.
- **`farmer_client_scores`**: split do `FOR ALL` → `SELECT` = gestor/master OU própria carteira+cobertura (reusa `carteira_visivel_para`); `INSERT/UPDATE/DELETE` = `farmer_id=auth.uid()` OU gestor/master.
- **`customer_visit_scores`**: `SELECT` ganha cobertura+gestor; write por carteira.
- chamadas de função embrulhadas em `(select ...)` → initPlan (perf RLS Supabase).
- `service_role` segue bypassando → engines de scoring (`calculate-scores` etc.) intactos. As RPCs view-as `_for(target)` (já na main) são `SECURITY DEFINER` → não afetadas.

Desenho passou por 2 consults do codex (split do `FOR ALL`, blast radius de gestor, write-path como risco maior).

## ⚠️ ATENÇÃO: migration manual necessária
`supabase/migrations/20260526020000_rls_score_carteira_hardening.sql`. Lovable não aplica automaticamente.

**Já aplicada e validada em produção via SQL Editor do Lovable (2026-05-25)** — a validação retornou `✅ RLS endurecida...`. Para re-verificar:

```sql
SELECT tablename, policyname, cmd FROM pg_policies
WHERE schemaname='public' AND tablename IN ('farmer_client_scores','customer_visit_scores')
ORDER BY tablename, cmd, policyname;
```
Esperado: nenhuma policy `ALL`; 1 SELECT + 3 write por tabela; helper `pode_ver_carteira_completa` existe.

## Follow-up de segurança (próximo PR)
Mesma exposição `FOR ALL master-OR-employee` confirmada em mais 5 tabelas de carteira: `farmer_recommendations`, `farmer_bundle_recommendations`, `farmer_calls`, `route_visits`, `farmer_copilot_sessions` (a `farmer_performance_scores` já está OK). Merecem o mesmo tratamento, com mapeamento de consumidores por tabela — não batchado aqui.

🤖 Generated with [Claude Code](https://claude.com/claude-code)