### PR TITLE
fix(fin): callOmie faz retry em fault transitório do Omie (SOAP broken response)

### DIFF
--- a/src/lib/omie/__tests__/omie-fault.test.ts
+++ b/src/lib/omie/__tests__/omie-fault.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { classifyOmieFault } from '../omie-fault';
+
+describe('classifyOmieFault', () => {
+  it('classifica a causa-raiz observada (SOAP broken response) como transient', () => {
+    // String exata vista em fin_sync_log nas linhas error de 27-28/05.
+    expect(
+      classifyOmieFault('SOAP-ERROR: Broken response from Application Server (BG)'),
+    ).toBe('transient');
+  });
+
+  it('classifica outras falhas de infra do servidor como transient', () => {
+    expect(classifyOmieFault('ERROR_INTERNAL: algo deu errado')).toBe('transient');
+    expect(classifyOmieFault('500 Internal Server Error')).toBe('transient');
+    expect(classifyOmieFault('503 Service Unavailable')).toBe('transient');
+    expect(classifyOmieFault('Service Temporarily Unavailable')).toBe('transient');
+  });
+
+  it('classifica rate-limit do Omie como rate_limit (não transient)', () => {
+    expect(
+      classifyOmieFault('Já existe uma requisição desse método. Aguarde 1 segundos.'),
+    ).toBe('rate_limit');
+    expect(classifyOmieFault('Consumo redundante detectado')).toBe('rate_limit');
+    expect(classifyOmieFault('consumo redundante')).toBe('rate_limit');
+    expect(classifyOmieFault('ERROR: REDUNDANT call')).toBe('rate_limit');
+  });
+
+  it('classifica erro de contrato/negócio como fatal (retry não ajuda)', () => {
+    expect(classifyOmieFault('Parâmetro [nPagina] inválido')).toBe('fatal');
+    expect(classifyOmieFault('Cliente não cadastrado')).toBe('fatal');
+    expect(classifyOmieFault('App Key inválida')).toBe('fatal');
+  });
+
+  it('NÃO trata SOAP-ERROR genérico (sem sinal de servidor) como transient', () => {
+    // SOAP fault também cobre erro de contrato/cliente → fatal sem sinal de infra.
+    expect(classifyOmieFault('SOAP-ERROR: Encoding: string is not UTF-8')).toBe('fatal');
+    expect(classifyOmieFault('SOAP-ENV:Client validation failed')).toBe('fatal');
+  });
+
+  it('é tolerante a entrada vazia/nula → fatal (não retry à toa)', () => {
+    expect(classifyOmieFault('')).toBe('fatal');
+    expect(classifyOmieFault(null)).toBe('fatal');
+    expect(classifyOmieFault(undefined)).toBe('fatal');
+  });
+
+  it('rate-limit tem precedência sobre transient quando ambos aparecem', () => {
+    // Defesa: se uma string contiver os dois sinais, rate_limit ganha (a espera
+    // pedida pelo Omie é a política correta).
+    expect(
+      classifyOmieFault('Consumo redundante - SOAP-ERROR interno'),
+    ).toBe('rate_limit');
+  });
+});

--- a/src/lib/omie/omie-fault.ts
+++ b/src/lib/omie/omie-fault.ts
@@ -1,0 +1,49 @@
+// Classificação de faults da API do Omie pra decidir política de retry no callOmie.
+//
+// ⚠️ ESPELHADO VERBATIM em supabase/functions/omie-financeiro/index.ts (callOmie).
+// Qualquer mudança aqui deve refletir lá e vice-versa.
+//
+// Causa-raiz (28/05/2026): o Omie retorna intermitentemente o fault
+// "SOAP-ERROR: Broken response from Application Server (BG)" — falha transitória
+// do servidor SOAP. O callOmie só fazia retry em rate-limit e LANÇAVA todo o
+// resto na 1ª tentativa, abortando a passada inteira de movimentações e
+// disparando alerta urgente do watchdog. Esta classificação distingue:
+//   - rate_limit: o Omie pede pra aguardar (requisição em voo / consumo redundante)
+//   - transient: falha de infra do Omie (reabsorvível com retry + backoff)
+//   - fatal: erro de contrato (parâmetro inválido, sem acesso) — retry não ajuda
+
+export type OmieFaultClass = 'rate_limit' | 'transient' | 'fatal';
+
+export function classifyOmieFault(faultstring: string | null | undefined): OmieFaultClass {
+  const fs = faultstring ?? '';
+
+  // Rate-limit: o Omie pede explicitamente pra aguardar e tentar de novo.
+  if (
+    fs.includes('Já existe uma requisição desse método') ||
+    fs.includes('Consumo redundante') ||
+    fs.includes('consumo redundante') ||
+    fs.includes('REDUNDANT')
+  ) {
+    return 'rate_limit';
+  }
+
+  // Transitório: falha de INFRAESTRUTURA do servidor do Omie (reabsorvível).
+  // "SOAP-ERROR: Broken response from Application Server (BG)" foi a causa-raiz
+  // observada — casa aqui por "Broken response"/"Application Server".
+  // Conservador de propósito: NÃO incluímos o "SOAP-ERROR" genérico, porque um
+  // SOAP fault também cobre erro de CONTRATO (ex: SOAP-ENV:Client, validação),
+  // que retry nunca resolve. Só sinais inequívocos de instabilidade de servidor.
+  if (
+    fs.includes('Broken response') ||
+    fs.includes('Application Server') ||
+    fs.includes('ERROR_INTERNAL') ||
+    fs.includes('Internal Server Error') ||
+    fs.includes('Service Unavailable') ||
+    fs.includes('Service Temporarily Unavailable')
+  ) {
+    return 'transient';
+  }
+
+  // Tudo mais (parâmetro inválido, sem permissão, etc.) → fatal: retry não ajuda.
+  return 'fatal';
+}

