### PR TITLE
fix(types): props obrigatórias faltantes (KpiCards test + FinanceiroFunding EmptyState)

### DIFF
--- a/src/components/reposicao/oportunidades/__tests__/KpiCards.test.tsx
+++ b/src/components/reposicao/oportunidades/__tests__/KpiCards.test.tsx
@@ -10,6 +10,7 @@ describe("KpiCards", () => {
     render(
       <KpiCards
         totalEconomia={1000}
+        ganhoLiquidoPotencial={600}
         oportunidadesCount={5}
         totalSkusAtivos={50}
         dataLimiteMaisProxima="2026-01-20"
@@ -32,6 +33,7 @@ describe("KpiCards", () => {
     render(
       <KpiCards
         totalEconomia={0}
+        ganhoLiquidoPotencial={0}
         oportunidadesCount={0}
         totalSkusAtivos={0}
         dataLimiteMaisProxima={null}

--- a/src/pages/FinanceiroFunding.tsx
+++ b/src/pages/FinanceiroFunding.tsx
@@ -9,6 +9,7 @@ import { FundingInputsDialog } from '@/components/financeiro/FundingInputsDialog
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { PageSkeleton } from '@/components/ui/page-skeleton';
 import { EmptyState } from '@/components/EmptyState';
+import { Banknote } from 'lucide-react';
 import {
   Table,
   TableBody,
@@ -307,6 +308,7 @@ export default function FinanceiroFunding() {
           {/* Tabela de títulos */}
           {data.titulos.length === 0 ? (
             <EmptyState
+              icon={Banknote}
               tone="operational"
               title="Nenhum recebível disponível"
               description={`Nenhum recebível em aberto com vencimento futuro para ${selectedCompany}.`}


### PR DESCRIPTION
## Resumo
Corrige 2 erros de tipo latentes pegos por `tsc --noEmit -p tsconfig.app.json` (que checa o `src` inteiro, incl. testes):

1. **`KpiCards.test.tsx`** (Otimizador de Compras, #325) — os 2 fixtures de render não passavam a prop obrigatória `ganhoLiquidoPotencial`.
2. **`FinanceiroFunding.tsx`** (Funding, #345) — o `<EmptyState>` da tabela vazia não passava a prop obrigatória `icon` → agora `Banknote`.

## Por que escaparam do CI
O `typecheck` do CI roda `tsc --noEmit` no `tsconfig.json` root, que tem `files: []` + `references` — em modo não-build, **não type-checa o `src`** (é no-op). Quem pega esses erros é `tsc -p tsconfig.app.json` (ambiente Lovable/local). **Follow-up sugerido:** trocar o passo de typecheck do CI para `tsc -b` ou `tsc --noEmit -p tsconfig.app.json` (o `src` está limpo sob esse config agora, então a troca não derruba PRs).

## Test plan
- [x] `tsc --noEmit -p tsconfig.app.json` — limpo (src + testes)
- [x] `bun run test src/components/reposicao/oportunidades/__tests__/KpiCards.test.tsx` — 2/2

🤖 Generated with [Claude Code](https://claude.com/claude-code)