### PR TITLE
docs(strict): triagem read-only + validada de candidatos .tsx

### DIFF
--- a/docs/strict-migration-lanes.md
+++ b/docs/strict-migration-lanes.md
@@ -139,3 +139,8 @@ subgrafos sujos (`noUnusedLocals`/`strictNullChecks`) → cascata. **Promova lea
 - **Reestruturar `tsconfig.strict.json` por lane** (fragmento por lane + include
   gerado, ou project references) pra eliminar de vez o conflito de append. **Flag-day**:
   só numa janela sem PRs strict em voo. Por ora a convenção de append basta. Ver CLAUDE.md §10.
+- **Lote `.tsx` pré-triado e VALIDADO** (2026-05-27) em [`docs/strict-tsx-ready-candidates.md`]:
+  **119 `.tsx` leaf compilam strict-clean** (promoção mecânica, append-only, zero edição de source)
+  + 12 com fix conhecido (10 dead-code trivial, 1 guard, 1 zodResolver). Triagem reprodutível via
+  `bun scripts/strict-tsx-triage.mjs` (encoda o filtro correto — aspas duplas+simples, exclui
+  `lazy()`/`import()`). Consumir numa **janela calma**; re-rodar o script (números mudam com o strict).

--- a/docs/strict-tsx-ready-candidates.md
+++ b/docs/strict-tsx-ready-candidates.md
@@ -1,0 +1,89 @@
+# Candidatos `.tsx` à promoção strict — triagem validada (2026-05-27)
+
+> Artefato **read-only** para ser consumido numa **janela calma** (sem PRs em voo / CPU calma),
+> conforme a disciplina do `docs/strict-migration-lanes.md` e o handoff do CLAUDE.md §10
+> ("strict-mode: só em janela sem PRs em voo, leaf-first, sem reordenar o include").
+>
+> Gerado por `bun scripts/strict-tsx-triage.mjs` (filtro correto: casa aspas duplas+simples,
+> exclui `lazy()`/`import()` dinâmico) e **validado** anexando os 131 READY ao `include` e
+> rodando `heavy bun run typecheck:strict`. O tsconfig **não** foi commitado — só este relatório
+> e o script. Re-rode o script quando o strict crescer (os números mudam).
+
+## Estado na geração
+
+- strict atual: **539** arquivos no `include` (~63% de 853 `.ts/.tsx`).
+- `.tsx` fora do strict: **303**.
+- Classificação dos 303: **READY=131, NEAR=83, RISKY=51, LAZY=10**.
+
+## Veredito da validação (typecheck:strict com os 131 READY anexados)
+
+Todos os erros caíram **dentro** do conjunto READY (zero erro transitivo fora — confirma que o
+resolvedor de deps do filtro está correto: READY não puxa nenhum arquivo novo pro programa).
+
+- **119 dos 131 compilam LIMPO** sob strict → **promoção mecânica** (append-only no `include`,
+  zero edição de source). Lote pronto.
+- **12 precisam de fix de source** antes de promover (detalhe abaixo).
+
+### Lote A — 119 mecânicos (zero edição de source)
+
+Append-only no fim do `include` do `tsconfig.strict.json`, rodar `heavy bun run typecheck:strict`
+(deve seguir verde), commitar. Pegue a lista exata com:
+
+```bash
+bun scripts/strict-tsx-triage.mjs --ready   # 131 READY; tire os 12 da lista B = 119 mecânicos
+```
+
+Distribuição por área (todos leaf presentacionais, deps já no strict):
+`reposicao/*` (~45), `farmer/{copilot,bundles,locc,tacticalPlan}` (~8), `des/{historico,checkinQualitativo,simulador}` (~10),
+`notificacoes` (5), `loyalty` (5), `customerDashboard` (5), `unifiedAI` (4), `skuMapeamento` (4),
+`tintColorSelect` (3), `salesOrderEdit` (3), `financeiro/cockpit` (3), `call`/`telefonia` (5),
+`analyticsSync`/`customer`/`adminCustomers`/`picking`/`dashboard`/`salesOrders` + `VoiceServiceInput`.
+
+> Sugestão de fatiamento (evita um PR gigante): por área-pai (`reposicao/*`, `farmer/*`, `des/*`, …),
+> ~4-6 PRs pequenos, cada um append-only. NÃO reordene o array `include` (reordenar = conflito com
+> todo PR em voo).
+
+### Lote B — 12 precisam de fix de source
+
+**B1 — dead-code only (10 arquivos; fix trivial = apagar import/var não usado, depois promover):**
+
+| Arquivo | Erros |
+|---|---|
+| `pages/FarmerRecommendations.tsx` | 11× TS6133/6192 (imports `TrendingUp/Package/Sparkles/CardHeader/CardTitle/CustomerRecommendations/Recommendation`, vars `isAdmin/activeTab/setActiveTab`, 1 import inteiro não usado) |
+| `pages/CoachingSPIN.tsx` | 11× TS6133 (`ScrollArea/Filter/ArrowRight/Eye/EyeOff/FileText/Mic/Play/Zap/Button/Textarea`) |
+| `components/unified-order/CartSummaryBar.tsx` | 9× TS6133 (`isWeekend/fmt/Badge` + vars `cart/totalEstimated/notes/setNotes/volumesColacor/volumesOben`) |
+| `pages/UXRules.tsx` | 5× TS6133 (`RefreshCw/BarChart3/MessageSquare/Phone/HelpCircle`) |
+| `pages/DesignSystem.tsx` | 5× TS6133 (`ChevronRight/Eye/EyeOff/X/Package`) |
+| `components/SharpeningSuggestions.tsx` | 4× TS6133 (`ChevronRight/formatDistanceToNow/ptBR` + var `ref`) |
+| `pages/FarmerIPFDashboard.tsx` | 2× TS6133 (`useState/Users`) |
+| `components/unified-order/ProductItemForm.tsx` | 2× TS6133 (`useCallback/useRef`) |
+| `components/recebimento/LoteScannerOCR.tsx` | 1× TS6133 (`React` — import default não usado) |
+| `components/aiOps/DecisionCard.tsx` | 1× TS6133 (prop `customerPhone` declarada e não usada) |
+
+> ⚠️ Em `DecisionCard` e `CartSummaryBar`, alguns "não usados" são **props/vars desestruturadas** —
+> conferir se é dead-code real ou se faltou fiar (apagar a prop muda a interface do componente).
+> Os de `import` (lucide/date-fns/ui) são 100% seguros de apagar.
+
+**B2 — typing real (2 arquivos):**
+
+| Arquivo | Erro | Fix provável |
+|---|---|---|
+| `components/tintImport/ImportCard.tsx:183` | TS18048 `'r.failed_chunks' is possibly 'undefined'` | guard `r.failed_chunks ?? 0` / `?.` — 1 linha |
+| `components/standard-process/StandardProcessForm.tsx:54,247,251` | TS2322/TS2345 — `Resolver<>` / `SubmitHandler<>` mismatch (zod com campos opcionais c/ default vs required) | **mesmo padrão deferido** do `AdminStandardProcessNew` (lane doc). Resolver com `zodResolver` quando o schema tem optional-com-default vs required no tipo inferido. Médio; fazer junto do irmão. |
+
+## NEAR (83) — batcháveis quando os blockers forem promovidos
+
+`bun scripts/strict-tsx-triage.mjs` lista cada NEAR com seus 1-2 blockers. Padrão comum: o blocker
+é o `./types.ts`/`./config.ts`/`useX.ts` da própria feature. Promova o blocker (se for `.ts` leaf)
+no mesmo lote e o NEAR vira READY. Áreas: `farmer/{calls,copilot,locc}` (blocker = `types.ts`/`config.ts`),
+`analyticsSync` (blocker = `useAnalyticsSync.ts`), `customer360`, `customer`, `des/simulador`.
+
+> Atenção a lanes quentes: `farmer/*` é farmer-adjacent (coordene com sessões farmer/scoring);
+> `financeiroV2Service` é blocker de `RequireFinanceiroAccess` (alto, em churn).
+
+## RISKY (51) e LAZY (10)
+
+- **RISKY**: tocam `supabase`/`.rpc(`/`posthog`/`useUrlState` no corpo. Promovíveis, mas exigem que
+  o cliente supabase e tipos estejam estáveis — caso a caso, não em lote cego.
+- **LAZY**: usam `lazy()`/`import()` dinâmico = **não são leaf** (puxam o subgrafo lazy). Excluídos
+  de propósito. Só promover com o método bottom-up (subgrafo lazy limpo primeiro) — ver lição no lane doc.

