### PR TITLE
chore(strict): promove 6 leaves (tint/picking/offline/time)

### DIFF
--- a/docs/strict-migration-lanes.md
+++ b/docs/strict-migration-lanes.md
@@ -104,6 +104,12 @@ subgrafos sujos (`noUnusedLocals`/`strictNullChecks`) → cascata. **Promova lea
   segurança #322/#324/#327), pure-leaf, strict-clean por construção — `lib/financeiro/dre-period`,
   `lib/financeiro/omie-request`. Append-only no `include`. **NÃO toco** mais nada de financeiro
   (engines/services em churn por outras sessões); fatia disjunta da `cranky-driscoll` (que não tem `lib/financeiro/*`).
+- 🔵 **`claude/strict-promote-leaf-tint-picking`** (sessão strange-hellman, 2026-05-27): lote leaf puro das lanes
+  **tint/picking/offline/time** (disjunto de hooks=loving-nash, lib-leaf=cranky-driscoll, farmer/scoring, financeiro):
+  `lib/tint/compute-price` (novo, tested), `lib/picking/view-pref`, `lib/picking/optimistic-merge`,
+  `lib/offline-handlers`, `lib/time/sp-day`, `lib/routeCrumbs`. Append-only; `typecheck:strict` verde com os 6
+  (transitivos de optimistic-merge/offline-handlers — picking-confirm/recebimento-* services + useOfflineFlush —
+  já strict-clean). Tsconfig-only, zero edição de source. **NÃO toco** scoring/visit-scoring/farmer/financeiro/hooks.
 
 ## Follow-up registrado
 

--- a/tsconfig.strict.json
+++ b/tsconfig.strict.json
@@ -496,6 +496,12 @@
     "src/hooks/unifiedOrder/useProductCatalog.ts",
     "src/lib/postgrest.ts",
     "src/lib/financeiro/dre-period.ts",
-    "src/lib/financeiro/omie-request.ts"
+    "src/lib/financeiro/omie-request.ts",
+    "src/lib/tint/compute-price.ts",
+    "src/lib/picking/view-pref.ts",
+    "src/lib/time/sp-day.ts",
+    "src/lib/routeCrumbs.ts",
+    "src/lib/picking/optimistic-merge.ts",
+    "src/lib/offline-handlers.ts"
   ]
 }


### PR DESCRIPTION
## Resumo
Promoção TypeScript strict — lote **leaf puro**, **tsconfig-only** (zero edição de source). Segue o protocolo de `docs/strict-migration-lanes.md` (leaf-first, append-only, lane reservada).

## Promovidos (6)
- `lib/tint/compute-price` (novo, 7 testes — money-path)
- `lib/picking/view-pref`, `lib/picking/optimistic-merge`
- `lib/offline-handlers`
- `lib/time/sp-day`, `lib/routeCrumbs`

`typecheck:strict` **verde com os 6** (load calmo, run completou). Os transitivos de `optimistic-merge`/`offline-handlers` (picking-confirm + recebimento-* services + useOfflineFlush) já estão strict-clean.

## Coordenação
Lanes **disjuntas** das reservas ativas: hooks (loving-nash), lib-leaf list (cranky-driscoll), farmer/scoring, financeiro (churn). Reserva registrada na lane doc no 1º commit. Append no fim do `include`, sem reordenar (evita conflito com PRs strict em voo).

## Validação
- ✅ `bun run typecheck:strict` exit 0 (CI re-valida como gate)
- Tsconfig + lane doc only

🤖 Generated with [Claude Code](https://claude.com/claude-code)