### PR TITLE
fix(rota): hardening dos critérios da lista de ligação (codex §6.5)

### DIFF
--- a/docs/superpowers/specs/2026-05-28-whatsapp-pr2-rota-disparo-design.md
+++ b/docs/superpowers/specs/2026-05-28-whatsapp-pr2-rota-disparo-design.md
@@ -157,13 +157,21 @@ Ordena `callQueue` e `whatsappQueue` por `valor_da_ligacao` desc.
 - **Novos clientes (cold-start):** entram **sempre** (pedido explícito do founder — ver §9), por uma trilha própria (sem histórico → sem `prontidao_recompra`; usa boas-vindas/intro + cota mínima garantida na fila).
 - **Armadilha consciente:** otimizar só `valor_da_ligacao` ignora win-back e aquisição. Por isso as duas cotas acima são **piso garantido**, aplicadas **antes** do corte por capacidade.
 
-### 6.5 Perguntas abertas pro codex (passe adversário)
-1. A fórmula `P×ticket×margem×prontidão` dupla-conta `prontidao` com `P(converte)` (ambos crescem com `atraso_relativo`)? Separar ou aceitar?
-2. `margem%` média da empresa na v1 é viés aceitável, ou distorce a ordenação a ponto de inverter prioridades? Vale gate só de "margem não-negativa" e ordenar por receita esperada até ter margem por-cliente?
-3. Reserva de 20% win-back: número arbitrário. Como calibrar (valor esperado da recuperação × prob. de sucesso vs. custo de oportunidade do top)?
-4. Cota de cold-start: piso fixo (ex.: 3/dia/vendedora) ou proporcional? Risco de afogar a fila com novos que não pagam.
-5. O corte por capacidade (quantos cabem no dia) deve ser por **tempo estimado de ligação** (não por contagem) — o codex já apontou isso na capacidade. Como estimar o tempo por candidato (histórico de `farmer_calls.duracao`)?
-6. WhatsApp first vs. ligação first por cliente: existe risco de canibalizar (IA fecha barato o que a vendedora fecharia com ticket maior)? Regra de roteamento por ticket_esperado?
+### 6.5 Passe adversário do codex — FEITO (2026-05-31)
+
+Veredito do codex: **sem P1 matemático**; vários **P2 operacionais** que distorceriam o piloto. Decisão (Lucas + Claude + codex) — corrigir os baratos/seguros agora (helpers puros, frontend-only, sem deploy), adiar os que pedem dado real do piloto.
+
+**✅ Corrigidos agora (`src/lib/whatsapp/contact-list.ts`, +3 testes; PR de hardening):**
+- **#3 win-back por VALOR + piso** — era bug: o win-back era ordenado por profundidade de churn (`dias/intervalo`), então sumido **barato** passava na frente de quase-due **lucrativo**. Agora ordena por `valorDaLigacao` e só reserva win-back com `valor >= 70% do corte do top` (`WINBACK_VALUE_FLOOR_PCT`).
+- **#7/#6 dedup de canal** — a `whatsappQueue` não excluía quem estava na `callQueue` (a IA falaria com quem a vendedora ligaria). Agora exclui: humano pega o topo, IA pega o resto elegível.
+- **#4 guardrail cold-start %** — piso fixo de 3/dia virou `min(piso, ceil(cap × 10%))` (`COLD_START_MAX_PCT`) → não afoga a fila quando o cap é pequeno.
+- **#2 nomenclatura** — doc no `valorDaLigacao`: é **valor esperado** (proxy), não lucro real (margem é constante na v1 → não afeta ranking, só escala).
+
+**⏸️ Adiados (precisam de dado do piloto / são maiores — registrar como métrica):**
+- **#1 dupla-contagem prontidão × pConverte** (P2) — ambos co-variam com recência. Direção é desejada (priorizar quem está due); extremos já contidos pelo gate `jit_prematuro` + reserva. De-viés preciso (tirar recência do `pConverte` OU abrandar `prontidao`) exige medir no piloto se a fila super-indexa em sumidos — **e mexer data-free quebraria o gate `jit_prematuro` (que usa `prontidao <= 0.3`)**. Monitorar.
+- **#5 capacidade por TEMPO (min) em vez de contagem** (P2, quase-P1 pelo corte 16:30) — precisa de duração real por bucket (`farmer_calls.duracao`). Vira métrica do piloto + troca de `capacidadeLigacoes` (contagem) por orçamento de minutos no PR2c.
+- **#6 roteamento fino por ticket** (alto-ticket → ligação; baixo/médio previsível → WhatsApp) — o dedup do #7 é a peça v1; routing fino depois.
+- **#8 cadência por janela-de-rota** (em vez de `contatadoHaDias < 3`) — hoje **inerte** (`route_contact_log` vazio até o disparo). Wire no PR2c quando houver dado.
 
 ---
 
