### PR TITLE
fix(reposição): conserta trigger atualizado_em da sku_fornecedor_externo (UPDATE quebrado)

### DIFF
--- a/supabase/migrations/20260530180000_fix_sku_fornecedor_externo_atualizado_em_trigger.sql
+++ b/supabase/migrations/20260530180000_fix_sku_fornecedor_externo_atualizado_em_trigger.sql
@@ -1,0 +1,27 @@
+-- Conserta o trigger de timestamp da sku_fornecedor_externo. O trigger
+-- `sku_fornecedor_externo_set_atualizado_em` (BEFORE UPDATE) estava ligado à função
+-- GENÉRICA `update_updated_at_column()`, que faz `NEW.updated_at = now()` — mas a tabela
+-- usa a coluna `atualizado_em` (pt-BR), NÃO `updated_at`. Resultado: TODA UPDATE na tabela
+-- falhava com `record "new" has no field "updated_at"` — inclusive o "editar mapeamento"
+-- do app (que nunca funcionou; o founder só adicionava). O nome do trigger já dizia a
+-- intenção certa ("set_atualizado_em"), só estava na função errada.
+--
+-- Fix: função dedicada que seta `atualizado_em` + repoint do trigger. Escopo confirmado =
+-- só esta tabela tem o mismatch (não é sistêmico). A `update_updated_at_column` genérica
+-- segue intacta pras tabelas que de fato têm `updated_at`.
+
+CREATE OR REPLACE FUNCTION public.set_atualizado_em_column()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path TO 'public'
+AS $$
+BEGIN
+  NEW.atualizado_em = now();
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS sku_fornecedor_externo_set_atualizado_em ON public.sku_fornecedor_externo;
+CREATE TRIGGER sku_fornecedor_externo_set_atualizado_em
+  BEFORE UPDATE ON public.sku_fornecedor_externo
+  FOR EACH ROW EXECUTE FUNCTION public.set_atualizado_em_column();


### PR DESCRIPTION
O trigger `sku_fornecedor_externo_set_atualizado_em` (BEFORE UPDATE) chamava a função genérica `update_updated_at_column()` (que faz `NEW.updated_at = now()`), mas a tabela usa a coluna **`atualizado_em`** — não `updated_at`. Resultado: **toda UPDATE na tabela falhava** (`record new has no field updated_at`), inclusive o "editar mapeamento" do app (nunca funcionou; só adicionar funcionava).

Descoberto ao corrigir 3 mapeamentos via SQL Editor durante o teste da feature de auto-mapeamento (#480).

**Fix:** função dedicada `set_atualizado_em_column()` (seta `atualizado_em`) + repoint do trigger. Escopo confirmado = **só esta tabela** tinha o mismatch (grep no snapshot). A `update_updated_at_column` genérica fica intacta pras tabelas com `updated_at`.

⚠️ **MIGRATION MANUAL** — rodar no SQL Editor (entregue inline no chat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)