### PR TITLE
chore(strict): promove 16 .tsx/.ts de clusters frios (687→703)

### DIFF
--- a/tsconfig.strict.json
+++ b/tsconfig.strict.json
@@ -705,6 +705,22 @@
     "src/components/reposicao/oportunidades/KpiCards.tsx",
     "src/components/reposicao/oportunidades/OportunidadesFiltros.tsx",
     "src/components/reposicao/oportunidades/GerarCicloDialog.tsx",
-    "src/components/reposicao/oportunidades/OportunidadesTable.tsx"
+    "src/components/reposicao/oportunidades/OportunidadesTable.tsx",
+    "src/components/analyticsSync/useAnalyticsSync.ts",
+    "src/components/analyticsSync/EngineCards.tsx",
+    "src/components/analyticsSync/EngineConfigCard.tsx",
+    "src/components/reposicao/pedidos/useDetalhesModal.ts",
+    "src/components/reposicao/pedidos/ItensTable.tsx",
+    "src/components/reposicao/pedidos/DetalhesModal.tsx",
+    "src/components/reposicao/aumentoDetail/MapeamentoDialog.tsx",
+    "src/components/reposicao/aumentoDetail/ItemRow.tsx",
+    "src/hooks/useBreadcrumbs.ts",
+    "src/components/shell/GlobalBreadcrumbs.tsx",
+    "src/hooks/useCallLog.ts",
+    "src/components/telefonia/CallHistoryTabs.tsx",
+    "src/components/skuMapeamento/useSkuMapeamento.ts",
+    "src/pages/AdminSkuMapeamento.tsx",
+    "src/components/notificacoes/useNotificacoes.ts",
+    "src/pages/AdminNotificacoes.tsx"
   ]
 }


### PR DESCRIPTION
## Resumo

Continuação do strict em **clusters frios** (decisão do founder: seguir no strict frio), trazendo o **blocker `.ts` no mesmo lote** que os dependentes `.tsx` — padrão do cluster `oportunidades`.

Clusters (todos fora de farmer/scoring/financeiro/customer360/data-health):
- **analyticsSync**: `useAnalyticsSync` + `EngineCards` + `EngineConfigCard`
- **reposicao/pedidos**: `useDetalhesModal` + `ItensTable` + `DetalhesModal`
- **reposicao/aumentoDetail**: `MapeamentoDialog` + `ItemRow`
- **shell**: `useBreadcrumbs` + `GlobalBreadcrumbs`
- **telefonia**: `useCallLog` + `CallHistoryTabs`
- **skuMapeamento**: `useSkuMapeamento` + `AdminSkuMapeamento` (page)
- **notificacoes**: `useNotificacoes` + `AdminNotificacoes` (page)

**Tsconfig-only, zero edição de source.** `typecheck:strict` verde com os 16. Evitei deliberadamente: data-health (lane da sessão Sentinela ativa), services financeiro (`financeiroService`/V2), barrel `lib/reposicao`, impersonation.

Progresso strict: **687 → 703** (~82% de 853).

## Test plan
- [x] `heavy bun run typecheck:strict` verde (exit 0, 0 erros) na base pós-#441
- [x] diff só `tsconfig.strict.json`
- [ ] CI `validate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)