### PR TITLE
feat(data-health): checks de estoque + reposição no Sentinela (Fase 2)

### DIFF
--- a/src/pages/AdminReposicaoCockpit.tsx
+++ b/src/pages/AdminReposicaoCockpit.tsx
@@ -26,6 +26,7 @@ import { EtapasGrid } from "@/components/reposicao/EtapasGrid";
 import { SmartAlertsSection } from "@/components/reposicao/SmartAlertsSection";
 import { MetricsStrip } from "@/components/reposicao/MetricsStrip";
 import { AuditLogSection } from "@/components/reposicao/AuditLogSection";
+import { DataHealthBanner } from "@/components/dataHealth/DataHealthBanner";
 
 export default function AdminReposicaoCockpit() {
   const navigate = useNavigate();
@@ -308,6 +309,9 @@ export default function AdminReposicaoCockpit() {
       </header>
 
       <ContinuarBanner currentStep={currentStep} />
+
+      <DataHealthBanner source="reposicao_sugestoes" />
+      <DataHealthBanner source="estoque_inventario" />
 
       <SmartAlertsSection />
 

--- a/supabase/migrations/20260527200000_data_health_add_estoque_reposicao.sql
+++ b/supabase/migrations/20260527200000_data_health_add_estoque_reposicao.sql
@@ -1,0 +1,140 @@
+-- Sentinela de Saúde de Dados — Fase 2: adiciona checks de ESTOQUE e REPOSIÇÃO (domain 'estoque').
+-- Completa a cobertura do spec original (financeiro + carteira já estavam; vendas adicionado em
+-- 20260527180000). Mesmos princípios: frescor de tabela como verdade primária, sem verde silencioso.
+--
+-- Sinais (baseline validado em prod 2026-05-27: estoque 0,4h, reposição mesmo dia):
+--  - estoque_inventario: inventory_position.synced_at (hora REAL do sync, ≠ data-Omie). Cron
+--    sync-inventory-vendas-30m (30/30min) → stale > 3h, broken se nunca.
+--  - reposicao_sugestoes: pedido_compra_sugerido.data_ciclo. Cron gerar-pedidos-diario-oben (9h15)
+--    → stale > 3 dias (threshold generoso: o ciclo pode pular dias sem demanda), broken se nunca.
+-- Ambos severity 'warning' (estoque/reposição não são money-critical como saldo/vendas).
+
+CREATE OR REPLACE FUNCTION public.get_data_health()
+RETURNS TABLE (
+  source text, domain text, status text,
+  age_seconds bigint, expected_max_age_seconds bigint, freshness_basis text,
+  message text, last_error text, probable_cause text, how_to_fix text, severity text
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_full boolean;
+BEGIN
+  IF auth.uid() IS NULL THEN
+    RAISE EXCEPTION 'Acesso negado: não autenticado' USING ERRCODE = '42501';
+  END IF;
+  v_full := COALESCE(public.pode_ver_carteira_completa(auth.uid()), false);
+
+  RETURN QUERY
+  WITH checks AS (
+    -- ── FINANCEIRO: saldo bancário ──
+    SELECT 'saldo_bancario'::text AS source, 'financeiro'::text AS domain,
+      CASE WHEN max(cc.saldo_data) IS NULL THEN 'broken'
+           WHEN now() - max(cc.saldo_data)::timestamptz > interval '36 hours' THEN 'stale' ELSE 'ok' END AS status,
+      EXTRACT(EPOCH FROM now() - max(cc.saldo_data)::timestamptz)::bigint AS age_seconds,
+      (36*3600)::bigint AS expected_max_age_seconds, 'max_saldo_data'::text AS freshness_basis,
+      CASE WHEN max(cc.saldo_data) IS NULL THEN 'Saldo bancário nunca sincronizou'
+           ELSE 'Saldo bancário: último sync ' || to_char(max(cc.saldo_data), 'DD/MM') END AS message,
+      NULL::text AS last_error,
+      CASE WHEN max(cc.saldo_data) IS NULL THEN 'ListarExtrato falhando ou nunca rodou' ELSE NULL END AS probable_cause,
+      'Rode sync_contas_correntes no chat do Lovable e cheque os logs do omie-financeiro'::text AS how_to_fix,
+      'critical'::text AS severity
+    FROM public.fin_contas_correntes cc WHERE cc.ativo = true
+    UNION ALL
+    SELECT 'contas_receber', 'financeiro',
+      CASE WHEN max(cr.updated_at) IS NULL THEN 'broken'
+           WHEN now() - max(cr.updated_at) > interval '26 hours' THEN 'stale' ELSE 'ok' END,
+      EXTRACT(EPOCH FROM now() - max(cr.updated_at))::bigint, (26*3600)::bigint, 'max_updated_at',
+      'Contas a receber: atualizado ' || COALESCE(to_char(max(cr.updated_at),'DD/MM HH24:MI'),'nunca'),
+      NULL, CASE WHEN max(cr.updated_at) IS NULL THEN 'Sync CR nunca completou' ELSE NULL END,
+      'Rode sync_contas_receber no Lovable', 'warning'
+    FROM public.fin_contas_receber cr
+    UNION ALL
+    SELECT 'contas_pagar', 'financeiro',
+      CASE WHEN max(cp.updated_at) IS NULL THEN 'broken'
+           WHEN now() - max(cp.updated_at) > interval '26 hours' THEN 'stale' ELSE 'ok' END,
+      EXTRACT(EPOCH FROM now() - max(cp.updated_at))::bigint, (26*3600)::bigint, 'max_updated_at',
+      'Contas a pagar: atualizado ' || COALESCE(to_char(max(cp.updated_at),'DD/MM HH24:MI'),'nunca'),
+      NULL, CASE WHEN max(cp.updated_at) IS NULL THEN 'Sync CP nunca completou' ELSE NULL END,
+      'Rode sync_contas_pagar no Lovable', 'warning'
+    FROM public.fin_contas_pagar cp
+    UNION ALL
+    SELECT 'omie_sync_financeiro'::text, 'omie_sync'::text,
+      COALESCE((SELECT CASE WHEN l.status='error' THEN 'broken' ELSE 'ok' END FROM public.fin_sync_log l
+                WHERE l.completed_at IS NOT NULL ORDER BY l.completed_at DESC LIMIT 1), 'unknown'),
+      (SELECT EXTRACT(EPOCH FROM now() - l.completed_at)::bigint FROM public.fin_sync_log l
+                WHERE l.completed_at IS NOT NULL ORDER BY l.completed_at DESC LIMIT 1),
+      NULL::bigint, 'fin_sync_log'::text,
+      'Último sync financeiro: ' || COALESCE((SELECT l.status FROM public.fin_sync_log l
+        WHERE l.completed_at IS NOT NULL ORDER BY l.completed_at DESC LIMIT 1), 'sem registro'),
+      (SELECT l.error_message FROM public.fin_sync_log l WHERE l.status='error' AND l.completed_at IS NOT NULL ORDER BY l.completed_at DESC LIMIT 1),
+      CASE WHEN (SELECT l.status FROM public.fin_sync_log l WHERE l.completed_at IS NOT NULL ORDER BY l.completed_at DESC LIMIT 1)='error'
+           THEN 'A última action de sync financeiro falhou' ELSE NULL END,
+      'Cheque fin_sync_log e re-rode a action que falhou'::text, 'critical'::text
+    UNION ALL
+    -- ── VENDAS: frescor do sync inbound de pedidos (worst-of oben/colacor) ──
+    SELECT 'vendas_pedidos'::text, 'vendas'::text,
+      CASE WHEN v.oben_last IS NULL OR v.colacor_last IS NULL THEN 'broken'
+           WHEN now() - LEAST(v.oben_last, v.colacor_last) > interval '6 hours' THEN 'stale' ELSE 'ok' END,
+      EXTRACT(EPOCH FROM now() - LEAST(v.oben_last, v.colacor_last))::bigint,
+      (6*3600)::bigint, 'fin_sync_log.sync_pedidos'::text,
+      'Sync de pedidos: oben ' || COALESCE(to_char(v.oben_last,'DD/MM HH24:MI'),'nunca')
+        || ' · colacor ' || COALESCE(to_char(v.colacor_last,'DD/MM HH24:MI'),'nunca'),
+      v.last_err,
+      CASE WHEN v.oben_last IS NULL OR v.colacor_last IS NULL
+           THEN 'Cron vendas-sync-pedidos não rodou/completou para alguma conta' ELSE NULL END,
+      'Cheque os crons vendas-sync-pedidos-{oben,colacor}-2h e fin_sync_log (action sync_pedidos)'::text, 'critical'::text
+    FROM (
+      SELECT
+        (SELECT max(l.completed_at) FROM public.fin_sync_log l WHERE l.action='sync_pedidos' AND l.status='complete' AND 'oben' = ANY(l.companies)) AS oben_last,
+        (SELECT max(l.completed_at) FROM public.fin_sync_log l WHERE l.action='sync_pedidos' AND l.status='complete' AND 'colacor' = ANY(l.companies)) AS colacor_last,
+        (SELECT l.error_message FROM public.fin_sync_log l WHERE l.action='sync_pedidos' AND l.status='error' ORDER BY l.started_at DESC LIMIT 1) AS last_err
+    ) v
+    UNION ALL
+    -- ── ESTOQUE: frescor do sync de inventário (synced_at = hora real do sync) ──
+    SELECT 'estoque_inventario'::text, 'estoque'::text,
+      CASE WHEN max(ip.synced_at) IS NULL THEN 'broken'
+           WHEN now() - max(ip.synced_at) > interval '3 hours' THEN 'stale' ELSE 'ok' END,
+      EXTRACT(EPOCH FROM now() - max(ip.synced_at))::bigint, (3*3600)::bigint, 'inventory_position.synced_at',
+      'Inventário: sincronizado ' || COALESCE(to_char(max(ip.synced_at),'DD/MM HH24:MI'),'nunca'),
+      NULL, CASE WHEN max(ip.synced_at) IS NULL THEN 'sync_inventory nunca rodou' ELSE NULL END,
+      'Cheque o cron sync-inventory-vendas-30m (omie-analytics-sync sync_inventory)', 'warning'
+    FROM public.inventory_position ip
+    UNION ALL
+    -- ── REPOSIÇÃO: frescor do ciclo de sugestão de compra ──
+    SELECT 'reposicao_sugestoes'::text, 'estoque'::text,
+      CASE WHEN max(pcs.data_ciclo) IS NULL THEN 'broken'
+           WHEN current_date - max(pcs.data_ciclo) > 3 THEN 'stale' ELSE 'ok' END,
+      CASE WHEN max(pcs.data_ciclo) IS NULL THEN NULL
+           ELSE (current_date - max(pcs.data_ciclo))::bigint * 86400 END,
+      (3*86400)::bigint, 'pedido_compra_sugerido.data_ciclo',
+      'Sugestão de compra: último ciclo ' || COALESCE(to_char(max(pcs.data_ciclo),'DD/MM/YYYY'),'nunca'),
+      NULL, CASE WHEN max(pcs.data_ciclo) IS NULL THEN 'gerar-pedidos nunca gerou sugestão' ELSE NULL END,
+      'Cheque o cron gerar-pedidos-diario-oben'::text, 'warning'
+    FROM public.pedido_compra_sugerido pcs
+    UNION ALL
+    -- ── CARTEIRA: frescor de farmer_client_scores.calculated_at (scoring noturno) ──
+    SELECT 'carteira_scores'::text, 'carteira'::text,
+      CASE WHEN max(fcs.calculated_at) IS NULL THEN 'broken'
+           WHEN now() - max(fcs.calculated_at) > interval '36 hours' THEN 'stale' ELSE 'ok' END,
+      EXTRACT(EPOCH FROM now() - max(fcs.calculated_at))::bigint, (36*3600)::bigint, 'calculated_at',
+      'Scoring de carteira: recalculado ' || COALESCE(to_char(max(fcs.calculated_at),'DD/MM HH24:MI'),'nunca'),
+      NULL, CASE WHEN max(fcs.calculated_at) IS NULL THEN 'calculate-scores nunca rodou' ELSE NULL END,
+      'Re-rode calculate-scores / scoring-recalc-batch no Lovable', 'warning'
+    FROM public.farmer_client_scores fcs
+  )
+  SELECT
+    c.source, c.domain, COALESCE(NULLIF(c.status, ''), 'unknown'),
+    c.age_seconds, c.expected_max_age_seconds, c.freshness_basis, c.message,
+    CASE WHEN v_full THEN c.last_error ELSE NULL END,
+    CASE WHEN v_full THEN c.probable_cause ELSE NULL END,
+    CASE WHEN v_full THEN c.how_to_fix ELSE NULL END,
+    c.severity
+  FROM checks c;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.get_data_health() FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.get_data_health() TO authenticated;


### PR DESCRIPTION
## Contexto
Completa a cobertura do Sentinela conforme o spec original (financeiro + carteira + vendas já estavam).

## Mudanças
- **migration `20260527200000`** — `get_data_health` ganha 2 checks (domain `estoque`):
  - `estoque_inventario`: `inventory_position.synced_at` (hora real do sync ≠ data-Omie), stale > 3h
  - `reposicao_sugestoes`: `pedido_compra_sugerido.data_ciclo`, stale > 3 dias (generoso — o ciclo pode pular dias), broken se nunca
- **`AdminReposicaoCockpit`** — `<DataHealthBanner>` (estoque + reposição), não-bloqueante (só aparece se stale/broken)

Sem mudança de tipo no frontend (`HealthDomain` já tem `estoque`; `DOMAIN_LABEL` já tem "Estoque / Reposição").

✅ Baseline validado em prod: estoque 0,4h, reposição mesmo dia → ambos ficarão `ok`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)