### PR TITLE
fix(reposição): paginação do omie-vendas-sync com start_page>1 (era no-op silencioso)

### DIFF
--- a/supabase/functions/omie-vendas-sync/index.ts
+++ b/supabase/functions/omie-vendas-sync/index.ts
@@ -296,7 +296,10 @@ async function syncProducts(supabase: SupabaseClient, startPage = 1, maxPages = 
   let totalSynced = 0;
   let pagesProcessed = 0;
 
-  while (pagina <= totalPaginas && pagesProcessed < maxPages) {
+  // `pagesProcessed === 0` força a 1ª iteração mesmo com startPage > 1: totalPaginas (init=1) só é
+  // aprendido DENTRO do loop, então `pagina <= totalPaginas` era falso de cara p/ startPage>1 →
+  // no-op silencioso (não paginava além da pág. 12; bug pego pelo founder 2026-05-31). startPage=1 inalterado.
+  while ((pagina <= totalPaginas || pagesProcessed === 0) && pagesProcessed < maxPages) {
     const result = await callOmieVendasApi(
       "geral/produtos/",
       "ListarProdutos",
@@ -382,7 +385,8 @@ async function syncEstoque(supabase: SupabaseClient, startPage = 1, maxPages = 3
   let totalUpdated = 0;
   let pagesProcessed = 0;
 
-  while (pagina <= totalPaginas && pagesProcessed < maxPages) {
+  // mesmo fix do syncProducts: força a 1ª iteração p/ startPage>1 funcionar (era no-op). startPage=1 inalterado.
+  while ((pagina <= totalPaginas || pagesProcessed === 0) && pagesProcessed < maxPages) {
     const result = await callOmieVendasApi(
       "estoque/consulta/",
       "ListarPosEstoque",
@@ -927,7 +931,9 @@ async function syncPedidos(
     return { address: '', phone: '' };
   }
 
-  while (pagina <= totalPaginas && pagesProcessed < maxPages) {
+  // mesmo fix (syncPedidos): força a 1ª iteração p/ startPage>1 funcionar (era no-op). startPage=1 inalterado —
+  // o fluxo do cron (start_page=1 + janela de data) NÃO muda; só destrava paginação manual além de maxPages.
+  while ((pagina <= totalPaginas || pagesProcessed === 0) && pagesProcessed < maxPages) {
     const listParams: Record<string, unknown> = { pagina, registros_por_pagina: 50, filtrar_apenas_inclusao: "N" };
     if (dateFrom) listParams.filtrar_por_data_de = dateFrom;
     if (dateTo) listParams.filtrar_por_data_ate = dateTo;


### PR DESCRIPTION
## Bug (pego pelo founder ao re-sincronizar produtos pra a Fase 1)

`syncProducts`, `syncEstoque` e `syncPedidos` inicializam `totalPaginas = 1` e usam `while (pagina <= totalPaginas && pagesProcessed < maxPages)`. Como `totalPaginas` só é aprendido **dentro** do loop, qualquer `start_page > 1` torna a condição falsa de cara (`13 <= 1` → false), o loop **nunca executa**, e a função retorna `complete=true, synced=0` enganosamente.

**Efeito:** `start_page > 1` é no-op silencioso → o sync **nunca alcança além da página `maxPages`**. Em produção, o `sync_products` parava em ~1.200 de ~3.700 produtos da Oben (12 de 37 páginas).

Evidência:
- `start_page=1` → totalPaginas=37, 965 sincronizados (pgs 1–12) ✅
- `start_page=13` → totalPaginas=1, 0 sincronizados, `complete=true` ❌ (deveria pegar pgs 13–24)

## Fix

`while ((pagina <= totalPaginas || pagesProcessed === 0) && pagesProcessed < maxPages)` — `pagesProcessed === 0` força a 1ª iteração, que aprende o `total_de_paginas` real; daí em diante `pagina <= totalPaginas` controla normalmente. Aplicado nas **3 funções paginadas** (mesmo bug).

⚠️ **`start_page = 1` (o fluxo do cron) fica inalterado** — o fix só destrava a paginação manual além de `maxPages`. `sync_pedidos` é o mais sensível (money-path de receita), mas seu fluxo de cron (`start_page=1` + janela de data) não muda.

## Verificação

- `deno check`: **5 erros pré-existentes (idêntico à main), 0 introduzidos** pelo fix (os 5 são ruído do deno local sem a config do Edge Runtime; o CI do projeto não roda deno nos edge functions).
- Lógica: `start_page=1` roda igual; `start_page=13` passa a paginar 13→24.

## Sem migration

Só edge function. **Requer redeploy do `omie-vendas-sync` via Lovable** (da `main`, após o merge).

## Pós-merge (destrava a verificação da Fase 1)

Redeploy → invocar `sync_products` oben com `start_page` 1, 13, 25, 37 (4 chamadas, agora funcionam) → cobre as 37 páginas → todos os produtos (incl. os 193 Sayerlack) ganham `tipoItem`. Depois, a query de cobertura do `metadata->>'tipo_produto'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
