### PR TITLE
feat(whatsapp): montarCestaRecompra — cesta de recompra accept-a-proposal (codex-reviewed)

### DIFF
--- a/src/lib/whatsapp/cesta-recompra.test.ts
+++ b/src/lib/whatsapp/cesta-recompra.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from 'vitest';
+import { montarCestaRecompra, mediana, medianaComTendencia } from './cesta-recompra';
+import type { PedidoLine, CestaOpts } from './cesta-recompra';
+import { addDaysIso } from './route-schedule';
+
+const HOJE = '2026-03-25';
+function line(sku: number, quantity: number, order_date: string, over: Partial<PedidoLine> = {}): PedidoLine {
+  return { omie_codigo_produto: sku, quantity, unit_price: 10, order_date, account: 'oben', status: 'FATURADO', ...over };
+}
+const OPTS: CestaOpts = { account: 'oben', hoje: HOJE, statusValidos: ['FATURADO', 'CONCLUIDO'] };
+const skus = (items: { omie_codigo_produto: number }[]) => items.map(i => i.omie_codigo_produto);
+
+describe('mediana', () => {
+  it('ímpar e par', () => {
+    expect(mediana([3, 1, 2])).toBe(2);
+    expect(mediana([1, 2, 3, 4])).toBe(2.5);
+  });
+});
+
+describe('medianaComTendencia', () => {
+  it('estável → mediana', () => expect(medianaComTendencia([5, 5, 5])).toBe(5));
+  it('crescente forte → puxa pra cima (mediana das últimas 3)', () => {
+    expect(medianaComTendencia([2, 4, 6, 8])).toBe(6); // base 5; últimas3 [4,6,8] med 6
+  });
+  it('não-crescente → mediana base', () => expect(medianaComTendencia([3, 1, 4, 1])).toBe(2));
+});
+
+describe('montarCestaRecompra — filtros e degradação', () => {
+  it('cliente com < 2 pedidos → cesta vazia, confiança baixa (não fabrica de 1 compra)', () => {
+    const r = montarCestaRecompra([line(100, 5, '2026-03-01')], OPTS);
+    expect(r.principal).toEqual([]);
+    expect(r.secundarios).toEqual([]);
+    expect(r.totalPedidos).toBe(1);
+    expect(r.confianca).toBe('baixa');
+  });
+  it('filtra outra conta, status fora da whitelist e fora da janela', () => {
+    const r = montarCestaRecompra([
+      line(100, 5, '2026-03-01'),
+      line(100, 5, '2026-02-01'),
+      line(200, 1, '2026-03-01', { account: 'colacor' }),  // outra conta
+      line(300, 1, '2026-03-01', { status: 'CANCELADO' }), // status inválido
+      line(400, 1, '2025-01-01'),                          // fora da janela 180d
+    ], OPTS);
+    expect(r.totalPedidos).toBe(2);
+    const all = skus([...r.principal, ...r.secundarios]);
+    expect(all).toContain(100);
+    expect(all).not.toContain(200);
+    expect(all).not.toContain(300);
+    expect(all).not.toContain(400);
+  });
+});
+
+describe('montarCestaRecompra — recorrência (frac mínima) [codex Q1]', () => {
+  it('SKU em 2 de 12 pedidos, não-due → excluído (ruído histórico)', () => {
+    const lines: PedidoLine[] = [];
+    for (let i = 0; i < 12; i++) lines.push(line(100, 3, addDaysIso(HOJE, -(i * 30 + 5)))); // frequente, 12 datas
+    lines.push(line(999, 1, addDaysIso(HOJE, -15)));  // 2 compras recentes, não-due
+    lines.push(line(999, 1, addDaysIso(HOJE, -43)));
+    const r = montarCestaRecompra(lines, { ...OPTS, janelaDias: 420 });
+    const all = skus([...r.principal, ...r.secundarios]);
+    expect(all).toContain(100);     // frequente entra
+    expect(all).not.toContain(999); // 2/12 + não-due → ruído, fora
+  });
+});
+
+describe('montarCestaRecompra — principal vs secundário [codex Q3]', () => {
+  // 5 datas distintas do cliente
+  const D = ['2026-01-01', '2026-01-25', '2026-02-20', '2026-03-10', '2026-03-22'];
+  const lines: PedidoLine[] = [
+    ...D.map(d => line(10, 4, d)),               // FREQ: em todas as 5 (frac 1.0), não-due
+    line(20, 2, '2026-01-01'), line(20, 2, '2026-01-25'), // DUE: 2 compras antigas → atrasado
+    line(30, 1, '2026-03-10'), line(30, 1, '2026-03-22'), // SEC: 2 compras recentes → não-due, frac 0.4
+  ];
+  const r = montarCestaRecompra(lines, OPTS);
+  it('frequente (≥50% dos pedidos) entra na principal mesmo sem due', () => {
+    expect(skus(r.principal)).toContain(10);
+  });
+  it('atrasado (due alto) entra na principal e lidera a ordem', () => {
+    expect(skus(r.principal)).toContain(20);
+    expect(r.principal[0].omie_codigo_produto).toBe(20); // maior dueRatio primeiro
+  });
+  it('recorrente recente, não-due e infrequente → secundário ("também costuma levar")', () => {
+    expect(skus(r.secundarios)).toContain(30);
+    expect(skus(r.principal)).not.toContain(30);
+  });
+});
+
+describe('montarCestaRecompra — cap da principal + overflow vira secundário', () => {
+  it('10 SKUs due, cap 8 → principal tem 8 (top por due), resto secundário', () => {
+    const lines: PedidoLine[] = [];
+    for (let i = 0; i < 10; i++) {
+      const last = addDaysIso(HOJE, -(25 + i));      // dueRatio = (25+i)/30, crescente, todos ≥0.8 e não-stale
+      lines.push(line(100 + i, 2, last));
+      lines.push(line(100 + i, 2, addDaysIso(last, -30)));
+    }
+    const r = montarCestaRecompra(lines, OPTS);
+    expect(r.principal.length).toBe(8);
+    expect(r.secundarios.length).toBeGreaterThanOrEqual(2);
+    // o de menor due (i=0) não está na principal
+    expect(skus(r.principal)).not.toContain(100);
+  });
+});
+
+describe('montarCestaRecompra — stale, dedup mesmo-dia, fracionado [codex Q4/P2/UOM]', () => {
+  it('SKU não comprado há > max(2.5×cadência, 90d) → excluído (stale)', () => {
+    const r = montarCestaRecompra([
+      line(100, 2, '2025-10-01'), line(100, 2, '2025-11-01'), // última há ~144d, cadência 31 → stale
+      line(200, 2, '2026-02-20'), line(200, 2, '2026-03-15'), // válido recente
+    ], OPTS);
+    expect(skus([...r.principal, ...r.secundarios])).not.toContain(100);
+    expect(skus([...r.principal, ...r.secundarios])).toContain(200);
+  });
+  it('2 pedidos no MESMO dia contam como 1 (cadência por dia canônico)', () => {
+    const r = montarCestaRecompra([
+      line(100, 2, '2026-02-01'), line(100, 3, '2026-02-01'), // mesmo dia
+      line(100, 2, '2026-03-01'),
+    ], OPTS);
+    const item = [...r.principal, ...r.secundarios].find(i => i.omie_codigo_produto === 100);
+    expect(item?.nPedidos).toBe(2); // 2 datas distintas, não 3
+  });
+  it('quantidade fracionada → confidence baixa (UOM não validável no helper)', () => {
+    const r = montarCestaRecompra([
+      line(100, 1.5, '2026-01-20'), line(100, 1.5, '2026-02-20'), line(100, 1.5, '2026-03-20'),
+    ], OPTS);
+    const item = [...r.principal, ...r.secundarios].find(i => i.omie_codigo_produto === 100);
+    expect(item?.confidence).toBe('baixa');
+  });
+  it('ultimoPrecoRef presente só como referência (debug), não na decisão', () => {
+    const r = montarCestaRecompra([
+      line(100, 2, '2026-02-20', { unit_price: 12 }), line(100, 2, '2026-03-20', { unit_price: 15 }),
+    ], OPTS);
+    const item = [...r.principal, ...r.secundarios].find(i => i.omie_codigo_produto === 100);
+    expect(item?.ultimoPrecoRef).toBe(15);
+  });
+});

