### PR TITLE
fix(rls): farmer_copilot_sessions SELECT own-only (privacidade)

### DIFF
--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,10 +21,10 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **78** custom migrations totais
-- **398** objetos esperados (criados por estas migrations)
+- **79** custom migrations totais
+- **399** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
-  - `rls_policy`: 136
+  - `rls_policy`: 137
   - `index`: 95
   - `function`: 58
   - `table`: 55
@@ -810,6 +810,12 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | `table` | `public.farmer_mixgap_feedback` | — |
 | `function` | `public.mark_mixgap_feedback` | — |
 | `function` | `public._carteira_mixgap_for_owner` | — |
+
+### `20260527010000_rls_copilot_sessions_select_own_only.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `rls_policy` | `public.fcop_select_carteira` | `farmer_copilot_sessions` |
 
 ## Próximos passos quando algo der `❌`
 

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 78
+-- Total de custom migrations: 79
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -97,7 +97,8 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260526060000', 'views_security_invoker_hardening', '20260526060000_views_security_invoker_hardening.sql'),
   ('20260526080000', 'fix_sayerlack_cron_vault', '20260526080000_fix_sayerlack_cron_vault.sql'),
   ('20260526100000', 'fin_funding_inputs', '20260526100000_fin_funding_inputs.sql'),
-  ('20260526230000', 'mixgap_feedback', '20260526230000_mixgap_feedback.sql')
+  ('20260526230000', 'mixgap_feedback', '20260526230000_mixgap_feedback.sql'),
+  ('20260527010000', 'rls_copilot_sessions_select_own_only', '20260527010000_rls_copilot_sessions_select_own_only.sql')
 )
 SELECT
   e.version,
@@ -513,7 +514,8 @@ WITH expected_objects (migration, kind, schema_name, object_name, parent_name) A
   ('fin_funding_inputs', 'rls_policy', 'public', 'fin_funding_inputs_write_master', 'fin_funding_inputs'),
   ('mixgap_feedback', 'table', 'public', 'farmer_mixgap_feedback', ''),
   ('mixgap_feedback', 'function', 'public', 'mark_mixgap_feedback', ''),
-  ('mixgap_feedback', 'function', 'public', '_carteira_mixgap_for_owner', '')
+  ('mixgap_feedback', 'function', 'public', '_carteira_mixgap_for_owner', ''),
+  ('rls_copilot_sessions_select_own_only', 'rls_policy', 'public', 'fcop_select_carteira', 'farmer_copilot_sessions')
 )
 SELECT
   e.migration,

--- a/supabase/migrations/20260527010000_rls_copilot_sessions_select_own_only.sql
+++ b/supabase/migrations/20260527010000_rls_copilot_sessions_select_own_only.sql
@@ -1,0 +1,33 @@
+-- ============================================================
+-- RLS: farmer_copilot_sessions SELECT → own-only (privacidade)
+-- ============================================================
+-- Follow-up de 20260526040000_rls_carteira_relacionamento_hardening.sql (que
+-- endureceu as 5 tabelas de relacionamento da carteira). Decisão por codex
+-- consult (2026-05-27): das 2 tabelas SENSÍVEIS, tratar diferente —
+--
+--   • farmer_calls: MANTER com cobertura. O Customer 360 lê calls por
+--     customer_user_id (useCustomerCalls / customer360 hooks) → o dono precisa
+--     ver o histórico COMPLETO de ligações do cliente, inclusive feitas por dono
+--     anterior ou cobertura. Apertar quebraria a continuidade do 360 (histórico
+--     vira parcial por vendedor). Continuidade do relacionamento > ganho marginal
+--     de privacidade. (Não mexe aqui.)
+--
+--   • farmer_copilot_sessions: APERTAR pra own-only. É a sessão de TRABALHO do
+--     vendedor com a IA copilot (raciocínio/notas/sugestões), NÃO histórico
+--     institucional do cliente. Nenhum consumidor a lê por customer_user_id
+--     (useFarmerPerformance e useCopilotEngine leem por farmer_id) → apertar NÃO
+--     quebra nenhuma view, e fecha a leitura da sessão-de-trabalho de um vendedor
+--     por outro (cobertura).
+--
+-- Só redefine a policy de SELECT (fcop_select_carteira): remove a 3ª cláusula
+-- carteira_visivel_para(customer_user_id). INSERT/UPDATE/DELETE permanecem como a
+-- migration anterior os deixou (pode_ver OR farmer_id=uid). service_role bypassa.
+-- Idempotente (DROP IF EXISTS + CREATE). Depende da migration 20260526040000.
+
+DROP POLICY IF EXISTS "fcop_select_carteira" ON public.farmer_copilot_sessions;
+CREATE POLICY "fcop_select_carteira" ON public.farmer_copilot_sessions
+  FOR SELECT TO authenticated
+  USING (
+    (SELECT public.pode_ver_carteira_completa((SELECT auth.uid())))
+    OR farmer_id = (SELECT auth.uid())
+  );


### PR DESCRIPTION
## Resumo

Follow-up de `20260526040000` (hardening das 5 tabelas de relacionamento da carteira). Das 2 tabelas **sensíveis**, decisão codex-validada:

- **`farmer_calls`: MANTÉM cobertura.** O Customer 360 lê calls por `customer_user_id` (`useCustomerCalls`/`customer360`), então o dono precisa do histórico **completo** de ligações do cliente (inclusive de dono anterior/cobertura). Apertar quebraria a continuidade do 360. **Não mexe.**
- **`farmer_copilot_sessions`: APERTA pra own-only** (`pode_ver OR farmer_id=uid`). É sessão de trabalho do vendedor com a IA (raciocínio/notas/sugestões), não histórico do cliente. **Nenhum consumidor lê por `customer_user_id`** (`useFarmerPerformance`/`useCopilotEngine` leem por `farmer_id`) → não quebra view, e fecha leitura de sessão-de-trabalho alheia por cobertura.

Só redefine a policy de SELECT (`fcop_select_carteira`), removendo a 3ª cláusula `carteira_visivel_para`. INSERT/UPDATE/DELETE inalterados. Idempotente. Depende da `20260526040000`.

## ⚠️ ATENÇÃO: migration manual

Lovable não aplica; mergear não toca o banco.

<details><summary>SQL pra colar no SQL Editor</summary>

```sql
DROP POLICY IF EXISTS "fcop_select_carteira" ON public.farmer_copilot_sessions;
CREATE POLICY "fcop_select_carteira" ON public.farmer_copilot_sessions
  FOR SELECT TO authenticated
  USING (
    (SELECT public.pode_ver_carteira_completa((SELECT auth.uid())))
    OR farmer_id = (SELECT auth.uid())
  );
```
</details>

Validação pós-apply:

```sql
SELECT CASE WHEN EXISTS (
  SELECT 1 FROM pg_policies
  WHERE schemaname='public' AND tablename='farmer_copilot_sessions'
    AND policyname='fcop_select_carteira'
    AND qual NOT ILIKE '%carteira_visivel_para%' AND qual ILIKE '%farmer_id%'
) THEN '✅ copilot SELECT own-only' ELSE '❌ não apertou' END AS status;
```

## Follow-up registrado (codex, opcional, futuro)
`farmer_calls`: se virar problema cultural, o 360 pode mostrar metadados/resumo por padrão e abrir transcrição só p/ owner/gerência (camada de apresentação, não RLS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)