### PR TITLE
fix(boot): blindagem contra spinner infinito no domínio publicado

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,7 +35,74 @@
 </head>
 
   <body>
-    <div id="root"><div style="display:flex;align-items:center;justify-content:center;min-height:100vh;background:#1a1a2e;"><div style="width:40px;height:40px;border:3px solid rgba(255,255,255,0.15);border-top-color:#fff;border-radius:50%;animation:spin 0.8s linear infinite;"></div></div><style>@keyframes spin{to{transform:rotate(360deg)}}</style></div>
+    <div id="root"><div id="boot-spinner" style="display:flex;align-items:center;justify-content:center;min-height:100vh;background:#1a1a2e;"><div style="width:40px;height:40px;border:3px solid rgba(255,255,255,0.15);border-top-color:#fff;border-radius:50%;animation:spin 0.8s linear infinite;"></div></div><style>@keyframes spin{to{transform:rotate(360deg)}}</style></div>
+    <script>
+      // Boot watchdog — roda FORA do bundle JS, então recupera mesmo quando o
+      // bundle/service-worker falha e o React nunca monta (spinner escuro infinito).
+      // Desenhado pra NÃO repetir o incidente do reload() antigo: só age após
+      // timeout, só se o app não montou, e no máximo 1× por sessão (anti-loop).
+      (function () {
+        try {
+          if (window.self !== window.top) return; // dentro de iframe (editor Lovable)
+          var host = location.hostname;
+          if (host.indexOf("id-preview--") !== -1 || host.indexOf("lovableproject.com") !== -1) return; // preview Lovable
+        } catch (e) { return; }
+
+        var BOOT_TIMEOUT_MS = 15000; // generoso: cobre rede lenta sem falso-positivo
+        var RECOVERY_KEY = "__boot_recovery_attempted__";
+
+        function booted() {
+          return window.__APP_BOOTED__ === true || !document.getElementById("boot-spinner");
+        }
+
+        function showFallback() {
+          var root = document.getElementById("root");
+          if (!root) return;
+          root.innerHTML =
+            '<div style="min-height:100vh;display:flex;align-items:center;justify-content:center;background:#1a1a2e;color:#fff;font-family:system-ui,-apple-system,sans-serif;padding:24px;text-align:center;">' +
+              '<div style="max-width:360px;">' +
+                '<div style="font-size:18px;font-weight:600;margin-bottom:8px;">Não foi possível carregar o app</div>' +
+                '<div style="font-size:14px;opacity:0.7;margin-bottom:20px;">Verifique sua conexão e tente novamente.</div>' +
+                '<button onclick="location.reload()" style="background:#fff;color:#1a1a2e;border:none;border-radius:8px;padding:10px 20px;font-size:14px;font-weight:600;cursor:pointer;">Recarregar</button>' +
+              '</div>' +
+            '</div>';
+        }
+
+        function recover() {
+          var done = false;
+          function go() { if (done) return; done = true; location.reload(); }
+          setTimeout(go, 2000); // teto caso unregister/caches.delete trave
+          try {
+            var tasks = [];
+            if ("serviceWorker" in navigator) {
+              tasks.push(navigator.serviceWorker.getRegistrations().then(function (rs) {
+                return Promise.all(rs.map(function (r) { return r.unregister(); }));
+              }));
+            }
+            if ("caches" in window) {
+              tasks.push(caches.keys().then(function (ks) {
+                return Promise.all(ks.map(function (k) { return caches.delete(k); }));
+              }));
+            }
+            Promise.all(tasks).then(go).catch(go);
+          } catch (e) { go(); }
+        }
+
+        setTimeout(function () {
+          if (booted()) return;
+          var attempted;
+          try { attempted = sessionStorage.getItem(RECOVERY_KEY); } catch (e) { attempted = null; }
+          if (attempted) {
+            // Já limpou SW + recarregou 1× nesta sessão e SEGUE travado →
+            // não fica em loop; mostra mensagem acionável em vez do spinner eterno.
+            showFallback();
+            return;
+          }
+          try { sessionStorage.setItem(RECOVERY_KEY, "1"); } catch (e) {}
+          recover();
+        }, BOOT_TIMEOUT_MS);
+      })();
+    </script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -127,6 +127,20 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
   useEffect(() => {
     let isMounted = true;
 
+    // Failsafe: nunca deixar o app preso num spinner pra sempre. Se o bootstrap
+    // de auth do Supabase travar (lock do navigator.locks preso por outra aba,
+    // token corrompido, ou query de role sem timeout), força loading=false pra
+    // que o ProtectedRoute redirecione pro /auth (login) em vez de spinner
+    // infinito. 10s é folgado: o caminho normal resolve em <1s.
+    const loadingFailsafe = setTimeout(() => {
+      if (isMounted) {
+        logger.error('Auth bootstrap timed out — forcing loading=false (failsafe)', {
+          stage: 'auth_failsafe',
+        });
+        setLoading(false);
+      }
+    }, 10_000);
+
     // Set up auth state listener FIRST
     const { data: { subscription } } = supabase.auth.onAuthStateChange(
       (event, session) => {
@@ -176,6 +190,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
 
     return () => {
       isMounted = false;
+      clearTimeout(loadingFailsafe);
       subscription.unsubscribe();
     };
   }, []);

--- a/src/contexts/__tests__/AuthContext.failsafe.test.tsx
+++ b/src/contexts/__tests__/AuthContext.failsafe.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import type { ReactNode } from 'react';
+
+// Supabase auth que NUNCA resolve: getSession pendente pra sempre e nenhum
+// evento de auth disparado. Reproduz a trava de bootstrap (lock do
+// navigator.locks preso, token corrompido, request pendurado). Sem o failsafe,
+// `loading` ficaria true pra sempre → ProtectedRoute gira eternamente e o login
+// nunca aparece.
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    auth: {
+      onAuthStateChange: vi.fn(() => ({
+        data: { subscription: { unsubscribe: vi.fn() } },
+      })),
+      getSession: vi.fn(() => new Promise(() => {})),
+    },
+    from: vi.fn(),
+  },
+}));
+
+import { AuthProvider, useAuth } from '@/contexts/AuthContext';
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <AuthProvider>{children}</AuthProvider>;
+}
+
+describe('AuthContext loading failsafe', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it('força loading=false após o timeout quando o bootstrap de auth trava', async () => {
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    // Bootstrap pendente: ainda carregando.
+    expect(result.current.loading).toBe(true);
+
+    // Antes do failsafe (10s): segue carregando — prova que é o timer que
+    // destrava, não outro caminho.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(9_000);
+    });
+    expect(result.current.loading).toBe(true);
+
+    // Após o failsafe: loading vira false → ProtectedRoute redireciona pro /auth.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_500);
+    });
+    expect(result.current.loading).toBe(false);
+    expect(result.current.user).toBeNull();
+  });
+});

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,13 @@ import { createRoot } from "react-dom/client";
 import App from "./App.tsx";
 import "./index.css";
 
