### PR TITLE
feat(visitas): agendadas de hoje como parada no route planner (4ª fonte) [Fase 2]

### DIFF
--- a/src/components/reposicao/routePlanner/constants.ts
+++ b/src/components/reposicao/routePlanner/constants.ts
@@ -9,6 +9,7 @@ export const STOP_DURATION_MIN: Record<StopType, number> = {
   sales_visit: 20,
   hybrid_visit: 30,
   manual_visit: 15,
+  scheduled_visit: 20,
 };
 
 export const PRIORITY_CONFIG: Record<
@@ -29,4 +30,5 @@ export const STOP_CONFIG: Record<
   sales_visit: { label: 'Comercial', color: 'hsl(30, 90%, 50%)', bgClass: 'bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-200', textClass: 'text-orange-600', markerColor: '#f97316' },
   hybrid_visit: { label: 'Híbrido', color: 'hsl(270, 70%, 55%)', bgClass: 'bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200', textClass: 'text-purple-600', markerColor: '#a855f7' },
   manual_visit: { label: 'Manual', color: 'hsl(180, 70%, 45%)', bgClass: 'bg-cyan-100 text-cyan-800 dark:bg-cyan-900 dark:text-cyan-200', textClass: 'text-cyan-600', markerColor: '#06b6d4' },
+  scheduled_visit: { label: 'Agendada', color: 'hsl(45, 100%, 50%)', bgClass: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200', textClass: 'text-yellow-600', markerColor: '#eab308' },
 };

--- a/src/components/reposicao/routePlanner/renderHelpers.tsx
+++ b/src/components/reposicao/routePlanner/renderHelpers.tsx
@@ -1,6 +1,6 @@
 // Helpers de apresentação das paradas de rota.
 // Extraído de src/pages/AdminRoutePlanner.tsx (god-component split).
-import { Truck, ShoppingBag, Layers, Users } from 'lucide-react';
+import { Truck, ShoppingBag, Layers, Users, Calendar } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import type { StopType, ManualCustomer, RouteStop } from './types';
 
@@ -18,6 +18,7 @@ export const getStopIcon = (type: StopType) => {
     case 'sales_visit': return <ShoppingBag className="w-3.5 h-3.5" />;
     case 'hybrid_visit': return <Layers className="w-3.5 h-3.5" />;
     case 'manual_visit': return <Users className="w-3.5 h-3.5" />;
+    case 'scheduled_visit': return <Calendar className="w-3.5 h-3.5" />;
   }
 };
 

--- a/src/components/reposicao/routePlanner/types.ts
+++ b/src/components/reposicao/routePlanner/types.ts
@@ -6,7 +6,8 @@ export type StopType =
   | 'deliver_tools'
   | 'sales_visit'
   | 'hybrid_visit'
-  | 'manual_visit';
+  | 'manual_visit'
+  | 'scheduled_visit';
 export type PlanningMode = 'logistica' | 'comercial' | 'hibrido' | 'manual';
 export type FilterPeriod = 'all' | 'manha' | 'tarde';
 export type ManualFilter = 'todos' | 'nunca_visitados' | 'sem_compra_30d';

--- a/src/hooks/useRoutePlanner.ts
+++ b/src/hooks/useRoutePlanner.ts
@@ -23,6 +23,9 @@ import type {
 import { enrichWithPriority } from '@/components/reposicao/routePlanner/priority';
 import { STOP_DURATION_MIN } from '@/components/reposicao/routePlanner/constants';
 import type { Tables } from '@/integrations/supabase/types';
+import { visitasAgendadasTable } from '@/integrations/supabase/visitasAgendadas';
+import type { VisitaAgendadaRow } from '@/integrations/supabase/visitasAgendadas';
+import { agendaToRouteStop } from '@/lib/visitas/agenda-to-stop';
 
 // Linha de route_visits enriquecida com o nome do cliente (resolvido via profiles).
 export type TodayVisitRow = Tables<'route_visits'> & { customerName: string };
@@ -50,6 +53,7 @@ export function useRoutePlanner() {
 
   const [logisticStops, setLogisticStops] = useState<RouteStop[]>([]);
   const [commercialStops, setCommercialStops] = useState<RouteStop[]>([]);
+  const [scheduledVisitStops, setScheduledVisitStops] = useState<RouteStop[]>([]);
   const [loading, setLoading] = useState(true);
   const [geocoding, setGeocoding] = useState(false);
   const [filterPeriod, setFilterPeriod] = useState<FilterPeriod>('all');
@@ -96,6 +100,11 @@ export function useRoutePlanner() {
       loadCommercialStops();
     }
   }, [scoringLoading, agenda]);
