### PR TITLE
fix(farmer): KPIs do dia não zeram à noite (fuso America/Sao_Paulo)

### DIFF
--- a/src/hooks/useMyKpis.ts
+++ b/src/hooks/useMyKpis.ts
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
+import { spDayRangeUtc } from '@/lib/time/sp-day';
 
 export interface FarmerKpis {
   calls_today: number;
@@ -23,13 +24,15 @@ export function useMyKpis() {
       if (!user) {
         return { calls_today: 0, revenue_today: 0, margin_today: 0, avg_ticket_today: 0, pending_link_count: 0 };
       }
-      const todayIso = new Date().toISOString().slice(0, 10);
+      // Janela do dia no fuso de São Paulo, como instantes UTC. Sem isto, a data UTC
+      // (toISOString) vira "amanhã" das 21h-24h locais → KPIs do dia zeram à noite.
+      const { startUtc, endUtc } = spDayRangeUtc();
 
-       
       const { data: calls } = await supabase.from('farmer_calls')
         .select('revenue_generated, margin_generated')
         .eq('farmer_id', user.id)
-        .gte('started_at', todayIso);
+        .gte('started_at', startUtc)
+        .lt('started_at', endUtc);
 
       const callsArr = (calls ?? []) as Array<{ revenue_generated: number | null; margin_generated: number | null }>;
       const revenue = callsArr.reduce((s, c) => s + Number(c.revenue_generated ?? 0), 0);

--- a/src/lib/time/__tests__/sp-day.test.ts
+++ b/src/lib/time/__tests__/sp-day.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { spDayRangeUtc } from '../sp-day';
+
+describe('spDayRangeUtc — janela do dia em America/Sao_Paulo como instantes UTC', () => {
+  it('dia em SP (UTC-3) → [03:00Z do dia, 03:00Z do dia seguinte)', () => {
+    // 14:00 SP = 17:00Z, claramente dentro do dia 27 em SP
+    const { startUtc, endUtc } = spDayRangeUtc(new Date('2026-05-27T17:00:00.000Z'));
+    expect(startUtc).toBe('2026-05-27T03:00:00.000Z');
+    expect(endUtc).toBe('2026-05-28T03:00:00.000Z');
+  });
+
+  it('BUG QUE CORRIGE: 23:30 SP (= 02:30Z do dia seguinte) ainda é o dia 27 em SP', () => {
+    // now = 2026-05-28T02:30Z; toISOString().slice(0,10) daria "2026-05-28" (dia errado) →
+    // a query antiga .gte("2026-05-28") perderia todas as calls do dia 27. Aqui a janela
+    // permanece no 27.
+    const now = new Date('2026-05-27T23:30:00-03:00'); // = 2026-05-28T02:30:00Z
+    expect(now.toISOString()).toBe('2026-05-28T02:30:00.000Z'); // sanidade: já virou no UTC
+    const { startUtc, endUtc } = spDayRangeUtc(now);
+    expect(startUtc).toBe('2026-05-27T03:00:00.000Z');
+    expect(endUtc).toBe('2026-05-28T03:00:00.000Z');
+  });
+
+  it('madrugada em SP (01:00 SP = 04:00Z) → janela do mesmo dia local', () => {
+    const now = new Date('2026-05-27T01:00:00-03:00'); // = 04:00Z
+    const { startUtc, endUtc } = spDayRangeUtc(now);
+    expect(startUtc).toBe('2026-05-27T03:00:00.000Z');
+    expect(endUtc).toBe('2026-05-28T03:00:00.000Z');
+    // o instante atual cai dentro de [start, end)
+    expect(now.getTime()).toBeGreaterThanOrEqual(new Date(startUtc).getTime());
+    expect(now.getTime()).toBeLessThan(new Date(endUtc).getTime());
+  });
+
+  it('janela tem exatamente 24h', () => {
+    const { startUtc, endUtc } = spDayRangeUtc(new Date('2026-05-27T12:00:00.000Z'));
+    expect(new Date(endUtc).getTime() - new Date(startUtc).getTime()).toBe(24 * 60 * 60 * 1000);
+  });
+});

--- a/src/lib/time/sp-day.ts
+++ b/src/lib/time/sp-day.ts
@@ -1,0 +1,50 @@
+/**
+ * Janela [início, fim) do DIA corrente no fuso America/Sao_Paulo, como instantes UTC (ISO).
+ *
+ * Use com colunas `timestamptz`:
+ *   `.gte('started_at', startUtc).lt('started_at', endUtc)`
+ *
+ * Por que não usar `new Date().toISOString().slice(0,10)` direto:
+ *  - `toISOString()` é UTC → no Brasil (UTC-3), das ~21h às 24h locais a data UTC já virou o
+ *    DIA SEGUINTE → uma query `.gte(dataUTC)` perde TODAS as linhas do dia local (KPIs zeram à noite).
+ *  - mesmo a data certa como STRING (yyyy-mm-dd) com `.gte` numa `timestamptz` compara contra
+ *    meia-noite UTC, não meia-noite de São Paulo → janela deslocada 3h.
+ * A solução é resolver o dia EM SP e materializar as fronteiras como instantes UTC.
+ */
+export function spDayRangeUtc(now: Date = new Date()): { startUtc: string; endUtc: string } {
+  // (1) Qual é o dia corrente EM São Paulo (robusto à virada de data UTC).
+  const fmt = new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'America/Sao_Paulo',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  });
+  const [y, m, d] = fmt.format(now).split('-').map(Number); // 'yyyy-mm-dd'
+
+  // (2) Offset de SP neste instante, em ms (robusto a DST: compara wall-clock SP × UTC).
+  const offsetMs = spOffsetMs(now);
+
+  // (3) Meia-noite local de SP → instante UTC = (meia-noite como-se-UTC) − offset.
+  const startMs = Date.UTC(y, m - 1, d, 0, 0, 0) - offsetMs;
+  const endMs = startMs + 24 * 60 * 60 * 1000; // Brasil sem horário de verão desde 2019 → dia = 24h.
+
+  return { startUtc: new Date(startMs).toISOString(), endUtc: new Date(endMs).toISOString() };
+}
+
+/** Offset de America/Sao_Paulo em `date`, em ms (SP − UTC; negativo p/ UTC-3). */
+function spOffsetMs(date: Date): number {
+  const dtf = new Intl.DateTimeFormat('en-US', {
+    timeZone: 'America/Sao_Paulo',
+    hour12: false,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  });
+  const p = Object.fromEntries(dtf.formatToParts(date).map((x) => [x.type, x.value]));
+  const hour = p.hour === '24' ? '00' : p.hour; // alguns runtimes emitem '24' p/ meia-noite
+  const asUtc = Date.UTC(+p.year, +p.month - 1, +p.day, +hour, +p.minute, +p.second);
+  return asUtc - date.getTime();
+}


### PR DESCRIPTION
## Achado da auditoria (codex-validado)

`useMyKpis` usava `new Date().toISOString().slice(0,10)` (data **UTC**) em `.gte('started_at', dia)`. No Brasil (UTC-3), das ~21h às 24h locais a data UTC já virou **amanhã** → `revenue_today`/`calls_today`/`margin_today` **zeram no fim do expediente** do vendedor. Além disso, `.gte(string-de-data)` numa `timestamptz` compara contra meia-noite **UTC**, não de São Paulo (janela deslocada 3h).

**Fix:** helper `spDayRangeUtc()` (`src/lib/time/sp-day.ts`) resolve o dia **em SP** e materializa `[início, fim)` como **instantes UTC** (offset via `Intl`, robusto a DST); o hook passa a usar `.gte(startUtc).lt(endUtc)`.

4 testes — inclui o caso `23:30 SP` (= 02:30Z do dia seguinte) que reproduz o bug e prova que a janela permanece no dia local. Vitest · typecheck:strict · baseline `tsconfig.app.json` = **0 erros**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)