### PR TITLE
fix(fin): PMR/PMP/Ciclo mostram "—/sem dados" em vez de "0" falso

### DIFF
--- a/src/components/financeiro/cashflow/PosicaoAgora.tsx
+++ b/src/components/financeiro/cashflow/PosicaoAgora.tsx
@@ -84,7 +84,7 @@ export function PosicaoAgora() {
               entradas30={active.entradas_30d}
               saidas30={active.saidas_30d}
               totalCR={active.total_cr_aberto}
-              pmr={active.pmr}
+              pmr={active.pmr ?? 0}
             />
           )}
         </>

--- a/src/components/financeiro/cashflow/posicaoAgora/CicloFinanceiroCard.tsx
+++ b/src/components/financeiro/cashflow/posicaoAgora/CicloFinanceiroCard.tsx
@@ -14,6 +14,17 @@ export function CicloFinanceiroCard({ active }: { active: CapitalDeGiro }) {
         </CardTitle>
       </CardHeader>
       <CardContent className="space-y-6">
+        {(active.pmr === null || active.pmp === null || active.ciclo_financeiro === null) ? (
+          <div className="p-4 rounded-lg bg-muted/40 border text-sm text-muted-foreground">
+            <p className="font-medium text-foreground">Prazos indisponíveis</p>
+            <p className="mt-1">
+              PMR/PMP/ciclo dependem da data de baixa dos títulos, que ainda não é sincronizada
+              do Omie. Os demais indicadores desta tela (capital de giro, concentração, projeção)
+              estão corretos.
+            </p>
+          </div>
+        ) : (
+        <>
         <div className="space-y-3">
           {/* PMR Bar */}
           <div>
@@ -58,6 +69,8 @@ export function CicloFinanceiroCard({ active }: { active: CapitalDeGiro }) {
             </p>
           )}
         </div>
+        </>
+        )}
       </CardContent>
     </Card>
   );

