### PR TITLE
fix(sync+scoring): restaura cron de vendas, conserta calculate-scores e timeout de 13 crons

### DIFF
--- a/supabase/functions/calculate-scores/index.ts
+++ b/supabase/functions/calculate-scores/index.ts
@@ -75,6 +75,13 @@ interface FarmerClientScoreSeed {
 
 interface ScoreUpdate {
   id: string;
+  // customer_user_id + farmer_id são NOT NULL em farmer_client_scores. O upsert
+  // onConflict:'id' gera INSERT...ON CONFLICT, e o INSERT valida NOT NULL ANTES de
+  // detectar o conflito → sem estas colunas o batch inteiro estoura (erro só logado,
+  // não lançado) e nada persiste, mesmo a função retornando 200. Por isso o
+  // calculated_at ficava congelado. (incidente 2026-05-27)
+  customer_user_id: string;
+  farmer_id: string;
   health_score: number;
   health_class: string;
   churn_risk: number;
@@ -439,6 +446,9 @@ Deno.serve(async (req) => {
 
       updates.push({
         id: client.id,
+        // NOT NULL — obrigatórias no INSERT do upsert onConflict:'id' (ver ScoreUpdate)
+        customer_user_id: client.customer_user_id,
+        farmer_id: client.farmer_id,
         health_score: healthScore,
         health_class: healthClass,
         churn_risk: churnRisk,

--- a/supabase/migrations/20260527120000_data_health_rpc_fix.sql
+++ b/supabase/migrations/20260527120000_data_health_rpc_fix.sql
@@ -1,0 +1,107 @@
+-- Sentinela de Saúde de Dados — correção dos checks de carteira e omie_sync (revelados na validação).
+-- 1) carteira: get_carteira_saude() não tem chave 'status' (tem crons/sync/score_coverage) → dava
+--    'unknown' falso. Trocado por frescor direto de farmer_client_scores.calculated_at (alinhado ao
+--    design: frescor de tabela como verdade primária).
+-- 2) omie_sync: "qualquer erro em 24h = broken" era agressivo demais (flaga transitório recuperado).
+--    Trocado por STATUS DO ÚLTIMO sync (estado atual), com subqueries que sempre retornam 1 linha.
+
+CREATE OR REPLACE FUNCTION public.get_data_health()
+RETURNS TABLE (
+  source text, domain text, status text,
+  age_seconds bigint, expected_max_age_seconds bigint, freshness_basis text,
+  message text, last_error text, probable_cause text, how_to_fix text, severity text
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_full boolean;
+BEGIN
+  IF auth.uid() IS NULL THEN
+    RAISE EXCEPTION 'Acesso negado: não autenticado' USING ERRCODE = '42501';
+  END IF;
+  v_full := COALESCE(public.pode_ver_carteira_completa(auth.uid()), false);
+
+  RETURN QUERY
+  WITH checks AS (
+    -- ── FINANCEIRO: saldo bancário ──
+    SELECT 'saldo_bancario'::text AS source, 'financeiro'::text AS domain,
+      CASE WHEN max(cc.saldo_data) IS NULL THEN 'broken'
+           WHEN now() - max(cc.saldo_data)::timestamptz > interval '36 hours' THEN 'stale'
+           ELSE 'ok' END AS status,
+      EXTRACT(EPOCH FROM now() - max(cc.saldo_data)::timestamptz)::bigint AS age_seconds,
+      (36*3600)::bigint AS expected_max_age_seconds, 'max_saldo_data'::text AS freshness_basis,
+      CASE WHEN max(cc.saldo_data) IS NULL THEN 'Saldo bancário nunca sincronizou'
+           ELSE 'Saldo bancário: último sync ' || to_char(max(cc.saldo_data), 'DD/MM') END AS message,
+      NULL::text AS last_error,
+      CASE WHEN max(cc.saldo_data) IS NULL THEN 'ListarExtrato falhando ou nunca rodou' ELSE NULL END AS probable_cause,
+      'Rode sync_contas_correntes no chat do Lovable e cheque os logs do omie-financeiro'::text AS how_to_fix,
+      'critical'::text AS severity
+    FROM public.fin_contas_correntes cc WHERE cc.ativo = true
+
+    UNION ALL
+    -- ── FINANCEIRO: contas a receber ──
+    SELECT 'contas_receber', 'financeiro',
+      CASE WHEN max(cr.updated_at) IS NULL THEN 'broken'
+           WHEN now() - max(cr.updated_at) > interval '26 hours' THEN 'stale' ELSE 'ok' END,
+      EXTRACT(EPOCH FROM now() - max(cr.updated_at))::bigint, (26*3600)::bigint, 'max_updated_at',
+      'Contas a receber: atualizado ' || COALESCE(to_char(max(cr.updated_at),'DD/MM HH24:MI'),'nunca'),
+      NULL, CASE WHEN max(cr.updated_at) IS NULL THEN 'Sync CR nunca completou' ELSE NULL END,
+      'Rode sync_contas_receber no Lovable', 'warning'
+    FROM public.fin_contas_receber cr
+
+    UNION ALL
+    -- ── FINANCEIRO: contas a pagar ──
+    SELECT 'contas_pagar', 'financeiro',
+      CASE WHEN max(cp.updated_at) IS NULL THEN 'broken'
+           WHEN now() - max(cp.updated_at) > interval '26 hours' THEN 'stale' ELSE 'ok' END,
+      EXTRACT(EPOCH FROM now() - max(cp.updated_at))::bigint, (26*3600)::bigint, 'max_updated_at',
+      'Contas a pagar: atualizado ' || COALESCE(to_char(max(cp.updated_at),'DD/MM HH24:MI'),'nunca'),
+      NULL, CASE WHEN max(cp.updated_at) IS NULL THEN 'Sync CP nunca completou' ELSE NULL END,
+      'Rode sync_contas_pagar no Lovable', 'warning'
+    FROM public.fin_contas_pagar cp
+
+    UNION ALL
+    -- ── OMIE SYNC: status do ÚLTIMO sync financeiro (estado atual, não "qualquer erro em 24h") ──
+    SELECT 'omie_sync_financeiro'::text, 'omie_sync'::text,
+      COALESCE((SELECT CASE WHEN l.status = 'error' THEN 'broken' ELSE 'ok' END
+                FROM public.fin_sync_log l WHERE l.completed_at IS NOT NULL
+                ORDER BY l.completed_at DESC LIMIT 1), 'unknown'),
+      (SELECT EXTRACT(EPOCH FROM now() - l.completed_at)::bigint
+                FROM public.fin_sync_log l WHERE l.completed_at IS NOT NULL
+                ORDER BY l.completed_at DESC LIMIT 1),
+      NULL::bigint, 'fin_sync_log'::text,
+      'Último sync financeiro: ' || COALESCE(
+        (SELECT l.status FROM public.fin_sync_log l WHERE l.completed_at IS NOT NULL ORDER BY l.completed_at DESC LIMIT 1),
+        'sem registro'),
+      (SELECT l.error_message FROM public.fin_sync_log l
+       WHERE l.status='error' AND l.completed_at IS NOT NULL ORDER BY l.completed_at DESC LIMIT 1),
+      CASE WHEN (SELECT l.status FROM public.fin_sync_log l WHERE l.completed_at IS NOT NULL ORDER BY l.completed_at DESC LIMIT 1) = 'error'
+           THEN 'A última action de sync financeiro falhou' ELSE NULL END,
+      'Cheque fin_sync_log e re-rode a action que falhou'::text, 'critical'::text
+
+    UNION ALL
+    -- ── CARTEIRA: frescor de farmer_client_scores.calculated_at (scoring noturno) ──
+    SELECT 'carteira_scores'::text, 'carteira'::text,
+      CASE WHEN max(fcs.calculated_at) IS NULL THEN 'broken'
+           WHEN now() - max(fcs.calculated_at) > interval '36 hours' THEN 'stale' ELSE 'ok' END,
+      EXTRACT(EPOCH FROM now() - max(fcs.calculated_at))::bigint, (36*3600)::bigint, 'calculated_at',
+      'Scoring de carteira: recalculado ' || COALESCE(to_char(max(fcs.calculated_at),'DD/MM HH24:MI'),'nunca'),
+      NULL, CASE WHEN max(fcs.calculated_at) IS NULL THEN 'calculate-scores nunca rodou' ELSE NULL END,
+      'Re-rode calculate-scores / scoring-recalc-batch no Lovable', 'warning'
+    FROM public.farmer_client_scores fcs
+  )
+  SELECT
+    c.source, c.domain, COALESCE(NULLIF(c.status, ''), 'unknown'),
+    c.age_seconds, c.expected_max_age_seconds, c.freshness_basis, c.message,
+    CASE WHEN v_full THEN c.last_error ELSE NULL END,
+    CASE WHEN v_full THEN c.probable_cause ELSE NULL END,
+    CASE WHEN v_full THEN c.how_to_fix ELSE NULL END,
+    c.severity
+  FROM checks c;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.get_data_health() FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.get_data_health() TO authenticated;

--- a/supabase/migrations/20260527160000_cron_vendas_sync_pedidos.sql
+++ b/supabase/migrations/20260527160000_cron_vendas_sync_pedidos.sql
@@ -1,0 +1,65 @@
+-- Restaura o cron do sync INBOUND de pedidos de venda (omie-vendas-sync / sync_pedidos),
+-- que cria linha nova em sales_orders a partir do Omie.
+--
+-- CONTEXTO (incidente 2026-05-27): sales_orders ficou congelada por 8 dias (oben parou em
+-- 19/05; colacor em 17/04). Causa-raiz: NENHUM cron chamava omie-vendas-sync sync_pedidos.
+-- Os crons de vendas ativos chamam omie-analytics-sync (que SÓ enriquece pedido existente,
+-- gate `if (existingOrder)`, e ainda morre 546 WORKER_RESOURCE_LIMIT). O cron de sync_pedidos
+-- existia no banco mas nunca foi versionado em migration → foi perdido sem rastro.
+-- ESTA migration versiona o cron pra que isso não se repita (a lição do incidente).
+--
+-- Desenho (revisado com codex): contas separadas e escalonadas; janela ROLANTE (data de/até
+-- computadas em runtime, fuso America/Sao_Paulo, 5 dias de margem — a função é idempotente por
+-- hash_payload, então overlap é barato e não duplica); max_pages 10 (bounded p/ caber no
+-- wall-clock ~150s da edge). sync_pedidos (insert) roda ANTES do enrich do analytics-sync.
+-- Monitoramento: omie-vendas-sync loga em fin_sync_log (action='sync_pedidos') → o watchdog
+-- fin_sync_watchdog (#321/#330) passa a cobrir vendas. cron.schedule faz upsert por nome
+-- (idempotente — pode rerodar).
+
+-- OBEN (carteira principal) — a cada 2h, :05
+SELECT cron.schedule(
+  'vendas-sync-pedidos-oben-2h',
+  '5 */2 * * *',
+  $cron$
+  SELECT net.http_post(
+    url := 'https://fzvklzpomgnyikkfkzai.supabase.co/functions/v1/omie-vendas-sync',
+    headers := jsonb_build_object(
+      'Content-Type','application/json',
+      'x-cron-secret', (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'CRON_SECRET' LIMIT 1)
+    ),
+    body := jsonb_build_object(
+      'action','sync_pedidos',
+      'account','oben',
+      'date_from', to_char((now() AT TIME ZONE 'America/Sao_Paulo')::date - 5, 'DD/MM/YYYY'),
+      'date_to',   to_char((now() AT TIME ZONE 'America/Sao_Paulo')::date,     'DD/MM/YYYY'),
+      'start_page', 1,
+      'max_pages', 10
+    ),
+    timeout_milliseconds := 150000
+  );
+  $cron$
+);
+
+-- COLACOR — a cada 2h, :20 (escalonado 15min depois do oben)
+SELECT cron.schedule(
+  'vendas-sync-pedidos-colacor-2h',
+  '20 */2 * * *',
+  $cron$
+  SELECT net.http_post(
+    url := 'https://fzvklzpomgnyikkfkzai.supabase.co/functions/v1/omie-vendas-sync',
+    headers := jsonb_build_object(
+      'Content-Type','application/json',
+      'x-cron-secret', (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'CRON_SECRET' LIMIT 1)
+    ),
+    body := jsonb_build_object(
+      'action','sync_pedidos',
+      'account','colacor',
+      'date_from', to_char((now() AT TIME ZONE 'America/Sao_Paulo')::date - 5, 'DD/MM/YYYY'),
+      'date_to',   to_char((now() AT TIME ZONE 'America/Sao_Paulo')::date,     'DD/MM/YYYY'),
+      'start_page', 1,
+      'max_pages', 10
+    ),
+    timeout_milliseconds := 150000
+  );
+  $cron$
+);

--- a/supabase/migrations/20260527170000_crons_timeout_fix.sql
+++ b/supabase/migrations/20260527170000_crons_timeout_fix.sql
@@ -1,0 +1,138 @@
+-- Fix sistêmico: 13 crons sem timeout_milliseconds explícito → pg_net usava o DEFAULT de 5s.
+-- Qualquer função que leva >5s era ABORTADA aos 5s e a edge cancelada antes de gravar, enquanto
+-- cron.job_run_details mostrava "succeeded" (só registra o enqueue do net.http_post). Falha
+-- silenciosa de uma classe inteira de jobs. Descoberto via o incidente do calculate-scores
+-- (2026-05-27), cujo cron daily-calculate-scores tinha o mesmo bug (corrigido em migration própria).
+--
+-- Fix: re-agenda cada um com timeout_milliseconds := 150000 (teto de wall-clock da edge — nunca
+-- aborta antes do limite da própria função). cron.schedule faz upsert por nome (idempotente).
+-- Comandos preservados verbatim do banco, só adicionando o timeout. sayerlack-portal-watchdog
+-- (~350ms, */5) não era bomba, mas ganha o timeout por uniformidade/segurança.
+
+-- 1) carteira-positivacao-snapshot-mensal
+SELECT cron.schedule('carteira-positivacao-snapshot-mensal', '0 8 1 * *', $cron$
+SELECT net.http_post(
+  url := 'https://fzvklzpomgnyikkfkzai.supabase.co/functions/v1/carteira-positivacao-snapshot',
+  headers := jsonb_build_object('x-cron-secret', (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name='CRON_SECRET' LIMIT 1)),
+  timeout_milliseconds := 150000
+);
+$cron$);
+
+-- 2) carteira-rebuild-nightly
+SELECT cron.schedule('carteira-rebuild-nightly', '30 7 * * *', $cron$
+SELECT net.http_post(
+  url := 'https://fzvklzpomgnyikkfkzai.supabase.co/functions/v1/carteira-rebuild',
+  headers := jsonb_build_object('x-cron-secret', (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name='CRON_SECRET' LIMIT 1)),
+  timeout_milliseconds := 150000
+);
+$cron$);
+
+-- 3) compute-association-rules-daily
+SELECT cron.schedule('compute-association-rules-daily', '30 7 * * *', $cron$
+SELECT net.http_post(
+  url:='https://fzvklzpomgnyikkfkzai.supabase.co/functions/v1/omie-analytics-sync',
+  headers:=jsonb_build_object('Content-Type','application/json','x-cron-secret', (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name='CRON_SECRET')),
+  body:='{"action": "compute_association_rules"}'::jsonb,
+  timeout_milliseconds := 150000
+);
+$cron$);
+
+-- 4) compute-costs-daily
+SELECT cron.schedule('compute-costs-daily', '0 7 * * *', $cron$
+SELECT net.http_post(
+  url:='https://fzvklzpomgnyikkfkzai.supabase.co/functions/v1/omie-analytics-sync',
+  headers:=jsonb_build_object('Content-Type','application/json','x-cron-secret', (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name='CRON_SECRET')),
+  body:='{"action": "compute_costs"}'::jsonb,
+  timeout_milliseconds := 150000
+);
+$cron$);
+
+-- 5) monthly-tool-report
+SELECT cron.schedule('monthly-tool-report', '0 9 1 * *', $cron$
+SELECT net.http_post(
+  url:='https://fzvklzpomgnyikkfkzai.supabase.co/functions/v1/monthly-report',
+  headers:=jsonb_build_object('Content-Type','application/json','x-cron-secret', (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name='CRON_SECRET')),
+  body:='{"send_email": true}'::jsonb,
+  timeout_milliseconds := 150000
+);
+$cron$);
+
+-- 6) omie-sync-metadados-daily
+SELECT cron.schedule('omie-sync-metadados-daily', '30 8 * * *', $cron$
+SELECT net.http_post(
+  url:='https://fzvklzpomgnyikkfkzai.supabase.co/functions/v1/omie-sync-metadados',
+  headers:=jsonb_build_object('Content-Type','application/json','x-cron-secret',(SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name='CRON_SECRET')),
+  body:='{"accounts":["vendas","colacor_vendas"]}'::jsonb,
+  timeout_milliseconds := 150000
+);
+$cron$);
+
+-- 7) omie-sync-status-produtos-diario
+SELECT cron.schedule('omie-sync-status-produtos-diario', '30 6 * * *', $cron$
+SELECT net.http_post(
+  url := 'https://fzvklzpomgnyikkfkzai.supabase.co/functions/v1/omie-sync-status-produtos',
+  headers := jsonb_build_object('Content-Type', 'application/json', 'x-cron-secret', (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'CRON_SECRET' LIMIT 1)),
+  body := jsonb_build_object('empresa', 'ALL'),
+  timeout_milliseconds := 150000
+);
+$cron$);
+
+-- 8) process-recurring-orders-daily
+SELECT cron.schedule('process-recurring-orders-daily', '0 7 * * *', $cron$
+SELECT net.http_post(
+  url:='https://fzvklzpomgnyikkfkzai.supabase.co/functions/v1/process-recurring-orders',
+  headers:=jsonb_build_object('Content-Type','application/json','x-cron-secret',(SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name='CRON_SECRET')),
+  body:='{}'::jsonb,
+  timeout_milliseconds := 150000
+);
+$cron$);
+
+-- 9) sayerlack-portal-watchdog (fast ~350ms; timeout por uniformidade)
+SELECT cron.schedule('sayerlack-portal-watchdog', '*/5 * * * *', $cron$
+SELECT net.http_post(
+  url := 'https://fzvklzpomgnyikkfkzai.supabase.co/functions/v1/enviar-pedido-portal-sayerlack',
+  headers := jsonb_build_object('Content-Type', 'application/json', 'x-cron-secret', (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'CRON_SECRET' LIMIT 1)),
+  body := jsonb_build_object('watchdog', true, 'minutos', 5),
+  timeout_milliseconds := 150000
+);
+$cron$);
+
+-- 10) sync-colacor-vendas-products
+SELECT cron.schedule('sync-colacor-vendas-products', '15 6 * * *', $cron$
+SELECT net.http_post(
+  url:='https://fzvklzpomgnyikkfkzai.supabase.co/functions/v1/omie-analytics-sync',
+  headers:=jsonb_build_object('Content-Type','application/json','x-cron-secret', (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name='CRON_SECRET')),
+  body:='{"action": "sync_products", "account": "colacor_vendas", "max_pages": 50}'::jsonb,
+  timeout_milliseconds := 150000
+);
+$cron$);
+
+-- 11) sync-reprocess-operational
+SELECT cron.schedule('sync-reprocess-operational', '15 */2 * * *', $cron$
+SELECT net.http_post(
+  url:='https://fzvklzpomgnyikkfkzai.supabase.co/functions/v1/sync-reprocess',
+  headers:=jsonb_build_object('Content-Type','application/json','x-cron-secret',(SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name='CRON_SECRET')),
+  body:='{"action": "reprocess_operational", "account": "oben"}'::jsonb,
+  timeout_milliseconds := 150000
+);
+$cron$);
+
+-- 12) sync-reprocess-strategic
+SELECT cron.schedule('sync-reprocess-strategic', '30 2 * * *', $cron$
+SELECT net.http_post(
+  url:='https://fzvklzpomgnyikkfkzai.supabase.co/functions/v1/sync-reprocess',
+  headers:=jsonb_build_object('Content-Type','application/json','x-cron-secret',(SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name='CRON_SECRET')),
+  body:='{"action": "reprocess_strategic", "account": "oben"}'::jsonb,
+  timeout_milliseconds := 150000
+);
+$cron$);
+
+-- 13) weekly-algorithm-a-audit
+SELECT cron.schedule('weekly-algorithm-a-audit', '0 3 * * 0', $cron$
+SELECT net.http_post(
+  url:='https://fzvklzpomgnyikkfkzai.supabase.co/functions/v1/algorithm-a-audit',
+  headers:=jsonb_build_object('Content-Type','application/json','x-cron-secret', (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name='CRON_SECRET')),
+  body:='{"triggered_by": "cron"}'::jsonb,
+  timeout_milliseconds := 150000
+);
+$cron$);


