### PR TITLE
feat(whatsapp): formatarPropostaRecompra — texto da proposta accept-a-proposal

### DIFF
--- a/src/lib/whatsapp/proposta-format.test.ts
+++ b/src/lib/whatsapp/proposta-format.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { formatarLinhaItem, formatarPropostaRecompra } from './proposta-format';
+import type { CestaItem, CestaResult } from './cesta-recompra';
+
+function item(sku: number, qtdSugerida: number, over: Partial<CestaItem> = {}): CestaItem {
+  return {
+    omie_codigo_produto: sku, qtdSugerida, dueRatio: 1, nPedidos: 3, cadenciaDias: 30,
+    confidence: 'media', motivo: 'recorrente_due', ultimoPrecoRef: 10, ...over,
+  };
+}
+function cesta(principal: CestaItem[], secundarios: CestaItem[] = []): CestaResult {
+  return { principal, secundarios, totalPedidos: 5, confianca: 'media' };
+}
+const NOMES: Record<number, string> = { 100: 'Lixa Grão 120', 200: 'Disco de Corte 7"', 300: 'Cola Branca 1kg', 400: 'Fita Crepe', 500: 'Verniz 900ml', 600: 'Estopa' };
+
+describe('formatarLinhaItem', () => {
+  it('quantidade inteira + nome', () => {
+    expect(formatarLinhaItem(item(100, 3), NOMES)).toBe('• 3× Lixa Grão 120');
+  });
+  it('quantidade fracionada preserva o decimal', () => {
+    expect(formatarLinhaItem(item(100, 1.5), NOMES)).toBe('• 1.5× Lixa Grão 120');
+  });
+  it('SKU sem nome cai pro código (orquestrador deve enriquecer)', () => {
+    expect(formatarLinhaItem(item(999, 2), NOMES)).toBe('• 2× Cód. 999');
+  });
+});
+
+describe('formatarPropostaRecompra', () => {
+  it('monta saudação + intro + itens da principal + CTA', () => {
+    const r = formatarPropostaRecompra(cesta([item(100, 3), item(200, 2)]), { nomesPorSku: NOMES });
+    expect(r.vazia).toBe(false);
+    expect(r.itensPrincipais).toBe(2);
+    expect(r.texto).toContain('Olá!');
+    expect(r.texto).toContain('costuma repor');
+    expect(r.texto).toContain('• 3× Lixa Grão 120');
+    expect(r.texto).toContain('• 2× Disco de Corte 7"');
+    expect(r.texto).toContain('entrega de amanhã');
+  });
+  it('usa o primeiro nome do cliente quando disponível', () => {
+    const r = formatarPropostaRecompra(cesta([item(100, 3)]), { nomesPorSku: NOMES, primeiroNome: 'João' });
+    expect(r.texto).toContain('Olá, João!');
+  });
+  it('lista secundários ("também costuma levar") capados em maxSecundarios', () => {
+    const sec = [item(300, 1), item(400, 1), item(500, 1), item(600, 1)]; // 4
+    const r = formatarPropostaRecompra(cesta([item(100, 3)], sec), { nomesPorSku: NOMES }); // default max 3
+    expect(r.texto).toContain('também costuma levar');
+    expect(r.texto).toContain('Cola Branca 1kg');
+    expect(r.texto).toContain('Verniz 900ml');     // 3º secundário entra
+    expect(r.texto).not.toContain('Estopa');        // 4º secundário (cap) não entra
+  });
+  it('sem secundários → não imprime o bloco "também costuma levar"', () => {
+    const r = formatarPropostaRecompra(cesta([item(100, 3)]), { nomesPorSku: NOMES });
+    expect(r.texto).not.toContain('também costuma levar');
+  });
+  it('principal vazia → vazia=true, texto vazio (orquestrador não envia)', () => {
+    const r = formatarPropostaRecompra(cesta([]), { nomesPorSku: {} });
+    expect(r.vazia).toBe(true);
+    expect(r.texto).toBe('');
+    expect(r.itensPrincipais).toBe(0);
+  });
+  it('cópia é parametrizável (founder troca as palavras sem mexer no código)', () => {
+    const r = formatarPropostaRecompra(cesta([item(100, 3)]), {
+      nomesPorSku: NOMES,
+      saudacao: () => 'Oi! ',
+      introPrincipal: 'Separei sua reposição:',
+      cta: 'Posso fechar o pedido?',
+    });
+    expect(r.texto).toContain('Oi!');
+    expect(r.texto).toContain('Separei sua reposição:');
+    expect(r.texto).toContain('Posso fechar o pedido?');
+    expect(r.texto).not.toContain('entrega de amanhã'); // CTA default substituído
+  });
+});

