### PR TITLE
fix(reposicao): otimizador não credita aumento-evitado fictício (vigência hoje)

### DIFF
--- a/src/lib/reposicao/__tests__/compras-otimizador-helpers.test.ts
+++ b/src/lib/reposicao/__tests__/compras-otimizador-helpers.test.ts
@@ -66,6 +66,9 @@ describe('aumentoEvitadoRs — só a qtd consumida APÓS a vigência', () => {
   it('sem aumento/dias → 0', () => {
     expect(aumentoEvitadoRs({ q_cand: 400, q_base: 100, demanda_diaria: 10, dias_ate_aumento: null, aumento_perc: null, preco_unit: 50 })).toBe(0);
   });
+  it('aumento vigente HOJE (dias_ate_aumento = 0) → 0 (sem janela pra antecipar, não credita fictício)', () => {
+    expect(aumentoEvitadoRs({ q_cand: 400, q_base: 100, demanda_diaria: 10, dias_ate_aumento: 0, aumento_perc: 10, preco_unit: 50 })).toBe(0);
+  });
 });
 
 describe('impactoPrazoRs — (prazo_cand% − prazo_padrão%) × valor_candidato; +encargo=custo', () => {

--- a/src/lib/reposicao/compras-otimizador-helpers.ts
+++ b/src/lib/reposicao/compras-otimizador-helpers.ts
@@ -58,7 +58,11 @@ export function capitalExtra(input: { valor_extra: number; cm_anual: number; dem
 
 export function aumentoEvitadoRs(input: { q_cand: number; q_base: number; demanda_diaria: number | null; dias_ate_aumento: number | null; aumento_perc: number | null; preco_unit: number }): number {
   const d = input.demanda_diaria ?? 0;
-  if (!input.aumento_perc || input.dias_ate_aumento == null || input.dias_ate_aumento < 0) return 0;
+  // dias_ate_aumento <= 0 (não < 0): com 0 o aumento vigora HOJE → não há janela
+  // pra antecipar a compra; creditar "aumento evitado" seria ganho fictício
+  // (consumoAteVigencia=0 deixaria toda a qtd extra elegível). Alinha com a geração
+  // de candidato, que já exige dias_ate_aumento > 0.
+  if (!input.aumento_perc || input.dias_ate_aumento == null || input.dias_ate_aumento <= 0) return 0;
   const consumoAteVigencia = d * input.dias_ate_aumento;
   const qElegivel = Math.max(0, input.q_cand - Math.max(input.q_base, consumoAteVigencia));
   return qElegivel * input.preco_unit * (input.aumento_perc / 100);


### PR DESCRIPTION
## Achado da auditoria (codex-validado)

`aumentoEvitadoRs` (src/lib/reposicao/compras-otimizador-helpers.ts) desistia só com `dias_ate_aumento < 0`. Com `=== 0` (aumento vigora **hoje**), `consumoAteVigencia = demanda*0 = 0` → `qElegivel = q_cand − q_base` (toda a qtd extra) virava "aumento evitado" → `beneficio_liquido_rs` inflado → recomenda `comprar_mais` **fictício** (não existe janela pra antecipar compra contra um aumento já vigente).

**Fix:** guarda → `<= 0` (alinha com `gerarCandidatos`, que já exige `dias_ate_aumento > 0`). +1 teste cobrindo vigência-hoje→0.

Vitest 21/21 · typecheck:strict 0 erros.

🤖 Generated with [Claude Code](https://claude.com/claude-code)