### PR TITLE
feat(rota): preview da proposta accept-a-proposal (phone-free)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -169,6 +169,7 @@ const AdminCalculadora = lazy(() => import("./pages/AdminCalculadora"));
 const Telefonia = lazy(() => import("./pages/Telefonia"));
 const WhatsappInbox = lazy(() => import("./pages/WhatsappInbox"));
 const RotaListaLigacao = lazy(() => import("./pages/RotaListaLigacao"));
+const RotaPropostas = lazy(() => import("./pages/RotaPropostas"));
 
 const PageLoader = () => <PageSkeleton variant="auto" />;
 
@@ -367,6 +368,7 @@ const App = () => (
                 <Route path="telefonia" element={<Telefonia />} />
                 <Route path="whatsapp" element={<WhatsappInbox />} />
                 <Route path="rota/ligacoes" element={<RotaListaLigacao />} />
+                <Route path="rota/propostas" element={<RotaPropostas />} />
               </Route>
             </Route>
 

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { ImpersonationBanner } from '@/components/impersonation/ImpersonationBanner';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { BookOpen, Lock, Calculator, Palette, LayoutDashboard, Users, ShoppingCart, Phone, BarChart3, Settings, ChevronLeft, ChevronRight, Bell, User, LogOut, Package, TrendingUp, Target, Menu, X, PlusCircle, Shield, Wrench, Award, DollarSign, UserCheck, FileCheck, Factory, Percent, Link2, Globe2, Database, Library, Crosshair, ListChecks, Landmark, UserX, ShieldCheck, MessageCircle } from 'lucide-react';
+import { BookOpen, Lock, Calculator, Palette, LayoutDashboard, Users, ShoppingCart, Phone, BarChart3, Settings, ChevronLeft, ChevronRight, Bell, User, LogOut, Package, TrendingUp, Target, Menu, X, PlusCircle, Shield, Wrench, Award, DollarSign, UserCheck, FileCheck, Factory, Percent, Link2, Globe2, Database, Library, Crosshair, ListChecks, Landmark, UserX, ShieldCheck, MessageCircle, MessageSquareText } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useAuth } from '@/contexts/AuthContext';
 import { AppShellProvider } from '@/contexts/AppShellContext';
