### PR TITLE
fix(sayerlack): claim atômico no envio ao portal (fecha duplo-disparo)

### DIFF
--- a/supabase/functions/enviar-pedido-portal-sayerlack/index.ts
+++ b/supabase/functions/enviar-pedido-portal-sayerlack/index.ts
@@ -2207,8 +2207,27 @@ Deno.serve(async (req) => {
     );
   }
 
-  // === MODO SÍNCRONO (legado, usado pelo cron disparar-pedidos-aprovados) ===
-  const { detalhes, sucesso, falhasDef, falhasTmp, indeterminados } = await processCandidatos(supabase, candidatos);
+  // === MODO SÍNCRONO (legado) ===
+  // Mesmo CLAIM ATÔMICO do async (ver acima). Hoje não-exercido (todos os callers
+  // reais — disparar-pedidos-aprovados e o botão — usam async_mode; o lote cron é
+  // no-op), mas fecha a rota: sem isso o processarPedido marcaria enviando_portal de
+  // forma incondicional → duplo-envio se 2 síncronos concorressem no mesmo pedido.
+  const idsSync = candidatos.map((c) => c.id);
+  const { data: claimedSync, error: claimErrSync } = await supabase
+    .from("pedido_compra_sugerido")
+    .update({ status_envio_portal: "enviando_portal", portal_erro: null })
+    .in("id", idsSync)
+    .or("status_envio_portal.is.null,status_envio_portal.neq.enviando_portal")
+    .select("id");
+  if (claimErrSync) {
+    return new Response(
+      JSON.stringify({ error: `Falha ao reservar pedidos: ${claimErrSync.message}` }),
+      { headers: { ...corsHeaders, "Content-Type": "application/json" }, status: 500 },
+    );
+  }
+  const claimedSyncIds = new Set((claimedSync ?? []).map((r) => (r as { id: number }).id));
+  const candidatosSync = candidatos.filter((c) => claimedSyncIds.has(c.id));
+  const { detalhes, sucesso, falhasDef, falhasTmp, indeterminados } = await processCandidatos(supabase, candidatosSync);
 
   // Se algum erro foi BROWSERLESS_TOKEN invalido, devolve 500
   const tokenInvalid = detalhes.find((d) => (d.erro ?? "").includes("BROWSERLESS_TOKEN invalido"));

