### PR TITLE
fix(telefonia): NVOIP em vez do app Telefone do iOS + hardening da Central

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,11 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0" />
+    <!-- iOS/Safari auto-linka números de telefone em texto (vira <a href="tel:">),
+         inclusive o número dentro do botão "Ligar 37 9..." da Central de Telefonia →
+         o toque abria o app Telefone do SO em vez de chamar via NVOIP. Desliga só a
+         auto-detecção; links tel: explícitos (CallButton em celular) seguem ativos. -->
+    <meta name="format-detection" content="telephone=no" />
     <title>Colacor</title>
     <meta name="description" content="Colacor - Serviço profissional de afiação de ferramentas. Agende sua coleta!">
     <link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/src/__tests__/index-html.test.ts
+++ b/src/__tests__/index-html.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// Regressão: o iOS/Safari auto-detecta números de telefone em texto e os transforma
+// em <a href="tel:"> — inclusive o número da Central de Telefonia. Sem esta meta, o
+// toque abre o app Telefone do SO em vez de chamar via NVOIP. NÃO remover.
+describe('index.html — meta format-detection (anti auto-link tel: do iOS)', () => {
+  const html = readFileSync(resolve(process.cwd(), 'index.html'), 'utf-8');
+
+  it('contém <meta name="format-detection" content="telephone=no"> (ordem dos atributos indiferente)', () => {
+    const metas = html.match(/<meta\b[^>]*>/gi) ?? [];
+    const found = metas.some(
+      (tag) =>
+        /name\s*=\s*"format-detection"/i.test(tag) &&
+        /content\s*=\s*"telephone=no"/i.test(tag)
+    );
+    expect(found).toBe(true);
+  });
+});

--- a/src/components/telefonia/CallHistoryRow.tsx
+++ b/src/components/telefonia/CallHistoryRow.tsx
@@ -2,7 +2,7 @@
 import { PhoneIncoming, PhoneOutgoing, PhoneMissed, Mic } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useNavigate } from 'react-router-dom';
-import { formatBrPhone } from '@/lib/phone';
+import { formatBrPhone, normalizeBrPhone } from '@/lib/phone';
 import { cn } from '@/lib/utils';
 import type { CallLogRow } from '@/types/call-log';
 
@@ -11,11 +11,12 @@ const STATUS_LABEL: Record<string, string> = {
   busy: 'ocupado', failed: 'falhou', canceled: 'cancelada', ended: 'encerrada',
 };
 
