### PR TITLE
feat(clientes-nv): export CSV (todos) + cron noturno de refresh

### DIFF
--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,14 +21,14 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **94** custom migrations totais
-- **432** objetos esperados (criados por estas migrations)
+- **98** custom migrations totais
+- **481** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
   - `rls_policy`: 139
   - `index`: 96
-  - `function`: 70
+  - `cron_job`: 82
+  - `function`: 72
   - `table`: 57
-  - `cron_job`: 35
   - `trigger`: 31
   - `enum_value`: 4
 
@@ -920,6 +920,75 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 ### `20260527220001_fin_sync_cursor_backfill_desde.sql`
 
 > _Nenhum objeto extraído via regex._ Migration provavelmente é `ALTER TABLE` / `UPDATE` / `INSERT` / RLS-only. Validar manualmente.
+
+### `20260527230000_cron_baseline.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `cron_job` | `cron.afiacao_ciclo_oportunidade_diario` | — |
+| `cron_job` | `cron.afiacao_dispatch_notificacoes_diario` | — |
+| `cron_job` | `cron.afiacao_estados_eventos_diarios` | — |
+| `cron_job` | `cron.afiacao_limpeza_sugestoes_mensal` | — |
+| `cron_job` | `cron.afiacao_omie_oben_sku_items_history_daily` | — |
+| `cron_job` | `cron.afiacao_omie_oben_sync_incremental_2h` | — |
+| `cron_job` | `cron.afiacao_ranking_refresh_semanal` | — |
+| `cron_job` | `cron.afiacao_sugestoes_diarias` | — |
+| `cron_job` | `cron.call-log-missed-backstop` | — |
+| `cron_job` | `cron.carteira-positivacao-snapshot-mensal` | — |
+| `cron_job` | `cron.carteira-rebuild-nightly` | — |
+| `cron_job` | `cron.compute-association-rules-daily` | — |
+| `cron_job` | `cron.compute-costs-daily` | — |
+| `cron_job` | `cron.daily-calculate-scores` | — |
+| `cron_job` | `cron.data-health-watchdog` | — |
+| `cron_job` | `cron.detectar-outliers-diario` | — |
+| `cron_job` | `cron.disparar-pedidos-aprovados-oben` | — |
+| `cron_job` | `cron.fin-cashflow-snapshot-diario` | — |
+| `cron_job` | `cron.fin-ic-reconcile-daily` | — |
+| `cron_job` | `cron.fin-refresh-analise-dimensoes` | — |
+| `cron_job` | `cron.fin-sync-base-diario` | — |
+| `cron_job` | `cron.fin-sync-continuacao-10min` | — |
+| `cron_job` | `cron.fin-sync-cp-2x` | — |
+| `cron_job` | `cron.fin-sync-cr-2x` | — |
+| `cron_job` | `cron.fin-sync-heartbeat` | — |
+| `cron_job` | `cron.fin-sync-mov-2x` | — |
+| `cron_job` | `cron.fin-sync-watchdog` | — |
+| `cron_job` | `cron.gerar-pedidos-diario-oben` | — |
+| `cron_job` | `cron.monthly-tool-report` | — |
+| `cron_job` | `cron.omie-sync-estoque-diario` | — |
+| `cron_job` | `cron.omie-sync-metadados-daily` | — |
+| `cron_job` | `cron.omie-sync-status-produtos-diario` | — |
+| `cron_job` | `cron.process-recurring-orders-daily` | — |
+| `cron_job` | `cron.sayerlack-portal-watchdog` | — |
+| `cron_job` | `cron.scoring-recalc-batch-nightly` | — |
+| `cron_job` | `cron.sync-colacor-vendas-products` | — |
+| `cron_job` | `cron.sync-inventory-vendas-30m` | — |
+| `cron_job` | `cron.sync-omie-services-hourly` | — |
+| `cron_job` | `cron.sync-products-customers-daily` | — |
+| `cron_job` | `cron.sync-reprocess-operational` | — |
+| `cron_job` | `cron.sync-reprocess-strategic` | — |
+| `cron_job` | `cron.vendas-sync-pedidos-colacor-2h` | — |
+| `cron_job` | `cron.vendas-sync-pedidos-oben-2h` | — |
+| `cron_job` | `cron.visit-score-recalc-batch-nightly` | — |
+| `cron_job` | `cron.weekly-algorithm-a-audit` | — |
+
+### `20260527235000_dispatch_notifications_frequente.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `cron_job` | `cron.afiacao_dispatch_notificacoes_30min` | — |
+
+### `20260527240000_data_health_alert_channel.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `public._data_health_compute` | — |
+| `function` | `public.fin_sync_heartbeat` | — |
+
+### `20260527250000_nao_vinculados_cron.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `cron_job` | `cron.nao-vinculados-refresh-diario` | — |
 
 ## Próximos passos quando algo der `❌`
 

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 94
+-- Total de custom migrations: 98
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -113,7 +113,11 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260527200000', 'data_health_add_estoque_reposicao', '20260527200000_data_health_add_estoque_reposicao.sql'),
   ('20260527210000', 'data_health_compute_internal', '20260527210000_data_health_compute_internal.sql'),
   ('20260527220000', 'data_health_watchdog', '20260527220000_data_health_watchdog.sql'),
