### PR TITLE
feat(financeiro): lente contábil agregada (DSO) pro colacor

### DIFF
--- a/src/components/financeiro/cashflow/PosicaoAgora.tsx
+++ b/src/components/financeiro/cashflow/PosicaoAgora.tsx
@@ -9,6 +9,7 @@ import { Building2 } from 'lucide-react';
 import { usePosicaoAgora } from './posicaoAgora/usePosicaoAgora';
 import { KpiCards } from './posicaoAgora/KpiCards';
 import { CicloFinanceiroCard } from './posicaoAgora/CicloFinanceiroCard';
+import { DsoDpoCard } from './posicaoAgora/DsoDpoCard';
 import { Projecao30dCard } from './posicaoAgora/Projecao30dCard';
 import { ComparativoEmpresasCard } from './posicaoAgora/ComparativoEmpresasCard';
 import { ConcentracaoRiscoCard } from './posicaoAgora/ConcentracaoRiscoCard';
@@ -63,6 +64,9 @@ export function PosicaoAgora() {
 
           {/* Ciclo Financeiro Visual */}
           <CicloFinanceiroCard active={active} />
+
+          {/* Lente contábil agregada (DSO/DPO) — só colacor (liquida em lote → PMR/PMP em "—") */}
+          {active.company === 'colacor' && <DsoDpoCard />}
 
           {/* Projeção 30 dias */}
           <Projecao30dCard active={active} />

--- a/src/components/financeiro/cashflow/posicaoAgora/DsoDpoCard.tsx
+++ b/src/components/financeiro/cashflow/posicaoAgora/DsoDpoCard.tsx
@@ -1,0 +1,75 @@
+// Lente contábil agregada (DSO) — alternativa honesta ao PMR title-based pra empresas
+// que liquidam em lote (colacor). Point-in-time (AR aberto ÷ receita bruta TTM); NÃO usa
+// data de baixa. Colacor-only (v1). DPO FORA da v1 (codex): AP do colacor inclui
+// matéria-prima/capex/tributo (≠ CMV) → DPO-sobre-CMV seria incoerente (~1300+ dias).
+// Ver dso-dpo-helpers.ts + §5.
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Scale } from 'lucide-react';
+import { useQuery } from '@tanstack/react-query';
+import { getDsoDpoColacor } from '@/services/financeiroService';
+
+export function DsoDpoCard() {
+  const { data, isLoading } = useQuery({
+    queryKey: ['dso-dpo-colacor'],
+    queryFn: () => getDsoDpoColacor(),
+    staleTime: 5 * 60 * 1000,
+  });
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base flex items-center gap-2">
+          <Scale className="w-4 h-4" />
+          Lente contábil agregada (DSO)
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {isLoading ? (
+          <div className="text-sm text-muted-foreground">Calculando…</div>
+        ) : !data || data.dso === null ? (
+          <div className="p-4 rounded-lg bg-muted/40 border text-sm text-muted-foreground">
+            <p className="font-medium text-foreground">DSO indisponível</p>
+            <p className="mt-1">
+              Depende de 12 meses fechados de DRE (competência) com receita &gt; 0. O DRE competência
+              do colacor precisa ser <strong>regenerado</strong>: o contas-a-receber ficou congelado
+              em 2022 até a correção recente (#426), então os snapshots de DRE ainda refletem receita
+              zerada. Após regenerar (e validar), o DSO aparece aqui automaticamente.
+            </p>
+            {data && (
+              <div className="mt-2 text-xs space-y-1">
+                {data.caveats
+                  .filter((c) => c.includes('TTM') || c.includes('incoerente_plausibilidade'))
+                  .map((c) => (
+                    <p key={c}>• {c}</p>
+                  ))}
+              </div>
+            )}
+          </div>
+        ) : (
+          <>
+            <p className="text-xs text-muted-foreground">
+              Período: {data.periodo_label} · últimos 12 meses fechados (competência)
+            </p>
+            <div className="rounded-lg border p-3">
+              <div className="text-sm text-muted-foreground">
+                DSO <span className="text-xs">· sobre receita bruta · point-in-time</span>
+              </div>
+              <div className="kpi-value text-2xl mt-1">{data.dso} dias</div>
+            </div>
+            <div className="p-3 rounded-lg bg-muted/40 border text-xs text-muted-foreground space-y-1">
+              {data.caveats
+                .filter((c) => !c.toLowerCase().includes('dpo'))
+                .map((c) => (
+                  <p key={c}>• {c}</p>
+                ))}
+              <p>
+                • DPO omitido na v1: o AP do colacor inclui matéria-prima/capex/tributo (≠ CMV) e não
+                há denominador de compras confiável — DPO-sobre-CMV seria incoerente.
+              </p>
+            </div>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/lib/financeiro/__tests__/dso-dpo-helpers.test.ts
+++ b/src/lib/financeiro/__tests__/dso-dpo-helpers.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from 'vitest';
+import { calcularDsoDpo, janelaTTM, type DsoDpoInput } from '../dso-dpo-helpers';
+
+const base: DsoDpoInput = {
+  arAberto: 100_000,
+  apAberto: 60_000,
+  receitaBrutaTTM: 1_200_000,
+  cmvTTM: 730_000,
+  mesesFechados: 12,
+  diasPeriodo: 365,
+  periodoLabel: 'jun/2025–mai/2026',
+};
+
+describe('calcularDsoDpo', () => {
+  it('calcula DSO = AR aberto ÷ receita_bruta diária TTM (arredondado em dias)', () => {
+    // 100.000 / (1.200.000/365) = 100.000 / 3287,67 = 30,42 → 30
+    const r = calcularDsoDpo(base);
+    expect(r.dso).toBe(30);
+  });
+
+  it('calcula DPO = AP aberto ÷ CMV diário TTM', () => {
+    // 60.000 / (730.000/365) = 60.000 / 2000 = 30
+    const r = calcularDsoDpo(base);
+    expect(r.dpo).toBe(30);
+  });
+
+  it('AR aberto = 0 com receita > 0 → DSO 0 (NÃO null) [codex]', () => {
+    const r = calcularDsoDpo({ ...base, arAberto: 0 });
+    expect(r.dso).toBe(0);
+  });
+
+  it('AP aberto = 0 com CMV > 0 → DPO 0', () => {
+    const r = calcularDsoDpo({ ...base, apAberto: 0 });
+    expect(r.dpo).toBe(0);
+  });
+
+  it('receita TTM ausente/≤0 → DSO null', () => {
+    expect(calcularDsoDpo({ ...base, receitaBrutaTTM: 0 }).dso).toBeNull();
+    expect(calcularDsoDpo({ ...base, receitaBrutaTTM: null }).dso).toBeNull();
+    expect(calcularDsoDpo({ ...base, receitaBrutaTTM: -5 }).dso).toBeNull();
+  });
+
+  it('CMV TTM ausente/≤0 → DPO null', () => {
+    expect(calcularDsoDpo({ ...base, cmvTTM: 0 }).dpo).toBeNull();
+    expect(calcularDsoDpo({ ...base, cmvTTM: null }).dpo).toBeNull();
+  });
+
+  it('AR/AP aberto null → respectivo indicador null (denominador ok)', () => {
+    expect(calcularDsoDpo({ ...base, arAberto: null }).dso).toBeNull();
+    expect(calcularDsoDpo({ ...base, apAberto: null }).dpo).toBeNull();
+  });
+
+  it('TTM incompleto (<12 meses fechados) → DSO e DPO null + caveat', () => {
+    const r = calcularDsoDpo({ ...base, mesesFechados: 9 });
+    expect(r.dso).toBeNull();
+    expect(r.dpo).toBeNull();
+    expect(r.caveats.some((c) => c.includes('TTM incompleto'))).toBe(true);
+  });
+
+  it('diasPeriodo ≤ 0 → null (sem divisão por zero)', () => {
+    const r = calcularDsoDpo({ ...base, diasPeriodo: 0 });
+    expect(r.dso).toBeNull();
+    expect(r.dpo).toBeNull();
+  });
+
+  it('caveats obrigatórios sempre presentes (snapshot + DPO sobre CMV)', () => {
+    const r = calcularDsoDpo(base);
+    expect(r.caveats.some((c) => c.toLowerCase().includes('point-in-time'))).toBe(true);
+    expect(r.caveats.some((c) => c.toLowerCase().includes('cmv'))).toBe(true);
+  });
+
+  it('disponivel=true se ao menos um indicador computou; false se nenhum', () => {
+    expect(calcularDsoDpo(base).disponivel).toBe(true);
+    expect(calcularDsoDpo({ ...base, mesesFechados: 0 }).disponivel).toBe(false);
+    // só DSO computa (CMV ausente) → ainda disponivel
+    expect(calcularDsoDpo({ ...base, cmvTTM: null }).disponivel).toBe(true);
+  });
+
+  it('saldo negativo (não deveria ocorrer) é tratado como 0, não infla', () => {
+    expect(calcularDsoDpo({ ...base, arAberto: -1000 }).dso).toBe(0);
+  });
+
+  it('guard de plausibilidade: DSO > 730 dias → null + caveat (não mostra falsa precisão)', () => {
+    // AR 1M / receita 100k/ano = 3650 dias → descartado
+    const r = calcularDsoDpo({ ...base, arAberto: 1_000_000, receitaBrutaTTM: 100_000 });
+    expect(r.dso).toBeNull();
+    expect(r.caveats.some((c) => c.includes('incoerente_plausibilidade'))).toBe(true);
+  });
+
+  it('guard de plausibilidade: DPO > 730 (caso colacor real AP 792k / CMV 199k ≈ 1450d) → null', () => {
+    const r = calcularDsoDpo({ ...base, apAberto: 792_550, cmvTTM: 199_482 });
+    expect(r.dpo).toBeNull();
+    expect(r.caveats.some((c) => c.includes('incoerente_plausibilidade'))).toBe(true);
+  });
+
+  it('valor plausível (≤730) NÃO é descartado', () => {
+    // AR 600k / (1.2M/365) = 182,5 → Math.round = 183 dias → mantém (≤730)
+    const r = calcularDsoDpo({ ...base, arAberto: 600_000 });
+    expect(r.dso).toBe(183);
+    expect(r.caveats.some((c) => c.includes('incoerente_plausibilidade'))).toBe(false);
+  });
+
+  it('eco dos insumos no resultado (transparência)', () => {
+    const r = calcularDsoDpo(base);
+    expect(r.ar_aberto).toBe(100_000);
+    expect(r.receita_bruta_ttm).toBe(1_200_000);
+    expect(r.meses_fechados).toBe(12);
+    expect(r.periodo_label).toBe('jun/2025–mai/2026');
+  });
+});
+
+describe('janelaTTM', () => {
+  it('exclui o mês corrente; pega os 12 fechados (meio do ano)', () => {
+    const j = janelaTTM(new Date(2026, 4, 30)); // maio/2026 (corrente, não entra)
+    expect(j.pares).toHaveLength(12);
+    expect(j.pares[0]).toEqual({ ano: 2025, mes: 5 });
+    expect(j.pares[11]).toEqual({ ano: 2026, mes: 4 });
+    expect(j.periodoLabel).toBe('05/2025–04/2026');
+    expect(j.diasPeriodo).toBe(365);
+  });
+
+  it('vira o ano corretamente (janeiro → ano anterior inteiro)', () => {
+    const j = janelaTTM(new Date(2026, 0, 10)); // jan/2026 corrente
+    expect(j.pares[0]).toEqual({ ano: 2025, mes: 1 });
+    expect(j.pares[11]).toEqual({ ano: 2025, mes: 12 });
+    expect(j.periodoLabel).toBe('01/2025–12/2025');
+    expect(j.diasPeriodo).toBe(365);
+  });
+
+  it('conta o dia extra de fevereiro bissexto (2024)', () => {
+    const j = janelaTTM(new Date(2024, 2, 1)); // mar/2024 corrente → TTM mar/23–fev/24
+    expect(j.pares[0]).toEqual({ ano: 2023, mes: 3 });
+    expect(j.pares[11]).toEqual({ ano: 2024, mes: 2 });
+    expect(j.diasPeriodo).toBe(366);
+  });
+});

--- a/src/lib/financeiro/dso-dpo-helpers.ts
+++ b/src/lib/financeiro/dso-dpo-helpers.ts
@@ -1,0 +1,173 @@
+/**
+ * DSO/DPO contábil agregado (point-in-time) — "Lente contábil agregada".
+ *
+ * Alternativa HONESTA ao PMR/PMP title-based pra empresas que liquidam em LOTE
+ * (colacor: cobertura de baixa derivável ~10% → PMR/PMP/ciclo em "—" pelo gate 40%).
+ * NÃO depende da data de baixa: usa o saldo ABERTO de hoje ÷ o fluxo do DRE TTM.
+ *
+ * Metodologia (validada com codex, consult adversarial 2026-05-30):
+ *   • DSO = AR aberto hoje ÷ (receita_BRUTA TTM ÷ dias do período)
+ *     — receita_bruta (não líquida): o AR é face do título, inclui tributo.
+ *   • DPO = AP aberto hoje ÷ (CMV TTM ÷ dias do período)
+ *     — CMV é PROXY de compras (bom só se estoque estável); AP total inclui
+ *       tributo/folha/capex → rotular, NÃO chamar de "prazo médio de pagamento".
+ *   • TTM (12 meses fechados) — capital de giro não pode ser ruidoso (≠ trimestre).
+ *   • Regime COMPETÊNCIA (saldo AR/AP é posição patrimonial; DRE competência).
+ *   • Point-in-time (saldo de hoje, não AR médio): não há série histórica de saldo
+ *     e reconstruir AR médio precisaria da baixa que o colacor não tem.
+ *
+ * Degradação honesta (codex):
+ *   • saldo aberto = 0 com fluxo > 0 → indicador 0 (NÃO null).
+ *   • null SÓ se: denominador (receita/CMV) ausente ou ≤0, OU TTM < 12 meses fechados,
+ *     OU dias do período ≤ 0, OU saldo aberto ausente.
+ *
+ * ⚠️ Só os títulos ABERTOS (OPEN_TITLE_STATUSES) entram no saldo: títulos liquidados
+ * têm `saldo` cheio (bug #396, valor_recebido sempre 0) — contá-los infla o AR/AP.
+ */
+
+export interface DsoDpoInput {
+  /** Σ saldo dos títulos de CR ABERTOS hoje (R$) — só status ∈ OPEN_TITLE_STATUSES. */
+  arAberto: number | null;
+  /** Σ saldo dos títulos de CP ABERTOS hoje (R$). */
+  apAberto: number | null;
+  /** Σ receita_bruta dos meses fechados no TTM (R$, competência). */
+  receitaBrutaTTM: number | null;
+  /** Σ cmv dos meses fechados no TTM (R$, competência). */
+  cmvTTM: number | null;
+  /** nº de meses com snapshot de DRE no TTM (12 = completo). */
+  mesesFechados: number;
+  /** dias cobertos pelo TTM (p/ a taxa diária; ~365). */
+  diasPeriodo: number;
+  /** rótulo do período, ex.: "jun/2025–mai/2026". */
+  periodoLabel: string;
+}
+
+export interface DsoDpoResult {
+  /** dias (arredondado) ou null se indisponível. */
+  dso: number | null;
+  dpo: number | null;
+  // eco dos insumos (transparência/auditoria)
+  ar_aberto: number | null;
+  ap_aberto: number | null;
+  receita_bruta_ttm: number | null;
+  cmv_ttm: number | null;
+  meses_fechados: number;
+  dias_periodo: number;
+  periodo_label: string;
+  /** true se ao menos um dos dois indicadores computou. */
+  disponivel: boolean;
+  caveats: string[];
+}
+
+export const TTM_MESES_MIN = 12;
+
+/**
+ * Teto de plausibilidade (dias). DSO/DPO acima disso é descartado (→ null) em vez de
+ * exibir um número com falsa precisão (codex): 730 dias = 2 anos de receita/compras
+ * parados no balanço = quase certo dado incoerente (ex.: colacor AP 792k ÷ CMV 199k ≈
+ * 1327 dias porque AP inclui matéria-prima/capex/tributo, ≠ CMV). NÃO esconde problema:
+ * o caveat explica a inconsistência; só evita o KPI mentir "1327 dias".
+ */
+export const PLAUSIBILIDADE_TETO_DIAS = 730;
+
+export interface JanelaTTM {
+  /** os 12 pares (ano, mes) dos meses FECHADOS, do mais antigo ao mais recente. */
+  pares: { ano: number; mes: number }[];
+  /** dias cobertos (1º dia do mais antigo → último dia do mais recente). */
+  diasPeriodo: number;
+  /** rótulo "MM/AAAA–MM/AAAA". */
+  periodoLabel: string;
+}
+
+/**
+ * Janela TTM = os 12 meses FECHADOS (exclui o mês corrente, que está em curso).
+ * Pura (recebe `hoje`) → testável e sem surpresa de fuso (usa componentes locais).
+ * Ex.: hoje=2026-05-xx → 05/2025 … 04/2026.
+ */
+export function janelaTTM(hoje: Date): JanelaTTM {
+  const y = hoje.getFullYear();
+  const m = hoje.getMonth(); // 0-11, mês corrente (em curso, NÃO entra)
+  const pares: { ano: number; mes: number }[] = [];
+  for (let i = TTM_MESES_MIN; i >= 1; i--) {
+    const d = new Date(y, m - i, 1); // i meses atrás do 1º dia do mês corrente
+    pares.push({ ano: d.getFullYear(), mes: d.getMonth() + 1 });
+  }
+  const oldest = pares[0];
+  const newest = pares[pares.length - 1];
+  const inicio = new Date(oldest.ano, oldest.mes - 1, 1);
+  const fim = new Date(newest.ano, newest.mes, 0); // dia 0 do mês seguinte = último dia
+  const diasPeriodo = Math.round((fim.getTime() - inicio.getTime()) / 86_400_000) + 1;
+  const fmt = (p: { ano: number; mes: number }) => `${String(p.mes).padStart(2, '0')}/${p.ano}`;
+  return { pares, diasPeriodo, periodoLabel: `${fmt(oldest)}–${fmt(newest)}` };
+}
+
+const CAVEAT_SNAPSHOT =
+  'Point-in-time: saldo aberto de HOJE ÷ fluxo dos últimos 12m — sensível a pico recente de faturamento; é lente de balanço agregada, NÃO prazo por título (≠ PMR/PMP).';
+const CAVEAT_DPO_CMV =
+  'DPO calculado sobre CMV (proxy de compras) e AP total (inclui tributo/folha/capex) — não é o prazo médio de pagamento real a fornecedores.';
+
+/** AR/AP aberto ÷ fluxo diário (TTM). Aplica a degradação honesta. */
+function razaoEmDias(
+  saldoAberto: number | null,
+  fluxoTTM: number | null,
+  diasPeriodo: number,
+  ttmOk: boolean,
+): number | null {
+  if (!ttmOk) return null;
+  // denominador ausente ou ≤0 → não dá pra calcular
+  if (fluxoTTM == null || !(fluxoTTM > 0)) return null;
+  // saldo ausente → null; saldo 0 (ou negativo, que não deveria ocorrer) → 0 com fluxo>0
+  if (saldoAberto == null) return null;
+  const saldo = saldoAberto > 0 ? saldoAberto : 0;
+  const fluxoDiario = fluxoTTM / diasPeriodo;
+  return Math.round(saldo / fluxoDiario);
+}
+
+export function calcularDsoDpo(input: DsoDpoInput): DsoDpoResult {
+  const { arAberto, apAberto, receitaBrutaTTM, cmvTTM, mesesFechados, diasPeriodo, periodoLabel } =
+    input;
+
+  const ttmOk = mesesFechados >= TTM_MESES_MIN && diasPeriodo > 0;
+
+  const dsoRaw = razaoEmDias(arAberto, receitaBrutaTTM, diasPeriodo, ttmOk);
+  const dpoRaw = razaoEmDias(apAberto, cmvTTM, diasPeriodo, ttmOk);
+
+  const caveats = [CAVEAT_SNAPSHOT, CAVEAT_DPO_CMV];
+  if (!ttmOk) {
+    caveats.push(
+      `TTM incompleto (${mesesFechados}/${TTM_MESES_MIN} meses fechados${
+        diasPeriodo > 0 ? '' : ', período inválido'
+      }) — DSO/DPO não calculados.`,
+    );
+  }
+
+  // Guard de plausibilidade (codex): descarta valor com falsa precisão em vez de exibi-lo.
+  let dso = dsoRaw;
+  let dpo = dpoRaw;
+  if (dsoRaw !== null && dsoRaw > PLAUSIBILIDADE_TETO_DIAS) {
+    dso = null;
+    caveats.push(
+      `DSO calculado (${dsoRaw} dias) acima do teto de plausibilidade (${PLAUSIBILIDADE_TETO_DIAS}) — descartado (incoerente_plausibilidade: AR aberto vs receita fora da faixa).`,
+    );
+  }
+  if (dpoRaw !== null && dpoRaw > PLAUSIBILIDADE_TETO_DIAS) {
+    dpo = null;
+    caveats.push(
+      `DPO calculado (${dpoRaw} dias) acima do teto de plausibilidade (${PLAUSIBILIDADE_TETO_DIAS}) — descartado (incoerente_plausibilidade: AP aberto inclui não-CMV, denominador incoerente).`,
+    );
+  }
+
+  return {
+    dso,
+    dpo,
+    ar_aberto: arAberto,
+    ap_aberto: apAberto,
+    receita_bruta_ttm: receitaBrutaTTM,
+    cmv_ttm: cmvTTM,
+    meses_fechados: mesesFechados,
+    dias_periodo: diasPeriodo,
+    periodo_label: periodoLabel,
+    disponivel: dso !== null || dpo !== null,
+    caveats,
+  };
+}

--- a/src/services/financeiroService.ts
+++ b/src/services/financeiroService.ts
@@ -1,6 +1,8 @@
 import { supabase } from "@/integrations/supabase/client";
 import type { Company } from "@/contexts/CompanyContext";
 import { agregarRealizadoPorDia } from "@/lib/financeiro/fluxo-realizado-helpers";
+import { janelaTTM, calcularDsoDpo, type DsoDpoResult } from "@/lib/financeiro/dso-dpo-helpers";
+import { OPEN_TITLE_STATUSES } from "@/lib/financeiro/titulo-status";
 import type {
   FinAgingPagarView,
   FinAgingReceberView,
@@ -804,6 +806,74 @@ export async function getLastSyncTime(): Promise<string | null> {
   }
 
   return latest;
+}
+
+// ═══════════════ Lente contábil agregada — DSO/DPO (colacor) ═══════════════
+
+/** Soma paginada do `saldo` dos títulos ABERTOS (robusto vs cap 1000 do PostgREST). */
+async function somarSaldoAberto(
+  tabela: 'fin_contas_receber' | 'fin_contas_pagar',
+  company: Company,
+): Promise<number> {
+  const PAGE = 1000;
+  const statuses = [...OPEN_TITLE_STATUSES];
+  let from = 0;
+  let total = 0;
+  for (;;) {
+    const { data, error } = await supabase
+      .from(tabela)
+      .select('saldo')
+      .eq('company', company)
+      .in('status_titulo', statuses)
+      .range(from, from + PAGE - 1);
+    if (error) throw error;
+    const rows = (data ?? []) as Array<{ saldo: number | null }>;
+    for (const r of rows) total += r.saldo ?? 0;
+    if (rows.length < PAGE) break;
+    from += PAGE;
+  }
+  return total;
+}
+
+/**
+ * DSO/DPO contábil agregado (point-in-time) do colacor — alternativa honesta ao
+ * PMR/PMP title-based (que fica em "—" pro colacor: liquida em lote, cobertura de
+ * baixa ~10%). NÃO usa data de baixa: saldo aberto de hoje ÷ fluxo do DRE TTM.
+ * Metodologia/degradação no helper. Client-side (sem edge/migration). Colacor-only (v1).
+ */
+export async function getDsoDpoColacor(hoje: Date = new Date()): Promise<DsoDpoResult> {
+  const company: Company = 'colacor';
+  const { pares, diasPeriodo, periodoLabel } = janelaTTM(hoje);
+
+  // DRE competência TTM: getDRE recebe 1 ano por chamada → agrupa os pares por ano.
+  const anos = Array.from(new Set(pares.map((p) => p.ano)));
+  let receitaBrutaTTM = 0;
+  let cmvTTM = 0;
+  let mesesFechados = 0;
+  for (const ano of anos) {
+    const meses = pares.filter((p) => p.ano === ano).map((p) => p.mes);
+    const dre = await getDRE(company, ano, meses, 'competencia');
+    for (const row of dre) {
+      receitaBrutaTTM += row.receita_bruta ?? 0;
+      cmvTTM += row.cmv ?? 0;
+      mesesFechados += 1;
+    }
+  }
+
+  const [arAberto, apAberto] = await Promise.all([
+    somarSaldoAberto('fin_contas_receber', company),
+    somarSaldoAberto('fin_contas_pagar', company),
+  ]);
+
+  return calcularDsoDpo({
+    arAberto,
+    apAberto,
+    receitaBrutaTTM,
+    cmvTTM,
+    mesesFechados,
+    diasPeriodo,
+    periodoLabel,
+  });
 }
 
 // ═══════════════ A2 — Retorno & Valor (contrato com fin-valor-engine) ═══════════════


### PR DESCRIPTION
## O que
Dá ao **colacor** (que liquida em lote → PMR/PMP title-based em "—") um **DSO contábil agregado** point-in-time que NÃO depende da data de baixa: `AR aberto hoje ÷ receita bruta diária TTM`. Seção separada do Ciclo Financeiro, colacor-only (v1).

## Decisões (codex, 2 consults money-path)
- **DSO sobre receita_bruta TTM** (12m fechados, competência); AR aberto = Σ saldo dos títulos ABERTOS.
- **DPO fora da v1**: AP do colacor (792k) >> CMV (199k) → DPO-sobre-CMV incoerente (~1300d); sem denominador de compras confiável. Card explica.
- **Guard de plausibilidade** (>730 dias → null) pra nunca exibir falsa precisão.
- **Degradação honesta**: receita≤0 ou <12 meses → null; AR=0 c/ receita>0 → 0.
- Soma de AR/AP **paginada** (robusto vs cap 1000).

## Validação
Helper puro **19 testes** (vitest) + janela TTM (off-by-one/bissexto) + guard. `validate` local verde (strict+baseline+test+lint+build). **Client-side — sem migration/edge/deploy.**

## ⚠️ Data-fix pra acender o DSO
O card mostra **"DSO indisponível"** (empty-state acionável) até o **DRE competência do colacor ser regenerado** (o CR ficou congelado em 2022 até #426; snapshots de DRE ainda com receita zerada). `calcular_dre` pós-#426 acende o DSO sem mudança de código.

🤖 Generated with [Claude Code](https://claude.com/claude-code)