### PR TITLE
feat(fin): liga PMR/PMP/ciclo à baixa derivada (v_capital_giro_prazos)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,8 @@ dist-ssr
 # Agent tooling artifacts (per-developer, never commit)
 .codex/
 AGENTS.md
+.context/
+deno.lock
 
 
 # Serena MCP local project cache

--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,12 +21,12 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **103** custom migrations totais
-- **487** objetos esperados (criados por estas migrations)
+- **105** custom migrations totais
+- **488** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
   - `rls_policy`: 139
   - `index`: 96
-  - `cron_job`: 82
+  - `cron_job`: 83
   - `function`: 78
   - `table`: 57
   - `trigger`: 31
@@ -1010,6 +1010,12 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | --- | --- | --- |
 | `function` | `public.fin_sync_watchdog_check` | — |
 
+### `20260528010000_cron_sync_customers_dedicated.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `cron_job` | `cron.sync-customers-vendas-daily` | — |
+
 ### `20260528120000_reposicao_custo_cmc_em_transito.sql`
 
 | Tipo | Objeto | Parent |
@@ -1017,6 +1023,10 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | `function` | `public.gerar_pedidos_sugeridos_ciclo` | — |
 
 ### `20260528120001_v_titulo_baixas.sql`
+
+> _Nenhum objeto extraído via regex._ Migration provavelmente é `ALTER TABLE` / `UPDATE` / `INSERT` / RLS-only. Validar manualmente.
+
+### `20260528120002_v_capital_giro_prazos.sql`
 
 > _Nenhum objeto extraído via regex._ Migration provavelmente é `ALTER TABLE` / `UPDATE` / `INSERT` / RLS-only. Validar manualmente.
 

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 103
+-- Total de custom migrations: 105
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -121,8 +121,10 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260527250000', 'nao_vinculados_cron', '20260527250000_nao_vinculados_cron.sql'),
   ('20260527260000', 'data_health_vendas_cadastros_dado', '20260527260000_data_health_vendas_cadastros_dado.sql'),
   ('20260528000000', 'fin_sync_watchdog_tail_failing', '20260528000000_fin_sync_watchdog_tail_failing.sql'),
+  ('20260528010000', 'cron_sync_customers_dedicated', '20260528010000_cron_sync_customers_dedicated.sql'),
   ('20260528120000', 'reposicao_custo_cmc_em_transito', '20260528120000_reposicao_custo_cmc_em_transito.sql'),
-  ('20260528120001', 'v_titulo_baixas', '20260528120001_v_titulo_baixas.sql')
+  ('20260528120001', 'v_titulo_baixas', '20260528120001_v_titulo_baixas.sql'),
+  ('20260528120002', 'v_capital_giro_prazos', '20260528120002_v_capital_giro_prazos.sql')
 )
 SELECT
   e.version,
@@ -627,6 +629,7 @@ WITH expected_objects (migration, kind, schema_name, object_name, parent_name) A
   ('nao_vinculados_cron', 'cron_job', 'cron', 'nao-vinculados-refresh-diario', ''),
   ('data_health_vendas_cadastros_dado', 'function', 'public', '_data_health_compute', ''),
   ('fin_sync_watchdog_tail_failing', 'function', 'public', 'fin_sync_watchdog_check', ''),
+  ('cron_sync_customers_dedicated', 'cron_job', 'cron', 'sync-customers-vendas-daily', ''),
   ('reposicao_custo_cmc_em_transito', 'function', 'public', 'gerar_pedidos_sugeridos_ciclo', '')
 )
 SELECT

--- a/src/services/financeiroService.ts
+++ b/src/services/financeiroService.ts
@@ -547,23 +547,17 @@ export async function getCapitalDeGiro(company: Company | 'all'): Promise<Capita
       .eq("company", co)
       .eq("ativo", true);
 