@@ -275,7 +283,7 @@ Decisão ao fim: se a IA satura o tier e o lucro/minuto da vendedora está no te
 
 ## 13. Dependências abertas
 
-1. **Passe adversário do codex nos critérios §6** — pendente (OOM da máquina; rodar com RAM livre). Alvos = §6.5.
+1. ✅ **Passe adversário do codex nos critérios §6** — FEITO (2026-05-31). Sem P1; P2 corrigidos (#3/#4/#7/#2) + adiados (#1/#5/#6/#8) — ver §6.5.
 2. **Validar grafia/formato das cidades da rota no banco** — query por-cidade já enviada ao founder; semear `route_schedule` com as chaves confirmadas. Confirmar exclusão de `DIVINÓPOLIS (TO)`.
 3. **Conta 360dialog + número + secrets** (`D360_API_KEY`/`D360_BASE_URL`) — bloqueia PR2b (founder pega o celular no fim de semana).
 4. **Templates Meta aprovados** (accept-a-proposal / boas-vindas) — submeter na 360dialog.

--- a/src/lib/whatsapp/contact-list.test.ts
+++ b/src/lib/whatsapp/contact-list.test.ts
@@ -79,26 +79,35 @@ describe('buildContactList — ordenação, reservas e buckets', () => {
     const vals = r.callQueue.map(c => c.valorDaLigacao);
     expect([...vals].sort((a, b) => b - a)).toEqual(vals); // já ordenado desc
   });
-  it('reserva piso de win-back (clientes sumindo) e cold-start mesmo com top forte', () => {
-    const tops = Array.from({ length: 20 }, (_, i) =>
-      cand({ customerUserId: `top${i}`, ticketEsperado: 5000 }));            // alto valor, no ciclo
-    const winbacks = [cand({ customerUserId: 'wb1', diasDesdeUltima: 90, intervaloMedioDias: 30, ticketEsperado: 800 })];
-    const colds = [cand({ customerUserId: 'cs1', isColdStart: true, diasDesdeUltima: null, intervaloMedioDias: null })];
-    const r = buildContactList([...tops, ...winbacks, ...colds],
-      { winBackReservaPct: 0.2, coldStartPisoDia: 1, capacidadeLigacoes: 10, cadenciaMinDias: 3 });
-    expect(r.callQueue.find(c => c.customerUserId === 'wb1')?.bucket).toBe('winback');
-    expect(r.callQueue.find(c => c.customerUserId === 'cs1')?.bucket).toBe('coldstart');
-    expect(r.callQueue.length).toBe(10);
+  it('win-back reservado é ordenado por VALOR e exige piso (não o sumido mais barato) [codex #3]', () => {
+    const tops = Array.from({ length: 3 }, (_, i) => cand({ customerUserId: `top${i}`, ticketEsperado: 5000 })); // valor 500
+    const wbHi = cand({ customerUserId: 'wbHi', diasDesdeUltima: 45, intervaloMedioDias: 30, ticketEsperado: 4500 }); // winback, valor 450 (>= piso)
+    const wbLo = cand({ customerUserId: 'wbLo', diasDesdeUltima: 90, intervaloMedioDias: 30, ticketEsperado: 400 });  // winback, valor 40 (< piso)
+    const r = buildContactList([...tops, wbHi, wbLo],
+      { winBackReservaPct: 0.34, coldStartPisoDia: 0, capacidadeLigacoes: 3, cadenciaMinDias: 3 });
+    expect(r.callQueue.find(c => c.customerUserId === 'wbHi')?.bucket).toBe('winback'); // valioso entra na reserva
+    expect(r.callQueue.find(c => c.customerUserId === 'wbLo')).toBeUndefined();          // sumido barato NÃO ocupa reserva
+    expect(r.callQueue.length).toBe(3);
   });
-  it('whatsappQueue exclui cold-start, sem-histórico e janela-aberta (vão p/ humano)', () => {
+  it('cold-start é limitado a % do cap (não o piso cego) quando o cap é pequeno [codex #4]', () => {
+    const tops = Array.from({ length: 5 }, (_, i) => cand({ customerUserId: `top${i}`, ticketEsperado: 5000 }));
+    const colds = Array.from({ length: 3 }, (_, i) => cand({ customerUserId: `cs${i}`, isColdStart: true }));
+    const r = buildContactList([...tops, ...colds],
+      { winBackReservaPct: 0, coldStartPisoDia: 3, capacidadeLigacoes: 5, cadenciaMinDias: 3 });
+    // ceil(5*0.10)=1, min(3,1)=1 → só 1 cold-start, não 3
+    expect(r.callQueue.filter(c => c.bucket === 'coldstart').length).toBe(1);
+  });
+  it('whatsappQueue dedup contra callQueue + filtra cold-start/sem-hist/janela [codex #6/#7]', () => {
     const r = buildContactList([
-      cand({ customerUserId: 'wa-ok' }),
+      cand({ customerUserId: 'hi', ticketEsperado: 5000 }),     // topo → vai pra callQueue
+      cand({ customerUserId: 'wa-ok' }),                         // overflow elegível → whatsappQueue
       cand({ customerUserId: 'wa-cold', isColdStart: true }),
       cand({ customerUserId: 'wa-nohist', intervaloMedioDias: null }),
       cand({ customerUserId: 'wa-janela', janela24hAberta: true }),
-    ], CFG);
+    ], { winBackReservaPct: 0, coldStartPisoDia: 0, capacidadeLigacoes: 1, cadenciaMinDias: 3 });
     const ids = r.whatsappQueue.map((x: ScoredCandidate) => x.customerUserId);
     expect(ids).toContain('wa-ok');
+    expect(ids).not.toContain('hi');        // já está na callQueue → não duplica canal
     expect(ids).not.toContain('wa-cold');
     expect(ids).not.toContain('wa-nohist');
     expect(ids).not.toContain('wa-janela');

--- a/src/lib/whatsapp/contact-list.ts
+++ b/src/lib/whatsapp/contact-list.ts
@@ -26,6 +26,13 @@ export function prontidaoRecompra(diasDesdeUltima: number | null, intervaloMedio
   return ratio; // mapeia [0.2,1] → [0.2,1] linear
 }
 
+/**
+ * VALOR ESPERADO (proxy de ordenação), NÃO lucro real. v1: margemPerc é CONSTANTE
+ * (média da empresa) → não afeta o ranking, só a escala. Vira lucro de verdade só com
+ * margem por-cliente/SKU (vem do cockpit de valor — calibração do piloto). Codex §6.5 #2.
+ * ⚠️ prontidao e pConverte podem co-variar com recência (dupla-contagem leve, codex #1):
+ * direção desejada (priorizar quem está due); extremos contidos pelo gate jit_prematuro + reserva.
+ */
 export function valorDaLigacao(c: ContactCandidate): number {
   const pront = prontidaoRecompra(c.diasDesdeUltima, c.intervaloMedioDias);
   return c.pConverte * c.ticketEsperado * c.margemPerc * pront;
@@ -52,7 +59,9 @@ export interface ContactListResult {
 
 const LIMIAR_PRONTIDAO_BAIXA = 0.3;
 const LIMIAR_P_BAIXA = 0.3;
-const LIMIAR_WINBACK = 1.5; // dias/intervalo >= 1.5 → cliente sumindo/churn
+const LIMIAR_WINBACK = 1.5;            // dias/intervalo >= 1.5 → cliente sumindo/churn
+const WINBACK_VALUE_FLOOR_PCT = 0.7;   // win-back só reserva slot se valor >= 70% do corte do top (codex #3)
+const COLD_START_MAX_PCT = 0.10;       // cold-start limitado a ~10% do cap, além do piso (codex #4)
 
 function score(c: ContactCandidate): ScoredCandidate {
   return {
@@ -92,6 +101,9 @@ export function buildContactList(candidates: ContactCandidate[], cfg: ContactCon
   // --- callQueue com reservas (piso) aplicadas ANTES do corte por capacidade ---
   const cap = Math.max(0, Math.floor(cfg.capacidadeLigacoes));
   const winbackSlots = Math.round(cap * cfg.winBackReservaPct);
+  // corte do top: valor do último candidato que entraria no cap → piso p/ reservar win-back (codex #3).
+  const topCutValue = cap > 0 && vivos.length > 0 ? vivos[Math.min(cap, vivos.length) - 1].valorDaLigacao : 0;
+  const winbackFloor = topCutValue * WINBACK_VALUE_FLOOR_PCT;
   const usados = new Set<string>();
   const pick = (pool: ScoredCandidate[], n: number, bucket: Bucket): ScoredCandidate[] => {
     const out: ScoredCandidate[] = [];
@@ -105,16 +117,21 @@ export function buildContactList(candidates: ContactCandidate[], cfg: ContactCon
   };
 
   const coldPool = vivos.filter(s => s.isColdStart);
-  const cold = pick(coldPool, Math.min(cfg.coldStartPisoDia, cap), 'coldstart');
-  const winbackPool = vivos.filter(isWinback).sort((a, b) =>
-    (b.diasDesdeUltima! / b.intervaloMedioDias!) - (a.diasDesdeUltima! / a.intervaloMedioDias!));
+  const coldCap = Math.min(cfg.coldStartPisoDia, Math.ceil(cap * COLD_START_MAX_PCT)); // guardrail %, não piso cego
+  const cold = pick(coldPool, coldCap, 'coldstart');
+  // win-back: ordenado por VALOR (não profundidade de churn) e só acima do piso — não deixa sumido barato roubar reserva.
+  const winbackPool = vivos.filter(s => isWinback(s) && s.valorDaLigacao >= winbackFloor)
+    .sort((a, b) => b.valorDaLigacao - a.valorDaLigacao);
   const winback = pick(winbackPool, Math.min(winbackSlots, cap - cold.length), 'winback');
   const top = pick(vivos, cap - cold.length - winback.length, 'top'); // vivos já ordenado por valor
 
   const callQueue = [...top, ...winback, ...cold]; // top primeiro; reservas garantidas
 
-  // --- whatsappQueue (accept-a-proposal): recompra previsível; fora cold-start/sem-hist/janela aberta ---
-  const whatsappQueue = vivos.filter(s => !s.isColdStart && s.intervaloMedioDias != null && !s.janela24hAberta);
+  // --- whatsappQueue (accept-a-proposal): dedup contra a callQueue (não duplica canal — codex #6/#7);
+  // o humano pega o topo, a IA pega o resto elegível (fora cold-start/sem-hist/janela aberta). Já vem ordenada por valor (vivos).
+  const callIds = new Set(callQueue.map(c => c.customerUserId));
+  const whatsappQueue = vivos.filter(s =>
+    !callIds.has(s.customerUserId) && !s.isColdStart && s.intervaloMedioDias != null && !s.janela24hAberta);
 
   return { callQueue, whatsappQueue, excluidos };
 }


### PR DESCRIPTION
## O que é

Hardening dos critérios da lista de ligação por rota (PR2a) após o **passe adversário do codex (§6.5)**. **Frontend-only** — sem deploy de edge, sem migration.

Veredito do codex: **sem P1 matemático**; P2 operacionais que distorceriam o piloto. Corrigidos os baratos/seguros agora; adiados os que pedem dado real.

**✅ Corrigidos (`src/lib/whatsapp/contact-list.ts`, +3 testes TDD):**
- **#3 win-back por VALOR + piso** — *era bug*: o win-back era ordenado por profundidade de churn (`dias/intervalo`), então um sumido **barato** passava na frente de um quase-due **lucrativo**. Agora ordena por `valorDaLigacao` e só reserva win-back com `valor >= 70%` do corte do top.
- **#7/#6 dedup de canal** — a `whatsappQueue` não excluía quem já estava na `callQueue` (a IA falaria com quem a vendedora vai ligar). Agora exclui: humano pega o topo, IA pega o resto.
- **#4 guardrail cold-start** — piso fixo de 3/dia → `min(piso, ceil(cap×10%))` (não afoga a fila quando o cap é pequeno).
- **#2 nomenclatura** — doc claro: `valorDaLigacao` é **valor esperado** (proxy), não lucro real (margem é constante na v1).

**⏸️ Adiados pro piloto** (ver §6.5 do spec): #1 dupla-contagem prontidão×pConverte (mexer data-free quebraria o gate `jit_prematuro`), #5 capacidade por TEMPO (precisa duração real), #8 cadência por janela-de-rota (`route_contact_log` vazio até o disparo).

## Verificação
- ✅ vitest **1935/1935**, typecheck, lint 0 errors, build — verdes.
- ✅ Sem `any`, sem `.or()` cru. Sem deploy/migration (helper consumido pelo `useRouteContactList`, pega no próximo build do Lovable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)