### PR TITLE
fix(reposição): cron diário para de ZERAR params de SKUs (causa-raiz do limbo de 146 SKUs)

### DIFF
--- a/supabase/migrations/20260531140000_reposicao_atualizar_params_nao_zera.sql
+++ b/supabase/migrations/20260531140000_reposicao_atualizar_params_nao_zera.sql
@@ -1,0 +1,56 @@
+-- Reposição — atualizar_parametros_numericos_skus para de ZERAR params (causa-raiz do limbo)
+-- ============================================================================
+-- CAUSA-RAIZ (confirmada em prod): a função atualizar_parametros_numericos_skus — rodada pelo CRON
+-- DIÁRIO omie-cron-diario (+ 3 telas) — sobrescrevia os 5 campos de CONFIG com os *_sugerido da
+-- v_sku_parametros_sugeridos SEM COALESCE. Para SKU em status != OK (ex AGUARDANDO_SEGUNDA_ORDEM)
+-- os *_sugerido são NULL → ela ZERAVA ponto_pedido/estoque_maximo/etc, SEM tocar
+-- habilitado_reposicao_automatica. Resultado medido: 146 SKUs (6 fornecedores) habilitado=true +
+-- params NULL = limbo (não compram, re-zerados todo dia); 92 deles tinham config APROVADA por humano,
+-- destruída pelo cron. O motor exige ponto E max NOT NULL → esses SKUs param de comprar silenciosamente.
+--
+-- FIX (challenge codex): COALESCE nos 5 campos de CONFIG — só atualiza quando há sugestão válida
+-- (status OK → sugerido não-NULL → sobrescreve normalmente; status != OK → sugerido NULL → PRESERVA o
+-- valor existente). Métricas derivadas (demanda/lt/z) seguem sempre frescas (não são config humana).
+-- Mesmo padrão de preencher_parametros_faltantes_skus (#487). NÃO congela SKU OK (sugerido não-NULL
+-- ainda sobrescreve). Tirar um SKU da reposição = habilitado_reposicao_automatica=false (NÃO zerar params).
+-- Corpo VERBATIM do snapshot + COALESCE nos 5 config. Validado em PostgreSQL 17 local.
+
+CREATE OR REPLACE FUNCTION public.atualizar_parametros_numericos_skus(p_empresa text) RETURNS integer
+    LANGUAGE plpgsql
+    SET search_path TO 'public', 'pg_temp'
+    AS $$
+DECLARE
+  atualizados int := 0;
+BEGIN
+  UPDATE sku_parametros sp
+  SET
+    sku_descricao = COALESCE(v.sku_descricao, sp.sku_descricao),
+    fornecedor_nome = COALESCE(v.fornecedor_nome, sp.fornecedor_nome),
+    -- métricas derivadas: sempre frescas (não são config humana)
+    demanda_media_diaria = v.demanda_media_diaria,
+    demanda_desvio_padrao = v.demanda_sigma_diario,
+    demanda_coef_variacao = v.coef_variacao_ordem,
+    demanda_dias_com_movimento = v.num_ordens,
+    valor_vendido_90d = v.valor_total_90d,
+    lt_medio_dias_uteis = v.lead_time_medio,
+    lt_desvio_padrao_dias = v.lead_time_desvio,
+    lt_p95_dias = v.lt_p95_dias,
+    fonte_leadtime = v.fonte_leadtime,
+    z_score = v.z_aplicado,
+    -- [FIX limbo 2026-05-31] CONFIG via COALESCE: NÃO zera quando o sugerido é NULL (status != OK).
+    -- Preserva config (inclusive aprovada manualmente) de SKUs que oscilam pra fora de OK.
+    estoque_seguranca = COALESCE(v.estoque_seguranca_sugerido, sp.estoque_seguranca),
+    ponto_pedido = COALESCE(v.ponto_pedido_sugerido, sp.ponto_pedido),
+    estoque_minimo = COALESCE(v.estoque_minimo_sugerido, sp.estoque_minimo),
+    cobertura_alvo_dias = COALESCE(v.cobertura_alvo_dias, sp.cobertura_alvo_dias),
+    estoque_maximo = COALESCE(v.estoque_maximo_sugerido, sp.estoque_maximo),
+    ultima_atualizacao_calculo = NOW()
+  FROM v_sku_parametros_sugeridos v
+  WHERE sp.empresa = v.empresa
+    AND sp.sku_codigo_omie = v.sku_codigo_omie
+    AND sp.empresa = p_empresa;
+
+  GET DIAGNOSTICS atualizados = ROW_COUNT;
+  RETURN atualizados;
+END;
+$$;


### PR DESCRIPTION
## Causa-raiz (confirmada em produção)

A função **`atualizar_parametros_numericos_skus`** — rodada pelo **cron diário `omie-cron-diario`** (+ 3 telas) — sobrescrevia os 5 campos de config (`ponto_pedido`, `estoque_maximo`, `estoque_minimo`, `estoque_seguranca`, `cobertura_alvo_dias`) com os `*_sugerido` da view-mãe **sem COALESCE**. Para SKU em status ≠ OK (ex.: `AGUARDANDO_SEGUNDA_ORDEM`) os sugeridos são **NULL** → **zerava os params**, sem tocar `habilitado_reposicao_automatica`.

**Dano medido:** **146 SKUs** (6 fornecedores) com `habilitado=true` + `ponto_pedido`/`estoque_maximo` NULL = limbo (não compram), **re-zerados todo dia** (`calc_tocado_ult_7d=146`). **92** tinham config **aprovada por humano**, destruída. (Os 19 do cold-start eram só o subconjunto com recorrência forte.)

## Fix (challenge codex)

`COALESCE(v.<campo>_sugerido, sp.<campo>)` nos 5 campos de config — só atualiza quando há sugestão válida (status OK → sobrescreve; status ≠ OK → **preserva** o existente). Métricas (demanda/lt/z) seguem sempre frescas. Não congela SKU OK. Mesmo padrão do `preencher_parametros_faltantes_skus` (#487). Tirar SKU da reposição = `habilitado=false` (nunca zerar params).

Validado em PostgreSQL 17 local: SKU OK atualiza; SKU não-OK **preserva** os params (antes zerava).

## ⚠️ Parte SQL — APLICAÇÃO MANUAL via SQL Editor

`supabase/migrations/20260531140000_*` é `CREATE OR REPLACE FUNCTION` (corpo verbatim + COALESCE). Entregue como bloco pra colar.

## Follow-ups (não-bloqueantes, registrados)

- **(B) Guardrail anti-recorrência:** check no Sentinela de Saúde de Dados (`habilitado=true AND (ponto_pedido OR estoque_maximo) NULL`). ⚠️ Não incluí aqui porque o `_data_health_compute` é arquivo quente multi-sessão (§5) — fazer em janela sem colisão.
- **(C) Limpeza dos 146 legados:** o fix para o sangramento, mas não restaura quem já foi zerado (`COALESCE(NULL,NULL)=NULL`). Os 19 que vendem → cold-start #514 (promover). Os 92 aprovados → restaurar via PITR/re-aprovar. Resto → desabilitar explicitamente. Decisão operacional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)