### PR TITLE
feat(reposição): parser Sayerlack lê variante-espaço + tela mede risco do motor

### DIFF
--- a/docs/superpowers/specs/2026-05-30-sentinela-sayerlack-mapeamento-gap-design.md
+++ b/docs/superpowers/specs/2026-05-30-sentinela-sayerlack-mapeamento-gap-design.md
@@ -1,0 +1,78 @@
+# Sentinela — check "motor Sayerlack sem de-para" — Design
+
+**Data:** 2026-05-30
+**Status:** especado (follow-up do PR do parser-variante-espaço + fonte-motor). **NÃO implementar antes do backlog do gap cair pra ~0** (senão nasce vermelho permanente).
+
+## Objetivo
+
+Adicionar um check ao Sentinela de Saúde de Dados que vigia o **quadrante perigoso** do mapeamento Sayerlack: **SKU que o motor de reposição PODE comprar e que está SEM de-para ativo no portal**. Hoje esse gap só é descoberto quando o pedido **falha no disparo** (`status_envio_portal = 'erro_nao_retentavel'`) — reativo, e foi assim que o gap de 94 SKUs passou despercebido. O check antecipa: alerta na transição ok→degradado, antes do pedido falhar.
+
+## Contexto
+
+- O PR anterior (parser `sayerlack-sku` v2 + fonte-motor na tela de Mapeamento SKU) fechou ~87 dos 94 SKUs do gap via auto-apply, deixando ~7 manuais. Mas **o gap reabre silenciosamente** sempre que: um SKU Sayerlack novo entra no Omie com reposição automática ligada, ou um produto fracionado é "promovido", etc. Sem um vigia, só o `erro_nao_retentavel` denuncia — tarde.
+- A medição do risco na tela (`faltantesMotor`) é **client-side e aproximada**: espelha só os predicados do motor que vivem em `sku_parametros` (reposição ligada, tipo automática, ponto/máximo definidos), **não** os de join externo (`familia_nao_comprada`, `omie_products.ativo`, `sku_status_omie.ativo_no_omie`) nem o `NOT ILIKE 450/405ML` por `omie_products.descricao`. Pro check do Sentinela (que é SQL), a hora é de criar a **view fiel** ao motor — assim o check e (opcionalmente) a tela passam a usar a MESMA fonte fiel.
+- Infra do Sentinela ativo (ver `2026-05-27-sentinela-ativo-design.md`): `_data_health_compute()` (fonte única, SECURITY DEFINER, sem gate) → `get_data_health()` (wrapper com redação por papel) + `data_health_watchdog()` (cron `data-health-watchdog */30`, alerta na transição ok→degradado pros domínios não-financeiros via `fin_alertas` + `fornecedor_alerta`). O domínio **reposição** já é coberto pelo watchdog.
+
+## Princípios (herdados do Sentinela ativo)
+
+- **Fonte única de verdade**: o check vive em `_data_health_compute()`; dashboard e watchdog leem dela. A contagem do gap vem de uma **view** (não reimplementar o predicado em dois lugares).
+- **Vigiar EFEITO NO DADO, não status técnico**: o check conta SKUs no quadrante de risco, não "o cron rodou". É falha futura determinística (o motor vai pedir, o portal vai recusar).
+- **Baixo ruído**: 1 email na transição ok→degradado; silêncio enquanto persiste; dismiss na recuperação (count→0).
+- **Sem verde silencioso**: count desconhecido (erro de query) → `unknown`/`broken`, nunca 0.
+
+## Design
+
+### 1. View fiel ao motor — `v_sayerlack_mapeamento_gap`
+`security_invoker = on`, idempotente (`CREATE OR REPLACE`). Espelha os predicados ESTRUTURAIS da RPC `gerar_pedidos_sugeridos_ciclo` (sem o dinâmico `estoque_efetivo <= ponto_pedido` — queremos todos os elegíveis, não só os que precisam HOJE):
+
+```
+FROM sku_parametros sp
+LEFT JOIN sku_grupo_producao sg   ON (empresa, sku)            -- traz grupo_codigo (display)
+LEFT JOIN omie_products op        ON op.omie_codigo_produto::text = sp.sku_codigo_omie::text
+LEFT JOIN familia_nao_comprada fnc ON (empresa, op.familia)
+LEFT JOIN sku_status_omie sso     ON (empresa, sku)
+WHERE sp.empresa='OBEN'
+  AND sp.fornecedor_nome ILIKE '%SAYERLACK%'
+  AND sp.habilitado_reposicao_automatica = TRUE
+  AND COALESCE(sp.tipo_reposicao,'automatica') = 'automatica'
+  AND fnc.id IS NULL
+  AND COALESCE(op.ativo, true) = true
+  AND COALESCE(sso.ativo_no_omie, true) = true
+  AND COALESCE(op.descricao,'') NOT ILIKE '%450ML'
+  AND COALESCE(op.descricao,'') NOT ILIKE '%405ML'
+  AND sp.ponto_pedido IS NOT NULL AND sp.estoque_maximo IS NOT NULL
+  AND NOT EXISTS (SELECT 1 FROM sku_fornecedor_externo m
+                  WHERE m.empresa=sp.empresa AND m.fornecedor_nome ILIKE '%SAYERLACK%'
+                    AND m.sku_omie = sp.sku_codigo_omie::text AND m.ativo = true)
+```
+Colunas: `empresa, sku_codigo_omie, sku_descricao, grupo_codigo`. Reutilizável: a tela de Mapeamento pode trocar a aproximação client-side por esta view (fecha a limitação documentada no PR — opcional).
+
+### 2. Check em `_data_health_compute()`
+Novo check (CTE no `WITH checks`):
+- `source = 'reposicao_mapeamento_sayerlack'`, `domain = 'reposicao'`.
+- `n_gap = (SELECT count(*) FROM v_sayerlack_mapeamento_gap)`.
+- `n_gap_em_pedido_aberto` = SKUs do gap que JÁ estão num `pedido_compra_sugerido` não-disparado (status pendente/aprovado) — esses vão falhar no próximo disparo (urgência maior).
+- **status / severity**:
+  - `n_gap = 0` → `ok` / `info`.
+  - `n_gap_em_pedido_aberto > 0` → `broken` / `critical` (há pedido que vai recusar no portal).
+  - senão (`n_gap > 0`) → `degraded`(ou `stale`, conforme vocabulário vigente) / `warning`.
+- `message`: "N SKUs Sayerlack compráveis pelo motor sem de-para no portal (M já em pedido aberto)".
+- `how_to_fix`: "Mapeamento SKU → Validar mapeamentos → Gravar automaticamente; restante manual".
+- `freshness_basis`: contagem (não é frescor temporal) — usar a convenção do projeto pra checks não-temporais.
+
+### 3. Push
+O domínio `reposicao` já está no IN do `data_health_watchdog`. **Confirmar** que o watchdog itera por `source` dentro do domínio (e não por um source fixo) — se for fixo, adicionar `reposicao_mapeamento_sayerlack` ao conjunto vigiado. Transição ok→degradado/broken → `fin_alertas` (`tipo='data_health_reposicao_mapeamento_sayerlack'`, UNIQUE parcial anti-spam) + enfileira `fornecedor_alerta`. Dismiss no retorno a `ok`.
+
+## Pré-condição de ativação (importante)
+
+**Aplicar a migration do check SÓ depois do backlog do gap estar ~0** (auto-apply dos ~87 + cadastro manual dos ~7 do PR anterior). Se aplicar antes, o check nasce `warning`/`broken` e o watchdog dispara email na hora — vermelho permanente até zerar (anti-padrão que o founder rejeita). Sequência: merge do PR → auto-apply na UI → mapear os 7 → **então** colar a migration do check (nasce verde, vira regressão alertável).
+
+## Não-objetivos
+
+- Não vigia outros fornecedores de portal (só Sayerlack/OBEN tem automação de portal hoje).
+- Não auto-corrige (não dispara o auto-apply sozinho) — só alerta; a gravação segue revisada por humano (gate do gabarito).
+- Não mede o dinâmico "precisa repor hoje" — o check é estrutural (quem PODE ser pedido), não "quem será pedido neste ciclo".
+
+## Migration (ritual Lovable — CLAUDE.md §5)
+
+1 migration custom (view + `CREATE OR REPLACE` de `_data_health_compute` com o check novo; e ajuste do watchdog se o IN for por source fixo). Entregar o SQL inline pra colar no SQL Editor + query de validação (`SELECT source, status, severity, message FROM get_data_health() WHERE source='reposicao_mapeamento_sayerlack'`). Consult codex no desenho da view (fidelidade ao motor) recomendado.

