### PR TITLE
refactor(visitas): tipo gerado em visitasAgendadas (remove cast estreito TS2589)

### DIFF
--- a/src/integrations/supabase/visitasAgendadas.ts
+++ b/src/integrations/supabase/visitasAgendadas.ts
@@ -1,60 +1,18 @@
 import { supabase } from '@/integrations/supabase/client';
+import type { Tables } from '@/integrations/supabase/types';
 
 export type VisitaStatus = 'pendente' | 'realizada' | 'cancelada';
 
-export interface VisitaAgendadaRow {
-  id: string;
-  customer_user_id: string;
-  scheduled_by: string;
-  scheduled_date: string;   // 'YYYY-MM-DD'
-  status: VisitaStatus;
-  visit_type: string;
-  notes: string | null;
-  route_visit_id: string | null;
-  created_at: string;
-  updated_at: string;
-}
-
-// ---------------------------------------------------------------------------
-// Builder estreito — `visitas_agendadas` ainda não está no types.ts gerado.
-// Declarar só os métodos usados evita a instanciação "excessively deep" (TS2589)
-// do builder genérico do Supabase. Este é o ÚNICO ponto de cast (via unknown,
-// nunca any). Pós type-regen via Lovable: trocar por supabase.from('visitas_agendadas').
-// ---------------------------------------------------------------------------
-type DbError = { code?: string; message: string } | null;
-type DbResult<T = unknown> = Promise<{ data: T; error: DbError }>;
-
-export interface VisitaInsert {
-  customer_user_id: string;
-  scheduled_by: string;
-  scheduled_date: string;
-  notes: string | null;
-  visit_type: string;
-  status: string;
-}
-
-export interface VisitaUpdate {
-  scheduled_date?: string;
-  status?: string;
-}
-
-export interface VisitaFilter {
-  select: (cols: string) => VisitaFilter;
-  insert: (row: VisitaInsert) => DbResult;
-  update: (patch: VisitaUpdate) => VisitaFilter;
-  eq: (col: string, val: string) => VisitaFilter;
-  in: (col: string, vals: string[]) => VisitaFilter;
-  order: (col: string, opts: { ascending: boolean }) => VisitaFilter;
-  then: <T>(
-    onFulfilled: (value: { data: unknown; error: DbError }) => T,
-  ) => Promise<T>;
-}
-
-type VisitasClient = { from: (table: 'visitas_agendadas') => VisitaFilter };
-
 /**
- * Builder tipado e estreito para a tabela `visitas_agendadas`. Único ponto de cast.
+ * Row de `visitas_agendadas`. Deriva do tipo gerado (`types.ts`) e estreita
+ * `status` (coluna `text` no banco) pro union de domínio. Os consumidores fazem
+ * o cast estreito no boundary da query (`data as unknown as VisitaAgendadaRow[]`).
  */
-export function visitasAgendadasTable(): VisitaFilter {
-  return (supabase as unknown as VisitasClient).from('visitas_agendadas');
+export type VisitaAgendadaRow = Omit<Tables<'visitas_agendadas'>, 'status'> & {
+  status: VisitaStatus;
+};
+
+/** Builder tipado pra `visitas_agendadas` (tabela já presente no types.ts gerado). */
+export function visitasAgendadasTable() {
+  return supabase.from('visitas_agendadas');
 }


### PR DESCRIPTION
## Resumo
Limpeza prometida no fechamento da feature **Agendar visita**: a tabela `visitas_agendadas` agora está no `types.ts` gerado (regen via Lovable), então o workaround do builder estreito — criado pra evitar o **TS2589** ("excessively deep type instantiation") quando a tabela era untyped — não é mais necessário.

- `visitasAgendadasTable()` retorna `supabase.from('visitas_agendadas')` (builder real tipado).
- `VisitaAgendadaRow` deriva de `Tables<'visitas_agendadas'>` com **override de `status`** pra preservar a união de domínio (`'pendente' | 'realizada' | 'cancelada'`) — a coluna é `text` no banco.
- Remove `VisitaInsert`/`VisitaUpdate`/`VisitaFilter`/`VisitasClient`/`DbError`/`DbResult` (sem consumidores externos — verificado por grep).
- **Consumidores inalterados** (`useVisitasAgendadas`, `useRoutePlanner`): já casteiam no boundary da query (`data as unknown as VisitaAgendadaRow[]`), que segue válido.

**61 → 18 linhas.** Sem mudança de comportamento — refactor de tipos puro.

## Sem backend
Front puro. Nenhuma migration/SQL/edge function. A precondição (tabela no `types.ts`) já está na main.

## Test plan
- [x] typecheck (`tsc -p tsconfig.app.json`): **0**
- [x] lint: **0 errors** (80 warnings de `exhaustive-deps`, baseline, não-bloqueantes)
- [x] test (vitest): **1918/1918**
- [x] build: **✓**

🤖 Generated with [Claude Code](https://claude.com/claude-code)