### PR TITLE
fix(security): remove JWT anon hardcoded do cron sayerlack-portal-watchdog

### DIFF
--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,15 +21,15 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **75** custom migrations totais
-- **391** objetos esperados (criados por estas migrations)
+- **76** custom migrations totais
+- **392** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
   - `rls_policy`: 134
   - `index`: 95
   - `function`: 56
   - `table`: 53
   - `trigger`: 31
-  - `cron_job`: 18
+  - `cron_job`: 19
   - `enum_value`: 4
 
 ## Inventário por migration
@@ -788,6 +788,12 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 ### `20260526060000_views_security_invoker_hardening.sql`
 
 > _Nenhum objeto extraído via regex._ Migration provavelmente é `ALTER TABLE` / `UPDATE` / `INSERT` / RLS-only. Validar manualmente.
+
+### `20260526080000_fix_sayerlack_cron_vault.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `cron_job` | `cron.sayerlack-portal-watchdog` | — |
 
 ## Próximos passos quando algo der `❌`
 

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 75
+-- Total de custom migrations: 76
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -94,7 +94,8 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260526020000', 'rls_score_carteira_hardening', '20260526020000_rls_score_carteira_hardening.sql'),
   ('20260526030000', 'fin_sync_watchdog_sweep_orphans', '20260526030000_fin_sync_watchdog_sweep_orphans.sql'),
   ('20260526040000', 'rls_carteira_relacionamento_hardening', '20260526040000_rls_carteira_relacionamento_hardening.sql'),
-  ('20260526060000', 'views_security_invoker_hardening', '20260526060000_views_security_invoker_hardening.sql')
+  ('20260526060000', 'views_security_invoker_hardening', '20260526060000_views_security_invoker_hardening.sql'),
+  ('20260526080000', 'fix_sayerlack_cron_vault', '20260526080000_fix_sayerlack_cron_vault.sql')
 )
 SELECT
   e.version,
@@ -503,7 +504,8 @@ WITH expected_objects (migration, kind, schema_name, object_name, parent_name) A
   ('rls_carteira_relacionamento_hardening', 'rls_policy', 'public', 'fcop_select_carteira', 'farmer_copilot_sessions'),
   ('rls_carteira_relacionamento_hardening', 'rls_policy', 'public', 'fcop_insert_own_or_gestor', 'farmer_copilot_sessions'),
   ('rls_carteira_relacionamento_hardening', 'rls_policy', 'public', 'fcop_update_own_or_gestor', 'farmer_copilot_sessions'),
-  ('rls_carteira_relacionamento_hardening', 'rls_policy', 'public', 'fcop_delete_own_or_gestor', 'farmer_copilot_sessions')
+  ('rls_carteira_relacionamento_hardening', 'rls_policy', 'public', 'fcop_delete_own_or_gestor', 'farmer_copilot_sessions'),
+  ('fix_sayerlack_cron_vault', 'cron_job', 'cron', 'sayerlack-portal-watchdog', '')
 )
 SELECT
   e.migration,