--- a/src/components/skuMapeamento/ValidacaoDialog.tsx
+++ b/src/components/skuMapeamento/ValidacaoDialog.tsx
@@ -75,10 +75,19 @@ export function ValidacaoDialog({ open, onOpenChange, validando, validacao, grav
                         <div key={s.sku_omie}>{s.sku_omie} → <b>{s.sku_portal}</b> <span className="text-muted-foreground">({s.sufixo})</span></div>
                       ))}
                     </div>
-                    <Button size="sm" onClick={() => gravarSeguros(validacao.sugestoes!.seguros)} disabled={gravandoSeguros}>
-                      {gravandoSeguros ? <Loader2 className="h-4 w-4 mr-1 animate-spin" /> : <Wand2 className="h-4 w-4 mr-1" />}
-                      Gravar {validacao.sugestoes.seguros.length} automaticamente (fator 1 · revise)
-                    </Button>
+                    {(validacao.gabarito?.divergem.length ?? 0) > 0 ? (
+                      // GATE money-path: se o parser DIVERGE de algum mapeamento manual, não auto-gravar
+                      // em lote — gravar agora arriscaria de-para errado (PO errado no fornecedor).
+                      <div className="text-xs text-status-warning border-t pt-2">
+                        Auto-gravação bloqueada: resolva as {validacao.gabarito!.divergem.length} divergência(s) do gabarito
+                        acima antes de gravar em lote (o parser discorda de um mapeamento manual existente).
+                      </div>
+                    ) : (
+                      <Button size="sm" onClick={() => gravarSeguros(validacao.sugestoes!.seguros)} disabled={gravandoSeguros}>
+                        {gravandoSeguros ? <Loader2 className="h-4 w-4 mr-1 animate-spin" /> : <Wand2 className="h-4 w-4 mr-1" />}
+                        Gravar {validacao.sugestoes.seguros.length} automaticamente (fator 1 · revise)
+                      </Button>
+                    )}
                   </>
                 ) : (
                   <div className="text-xs text-muted-foreground border-t pt-2">Nenhum código novo extraível dos faltantes.</div>
@@ -91,13 +100,17 @@ export function ValidacaoDialog({ open, onOpenChange, validando, validacao, grav
               </div>
             )}
 
-            {validacao.faltantes.length > 0 ? (
+            {validacao.faltantesMotor.length > 0 ? (
               <Alert variant="destructive">
                 <AlertTriangle className="h-4 w-4" />
-                <AlertTitle>{validacao.faltantes.length} SKU(s) sem mapeamento</AlertTitle>
+                <AlertTitle>{validacao.faltantesMotor.length} SKU(s) que o motor pode pedir sem de-para no portal</AlertTitle>
                 <AlertDescription>
-                  <div className="max-h-48 overflow-y-auto mt-2 space-y-1 text-xs">
-                    {validacao.faltantes.map((f) => (
+                  <div className="text-xs mt-1 mb-2">
+                    Compráveis pela reposição automática e sem mapeamento ativo — o disparo falharia
+                    com "erro_nao_retentavel". {validacao.faltantes.length} também aparecem no histórico de pedidos.
+                  </div>
+                  <div className="max-h-48 overflow-y-auto space-y-1 text-xs">
+                    {validacao.faltantesMotor.map((f) => (
                       <div key={f.sku_codigo_omie} className="font-mono">
                         {f.sku_codigo_omie} — {f.sku_descricao}
                       </div>
@@ -108,7 +121,7 @@ export function ValidacaoDialog({ open, onOpenChange, validando, validacao, grav
             ) : (
               <Alert>
                 <CheckCircle2 className="h-4 w-4" />
-                <AlertTitle>Todos os SKUs do histórico estão mapeados</AlertTitle>
+                <AlertTitle>Nenhum SKU comprável pelo motor está sem mapeamento</AlertTitle>
               </Alert>
             )}
 

--- a/src/components/skuMapeamento/__tests__/ValidacaoDialog.test.tsx
+++ b/src/components/skuMapeamento/__tests__/ValidacaoDialog.test.tsx
@@ -10,31 +10,34 @@ describe("ValidacaoDialog", () => {
     expect(document.querySelector(".animate-spin")).toBeTruthy();
   });
 
-  it("mostra faltantes e KPIs", () => {
+  it("mostra o risco do motor (faltantesMotor) + KPIs e a nota do histórico", () => {
     const validacao: ValidacaoResult = {
-      faltantes: [{ empresa: "OBEN", fornecedor_nome: "RENNER", sku_codigo_omie: "999", sku_descricao: "Cola" }],
+      faltantes: [], // histórico vazio
+      faltantesMotor: [{ empresa: "OBEN", fornecedor_nome: "RENNER", sku_codigo_omie: "999", sku_descricao: "Cola" }],
       suspeitos: [],
       total: 5,
       automaticos: 2,
       manuais: 3,
     };
     render(<ValidacaoDialog open onOpenChange={vi.fn()} validando={false} validacao={validacao} gravarSeguros={vi.fn()} gravandoSeguros={false} />);
-    expect(screen.getByText("1 SKU(s) sem mapeamento")).toBeTruthy();
+    expect(screen.getByText("1 SKU(s) que o motor pode pedir sem de-para no portal")).toBeTruthy();
     expect(screen.getByText(/999 — Cola/)).toBeTruthy();
+    expect(screen.getByText(/também aparecem no histórico de pedidos/)).toBeTruthy();
     expect(screen.getByText("5")).toBeTruthy();
   });
 
-  it("mostra sucesso quando não há faltantes", () => {
-    const validacao: ValidacaoResult = { faltantes: [], suspeitos: [], total: 5, automaticos: 5, manuais: 0 };
+  it("mostra sucesso quando o motor não tem faltantes", () => {
+    const validacao: ValidacaoResult = { faltantes: [], faltantesMotor: [], suspeitos: [], total: 5, automaticos: 5, manuais: 0 };
     render(<ValidacaoDialog open onOpenChange={vi.fn()} validando={false} validacao={validacao} gravarSeguros={vi.fn()} gravandoSeguros={false} />);
-    expect(screen.getByText("Todos os SKUs do histórico estão mapeados")).toBeTruthy();
+    expect(screen.getByText("Nenhum SKU comprável pelo motor está sem mapeamento")).toBeTruthy();
   });
 
   it("auto-preenchimento: mostra seguros + gate e dispara gravarSeguros no clique", () => {
     const gravar = vi.fn();
     const seguros = [{ sku_omie: "8689775154", descricao: "POLIULACK BRILHANTE SB.2300.00GL", sku_portal: "SB.2300.00GL", sufixo: "GL" }];
     const validacao: ValidacaoResult = {
-      faltantes: [{ empresa: "OBEN", fornecedor_nome: "RENNER", sku_codigo_omie: "8689775154", sku_descricao: "POLIULACK BRILHANTE SB.2300.00GL" }],
+      faltantes: [],
+      faltantesMotor: [{ empresa: "OBEN", fornecedor_nome: "RENNER", sku_codigo_omie: "8689775154", sku_descricao: "POLIULACK BRILHANTE SB.2300.00GL" }],
       suspeitos: [],
       total: 1,
       automaticos: 0,
@@ -47,5 +50,23 @@ describe("ValidacaoDialog", () => {
     const btn = screen.getByRole("button", { name: /Gravar 1 automaticamente/ });
     fireEvent.click(btn);
     expect(gravar).toHaveBeenCalledWith(seguros);
+  });
+
+  it("GATE: bloqueia auto-gravação quando o gabarito diverge (codex)", () => {
+    const seguros = [{ sku_omie: "999", descricao: "X TEH 3505.00FG", sku_portal: "TEH.3505.00FG", sufixo: "FG" }];
+    const validacao: ValidacaoResult = {
+      faltantes: [],
+      faltantesMotor: [{ empresa: "OBEN", fornecedor_nome: "RENNER", sku_codigo_omie: "999", sku_descricao: "X TEH 3505.00FG" }],
+      suspeitos: [],
+      total: 2,
+      automaticos: 0,
+      manuais: 2,
+      gabarito: { batem: 1, divergem: [{ sku_omie: "A", salvo: "FC.6902L", extraido: "FC.6902L5" }], naoValidavel: 0, total: 2 },
+      sugestoes: { seguros, semCodigo: [], multiplos: [] },
+    };
+    render(<ValidacaoDialog open onOpenChange={vi.fn()} validando={false} validacao={validacao} gravarSeguros={vi.fn()} gravandoSeguros={false} />);
+    // botão de auto-gravar NÃO renderiza; aviso de bloqueio aparece.
+    expect(screen.queryByRole("button", { name: /Gravar .* automaticamente/ })).toBeNull();
+    expect(screen.getByText(/Auto-gravação bloqueada/)).toBeTruthy();
   });
 });

--- a/src/components/skuMapeamento/__tests__/grava-seguros.test.ts
+++ b/src/components/skuMapeamento/__tests__/grava-seguros.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { dividirSegurosParaGravar } from '../grava-seguros';
+import type { SugestaoSegura } from '@/lib/reposicao/sayerlack-sku';
+
+const seg = (sku: string): SugestaoSegura => ({ sku_omie: sku, descricao: '', sku_portal: `P-${sku}`, sufixo: 'QT' });
+
+describe('dividirSegurosParaGravar (auto-apply nunca sobrescreve mapa existente)', () => {
+  it('separa novos (a inserir) de já-existentes (pulados pra revisão)', () => {
+    // skusExistentes = SKUs que JÁ têm linha no banco (ativa OU inativa) no momento do clique.
+    const r = dividirSegurosParaGravar([seg('A'), seg('B'), seg('C')], new Set(['B']));
+    expect(r.novos.map((s) => s.sku_omie)).toEqual(['A', 'C']);
+    expect(r.pulados).toEqual(['B']);
+  });
+
+  it('todos já existem → nada a inserir (nenhuma sobrescrita)', () => {
+    const r = dividirSegurosParaGravar([seg('A'), seg('B')], new Set(['A', 'B']));
+    expect(r.novos).toEqual([]);
+    expect(r.pulados).toEqual(['A', 'B']);
+  });
+
+  it('nenhum existe → todos novos', () => {
+    const r = dividirSegurosParaGravar([seg('A')], new Set<string>());
+    expect(r.novos.map((s) => s.sku_omie)).toEqual(['A']);
+    expect(r.pulados).toEqual([]);
+  });
+});

--- a/src/components/skuMapeamento/grava-seguros.ts
+++ b/src/components/skuMapeamento/grava-seguros.ts
@@ -1,0 +1,20 @@
+import type { SugestaoSegura } from '@/lib/reposicao/sayerlack-sku';
+
+/**
+ * Particiona os mapeamentos "seguros" (auto-extraídos) em:
+ *  - `novos`: sem linha no banco → a inserir;
+ *  - `pulados`: JÁ têm linha (ativa OU inativa) → nunca sobrescrever (revisão manual).
+ *
+ * `skusExistentes` deve ser RE-CONSULTADO no banco no momento da gravação (não do snapshot
+ * do react-query da validação) — fecha a janela de corrida em que outro usuário cria/corrige
+ * um mapa ativo entre validar e gravar. O auto-apply só INSERE; nunca atualiza um de-para
+ * existente (que pode ser um mapa manual correto, ou um inativo intencional). Catch do codex.
+ */
+export function dividirSegurosParaGravar(
+  seguros: SugestaoSegura[],
+  skusExistentes: Set<string>,
+): { novos: SugestaoSegura[]; pulados: string[] } {
+  const novos = seguros.filter((s) => !skusExistentes.has(s.sku_omie));
+  const pulados = seguros.filter((s) => skusExistentes.has(s.sku_omie)).map((s) => s.sku_omie);
+  return { novos, pulados };
+}

--- a/src/components/skuMapeamento/types.ts
+++ b/src/components/skuMapeamento/types.ts
@@ -22,7 +22,8 @@ export interface DescricaoLookup {
 }
 
 export interface ValidacaoResult {
-  faltantes: { empresa: string; fornecedor_nome: string; sku_codigo_omie: string; sku_descricao: string }[];
+  faltantes: { empresa: string; fornecedor_nome: string; sku_codigo_omie: string; sku_descricao: string }[]; // do histórico de pedidos
+  faltantesMotor: { empresa: string; fornecedor_nome: string; sku_codigo_omie: string; sku_descricao: string }[]; // risco real: o motor pode pedir e o portal recusa
   suspeitos: Mapeamento[];
   total: number;
   automaticos: number;

--- a/src/components/skuMapeamento/useSkuMapeamento.ts
+++ b/src/components/skuMapeamento/useSkuMapeamento.ts
@@ -6,6 +6,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
 import { toast } from 'sonner';
 import { EMPTY_FORM } from './config';
+import { dividirSegurosParaGravar } from './grava-seguros';
 import type { Mapeamento, DescricaoLookup, ValidacaoResult } from './types';
 import { validarGabarito, sugerirMapeamentos, ehProdutoFracionado, PARSER_VERSION, type SugestaoSegura } from '@/lib/reposicao/sayerlack-sku';
 
@@ -115,24 +116,47 @@ export function useSkuMapeamento() {
   // unidade_portal = sufixo do código; observacoes marca como auto pro contador `automaticos`.
   const gravarSegurosMut = useMutation({
     mutationFn: async (seguros: SugestaoSegura[]) => {
-      if (seguros.length === 0) return 0;
-      const rows = seguros.map((s) => ({
-        empresa: 'OBEN',
-        fornecedor_nome: 'RENNER SAYERLACK S/A',
-        sku_omie: s.sku_omie,
-        sku_portal: s.sku_portal,
-        unidade_portal: s.sufixo || 'UN',
-        fator_conversao: 1,
-        ativo: true,
-        observacoes: `extraído automaticamente (parser v${PARSER_VERSION})`,
-      }));
-      const { error } = await supabase.from('sku_fornecedor_externo').insert(rows);
-      if (error) throw error;
-      return rows.length;
+      if (seguros.length === 0) return { criados: 0, pulados: [] as string[] };
+      // RE-CONSULTA no clique (não confiar no snapshot do react-query da validação): pega
+      // QUALQUER linha existente — ativa OU inativa — pros SKUs dos seguros. Só inserimos os
+      // genuinamente novos; existentes são PULADOS pra revisão manual. Fecha a janela de corrida
+      // em que um mapa ativo correto poderia ser sobrescrito pelo parser (fator 1). Catch do codex.
+      const { data: existentesData, error: eCheck } = await supabase
+        .from('sku_fornecedor_externo')
+        .select('sku_omie')
+        .eq('empresa', 'OBEN')
+        .ilike('fornecedor_nome', '%SAYERLACK%')
+        .in('sku_omie', seguros.map((s) => s.sku_omie));
+      if (eCheck) throw eCheck;
+      const skusExistentes = new Set((existentesData ?? []).map((r) => (r as { sku_omie: string }).sku_omie));
+      const { novos, pulados } = dividirSegurosParaGravar(seguros, skusExistentes);
+      if (novos.length > 0) {
+        const rows = novos.map((s) => ({
+          empresa: 'OBEN',
+          fornecedor_nome: 'RENNER SAYERLACK S/A',
+          sku_omie: s.sku_omie,
+          sku_portal: s.sku_portal,
+          unidade_portal: s.sufixo || 'UN',
+          fator_conversao: 1,
+          ativo: true,
+          observacoes: `extraído automaticamente (parser v${PARSER_VERSION})`,
+        }));
+        // ignoreDuplicates: INSERT ... ON CONFLICT DO NOTHING — rede contra corrida entre a
+        // re-consulta e o insert; nunca sobrescreve uma linha existente.
+        const { error } = await supabase
+          .from('sku_fornecedor_externo')
+          .upsert(rows, { onConflict: 'empresa,fornecedor_nome,sku_omie', ignoreDuplicates: true });
+        if (error) throw error;
+      }
+      return { criados: novos.length, pulados };
     },
-    onSuccess: (n) => {
+    onSuccess: ({ criados, pulados }) => {
       qc.invalidateQueries({ queryKey: ['sku-mapeamento'] });
-      toast.success(`${n} mapeamento(s) criado(s) automaticamente`);
+      if (criados > 0) toast.success(`${criados} mapeamento(s) criado(s) automaticamente`);
+      if (pulados.length > 0) {
+        toast.info(`${pulados.length} SKU(s) já tinham mapeamento — pulados (revise manualmente): ${pulados.slice(0, 5).join(', ')}${pulados.length > 5 ? '…' : ''}`);
+      }
+      if (criados === 0 && pulados.length === 0) toast.info('Nenhum mapeamento novo a gravar');
       setOpenValidar(false);
     },
     onError: (e: Error) => toast.error(e.message ?? 'Erro ao gravar mapeamentos'),
@@ -163,7 +187,26 @@ export function useSkuMapeamento() {
     setValidando(true);
     setOpenValidar(true);
     try {
-      // SKUs em pedidos Sayerlack OBEN sem mapeamento ativo
+      // (1) UNIVERSO DO MOTOR — o que a engine de reposição PODE sugerir e vai falhar no portal
+      // sem de-para. Espelha os predicados ESTRUTURAIS da RPC gerar_pedidos_sugeridos_ciclo que
+      // vivem em sku_parametros: reposição automática ligada, tipo 'automatica', ponto de pedido
+      // e estoque máximo definidos. NÃO espelha os predicados de join externo (familia_nao_comprada,
+      // omie_products.ativo, sku_status_omie) nem o dinâmico estoque<=ponto — eventual inflação é
+      // benigna (de-para que o motor não chega a usar) e é filtrada na revisão humana antes de gravar.
+      // É a FONTE do risco real (≠ histórico: pega SKU que o motor pede mesmo que nunca tenha sido pedido).
+      const { data: motor, error: e0 } = await supabase
+        .from('sku_parametros')
+        .select('sku_codigo_omie, sku_descricao')
+        .eq('empresa', 'OBEN')
+        .ilike('fornecedor_nome', '%SAYERLACK%')
+        .eq('ativo', true)
+        .eq('habilitado_reposicao_automatica', true)
+        .or('tipo_reposicao.is.null,tipo_reposicao.eq.automatica')
+        .not('ponto_pedido', 'is', null)
+        .not('estoque_maximo', 'is', null);
+      if (e0) throw e0;
+
+      // (2) HISTÓRICO — SKUs que já apareceram em pedidos Sayerlack OBEN (visão complementar).
       const { data: itens, error: e1 } = await supabase
         .from('pedido_compra_item')
         .select('sku_codigo_omie, sku_descricao, pedido_id, pedido_compra_sugerido!inner(empresa, fornecedor_nome)')
@@ -181,6 +224,17 @@ export function useSkuMapeamento() {
           .filter((m) => m.ativo && m.empresa === 'OBEN' && /SAYERLACK/i.test(m.fornecedor_nome))
           .map((m) => m.sku_omie),
       );
+
+      // faltantesMotor: universo do motor − mapeados ativos − fracionados (450/405ml).
+      const faltantesMotor: ValidacaoResult['faltantesMotor'] = [];
+      const vistosMotor = new Set<string>();
+      (motor as Array<{ sku_codigo_omie: string | number; sku_descricao: string }> | null)?.forEach((r) => {
+        const sku = String(r.sku_codigo_omie);
+        if (vistosMotor.has(sku)) return;
+        vistosMotor.add(sku);
+        if (mapAtivos.has(sku) || ehProdutoFracionado(r.sku_descricao)) return;
+        faltantesMotor.push({ empresa: 'OBEN', fornecedor_nome: 'RENNER SAYERLACK S/A', sku_codigo_omie: sku, sku_descricao: r.sku_descricao });
+      });
 
       // SKUs com reposição automática DESLIGADA: o motor não pede → não são "faltantes" reais.
       // (ex.: produtos não-comprados pelo portal, como os 8:1 e o selante base água)
@@ -224,13 +278,15 @@ export function useSkuMapeamento() {
         .map((m) => ({ sku_omie: m.sku_omie, sku_portal: m.sku_portal, descricao: descricoes?.get(m.sku_omie) ?? null }));
       const gabarito = validarGabarito(gabaritoRows);
 
-      // SUGESTÕES: extrai o código da descrição dos faltantes
+      // SUGESTÕES vêm do MOTOR (risco real), não mais só do histórico — fecha o gap que o
+      // motor pode disparar mesmo que o SKU nunca tenha aparecido num pedido anterior.
       const sugestoes = sugerirMapeamentos(
-        faltantes.map((f) => ({ sku_codigo_omie: f.sku_codigo_omie, sku_descricao: f.sku_descricao })),
+        faltantesMotor.map((f) => ({ sku_codigo_omie: f.sku_codigo_omie, sku_descricao: f.sku_descricao })),
       );
 
       setValidacao({
         faltantes,
+        faltantesMotor,
         suspeitos,
         total: mapeamentos?.length ?? 0,
         automaticos,

--- a/src/lib/reposicao/__tests__/sayerlack-sku.test.ts
+++ b/src/lib/reposicao/__tests__/sayerlack-sku.test.ts
@@ -173,3 +173,66 @@ describe('ehProdutoFracionado (não-comprado pelo portal)', () => {
     expect(ehProdutoFracionado('')).toBe(false);
   });
 });
+
+// ─── Variante separador-ESPAÇO (tingidores "TEH 3505.211FG") ───────────────────
+// Descoberta (gap de mapeamento Sayerlack OBEN, 2026-05-30): ~26 tingidores trazem o
+// código na descrição com ESPAÇO no lugar do 1º ponto ("TEH 3505.211FG") em vez do
+// formato pontuado ("TEH.3505.211FG"). O gabarito provou que o sku_portal CORRETO é
+// PONTUADO (4/4 já mapeados usam ponto, manuais e auto), então normalizamos espaço→ponto.
+// A variante é ESTREITA de propósito: EXIGE a 2ª parte pontuada (.\d{2,4}). É isso que
+// rejeita o falso-positivo "PU 6611A" (apontado pelo codex) e o degenerado "TEH 3505.TG5BB".
+describe('sayerlack-sku parser — variante separador-espaço (tingidores)', () => {
+  it.each([
+    ['TINGIDOR CARAMELO TEH 3505.211FG', 'TEH.3505.211FG'],
+    ['TINGIDOR NOGAL MEDIO TEH 3505.110FG', 'TEH.3505.110FG'],
+    ['TINGIDOR LUCIANO 02 TEH 3505.00BB', 'TEH.3505.00BB'],
+    ['TINGIDOR MEL TEH 3505.1210FG', 'TEH.3505.1210FG'],
+    ['TINGIDOR NOGUEIRA CLARO TEH 3505.308BB', 'TEH.3505.308BB'],
+  ])('normaliza espaço→ponto (formato do portal): %s → %s', (desc, esperado) => {
+    const r = resolverSayerlack(desc);
+    expect(r.status).toBe('ok');
+    if (r.status === 'ok') expect(r.codigo).toBe(esperado);
+  });
+
+  it('NÃO cria falso-positivo "PU 6611A" (sem 2ª parte pontuada) — codex', () => {
+    expect(resolverSayerlack('VERNIZ05 PU 6611A BH').status).toBe('sem_codigo');
+  });
+
+  it('NÃO casa o degenerado TG5 (2ª parte não-numérica)', () => {
+    expect(resolverSayerlack('TINGIDOR DETTAGLI TEH 3505.TG5BB').status).toBe('sem_codigo');
+    expect(resolverSayerlack('TINGIDOR DETTAGLI TEH 3505.TG5FG').status).toBe('sem_codigo');
+  });
+
+  // codex challenge: a 2ª parte pontuada NÃO basta — "PU 6611.22BH" / "RAL 9010.20BR" têm a
+  // forma "PALAVRA NNNN.NN+sufixo" mas o prefixo NÃO é de tingidor → seria de-para inventado
+  // (PO errado). A variante-espaço só vale pros prefixos de tingidor observados (TEH/TE/TM/TY).
+  it('NÃO casa "PALAVRA NNNN.NN+sufixo" com prefixo fora da família tingidor', () => {
+    expect(resolverSayerlack('VERNIZ05 PU 6611.22BH').status).toBe('sem_codigo');
+    expect(resolverSayerlack('COR RAL 9010.20BR').status).toBe('sem_codigo');
+    expect(resolverSayerlack('CAIXA AB 1234.56CD').status).toBe('sem_codigo');
+  });
+
+  it('a variante-espaço cobre os prefixos de tingidor (TEH/TE/TM/TY)', () => {
+    expect(resolverSayerlack('TINGIDOR CARAMELO TEH 3505.211FG')).toMatchObject({ status: 'ok', codigo: 'TEH.3505.211FG' });
+    expect(resolverSayerlack('TINGIDOR CONCENTRADO MOGNO TE 3550.62FG')).toMatchObject({ status: 'ok', codigo: 'TE.3550.62FG' });
+    expect(resolverSayerlack('TINTA MORDENTE TM 3610.503FG')).toMatchObject({ status: 'ok', codigo: 'TM.3610.503FG' });
+    expect(resolverSayerlack('ACQUACOLOR TY 1480.7191BG')).toMatchObject({ status: 'ok', codigo: 'TY.1480.7191BG' });
+  });
+
+  it('NÃO casa quando o sufixo está destacado por espaço ("...325 500ML")', () => {
+    expect(resolverSayerlack('TINGIDOR NOGAL ANTIGO TEH 3505.325 500ML').status).toBe('sem_codigo');
+  });
+
+  it('o formato pontuado pré-existente segue intacto (sem dupla-contagem)', () => {
+    expect(extrairCodigosSayerlack('TINGIDOR AMARELO TEH.3550.07FG')).toEqual(['TEH.3550.07FG']);
+  });
+
+  it('sugerirMapeamentos classifica o tingidor-espaço como seguro com sku_portal pontuado', () => {
+    const r = sugerirMapeamentos([
+      { sku_codigo_omie: '8689783786', sku_descricao: 'TINGIDOR CARAMELO TEH 3505.211FG' },
+    ]);
+    expect(r.seguros).toEqual([
+      { sku_omie: '8689783786', descricao: 'TINGIDOR CARAMELO TEH 3505.211FG', sku_portal: 'TEH.3505.211FG', sufixo: 'FG' },
+    ]);
+  });
+});

--- a/src/lib/reposicao/sayerlack-sku.ts
+++ b/src/lib/reposicao/sayerlack-sku.ts
@@ -20,21 +20,37 @@
 // Token do código: começa em fronteira de palavra, letras+díg opcionais, .díg, [.díg]?, sufixo.
 const CODIGO_RE = /\b[A-Z]{2,4}\d{0,2}\.\d{3,4}(?:\.\d{2,4})?[A-Z]{1,3}\d?\b/g;
 
+// Variante separador-ESPAÇO: os TINGIDORES trazem o código com ESPAÇO no lugar do 1º ponto
+// na descrição Omie ("TEH 3505.211FG") em vez do formato pontuado ("TEH.3505.211FG").
+// extrairCodigosSayerlack normaliza a saída (espaço→ponto) — o gabarito provou que o
+// sku_portal correto é PONTUADO (formato que o portal busca).
+// DUPLAMENTE ESTREITA (money-path — catch do codex 2026-05-30):
+//   (a) EXIGE a 2ª parte pontuada (\.\d{2,4}) → rejeita "PU 6611A" (sem 2ª parte);
+//   (b) o PREFIXO é restrito à família de tingidor/mordente/acquacolor (TEH|TE|TM|TY) → sem
+//       isso, "PU 6611.22BH" ou "COR RAL 9010.20BR" (palavra comum + núm.núm) virariam
+//       de-para inventado (PO errado). Só o ponto colado ao prefixo é sinal forte de código;
+//       o espaço é ambíguo, então o prefixo precisa ser de uma família conhecida.
+// TEH antes de TE na alternância (match guloso do prefixo mais longo).
+const CODIGO_ESPACO_RE = /\b(?:TEH|TE|TM|TY)\d{0,2} \d{3,4}\.\d{2,4}[A-Z]{1,3}\d?\b/g;
+
 // O sufixo = trecho final de letras (+ 1 dígito opcional, ex L5) do código.
 const SUFIXO_RE = /([A-Z]{1,3}\d?)$/;
 
-const PARSER_VERSION = 1;
+const PARSER_VERSION = 2; // v2: + variante separador-espaço (tingidores), saída normalizada pra ponto
 export { PARSER_VERSION };
 
 function norm(s: string | null | undefined): string {
   return (s ?? '').normalize('NFKC').trim().toUpperCase();
 }
 
-/** Todos os códigos Sayerlack distintos encontrados na descrição (ordem de aparição). */
+/** Todos os códigos Sayerlack distintos encontrados na descrição (ordem de aparição).
+ *  Casa o formato pontuado e a variante separador-espaço (esta normalizada espaço→ponto). */
 export function extrairCodigosSayerlack(descricao: string | null | undefined): string[] {
   if (!descricao) return [];
-  const matches = norm(descricao).match(CODIGO_RE) ?? [];
-  return [...new Set(matches)];
+  const d = norm(descricao);
+  const pontuados = d.match(CODIGO_RE) ?? [];
+  const espacados = (d.match(CODIGO_ESPACO_RE) ?? []).map((m) => m.replace(' ', '.'));
+  return [...new Set([...pontuados, ...espacados])];
 }
 
 /** O sufixo/embalagem do código (ex.: "QT", "GL", "L5", "CGL"). NÃO é unidade comercial. */


### PR DESCRIPTION
## Contexto

Investigação dos números do mapeamento Sayerlack OBEN revelou o funil real:

- **446** itens Sayerlack no catálogo do Omie (universo amplo)
- **272** em `sku_parametros` (motor de reposição): 254 ativos + 18 inativos
- dos 254 ativos: **251 com grupo** de lead time, **143 com de-para** pro portal
- **94** SKUs ativos com grupo + reposição ligada **sem mapa** → o motor pede e o portal recusa (`status_envio_portal = 'erro_nao_retentavel'`)

Dos 94, o parser antigo só auto-mapeava **61**. Os outros 33: 26 tingidores com o código em formato espaço (`TEH 3505.211FG`) que a regex (só ponto) não pegava + ~7 manuais.

## O que muda

1. **Parser `sayerlack-sku` v2** — lê o código com separador-ESPAÇO e normaliza pra ponto (`TEH 3505.211FG` → `TEH.3505.211FG`; formato do portal confirmado pelo gabarito 4/4). Variante **duplamente estreita** (money-path): exige a 2ª parte pontuada **e** prefixo de tingidor (`TEH|TE|TM|TY`). Rejeita falsos-positivos `PU 6611.22BH` / `RAL 9010.20BR` / `PU 6611A`. **+26 tingidores → cobertura 87/94.** `PARSER_VERSION` 1→2.
2. **Fonte-motor na validação** — a tela passa a medir o risco REAL (`sku_parametros`: reposição ligada, tipo automática, ponto/máximo definidos) além do histórico de pedidos; o auto-apply cobre o universo do motor (não só o que já foi pedido).
3. **Auto-apply seguro** — re-consulta o banco no clique e insere SÓ os novos (`dividirSegurosParaGravar` + `ignoreDuplicates`); nunca sobrescreve mapa ativo/inativo existente; reporta os pulados.
4. **Gate efetivo** — auto-gravação bloqueada quando o gabarito diverge (com a fonte-motor o blast aumentou).

## Validação

- **TDD** nos helpers puros: parser (64 testes, gabarito de 37 reais intacto, 0 falso-positivo) + `dividirSegurosParaGravar` (3).
- Suíte **1841/1841**, lint e typecheck limpos.
- **Codex**: 1 consult (design) + 2 challenges adversariais → **3 P1 corrigidos** (falso-positivo da regex, upsert cego sobre snapshot stale, gate inerte). Re-challenge: _"3 P1 fechados, sem novo P1."_

## Sem migration

Tudo client-side + parser puro. **Não toca o banco.**

## Passos manuais pós-merge

1. Tela **Mapeamento SKU → "Validar mapeamentos" → "Gravar automaticamente"** (fecha ~87; o gate impede se houver divergência no gabarito).
2. Cadastrar à mão os ~7 restantes (2 cartelas, lâmina, 2 dettagli, verniz05, nogal-antigo-500ml).

## Limitações conhecidas / follow-ups

- Fonte-motor é client-side: não espelha os predicados de join externo do motor (família não-comprada, ativo no Omie, status Omie). Inflação possível é **benigna** (de-para correto que o motor não usa hoje) e filtrada na revisão. Fidelidade 100% pediria uma view — tratada no follow-up abaixo.
- Nit teórico (Codex): `X-TE 3505.22FG` casaria por fronteira de hífen, mas exige produto não-tingidor com esse formato exato — sem furo prático.
- **Follow-up especado neste PR** (`docs/superpowers/specs/2026-05-30-sentinela-sayerlack-mapeamento-gap-design.md`): check no Sentinela pro quadrante "motor sem mapa" (alerta antes do `erro_nao_retentavel`), usando uma view fiel ao motor como fonte única. **Ativar só depois do backlog cair pra ~0** (senão vermelho permanente).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
