### PR TITLE
chore(strict): fixa zodResolver StandardProcessForm + promove o par (669→671)

### DIFF
--- a/src/components/standard-process/StandardProcessForm.tsx
+++ b/src/components/standard-process/StandardProcessForm.tsx
@@ -24,6 +24,10 @@ const headerSchema = z.object({
   target_audience: z.string().optional(),
 });
 
+// z.input = shape do formulário (campos com .default() são opcionais na entrada);
+// z.infer (=z.output) = valores após parse/defaults (todos presentes). O resolver do
+// zod transforma input→output, então useForm recebe os 3 genéricos: <input, ctx, output>.
+type HeaderInput = z.input<typeof headerSchema>;
 type HeaderValues = z.infer<typeof headerSchema>;
 
 const emptyEtapa = (ordem: number): StandardProcessEtapa => ({
@@ -50,7 +54,7 @@ export function StandardProcessForm({ initial, onSaved }: Props) {
   const save = useSaveStandardProcess();
   const { data: specs } = useKbProductSpecsList();
 
-  const { register, handleSubmit, formState: { errors } } = useForm<HeaderValues>({
+  const { register, handleSubmit, formState: { errors } } = useForm<HeaderInput, unknown, HeaderValues>({
     resolver: zodResolver(headerSchema),
     defaultValues: {
       name: initial?.name ?? '',

--- a/tsconfig.strict.json
+++ b/tsconfig.strict.json
@@ -687,6 +687,8 @@
     "src/pages/DesignSystem.tsx",
     "src/pages/FarmerIPFDashboard.tsx",
     "src/pages/FarmerRecommendations.tsx",
-    "src/pages/UXRules.tsx"
+    "src/pages/UXRules.tsx",
+    "src/components/standard-process/StandardProcessForm.tsx",
+    "src/pages/AdminStandardProcessNew.tsx"
   ]
 }


### PR DESCRIPTION
## Resumo

O **12º (e último) arquivo do Lote B** — o único com **typing real** (não dead-code).

`headerSchema` tem campos `.default('')` → opcionais na **entrada**, presentes na **saída**. `useForm<HeaderValues>` (onde `HeaderValues = z.infer` = output) conflitava com o resolver do zod, que é tipado `<input, any, output>` (TS2322 no `Resolver<>`, TS2345 no `SubmitHandler<>`).

**Fix idiomático (3 genéricos do react-hook-form):**
```ts
type HeaderInput  = z.input<typeof headerSchema>;   // form (defaults opcionais)
type HeaderValues = z.infer<typeof headerSchema>;   // output (após parse)
useForm<HeaderInput, unknown, HeaderValues>({ resolver: zodResolver(headerSchema), ... })
```
`handleSubmit` passa a entregar `HeaderValues` (output), alinhando o `SubmitHandler`. **Mudança type-only — zero runtime.** (RHF 7.76 + @hookform/resolvers 5.2 suportam o transform typing.)

Destrava o irmão **`AdminStandardProcessNew`** (wrapper fino do form), promovido junto. **Fecha o Lote B inteiro (12/12).**

Progresso strict: **669 → 671** (~79% de 853).

## Test plan

- [x] `heavy bun run typecheck:strict` verde (exit 0, 0 erros)
- [x] `heavy bun lint` 0 erros
- [ ] CI `validate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)