### PR TITLE
feat(orcamento): Orçamento Rolling — Forecast de Aterrissagem (sub-PR A)

### DIFF
--- a/docs/FINANCEIRO_CONFIABILIDADE.md
+++ b/docs/FINANCEIRO_CONFIABILIDADE.md
@@ -223,6 +223,27 @@ Por título de `fin_contas_receber`, responde **"vale antecipar este recebível?
 
 **Onde:** helper `src/lib/financeiro/funding-helpers.ts` (vitest, 33 testes); edge `supabase/functions/fin-funding/index.ts` (master-only, compõe `fin-cashflow-engine` + `fin-next-best-action` (A4) + `empresa_configuracao_custos` + `fin_contas_receber`); tabela `fin_funding_inputs` (migration manual `20260526100000_fin_funding_inputs.sql`, RLS master-only); hook `useFunding` + `FundingInputsDialog` + página `/financeiro/funding` (decisão por título + planejador de cobertura). ⚠️ **Re-deploy da `fin-funding` necessário após o merge do sub-PR B** (compõe o A4 agora).
 
+## 🔧 Orçamento Rolling — Forecast de Aterrissagem (sub-PR A) (2026-05-27)
+
+Constrói SOBRE o "Orçado × Realizado" que já existia (`/financeiro/orcamento`): projeta **onde o ano FECHA** (`landing = realizado dos meses FECHADOS + forecast dos restantes`) e a **variância projetada** vs orçado anual. **Client-side** (helper puro testado + estende a página; **sem edge function, sem migration**). Metodologia revisada por **Codex em 2 etapas** (metodologia + spec) + 1 no plano.
+
+**Princípio (Codex): método POR LINHA, não média global** — pipeline ORDENADO `projetarDRE` (drivers usam a base *forecasted* da etapa anterior): `receita_bruta → deducoes → receita_liquida → cmv → demais → impostos → derivadas`.
+
+| Linha | Forecast |
+|---|---|
+| receita_bruta | sazonal ajustado (`receita_ano-1[mes] × fator_tendência_YTD`, cap [0,5;2,0]) → run-rate → orçado |
+| deduções / cmv | **driver razão-YTD** (% da receita_bruta / receita_líquida **forecasted**) |
+| despesas fixas / outras | run-rate dos meses fechados |
+| financeiras | média dos últimos 3 fechados |
+| **impostos** | **razão YTD** (Σimp/Σreceita fechados × receita FC) — **nunca média cega**; flag <3 fechados/<1 trimestre |
+| derivadas | **calculadas** (fórmulas FinDRE); orçado das derivadas **calculado das 11 linhas orçadas** |
+
+**Variância sign-aware** por conjunto literal (receita/derivadas-de-resultado acima=favorável; deduções/cmv/despesas/impostos acima=desfavorável) + `fura_meta` = `|var| > max(10%×orçado, piso)` (orçado≤0 → só piso). **Mês corrente parcial NÃO entra na base nem no realizado** (só meses fechados). **Degradação honesta:** 0 fechados→sem forecast; <3→confiança baixa; denominador de driver ≤0 → run-rate + flag (sem NaN); orçado AUSENTE (≠ zero) → variância não computável. **Por empresa.**
+
+**Limitações v1 / o que ficou pro sub-PR B + v2:** versionamento/snapshot histórico do forecast = v2; impostos regime-aware (compõe `fin-regime-tributario`) = v2; decomposição de variância volume/preço/mix = v2; consolidado cross-CNPJ = v2. **sub-PR B (plano à parte):** drill de variância por categoria (reusa `getAnaliseDimensional`) + seed de baixa fricção (`seedOrcamento` winsorizado). ⚠️ **Follow-up de regime:** a página exibe badge "Regime de Caixa" mas chama `getDRE` no default `competencia` — v1 manteve consistência (competência explícita nos dois); confirmar com o founder qual é o correto e alinhar as duas telas.
+
+**Onde:** helper `src/lib/financeiro/orcamento-forecast-helpers.ts` (vitest, 20 testes; `projetarDRE` + primitivas); página `src/pages/FinanceiroOrcamento.tsx` (seção "Forecast de aterrissagem"); item na sidebar (`/financeiro/orcamento`, antes órfã). **Sem migration, sem edge function, sem deploy** (client-side puro).
+
 ## ✅ MVP Operacional (pode usar agora para gestão diária)
 
 Estes dados vêm direto do Omie sem transformação opinativa.

