### PR TITLE
fix(sentinela): restaura split de portal do #490 (regressão da Fase 2/#493) + higiene de cancelamento

### DIFF
--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,15 +21,15 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **121** custom migrations totais
-- **522** objetos esperados (criados por estas migrations)
+- **125** custom migrations totais
+- **541** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
-  - `rls_policy`: 142
-  - `index`: 100
-  - `function`: 95
-  - `cron_job`: 88
-  - `table`: 61
-  - `trigger`: 32
+  - `rls_policy`: 146
+  - `index`: 104
+  - `function`: 102
+  - `cron_job`: 89
+  - `table`: 62
+  - `trigger`: 34
   - `enum_value`: 4
 
 ## Inventário por migration
@@ -1093,6 +1093,24 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | `function` | `public._data_health_compute` | — |
 | `function` | `public.fin_sync_heartbeat` | — |
 
+### `20260530120000_visitas_agendadas.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `table` | `public.visitas_agendadas` | — |
+| `index` | `public.uq_vag_pendente_cliente_vendedor_data` | `visitas_agendadas` |
+| `index` | `public.uq_vag_route_visit_id` | `visitas_agendadas` |
+| `index` | `public.idx_vag_scheduled_by_date` | `visitas_agendadas` |
+| `index` | `public.idx_vag_pending_by_seller` | `visitas_agendadas` |
+| `function` | `public.set_updated_at_visitas_agendadas` | — |
+| `function` | `public.reconcile_visita_agendada` | — |
+| `trigger` | `public.trg_vag_updated_at` | `visitas_agendadas` |
+| `trigger` | `public.trg_reconcile_visita_agendada` | `route_visits` |
+| `rls_policy` | `public.vag_select_own` | `visitas_agendadas` |
+| `rls_policy` | `public.vag_insert_own_carteira` | `visitas_agendadas` |
+| `rls_policy` | `public.vag_update_own_pending` | `visitas_agendadas` |
+| `rls_policy` | `public.vag_delete_gestor` | `visitas_agendadas` |
+
 ### `20260530140000_fin_watchdog_sync_stale_grace_email.sql`
 
 | Tipo | Objeto | Parent |
@@ -1142,6 +1160,27 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | Tipo | Objeto | Parent |
 | --- | --- | --- |
 | `function` | `public._data_health_compute` | — |
+
+### `20260530200000_reposicao_classificar_sayerlack_grupo_default.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `public.classificar_sayerlack_grupo_default` | — |
+| `cron_job` | `cron.reposicao-classificar-sayerlack-grupo` | — |
+
+### `20260530210000_data_health_restaura_portal_split.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `public._data_health_compute` | — |
+| `function` | `public.data_health_watchdog` | — |
+| `function` | `public.fin_sync_heartbeat` | — |
+
+### `20260530210001_cancelar_pedido_limpa_portal.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `public.cancelar_pedido_sugerido` | — |
 
 ## Próximos passos quando algo der `❌`
 

--- a/docs/superpowers/plans/2026-05-28-portal-sayerlack-robustez.md
+++ b/docs/superpowers/plans/2026-05-28-portal-sayerlack-robustez.md
@@ -8,9 +8,31 @@
 > (`erro_nao_retentavel→falha_envio`) viraram **cleanup futuro de higiene** (o motor já ignora cancelados; a
 > Fase 2 tira o falso-positivo sem mexer na máquina de estados recém-estabilizada).
 > **Fase 0 (reset) e Fase 2 (filtros acionáveis nos checks) é o que entreguei.** Migration
