### PR TITLE
feat(rota): tela de tuning master-only dos parâmetros da lista de ligação

### DIFF
--- a/src/components/rota/RouteDisparoConfigPanel.tsx
+++ b/src/components/rota/RouteDisparoConfigPanel.tsx
@@ -1,0 +1,93 @@
+import { useState, useEffect, type ChangeEvent } from 'react';
+import { Settings2, ChevronDown, ChevronUp } from 'lucide-react';
+import { toast } from 'sonner';
+import { useAuth } from '@/contexts/AuthContext';
+import { Card } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { useRouteDisparoConfig, useUpdateRouteDisparoConfig } from '@/queries/useRouteDisparoConfig';
+import { configToForm, formToConfig } from '@/lib/whatsapp/disparo-config';
+import type { ConfigForm } from '@/lib/whatsapp/disparo-config';
+
+const EMPTY: ConfigForm = {
+  disparoInicio: '07:30', disparoCorte: '15:30', metaTierCap: '1000',
+  winBackReservaPercent: '20', coldStartPisoDia: '3', capacidadeLigacoesDia: '40', cadenciaMinDias: '3',
+};
+
+function Campo({ id, label, value, onChange, hint, type = 'number' }: {
+  id: string; label: string; value: string; onChange: (e: ChangeEvent<HTMLInputElement>) => void; hint?: string; type?: string;
+}) {
+  return (
+    <div className="space-y-1">
+      <Label htmlFor={id} className="text-xs">{label}</Label>
+      <Input id={id} type={type} value={value} onChange={onChange} className="h-8" />
+      {hint && <p className="text-[11px] text-muted-foreground">{hint}</p>}
+    </div>
+  );
+}
+
+/** Tela de tuning (master-only) dos parâmetros da lista de ligação + disparo. Self-gated por isMaster. */
+export function RouteDisparoConfigPanel() {
+  const { isMaster } = useAuth();
+  const { data } = useRouteDisparoConfig();
+  const update = useUpdateRouteDisparoConfig();
+  const [aberto, setAberto] = useState(false);
+  const [form, setForm] = useState<ConfigForm>(EMPTY);
+
+  useEffect(() => { if (data) setForm(configToForm(data)); }, [data]);
+
+  if (!isMaster) return null;
+
+  const set = (k: keyof ConfigForm) => (e: ChangeEvent<HTMLInputElement>) =>
+    setForm(f => ({ ...f, [k]: e.target.value }));
+
+  const salvar = () => {
+    update.mutate(formToConfig(form), {
+      onSuccess: () => toast.success('Parâmetros salvos — a lista re-ranqueia.'),
+      onError: (err) => toast.error(`Falha ao salvar: ${err instanceof Error ? err.message : 'erro'}`),
+    });
+  };
+
+  return (
+    <Card className="p-3">
+      <button
+        type="button"
+        onClick={() => setAberto(a => !a)}
+        className="flex items-center gap-2 w-full text-left text-sm font-medium"
+      >
+        <Settings2 className="w-4 h-4 text-muted-foreground" />
+        Configurar parâmetros
+        <span className="text-xs font-normal text-muted-foreground">(master)</span>
+        {aberto ? <ChevronUp className="w-4 h-4 ml-auto" /> : <ChevronDown className="w-4 h-4 ml-auto" />}
+      </button>
+
+      {aberto && (
+        <div className="mt-3 space-y-4">
+          <div>
+            <div className="text-xs uppercase tracking-wide text-muted-foreground mb-2">Lista de ligação (ao vivo)</div>
+            <div className="grid grid-cols-2 gap-3">
+              <Campo id="capacidadeLigacoesDia" label="Ligações/dia (por vendedora)" value={form.capacidadeLigacoesDia} onChange={set('capacidadeLigacoesDia')} />
+              <Campo id="winBackReservaPercent" label="Reserva win-back (%)" hint="0–100" value={form.winBackReservaPercent} onChange={set('winBackReservaPercent')} />
+              <Campo id="coldStartPisoDia" label="Piso de novos clientes/dia" value={form.coldStartPisoDia} onChange={set('coldStartPisoDia')} />
+              <Campo id="cadenciaMinDias" label="Cadência mínima (dias)" value={form.cadenciaMinDias} onChange={set('cadenciaMinDias')} />
+            </div>
+          </div>
+          <div>
+            <div className="text-xs uppercase tracking-wide text-muted-foreground mb-2">Disparo WhatsApp (ativa no PR2b-send)</div>
+            <div className="grid grid-cols-2 gap-3">
+              <Campo id="disparoInicio" label="Início do disparo" type="time" value={form.disparoInicio} onChange={set('disparoInicio')} />
+              <Campo id="disparoCorte" label="Corte do disparo" type="time" value={form.disparoCorte} onChange={set('disparoCorte')} />
+              <Campo id="metaTierCap" label="Teto Meta (msgs/24h)" value={form.metaTierCap} onChange={set('metaTierCap')} />
+            </div>
+          </div>
+          <div className="flex justify-end">
+            <Button size="sm" onClick={salvar} disabled={update.isPending}>
+              {update.isPending ? 'Salvando…' : 'Salvar'}
+            </Button>
+          </div>
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/src/lib/whatsapp/disparo-config.test.ts
+++ b/src/lib/whatsapp/disparo-config.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { formToConfig, configToForm, isValidHHMM } from './disparo-config';
+import type { ConfigForm } from './disparo-config';
+
+const FORM: ConfigForm = {
+  disparoInicio: '07:30', disparoCorte: '15:30', metaTierCap: '1000',
+  winBackReservaPercent: '20', coldStartPisoDia: '3', capacidadeLigacoesDia: '40', cadenciaMinDias: '3',
+};
+
+describe('isValidHHMM', () => {
+  it('aceita horas válidas', () => {
+    expect(isValidHHMM('07:30')).toBe(true);
+    expect(isValidHHMM('00:00')).toBe(true);
+    expect(isValidHHMM('23:59')).toBe(true);
+  });
+  it('rejeita inválidas', () => {
+    expect(isValidHHMM('24:00')).toBe(false);
+    expect(isValidHHMM('7:30')).toBe(false);
+    expect(isValidHHMM('99:99')).toBe(false);
+    expect(isValidHHMM('abc')).toBe(false);
+    expect(isValidHHMM('')).toBe(false);
+  });
+});
+
+describe('formToConfig', () => {
+  it('converte % de win-back (0-100) → fração (0-1)', () => {
+    expect(formToConfig({ ...FORM, winBackReservaPercent: '20' }).win_back_reserva_pct).toBeCloseTo(0.2, 5);
+  });
+  it('clampa % fora de [0,100]', () => {
+    expect(formToConfig({ ...FORM, winBackReservaPercent: '150' }).win_back_reserva_pct).toBe(1);
+    expect(formToConfig({ ...FORM, winBackReservaPercent: '-10' }).win_back_reserva_pct).toBe(0);
+  });
+  it('coerce inteiros ≥ 0 (não-número vira 0; decimal trunca)', () => {
+    expect(formToConfig({ ...FORM, capacidadeLigacoesDia: '40' }).capacidade_ligacoes_dia).toBe(40);
+    expect(formToConfig({ ...FORM, capacidadeLigacoesDia: '-5' }).capacidade_ligacoes_dia).toBe(0);
+    expect(formToConfig({ ...FORM, capacidadeLigacoesDia: 'abc' }).capacidade_ligacoes_dia).toBe(0);
+    expect(formToConfig({ ...FORM, coldStartPisoDia: '2.9' }).cold_start_piso_dia).toBe(2);
+  });
+  it('hora inválida cai pro default (inicio 07:30 / corte 15:30)', () => {
+    expect(formToConfig({ ...FORM, disparoInicio: '99:99' }).disparo_inicio).toBe('07:30');
+    expect(formToConfig({ ...FORM, disparoCorte: 'xx' }).disparo_corte).toBe('15:30');
+  });
+  it('hora válida é preservada', () => {
+    expect(formToConfig({ ...FORM, disparoInicio: '08:15' }).disparo_inicio).toBe('08:15');
+  });
+});
+
+describe('configToForm', () => {
+  it('mostra a fração como % (0-1 → 0-100) e numéricos como string', () => {
+    const form = configToForm({
+      disparo_inicio: '07:30', disparo_corte: '15:30', meta_tier_cap: 1000,
+      win_back_reserva_pct: 0.2, cold_start_piso_dia: 3, capacidade_ligacoes_dia: 40, cadencia_min_dias: 3,
+    });
+    expect(form.winBackReservaPercent).toBe('20');
+    expect(form.capacidadeLigacoesDia).toBe('40');
+    expect(form.disparoInicio).toBe('07:30');
+  });
+  it('round-trip form→config→form preserva', () => {
+    expect(configToForm(formToConfig(FORM))).toEqual(FORM);
+  });
+});

--- a/src/lib/whatsapp/disparo-config.ts
+++ b/src/lib/whatsapp/disparo-config.ts
@@ -1,0 +1,57 @@
+// Coerção/validação dos parâmetros de disparo (tabela route_disparo_config). PURO/testável.
+// O form usa strings (inputs) + % p/ a reserva; o DB usa números + fração. Estes helpers
+// convertem nos dois sentidos com clamps (não deixa salvar lixo no money-path da lista).
+
+export interface RouteDisparoConfig {
+  disparo_inicio: string;          // 'HH:MM'
+  disparo_corte: string;           // 'HH:MM'
+  meta_tier_cap: number;
+  win_back_reserva_pct: number;    // 0-1
+  cold_start_piso_dia: number;
+  capacidade_ligacoes_dia: number;
+  cadencia_min_dias: number;
+}
+export interface ConfigForm {
+  disparoInicio: string;
+  disparoCorte: string;
+  metaTierCap: string;
+  winBackReservaPercent: string;   // 0-100 (exibição)
+  coldStartPisoDia: string;
+  capacidadeLigacoesDia: string;
+  cadenciaMinDias: string;
+}
+
+export function isValidHHMM(s: string): boolean {
+  return /^([01]\d|2[0-3]):[0-5]\d$/.test(s);
+}
+
+function intGE0(s: string): number {
+  const n = parseInt(s, 10); // trunca decimal ('2.9'→2)
+  return Number.isFinite(n) ? Math.max(0, n) : 0;
+}
+
+export function formToConfig(form: ConfigForm): RouteDisparoConfig {
+  const pct = Number(form.winBackReservaPercent);
+  const pctFrac = Number.isFinite(pct) ? Math.min(1, Math.max(0, pct / 100)) : 0;
+  return {
+    disparo_inicio: isValidHHMM(form.disparoInicio) ? form.disparoInicio : '07:30',
+    disparo_corte: isValidHHMM(form.disparoCorte) ? form.disparoCorte : '15:30',
+    meta_tier_cap: intGE0(form.metaTierCap),
+    win_back_reserva_pct: pctFrac,
+    cold_start_piso_dia: intGE0(form.coldStartPisoDia),
+    capacidade_ligacoes_dia: intGE0(form.capacidadeLigacoesDia),
+    cadencia_min_dias: intGE0(form.cadenciaMinDias),
+  };
+}
+
+export function configToForm(cfg: RouteDisparoConfig): ConfigForm {
+  return {
+    disparoInicio: cfg.disparo_inicio,
+    disparoCorte: cfg.disparo_corte,
+    metaTierCap: String(cfg.meta_tier_cap),
+    winBackReservaPercent: String(Math.round(cfg.win_back_reserva_pct * 100)),
+    coldStartPisoDia: String(cfg.cold_start_piso_dia),
+    capacidadeLigacoesDia: String(cfg.capacidade_ligacoes_dia),
+    cadenciaMinDias: String(cfg.cadencia_min_dias),
+  };
+}

--- a/src/pages/RotaListaLigacao.tsx
+++ b/src/pages/RotaListaLigacao.tsx
@@ -7,6 +7,7 @@ import { EmptyState } from '@/components/EmptyState';
 import { Badge } from '@/components/ui/badge';
 import { Card } from '@/components/ui/card';
 import { CallButton } from '@/components/call/CallButton';
+import { RouteDisparoConfigPanel } from '@/components/rota/RouteDisparoConfigPanel';
 
 function todayIso(): string {
   return new Date().toISOString().slice(0, 10);
@@ -30,6 +31,7 @@ export default function RotaListaLigacao() {
     return (
       <div className="p-4 space-y-3">
         <h1 className="font-display text-2xl">Lista de ligação por rota</h1>
+        <RouteDisparoConfigPanel />
         <EmptyState
           icon={Phone}
           tone="operational"
@@ -61,6 +63,8 @@ export default function RotaListaLigacao() {
           {data.callQueue.length} ligações priorizadas
         </p>
       </header>
+
+      <RouteDisparoConfigPanel />
 
       {[...byFarmer.entries()].map(([farmer, list]) => (
         <Card key={farmer} className="p-3">

--- a/src/queries/useRouteDisparoConfig.ts
+++ b/src/queries/useRouteDisparoConfig.ts
@@ -1,0 +1,46 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import type { RouteDisparoConfig } from '@/lib/whatsapp/disparo-config';
+
+// route_disparo_config ainda não está no types.ts gerado → cast (padrão useWhatsappInbox/useRouteContactList).
+type PgRes = { data: unknown; error: { message: string } | null };
+interface RouteBuilder {
+  select: (c: string) => RouteBuilder;
+  update: (v: Record<string, unknown>) => RouteBuilder;
+  eq: (k: string, v: unknown) => RouteBuilder;
+  maybeSingle: () => PromiseLike<PgRes>;
+  then: PromiseLike<PgRes>['then'];
+}
+function routeFrom(t: string): RouteBuilder {
+  return (supabase as unknown as { from: (t: string) => RouteBuilder }).from(t);
+}
+
+const COLS = 'disparo_inicio, disparo_corte, meta_tier_cap, win_back_reserva_pct, cold_start_piso_dia, capacidade_ligacoes_dia, cadencia_min_dias';
+
+export function useRouteDisparoConfig() {
+  return useQuery<RouteDisparoConfig | null>({
+    queryKey: ['route-disparo-config'],
+    staleTime: 60_000,
+    queryFn: async () => {
+      const res = await routeFrom('route_disparo_config').select(COLS).eq('id', true).maybeSingle();
+      if (res.error) throw new Error(res.error.message);
+      return (res.data ?? null) as RouteDisparoConfig | null;
+    },
+  });
+}
+
+export function useUpdateRouteDisparoConfig() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (cfg: RouteDisparoConfig) => {
+      const res = await (routeFrom('route_disparo_config')
+        .update({ ...cfg, updated_at: new Date().toISOString() })
+        .eq('id', true) as PromiseLike<PgRes>);
+      if (res.error) throw new Error(res.error.message); // RLS master-only barra não-master no servidor
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['route-disparo-config'] });
+      qc.invalidateQueries({ queryKey: ['route-contact-list'] }); // re-ranqueia a lista ao vivo
+    },
+  });
+}


### PR DESCRIPTION
## O que é

Tela de **tuning (master-only)** dos parâmetros da lista de ligação por rota, embutida na própria `/rota/ligacoes` — você ajusta e a **lista re-ranqueia ao vivo** (invalida a query). **Frontend-only, phone-free, sem migration** (a tabela `route_disparo_config` já existe do PR2a).

- Painel colapsável "Configurar parâmetros (master)", self-gated por `isMaster` (e RLS `route_config_master_write` no servidor — UI **e** banco barram não-master).
- **Lista de ligação (ao vivo):** ligações/dia, reserva win-back (%), piso cold-start, cadência mínima → o `useRouteContactList` lê esses params, então mexer re-ranqueia na hora.
- **Disparo WhatsApp (ativa no PR2b-send):** início/corte do disparo, teto Meta — pré-configuráveis agora.
- Aparece tanto na lista cheia quanto no estado vazio (você pode tunar justamente quando a fila vier vazia).

## Decisões
- Helper puro **`disparo-config.ts`** (`formToConfig`/`configToForm`/`isValidHHMM`, 9 testes TDD): converte % ↔ fração, **clampa** (pct [0,1], inteiros ≥0), valida `HH:MM` (inválido → default 07:30/15:30). Não deixa salvar lixo no money-path da lista.
- Hook `useRouteDisparoConfig` (read + update, cast pattern; invalida `route-contact-list` no save).
- ⚠️ **Honesto:** calibrar esses números é atividade do **piloto** (você ajusta com base no que converte). A tela existe pra quando esse momento chegar; os defaults atuais são sensatos.

## Verificação
- ✅ typecheck OK, helper 9 testes (bun). Suíte cheia + build validam no CI (auto-merge só funde no verde).
- ✅ Sem `any`, sem `.or()`. RLS master-only no servidor + gate `isMaster` na UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
