### PR TITLE
feat(telefonia): toggle de transporte (WebRTC×Nvoip) na própria tela

### DIFF
--- a/src/pages/Telefonia.tsx
+++ b/src/pages/Telefonia.tsx
@@ -7,6 +7,8 @@ import { CallHistoryTabs } from '@/components/telefonia/CallHistoryTabs';
 import { CallDialerView } from '@/components/call/CallDialerView';
 import { useCallBackend } from '@/hooks/useCallBackend';
 import { useIsTelefoniaManager } from '@/hooks/useIsTelefoniaManager';
+import { useFeatureFlag } from '@/hooks/useFeatureFlag';
+import { Switch } from '@/components/ui/switch';
 import { normalizeBrPhone, formatBrPhone } from '@/lib/phone';
 import type { CallLogTab } from '@/hooks/useCallLog';
 
@@ -20,6 +22,10 @@ export default function Telefonia() {
   const [callSeq, setCallSeq] = useState(0);
   const call = useCallBackend();
   const isManager = useIsTelefoniaManager();
+  // Controle de transporte NA PRÓPRIA tela (sem depender do /settings escondido,
+  // cujo flag em localStorage é frágil no Safari iOS). Liga aqui → o backend muda
+  // na hora (useCallBackend escuta o mesmo flag via storage event).
+  const [useWebRTC, setUseWebRTC] = useFeatureFlag('useWebRTCCall', false);
 
   // Sessão de chamada ÚNICA: a página é dona; DialPad e o histórico só disparam.
   const startCall = useCallback(
@@ -63,6 +69,22 @@ export default function Telefonia() {
       <h1 className="text-xl font-semibold mb-4">Central de Telefonia</h1>
       <div className="flex flex-col md:flex-row gap-4">
         <div className="flex flex-col gap-3">
+          <div className="w-full max-w-[260px] rounded-lg border border-border bg-card p-3 flex items-center justify-between gap-2">
+            <div className="min-w-0">
+              <p className="text-sm font-medium">Ligar pelo navegador</p>
+              <p className="text-[11px] text-muted-foreground mt-0.5">
+                {useWebRTC
+                  ? 'WebRTC — grava + copiloto ao vivo'
+                  : 'Operadora (Nvoip) — sem copiloto ao vivo'}
+              </p>
+            </div>
+            <Switch
+              checked={useWebRTC}
+              onCheckedChange={setUseWebRTC}
+              disabled={busy}
+              aria-label="Ligar pelo navegador (WebRTC)"
+            />
+          </div>
           <DialPad
             key={dialPrefill}
             initialPhone={dialPrefill}


### PR DESCRIPTION
## Por quê
A flag `useWebRTCCall` (que escolhe WebRTC in-browser × Nvoip click-to-call) só era acessível via `/settings` — que **não tem item de menu no mobile** — e mora em `localStorage` **por aparelho**, frágil no Safari iOS (não propagava pra Central; não sobrevivia a refresh). Resultado: no iPhone era impossível, na prática, ativar o WebRTC pra testar gravação + copiloto ao vivo.

## O que muda
Coloca o controle de transporte **na própria tela da Central de Telefonia**: um switch "Ligar pelo navegador".
- Ligado → **WebRTC** (grava + copiloto ao vivo); desligado → **Operadora (Nvoip)**.
- Troca o backend **na hora** (o `useCallBackend` escuta o mesmo flag via storage event) — sem depender do `/settings` nem do flag persistir.
- **Desabilitado durante chamada ativa** (não troca backend no meio).
- **Default inalterado** (Nvoip click-to-call) — é opt-in, reversível.

Contido a `src/pages/Telefonia.tsx` (+22 linhas). Não toca `CallButton`/Customer 360.

## Contexto
Passo de desbloqueio pra **pilotar o WebRTC num iPhone real** (única forma de ter gravação + tempo real no celular; confirmado por análise + consult codex). Próximos passos dependem do resultado do piloto (política central de transporte, fim do `tel:` silencioso no CallButton, painel de copiloto na superfície mobile).

## Sem migration
Mudança 100% frontend.

## Test plan
- [ ] CI `validate` (typecheck app + strict + test + build + lint)
- [ ] iPhone real: na Central, ligar o switch → rótulo muda pra "backend: WEBRTC" → Ligar → permitir microfone → validar áudio/preroll/queda ao bloquear tela

🤖 Generated with [Claude Code](https://claude.com/claude-code)