### PR TITLE
feat(tint): useTintPricing → RPC get_tint_price (Fase 2 do hardening da receita)

### DIFF
--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,15 +21,15 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **84** custom migrations totais
-- **409** objetos esperados (criados por estas migrations)
+- **88** custom migrations totais
+- **426** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
   - `rls_policy`: 139
   - `index`: 96
-  - `function`: 63
+  - `function`: 65
   - `table`: 57
+  - `cron_job`: 34
   - `trigger`: 31
-  - `cron_job`: 19
   - `enum_value`: 4
 
 ## Inventário por migration
@@ -844,12 +844,49 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 
 > _Nenhum objeto extraído via regex._ Migration provavelmente é `ALTER TABLE` / `UPDATE` / `INSERT` / RLS-only. Validar manualmente.
 
+### `20260527160000_cron_vendas_sync_pedidos.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `cron_job` | `cron.vendas-sync-pedidos-oben-2h` | — |
+| `cron_job` | `cron.vendas-sync-pedidos-colacor-2h` | — |
+
 ### `20260527160000_matview_ranking_negociacao_private.sql`
 
 | Tipo | Objeto | Parent |
 | --- | --- | --- |
 | `function` | `public.refresh_sku_ranking_negociacao` | — |
 | `function` | `public.get_sku_ranking_negociacao_paralela` | — |
+
+### `20260527170000_crons_timeout_fix.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `cron_job` | `cron.carteira-positivacao-snapshot-mensal` | — |
+| `cron_job` | `cron.carteira-rebuild-nightly` | — |
+| `cron_job` | `cron.compute-association-rules-daily` | — |
+| `cron_job` | `cron.compute-costs-daily` | — |
+| `cron_job` | `cron.monthly-tool-report` | — |
+| `cron_job` | `cron.omie-sync-metadados-daily` | — |
+| `cron_job` | `cron.omie-sync-status-produtos-diario` | — |
+| `cron_job` | `cron.process-recurring-orders-daily` | — |
+| `cron_job` | `cron.sayerlack-portal-watchdog` | — |
+| `cron_job` | `cron.sync-colacor-vendas-products` | — |
+| `cron_job` | `cron.sync-reprocess-operational` | — |
+| `cron_job` | `cron.sync-reprocess-strategic` | — |
+| `cron_job` | `cron.weekly-algorithm-a-audit` | — |
+
+### `20260527180000_data_health_add_vendas.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `public.get_data_health` | — |
+
+### `20260527180000_get_tint_price_rpc.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `public.get_tint_price` | — |
 
 ## Próximos passos quando algo der `❌`
 

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 84
+-- Total de custom migrations: 88
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -103,7 +103,11 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260527120000', 'clientes_nao_vinculados', '20260527120000_clientes_nao_vinculados.sql'),
   ('20260527120000', 'data_health_rpc_fix', '20260527120000_data_health_rpc_fix.sql'),
   ('20260527140000', 'revoke_carteira_internals_anon', '20260527140000_revoke_carteira_internals_anon.sql'),
-  ('20260527160000', 'matview_ranking_negociacao_private', '20260527160000_matview_ranking_negociacao_private.sql')
+  ('20260527160000', 'cron_vendas_sync_pedidos', '20260527160000_cron_vendas_sync_pedidos.sql'),
+  ('20260527160000', 'matview_ranking_negociacao_private', '20260527160000_matview_ranking_negociacao_private.sql'),
+  ('20260527170000', 'crons_timeout_fix', '20260527170000_crons_timeout_fix.sql'),
+  ('20260527180000', 'data_health_add_vendas', '20260527180000_data_health_add_vendas.sql'),
+  ('20260527180000', 'get_tint_price_rpc', '20260527180000_get_tint_price_rpc.sql')
 )
 SELECT
   e.version,
@@ -529,8 +533,25 @@ WITH expected_objects (migration, kind, schema_name, object_name, parent_name) A
   ('clientes_nao_vinculados', 'rls_policy', 'public', 'nv_select', 'omie_clientes_nao_vinculados'),
   ('clientes_nao_vinculados', 'rls_policy', 'public', 'nv_state_select', 'omie_nao_vinculados_state'),
   ('data_health_rpc_fix', 'function', 'public', 'get_data_health', ''),
+  ('cron_vendas_sync_pedidos', 'cron_job', 'cron', 'vendas-sync-pedidos-oben-2h', ''),
+  ('cron_vendas_sync_pedidos', 'cron_job', 'cron', 'vendas-sync-pedidos-colacor-2h', ''),
   ('matview_ranking_negociacao_private', 'function', 'public', 'refresh_sku_ranking_negociacao', ''),