+declare global {
+  interface Window {
+    /** Setado após o React montar; lido pelo watchdog de boot no index.html. */
+    __APP_BOOTED__?: boolean;
+  }
+}
+
 const isInLovablePreview =
   window.location.hostname.includes("id-preview--") ||
   window.location.hostname.includes("lovableproject.com");
@@ -33,4 +40,28 @@ if (isInLovablePreview || isInIframe) {
   })();
 }
 
+// Vite dispara este evento quando um dynamic import (chunk de rota lazy) falha
+// ao carregar — causa #1 de tela branca/spinner pós-deploy (o chunk hash velho
+// sumiu do servidor). Recarrega 1× pra buscar os chunks novos (guarda anti-loop).
+window.addEventListener("vite:preloadError", () => {
+  try {
+    if (sessionStorage.getItem("__preload_error_reloaded__")) return;
+    sessionStorage.setItem("__preload_error_reloaded__", "1");
+  } catch {
+    // sessionStorage indisponível: ainda assim recarrega (sem guarda).
+  }
+  window.location.reload();
+});
+
 createRoot(document.getElementById("root")!).render(<App />);
+
+// Sinaliza pro watchdog de boot (no index.html) que o bundle executou e o React
+// montou. Limpar as guardas de recuperação permite que o watchdog/preloadError
+// recuperem de novo caso uma falha POSTERIOR estrague o app na mesma sessão.
+window.__APP_BOOTED__ = true;
+try {
+  sessionStorage.removeItem("__boot_recovery_attempted__");
+  sessionStorage.removeItem("__preload_error_reloaded__");
+} catch {
+  // ignore
+}


