### PR TITLE
feat(data-health): Sentinela de Saúde de Dados (Fase 1: financeiro + carteira)

### DIFF
--- a/docs/superpowers/plans/2026-05-26-sentinela-saude-dados.md
+++ b/docs/superpowers/plans/2026-05-26-sentinela-saude-dados.md
@@ -1,0 +1,654 @@
+# Sentinela de Saúde de Dados — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Construir uma camada de saúde de dados que transforma falhas silenciosas de sync (como o bug do saldo R$ 0) em alertas visíveis: badge global + tela diagnóstica (master/gestão) + banners inline nas telas críticas.
+
+**Architecture:** Uma RPC Postgres `SECURITY DEFINER` on-demand (`get_data_health`) que unifica frescor de tabelas + `fin_sync_log` + `get_carteira_saude` num diagnóstico com redação por papel. Frontend lê via react-query e renderiza badge/tela/banners. Lógica de status/rollup/cor isolada num helper puro testado por vitest. Read-only; 1 migration; sem cron/edge novo.
+
+**Tech Stack:** Postgres (RPC SQL), Supabase, React 18 + TS, @tanstack/react-query, shadcn/ui, vitest. Spec: `docs/superpowers/specs/2026-05-26-sentinela-saude-dados-design.md`.
+
+**Constraint Lovable:** a migration da RPC é aplicada MANUALMENTE pelo founder no SQL Editor do Lovable (sem CLI). O frontend mergeia normal (rebuild automático). Tasks de migration entregam o bloco SQL + a query de validação.
+
+---
+
+## Estrutura de arquivos
+
+| Arquivo | Responsabilidade |
+| --- | --- |
+| Create `src/lib/dataHealth/types.ts` | Tipo `DataHealthCheck` + `HealthStatus` + `HealthDomain` (contrato compartilhado front) |
+| Create `src/lib/dataHealth/health-helpers.ts` | Lógica PURA: rollup por domínio, nível do badge, formatação de idade, mensagem de banner, regra "sem verde silencioso" |
+| Create `src/lib/dataHealth/__tests__/health-helpers.test.ts` | Testes vitest do helper puro |
+| Create `supabase/migrations/<ts>_data_health_rpc.sql` | RPC `get_data_health()` (Fase 1: financeiro + carteira) |
+| Create `src/hooks/useDataHealth.ts` | Hook react-query: chama a RPC, mapeia erro→estado vermelho |
+| Create `src/components/shell/DataHealthBadge.tsx` | Badge no topbar (master/gestão) |
+| Create `src/pages/SaudeDados.tsx` | Tela `/gestao/saude-dados` (master/gestão) |
+| Create `src/components/dataHealth/DataHealthBanner.tsx` | Banner inline por fonte (qualquer staff) |
+| Modify `src/App.tsx` | Rota lazy `gestao/saude-dados` + item de nav (seção Gestão, masterOnly/managerOnly) |
+| Modify `src/components/AppShell.tsx` | Montar `<DataHealthBadge/>` no topbar |
+| Modify `src/components/financeiro/dashboard/VisaoGeralTab.tsx` | `<DataHealthBanner source="saldo_bancario"/>` acima das Contas Correntes |
+
+---
+
+## FASE 1 — Fatia MVP end-to-end (financeiro + carteira)
+
+### Task 1: Tipos + helper puro (TDD)
+
+**Files:**
+- Create: `src/lib/dataHealth/types.ts`
+- Create: `src/lib/dataHealth/health-helpers.ts`
+- Test: `src/lib/dataHealth/__tests__/health-helpers.test.ts`
+
+- [ ] **Step 1: Criar os tipos**
+
+Create `src/lib/dataHealth/types.ts`:
+
+```ts
+export type HealthStatus = 'ok' | 'stale' | 'broken' | 'unknown';
+export type HealthDomain = 'financeiro' | 'omie_sync' | 'carteira' | 'estoque';
+export type HealthLevel = 'green' | 'amber' | 'red';
+
+/** Um check individual retornado pela RPC get_data_health. */
+export interface DataHealthCheck {
+  source: string;
+  domain: HealthDomain;
+  status: HealthStatus;
+  age_seconds: number | null;
+  expected_max_age_seconds: number | null;
+  freshness_basis: string | null;
+  message: string;            // sempre presente (banner-safe)
+  last_error: string | null;       // só audiência full
+  probable_cause: string | null;   // só audiência full
+  how_to_fix: string | null;       // só audiência full
+  severity: 'critical' | 'warning' | 'info';
+}
+```
+
+- [ ] **Step 2: Escrever os testes que falham**
+
+Create `src/lib/dataHealth/__tests__/health-helpers.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { badgeLevel, rollupDomain, formatAge, isHealthy } from '../health-helpers';
+import type { DataHealthCheck } from '../types';
+
+const mk = (over: Partial<DataHealthCheck>): DataHealthCheck => ({
+  source: 's', domain: 'financeiro', status: 'ok', age_seconds: 0,
+  expected_max_age_seconds: 3600, freshness_basis: 'max_updated_at',
+  message: '', last_error: null, probable_cause: null, how_to_fix: null,
+  severity: 'info', ...over,
+});
+
+describe('badgeLevel', () => {
+  it('verde quando todos ok', () => {
+    expect(badgeLevel([mk({ status: 'ok' }), mk({ status: 'ok' })])).toBe('green');
+  });
+  it('vermelho quando algum broken', () => {
+    expect(badgeLevel([mk({ status: 'ok' }), mk({ status: 'broken' })])).toBe('red');
+  });
+  it('amarelo quando algum stale (e nenhum broken)', () => {
+    expect(badgeLevel([mk({ status: 'ok' }), mk({ status: 'stale' })])).toBe('amber');
+  });
+  it('SEM VERDE SILENCIOSO: lista vazia => vermelho (não consegue provar saúde)', () => {
+    expect(badgeLevel([])).toBe('red');
+  });
+  it('SEM VERDE SILENCIOSO: unknown => vermelho', () => {
+    expect(badgeLevel([mk({ status: 'unknown' })])).toBe('red');
+  });
+});
+
+describe('rollupDomain', () => {
+  it('agrupa pegando o pior status do domínio', () => {
+    const checks = [
+      mk({ domain: 'financeiro', source: 'cp', status: 'ok' }),
+      mk({ domain: 'financeiro', source: 'cr', status: 'stale' }),
+      mk({ domain: 'carteira', source: 'scores', status: 'ok' }),
+    ];
+    const r = rollupDomain(checks);
+    expect(r.find(d => d.domain === 'financeiro')?.status).toBe('stale');
+    expect(r.find(d => d.domain === 'carteira')?.status).toBe('ok');
+  });
+});
+
+describe('formatAge', () => {
+  it('null => "desconhecido"', () => { expect(formatAge(null)).toBe('desconhecido'); });
+  it('segundos => "há X min"', () => { expect(formatAge(120)).toBe('há 2 min'); });
+  it('horas', () => { expect(formatAge(7200)).toBe('há 2 h'); });
+  it('dias', () => { expect(formatAge(172800)).toBe('há 2 dias'); });
+});
+
+describe('isHealthy', () => {
+  it('só ok', () => { expect(isHealthy([mk({ status: 'ok' })])).toBe(true); });
+  it('stale não é healthy', () => { expect(isHealthy([mk({ status: 'stale' })])).toBe(false); });
+});
+```
+
+- [ ] **Step 3: Rodar os testes pra confirmar que falham**
+
+Run: `heavy bun run test -- src/lib/dataHealth/__tests__/health-helpers.test.ts`
+Expected: FAIL (`badgeLevel`/`rollupDomain`/`formatAge`/`isHealthy` is not a function).
+
+- [ ] **Step 4: Implementar o helper puro**
+
+Create `src/lib/dataHealth/health-helpers.ts`:
+
+```ts
+import type { DataHealthCheck, HealthDomain, HealthLevel, HealthStatus } from './types';
+
+const STATUS_RANK: Record<HealthStatus, number> = { ok: 0, stale: 1, unknown: 2, broken: 3 };
+
+function worst(a: HealthStatus, b: HealthStatus): HealthStatus {
+  return STATUS_RANK[a] >= STATUS_RANK[b] ? a : b;
+}
+
+/** Nível do badge. SEM VERDE SILENCIOSO: vazio ou qualquer unknown/broken => red. */
+export function badgeLevel(checks: DataHealthCheck[]): HealthLevel {
+  if (checks.length === 0) return 'red';
+  if (checks.some(c => c.status === 'broken' || c.status === 'unknown')) return 'red';
+  if (checks.some(c => c.status === 'stale')) return 'amber';
+  return 'green';
+}
+
+export function isHealthy(checks: DataHealthCheck[]): boolean {
+  return checks.length > 0 && checks.every(c => c.status === 'ok');
+}
+
+export interface DomainRollup { domain: HealthDomain; status: HealthStatus; checks: DataHealthCheck[]; }
+
+export function rollupDomain(checks: DataHealthCheck[]): DomainRollup[] {
+  const byDomain = new Map<HealthDomain, DataHealthCheck[]>();
+  for (const c of checks) {
+    const arr = byDomain.get(c.domain) ?? [];
+    arr.push(c);
+    byDomain.set(c.domain, arr);
+  }
+  return [...byDomain.entries()].map(([domain, list]) => ({
+    domain,
+    status: list.reduce<HealthStatus>((acc, c) => worst(acc, c.status), 'ok'),
+    checks: list,
+  }));
+}
+
+export function formatAge(seconds: number | null): string {
+  if (seconds == null) return 'desconhecido';
+  if (seconds < 3600) return `há ${Math.round(seconds / 60)} min`;
+  if (seconds < 86400) return `há ${Math.round(seconds / 3600)} h`;
+  return `há ${Math.round(seconds / 86400)} dias`;
+}
+```
+
+- [ ] **Step 5: Rodar os testes pra confirmar que passam**
+
+Run: `heavy bun run test -- src/lib/dataHealth/__tests__/health-helpers.test.ts`
+Expected: PASS (todos).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/dataHealth/types.ts src/lib/dataHealth/health-helpers.ts src/lib/dataHealth/__tests__/health-helpers.test.ts
+git commit -m "feat(data-health): tipos + helper puro de saúde de dados (TDD)"
+```
+
+---
+
+### Task 2: RPC `get_data_health()` (Fase 1: financeiro + carteira)
+
+**Files:**
+- Create: `supabase/migrations/20260526160000_data_health_rpc.sql`
+
+> ⚠️ Migration aplicada MANUALMENTE no SQL Editor do Lovable. Esta task entrega o arquivo + a query de validação. Use a skill `lovable-db-operator` pra empacotar.
+
+- [ ] **Step 1: Escrever a migration**
+
+Create `supabase/migrations/20260526160000_data_health_rpc.sql`:
+
+```sql
+-- Sentinela de Saúde de Dados — RPC on-demand de diagnóstico (Fase 1: financeiro + carteira).
+-- Verdade primária = frescor de tabela + fin_sync_log. net._http_response = evidência (Fase 2).
+-- cron.job_run_details NÃO é fonte (reporta 'succeeded' mesmo em 401).
+-- Redação por papel: full (master/gestor) vê erro/causa/como-resolver; demais veem só banner-safe.
+-- SEM VERDE SILENCIOSO: o que não consegue provar => 'unknown'/'broken'.
+
+CREATE OR REPLACE FUNCTION public.get_data_health()
+RETURNS TABLE (
+  source text, domain text, status text,
+  age_seconds bigint, expected_max_age_seconds bigint, freshness_basis text,
+  message text, last_error text, probable_cause text, how_to_fix text, severity text
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_full boolean;
+BEGIN
+  IF auth.uid() IS NULL THEN
+    RAISE EXCEPTION 'Acesso negado: não autenticado' USING ERRCODE = '42501';
+  END IF;
+  -- audiência full = master OU gestor comercial (helper existente). COALESCE => fail-closed.
+  v_full := COALESCE(public.pode_ver_carteira_completa(auth.uid()), false);
+
+  RETURN QUERY
+  WITH checks AS (
+    -- ── FINANCEIRO: saldo bancário (frescor por saldo_data) ──
+    SELECT 'saldo_bancario'::text AS source, 'financeiro'::text AS domain,
+      CASE
+        WHEN max(cc.saldo_data) IS NULL THEN 'broken'
+        WHEN now() - max(cc.saldo_data)::timestamptz > interval '36 hours' THEN 'stale'
+        ELSE 'ok'
+      END AS status,
+      EXTRACT(EPOCH FROM now() - max(cc.saldo_data)::timestamptz)::bigint AS age_seconds,
+      (36*3600)::bigint AS expected_max_age_seconds,
+      'max_saldo_data'::text AS freshness_basis,
+      CASE WHEN max(cc.saldo_data) IS NULL
+           THEN 'Saldo bancário nunca sincronizou'
+           ELSE 'Saldo bancário: último sync ' || to_char(max(cc.saldo_data), 'DD/MM') END AS message,
+      NULL::text AS last_error,
+      CASE WHEN max(cc.saldo_data) IS NULL THEN 'ListarExtrato falhando ou nunca rodou' ELSE NULL END AS probable_cause,
+      'Rode sync_contas_correntes no chat do Lovable e cheque os logs do omie-financeiro'::text AS how_to_fix,
+      'critical'::text AS severity
+    FROM public.fin_contas_correntes cc WHERE cc.ativo = true
+
+    UNION ALL
+    -- ── FINANCEIRO: contas a receber (frescor por updated_at) ──
+    SELECT 'contas_receber', 'financeiro',
+      CASE WHEN max(cr.updated_at) IS NULL THEN 'broken'
+           WHEN now() - max(cr.updated_at) > interval '26 hours' THEN 'stale' ELSE 'ok' END,
+      EXTRACT(EPOCH FROM now() - max(cr.updated_at))::bigint, (26*3600)::bigint, 'max_updated_at',
+      'Contas a receber: atualizado ' || COALESCE(to_char(max(cr.updated_at),'DD/MM HH24:MI'),'nunca'),
+      NULL, CASE WHEN max(cr.updated_at) IS NULL THEN 'Sync CR nunca completou' ELSE NULL END,
+      'Rode sync_contas_receber no Lovable', 'warning'
+    FROM public.fin_contas_receber cr
+
+    UNION ALL
+    -- ── FINANCEIRO: contas a pagar ──
+    SELECT 'contas_pagar', 'financeiro',
+      CASE WHEN max(cp.updated_at) IS NULL THEN 'broken'
+           WHEN now() - max(cp.updated_at) > interval '26 hours' THEN 'stale' ELSE 'ok' END,
+      EXTRACT(EPOCH FROM now() - max(cp.updated_at))::bigint, (26*3600)::bigint, 'max_updated_at',
+      'Contas a pagar: atualizado ' || COALESCE(to_char(max(cp.updated_at),'DD/MM HH24:MI'),'nunca'),
+      NULL, CASE WHEN max(cp.updated_at) IS NULL THEN 'Sync CP nunca completou' ELSE NULL END,
+      'Rode sync_contas_pagar no Lovable', 'warning'
+    FROM public.fin_contas_pagar cp
+
+    UNION ALL
+    -- ── FINANCEIRO: erro explícito recente em fin_sync_log ──
+    SELECT 'omie_sync_financeiro', 'omie_sync',
+      CASE WHEN bool_or(l.status = 'error') THEN 'broken' ELSE 'ok' END,
+      NULL::bigint, NULL::bigint, 'fin_sync_log',
+      CASE WHEN bool_or(l.status='error') THEN 'Sync financeiro com erro nas últimas 24h' ELSE 'Sync financeiro sem erros recentes' END,
+      max(l.error_message) FILTER (WHERE l.status='error'),
+      CASE WHEN bool_or(l.status='error') THEN 'Falha em action de sync (ver fin_sync_log)' ELSE NULL END,
+      'Cheque fin_sync_log e re-rode a action que falhou', 'critical'
+    FROM public.fin_sync_log l WHERE l.completed_at > now() - interval '24 hours'
+
+    UNION ALL
+    -- ── CARTEIRA: reusa get_carteira_saude (jsonb) ──
+    SELECT 'carteira_scores', 'carteira',
+      COALESCE((public.get_carteira_saude() ->> 'status'), 'unknown'),
+      NULL::bigint, NULL::bigint, 'calculated_at',
+      'Carteira/scoring: ' || COALESCE((public.get_carteira_saude() ->> 'status'), 'desconhecido'),
+      NULL, NULL, 'Re-rode calculate-scores no Lovable', 'warning'
+  )
+  SELECT
+    c.source, c.domain,
+    -- SEM VERDE SILENCIOSO: status nulo/desconhecido => 'unknown'
+    COALESCE(NULLIF(c.status, ''), 'unknown'),
+    c.age_seconds, c.expected_max_age_seconds, c.freshness_basis, c.message,
+    CASE WHEN v_full THEN c.last_error ELSE NULL END,
+    CASE WHEN v_full THEN c.probable_cause ELSE NULL END,
+    CASE WHEN v_full THEN c.how_to_fix ELSE NULL END,
+    c.severity
+  FROM checks c;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.get_data_health() FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.get_data_health() TO authenticated;
+```
+
+- [ ] **Step 2: Query de validação (colar no SQL Editor após o apply)**
+
+```sql
+SELECT 'get_data_health OK' AS status, count(*) AS n_checks,
+       count(*) FILTER (WHERE status NOT IN ('ok','stale','broken','unknown')) AS status_invalidos
+FROM public.get_data_health();
+```
+Expected: `n_checks >= 5`, `status_invalidos = 0`. (Se o saldo estiver quebrado, deve aparecer `saldo_bancario` com `broken`.)
+
+- [ ] **Step 3: Commit do arquivo (apply é manual no Lovable)**
+
+```bash
+git add supabase/migrations/20260526160000_data_health_rpc.sql
+git commit -m "feat(data-health): RPC get_data_health (financeiro + carteira)"
+```
+
+> ⚠️ No PR: marcar "ATENÇÃO: migration manual necessária" + colar o bloco SQL no body. Confirmar que `public.pode_ver_carteira_completa(uuid)` e `public.get_carteira_saude()` existem em produção (se não, ajustar o gate/check no apply).
+
+---
+
+### Task 3: Hook `useDataHealth`
+
+**Files:**
+- Create: `src/hooks/useDataHealth.ts`
+
+- [ ] **Step 1: Implementar o hook**
+
+Create `src/hooks/useDataHealth.ts`:
+
+```ts
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import type { DataHealthCheck } from '@/lib/dataHealth/types';
+
+export function useDataHealth() {
+  return useQuery<DataHealthCheck[]>({
+    queryKey: ['data-health'],
+    staleTime: 60_000,
+    refetchInterval: 120_000,
+    queryFn: async () => {
+      const { data, error } = await supabase.rpc('get_data_health');
+      if (error) throw error;
+      return (data ?? []) as unknown as DataHealthCheck[];
+    },
+  });
+}
+```
+
+- [ ] **Step 2: Rodar typecheck**
+
+Run: `heavy bun run typecheck:strict` (se o arquivo entrar no include) e `bunx tsc --noEmit`
+Expected: 0 erros novos. (Se `get_data_health` não estiver nos tipos gerados, usar `supabase.rpc('get_data_health' as never)` ou cast — seguir o padrão do repo pra RPCs fora dos tipos.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/hooks/useDataHealth.ts
+git commit -m "feat(data-health): hook useDataHealth (react-query)"
+```
+
+---
+
+### Task 4: `DataHealthBadge` no topbar
+
+**Files:**
+- Create: `src/components/shell/DataHealthBadge.tsx`
+- Modify: `src/components/AppShell.tsx` (montar o badge no topbar, perto do NetworkStatusIndicator)
+
+- [ ] **Step 1: Implementar o badge**
+
+Create `src/components/shell/DataHealthBadge.tsx`:
+
+```tsx
+import { useNavigate } from 'react-router-dom';
+import { ShieldCheck, ShieldAlert, ShieldQuestion } from 'lucide-react';
+import { useDataHealth } from '@/hooks/useDataHealth';
+import { badgeLevel } from '@/lib/dataHealth/health-helpers';
+import { useAuth } from '@/contexts/AuthContext';
+import { cn } from '@/lib/utils';
+
+export function DataHealthBadge() {
+  const navigate = useNavigate();
+  const { isMaster, isStaff } = useAuth();
+  const { data, isError } = useDataHealth();
+
+  // Badge só pra master/gestão (banners inline cobrem o resto)
+  if (!isStaff) return null;
+
+  // SEM VERDE SILENCIOSO: erro de query => vermelho
+  const level = isError ? 'red' : badgeLevel(data ?? []);
+  if (level === 'green') return null; // verde = silencioso por design (só aparece quando há problema)
+
+  const cfg = {
+    red: { Icon: ShieldAlert, cls: 'text-status-error', label: 'Saúde de dados: problema' },
+    amber: { Icon: ShieldQuestion, cls: 'text-status-warning', label: 'Saúde de dados: atenção' },
+  }[level];
+
+  return (
+    <button
+      onClick={() => navigate('/gestao/saude-dados')}
+      title={cfg.label}
+      aria-label={cfg.label}
+      className={cn('inline-flex items-center justify-center h-8 w-8 rounded-md hover:bg-accent', cfg.cls)}
+    >
+      <cfg.Icon className="h-4 w-4" />
+    </button>
+  );
+}
+```
+
+> Nota: verde não renderiza nada (não polui o topbar quando está tudo ok). O badge só aparece em amber/red. A tela `/gestao/saude-dados` mostra o verde também.
+
+- [ ] **Step 2: Montar no topbar do AppShell**
+
+Modify `src/components/AppShell.tsx`: importar e renderizar `<DataHealthBadge />` ao lado do `<NetworkStatusIndicator />` no topbar.
+
+```tsx
+import { DataHealthBadge } from '@/components/shell/DataHealthBadge';
+// ...no topbar, perto de <NetworkStatusIndicator />:
+<DataHealthBadge />
+```
+
+- [ ] **Step 3: Verificar no browser (não há teste unitário de componente)**
+
+Subir `bun dev`, logar como master, abrir o app. Se houver fonte stale/broken, o ícone aparece no topbar e leva pra `/gestao/saude-dados` ao clicar.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/shell/DataHealthBadge.tsx src/components/AppShell.tsx
+git commit -m "feat(data-health): badge de saúde no topbar (master/gestão)"
+```
+
+---
+
+### Task 5: Tela `SaudeDados` + rota
+
+**Files:**
+- Create: `src/pages/SaudeDados.tsx`
+- Modify: `src/App.tsx` (rota lazy + item de nav na seção Gestão, `managerOnly`)
+
+- [ ] **Step 1: Implementar a tela**
+
+Create `src/pages/SaudeDados.tsx`:
+
+```tsx
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { PageSkeleton } from '@/components/ui/page-skeleton';
+import { EmptyState } from '@/components/EmptyState';
+import { ShieldAlert } from 'lucide-react';
+import { useDataHealth } from '@/hooks/useDataHealth';
+import { rollupDomain, formatAge, badgeLevel } from '@/lib/dataHealth/health-helpers';
+
+const DOMAIN_LABEL: Record<string, string> = {
+  financeiro: 'Financeiro', omie_sync: 'Syncs Omie', carteira: 'Carteira / Scoring', estoque: 'Estoque / Reposição',
+};
+const STATUS_CLS: Record<string, string> = {
+  ok: 'text-status-success', stale: 'text-status-warning', broken: 'text-status-error', unknown: 'text-status-error',
+};
+
+export default function SaudeDados() {
+  const { data, isLoading, isError } = useDataHealth();
+  if (isLoading) return <PageSkeleton variant="list" />;
+
+  if (isError || !data) {
+    // SEM VERDE SILENCIOSO: erro => estado vermelho explícito, não tela vazia.
+    return (
+      <div className="max-w-4xl mx-auto p-4">
+        <EmptyState icon={ShieldAlert} title="Saúde de dados indisponível"
+          description="Não foi possível computar os checks. Trate como NÃO confiável até resolver." tone="operational" />
+      </div>
+    );
+  }
+
+  const domains = rollupDomain(data);
+  return (
+    <div className="max-w-4xl mx-auto p-4 space-y-4">
+      <div>
+        <h1 className="font-display" style={{ fontSize: '2rem', fontWeight: 500, letterSpacing: '-0.04em', lineHeight: 1.1 }}>
+          Saúde de Dados
+        </h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          Frescor e integridade das fontes que alimentam as decisões. Nível: {badgeLevel(data)}.
+        </p>
+      </div>
+      {domains.map(d => (
+        <Card key={d.domain}>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-base flex items-center gap-2">
+              <span className={STATUS_CLS[d.status]}>●</span>{DOMAIN_LABEL[d.domain] ?? d.domain}
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            {d.checks.map(c => (
+              <div key={c.source} className="border-b last:border-0 py-2">
+                <div className="flex items-center justify-between">
+                  <span className="text-sm font-medium">{c.message}</span>
+                  <span className={`text-xs font-medium ${STATUS_CLS[c.status]}`}>
+                    {c.status} · {formatAge(c.age_seconds)}
+                  </span>
+                </div>
+                {c.probable_cause && <p className="text-xs text-muted-foreground mt-0.5">Causa provável: {c.probable_cause}</p>}
+                {c.how_to_fix && <p className="text-xs text-status-info mt-0.5">Como resolver: {c.how_to_fix}</p>}
+                {c.last_error && <p className="text-xs text-status-error mt-0.5 font-mono">{c.last_error}</p>}
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Adicionar rota + nav no App.tsx**
+
+Modify `src/App.tsx`:
+- Declarar lazy: `const SaudeDados = lazy(() => import("./pages/SaudeDados"));`
+- Adicionar rota dentro do bloco autenticado: `<Route path="gestao/saude-dados" element={<SaudeDados />} />`
+
+Modify `src/components/AppShell.tsx` — adicionar item na seção "Gestão" do `unifiedNavSections`:
+```tsx
+{ icon: ShieldCheck, label: 'Saúde de Dados', path: '/gestao/saude-dados', managerOnly: true },
+```
+(importar `ShieldCheck` de lucide-react se ainda não estiver.)
+
+- [ ] **Step 3: Verificar no browser**
+
+`bun dev` → logar master → abrir `/gestao/saude-dados` → ver os domínios e checks; forçar um stale (ex: a fonte de saldo) e confirmar que aparece vermelho/amarelo com causa + como-resolver.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/pages/SaudeDados.tsx src/App.tsx src/components/AppShell.tsx
+git commit -m "feat(data-health): tela /gestao/saude-dados (master/gestão)"
+```
+
+---
+
+### Task 6: `DataHealthBanner` inline + wiring no financeiro
+
+**Files:**
+- Create: `src/components/dataHealth/DataHealthBanner.tsx`
+- Modify: `src/components/financeiro/dashboard/VisaoGeralTab.tsx`
+
+- [ ] **Step 1: Implementar o banner**
+
+Create `src/components/dataHealth/DataHealthBanner.tsx`:
+
+```tsx
+import { AlertTriangle } from 'lucide-react';
+import { useDataHealth } from '@/hooks/useDataHealth';
+import { cn } from '@/lib/utils';
+
+/** Banner inline não-bloqueante pra UMA fonte. Aparece pra qualquer staff que abra a tela. */
+export function DataHealthBanner({ source }: { source: string }) {
+  const { data } = useDataHealth();
+  const check = data?.find(c => c.source === source);
+  if (!check || check.status === 'ok') return null;
+
+  const isBroken = check.status === 'broken' || check.status === 'unknown';
+  return (
+    <div className={cn(
+      'flex items-start gap-2 rounded-md border px-3 py-2 text-sm mb-3',
+      isBroken ? 'bg-status-error-bg border-status-error/30 text-status-error'
+               : 'bg-status-warning-bg border-status-warning/30 text-status-warning',
+    )}>
+      <AlertTriangle className="h-4 w-4 shrink-0 mt-0.5" />
+      <span>{check.message} — dado não confiável, não decida por aqui.</span>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Wire no VisaoGeralTab (acima das Contas Correntes)**
+
+Modify `src/components/financeiro/dashboard/VisaoGeralTab.tsx`: importar e renderizar `<DataHealthBanner source="saldo_bancario" />` logo antes do card "Contas Correntes".
+
+```tsx
+import { DataHealthBanner } from '@/components/dataHealth/DataHealthBanner';
+// ...antes do bloco {/* Contas Correntes */}:
+<DataHealthBanner source="saldo_bancario" />
+```
+
+- [ ] **Step 3: Verificar no browser**
+
+`bun dev` → `/financeiro` (Visão Geral). Se o saldo estiver stale/broken, o banner aparece acima das Contas Correntes. (Se o saldo estiver ok, o banner some — comportamento correto.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/dataHealth/DataHealthBanner.tsx src/components/financeiro/dashboard/VisaoGeralTab.tsx
+git commit -m "feat(data-health): banner inline de saldo no financeiro"
+```
+
+---
+
+### Task 7: Gate completo + ship da Fase 1
+
+- [ ] **Step 1: Rodar o gate completo (lição: typecheck:strict + tests + build antes do push)**
+
+```bash
+heavy bun run typecheck:strict
+heavy bun run test
+heavy bun run build
+bun lint
+```
+Expected: typecheck:strict 0 erros; tests todos passando; build ok; lint sem erro novo nos arquivos tocados.
+
+- [ ] **Step 2: PR + merge**
+
+```bash
+git push -u origin feat/sentinela-saude-dados
+gh pr create --base main --title "feat(data-health): Sentinela de Saúde de Dados (Fase 1: financeiro + carteira)" --body "<resumo + ATENÇÃO migration manual: colar supabase/migrations/20260526160000_data_health_rpc.sql no SQL Editor do Lovable + query de validação>"
+gh pr merge <n> --squash --auto
+```
+
+- [ ] **Step 3: Entregar a migration pro founder (ritual Lovable)**
+
+Colar na conversa: o bloco SQL da RPC (1 bloco) + a query de validação. Confirmar `pode_ver_carteira_completa` e `get_carteira_saude` existem em prod. Após apply + "Success", validar que o badge/tela/banner reagem ao estado real.
+
+---
+
+## FASE 2 — Estender domínios (após Fase 1 em produção)
+
+> Mesmo padrão: adicionar blocos `UNION ALL` na RPC (nova migration `ALTER`/`CREATE OR REPLACE`) + um `<DataHealthBanner>` na tela do domínio. Cada um é um PR pequeno.
+
+### Task 8: Checks de Omie sync (evidência HTTP) + estoque/reposição
+- [ ] Adicionar à RPC (via `CREATE OR REPLACE`): bloco por entidade Omie usando `fin_sync_log` por `action`/`company`; e bloco de `net._http_response` como EVIDÊNCIA (janela 24-72h, allowlist de funções, `left(content,500)`) — marcado `severity='info'`, nunca canônico.
+- [ ] Adicionar checks de estoque/reposição (frescor de picking/recebimento + sugestão de compra) — confirmar colunas exatas antes (ex: `picking_tasks`, `nfe_recebimentos`, `pedido_compra_sugerido`).
+- [ ] `<DataHealthBanner source="carteira_scores" />` em `/farmer` (FarmerCalls).
+- [ ] Gate completo + PR + migration manual.
+
+### Task 9 (futuro, fora do MVP): snapshot por cron
+- [ ] `data_health_snapshot` + cron (dead-man switch: alerta mesmo sem ninguém abrir o app). Só quando houver demanda de histórico/alerta proativo.
+
+---
+
+## Self-Review (preenchido)
+
+- **Cobertura da spec:** badge ✓(T4), tela master/gestão ✓(T5), banner inline ✓(T6), 4 domínios (financeiro+carteira na Fase 1 ✓; omie+estoque na Fase 2 ✓), redação por papel ✓(T2 `v_full`), sem-verde-silencioso ✓(T1 testes + T2 COALESCE unknown + T4/T5 erro→vermelho), read-only ✓, 1 migration sem cron/edge ✓(T2).
+- **Placeholders:** nenhum — código real em cada step. (Fase 2 lista colunas a confirmar antes, explicitamente, porque não foram verificadas.)
+- **Consistência de tipos:** `DataHealthCheck` (T1) = retorno da RPC (T2) = consumo do hook (T3) = badge/tela/banner (T4-6). `badgeLevel`/`rollupDomain`/`formatAge` mesmos nomes em todo lugar.
+- **Risco conhecido:** se `supabase.rpc('get_data_health')` não estiver nos tipos gerados, cast (T3 nota). Se `pode_ver_carteira_completa`/`get_carteira_saude` não existirem em prod, ajustar no apply (T2 nota).

--- a/docs/superpowers/specs/2026-05-26-sentinela-saude-dados-design.md
+++ b/docs/superpowers/specs/2026-05-26-sentinela-saude-dados-design.md
@@ -1,0 +1,119 @@
+# Sentinela de Saúde de Dados — Design
+
+> Spec de design (brainstorming). Data: 2026-05-26. Autor: sessão Claude + consulta Codex.
+> Status: aprovado pelo founder, aguardando plano de implementação.
+
+## Problema
+
+O app é profundo e bem-construído, mas o gargalo pra "nível mundial" não é polish de UI — é **confiança nos dados**. O sintoma comprovado nesta sessão: os saldos das contas correntes apareceram **R$ 0,00 silenciosamente por semanas** porque um sync chamava um método Omie inexistente (`ResumirContaCorrente`). Foi uma **falha de dados SILENCIOSA numa tela de dinheiro**. O `CLAUDE.md` documenta o mesmo padrão repetidamente (crons 401, dados 56 dias parados, cursores travados).
+
+A **Sentinela de Saúde de Dados** transforma falhas silenciosas de dados em **alertas visíveis** — antes que enganem alguém numa decisão.
+
+## Escopo (MVP) — decisões travadas
+
+| Decisão | Escolha |
+| --- | --- |
+| O que faz ao detectar | Badge global + tela "Saúde de Dados" + **banner inline não-bloqueante** nas telas críticas |
+| Fontes cobertas | Financeiro, Syncs Omie + crons, Carteira/scoring, Estoque/reposição (registro extensível) |
+| Audiência do badge + tela | Master/gestão (banners inline aparecem pra quem abre a tela crítica) |
+| Ação | **Só diagnóstico** (read-only). Sem botão "re-executar sync" no MVP |
+| Arquitetura | RPC on-demand (sem cron novo, sem edge function) |
+
+**Fora do escopo (pilares posteriores):** snapshot por cron (histórico/tendência/dead-man switch), circuit-breakers que **bloqueiam** telas, "Runbook Autopilot" com botão de ação, Decision Ledger.
+
+## Princípio não-negociável: SEM VERDE SILENCIOSO
+
+A camada que existe pra pegar falhas silenciosas **não pode falhar em silêncio**. Se a Sentinela não consegue *provar* saúde (tabela vazia, não consegue ler `cron`/`net`, correlação ambígua, erro de query), o status é **`unknown` ou `broken`** com `probable_cause='diagnostic_incomplete'` — nunca verde por omissão. Erro de query no frontend → badge vermelho/cinza, **nunca some**.
+
+## Arquitetura
+
+### Abordagem escolhida: RPC on-demand
+Uma RPC Postgres `SECURITY DEFINER` `get_data_health()` que computa todos os checks **ao vivo** quando o badge/tela carrega. Frontend lê via react-query (`staleTime ~60s`). **1 migration + frontend; zero cron novo; zero edge function.** Combina com o constraint do Lovable (deploy manual mínimo) e a saúde é sempre fresca.
+
+Constrói sobre infra existente, não reinventa: `fin_sync_log` (status/error_message/completed_at/companies), `get_carteira_saude()` (`20260525160000`), watchdogs `fin_sync_watchdog` (`20260525200000` + sweep `20260526030000`).
+
+### Fonte de verdade (correção crítica do Codex)
+- **Primária:** frescor de tabela (`max(updated_at)` / `max(saldo_data)` / `calculated_at`) + `fin_sync_log` (status='error' recente, `completed_at`).
+- **Evidência (secundária):** `net._http_response` — status HTTP recente, escopado a janela curta (24-72h) + allowlist de funções + `left(content, 500)`. Marcado como `evidence`, não status canônico (a correlação job→HTTP é fraca porque os crons fazem `PERFORM net.http_post(...)` e descartam o `request_id`).
+- **NÃO usar como verdade:** `cron.job_run_details` — reporta `succeeded` mesmo quando o `pg_net` só *enfileirou* a chamada (mesmo em 401). Foi exatamente o ponto cego do bug do saldo. (O `get_carteira_saude()` atual ainda repete esse ponto cego — a Sentinela corrige.)
+
+### Registro de checks: blocos `UNION ALL` estáticos in-RPC
+Cada check é um bloco SQL estático com contrato de saída consistente. **Não** usar tabela de config com texto de query (vira "mini query engine" numa função privilegiada). Extensível = adicionar um bloco `UNION ALL`.
+
+### Contrato de cada check
+```
+{
+  source:                 text,   -- ex: 'saldo_bancario', 'omie_cr_colacor'
+  domain:                 text,   -- 'financeiro' | 'omie_sync' | 'carteira' | 'estoque'
+  status:                 text,   -- 'ok' | 'stale' | 'broken' | 'unknown'
+  observed_at:            timestamptz,  -- o timestamp de frescor observado
+  age_seconds:            bigint,
+  expected_max_age_seconds: bigint,     -- threshold (default por check)
+  freshness_basis:        text,   -- 'max_updated_at' | 'max_saldo_data' | 'calculated_at' | 'last_complete_sync'
+  last_error:             text,   -- só pra audiência full
+  probable_cause:         text,   -- só pra audiência full
+  how_to_fix:             text,   -- só pra audiência full (ex: "rode sync_contas_correntes no chat do Lovable")
+  severity:               text    -- 'critical' | 'warning' | 'info'
+}
+```
+
+### Checks por domínio (separados, depois roll-up)
+Reportar cada sub-fonte **separadamente** (CP fresco não pode mascarar CR stale), e a tela faz o roll-up por domínio.
+
+- **Financeiro:** saldo bancário (`fin_contas_correntes.saldo_data` null/velho), CR / CP / movimentações / aging — **cada um** com idade própria.
+- **Syncs Omie + crons:** último `fin_sync_log` ok por entidade/empresa + evidência HTTP recente.
+- **Carteira/scoring:** `farmer_client_scores` / `customer_visit_scores` (`calculated_at`) + snapshot de positivação.
+- **Estoque/reposição:** frescor de picking/recebimento + sugestão de compra.
+
+(Cada check define explicitamente sua `freshness_basis` e `expected_max_age_seconds` — não há mapeamento genérico "uma coluna serve todas", porque `updated_at`/`saldo_data`/`calculated_at`/`completed_at` significam coisas diferentes.)
+
+### Segurança e redação por papel (1 RPC, 2 audiências)
+Gate **no corpo da RPC**, fail-closed:
+- `auth.uid()` obrigatório (senão erro).
+- Audiência **full** = `master` OU `employee` + depto gestão (`COALESCE(..., false)` em todo check de papel).
+- `SECURITY DEFINER SET search_path = public, pg_temp`; `GRANT EXECUTE TO authenticated`; revoke `anon/public`.
+- **NÃO** copiar o bypass de cron (`request.jwt.claims IS NULL`) do `20260524203000` — esta RPC é user-facing, não precisa de acesso de cron.
+
+**Redação:** a RPC **deriva a audiência do papel do chamador** (`auth.uid()` → check de papel), sem parâmetro. Audiência full (master/gestão) → todos os campos. Qualquer outro `authenticated` → só campos banner-safe (`source`, `status`, `age_seconds`, `message`), pro banner inline. Assim a mesma RPC serve as duas superfícies sem vazar HTTP/erro/causa pra quem não é gestão.
+
+## Componentes (unidades isoladas)
+
+| Unidade | Faz | Depende de |
+| --- | --- | --- |
+| `get_data_health()` (RPC SQL) | Computa todos os checks; redação derivada do papel do chamador | `fin_contas_correntes`, `fin_contas_receber/pagar`, `fin_sync_log`, `farmer_client_scores`, `customer_visit_scores`, `net._http_response` (evidência), tabelas de estoque/reposição |
+| `src/lib/dataHealth/health-helpers.ts` (puro) | Roll-up domínio, derivação de cor do badge, formatação de idade — **testável isolado (vitest)** | nada (puro) |
+| `useDataHealth()` (react-query hook) | Lê a RPC, staleTime 60s, mapeia erro→badge vermelho | RPC, helpers |
+| `<DataHealthBadge />` (topbar) | Verde/amarelo/vermelho + contagem; master/gestão | `useDataHealth` |
+| `SaudeDados.tsx` (`/gestao/saude-dados`) | Lista por fonte: status/idade/erro/causa/como-resolver; master/gestão | `useDataHealth` |
+| `<DataHealthBanner source=... />` | Banner inline não-bloqueante numa tela crítica | `useDataHealth` (filtra a fonte) |
+
+## Fluxo de dados
+1. Badge/tela/banner montam → `useDataHealth()` chama `get_data_health()`.
+2. RPC computa checks ao vivo, aplica redação por papel, retorna array.
+3. Helper puro faz roll-up por domínio + deriva cor do badge.
+4. UI renderiza. Erro de query → estado vermelho/unknown explícito.
+
+## Tratamento de erro
+- RPC não consegue ler uma fonte → aquele check vira `unknown`/`broken` (`diagnostic_incomplete`), não some.
+- `useDataHealth` com erro/timeout → badge vermelho "saúde indisponível", não verde.
+- Cada check é independente: um falhar não derruba os outros (blocos `UNION ALL` com `COALESCE`/try-safe por bloco).
+
+## Testes
+- **Helper puro** (`health-helpers.ts`): roll-up, cor do badge, formatação de idade, lógica "sem verde silencioso" → vitest.
+- **RPC**: validada pelo ritual Lovable (apply no SQL Editor + query de checagem retornando os checks esperados; incluir um cenário stale forçado).
+
+## Deploy (constraint Lovable)
+- **1 migration** (a RPC + grants) colada no SQL Editor → Run → validar.
+- Frontend mergeia normal (rebuild automático do Lovable).
+- Sem edge function, sem cron.
+
+## Critérios de sucesso
+1. Se o saldo bancário parar de sincronizar, o badge fica vermelho e `/financeiro` mostra banner "Saldo não sincroniza há X dias" — **o bug do saldo seria pego no dia 1**.
+2. A Sentinela nunca mostra verde quando não consegue provar saúde.
+3. Zero edge function / cron novo no MVP.
+4. Master/gestão veem diagnóstico completo; outros veem só o banner-safe.
+
+## Riscos / pontos de atenção
+- Acesso `SECURITY DEFINER` aos schemas `cron`/`net`: confirmar grants no apply; se falhar leitura, degradar pra `unknown` (não quebrar).
+- Performance da leitura de `net._http_response`: escopar duro (janela curta + allowlist + `left(content,500)`).
+- `expected_max_age_seconds` por check: começar com defaults sensatos (saldo ~36h, CR/CP ~26h, scoring ~30h); ajustáveis depois.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -152,6 +152,7 @@ const PerformanceHub = lazy(() => import("./pages/PerformanceHub"));
 const VendasFerramentas = lazy(() => import("./pages/VendasFerramentas"));
 const GestaoAdmin = lazy(() => import("./pages/GestaoAdmin"));
 const GestaoGovernanca = lazy(() => import("./pages/GestaoGovernanca"));
+const SaudeDados = lazy(() => import("./pages/SaudeDados"));
 const AdminAjuda = lazy(() => import("./pages/AdminAjuda"));
 const AdminDesTrimestreAtual = lazy(() => import("./pages/AdminDesTrimestreAtual"));
 const AdminNotificacoes = lazy(() => import("./pages/AdminNotificacoes"));
@@ -341,6 +342,7 @@ const App = () => (
               <Route path="vendas/ferramentas" element={<VendasFerramentas />} />
               <Route path="gestao/admin" element={<GestaoAdmin />} />
               <Route path="gestao/governanca" element={<GestaoGovernanca />} />
+              <Route path="gestao/saude-dados" element={<SaudeDados />} />
               <Route path="admin/ajuda" element={<AdminAjuda />} />
               <Route path="admin/des/trimestre-atual" element={<AdminDesTrimestreAtual />} />
               <Route path="admin/notificacoes" element={<AdminNotificacoes />} />

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { ImpersonationBanner } from '@/components/impersonation/ImpersonationBanner';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { BookOpen, Lock, Calculator, FileText, Palette, Beaker, FileUp, Droplets, LayoutDashboard, Users, ShoppingCart, ShoppingBag, Phone, GraduationCap, BarChart3, Settings, ChevronLeft, ChevronRight, Search, Bell, User, LogOut, Package, TrendingUp, Headphones, Target, Menu, X, ClipboardList, PlusCircle, Shield, Wrench, Award, Scissors, DollarSign, Layers, Printer, UserCheck, FileCheck, Boxes, AlertTriangle, PlayCircle, Factory, Truck, Percent, Sparkles, Handshake, Link2, Globe2, Database, Library, Crosshair, ListChecks } from 'lucide-react';
+import { BookOpen, Lock, Calculator, FileText, Palette, Beaker, FileUp, Droplets, LayoutDashboard, Users, ShoppingCart, ShoppingBag, Phone, GraduationCap, BarChart3, Settings, ChevronLeft, ChevronRight, Search, Bell, User, LogOut, Package, TrendingUp, Headphones, Target, Menu, X, ClipboardList, PlusCircle, Shield, Wrench, Award, Scissors, DollarSign, Layers, Printer, UserCheck, FileCheck, Boxes, AlertTriangle, PlayCircle, Factory, Truck, Percent, Sparkles, Handshake, Link2, Globe2, Database, Library, Crosshair, ListChecks, ShieldCheck } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useAuth } from '@/contexts/AuthContext';
 import { AppShellProvider } from '@/contexts/AppShellContext';
@@ -32,6 +32,7 @@ import { CommandPaletteTrigger } from '@/components/shell/CommandPaletteTrigger'
 import { CompanySwitcher } from '@/components/shell/CompanySwitcher';
 import { ActiveOverrideBadge } from '@/components/financeiro/ActiveOverrideBadge';
 import { NetworkStatusIndicator } from '@/components/shell/NetworkStatusIndicator';
+import { DataHealthBadge } from '@/components/shell/DataHealthBadge';
 import { ThemeToggle } from '@/components/shell/ThemeToggle';
 import { PageViewTracker } from '@/components/shell/PageViewTracker';
 import { AnalyticsIdentify } from '@/components/shell/AnalyticsIdentify';
@@ -156,6 +157,7 @@ const unifiedNavSections: { title: string; items: NavItem[] }[] = [
       { icon: Factory, label: 'Processos padrão', path: '/admin/standard-processes' },
       { icon: Shield, label: 'Admin & Relatórios', path: '/gestao/admin', managerOnly: true },
       { icon: Lock, label: 'Governança', path: '/gestao/governanca', managerOnly: true },
+      { icon: ShieldCheck, label: 'Saúde de Dados', path: '/gestao/saude-dados', managerOnly: true },
     ],
   },
 ];
@@ -641,6 +643,7 @@ function AppTopbar({ sidebarCollapsed, onMobileMenuToggle }: { sidebarCollapsed:
         <ActiveOverrideBadge />
         <CompanySwitcher />
         <NetworkStatusIndicator />
+        <DataHealthBadge />
         <ThemeToggle />
         <HelpDrawer />
 

--- a/src/components/dataHealth/DataHealthBanner.tsx
+++ b/src/components/dataHealth/DataHealthBanner.tsx
@@ -1,0 +1,22 @@
+import { AlertTriangle } from 'lucide-react';
+import { useDataHealth } from '@/hooks/useDataHealth';
+import { cn } from '@/lib/utils';
+
+/** Banner inline não-bloqueante pra UMA fonte. Aparece pra qualquer staff que abra a tela. */
+export function DataHealthBanner({ source }: { source: string }) {
+  const { data } = useDataHealth();
+  const check = data?.find(c => c.source === source);
+  if (!check || check.status === 'ok') return null;
+
+  const isBroken = check.status === 'broken' || check.status === 'unknown';
+  return (
+    <div className={cn(
+      'flex items-start gap-2 rounded-md border px-3 py-2 text-sm mb-3',
+      isBroken ? 'bg-status-error-bg border-status-error/30 text-status-error'
+               : 'bg-status-warning-bg border-status-warning/30 text-status-warning',
+    )}>
+      <AlertTriangle className="h-4 w-4 shrink-0 mt-0.5" />
+      <span>{check.message} — dado não confiável, não decida por aqui.</span>
+    </div>
+  );
+}

--- a/src/components/financeiro/dashboard/VisaoGeralTab.tsx
+++ b/src/components/financeiro/dashboard/VisaoGeralTab.tsx
@@ -15,6 +15,7 @@ import type { FinAlert } from '@/utils/financeiroAlerts';
 import { fmt, fmtCompact, formatCnpj } from '@/components/financeiro/dashboard/format';
 import { KpiCard } from '@/components/financeiro/dashboard/KpiCard';
 import { AgingCard } from '@/components/financeiro/dashboard/AgingCard';
+import { DataHealthBanner } from '@/components/dataHealth/DataHealthBanner';
 
 export function VisaoGeralTab({
   alerts, activeResumo, resumo, view, agingReceber, agingPagar, inadimplentes,
@@ -264,6 +265,7 @@ export function VisaoGeralTab({
       )}
 
       {/* Contas Correntes */}
+      <DataHealthBanner source="saldo_bancario" />
       {activeResumo && activeResumo.contas_correntes.length > 0 && (
         <Card>
           <CardHeader className="pb-3">

--- a/src/components/financeiro/dashboard/__tests__/VisaoGeralTab.test.tsx
+++ b/src/components/financeiro/dashboard/__tests__/VisaoGeralTab.test.tsx
@@ -1,9 +1,17 @@
 import { describe, it, expect } from 'vitest';
+import type { ReactElement } from 'react';
 import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { AlertTriangle } from 'lucide-react';
 import { VisaoGeralTab } from '../VisaoGeralTab';
 import type { FinResumo, AgingData } from '@/services/financeiroService';
 import type { FinAlert } from '@/utils/financeiroAlerts';
+
+// VisaoGeralTab usa <DataHealthBanner> (react-query) → precisa de QueryClientProvider.
+const renderWithClient = (ui: ReactElement) => {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(<QueryClientProvider client={qc}>{ui}</QueryClientProvider>);
+};
 
 const resumoCo: FinResumo = {
   contas_correntes: [{ descricao: 'Conta BB', saldo_atual: 5000, banco: 'Banco do Brasil' }],
@@ -27,7 +35,7 @@ const inadimplentes = [{ nome: 'Cliente XPTO', cnpj: '12345678000190', total_ven
 
 describe('VisaoGeralTab', () => {
   it('renderiza os 4 KPIs sempre, sem cards de consolidado quando view != all', () => {
-    render(
+    renderWithClient(
       <VisaoGeralTab
         alerts={[]}
         activeResumo={null}
@@ -47,7 +55,7 @@ describe('VisaoGeralTab', () => {
   });
 
   it('view=all com dados → cards de empresa, indicadores, regime, inadimplentes e contas correntes', () => {
-    render(
+    renderWithClient(
       <VisaoGeralTab
         alerts={[]}
         activeResumo={resumoCo}
@@ -71,7 +79,7 @@ describe('VisaoGeralTab', () => {
     const alerts: FinAlert[] = [
       { severity: 'critical', company: 'colacor', message: 'Alerta teste', metric: 'metric x', icon: AlertTriangle },
     ];
-    render(
+    renderWithClient(
       <VisaoGeralTab
         alerts={alerts}
         activeResumo={null}

--- a/src/components/shell/DataHealthBadge.tsx
+++ b/src/components/shell/DataHealthBadge.tsx
@@ -1,0 +1,33 @@
+import { useNavigate } from 'react-router-dom';
+import { ShieldAlert, ShieldQuestion } from 'lucide-react';
+import { useDataHealth } from '@/hooks/useDataHealth';
+import { badgeLevel } from '@/lib/dataHealth/health-helpers';
+import { useAuth } from '@/contexts/AuthContext';
+import { cn } from '@/lib/utils';
+
+export function DataHealthBadge() {
+  const navigate = useNavigate();
+  const { isStaff } = useAuth();
+  const { data, isError } = useDataHealth();
+
+  if (!isStaff) return null;
+
+  const level = isError ? 'red' : badgeLevel(data ?? []);
+  if (level === 'green') return null; // verde não polui o topbar
+
+  const cfg = {
+    red: { Icon: ShieldAlert, cls: 'text-status-error', label: 'Saúde de dados: problema' },
+    amber: { Icon: ShieldQuestion, cls: 'text-status-warning', label: 'Saúde de dados: atenção' },
+  }[level];
+
+  return (
+    <button
+      onClick={() => navigate('/gestao/saude-dados')}
+      title={cfg.label}
+      aria-label={cfg.label}
+      className={cn('inline-flex items-center justify-center h-8 w-8 rounded-md hover:bg-accent', cfg.cls)}
+    >
+      <cfg.Icon className="h-4 w-4" />
+    </button>
+  );
+}

--- a/src/hooks/useDataHealth.ts
+++ b/src/hooks/useDataHealth.ts
@@ -1,0 +1,18 @@
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import type { DataHealthCheck } from '@/lib/dataHealth/types';
+
+export function useDataHealth() {
+  return useQuery<DataHealthCheck[]>({
+    queryKey: ['data-health'],
+    staleTime: 60_000,
+    refetchInterval: 120_000,
+    queryFn: async () => {
+      // RPC ainda não está nos tipos gerados do Supabase — cast `as never`
+      // segue o padrão do repo (ex.: AdminReposicaoOportunidades).
+      const { data, error } = await supabase.rpc('get_data_health' as never);
+      if (error) throw error;
+      return (data ?? []) as unknown as DataHealthCheck[];
+    },
+  });
+}

--- a/src/lib/dataHealth/__tests__/health-helpers.test.ts
+++ b/src/lib/dataHealth/__tests__/health-helpers.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { badgeLevel, rollupDomain, formatAge, isHealthy } from '../health-helpers';
+import type { DataHealthCheck } from '../types';
+
+const mk = (over: Partial<DataHealthCheck>): DataHealthCheck => ({
+  source: 's', domain: 'financeiro', status: 'ok', age_seconds: 0,
+  expected_max_age_seconds: 3600, freshness_basis: 'max_updated_at',
+  message: '', last_error: null, probable_cause: null, how_to_fix: null,
+  severity: 'info', ...over,
+});
+
+describe('badgeLevel', () => {
+  it('verde quando todos ok', () => {
+    expect(badgeLevel([mk({ status: 'ok' }), mk({ status: 'ok' })])).toBe('green');
+  });
+  it('vermelho quando algum broken', () => {
+    expect(badgeLevel([mk({ status: 'ok' }), mk({ status: 'broken' })])).toBe('red');
+  });
+  it('amarelo quando algum stale (e nenhum broken)', () => {
+    expect(badgeLevel([mk({ status: 'ok' }), mk({ status: 'stale' })])).toBe('amber');
+  });
+  it('SEM VERDE SILENCIOSO: lista vazia => vermelho (não consegue provar saúde)', () => {
+    expect(badgeLevel([])).toBe('red');
+  });
+  it('SEM VERDE SILENCIOSO: unknown => vermelho', () => {
+    expect(badgeLevel([mk({ status: 'unknown' })])).toBe('red');
+  });
+});
+
+describe('rollupDomain', () => {
+  it('agrupa pegando o pior status do domínio', () => {
+    const checks = [
+      mk({ domain: 'financeiro', source: 'cp', status: 'ok' }),
+      mk({ domain: 'financeiro', source: 'cr', status: 'stale' }),
+      mk({ domain: 'carteira', source: 'scores', status: 'ok' }),
+    ];
+    const r = rollupDomain(checks);
+    expect(r.find(d => d.domain === 'financeiro')?.status).toBe('stale');
+    expect(r.find(d => d.domain === 'carteira')?.status).toBe('ok');
+  });
+});
+
+describe('formatAge', () => {
+  it('null => "desconhecido"', () => { expect(formatAge(null)).toBe('desconhecido'); });
+  it('segundos => "há X min"', () => { expect(formatAge(120)).toBe('há 2 min'); });
+  it('horas', () => { expect(formatAge(7200)).toBe('há 2 h'); });
+  it('dias', () => { expect(formatAge(172800)).toBe('há 2 dias'); });
+});
+
+describe('isHealthy', () => {
+  it('só ok', () => { expect(isHealthy([mk({ status: 'ok' })])).toBe(true); });
+  it('stale não é healthy', () => { expect(isHealthy([mk({ status: 'stale' })])).toBe(false); });
+});

--- a/src/lib/dataHealth/health-helpers.ts
+++ b/src/lib/dataHealth/health-helpers.ts
@@ -1,0 +1,42 @@
+import type { DataHealthCheck, HealthDomain, HealthLevel, HealthStatus } from './types';
+
+const STATUS_RANK: Record<HealthStatus, number> = { ok: 0, stale: 1, unknown: 2, broken: 3 };
+
+function worst(a: HealthStatus, b: HealthStatus): HealthStatus {
+  return STATUS_RANK[a] >= STATUS_RANK[b] ? a : b;
+}
+
+/** Nível do badge. SEM VERDE SILENCIOSO: vazio ou qualquer unknown/broken => red. */
+export function badgeLevel(checks: DataHealthCheck[]): HealthLevel {
+  if (checks.length === 0) return 'red';
+  if (checks.some(c => c.status === 'broken' || c.status === 'unknown')) return 'red';
+  if (checks.some(c => c.status === 'stale')) return 'amber';
+  return 'green';
+}
+
+export function isHealthy(checks: DataHealthCheck[]): boolean {
+  return checks.length > 0 && checks.every(c => c.status === 'ok');
+}
+
+export interface DomainRollup { domain: HealthDomain; status: HealthStatus; checks: DataHealthCheck[]; }
+
+export function rollupDomain(checks: DataHealthCheck[]): DomainRollup[] {
+  const byDomain = new Map<HealthDomain, DataHealthCheck[]>();
+  for (const c of checks) {
+    const arr = byDomain.get(c.domain) ?? [];
+    arr.push(c);
+    byDomain.set(c.domain, arr);
+  }
+  return [...byDomain.entries()].map(([domain, list]) => ({
+    domain,
+    status: list.reduce<HealthStatus>((acc, c) => worst(acc, c.status), 'ok'),
+    checks: list,
+  }));
+}
+
+export function formatAge(seconds: number | null): string {
+  if (seconds == null) return 'desconhecido';
+  if (seconds < 3600) return `há ${Math.round(seconds / 60)} min`;
+  if (seconds < 86400) return `há ${Math.round(seconds / 3600)} h`;
+  return `há ${Math.round(seconds / 86400)} dias`;
+}

--- a/src/lib/dataHealth/types.ts
+++ b/src/lib/dataHealth/types.ts
@@ -1,0 +1,18 @@
+export type HealthStatus = 'ok' | 'stale' | 'broken' | 'unknown';
+export type HealthDomain = 'financeiro' | 'omie_sync' | 'carteira' | 'estoque';
+export type HealthLevel = 'green' | 'amber' | 'red';
+
+/** Um check individual retornado pela RPC get_data_health. */
+export interface DataHealthCheck {
+  source: string;
+  domain: HealthDomain;
+  status: HealthStatus;
+  age_seconds: number | null;
+  expected_max_age_seconds: number | null;
+  freshness_basis: string | null;
+  message: string;            // sempre presente (banner-safe)
+  last_error: string | null;       // só audiência full
+  probable_cause: string | null;   // só audiência full
+  how_to_fix: string | null;       // só audiência full
+  severity: 'critical' | 'warning' | 'info';
+}

--- a/src/pages/SaudeDados.tsx
+++ b/src/pages/SaudeDados.tsx
@@ -1,0 +1,65 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { PageSkeleton } from '@/components/ui/page-skeleton';
+import { EmptyState } from '@/components/EmptyState';
+import { ShieldAlert } from 'lucide-react';
+import { useDataHealth } from '@/hooks/useDataHealth';
+import { rollupDomain, formatAge, badgeLevel } from '@/lib/dataHealth/health-helpers';
+
+const DOMAIN_LABEL: Record<string, string> = {
+  financeiro: 'Financeiro', omie_sync: 'Syncs Omie', carteira: 'Carteira / Scoring', estoque: 'Estoque / Reposição',
+};
+const STATUS_CLS: Record<string, string> = {
+  ok: 'text-status-success', stale: 'text-status-warning', broken: 'text-status-error', unknown: 'text-status-error',
+};
+
+export default function SaudeDados() {
+  const { data, isLoading, isError } = useDataHealth();
+  if (isLoading) return <PageSkeleton variant="list" />;
+
+  if (isError || !data) {
+    return (
+      <div className="max-w-4xl mx-auto p-4">
+        <EmptyState icon={ShieldAlert} title="Saúde de dados indisponível"
+          description="Não foi possível computar os checks. Trate como NÃO confiável até resolver." tone="operational" />
+      </div>
+    );
+  }
+
+  const domains = rollupDomain(data);
+  return (
+    <div className="max-w-4xl mx-auto p-4 space-y-4">
+      <div>
+        <h1 className="font-display" style={{ fontSize: '2rem', fontWeight: 500, letterSpacing: '-0.04em', lineHeight: 1.1 }}>
+          Saúde de Dados
+        </h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          Frescor e integridade das fontes que alimentam as decisões. Nível: {badgeLevel(data)}.
+        </p>
+      </div>
+      {domains.map(d => (
+        <Card key={d.domain}>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-base flex items-center gap-2">
+              <span className={STATUS_CLS[d.status]}>●</span>{DOMAIN_LABEL[d.domain] ?? d.domain}
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            {d.checks.map(c => (
+              <div key={c.source} className="border-b last:border-0 py-2">
+                <div className="flex items-center justify-between">
+                  <span className="text-sm font-medium">{c.message}</span>
+                  <span className={`text-xs font-medium ${STATUS_CLS[c.status]}`}>
+                    {c.status} · {formatAge(c.age_seconds)}
+                  </span>
+                </div>
+                {c.probable_cause && <p className="text-xs text-muted-foreground mt-0.5">Causa provável: {c.probable_cause}</p>}
+                {c.how_to_fix && <p className="text-xs text-status-info mt-0.5">Como resolver: {c.how_to_fix}</p>}
+                {c.last_error && <p className="text-xs text-status-error mt-0.5 font-mono">{c.last_error}</p>}
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/supabase/migrations/20260526160000_data_health_rpc.sql
+++ b/supabase/migrations/20260526160000_data_health_rpc.sql
@@ -1,0 +1,102 @@
+-- Sentinela de Saúde de Dados — RPC on-demand de diagnóstico (Fase 1: financeiro + carteira).
+-- Verdade primária = frescor de tabela + fin_sync_log. net._http_response = evidência (Fase 2).
+-- cron.job_run_details NÃO é fonte (reporta 'succeeded' mesmo em 401).
+-- Redação por papel: full (master/gestor) vê erro/causa/como-resolver; demais veem só banner-safe.
+-- SEM VERDE SILENCIOSO: o que não consegue provar => 'unknown'/'broken'.
+
+CREATE OR REPLACE FUNCTION public.get_data_health()
+RETURNS TABLE (
+  source text, domain text, status text,
+  age_seconds bigint, expected_max_age_seconds bigint, freshness_basis text,
+  message text, last_error text, probable_cause text, how_to_fix text, severity text
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_full boolean;
+BEGIN
+  IF auth.uid() IS NULL THEN
+    RAISE EXCEPTION 'Acesso negado: não autenticado' USING ERRCODE = '42501';
+  END IF;
+  -- audiência full = master OU gestor comercial (helper existente). COALESCE => fail-closed.
+  v_full := COALESCE(public.pode_ver_carteira_completa(auth.uid()), false);
+
+  RETURN QUERY
+  WITH checks AS (
+    -- ── FINANCEIRO: saldo bancário (frescor por saldo_data) ──
+    SELECT 'saldo_bancario'::text AS source, 'financeiro'::text AS domain,
+      CASE
+        WHEN max(cc.saldo_data) IS NULL THEN 'broken'
+        WHEN now() - max(cc.saldo_data)::timestamptz > interval '36 hours' THEN 'stale'
+        ELSE 'ok'
+      END AS status,
+      EXTRACT(EPOCH FROM now() - max(cc.saldo_data)::timestamptz)::bigint AS age_seconds,
+      (36*3600)::bigint AS expected_max_age_seconds,
+      'max_saldo_data'::text AS freshness_basis,
+      CASE WHEN max(cc.saldo_data) IS NULL
+           THEN 'Saldo bancário nunca sincronizou'
+           ELSE 'Saldo bancário: último sync ' || to_char(max(cc.saldo_data), 'DD/MM') END AS message,
+      NULL::text AS last_error,
+      CASE WHEN max(cc.saldo_data) IS NULL THEN 'ListarExtrato falhando ou nunca rodou' ELSE NULL END AS probable_cause,
+      'Rode sync_contas_correntes no chat do Lovable e cheque os logs do omie-financeiro'::text AS how_to_fix,
+      'critical'::text AS severity
+    FROM public.fin_contas_correntes cc WHERE cc.ativo = true
+
+    UNION ALL
+    -- ── FINANCEIRO: contas a receber (frescor por updated_at) ──
+    SELECT 'contas_receber', 'financeiro',
+      CASE WHEN max(cr.updated_at) IS NULL THEN 'broken'
+           WHEN now() - max(cr.updated_at) > interval '26 hours' THEN 'stale' ELSE 'ok' END,
+      EXTRACT(EPOCH FROM now() - max(cr.updated_at))::bigint, (26*3600)::bigint, 'max_updated_at',
+      'Contas a receber: atualizado ' || COALESCE(to_char(max(cr.updated_at),'DD/MM HH24:MI'),'nunca'),
+      NULL, CASE WHEN max(cr.updated_at) IS NULL THEN 'Sync CR nunca completou' ELSE NULL END,
+      'Rode sync_contas_receber no Lovable', 'warning'
+    FROM public.fin_contas_receber cr
+
+    UNION ALL
+    -- ── FINANCEIRO: contas a pagar ──
+    SELECT 'contas_pagar', 'financeiro',
+      CASE WHEN max(cp.updated_at) IS NULL THEN 'broken'
+           WHEN now() - max(cp.updated_at) > interval '26 hours' THEN 'stale' ELSE 'ok' END,
+      EXTRACT(EPOCH FROM now() - max(cp.updated_at))::bigint, (26*3600)::bigint, 'max_updated_at',
+      'Contas a pagar: atualizado ' || COALESCE(to_char(max(cp.updated_at),'DD/MM HH24:MI'),'nunca'),
+      NULL, CASE WHEN max(cp.updated_at) IS NULL THEN 'Sync CP nunca completou' ELSE NULL END,
+      'Rode sync_contas_pagar no Lovable', 'warning'
+    FROM public.fin_contas_pagar cp
+
+    UNION ALL
+    -- ── FINANCEIRO: erro explícito recente em fin_sync_log ──
+    SELECT 'omie_sync_financeiro', 'omie_sync',
+      CASE WHEN bool_or(l.status = 'error') THEN 'broken' ELSE 'ok' END,
+      NULL::bigint, NULL::bigint, 'fin_sync_log',
+      CASE WHEN bool_or(l.status='error') THEN 'Sync financeiro com erro nas últimas 24h' ELSE 'Sync financeiro sem erros recentes' END,
+      max(l.error_message) FILTER (WHERE l.status='error'),
+      CASE WHEN bool_or(l.status='error') THEN 'Falha em action de sync (ver fin_sync_log)' ELSE NULL END,
+      'Cheque fin_sync_log e re-rode a action que falhou', 'critical'
+    FROM public.fin_sync_log l WHERE l.completed_at > now() - interval '24 hours'
+
+    UNION ALL
+    -- ── CARTEIRA: reusa get_carteira_saude (jsonb) ──
+    SELECT 'carteira_scores', 'carteira',
+      COALESCE((public.get_carteira_saude() ->> 'status'), 'unknown'),
+      NULL::bigint, NULL::bigint, 'calculated_at',
+      'Carteira/scoring: ' || COALESCE((public.get_carteira_saude() ->> 'status'), 'desconhecido'),
+      NULL, NULL, 'Re-rode calculate-scores no Lovable', 'warning'
+  )
+  SELECT
+    c.source, c.domain,
+    -- SEM VERDE SILENCIOSO: status nulo/vazio => 'unknown'
+    COALESCE(NULLIF(c.status, ''), 'unknown'),
+    c.age_seconds, c.expected_max_age_seconds, c.freshness_basis, c.message,
+    CASE WHEN v_full THEN c.last_error ELSE NULL END,
+    CASE WHEN v_full THEN c.probable_cause ELSE NULL END,
+    CASE WHEN v_full THEN c.how_to_fix ELSE NULL END,
+    c.severity
+  FROM checks c;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.get_data_health() FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.get_data_health() TO authenticated;


### PR DESCRIPTION
## Resumo
Camada de confiança que transforma falhas SILENCIOSAS de sync (como o bug do saldo R$ 0) em alertas visíveis. Fase 1 = financeiro + carteira.

- **RPC `get_data_health()`** (`SECURITY DEFINER`, on-demand): unifica frescor de tabela + `fin_sync_log` + `get_carteira_saude` num diagnóstico. Redação por papel (`pode_ver_carteira_completa`): master/gestão veem erro/causa/como-resolver; demais veem só banner-safe. **Sem verde silencioso** (`COALESCE→unknown`). `cron.job_run_details` NÃO é fonte (ponto cego do bug do saldo).
- **Badge no topbar** (master/gestão; só aparece em amber/red).
- **Tela `/gestao/saude-dados`** (master/gestão): status/idade/causa/como-resolver por fonte.
- **Banner inline** `<DataHealthBanner source="saldo_bancario"/>` no financeiro (não-bloqueante, pra qualquer staff) — fora do condicional de contas, então aparece mesmo se o saldo quebrar e zerar a lista.
- Helper puro testado (TDD, 12 testes). Read-only; 1 migration; sem cron/edge novo.

Spec: `docs/superpowers/specs/2026-05-26-sentinela-saude-dados-design.md` · Plano: `docs/superpowers/plans/2026-05-26-sentinela-saude-dados.md`

## ⚠️ ATENÇÃO: migration manual necessária
A RPC NÃO entra com o merge. Após mergear, colar `supabase/migrations/20260526160000_data_health_rpc.sql` no SQL Editor do Lovable → Run. **Confirmar que `public.pode_ver_carteira_completa(uuid)` e `public.get_carteira_saude()` existem em prod** (se não, ajustar no apply). Validação pós-apply:
```sql
SELECT 'get_data_health OK' AS status, count(*) AS n_checks,
       count(*) FILTER (WHERE status NOT IN ('ok','stale','broken','unknown')) AS status_invalidos
FROM public.get_data_health();
```
Esperado: `n_checks >= 5`, `status_invalidos = 0`.

## Verificação
- helper TDD: 12/12 · VisaoGeralTab (regressão corrigida): 3/3 · typecheck:strict: 0 · lint: 0 · build: ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)