### PR TITLE
fix(fin): paginação data-driven CR/CP — sync truncava listas grandes (colacor 12.8k→~29k)

### DIFF
--- a/supabase/functions/omie-financeiro/index.ts
+++ b/supabase/functions/omie-financeiro/index.ts
@@ -570,24 +570,21 @@ async function syncContasPagar(
   maxPages = 500,
   startPage = 1
 ) {
+  // Ver nota em syncContasReceber: 100 = limite real do Omie; paginação data-driven
+  // (pára em página parcial/vazia), não confia no total_de_paginas sub-reportado.
+  const PAGE_SIZE = 100;
   let pagina = startPage;
   let totalPaginas = 1;
   let totalSynced = 0;
   let pagesProcessed = 0;
-  let consecutiveEmpty = 0;
+  let reachedEnd = false;
 
-  while (pagina <= totalPaginas && pagesProcessed < maxPages && !isTimeBudgetExhausted()) {
-    const params: Record<string, unknown> = {
-      pagina,
-      registros_por_pagina: 500,
-    };
-    // Omie lcpListarRequest não aceita filtros de data
-
+  while (pagesProcessed < maxPages && !isTimeBudgetExhausted()) {
     const result = await callOmie(
       company,
       "financas/contapagar/",
       "ListarContasPagar",
-      params
+      { pagina, registros_por_pagina: PAGE_SIZE }
     );
     if (!result) break;
 
@@ -596,6 +593,7 @@ async function syncContasPagar(
       (result.conta_pagar_cadastro as OmieContaPagar[] | undefined)
       || (result.titulosEncontrados as OmieContaPagar[] | undefined)
       || [];
+    if (titulos.length === 0) { reachedEnd = true; break; } // página vazia = fim real
 
     const rows = titulos.map((t) => {
       const statusMap: Record<string, string> = {
@@ -676,19 +674,19 @@ async function syncContasPagar(
       else totalSynced += validRows.length;
     }
 
-    if (validRows.length === 0) { consecutiveEmpty++; } else { consecutiveEmpty = 0; }
     console.log(`[Fin][${company}] CP p${pagina}/${totalPaginas} (+${validRows.length})`);
-    if (consecutiveEmpty >= 10) { console.log(`[Fin][${company}] CP early exit: 10 empty pages`); break; }
     pagina++;
     pagesProcessed++;
+    // Fim real = página parcial (< PAGE_SIZE). Data-driven, não confia só em total_de_paginas.
+    if (titulos.length < PAGE_SIZE) { reachedEnd = true; break; }
   }
 
   const timedOut = isTimeBudgetExhausted();
   if (timedOut) console.log(`[Fin][${company}] CP stopped: time budget exhausted`);
   return {
     totalSynced,
-    complete: pagina > totalPaginas,
-    nextPage: pagina > totalPaginas ? null : pagina,
+    complete: reachedEnd,
+    nextPage: reachedEnd ? null : pagina,
     timedOut,
   };
 }
@@ -702,24 +700,23 @@ async function syncContasReceber(
   maxPages = 500,
   startPage = 1
 ) {
+  // 100 = limite real do Omie p/ contareceber. O 500 antigo era IGNORADO pelo Omie
+  // (retornava 100/pág) mas o total_de_paginas vinha sub-reportado p/ listas grandes →
+  // a paginação parava cedo e perdia os títulos recentes (colacor: ~29k no Omie, só
+  // ~12.8k sincronizados, faltando 3,5 anos de recebíveis). Paginação agora é data-driven.
+  const PAGE_SIZE = 100;
   let pagina = startPage;
   let totalPaginas = 1;
   let totalSynced = 0;
   let pagesProcessed = 0;
-  let consecutiveEmpty = 0;
+  let reachedEnd = false;
 
-  while (pagina <= totalPaginas && pagesProcessed < maxPages && !isTimeBudgetExhausted()) {
-    const params: Record<string, unknown> = {
-      pagina,
-      registros_por_pagina: 500,
-    };
-    // Omie lcrListarRequest não aceita filtros de data
-
+  while (pagesProcessed < maxPages && !isTimeBudgetExhausted()) {
     const result = await callOmie(
       company,
       "financas/contareceber/",
       "ListarContasReceber",
-      params
+      { pagina, registros_por_pagina: PAGE_SIZE }
     );
     if (!result) break;
 
@@ -728,6 +725,7 @@ async function syncContasReceber(
       (result.conta_receber_cadastro as OmieContaReceber[] | undefined)
       || (result.titulosEncontrados as OmieContaReceber[] | undefined)
       || [];
+    if (titulos.length === 0) { reachedEnd = true; break; } // página vazia = fim real
 
     const rows = titulos.map((t) => {
       let status = t.status_titulo || "ABERTO";
@@ -796,19 +794,21 @@ async function syncContasReceber(
       else totalSynced += validRows.length;
     }
 
-    if (validRows.length === 0) { consecutiveEmpty++; } else { consecutiveEmpty = 0; }
     console.log(`[Fin][${company}] CR p${pagina}/${totalPaginas} (+${validRows.length})`);
-    if (consecutiveEmpty >= 10) { console.log(`[Fin][${company}] CR early exit: 10 empty pages`); break; }
     pagina++;
     pagesProcessed++;
+    // Fim real = página parcial (o Omie só devolve < PAGE_SIZE na última página).
+    // Data-driven de propósito: NÃO confia só em total_de_paginas, que o Omie
+    // sub-reporta em listas grandes (era a causa do truncamento do CR do colacor).
+    if (titulos.length < PAGE_SIZE) { reachedEnd = true; break; }
   }
 
   const timedOut = isTimeBudgetExhausted();
   if (timedOut) console.log(`[Fin][${company}] CR stopped: time budget exhausted`);
   return {
     totalSynced,
-    complete: pagina > totalPaginas,
-    nextPage: pagina > totalPaginas ? null : pagina,
+    complete: reachedEnd,
+    nextPage: reachedEnd ? null : pagina,
     timedOut,
   };
 }

--- a/supabase/functions/omie-financeiro/index.ts
+++ b/supabase/functions/omie-financeiro/index.ts
@@ -570,14 +570,15 @@ async function syncContasPagar(
   maxPages = 500,
   startPage = 1
 ) {
-  // Ver nota em syncContasReceber: 100 = limite real do Omie; paginação data-driven
-  // (pára em página parcial/vazia), não confia no total_de_paginas sub-reportado.
+  // Ver nota em syncContasReceber: 100 = limite real do Omie; paginação data-driven —
+  // pagina até a página VAZIA (fim real), não confia no total_de_paginas sub-reportado.
   const PAGE_SIZE = 100;
   let pagina = startPage;
   let totalPaginas = 1;
   let totalSynced = 0;
   let pagesProcessed = 0;
   let reachedEnd = false;
+  let lastFingerprint = "";
 
   while (pagesProcessed < maxPages && !isTimeBudgetExhausted()) {
     const result = await callOmie(
@@ -588,12 +589,15 @@ async function syncContasPagar(
     );
     if (!result) break;
 
-    totalPaginas = (result.total_de_paginas as number) || 1;
+    totalPaginas = (result.total_de_paginas as number) || 1; // só p/ log/sanity
     const titulos: OmieContaPagar[] =
       (result.conta_pagar_cadastro as OmieContaPagar[] | undefined)
       || (result.titulosEncontrados as OmieContaPagar[] | undefined)
       || [];
     if (titulos.length === 0) { reachedEnd = true; break; } // página vazia = fim real
+    const fp = `${(titulos[0] as { codigo_lancamento_omie?: number })?.codigo_lancamento_omie ?? ""}:${titulos.length}`;
+    if (fp === lastFingerprint) { console.error(`[Fin][${company}] CP p${pagina}: página repetida (anomalia Omie) — parando`); reachedEnd = true; break; }
+    lastFingerprint = fp;
 
     const rows = titulos.map((t) => {
       const statusMap: Record<string, string> = {
@@ -677,8 +681,6 @@ async function syncContasPagar(
     console.log(`[Fin][${company}] CP p${pagina}/${totalPaginas} (+${validRows.length})`);
     pagina++;
     pagesProcessed++;
-    // Fim real = página parcial (< PAGE_SIZE). Data-driven, não confia só em total_de_paginas.
-    if (titulos.length < PAGE_SIZE) { reachedEnd = true; break; }
   }
 
   const timedOut = isTimeBudgetExhausted();
@@ -703,13 +705,15 @@ async function syncContasReceber(
   // 100 = limite real do Omie p/ contareceber. O 500 antigo era IGNORADO pelo Omie
   // (retornava 100/pág) mas o total_de_paginas vinha sub-reportado p/ listas grandes →
   // a paginação parava cedo e perdia os títulos recentes (colacor: ~29k no Omie, só
-  // ~12.8k sincronizados, faltando 3,5 anos de recebíveis). Paginação agora é data-driven.
+  // ~12.8k sincronizados, faltando 3,5 anos de recebíveis). Paginação agora é data-driven:
+  // pagina até a página VAZIA (fim real). Página parcial no meio NÃO trunca.
   const PAGE_SIZE = 100;
   let pagina = startPage;
   let totalPaginas = 1;
   let totalSynced = 0;
   let pagesProcessed = 0;
   let reachedEnd = false;
+  let lastFingerprint = "";
 
   while (pagesProcessed < maxPages && !isTimeBudgetExhausted()) {
     const result = await callOmie(
@@ -720,12 +724,18 @@ async function syncContasReceber(
     );
     if (!result) break;
 
-    totalPaginas = (result.total_de_paginas as number) || 1;
+    totalPaginas = (result.total_de_paginas as number) || 1; // só p/ log/sanity
     const titulos: OmieContaReceber[] =
       (result.conta_receber_cadastro as OmieContaReceber[] | undefined)
       || (result.titulosEncontrados as OmieContaReceber[] | undefined)
       || [];
     if (titulos.length === 0) { reachedEnd = true; break; } // página vazia = fim real
+    // Guard anti-loop: se o Omie repetir a mesma página (em vez de vazia além do fim),
+    // pararíamos só no maxPages e o cursor resumiria pra sempre. Fingerprint = 1º código
+    // + count; página repetida = fim (anômalo, logado).
+    const fp = `${(titulos[0] as { codigo_lancamento_omie?: number })?.codigo_lancamento_omie ?? ""}:${titulos.length}`;
+    if (fp === lastFingerprint) { console.error(`[Fin][${company}] CR p${pagina}: página repetida (anomalia Omie) — parando`); reachedEnd = true; break; }
+    lastFingerprint = fp;
 
     const rows = titulos.map((t) => {
       let status = t.status_titulo || "ABERTO";
@@ -797,10 +807,6 @@ async function syncContasReceber(
     console.log(`[Fin][${company}] CR p${pagina}/${totalPaginas} (+${validRows.length})`);
     pagina++;
     pagesProcessed++;
-    // Fim real = página parcial (o Omie só devolve < PAGE_SIZE na última página).
-    // Data-driven de propósito: NÃO confia só em total_de_paginas, que o Omie
-    // sub-reporta em listas grandes (era a causa do truncamento do CR do colacor).
-    if (titulos.length < PAGE_SIZE) { reachedEnd = true; break; }
   }
 
   const timedOut = isTimeBudgetExhausted();


### PR DESCRIPTION
## ⚠️ Sem migration. Requer redeploy do `omie-financeiro` + re-sync do colacor (passos na conversa).

## Causa-raiz (auditoria "Max")

O `fin_contas_receber` do colacor estava **congelado em set/2022** — `debug_raw` provou que o Omie tem **~29.212 recebíveis** do colacor (até hoje) mas só **~12.800** (os mais antigos, ≤2022) eram sincronizados. **Faltavam ~16.400 recebíveis recentes (2023-2026)** → receita/aging/caixa do colacor 3,5 anos defasados. CP estava OK (lista menor). A baixa ausente foi o sintoma que levou até aqui.

O `syncContasReceber`/`syncContasPagar` confiava no `total_de_paginas` do Omie (sub-reportado p/ listas grandes) + `registros_por_pagina: 500` (ignorado pelo Omie, devolve 100/pág) + early-exit por `validRows`-vazio. Resultado: parava cedo e marcava "completo".

## Fix (validado em codex challenge, 2 rodadas)

`syncContasReceber` **e** `syncContasPagar`:
- `PAGE_SIZE = 100` (limite real do Omie → `total_de_paginas` deixa de mentir).
- **Paginação data-driven**: pagina até a **página vazia** (fim real). Página parcial no meio NÃO trunca (era o falso-fim — codex #3).
- **Guard anti-loop**: fingerprint (1º código + count) detecta página repetida (se o Omie repetir além do fim em vez de devolver vazia) → para + loga anomalia (codex #1).
- Removido o early-exit por `validRows` (página de código-nulo não é fim).
- `total_de_paginas` mantido só p/ log. Cursor preserva resume por time-budget (`complete:false` → `nextPage` persistido).

## Test plan
- [x] `deno check` — 0 erro novo (10 pré-existentes no debug_raw/logging, idênticos ao main)
- [x] codex challenge — 2 guards aplicados (#1 repeat, #3 partial); #2/#4 já cobertos
- [ ] **Pós-merge (operação assistida):** redeploy → reset cursor colacor CR+CP → re-sync → validar colacor CR salta p/ ~29k com títulos 2023-2026. Monitorar CP (count/datas) — codex #5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)