### PR TITLE
feat(fin): DRE-caixa aloca pelo mês da baixa derivada (fecha a cascata)

### DIFF
--- a/src/lib/financeiro/__tests__/dre-helpers.test.ts
+++ b/src/lib/financeiro/__tests__/dre-helpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { classificarLinhaDRE, REGIME_POR_EMPRESA, resolverDataCaixa, bucketizarCaixa, montarDRE, scoreConfianca, calcularRBT12, faixaPorRBT12, aliquotaEfetivaSimples, anexoPorFatorR, impostoTeoricoSimples, impostoTeoricoPresumido, normalizarConfigTributario } from '../dre-helpers';
+import { classificarLinhaDRE, REGIME_POR_EMPRESA, resolverDataCaixa, valorCaixaEfetivo, dedupePorCodigo, bucketizarCaixa, montarDRE, scoreConfianca, calcularRBT12, faixaPorRBT12, aliquotaEfetivaSimples, anexoPorFatorR, impostoTeoricoSimples, impostoTeoricoPresumido, normalizarConfigTributario } from '../dre-helpers';
 
 const M = (pairs: Array<[string, string]>) => new Map<string, string>(pairs);
 
@@ -87,6 +87,41 @@ describe('resolverDataCaixa', () => {
   it('sem nenhuma data → null', () => {
     expect(resolverDataCaixa({ data_real: null, data_vencimento: null }))
       .toEqual({ data_efetiva: null, usou_fallback: false });
+  });
+});
+
+describe('valorCaixaEfetivo (robusto a valor_recebido=0/null)', () => {
+  it('usa o valor real quando > 0', () => {
+    expect(valorCaixaEfetivo(800, 1000)).toBe(800);
+  });
+  it('valor_recebido = 0 (liquidado, #396) → valor_documento (NÃO zero)', () => {
+    expect(valorCaixaEfetivo(0, 1000)).toBe(1000);
+  });
+  it('valor_recebido null → valor_documento', () => {
+    expect(valorCaixaEfetivo(null, 1000)).toBe(1000);
+  });
+  it('ambos ausentes → 0', () => {
+    expect(valorCaixaEfetivo(0, null)).toBe(0);
+  });
+});
+
+describe('dedupePorCodigo (anti double-count do load DRE-caixa)', () => {
+  it('dedupe por omie_codigo_lancamento, mantém a 1ª ocorrência', () => {
+    const r = dedupePorCodigo([
+      { omie_codigo_lancamento: 1, v: 'a' },
+      { omie_codigo_lancamento: 1, v: 'b' }, // duplicata (venc-no-mês ∩ baixa-no-mês)
+      { omie_codigo_lancamento: 2, v: 'c' },
+    ]);
+    expect(r).toHaveLength(2);
+    expect(r.find((x) => x.omie_codigo_lancamento === 1)?.v).toBe('a');
+  });
+  it('linhas SEM código (null) são todas preservadas', () => {
+    const r = dedupePorCodigo([
+      { omie_codigo_lancamento: null, v: 'x' },
+      { omie_codigo_lancamento: null, v: 'y' },
+      { omie_codigo_lancamento: 5, v: 'z' },
+    ]);
+    expect(r).toHaveLength(3);
   });
 });
 