@@ -85,6 +85,7 @@ const unifiedNavSections: { title: string; items: NavItem[] }[] = [
       { icon: Phone, label: 'Telefonia', path: '/telefonia' },
       { icon: MessageCircle, label: 'WhatsApp', path: '/whatsapp', managerOnly: true },
       { icon: ListChecks, label: 'Lista de ligação', path: '/rota/ligacoes', managerOnly: true },
+      { icon: MessageSquareText, label: 'Preview propostas', path: '/rota/propostas', managerOnly: true },
     ],
   },
   {

--- a/src/lib/whatsapp/cesta-ativos.test.ts
+++ b/src/lib/whatsapp/cesta-ativos.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { filtrarCestaPorAtivos } from './cesta-ativos';
+import type { CestaItem, CestaResult } from './cesta-recompra';
+
+function item(sku: number): CestaItem {
+  return {
+    omie_codigo_produto: sku, qtdSugerida: 2, dueRatio: 1, nPedidos: 3, cadenciaDias: 30,
+    confidence: 'media', motivo: 'recorrente_due', ultimoPrecoRef: 10,
+  };
+}
+function cesta(principal: number[], secundarios: number[]): CestaResult {
+  return {
+    principal: principal.map(item), secundarios: secundarios.map(item),
+    totalPedidos: 5, confianca: 'media',
+  };
+}
+
+describe('filtrarCestaPorAtivos', () => {
+  it('remove SKU inativo da principal e dos secundários (codex P1: não propor SKU morto)', () => {
+    const r = filtrarCestaPorAtivos(cesta([100, 200], [300, 400]), new Set([100, 300]));
+    expect(r.cesta.principal.map(i => i.omie_codigo_produto)).toEqual([100]);
+    expect(r.cesta.secundarios.map(i => i.omie_codigo_produto)).toEqual([300]);
+    expect(r.removidos).toBe(2); // 200 e 400 inativos
+  });
+  it('mantém todos quando todos ativos', () => {
+    const r = filtrarCestaPorAtivos(cesta([100, 200], []), new Set([100, 200]));
+    expect(r.cesta.principal.length).toBe(2);
+    expect(r.removidos).toBe(0);
+  });
+  it('todos inativos → cesta vazia, removidos = total', () => {
+    const r = filtrarCestaPorAtivos(cesta([100], [200, 300]), new Set<number>());
+    expect(r.cesta.principal).toEqual([]);
+    expect(r.cesta.secundarios).toEqual([]);
+    expect(r.removidos).toBe(3);
+  });
+  it('preserva totalPedidos e confianca', () => {
+    const r = filtrarCestaPorAtivos(cesta([100], []), new Set([100]));
+    expect(r.cesta.totalPedidos).toBe(5);
+    expect(r.cesta.confianca).toBe('media');
+  });
+});

--- a/src/lib/whatsapp/cesta-ativos.ts
+++ b/src/lib/whatsapp/cesta-ativos.ts
@@ -1,0 +1,13 @@
+import type { CestaResult } from './cesta-recompra';
+
+/**
+ * Remove SKUs inativos (ativo=false no omie_products, dado já sincronizado) da cesta — codex P1:
+ * não propor SKU morto. Pré-filtro PHONE-FREE; o preço FIRME/estoque ainda é validado no Omie no envio.
+ */
+export function filtrarCestaPorAtivos(cesta: CestaResult, ativos: Set<number>): { cesta: CestaResult; removidos: number } {
+  const ativo = (sku: number) => ativos.has(sku);
+  const principal = cesta.principal.filter(i => ativo(i.omie_codigo_produto));
+  const secundarios = cesta.secundarios.filter(i => ativo(i.omie_codigo_produto));
+  const removidos = (cesta.principal.length - principal.length) + (cesta.secundarios.length - secundarios.length);
+  return { cesta: { ...cesta, principal, secundarios }, removidos };
+}

--- a/src/pages/RotaPropostas.tsx
+++ b/src/pages/RotaPropostas.tsx
@@ -1,0 +1,90 @@
+import { useMemo, useState } from 'react';
+import { MessageSquareText, ChevronDown, ChevronUp } from 'lucide-react';
+import { useRouteContactList } from '@/queries/useRouteContactList';
+import type { RouteContactItem } from '@/queries/useRouteContactList';
+import { usePropostaPreview } from '@/queries/usePropostaPreview';
+import { PageSkeleton } from '@/components/ui/page-skeleton';
+import { EmptyState } from '@/components/EmptyState';
+import { Card } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+
+function todayIso(): string { return new Date().toISOString().slice(0, 10); }
+
+function PropostaRow({ cliente }: { cliente: RouteContactItem }) {
+  const [aberto, setAberto] = useState(false);
+  const { data, isLoading } = usePropostaPreview(cliente.customerUserId, { enabled: aberto });
+
+  return (
+    <Card className="p-3">
+      <button type="button" onClick={() => setAberto(a => !a)} className="flex items-center gap-2 w-full text-left">
+        <div className="flex-1 min-w-0">
+          <div className="text-sm truncate">{cliente.name}</div>
+          <div className="text-xs text-muted-foreground font-tabular">{cliente.cityKey.city}</div>
+        </div>
+        <span className="kpi-value text-sm w-24 text-right">R$ {Math.round(cliente.valorDaLigacao)}</span>
+        {aberto ? <ChevronUp className="w-4 h-4" /> : <ChevronDown className="w-4 h-4" />}
+      </button>
+
+      {aberto && (
+        <div className="mt-3 border-t pt-3">
+          {isLoading && <div className="text-xs text-muted-foreground">Gerando proposta…</div>}
+          {!isLoading && data && (
+            data.proposta.vazia ? (
+              <div className="text-xs text-muted-foreground">
+                {data.semHistorico ? 'Sem histórico de pedidos recentes.' : 'Sem cesta de recompra confiável (histórico fino ou só SKUs inativos).'}
+              </div>
+            ) : (
+              <>
+                <pre className="whitespace-pre-wrap text-sm bg-muted/40 rounded-md p-3 font-sans">{data.proposta.texto}</pre>
+                <div className="flex flex-wrap gap-2 mt-2 text-[11px] text-muted-foreground">
+                  <Badge variant="secondary">{data.proposta.itensPrincipais} itens principais</Badge>
+                  {data.removidosInativos > 0 && <Badge variant="outline">{data.removidosInativos} SKU inativo oculto</Badge>}
+                  <span>conta: {data.account}</span>
+                  <span>· {data.totalPedidos} pedidos</span>
+                </div>
+                {data.statusesVistos.length > 0 && (
+                  <div className="text-[11px] text-muted-foreground mt-1">status no histórico: {data.statusesVistos.join(', ')}</div>
+                )}
+              </>
+            )
+          )}
+        </div>
+      )}
+    </Card>
+  );
+}
+
+export default function RotaPropostas() {
+  const workday = useMemo(() => todayIso(), []);
+  const { data, isLoading } = useRouteContactList(workday);
+
+  if (isLoading) return <PageSkeleton variant="list" />;
+
+  const fila = data?.whatsappQueue ?? [];
+  const cidadesLabel = data?.cidades?.length ? data.cidades.join(', ') : null;
+
+  return (
+    <div className="p-4 space-y-4">
+      <header>
+        <h1 className="font-display text-2xl">Preview das propostas (WhatsApp)</h1>
+        <p className="text-sm text-muted-foreground">
+          {data?.dailyOnly ? 'Motor diário (Divinópolis + Carmo do Cajuru)' : cidadesLabel ? `Rota de amanhã — ${cidadesLabel}` : 'Sem rota para amanhã'}
+          {' · '}o que a IA proporia (gerado do histórico — phone-free; envio só no PR2b-send)
+        </p>
+      </header>
+
+      {fila.length === 0 ? (
+        <EmptyState
+          icon={MessageSquareText}
+          tone="operational"
+          title="Nenhum cliente na fila de WhatsApp"
+          description="A fila de proposta (accept-a-proposal) vem dos clientes com recompra previsível nas cidades de amanhã."
+        />
+      ) : (
+        <div className="space-y-2">
+          {fila.map(c => <PropostaRow key={c.customerUserId} cliente={c} />)}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/queries/usePropostaPreview.ts
+++ b/src/queries/usePropostaPreview.ts
@@ -1,0 +1,126 @@
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import { montarCestaRecompra } from '@/lib/whatsapp/cesta-recompra';
+import type { PedidoLine } from '@/lib/whatsapp/cesta-recompra';
+import { filtrarCestaPorAtivos } from '@/lib/whatsapp/cesta-ativos';
+import { formatarPropostaRecompra } from '@/lib/whatsapp/proposta-format';
+import type { PropostaFormatada } from '@/lib/whatsapp/proposta-format';
+
+// Status do Omie que NUNCA contam como compra válida (cancelamento/exclusão). Tudo o mais é
+// permissivo no PREVIEW — a whitelist EXATA é decisão do founder no lançamento (surfaçamos os vistos).
+const STATUS_CANCELAMENTO = new Set(['CANCELADO', 'CANCELADA', 'EXCLUIDO', 'EXCLUÍDO', 'CANCELED']);
+const JANELA_FETCH_DIAS = 365;
+
+function hojeIso(): string { return new Date().toISOString().slice(0, 10); }
+function addDays(iso: string, n: number): string {
+  const d = new Date(iso + 'T12:00:00Z'); d.setUTCDate(d.getUTCDate() + n); return d.toISOString().slice(0, 10);
+}
+
+interface OrderRow { id: string; account: string; order_date_kpi: string | null; created_at: string; status: string }
+interface ItemRow { omie_codigo_produto: number | null; quantity: number; unit_price: number; sales_order_id: string }
+interface ProdRow { omie_codigo_produto: number; descricao: string; ativo: boolean }
+interface ProfileRow { name: string | null; razao_social: string | null }
+
+export interface PropostaPreview {
+  proposta: PropostaFormatada;
+  account: string | null;
+  totalPedidos: number;
+  removidosInativos: number;
+  statusesVistos: string[];     // ajuda o founder a definir a whitelist real
+  nomeCliente: string | null;
+  semHistorico: boolean;
+}
+
+export function usePropostaPreview(customerUserId: string | undefined, opts?: { enabled?: boolean }) {
+  return useQuery<PropostaPreview>({
+    queryKey: ['proposta-preview', customerUserId],
+    enabled: (opts?.enabled ?? true) && !!customerUserId,
+    staleTime: 60_000,
+    queryFn: async () => {
+      const hoje = hojeIso();
+      const desde = addDays(hoje, -JANELA_FETCH_DIAS);
+
+      // 1) pedidos recentes do cliente (data canônica + account + status)
+      const { data: ordersData, error: oErr } = await supabase
+        .from('sales_orders')
+        .select('id, account, order_date_kpi, created_at, status')
+        .eq('customer_user_id', customerUserId!)
+        .gte('created_at', desde);
+      if (oErr) throw oErr;
+      const orders = (ordersData ?? []) as OrderRow[];
+
+      const vazio = (): PropostaPreview => ({
+        proposta: { texto: '', itensPrincipais: 0, vazia: true },
+        account: null, totalPedidos: 0, removidosInativos: 0, statusesVistos: [], nomeCliente: null, semHistorico: true,
+      });
+      if (orders.length === 0) return vazio();
+
+      // account predominante + status vistos
+      const porAccount = new Map<string, number>();
+      const statusSet = new Set<string>();
+      for (const o of orders) {
+        porAccount.set(o.account, (porAccount.get(o.account) ?? 0) + 1);
+        if (o.status) statusSet.add(o.status);
+      }
+      const account = [...porAccount.entries()].sort((a, b) => b[1] - a[1])[0][0];
+      const statusesVistos = [...statusSet].sort();
+      const statusValidos = statusesVistos.filter(s => !STATUS_CANCELAMENTO.has(s.toUpperCase()));
+      const orderById = new Map(orders.map(o => [o.id, o]));
+
+      // 2) itens dos pedidos do cliente
+      const { data: itemsData, error: iErr } = await supabase
+        .from('order_items')
+        .select('omie_codigo_produto, quantity, unit_price, sales_order_id')
+        .eq('customer_user_id', customerUserId!);
+      if (iErr) throw iErr;
+
+      const lines: PedidoLine[] = [];
+      for (const it of (itemsData ?? []) as ItemRow[]) {
+        const ord = orderById.get(it.sales_order_id);
+        if (!ord || it.omie_codigo_produto == null) continue;
+        lines.push({
+          omie_codigo_produto: it.omie_codigo_produto,
+          quantity: it.quantity,
+          unit_price: it.unit_price,
+          order_date: (ord.order_date_kpi ?? ord.created_at).slice(0, 10),
+          account: ord.account,
+          status: ord.status,
+        });
+      }
+
+      // 3) cesta
+      const cesta = montarCestaRecompra(lines, { account, hoje, statusValidos });
+      const skus = [...new Set([...cesta.principal, ...cesta.secundarios].map(i => i.omie_codigo_produto))];
+
+      // 4) nomes + ativos (omie_products, dado sincronizado)
+      const nomesPorSku: Record<number, string> = {};
+      const ativos = new Set<number>();
+      if (skus.length > 0) {
+        const { data: prodData } = await supabase
+          .from('omie_products')
+          .select('omie_codigo_produto, descricao, ativo')
+          .eq('account', account)
+          .in('omie_codigo_produto', skus);
+        for (const p of (prodData ?? []) as ProdRow[]) {
+          nomesPorSku[p.omie_codigo_produto] = p.descricao;
+          if (p.ativo) ativos.add(p.omie_codigo_produto);
+        }
+      }
+      const { cesta: cestaFiltrada, removidos } = filtrarCestaPorAtivos(cesta, ativos);
+
+      // 5) nome do cliente + formata
+      const { data: prof } = await supabase
+        .from('profiles').select('name, razao_social').eq('user_id', customerUserId!).maybeSingle();
+      const p = (prof ?? null) as ProfileRow | null;
+      const nomeCliente = p?.razao_social || p?.name || null;
+      const primeiroNome = nomeCliente ? nomeCliente.split(' ')[0] : undefined;
+
+      const proposta = formatarPropostaRecompra(cestaFiltrada, { nomesPorSku, primeiroNome });
+
+      return {
+        proposta, account, totalPedidos: cesta.totalPedidos, removidosInativos: removidos,
+        statusesVistos, nomeCliente, semHistorico: false,
+      };
+    },
+  });
+}


### PR DESCRIPTION
## O que é

**Preview da proposta accept-a-proposal** — tela `/rota/propostas` (master, seção Vendas) que mostra **o que a IA proporia pra cada cliente real** da fila de WhatsApp da rota de amanhã, **gerado do histórico** (`order_items` × `sales_orders` × `omie_products`). **100% phone-free** (lê dado Omie já sincronizado) — o envio é que precisa do 360dialog (PR2b-send).

**Por que importa:** valida o motor inteiro (lista→cesta→texto) contra a **realidade** + deixa o founder **ajustar copy/cesta e ver problemas de dado ANTES do telefone chegar**. De-risca o lançamento.

## Como funciona
- Lista a `whatsappQueue` (de `useRouteContactList`); cada cliente expande sob-demanda → gera o preview.
- `usePropostaPreview(customerUserId)`: busca pedidos recentes (365d) + itens → infere **account predominante** → `montarCestaRecompra` → busca **nomes + flag `ativo`** do `omie_products` → **filtra SKU inativo** (`filtrarCestaPorAtivos`, codex P1: não propor SKU morto) → `formatarPropostaRecompra`.
- Mostra: o **texto da proposta**, nº de itens, **SKUs inativos ocultados**, conta, totalPedidos, e os **status vistos no histórico** (ajuda o founder a definir a whitelist real — homework de lançamento).

## Premissas rotuladas (preview, não produção)
- **Account** = o predominante nos pedidos do cliente (inferido, não chutado).
- **Status**: permissivo no preview (exclui só cancelamento óbvio: CANCELADO/EXCLUIDO/…); a whitelist EXATA é decisão do founder no lançamento — e o preview **mostra os status reais** pra isso.
- **Preço firme** NÃO entra (regra "a IA nunca inventa preço" — vem do Omie no envio).

## Verificação
- ✅ Helper puro `filtrarCestaPorAtivos` (4 testes TDD). typecheck OK; suíte+build no CI (auto-merge só funde no verde).
- ✅ Reads tipados (sem `any`, sem `.or()`). Self-gated master + RLS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
