### PR TITLE
chore(strict): promove 14 .tsx de lanes frias (671→685)

### DIFF
--- a/src/components/reposicao/alertas/AlertaDrillSheet.tsx
+++ b/src/components/reposicao/alertas/AlertaDrillSheet.tsx
@@ -121,7 +121,7 @@ export function AlertaDrillSheet({
                       <>
                         <div>σ atual: <span className="font-mono">{fmt(impacto.sigma_atual)}</span> → sem outlier: <span className="font-mono">{fmt(impacto.sigma_sem)}</span></div>
                         <div>Média atual: <span className="font-mono">{fmt(impacto.media_atual)}</span> → sem: <span className="font-mono">{fmt(impacto.media_sem)}</span></div>
-                        {impacto.em_atual !== undefined && (
+                        {impacto.em_atual !== undefined && impacto.delta_em !== undefined && (
                           <div className="pt-2 p-2 bg-muted/50 rounded">
                             Estoque mínimo sugerido: <span className="font-mono">{impacto.em_atual}</span> → <span className="font-mono">{impacto.em_sem}</span>{" "}
                             <Badge variant={impacto.delta_em < 0 ? "success" : "warning"}>

--- a/tsconfig.strict.json
+++ b/tsconfig.strict.json
@@ -689,6 +689,20 @@
     "src/pages/FarmerRecommendations.tsx",
     "src/pages/UXRules.tsx",
     "src/components/standard-process/StandardProcessForm.tsx",
-    "src/pages/AdminStandardProcessNew.tsx"
+    "src/pages/AdminStandardProcessNew.tsx",
+    "src/components/aiOps/DecisionList.tsx",
+    "src/components/customer/CustomerProcessTab.tsx",
+    "src/components/customerDashboard/PedidosAndamento.tsx",
+    "src/components/des/simulador/SimulationResult.tsx",
+    "src/components/reposicao/alertas/AlertaDrillSheet.tsx",
+    "src/components/reposicao/alertas/AlertasTable.tsx",
+    "src/components/reposicao/aplicacao/ProntosTab.tsx",
+    "src/components/reposicao/pedidos/PedidoRow.tsx",
+    "src/components/reposicao/promocoes/CampanhasTable.tsx",
+    "src/components/reposicao/revisao/RevisaoTable.tsx",
+    "src/components/reposicao/slaFornecedor/SkuComplianceTable.tsx",
+    "src/components/unifiedAI/AIResultPanel.tsx",
+    "src/pages/AdminStandardProcessDetail.tsx",
+    "src/pages/TintImport.tsx"
   ]
 }


### PR DESCRIPTION
## Resumo

Continuação do strict pós-Lote A+B. **14 `.tsx` que eram NEAR viraram READY** (seus blockers — `./types`/`useX`/`config` — entraram no strict nos lotes anteriores). Mantém-se **fora das lanes quentes** farmer/scoring/financeiro/customer360 (coordenação com sessões paralelas — decisão eu+Codex).

- **13 mecânicos** (tsconfig-only): `reposicao/{alertas/AlertasTable, aplicacao/ProntosTab, pedidos/PedidoRow, promocoes/CampanhasTable, revisao/RevisaoTable, slaFornecedor/SkuComplianceTable}`, `des/simulador/SimulationResult`, `aiOps/DecisionList`, `unifiedAI/AIResultPanel`, `customer/CustomerProcessTab`, `customerDashboard/PedidosAndamento`, `TintImport`, `AdminStandardProcessDetail`.
- **1 fix:** `reposicao/alertas/AlertaDrillSheet` — guard estendido (`em_atual !== undefined && delta_em !== undefined`) narrowa `delta_em` para `number` nas comparações do badge de estoque mínimo (TS18048). Mesmo grupo de números → behavior-preserving.

Progresso strict: **671 → 685** (~80% de 853).

## Test plan

- [x] `heavy bun run typecheck:strict` verde (exit 0, 0 erros)
- [x] `heavy bun lint` 0 erros
- [ ] CI `validate` (typecheck + strict + test + build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)