### PR TITLE
feat(whatsapp): PR2b foundation — opt-in/STOP no inbound + pacing do disparo (phone-free)

### DIFF
--- a/src/lib/whatsapp/disparo.test.ts
+++ b/src/lib/whatsapp/disparo.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { selectDisparoBatch } from './disparo';
+import type { DisparoCandidate, DisparoConfig } from './disparo';
+
+function c(id: string, valor: number, optIn = 'opt_in'): DisparoCandidate {
+  return { customerUserId: id, valorDaLigacao: valor, optInStatus: optIn };
+}
+const CFG: DisparoConfig = { metaTierCap: 1000, disparoInicio: '07:30', disparoCorte: '15:30', jaEnviadosHoje: 0 };
+
+describe('selectDisparoBatch — janela de horário', () => {
+  it('antes do início → pausa fora_da_janela', () => {
+    const r = selectDisparoBatch([c('a', 100)], CFG, '07:00');
+    expect(r.enviarAgora).toEqual([]);
+    expect(r.motivoPausa).toBe('fora_da_janela');
+  });
+  it('depois do corte → pausa fora_da_janela', () => {
+    const r = selectDisparoBatch([c('a', 100)], CFG, '16:00');
+    expect(r.enviarAgora).toEqual([]);
+    expect(r.motivoPausa).toBe('fora_da_janela');
+  });
+  it('dentro da janela → envia', () => {
+    const r = selectDisparoBatch([c('a', 100)], CFG, '09:00');
+    expect(r.enviarAgora.map(x => x.customerUserId)).toEqual(['a']);
+    expect(r.motivoPausa).toBeNull();
+  });
+  it('início e corte são inclusivos', () => {
+    expect(selectDisparoBatch([c('a', 100)], CFG, '07:30').enviarAgora.length).toBe(1);
+    expect(selectDisparoBatch([c('a', 100)], CFG, '15:30').enviarAgora.length).toBe(1);
+  });
+});
+
+describe('selectDisparoBatch — opt-in e teto do tier', () => {
+  it('exclui opt_out; inclui opt_in e unknown (primeiro toque)', () => {
+    const r = selectDisparoBatch([c('a', 100, 'opt_in'), c('b', 90, 'opt_out'), c('u', 80, 'unknown')], CFG, '09:00');
+    expect(r.enviarAgora.map(x => x.customerUserId)).toEqual(['a', 'u']);
+  });
+  it('respeita o cap e sinaliza cap_atingido, preservando a ordem por valor', () => {
+    const q = [c('a', 300), c('b', 200), c('c', 100)];
+    const r = selectDisparoBatch(q, { ...CFG, metaTierCap: 2 }, '09:00');
+    expect(r.enviarAgora.map(x => x.customerUserId)).toEqual(['a', 'b']);
+    expect(r.motivoPausa).toBe('cap_atingido');
+  });
+  it('desconta o já enviado hoje do cap', () => {
+    const q = [c('a', 300), c('b', 200)];
+    const r = selectDisparoBatch(q, { ...CFG, metaTierCap: 5, jaEnviadosHoje: 4 }, '09:00');
+    expect(r.enviarAgora.map(x => x.customerUserId)).toEqual(['a']);
+    expect(r.motivoPausa).toBe('cap_atingido');
+  });
+  it('cap já esgotado → nada, cap_atingido', () => {
+    const r = selectDisparoBatch([c('a', 100)], { ...CFG, metaTierCap: 3, jaEnviadosHoje: 3 }, '09:00');
+    expect(r.enviarAgora).toEqual([]);
+    expect(r.motivoPausa).toBe('cap_atingido');
+  });
+  it('fila vazia dentro da janela → nada, sem motivo de pausa', () => {
+    const r = selectDisparoBatch([], CFG, '09:00');
+    expect(r.enviarAgora).toEqual([]);
+    expect(r.motivoPausa).toBeNull();
+  });
+  it('todos opt_out dentro da janela → nada, sem cap_atingido (não havia elegível)', () => {
+    const r = selectDisparoBatch([c('a', 100, 'opt_out'), c('b', 90, 'opt_out')], CFG, '09:00');
+    expect(r.enviarAgora).toEqual([]);
+    expect(r.motivoPausa).toBeNull();
+  });
+});

