### PR TITLE
fix(saude-dados): check ok não exibe mais erro já recuperado

### DIFF
--- a/src/lib/dataHealth/__tests__/health-helpers.test.ts
+++ b/src/lib/dataHealth/__tests__/health-helpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { badgeLevel, rollupDomain, formatAge, isHealthy } from '../health-helpers';
+import { badgeLevel, rollupDomain, formatAge, isHealthy, shouldShowDiagnostics } from '../health-helpers';
 import type { DataHealthCheck } from '../types';
 
 const mk = (over: Partial<DataHealthCheck>): DataHealthCheck => ({
@@ -50,4 +50,19 @@ describe('formatAge', () => {
 describe('isHealthy', () => {
   it('só ok', () => { expect(isHealthy([mk({ status: 'ok' })])).toBe(true); });
   it('stale não é healthy', () => { expect(isHealthy([mk({ status: 'stale' })])).toBe(false); });
+});
+
+describe('shouldShowDiagnostics', () => {
+  it('check ok NÃO exibe diagnóstico (esconde erro transitório já recuperado)', () => {
+    expect(shouldShowDiagnostics(mk({ status: 'ok', last_error: 'orphaned_running_timeout' }))).toBe(false);
+  });
+  it('stale exibe diagnóstico', () => {
+    expect(shouldShowDiagnostics(mk({ status: 'stale' }))).toBe(true);
+  });
+  it('broken exibe diagnóstico', () => {
+    expect(shouldShowDiagnostics(mk({ status: 'broken' }))).toBe(true);
+  });
+  it('unknown exibe diagnóstico', () => {
+    expect(shouldShowDiagnostics(mk({ status: 'unknown' }))).toBe(true);
+  });
 });

--- a/src/lib/dataHealth/health-helpers.ts
+++ b/src/lib/dataHealth/health-helpers.ts
@@ -18,6 +18,16 @@ export function isHealthy(checks: DataHealthCheck[]): boolean {
   return checks.length > 0 && checks.every(c => c.status === 'ok');
 }
 
+/**
+ * Diagnóstico (último erro, causa provável, como resolver) só vale para check
+ * NÃO-ok. Um check saudável não pode exibir falha transitória já recuperada — ex:
+ * a órfã `orphaned_running_timeout` que o fin-sync-watchdog marca e que o `last_error`
+ * da RPC carrega indefinidamente — como se fosse problema atual.
+ */
+export function shouldShowDiagnostics(check: DataHealthCheck): boolean {
+  return check.status !== 'ok';
+}
+
 export interface DomainRollup { domain: HealthDomain; status: HealthStatus; checks: DataHealthCheck[]; }
 
 export function rollupDomain(checks: DataHealthCheck[]): DomainRollup[] {

--- a/src/pages/SaudeDados.tsx
+++ b/src/pages/SaudeDados.tsx
@@ -3,7 +3,7 @@ import { PageSkeleton } from '@/components/ui/page-skeleton';
 import { EmptyState } from '@/components/EmptyState';
 import { ShieldAlert } from 'lucide-react';
 import { useDataHealth } from '@/hooks/useDataHealth';
-import { rollupDomain, formatAge, badgeLevel } from '@/lib/dataHealth/health-helpers';
+import { rollupDomain, formatAge, badgeLevel, shouldShowDiagnostics } from '@/lib/dataHealth/health-helpers';
 
 const DOMAIN_LABEL: Record<string, string> = {
   financeiro: 'Financeiro', omie_sync: 'Syncs Omie', carteira: 'Carteira / Scoring', estoque: 'Estoque / Reposição', vendas: 'Vendas / Pedidos', alertas: 'Canal de alerta',
@@ -52,9 +52,13 @@ export default function SaudeDados() {
                     {c.status} · {formatAge(c.age_seconds)}
                   </span>
                 </div>
-                {c.probable_cause && <p className="text-xs text-muted-foreground mt-0.5">Causa provável: {c.probable_cause}</p>}
-                {c.how_to_fix && <p className="text-xs text-status-info mt-0.5">Como resolver: {c.how_to_fix}</p>}
-                {c.last_error && <p className="text-xs text-status-error mt-0.5 font-mono">{c.last_error}</p>}
+                {shouldShowDiagnostics(c) && (
+                  <>
+                    {c.probable_cause && <p className="text-xs text-muted-foreground mt-0.5">Causa provável: {c.probable_cause}</p>}
+                    {c.how_to_fix && <p className="text-xs text-status-info mt-0.5">Como resolver: {c.how_to_fix}</p>}
+                    {c.last_error && <p className="text-xs text-status-error mt-0.5 font-mono">{c.last_error}</p>}
+                  </>
+                )}
               </div>
             ))}
           </CardContent>


### PR DESCRIPTION
## Resumo
- O card de Saúde de Dados com `status=ok` exibia o `last_error` em vermelho — ex.: `orphaned_running_timeout`, que o `fin-sync-watchdog` grava ao varrer uma órfã de `sync_pedidos` já recuperada nos ciclos seguintes. A página renderizava `last_error`/`how_to_fix`/`probable_cause` sempre que não-nulos, ignorando o status → falso alarme num check saudável.
- Fix na camada de apresentação (**sem migration**): `shouldShowDiagnostics(check) = status !== 'ok'` (lógica pura testada); `SaudeDados.tsx` só renderiza os 3 campos de diagnóstico quando o check não está ok. Vale pra todos os domínios. Coerente com a filosofia tail-failing adotada hoje no watchdog.
- O watchdog e os alertas por email **não** são afetados (usam `message` e só disparam com `status <> 'ok'`). Único consumidor de `last_error` é a página.

## Test plan
- [x] vitest `health-helpers` — 16/16 (regressão: status ok + last_error → esconde)
- [x] `typecheck:strict` rc=0 (cobre `health-helpers.ts`)
- [x] `tsc -p tsconfig.app.json` rc=0 (cobre `SaudeDados.tsx`)

ℹ️ Sem migration / sem deploy de edge — React puro; o build normal do Lovable publica.

🤖 Generated with [Claude Code](https://claude.com/claude-code)