### PR TITLE
fix(test): KpiCards passa ganhoLiquidoPotencial (typecheck:strict verde)

### DIFF
--- a/src/components/reposicao/oportunidades/__tests__/KpiCards.test.tsx
+++ b/src/components/reposicao/oportunidades/__tests__/KpiCards.test.tsx
@@ -10,6 +10,7 @@ describe("KpiCards", () => {
     render(
       <KpiCards
         totalEconomia={1000}
+        ganhoLiquidoPotencial={600}
         oportunidadesCount={5}
         totalSkusAtivos={50}
         dataLimiteMaisProxima="2026-01-20"
@@ -21,6 +22,8 @@ describe("KpiCards", () => {
     expect(screen.getByText("SKUs com oportunidade")).toBeTruthy();
     expect(screen.getByText("5")).toBeTruthy();
     expect(screen.getByText("de 50 SKUs ativos")).toBeTruthy();
+    expect(screen.getByText("Ganho líquido potencial")).toBeTruthy();
+    expect(screen.getByText(/600,00/)).toBeTruthy();
     expect(screen.getByText(/1\.000,00/)).toBeTruthy();
     expect(screen.getByText(/em 3 dias/)).toBeTruthy();
     expect(screen.getByText(/2 eventos encerra/)).toBeTruthy();
@@ -32,6 +35,7 @@ describe("KpiCards", () => {
     render(
       <KpiCards
         totalEconomia={0}
+        ganhoLiquidoPotencial={0}
         oportunidadesCount={0}
         totalSkusAtivos={0}
         dataLimiteMaisProxima={null}


### PR DESCRIPTION
## Resumo

**Fix-forward** de uma regressão de interação entre PRs na `main`: o componente `KpiCards` ganhou a prop obrigatória `ganhoLiquidoPotencial` (KPI net-R$ do otimizador de compras), mas o teste `KpiCards.test.tsx` não foi atualizado → `typecheck:strict` **vermelho** na main (`TS2741`, 2 ocorrências).

## O que muda
- Adiciona `ganhoLiquidoPotencial` aos 2 renders do teste (600 no caso com oportunidades, 0 no vazio).
- Adiciona asserção do KPI novo ("Ganho líquido potencial" + `/600,00/`) pra o teste de fato cobrir a prop, não só satisfazer o tipo.

## Testes
- `typecheck:strict`: EXIT=0, **0 erros**.
- `KpiCards.test.tsx`: 2/2 passam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)