### PR TITLE
chore(strict): promove 14 leaves .ts de components

### DIFF
--- a/docs/strict-migration-lanes.md
+++ b/docs/strict-migration-lanes.md
@@ -114,6 +114,11 @@ subgrafos sujos (`noUnusedLocals`/`strictNullChecks`) → cascata. **Promova lea
   `lib/dataHealth/{types,health-helpers}` + `lib/impersonation/{types,effective-user}`. Self-contained (types + helper
   que importa só os próprios types); nenhum PR aberto toca essas áreas. `typecheck:strict` verde com os 4. Tsconfig-only.
   **NÃO toco** carteira/mixgap/positivacao (farmer-adjacent) nem clientes-nao-vinculados (churn recente do #383).
+- 🔵 **`claude/strict-promote-leaf-components`** (sessão strange-hellman, 2026-05-27): terceiro lote leaf — **`.ts` puros**
+  (types/config/format/priority, **sem JSX**) de `components/{adminCustomers,aiOps,analyticsSync,customerDashboard}` +
+  `components/des/{simulador,checkinQualitativo,historico}`. 14 arquivos; imports só de `lucide-react` (pacote tipado) ou
+  os próprios `./types`. `typecheck:strict` verde. Tsconfig-only. **NÃO toco** os `useX.ts` (puxam queries/deps, não-leaf),
+  nem `components/{farmer,financeiro,customer360}` (lanes quentes / reserva cranky-driscoll).
 
 ## Follow-up registrado
 

--- a/tsconfig.strict.json
+++ b/tsconfig.strict.json
@@ -506,6 +506,20 @@
     "src/lib/dataHealth/types.ts",
     "src/lib/dataHealth/health-helpers.ts",
     "src/lib/impersonation/types.ts",
-    "src/lib/impersonation/effective-user.ts"
+    "src/lib/impersonation/effective-user.ts",
+    "src/components/adminCustomers/config.ts",
+    "src/components/adminCustomers/types.ts",
+    "src/components/aiOps/config.ts",
+    "src/components/aiOps/types.ts",
+    "src/components/analyticsSync/types.ts",
+    "src/components/customerDashboard/config.ts",
+    "src/components/customerDashboard/types.ts",
+    "src/components/customerDashboard/priority.ts",
+    "src/components/des/simulador/format.ts",
+    "src/components/des/simulador/types.ts",
+    "src/components/des/checkinQualitativo/format.ts",
+    "src/components/des/checkinQualitativo/types.ts",
+    "src/components/des/historico/format.ts",
+    "src/components/des/historico/types.ts"
   ]
 }


### PR DESCRIPTION
## Resumo
Terceira slice da promoção strict — **leaf puro, tsconfig-only**. Arquivos **`.ts` sem JSX** (types/config/format/priority) de áreas não-quentes.

## Promovidos (14)
- `components/adminCustomers/{config,types}`
- `components/aiOps/{config,types}`
- `components/analyticsSync/types`
- `components/customerDashboard/{config,types,priority}`
- `components/des/simulador/{format,types}`
- `components/des/checkinQualitativo/{format,types}`
- `components/des/historico/{format,types}`

Imports só de `lucide-react` (pacote tipado externo) ou os próprios `./types` → leaf. `typecheck:strict` **verde com os 14** (CI re-valida).

## Coordenação
**Não toco** os `useX.ts` (puxam queries/supabase → não-leaf) nem `components/{farmer,financeiro,customer360}` (lanes quentes / reserva cranky-driscoll). Append no fim do include. Lane reservada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)