### PR TITLE
fix(reposição): validação de mapeamento só mostra SKU que o motor vai pedir

### DIFF
--- a/src/components/skuMapeamento/useSkuMapeamento.ts
+++ b/src/components/skuMapeamento/useSkuMapeamento.ts
@@ -7,7 +7,7 @@ import { supabase } from '@/integrations/supabase/client';
 import { toast } from 'sonner';
 import { EMPTY_FORM } from './config';
 import type { Mapeamento, DescricaoLookup, ValidacaoResult } from './types';
-import { validarGabarito, sugerirMapeamentos, PARSER_VERSION, type SugestaoSegura } from '@/lib/reposicao/sayerlack-sku';
+import { validarGabarito, sugerirMapeamentos, ehProdutoFracionado, PARSER_VERSION, type SugestaoSegura } from '@/lib/reposicao/sayerlack-sku';
 
 export function useSkuMapeamento() {
   const qc = useQueryClient();
@@ -182,16 +182,28 @@ export function useSkuMapeamento() {
           .map((m) => m.sku_omie),
       );
 
+      // SKUs com reposição automática DESLIGADA: o motor não pede → não são "faltantes" reais.
+      // (ex.: produtos não-comprados pelo portal, como os 8:1 e o selante base água)
+      const { data: spDesligados } = await supabase
+        .from('sku_parametros')
+        .select('sku_codigo_omie')
+        .eq('empresa', 'OBEN')
+        .eq('habilitado_reposicao_automatica', false);
+      const skusDesligados = new Set(
+        (spDesligados ?? []).map((r) => String((r as { sku_codigo_omie: unknown }).sku_codigo_omie)),
+      );
+
       const faltantes: ValidacaoResult['faltantes'] = [];
       skusUnicos.forEach((desc, sku) => {
-        if (!mapAtivos.has(sku)) {
-          faltantes.push({
-            empresa: 'OBEN',
-            fornecedor_nome: 'RENNER SAYERLACK S/A',
-            sku_codigo_omie: sku,
-            sku_descricao: desc,
-          });
-        }
+        // só conta como faltante o que o motor REALMENTE vai pedir: não-mapeado, não-fracionado
+        // (450/405ml), e com reposição ligada. O resto é fantasma histórico (não-comprado).
+        if (mapAtivos.has(sku) || ehProdutoFracionado(desc) || skusDesligados.has(String(sku))) return;
+        faltantes.push({
+          empresa: 'OBEN',
+          fornecedor_nome: 'RENNER SAYERLACK S/A',
+          sku_codigo_omie: sku,
+          sku_descricao: desc,
+        });
       });
 
       const suspeitos = (mapeamentos ?? []).filter(

--- a/src/lib/reposicao/__tests__/sayerlack-sku.test.ts
+++ b/src/lib/reposicao/__tests__/sayerlack-sku.test.ts
@@ -6,6 +6,7 @@ import {
   compararComGabarito,
   validarGabarito,
   sugerirMapeamentos,
+  ehProdutoFracionado,
 } from '../sayerlack-sku';
 
 // GABARITO REAL — mapeamentos que o founder já fez na mão (descricao Omie → sku_portal salvo).
@@ -155,5 +156,20 @@ describe('sugerirMapeamentos (auto-preenchimento dos faltantes)', () => {
     const r = sugerirMapeamentos([{ sku_codigo_omie: '1', sku_descricao: 'WP12.3900QT CONCENTRADO PRETO' }]);
     expect(r.seguros[0].sku_portal).toBe('WP12.3900QT');
     expect(r.seguros[0].sufixo).toBe('QT');
+  });
+});
+
+describe('ehProdutoFracionado (não-comprado pelo portal)', () => {
+  it('true pra descrição terminando em 450ML / 405ML (case/espaço-insensível)', () => {
+    expect(ehProdutoFracionado('BASE PU METALLIC PEARL MULT INTER WFOI.6736 450ML')).toBe(true);
+    expect(ehProdutoFracionado('BASE PU ACRI FOSCO INTER WJOI.7585 405ML')).toBe(true);
+    expect(ehProdutoFracionado('  base microtex transp wfot.6861 450ml  ')).toBe(true);
+  });
+
+  it('false pra produto comprado normal (sufixo de embalagem como GL/QT)', () => {
+    expect(ehProdutoFracionado('POLIULACK BRILHANTE SB.2300.00GL')).toBe(false);
+    expect(ehProdutoFracionado('CATALISADOR FC.6902QT')).toBe(false);
+    expect(ehProdutoFracionado(null)).toBe(false);
+    expect(ehProdutoFracionado('')).toBe(false);
   });
 });

--- a/src/lib/reposicao/sayerlack-sku.ts
+++ b/src/lib/reposicao/sayerlack-sku.ts
@@ -42,6 +42,17 @@ export function sufixoSayerlack(codigo: string): string {
   return norm(codigo).match(SUFIXO_RE)?.[1] ?? '';
 }
 
+/**
+ * Produto FRACIONADO (descrição termina em 450ML/405ML): no Omie é o item-pai (QT)
+ * transformado em unidades menores — só VENDIDO, nunca COMPRADO pelo portal Sayerlack.
+ * Espelha a exclusão da RPC gerar_pedidos_sugeridos_ciclo (NOT ILIKE '%450ML'/'%405ML'),
+ * pra tirar esses fantasmas históricos da validação de mapeamento.
+ */
+export function ehProdutoFracionado(descricao: string | null | undefined): boolean {
+  const d = norm(descricao);
+  return d.endsWith('450ML') || d.endsWith('405ML');
+}
+
 export type ResolucaoSayerlack =
   | { status: 'ok'; codigo: string; sufixo: string; candidatos: string[] }
   | { status: 'sem_codigo'; candidatos: [] }


### PR DESCRIPTION
A tela `/admin/sku-mapeamento` listava como **faltante** produtos **não-comprados** pelo portal Sayerlack (fantasmas de pedidos históricos):
- **fracionados 450ML/405ML** (item-pai QT fatiado — só vendido, nunca comprado);
- **SKUs com reposição automática desligada** (ex.: primers 8:1, selante base água).

Agora a validação **filtra os dois** → só mostra SKU não-mapeado que o motor **realmente vai sugerir**. Para de cobrar mapeamento de produto que nem é comprado.

- Helper puro `ehProdutoFracionado` (espelha `NOT ILIKE '%450ML'/'%405ML'` da RPC `gerar_pedidos_sugeridos_ciclo`) + 2 testes.
- `handleValidar`: query `sku_parametros` desligados + filtro (`mapAtivos OR fracionado OR desligado → ignora`).

Frontend-only (sem migration/edge). Os 450/405ml já eram excluídos do **motor** (20260515000202 + 20260530143818); isto fecha a ponta na **tela**. Os 3 não-comprados viram desligados via SQL (entregue no chat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)