+
+  // Load scheduled visits for today (comercial + hibrido modes)
+  useEffect(() => {
+    if (user && isStaff) loadScheduledVisits();
+  }, [user, isStaff]);
 
   // Always load today's visits (all modes)
   useEffect(() => {
@@ -475,6 +484,97 @@ export function useRoutePlanner() {
     return `${m}:${String(s).padStart(2, '0')}`;
   };
 
+  const loadScheduledVisits = async () => {
+    if (!user) {
+      setScheduledVisitStops([]);
+      return;
+    }
+    try {
+      const today = new Date().toISOString().split('T')[0];
+      const { data, error } = await visitasAgendadasTable()
+        .select('*')
+        .eq('scheduled_by', user.id)
+        .eq('status', 'pendente')
+        .eq('scheduled_date', today);
+
+      if (error) {
+        console.error('Error loading scheduled visits:', error);
+        setScheduledVisitStops([]);
+        return;
+      }
+
+      const rows = (data as unknown as VisitaAgendadaRow[]) || [];
+      if (rows.length === 0) {
+        setScheduledVisitStops([]);
+        return;
+      }
+
+      const customerIds = [...new Set(rows.map(r => r.customer_user_id))];
+
+      const [{ data: profiles }, { data: addresses }] = await Promise.all([
+        supabase
+          .from('profiles')
+          .select('user_id, name, phone, business_hours_open, business_hours_close')
+          .in('user_id', customerIds),
+        supabase
+          .from('addresses')
+          .select('*')
+          .in('user_id', customerIds)
+          .order('is_default', { ascending: false }),
+      ]);
+
+      const profileMap = new Map((profiles || []).map(p => [p.user_id, p]));
+      // Pick first address per customer (default if available, then any)
+      const addressMap = (addresses || []).reduce((map, addr) => {
+        if (!map.has(addr.user_id)) map.set(addr.user_id, addr);
+        return map;
+      }, new Map<string, Tables<'addresses'>>());
+
+      const stops: RouteStop[] = rows.map(row => {
+        const profile = profileMap.get(row.customer_user_id);
+        const addr = addressMap.get(row.customer_user_id);
+
+        const input = agendaToRouteStop(
+          row,
+          profile
+            ? {
+                name: profile.name,
+                phone: profile.phone,
+                business_hours_open: profile.business_hours_open,
+                business_hours_close: profile.business_hours_close,
+              }
+            : undefined,
+          addr
+            ? {
+                street: addr.street,
+                number: addr.number,
+                neighborhood: addr.neighborhood,
+                city: addr.city,
+                state: addr.state,
+                zip_code: addr.zip_code,
+                complement: addr.complement,
+              }
+            : undefined,
+        );
+
+        // Visita agendada manualmente: prioridade explícita 'alta' (compromisso explícito).
+        // NÃO usa enrichWithPriority porque scheduled_visit não tem scoring mapeado
+        // e resultaria em score 0 / label 'baixa' — incorreto para um compromisso agendado.
+        return {
+          ...input,
+          priorityScore: 70,
+          priorityLabel: 'alta' as RouteStop['priorityLabel'],
+          priorityFactors: ['Agendada manualmente'],
+        };
+      });
+
+      setScheduledVisitStops(stops);
+    } catch (err) {
+      console.error('Error loading scheduled visits:', err);
+      setScheduledVisitStops([]);
+    }
+  };
+
   const loadCommercialStops = async () => {
     try {
       // Gather customer IDs from logistic stops for hybrid detection
@@ -614,10 +714,19 @@ export function useRoutePlanner() {
     const mergedLogisticCustomerIds = new Set(upgraded.filter(s => s.stopType === 'hybrid_visit').map(s => s.customerUserId));
     const uniqueCommercial = commercialStops.filter(s => !mergedLogisticCustomerIds.has(s.customerUserId));
 
+    // Dedup scheduled visits against customers already present in logistic or commercial
+    const existingCustomerIds = new Set([
+      ...upgraded.map(s => s.customerUserId),
+      ...uniqueCommercial.map(s => s.customerUserId),
+    ]);
+    const uniqueScheduled = scheduledVisitStops.filter(
+      s => !existingCustomerIds.has(s.customerUserId),
+    );
+
     switch (planningMode) {
       case 'logistica': return upgraded.filter(s => s.stopType === 'pickup_tools' || s.stopType === 'deliver_tools');
-      case 'comercial': return [...uniqueCommercial, ...upgraded.filter(s => s.stopType === 'hybrid_visit')];
-      case 'hibrido': return [...upgraded, ...uniqueCommercial];
+      case 'comercial': return [...uniqueCommercial, ...upgraded.filter(s => s.stopType === 'hybrid_visit'), ...uniqueScheduled];
+      case 'hibrido': return [...upgraded, ...uniqueCommercial, ...uniqueScheduled];
       case 'manual': {
         // Build manual stops from selected customers
         const manualStops: RouteStop[] = Array.from(selectedCustomerIds).map(userId => {
@@ -642,7 +751,7 @@ export function useRoutePlanner() {
         return manualStops;
       }
     }
-  }, [logisticStops, commercialStops, planningMode, selectedCustomerIds, manualCustomers]);
+  }, [logisticStops, commercialStops, scheduledVisitStops, planningMode, selectedCustomerIds, manualCustomers]);
 
   // Geocode stops progressively (max 15, 1.1s delay between calls)
   const geocodedCoords = useRef<Map<string, { lat: number; lng: number }>>(new Map());
@@ -848,7 +957,7 @@ export function useRoutePlanner() {
 
   // Stats
   const stopCounts = useMemo(() => {
-    const counts: Record<string, number> = { pickup_tools: 0, deliver_tools: 0, sales_visit: 0, hybrid_visit: 0 };
+    const counts: Record<string, number> = { pickup_tools: 0, deliver_tools: 0, sales_visit: 0, hybrid_visit: 0, scheduled_visit: 0 };
     optimizedRoute.forEach(s => counts[s.stopType]++);
     return counts;
   }, [optimizedRoute]);

--- a/src/lib/visitas/__tests__/agenda-to-stop.test.ts
+++ b/src/lib/visitas/__tests__/agenda-to-stop.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest';
+import { agendaToRouteStop } from '../agenda-to-stop';
+import type { AgendaStopProfile, AgendaStopAddress } from '../agenda-to-stop';
+import type { VisitaAgendadaRow } from '@/integrations/supabase/visitasAgendadas';
+
+const baseRow: VisitaAgendadaRow = {
+  id: 'abc-123',
+  customer_user_id: 'user-456',
+  scheduled_by: 'staff-789',
+  scheduled_date: '2026-05-30',
+  status: 'pendente',
+  visit_type: 'comercial',
+  notes: null,
+  route_visit_id: null,
+  created_at: '2026-05-29T10:00:00Z',
+  updated_at: '2026-05-29T10:00:00Z',
+};
+
+const fullProfile: AgendaStopProfile = {
+  name: 'Marcenaria Silva',
+  phone: '(11) 99999-1234',
+  business_hours_open: '08:00',
+  business_hours_close: '18:00',
+};
+
+const fullAddress: AgendaStopAddress = {
+  street: 'Rua das Flores',
+  number: '42',
+  neighborhood: 'Centro',
+  city: 'São Paulo',
+  state: 'SP',
+  zip_code: '01310-100',
+  complement: 'Sala 3',
+};
+
+describe('agendaToRouteStop', () => {
+  it('com perfil e endereço completos retorna campos corretos', () => {
+    const result = agendaToRouteStop(baseRow, fullProfile, fullAddress);
+
+    expect(result.id).toBe('scheduled-visit-abc-123');
+    expect(result.stopType).toBe('scheduled_visit');
+    expect(result.customerUserId).toBe('user-456');
+    expect(result.customerName).toBe('Marcenaria Silva');
+    expect(result.phone).toBe('(11) 99999-1234');
+    expect(result.businessHoursOpen).toBe('08:00');
+    expect(result.businessHoursClose).toBe('18:00');
+    expect(result.timeSlot).toBeNull();
+    expect(result.status).toBe('scheduled');
+    expect(result.visitReason).toBe('Visita agendada');
+
+    expect(result.address.street).toBe('Rua das Flores');
+    expect(result.address.number).toBe('42');
+    expect(result.address.neighborhood).toBe('Centro');
+    expect(result.address.city).toBe('São Paulo');
+    expect(result.address.state).toBe('SP');
+    expect(result.address.zip_code).toBe('01310-100');
+    expect(result.address.complement).toBe('Sala 3');
+  });
+
+  it('sem endereço retorna strings vazias nos campos de endereço', () => {
+    const result = agendaToRouteStop(baseRow, fullProfile, undefined);
+
+    expect(result.address.street).toBe('');
+    expect(result.address.number).toBe('');
+    expect(result.address.neighborhood).toBe('');
+    expect(result.address.city).toBe('');
+    expect(result.address.state).toBe('');
+    expect(result.address.zip_code).toBe('');
+    expect(result.address.complement).toBeUndefined();
+  });
+
+  it('com notes preenche visitReason com prefixo "Agendada ·"', () => {
+    const rowWithNotes: VisitaAgendadaRow = { ...baseRow, notes: 'Apresentar novo catálogo' };
+    const result = agendaToRouteStop(rowWithNotes, fullProfile, fullAddress);
+
+    expect(result.visitReason).toBe('Agendada · Apresentar novo catálogo');
+  });
+
+  it('sem notes usa visitReason padrão', () => {
+    const result = agendaToRouteStop(baseRow, fullProfile, fullAddress);
+    expect(result.visitReason).toBe('Visita agendada');
+  });
+
+  it('sem perfil usa fallback "Cliente" e phone null', () => {
+    const result = agendaToRouteStop(baseRow, undefined, fullAddress);
+
+    expect(result.customerName).toBe('Cliente');
+    expect(result.phone).toBeNull();
+    expect(result.businessHoursOpen).toBeNull();
+    expect(result.businessHoursClose).toBeNull();
+  });
+
+  it('perfil com name null usa fallback "Cliente"', () => {
+    const profileNullName: AgendaStopProfile = { ...fullProfile, name: null };
+    const result = agendaToRouteStop(baseRow, profileNullName, fullAddress);
+
+    expect(result.customerName).toBe('Cliente');
+  });
+
+  it('endereço sem complement não inclui a chave complement no objeto', () => {
+    const addrNoComplement: AgendaStopAddress = { ...fullAddress, complement: null };
+    const result = agendaToRouteStop(baseRow, fullProfile, addrNoComplement);
+
+    expect('complement' in result.address).toBe(false);
+  });
+});

--- a/src/lib/visitas/agenda-to-stop.ts
+++ b/src/lib/visitas/agenda-to-stop.ts
@@ -1,0 +1,81 @@
+// Helper puro: converte uma linha de visita agendada + dados resolvidos de perfil/endereço
+// no input esperado por `enrichWithPriority` (sem os campos de prioridade).
+// PURA — sem chamadas ao Supabase; testável de forma isolada.
+import type { VisitaAgendadaRow } from '@/integrations/supabase/visitasAgendadas';
+
+export interface AgendaStopProfile {
+  name: string | null;
+  phone: string | null;
+  business_hours_open: string | null;
+  business_hours_close: string | null;
+}
+
+export interface AgendaStopAddress {
+  street: string;
+  number: string;
+  neighborhood: string;
+  city: string;
+  state: string;
+  zip_code: string;
+  complement: string | null;
+}
+
+export interface AgendaRouteStopInput {
+  id: string;
+  stopType: 'scheduled_visit';
+  customerUserId: string;
+  customerName: string;
+  phone: string | null;
+  address: {
+    street: string;
+    number: string;
+    neighborhood: string;
+    city: string;
+    state: string;
+    zip_code: string;
+    complement?: string;
+  };
+  timeSlot: null;
+  businessHoursOpen: string | null;
+  businessHoursClose: string | null;
+  status: 'scheduled';
+  visitReason: string;
+}
+
+/**
+ * Converte uma linha de `visitas_agendadas` + dados resolvidos de perfil/endereço
+ * no formato de input do `enrichWithPriority`.
+ *
+ * - `id` = `scheduled-visit-{row.id}`
+ * - `customerName` = nome do perfil ou 'Cliente'
+ * - `address` = campos do endereço (strings vazias se addr ausente)
+ * - `complement` = omitido do objeto quando ausente (undefined)
+ * - `visitReason` = 'Agendada · {notes}' quando há notas; 'Visita agendada' quando não há
+ */
+export function agendaToRouteStop(
+  row: VisitaAgendadaRow,
+  profile: AgendaStopProfile | undefined,
+  addr: AgendaStopAddress | undefined,
+): AgendaRouteStopInput {
+  return {
+    id: `scheduled-visit-${row.id}`,
+    stopType: 'scheduled_visit',
+    customerUserId: row.customer_user_id,
+    customerName: profile?.name ?? 'Cliente',
+    phone: profile?.phone ?? null,
+    address: {
+      street: addr?.street ?? '',
+      number: addr?.number ?? '',
+      neighborhood: addr?.neighborhood ?? '',
+      city: addr?.city ?? '',
+      state: addr?.state ?? '',
+      zip_code: addr?.zip_code ?? '',
+      ...(addr?.complement ? { complement: addr.complement } : {}),
+    },
+    timeSlot: null,
+    businessHoursOpen: profile?.business_hours_open ?? null,
+    businessHoursClose: profile?.business_hours_close ?? null,
+    status: 'scheduled',
+    visitReason: row.notes ? `Agendada · ${row.notes}` : 'Visita agendada',
+  };
+}


### PR DESCRIPTION
## Resumo

**Fase 2** da feature "Agendar visita" (Fase 1 = #495). As visitas agendadas **pendentes de hoje** agora aparecem como **parada no route planner** (no mapa + na rota otimizada), com badge **"Agendada"** (amarela, ícone calendário) — completando o "entram como parada na rota do dia agendado" do design.

- **`StopType` ganha `'scheduled_visit'`** + entradas em `STOP_CONFIG` (badge "Agendada"), `STOP_DURATION_MIN` (20min) e no `getStopIcon`.
- **`loadScheduledVisits()`** no `useRoutePlanner`: busca as agendadas pendentes do dia (do próprio vendedor), resolve nome/endereço (bulk, sem N+1) e monta `RouteStop[]`. Entra no `allStops` nos modos **comercial** e **híbrido**, **deduplicado** contra clientes já presentes (logística/comercial têm precedência). Gated em `user && isStaff`.
- **Prioridade explícita** (`70/'alta'/['Agendada manualmente']`) — `enrichWithPriority` daria 0 ('baixa') para uma agendada (compromisso explícito do vendedor merece prioridade real na ordenação da rota).
- **Helper puro TDD** `agendaToRouteStop(row, profile, addr)` (`src/lib/visitas/agenda-to-stop.ts`, 7 testes) faz o mapeamento row→stop.
- **Check-in pelo card da rota** já fecha a agenda (via o trigger da Fase 1) e o **geocoding** (Nominatim) pega a parada nova automaticamente — sem código extra.

Spec: `docs/superpowers/specs/2026-05-30-agendar-visita-design.md` (§7.3) · Plano: `docs/superpowers/plans/2026-05-30-agendar-visita.md` (Task 8).

## Sem backend
**Front puro** — zero migration, zero Edge Function. Depende apenas da **migration da Fase 1 (#495)** já aplicada no Lovable + tipos regenerados pra funcionar em runtime (sem ela, a query falha e a fonte vira `[]` graciosamente, sem crash).

## Test Plan
- [x] `bun run test` — 1832/1832 (inclui `agendaToRouteStop`)
- [x] `bunx tsc --noEmit -p tsconfig.app.json` — 0 erros (todos os `Record<StopType>` estendidos)
- [x] `bun lint` — 0 errors
- [ ] **QA no device** (pós-migration da Fase 1 aplicada): agendar um cliente pra **hoje** → abrir `/admin/route-planner` (modo comercial/híbrido) → a parada aparece com badge **"Agendada"** no mapa e na lista; check-in pelo card fecha a agenda; cliente que já é parada comercial/logística NÃO duplica.

## Limitações / notas
- Modo **logística puro** não inclui agendadas (são visitas comerciais) — intencional.
- Dívida pré-existente (não desta PR): `useEffect` dos loaders do hook não lista as funções nos deps (padrão sistêmico do hook; warning não-bloqueante).

🤖 Generated with [Claude Code](https://claude.com/claude-code)