### PR TITLE
test(lib): cobertura do agruparPorMes (agrupamento mensal)

### DIFF
--- a/docs/superpowers/specs/2026-05-26-agrupar-por-mes-test-design.md
+++ b/docs/superpowers/specs/2026-05-26-agrupar-por-mes-test-design.md
@@ -1,0 +1,31 @@
+# Cobertura de teste do `agruparPorMes` — Design Spec
+
+> **Data:** 2026-05-26
+> **Status:** continuação autônoma (lane seguro/não-colidente). `src/lib/agruparPorMes.ts` (agrupa registros por mês com headers e meses vazios — usado em `/admin/reposicao/{promocoes,aumentos}`) sem teste. Pura/determinística (com `new Date` fixado). 
+
+## Goal
+
+Travar as 6 funções de agrupamento mensal. Sem mudança de código.
+
+## Regras (do código)
+
+- **`chaveMes`** → `YYYY-MM` de ISO; null/sem-mês → `null`.
+- **`formatarMesAno`** → `"Abril 2026"`; mês fora de 1-12/inválido → devolve a chave crua.
+- **`chaveMesAtual`** → `YYYY-MM` do mês corrente (`new Date`).
+- **`gerarRangeMeses(antiga, recente)`** → todas as chaves no intervalo inclusivo, **do mais recente p/ o mais antigo**; vira de ano; `recente < antiga` → `[]`; chave inválida → `[]`; cap de 600.
+- **`agruparPorMes(itens, pegarData)`** → agrupa por mês; padding de meses vazios **do item mais antigo** até `max(item mais recente, mês atual)`; ordenado recente→antigo; item sem data ignorado; lista vazia → `[]`.
+- **`chavesUltimosNMeses(n)`** → `Set` dos N meses mais recentes (`new Date`), vira de ano.
+
+## Cenários-chave
+
+- `chaveMes`/`formatarMesAno`: extração + boundaries + inválidos.
+- `gerarRangeMeses`: mesmo mês, intervalo, virada de ano, recente<antiga→[], inválido→[].
+- Com `vi.setSystemTime(15/05/2026)`: `chaveMesAtual`→`2026-05`; `chavesUltimosNMeses(3/6)`; `agruparPorMes` (vazio, padding de meses vazios incluindo mês atual, extensão a item futuro com old+futuro, **único item futuro NÃO pada até o atual** — o range parte do item mais antigo).
+
+## Testing
+
+`src/lib/__tests__/agruparPorMes.test.ts` (vitest; `vi.useFakeTimers`/`setSystemTime` p/ as date-dependentes). 17 casos, verde; lint limpo; sem tocar o módulo.
+
+## Out-of-scope
+
+- As páginas que consomem; o cap de 600 (safeguard improvável).