--- a/src/lib/whatsapp/cesta-recompra.ts
+++ b/src/lib/whatsapp/cesta-recompra.ts
@@ -1,0 +1,155 @@
+// Montador da cesta de recompra (accept-a-proposal). PURO/testável.
+// Metodologia revisada adversarialmente com codex (2026-05-31). O helper EMITE CANDIDATOS +
+// confiança; a validação de SKU ativo / preço firme / estoque é no ENVIO (Omie), nunca aqui
+// (regra "a IA nunca inventa preço/SKU"). ultimoPrecoRef é só debug — nunca vai na mensagem.
+
+export interface PedidoLine {
+  omie_codigo_produto: number;
+  quantity: number;
+  unit_price: number;
+  order_date: string; // 'YYYY-MM-DD' (order_date_kpi — dia canônico)
+  account: string;
+  status: string;
+}
+export interface CestaOpts {
+  account: string;            // particiona por conta (codex P1: mesmo cliente em contas ≠ mistura padrão)
+  hoje: string;               // 'YYYY-MM-DD'
+  statusValidos: string[];    // whitelist EXPLÍCITA de status comerciais (codex P1)
+  janelaDias?: number;        // default 180
+  capPrincipal?: number;      // default 8
+  fracaoMinima?: number;      // default 0.20
+  dueRatioPrincipal?: number; // default 0.70
+  frequenteFrac?: number;     // default 0.50
+}
+export type Confianca = 'alta' | 'media' | 'baixa';
+export interface CestaItem {
+  omie_codigo_produto: number;
+  qtdSugerida: number;
+  dueRatio: number;
+  nPedidos: number;
+  cadenciaDias: number | null;
+  confidence: Confianca;
+  motivo: 'recorrente_due' | 'frequente' | 'secundario';
+  ultimoPrecoRef: number; // SÓ observabilidade/debug — não usar em mensagem nem decisão
+}
+export interface CestaResult {
+  principal: CestaItem[];
+  secundarios: CestaItem[];
+  totalPedidos: number;
+  confianca: Confianca;
+}
+
+const DUE_RECORRENCIA = 0.8;   // dueRatio que dispensa a fração mínima na recorrência
+const STALE_FLOOR_DIAS = 90;   // piso absoluto de stale (codex Q4: cadência fraca não confiável)
+const STALE_MULT = 2.5;
+
+export function mediana(nums: number[]): number {
+  if (nums.length === 0) return 0;
+  const s = [...nums].sort((a, b) => a - b);
+  const m = Math.floor(s.length / 2);
+  return s.length % 2 ? s[m] : (s[m - 1] + s[m]) / 2;
+}
+
+/** Mediana com ajuste de tendência: cliente em crescimento (últimas compras subindo) puxa pra cima. */
+export function medianaComTendencia(qtys: number[]): number {
+  const base = mediana(qtys);
+  if (qtys.length >= 2) {
+    const ult = qtys.slice(-3);
+    const crescente = ult.every((v, i) => i === 0 || v > ult[i - 1]);
+    const ultimaQtd = qtys[qtys.length - 1];
+    if (crescente && ultimaQtd >= 1.3 * base) return mediana(ult);
+  }
+  return base;
+}
+
+function diffDaysIso(from: string, to: string): number {
+  return Math.round((Date.parse(to + 'T12:00:00Z') - Date.parse(from + 'T12:00:00Z')) / 86_400_000);
+}
+function addDays(iso: string, n: number): string {
+  const d = new Date(iso + 'T12:00:00Z');
+  d.setUTCDate(d.getUTCDate() + n);
+  return d.toISOString().slice(0, 10);
+}
+
+interface Cand extends CestaItem { layer: 'principal' | 'secundario' }
+
+export function montarCestaRecompra(lines: PedidoLine[], opts: CestaOpts): CestaResult {
+  const janela = opts.janelaDias ?? 180;
+  const cap = opts.capPrincipal ?? 8;
+  const fracMin = opts.fracaoMinima ?? 0.20;
+  const dueP = opts.dueRatioPrincipal ?? 0.70;
+  const freqF = opts.frequenteFrac ?? 0.50;
+  const cutoff = addDays(opts.hoje, -janela);
+
+  // filtro: conta + whitelist de status + janela (compare ISO lexicográfico p/ 'YYYY-MM-DD')
+  const valid = lines.filter(l =>
+    l.account === opts.account && opts.statusValidos.includes(l.status) && l.order_date >= cutoff);
+
+  const totalPedidos = new Set(valid.map(l => l.order_date)).size;
+  if (totalPedidos < 2) return { principal: [], secundarios: [], totalPedidos, confianca: 'baixa' };
+
+  const bySku = new Map<number, PedidoLine[]>();
+  for (const l of valid) {
+    const arr = bySku.get(l.omie_codigo_produto);
+    if (arr) arr.push(l); else bySku.set(l.omie_codigo_produto, [l]);
+  }
+
+  const cands: Cand[] = [];
+  for (const [sku, slines] of bySku) {
+    // agrega por DIA canônico (codex P2: 2 pedidos no mesmo dia = 1 compra)
+    const qtyPorDia = new Map<string, number>();
+    for (const l of slines) qtyPorDia.set(l.order_date, (qtyPorDia.get(l.order_date) ?? 0) + l.quantity);
+    const datas = [...qtyPorDia.keys()].sort();
+    const nPedidos = datas.length;
+    if (nPedidos < 2) continue; // piso de recorrência
+
+    const qtysPorDia = datas.map(d => qtyPorDia.get(d) as number);
+    const intervals: number[] = [];
+    for (let i = 1; i < datas.length; i++) intervals.push(diffDaysIso(datas[i - 1], datas[i]));
+    const cadenciaDias = mediana(intervals);
+    const lastDate = datas[datas.length - 1];
+    const diasDesdeUltima = diffDaysIso(lastDate, opts.hoje);
+    const dueRatio = cadenciaDias > 0 ? diasDesdeUltima / cadenciaDias : diasDesdeUltima;
+    const fracPedidos = nPedidos / totalPedidos;
+
+    // recorrência: ≥2 (já garantido) E (fração mínima OU já due)
+    if (!(fracPedidos >= fracMin || dueRatio >= DUE_RECORRENCIA)) continue;
+    // stale: não comprado há mais que max(2.5×cadência, 90d)
+    if (diasDesdeUltima > Math.max(STALE_MULT * cadenciaDias, STALE_FLOOR_DIAS)) continue;
+
+    const qtdSugerida = medianaComTendencia(qtysPorDia);
+    const fracionada = !Number.isInteger(qtdSugerida) || qtysPorDia.some(q => !Number.isInteger(q));
+
+    let confidence: Confianca = 'media';
+    if (nPedidos >= 4) confidence = 'alta';
+    if (nPedidos < 3) confidence = 'baixa';
+    if (fracionada) confidence = 'baixa';
+
+    const ultimoPrecoRef = slines.filter(l => l.order_date === lastDate).pop()?.unit_price ?? 0;
+
+    const isDue = dueRatio >= dueP;
+    const isFreq = fracPedidos >= freqF;
+    const layer: 'principal' | 'secundario' = (isDue || isFreq) ? 'principal' : 'secundario';
+    const motivo: CestaItem['motivo'] = layer === 'secundario' ? 'secundario' : (isDue ? 'recorrente_due' : 'frequente');
+
+    cands.push({ omie_codigo_produto: sku, qtdSugerida, dueRatio, nPedidos, cadenciaDias, confidence, motivo, ultimoPrecoRef, layer });
+  }
+
+  const byDueDesc = (a: Cand, b: Cand) => b.dueRatio - a.dueRatio;
+  const principalCands = cands.filter(c => c.layer === 'principal').sort(byDueDesc);
+  const secundariosCands = cands.filter(c => c.layer === 'secundario').sort(byDueDesc);
+  const principal = principalCands.slice(0, cap);
+  const overflow = principalCands.slice(cap); // estourou o cap → vira "também costuma levar"
+  const secundarios = [...overflow, ...secundariosCands].sort(byDueDesc);
+
+  const strip = (c: Cand): CestaItem => {
+    const { layer: _layer, ...item } = c;
+    return item;
+  };
+
+  let confianca: Confianca = 'alta';
+  if (totalPedidos < 6) confianca = 'media';
+  if (totalPedidos < 3) confianca = 'baixa';
+
+  return { principal: principal.map(strip), secundarios: secundarios.map(strip), totalPedidos, confianca };
+}