--- a/supabase/functions/enviar-pedido-portal-sayerlack/index.ts
+++ b/supabase/functions/enviar-pedido-portal-sayerlack/index.ts
@@ -2135,16 +2135,50 @@ Deno.serve(async (req) => {
   // ao timeout do edge function caller.
   const asyncMode = body?.async_mode === true || body?.async === true;
   if (asyncMode) {
-    // Marca todos os candidatos como enviando_portal IMEDIATAMENTE para a UI já
-    // refletir o estado correto antes do background pegar.
+    // CLAIM ATÔMICO: transiciona p/ enviando_portal SÓ os candidatos que NÃO estão
+    // já em voo. Um UPDATE ... RETURNING é atômico (lock de linha + re-avaliação do
+    // WHERE após o commit concorrente): se 2 requests competem pelo MESMO pedido
+    // (ex.: "aprovar e disparar" + cron de corte no mesmo instante), só um claима;
+    // o outro vê enviando_portal e é EXCLUÍDO do RETURNING. Fecha o duplo-envio ao
+    // portal (2ª sessão no Browserless → PO duplicado no fornecedor). O `is.null`
+    // cobre o pedido fresco (status_envio_portal NULL), que o `neq` sozinho perderia.
     const ids = candidatos.map((c) => c.id);
-    await supabase
+    const { data: claimedRows, error: claimErr } = await supabase
       .from("pedido_compra_sugerido")
       .update({ status_envio_portal: "enviando_portal", portal_erro: null })
-      .in("id", ids);
+      .in("id", ids)
+      .or("status_envio_portal.is.null,status_envio_portal.neq.enviando_portal")
+      .select("id");
+    if (claimErr) {
+      console.error("[envio-portal][async] Erro no claim atomico:", claimErr.message);
+      return new Response(
+        JSON.stringify({ error: `Falha ao reservar pedidos: ${claimErr.message}` }),
+        { headers: { ...corsHeaders, "Content-Type": "application/json" }, status: 500 },
+      );
+    }
+    const claimedIds = new Set((claimedRows ?? []).map((r) => (r as { id: number }).id));
+    const candidatosClaimed = candidatos.filter((c) => claimedIds.has(c.id));
+    const jaEmVoo = candidatos.length - candidatosClaimed.length;
+    if (jaEmVoo > 0) {
+      console.log(`[envio-portal][async] ${jaEmVoo} pedido(s) ja em voo (enviando_portal) — pulados pelo claim atomico`);
+    }
+    if (candidatosClaimed.length === 0) {
+      return new Response(
+        JSON.stringify({
+          modo,
+          async: true,
+          accepted: true,
+          pedido_ids: [],
+          ja_em_voo: jaEmVoo,
+          candidatos_encontrados: candidatos.length,
+          duracao_total_ms: Date.now() - tStart,
+        }),
+        { headers: { ...corsHeaders, "Content-Type": "application/json" }, status: 202 },
+      );
+    }
 
-    // Dispara em background. Erros vão para o log e o watchdog libera depois.
-    const bgTask = processCandidatos(supabase, candidatos)
+    // Dispara em background SÓ os reservados. Erros vão para o log e o watchdog libera depois.
+    const bgTask = processCandidatos(supabase, candidatosClaimed)
       .then((r) => {
         console.log(`[envio-portal][async] OK processados=${r.detalhes.length} sucesso=${r.sucesso} falhas=${r.falhasDef + r.falhasTmp} indeterminados=${r.indeterminados}`);
       })
@@ -2164,7 +2198,8 @@ Deno.serve(async (req) => {
         modo,
         async: true,
         accepted: true,
-        pedido_ids: ids,
+        pedido_ids: candidatosClaimed.map((c) => c.id),
+        ja_em_voo: jaEmVoo,
         candidatos_encontrados: candidatos.length,
         duracao_total_ms: Date.now() - tStart,
       }),


### PR DESCRIPTION
Fast-follow do #468 — fecha a ressalva de concorrência que o codex sinalizou.

## Problema
O pre-mark async marcava `status_envio_portal='enviando_portal'` **incondicionalmente** (o log dizia "(locked)" mas não era lock). Dois disparos do mesmo pedido na janela de ~45s — ex.: **"aprovar e disparar"** (#468) + cron de corte no mesmo instante — abriam **2 sessões no Browserless → PO duplicado** no fornecedor. Só o modo LOTE tinha lock real (`envio_portal_lock_candidatos`).

## Fix (edge-only, sem migration)
`UPDATE ... RETURNING` **condicional** = claim atômico (lock de linha + re-avaliação do WHERE após commit concorrente). Processa só os pedidos que **este** request transicionou p/ `enviando_portal`; quem já está em voo é excluído do RETURNING (`ja_em_voo`) e pulado. Predicado NULL-safe (`status_envio_portal IS NULL OR <> 'enviando_portal'`) p/ cobrir o pedido fresco. Aplicado nos **dois** caminhos (async + síncrono legado).

## Revisão codex (consult)
- ✅ Claim atômico correto sob READ COMMITTED; ✅ PostgREST `.or(is.null, neq)` NULL-safe; ✅ não interfere no lote; ✅ serializa frontend × motor `*/15`.
- **Medium** (modo síncrono sem claim) → **corrigido** neste PR (2º commit).
- **Low** (claim aceita estados não-`enviando` p/ force-reenvio) = eligibilidade pré-existente, intencional (forçar reenvio), não introduzido aqui.

## Validação
`deno lint` faz parse limpo (só 2 `@ts-ignore` pré-existentes do `EdgeRuntime`). `deno check` local não roda (deps `npm:` sem `deno install` — setup, não código).

⚠️ **Requer redeploy do `enviar-pedido-portal-sayerlack` via Lovable APÓS o merge** (verbatim do repo). Até lá prod fica com o pre-mark antigo — mas os guards de UI do #468 + o motor já cobrem os caminhos realistas; este PR fecha o resíduo (cron no exato instante).

🤖 Generated with [Claude Code](https://claude.com/claude-code)