### PR TITLE
fix(telefonia): aviso LGPD de gravação não tocava (preroll dependia de env ausente)

### DIFF
--- a/src/contexts/WebRTCCallContext.tsx
+++ b/src/contexts/WebRTCCallContext.tsx
@@ -139,7 +139,12 @@ export function WebRTCCallProvider({ children }: ProviderProps) {
   const prerollPlayRef = useRef<(() => void) | null>(null);
   const prerollDurationRef = useRef<number | null>(null);
   const prerollFinishTimerRef = useRef<number | null>(null);
-  const prerollUrl = (import.meta.env.VITE_NVOIP_SIP_PREROLL_URL as string | undefined);
+  // Default pro MP3 servido em public/ — o aviso LGPD NÃO pode depender de uma env
+  // estar setada no build (não estava em produção → o pre-roll era pulado e a gravação
+  // saía sem aviso). A env fica como override opcional (CDN/arquivo custom).
+  const prerollUrl =
+    (import.meta.env.VITE_NVOIP_SIP_PREROLL_URL as string | undefined) ||
+    '/preroll/aviso-gravacao-lgpd.mp3';
 
   // PR4 — Refs pra persistência da sessão de chamada
   const analysisHistoryRef = useRef<SpinAnalysis[]>([]);

--- a/src/lib/sip/audio-preroll.test.ts
+++ b/src/lib/sip/audio-preroll.test.ts
@@ -20,6 +20,7 @@ describe('mixPrerollWithMic', () => {
       })),
       decodeAudioData: vi.fn().mockResolvedValue({ duration: 5 }),
       destination: {},
+      resume: vi.fn().mockResolvedValue(undefined),
       close: vi.fn().mockResolvedValue(undefined),
     };
     vi.stubGlobal('AudioContext', vi.fn(() => audioContextMock));
@@ -47,8 +48,10 @@ describe('mixPrerollWithMic', () => {
     // Antes de play(): source NÃO foi iniciado
     expect(source.start).not.toHaveBeenCalled();
 
-    // Após play(): source inicia
+    // Após play(): retoma o AudioContext (hardening iOS — pode ter suspendido entre
+    // o gesto e o 'established') e inicia o source.
     result.play();
+    expect(audioContextMock.resume).toHaveBeenCalledTimes(1);
     expect(source.start).toHaveBeenCalledTimes(1);
   });
 

--- a/src/lib/sip/audio-preroll.ts
+++ b/src/lib/sip/audio-preroll.ts
@@ -48,6 +48,10 @@ export async function mixPrerollWithMic(
     play: () => {
       if (played) return;
       played = true;
+      // iOS/Safari: o AudioContext pode ter suspendido entre o makeCall (gesto do
+      // usuário) e o 'established' (segundos depois). resume() reativa antes de tocar
+      // — no-op se já estiver running. Sem isso, no iPhone o aviso pode não sair.
+      void ctx.resume();
       prerollSource.start();
     },
     close: () => {


### PR DESCRIPTION
## Bug
Na Central de Telefonia (WebRTC), ligar **"Gravar esta chamada"** gravava a ligação **sem tocar o aviso LGPD** ("Sara") pro cliente — risco de compliance.

## Causa-raiz
O pre-roll só é mixado se `VITE_NVOIP_SIP_PREROLL_URL` estiver setada. Essa env **só existe no `.env.example`**, não no `.env` real nem no build de produção do Lovable → `prerollUrl = undefined` → o bloco inteiro do aviso (`if (prerollUrl)`) é **pulado**. A gravação/transcrição até ligava, mas sem o aviso ao cliente.

## Correção
- **`WebRTCCallContext`:** `prerollUrl` agora cai pro caminho estático `/preroll/aviso-gravacao-lgpd.mp3` (o MP3 está commitado em `public/preroll/`, sempre servido). A env vira **override opcional** (CDN/arquivo custom). Some a dependência frágil de env de build.
- **`audio-preroll.ts`:** `void ctx.resume()` antes de `prerollSource.start()` — no iOS/Safari o `AudioContext` pode suspender entre o tap (makeCall) e o atendimento ('established'); `resume()` reativa (no-op se já running). Sem isso o aviso pode não sair no iPhone.

Contido a 2 arquivos (+10/-1). Só afeta o caminho WebRTC com gravação ligada.

## Sem migration
Mudança 100% frontend.

## Test plan
- [ ] CI `validate`
- [ ] iPhone real: Central → "Gravar esta chamada" ON → ligar pra um 2º telefone → no 2º telefone deve **tocar o aviso "Sara"** ao atender; no iPhone que liga, aparece o banner "🔇 Aviso de gravação LGPD tocando"

🤖 Generated with [Claude Code](https://claude.com/claude-code)