### PR TITLE
feat(fin): view v_titulo_baixas — data de baixa derivada (Fase 3 início)

### DIFF
--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,13 +21,13 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **100** custom migrations totais
-- **485** objetos esperados (criados por estas migrations)
+- **103** custom migrations totais
+- **487** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
   - `rls_policy`: 139
   - `index`: 96
   - `cron_job`: 82
-  - `function`: 76
+  - `function`: 78
   - `table`: 57
   - `trigger`: 31
   - `enum_value`: 4
@@ -998,11 +998,27 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | --- | --- | --- |
 | `cron_job` | `cron.nao-vinculados-refresh-diario` | — |
 
+### `20260527260000_data_health_vendas_cadastros_dado.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `public._data_health_compute` | — |
+
 ### `20260528000000_fin_sync_watchdog_tail_failing.sql`
 
 | Tipo | Objeto | Parent |
 | --- | --- | --- |
 | `function` | `public.fin_sync_watchdog_check` | — |
+
+### `20260528120000_reposicao_custo_cmc_em_transito.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `public.gerar_pedidos_sugeridos_ciclo` | — |
+
+### `20260528120001_v_titulo_baixas.sql`
+
+> _Nenhum objeto extraído via regex._ Migration provavelmente é `ALTER TABLE` / `UPDATE` / `INSERT` / RLS-only. Validar manualmente.
 
 ## Próximos passos quando algo der `❌`
 

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 100
+-- Total de custom migrations: 103
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -119,7 +119,10 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260527240000', 'data_health_alert_channel', '20260527240000_data_health_alert_channel.sql'),
   ('20260527250000', 'data_health_checks_high', '20260527250000_data_health_checks_high.sql'),
   ('20260527250000', 'nao_vinculados_cron', '20260527250000_nao_vinculados_cron.sql'),
-  ('20260528000000', 'fin_sync_watchdog_tail_failing', '20260528000000_fin_sync_watchdog_tail_failing.sql')
+  ('20260527260000', 'data_health_vendas_cadastros_dado', '20260527260000_data_health_vendas_cadastros_dado.sql'),
+  ('20260528000000', 'fin_sync_watchdog_tail_failing', '20260528000000_fin_sync_watchdog_tail_failing.sql'),
+  ('20260528120000', 'reposicao_custo_cmc_em_transito', '20260528120000_reposicao_custo_cmc_em_transito.sql'),
+  ('20260528120001', 'v_titulo_baixas', '20260528120001_v_titulo_baixas.sql')
 )
 SELECT
   e.version,
@@ -622,7 +625,9 @@ WITH expected_objects (migration, kind, schema_name, object_name, parent_name) A
   ('data_health_checks_high', 'function', 'public', 'data_health_watchdog', ''),
   ('data_health_checks_high', 'function', 'public', 'fin_sync_heartbeat', ''),
   ('nao_vinculados_cron', 'cron_job', 'cron', 'nao-vinculados-refresh-diario', ''),
-  ('fin_sync_watchdog_tail_failing', 'function', 'public', 'fin_sync_watchdog_check', '')
+  ('data_health_vendas_cadastros_dado', 'function', 'public', '_data_health_compute', ''),
+  ('fin_sync_watchdog_tail_failing', 'function', 'public', 'fin_sync_watchdog_check', ''),
+  ('reposicao_custo_cmc_em_transito', 'function', 'public', 'gerar_pedidos_sugeridos_ciclo', '')
 )
 SELECT
   e.migration,

