### PR TITLE
fix(telefonia): ownership por instância no WebRTCDialer (sessão global vazava em listas)

### DIFF
--- a/src/components/call/WebRTCDialer.tsx
+++ b/src/components/call/WebRTCDialer.tsx
@@ -1,30 +1,48 @@
-import { useWebRTCCall } from '@/hooks/useWebRTCCall';
+import { useId } from 'react';
+import { useWebRTCCallContextOptional } from '@/contexts/WebRTCCallContext';
 import { CallDialerView, type CallDialerViewProps } from './CallDialerView';
 
 type Props = Pick<CallDialerViewProps, 'phoneNumber' | 'customerName' | 'onCallEnd' | 'compact' | 'floating'>;
 
+/**
+ * Dialer WebRTC in-app. A sessão WebRTC é ÚNICA/global (WebRTCCallContext), então
+ * em telas com VÁRIOS dialers (listas: agenda, carteira) só o dialer que INICIOU a
+ * chamada (owner, via claimCall) reflete o estado ativo; os demais ficam idle.
+ * Sem isso, todos mostrariam o card ativo e disparariam onCallEnd → a chamada seria
+ * registrada/preenchida na linha errada (ou em várias).
+ *
+ * Usa o contexto OPCIONAL: se o provider ainda não montou (cold load), degrada pro
+ * botão idle em vez de lançar (não derruba a árvore).
+ */
 export function WebRTCDialer(props: Props) {
-  const call = useWebRTCCall();
+  const id = useId();
+  const ctx = useWebRTCCallContextOptional();
+  // `owned` = este dialer é o dono da chamada atual (e o contexto existe).
+  const owned = ctx && ctx.callOwnerId === id ? ctx : null;
 
   return (
     <CallDialerView
       {...props}
-      callState={call.callState}
-      callDuration={call.callDuration}
-      audioLink={call.audioLink}
-      error={call.error}
-      isActive={call.isActive}
-      isConnecting={call.isConnecting}
-      isRinging={call.isRinging}
-      isEstablished={call.isEstablished}
-      isFinished={call.isFinished}
-      onMakeCall={call.makeCall}
-      onEndCall={call.endCall}
-      remoteStream={call.remoteStream}
-      isMuted={call.isMuted}
-      onToggleMute={call.toggleMute}
-      prerollPlaying={call.prerollPlaying}
-      prerollEndsAt={call.prerollEndsAt}
+      callState={owned ? owned.callState : 'idle'}
+      callDuration={owned ? owned.callDuration : 0}
+      audioLink={owned ? owned.audioLink : null}
+      error={owned ? owned.error : null}
+      isActive={!!owned && owned.isActive}
+      isConnecting={!!owned && owned.isConnecting}
+      isRinging={!!owned && owned.isRinging}
+      isEstablished={!!owned && owned.isEstablished}
+      isFinished={!!owned && owned.isFinished}
+      onMakeCall={() => {
+        if (!ctx) return;
+        ctx.claimCall(id);
+        void ctx.makeCall(props.phoneNumber);
+      }}
+      onEndCall={() => { void ctx?.endCall(); }}
+      remoteStream={owned ? owned.remoteStream : null}
+      isMuted={!!owned && owned.isMuted}
+      onToggleMute={() => ctx?.toggleMute()}
+      prerollPlaying={!!owned && owned.prerollPlaying}
+      prerollEndsAt={owned ? owned.prerollEndsAt : null}
       backendLabel="WebRTC"
     />
   );

--- a/src/components/call/__tests__/WebRTCDialer.test.tsx
+++ b/src/components/call/__tests__/WebRTCDialer.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+// Contexto WebRTC controlável. callOwnerId NÃO bate com o useId interno do dialer,
+// então o dialer renderizado é sempre um NÃO-dono — mesmo com chamada global ativa.
+const claimCall = vi.fn();
+const makeCall = vi.fn();
+const ctx = {
+  callState: 'established',
+  callDuration: 42,
+  audioLink: null,
+  error: null,
+  isActive: true,
+  isConnecting: false,
+  isRinging: false,
+  isEstablished: true,
+  isFinished: true,
+  remoteStream: null,
+  isMuted: false,
+  prerollPlaying: true,
+  prerollEndsAt: 123,
+  callOwnerId: 'outro-dialer',
+  claimCall,
+  makeCall,
+  endCall: vi.fn(),
+  toggleMute: vi.fn(),
+};
+
+vi.mock('@/contexts/WebRTCCallContext', () => ({
+  useWebRTCCallContextOptional: () => ctx,
+}));
+
+// Stub do CallDialerView expondo as props que importam pro ownership.
+vi.mock('../CallDialerView', () => ({
+  CallDialerView: (p: {
+    callState: string;
+    isActive: boolean;
+    isFinished: boolean;
+    onMakeCall: () => void;
+  }) => (
+    <div
+      data-testid="cdv"
+      data-callstate={p.callState}
+      data-isactive={String(p.isActive)}
+      data-isfinished={String(p.isFinished)}
+    >
+      <button onClick={p.onMakeCall}>ligar</button>
+    </div>
+  ),
+}));
+
+import { WebRTCDialer } from '../WebRTCDialer';
+
+describe('WebRTCDialer — ownership por instância (sessão WebRTC é global)', () => {
+  beforeEach(() => {
+    claimCall.mockClear();
+    makeCall.mockClear();
+  });
+
+  it('NÃO-dono fica idle mesmo com chamada global ativa (não vaza card nem onCallEnd)', () => {
+    render(<WebRTCDialer phoneNumber="37999990000" customerName="Cliente A" />);
+    const cdv = screen.getByTestId('cdv');
+    // Apesar do contexto estar 'established'/isFinished, este dialer (não-dono) recebe idle.
+    expect(cdv.getAttribute('data-callstate')).toBe('idle');
+    expect(cdv.getAttribute('data-isactive')).toBe('false');
+    expect(cdv.getAttribute('data-isfinished')).toBe('false');
+  });
+
+  it('clicar Ligar reivindica ownership e disca o telefone da própria linha', () => {
+    render(<WebRTCDialer phoneNumber="37999990000" customerName="Cliente A" />);
+    fireEvent.click(screen.getByText('ligar'));
+    expect(claimCall).toHaveBeenCalledTimes(1);
+    expect(makeCall).toHaveBeenCalledWith('37999990000');
+  });
+});

--- a/src/contexts/WebRTCCallContext.tsx
+++ b/src/contexts/WebRTCCallContext.tsx
@@ -39,6 +39,12 @@ export interface WebRTCCallContextValue {
   audioLink: string | null;
   makeCall: (phoneNumber: string, opts?: { forceRecord?: boolean }) => Promise<void>;
   endCall: () => Promise<void>;
+  /** Ownership de UI: id do <WebRTCDialer> que iniciou a chamada atual (via claimCall).
+   *  Em telas com VÁRIOS dialers (listas), só o dono reflete o estado ativo — os
+   *  demais ficam idle. Sem isso, todos mostrariam o card e disparariam onCallEnd
+   *  (a sessão WebRTC é única/global), registrando a chamada na linha errada. */
+  callOwnerId: string | null;
+  claimCall: (ownerId: string) => void;
   isActive: boolean;
   isConnecting: boolean;
   isRinging: boolean;
@@ -128,6 +134,8 @@ export function WebRTCCallProvider({ children }: ProviderProps) {
   const [prerollPlaying, setPrerollPlaying] = useState(false);
   const [prerollEndsAt, setPrerollEndsAt] = useState<number | null>(null);
   const [vendorMicStream, setVendorMicStream] = useState<MediaStream | null>(null);
+  // Ownership de UI: qual <WebRTCDialer> iniciou a chamada atual (ver type).
+  const [callOwnerId, setCallOwnerId] = useState<string | null>(null);
   // PR-INBOUND-CALLS
   const [incomingCall, setIncomingCall] = useState<IncomingCallInfo | null>(null);
 
@@ -524,6 +532,14 @@ export function WebRTCCallProvider({ children }: ProviderProps) {
     turnsRef.current = transcription.turns;
   }, [transcription.turns]);
 
+  // Ownership: o <WebRTCDialer> que vai discar se declara dono ANTES do makeCall.
+  const claimCall = useCallback((ownerId: string) => setCallOwnerId(ownerId), []);
+
+  // Libera o dono quando a chamada volta a idle (a próxima chamada re-reivindica).
+  useEffect(() => {
+    if (callState === 'idle') setCallOwnerId(null);
+  }, [callState]);
+
   const value: WebRTCCallContextValue = {
     callState,
     callId: null,
@@ -531,6 +547,8 @@ export function WebRTCCallProvider({ children }: ProviderProps) {
     audioLink: null,
     makeCall,
     endCall,
+    callOwnerId,
+    claimCall,
     isActive, isConnecting, isRinging, isEstablished, isFinished,
     error,
     localStream,


### PR DESCRIPTION
## Follow-up do #536 (achado P1 na revisão do codex)
A sessão WebRTC é **única/global** (`WebRTCCallContext`). Ao tornar o WebRTC o backend padrão (#536), um bug latente virou regressão: em telas com **vários `<Dialer>`** (`AgendaQueueCard`, listas da carteira/`FarmerDashboard`), quando UMA chamada fica ativa, **todos** os dialers da tela passavam a mostrar o card ativo e, ao encerrar, **cada um disparava o seu `onCallEnd`** → chamada registrada/preenchida na **linha errada (ou em várias)**. No caminho antigo (Nvoip, estado por-instância) isso não acontecia.

## Correção — ownership por instância
- **`WebRTCCallContext`**: novo `callOwnerId` + `claimCall(ownerId)`. O dialer se declara dono **antes** do `makeCall`; o dono é liberado quando a chamada volta a `idle`.
- **`WebRTCDialer`**: usa `useId()`; **só o dono** reflete o estado ativo — os não-donos ficam `idle` (não vazam card, não disparam `onCallEnd`). Passou a usar o **contexto opcional** → degrada pro botão idle em vez de **lançar** se o provider ainda está carregando no cold load (resolve o P2 do review).
- **Teste novo** (`WebRTCDialer.test.tsx`): não-dono fica `idle` mesmo com chamada global ativa; clicar reivindica ownership + disca o telefone da própria linha.

## Verificação local
typecheck `tsconfig.app.json` **0 erros** · lint **0 erros** · testes de chamada **18/18** (novo WebRTCDialer + Dialer + CallButton + useCallBackend + WebRTCCallContext + AgendaQueueCard).

## ⚠️ Republicação
Republicar o app **só depois deste PR mergear** (junto com o #536) — assim a regressão de multi-dialer não chega aos vendedores.

## Sem migration — frontend only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)