-    // CR recebidos últimos 90 dias (para calcular PMR)
-    const d90ago = new Date();
-    d90ago.setDate(d90ago.getDate() - 90);
-    const { data: crRecebidos } = await supabase
-      .from("fin_contas_receber")
-      .select("data_emissao, data_recebimento, valor_recebido")
+    // PMR/PMP: baixa derivada das movimentações (view v_capital_giro_prazos), porque
+    // o Omie NÃO traz data de baixa no LIST de títulos (data_recebimento/pagamento
+    // sempre NULL — ver v_titulo_baixas). A view agrega PMR/PMP ponderado por valor +
+    // a cobertura (fração dos liquidados com baixa derivável) por empresa.
+    const COBERTURA_MIN = 0.4;
+    // view nova ainda não nos tipos gerados → `as never` (padrão do repo p/ views)
+    const { data: prazos } = await supabase
+      .from("v_capital_giro_prazos" as never)
+      .select("pmr, pmp, pmr_cobertura, pmp_cobertura")
       .eq("company", co)
-      .in("status_titulo", ["RECEBIDO", "LIQUIDADO"])
-      .gte("data_recebimento", d90ago.toISOString().slice(0, 10));
-
-    // CP pagos últimos 90 dias (para calcular PMP)
-    const { data: cpPagos } = await supabase
-      .from("fin_contas_pagar")
-      .select("data_emissao, data_pagamento, valor_pago")
-      .eq("company", co)
-      .in("status_titulo", ["PAGO", "LIQUIDADO"])
-      .gte("data_pagamento", d90ago.toISOString().slice(0, 10));
+      .maybeSingle();
 
     type CrRow = { valor_documento: number | null; valor_recebido: number | null };
     type CpRow = { valor_documento: number | null; valor_pago: number | null };
@@ -576,31 +570,14 @@ export async function getCapitalDeGiro(company: Company | 'all'): Promise<Capita
     const totalCP = calcSaldoCP(cpAberto as CpRow[] | null);
     const totalCC = (ccs || []).reduce((s, c) => s + (c.saldo_atual || 0), 0);
 
-    // PMR: média ponderada de dias entre emissão e recebimento
-    let pmrNumerator = 0, pmrDenominator = 0;
-    for (const r of crRecebidos || []) {
-      const valor = r.valor_recebido ?? 0;
-      if (r.data_emissao && r.data_recebimento && valor > 0) {
-        const dias = Math.max(0, (new Date(r.data_recebimento).getTime() - new Date(r.data_emissao).getTime()) / 86400000);
-        pmrNumerator += dias * valor;
-        pmrDenominator += valor;
-      }
-    }
-    // null (não 0) quando não há baixas datadas: mostrar 0 dias parece "recebimento
-    // instantâneo" e engana. Hoje o sync não popula data_recebimento → cai aqui.
-    const pmr = pmrDenominator > 0 ? Math.round(pmrNumerator / pmrDenominator) : null;
-
-    // PMP: média ponderada de dias entre emissão e pagamento
-    let pmpNumerator = 0, pmpDenominator = 0;
-    for (const p of cpPagos || []) {
-      const valor = p.valor_pago ?? 0;
-      if (p.data_emissao && p.data_pagamento && valor > 0) {
-        const dias = Math.max(0, (new Date(p.data_pagamento).getTime() - new Date(p.data_emissao).getTime()) / 86400000);
-        pmpNumerator += dias * valor;
-        pmpDenominator += valor;
-      }
-    }
-    const pmp = pmpDenominator > 0 ? Math.round(pmpNumerator / pmpDenominator) : null;
+    // Gate de confiança por empresa: prazo só quando a cobertura é suficiente.
+    // Cobertura baixa → NULL (= "—", degradação honesta) pra não mostrar o prazo de
+    // uma amostra não-representativa (ex: colacor ~9% — liquida sem movimento `mf`).
+    // oben/sc têm ~100% → mostram PMR/PMP reais. NULL (não 0) evita o falso
+    // "recebimento instantâneo".
+    const p = (prazos ?? {}) as { pmr?: number | null; pmp?: number | null; pmr_cobertura?: number | null; pmp_cobertura?: number | null };
+    const pmr = Number(p.pmr_cobertura ?? 0) >= COBERTURA_MIN && p.pmr != null ? Number(p.pmr) : null;
+    const pmp = Number(p.pmp_cobertura ?? 0) >= COBERTURA_MIN && p.pmp != null ? Number(p.pmp) : null;
 
     // Concentração top 5
     const crByClient = new Map<string, number>();