--- a/supabase/migrations/20260528120001_v_titulo_baixas.sql
+++ b/supabase/migrations/20260528120001_v_titulo_baixas.sql
@@ -1,0 +1,64 @@
+-- ============================================================
+-- v_titulo_baixas — data de baixa real derivada das movimentações
+-- Spec: docs/superpowers/specs/2026-05-27-omie-baixa-date-root-fix-design.md (Fase 3)
+-- ============================================================
+-- O Omie NÃO retorna a data de baixa no LIST de títulos (data_recebimento/
+-- data_pagamento sempre NULL). Ela existe em fin_movimentacoes (dDtPagamento,
+-- gravado em data_movimento), joinável por omie_codigo_lancamento (=nCodTitulo).
+-- Esta view DERIVA a baixa dos movimentos — NUNCA grava na coluna base (o sync
+-- re-zeraria; decisão codex). Fonte única p/ front (TS) e edges (Deno).
+--
+-- Type-match: CR casa só movimento de ENTRADA ('E'); CP só de SAÍDA ('S') →
+-- exclui estornos (sinal oposto). data_baixa_final = MAX (quitação final).
+-- prazo_ponderado_dias = média do prazo (emissão→baixa) PONDERADA por valor
+-- (pagamento parcial: cada baixa pesa pelo seu valor). NULL se sem emissão.
+-- Cobertura é implícita: título com linha aqui = baixa derivável; ausência =
+-- degradação honesta (o consumidor cai no fallback). Recomputável/idempotente.
+
+CREATE OR REPLACE VIEW public.v_titulo_baixas
+WITH (security_invoker = on) AS
+WITH mov AS (
+  SELECT company, omie_codigo_lancamento AS cod, tipo,
+         data_movimento, abs(valor) AS valor
+  FROM public.fin_movimentacoes
+  WHERE omie_codigo_lancamento IS NOT NULL
+    AND data_movimento IS NOT NULL
+    AND tipo IN ('E', 'S')
+)
+SELECT
+  cr.company,
+  cr.omie_codigo_lancamento,
+  'CR'::text AS tipo,
+  max(m.data_movimento) AS data_baixa_final,
+  sum(m.valor) AS valor_baixado,
+  count(*)::int AS n_movimentos,
+  CASE WHEN cr.data_emissao IS NOT NULL AND sum(m.valor) > 0
+       THEN round(sum(m.valor * (m.data_movimento - cr.data_emissao)) / sum(m.valor))
+       ELSE NULL END AS prazo_ponderado_dias
+FROM public.fin_contas_receber cr
+JOIN mov m
+  ON m.company = cr.company
+ AND m.cod = cr.omie_codigo_lancamento
+ AND m.tipo = 'E'
+WHERE cr.omie_codigo_lancamento IS NOT NULL
+GROUP BY cr.company, cr.omie_codigo_lancamento, cr.data_emissao
+UNION ALL
+SELECT
+  cp.company,
+  cp.omie_codigo_lancamento,
+  'CP'::text AS tipo,
+  max(m.data_movimento) AS data_baixa_final,
+  sum(m.valor) AS valor_baixado,
+  count(*)::int AS n_movimentos,
+  CASE WHEN cp.data_emissao IS NOT NULL AND sum(m.valor) > 0
+       THEN round(sum(m.valor * (m.data_movimento - cp.data_emissao)) / sum(m.valor))
+       ELSE NULL END AS prazo_ponderado_dias
+FROM public.fin_contas_pagar cp
+JOIN mov m
+  ON m.company = cp.company
+ AND m.cod = cp.omie_codigo_lancamento
+ AND m.tipo = 'S'
+WHERE cp.omie_codigo_lancamento IS NOT NULL
+GROUP BY cp.company, cp.omie_codigo_lancamento, cp.data_emissao;
+
+GRANT SELECT ON public.v_titulo_baixas TO authenticated, service_role;

--- a/supabase/migrations/20260528120001_v_titulo_baixas.sql
+++ b/supabase/migrations/20260528120001_v_titulo_baixas.sql
@@ -8,22 +8,31 @@
 -- Esta view DERIVA a baixa dos movimentos — NUNCA grava na coluna base (o sync
 -- re-zeraria; decisão codex). Fonte única p/ front (TS) e edges (Deno).
 --