--- a/docs/superpowers/plans/2026-05-27-orcamento-rolling.md
+++ b/docs/superpowers/plans/2026-05-27-orcamento-rolling.md
@@ -1,0 +1,246 @@
+# Orçamento Rolling — Plano sub-PR A: Forecast de Aterrissagem + Variância Projetada
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Passos com checkbox. **Regra desta fronteira: Codex em todas as etapas** (metodologia ✓, spec ✓ [2 passes], plano ✓ [1 passe — findings incorporados abaixo], código ← Codex adversarial na Task 4).
+
+**Goal:** Projetar onde o ano FECHA (realizado dos meses fechados + forecast dos restantes, por método-por-linha) e a variância projetada vs orçado, sobre a página `/financeiro/orcamento` que já existe. Client-side, sem edge function, sem migration.
+
+**Architecture:** Helper puro TDD `src/lib/financeiro/orcamento-forecast-helpers.ts` (orquestrador ordenado `projetarDRE`) + estende `src/pages/FinanceiroOrcamento.tsx` + item na sidebar. Reusa `getDRE(company, ano, undefined, regime)` (ano e ano-1) + `getOrcamento`.
+
+**Tech Stack:** TypeScript, vitest, React + shadcn/ui. **Spec:** `docs/superpowers/specs/2026-05-27-orcamento-rolling-design.md`.
+
+**⚠️ Decisões travadas pelo Codex (plano):**
+- **Nomes das derivadas = FinDRE** (não inventar): `receita_liquida, lucro_bruto, resultado_operacional, resultado_antes_impostos, resultado_liquido`.
+- **Regime explícito**: o helper é regime-AGNÓSTICO (recebe os arrays de DRE). A página passa **um** regime consistente pros dois (ano + ano-1). ⚠️ A página atual chama `getDRE` no default (`competencia`) mas exibe badge "Regime de Caixa" — **inconsistência pré-existente**; a Task 3 deixa o regime explícito e há um item de follow-up pra confirmar com o founder qual é o correto. v1: usar o MESMO que a comparação orçado×realizado existente já usa (consistência) = `competencia` (default atual), explícito.
+- **`orcado` distingue AUSENTE de ZERO**: `Partial<Record<LinhaInput, (number|null)[]>>` — chave ausente OU todos null → `orcado_ano=null` (variância não computável). Senão soma `(x ?? 0)`.
+
+---
+
+### Task 0: Branch + spec (FEITO)
+- [x] Branch `feat/orcamento-rolling` de `origin/main`. Spec commitada (2 passes Codex).
+
+---
+
+### Task 1: Helper — primitivas (TDD)
+
+**Files:** Create `src/lib/financeiro/orcamento-forecast-helpers.ts` + `__tests__/orcamento-forecast-helpers.test.ts`
+
+```ts
+export const LINHAS_INPUT = ['receita_bruta','deducoes','cmv','despesas_operacionais','despesas_administrativas','despesas_comerciais','despesas_financeiras','receitas_financeiras','outras_receitas','outras_despesas','impostos'] as const;
+export type LinhaInput = typeof LINHAS_INPUT[number];
+export const LINHAS_RECEITA = new Set<string>(['receita_bruta','receitas_financeiras','outras_receitas']);
+export const LINHAS_DESPESA_FIXA = new Set<string>(['despesas_operacionais','despesas_administrativas','despesas_comerciais']); // run-rate
+export const LINHAS_FINANCEIRA = new Set<string>(['receitas_financeiras','despesas_financeiras']); // média móvel 3m
+export const LINHAS_DERIV_FAVORAVEL_CIMA = new Set<string>(['receita_liquida','lucro_bruto','resultado_operacional','resultado_antes_impostos','resultado_liquido']);
+export type MesDRE = { mes: number } & Partial<Record<LinhaInput, number>>;
+export type DerivadasResult = { receita_liquida: number; lucro_bruto: number; resultado_operacional: number; resultado_antes_impostos: number; resultado_liquido: number };
+```
+
+- [ ] **Step 1: testes que falham** — `mesesFechados`, `razaoYTD`, `fatorTendenciaYTD`, `derivarLinhas`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { mesesFechados, razaoYTD, fatorTendenciaYTD, derivarLinhas } from '../orcamento-forecast-helpers';
+
+describe('mesesFechados', () => {
+  it('ano corrente exclui o mês corrente e futuros', () => { expect(mesesFechados(2026, new Date('2026-05-15'))).toEqual([1,2,3,4]); });
+  it('ano passado = 12', () => { expect(mesesFechados(2025, new Date('2026-05-15'))).toHaveLength(12); });
+  it('ano futuro = []', () => { expect(mesesFechados(2027, new Date('2026-05-15'))).toEqual([]); });
+});
+describe('razaoYTD', () => {
+  it('Σnum/Σden', () => { expect(razaoYTD([10,20],[100,100])).toBeCloseTo(0.15,6); });
+  it('denominador <=0 → null', () => { expect(razaoYTD([10],[0])).toBeNull(); expect(razaoYTD([10],[-5])).toBeNull(); });
+  it('vazio → null', () => { expect(razaoYTD([],[])).toBeNull(); });
+});
+describe('fatorTendenciaYTD', () => {
+  it('Σreceita atual / ano-1 (mesmos meses), cap [0.5,2.0]', () => {
+    expect(fatorTendenciaYTD([{mes:1,receita_bruta:110},{mes:2,receita_bruta:130}],[{mes:1,receita_bruta:100},{mes:2,receita_bruta:100}],[1,2])).toBeCloseTo(1.2,6);
+  });
+  it('cap superior 2.0', () => { expect(fatorTendenciaYTD([{mes:1,receita_bruta:500}],[{mes:1,receita_bruta:100}],[1])).toBe(2.0); });
+  it('base ano-1 <=0 → null', () => { expect(fatorTendenciaYTD([{mes:1,receita_bruta:100}],[],[1])).toBeNull(); });
+});
+describe('derivarLinhas', () => {
+  it('fórmulas e sinais (FinDRE)', () => {
+    const d = derivarLinhas({ receita_bruta:1000, deducoes:100, cmv:400, despesas_operacionais:50, despesas_administrativas:30, despesas_comerciais:20, receitas_financeiras:10, despesas_financeiras:5, outras_receitas:0, outras_despesas:0, impostos:40 });
+    expect(d.receita_liquida).toBe(900);
+    expect(d.lucro_bruto).toBe(500);
+    expect(d.resultado_operacional).toBe(400);
+    expect(d.resultado_antes_impostos).toBe(405); // 400 +10 -5 +0 -0
+    expect(d.resultado_liquido).toBe(365); // 405 - 40
+  });
+  it('campos omitidos = 0, sem NaN (Codex P3)', () => {
+    const d = derivarLinhas({ receita_bruta:500 });
+    expect(d.receita_liquida).toBe(500); expect(Number.isNaN(d.resultado_liquido)).toBe(false); expect(d.resultado_liquido).toBe(500);
+  });
+});
+```
+
+- [ ] **Step 2-4: TDD.** Impl:
+  - `mesesFechados(ano, hoje=new Date())`: `ano<hoje.getFullYear()`→1..12; `>`→[]; `=`→`1..(hoje.getMonth())` (getMonth 0-based → mês corrente em curso excluído).
+  - `razaoYTD(num[],den[])`: `s=Σden`; `s<=0`→null; senão `Σnum/s`.
+  - `fatorTendenciaYTD(atual,anoAnt,fechados)`: soma `receita_bruta` nos `fechados` de cada; base anoAnt `<=0`→null; senão `clamp(somaAtual/somaAnt,0.5,2.0)`.
+  - `derivarLinhas(i)`: usa `(i.x ?? 0)`; aplica as 5 fórmulas FinDRE.
+- [ ] **Step 5: commit** — `feat(orcamento): primitivas de forecast + testes`.
+
+---
+
+### Task 2: Helper — `projetarDRE` (pipeline ordenado) + variância (TDD)
+
+**Contrato:**
+```ts
+export type MetodoForecast = 'sazonal_ajustado'|'run_rate'|'driver_receita'|'media_movel'|'razao_ytd_imposto'|'orcado_remanescente'|'sem_forecast';
+export type ForecastLinha = { dre_linha: string; realizado_fechado: number; forecast_restante: number; landing: number; orcado_ano: number|null; variancia: number|null; favoravel: boolean|null; fura_meta: boolean; metodo: MetodoForecast; confianca: 'alta'|'media'|'baixa'; flags: string[] };
+export type ForecastResult = { company: string; ano: number; meses_fechados: number; linhas: ForecastLinha[]; confianca_geral: 'alta'|'media'|'baixa'; motivos: string[] };
+export function projetarDRE(input: {
+  company: string; ano: number; hoje?: Date;
+  dreAtual: MesDRE[]; dreAnoAnterior: MesDRE[];
+  orcado: Partial<Record<LinhaInput, (number|null)[]>>; // [mes-1]; chave ausente/all-null → orcado_ano=null
+  pisoFuraMeta?: number; // default 5000
+}): ForecastResult;
+```
+
+**Ordem topológica (por mês restante), depois agrega:**
+`receita_bruta` → `deducoes (driver razaoYTD ded/receita × receita_bruta_FC)` → `receita_liquida (calc)` → `cmv (driver razaoYTD cmv/recliq × receita_liquida_FC)` → despesas fixas (run-rate) / financeiras (média 3m) / outras (run-rate) → `impostos (razaoYTD imp/receita × receita_bruta_FC)` → derivadas (calc).
+**Métodos por linha:** `receita_bruta`: sazonal_ajustado se `fator!=null` E há `ano-1[mes]`; senão run-rate (média fechados); senão orcado_remanescente. **Despesas: lista LITERAL** (`LINHAS_DESPESA_FIXA`=run-rate; `LINHAS_FINANCEIRA`=média últimos 3 fechados; `outras_*`=run-rate). **Guard:** driver com `razaoYTD==null` (denominador≤0) → degrada p/ run-rate da própria linha + flag `denominador_zero`.
+**orcado_ano:** input = `null` se chave ausente/all-null, senão `Σ(x??0)`. **Derivadas (landing E orcado_ano): `derivarLinhas`** (orcado: inputs null→0, flag `orcado_incompleto` se algum input null).
+**Variância:** `variancia=landing−orcado_ano` (null se orcado_ano null). `favoravel = (LINHAS_RECEITA.has(l)||LINHAS_DERIV_FAVORAVEL_CIMA.has(l)) ? variancia>=0 : variancia<=0`. `fura_meta = variancia!=null && |variancia| > (orcado_ano>0 ? max(0.10*orcado_ano, piso) : piso)`.
+**Confiança (precedência):** `meses_fechados===0` → todas `sem_forecast`/forecast_restante=0/confianca baixa + motivo "aguardando 1º mês fechado". Senão por linha: guard-degradado (denominador_zero) OU `<3` fechados em linha variável (receita/cmv/comerciais) OU imposto `<3` fechados → **baixa**; sazonal indisponível→run-rate (sem ano-1) → **media**; senão **alta**. `confianca_geral` = pior das linhas com orçado.
+
+- [ ] **Step 1: testes que falham — ASSERTIVOS (forecasted DIVERGE do histórico; Codex P1):**
+
+```ts
+import { projetarDRE, LINHAS_INPUT } from '../orcamento-forecast-helpers';
+// orçado: por padrão AUSENTE (não zero). orcUniforme preenche só as linhas passadas.
+const orcUniforme = (vals: Partial<Record<string,number>>) => { const o: Partial<Record<string, (number|null)[]>> = {}; for (const k of Object.keys(vals)) o[k as never] = Array(12).fill(vals[k]); return o; };
+
+it('0 meses fechados → sem forecast, forecast_restante=0, sem NaN', () => {
+  const r = projetarDRE({ company:'oben', ano:2026, hoje:new Date('2026-01-10'), dreAtual:[], dreAnoAnterior:[], orcado:orcUniforme({receita_bruta:100}) });
+  expect(r.meses_fechados).toBe(0);
+  const rb = r.linhas.find(l=>l.dre_linha==='receita_bruta')!;
+  expect(rb.metodo).toBe('sem_forecast'); expect(rb.forecast_restante).toBe(0); expect(Number.isFinite(rb.landing)).toBe(true);
+});
+
+it('sazonal ajustado É USADO e deduções/cmv usam a base FORECASTED (não histórica)', () => {
+  // hoje fev → fechado jan. atual jan receita 120; ano-1 jan-dez receita 100/mês.
+  // fator = 120/100 = 1.2 → forecast receita de cada mês restante = 100(ano-1) × 1.2 = 120.
+  // deducoes jan=12 → razão 12/120=0.10 → forecast deducoes mês = 0.10×120=12.
+  // cmv jan=48 → receita_liquida jan=108 → razão 48/108=0.4444 → forecast cmv mês=0.4444×(120-12)=48.
+  const anoAnt = Array.from({length:12},(_,i)=>({mes:i+1, receita_bruta:100, deducoes:10, cmv:40}));
+  const r = projetarDRE({ company:'oben', ano:2026, hoje:new Date('2026-02-10'), dreAtual:[{mes:1,receita_bruta:120,deducoes:12,cmv:48}], dreAnoAnterior:anoAnt, orcado:{} });
+  const rb = r.linhas.find(l=>l.dre_linha==='receita_bruta')!;
+  expect(rb.metodo).toBe('sazonal_ajustado');
+  expect(rb.forecast_restante).toBeCloseTo(120*11, 0); // 11 meses restantes (fev-dez) × 120
+  const ded = r.linhas.find(l=>l.dre_linha==='deducoes')!;
+  expect(ded.forecast_restante).toBeCloseTo(12*11, 0); // prova driver sobre receita FORECASTED (120), não histórica
+  const cmv = r.linhas.find(l=>l.dre_linha==='cmv')!;
+  expect(cmv.forecast_restante).toBeCloseTo(48*11, 0); // prova cmv sobre receita_liquida FORECASTED
+});
+
+it('imposto razão-YTD ≠ média mensal (números divergentes)', () => {
+  // fechados jan(imp 0, rec 100), fev(imp 60, rec 200), mar(imp 0, rec 100). hoje abr.
+  // média mensal imposto = 20/mês × 9 = 180. razão YTD = 60/400=0.15; receita run-rate=400/3≈133.3/mês ×9=1200; imposto=0.15×1200=180? 
+  // → escolher números que divirjam: rec jan100/fev100/mar100 (run-rate=100), imp 0/0/45 → razão=45/300=0.15 → forecast=0.15×100×9=135; média mensal=15×9=135 (igual). 
+  // Pra divergir: rec 100/100/400 (run-rate=200/mês), imp 0/0/60 → razão=60/600=0.10 → 0.10×200×9=180; média mensal imposto=20×9=180 (ainda igual pois receita média ∝). 
+  // Divergência real: receita NÃO constante no forecast. Use sazonal: ano-1 dá receita restante alta enquanto imposto YTD baixo.
+  const anoAnt = Array.from({length:12},(_,i)=>({mes:i+1, receita_bruta:300}));
+  const dre = [{mes:1,receita_bruta:100,impostos:5},{mes:2,receita_bruta:100,impostos:5},{mes:3,receita_bruta:100,impostos:5}]; // razão=15/300=0.05
+  const r = projetarDRE({ company:'colacor', ano:2026, hoje:new Date('2026-04-10'), dreAtual:dre, dreAnoAnterior:anoAnt, orcado:{} });
+  const imp = r.linhas.find(l=>l.dre_linha==='impostos')!;
+  expect(imp.metodo).toBe('razao_ytd_imposto');
+  // fator tendência=300/(3×300? não, mesmos meses fechados jan-mar ano-1=900) → 300/900=0.333 → cap 0.5 → receita FC mês=300×0.5=150
+  // imposto FC = 0.05 × 150 × 9 = 67.5  (média mensal seria 5×9=45 → DIVERGE)
+  expect(imp.forecast_restante).toBeCloseTo(0.05*150*9, 0);
+  expect(imp.forecast_restante).not.toBeCloseTo(5*9, 0);
+});
+
+it('mês corrente PARCIAL não entra na base nem no landing por realizado', () => {
+  // hoje maio. fechados jan-abr receita 100/mês. maio parcial ENORME (9999) presente em dreAtual.
+  const dre = [1,2,3,4].map(m=>({mes:m, receita_bruta:100})).concat([{mes:5, receita_bruta:9999}]);
+  const r = projetarDRE({ company:'oben', ano:2026, hoje:new Date('2026-05-20'), dreAtual:dre, dreAnoAnterior:[], orcado:{} });
+  const rb = r.linhas.find(l=>l.dre_linha==='receita_bruta')!;
+  expect(rb.realizado_fechado).toBe(400); // só jan-abr; maio parcial NÃO entra
+  expect(rb.forecast_restante).toBeCloseTo(100*8,0); // run-rate 100 × 8 (mai-dez)
+});
+
+it('variância sign-aware — parametrizado, nenhuma invertida', () => {
+  // landing > orcado em TODAS. receita acima=favorável; custo/dedução/imposto acima=desfavorável.
+  // monta dreAtual com 12 meses fechados (ano passado) p/ landing=realizado; orçado menor.
+  const dre = Array.from({length:12},(_,i)=>({mes:i+1, receita_bruta:100, deducoes:10, cmv:40, despesas_operacionais:5, despesas_administrativas:5, despesas_comerciais:5, despesas_financeiras:2, receitas_financeiras:3, outras_receitas:1, outras_despesas:1, impostos:8 }));
+  const orc: Partial<Record<string,(number|null)[]>> = {}; for (const k of LINHAS_INPUT) orc[k] = Array(12).fill(1); // orçado baixo → landing>orçado
+  const r = projetarDRE({ company:'oben', ano:2025, hoje:new Date('2026-05-10'), dreAtual:dre, dreAnoAnterior:[], orcado:orc });
+  const fav = (l:string)=> r.linhas.find(x=>x.dre_linha===l)!.favoravel;
+  expect(fav('receita_bruta')).toBe(true); expect(fav('receitas_financeiras')).toBe(true); expect(fav('outras_receitas')).toBe(true);
+  expect(fav('deducoes')).toBe(false); expect(fav('cmv')).toBe(false); expect(fav('despesas_financeiras')).toBe(false); expect(fav('impostos')).toBe(false);
+  expect(fav('resultado_liquido')).toBe(true); // derivada de resultado acima → favorável
+});
+
+it('orçado AUSENTE → variancia null (não 0)', () => {
+  const dre = Array.from({length:12},(_,i)=>({mes:i+1, receita_bruta:100}));
+  const r = projetarDRE({ company:'oben', ano:2025, hoje:new Date('2026-05-10'), dreAtual:dre, dreAnoAnterior:[], orcado:{} }); // nada orçado
+  const rb = r.linhas.find(l=>l.dre_linha==='receita_bruta')!;
+  expect(rb.orcado_ano).toBeNull(); expect(rb.variancia).toBeNull(); expect(rb.fura_meta).toBe(false);
+});
+
+it('fura_meta com orcado<=0 usa só piso', () => {
+  const dre = Array.from({length:12},(_,i)=>({mes:i+1, outras_despesas:500})); // landing=6000
+  const orc = { outras_despesas: Array(12).fill(0) }; // orçado 0
+  const r = projetarDRE({ company:'oben', ano:2025, hoje:new Date('2026-05-10'), dreAtual:dre, dreAnoAnterior:[], orcado:orc, pisoFuraMeta:5000 });
+  const od = r.linhas.find(l=>l.dre_linha==='outras_despesas')!;
+  expect(od.orcado_ano).toBe(0); expect(od.fura_meta).toBe(true); // |6000|>5000 piso; sem divisão por 0
+});
+
+it('denominador de driver <=0 → run-rate + flag, sem NaN/Infinity', () => {
+  // receita_bruta fechada = 0 (mas há deducoes) → razão deducoes/receita = null → run-rate
+  const dre = [{mes:1,receita_bruta:0,deducoes:10},{mes:2,receita_bruta:0,deducoes:10},{mes:3,receita_bruta:0,deducoes:10}];
+  const r = projetarDRE({ company:'oben', ano:2026, hoje:new Date('2026-04-10'), dreAtual:dre, dreAnoAnterior:[], orcado:{} });
+  const ded = r.linhas.find(l=>l.dre_linha==='deducoes')!;
+  expect(ded.flags).toContain('denominador_zero');
+  expect(Number.isFinite(ded.forecast_restante)).toBe(true);
+  expect(ded.forecast_restante).toBeCloseTo(10*9,0); // run-rate 10/mês × 9
+});
+
+it('derivadas: landing E orcado_ano calculados das 11 linhas (não null)', () => {
+  const dre = Array.from({length:12},(_,i)=>({mes:i+1, receita_bruta:100, deducoes:10, cmv:40, impostos:8 }));
+  const orc: Partial<Record<string,(number|null)[]>> = {}; for (const k of LINHAS_INPUT) orc[k]=Array(12).fill(k==='receita_bruta'?90: k==='deducoes'?9: k==='cmv'?36: k==='impostos'?7:0);
+  const r = projetarDRE({ company:'oben', ano:2025, hoje:new Date('2026-05-10'), dreAtual:dre, dreAnoAnterior:[], orcado:orc });
+  const rl = r.linhas.find(l=>l.dre_linha==='resultado_liquido')!;
+  expect(rl.landing).toBeCloseTo(12*(100-10-40-8),0); // 42×12=504
+  expect(rl.orcado_ano).toBeCloseTo(12*(90-9-36-7),0); // 38×12=456 (NÃO null)
+  expect(rl.variancia).toBeCloseTo(504-456,0);
+});
+```
+
+- [ ] **Step 2-4: TDD** — ver falhar → implementar `projetarDRE` na ordem topológica → ver passar. **Nenhum `NaN`/`Infinity` em nenhum campo.**
+- [ ] **Step 5: commit** — `feat(orcamento): projetarDRE (pipeline ordenado) + variância sign-aware + degradação`.
+
+---
+
+### Task 3: Página — seção "Forecast de aterrissagem" + sidebar
+
+**Files:** Modify `src/pages/FinanceiroOrcamento.tsx`, `src/components/AppShell.tsx`.
+
+- [ ] **Step 1 — adapter explícito (Codex P2):** na página, montar:
+  - `dreAtual = await getDRE(company, ano, undefined, REGIME)` e `dreAnoAnterior = await getDRE(company, ano-1, undefined, REGIME)`, com **`REGIME` explícito** = o mesmo que a comparação existente usa (hoje default `'competencia'` — manter consistente; ⚠️ ver follow-up de regime).
+  - `orcado: Partial<Record<LinhaInput,(number|null)[]>>` a partir de `orcamento`/`draft`: pra cada linha que tem AO MENOS uma entrada, array de 12 (`mes` sem valor → 0); linha sem NENHUMA entrada → **omitir a chave** (→ orcado_ano null). NÃO inicializar tudo com zero.
+  - `const fc = projetarDRE({ company, ano, dreAtual, dreAnoAnterior, orcado })`.
+- [ ] **Step 2 — render:** card "Forecast de aterrissagem {ano}" com tabela por linha (inputs + 5 derivadas, na ordem do DRE): **Landing** (`realizado_fechado`+`forecast_restante`), **Orçado ano** (`—` se null), **Variância** (`text-status-success` se favoravel, `text-status-error` senão; `—` se null), **% vs orçado**, badge **"vai furar a meta"** se `fura_meta`, chips **método** + **confiança**. Banner quando `meses_fechados===0`. Labels das derivadas: mapa próprio (FinDRE não está em `DRE_LINHAS`). NUNCA `text-emerald/red-600`.
+- [ ] **Step 3 — sidebar:** `AppShell.tsx` item `{ icon: Target, label: 'Orçamento', path: '/financeiro/orcamento' }` na seção Financeiro (rota órfã hoje). Mesmo gate da seção.
+- [ ] **Step 4:** `bunx tsc --noEmit -p tsconfig.app.json` + `bun lint` limpos.
+- [ ] **Step 5: commit** — `feat(orcamento): seção Forecast de aterrissagem + sidebar`.
+
+---
+
+### Task 4: Docs + validação + Codex adversarial + PR
+
+- [ ] **Step 1:** seção no `docs/FINANCEIRO_CONFIABILIDADE.md` (método-por-linha, pipeline ordenado, imposto razão-YTD, variância sign-aware, regime explícito + ⚠️ follow-up caixa×competência, degradação, limitações v1, sub-PR B pendente).
+- [ ] **Step 2: validação** — `heavy bun run test` + `heavy bun run typecheck:strict` + `bunx tsc --noEmit -p tsconfig.app.json` + `bun lint` + `heavy bun run build`.
+- [ ] **Step 3: Codex ADVERSARIAL no código** (`orcamento-forecast-helpers.ts` + integração): ordem do pipeline no código, sinais das derivadas, sign-aware nas 16 linhas, guards NaN, imposto razão-YTD, adapter orçado ausente×zero. Incorporar P1/P2.
+- [ ] **Step 4: PR** — push; `gh pr create` (sem migration/deploy — client-side); auto-merge `--squash --auto`.
+
+---
+
+## Notas
+- **Sem migration, sem edge function** — client-side sobre `fin_orcamento`/DRE.
+- **`tsc --noEmit -p tsconfig.app.json`** é o typecheck que pega o `src`.
+- **Codex em todas as etapas**: metodologia ✓, spec ✓, plano ✓, código (Task 4 adversarial).
+- **Follow-up de regime** (não bloqueia v1): confirmar com o founder se o orçamento é caixa ou competência (a página exibe "Regime de Caixa" mas chama `getDRE` no default competência). v1 mantém consistência com a comparação existente; corrigir nas duas telas juntas se for bug.
+- **sub-PR B (plano separado):** drill de variância por categoria (`getAnaliseDimensional`) + seed winsorizado (`seedOrcamento`).

--- a/docs/superpowers/specs/2026-05-27-orcamento-rolling-design.md
+++ b/docs/superpowers/specs/2026-05-27-orcamento-rolling-design.md
@@ -1,0 +1,152 @@
+# Orçamento Rolling — Design (forecast de aterrissagem + variância projetada)
+
+**Data:** 2026-05-27
+**Programa:** Estado da Arte do Financeiro (fronteira #3, após Funding & dívida)
+**Status:** scope aprovado ("rolling completo") + 1 passe Codex na metodologia incorporado. (Regra desta fronteira: **Codex em todas as etapas** — metodologia ✓, spec, plano, código.)
+
+## Objetivo
+
+Transformar o **"Orçado × Realizado" que já existe** num **orçamento rolling**: projetar **onde o ano vai fechar** (forecast de aterrissagem) vs. o orçado, com a **variância projetada** por linha, e tornar o orçamento mais usável (drill de variância + seed de baixa fricção + descoberta na sidebar).
+
+## Contexto — o que JÁ existe (NÃO reimplementar)
+
+- **`fin_orcamento`** (`company, ano, mes, dre_linha, valor_orcado, notas`) — orçamento mensal por linha de DRE. CRUD em `financeiroV2Service.ts` (`getOrcamento`/`upsertOrcamento`, upsert `onConflict: company,ano,mes,dre_linha`).
+- **`src/pages/FinanceiroOrcamento.tsx`** ("Orçado × Realizado") — rota viva `/financeiro/orcamento`: grid editável de orçamento, realizado via `getDRE(company, ano)` (DRE v2 mensal, **regime de CAIXA**), resumo YTD (orçado vs realizado vs variação% + favorável/desfavorável sign-aware) e grid mensal orçado/real/diff + audit trail. **NÃO está na sidebar** (só por URL).
+- **Análise dimensional** (`financeiroV2Service.getAnaliseDimensional`) — CR/CP por categoria/departamento/centro_custo/vendedor/cliente/fornecedor. Reusável no drill de variância.
+- **Linhas DRE** (`DRE_LINHAS`): orçáveis = `receita_bruta, deducoes, cmv, despesas_operacionais, despesas_administrativas, despesas_comerciais, despesas_financeiras, receitas_financeiras, outras_receitas, outras_despesas, impostos`. Derivadas (em `FinDRE`, NÃO orçadas) = `receita_liquida, lucro_bruto, resultado_operacional, lucro_liquido`.
+
+## Princípio (Codex): método POR LINHA, não média global
+
+Não "preencher o ano com a média" (vira calculadora de falsa precisão). **Projetar o restante com premissa coerente pra NATUREZA de cada linha**, **por empresa** (Simples × Presumido não consolidam ingênuo — v1 é por-empresa, sem consolidado), com **degradação honesta** (bloqueia o forecast em vez de fabricar número).
+
+---
+
+## Sub-PR A — Forecast de aterrissagem + variância projetada
+
+### Landing por linha
+`landing_linha = Σ realizado(meses FECHADOS) + Σ forecast(meses restantes)`.
+- **Mês fechado** = mês < mês corrente (no ano corrente) — totalmente realizado. **O mês corrente é "em curso"** e entra no landing pelo **forecast**, NÃO pelo realizado parcial cru (incluir o parcial subestima — Codex [a]).
+- Ano passado/fechado: todos os 12 meses são realizados → landing = realizado (sem forecast).
+
+### Semântica das linhas (precondição — Codex [P1.1])
+**`deducoes` e `impostos` são DISJUNTOS** (senão o `lucro_liquido` subtrai imposto 2×). Conforme o mapeamento do DRE v2 (Onda 3a): **`deducoes`** = tributos **sobre receita** (ICMS/ISS/PIS/COFINS/IPI) + devoluções/abatimentos; **`impostos`** = **IRPJ/CSLL** (e, no Simples, a parcela do DAS que o DRE v2 NÃO alocou em deduções). Todas as 11 linhas orçáveis são **magnitudes positivas** (deduções/cmv/despesas/impostos subtraem). As **derivadas** são calculadas pela **mesma fórmula que o DRE v2 usa no realizado** (consistência realizado↔forecast). Se o mapeamento de uma empresa não deixar deduções/impostos limpos → flag + confiança baixa (não fabrica).
+
+### Forecast é um PIPELINE ORDENADO (não função por-linha isolada — Codex [P1.3])
+Os drivers criam dependência → a ordem importa. `projetarDRE(company, ano, dreFechado[], dreAnoAnterior[], orcado[])` projeta **mês a mês restante** nesta ordem topológica, e só então agrega:
+`receita_bruta → deducoes (driver s/ receita_bruta forecasted) → receita_liquida (calc) → cmv (driver s/ receita_liquida forecasted) → despesas_* / financeiras / outras → impostos → derivadas (calc)`.
+
+### Matriz de método por linha
+
+| Linha | Método |
+|---|---|
+| `receita_bruta` | **sazonal AJUSTADO por tendência** (Codex [P2.2]): `receita_mes_ano_anterior × fator_tendencia`, com `fator = Σreceita_YTD_fechado_atual / Σreceita_YTD_mesmos_meses_ano_anterior` (cap em [0,5; 2,0] + flag se fora) — exige ≥12m histórico. Senão **run-rate** (média dos meses fechados). Senão **orçado remanescente** (fallback). |
+| `deducoes` | **driver**: `(Σdeducoes_fechado / Σreceita_bruta_fechado)` × receita_bruta forecasted do mês. |
+| `cmv` | **driver**: `(Σcmv_fechado / Σreceita_liquida_fechado)` × receita_liquida forecasted do mês (margem histórica). |
+| `despesas_administrativas`, `despesas_operacionais` | **run-rate** (média dos meses fechados). |
+| `despesas_comerciais` | v1: **run-rate** (separação fixa+variável formal = v2 → flag). |
+| `receitas_financeiras`, `despesas_financeiras` | **média dos últimos 3 meses fechados** (ou todos os fechados se <3). |
+| `outras_receitas`, `outras_despesas` | run-rate (esporádicas → flag de baixa confiança). |
+| `impostos` | **razão YTD** (Codex [P1.4]): `(Σimpostos_fechado / Σreceita_bruta_fechado)` × receita_bruta forecasted — suaviza a lumpiness do IRPJ/CSLL trimestral em caixa. **NUNCA média mensal cega**. **Flag/confiança baixa** quando <3 meses fechados OU <1 trimestre completo (Presumido tem recolhimento trimestral → razão pode nascer 0). Regime-aware (compor `fin-regime-tributario`) = **v2**. |
+| **derivadas** | **SEMPRE calculadas** dos inputs forecasted (fórmulas abaixo, idênticas ao DRE v2) — nunca orçadas direto. |
+
+**Fórmulas das derivadas** (inputs como magnitudes positivas; deduções/cmv/despesas/impostos subtraem; **idênticas ao DRE v2** p/ consistência):
+- `receita_liquida = receita_bruta − deducoes`
+- `lucro_bruto = receita_liquida − cmv`
+- `resultado_operacional = lucro_bruto − despesas_operacionais − despesas_administrativas − despesas_comerciais`
+- `lucro_liquido = resultado_operacional + receitas_financeiras − despesas_financeiras + outras_receitas − outras_despesas − impostos`
+
+⚠️ As derivadas NÃO contêm impostos em duplicidade: `deducoes` = tributos sobre receita; `impostos` = IRPJ/CSLL/DAS — disjuntos (ver "Semântica das linhas").
+
+### Orçado anual das derivadas (Codex [P1.2])
+As derivadas **não existem em `fin_orcamento`** (só as 11 linhas-input são orçadas). O `orcado_ano` de cada derivada é **calculado das 11 linhas orçadas** pelas MESMAS fórmulas acima (ex.: `orcado_lucro_liquido = orcado_resultado_operacional + orcado_receitas_financeiras − … − orcado_impostos`). Sem isso a variância das derivadas compararia contra null/zero (sinal errado). Tanto `landing` quanto `orcado_ano` das derivadas usam as mesmas fórmulas.
+
+### Variância projetada (sign-aware — Codex [P2.1])
+`variancia_linha = landing − orcado_ano` por linha.
+- **Conjunto EXPLÍCITO de receita** `LINHAS_RECEITA = {receita_bruta, receitas_financeiras, outras_receitas}` + as derivadas de resultado `{receita_liquida, lucro_bruto, resultado_operacional, lucro_liquido}`: landing > orçado → **favorável**.
+- **Todas as outras** (`deducoes`, `cmv`, `despesas_operacionais`, `despesas_administrativas`, `despesas_comerciais`, `despesas_financeiras`, `outras_despesas`, `impostos`): landing > orçado → **desfavorável**.
+- ⚠️ Classificação por **conjunto literal de linhas** (NÃO prefixo `despesas_*` — `despesas_financeiras` não pode cair no balaio de "financeira/receita"). Teste **parametrizado nas 11 linhas + 4 derivadas**.
+- **Alerta "vai furar a meta"**: `|variancia| > max(0,10 × |orcado_ano|, piso_absoluto_R$)`; se `orcado_ano <= 0` → usa **só o piso absoluto** (evita divisão/ruído — Codex [P3.2]).
+- ⚠️ Ressalva (Codex [e]): despesa **menor** que o orçado é "favorável contábil" mas pode ser subinvestimento — v1 mostra o sinal contábil + **nota**; decomposição volume/preço/mix = v2.
+
+### Confiança / bloqueio honesto (Codex [P2.4]/[g])
+- **0 meses fechados** no ano corrente → **sem forecast** (mostra só orçado + "aguardando 1º mês fechado").
+- **<3 meses fechados** p/ linha variável (receita/cmv/comerciais) → forecast com **confiança baixa** + flag.
+- **Sem ≥12m de histórico** → receita cai de sazonal p/ run-rate (flag "sem sazonalidade").
+- **Denominador de driver ≤ 0** (Codex [P2.4]): `Σreceita_bruta_fechado ≤ 0` (deduções/impostos) ou `Σreceita_liquida_fechado ≤ 0` (cmv) → o driver NÃO roda (cairia em `NaN`/`Infinity`) → degrada p/ run-rate da própria linha + flag; se nem isso → sem forecast da linha.
+- **Imposto sem ciclo tributário completo** (<1 trimestre fechado, Presumido) → flag/confiança baixa.
+- Linha sem orçado → variância não computável (mostra só o landing).
+- **NUNCA fabrica** (padrão do programa).
+
+---
+
+## Sub-PR B — Variância inteligente + seed + sidebar
+
+- **Drill de variância**: ao expandir uma linha DRE com desvio, mostrar as **categorias** que mais contribuíram (reusa `getAnaliseDimensional('cr'|'cp', company, 'categoria', ano, mes)`). v1: top-N categorias por contribuição ao desvio. Decomposição volume/preço/mix = v2.
+- **Seed de baixa fricção**: botão "Sugerir orçamento {ano+1}" = realizado do ano (anualizado se parcial) × `(1 + crescimento%)` por linha. **Tratamento de one-off (Codex [P2.3]): winsoriza o outlier do CÁLCULO por padrão** (mês cujo valor desvia >Nσ da mediana é capado ao limite, NÃO entra cru) e mostra reconciliação ("X meses ajustados"). **Bloqueia o seed da linha** quando amostra é curta/esparsa (<3 meses com valor, ou linha esporádica `outras_*`) → não sugere número, marca "preencher manual". Preenche o draft; o founder revisa e salva. Reduz ~120 células digitadas.
+- **Sidebar**: adicionar `/financeiro/orcamento` na seção Financeiro do `AppShell` (label "Orçamento", ícone `Target`).
+
+---
+
+## Arquitetura
+
+**Client-side** (igual ao padrão da tela existente, que já roda `getDRE`+`getOrcamento` no front) — **SEM edge function**. Mantém impostos como **% da receita** (não compõe o regime engine master-only) pra ficar client-side e honesto.
+
+- Helper puro `src/lib/financeiro/orcamento-forecast-helpers.ts` (TDD) — toda a matemática (forecast por método, derivadas, variância sign-aware, confiança, seed). Não é espelhado em Deno (não há edge function).
+- Estende `src/pages/FinanceiroOrcamento.tsx`: nova seção/coluna "Forecast de aterrissagem" + variância projetada + drill + botão de seed.
+- Reusa `getDRE` (realizado, inclusive ano anterior p/ sazonalidade/seed via `getDRE(company, ano-1)`), `getOrcamento`/`upsertOrcamento`, `getAnaliseDimensional`.
+- **Sem migration** (reusa `fin_orcamento`). **Versionamento de forecast** (snapshot histórico) = **v2** — v1 recomputa ao vivo (determinístico) e **expõe método+params por linha** (transparência de "como o número foi feito").
+
+## Contrato de tipos (esboço)
+
+```ts
+type MetodoForecast = 'sazonal' | 'run_rate' | 'driver_receita' | 'media_movel' | 'orcado_remanescente' | 'imposto_pct_receita';
+
+type ForecastLinha = {
+  dre_linha: string;
+  realizado_fechado: number;   // Σ meses fechados
+  forecast_restante: number;   // Σ meses restantes
+  landing: number;             // realizado_fechado + forecast_restante
+  orcado_ano: number | null;
+  variancia: number | null;    // landing − orcado_ano
+  favoravel: boolean | null;   // sign-aware
+  fura_meta: boolean;          // |variancia| > threshold
+  metodo: MetodoForecast;
+  confianca: 'alta' | 'media' | 'baixa';
+  flags: string[];             // 'sem_orcado','sem_sazonalidade','poucos_meses','derivada','subinvestimento_possivel'
+};
+
+type ForecastResult = {
+  company: string; ano: number; meses_fechados: number;
+  linhas: ForecastLinha[];     // inputs + derivadas
+  confianca_geral: 'alta' | 'media' | 'baixa';
+  motivos: string[];
+};
+
+type SeedLinha = { dre_linha: string; mes: number; valor_sugerido: number | null; flag?: 'winsorizado' | 'amostra_curta_sem_sugestao' };
+```
+
+> O forecast é um **orquestrador ordenado** `projetarDRE(...)` (não `forecastLinha` isolado): projeta mês-a-mês na ordem topológica `receita_bruta → deducoes → receita_liquida → cmv → demais → impostos → derivadas`, garantindo que os drivers (deduções/cmv) usem a base **forecasted** da etapa anterior.
+
+## Degradação honesta (resumo)
+Sem mês fechado → sem forecast. <3 meses p/ linha variável → confiança baixa. Sem histórico p/ sazonal → run-rate + flag. Sem orçado → só landing. One-off no seed → flag, não cega. Nunca fabrica recomendação.
+
+## Escopo v1 vs v2
+**v1 (sub-PR A + B):** matriz de método por linha · landing = fechados + forecast(restantes) · mês corrente fora da base · variância projetada sign-aware + alerta de meta · bloqueio honesto · derivadas calculadas · por-empresa · drill por categoria (top-N) · seed histórico×crescimento com flag de outlier · sidebar.
+**v2:** versionamento/snapshot histórico do forecast (auditar "por que mudou") · impostos regime-aware (compõe `fin-regime-tributario`) · decomposição de variância volume/preço/mix · consolidado multi-empresa com eliminação intercompany · despesas comerciais fixa+variável formal (se a separação existir).
+
+## Plano de testes (helper, TDD)
+- `mesesFechados`: ano corrente exclui mês corrente; ano passado = 12.
+- **Ordem do pipeline `projetarDRE`**: deduções usam receita_bruta **forecasted** (não histórica); cmv usa receita_liquida **forecasted** (teste que prova a topological order).
+- métodos: run-rate (média fechados × restantes); **sazonal ajustado** (ano-1 mesmo mês × fator_tendencia_YTD; cap [0,5;2,0]); driver deduções/cmv (razão YTD); **imposto razão YTD** (não média mensal); média móvel (últimos 3 fechados); fallback orçado-remanescente.
+- mês corrente parcial NÃO entra na base.
+- derivadas (landing E orçado): `receita_liquida`/`lucro_bruto`/`resultado`/`lucro_liquido` corretas a partir dos inputs (sinais); **orçado das derivadas calculado das 11 linhas** (não null/zero).
+- **variância sign-aware PARAMETRIZADA nas 11 linhas + 4 derivadas** (conjunto literal): receita/derivadas-de-resultado acima → favorável; deduções/cmv/despesas/impostos acima → desfavorável; nenhuma invertida.
+- `fura_meta`: `|var| > max(10%×|orcado|, piso)`; `orcado<=0` → só piso (sem divisão).
+- **denominador de driver ≤ 0** → degrada p/ run-rate + flag (sem NaN/Infinity).
+- confiança/bloqueio: 0 fechados → sem forecast; <3 → baixa; sem histórico → run-rate+flag; imposto <1 trimestre (Presumido) → flag.
+- `seedOrcamento`: realizado×(1+g); anualiza parcial; **winsoriza outlier (>Nσ da mediana)** no cálculo; amostra curta/esparsa → `valor_sugerido: null` + flag (não fabrica).
+
+## Codex — findings incorporados (rastreabilidade)
+**Metodologia (passe 1):** método **por linha** ✅ · mês corrente parcial fora da base ✅ · sazonal só com histórico ✅ · derivadas calculadas ✅ · imposto nunca média cega ✅ · variância sign-aware ✅ · seed trata one-offs ✅ · bloqueio honesto ✅ · por empresa ✅.
+**Spec (passe 2):** [P1.1] disjunção semântica deduções×impostos (anti double-count) ✅ · [P1.2] orçado das derivadas calculado das 11 linhas ✅ · [P1.3] pipeline ordenado (drivers usam base forecasted) ✅ · [P1.4] imposto razão-YTD + flag Presumido/<trimestre ✅ · [P2.1] sign-aware por conjunto literal + teste parametrizado ✅ · [P2.2] sazonal ajustado por tendência YTD ✅ · [P2.3] seed winsoriza outlier + bloqueia amostra curta ✅ · [P2.4] guard de denominador ≤ 0 ✅ · [P3.1] janela da média móvel definida (3 fechados) ✅ · [P3.2] fura_meta com piso absoluto p/ orçado≤0 ✅.
+**Adiados:** versionamento/snapshot = v2 (v1 expõe método+params por linha) ⏳ · regime-aware tax = v2 ⏳ · decomposição volume/preço/mix = v2 ⏳ · consolidado cross-CNPJ = v2 ⏳.

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -126,6 +126,7 @@ const unifiedNavSections: { title: string; items: NavItem[] }[] = [
       { icon: Shield, label: 'Cockpit CFO', path: '/financeiro/cockpit', managerOnly: true },
       { icon: DollarSign, label: 'Gestão Financeira', path: '/financeiro/gestao', managerOnly: true },
       { icon: BarChart3, label: 'Análise e Config', path: '/financeiro/analise', managerOnly: true },
+      { icon: Target, label: 'Orçamento', path: '/financeiro/orcamento', managerOnly: true },
       { icon: TrendingUp, label: 'Retorno & Valor', path: '/financeiro/valor', masterOnly: true },
       { icon: Percent, label: 'Regime Tributário', path: '/financeiro/regime-tributario', masterOnly: true },
       { icon: Landmark, label: 'Custo de Funding', path: '/financeiro/funding', masterOnly: true },

--- a/src/lib/financeiro/__tests__/orcamento-forecast-helpers.test.ts
+++ b/src/lib/financeiro/__tests__/orcamento-forecast-helpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { mesesFechados, razaoYTD, fatorTendenciaYTD, derivarLinhas } from '../orcamento-forecast-helpers';
+import { mesesFechados, razaoYTD, fatorTendenciaYTD, derivarLinhas, projetarDRE, LINHAS_INPUT } from '../orcamento-forecast-helpers';
 
 describe('mesesFechados', () => {
   it('ano corrente exclui o mês corrente e futuros', () => { expect(mesesFechados(2026, new Date('2026-05-15'))).toEqual([1,2,3,4]); });
@@ -31,4 +31,104 @@ describe('derivarLinhas', () => {
     const d = derivarLinhas({ receita_bruta:500 });
     expect(d.receita_liquida).toBe(500); expect(Number.isNaN(d.resultado_liquido)).toBe(false); expect(d.resultado_liquido).toBe(500);
   });
+});
+
+// ─── Task 2: projetarDRE (pipeline ordenado) ───────────────────────────────
+// orçado: por padrão AUSENTE (não zero). orcUniforme preenche só as linhas passadas.
+const orcUniforme = (vals: Partial<Record<string,number>>) => { const o: Partial<Record<string, (number|null)[]>> = {}; for (const k of Object.keys(vals)) o[k as never] = Array(12).fill(vals[k]); return o; };
+
+it('0 meses fechados → sem forecast, forecast_restante=0, sem NaN', () => {
+  const r = projetarDRE({ company:'oben', ano:2026, hoje:new Date('2026-01-10'), dreAtual:[], dreAnoAnterior:[], orcado:orcUniforme({receita_bruta:100}) });
+  expect(r.meses_fechados).toBe(0);
+  const rb = r.linhas.find(l=>l.dre_linha==='receita_bruta')!;
+  expect(rb.metodo).toBe('sem_forecast'); expect(rb.forecast_restante).toBe(0); expect(Number.isFinite(rb.landing)).toBe(true);
+});
+
+it('sazonal ajustado É USADO e deduções/cmv usam a base FORECASTED (não histórica)', () => {
+  // hoje fev → fechado jan. atual jan receita 120; ano-1 jan-dez receita 100/mês.
+  // fator = 120/100 = 1.2 → forecast receita de cada mês restante = 100(ano-1) × 1.2 = 120.
+  // deducoes jan=12 → razão 12/120=0.10 → forecast deducoes mês = 0.10×120=12.
+  // cmv jan=48 → receita_liquida jan=108 → razão 48/108=0.4444 → forecast cmv mês=0.4444×(120-12)=48.
+  const anoAnt = Array.from({length:12},(_,i)=>({mes:i+1, receita_bruta:100, deducoes:10, cmv:40}));
+  const r = projetarDRE({ company:'oben', ano:2026, hoje:new Date('2026-02-10'), dreAtual:[{mes:1,receita_bruta:120,deducoes:12,cmv:48}], dreAnoAnterior:anoAnt, orcado:{} });
+  const rb = r.linhas.find(l=>l.dre_linha==='receita_bruta')!;
+  expect(rb.metodo).toBe('sazonal_ajustado');
+  expect(rb.forecast_restante).toBeCloseTo(120*11, 0); // 11 meses restantes (fev-dez) × 120
+  const ded = r.linhas.find(l=>l.dre_linha==='deducoes')!;
+  expect(ded.forecast_restante).toBeCloseTo(12*11, 0); // prova driver sobre receita FORECASTED (120), não histórica
+  const cmv = r.linhas.find(l=>l.dre_linha==='cmv')!;
+  expect(cmv.forecast_restante).toBeCloseTo(48*11, 0); // prova cmv sobre receita_liquida FORECASTED
+});
+
+it('imposto razão-YTD ≠ média mensal (números divergentes)', () => {
+  // fechados jan(imp 0, rec 100), fev(imp 60, rec 200), mar(imp 0, rec 100). hoje abr.
+  // média mensal imposto = 20/mês × 9 = 180. razão YTD = 60/400=0.15; receita run-rate=400/3≈133.3/mês ×9=1200; imposto=0.15×1200=180?
+  // → escolher números que divirjam: rec jan100/fev100/mar100 (run-rate=100), imp 0/0/45 → razão=45/300=0.15 → forecast=0.15×100×9=135; média mensal=15×9=135 (igual).
+  // Pra divergir: rec 100/100/400 (run-rate=200/mês), imp 0/0/60 → razão=60/600=0.10 → 0.10×200×9=180; média mensal imposto=20×9=180 (ainda igual pois receita média ∝).
+  // Divergência real: receita NÃO constante no forecast. Use sazonal: ano-1 dá receita restante alta enquanto imposto YTD baixo.
+  const anoAnt = Array.from({length:12},(_,i)=>({mes:i+1, receita_bruta:300}));
+  const dre = [{mes:1,receita_bruta:100,impostos:5},{mes:2,receita_bruta:100,impostos:5},{mes:3,receita_bruta:100,impostos:5}]; // razão=15/300=0.05
+  const r = projetarDRE({ company:'colacor', ano:2026, hoje:new Date('2026-04-10'), dreAtual:dre, dreAnoAnterior:anoAnt, orcado:{} });
+  const imp = r.linhas.find(l=>l.dre_linha==='impostos')!;
+  expect(imp.metodo).toBe('razao_ytd_imposto');
+  // fator tendência=300/(3×300? não, mesmos meses fechados jan-mar ano-1=900) → 300/900=0.333 → cap 0.5 → receita FC mês=300×0.5=150
+  // imposto FC = 0.05 × 150 × 9 = 67.5  (média mensal seria 5×9=45 → DIVERGE)
+  expect(imp.forecast_restante).toBeCloseTo(0.05*150*9, 0);
+  expect(imp.forecast_restante).not.toBeCloseTo(5*9, 0);
+});
+
+it('mês corrente PARCIAL não entra na base nem no landing por realizado', () => {
+  // hoje maio. fechados jan-abr receita 100/mês. maio parcial ENORME (9999) presente em dreAtual.
+  const dre = [1,2,3,4].map(m=>({mes:m, receita_bruta:100})).concat([{mes:5, receita_bruta:9999}]);
+  const r = projetarDRE({ company:'oben', ano:2026, hoje:new Date('2026-05-20'), dreAtual:dre, dreAnoAnterior:[], orcado:{} });
+  const rb = r.linhas.find(l=>l.dre_linha==='receita_bruta')!;
+  expect(rb.realizado_fechado).toBe(400); // só jan-abr; maio parcial NÃO entra
+  expect(rb.forecast_restante).toBeCloseTo(100*8,0); // run-rate 100 × 8 (mai-dez)
+});
+
+it('variância sign-aware — parametrizado, nenhuma invertida', () => {
+  // landing > orcado em TODAS. receita acima=favorável; custo/dedução/imposto acima=desfavorável.
+  // monta dreAtual com 12 meses fechados (ano passado) p/ landing=realizado; orçado menor.
+  const dre = Array.from({length:12},(_,i)=>({mes:i+1, receita_bruta:100, deducoes:10, cmv:40, despesas_operacionais:5, despesas_administrativas:5, despesas_comerciais:5, despesas_financeiras:2, receitas_financeiras:3, outras_receitas:1, outras_despesas:1, impostos:8 }));
+  const orc: Partial<Record<string,(number|null)[]>> = {}; for (const k of LINHAS_INPUT) orc[k] = Array(12).fill(1); // orçado baixo → landing>orçado
+  const r = projetarDRE({ company:'oben', ano:2025, hoje:new Date('2026-05-10'), dreAtual:dre, dreAnoAnterior:[], orcado:orc });
+  const fav = (l:string)=> r.linhas.find(x=>x.dre_linha===l)!.favoravel;
+  expect(fav('receita_bruta')).toBe(true); expect(fav('receitas_financeiras')).toBe(true); expect(fav('outras_receitas')).toBe(true);
+  expect(fav('deducoes')).toBe(false); expect(fav('cmv')).toBe(false); expect(fav('despesas_financeiras')).toBe(false); expect(fav('impostos')).toBe(false);
+  expect(fav('resultado_liquido')).toBe(true); // derivada de resultado acima → favorável
+});
+
+it('orçado AUSENTE → variancia null (não 0)', () => {
+  const dre = Array.from({length:12},(_,i)=>({mes:i+1, receita_bruta:100}));
+  const r = projetarDRE({ company:'oben', ano:2025, hoje:new Date('2026-05-10'), dreAtual:dre, dreAnoAnterior:[], orcado:{} }); // nada orçado
+  const rb = r.linhas.find(l=>l.dre_linha==='receita_bruta')!;
+  expect(rb.orcado_ano).toBeNull(); expect(rb.variancia).toBeNull(); expect(rb.fura_meta).toBe(false);
+});
+
+it('fura_meta com orcado<=0 usa só piso', () => {
+  const dre = Array.from({length:12},(_,i)=>({mes:i+1, outras_despesas:500})); // landing=6000
+  const orc = { outras_despesas: Array(12).fill(0) }; // orçado 0
+  const r = projetarDRE({ company:'oben', ano:2025, hoje:new Date('2026-05-10'), dreAtual:dre, dreAnoAnterior:[], orcado:orc, pisoFuraMeta:5000 });
+  const od = r.linhas.find(l=>l.dre_linha==='outras_despesas')!;
+  expect(od.orcado_ano).toBe(0); expect(od.fura_meta).toBe(true); // |6000|>5000 piso; sem divisão por 0
+});
+
+it('denominador de driver <=0 → run-rate + flag, sem NaN/Infinity', () => {
+  // receita_bruta fechada = 0 (mas há deducoes) → razão deducoes/receita = null → run-rate
+  const dre = [{mes:1,receita_bruta:0,deducoes:10},{mes:2,receita_bruta:0,deducoes:10},{mes:3,receita_bruta:0,deducoes:10}];
+  const r = projetarDRE({ company:'oben', ano:2026, hoje:new Date('2026-04-10'), dreAtual:dre, dreAnoAnterior:[], orcado:{} });
+  const ded = r.linhas.find(l=>l.dre_linha==='deducoes')!;
+  expect(ded.flags).toContain('denominador_zero');
+  expect(Number.isFinite(ded.forecast_restante)).toBe(true);
+  expect(ded.forecast_restante).toBeCloseTo(10*9,0); // run-rate 10/mês × 9
+});
+
+it('derivadas: landing E orcado_ano calculados das 11 linhas (não null)', () => {
+  const dre = Array.from({length:12},(_,i)=>({mes:i+1, receita_bruta:100, deducoes:10, cmv:40, impostos:8 }));
+  const orc: Partial<Record<string,(number|null)[]>> = {}; for (const k of LINHAS_INPUT) orc[k]=Array(12).fill(k==='receita_bruta'?90: k==='deducoes'?9: k==='cmv'?36: k==='impostos'?7:0);
+  const r = projetarDRE({ company:'oben', ano:2025, hoje:new Date('2026-05-10'), dreAtual:dre, dreAnoAnterior:[], orcado:orc });
+  const rl = r.linhas.find(l=>l.dre_linha==='resultado_liquido')!;
+  expect(rl.landing).toBeCloseTo(12*(100-10-40-8),0); // 42×12=504
+  expect(rl.orcado_ano).toBeCloseTo(12*(90-9-36-7),0); // 38×12=456 (NÃO null)
+  expect(rl.variancia).toBeCloseTo(504-456,0);
 });

--- a/src/lib/financeiro/__tests__/orcamento-forecast-helpers.test.ts
+++ b/src/lib/financeiro/__tests__/orcamento-forecast-helpers.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { mesesFechados, razaoYTD, fatorTendenciaYTD, derivarLinhas } from '../orcamento-forecast-helpers';
+
+describe('mesesFechados', () => {
+  it('ano corrente exclui o mês corrente e futuros', () => { expect(mesesFechados(2026, new Date('2026-05-15'))).toEqual([1,2,3,4]); });
+  it('ano passado = 12', () => { expect(mesesFechados(2025, new Date('2026-05-15'))).toHaveLength(12); });
+  it('ano futuro = []', () => { expect(mesesFechados(2027, new Date('2026-05-15'))).toEqual([]); });
+});
+describe('razaoYTD', () => {
+  it('Σnum/Σden', () => { expect(razaoYTD([10,20],[100,100])).toBeCloseTo(0.15,6); });
+  it('denominador <=0 → null', () => { expect(razaoYTD([10],[0])).toBeNull(); expect(razaoYTD([10],[-5])).toBeNull(); });
+  it('vazio → null', () => { expect(razaoYTD([],[])).toBeNull(); });
+});
+describe('fatorTendenciaYTD', () => {
+  it('Σreceita atual / ano-1 (mesmos meses), cap [0.5,2.0]', () => {
+    expect(fatorTendenciaYTD([{mes:1,receita_bruta:110},{mes:2,receita_bruta:130}],[{mes:1,receita_bruta:100},{mes:2,receita_bruta:100}],[1,2])).toBeCloseTo(1.2,6);
+  });
+  it('cap superior 2.0', () => { expect(fatorTendenciaYTD([{mes:1,receita_bruta:500}],[{mes:1,receita_bruta:100}],[1])).toBe(2.0); });
+  it('base ano-1 <=0 → null', () => { expect(fatorTendenciaYTD([{mes:1,receita_bruta:100}],[],[1])).toBeNull(); });
+});
+describe('derivarLinhas', () => {
+  it('fórmulas e sinais (FinDRE)', () => {
+    const d = derivarLinhas({ receita_bruta:1000, deducoes:100, cmv:400, despesas_operacionais:50, despesas_administrativas:30, despesas_comerciais:20, receitas_financeiras:10, despesas_financeiras:5, outras_receitas:0, outras_despesas:0, impostos:40 });
+    expect(d.receita_liquida).toBe(900);
+    expect(d.lucro_bruto).toBe(500);
+    expect(d.resultado_operacional).toBe(400);
+    expect(d.resultado_antes_impostos).toBe(405);
+    expect(d.resultado_liquido).toBe(365);
+  });
+  it('campos omitidos = 0, sem NaN', () => {
+    const d = derivarLinhas({ receita_bruta:500 });
+    expect(d.receita_liquida).toBe(500); expect(Number.isNaN(d.resultado_liquido)).toBe(false); expect(d.resultado_liquido).toBe(500);
+  });
+});

--- a/src/lib/financeiro/__tests__/orcamento-forecast-helpers.test.ts
+++ b/src/lib/financeiro/__tests__/orcamento-forecast-helpers.test.ts
@@ -23,9 +23,9 @@ describe('derivarLinhas', () => {
     const d = derivarLinhas({ receita_bruta:1000, deducoes:100, cmv:400, despesas_operacionais:50, despesas_administrativas:30, despesas_comerciais:20, receitas_financeiras:10, despesas_financeiras:5, outras_receitas:0, outras_despesas:0, impostos:40 });
     expect(d.receita_liquida).toBe(900);
     expect(d.lucro_bruto).toBe(500);
-    expect(d.resultado_operacional).toBe(400);
-    expect(d.resultado_antes_impostos).toBe(405);
-    expect(d.resultado_liquido).toBe(365);
+    expect(d.resultado_operacional).toBe(405); // 500 -50 -30 -20 +10 -5 (financeiras no operacional, = DRE v2)
+    expect(d.resultado_antes_impostos).toBe(405); // 405 + 0 - 0 (só outras)
+    expect(d.resultado_liquido).toBe(365); // 405 - 40
   });
   it('campos omitidos = 0, sem NaN', () => {
     const d = derivarLinhas({ receita_bruta:500 });

--- a/src/lib/financeiro/orcamento-forecast-helpers.ts
+++ b/src/lib/financeiro/orcamento-forecast-helpers.ts
@@ -120,26 +120,6 @@ function orcadoAno(
   return arr.reduce<number>((acc, v) => acc + (v ?? 0), 0);
 }
 
-/** Helper interno: calcula orcado_ano para derivada (null→0; flag se algum input for null) */
-function orcadoAnoDerivada(
-  orcado: Partial<Record<LinhaInput, (number | null)[]>>,
-  linhasUsadas: LinhaInput[]
-): { valor: number; incompleto: boolean } {
-  let incompleto = false;
-  const vals: Partial<Record<LinhaInput, number>> = {};
-  for (const l of linhasUsadas) {
-    const v = orcadoAno(orcado, l);
-    if (v === null) incompleto = true;
-    vals[l] = v ?? 0;
-  }
-  return { valor: 0, incompleto }; // valor calculado por derivarLinhas depois
-}
-
-/** Constrói objeto de inputs para derivarLinhas a partir de um mapa parcial */
-function toInputs(m: Partial<Record<LinhaInput, number>>): Partial<Record<LinhaInput, number>> {
-  return m;
-}
-
 export function projetarDRE(input: {
   company: string;
   ano: number;
@@ -238,8 +218,6 @@ export function projetarDRE(input: {
   let metodoRecBruta: MetodoForecast = 'run_rate';
 
   if (fator !== null) {
-    // tentativa sazonal: verificamos se há ano anterior com receita em pelo menos um mês restante
-    const temAnoAnt = restantes.some(m => (dreAntPorMes.get(m)?.receita_bruta ?? 0) > 0 || dreAntPorMes.has(m));
     if (dreAnoAnterior.length > 0) {
       // sazonal: usa ano-1 × fator (mesmo para meses sem dados → 0 × fator = 0)
       for (const m of restantes) {

--- a/src/lib/financeiro/orcamento-forecast-helpers.ts
+++ b/src/lib/financeiro/orcamento-forecast-helpers.ts
@@ -1,0 +1,95 @@
+export const LINHAS_INPUT = ['receita_bruta','deducoes','cmv','despesas_operacionais','despesas_administrativas','despesas_comerciais','despesas_financeiras','receitas_financeiras','outras_receitas','outras_despesas','impostos'] as const;
+export type LinhaInput = typeof LINHAS_INPUT[number];
+export const LINHAS_RECEITA = new Set<string>(['receita_bruta','receitas_financeiras','outras_receitas']);
+export const LINHAS_DESPESA_FIXA = new Set<string>(['despesas_operacionais','despesas_administrativas','despesas_comerciais']);
+export const LINHAS_FINANCEIRA = new Set<string>(['receitas_financeiras','despesas_financeiras']);
+export const LINHAS_DERIV_FAVORAVEL_CIMA = new Set<string>(['receita_liquida','lucro_bruto','resultado_operacional','resultado_antes_impostos','resultado_liquido']);
+export type MesDRE = { mes: number } & Partial<Record<LinhaInput, number>>;
+export type DerivadasResult = { receita_liquida: number; lucro_bruto: number; resultado_operacional: number; resultado_antes_impostos: number; resultado_liquido: number };
+
+/**
+ * Retorna a lista de meses fechados (com dados completos) para um dado ano.
+ * - Ano passado: [1..12]
+ * - Ano corrente: [1..mesAtual-1] (mês em curso fica fora)
+ * - Ano futuro: []
+ */
+export function mesesFechados(ano: number, hoje: Date = new Date()): number[] {
+  const anoAtual = hoje.getFullYear();
+  if (ano < anoAtual) {
+    return [1,2,3,4,5,6,7,8,9,10,11,12];
+  }
+  if (ano > anoAtual) {
+    return [];
+  }
+  // ano === anoAtual: getMonth() é 0-based, então maio = 4 → fechados = [1,2,3,4]
+  const mesCorrente = hoje.getMonth(); // 0-based: jan=0, mai=4
+  return Array.from({ length: mesCorrente }, (_, i) => i + 1);
+}
+
+/**
+ * Razão YTD: Σnum / Σden.
+ * Retorna null se Σden <= 0 ou se arrays vazios.
+ */
+export function razaoYTD(num: number[], den: number[]): number | null {
+  const s = den.reduce((acc, v) => acc + v, 0);
+  if (s <= 0) return null;
+  const n = num.reduce((acc, v) => acc + v, 0);
+  return n / s;
+}
+
+/**
+ * Fator de tendência YTD: Σreceita_bruta(atual) / Σreceita_bruta(anoAnt),
+ * apenas nos meses em `fechados`, com cap [0.5, 2.0].
+ * Retorna null se a base do ano anterior for <= 0.
+ */
+export function fatorTendenciaYTD(
+  atual: MesDRE[],
+  anoAnt: MesDRE[],
+  fechados: number[]
+): number | null {
+  const fechadosSet = new Set(fechados);
+
+  const somaAtual = atual
+    .filter(m => fechadosSet.has(m.mes))
+    .reduce((acc, m) => acc + (m.receita_bruta ?? 0), 0);
+
+  const somaAnt = anoAnt
+    .filter(m => fechadosSet.has(m.mes))
+    .reduce((acc, m) => acc + (m.receita_bruta ?? 0), 0);
+
+  if (somaAnt <= 0) return null;
+
+  return Math.min(2.0, Math.max(0.5, somaAtual / somaAnt));
+}
+
+/**
+ * Deriva as linhas calculadas do DRE a partir das linhas de input.
+ * Campos omitidos são tratados como 0.
+ */
+export function derivarLinhas(i: Partial<Record<LinhaInput, number>>): DerivadasResult {
+  const receita_bruta          = i.receita_bruta          ?? 0;
+  const deducoes               = i.deducoes               ?? 0;
+  const cmv                    = i.cmv                    ?? 0;
+  const despesas_operacionais  = i.despesas_operacionais  ?? 0;
+  const despesas_administrativas = i.despesas_administrativas ?? 0;
+  const despesas_comerciais    = i.despesas_comerciais    ?? 0;
+  const receitas_financeiras   = i.receitas_financeiras   ?? 0;
+  const despesas_financeiras   = i.despesas_financeiras   ?? 0;
+  const outras_receitas        = i.outras_receitas        ?? 0;
+  const outras_despesas        = i.outras_despesas        ?? 0;
+  const impostos               = i.impostos               ?? 0;
+
+  const receita_liquida           = receita_bruta - deducoes;
+  const lucro_bruto               = receita_liquida - cmv;
+  const resultado_operacional     = lucro_bruto - despesas_operacionais - despesas_administrativas - despesas_comerciais;
+  const resultado_antes_impostos  = resultado_operacional + receitas_financeiras - despesas_financeiras + outras_receitas - outras_despesas;
+  const resultado_liquido         = resultado_antes_impostos - impostos;
+
+  return {
+    receita_liquida,
+    lucro_bruto,
+    resultado_operacional,
+    resultado_antes_impostos,
+    resultado_liquido,
+  };
+}

--- a/src/lib/financeiro/orcamento-forecast-helpers.ts
+++ b/src/lib/financeiro/orcamento-forecast-helpers.ts
@@ -62,6 +62,420 @@ export function fatorTendenciaYTD(
   return Math.min(2.0, Math.max(0.5, somaAtual / somaAnt));
 }
 
+// ─── Task 2: projetarDRE ──────────────────────────────────────────────────────
+
+export type MetodoForecast =
+  | 'sazonal_ajustado'
+  | 'run_rate'
+  | 'driver_receita'
+  | 'media_movel'
+  | 'razao_ytd_imposto'
+  | 'orcado_remanescente'
+  | 'sem_forecast';
+
+export type ForecastLinha = {
+  dre_linha: string;
+  realizado_fechado: number;
+  forecast_restante: number;
+  landing: number;
+  orcado_ano: number | null;
+  variancia: number | null;
+  favoravel: boolean | null;
+  fura_meta: boolean;
+  metodo: MetodoForecast;
+  confianca: 'alta' | 'media' | 'baixa';
+  flags: string[];
+};
+
+export type ForecastResult = {
+  company: string;
+  ano: number;
+  meses_fechados: number;
+  linhas: ForecastLinha[];
+  confianca_geral: 'alta' | 'media' | 'baixa';
+  motivos: string[];
+};
+
+/** Helper interno: média dos últimos N valores de um array (ou todos se array.length < N) */
+function mediaMeses(valores: number[], n: number): number {
+  if (valores.length === 0) return 0;
+  const slice = valores.slice(-n);
+  return slice.reduce((acc, v) => acc + v, 0) / slice.length;
+}
+
+/** Helper interno: run-rate = média simples de um array */
+function runRate(valores: number[]): number {
+  if (valores.length === 0) return 0;
+  return valores.reduce((acc, v) => acc + v, 0) / valores.length;
+}
+
+/** Helper interno: soma o orcado de uma linha (null se chave ausente ou todos null) */
+function orcadoAno(
+  orcado: Partial<Record<LinhaInput, (number | null)[]>>,
+  linha: LinhaInput
+): number | null {
+  const arr = orcado[linha];
+  if (!arr) return null;
+  if (arr.every(v => v === null)) return null;
+  return arr.reduce<number>((acc, v) => acc + (v ?? 0), 0);
+}
+
+/** Helper interno: calcula orcado_ano para derivada (null→0; flag se algum input for null) */
+function orcadoAnoDerivada(
+  orcado: Partial<Record<LinhaInput, (number | null)[]>>,
+  linhasUsadas: LinhaInput[]
+): { valor: number; incompleto: boolean } {
+  let incompleto = false;
+  const vals: Partial<Record<LinhaInput, number>> = {};
+  for (const l of linhasUsadas) {
+    const v = orcadoAno(orcado, l);
+    if (v === null) incompleto = true;
+    vals[l] = v ?? 0;
+  }
+  return { valor: 0, incompleto }; // valor calculado por derivarLinhas depois
+}
+
+/** Constrói objeto de inputs para derivarLinhas a partir de um mapa parcial */
+function toInputs(m: Partial<Record<LinhaInput, number>>): Partial<Record<LinhaInput, number>> {
+  return m;
+}
+
+export function projetarDRE(input: {
+  company: string;
+  ano: number;
+  hoje?: Date;
+  dreAtual: MesDRE[];
+  dreAnoAnterior: MesDRE[];
+  orcado: Partial<Record<LinhaInput, (number | null)[]>>;
+  pisoFuraMeta?: number;
+}): ForecastResult {
+  const { company, ano, dreAtual, dreAnoAnterior, orcado } = input;
+  const hoje = input.hoje ?? new Date();
+  const piso = input.pisoFuraMeta ?? 5000;
+
+  const fechados = mesesFechados(ano, hoje);
+  const fechadosSet = new Set(fechados);
+  const todosOsMeses = [1,2,3,4,5,6,7,8,9,10,11,12];
+  const restantes = todosOsMeses.filter(m => !fechadosSet.has(m));
+
+  // ── Caso especial: 0 meses fechados ──────────────────────────────────────
+  if (fechados.length === 0) {
+    const TODAS_LINHAS_INPUT = [...LINHAS_INPUT] as LinhaInput[];
+    const DERIVADAS = ['receita_liquida','lucro_bruto','resultado_operacional','resultado_antes_impostos','resultado_liquido'] as const;
+
+    const linhas: ForecastLinha[] = [
+      ...TODAS_LINHAS_INPUT.map((l): ForecastLinha => ({
+        dre_linha: l,
+        realizado_fechado: 0,
+        forecast_restante: 0,
+        landing: 0,
+        orcado_ano: orcadoAno(orcado, l),
+        variancia: null,
+        favoravel: null,
+        fura_meta: false,
+        metodo: 'sem_forecast',
+        confianca: 'baixa',
+        flags: [],
+      })),
+      ...DERIVADAS.map((l): ForecastLinha => ({
+        dre_linha: l,
+        realizado_fechado: 0,
+        forecast_restante: 0,
+        landing: 0,
+        orcado_ano: null,
+        variancia: null,
+        favoravel: null,
+        fura_meta: false,
+        metodo: 'sem_forecast',
+        confianca: 'baixa',
+        flags: [],
+      })),
+    ];
+
+    return {
+      company,
+      ano,
+      meses_fechados: 0,
+      linhas,
+      confianca_geral: 'baixa',
+      motivos: ['Aguardando o 1º mês fechado para projetar.'],
+    };
+  }
+
+  // ── Helpers para acessar DRE por mês ────────────────────────────────────
+  const dreAtualPorMes = new Map<number, MesDRE>(dreAtual.map(m => [m.mes, m]));
+  const dreAntPorMes = new Map<number, MesDRE>(dreAnoAnterior.map(m => [m.mes, m]));
+
+  /** Valor de uma linha num mês do DRE atual (0 se ausente) */
+  const valAtual = (mes: number, l: LinhaInput): number => dreAtualPorMes.get(mes)?.[l] ?? 0;
+  const valAnt = (mes: number, l: LinhaInput): number => dreAntPorMes.get(mes)?.[l] ?? 0;
+
+  /** Array de valores de uma linha nos meses fechados */
+  const valoresFechados = (l: LinhaInput): number[] => fechados.map(m => valAtual(m, l));
+
+  // ── Primitivas globais ───────────────────────────────────────────────────
+  const fator = fatorTendenciaYTD(dreAtual, dreAnoAnterior, fechados);
+  const recBrutaFechados = valoresFechados('receita_bruta');
+  const deducoesFechados = valoresFechados('deducoes');
+  const recLiqFechados = fechados.map(m => valAtual(m, 'receita_bruta') - valAtual(m, 'deducoes'));
+  const cmvFechados = valoresFechados('cmv');
+
+  // ── Forecast por mês (na ordem topológica) ──────────────────────────────
+  // Armazenamos o forecast de cada linha por mês restante
+  const fcPorMes: Record<LinhaInput, number[]> = {} as Record<LinhaInput, number[]>;
+  const metodoPorLinha: Record<LinhaInput, MetodoForecast> = {} as Record<LinhaInput, MetodoForecast>;
+  const flagsPorLinha: Record<LinhaInput, string[]> = {} as Record<LinhaInput, string[]>;
+
+  for (const l of LINHAS_INPUT) {
+    fcPorMes[l] = [];
+    metodoPorLinha[l] = 'run_rate';
+    flagsPorLinha[l] = [];
+  }
+
+  // a) receita_bruta: sazonal_ajustado / run_rate / orcado_remanescente
+  const rrReceita = runRate(recBrutaFechados);
+  const recBrutaFC: number[] = [];
+  let metodoRecBruta: MetodoForecast = 'run_rate';
+
+  if (fator !== null) {
+    // tentativa sazonal: verificamos se há ano anterior com receita em pelo menos um mês restante
+    const temAnoAnt = restantes.some(m => (dreAntPorMes.get(m)?.receita_bruta ?? 0) > 0 || dreAntPorMes.has(m));
+    if (dreAnoAnterior.length > 0) {
+      // sazonal: usa ano-1 × fator (mesmo para meses sem dados → 0 × fator = 0)
+      for (const m of restantes) {
+        recBrutaFC.push(valAnt(m, 'receita_bruta') * fator);
+      }
+      metodoRecBruta = 'sazonal_ajustado';
+    } else {
+      // fator existe mas não há ano anterior → run-rate
+      for (const _m of restantes) recBrutaFC.push(rrReceita);
+      metodoRecBruta = 'run_rate';
+    }
+  } else if (fechados.length >= 1) {
+    // run-rate
+    for (const _m of restantes) recBrutaFC.push(rrReceita);
+    metodoRecBruta = 'run_rate';
+  } else {
+    // fallback orcado (nunca chega aqui pois fechados.length=0 foi tratado acima)
+    for (const m of restantes) {
+      recBrutaFC.push(orcado.receita_bruta?.[m - 1] ?? 0);
+    }
+    metodoRecBruta = 'orcado_remanescente';
+  }
+  fcPorMes['receita_bruta'] = recBrutaFC;
+  metodoPorLinha['receita_bruta'] = metodoRecBruta;
+
+  // b) deducoes: driver razaoYTD(ded/receita_bruta) ou run-rate + flag
+  const rDed = razaoYTD(deducoesFechados, recBrutaFechados);
+  const deducoesFC: number[] = [];
+  let metodoDed: MetodoForecast;
+  if (rDed !== null) {
+    for (let i = 0; i < restantes.length; i++) deducoesFC.push(rDed * recBrutaFC[i]);
+    metodoDed = 'driver_receita';
+  } else {
+    const rrDed = runRate(deducoesFechados);
+    for (const _m of restantes) deducoesFC.push(rrDed);
+    metodoDed = 'run_rate';
+    flagsPorLinha['deducoes'].push('denominador_zero');
+  }
+  fcPorMes['deducoes'] = deducoesFC;
+  metodoPorLinha['deducoes'] = metodoDed;
+
+  // c) receita_liquida_FC (calc intermediário, não é linha de output separada)
+  const recLiqFC: number[] = recBrutaFC.map((rb, i) => rb - deducoesFC[i]);
+
+  // d) cmv: driver razaoYTD(cmv/receita_liquida) ou run-rate + flag
+  const rCmv = razaoYTD(cmvFechados, recLiqFechados);
+  const cmvFC: number[] = [];
+  let metodoCmv: MetodoForecast;
+  if (rCmv !== null) {
+    for (let i = 0; i < restantes.length; i++) cmvFC.push(rCmv * recLiqFC[i]);
+    metodoCmv = 'driver_receita';
+  } else {
+    const rrCmv = runRate(cmvFechados);
+    for (const _m of restantes) cmvFC.push(rrCmv);
+    metodoCmv = 'run_rate';
+    flagsPorLinha['cmv'].push('denominador_zero');
+  }
+  fcPorMes['cmv'] = cmvFC;
+  metodoPorLinha['cmv'] = metodoCmv;
+
+  // e) LINHAS_DESPESA_FIXA + outras_receitas + outras_despesas: run-rate
+  const linhasRunRate: LinhaInput[] = [
+    'despesas_operacionais', 'despesas_administrativas', 'despesas_comerciais',
+    'outras_receitas', 'outras_despesas',
+  ];
+  for (const l of linhasRunRate) {
+    const rr = runRate(valoresFechados(l));
+    fcPorMes[l] = restantes.map(() => rr);
+    metodoPorLinha[l] = 'run_rate';
+  }
+
+  // f) LINHAS_FINANCEIRA: média dos últimos 3 meses fechados
+  const linhasFinanceira: LinhaInput[] = ['receitas_financeiras', 'despesas_financeiras'];
+  for (const l of linhasFinanceira) {
+    const vals = valoresFechados(l);
+    const media = mediaMeses(vals, 3);
+    fcPorMes[l] = restantes.map(() => media);
+    metodoPorLinha[l] = 'media_movel';
+  }
+
+  // g) impostos: razaoYTD(impostos/receita_bruta) ou run-rate + flag
+  const impostosFechados = valoresFechados('impostos');
+  const rImp = razaoYTD(impostosFechados, recBrutaFechados);
+  const impostosFC: number[] = [];
+  let metodoImp: MetodoForecast;
+  if (rImp !== null) {
+    for (let i = 0; i < restantes.length; i++) impostosFC.push(rImp * recBrutaFC[i]);
+    metodoImp = 'razao_ytd_imposto';
+  } else {
+    const rrImp = runRate(impostosFechados);
+    for (const _m of restantes) impostosFC.push(rrImp);
+    metodoImp = 'run_rate';
+    flagsPorLinha['impostos'].push('denominador_zero');
+  }
+  fcPorMes['impostos'] = impostosFC;
+  metodoPorLinha['impostos'] = metodoImp;
+
+  // ── Agrega: realizado_fechado e forecast_restante por linha-input ────────
+  const realizadoFechado: Partial<Record<LinhaInput, number>> = {};
+  const forecastRestante: Partial<Record<LinhaInput, number>> = {};
+  const landingInput: Partial<Record<LinhaInput, number>> = {};
+
+  for (const l of LINHAS_INPUT) {
+    realizadoFechado[l] = valoresFechados(l).reduce((acc, v) => acc + v, 0);
+    forecastRestante[l] = (fcPorMes[l] ?? []).reduce((acc, v) => acc + v, 0);
+    landingInput[l] = (realizadoFechado[l] ?? 0) + (forecastRestante[l] ?? 0);
+  }
+
+  // ── Confiança por linha-input ────────────────────────────────────────────
+  const linhasVariaveis = new Set<LinhaInput>(['receita_bruta', 'cmv', 'despesas_comerciais', 'impostos']);
+
+  function confiancaLinha(l: LinhaInput): 'alta' | 'media' | 'baixa' {
+    const flags = flagsPorLinha[l] ?? [];
+    if (flags.includes('denominador_zero')) return 'baixa';
+    if (fechados.length < 3 && linhasVariaveis.has(l)) return 'baixa';
+    // sazonal indisponível → run-rate (sem ano anterior ou sem fator)
+    if (l === 'receita_bruta' && metodoPorLinha[l] === 'run_rate') return 'media';
+    return 'alta';
+  }
+
+  // ── Variância e fura_meta ────────────────────────────────────────────────
+  function calcVariancia(l: string, landing: number, oAno: number | null): number | null {
+    if (oAno === null) return null;
+    return landing - oAno;
+  }
+
+  function calcFavoravel(l: string, variancia: number | null): boolean | null {
+    if (variancia === null) return null;
+    const isReceita = LINHAS_RECEITA.has(l) || LINHAS_DERIV_FAVORAVEL_CIMA.has(l);
+    return isReceita ? variancia >= 0 : variancia <= 0;
+  }
+
+  function calcFuraMeta(variancia: number | null, oAno: number | null): boolean {
+    if (variancia === null) return false;
+    const threshold = (oAno !== null && oAno > 0) ? Math.max(0.10 * oAno, piso) : piso;
+    return Math.abs(variancia) > threshold;
+  }
+
+  // ── Monta linhas de input ────────────────────────────────────────────────
+  const linhasInput: ForecastLinha[] = LINHAS_INPUT.map(l => {
+    const real = realizadoFechado[l] ?? 0;
+    const fc = forecastRestante[l] ?? 0;
+    const landing = real + fc;
+    const oAno = orcadoAno(orcado, l);
+    const variancia = calcVariancia(l, landing, oAno);
+    const favoravel = calcFavoravel(l, variancia);
+    return {
+      dre_linha: l,
+      realizado_fechado: real,
+      forecast_restante: fc,
+      landing,
+      orcado_ano: oAno,
+      variancia,
+      favoravel,
+      fura_meta: calcFuraMeta(variancia, oAno),
+      metodo: metodoPorLinha[l],
+      confianca: confiancaLinha(l),
+      flags: flagsPorLinha[l] ?? [],
+    };
+  });
+
+  // ── Derivadas ────────────────────────────────────────────────────────────
+  // Landing das derivadas via derivarLinhas sobre os landings dos inputs
+  const derivLanding = derivarLinhas(
+    Object.fromEntries(LINHAS_INPUT.map(l => [l, landingInput[l] ?? 0])) as Record<LinhaInput, number>
+  );
+
+  // orcado_ano das derivadas via derivarLinhas sobre os orcado_ano (null→0)
+  const inputsOrcado: Partial<Record<LinhaInput, number>> = {};
+  let algumInputNullOrcado = false;
+  for (const l of LINHAS_INPUT) {
+    const v = orcadoAno(orcado, l);
+    if (v === null) algumInputNullOrcado = true;
+    inputsOrcado[l] = v ?? 0;
+  }
+  const derivOrcado = derivarLinhas(inputsOrcado as Record<LinhaInput, number>);
+
+  type DerivaKey = keyof typeof derivLanding;
+  const DERIVADAS_KEYS: DerivaKey[] = [
+    'receita_liquida', 'lucro_bruto', 'resultado_operacional',
+    'resultado_antes_impostos', 'resultado_liquido',
+  ];
+
+  // Confiança das derivadas: pior dos inputs (simplificado: pior confiança das linhas-input)
+  function piorConfianca(confs: Array<'alta' | 'media' | 'baixa'>): 'alta' | 'media' | 'baixa' {
+    if (confs.includes('baixa')) return 'baixa';
+    if (confs.includes('media')) return 'media';
+    return 'alta';
+  }
+  const confTodasInputs = linhasInput.map(l => l.confianca);
+
+  const linhasDerivadas: ForecastLinha[] = DERIVADAS_KEYS.map(l => {
+    const landing = derivLanding[l];
+    // orcado_ano da derivada: se ALGUM input for null → null; senão usa derivado
+    // Mas: se algumInputNullOrcado=true, o orcado_ano é null pra derivada?
+    // Interpretação do contrato: "se ALGUM input usado for null, adicione flag 'orcado_incompleto'"
+    // Mas orcado_ano da derivada ainda é calculado (com 0 no lugar do null)
+    // Isso é consistente com o teste que espera orcado_ano não-null quando todos têm orçado
+    const oAno = algumInputNullOrcado ? null : derivOrcado[l];
+    const flags: string[] = algumInputNullOrcado ? ['orcado_incompleto'] : [];
+    const variancia = calcVariancia(l, landing, oAno);
+    const favoravel = calcFavoravel(l, variancia);
+    return {
+      dre_linha: l,
+      realizado_fechado: 0, // derivada não tem realizado próprio
+      forecast_restante: 0, // derivada não tem forecast próprio
+      landing,
+      orcado_ano: oAno,
+      variancia,
+      favoravel,
+      fura_meta: calcFuraMeta(variancia, oAno),
+      metodo: 'sem_forecast' as MetodoForecast,
+      confianca: piorConfianca(confTodasInputs),
+      flags,
+    };
+  });
+
+  const todasLinhas = [...linhasInput, ...linhasDerivadas];
+
+  // ── confianca_geral ───────────────────────────────────────────────────────
+  const linhasComOrcado = todasLinhas.filter(l => l.orcado_ano !== null);
+  const confiancaGeral: 'alta' | 'media' | 'baixa' =
+    linhasComOrcado.length === 0
+      ? 'baixa'
+      : piorConfianca(linhasComOrcado.map(l => l.confianca));
+
+  return {
+    company,
+    ano,
+    meses_fechados: fechados.length,
+    linhas: todasLinhas,
+    confianca_geral: confiancaGeral,
+    motivos: [],
+  };
+}
+
 /**
  * Deriva as linhas calculadas do DRE a partir das linhas de input.
  * Campos omitidos são tratados como 0.

--- a/src/lib/financeiro/orcamento-forecast-helpers.ts
+++ b/src/lib/financeiro/orcamento-forecast-helpers.ts
@@ -219,9 +219,11 @@ export function projetarDRE(input: {
 
   if (fator !== null) {
     if (dreAnoAnterior.length > 0) {
-      // sazonal: usa ano-1 × fator (mesmo para meses sem dados → 0 × fator = 0)
+      // sazonal: ano-1[mes] × fator. ⚠️ Se o ano anterior é ESPARSO (mês ausente/zero), NÃO zera o
+      // forecast — cai pra run-rate naquele mês (Codex P1.3); senão receita/ded/cmv/imposto zerariam.
       for (const m of restantes) {
-        recBrutaFC.push(valAnt(m, 'receita_bruta') * fator);
+        const baseAnt = dreAntPorMes.get(m)?.receita_bruta;
+        recBrutaFC.push(baseAnt != null && baseAnt > 0 ? baseAnt * fator : rrReceita);
       }
       metodoRecBruta = 'sazonal_ajustado';
     } else {
@@ -385,12 +387,16 @@ export function projetarDRE(input: {
     Object.fromEntries(LINHAS_INPUT.map(l => [l, landingInput[l] ?? 0])) as Record<LinhaInput, number>
   );
 
-  // orcado_ano das derivadas via derivarLinhas sobre os orcado_ano (null→0)
+  // orcado_ano das derivadas via derivarLinhas sobre os orcado_ano (null→0).
+  // algumInputNullOrcado: algum input sem orçado (→ flag orcado_incompleto, mas computa com 0).
+  // algumInputComOrcado: ao menos um input orçado (→ vale derivar; se NENHUM, o orçado derivado é null).
   const inputsOrcado: Partial<Record<LinhaInput, number>> = {};
   let algumInputNullOrcado = false;
+  let algumInputComOrcado = false;
   for (const l of LINHAS_INPUT) {
     const v = orcadoAno(orcado, l);
     if (v === null) algumInputNullOrcado = true;
+    else algumInputComOrcado = true;
     inputsOrcado[l] = v ?? 0;
   }
   const derivOrcado = derivarLinhas(inputsOrcado as Record<LinhaInput, number>);
@@ -411,13 +417,11 @@ export function projetarDRE(input: {
 
   const linhasDerivadas: ForecastLinha[] = DERIVADAS_KEYS.map(l => {
     const landing = derivLanding[l];
-    // orcado_ano da derivada: se ALGUM input for null → null; senão usa derivado
-    // Mas: se algumInputNullOrcado=true, o orcado_ano é null pra derivada?
-    // Interpretação do contrato: "se ALGUM input usado for null, adicione flag 'orcado_incompleto'"
-    // Mas orcado_ano da derivada ainda é calculado (com 0 no lugar do null)
-    // Isso é consistente com o teste que espera orcado_ano não-null quando todos têm orçado
-    const oAno = algumInputNullOrcado ? null : derivOrcado[l];
-    const flags: string[] = algumInputNullOrcado ? ['orcado_incompleto'] : [];
+    // orcado_ano da derivada: só null se NENHUM input tiver orçado (nada a comparar). Se ao menos um
+    // input tem orçado, calcula (inputs ausentes = 0) e FLAG 'orcado_incompleto' — não some a variância
+    // só porque uma linha não-relacionada ficou sem orçar (Codex P1.2).
+    const oAno = algumInputComOrcado ? derivOrcado[l] : null;
+    const flags: string[] = (algumInputComOrcado && algumInputNullOrcado) ? ['orcado_incompleto'] : [];
     const variancia = calcVariancia(l, landing, oAno);
     const favoravel = calcFavoravel(l, variancia);
     return {
@@ -473,8 +477,10 @@ export function derivarLinhas(i: Partial<Record<LinhaInput, number>>): Derivadas
 
   const receita_liquida           = receita_bruta - deducoes;
   const lucro_bruto               = receita_liquida - cmv;
-  const resultado_operacional     = lucro_bruto - despesas_operacionais - despesas_administrativas - despesas_comerciais;
-  const resultado_antes_impostos  = resultado_operacional + receitas_financeiras - despesas_financeiras + outras_receitas - outras_despesas;
+  // Fórmula IDÊNTICA ao DRE v2 oficial (dre-helpers.ts): financeiras entram no RESULTADO OPERACIONAL;
+  // resultado_antes_impostos só soma outras_receitas/despesas (Codex P1.1 — manter consistente com o realizado).
+  const resultado_operacional     = lucro_bruto - despesas_operacionais - despesas_administrativas - despesas_comerciais + receitas_financeiras - despesas_financeiras;
+  const resultado_antes_impostos  = resultado_operacional + outras_receitas - outras_despesas;
   const resultado_liquido         = resultado_antes_impostos - impostos;
 
   return {

--- a/src/lib/financeiro/orcamento-forecast-helpers.ts
+++ b/src/lib/financeiro/orcamento-forecast-helpers.ts
@@ -188,7 +188,6 @@ export function projetarDRE(input: {
 
   /** Valor de uma linha num mês do DRE atual (0 se ausente) */
   const valAtual = (mes: number, l: LinhaInput): number => dreAtualPorMes.get(mes)?.[l] ?? 0;
-  const valAnt = (mes: number, l: LinhaInput): number => dreAntPorMes.get(mes)?.[l] ?? 0;
 
   /** Array de valores de uma linha nos meses fechados */
   const valoresFechados = (l: LinhaInput): number[] => fechados.map(m => valAtual(m, l));
@@ -341,7 +340,7 @@ export function projetarDRE(input: {
   }
 
   // ── Variância e fura_meta ────────────────────────────────────────────────
-  function calcVariancia(l: string, landing: number, oAno: number | null): number | null {
+  function calcVariancia(landing: number, oAno: number | null): number | null {
     if (oAno === null) return null;
     return landing - oAno;
   }
@@ -364,7 +363,7 @@ export function projetarDRE(input: {
     const fc = forecastRestante[l] ?? 0;
     const landing = real + fc;
     const oAno = orcadoAno(orcado, l);
-    const variancia = calcVariancia(l, landing, oAno);
+    const variancia = calcVariancia(landing, oAno);
     const favoravel = calcFavoravel(l, variancia);
     return {
       dre_linha: l,
@@ -422,7 +421,7 @@ export function projetarDRE(input: {
     // só porque uma linha não-relacionada ficou sem orçar (Codex P1.2).
     const oAno = algumInputComOrcado ? derivOrcado[l] : null;
     const flags: string[] = (algumInputComOrcado && algumInputNullOrcado) ? ['orcado_incompleto'] : [];
-    const variancia = calcVariancia(l, landing, oAno);
+    const variancia = calcVariancia(landing, oAno);
     const favoravel = calcFavoravel(l, variancia);
     return {
       dre_linha: l,

--- a/src/pages/FinanceiroOrcamento.tsx
+++ b/src/pages/FinanceiroOrcamento.tsx
@@ -8,8 +8,9 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@
 import { COMPANIES, ALL_COMPANIES, type Company } from '@/contexts/CompanyContext';
 import { getDRE, DRE_LINHAS, type FinDRE } from '@/services/financeiroService';
 import { getOrcamento, upsertOrcamento, type OrcamentoLinha } from '@/services/financeiroV2Service';
+import { projetarDRE, LINHAS_INPUT, type MesDRE, type LinhaInput } from '@/lib/financeiro/orcamento-forecast-helpers';
 import { toast } from 'sonner';
-import { Loader2, Save, Building2, Calendar, TrendingUp, TrendingDown, Target, History } from 'lucide-react';
+import { Loader2, Save, Building2, Calendar, TrendingUp, TrendingDown, Target, History, Plane } from 'lucide-react';
 import { AuditTrailDrawer } from '@/components/financeiro/AuditTrailDrawer';
 
 const fmt = (v: number) => v.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
@@ -23,11 +24,49 @@ const mesesNome = ['Jan','Fev','Mar','Abr','Mai','Jun','Jul','Ago','Set','Out','
 const dreLinhas = DRE_LINHAS.map(l => l.value);
 const dreLabelMap = Object.fromEntries(DRE_LINHAS.map(l => [l.value, l.label]));
 
+const DERIVADAS_LABEL: Record<string, string> = {
+  receita_liquida: 'Receita Líquida',
+  lucro_bruto: 'Lucro Bruto',
+  resultado_operacional: 'Resultado Operacional',
+  resultado_antes_impostos: 'Result. antes Impostos',
+  resultado_liquido: 'Resultado Líquido',
+};
+
+function forecastLabel(linha: string): string {
+  return dreLabelMap[linha] ?? DERIVADAS_LABEL[linha] ?? linha;
+}
+
+/**
+ * Constrói o mapa orcado para projetarDRE.
+ * Regra CRÍTICA: chave ausente = não orçado (orcado_ano null).
+ * Chave presente com array = ao menos uma entrada existe → preenche os 12 meses (ausente → 0).
+ */
+function buildOrcadoForecast(
+  draft: Record<string, number>,
+): Partial<Record<LinhaInput, (number | null)[]>> {
+  const result: Partial<Record<LinhaInput, (number | null)[]>> = {};
+  for (const l of LINHAS_INPUT) {
+    // Verifica se existe ao menos um valor salvo para essa linha
+    const temEntrada = Array.from({ length: 12 }, (_, i) => i + 1).some(
+      mes => `${mes}_${l}` in draft,
+    );
+    if (!temEntrada) continue; // ausente: não inclui a chave
+    // Inclui a linha com 12 posições; meses sem entrada viram 0
+    const arr: (number | null)[] = Array.from({ length: 12 }, (_, i) => {
+      const key = `${i + 1}_${l}`;
+      return key in draft ? (draft[key] ?? 0) : 0;
+    });
+    result[l] = arr;
+  }
+  return result;
+}
+
 const FinanceiroOrcamento = () => {
   const [company, setCompany] = useState<Company>('oben');
   const [ano, setAno] = useState(new Date().getFullYear());
   const [orcamento, setOrcamento] = useState<OrcamentoLinha[]>([]);
   const [dre, setDre] = useState<FinDRE[]>([]);
+  const [dreAnoAnterior, setDreAnoAnterior] = useState<FinDRE[]>([]);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [editMode, setEditMode] = useState(false);
@@ -37,12 +76,14 @@ const FinanceiroOrcamento = () => {
   const load = useCallback(async () => {
     setLoading(true);
     try {
-      const [orc, dreData] = await Promise.all([
+      const [orc, dreData, dreAntData] = await Promise.all([
         getOrcamento(company, ano),
-        getDRE(company, ano),
+        getDRE(company, ano, undefined, 'competencia'),
+        getDRE(company, ano - 1, undefined, 'competencia'),
       ]);
       setOrcamento(orc);
       setDre(dreData);
+      setDreAnoAnterior(dreAntData);
 
       // Init draft from existing orcamento
       const d: Record<string, number> = {};
@@ -102,6 +143,45 @@ const FinanceiroOrcamento = () => {
       return { linha, label: dreLabelMap[linha], orcYtd, realYtd, variacao };
     });
   }, [draft, dre, currentMonth]);
+
+  // Adapter: constrói orcado para o forecast (ausente ≠ zero)
+  const orcadoForecast = useMemo((): ReturnType<typeof buildOrcadoForecast> => {
+    return buildOrcadoForecast(draft);
+  }, [draft]);
+
+  // Forecast de aterrissagem
+  const dreAtualMesDRE = useMemo((): MesDRE[] => {
+    return dre.map(d => {
+      const row: MesDRE = { mes: d.mes };
+      for (const l of LINHAS_INPUT) {
+        const v = (d as unknown as Record<string, number | undefined>)[l];
+        if (typeof v === 'number') row[l] = v;
+      }
+      return row;
+    });
+  }, [dre]);
+
+  const dreAnoAnteriorMesDRE = useMemo((): MesDRE[] => {
+    return dreAnoAnterior.map(d => {
+      const row: MesDRE = { mes: d.mes };
+      for (const l of LINHAS_INPUT) {
+        const v = (d as unknown as Record<string, number | undefined>)[l];
+        if (typeof v === 'number') row[l] = v;
+      }
+      return row;
+    });
+  }, [dreAnoAnterior]);
+
+  const forecast = useMemo(
+    () => projetarDRE({
+      company,
+      ano,
+      dreAtual: dreAtualMesDRE,
+      dreAnoAnterior: dreAnoAnteriorMesDRE,
+      orcado: orcadoForecast,
+    }),
+    [company, ano, dreAtualMesDRE, dreAnoAnteriorMesDRE, orcadoForecast],
+  );
 
   if (loading) {
     return <div className="flex items-center justify-center py-24"><Loader2 className="w-8 h-8 animate-spin" /></div>;
@@ -194,6 +274,119 @@ const FinanceiroOrcamento = () => {
               </TableBody>
             </Table>
           </div>
+        </CardContent>
+      </Card>
+
+      {/* Forecast de aterrissagem */}
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-base flex items-center gap-2">
+            <Plane className="w-4 h-4" />
+            Forecast de aterrissagem {ano}
+            <Badge
+              variant="outline"
+              className={`text-[10px] ${
+                forecast.confianca_geral === 'alta'
+                  ? 'text-status-success'
+                  : forecast.confianca_geral === 'media'
+                  ? 'text-muted-foreground'
+                  : 'text-status-warning'
+              }`}
+            >
+              Confiança {forecast.confianca_geral}
+            </Badge>
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="p-0">
+          {forecast.meses_fechados === 0 ? (
+            <p className="px-4 pb-4 text-sm text-muted-foreground">
+              Aguardando o 1º mês fechado de {ano} para projetar a aterrissagem.
+            </p>
+          ) : (
+            <div className="overflow-x-auto">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead className="sticky left-0 bg-background min-w-[200px]">Linha DRE</TableHead>
+                    <TableHead className="text-right w-28">Landing</TableHead>
+                    <TableHead className="text-right w-28">Orçado</TableHead>
+                    <TableHead className="text-right w-28">Variância</TableHead>
+                    <TableHead className="text-right w-24">% vs Orç.</TableHead>
+                    <TableHead className="w-32">Status</TableHead>
+                    <TableHead className="w-36">Método / Conf.</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {forecast.linhas.map((linha, idx) => {
+                    const isDerivada = idx >= LINHAS_INPUT.length;
+                    const pctVsOrc =
+                      linha.orcado_ano !== null && linha.orcado_ano > 0 && linha.variancia !== null
+                        ? ((linha.variancia / linha.orcado_ano) * 100).toFixed(1) + '%'
+                        : '—';
+                    const varianciaCor =
+                      linha.favoravel === true
+                        ? 'text-status-success'
+                        : linha.favoravel === false
+                        ? 'text-status-error'
+                        : 'text-muted-foreground';
+
+                    return (
+                      <TableRow
+                        key={linha.dre_linha}
+                        className={isDerivada ? 'bg-muted/30' : undefined}
+                      >
+                        <TableCell
+                          className={`sticky left-0 bg-background text-xs ${
+                            isDerivada ? 'font-medium bg-muted/30' : ''
+                          }`}
+                        >
+                          {forecastLabel(linha.dre_linha)}
+                        </TableCell>
+                        <TableCell className={`text-right text-sm ${isDerivada ? 'font-medium' : ''}`}>
+                          {fmtCompact(linha.landing)}
+                        </TableCell>
+                        <TableCell className="text-right text-sm text-muted-foreground">
+                          {linha.orcado_ano !== null ? fmtCompact(linha.orcado_ano) : '—'}
+                        </TableCell>
+                        <TableCell className={`text-right text-sm font-medium ${varianciaCor}`}>
+                          {linha.variancia !== null ? fmtCompact(linha.variancia) : '—'}
+                        </TableCell>
+                        <TableCell className={`text-right text-xs ${varianciaCor}`}>
+                          {pctVsOrc}
+                        </TableCell>
+                        <TableCell>
+                          <div className="flex flex-wrap gap-1">
+                            {linha.fura_meta && (
+                              <Badge variant="outline" className="text-[10px] text-status-warning border-status-warning/50">
+                                Vai furar a meta
+                              </Badge>
+                            )}
+                          </div>
+                        </TableCell>
+                        <TableCell>
+                          {!isDerivada && (
+                            <div className="flex flex-wrap gap-1">
+                              <Badge variant="secondary" className="text-[10px]">
+                                {linha.metodo.replace(/_/g, ' ')}
+                              </Badge>
+                              <Badge
+                                variant="outline"
+                                className={`text-[10px] ${
+                                  linha.confianca === 'baixa' ? 'text-status-warning' : 'text-muted-foreground'
+                                }`}
+                              >
+                                {linha.confianca}
+                              </Badge>
+                            </div>
+                          )}
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })}
+                </TableBody>
+              </Table>
+            </div>
+          )}
         </CardContent>
       </Card>
 


### PR DESCRIPTION
## Resumo
Fronteira #3 do programa financeiro. Constrói SOBRE o "Orçado × Realizado" existente (`/financeiro/orcamento`): projeta **onde o ano FECHA** (realizado dos meses fechados + forecast dos restantes, por **método-por-linha**) e a **variância projetada** vs orçado. **Client-side, sem migration, sem edge function, sem deploy.**

- Helper puro `src/lib/financeiro/orcamento-forecast-helpers.ts` (**20 testes**) — `projetarDRE` (pipeline ORDENADO: receita→deduções→rec.líq→cmv→…→impostos→derivadas) + primitivas.
- Métodos: receita sazonal-ajustado por tendência; deduções/cmv **driver razão-YTD** sobre base forecasted; impostos **razão-YTD** (não média cega); derivadas **calculadas** (= DRE v2); variância **sign-aware**; degradação honesta.
- Seção "Forecast de aterrissagem" na página + item na **sidebar** (rota antes órfã).
- **Codex em TODAS as etapas** (instrução do founder): metodologia + spec (10 findings) + plano (8 P1 de testes fracos) + **código adversarial (3 P1**: resultado_operacional = DRE oficial c/ financeiras; orçado-derivado não some variância; sazonal esparso → run-rate).

## Limitações v1 / v2
Versionamento de forecast, impostos regime-aware, decomposição volume/preço/mix, consolidado cross-CNPJ = v2. **sub-PR B (plano à parte):** drill de variância por categoria + seed winsorizado.

⚠️ **Follow-up de regime** (não bloqueia): a página exibe badge "Regime de Caixa" mas chama `getDRE` no default `competencia`; v1 manteve consistência (competência explícita). Confirmar qual é o correto.

## Test plan
- [x] `bun run test` — 1574 testes (20 do orçamento)
- [x] `bun run typecheck:strict` (0 erros) + `tsc --noEmit -p tsconfig.app.json` + `bun lint` (0 erros)
- [x] `bun run build`
- (sem migration, sem deploy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)