### PR TITLE
fix(security): security_invoker=on em 3 views que bypassavam RLS

### DIFF
--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,7 +21,7 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **74** custom migrations totais
+- **75** custom migrations totais
 - **391** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
   - `rls_policy`: 134
@@ -784,6 +784,10 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | `rls_policy` | `public.fcop_insert_own_or_gestor` | `farmer_copilot_sessions` |
 | `rls_policy` | `public.fcop_update_own_or_gestor` | `farmer_copilot_sessions` |
 | `rls_policy` | `public.fcop_delete_own_or_gestor` | `farmer_copilot_sessions` |
+
+### `20260526060000_views_security_invoker_hardening.sql`
+
+> _Nenhum objeto extraído via regex._ Migration provavelmente é `ALTER TABLE` / `UPDATE` / `INSERT` / RLS-only. Validar manualmente.
 
 ## Próximos passos quando algo der `❌`
 

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 74
+-- Total de custom migrations: 75
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -93,7 +93,8 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260525230000', 'impersonation_audit', '20260525230000_impersonation_audit.sql'),
   ('20260526020000', 'rls_score_carteira_hardening', '20260526020000_rls_score_carteira_hardening.sql'),
   ('20260526030000', 'fin_sync_watchdog_sweep_orphans', '20260526030000_fin_sync_watchdog_sweep_orphans.sql'),
-  ('20260526040000', 'rls_carteira_relacionamento_hardening', '20260526040000_rls_carteira_relacionamento_hardening.sql')
+  ('20260526040000', 'rls_carteira_relacionamento_hardening', '20260526040000_rls_carteira_relacionamento_hardening.sql'),
+  ('20260526060000', 'views_security_invoker_hardening', '20260526060000_views_security_invoker_hardening.sql')
 )
 SELECT
   e.version,