-  ('matview_ranking_negociacao_private', 'function', 'public', 'get_sku_ranking_negociacao_paralela', '')
+  ('matview_ranking_negociacao_private', 'function', 'public', 'get_sku_ranking_negociacao_paralela', ''),
+  ('crons_timeout_fix', 'cron_job', 'cron', 'carteira-positivacao-snapshot-mensal', ''),
+  ('crons_timeout_fix', 'cron_job', 'cron', 'carteira-rebuild-nightly', ''),
+  ('crons_timeout_fix', 'cron_job', 'cron', 'compute-association-rules-daily', ''),
+  ('crons_timeout_fix', 'cron_job', 'cron', 'compute-costs-daily', ''),
+  ('crons_timeout_fix', 'cron_job', 'cron', 'monthly-tool-report', ''),
+  ('crons_timeout_fix', 'cron_job', 'cron', 'omie-sync-metadados-daily', ''),
+  ('crons_timeout_fix', 'cron_job', 'cron', 'omie-sync-status-produtos-diario', ''),
+  ('crons_timeout_fix', 'cron_job', 'cron', 'process-recurring-orders-daily', ''),
+  ('crons_timeout_fix', 'cron_job', 'cron', 'sayerlack-portal-watchdog', ''),
+  ('crons_timeout_fix', 'cron_job', 'cron', 'sync-colacor-vendas-products', ''),
+  ('crons_timeout_fix', 'cron_job', 'cron', 'sync-reprocess-operational', ''),
+  ('crons_timeout_fix', 'cron_job', 'cron', 'sync-reprocess-strategic', ''),
+  ('crons_timeout_fix', 'cron_job', 'cron', 'weekly-algorithm-a-audit', ''),
+  ('data_health_add_vendas', 'function', 'public', 'get_data_health', ''),
+  ('get_tint_price_rpc', 'function', 'public', 'get_tint_price', '')
 )
 SELECT
   e.migration,

--- a/src/hooks/useTintPricing.ts
+++ b/src/hooks/useTintPricing.ts
@@ -1,9 +1,14 @@
 import { useQuery } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
-import { computeTintPrice, type TintCoranteInput, type TintOmiePriceMap } from '@/lib/tint/compute-price';
+import type { TintPriceBreakdown } from '@/lib/tint/compute-price';
 
-// O cálculo puro vive em @/lib/tint/compute-price (testado; money-path). Os tipos
-// são re-exportados aqui para manter a API pública do hook estável.
+// O preço vem da RPC SECURITY DEFINER `get_tint_price` (hardening da receita:
+// `tint_formula_itens` deixou de ser legível diretamente por cliente). A RPC
+// computa o custo server-side e devolve só o agregado (`custoCorantes`/
+// `precoFinal`) ao cliente; a receita (`itensCorantes`) só volta preenchida para
+// staff. O cálculo puro de referência — oráculo de paridade do SQL — vive em
+// @/lib/tint/compute-price (testado), e os tipos são re-exportados aqui para
+// manter a API pública do hook estável.
 export type { TintCoranteItem, TintPriceBreakdown } from '@/lib/tint/compute-price';
 
 export function useTintPricing(formulaId: string | null) {
@@ -11,39 +16,14 @@ export function useTintPricing(formulaId: string | null) {
     queryKey: ['tint-pricing', formulaId],
     staleTime: 5 * 60 * 1000,
     enabled: !!formulaId,
-    queryFn: async () => {
+    queryFn: async (): Promise<TintPriceBreakdown | null> => {
       if (!formulaId) return null;
 
-      // Itens da fórmula (a "receita") + corantes + custo Omie.
-      const { data: items, error } = await supabase
-        .from('tint_formula_itens')
-        .select('qtd_ml, ordem, corante_id')
-        .eq('formula_id', formulaId)
-        .order('ordem');
+      const { data, error } = await supabase
+        .rpc('get_tint_price' as never, { p_formula_id: formulaId } as never);
 
-      if (error || !items) return null;
-
-      const coranteIds = items.map(i => i.corante_id);
-      const { data: corantes } = await supabase
-        .from('tint_corantes')
-        .select('id, descricao, volume_total_ml, omie_product_id')
-        .in('id', coranteIds);
-
-      if (!corantes) return null;
-
-      const omieIds = corantes.filter(c => c.omie_product_id).map(c => c.omie_product_id!);
-      const omieProducts: TintOmiePriceMap = {};
-      if (omieIds.length > 0) {
-        const { data: prods } = await supabase
-          .from('omie_products')
-          .select('id, valor_unitario')
-          .in('id', omieIds);
-        if (prods) {
-          for (const p of prods) omieProducts[p.id] = { valor_unitario: p.valor_unitario };
-        }
-      }
-
-      return computeTintPrice(items, corantes as TintCoranteInput[], omieProducts);
+      if (error || !data) return null;
+      return data as unknown as TintPriceBreakdown;
     },
   });
 }

