### PR TITLE
ci: bump actions/checkout v4→v5 (roda em Node 24)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2


### PR DESCRIPTION
## Resumo

Bump de `actions/checkout@v4` → `@v5` no [.github/workflows/ci.yml](.github/workflows/ci.yml). Uma linha.

## Por quê

Todo run de CI emitia o annotation:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: `actions/checkout@v4`. Actions will be forced to run with Node.js 24 by default starting June 16th, 2026. Node.js 20 will be removed from the runner on September 16th, 2026.

Era **aviso**, não erro — aparecia inclusive nos runs que passavam e nunca derrubou o CI. O `actions/checkout@v5` roda em Node 24, então o aviso some.

## Escopo

- Só a versão da action muda. Zero mudança de comportamento do pipeline.
- `oven-sh/setup-bun@v2` **não** aparecia no aviso do GitHub (já roda em runtime suportado), então fica como está.
- Sem VERSION/CHANGELOG bump (este repo não usa esse fluxo).

## Validação

A validação real é o próprio `validate` rodando neste PR com o `checkout@v5`. Se passar, o aviso de Node 20 não aparece mais.

🤖 Generated with [Claude Code](https://claude.com/claude-code)