### PR TITLE
fix(telefonia): clareza no erro da Nvoip (valida OAUTH_BASIC + surfaca erro real)

### DIFF
--- a/src/lib/invoke-function.ts
+++ b/src/lib/invoke-function.ts
@@ -35,15 +35,34 @@ export async function invokeFunction<T = unknown>(
   });
 
   if (error) {
-    const errWithMeta = error as { message?: string; code?: string; status?: number };
+    const errWithMeta = error as { message?: string; code?: string; status?: number; context?: unknown };
+    // FunctionsHttpError expõe a Response da função em `context`. O corpo traz o erro
+    // REAL do servidor (ex.: "Falha ao autenticar na Nvoip: 401"); o `error.message` do
+    // supabase é sempre o genérico "Edge Function returned a non-2xx status code".
+    let serverMessage: string | undefined;
+    const ctx = errWithMeta.context;
+    if (ctx && typeof (ctx as Response).clone === 'function') {
+      try {
+        const parsed: unknown = await (ctx as Response).clone().json();
+        if (
+          parsed && typeof parsed === 'object' &&
+          'error' in parsed && typeof (parsed as { error: unknown }).error === 'string'
+        ) {
+          serverMessage = (parsed as { error: string }).error;
+        }
+      } catch {
+        /* corpo não-JSON ou já consumido — mantém o fallback genérico */
+      }
+    }
     logger.error(`Edge function failed: ${functionName}`, {
       functionName,
       errorCode: errWithMeta.code,
       httpStatus: errWithMeta.status,
+      serverMessage,
       error,
     });
     throw new EdgeFunctionError(
-      error.message || `Erro ao chamar ${functionName}`,
+      serverMessage || error.message || `Erro ao chamar ${functionName}`,
       functionName,
     );
   }

--- a/supabase/functions/nvoip-calls/index.ts
+++ b/supabase/functions/nvoip-calls/index.ts
@@ -62,9 +62,11 @@ Deno.serve(async (req) => {
     const numbersip = Deno.env.get("NVOIP_NUMBERSIP");
     const userToken = Deno.env.get("NVOIP_USER_TOKEN");
 
-    if (!napikey || !numbersip || !userToken) {
+    // NVOIP_OAUTH_BASIC (Basic client auth do OAuth) também é obrigatório — sem ele o
+    // header vira "Basic " vazio e a Nvoip devolve um 401 opaco no /oauth/token.
+    if (!napikey || !numbersip || !userToken || !NVOIP_OAUTH_BASIC_ENV) {
       return new Response(
-        JSON.stringify({ error: "Credenciais Nvoip não configuradas. Configure NVOIP_NAPIKEY, NVOIP_NUMBERSIP e NVOIP_USER_TOKEN." }),
+        JSON.stringify({ error: "Credenciais Nvoip não configuradas. Configure NVOIP_NAPIKEY, NVOIP_NUMBERSIP, NVOIP_USER_TOKEN e NVOIP_OAUTH_BASIC." }),
         { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } }
       );
     }


### PR DESCRIPTION
## Contexto
O click-to-call da Nvoip falhava com um toast opaco **"Edge Function returned a non-2xx status code"**. O log de produção da `nvoip-calls` revelou a causa real: **401 no `/v2/oauth/token`** (credenciais REST da Nvoip rejeitadas). A correção das credenciais é no **backend (Lovable)** — este PR é só de **clareza/diagnóstico**.

## Mudanças
- **`supabase/functions/nvoip-calls/index.ts`:** inclui `NVOIP_OAUTH_BASIC` na checagem de "Credenciais Nvoip não configuradas". Faltava — e sem ele o header OAuth vira `Basic ` vazio, produzindo exatamente um 401 opaco. Agora dá mensagem clara.
- **`src/lib/invoke-function.ts`:** ao receber erro, lê o corpo da `Response` (`error.context`) e usa a mensagem **real** do servidor (ex.: "Falha ao autenticar na Nvoip: 401") em vez do genérico do supabase-js. Backward-compatible (sem `context` → fallback inalterado). Beneficia **todos** os callers de edge function.

## ⚠️ Deploy manual da edge function
A `nvoip-calls` é Deno — **precisa de REDEPLOY manual via chat do Lovable** (ler de `supabase/functions/nvoip-calls/index.ts`). O front (`invokeFunction`) entra no republish normal.

## Sem migration

## Test plan
- [ ] CI `validate` (typecheck app + strict + test + build + lint) — `invoke-function.ts` está no strict
- [ ] Após corrigir as credenciais no Lovable: ligar sem WebRTC → deve **conectar** (não mais 401)
- [ ] Se ainda falhar: o toast agora mostra a **causa real** da Nvoip

🤖 Generated with [Claude Code](https://claude.com/claude-code)