### PR TITLE
fix(valor): NCG ausente não fabrica ROIC (ausente ≠ R$0) + frescor + reconcilia com Cockpit

### DIFF
--- a/docs/FINANCEIRO_CONFIABILIDADE.md
+++ b/docs/FINANCEIRO_CONFIABILIDADE.md
@@ -260,6 +260,17 @@ Uma auditoria de consistência achou que o **Cockpit** (`/financeiro/cockpit`, c
 - Helper `src/lib/financeiro/cockpit-consolida-helpers.ts` (13 testes; `consolidarCockpit`) + `getProjecaoSnapshotsCockpit`. **Codex em todas as etapas** (metodologia + spec [3 P1] + plano [3 P1 anti-impl-preguiçosa] + adversarial). **CLIENT-SIDE — sem migration/deploy** (o snapshot já é gravado pelo cron `fin-cashflow-snapshot-diario`).
 - **Limitações:** snapshot até 1 dia stale (data visível); intercompany não eliminado; caixa consolidado não-fungível (por isso a quebra por empresa). A decomposição ACO/PCO detalhada e os cenários ficam na tela **Capital de Giro** (live).
 
+## 🔧 Valor A2 — Guard de NCG indisponível (ausente ≠ R$0) (2026-05-28)
+
+Seguindo a consolidação do Cockpit, a mesma auditoria achou um furo no **Valor A2** (`/financeiro/valor`, ROIC/EVA): o engine lê o **NCG da engine A1** (`fin_projecao_snapshots.ncg`) como capital de giro — mesma fonte do Cockpit — mas, quando **não havia snapshot de NCG**, assumia `capital_giro = 0` silenciosamente. Com ativo fixo informado, o capital investido virava só o ativo fixo (subestimado) → **ROIC superestimado**, confiança **não** rebaixada (o "parcial" só olhava ativo fixo), e o aviso ficava enterrado num motivo. Violava "ausente ≠ zero" e divergia do Cockpit (que já trata NCG ausente como parcial). Corrigido:
+
+- **NCG ausente → capital de giro e capital investido `null` (indisponível), não R$0**; ROIC/spread/EVA viram `null` (não fabricados) e a confiança cai pra **baixa**. UI diz "Sem snapshot de NCG — capital de giro indisponível (rode a projeção)", e **não** mais "* capital parcial (sem ativo fixo)" (mensagem errada nesse caso).
+- **NCG negativo (folga) e zero são valores REAIS** (não ausência — `s.ncg != null`, sem truthiness). Capital investido ≤0 por folga grande continua dando `roic=null` **por capital conhecido** → confiança **media** (distinto de NCG ausente = baixa).
+- **Frescor honesto (Codex P1):** snapshot de NCG com 45+ dias (cron é diário) → confiança **media** + "NCG de {data} (Nd atrás)" visível na tela. Stale NÃO vira indisponível (o NCG é real; pipeline morto já é vigiado pelo Sentinela).
+- **Guard anti-coerção (Codex P1):** `capital_normalizado` null não vira `null + ajuste = número`. EBIT/NOPAT normalizado seguem calculados e exibidos; só as métricas que dependem de capital ficam null.
+- Toda a resolução de capital (resolver + frescor + −12m + capitalInvestido) numa **função pura composta `resolverCapitalParaValor`** (testada ponta-a-ponta) espelhada verbatim no edge — não sobra `capital_giro = ncg ? ncg : 0` inline (Codex P1). **Reconciliação:** com snapshot válido, `A2.capital_giro` = último `fin_projecao_snapshots.ncg` da empresa = o mesmo NCG que o Cockpit usa.
+- Helper `valor-helpers.ts` (+novos `resolverCapitalGiro`/`frescorGiro`/`acharCapitalGiroAnterior`/`resolverCapitalParaValor`; 56 testes) espelhado no engine `fin-valor-engine`. **Codex em todas as etapas** (spec [3 P1] + plano [3 P1: composta anti-inline + asserts exatos + distinção NCG-ausente×capital≤0] + adversarial). **Sem migration; requer deploy do `fin-valor-engine` via Lovable** (ROIC/EVA são calculados no edge). A4 (`fin-next-best-action`) lê só `wacc`/`spread` (já nullable) → não quebra.
+
 ## ✅ MVP Operacional (pode usar agora para gestão diária)
 
 Estes dados vêm direto do Omie sem transformação opinativa.

--- a/docs/superpowers/plans/2026-05-28-valor-ncg-guard.md
+++ b/docs/superpowers/plans/2026-05-28-valor-ncg-guard.md
@@ -1,0 +1,207 @@
+# Valor A2 — Guard de NCG indisponível — Plano de implementação
+
+> **Sub-skill:** subagent-driven-development OU execução inline com TDD. Steps em checkbox.
+
+**Goal:** Quando o snapshot de NCG está ausente, o Valor A2 para de fabricar `capital_giro=0`/ROIC superestimado; capital/ROIC/EVA viram `null`, confiança vira `baixa`, e a UI diz "sem snapshot de NCG". Snapshot velho → confiança `media` + visível.
+
+**Arquitetura:** helper TS puro (TDD vitest) espelhado verbatim no Deno `fin-valor-engine`; contrato nullable; UI null-aware. Sem migration. Deploy do edge via Lovable.
+
+**Spec:** `docs/superpowers/specs/2026-05-28-valor-ncg-guard-design.md`
+
+---
+
+### Task 1: Helpers puros + tipos nullable (`valor-helpers.ts`) — TDD
+
+**Files:**
+- Modify: `src/lib/financeiro/valor-helpers.ts`
+- Test: `src/lib/financeiro/__tests__/valor-helpers.test.ts`
+
+- [ ] **Step 1 — Testes falhando** (adicionar ao test existente):
+
+```ts
+import { resolverCapitalGiro, frescorGiro, acharCapitalGiroAnterior } from '../valor-helpers';
+
+describe('resolverCapitalGiro', () => {
+  it('pega o snapshot mais recente com ncg não-nulo (negativo é real)', () => {
+    const r = resolverCapitalGiro([
+      { ncg: null, snapshot_at: '2026-05-28T10:00:00Z' },
+      { ncg: -5000, snapshot_at: '2026-05-27T10:00:00Z' },
+      { ncg: 9999, snapshot_at: '2026-05-20T10:00:00Z' },
+    ]);
+    expect(r.capital_giro).toBe(-5000);
+    expect(r.disponivel).toBe(true);
+    expect(r.snapshot_at).toBe('2026-05-27T10:00:00Z');
+  });
+  it('ncg zero é valor REAL (não ausência)', () => {
+    const r = resolverCapitalGiro([{ ncg: 0, snapshot_at: '2026-05-28T10:00:00Z' }]);
+    expect(r.capital_giro).toBe(0);
+    expect(r.disponivel).toBe(true);
+  });
+  it('todos null → indisponível', () => {
+    const r = resolverCapitalGiro([{ ncg: null, snapshot_at: '2026-05-28T10:00:00Z' }]);
+    expect(r.capital_giro).toBeNull();
+    expect(r.disponivel).toBe(false);
+  });
+  it('sem snapshots → indisponível', () => {
+    const r = resolverCapitalGiro([]);
+    expect(r.disponivel).toBe(false);
+    expect(r.snapshot_at).toBeNull();
+  });
+});
+
+describe('frescorGiro', () => {
+  const hoje = Date.parse('2026-05-28T00:00:00Z');
+  it('fresco < limiar → não stale', () => {
+    expect(frescorGiro('2026-05-20T00:00:00Z', hoje, 45)).toEqual({ dias: 8, stale: false });
+  });
+  it('velho > limiar → stale', () => {
+    const r = frescorGiro('2026-01-01T00:00:00Z', hoje, 45);
+    expect(r.stale).toBe(true);
+    expect(r.dias).toBeGreaterThan(45);
+  });
+  it('snapshot_at null → dias null, não stale', () => {
+    expect(frescorGiro(null, hoje, 45)).toEqual({ dias: null, stale: false });
+  });
+});
+
+describe('acharCapitalGiroAnterior', () => {
+  it('acha o snapshot ~365d antes do ref dentro da tolerância', () => {
+    const snaps = [
+      { ncg: 1000, snapshot_at: '2026-05-27T00:00:00Z' },
+      { ncg: 800, snapshot_at: '2025-05-26T00:00:00Z' },
+    ];
+    expect(acharCapitalGiroAnterior(snaps, '2026-05-27T00:00:00Z')).toBe(800);
+  });
+  it('sem snapshot próximo de −365d → null', () => {
+    const snaps = [{ ncg: 1000, snapshot_at: '2026-05-27T00:00:00Z' }];
+    expect(acharCapitalGiroAnterior(snaps, '2026-05-27T00:00:00Z')).toBeNull();
+  });
+});
+```
+Adicionar também casos em `capitalInvestido`, `normalizarComingling`, `scoreConfiancaValor` (matriz do spec): giro null → `capital_investido:null`+`giro_indisponivel:true`+`parcial:true`; giro 0 real + ativo fixo → capital = ativo fixo, `giro_indisponivel:false`; `normalizarComingling({capital_reportado:null, intercompany_giro:-500,...})` → `capital_normalizado:null` (NÃO −500), `ebit_normalizado` calculado; `scoreConfiancaValor({giro_indisponivel:true,...})` → `baixa`; `{giro_stale:true,...}` → `media`.
+
+- [ ] **Step 2 — Rodar, ver falhar:** `heavy bun run test src/lib/financeiro/__tests__/valor-helpers.test.ts`
+
+- [ ] **Step 3 — Implementar:**
+
+```ts
+export type SnapNcg = { ncg: number | null; snapshot_at: string };
+
+export function resolverCapitalGiro(snaps: SnapNcg[]): { capital_giro: number | null; snapshot_at: string | null; disponivel: boolean } {
+  // snaps já vêm ordenados desc por snapshot_at; mas não confie — pegue o mais recente com ncg != null.
+  let melhor: SnapNcg | null = null;
+  for (const s of snaps) {
+    if (s.ncg == null) continue;
+    if (melhor == null || Date.parse(s.snapshot_at) > Date.parse(melhor.snapshot_at)) melhor = s;
+  }
+  if (melhor == null) return { capital_giro: null, snapshot_at: null, disponivel: false };
+  return { capital_giro: Number(melhor.ncg), snapshot_at: melhor.snapshot_at, disponivel: true };
+}
+
+export function frescorGiro(snapshot_at: string | null, hojeMs: number, limiarStaleDias = 45): { dias: number | null; stale: boolean } {
+  if (!snapshot_at) return { dias: null, stale: false };
+  const t = Date.parse(snapshot_at);
+  if (!Number.isFinite(t)) return { dias: null, stale: false };
+  const dias = Math.round((hojeMs - t) / 86400000);
+  return { dias, stale: dias > limiarStaleDias };
+}
+
+export function acharCapitalGiroAnterior(snaps: SnapNcg[], refSnapshotAt: string, opts?: { janelaDias?: number; toleranciaDias?: number }): number | null {
+  const janela = opts?.janelaDias ?? 365;
+  const tol = opts?.toleranciaDias ?? 60;
+  const alvo = Date.parse(refSnapshotAt) - janela * 86400000;
+  let melhor: { ncg: number; dist: number } | null = null;
+  for (const s of snaps) {
+    if (s.ncg == null) continue;
+    const dist = Math.abs(Date.parse(s.snapshot_at) - alvo);
+    if (melhor == null || dist < melhor.dist) melhor = { ncg: Number(s.ncg), dist };
+  }
+  return melhor && melhor.dist <= tol * 86400000 ? melhor.ncg : null;
+}
+```
+
+`capitalInvestido` — `capital_giro: number | null`; result `capital_investido: number | null`, `capital_giro: number | null`, novo `giro_indisponivel: boolean`:
+```ts
+export function capitalInvestido(input: { capital_giro: number | null; ativo_fixo: AtivoFixoInput; ajustes?: number; }): CapitalInvestidoResult {
+  const ajustes = input.ajustes ?? 0;
+  const motivos: string[] = [];
+  let ativo_fixo = 0;
+  let parcial = false;
+  const giro_indisponivel = input.capital_giro == null;
+  if (input.ativo_fixo && input.ativo_fixo.operacional && Number.isFinite(input.ativo_fixo.valor)) {
+    ativo_fixo = input.ativo_fixo.valor;
+  } else {
+    parcial = true;
+    motivos.push('Ativo fixo operacional não informado — capital investido parcial (só giro − ajustes).');
+  }
+  if (giro_indisponivel) {
+    parcial = true;
+    motivos.push('Sem snapshot de NCG — capital de giro indisponível; ROIC/EVA não calculáveis.');
+    return { capital_investido: null, capital_giro: null, ativo_fixo, ajustes, parcial, giro_indisponivel: true, motivos };
+  }
+  const capital_investido = (input.capital_giro as number) + ativo_fixo - ajustes;
+  return { capital_investido, capital_giro: input.capital_giro, ativo_fixo, ajustes, parcial, giro_indisponivel: false, motivos };
+}
+```
+(Atualizar `CapitalInvestidoResult`: `capital_investido: number | null; capital_giro: number | null; giro_indisponivel: boolean`.)
+
+`normalizarComingling` — `capital_reportado: number | null` → `capital_normalizado: number | null` com guard:
+```ts
+const capital_normalizado = input.capital_reportado == null ? null : input.capital_reportado + ajuste_intercompany_capital;
+```
+(Atualizar tipo `CominglingResult.capital_reportado: number | null; capital_normalizado: number | null`.)
+
+`scoreConfiancaValor` — novos inputs `giro_indisponivel?: boolean`, `giro_stale?: boolean`:
+```ts
+if (input.giro_indisponivel) rebaixar(1, 'Sem snapshot de NCG — capital de giro indisponível; ROIC/EVA não calculáveis.');
+else if (input.giro_stale) rebaixar(2, 'NCG desatualizado (snapshot antigo) — capital de giro pode estar defasado.');
+```
+
+- [ ] **Step 4 — Rodar, ver passar.** `heavy bun run test src/lib/financeiro/__tests__/valor-helpers.test.ts`
+- [ ] **Step 5 — Commit:** `feat(valor): helpers resolverCapitalGiro/frescorGiro + capital/comingling/confiança null-aware (TDD)`
+
+---
+
+### Task 2: Espelho no edge `fin-valor-engine` + contrato
+
+**Files:**
+- Modify: `supabase/functions/fin-valor-engine/index.ts` (L244-340)
+- Modify: `src/services/financeiroService.ts` (L831-854)
+
+- [ ] **Step 1 — Edge:** copiar verbatim os helpers novos/alterados (`resolverCapitalGiro`, `frescorGiro`, `acharCapitalGiroAnterior`, `capitalInvestido`, `normalizarComingling`, `scoreConfiancaValor`) para a seção de helpers do `index.ts`. Substituir L244-263 por:
+```ts
+const { data: snaps } = await db.from("fin_projecao_snapshots")
+  .select("ncg, snapshot_at").eq("company", company).order("snapshot_at", { ascending: false }).limit(400);
+const snapRows = (snaps ?? []) as Array<{ ncg: number | null; snapshot_at: string }>;
+const giro = resolverCapitalGiro(snapRows);
+const capital_giro = giro.capital_giro;                       // number | null
+const frescor = frescorGiro(giro.snapshot_at, Date.now());    // staleness honesto
+const capital_giro_anterior = giro.disponivel && giro.snapshot_at
+  ? acharCapitalGiroAnterior(snapRows, giro.snapshot_at) : null;
+```
+- [ ] **Step 2 — Edge wire:** `capRep = capitalInvestido({ capital_giro, ativo_fixo, ajustes })` (já aceita null). `capAnterior` só quando `capital_giro_anterior != null` (inalterado). `normalizarComingling({ ebit_reportado: nopatAtual.ebit, capital_reportado: capRep.capital_investido, ... })` (agora aceita null). `scoreConfiancaValor({ ..., giro_indisponivel: capRep.giro_indisponivel, giro_stale: frescor.stale })`. **Remover** o motivo enterrado da L340 (`if (giro_indisponivel) motivos.push(...)`) — agora vem estruturado de `capRep.motivos`. Expor no result: `giro_indisponivel: capRep.giro_indisponivel`, `giro_snapshot_at: giro.snapshot_at`, `giro_dias: frescor.dias`.
+- [ ] **Step 3 — `deno check`:** `cd supabase/functions/fin-valor-engine && deno check index.ts` (erro-set inalterado).
+- [ ] **Step 4 — Contrato** `ValorEmpresaResult`: `reportado.capital_investido: number | null; capital_giro: number | null; giro_indisponivel: boolean; giro_snapshot_at: string | null; giro_dias: number | null;` e `normalizado.capital_investido: number | null;`.
+- [ ] **Step 5 — Commit:** `feat(valor): fin-valor-engine usa guard de NCG (espelho) + contrato nullable`
+
+---
+
+### Task 3: UI `FinanceiroValor.tsx`
+
+**Files:** Modify `src/pages/FinanceiroValor.tsx`
+
+- [ ] **Step 1 — Mensagens:** gate L48 → `data.reportado.capital_parcial && !data.reportado.giro_indisponivel && modo === 'reportado'` (não dizer "sem ativo fixo" quando o parcial vem do NCG). Adicionar, quando `data.reportado.giro_indisponivel && modo === 'reportado'`: `<p className="text-xs text-status-warning">Sem snapshot de NCG — capital de giro indisponível (rode a projeção de caixa). ROIC/EVA não calculáveis.</p>`.
+- [ ] **Step 2 — Frescor:** quando `reportado.giro_snapshot_at`, exibir "NCG de DD/MM/YYYY" + "(Nd atrás)" se `giro_dias != null && giro_dias > 1`, com `text-status-warning` quando muito defasado (espelha `Projecao13Card`).
+- [ ] **Step 3 — tsc:** `bunx tsc --noEmit -p tsconfig.app.json` (capital_investido/capital_giro null já passam por `brl()`).
+- [ ] **Step 4 — Commit:** `feat(valor): UI distingue giro indisponível de ativo-fixo parcial + frescor do NCG`
+
+---
+
+### Task 4: Docs + validação + Codex adversarial + PR + deploy + CLAUDE.md
+
+- [ ] **Step 1 — Docs:** seção em `docs/FINANCEIRO_CONFIABILIDADE.md` (Valor A2: NCG ausente ≠ R$0; staleness; reconciliação com Cockpit).
+- [ ] **Step 2 — Validação completa:** `heavy bun run test` + `heavy bun run typecheck:strict` + `bunx tsc --noEmit -p tsconfig.app.json` + `bun lint` + `heavy bun run build`.
+- [ ] **Step 3 — Codex adversarial** no diff (`/codex` consult): foco em coerção null, staleness, espelho edge≡helper, confiança.
+- [ ] **Step 4 — PR + auto-merge** `--squash --auto`; CI `validate`.
+- [ ] **Step 5 — Deploy:** instrução pro founder colar no chat do Lovable (ler `supabase/functions/fin-valor-engine/index.ts` do repo, deploy verbatim). **Sem migration.**
+- [ ] **Step 6 — CLAUDE.md §5:** registrar (PR de housekeeping).

--- a/docs/superpowers/plans/2026-05-28-valor-ncg-guard.md
+++ b/docs/superpowers/plans/2026-05-28-valor-ncg-guard.md
@@ -157,8 +157,55 @@ if (input.giro_indisponivel) rebaixar(1, 'Sem snapshot de NCG — capital de gir
 else if (input.giro_stale) rebaixar(2, 'NCG desatualizado (snapshot antigo) — capital de giro pode estar defasado.');
 ```
 
+**Composta `resolverCapitalParaValor` (Codex plano P1.1 — defeita o "inline 0"):** encapsula TODO o bloco de capital (hoje inline no edge L244-298), pra ser testável ponta-a-ponta e espelhada verbatim — o edge NÃO pode mais ter `capital_giro = latestNcg ? ... : 0` inline:
+```ts
+export function resolverCapitalParaValor(input: {
+  snaps: SnapNcg[]; ativo_fixo: AtivoFixoInput; ajustes?: number; hojeMs: number; limiarStaleDias?: number;
+}): {
+  capital: CapitalInvestidoResult;        // capital_investido/capital_giro number|null + giro_indisponivel
+  capital_anterior: number | null;        // capital investido do ponto −12m (null se giro atual indisponível)
+  giro_snapshot_at: string | null; giro_dias: number | null; giro_stale: boolean;
+} {
+  const giro = resolverCapitalGiro(input.snaps);
+  const frescor = frescorGiro(giro.snapshot_at, input.hojeMs, input.limiarStaleDias);
+  const capital = capitalInvestido({ capital_giro: giro.capital_giro, ativo_fixo: input.ativo_fixo, ajustes: input.ajustes });
+  const capital_giro_anterior = giro.disponivel && giro.snapshot_at ? acharCapitalGiroAnterior(input.snaps, giro.snapshot_at) : null;
+  const capital_anterior = capital_giro_anterior != null
+    ? capitalInvestido({ capital_giro: capital_giro_anterior, ativo_fixo: input.ativo_fixo, ajustes: input.ajustes }).capital_investido
+    : null;
+  return { capital, capital_anterior, giro_snapshot_at: giro.snapshot_at, giro_dias: frescor.dias, giro_stale: frescor.stale };
+}
+```
+
+**Testes de orquestração da composta (Codex P1.1 + P1.3 — asserts EXATOS):**
+```ts
+describe('resolverCapitalParaValor', () => {
+  const hoje = Date.parse('2026-05-28T00:00:00Z');
+  const af = null; // sem ativo fixo
+  it('NCG ausente (todos null) → capital_investido/capital_giro null, giro_indisponivel, sem anterior', () => {
+    const r = resolverCapitalParaValor({ snaps: [{ ncg: null, snapshot_at: '2026-05-28T00:00:00Z' }], ativo_fixo: af, hojeMs: hoje });
+    expect(r.capital.capital_investido).toBeNull();
+    expect(r.capital.capital_giro).toBeNull();
+    expect(r.capital.giro_indisponivel).toBe(true);
+    expect(r.capital_anterior).toBeNull();
+  });
+  it('NCG negativo grande + sem ativo fixo → giro DISPONÍVEL mas capital_investido ≤ 0 (roic null por capital, NÃO por ausência)', () => {
+    const r = resolverCapitalParaValor({ snaps: [{ ncg: -50000, snapshot_at: '2026-05-27T00:00:00Z' }], ativo_fixo: af, hojeMs: hoje });
+    expect(r.capital.giro_indisponivel).toBe(false);
+    expect(r.capital.capital_investido).toBe(-50000);
+    expect(roic({ nopat: 1000, capital_investido: r.capital.capital_investido })).toBeNull(); // capital≤0
+  });
+  it('NCG válido recente → capital_giro = ncg (happy-path idêntico), não stale', () => {
+    const r = resolverCapitalParaValor({ snaps: [{ ncg: 300000, snapshot_at: '2026-05-25T00:00:00Z' }], ativo_fixo: af, hojeMs: hoje });
+    expect(r.capital.capital_giro).toBe(300000);
+    expect(r.giro_stale).toBe(false);
+  });
+});
+```
+Confiança: `scoreConfiancaValor({giro_indisponivel:true,...}).nivel === 'baixa'` (exato); `{giro_stale:true,...}.nivel === 'media'`; capital≤0 conhecido (`roic_null:true, giro_indisponivel:false`) → `'media'` (distinção P1.3). Normalização: `normalizarComingling({capital_reportado:null, intercompany_giro:-500,...}).capital_normalizado === null` (NÃO −500) e `.ebit_normalizado` calculado.
+
 - [ ] **Step 4 — Rodar, ver passar.** `heavy bun run test src/lib/financeiro/__tests__/valor-helpers.test.ts`
-- [ ] **Step 5 — Commit:** `feat(valor): helpers resolverCapitalGiro/frescorGiro + capital/comingling/confiança null-aware (TDD)`
+- [ ] **Step 5 — Commit:** `feat(valor): helpers resolverCapitalGiro/frescorGiro/resolverCapitalParaValor + capital/comingling/confiança null-aware (TDD)`
 
 ---
 
@@ -168,18 +215,17 @@ else if (input.giro_stale) rebaixar(2, 'NCG desatualizado (snapshot antigo) — 
 - Modify: `supabase/functions/fin-valor-engine/index.ts` (L244-340)
 - Modify: `src/services/financeiroService.ts` (L831-854)
 
-- [ ] **Step 1 — Edge:** copiar verbatim os helpers novos/alterados (`resolverCapitalGiro`, `frescorGiro`, `acharCapitalGiroAnterior`, `capitalInvestido`, `normalizarComingling`, `scoreConfiancaValor`) para a seção de helpers do `index.ts`. Substituir L244-263 por:
+- [ ] **Step 1 — Edge:** copiar verbatim TODOS os helpers novos/alterados (`resolverCapitalGiro`, `frescorGiro`, `acharCapitalGiroAnterior`, **`resolverCapitalParaValor`**, `capitalInvestido`, `normalizarComingling`, `scoreConfiancaValor`) para a seção de helpers do `index.ts`. Substituir L244-298 (bloco de capital inteiro) por **uma** chamada à composta:
 ```ts
 const { data: snaps } = await db.from("fin_projecao_snapshots")
   .select("ncg, snapshot_at").eq("company", company).order("snapshot_at", { ascending: false }).limit(400);
 const snapRows = (snaps ?? []) as Array<{ ncg: number | null; snapshot_at: string }>;
-const giro = resolverCapitalGiro(snapRows);
-const capital_giro = giro.capital_giro;                       // number | null
-const frescor = frescorGiro(giro.snapshot_at, Date.now());    // staleness honesto
-const capital_giro_anterior = giro.disponivel && giro.snapshot_at
-  ? acharCapitalGiroAnterior(snapRows, giro.snapshot_at) : null;
+const cap = resolverCapitalParaValor({ snaps: snapRows, ativo_fixo, ajustes, hojeMs: Date.now() });
+const capRep = cap.capital;            // {capital_investido, capital_giro, ..., giro_indisponivel}
+const capAnterior = cap.capital_anterior;
 ```
-- [ ] **Step 2 — Edge wire:** `capRep = capitalInvestido({ capital_giro, ativo_fixo, ajustes })` (já aceita null). `capAnterior` só quando `capital_giro_anterior != null` (inalterado). `normalizarComingling({ ebit_reportado: nopatAtual.ebit, capital_reportado: capRep.capital_investido, ... })` (agora aceita null). `scoreConfiancaValor({ ..., giro_indisponivel: capRep.giro_indisponivel, giro_stale: frescor.stale })`. **Remover** o motivo enterrado da L340 (`if (giro_indisponivel) motivos.push(...)`) — agora vem estruturado de `capRep.motivos`. Expor no result: `giro_indisponivel: capRep.giro_indisponivel`, `giro_snapshot_at: giro.snapshot_at`, `giro_dias: frescor.dias`.
+**NÃO** deixar nenhum `capital_giro = latestNcg ? ... : 0` inline (Codex P1.1 — defeitado pela composta).
+- [ ] **Step 2 — Edge wire:** `normalizarComingling({ ebit_reportado: nopatAtual.ebit, capital_reportado: capRep.capital_investido, ... })` (agora aceita null). `scoreConfiancaValor({ ..., giro_indisponivel: capRep.giro_indisponivel, giro_stale: cap.giro_stale })`. **Remover** o motivo enterrado da L340. Expor no result: `giro_indisponivel: capRep.giro_indisponivel`, `giro_snapshot_at: cap.giro_snapshot_at`, `giro_dias: cap.giro_dias`. **Auditar coerção null (Codex P1.2)** em todos os sites: `roic/eva/incremental` (já null-safe), `cg/roicNorm/evaNorm` (guard na composta/comingling), `result` (`normalizado.capital_investido = cg.capital_normalizado` pode ser null — contrato nullable).
 - [ ] **Step 3 — `deno check`:** `cd supabase/functions/fin-valor-engine && deno check index.ts` (erro-set inalterado).
 - [ ] **Step 4 — Contrato** `ValorEmpresaResult`: `reportado.capital_investido: number | null; capital_giro: number | null; giro_indisponivel: boolean; giro_snapshot_at: string | null; giro_dias: number | null;` e `normalizado.capital_investido: number | null;`.
 - [ ] **Step 5 — Commit:** `feat(valor): fin-valor-engine usa guard de NCG (espelho) + contrato nullable`

--- a/docs/superpowers/specs/2026-05-28-valor-ncg-guard-design.md
+++ b/docs/superpowers/specs/2026-05-28-valor-ncg-guard-design.md
@@ -1,0 +1,52 @@
+# Valor A2 — Guard de NCG indisponível (capital de giro ausente ≠ R$0)
+
+**Data:** 2026-05-28
+**Tipo:** Consolidação/hardening do módulo financeiro (não é feature nova).
+**Frente:** "provar que os números batem entre telas — ou degradar honestamente". Alvo escolhido por consult Codex após a Consolidação do Cockpit.
+
+## Problema (confirmado no código)
+
+O engine de Valor A2 (`supabase/functions/fin-valor-engine/index.ts`) usa o **NCG da engine A1** como `capital_giro` (lê `fin_projecao_snapshots.ncg`, igual ao Cockpit). Mas quando **não há snapshot de NCG válido** (todos `ncg == null` ou sem snapshot):
+
+- L250: `capital_giro = latestNcg ? Number(latestNcg.ncg) : 0` → **vira 0**.
+- L297: `capitalInvestido({ capital_giro: 0, ativo_fixo, ajustes })` → se `ativo_fixo` foi informado, `capital_investido = ativo_fixo` (**subestimado**, sem o giro).
+- L315: `roic = nopat / capital_investido` → como `capital_investido > 0`, **NÃO retorna null** → **ROIC superestimado** (capital menor que o real).
+- `capRep.parcial` só fica `true` por **ativo fixo** ausente (`valor-helpers.ts:82`) — **não** pela falta de giro → `scoreConfiancaValor` **não rebaixa** a confiança pela ausência de NCG.
+- L340: só empilha um texto no `motivos` ("capital de giro assumido 0 (ROIC pode estar superestimado)") — mas o número **já nasceu errado**.
+
+Isso **viola "ausente ≠ zero"** e **diverge do Cockpit**, que já trata NCG ausente como parcial (`useFinanceiroCockpit.ts` + `COCKPIT_VAZIO.ncg_parcial=true`) e usa `cockpit.ncg_total` da engine A1.
+
+> Nota: NCG **negativo** (folga) é valor REAL, não ausência. O guard só dispara quando **não há nenhum** `ncg` não-nulo. `capital_investido ≤ 0` por folga grande continua retornando `roic=null` legitimamente (motivo diferente de "giro indisponível").
+
+## Objetivo / critério de pronto
+
+1. **Empresa com snapshot válido:** `Valor A2.reportado.capital_giro` == último `fin_projecao_snapshots.ncg` não-nulo da empresa — **o mesmo valor** que alimenta o Cockpit. Comportamento idêntico ao atual no happy-path (zero regressão).
+2. **Empresa sem NCG válido:** `capital_giro` e `capital_investido` viram **`null` (indisponível)**, `roic`/`spread`/`eva` viram **`null`**, a **confiança vira `baixa`**, e a UI diz **"sem snapshot de NCG"**, nunca "R$0" nem "capital parcial (sem ativo fixo)". Nenhum ROIC/EVA é fabricado.
+
+## Mudanças (superfície fechada no A2)
+
+### Helper puro `src/lib/financeiro/valor-helpers.ts` (espelhado verbatim no Deno)
+- **Novo** `resolverCapitalGiro(snaps)`: encapsula "último snapshot com `ncg` não-nulo" → `{ capital_giro: number | null; snapshot_at: string | null; disponivel: boolean }`. (Hoje inline no edge L245-251.)
+- **Novo** `acharCapitalGiroAnterior(snaps, refSnapshotAt, opts?)`: o lookup ~365d antes com tolerância ≤60d (hoje inline L252-263) → `number | null`.
+- **`capitalInvestido`**: `capital_giro: number | null`. Quando `null` → `capital_investido: null`, `capital_giro: null`, **novo** `giro_indisponivel: true`, `parcial: true`, motivo "Sem snapshot de NCG — capital de giro indisponível; ROIC/EVA não calculáveis." Tipo de retorno: `capital_investido: number | null`, `capital_giro: number | null`, `giro_indisponivel: boolean`.
+- **`normalizarComingling`**: `capital_reportado: number | null` → `capital_normalizado: number | null` (null quando reportado null). Normalização de EBIT (pró-labore/aluguel) **inalterada** (independe do capital).
+- **`scoreConfiancaValor`**: novo input `giro_indisponivel: boolean` → `rebaixar(1, …)` (baixa: a métrica central de capital está ausente, mais severo que o `roic_null` por capital ≤0).
+- `roic`/`spread`/`eva`/`roicIncremental`: **já são null-safe** (`capital_investido: number | null`) — sem mudança.
+
+### Edge `supabase/functions/fin-valor-engine/index.ts`
+- Substitui L245-263 pelas chamadas dos helpers; passa `capital_giro: number | null` ao `capitalInvestido`; `normalizarComingling` null-safe; passa `giro_indisponivel` ao `scoreConfiancaValor`; remove o motivo enterrado L340 (agora estruturado). **Espelho verbatim** do helper.
+
+### Contrato `src/services/financeiroService.ts`
+- `ValorEmpresaResult.reportado.capital_investido: number | null`, `.capital_giro: number | null`, **novo** `.giro_indisponivel: boolean`; `normalizado.capital_investido: number | null`.
+
+### UI `src/pages/FinanceiroValor.tsx`
+- `brl()`/`pct()` **já** renderizam `—` para null (sem mudança no número). **Novo**: quando `reportado.giro_indisponivel`, exibir "Sem snapshot de NCG — capital de giro indisponível (rode a projeção de caixa). ROIC/EVA não calculáveis." e **não** mostrar o "* capital parcial (sem ativo fixo)" enganoso nesse caso.
+
+## Entrega / risco
+- **Sem migration.** **Com deploy** do `fin-valor-engine` via chat do Lovable (ROIC/EVA são calculados no edge — client-side só avisaria depois do número nascer errado, como o Codex apontou).
+- **Tela master-only** → blast radius baixo. A mudança só torna ROIC/EVA `null` em MAIS casos (giro ausente) — estritamente mais honesto, nunca superestima. Happy-path (snapshot válido) inalterado.
+
+## Não-objetivos
+- Backfill da data de baixa do Omie (adiado, money-path sensível).
+- Mudar a definição de NCG (continua ACO−PCO da engine A1 — só o tratamento de ausência muda).
+- Cobertura cross-CNPJ ou margens Cockpit×Orçamento (descartados pelo Codex: menor valor/maior risco agora).

--- a/docs/superpowers/specs/2026-05-28-valor-ncg-guard-design.md
+++ b/docs/superpowers/specs/2026-05-28-valor-ncg-guard-design.md
@@ -26,21 +26,31 @@ Isso **viola "ausente ≠ zero"** e **diverge do Cockpit**, que já trata NCG au
 ## Mudanças (superfície fechada no A2)
 
 ### Helper puro `src/lib/financeiro/valor-helpers.ts` (espelhado verbatim no Deno)
-- **Novo** `resolverCapitalGiro(snaps)`: encapsula "último snapshot com `ncg` não-nulo" → `{ capital_giro: number | null; snapshot_at: string | null; disponivel: boolean }`. (Hoje inline no edge L245-251.)
-- **Novo** `acharCapitalGiroAnterior(snaps, refSnapshotAt, opts?)`: o lookup ~365d antes com tolerância ≤60d (hoje inline L252-263) → `number | null`.
+- **Novo** `resolverCapitalGiro(snaps)`: encapsula "último snapshot com `ncg` não-nulo" → `{ capital_giro: number | null; snapshot_at: string | null; disponivel: boolean }`. (Hoje inline no edge L245-251.) Usa `s.ncg != null` (truthiness NÃO — `0` e negativo são valores REAIS; só `null`/sem snapshot falha).
+- **Novo** `frescorGiro(snapshot_at, hojeMs, limiarStaleDias = 45)` → `{ dias: number | null; stale: boolean }` (**Codex P1.3**): puro/determinístico (`hojeMs` injetado p/ testar). `dias = round((hojeMs − Date.parse(snapshot_at))/86400000)`; `stale = dias != null && dias > limiar`. O cron de snapshot é diário → um NCG com 45+ dias indica pipeline quebrado / NCG potencialmente desatualizado. **Stale NÃO vira indisponível** (não esconde um NCG real) — só rebaixa a confiança e fica visível na UI.
+- **Novo** `acharCapitalGiroAnterior(snaps, refSnapshotAt, opts?)`: o lookup ~365d antes com tolerância ≤60d (hoje inline L252-263) → `number | null`. **Só é chamado quando o giro atual está disponível** (sem ponto atual, incremental não existe — Codex resposta 3).
 - **`capitalInvestido`**: `capital_giro: number | null`. Quando `null` → `capital_investido: null`, `capital_giro: null`, **novo** `giro_indisponivel: true`, `parcial: true`, motivo "Sem snapshot de NCG — capital de giro indisponível; ROIC/EVA não calculáveis." Tipo de retorno: `capital_investido: number | null`, `capital_giro: number | null`, `giro_indisponivel: boolean`.
-- **`normalizarComingling`**: `capital_reportado: number | null` → `capital_normalizado: number | null` (null quando reportado null). Normalização de EBIT (pró-labore/aluguel) **inalterada** (independe do capital).
-- **`scoreConfiancaValor`**: novo input `giro_indisponivel: boolean` → `rebaixar(1, …)` (baixa: a métrica central de capital está ausente, mais severo que o `roic_null` por capital ≤0).
+- **`normalizarComingling`**: `capital_reportado: number | null` → `capital_normalizado: number | null`. **Guard explícito anti-coerção (Codex P1.1):** `capital_normalizado = capital_reportado == null ? null : capital_reportado + ajuste_intercompany_capital` (nunca `null + (−X)` → 0). A normalização de **EBIT** (pró-labore/aluguel) é **inalterada** (independe do capital) — EBIT/NOPAT normalizado seguem calculáveis e exibidos; só `capital_normalizado`/ROIC/EVA normalizados ficam null.
+- **`scoreConfiancaValor`**: dois novos inputs (**Codex P1.2**): `giro_indisponivel: boolean` → `rebaixar(1, …)` (**baixa** — métrica central de capital ausente, mais severo); `giro_stale: boolean` → `rebaixar(2, 'NCG de DD/MM/YYYY (Nd atrás) — capital de giro pode estar desatualizado.')` (**media**). O `roic_null` por capital ≤0 **conhecido** segue `media` (não confundir com indisponível).
 - `roic`/`spread`/`eva`/`roicIncremental`: **já são null-safe** (`capital_investido: number | null`) — sem mudança.
 
 ### Edge `supabase/functions/fin-valor-engine/index.ts`
 - Substitui L245-263 pelas chamadas dos helpers; passa `capital_giro: number | null` ao `capitalInvestido`; `normalizarComingling` null-safe; passa `giro_indisponivel` ao `scoreConfiancaValor`; remove o motivo enterrado L340 (agora estruturado). **Espelho verbatim** do helper.
 
 ### Contrato `src/services/financeiroService.ts`
-- `ValorEmpresaResult.reportado.capital_investido: number | null`, `.capital_giro: number | null`, **novo** `.giro_indisponivel: boolean`; `normalizado.capital_investido: number | null`.
+- `ValorEmpresaResult.reportado.capital_investido: number | null`, `.capital_giro: number | null`, **novos** `.giro_indisponivel: boolean`, `.giro_snapshot_at: string | null`, `.giro_dias: number | null`; `normalizado.capital_investido: number | null`.
 
 ### UI `src/pages/FinanceiroValor.tsx`
-- `brl()`/`pct()` **já** renderizam `—` para null (sem mudança no número). **Novo**: quando `reportado.giro_indisponivel`, exibir "Sem snapshot de NCG — capital de giro indisponível (rode a projeção de caixa). ROIC/EVA não calculáveis." e **não** mostrar o "* capital parcial (sem ativo fixo)" enganoso nesse caso.
+- `brl()`/`pct()` **já** renderizam `—` para null (sem mudança no número).
+- **Mensagem giro-específica:** quando `reportado.giro_indisponivel`, exibir "Sem snapshot de NCG — capital de giro indisponível (rode a projeção de caixa). ROIC/EVA não calculáveis." e **gate** o "* capital parcial (sem ativo fixo)" (L48) para `capital_parcial && !giro_indisponivel` (não mostrar o motivo errado quando o parcial vem do NCG — **Codex resposta 7**).
+- **Frescor visível:** quando há giro, exibir "NCG de DD/MM/YYYY" e, se `giro_dias != null && giro_dias > 1`, "(Nd atrás)" com aviso quando stale — espelha o padrão do Cockpit (`Projecao13Card`).
+
+## Matriz de testes (vitest, Codex resposta 7)
+`resolverCapitalGiro`: (a) snapshots com ncg negativo → retorna o negativo, disponível; (b) ncg **zero** real → retorna 0, disponível (truthiness NÃO); (c) todos `ncg==null` → `{capital_giro:null, disponivel:false}`; (d) sem snapshots → indisponível; (e) mistura → pega o mais recente com ncg não-nulo + `snapshot_at`.
+`frescorGiro`: fresco (<limiar) → `stale:false`; velho (>limiar) → `stale:true` + `dias`; `snapshot_at` null → `{dias:null, stale:false}`.
+`capitalInvestido`: giro null → `capital_investido:null`, `giro_indisponivel:true`, `parcial:true`; giro 0 real + ativo fixo → capital = ativo fixo (válido, `giro_indisponivel:false`); giro negativo → capital pode ser ≤0 → ROIC null por capital (motivo distinto).
+`normalizarComingling`: `capital_reportado:null` + `intercompany_giro:-X` → `capital_normalizado:null` (NÃO `−X`); EBIT normalizado segue calculado.
+`scoreConfiancaValor`: `giro_indisponivel:true` → `baixa`; `giro_stale:true` (sem indisponível) → `media`; `roic_null` por capital≤0 → `media`.
 
 ## Entrega / risco
 - **Sem migration.** **Com deploy** do `fin-valor-engine` via chat do Lovable (ROIC/EVA são calculados no edge — client-side só avisaria depois do número nascer errado, como o Codex apontou).

--- a/src/lib/financeiro/__tests__/valor-helpers.test.ts
+++ b/src/lib/financeiro/__tests__/valor-helpers.test.ts
@@ -12,6 +12,10 @@ import {
   roicIncremental,
   normalizarComingling,
   scoreConfiancaValor,
+  resolverCapitalGiro,
+  frescorGiro,
+  acharCapitalGiroAnterior,
+  resolverCapitalParaValor,
 } from '../valor-helpers';
 
 describe('calcularNOPAT', () => {
@@ -297,5 +301,173 @@ describe('scoreConfiancaValor', () => {
     });
     expect(r.nivel).toBe('media');
     expect(r.motivos.some((m) => m.toLowerCase().includes('ttm incompleto'))).toBe(true);
+  });
+
+  it('giro indisponível → baixa + motivo de NCG (mais severo que roic_null por capital≤0)', () => {
+    const r = scoreConfiancaValor({
+      roic_null: true, wacc_null: false, eva_null: true, capital_parcial: true,
+      normalizacao_aplicada: true, imposto_teorico_parcial: false, dre_confianca: 'alta',
+      giro_indisponivel: true,
+    });
+    expect(r.nivel).toBe('baixa');
+    expect(r.motivos.some((m) => m.toLowerCase().includes('snapshot de ncg'))).toBe(true);
+  });
+
+  it('giro stale (sem indisponível) → media + motivo de NCG desatualizado', () => {
+    const r = scoreConfiancaValor({
+      roic_null: false, wacc_null: false, eva_null: false, capital_parcial: false,
+      normalizacao_aplicada: true, imposto_teorico_parcial: false, dre_confianca: 'alta',
+      giro_stale: true,
+    });
+    expect(r.nivel).toBe('media');
+    expect(r.motivos.some((m) => m.toLowerCase().includes('desatualiz'))).toBe(true);
+  });
+
+  it('roic_null por capital≤0 CONHECIDO (giro disponível) → media, NÃO baixa', () => {
+    const r = scoreConfiancaValor({
+      roic_null: true, wacc_null: false, eva_null: false, capital_parcial: false,
+      normalizacao_aplicada: true, imposto_teorico_parcial: false, dre_confianca: 'alta',
+      giro_indisponivel: false,
+    });
+    expect(r.nivel).toBe('media');
+  });
+});
+
+describe('resolverCapitalGiro', () => {
+  it('pega o snapshot mais recente com ncg não-nulo (negativo é valor real)', () => {
+    const r = resolverCapitalGiro([
+      { ncg: null, snapshot_at: '2026-05-28T10:00:00Z' },
+      { ncg: -5000, snapshot_at: '2026-05-27T10:00:00Z' },
+      { ncg: 9999, snapshot_at: '2026-05-20T10:00:00Z' },
+    ]);
+    expect(r.capital_giro).toBe(-5000);
+    expect(r.disponivel).toBe(true);
+    expect(r.snapshot_at).toBe('2026-05-27T10:00:00Z');
+  });
+  it('ncg zero é valor REAL (não ausência) — truthiness não', () => {
+    const r = resolverCapitalGiro([{ ncg: 0, snapshot_at: '2026-05-28T10:00:00Z' }]);
+    expect(r.capital_giro).toBe(0);
+    expect(r.disponivel).toBe(true);
+  });
+  it('todos null → indisponível', () => {
+    const r = resolverCapitalGiro([{ ncg: null, snapshot_at: '2026-05-28T10:00:00Z' }]);
+    expect(r.capital_giro).toBeNull();
+    expect(r.disponivel).toBe(false);
+    expect(r.snapshot_at).toBeNull();
+  });
+  it('sem snapshots → indisponível', () => {
+    const r = resolverCapitalGiro([]);
+    expect(r.disponivel).toBe(false);
+    expect(r.snapshot_at).toBeNull();
+  });
+  it('ordem fora de ordem → pega o mais recente por data (não confia no array)', () => {
+    const r = resolverCapitalGiro([
+      { ncg: 100, snapshot_at: '2026-05-01T00:00:00Z' },
+      { ncg: 200, snapshot_at: '2026-05-27T00:00:00Z' },
+      { ncg: 150, snapshot_at: '2026-05-10T00:00:00Z' },
+    ]);
+    expect(r.capital_giro).toBe(200);
+  });
+});
+
+describe('frescorGiro', () => {
+  const hoje = Date.parse('2026-05-28T00:00:00Z');
+  it('fresco (8 dias) → não stale, dias=8', () => {
+    expect(frescorGiro('2026-05-20T00:00:00Z', hoje, 45)).toEqual({ dias: 8, stale: false });
+  });
+  it('velho (>120 dias) → stale, dias grande', () => {
+    const r = frescorGiro('2026-01-01T00:00:00Z', hoje, 45);
+    expect(r.stale).toBe(true);
+    expect(r.dias).toBeGreaterThan(120);
+  });
+  it('snapshot_at null → dias null, não stale', () => {
+    expect(frescorGiro(null, hoje, 45)).toEqual({ dias: null, stale: false });
+  });
+  it('snapshot_at inválido → dias null, não stale', () => {
+    expect(frescorGiro('lixo', hoje, 45)).toEqual({ dias: null, stale: false });
+  });
+});
+
+describe('acharCapitalGiroAnterior', () => {
+  it('acha o snapshot ~365d antes do ref dentro da tolerância', () => {
+    const snaps = [
+      { ncg: 1000, snapshot_at: '2026-05-27T00:00:00Z' },
+      { ncg: 800, snapshot_at: '2025-05-26T00:00:00Z' },
+    ];
+    expect(acharCapitalGiroAnterior(snaps, '2026-05-27T00:00:00Z')).toBe(800);
+  });
+  it('sem snapshot próximo de −365d (fora da tolerância) → null', () => {
+    const snaps = [{ ncg: 1000, snapshot_at: '2026-05-27T00:00:00Z' }];
+    expect(acharCapitalGiroAnterior(snaps, '2026-05-27T00:00:00Z')).toBeNull();
+  });
+});
+
+describe('resolverCapitalParaValor (orquestração — defeita o "inline 0")', () => {
+  const hoje = Date.parse('2026-05-28T00:00:00Z');
+  const af = null; // sem ativo fixo
+
+  it('NCG ausente (todos null) → capital_investido/capital_giro null, giro_indisponivel, sem anterior', () => {
+    const r = resolverCapitalParaValor({ snaps: [{ ncg: null, snapshot_at: '2026-05-28T00:00:00Z' }], ativo_fixo: af, hojeMs: hoje });
+    expect(r.capital.capital_investido).toBeNull();
+    expect(r.capital.capital_giro).toBeNull();
+    expect(r.capital.giro_indisponivel).toBe(true);
+    expect(r.capital.parcial).toBe(true);
+    expect(r.capital_anterior).toBeNull();
+    expect(r.giro_snapshot_at).toBeNull();
+  });
+
+  it('NCG ausente + ativo fixo informado → AINDA capital null (não vira ativo_fixo isolado)', () => {
+    const ativo = { valor: 500000, data_ref: null, fonte: 'reposicao' as const, base: 'reposicao' as const, operacional: true };
+    const r = resolverCapitalParaValor({ snaps: [], ativo_fixo: ativo, hojeMs: hoje });
+    expect(r.capital.capital_investido).toBeNull(); // NÃO 500000 — sem giro, ROIC não nasce
+    expect(r.capital.giro_indisponivel).toBe(true);
+  });
+
+  it('NCG negativo grande sem ativo fixo → giro DISPONÍVEL, capital≤0, roic null POR CAPITAL (não por ausência)', () => {
+    const r = resolverCapitalParaValor({ snaps: [{ ncg: -50000, snapshot_at: '2026-05-27T00:00:00Z' }], ativo_fixo: af, hojeMs: hoje });
+    expect(r.capital.giro_indisponivel).toBe(false);
+    expect(r.capital.capital_investido).toBe(-50000);
+    expect(roic({ nopat: 1000, capital_investido: r.capital.capital_investido })).toBeNull();
+  });
+
+  it('NCG válido recente → capital_giro = ncg (happy-path idêntico), não stale', () => {
+    const r = resolverCapitalParaValor({ snaps: [{ ncg: 300000, snapshot_at: '2026-05-25T00:00:00Z' }], ativo_fixo: af, hojeMs: hoje });
+    expect(r.capital.capital_giro).toBe(300000);
+    expect(r.capital.capital_investido).toBe(300000);
+    expect(r.giro_stale).toBe(false);
+    expect(r.giro_dias).toBe(3);
+  });
+
+  it('NCG válido porém VELHO → disponível mas stale (capital real, confiança rebaixada depois)', () => {
+    const r = resolverCapitalParaValor({ snaps: [{ ncg: 300000, snapshot_at: '2026-01-01T00:00:00Z' }], ativo_fixo: af, hojeMs: hoje });
+    expect(r.capital.capital_giro).toBe(300000);
+    expect(r.giro_stale).toBe(true);
+  });
+});
+
+describe('normalizarComingling — capital null não coage', () => {
+  it('capital_reportado null + intercompany_giro -500 → capital_normalizado null (NÃO -500); ebit normalizado segue', () => {
+    const r = normalizarComingling({
+      ebit_reportado: 10000, capital_reportado: null,
+      prolabore_real_ttm: 1000, prolabore_mercado_ttm: 3000, aluguel_mercado_ttm: null, intercompany_giro: -500,
+    });
+    expect(r.capital_normalizado).toBeNull();
+    expect(r.capital_reportado).toBeNull();
+    expect(r.ebit_normalizado).toBe(10000 + (1000 - 3000)); // EBIT independe do capital
+  });
+});
+
+describe('capitalInvestido — giro nullable', () => {
+  it('giro null → capital null + giro_indisponivel + parcial', () => {
+    const r = capitalInvestido({ capital_giro: null, ativo_fixo: null });
+    expect(r.capital_investido).toBeNull();
+    expect(r.capital_giro).toBeNull();
+    expect(r.giro_indisponivel).toBe(true);
+    expect(r.parcial).toBe(true);
+  });
+  it('giro 0 REAL + ativo fixo → capital = ativo fixo, giro_indisponivel false', () => {
+    const r = capitalInvestido({ capital_giro: 0, ativo_fixo: { valor: 500000, data_ref: null, fonte: 'reposicao', base: 'reposicao', operacional: true } });
+    expect(r.capital_investido).toBe(500000);
+    expect(r.giro_indisponivel).toBe(false);
   });
 });

--- a/src/lib/financeiro/__tests__/valor-helpers.test.ts
+++ b/src/lib/financeiro/__tests__/valor-helpers.test.ts
@@ -368,6 +368,15 @@ describe('resolverCapitalGiro', () => {
     ]);
     expect(r.capital_giro).toBe(200);
   });
+  it('ncg string vazia/whitespace (cast runtime) → ausência, NÃO 0 (Number("")===0 seria fabricação)', () => {
+    expect(resolverCapitalGiro([{ ncg: '' as unknown as number, snapshot_at: '2026-05-28T00:00:00Z' }]).disponivel).toBe(false);
+    expect(resolverCapitalGiro([{ ncg: '   ' as unknown as number, snapshot_at: '2026-05-28T00:00:00Z' }]).disponivel).toBe(false);
+  });
+  it('ncg string numérica (PostgREST numeric) → valor real', () => {
+    const r = resolverCapitalGiro([{ ncg: '300000' as unknown as number, snapshot_at: '2026-05-28T00:00:00Z' }]);
+    expect(r.capital_giro).toBe(300000);
+    expect(r.disponivel).toBe(true);
+  });
 });
 
 describe('frescorGiro', () => {

--- a/src/lib/financeiro/valor-helpers.ts
+++ b/src/lib/financeiro/valor-helpers.ts
@@ -59,16 +59,17 @@ export type AtivoFixoInput = {
 } | null;
 
 export type CapitalInvestidoResult = {
-  capital_investido: number;
-  capital_giro: number;
+  capital_investido: number | null;   // null quando giro indisponível (ausente ≠ R$0)
+  capital_giro: number | null;
   ativo_fixo: number;
   ajustes: number;
   parcial: boolean;
+  giro_indisponivel: boolean;          // capital de giro (NCG) não veio do snapshot
   motivos: string[];
 };
 
 export function capitalInvestido(input: {
-  capital_giro: number;
+  capital_giro: number | null;
   ativo_fixo: AtivoFixoInput;
   ajustes?: number;
 }): CapitalInvestidoResult {
@@ -76,14 +77,87 @@ export function capitalInvestido(input: {
   const motivos: string[] = [];
   let ativo_fixo = 0;
   let parcial = false;
+  const giro_indisponivel = input.capital_giro == null;
   if (input.ativo_fixo && input.ativo_fixo.operacional && Number.isFinite(input.ativo_fixo.valor)) {
     ativo_fixo = input.ativo_fixo.valor;
   } else {
     parcial = true;
     motivos.push('Ativo fixo operacional não informado — capital investido parcial (só giro − ajustes).');
   }
-  const capital_investido = input.capital_giro + ativo_fixo - ajustes;
-  return { capital_investido, capital_giro: input.capital_giro, ativo_fixo, ajustes, parcial, motivos };
+  // Giro ausente NÃO vira R$0: sem o NCG, o capital investido é indisponível (ROIC/EVA não calculáveis).
+  if (giro_indisponivel) {
+    motivos.push('Sem snapshot de NCG — capital de giro indisponível; ROIC/EVA não calculáveis.');
+    return { capital_investido: null, capital_giro: null, ativo_fixo, ajustes, parcial: true, giro_indisponivel: true, motivos };
+  }
+  const capital_investido = (input.capital_giro as number) + ativo_fixo - ajustes;
+  return { capital_investido, capital_giro: input.capital_giro, ativo_fixo, ajustes, parcial, giro_indisponivel: false, motivos };
+}
+
+// ===================== Resolução de capital de giro a partir dos snapshots da engine A1 =====================
+export type SnapNcg = { ncg: number | null; snapshot_at: string };
+
+// Último snapshot com ncg NÃO-nulo. `s.ncg != null` (NÃO truthiness): 0 e negativo são valores REAIS;
+// só null/sem snapshot conta como ausência. Não confia na ordem do array — pega o mais recente por data.
+export function resolverCapitalGiro(snaps: SnapNcg[]): { capital_giro: number | null; snapshot_at: string | null; disponivel: boolean } {
+  let melhor: SnapNcg | null = null;
+  for (const s of snaps) {
+    if (s.ncg == null) continue;
+    if (melhor == null || Date.parse(s.snapshot_at) > Date.parse(melhor.snapshot_at)) melhor = s;
+  }
+  if (melhor == null) return { capital_giro: null, snapshot_at: null, disponivel: false };
+  return { capital_giro: Number(melhor.ncg), snapshot_at: melhor.snapshot_at, disponivel: true };
+}
+
+// Frescor do NCG: cron de snapshot é diário → 45+ dias indica pipeline defasado. Stale NÃO vira
+// indisponível (o NCG é real) — só rebaixa a confiança e fica visível. `hojeMs` injetado p/ testar puro.
+export function frescorGiro(snapshot_at: string | null, hojeMs: number, limiarStaleDias = 45): { dias: number | null; stale: boolean } {
+  if (!snapshot_at) return { dias: null, stale: false };
+  const t = Date.parse(snapshot_at);
+  if (!Number.isFinite(t)) return { dias: null, stale: false };
+  const dias = Math.round((hojeMs - t) / 86400000);
+  return { dias, stale: dias > limiarStaleDias };
+}
+
+// NCG ~365d antes do snapshot atual (ponto −12m do ROIC incremental), com tolerância.
+export function acharCapitalGiroAnterior(snaps: SnapNcg[], refSnapshotAt: string, opts?: { janelaDias?: number; toleranciaDias?: number }): number | null {
+  const janela = opts?.janelaDias ?? 365;
+  const tol = opts?.toleranciaDias ?? 60;
+  const alvo = Date.parse(refSnapshotAt) - janela * 86400000;
+  let melhor: { ncg: number; dist: number } | null = null;
+  for (const s of snaps) {
+    if (s.ncg == null) continue;
+    const dist = Math.abs(Date.parse(s.snapshot_at) - alvo);
+    if (melhor == null || dist < melhor.dist) melhor = { ncg: Number(s.ncg), dist };
+  }
+  return melhor && melhor.dist <= tol * 86400000 ? melhor.ncg : null;
+}
+
+// Orquestração pura do bloco de capital (resolver + frescor + anterior + capitalInvestido) — testável
+// ponta-a-ponta e espelhada verbatim no edge. Defeita o "capital_giro = ncg ? ncg : 0" inline.
+export function resolverCapitalParaValor(input: {
+  snaps: SnapNcg[];
+  ativo_fixo: AtivoFixoInput;
+  ajustes?: number;
+  hojeMs: number;
+  limiarStaleDias?: number;
+}): {
+  capital: CapitalInvestidoResult;
+  capital_anterior: number | null;
+  giro_snapshot_at: string | null;
+  giro_dias: number | null;
+  giro_stale: boolean;
+} {
+  const giro = resolverCapitalGiro(input.snaps);
+  const frescor = frescorGiro(giro.snapshot_at, input.hojeMs, input.limiarStaleDias);
+  const capital = capitalInvestido({ capital_giro: giro.capital_giro, ativo_fixo: input.ativo_fixo, ajustes: input.ajustes });
+  // Sem o ponto atual de giro, o incremental não existe (anterior forçado a null).
+  const capital_giro_anterior = giro.disponivel && giro.snapshot_at
+    ? acharCapitalGiroAnterior(input.snaps, giro.snapshot_at)
+    : null;
+  const capital_anterior = capital_giro_anterior != null
+    ? capitalInvestido({ capital_giro: capital_giro_anterior, ativo_fixo: input.ativo_fixo, ajustes: input.ajustes }).capital_investido
+    : null;
+  return { capital, capital_anterior, giro_snapshot_at: giro.snapshot_at, giro_dias: frescor.dias, giro_stale: frescor.stale };
 }
 
 export type KeDecomposto = {
@@ -182,8 +256,8 @@ export function roicIncremental(input: {
 export type CominglingResult = {
   ebit_reportado: number;
   ebit_normalizado: number;
-  capital_reportado: number;
-  capital_normalizado: number;
+  capital_reportado: number | null;
+  capital_normalizado: number | null;
   ajuste_prolabore: number;
   ajuste_aluguel: number;
   ajuste_intercompany_capital: number;
@@ -193,7 +267,7 @@ export type CominglingResult = {
 
 export function normalizarComingling(input: {
   ebit_reportado: number;
-  capital_reportado: number;
+  capital_reportado: number | null;
   prolabore_real_ttm: number | null;
   prolabore_mercado_ttm: number | null;
   aluguel_mercado_ttm: number | null;
@@ -229,7 +303,8 @@ export function normalizarComingling(input: {
   }
 
   const ebit_normalizado = input.ebit_reportado + ajuste_prolabore + ajuste_aluguel;
-  const capital_normalizado = input.capital_reportado + ajuste_intercompany_capital;
+  // Guard anti-coerção: capital_reportado null NÃO pode virar `null + ajuste` = número.
+  const capital_normalizado = input.capital_reportado == null ? null : input.capital_reportado + ajuste_intercompany_capital;
   if (!aplicado) motivos.push('Sem inputs de normalização — só visão reportada; possível comingling do dono não ajustado.');
 
   return {
@@ -263,19 +338,28 @@ export function scoreConfiancaValor(input: {
   imposto_teorico_parcial: boolean;
   dre_confianca: 'alta' | 'media' | 'baixa';
   ttm_parcial?: boolean;   // janela TTM com < 12 meses de DRE (anualização parcial)
+  giro_indisponivel?: boolean;  // sem snapshot de NCG → capital/ROIC/EVA indisponíveis (mais severo)
+  giro_stale?: boolean;         // NCG real porém antigo → defasagem possível
 }): ConfiancaValor {
   const motivos: string[] = [];
   let nivel = 3; // 3=alta, 2=media, 1=baixa — pega o pior sinal
   const rebaixar = (para: number, motivo: string) => { if (para < nivel) nivel = para; motivos.push(motivo); };
 
   if (input.ttm_parcial) rebaixar(2, 'TTM incompleto (menos de 12 meses de DRE) — anualização parcial.');
-  if (input.capital_parcial) rebaixar(2, 'Capital investido parcial (sem ativo fixo) — ROIC/EVA parciais.');
+  // NCG ausente é o sinal mais severo (dado central de capital faltando) e domina o "(sem ativo fixo)".
+  if (input.giro_indisponivel) {
+    rebaixar(1, 'Sem snapshot de NCG — capital de giro indisponível; ROIC/EVA não calculáveis.');
+  } else {
+    if (input.giro_stale) rebaixar(2, 'NCG desatualizado (snapshot antigo) — capital de giro pode estar defasado.');
+    if (input.capital_parcial) rebaixar(2, 'Capital investido parcial (sem ativo fixo) — ROIC/EVA parciais.');
+  }
   if (input.wacc_null) rebaixar(2, 'WACC/EVA/spread indisponíveis (faltam dívida, PL ou Ke).');
   if (!input.normalizacao_aplicada) rebaixar(2, 'Sem normalização de comingling — só visão reportada.');
   if (input.imposto_teorico_parcial) rebaixar(2, 'Config tributária incompleta — imposto operacional parcial (propaga da Onda 3).');
   if (input.dre_confianca === 'baixa') rebaixar(1, 'DRE subjacente com confiança baixa.');
   else if (input.dre_confianca === 'media') rebaixar(2, 'DRE subjacente com confiança média.');
-  if (input.roic_null) rebaixar(2, 'ROIC indisponível (capital investido ≤ 0).');
+  // roic_null por capital ≤0 CONHECIDO (giro disponível) é media; quando o giro está indisponível já caiu pra baixa acima.
+  if (input.roic_null && !input.giro_indisponivel) rebaixar(2, 'ROIC indisponível (capital investido ≤ 0).');
 
   return {
     nivel: nivel === 3 ? 'alta' : nivel === 2 ? 'media' : 'baixa',

--- a/src/lib/financeiro/valor-helpers.ts
+++ b/src/lib/financeiro/valor-helpers.ts
@@ -96,16 +96,25 @@ export function capitalInvestido(input: {
 // ===================== Resolução de capital de giro a partir dos snapshots da engine A1 =====================
 export type SnapNcg = { ncg: number | null; snapshot_at: string };
 
-// Último snapshot com ncg NÃO-nulo. `s.ncg != null` (NÃO truthiness): 0 e negativo são valores REAIS;
-// só null/sem snapshot conta como ausência. Não confia na ordem do array — pega o mais recente por data.
+// ncg pode chegar como número OU string numérica (PostgREST devolve `numeric` como string p/ preservar precisão).
+// null / '' / whitespace / NaN / Infinity → AUSÊNCIA (NÃO vira 0 — `Number('')===0` seria fabricação). 0 e negativo são REAIS.
+function ncgFinito(ncg: unknown): number | null {
+  if (ncg == null) return null;
+  if (typeof ncg === 'string' && ncg.trim() === '') return null;
+  const n = Number(ncg);
+  return Number.isFinite(n) ? n : null;
+}
+
+// Último snapshot com ncg válido. Não confia na ordem do array — pega o mais recente por data.
 export function resolverCapitalGiro(snaps: SnapNcg[]): { capital_giro: number | null; snapshot_at: string | null; disponivel: boolean } {
-  let melhor: SnapNcg | null = null;
+  let melhor: { ncg: number; snapshot_at: string } | null = null;
   for (const s of snaps) {
-    if (s.ncg == null) continue;
-    if (melhor == null || Date.parse(s.snapshot_at) > Date.parse(melhor.snapshot_at)) melhor = s;
+    const n = ncgFinito(s.ncg);
+    if (n == null) continue;
+    if (melhor == null || Date.parse(s.snapshot_at) > Date.parse(melhor.snapshot_at)) melhor = { ncg: n, snapshot_at: s.snapshot_at };
   }
   if (melhor == null) return { capital_giro: null, snapshot_at: null, disponivel: false };
-  return { capital_giro: Number(melhor.ncg), snapshot_at: melhor.snapshot_at, disponivel: true };
+  return { capital_giro: melhor.ncg, snapshot_at: melhor.snapshot_at, disponivel: true };
 }
 
 // Frescor do NCG: cron de snapshot é diário → 45+ dias indica pipeline defasado. Stale NÃO vira
@@ -125,9 +134,10 @@ export function acharCapitalGiroAnterior(snaps: SnapNcg[], refSnapshotAt: string
   const alvo = Date.parse(refSnapshotAt) - janela * 86400000;
   let melhor: { ncg: number; dist: number } | null = null;
   for (const s of snaps) {
-    if (s.ncg == null) continue;
+    const n = ncgFinito(s.ncg);
+    if (n == null) continue;
     const dist = Math.abs(Date.parse(s.snapshot_at) - alvo);
-    if (melhor == null || dist < melhor.dist) melhor = { ncg: Number(s.ncg), dist };
+    if (melhor == null || dist < melhor.dist) melhor = { ncg: n, dist };
   }
   return melhor && melhor.dist <= tol * 86400000 ? melhor.ncg : null;
 }

--- a/src/pages/FinanceiroValor.tsx
+++ b/src/pages/FinanceiroValor.tsx
@@ -13,6 +13,7 @@ const NOME: Record<string, string> = { colacor: 'Colacor', oben: 'Oben', colacor
 
 const pct = (x: number | null | undefined) => (x == null ? '—' : `${(x * 100).toFixed(1)}%`);
 const brl = (x: number | null | undefined) => (x == null ? '—' : x.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL', maximumFractionDigits: 0 }));
+const dataBR = (iso: string | null) => (iso ? `${iso.slice(8, 10)}/${iso.slice(5, 7)}/${iso.slice(0, 4)}` : '—');
 
 function nivelClasses(n: 'alta' | 'media' | 'baixa') {
   if (n === 'alta') return 'text-status-success bg-status-success-bg';
@@ -41,11 +42,17 @@ function EmpresaCard({ company, modo }: { company: string; modo: 'reportado' | '
           <span className="text-muted-foreground">Spread</span><span className={`text-right ${spreadV != null && spreadV < 0 ? 'text-status-error' : 'text-status-success'}`}>{pct(spreadV)}</span>
           <span className="text-muted-foreground">EVA</span><span className="text-right">{brl(evaV)}</span>
           <span className="text-muted-foreground">NOPAT (TTM)</span><span className="text-right">{brl(v.nopat)}</span>
-          <span className="text-muted-foreground">Capital investido</span><span className="text-right">{brl(v.capital_investido)}{data.reportado.capital_parcial && modo === 'reportado' ? ' *' : ''}</span>
+          <span className="text-muted-foreground">Capital investido</span><span className="text-right">{brl(v.capital_investido)}{data.reportado.capital_parcial && !data.reportado.giro_indisponivel && modo === 'reportado' ? ' *' : ''}</span>
           {modo === 'reportado' && (<><span className="text-muted-foreground">Margem op. pré-imposto</span><span className="text-right">{pct(data.reportado.margem_operacional_pre_imposto)}</span></>)}
           <span className="text-muted-foreground">ROIC incremental</span><span className="kpi-value text-right">{pct(data.reportado.roic_incremental)}</span>
         </div>
-        {data.reportado.capital_parcial && modo === 'reportado' && <p className="text-xs text-status-warning">* capital parcial (sem ativo fixo)</p>}
+        {data.reportado.giro_indisponivel && modo === 'reportado' && <p className="text-xs text-status-warning">Sem snapshot de NCG — capital de giro indisponível (rode a projeção de caixa). ROIC/EVA não calculáveis.</p>}
+        {data.reportado.capital_parcial && !data.reportado.giro_indisponivel && modo === 'reportado' && <p className="text-xs text-status-warning">* capital parcial (sem ativo fixo)</p>}
+        {modo === 'reportado' && data.reportado.giro_snapshot_at && (
+          <p className={`text-xs ${data.reportado.giro_dias != null && data.reportado.giro_dias > 45 ? 'text-status-warning' : 'text-muted-foreground'}`}>
+            NCG de {dataBR(data.reportado.giro_snapshot_at)}{data.reportado.giro_dias != null && data.reportado.giro_dias > 1 ? ` (${data.reportado.giro_dias}d atrás)` : ''}
+          </p>
+        )}
         {data.reportado.incremental.aviso && <p className="text-xs text-muted-foreground">{data.reportado.incremental.aviso}</p>}
         {modo === 'normalizado' && !data.normalizado.aplicado && <p className="text-xs text-status-warning">Sem inputs de normalização — igual ao reportado.</p>}
         {modo === 'normalizado' && data.normalizado.nopat_aproximado && <p className="text-xs text-muted-foreground">NOPAT normalizado é aproximado: o imposto absoluto (IRPJ+CSLL) não é recalculado sobre o EBIT ajustado.</p>}

--- a/src/services/financeiroService.ts
+++ b/src/services/financeiroService.ts
@@ -835,7 +835,8 @@ export interface ValorEmpresaResult {
   reportado: {
     ebit: number; nopat: number; imposto_operacional_nopat: number; carga_tributaria_regime_total: number;
     margem_operacional_pre_imposto: number; receita_liquida_ttm: number;
-    capital_investido: number; capital_giro: number; ativo_fixo: number; ajustes: number; capital_parcial: boolean;
+    capital_investido: number | null; capital_giro: number | null; ativo_fixo: number; ajustes: number; capital_parcial: boolean;
+    giro_indisponivel: boolean; giro_snapshot_at: string | null; giro_dias: number | null;
     roic: number | null; wacc: number | null; spread: number | null; eva: number | null;
     roic_incremental: number | null;
     incremental: { delta_nopat: number | null; delta_capital: number | null; aviso: string | null };
@@ -843,7 +844,7 @@ export interface ValorEmpresaResult {
     peso_divida: number | null; peso_equity: number | null;
   };
   normalizado: {
-    ebit: number; nopat: number; capital_investido: number;
+    ebit: number; nopat: number; capital_investido: number | null;
     roic: number | null; spread: number | null; eva: number | null;
     ajuste_prolabore: number; ajuste_aluguel: number; ajuste_intercompany_capital: number; aplicado: boolean;
     nopat_aproximado: boolean;

--- a/supabase/functions/fin-valor-engine/index.ts
+++ b/supabase/functions/fin-valor-engine/index.ts
@@ -81,11 +81,17 @@ function capitalInvestido(input: { capital_giro: number | null; ativo_fixo: Ativ
   return { capital_investido, capital_giro: input.capital_giro, ativo_fixo, ajustes, parcial, giro_indisponivel: false, motivos };
 }
 type SnapNcg = { ncg: number | null; snapshot_at: string };
+function ncgFinito(ncg: unknown): number | null {
+  if (ncg == null) return null;
+  if (typeof ncg === "string" && ncg.trim() === "") return null;
+  const n = Number(ncg);
+  return Number.isFinite(n) ? n : null;
+}
 function resolverCapitalGiro(snaps: SnapNcg[]): { capital_giro: number | null; snapshot_at: string | null; disponivel: boolean } {
-  let melhor: SnapNcg | null = null;
-  for (const s of snaps) { if (s.ncg == null) continue; if (melhor == null || Date.parse(s.snapshot_at) > Date.parse(melhor.snapshot_at)) melhor = s; }
+  let melhor: { ncg: number; snapshot_at: string } | null = null;
+  for (const s of snaps) { const n = ncgFinito(s.ncg); if (n == null) continue; if (melhor == null || Date.parse(s.snapshot_at) > Date.parse(melhor.snapshot_at)) melhor = { ncg: n, snapshot_at: s.snapshot_at }; }
   if (melhor == null) return { capital_giro: null, snapshot_at: null, disponivel: false };
-  return { capital_giro: Number(melhor.ncg), snapshot_at: melhor.snapshot_at, disponivel: true };
+  return { capital_giro: melhor.ncg, snapshot_at: melhor.snapshot_at, disponivel: true };
 }
 function frescorGiro(snapshot_at: string | null, hojeMs: number, limiarStaleDias = 45): { dias: number | null; stale: boolean } {
   if (!snapshot_at) return { dias: null, stale: false };
@@ -98,7 +104,7 @@ function acharCapitalGiroAnterior(snaps: SnapNcg[], refSnapshotAt: string, opts?
   const janela = opts?.janelaDias ?? 365; const tol = opts?.toleranciaDias ?? 60;
   const alvo = Date.parse(refSnapshotAt) - janela * 86400000;
   let melhor: { ncg: number; dist: number } | null = null;
-  for (const s of snaps) { if (s.ncg == null) continue; const dist = Math.abs(Date.parse(s.snapshot_at) - alvo); if (melhor == null || dist < melhor.dist) melhor = { ncg: Number(s.ncg), dist }; }
+  for (const s of snaps) { const n = ncgFinito(s.ncg); if (n == null) continue; const dist = Math.abs(Date.parse(s.snapshot_at) - alvo); if (melhor == null || dist < melhor.dist) melhor = { ncg: n, dist }; }
   return melhor && melhor.dist <= tol * 86400000 ? melhor.ncg : null;
 }
 function resolverCapitalParaValor(input: { snaps: SnapNcg[]; ativo_fixo: AtivoFixoInput; ajustes?: number; hojeMs: number; limiarStaleDias?: number }): { capital: CapitalInvestidoResult; capital_anterior: number | null; giro_snapshot_at: string | null; giro_dias: number | null; giro_stale: boolean } {

--- a/supabase/functions/fin-valor-engine/index.ts
+++ b/supabase/functions/fin-valor-engine/index.ts
@@ -65,14 +65,49 @@ function margemOperacionalPreImposto(input: { ebit: number; receita_liquida: num
   return input.ebit / input.receita_liquida;
 }
 type AtivoFixoInput = { valor: number; data_ref: string | null; fonte: "book" | "avaliacao" | "reposicao" | "seguro" | null; base: "reposicao" | "book" | null; operacional: boolean } | null;
-function capitalInvestido(input: { capital_giro: number; ativo_fixo: AtivoFixoInput; ajustes?: number }) {
+type CapitalInvestidoResult = { capital_investido: number | null; capital_giro: number | null; ativo_fixo: number; ajustes: number; parcial: boolean; giro_indisponivel: boolean; motivos: string[] };
+function capitalInvestido(input: { capital_giro: number | null; ativo_fixo: AtivoFixoInput; ajustes?: number }): CapitalInvestidoResult {
   const ajustes = input.ajustes ?? 0;
   const motivos: string[] = [];
   let ativo_fixo = 0; let parcial = false;
+  const giro_indisponivel = input.capital_giro == null;
   if (input.ativo_fixo && input.ativo_fixo.operacional && Number.isFinite(input.ativo_fixo.valor)) ativo_fixo = input.ativo_fixo.valor;
   else { parcial = true; motivos.push("Ativo fixo operacional não informado — capital investido parcial (só giro − ajustes)."); }
-  const capital_investido = input.capital_giro + ativo_fixo - ajustes;
-  return { capital_investido, capital_giro: input.capital_giro, ativo_fixo, ajustes, parcial, motivos };
+  if (giro_indisponivel) {
+    motivos.push("Sem snapshot de NCG — capital de giro indisponível; ROIC/EVA não calculáveis.");
+    return { capital_investido: null, capital_giro: null, ativo_fixo, ajustes, parcial: true, giro_indisponivel: true, motivos };
+  }
+  const capital_investido = (input.capital_giro as number) + ativo_fixo - ajustes;
+  return { capital_investido, capital_giro: input.capital_giro, ativo_fixo, ajustes, parcial, giro_indisponivel: false, motivos };
+}
+type SnapNcg = { ncg: number | null; snapshot_at: string };
+function resolverCapitalGiro(snaps: SnapNcg[]): { capital_giro: number | null; snapshot_at: string | null; disponivel: boolean } {
+  let melhor: SnapNcg | null = null;
+  for (const s of snaps) { if (s.ncg == null) continue; if (melhor == null || Date.parse(s.snapshot_at) > Date.parse(melhor.snapshot_at)) melhor = s; }
+  if (melhor == null) return { capital_giro: null, snapshot_at: null, disponivel: false };
+  return { capital_giro: Number(melhor.ncg), snapshot_at: melhor.snapshot_at, disponivel: true };
+}
+function frescorGiro(snapshot_at: string | null, hojeMs: number, limiarStaleDias = 45): { dias: number | null; stale: boolean } {
+  if (!snapshot_at) return { dias: null, stale: false };
+  const t = Date.parse(snapshot_at);
+  if (!Number.isFinite(t)) return { dias: null, stale: false };
+  const dias = Math.round((hojeMs - t) / 86400000);
+  return { dias, stale: dias > limiarStaleDias };
+}
+function acharCapitalGiroAnterior(snaps: SnapNcg[], refSnapshotAt: string, opts?: { janelaDias?: number; toleranciaDias?: number }): number | null {
+  const janela = opts?.janelaDias ?? 365; const tol = opts?.toleranciaDias ?? 60;
+  const alvo = Date.parse(refSnapshotAt) - janela * 86400000;
+  let melhor: { ncg: number; dist: number } | null = null;
+  for (const s of snaps) { if (s.ncg == null) continue; const dist = Math.abs(Date.parse(s.snapshot_at) - alvo); if (melhor == null || dist < melhor.dist) melhor = { ncg: Number(s.ncg), dist }; }
+  return melhor && melhor.dist <= tol * 86400000 ? melhor.ncg : null;
+}
+function resolverCapitalParaValor(input: { snaps: SnapNcg[]; ativo_fixo: AtivoFixoInput; ajustes?: number; hojeMs: number; limiarStaleDias?: number }): { capital: CapitalInvestidoResult; capital_anterior: number | null; giro_snapshot_at: string | null; giro_dias: number | null; giro_stale: boolean } {
+  const giro = resolverCapitalGiro(input.snaps);
+  const frescor = frescorGiro(giro.snapshot_at, input.hojeMs, input.limiarStaleDias);
+  const capital = capitalInvestido({ capital_giro: giro.capital_giro, ativo_fixo: input.ativo_fixo, ajustes: input.ajustes });
+  const capital_giro_anterior = giro.disponivel && giro.snapshot_at ? acharCapitalGiroAnterior(input.snaps, giro.snapshot_at) : null;
+  const capital_anterior = capital_giro_anterior != null ? capitalInvestido({ capital_giro: capital_giro_anterior, ativo_fixo: input.ativo_fixo, ajustes: input.ajustes }).capital_investido : null;
+  return { capital, capital_anterior, giro_snapshot_at: giro.snapshot_at, giro_dias: frescor.dias, giro_stale: frescor.stale };
 }
 type KeDecomposto = { ancora: number; premio_risco_equity: number; premio_tamanho_private: number; premio_iliquidez_controle: number };
 function somarKe(d: KeDecomposto): number { return d.ancora + d.premio_risco_equity + d.premio_tamanho_private + d.premio_iliquidez_controle; }
@@ -111,7 +146,7 @@ function roicIncremental(input: { nopat_atual: number; nopat_anterior: number | 
   if (delta_capital < limiar) return { roic_incremental: null, delta_nopat, delta_capital, aviso: "Variação de capital pequena ou negativa — ROIC incremental seria ruído." };
   return { roic_incremental: delta_nopat / delta_capital, delta_nopat, delta_capital, aviso: null };
 }
-function normalizarComingling(input: { ebit_reportado: number; capital_reportado: number; prolabore_real_ttm: number | null; prolabore_mercado_ttm: number | null; aluguel_mercado_ttm: number | null; intercompany_giro: number | null }) {
+function normalizarComingling(input: { ebit_reportado: number; capital_reportado: number | null; prolabore_real_ttm: number | null; prolabore_mercado_ttm: number | null; aluguel_mercado_ttm: number | null; intercompany_giro: number | null }) {
   const motivos: string[] = []; let aplicado = false;
   let ajuste_prolabore = 0;
   if (input.prolabore_real_ttm != null && input.prolabore_mercado_ttm != null) { ajuste_prolabore = input.prolabore_real_ttm - input.prolabore_mercado_ttm; aplicado = true; }
@@ -122,21 +157,26 @@ function normalizarComingling(input: { ebit_reportado: number; capital_reportado
   let ajuste_intercompany_capital = 0;
   if (input.intercompany_giro != null) { ajuste_intercompany_capital = -input.intercompany_giro; aplicado = true; }
   const ebit_normalizado = input.ebit_reportado + ajuste_prolabore + ajuste_aluguel;
-  const capital_normalizado = input.capital_reportado + ajuste_intercompany_capital;
+  const capital_normalizado = input.capital_reportado == null ? null : input.capital_reportado + ajuste_intercompany_capital;
   if (!aplicado) motivos.push("Sem inputs de normalização — só visão reportada; possível comingling do dono não ajustado.");
   return { ebit_reportado: input.ebit_reportado, ebit_normalizado, capital_reportado: input.capital_reportado, capital_normalizado, ajuste_prolabore, ajuste_aluguel, ajuste_intercompany_capital, aplicado, motivos };
 }
-function scoreConfiancaValor(input: { roic_null: boolean; wacc_null: boolean; eva_null: boolean; capital_parcial: boolean; normalizacao_aplicada: boolean; imposto_teorico_parcial: boolean; dre_confianca: "alta" | "media" | "baixa"; ttm_parcial?: boolean }) {
+function scoreConfiancaValor(input: { roic_null: boolean; wacc_null: boolean; eva_null: boolean; capital_parcial: boolean; normalizacao_aplicada: boolean; imposto_teorico_parcial: boolean; dre_confianca: "alta" | "media" | "baixa"; ttm_parcial?: boolean; giro_indisponivel?: boolean; giro_stale?: boolean }) {
   const motivos: string[] = []; let nivel = 3;
   const rebaixar = (para: number, motivo: string) => { if (para < nivel) nivel = para; motivos.push(motivo); };
   if (input.ttm_parcial) rebaixar(2, "TTM incompleto (menos de 12 meses de DRE) — anualização parcial.");
-  if (input.capital_parcial) rebaixar(2, "Capital investido parcial (sem ativo fixo) — ROIC/EVA parciais.");
+  if (input.giro_indisponivel) {
+    rebaixar(1, "Sem snapshot de NCG — capital de giro indisponível; ROIC/EVA não calculáveis.");
+  } else {
+    if (input.giro_stale) rebaixar(2, "NCG desatualizado (snapshot antigo) — capital de giro pode estar defasado.");
+    if (input.capital_parcial) rebaixar(2, "Capital investido parcial (sem ativo fixo) — ROIC/EVA parciais.");
+  }
   if (input.wacc_null) rebaixar(2, "WACC/EVA/spread indisponíveis (faltam dívida, PL ou Ke).");
   if (!input.normalizacao_aplicada) rebaixar(2, "Sem normalização de comingling — só visão reportada.");
   if (input.imposto_teorico_parcial) rebaixar(2, "Config tributária incompleta — imposto operacional parcial (propaga da Onda 3).");
   if (input.dre_confianca === "baixa") rebaixar(1, "DRE subjacente com confiança baixa.");
   else if (input.dre_confianca === "media") rebaixar(2, "DRE subjacente com confiança média.");
-  if (input.roic_null) rebaixar(2, "ROIC indisponível (capital investido ≤ 0).");
+  if (input.roic_null && !input.giro_indisponivel) rebaixar(2, "ROIC indisponível (capital investido ≤ 0).");
   return {
     nivel: (nivel === 3 ? "alta" : nivel === 2 ? "media" : "baixa") as "alta" | "media" | "baixa",
     motivos, roic_disponivel: !input.roic_null, wacc_disponivel: !input.wacc_null, eva_disponivel: !input.eva_null, normalizado_disponivel: input.normalizacao_aplicada,
@@ -241,26 +281,11 @@ serve(async (req: Request) => {
   const ano_mes_fim = `${Math.floor((idxFim - 1) / 12)}-${String(((idxFim - 1) % 12) + 1).padStart(2, "0")}`;
   const dre_confianca: "alta" | "media" | "baixa" = ttm.confianca_pior === 1 ? "baixa" : ttm.confianca_pior === 2 ? "media" : "alta";
 
-  // 3) Capital de giro: último ncg snapshot + ncg ~365d antes
+  // 3) Capital de giro: snapshots crus da engine A1. Resolução (ausente ≠ R$0 + frescor + −12m) na
+  // composta pura `resolverCapitalParaValor`, chamada na seção 6 (depende de ativo_fixo/ajustes).
   const { data: snaps } = await db.from("fin_projecao_snapshots")
     .select("ncg, snapshot_at").eq("company", company).order("snapshot_at", { ascending: false }).limit(400);
-  const snapRows = (snaps ?? []) as Array<{ ncg: number | null; snapshot_at: string }>;
-  // Último snapshot com ncg NÃO-nulo — um snapshot ruim (ncg null) não deve forçar giro=0 falso.
-  const latestNcg = snapRows.find((s) => s.ncg != null) ?? null;
-  const capital_giro = latestNcg ? Number(latestNcg.ncg) : 0;
-  const giro_indisponivel = latestNcg == null;
-  let capital_giro_anterior: number | null = null;
-  if (latestNcg) {
-    const alvo = new Date(latestNcg.snapshot_at).getTime() - 365 * 86400000;
-    let melhor: { ncg: number | null; dist: number } | null = null;
-    for (const s of snapRows) {
-      if (s.ncg == null) continue;
-      const dist = Math.abs(new Date(s.snapshot_at).getTime() - alvo);
-      if (melhor == null || dist < melhor.dist) melhor = { ncg: s.ncg, dist };
-    }
-    // só aceita se o snapshot encontrado está a ≤ 60 dias do alvo (senão não há histórico real de 12m)
-    if (melhor && melhor.dist <= 60 * 86400000) capital_giro_anterior = Number(melhor.ncg);
-  }
+  const snapRows = (snaps ?? []) as SnapNcg[];
 
   // 4) Inputs manuais (mensais → TTM via ×12)
   const numOrNull = (x: unknown): number | null => {
@@ -293,9 +318,10 @@ serve(async (req: Request) => {
   const nopatAtual = calcularNOPAT(nopatIn(ttm));
   const nopatAnterior = ttmAnterior.count >= 12 ? calcularNOPAT(nopatIn(ttmAnterior)) : null;
 
-  // 6) Capital investido (reportado) — AF cancela no incremental (mesmo AF nos dois pontos)
-  const capRep = capitalInvestido({ capital_giro, ativo_fixo, ajustes });
-  const capAnterior = capital_giro_anterior != null ? capitalInvestido({ capital_giro: capital_giro_anterior, ativo_fixo, ajustes }).capital_investido : null;
+  // 6) Capital investido (reportado) — bloco inteiro na composta pura (ausente ≠ R$0). AF cancela no incremental.
+  const cap = resolverCapitalParaValor({ snaps: snapRows, ativo_fixo, ajustes, hojeMs: Date.now() });
+  const capRep = cap.capital;
+  const capAnterior = cap.capital_anterior;
 
   // 7) WACC (base + cenários)
   const keSoma = (ke: KeDecomposto | null | undefined): number | null => {
@@ -332,12 +358,12 @@ serve(async (req: Request) => {
   const confianca = scoreConfiancaValor({
     roic_null: roicRep == null, wacc_null: waccBase.wacc == null, eva_null: evaRep == null,
     capital_parcial: capRep.parcial, normalizacao_aplicada: cg.aplicado, imposto_teorico_parcial, dre_confianca,
-    ttm_parcial: ttm.count < 12,
+    ttm_parcial: ttm.count < 12, giro_indisponivel: capRep.giro_indisponivel, giro_stale: cap.giro_stale,
   });
   // Normalização muda o EBIT mas o imposto absoluto (irpj+csll) não é recomputado → NOPAT normalizado é aproximado.
   const nopat_normalizado_aproximado = cg.aplicado && (cg.ajuste_prolabore !== 0 || cg.ajuste_aluguel !== 0);
+  // Motivo de NCG ausente/defasado vem estruturado de capRep.motivos / scoreConfiancaValor (não mais inline).
   const motivos = [...capRep.motivos, ...waccBase.motivos, ...cg.motivos];
-  if (giro_indisponivel) motivos.push("Sem snapshot de NCG disponível — capital de giro assumido 0 (ROIC pode estar superestimado).");
 
   const result = {
     company, regime,
@@ -349,6 +375,7 @@ serve(async (req: Request) => {
       margem_operacional_pre_imposto: margemOperacionalPreImposto({ ebit: nopatAtual.ebit, receita_liquida: ttm.receita_liquida }),
       receita_liquida_ttm: ttm.receita_liquida,
       capital_investido: capRep.capital_investido, capital_giro: capRep.capital_giro, ativo_fixo: capRep.ativo_fixo, ajustes: capRep.ajustes, capital_parcial: capRep.parcial,
+      giro_indisponivel: capRep.giro_indisponivel, giro_snapshot_at: cap.giro_snapshot_at, giro_dias: cap.giro_dias,
       roic: roicRep, wacc: waccBase.wacc, spread: spreadRep, eva: evaRep,
       roic_incremental: incremental.roic_incremental,
       incremental: { delta_nopat: incremental.delta_nopat, delta_capital: incremental.delta_capital, aviso: incremental.aviso },


### PR DESCRIPTION
## Resumo

Frente de consolidação financeira (alvo escolhido por consult Codex após a Consolidação do Cockpit): o engine de **Valor A2** (`/financeiro/valor`, ROIC/EVA) lê o **NCG da engine A1** (`fin_projecao_snapshots.ncg`) como capital de giro — mesma fonte do Cockpit — mas, quando **não havia snapshot de NCG**, assumia `capital_giro = 0` silenciosamente. Com ativo fixo informado, o capital investido virava só o ativo fixo (subestimado) → **ROIC superestimado**, confiança **não** rebaixada (o "parcial" só olhava ativo fixo), e o aviso ficava enterrado num motivo. Violava "ausente ≠ zero" e divergia do Cockpit (que já trata NCG ausente como parcial).

**Sem migration. Requer deploy do `fin-valor-engine` via chat do Lovable** (ROIC/EVA são calculados no edge — client-side só avisaria depois do número nascer errado).

## O que muda

- **NCG ausente → `capital_giro`/`capital_investido` = `null` (indisponível), não R$0**; `roic`/`spread`/`eva` = `null` (não fabricados); confiança = **baixa**; a UI diz "Sem snapshot de NCG — capital de giro indisponível (rode a projeção)" e não mais "* capital parcial (sem ativo fixo)".
- **0 e negativo (folga) são NCG REAIS** (`ncgFinito`, sem truthiness). Capital ≤0 por folga → `roic=null` **por capital conhecido** → confiança **media** (distinto de ausente = baixa).
- **Frescor honesto:** NCG com 45+ dias (cron é diário) → confiança **media** + "NCG de DD/MM/YYYY (Nd atrás)" visível. Stale ≠ indisponível (o NCG é real; pipeline morto já é vigiado pelo Sentinela).
- **Guard anti-coerção:** `capital_normalizado` null não vira `null + ajuste = número`. EBIT/NOPAT normalizado seguem calculados.
- **Função pura composta `resolverCapitalParaValor`** (resolver + frescor + −12m + capitalInvestido) testada ponta-a-ponta e espelhada **verbatim** no edge — não sobra `capital_giro = ncg ? ncg : 0` inline.
- **Reconciliação (critério de pronto):** com snapshot válido, `A2.reportado.capital_giro` == último `fin_projecao_snapshots.ncg` da empresa = o mesmo NCG que o Cockpit usa.
- **`ncgFinito`** (Codex P2): `ncg` como `''`/whitespace (cast runtime do PostgREST) não fabrica giro=0 — tratado como ausência. String numérica (`numeric` do Postgres) segue valor real.

## Validação

- `bun run test`: **313 arquivos / 1705 testes** (58 no `valor-helpers`) ✅
- `typecheck:strict` ✅ · `tsc -p tsconfig.app.json` limpo ✅ · `bun lint` 0 errors ✅ · `bun run build` ✅
- `deno check` no `fin-valor-engine` ✅

## Codex (todas as etapas)

Spec (3 P1: coerção null, confiança 2 níveis, staleness) + plano (3 P1: composta anti-inline, asserts exatos, distinção NCG-ausente×capital≤0) + **adversarial no código: sem P1** (P2 `ncgFinito` endurecido; P3 cosmético do `Math.round` deixado — `round` é correto pro display "Nd atrás").

## Não-objetivos

Backfill da baixa do Omie (adiado); redefinir NCG (segue ACO−PCO da engine A1 — só o tratamento de ausência muda); A4 lê só `wacc`/`spread` (já nullable) → não quebra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)