--- a/src/lib/financeiro/dre-helpers.ts
+++ b/src/lib/financeiro/dre-helpers.ts
@@ -120,6 +120,30 @@ export function resolverDataCaixa(input: {
   return { data_efetiva: null, usou_fallback: false };
 }
 
+// Valor de caixa efetivo, robusto a valor_recebido/valor_pago = 0 OU null (#396: liquidado
+// tem valor_recebido=0). `0 ?? doc` mantinha 0 → liquidado com baixa real alocaria ZERO no
+// DRE-caixa. Usa o valor real se > 0, senão o valor de documento (face). Espelhado no engine.
+export function valorCaixaEfetivo(valorReal: number | null | undefined, valorDocumento: number | null | undefined): number {
+  const real = Number(valorReal ?? 0);
+  if (real > 0) return real;
+  return Number(valorDocumento ?? 0);
+}
+
+// Merge do load do DRE-caixa: títulos por (vencimento-no-mês) ∪ (baixa-no-mês). Dedupe por
+// omie_codigo_lancamento (um título pode aparecer nas duas queries) → evita DOUBLE-COUNT.
+// Linha SEM código (null) nunca vem da query-por-código → preservada (só cai no fallback
+// por vencimento). Mantém a 1ª ocorrência de cada código. Espelhado no engine.
+export function dedupePorCodigo<T extends { omie_codigo_lancamento?: number | null }>(rows: T[]): T[] {
+  const byCode = new Map<number, T>();
+  const semCodigo: T[] = [];
+  for (const r of rows) {
+    const c = r.omie_codigo_lancamento;
+    if (c == null) semCodigo.push(r);
+    else if (!byCode.has(Number(c))) byCode.set(Number(c), r);
+  }
+  return [...byCode.values(), ...semCodigo];
+}
+
 export type TituloCaixa = { valor: number; data_real: string | null; data_vencimento: string | null };
 
 // Bucketiza por data EFETIVA dentro de [inicio, fim) (fim exclusivo, ISO yyyy-mm-dd).

--- a/supabase/functions/omie-financeiro/index.ts
+++ b/supabase/functions/omie-financeiro/index.ts
@@ -1212,6 +1212,63 @@ function resolverDataCaixa(input: {
   return { data_efetiva: null, usou_fallback: false };
 }
 
+// Espelho VERBATIM de dre-helpers.ts (Fase 3 baixa derivada no DRE-caixa).
+function valorCaixaEfetivo(valorReal: number | null | undefined, valorDocumento: number | null | undefined): number {
+  const real = Number(valorReal ?? 0);
+  if (real > 0) return real;
+  return Number(valorDocumento ?? 0);
+}
+function dedupePorCodigo<T extends { omie_codigo_lancamento?: number | null }>(rows: T[]): T[] {
+  const byCode = new Map<number, T>();
+  const semCodigo: T[] = [];
+  for (const r of rows) {
+    const c = r.omie_codigo_lancamento;
+    if (c == null) semCodigo.push(r);
+    else if (!byCode.has(Number(c))) byCode.set(Number(c), r);
+  }
+  return [...byCode.values(), ...semCodigo];
+}
+
+// Fase 3: baixa REAL derivada (v_titulo_baixas) por título, paginada. THROW em erro —
+// baixaMap parcial reintroduziria double-count/perda no DRE-caixa (codex). NUNCA degradar
+// silenciosamente pra vencimento aqui.
+async function carregarBaixaMapDRE(db: SupabaseClient, company: string, tipo: "CR" | "CP"): Promise<Map<number, string>> {
+  const map = new Map<number, string>();
+  const PAGE = 1000;
+  let from = 0;
+  for (;;) {
+    const { data, error } = await db.from("v_titulo_baixas")
+      .select("omie_codigo_lancamento, data_baixa_final")
+      .eq("company", company).eq("tipo", tipo)
+      .order("omie_codigo_lancamento", { ascending: true })
+      .range(from, from + PAGE - 1);
+    if (error) throw error;
+    const rows = (data ?? []) as Array<{ omie_codigo_lancamento: number | null; data_baixa_final: string | null }>;
+    for (const r of rows) {
+      if (r.omie_codigo_lancamento != null && r.data_baixa_final) map.set(Number(r.omie_codigo_lancamento), r.data_baixa_final);
+    }
+    if (rows.length < PAGE) break;
+    from += PAGE;
+  }
+  return map;
+}
+
+// Carrega títulos por lista de códigos, em chunks (PostgREST .in() estoura se a lista for grande).
+async function fetchTitulosPorCodigos(
+  db: SupabaseClient, table: string, select: string, company: string, statuses: string[], codes: number[],
+): Promise<Array<Record<string, unknown>>> {
+  const out: Array<Record<string, unknown>> = [];
+  const CHUNK = 200;
+  for (let i = 0; i < codes.length; i += CHUNK) {
+    const chunk = codes.slice(i, i + CHUNK);
+    const { data, error } = await db.from(table)
+      .select(select).eq("company", company).in("status_titulo", statuses).in("omie_codigo_lancamento", chunk);
+    if (error) throw error;
+    out.push(...((data ?? []) as unknown as Array<Record<string, unknown>>));
+  }
+  return out;
+}
+
 type DRECalculada = {
   receita_bruta: number; deducoes: number; receita_liquida: number;
   cmv: number; lucro_bruto: number;
@@ -1449,10 +1506,24 @@ async function calcularDRE(
       : `${ano}-${String(mes + 1).padStart(2, "0")}-01`;
   const regimeTrib: RegimeTributario = REGIME_POR_EMPRESA[company] ?? "presumido";
 
+  // ── Fase 3: baixa REAL derivada (só no regime caixa) ──
+  // No caixa, a data de baixa derivada (v_titulo_baixas) é a data EFETIVA do título;
+  // fallback p/ vencimento ("estimado") onde não houver. baixaMap throw em erro (parcial
+  // reintroduz double-count). Competência não usa (bucketiza por emissão).
+  const baixaMapCR = regime === "caixa" ? await carregarBaixaMapDRE(db, company, "CR") : new Map<number, string>();
+  const baixaMapCP = regime === "caixa" ? await carregarBaixaMapDRE(db, company, "CP") : new Map<number, string>();
+  const codigosNoMes = (map: Map<number, string>) =>
+    [...map.entries()].filter(([, d]) => d >= inicioMes && d < fimMes).map(([c]) => c);
+
   // ── Buscar títulos ──
-  // Competência: bucketiza por data_emissao (server-side). Caixa: precisa da data EFETIVA
-  // (recebimento/pagamento) com fallback p/ vencimento → busca um superset (data real OU
-  // vencimento na janela) e bucketiza client-side via resolverDataCaixa.
+  // Competência: bucketiza por data_emissao (server-side). Caixa: a data efetiva é a BAIXA
+  // derivada (ou vencimento, fallback). Carrega (venc-no-mês) ∪ (baixa-no-mês), dedupe por
+  // código → cada título cai no mês da baixa quando há baixa, senão no mês do vencimento.
+  // Sem o ramo baixa-no-mês, título pago atrasado (venc anterior, baixa neste mês) sumiria.
+  const SEL_CR = "valor_documento, valor_recebido, data_recebimento, data_vencimento, categoria_codigo, categoria_descricao, omie_codigo_lancamento";
+  const SEL_CP = "valor_documento, valor_pago, data_pagamento, data_vencimento, categoria_codigo, categoria_descricao, omie_codigo_lancamento";
+  const ST_CR = ["RECEBIDO", "PARCIAL", "LIQUIDADO"];
+  const ST_CP = ["PAGO", "PARCIAL", "LIQUIDADO"];
   async function buscarCR() {
     if (regime === "competencia") {
       const { data, error } = await db.from("fin_contas_receber")
@@ -1462,12 +1533,12 @@ async function calcularDRE(
       if (error) throw error; // não silenciar falha de DB como DRE vazia
       return data ?? [];
     }
-    const { data, error } = await db.from("fin_contas_receber")
-      .select("valor_documento, valor_recebido, data_recebimento, data_vencimento, categoria_codigo, categoria_descricao")
-      .eq("company", company).in("status_titulo", ["RECEBIDO", "PARCIAL", "LIQUIDADO"])
+    const { data, error } = await db.from("fin_contas_receber").select(SEL_CR)
+      .eq("company", company).in("status_titulo", ST_CR)
       .or(`and(data_recebimento.gte.${inicioMes},data_recebimento.lt.${fimMes}),and(data_recebimento.is.null,data_vencimento.gte.${inicioMes},data_vencimento.lt.${fimMes})`);
     if (error) throw error; // não silenciar falha de DB como DRE vazia
-    return data ?? [];
+    const porBaixa = await fetchTitulosPorCodigos(db, "fin_contas_receber", SEL_CR, company, ST_CR, codigosNoMes(baixaMapCR));
+    return dedupePorCodigo([...(data ?? []) as Array<Record<string, unknown>>, ...porBaixa]);
   }
   async function buscarCP() {
     if (regime === "competencia") {
@@ -1478,12 +1549,12 @@ async function calcularDRE(
       if (error) throw error; // não silenciar falha de DB como DRE vazia
       return data ?? [];
     }
-    const { data, error } = await db.from("fin_contas_pagar")
-      .select("valor_documento, valor_pago, data_pagamento, data_vencimento, categoria_codigo, categoria_descricao")
-      .eq("company", company).in("status_titulo", ["PAGO", "PARCIAL", "LIQUIDADO"])
+    const { data, error } = await db.from("fin_contas_pagar").select(SEL_CP)
+      .eq("company", company).in("status_titulo", ST_CP)
       .or(`and(data_pagamento.gte.${inicioMes},data_pagamento.lt.${fimMes}),and(data_pagamento.is.null,data_vencimento.gte.${inicioMes},data_vencimento.lt.${fimMes})`);
     if (error) throw error; // não silenciar falha de DB como DRE vazia
-    return data ?? [];
+    const porBaixa = await fetchTitulosPorCodigos(db, "fin_contas_pagar", SEL_CP, company, ST_CP, codigosNoMes(baixaMapCP));
+    return dedupePorCodigo([...(data ?? []) as Array<Record<string, unknown>>, ...porBaixa]);
   }
   const receitas = await buscarCR();
   const despesas = await buscarCP();
@@ -1523,12 +1594,19 @@ async function calcularDRE(
       if (regime === "competencia") {
         val = Number(row.valor_documento ?? 0);
       } else {
-        const dataReal = isReceita ? (row.data_recebimento as string | null) : (row.data_pagamento as string | null);
+        // data EFETIVA = baixa DERIVADA (v_titulo_baixas) onde houver; senão vencimento (fallback "estimado").
+        // A coluna base data_recebimento/data_pagamento é sempre NULL no LIST do Omie → não serve.
+        const codLanc = row.omie_codigo_lancamento as number | null;
+        const baixaMap = isReceita ? baixaMapCR : baixaMapCP;
+        const dataReal = codLanc != null ? (baixaMap.get(Number(codLanc)) ?? null) : null;
         const venc = row.data_vencimento as string | null;
         const { data_efetiva, usou_fallback } = resolverDataCaixa({ data_real: dataReal, data_vencimento: venc });
         if (!data_efetiva || data_efetiva < inicioMes || data_efetiva >= fimMes) continue;
         usouFallback = usou_fallback;
-        val = isReceita ? Number(row.valor_recebido ?? row.valor_documento ?? 0) : Number(row.valor_pago ?? row.valor_documento ?? 0);
+        // valorCaixaEfetivo: liquidado tem valor_recebido=0 (#396) → cai no valor_documento (face),
+        // senão alocaria ZERO. Parcial real (valor_recebido>0) usa o valor recebido.
+        val = isReceita ? valorCaixaEfetivo(row.valor_recebido as number | null, row.valor_documento as number | null)
+                        : valorCaixaEfetivo(row.valor_pago as number | null, row.valor_documento as number | null);
         caixaValor += val;
         if (usouFallback) fallbackValor += val;
       }


### PR DESCRIPTION
## Summary

Último consumidor da cascata da data de baixa. `calcularDRE(regime='caixa')` alocava **tudo pelo VENCIMENTO** ("estimado", `fallback_pct`≈100%) porque `data_recebimento`/`data_pagamento` são sempre NULL no LIST do Omie. Agora aloca pela **baixa derivada real** (`v_titulo_baixas`), com vencimento só como fallback honesto.

Fix (3 passes codex — o risco aqui é **double-count no DRE**):

- **Load (caixa):** carrega títulos por **(vencimento-no-mês) ∪ (baixa-derivada-no-mês)** e **dedupe por `omie_codigo_lancamento`** → cada título cai no mês da baixa quando há baixa, senão no mês do vencimento. Sem o ramo baixa-no-mês, título **pago atrasado** (venc mês anterior, baixa neste mês) sumiria; o dedupe evita **double-count** (venc∩baixa no mesmo mês).
- **`baixaMap` paginado** (anti-cap-1000); **THROW em erro de carga** (parcial reintroduz double-count → **nunca degrada silencioso** pra vencimento). `.in()` por códigos em **chunks**.
- **`valorCaixaEfetivo`:** liquidado tem `valor_recebido=0` (#396) → `0 ?? doc` mantinha 0 → alocaria **ZERO**; agora usa `valor_documento` (face) quando o valor real é 0/null. Parcial real (`valor_recebido>0`) usa o valor.
- **Competência INTACTO** (bucketiza por emissão). `resolverDataCaixa` inalterado (recebe a baixa como `data_real`). `fallback_pct` cai (mais real) → confiança sobe; **colacor ~10% cobertura segue honesto** (maioria fallback, confiança baixa).
- Helpers puros `valorCaixaEfetivo` + `dedupePorCodigo` (+6 testes); **espelho verbatim** no engine.

**Fecha a cascata da data de baixa (5/5 consumidores):** PMR/PMP/ciclo · getFluxoCaixa · aging/projeção 13s · dias_cobertura · valor-cockpit · **DRE-caixa**.

**Limitação v1 (codex):** pagamento PARCIAL em meses diferentes → `data_baixa_final=MAX` joga tudo no mês da última parcela (raro; v2 = por movimento). Custo: `baixaMap` carregado por chamada mensal (aceitável; otimização = cache por batch anual, v2).

## ⚠️ Redeploy manual necessário (sem migration)

Muda o **engine Deno `omie-financeiro`** → redeploy manual via chat do Lovable (ler `supabase/functions/omie-financeiro/index.ts` da main, deploy **verbatim**). As views já estão aplicadas. O helper `dre-helpers.ts` é frontend (deploy normal).

## Test plan

- [x] `bun run test` — 1753/1753 (dre-helpers +6: valorCaixaEfetivo, dedupePorCodigo)
- [x] `bunx tsc -p tsconfig.app.json` + `tsconfig.strict.json` — 0 erros
- [x] `deno check` — 10 erros pré-existentes (= baseline da main), **zero novo**
- [ ] Pós-redeploy: DRE-caixa (oben, mês recente) → `fallback_pct` cai muito (vira real); totais batem ~com competência defasado pelo prazo; colacor segue alto fallback (honesto)

🤖 Generated with [Claude Code](https://claude.com/claude-code)