--- a/supabase/migrations/20260527180000_get_tint_price_rpc.sql
+++ b/supabase/migrations/20260527180000_get_tint_price_rpc.sql
@@ -1,0 +1,69 @@
+-- Fase 1 do hardening da receita tintométrica (spec
+-- docs/superpowers/specs/2026-05-27-tint-recipe-hardening-design.md).
+-- Cria a RPC SECURITY DEFINER que computa o preço de uma fórmula server-side,
+-- para que o cliente obtenha o PREÇO sem precisar ler `tint_formula_itens` (a
+-- "receita" = corante_id + qtd_ml, IP central). O gate de staff devolve o
+-- breakdown completo (`itensCorantes`) ao operador; ao cliente, só o agregado.
+--
+-- O cálculo espelha VERBATIM o helper puro testado `computeTintPrice`
+-- (src/lib/tint/compute-price.ts): custoItem = qtd_ml × valor_unitario/volume_total_ml.
+-- Diferença float (JS) × numeric (SQL) é sub-centavo e arredondada no consumidor.
+--
+-- ⚠️ ESTA migration NÃO aperta a RLS de `tint_formula_itens` — isso é a Fase 3,
+-- aplicada SÓ depois de o front-end (Fase 2) já consumir esta RPC em produção,
+-- senão o app antigo (que lê a tabela direto) quebraria. Aplicada manualmente no
+-- Lovable e validada por paridade de preço antes do cutover (2026-05-27).
+
+CREATE OR REPLACE FUNCTION public.get_tint_price(p_formula_id uuid)
+RETURNS jsonb
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_is_staff boolean;
+  v_custo_corantes numeric;
+  v_itens jsonb;
+BEGIN
+  v_is_staff := auth.uid() IS NOT NULL
+    AND (public.has_role(auth.uid(), 'employee'::app_role) OR public.has_role(auth.uid(), 'master'::app_role));
+
+  WITH calc AS (
+    SELECT
+      fi.ordem,
+      COALESCE(c.descricao, '?') AS corante_descricao,
+      fi.qtd_ml,
+      (op.valor_unitario IS NOT NULL AND c.volume_total_ml IS NOT NULL AND c.volume_total_ml > 0) AS custo_disponivel,
+      CASE WHEN op.valor_unitario IS NOT NULL AND c.volume_total_ml IS NOT NULL AND c.volume_total_ml > 0
+           THEN op.valor_unitario / c.volume_total_ml ELSE 0 END AS custo_por_ml,
+      CASE WHEN op.valor_unitario IS NOT NULL AND c.volume_total_ml IS NOT NULL AND c.volume_total_ml > 0
+           THEN fi.qtd_ml * (op.valor_unitario / c.volume_total_ml) ELSE 0 END AS custo_item
+    FROM tint_formula_itens fi
+    LEFT JOIN tint_corantes c  ON c.id = fi.corante_id
+    LEFT JOIN omie_products op ON op.id = c.omie_product_id
+    WHERE fi.formula_id = p_formula_id
+  )
+  SELECT
+    COALESCE(SUM(custo_item), 0),
+    COALESCE(jsonb_agg(jsonb_build_object(
+      'coranteDescricao', corante_descricao,
+      'qtdMl', qtd_ml,
+      'custoPorMl', custo_por_ml,
+      'custoItem', custo_item,
+      'custoDisponivel', custo_disponivel
+    ) ORDER BY ordem), '[]'::jsonb)
+  INTO v_custo_corantes, v_itens
+  FROM calc;
+
+  RETURN jsonb_build_object(
+    'custoBase', 0,
+    'custoCorantes', v_custo_corantes,
+    'precoFinal', v_custo_corantes,
+    'itensCorantes', CASE WHEN v_is_staff THEN v_itens ELSE '[]'::jsonb END
+  );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.get_tint_price(uuid) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.get_tint_price(uuid) TO authenticated;


### PR DESCRIPTION
## Resumo
Fase 2 do hardening da receita (spec `2026-05-27-tint-recipe-hardening-design.md`). `useTintPricing` troca as **3 leituras de tabela** (incl. `tint_formula_itens` = a receita) por **1 chamada à RPC** `get_tint_price`. Cliente obtém o preço sem ler a receita; staff recebe o breakdown (gate no corpo da RPC).

## Estado do rollout faseado
- **Fase 1 (RPC) — ✅ JÁ APLICADA** no Lovable e validada por paridade de preço (5 fórmulas, valores sãos; SQL espelha o helper `computeTintPrice` testado). Esta PR só **registra** a migration no histórico (`20260527180000_get_tint_price_rpc.sql`).
- **Fase 2 (esta PR)** — cutover do front-end. Ao mergear → Lovable rebuilda o SPA → o app passa a usar a RPC. Reversível (revert da PR).
- **Fase 3 (a seguir, manual)** — apertar a RLS de `tint_formula_itens` p/ staff-only. ⚠️ **Aplicar SÓ depois** de confirmar que este build está live e os preços batem no app (senão o app antigo, que lê a tabela direto, quebra).

## Validação
- ✅ `bunx tsc --noEmit` exit 0
- ✅ 18 testes tint (helper + tintColorSelect) — zero regressão
- Preço idêntico por construção (RPC = helper testado; diff float/numeric sub-centavo, arredondada no consumidor)

## ⚠️ Pós-merge (founder)
Depois do rebuild do Lovable: abrir o wizard de pedido, selecionar uma cor de tinta custom e **conferir que o preço bate** com o de antes. Confirmado isso, eu entrego o SQL da Fase 3 (RLS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)