### PR TITLE
refactor(ui): migra cores de STATUS p/ tokens (fatia 1 — indicadores)

### DIFF
--- a/src/components/aiOps/EvidenceItem.tsx
+++ b/src/components/aiOps/EvidenceItem.tsx
@@ -6,7 +6,7 @@ import type { Evidence } from './types';
 export function EvidenceItem({ evidence }: { evidence: Evidence }) {
   const colorMap = {
     critical: 'text-destructive',
-    warning: 'text-amber-600 dark:text-amber-400',
+    warning: 'text-status-warning',
     info: 'text-muted-foreground',
   };
   const iconMap = {

--- a/src/components/tintImport/ImportCard.tsx
+++ b/src/components/tintImport/ImportCard.tsx
@@ -175,7 +175,7 @@ export function ImportCard({
             <h3 className="text-sm font-semibold">Resultado</h3>
             {results.map((r, i) => (
               <div key={i} className="border rounded-md p-3 flex items-start gap-3">
-                {r.status === 'concluido' ? <CheckCircle className="w-4 h-4 text-green-500 mt-0.5" /> : <AlertTriangle className="w-4 h-4 text-yellow-500 mt-0.5" />}
+                {r.status === 'concluido' ? <CheckCircle className="w-4 h-4 text-status-success mt-0.5" /> : <AlertTriangle className="w-4 h-4 text-status-warning mt-0.5" />}
                 <div className="text-sm">
                   <p className="font-medium">{r.name}</p>
                   <p className="text-muted-foreground">

--- a/src/pages/ToolReports.tsx
+++ b/src/pages/ToolReports.tsx
@@ -58,7 +58,7 @@ const CRIT_CONFIG: Record<Criticality, {
 }> = {
   critical: { label: 'Crítica', icon: AlertTriangle, badgeClass: 'border-destructive/40 bg-destructive/10 text-destructive', bgClass: 'bg-destructive/10' },
   attention: { label: 'Atenção', icon: Clock, badgeClass: 'border-status-warning/40 bg-status-warning-bg text-status-warning', bgClass: 'bg-status-warning-bg' },
-  healthy: { label: 'Saudável', icon: ShieldCheck, badgeClass: 'border-emerald-400/40 bg-emerald-50 text-emerald-700 dark:bg-emerald-900/20 dark:text-emerald-300', bgClass: 'bg-emerald-50 dark:bg-emerald-900/20' },
+  healthy: { label: 'Saudável', icon: ShieldCheck, badgeClass: 'border-status-success/40 bg-status-success-bg text-status-success', bgClass: 'bg-status-success-bg' },
   unscheduled: { label: 'Não agendada', icon: HelpCircle, badgeClass: 'border-border bg-muted text-muted-foreground', bgClass: 'bg-muted' },
 };
 
@@ -85,12 +85,12 @@ function computeRecommendation(
     return { title: 'Afiar em breve', description: 'A próxima afiação está se aproximando — agende para evitar desgaste excessivo.', icon: Clock, color: 'text-status-warning' };
   }
   if (avgInterval && recommendedInterval && avgInterval < recommendedInterval * 0.7) {
-    return { title: 'Uso intenso detectado', description: 'O intervalo real está abaixo do recomendado. Considere revisar a carga de trabalho ou o intervalo de afiação.', icon: TrendingUp, color: 'text-amber-600' };
+    return { title: 'Uso intenso detectado', description: 'O intervalo real está abaixo do recomendado. Considere revisar a carga de trabalho ou o intervalo de afiação.', icon: TrendingUp, color: 'text-status-warning' };
   }
   if (anomalyCount >= 3) {
-    return { title: 'Revisar condição geral', description: 'Múltiplas anomalias registradas. Avalie se a ferramenta precisa de reparo ou substituição.', icon: AlertTriangle, color: 'text-amber-600' };
+    return { title: 'Revisar condição geral', description: 'Múltiplas anomalias registradas. Avalie se a ferramenta precisa de reparo ou substituição.', icon: AlertTriangle, color: 'text-status-warning' };
   }
-  return { title: 'Manter rotina atual', description: 'Ferramenta bem cuidada — continue seguindo o intervalo recomendado.', icon: CheckCircle, color: 'text-emerald-600 dark:text-emerald-400' };
+  return { title: 'Manter rotina atual', description: 'Ferramenta bem cuidada — continue seguindo o intervalo recomendado.', icon: CheckCircle, color: 'text-status-success' };
 }
 
 /* ─── Stat Row component ─── */


### PR DESCRIPTION
## Resumo
Primeira fatia do **sweep de cores** (§10 / task #42). Metodologia validada com o Codex (**abordagem B**: dirigida por contexto de código — converter SÓ status, deixar decorativo intacto).

**Convertido (status real → tokens):**
- `EvidenceItem` — severidade `warning` → `text-status-warning` (critical/info já eram `text-destructive`/`text-muted-foreground`)
- `ImportCard` — ícone de resultado `concluido` → `text-status-success` / else → `text-status-warning`
- `ToolReports` — config `healthy` espelha o irmão `attention` (que já usa tokens) + 3 recomendações de condição da ferramenta (amber→warning, emerald→success)

**Deliberadamente NÃO tocado** (converter regrediria a semântica — confirmado na investigação): categorias SPIN, colunas de kanban, medalhas de ranking, `Sparkles` decorativo, e `StatusBadge` (cujas cores são chaves de map do `ORDER_STATUS`, já renderiza via token).

Tokens são theme-aware → substituem os pares `light + dark:`.

## Risco
Baixo: tokens `status-*` já usados 200+× no app; `healthy` espelha exatamente o sibling `attention`. Mudança puramente de className (zero impacto de tipo). **Spot-check visual** recomendado como follow-up (passo 6 do plano do Codex); o /design-review completo fica pra auditoria final.

## Test plan
- [x] grep confirma 0 cor hardcoded restante nos 3 arquivos
- [x] `eslint` → 0 erros (1 warning pré-existente de exhaustive-deps, não relacionado)
- [ ] CI `validate` (build compila as classes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)