### PR TITLE
fix(seg): 403 do badge negociação paralela — matview p/ schema private

### DIFF
--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,12 +21,12 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **83** custom migrations totais
-- **407** objetos esperados (criados por estas migrations)
+- **84** custom migrations totais
+- **409** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
   - `rls_policy`: 139
   - `index`: 96
-  - `function`: 61
+  - `function`: 63
   - `table`: 57
   - `trigger`: 31
   - `cron_job`: 19
@@ -843,6 +843,13 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 ### `20260527140000_revoke_carteira_internals_anon.sql`
 
 > _Nenhum objeto extraído via regex._ Migration provavelmente é `ALTER TABLE` / `UPDATE` / `INSERT` / RLS-only. Validar manualmente.
+
+### `20260527160000_matview_ranking_negociacao_private.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `public.refresh_sku_ranking_negociacao` | — |
+| `function` | `public.get_sku_ranking_negociacao_paralela` | — |
 
 ## Próximos passos quando algo der `❌`
 

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 83
+-- Total de custom migrations: 84
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -102,7 +102,8 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260527010000', 'rls_copilot_sessions_select_own_only', '20260527010000_rls_copilot_sessions_select_own_only.sql'),
   ('20260527120000', 'clientes_nao_vinculados', '20260527120000_clientes_nao_vinculados.sql'),
   ('20260527120000', 'data_health_rpc_fix', '20260527120000_data_health_rpc_fix.sql'),
-  ('20260527140000', 'revoke_carteira_internals_anon', '20260527140000_revoke_carteira_internals_anon.sql')
+  ('20260527140000', 'revoke_carteira_internals_anon', '20260527140000_revoke_carteira_internals_anon.sql'),
+  ('20260527160000', 'matview_ranking_negociacao_private', '20260527160000_matview_ranking_negociacao_private.sql')
 )
 SELECT
   e.version,
@@ -527,7 +528,9 @@ WITH expected_objects (migration, kind, schema_name, object_name, parent_name) A
   ('clientes_nao_vinculados', 'function', 'public', 'finalize_nao_vinculados_snapshot', ''),
   ('clientes_nao_vinculados', 'rls_policy', 'public', 'nv_select', 'omie_clientes_nao_vinculados'),
   ('clientes_nao_vinculados', 'rls_policy', 'public', 'nv_state_select', 'omie_nao_vinculados_state'),
-  ('data_health_rpc_fix', 'function', 'public', 'get_data_health', '')
+  ('data_health_rpc_fix', 'function', 'public', 'get_data_health', ''),
+  ('matview_ranking_negociacao_private', 'function', 'public', 'refresh_sku_ranking_negociacao', ''),
+  ('matview_ranking_negociacao_private', 'function', 'public', 'get_sku_ranking_negociacao_paralela', '')
 )
 SELECT
   e.migration,

