### PR TITLE
fix(security): comparação constant-time do webhook secret em omie-nfe-webhook

### DIFF
--- a/supabase/functions/omie-nfe-webhook/index.ts
+++ b/supabase/functions/omie-nfe-webhook/index.ts
@@ -13,6 +13,13 @@ function jsonResponse(body: Record<string, unknown>, status = 200) {
   });
 }
 
+function timingSafeEq(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  return diff === 0;
+}
+
 /** Smart rounding: if qty is within 5% of nearest integer, round it */
 function smartRound(qty: number): number {
   const rounded = Math.round(qty);
@@ -27,7 +34,7 @@ Deno.serve(async (req) => {
   // Shared-secret webhook auth (Omie cannot send a JWT).
   const expectedSecret = Deno.env.get("OMIE_WEBHOOK_SECRET");
   const providedSecret = req.headers.get("x-webhook-secret");
-  if (!expectedSecret || !providedSecret || providedSecret !== expectedSecret) {
+  if (!expectedSecret || !providedSecret || !timingSafeEq(expectedSecret, providedSecret)) {
     return jsonResponse({ error: "Unauthorized" }, 401);
   }
 


### PR DESCRIPTION
## Resumo

Alinha o `omie-nfe-webhook` ao padrão de segurança já usado pelo webhook irmão `omie-webhook`:

- Adiciona a função `timingSafeEq` (comparação byte-a-byte **constant-time**), idêntica à de `supabase/functions/omie-webhook/index.ts:44-49`.
- Troca a comparação simples `providedSecret !== expectedSecret` por `!timingSafeEq(expectedSecret, providedSecret)` na validação do `x-webhook-secret` (`omie-nfe-webhook/index.ts:~37`).

Elimina o timing side-channel na validação do secret.

## Severidade: BAIXA

Side-channel sobre o secret de um webhook exposto pela internet através da edge infra é praticamente inexplorável (jitter de rede + cold starts dominam qualquer diferença de tempo de comparação). É **higiene/consistência** entre os dois webhooks irmãos, não correção de vulnerabilidade explorável.

## Validação

Edge function Deno — o CI **não** typecheck/linta `supabase/functions/` (CLAUDE.md §5). Validado manualmente:

- `deno check supabase/functions/omie-nfe-webhook/index.ts` → **4 erros**, todos pré-existentes (`TS2345` em `parseFloat`/`parseInt` sobre tipos `{}`).
- `deno check` na versão de `origin/main` → **os mesmos 4 erros**.
- ✅ Erro-set **idêntico** — a mudança não introduz nenhum erro novo.

## ⚠️ Requer redeploy manual após o merge

Edge function lida do repo só após deploy manual via chat do Lovable (CLAUDE.md §5). Após mergear:

> read `supabase/functions/omie-nfe-webhook/index.ts` from main and deploy verbatim

Sem isso, a `main` e a produção divergem (produção segue com a comparação não-constant-time).

🤖 Generated with [Claude Code](https://claude.com/claude-code)