### PR TITLE
test(dashboard): cobertura do priority-rules (card de prioridade nº1)

### DIFF
--- a/docs/superpowers/specs/2026-05-26-priority-rules-test-design.md
+++ b/docs/superpowers/specs/2026-05-26-priority-rules-test-design.md
@@ -1,0 +1,26 @@
+# Cobertura de teste do `priority-rules` (dashboard) — Design Spec
+
+> **Data:** 2026-05-26
+> **Status:** continuação autônoma. `src/lib/dashboard/priority-rules.ts` (escolhe o card de prioridade nº1 do dashboard por persona) sem teste. Lane seguro/não-colidente (arquivo de teste novo) — strict-mode está em sessão paralela; financeiro em churn. Pura → teste durável.
+
+## Goal
+
+Travar `variantFromScore` e `pickWinner` — a regra que decide o que o usuário vê primeiro no dashboard. Sem mudança de código.
+
+## Regras (do código)
+
+- **`variantFromScore(score)`** → thresholds inclusivos: `≥90` critical, `≥60` warning, `≥30` info, senão success.
+- **`pickWinner(candidates, personaZoneOrder)`** → maior `score` vence; empate desempata por **ordem da zona em `personaZoneOrder`** (índice menor vence, via `indexOf`); `[]` → `null`; não muta a entrada (`[...candidates]`).
+
+## Cenários
+
+1. `variantFromScore`: boundaries 90/89, 60/59, 30/29, 0.
+2. `pickWinner`: vazio→null; único→ele; maior score; empate→zona primeiro no order; tie-break usa a ordem da persona (não a de inserção); não muta a entrada.
+
+## Testing
+
+`src/lib/dashboard/__tests__/priority-rules.test.ts` (vitest, sem mocks). 10 casos, verde; lint limpo; sem tocar o módulo.
+
+## Out-of-scope
+
+- O `item`/`icon` do candidato (irrelevante pro algoritmo); quem monta os candidates.

--- a/src/lib/dashboard/__tests__/priority-rules.test.ts
+++ b/src/lib/dashboard/__tests__/priority-rules.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import {
+  variantFromScore,
+  pickWinner,
+  type PriorityCandidate,
+  type PriorityItem,
+} from '../priority-rules';
+import type { ZoneId } from '../persona-config';
+
+function cand(zone: ZoneId, score: number, id = zone): PriorityCandidate {
+  // pickWinner só lê .zone e .score; item é irrelevante pro algoritmo.
+  return { zone, score, item: { id } as unknown as PriorityItem };
+}
+
+describe('variantFromScore', () => {
+  it('≥90 → critical (boundary inclusive)', () => {
+    expect(variantFromScore(100)).toBe('critical');
+    expect(variantFromScore(90)).toBe('critical');
+  });
+
+  it('60-89 → warning (boundaries)', () => {
+    expect(variantFromScore(89)).toBe('warning');
+    expect(variantFromScore(60)).toBe('warning');
+  });
+
+  it('30-59 → info (boundaries)', () => {
+    expect(variantFromScore(59)).toBe('info');
+    expect(variantFromScore(30)).toBe('info');
+  });
+
+  it('<30 → success (boundaries)', () => {
+    expect(variantFromScore(29)).toBe('success');
+    expect(variantFromScore(0)).toBe('success');
+  });
+});
+
+describe('pickWinner', () => {
+  const order: ZoneId[] = ['vendas', 'estoque', 'reposicao', 'financeiro', 'tintometrico', 'sistema'];
+
+  it('lista vazia → null', () => {
+    expect(pickWinner([], order)).toBeNull();
+  });
+
+  it('único candidato → ele mesmo', () => {
+    const c = cand('estoque', 42);
+    expect(pickWinner([c], order)).toBe(c);
+  });
+
+  it('maior score vence', () => {
+    const win = cand('financeiro', 95);
+    const r = pickWinner([cand('vendas', 50), win, cand('estoque', 70)], order);
+    expect(r).toBe(win);
+  });
+
+  it('empate no score → zona que aparece primeiro no zoneOrder da persona vence', () => {
+    // ambos score 80; 'estoque' (idx 1) vence 'financeiro' (idx 3)
+    const r = pickWinner([cand('financeiro', 80), cand('estoque', 80)], order);
+    expect(r?.zone).toBe('estoque');
+  });
+
+  it('tie-break respeita a ordem da persona (não a ordem de inserção)', () => {
+    // ordem custom: reposicao antes de vendas
+    const custom: ZoneId[] = ['reposicao', 'vendas'];
+    const r = pickWinner([cand('vendas', 80), cand('reposicao', 80)], custom);
+    expect(r?.zone).toBe('reposicao');
+  });
+
+  it('não muta o array de entrada', () => {
+    const input = [cand('vendas', 50), cand('financeiro', 95)];
+    const snapshot = input.map((c) => c.zone);
+    pickWinner(input, order);
+    expect(input.map((c) => c.zone)).toEqual(snapshot);
+  });
+});


### PR DESCRIPTION
## Resumo
Cobertura de teste **aditiva** (test-only) para `src/lib/dashboard/priority-rules.ts`, sem teste até agora. É a regra que decide qual card de prioridade aparece **primeiro** no dashboard por persona.

Trava:
- `variantFromScore` — thresholds inclusivos (≥90 critical, ≥60 warning, ≥30 info, else success), com boundaries
- `pickWinner` — maior score vence; empate desempata pela **ordem da zona em `personaZoneOrder`** (não a de inserção); `[]` → `null`; **não muta** a entrada

10 casos, sem mocks (funções puras).

## Sem mudança de código
`priority-rules.ts` não foi tocado. Só o teste + a spec. Lane não-colidente (arquivo novo) — escolhido porque strict-mode está em sessão paralela (`docs/strict-hooks-leaf-bookkeeping`) e financeiro em churn.

## Test plan
- [x] `bun run test -- src/lib/dashboard/__tests__/priority-rules.test.ts` → 10/10 verde
- [x] `eslint` → exit 0
- [ ] CI `validate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)