### PR TITLE
fix(fin): reduz órfãs de sync_movimentacoes (budget 130→100s + metadata morto)

### DIFF
--- a/supabase/functions/omie-financeiro/index.ts
+++ b/supabase/functions/omie-financeiro/index.ts
@@ -305,7 +305,7 @@ interface MovimentoRow {
   conciliado: boolean;
   omie_codigo_lancamento: number | null;
   natureza: string | null;
-  metadata: { detalhes: OmieMovimentoDetalhes; resumo: OmieMovimentoResumo };
+  metadata: null; // antes {detalhes, resumo} bruto; agora não persistido (peso morto)
   updated_at: string;
 }
 
@@ -345,7 +345,13 @@ async function setAuditOrigem(
 let apiCallCount = 0;
 let rateLimitHits = 0;
 let globalStartTime = Date.now();
-const TIME_BUDGET_MS = 130_000; // stop before 150s edge function timeout
+// 100s (não 130s): folga real antes do kill DURO de 150s da edge fn. Como o
+// budget é checado no TOPO de cada página, um callOmie/upsert lento começando
+// perto do teto pode overshootar os 150s e a plataforma mata a função
+// mid-página → linha fin_sync_log órfã em 'running' (medido: mov p95 129s/max
+// 131s raspava os 130s antigos). Todos os syncs que usam isto têm cursor de
+// continuação + cron */10, então mais ciclos é trade aceitável por zero órfã.
+const TIME_BUDGET_MS = 100_000;
 
 function isTimeBudgetExhausted(): boolean {
   return Date.now() - globalStartTime >= TIME_BUDGET_MS;
@@ -951,10 +957,11 @@ async function syncMovimentacoes(
           conciliado: false,
           omie_codigo_lancamento: codigoLancamento > 0 ? codigoLancamento : null,
           natureza: detalhes.cOrigem || null,
-          metadata: {
-            detalhes,
-            resumo,
-          },
+          // metadata era {detalhes, resumo} = payload Omie BRUTO (85% da linha,
+          // ~1KB) que NINGUÉM lê (todos os campos úteis já estão normalizados
+          // acima). Peso morto que engordava o upsert por página. Null daqui pra
+          // frente; sem backfill (~8MB nas ~8k linhas antigas é irrelevante).
+          metadata: null,
           updated_at: new Date().toISOString(),
         };
       })


### PR DESCRIPTION
## Resumo

Ataca a **causa-raiz** das 17 órfãs `running`/dia (quase todas `sync_movimentacoes`) que o watchdog iteração 2 ([#330](https://github.com/LucasSardenbergL/afiacao/pull/330)) passou a **detectar**. Validado por diagnóstico read-only em produção + 3 consultas codex.

**Diagnóstico:** `sync_movimentacoes` completo tem **p95 129s / max 131s** vs `TIME_BUDGET_MS=130s` e kill **duro** de 150s da edge fn. As passes raspavam o budget e às vezes passavam dos 150s **antes** de cortar + gravar cursor + `completeSync` → linha órfã em `running`. O `metadata` (payload Omie bruto) é **85% da linha** (~1KB) mas **ninguém lê** — peso morto.

## O que muda (edge fn `omie-financeiro`)

- **`TIME_BUDGET_MS` 130_000 → 100_000**: 50s de folga antes do kill de 150s. Global (CP/CR/mov), mas seguro — os 3 têm **cursor de continuação** + cron `*/10` que drena pendentes. Trade: mais ciclos por **zero órfã**.
- **`syncMovimentacoes`: `metadata` `{detalhes, resumo}` → `null`**. Confirmado por grep que ninguém lê (`FinanceiroConciliacao`/`financeiroService` só usam campos já normalizados em colunas próprias). Upsert por página mais leve. Sem backfill (~8MB nas ~8k linhas antigas é irrelevante). Tipo `MovimentoRow.metadata` ajustado.

CP/CR **não** mexidos (linhas já ~190 bytes, metadata pequena/específica).

## ⚠️ Requer redeploy do `omie-financeiro`

Sem migration / sem SQL pra colar. Após mergear, redeploy via chat do Lovable (lê do repo/main).

## Testes
- `deno check`: 10 erros pré-existentes (debug_raw, `result[co]` unknown), **0 introduzidos**.
- Validar pós-deploy: órfãs/dia → ~0, páginas/run, tempo até completar cursor (ressalva codex: se 1 página Omie+upsert > 100s ainda pode morrer → próximo lever seria `nRegPorPagina` menor só pra mov; improvável).

🤖 Generated with [Claude Code](https://claude.com/claude-code)