### PR TITLE
feat(fin): backfill histórico de movimentações via janela no cursor (Fase 0)

### DIFF
--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,14 +21,14 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **89** custom migrations totais
-- **426** objetos esperados (criados por estas migrations)
+- **94** custom migrations totais
+- **432** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
   - `rls_policy`: 139
   - `index`: 96
-  - `function`: 65
+  - `function`: 70
   - `table`: 57
-  - `cron_job`: 34
+  - `cron_job`: 35
   - `trigger`: 31
   - `enum_value`: 4
 
@@ -888,7 +888,36 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | --- | --- | --- |
 | `function` | `public.get_tint_price` | — |
 
+### `20260527190000_drop_redundant_sync_orders_cron.sql`
+
+> _Nenhum objeto extraído via regex._ Migration provavelmente é `ALTER TABLE` / `UPDATE` / `INSERT` / RLS-only. Validar manualmente.
+
 ### `20260527190000_drop_tint_formula_itens_public_select.sql`
+
+> _Nenhum objeto extraído via regex._ Migration provavelmente é `ALTER TABLE` / `UPDATE` / `INSERT` / RLS-only. Validar manualmente.
+
+### `20260527200000_data_health_add_estoque_reposicao.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `public.get_data_health` | — |
+
+### `20260527210000_data_health_compute_internal.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `public._data_health_compute` | — |
+| `function` | `public.get_data_health` | — |
+
+### `20260527220000_data_health_watchdog.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `public.data_health_watchdog` | — |
+| `function` | `public.fin_sync_heartbeat` | — |
+| `cron_job` | `cron.data-health-watchdog` | — |
+
+### `20260527220001_fin_sync_cursor_backfill_desde.sql`
 
 > _Nenhum objeto extraído via regex._ Migration provavelmente é `ALTER TABLE` / `UPDATE` / `INSERT` / RLS-only. Validar manualmente.
 

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 89
+-- Total de custom migrations: 94
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -108,7 +108,12 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260527170000', 'crons_timeout_fix', '20260527170000_crons_timeout_fix.sql'),
   ('20260527180000', 'data_health_add_vendas', '20260527180000_data_health_add_vendas.sql'),
   ('20260527180000', 'get_tint_price_rpc', '20260527180000_get_tint_price_rpc.sql'),
-  ('20260527190000', 'drop_tint_formula_itens_public_select', '20260527190000_drop_tint_formula_itens_public_select.sql')
+  ('20260527190000', 'drop_redundant_sync_orders_cron', '20260527190000_drop_redundant_sync_orders_cron.sql'),
+  ('20260527190000', 'drop_tint_formula_itens_public_select', '20260527190000_drop_tint_formula_itens_public_select.sql'),
+  ('20260527200000', 'data_health_add_estoque_reposicao', '20260527200000_data_health_add_estoque_reposicao.sql'),
+  ('20260527210000', 'data_health_compute_internal', '20260527210000_data_health_compute_internal.sql'),
+  ('20260527220000', 'data_health_watchdog', '20260527220000_data_health_watchdog.sql'),
+  ('20260527220001', 'fin_sync_cursor_backfill_desde', '20260527220001_fin_sync_cursor_backfill_desde.sql')
 )
 SELECT
   e.version,
@@ -552,7 +557,13 @@ WITH expected_objects (migration, kind, schema_name, object_name, parent_name) A
   ('crons_timeout_fix', 'cron_job', 'cron', 'sync-reprocess-strategic', ''),
   ('crons_timeout_fix', 'cron_job', 'cron', 'weekly-algorithm-a-audit', ''),
   ('data_health_add_vendas', 'function', 'public', 'get_data_health', ''),
-  ('get_tint_price_rpc', 'function', 'public', 'get_tint_price', '')
+  ('get_tint_price_rpc', 'function', 'public', 'get_tint_price', ''),
+  ('data_health_add_estoque_reposicao', 'function', 'public', 'get_data_health', ''),
+  ('data_health_compute_internal', 'function', 'public', '_data_health_compute', ''),
+  ('data_health_compute_internal', 'function', 'public', 'get_data_health', ''),
+  ('data_health_watchdog', 'function', 'public', 'data_health_watchdog', ''),
+  ('data_health_watchdog', 'function', 'public', 'fin_sync_heartbeat', ''),
+  ('data_health_watchdog', 'cron_job', 'cron', 'data-health-watchdog', '')
 )
 SELECT
   e.migration,

