### PR TITLE
test(utils): cobertura do shareOrderViaWhatsApp (mensagem + URL wa.me)

### DIFF
--- a/docs/superpowers/specs/2026-05-26-whatsapp-share-test-design.md
+++ b/docs/superpowers/specs/2026-05-26-whatsapp-share-test-design.md
@@ -1,0 +1,30 @@
+# Cobertura de teste do `shareOrderViaWhatsApp` — Design Spec
+
+> **Data:** 2026-05-26
+> **Status:** continuação autônoma (lane seguro/não-colidente — arquivo de teste novo). `src/utils/whatsappShare.ts` (compartilha pedido via WhatsApp) sem teste. Customer-facing: mensagem/URL errada = comunicação errada com o cliente.
+
+## Goal
+
+Travar a montagem da mensagem + a URL `wa.me` que abre no WhatsApp. Sem mudança de código.
+
+## Regras (do código)
+
+- Monta `msg` com: header `*Pedido Colacor*`, `Cliente: <nome>`, linha de `Pedido(s): a + b` **só** se `orderNumbers` não-vazio, lista de itens (`• {qtd}x {desc}{ (Cor: id — nome) se tintCorId} - {qtd×preço em BRL}`), `*Total: {BRL}*`, `Data: {dd/mm/aaaa hh:mm pt-BR}`.
+- Abre `window.open('https://wa.me/?text=' + encodeURIComponent(msg), '_blank')`. Não retorna nada (efeito colateral).
+
+## Cenários
+
+1. Abre `wa.me/?text=` em `_blank`; mensagem contém header + cliente + `Data:`.
+2. Item: `• qtd x desc` + BRL de `qtd×preço` + `*Total:`.
+3. `tintCorId` presente → inclui `Cor: <id>` + nome.
+4. Sem `tintCorId` → sem `Cor:`.
+5. `orderNumbers` → `Pedido(s): a + b`; vazio → sem a linha.
+6. Múltiplos itens → múltiplas linhas.
+
+## Testing
+
+`src/utils/__tests__/whatsappShare.test.ts` (vitest; `vi.spyOn(window,'open')`, decodifica o `text=`). Asserts por `toContain` (evita NBSP do BRL e fragilidade de TZ na data — só checa o ano). 7 casos, verde; lint limpo; sem tocar o módulo.
+
+## Out-of-scope
+
+- Formatação exata da data (ICU/TZ-dependente); o comportamento real do WhatsApp.