--- a/scripts/strict-tsx-triage.mjs
+++ b/scripts/strict-tsx-triage.mjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env bun
+/**
+ * Triagem read-only de candidatos `.tsx` à promoção para `tsconfig.strict.json`.
+ *
+ * Por quê: a migração strict é leaf-first (ver docs/strict-migration-lanes.md). Promover
+ * um arquivo puxa seus imports transitivos pro programa strict — então só é seguro promover
+ * um `.tsx` quando TODOS os seus imports locais (src) JÁ estão no strict. Este script encoda
+ * o filtro correto, evitando os 2 bugs que já custaram um lote refeito:
+ *   (1) casar imports com aspas DUPLAS e SIMPLES (`from "..."` e `from '...'`);
+ *   (2) excluir `lazy(() => import())` / `import()` dinâmico — contam como import pro tsc
+ *       e puxam o subgrafo (um "leaf" que lazy-carrega outro arquivo NÃO é leaf).
+ *
+ * Saída: classifica cada `.tsx` ainda fora do strict em READY / NEAR / RISKY / LAZY.
+ *   READY  = leaf de verdade (todos os imports locais já no strict, sem lazy/dynamic, sem
+ *            supabase/rpc/posthog/useUrlState no corpo). Candidato a promoção mecânica
+ *            (tsconfig-only) — sujeito a validação por `typecheck:strict` (ver doc).
+ *   NEAR   = 1-2 blockers locais (imports ainda fora do strict). Batchável junto se os
+ *            blockers também forem promovidos no mesmo lote.
+ *   RISKY  = toca supabase/.rpc(/posthog/useUrlState — promover exige cuidado extra.
+ *   LAZY   = usa lazy()/import() dinâmico — não é leaf, exclua.
+ *
+ * Uso:  bun scripts/strict-tsx-triage.mjs            # resumo
+ *       bun scripts/strict-tsx-triage.mjs --ready    # só os paths READY (1 por linha)
+ *
+ * NOTA: READY garante que as deps estão no strict, NÃO que o corpo do arquivo é strict-clean.
+ * Sempre valide o lote escolhido anexando ao include e rodando `heavy bun run typecheck:strict`
+ * (com CPU calma) antes de commitar. Ver docs/strict-tsx-ready-candidates.md.
+ */
+import { readFileSync, existsSync, readdirSync, statSync } from 'fs';
+import { dirname, resolve, join } from 'path';
+
+const ROOT = process.cwd();
+const onlyReady = process.argv.includes('--ready');
+
+// Conjunto já no strict (paths "src/..." do include)
+const tscRaw = readFileSync(join(ROOT, 'tsconfig.strict.json'), 'utf8');
+const strict = new Set([...tscRaw.matchAll(/"(src\/[^"]+)"/g)].map((m) => m[1]));
+
+// Todos os .tsx de src (sem testes/d.ts)
+function walk(dir, acc = []) {
+  for (const e of readdirSync(dir)) {
+    const p = join(dir, e);
+    if (statSync(p).isDirectory()) walk(p, acc);
+    else if (p.endsWith('.tsx') && !p.endsWith('.test.tsx') && !p.endsWith('.d.ts')) {
+      acc.push(p.replace(ROOT + '/', ''));
+    }
+  }
+  return acc;
+}
+const allTsx = walk(join(ROOT, 'src')).sort();
+const notStrict = allTsx.filter((f) => !strict.has(f));
+
+function resolveImport(fromFile, spec) {
+  let base;
+  if (spec.startsWith('@/')) base = join('src', spec.slice(2));
+  else if (spec.startsWith('.')) base = resolve(dirname(fromFile), spec).replace(ROOT + '/', '');
+  else return { external: true };
+  const cands = [base, base + '.ts', base + '.tsx', join(base, 'index.ts'), join(base, 'index.tsx'), base + '.d.ts'];
+  for (const c of cands) if (existsSync(join(ROOT, c))) return { path: c };
+  return { path: base, missing: true };
+}
+
+const RISKY = /supabase|\.rpc\(|useUrlState|posthog/i;
+const results = [];
+
+for (const f of notStrict) {
+  const src = readFileSync(join(ROOT, f), 'utf8');
+  const hasLazy = /\blazy\s*\(|React\.lazy|\bimport\s*\(/.test(src);
+  const imps = [...src.matchAll(/from\s+["']([^"']+)["']/g)].map((m) => m[1]);
+  const local = imps.map((s) => ({ spec: s, ...resolveImport(f, s) })).filter((r) => !r.external);
+  const localSrc = local.filter((r) => r.path && r.path.startsWith('src/'));
+  const blockers = localSrc.filter((r) => !strict.has(r.path) && !r.missing).map((r) => r.path);
+  const missing = localSrc.filter((r) => r.missing).map((r) => r.path);
+  const risky = RISKY.test(src);
+  results.push({ f, loc: src.split('\n').length, hasLazy, risky, blockers, missing });
+}
+
+const ready = results.filter((r) => !r.hasLazy && !r.risky && r.blockers.length === 0 && r.missing.length === 0);
+const near = results.filter((r) => !r.hasLazy && !r.risky && r.blockers.length > 0 && r.blockers.length <= 2 && r.missing.length === 0);
+
+if (onlyReady) {
+  ready.sort((a, b) => a.loc - b.loc).forEach((r) => console.log(r.f));
+} else {
+  console.log(`strict atual: ${strict.size} | .tsx fora do strict: ${notStrict.length}`);
+  console.log(`READY=${ready.length} NEAR=${near.length} RISKY=${results.filter((r) => r.risky && !r.hasLazy).length} LAZY=${results.filter((r) => r.hasLazy).length}\n`);
+  console.log('=== READY (leaf de verdade — candidato a promoção mecânica) ===');
+  ready.sort((a, b) => a.loc - b.loc).forEach((r) => console.log(`  [${String(r.loc).padStart(3)}L] ${r.f}`));
+  console.log('\n=== NEAR (1-2 blockers — batchável com os blockers) ===');
+  near.sort((a, b) => a.blockers.length - b.blockers.length).forEach((r) => console.log(`  [${r.blockers.length}b] ${r.f}  ←  ${r.blockers.join(', ')}`));
+}


### PR DESCRIPTION
## Resumo

Artefato **read-only** (zero toque em `tsconfig.strict.json` ou em source) que deixa o próximo lote de promoção strict **quase mecânico** para uma janela calma — conforme a disciplina do `docs/strict-migration-lanes.md` e o handoff do CLAUDE.md §10 ("strict-mode: só em janela sem PRs em voo, leaf-first").

Decisão tomada com o Codex: num repo com ~13 worktrees ativas, o gargalo é **colisão/retrabalho**, não capacidade. Então em vez de promover agora (tocaria o `tsconfig.strict.json` contendido), entrego a triagem validada.

## O que tem

- **`scripts/strict-tsx-triage.mjs`** — triagem reprodutível que encoda o filtro correto, evitando os 2 bugs que já custaram um lote refeito: (1) casar imports com aspas **duplas E simples**; (2) **excluir `lazy()`/`import()` dinâmico** (puxam o subgrafo = não-leaf).
- **`docs/strict-tsx-ready-candidates.md`** — relatório **validado**: anexei os 131 READY ao `include` e rodei `typecheck:strict`. Resultado: **119 compilam strict-clean** (promoção mecânica, zero edição de source) + **12 com fix conhecido** (10 dead-code trivial, 1 guard de `undefined`, 1 zodResolver). **Zero erro transitivo fora do READY** — confirma que o resolvedor de deps do filtro está correto.
- ponteiro no `docs/strict-migration-lanes.md`.

## Estado na geração

strict 539/853 (~63%); `.tsx` fora do strict: 303 → READY=131, NEAR=83, RISKY=51, LAZY=10.

## Test plan

- [x] `bun scripts/strict-tsx-triage.mjs` reproduz os 131 READY idênticos
- [x] validação por `typecheck:strict` com os 131 anexados (revertido, não commitado) → 119 limpos / 12 com erro mapeado
- [x] docs-only + script — nenhum arquivo de app ou config tocado

🤖 Generated with [Claude Code](https://claude.com/claude-code)