### PR TITLE
fix(types) + ci: corrige 3 erros TS2741 e faz o CI checar o app (tsconfig.app.json)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,9 @@
 # garante que isso não repita.
 #
 # Decisões de bloqueio:
-# - typecheck (tsc --noEmit): blocking — qualquer regressão de tipos quebra o PR
+# - typecheck (tsc -p tsconfig.app.json): blocking — checa TODO o src (strict:false).
+#   O root tsconfig.json é references-only (files:[]), então `tsc --noEmit` cru é
+#   no-op; o -p força a checagem do app (pega TS2741/prop faltando etc.).
 # - test (vitest run): blocking — regressão de comportamento documentado
 # - build (vite build): blocking — pega Tailwind quebrado + import errors + PWA setup
 # - lint (eslint): informational — main hoje tem 1300 errors herdados (97%
@@ -38,8 +40,8 @@ jobs:
         run: bun install --frozen-lockfile
 
       # ─── Blocking checks ────────────────────────────────────────────
-      - name: Type check
-        run: bunx tsc --noEmit
+      - name: Type check (app — todo o src, ver tsconfig.app.json)
+        run: bunx tsc --noEmit -p tsconfig.app.json
 
       - name: Type check (strict mode — files migrados, ver tsconfig.strict.json)
         run: bun run typecheck:strict

--- a/src/components/reposicao/oportunidades/__tests__/KpiCards.test.tsx
+++ b/src/components/reposicao/oportunidades/__tests__/KpiCards.test.tsx
@@ -10,6 +10,7 @@ describe("KpiCards", () => {
     render(
       <KpiCards
         totalEconomia={1000}
+        ganhoLiquidoPotencial={750}
         oportunidadesCount={5}
         totalSkusAtivos={50}
         dataLimiteMaisProxima="2026-01-20"
@@ -18,6 +19,8 @@ describe("KpiCards", () => {
         onGerarCiclo={onGerarCiclo}
       />
     );
+    expect(screen.getByText("Ganho líquido potencial")).toBeTruthy();
+    expect(screen.getByText(/750,00/)).toBeTruthy();
     expect(screen.getByText("SKUs com oportunidade")).toBeTruthy();
     expect(screen.getByText("5")).toBeTruthy();
     expect(screen.getByText("de 50 SKUs ativos")).toBeTruthy();
@@ -32,6 +35,7 @@ describe("KpiCards", () => {
     render(
       <KpiCards
         totalEconomia={0}
+        ganhoLiquidoPotencial={0}
         oportunidadesCount={0}
         totalSkusAtivos={0}
         dataLimiteMaisProxima={null}

--- a/src/pages/FinanceiroFunding.tsx
+++ b/src/pages/FinanceiroFunding.tsx
@@ -9,6 +9,7 @@ import { FundingInputsDialog } from '@/components/financeiro/FundingInputsDialog
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { PageSkeleton } from '@/components/ui/page-skeleton';
 import { EmptyState } from '@/components/EmptyState';
+import { Inbox } from 'lucide-react';
 import {
   Table,
   TableBody,
@@ -307,6 +308,7 @@ export default function FinanceiroFunding() {
           {/* Tabela de títulos */}
           {data.titulos.length === 0 ? (
             <EmptyState
+              icon={Inbox}
               tone="operational"
               title="Nenhum recebível disponível"
               description={`Nenhum recebível em aberto com vencimento futuro para ${selectedCompany}.`}


### PR DESCRIPTION
## O quê

3 erros `TS2741` (propriedade obrigatória faltando) introduzidos por merges paralelos:

- `KpiCards` (reposicao/oportunidades) passou a exigir `ganhoLiquidoPotencial` (feature do otimizador de compras) mas o test mock não passava → adicionado nos 2 renders + asserção do novo KPI.
- `FinanceiroFunding.tsx:309` usava `<EmptyState>` sem o `icon` (que é obrigatório em `EmptyStateProps`) → `icon={Inbox}`.

## Por que escaparam do CI

Gap conhecido: o CI roda `typecheck:strict` (cujo `include` curado **não** cobre esses arquivos) + `bunx tsc --noEmit` (que é **no-op** — o root `tsconfig.json` tem `files: []` + `references`). Esses erros só aparecem em `tsc -p tsconfig.app.json` (`include: ["src"]`), que o CI não roda. Por isso o #350 mergeou sem pegá-los.

## Verificação

- `tsc -p tsconfig.app.json` → **0 erros** (era 3).
- `vitest run KpiCards.test.tsx` → **2/2 passando** (asserções novas: label + valor).

## Recomendação (separado)

Vale trocar o `bunx tsc --noEmit` no-op do CI por `tsc -p tsconfig.app.json` (ou `tsc -b`) pra pegar essa classe de erro. App-scope está em 0 erros agora, então habilitar seria seguro. Deixo como decisão à parte (afeta todos os PRs em voo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)