### PR TITLE
feat(novo-pedido): pré-seleção de cliente no Customer 360 → /sales/new

### DIFF
--- a/docs/superpowers/plans/2026-05-31-novo-pedido-preselect-cliente.md
+++ b/docs/superpowers/plans/2026-05-31-novo-pedido-preselect-cliente.md
@@ -1,0 +1,293 @@
+# Pré-seleção de cliente no "Novo pedido" — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `/sales/new?customer=<user_id>` pré-seleciona o cliente no fluxo de pedido staff, reusando o `selectCustomer` existente.
+
+**Architecture:** Helper puro `buildOmieCustomer` (TDD) → método `selectCustomerByUserId` no `useUnifiedOrder` (2 lookups paralelos + build + `selectCustomer`) → `useEffect` run-once no `UnifiedOrder.tsx` que lê o param. Degradação silenciosa; money-path (`selectCustomer`) intacto.
+
+**Tech Stack:** React + react-router-dom (`useSearchParams`), Supabase JS, vitest.
+
+**Spec:** `docs/superpowers/specs/2026-05-31-novo-pedido-preselect-cliente-design.md`
+
+---
+
+## File Structure
+
+- **Create:** `src/lib/unified-order/build-omie-customer.ts` — helper puro que monta `OmieCustomer | null` dos 2 registros.
+- **Create:** `src/lib/unified-order/__tests__/build-omie-customer.test.ts` — testes do helper.
+- **Modify:** `src/hooks/useUnifiedOrder.ts` — adiciona `selectCustomerByUserId` (data layer) + expõe no return.
+- **Modify:** `src/pages/UnifiedOrder.tsx` — lê `?customer=` e dispara a pré-seleção uma vez.
+
+---
+
+## Task 1: Helper puro `buildOmieCustomer` (TDD)
+
+**Files:**
+- Create: `src/lib/unified-order/build-omie-customer.ts`
+- Test: `src/lib/unified-order/__tests__/build-omie-customer.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// src/lib/unified-order/__tests__/build-omie-customer.test.ts
+import { describe, it, expect } from 'vitest';
+import { buildOmieCustomer } from '../build-omie-customer';
+
+const UID = 'user-123';
+
+describe('buildOmieCustomer', () => {
+  it('monta OmieCustomer completo com profile + mapeamento omie', () => {
+    const r = buildOmieCustomer(
+      UID,
+      { razao_social: 'ACME LTDA', name: 'Acme', document: '12345678000199' },
+      { omie_codigo_cliente: 555, omie_codigo_vendedor: 42 },
+    );
+    expect(r).toEqual({
+      codigo_cliente: 555,
+      razao_social: 'ACME LTDA',
+      nome_fantasia: 'Acme',
+      cnpj_cpf: '12345678000199',
+      codigo_vendedor: 42,
+      local_user_id: UID,
+    });
+  });
+
+  it('sem mapeamento omie → codigo_cliente=0 e vendedor null (cliente local)', () => {
+    const r = buildOmieCustomer(
+      UID,
+      { razao_social: 'ACME LTDA', name: 'Acme', document: '123' },
+      null,
+    );
+    expect(r?.codigo_cliente).toBe(0);
+    expect(r?.codigo_vendedor).toBeNull();
+    expect(r?.local_user_id).toBe(UID);
+  });
+
+  it('sem profile → null (não dá pra identificar)', () => {
+    expect(buildOmieCustomer(UID, null, { omie_codigo_cliente: 555, omie_codigo_vendedor: 42 })).toBeNull();
+  });
+
+  it('razao_social ausente → cai pro name', () => {
+    const r = buildOmieCustomer(UID, { razao_social: null, name: 'Acme', document: '123' }, null);
+    expect(r?.razao_social).toBe('Acme');
+  });
+
+  it('document ausente → cnpj_cpf string vazia (tipo exige string)', () => {
+    const r = buildOmieCustomer(UID, { razao_social: 'ACME', name: 'Acme', document: null }, null);
+    expect(r?.cnpj_cpf).toBe('');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/lucassardenberg/Projetos/afiacao/.claude/worktrees/novo-pedido-preselect && heavy bun run test -- build-omie-customer`
+Expected: FAIL — `Cannot find module '../build-omie-customer'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+// src/lib/unified-order/build-omie-customer.ts
+import type { OmieCustomer } from '@/hooks/unifiedOrder/types';
+
+export interface ProfileIdentity {
+  razao_social: string | null;
+  name: string | null;
+  document: string | null;
+}
+
+export interface OmieMapping {
+  omie_codigo_cliente: number;
+  omie_codigo_vendedor: number | null;
+}
+
+/**
+ * Monta um OmieCustomer a partir da identidade (profiles) + mapeamento (omie_clientes),
+ * ambos buscados por user_id. Puro (sem I/O). Retorna null se não há identidade mínima
+ * (sem profile não dá pra pré-selecionar). codigo_cliente=0 = cliente local/não-sincronizado,
+ * caso que o fluxo manual de pedido já trata.
+ */
+export function buildOmieCustomer(
+  userId: string,
+  profile: ProfileIdentity | null,
+  omie: OmieMapping | null,
+): OmieCustomer | null {
+  if (!profile) return null;
+  const nome = profile.razao_social || profile.name || '';
+  return {
+    codigo_cliente: omie?.omie_codigo_cliente ?? 0,
+    razao_social: nome,
+    nome_fantasia: profile.name || nome,
+    cnpj_cpf: profile.document ?? '',
+    codigo_vendedor: omie?.omie_codigo_vendedor ?? null,
+    local_user_id: userId,
+  };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /Users/lucassardenberg/Projetos/afiacao/.claude/worktrees/novo-pedido-preselect && heavy bun run test -- build-omie-customer`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/unified-order/build-omie-customer.ts src/lib/unified-order/__tests__/build-omie-customer.test.ts
+git commit -m "feat(novo-pedido): helper puro buildOmieCustomer (user_id → OmieCustomer)"
+```
+
+---
+
+## Task 2: `selectCustomerByUserId` no `useUnifiedOrder`
+
+**Files:**
+- Modify: `src/hooks/useUnifiedOrder.ts`
+
+Contexto: o hook já importa `supabase` e `useCallback`, já tem `selectCustomer` (de `useCustomerSelection`) e o precedente `handleAICustomerSelect` (resolve por user_id e chama `selectCustomer`). Adicionar um método irmão focado, que parte só do `user_id`.
+
+- [ ] **Step 1: Adicionar o import do helper**
+
+No topo de `src/hooks/useUnifiedOrder.ts`, junto aos demais imports de `@/lib` / `@/hooks`:
+
+```ts
+import { buildOmieCustomer } from '@/lib/unified-order/build-omie-customer';
+```
+
+- [ ] **Step 2: Definir `selectCustomerByUserId`**
+
+Logo **após** a definição de `handleAICustomerSelect` (o `useCallback` que termina em `}, [selectCustomer]);`), adicionar:
+
+```ts
+  // Pré-seleção por user_id (deep-link "Novo pedido" do Customer 360).
+  // Busca identidade (profiles) + mapeamento Omie (omie_clientes) por user_id,
+  // monta o OmieCustomer e reusa o selectCustomer existente. Falha → silencioso
+  // (não pré-seleciona; o vendedor escolhe no passo Cliente). NÃO altera o money-path.
+  const selectCustomerByUserId = useCallback(async (userId: string) => {
+    if (!userId) return;
+    try {
+      const [{ data: profile }, { data: omie }] = await Promise.all([
+        supabase.from('profiles')
+          .select('razao_social, name, document')
+          .eq('user_id', userId).maybeSingle(),
+        supabase.from('omie_clientes')
+          .select('omie_codigo_cliente, omie_codigo_vendedor')
+          .eq('user_id', userId).maybeSingle(),
+      ]);
+      const omieCustomer = buildOmieCustomer(userId, profile, omie);
+      if (omieCustomer) await selectCustomer(omieCustomer);
+    } catch {
+      // fallback silencioso: mantém o fluxo manual intacto
+    }
+  }, [selectCustomer]);
+```
+
+- [ ] **Step 3: Expor no return do hook**
+
+No objeto retornado (bloco `return { ... }`, seção `// Customer`), adicionar `selectCustomerByUserId` ao lado de `selectCustomer`:
+
+```ts
+    loadingCustomer, customerUserId, selectCustomer, selectCustomerByUserId, clearCustomer,
+```
+
+(Substitui a linha existente `loadingCustomer, customerUserId, selectCustomer, clearCustomer,` — apenas inserindo `selectCustomerByUserId,` após `selectCustomer,`.)
+
+- [ ] **Step 4: Verificar typecheck**
+
+Run: `cd /Users/lucassardenberg/Projetos/afiacao/.claude/worktrees/novo-pedido-preselect && heavy bun run typecheck`
+Expected: exit 0 (sem erros). Confirma que o select tipa contra `profiles`/`omie_clientes` e que `profile`/`omie` batem com `ProfileIdentity`/`OmieMapping` do helper.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hooks/useUnifiedOrder.ts
+git commit -m "feat(novo-pedido): selectCustomerByUserId no useUnifiedOrder (reusa selectCustomer)"
+```
+
+---
+
+## Task 3: Fiação no `UnifiedOrder.tsx` (ler `?customer=` + run-once)
+
+**Files:**
+- Modify: `src/pages/UnifiedOrder.tsx`
+
+- [ ] **Step 1: Adicionar imports `useRef` e `useSearchParams`**
+
+Linha 1 — adicionar `useRef`:
+```ts
+import { useEffect, useMemo, useRef, useState } from 'react';
+```
+Adicionar (após os imports de react-router já existentes, ou junto aos imports do topo):
+```ts
+import { useSearchParams } from 'react-router-dom';
+```
+
+- [ ] **Step 2: Ler o param e disparar a pré-seleção uma vez**
+
+Logo após `const h = useUnifiedOrder();` (linha ~46), adicionar:
+
+```ts
+  const [searchParams] = useSearchParams();
+  const preselectCustomerId = searchParams.get('customer');
+  const preselectedRef = useRef(false);
+
+  useEffect(() => {
+    if (
+      preselectCustomerId &&
+      h.isStaff &&
+      !h.selectedCustomer &&
+      !preselectedRef.current
+    ) {
+      preselectedRef.current = true;
+      void h.selectCustomerByUserId(preselectCustomerId);
+    }
+  }, [preselectCustomerId, h.isStaff, h.selectedCustomer, h.selectCustomerByUserId]);
+```
+
+> O stepper avança sozinho: `currentStep` deriva de `selectedCustomer`. O `loadingCustomer` existente cobre o tempo da resolução. O guard `!h.selectedCustomer` evita sobrescrever seleção manual; o `preselectedRef` garante run-once mesmo se o efeito re-rodar.
+
+- [ ] **Step 3: Verificar typecheck + lint**
+
+Run: `cd /Users/lucassardenberg/Projetos/afiacao/.claude/worktrees/novo-pedido-preselect && heavy bun run typecheck && heavy bun run lint`
+Expected: typecheck exit 0; lint 0 errors (warnings de exhaustive-deps pré-existentes OK). Se o lint apontar `exhaustive-deps` na nova `useEffect`, as deps já estão completas (`preselectCustomerId, h.isStaff, h.selectedCustomer, h.selectCustomerByUserId`) — não suprimir.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/pages/UnifiedOrder.tsx
+git commit -m "feat(novo-pedido): UnifiedOrder lê ?customer= e pré-seleciona (run-once, staff)"
+```
+
+---
+
+## Task 4: Validação final
+
+**Files:** nenhum (só validação)
+
+- [ ] **Step 1: Suíte completa**
+
+Run: `cd /Users/lucassardenberg/Projetos/afiacao/.claude/worktrees/novo-pedido-preselect && heavy bun run typecheck && heavy bun run lint && heavy bun run test && heavy bun run build`
+Expected: typecheck 0 · lint 0 errors · test todos passando (incl. os 5 novos do buildOmieCustomer) · build ✓.
+
+- [ ] **Step 2: Confirmar escopo intacto**
+
+Run: `git diff --stat origin/main`
+Expected: só 4 arquivos tocados (2 criados em `src/lib/unified-order/`, `useUnifiedOrder.ts`, `UnifiedOrder.tsx`). `CustomerHero.tsx`, `selectCustomer`/`useCustomerSelection` **não** aparecem (money-path intacto).
+
+---
+
+## Self-Review (autor do plano)
+
+**Spec coverage:**
+- §3.1 helper puro → Task 1 ✓
+- §3.2 selectCustomerByUserId (2 lookups paralelos + buildOmieCustomer + selectCustomer + fallback silencioso) → Task 2 ✓
+- §3.3 fiação UnifiedOrder (param + run-once + staff + sem-seleção-prévia) → Task 3 ✓
+- §4 privacidade (só user_id na URL) → CustomerHero já manda só `user_id` (#516), inalterado ✓
+- §5 degradação (reusa selectCustomer; run-once; fallback silencioso) → Tasks 2/3 ✓
+- §6 testes (buildOmieCustomer TDD; fiação → QA manual) → Task 1 + nota no Task 4 ✓
+- §7 fora de escopo (não toca selectCustomer/handleAICustomerSelect/CustomerHero) → confirmado no Task 4 Step 2 ✓
+
+**Placeholder scan:** nenhum TBD/TODO; todo passo tem código real.
+
+**Type consistency:** `buildOmieCustomer(userId, profile, omie)` — assinatura idêntica em Task 1 (def) e Task 2 (uso). `ProfileIdentity` = `{razao_social, name, document}` bate com o `.select('razao_social, name, document')`. `OmieMapping` = `{omie_codigo_cliente, omie_codigo_vendedor}` bate com o `.select('omie_codigo_cliente, omie_codigo_vendedor')`. `selectCustomerByUserId` exposto no return (Task 2 Step 3) e consumido como `h.selectCustomerByUserId` (Task 3 Step 2). `OmieCustomer` importado de `@/hooks/unifiedOrder/types`.

--- a/docs/superpowers/specs/2026-05-31-novo-pedido-preselect-cliente-design.md
+++ b/docs/superpowers/specs/2026-05-31-novo-pedido-preselect-cliente-design.md
@@ -1,0 +1,101 @@
+# Pré-seleção de cliente no "Novo pedido" (Customer 360 → /sales/new)
+
+**Data:** 2026-05-31
+**Autor:** Lucas + Claude (decisão A confirmada por consult codex)
+**Status:** aprovado (founder: "Siga")
+
+---
+
+## 1. Problema
+
+O botão **"Novo pedido"** do Customer 360 (`CustomerHero.tsx`) navega para `/sales/new?customer=<user_id>` (corrigido no #516, antes era a rota morta `/admin/orders/new`). Mas o `useUnifiedOrder` **ignora** o param `?customer=` → o vendedor abre o cliente no 360, clica "Novo pedido", e cai no passo "Cliente" tendo que **buscar de novo o mesmo cliente** que já tinha aberto. Fricção óbvia no caminho comercial; parece produto inacabado no fluxo de dinheiro.
+
+> Gap registrado como follow-up no #516. Priorizado como próxima atividade (decisão eu + codex: opção A, "completar Novo pedido"). Codex: maior valor, risco aceitável **se a mudança for estreita** (ler `?customer=`, hidratar pelo caminho existente, TDD, review).
+
+## 2. Comportamento atual (confirmado por trace — o "smoke test" do codex)
+
+- `useUnifiedOrder` (`src/hooks/useUnifiedOrder.ts`): expõe `selectCustomer(omieCustomer: OmieCustomer)` (vem do hook `useCustomerSelection`) — o **caminho validado** de seleção. NÃO lê `searchParams`.
+- `currentStep` (staff) deriva de `selectedCustomer`: `!selectedCustomer ? 0 (Cliente) : cart.length===0 ? 1 (Itens) : 2 (Revisão)`. **Selecionar um cliente já faz o stepper pular pra "Itens"** — sem manipular step manualmente.
+- Precedente interno `handleAICustomerSelect(customer)`: resolve `codigo_cliente` por `user_id` via `omie_clientes`, monta `OmieCustomer`, chama `selectCustomer`. É o padrão a **espelhar** (não refatorar).
+- `OmieCustomer` (shape usado): `{ codigo_cliente, razao_social, nome_fantasia, cnpj_cpf, codigo_vendedor, local_user_id }`.
+
+**Fontes de dados por `user_id`:**
+- `omie_clientes` (tabela de MAPEAMENTO, sem identidade): `omie_codigo_cliente`, `omie_codigo_vendedor`, `user_id`.
+- `profiles` (identidade): `razao_social`, `name`, `document` (cnpj_cpf), `user_id`.
+
+## 3. Design (estreito — reusa o caminho existente)
+
+### 3.1 Helper puro `buildOmieCustomer` (TDD)
+Arquivo novo: `src/lib/unified-order/build-omie-customer.ts`.
+```ts
+// Monta o OmieCustomer a partir dos 2 registros buscados por user_id.
+// Puro e testável: sem I/O. Retorna null se não há identidade mínima (sem profile).
+export function buildOmieCustomer(
+  userId: string,
+  profile: { razao_social: string | null; name: string | null; document: string | null } | null,
+  omie: { omie_codigo_cliente: number; omie_codigo_vendedor: number | null } | null,
+): OmieCustomer | null {
+  if (!profile) return null;                       // sem identidade → não dá pra pré-selecionar
+  const nome = profile.razao_social || profile.name || '';
+  return {
+    codigo_cliente: omie?.omie_codigo_cliente ?? 0, // 0 = cliente local/não-sincronizado (fluxo manual já trata)
+    razao_social: nome,
+    nome_fantasia: profile.name || nome,
+    cnpj_cpf: profile.document ?? null,
+    codigo_vendedor: omie?.omie_codigo_vendedor ?? null,
+    local_user_id: userId,
+  };
+}
+```
+> O tipo `OmieCustomer` é importado de `@/hooks/unifiedOrder/types` (definido em `src/hooks/unifiedOrder/types.ts:84`; re-exportado por `@/hooks/useUnifiedOrder`). O helper importa direto de `@/hooks/unifiedOrder/types` (evita ciclo com o hook).
+
+### 3.2 `selectCustomerByUserId(userId)` no `useUnifiedOrder` (camada de dados)
+- Busca **em paralelo** (`Promise.all`): `profiles` (razao_social/name/document por `user_id`) + `omie_clientes` (omie_codigo_cliente/omie_codigo_vendedor por `user_id`). Ambos `.maybeSingle()`.
+- `const omieCustomer = buildOmieCustomer(userId, profile, omie)`.
+- Se `omieCustomer` → `await selectCustomer(omieCustomer)` (o caminho existente; dispara os downstream loads de endereço/preço/pagamento/ferramentas como na seleção manual).
+- Se `null` → **fallback silencioso** (não pré-seleciona; retorna sem erro). NÃO quebra o fluxo manual.
+- Exposto no return do hook como `selectCustomerByUserId`.
+- `useCallback` com dep `[selectCustomer]` (espelha `handleAICustomerSelect`).
+
+### 3.3 Fiação no `UnifiedOrder.tsx`
+- Lê `const [searchParams] = useSearchParams(); const preselectId = searchParams.get('customer');`.
+- `useEffect` run-once (guard por `useRef(false)`): dispara **só** se `preselectId && isStaff && !selectedCustomer && !preselectedRef.current` → seta o ref, chama `selectCustomerByUserId(preselectId)`.
+- Selecionar avança o stepper sozinho (via `currentStep`).
+- Exibe o `loadingCustomer` existente durante a resolução (sem novo estado de loading).
+
+## 4. Privacidade
+
+Só o `user_id` (UUID opaco) trafega na URL. `cnpj_cpf`, nome e demais PII **nunca** vão na query string (regra de privacidade) — são buscados client-side a partir do `user_id`. A `CustomerHero` já passa só `customer.user_id` (#516) → nenhuma mudança lá.
+
+## 5. Degradação honesta (mitiga o risco apontado pelo codex)
+
+> Risco do codex: "mexer no fluxo de pedido e quebrar seleção/endereço/pagamento por causa dos efeitos online do `selectCustomer`."
+
+Mitigações:
+- **Reusa `selectCustomer` verbatim** — zero money-path novo; a resolução é puramente aditiva (2 reads + build).
+- **Run-once guard** + dispara só com `?customer=` presente, modo staff, e **sem** seleção prévia → nunca sobrescreve uma escolha manual nem re-dispara.
+- **Fallback silencioso** em qualquer falha de resolução (sem profile, sem mapeamento Omie, erro de rede) → o vendedor cai no passo "Cliente" manual, fluxo 100% intacto. Sem toast de erro assustador.
+- `codigo_cliente=0` quando não há mapeamento Omie = exatamente o que o fluxo manual já faz pra cliente local/não-sincronizado.
+
+## 6. Testes
+
+- **Unit (vitest, TDD)** do `buildOmieCustomer`: profile presente + omie presente → OmieCustomer completo; profile presente + omie ausente → `codigo_cliente=0`, vendedor null; profile ausente → `null`; razao_social ausente → fallback pra `name`; document ausente → `cnpj_cpf` null.
+- **Fiação do mount** (`UnifiedOrder` lendo o param + run-once): coberta por **verificação manual no QA** (mock de hook + router + selectCustomer rende pouco sinal pra muito setup). Documentar no PR o passo de QA: abrir Customer 360 → "Novo pedido" → cliente pré-selecionado, stepper em "Itens".
+- Suíte completa verde (typecheck/lint/test/build).
+
+## 7. Fora de escopo
+
+- Mudar/refatorar `selectCustomer` ou `handleAICustomerSelect` (money-path — manter intacto).
+- Pré-seleção a partir de outras telas (só a `CustomerHero` manda `?customer=` hoje; o mecanismo fica pronto pra futuros callers).
+- Pré-preencher itens/carrinho a partir da URL (só o cliente).
+- Modo cliente (`isCustomerMode`) — lá o cliente é o próprio usuário, não se aplica.
+
+## 8. Arquivos
+
+- **Criar:** `src/lib/unified-order/build-omie-customer.ts` + teste `src/lib/unified-order/__tests__/build-omie-customer.test.ts`.
+- **Modificar:** `src/hooks/useUnifiedOrder.ts` (add `selectCustomerByUserId` + expor no return), `src/pages/UnifiedOrder.tsx` (ler param + useEffect run-once).
+- **Inalterado:** `CustomerHero.tsx` (já passa `?customer=<user_id>`), `selectCustomer`/`useCustomerSelection`.
+
+## 9. Risco
+
+Baixo. Mudança aditiva sobre um caminho validado; degradação silenciosa preserva o fluxo manual. O único risco real (efeitos online do `selectCustomer`) é o **mesmo** que a seleção manual já exercita todo dia — não introduzimos comportamento novo no money-path, só uma nova porta de entrada (programática) pro mesmo `selectCustomer`. Verificação de runtime fica pro QA final (browser headless não renderiza a SPA).

--- a/src/hooks/useOrderDeepLink.ts
+++ b/src/hooks/useOrderDeepLink.ts
@@ -1,6 +1,5 @@
 import { useEffect, useRef, useMemo } from 'react';
 import { useSearchParams } from 'react-router-dom';
-import { supabase } from '@/integrations/supabase/client';
 import { logger } from '@/lib/logger';
 import type { OmieCustomer, Product } from '@/hooks/useUnifiedOrder';
 
@@ -22,12 +21,13 @@ export interface DeepLinkParams {
 }
 
 /**
- * Reads deep-link query params once and drives automatic
- * customer selection + product addition in the unified order flow.
+ * Reads deep-link query params once and drives automatic product addition
+ * in the unified order flow. A seleção de cliente a partir de `?customer=<user_id>`
+ * é responsabilidade do `selectCustomerByUserId` (useUnifiedOrder) — ver UnifiedOrder.tsx.
+ * O ramo de produto só dispara após o cliente estar selecionado.
  */
 export function useOrderDeepLink({
   selectedCustomer,
-  selectCustomer,
   addProductToCart,
   obenProducts,
   colacorProducts,
@@ -36,7 +36,6 @@ export function useOrderDeepLink({
   loadingCustomer,
 }: {
   selectedCustomer: OmieCustomer | null;
-  selectCustomer: (c: OmieCustomer) => void;
   addProductToCart: (p: Product) => void;
   obenProducts: Product[];
   colacorProducts: Product[];
@@ -51,44 +50,7 @@ export function useOrderDeepLink({
     productId: searchParams.get(PARAM_KEYS.product) || null,
   }), [searchParams]);
 
-  const customerHandled = useRef(false);
   const productHandled = useRef(false);
-
-  /* ── Auto-select customer ── */
-  useEffect(() => {
-    if (!params.customerId || customerHandled.current || selectedCustomer) return;
-    customerHandled.current = true;
-
-    (async () => {
-      try {
-        const { data, error } = await supabase.functions.invoke('omie-vendas-sync', {
-          body: { action: 'listar_clientes', search: params.customerId },
-        });
-        if (error || !data?.clientes?.length) {
-          logger.warn('DeepLink: customer not found', {
-            stage: 'resolve_order',
-            customerIdParam: params.customerId,
-            error,
-          });
-          return;
-        }
-
-        // Try exact codigo_cliente match first, then take first result
-        const clientes = data.clientes as OmieCustomer[];
-        const exact = clientes.find(
-          c => String(c.codigo_cliente) === params.customerId
-            || c.cnpj_cpf?.replace(/\D/g, '') === params.customerId?.replace(/\D/g, ''),
-        );
-        selectCustomer(exact || clientes[0]);
-      } catch (err) {
-        logger.warn('DeepLink: error fetching customer', {
-          stage: 'resolve_order',
-          customerIdParam: params.customerId,
-          error: err,
-        });
-      }
-    })();
-  }, [params.customerId, selectedCustomer, selectCustomer]);
 
   /* ── Auto-add product after customer is selected & products loaded ── */
   useEffect(() => {

--- a/src/hooks/useOrderDeepLink.ts
+++ b/src/hooks/useOrderDeepLink.ts
@@ -5,7 +5,7 @@ import type { OmieCustomer, Product } from '@/hooks/useUnifiedOrder';
 
 /* ─── Deep-link query param keys ─── */
 const PARAM_KEYS = {
-  customer: 'customer',
+  // O param `customer` é lido pelo selectCustomerByUserId (useUnifiedOrder), não aqui.
   product: 'product',
   // Future extensions:
   // tool: 'tool',
@@ -13,7 +13,6 @@ const PARAM_KEYS = {
 } as const;
 
 export interface DeepLinkParams {
-  customerId: string | null;
   productId: string | null;
   // Future:
   // toolId: string | null;
@@ -46,7 +45,6 @@ export function useOrderDeepLink({
   const [searchParams] = useSearchParams();
 
   const params = useMemo<DeepLinkParams>(() => ({
-    customerId: searchParams.get(PARAM_KEYS.customer) || null,
     productId: searchParams.get(PARAM_KEYS.product) || null,
   }), [searchParams]);
 

--- a/src/hooks/useUnifiedOrder.ts
+++ b/src/hooks/useUnifiedOrder.ts
@@ -18,6 +18,7 @@ import type { AIOrderResult, AICustomerMatch } from '@/components/UnifiedAIAssis
 import type { IdentifiedItem } from '@/components/VoiceServiceInput';
 import { logger } from '@/lib/logger';
 import { maskDocument } from '@/lib/format';
+import { buildOmieCustomer } from '@/lib/unified-order/build-omie-customer';
 
 // Re-export shared types for backwards compatibility
 export { VOLUME_UNITS };
@@ -455,6 +456,28 @@ export function useUnifiedOrder() {
     await selectCustomer(omieCustomer);
   }, [selectCustomer]);
 
+  // Pré-seleção por user_id (deep-link "Novo pedido" do Customer 360).
+  // Busca identidade (profiles) + mapeamento Omie (omie_clientes) por user_id,
+  // monta o OmieCustomer e reusa o selectCustomer existente. Falha → silencioso
+  // (não pré-seleciona; o vendedor escolhe no passo Cliente). NÃO altera o money-path.
+  const selectCustomerByUserId = useCallback(async (userId: string) => {
+    if (!userId) return;
+    try {
+      const [{ data: profile }, { data: omie }] = await Promise.all([
+        supabase.from('profiles')
+          .select('razao_social, name, document')
+          .eq('user_id', userId).maybeSingle(),
+        supabase.from('omie_clientes')
+          .select('omie_codigo_cliente, omie_codigo_vendedor')
+          .eq('user_id', userId).maybeSingle(),
+      ]);
+      const omieCustomer = buildOmieCustomer(userId, profile, omie);
+      if (omieCustomer) await selectCustomer(omieCustomer);
+    } catch {
+      // fallback silencioso: mantém o fluxo manual intacto
+    }
+  }, [selectCustomer]);
+
   // Unified AI handler
   const handleUnifiedAIResult = useCallback((result: AIOrderResult) => {
     const newCartItems: CartItem[] = [];
@@ -674,7 +697,7 @@ export function useUnifiedOrder() {
     authLoading, user, isStaff, isCustomerMode,
     // Customer
     customerSearch, setCustomerSearch, customers, selectedCustomer, searchingCustomers,
-    loadingCustomer, customerUserId, selectCustomer, clearCustomer,
+    loadingCustomer, customerUserId, selectCustomer, selectCustomerByUserId, clearCustomer,
     // Products
     obenProducts, colacorProducts, productSearch, setProductSearch,
     loadingObenProducts, loadingColacorProducts,

--- a/src/lib/unified-order/__tests__/build-omie-customer.test.ts
+++ b/src/lib/unified-order/__tests__/build-omie-customer.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { buildOmieCustomer } from '../build-omie-customer';
+
+const UID = 'user-123';
+
+describe('buildOmieCustomer', () => {
+  it('monta OmieCustomer completo com profile + mapeamento omie', () => {
+    const r = buildOmieCustomer(
+      UID,
+      { razao_social: 'ACME LTDA', name: 'Acme', document: '12345678000199' },
+      { omie_codigo_cliente: 555, omie_codigo_vendedor: 42 },
+    );
+    expect(r).toEqual({
+      codigo_cliente: 555,
+      razao_social: 'ACME LTDA',
+      nome_fantasia: 'Acme',
+      cnpj_cpf: '12345678000199',
+      codigo_vendedor: 42,
+      local_user_id: UID,
+    });
+  });
+
+  it('sem mapeamento omie → codigo_cliente=0 e vendedor null (cliente local)', () => {
+    const r = buildOmieCustomer(
+      UID,
+      { razao_social: 'ACME LTDA', name: 'Acme', document: '123' },
+      null,
+    );
+    expect(r?.codigo_cliente).toBe(0);
+    expect(r?.codigo_vendedor).toBeNull();
+    expect(r?.local_user_id).toBe(UID);
+  });
+
+  it('sem profile → null (não dá pra identificar)', () => {
+    expect(buildOmieCustomer(UID, null, { omie_codigo_cliente: 555, omie_codigo_vendedor: 42 })).toBeNull();
+  });
+
+  it('razao_social ausente → cai pro name', () => {
+    const r = buildOmieCustomer(UID, { razao_social: null, name: 'Acme', document: '123' }, null);
+    expect(r?.razao_social).toBe('Acme');
+  });
+
+  it('document ausente → cnpj_cpf string vazia (tipo exige string)', () => {
+    const r = buildOmieCustomer(UID, { razao_social: 'ACME', name: 'Acme', document: null }, null);
+    expect(r?.cnpj_cpf).toBe('');
+  });
+});

--- a/src/lib/unified-order/build-omie-customer.ts
+++ b/src/lib/unified-order/build-omie-customer.ts
@@ -1,0 +1,35 @@
+import type { OmieCustomer } from '@/hooks/unifiedOrder/types';
+
+export interface ProfileIdentity {
+  razao_social: string | null;
+  name: string | null;
+  document: string | null;
+}
+
+export interface OmieMapping {
+  omie_codigo_cliente: number;
+  omie_codigo_vendedor: number | null;
+}
+
+/**
+ * Monta um OmieCustomer a partir da identidade (profiles) + mapeamento (omie_clientes),
+ * ambos buscados por user_id. Puro (sem I/O). Retorna null se não há identidade mínima
+ * (sem profile não dá pra pré-selecionar). codigo_cliente=0 = cliente local/não-sincronizado,
+ * caso que o fluxo manual de pedido já trata.
+ */
+export function buildOmieCustomer(
+  userId: string,
+  profile: ProfileIdentity | null,
+  omie: OmieMapping | null,
+): OmieCustomer | null {
+  if (!profile) return null;
+  const nome = profile.razao_social || profile.name || '';
+  return {
+    codigo_cliente: omie?.omie_codigo_cliente ?? 0,
+    razao_social: nome,
+    nome_fantasia: profile.name || nome,
+    cnpj_cpf: profile.document ?? '',
+    codigo_vendedor: omie?.omie_codigo_vendedor ?? null,
+    local_user_id: userId,
+  };
+}

--- a/src/pages/UnifiedOrder.tsx
+++ b/src/pages/UnifiedOrder.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { Loader2, CheckCircle, Building2, Scissors, Wifi } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { track } from '@/lib/analytics';
@@ -47,6 +48,22 @@ const UnifiedOrder = () => {
   const { isCustomerMode } = h;
   const { user } = useAuth();
   const [restoreOpen, setRestoreOpen] = useState(false);
+
+  const [searchParams] = useSearchParams();
+  const preselectCustomerId = searchParams.get('customer');
+  const preselectedRef = useRef(false);
+
+  useEffect(() => {
+    if (
+      preselectCustomerId &&
+      h.isStaff &&
+      !h.selectedCustomer &&
+      !preselectedRef.current
+    ) {
+      preselectedRef.current = true;
+      void h.selectCustomerByUserId(preselectCustomerId);
+    }
+  }, [preselectCustomerId, h.isStaff, h.selectedCustomer, h.selectCustomerByUserId]);
 
   useOrderDeepLink({
     selectedCustomer: h.selectedCustomer,

--- a/src/pages/UnifiedOrder.tsx
+++ b/src/pages/UnifiedOrder.tsx
@@ -67,7 +67,6 @@ const UnifiedOrder = () => {
 
   useOrderDeepLink({
     selectedCustomer: h.selectedCustomer,
-    selectCustomer: h.selectCustomer,
     addProductToCart: h.addProductToCart,
     obenProducts: h.obenProducts,
     colacorProducts: h.colacorProducts,


### PR DESCRIPTION
## Resumo
O botão **"Novo pedido"** do Customer 360 levava a `/sales/new?customer=<user_id>` mas o cliente **não era pré-selecionado** — o vendedor tinha que re-buscar quem já tinha aberto. Agora `?customer=<user_id>` pré-seleciona o cliente no fluxo de pedido staff, reusando o `selectCustomer` existente.

Decisão **A** confirmada por consult codex; mudança **estreita** (ler param → hidratar pelo caminho existente → TDD), com degradação silenciosa que preserva o fluxo manual.

### O que entrou (4 commits de código)
1. **`buildOmieCustomer`** (helper puro, TDD 5 testes) — monta `OmieCustomer` dos 2 lookups (`profiles` + `omie_clientes`) por `user_id`.
2. **`selectCustomerByUserId`** no `useUnifiedOrder` — 2 lookups paralelos + `buildOmieCustomer` + reusa `selectCustomer`. Fallback silencioso.
3. **Fiação no `UnifiedOrder.tsx`** — lê `?customer=`, `useEffect` run-once (guard `staff && !selectedCustomer && !ref`). O stepper avança sozinho.
4. **Fix P2 (bônus, achado no review):** remove o ramo-cliente **morto** do `useOrderDeepLink` (lia `?customer=` como busca textual no Omie → com UUID nunca casava → desperdiçava 1 chamada + `logger.warn` espúrio a **cada** abertura). Agora `selectCustomerByUserId` é o dono. **Bônus:** `?customer=<uuid>&product=<id>` (de FarmerRecommendations/Bundles) passa a funcionar **ponta-a-ponta** — antes nunca funcionava.

### Privacidade
Só o `user_id` (UUID) na URL; `cnpj_cpf`/nome **nunca** (buscados client-side). `CustomerHero` inalterado.

### Money-path intacto
`selectCustomer`/`useCustomerSelection`/`CustomerHero` **sem diff**. A pré-seleção é uma nova porta de entrada (programática) pro MESMO `selectCustomer` — zero comportamento novo no fluxo de pedido.

## Sem backend
Front puro. Sem migration/SQL/edge.

## Qualidade
- **3 reviews** (subagent-driven): conformidade-spec ✅ · qualidade (achou+corrigiu o P2) · review final ✅ PRONTO PRA MERGE.
- typecheck **0** · lint **0 errors** · test **1940/1940** · build **✓**.

## Test plan
- [x] TDD `buildOmieCustomer` (5 testes: completo, sem-omie→codigo 0, sem-profile→null, razao→name, document→'').
- [x] Suíte + typecheck + lint + build verdes.
- [ ] **QA manual no device** (a fiação do mount não tem teste unitário — spec §6): abrir Customer 360 → "Novo pedido" → cliente **pré-selecionado**, stepper já em "Itens". Testar também via FarmerRecommendations (`?customer=&product=` → cliente + produto no carrinho).

🤖 Generated with [Claude Code](https://claude.com/claude-code)