### PR TITLE
chore(strict): Lote B — fixa + promove 11 .tsx (658→669)

### DIFF
--- a/src/components/SharpeningSuggestions.tsx
+++ b/src/components/SharpeningSuggestions.tsx
@@ -1,17 +1,16 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Bell, Calendar, ChevronRight, AlertTriangle, Clock, Wrench } from 'lucide-react';
+import { Bell, Calendar, AlertTriangle, Clock, Wrench } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useSharpeningSuggestions, SharpeningTool } from '@/hooks/useSharpeningSuggestions';
-import { format, formatDistanceToNow } from 'date-fns';
-import { ptBR } from 'date-fns/locale';
+import { format } from 'date-fns';
 import { cn } from '@/lib/utils';
 
 interface SharpeningSuggestionsProps {
   compact?: boolean;
 }
 
-export const SharpeningSuggestions = React.forwardRef<HTMLDivElement, SharpeningSuggestionsProps>(function SharpeningSuggestions({ compact = false }, ref) {
+export const SharpeningSuggestions = React.forwardRef<HTMLDivElement, SharpeningSuggestionsProps>(function SharpeningSuggestions({ compact = false }, _ref) {
   const navigate = useNavigate();
   const { overdueTools, dueSoonTools, upcomingTools, loading } = useSharpeningSuggestions();
 

--- a/src/components/aiOps/DecisionCard.tsx
+++ b/src/components/aiOps/DecisionCard.tsx
@@ -12,7 +12,6 @@ import type { AIDecision, Evidence } from './types';
 export function DecisionCard({
   decision,
   customerName,
-  customerPhone,
   onAccept,
   onDismiss,
 }: {

--- a/src/components/recebimento/LoteScannerOCR.tsx
+++ b/src/components/recebimento/LoteScannerOCR.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState, useCallback, useEffect } from 'react';
+import { useRef, useState, useCallback, useEffect } from 'react';
 import { createWorker } from 'tesseract.js';
 import { Camera, X, Loader2, ScanLine, CheckCircle2, AlertTriangle } from 'lucide-react';
 import { Button } from '@/components/ui/button';

--- a/src/components/tintImport/ImportCard.tsx
+++ b/src/components/tintImport/ImportCard.tsx
@@ -180,7 +180,7 @@ export function ImportCard({
                   <p className="font-medium">{r.name}</p>
                   <p className="text-muted-foreground">
                     {r.registros_importados ?? r.imported ?? 0} importados, {r.registros_atualizados ?? r.updated ?? 0} atualizados, {r.registros_erro ?? r.errors ?? 0} erros
-                    {r.failed_chunks > 0 && <span className="text-destructive"> ({r.failed_chunks} chunks falharam)</span>}
+                    {(r.failed_chunks ?? 0) > 0 && <span className="text-destructive"> ({r.failed_chunks} chunks falharam)</span>}
                   </p>
                   {r.erros && r.erros.length > 0 && (
                     <ul className="text-xs text-destructive mt-1">

--- a/src/components/unified-order/CartSummaryBar.tsx
+++ b/src/components/unified-order/CartSummaryBar.tsx
@@ -1,6 +1,5 @@
 import { useState, useMemo } from 'react';
 import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
 import { Label } from '@/components/ui/label';
 import { Input } from '@/components/ui/input';
 
@@ -11,12 +10,11 @@ import {
   Send, Loader2, AlertCircle, Check, ChevronsUpDown, FileText, Calendar, CloudOff,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import { format, addDays, startOfWeek, isWeekend } from 'date-fns';
+import { format, addDays, startOfWeek } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
 import type {
   ProductCartItem, ServiceCartItem, FormaPagamento,
 } from '@/hooks/useUnifiedOrder';
-import { fmt } from '@/hooks/useUnifiedOrder';
 
 interface CartSummaryBarProps {
   cart: { length: number };
@@ -146,14 +144,12 @@ function PaymentCombobox({
 }
 
 export function CartSummaryBar({
-  cart, obenProductItems, colacorProductItems, serviceItems, totalEstimated,
+  obenProductItems, colacorProductItems, serviceItems,
   submitting, vendedorDivergencias,
   sortedFormasPagamentoOben, sortedFormasPagamentoColacor,
   selectedParcelaOben, setSelectedParcelaOben,
   selectedParcelaColacor, setSelectedParcelaColacor,
   loadingFormas, customerParcelaRankingOben, customerParcelaRankingColacor,
-  notes, setNotes,
-  volumesOben, volumesColacor,
   ordemCompra, setOrdemCompra, isOrdemCompraCustomer,
   readyByDate, setReadyByDate,
   onSubmit, onSubmitQuote, offline = false,

--- a/src/components/unified-order/ProductItemForm.tsx
+++ b/src/components/unified-order/ProductItemForm.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef } from 'react';
+import { useState } from 'react';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';

--- a/src/pages/CoachingSPIN.tsx
+++ b/src/pages/CoachingSPIN.tsx
@@ -2,18 +2,14 @@ import { useState, useMemo } from 'react';
 
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
-import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { Textarea } from '@/components/ui/textarea';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Progress } from '@/components/ui/progress';
-import { ScrollArea } from '@/components/ui/scroll-area';
 import { Separator } from '@/components/ui/separator';
 import {
   Target, MessageSquare, Brain, AlertTriangle, CheckCircle2,
   XCircle, HelpCircle, TrendingUp, Clock, Phone, ChevronDown,
-  ChevronUp, Lightbulb, Search, Filter, Star, BarChart3,
-  ArrowRight, Play, Mic, FileText, Zap, Award, Eye, EyeOff,
+  ChevronUp, Lightbulb, Search, Star, BarChart3, Award,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 

--- a/src/pages/DesignSystem.tsx
+++ b/src/pages/DesignSystem.tsx
@@ -18,8 +18,8 @@ import { cn } from '@/lib/utils';
 import {
   AlertCircle, CheckCircle, Info, AlertTriangle, Plus, Search,
   ArrowRight, Trash2, Edit, Phone, ShoppingCart, TrendingUp,
-  Copy, ChevronRight, Loader2, X, Eye, EyeOff, MessageSquare,
-  Star, Zap, Package, Users, BarChart3
+  Copy, Loader2, MessageSquare,
+  Star, Zap, Users, BarChart3
 } from 'lucide-react';
 
 /* ─── Helpers ─── */

--- a/src/pages/FarmerIPFDashboard.tsx
+++ b/src/pages/FarmerIPFDashboard.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
@@ -7,7 +7,7 @@ import { Progress } from '@/components/ui/progress';
 import { useAuth } from '@/contexts/AuthContext';
 import { useFarmerPerformance } from '@/hooks/useFarmerPerformance';
 import {
-  Loader2, TrendingUp, DollarSign, BarChart3, Users, ShieldCheck,
+  Loader2, TrendingUp, DollarSign, BarChart3, ShieldCheck,
   RefreshCw, Layers, Target, type LucideIcon
 } from 'lucide-react';
 

--- a/src/pages/FarmerRecommendations.tsx
+++ b/src/pages/FarmerRecommendations.tsx
@@ -1,16 +1,15 @@
 import { useEffect, useState } from 'react';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { useCrossSellEngine, type CustomerRecommendations, type Recommendation } from '@/hooks/useCrossSellEngine';
+import { useCrossSellEngine } from '@/hooks/useCrossSellEngine';
 import { useAuth } from '@/contexts/AuthContext';
 import { useNavigate } from 'react-router-dom';
 import {
-  Loader2, RefreshCw, TrendingUp, ShoppingCart, ArrowUpRight,
+  Loader2, RefreshCw, ShoppingCart, ArrowUpRight,
   DollarSign, Target, Search, ChevronDown, ChevronUp, Filter,
-  Package, Sparkles, Plus,
+  Plus,
 } from 'lucide-react';
 import {
   DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger,
@@ -27,14 +26,13 @@ const StockBadge = ({ estoque }: { estoque: number | null }) => {
 
 const FarmerRecommendations = () => {
   const navigate = useNavigate();
-  const { isStaff, isAdmin, loading: authLoading } = useAuth();
+  const { isStaff, loading: authLoading } = useAuth();
   const {
     recommendations, loading, calculating, calculateRecommendations,
   } = useCrossSellEngine();
   const [expandedClient, setExpandedClient] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
   const [filterType, setFilterType] = useState<'all' | 'cross_sell' | 'up_sell'>('all');
-  const [activeTab, setActiveTab] = useState<'engine' | 'legacy'>('engine');
 
   useEffect(() => {
     if (!authLoading && isStaff) calculateRecommendations();

--- a/src/pages/UXRules.tsx
+++ b/src/pages/UXRules.tsx
@@ -4,9 +4,9 @@ import { Badge } from '@/components/ui/badge';
 import { Separator } from '@/components/ui/separator';
 import {
   Search, Filter, MousePointerClick, PanelRightOpen, AlertTriangle,
-  Target, Keyboard, Monitor, Smartphone, Tablet, Zap, RefreshCw,
-  ShoppingCart, Phone, MessageSquare, BarChart3, Headphones, GraduationCap,
-  ArrowRight, CheckCircle, XCircle, HelpCircle
+  Target, Keyboard, Monitor, Smartphone, Tablet, Zap,
+  ShoppingCart, Headphones, GraduationCap,
+  ArrowRight, CheckCircle, XCircle
 } from 'lucide-react';
 
 function Rule({ number, icon: Icon, title, children }: { number: number; icon: React.ElementType; title: string; children: React.ReactNode }) {

--- a/tsconfig.strict.json
+++ b/tsconfig.strict.json
@@ -676,6 +676,17 @@
     "src/components/unifiedAI/SuggestionsList.tsx",
     "src/pages/DesignPreview.tsx",
     "src/pages/FinanceiroIntercompanyFila.tsx",
-    "src/test/render-throws.tsx"
+    "src/test/render-throws.tsx",
+    "src/components/SharpeningSuggestions.tsx",
+    "src/components/aiOps/DecisionCard.tsx",
+    "src/components/recebimento/LoteScannerOCR.tsx",
+    "src/components/tintImport/ImportCard.tsx",
+    "src/components/unified-order/CartSummaryBar.tsx",
+    "src/components/unified-order/ProductItemForm.tsx",
+    "src/pages/CoachingSPIN.tsx",
+    "src/pages/DesignSystem.tsx",
+    "src/pages/FarmerIPFDashboard.tsx",
+    "src/pages/FarmerRecommendations.tsx",
+    "src/pages/UXRules.tsx"
   ]
 }


### PR DESCRIPTION
## Resumo

**Lote B** da triagem strict (`docs/strict-tsx-ready-candidates.md`): os **11 `.tsx`** que eram READY (deps já no strict) mas tinham erro próprio. Todos os fixes são **behavior-preserving**:

- **10 dead-code:** imports/vars não usados removidos (lucide, date-fns, ui), `useState` morto, `forwardRef` `ref`→`_ref`. Em `DecisionCard` e `CartSummaryBar`, as props ignoradas saíram **só do destructure** — o **tipo segue na interface**, preservando o contrato com os callers (comportamento idêntico, pois já eram ignoradas).
- **1 guard:** `tintImport/ImportCard` → `(r.failed_chunks ?? 0) > 0` (TS18048).

Fica de fora só o **12º** (`StandardProcessForm` — `zodResolver` optional-vs-required, médio; melhor fazer junto do irmão `AdminStandardProcessNew`).

Progresso strict: **658 → 669** (~78% de 853).

## Test plan

- [x] `heavy bun run typecheck:strict` verde (exit 0, 0 erros)
- [x] `heavy bun lint` 0 erros (`_ref` aceito; 82 warnings pré-existentes)
- [x] `heavy bun run test` — 1625 testes verdes (inclui os do fluxo de pedido / `CartSummaryBar`)
- [ ] CI `validate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)