-  ('20260527220001', 'fin_sync_cursor_backfill_desde', '20260527220001_fin_sync_cursor_backfill_desde.sql')
+  ('20260527220001', 'fin_sync_cursor_backfill_desde', '20260527220001_fin_sync_cursor_backfill_desde.sql'),
+  ('20260527230000', 'cron_baseline', '20260527230000_cron_baseline.sql'),
+  ('20260527235000', 'dispatch_notifications_frequente', '20260527235000_dispatch_notifications_frequente.sql'),
+  ('20260527240000', 'data_health_alert_channel', '20260527240000_data_health_alert_channel.sql'),
+  ('20260527250000', 'nao_vinculados_cron', '20260527250000_nao_vinculados_cron.sql')
 )
 SELECT
   e.version,
@@ -563,7 +567,56 @@ WITH expected_objects (migration, kind, schema_name, object_name, parent_name) A
   ('data_health_compute_internal', 'function', 'public', 'get_data_health', ''),
   ('data_health_watchdog', 'function', 'public', 'data_health_watchdog', ''),
   ('data_health_watchdog', 'function', 'public', 'fin_sync_heartbeat', ''),
-  ('data_health_watchdog', 'cron_job', 'cron', 'data-health-watchdog', '')
+  ('data_health_watchdog', 'cron_job', 'cron', 'data-health-watchdog', ''),
+  ('cron_baseline', 'cron_job', 'cron', 'afiacao_ciclo_oportunidade_diario', ''),
+  ('cron_baseline', 'cron_job', 'cron', 'afiacao_dispatch_notificacoes_diario', ''),
+  ('cron_baseline', 'cron_job', 'cron', 'afiacao_estados_eventos_diarios', ''),
+  ('cron_baseline', 'cron_job', 'cron', 'afiacao_limpeza_sugestoes_mensal', ''),
+  ('cron_baseline', 'cron_job', 'cron', 'afiacao_omie_oben_sku_items_history_daily', ''),
+  ('cron_baseline', 'cron_job', 'cron', 'afiacao_omie_oben_sync_incremental_2h', ''),
+  ('cron_baseline', 'cron_job', 'cron', 'afiacao_ranking_refresh_semanal', ''),
+  ('cron_baseline', 'cron_job', 'cron', 'afiacao_sugestoes_diarias', ''),
+  ('cron_baseline', 'cron_job', 'cron', 'call-log-missed-backstop', ''),
+  ('cron_baseline', 'cron_job', 'cron', 'carteira-positivacao-snapshot-mensal', ''),
+  ('cron_baseline', 'cron_job', 'cron', 'carteira-rebuild-nightly', ''),
+  ('cron_baseline', 'cron_job', 'cron', 'compute-association-rules-daily', ''),
+  ('cron_baseline', 'cron_job', 'cron', 'compute-costs-daily', ''),
+  ('cron_baseline', 'cron_job', 'cron', 'daily-calculate-scores', ''),
+  ('cron_baseline', 'cron_job', 'cron', 'data-health-watchdog', ''),
+  ('cron_baseline', 'cron_job', 'cron', 'detectar-outliers-diario', ''),
+  ('cron_baseline', 'cron_job', 'cron', 'disparar-pedidos-aprovados-oben', ''),
+  ('cron_baseline', 'cron_job', 'cron', 'fin-cashflow-snapshot-diario', ''),
+  ('cron_baseline', 'cron_job', 'cron', 'fin-ic-reconcile-daily', ''),
+  ('cron_baseline', 'cron_job', 'cron', 'fin-refresh-analise-dimensoes', ''),
+  ('cron_baseline', 'cron_job', 'cron', 'fin-sync-base-diario', ''),
+  ('cron_baseline', 'cron_job', 'cron', 'fin-sync-continuacao-10min', ''),
+  ('cron_baseline', 'cron_job', 'cron', 'fin-sync-cp-2x', ''),
+  ('cron_baseline', 'cron_job', 'cron', 'fin-sync-cr-2x', ''),
+  ('cron_baseline', 'cron_job', 'cron', 'fin-sync-heartbeat', ''),
+  ('cron_baseline', 'cron_job', 'cron', 'fin-sync-mov-2x', ''),
+  ('cron_baseline', 'cron_job', 'cron', 'fin-sync-watchdog', ''),
+  ('cron_baseline', 'cron_job', 'cron', 'gerar-pedidos-diario-oben', ''),
+  ('cron_baseline', 'cron_job', 'cron', 'monthly-tool-report', ''),
+  ('cron_baseline', 'cron_job', 'cron', 'omie-sync-estoque-diario', ''),
+  ('cron_baseline', 'cron_job', 'cron', 'omie-sync-metadados-daily', ''),
+  ('cron_baseline', 'cron_job', 'cron', 'omie-sync-status-produtos-diario', ''),
+  ('cron_baseline', 'cron_job', 'cron', 'process-recurring-orders-daily', ''),
+  ('cron_baseline', 'cron_job', 'cron', 'sayerlack-portal-watchdog', ''),
+  ('cron_baseline', 'cron_job', 'cron', 'scoring-recalc-batch-nightly', ''),
+  ('cron_baseline', 'cron_job', 'cron', 'sync-colacor-vendas-products', ''),
+  ('cron_baseline', 'cron_job', 'cron', 'sync-inventory-vendas-30m', ''),
+  ('cron_baseline', 'cron_job', 'cron', 'sync-omie-services-hourly', ''),
+  ('cron_baseline', 'cron_job', 'cron', 'sync-products-customers-daily', ''),
+  ('cron_baseline', 'cron_job', 'cron', 'sync-reprocess-operational', ''),
+  ('cron_baseline', 'cron_job', 'cron', 'sync-reprocess-strategic', ''),
+  ('cron_baseline', 'cron_job', 'cron', 'vendas-sync-pedidos-colacor-2h', ''),
+  ('cron_baseline', 'cron_job', 'cron', 'vendas-sync-pedidos-oben-2h', ''),
+  ('cron_baseline', 'cron_job', 'cron', 'visit-score-recalc-batch-nightly', ''),
+  ('cron_baseline', 'cron_job', 'cron', 'weekly-algorithm-a-audit', ''),
+  ('dispatch_notifications_frequente', 'cron_job', 'cron', 'afiacao_dispatch_notificacoes_30min', ''),
+  ('data_health_alert_channel', 'function', 'public', '_data_health_compute', ''),
+  ('data_health_alert_channel', 'function', 'public', 'fin_sync_heartbeat', ''),
+  ('nao_vinculados_cron', 'cron_job', 'cron', 'nao-vinculados-refresh-diario', '')
 )
 SELECT
   e.migration,