-> `20260530200000_data_health_checks_acionaveis.sql`. **Follow-up de higiene pendente:** Fix 1.1 (cancelar limpa
-> portal) + filtro de cancelados na aba Pendentes do `AdminPortalSayerlack` (artefatos guardados em `/tmp/fase1-ref/`).
-> **LIÇÃO:** re-checar `gh pr list`/main ANTES de cada fase, não só no início (§14). Esta saga foi um caso-escola.
+> `20260530200000_data_health_checks_acionaveis.sql` (#493).
+>
+> ⚠️ **ATUALIZAÇÃO 2026-05-30 (2) — minha Fase 2 REGREDIU o #490 (cascata multi-sessão), CORRIGIDA:**
+> Enquanto eu fazia a Fase 2 (#493), OUTRA sessão entregou o **#490** (`20260530190000_data_health_portal_push.sql`):
+> **promoveu disparo/portal ao push E dividiu `reposicao_portal` em dois** — `reposicao_portal_pipeline`
+> (automático DEVERIA drenar) × `reposicao_portal_humano` (precisa de gente) — recriando `data_health_watchdog`
+> + `fin_sync_heartbeat` com o IN-list ampliado (6→9 fontes no push). Minha #493 partiu do corpo do #460/#194751
+> (sem o split), então **reverteu o `_data_health_compute` pro `reposicao_portal` único** e **NÃO** recriou
+> watchdog/heartbeat → o watchdog do #490 ficou procurando `reposicao_portal_pipeline`/`_humano` que o compute
+> não produzia mais = **push de portal quebrado**. **Fix-forward:** `20260530210000_data_health_restaura_portal_split.sql`
+> = **#490 VERBATIM** (SQL idêntico, só cabeçalho anti-cascata) — supersede a #493 por timestamp + CREATE OR REPLACE.
+> O split pipeline/humano é estritamente MAIS acionável que o filtro de check-único da #493 (que o split já subsume),
+> e o `reposicao_disparo` é idêntico nas duas → restaurar #490 não perde nada. Validado em Postgres 17 efêmero
+> (14 checks, watchdog/heartbeat OK).
+>
+> ✅ **Fix 1.1 (higiene de cancelamento) ENTREGUE nesta PR:** `20260530210001_cancelar_pedido_limpa_portal.sql`
+> (RPC `cancelar_pedido_sugerido` agora zera `status_envio_portal='nao_aplicavel'` + `portal_proximo_retry_em=NULL`,
+> guard `disparado/concluido_recebido` preservado, corpo verbatim do schema-snapshot 843-866 + 2 linhas) +
+> espelho no frontend (`useDetalhesModal.ts`, bloco de cancelamento por remoção de todos os itens). Artefatos
+> antigos guardados em `/tmp/fase1-ref/`.
+>
+> **LIÇÃO (reforçada):** re-checar `gh pr list`/main ANTES de cada fase, não só no início (§14). Esta saga foi
+> um caso-escola DUPLO: o `_data_health_compute` é arquivo quente multi-sessão; 3 sessões o tocaram em paralelo
+> (#460, #490, #493) e a regressão por CREATE OR REPLACE de corpo velho é silenciosa. Mitigação: cabeçalho que
+> manda a próxima sessão "partir DESTA migração (maior timestamp)".
 
 > **For agentic workers:** Use superpowers:executing-plans para executar fase a fase, com checkpoint de revisão entre fases. Cada fase que toca banco/edge **não** roda no merge — vira bloco SQL pro SQL Editor do Lovable (ritual `lovable-db-operator`) e/ou deploy manual de edge via chat do Lovable. Steps usam checkbox (`- [ ]`).
 

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 121
+-- Total de custom migrations: 125
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -133,6 +133,7 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260528140000', 'whatsapp_fundacao', '20260528140000_whatsapp_fundacao.sql'),
   ('20260528150000', 'fin_estoque_omie_feed', '20260528150000_fin_estoque_omie_feed.sql'),
   ('20260528194751', 'data_health_consolida_last_error_e_reposicao_checks', '20260528194751_data_health_consolida_last_error_e_reposicao_checks.sql'),
+  ('20260530120000', 'visitas_agendadas', '20260530120000_visitas_agendadas.sql'),
   ('20260530140000', 'fin_watchdog_sync_stale_grace_email', '20260530140000_fin_watchdog_sync_stale_grace_email.sql'),
   ('20260530143818', 'reposicao_excluir_405ml', '20260530143818_reposicao_excluir_405ml.sql'),
   ('20260530160000', 'data_health_diagnostico_gate_status', '20260530160000_data_health_diagnostico_gate_status.sql'),
@@ -140,7 +141,10 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260530180000', 'fix_sku_fornecedor_externo_atualizado_em_trigger', '20260530180000_fix_sku_fornecedor_externo_atualizado_em_trigger.sql'),
   ('20260530190000', 'data_health_portal_push', '20260530190000_data_health_portal_push.sql'),
   ('20260530190000', 'reposicao_preencher_parametros_faltantes', '20260530190000_reposicao_preencher_parametros_faltantes.sql'),
-  ('20260530200000', 'data_health_checks_acionaveis', '20260530200000_data_health_checks_acionaveis.sql')
+  ('20260530200000', 'data_health_checks_acionaveis', '20260530200000_data_health_checks_acionaveis.sql'),
+  ('20260530200000', 'reposicao_classificar_sayerlack_grupo_default', '20260530200000_reposicao_classificar_sayerlack_grupo_default.sql'),
+  ('20260530210000', 'data_health_restaura_portal_split', '20260530210000_data_health_restaura_portal_split.sql'),
+  ('20260530210001', 'cancelar_pedido_limpa_portal', '20260530210001_cancelar_pedido_limpa_portal.sql')
 )
 SELECT
   e.version,
@@ -670,6 +674,19 @@ WITH expected_objects (migration, kind, schema_name, object_name, parent_name) A
   ('fin_estoque_omie_feed', 'cron_job', 'cron', 'sync-inventory-servicos-1h', ''),
   ('data_health_consolida_last_error_e_reposicao_checks', 'function', 'public', '_data_health_compute', ''),
   ('data_health_consolida_last_error_e_reposicao_checks', 'function', 'public', 'fin_sync_heartbeat', ''),
+  ('visitas_agendadas', 'table', 'public', 'visitas_agendadas', ''),
+  ('visitas_agendadas', 'index', 'public', 'uq_vag_pendente_cliente_vendedor_data', 'visitas_agendadas'),
+  ('visitas_agendadas', 'index', 'public', 'uq_vag_route_visit_id', 'visitas_agendadas'),
+  ('visitas_agendadas', 'index', 'public', 'idx_vag_scheduled_by_date', 'visitas_agendadas'),
+  ('visitas_agendadas', 'index', 'public', 'idx_vag_pending_by_seller', 'visitas_agendadas'),
+  ('visitas_agendadas', 'function', 'public', 'set_updated_at_visitas_agendadas', ''),
+  ('visitas_agendadas', 'function', 'public', 'reconcile_visita_agendada', ''),
+  ('visitas_agendadas', 'trigger', 'public', 'trg_vag_updated_at', 'visitas_agendadas'),
+  ('visitas_agendadas', 'trigger', 'public', 'trg_reconcile_visita_agendada', 'route_visits'),
+  ('visitas_agendadas', 'rls_policy', 'public', 'vag_select_own', 'visitas_agendadas'),
+  ('visitas_agendadas', 'rls_policy', 'public', 'vag_insert_own_carteira', 'visitas_agendadas'),
+  ('visitas_agendadas', 'rls_policy', 'public', 'vag_update_own_pending', 'visitas_agendadas'),
+  ('visitas_agendadas', 'rls_policy', 'public', 'vag_delete_gestor', 'visitas_agendadas'),
   ('fin_watchdog_sync_stale_grace_email', 'function', 'public', 'fin_sync_watchdog_check', ''),
   ('reposicao_excluir_405ml', 'function', 'public', 'gerar_pedidos_sugeridos_ciclo', ''),
   ('data_health_diagnostico_gate_status', 'function', 'public', '_data_health_compute', ''),
@@ -680,7 +697,13 @@ WITH expected_objects (migration, kind, schema_name, object_name, parent_name) A
   ('data_health_portal_push', 'function', 'public', 'fin_sync_heartbeat', ''),
   ('reposicao_preencher_parametros_faltantes', 'function', 'public', 'preencher_parametros_faltantes_skus', ''),
   ('reposicao_preencher_parametros_faltantes', 'cron_job', 'cron', 'reposicao-preencher-parametros-faltantes', ''),
-  ('data_health_checks_acionaveis', 'function', 'public', '_data_health_compute', '')
+  ('data_health_checks_acionaveis', 'function', 'public', '_data_health_compute', ''),
+  ('reposicao_classificar_sayerlack_grupo_default', 'function', 'public', 'classificar_sayerlack_grupo_default', ''),
+  ('reposicao_classificar_sayerlack_grupo_default', 'cron_job', 'cron', 'reposicao-classificar-sayerlack-grupo', ''),
+  ('data_health_restaura_portal_split', 'function', 'public', '_data_health_compute', ''),
+  ('data_health_restaura_portal_split', 'function', 'public', 'data_health_watchdog', ''),
+  ('data_health_restaura_portal_split', 'function', 'public', 'fin_sync_heartbeat', ''),
+  ('cancelar_pedido_limpa_portal', 'function', 'public', 'cancelar_pedido_sugerido', '')
 )
 SELECT
   e.migration,

--- a/src/components/reposicao/pedidos/useDetalhesModal.ts
+++ b/src/components/reposicao/pedidos/useDetalhesModal.ts
@@ -251,6 +251,10 @@ export function useDetalhesModal({ pedido, open, onOpenChange, onApproved }: Use
       updates.cancelado_por = user?.email ?? 'sistema';
       updates.cancelado_em = new Date().toISOString();
       updates.justificativa_cancelamento = 'Todos os itens foram removidos manualmente';
+      // Higiene de estado: cancelar limpa o sub-fluxo do portal (espelha cancelar_pedido_sugerido)
+      // — senão um cancelado fica com status_envio_portal sujo e o check reposicao_portal_pipeline o conta.
+      updates.status_envio_portal = 'nao_aplicavel';
+      updates.portal_proximo_retry_em = null;
     }
     const { error: errPed } = await supabase
       .from('pedido_compra_sugerido')

--- a/supabase/migrations/20260530210000_data_health_restaura_portal_split.sql
+++ b/supabase/migrations/20260530210000_data_health_restaura_portal_split.sql
@@ -1,0 +1,404 @@
+-- ⚠️ RESTAURAÇÃO ANTI-CASCATA (2026-05-30, fix da regressão do PR #493):
+--   A 20260530200000 (#493, "filtros acionáveis") foi construída do corpo do #460 (reposicao_portal
+--   ÚNICO) e, por ter timestamp maior, REVERTEU a divisão pipeline×humano do #490 (20260530190000).
+--   Como o #493 não tocou data_health_watchdog/fin_sync_heartbeat (que o #490 fez referenciar
+--   reposicao_portal_pipeline/humano), o push do portal dessincronizou — o watchdog passou a procurar
+--   sources que o compute não produzia mais. Esta migration RESTAURA o #490 VERBATIM (compute
+--   pipeline/humano + watchdog + heartbeat), re-estabelecendo a consistência. CREATE OR REPLACE
+--   idempotente — só aplica o estado correto, independente do que está no banco. O filtro de cancelados
+--   do #493 é coberto melhor pela higiene (20260530210001: cancelar limpa status_envio_portal na origem).
+--   CORPO ABAIXO = VERBATIM do 20260530190000 (#490). NÃO EDITAR (qualquer edição arrisca nova cascata).
+--   Cabeçalho original do #490 preservado:
+-- ============================================================
+-- Sentinela — promove os checks de AÇÃO da reposição ao PUSH + refina o de portal
+-- ============================================================
+-- ⚠️ DESCOBERTO NO PRÉ-CHECK DO APPLY (2026-05-30): as migrations 20260528020000 (#450) e
+-- 20260528194751 NUNCA foram aplicadas em prod (armadilha §5 — Lovable não aplica migration
+-- custom automaticamente). Prod estava no estado de 11 checks (20260527250000), SEM
+-- reposicao_disparo/reposicao_portal. Como esta é CREATE OR REPLACE (substituição total), ela
+-- é a FONTE VIVA: traz prod de 11→14 checks E incorpora o que a 194751 pretendia mas nunca
+-- chegou (AT TIME ZONE 'America/Sao_Paulo' nas datas exibidas, fix P1 do "erro técnico velho
+-- num card verde" no SELECT final, heartbeat rico) — além do split de portal. Supersede as
+-- duas órfãs (não precisam mais ser aplicadas).
+-- Os checks reposicao_disparo/reposicao_portal existiam (20260528194751) mas só no
+-- dashboard+digest, FORA do push (decisão #450: backlog incerto = ruído). O backlog
+-- foi triado/drenado pelo incidente Sayerlack (#468/#470: motor sayerlack-retry-orfaos
+-- */15 + claim atômico). Foto de prod (2026-05-30): tudo limpo → promover é seguro
+-- (o push só dispara na transição ok→degradado; anti-spam por UNIQUE parcial).
+--
+-- O reposicao_portal antigo só via 'pendente_envio_portal' → CEGO justo nos estados
+-- perigosos do incidente. Refino (eu + codex, consult adversarial): DIVIDIR em dois,
+-- por semântica e SLA distintos —
+--   • reposicao_portal_pipeline (automático DEVERIA drenar): pendente/erro_retentavel
+--     fresco (retry não-futuro, tentativas<3, <3d) + enviando_portal. >1h=stale/>6h=broken.
+--   • reposicao_portal_humano (NÃO drena sozinho): indeterminado_requer_conciliacao
+--     (risco de PO duplicado — o motor NÃO toca), erro_nao_retentavel (SKU sem mapeamento),
+--     aceito_portal_sem_protocolo, falha_envio_portal, erro_retentavel esgotado
+--     (tentativas>=3 ou >3d). >2h=stale/>24h=broken.
+-- reposicao_disparo fica VERBATIM (status='aprovado_aguardando_disparo', >48h/>168h) —
+-- portal-first deixa o pedido travado nesse status, então o portal dispara rápido e o
+-- disparo é a escalação de 48h (codex: cobertura complementar aceitável).
+--
+-- Promove os 3 ao push (data_health_watchdog IN += reposicao_disparo/portal_pipeline/portal_humano,
+-- 6→9). Frontend NÃO muda (get_data_health repassa tudo; SaudeDados agrupa por domain='estoque'
+-- e renderiza c.message). Severidade 'warning' (o push emaila igual; a mensagem carrega a urgência).
+--
+-- Corpo dos 11 checks inalterados (saldo/CR/CP/omie_sync/vendas_pedidos/estoque_inventario/
+-- reposicao_sugestoes/carteira_scores/custos_produtos/vendas_cadastros/alert_channel) +
+-- reposicao_disparo + AT TIME ZONE + fix do SELECT (P1) = VERBATIM da 20260528194751.
+-- Só o bloco reposicao_portal vira 2 blocos, e os IN-list do watchdog/heartbeat são ampliados.
+
+CREATE OR REPLACE FUNCTION public._data_health_compute()
+RETURNS TABLE (
+  source text, domain text, status text,
+  age_seconds bigint, expected_max_age_seconds bigint, freshness_basis text,
+  message text, last_error text, probable_cause text, how_to_fix text, severity text
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+  WITH checks AS (
+    SELECT 'saldo_bancario'::text AS source, 'financeiro'::text AS domain,
+      CASE WHEN max(cc.saldo_data) IS NULL THEN 'broken'
+           WHEN now() - max(cc.saldo_data)::timestamptz > interval '36 hours' THEN 'stale' ELSE 'ok' END AS status,
+      EXTRACT(EPOCH FROM now() - max(cc.saldo_data)::timestamptz)::bigint AS age_seconds,
+      (36*3600)::bigint AS expected_max_age_seconds, 'max_saldo_data'::text AS freshness_basis,
+      CASE WHEN max(cc.saldo_data) IS NULL THEN 'Saldo bancário nunca sincronizou'
+           ELSE 'Saldo bancário: último sync ' || to_char(max(cc.saldo_data), 'DD/MM') END AS message,
+      NULL::text AS last_error,
+      CASE WHEN max(cc.saldo_data) IS NULL THEN 'ListarExtrato falhando ou nunca rodou' ELSE NULL END AS probable_cause,
+      'Rode sync_contas_correntes no chat do Lovable e cheque os logs do omie-financeiro'::text AS how_to_fix,
+      'critical'::text AS severity
+    FROM public.fin_contas_correntes cc WHERE cc.ativo = true
+    UNION ALL
+    SELECT 'contas_receber', 'financeiro',
+      CASE WHEN max(cr.updated_at) IS NULL THEN 'broken'
+           WHEN now() - max(cr.updated_at) > interval '26 hours' THEN 'stale' ELSE 'ok' END,
+      EXTRACT(EPOCH FROM now() - max(cr.updated_at))::bigint, (26*3600)::bigint, 'max_updated_at',
+      'Contas a receber: atualizado ' || COALESCE(to_char(max(cr.updated_at) AT TIME ZONE 'America/Sao_Paulo','DD/MM HH24:MI'),'nunca'),
+      NULL, CASE WHEN max(cr.updated_at) IS NULL THEN 'Sync CR nunca completou' ELSE NULL END,
+      'Rode sync_contas_receber no Lovable', 'warning'
+    FROM public.fin_contas_receber cr
+    UNION ALL
+    SELECT 'contas_pagar', 'financeiro',
+      CASE WHEN max(cp.updated_at) IS NULL THEN 'broken'
+           WHEN now() - max(cp.updated_at) > interval '26 hours' THEN 'stale' ELSE 'ok' END,
+      EXTRACT(EPOCH FROM now() - max(cp.updated_at))::bigint, (26*3600)::bigint, 'max_updated_at',
+      'Contas a pagar: atualizado ' || COALESCE(to_char(max(cp.updated_at) AT TIME ZONE 'America/Sao_Paulo','DD/MM HH24:MI'),'nunca'),
+      NULL, CASE WHEN max(cp.updated_at) IS NULL THEN 'Sync CP nunca completou' ELSE NULL END,
+      'Rode sync_contas_pagar no Lovable', 'warning'
+    FROM public.fin_contas_pagar cp
+    UNION ALL
+    SELECT 'omie_sync_financeiro'::text, 'omie_sync'::text,
+      COALESCE((SELECT CASE WHEN l.status='error' THEN 'broken' ELSE 'ok' END FROM public.fin_sync_log l
+                WHERE l.completed_at IS NOT NULL ORDER BY l.completed_at DESC LIMIT 1), 'unknown'),
+      (SELECT EXTRACT(EPOCH FROM now() - l.completed_at)::bigint FROM public.fin_sync_log l
+                WHERE l.completed_at IS NOT NULL ORDER BY l.completed_at DESC LIMIT 1),
+      NULL::bigint, 'fin_sync_log'::text,
+      'Último sync financeiro: ' || COALESCE((SELECT l.status FROM public.fin_sync_log l
+        WHERE l.completed_at IS NOT NULL ORDER BY l.completed_at DESC LIMIT 1), 'sem registro'),
+      (SELECT l.error_message FROM public.fin_sync_log l WHERE l.status='error' AND l.completed_at IS NOT NULL ORDER BY l.completed_at DESC LIMIT 1),
+      CASE WHEN (SELECT l.status FROM public.fin_sync_log l WHERE l.completed_at IS NOT NULL ORDER BY l.completed_at DESC LIMIT 1)='error'
+           THEN 'A última action de sync financeiro falhou' ELSE NULL END,
+      'Cheque fin_sync_log e re-rode a action que falhou'::text, 'critical'::text
+    UNION ALL
+    SELECT 'vendas_pedidos'::text, 'vendas'::text,
+      CASE WHEN v.oben_last IS NULL OR v.colacor_last IS NULL THEN 'broken'
+           WHEN now() - LEAST(v.oben_last, v.colacor_last) > interval '6 hours' THEN 'stale' ELSE 'ok' END,
+      EXTRACT(EPOCH FROM now() - LEAST(v.oben_last, v.colacor_last))::bigint,
+      (6*3600)::bigint, 'fin_sync_log.sync_pedidos'::text,
+      'Sync de pedidos: oben ' || COALESCE(to_char(v.oben_last AT TIME ZONE 'America/Sao_Paulo','DD/MM HH24:MI'),'nunca')
+        || ' · colacor ' || COALESCE(to_char(v.colacor_last AT TIME ZONE 'America/Sao_Paulo','DD/MM HH24:MI'),'nunca'),
+      v.last_err,
+      CASE WHEN v.oben_last IS NULL OR v.colacor_last IS NULL
+           THEN 'Cron vendas-sync-pedidos não rodou/completou para alguma conta' ELSE NULL END,
+      'Cheque os crons vendas-sync-pedidos-{oben,colacor}-2h e fin_sync_log (action sync_pedidos)'::text, 'critical'::text
+    FROM (
+      SELECT
+        (SELECT max(l.completed_at) FROM public.fin_sync_log l WHERE l.action='sync_pedidos' AND l.status='complete' AND 'oben' = ANY(l.companies)) AS oben_last,
+        (SELECT max(l.completed_at) FROM public.fin_sync_log l WHERE l.action='sync_pedidos' AND l.status='complete' AND 'colacor' = ANY(l.companies)) AS colacor_last,
+        (SELECT l.error_message FROM public.fin_sync_log l WHERE l.action='sync_pedidos' AND l.status='error' ORDER BY l.started_at DESC LIMIT 1) AS last_err
+    ) v
+    UNION ALL
+    SELECT 'estoque_inventario'::text, 'estoque'::text,
+      CASE WHEN max(ip.synced_at) IS NULL THEN 'broken'
+           WHEN now() - max(ip.synced_at) > interval '3 hours' THEN 'stale' ELSE 'ok' END,
+      EXTRACT(EPOCH FROM now() - max(ip.synced_at))::bigint, (3*3600)::bigint, 'inventory_position.synced_at',
+      'Inventário: sincronizado ' || COALESCE(to_char(max(ip.synced_at) AT TIME ZONE 'America/Sao_Paulo','DD/MM HH24:MI'),'nunca'),
+      NULL, CASE WHEN max(ip.synced_at) IS NULL THEN 'sync_inventory nunca rodou' ELSE NULL END,
+      'Cheque o cron sync-inventory-vendas-30m (omie-analytics-sync sync_inventory)', 'warning'
+    FROM public.inventory_position ip
+    UNION ALL
+    SELECT 'reposicao_sugestoes'::text, 'estoque'::text,
+      CASE WHEN max(pcs.data_ciclo) IS NULL THEN 'broken'
+           WHEN current_date - max(pcs.data_ciclo) > 3 THEN 'stale' ELSE 'ok' END,
+      CASE WHEN max(pcs.data_ciclo) IS NULL THEN NULL
+           ELSE (current_date - max(pcs.data_ciclo))::bigint * 86400 END,
+      (3*86400)::bigint, 'pedido_compra_sugerido.data_ciclo',
+      'Sugestão de compra: último ciclo ' || COALESCE(to_char(max(pcs.data_ciclo),'DD/MM/YYYY'),'nunca'),
+      NULL, CASE WHEN max(pcs.data_ciclo) IS NULL THEN 'gerar-pedidos nunca gerou sugestão' ELSE NULL END,
+      'Cheque o cron gerar-pedidos-diario-oben'::text, 'warning'
+    FROM public.pedido_compra_sugerido pcs
+    UNION ALL
+    SELECT 'carteira_scores'::text, 'carteira'::text,
+      CASE WHEN max(fcs.calculated_at) IS NULL THEN 'broken'
+           WHEN now() - max(fcs.calculated_at) > interval '36 hours' THEN 'stale' ELSE 'ok' END,
+      EXTRACT(EPOCH FROM now() - max(fcs.calculated_at))::bigint, (36*3600)::bigint, 'calculated_at',
+      'Scoring de carteira: recalculado ' || COALESCE(to_char(max(fcs.calculated_at) AT TIME ZONE 'America/Sao_Paulo','DD/MM HH24:MI'),'nunca'),
+      NULL, CASE WHEN max(fcs.calculated_at) IS NULL THEN 'calculate-scores nunca rodou' ELSE NULL END,
+      'Re-rode calculate-scores / scoring-recalc-batch no Lovable', 'warning'
+    FROM public.farmer_client_scores fcs
+    UNION ALL
+    SELECT 'custos_produtos'::text, 'estoque'::text,
+      CASE WHEN max(pc.updated_at) IS NULL THEN 'broken'
+           WHEN now() - max(pc.updated_at) > interval '30 hours' THEN 'stale' ELSE 'ok' END,
+      EXTRACT(EPOCH FROM now() - max(pc.updated_at))::bigint, (30*3600)::bigint, 'product_costs.updated_at'::text,
+      'Custos de produto: recalculado ' || COALESCE(to_char(max(pc.updated_at) AT TIME ZONE 'America/Sao_Paulo','DD/MM HH24:MI'),'nunca'),
+      NULL, CASE WHEN max(pc.updated_at) IS NULL THEN 'compute_costs nunca rodou' ELSE NULL END,
+      'Cheque o cron compute-costs-daily (omie-analytics-sync compute_costs)'::text, 'warning'::text
+    FROM public.product_costs pc
+    UNION ALL
+    SELECT 'vendas_cadastros'::text, 'vendas'::text,
+      CASE WHEN vc.max_clientes IS NULL OR vc.max_produtos IS NULL THEN 'broken'
+           WHEN now() - LEAST(vc.max_clientes, vc.max_produtos) > interval '30 hours' THEN 'stale' ELSE 'ok' END,
+      EXTRACT(EPOCH FROM now() - LEAST(vc.max_clientes, vc.max_produtos))::bigint, (30*3600)::bigint,
+      'max(updated_at) de omie_clientes/omie_products'::text,
+      'Cadastros Omie: clientes ' || COALESCE(to_char(vc.max_clientes AT TIME ZONE 'America/Sao_Paulo','DD/MM HH24:MI'),'nunca')
+        || ' · produtos ' || COALESCE(to_char(vc.max_produtos AT TIME ZONE 'America/Sao_Paulo','DD/MM HH24:MI'),'nunca'),
+      NULL,
+      CASE WHEN vc.max_clientes IS NULL OR vc.max_produtos IS NULL THEN 'omie_clientes/omie_products vazio (sync nunca populou)'
+           ELSE 'Nenhum cron atualizou clientes/produtos há mais de 30h' END,
+      'Cheque os crons de cadastro (sync-customers-vendas-daily / omie-cron-diario / sync-colacor-vendas-products)'::text,
+      'warning'::text
+    FROM (
+      SELECT (SELECT max(updated_at) FROM public.omie_clientes) AS max_clientes,
+             (SELECT max(updated_at) FROM public.omie_products) AS max_produtos
+    ) vc
+    UNION ALL
+    -- Track A (ação): pedidos APROVADOS não despachados ao fornecedor. O cron disparar-pedidos-aprovados
+    -- (0 13) só processa data_ciclo=hoje → aprovação não-disparada no dia fica órfã. >2d=stale / >7d=broken.
+    SELECT 'reposicao_disparo'::text, 'estoque'::text,
+      CASE WHEN rd.aguardando = 0 THEN 'ok'
+           WHEN rd.mais_antigo_h > 168 THEN 'broken'
+           WHEN rd.mais_antigo_h > 48 THEN 'stale' ELSE 'ok' END,
+      (rd.mais_antigo_h * 3600)::bigint, (48*3600)::bigint,
+      'pedido_compra_sugerido.aprovado_em (status=aprovado_aguardando_disparo)'::text,
+      CASE WHEN rd.aguardando = 0 THEN 'Disparo de compra: nenhum pedido aprovado pendente'
+           ELSE 'Disparo de compra: ' || rd.aguardando::text || ' pedido(s) aprovado(s) aguardando disparo (mais antigo ' || COALESCE(rd.mais_antigo_txt,'?') || ')' END,
+      NULL,
+      CASE WHEN rd.mais_antigo_h > 48 THEN 'Pedido aprovado não foi disparado ao fornecedor (o cron disparar-pedidos-aprovados só processa o ciclo do dia → aprovações antigas ficam órfãs)' ELSE NULL END,
+      'Em /admin/reposicao: dispare (re-rode disparar-pedidos-aprovados com o pedido_id) ou cancele/expire os pedidos presos em aprovado_aguardando_disparo'::text,
+      'warning'::text
+    FROM (
+      SELECT
+        (count(*) FILTER (WHERE status='aprovado_aguardando_disparo'))::int AS aguardando,
+        COALESCE(round(EXTRACT(EPOCH FROM now() - min(aprovado_em) FILTER (WHERE status='aprovado_aguardando_disparo'))/3600)::int, 0) AS mais_antigo_h,
+        to_char((min(aprovado_em) FILTER (WHERE status='aprovado_aguardando_disparo')) AT TIME ZONE 'America/Sao_Paulo','DD/MM') AS mais_antigo_txt
+      FROM public.pedido_compra_sugerido
+    ) rd
+    UNION ALL
+    -- Track A (ação) — PIPELINE travado: estados que o automático DEVERIA drenar e não drenou. O motor
+    -- sayerlack-retry-orfaos (*/15) re-dispara pendente_envio_portal/erro_retentavel frescos (tentativas<3,
+    -- <3d, retry não-futuro); o watchdog sayerlack-portal-watchdog (*/5) destrava enviando_portal preso.
+    -- Se um desses fica >1h, o automático parou. >1h=stale / >6h=broken.
+    SELECT 'reposicao_portal_pipeline'::text, 'estoque'::text,
+      CASE WHEN pl.pendentes = 0 THEN 'ok'
+           WHEN now() - pl.mais_antigo > interval '6 hours' THEN 'broken'
+           WHEN now() - pl.mais_antigo > interval '1 hour' THEN 'stale' ELSE 'ok' END,
+      EXTRACT(EPOCH FROM now() - pl.mais_antigo)::bigint, (3600)::bigint,
+      'pedido_compra_sugerido.status_envio_portal (pipeline: pendente/erro_retentavel fresco/enviando)'::text,
+      CASE WHEN pl.pendentes = 0 THEN 'Portal Sayerlack (pipeline): nada travado'
+           ELSE 'Portal Sayerlack (pipeline): ' || pl.pendentes::text || ' pedido(s) sem progredir (mais antigo ' || COALESCE(pl.mais_antigo_txt,'?') || ')' END,
+      NULL,
+      CASE WHEN now() - pl.mais_antigo > interval '1 hour' THEN 'O automático parou de drenar a fila do portal (motor sayerlack-retry-orfaos */15 ou watchdog sayerlack-portal-watchdog */5)' ELSE NULL END,
+      'Cheque os crons sayerlack-retry-orfaos e sayerlack-portal-watchdog + a edge enviar-pedido-portal-sayerlack (logs no Lovable)'::text,
+      'warning'::text
+    FROM (
+      SELECT
+        count(*)::int AS pendentes,
+        min(atualizado_em) AS mais_antigo,
+        to_char(min(atualizado_em) AT TIME ZONE 'America/Sao_Paulo','DD/MM HH24:MI') AS mais_antigo_txt
+      FROM public.pedido_compra_sugerido
+      WHERE (
+        status_envio_portal IN ('pendente_envio_portal','erro_retentavel')
+        AND (portal_proximo_retry_em IS NULL OR portal_proximo_retry_em < now())
+        AND COALESCE(portal_tentativas, 0) < 3
+        AND atualizado_em >= now() - interval '3 days'
+      )
+      OR status_envio_portal = 'enviando_portal'
+    ) pl
+    UNION ALL
+    -- Track A (ação) — precisa HUMANO: estados que NÃO drenam sozinhos. indeterminado_requer_conciliacao
+    -- (PO talvez no fornecedor sem Omie — o motor NÃO toca, re-disparo duplicaria) = risco de dinheiro;
+    -- erro_nao_retentavel (SKU sem mapeamento) = compra bloqueada; aceito_portal_sem_protocolo/falha_envio_portal
+    -- = conciliação; erro_retentavel esgotado (tentativas>=3 ou >3d) = motor desistiu. >2h=stale / >24h=broken.
+    SELECT 'reposicao_portal_humano'::text, 'estoque'::text,
+      CASE WHEN hu.pendentes = 0 THEN 'ok'
+           WHEN now() - hu.mais_antigo > interval '24 hours' THEN 'broken'
+           WHEN now() - hu.mais_antigo > interval '2 hours' THEN 'stale' ELSE 'ok' END,
+      EXTRACT(EPOCH FROM now() - hu.mais_antigo)::bigint, (2*3600)::bigint,
+      'pedido_compra_sugerido.status_envio_portal (humano: indeterminado/erro_nao_retentavel/aceito_sem_protocolo/falha/erro_retentavel esgotado)'::text,
+      CASE WHEN hu.pendentes = 0 THEN 'Portal Sayerlack (ação humana): nada pendente'
+           ELSE 'Portal Sayerlack (ação humana): ' || hu.pendentes::text || ' pedido(s) precisando intervenção (mais antigo ' || COALESCE(hu.mais_antigo_txt,'?') || ')' END,
+      NULL,
+      CASE WHEN now() - hu.mais_antigo > interval '2 hours' THEN 'Pedido(s) que o automático não resolve: conciliar indeterminado (NÃO re-disparar — duplica PO), mapear SKU (erro_nao_retentavel), ou conferir protocolo' ELSE NULL END,
+      'Em /admin/reposicao: concilie os indeterminado_requer_conciliacao (cheque o fornecedor ANTES — NÃO re-dispare), faça o de-para dos erro_nao_retentavel, e confira aceito_portal_sem_protocolo'::text,
+      'warning'::text
+    FROM (
+      SELECT
+        count(*)::int AS pendentes,
+        min(atualizado_em) AS mais_antigo,
+        to_char(min(atualizado_em) AT TIME ZONE 'America/Sao_Paulo','DD/MM HH24:MI') AS mais_antigo_txt
+      FROM public.pedido_compra_sugerido
+      WHERE status_envio_portal IN ('indeterminado_requer_conciliacao','erro_nao_retentavel','aceito_portal_sem_protocolo','falha_envio_portal')
+         OR (status_envio_portal = 'erro_retentavel' AND (COALESCE(portal_tentativas, 0) >= 3 OR atualizado_em < now() - interval '3 days'))
+    ) hu
+    UNION ALL
+    SELECT 'alert_channel'::text, 'alertas'::text,
+      CASE WHEN ac.stuck_pendentes > 0 OR ac.falhas_24h >= 5 THEN 'broken'
+           WHEN ac.falhas_24h > 0 THEN 'stale' ELSE 'ok' END,
+      ac.oldest_pendente_age_seconds, (2*3600)::bigint, 'fornecedor_alerta.pendente_notificacao'::text,
+      CASE WHEN ac.stuck_pendentes > 0
+             THEN 'Canal de alerta: ' || ac.stuck_pendentes::text || ' email(s) presos há mais de 2h — dispatch parou de drenar'
+           WHEN ac.falhas_24h >= 5
+             THEN 'Canal de alerta: ' || ac.falhas_24h::text || ' falhas de envio nas últimas 24h (falha sistêmica)'
+           WHEN ac.falhas_24h > 0
+             THEN 'Canal de alerta: ' || ac.falhas_24h::text || ' falha(s) de envio nas últimas 24h'
+           ELSE 'Canal de alerta: drenando normalmente (' || ac.pendentes_total::text || ' na fila)' END,
+      ac.ultimo_erro,
+      CASE WHEN ac.stuck_pendentes > 0 THEN 'Cron afiacao_dispatch_notificacoes_30min não rodou ou a edge dispatch-notifications falhou (token Gmail revogado?)'
+           WHEN ac.falhas_24h > 0 THEN 'Envio de email falhando (Gmail / token / destinatário)' ELSE NULL END,
+      'Cheque a edge dispatch-notifications (logs no Lovable), o refresh token do Gmail e o net._http_response do cron afiacao_dispatch_notificacoes_30min'::text,
+      'critical'::text
+    FROM (
+      SELECT
+        (count(*) FILTER (WHERE fa.status='pendente_notificacao' AND fa.criado_em < now() - interval '2 hours'))::bigint AS stuck_pendentes,
+        (count(*) FILTER (WHERE fa.status='pendente_notificacao'))::bigint AS pendentes_total,
+        (count(*) FILTER (WHERE fa.status='falha_notificacao' AND fa.criado_em > now() - interval '24 hours'))::bigint AS falhas_24h,
+        EXTRACT(EPOCH FROM now() - min(fa.criado_em) FILTER (WHERE fa.status='pendente_notificacao' AND fa.criado_em < now() - interval '2 hours'))::bigint AS oldest_pendente_age_seconds,
+        (SELECT f2.erro_notificacao FROM public.fornecedor_alerta f2
+          WHERE f2.status='falha_notificacao' AND f2.erro_notificacao IS NOT NULL
+          ORDER BY f2.criado_em DESC LIMIT 1) AS ultimo_erro
+      FROM public.fornecedor_alerta fa
+    ) ac
+  )
+  -- P1: campos de "problema" (erro técnico, causa provável, remédio) só saem quando
+  -- o check NÃO está ok. Check verde = nada a reportar.
+  SELECT c.source, c.domain, COALESCE(NULLIF(c.status, ''), 'unknown') AS status,
+    c.age_seconds, c.expected_max_age_seconds, c.freshness_basis, c.message,
+    CASE WHEN COALESCE(NULLIF(c.status,''),'unknown') = 'ok' THEN NULL ELSE c.last_error END AS last_error,
+    CASE WHEN COALESCE(NULLIF(c.status,''),'unknown') = 'ok' THEN NULL ELSE c.probable_cause END AS probable_cause,
+    CASE WHEN COALESCE(NULLIF(c.status,''),'unknown') = 'ok' THEN NULL ELSE c.how_to_fix END AS how_to_fix,
+    c.severity
+  FROM checks c;
+$$;
+
+REVOKE ALL ON FUNCTION public._data_health_compute() FROM PUBLIC, anon, authenticated;
+
+-- Watchdog: PROMOVE os 3 checks de ação ao push (IN 6→9). Alerta na transição ok→degradado
+-- (anti-spam UNIQUE parcial). Não colide com fin_sync_watchdog (tipos data_health_* distintos).
+-- Corpo verbatim da 20260527250000; só amplio o IN.
+CREATE OR REPLACE FUNCTION public.data_health_watchdog()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  r record;
+  v_sev_fin text;
+  v_sev_forn text;
+BEGIN
+  FOR r IN
+    SELECT * FROM public._data_health_compute()
+    WHERE source IN ('vendas_pedidos','estoque_inventario','reposicao_sugestoes','carteira_scores',
+                     'custos_produtos','vendas_cadastros',
+                     'reposicao_disparo','reposicao_portal_pipeline','reposicao_portal_humano')
+  LOOP
+    v_sev_fin  := CASE WHEN r.severity = 'critical' THEN 'critico' ELSE 'aviso' END;
+    v_sev_forn := CASE WHEN r.severity = 'critical' THEN 'urgente' ELSE 'atencao' END;
+    IF r.status <> 'ok' THEN
+      INSERT INTO fin_alertas (company, tipo, severidade, mensagem, contexto)
+      VALUES ('oben', 'data_health_' || r.source, v_sev_fin, r.message,
+              jsonb_build_object('source', r.source, 'domain', r.domain, 'status', r.status,
+                                 'age_seconds', r.age_seconds, 'freshness_basis', r.freshness_basis))
+      ON CONFLICT (company, tipo) WHERE dismissed_at IS NULL DO NOTHING;
+      IF FOUND THEN
+        INSERT INTO fornecedor_alerta (empresa, tipo, severidade, titulo, mensagem, status)
+        VALUES ('oben', 'outro', v_sev_forn, '[Saúde de dados] ' || r.source, r.message, 'pendente_notificacao');
+      END IF;
+    ELSE
+      UPDATE fin_alertas SET dismissed_at = now()
+      WHERE company = 'oben' AND tipo = 'data_health_' || r.source AND dismissed_at IS NULL;
+    END IF;
+  END LOOP;
+END;
+$$;
+
+-- Heartbeat: versão rica (AT TIME ZONE BRT + título honesto + lista de alertas ativos) da
+-- 20260528194751, com os 2 sources de portal divididos no resumo de saúde de dados (reposicao_portal
+-- → reposicao_portal_pipeline + reposicao_portal_humano). Dead-man-switch informativo.
+CREATE OR REPLACE FUNCTION public.fin_sync_heartbeat()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $$
+DECLARE
+  v_resumo text;
+  v_ativos int;
+  v_lista_ativos text;
+  v_dh_ativos int;
+  v_dh_resumo text;
+  v_titulo text;
+BEGIN
+  SELECT count(*) INTO v_ativos
+  FROM fin_alertas WHERE tipo LIKE 'sync_%' AND dismissed_at IS NULL;
+
+  SELECT string_agg(
+           format('%s/%s (desde %s)', company, tipo,
+                  to_char(criado_em AT TIME ZONE 'America/Sao_Paulo', 'DD/MM HH24:MI')),
+           E'\n' ORDER BY company, tipo)
+    INTO v_lista_ativos
+  FROM fin_alertas WHERE tipo LIKE 'sync_%' AND dismissed_at IS NULL;
+
+  SELECT string_agg(linha, E'\n' ORDER BY linha) INTO v_resumo
+  FROM (
+    SELECT format('%s/%s: %s', co, re,
+                  COALESCE(to_char(m.mx AT TIME ZONE 'America/Sao_Paulo', 'DD/MM HH24:MI'), 'NUNCA')) AS linha
+    FROM unnest(ARRAY['oben','colacor','colacor_sc']) AS co
+    CROSS JOIN unnest(ARRAY['contas_pagar','contas_receber','movimentacoes']) AS re
+    CROSS JOIN LATERAL (
+      SELECT max(l.completed_at) AS mx FROM fin_sync_log l
+      WHERE l.status='complete' AND l.action='sync_'||re AND co = ANY(l.companies)
+    ) m
+  ) s;
+
+  SELECT count(*) INTO v_dh_ativos
+  FROM fin_alertas WHERE tipo LIKE 'data_health_%' AND dismissed_at IS NULL;
+
+  SELECT string_agg(format('%s: %s', source, status), E'\n' ORDER BY source) INTO v_dh_resumo
+  FROM public._data_health_compute()
+  WHERE source IN ('vendas_pedidos','estoque_inventario','reposicao_sugestoes','carteira_scores',
+                   'custos_produtos','vendas_cadastros','reposicao_disparo',
+                   'reposicao_portal_pipeline','reposicao_portal_humano','alert_channel');
+
+  v_titulo := '[Watchdog'
+              || CASE WHEN (v_ativos + v_dh_ativos) > 0
+                   THEN ': '||(v_ativos + v_dh_ativos)||' alerta(s) ativo(s)'
+                   ELSE ' OK' END
+              || '] '||to_char(now() AT TIME ZONE 'America/Sao_Paulo', 'DD/MM');
+
+  INSERT INTO fornecedor_alerta (empresa, tipo, severidade, titulo, mensagem, status)
+  VALUES ('oben', 'outro', 'info',
+          v_titulo,
+          'Watchdog do sync rodou. Alertas de sync ativos: '||v_ativos||'.'||
+          CASE WHEN v_ativos > 0 THEN E'\n'||COALESCE(v_lista_ativos,'') ELSE '' END||
+          E'\n\nÚltimo sync OK por empresa/recurso (horário de Brasília):\n'||COALESCE(v_resumo,'(sem dados)')||
+          E'\n\nSaúde de dados — alertas ativos: '||v_dh_ativos||
+          E'.\nChecks de saúde de dados:\n'||COALESCE(v_dh_resumo,'(sem dados)'),
+          'pendente_notificacao');
+END;
+$$;

--- a/supabase/migrations/20260530210001_cancelar_pedido_limpa_portal.sql
+++ b/supabase/migrations/20260530210001_cancelar_pedido_limpa_portal.sql
@@ -1,0 +1,43 @@
+-- ============================================================
+-- Portal Sayerlack — Fase 1.1: cancelar limpa o sub-fluxo do portal
+-- ============================================================
+-- A RPC cancelar_pedido_sugerido setava status='cancelado_humano' mas NUNCA
+-- tocava status_envio_portal → um pedido cancelado ficava com
+-- status_envio_portal='pendente_envio_portal' (e portal_proximo_retry_em
+-- agendado) pra sempre, poluindo a aba Pendentes, os KPIs e o check de saúde
+-- de dados reposicao_portal (que filtra só por status_envio_portal). Foi a
+-- causa dos ids 153/166/172 aparecerem como "presos no portal" mesmo cancelados.
+--
+-- Fix: ao cancelar, também zera o sub-fluxo do portal (nao_aplicavel) e cancela
+-- qualquer retry agendado. Corpo verbatim do schema-snapshot (843-866) + as 2
+-- linhas novas; o guard de status (disparado/concluido_recebido) é preservado.
+-- Idempotente (CREATE OR REPLACE; re-rodar não muda nada).
+
+CREATE OR REPLACE FUNCTION public.cancelar_pedido_sugerido(
+  p_pedido_id bigint, p_usuario text, p_justificativa text
+) RETURNS jsonb
+LANGUAGE plpgsql
+SET search_path TO 'public', 'pg_temp'
+AS $$
+DECLARE
+  v_pedido RECORD;
+BEGIN
+  SELECT * INTO v_pedido FROM pedido_compra_sugerido WHERE id = p_pedido_id;
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('error', 'pedido não encontrado');
+  END IF;
+  IF v_pedido.status IN ('disparado', 'concluido_recebido') THEN
+    RETURN jsonb_build_object('error', 'pedido já foi disparado em ' || v_pedido.horario_disparo_real::text);
+  END IF;
+  UPDATE pedido_compra_sugerido
+  SET status = 'cancelado_humano',
+      cancelado_por = p_usuario,
+      cancelado_em = NOW(),
+      justificativa_cancelamento = p_justificativa,
+      status_envio_portal = 'nao_aplicavel',  -- Fase 1: cancelar limpa o sub-fluxo do portal
+      portal_proximo_retry_em = NULL,         -- Fase 1: e cancela qualquer retry agendado
+      atualizado_em = NOW()
+  WHERE id = p_pedido_id;
+  RETURN jsonb_build_object('status', 'ok', 'pedido_id', p_pedido_id);
+END;
+$$;


### PR DESCRIPTION
## O que e por quê

Dois consertos no fluxo do portal Sayerlack + Sentinela de Saúde de Dados:

### 1. Restauração do split de portal do #490 (corrige regressão da minha Fase 2/#493)

A Fase 2 (#493, `20260530200000_data_health_checks_acionaveis.sql`) **partiu do corpo do #460/#194751** sem conhecer o **#490** (`20260530190000_data_health_portal_push.sql`, entregue em paralelo por outra sessão), que havia:
- dividido `reposicao_portal` em **`reposicao_portal_pipeline`** (automático *deveria* drenar) × **`reposicao_portal_humano`** (precisa de gente), por semântica/SLA distintos;
- promovido `reposicao_disparo`/portal ao **push**, recriando `data_health_watchdog` + `fin_sync_heartbeat` com o IN-list 6→9 fontes.

A #493 (CREATE OR REPLACE de corpo velho) **reverteu** o `_data_health_compute` pro `reposicao_portal` único e **não** recriou watchdog/heartbeat → o watchdog do #490 ficou procurando `reposicao_portal_pipeline`/`_humano` que o compute não produzia mais = **push de portal quebrado** (silencioso).

**Fix-forward:** `20260530210000_data_health_restaura_portal_split.sql` = **#490 VERBATIM** (SQL executável idêntico, confirmado por `diff`; só cabeçalho anti-cascata). Supersede a #493 por timestamp + CREATE OR REPLACE. O split é estritamente **mais** acionável que o filtro de check-único da #493 (que o split já subsume); `reposicao_disparo` é idêntico nas duas → restaurar **não perde nada**.

### 2. Higiene de cancelamento (Fix 1.1 do plano)

`20260530210001_cancelar_pedido_limpa_portal.sql`: a RPC `cancelar_pedido_sugerido` setava `status='cancelado_humano'` mas **nunca tocava `status_envio_portal`** → cancelado ficava `pendente_envio_portal` pra sempre, poluindo a aba Pendentes, os KPIs e o check `reposicao_portal_pipeline`. Agora zera `status_envio_portal='nao_aplicavel'` + `portal_proximo_retry_em=NULL`. Corpo **verbatim do schema-snapshot (843-866)** + 2 linhas; guard `disparado/concluido_recebido` preservado; idempotente.

Espelho no frontend: `useDetalhesModal.ts` (bloco de cancelamento por remoção de todos os itens) limpa os mesmos 2 campos.

## ⚠️ MIGRATIONS MANUAIS (Lovable não aplica no merge)

Colar **as duas** no SQL Editor do Lovable após o merge. A `210000` é idempotente e supersede o que estiver vivo no banco. SQL inline + validação na conversa.

## Validação

- Postgres 17 efêmero: restauração aplica → **14 checks** (`reposicao_portal_pipeline` + `reposicao_portal_humano` presentes), `data_health_watchdog` OK, `fin_sync_heartbeat` OK.
- Higiene: `cancelar_pedido_sugerido` num pedido cancelável → `status=cancelado_humano, status_envio_portal=nao_aplicavel, retry_limpo=t`; guard de disparado intacto.
- `diff` do SQL executável #490 × 210000 = **idêntico**.
- typecheck (`tsc -p tsconfig.app.json`) ✓ · lint errors-only ✓ · audit regenerado (125 migrations).

## Lição (§14)

Re-checar `gh pr list`/main **antes de cada fase**, não só no início. O `_data_health_compute` é arquivo quente multi-sessão; 3 sessões o tocaram em paralelo (#460/#490/#493) e a regressão por CREATE OR REPLACE de corpo velho é silenciosa. Cabeçalho da migration manda a próxima sessão "partir DESTA (maior timestamp)".

🤖 Generated with [Claude Code](https://claude.com/claude-code)