### PR DESCRIPTION
## O que é

Helper puro **`montarCestaRecompra`** (`src/lib/whatsapp/cesta-recompra.ts`) — o **conteúdo da proposta accept-a-proposal**: dado o histórico de pedidos do cliente, monta a cesta de recompra ("você costuma comprar X, Y, Z — quer repor?"). **Frontend-only, phone-free** (testável contra o padrão de compra; o envio real pluga isso no PR2b-send quando vier o 360dialog). **Sem deploy/migration.**

Metodologia revisada em **passe adversário do codex** (veredito: sólida pro piloto com os 2 P1 corrigidos). Decisões dobradas no helper:

- **Cesta principal vs secundária (P1)** — principal só com SKU **due** (`dueRatio≥0.7`) ou **frequente** (`≥50% dos pedidos`), ordenada por due, **cap 8**; o resto recorrente vira **secundário** ("também costuma levar"). Não manda "tudo recorrente" cegamente.
- **Particiona por `account` + whitelist explícita de status (P1)** — mesmo `customer_user_id` em contas ≠ não mistura; status comercial é whitelist (não "não-cancelado").
- **Recorrência com fração mínima** — `≥2 pedidos E (≥20% dos pedidos OU due≥0.8)` (um SKU em 2 de 40 é ruído).
- **Quantidade = mediana + ajuste de tendência** (cliente crescendo não é subestimado).
- **Dedup mesmo-dia** (cadência por dia canônico `order_date_kpi`), **cadência fraca** (`<3 compras`→baixa confiança), **stale** por `max(2.5×cadência, 90d)`.
- **UOM/preço** — qty fracionada → `confidence: baixa`; `ultimoPrecoRef` só debug (nunca na mensagem).

**Output:** `{ principal[], secundarios[], totalPedidos, confianca }`, cada item com `qtdSugerida`, `dueRatio`, `confidence`, `motivo`. **Degradação honesta**: <2 pedidos → cesta vazia, confiança baixa (não fabrica de 1 compra).

## Fica pro orquestrador (PR2b-send) — codex concorda
Validação Omie de **SKU ativo / preço firme / estoque** é no **envio** (o helper só emite candidatos + confiança — regra "a IA nunca inventa preço/SKU"). Devolução/sazonal 365d = pós-piloto.

## Verificação
- ✅ vitest **15 testes novos** (mediana, tendência, filtros, recorrência, principal/secundário, cap, stale, dedup mesmo-dia, fracionada→baixa, ultimoPreco) — suíte cheia verde, typecheck, lint 0 errors, build.
- ✅ Sem `any`, sem `.or()`. Sem deploy/migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
