### PR TITLE
feat(visitas): Agendar visita — fila de visitas datadas (Customer 360 → route planner) [Fase 1]

### DIFF
--- a/docs/superpowers/plans/2026-05-30-agendar-visita.md
+++ b/docs/superpowers/plans/2026-05-30-agendar-visita.md
@@ -1,0 +1,885 @@
+# Agendar visita — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Dar ao vendedor uma fila persistente de visitas agendadas (datadas) a clientes da carteira dele — criada do Customer 360, vista numa agenda "Próximas visitas" no route planner, com navegação (Waze) e check-in 1-toque que fecha a agenda automaticamente.
+
+**Architecture:** Tabela nova `visitas_agendadas` (owner-scoped, RLS endurecida por GRANT-por-coluna + carteira) + trigger de reconciliação no `route_visits` (check-in fecha a agenda). Front-end: helpers puros (`navLink`, `deriveVisitaStatus`), módulo de acesso tipado, hook `useVisitasAgendadas` (TanStack Query, optimistic), `AgendarVisitaDialog` (2 entradas) e `ScheduledVisitsPanel` (agenda + Waze + check-in 1-toque). Backend aplicado **manualmente via Lovable**.
+
+**Tech Stack:** React 18 + TypeScript, Vite, vitest, Supabase (Postgres + RLS), TanStack Query. Spec: `docs/superpowers/specs/2026-05-30-agendar-visita-design.md`.
+
+---
+
+## Fases
+
+- **Fase 1 (núcleo shippable) — Tasks 1–7:** banco + helpers + hook + dialog + agenda no route planner + check-in 1-toque. Entrega sozinha valor testável: o vendedor agenda, vê a agenda, navega e faz check-in (que fecha a agenda).
+- **Fase 2 (fast-follow) — Task 8:** integrar agendadas de hoje como **parada no mapa** do route planner (4ª fonte em `useRoutePlanner`). É a parte mais pesada (toca o god-hook); pode ser plano/PR separado.
+
+---
+
+## File Structure
+
+| Arquivo | Responsabilidade | Ação |
+| --- | --- | --- |
+| `supabase/migrations/20260530NNNNNN_visitas_agendadas.sql` | Tabela + constraints + índices + RLS/grants + trigger reconciliação + updated_at | Criar (apply manual Lovable) |
+| `src/lib/visitas/visita-status.ts` | Helper puro `deriveVisitaStatus` | Criar |
+| `src/lib/visitas/__tests__/visita-status.test.ts` | Testes do helper | Criar |
+| `src/lib/maps/nav-link.ts` | Helper puro `navLink` (Waze/Maps) | Criar |
+| `src/lib/maps/__tests__/nav-link.test.ts` | Testes do helper | Criar |
+| `src/hooks/useRoutePlanner.ts` | Refatorar `openInWaze` p/ usar `navLink` (DRY) | Modificar |
+| `src/integrations/supabase/visitasAgendadas.ts` | Tipo `VisitaAgendadaRow` + acesso tipado à tabela nova | Criar |
+| `src/hooks/useVisitasAgendadas.ts` | Query + mutations (agendar/remarcar/cancelar) + check-in | Criar |
+| `src/components/visitas/AgendarVisitaDialog.tsx` | Dialog de agendar | Criar |
+| `src/components/adminCustomers/Customer360View.tsx` | Ligar o item "Agendar visita" do dropdown | Modificar |
+| `src/components/customer360/CustomerHero.tsx` | Botão "Agendar visita" no header | Modificar |
+| `src/components/reposicao/routePlanner/ScheduledVisitsPanel.tsx` | Painel "Próximas visitas" | Criar |
+| `src/pages/AdminRoutePlanner.tsx` | Montar o painel | Modificar |
+
+**Validações canônicas (CLAUDE.md §2/§13):** `heavy bun run test` · `heavy bun run typecheck:strict` · `heavy bunx tsc --noEmit -p tsconfig.app.json` · `bun lint`. Prefixo `heavy` obrigatório.
+
+**Dependência de tipos:** a tabela `visitas_agendadas` só entra em `src/integrations/supabase/types.ts` quando o founder **regenera os tipos via Lovable** (após aplicar a migration). Até lá, o módulo `visitasAgendadas.ts` isola **um único** cast `as unknown as` (NUNCA `as any` — o lint bloqueia) pra a tabela. O código compila e os testes de helper puro passam **sem** a migration aplicada; o runtime real é QA do founder pós-apply.
+
+---
+
+## Task 1: Migration `visitas_agendadas` (backend, Lovable) + revisão adversária codex
+
+**Files:**
+- Create: `supabase/migrations/20260530NNNNNN_visitas_agendadas.sql` (NNNNNN = timestamp no apply; ex.: `20260530120000`)
+
+- [ ] **Step 1: Escrever a migration completa**
+
+```sql
+-- visitas_agendadas: fila persistente de visitas datadas, owner-scoped.
+CREATE TABLE public.visitas_agendadas (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  customer_user_id uuid NOT NULL,
+  scheduled_by uuid NOT NULL,
+  scheduled_date date NOT NULL,
+  status text NOT NULL DEFAULT 'pendente',
+  visit_type text NOT NULL DEFAULT 'comercial',
+  notes text,
+  route_visit_id uuid REFERENCES public.route_visits(id),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT visitas_agendadas_status_check CHECK (status IN ('pendente','realizada','cancelada'))
+);
+
+-- Anti-duplicata: 1 pendente por (cliente, vendedor, data).
+CREATE UNIQUE INDEX uq_vag_pendente_cliente_vendedor_data
+  ON public.visitas_agendadas (customer_user_id, scheduled_by, scheduled_date)
+  WHERE status = 'pendente';
+-- Uma visita realizada fecha no máximo uma agenda.
+CREATE UNIQUE INDEX uq_vag_route_visit_id
+  ON public.visitas_agendadas (route_visit_id)
+  WHERE route_visit_id IS NOT NULL;
+-- Calendário do vendedor.
+CREATE INDEX idx_vag_scheduled_by_date
+  ON public.visitas_agendadas (scheduled_by, scheduled_date);
+CREATE INDEX idx_vag_pending_by_seller
+  ON public.visitas_agendadas (scheduled_by, scheduled_date)
+  WHERE status = 'pendente';
+
+-- updated_at automático.
+CREATE OR REPLACE FUNCTION public.set_updated_at_visitas_agendadas()
+RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN NEW.updated_at = now(); RETURN NEW; END;
+$$;
+CREATE TRIGGER trg_vag_updated_at
+  BEFORE UPDATE ON public.visitas_agendadas
+  FOR EACH ROW EXECUTE FUNCTION public.set_updated_at_visitas_agendadas();
+
+-- RLS + grants endurecidos.
+ALTER TABLE public.visitas_agendadas ENABLE ROW LEVEL SECURITY;
+
+-- ⚠️ Supabase concede privilégios DEFAULT em tabela nova do public p/ anon/authenticated.
+-- Sem REVOKE primeiro, o GRANT por coluna NÃO surte efeito (o UPDATE cheio default fica).
+REVOKE ALL ON public.visitas_agendadas FROM anon, authenticated, PUBLIC;
+
+GRANT SELECT, INSERT ON public.visitas_agendadas TO authenticated;
+GRANT UPDATE (scheduled_date, visit_type, notes, status) ON public.visitas_agendadas TO authenticated;
+-- (sem UPDATE em scheduled_by/customer_user_id/route_visit_id → imutáveis; sem DELETE; anon sem nada)
+
+CREATE POLICY "vag_select_own" ON public.visitas_agendadas
+  FOR SELECT TO authenticated
+  USING (
+    scheduled_by = (SELECT auth.uid())
+    OR (SELECT public.pode_ver_carteira_completa((SELECT auth.uid())))
+  );
+
+CREATE POLICY "vag_insert_own_carteira" ON public.visitas_agendadas
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    scheduled_by = (SELECT auth.uid())
+    AND public.carteira_visivel_para(customer_user_id, (SELECT auth.uid()))
+    AND status = 'pendente'
+    AND route_visit_id IS NULL
+  );
+
+CREATE POLICY "vag_update_own_pending" ON public.visitas_agendadas
+  FOR UPDATE TO authenticated
+  USING (
+    scheduled_by = (SELECT auth.uid())
+    AND status = 'pendente'
+  )
+  WITH CHECK (
+    scheduled_by = (SELECT auth.uid())
+    AND status IN ('pendente','cancelada')
+    AND route_visit_id IS NULL
+  );
+
+CREATE POLICY "vag_delete_gestor" ON public.visitas_agendadas
+  FOR DELETE TO authenticated
+  USING ((SELECT public.pode_ver_carteira_completa((SELECT auth.uid()))));
+
+-- Reconciliação: check-in no route_visits fecha a agenda pendente correspondente.
+CREATE OR REPLACE FUNCTION public.reconcile_visita_agendada()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  UPDATE public.visitas_agendadas va
+  SET status = 'realizada',
+      route_visit_id = NEW.id,
+      updated_at = now()
+  WHERE va.customer_user_id = NEW.customer_user_id
+    AND va.scheduled_by    = NEW.visited_by
+    AND va.scheduled_date  = NEW.visit_date
+    AND va.status = 'pendente'
+    AND va.route_visit_id IS NULL;
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER trg_reconcile_visita_agendada
+  AFTER INSERT OR UPDATE OF check_in_at ON public.route_visits
+  FOR EACH ROW
+  WHEN (NEW.check_in_at IS NOT NULL)
+  EXECUTE FUNCTION public.reconcile_visita_agendada();
+```
+
+- [ ] **Step 2: Revisão adversária do SQL pelo codex (ANTES do Lovable)**
+
+Rodar consult adversária no SQL final (escrever o brief num arquivo e chamar):
+```bash
+codex exec "$(cat /tmp/codex-vag-sql-review.txt)" -C /Users/lucassardenberg/Projetos/afiacao/.claude/worktrees/mystifying-lamarr-975bbd -s read-only -c 'model_reasoning_effort="medium"'
+```
+Brief: "Revise adversarialmente esta migration (RLS/grants/trigger). Confirme: (1) REVOKE+GRANT-por-coluna realmente torna scheduled_by/customer_user_id/route_visit_id imutáveis p/ authenticated via PostgREST; (2) a WITH CHECK do UPDATE impede status='realizada' externo; (3) o trigger SECURITY DEFINER é idempotente e não vira bypass; (4) nenhum furo de IDOR/BFLA vs os padrões 20260526020000/040000. Aponte só o que MUDA o SQL." Incorporar P1/P2 achados antes de entregar.
+
+- [ ] **Step 3: Entregar p/ o founder aplicar via Lovable (skill `lovable-db-operator`)**
+
+Usar a skill `lovable-db-operator` p/ empacotar: bloco SQL pronto pra colar no SQL Editor + query de validação + nota de PR "⚠️ migration manual necessária". Validação pós-apply (colar no SQL Editor):
+```sql
+SELECT 'visitas_agendadas OK' AS status,
+  (SELECT count(*) FROM pg_policies WHERE tablename='visitas_agendadas') AS policies,         -- esperado 4
+  (SELECT count(*) FROM pg_trigger WHERE tgrelid='public.visitas_agendadas'::regclass) AS triggers_tbl, -- >=1 (updated_at)
+  (SELECT count(*) FROM pg_trigger WHERE tgname='trg_reconcile_visita_agendada') AS recon_trigger,     -- 1
+  (SELECT count(*) FROM pg_indexes WHERE tablename='visitas_agendadas') AS indexes;            -- >=5 (pk+4)
+```
+
+- [ ] **Step 4: Founder regenera os tipos Supabase via Lovable** (pra `visitas_agendadas` entrar em `types.ts`). Não bloqueia o resto do plano (o módulo da Task 4 isola o cast), mas habilita simplificar o cast depois.
+
+- [ ] **Step 5: Commit**
+```bash
+git add supabase/migrations/20260530NNNNNN_visitas_agendadas.sql
+git commit -m "feat(visitas): migration visitas_agendadas (RLS endurecida + trigger de reconciliacao)"
+```
+
+> ⚠️ As Tasks 5–8 só funcionam em RUNTIME após o founder aplicar esta migration. O código compila/testa antes (tipos locais). QA real é pós-apply.
+
+---
+
+## Task 2: Helper puro `deriveVisitaStatus` (TDD)
+
+**Files:**
+- Create: `src/lib/visitas/visita-status.ts`
+- Test: `src/lib/visitas/__tests__/visita-status.test.ts`
+
+- [ ] **Step 1: Escrever o teste que falha**
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { deriveVisitaStatus } from '../visita-status';
+
+describe('deriveVisitaStatus', () => {
+  const hoje = '2026-05-30';
+  it('realizada/cancelada passam direto', () => {
+    expect(deriveVisitaStatus('2026-05-01', 'realizada', hoje)).toBe('realizada');
+    expect(deriveVisitaStatus('2026-06-10', 'cancelada', hoje)).toBe('cancelada');
+  });
+  it('pendente no passado → atrasada', () => {
+    expect(deriveVisitaStatus('2026-05-29', 'pendente', hoje)).toBe('atrasada');
+  });
+  it('pendente hoje → hoje', () => {
+    expect(deriveVisitaStatus('2026-05-30', 'pendente', hoje)).toBe('hoje');
+  });
+  it('pendente no futuro → futura', () => {
+    expect(deriveVisitaStatus('2026-06-01', 'pendente', hoje)).toBe('futura');
+  });
+});
+```
+
+- [ ] **Step 2: Rodar e confirmar que falha**
+
+Run: `heavy bun run test src/lib/visitas/__tests__/visita-status.test.ts`
+Expected: FAIL (`deriveVisitaStatus is not a function`).
+
+- [ ] **Step 3: Implementar**
+
+```ts
+export type VisitaStatusDerivado = 'realizada' | 'cancelada' | 'atrasada' | 'hoje' | 'futura';
+
+/**
+ * Deriva o estado de exibição de uma visita agendada. 'atrasada' NÃO é coluna no
+ * banco — é pendente com scheduled_date < hoje. Datas em ISO 'YYYY-MM-DD' (comparação
+ * lexicográfica = cronológica nesse formato).
+ */
+export function deriveVisitaStatus(
+  scheduledDate: string,
+  status: string,
+  today: string,
+): VisitaStatusDerivado {
+  if (status === 'realizada') return 'realizada';
+  if (status === 'cancelada') return 'cancelada';
+  if (scheduledDate < today) return 'atrasada';
+  if (scheduledDate === today) return 'hoje';
+  return 'futura';
+}
+```
+
+- [ ] **Step 4: Rodar e confirmar que passa**
+
+Run: `heavy bun run test src/lib/visitas/__tests__/visita-status.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+```bash
+git add src/lib/visitas/visita-status.ts src/lib/visitas/__tests__/visita-status.test.ts
+git commit -m "feat(visitas): helper deriveVisitaStatus (TDD)"
+```
+
+---
+
+## Task 3: Helper puro `navLink` (TDD) + DRY no route planner
+
+**Files:**
+- Create: `src/lib/maps/nav-link.ts`
+- Test: `src/lib/maps/__tests__/nav-link.test.ts`
+- Modify: `src/hooks/useRoutePlanner.ts` (refatorar `openInWaze`, ~linhas 784-791, p/ usar `navLink`)
+
+- [ ] **Step 1: Escrever o teste que falha**
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { navLink } from '../nav-link';
+
+describe('navLink', () => {
+  it('com coords → Waze por lat/lng', () => {
+    expect(navLink('Rua X, 10, Divinópolis, MG', -20.1, -44.9))
+      .toBe('https://waze.com/ul?ll=-20.1,-44.9&navigate=yes');
+  });
+  it('sem coords mas com endereço → Waze por query', () => {
+    expect(navLink('Rua X, 10, Divinópolis, MG', null, null))
+      .toBe('https://waze.com/ul?q=Rua%20X%2C%2010%2C%20Divin%C3%B3polis%2C%20MG&navigate=yes');
+  });
+  it('sem coords e sem endereço → null', () => {
+    expect(navLink(null)).toBeNull();
+    expect(navLink('   ')).toBeNull();
+    expect(navLink('', null, null)).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Rodar e confirmar que falha**
+
+Run: `heavy bun run test src/lib/maps/__tests__/nav-link.test.ts`
+Expected: FAIL.
+
+- [ ] **Step 3: Implementar**
+
+```ts
+/**
+ * Monta um link de navegação Waze a partir de coordenadas ou, na falta, de um
+ * endereço-texto. Retorna null quando não há nem coords nem endereço utilizável
+ * (o call-site esconde o botão "Ir").
+ */
+export function navLink(
+  addressQuery: string | null | undefined,
+  lat?: number | null,
+  lng?: number | null,
+): string | null {
+  if (lat != null && lng != null) {
+    return `https://waze.com/ul?ll=${lat},${lng}&navigate=yes`;
+  }
+  const q = (addressQuery ?? '').trim();
+  if (q.length === 0) return null;
+  return `https://waze.com/ul?q=${encodeURIComponent(q)}&navigate=yes`;
+}
+```
+
+- [ ] **Step 4: Rodar e confirmar que passa**
+
+Run: `heavy bun run test src/lib/maps/__tests__/nav-link.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: DRY — refatorar `openInWaze` no route planner**
+
+Em `src/hooks/useRoutePlanner.ts`, localizar o `openInWaze` (≈ linhas 784-791):
+```tsx
+const openInWaze = (stop: RouteStop) => {
+  if (stop.lat && stop.lng) {
+    window.open(`https://waze.com/ul?ll=${stop.lat},${stop.lng}&navigate=yes`, '_blank');
+  } else {
+    const q = `${stop.address.street}, ${stop.address.number}, ${stop.address.city}, ${stop.address.state}`;
+    window.open(`https://waze.com/ul?q=${encodeURIComponent(q)}&navigate=yes`, '_blank');
+  }
+};
+```
+Substituir por (importar `navLink` de `@/lib/maps/nav-link` no topo do arquivo):
+```tsx
+const openInWaze = (stop: RouteStop) => {
+  const q = `${stop.address.street}, ${stop.address.number}, ${stop.address.city}, ${stop.address.state}`;
+  const href = navLink(q, stop.lat ?? null, stop.lng ?? null);
+  if (href) window.open(href, '_blank');
+};
+```
+
+- [ ] **Step 6: Typecheck + lint + test**
+
+Run: `heavy bunx tsc --noEmit -p tsconfig.app.json` → 0 erros.
+Run: `bun lint` → sem novos errors.
+Run: `heavy bun run test src/lib/maps/__tests__/nav-link.test.ts` → PASS.
+
+- [ ] **Step 7: Commit**
+```bash
+git add src/lib/maps/nav-link.ts src/lib/maps/__tests__/nav-link.test.ts src/hooks/useRoutePlanner.ts
+git commit -m "feat(maps): helper navLink (Waze) + DRY no openInWaze do route planner"
+```
+
+---
+
+## Task 4: Módulo de acesso tipado `visitasAgendadas.ts`
+
+**Files:**
+- Create: `src/integrations/supabase/visitasAgendadas.ts`
+
+Contexto: a tabela ainda NÃO está nos tipos gerados. Isolamos **um** cast `as unknown as` aqui (lint proíbe `as any`). Após o founder regenerar os tipos, simplificar.
+
+- [ ] **Step 1: Criar o módulo**
+
+```ts
+import { supabase } from '@/integrations/supabase/client';
+
+export type VisitaStatus = 'pendente' | 'realizada' | 'cancelada';
+
+export interface VisitaAgendadaRow {
+  id: string;
+  customer_user_id: string;
+  scheduled_by: string;
+  scheduled_date: string;   // 'YYYY-MM-DD'
+  status: VisitaStatus;
+  visit_type: string;
+  notes: string | null;
+  route_visit_id: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface NovaVisitaAgendada {
+  customer_user_id: string;
+  scheduled_by: string;
+  scheduled_date: string;
+  notes?: string | null;
+  visit_type?: string;
+}
+
+/**
+ * Acesso à tabela `visitas_agendadas` antes dela existir nos tipos gerados do
+ * Supabase. Único ponto com cast (via `unknown`, nunca `any`). Depois do regen
+ * de tipos via Lovable, trocar por `supabase.from('visitas_agendadas')` direto.
+ */
+export function visitasAgendadasTable() {
+  return (supabase as unknown as {
+    from: (table: string) => ReturnType<typeof supabase.from>;
+  }).from('visitas_agendadas');
+}
+```
+
+- [ ] **Step 2: Typecheck + lint**
+
+Run: `heavy bunx tsc --noEmit -p tsconfig.app.json` → 0 erros.
+Run: `bun lint` → sem novos errors (sem `no-explicit-any`).
+
+- [ ] **Step 3: Commit**
+```bash
+git add src/integrations/supabase/visitasAgendadas.ts
+git commit -m "feat(visitas): modulo de acesso tipado visitasAgendadas (pre type-regen)"
+```
+
+---
+
+## Task 5: Hook `useVisitasAgendadas` (query + mutations optimistic)
+
+**Files:**
+- Create: `src/hooks/useVisitasAgendadas.ts`
+
+Contexto: padrão de mutation optimista (cancel/snapshot/setQueryData/rollback/invalidate) como em `src/hooks/useMarkMixGapFeedback.ts`. Toast via `import { toast } from 'sonner'`. Auth via `useAuth()` (`src/contexts/AuthContext.tsx`) → `user.id`. Tratar `unique_violation` (Postgres code `23505`).
+
+- [ ] **Step 1: Implementar o hook**
+
+```ts
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { useAuth } from '@/contexts/AuthContext';
+import {
+  visitasAgendadasTable,
+  type VisitaAgendadaRow,
+} from '@/integrations/supabase/visitasAgendadas';
+
+const KEY = (uid: string | undefined) => ['visitas-agendadas', uid];
+
+function isUniqueViolation(err: unknown): boolean {
+  return typeof err === 'object' && err !== null && (err as { code?: string }).code === '23505';
+}
+
+export function useVisitasAgendadas() {
+  const { user } = useAuth();
+  const qc = useQueryClient();
+  const uid = user?.id;
+  const key = KEY(uid);
+
+  const proximas = useQuery({
+    queryKey: key,
+    enabled: !!uid,
+    queryFn: async (): Promise<VisitaAgendadaRow[]> => {
+      const { data, error } = await visitasAgendadasTable()
+        .select('*')
+        .eq('scheduled_by', uid!)
+        .in('status', ['pendente'])
+        .order('scheduled_date', { ascending: true });
+      if (error) throw error;
+      return (data ?? []) as unknown as VisitaAgendadaRow[];
+    },
+  });
+
+  const agendar = useMutation({
+    mutationFn: async (input: { customerUserId: string; scheduledDate: string; notes?: string }) => {
+      const { error } = await visitasAgendadasTable().insert({
+        customer_user_id: input.customerUserId,
+        scheduled_by: uid!,
+        scheduled_date: input.scheduledDate,
+        notes: input.notes ?? null,
+        visit_type: 'comercial',
+        status: 'pendente',
+      });
+      if (error) throw error;
+    },
+    onError: (err) => {
+      if (isUniqueViolation(err)) {
+        toast.error('Já existe visita pendente pra esse cliente nessa data');
+      } else {
+        toast.error('Não foi possível agendar a visita');
+      }
+    },
+    onSuccess: () => {
+      toast.success('Visita agendada');
+      qc.invalidateQueries({ queryKey: key });
+    },
+  });
+
+  const remarcar = useMutation({
+    mutationFn: async (input: { id: string; scheduledDate: string }) => {
+      const { error } = await visitasAgendadasTable()
+        .update({ scheduled_date: input.scheduledDate })
+        .eq('id', input.id);
+      if (error) throw error;
+    },
+    onError: (err) =>
+      toast.error(isUniqueViolation(err)
+        ? 'Já existe visita pendente nessa nova data'
+        : 'Não foi possível remarcar'),
+    onSuccess: () => qc.invalidateQueries({ queryKey: key }),
+  });
+
+  const cancelar = useMutation({
+    mutationFn: async (id: string) => {
+      const { error } = await visitasAgendadasTable()
+        .update({ status: 'cancelada' })
+        .eq('id', id);
+      if (error) throw error;
+    },
+    onMutate: async (id) => {
+      await qc.cancelQueries({ queryKey: key });
+      const prev = qc.getQueryData<VisitaAgendadaRow[]>(key);
+      qc.setQueryData<VisitaAgendadaRow[]>(key, (old) => (old ?? []).filter((v) => v.id !== id));
+      return { prev };
+    },
+    onError: (_e, _id, ctx) => {
+      if (ctx?.prev) qc.setQueryData(key, ctx.prev);
+      toast.error('Não foi possível cancelar');
+    },
+    onSettled: () => qc.invalidateQueries({ queryKey: key }),
+  });
+
+  return { proximas, agendar, remarcar, cancelar };
+}
+```
+
+- [ ] **Step 2: Typecheck + lint**
+
+Run: `heavy bunx tsc --noEmit -p tsconfig.app.json` → 0 erros.
+Run: `bun lint` → sem novos errors.
+
+- [ ] **Step 3: Commit**
+```bash
+git add src/hooks/useVisitasAgendadas.ts
+git commit -m "feat(visitas): hook useVisitasAgendadas (query + mutations optimistic)"
+```
+
+---
+
+## Task 6: `AgendarVisitaDialog` + 2 pontos de entrada
+
+**Files:**
+- Create: `src/components/visitas/AgendarVisitaDialog.tsx`
+- Modify: `src/components/adminCustomers/Customer360View.tsx` (dropdown, ~linhas 109-114)
+- Modify: `src/components/customer360/CustomerHero.tsx` (ações, ~linha 164)
+
+- [ ] **Step 1: Criar o dialog**
+
+```tsx
+import { useState } from 'react';
+import {
+  Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter, DialogTrigger,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { useVisitasAgendadas } from '@/hooks/useVisitasAgendadas';
+
+function hojeISO(): string {
+  return new Date().toISOString().split('T')[0];
+}
+
+export function AgendarVisitaDialog({
+  customerUserId,
+  customerName,
+  trigger,
+}: {
+  customerUserId: string;
+  customerName: string;
+  trigger: React.ReactNode;
+}) {
+  const { agendar } = useVisitasAgendadas();
+  const [open, setOpen] = useState(false);
+  const [date, setDate] = useState(hojeISO());
+  const [notes, setNotes] = useState('');
+
+  const submit = () => {
+    agendar.mutate(
+      { customerUserId, scheduledDate: date, notes: notes.trim() || undefined },
+      { onSuccess: () => { setOpen(false); setNotes(''); setDate(hojeISO()); } },
+    );
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>{trigger}</DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Agendar visita — {customerName}</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-3">
+          <div className="space-y-1">
+            <Label htmlFor="vag-date">Data</Label>
+            <Input id="vag-date" type="date" min={hojeISO()} value={date}
+              onChange={(e) => setDate(e.target.value)} />
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor="vag-notes">Motivo (opcional)</Label>
+            <Textarea id="vag-notes" value={notes} maxLength={500}
+              onChange={(e) => setNotes(e.target.value)}
+              placeholder="Por que vale visitar esse cliente?" />
+          </div>
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => setOpen(false)}>Cancelar</Button>
+          <Button onClick={submit} disabled={agendar.isPending || !date}>
+            {agendar.isPending ? 'Agendando…' : 'Agendar'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+```
+> Confirme que `src/components/ui/textarea.tsx` e `label.tsx` existem (shadcn). Se não, usar `<textarea>`/`<label>` nativos com classes equivalentes.
+
+- [ ] **Step 2: Ligar no dropdown do Customer360View**
+
+Em `src/components/adminCustomers/Customer360View.tsx`, importar no topo:
+```ts
+import { AgendarVisitaDialog } from '@/components/visitas/AgendarVisitaDialog';
+```
+Trocar o item desabilitado (linhas ~109-114):
+```tsx
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem disabled>
+                <Calendar className="w-3.5 h-3.5 mr-2" /> Agendar visita
+                <span className="ml-2 text-[10px] text-muted-foreground">em breve</span>
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+```
+por:
+```tsx
+            <DropdownMenuContent align="end">
+              <AgendarVisitaDialog
+                customerUserId={customer.user_id}
+                customerName={customer.name}
+                trigger={
+                  <DropdownMenuItem onSelect={(e) => e.preventDefault()}>
+                    <Calendar className="w-3.5 h-3.5 mr-2" /> Agendar visita
+                  </DropdownMenuItem>
+                }
+              />
+            </DropdownMenuContent>
+```
+> `onSelect={(e) => e.preventDefault()}` impede o menu de fechar antes do dialog abrir (padrão Radix DropdownMenuItem + Dialog).
+
+- [ ] **Step 3: Botão no CustomerHero**
+
+Em `src/components/customer360/CustomerHero.tsx`, importar `AgendarVisitaDialog` e `Calendar` (de `lucide-react`). No bloco "Ações rápidas" (após o botão "Novo pedido", ~linha 169), adicionar:
+```tsx
+            <AgendarVisitaDialog
+              customerUserId={customer.user_id}
+              customerName={customer.name}
+              trigger={
+                <Button variant="outline" size="sm">
+                  <Calendar className="w-3.5 h-3.5 mr-1.5" />
+                  Agendar visita
+                </Button>
+              }
+            />
+```
+
+- [ ] **Step 4: Typecheck + lint**
+
+Run: `heavy bunx tsc --noEmit -p tsconfig.app.json` → 0 erros.
+Run: `bun lint` → sem novos errors.
+
+- [ ] **Step 5: Commit**
+```bash
+git add src/components/visitas/AgendarVisitaDialog.tsx src/components/adminCustomers/Customer360View.tsx src/components/customer360/CustomerHero.tsx
+git commit -m "feat(visitas): AgendarVisitaDialog + entradas no dropdown e no CustomerHero"
+```
+
+---
+
+## Task 7: Painel "Próximas visitas" + check-in 1-toque
+
+**Files:**
+- Create: `src/components/reposicao/routePlanner/ScheduledVisitsPanel.tsx`
+- Modify: `src/hooks/useVisitasAgendadas.ts` (adicionar mutation `checkIn`)
+- Modify: `src/pages/AdminRoutePlanner.tsx` (montar o painel)
+
+Contexto: o check-in cria uma linha em `route_visits` (espelha `handleCheckIn`: `customer_user_id`, `visited_by`, `visit_type='comercial'`, `check_in_at`, lat/lng opcional via geolocalização) → o trigger da Task 1 fecha a agenda. Decisão (desvio do spec): mutation dedicada `checkIn` em vez de reusar `handleCheckIn` do god-hook (desacopla; o trigger faz a reconciliação).
+
+- [ ] **Step 1: Adicionar a mutation `checkIn` ao hook**
+
+Em `src/hooks/useVisitasAgendadas.ts`, dentro do `useVisitasAgendadas`, adicionar (e incluir `checkIn` no return):
+```ts
+  const checkIn = useMutation({
+    mutationFn: async (input: { customerUserId: string }) => {
+      const coords = await new Promise<{ lat: number; lng: number } | null>((resolve) => {
+        if (!navigator.geolocation) return resolve(null);
+        navigator.geolocation.getCurrentPosition(
+          (p) => resolve({ lat: p.coords.latitude, lng: p.coords.longitude }),
+          () => resolve(null),
+          { timeout: 5000 },
+        );
+      });
+      const { error } = await (supabase.from('route_visits')).insert({
+        customer_user_id: input.customerUserId,
+        visited_by: uid!,
+        visit_type: 'comercial',
+        check_in_at: new Date().toISOString(),
+        ...(coords ? { lat: coords.lat, lng: coords.lng } : {}),
+      });
+      if (error) throw error;
+    },
+    onError: () => toast.error('Não foi possível fazer check-in'),
+    onSuccess: () => {
+      toast.success('Check-in feito');
+      qc.invalidateQueries({ queryKey: key });
+    },
+  });
+```
+Importar `supabase` de `@/integrations/supabase/client` no topo. Incluir `checkIn` no `return { ... }`.
+> `route_visits` JÁ está nos tipos gerados → `.insert` tipado direto (sem cast).
+
+- [ ] **Step 2: Criar o painel**
+
+```tsx
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Calendar, Navigation, CheckCircle2, X } from 'lucide-react';
+import { format, parseISO } from 'date-fns';
+import { ptBR } from 'date-fns/locale';
+import { useVisitasAgendadas } from '@/hooks/useVisitasAgendadas';
+import { deriveVisitaStatus } from '@/lib/visitas/visita-status';
+import { navLink } from '@/lib/maps/nav-link';
+import { cn } from '@/lib/utils';
+
+function hojeISO(): string {
+  return new Date().toISOString().split('T')[0];
+}
+
+export function ScheduledVisitsPanel({
+  nomePorCliente,
+  enderecoPorCliente,
+}: {
+  // mapas cliente→nome/endereço carregados pela página (route planner já carrega clientes)
+  nomePorCliente: Record<string, string>;
+  enderecoPorCliente: Record<string, { query: string | null; lat: number | null; lng: number | null }>;
+}) {
+  const { proximas, cancelar, checkIn } = useVisitasAgendadas();
+  const hoje = hojeISO();
+  const visitas = proximas.data ?? [];
+
+  if (proximas.isLoading) return null;
+  if (visitas.length === 0) return null;
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-sm flex items-center gap-2">
+          <Calendar className="w-4 h-4" /> Próximas visitas
+          <Badge variant="secondary" className="text-[10px]">{visitas.length}</Badge>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        {visitas.map((v) => {
+          const d = deriveVisitaStatus(v.scheduled_date, v.status, hoje);
+          const end = enderecoPorCliente[v.customer_user_id];
+          const href = end ? navLink(end.query, end.lat, end.lng) : null;
+          return (
+            <div key={v.id} className="flex items-center gap-2 text-sm border-b last:border-b-0 pb-2 last:pb-0">
+              <div className="flex-1 min-w-0">
+                <div className="font-medium truncate">{nomePorCliente[v.customer_user_id] ?? v.customer_user_id}</div>
+                <div className={cn('text-xs', d === 'atrasada' ? 'text-status-warning-bold' : 'text-muted-foreground')}>
+                  {d === 'atrasada' ? 'Atrasada · ' : ''}{format(parseISO(v.scheduled_date), "dd 'de' MMM", { locale: ptBR })}
+                </div>
+              </div>
+              {href && (
+                <Button asChild variant="ghost" size="icon" className="h-8 w-8" title="Ir (Waze)">
+                  <a href={href} target="_blank" rel="noopener noreferrer"><Navigation className="w-4 h-4" /></a>
+                </Button>
+              )}
+              <Button variant="ghost" size="icon" className="h-8 w-8" title="Check-in"
+                disabled={checkIn.isPending}
+                onClick={() => checkIn.mutate({ customerUserId: v.customer_user_id })}>
+                <CheckCircle2 className="w-4 h-4 text-status-success-bold" />
+              </Button>
+              <Button variant="ghost" size="icon" className="h-8 w-8" title="Cancelar"
+                disabled={cancelar.isPending}
+                onClick={() => cancelar.mutate(v.id)}>
+                <X className="w-4 h-4 text-muted-foreground" />
+              </Button>
+            </div>
+          );
+        })}
+      </CardContent>
+    </Card>
+  );
+}
+```
+
+- [ ] **Step 3: Montar o painel no AdminRoutePlanner**
+
+Em `src/pages/AdminRoutePlanner.tsx`, importar `ScheduledVisitsPanel` e renderizar logo após o `StatsStrip` (≈ linha 182). Construir os mapas `nomePorCliente`/`enderecoPorCliente` a partir dos clientes que o hook do route planner já carrega (`loadManualCustomers`/stops); se a página não expõe isso prontamente, passar mapas vazios `{}` na v1 (o painel ainda lista nome via `customer_user_id` fallback e esconde o botão "Ir" quando não há endereço) e enriquecer na Task 8.
+```tsx
+<ScheduledVisitsPanel nomePorCliente={nomePorCliente} enderecoPorCliente={enderecoPorCliente} />
+```
+
+- [ ] **Step 4: Typecheck + lint**
+
+Run: `heavy bunx tsc --noEmit -p tsconfig.app.json` → 0 erros.
+Run: `bun lint` → sem novos errors.
+
+- [ ] **Step 5: Commit**
+```bash
+git add src/hooks/useVisitasAgendadas.ts src/components/reposicao/routePlanner/ScheduledVisitsPanel.tsx src/pages/AdminRoutePlanner.tsx
+git commit -m "feat(visitas): painel Proximas visitas no route planner + check-in 1-toque"
+```
+
+> **Fim da Fase 1 — feature shippable.** Validação final + QA na Task "Validação".
+
+---
+
+## Task 8 (Fase 2): Agendadas de hoje como parada no mapa do route planner
+
+**Files:**
+- Modify: `src/components/reposicao/routePlanner/types.ts` (novo `StopType` `'scheduled_visit'`)
+- Modify: `src/hooks/useRoutePlanner.ts` (fonte `loadScheduledVisits` + merge no `allStops` useMemo ~linha 595)
+
+Contexto: o route planner é **today-only**. Esta task surfacea as agendadas com `scheduled_date = hoje` como `RouteStop` (badge "Agendada"), entrando no mapa Leaflet + otimização. `RouteStop` shape em `routePlanner/types.ts:43-70` (id, stopType, customerUserId, customerName, phone, address{...}, lat?, lng?, priorityScore, priorityLabel, priorityFactors, etc.).
+
+- [ ] **Step 1: Adicionar o StopType**
+
+Em `routePlanner/types.ts`, no union `StopType`, adicionar `| 'scheduled_visit'`.
+
+- [ ] **Step 2: Carregar agendadas de hoje e mapear p/ RouteStop**
+
+Em `useRoutePlanner.ts`, criar `loadScheduledVisits()` que: query `visitasAgendadasTable().select('*').eq('scheduled_by', user.id).eq('status','pendente').eq('scheduled_date', today)`; enriquece endereço por cliente (mesma fonte de `loadManualCustomers`: tabela `addresses` is_default / `order.address`); mapeia p/ `RouteStop` com `stopType:'scheduled_visit'`, `visitReason:'Visita agendada'`, `priorityScore` fixo (ex.: 70) e `priorityLabel:'alta'`, `priorityFactors:['Agendada manualmente']`. Reusar o pipeline de geocoding existente (≈ linhas 662-706) p/ preencher lat/lng.
+
+- [ ] **Step 3: Mesclar no `allStops`**
+
+No `useMemo` que combina as fontes (≈ linha 595-644), incluir as agendadas (dedup por `customerUserId` se já houver outra parada do mesmo cliente — preferir manter a agendada com badge). Garantir que o `RouteStopCard` exibe o badge "Agendada" p/ `stopType==='scheduled_visit'`.
+
+- [ ] **Step 4: Typecheck + lint + smoke**
+
+Run: `heavy bunx tsc --noEmit -p tsconfig.app.json` → 0 erros.
+Run: `bun lint` → sem novos errors.
+
+- [ ] **Step 5: Commit**
+```bash
+git add src/components/reposicao/routePlanner/types.ts src/hooks/useRoutePlanner.ts
+git commit -m "feat(visitas): agendadas de hoje como parada no route planner (4a fonte)"
+```
+
+---
+
+## Task 9: Validação final + QA
+
+**Files:** nenhum (verificação)
+
+- [ ] **Step 1: Suíte completa**
+
+Run: `heavy bun run test` → 100% PASS (inclui `deriveVisitaStatus` + `navLink`).
+Run: `heavy bun run typecheck:strict` → 0 erros.
+Run: `heavy bunx tsc --noEmit -p tsconfig.app.json` → 0 erros.
+Run: `bun lint` → sem novos errors.
+
+- [ ] **Step 2: QA manual (founder, pós-apply da migration + regen de tipos)**
+
+- Agendar pelos 2 pontos de entrada (dropdown do detalhe + header 360°); ver na agenda "Próximas visitas".
+- "Ir" abre Waze no endereço/coords; botão some quando o cliente não tem endereço.
+- Check-in 1-toque cria `route_visits` e a agenda some da lista (vira `realizada`).
+- Tentar agendar 2× o mesmo cliente/data → toast "já existe visita pendente…".
+- Atrasada (data passada, pendente) aparece com destaque.
+- (Fase 2) agendada de hoje aparece como parada no mapa.
+
+- [ ] **Step 3: Validação de segurança (founder, via Lovable SQL Editor, com JWT de vendedor)**
+
+Confirmar que `authenticated` (vendedor) **não** consegue: `UPDATE` de `route_visit_id`/`customer_user_id`/`scheduled_by`; setar `status='realizada'`; `DELETE`; nem ler agenda de outro vendedor (a menos que gestor/master). `anon` não enxerga a tabela.
+
+---
+
+## Notas
+- **Migration é manual via Lovable** (CLAUDE.md §5) — usar `lovable-db-operator`. PR sinaliza "⚠️ migration manual necessária".
+- **Deploy:** sem edge function/cron. Só a migration.
+- **Limitações v1** (no spec §10): reatribuição de carteira (agenda velha fica com o vendedor antigo, que pode cancelar); check-in de cobertura não fecha a agenda do dono; `navLink` depende de endereço/coords.
+- **Fase 2 (Task 8)** pode virar PR separado se a integração no god-hook do route planner ficar arriscada — a Fase 1 já é shippable.

--- a/docs/superpowers/specs/2026-05-30-agendar-visita-design.md
+++ b/docs/superpowers/specs/2026-05-30-agendar-visita-design.md
@@ -1,0 +1,202 @@
+# Agendar visita — fila persistente de visitas datadas (Customer 360 → route planner)
+
+**Data:** 2026-05-30
+**Autor:** Lucas + Claude (design endurecido por consult adversária do codex)
+**Status:** aprovado (escopo + abordagem travados; aguardando review do spec escrito)
+
+---
+
+## 1. Problema
+
+Hoje o vendedor só visita os clientes que o **sistema de sugestão** (score `customer_visit_scores` → `useMyVisitSuggestions` → `pickDailyMix`) coloca na lista do dia. Quando ele julga interessante visitar um cliente **da carteira dele que o score não priorizou**, não há como registrar isso: o item "Agendar visita" no Customer 360 está **desabilitado ("em breve")**, o route planner só tem seleção manual **de sessão** (`useState`, não persiste), e `route_visits` só registra visitas **já realizadas** (check-in/check-out).
+
+A feature dá ao vendedor uma **fila persistente de visitas agendadas (datadas)**, que ele cria manualmente "furando o filtro" do app, vê numa agenda "Próximas visitas", e que vira parada na rota do dia agendado.
+
+## 2. Decisões travadas (Q&A com o founder)
+
+1. **Modelo datado** — toda visita agendada tem `scheduled_date` (hoje ou futuro). Não é backlog sem data.
+2. **Só carteira + cobertura** — o vendedor só agenda pra cliente que é dele (`carteira_assignments`) ou que ele cobre (`carteira_coverage`). Travado no banco via `carteira_visivel_para()`. "Furar o filtro" = visitar cliente seu que o score não sugeriu.
+3. **Onde aparece** — (a) como **4ª fonte de paradas** no route planner na data agendada **e** (b) numa lista **"Próximas visitas"** ordenada por data.
+4. **Ciclo de vida** — **check-in fecha a agendada automaticamente** (trigger): ao fazer check-in num cliente com agenda pendente pra aquela data, ela vira `realizada`. Pendente que passou da data sem check-in é **`atrasada`** (derivado, continua visível).
+5. **Entrada na UI** — no **dropdown do Customer360View** (liga o item desabilitado) **e** no **header do CustomerHero** (botão ao lado de Ligar/WhatsApp/Novo pedido).
+6. **Navegação** — botão **"Ir"** abre o **Waze** (fallback Google Maps) pro endereço/coordenadas do cliente.
+7. **Check-in 1-toque** — como a agenda já tem cliente+data, o check-in é um toque (reusa o fluxo existente), sem digitar.
+
+## 3. Escopo
+
+### 3.1 Dentro do escopo
+- Tabela nova `visitas_agendadas` (owner-scoped, endurecida — ver §4/§5).
+- Trigger de reconciliação no `route_visits` (check-in fecha a agenda).
+- UI: dialog de agendar (2 entradas), painel "Próximas visitas" no route planner, integração como 4ª fonte de paradas, botão "Ir" (Waze), check-in 1-toque.
+- Helpers puros TDD: `navLink` (Waze/Maps) e `deriveVisitaStatus`.
+- 1 migration aplicada manualmente via Lovable (ritual `lovable-db-operator`).
+
+### 3.2 Fora de escopo (deferido)
+- **Check-in/out automático por geofence** — inviável de forma confiável em web/PWA (background não funciona com app fechado; iOS não suporta; conflita com navegar no Waze, que joga nosso app pra segundo plano). **Spec própria depois**, com spike de viabilidade e a conversa honesta sobre app nativo.
+- **Split `created_by`/`assigned_to`** (posse operacional separada do criador) — v2, só se reatribuição de carteira virar comum (ver §10).
+- Geocoding de endereços que não têm coordenadas — usa fallback de endereço-texto no Waze (§7.4).
+
+## 4. Modelo de dados — `visitas_agendadas`
+
+| coluna | tipo | nota |
+|---|---|---|
+| `id` | uuid PK | `gen_random_uuid()` |
+| `customer_user_id` | uuid NOT NULL | cliente (`profiles.user_id`) |
+| `scheduled_by` | uuid NOT NULL | vendedor que agendou = dono (auth.uid()) |
+| `scheduled_date` | date NOT NULL | data-alvo (hoje ou futuro) |
+| `status` | text NOT NULL default `pendente` | CHECK IN (`pendente`,`realizada`,`cancelada`) |
+| `visit_type` | text NOT NULL default `comercial` | flexível (UI v1 fixa `comercial`) |
+| `notes` | text | opcional (motivo) |
+| `route_visit_id` | uuid → `route_visits(id)` | preenchido só pela reconciliação |
+| `created_at`/`updated_at` | timestamptz NOT NULL default now() | `updated_at` por trigger |
+
+- **`atrasada` é DERIVADO na aplicação** (`status='pendente' AND scheduled_date < hoje`), não é coluna.
+- **Constraints/índices:**
+  - `CHECK (status IN ('pendente','realizada','cancelada'))`.
+  - Unique parcial anti-duplicata: `(customer_user_id, scheduled_by, scheduled_date) WHERE status='pendente'`.
+  - Unique parcial `(route_visit_id) WHERE route_visit_id IS NOT NULL` — uma visita realizada fecha **no máximo uma** agenda.
+  - Índices: `(scheduled_by, scheduled_date)`; parcial `(scheduled_by, scheduled_date) WHERE status='pendente'`.
+  - FK `route_visit_id` default (NO ACTION/RESTRICT) — não deletamos `route_visits` (visita realizada é fato auditável).
+
+## 5. Segurança — RLS + grants (endurecido pelo codex)
+
+**Princípio (codex P1):** RLS sozinha não compara OLD vs NEW. Em vez de um trigger-guard de OLD/NEW, usamos **GRANT por coluna** pra tornar `scheduled_by`/`customer_user_id`/`route_visit_id` **imutáveis** pro vendedor — só a trigger de reconciliação (SECURITY DEFINER, roda como owner, ignora grant/RLS) os altera.
+
+```sql
+ALTER TABLE public.visitas_agendadas ENABLE ROW LEVEL SECURITY;
+
+-- ⚠️ O Supabase concede privilégios DEFAULT em tabela nova do public pra anon/authenticated.
+-- Sem REVOKE primeiro, o GRANT por coluna NÃO surte efeito (o UPDATE cheio default permanece).
+-- (Lição CLAUDE.md §10: "REVOKE FROM PUBLIC não basta — anon/authenticated têm grant explícito".)
+REVOKE ALL ON public.visitas_agendadas FROM anon, authenticated, PUBLIC;
+
+-- Grants: vendedor só atualiza colunas "soft"; sem DELETE pra authenticated; anon sem nada.
+GRANT SELECT, INSERT ON public.visitas_agendadas TO authenticated;
+GRANT UPDATE (scheduled_date, visit_type, notes, status) ON public.visitas_agendadas TO authenticated;
+-- (NENHUM grant de UPDATE em scheduled_by/customer_user_id/route_visit_id → imutáveis)
+-- (NENHUM grant de DELETE pra authenticated → cancelar é status, não delete físico)
+-- (NENHUM grant pra anon → tabela invisível na API pública)
+
+-- SELECT: própria + time gestor/master
+CREATE POLICY "vag_select_own" ON public.visitas_agendadas
+  FOR SELECT TO authenticated
+  USING (
+    scheduled_by = (SELECT auth.uid())
+    OR (SELECT public.pode_ver_carteira_completa((SELECT auth.uid())))
+  );
+
+-- INSERT: própria + carteira/cobertura + estado inicial limpo
+CREATE POLICY "vag_insert_own_carteira" ON public.visitas_agendadas
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    scheduled_by = (SELECT auth.uid())
+    AND public.carteira_visivel_para(customer_user_id, (SELECT auth.uid()))
+    AND status = 'pendente'
+    AND route_visit_id IS NULL
+  );
+
+-- UPDATE: só remarcar/cancelar/editar nota da PRÓPRIA PENDENTE.
+-- NÃO re-checa carteira (senão cliente reatribuído travaria o cancelamento da agenda velha).
+CREATE POLICY "vag_update_own_pending" ON public.visitas_agendadas
+  FOR UPDATE TO authenticated
+  USING (
+    scheduled_by = (SELECT auth.uid())
+    AND status = 'pendente'
+  )
+  WITH CHECK (
+    scheduled_by = (SELECT auth.uid())
+    AND status IN ('pendente','cancelada')
+    AND route_visit_id IS NULL
+  );
+
+-- DELETE: só gestor/master (limpeza administrativa).
+CREATE POLICY "vag_delete_gestor" ON public.visitas_agendadas
+  FOR DELETE TO authenticated
+  USING ((SELECT public.pode_ver_carteira_completa((SELECT auth.uid()))));
+```
+
+- `service_role` bypassa RLS (engines). `(SELECT auth.uid())` = padrão initPlan recente.
+- **Por que o vendedor não forja conclusão:** o GRANT bloqueia `route_visit_id` (não está na lista) e a WITH CHECK do UPDATE só aceita `status IN ('pendente','cancelada')` → ele **não consegue** setar `realizada` nem `route_visit_id` via PostgREST. `customer_user_id` imutável → não dá pra "mover" a agenda pra cliente fora da carteira.
+- `carteira_visivel_para(uuid,uuid)` já é `STABLE SECURITY DEFINER SET search_path=public` (formato certo pra RLS); **não** alteramos seus grants (helper compartilhado por outras policies).
+
+## 6. Reconciliação — check-in fecha a agenda
+
+```sql
+CREATE OR REPLACE FUNCTION public.reconcile_visita_agendada()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  UPDATE public.visitas_agendadas va
+  SET status = 'realizada',
+      route_visit_id = NEW.id,
+      updated_at = now()
+  WHERE va.customer_user_id = NEW.customer_user_id
+    AND va.scheduled_by    = NEW.visited_by
+    AND va.scheduled_date  = NEW.visit_date
+    AND va.status = 'pendente'
+    AND va.route_visit_id IS NULL;
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER trg_reconcile_visita_agendada
+  AFTER INSERT OR UPDATE OF check_in_at ON public.route_visits
+  FOR EACH ROW
+  WHEN (NEW.check_in_at IS NOT NULL)
+  EXECUTE FUNCTION public.reconcile_visita_agendada();
+```
+
+- **Idempotente** (codex P2): a cláusula `status='pendente' AND route_visit_id IS NULL` garante que repetir o update de `check_in_at` não fecha de novo (no-op após a 1ª vez) — por isso não precisa de `OLD.check_in_at` no `WHEN` (que nem seria permitido num trigger `INSERT OR UPDATE`).
+- `SECURITY DEFINER` + `SET search_path=public`: roda como owner (ignora o GRANT por coluna e a RLS), por isso consegue setar `realizada`+`route_visit_id`. Match estreito por `(customer_user_id, visited_by=scheduled_by, visit_date)` + a unique parcial garante **no máximo uma** pendente por chave.
+- Convive com o trigger existente `enqueue_visit_score_recalc_from_visit` (triggers independentes).
+- **Comportamento de cobertura (v1):** se quem agendou (`scheduled_by` = dono) for diferente de quem faz o check-in (`visited_by` = cobertura), **não** reconcilia — a agenda do dono fica pendente. Aceitável v1 (a intenção do dono segue aberta); documentado.
+
+## 7. UI
+
+### 7.1 Dialog "Agendar visita" (`AgendarVisitaDialog`)
+- Entradas: **dropdown do `Customer360View`** (liga o item hoje desabilitado) **e** botão no **`CustomerHero`** (header 360°).
+- Campos: data (default hoje, `min` = hoje), nota (opcional). `visit_type` fixo `comercial` na v1.
+- Submit → mutation `agendar` (insert). Sucesso → toast + invalida "Próximas visitas". **Trata `unique_violation`** (código `23505`) → toast "Já existe visita pendente pra esse cliente nessa data".
+
+### 7.2 Hook `useVisitasAgendadas`
+- Query `proximasVisitas`: pendentes do vendedor (`scheduled_by = user.id`) por `scheduled_date ASC`.
+- Mutations: `agendar` (insert), `remarcar` (update `scheduled_date`), `cancelar` (update `status='cancelada'`), `editarNota` (update `notes`). Todas com optimistic + rollback (padrão `tanstack-query` do repo) e tratamento de `unique_violation`.
+
+### 7.3 Painel "Próximas visitas" (no route planner `/admin/route-planner`)
+- Lista pendentes/atrasadas agrupadas: **Atrasadas** (destaque `status-warning`), **Hoje**, **Amanhã**, **Futuras**.
+- Cada linha: nome do cliente, data, **"Ir"** (Waze), **check-in 1-toque**, remarcar, cancelar.
+- **Integração na rota:** agendadas com `scheduled_date` = data de planejamento entram como **4ª fonte de paradas** (badge "Agendada") no `useRoutePlanner` (junto das logísticas/comerciais/manuais).
+
+### 7.4 Navegação — helper puro `navLink(endereco, lat?, lng?)`
+- Com coords: `https://waze.com/ul?ll=<lat>,<lng>&navigate=yes`.
+- Sem coords: `https://waze.com/ul?q=<endereço URL-encoded>&navigate=yes`.
+- Sem endereço **nem** coords → retorna `null` (botão "Ir" some). Fonte do endereço/coords: endereço default do cliente (o route planner já carrega isso em `loadManualCustomers`).
+
+### 7.5 Check-in 1-toque
+- Reusa o fluxo de check-in existente do `useRoutePlanner` (cria `route_visits` com `visited_by`/`customer_user_id`/`visit_date`) → a trigger §6 fecha a agenda. Extrair uma ação compartilhada `checkInCustomer(customerId)` se necessário pra chamar fora do fluxo de seleção da rota.
+
+## 8. Migration + Lovable
+- 1 migration `supabase/migrations/20260530NNNNNN_visitas_agendadas.sql` com: tabela + CHECK + índices/uniques + trigger `updated_at` + RLS + grants + função/trigger de reconciliação.
+- **Apply manual via Lovable SQL Editor** (CLAUDE.md §5) — usar a skill **`lovable-db-operator`** pra empacotar: bloco(s) SQL prontos pra colar, query de validação pós-apply (count de tabela/policies/trigger/índices), nota de PR "⚠️ migration manual necessária", e regenerar o audit.
+- Sem edge function. Sem cron. (A derivação de `atrasada` é em runtime; não precisa de job.)
+
+## 9. Testes
+- **Helpers puros (TDD vitest):**
+  - `navLink(endereco, lat?, lng?)` — com coords, sem coords (q-fallback), sem nada (null), URL-encoding.
+  - `deriveVisitaStatus(scheduled_date, status, hoje)` → `realizada`|`cancelada`|`atrasada`|`hoje`|`futura`.
+- **Componentes/hook:** testes de `useVisitasAgendadas` (agendar/cancelar/remarcar, tratamento de `unique_violation`) onde fizer sentido.
+- **QA manual no device** (o headless não renderiza a SPA): agendar pelos 2 pontos de entrada; ver na agenda; "Ir" abre Waze; check-in fecha a agenda; tentativa de duplicata mostra o toast certo.
+- **Validação de segurança (manual, via Lovable SQL Editor):** confirmar que `authenticated` **não** consegue `UPDATE` de `route_visit_id`/`customer_user_id`/`status='realizada'` nem `DELETE` (testar com um JWT de vendedor).
+
+## 10. Limitações v1 (documentadas)
+- **Reatribuição de carteira:** se um cliente muda de dono, a agenda pendente que o vendedor antigo criou continua aparecendo **pra ele** (SELECT por `scheduled_by`). Ela não auto-reconcilia sob o check-in do novo dono (`visited_by` diferente). O vendedor antigo ainda consegue **cancelar** a própria agenda velha (a policy de UPDATE não re-checa carteira de propósito). v2: split `created_by`/`assigned_to` se isso incomodar.
+- **Cobertura:** check-in de um vendedor de cobertura não fecha a agenda do dono (ver §6).
+- **Geofence/auto check-in:** fora de escopo (spec própria).
+- **`navLink`** depende do cliente ter endereço/coords; sem isso o botão "Ir" some.
+
+## 11. Referências
+- Consult adversária do codex (gpt-5.5, 2026-05-30): achados P1 (UPDATE mutável demais; `status`/`route_visit_id` forjáveis; sem DELETE pro vendedor), P2 (initPlan, trigger estreita+idempotente, unique em `route_visit_id`, índices), P3 (CHECK de status). Todos incorporados acima (o trigger-guard OLD/NEW foi substituído por **GRANT por coluna**, mais simples e equivalente).
+- Padrões do repo: RLS por dono = `call_log` (`20260523120000`); carteira = `carteira_visivel_para`/`pode_ver_carteira_completa` (`20260524120000`); hardening recente = `20260526020000`/`20260526040000`.

--- a/docs/superpowers/specs/2026-05-30-agendar-visita-design.md
+++ b/docs/superpowers/specs/2026-05-30-agendar-visita-design.md
@@ -121,6 +121,8 @@ CREATE POLICY "vag_delete_gestor" ON public.visitas_agendadas
 
 ## 6. Reconciliação — check-in fecha a agenda
 
+A função usa `scheduled_date <= NEW.visit_date` (cobre visitas **atrasadas**, não só o dia exato), fecha a pendente **mais antiga devida** (subquery ordenada por `scheduled_date ASC LIMIT 1`), exclui futuras (`scheduled_date > visit_date`), e é idempotente via `NOT EXISTS` (além da unique parcial em `route_visit_id`).
+
 ```sql
 CREATE OR REPLACE FUNCTION public.reconcile_visita_agendada()
 RETURNS trigger
@@ -129,15 +131,28 @@ SECURITY DEFINER
 SET search_path = public
 AS $$
 BEGIN
+  -- Fecha a agenda pendente DEVIDA (scheduled_date <= data do check-in) MAIS ANTIGA
+  -- deste cliente+vendedor. O `<=` cobre visitas ATRASADAS (scheduled_date < hoje),
+  -- não só as do dia exato. Futuras (scheduled_date > visit_date) NÃO são fechadas.
+  -- Idempotente: o NOT EXISTS impede um mesmo route_visit fechar uma 2ª agenda num
+  -- eventual re-disparo (a unique em route_visit_id também barraria).
   UPDATE public.visitas_agendadas va
   SET status = 'realizada',
       route_visit_id = NEW.id,
       updated_at = now()
-  WHERE va.customer_user_id = NEW.customer_user_id
-    AND va.scheduled_by    = NEW.visited_by
-    AND va.scheduled_date  = NEW.visit_date
-    AND va.status = 'pendente'
-    AND va.route_visit_id IS NULL;
+  WHERE va.id = (
+    SELECT v.id FROM public.visitas_agendadas v
+    WHERE v.customer_user_id = NEW.customer_user_id
+      AND v.scheduled_by    = NEW.visited_by
+      AND v.status = 'pendente'
+      AND v.route_visit_id IS NULL
+      AND v.scheduled_date <= NEW.visit_date
+    ORDER BY v.scheduled_date ASC
+    LIMIT 1
+  )
+  AND NOT EXISTS (
+    SELECT 1 FROM public.visitas_agendadas v2 WHERE v2.route_visit_id = NEW.id
+  );
   RETURN NEW;
 END;
 $$;
@@ -149,10 +164,13 @@ CREATE TRIGGER trg_reconcile_visita_agendada
   EXECUTE FUNCTION public.reconcile_visita_agendada();
 ```
 
-- **Idempotente** (codex P2): a cláusula `status='pendente' AND route_visit_id IS NULL` garante que repetir o update de `check_in_at` não fecha de novo (no-op após a 1ª vez) — por isso não precisa de `OLD.check_in_at` no `WHEN` (que nem seria permitido num trigger `INSERT OR UPDATE`).
-- `SECURITY DEFINER` + `SET search_path=public`: roda como owner (ignora o GRANT por coluna e a RLS), por isso consegue setar `realizada`+`route_visit_id`. Match estreito por `(customer_user_id, visited_by=scheduled_by, visit_date)` + a unique parcial garante **no máximo uma** pendente por chave.
+- **`scheduled_date <= NEW.visit_date`**: cobre visitas atrasadas (agendadas pro passado, check-in feito hoje) — o bug original usava `=` e nunca reconciliava visitas em atraso porque `route_visits.visit_date` defaulta pra `CURRENT_DATE`. Futuras (`scheduled_date > visit_date`) **não** são fechadas.
+- **Subquery + `ORDER BY scheduled_date ASC LIMIT 1`**: fecha a mais antiga devida quando há mais de uma pendente — comportamento determinístico e conservador (fecha só uma por check-in).
+- **`NOT EXISTS`**: guard de idempotência extra — se o trigger re-disparar (UPDATE de `check_in_at`), não fecha uma 2ª agenda com o mesmo `route_visit_id` (a unique parcial `uq_vag_route_visit_id` também barraria no banco).
+- `SECURITY DEFINER` + `SET search_path=public`: roda como owner (ignora GRANT por coluna e RLS), por isso consegue setar `realizada`+`route_visit_id`.
 - Convive com o trigger existente `enqueue_visit_score_recalc_from_visit` (triggers independentes).
 - **Comportamento de cobertura (v1):** se quem agendou (`scheduled_by` = dono) for diferente de quem faz o check-in (`visited_by` = cobertura), **não** reconcilia — a agenda do dono fica pendente. Aceitável v1 (a intenção do dono segue aberta); documentado.
+- **Limitação v1:** visita feita **antes** da data agendada (`scheduled_date > hoje`) não auto-reconcilia — o vendedor cancela/remarca a futura na mão.
 
 ## 7. UI
 

--- a/docs/superpowers/specs/2026-05-30-agendar-visita-design.md
+++ b/docs/superpowers/specs/2026-05-30-agendar-visita-design.md
@@ -121,7 +121,7 @@ CREATE POLICY "vag_delete_gestor" ON public.visitas_agendadas
 
 ## 6. Reconciliação — check-in fecha a agenda
 
-A função usa `scheduled_date <= NEW.visit_date` (cobre visitas **atrasadas**, não só o dia exato), fecha a pendente **mais antiga devida** (subquery ordenada por `scheduled_date ASC LIMIT 1`), exclui futuras (`scheduled_date > visit_date`), e é idempotente via `NOT EXISTS` (além da unique parcial em `route_visit_id`).
+A função usa `scheduled_date <= NEW.visit_date` (cobre visitas **atrasadas**, não só o dia exato), fecha a pendente **mais antiga devida** (subquery ordenada por `scheduled_date ASC LIMIT 1`), exclui futuras (`scheduled_date > visit_date`), e é idempotente via `NOT EXISTS` (além da unique parcial em `route_visit_id`). Os guards externos `va.status='pendente' AND va.route_visit_id IS NULL` no UPDATE tornam check-ins concorrentes seguros: o 2º não sobrescreve o `route_visit_id` já gravado pelo 1º.
 
 ```sql
 CREATE OR REPLACE FUNCTION public.reconcile_visita_agendada()
@@ -132,10 +132,11 @@ SET search_path = public
 AS $$
 BEGIN
   -- Fecha a agenda pendente DEVIDA (scheduled_date <= data do check-in) MAIS ANTIGA
-  -- deste cliente+vendedor. O `<=` cobre visitas ATRASADAS (scheduled_date < hoje),
-  -- não só as do dia exato. Futuras (scheduled_date > visit_date) NÃO são fechadas.
-  -- Idempotente: o NOT EXISTS impede um mesmo route_visit fechar uma 2ª agenda num
-  -- eventual re-disparo (a unique em route_visit_id também barraria).
+  -- deste cliente+vendedor. O `<=` cobre visitas ATRASADAS (scheduled_date < hoje).
+  -- Futuras (scheduled_date > visit_date) NÃO são fechadas.
+  -- Os filtros externos `va.status='pendente' AND va.route_visit_id IS NULL` tornam
+  -- um 2º check-in concorrente um no-op (não sobrescreve o route_visit_id do 1º).
+  -- O NOT EXISTS impede um mesmo route_visit fechar uma 2ª agenda num re-disparo.
   UPDATE public.visitas_agendadas va
   SET status = 'realizada',
       route_visit_id = NEW.id,
@@ -150,6 +151,8 @@ BEGIN
     ORDER BY v.scheduled_date ASC
     LIMIT 1
   )
+  AND va.status = 'pendente'
+  AND va.route_visit_id IS NULL
   AND NOT EXISTS (
     SELECT 1 FROM public.visitas_agendadas v2 WHERE v2.route_visit_id = NEW.id
   );
@@ -166,6 +169,7 @@ CREATE TRIGGER trg_reconcile_visita_agendada
 
 - **`scheduled_date <= NEW.visit_date`**: cobre visitas atrasadas (agendadas pro passado, check-in feito hoje) — o bug original usava `=` e nunca reconciliava visitas em atraso porque `route_visits.visit_date` defaulta pra `CURRENT_DATE`. Futuras (`scheduled_date > visit_date`) **não** são fechadas.
 - **Subquery + `ORDER BY scheduled_date ASC LIMIT 1`**: fecha a mais antiga devida quando há mais de uma pendente — comportamento determinístico e conservador (fecha só uma por check-in).
+- **`va.status='pendente' AND va.route_visit_id IS NULL` (outer WHERE)**: guard de concorrência — um 2º check-in concorrente do mesmo cliente+vendedor encontra a linha já com `status='realizada'` e `route_visit_id` preenchido pelo 1º, e vira no-op. Sem esses dois filtros, o 2º UPDATE sobrescreveria o `route_visit_id` já gravado (link loss).
 - **`NOT EXISTS`**: guard de idempotência extra — se o trigger re-disparar (UPDATE de `check_in_at`), não fecha uma 2ª agenda com o mesmo `route_visit_id` (a unique parcial `uq_vag_route_visit_id` também barraria no banco).
 - `SECURITY DEFINER` + `SET search_path=public`: roda como owner (ignora GRANT por coluna e RLS), por isso consegue setar `realizada`+`route_visit_id`.
 - Convive com o trigger existente `enqueue_visit_score_recalc_from_visit` (triggers independentes).

--- a/src/components/adminCustomers/Customer360View.tsx
+++ b/src/components/adminCustomers/Customer360View.tsx
@@ -29,6 +29,7 @@ import { CustomerContactsTab } from '@/components/customer/CustomerContactsTab';
 import { fmt, HEALTH_CLASSES, formatDocument } from './config';
 import { MetricCard, ScoreItem } from './cards';
 import { RequiresPoToggle } from './RequiresPoToggle';
+import { AgendarVisitaDialog } from '@/components/visitas/AgendarVisitaDialog';
 import type { Customer, ClientScore, ToolCategory, UserTool, SalesOrder } from './types';
 
 export function Customer360View({
@@ -107,10 +108,15 @@ export function Customer360View({
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
-              <DropdownMenuItem disabled>
-                <Calendar className="w-3.5 h-3.5 mr-2" /> Agendar visita
-                <span className="ml-2 text-[10px] text-muted-foreground">em breve</span>
-              </DropdownMenuItem>
+              <AgendarVisitaDialog
+                customerUserId={customer.user_id}
+                customerName={customer.name}
+                trigger={
+                  <DropdownMenuItem onSelect={(e) => e.preventDefault()}>
+                    <Calendar className="w-3.5 h-3.5 mr-2" /> Agendar visita
+                  </DropdownMenuItem>
+                }
+              />
             </DropdownMenuContent>
           </DropdownMenu>
         </div>

--- a/src/components/customer360/CustomerHero.tsx
+++ b/src/components/customer360/CustomerHero.tsx
@@ -2,11 +2,12 @@
 // Extraído de src/pages/Customer360.tsx (god-component split).
 import { Link } from 'react-router-dom';
 import {
-  ArrowLeft, Building2, MessageSquare, ShoppingBag, AlertCircle, Activity,
+  ArrowLeft, Building2, Calendar, MessageSquare, ShoppingBag, AlertCircle, Activity,
 } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { CallButton } from '@/components/call/CallButton';
+import { AgendarVisitaDialog } from '@/components/visitas/AgendarVisitaDialog';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
 import { whatsappLink } from '@/lib/phone';
@@ -167,6 +168,16 @@ export function CustomerHero({
                 Novo pedido
               </Link>
             </Button>
+            <AgendarVisitaDialog
+              customerUserId={customer.user_id}
+              customerName={customer.name}
+              trigger={
+                <Button variant="outline" size="sm">
+                  <Calendar className="w-3.5 h-3.5 mr-1.5" />
+                  Agendar visita
+                </Button>
+              }
+            />
           </div>
         </div>
       </header>

--- a/src/components/customer360/__tests__/CustomerHero.test.tsx
+++ b/src/components/customer360/__tests__/CustomerHero.test.tsx
@@ -5,6 +5,14 @@ import { TooltipProvider } from '@/components/ui/tooltip';
 import { CustomerHero } from '../CustomerHero';
 import type { Customer, CustomerScore } from '../viewTypes';
 
+// AgendarVisitaDialog (renderizado pelo CustomerHero) usa useVisitasAgendadas →
+// useAuth/useQueryClient. Mockamos o hook: este é um teste unitário do hero, não do dialog.
+vi.mock('@/hooks/useVisitasAgendadas', () => ({
+  useVisitasAgendadas: () => ({
+    agendar: { mutate: vi.fn(), isPending: false },
+  }),
+}));
+
 const customer = {
   name: 'Acme Ltda',
   document: '12345678000190',

--- a/src/components/reposicao/routePlanner/ScheduledVisitsPanel.tsx
+++ b/src/components/reposicao/routePlanner/ScheduledVisitsPanel.tsx
@@ -22,7 +22,7 @@ export function ScheduledVisitsPanel() {
   const { proximas, cancelar, checkIn } = useVisitasAgendadas();
 
   const visits = proximas.data ?? [];
-  const customerIds = [...new Set(visits.map((v) => v.customer_user_id))];
+  const customerIds = [...new Set(visits.map((v) => v.customer_user_id))].sort();
 
   // Resolve nomes dos clientes
   const namesQuery = useQuery({

--- a/src/components/reposicao/routePlanner/ScheduledVisitsPanel.tsx
+++ b/src/components/reposicao/routePlanner/ScheduledVisitsPanel.tsx
@@ -1,0 +1,162 @@
+// Painel "Próximas visitas" — exibe visitas agendadas pendentes do vendedor com
+// ações de 1 toque: Ir (Waze), Check-in e Cancelar. Resolve nomes e endereços
+// internamente (não recebe props de dados externos).
+import { useQuery } from '@tanstack/react-query';
+import { format, parseISO } from 'date-fns';
+import { ptBR } from 'date-fns/locale';
+import { Calendar, MapPin, CheckCircle2, X } from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { supabase } from '@/integrations/supabase/client';
+import { useVisitasAgendadas } from '@/hooks/useVisitasAgendadas';
+import { deriveVisitaStatus } from '@/lib/visitas/visita-status';
+import { navLink } from '@/lib/maps/nav-link';
+
+// hoje em ISO 'YYYY-MM-DD' — convencão UTC usada no restante do route planner
+function hojeISO(): string {
+  return new Date().toISOString().split('T')[0];
+}
+
+export function ScheduledVisitsPanel() {
+  const { proximas, cancelar, checkIn } = useVisitasAgendadas();
+
+  const visits = proximas.data ?? [];
+  const customerIds = [...new Set(visits.map((v) => v.customer_user_id))];
+
+  // Resolve nomes dos clientes
+  const namesQuery = useQuery({
+    queryKey: ['scheduled-visits-names', customerIds],
+    enabled: customerIds.length > 0,
+    queryFn: async (): Promise<Record<string, string>> => {
+      const { data, error } = await supabase
+        .from('profiles')
+        .select('user_id, name, razao_social')
+        .in('user_id', customerIds);
+      if (error) throw new Error(error.message);
+      const map: Record<string, string> = {};
+      for (const p of data ?? []) {
+        map[p.user_id] = p.razao_social || p.name;
+      }
+      return map;
+    },
+  });
+
+  // Resolve endereços (best-effort para o botão "Ir")
+  const addressesQuery = useQuery({
+    queryKey: ['scheduled-visits-addresses', customerIds],
+    enabled: customerIds.length > 0,
+    queryFn: async (): Promise<Record<string, string>> => {
+      const { data, error } = await supabase
+        .from('addresses')
+        .select('user_id, street, number, city, state, is_default')
+        .in('user_id', customerIds)
+        .order('is_default', { ascending: false });
+      if (error) throw new Error(error.message);
+
+      const map: Record<string, string> = {};
+      for (const addr of data ?? []) {
+        // Mantém só o primeiro por user_id (ordenado por is_default desc → default vem primeiro)
+        if (!map[addr.user_id]) {
+          map[addr.user_id] = [addr.street, addr.number, addr.city, addr.state]
+            .filter(Boolean)
+            .join(', ');
+        }
+      }
+      return map;
+    },
+  });
+
+  // Enquanto carrega as visitas, não renderiza nada
+  if (proximas.isLoading) return null;
+
+  // Sem visitas pendentes: painel oculto
+  if (visits.length === 0) return null;
+
+  const nameMap = namesQuery.data ?? {};
+  const addressMap = addressesQuery.data ?? {};
+  const hoje = hojeISO();
+
+  return (
+    <Card>
+      <CardHeader className="pb-2 pt-3 px-4">
+        <CardTitle className="text-sm font-semibold flex items-center gap-2">
+          <Calendar className="w-4 h-4 text-primary" />
+          Próximas visitas
+          <Badge variant="secondary" className="ml-auto text-xs">
+            {visits.length}
+          </Badge>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="px-4 pb-3 space-y-2">
+        {visits.map((visita) => {
+          const statusDerivado = deriveVisitaStatus(visita.scheduled_date, visita.status, hoje);
+          const isAtrasada = statusDerivado === 'atrasada';
+          const nome = nameMap[visita.customer_user_id] ?? visita.customer_user_id;
+          const endereco = addressMap[visita.customer_user_id] ?? null;
+          const wazeHref = navLink(endereco);
+          const isPending = checkIn.isPending && checkIn.variables?.customerUserId === visita.customer_user_id;
+
+          return (
+            <div
+              key={visita.id}
+              className="flex items-center gap-2 text-sm py-1 border-b last:border-b-0 border-border/50"
+            >
+              {/* Data */}
+              <span className={`text-xs shrink-0 ${isAtrasada ? 'text-status-warning-bold font-semibold' : 'text-muted-foreground'}`}>
+                {isAtrasada && 'Atrasada · '}
+                {format(parseISO(visita.scheduled_date), "dd 'de' MMM", { locale: ptBR })}
+              </span>
+
+              {/* Nome */}
+              <span className="flex-1 truncate font-medium text-foreground">
+                {nome}
+              </span>
+
+              {/* Ações */}
+              <div className="flex items-center gap-1 shrink-0">
+                {/* Botão Ir (Waze) */}
+                {wazeHref && (
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-7 w-7"
+                    asChild
+                  >
+                    <a href={wazeHref} target="_blank" rel="noreferrer" aria-label="Navegar no Waze">
+                      <MapPin className="w-3.5 h-3.5" />
+                    </a>
+                  </Button>
+                )}
+
+                {/* Check-in */}
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-7 w-7 text-status-success-bold hover:text-status-success-bold"
+                  disabled={isPending}
+                  onClick={() => checkIn.mutate({ customerUserId: visita.customer_user_id })}
+                  aria-label="Fazer check-in"
+                >
+                  <CheckCircle2 className="w-3.5 h-3.5" />
+                </Button>
+
+                {/* Cancelar */}
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-7 w-7 text-muted-foreground hover:text-destructive"
+                  disabled={cancelar.isPending}
+                  onClick={() => cancelar.mutate(visita.id)}
+                  aria-label="Cancelar visita"
+                >
+                  <X className="w-3.5 h-3.5" />
+                </Button>
+              </div>
+            </div>
+          );
+        })}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/reposicao/routePlanner/ScheduledVisitsPanel.tsx
+++ b/src/components/reposicao/routePlanner/ScheduledVisitsPanel.tsx
@@ -12,11 +12,7 @@ import { supabase } from '@/integrations/supabase/client';
 import { useVisitasAgendadas } from '@/hooks/useVisitasAgendadas';
 import { deriveVisitaStatus } from '@/lib/visitas/visita-status';
 import { navLink } from '@/lib/maps/nav-link';
-
-// hoje em ISO 'YYYY-MM-DD' — convencão UTC usada no restante do route planner
-function hojeISO(): string {
-  return new Date().toISOString().split('T')[0];
-}
+import { hojeISO } from '@/lib/visitas/today';
 
 export function ScheduledVisitsPanel() {
   const { proximas, cancelar, checkIn } = useVisitasAgendadas();

--- a/src/components/visitas/AgendarVisitaDialog.tsx
+++ b/src/components/visitas/AgendarVisitaDialog.tsx
@@ -1,0 +1,65 @@
+import { useState } from 'react';
+import {
+  Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter, DialogTrigger,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { useVisitasAgendadas } from '@/hooks/useVisitasAgendadas';
+
+function hojeISO(): string {
+  return new Date().toISOString().split('T')[0];
+}
+
+export function AgendarVisitaDialog({
+  customerUserId,
+  customerName,
+  trigger,
+}: {
+  customerUserId: string;
+  customerName: string;
+  trigger: React.ReactNode;
+}) {
+  const { agendar } = useVisitasAgendadas();
+  const [open, setOpen] = useState(false);
+  const [date, setDate] = useState(hojeISO());
+  const [notes, setNotes] = useState('');
+
+  const submit = () => {
+    agendar.mutate(
+      { customerUserId, scheduledDate: date, notes: notes.trim() || undefined },
+      { onSuccess: () => { setOpen(false); setNotes(''); setDate(hojeISO()); } },
+    );
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>{trigger}</DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Agendar visita — {customerName}</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-3">
+          <div className="space-y-1">
+            <Label htmlFor="vag-date">Data</Label>
+            <Input id="vag-date" type="date" min={hojeISO()} value={date}
+              onChange={(e) => setDate(e.target.value)} />
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor="vag-notes">Motivo (opcional)</Label>
+            <Textarea id="vag-notes" value={notes} maxLength={500}
+              onChange={(e) => setNotes(e.target.value)}
+              placeholder="Por que vale visitar esse cliente?" />
+          </div>
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => setOpen(false)}>Cancelar</Button>
+          <Button onClick={submit} disabled={agendar.isPending || !date}>
+            {agendar.isPending ? 'Agendando…' : 'Agendar'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/visitas/AgendarVisitaDialog.tsx
+++ b/src/components/visitas/AgendarVisitaDialog.tsx
@@ -7,10 +7,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { useVisitasAgendadas } from '@/hooks/useVisitasAgendadas';
-
-function hojeISO(): string {
-  return new Date().toISOString().split('T')[0];
-}
+import { hojeISO } from '@/lib/visitas/today';
 
 export function AgendarVisitaDialog({
   customerUserId,

--- a/src/hooks/useRoutePlanner.ts
+++ b/src/hooks/useRoutePlanner.ts
@@ -10,6 +10,7 @@ import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
 import { useFarmerScoring } from '@/hooks/useFarmerScoring';
 import { toast } from 'sonner';
+import { navLink } from '@/lib/maps/nav-link';
 import type {
   StopType,
   PlanningMode,
@@ -782,12 +783,9 @@ export function useRoutePlanner() {
   }, [filteredStops, filterPeriod]);
 
   const openInWaze = (stop: RouteStop) => {
-    if (stop.lat && stop.lng) {
-      window.open(`https://waze.com/ul?ll=${stop.lat},${stop.lng}&navigate=yes`, '_blank');
-    } else {
-      const q = `${stop.address.street}, ${stop.address.number}, ${stop.address.city}, ${stop.address.state}`;
-      window.open(`https://waze.com/ul?q=${encodeURIComponent(q)}&navigate=yes`, '_blank');
-    }
+    const q = `${stop.address.street}, ${stop.address.number}, ${stop.address.city}, ${stop.address.state}`;
+    const href = navLink(q, stop.lat ?? null, stop.lng ?? null);
+    if (href) window.open(href, '_blank');
   };
 
   const openInGoogleMaps = (stop: RouteStop) => {

--- a/src/hooks/useVisitasAgendadas.ts
+++ b/src/hooks/useVisitasAgendadas.ts
@@ -1,47 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { useAuth } from '@/contexts/AuthContext';
-import { supabase } from '@/integrations/supabase/client';
-import type { VisitaAgendadaRow } from '@/integrations/supabase/visitasAgendadas';
-
-// ---------------------------------------------------------------------------
-// Typed builder (shape mínimo) — `visitas_agendadas` não está no types.ts gerado.
-// Evita a instanciação de tipo "excessively deep" do builder genérico do Supabase.
-// ---------------------------------------------------------------------------
-type DbError = { code?: string; message: string } | null;
-type DbResult<T = unknown> = Promise<{ data: T; error: DbError }>;
-
-interface VisitaInsert {
-  customer_user_id: string;
-  scheduled_by: string;
-  scheduled_date: string;
-  notes: string | null;
-  visit_type: string;
-  status: string;
-}
-
-interface VisitaUpdate {
-  scheduled_date?: string;
-  status?: string;
-}
-
-interface VisitaFilter {
-  select: (cols: string) => VisitaFilter;
-  insert: (row: VisitaInsert) => DbResult;
-  update: (patch: VisitaUpdate) => VisitaFilter;
-  eq: (col: string, val: string) => VisitaFilter;
-  in: (col: string, vals: string[]) => VisitaFilter;
-  order: (col: string, opts: { ascending: boolean }) => VisitaFilter;
-  then: <T>(
-    onFulfilled: (value: { data: unknown; error: DbError }) => T
-  ) => Promise<T>;
-}
-
-type VisitasClient = { from: (table: 'visitas_agendadas') => VisitaFilter };
-
-function visitasTable(): VisitaFilter {
-  return (supabase as unknown as VisitasClient).from('visitas_agendadas');
-}
+import { visitasAgendadasTable, type VisitaAgendadaRow } from '@/integrations/supabase/visitasAgendadas';
 
 // ---------------------------------------------------------------------------
 // Hook
@@ -66,7 +26,7 @@ export function useVisitasAgendadas() {
     queryKey: key,
     enabled: !!uid,
     queryFn: async (): Promise<VisitaAgendadaRow[]> => {
-      const { data, error } = await visitasTable()
+      const { data, error } = await visitasAgendadasTable()
         .select('*')
         .eq('scheduled_by', uid!)
         .in('status', ['pendente'])
@@ -82,7 +42,7 @@ export function useVisitasAgendadas() {
       scheduledDate: string;
       notes?: string;
     }) => {
-      const { error } = await visitasTable().insert({
+      const { error } = await visitasAgendadasTable().insert({
         customer_user_id: input.customerUserId,
         scheduled_by: uid!,
         scheduled_date: input.scheduledDate,
@@ -107,7 +67,7 @@ export function useVisitasAgendadas() {
 
   const remarcar = useMutation({
     mutationFn: async (input: { id: string; scheduledDate: string }) => {
-      const { error } = await visitasTable()
+      const { error } = await visitasAgendadasTable()
         .update({ scheduled_date: input.scheduledDate })
         .eq('id', input.id);
       if (error) throw Object.assign(new Error(error.message), { code: error.code });
@@ -123,7 +83,7 @@ export function useVisitasAgendadas() {
 
   const cancelar = useMutation({
     mutationFn: async (id: string) => {
-      const { error } = await visitasTable()
+      const { error } = await visitasAgendadasTable()
         .update({ status: 'cancelada' })
         .eq('id', id);
       if (error) throw new Error(error.message);

--- a/src/hooks/useVisitasAgendadas.ts
+++ b/src/hooks/useVisitasAgendadas.ts
@@ -43,6 +43,7 @@ export function useVisitasAgendadas() {
       scheduledDate: string;
       notes?: string;
     }) => {
+      if (!uid) throw new Error('Sessão não autenticada');
       const { error } = await visitasAgendadasTable().insert({
         customer_user_id: input.customerUserId,
         scheduled_by: uid!,
@@ -106,6 +107,7 @@ export function useVisitasAgendadas() {
 
   const checkIn = useMutation({
     mutationFn: async (input: { customerUserId: string }) => {
+      if (!uid) throw new Error('Sessão não autenticada');
       const coords = await new Promise<{ lat: number; lng: number } | null>((resolve) => {
         if (!navigator.geolocation) return resolve(null);
         navigator.geolocation.getCurrentPosition(

--- a/src/hooks/useVisitasAgendadas.ts
+++ b/src/hooks/useVisitasAgendadas.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { useAuth } from '@/contexts/AuthContext';
+import { supabase } from '@/integrations/supabase/client';
 import { visitasAgendadasTable, type VisitaAgendadaRow } from '@/integrations/supabase/visitasAgendadas';
 
 // ---------------------------------------------------------------------------
@@ -103,5 +104,31 @@ export function useVisitasAgendadas() {
     onSettled: () => void qc.invalidateQueries({ queryKey: key }),
   });
 
-  return { proximas, agendar, remarcar, cancelar };
+  const checkIn = useMutation({
+    mutationFn: async (input: { customerUserId: string }) => {
+      const coords = await new Promise<{ lat: number; lng: number } | null>((resolve) => {
+        if (!navigator.geolocation) return resolve(null);
+        navigator.geolocation.getCurrentPosition(
+          (p) => resolve({ lat: p.coords.latitude, lng: p.coords.longitude }),
+          () => resolve(null),
+          { timeout: 5000 },
+        );
+      });
+      const { error } = await supabase.from('route_visits').insert({
+        customer_user_id: input.customerUserId,
+        visited_by: uid!,
+        visit_type: 'comercial',
+        check_in_at: new Date().toISOString(),
+        ...(coords ? { lat: coords.lat, lng: coords.lng } : {}),
+      });
+      if (error) throw error;
+    },
+    onError: () => toast.error('Não foi possível fazer check-in'),
+    onSuccess: () => {
+      toast.success('Check-in feito');
+      void qc.invalidateQueries({ queryKey: key });
+    },
+  });
+
+  return { proximas, agendar, remarcar, cancelar, checkIn };
 }

--- a/src/hooks/useVisitasAgendadas.ts
+++ b/src/hooks/useVisitasAgendadas.ts
@@ -1,0 +1,147 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { useAuth } from '@/contexts/AuthContext';
+import { supabase } from '@/integrations/supabase/client';
+import type { VisitaAgendadaRow } from '@/integrations/supabase/visitasAgendadas';
+
+// ---------------------------------------------------------------------------
+// Typed builder (shape mínimo) — `visitas_agendadas` não está no types.ts gerado.
+// Evita a instanciação de tipo "excessively deep" do builder genérico do Supabase.
+// ---------------------------------------------------------------------------
+type DbError = { code?: string; message: string } | null;
+type DbResult<T = unknown> = Promise<{ data: T; error: DbError }>;
+
+interface VisitaInsert {
+  customer_user_id: string;
+  scheduled_by: string;
+  scheduled_date: string;
+  notes: string | null;
+  visit_type: string;
+  status: string;
+}
+
+interface VisitaUpdate {
+  scheduled_date?: string;
+  status?: string;
+}
+
+interface VisitaFilter {
+  select: (cols: string) => VisitaFilter;
+  insert: (row: VisitaInsert) => DbResult;
+  update: (patch: VisitaUpdate) => VisitaFilter;
+  eq: (col: string, val: string) => VisitaFilter;
+  in: (col: string, vals: string[]) => VisitaFilter;
+  order: (col: string, opts: { ascending: boolean }) => VisitaFilter;
+  then: <T>(
+    onFulfilled: (value: { data: unknown; error: DbError }) => T
+  ) => Promise<T>;
+}
+
+type VisitasClient = { from: (table: 'visitas_agendadas') => VisitaFilter };
+
+function visitasTable(): VisitaFilter {
+  return (supabase as unknown as VisitasClient).from('visitas_agendadas');
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+const KEY = (uid: string | undefined) => ['visitas-agendadas', uid];
+
+function isUniqueViolation(err: unknown): boolean {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    (err as { code?: string }).code === '23505'
+  );
+}
+
+export function useVisitasAgendadas() {
+  const { user } = useAuth();
+  const qc = useQueryClient();
+  const uid = user?.id;
+  const key = KEY(uid);
+
+  const proximas = useQuery({
+    queryKey: key,
+    enabled: !!uid,
+    queryFn: async (): Promise<VisitaAgendadaRow[]> => {
+      const { data, error } = await visitasTable()
+        .select('*')
+        .eq('scheduled_by', uid!)
+        .in('status', ['pendente'])
+        .order('scheduled_date', { ascending: true });
+      if (error) throw new Error(error.message);
+      return (data as unknown as VisitaAgendadaRow[]) ?? [];
+    },
+  });
+
+  const agendar = useMutation({
+    mutationFn: async (input: {
+      customerUserId: string;
+      scheduledDate: string;
+      notes?: string;
+    }) => {
+      const { error } = await visitasTable().insert({
+        customer_user_id: input.customerUserId,
+        scheduled_by: uid!,
+        scheduled_date: input.scheduledDate,
+        notes: input.notes ?? null,
+        visit_type: 'comercial',
+        status: 'pendente',
+      });
+      if (error) throw Object.assign(new Error(error.message), { code: error.code });
+    },
+    onError: (err) => {
+      if (isUniqueViolation(err)) {
+        toast.error('Já existe visita pendente pra esse cliente nessa data');
+      } else {
+        toast.error('Não foi possível agendar a visita');
+      }
+    },
+    onSuccess: () => {
+      toast.success('Visita agendada');
+      void qc.invalidateQueries({ queryKey: key });
+    },
+  });
+
+  const remarcar = useMutation({
+    mutationFn: async (input: { id: string; scheduledDate: string }) => {
+      const { error } = await visitasTable()
+        .update({ scheduled_date: input.scheduledDate })
+        .eq('id', input.id);
+      if (error) throw Object.assign(new Error(error.message), { code: error.code });
+    },
+    onError: (err) =>
+      toast.error(
+        isUniqueViolation(err)
+          ? 'Já existe visita pendente nessa nova data'
+          : 'Não foi possível remarcar'
+      ),
+    onSuccess: () => void qc.invalidateQueries({ queryKey: key }),
+  });
+
+  const cancelar = useMutation({
+    mutationFn: async (id: string) => {
+      const { error } = await visitasTable()
+        .update({ status: 'cancelada' })
+        .eq('id', id);
+      if (error) throw new Error(error.message);
+    },
+    onMutate: async (id) => {
+      await qc.cancelQueries({ queryKey: key });
+      const prev = qc.getQueryData<VisitaAgendadaRow[]>(key);
+      qc.setQueryData<VisitaAgendadaRow[]>(key, (old) =>
+        (old ?? []).filter((v) => v.id !== id)
+      );
+      return { prev };
+    },
+    onError: (_e, _id, ctx) => {
+      if (ctx?.prev) qc.setQueryData(key, ctx.prev);
+      toast.error('Não foi possível cancelar');
+    },
+    onSettled: () => void qc.invalidateQueries({ queryKey: key }),
+  });
+
+  return { proximas, agendar, remarcar, cancelar };
+}

--- a/src/integrations/supabase/visitasAgendadas.ts
+++ b/src/integrations/supabase/visitasAgendadas.ts
@@ -1,0 +1,38 @@
+import { supabase } from '@/integrations/supabase/client';
+
+export type VisitaStatus = 'pendente' | 'realizada' | 'cancelada';
+
+export interface VisitaAgendadaRow {
+  id: string;
+  customer_user_id: string;
+  scheduled_by: string;
+  scheduled_date: string;   // 'YYYY-MM-DD'
+  status: VisitaStatus;
+  visit_type: string;
+  notes: string | null;
+  route_visit_id: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface NovaVisitaAgendada {
+  customer_user_id: string;
+  scheduled_by: string;
+  scheduled_date: string;
+  notes?: string | null;
+  visit_type?: string;
+}
+
+/**
+ * Acesso à tabela `visitas_agendadas` antes dela existir nos tipos gerados do
+ * Supabase. Único ponto com cast (via `unknown`, nunca `any`). Depois do regen
+ * de tipos via Lovable, trocar por `supabase.from('visitas_agendadas')` direto.
+ *
+ * Forma (a): cast do supabase para objeto com `from(table: string)` retornando
+ * o tipo que o próprio `from` nativo retorna quando chamado com string genérica.
+ */
+export function visitasAgendadasTable() {
+  return (supabase as unknown as {
+    from: (table: string) => ReturnType<typeof supabase.from>;
+  }).from('visitas_agendadas');
+}

--- a/src/integrations/supabase/visitasAgendadas.ts
+++ b/src/integrations/supabase/visitasAgendadas.ts
@@ -23,16 +23,46 @@ export interface NovaVisitaAgendada {
   visit_type?: string;
 }
 
+// ---------------------------------------------------------------------------
+// Builder estreito — `visitas_agendadas` ainda não está no types.ts gerado.
+// Declarar só os métodos usados evita a instanciação "excessively deep" (TS2589)
+// do builder genérico do Supabase. Este é o ÚNICO ponto de cast (via unknown,
+// nunca any). Pós type-regen via Lovable: trocar por supabase.from('visitas_agendadas').
+// ---------------------------------------------------------------------------
+type DbError = { code?: string; message: string } | null;
+type DbResult<T = unknown> = Promise<{ data: T; error: DbError }>;
+
+export interface VisitaInsert {
+  customer_user_id: string;
+  scheduled_by: string;
+  scheduled_date: string;
+  notes: string | null;
+  visit_type: string;
+  status: string;
+}
+
+export interface VisitaUpdate {
+  scheduled_date?: string;
+  status?: string;
+}
+
+export interface VisitaFilter {
+  select: (cols: string) => VisitaFilter;
+  insert: (row: VisitaInsert) => DbResult;
+  update: (patch: VisitaUpdate) => VisitaFilter;
+  eq: (col: string, val: string) => VisitaFilter;
+  in: (col: string, vals: string[]) => VisitaFilter;
+  order: (col: string, opts: { ascending: boolean }) => VisitaFilter;
+  then: <T>(
+    onFulfilled: (value: { data: unknown; error: DbError }) => T,
+  ) => Promise<T>;
+}
+
+type VisitasClient = { from: (table: 'visitas_agendadas') => VisitaFilter };
+
 /**
- * Acesso à tabela `visitas_agendadas` antes dela existir nos tipos gerados do
- * Supabase. Único ponto com cast (via `unknown`, nunca `any`). Depois do regen
- * de tipos via Lovable, trocar por `supabase.from('visitas_agendadas')` direto.
- *
- * Forma (a): cast do supabase para objeto com `from(table: string)` retornando
- * o tipo que o próprio `from` nativo retorna quando chamado com string genérica.
+ * Builder tipado e estreito para a tabela `visitas_agendadas`. Único ponto de cast.
  */
-export function visitasAgendadasTable() {
-  return (supabase as unknown as {
-    from: (table: string) => ReturnType<typeof supabase.from>;
-  }).from('visitas_agendadas');
+export function visitasAgendadasTable(): VisitaFilter {
+  return (supabase as unknown as VisitasClient).from('visitas_agendadas');
 }

--- a/src/integrations/supabase/visitasAgendadas.ts
+++ b/src/integrations/supabase/visitasAgendadas.ts
@@ -15,14 +15,6 @@ export interface VisitaAgendadaRow {
   updated_at: string;
 }
 
-export interface NovaVisitaAgendada {
-  customer_user_id: string;
-  scheduled_by: string;
-  scheduled_date: string;
-  notes?: string | null;
-  visit_type?: string;
-}
-
 // ---------------------------------------------------------------------------
 // Builder estreito — `visitas_agendadas` ainda não está no types.ts gerado.
 // Declarar só os métodos usados evita a instanciação "excessively deep" (TS2589)

--- a/src/lib/maps/__tests__/nav-link.test.ts
+++ b/src/lib/maps/__tests__/nav-link.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { navLink } from '../nav-link';
+
+describe('navLink', () => {
+  it('com coords → Waze por lat/lng', () => {
+    expect(navLink('Rua X, 10, Divinópolis, MG', -20.1, -44.9))
+      .toBe('https://waze.com/ul?ll=-20.1,-44.9&navigate=yes');
+  });
+  it('sem coords mas com endereço → Waze por query', () => {
+    expect(navLink('Rua X, 10, Divinópolis, MG', null, null))
+      .toBe('https://waze.com/ul?q=Rua%20X%2C%2010%2C%20Divin%C3%B3polis%2C%20MG&navigate=yes');
+  });
+  it('sem coords e sem endereço → null', () => {
+    expect(navLink(null)).toBeNull();
+    expect(navLink('   ')).toBeNull();
+    expect(navLink('', null, null)).toBeNull();
+  });
+});

--- a/src/lib/maps/nav-link.ts
+++ b/src/lib/maps/nav-link.ts
@@ -1,0 +1,17 @@
+/**
+ * Monta um link de navegação Waze a partir de coordenadas ou, na falta, de um
+ * endereço-texto. Retorna null quando não há nem coords nem endereço utilizável
+ * (o call-site esconde o botão "Ir").
+ */
+export function navLink(
+  addressQuery: string | null | undefined,
+  lat?: number | null,
+  lng?: number | null,
+): string | null {
+  if (lat != null && lng != null) {
+    return `https://waze.com/ul?ll=${lat},${lng}&navigate=yes`;
+  }
+  const q = (addressQuery ?? '').trim();
+  if (q.length === 0) return null;
+  return `https://waze.com/ul?q=${encodeURIComponent(q)}&navigate=yes`;
+}

--- a/src/lib/visitas/__tests__/visita-status.test.ts
+++ b/src/lib/visitas/__tests__/visita-status.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { deriveVisitaStatus } from '../visita-status';
+
+describe('deriveVisitaStatus', () => {
+  const hoje = '2026-05-30';
+  it('realizada/cancelada passam direto', () => {
+    expect(deriveVisitaStatus('2026-05-01', 'realizada', hoje)).toBe('realizada');
+    expect(deriveVisitaStatus('2026-06-10', 'cancelada', hoje)).toBe('cancelada');
+  });
+  it('pendente no passado → atrasada', () => {
+    expect(deriveVisitaStatus('2026-05-29', 'pendente', hoje)).toBe('atrasada');
+  });
+  it('pendente hoje → hoje', () => {
+    expect(deriveVisitaStatus('2026-05-30', 'pendente', hoje)).toBe('hoje');
+  });
+  it('pendente no futuro → futura', () => {
+    expect(deriveVisitaStatus('2026-06-01', 'pendente', hoje)).toBe('futura');
+  });
+});

--- a/src/lib/visitas/today.ts
+++ b/src/lib/visitas/today.ts
@@ -1,0 +1,4 @@
+/** Data de hoje em ISO 'YYYY-MM-DD' (UTC, consistente com a convenção do route planner). */
+export function hojeISO(): string {
+  return new Date().toISOString().split('T')[0];
+}

--- a/src/lib/visitas/visita-status.ts
+++ b/src/lib/visitas/visita-status.ts
@@ -1,0 +1,18 @@
+export type VisitaStatusDerivado = 'realizada' | 'cancelada' | 'atrasada' | 'hoje' | 'futura';
+
+/**
+ * Deriva o estado de exibição de uma visita agendada. 'atrasada' NÃO é coluna no
+ * banco — é pendente com scheduled_date < hoje. Datas em ISO 'YYYY-MM-DD' (comparação
+ * lexicográfica = cronológica nesse formato).
+ */
+export function deriveVisitaStatus(
+  scheduledDate: string,
+  status: string,
+  today: string,
+): VisitaStatusDerivado {
+  if (status === 'realizada') return 'realizada';
+  if (status === 'cancelada') return 'cancelada';
+  if (scheduledDate < today) return 'atrasada';
+  if (scheduledDate === today) return 'hoje';
+  return 'futura';
+}

--- a/src/pages/AdminRoutePlanner.tsx
+++ b/src/pages/AdminRoutePlanner.tsx
@@ -14,6 +14,7 @@ import { PlanningModeSelector } from '@/components/reposicao/routePlanner/Planni
 import { PeriodFilter } from '@/components/reposicao/routePlanner/PeriodFilter';
 import { RouteActionButtons } from '@/components/reposicao/routePlanner/RouteActionButtons';
 import { ManualModeCard } from '@/components/reposicao/routePlanner/ManualModeCard';
+import { ScheduledVisitsPanel } from '@/components/reposicao/routePlanner/ScheduledVisitsPanel';
 import { useRoutePlanner } from '@/hooks/useRoutePlanner';
 
 // Fix default marker icons for Leaflet + bundlers
@@ -180,6 +181,9 @@ const AdminRoutePlanner = () => {
 
         {/* Stats */}
         <StatsStrip planningMode={planningMode} stopCounts={stopCounts} />
+
+        {/* Próximas visitas agendadas */}
+        <ScheduledVisitsPanel />
 
         {/* Map */}
         <Card className="overflow-hidden">

--- a/supabase/migrations/20260530120000_visitas_agendadas.sql
+++ b/supabase/migrations/20260530120000_visitas_agendadas.sql
@@ -1,5 +1,6 @@
 -- visitas_agendadas: fila persistente de visitas datadas, owner-scoped.
-CREATE TABLE public.visitas_agendadas (
+-- Idempotente: pode rerodar (IF NOT EXISTS / DROP ... IF EXISTS / CREATE OR REPLACE).
+CREATE TABLE IF NOT EXISTS public.visitas_agendadas (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   customer_user_id uuid NOT NULL,
   scheduled_by uuid NOT NULL,
@@ -14,17 +15,17 @@ CREATE TABLE public.visitas_agendadas (
 );
 
 -- Anti-duplicata: 1 pendente por (cliente, vendedor, data).
-CREATE UNIQUE INDEX uq_vag_pendente_cliente_vendedor_data
+CREATE UNIQUE INDEX IF NOT EXISTS uq_vag_pendente_cliente_vendedor_data
   ON public.visitas_agendadas (customer_user_id, scheduled_by, scheduled_date)
   WHERE status = 'pendente';
 -- Uma visita realizada fecha no máximo uma agenda.
-CREATE UNIQUE INDEX uq_vag_route_visit_id
+CREATE UNIQUE INDEX IF NOT EXISTS uq_vag_route_visit_id
   ON public.visitas_agendadas (route_visit_id)
   WHERE route_visit_id IS NOT NULL;
 -- Calendário do vendedor.
-CREATE INDEX idx_vag_scheduled_by_date
+CREATE INDEX IF NOT EXISTS idx_vag_scheduled_by_date
   ON public.visitas_agendadas (scheduled_by, scheduled_date);
-CREATE INDEX idx_vag_pending_by_seller
+CREATE INDEX IF NOT EXISTS idx_vag_pending_by_seller
   ON public.visitas_agendadas (scheduled_by, scheduled_date)
   WHERE status = 'pendente';
 
@@ -33,6 +34,7 @@ CREATE OR REPLACE FUNCTION public.set_updated_at_visitas_agendadas()
 RETURNS trigger LANGUAGE plpgsql AS $$
 BEGIN NEW.updated_at = now(); RETURN NEW; END;
 $$;
+DROP TRIGGER IF EXISTS trg_vag_updated_at ON public.visitas_agendadas;
 CREATE TRIGGER trg_vag_updated_at
   BEFORE UPDATE ON public.visitas_agendadas
   FOR EACH ROW EXECUTE FUNCTION public.set_updated_at_visitas_agendadas();
@@ -48,6 +50,7 @@ GRANT SELECT, INSERT ON public.visitas_agendadas TO authenticated;
 GRANT UPDATE (scheduled_date, visit_type, notes, status) ON public.visitas_agendadas TO authenticated;
 -- (sem UPDATE em scheduled_by/customer_user_id/route_visit_id → imutáveis; sem DELETE; anon sem nada)
 
+DROP POLICY IF EXISTS "vag_select_own" ON public.visitas_agendadas;
 CREATE POLICY "vag_select_own" ON public.visitas_agendadas
   FOR SELECT TO authenticated
   USING (
@@ -55,6 +58,7 @@ CREATE POLICY "vag_select_own" ON public.visitas_agendadas
     OR (SELECT public.pode_ver_carteira_completa((SELECT auth.uid())))
   );
 
+DROP POLICY IF EXISTS "vag_insert_own_carteira" ON public.visitas_agendadas;
 CREATE POLICY "vag_insert_own_carteira" ON public.visitas_agendadas
   FOR INSERT TO authenticated
   WITH CHECK (
@@ -64,6 +68,7 @@ CREATE POLICY "vag_insert_own_carteira" ON public.visitas_agendadas
     AND route_visit_id IS NULL
   );
 
+DROP POLICY IF EXISTS "vag_update_own_pending" ON public.visitas_agendadas;
 CREATE POLICY "vag_update_own_pending" ON public.visitas_agendadas
   FOR UPDATE TO authenticated
   USING (
@@ -76,6 +81,7 @@ CREATE POLICY "vag_update_own_pending" ON public.visitas_agendadas
     AND route_visit_id IS NULL
   );
 
+DROP POLICY IF EXISTS "vag_delete_gestor" ON public.visitas_agendadas;
 CREATE POLICY "vag_delete_gestor" ON public.visitas_agendadas
   FOR DELETE TO authenticated
   USING ((SELECT public.pode_ver_carteira_completa((SELECT auth.uid()))));
@@ -101,6 +107,7 @@ BEGIN
 END;
 $$;
 
+DROP TRIGGER IF EXISTS trg_reconcile_visita_agendada ON public.route_visits;
 CREATE TRIGGER trg_reconcile_visita_agendada
   AFTER INSERT OR UPDATE OF check_in_at ON public.route_visits
   FOR EACH ROW

--- a/supabase/migrations/20260530120000_visitas_agendadas.sql
+++ b/supabase/migrations/20260530120000_visitas_agendadas.sql
@@ -94,15 +94,28 @@ SECURITY DEFINER
 SET search_path = public
 AS $$
 BEGIN
+  -- Fecha a agenda pendente DEVIDA (scheduled_date <= data do check-in) MAIS ANTIGA
+  -- deste cliente+vendedor. O `<=` cobre visitas ATRASADAS (scheduled_date < hoje),
+  -- não só as do dia exato. Futuras (scheduled_date > visit_date) NÃO são fechadas.
+  -- Idempotente: o NOT EXISTS impede um mesmo route_visit fechar uma 2ª agenda num
+  -- eventual re-disparo (a unique em route_visit_id também barraria).
   UPDATE public.visitas_agendadas va
   SET status = 'realizada',
       route_visit_id = NEW.id,
       updated_at = now()
-  WHERE va.customer_user_id = NEW.customer_user_id
-    AND va.scheduled_by    = NEW.visited_by
-    AND va.scheduled_date  = NEW.visit_date
-    AND va.status = 'pendente'
-    AND va.route_visit_id IS NULL;
+  WHERE va.id = (
+    SELECT v.id FROM public.visitas_agendadas v
+    WHERE v.customer_user_id = NEW.customer_user_id
+      AND v.scheduled_by    = NEW.visited_by
+      AND v.status = 'pendente'
+      AND v.route_visit_id IS NULL
+      AND v.scheduled_date <= NEW.visit_date
+    ORDER BY v.scheduled_date ASC
+    LIMIT 1
+  )
+  AND NOT EXISTS (
+    SELECT 1 FROM public.visitas_agendadas v2 WHERE v2.route_visit_id = NEW.id
+  );
   RETURN NEW;
 END;
 $$;

--- a/supabase/migrations/20260530120000_visitas_agendadas.sql
+++ b/supabase/migrations/20260530120000_visitas_agendadas.sql
@@ -95,10 +95,11 @@ SET search_path = public
 AS $$
 BEGIN
   -- Fecha a agenda pendente DEVIDA (scheduled_date <= data do check-in) MAIS ANTIGA
-  -- deste cliente+vendedor. O `<=` cobre visitas ATRASADAS (scheduled_date < hoje),
-  -- não só as do dia exato. Futuras (scheduled_date > visit_date) NÃO são fechadas.
-  -- Idempotente: o NOT EXISTS impede um mesmo route_visit fechar uma 2ª agenda num
-  -- eventual re-disparo (a unique em route_visit_id também barraria).
+  -- deste cliente+vendedor. O `<=` cobre visitas ATRASADAS (scheduled_date < hoje).
+  -- Futuras (scheduled_date > visit_date) NÃO são fechadas.
+  -- Os filtros externos `va.status='pendente' AND va.route_visit_id IS NULL` tornam
+  -- um 2º check-in concorrente um no-op (não sobrescreve o route_visit_id do 1º).
+  -- O NOT EXISTS impede um mesmo route_visit fechar uma 2ª agenda num re-disparo.
   UPDATE public.visitas_agendadas va
   SET status = 'realizada',
       route_visit_id = NEW.id,
@@ -113,6 +114,8 @@ BEGIN
     ORDER BY v.scheduled_date ASC
     LIMIT 1
   )
+  AND va.status = 'pendente'
+  AND va.route_visit_id IS NULL
   AND NOT EXISTS (
     SELECT 1 FROM public.visitas_agendadas v2 WHERE v2.route_visit_id = NEW.id
   );

--- a/supabase/migrations/20260530120000_visitas_agendadas.sql
+++ b/supabase/migrations/20260530120000_visitas_agendadas.sql
@@ -1,0 +1,108 @@
+-- visitas_agendadas: fila persistente de visitas datadas, owner-scoped.
+CREATE TABLE public.visitas_agendadas (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  customer_user_id uuid NOT NULL,
+  scheduled_by uuid NOT NULL,
+  scheduled_date date NOT NULL,
+  status text NOT NULL DEFAULT 'pendente',
+  visit_type text NOT NULL DEFAULT 'comercial',
+  notes text,
+  route_visit_id uuid REFERENCES public.route_visits(id),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT visitas_agendadas_status_check CHECK (status IN ('pendente','realizada','cancelada'))
+);
+
+-- Anti-duplicata: 1 pendente por (cliente, vendedor, data).
+CREATE UNIQUE INDEX uq_vag_pendente_cliente_vendedor_data
+  ON public.visitas_agendadas (customer_user_id, scheduled_by, scheduled_date)
+  WHERE status = 'pendente';
+-- Uma visita realizada fecha no máximo uma agenda.
+CREATE UNIQUE INDEX uq_vag_route_visit_id
+  ON public.visitas_agendadas (route_visit_id)
+  WHERE route_visit_id IS NOT NULL;
+-- Calendário do vendedor.
+CREATE INDEX idx_vag_scheduled_by_date
+  ON public.visitas_agendadas (scheduled_by, scheduled_date);
+CREATE INDEX idx_vag_pending_by_seller
+  ON public.visitas_agendadas (scheduled_by, scheduled_date)
+  WHERE status = 'pendente';
+
+-- updated_at automático.
+CREATE OR REPLACE FUNCTION public.set_updated_at_visitas_agendadas()
+RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN NEW.updated_at = now(); RETURN NEW; END;
+$$;
+CREATE TRIGGER trg_vag_updated_at
+  BEFORE UPDATE ON public.visitas_agendadas
+  FOR EACH ROW EXECUTE FUNCTION public.set_updated_at_visitas_agendadas();
+
+-- RLS + grants endurecidos.
+ALTER TABLE public.visitas_agendadas ENABLE ROW LEVEL SECURITY;
+
+-- ⚠️ Supabase concede privilégios DEFAULT em tabela nova do public p/ anon/authenticated.
+-- Sem REVOKE primeiro, o GRANT por coluna NÃO surte efeito (o UPDATE cheio default fica).
+REVOKE ALL ON public.visitas_agendadas FROM anon, authenticated, PUBLIC;
+
+GRANT SELECT, INSERT ON public.visitas_agendadas TO authenticated;
+GRANT UPDATE (scheduled_date, visit_type, notes, status) ON public.visitas_agendadas TO authenticated;
+-- (sem UPDATE em scheduled_by/customer_user_id/route_visit_id → imutáveis; sem DELETE; anon sem nada)
+
+CREATE POLICY "vag_select_own" ON public.visitas_agendadas
+  FOR SELECT TO authenticated
+  USING (
+    scheduled_by = (SELECT auth.uid())
+    OR (SELECT public.pode_ver_carteira_completa((SELECT auth.uid())))
+  );
+
+CREATE POLICY "vag_insert_own_carteira" ON public.visitas_agendadas
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    scheduled_by = (SELECT auth.uid())
+    AND public.carteira_visivel_para(customer_user_id, (SELECT auth.uid()))
+    AND status = 'pendente'
+    AND route_visit_id IS NULL
+  );
+
+CREATE POLICY "vag_update_own_pending" ON public.visitas_agendadas
+  FOR UPDATE TO authenticated
+  USING (
+    scheduled_by = (SELECT auth.uid())
+    AND status = 'pendente'
+  )
+  WITH CHECK (
+    scheduled_by = (SELECT auth.uid())
+    AND status IN ('pendente','cancelada')
+    AND route_visit_id IS NULL
+  );
+
+CREATE POLICY "vag_delete_gestor" ON public.visitas_agendadas
+  FOR DELETE TO authenticated
+  USING ((SELECT public.pode_ver_carteira_completa((SELECT auth.uid()))));
+
+-- Reconciliação: check-in no route_visits fecha a agenda pendente correspondente.
+CREATE OR REPLACE FUNCTION public.reconcile_visita_agendada()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  UPDATE public.visitas_agendadas va
+  SET status = 'realizada',
+      route_visit_id = NEW.id,
+      updated_at = now()
+  WHERE va.customer_user_id = NEW.customer_user_id
+    AND va.scheduled_by    = NEW.visited_by
+    AND va.scheduled_date  = NEW.visit_date
+    AND va.status = 'pendente'
+    AND va.route_visit_id IS NULL;
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER trg_reconcile_visita_agendada
+  AFTER INSERT OR UPDATE OF check_in_at ON public.route_visits
+  FOR EACH ROW
+  WHEN (NEW.check_in_at IS NOT NULL)
+  EXECUTE FUNCTION public.reconcile_visita_agendada();


### PR DESCRIPTION
## Resumo

Fila persistente de **visitas agendadas (datadas)** que o vendedor cria manualmente "furando o filtro" do sistema de sugestão — para visitar um cliente **da carteira dele** que o score não priorizou.

- **Nova tabela `visitas_agendadas`** (owner-scoped) + **RLS endurecida** (GRANT por coluna → `scheduled_by`/`customer_user_id`/`route_visit_id` imutáveis pro vendedor; INSERT travado na carteira via `carteira_visivel_para`; sem DELETE pro vendedor; leitura de time pra gestor/master) + **trigger de reconciliação** no `route_visits` (check-in fecha a agenda, cobre **atrasadas**, concorrência-safe, idempotente).
- **Dialog "Agendar visita"** (data + nota) a partir de **2 entradas**: dropdown do `Customer360View` (liga o item antes desabilitado) **e** botão no header do `CustomerHero`.
- **Painel "Próximas visitas"** no route planner (`/admin/route-planner`): lista as pendentes por data (destaque pra **atrasada**), com **"Ir" (Waze)**, **check-in 1-toque** e cancelar. Auto-resolve nome/endereço do cliente.
- **Helpers puros (TDD):** `deriveVisitaStatus` e `navLink` (Waze) — este último também deduplica o `openInWaze` existente do route planner (DRY).
- **Hardening + 2 passadas adversárias do codex no SQL** (a 2ª pegou um furo de concorrência no trigger; corrigido).

Spec: `docs/superpowers/specs/2026-05-30-agendar-visita-design.md` · Plano: `docs/superpowers/plans/2026-05-30-agendar-visita.md`

---

## ⚠️ Migration manual necessária

O Lovable Cloud **não** aplica migrations custom automaticamente. Após o merge:

**🟣 Lovable → SQL Editor → cola o bloco → Run** (idempotente, pode rerodar):

\`\`\`sql
-- visitas_agendadas: fila persistente de visitas datadas, owner-scoped.
-- Idempotente: pode rerodar (IF NOT EXISTS / DROP ... IF EXISTS / CREATE OR REPLACE).
CREATE TABLE IF NOT EXISTS public.visitas_agendadas (
  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
  customer_user_id uuid NOT NULL,
  scheduled_by uuid NOT NULL,
  scheduled_date date NOT NULL,
  status text NOT NULL DEFAULT 'pendente',
  visit_type text NOT NULL DEFAULT 'comercial',
  notes text,
  route_visit_id uuid REFERENCES public.route_visits(id),
  created_at timestamptz NOT NULL DEFAULT now(),
  updated_at timestamptz NOT NULL DEFAULT now(),
  CONSTRAINT visitas_agendadas_status_check CHECK (status IN ('pendente','realizada','cancelada'))
);

CREATE UNIQUE INDEX IF NOT EXISTS uq_vag_pendente_cliente_vendedor_data
  ON public.visitas_agendadas (customer_user_id, scheduled_by, scheduled_date)
  WHERE status = 'pendente';
CREATE UNIQUE INDEX IF NOT EXISTS uq_vag_route_visit_id
  ON public.visitas_agendadas (route_visit_id)
  WHERE route_visit_id IS NOT NULL;
CREATE INDEX IF NOT EXISTS idx_vag_scheduled_by_date
  ON public.visitas_agendadas (scheduled_by, scheduled_date);
CREATE INDEX IF NOT EXISTS idx_vag_pending_by_seller
  ON public.visitas_agendadas (scheduled_by, scheduled_date)
  WHERE status = 'pendente';

CREATE OR REPLACE FUNCTION public.set_updated_at_visitas_agendadas()
RETURNS trigger LANGUAGE plpgsql AS $$
BEGIN NEW.updated_at = now(); RETURN NEW; END;
$$;
DROP TRIGGER IF EXISTS trg_vag_updated_at ON public.visitas_agendadas;
CREATE TRIGGER trg_vag_updated_at
  BEFORE UPDATE ON public.visitas_agendadas
  FOR EACH ROW EXECUTE FUNCTION public.set_updated_at_visitas_agendadas();

ALTER TABLE public.visitas_agendadas ENABLE ROW LEVEL SECURITY;

REVOKE ALL ON public.visitas_agendadas FROM anon, authenticated, PUBLIC;
GRANT SELECT, INSERT ON public.visitas_agendadas TO authenticated;
GRANT UPDATE (scheduled_date, visit_type, notes, status) ON public.visitas_agendadas TO authenticated;

DROP POLICY IF EXISTS "vag_select_own" ON public.visitas_agendadas;
CREATE POLICY "vag_select_own" ON public.visitas_agendadas
  FOR SELECT TO authenticated
  USING (
    scheduled_by = (SELECT auth.uid())
    OR (SELECT public.pode_ver_carteira_completa((SELECT auth.uid())))
  );

DROP POLICY IF EXISTS "vag_insert_own_carteira" ON public.visitas_agendadas;
CREATE POLICY "vag_insert_own_carteira" ON public.visitas_agendadas
  FOR INSERT TO authenticated
  WITH CHECK (
    scheduled_by = (SELECT auth.uid())
    AND public.carteira_visivel_para(customer_user_id, (SELECT auth.uid()))
    AND status = 'pendente'
    AND route_visit_id IS NULL
  );

DROP POLICY IF EXISTS "vag_update_own_pending" ON public.visitas_agendadas;
CREATE POLICY "vag_update_own_pending" ON public.visitas_agendadas
  FOR UPDATE TO authenticated
  USING (
    scheduled_by = (SELECT auth.uid())
    AND status = 'pendente'
  )
  WITH CHECK (
    scheduled_by = (SELECT auth.uid())
    AND status IN ('pendente','cancelada')
    AND route_visit_id IS NULL
  );

DROP POLICY IF EXISTS "vag_delete_gestor" ON public.visitas_agendadas;
CREATE POLICY "vag_delete_gestor" ON public.visitas_agendadas
  FOR DELETE TO authenticated
  USING ((SELECT public.pode_ver_carteira_completa((SELECT auth.uid()))));

CREATE OR REPLACE FUNCTION public.reconcile_visita_agendada()
RETURNS trigger
LANGUAGE plpgsql
SECURITY DEFINER
SET search_path = public
AS $$
BEGIN
  UPDATE public.visitas_agendadas va
  SET status = 'realizada',
      route_visit_id = NEW.id,
      updated_at = now()
  WHERE va.id = (
    SELECT v.id FROM public.visitas_agendadas v
    WHERE v.customer_user_id = NEW.customer_user_id
      AND v.scheduled_by    = NEW.visited_by
      AND v.status = 'pendente'
      AND v.route_visit_id IS NULL
      AND v.scheduled_date <= NEW.visit_date
    ORDER BY v.scheduled_date ASC
    LIMIT 1
  )
  AND va.status = 'pendente'
  AND va.route_visit_id IS NULL
  AND NOT EXISTS (
    SELECT 1 FROM public.visitas_agendadas v2 WHERE v2.route_visit_id = NEW.id
  );
  RETURN NEW;
END;
$$;

DROP TRIGGER IF EXISTS trg_reconcile_visita_agendada ON public.route_visits;
CREATE TRIGGER trg_reconcile_visita_agendada
  AFTER INSERT OR UPDATE OF check_in_at ON public.route_visits
  FOR EACH ROW
  WHEN (NEW.check_in_at IS NOT NULL)
  EXECUTE FUNCTION public.reconcile_visita_agendada();
\`\`\`

**Validação pós-apply** (colar e Run — esperado: `policies=4, recon_trigger=1, indexes>=5`):

\`\`\`sql
SELECT 'visitas_agendadas OK' AS status,
  (SELECT count(*) FROM pg_policies WHERE tablename='visitas_agendadas') AS policies,
  (SELECT count(*) FROM pg_trigger WHERE tgname='trg_reconcile_visita_agendada') AS recon_trigger,
  (SELECT count(*) FROM pg_indexes WHERE tablename='visitas_agendadas') AS indexes;
\`\`\`

**Depois:** regenerar os **tipos Supabase** via Lovable (pra `visitas_agendadas` entrar em `src/integrations/supabase/types.ts`). Até lá, o front usa um cast isolado em `src/integrations/supabase/visitasAgendadas.ts` (funciona, mas o ideal é simplificar pós-regen).

---

## Test Plan

- [x] `bun run test` — 1760/1760 (inclui `deriveVisitaStatus` + `navLink`)
- [x] `bun run typecheck:strict` + `bunx tsc --noEmit -p tsconfig.app.json` — 0 erros
- [x] `bun lint` — 0 errors
- [ ] **Aplicar a migration no Lovable** + regenerar tipos (passos acima)
- [ ] **QA no device** (headless não renderiza a SPA): agendar pelos 2 pontos; ver na agenda; "Ir" abre Waze; **check-in fecha a agenda** (inclusive uma **atrasada**); duplicata mostra o toast certo
- [ ] **QA de segurança** (SQL Editor, JWT de vendedor): confirmar que `authenticated` NÃO consegue `UPDATE` de `route_visit_id`/`customer_user_id`/`status='realizada'` nem `DELETE`; `anon` não enxerga a tabela

## Fora de escopo / limitações v1
- **Fase 2 (PR à parte):** agendadas de hoje como **parada no mapa** do route planner (4ª fonte — toca o god-hook `useRoutePlanner`).
- **Geofence/auto check-in-out:** deferido (inviável confiável em web/PWA) — spec própria.
- Reatribuição de carteira (agenda velha fica com o vendedor antigo, que pode cancelar); check-in de cobertura não fecha a agenda do dono; visita feita ANTES da data agendada não auto-reconcilia.
- **Follow-up de gating de rota** (registrado à parte): `/admin/*` é alcançável por customer aprovado (ProtectedRoute só checa aprovação) — RLS protege os dados; é hardening de navegação, não desta feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)