### PR TITLE
chore(strict): promove 12 .tsx/.ts de clusters frios (703→715)

### DIFF
--- a/src/components/aiOps/useAiOps.ts
+++ b/src/components/aiOps/useAiOps.ts
@@ -104,22 +104,23 @@ export function useAiOps() {
   const prioridades = filtered.filter((d) => d.status === 'pending');
 
   // Oportunidades: customers with good metrics but could buy more (expansion)
+  // null/undefined em métrica → 0 (reproduz a coerção numérica implícita do JS:
+  // `null > 0` é false, `null < 1.5` é true; o guard de faturamento>0 vem primeiro).
   const oportunidades = filtered.filter(
     (d) =>
       d.status === 'pending' &&
-      d.customer_metrics?.faturamento_90d > 0 &&
-      (d.customer_metrics?.atraso_relativo === null ||
-        d.customer_metrics?.atraso_relativo < 1.5)
+      (d.customer_metrics?.faturamento_90d ?? 0) > 0 &&
+      (d.customer_metrics?.atraso_relativo ?? 0) < 1.5
   );
 
   // Riscos: high churn risk (atraso >= 2x or big revenue drop)
   const riscos = filtered.filter(
     (d) =>
       d.status === 'pending' &&
-      (d.customer_metrics?.atraso_relativo >= 2.0 ||
-        (d.customer_metrics?.faturamento_prev_90d > 0 &&
-          d.customer_metrics?.faturamento_90d <
-            d.customer_metrics?.faturamento_prev_90d * 0.5))
+      ((d.customer_metrics?.atraso_relativo ?? 0) >= 2.0 ||
+        ((d.customer_metrics?.faturamento_prev_90d ?? 0) > 0 &&
+          (d.customer_metrics?.faturamento_90d ?? 0) <
+            (d.customer_metrics?.faturamento_prev_90d ?? 0) * 0.5))
   );
 
   return {

--- a/tsconfig.strict.json
+++ b/tsconfig.strict.json
@@ -721,6 +721,18 @@
     "src/components/skuMapeamento/useSkuMapeamento.ts",
     "src/pages/AdminSkuMapeamento.tsx",
     "src/components/notificacoes/useNotificacoes.ts",
-    "src/pages/AdminNotificacoes.tsx"
+    "src/pages/AdminNotificacoes.tsx",
+    "src/components/customerDashboard/useCustomerDashboard.ts",
+    "src/components/CustomerDashboard.tsx",
+    "src/components/tintColorSelect/useTintColorSelect.ts",
+    "src/components/TintColorSelectDialog.tsx",
+    "src/components/reposicao/promocoes/useUploadPromocoes.ts",
+    "src/components/reposicao/promocoes/UploadDialog.tsx",
+    "src/components/reposicao/cicloHoje/useCicloHoje.ts",
+    "src/components/reposicao/cicloHoje/AutoApproveDialog.tsx",
+    "src/components/aiOps/useAiOps.ts",
+    "src/pages/AIops.tsx",
+    "src/components/reposicao/cadeiaLogistica/useCadeiaLogistica.ts",
+    "src/pages/AdminReposicaoCadeiaLogistica.tsx"
   ]
 }


### PR DESCRIPTION
## Resumo

Batch 4 do strict frio. Clusters (blocker `.ts` + dependentes, fora de farmer/scoring/financeiro/data-health):
- **customerDashboard**: `useCustomerDashboard` + `CustomerDashboard`
- **tintColorSelect**: `useTintColorSelect` + `TintColorSelectDialog`
- **reposicao/promocoes**: `useUploadPromocoes` + `UploadDialog`
- **reposicao/cicloHoje**: `useCicloHoje` + `AutoApproveDialog`
- **reposicao/cadeiaLogistica**: `useCadeiaLogistica` + `AdminReposicaoCadeiaLogistica` (page)
- **aiOps**: `useAiOps` + `AIops` (page)

**11 tsconfig-only + 1 fix** em `useAiOps`: 5× `?? 0` em comparações de métrica nullable (TS18047). **Behavior-preserving** — reproduz a coerção numérica implícita do JS (`null > 0`=false, `null < 1.5`→`0<1.5`=true; `undefined` coberto pelo guard `faturamento>0` que vem antes na cadeia `&&`). O strict só forçou tornar a coerção explícita.

Progresso strict: **703 → 715** (~84% de 853).

## Test plan
- [x] `heavy bun run typecheck:strict` verde (0 erros)
- [x] `heavy bun lint` verde (0 erros)
- [ ] CI `validate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)