### PR TITLE
chore(ts-strict): promove 2 helpers financeiro leaf a strict

### DIFF
--- a/docs/strict-migration-lanes.md
+++ b/docs/strict-migration-lanes.md
@@ -100,6 +100,10 @@ subgrafos sujos (`noUnusedLocals`/`strictNullChecks`) → cascata. **Promova lea
   `importacaoId` não usado + 2 chaves de cache `string|null` guardadas em useDirectTintImport). **NÃO toco**
   `useMyAgendaToday` (puxa `lib/scoring/agenda`, lane farmer) nem `useAdminOrderDetail`/`useCallLog` (PR #228) nem
   `useValor` (financeiro-a2) nem `useRoutePlanner` (reposição).
+- ✅ **`claude/strict-promote-fin-helpers`** (2026-05-26): 2 helpers **novos** (criados hoje nos PRs de
+  segurança #322/#324/#327), pure-leaf, strict-clean por construção — `lib/financeiro/dre-period`,
+  `lib/financeiro/omie-request`. Append-only no `include`. **NÃO toco** mais nada de financeiro
+  (engines/services em churn por outras sessões); fatia disjunta da `cranky-driscoll` (que não tem `lib/financeiro/*`).
 
 ## Follow-up registrado
 

--- a/tsconfig.strict.json
+++ b/tsconfig.strict.json
@@ -494,6 +494,8 @@
     "src/hooks/useDirectTintImport.ts",
     "src/hooks/unifiedOrder/useCart.ts",
     "src/hooks/unifiedOrder/useProductCatalog.ts",
-    "src/lib/postgrest.ts"
+    "src/lib/postgrest.ts",
+    "src/lib/financeiro/dre-period.ts",
+    "src/lib/financeiro/omie-request.ts"
   ]
 }


### PR DESCRIPTION
## Resumo
Promoção **tsconfig-only** (zero edição de source) ao TypeScript strict de 2 helpers **criados hoje** nos PRs de segurança money-path:
- `src/lib/financeiro/dre-period.ts` (#322 — validação de período do DRE)
- `src/lib/financeiro/omie-request.ts` (#324/#327 — allow-list de empresa + gate de acesso)

Ambos **pure-leaf** (importam nada/só tipo) → cascata transitiva zero. `typecheck:strict` verde (0 erros).

## Protocolo de coordenação (CLAUDE.md §10 / strict-migration-lanes)
- **Append-only** no fim do `include` (sem reordenar).
- Reserva registrada em `docs/strict-migration-lanes.md`.
- Fatia **disjunta** da `cranky-driscoll` (`feat/strict-promote-lib-leaf`, que não reivindica `lib/financeiro/*`).

## Test plan
- [x] `bun run typecheck:strict` → EXIT 0, 0 erros (CPU calma, run completo)
- [ ] CI `validate` (typecheck:strict é o gate real)

🤖 Generated with [Claude Code](https://claude.com/claude-code)