--- a/supabase/functions/omie-financeiro/index.ts
+++ b/supabase/functions/omie-financeiro/index.ts
@@ -379,6 +379,49 @@ function getCredentials(company: Company) {
   }
 }
 
+// ── Classificação de faults do Omie (decide política de retry) ──────────────
+// ⚠️ ESPELHADO VERBATIM de src/lib/omie/omie-fault.ts (testado em vitest).
+// Qualquer mudança aqui deve refletir lá e vice-versa.
+type OmieFaultClass = 'rate_limit' | 'transient' | 'fatal';
+
+function classifyOmieFault(faultstring: string | null | undefined): OmieFaultClass {
+  const fs = faultstring ?? '';
+
+  if (
+    fs.includes('Já existe uma requisição desse método') ||
+    fs.includes('Consumo redundante') ||
+    fs.includes('consumo redundante') ||
+    fs.includes('REDUNDANT')
+  ) {
+    return 'rate_limit';
+  }
+
+  // Transitório: instabilidade de infra do servidor do Omie. NÃO inclui o
+  // "SOAP-ERROR" genérico (SOAP fault também cobre erro de contrato/cliente).
+  if (
+    fs.includes('Broken response') ||
+    fs.includes('Application Server') ||
+    fs.includes('ERROR_INTERNAL') ||
+    fs.includes('Internal Server Error') ||
+    fs.includes('Service Unavailable') ||
+    fs.includes('Service Temporarily Unavailable')
+  ) {
+    return 'transient';
+  }
+
+  return 'fatal';
+}
+
+// Backoff curto com jitter pra faults transitórios (1s, 2s, 4s + jitter, cap 4s).
+// Curto de propósito: o budget de invocação é 100s; o cursor de continuação */10
+// retoma o que faltar. Jitter evita sincronizar as 3 empresas e piorar rate-limit.
+async function transientBackoff(attempt: number, company: string, reason: string): Promise<void> {
+  const base = Math.min(1000 * 2 ** attempt, 4000);
+  const delay = base + Math.floor(Math.random() * 500);
+  console.log(`[Fin][${company}] Omie transitório, retry em ${(delay / 1000).toFixed(1)}s: ${reason}`);
+  await new Promise((r) => setTimeout(r, delay));
+}
+
 async function callOmie(
   company: Company,
   endpoint: string,
@@ -398,28 +441,65 @@ async function callOmie(
 
   const maxRetries = 3;
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
-    const res = await fetch(`${OMIE_API_URL}/${endpoint}`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(body),
-    });
+    // 1) fetch — erro de REDE (DNS/conexão/timeout) é transitório.
+    let res: Response;
+    try {
+      res = await fetch(`${OMIE_API_URL}/${endpoint}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+    } catch (netErr) {
+      if (attempt < maxRetries && !isTimeBudgetExhausted()) {
+        await transientBackoff(attempt, company, `rede: ${String(netErr).slice(0, 50)}`);
+        continue;
+      }
+      throw netErr instanceof Error ? netErr : new Error(`Omie (${company}): ${String(netErr)}`);
+    }
     apiCallCount++;
-    const result = (await res.json()) as OmieGenericResponse;
 
+    // 2) HTTP status ANTES de parsear: 429 = rate-limit, 5xx = transitório, demais 4xx = fatal.
+    if (!res.ok) {
+      if (res.status === 429 && attempt < maxRetries && !isTimeBudgetExhausted()) {
+        rateLimitHits++;
+        console.log(`[Fin][${company}] HTTP 429, waiting 5s`);
+        await new Promise((r) => setTimeout(r, 5000));
+        continue;
+      }
+      if (res.status >= 500 && attempt < maxRetries && !isTimeBudgetExhausted()) {
+        await transientBackoff(attempt, company, `HTTP ${res.status}`);
+        continue;
+      }
+      throw new Error(`Omie (${company}): HTTP ${res.status}`);
+    }
+
+    // 3) parse — corpo 200 não-JSON / quebrado é transitório.
+    let result: OmieGenericResponse;
+    try {
+      result = (await res.json()) as OmieGenericResponse;
+    } catch (parseErr) {
+      if (attempt < maxRetries && !isTimeBudgetExhausted()) {
+        await transientBackoff(attempt, company, `corpo não-JSON`);
+        continue;
+      }
+      throw new Error(`Omie (${company}): resposta não-JSON (${String(parseErr).slice(0, 50)})`);
+    }
+
+    // 4) faultstring — classifica e aplica política por classe.
     if (result.faultstring) {
       const fs = String(result.faultstring);
-      const isRateLimit =
-        fs.includes("Já existe uma requisição desse método") ||
-        fs.includes("Consumo redundante") ||
-        fs.includes("REDUNDANT") ||
-        fs.includes("consumo redundante");
-      if (isRateLimit && attempt < maxRetries) {
+      const klass = classifyOmieFault(fs);
+      if (klass === "rate_limit" && attempt < maxRetries) {
         rateLimitHits++;
         const waitMatch = fs.match(/Aguarde (\d+) segundos/);
         const requestedDelay = waitMatch ? parseInt(waitMatch[1]) : (attempt + 1) * 5;
         const delay = Math.min(requestedDelay + 2, 15) * 1000;
         console.log(`[Fin][${company}] Rate limit, waiting ${delay / 1000}s`);
         await new Promise((r) => setTimeout(r, delay));
+        continue;
+      }
+      if (klass === "transient" && attempt < maxRetries && !isTimeBudgetExhausted()) {
+        await transientBackoff(attempt, company, fs.slice(0, 70));
         continue;
       }
       throw new Error(`Omie (${company}): ${fs}`);


### PR DESCRIPTION
## Causa-raiz (confirmada com evidência de prod)

O watchdog disparou 2 alertas **urgentes** (`[Sync erro]` colacor + oben) pra `sync_movimentacoes`. Diagnóstico via `fin_sync_log`:

- ~12 linhas `error` ao longo do dia 27/05, **todas** = `Error: Omie (colacor): SOAP-ERROR: Broken response from Application Server (BG)`, `rl=0`, intermitentes (a passada seguinte do mesmo cursor completa normal).
- Completes a ~100s confirmam o budget do #338; **zero** `orphaned_running_timeout` → **não** é kill por tempo.
- `backfill_desde=<coluna ausente>` → migration do #407 não aplicada → **não** é o backfill.

A API do Omie devolve intermitentemente o fault `SOAP-ERROR: Broken response from Application Server (BG)` (falha de infra do servidor SOAP deles). O `callOmie` só fazia retry em **rate-limit** e **lançava** qualquer outro fault na 1ª tentativa → uma página com resposta quebrada abortava a passada inteira (com progresso parcial) → o catch gravava `status='error'` → watchdog alertava.

## Fix

`classifyOmieFault()` classifica o fault em `rate_limit | transient | fatal`; o `callOmie` aplica política por classe com retry + backoff:

- **transient** (faultstring de infra, HTTP 5xx, erro de rede, corpo 200 não-JSON): backoff curto com jitter (1/2/4s, cap 4s) + **guard de time-budget** (não queima os 100s; a continuação `*/10` retoma o resto pelo cursor).
- **rate_limit** (faultstring + HTTP 429): espera pedida pelo Omie, **preservada**.
- **fatal** (contrato/negócio): lança na hora — retry não ajudaria.

Conservador: o `SOAP-ERROR` genérico **não** vira transient (SOAP fault também cobre erro de contrato); o fault observado casa por `Broken response`/`Application Server`. Esgotado o retry, ainda lança → **outage real do Omie continua alertando** (correto). Não mexi no watchdog — a resposta é não gerar o erro, não escondê-lo.

Classificação revisada com **codex** (estreitou o transient, separou política por classe, HTTP-status antes de parsear, jitter). Helper puro `src/lib/omie/omie-fault.ts` testado (vitest, 7 casos) **espelhado verbatim** no edge.

## Validação

- typecheck:strict ✓ · lint 0 errors ✓ · 1633/1633 testes ✓ · build ✓
- `deno check` do edge com **erro-set idêntico à main** (10 pré-existentes no bloco `debug_raw`, não tocado)

## ⚠️ ATENÇÃO: redeploy manual necessário

Sem migration. **Requer redeploy do edge `omie-financeiro` no chat do Lovable** (ler o arquivo do repo e deployar verbatim). Sem isso, main e produção divergem e o alerta continua.

🤖 Generated with [Claude Code](https://claude.com/claude-code)