### PR TITLE
feat(reposição): aprovar = disparar na hora + motor de retry Sayerlack

### DIFF
--- a/src/components/reposicao/pedidos/DetalhesModal.tsx
+++ b/src/components/reposicao/pedidos/DetalhesModal.tsx
@@ -141,7 +141,7 @@ export function DetalhesModal({
                 title={!condicaoSelecionada ? 'Selecione a condição de pagamento antes de aprovar' : ''}
               >
                 {aprovarMutation.isPending && <Loader2 className="w-4 h-4 mr-1 animate-spin" />}
-                ✓ Aprovar pedido completo
+                ✓ Aprovar e disparar agora
               </Button>
             </>
           )}

--- a/src/components/reposicao/pedidos/PedidoRow.tsx
+++ b/src/components/reposicao/pedidos/PedidoRow.tsx
@@ -24,6 +24,10 @@ export function PedidoRow({
   const podeAprovar = p.status === 'pendente_aprovacao' || p.status === 'bloqueado_guardrail';
   const podeCancelar = ['pendente_aprovacao', 'bloqueado_guardrail', 'aprovado_aguardando_disparo'].includes(p.status);
   const podeDisparar = p.status === 'aprovado_aguardando_disparo';
+  // Guard de concorrência: enquanto o envio ao portal está em voo (após "aprovar e
+  // disparar" ou um disparo manual), trava o botão pra não abrir uma 2ª sessão no
+  // Browserless e gerar PO duplicado no fornecedor.
+  const enviandoPortal = p.status_envio_portal === 'enviando_portal';
 
   const showAprovacao = p.status === 'aprovado_aguardando_disparo' || p.status === 'disparado';
 
@@ -71,9 +75,9 @@ export function PedidoRow({
             <Button size="sm" variant="default" onClick={onVerDetalhes}>Aprovar</Button>
           )}
           {podeDisparar && (
-            <Button size="sm" variant="default" onClick={onDisparar} disabled={disparando}>
-              {disparando ? <Loader2 className="w-4 h-4 mr-1 animate-spin" /> : <Zap className="w-4 h-4 mr-1" />}
-              Disparar
+            <Button size="sm" variant="default" onClick={onDisparar} disabled={disparando || enviandoPortal}>
+              {(disparando || enviandoPortal) ? <Loader2 className="w-4 h-4 mr-1 animate-spin" /> : <Zap className="w-4 h-4 mr-1" />}
+              {enviandoPortal ? 'Enviando…' : 'Disparar'}
             </Button>
           )}
           {podeCancelar && (

--- a/src/components/reposicao/pedidos/__tests__/disparo-feedback.test.ts
+++ b/src/components/reposicao/pedidos/__tests__/disparo-feedback.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { interpretarRespostaDisparo } from '../shared';
+
+describe('interpretarRespostaDisparo', () => {
+  it('Omie direto (disparados>0) → success citando Omie', () => {
+    const r = interpretarRespostaDisparo({ disparados: 1 }, 130);
+    expect(r.tone).toBe('success');
+    expect(r.message).toContain('#130');
+    expect(r.message).toContain('Omie');
+  });
+
+  it('portal Sayerlack em background (aguardando_portal_sayerlack>0) → success, diz "iniciado" e NÃO "enviado"', () => {
+    const r = interpretarRespostaDisparo({ aguardando_portal_sayerlack: 1 }, 159);
+    expect(r.tone).toBe('success');
+    expect(r.message).toContain('iniciado');
+    // codex: no 202 ainda não é terminal — não afirmar "enviado"
+    expect(r.message).not.toContain('enviado');
+  });
+
+  it('falhas>0 → error', () => {
+    const r = interpretarRespostaDisparo({ falhas: 1 }, 7);
+    expect(r.tone).toBe('error');
+    expect(r.message).toContain('falha');
+  });
+
+  it('vazio/null → info "nada a disparar"', () => {
+    expect(interpretarRespostaDisparo(null, 1).tone).toBe('info');
+    expect(interpretarRespostaDisparo(undefined, 1).tone).toBe('info');
+    expect(interpretarRespostaDisparo({}, 1).message).toContain('nada a disparar');
+  });
+
+  it('prioridade: disparados (Omie) ganha de aguardando/falhas', () => {
+    const r = interpretarRespostaDisparo(
+      { disparados: 1, aguardando_portal_sayerlack: 1, falhas: 1 },
+      5,
+    );
+    expect(r.tone).toBe('success');
+    expect(r.message).toContain('Omie');
+  });
+
+  it('aguardando ganha de falhas quando não houve disparo direto', () => {
+    const r = interpretarRespostaDisparo({ aguardando_portal_sayerlack: 1, falhas: 1 }, 9);
+    expect(r.tone).toBe('success');
+    expect(r.message).toContain('iniciado');
+  });
+});

--- a/src/components/reposicao/pedidos/shared.ts
+++ b/src/components/reposicao/pedidos/shared.ts
@@ -34,6 +34,36 @@ export function formatTime(iso: string | null) {
   }
 }
 
+/* ─── Feedback do disparo (compartilhado entre o botão "Disparar" e o "Aprovar e disparar") ─── */
+export interface RespostaDisparo {
+  disparados?: number | null;
+  falhas?: number | null;
+  aguardando_portal_sayerlack?: number | null;
+}
+
+// Traduz a resposta da edge disparar-pedidos-aprovados num toast.
+// O disparo do portal Sayerlack é assíncrono (202 + processamento em background):
+// nesse caso a mensagem diz "iniciado", NUNCA "enviado" — o terminal (sucesso/falha)
+// aparece na linha do pedido, que atualiza sozinha.
+export function interpretarRespostaDisparo(
+  data: RespostaDisparo | null | undefined,
+  pedidoId: number,
+): { tone: 'success' | 'error' | 'info'; message: string } {
+  const ok = data?.disparados ?? 0;
+  const fail = data?.falhas ?? 0;
+  const aguardandoPortal = data?.aguardando_portal_sayerlack ?? 0;
+  if (ok > 0) {
+    return { tone: 'success', message: `Pedido #${pedidoId} disparado e registrado no Omie` };
+  }
+  if (aguardandoPortal > 0) {
+    return { tone: 'success', message: `Pedido #${pedidoId}: envio ao portal Sayerlack iniciado — acompanhe o status na lista (atualiza sozinho)` };
+  }
+  if (fail > 0) {
+    return { tone: 'error', message: `Pedido #${pedidoId}: falha ao disparar` };
+  }
+  return { tone: 'info', message: `Pedido #${pedidoId}: nada a disparar` };
+}
+
 /* ─── Portal B2B status meta ─── */
 export const portalStatusMeta: Record<StatusEnvioPortal, { label: string; className: string }> = {
   nao_aplicavel: { label: '—', className: 'bg-muted text-muted-foreground border-border' },

--- a/src/components/reposicao/pedidos/useDetalhesModal.ts
+++ b/src/components/reposicao/pedidos/useDetalhesModal.ts
@@ -7,7 +7,7 @@ import { useAuth } from '@/contexts/AuthContext';
 import { toast } from 'sonner';
 import { logger } from '@/lib/logger';
 import { PedidoSugerido, PedidoItem, CondicaoPagamento } from './types';
-import { formatTime } from './shared';
+import { interpretarRespostaDisparo, type RespostaDisparo } from './shared';
 
 export type Linha = PedidoItem & { _qtd: number; _valor: number };
 
@@ -182,16 +182,39 @@ export function useDetalhesModal({ pedido, open, onOpenChange, onApproved }: Use
       if (condicaoMudou) {
         await salvarCondicaoMutation.mutateAsync();
       }
-      const { data, error } = await supabase.rpc('aprovar_pedido_sugerido', {
+      const { error } = await supabase.rpc('aprovar_pedido_sugerido', {
         p_pedido_id: pedido.id,
         p_usuario: user?.email ?? 'sistema',
       });
-      if (error) throw error;
-      return data;
+      if (error) throw error; // falha de aprovação → onError (correto)
+
+      // APROVAR = DISPARAR NA HORA. Em vez de esperar o cron de corte, dispara já.
+      // Best-effort: a falha do disparo NÃO reverte a aprovação — o cron de corte
+      // (rede de segurança) pega depois, e o motor de retry */15 cobre falha
+      // transitória do portal. Aprovar e disparar são estados distintos (codex).
+      const pedidoId = pedido.id;
+      try {
+        const { data: dd, error: de } = await supabase.functions.invoke('disparar-pedidos-aprovados', {
+          body: { empresa: pedido.empresa, pedido_id: pedidoId },
+        });
+        if (de) throw de;
+        return { disparoOk: true as const, feedback: interpretarRespostaDisparo(dd as RespostaDisparo, pedidoId) };
+      } catch (e) {
+        logger.error('Pedido aprovado, mas o disparo imediato falhou (cron de corte assume)', { error: e, pedidoId });
+        return { disparoOk: false as const, feedback: null };
+      }
     },
-    onSuccess: () => {
-      const horario = pedido?.horario_corte_planejado ? formatTime(pedido.horario_corte_planejado) : 'horário planejado';
-      toast.success(`Pedido aprovado. Será disparado às ${horario}.`);
+    onSuccess: (result) => {
+      if (result) {
+        if (result.disparoOk && result.feedback) {
+          const { tone, message } = result.feedback;
+          if (tone === 'error') toast.error(message);
+          else if (tone === 'info') toast.info(message);
+          else toast.success(message);
+        } else {
+          toast.warning('Pedido aprovado. O envio automático não saiu agora — será reprocessado pela rede de segurança (ou use "Disparar").');
+        }
+      }
       queryClient.invalidateQueries({ queryKey: ['pedidos-ciclo'] });
       onApproved();
       onOpenChange(false);

--- a/src/pages/AdminReposicaoPedidos.tsx
+++ b/src/pages/AdminReposicaoPedidos.tsx
@@ -12,7 +12,7 @@ import { toast } from 'sonner';
 import { format } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
 import { PedidoSugerido } from '@/components/reposicao/pedidos/types';
-import { EMPRESA } from '@/components/reposicao/pedidos/shared';
+import { EMPRESA, interpretarRespostaDisparo, type RespostaDisparo } from '@/components/reposicao/pedidos/shared';
 import { CycleIndicator } from '@/components/reposicao/pedidos/CycleIndicator';
 import { PedidoRow } from '@/components/reposicao/pedidos/PedidoRow';
 import { DetalhesModal } from '@/components/reposicao/pedidos/DetalhesModal';
@@ -110,13 +110,10 @@ export default function AdminReposicaoPedidos() {
       return data;
     },
     onSuccess: (data, pedidoId) => {
-      const ok = data?.disparados ?? 0;
-      const fail = data?.falhas ?? 0;
-      const aguardandoPortal = data?.aguardando_portal_sayerlack ?? 0;
-      if (ok > 0) toast.success(`Pedido #${pedidoId} disparado e registrado no Omie`);
-      else if (aguardandoPortal > 0) toast.success(`Pedido #${pedidoId}: envio ao portal Sayerlack iniciado em segundo plano`);
-      else if (fail > 0) toast.error(`Pedido #${pedidoId}: falha ao disparar`);
-      else toast.info(`Pedido #${pedidoId}: nada a disparar (${JSON.stringify(data)})`);
+      const { tone, message } = interpretarRespostaDisparo(data as RespostaDisparo, pedidoId);
+      if (tone === 'error') toast.error(message);
+      else if (tone === 'info') toast.info(message);
+      else toast.success(message);
       queryClient.invalidateQueries({ queryKey: ['pedidos-ciclo'] });
     },
     onError: (e: Error) => {

--- a/supabase/migrations/20260528040000_sayerlack_retry_motor.sql
+++ b/supabase/migrations/20260528040000_sayerlack_retry_motor.sql
@@ -1,0 +1,121 @@
+-- MOTOR DE RETRY dos órfãos retentáveis do portal Sayerlack — fecha a REMEDIAÇÃO do incidente
+-- (~R$82k de pedidos órfãos). O Sentinela (checks reposicao_disparo/reposicao_portal, PR #450) já
+-- fechou a DETECÇÃO; faltava o conserto automático.
+--
+-- BUG SISTÊMICO (Track A): o loop de retry de envio ao portal NÃO TINHA motor agendado.
+--   • O fluxo é portal-FIRST: o portal precisa suceder (obter protocolo) ANTES de criar o pedido no
+--     Omie (status='disparado'). Uma falha transitória do Browserless deixa o pedido em
+--     status='aprovado_aguardando_disparo' + status_envio_portal IN (pendente_envio_portal/erro_retentavel),
+--     agendando portal_proximo_retry_em=+15min.
+--   • Esse retry de +15min NUNCA era disparado: o único cron (sayerlack-portal-watchdog */5) chama a edge
+--     com {watchdog:true} → roda só runWatchdog (des-trava enviando_portal preso) e RETORNA. O modo LOTE
+--     (body {}) exige status='disparado' — que no fluxo portal-first só existe APÓS sucesso → NO-OP pra
+--     falha de portal. E o disparo diário é ciclo-scoped (data_ciclo=hoje) → aprovação de ciclo antigo
+--     que falhou transitório fica órfã pra sempre.
+--
+-- FIX: motor SQL-only (sem redeploy de edge) que re-dirige o caminho PROVADO
+-- disparar-pedidos-aprovados {empresa:OBEN, pedido_id} (re-roda o fluxo inteiro: portal async → Omie;
+-- o guard de idempotência pula o portal se já há sucesso_portal+protocolo, não duplica no fornecedor).
+-- Validado empíricamente: pedido #149 estava travado em enviando_portal (tent=2); re-disparo {pedido_id:149}
+-- → sucesso_portal + protocolo 2098269 + disparado em ~45s (Browserless respondeu; falhas eram TRANSITÓRIAS).
+--
+-- DESENHO (revisado com codex — 1 correção crítica de money-path):
+--   • SELETOR POSITIVO: status_envio_portal IN ('pendente_envio_portal','erro_retentavel') — NUNCA NOT IN.
+--     Um NOT IN incluiria 'indeterminado_requer_conciliacao' (estado que o watchdog crava quando o
+--     Browserless trava: "não sei se o portal recebeu") → auto-redrive poderia DUPLICAR o PO na Renner.
+--     Também exclui 'erro_nao_retentavel' (SKU sem mapeamento — precisa humano, não retry).
+--   • AGE-BOUND 3 dias: só re-dispara FRESCOS. Órfão velho pode estar obsoleto (estoque/demanda mudaram,
+--     compra manual já feita) → re-disparar criaria PO obsoleto no fornecedor. Velhos = revisão humana
+--     (Sentinela alerta + re-disparo manual por {pedido_id} após o founder confirmar validade).
+--   • LIMIT 1 por run: Browserless é frágil; 1 disparo por ciclo não sobrecarrega (cada disparo é async).
+--   • portal_tentativas < 3: respeita o MAX_TENTATIVAS=3 da edge (3 falhas → erro_nao_retentavel, fora).
+--     NÃO subimos o teto agora — o bug era falta de motor, não teto baixo; medir antes (codex).
+--   • pg_try_advisory_xact_lock: anti-overlap (auto-release no fim da transação do cron).
+--   • Log de auditoria do que o motor auto-disparou (pedido_id + request_id + tentativa).
+--
+-- ⚠️ NÃO cobre (por design — triagem humana): erro_nao_retentavel (SKU sem mapeamento), órfão >3d
+-- (revisão de obsolescência), nem o backlog ATUAL de ~R$82k (aprovado 22/04 e 14/05, fora da janela 3d) →
+-- esses são re-dispatch manual operacional. O cron sayerlack-portal-lote-retry (*/15, no-op no fluxo
+-- portal-first) é deixado como está (inofensivo, candidatos=0); remoção fica pra cleanup futuro.
+
+-- 1) Log de auditoria do motor (interno; RLS on sem policy → só service_role/postgres, leitura via SQL Editor)
+CREATE TABLE IF NOT EXISTS public.sayerlack_retry_motor_log (
+  id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  pedido_id bigint NOT NULL,
+  tentativa_no_disparo int,
+  status_envio_portal_no_disparo text,
+  aprovado_em timestamptz,
+  request_id bigint,
+  criado_em timestamptz NOT NULL DEFAULT now()
+);
+ALTER TABLE public.sayerlack_retry_motor_log ENABLE ROW LEVEL SECURITY;
+
+-- 2) Função do motor
+CREATE OR REPLACE FUNCTION public.sayerlack_retry_orfaos()
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $fn$
+DECLARE
+  v_pedido record;
+  v_cron_secret text;
+  v_request_id bigint;
+  v_url constant text := 'https://fzvklzpomgnyikkfkzai.supabase.co/functions/v1/disparar-pedidos-aprovados';
+BEGIN
+  -- anti-overlap (codex): xact-level, auto-release no fim da transação do cron
+  IF NOT pg_try_advisory_xact_lock(hashtext('sayerlack_retry_orfaos')) THEN
+    RETURN jsonb_build_object('skipped', 'lock_indisponivel');
+  END IF;
+
+  SELECT id,
+         COALESCE(portal_tentativas, 0) AS tent,
+         status_envio_portal,
+         aprovado_em
+    INTO v_pedido
+  FROM public.pedido_compra_sugerido
+  WHERE empresa = 'OBEN'
+    AND fornecedor_nome ILIKE '%SAYERLACK%'
+    AND status IN ('aprovado_aguardando_disparo', 'falha_envio')
+    -- SELETOR POSITIVO (codex): só retentável de verdade; nunca indeterminado/nao_retentavel
+    AND status_envio_portal IN ('pendente_envio_portal', 'erro_retentavel')
+    AND COALESCE(portal_tentativas, 0) < 3
+    AND (portal_proximo_retry_em IS NULL OR portal_proximo_retry_em <= now())
+    AND aprovado_em >= now() - INTERVAL '3 days'  -- só FRESCOS; velhos = revisão humana
+  ORDER BY aprovado_em ASC
+  LIMIT 1;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('candidatos', 0);
+  END IF;
+
+  SELECT decrypted_secret INTO v_cron_secret
+  FROM vault.decrypted_secrets WHERE name = 'CRON_SECRET' LIMIT 1;
+
+  SELECT net.http_post(
+    url := v_url,
+    headers := jsonb_build_object(
+      'Content-Type', 'application/json',
+      'x-cron-secret', v_cron_secret
+    ),
+    body := jsonb_build_object('empresa', 'OBEN', 'pedido_id', v_pedido.id),
+    timeout_milliseconds := 60000
+  ) INTO v_request_id;
+
+  INSERT INTO public.sayerlack_retry_motor_log
+    (pedido_id, tentativa_no_disparo, status_envio_portal_no_disparo, aprovado_em, request_id)
+  VALUES (v_pedido.id, v_pedido.tent, v_pedido.status_envio_portal, v_pedido.aprovado_em, v_request_id);
+
+  RETURN jsonb_build_object(
+    'disparado', v_pedido.id,
+    'tentativa', v_pedido.tent,
+    'request_id', v_request_id
+  );
+END;
+$fn$;
+
+REVOKE ALL ON FUNCTION public.sayerlack_retry_orfaos() FROM anon, authenticated, PUBLIC;
+
+-- 3) Cron */15 (alinha com o backoff de retry de 15min; idle é barato — candidatos=0 retorna rápido)
+SELECT cron.schedule('sayerlack-retry-orfaos', '*/15 * * * *',
+  $cron$ SELECT public.sayerlack_retry_orfaos(); $cron$);


### PR DESCRIPTION
## O que muda

### 1. Aprovar = disparar na hora (frontend — a feature pedida)
Antes: aprovar um pedido (modal de detalhes) só setava `aprovado_aguardando_disparo` e mostrava **"será disparado às 13h"** — esperava o cron de corte. Agora o aprovar **encadeia `disparar-pedidos-aprovados {pedido_id}` na hora**.
- **Best-effort:** falha do disparo **NÃO** reverte a aprovação — o cron de corte + o motor de retry `*/15` são a rede de segurança (aprovar e disparar são estados distintos).
- Botão → **"✓ Aprovar e disparar agora"**; toast honesto ("envio iniciado, acompanhe na lista" — **não** "enviado", o portal é async 202+~45s).
- Só o aprovar **individual** (modal). Lote/auto-aprovação do cockpit ficam approve-only.
- Helper puro testável `interpretarRespostaDisparo` (extraído da lógica inline do `dispararMutation`; `AdminReposicaoPedidos` agora usa o mesmo → DRY).
- **Guard de concorrência (UI):** o botão "Disparar" da linha trava ("Enviando…") quando `status_envio_portal='enviando_portal'` → não abre 2ª sessão no Browserless (PO duplicado).

### 2. Motor de retry de órfãos Sayerlack (migration)
> ⚠️ **migration manual — JÁ APLICADA EM PROD** via SQL Editor (validada: `cron_ativo=1`, `dry_run={"candidatos":0}`).

`sayerlack_retry_orfaos()` — seletor **positivo** (`pendente_envio_portal`/`erro_retentavel`, nunca `indeterminado`/`erro_nao_retentavel`); **age-bound 3d** (só frescos; órfão velho = revisão humana); `tent<3`; `LIMIT 1`; advisory lock — re-dispara via `disparar {pedido_id}`. Cron `sayerlack-retry-orfaos */15` + tabela de log. Fecha a **remediação automática** do incidente (falha transitória do Browserless em pedido fresco se auto-cura; antes o retry de +15min não tinha motor agendado).

## Desenho revisado com codex (2 consults)
- **Motor:** seletor positivo (evita re-disparar `indeterminado` → PO duplicado na Renner), age-bound (evita PO obsoleto), **não** subir MAX_TENTATIVAS (medir primeiro).
- **Feature:** encadear no `onSuccess`, best-effort, fechar modal + status na linha, toast honesto. Ressalva de concorrência (duplo-disparo na janela ~45s) → guards de UI agora + claim atômico na edge como **fast-follow**.

## Teste
- `__tests__/disparo-feedback.test.ts` (6 casos: Omie / portal-bg "iniciado" não "enviado" / falha / vazio / prioridades).
- Gate local: **1687 testes** ✓, tsc baseline+strict ✓, lint **0 errors**.

## Fast-follow (separado)
Claim atômico na edge `enviar-pedido-portal-sayerlack` (modo individual não tem CAS — o `(locked)` é update incondicional) → fecha o resíduo de concorrência (cron no exato instante).

🤖 Generated with [Claude Code](https://claude.com/claude-code)