--- a/src/hooks/useExportNaoVinculados.ts
+++ b/src/hooks/useExportNaoVinculados.ts
@@ -1,0 +1,53 @@
+import { useMutation } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import { track } from '@/lib/analytics';
+import { toCsv, type NaoVinculadoCsvRow } from '@/lib/clientes-nao-vinculados/csv';
+
+const EMPRESA = 'oben';
+const PAGE = 1000;
+
+// View nova não está no types.ts → cast por shape mínimo (sem any).
+type PgRange = PromiseLike<{ data: unknown; error: { message: string } | null }> & {
+  eq: (col: string, val: string) => PgRange;
+  order: (col: string, opts: { ascending: boolean }) => PgRange;
+  range: (from: number, to: number) => PgRange;
+};
+
+// Exporta TODOS os não-vinculados do último run completo como CSV (não a lista capada da tela).
+// Pagina por omie_codigo_cliente (chave estável → sem pular/duplicar linha entre páginas).
+export function useExportNaoVinculados() {
+  return useMutation({
+    mutationFn: async (): Promise<number> => {
+      const client = supabase as unknown as { from: (t: string) => { select: (c: string) => PgRange } };
+      const all: NaoVinculadoCsvRow[] = [];
+      let from = 0;
+      while (true) {
+        const { data, error } = await client
+          .from('v_clientes_nao_vinculados_atual')
+          .select('omie_codigo_cliente, cnpj_cpf, razao_social, nome_fantasia, cidade, uf, codigo_vendedor')
+          .eq('empresa', EMPRESA)
+          .order('omie_codigo_cliente', { ascending: true })
+          .range(from, from + PAGE - 1);
+        if (error) throw new Error(error.message);
+        const rows = (data as NaoVinculadoCsvRow[]) ?? [];
+        all.push(...rows);
+        if (rows.length < PAGE) break;
+        from += PAGE;
+      }
+
+      // BOM UTF-8 → Excel mostra acentos corretamente.
+      const blob = new Blob(['﻿' + toCsv(all)], { type: 'text/csv;charset=utf-8;' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `clientes-nao-vinculados-oben-${new Date().toISOString().slice(0, 10)}.csv`;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+
+      track('carteira.nao_vinculados_export', { linhas: all.length });
+      return all.length;
+    },
+  });
+}

--- a/src/lib/clientes-nao-vinculados/__tests__/csv.test.ts
+++ b/src/lib/clientes-nao-vinculados/__tests__/csv.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { toCsv } from '../csv';
+
+describe('toCsv', () => {
+  it('começa com a linha de cabeçalho', () => {
+    expect(toCsv([]).split('\r\n')[0]).toBe('codigo_omie;cnpj_cpf;razao_social;nome_fantasia;cidade;uf;codigo_vendedor');
+  });
+
+  it('monta uma linha com os campos na ordem certa', () => {
+    const csv = toCsv([
+      { omie_codigo_cliente: 42, cnpj_cpf: '12345678000199', razao_social: 'Marcenaria Silva', nome_fantasia: 'Móveis Silva', cidade: 'Curitiba', uf: 'PR', codigo_vendedor: 7 },
+    ]);
+    expect(csv.split('\r\n')[1]).toBe('42;12345678000199;Marcenaria Silva;Móveis Silva;Curitiba;PR;7');
+  });
+
+  it('null/undefined viram célula vazia', () => {
+    const csv = toCsv([
+      { omie_codigo_cliente: 1, cnpj_cpf: null, razao_social: null, nome_fantasia: null, cidade: null, uf: null, codigo_vendedor: null },
+    ]);
+    expect(csv.split('\r\n')[1]).toBe('1;;;;;;');
+  });
+
+  it('escapa campo com delimitador, aspas e quebra de linha (RFC4180)', () => {
+    const csv = toCsv([
+      { omie_codigo_cliente: 9, cnpj_cpf: null, razao_social: 'Silva; Souza "ME"\nLtda', nome_fantasia: null, cidade: null, uf: null, codigo_vendedor: null },
+    ]);
+    // o campo problemático fica entre aspas, com aspas internas dobradas
+    expect(csv.split('\r\n')[0]).toBe('codigo_omie;cnpj_cpf;razao_social;nome_fantasia;cidade;uf;codigo_vendedor');
+    expect(csv).toContain('9;;"Silva; Souza ""ME""\nLtda";;;;');
+  });
+
+  it('separa linhas com CRLF (Excel)', () => {
+    const csv = toCsv([
+      { omie_codigo_cliente: 1, cnpj_cpf: null, razao_social: 'A', nome_fantasia: null, cidade: null, uf: null, codigo_vendedor: null },
+      { omie_codigo_cliente: 2, cnpj_cpf: null, razao_social: 'B', nome_fantasia: null, cidade: null, uf: null, codigo_vendedor: null },
+    ]);
+    expect(csv.split('\r\n')).toHaveLength(3); // header + 2 linhas
+  });
+});

--- a/src/lib/clientes-nao-vinculados/csv.ts
+++ b/src/lib/clientes-nao-vinculados/csv.ts
@@ -1,0 +1,39 @@
+// CSV puro do relatório de clientes não-vinculados.
+// Delimitador ';' (Excel pt-BR abre direto); o BOM UTF-8 é adicionado no download (não aqui).
+
+export interface NaoVinculadoCsvRow {
+  omie_codigo_cliente: number;
+  cnpj_cpf: string | null;
+  razao_social: string | null;
+  nome_fantasia: string | null;
+  cidade: string | null;
+  uf: string | null;
+  codigo_vendedor: number | null;
+}
+
+const DELIM = ';';
+const HEADER = ['codigo_omie', 'cnpj_cpf', 'razao_social', 'nome_fantasia', 'cidade', 'uf', 'codigo_vendedor'];
+
+function cell(v: string | number | null | undefined): string {
+  const s = v == null ? '' : String(v);
+  if (s.includes(DELIM) || s.includes('"') || s.includes('\n') || s.includes('\r')) {
+    return '"' + s.replace(/"/g, '""') + '"';
+  }
+  return s;
+}
+
+export function toCsv(rows: NaoVinculadoCsvRow[]): string {
+  const lines = [HEADER.join(DELIM)];
+  for (const r of rows) {
+    lines.push([
+      cell(r.omie_codigo_cliente),
+      cell(r.cnpj_cpf),
+      cell(r.razao_social),
+      cell(r.nome_fantasia),
+      cell(r.cidade),
+      cell(r.uf),
+      cell(r.codigo_vendedor),
+    ].join(DELIM));
+  }
+  return lines.join('\r\n');
+}

--- a/src/pages/ClientesNaoVinculados.tsx
+++ b/src/pages/ClientesNaoVinculados.tsx
@@ -1,4 +1,4 @@
-import { RefreshCw, UserX } from 'lucide-react';
+import { RefreshCw, UserX, Download } from 'lucide-react';
 import { Card, CardHeader } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -7,6 +7,7 @@ import { PageSkeleton } from '@/components/ui/page-skeleton';
 import { useAuth } from '@/contexts/AuthContext';
 import { useClientesNaoVinculados } from '@/hooks/useClientesNaoVinculados';
 import { useRefreshClientesNaoVinculados } from '@/hooks/useRefreshClientesNaoVinculados';
+import { useExportNaoVinculados } from '@/hooks/useExportNaoVinculados';
 
 function formatFrescor(iso: string | null): string {
   if (!iso) return 'nunca sincronizado';
@@ -18,6 +19,7 @@ export default function ClientesNaoVinculados() {
   const podeVer = isMaster || isGestorComercial;
   const { data, isLoading } = useClientesNaoVinculados();
   const refresh = useRefreshClientesNaoVinculados();
+  const exportar = useExportNaoVinculados();
 
   if (!podeVer) {
     return (
@@ -53,15 +55,26 @@ export default function ClientesNaoVinculados() {
             Clientes no Omie sem conta no app — alvos pra convidar/criar conta. {formatFrescor(state?.last_complete_synced_at ?? null)}.
           </p>
         </div>
-        <Button
-          size="sm"
-          variant="outline"
-          onClick={() => refresh.mutate()}
-          disabled={running || refresh.isPending}
-        >
-          <RefreshCw className={`w-4 h-4 mr-2 ${running ? 'animate-spin' : ''}`} />
-          {running ? 'Atualizando…' : 'Atualizar'}
-        </Button>
+        <div className="flex items-center gap-2 shrink-0">
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => exportar.mutate()}
+            disabled={total === 0 || exportar.isPending}
+          >
+            <Download className="w-4 h-4 mr-2" />
+            {exportar.isPending ? 'Exportando…' : 'Exportar CSV'}
+          </Button>
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => refresh.mutate()}
+            disabled={running || refresh.isPending}
+          >
+            <RefreshCw className={`w-4 h-4 mr-2 ${running ? 'animate-spin' : ''}`} />
+            {running ? 'Atualizando…' : 'Atualizar'}
+          </Button>
+        </div>
       </header>
 
       {erro && (

--- a/supabase/migrations/20260527250000_nao_vinculados_cron.sql
+++ b/supabase/migrations/20260527250000_nao_vinculados_cron.sql
@@ -1,0 +1,26 @@
+-- Cron noturno: refresh do relatório de clientes não-vinculados (Oben).
+-- start_nao_vinculados é ASSÍNCRONO (EdgeRuntime.waitUntil + 202), então o timeout só
+-- precisa cobrir o 202 imediato — o run em si continua em background no edge.
+-- ⚠️ timeout_milliseconds EXPLÍCITO (o default de 5s do pg_net mataria HTTP >5s silenciosamente
+--    e o job_run_details mentiria "succeeded" — incidente já registrado no CLAUDE.md §5).
+-- cron.schedule faz upsert por nome → idempotente.
+
+SELECT cron.schedule(
+  'nao-vinculados-refresh-diario',
+  '30 8 * * *',  -- 08:30 UTC ≈ 05:30 BRT (fora do pico)
+  $$
+  SELECT net.http_post(
+    url := 'https://fzvklzpomgnyikkfkzai.supabase.co/functions/v1/omie-analytics-sync',
+    headers := jsonb_build_object(
+      'Content-Type', 'application/json',
+      'x-cron-secret', (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'CRON_SECRET' LIMIT 1)
+    ),
+    body := jsonb_build_object('action', 'start_nao_vinculados', 'account', 'vendas'),
+    timeout_milliseconds := 60000
+  );
+  $$
+);
+
+SELECT 'CRON OK' AS status,
+  (SELECT count(*) FROM cron.job WHERE jobname = 'nao-vinculados-refresh-diario') AS jobs;
+-- esperado: jobs=1


### PR DESCRIPTION
## Summary
Dois follow-ups da feature de clientes não-vinculados (lane de B):
1. **Export CSV** — botão "Exportar CSV" baixa TODOS os não-vinculados (não a lista capada em 1000): hook `useExportNaoVinculados` pagina a view por `omie_codigo_cliente` (chave estável → sem pular/duplicar entre páginas), monta CSV (helper puro TDD `toCsv`, delimitador `;` + BOM UTF-8 p/ Excel pt-BR) e dispara download. Evento `carteira.nao_vinculados_export`.
2. **Cron noturno** — `nao-vinculados-refresh-diario` (`30 8 * * *`) dispara `start_nao_vinculados` pra o relatório não ficar stale entre cliques. `timeout_milliseconds := 60000` EXPLÍCITO (o run é async/202; o default de 5s do pg_net mataria silenciosamente — incidente já no §5).

## ATENÇÃO: migration manual
`supabase/migrations/20260527250000_nao_vinculados_cron.sql` (BLOCO no corpo) → SQL Editor (esperado `jobs=1`). Sem edge novo. Front re-publish após merge.

## Validação local
- `toCsv`: 5 testes (cabeçalho, ordem, null→vazio, escape RFC4180 de `;`/`"`/quebra, CRLF)
- tsc app + build OK; eslint dos novos arquivos limpo

## Test plan
- [ ] BLOCO do cron aplicado (`jobs=1`)
- [ ] Front publicado; botão "Exportar CSV" baixa ~10.485 linhas (não 1000)
- [ ] CI verde

🤖 Generated with [Claude Code](https://claude.com/claude-code)