--- a/supabase/functions/omie-financeiro/index.ts
+++ b/supabase/functions/omie-financeiro/index.ts
@@ -894,7 +894,11 @@ async function syncMovimentacoes(
   filtroDataDe?: string,
   filtroDataAte?: string,
   maxPages = 500,
-  startPage?: number
+  startPage?: number,
+  // Páginas vazias consecutivas que disparam o early-exit. 30 no incremental
+  // (para logo após a janela de 3 meses). No backfill (janela ampla) sobe pra
+  // 300 — senão buracos longos no histórico encerrariam o backfill cedo.
+  maxEmptyPages = 30,
 ) {
   const dataInicioIso = parseOmieDate(filtroDataDe) || null;
   const dataFimIso = parseOmieDate(filtroDataAte) || null;
@@ -995,9 +999,9 @@ async function syncMovimentacoes(
       `[Fin][${company}] Mov p${pagina}/${totalPaginas} (+${uniqueRows.length}) empty_streak=${consecutiveEmptyPages}`
     );
 
-    // Early exit after 30 consecutive empty pages
-    if (consecutiveEmptyPages >= 30) {
-      console.log(`[Fin][${company}] Mov early exit: 30 páginas vazias consecutivas`);
+    // Early exit after N consecutive empty pages (N=30 incremental, 300 backfill)
+    if (consecutiveEmptyPages >= maxEmptyPages) {
+      console.log(`[Fin][${company}] Mov early exit: ${maxEmptyPages} páginas vazias consecutivas`);
       break;
     }
 
@@ -1772,18 +1776,44 @@ async function readCursorStartPage(
   }
 }
 
+// Janela de backfill persistida no cursor (só movimentações usam). Faz a
+// continuação `*/10` herdar a janela ampla durante o backfill. undefined =
+// incremental normal. Ver migration 20260527220001.
+async function readCursorBackfillDesde(
+  db: SupabaseClient,
+  company: string,
+  resource: string,
+): Promise<string | undefined> {
+  try {
+    const { data } = await db
+      .from("fin_sync_cursor")
+      .select("backfill_desde")
+      .eq("company", company)
+      .eq("resource", resource)
+      .maybeSingle();
+    const bf = (data as { backfill_desde?: string | null } | null)?.backfill_desde;
+    return bf ?? undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 async function writeCursor(
   db: SupabaseClient,
   company: string,
   resource: string,
   result: { complete?: boolean; nextPage?: number | null },
+  backfillDesde?: string | null,
 ): Promise<void> {
   const nextPage = result.complete ? null : (result.nextPage ?? null);
+  // Ao completar (página 1), limpa a janela de backfill → volta ao incremental.
+  // Enquanto pendente, preserva a janela pra a continuação herdar.
+  const bf = result.complete ? null : (backfillDesde ?? null);
   try {
     await db
       .from("fin_sync_cursor")
       .upsert(
-        { company, resource, next_page: nextPage, updated_at: new Date().toISOString() },
+        { company, resource, next_page: nextPage, backfill_desde: bf, updated_at: new Date().toISOString() },
         { onConflict: "company,resource" },
       );
   } catch {
@@ -1911,15 +1941,21 @@ serve(async (req) => {
       }
 
       case "sync_movimentacoes": {
-        const dataInicio =
-          filtro_data_de ||
-          formatOmieDate(new Date(new Date().setMonth(new Date().getMonth() - 3)));
         const dataFim = filtro_data_ate || formatOmieDate(new Date());
+        const incrementalDe = formatOmieDate(new Date(new Date().setMonth(new Date().getMonth() - 3)));
         for (const co of targetCompanies) {
           // mov: undefined = fresh (começa da última página/mais recente); int = resume
           const startPage = await readCursorStartPage(supabase, co, "movimentacoes");
-          const r = await syncMovimentacoes(supabase, co, dataInicio, dataFim, maxPages, startPage);
-          await writeCursor(supabase, co, "movimentacoes", r);
+          const cursorBackfill = await readCursorBackfillDesde(supabase, co, "movimentacoes");
+          // Backfill = janela ampla client-side. Inicia via body.filtro_data_de (só
+          // quando NÃO há resume pendente, pra não reiniciar no meio); resume herda a
+          // janela persistida no cursor. NULL = incremental (3 meses, early-exit 30).
+          const backfillDesde =
+            startPage !== undefined ? (cursorBackfill ?? null) : (filtro_data_de ?? null);
+          const dataInicio = backfillDesde || incrementalDe;
+          const maxEmpty = backfillDesde ? 300 : 30;
+          const r = await syncMovimentacoes(supabase, co, dataInicio, dataFim, maxPages, startPage, maxEmpty);
+          await writeCursor(supabase, co, "movimentacoes", r, backfillDesde);
           result[co] = r;
         }
         break;

--- a/supabase/migrations/20260527220001_fin_sync_cursor_backfill_desde.sql
+++ b/supabase/migrations/20260527220001_fin_sync_cursor_backfill_desde.sql
@@ -1,0 +1,14 @@
+-- ============================================================
+-- fin_sync_cursor.backfill_desde — janela de backfill persistida no cursor
+-- Objetivo: backfill histórico de movimentações Omie sem footgun de deploy.
+-- Spec: docs/superpowers/specs/2026-05-27-omie-baixa-date-root-fix-design.md
+-- ============================================================
+-- A janela de data das movimentações é aplicada CLIENT-SIDE no sync (não vai
+-- pro Omie), então o cursor de paginação é consistente independentemente dela.
+-- Persistir a janela de backfill no cursor faz a continuação `*/10` (que invoca
+-- só {action, company}) herdar a janela ampla durante o backfill, sem precisar
+-- mudar o default da main nem reverter deploy. NULL = modo incremental normal.
+-- Coluna NEUTRA pra CR/CP (eles não usam — seus endpoints não filtram por data).
+
+ALTER TABLE public.fin_sync_cursor
+  ADD COLUMN IF NOT EXISTS backfill_desde date;


### PR DESCRIPTION
## ⚠️ ATENÇÃO: migration manual necessária

Adiciona `supabase/migrations/20260527220001_fin_sync_cursor_backfill_desde.sql`. **Lovable não aplica automaticamente** — mergear NÃO toca o banco. Cole no SQL Editor:

```sql
ALTER TABLE public.fin_sync_cursor
  ADD COLUMN IF NOT EXISTS backfill_desde date;
```

Validação pós-apply:

```sql
SELECT CASE WHEN EXISTS (
  SELECT 1 FROM information_schema.columns
  WHERE table_schema='public' AND table_name='fin_sync_cursor' AND column_name='backfill_desde'
) THEN '✅ backfill_desde existe' ELSE '❌ FALTANDO' END AS status;
```

**E redeploy do `omie-financeiro`** (lê da main verbatim).

## Contexto

Fase 0 do root-fix da data de baixa (spec `docs/superpowers/specs/2026-05-27-omie-baixa-date-root-fix-design.md`). A baixa real vem das movimentações (`dDtPagamento`), mas o sync filtra **client-side** pros últimos 3 meses → só ~5 meses no banco (cobertura de baixa derivável 17-23%). O `debug_raw` confirmou: o Omie tem o histórico inteiro; o limite é nosso filtro client-side.

## Summary

- **`fin_sync_cursor.backfill_desde`** (date, nullable): janela de backfill persistida no cursor. Como a janela das movimentações é **client-side** (não vai pro Omie), o cursor de paginação é consistente independentemente dela — então persistir a janela faz a continuação `*/10` (que invoca só `{action, company}`) **herdar** a janela ampla durante o backfill, **sem mudar o default da main nem reverter deploy** (os footguns do plano B' que o codex apontou).
- Backfill é **opt-in pelo trigger** (`filtro_data_de`), só inicia quando **não há resume pendente** (não reinicia no meio), e **limpa-se ao completar** (página 1 → volta ao incremental de 3 meses).
- **Early-exit** sobe de 30 → **300 páginas vazias** no backfill (evita encerrar cedo em buracos do histórico).
- Coluna **neutra pra CR/CP** (não usam — seus endpoints não filtram por data).
- Desenho validado com codex em 2 rodadas (a 2ª corrigiu o pressuposto: janela é client-side → B'/A simplificam; lean-A escolhido por eliminar footgun em sistema solo/manual/money-path).

## Test plan
- [x] `deno check` — 0 erro novo (10 pré-existentes no handler `debug_raw`, idênticos ao main)
- [x] `typecheck:strict` (front intacto)
- [ ] **Operação assistida pós-merge** (ver checklist na conversa): aplicar migration → redeploy → trigger backfill com `filtro_data_de=01/01/2018` → monitorar cursor até `next_page IS NULL` nas 3 empresas → validar cobertura.

🤖 Generated with [Claude Code](https://claude.com/claude-code)