### PR DESCRIPTION
## Contexto

Incidente diagnosticado em 2026-05-27, **puxado pelo Sentinela de Saúde de Dados** (que flagou `carteira_scores` stale). Investigação via SQL ao vivo no Lovable revelou 3 bugs encadeados/independentes.

## 3 fixes

1. **Vendas morto 8 dias** — `sales_orders` congelou (oben 19/05, colacor 17/04). Causa: **nenhum cron** chamava `omie-vendas-sync sync_pedidos` (criador inbound de `sales_orders`); o cron tinha sido perdido pq **nunca foi versionado**. A migration `20260527160000` recria oben + colacor (janela rolante 5d, `max_pages` 10, escalonados, idempotente por `hash_payload`). Backfill manual já recuperou os dois (oben→1246, colacor→1023). Desenho revisado com codex.

2. **`calculate-scores` não persistia** — o update-path (`upsert` `onConflict:'id'`) mandava batch parcial **sem `customer_user_id`/`farmer_id`** (NOT NULL sem default). `INSERT...ON CONFLICT` valida NOT NULL **antes** do conflito → batch estourava, erro só logado (não lançado), função retornava `200 "6908 clients"` **sem gravar** → `calculated_at` congelado em 25/05. Fix: incluir as 2 colunas (já disponíveis no row lido). Requer **redeploy via Lovable**.

3. **13 crons sem `timeout_milliseconds`** — `pg_net` usava o default de **5s** → funções >5s abortadas antes de gravar, com `job_run_details` mentindo "succeeded". Classe inteira de falha silenciosa (compute_costs, compute_association_rules, carteira-rebuild, sync-reprocess, etc.). Migration `20260527170000` re-agenda os 13 com timeout 150000.

## ⚠️ Ações manuais (Lovable)

- **SQL Editor:** as 2 migrations foram aplicadas via blocos colados (cron de vendas + timeout dos 13). Idempotentes (`cron.schedule` = upsert por nome).
- **Redeploy:** `calculate-scores` precisa ser redeployado via chat do Lovable (lê o arquivo da main verbatim).

## Test plan

- [x] Backfill de vendas confirmado (oben/colacor recuperaram, contagem subiu)
- [x] Cron de vendas validado (`vendas-sync-pedidos-{oben,colacor}-2h` active)
- [x] Timeout dos 13 crons validado (0 sem timeout)
- [ ] Pós-deploy: re-fire `calculate-scores` → `calculated_at` avança → Sentinela carteira = ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)