### PR TITLE
fix(gamificação): rota inexistente /orders/new → /new-order

### DIFF
--- a/src/pages/Gamification.tsx
+++ b/src/pages/Gamification.tsx
@@ -24,7 +24,7 @@ const LEVEL_CONFIG = [
 
 const PILLAR_CONFIG = [
   { key: 'consistency_score', label: 'Consistência', icon: Target, weight: '40%', description: 'Ferramentas mantidas dentro da janela ideal', hint: 'Cadastre e acompanhe suas ferramentas para melhorar', route: '/tools' },
-  { key: 'organization_score', label: 'Organização', icon: Shield, weight: '20%', description: 'Qualidade de envio das ferramentas', hint: 'Envie ferramentas limpas, identificadas e bem embaladas', route: '/orders/new' },
+  { key: 'organization_score', label: 'Organização', icon: Shield, weight: '20%', description: 'Qualidade de envio das ferramentas', hint: 'Envie ferramentas limpas, identificadas e bem embaladas', route: '/new-order' },
   { key: 'education_score', label: 'Educação', icon: BookOpen, weight: '15%', description: 'Treinamentos técnicos concluídos', hint: 'Complete treinamentos para ganhar pontos aqui', route: '/training' },
   { key: 'referral_score', label: 'Indicação', icon: Users, weight: '15%', description: 'Indicações convertidas', hint: 'Indique profissionais e ganhe pontos quando se tornarem clientes', route: '/support' },
   { key: 'efficiency_score', label: 'Eficiência', icon: Zap, weight: '10%', description: 'Gestão preventiva vs emergencial', hint: 'Planeje manutenções preventivas e evite emergências', route: '/tools' },
@@ -46,7 +46,7 @@ const PILLAR_ACTIONS: Record<string, { tip: string; cta: string; route: string }
   organization_score: {
     tip: 'Melhore a qualidade de envio: ferramentas limpas, identificadas, separadas por tipo e bem embaladas.',
     cta: 'Novo pedido',
-    route: '/orders/new',
+    route: '/new-order',
   },
   education_score: {
     tip: 'Complete treinamentos técnicos disponíveis para ganhar pontos nesse pilar.',


### PR DESCRIPTION
## Resumo

Corrige um bug pré-existente em `src/pages/Gamification.tsx`: o pilar "Organização" (em `PILLAR_CONFIG` e `PILLAR_ACTIONS`) apontava para `/orders/new` — rota que **não existe** na árvore → caía em `NotFound`. A rota correta do wizard de pedido do cliente é `/new-order`. 2 linhas, 2 ocorrências.

## Contexto

Este branch começou como "gate de rotas staff (RequireStaff)", mas a **mesma feature foi implementada e mergeada em paralelo via #508** ("gating de rota por staff, fail-closed"). Para não duplicar o que já está em produção, reduzi o branch ao **único trabalho não coberto pelo #508**: o fix do Gamification. (O PR original #509 ficou preso em estado CONFLICTING/CLOSED após o reset do branch; este é o substituto limpo.)

## Verificação

- `tsc --noEmit -p tsconfig.app.json`: 0 erros
- `eslint src/pages/Gamification.tsx`: 0 erros
- 1 commit sobre a main atual (diff: `Gamification.tsx | 4 ++--`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)