### PR TITLE
chore(strict): promove 6 frios — adminCustomers + impersonation (715→721)

### DIFF
--- a/tsconfig.strict.json
+++ b/tsconfig.strict.json
@@ -733,6 +733,12 @@
     "src/components/aiOps/useAiOps.ts",
     "src/pages/AIops.tsx",
     "src/components/reposicao/cadeiaLogistica/useCadeiaLogistica.ts",
-    "src/pages/AdminReposicaoCadeiaLogistica.tsx"
+    "src/pages/AdminReposicaoCadeiaLogistica.tsx",
+    "src/components/adminCustomers/RequiresPoToggle.tsx",
+    "src/components/adminCustomers/Customer360View.tsx",
+    "src/contexts/ImpersonationContext.tsx",
+    "src/components/impersonation/ImpersonationBanner.tsx",
+    "src/hooks/useImpersonationTargets.ts",
+    "src/components/impersonation/ViewAsPicker.tsx"
   ]
 }


### PR DESCRIPTION
## Resumo

Batch frio final desta rodada (clusters limpos, tsconfig-only):
- **adminCustomers**: `RequiresPoToggle` + `Customer360View`
- **impersonation** (#331 estável): `ImpersonationContext` + `ImpersonationBanner` + `useImpersonationTargets` + `ViewAsPicker`

`typecheck:strict` verde, zero edição de source.

**Dropados do batch** (a triagem revelou que não são leaf / têm risco):
- `reposicao/CicloHojePanel` + `AdminReposicaoSessaoPedidos` — `CicloHojePanel` faz `lazy(() => import("@/pages/AdminReposicaoPedidos"))`, puxando uma **página god-component + subgrafo** (lição do lane doc: `lazy()`/`import()` = não-leaf). Tem um bug latente em `CiclosAnteriores` (`string|null`).
- `shell/CommandPalette` — RISKY (supabase/useGlobalSearch) + `Icon` unused a fixar + componente de alto tráfego.

Progresso strict: **715 → 721** (~85% de 853).

## Test plan
- [x] `heavy bun run typecheck:strict` verde (0 erros)
- [x] tsconfig-only
- [ ] CI `validate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)