### PR TITLE
feat(carteira): instrumenta superfícies da carteira com analytics (bake mensurável)

### DIFF
--- a/src/components/carteira/CarteiraSaudePanel.tsx
+++ b/src/components/carteira/CarteiraSaudePanel.tsx
@@ -1,7 +1,9 @@
+import { useEffect, useRef } from 'react';
 import { Card, CardHeader, CardTitle } from '@/components/ui/card';
 import { Loader2 } from 'lucide-react';
 import { useCarteiraSaude } from '@/hooks/useCarteiraSaude';
 import { statusCron, statusSync, statusCoverage, nivelAgregado } from '@/lib/carteira-saude/status';
+import { track } from '@/lib/analytics';
 import type { SaudeNivel } from '@/lib/carteira-saude/types';
 
 const DOT: Record<SaudeNivel, string> = {
@@ -29,6 +31,18 @@ function Row({ nivel, label, detail, acao }: { nivel: SaudeNivel; label: string;
 
 export function CarteiraSaudePanel() {
   const { data, isLoading } = useCarteiraSaude();
+
+  const tracked = useRef(false);
+  useEffect(() => {
+    if (!data || tracked.current) return;
+    tracked.current = true;
+    const niveis = [
+      ...data.crons.map((c) => statusCron(c, c.jobname === MENSAL ? null : NIGHTLY_MAX_AGE).nivel),
+      statusSync(data.sync).nivel,
+      statusCoverage(data.score_coverage).nivel,
+    ];
+    track('carteira.saude_vista', { nivel: nivelAgregado(niveis) });
+  }, [data]);
 
   if (isLoading) {
     return (

--- a/src/components/farmer/ClientesAPositivarCard.tsx
+++ b/src/components/farmer/ClientesAPositivarCard.tsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom';
 import { Card, CardHeader } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
+import { track } from '@/lib/analytics';
 import type { ClienteAPositivar } from '@/lib/positivacao/types';
 
 export function ClientesAPositivarCard({ clientes }: { clientes: ClienteAPositivar[] }) {
@@ -24,6 +25,10 @@ export function ClientesAPositivarCard({ clientes }: { clientes: ClienteAPositiv
           <Link
             key={c.customer_user_id}
             to={`/admin/customers/${c.customer_user_id}/360`}
+            onClick={() => track('carteira.a_positivar_cliente_aberto', {
+              dias_sem_comprar: c.days_since_last_purchase,
+              churn_alto: (c.churn_risk ?? 0) >= 60,
+            })}
             className="p-3 flex items-center justify-between gap-3 hover:bg-muted/30"
           >
             <div className="min-w-0">

--- a/src/components/farmer/MixGapCard.tsx
+++ b/src/components/farmer/MixGapCard.tsx
@@ -1,11 +1,21 @@
+import { useEffect, useRef } from 'react';
 import { Link } from 'react-router-dom';
 import { Card, CardHeader } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { useMyMixGap } from '@/hooks/useMyMixGap';
 import { buildPorQue } from '@/lib/mixgap/format';
+import { track } from '@/lib/analytics';
 
 export function MixGapCard() {
   const { data } = useMyMixGap();
+  const totalComGap = data?.totalComGap ?? 0;
+  const tracked = useRef(false);
+  useEffect(() => {
+    if (totalComGap > 0 && !tracked.current) {
+      tracked.current = true;
+      track('carteira.mixgap_visto', { total_com_gap: totalComGap });
+    }
+  }, [totalComGap]);
   if (!data || data.totalComGap === 0) return null;
   return (
     <Card>
@@ -20,6 +30,7 @@ export function MixGapCard() {
           <Link
             key={g.customer_user_id}
             to={`/admin/customers/${g.customer_user_id}/360`}
+            onClick={() => track('carteira.mixgap_cliente_aberto', { familia: g.familia_faltante })}
             className="p-3 flex items-center justify-between gap-3 hover:bg-muted/30"
           >
             <div className="min-w-0">

--- a/src/components/farmer/PositivacaoHero.tsx
+++ b/src/components/farmer/PositivacaoHero.tsx
@@ -1,4 +1,6 @@
+import { useEffect, useRef } from 'react';
 import { Card } from '@/components/ui/card';
+import { track } from '@/lib/analytics';
 import type { PositivacaoKpis } from '@/hooks/useMyPositivacao';
 
 function KpiCard({ label, value, sub }: { label: string; value: string; sub?: string }) {
@@ -12,6 +14,19 @@ function KpiCard({ label, value, sub }: { label: string; value: string; sub?: st
 }
 
 export function PositivacaoHero({ kpis, isHunter }: { kpis: PositivacaoKpis; isHunter: boolean }) {
+  const tracked = useRef(false);
+  useEffect(() => {
+    if (tracked.current) return;
+    tracked.current = true;
+    track('carteira.positivacao_vista', {
+      pct: kpis.pctPositivacao,
+      positivados: kpis.positivados,
+      total_eligible: kpis.totalEligible,
+      a_positivar: kpis.aPositivar.length,
+      is_hunter: isHunter,
+    });
+  }, [kpis, isHunter]);
+
   const ticket = `R$ ${kpis.ticketMedio.toLocaleString('pt-BR', { maximumFractionDigits: 0 })}`;
   return (
     <div className="space-y-3">

--- a/src/contexts/ImpersonationContext.tsx
+++ b/src/contexts/ImpersonationContext.tsx
@@ -2,6 +2,7 @@ import { createContext, useContext, useState, useEffect, useCallback, useMemo, t
 import { useAuth } from '@/contexts/AuthContext';
 import { supabase } from '@/integrations/supabase/client';
 import { resolveEffectiveUserId, loadPersistedTarget, persistTarget } from '@/lib/impersonation/effective-user';
+import { track } from '@/lib/analytics';
 import type { ImpersonationTarget } from '@/lib/impersonation/types';
 
 interface ImpersonationContextType {
@@ -43,6 +44,7 @@ export function ImpersonationProvider({ children }: { children: ReactNode }) {
     setAuditId(typeof data === 'string' ? data : null);
     setTarget(t);
     persistTarget(t);
+    track('carteira.ver_como_iniciado', { grupo: t.grupo });
   }, [isMaster]);
 
   const stopImpersonation = useCallback(async () => {


### PR DESCRIPTION
## Por quê
Subimos muita superfície de carteira nesta sessão (positivação, Mix/Gap, saúde, "Ver como") mas **não sabemos se algum vendedor usa**. Isto torna o **bake mensurável** — em vez de torcer, medir. **Decisão Claude + Codex** (ambos: "bake, mas instrumente o bake").

## O que
6 eventos PostHog via `track()` (convenção `carteira.<ação>` do §2), **todos PII-safe** (contagens, bools, enums — nunca nome/telefone/id/CPF):
- `carteira.positivacao_vista` `{pct, positivados, total_eligible, a_positivar, is_hunter}` (PositivacaoHero)
- `carteira.mixgap_visto` `{total_com_gap}` + `carteira.mixgap_cliente_aberto` `{familia}` (MixGapCard)
- `carteira.a_positivar_cliente_aberto` `{dias_sem_comprar, churn_alto}` (ClientesAPositivarCard)
- `carteira.saude_vista` `{nivel}` (CarteiraSaudePanel)
- `carteira.ver_como_iniciado` `{grupo}` (ImpersonationContext)

`familia`=categoria de produto, `grupo`=farmer/hunter/closer, `nivel`=verde/amarelo/vermelho — nada identifica cliente.

## Rollout
**Sem migration, sem edge function.** Só front-end → deploy normal pelo Lovable. Depois: criar um dashboard no PostHog ("Adoção Carteira") com esses eventos pra ler o bake.

## Test plan
- [x] typecheck:strict 0 · lint 0 errors · build OK · testes de carteira (14) verdes
- [ ] Pós-deploy: confirmar que os eventos chegam no PostHog (abrir FarmerCalls → ver os eventos no Live)