--- a/supabase/migrations/20260526080000_fix_sayerlack_cron_vault.sql
+++ b/supabase/migrations/20260526080000_fix_sayerlack_cron_vault.sql
@@ -1,0 +1,52 @@
+-- 20260526080000_fix_sayerlack_cron_vault.sql
+-- ============================================================
+-- Remove o JWT anon hardcoded do cron sayerlack-portal-watchdog.
+-- Follow-up do item 2 do supabase/schema-security-report.md (P2 codex #246).
+-- ============================================================
+-- Estado atual em prod (confirmado por dump de cron.job 2026-05-26):
+--   O cron embute um JWT anon LITERAL nos headers Authorization + apikey
+--   (os outros ~32 crons não fazem isso). O `x-cron-secret` JÁ vem do Vault
+--   (decrypted_secrets/CRON_SECRET) — ou seja, o watchdog autoriza certo pela
+--   1ª checagem do authorizeCronOrStaff (x-cron-secret == CRON_SECRET → true);
+--   o JWT anon só existia pra passar o verify_jwt do GATEWAY do Supabase.
+--   Severidade: BAIXA (a anon key é pública — vai no bundle do front), mas
+--   higiene ruim ter o literal baked no cron + no dump.
+--
+-- ⚠️ PRÉ-REQUISITO (ordem importa): a edge function `enviar-pedido-portal-sayerlack`
+--   precisa estar com `verify_jwt = false` (ajuste no chat do Lovable) ANTES
+--   de aplicar esta migration. Com verify_jwt=false o gateway deixa a request
+--   passar sem JWT e a própria função gateia via x-cron-secret (igual aos
+--   ~32 crons que já rodam assim). Se aplicar com verify_jwt ainda = true, o
+--   gateway dá 401 e o watchdog (que concilia pedidos Sayerlack travados em
+--   `enviando_portal`) PARA. Conferir o resultado em `net._http_response`
+--   (status_code 200) depois de aplicar.
+--
+-- cron.schedule faz upsert por nome → idempotente, sobrescreve a versão com JWT.
+-- Preserva URL, schedule (*/5) e body ({watchdog:true, minutos:5}) atuais;
+-- só troca os headers (remove Authorization + apikey; mantém x-cron-secret Vault).
+
+SELECT cron.schedule(
+  'sayerlack-portal-watchdog',
+  '*/5 * * * *',
+  $cron$SELECT net.http_post(
+    url := 'https://fzvklzpomgnyikkfkzai.supabase.co/functions/v1/enviar-pedido-portal-sayerlack',
+    headers := jsonb_build_object(
+      'Content-Type', 'application/json',
+      'x-cron-secret', (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'CRON_SECRET' LIMIT 1)
+    ),
+    body := jsonb_build_object('watchdog', true, 'minutos', 5)
+  );$cron$
+);
+
+-- ============================================================
+-- Validação
+-- ============================================================
+SELECT
+  CASE
+    WHEN command ILIKE '%eyJ%'                          THEN '❌ ainda tem JWT hardcoded (eyJ...)'
+    WHEN command NOT ILIKE '%decrypted_secret%CRON_SECRET%' THEN '❌ x-cron-secret não vem do Vault'
+    WHEN command ILIKE '%app.settings.cron_secret%'     THEN '⚠️ ainda usa GUC app.settings.cron_secret'
+    ELSE '✅ cron limpo: x-cron-secret do Vault, sem JWT anon hardcoded'
+  END AS status
+FROM cron.job
+WHERE jobname = 'sayerlack-portal-watchdog';


### PR DESCRIPTION
## ⚠️ ATENÇÃO: migration manual necessária + PRÉ-REQUISITO no Lovable

Adiciona `supabase/migrations/20260526080000_fix_sayerlack_cron_vault.sql`. **Lovable não aplica automaticamente.**

**ORDEM IMPORTA (caminho de dinheiro):**
1. **Lovable chat:** setar `verify_jwt = false` em `enviar-pedido-portal-sayerlack` PRIMEIRO.
2. **SQL Editor:** colar o `cron.schedule` desta migration (recola sem o JWT).
3. Conferir `net._http_response` = 200.

Se aplicar o passo 2 com `verify_jwt` ainda `true`, o gateway dá **401** e o watchdog (concilia pedidos Sayerlack travados em `enviando_portal`) **para**.

## Contexto

Item 2 do `supabase/schema-security-report.md` (P2 do codex no #246). O cron `sayerlack-portal-watchdog` embutia um **JWT anon literal** nos headers `Authorization` + `apikey` (os outros ~32 crons usam só Vault). **Severidade baixa** — a anon key é pública (vai no bundle do front) — mas higiene ruim ter o literal baked no cron + no `pg_dump`.

Dump de `cron.job` confirmou: o `x-cron-secret` **já vem do Vault** (`decrypted_secrets`/`CRON_SECRET`), então o watchdog **autoriza certo** pela 1ª checagem do `authorizeCronOrStaff` (linha 1877). O JWT anon só existia pra passar o `verify_jwt` do **gateway** do Supabase. Como a função se gateia sozinha via `x-cron-secret`, com `verify_jwt=false` o JWT vira desnecessário (padrão dos outros crons).

A migration recola o `cron.schedule` (upsert por nome → idempotente) **sem** `Authorization`/`apikey`, preservando URL, schedule (`*/5`) e body (`{watchdog:true, minutos:5}`).

## Validação pós-apply (read-only)

```sql
SELECT CASE
  WHEN command ILIKE '%eyJ%' THEN '❌ ainda tem JWT hardcoded'
  WHEN command NOT ILIKE '%decrypted_secret%CRON_SECRET%' THEN '❌ x-cron-secret fora do Vault'
  ELSE '✅ cron limpo: x-cron-secret do Vault, sem JWT anon' END AS status
FROM cron.job WHERE jobname = 'sayerlack-portal-watchdog';
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)