--- a/src/components/reposicao/negociacaoParalela/useNegociacaoParalela.ts
+++ b/src/components/reposicao/negociacaoParalela/useNegociacaoParalela.ts
@@ -77,11 +77,11 @@ export function useNegociacaoParalela() {
   const { data: ranking = [], isLoading: loadingRanking } = useQuery({
     queryKey: ["negociacao-paralela-ranking", EMPRESA],
     queryFn: async () => {
+      // A matview foi movida p/ schema `private` (não exposto via REST direto);
+      // o ranking vem por RPC SECURITY DEFINER staff-guard, que já filtra a
+      // empresa e ordena por score_final desc no servidor.
       const { data, error } = await supabase
-        .from("mv_sku_ranking_negociacao_paralela" as never)
-        .select("*")
-        .eq("empresa", EMPRESA)
-        .order("score_final", { ascending: false });
+        .rpc("get_sku_ranking_negociacao_paralela" as never, { p_empresa: EMPRESA } as never);
       if (error) throw error;
       return (data ?? []) as unknown as RankingRow[];
     },

--- a/supabase/migrations/20260527160000_matview_ranking_negociacao_private.sql
+++ b/supabase/migrations/20260527160000_matview_ranking_negociacao_private.sql
@@ -1,0 +1,93 @@
+-- Corrige o 403 "permission denied for materialized view" que quebrava a view
+-- security_invoker `v_sugestao_negociacao_ativa` (badge da sidebar + páginas de
+-- negociação paralela) para TODO usuário autenticado (inclusive master).
+--
+-- Causa-raiz: a matview `mv_sku_ranking_negociacao_paralela` foi DELIBERADAMENTE
+-- revogada de anon/authenticated em 2026-05-10 (migrations 20260510223800 /
+-- 20260510235956) para não expor o ranking de compras na API. Mas a view
+-- `v_sugestao_negociacao_ativa` é `security_invoker=on` e faz LEFT JOIN com a
+-- matview só para puxar `categoria` → o invoker (qualquer staff) tenta ler a
+-- matview com os próprios privilégios e leva 403.
+--
+-- Fix (recomendação Codex): mover a matview para um schema `private` NÃO exposto
+-- pelo PostgREST. Assim o invoker pode receber GRANT SELECT (a view volta a
+-- funcionar e a RLS das tabelas-base segue valendo), mas a matview continua
+-- inacessível via /rest/v1 direto (schema não roteado) — preservando a decisão
+-- de segurança original. Nenhuma config do Supabase precisa mudar (PostgREST só
+-- expõe `public`/`graphql_public` por padrão).
+
+-- 1. Schema privado.
+CREATE SCHEMA IF NOT EXISTS private;
+
+-- 2. Move a matview (idempotente). Os índices (incl. o UNIQUE exigido pelo
+--    REFRESH ... CONCURRENTLY) seguem junto automaticamente.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relname = 'mv_sku_ranking_negociacao_paralela'
+      AND n.nspname = 'public'
+      AND c.relkind = 'm'
+  ) THEN
+    ALTER MATERIALIZED VIEW public.mv_sku_ranking_negociacao_paralela SET SCHEMA private;
+  END IF;
+END $$;
+
+-- 3. A view `v_sugestao_negociacao_ativa` (security_invoker) referencia a matview
+--    por OID, então SEGUE o move automaticamente — não precisa recriar. O invoker
+--    (authenticated) só precisa de USAGE no schema + SELECT na matview privada.
+--    Como `private` não é exposto pelo PostgREST, isso NÃO permite GET direto em
+--    /rest/v1/mv_sku_ranking_negociacao_paralela.
+GRANT USAGE ON SCHEMA private TO authenticated;
+GRANT SELECT ON private.mv_sku_ranking_negociacao_paralela TO authenticated;
+
+-- 4. Função de REFRESH (SECURITY DEFINER) referenciava `public.mv_...` qualificado
+--    → recria apontando para `private.mv_...` (corpo verbatim, só o schema muda).
+CREATE OR REPLACE FUNCTION public.refresh_sku_ranking_negociacao()
+RETURNS TABLE(skus_ranqueados integer, atualizado_em timestamp with time zone)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'private'
+AS $$
+BEGIN
+  IF auth.uid() IS NULL OR NOT (public.has_role(auth.uid(), 'employee'::app_role) OR public.has_role(auth.uid(), 'master'::app_role)) THEN
+    RAISE EXCEPTION 'Acesso negado: requer perfil staff' USING ERRCODE = '42501';
+  END IF;
+  REFRESH MATERIALIZED VIEW CONCURRENTLY private.mv_sku_ranking_negociacao_paralela;
+  RETURN QUERY SELECT COUNT(*)::int, now() FROM private.mv_sku_ranking_negociacao_paralela;
+END;
+$$;
+
+-- 5. Geradora `sugerir_negociacao_paralela_hoje` referencia `mv_...` NÃO-qualificado
+--    no corpo → adiciona `private` ao search_path (sem recriar o corpo longo).
+--    `public` permanece primeiro: todas as outras tabelas continuam resolvendo de
+--    public; só a matview (que agora só existe em private) resolve de private.
+ALTER FUNCTION public.sugerir_negociacao_paralela_hoje(text, integer)
+  SET search_path TO 'public', 'private';
+
+-- 6. Read-RPC staff-guard para o ranking. O front-end lia a matview DIRETO
+--    (também 403 desde o revoke); como a matview agora é privada, a leitura passa
+--    por este RPC SECURITY DEFINER (mesmo gate das funções irmãs). Definer lê a
+--    matview privada; authenticated só recebe EXECUTE.
+CREATE OR REPLACE FUNCTION public.get_sku_ranking_negociacao_paralela(p_empresa text DEFAULT 'OBEN')
+RETURNS SETOF private.mv_sku_ranking_negociacao_paralela
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'public', 'private'
+AS $$
+BEGIN
+  IF auth.uid() IS NULL OR NOT (public.has_role(auth.uid(), 'employee'::app_role) OR public.has_role(auth.uid(), 'master'::app_role)) THEN
+    RAISE EXCEPTION 'Acesso negado: requer perfil staff' USING ERRCODE = '42501';
+  END IF;
+  RETURN QUERY
+    SELECT *
+    FROM private.mv_sku_ranking_negociacao_paralela
+    WHERE empresa = p_empresa
+    ORDER BY score_final DESC;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.get_sku_ranking_negociacao_paralela(text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_sku_ranking_negociacao_paralela(text) TO authenticated;


### PR DESCRIPTION
## 🔴 ATENÇÃO: migration manual necessária (Lovable → SQL Editor)
Esta PR adiciona `supabase/migrations/20260527160000_matview_ranking_negociacao_private.sql`. **O Lovable NÃO aplica automaticamente.** Cole o bloco abaixo no SQL Editor → Run, depois rode a query de validação. O front-end já aponta pro novo RPC (degrada até a migration ser aplicada).

## Problema
Badge "negociação paralela" (sidebar) → **403 `permission denied for materialized view` a cada 60s** para TODO staff (inclusive master). Diagnóstico (`has_table_privilege`): só `mv_sku_ranking_negociacao_paralela` estava sem grant (anon=false, authenticated=false) — **revogada de propósito** em 2026-05-10 (`20260510223800`/`20260510235956`) p/ não expor ranking de compras na API. Mas a view `v_sugestao_negociacao_ativa` é `security_invoker=on` e faz LEFT JOIN com a matview → o invoker (staff) tenta lê-la com os próprios privilégios → 403. Bug gêmeo: `useNegociacaoParalela` lia a matview direto (mesmo 403, não notado).

## Fix (consultado com Codex)
Mover a matview p/ schema **`private`** (não roteado pelo PostgREST → some de `/rest/v1`, sem mexer em config do Supabase). O invoker recebe `GRANT SELECT` (view volta a funcionar; RLS das tabelas-base preservada por manter `security_invoker=on`) mas a matview fica inacessível via REST direto — respeitando o revoke original. Descartado: `GRANT TO authenticated` (reverteria o hardening) e `security_invoker=off` (furaria a RLS — alerta do Codex).

Objetos:
- View `v_sugestao_negociacao_ativa`: **segue o move por OID, não recriada** (zero risco de drift nas 20 colunas).
- `refresh_sku_ranking_negociacao` (definer, `public.mv_` qualificado): recriada → `private.mv_`.
- `sugerir_negociacao_paralela_hoje` (definer, `mv_` não-qualificado): `ALTER FUNCTION ... SET search_path TO 'public','private'` (sem tocar o corpo).
- Novo `get_sku_ranking_negociacao_paralela(p_empresa)` (definer staff-guard): read-RPC do ranking; front-end migrado da leitura direta da matview p/ ele.

## SQL para colar (🟣 Lovable → SQL Editor)
```sql
CREATE SCHEMA IF NOT EXISTS private;

DO $$
BEGIN
  IF EXISTS (SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace
    WHERE c.relname='mv_sku_ranking_negociacao_paralela' AND n.nspname='public' AND c.relkind='m') THEN
    ALTER MATERIALIZED VIEW public.mv_sku_ranking_negociacao_paralela SET SCHEMA private;
  END IF;
END $$;

GRANT USAGE ON SCHEMA private TO authenticated;
GRANT SELECT ON private.mv_sku_ranking_negociacao_paralela TO authenticated;

CREATE OR REPLACE FUNCTION public.refresh_sku_ranking_negociacao()
RETURNS TABLE(skus_ranqueados integer, atualizado_em timestamp with time zone)
LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public','private' AS $$
BEGIN
  IF auth.uid() IS NULL OR NOT (public.has_role(auth.uid(),'employee'::app_role) OR public.has_role(auth.uid(),'master'::app_role)) THEN
    RAISE EXCEPTION 'Acesso negado: requer perfil staff' USING ERRCODE='42501';
  END IF;
  REFRESH MATERIALIZED VIEW CONCURRENTLY private.mv_sku_ranking_negociacao_paralela;
  RETURN QUERY SELECT COUNT(*)::int, now() FROM private.mv_sku_ranking_negociacao_paralela;
END; $$;

ALTER FUNCTION public.sugerir_negociacao_paralela_hoje(text, integer) SET search_path TO 'public','private';

CREATE OR REPLACE FUNCTION public.get_sku_ranking_negociacao_paralela(p_empresa text DEFAULT 'OBEN')
RETURNS SETOF private.mv_sku_ranking_negociacao_paralela
LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path TO 'public','private' AS $$
BEGIN
  IF auth.uid() IS NULL OR NOT (public.has_role(auth.uid(),'employee'::app_role) OR public.has_role(auth.uid(),'master'::app_role)) THEN
    RAISE EXCEPTION 'Acesso negado: requer perfil staff' USING ERRCODE='42501';
  END IF;
  RETURN QUERY SELECT * FROM private.mv_sku_ranking_negociacao_paralela WHERE empresa=p_empresa ORDER BY score_final DESC;
END; $$;

REVOKE ALL ON FUNCTION public.get_sku_ranking_negociacao_paralela(text) FROM PUBLIC;
GRANT EXECUTE ON FUNCTION public.get_sku_ranking_negociacao_paralela(text) TO authenticated;
```

## Validação (rodar depois)
```sql
SELECT
  (SELECT n.nspname FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace
     WHERE c.relname='mv_sku_ranking_negociacao_paralela') AS schema_matview,           -- esperado: private
  has_schema_privilege('authenticated','private','USAGE') AS auth_usa_private,           -- esperado: true
  has_table_privilege('authenticated','private.mv_sku_ranking_negociacao_paralela','SELECT') AS auth_le_matview, -- true
  has_function_privilege('authenticated','public.get_sku_ranking_negociacao_paralela(text)','EXECUTE') AS auth_exec_rpc, -- true
  to_regclass('public.mv_sku_ranking_negociacao_paralela') IS NULL AS matview_fora_de_public; -- true (some da API REST)
```

## Validação local
- ✅ `bunx tsc --noEmit` exit 0
- View não recriada (OID-follow) → sem risco de drift de schema
- Após apply: testar o badge (sem 403 no console) + página de negociação paralela

🤖 Generated with [Claude Code](https://claude.com/claude-code)