--- a/supabase/migrations/20260526060000_views_security_invoker_hardening.sql
+++ b/supabase/migrations/20260526060000_views_security_invoker_hardening.sql
@@ -1,0 +1,70 @@
+-- 20260526060000_views_security_invoker_hardening.sql
+-- ============================================================
+-- Flip security_invoker=on em 3 views que rodavam com direitos do OWNER
+-- (bypassando a RLS do usuário chamador). Follow-up do item 1 do
+-- supabase/schema-security-report.md (P2 do codex no #246).
+-- ============================================================
+-- Achado: 3 das 37 views NÃO tinham WITH (security_invoker=on) → ao serem
+-- consultadas via PostgREST por um usuário authenticated, rodavam com os
+-- privilégios do owner e IGNORAVAM a RLS das tabelas-base. Um não-staff
+-- (ex.: customer) podia bater direto em /rest/v1/<view> e ler dados que a
+-- RLS das tabelas deveria bloquear.
+--
+-- Decisão (investigação caso-a-caso, como manda o schema-security-report):
+--
+--   1. score_recalc_pending / visit_score_recalc_pending
+--      - Views triviais sobre score_recalc_queue / visit_score_recalc_queue
+--        (filtram processed_at IS NULL).
+--      - Bases têm RLS "Staff can view recalc queue" (master OR employee).
+--      - Consumidores: SÓ edge functions (scoring-recalc-client/batch,
+--        visit-score-recalc-client/batch) que rodam via service_role
+--        (bypassa RLS → INALTERADAS). Zero consumidor frontend.
+--      - Pós-flip: service_role intacto; staff direto ainda vê (RLS staff);
+--        não-staff fica bloqueado (fecha o vazamento de customer_user_id/
+--        farmer_id da fila). SEGURO, zero impacto de UI.
+--
+--   2. v_oportunidade_economica_hoje
+--      - View de oportunidades comerciais por SKU (promoções + aumentos),
+--        dado company-wide (NÃO per-cliente/PII).
+--      - Cadeia: promocao_campanha + promocao_item (ambas "Staff vê") +
+--        v_promocao_item_efetivo + v_sku_aumento_vigente +
+--        v_sku_parametros_sugeridos (os 3 sub-views JÁ são security_invoker=on
+--        e já consumidos por telas de staff hoje → cadeia provada staff-safe;
+--        base sku_parametros = staff_sku_parametros_select).
+--      - Consumidores (todos staff-gated): badge em AppShell
+--        (enableReposicaoPolls = isStaff && !isSalesOnly), useReposicaoStatus
+--        (cockpit), AdminReposicaoMercado. Todos com count filtrado por empresa.
+--      - Pós-flip: chamador staff enxerga a cadeia inteira via "Staff vê" →
+--        MESMO count (neutro pra staff); não-staff via PostgREST fica bloqueado
+--        (fecha o vazamento da inteligência comercial). NEUTRO pra UI de staff.
+--
+-- Idempotente: ALTER VIEW ... SET (security_invoker = on) é re-rodável.
+-- Reversível: ALTER VIEW ... SET (security_invoker = off) restaura o anterior
+-- (caso algum count de staff mude inesperadamente — smoke-test no cockpit da
+-- Reposição após aplicar).
+
+ALTER VIEW public.score_recalc_pending          SET (security_invoker = on);
+ALTER VIEW public.visit_score_recalc_pending    SET (security_invoker = on);
+ALTER VIEW public.v_oportunidade_economica_hoje SET (security_invoker = on);
+
+-- ============================================================
+-- Validação
+-- ============================================================
+WITH v(name) AS (
+  VALUES ('score_recalc_pending'),('visit_score_recalc_pending'),
+         ('v_oportunidade_economica_hoje')
+)
+SELECT
+  CASE WHEN (
+    SELECT count(*)
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public'
+      AND c.relname IN (SELECT name FROM v)
+      AND (
+        array_to_string(c.reloptions, ',') ILIKE '%security_invoker=on%'
+        OR array_to_string(c.reloptions, ',') ILIKE '%security_invoker=true%'
+      )
+  ) = 3
+  THEN '✅ 3 views agora com security_invoker=on (respeitam a RLS do chamador)'
+  ELSE '❌ FALTANDO — confira reloptions das views abaixo' END AS status;


### PR DESCRIPTION
## ⚠️ ATENÇÃO: migration manual necessária

Adiciona `supabase/migrations/20260526060000_views_security_invoker_hardening.sql`.
**Lovable não aplica automaticamente** — mergear NÃO toca o banco. Colar no SQL Editor do Lovable + rodar (`ALTER VIEW` + validação de `reloptions`).

## Contexto

Item 1 do `supabase/schema-security-report.md` (P2 do codex no #246). 3 das 37 views NÃO tinham `WITH (security_invoker=on)` → rodavam com direitos do **owner**, ignorando a RLS das tabelas-base quando consultadas via PostgREST por `authenticated`. Um não-staff (customer) podia bater direto em `/rest/v1/<view>` e ler o que a RLS deveria bloquear.

## Decisão (investigação caso-a-caso, como manda o report)

**`score_recalc_pending` + `visit_score_recalc_pending`** — views triviais sobre as filas de recalc. Consumidas **só por edge functions** (scoring/visit-recalc, via `service_role` → bypassa RLS → inalteradas). Bases têm RLS "Staff can view". Flip fecha o vazamento de `customer_user_id`/`farmer_id` da fila pra não-staff. **Zero consumidor frontend, zero risco de UI.**

**`v_oportunidade_economica_hoje`** — oportunidades comerciais por SKU (promoções + aumentos), dado **company-wide, não-PII**. Cadeia inteira **staff-readable**: os 3 sub-views (`v_promocao_item_efetivo`, `v_sku_aumento_vigente`, `v_sku_parametros_sugeridos`) **já são** `security_invoker=on` e já consumidos por telas de staff; bases `promocao_*`/`sku_parametros` = "Staff vê". Consumidores **todos staff-gated**: badge no `AppShell` (`isStaff && !isSalesOnly`), `useReposicaoStatus` (cockpit), `AdminReposicaoMercado`. Flip é **NEUTRO pra staff** (mesmo `count`) e fecha o bypass pra não-staff.

## Smoke-test pós-apply (recomendado)

Abrir o cockpit/badge da Reposição (staff) e conferir que o contador de "oportunidades ativas" continua igual. Reversível: `ALTER VIEW ... SET (security_invoker = off)`.

## Validação pós-apply (read-only)

```sql
WITH v(name) AS (VALUES ('score_recalc_pending'),('visit_score_recalc_pending'),('v_oportunidade_economica_hoje'))
SELECT CASE WHEN (
  SELECT count(*) FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace
  WHERE n.nspname='public' AND c.relname IN (SELECT name FROM v)
    AND (array_to_string(c.reloptions,',') ILIKE '%security_invoker=on%'
      OR array_to_string(c.reloptions,',') ILIKE '%security_invoker=true%')
) = 3 THEN '✅ 3 views com security_invoker=on' ELSE '❌ FALTANDO' END AS status;
```

## Nota sobre o item 2 do report (cron `sayerlack-portal-watchdog`)

O JWT anon hardcoded **já foi removido** na migration `20260524100500` (recovery de crons de 2026-05-24): a versão atual usa só `Content-Type` + `x-cron-secret` do Vault. Item 2 está resolvido em prod (pendente só de uma verificação do estado vivo do cron) — NÃO precisa de migration nova.

🤖 Generated with [Claude Code](https://claude.com/claude-code)