### PR TITLE
test(call-log): cobertura do recording-policy (guard LGPD)

### DIFF
--- a/docs/superpowers/specs/2026-05-26-recording-policy-test-design.md
+++ b/docs/superpowers/specs/2026-05-26-recording-policy-test-design.md
@@ -1,0 +1,31 @@
+# Cobertura de teste do `recording-policy` (LGPD) — Design Spec
+
+> **Data:** 2026-05-26
+> **Status:** continuação autônoma (lane seguro/não-colidente; strict ocupado por sessão paralela, financeiro em churn). `src/lib/call-log/recording-policy.ts` decide se uma ligação é **auto-gravada + toca o aviso de consentimento (LGPD)** — sem teste. Ângulo legal/privacidade → vale travar.
+
+## Goal
+
+Travar a decisão de auto-gravação e a resolução de quem-está-na-linha. Sem mudança de código.
+
+## Regras (do código)
+
+- **`shouldAutoRecord(kind)`** → `true` para `cliente`/`fornecedor`; `false` para `desconhecido` (não grava número não-cadastrado).
+- **`resolveCallParty(rawPhone)`** (async) → delega a `resolveCustomerByPhone`. Com match → `{ kind:'cliente', customerUserId, contactName, contactCargo, matchConfidence:'last8', phoneNormalized }`. Sem match → `{ kind:'desconhecido', customerUserId:null, matchConfidence:'none', phoneNormalized }`. Sempre preserva o telefone normalizado.
+
+## Cenários
+
+1. `shouldAutoRecord`: cliente/fornecedor → true; **desconhecido → false** (guard LGPD).
+2. `resolveCallParty`: cadastrado → cliente + mapeia contato + `last8`; sem match → desconhecido + null + `none`, preservando o telefone.
+3. Encadeamento: `shouldAutoRecord(resolveCallParty(...).kind)` — cadastrado grava, desconhecido não.
+
+## Mock
+
+- `vi.mock('@/lib/call-session/resolve-customer')` → `resolveCustomerByPhone` controlado (DB-backed; isola a política do lookup).
+
+## Testing
+
+`src/lib/call-log/__tests__/recording-policy.test.ts` (vitest). 5 casos, verde; lint limpo; sem tocar o módulo.
+
+## Out-of-scope
+
+- O lookup real (`resolveCustomerByPhone`, mockado); o ramo `fornecedor` dormente (sem fonte de telefone hoje — `shouldAutoRecord` já o trata).

--- a/src/lib/call-log/__tests__/recording-policy.test.ts
+++ b/src/lib/call-log/__tests__/recording-policy.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/lib/call-session/resolve-customer', () => ({
+  resolveCustomerByPhone: vi.fn(),
+}));
+
+import { shouldAutoRecord, resolveCallParty } from '../recording-policy';
+import { resolveCustomerByPhone } from '@/lib/call-session/resolve-customer';
+
+const mockResolve = vi.mocked(resolveCustomerByPhone);
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('shouldAutoRecord (guard LGPD)', () => {
+  it('cliente e fornecedor → auto-grava (toca o aviso de consentimento)', () => {
+    expect(shouldAutoRecord('cliente')).toBe(true);
+    expect(shouldAutoRecord('fornecedor')).toBe(true);
+  });
+
+  it('desconhecido → NÃO auto-grava (não grava número não-cadastrado)', () => {
+    expect(shouldAutoRecord('desconhecido')).toBe(false);
+  });
+});
+
+describe('resolveCallParty', () => {
+  it('número cadastrado → cliente, mapeia contato, matchConfidence last8', async () => {
+    mockResolve.mockResolvedValue({
+      customerUserId: 'user-1',
+      phoneDialed: '37999998888',
+      contactName: 'João',
+      contactCargo: 'Comprador',
+    });
+    const r = await resolveCallParty('(37) 99999-8888');
+    expect(r).toEqual({
+      kind: 'cliente',
+      customerUserId: 'user-1',
+      contactName: 'João',
+      contactCargo: 'Comprador',
+      matchConfidence: 'last8',
+      phoneNormalized: '37999998888',
+    });
+  });
+
+  it('sem match → desconhecido, sem userId, matchConfidence none, mas preserva o telefone', async () => {
+    mockResolve.mockResolvedValue({ customerUserId: null, phoneDialed: '37999998888' });
+    const r = await resolveCallParty('(37) 99999-8888');
+    expect(r).toEqual({
+      kind: 'desconhecido',
+      customerUserId: null,
+      matchConfidence: 'none',
+      phoneNormalized: '37999998888',
+    });
+  });
+
+  it('encadeia com shouldAutoRecord: cadastrado grava, desconhecido não', async () => {
+    mockResolve.mockResolvedValueOnce({ customerUserId: 'u1', phoneDialed: '111' });
+    const cliente = await resolveCallParty('111');
+    expect(shouldAutoRecord(cliente.kind)).toBe(true);
+
+    mockResolve.mockResolvedValueOnce({ customerUserId: null, phoneDialed: '222' });
+    const desconhecido = await resolveCallParty('222');
+    expect(shouldAutoRecord(desconhecido.kind)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Resumo
Cobertura de teste **aditiva** (test-only) para `src/lib/call-log/recording-policy.ts` — decide se uma ligação é **auto-gravada + toca o aviso de consentimento (LGPD)**. Sem teste até agora; ângulo legal/privacidade.

Trava:
- `shouldAutoRecord` — `cliente`/`fornecedor` → grava; **`desconhecido` → NÃO grava** (não grava número não-cadastrado — o guard de privacidade)
- `resolveCallParty` — match → `cliente` + mapeia contato + `matchConfidence:'last8'`; sem match → `desconhecido` + `null` + `'none'`, **sempre preservando o telefone normalizado**
- Encadeamento `shouldAutoRecord(resolveCallParty(...).kind)`

5 casos; `resolveCustomerByPhone` (DB-backed) mockado.

## Sem mudança de código
`recording-policy.ts` não foi tocado. Só o teste + a spec. Lane não-colidente (arquivo novo).

## Test plan
- [x] `bun run test -- src/lib/call-log/__tests__/recording-policy.test.ts` → 5/5 verde
- [x] `eslint` → exit 0
- [ ] CI `validate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)