--- a/supabase/migrations/20260528120002_v_capital_giro_prazos.sql
+++ b/supabase/migrations/20260528120002_v_capital_giro_prazos.sql
@@ -1,0 +1,55 @@
+-- ============================================================
+-- v_capital_giro_prazos — PMR/PMP/cobertura por empresa (agregado de v_titulo_baixas)
+-- Spec: docs/superpowers/specs/2026-05-27-omie-baixa-date-root-fix-design.md (Fase 3)
+-- ============================================================
+-- Agrega a baixa derivada (v_titulo_baixas) em PMR/PMP por empresa, ponderado por
+-- valor, + a COBERTURA (fração dos títulos liquidados com baixa derivável). O front
+-- (getCapitalDeGiro) lê 1 linha/empresa em vez de baixar ~14k linhas de título.
+-- O gate de confiança fica no consumidor: cobertura baixa → degrada PMR/PMP pra
+-- NULL ("—"), conforme codex (não mostrar colacor a ~9% como se fosse confiável).
+-- security_invoker → RLS das base-tables preservada. Idempotente.
+
+CREATE OR REPLACE VIEW public.v_capital_giro_prazos
+WITH (security_invoker = on) AS
+WITH companies AS (
+  SELECT DISTINCT company FROM public.fin_contas_receber
+  UNION
+  SELECT DISTINCT company FROM public.fin_contas_pagar
+),
+cr_baixa AS (
+  SELECT company,
+    round(sum(prazo_ponderado_dias * valor_baixado) / nullif(sum(valor_baixado), 0)) AS pmr,
+    count(*) AS n
+  FROM public.v_titulo_baixas
+  WHERE tipo = 'CR' AND prazo_ponderado_dias IS NOT NULL
+  GROUP BY company
+),
+cp_baixa AS (
+  SELECT company,
+    round(sum(prazo_ponderado_dias * valor_baixado) / nullif(sum(valor_baixado), 0)) AS pmp,
+    count(*) AS n
+  FROM public.v_titulo_baixas
+  WHERE tipo = 'CP' AND prazo_ponderado_dias IS NOT NULL
+  GROUP BY company
+),
+cr_set AS (
+  SELECT company, count(*) AS n FROM public.fin_contas_receber
+  WHERE status_titulo IN ('RECEBIDO', 'LIQUIDADO') GROUP BY company
+),
+cp_set AS (
+  SELECT company, count(*) AS n FROM public.fin_contas_pagar
+  WHERE status_titulo IN ('PAGO', 'LIQUIDADO') GROUP BY company
+)
+SELECT
+  c.company,
+  crb.pmr,
+  cpb.pmp,
+  round(coalesce(crb.n, 0)::numeric / nullif(crs.n, 0), 3) AS pmr_cobertura,
+  round(coalesce(cpb.n, 0)::numeric / nullif(cps.n, 0), 3) AS pmp_cobertura
+FROM companies c
+LEFT JOIN cr_baixa crb ON crb.company = c.company
+LEFT JOIN cp_baixa cpb ON cpb.company = c.company
+LEFT JOIN cr_set  crs ON crs.company = c.company
+LEFT JOIN cp_set  cps ON cps.company = c.company;
+
+GRANT SELECT ON public.v_capital_giro_prazos TO authenticated, service_role;


### PR DESCRIPTION
## Resumo

