### PR TITLE
refactor(tint): extrai cálculo de preço p/ helper puro testado (money-path)

### DIFF
--- a/docs/superpowers/specs/2026-05-27-tint-recipe-hardening-design.md
+++ b/docs/superpowers/specs/2026-05-27-tint-recipe-hardening-design.md
@@ -8,7 +8,16 @@
 
 ---
 
-## ⚠️ PASSO 0 (gating — fazer ANTES de qualquer RLS): a UI mostra a receita ao cliente?
+## ✅ PASSO 0 — RESOLVIDO (2026-05-27): a UI **NÃO** mostra a receita ao cliente
+
+Verificado: `useTintPricing` tem **um único consumidor** (`useTintColorSelect.ts:185`), que usa **só** `pricing.custoCorantes` (agregado, linha 298) + `precoFinal`. **`itensCorantes`/`coranteDescricao`/`qtdMl` não são renderizados em lugar nenhum do `src/`** (grep global vazio fora do hook e dos testes). Logo: **caso "cliente só precisa do preço"** → seguir o design abaixo, sem pré-requisito de UX.
+
+### Passo 1 FEITO (PR helper-tdd): cálculo extraído + testado (oráculo do SQL)
+`computeTintPrice` em **`src/lib/tint/compute-price.ts`** (puro, espelha verbatim a lógica que estava inline; 7 testes em `__tests__/compute-price.test.ts` cobrindo paridade + edge: sem omie_product_id, volume null/0, omie ausente, corante fantasma, fórmula vazia, mix). `useTintPricing` refatorado pra chamá-lo (comportamento idêntico, agora testado). **Este helper é o oráculo de paridade que o SQL da RPC do Passo 2 deve reproduzir.** Falta: Passo 2 (RPC + RLS, rollout faseado).
+
+---
+
+## ⚠️ PASSO 0 (original — gating): a UI mostra a receita ao cliente?
 
 `useTintPricing` (`src/hooks/useTintPricing.ts`) retorna `TintPriceBreakdown` com **`itensCorantes`** (cada corante: `coranteDescricao` + `qtdMl`) — isto É a receita. É consumido em `src/components/tintColorSelect/useTintColorSelect.ts:185` (`useTintPricing(selectedFormula?.id)`), usado no wizard de pedido (`UnifiedOrder.tsx`, `SalesOrderEdit.tsx`) via `TintColorSelectDialog`.
 

--- a/src/hooks/useTintPricing.ts
+++ b/src/hooks/useTintPricing.ts
@@ -1,30 +1,20 @@
 import { useQuery } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
+import { computeTintPrice, type TintCoranteInput, type TintOmiePriceMap } from '@/lib/tint/compute-price';
 
