### PR TITLE
fix(reposicao): guard também bloqueia nQtde<=0 no disparo

### DIFF
--- a/supabase/functions/disparar-pedidos-aprovados/index.ts
+++ b/supabase/functions/disparar-pedidos-aprovados/index.ts
@@ -500,10 +500,11 @@ async function processarPedido(
       throw new Error("Pedido sem itens");
     }
 
-    // a.1 Guard de custo (money-path): nunca enviar nValUnit <= 0 ao Omie.
-    // Roda ANTES do portal Sayerlack — senão o fornecedor recebe o pedido e o
-    // Omie falha depois (pedido fica em falha_envio sem registro, e a engine
-    // re-sugere os mesmos SKUs no ciclo seguinte). Falha cedo, com motivo claro.
+    // a.1 Guard de payload (money-path): nunca enviar item inválido (preço ou
+    // quantidade <= 0) ao Omie. Roda ANTES do portal Sayerlack — senão o
+    // fornecedor recebe o pedido e o Omie falha depois (pedido fica em
+    // falha_envio sem registro, e a engine re-sugere os mesmos SKUs no ciclo
+    // seguinte). Falha cedo, com motivo claro.
     const itensSemCusto = (items as ItemRow[]).filter(
       (it) => !(Number(it.preco_unitario) > 0),
     );
@@ -513,6 +514,18 @@ async function processarPedido(
         .join("; ");
       throw new Error(
         `SKU(s) sem custo (preço unitário 0): ${lista}. Defina o custo antes de disparar.`,
+      );
+    }
+    // nQtde <= 0 quebra o Omie com "O preenchimento da tag [nQtde] é obrigatório".
+    const itensSemQtde = (items as ItemRow[]).filter(
+      (it) => !(Number(it.qtde_final) > 0),
+    );
+    if (itensSemQtde.length > 0) {
+      const lista = itensSemQtde
+        .map((it) => `${it.sku_codigo_omie} (${it.sku_descricao ?? "sem descrição"})`)
+        .join("; ");
+      throw new Error(
+        `SKU(s) com quantidade 0: ${lista}. Ajuste a quantidade ou remova o item antes de disparar.`,
       );
     }
 


### PR DESCRIPTION
Complementa o guard de preço do #422. Item com `qtde_final = 0` quebrava o `IncluirPedCompra` do Omie (`"O preenchimento da tag [nQtde] é obrigatório"`) — caso real: pedido #194 reached the portal mas falhou no Omie por causa de um item com quantidade 0.

Mesma classe de payload inválido: o guard agora barra `nValUnit<=0` **e** `nQtde<=0`, **antes do portal Sayerlack**, com mensagem clara por SKU.

Sem migration. Só edge `disparar-pedidos-aprovados`. `deno check` limpo.

Após merge: redeploy de `disparar-pedidos-aprovados` (pega os dois guards de uma vez).