### PR TITLE
fix(build): corrige TDZ que travava o boot (chunks circulares no manualChunks)

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -165,12 +165,15 @@ export default defineConfig(({ mode }) => ({
   build: {
     rollupOptions: {
       output: {
-        // Function-form pra agrupar lazy pages por módulo + manter vendors split.
-        // Antes: 119 chunks separados (1 por lazy page) → TTFB extra por navegação.
-        // Agora: peers de um mesmo módulo no mesmo chunk (ex: 22 pages de Reposição = 1 chunk).
-        // Vendors continuam separados (cacheable, raramente mudam).
+        // Só agrupa VENDORS (node_modules) em buckets cacheáveis. NÃO agrupar
+        // páginas por feature: o agrupamento anterior (feature-admin/financeiro/...)
+        // criava chunks com dependência circular (páginas se importam entre si),
+        // e o Rollup avisava "Circular chunk: feature-admin -> feature-financeiro".
+        // Em produção isso virava um TDZ em runtime ("Cannot access 'X' before
+        // initialization") que crashava o boot ANTES do React montar → tela
+        // travada. Deixar o Rollup auto-splitar as páginas (1 chunk por rota lazy)
+        // é circular-safe e era o comportamento que funcionava.
         manualChunks(id) {
-          // ─── Vendors ──────────────────────────────────────────────────
           if (id.includes('node_modules')) {
             if (/[\\/](react|react-dom|react-router-dom|scheduler)[\\/]/.test(id)) return 'vendor-react';
             if (id.includes('@tanstack/react-query')) return 'vendor-query';
@@ -182,31 +185,7 @@ export default defineConfig(({ mode }) => ({
             if (id.includes('date-fns')) return 'vendor-dates';
             return; // resto: deixar Rollup decidir
           }
-
-          // ─── Feature chunks (agrupa lazy pages do mesmo módulo) ──────
-          // ORDEM IMPORTA: AdminReposicao deve vir ANTES de Admin (catchall)
-          if (id.includes('/src/pages/')) {
-            if (id.includes('/AdminReposicao')) return 'feature-reposicao';
-            if (id.includes('/Farmer')) return 'feature-farmer';
-            if (id.includes('/Financeiro')) return 'feature-financeiro';
-            if (id.includes('/Tint') || id.includes('/AdminTint')) return 'feature-tintometrico';
-            if (id.includes('/Governance')) return 'feature-governance';
-            if (id.includes('/Sales')) return 'feature-sales';
-            if (id.includes('/Recebimento')) return 'feature-estoque';
-            if (id.includes('/picking/')) return 'feature-estoque';
-            // Docs internos: baixo uso, cabe num bundle único
-            if (
-              id.includes('/DesignSystem') ||
-              id.includes('/DesignPreview') ||
-              id.includes('/UXRules') ||
-              id.includes('/TechnicalDocs') ||
-              id.includes('/TintApiContract')
-            ) return 'feature-docs';
-            // Admin (catchall depois de AdminReposicao + AdminTint)
-            if (id.includes('/Admin')) return 'feature-admin';
-            // Restantes (~15 pages cliente: Orders, Tools, Profile, etc.) ficam
-            // no chunk principal pra navegação inicial rápida do customer
-          }
+          // App code: sem agrupamento manual → Rollup decide (circular-safe).
         },
       },
     },


### PR DESCRIPTION
## Causa-raiz (produção-down)

A tela travava no domínio publicado por `Uncaught ReferenceError: Cannot access 'X' before initialization` em `feature-financeiro-*.js` — um **TDZ (temporal dead zone) por dependência circular entre chunks**. O `manualChunks` agrupava páginas lazy por feature (`feature-admin`, `feature-financeiro`, ...); como essas páginas se importam entre si, o Rollup criava chunks com ciclo (avisava `Circular chunk: feature-admin -> feature-financeiro -> feature-admin`, 9 avisos no total). Em runtime, um chunk acessava um `const` de outro ainda não inicializado → crash **antes do React montar** → tela escura, sem login.

Era a **causa-raiz real** do "fica carregando e não abre o login" — não o service worker (essa era uma hipótese; o console de produção do founder mostrou o TDZ). Confirmado: o hard refresh não resolvia (bundle deterministicamente quebrado) e o watchdog do #412 limpava SW+cache e ainda falhava (servidor entrega app que crasha sozinho).

## Fix

Remove o agrupamento de páginas por feature no `manualChunks` ([vite.config.ts](vite.config.ts)). Mantém só o split de **vendors** (node_modules, que é um DAG circular-safe) e deixa o Rollup auto-splitar as páginas (1 chunk por rota lazy) — o comportamento estável que existia antes da otimização de chunks. Build passa de **9 → 0** avisos de chunk circular.

## Verificação (Chrome real, `bun preview` do build de produção)

- [x] Build OK, **0 chunks circulares** (eram 9)
- [x] `/` → redireciona pra `/auth`, **tela de login renderiza** (heading Colacor, campos E-mail/Senha, botão Entrar)
- [x] Console **sem o TDZ** `Cannot access ... before initialization`
- [x] baseline typecheck 0 · strict typecheck 0 · lint 0 erros
- [x] (bônus) o failsafe de auth do #412 disparou no preview e degradou pro login graciosamente — prova de que a rede de segurança funciona em browser real

## Relação com o #412

O #412 (watchdog + failsafe de boot) **degrada o sintoma** (mostra mensagem/recarrega em vez de spinner eterno). Este PR **remove a causa**. Os dois são complementares: mesmo com a causa corrigida, o watchdog segue protegendo contra futuras falhas de boot/deploy.

## ⚠️ Publicar no Lovable

Após mergear, **publicar pelo Lovable** pra valer em produção (build novo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)