### PR TITLE
fix(reposição): sync lê tipoItem do Omie (Produto Acabado) — Fase 1 do sinal fabricado

### DIFF
--- a/supabase/functions/omie-vendas-sync/index.ts
+++ b/supabase/functions/omie-vendas-sync/index.ts
@@ -23,6 +23,12 @@ interface OmieProdutoCadastro {
   peso_liq?: number;
   cfop?: string;
   recomendacoes_fiscais?: { tipo_produto?: string };
+  // Tipo do item no Omie (00..99; '04' = Produto Acabado = fabricado internamente, nunca comprar).
+  // A doc do Omie usa `tipoItem`; o retorno do ListarProdutos pode vir snake_case (`tipo_item`)
+  // ou no genérico `tipo`. O batch NÃO traz `recomendacoes_fiscais.tipo_produto` (sempre null),
+  // por isso lemos as variações abaixo.
+  tipoItem?: string | number;
+  tipo_item?: string | number;
 }
 
 interface OmiePosEstoque {
@@ -342,7 +348,10 @@ async function syncProducts(supabase: SupabaseClient, startPage = 1, maxPages = 
           peso_liq: prod.peso_liq,
           descricao_familia: prod.descricao_familia,
           cfop: prod.cfop,
-          tipo_produto: prod.recomendacoes_fiscais?.tipo_produto ?? null,
+          // money-path: '04' aqui = Produto Acabado (fabricado, nunca comprar) — usado pelo motor
+          // de reposição e pela auto-criação de OP em submitOrder. Lê o campo REAL do Omie
+          // (tipoItem/tipo_item/tipo), com fallback ao recomendacoes_fiscais legado.
+          tipo_produto: prod.tipoItem ?? prod.tipo_item ?? prod.tipo ?? prod.recomendacoes_fiscais?.tipo_produto ?? null,
         },
         account,
         updated_at: new Date().toISOString(),


### PR DESCRIPTION
## Contexto

Investigando por que tingidores **desenvolvidos** (fabricados internamente — Produto Acabado com Estrutura no Omie) entram no motor de reposição e na tela de de-para Sayerlack, descobrimos (Codex + doc oficial do Omie) que o sinal "produto acabado" **nunca chegou ao banco**: `metadata.tipo_produto` está null em **7903/7903** produtos.

**Causa-raiz:** o `omie-vendas-sync` lia `recomendacoes_fiscais.tipo_produto` — campo que o `ListarProdutos` em **lote** não retorna. O tipo real vem em **`tipoItem`** (top-level no próprio lote; `'04'` = Produto Acabado). Era só ler a chave certa — sem N+1.

## O que muda

`omie-vendas-sync` passa a ler `tipoItem ?? tipo_item ?? tipo ?? recomendacoes_fiscais.tipo_produto` (robusto a variações de nome do retorno do Omie), mantendo o valor em `metadata.tipo_produto` (compatível com quem já lê).

## Bug colateral que isto conserta

[`submitOrder.ts:214-217`](src/services/orderSubmission/submitOrder.ts#L214) **auto-cria ordem de produção** pra Produto Acabado filtrando `metadata.tipo_produto IN ('04','4')`. Como o campo era sempre null, **essa auto-criação nunca disparava** — provável que OPs de produto acabado não estejam sendo criadas automaticamente na venda. Ler o `tipoItem` conserta isso junto.

## Sem migration

Só edge function. **Requer redeploy manual do `omie-vendas-sync` via chat do Lovable** (lendo da `main`, **após o merge** — lição §5/§10: deployar antes do merge pega a main velha).

## Verificação (Fase 1 é a prova do sinal)

Após merge → redeploy → rodar `sync_products` (oben), conferir no SQL Editor:

```sql
SELECT COALESCE(metadata->>'tipo_produto','(null)') AS tipo_produto, count(*) AS qtd
FROM omie_products
WHERE account IN ('oben','vendas')
GROUP BY 1 ORDER BY qtd DESC;
```

Esperado: deixar de ser `(null)` pra todos; aparecer `04` (Produto Acabado) e outros códigos. Aí medimos quantos dos 193 Sayerlack do motor são `04`.

## Próximas fases (Codex)

- **Fase 2:** migration com colunas tipadas (`tipo_item_omie`, `has_estrutura_omie`, `is_fabricado_omie`) + backfill (tipoItem + `geral/malha/ListarEstruturas` em lote).
- **Fase 3:** trava no motor (RPC `is_fabricado_omie IS NOT TRUE`) + tela de de-para + bloqueio no `submitOrder` (erro classificado `produto_fabricado_internamente`).

⚠️ Até a Fase 3, o auto-apply do mapeamento ([#507](https://github.com/LucasSardenbergL/afiacao/pull/507)) segue **segurado** (ainda incluiria os desenvolvidos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
