### PR TITLE
fix(telefonia): bloqueia iniciar chamada de outra linha enquanto há uma ativa

### DIFF
--- a/src/components/call/WebRTCDialer.tsx
+++ b/src/components/call/WebRTCDialer.tsx
@@ -1,4 +1,5 @@
 import { useId } from 'react';
+import { toast } from 'sonner';
 import { useWebRTCCallContextOptional } from '@/contexts/WebRTCCallContext';
 import { CallDialerView, type CallDialerViewProps } from './CallDialerView';
 
@@ -19,6 +20,8 @@ export function WebRTCDialer(props: Props) {
   const ctx = useWebRTCCallContextOptional();
   // `owned` = este dialer é o dono da chamada atual (e o contexto existe).
   const owned = ctx && ctx.callOwnerId === id ? ctx : null;
+  // Sessão WebRTC é única: há uma chamada em curso (de qualquer linha)?
+  const busy = !!ctx && (ctx.isActive || ctx.isConnecting || ctx.isRinging || ctx.isEstablished);
 
   return (
     <CallDialerView
@@ -34,6 +37,12 @@ export function WebRTCDialer(props: Props) {
       isFinished={!!owned && owned.isFinished}
       onMakeCall={() => {
         if (!ctx) return;
+        // Não rouba uma chamada ativa de OUTRA linha (a sessão é única). Sem isso,
+        // clicar outra linha transferia o card e tentava uma 2ª chamada concorrente.
+        if (busy && !owned) {
+          toast.info('Já existe uma chamada em andamento');
+          return;
+        }
         ctx.claimCall(id);
         void ctx.makeCall(props.phoneNumber);
       }}

--- a/src/components/call/__tests__/WebRTCDialer.test.tsx
+++ b/src/components/call/__tests__/WebRTCDialer.test.tsx
@@ -1,34 +1,18 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 
-// Contexto WebRTC controlável. callOwnerId NÃO bate com o useId interno do dialer,
-// então o dialer renderizado é sempre um NÃO-dono — mesmo com chamada global ativa.
 const claimCall = vi.fn();
 const makeCall = vi.fn();
-const ctx = {
-  callState: 'established',
-  callDuration: 42,
-  audioLink: null,
-  error: null,
-  isActive: true,
-  isConnecting: false,
-  isRinging: false,
-  isEstablished: true,
-  isFinished: true,
-  remoteStream: null,
-  isMuted: false,
-  prerollPlaying: true,
-  prerollEndsAt: 123,
-  callOwnerId: 'outro-dialer',
-  claimCall,
-  makeCall,
-  endCall: vi.fn(),
-  toggleMute: vi.fn(),
-};
+
+// Holder mutável acessível pelo factory do mock (hoisted), pra variar o estado do
+// contexto (ocioso × ocupado) entre os testes.
+const h = vi.hoisted(() => ({ ctx: null as unknown }));
 
 vi.mock('@/contexts/WebRTCCallContext', () => ({
-  useWebRTCCallContextOptional: () => ctx,
+  useWebRTCCallContextOptional: () => h.ctx,
 }));
+
+vi.mock('sonner', () => ({ toast: { info: vi.fn(), success: vi.fn(), error: vi.fn() } }));
 
 // Stub do CallDialerView expondo as props que importam pro ownership.
 vi.mock('../CallDialerView', () => ({
@@ -51,6 +35,30 @@ vi.mock('../CallDialerView', () => ({
 
 import { WebRTCDialer } from '../WebRTCDialer';
 
+function makeCtx(over: Record<string, unknown> = {}) {
+  return {
+    callState: 'idle',
+    callDuration: 0,
+    audioLink: null,
+    error: null,
+    isActive: false,
+    isConnecting: false,
+    isRinging: false,
+    isEstablished: false,
+    isFinished: false,
+    remoteStream: null,
+    isMuted: false,
+    prerollPlaying: false,
+    prerollEndsAt: null,
+    callOwnerId: null,
+    claimCall,
+    makeCall,
+    endCall: vi.fn(),
+    toggleMute: vi.fn(),
+    ...over,
+  };
+}
+
 describe('WebRTCDialer — ownership por instância (sessão WebRTC é global)', () => {
   beforeEach(() => {
     claimCall.mockClear();
@@ -58,18 +66,27 @@ describe('WebRTCDialer — ownership por instância (sessão WebRTC é global)',
   });
 
   it('NÃO-dono fica idle mesmo com chamada global ativa (não vaza card nem onCallEnd)', () => {
+    h.ctx = makeCtx({ callState: 'established', isActive: true, isEstablished: true, isFinished: true, callOwnerId: 'outro-dialer' });
     render(<WebRTCDialer phoneNumber="37999990000" customerName="Cliente A" />);
     const cdv = screen.getByTestId('cdv');
-    // Apesar do contexto estar 'established'/isFinished, este dialer (não-dono) recebe idle.
     expect(cdv.getAttribute('data-callstate')).toBe('idle');
     expect(cdv.getAttribute('data-isactive')).toBe('false');
     expect(cdv.getAttribute('data-isfinished')).toBe('false');
   });
 
-  it('clicar Ligar reivindica ownership e disca o telefone da própria linha', () => {
+  it('clicar Ligar com a sessão OCIOSA reivindica ownership e disca a própria linha', () => {
+    h.ctx = makeCtx();
     render(<WebRTCDialer phoneNumber="37999990000" customerName="Cliente A" />);
     fireEvent.click(screen.getByText('ligar'));
     expect(claimCall).toHaveBeenCalledTimes(1);
     expect(makeCall).toHaveBeenCalledWith('37999990000');
+  });
+
+  it('clicar Ligar com OUTRA chamada ativa NÃO rouba a sessão (não reivindica nem disca)', () => {
+    h.ctx = makeCtx({ callState: 'established', isActive: true, isEstablished: true, callOwnerId: 'outro-dialer' });
+    render(<WebRTCDialer phoneNumber="37999990000" customerName="Cliente A" />);
+    fireEvent.click(screen.getByText('ligar'));
+    expect(claimCall).not.toHaveBeenCalled();
+    expect(makeCall).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Follow-up do #541 (2º achado do codex re-review)
Com WebRTC (sessão **única/global**), o #541 fez os não-donos ficarem `idle` — mas o botão "Ligar" deles seguia **clicável** durante uma chamada ativa. Clicar outra linha reivindicava ownership e tentava uma **2ª chamada concorrente** (nem `makeCall` nem `SipClient.makeCall` guardam sessão ocupada) → card transferido pra linha errada + chamada conflitante.

## Correção
`WebRTCDialer.onMakeCall` agora bloqueia (toast "Já existe uma chamada em andamento") quando o contexto está **ocupado** (`isActive || isConnecting || isRinging || isEstablished`) e este dialer **não é o dono**. Contido ao WebRTCDialer (não mexe no `makeCall` do contexto, que a Central já gateia por conta própria).

+ teste: clicar com outra chamada ativa **não** reivindica ownership nem disca.

## Nota (#2 do review, benigno — não corrigido aqui)
O dono não é liberado em estados terminais (só em `idle`), mas o próximo `claimCall` sobrescreve o dono velho → não é o bug de `onCallEnd` na linha errada; só um card "encerrada" que persiste na linha até a próxima chamada. Auto-cura.

## Verificação
typecheck `tsconfig.app.json` **0 erros** · lint **0 erros** · WebRTCDialer **3/3**.

## Republicação
Junto com #536 + #541. Frontend only, sem migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)