### PR TITLE
test(call-session): cobertura do buildSessionPayload

### DIFF
--- a/docs/superpowers/specs/2026-05-26-build-session-payload-test-design.md
+++ b/docs/superpowers/specs/2026-05-26-build-session-payload-test-design.md
@@ -1,0 +1,33 @@
+# Cobertura de teste do `buildSessionPayload` — Design Spec
+
+> **Data:** 2026-05-26
+> **Status:** continuação autônoma (lane seguro/não-colidente). `src/lib/call-session/build-session-payload.ts` monta o payload de `farmer_calls.insert` ao fim de uma ligação — sem teste.
+
+## Goal
+
+Travar o cálculo de duração, o "lite" do transcript, a serialização e os defaults. Sem mudança de código.
+
+## Regras (do código)
+
+- `duration_seconds = ended - started` em segundos, arredondado; **negativo → 0**.
+- `transcript` vira "lite": só `speaker/text/isFinal/startedAt` (dropa `id`/`endedAt`).
+- `started_at`/`ended_at` → ISO.
+- `entities_extracted = aggregateEntities(analyses)`; `analyses` passa cru.
+- defaults: `call_type='venda'`, `call_result='atendeu'` (vendedor edita depois).
+- passthrough: `farmer_id`, `customer_user_id`, `phone_dialed`, `call_backend`.
+
+## Cenários
+
+1. duração 150s + ISO; 2. duração negativa→0; 3. sub-segundo arredonda; 4. transcript lite (dropa id/endedAt); 5. `entities_extracted` do `aggregateEntities` (chamado com `analyses`); 6. passthrough de analyses + identificadores; 7. defaults venda/atendeu.
+
+## Mock
+
+- `vi.mock('../aggregate-entities')` → `aggregateEntities` retorna sentinela (isola do agregador, que tem teste próprio à parte).
+
+## Testing
+
+`src/lib/call-session/__tests__/build-session-payload.test.ts` (vitest). 7 casos, verde; lint limpo; sem tocar o módulo.
+
+## Out-of-scope
+
+- `aggregateEntities` (mockado); o insert real no Supabase.

--- a/src/lib/call-session/__tests__/build-session-payload.test.ts
+++ b/src/lib/call-session/__tests__/build-session-payload.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../aggregate-entities', () => ({
+  aggregateEntities: vi.fn(() => ({ produtos: ['lixa'] })),
+}));
+
+import { buildSessionPayload, type BuildSessionPayloadInput } from '../build-session-payload';
+import { aggregateEntities } from '../aggregate-entities';
+import type { TranscriptTurn } from '@/lib/transcription/types';
+import type { SpinAnalysis } from '@/lib/spin/types';
+
+const mockAggregate = vi.mocked(aggregateEntities);
+
+function turn(over: Partial<TranscriptTurn> = {}): TranscriptTurn {
+  return {
+    id: 'turn-1',
+    speaker: 'vendedor',
+    text: 'olá',
+    isFinal: true,
+    startedAt: 1000,
+    endedAt: 2000,
+    ...over,
+  } as unknown as TranscriptTurn;
+}
+
+const analyses = [{ tag: 'a' }] as unknown as SpinAnalysis[];
+
+function makeInput(over: Partial<BuildSessionPayloadInput> = {}): BuildSessionPayloadInput {
+  return {
+    farmerId: 'farmer-1',
+    customerUserId: 'cust-1',
+    phoneDialed: '37999998888',
+    callBackend: 'webrtc',
+    startedAt: new Date('2026-05-26T10:00:00.000Z'),
+    endedAt: new Date('2026-05-26T10:02:30.000Z'), // +150s
+    turns: [turn()],
+    analyses,
+    ...over,
+  };
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('buildSessionPayload', () => {
+  it('calcula duration_seconds (arredondado) e serializa timestamps em ISO', () => {
+    const p = buildSessionPayload(makeInput());
+    expect(p.duration_seconds).toBe(150);
+    expect(p.started_at).toBe('2026-05-26T10:00:00.000Z');
+    expect(p.ended_at).toBe('2026-05-26T10:02:30.000Z');
+  });
+
+  it('duração negativa (ended antes de started) → 0', () => {
+    const p = buildSessionPayload(makeInput({
+      startedAt: new Date('2026-05-26T10:05:00.000Z'),
+      endedAt: new Date('2026-05-26T10:00:00.000Z'),
+    }));
+    expect(p.duration_seconds).toBe(0);
+  });
+
+  it('arredonda sub-segundo', () => {
+    const p = buildSessionPayload(makeInput({
+      startedAt: new Date(0),
+      endedAt: new Date(2600), // 2.6s → 3
+    }));
+    expect(p.duration_seconds).toBe(3);
+  });
+
+  it('transcript fica "lite" — só speaker/text/isFinal/startedAt (dropa id/endedAt)', () => {
+    const p = buildSessionPayload(makeInput({ turns: [turn({ id: 'x', text: 'oi', endedAt: 9999 })] }));
+    expect(p.transcript).toEqual([{ speaker: 'vendedor', text: 'oi', isFinal: true, startedAt: 1000 }]);
+  });
+
+  it('entities_extracted vem do aggregateEntities (chamado com as analyses)', () => {
+    const p = buildSessionPayload(makeInput());
+    expect(mockAggregate).toHaveBeenCalledWith(analyses);
+    expect(p.entities_extracted).toEqual({ produtos: ['lixa'] });
+  });
+
+  it('passa analyses cru e os campos identificadores adiante', () => {
+    const p = buildSessionPayload(makeInput());
+    expect(p.analyses).toBe(analyses);
+    expect(p).toMatchObject({
+      farmer_id: 'farmer-1',
+      customer_user_id: 'cust-1',
+      phone_dialed: '37999998888',
+      call_backend: 'webrtc',
+    });
+  });
+
+  it('defaults conservadores: call_type=venda, call_result=atendeu', () => {
+    const p = buildSessionPayload(makeInput());
+    expect(p.call_type).toBe('venda');
+    expect(p.call_result).toBe('atendeu');
+  });
+});


### PR DESCRIPTION
## Resumo
Cobertura de teste **aditiva** (test-only) para `src/lib/call-session/build-session-payload.ts` (monta o payload de `farmer_calls.insert` ao fim de uma ligação), sem teste até agora.

Trava: `duration_seconds` (arredondado; **negativo→0**), `transcript` "lite" (dropa `id`/`endedAt`), ISO timestamps, `entities_extracted` via `aggregateEntities` (mockado), passthrough de `analyses` + identificadores, defaults `call_type='venda'`/`call_result='atendeu'`. 7 casos.

## Sem mudança de código
Só o teste + a spec. Lane não-colidente (arquivo novo).

## Test plan
- [x] `bun run test -- src/lib/call-session/__tests__/build-session-payload.test.ts` → 7/7 verde
- [x] `eslint` → exit 0
- [ ] CI `validate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)