Fase 3 do fix da data de baixa do Omie. Liga **PMR/PMP/ciclo financeiro** (cards de capital de giro) à **baixa derivada das movimentações** (`v_titulo_baixas`, já em prod via #434), porque o Omie **nunca** retorna data de baixa no LIST de títulos (`data_recebimento`/`data_pagamento` sempre NULL) — o `getCapitalDeGiro` calculava prazo sobre dados vazios e mostrava sempre "—".

- **Nova view `v_capital_giro_prazos`** (`security_invoker`): agrega `v_titulo_baixas` em PMR/PMP **ponderado por valor** + a **cobertura** (fração dos liquidados com baixa derivável) por empresa. O front lê **1 linha/empresa** em vez de baixar ~14k títulos.
- **Gate de confiança no consumidor** (`getCapitalDeGiro`): cobertura `<40%` → degrada PMR/PMP pra `null` ("—", degradação honesta) pra não exibir prazo de amostra não-representativa. oben/sc (~100%) voltam a mostrar prazo real; colacor (~9%, liquida sem movimento `mf`) segue "—".
- Remove as 2 queries que liam `data_recebimento`/`data_pagamento` (sempre NULL) e os loops de PMR/PMP.

## ⚠️ ATENÇÃO: migration manual necessária

Este PR adiciona `supabase/migrations/20260528120002_v_capital_giro_prazos.sql`. **Lovable não aplica automaticamente** — mergear NÃO toca o banco. Precisa colar no SQL Editor do Lovable e rodar.

<details><summary>SQL pra aplicar</summary>

```sql
CREATE OR REPLACE VIEW public.v_capital_giro_prazos
WITH (security_invoker = on) AS
WITH companies AS (
  SELECT DISTINCT company FROM public.fin_contas_receber
  UNION
  SELECT DISTINCT company FROM public.fin_contas_pagar
),
cr_baixa AS (
  SELECT company,
    round(sum(prazo_ponderado_dias * valor_baixado) / nullif(sum(valor_baixado), 0)) AS pmr,
    count(*) AS n
  FROM public.v_titulo_baixas
  WHERE tipo = 'CR' AND prazo_ponderado_dias IS NOT NULL
  GROUP BY company
),
cp_baixa AS (
  SELECT company,
    round(sum(prazo_ponderado_dias * valor_baixado) / nullif(sum(valor_baixado), 0)) AS pmp,
    count(*) AS n
  FROM public.v_titulo_baixas
  WHERE tipo = 'CP' AND prazo_ponderado_dias IS NOT NULL
  GROUP BY company
),
cr_set AS (
  SELECT company, count(*) AS n FROM public.fin_contas_receber
  WHERE status_titulo IN ('RECEBIDO', 'LIQUIDADO') GROUP BY company
),
cp_set AS (
  SELECT company, count(*) AS n FROM public.fin_contas_pagar
  WHERE status_titulo IN ('PAGO', 'LIQUIDADO') GROUP BY company
)
SELECT
  c.company,
  crb.pmr,
  cpb.pmp,
  round(coalesce(crb.n, 0)::numeric / nullif(crs.n, 0), 3) AS pmr_cobertura,
  round(coalesce(cpb.n, 0)::numeric / nullif(cps.n, 0), 3) AS pmp_cobertura
FROM companies c
LEFT JOIN cr_baixa crb ON crb.company = c.company
LEFT JOIN cp_baixa cpb ON cpb.company = c.company
LEFT JOIN cr_set  crs ON crs.company = c.company
LEFT JOIN cp_set  cps ON cps.company = c.company;

GRANT SELECT ON public.v_capital_giro_prazos TO authenticated, service_role;
```
</details>

Validação pós-apply:

```sql
SELECT company, pmr, pmp, pmr_cobertura, pmp_cobertura
FROM public.v_capital_giro_prazos ORDER BY company;
```

Esperado: 3 linhas (colacor/oben/colacor_sc). oben/sc com `pmr_cobertura`/`pmp_cobertura` altos (~1.0) e PMR/PMP preenchidos; colacor com cobertura baixa (~0.09) → o front mostra "—".

## Test plan

- [x] `bunx tsc -p tsconfig.app.json` (baseline) + `tsconfig.strict.json` — 0 erros
- [x] `bun run test` — 1649/1649 passando
- [ ] Pós-apply da migration: cards de ciclo (oben/sc) mostram PMR/PMP reais; colacor "—"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