--- a/src/utils/__tests__/whatsappShare.test.ts
+++ b/src/utils/__tests__/whatsappShare.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { shareOrderViaWhatsApp } from '../whatsappShare';
+
+let openSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+});
+afterEach(() => {
+  openSpy.mockRestore();
+});
+
+/** Extrai e decodifica o `text=` da URL passada pro window.open. */
+function decodedMessage(): string {
+  expect(openSpy).toHaveBeenCalledTimes(1);
+  const [url, target] = openSpy.mock.calls[0];
+  expect(String(url)).toMatch(/^https:\/\/wa\.me\/\?text=/);
+  expect(target).toBe('_blank');
+  const text = String(url).replace('https://wa.me/?text=', '');
+  return decodeURIComponent(text);
+}
+
+const fixedDate = new Date(2026, 4, 15, 9, 30); // 15/05/2026 09:30 (TZ local — só checamos o ano)
+
+describe('shareOrderViaWhatsApp', () => {
+  it('abre wa.me/?text= num _blank com a mensagem codificada', () => {
+    shareOrderViaWhatsApp({
+      customerName: 'ACME LTDA',
+      items: [{ description: 'Lixa', quantity: 2, unitPrice: 10 }],
+      total: 20,
+      date: fixedDate,
+    });
+    const msg = decodedMessage();
+    expect(msg).toContain('*Pedido Colacor*');
+    expect(msg).toContain('Cliente: ACME LTDA');
+    expect(msg).toContain('Data:');
+    expect(msg).toContain('2026');
+  });
+
+  it('formata cada item: • qtd x descrição - total em BRL (qtd × preço)', () => {
+    shareOrderViaWhatsApp({
+      customerName: 'X',
+      items: [{ description: 'Disco', quantity: 3, unitPrice: 50 }],
+      total: 150,
+      date: fixedDate,
+    });
+    const msg = decodedMessage();
+    expect(msg).toContain('• 3x Disco');
+    expect(msg).toContain('R$'); // moeda
+    expect(msg).toContain('150,00'); // 3 × 50
+    expect(msg).toContain('*Total:');
+  });
+
+  it('inclui a cor da tinta quando tintCorId está presente', () => {
+    shareOrderViaWhatsApp({
+      customerName: 'X',
+      items: [{ description: 'Base', quantity: 1, unitPrice: 100, tintCorId: 'COR123', tintNomeCor: 'Azul Profundo' }],
+      total: 100,
+      date: fixedDate,
+    });
+    const msg = decodedMessage();
+    expect(msg).toContain('Cor: COR123');
+    expect(msg).toContain('Azul Profundo');
+  });
+
+  it('omite a cor quando não há tintCorId', () => {
+    shareOrderViaWhatsApp({
+      customerName: 'X',
+      items: [{ description: 'Base', quantity: 1, unitPrice: 100 }],
+      total: 100,
+      date: fixedDate,
+    });
+    expect(decodedMessage()).not.toContain('Cor:');
+  });
+
+  it('lista os números de pedido quando fornecidos (juntos por " + ")', () => {
+    shareOrderViaWhatsApp({
+      customerName: 'X',
+      items: [{ description: 'A', quantity: 1, unitPrice: 1 }],
+      total: 1,
+      orderNumbers: ['PV 100', 'PV 200'],
+      date: fixedDate,
+    });
+    expect(decodedMessage()).toContain('Pedido(s): PV 100 + PV 200');
+  });
+
+  it('omite a linha de pedido quando orderNumbers está vazio', () => {
+    shareOrderViaWhatsApp({
+      customerName: 'X',
+      items: [{ description: 'A', quantity: 1, unitPrice: 1 }],
+      total: 1,
+      date: fixedDate,
+    });
+    expect(decodedMessage()).not.toContain('Pedido(s):');
+  });
+
+  it('múltiplos itens viram múltiplas linhas', () => {
+    shareOrderViaWhatsApp({
+      customerName: 'X',
+      items: [
+        { description: 'A', quantity: 1, unitPrice: 1 },
+        { description: 'B', quantity: 2, unitPrice: 2 },
+      ],
+      total: 5,
+      date: fixedDate,
+    });
+    const msg = decodedMessage();
+    expect(msg).toContain('• 1x A');
+    expect(msg).toContain('• 2x B');
+  });
+});


### PR DESCRIPTION
## Resumo
Cobertura de teste **aditiva** (test-only) para `src/utils/whatsappShare.ts`, sem teste até agora. Customer-facing: mensagem/URL errada = comunicação errada com o cliente.

Trava:
- URL `https://wa.me/?text=<encoded>` aberta em `_blank`
- Mensagem: header `*Pedido Colacor*`, cliente, `Pedido(s):` (só quando há orderNumbers), itens (`• qtd x desc` + cor da tinta opcional + BRL de qtd×preço), `*Total:*`, `Data:`
- Cor da tinta incluída só quando `tintCorId` presente; múltiplos itens → múltiplas linhas

7 casos. `vi.spyOn(window,'open')` + decodifica o `text=`; asserts por `toContain` (evita NBSP do BRL e fragilidade de TZ na data).

## Sem mudança de código
`whatsappShare.ts` não foi tocado. Só o teste + a spec. Lane não-colidente (arquivo novo).

## Test plan
- [x] `bun run test -- src/utils/__tests__/whatsappShare.test.ts` → 7/7 verde
- [x] `eslint` → exit 0
- [ ] CI `validate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)