--- Type-match: CR casa só movimento de ENTRADA ('E'); CP só de SAÍDA ('S') →
--- exclui estornos (sinal oposto). data_baixa_final = MAX (quitação final).
--- prazo_ponderado_dias = média do prazo (emissão→baixa) PONDERADA por valor
--- (pagamento parcial: cada baixa pesa pelo seu valor). NULL se sem emissão.
--- Cobertura é implícita: título com linha aqui = baixa derivável; ausência =
--- degradação honesta (o consumidor cai no fallback). Recomputável/idempotente.
+-- SÓ TÍTULOS LIQUIDADOS (status RECEBIDO/LIQUIDADO p/ CR, PAGO/LIQUIDADO p/ CP):
+-- a view significa "baixa final do título quitado". Título aberto com pagamento
+-- PARCIAL fica de fora (senão aging/DRE/PMR o tratariam como liquidado — P1 codex).
+-- Caixa parcial por dia já vem direto de fin_movimentacoes no getFluxoCaixa.
+-- O filtro de status também mitiga estorno: título estornado volta a ABERTO → sai.
+-- Type-match: CR casa só movimento de ENTRADA ('E'); CP só de SAÍDA ('S').
+-- data_baixa_final = MAX (quitação final). prazo_ponderado_dias = média do prazo
+-- (emissão→baixa) PONDERADA por valor (parcial: cada baixa pesa pelo seu valor).
+-- NULL se sem emissão. Cobertura implícita: título com linha = baixa derivável;
+-- ausência = degradação honesta (consumidor cai no fallback). Idempotente.
+-- código é 1:1 (UNIQUE company,omie_codigo_lancamento) → GROUP BY seguro.
+-- ⚠️ Limitação: o sync grava valor=abs(); o sinal do estorno se perde no banco.
+-- Estorno DENTRO de um título ainda-liquidado (raro) pode inflar valor_baixado/
+-- atrasar a data. Refino futuro = analisar natureza dos movimentos casados.
 
 CREATE OR REPLACE VIEW public.v_titulo_baixas
 WITH (security_invoker = on) AS
 WITH mov AS (
   SELECT company, omie_codigo_lancamento AS cod, tipo,
-         data_movimento, abs(valor) AS valor
+         data_movimento, valor
   FROM public.fin_movimentacoes
   WHERE omie_codigo_lancamento IS NOT NULL
     AND data_movimento IS NOT NULL
     AND tipo IN ('E', 'S')
+    AND valor > 0
 )
 SELECT
   cr.company,
@@ -41,6 +50,7 @@ JOIN mov m
  AND m.cod = cr.omie_codigo_lancamento
  AND m.tipo = 'E'
 WHERE cr.omie_codigo_lancamento IS NOT NULL
+  AND cr.status_titulo IN ('RECEBIDO', 'LIQUIDADO')
 GROUP BY cr.company, cr.omie_codigo_lancamento, cr.data_emissao
 UNION ALL
 SELECT
@@ -59,6 +69,7 @@ JOIN mov m
  AND m.cod = cp.omie_codigo_lancamento
  AND m.tipo = 'S'
 WHERE cp.omie_codigo_lancamento IS NOT NULL
+  AND cp.status_titulo IN ('PAGO', 'LIQUIDADO')
 GROUP BY cp.company, cp.omie_codigo_lancamento, cp.data_emissao;
 
 GRANT SELECT ON public.v_titulo_baixas TO authenticated, service_role;


### PR DESCRIPTION
## ⚠️ Migration manual necessária (Lovable não aplica). SQL + validação na conversa.

## Summary

Fase 3 do root-fix da baixa. Cria `v_titulo_baixas` — a **fonte única** (front TS + edges Deno) da data de baixa real, derivada de `fin_movimentacoes` (o Omie não traz no LIST). **NÃO grava na coluna base** (o sync re-zeraria — decisão codex).

- Por `(company, omie_codigo_lancamento)`, type-match CR↔E / CP↔S, **só títulos liquidados** (RECEBIDO/LIQUIDADO / PAGO/LIQUIDADO).
- `data_baixa_final` = MAX (quitação), `prazo_ponderado_dias` = média ponderada por valor (parcial), `valor_baixado`, `n_movimentos`.
- `security_invoker=on` (RLS das base-tables preservada). Recomputável/idempotente.
- **Codex review (2 P1 corrigidos):** settled-only (não tratar parcial como quitado) + `valor>0` (não `abs` cego). GROUP BY seguro (UNIQUE = código 1:1).

## Fora de escopo (próximo)
- Ligar consumidores: aging-helpers (+ mirror Deno fin-cashflow-engine), valor-cockpit (+ fin-valor-cockpit), DRE-caixa (omie-financeiro), PMR/PMP. Cada um JOIN na view, degradação honesta onde não houver linha.

## Test plan
- [x] codex review (2 P1 aplicados)
- [ ] **Apply manual + validação** (conversa): view existe + cobertura sanity (oben/sc ~100%, colacor ~18% por característica do dado).

🤖 Generated with [Claude Code](https://claude.com/claude-code)