-export interface TintCoranteItem {
-  coranteDescricao: string;
-  qtdMl: number;
-  custoPorMl: number;
-  custoItem: number;
-  custoDisponivel: boolean;
-}
-
-export interface TintPriceBreakdown {
-  custoBase: number;
-  itensCorantes: TintCoranteItem[];
-  custoCorantes: number;
-  precoFinal: number;
-}
+// O cálculo puro vive em @/lib/tint/compute-price (testado; money-path). Os tipos
+// são re-exportados aqui para manter a API pública do hook estável.
+export type { TintCoranteItem, TintPriceBreakdown } from '@/lib/tint/compute-price';
 
 export function useTintPricing(formulaId: string | null) {
   return useQuery({
     queryKey: ['tint-pricing', formulaId],
     staleTime: 5 * 60 * 1000,
     enabled: !!formulaId,
-    queryFn: async (): Promise<TintPriceBreakdown | null> => {
+    queryFn: async () => {
       if (!formulaId) return null;
 
-      // Get formula items with corante details
+      // Itens da fórmula (a "receita") + corantes + custo Omie.
       const { data: items, error } = await supabase
         .from('tint_formula_itens')
         .select('qtd_ml, ordem, corante_id')
@@ -33,7 +23,6 @@ export function useTintPricing(formulaId: string | null) {
 
       if (error || !items) return null;
 
-      // Get all corante ids
       const coranteIds = items.map(i => i.corante_id);
       const { data: corantes } = await supabase
         .from('tint_corantes')
@@ -42,9 +31,8 @@ export function useTintPricing(formulaId: string | null) {
 
       if (!corantes) return null;
 
-      // Get omie products for cost
       const omieIds = corantes.filter(c => c.omie_product_id).map(c => c.omie_product_id!);
-      const omieProducts: Record<string, { valor_unitario: number }> = {};
+      const omieProducts: TintOmiePriceMap = {};
       if (omieIds.length > 0) {
         const { data: prods } = await supabase
           .from('omie_products')
@@ -55,27 +43,7 @@ export function useTintPricing(formulaId: string | null) {
         }
       }
 
-      const itensCorantes: TintCoranteItem[] = items.map(item => {
-        const corante = corantes.find(c => c.id === item.corante_id);
-        if (!corante) return { coranteDescricao: '?', qtdMl: item.qtd_ml, custoPorMl: 0, custoItem: 0, custoDisponivel: false };
-
-        const omie = corante.omie_product_id ? omieProducts[corante.omie_product_id] : null;
-        const custoDisponivel = !!omie && !!corante.volume_total_ml && corante.volume_total_ml > 0;
-        const custoPorMl = custoDisponivel ? omie!.valor_unitario / corante.volume_total_ml : 0;
-        const custoItem = item.qtd_ml * custoPorMl;
-
-        return {
-          coranteDescricao: corante.descricao,
-          qtdMl: item.qtd_ml,
-          custoPorMl,
-          custoItem,
-          custoDisponivel,
-        };
-      });
-
-      const custoCorantes = itensCorantes.reduce((sum, i) => sum + i.custoItem, 0);
-
-      return { custoBase: 0, itensCorantes, custoCorantes, precoFinal: custoCorantes };
+      return computeTintPrice(items, corantes as TintCoranteInput[], omieProducts);
     },
   });
 }

--- a/src/lib/tint/__tests__/compute-price.test.ts
+++ b/src/lib/tint/__tests__/compute-price.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import {
+  computeTintPrice,
+  type TintFormulaItemInput,
+  type TintCoranteInput,
+  type TintOmiePriceMap,
+} from '../compute-price';
+
+describe('computeTintPrice', () => {
+  it('soma o custo de cada corante: qtd_ml × (valor_unitario / volume_total_ml)', () => {
+    const items: TintFormulaItemInput[] = [
+      { corante_id: 'c1', qtd_ml: 10 },
+      { corante_id: 'c2', qtd_ml: 5 },
+    ];
+    const corantes: TintCoranteInput[] = [
+      { id: 'c1', descricao: 'Amarelo', volume_total_ml: 1000, omie_product_id: 'o1' },
+      { id: 'c2', descricao: 'Azul', volume_total_ml: 500, omie_product_id: 'o2' },
+    ];
+    const omie: TintOmiePriceMap = {
+      o1: { valor_unitario: 100 }, // 100/1000 = 0,1 /ml → 10ml = 1,00
+      o2: { valor_unitario: 50 }, //  50/500  = 0,1 /ml →  5ml = 0,50
+    };
+
+    const r = computeTintPrice(items, corantes, omie);
+
+    expect(r.itensCorantes).toHaveLength(2);
+    expect(r.itensCorantes[0]).toMatchObject({ coranteDescricao: 'Amarelo', qtdMl: 10, custoPorMl: 0.1, custoItem: 1, custoDisponivel: true });
+    expect(r.itensCorantes[1]).toMatchObject({ coranteDescricao: 'Azul', qtdMl: 5, custoPorMl: 0.1, custoItem: 0.5, custoDisponivel: true });
+    expect(r.custoCorantes).toBeCloseTo(1.5, 10);
+    expect(r.precoFinal).toBeCloseTo(1.5, 10);
+    expect(r.custoBase).toBe(0);
+  });
+
+  it('corante sem omie_product_id → custo 0 e custoDisponivel=false (não fabrica preço)', () => {
+    const items = [{ corante_id: 'c1', qtd_ml: 10 }];
+    const corantes: TintCoranteInput[] = [
+      { id: 'c1', descricao: 'Sem Omie', volume_total_ml: 1000, omie_product_id: null },
+    ];
+    const r = computeTintPrice(items, corantes, {});
+    expect(r.itensCorantes[0]).toMatchObject({ custoPorMl: 0, custoItem: 0, custoDisponivel: false });
+    expect(r.custoCorantes).toBe(0);
+  });
+
+  it('volume_total_ml null ou 0 → custoDisponivel=false e custo 0 (evita divisão por zero)', () => {
+    const items = [{ corante_id: 'c1', qtd_ml: 10 }, { corante_id: 'c2', qtd_ml: 10 }];
+    const corantes: TintCoranteInput[] = [
+      { id: 'c1', descricao: 'Vol null', volume_total_ml: null, omie_product_id: 'o1' },
+      { id: 'c2', descricao: 'Vol zero', volume_total_ml: 0, omie_product_id: 'o2' },
+    ];
+    const omie: TintOmiePriceMap = { o1: { valor_unitario: 100 }, o2: { valor_unitario: 100 } };
+    const r = computeTintPrice(items, corantes, omie);
+    expect(r.itensCorantes[0].custoDisponivel).toBe(false);
+    expect(r.itensCorantes[0].custoItem).toBe(0);
+    expect(r.itensCorantes[1].custoDisponivel).toBe(false);
+    expect(r.itensCorantes[1].custoItem).toBe(0);
+    expect(r.custoCorantes).toBe(0);
+  });
+
+  it('omie_product_id presente mas sem entrada no mapa de preços → custo 0', () => {
+    const items = [{ corante_id: 'c1', qtd_ml: 10 }];
+    const corantes: TintCoranteInput[] = [
+      { id: 'c1', descricao: 'Omie ausente', volume_total_ml: 1000, omie_product_id: 'o-faltando' },
+    ];
+    const r = computeTintPrice(items, corantes, {});
+    expect(r.itensCorantes[0]).toMatchObject({ custoPorMl: 0, custoItem: 0, custoDisponivel: false });
+    expect(r.custoCorantes).toBe(0);
+  });
+
+  it('item cujo corante não existe na lista → placeholder "?" com custo 0', () => {
+    const items = [{ corante_id: 'fantasma', qtd_ml: 10 }];
+    const r = computeTintPrice(items, [], {});
+    expect(r.itensCorantes[0]).toMatchObject({ coranteDescricao: '?', qtdMl: 10, custoItem: 0, custoDisponivel: false });
+    expect(r.custoCorantes).toBe(0);
+  });
+
+  it('fórmula sem itens → tudo zerado', () => {
+    const r = computeTintPrice([], [], {});
+    expect(r.itensCorantes).toEqual([]);
+    expect(r.custoCorantes).toBe(0);
+    expect(r.precoFinal).toBe(0);
+    expect(r.custoBase).toBe(0);
+  });
+
+  it('mistura disponível + indisponível → soma só o que tem custo', () => {
+    const items = [{ corante_id: 'c1', qtd_ml: 10 }, { corante_id: 'c2', qtd_ml: 20 }];
+    const corantes: TintCoranteInput[] = [
+      { id: 'c1', descricao: 'Com custo', volume_total_ml: 100, omie_product_id: 'o1' }, // 200/100=2/ml ×10 = 20
+      { id: 'c2', descricao: 'Sem custo', volume_total_ml: 100, omie_product_id: null },
+    ];
+    const omie: TintOmiePriceMap = { o1: { valor_unitario: 200 } };
+    const r = computeTintPrice(items, corantes, omie);
+    expect(r.itensCorantes[0].custoItem).toBe(20);
+    expect(r.itensCorantes[1].custoItem).toBe(0);
+    expect(r.custoCorantes).toBe(20);
+    expect(r.precoFinal).toBe(20);
+  });
+});

--- a/src/lib/tint/compute-price.ts
+++ b/src/lib/tint/compute-price.ts
@@ -1,0 +1,74 @@
+// Cálculo puro do preço de uma fórmula tintométrica (custo dos corantes).
+// Espelha VERBATIM a lógica que vivia inline em `useTintPricing` — extraído para:
+//  (a) tornar o money-path de preço testável (antes não era), e
+//  (b) servir de oráculo de paridade para a futura RPC SQL `get_tint_price`
+//      (hardening da receita; ver
+//      docs/superpowers/specs/2026-05-27-tint-recipe-hardening-design.md).
+// Qualquer mudança aqui muda o preço cobrado — alterar só com teste de paridade.
+
+export interface TintCoranteItem {
+  coranteDescricao: string;
+  qtdMl: number;
+  custoPorMl: number;
+  custoItem: number;
+  custoDisponivel: boolean;
+}
+
+export interface TintPriceBreakdown {
+  custoBase: number;
+  itensCorantes: TintCoranteItem[];
+  custoCorantes: number;
+  precoFinal: number;
+}
+
+/** Item da fórmula: quantidade de um corante (a "receita" — IP a proteger). */
+export interface TintFormulaItemInput {
+  qtd_ml: number;
+  corante_id: string;
+}
+
+/** Corante e seu vínculo com o produto Omie (para custo). */
+export interface TintCoranteInput {
+  id: string;
+  descricao: string;
+  volume_total_ml: number | null;
+  omie_product_id: string | null;
+}
+
+/** `valor_unitario` do produto Omie, indexado por `omie_product_id`. */
+export type TintOmiePriceMap = Record<string, { valor_unitario: number }>;
+
+/**
+ * Custo dos corantes de uma fórmula = Σ (qtd_ml × valor_unitario / volume_total_ml).
+ * `custoBase` é 0 (a base entra no preço fora deste cálculo, no consumidor).
+ * `precoFinal` aqui = `custoCorantes` (idêntico ao comportamento original).
+ */
+export function computeTintPrice(
+  items: TintFormulaItemInput[],
+  corantes: TintCoranteInput[],
+  omieProducts: TintOmiePriceMap,
+): TintPriceBreakdown {
+  const itensCorantes: TintCoranteItem[] = items.map((item) => {
+    const corante = corantes.find((c) => c.id === item.corante_id);
+    if (!corante) {
+      return { coranteDescricao: '?', qtdMl: item.qtd_ml, custoPorMl: 0, custoItem: 0, custoDisponivel: false };
+    }
+
+    const omie = corante.omie_product_id ? omieProducts[corante.omie_product_id] : null;
+    const custoDisponivel = !!omie && !!corante.volume_total_ml && corante.volume_total_ml > 0;
+    const custoPorMl = custoDisponivel ? omie!.valor_unitario / corante.volume_total_ml! : 0;
+    const custoItem = item.qtd_ml * custoPorMl;
+
+    return {
+      coranteDescricao: corante.descricao,
+      qtdMl: item.qtd_ml,
+      custoPorMl,
+      custoItem,
+      custoDisponivel,
+    };
+  });
+
+  const custoCorantes = itensCorantes.reduce((sum, i) => sum + i.custoItem, 0);
+
+  return { custoBase: 0, itensCorantes, custoCorantes, precoFinal: custoCorantes };
+}


### PR DESCRIPTION
## Resumo
Passo 1 do hardening da receita tintométrica (spec `docs/superpowers/specs/2026-05-27-tint-recipe-hardening-design.md`). **Sem mudança de comportamento** — só extrai e testa o cálculo de preço.

## Passo 0 (gating) — RESOLVIDO
`useTintPricing` tem **1 consumidor** (`useTintColorSelect:185`) que usa só `custoCorantes`/`precoFinal`. **`itensCorantes` (a receita) NÃO é renderizado em nenhum lugar** do `src/` → caso "cliente só precisa do preço", sem pré-requisito de UX pro hardening.

## O que mudou
- **Novo** `src/lib/tint/compute-price.ts` — `computeTintPrice(items, corantes, omieProducts)` puro, espelha verbatim a lógica que estava inline. Tipos movidos pra cá (re-exportados de `useTintPricing` → API estável).
- **Novo** `__tests__/compute-price.test.ts` — 7 testes (paridade + edge: sem omie_product_id, volume null/0, omie ausente, corante fantasma, vazio, mix).
- `useTintPricing` refatorado pra chamar o helper (comportamento idêntico).

## Por quê
O money-path de preço de tinta custom **não era testado**. Agora é. E o helper vira o **oráculo de paridade** pro SQL da RPC `get_tint_price` do Passo 2 (rollout faseado RPC+RLS, a fazer com o founder — não toca DB nesta PR).

## Validação
- ✅ `bunx tsc --noEmit` exit 0
- ✅ 18 testes tint (7 novos + 11 tintColorSelect) — zero regressão
- Sem DB, sem mudança de comportamento, sem mudança de preço

🤖 Generated with [Claude Code](https://claude.com/claude-code)