### PR TITLE
feat(data-health): 2 checks HIGH de frescor (custos_produtos + vendas_cadastros)

### DIFF
--- a/supabase/migrations/20260527250000_data_health_checks_high.sql
+++ b/supabase/migrations/20260527250000_data_health_checks_high.sql
@@ -1,0 +1,276 @@
+-- Triagem dos 45 crons (eu + codex, 4o consult): dos ~28 não-cobertos pelo Sentinela, só 4 são HIGH
+-- (dano de negócio real + ninguém notaria rápido). NÃO cobrir por simetria. Desta leva entram os 2 HIGH
+-- de FRESCOR DE DADO (limpos, sem precisar calibrar threshold com prod — daily → stale>30h, padrão CR/CP):
+--   • custos_produtos    — compute-costs-daily escreve product_costs.updated_at (upsert seta updated_at
+--                          explicitamente → avança a cada run). Custo velho = margem/valor/decisão de
+--                          dinheiro errada. domínio 'estoque' (economia de produto), severity warning.
+--   • vendas_cadastros   — sync-products-customers-daily (omie-analytics-sync sync_all account=vendas)
+--                          loga em sync_state (entity_type customers/products, last_sync_at+status+erro).
+--                          Morte calada = clientes/produtos novos somem do CRM/carteira/catálogo. domínio
+--                          'vendas', severity critical (master data).
+-- Os 2 HIGH de AÇÃO (disparar-pedidos-aprovados, sayerlack-portal) ficam DEFERIDOS: são "monitorar fila
+-- de trabalho envelhecendo", exigem semântica de fila + calibração de threshold com dado de prod (qual
+-- idade de "aprovado parado" é anormal?) — construir sem calibrar = falso-alarme. Backlog c/ spec próprio.
+-- Ambos os checks reusam domínios existentes ('vendas'/'estoque') → sem mudança de frontend.
+-- Corpo = verbatim da migration 20260527240000 (9 checks, com alert_channel); acrescento 2 UNION ALL.
+
+CREATE OR REPLACE FUNCTION public._data_health_compute()
+RETURNS TABLE (
+  source text, domain text, status text,
+  age_seconds bigint, expected_max_age_seconds bigint, freshness_basis text,
+  message text, last_error text, probable_cause text, how_to_fix text, severity text
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+  WITH checks AS (
+    SELECT 'saldo_bancario'::text AS source, 'financeiro'::text AS domain,
+      CASE WHEN max(cc.saldo_data) IS NULL THEN 'broken'
+           WHEN now() - max(cc.saldo_data)::timestamptz > interval '36 hours' THEN 'stale' ELSE 'ok' END AS status,
+      EXTRACT(EPOCH FROM now() - max(cc.saldo_data)::timestamptz)::bigint AS age_seconds,
+      (36*3600)::bigint AS expected_max_age_seconds, 'max_saldo_data'::text AS freshness_basis,
+      CASE WHEN max(cc.saldo_data) IS NULL THEN 'Saldo bancário nunca sincronizou'
+           ELSE 'Saldo bancário: último sync ' || to_char(max(cc.saldo_data), 'DD/MM') END AS message,
+      NULL::text AS last_error,
+      CASE WHEN max(cc.saldo_data) IS NULL THEN 'ListarExtrato falhando ou nunca rodou' ELSE NULL END AS probable_cause,
+      'Rode sync_contas_correntes no chat do Lovable e cheque os logs do omie-financeiro'::text AS how_to_fix,
+      'critical'::text AS severity
+    FROM public.fin_contas_correntes cc WHERE cc.ativo = true
+    UNION ALL
+    SELECT 'contas_receber', 'financeiro',
+      CASE WHEN max(cr.updated_at) IS NULL THEN 'broken'
+           WHEN now() - max(cr.updated_at) > interval '26 hours' THEN 'stale' ELSE 'ok' END,
+      EXTRACT(EPOCH FROM now() - max(cr.updated_at))::bigint, (26*3600)::bigint, 'max_updated_at',
+      'Contas a receber: atualizado ' || COALESCE(to_char(max(cr.updated_at),'DD/MM HH24:MI'),'nunca'),
+      NULL, CASE WHEN max(cr.updated_at) IS NULL THEN 'Sync CR nunca completou' ELSE NULL END,
+      'Rode sync_contas_receber no Lovable', 'warning'
+    FROM public.fin_contas_receber cr
+    UNION ALL
+    SELECT 'contas_pagar', 'financeiro',
+      CASE WHEN max(cp.updated_at) IS NULL THEN 'broken'
+           WHEN now() - max(cp.updated_at) > interval '26 hours' THEN 'stale' ELSE 'ok' END,
+      EXTRACT(EPOCH FROM now() - max(cp.updated_at))::bigint, (26*3600)::bigint, 'max_updated_at',
+      'Contas a pagar: atualizado ' || COALESCE(to_char(max(cp.updated_at),'DD/MM HH24:MI'),'nunca'),
+      NULL, CASE WHEN max(cp.updated_at) IS NULL THEN 'Sync CP nunca completou' ELSE NULL END,
+      'Rode sync_contas_pagar no Lovable', 'warning'
+    FROM public.fin_contas_pagar cp
+    UNION ALL
+    SELECT 'omie_sync_financeiro'::text, 'omie_sync'::text,
+      COALESCE((SELECT CASE WHEN l.status='error' THEN 'broken' ELSE 'ok' END FROM public.fin_sync_log l
+                WHERE l.completed_at IS NOT NULL ORDER BY l.completed_at DESC LIMIT 1), 'unknown'),
+      (SELECT EXTRACT(EPOCH FROM now() - l.completed_at)::bigint FROM public.fin_sync_log l
+                WHERE l.completed_at IS NOT NULL ORDER BY l.completed_at DESC LIMIT 1),
+      NULL::bigint, 'fin_sync_log'::text,
+      'Último sync financeiro: ' || COALESCE((SELECT l.status FROM public.fin_sync_log l
+        WHERE l.completed_at IS NOT NULL ORDER BY l.completed_at DESC LIMIT 1), 'sem registro'),
+      (SELECT l.error_message FROM public.fin_sync_log l WHERE l.status='error' AND l.completed_at IS NOT NULL ORDER BY l.completed_at DESC LIMIT 1),
+      CASE WHEN (SELECT l.status FROM public.fin_sync_log l WHERE l.completed_at IS NOT NULL ORDER BY l.completed_at DESC LIMIT 1)='error'
+           THEN 'A última action de sync financeiro falhou' ELSE NULL END,
+      'Cheque fin_sync_log e re-rode a action que falhou'::text, 'critical'::text
+    UNION ALL
+    SELECT 'vendas_pedidos'::text, 'vendas'::text,
+      CASE WHEN v.oben_last IS NULL OR v.colacor_last IS NULL THEN 'broken'
+           WHEN now() - LEAST(v.oben_last, v.colacor_last) > interval '6 hours' THEN 'stale' ELSE 'ok' END,
+      EXTRACT(EPOCH FROM now() - LEAST(v.oben_last, v.colacor_last))::bigint,
+      (6*3600)::bigint, 'fin_sync_log.sync_pedidos'::text,
+      'Sync de pedidos: oben ' || COALESCE(to_char(v.oben_last,'DD/MM HH24:MI'),'nunca')
+        || ' · colacor ' || COALESCE(to_char(v.colacor_last,'DD/MM HH24:MI'),'nunca'),
+      v.last_err,
+      CASE WHEN v.oben_last IS NULL OR v.colacor_last IS NULL
+           THEN 'Cron vendas-sync-pedidos não rodou/completou para alguma conta' ELSE NULL END,
+      'Cheque os crons vendas-sync-pedidos-{oben,colacor}-2h e fin_sync_log (action sync_pedidos)'::text, 'critical'::text
+    FROM (
+      SELECT
+        (SELECT max(l.completed_at) FROM public.fin_sync_log l WHERE l.action='sync_pedidos' AND l.status='complete' AND 'oben' = ANY(l.companies)) AS oben_last,
+        (SELECT max(l.completed_at) FROM public.fin_sync_log l WHERE l.action='sync_pedidos' AND l.status='complete' AND 'colacor' = ANY(l.companies)) AS colacor_last,
+        (SELECT l.error_message FROM public.fin_sync_log l WHERE l.action='sync_pedidos' AND l.status='error' ORDER BY l.started_at DESC LIMIT 1) AS last_err
+    ) v
+    UNION ALL
+    SELECT 'estoque_inventario'::text, 'estoque'::text,
+      CASE WHEN max(ip.synced_at) IS NULL THEN 'broken'
+           WHEN now() - max(ip.synced_at) > interval '3 hours' THEN 'stale' ELSE 'ok' END,
+      EXTRACT(EPOCH FROM now() - max(ip.synced_at))::bigint, (3*3600)::bigint, 'inventory_position.synced_at',
+      'Inventário: sincronizado ' || COALESCE(to_char(max(ip.synced_at),'DD/MM HH24:MI'),'nunca'),
+      NULL, CASE WHEN max(ip.synced_at) IS NULL THEN 'sync_inventory nunca rodou' ELSE NULL END,
+      'Cheque o cron sync-inventory-vendas-30m (omie-analytics-sync sync_inventory)', 'warning'
+    FROM public.inventory_position ip
+    UNION ALL
+    SELECT 'reposicao_sugestoes'::text, 'estoque'::text,
+      CASE WHEN max(pcs.data_ciclo) IS NULL THEN 'broken'
+           WHEN current_date - max(pcs.data_ciclo) > 3 THEN 'stale' ELSE 'ok' END,
+      CASE WHEN max(pcs.data_ciclo) IS NULL THEN NULL
+           ELSE (current_date - max(pcs.data_ciclo))::bigint * 86400 END,
+      (3*86400)::bigint, 'pedido_compra_sugerido.data_ciclo',
+      'Sugestão de compra: último ciclo ' || COALESCE(to_char(max(pcs.data_ciclo),'DD/MM/YYYY'),'nunca'),
+      NULL, CASE WHEN max(pcs.data_ciclo) IS NULL THEN 'gerar-pedidos nunca gerou sugestão' ELSE NULL END,
+      'Cheque o cron gerar-pedidos-diario-oben'::text, 'warning'
+    FROM public.pedido_compra_sugerido pcs
+    UNION ALL
+    SELECT 'carteira_scores'::text, 'carteira'::text,
+      CASE WHEN max(fcs.calculated_at) IS NULL THEN 'broken'
+           WHEN now() - max(fcs.calculated_at) > interval '36 hours' THEN 'stale' ELSE 'ok' END,
+      EXTRACT(EPOCH FROM now() - max(fcs.calculated_at))::bigint, (36*3600)::bigint, 'calculated_at',
+      'Scoring de carteira: recalculado ' || COALESCE(to_char(max(fcs.calculated_at),'DD/MM HH24:MI'),'nunca'),
+      NULL, CASE WHEN max(fcs.calculated_at) IS NULL THEN 'calculate-scores nunca rodou' ELSE NULL END,
+      'Re-rode calculate-scores / scoring-recalc-batch no Lovable', 'warning'
+    FROM public.farmer_client_scores fcs
+    UNION ALL
+    -- HIGH (frescor): custos de produto (compute-costs-daily → product_costs.updated_at). Custo velho =
+    -- margem/valor/decisão de dinheiro em dado velho. Daily → stale>30h.
+    SELECT 'custos_produtos'::text, 'estoque'::text,
+      CASE WHEN max(pc.updated_at) IS NULL THEN 'broken'
+           WHEN now() - max(pc.updated_at) > interval '30 hours' THEN 'stale' ELSE 'ok' END,
+      EXTRACT(EPOCH FROM now() - max(pc.updated_at))::bigint, (30*3600)::bigint, 'product_costs.updated_at'::text,
+      'Custos de produto: recalculado ' || COALESCE(to_char(max(pc.updated_at),'DD/MM HH24:MI'),'nunca'),
+      NULL, CASE WHEN max(pc.updated_at) IS NULL THEN 'compute_costs nunca rodou' ELSE NULL END,
+      'Cheque o cron compute-costs-daily (omie-analytics-sync compute_costs)'::text, 'warning'::text
+    FROM public.product_costs pc
+    UNION ALL
+    -- HIGH (frescor): sync de clientes/produtos do Omie (sync-products-customers-daily → sync_state).
+    -- Morte calada = clientes/produtos novos somem do CRM/carteira/catálogo. Daily → stale>30h. broken se
+    -- faltar entidade (uma nunca rodou), nunca sincronizou, ou última terminou em erro.
+    SELECT 'vendas_cadastros'::text, 'vendas'::text,
+      CASE WHEN ss.n_entidades < 2 OR ss.pior_last IS NULL OR ss.algum_erro THEN 'broken'
+           WHEN now() - ss.pior_last > interval '30 hours' THEN 'stale' ELSE 'ok' END,
+      EXTRACT(EPOCH FROM now() - ss.pior_last)::bigint, (30*3600)::bigint, 'sync_state.last_sync_at (customers/products)'::text,
+      'Sync de clientes/produtos (vendas): ' || COALESCE(to_char(ss.pior_last,'DD/MM HH24:MI'),'nunca'),
+      ss.erro_msg,
+      CASE WHEN ss.n_entidades < 2 OR ss.pior_last IS NULL THEN 'sync_all (customers/products) nunca completou para alguma entidade'
+           WHEN ss.algum_erro THEN 'Última sync de clientes/produtos terminou em erro' ELSE NULL END,
+      'Cheque o cron sync-products-customers-daily (omie-analytics-sync sync_all account=vendas) e a tabela sync_state'::text,
+      'critical'::text
+    FROM (
+      SELECT
+        count(*)::int AS n_entidades,
+        min(s.last_sync_at) AS pior_last,
+        bool_or(s.status = 'error') AS algum_erro,
+        (SELECT s2.error_message FROM public.sync_state s2
+          WHERE s2.account='vendas' AND s2.entity_type IN ('customers','products') AND s2.status='error'
+          ORDER BY s2.updated_at DESC LIMIT 1) AS erro_msg
+      FROM public.sync_state s
+      WHERE s.account='vendas' AND s.entity_type IN ('customers','products')
+    ) ss
+    UNION ALL
+    -- 9º check: o PRÓPRIO canal de alerta (dispatch-notifications drena fornecedor_alerta).
+    SELECT 'alert_channel'::text, 'alertas'::text,
+      CASE WHEN ac.stuck_pendentes > 0 OR ac.falhas_24h >= 5 THEN 'broken'
+           WHEN ac.falhas_24h > 0 THEN 'stale' ELSE 'ok' END,
+      ac.oldest_pendente_age_seconds, (2*3600)::bigint, 'fornecedor_alerta.pendente_notificacao'::text,
+      CASE WHEN ac.stuck_pendentes > 0
+             THEN 'Canal de alerta: ' || ac.stuck_pendentes::text || ' email(s) presos há mais de 2h — dispatch parou de drenar'
+           WHEN ac.falhas_24h >= 5
+             THEN 'Canal de alerta: ' || ac.falhas_24h::text || ' falhas de envio nas últimas 24h (falha sistêmica)'
+           WHEN ac.falhas_24h > 0
+             THEN 'Canal de alerta: ' || ac.falhas_24h::text || ' falha(s) de envio nas últimas 24h'
+           ELSE 'Canal de alerta: drenando normalmente (' || ac.pendentes_total::text || ' na fila)' END,
+      ac.ultimo_erro,
+      CASE WHEN ac.stuck_pendentes > 0 THEN 'Cron afiacao_dispatch_notificacoes_30min não rodou ou a edge dispatch-notifications falhou (token Gmail revogado?)'
+           WHEN ac.falhas_24h > 0 THEN 'Envio de email falhando (Gmail / token / destinatário)' ELSE NULL END,
+      'Cheque a edge dispatch-notifications (logs no Lovable), o refresh token do Gmail e o net._http_response do cron afiacao_dispatch_notificacoes_30min'::text,
+      'critical'::text
+    FROM (
+      SELECT
+        (count(*) FILTER (WHERE fa.status='pendente_notificacao' AND fa.criado_em < now() - interval '2 hours'))::bigint AS stuck_pendentes,
+        (count(*) FILTER (WHERE fa.status='pendente_notificacao'))::bigint AS pendentes_total,
+        (count(*) FILTER (WHERE fa.status='falha_notificacao' AND fa.criado_em > now() - interval '24 hours'))::bigint AS falhas_24h,
+        EXTRACT(EPOCH FROM now() - min(fa.criado_em) FILTER (WHERE fa.status='pendente_notificacao' AND fa.criado_em < now() - interval '2 hours'))::bigint AS oldest_pendente_age_seconds,
+        (SELECT f2.erro_notificacao FROM public.fornecedor_alerta f2
+          WHERE f2.status='falha_notificacao' AND f2.erro_notificacao IS NOT NULL
+          ORDER BY f2.criado_em DESC LIMIT 1) AS ultimo_erro
+      FROM public.fornecedor_alerta fa
+    ) ac
+  )
+  SELECT c.source, c.domain, COALESCE(NULLIF(c.status, ''), 'unknown') AS status,
+    c.age_seconds, c.expected_max_age_seconds, c.freshness_basis, c.message,
+    c.last_error, c.probable_cause, c.how_to_fix, c.severity
+  FROM checks c;
+$$;
+
+REVOKE ALL ON FUNCTION public._data_health_compute() FROM PUBLIC, anon, authenticated;
+
+-- Watchdog: os 2 novos HIGH ENTRAM no push (alerta na transição ok→degradado). Não colidem com o
+-- fin_sync_watchdog (tipos data_health_* distintos). custos_produtos='estoque'/warning→aviso/atencao;
+-- vendas_cadastros='vendas'/critical→critico/urgente. Corpo verbatim da 20260527220000; só amplio o IN.
+CREATE OR REPLACE FUNCTION public.data_health_watchdog()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  r record;
+  v_sev_fin text;
+  v_sev_forn text;
+BEGIN
+  FOR r IN
+    SELECT * FROM public._data_health_compute()
+    WHERE source IN ('vendas_pedidos','estoque_inventario','reposicao_sugestoes','carteira_scores',
+                     'custos_produtos','vendas_cadastros')
+  LOOP
+    v_sev_fin  := CASE WHEN r.severity = 'critical' THEN 'critico' ELSE 'aviso' END;
+    v_sev_forn := CASE WHEN r.severity = 'critical' THEN 'urgente' ELSE 'atencao' END;
+    IF r.status <> 'ok' THEN
+      INSERT INTO fin_alertas (company, tipo, severidade, mensagem, contexto)
+      VALUES ('oben', 'data_health_' || r.source, v_sev_fin, r.message,
+              jsonb_build_object('source', r.source, 'domain', r.domain, 'status', r.status,
+                                 'age_seconds', r.age_seconds, 'freshness_basis', r.freshness_basis))
+      ON CONFLICT (company, tipo) WHERE dismissed_at IS NULL DO NOTHING;
+      IF FOUND THEN
+        INSERT INTO fornecedor_alerta (empresa, tipo, severidade, titulo, mensagem, status)
+        VALUES ('oben', 'outro', v_sev_forn, '[Saúde de dados] ' || r.source, r.message, 'pendente_notificacao');
+      END IF;
+    ELSE
+      UPDATE fin_alertas SET dismissed_at = now()
+      WHERE company = 'oben' AND tipo = 'data_health_' || r.source AND dismissed_at IS NULL;
+    END IF;
+  END LOOP;
+END;
+$$;
+
+-- Heartbeat: inclui os 2 novos no resumo de saúde de dados. Corpo verbatim da 20260527240000; só amplio o IN.
+CREATE OR REPLACE FUNCTION public.fin_sync_heartbeat()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $$
+DECLARE
+  v_resumo text;
+  v_ativos int;
+  v_dh_ativos int;
+  v_dh_resumo text;
+BEGIN
+  SELECT count(*) INTO v_ativos
+  FROM fin_alertas WHERE tipo LIKE 'sync_%' AND dismissed_at IS NULL;
+
+  SELECT string_agg(linha, E'\n' ORDER BY linha) INTO v_resumo
+  FROM (
+    SELECT format('%s/%s: %s', co, re, COALESCE(to_char(m.mx, 'DD/MM HH24:MI'), 'NUNCA')) AS linha
+    FROM unnest(ARRAY['oben','colacor','colacor_sc']) AS co
+    CROSS JOIN unnest(ARRAY['contas_pagar','contas_receber','movimentacoes']) AS re
+    CROSS JOIN LATERAL (
+      SELECT max(l.completed_at) AS mx FROM fin_sync_log l
+      WHERE l.status='complete' AND l.action='sync_'||re AND co = ANY(l.companies)
+    ) m
+  ) s;
+
+  SELECT count(*) INTO v_dh_ativos
+  FROM fin_alertas WHERE tipo LIKE 'data_health_%' AND dismissed_at IS NULL;
+
+  SELECT string_agg(format('%s: %s', source, status), E'\n' ORDER BY source) INTO v_dh_resumo
+  FROM public._data_health_compute()
+  WHERE source IN ('vendas_pedidos','estoque_inventario','reposicao_sugestoes','carteira_scores',
+                   'custos_produtos','vendas_cadastros','alert_channel');
+
+  INSERT INTO fornecedor_alerta (empresa, tipo, severidade, titulo, mensagem, status)
+  VALUES ('oben', 'outro', 'info',
+          '[Watchdog OK] '||to_char(now(),'DD/MM'),
+          'Watchdog do sync rodou. Alertas de sync ativos: '||v_ativos||
+          E'.\n\nÚltimo sync OK por empresa/recurso:\n'||COALESCE(v_resumo,'(sem dados)')||
+          E'\n\nSaúde de dados — alertas ativos: '||v_dh_ativos||
+          E'.\nChecks (vendas/cadastros/estoque/custos/reposição/carteira/canal):\n'||COALESCE(v_dh_resumo,'(sem dados)'),
+          'pendente_notificacao');
+END;
+$$;


### PR DESCRIPTION
## Resumo

Triagem dos 45 crons (eu + codex, 4º consult): dos ~28 não-cobertos pelo Sentinela, **só 4 são HIGH** (dano de negócio real + ninguém notaria rápido). **Não cobrir por simetria.** Esta PR entra com os **2 HIGH de FRESCOR DE DADO** (limpos, verificados no código, sem precisar calibrar threshold com prod):

- **`custos_produtos`** (domínio `estoque`, warning) — `product_costs.updated_at` (compute-costs seta `updated_at` no upsert → avança a cada run). Daily → `stale>30h`. Custo velho alimenta margem/valor/financeiro = decisão de dinheiro em dado velho.
- **`vendas_cadastros`** (domínio `vendas`, critical) — `sync_state` (entity_type `customers`/`products`, account `vendas`, via `last_sync_at`+`status`+`error_message`; mesmo padrão do `omie_sync_financeiro`/`fin_sync_log`). Daily → `stale>30h`. Morte calada = clientes/produtos novos somem do CRM/carteira/catálogo.

Ambos **entram no push do watchdog** (tipos `data_health_*` distintos → sem colisão com `fin_sync_watchdog`) + no heartbeat. Domínios reusados → **SQL-only, sem frontend**.

## Deferidos (backlog — precisam calibrar threshold com dado de prod)

Os **2 HIGH de AÇÃO** são "monitorar fila de trabalho envelhecendo" e exigem semântica de fila + calibração (qual idade de "aprovado parado" é anormal?) — construir sem calibrar = falso-alarme:
- `disparar-pedidos-aprovados` (pedido de compra aprovado não despachado ao fornecedor)
- `sayerlack-portal-watchdog` (fila de pedidos pendentes no portal Sayerlack)
- `process-recurring-orders` — investigar se cria pedido/receita automático (→ vira HIGH) ou só prep (→ MEDIUM).

MEDIUM (~8) e LOW (~16) ficam no backlog, sem check (cobertura por simetria gera ruído).

## ⚠️ ATENÇÃO: migration manual (SQL Editor do Lovable) — 1 bloco

`20260527250000_data_health_checks_high.sql`: `_data_health_compute()` (11 checks) + `data_health_watchdog()` (push dos 2 novos) + `fin_sync_heartbeat()` (resumo).

## Test plan
- [x] SQL-only (sem mudança de TS; domínios `vendas`/`estoque` reusados)
- [ ] Aplicar o bloco no SQL Editor + validar (11 checks; `custos_produtos`/`vendas_cadastros` = ok)

🤖 Generated with [Claude Code](https://claude.com/claude-code)