### PR TITLE
chore(sayerlack): remove cron lote-retry morto (no-op)

### DIFF
--- a/supabase/migrations/20260530170000_unschedule_sayerlack_lote_retry.sql
+++ b/supabase/migrations/20260530170000_unschedule_sayerlack_lote_retry.sql
@@ -1,0 +1,14 @@
+-- Remove o cron sayerlack-portal-lote-retry (criado em 20260528030000, PR #453): descobriu-se
+-- depois que é NO-OP no fluxo portal-FIRST. O modo LOTE da edge enviar-pedido-portal-sayerlack
+-- busca status='disparado' AND status_envio_portal IN (pendente_envio_portal, erro_retentavel) —
+-- mas como o portal precisa SUCEDER (obter protocolo) ANTES de o pedido virar 'disparado', uma
+-- falha de portal deixa o pedido em status='aprovado_aguardando_disparo' (≠ 'disparado'), então o
+-- lote NUNCA acha candidato. A remediação real é o MOTOR sayerlack_retry_orfaos (cron
+-- sayerlack-retry-orfaos */15, migration 20260528040000), que re-dispara via
+-- disparar-pedidos-aprovados {pedido_id} só os órfãos retentáveis frescos.
+--
+-- Este cron morto rodava a cada 15min achando 0 candidatos — inofensivo (retorna rápido, e o claim
+-- atômico protegeria mesmo se achasse algo), mas é cruft confuso (dois */15 de retry Sayerlack, um
+-- dead). Removido pra deixar o estado limpo. cron.unschedule por jobid via FROM cron.job é
+-- idempotente (0 linhas se já não existir, sem erro).
+SELECT cron.unschedule(jobid) FROM cron.job WHERE jobname = 'sayerlack-portal-lote-retry';


### PR DESCRIPTION
Remove o cron `sayerlack-portal-lote-retry */15` (#453), que se revelou **NO-OP** no fluxo portal-FIRST: o modo LOTE busca `status='disparado'` + portal pendente, mas o portal sucede ANTES de virar disparado → 0 candidatos sempre. A remediação real é o motor `sayerlack_retry_orfaos` (#468). Inofensivo, mas cruft confuso (dois `*/15` de retry Sayerlack).

⚠️ **MIGRATION MANUAL** — rodar no SQL Editor:
```sql
SELECT cron.unschedule(jobid) FROM cron.job WHERE jobname = 'sayerlack-portal-lote-retry';
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)