### PR TITLE
fix(sayerlack): cron de lote-retry — o motor que faltava no loop de retry do portal

### DIFF
--- a/supabase/migrations/20260528030000_cron_sayerlack_lote_retry.sql
+++ b/supabase/migrations/20260528030000_cron_sayerlack_lote_retry.sql
@@ -1,0 +1,28 @@
+-- Conserta o BUG SISTÊMICO do portal Sayerlack (descoberto pela investigação do Track A): o loop de
+-- retry de envio ao portal NÃO TINHA motor agendado. O único cron (sayerlack-portal-watchdog */5) chama
+-- a edge com {watchdog:true} → roda APENAS runWatchdog (des-trava itens presos em 'enviando_portal') e
+-- RETORNA — nunca alcança o modo LOTE (que re-envia pendente_envio_portal/erro_retentavel com
+-- portal_proximo_retry_em vencido). Resultado: todo envio que falha transitório (timeout do Browserless)
+-- agenda um retry (+15min) que NUNCA é disparado → pedido órfão pra sempre. Era a causa do backlog de
+-- ~R$21k de pedidos Sayerlack retentáveis parados desde 14-15/05.
+--
+-- FIX: cron dedicado que chama a edge em MODO LOTE (body {} = sem watchdog, sem pedido_id). O lote já é
+-- bounded (MAX_PEDIDOS_POR_EXECUCAO=5/run) + async (202 + EdgeRuntime.waitUntil em background) + tem lock
+-- anti-overlap, então é seguro agendar. */15 alinha com o backoff de retry de 15min. Idle é barato
+-- (candidatos=0 → retorna rápido). Coexiste com o watchdog */5 (concerns distintos: enviando_portal preso
+-- × re-envio de retentável). ⚠️ NÃO cobre: erro_nao_retentavel (SKU sem mapeamento — precisa mapear/cancelar),
+-- falha_envio_portal com tentativas>=3 (precisa "Forçar reenvio ao portal" na UI), nem aprovado_aguardando_disparo
+-- órfão (precisa re-disparo via disparar-pedidos-aprovados com pedido_id). Esses são triagem operacional.
+-- ⚠️ Ao aplicar, o cron passa a re-enviar o backlog retentável atual (~R$21k, aprovado 14-15/05) — revise/
+-- cancele os que estiverem obsoletos ANTES, se houver.
+
+SELECT cron.schedule('sayerlack-portal-lote-retry', '*/15 * * * *',
+  $$ SELECT net.http_post(
+    url := 'https://fzvklzpomgnyikkfkzai.supabase.co/functions/v1/enviar-pedido-portal-sayerlack',
+    headers := jsonb_build_object(
+      'Content-Type', 'application/json',
+      'x-cron-secret', (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name='CRON_SECRET' LIMIT 1)
+    ),
+    body := '{}'::jsonb,
+    timeout_milliseconds := 60000
+  ); $$);


### PR DESCRIPTION
## Resumo

Investigação do Track A → **bug sistêmico** no portal Sayerlack: o loop de retry de envio **não tinha motor agendado**. O cron `sayerlack-portal-watchdog` (`*/5`) chama `{watchdog:true}` → roda só `runWatchdog` (des-trava `enviando_portal`) e RETORNA — **nunca alcança o modo LOTE** que re-envia `pendente_envio_portal`/`erro_retentavel` com `portal_proximo_retry_em` vencido. Todo timeout transitório do Browserless agendava retry +15min que **nunca disparava** → órfão. Backlog: ~R$21k de pedidos retentáveis parados há ~2 semanas.

**Fix (cron-only):** `sayerlack-portal-lote-retry` (`*/15`) chama a edge em modo lote (`body {}`). O lote é bounded (5/run), async (202 + waitUntil), com lock anti-overlap. **Sem double-send:** o conjunto retentável é só "POST comprovadamente nunca saiu" (caso ambíguo pós-submit → `indeterminado_requer_conciliacao`, fora do retry). **Codex validou** (cron-lote > estender watchdog; risco de double-send mitigado pelo indeterminado).

**Não cobre** (triagem operacional à parte): `erro_nao_retentavel` (SKU sem mapeamento), `falha_envio_portal` tent>=3 (Forçar reenvio na UI), `aprovado_aguardando_disparo` órfão (re-disparo). Camada 2 (fragilidade do Browserless) é projeto à parte.

## ⚠️ Migration manual via SQL Editor — APLICAR APÓS triar o backlog antigo
Codex money-path: o backlog de 2 semanas pode ter pedido obsoleto/cancelado/enviado-manual. Revise antes (o cron passa a re-enviar os retentáveis ao aplicar).

## Test plan
- [x] Cron-only (sem edge); lote já é bounded+async+lock
- [ ] Aplicar (após triar) → `cron.job` tem `sayerlack-portal-lote-retry` `*/15`; monitorar `status_envio_portal` dos retentáveis virando `sucesso_portal`

🤖 Generated with [Claude Code](https://claude.com/claude-code)