### PR DESCRIPTION
## Resumo

Conserta o sintoma reportado pelo founder: **o domínio publicado fica no spinner escuro e nunca abre o login**. Diagnóstico (via `/investigate`): o spinner escuro (#1a1a2e) é o estático do `#root` no `index.html` → o **React nunca montou**. O service worker do PWA (`registerType: "autoUpdate"`, precache do `index.html`) serve um app-shell velho que aponta pra um chunk JS que sumiu num deploy. `Ctrl+Shift+R` não resolve porque não desregistra o SW — confirmado pelo founder. Como o erro acontece **antes** do React iniciar, nem `ErrorBoundary` nem `Suspense` recuperam, e no domínio publicado não havia nenhuma rede de segurança.

Blindagem de boot em **3 camadas**, independente de mudanças futuras no código:

- **`index.html`** — watchdog inline (fora do bundle): se o app não montar em 15s, desregistra SW + limpa caches e recarrega 1× (guarda anti-loop em `sessionStorage`), com fallback de mensagem acionável se a recuperação falhar. Pula preview/iframe. Desenhado pra **não** repetir o incidente do `reload()` antigo (`3e352c01`): só age após timeout, só se não montou, no máximo 1× por sessão.
- **`src/main.tsx`** — handler `vite:preloadError` (reload 1× em chunk 404 pós-deploy) + sinal `window.__APP_BOOTED__` após montar (limpa as guardas de recuperação).
- **`src/contexts/AuthContext.tsx`** — failsafe de 10s que força `loading=false` se o `getSession()`/`onAuthStateChange` do Supabase travar (lock do `navigator.locks`), garantindo que o `ProtectedRoute` redirecione pro `/auth` em vez de spinner infinito.

## Test Coverage

- Novo teste de regressão `src/contexts/__tests__/AuthContext.failsafe.test.tsx`: monta o `AuthProvider` com `supabase.auth` que **nunca resolve** → sem o failsafe `loading` ficaria `true` pra sempre; com o fix vira `false` após 10s (assert antes/depois do timeout).
- O watchdog do `index.html` é script inline fora do bundle (não unit-testável em vitest por design); verificado no build: presente no `dist/index.html`.

## Verificação local (estado mesclado com a main)

- [x] typecheck baseline (`tsconfig.app.json`): 0 erros
- [x] typecheck:strict (AuthContext incluído): 0 erros
- [x] lint: 0 erros
- [x] suíte completa (vitest): 307 arquivos / 1626 testes passando
- [x] build de produção: OK, watchdog confirmado no `dist/index.html`

## ⚠️ Para resolver em produção

Essa blindagem protege **do próximo deploy em diante**. Após mergear, **é preciso publicar pelo Lovable** (build de produção que gera o SW novo) pra que pare de acontecer no domínio publicado. Usuários travados agora no shell velho devem se curar sozinhos em 1-2 reloads depois da publicação (`skipWaiting`); no pior caso, uma limpeza manual de dados do site de uma vez resolve a transição.

🤖 Generated with [Claude Code](https://claude.com/claude-code)