### PR TITLE
fix(dashboard): troca de persona reativa sem reload

### DIFF
--- a/src/components/dashboard/DashboardShell.tsx
+++ b/src/components/dashboard/DashboardShell.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useMemo, useRef } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
-import { usePersona } from '@/hooks/usePersona';
 import { DashboardPersonaProvider, useDashboardPersonaContext } from '@/contexts/DashboardPersonaContext';
 import { DashboardEditModeProvider } from '@/contexts/DashboardEditModeContext';
 import { useRegisterShortcuts } from '@/components/shell/ShortcutsRegistry';
@@ -22,9 +21,8 @@ import { PERSONA_CONFIG, type ZoneId } from '@/lib/dashboard/persona-config';
 import type { PriorityCandidate } from '@/lib/dashboard/priority-rules';
 
 export function DashboardShell() {
-  const resolved = usePersona();
   return (
-    <DashboardPersonaProvider resolved={resolved}>
+    <DashboardPersonaProvider>
       <DashboardEditModeProvider>
         <DashboardBody />
       </DashboardEditModeProvider>

--- a/src/contexts/DashboardPersonaContext.tsx
+++ b/src/contexts/DashboardPersonaContext.tsx
@@ -1,6 +1,7 @@
 import { createContext, useContext, useMemo, useState, type ReactNode } from 'react';
 import type { Persona } from '@/lib/dashboard/persona-config';
 import type { PersonaSource } from '@/lib/dashboard/persona-detect';
+import { usePersona } from '@/hooks/usePersona';
 
 const STORAGE_KEY = 'dashboardPersonaOverride';
 
@@ -20,19 +21,18 @@ export function useDashboardPersonaContext(): DashboardPersonaCtx {
   return v;
 }
 
-export function DashboardPersonaProvider({
-  resolved,
-  children,
-}: {
-  /** Persona resolvida pelo hook usePersona considerando o override atual. */
-  resolved: { persona: Persona; source: PersonaSource };
-  children: ReactNode;
-}) {
+export function DashboardPersonaProvider({ children }: { children: ReactNode }) {
   const [override, setOverrideState] = useState<Persona | null>(() => {
     if (typeof window === 'undefined') return null;
     const raw = localStorage.getItem(STORAGE_KEY);
     return raw && typeof raw === 'string' ? (raw as Persona) : null;
   });
+
+  // usePersona é chamado AQUI (abaixo do estado de override) pra que trocar de
+  // persona re-renderize e recompute a resolução. Antes ele vivia no
+  // DashboardShell (pai), então o setOverride do filho nunca re-rodava a
+  // resolução → a troca só aparecia após reload.
+  const resolved = usePersona(override);
 
   const setOverride = (p: Persona) => {
     setOverrideState(p);

--- a/src/contexts/__tests__/DashboardPersonaContext.test.tsx
+++ b/src/contexts/__tests__/DashboardPersonaContext.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+
+vi.mock('@/contexts/AuthContext', () => ({ useAuth: vi.fn() }));
+vi.mock('@/hooks/useCommercialRole', () => ({ useCommercialRole: vi.fn() }));
+vi.mock('@/hooks/useSalesOnlyRestriction', () => ({ useSalesOnlyRestriction: vi.fn() }));
+vi.mock('@/hooks/useUserDepartment', () => ({ useUserDepartment: vi.fn() }));
+vi.mock('@/lib/dashboard/route-tracker', () => ({ getRouteCounts: vi.fn(() => ({})) }));
+
+import { useAuth } from '@/contexts/AuthContext';
+import { useCommercialRole } from '@/hooks/useCommercialRole';
+import { useSalesOnlyRestriction } from '@/hooks/useSalesOnlyRestriction';
+import { useUserDepartment } from '@/hooks/useUserDepartment';
+import { DashboardPersonaProvider, useDashboardPersonaContext } from '../DashboardPersonaContext';
+
+const mockedUseAuth = vi.mocked(useAuth);
+const mockedCommercial = vi.mocked(useCommercialRole);
+const mockedSalesOnly = vi.mocked(useSalesOnlyRestriction);
+const mockedDept = vi.mocked(useUserDepartment);
+
+function Consumer() {
+  const { persona, source, setOverride, clearOverride } = useDashboardPersonaContext();
+  return (
+    <div>
+      <span data-testid="persona">{persona}</span>
+      <span data-testid="source">{source}</span>
+      <button onClick={() => setOverride('vendedor')}>vendedor</button>
+      <button onClick={() => clearOverride()}>clear</button>
+    </div>
+  );
+}
+
+describe('DashboardPersonaProvider', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    mockedUseAuth.mockReturnValue({ role: 'master' } as ReturnType<typeof useAuth>);
+    mockedCommercial.mockReturnValue({ commercialRole: null } as ReturnType<typeof useCommercialRole>);
+    mockedSalesOnly.mockReturnValue(false);
+    mockedDept.mockReturnValue({ department: null } as ReturnType<typeof useUserDepartment>);
+  });
+
+  it('troca de persona reativamente quando setOverride é chamado (sem reload)', () => {
+    render(<DashboardPersonaProvider><Consumer /></DashboardPersonaProvider>);
+    expect(screen.getByTestId('persona').textContent).toBe('master');
+    expect(screen.getByTestId('source').textContent).toBe('default');
+    act(() => { screen.getByText('vendedor').click(); });
+    expect(screen.getByTestId('persona').textContent).toBe('vendedor');
+    expect(screen.getByTestId('source').textContent).toBe('manual');
+  });
+
+  it('persiste o override no localStorage e limpa com clearOverride', () => {
+    render(<DashboardPersonaProvider><Consumer /></DashboardPersonaProvider>);
+    act(() => { screen.getByText('vendedor').click(); });
+    expect(localStorage.getItem('dashboardPersonaOverride')).toBe('vendedor');
+    act(() => { screen.getByText('clear').click(); });
+    expect(localStorage.getItem('dashboardPersonaOverride')).toBeNull();
+    expect(screen.getByTestId('persona').textContent).toBe('master');
+  });
+
+  it('inicializa a partir do override persistido no localStorage', () => {
+    localStorage.setItem('dashboardPersonaOverride', 'financeiro');
+    render(<DashboardPersonaProvider><Consumer /></DashboardPersonaProvider>);
+    expect(screen.getByTestId('persona').textContent).toBe('financeiro');
+    expect(screen.getByTestId('source').textContent).toBe('manual');
+  });
+});

--- a/src/hooks/usePersona.ts
+++ b/src/hooks/usePersona.ts
@@ -7,20 +7,14 @@ import { getRouteCounts } from '@/lib/dashboard/route-tracker';
 import { inferPersona, type InferPersonaResult } from '@/lib/dashboard/persona-detect';
 import type { Persona } from '@/lib/dashboard/persona-config';
 
-const STORAGE_KEY = 'dashboardPersonaOverride';
-
-function readOverride(): Persona | null {
-  if (typeof window === 'undefined') return null;
-  const raw = localStorage.getItem(STORAGE_KEY);
-  return raw ? (raw as Persona) : null;
-}
-
 /**
- * Resolve persona combinando todos os sinais. Lê override do localStorage diretamente
- * pra evitar dependência circular com DashboardPersonaContext (que envolve em volta).
- * O Context expõe setOverride/clearOverride pra UI.
+ * Resolve persona combinando todos os sinais. O override manual é a única fonte
+ * de verdade do DashboardPersonaContext e entra como argumento — listá-lo nas
+ * deps do useMemo garante que trocar de persona recomputa a resolução na hora.
+ * Por isso o hook é chamado dentro do provider (abaixo do estado de override),
+ * não acima dele.
  */
-export function usePersona(): InferPersonaResult {
+export function usePersona(override: Persona | null): InferPersonaResult {
   const { role } = useAuth();
   const { commercialRole } = useCommercialRole();
   const isSalesOnly = useSalesOnlyRestriction();
@@ -28,12 +22,12 @@ export function usePersona(): InferPersonaResult {
 
   return useMemo(() => {
     return inferPersona({
-      override: readOverride(),
+      override,
       role,
       commercialRole,
       isSalesOnly,
       routeCounts: getRouteCounts(),
       userDepartment: department,
     });
-  }, [role, commercialRole, isSalesOnly, department]);
+  }, [override, role, commercialRole, isSalesOnly, department]);
 }


### PR DESCRIPTION
## Resumo
- Trocar a visão no dropdown "Trocar visão" do Master Dashboard não reagia ao clique — a ordem dos cockpits e a ação prioritária só mudavam após recarregar a página.
- **Causa-raiz:** `usePersona()` era chamado no `DashboardShell` (pai), mas o estado de troca manual vivia no `DashboardPersonaProvider` (filho) → o `setOverride` do filho nunca re-rodava a resolução do pai. Além disso, o override ficava fora das deps do `useMemo` de `usePersona`.
- **Fix:** `usePersona(override)` recebe o override por argumento (entra nas deps do memo) e a chamada do hook foi movida para **dentro** do provider, abaixo do `useState` — colapsa as duas fontes de verdade numa só.

## Arquivos
- `src/hooks/usePersona.ts` — assinatura `usePersona(override)`, `override` nas deps, removido `readOverride()`/`STORAGE_KEY` daqui.
- `src/contexts/DashboardPersonaContext.tsx` — provider é dono do `override` e chama `usePersona(override)`; removida a prop `resolved`.
- `src/components/dashboard/DashboardShell.tsx` — deixa de chamar `usePersona`; renderiza `<DashboardPersonaProvider>` sem props.
- `src/contexts/__tests__/DashboardPersonaContext.test.tsx` — teste de regressão (troca reativa sem reload + persistência localStorage).

## Verificação
- Teste novo: 3/3.
- Suíte completa: 311 arquivos / 1659 testes, sem regressões.
- `typecheck:strict` + baseline `tsc -p tsconfig.app.json`: exit 0.

Fix puro de frontend — sem migration / edge function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)