-export function CallHistoryRow({ row, onCallBack }: { row: CallLogRow; onCallBack: (phone: string) => void }) {
+export function CallHistoryRow({ row, onCallBack }: { row: CallLogRow; onCallBack: (phone: string, name?: string) => void }) {
   const navigate = useNavigate();
   const missed = row.direction === 'inbound' && row.status === 'missed';
   const Icon = missed ? PhoneMissed : row.direction === 'inbound' ? PhoneIncoming : PhoneOutgoing;
   const phone = row.phone_raw ?? row.phone_normalized ?? '';
+  const canCall = normalizeBrPhone(phone).length >= 10;
   const known = !!row.customer_user_id;
   const name = row.display_name ?? (known ? 'Cliente' : 'Desconhecido');
 
@@ -45,7 +46,9 @@ export function CallHistoryRow({ row, onCallBack }: { row: CallLogRow; onCallBac
             onClick={() => navigate(`/admin/customers/${row.customer_user_id}`)}>ver cliente</Button>
         )}
         <Button size="sm" variant="outline" className="h-7 text-xs"
-          onClick={() => onCallBack(phone)}>religar</Button>
+          disabled={!canCall}
+          title={canCall ? `Religar para ${formatBrPhone(phone)}` : 'Telefone inválido'}
+          onClick={() => onCallBack(phone, name)}>religar</Button>
       </div>
     </div>
   );

--- a/src/components/telefonia/CallHistoryTabs.tsx
+++ b/src/components/telefonia/CallHistoryTabs.tsx
@@ -17,7 +17,7 @@ export function CallHistoryTabs({
   userId, tab, onTabChange, onCallBack, isManager,
 }: {
   userId: string | undefined; tab: CallLogTab; onTabChange: (t: CallLogTab) => void;
-  onCallBack: (phone: string) => void; isManager: boolean;
+  onCallBack: (phone: string, name?: string) => void; isManager: boolean;
 }) {
   const { data: rows = [], isLoading } = useCallLog(tab, userId);
   const ack = useAcknowledgeMissed(userId);

--- a/src/components/telefonia/DialPad.tsx
+++ b/src/components/telefonia/DialPad.tsx
@@ -4,41 +4,60 @@ import { Phone, Delete } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Switch } from '@/components/ui/switch';
-import { useCallBackend } from '@/hooks/useCallBackend';
 import { formatBrPhone, normalizeBrPhone } from '@/lib/phone';
 
 const KEYS = ['1','2','3','4','5','6','7','8','9','*','0','#'];
 
-export function DialPad({ initialPhone = '' }: { initialPhone?: string }) {
+export interface DialPadProps {
+  initialPhone?: string;
+  /** Inicia a chamada via backend (NVOIP/WebRTC). Dono da sessão é a página. */
+  onCall: (phone: string, opts: { forceRecord: boolean }) => void;
+  /** Backend ativo, só pra rótulo informativo. */
+  backend: string;
+  /** Desabilita o botão "Ligar" enquanto há chamada em andamento. */
+  busy?: boolean;
+}
+
+export function DialPad({ initialPhone = '', onCall, backend, busy = false }: DialPadProps) {
   const [value, setValue] = useState(initialPhone);
   const [forceRecord, setForceRecord] = useState(false);
-  const call = useCallBackend();
-  const valid = normalizeBrPhone(value).length >= 10;
+  const normalized = normalizeBrPhone(value);
+  const valid = normalized.length >= 10;
 
   return (
-    <div className="w-full max-w-[240px] rounded-lg border border-border bg-card p-3">
+    <div className="w-full max-w-[260px] rounded-lg border border-border bg-card p-3">
       <div className="text-[10px] uppercase tracking-wide text-muted-foreground mb-1.5">Discar</div>
       <div className="flex items-center gap-1">
         <Input value={value} onChange={(e) => setValue(e.target.value)}
-          placeholder="número" className="text-center font-mono" />
-        <Button size="icon" variant="ghost" className="h-9 w-9 shrink-0"
+          inputMode="tel" placeholder="número" className="text-center font-mono" />
+        <Button size="icon" variant="ghost" className="h-11 w-11 shrink-0"
+          aria-label="Apagar último dígito"
           onClick={() => setValue((v) => v.slice(0, -1))}><Delete className="h-4 w-4" /></Button>
       </div>
       <div className="grid grid-cols-3 gap-1.5 mt-2">
         {KEYS.map((k) => (
-          <Button key={k} variant="outline" className="h-10" onClick={() => setValue((v) => v + k)}>{k}</Button>
+          <Button key={k} variant="outline" className="h-12 text-base" onClick={() => setValue((v) => v + k)}>{k}</Button>
         ))}
       </div>
       <div className="flex items-center justify-between mt-2 text-xs">
         <span className="text-muted-foreground">Gravar esta chamada</span>
         <Switch checked={forceRecord} onCheckedChange={setForceRecord} />
       </div>
-      <Button className="w-full mt-2 bg-status-success hover:bg-status-success/90" disabled={!valid}
-        onClick={() => call.makeCall(normalizeBrPhone(value), { forceRecord })}>
-        <Phone className="h-4 w-4 mr-1.5" /> Ligar {valid ? formatBrPhone(value) : ''}
+      {/* Número fica numa linha NÃO-interativa — fora do label do botão pra não
+          virar <a href="tel:"> auto-detectado pelo iOS (abriria o app Telefone do SO). */}
+      {valid && (
+        <p className="mt-2 text-center font-mono text-sm tabular-nums" aria-hidden="true">
+          {formatBrPhone(value)}
+        </p>
+      )}
+      <Button className="w-full mt-2 h-12 bg-status-success hover:bg-status-success/90"
+        disabled={!valid || busy}
+        aria-label={valid ? `Ligar para ${formatBrPhone(value)}` : 'Ligar'}
+        onClick={() => onCall(normalized, { forceRecord })}>
+        <Phone className="h-4 w-4 mr-1.5" /> {busy ? 'Em chamada…' : 'Ligar'}
       </Button>
       <p className="text-[10px] text-center text-muted-foreground mt-1.5">
-        backend: {call.backend.toUpperCase()} · cliente/fornecedor grava automático
+        backend: {backend.toUpperCase()} · cliente/fornecedor grava automático
       </p>
     </div>
   );

--- a/src/hooks/useNvoipCall.ts
+++ b/src/hooks/useNvoipCall.ts
@@ -2,6 +2,11 @@ import { useState, useRef, useCallback, useEffect } from 'react';
 import { invokeFunction } from '@/lib/invoke-function';
 import { toast } from 'sonner';
 import { normalizeBrPhone, formatBrPhone } from '@/lib/phone';
+import { logger } from '@/lib/logger';
+
+// Após N polls consecutivos falhando (rede caiu, função fora do ar), paramos de
+// pollar e marcamos erro — em vez de bater na Edge Function a cada 2s pra sempre.
+const MAX_CONSECUTIVE_POLL_ERRORS = 5;
 
 export type NvoipCallState =
   | 'idle'
@@ -45,6 +50,15 @@ export function useNvoipCall(): UseNvoipCallReturn {
 
   const pollingRef = useRef<number | null>(null);
   const durationRef = useRef<number | null>(null);
+  const pollErrorsRef = useRef(0);
+  // ID da chamada cujo polling é o "vivo". Respostas de poll de uma chamada
+  // anterior (já encerrada) que chegam atrasadas são descartadas comparando
+  // contra este ref — senão poderiam setar estado terminal e parar o polling
+  // de uma chamada nova que começou no intervalo.
+  const activeCallIdRef = useRef<string | null>(null);
+  // Espelha callState pra leitura síncrona no guard de concorrência (sem stale closure).
+  const callStateRef = useRef<NvoipCallState>('idle');
+  callStateRef.current = callState;
 
   const stopPolling = useCallback(() => {
     if (pollingRef.current) {
@@ -70,6 +84,13 @@ export function useNvoipCall(): UseNvoipCallReturn {
           callId: id,
         });
 
+        // Resposta atrasada de uma chamada que já não é a ativa (ex.: a chamada
+        // foi encerrada e outra começou). Descarta pra não sobrescrever o estado
+        // da chamada atual nem parar o polling dela.
+        if (id !== activeCallIdRef.current) return;
+
+        pollErrorsRef.current = 0;
+
         const state = data.state || 'error';
         setCallState(state);
 
@@ -84,8 +105,9 @@ export function useNvoipCall(): UseNvoipCallReturn {
           }, 1000);
         }
 
-        // Stop polling on terminal states
-        const terminalStates: NvoipCallState[] = ['finished', 'noanswer', 'busy', 'failed'];
+        // Stop polling on terminal states ('error' incluído: estado final do backend
+        // também encerra o polling, senão batíamos na Edge Function a cada 2s pra sempre).
+        const terminalStates: NvoipCallState[] = ['finished', 'noanswer', 'busy', 'failed', 'error'];
         if (terminalStates.includes(state)) {
           stopPolling();
 
@@ -94,7 +116,17 @@ export function useNvoipCall(): UseNvoipCallReturn {
           }
         }
       } catch (err) {
-        console.error('Error polling call status:', err);
+        pollErrorsRef.current += 1;
+        logger.warn('Falha ao consultar status da chamada Nvoip', {
+          callId: id,
+          consecutiveErrors: pollErrorsRef.current,
+          error: err instanceof Error ? err.message : String(err),
+        });
+        if (pollErrorsRef.current >= MAX_CONSECUTIVE_POLL_ERRORS) {
+          stopPolling();
+          setCallState('error');
+          setError('Conexão perdida ao acompanhar a chamada');
+        }
       }
     },
     [stopPolling]
@@ -105,7 +137,26 @@ export function useNvoipCall(): UseNvoipCallReturn {
     // (useCallBackend retorna a união dos dois). Nvoip ignora por ora — a gravação
     // do lado Nvoip é controlada server-side na própria Edge Function.
     async (phoneNumber: string, _opts?: { forceRecord?: boolean }) => {
+      // Guard de concorrência: já há uma chamada em andamento (conectando/tocando/em curso).
+      // Sem isso, dois cliques (ou "religar" do histórico durante uma chamada) abririam
+      // sessões paralelas com polling concorrente.
+      const active = !['idle', 'finished', 'noanswer', 'busy', 'failed', 'error'].includes(
+        callStateRef.current
+      );
+      if (active) {
+        toast.info('Já existe uma chamada em andamento');
+        return;
+      }
+
+      stopPolling();
+      pollErrorsRef.current = 0;
+      // Invalida qualquer poll em voo de uma chamada anterior (a resposta dele
+      // será descartada pelo guard `id !== activeCallIdRef.current`).
+      activeCallIdRef.current = null;
       setError(null);
+      // Seta o ref junto com o state pra fechar a janela síncrona do guard de
+      // concorrência: dois disparos no mesmo tick passam a ver 'connecting'.
+      callStateRef.current = 'connecting';
       setCallState('connecting');
       setCallDuration(0);
       setAudioLink(null);
@@ -126,6 +177,7 @@ export function useNvoipCall(): UseNvoipCallReturn {
         }
 
         setCallId(data.callId);
+        activeCallIdRef.current = data.callId;
         setCallState((data.state as NvoipCallState) || 'calling_origin');
 
         // Start polling every 2 seconds
@@ -143,7 +195,7 @@ export function useNvoipCall(): UseNvoipCallReturn {
         });
       }
     },
-    [pollCallStatus]
+    [pollCallStatus, stopPolling]
   );
 
   const endCall = useCallback(async () => {
@@ -153,9 +205,14 @@ export function useNvoipCall(): UseNvoipCallReturn {
       await invokeFunction('nvoip-calls', { action: 'end_call', callId });
       setCallState('finished');
       stopPolling();
+      // Não queremos mais resultados de poll desta chamada encerrada.
+      activeCallIdRef.current = null;
       toast.success('Chamada encerrada');
     } catch (err) {
-      console.error('Error ending call:', err);
+      logger.error('Erro ao encerrar chamada Nvoip', {
+        callId,
+        error: err instanceof Error ? err.message : String(err),
+      });
       toast.error('Erro ao encerrar', {
         description: err instanceof Error ? err.message : undefined,
       });

--- a/src/pages/Telefonia.tsx
+++ b/src/pages/Telefonia.tsx
@@ -1,29 +1,101 @@
 // src/pages/Telefonia.tsx
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
+import { toast } from 'sonner';
 import { useAuth } from '@/contexts/AuthContext';
 import { DialPad } from '@/components/telefonia/DialPad';
 import { CallHistoryTabs } from '@/components/telefonia/CallHistoryTabs';
+import { CallDialerView } from '@/components/call/CallDialerView';
 import { useCallBackend } from '@/hooks/useCallBackend';
 import { useIsTelefoniaManager } from '@/hooks/useIsTelefoniaManager';
+import { normalizeBrPhone, formatBrPhone } from '@/lib/phone';
 import type { CallLogTab } from '@/hooks/useCallLog';
 
 export default function Telefonia() {
   const { user } = useAuth();
   const [tab, setTab] = useState<CallLogTab>('recentes');
   const [dialPrefill, setDialPrefill] = useState('');
+  const [activePhone, setActivePhone] = useState('');
+  const [activeName, setActiveName] = useState('');
+  // Remonta o painel a cada nova tentativa → reseta o "dispensar" (X) do card anterior.
+  const [callSeq, setCallSeq] = useState(0);
   const call = useCallBackend();
   const isManager = useIsTelefoniaManager();
+
+  // Sessão de chamada ÚNICA: a página é dona; DialPad e o histórico só disparam.
+  const startCall = useCallback(
+    (phone: string, opts?: { forceRecord?: boolean }, name = '') => {
+      // Guarda no nível da página: se já há chamada em andamento (ex.: tocar
+      // "religar" no histórico durante uma chamada), NÃO troca número/nome
+      // exibidos — senão o card da chamada ativa passaria a mostrar o número
+      // novo e o operador poderia encerrar a chamada errada. O hook também
+      // barra internamente; aqui é pra manter a UI coerente com o que está no ar.
+      if (call.isActive) {
+        toast.info('Já existe uma chamada em andamento');
+        return;
+      }
+      const normalized = normalizeBrPhone(phone);
+      setActivePhone(normalized);
+      setActiveName(name);
+      setCallSeq((n) => n + 1);
+      call.makeCall(normalized, opts);
+    },
+    [call]
+  );
+
+  const busy = call.isActive || call.callState === 'connecting';
+
+  // No backend WebRTC o áudio remoto, mute e o aviso LGPD vivem no hook. Sem
+  // repassar isso, a chamada conectaria sem áudio tocando nesta tela. Em Nvoip
+  // (click-to-call, sem stream local) não há nada disso → objeto vazio.
+  const webrtcExtras =
+    call.backend === 'webrtc'
+      ? {
+          remoteStream: call.remoteStream,
+          isMuted: call.isMuted,
+          onToggleMute: call.toggleMute,
+          prerollPlaying: call.prerollPlaying,
+          prerollEndsAt: call.prerollEndsAt,
+        }
+      : {};
 
   return (
     <div className="container py-6">
       <h1 className="text-xl font-semibold mb-4">Central de Telefonia</h1>
       <div className="flex flex-col md:flex-row gap-4">
-        <DialPad key={dialPrefill} initialPhone={dialPrefill} />
+        <div className="flex flex-col gap-3">
+          <DialPad
+            key={dialPrefill}
+            initialPhone={dialPrefill}
+            backend={call.backend}
+            busy={busy}
+            onCall={(phone, opts) => startCall(phone, opts)}
+          />
+          {call.callState !== 'idle' && (
+            <CallDialerView
+              key={callSeq}
+              phoneNumber={activePhone}
+              customerName={activeName || formatBrPhone(activePhone)}
+              callState={call.callState}
+              callDuration={call.callDuration}
+              audioLink={call.audioLink}
+              error={call.error}
+              isActive={call.isActive}
+              isConnecting={call.isConnecting}
+              isRinging={call.isRinging}
+              isEstablished={call.isEstablished}
+              isFinished={call.isFinished}
+              onMakeCall={() => startCall(activePhone)}
+              onEndCall={call.endCall}
+              backendLabel={call.backend === 'webrtc' ? 'WebRTC' : 'Nvoip'}
+              {...webrtcExtras}
+            />
+          )}
+        </div>
         <div className="flex-1 rounded-lg border border-border bg-card p-3">
           <CallHistoryTabs
             userId={user?.id} tab={tab} onTabChange={setTab}
             isManager={isManager}
-            onCallBack={(phone) => { setDialPrefill(phone); call.makeCall(phone); }}
+            onCallBack={(phone, name) => { setDialPrefill(phone); startCall(phone, undefined, name); }}
           />
         </div>
       </div>


### PR DESCRIPTION
## Bug original
Na Central de Telefonia (`/telefonia`), tocar **Ligar** no iOS abria o **app Telefone do SO** em vez de chamar via **NVOIP**.

**Causa-raiz:** o iOS auto-linka números de telefone em texto puro (vira `<a href="tel:">`), e o número estava *dentro* do label do botão `Ligar 37 9...`. Não era bug da lógica de chamada.

## O que mudou (6 arquivos, só frontend)
- **Fix primário** — `<meta name="format-detection" content="telephone=no">` no `index.html` (desliga só a auto-detecção; links `tel:` explícitos, como o `CallButton` do celular, seguem ativos) + **teste de regressão** (`src/__tests__/index-html.test.ts`, order-independent).
- **Defense-in-depth** — número saiu do label do botão para uma linha `aria-hidden` própria; o botão diz só "Ligar"/"Em chamada…". Mesmo sem a meta, o CTA não tem número discável contíguo.
- **Sessão de chamada única** — antes a página **e** o `DialPad` criavam cada um sua sessão (`useCallBackend` em dobro). Agora a página `Telefonia` é a única dona; o `DialPad` virou controlado por props (`onCall`/`backend`/`busy`).
- **Status visível** — a Central passou a renderizar a `CallDialerView` (antes só tinha toast).
- **Touch targets 44px+** (WCAG AA, uso com luva) — teclas `h-12`, apagar `h-11`, `inputMode="tel"`.

## Hardening do `useNvoipCall` (revisão codex)
- **Guard de concorrência** (`callStateRef` setado de forma síncrona) — barra 2º disparo no mesmo tick; guarda espelhada no `startCall` da página pra não trocar o número exibido de uma chamada ativa.
- **Descarte de poll obsoleto** (`activeCallIdRef`) — resposta atrasada de uma chamada antiga não derruba mais o polling da nova.
- **Estado terminal de erro** — após 5 falhas consecutivas de poll, para o polling e marca `error`; erros silenciosos agora vão pro `logger`.
- **WebRTC** — props `remoteStream`/`isMuted`/`toggleMute`/`preroll*` repassadas condicionalmente (narrow por `backend`), senão a flag WebRTC conectaria sem áudio nesta tela.
- **Religar inválido** — botão desabilitado quando o telefone normalizado tem `< 10` dígitos.

## Revisão de IA
Changeset revisado pelo **codex** (read-only consult): **4 P1 + 2 P2 incorporados**. Descartado o P2 de incluir `error` em `isFinished` (mudaria `onCallEnd` de consumidores fora do escopo — FarmerCalls).

## Sem migration
Mudança **100% frontend** — **nenhuma migration / passo no Lovable** necessário.

## Test plan
- [x] `tsc --noEmit -p tsconfig.app.json` — 0 erros
- [x] `bun run typecheck:strict` — 0 erros
- [x] `bun lint` — 0 erros (82 warnings pré-existentes, baseline)
- [x] `bun run test` — **1650/1650** (310 arquivos)
- [x] `bun run build` — build PWA OK
- [ ] Smoke manual no iPhone real (Chrome do founder): tocar Ligar → chama via NVOIP, não abre o app Telefone

🤖 Generated with [Claude Code](https://claude.com/claude-code)