--- a/src/lib/__tests__/agruparPorMes.test.ts
+++ b/src/lib/__tests__/agruparPorMes.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  chaveMes,
+  formatarMesAno,
+  chaveMesAtual,
+  gerarRangeMeses,
+  agruparPorMes,
+  chavesUltimosNMeses,
+} from '../agruparPorMes';
+
+// Fixa "hoje" em 15/05/2026 (local) para as funções que usam new Date().
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date(2026, 4, 15, 12, 0, 0));
+});
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('chaveMes', () => {
+  it('extrai YYYY-MM de data ISO (curta ou completa)', () => {
+    expect(chaveMes('2026-04-15')).toBe('2026-04');
+    expect(chaveMes('2026-04-15T10:30:00Z')).toBe('2026-04');
+  });
+
+  it('null/undefined/vazio/sem mês → null', () => {
+    expect(chaveMes(null)).toBeNull();
+    expect(chaveMes(undefined)).toBeNull();
+    expect(chaveMes('')).toBeNull();
+    expect(chaveMes('2026')).toBeNull();
+    expect(chaveMes('lixo')).toBeNull();
+  });
+});
+
+describe('formatarMesAno', () => {
+  it('YYYY-MM → "Mês Ano" em pt-BR', () => {
+    expect(formatarMesAno('2026-01')).toBe('Janeiro 2026');
+    expect(formatarMesAno('2026-04')).toBe('Abril 2026');
+    expect(formatarMesAno('2026-12')).toBe('Dezembro 2026');
+  });
+
+  it('mês fora de 1-12 ou inválido → devolve a chave crua', () => {
+    expect(formatarMesAno('2026-13')).toBe('2026-13');
+    expect(formatarMesAno('2026-00')).toBe('2026-00');
+    expect(formatarMesAno('abc')).toBe('abc');
+  });
+});
+
+describe('chaveMesAtual', () => {
+  it('retorna o mês corrente (com new Date fixado)', () => {
+    expect(chaveMesAtual()).toBe('2026-05');
+  });
+});
+
+describe('gerarRangeMeses', () => {
+  it('mesmo mês → uma chave', () => {
+    expect(gerarRangeMeses('2026-04', '2026-04')).toEqual(['2026-04']);
+  });
+
+  it('intervalo no mesmo ano, ordenado do mais recente p/ o mais antigo', () => {
+    expect(gerarRangeMeses('2026-01', '2026-03')).toEqual(['2026-03', '2026-02', '2026-01']);
+  });
+
+  it('atravessa a virada de ano', () => {
+    expect(gerarRangeMeses('2025-11', '2026-02')).toEqual(['2026-02', '2026-01', '2025-12', '2025-11']);
+  });
+
+  it('recente anterior ao antigo → vazio', () => {
+    expect(gerarRangeMeses('2026-05', '2026-03')).toEqual([]);
+  });
+
+  it('chave inválida → vazio', () => {
+    expect(gerarRangeMeses('', '')).toEqual([]);
+    expect(gerarRangeMeses('2026-04', 'xx')).toEqual([]);
+  });
+});
+
+describe('chavesUltimosNMeses', () => {
+  it('retorna o conjunto dos N meses mais recentes (com new Date fixado)', () => {
+    expect(chavesUltimosNMeses(3)).toEqual(new Set(['2026-05', '2026-04', '2026-03']));
+  });
+
+  it('atravessa a virada de ano para trás', () => {
+    expect(chavesUltimosNMeses(6)).toEqual(
+      new Set(['2026-05', '2026-04', '2026-03', '2026-02', '2026-01', '2025-12']),
+    );
+  });
+});
+
+describe('agruparPorMes', () => {
+  type Reg = { quando: string | null };
+  const pegar = (r: Reg) => r.quando;
+
+  it('lista vazia → []', () => {
+    expect(agruparPorMes([], pegar)).toEqual([]);
+  });
+
+  it('agrupa por mês e preenche meses vazios entre o mais antigo e o mês atual', () => {
+    const itens: Reg[] = [{ quando: '2026-03-10' }, { quando: '2026-05-02' }, { quando: '2026-05-20' }];
+    const grupos = agruparPorMes(itens, pegar);
+    expect(grupos.map((g) => g.chave)).toEqual(['2026-05', '2026-04', '2026-03']);
+    expect(grupos[0]).toMatchObject({ chave: '2026-05', label: 'Maio 2026', vazio: false });
+    expect(grupos[0].itens).toHaveLength(2);
+    expect(grupos[1]).toMatchObject({ chave: '2026-04', vazio: true });
+    expect(grupos[1].itens).toEqual([]);
+    expect(grupos[2]).toMatchObject({ chave: '2026-03', vazio: false });
+  });
+
+  it('estende o range até um item futuro, preenchendo os meses vazios (inclui o mês atual)', () => {
+    // item mais antigo 2026-03, item futuro 2026-07, "hoje" 2026-05
+    const grupos = agruparPorMes([{ quando: '2026-03-01' }, { quando: '2026-07-01' }], pegar);
+    expect(grupos.map((g) => g.chave)).toEqual(['2026-07', '2026-06', '2026-05', '2026-04', '2026-03']);
+    expect(grupos[0]).toMatchObject({ chave: '2026-07', vazio: false });
+    expect(grupos.find((g) => g.chave === '2026-05')).toMatchObject({ vazio: true }); // mês atual, sem item
+  });
+
+  it('um único item futuro NÃO faz padding até o mês atual (range = só o item)', () => {
+    const grupos = agruparPorMes([{ quando: '2026-07-01' }], pegar);
+    expect(grupos.map((g) => g.chave)).toEqual(['2026-07']);
+  });
+
+  it('ignora itens sem data válida', () => {
+    const grupos = agruparPorMes([{ quando: null }, { quando: 'lixo' }], pegar);
+    expect(grupos).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Resumo
Cobertura de teste **aditiva** (test-only) para `src/lib/agruparPorMes.ts` (agrupamento mensal com headers + meses vazios, usado em `/admin/reposicao/{promocoes,aumentos}`), sem teste até agora.

Trava as 6 funções:
- `chaveMes` (YYYY-MM de ISO; sem mês → null) · `formatarMesAno` ("Abril 2026"; mês inválido → chave crua)
- `gerarRangeMeses` — intervalo inclusivo recente→antigo, **virada de ano**, `recente<antiga`→`[]`, inválido→`[]`
- `agruparPorMes` — padding de meses vazios **do item mais antigo** até `max(recente, mês atual)`; item sem data ignorado; **único item futuro NÃO pada até o atual** (comportamento real do range)
- `chaveMesAtual` / `chavesUltimosNMeses` — com `vi.setSystemTime`

17 casos. Date-dependentes determinísticas via `vi.useFakeTimers`/`setSystemTime(15/05/2026)`.

## Sem mudança de código
`agruparPorMes.ts` não foi tocado. Só o teste + a spec. Lane não-colidente (arquivo novo).

## Test plan
- [x] `bun run test -- src/lib/__tests__/agruparPorMes.test.ts` → 17/17 verde
- [x] `eslint` → exit 0
- [ ] CI `validate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)