### PR TITLE
ci: typecheck checa o src de verdade (-p tsconfig.app.json)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,13 @@
 # garante que isso não repita.
 #
 # Decisões de bloqueio:
-# - typecheck (tsc --noEmit): blocking — qualquer regressão de tipos quebra o PR
+# - typecheck (tsc --noEmit -p tsconfig.app.json): blocking — qualquer regressão
+#   de tipos no src/ quebra o PR. ⚠️ Tem que ser `-p tsconfig.app.json`, NÃO o
+#   `tsc --noEmit` cru: o tsconfig.json root usa `"files": []` + `"references"`,
+#   e em modo não-build o tsc ignora as references e checa só o `files` (vazio)
+#   → no-op que não type-checava o src de jeito nenhum. Isso deixou passar 2
+#   TS2741 reais (#325 KpiCards.test.tsx, #345 FinanceiroFunding.tsx), só pegos
+#   pelo Lovable. `-p tsconfig.app.json` checa src+testes de verdade (~27s).
 # - test (vitest run): blocking — regressão de comportamento documentado
 # - build (vite build): blocking — pega Tailwind quebrado + import errors + PWA setup
 # - lint (eslint): informational — main hoje tem 1300 errors herdados (97%
@@ -39,7 +45,7 @@ jobs:
 
       # ─── Blocking checks ────────────────────────────────────────────
       - name: Type check
-        run: bunx tsc --noEmit
+        run: bunx tsc --noEmit -p tsconfig.app.json
 
       - name: Type check (strict mode — files migrados, ver tsconfig.strict.json)
         run: bun run typecheck:strict

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -649,7 +649,7 @@ Esta tabela é viva — ao instalar/remover skill, atualizar aqui.
 
 Persistido em 2026-05-17 após primeira run completa do skill com sucesso.
 
-- **typecheck**: `bun run typecheck:strict` (incremental strict em `tsconfig.strict.json`) + `bunx tsc --noEmit` (baseline com `strict: false`)
+- **typecheck**: `bun run typecheck:strict` (incremental strict em `tsconfig.strict.json`) + `bunx tsc --noEmit -p tsconfig.app.json` (baseline com `strict: false`, checa todo o `src/`+testes). ⚠️ **NÃO usar `bunx tsc --noEmit` cru** como baseline: o `tsconfig.json` root tem `"files": []` + `"references"` e, em modo não-build, o tsc ignora as references e checa só o `files` (vazio) → no-op silencioso (não type-checa o `src/`). Foi assim que 2 TS2741 reais (#325 `KpiCards.test.tsx`, #345 `FinanceiroFunding.tsx`) passaram pelo CI e só foram pegos pelo Lovable. O passo de typecheck do CI (`.github/workflows/ci.yml`) já usa `-p tsconfig.app.json` desde 2026-05-26.
 - **lint**: `bun lint` (eslint flat config)
 - **test**: `bun run test` (vitest run) — canônico, é o que CI executa. `bun test` (runner nativo) cobre só parte por causa de jsdom incompleto + `vi.hoisted/mocked/importActual` não suportados; bunfig.toml + src/test/bun-setup.ts polifillam localStorage/MediaStream/matchMedia mas alguns testes ainda falham. Sempre `bun run test` pra resultado oficial. Ver §2 pro detalhe.
 - **deadcode**: `bunx knip --reporter compact`. ⚠️ Ignorar a seção "Unlisted dependencies (38)" — são imports `npm:` das Edge Functions Deno, false-positive pro runtime Node.


### PR DESCRIPTION
## Problema

O passo de typecheck do CI (`.github/workflows/ci.yml`) rodava `bunx tsc --noEmit` cru. Mas o `tsconfig.json` root tem `"files": []` + `"references"` pros sub-projetos. Em modo **não-build**, o tsc **ignora as references** e checa só o `files` (vazio) → o passo era um **no-op silencioso** que não type-checava o `src/` de jeito nenhum.

Resultado: 2 erros reais de prop obrigatória faltante (TS2741) passaram pelo CI e só foram pegos pelo ambiente do Lovable:
- #325 — `KpiCards.test.tsx`
- #345 — `FinanceiroFunding.tsx`

(ambos já corrigidos no #353.)

## Mudança

- Troca o passo de typecheck de `bunx tsc --noEmit` → **`bunx tsc --noEmit -p tsconfig.app.json`** (checa todo o `src/` + testes de verdade, ~27s vs ~1s do no-op).
- `typecheck:strict` fica intacto.
- Comentário do topo do `ci.yml` atualizado explicando o porquê.
- CLAUDE.md §13 (Health Stack) registra que o baseline canônico passou a ser `-p tsconfig.app.json` (com a armadilha do `tsc --noEmit` cru documentada).

### Por que `-p tsconfig.app.json` e não `tsc -b`

`tsc -b` (app+node via references) também roda limpo, mas: leva ~2:30 (vs 27s) e gera `tsconfig.app.tsbuildinfo`/`tsconfig.node.tsbuildinfo` (que nem estão no `.gitignore`). Os 2 bugs estavam ambos no `src/`, 100% coberto pelo `tsconfig.app.json`. O node config cobre só `vite.config.ts`, que já é exercitado indiretamente pelo passo de build do vite.

## Verificação local

- `bunx tsc --noEmit` (root) → exit 0 em ~1s (no-op confirmado)
- `bunx tsc --noEmit -p tsconfig.app.json` → **exit 0, limpo** em ~27s (main atual já sem os erros, corrigidos no #353)

Não há migration. Sem mudança de runtime — só CI/config de repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)