### PR TITLE
fix(viewas): restaura impersonação após reload de página

### DIFF
--- a/src/contexts/ImpersonationContext.tsx
+++ b/src/contexts/ImpersonationContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState, useCallback, useMemo, type ReactNode } from 'react';
+import { createContext, useContext, useState, useEffect, useCallback, useMemo, type ReactNode } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
 import { supabase } from '@/integrations/supabase/client';
 import { resolveEffectiveUserId, loadPersistedTarget, persistTarget } from '@/lib/impersonation/effective-user';
@@ -22,6 +22,18 @@ export function ImpersonationProvider({ children }: { children: ReactNode }) {
 
   const realUserId = user?.id ?? null;
   const effectiveUserId = resolveEffectiveUserId(realUserId, target);
+
+  // Hard reload: no mount o `isMaster` ainda é false (auth assíncrono), então o
+  // init do useState acima cai pra null e a impersonação se perderia. Quando o
+  // master é confirmado, restaura do sessionStorage (continuidade entre reloads).
+  // stopImpersonation limpa o sessionStorage antes deste efeito rodar, então não
+  // re-restaura após "Sair".
+  useEffect(() => {
+    if (isMaster && !target) {
+      const persisted = loadPersistedTarget();
+      if (persisted) setTarget(persisted);
+    }
+  }, [isMaster, target]);
 
   const startImpersonation = useCallback(async (t: ImpersonationTarget, reason?: string) => {
     if (!isMaster) return;


### PR DESCRIPTION
## Bug (achado no smoke test)
Ao impersonar (Ver como X) e dar **F5 / reload**, a impersonação se perdia: o banner sumia e os dados voltavam pros do master, silenciosamente.

**Causa:** o `ImpersonationProvider` inicializa `target` com `useState(() => isMaster ? loadPersistedTarget() : null)`. Num reload, `isMaster` (do `useAuth`) ainda é `false` no mount (role carrega assíncrono), então o init cai pra `null` e o `sessionStorage` nunca é lido. Navegação SPA (clique no menu) não tinha o problema — só reload de página.

**Fix:** `useEffect` que restaura do `sessionStorage` quando `isMaster` vira `true`. `stopImpersonation` limpa o `sessionStorage` antes do efeito rodar, então "Sair" não re-restaura.

Falha era *fail-safe* (revertia pro master, não pra identidade errada), mas é um wart de UX — F5 não deve dropar a sessão de QA.

## Test plan
- [x] typecheck:strict 0 · lint 0 errors · testes de impersonação (4) verdes
- [ ] Smoke: impersonar Regina → F5 → banner + dados da Regina persistem