### PR TITLE
feat(data-health): check do canal de alerta + dispatch */30 (quem vigia o vigia)

### DIFF
--- a/src/lib/dataHealth/types.ts
+++ b/src/lib/dataHealth/types.ts
@@ -1,5 +1,5 @@
 export type HealthStatus = 'ok' | 'stale' | 'broken' | 'unknown';
-export type HealthDomain = 'financeiro' | 'omie_sync' | 'carteira' | 'estoque' | 'vendas';
+export type HealthDomain = 'financeiro' | 'omie_sync' | 'carteira' | 'estoque' | 'vendas' | 'alertas';
 export type HealthLevel = 'green' | 'amber' | 'red';
 
 /** Um check individual retornado pela RPC get_data_health. */

--- a/src/pages/SaudeDados.tsx
+++ b/src/pages/SaudeDados.tsx
@@ -6,7 +6,7 @@ import { useDataHealth } from '@/hooks/useDataHealth';
 import { rollupDomain, formatAge, badgeLevel } from '@/lib/dataHealth/health-helpers';
 
 const DOMAIN_LABEL: Record<string, string> = {
-  financeiro: 'Financeiro', omie_sync: 'Syncs Omie', carteira: 'Carteira / Scoring', estoque: 'Estoque / Reposição', vendas: 'Vendas / Pedidos',
+  financeiro: 'Financeiro', omie_sync: 'Syncs Omie', carteira: 'Carteira / Scoring', estoque: 'Estoque / Reposição', vendas: 'Vendas / Pedidos', alertas: 'Canal de alerta',
 };
 const STATUS_CLS: Record<string, string> = {
   ok: 'text-status-success', stale: 'text-status-warning', broken: 'text-status-error', unknown: 'text-status-error',

--- a/supabase/migrations/20260527235000_dispatch_notifications_frequente.sql
+++ b/supabase/migrations/20260527235000_dispatch_notifications_frequente.sql
@@ -1,0 +1,15 @@
+-- Hardening do canal de alerta (1/2): a cadência do dispatch-notifications era DIÁRIA (10 11 * * *),
+-- então os alertas da Sentinela (watchdog */30 → enfileira em fornecedor_alerta) só saíam por email
+-- no batch das 11:10 → latência de alerta de até ~24h, o que contradiz o "ativo" (o incidente que
+-- originou tudo era sobre VELOCIDADE: 8 dias mudo). Bump pra */30 (alinha com o watchdog; latência
+-- worst-case ~60min). Idle é barato: o dispatch faz early-return em 0 pendentes ANTES de pegar token
+-- OAuth/chamar Gmail. Volume bounded: o anti-spam (UNIQUE parcial em fin_alertas (company,tipo)
+-- WHERE dismissed_at IS NULL) já garante 1 email por transição — */30 só envia MAIS CEDO, não mais.
+-- Renomeio o job (o nome "diario" viraria mentira). unschedule guardado por jobid = idempotente
+-- (no-op se ausente; nunca deixa 2 crons ativos). Comando idêntico ao atual (mesma URL/headers/body/
+-- timeout) — só schedule + nome mudam.
+
+SELECT cron.unschedule(jobid) FROM cron.job WHERE jobname = 'afiacao_dispatch_notificacoes_diario';
+
+SELECT cron.schedule('afiacao_dispatch_notificacoes_30min', '*/30 * * * *',
+  ' select net.http_post( url := ''https://fzvklzpomgnyikkfkzai.supabase.co/functions/v1/dispatch-notifications'', headers := jsonb_build_object( ''Content-Type'', ''application/json'', ''x-cron-secret'', (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name=''CRON_SECRET'') ), body := ''{}''::jsonb, timeout_milliseconds := 60000 ); ');

--- a/supabase/migrations/20260527240000_data_health_alert_channel.sql
+++ b/supabase/migrations/20260527240000_data_health_alert_channel.sql
@@ -1,0 +1,200 @@
+-- Hardening do canal de alerta (2/2): "quem vigia o vigia". A Sentinela depende de
+-- fornecedor_alerta → dispatch-notifications → Gmail. Se esse pipe travar, o watchdog detecta a
+-- degradação corretamente e mesmo assim NINGUÉM é avisado — reabrindo exatamente a classe de falha
+-- silenciosa que o incidente expôs. Adiciono um 9º check 'alert_channel' na fonte-de-verdade
+-- (_data_health_compute) → aparece no dashboard (pull, sempre funciona) + badge do topbar + seção do
+-- heartbeat automaticamente. PRINCÍPIO: o check do canal NÃO entra no loop de push do watchdog
+-- (vendas/estoque/reposição/carteira) — não se avisa a quebra do canal PELO canal quebrado (falsa
+-- confiança). As superfícies do canal são: dashboard (pull), heartbeat (conteúdo) e a AUSÊNCIA do
+-- heartbeat (dead-man-switch). Threshold 2h = 4 ciclos de */30 perdidos = inequivocamente travado.
+-- Corpo dos 8 checks = verbatim da migration 20260527210000; só acrescento o UNION ALL do 9º.
+
+CREATE OR REPLACE FUNCTION public._data_health_compute()
+RETURNS TABLE (
+  source text, domain text, status text,
+  age_seconds bigint, expected_max_age_seconds bigint, freshness_basis text,
+  message text, last_error text, probable_cause text, how_to_fix text, severity text
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+  WITH checks AS (
+    SELECT 'saldo_bancario'::text AS source, 'financeiro'::text AS domain,
+      CASE WHEN max(cc.saldo_data) IS NULL THEN 'broken'
+           WHEN now() - max(cc.saldo_data)::timestamptz > interval '36 hours' THEN 'stale' ELSE 'ok' END AS status,
+      EXTRACT(EPOCH FROM now() - max(cc.saldo_data)::timestamptz)::bigint AS age_seconds,
+      (36*3600)::bigint AS expected_max_age_seconds, 'max_saldo_data'::text AS freshness_basis,
+      CASE WHEN max(cc.saldo_data) IS NULL THEN 'Saldo bancário nunca sincronizou'
+           ELSE 'Saldo bancário: último sync ' || to_char(max(cc.saldo_data), 'DD/MM') END AS message,
+      NULL::text AS last_error,
+      CASE WHEN max(cc.saldo_data) IS NULL THEN 'ListarExtrato falhando ou nunca rodou' ELSE NULL END AS probable_cause,
+      'Rode sync_contas_correntes no chat do Lovable e cheque os logs do omie-financeiro'::text AS how_to_fix,
+      'critical'::text AS severity
+    FROM public.fin_contas_correntes cc WHERE cc.ativo = true
+    UNION ALL
+    SELECT 'contas_receber', 'financeiro',
+      CASE WHEN max(cr.updated_at) IS NULL THEN 'broken'
+           WHEN now() - max(cr.updated_at) > interval '26 hours' THEN 'stale' ELSE 'ok' END,
+      EXTRACT(EPOCH FROM now() - max(cr.updated_at))::bigint, (26*3600)::bigint, 'max_updated_at',
+      'Contas a receber: atualizado ' || COALESCE(to_char(max(cr.updated_at),'DD/MM HH24:MI'),'nunca'),
+      NULL, CASE WHEN max(cr.updated_at) IS NULL THEN 'Sync CR nunca completou' ELSE NULL END,
+      'Rode sync_contas_receber no Lovable', 'warning'
+    FROM public.fin_contas_receber cr
+    UNION ALL
+    SELECT 'contas_pagar', 'financeiro',
+      CASE WHEN max(cp.updated_at) IS NULL THEN 'broken'
+           WHEN now() - max(cp.updated_at) > interval '26 hours' THEN 'stale' ELSE 'ok' END,
+      EXTRACT(EPOCH FROM now() - max(cp.updated_at))::bigint, (26*3600)::bigint, 'max_updated_at',
+      'Contas a pagar: atualizado ' || COALESCE(to_char(max(cp.updated_at),'DD/MM HH24:MI'),'nunca'),
+      NULL, CASE WHEN max(cp.updated_at) IS NULL THEN 'Sync CP nunca completou' ELSE NULL END,
+      'Rode sync_contas_pagar no Lovable', 'warning'
+    FROM public.fin_contas_pagar cp
+    UNION ALL
+    SELECT 'omie_sync_financeiro'::text, 'omie_sync'::text,
+      COALESCE((SELECT CASE WHEN l.status='error' THEN 'broken' ELSE 'ok' END FROM public.fin_sync_log l
+                WHERE l.completed_at IS NOT NULL ORDER BY l.completed_at DESC LIMIT 1), 'unknown'),
+      (SELECT EXTRACT(EPOCH FROM now() - l.completed_at)::bigint FROM public.fin_sync_log l
+                WHERE l.completed_at IS NOT NULL ORDER BY l.completed_at DESC LIMIT 1),
+      NULL::bigint, 'fin_sync_log'::text,
+      'Último sync financeiro: ' || COALESCE((SELECT l.status FROM public.fin_sync_log l
+        WHERE l.completed_at IS NOT NULL ORDER BY l.completed_at DESC LIMIT 1), 'sem registro'),
+      (SELECT l.error_message FROM public.fin_sync_log l WHERE l.status='error' AND l.completed_at IS NOT NULL ORDER BY l.completed_at DESC LIMIT 1),
+      CASE WHEN (SELECT l.status FROM public.fin_sync_log l WHERE l.completed_at IS NOT NULL ORDER BY l.completed_at DESC LIMIT 1)='error'
+           THEN 'A última action de sync financeiro falhou' ELSE NULL END,
+      'Cheque fin_sync_log e re-rode a action que falhou'::text, 'critical'::text
+    UNION ALL
+    SELECT 'vendas_pedidos'::text, 'vendas'::text,
+      CASE WHEN v.oben_last IS NULL OR v.colacor_last IS NULL THEN 'broken'
+           WHEN now() - LEAST(v.oben_last, v.colacor_last) > interval '6 hours' THEN 'stale' ELSE 'ok' END,
+      EXTRACT(EPOCH FROM now() - LEAST(v.oben_last, v.colacor_last))::bigint,
+      (6*3600)::bigint, 'fin_sync_log.sync_pedidos'::text,
+      'Sync de pedidos: oben ' || COALESCE(to_char(v.oben_last,'DD/MM HH24:MI'),'nunca')
+        || ' · colacor ' || COALESCE(to_char(v.colacor_last,'DD/MM HH24:MI'),'nunca'),
+      v.last_err,
+      CASE WHEN v.oben_last IS NULL OR v.colacor_last IS NULL
+           THEN 'Cron vendas-sync-pedidos não rodou/completou para alguma conta' ELSE NULL END,
+      'Cheque os crons vendas-sync-pedidos-{oben,colacor}-2h e fin_sync_log (action sync_pedidos)'::text, 'critical'::text
+    FROM (
+      SELECT
+        (SELECT max(l.completed_at) FROM public.fin_sync_log l WHERE l.action='sync_pedidos' AND l.status='complete' AND 'oben' = ANY(l.companies)) AS oben_last,
+        (SELECT max(l.completed_at) FROM public.fin_sync_log l WHERE l.action='sync_pedidos' AND l.status='complete' AND 'colacor' = ANY(l.companies)) AS colacor_last,
+        (SELECT l.error_message FROM public.fin_sync_log l WHERE l.action='sync_pedidos' AND l.status='error' ORDER BY l.started_at DESC LIMIT 1) AS last_err
+    ) v
+    UNION ALL
+    SELECT 'estoque_inventario'::text, 'estoque'::text,
+      CASE WHEN max(ip.synced_at) IS NULL THEN 'broken'
+           WHEN now() - max(ip.synced_at) > interval '3 hours' THEN 'stale' ELSE 'ok' END,
+      EXTRACT(EPOCH FROM now() - max(ip.synced_at))::bigint, (3*3600)::bigint, 'inventory_position.synced_at',
+      'Inventário: sincronizado ' || COALESCE(to_char(max(ip.synced_at),'DD/MM HH24:MI'),'nunca'),
+      NULL, CASE WHEN max(ip.synced_at) IS NULL THEN 'sync_inventory nunca rodou' ELSE NULL END,
+      'Cheque o cron sync-inventory-vendas-30m (omie-analytics-sync sync_inventory)', 'warning'
+    FROM public.inventory_position ip
+    UNION ALL
+    SELECT 'reposicao_sugestoes'::text, 'estoque'::text,
+      CASE WHEN max(pcs.data_ciclo) IS NULL THEN 'broken'
+           WHEN current_date - max(pcs.data_ciclo) > 3 THEN 'stale' ELSE 'ok' END,
+      CASE WHEN max(pcs.data_ciclo) IS NULL THEN NULL
+           ELSE (current_date - max(pcs.data_ciclo))::bigint * 86400 END,
+      (3*86400)::bigint, 'pedido_compra_sugerido.data_ciclo',
+      'Sugestão de compra: último ciclo ' || COALESCE(to_char(max(pcs.data_ciclo),'DD/MM/YYYY'),'nunca'),
+      NULL, CASE WHEN max(pcs.data_ciclo) IS NULL THEN 'gerar-pedidos nunca gerou sugestão' ELSE NULL END,
+      'Cheque o cron gerar-pedidos-diario-oben'::text, 'warning'
+    FROM public.pedido_compra_sugerido pcs
+    UNION ALL
+    SELECT 'carteira_scores'::text, 'carteira'::text,
+      CASE WHEN max(fcs.calculated_at) IS NULL THEN 'broken'
+           WHEN now() - max(fcs.calculated_at) > interval '36 hours' THEN 'stale' ELSE 'ok' END,
+      EXTRACT(EPOCH FROM now() - max(fcs.calculated_at))::bigint, (36*3600)::bigint, 'calculated_at',
+      'Scoring de carteira: recalculado ' || COALESCE(to_char(max(fcs.calculated_at),'DD/MM HH24:MI'),'nunca'),
+      NULL, CASE WHEN max(fcs.calculated_at) IS NULL THEN 'calculate-scores nunca rodou' ELSE NULL END,
+      'Re-rode calculate-scores / scoring-recalc-batch no Lovable', 'warning'
+    FROM public.farmer_client_scores fcs
+    UNION ALL
+    -- 9º check: o PRÓPRIO canal de alerta (dispatch-notifications drena fornecedor_alerta).
+    -- broken = email preso >2h (canal não drena) OU ≥5 falhas em 24h (falha sistêmica de envio);
+    -- stale = 1..4 falhas recentes sem backlog travado (falha isolada); ok caso contrário.
+    SELECT 'alert_channel'::text, 'alertas'::text,
+      CASE WHEN ac.stuck_pendentes > 0 OR ac.falhas_24h >= 5 THEN 'broken'
+           WHEN ac.falhas_24h > 0 THEN 'stale' ELSE 'ok' END,
+      ac.oldest_pendente_age_seconds, (2*3600)::bigint, 'fornecedor_alerta.pendente_notificacao'::text,
+      CASE WHEN ac.stuck_pendentes > 0
+             THEN 'Canal de alerta: ' || ac.stuck_pendentes::text || ' email(s) presos há mais de 2h — dispatch parou de drenar'
+           WHEN ac.falhas_24h >= 5
+             THEN 'Canal de alerta: ' || ac.falhas_24h::text || ' falhas de envio nas últimas 24h (falha sistêmica)'
+           WHEN ac.falhas_24h > 0
+             THEN 'Canal de alerta: ' || ac.falhas_24h::text || ' falha(s) de envio nas últimas 24h'
+           ELSE 'Canal de alerta: drenando normalmente (' || ac.pendentes_total::text || ' na fila)' END,
+      ac.ultimo_erro,
+      CASE WHEN ac.stuck_pendentes > 0 THEN 'Cron afiacao_dispatch_notificacoes_30min não rodou ou a edge dispatch-notifications falhou (token Gmail revogado?)'
+           WHEN ac.falhas_24h > 0 THEN 'Envio de email falhando (Gmail / token / destinatário)' ELSE NULL END,
+      'Cheque a edge dispatch-notifications (logs no Lovable), o refresh token do Gmail e o net._http_response do cron afiacao_dispatch_notificacoes_30min'::text,
+      'critical'::text
+    FROM (
+      SELECT
+        (count(*) FILTER (WHERE fa.status='pendente_notificacao' AND fa.criado_em < now() - interval '2 hours'))::bigint AS stuck_pendentes,
+        (count(*) FILTER (WHERE fa.status='pendente_notificacao'))::bigint AS pendentes_total,
+        (count(*) FILTER (WHERE fa.status='falha_notificacao' AND fa.criado_em > now() - interval '24 hours'))::bigint AS falhas_24h,
+        EXTRACT(EPOCH FROM now() - min(fa.criado_em) FILTER (WHERE fa.status='pendente_notificacao' AND fa.criado_em < now() - interval '2 hours'))::bigint AS oldest_pendente_age_seconds,
+        (SELECT f2.erro_notificacao FROM public.fornecedor_alerta f2
+          WHERE f2.status='falha_notificacao' AND f2.erro_notificacao IS NOT NULL
+          ORDER BY f2.criado_em DESC LIMIT 1) AS ultimo_erro
+      FROM public.fornecedor_alerta fa
+    ) ac
+  )
+  SELECT c.source, c.domain, COALESCE(NULLIF(c.status, ''), 'unknown') AS status,
+    c.age_seconds, c.expected_max_age_seconds, c.freshness_basis, c.message,
+    c.last_error, c.probable_cause, c.how_to_fix, c.severity
+  FROM checks c;
+$$;
+
+-- Re-revoga (CREATE OR REPLACE preserva grants, mas reforço idempotente): só funções definer/cron a chamam.
+REVOKE ALL ON FUNCTION public._data_health_compute() FROM PUBLIC, anon, authenticated;
+
+-- Heartbeat: inclui 'alert_channel' no resumo de saúde de dados (o dead-man-switch passa a reportar
+-- o status do canal; a AUSÊNCIA do heartbeat continua sinalizando morte total do dispatch). Corpo =
+-- verbatim da migration 20260527220000; só amplio o IN e o rótulo.
+CREATE OR REPLACE FUNCTION public.fin_sync_heartbeat()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $$
+DECLARE
+  v_resumo text;
+  v_ativos int;
+  v_dh_ativos int;
+  v_dh_resumo text;
+BEGIN
+  SELECT count(*) INTO v_ativos
+  FROM fin_alertas WHERE tipo LIKE 'sync_%' AND dismissed_at IS NULL;
+
+  SELECT string_agg(linha, E'\n' ORDER BY linha) INTO v_resumo
+  FROM (
+    SELECT format('%s/%s: %s', co, re, COALESCE(to_char(m.mx, 'DD/MM HH24:MI'), 'NUNCA')) AS linha
+    FROM unnest(ARRAY['oben','colacor','colacor_sc']) AS co
+    CROSS JOIN unnest(ARRAY['contas_pagar','contas_receber','movimentacoes']) AS re
+    CROSS JOIN LATERAL (
+      SELECT max(l.completed_at) AS mx FROM fin_sync_log l
+      WHERE l.status='complete' AND l.action='sync_'||re AND co = ANY(l.companies)
+    ) m
+  ) s;
+
+  SELECT count(*) INTO v_dh_ativos
+  FROM fin_alertas WHERE tipo LIKE 'data_health_%' AND dismissed_at IS NULL;
+
+  SELECT string_agg(format('%s: %s', source, status), E'\n' ORDER BY source) INTO v_dh_resumo
+  FROM public._data_health_compute()
+  WHERE source IN ('vendas_pedidos','estoque_inventario','reposicao_sugestoes','carteira_scores','alert_channel');
+
+  INSERT INTO fornecedor_alerta (empresa, tipo, severidade, titulo, mensagem, status)
+  VALUES ('oben', 'outro', 'info',
+          '[Watchdog OK] '||to_char(now(),'DD/MM'),
+          'Watchdog do sync rodou. Alertas de sync ativos: '||v_ativos||
+          E'.\n\nÚltimo sync OK por empresa/recurso:\n'||COALESCE(v_resumo,'(sem dados)')||
+          E'\n\nSaúde de dados — alertas ativos: '||v_dh_ativos||
+          E'.\nChecks (vendas/estoque/reposição/carteira/canal):\n'||COALESCE(v_dh_resumo,'(sem dados)'),
+          'pendente_notificacao');
+END;
+$$;


### PR DESCRIPTION
## Resumo

Fecha o **último risco residual** da Sentinela Ativo (#401): se o `dispatch-notifications` parar de drenar `fornecedor_alerta`, **todos** os alertas da Sentinela ficam mudos — reabrindo a classe de falha silenciosa que o incidente de 2026-05-27 expôs. Decisão eu + codex (2 consults).

- **dispatch-notifications: cadência diária → `*/30`.** Era `10 11 * * *` (1×/dia), então os alertas do watchdog (que roda `*/30`) só saíam por email no batch das 11:10 → latência de até ~24h, contradizendo o "ativo". `*/30` alinha com o watchdog (worst-case ~60min). Idle é barato (early-return em 0 pendentes antes do OAuth/Gmail); volume bounded pelo anti-spam (UNIQUE parcial em `fin_alertas`). Job renomeado (`diario`→`30min`); `unschedule` guardado por jobid = idempotente.
- **9º check `alert_channel`** (domínio `alertas`) na fonte-de-verdade `_data_health_compute()`: `broken` se email preso >2h **ou** ≥5 falhas/24h; `stale` se 1..4 falhas recentes; `ok` caso contrário. Severity `critical`. Flui pro dashboard (pull), badge do topbar e heartbeat automaticamente.
- **Princípio:** `alert_channel` fica **fora** do loop de push do watchdog — não se avisa a quebra do canal **pelo** canal quebrado. As superfícies são: dashboard (pull, sempre funciona), seção no heartbeat e a **ausência** do heartbeat (dead-man-switch).
- **Sem mudança de contrato** do `get_data_health()`. Frontend: +1 domínio no type + label.

## ⚠️ ATENÇÃO: migrations manuais necessárias (SQL Editor do Lovable)

2 blocos, na ordem:
1. `20260527235000_dispatch_notifications_frequente.sql` — reschedule do dispatch pra `*/30`.
2. `20260527240000_data_health_alert_channel.sql` — `_data_health_compute()` (9 checks) + `fin_sync_heartbeat()` estendido.

## Test plan
- [x] `typecheck:strict` + baseline `tsc -p tsconfig.app.json`
- [x] `bun lint` (0 errors)
- [x] `bun run test` (1625/1625)
- [x] `bun run build`
- [ ] Aplicar os 2 blocos no SQL Editor + validar (paridade 9 checks; `alert_channel`=ok; cron `..._30min` ativo e `_diario` removido)

🤖 Generated with [Claude Code](https://claude.com/claude-code)