### PR TITLE
fix(omie-analytics-sync): sync_customers em background (waitUntil) + cron dedicado

### DIFF
--- a/supabase/functions/omie-analytics-sync/index.ts
+++ b/supabase/functions/omie-analytics-sync/index.ts
@@ -1026,9 +1026,26 @@ serve(async (req) => {
     let result: unknown;
 
     switch (action) {
-      case "sync_customers":
-        result = await syncCustomers(supabaseAdmin, account);
-        break;
+      case "sync_customers": {
+        // syncCustomers enumera ~10k clientes do Omie — pesado demais p/ o budget SÍNCRONO do request
+        // (dava WORKER_RESOURCE_LIMIT e prendia sync_state.customers em 'running' indefinidamente).
+        // Roda em BACKGROUND via EdgeRuntime.waitUntil (mesmo padrão do start_nao_vinculados, que
+        // completa o MESMO volume): responde 202 na hora; o sync_state (running→complete) é a fonte
+        // de progresso/verdade. O worker dedicado tem budget estendido p/ background.
+        const bgTask = syncCustomers(supabaseAdmin, account as OmieAccount).catch((e) => {
+          console.error("[sync_customers][bg]", e instanceof Error ? e.message : e);
+        });
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore - EdgeRuntime existe no runtime do Supabase Edge
+        if (typeof EdgeRuntime !== "undefined" && typeof EdgeRuntime.waitUntil === "function") {
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
+          EdgeRuntime.waitUntil(bgTask);
+        }
+        return new Response(JSON.stringify({ accepted: true, background: true }), {
+          status: 202, headers: { ...corsHeaders, "Content-Type": "application/json" },
+        });
+      }
       case "sync_products":
         result = await syncProducts(supabaseAdmin, account, start_page || 1, max_pages || 10);
         break;
@@ -1045,14 +1062,16 @@ serve(async (req) => {
         result = await computeAssociationRules(supabaseAdmin);
         break;
       case "sync_all": {
+        // customers SAIU do sync_all: agora tem cron dedicado (sync-customers-vendas-daily) que chama
+        // a action sync_customers em BACKGROUND. Rodar customers síncrono aqui dava WORKER_RESOURCE_LIMIT
+        // e RE-prendia sync_state.customers em 'running' a cada passada — clobberava o estado curado.
         const acct = account as OmieAccount;
-        const customers = await syncCustomers(supabaseAdmin, acct);
         const products = await syncProducts(supabaseAdmin, acct);
         const orders = await syncOrdersIncremental(supabaseAdmin, acct);
         const inventory = await syncInventory(supabaseAdmin, acct);
         const costs = await computeCosts(supabaseAdmin);
         const assocRules = await computeAssociationRules(supabaseAdmin);
-        result = { customers, products, orders, inventory, costs, assocRules };
+        result = { products, orders, inventory, costs, assocRules };
         break;
       }
       case "get_sync_state": {

--- a/supabase/migrations/20260528010000_cron_sync_customers_dedicated.sql
+++ b/supabase/migrations/20260528010000_cron_sync_customers_dedicated.sql
@@ -1,0 +1,22 @@
+-- Cron dedicado p/ o sync de clientes (vendas/oben). Contexto: o syncCustomers estava preso em
+-- sync_state.customers status='running' há ~2 meses. Causa em 2 camadas: (1) N+1 (~2-3 queries/cliente
+-- × ~10k) — corrigido no #435 (bulk reads + dedup + bulk upsert); (2) mesmo sem N+1, a enumeração de
+-- ~10k clientes do Omie NÃO cabe no budget SÍNCRONO do request → WORKER_RESOURCE_LIMIT. Fix: a action
+-- sync_customers agora roda em BACKGROUND (EdgeRuntime.waitUntil), igual o start_nao_vinculados (#383)
+-- que completa o MESMO volume. Este cron isola o customers no seu próprio worker (budget de background).
+--
+-- customers FOI REMOVIDO do sync_all (que rodava síncrono e re-prendia o estado a cada passada) — então
+-- este cron passa a ser o ÚNICO responsável pelo sync de clientes. timeout só cobre o 202 (o trabalho
+-- segue em background). 0 5 = antes do batch das 6h, e antes do data-health-watchdog pegar o frescor.
+-- ⚠️ Requer o redeploy do omie-analytics-sync (action sync_customers em background) ANTES de valer.
+
+SELECT cron.schedule('sync-customers-vendas-daily', '0 5 * * *',
+  $$ SELECT net.http_post(
+    url := 'https://fzvklzpomgnyikkfkzai.supabase.co/functions/v1/omie-analytics-sync',
+    headers := jsonb_build_object(
+      'Content-Type', 'application/json',
+      'x-cron-secret', (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name='CRON_SECRET' LIMIT 1)
+    ),
+    body := '{"action":"sync_customers","account":"vendas"}'::jsonb,
+    timeout_milliseconds := 60000
+  ); $$);


### PR DESCRIPTION
## Resumo

Sequência do #435. Aquele tirou o N+1 do `syncCustomers`, mas a validação em prod mostrou que **ainda estourava `WORKER_RESOURCE_LIMIT`** (confirmado via `net._http_response`: `{"code":"WORKER_RESOURCE_LIMIT"}`): a enumeração de ~10k clientes do Omie **não cabe no budget de um request síncrono**. 

**Prova de que background resolve:** o `syncNaoVinculados` (#383) faz a MESMA enumeração e **completa** — porque roda via `EdgeRuntime.waitUntil` (worker próprio, budget estendido de background).

**Fix:**
- A action `sync_customers` agora roda em **background** (`EdgeRuntime.waitUntil`, mesmo padrão do `start_nao_vinculados`): responde **202** na hora; o `sync_state` (`running`→`complete`) é a fonte de progresso/verdade.
- `customers` **removido do `sync_all`** — rodava síncrono (546) e **re-prendia** `sync_state.customers` em `running` a cada passada, clobberando o estado curado.
- **Cron dedicado** `sync-customers-vendas-daily` (`0 5 * * *`) chama `sync_customers` (background) → passa a ser o único responsável pelo sync de clientes (vendas/oben).

O bulk N+1-removal do #435 **continua** (deixa o background mais leve/rápido). `syncProducts` e os demais intactos.

## ⚠️ 2 passos manuais (após merge)
1. **Redeploy** do `omie-analytics-sync` via chat do Lovable (lê do repo, verbatim).
2. **Migration** `20260528010000_cron_sync_customers_dedicated.sql` via SQL Editor.

## Test plan
- [x] `deno check` limpo no diff (3 erros restantes são pré-existentes em `computeCosts`)
- [ ] Pós-deploy: invocar `sync_customers` → **202** → esperar ~90s → `sync_state.customers` = `complete`, `total_synced` > 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)