### PR TITLE
docs(claude): preferência de gestão de contexto (sugerir /compact proativamente)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,8 @@
 
 > **🗣️ Idioma das sessões (preferência do Lucas, 2026-05-20):** responda SEMPRE em **português brasileiro** — nesta sessão e em **qualquer sessão nova ou subagente/sessão spawnada a partir de outra que tenhamos**. Toda comunicação com o usuário (texto, resumos, perguntas, descrição de PR) em pt-BR. Código, rotas, commits e PRs já são pt-BR (ver §5).
 
+> **🪟 Gestão de contexto (preferência do Lucas, 2026-05-30):** em sessões longas, **sugira `/compact` proativamente** quando perceber sinais de contexto cheio (é lembrete, não automação — não tenho leitura contínua da % da janela). ⚠️ **Auto-compactar em 60% NÃO é viável e não deve ser re-tentado:** não existe setting de threshold (o auto-compact nativo só dispara perto do *limite*), nenhum hook dispara por % de contexto, e hook não invoca slash command (`/compact` não é programaticamente acionável — nem por hook, nem por mim). Quem quer "compactar cedo" usa: `/compact <foco>` manual + `/context` pra medir + subagentes (janela própria, não incham a sessão principal).
+
 ---
 
 ## 1. Produto


### PR DESCRIPTION
## O quê

Registra no topo do `CLAUDE.md`, junto da nota de idioma, uma preferência do Lucas sobre **gestão de contexto**:

- Em sessões longas, Claude deve **sugerir `/compact` proativamente** quando perceber sinais de contexto cheio (lembrete, não automação).
- Documenta a **limitação técnica** de que auto-compactar em 60% **não é viável** e **não deve ser re-tentado**: não existe setting de threshold (o auto-compact nativo só dispara perto do *limite*), nenhum hook dispara por % de contexto, e hook não invoca slash command.

## Por quê

O Lucas pediu uma "regra" pra auto-`/compact` em 60%. Confirmado na doc oficial do Claude Code que isso não é suportado nativamente nem via hook. Registrar a preferência + a limitação evita que sessões futuras percam tempo tentando implementar o gatilho via hook/setting.

## Escopo

Mudança de documentação apenas (2 linhas no `CLAUDE.md`). Sem migration, sem código, sem deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)