--- a/src/lib/whatsapp/disparo.ts
+++ b/src/lib/whatsapp/disparo.ts
@@ -1,0 +1,32 @@
+export interface DisparoCandidate {
+  customerUserId: string;
+  valorDaLigacao: number;
+  optInStatus: string; // 'opt_in' | 'unknown' | 'opt_out'
+}
+export interface DisparoConfig {
+  metaTierCap: number;   // teto de destinatários únicos/24h (ramp da Meta)
+  disparoInicio: string; // 'HH:MM' — só inicia disparo a partir daqui
+  disparoCorte: string;  // 'HH:MM' — para de iniciar disparo após isso (folga p/ faturar)
+  jaEnviadosHoje: number;// quantos já saíram hoje (consome do route_contact_log)
+}
+export interface DisparoResult {
+  enviarAgora: DisparoCandidate[];
+  motivoPausa: 'fora_da_janela' | 'cap_atingido' | null;
+}
+
+/**
+ * Seleciona o lote de disparo proativo agora. PURO/determinístico (hora injetada).
+ * - Fora de [disparoInicio, disparoCorte] (inclusivo) → pausa. Comparação lexicográfica de 'HH:MM' zero-padded.
+ * - Exclui opt_out; opt_in e unknown (primeiro toque) são elegíveis.
+ * - Respeita o teto do tier descontando o já enviado hoje. Preserva a ordem da fila (pré-ordenada por valor).
+ */
+export function selectDisparoBatch(queue: DisparoCandidate[], cfg: DisparoConfig, nowHHMM: string): DisparoResult {
+  if (nowHHMM < cfg.disparoInicio || nowHHMM > cfg.disparoCorte) {
+    return { enviarAgora: [], motivoPausa: 'fora_da_janela' };
+  }
+  const eligible = queue.filter(c => c.optInStatus !== 'opt_out');
+  const remaining = Math.max(0, cfg.metaTierCap - cfg.jaEnviadosHoje);
+  const enviarAgora = eligible.slice(0, remaining);
+  const motivoPausa = eligible.length > remaining ? 'cap_atingido' : null;
+  return { enviarAgora, motivoPausa };
+}

--- a/src/lib/whatsapp/opt-in.test.ts
+++ b/src/lib/whatsapp/opt-in.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { nextOptInStatus } from './opt-in';
+
+describe('nextOptInStatus', () => {
+  it('primeira resposta (unknown) → opt_in (consentimento)', () => {
+    expect(nextOptInStatus('unknown', 'oi, quanto custa?')).toBe('opt_in');
+  });
+  it('PARAR → opt_out, mesmo se estava opt_in', () => {
+    expect(nextOptInStatus('opt_in', 'PARAR')).toBe('opt_out');
+    expect(nextOptInStatus('unknown', 'parar')).toBe('opt_out');
+  });
+  it('opt_out é sticky (mensagem comum não reverte)', () => {
+    expect(nextOptInStatus('opt_out', 'oi de novo')).toBe('opt_out');
+  });
+  it('opt_in continua opt_in', () => {
+    expect(nextOptInStatus('opt_in', 'mais uma pergunta')).toBe('opt_in');
+  });
+  it('inbound sem texto (áudio/imagem) ainda é engajamento → opt_in se unknown', () => {
+    expect(nextOptInStatus('unknown', null)).toBe('opt_in');
+  });
+  it('status vazio tratado como unknown', () => {
+    expect(nextOptInStatus('', 'oi')).toBe('opt_in');
+  });
+});

--- a/src/lib/whatsapp/opt-in.ts
+++ b/src/lib/whatsapp/opt-in.ts
@@ -1,0 +1,17 @@
+import { isStopKeyword } from './stop-keyword';
+
+export type OptInStatus = 'unknown' | 'opt_in' | 'opt_out';
+
+/**
+ * Próximo opt_in_status de uma conversa dado o estado atual e o corpo do inbound.
+ * - "PARAR"/"SAIR"/... → opt_out (LGPD, tem precedência).
+ * - opt_out é STICKY: mensagem comum não reverte (re-inscrição é ação explícita à parte).
+ * - opt_in permanece opt_in.
+ * - unknown / vazio (primeira resposta do cliente) → opt_in (a resposta É consentimento).
+ */
+export function nextOptInStatus(current: string, body: string | null): OptInStatus {
+  if (isStopKeyword(body)) return 'opt_out';
+  if (current === 'opt_out') return 'opt_out';
+  if (current === 'opt_in') return 'opt_in';
+  return 'opt_in';
+}

--- a/supabase/functions/whatsapp-inbound/index.ts
+++ b/supabase/functions/whatsapp-inbound/index.ts
@@ -57,6 +57,22 @@ function timingSafeEq(a: string, b: string): boolean {
   return diff === 0;
 }
 
+// Espelho de src/lib/whatsapp/stop-keyword.ts + opt-in.ts (Deno não importa do src/).
+const STOP_KEYWORDS = new Set(["PARAR", "SAIR", "STOP", "CANCELAR", "DESCADASTRAR"]);
+function isStopKeyword(body: string | null | undefined): boolean {
+  if (!body) return false;
+  const t = body.normalize("NFD").replace(/[̀-ͯ]/g, "")
+    .toUpperCase().replace(/[^A-Z\s]/g, "").trim();
+  return STOP_KEYWORDS.has(t);
+}
+// "PARAR"→opt_out (LGPD, precede); opt_out é sticky; 1ª resposta (unknown)→opt_in.
+function nextOptInStatus(current: string, body: string | null): "unknown" | "opt_in" | "opt_out" {
+  if (isStopKeyword(body)) return "opt_out";
+  if (current === "opt_out") return "opt_out";
+  if (current === "opt_in") return "opt_in";
+  return "opt_in";
+}
+
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
 const SERVICE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
 
