### PR TITLE
chore(strict): promove 4 leaves (dataHealth/impersonation)

### DIFF
--- a/docs/strict-migration-lanes.md
+++ b/docs/strict-migration-lanes.md
@@ -110,6 +110,10 @@ subgrafos sujos (`noUnusedLocals`/`strictNullChecks`) → cascata. **Promova lea
   `lib/offline-handlers`, `lib/time/sp-day`, `lib/routeCrumbs`. Append-only; `typecheck:strict` verde com os 6
   (transitivos de optimistic-merge/offline-handlers — picking-confirm/recebimento-* services + useOfflineFlush —
   já strict-clean). Tsconfig-only, zero edição de source. **NÃO toco** scoring/visit-scoring/farmer/financeiro/hooks.
+- 🔵 **`claude/strict-promote-leaf-datahealth-impersonation`** (sessão strange-hellman, 2026-05-27): segundo lote leaf —
+  `lib/dataHealth/{types,health-helpers}` + `lib/impersonation/{types,effective-user}`. Self-contained (types + helper
+  que importa só os próprios types); nenhum PR aberto toca essas áreas. `typecheck:strict` verde com os 4. Tsconfig-only.
+  **NÃO toco** carteira/mixgap/positivacao (farmer-adjacent) nem clientes-nao-vinculados (churn recente do #383).
 
 ## Follow-up registrado
 

--- a/tsconfig.strict.json
+++ b/tsconfig.strict.json
@@ -502,6 +502,10 @@
     "src/lib/time/sp-day.ts",
     "src/lib/routeCrumbs.ts",
     "src/lib/picking/optimistic-merge.ts",
-    "src/lib/offline-handlers.ts"
+    "src/lib/offline-handlers.ts",
+    "src/lib/dataHealth/types.ts",
+    "src/lib/dataHealth/health-helpers.ts",
+    "src/lib/impersonation/types.ts",
+    "src/lib/impersonation/effective-user.ts"
   ]
 }


### PR DESCRIPTION
## Resumo
Segunda slice da promoção strict — **leaf puro, tsconfig-only**. Segue `docs/strict-migration-lanes.md`.

## Promovidos (4)
- `lib/dataHealth/types` + `lib/dataHealth/health-helpers`
- `lib/impersonation/types` + `lib/impersonation/effective-user`

Self-contained (cada helper importa só os próprios `./types`). `typecheck:strict` **verde com os 4** (load calmo, run completou; CI re-valida como gate).

## Coordenação
Nenhum PR aberto toca essas áreas. Disjunto das reservas ativas. **Não toco** farmer-adjacent (`carteira`/`mixgap`/`positivacao`/`scoring`/`visit-scoring`) nem `clientes-nao-vinculados` (churn recente do #383). Append no fim do include, sem reordenar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)