--- a/src/components/financeiro/cashflow/posicaoAgora/ComparativoEmpresasCard.tsx
+++ b/src/components/financeiro/cashflow/posicaoAgora/ComparativoEmpresasCard.tsx
@@ -54,12 +54,13 @@ export function ComparativoEmpresasCard({ data }: { data: CapitalDeGiro[] }) {
                     {line.label}
                   </TableCell>
                   {data.map(d => {
-                    const val = (d as unknown as Record<string, unknown>)[line.field] as number || 0;
+                    const raw = (d as unknown as Record<string, unknown>)[line.field] as number | null;
+                    const val = raw ?? 0;
                     const isResult = ['capital_giro', 'capital_giro_liquido', 'saldo_projetado_30d'].includes(line.field);
                     const color = isResult ? (val >= 0 ? 'text-status-success' : 'text-status-error') : '';
                     let display = '';
                     if (line.fmt === 'currency') display = fmtCompact(val);
-                    else if (line.fmt === 'days') display = `${val}d`;
+                    else if (line.fmt === 'days') display = raw == null ? '—' : `${raw}d`; // null = prazo sem dado de baixa
                     else if (line.fmt === 'pct') display = `${val.toFixed(0)}%`;
                     return (
                       <TableCell key={d.company} className={`text-right text-sm font-medium ${color}`}>

--- a/src/components/financeiro/cashflow/posicaoAgora/KpiCards.tsx
+++ b/src/components/financeiro/cashflow/posicaoAgora/KpiCards.tsx
@@ -31,12 +31,21 @@ export function KpiCards({ active }: { active: CapitalDeGiro }) {
       />
       <div className="p-4 rounded-lg border bg-card">
         <p className="text-xs text-muted-foreground font-medium">Ciclo Financeiro</p>
-        <p className={`text-2xl font-bold mt-1 ${active.ciclo_financeiro > 0 ? 'text-status-warning' : 'text-status-success'}`}>
-          {active.ciclo_financeiro} dias
-        </p>
-        <p className="text-xs text-muted-foreground mt-1">
-          PMR {active.pmr}d − PMP {active.pmp}d
-        </p>
+        {active.ciclo_financeiro === null ? (
+          <>
+            <p className="text-2xl font-bold mt-1 text-muted-foreground">—</p>
+            <p className="text-xs text-muted-foreground mt-1">sem dados de prazo</p>
+          </>
+        ) : (
+          <>
+            <p className={`text-2xl font-bold mt-1 ${active.ciclo_financeiro > 0 ? 'text-status-warning' : 'text-status-success'}`}>
+              {active.ciclo_financeiro} dias
+            </p>
+            <p className="text-xs text-muted-foreground mt-1">
+              PMR {active.pmr ?? '—'}d − PMP {active.pmp ?? '—'}d
+            </p>
+          </>
+        )}
       </div>
     </div>
   );

--- a/src/components/financeiro/cashflow/posicaoAgora/__tests__/consolidate.test.ts
+++ b/src/components/financeiro/cashflow/posicaoAgora/__tests__/consolidate.test.ts
@@ -43,9 +43,31 @@ describe("buildConsolidated", () => {
     expect(c.top5_cr_pct).toBe(0); // concentração não consolida
   });
 
-  it("PMR/PMP = 0 quando volume zero (evita divisão por zero)", () => {
+  it("PMR/PMP = null quando volume zero (sem base pra ponderar)", () => {
     const c = buildConsolidated([mk({ total_cr_aberto: 0, pmr: 99, total_cp_aberto: 0, pmp: 99 })])!;
-    expect(c.pmr).toBe(0);
-    expect(c.pmp).toBe(0);
+    expect(c.pmr).toBeNull();
+    expect(c.pmp).toBeNull();
+    expect(c.ciclo_financeiro).toBeNull();
+  });
+
+  it("PMR/PMP = null quando nenhuma empresa tem prazo (degradação honesta, não 0 falso)", () => {
+    const c = buildConsolidated([
+      mk({ total_cr_aberto: 100, pmr: null, total_cp_aberto: 50, pmp: null }),
+      mk({ total_cr_aberto: 300, pmr: null, total_cp_aberto: 150, pmp: null }),
+    ])!;
+    expect(c.pmr).toBeNull();
+    expect(c.pmp).toBeNull();
+    expect(c.ciclo_financeiro).toBeNull();
+    expect(c.total_cr_aberto).toBe(400); // o resto continua somando
+  });
+
+  it("pondera só as empresas COM prazo, ignorando as null", () => {
+    const c = buildConsolidated([
+      mk({ total_cr_aberto: 100, pmr: 10, total_cp_aberto: 50, pmp: 20 }),
+      mk({ total_cr_aberto: 300, pmr: null, total_cp_aberto: 150, pmp: null }), // sem dado → não dilui
+    ])!;
+    expect(c.pmr).toBe(10); // só a 1ª empresa pondera (a 2ª é null)
+    expect(c.pmp).toBe(20);
+    expect(c.ciclo_financeiro).toBe(-10);
   });
 });

--- a/src/components/financeiro/cashflow/posicaoAgora/consolidate.ts
+++ b/src/components/financeiro/cashflow/posicaoAgora/consolidate.ts
@@ -9,14 +9,16 @@ export function buildConsolidated(data: CapitalDeGiro[]): CapitalDeGiro | null {
   const totalCR = data.reduce((s, d) => s + d.total_cr_aberto, 0);
   const totalCP = data.reduce((s, d) => s + d.total_cp_aberto, 0);
 
-  // PMR ponderado pelo volume de CR de cada empresa
-  const pmrWeighted = totalCR > 0
-    ? Math.round(data.reduce((s, d) => s + d.pmr * d.total_cr_aberto, 0) / totalCR)
-    : 0;
-  // PMP ponderado pelo volume de CP de cada empresa
-  const pmpWeighted = totalCP > 0
-    ? Math.round(data.reduce((s, d) => s + d.pmp * d.total_cp_aberto, 0) / totalCP)
-    : 0;
+  // PMR/PMP ponderados por volume — só entre empresas COM prazo (pmr/pmp não-null) e
+  // com volume. null (não 0) quando nenhuma empresa tem prazo, pra não diluir um número
+  // real com zeros falsos nem mostrar "0 dias" enganoso. Ver §10 (auditoria 2026-05-27).
+  const weighted = (valKey: 'pmr' | 'pmp', wKey: 'total_cr_aberto' | 'total_cp_aberto'): number | null => {
+    const elig = data.filter((d) => d[valKey] !== null);
+    const w = elig.reduce((s, d) => s + d[wKey], 0);
+    return w > 0 ? Math.round(elig.reduce((s, d) => s + (d[valKey] as number) * d[wKey], 0) / w) : null;
+  };
+  const pmrWeighted = weighted('pmr', 'total_cr_aberto');
+  const pmpWeighted = weighted('pmp', 'total_cp_aberto');
 
   return {
     company: 'consolidado',
@@ -27,7 +29,7 @@ export function buildConsolidated(data: CapitalDeGiro[]): CapitalDeGiro | null {
     capital_giro_liquido: data.reduce((s, d) => s + d.capital_giro_liquido, 0),
     pmr: pmrWeighted,
     pmp: pmpWeighted,
-    ciclo_financeiro: pmrWeighted - pmpWeighted,
+    ciclo_financeiro: pmrWeighted !== null && pmpWeighted !== null ? pmrWeighted - pmpWeighted : null,
     top5_cr_pct: 0, // Não faz sentido consolidar % de concentração
     top5_cp_pct: 0,
     entradas_30d: data.reduce((s, d) => s + d.entradas_30d, 0),

--- a/src/services/financeiroService.ts
+++ b/src/services/financeiroService.ts
@@ -478,10 +478,12 @@ export interface CapitalDeGiro {
   saldo_cc: number;             // Saldo bancário
   capital_giro: number;         // CR - CP
   capital_giro_liquido: number; // CR + CC - CP
-  // Prazos médios (dias)
-  pmr: number;                  // Prazo Médio de Recebimento
-  pmp: number;                  // Prazo Médio de Pagamento
-  ciclo_financeiro: number;     // PMR - PMP (positivo = necessidade de capital)
+  // Prazos médios (dias). NULL = sem dado de baixa (data_recebimento/pagamento NULL no
+  // sync → não dá pra calcular). Antes era 0, que parecia "conversão instantânea" e
+  // enganava o CFO. UI mostra "—/sem dados" quando null. Ver §10 (auditoria 2026-05-27).
+  pmr: number | null;           // Prazo Médio de Recebimento
+  pmp: number | null;           // Prazo Médio de Pagamento
+  ciclo_financeiro: number | null; // PMR - PMP (positivo = necessidade de capital)
   // Concentração
   top5_cr_pct: number;          // % do CR nos 5 maiores clientes
   top5_cp_pct: number;          // % do CP nos 5 maiores fornecedores
@@ -563,7 +565,9 @@ export async function getCapitalDeGiro(company: Company | 'all'): Promise<Capita
         pmrDenominator += valor;
       }
     }
-    const pmr = pmrDenominator > 0 ? Math.round(pmrNumerator / pmrDenominator) : 0;
+    // null (não 0) quando não há baixas datadas: mostrar 0 dias parece "recebimento
+    // instantâneo" e engana. Hoje o sync não popula data_recebimento → cai aqui.
+    const pmr = pmrDenominator > 0 ? Math.round(pmrNumerator / pmrDenominator) : null;
 
     // PMP: média ponderada de dias entre emissão e pagamento
     let pmpNumerator = 0, pmpDenominator = 0;
@@ -575,7 +579,7 @@ export async function getCapitalDeGiro(company: Company | 'all'): Promise<Capita
         pmpDenominator += valor;
       }
     }
-    const pmp = pmpDenominator > 0 ? Math.round(pmpNumerator / pmpDenominator) : 0;
+    const pmp = pmpDenominator > 0 ? Math.round(pmpNumerator / pmpDenominator) : null;
 
     // Concentração top 5
     const crByClient = new Map<string, number>();
@@ -611,7 +615,7 @@ export async function getCapitalDeGiro(company: Company | 'all'): Promise<Capita
       capital_giro_liquido: totalCR + totalCC - totalCP,
       pmr,
       pmp,
-      ciclo_financeiro: pmr - pmp,
+      ciclo_financeiro: pmr !== null && pmp !== null ? pmr - pmp : null,
       top5_cr_pct: totalCR > 0 ? (top5CRSum / totalCR) * 100 : 0,
       top5_cp_pct: totalCP > 0 ? (top5CPSum / totalCP) * 100 : 0,
       entradas_30d: entradas30,


### PR DESCRIPTION
## Achado-headline da auditoria "Max" (codex-validado em 3 rodadas)

O cockpit do CFO (**Posição Agora**) mostrava **PMR / PMP / Ciclo Financeiro = "0 dias"** — que parece conversão de caixa **instantânea/ótima**, mas é **dado ausente**.

**Causa-raiz:** `getCapitalDeGiro` filtra `.gte('data_recebimento'/'data_pagamento', 90d)`, mas essas colunas são **NULL em 100% dos ~39 mil títulos baixados** (24.663 `RECEBIDO`, 14.566 `PAGO`) — o payload de LISTA do Omie não traz a data de baixa → o sync grava null → denominador 0 → `pmr=pmp=ciclo=0`.

**Por que degradação honesta (e não recuperar o número):** tentei derivar a data de baixa de `fin_movimentacoes` (tem `data_movimento` + `omie_codigo_lancamento`), mas o join é **não-confiável** — **29% de dias negativos** no oben CP (baixa antes da emissão), PMP médio implausível (6-10d vs 28-60d reais), colacor CR sem cobertura. Construir PMR/PMP nisso trocaria "0 falso" por "número falso-preciso" — **pior**. O fix real exige o sync capturar a data de baixa verdadeira do Omie (peça separada; `omie_codigo_lancamento` não é chave 1:1 confiável).

## Mudança
- `pmr`/`pmp`/`ciclo_financeiro` → `number | null` (null = sem baixa datada). Serviço emite **null** em vez de 0.
- `consolidate` pondera só empresas COM prazo (null se nenhuma) — +3 casos de teste.
- 3 cards (Ciclo / Kpi / Comparativo) mostram **"—/sem dados"** com explicação ("data de baixa não sincronizada do Omie").
- `StressTest` recebe `pmr ?? 0` (já recebia 0 na prática → **zero mudança de comportamento**).
- O **resto da tela** (capital de giro, concentração, projeção 30d) usa o aberto (≤503 linhas) e **está correto** — não muda.

## Não muda (registrado pra follow-up)
O mesmo NULL-baixa pode contaminar **DRE-caixa / fluxo realizado** (codex apontou) → varredura separada. Fix real do PMR/PMP = sync capturar a data de baixa do Omie.

## Testes
typecheck:strict **0** · baseline `tsconfig.app.json` **0** · **1565/1565** vitest (consolidate +3 casos de null).

🤖 Generated with [Claude Code](https://claude.com/claude-code)