@@ -76,10 +92,13 @@ async function processMessage(supabase: ReturnType<typeof createClient>, msg: Pa
 
   // 1) find-or-create da conversa SEM resetar estado (estado só muda se uma msg NOVA entrar).
   let conversationId: string | null = null;
+  let currentOptIn = "unknown";
   const { data: existing } = await supabase.from("whatsapp_conversations")
-    .select("id").eq("phone_key", phoneKey).maybeSingle();
+    .select("id, opt_in_status").eq("phone_key", phoneKey).maybeSingle();
   if (existing) {
-    conversationId = (existing as { id: string }).id;
+    const ex = existing as { id: string; opt_in_status?: string | null };
+    conversationId = ex.id;
+    currentOptIn = ex.opt_in_status ?? "unknown";
   } else {
     const customerUserId = await matchCustomer(supabase, msg.fromPhone);
     let operatorId: string | null = null;
@@ -106,7 +125,10 @@ async function processMessage(supabase: ReturnType<typeof createClient>, msg: Pa
   if (isNew) {
     const nowIso = new Date().toISOString();
     await supabase.from("whatsapp_conversations")
-      .update({ status: "aberta", last_inbound_at: nowIso, last_message_at: nowIso }).eq("id", conversationId);
+      .update({
+        status: "aberta", last_inbound_at: nowIso, last_message_at: nowIso,
+        opt_in_status: nextOptInStatus(currentOptIn, msg.body),
+      }).eq("id", conversationId);
   }
 }
 


### PR DESCRIPTION
## O que é

**PR2b — foundation (phone-free)** do disparo proativo por WhatsApp. Constrói o que dá **sem** a conta 360dialog: consumo de **opt-in/STOP** no inbound + o **motor de pacing** do disparo. O envio real fica pro PR2b-send (quando o número/360dialog estiver onboardado).

- Spec: `docs/superpowers/specs/2026-05-28-whatsapp-pr2-rota-disparo-design.md` (§5 opt-in/cadência, §7 pacing, §8b janela 24h)

**O que entrega:**
- **`nextOptInStatus`** (`src/lib/whatsapp/opt-in.ts`, 6 testes TDD) — o inbox passa a respeitar opt-out: `PARAR/SAIR/STOP/CANCELAR/DESCADASTRAR` → `opt_out` (sticky, LGPD); 1ª resposta do cliente → `opt_in`; `opt_in` permanece. Fiado no edge `whatsapp-inbound` (seta `opt_in_status` em cada inbound **novo**, sem resetar em webhook duplicado — preserva a idempotência do PR1).
- **`selectDisparoBatch`** (`src/lib/whatsapp/disparo.ts`, 10 testes TDD) — pacing do disparo: janela **07:30–15:30** (inclusiva; folga p/ faturar antes das 17:00), exclui `opt_out` (inclui `opt_in` + `unknown` p/ 1º toque), respeita o **teto do tier Meta** descontando o já enviado hoje, preserva ordem por valor. Puro/determinístico (hora injetada). Pronto pro PR2b-send plugar.

## ⚠️ Redeploy de edge necessário após o merge

A fiação do opt-in mexe no edge **`whatsapp-inbound`**. Após o merge, **redeploy via chat do Lovable** (ler `supabase/functions/whatsapp-inbound/index.ts` da main, deploy **verbatim**) pra o consumo de opt-in valer em produção. Sem isso, a main e a prod divergem (o inbox não vai marcar opt-out até o redeploy).

**Sem migration** — a coluna `whatsapp_conversations.opt_in_status` já existe (PR1 fundação).

## Verificação

- ✅ vitest **1934/1934** (+16 novos: opt-in 6 + disparo 10), typecheck (`tsc -p tsconfig.app.json`), lint **0 errors**, build (vite) — todos verdes.
- ✅ `deno check` do edge **net-zero** vs main (os 4 erros são atrito pré-existente do `supabase-js` sem generic `Database` no Deno; o PR1 subiu com eles, o runtime do Supabase compila/roda fine, o CI não roda deno check).
- ✅ Sem `any`, sem `.or()` cru.

## Ainda bloqueado (próximos)

- **PR2b-send** (disparo real accept-a-proposal: templates Meta, escrita em `route_contact_log`, invocação do `whatsapp-send`) — depende da conta **360dialog + número**.
- **PR2c** — Div/Cajuru diário + dashboard do piloto.
- **Codex §6.5** — passe adversário nos critérios (adiado por RAM).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
