### PR TITLE
style(cores): sweep slice 3 — status do módulo tintométrico → tokens

### DIFF
--- a/src/pages/TintIntegrations.tsx
+++ b/src/pages/TintIntegrations.tsx
@@ -26,8 +26,8 @@ const modeLabels: Record<IntegrationMode, string> = {
 };
 const modeColors: Record<IntegrationMode, string> = {
   csv_only: "bg-muted text-muted-foreground",
-  shadow_mode: "bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200",
-  automatic_primary: "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200",
+  shadow_mode: "bg-status-warning-bg text-status-warning",
+  automatic_primary: "bg-status-success-bg text-status-success",
 };
 
 export default function TintIntegrations() {
@@ -144,10 +144,10 @@ export default function TintIntegrations() {
 
   function getHealthStatus(setting: IntegrationSetting) {
     if (!setting.sync_enabled) return { label: "Desabilitado", color: "text-muted-foreground" };
-    if (!setting.last_heartbeat_at) return { label: "Sem heartbeat", color: "text-yellow-500" };
+    if (!setting.last_heartbeat_at) return { label: "Sem heartbeat", color: "text-status-warning" };
     const diff = Date.now() - new Date(setting.last_heartbeat_at).getTime();
-    if (diff < 5 * 60 * 1000) return { label: "Online", color: "text-green-500" };
-    if (diff < 30 * 60 * 1000) return { label: "Lento", color: "text-yellow-500" };
+    if (diff < 5 * 60 * 1000) return { label: "Online", color: "text-status-success" };
+    if (diff < 30 * 60 * 1000) return { label: "Lento", color: "text-status-warning" };
     return { label: "Offline", color: "text-destructive" };
   }
 

--- a/src/pages/TintMapping.tsx
+++ b/src/pages/TintMapping.tsx
@@ -229,7 +229,7 @@ function SkuTab() {
                       {isInactive ? (
                         <Badge variant="outline" className="bg-muted text-muted-foreground">Oculto</Badge>
                       ) : (
-                        <Badge variant="outline" className={sku.omie_product_id ? 'bg-green-500/10 text-green-700' : 'bg-yellow-500/10 text-yellow-700'}>
+                        <Badge variant="outline" className={sku.omie_product_id ? 'bg-status-success-bg text-status-success' : 'bg-status-warning-bg text-status-warning'}>
                           {sku.omie_product_id ? 'Mapeado' : 'Pendente'}
                         </Badge>
                       )}
@@ -321,7 +321,7 @@ function CoranteTab() {
                 <TableCell className="text-sm">{c.volume_total_ml}ml</TableCell>
                 <TableCell className="text-sm">{custoMl ? `R$ ${custoMl.toFixed(4)}` : '—'}</TableCell>
                 <TableCell>
-                  <Badge variant="outline" className={c.omie_product_id ? 'bg-green-500/10 text-green-700' : 'bg-yellow-500/10 text-yellow-700'}>
+                  <Badge variant="outline" className={c.omie_product_id ? 'bg-status-success-bg text-status-success' : 'bg-status-warning-bg text-status-warning'}>
                     {c.omie_product_id ? 'Mapeado' : 'Pendente'}
                   </Badge>
                 </TableCell>

--- a/src/pages/TintReconciliation.tsx
+++ b/src/pages/TintReconciliation.tsx
@@ -31,10 +31,10 @@ function isSyntheticRecord(item: Pick<ReconciliationItem, "entity_key" | "sync_v
 }
 
 const diffTypeLabels: Record<string, { label: string; color: string; icon: typeof AlertTriangle }> = {
-  match: { label: "Igual", color: "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300", icon: CheckCircle },
-  divergence: { label: "Divergência", color: "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300", icon: AlertTriangle },
-  only_csv: { label: "Só CSV", color: "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300", icon: MinusCircle },
-  only_sync: { label: "Só Sync", color: "bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-300", icon: MinusCircle },
+  match: { label: "Igual", color: "bg-status-success-bg text-status-success", icon: CheckCircle },
+  divergence: { label: "Divergência", color: "bg-status-warning-bg text-status-warning", icon: AlertTriangle },
+  only_csv: { label: "Só CSV", color: "bg-status-info-bg text-status-info", icon: MinusCircle },
+  only_sync: { label: "Só Sync", color: "bg-status-purple-bg text-status-purple", icon: MinusCircle },
 };
 
 function ValueDisplay({ label, value }: { label: string; value: unknown }) {
@@ -142,10 +142,10 @@ export default function TintReconciliation() {
 
           <div className="grid grid-cols-2 md:grid-cols-5 gap-3">
             <Card><CardContent className="p-4 text-center"><p className="text-2xl font-bold">{visibleItems.length}</p><p className="text-xs text-muted-foreground">Comparados</p></CardContent></Card>
-            <Card><CardContent className="p-4 text-center"><p className="text-2xl font-bold text-green-600">{counts.match || 0}</p><p className="text-xs text-muted-foreground">Iguais</p></CardContent></Card>
-            <Card><CardContent className="p-4 text-center"><p className="text-2xl font-bold text-yellow-600">{counts.divergence || 0}</p><p className="text-xs text-muted-foreground">Divergências</p></CardContent></Card>
-            <Card><CardContent className="p-4 text-center"><p className="text-2xl font-bold text-blue-600">{counts.only_csv || 0}</p><p className="text-xs text-muted-foreground">Só CSV</p></CardContent></Card>
-            <Card><CardContent className="p-4 text-center"><p className="text-2xl font-bold text-purple-600">{counts.only_sync || 0}</p><p className="text-xs text-muted-foreground">Só Sync</p></CardContent></Card>
+            <Card><CardContent className="p-4 text-center"><p className="text-2xl font-bold text-status-success">{counts.match || 0}</p><p className="text-xs text-muted-foreground">Iguais</p></CardContent></Card>
+            <Card><CardContent className="p-4 text-center"><p className="text-2xl font-bold text-status-warning">{counts.divergence || 0}</p><p className="text-xs text-muted-foreground">Divergências</p></CardContent></Card>
+            <Card><CardContent className="p-4 text-center"><p className="text-2xl font-bold text-status-info">{counts.only_csv || 0}</p><p className="text-xs text-muted-foreground">Só CSV</p></CardContent></Card>
+            <Card><CardContent className="p-4 text-center"><p className="text-2xl font-bold text-status-purple">{counts.only_sync || 0}</p><p className="text-xs text-muted-foreground">Só Sync</p></CardContent></Card>
           </div>
         </>
       )}
@@ -263,14 +263,14 @@ export default function TintReconciliation() {
                   <Badge className={dt.color}>{dt.label}</Badge>
                   <Badge variant="outline">{detailItem.entity_type}</Badge>
                   {synthetic && (
-                    <Badge variant="outline" className="gap-1 border-dashed border-yellow-500 text-yellow-700 dark:text-yellow-400">
+                    <Badge variant="outline" className="gap-1 border-dashed border-status-warning text-status-warning">
                       <FlaskConical className="h-3 w-3" /> Dado Sintético / Mock
                     </Badge>
                   )}
                 </div>
 
                 {synthetic && (
-                  <div className="bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 rounded-lg p-3 text-xs text-yellow-800 dark:text-yellow-300">
+                  <div className="bg-status-warning-bg border border-status-warning/40 rounded-lg p-3 text-xs text-status-warning">
                     ⚠️ Este registro foi gerado pela simulação e não representa um dado operacional real. 
                     Ele serve apenas para validar o fluxo de sincronização e reconciliação.
                   </div>


### PR DESCRIPTION
## Resumo
Terceira fatia do sweep de cores (§10 / task #42). Converte **17 ocorrências** de cores hardcoded para tokens do design system nos 3 pages do módulo tintométrico — **somente status real**.

## O que mudou (3 arquivos)
- **TintReconciliation**: mapa `diffTypeLabels` (match→success, divergence→warning, only_csv→info, only_sync→`status-purple`) + os 4 KPIs espelhando + 2 avisos "Dado Sintético / Mock" (warning).
- **TintMapping**: badge binário Mapeado(`success`)/Pendente(`warning`) — 2 callsites.
- **TintIntegrations**: modo de integração (shadow→warning, automatic→success) + heartbeat de conexão (Online→success, Sem heartbeat/Lento→warning).

Os pares `dark:` colapsam para um token único (theme-aware). Estados que já eram token (`Offline`=`text-destructive`, `Desabilitado`/`csv_only`=`muted`) foram preservados.

## Validação
- ✅ `bunx tsc --noEmit` (baseline) — exit 0
- ✅ Nenhum teste asserta nas strings de cor alteradas
- ✅ Os 3 arquivos ficaram **0 cores hardcoded** restantes
- Trocas 1:1 de className, sem mudança de lógica (17/17)

## Relação com #374
Fatia irmã/independente (arquivos disjuntos). Restante do sweep (~330) é decorativo/data-viz/acoplado → /design-review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)