### PR TITLE
chore(strict): promove cluster reposicao/oportunidades (685→692)

### DIFF
--- a/tsconfig.strict.json
+++ b/tsconfig.strict.json
@@ -703,6 +703,13 @@
     "src/components/reposicao/slaFornecedor/SkuComplianceTable.tsx",
     "src/components/unifiedAI/AIResultPanel.tsx",
     "src/pages/AdminStandardProcessDetail.tsx",
-    "src/pages/TintImport.tsx"
+    "src/pages/TintImport.tsx",
+    "src/lib/reposicao/compras-otimizador-helpers.ts",
+    "src/components/reposicao/oportunidades/shared.tsx",
+    "src/components/reposicao/oportunidades/components.tsx",
+    "src/components/reposicao/oportunidades/KpiCards.tsx",
+    "src/components/reposicao/oportunidades/OportunidadesFiltros.tsx",
+    "src/components/reposicao/oportunidades/GerarCicloDialog.tsx",
+    "src/components/reposicao/oportunidades/OportunidadesTable.tsx"
   ]
 }


### PR DESCRIPTION
## Resumo

Cascata de lane fria trazendo o **blocker leaf** no mesmo PR. O cluster `reposicao/oportunidades/` é enraizado no helper puro **testado** `compras-otimizador-helpers.ts` (`lib/reposicao`, 20 testes) → `shared.tsx` → `components.tsx` → `{KpiCards, OportunidadesFiltros, GerarCicloDialog, OportunidadesTable}`.

- **7 arquivos, tsconfig-only, zero edição de source.**
- Reposição já saiu do mutirão de decomposição (§10) → tipos estáveis.
- NÃO toca lanes quentes farmer/scoring/financeiro/customer360.

Progresso strict: **685 → 692** (~81% de 853).

## Test plan
- [x] `heavy bun run typecheck:strict` verde (exit 0, 0 erros)
- [x] zero source tocado → lint inalterado (0 erros)
- [ ] CI `validate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)