--- a/src/lib/whatsapp/proposta-format.ts
+++ b/src/lib/whatsapp/proposta-format.ts
@@ -1,0 +1,52 @@
+// Formata a cesta de recompra (montarCestaRecompra) no TEXTO da proposta accept-a-proposal.
+// PURO/testável. A CÓPIA é parametrizável (defaults sensatos informados por benchmark BEES/Yalo:
+// propor a cesta pronta + CTA claro) — a wording final é do founder (brand-voice), trocável via opts
+// sem tocar código. O texto produzido vira a variável dinâmica do template Meta aprovado.
+
+import type { CestaItem, CestaResult } from './cesta-recompra';
+
+export interface PropostaOpts {
+  nomesPorSku: Record<number, string>; // SKU → descrição (orquestrador enriquece via omie_products)
+  primeiroNome?: string;
+  saudacao?: (nome?: string) => string;
+  introPrincipal?: string;
+  introSecundario?: string;
+  cta?: string;
+  maxSecundarios?: number; // default 3 — não inflar a mensagem (codex: cesta enxuta)
+}
+export interface PropostaFormatada {
+  texto: string;
+  itensPrincipais: number;
+  vazia: boolean; // true = nada a propor (orquestrador NÃO envia)
+}
+
+function fmtQty(q: number): string {
+  return Number.isInteger(q) ? String(q) : String(Math.round(q * 10) / 10);
+}
+
+export function formatarLinhaItem(item: CestaItem, nomesPorSku: Record<number, string>): string {
+  const nome = nomesPorSku[item.omie_codigo_produto] ?? `Cód. ${item.omie_codigo_produto}`;
+  return `• ${fmtQty(item.qtdSugerida)}× ${nome}`;
+}
+
+const saudacaoDefault = (nome?: string) => (nome ? `Olá, ${nome}! ` : 'Olá! ');
+
+export function formatarPropostaRecompra(cesta: CestaResult, opts: PropostaOpts): PropostaFormatada {
+  if (cesta.principal.length === 0) return { texto: '', itensPrincipais: 0, vazia: true };
+
+  const saud = (opts.saudacao ?? saudacaoDefault)(opts.primeiroNome);
+  const introP = opts.introPrincipal ?? 'Vi que você costuma repor:';
+  const introS = opts.introSecundario ?? 'Você também costuma levar:';
+  const cta = opts.cta ?? 'Quer que eu já separe pra entrega de amanhã? 🚚';
+  const maxSec = opts.maxSecundarios ?? 3;
+
+  const linhas: string[] = [`${saud}${introP}`, ...cesta.principal.map(i => formatarLinhaItem(i, opts.nomesPorSku))];
+
+  const sec = cesta.secundarios.slice(0, maxSec);
+  if (sec.length > 0) {
+    linhas.push('', introS, ...sec.map(i => formatarLinhaItem(i, opts.nomesPorSku)));
+  }
+  linhas.push('', cta);
+
+  return { texto: linhas.join('\n'), itensPrincipais: cesta.principal.length, vazia: false };
+}


### PR DESCRIPTION
## O que é

Helper puro **`formatarPropostaRecompra`** (`src/lib/whatsapp/proposta-format.ts`) — pega a cesta de recompra (`montarCestaRecompra`, #523) e monta o **texto da proposta accept-a-proposal** que o cliente lê no WhatsApp:

```
Olá, João! Vi que você costuma repor:
• 3× Lixa Grão 120
• 2× Disco de Corte 7"

Você também costuma levar:
• 1× Cola Branca 1kg

Quer que eu já separe pra entrega de amanhã? 🚚
```

**Frontend-only, phone-free, sem deploy/migration.** Pareia direto com a cesta (cesta → formatter → texto). O texto produzido vira a **variável dinâmica do template Meta** aprovado.

## Decisões
- **Cópia parametrizável** (`saudacao`/`introPrincipal`/`introSecundario`/`cta` via opts, com defaults sensatos informados por benchmark BEES/Yalo: propor a cesta pronta + CTA claro). ⚠️ **A wording final é do founder** (brand-voice) — troca pelas opts, sem mexer no código.
- **Principal + secundários** ("também costuma levar"), secundários capados em `maxSecundarios` (default 3 — não inflar a mensagem).
- **Nome do SKU** vem do orquestrador (`nomesPorSku`, via `omie_products`); sem nome → fallback `Cód. {sku}`.
- **Cesta vazia → `vazia:true`, texto vazio** (o orquestrador não envia).
- Quantidade fracionada preserva o decimal (`1.5×`); preço **nunca** entra na mensagem (regra "a IA nunca inventa preço" — preço firme é do Omie no envio).

## Verificação
- ✅ 9 testes TDD (linha de item, saudação/nome, secundários+cap, vazia, cópia custom, fallback de nome). Suíte cheia verde, typecheck, lint 0 errors, build.
- ✅ Sem `any`, sem `.or()`. Pronto pro PR2b-send plugar (cesta → formatter → template Meta).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
