### PR TITLE
feat(cockpit): religa Cockpit financeiro às engines A1 (snapshot real) + rótulos honestos

### DIFF
--- a/docs/FINANCEIRO_CONFIABILIDADE.md
+++ b/docs/FINANCEIRO_CONFIABILIDADE.md
@@ -250,6 +250,16 @@ Constrói SOBRE o "Orçado × Realizado" que já existia (`/financeiro/orcamento
 
 **Onde:** helper `src/lib/financeiro/orcamento-forecast-helpers.ts` (vitest, 26 testes; `projetarDRE` + `seedOrcamento` + primitivas); página `src/pages/FinanceiroOrcamento.tsx` (seção "Forecast de aterrissagem" + botão "Sugerir orçamento"); item na sidebar (`/financeiro/orcamento`, antes órfã). **Sem migration, sem edge function, sem deploy** (client-side puro).
 
+## 🔧 Consolidação do Cockpit — religado às engines (2026-05-28)
+
+Uma auditoria de consistência achou que o **Cockpit** (`/financeiro/cockpit`, consolidado das 3 empresas) mostrava números ERRADOS porque foi construído com atalhos antes das engines A1 existirem: **projeção 13s** via RPC ingênua `fin_projecao_13_semanas` (joga CR/CP no vencimento; sem curva de cobrança/inadimplência/eventos/folha) e **NCG** = `CR−CP` (só abertos). Religado:
+
+- **Projeção 13s + NCG agora vêm da engine A1** via `fin_projecao_snapshots` (snapshot diário; curvas calibradas, inadimplência, eventos, folha; NCG = ACO−PCO real). **Snapshot-first** (não 3 invocações live — tela executiva semanal): mostra "dados de {data}".
+- **Consolidado COM decomposição por empresa** (Codex P1 — caixa NÃO é fungível entre 3 CNPJs distintos; somar pode esconder insolvência local). **Coorte por data de referência:** só snapshots do dia mais recente entram; empresa com snapshot mais antigo = `stale` (fora da soma, sinalizado); dedupe por empresa (latest-wins). **Cenário explícito** ("realista"). **Intercompany NÃO eliminado** (premissa documentada — CR de uma empresa pode ser CP de outra → aviso no bloco). **Falha parcial honesta** (banner "N de 3", números = mínimo conhecido; ausente ≠ zero).
+- **Rótulos honestos:** "Caixa Projetado 30d" (que não era 30d) → "Posição líquida (abertos)"; `DataBasisFooter` com regime dinâmico (não "caixa" fixo); badge "ACO−PCO (engine)" no NCG.
+- Helper `src/lib/financeiro/cockpit-consolida-helpers.ts` (13 testes; `consolidarCockpit`) + `getProjecaoSnapshotsCockpit`. **Codex em todas as etapas** (metodologia + spec [3 P1] + plano [3 P1 anti-impl-preguiçosa] + adversarial). **CLIENT-SIDE — sem migration/deploy** (o snapshot já é gravado pelo cron `fin-cashflow-snapshot-diario`).
+- **Limitações:** snapshot até 1 dia stale (data visível); intercompany não eliminado; caixa consolidado não-fungível (por isso a quebra por empresa). A decomposição ACO/PCO detalhada e os cenários ficam na tela **Capital de Giro** (live).
+
 ## ✅ MVP Operacional (pode usar agora para gestão diária)
 
 Estes dados vêm direto do Omie sem transformação opinativa.

--- a/docs/superpowers/plans/2026-05-27-cockpit-consolidacao.md
+++ b/docs/superpowers/plans/2026-05-27-cockpit-consolidacao.md
@@ -1,0 +1,172 @@
+# Cockpit — Consolidação (religar às engines) — Plano
+
+> **REQUIRED SUB-SKILL:** superpowers:subagent-driven-development. **Codex em todas as etapas:** metodologia ✓ · spec ✓ (3 P1) · plano ← Codex antes de executar · código ← Codex adversarial (Task 3).
+
+**Goal:** Cockpit consolidado lê projeção 13s + NCG do snapshot real (`fin_projecao_snapshots`, engine A1) em vez da RPC ingênua e do `CR−CP`; total + decomposição por empresa (caixa não-fungível entre CNPJs); coorte por data de referência; rótulos honestos. **Client-side, sem migration.** Spec: `docs/superpowers/specs/2026-05-27-cockpit-consolidacao-design.md`.
+
+---
+
+### Task 1: Helper `cockpit-consolida-helpers.ts` (TDD)
+
+**Files:** Create `src/lib/financeiro/cockpit-consolida-helpers.ts` + `__tests__/cockpit-consolida-helpers.test.ts`
+
+Contrato: ver spec (`SnapshotSemana`, `SnapshotEmpresa`, `SemanaConsolidada`, `CockpitConsolidado`, `consolidarCockpit`). `round2` padrão.
+
+- [ ] **Step 1: testes que falham:**
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { consolidarCockpit, type SnapshotEmpresa } from '../cockpit-consolida-helpers';
+
+const sem = (inicio: string, ent: number, sai: number, saldo: number) =>
+  ({ inicio, total_entradas: ent, total_saidas: sai, saldo_final: saldo });
+const snap = (company: string, at: string, ncg: number | null, semanas: ReturnType<typeof sem>[], saldo_tes = 0): SnapshotEmpresa =>
+  ({ company, snapshot_at: at, ncg, saldo_tesouraria: saldo_tes, semanas });
+const ESP = ['oben', 'colacor', 'colacor_sc'];
+
+describe('consolidarCockpit', () => {
+  it('consolida 3 empresas mesma data: soma por semana + NCG; completa=true; não parcial', () => {
+    const snaps = [
+      snap('oben', '2026-05-27T10:00:00Z', 100, [sem('2026-05-26', 10, 5, 105), sem('2026-06-02', 20, 5, 120)], 50),
+      snap('colacor', '2026-05-27T10:01:00Z', 200, [sem('2026-05-26', 30, 10, 220), sem('2026-06-02', 0, 0, 220)], 80),
+      snap('colacor_sc', '2026-05-27T10:02:00Z', 50, [sem('2026-05-26', 5, 1, 54), sem('2026-06-02', 5, 1, 58)], 20),
+    ];
+    const r = consolidarCockpit({ esperadas: ESP, snapshots: snaps });
+    expect(r.parcial).toBe(false);
+    expect(r.empresas_presentes).toEqual(ESP); // ordem esperadas
+    expect(r.ncg_total).toBe(350);             // 100+200+50
+    expect(r.ncg_parcial).toBe(false);
+    expect(r.saldo_tesouraria_total).toBe(150);
+    expect(r.projecao13).toHaveLength(2);
+    expect(r.projecao13[0].inicio).toBe('2026-05-26');
+    expect(r.projecao13[0].entradas_previstas).toBe(45);   // 10+30+5
+    expect(r.projecao13[0].saldo_projetado).toBe(379);     // 105+220+54
+    expect(r.projecao13[0].semana_label).toBe('26/05');    // sem new Date
+    expect(r.projecao13[0].completa).toBe(true);
+    expect(r.projecao13[0].por_empresa).toHaveLength(3);
+  });
+
+  it('COORTE por data de referência: snapshot stale (dia anterior) fica FORA da soma + flag stale (P1.3)', () => {
+    const snaps = [
+      snap('oben', '2026-05-27T10:00:00Z', 100, [sem('2026-05-26', 10, 0, 110)]),
+      snap('colacor', '2026-05-27T10:00:00Z', 200, [sem('2026-05-26', 20, 0, 220)]),
+      snap('colacor_sc', '2026-05-20T10:00:00Z', 999, [sem('2026-05-19', 1, 0, 1)]), // 7 dias atrás
+    ];
+    const r = consolidarCockpit({ esperadas: ESP, snapshots: snaps });
+    expect(r.data_referencia).toBe('2026-05-27');
+    expect(r.empresas_presentes).toEqual(['oben', 'colacor']);
+    expect(r.empresas_stale).toEqual(['colacor_sc']);
+    expect(r.parcial).toBe(true);
+    expect(r.ncg_total).toBe(300);            // 100+200; o 999 stale NÃO entra
+    expect(r.projecao13[0].saldo_projetado).toBe(330); // 110+220; sem o stale
+    expect(r.projecao13[0].completa).toBe(false);       // 2 de 3 esperadas
+  });
+
+  it('DEDUPE por empresa: 2 linhas de oben → fica a de snapshot_at maior, não soma 2× (P1.2)', () => {
+    const snaps = [
+      snap('oben', '2026-05-27T08:00:00Z', 100, [sem('2026-05-26', 10, 0, 110)]),
+      snap('oben', '2026-05-27T12:00:00Z', 150, [sem('2026-05-26', 15, 0, 165)]), // mais recente
+      snap('colacor', '2026-05-27T10:00:00Z', 200, [sem('2026-05-26', 20, 0, 220)]),
+      snap('colacor_sc', '2026-05-27T10:00:00Z', 50, [sem('2026-05-26', 5, 0, 55)]),
+    ];
+    const r = consolidarCockpit({ esperadas: ESP, snapshots: snaps });
+    expect(r.ncg_total).toBe(400);   // 150(recente)+200+50 — NÃO 100+150+...
+    expect(r.projecao13[0].saldo_projetado).toBe(440); // 165+220+55
+    expect(r.empresas_presentes).toEqual(ESP);
+  });
+
+  it('empresa ausente (sem snapshot) → ausente + parcial; completa=false', () => {
+    const snaps = [
+      snap('oben', '2026-05-27T10:00:00Z', 100, [sem('2026-05-26', 10, 0, 110)]),
+      snap('colacor', '2026-05-27T10:00:00Z', 200, [sem('2026-05-26', 20, 0, 220)]),
+    ];
+    const r = consolidarCockpit({ esperadas: ESP, snapshots: snaps });
+    expect(r.empresas_ausentes).toEqual(['colacor_sc']);
+    expect(r.parcial).toBe(true);
+    expect(r.ncg_total).toBe(300);
+    expect(r.projecao13[0].completa).toBe(false);
+    expect(r.ncg_por_empresa.find(e => e.company === 'colacor_sc')).toEqual({ company: 'colacor_sc', ncg: null, presente: false });
+  });
+
+  it('ncg null (engine não computou) ≠ ncg 0; null fora da soma + ncg_parcial', () => {
+    const snaps = [
+      snap('oben', '2026-05-27T10:00:00Z', null, [sem('2026-05-26', 10, 0, 110)]),
+      snap('colacor', '2026-05-27T10:00:00Z', 0, [sem('2026-05-26', 20, 0, 220)]),
+      snap('colacor_sc', '2026-05-27T10:00:00Z', 50, [sem('2026-05-26', 5, 0, 55)]),
+    ];
+    const r = consolidarCockpit({ esperadas: ESP, snapshots: snaps });
+    expect(r.ncg_total).toBe(50);        // 0 conta, null não
+    expect(r.ncg_parcial).toBe(true);    // oben null
+  });
+
+  it('inícios fora de ordem entre empresas → união ordenada asc; alinha por inicio', () => {
+    const snaps = [
+      snap('oben', '2026-05-27T10:00:00Z', 0, [sem('2026-06-02', 20, 0, 20), sem('2026-05-26', 10, 0, 10)]),
+      snap('colacor', '2026-05-27T10:00:00Z', 0, [sem('2026-05-26', 5, 0, 5), sem('2026-06-02', 7, 0, 7)]),
+      snap('colacor_sc', '2026-05-27T10:00:00Z', 0, [sem('2026-05-26', 1, 0, 1), sem('2026-06-02', 2, 0, 2)]),
+    ];
+    const r = consolidarCockpit({ esperadas: ESP, snapshots: snaps });
+    expect(r.projecao13.map(s => s.inicio)).toEqual(['2026-05-26', '2026-06-02']);
+    expect(r.projecao13[0].saldo_projetado).toBe(16); // 10+5+1
+  });
+
+  it('semana só de uma empresa → completa=false (soma só quem tem; ausente≠zero)', () => {
+    const snaps = [
+      snap('oben', '2026-05-27T10:00:00Z', 0, [sem('2026-05-26', 10, 0, 110), sem('2026-06-02', 5, 0, 115)]),
+      snap('colacor', '2026-05-27T10:00:00Z', 0, [sem('2026-05-26', 20, 0, 220)]), // sem a 2ª semana
+      snap('colacor_sc', '2026-05-27T10:00:00Z', 0, [sem('2026-05-26', 1, 0, 1)]),
+    ];
+    const r = consolidarCockpit({ esperadas: ESP, snapshots: snaps });
+    const w2 = r.projecao13.find(s => s.inicio === '2026-06-02')!;
+    expect(w2.saldo_projetado).toBe(115);  // só oben
+    expect(w2.completa).toBe(false);
+    expect(w2.por_empresa).toHaveLength(1);
+  });
+
+  it('vazio → tudo ausente, parcial, projeção vazia, sem NaN', () => {
+    const r = consolidarCockpit({ esperadas: ESP, snapshots: [] });
+    expect(r.empresas_ausentes).toEqual(ESP);
+    expect(r.parcial).toBe(true);
+    expect(r.ncg_total).toBe(0);
+    expect(r.projecao13).toEqual([]);
+    expect(r.data_referencia).toBeNull();
+  });
+
+  it('cap em 13 semanas a partir da menor âncora', () => {
+    const semanas = Array.from({ length: 16 }, (_, i) => sem(`2026-${String(1 + Math.floor(i / 4)).padStart(2,'0')}-0${(i % 4) + 1}`, 1, 0, 1));
+    const r = consolidarCockpit({ esperadas: ['oben'], snapshots: [snap('oben', '2026-05-27T10:00:00Z', 0, semanas)] });
+    expect(r.projecao13.length).toBeLessThanOrEqual(13);
+  });
+});
+```
+
+- [ ] **Step 2:** ver falhar. **Step 3:** implementar conforme a "Lógica" do spec (dedupe Map por company latest; coorte por `snapshot_at.slice(0,10)` == dataRef=max; presentes na ordem esperadas; NCG/saldo Σ não-null da coorte + parcial; projeção união de inícios asc, soma coorte por inicio, completa vs esperadas.length, label por slice, cap 13; round só na saída). **Step 4:** ver passar.
+- [ ] **Step 5: commit** — `feat(cockpit): helper consolidarCockpit (snapshot-first, coorte, total+empresa) + testes`.
+
+---
+
+### Task 2: Service + hook + cards + rótulos
+
+**Files:** Modify `src/services/financeiroV2Service.ts`, `src/components/financeiro/cockpit/useFinanceiroCockpit.ts`, `Projecao13Card.tsx`, `DataBasisFooter.tsx`, `FinanceiroCockpit.tsx` (+ card NCG), e os rótulos A-class.
+
+- [ ] **Step 1: `getProjecaoSnapshotsCockpit(companies, cenario='realista')`** no service: por empresa, último snapshot (`order snapshot_at desc limit 1`), valida `Array.isArray(dados)`, mapeia `{company, snapshot_at, ncg, saldo_tesouraria, semanas}`. `Promise.all`.
+- [ ] **Step 2: hook** — no `loadAll`, buscar os snapshots em paralelo; remover a RPC `fin_projecao_13_semanas` e o `ncg = totalCR − totalCP`; expor `cockpit = consolidarCockpit({ esperadas: ['oben','colacor','colacor_sc'], snapshots })`; `projecao13 = cockpit.projecao13`, `ncg = cockpit.ncg_total`. Manter `totalCR/totalCP` (risco liquidez/inadimplência).
+- [ ] **Step 3: cards** — `Projecao13Card` consome o novo shape (header cenário+data_referencia+banner parcial+aviso intercompany; marca semana `completa=false`; `.length` em vez de "13"). Card NCG: `ncg_total` + badge "N/3" se `ncg_parcial` + breakdown `ncg_por_empresa`. `DataBasisFooter` dinâmico por regime. "Caixa Projetado 30d" → rename "Posição líquida (CR+CC−CP abertos)". Labels A-class (caixa disponível, regime badge, receita valor cobertura, escopo).
+- [ ] **Step 4:** `bunx tsc --noEmit -p tsconfig.app.json` + `bun lint` limpos.
+- [ ] **Step 5: commit** — `feat(cockpit): religa projeção 13s + NCG ao snapshot real (engine A1) + rótulos honestos`.
+
+---
+
+### Task 3: Docs + validação + Codex adversarial + PR
+
+- [ ] **Step 1:** seção no `FINANCEIRO_CONFIABILIDADE.md` (Cockpit religado às engines; snapshot-first; total+empresa; limitações: stale até 1 dia, intercompany não eliminado, caixa não-fungível).
+- [ ] **Step 2: validação** — `heavy bun run test` + `heavy bun run typecheck:strict` + `bunx tsc --noEmit -p tsconfig.app.json` + `bun lint` + `heavy bun run build`.
+- [ ] **Step 3: Codex ADVERSARIAL** no helper + integração (coorte/dedupe corretos? completa vs esperadas? dados inválido? hooks ok? NaN? labels honestos?). Incorporar P1/P2.
+- [ ] **Step 4: PR** — push; `gh pr create` (sem migration/deploy — snapshot já gravado pelo cron); auto-merge `--squash --auto`.
+
+---
+
+## Notas
+- **Sem migration/edge/deploy** — o snapshot diário já é gravado pelo cron `fin-cashflow-snapshot-diario` (engine com `save_snapshot`). Só consumimos.
+- Coorte por data de referência (P1.3) = a chave da coerência matemática.
+- `tsc --noEmit -p tsconfig.app.json` é o typecheck do `src`.

--- a/docs/superpowers/plans/2026-05-27-cockpit-consolidacao.md
+++ b/docs/superpowers/plans/2026-05-27-cockpit-consolidacao.md
@@ -62,17 +62,64 @@ describe('consolidarCockpit', () => {
     expect(r.projecao13[0].completa).toBe(false);       // 2 de 3 esperadas
   });
 
-  it('DEDUPE por empresa: 2 linhas de oben → fica a de snapshot_at maior, não soma 2× (P1.2)', () => {
+  it('DEDUPE latest-wins por snapshot_at, NÃO ordem do array (P1.2): mais novo vem ANTES', () => {
     const snaps = [
-      snap('oben', '2026-05-27T08:00:00Z', 100, [sem('2026-05-26', 10, 0, 110)]),
-      snap('oben', '2026-05-27T12:00:00Z', 150, [sem('2026-05-26', 15, 0, 165)]), // mais recente
+      snap('oben', '2026-05-27T12:00:00Z', 150, [sem('2026-05-26', 15, 0, 165)]), // mais recente, mas 1º no array
+      snap('oben', '2026-05-27T08:00:00Z', 100, [sem('2026-05-26', 10, 0, 110)]), // mais antigo, depois
       snap('colacor', '2026-05-27T10:00:00Z', 200, [sem('2026-05-26', 20, 0, 220)]),
       snap('colacor_sc', '2026-05-27T10:00:00Z', 50, [sem('2026-05-26', 5, 0, 55)]),
     ];
     const r = consolidarCockpit({ esperadas: ESP, snapshots: snaps });
-    expect(r.ncg_total).toBe(400);   // 150(recente)+200+50 — NÃO 100+150+...
+    expect(r.ncg_total).toBe(400);   // 150(12:00)+200+50 — falha se "última no array vence" (daria 100)
     expect(r.projecao13[0].saldo_projetado).toBe(440); // 165+220+55
     expect(r.empresas_presentes).toEqual(ESP);
+  });
+
+  it('coorte: 3 empresas no MESMO DIA com horas diferentes → todas na coorte, não parcial (P1.1)', () => {
+    const snaps = [
+      snap('oben', '2026-05-27T06:00:00Z', 100, [sem('2026-05-26', 10, 0, 110)]),
+      snap('colacor', '2026-05-27T13:30:00Z', 200, [sem('2026-05-26', 20, 0, 220)]),
+      snap('colacor_sc', '2026-05-27T23:59:00Z', 50, [sem('2026-05-26', 5, 0, 55)]),
+    ];
+    const r = consolidarCockpit({ esperadas: ESP, snapshots: snaps });
+    expect(r.parcial).toBe(false);
+    expect(r.empresas_presentes).toEqual(ESP);
+    expect(r.data_referencia).toBe('2026-05-27');
+    expect(r.ncg_total).toBe(350);
+    expect(r.projecao13[0].completa).toBe(true);
+  });
+
+  it('coorte por DATA via slice (não new Date local): snapshot_at de madrugada Z não muda o dia (P2)', () => {
+    // 2026-05-27T01:00:00Z em America/Sao_Paulo (UTC-3) seria 2026-05-26 com new Date local — deve ficar 2026-05-27
+    const snaps = [snap('oben', '2026-05-27T01:00:00Z', 0, [sem('2026-05-01', 10, 0, 10)])];
+    const r = consolidarCockpit({ esperadas: ['oben'], snapshots: snaps });
+    expect(r.data_referencia).toBe('2026-05-27');
+    expect(r.projecao13[0].semana_label).toBe('01/05'); // não '30/04' (timezone)
+  });
+
+  it('saldo_tesouraria: 0 conta, null aciona parcial (simétrico ao ncg)', () => {
+    const snaps = [
+      snap('oben', '2026-05-27T10:00:00Z', 0, [sem('2026-05-26', 0, 0, 0)], 0),
+      snap('colacor', '2026-05-27T10:00:00Z', 0, [sem('2026-05-26', 0, 0, 0)], null),
+      snap('colacor_sc', '2026-05-27T10:00:00Z', 0, [sem('2026-05-26', 0, 0, 0)], 30),
+    ];
+    const r = consolidarCockpit({ esperadas: ESP, snapshots: snaps });
+    expect(r.saldo_tesouraria_total).toBe(30); // 0 + (null fora) + 30
+    expect(r.saldo_tesouraria_parcial).toBe(true); // colacor null
+    expect(r.projecao13[0].saldo_projetado).toBe(0); // saldo 0 real não some por filtro truthy
+  });
+
+  it('stale com a MESMA semana inicio que a coorte → ainda excluído (por data, não coincidência)', () => {
+    const snaps = [
+      snap('oben', '2026-05-27T10:00:00Z', 100, [sem('2026-05-26', 10, 0, 110)]),
+      snap('colacor', '2026-05-27T10:00:00Z', 200, [sem('2026-05-26', 20, 0, 220)]),
+      snap('colacor_sc', '2026-05-20T10:00:00Z', 999, [sem('2026-05-26', 99, 0, 999)]), // stale, mesma inicio
+    ];
+    const r = consolidarCockpit({ esperadas: ESP, snapshots: snaps });
+    expect(r.empresas_stale).toEqual(['colacor_sc']);
+    expect(r.ncg_total).toBe(300);                       // 999 não entra
+    expect(r.projecao13[0].saldo_projetado).toBe(330);   // 110+220, sem o 999
+    expect(r.projecao13[0].por_empresa).toHaveLength(2);
   });
 
   it('empresa ausente (sem snapshot) → ausente + parcial; completa=false', () => {
@@ -132,10 +179,13 @@ describe('consolidarCockpit', () => {
     expect(r.data_referencia).toBeNull();
   });
 
-  it('cap em 13 semanas a partir da menor âncora', () => {
-    const semanas = Array.from({ length: 16 }, (_, i) => sem(`2026-${String(1 + Math.floor(i / 4)).padStart(2,'0')}-0${(i % 4) + 1}`, 1, 0, 1));
+  it('cap nas 13 PRIMEIRAS semanas por menor inicio (não 13 quaisquer)', () => {
+    // 16 semanas sequenciais 2026-01-01..2026-01-16
+    const semanas = Array.from({ length: 16 }, (_, i) => sem(`2026-01-${String(i + 1).padStart(2, '0')}`, 1, 0, 1));
     const r = consolidarCockpit({ esperadas: ['oben'], snapshots: [snap('oben', '2026-05-27T10:00:00Z', 0, semanas)] });
-    expect(r.projecao13.length).toBeLessThanOrEqual(13);
+    expect(r.projecao13).toHaveLength(13);
+    expect(r.projecao13[0].inicio).toBe('2026-01-01');
+    expect(r.projecao13[12].inicio).toBe('2026-01-13'); // as 13 PRIMEIRAS, não 14/15/16
   });
 });
 ```

--- a/docs/superpowers/specs/2026-05-27-cockpit-consolidacao-design.md
+++ b/docs/superpowers/specs/2026-05-27-cockpit-consolidacao-design.md
@@ -46,31 +46,33 @@ export type SemanaConsolidada = {
 };
 
 export type CockpitConsolidado = {
-  projecao13: SemanaConsolidada[];      // ordenada por inicio
-  ncg_total: number;                    // Σ ncg não-null
-  ncg_por_empresa: { company: string; ncg: number | null }[];
-  ncg_parcial: boolean;                 // algum ncg null
+  projecao13: SemanaConsolidada[];      // coorte, ordenada por inicio, no MÁXIMO 13
+  ncg_total: number;                    // Σ ncg não-null da COORTE (mínimo conhecido se parcial)
+  ncg_por_empresa: { company: string; ncg: number | null; presente: boolean }[]; // ordem = esperadas
+  ncg_parcial: boolean;
   saldo_tesouraria_total: number;
-  empresas_presentes: string[];
-  empresas_ausentes: string[];
-  parcial: boolean;                     // empresas_ausentes.length > 0
+  saldo_tesouraria_parcial: boolean;
+  empresas_presentes: string[];         // na coorte (data de referência), ordem = esperadas
+  empresas_ausentes: string[];          // sem nenhum snapshot
+  empresas_stale: string[];             // têm snapshot, mas mais antigo que a data de referência (fora da coorte)
+  parcial: boolean;                     // (ausentes ∪ stale).length > 0
+  data_referencia: string | null;       // data (YYYY-MM-DD) da coorte usada
   snapshot_at_mais_antigo: string | null;
 };
 
 export function consolidarCockpit(input: {
-  esperadas: string[];                  // ['oben','colacor','colacor_sc']
+  esperadas: string[];                  // ['oben','colacor','colacor_sc'] (ordem preservada)
   snapshots: SnapshotEmpresa[];
 }): CockpitConsolidado;
 ```
 
-Lógica:
-1. `empresas_presentes = snapshots.map(s=>s.company)` (únicas); `empresas_ausentes = esperadas − presentes`; `parcial = ausentes.length>0`.
-2. `snapshot_at_mais_antigo = min(snapshot_at)` (ISO compare) ou null se vazio.
-3. **NCG:** `ncg_por_empresa` = cada `{company, ncg}`; `ncg_total = Σ ncg dos não-null`; `ncg_parcial = parcial || algum ncg==null`. `saldo_tesouraria_total = Σ saldo_tesouraria não-null`.
-4. **Projeção:** `inicios = união ordenada (asc) de todos os s.semanas[].inicio`. Para cada `inicio`: empresas que têm essa semana → soma `total_entradas/total_saidas/saldo_final`; `por_empresa` = `{company, saldo_final}` das que têm; `completa = (nº de empresas com a semana == empresas_presentes.length)`; `semana_label` = `dd/mm` de `inicio`. **Não zera ausência**: a soma só inclui quem tem a semana; `completa=false` sinaliza. `round2` nos valores.
-5. Retorna ordenado por `inicio`.
-
-`round2(n)=Math.round((n+Number.EPSILON)*100)/100`.
+Lógica (incorpora Codex no spec — P1.1/P1.2/P1.3/P2):
+1. **Dedupe por empresa (P1.2):** `Map<company, snapshot>` mantendo o de maior `snapshot_at` (parse `Date`, não string — P2.2). Evita somar a mesma empresa 2×.
+2. **Coorte por data de referência (P1.3, o crítico):** `dataRef = max(date(snapshot_at))` (YYYY-MM-DD, via slice da string ISO — sem `new Date`/timezone). **Coorte = empresas cujo snapshot é da `dataRef`** (mesma rodada diária → mesmas âncoras de semana). Empresa com snapshot mais antigo → `empresas_stale` (NÃO entra na soma); sem snapshot → `empresas_ausentes`. `parcial = (ausentes ∪ stale).length > 0`. `empresas_presentes` = coorte, **na ordem de `esperadas`** (P3.2).
+3. **NCG:** `ncg_por_empresa` = `esperadas.map(c => {company, ncg: coorte? : null, presente})`; `ncg_total = Σ ncg da coorte (não-null)`; `ncg_parcial = parcial || algum ncg da coorte == null`.
+4. **Saldo:** `saldo_tesouraria_total = Σ saldo_tesouraria da coorte (não-null)`; `saldo_tesouraria_parcial = parcial || algum == null`.
+5. **Projeção (só a coorte):** `inicios = união ordenada asc de todos os semanas[].inicio da coorte`; valida `Array.isArray` no service (P1.4). Para cada `inicio`: soma `total_entradas/total_saidas/saldo_final` das empresas da coorte que têm a semana; `por_empresa` = `{company, saldo_final}` (coorte); **`completa = (nº empresas com a semana === esperadas.length)`** (P1.1 — relativo a TODAS as esperadas, não só presentes); `semana_label` = `dd/mm` por **split de `inicio.slice(8,10)+'/'+inicio.slice(5,7)`** (sem `new Date` — P2.3). Soma só quem tem a semana (ausente ≠ zero). **Cap em 13** semanas a partir da menor âncora (P2.5).
+6. `snapshot_at_mais_antigo` = min da coorte (parse Date). Valores monetários: somados em **bruto**, `round2` só na saída (P2.4).
 
 ## Service `src/services/financeiroV2Service.ts`
 
@@ -79,7 +81,7 @@ export async function getProjecaoSnapshotsCockpit(
   companies: Company[], cenario = 'realista'
 ): Promise<SnapshotEmpresa[]>;
 ```
-Para cada company: `SELECT company, snapshot_at, ncg, saldo_tesouraria, dados FROM fin_projecao_snapshots WHERE company=? AND cenario=? ORDER BY snapshot_at DESC LIMIT 1`. Mapeia `dados` (Json) → `semanas` (extrai `{inicio, total_entradas, total_saidas, saldo_final}` de cada). Empresa sem linha → não entra (o helper marca ausente). Uma query por empresa (`Promise.all`) ou `.in('company',...)` + dedup do mais recente por empresa client-side.
+Para cada company: `SELECT company, snapshot_at, ncg, saldo_tesouraria, dados FROM fin_projecao_snapshots WHERE company=? AND cenario=? ORDER BY snapshot_at DESC LIMIT 1`. **Valida `Array.isArray(dados)` (P1.4)** → mapeia cada item para `{inicio, total_entradas, total_saidas, saldo_final}` (coage números, ignora item sem `inicio`); `dados` não-array → `semanas: []` (empresa entra no NCG mas sem projeção; helper trata). Empresa sem linha → não retorna (helper marca ausente). Uma query por empresa (`Promise.all`). Tipo do param = `Company[]` (os 3 códigos).
 
 ## Hook `useFinanceiroCockpit.ts`
 
@@ -89,10 +91,11 @@ Para cada company: `SELECT company, snapshot_at, ncg, saldo_tesouraria, dados FR
 
 ## UI
 
-- **`Projecao13Card`:** consome o novo shape (já tem `semana_label/entradas_previstas/saidas_previstas/saldo_projetado`) + header "Cenário: realista · dados de {snapshot_at}" + (opcional) expandir por-empresa por semana. Banner se `parcial`.
-- **Card de NCG:** mostra `ncg_total` + breakdown por empresa + aviso "não elimina intercompany". Substitui o número CR−CP.
+- **Bloco consolidado (header):** "Consolidado 3 CNPJ · Cenário: realista · dados de {data_referencia}" + **aviso de intercompany no bloco INTEIRO** (P2.6 — o double-count afeta projeção E NCG, não só NCG) + **banner de parcialidade** se `parcial` ("N de 3 empresas — ausentes/stale: …; números são mínimo conhecido").
+- **`Projecao13Card`:** consome o novo shape (`semana_label/entradas_previstas/saidas_previstas/saldo_projetado`); marca visualmente semanas com `completa=false`; não hardcoda "13" (usa `.length`).
+- **Card de NCG:** `ncg_total` **com badge "N/3" quando `ncg_parcial`** (P1.5 — total parcial não pode parecer definitivo) + breakdown `ncg_por_empresa` (presente/ausente). Substitui o número CR−CP.
 - **`DataBasisFooter`:** texto dinâmico pelo `regime` ativo (não "regime de caixa" fixo).
-- **"Caixa Projetado 30d":** renomear para "Posição líquida (abertos)" OU aplicar janela 30d real (decidir no plano — provável rename, trivial).
+- **"Caixa Projetado 30d":** **renomear** para "Posição líquida (CR+CC−CP abertos)" (P3.4 — rename é o seguro; o número atual não é janela de 30d).
 - **Labels (A-class):** "caixa disponível" (saldo bancário) vs A4/Funding (alocável pós-reserva) — rótulos; badge de regime ativo perto dos KPIs do Cockpit; "receita (vendas no app, cobertura X%)" no Cockpit de Valor; escopo "Consolidado 3 CNPJ" no título.
 
 ## Não-objetivos (v1)

--- a/docs/superpowers/specs/2026-05-27-cockpit-consolidacao-design.md
+++ b/docs/superpowers/specs/2026-05-27-cockpit-consolidacao-design.md
@@ -1,0 +1,110 @@
+# Cockpit Financeiro — Consolidação (religar às engines) — Design
+
+> **Status:** design (escopo ENXUTO aprovado por delegação founder+Codex). Metodologia revisada por Codex. Próximo: Codex no spec → plano → Codex no plano → execução → adversarial → PR. **Codex em todas as etapas.**
+
+## Objetivo
+
+O Cockpit financeiro (`/financeiro/cockpit`, consolidado das 3 empresas, usado semanalmente) mostra **números errados** porque foi construído com atalhos antes das engines A1 existirem:
+- **Projeção 13s:** RPC ingênua `fin_projecao_13_semanas` (joga CR/CP no vencimento; sem curva de cobrança, inadimplência, eventos, folha).
+- **NCG:** `totalCR − totalCP` (só abertos), em vez de `ACO − PCO` (com estoque/folha/tributos).
+
+Religar o Cockpit às engines (via **snapshot diário**), mantendo-o consolidado mas **honesto sobre a não-fungibilidade de caixa entre CNPJs** (Codex P1).
+
+## Decisões de metodologia (Codex)
+
+1. **Snapshot-first (não 3 invocações live):** lê o último `fin_projecao_snapshots` (cenário `realista`) das 3 empresas. Tela executiva semanal → confiável/rápida > fresca-ao-segundo. Exibe **"dados de {snapshot_at}"**. Live/cenários continua sendo a tela **Capital de Giro**.
+2. **Total + decomposição POR EMPRESA (Codex P1 — não fingir caixa único):** somar caixa entre 3 CNPJs distintos pode esconder insolvência local. Mostra o consolidado **e** a quebra por empresa (projeção e NCG).
+3. **Cenário explícito:** label "Cenário: realista" (sem toggle no v1 — Capital de Giro tem). O pior estado é mostrar número de cenário sem dizer qual.
+4. **Intercompany — premissa documentada:** v1 **NÃO elimina** intercompany (CR de colacor pode ser CP de colacor_sc → potencial double-count). Aviso textual; eliminação = futuro.
+5. **Falha parcial honesta:** se faltar snapshot de uma empresa → banner "X de 3 empresas" + cards marcados parciais; **não zera silenciosamente** (ausente ≠ zero).
+6. **Bordas:** alinhar semanas por **data `inicio`** (não índice); `ncg` null de uma empresa → fora da soma + flag; staleness = mostrar o snapshot mais antigo.
+
+## Fonte (verificado)
+
+`fin_projecao_snapshots` (gravado pelo cron `fin-cashflow-snapshot-diario` via `fin-cashflow-engine` com `save_snapshot`): colunas `company`, `cenario`, `snapshot_at`, **`dados` (Json = `semanas[]`)**, **`ncg` (número = `ncg.valor` = ACO−PCO)**, `saldo_tesouraria`, `liquidez_operacional_liquida`, `dias_cobertura`. Cada `semana` = `{inicio, fim, total_entradas, total_saidas, saldo_final, ...}`. A decomposição ACO/PCO detalhada NÃO está no snapshot (fica na tela Capital de Giro) — o Cockpit só precisa do **valor** do NCG + a projeção.
+
+## Helper puro `src/lib/financeiro/cockpit-consolida-helpers.ts` (TDD)
+
+```ts
+export type SnapshotSemana = { inicio: string; total_entradas: number; total_saidas: number; saldo_final: number };
+export type SnapshotEmpresa = {
+  company: string;
+  snapshot_at: string;
+  ncg: number | null;
+  saldo_tesouraria: number | null;
+  semanas: SnapshotSemana[];
+};
+
+export type SemanaConsolidada = {
+  inicio: string;
+  semana_label: string;                 // "dd/mm" (do inicio)
+  entradas_previstas: number;
+  saidas_previstas: number;
+  saldo_projetado: number;              // Σ saldo_final das presentes
+  por_empresa: { company: string; saldo_final: number }[];
+  completa: boolean;                    // todas as empresas presentes têm essa semana
+};
+
+export type CockpitConsolidado = {
+  projecao13: SemanaConsolidada[];      // ordenada por inicio
+  ncg_total: number;                    // Σ ncg não-null
+  ncg_por_empresa: { company: string; ncg: number | null }[];
+  ncg_parcial: boolean;                 // algum ncg null
+  saldo_tesouraria_total: number;
+  empresas_presentes: string[];
+  empresas_ausentes: string[];
+  parcial: boolean;                     // empresas_ausentes.length > 0
+  snapshot_at_mais_antigo: string | null;
+};
+
+export function consolidarCockpit(input: {
+  esperadas: string[];                  // ['oben','colacor','colacor_sc']
+  snapshots: SnapshotEmpresa[];
+}): CockpitConsolidado;
+```
+
+Lógica:
+1. `empresas_presentes = snapshots.map(s=>s.company)` (únicas); `empresas_ausentes = esperadas − presentes`; `parcial = ausentes.length>0`.
+2. `snapshot_at_mais_antigo = min(snapshot_at)` (ISO compare) ou null se vazio.
+3. **NCG:** `ncg_por_empresa` = cada `{company, ncg}`; `ncg_total = Σ ncg dos não-null`; `ncg_parcial = parcial || algum ncg==null`. `saldo_tesouraria_total = Σ saldo_tesouraria não-null`.
+4. **Projeção:** `inicios = união ordenada (asc) de todos os s.semanas[].inicio`. Para cada `inicio`: empresas que têm essa semana → soma `total_entradas/total_saidas/saldo_final`; `por_empresa` = `{company, saldo_final}` das que têm; `completa = (nº de empresas com a semana == empresas_presentes.length)`; `semana_label` = `dd/mm` de `inicio`. **Não zera ausência**: a soma só inclui quem tem a semana; `completa=false` sinaliza. `round2` nos valores.
+5. Retorna ordenado por `inicio`.
+
+`round2(n)=Math.round((n+Number.EPSILON)*100)/100`.
+
+## Service `src/services/financeiroV2Service.ts`
+
+```ts
+export async function getProjecaoSnapshotsCockpit(
+  companies: Company[], cenario = 'realista'
+): Promise<SnapshotEmpresa[]>;
+```
+Para cada company: `SELECT company, snapshot_at, ncg, saldo_tesouraria, dados FROM fin_projecao_snapshots WHERE company=? AND cenario=? ORDER BY snapshot_at DESC LIMIT 1`. Mapeia `dados` (Json) → `semanas` (extrai `{inicio, total_entradas, total_saidas, saldo_final}` de cada). Empresa sem linha → não entra (o helper marca ausente). Uma query por empresa (`Promise.all`) ou `.in('company',...)` + dedup do mais recente por empresa client-side.
+
+## Hook `useFinanceiroCockpit.ts`
+
+- **Remove** a RPC `fin_projecao_13_semanas` e o `ncg = totalCR − totalCP`.
+- Adiciona fetch de `getProjecaoSnapshotsCockpit(['oben','colacor','colacor_sc'])` (no `loadAll` existente, em paralelo) → `consolidarCockpit` → expõe `cockpit` (CockpitConsolidado). `projecao13` passa a vir de `cockpit.projecao13`; `ncg` de `cockpit.ncg_total`.
+- Mantém `totalCR/totalCP` (ainda usados em risco de liquidez/inadimplência), mas o **card de NCG** usa `ncg_total` (real).
+
+## UI
+
+- **`Projecao13Card`:** consome o novo shape (já tem `semana_label/entradas_previstas/saidas_previstas/saldo_projetado`) + header "Cenário: realista · dados de {snapshot_at}" + (opcional) expandir por-empresa por semana. Banner se `parcial`.
+- **Card de NCG:** mostra `ncg_total` + breakdown por empresa + aviso "não elimina intercompany". Substitui o número CR−CP.
+- **`DataBasisFooter`:** texto dinâmico pelo `regime` ativo (não "regime de caixa" fixo).
+- **"Caixa Projetado 30d":** renomear para "Posição líquida (abertos)" OU aplicar janela 30d real (decidir no plano — provável rename, trivial).
+- **Labels (A-class):** "caixa disponível" (saldo bancário) vs A4/Funding (alocável pós-reserva) — rótulos; badge de regime ativo perto dos KPIs do Cockpit; "receita (vendas no app, cobertura X%)" no Cockpit de Valor; escopo "Consolidado 3 CNPJ" no título.
+
+## Não-objetivos (v1)
+- Eliminação de intercompany (documentado como premissa).
+- Toggle de cenário / botão "atualizar agora" live (Capital de Giro já é a tela live/cenários).
+- Decomposição ACO/PCO no Cockpit (fica no Capital de Giro).
+- Drilldown empresa→semana→categoria (Codex sugeriu como ideal futuro).
+
+## Limitações documentadas
+- **Snapshot até 1 dia stale** (mostra `snapshot_at`); se o cron falhar, o Cockpit mostra dado velho com a data — honesto.
+- **Caixa consolidado não é fungível** entre CNPJs (por isso o breakdown por empresa).
+- **Intercompany não eliminado** (pode inflar CR/CP consolidados).
+
+## Validação / entrega
+TDD no helper (vitest). `heavy bun run test` + `typecheck:strict` + `tsc -p tsconfig.app.json` + `bun lint` + `build`. Codex adversarial. Docs em `FINANCEIRO_CONFIABILIDADE`. PR client-side (sem migration/deploy — o snapshot já é gravado pelo cron existente) + auto-merge `--squash --auto`.

--- a/src/components/financeiro/cashflow/NcgDecomposicao.tsx
+++ b/src/components/financeiro/cashflow/NcgDecomposicao.tsx
@@ -56,7 +56,13 @@ export function NcgDecomposicao() {
         <Card>
           <CardHeader><CardTitle className="text-xs">NCG (ACO − PCO)</CardTitle></CardHeader>
           <CardContent>
-            <div className={`text-2xl font-mono ${data.ncg.valor < 0 ? 'text-status-error' : 'text-status-success'}`}>
+            <div className={`text-2xl font-mono ${
+              data.ncg.valor <= 0
+                ? 'text-status-success'
+                : data.ncg.valor > data.indicadores.liquidez_operacional_liquida
+                ? 'text-status-warning'
+                : 'text-foreground'
+            }`}>
               {formatBRL(data.ncg.valor)}
             </div>
             <div className="text-xs text-muted-foreground mt-1">

--- a/src/components/financeiro/cockpit/DataBasisFooter.tsx
+++ b/src/components/financeiro/cockpit/DataBasisFooter.tsx
@@ -1,12 +1,12 @@
 // Rodapé "Base dos números" do Cockpit financeiro.
-// Extraído verbatim de src/pages/FinanceiroCockpit.tsx (god-component split).
 import { Info } from 'lucide-react';
 
-export function DataBasisFooter() {
+export function DataBasisFooter({ regime }: { regime: 'caixa' | 'competencia' }) {
+  const regimeLabel = regime === 'caixa' ? 'regime de caixa (pagamento/recebimento efetivo)' : 'regime de competência (data de emissão)';
   return (
     <div className="text-xs text-muted-foreground bg-muted/30 p-3 rounded-lg space-y-1">
       <p className="font-medium flex items-center gap-1"><Info className="w-3 h-3" /> Base dos números</p>
-      <p>Saldo bancário: consulta direta Omie (ResumirContaCorrente). CR/CP: títulos sincronizados (últimos 6 meses). DRE: regime de caixa (pagamento/recebimento efetivo). Projeção 13 semanas: baseada em vencimentos de títulos abertos.</p>
+      <p>Saldo bancário: consulta direta Omie (ResumirContaCorrente). CR/CP: títulos sincronizados. DRE: {regimeLabel} — alterne no seletor acima. Projeção 13 semanas + NCG: engine A1 (snapshot diário; curvas de cobrança calibradas, inadimplência, eventos, folha), consolidado das 3 empresas.</p>
       <p>Para números de controller, verifique: % mapeado ≥ 80%, conciliação ≥ 70%, mês fechado.</p>
     </div>
   );

--- a/src/components/financeiro/cockpit/Projecao13Card.tsx
+++ b/src/components/financeiro/cockpit/Projecao13Card.tsx
@@ -1,25 +1,43 @@
-// Card de projeção de caixa — 13 semanas.
-// Extraído verbatim de src/pages/FinanceiroCockpit.tsx (god-component split).
+// Card de projeção de caixa — 13 semanas (consolidado das 3 empresas via snapshot da engine A1).
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { Target, AlertTriangle } from 'lucide-react';
 import { fmtCompact } from './format';
-import type { FinProjecaoSemana } from './types';
+import type { SemanaConsolidada } from '@/lib/financeiro/cockpit-consolida-helpers';
 
 interface Projecao13CardProps {
-  projecao13: FinProjecaoSemana[];
+  projecao13: SemanaConsolidada[];
+  dataReferencia: string | null;
+  parcial: boolean;
+  empresasAusentes: string[];
+  empresasStale: string[];
 }
 
-export function Projecao13Card({ projecao13 }: Projecao13CardProps) {
+const labelData = (iso: string | null) => (iso ? `${iso.slice(8, 10)}/${iso.slice(5, 7)}/${iso.slice(0, 4)}` : '—');
+
+export function Projecao13Card({ projecao13, dataReferencia, parcial, empresasAusentes, empresasStale }: Projecao13CardProps) {
+  const negativas = projecao13.filter((w) => w.saldo_projetado < 0);
+  const foraDaCoorte = [...empresasAusentes, ...empresasStale];
   return (
     <Card>
       <CardHeader className="pb-3">
-        <CardTitle className="text-base flex items-center gap-2">
+        <CardTitle className="text-base flex flex-wrap items-center gap-2">
           <Target className="w-4 h-4" />
-          Projeção de Caixa — 13 Semanas
-          <Badge variant="outline" className="text-[10px]">Consolidado · Baseado em CR/CP abertos</Badge>
+          Projeção de Caixa — {projecao13.length} Semanas
+          <Badge variant="outline" className="text-[10px]">Consolidado 3 CNPJ · Cenário: realista</Badge>
+          <Badge variant="outline" className="text-[10px] text-muted-foreground">dados de {labelData(dataReferencia)}</Badge>
         </CardTitle>
+        <p className="text-[11px] text-muted-foreground">
+          Caixa somado das 3 empresas (engine A1: curvas de cobrança, inadimplência, eventos). Não é caixa fungível
+          entre CNPJs nem elimina lançamentos intercompany — veja a quebra por empresa.
+        </p>
+        {parcial && (
+          <p className="text-[11px] text-status-warning">
+            Parcial: {projecao13[0]?.por_empresa.length ?? 0} de 3 empresas na coorte. Fora: {foraDaCoorte.join(', ') || '—'}
+            {empresasStale.length > 0 && ' (stale = snapshot mais antigo)'}. Números são mínimo conhecido.
+          </p>
+        )}
       </CardHeader>
       <CardContent>
         <div className="overflow-x-auto">
@@ -34,29 +52,35 @@ export function Projecao13Card({ projecao13 }: Projecao13CardProps) {
               </TableRow>
             </TableHeader>
             <TableBody>
-              {projecao13.map((w, i) => (
-                <TableRow key={i} className={w.saldo_projetado < 0 ? 'bg-status-error-bg' : ''}>
-                  <TableCell className="text-xs">{w.semana_label}</TableCell>
-                  <TableCell className="text-right text-sm text-status-success">{fmtCompact(w.entradas_previstas)}</TableCell>
-                  <TableCell className="text-right text-sm text-status-error">{fmtCompact(w.saidas_previstas)}</TableCell>
-                  <TableCell className={`text-right text-sm font-medium ${w.fluxo_liquido >= 0 ? 'text-status-success' : 'text-status-error'}`}>
-                    {fmtCompact(w.fluxo_liquido)}
-                  </TableCell>
-                  <TableCell className={`text-right text-sm font-bold ${w.saldo_projetado >= 0 ? 'text-status-info' : 'text-status-error'}`}>
-                    {fmtCompact(w.saldo_projetado)}
-                    {w.saldo_projetado < 0 && <AlertTriangle className="inline w-3 h-3 ml-1 text-status-error" />}
-                  </TableCell>
-                </TableRow>
-              ))}
+              {projecao13.map((w, i) => {
+                const fluxo = w.entradas_previstas - w.saidas_previstas;
+                return (
+                  <TableRow key={i} className={w.saldo_projetado < 0 ? 'bg-status-error-bg' : ''}>
+                    <TableCell className="text-xs">
+                      {w.semana_label}
+                      {!w.completa && <span className="ml-1 text-[9px] text-status-warning" title="Nem todas as empresas têm esta semana">parc.</span>}
+                    </TableCell>
+                    <TableCell className="text-right text-sm text-status-success">{fmtCompact(w.entradas_previstas)}</TableCell>
+                    <TableCell className="text-right text-sm text-status-error">{fmtCompact(w.saidas_previstas)}</TableCell>
+                    <TableCell className={`text-right text-sm font-medium ${fluxo >= 0 ? 'text-status-success' : 'text-status-error'}`}>
+                      {fmtCompact(fluxo)}
+                    </TableCell>
+                    <TableCell className={`text-right text-sm font-bold ${w.saldo_projetado >= 0 ? 'text-status-info' : 'text-status-error'}`}>
+                      {fmtCompact(w.saldo_projetado)}
+                      {w.saldo_projetado < 0 && <AlertTriangle className="inline w-3 h-3 ml-1 text-status-error" />}
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
             </TableBody>
           </Table>
         </div>
-        {projecao13.some((w) => w.saldo_projetado < 0) && (
+        {negativas.length > 0 && (
           <div className="mt-3 p-3 rounded-lg bg-status-error-bg border border-status-error/20 flex items-start gap-2">
             <AlertTriangle className="w-4 h-4 text-status-error mt-0.5 shrink-0" />
             <p className="text-sm text-status-error-fg">
-              Projeção indica saldo negativo em {projecao13.filter((w) => w.saldo_projetado < 0).length} semana(s).
-              Ação necessária antes de {projecao13.find((w) => w.saldo_projetado < 0)?.semana_label}.
+              Projeção indica saldo negativo em {negativas.length} semana(s).
+              Ação necessária antes de {negativas[0]?.semana_label}.
             </p>
           </div>
         )}

--- a/src/components/financeiro/cockpit/Projecao13Card.tsx
+++ b/src/components/financeiro/cockpit/Projecao13Card.tsx
@@ -10,13 +10,23 @@ interface Projecao13CardProps {
   projecao13: SemanaConsolidada[];
   dataReferencia: string | null;
   parcial: boolean;
+  empresasPresentes: string[];
   empresasAusentes: string[];
   empresasStale: string[];
 }
 
 const labelData = (iso: string | null) => (iso ? `${iso.slice(8, 10)}/${iso.slice(5, 7)}/${iso.slice(0, 4)}` : '—');
+// Defasagem honesta (Codex P3): snapshot mais velho que ontem.
+const diasAtras = (iso: string | null): number | null => {
+  if (!iso) return null;
+  const hoje = new Date();
+  const hojeStr = `${hoje.getFullYear()}-${String(hoje.getMonth() + 1).padStart(2, '0')}-${String(hoje.getDate()).padStart(2, '0')}`;
+  const diff = (Date.parse(hojeStr) - Date.parse(iso)) / 86400000;
+  return Number.isFinite(diff) ? Math.round(diff) : null;
+};
 
-export function Projecao13Card({ projecao13, dataReferencia, parcial, empresasAusentes, empresasStale }: Projecao13CardProps) {
+export function Projecao13Card({ projecao13, dataReferencia, parcial, empresasPresentes, empresasAusentes, empresasStale }: Projecao13CardProps) {
+  const defasagem = diasAtras(dataReferencia);
   const negativas = projecao13.filter((w) => w.saldo_projetado < 0);
   const foraDaCoorte = [...empresasAusentes, ...empresasStale];
   return (
@@ -26,7 +36,9 @@ export function Projecao13Card({ projecao13, dataReferencia, parcial, empresasAu
           <Target className="w-4 h-4" />
           Projeção de Caixa — {projecao13.length} Semanas
           <Badge variant="outline" className="text-[10px]">Consolidado 3 CNPJ · Cenário: realista</Badge>
-          <Badge variant="outline" className="text-[10px] text-muted-foreground">dados de {labelData(dataReferencia)}</Badge>
+          <Badge variant="outline" className={`text-[10px] ${defasagem != null && defasagem > 1 ? 'text-status-warning border-status-warning/50' : 'text-muted-foreground'}`}>
+            dados de {labelData(dataReferencia)}{defasagem != null && defasagem > 1 ? ` · ${defasagem}d atrás` : ''}
+          </Badge>
         </CardTitle>
         <p className="text-[11px] text-muted-foreground">
           Caixa somado das 3 empresas (engine A1: curvas de cobrança, inadimplência, eventos). Não é caixa fungível
@@ -34,7 +46,7 @@ export function Projecao13Card({ projecao13, dataReferencia, parcial, empresasAu
         </p>
         {parcial && (
           <p className="text-[11px] text-status-warning">
-            Parcial: {projecao13[0]?.por_empresa.length ?? 0} de 3 empresas na coorte. Fora: {foraDaCoorte.join(', ') || '—'}
+            Parcial: {empresasPresentes.length} de 3 empresas na coorte. Fora: {foraDaCoorte.join(', ') || '—'}
             {empresasStale.length > 0 && ' (stale = snapshot mais antigo)'}. Números são mínimo conhecido.
           </p>
         )}

--- a/src/components/financeiro/cockpit/__tests__/Projecao13Card.test.tsx
+++ b/src/components/financeiro/cockpit/__tests__/Projecao13Card.test.tsx
@@ -16,7 +16,7 @@ function makeWeek(o: Partial<SemanaConsolidada> = {}): SemanaConsolidada {
   };
 }
 
-const baseProps = { dataReferencia: "2026-05-27", parcial: false, empresasAusentes: [], empresasStale: [] };
+const baseProps = { dataReferencia: "2026-05-27", parcial: false, empresasPresentes: ["oben", "colacor", "colacor_sc"], empresasAusentes: [], empresasStale: [] };
 
 describe("Projecao13Card", () => {
   it("renderiza semanas", () => {
@@ -41,6 +41,7 @@ describe("Projecao13Card", () => {
         projecao13={[makeWeek({ completa: false })]}
         dataReferencia="2026-05-27"
         parcial
+        empresasPresentes={["oben", "colacor"]}
         empresasAusentes={["colacor_sc"]}
         empresasStale={[]}
       />,

--- a/src/components/financeiro/cockpit/__tests__/Projecao13Card.test.tsx
+++ b/src/components/financeiro/cockpit/__tests__/Projecao13Card.test.tsx
@@ -1,22 +1,26 @@
 import { describe, it, expect } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { Projecao13Card } from "../Projecao13Card";
-import type { FinProjecaoSemana } from "../types";
+import type { SemanaConsolidada } from "@/lib/financeiro/cockpit-consolida-helpers";
 
-function makeWeek(o: Partial<FinProjecaoSemana> = {}): FinProjecaoSemana {
+function makeWeek(o: Partial<SemanaConsolidada> = {}): SemanaConsolidada {
   return {
+    inicio: "2026-05-26",
     semana_label: "S1",
     entradas_previstas: 1000,
     saidas_previstas: 500,
-    fluxo_liquido: 500,
     saldo_projetado: 500,
+    por_empresa: [{ company: "oben", saldo_final: 500 }],
+    completa: true,
     ...o,
-  } as unknown as FinProjecaoSemana;
+  };
 }
+
+const baseProps = { dataReferencia: "2026-05-27", parcial: false, empresasAusentes: [], empresasStale: [] };
 
 describe("Projecao13Card", () => {
   it("renderiza semanas", () => {
-    render(<Projecao13Card projecao13={[makeWeek(), makeWeek({ semana_label: "S2" })]} />);
+    render(<Projecao13Card projecao13={[makeWeek(), makeWeek({ semana_label: "S2" })]} {...baseProps} />);
     expect(screen.getByText("S1")).toBeTruthy();
     expect(screen.getByText("S2")).toBeTruthy();
   });
@@ -24,9 +28,23 @@ describe("Projecao13Card", () => {
   it("mostra alerta quando há saldo negativo", () => {
     render(
       <Projecao13Card
-        projecao13={[makeWeek({ semana_label: "S3", fluxo_liquido: -1000, saldo_projetado: -500 })]}
+        projecao13={[makeWeek({ semana_label: "S3", saldo_projetado: -500 })]}
+        {...baseProps}
       />,
     );
     expect(screen.getByText(/saldo negativo em 1 semana/)).toBeTruthy();
+  });
+
+  it("mostra banner de parcialidade quando parcial", () => {
+    render(
+      <Projecao13Card
+        projecao13={[makeWeek({ completa: false })]}
+        dataReferencia="2026-05-27"
+        parcial
+        empresasAusentes={["colacor_sc"]}
+        empresasStale={[]}
+      />,
+    );
+    expect(screen.getByText(/Parcial/)).toBeTruthy();
   });
 });

--- a/src/components/financeiro/cockpit/useFinanceiroCockpit.ts
+++ b/src/components/financeiro/cockpit/useFinanceiroCockpit.ts
@@ -2,7 +2,7 @@
 // Extraído verbatim de src/pages/FinanceiroCockpit.tsx (god-component split):
 // state, loadAll (resumo/aging/DRE/inadimplentes/projeção 13s/confiabilidade) e
 // todos os derivados consolidados.
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { type Company } from '@/contexts/CompanyContext';
 import { supabase } from '@/integrations/supabase/client';
 import { getResumoFinanceiro, getAgingReceber, getDRE, getTopInadimplentes, type FinResumo, type AgingData, type FinDRE } from '@/services/financeiroService';
@@ -14,9 +14,10 @@ import type { DrillDownType } from '@/components/financeiro/CockpitDrillDown';
 import type { FinConfiabilidadeRow, InadimplenteRow } from './types';
 
 const EMPRESAS_COCKPIT: Company[] = ['oben', 'colacor', 'colacor_sc'];
+// Default = indisponível/parcial (Codex P1): em falha de carga, NCG não pode aparecer como R$0 "saudável".
 const COCKPIT_VAZIO: CockpitConsolidado = {
-  projecao13: [], ncg_total: 0, ncg_por_empresa: [], ncg_parcial: false,
-  saldo_tesouraria_total: 0, saldo_tesouraria_parcial: false,
+  projecao13: [], ncg_total: 0, ncg_por_empresa: [], ncg_parcial: true,
+  saldo_tesouraria_total: 0, saldo_tesouraria_parcial: true,
   empresas_presentes: [], empresas_ausentes: [...EMPRESAS_COCKPIT], empresas_stale: [],
   parcial: true, data_referencia: null, snapshot_at_mais_antigo: null,
 };
@@ -34,10 +35,14 @@ export function useFinanceiroCockpit() {
   const { regime } = useFinanceiroRegime();
   const ano = new Date().getFullYear();
   const mes = new Date().getMonth() + 1;
+  // Guard de race (Codex P2): toggle rápido de regime pode resolver fora de ordem;
+  // só o último loadAll aplica os setters.
+  const loadIdRef = useRef(0);
 
   useEffect(() => { loadAll(); }, [regime]);
 
   const loadAll = async () => {
+    const loadId = ++loadIdRef.current;
     setLoading(true);
     try {
       const [res, ag, dr, inad, snaps] = await Promise.all([
@@ -51,6 +56,7 @@ export function useFinanceiroCockpit() {
           return [];
         }),
       ]);
+      if (loadId !== loadIdRef.current) return; // resposta obsoleta — descarta
       setResumo(res);
       setAging(ag);
       setDre(dr);

--- a/src/components/financeiro/cockpit/useFinanceiroCockpit.ts
+++ b/src/components/financeiro/cockpit/useFinanceiroCockpit.ts
@@ -6,10 +6,20 @@ import { useState, useEffect } from 'react';
 import { type Company } from '@/contexts/CompanyContext';
 import { supabase } from '@/integrations/supabase/client';
 import { getResumoFinanceiro, getAgingReceber, getDRE, getTopInadimplentes, type FinResumo, type AgingData, type FinDRE } from '@/services/financeiroService';
+import { getProjecaoSnapshotsCockpit } from '@/services/financeiroV2Service';
+import { consolidarCockpit, type CockpitConsolidado } from '@/lib/financeiro/cockpit-consolida-helpers';
 import { useFinanceiroRegime } from '@/hooks/useFinanceiroRegime';
 import { logger } from '@/lib/logger';
 import type { DrillDownType } from '@/components/financeiro/CockpitDrillDown';
-import type { FinConfiabilidadeRow, FinProjecaoSemana, InadimplenteRow } from './types';
+import type { FinConfiabilidadeRow, InadimplenteRow } from './types';
+
+const EMPRESAS_COCKPIT: Company[] = ['oben', 'colacor', 'colacor_sc'];
+const COCKPIT_VAZIO: CockpitConsolidado = {
+  projecao13: [], ncg_total: 0, ncg_por_empresa: [], ncg_parcial: false,
+  saldo_tesouraria_total: 0, saldo_tesouraria_parcial: false,
+  empresas_presentes: [], empresas_ausentes: [...EMPRESAS_COCKPIT], empresas_stale: [],
+  parcial: true, data_referencia: null, snapshot_at_mais_antigo: null,
+};
 
 export function useFinanceiroCockpit() {
   const [loading, setLoading] = useState(true);
@@ -17,7 +27,7 @@ export function useFinanceiroCockpit() {
   const [aging, setAging] = useState<AgingData | null>(null);
   const [dre, setDre] = useState<FinDRE[]>([]);
   const [inadimplentes, setInadimplentes] = useState<InadimplenteRow[]>([]);
-  const [projecao13, setProjecao13] = useState<FinProjecaoSemana[]>([]);
+  const [cockpit, setCockpit] = useState<CockpitConsolidado>(COCKPIT_VAZIO);
   const [confiabilidade, setConfiabilidade] = useState<FinConfiabilidadeRow[]>([]);
   const [drillDown, setDrillDown] = useState<DrillDownType>(null);
 
@@ -30,27 +40,22 @@ export function useFinanceiroCockpit() {
   const loadAll = async () => {
     setLoading(true);
     try {
-      const [res, ag, dr, inad] = await Promise.all([
+      const [res, ag, dr, inad, snaps] = await Promise.all([
         getResumoFinanceiro(['oben', 'colacor', 'colacor_sc']),
         getAgingReceber('all'),
         Promise.all(['oben', 'colacor', 'colacor_sc'].map(co => getDRE(co as Company, ano, undefined, regime))).then(r => r.flat()),
         getTopInadimplentes('all', 5),
+        // Projeção 13s + NCG consolidados via snapshot real da engine A1 (não a RPC ingênua)
+        getProjecaoSnapshotsCockpit(EMPRESAS_COCKPIT).catch((e) => {
+          logger.warn('Snapshots de projeção indisponíveis', { error: e instanceof Error ? e.message : String(e) });
+          return [];
+        }),
       ]);
       setResumo(res);
       setAging(ag);
       setDre(dr);
       setInadimplentes(inad);
-
-      // 13-week projection via RPC
-      try {
-        const { data: proj } = await supabase.rpc('fin_projecao_13_semanas', {});
-        setProjecao13(proj ?? []);
-      } catch (e) {
-        // RPC pode não existir ainda — registra para visibilidade em vez de falhar silencioso
-        logger.warn('RPC fin_projecao_13_semanas indisponível', {
-          error: e instanceof Error ? e.message : String(e),
-        });
-      }
+      setCockpit(consolidarCockpit({ esperadas: EMPRESAS_COCKPIT, snapshots: snaps }));
 
       // Confiabilidade for current month per company
       const confResults: FinConfiabilidadeRow[] = [];
@@ -84,7 +89,8 @@ export function useFinanceiroCockpit() {
   const totalCR = Object.values(resumo).reduce((s, r) => s + r.total_a_receber, 0);
   const totalCP = Object.values(resumo).reduce((s, r) => s + r.total_a_pagar, 0);
   const totalVencidoCR = Object.values(resumo).reduce((s, r) => s + r.total_vencido_receber, 0);
-  const ncg = totalCR - totalCP; // Necessidade de capital de giro
+  // NCG real (ACO−PCO) consolidado da engine A1, não o CR−CP ingênuo
+  const ncg = cockpit.ncg_total;
   const pctInadimplencia = totalCR > 0 ? (totalVencidoCR / totalCR) * 100 : 0;
 
   // DRE do mês mais recente
@@ -120,9 +126,10 @@ export function useFinanceiroCockpit() {
 
   return {
     loading,
+    regime,
     confiabilidade,
     dreConsolidado,
-    projecao13,
+    cockpit,
     inadimplentes,
     drillDown,
     setDrillDown,

--- a/src/lib/financeiro/__tests__/cockpit-consolida-helpers.test.ts
+++ b/src/lib/financeiro/__tests__/cockpit-consolida-helpers.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect } from 'vitest';
+import { consolidarCockpit, type SnapshotEmpresa } from '../cockpit-consolida-helpers';
+
+const sem = (inicio: string, ent: number, sai: number, saldo: number) =>
+  ({ inicio, total_entradas: ent, total_saidas: sai, saldo_final: saldo });
+const snap = (company: string, at: string, ncg: number | null, semanas: ReturnType<typeof sem>[], saldo_tes: number | null = 0): SnapshotEmpresa =>
+  ({ company, snapshot_at: at, ncg, saldo_tesouraria: saldo_tes, semanas });
+const ESP = ['oben', 'colacor', 'colacor_sc'];
+
+describe('consolidarCockpit', () => {
+  it('consolida 3 empresas mesma data: soma por semana + NCG; completa=true; não parcial', () => {
+    const snaps = [
+      snap('oben', '2026-05-27T10:00:00Z', 100, [sem('2026-05-26', 10, 5, 105), sem('2026-06-02', 20, 5, 120)], 50),
+      snap('colacor', '2026-05-27T10:01:00Z', 200, [sem('2026-05-26', 30, 10, 220), sem('2026-06-02', 0, 0, 220)], 80),
+      snap('colacor_sc', '2026-05-27T10:02:00Z', 50, [sem('2026-05-26', 5, 1, 54), sem('2026-06-02', 5, 1, 58)], 20),
+    ];
+    const r = consolidarCockpit({ esperadas: ESP, snapshots: snaps });
+    expect(r.parcial).toBe(false);
+    expect(r.empresas_presentes).toEqual(ESP);
+    expect(r.ncg_total).toBe(350);
+    expect(r.ncg_parcial).toBe(false);
+    expect(r.saldo_tesouraria_total).toBe(150);
+    expect(r.projecao13).toHaveLength(2);
+    expect(r.projecao13[0].inicio).toBe('2026-05-26');
+    expect(r.projecao13[0].entradas_previstas).toBe(45);
+    expect(r.projecao13[0].saldo_projetado).toBe(379);
+    expect(r.projecao13[0].semana_label).toBe('26/05');
+    expect(r.projecao13[0].completa).toBe(true);
+    expect(r.projecao13[0].por_empresa).toHaveLength(3);
+  });
+
+  it('COORTE por data: snapshot stale (dia anterior) fora da soma + flag stale', () => {
+    const snaps = [
+      snap('oben', '2026-05-27T10:00:00Z', 100, [sem('2026-05-26', 10, 0, 110)]),
+      snap('colacor', '2026-05-27T10:00:00Z', 200, [sem('2026-05-26', 20, 0, 220)]),
+      snap('colacor_sc', '2026-05-20T10:00:00Z', 999, [sem('2026-05-19', 1, 0, 1)]),
+    ];
+    const r = consolidarCockpit({ esperadas: ESP, snapshots: snaps });
+    expect(r.data_referencia).toBe('2026-05-27');
+    expect(r.empresas_presentes).toEqual(['oben', 'colacor']);
+    expect(r.empresas_stale).toEqual(['colacor_sc']);
+    expect(r.parcial).toBe(true);
+    expect(r.ncg_total).toBe(300);
+    expect(r.projecao13[0].saldo_projetado).toBe(330);
+    expect(r.projecao13[0].completa).toBe(false);
+  });
+
+  it('DEDUPE latest-wins por snapshot_at, NÃO ordem do array: mais novo vem ANTES', () => {
+    const snaps = [
+      snap('oben', '2026-05-27T12:00:00Z', 150, [sem('2026-05-26', 15, 0, 165)]),
+      snap('oben', '2026-05-27T08:00:00Z', 100, [sem('2026-05-26', 10, 0, 110)]),
+      snap('colacor', '2026-05-27T10:00:00Z', 200, [sem('2026-05-26', 20, 0, 220)]),
+      snap('colacor_sc', '2026-05-27T10:00:00Z', 50, [sem('2026-05-26', 5, 0, 55)]),
+    ];
+    const r = consolidarCockpit({ esperadas: ESP, snapshots: snaps });
+    expect(r.ncg_total).toBe(400);
+    expect(r.projecao13[0].saldo_projetado).toBe(440);
+    expect(r.empresas_presentes).toEqual(ESP);
+  });
+
+  it('coorte: 3 empresas no MESMO DIA com horas diferentes → todas na coorte, não parcial', () => {
+    const snaps = [
+      snap('oben', '2026-05-27T06:00:00Z', 100, [sem('2026-05-26', 10, 0, 110)]),
+      snap('colacor', '2026-05-27T13:30:00Z', 200, [sem('2026-05-26', 20, 0, 220)]),
+      snap('colacor_sc', '2026-05-27T23:59:00Z', 50, [sem('2026-05-26', 5, 0, 55)]),
+    ];
+    const r = consolidarCockpit({ esperadas: ESP, snapshots: snaps });
+    expect(r.parcial).toBe(false);
+    expect(r.empresas_presentes).toEqual(ESP);
+    expect(r.data_referencia).toBe('2026-05-27');
+    expect(r.ncg_total).toBe(350);
+    expect(r.projecao13[0].completa).toBe(true);
+  });
+
+  it('coorte por DATA via slice (não new Date local): snapshot_at de madrugada Z não muda o dia', () => {
+    const snaps = [snap('oben', '2026-05-27T01:00:00Z', 0, [sem('2026-05-01', 10, 0, 10)])];
+    const r = consolidarCockpit({ esperadas: ['oben'], snapshots: snaps });
+    expect(r.data_referencia).toBe('2026-05-27');
+    expect(r.projecao13[0].semana_label).toBe('01/05');
+  });
+
+  it('saldo_tesouraria: 0 conta, null aciona parcial (simétrico ao ncg)', () => {
+    const snaps = [
+      snap('oben', '2026-05-27T10:00:00Z', 0, [sem('2026-05-26', 0, 0, 0)], 0),
+      snap('colacor', '2026-05-27T10:00:00Z', 0, [sem('2026-05-26', 0, 0, 0)], null),
+      snap('colacor_sc', '2026-05-27T10:00:00Z', 0, [sem('2026-05-26', 0, 0, 0)], 30),
+    ];
+    const r = consolidarCockpit({ esperadas: ESP, snapshots: snaps });
+    expect(r.saldo_tesouraria_total).toBe(30);
+    expect(r.saldo_tesouraria_parcial).toBe(true);
+    expect(r.projecao13[0].saldo_projetado).toBe(0);
+  });
+
+  it('stale com a MESMA semana inicio que a coorte → ainda excluído (por data)', () => {
+    const snaps = [
+      snap('oben', '2026-05-27T10:00:00Z', 100, [sem('2026-05-26', 10, 0, 110)]),
+      snap('colacor', '2026-05-27T10:00:00Z', 200, [sem('2026-05-26', 20, 0, 220)]),
+      snap('colacor_sc', '2026-05-20T10:00:00Z', 999, [sem('2026-05-26', 99, 0, 999)]),
+    ];
+    const r = consolidarCockpit({ esperadas: ESP, snapshots: snaps });
+    expect(r.empresas_stale).toEqual(['colacor_sc']);
+    expect(r.ncg_total).toBe(300);
+    expect(r.projecao13[0].saldo_projetado).toBe(330);
+    expect(r.projecao13[0].por_empresa).toHaveLength(2);
+  });
+
+  it('empresa ausente (sem snapshot) → ausente + parcial; completa=false', () => {
+    const snaps = [
+      snap('oben', '2026-05-27T10:00:00Z', 100, [sem('2026-05-26', 10, 0, 110)]),
+      snap('colacor', '2026-05-27T10:00:00Z', 200, [sem('2026-05-26', 20, 0, 220)]),
+    ];
+    const r = consolidarCockpit({ esperadas: ESP, snapshots: snaps });
+    expect(r.empresas_ausentes).toEqual(['colacor_sc']);
+    expect(r.parcial).toBe(true);
+    expect(r.ncg_total).toBe(300);
+    expect(r.projecao13[0].completa).toBe(false);
+    expect(r.ncg_por_empresa.find(e => e.company === 'colacor_sc')).toEqual({ company: 'colacor_sc', ncg: null, presente: false });
+  });
+
+  it('ncg null ≠ ncg 0; null fora da soma + ncg_parcial', () => {
+    const snaps = [
+      snap('oben', '2026-05-27T10:00:00Z', null, [sem('2026-05-26', 10, 0, 110)]),
+      snap('colacor', '2026-05-27T10:00:00Z', 0, [sem('2026-05-26', 20, 0, 220)]),
+      snap('colacor_sc', '2026-05-27T10:00:00Z', 50, [sem('2026-05-26', 5, 0, 55)]),
+    ];
+    const r = consolidarCockpit({ esperadas: ESP, snapshots: snaps });
+    expect(r.ncg_total).toBe(50);
+    expect(r.ncg_parcial).toBe(true);
+  });
+
+  it('inícios fora de ordem → união ordenada asc; alinha por inicio', () => {
+    const snaps = [
+      snap('oben', '2026-05-27T10:00:00Z', 0, [sem('2026-06-02', 20, 0, 20), sem('2026-05-26', 10, 0, 10)]),
+      snap('colacor', '2026-05-27T10:00:00Z', 0, [sem('2026-05-26', 5, 0, 5), sem('2026-06-02', 7, 0, 7)]),
+      snap('colacor_sc', '2026-05-27T10:00:00Z', 0, [sem('2026-05-26', 1, 0, 1), sem('2026-06-02', 2, 0, 2)]),
+    ];
+    const r = consolidarCockpit({ esperadas: ESP, snapshots: snaps });
+    expect(r.projecao13.map(s => s.inicio)).toEqual(['2026-05-26', '2026-06-02']);
+    expect(r.projecao13[0].saldo_projetado).toBe(16);
+  });
+
+  it('semana só de uma empresa → completa=false (soma só quem tem)', () => {
+    const snaps = [
+      snap('oben', '2026-05-27T10:00:00Z', 0, [sem('2026-05-26', 10, 0, 110), sem('2026-06-02', 5, 0, 115)]),
+      snap('colacor', '2026-05-27T10:00:00Z', 0, [sem('2026-05-26', 20, 0, 220)]),
+      snap('colacor_sc', '2026-05-27T10:00:00Z', 0, [sem('2026-05-26', 1, 0, 1)]),
+    ];
+    const r = consolidarCockpit({ esperadas: ESP, snapshots: snaps });
+    const w2 = r.projecao13.find(s => s.inicio === '2026-06-02')!;
+    expect(w2.saldo_projetado).toBe(115);
+    expect(w2.completa).toBe(false);
+    expect(w2.por_empresa).toHaveLength(1);
+  });
+
+  it('vazio → tudo ausente, parcial, projeção vazia, sem NaN', () => {
+    const r = consolidarCockpit({ esperadas: ESP, snapshots: [] });
+    expect(r.empresas_ausentes).toEqual(ESP);
+    expect(r.parcial).toBe(true);
+    expect(r.ncg_total).toBe(0);
+    expect(r.projecao13).toEqual([]);
+    expect(r.data_referencia).toBeNull();
+  });
+
+  it('cap nas 13 PRIMEIRAS semanas por menor inicio (não 13 quaisquer)', () => {
+    const semanas = Array.from({ length: 16 }, (_, i) => sem(`2026-01-${String(i + 1).padStart(2, '0')}`, 1, 0, 1));
+    const r = consolidarCockpit({ esperadas: ['oben'], snapshots: [snap('oben', '2026-05-27T10:00:00Z', 0, semanas)] });
+    expect(r.projecao13).toHaveLength(13);
+    expect(r.projecao13[0].inicio).toBe('2026-01-01');
+    expect(r.projecao13[12].inicio).toBe('2026-01-13');
+  });
+});

--- a/src/lib/financeiro/cockpit-consolida-helpers.ts
+++ b/src/lib/financeiro/cockpit-consolida-helpers.ts
@@ -1,0 +1,154 @@
+export type SnapshotSemana = { inicio: string; total_entradas: number; total_saidas: number; saldo_final: number };
+
+export type SnapshotEmpresa = {
+  company: string;
+  snapshot_at: string;          // ISO 'YYYY-MM-DDThh:mm:ssZ'
+  ncg: number | null;
+  saldo_tesouraria: number | null;
+  semanas: SnapshotSemana[];
+};
+
+export type SemanaConsolidada = {
+  inicio: string;
+  semana_label: string;          // "dd/mm" do inicio
+  entradas_previstas: number;
+  saidas_previstas: number;
+  saldo_projetado: number;
+  por_empresa: { company: string; saldo_final: number }[];
+  completa: boolean;             // nº empresas com a semana === esperadas.length
+};
+
+export type CockpitConsolidado = {
+  projecao13: SemanaConsolidada[];
+  ncg_total: number;
+  ncg_por_empresa: { company: string; ncg: number | null; presente: boolean }[];
+  ncg_parcial: boolean;
+  saldo_tesouraria_total: number;
+  saldo_tesouraria_parcial: boolean;
+  empresas_presentes: string[];  // coorte, na ordem de `esperadas`
+  empresas_ausentes: string[];   // sem nenhum snapshot
+  empresas_stale: string[];      // têm snapshot, mas data < data_referencia
+  parcial: boolean;
+  data_referencia: string | null;
+  snapshot_at_mais_antigo: string | null;
+};
+
+const round2 = (n: number): number => Math.round((n + Number.EPSILON) * 100) / 100;
+const dataDe = (snapshotAt: string): string => snapshotAt.slice(0, 10);
+
+export function consolidarCockpit(input: { esperadas: string[]; snapshots: SnapshotEmpresa[] }): CockpitConsolidado {
+  const { esperadas, snapshots } = input;
+
+  // 1. Dedupe por empresa: latest-wins por snapshot_at (não ordem do array).
+  const dedup = new Map<string, SnapshotEmpresa>();
+  for (const s of snapshots) {
+    const atual = dedup.get(s.company);
+    if (!atual || Date.parse(s.snapshot_at) > Date.parse(atual.snapshot_at)) {
+      dedup.set(s.company, s);
+    }
+  }
+
+  // 2. Coorte por DATA de referência: max(dataDe(snapshot_at)).
+  let dataRef: string | null = null;
+  for (const s of dedup.values()) {
+    const d = dataDe(s.snapshot_at);
+    if (dataRef === null || d > dataRef) dataRef = d;
+  }
+
+  // coorte = empresas cujo dataDe(snapshot_at) === dataRef
+  const coorte = new Map<string, SnapshotEmpresa>();
+  if (dataRef !== null) {
+    for (const [company, s] of dedup) {
+      if (dataDe(s.snapshot_at) === dataRef) coorte.set(company, s);
+    }
+  }
+
+  // 3. Classificação na ordem de esperadas.
+  const empresas_presentes = esperadas.filter((c) => coorte.has(c));
+  const empresas_ausentes = esperadas.filter((c) => !dedup.has(c));
+  const empresas_stale = esperadas.filter((c) => dedup.has(c) && !coorte.has(c));
+
+  const parcial = empresas_ausentes.length + empresas_stale.length > 0;
+
+  // 4. NCG.
+  const ncg_por_empresa = esperadas.map((c) => {
+    const s = coorte.get(c);
+    return { company: c, ncg: s ? s.ncg : null, presente: !!s };
+  });
+  let ncgTotalRaw = 0;
+  let algumNcgNull = false;
+  for (const s of coorte.values()) {
+    if (s.ncg != null) ncgTotalRaw += s.ncg;
+    else algumNcgNull = true;
+  }
+  const ncg_total = round2(ncgTotalRaw);
+  const ncg_parcial = parcial || algumNcgNull;
+
+  // 5. Saldo tesouraria.
+  let saldoTesRaw = 0;
+  let algumSaldoNull = false;
+  for (const s of coorte.values()) {
+    if (s.saldo_tesouraria != null) saldoTesRaw += s.saldo_tesouraria;
+    else algumSaldoNull = true;
+  }
+  const saldo_tesouraria_total = round2(saldoTesRaw);
+  const saldo_tesouraria_parcial = parcial || algumSaldoNull;
+
+  // 6. Projeção (só a coorte): união de inícios, ordenada asc, cap nas 13 primeiras.
+  const iniciosSet = new Set<string>();
+  for (const s of coorte.values()) {
+    for (const w of s.semanas) iniciosSet.add(w.inicio);
+  }
+  const iniciosOrdenados = Array.from(iniciosSet).sort();
+  const inicios13 = iniciosOrdenados.slice(0, 13);
+
+  const projecao13: SemanaConsolidada[] = inicios13.map((inicio) => {
+    let entradas = 0;
+    let saidas = 0;
+    let saldo = 0;
+    const por_empresa: { company: string; saldo_final: number }[] = [];
+    // percorre na ordem de esperadas para por_empresa determinístico
+    for (const c of esperadas) {
+      const s = coorte.get(c);
+      if (!s) continue;
+      const w = s.semanas.find((sw) => sw.inicio === inicio);
+      if (!w) continue;
+      entradas += w.total_entradas;
+      saidas += w.total_saidas;
+      saldo += w.saldo_final;
+      por_empresa.push({ company: c, saldo_final: w.saldo_final });
+    }
+    return {
+      inicio,
+      semana_label: inicio.slice(8, 10) + '/' + inicio.slice(5, 7),
+      entradas_previstas: round2(entradas),
+      saidas_previstas: round2(saidas),
+      saldo_projetado: round2(saldo),
+      por_empresa,
+      completa: por_empresa.length === esperadas.length,
+    };
+  });
+
+  // 7. snapshot_at_mais_antigo da coorte.
+  let snapshot_at_mais_antigo: string | null = null;
+  for (const s of coorte.values()) {
+    if (snapshot_at_mais_antigo === null || s.snapshot_at < snapshot_at_mais_antigo) {
+      snapshot_at_mais_antigo = s.snapshot_at;
+    }
+  }
+
+  return {
+    projecao13,
+    ncg_total,
+    ncg_por_empresa,
+    ncg_parcial,
+    saldo_tesouraria_total,
+    saldo_tesouraria_parcial,
+    empresas_presentes,
+    empresas_ausentes,
+    empresas_stale,
+    parcial,
+    data_referencia: dataRef,
+    snapshot_at_mais_antigo,
+  };
+}

--- a/src/pages/FinanceiroCockpit.tsx
+++ b/src/pages/FinanceiroCockpit.tsx
@@ -18,9 +18,10 @@ import { DataBasisFooter } from '@/components/financeiro/cockpit/DataBasisFooter
 const FinanceiroCockpit = () => {
   const {
     loading,
+    regime,
     confiabilidade,
     dreConsolidado,
-    projecao13,
+    cockpit,
     inadimplentes,
     drillDown,
     setDrillDown,
@@ -67,22 +68,24 @@ const FinanceiroCockpit = () => {
           onClick={() => setDrillDown('caixa')}
         />
         <CockpitCard
-          title="Caixa Projetado 30d"
+          title="Posição líquida (abertos)"
           value={fmtCompact(totalCC + totalCR - totalCP)}
           positive={totalCC + totalCR - totalCP > 0}
           icon={Target}
-          detail={`+ ${fmtCompact(totalCR)} entradas / - ${fmtCompact(totalCP)} saídas`}
-          badge="CR+CC-CP abertos"
+          detail={`+ ${fmtCompact(totalCR)} a receber / - ${fmtCompact(totalCP)} a pagar (abertos)`}
+          badge="CR+CC−CP abertos · não é projeção"
           onClick={() => setDrillDown('cr_aberto')}
         />
         <CockpitCard
           title="Necessidade de CG"
           value={fmtCompact(ncg)}
-          positive={ncg >= 0}
-          icon={ncg >= 0 ? TrendingUp : TrendingDown}
-          detail={ncg >= 0 ? 'CR cobre CP — posição confortável' : 'CP excede CR — atenção ao caixa'}
-          detailColor={ncg >= 0 ? 'text-status-success' : 'text-status-error'}
-          badge="CR - CP"
+          positive={ncg <= 0}
+          icon={ncg <= 0 ? TrendingUp : TrendingDown}
+          detail={cockpit.ncg_parcial
+            ? `Parcial: ${cockpit.empresas_presentes.length}/3 empresas`
+            : ncg <= 0 ? 'PCO financia a operação (folga)' : 'Operação imobiliza capital de giro'}
+          detailColor={ncg <= 0 ? 'text-status-success' : 'text-status-warning'}
+          badge={cockpit.ncg_parcial ? `ACO−PCO (engine) · ${cockpit.empresas_presentes.length}/3` : 'ACO − PCO (engine A1)'}
           onClick={() => setDrillDown('cr_aberto')}
         />
       </div>
@@ -106,9 +109,15 @@ const FinanceiroCockpit = () => {
       {/* Row 3: Resultado por empresa */}
       <ResultadoPorEmpresa dreConsolidado={dreConsolidado} confiabilidade={confiabilidade} />
 
-      {/* Row 4: Projeção 13 semanas */}
-      {projecao13.length > 0 && (
-        <Projecao13Card projecao13={projecao13} />
+      {/* Row 4: Projeção 13 semanas (engine A1 via snapshot, consolidada) */}
+      {cockpit.projecao13.length > 0 && (
+        <Projecao13Card
+          projecao13={cockpit.projecao13}
+          dataReferencia={cockpit.data_referencia}
+          parcial={cockpit.parcial}
+          empresasAusentes={cockpit.empresas_ausentes}
+          empresasStale={cockpit.empresas_stale}
+        />
       )}
 
       {/* Row 5: Top inadimplentes */}
@@ -120,7 +129,7 @@ const FinanceiroCockpit = () => {
       <PeriodOverrideHistory />
 
       {/* Data basis footer */}
-      <DataBasisFooter />
+      <DataBasisFooter regime={regime} />
 
       <CockpitDrillDown type={drillDown} onClose={() => setDrillDown(null)} />
     </div>

--- a/src/pages/FinanceiroCockpit.tsx
+++ b/src/pages/FinanceiroCockpit.tsx
@@ -115,6 +115,7 @@ const FinanceiroCockpit = () => {
           projecao13={cockpit.projecao13}
           dataReferencia={cockpit.data_referencia}
           parcial={cockpit.parcial}
+          empresasPresentes={cockpit.empresas_presentes}
           empresasAusentes={cockpit.empresas_ausentes}
           empresasStale={cockpit.empresas_stale}
         />

--- a/src/services/financeiroV2Service.ts
+++ b/src/services/financeiroV2Service.ts
@@ -661,24 +661,32 @@ export async function getProjecaoSnapshotsCockpit(
     companies.map(async (company): Promise<SnapshotEmpresa | null> => {
       const { data, error } = await supabase
         .from('fin_projecao_snapshots')
-        .select('company, snapshot_at, ncg, saldo_tesouraria, dados')
+        .select('company, snapshot_at, ncg, saldo_tesouraria, dados, id')
         .eq('company', company)
         .eq('cenario', cenario)
         .order('snapshot_at', { ascending: false })
+        .order('id', { ascending: false }) // desempate determinístico (Codex P2)
         .limit(1)
         .maybeSingle();
       if (error) throw error;
       if (!data) return null;
       const dadosRaw = (data as { dados: unknown }).dados;
+      // ausente ≠ zero (Codex P1): campo numérico inválido descarta a semana (não vira 0 mentiroso).
       const semanas: SnapshotSemana[] = Array.isArray(dadosRaw)
         ? (dadosRaw as Array<Record<string, unknown>>)
-            .filter((w) => w && typeof w.inicio === 'string')
             .map((w) => ({
-              inicio: w.inicio as string,
-              total_entradas: Number(w.total_entradas) || 0,
-              total_saidas: Number(w.total_saidas) || 0,
-              saldo_final: Number(w.saldo_final) || 0,
+              inicio: w && typeof w.inicio === 'string' ? w.inicio : '',
+              total_entradas: Number(w?.total_entradas),
+              total_saidas: Number(w?.total_saidas),
+              saldo_final: Number(w?.saldo_final),
             }))
+            .filter(
+              (w): w is SnapshotSemana =>
+                w.inicio !== '' &&
+                Number.isFinite(w.total_entradas) &&
+                Number.isFinite(w.total_saidas) &&
+                Number.isFinite(w.saldo_final),
+            )
         : [];
       return {
         company: (data.company as string) ?? company,

--- a/src/services/financeiroV2Service.ts
+++ b/src/services/financeiroV2Service.ts
@@ -3,6 +3,7 @@ import type { Company } from "@/contexts/CompanyContext";
 import type { Json } from "@/integrations/supabase/types";
 import type { DimRowRaw } from "@/lib/financeiro/orcamento-drill-helpers";
 import { coletarTitulosEntidade, parseMesDataEmissao, type EntidadeRowRaw } from "@/lib/financeiro/orcamento-entidade-helpers";
+import type { SnapshotEmpresa, SnapshotSemana } from "@/lib/financeiro/cockpit-consolida-helpers";
 import type {
   FinFechamentoRow,
   FinFechamentoInsert,
@@ -644,6 +645,51 @@ export async function getTitulosEntidadeRaw(
       }));
     },
   });
+}
+
+/**
+ * Último snapshot de projeção 13s (cenário `realista`) por empresa, de `fin_projecao_snapshots`
+ * (gravado pelo cron diário via fin-cashflow-engine). Fonte do Cockpit consolidado: a projeção
+ * e o NCG vêm da engine A1 calibrada (não da RPC ingênua). `dados` (Json) = semanas[] — valida
+ * `Array.isArray` e extrai {inicio,total_entradas,total_saidas,saldo_final}. Uma query por empresa.
+ */
+export async function getProjecaoSnapshotsCockpit(
+  companies: Company[],
+  cenario = 'realista',
+): Promise<SnapshotEmpresa[]> {
+  const results = await Promise.all(
+    companies.map(async (company): Promise<SnapshotEmpresa | null> => {
+      const { data, error } = await supabase
+        .from('fin_projecao_snapshots')
+        .select('company, snapshot_at, ncg, saldo_tesouraria, dados')
+        .eq('company', company)
+        .eq('cenario', cenario)
+        .order('snapshot_at', { ascending: false })
+        .limit(1)
+        .maybeSingle();
+      if (error) throw error;
+      if (!data) return null;
+      const dadosRaw = (data as { dados: unknown }).dados;
+      const semanas: SnapshotSemana[] = Array.isArray(dadosRaw)
+        ? (dadosRaw as Array<Record<string, unknown>>)
+            .filter((w) => w && typeof w.inicio === 'string')
+            .map((w) => ({
+              inicio: w.inicio as string,
+              total_entradas: Number(w.total_entradas) || 0,
+              total_saidas: Number(w.total_saidas) || 0,
+              saldo_final: Number(w.saldo_final) || 0,
+            }))
+        : [];
+      return {
+        company: (data.company as string) ?? company,
+        snapshot_at: data.snapshot_at as string,
+        ncg: (data.ncg as number | null) ?? null,
+        saldo_tesouraria: (data.saldo_tesouraria as number | null) ?? null,
+        semanas,
+      };
+    }),
+  );
+  return results.filter((r): r is SnapshotEmpresa => r !== null);
 }
 
 // ═══════════════ 6. PERMISSÕES ═══════════════


### PR DESCRIPTION
## Resumo

O Cockpit financeiro (`/financeiro/cockpit`) foi construído **antes** das engines A1 (curvas de cobrança/aging/eventos) e nunca foi religado — calculava a projeção 13s por uma RPC legada e exibia **NCG = CR−CP** (proxy grosseiro), divergindo das telas que já usam a engine (NCG/Cashflow). Esta consolidação **religa o Cockpit à fonte real** (snapshot diário da engine via `fin_projecao_snapshots`, gravado pelo cron `fin-cashflow-snapshot-diario`) e torna os rótulos honestos sobre o que o número é.

**Client-side puro — sem migration, sem edge function, sem deploy.** Lê o snapshot que o cron já grava.

## O que muda

- **Helper novo** `src/lib/financeiro/cockpit-consolida-helpers.ts` (`consolidarCockpit`, 13 testes TDD): consolida os snapshots das 3 empresas por **coorte de data de referência** (dedupe latest-wins por `snapshot_at`), soma **total + por-empresa** (caixa **não é fungível** entre os 3 CNPJs), marca semanas `completa`/parcial, e degrada honestamente quando empresa está ausente/stale (**ausente ≠ zero**).
- **Service** `getProjecaoSnapshotsCockpit` em `financeiroV2Service.ts`: lê `fin_projecao_snapshots` (último por empresa via `.order(snapshot_at desc).order(id desc)`), valida `Array.isArray`, e filtra semanas com `Number.isFinite` nos 3 campos numéricos (descarta malformado em vez de virar 0).
- **Re-wire** `useFinanceiroCockpit.ts`: **NCG = ACO−PCO da engine** (não mais CR−CP); projeção 13s do snapshot real; guard de corrida (`loadIdRef`) no toggle de regime; `COCKPIT_VAZIO` marca `parcial:true` (falha de carga não vira falso-verde de R$0).
- **Rótulos honestos**: `Projecao13Card` (badge "Consolidado 3 CNPJ · dados de DD/MM/YYYY", defasagem "Nd atrás", aviso intercompany, banner parcial por coorte real), `DataBasisFooter` (regime-aware), `FinanceiroCockpit` ("Posição líquida (abertos)" no lugar de "Caixa Projetado 30d"; card NCG `positive` quando ≤0 = folga, badge "ACO − PCO (engine A1)").
- **Bug alinhado** `NcgDecomposicao.tsx`: cor do NCG estava invertida (NCG<0 pintava erro) — agora NCG≤0 = folga (sucesso), coerente com o Cockpit e com a semântica ACO−PCO.

## Validação

- `bun run test`: **310 arquivos / 1663 testes** ✅
- `bun run typecheck:strict`: limpo ✅
- `tsc --noEmit -p tsconfig.app.json`: limpo ✅
- `bun lint`: 0 errors (82 warnings exhaustive-deps pré-existentes) ✅
- `bun run build`: ✅

## Codex

Methodology + spec (3 P1 + P2) + plano (testes anti-impl-preguiçosa) + adversarial no código (2 P1: `Number.isFinite` no lugar de `||0`; `COCKPIT_VAZIO` parcial; + P2: banner por coorte, `.order(id desc)`, guard de corrida no regime, alinhamento do `NcgDecomposicao`).

## Não-objetivos

Invocar as engines ao vivo no Cockpit (mantém snapshot-first — tela executiva semanal, 3 invocações ao vivo seria caro); consolidar caixa fungível cross-CNPJ (não é — exibido total + quebra por empresa).

🤖 Generated with [Claude Code](https://claude.com/claude-code)