### PR TITLE
test(kb): cobertura do chunkText (chunking p/ RAG)

### DIFF
--- a/docs/superpowers/specs/2026-05-26-chunk-text-test-design.md
+++ b/docs/superpowers/specs/2026-05-26-chunk-text-test-design.md
@@ -1,0 +1,32 @@
+# Cobertura de teste do `chunkText` (RAG) — Design Spec
+
+> **Data:** 2026-05-26
+> **Status:** continuação autônoma (lane seguro/não-colidente). `src/lib/knowledge-base/chunk-text.ts` (quebra texto em chunks p/ embeddings/RAG) sem teste. Pura, sem deps. 
+
+## Goal
+
+Travar a quebra greedy por caractere com overlap. Sem mudança de código.
+
+## Regras (do código, `CHARS_PER_TOKEN=4`)
+
+- `maxChars = maxTokens*4`; `overlapChars = overlap*4`; `step = max(1, maxChars - overlapChars)` (piso 1 evita loop infinito).
+- texto vazio → `[]`.
+- `len ≤ maxChars` → 1 chunk `{content, charStart:0, charEnd:len, tokenEstimate:ceil(len/4)}`.
+- senão greedy: `pos=0`; chunk `[pos, min(pos+maxChars,len)]`; break se chegou ao fim; `pos += step`.
+
+## Cenários
+
+1. vazio → [].
+2. `len ≤ maxChars` → 1 chunk; `tokenEstimate = ceil(len/4)`.
+3. boundary `len === maxChars` → 1 chunk.
+4. longo → múltiplos chunks; overlap entre consecutivos = `overlapChars`; último encerra no fim; `content === slice(charStart,charEnd)`.
+5. `overlap=0` → contíguos (sem sobreposição).
+6. `overlap ≥ maxTokens` (step degenerado) → **termina** (piso 1), cobre até o fim — guard anti-loop.
+
+## Testing
+
+`src/lib/knowledge-base/__tests__/chunk-text.test.ts` (vitest, sem mocks). 6 casos, verde; lint limpo; sem tocar o módulo.
+
+## Out-of-scope
+
+- Split por sentença (refinamento futuro citado no código); a heurística de tokens (4 chars).

--- a/src/lib/knowledge-base/__tests__/chunk-text.test.ts
+++ b/src/lib/knowledge-base/__tests__/chunk-text.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { chunkText } from '../chunk-text';
+
+// CHARS_PER_TOKEN = 4 (interno). maxTokens=10 → maxChars=40; overlap=2 → overlapChars=8 → step=32.
+
+describe('chunkText', () => {
+  it('texto vazio → []', () => {
+    expect(chunkText('', { maxTokens: 10, overlap: 2 })).toEqual([]);
+  });
+
+  it('texto ≤ maxChars → 1 chunk cobrindo tudo, tokenEstimate = ceil(len/4)', () => {
+    const text = 'x'.repeat(30); // ≤ 40
+    const r = chunkText(text, { maxTokens: 10, overlap: 2 });
+    expect(r).toHaveLength(1);
+    expect(r[0]).toEqual({ content: text, charStart: 0, charEnd: 30, tokenEstimate: Math.ceil(30 / 4) });
+  });
+
+  it('boundary: len === maxChars → ainda 1 chunk', () => {
+    const text = 'x'.repeat(40);
+    const r = chunkText(text, { maxTokens: 10, overlap: 2 });
+    expect(r).toHaveLength(1);
+    expect(r[0].charEnd).toBe(40);
+  });
+
+  it('texto longo → múltiplos chunks com overlap = overlapChars', () => {
+    const text = 'x'.repeat(100);
+    const r = chunkText(text, { maxTokens: 10, overlap: 2 }); // maxChars 40, step 32
+    expect(r.map((c) => [c.charStart, c.charEnd])).toEqual([
+      [0, 40],
+      [32, 72],
+      [64, 100],
+    ]);
+    // overlap entre consecutivos = 8 chars (overlapChars)
+    expect(r[0].charEnd - r[1].charStart).toBe(8);
+    expect(r[1].charEnd - r[2].charStart).toBe(8);
+    // último chunk encerra exatamente no fim
+    expect(r[r.length - 1].charEnd).toBe(100);
+    // content sempre = slice(charStart,charEnd)
+    for (const c of r) expect(c.content).toBe(text.slice(c.charStart, c.charEnd));
+  });
+
+  it('overlap 0 → chunks contíguos (sem sobreposição)', () => {
+    const text = 'x'.repeat(100);
+    const r = chunkText(text, { maxTokens: 10, overlap: 0 }); // step = maxChars = 40
+    expect(r.map((c) => [c.charStart, c.charEnd])).toEqual([
+      [0, 40],
+      [40, 80],
+      [80, 100],
+    ]);
+  });
+
+  it('overlap ≥ maxTokens (step degenerado) → não entra em loop infinito (step piso 1)', () => {
+    const text = 'x'.repeat(50);
+    const r = chunkText(text, { maxTokens: 10, overlap: 10 }); // overlapChars 40 ≥ maxChars 40 → step max(1,0)=1
+    expect(r.length).toBeGreaterThan(0);
+    expect(r.length).toBeLessThan(text.length); // finito
+    expect(r[r.length - 1].charEnd).toBe(50); // cobre até o fim
+  });
+});


### PR DESCRIPTION
## Resumo
Cobertura de teste **aditiva** (test-only) para `src/lib/knowledge-base/chunk-text.ts` (quebra texto em chunks p/ embeddings/RAG), sem teste até agora. Pura, sem deps.

Trava a quebra greedy por caractere com overlap (`CHARS_PER_TOKEN=4`):
- vazio → `[]`; `len ≤ maxChars` → 1 chunk (`tokenEstimate=ceil(len/4)`); boundary `len===maxChars`
- longo → múltiplos chunks com **overlap = overlapChars**; último encerra no fim; `content === slice(charStart,charEnd)`
- `overlap=0` → contíguos; **`overlap ≥ maxTokens` → termina** (step piso 1, guard anti-loop infinito)

6 casos, sem mocks.

## Sem mudança de código
`chunk-text.ts` não foi tocado. Só o teste + a spec. Lane não-colidente (arquivo novo).

## Test plan
- [x] `bun run test -- src/lib/knowledge-base/__tests__/chunk-text.test.ts` → 6/6 verde
- [x] `eslint` → exit 0
- [ ] CI `validate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)