### PR TITLE
fix(nav): links mortos de "novo pedido" (Gamification + Customer 360)

### DIFF
--- a/src/components/customer360/CustomerHero.tsx
+++ b/src/components/customer360/CustomerHero.tsx
@@ -163,7 +163,7 @@ export function CustomerHero({
               </Button>
             )}
             <Button asChild size="sm">
-              <Link to={`/admin/orders/new?customer=${customer.user_id}`}>
+              <Link to={`/sales/new?customer=${customer.user_id}`}>
                 <ShoppingBag className="w-3.5 h-3.5 mr-1.5" />
                 Novo pedido
               </Link>

--- a/src/pages/Gamification.tsx
+++ b/src/pages/Gamification.tsx
@@ -24,7 +24,7 @@ const LEVEL_CONFIG = [
 
 const PILLAR_CONFIG = [
   { key: 'consistency_score', label: 'Consistência', icon: Target, weight: '40%', description: 'Ferramentas mantidas dentro da janela ideal', hint: 'Cadastre e acompanhe suas ferramentas para melhorar', route: '/tools' },
-  { key: 'organization_score', label: 'Organização', icon: Shield, weight: '20%', description: 'Qualidade de envio das ferramentas', hint: 'Envie ferramentas limpas, identificadas e bem embaladas', route: '/orders/new' },
+  { key: 'organization_score', label: 'Organização', icon: Shield, weight: '20%', description: 'Qualidade de envio das ferramentas', hint: 'Envie ferramentas limpas, identificadas e bem embaladas', route: '/new-order' },
   { key: 'education_score', label: 'Educação', icon: BookOpen, weight: '15%', description: 'Treinamentos técnicos concluídos', hint: 'Complete treinamentos para ganhar pontos aqui', route: '/training' },
   { key: 'referral_score', label: 'Indicação', icon: Users, weight: '15%', description: 'Indicações convertidas', hint: 'Indique profissionais e ganhe pontos quando se tornarem clientes', route: '/support' },
   { key: 'efficiency_score', label: 'Eficiência', icon: Zap, weight: '10%', description: 'Gestão preventiva vs emergencial', hint: 'Planeje manutenções preventivas e evite emergências', route: '/tools' },
@@ -46,7 +46,7 @@ const PILLAR_ACTIONS: Record<string, { tip: string; cta: string; route: string }
   organization_score: {
     tip: 'Melhore a qualidade de envio: ferramentas limpas, identificadas, separadas por tipo e bem embaladas.',
     cta: 'Novo pedido',
-    route: '/orders/new',
+    route: '/new-order',
   },
   education_score: {
     tip: 'Complete treinamentos técnicos disponíveis para ganhar pontos nesse pilar.',


### PR DESCRIPTION
## Resumo
Três links de "novo pedido" apontavam pra rotas **inexistentes**, caindo na tela de detalhe errada (via match de `:id`) ou no NotFound. Bug **pré-existente** (desde o PR #219, 2026-05-23) — não é regressão de nenhuma feature recente. Descoberto ao auditar a saúde da navegação antes do QA.

| Arquivo | Antes (morto) | Depois | Por quê |
|---|---|---|---|
| `Gamification.tsx` (cliente) ×2 | `/orders/new` | `/new-order` | `orders/:id` casaria `id="new"`. `/new-order` = UnifiedOrder modo cliente. |
| `CustomerHero.tsx` (Customer 360, staff) | `/admin/orders/new` | `/sales/new` | `admin/orders/:id` casaria `id="new"` → `AdminOrderDetail` quebrado. `/sales/new` = UnifiedOrder modo staff (com etapa Cliente). |

O param `?customer=` do CustomerHero foi **preservado** (hoje ignorado pelo `useUnifiedOrder`). **Pré-seleção do cliente via URL fica como follow-up** — toca o fluxo de pedido (caminho do dinheiro) e merece desenho próprio, não um patch às pressas. Com este fix o staff já chega na tela certa e seleciona o cliente no passo Cliente (fluxo normal).

## Sem backend
Front puro. 3 strings de rota. Sem migration/SQL/edge.

## Test plan
- [x] typecheck: **0** · lint: **0 errors** · test: **1918/1918** · build: **✓**
- [x] Nenhum teste referenciava as rotas antigas (grep)
- [ ] (amanhã, no device) clicar "Novo pedido" no Customer 360 → cai em `/sales/new`; pilar "Organização" na Gamificação → `/new-order`

🤖 Generated with [Claude Code](https://claude.com/claude-code)