### PR TITLE
feat(fin): dias_cobertura do caixa operacional projetado (follow-up B2)

### DIFF
--- a/src/hooks/useCashflowProjection.ts
+++ b/src/hooks/useCashflowProjection.ts
@@ -33,7 +33,8 @@ export type CashflowResult = {
   semanas: Semana[];
   ncg: NCGData;
   indicadores: {
-    dias_cobertura: number;
+    // null quando não há base de saída projetada (Fase 3 B2) → consumidor trata "—".
+    dias_cobertura: number | null;
     liquidez_operacional_liquida: number;
     saldo_tesouraria: number;
     inadimplencia_pct: number;

--- a/src/lib/financeiro/__tests__/aging-helpers.test.ts
+++ b/src/lib/financeiro/__tests__/aging-helpers.test.ts
@@ -5,7 +5,7 @@ import {
   calibrarCurvas, CURVA_DEFAULT,
   dataRecebimentoEsperada, aplicarCenarioCurva,
   inadimplenciaPonderada, prazoMedioPonderado,
-  statusLiquidado, valorPagoEfetivo, prazoComGate,
+  statusLiquidado, valorPagoEfetivo, prazoComGate, diasCoberturaProjetado,
 } from '../aging-helpers';
 
 describe('faixaAging', () => {
@@ -92,6 +92,26 @@ describe('prazoComGate (PMR/PMP por cobertura)', () => {
   it('cobertura null/undefined → null', () => {
     expect(prazoComGate(30, null)).toBe(null);
     expect(prazoComGate(30, undefined)).toBe(null);
+  });
+});
+
+describe('diasCoberturaProjetado (caixa operacional projetado)', () => {
+  it('saldo / saída diária média do horizonte', () => {
+    // 91000 de saída em 13 sem (91 dias) → 1000/dia; saldo 30000 → 30 dias
+    expect(diasCoberturaProjetado(30000, 91000, 13)).toBeCloseTo(30, 5);
+  });
+  it('saldo <= 0 → 0 (crítico)', () => {
+    expect(diasCoberturaProjetado(0, 91000, 13)).toBe(0);
+    expect(diasCoberturaProjetado(-500, 91000, 13)).toBe(0);
+  });
+  it('sem base de saída → null (não 999/infinito)', () => {
+    expect(diasCoberturaProjetado(30000, 0, 13)).toBe(null);
+  });
+  it('horizon 0 não divide por zero (clamp do divisor em 1)', () => {
+    // saidaDiaria = 7000 / max(1, 0) = 7000; dias = 7000/7000 = 1 (finito, sem NaN/Infinity)
+    const r = diasCoberturaProjetado(7000, 7000, 0);
+    expect(r).toBe(1);
+    expect(Number.isFinite(r as number)).toBe(true);
   });
 });
 

--- a/src/lib/financeiro/aging-helpers.ts
+++ b/src/lib/financeiro/aging-helpers.ts
@@ -62,6 +62,20 @@ export function prazoComGate(
   return (cobertura ?? 0) >= min && valor != null ? Number(valor) : null;
 }
 
+// dias_cobertura do CAIXA OPERACIONAL PROJETADO (Fase 3 B2): saldo / saída diária média
+// do horizonte (Σ saídas projetadas / horizon*7). saldo<=0 → 0 (crítico); sem base de
+// saída → null ("sem base", NÃO 999/cobertura infinita — que desligava o alerta).
+// Espelhado no fin-cashflow-engine.
+export function diasCoberturaProjetado(
+  saldoCc: number,
+  saidasHorizonte: number,
+  horizonWeeks: number,
+): number | null {
+  if (saldoCc <= 0) return 0;
+  const saidaDiaria = saidasHorizonte / Math.max(1, horizonWeeks * 7);
+  return saidaDiaria > 0.01 ? saldoCc / saidaDiaria : null;
+}
+
 export const FAIXAS: Faixa[] = ['a_vencer', '1-30', '31-60', '61-90', '+90'];
 
 export const LAG_MAX: Record<Faixa, number> = {

--- a/supabase/functions/fin-cashflow-engine/index.ts
+++ b/supabase/functions/fin-cashflow-engine/index.ts
@@ -285,6 +285,16 @@ function prazoComGate(
 ): number | null {
   return (cobertura ?? 0) >= min && valor != null ? Number(valor) : null;
 }
+// Espelho de aging-helpers.ts (Fase 3 B2): dias_cobertura do caixa operacional projetado.
+function diasCoberturaProjetado(
+  saldoCc: number,
+  saidasHorizonte: number,
+  horizonWeeks: number,
+): number | null {
+  if (saldoCc <= 0) return 0;
+  const saidaDiaria = saidasHorizonte / Math.max(1, horizonWeeks * 7);
+  return saidaDiaria > 0.01 ? saldoCc / saidaDiaria : null;
+}
 
 const FAIXAS: Faixa[] = ['a_vencer', '1-30', '31-60', '61-90', '+90'];
 
@@ -1004,7 +1014,8 @@ function calcularNCG(dados: DadosBase): NCG {
 }
 
 type Indicadores = {
-  dias_cobertura: number;
+  // null quando não há base de saída projetada (Fase 3 B2) → alerta de cobertura pula.
+  dias_cobertura: number | null;
   liquidez_operacional_liquida: number;
   saldo_tesouraria: number;
   inadimplencia_pct: number;
@@ -1020,14 +1031,19 @@ type Indicadores = {
 function calcularIndicadores(
   dados: DadosBase,
   ncg: NCG,
+  saidasHorizonte: number,
+  horizonWeeks: number,
+  company?: string,
 ): Indicadores {
   const hoje = new Date().toISOString().slice(0, 10);
-  const cutoff90 = new Date(Date.now() - 90 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
-  const saidasUltimos90 = dados.cps
-    .filter(c => c.data_pagamento && c.data_pagamento >= cutoff90)
-    .reduce((s, c) => s + c.valor_pago, 0);
-  const saidaDiariaMedia = saidasUltimos90 / 90;
-  const dias_cobertura = saidaDiariaMedia > 0 ? dados.saldo_cc / saidaDiariaMedia : 999;
+  // Fase 3 (B2): dias_cobertura do CAIXA OPERACIONAL PROJETADO, não da coluna base
+  // data_pagamento (sempre NULL → dava 999 "infinito" e desligava o alerta). Saída
+  // diária = Σ total_saidas do horizonte / (horizon*7) = CP por vencimento + folha/
+  // impostos (eventos) — operacional por construção, SEM transferência entre contas
+  // próprias (que não entram em CP/eventos). saldo<=0 → 0 (crítico); saída ~0 → null
+  // ("sem base de saída", não cobertura infinita); o alerta pula quando null. (codex)
+  const dias_cobertura = diasCoberturaProjetado(dados.saldo_cc, saidasHorizonte, horizonWeeks);
+  console.log(`[Cashflow][${company ?? '?'}] dias_cobertura=${dias_cobertura ?? 'null'} saidas_horizonte=${saidasHorizonte.toFixed(2)}`);
 
   const liquidez_operacional_liquida = dados.saldo_cc + ncg.aco.cr_aberto + ncg.aco.estoque - ncg.pco.total;
   const saldo_tesouraria = dados.saldo_cc - ncg.pco.folha_30d;
@@ -1126,7 +1142,8 @@ function avaliarAlertas(
     });
   }
 
-  if (indicadores.dias_cobertura < t.dias_cobertura_min) {
+  // dias_cobertura null = sem base de saída projetada → não dá pra avaliar (pula, não floda).
+  if (indicadores.dias_cobertura !== null && indicadores.dias_cobertura < t.dias_cobertura_min) {
     alertas.push({
       tipo: 'cobertura_baixa',
       severidade: 'aviso',
@@ -1194,7 +1211,9 @@ async function calcular(
   const premissas = aplicarCenario(taxas, cenario, dados.config, dados.curvas_aging);
   const { semanas, apos_horizonte, ar_impaired } = gerarSemanas(dados, premissas, horizon);
   const ncg = calcularNCG(dados);
-  const indicadores = calcularIndicadores(dados, ncg);
+  // Fase 3 (B2): saída operacional projetada do horizonte → dias_cobertura.
+  const saidasHorizonte = semanas.reduce((s, w) => s + w.total_saidas, 0);
+  const indicadores = calcularIndicadores(dados, ncg, saidasHorizonte, horizon, company);
   const alertas = avaliarAlertas(semanas, ncg, indicadores, dados.config);
 
   // Auditoria: premissas aplicadas (curvas c/ cenário) + curvas calibradas puras + ponte.


### PR DESCRIPTION
## Summary

Religa o **alerta de liquidez** "Caixa cobre só X dias", que estava **morto**: `dias_cobertura` lia `cps.data_pagamento` (sempre NULL no LIST do Omie) → saídas=0 → `dias_cobertura=999` ("cobertura infinita", otimista errado) → o alerta `if dias_cobertura < min` nunca disparava.

**Decisão de fonte (validada com codex): forward projetado.**
- `dias_cobertura = saldo_cc / (Σ total_saidas do horizonte / (horizon*7))`. A saída projetada = CP por vencimento + folha/impostos (eventos recorrentes/eventuais) → **operacional por construção**, **sem transferência entre contas próprias** (não entram em CP/eventos), **sem** dependência de classificar `natureza`, **sem** janela efetiva (janela fixa = horizonte).
- `saldo_cc <= 0` → **0** (crítico); sem base de saída → **null** ("sem base", não 999); o alerta **pula** quando null (não floda).
- Contrato `Indicadores.dias_cobertura` → `number | null`. A coluna `fin_projecao_snapshots.dias_cobertura` já é nullable (`numeric(10,2)`, sem NOT NULL); `dias_cobertura` **não** é renderizado em componente (só alerta + snapshot) → front só ajusta o tipo em `useCashflowProjection`.
- Helper puro **`diasCoberturaProjetado`** (`aging-helpers.ts`) + 4 testes; **espelho verbatim** no engine.

Fecha a **Fase 3 do engine de caixa**: aging `taxa_recebimento` (#458) + indicadores PMR/PMP/CCC (#463) + `dias_cobertura` (este).

## ⚠️ Redeploy manual necessário (sem migration)

Muda o **engine Deno `fin-cashflow-engine`** → redeploy manual via chat do Lovable (ler `supabase/functions/fin-cashflow-engine/index.ts` da main, deploy **verbatim**). O helper é frontend (deploy normal).

## Test plan

- [x] `bun run test` — 1711/1711 (incl. +4 `diasCoberturaProjetado`)
- [x] `bunx tsc -p tsconfig.app.json` + `tsconfig.strict.json` — 0 erros
- [x] `deno check` no engine — só falso-positivos `@ts-expect-error` + 1 TS2345 pré-existente (zero erro novo)
- [ ] Pós-redeploy: invocar o engine → `dias_cobertura` real (≠ 999); empresa com pouco caixa dispara o alerta "cobre só X dias"

🤖 Generated with [Claude Code](https://claude.com/claude-code)