### PR TITLE
feat(telefonia): WebRTC vira o único caminho de ligação (Nvoip click-to-call oculto)

### DIFF
--- a/src/components/call/CallButton.tsx
+++ b/src/components/call/CallButton.tsx
@@ -1,7 +1,3 @@
-import { Phone } from 'lucide-react';
-import { Button } from '@/components/ui/button';
-import { cn } from '@/lib/utils';
-import { useIsTouchDevice } from '@/hooks/useIsTouchDevice';
 import { Dialer } from './Dialer';
 
 interface CallButtonProps {
@@ -9,45 +5,18 @@ interface CallButtonProps {
   customerName: string;
   /** 'full' = botão "Ligar {telefone}"; 'icon' = ícone compacto. */
   variant?: 'full' | 'icon';
+  /** Mantido por compatibilidade de API; o dialer in-app renderiza o próprio botão. */
   className?: string;
 }
 
 /**
- * Botão de ligar que escolhe o backend certo por TIPO DE DISPOSITIVO (não por
- * largura de tela — notebook em janela estreita NÃO é "mobile"):
- * - DESKTOP/NOTEBOOK: dialer in-app <Dialer> (Nvoip click-to-call ou WebRTC,
- *   conforme a feature flag useWebRTCCall). Inicia a chamada DENTRO do app.
- * - CELULAR/TABLET (touch-primário): link tel: nativo (disca pela operadora) —
- *   o vendedor externo no celular continua usando o discador do aparelho.
+ * Botão de ligar — usa SEMPRE o dialer in-app (WebRTC) em qualquer dispositivo,
+ * iniciando a chamada DENTRO do app (grava + copiloto/transcrição ao vivo).
  *
- * Substitui os <a href="tel:..."> espalhados nas páginas de cliente, que no
- * desktop entregavam a chamada pro SO (macOS abria o app Telefone / erro WPC)
- * em vez de usar a telefonia in-app. Ver DEBUG report 2026-05-20.
+ * Antes, em dispositivo touch (celular/tablet), caía pro discador nativo via
+ * `<a href="tel:">` — o que abria o app Telefone do SO e perdia gravação + copiloto.
+ * Isso foi descontinuado: a ligação de venda agora roda sempre in-app via WebRTC.
  */
-export function CallButton({ phone, customerName, variant = 'full', className }: CallButtonProps) {
-  const isTouchDevice = useIsTouchDevice();
-
-  if (isTouchDevice) {
-    if (variant === 'icon') {
-      return (
-        <Button asChild variant="ghost" size="icon" className={cn('h-8 w-8 text-status-success', className)}>
-          <a href={`tel:${phone}`} title={`Ligar para ${phone}`}>
-            <Phone className="w-4 h-4" />
-          </a>
-        </Button>
-      );
-    }
-    return (
-      <Button asChild variant="outline" size="sm" className={className}>
-        <a href={`tel:${phone}`}>
-          <Phone className="w-3.5 h-3.5 mr-1.5" />
-          Ligar
-        </a>
-      </Button>
-    );
-  }
-
-  // Desktop: dialer in-app. Quando idle renderiza "Ligar {telefone}" (ou ícone se
-  // compact); quando a chamada inicia, vira card de status (inline).
+export function CallButton({ phone, customerName, variant = 'full' }: CallButtonProps) {
   return <Dialer phoneNumber={phone} customerName={customerName} compact={variant === 'icon'} />;
 }

--- a/src/components/call/Dialer.tsx
+++ b/src/components/call/Dialer.tsx
@@ -1,6 +1,4 @@
 import { lazy, Suspense } from 'react';
-import { useFeatureFlag } from '@/hooks/useFeatureFlag';
-import { NvoipDialer, NvoipFloatingDialer } from '@/components/NvoipDialer';
 import type { CallDialerViewProps } from './CallDialerView';
 
 const WebRTCDialer = lazy(() =>
@@ -9,16 +7,15 @@ const WebRTCDialer = lazy(() =>
 
 type Props = Pick<CallDialerViewProps, 'phoneNumber' | 'customerName' | 'onCallEnd' | 'compact' | 'floating'>;
 
+/**
+ * Dialer in-app. WebRTC é o único backend ativo (o `floating` é repassado e
+ * tratado pelo WebRTCDialer/CallDialerView). O Nvoip click-to-call foi
+ * descontinuado da UI — ver useCallBackend.
+ */
 export function Dialer(props: Props) {
-  const [useWebRTC] = useFeatureFlag('useWebRTCCall', false);
-
-  if (useWebRTC) {
-    return (
-      <Suspense fallback={null}>
-        <WebRTCDialer {...props} />
-      </Suspense>
-    );
-  }
-  if (props.floating) return <NvoipFloatingDialer {...props} />;
-  return <NvoipDialer {...props} />;
+  return (
+    <Suspense fallback={null}>
+      <WebRTCDialer {...props} />
+    </Suspense>
+  );
 }

--- a/src/components/call/__tests__/CallButton.test.tsx
+++ b/src/components/call/__tests__/CallButton.test.tsx
@@ -1,8 +1,8 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { CallButton } from '../CallButton';
 
-// Mock o Dialer in-app pra não puxar a árvore de telefonia (useNvoipCall/supabase).
+// Mock o Dialer in-app pra não puxar a árvore de telefonia (WebRTC/supabase).
 vi.mock('../Dialer', () => ({
   Dialer: (props: { phoneNumber: string; customerName: string; compact?: boolean }) => (
     <div data-testid="inapp-dialer" data-phone={props.phoneNumber} data-compact={String(!!props.compact)}>
@@ -11,39 +11,18 @@ vi.mock('../Dialer', () => ({
   ),
 }));
 
-// Mock a detecção de dispositivo touch — controla o branch desktop/notebook vs celular.
-const mockIsTouch = vi.fn();
-vi.mock('@/hooks/useIsTouchDevice', () => ({
-  useIsTouchDevice: () => mockIsTouch(),
-}));
-
 describe('CallButton', () => {
-  beforeEach(() => {
-    mockIsTouch.mockReset();
-  });
-
-  it('DESKTOP/NOTEBOOK (touch=false): renderiza o dialer in-app e NÃO um link tel: (regressão do bug)', () => {
-    mockIsTouch.mockReturnValue(false);
+  it('usa SEMPRE o dialer in-app (WebRTC) e NUNCA um link tel: — em qualquer dispositivo', () => {
     const { container } = render(<CallButton phone="37999998888" customerName="Cliente X" />);
 
     expect(screen.getByTestId('inapp-dialer')).toBeInTheDocument();
-    // O bug era abrir o app Telefone do Mac via href=tel:. Notebook (mesmo janela
-    // estreita) tem touch=false → nunca pode ter link tel:.
+    // Antes, em touch (celular/tablet), o botão caía pro discador nativo via href=tel:,
+    // perdendo gravação + copiloto. Agora a ligação de venda roda sempre in-app via
+    // WebRTC → nunca pode haver link tel:, em nenhum dispositivo.
     expect(container.querySelector('a[href^="tel:"]')).toBeNull();
   });
 
-  it('CELULAR/TABLET (touch=true): renderiza link tel: (discador nativo) e NÃO o dialer in-app', () => {
-    mockIsTouch.mockReturnValue(true);
-    const { container } = render(<CallButton phone="37999998888" customerName="Cliente X" />);
-
-    const telLink = container.querySelector('a[href^="tel:"]');
-    expect(telLink).not.toBeNull();
-    expect(telLink?.getAttribute('href')).toBe('tel:37999998888');
-    expect(screen.queryByTestId('inapp-dialer')).toBeNull();
-  });
-
-  it('variant="icon" no desktop passa compact=true pro Dialer', () => {
-    mockIsTouch.mockReturnValue(false);
+  it('variant="icon" passa compact=true pro Dialer', () => {
     render(<CallButton phone="37999998888" customerName="Cliente X" variant="icon" />);
     expect(screen.getByTestId('inapp-dialer').getAttribute('data-compact')).toBe('true');
   });

--- a/src/components/call/__tests__/Dialer.test.tsx
+++ b/src/components/call/__tests__/Dialer.test.tsx
@@ -1,14 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
-
-vi.mock('@/hooks/useFeatureFlag', () => ({
-  useFeatureFlag: vi.fn(),
-}));
-
-vi.mock('@/components/NvoipDialer', () => ({
-  NvoipDialer: () => <div data-testid="nvoip-dialer">nvoip</div>,
-  NvoipFloatingDialer: () => <div data-testid="nvoip-floating-dialer">nvoip-floating</div>,
-}));
 
 vi.mock('../WebRTCDialer', () => ({
   WebRTCDialer: () => <div data-testid="webrtc-dialer">webrtc</div>,
@@ -18,40 +9,16 @@ vi.mock('@/components/call/WebRTCDialer', () => ({
 }));
 
 import { Dialer } from '../Dialer';
-import { useFeatureFlag } from '@/hooks/useFeatureFlag';
 
-describe('Dialer dispatcher', () => {
-  beforeEach(() => vi.clearAllMocks());
-
-  it('renderiza NvoipDialer quando flag off (default)', () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (useFeatureFlag as any).mockReturnValue([false, vi.fn()]);
-    render(<Dialer phoneNumber="37999998888" customerName="Cliente" />);
-    expect(screen.getByTestId('nvoip-dialer')).toBeTruthy();
-    expect(screen.queryByTestId('webrtc-dialer')).toBeNull();
-  });
-
-  it('renderiza NvoipFloatingDialer quando flag off + floating=true', () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (useFeatureFlag as any).mockReturnValue([false, vi.fn()]);
-    render(<Dialer phoneNumber="37999998888" customerName="Cliente" floating />);
-    expect(screen.getByTestId('nvoip-floating-dialer')).toBeTruthy();
-    expect(screen.queryByTestId('nvoip-dialer')).toBeNull();
-  });
-
-  it('renderiza WebRTCDialer quando flag on', async () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (useFeatureFlag as any).mockReturnValue([true, vi.fn()]);
+describe('Dialer', () => {
+  it('renderiza SEMPRE o WebRTCDialer (Nvoip click-to-call descontinuado da UI)', async () => {
     render(<Dialer phoneNumber="37999998888" customerName="Cliente" />);
     // WebRTCDialer é lazy — espera resolver
     expect(await screen.findByTestId('webrtc-dialer')).toBeTruthy();
-    expect(screen.queryByTestId('nvoip-dialer')).toBeNull();
   });
 
-  it('passa a feature flag corretamente', () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (useFeatureFlag as any).mockReturnValue([false, vi.fn()]);
-    render(<Dialer phoneNumber="37999998888" customerName="Cliente" />);
-    expect(useFeatureFlag).toHaveBeenCalledWith('useWebRTCCall', false);
+  it('renderiza o WebRTCDialer também com floating=true', async () => {
+    render(<Dialer phoneNumber="37999998888" customerName="Cliente" floating />);
+    expect(await screen.findByTestId('webrtc-dialer')).toBeTruthy();
   });
 });

--- a/src/hooks/__tests__/useCallBackend.test.tsx
+++ b/src/hooks/__tests__/useCallBackend.test.tsx
@@ -1,24 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { renderHook } from '@testing-library/react';
-
-vi.mock('@/hooks/useFeatureFlag', () => ({
-  useFeatureFlag: vi.fn(),
-}));
-
-const nvoipReturn = {
-  callState: 'idle' as const,
-  callId: null,
-  callDuration: 0,
-  audioLink: null,
-  error: null,
-  isActive: false,
-  isConnecting: false,
-  isRinging: false,
-  isEstablished: false,
-  isFinished: false,
-  makeCall: vi.fn(),
-  endCall: vi.fn(),
-};
 
 const webrtcReturn = {
   callState: 'idle' as const,
@@ -37,40 +18,16 @@ const webrtcReturn = {
   remoteStream: null,
 };
 
-vi.mock('@/hooks/useNvoipCall', () => ({
-  useNvoipCall: () => nvoipReturn,
-}));
-
 vi.mock('@/hooks/useWebRTCCall', () => ({
   useWebRTCCall: () => webrtcReturn,
 }));
 
 import { useCallBackend } from '../useCallBackend';
-import { useFeatureFlag } from '@/hooks/useFeatureFlag';
 
 describe('useCallBackend dispatcher', () => {
-  beforeEach(() => vi.clearAllMocks());
-
-  it('retorna useNvoipCall quando flag off', () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (useFeatureFlag as any).mockReturnValue([false, vi.fn()]);
-    const { result } = renderHook(() => useCallBackend());
-    expect(result.current.backend).toBe('nvoip');
-    expect(result.current.makeCall).toBe(nvoipReturn.makeCall);
-  });
-
-  it('retorna useWebRTCCall quando flag on', () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (useFeatureFlag as any).mockReturnValue([true, vi.fn()]);
+  it('usa SEMPRE o backend WebRTC (Nvoip click-to-call descontinuado da UI)', () => {
     const { result } = renderHook(() => useCallBackend());
     expect(result.current.backend).toBe('webrtc');
     expect(result.current.makeCall).toBe(webrtcReturn.makeCall);
-  });
-
-  it('consulta a flag com nome correto e default false', () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (useFeatureFlag as any).mockReturnValue([false, vi.fn()]);
-    renderHook(() => useCallBackend());
-    expect(useFeatureFlag).toHaveBeenCalledWith('useWebRTCCall', false);
   });
 });

--- a/src/hooks/useCallBackend.ts
+++ b/src/hooks/useCallBackend.ts
@@ -1,32 +1,21 @@
-import { useFeatureFlag } from '@/hooks/useFeatureFlag';
-import { useNvoipCall } from '@/hooks/useNvoipCall';
 import { useWebRTCCall } from '@/hooks/useWebRTCCall';
 
 /**
- * Dispatcher único pra escolha do backend de telefonia.
- * Substitui o uso direto de useNvoipCall e useWebRTCCall em consumers
- * (modal "Nova ligação", dialers, etc.), garantindo que a feature flag
- * `useWebRTCCall` é o ponto único de verdade.
+ * Dispatcher do backend de telefonia.
  *
- * Returns a união das APIs (campos comuns + extras). O backend ativo é
- * identificado em `backend` ('nvoip' | 'webrtc').
+ * WebRTC in-browser é o ÚNICO caminho ativo: o vendedor liga direto pelo navegador
+ * (grava + copiloto/transcrição ao vivo, funciona no celular). O click-to-call da
+ * Nvoip foi DESCONTINUADO da interface — `useNvoipCall`/`NvoipDialer` viram código
+ * dormente (mantidos por ora p/ revert fácil; remoção futura como faxina).
  *
- * IMPORTANTE: Ambos os hooks são chamados em TODO render — React requer
- * que hooks sejam chamados em ordem fixa. O custo é negligível
- * (useNvoipCall é estado local; useWebRTCCall é consumer de Context).
+ * Mantém o campo `backend` no retorno por compatibilidade com os consumidores
+ * (CallDialerView, FarmerCalls) que checam 'webrtc' | 'nvoip'.
  *
- * IMPORTANTE 2: Quando webrtc está on, useWebRTCCall lança se a árvore
- * não estiver dentro de <WebRTCCallProvider>. Por isso esse hook deve
- * ser consumido apenas em rotas envolvidas pelo ConditionalWebRTCProvider
- * (todas as rotas autenticadas via AppShellLayout).
+ * IMPORTANTE: `useWebRTCCall` lança se a árvore não estiver dentro de
+ * <WebRTCCallProvider>. Por isso este hook só pode ser consumido em rotas
+ * envolvidas pelo ConditionalWebRTCProvider (rotas autenticadas via AppShellLayout).
  */
 export function useCallBackend() {
-  const [useWebRTC] = useFeatureFlag('useWebRTCCall', false);
-  const nvoip = useNvoipCall();
   const webrtc = useWebRTCCall();
-
-  if (useWebRTC) {
-    return { ...webrtc, backend: 'webrtc' as const };
-  }
-  return { ...nvoip, backend: 'nvoip' as const };
+  return { ...webrtc, backend: 'webrtc' as const };
 }

--- a/src/pages/SettingsConfig.tsx
+++ b/src/pages/SettingsConfig.tsx
@@ -87,7 +87,6 @@ const SettingsConfig = () => {
   const [activeTab, setActiveTab] = useState('recommendations');
   const [hasChanges, setHasChanges] = useState(false);
   const [newVisualEnabled, toggleNewVisual] = useFeatureFlag('newVisual', true);
-  const [useWebRTCEnabled, toggleWebRTC] = useFeatureFlag('useWebRTCCall', false);
 
   const updateWeight = (key: string, value: number) => {
     setWeights(prev => prev.map(w => w.key === key ? { ...w, value } : w));
@@ -132,32 +131,6 @@ const SettingsConfig = () => {
               </div>
             </div>
             <Switch checked={newVisualEnabled} onCheckedChange={toggleNewVisual} />
-          </CardContent>
-        </Card>
-
-        {/* WebRTC dialer feature flag — opt-in beta */}
-        <Card>
-          <CardContent className="p-4 flex items-center justify-between gap-3">
-            <div className="flex items-start gap-3 min-w-0">
-              <div className={cn(
-                'p-2 rounded-md shrink-0',
-                useWebRTCEnabled ? 'bg-foreground text-background' : 'bg-muted text-muted-foreground',
-              )}>
-                <Phone className="w-4 h-4" />
-              </div>
-              <div className="min-w-0">
-                <p className="text-sm font-medium">
-                  Chamadas WebRTC {useWebRTCEnabled ? 'ativadas' : 'desativadas'}
-                  <Badge variant="outline" className="ml-2 text-2xs">beta</Badge>
-                </p>
-                <p className="text-xs text-muted-foreground mt-0.5">
-                  {useWebRTCEnabled
-                    ? 'Ligar direto pelo navegador via SIP, sem aceitar no painel Nvoip. Requer permissão de microfone.'
-                    : 'Usa o click-to-call atual (vendedor atende ramal no painel Nvoip). Ative para ligar direto.'}
-                </p>
-              </div>
-            </div>
-            <Switch checked={useWebRTCEnabled} onCheckedChange={toggleWebRTC} />
           </CardContent>
         </Card>
 

--- a/src/pages/Telefonia.tsx
+++ b/src/pages/Telefonia.tsx
@@ -7,8 +7,6 @@ import { CallHistoryTabs } from '@/components/telefonia/CallHistoryTabs';
 import { CallDialerView } from '@/components/call/CallDialerView';
 import { useCallBackend } from '@/hooks/useCallBackend';
 import { useIsTelefoniaManager } from '@/hooks/useIsTelefoniaManager';
-import { useFeatureFlag } from '@/hooks/useFeatureFlag';
-import { Switch } from '@/components/ui/switch';
 import { normalizeBrPhone, formatBrPhone } from '@/lib/phone';
 import type { CallLogTab } from '@/hooks/useCallLog';
 
@@ -22,10 +20,6 @@ export default function Telefonia() {
   const [callSeq, setCallSeq] = useState(0);
   const call = useCallBackend();
   const isManager = useIsTelefoniaManager();
-  // Controle de transporte NA PRÓPRIA tela (sem depender do /settings escondido,
-  // cujo flag em localStorage é frágil no Safari iOS). Liga aqui → o backend muda
-  // na hora (useCallBackend escuta o mesmo flag via storage event).
-  const [useWebRTC, setUseWebRTC] = useFeatureFlag('useWebRTCCall', false);
 
   // Sessão de chamada ÚNICA: a página é dona; DialPad e o histórico só disparam.
   const startCall = useCallback(
@@ -69,22 +63,6 @@ export default function Telefonia() {
       <h1 className="text-xl font-semibold mb-4">Central de Telefonia</h1>
       <div className="flex flex-col md:flex-row gap-4">
         <div className="flex flex-col gap-3">
-          <div className="w-full max-w-[260px] rounded-lg border border-border bg-card p-3 flex items-center justify-between gap-2">
-            <div className="min-w-0">
-              <p className="text-sm font-medium">Ligar pelo navegador</p>
-              <p className="text-[11px] text-muted-foreground mt-0.5">
-                {useWebRTC
-                  ? 'WebRTC — grava + copiloto ao vivo'
-                  : 'Operadora (Nvoip) — sem copiloto ao vivo'}
-              </p>
-            </div>
-            <Switch
-              checked={useWebRTC}
-              onCheckedChange={setUseWebRTC}
-              disabled={busy}
-              aria-label="Ligar pelo navegador (WebRTC)"
-            />
-          </div>
           <DialPad
             key={dialPrefill}
             initialPhone={dialPrefill}


### PR DESCRIPTION
## Decisão
WebRTC foi validado em produção no iPhone (grava + copiloto/transcrição ao vivo, funciona no celular). Este PR o torna o **backend padrão e ÚNICO da interface**. O **click-to-call da Nvoip** — que está dando 401 e, por desenho, **não entrega tempo real** (o navegador nunca recebe o áudio) — sai da UI.

**Ocultar, não excluir:** o código da Nvoip (`useNvoipCall`, `NvoipDialer`, edge `nvoip-calls`) fica **dormente** pra revert trivial. Remoção é faxina futura, depois de semanas de WebRTC sólido.

## Mudanças
- **`useCallBackend`**: sempre WebRTC (removida a feature flag).
- **`Dialer`**: sempre `WebRTCDialer`.
- **`CallButton`**: remove o branch touch→`tel:`. O Customer 360 / carteira passam a ligar **in-app via WebRTC no celular também** (antes abriam o discador nativo do SO e perdiam gravação + copiloto).
- **`Telefonia` + `SettingsConfig`**: removem o interruptor "WebRTC" (virou inútil — sempre on).
- **Testes** atualizados: sempre-WebRTC, nunca `tel:`.

## Não mexe (de propósito)
- Chamadas **recebidas** (`IncomingCallModal`) + **agenda** (`AgendaTodayList`) — já eram WebRTC-only.
- `RouteStopCard` `tel:` — é dial rápido de **visita de rota**, não a telefonia de venda; fora de escopo.
- Edge `nvoip-calls` e `useNvoipCall`/`NvoipDialer` — ficam dormentes (não removidos).

## Verificação local
typecheck `tsconfig.app.json` (strict) **0 erros** · lint **0 erros** · 3 testes afetados **5/5** · único outro teste que toca os módulos mocka o `Dialer` (inafetado). Full suite + build no CI.

## Sem migration
Frontend only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)