### PR TITLE
feat(rota): camada de cross-sell na proposta accept-a-proposal (+ticket)

### DIFF
--- a/src/lib/whatsapp/cross-sell.test.ts
+++ b/src/lib/whatsapp/cross-sell.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { selecionarCrossSell } from './cross-sell';
+import type { CrossSellCand } from './cross-sell';
+
+function c(sku: number, lie: number | null, nome = `P${sku}`): CrossSellCand {
+  return { omie_codigo_produto: sku, nome, lie };
+}
+
+describe('selecionarCrossSell', () => {
+  it('exclui SKUs que já estão na cesta (não cross-sell do que já compra/recebe)', () => {
+    const r = selecionarCrossSell(new Set([100, 200]), [c(100, 50), c(300, 40), c(200, 30)], 5);
+    expect(r.map(x => x.omie_codigo_produto)).toEqual([300]);
+  });
+  it('ordena por lie (lucro incremental esperado) desc; null por último', () => {
+    const r = selecionarCrossSell(new Set<number>(), [c(1, 10), c(2, null), c(3, 90), c(4, 50)], 5);
+    expect(r.map(x => x.omie_codigo_produto)).toEqual([3, 4, 1, 2]);
+  });
+  it('dedupe por SKU mantendo o de maior lie', () => {
+    const r = selecionarCrossSell(new Set<number>(), [c(7, 10), c(7, 80), c(8, 20)], 5);
+    const sevens = r.filter(x => x.omie_codigo_produto === 7);
+    expect(sevens.length).toBe(1);
+    expect(sevens[0].lie).toBe(80);
+  });
+  it('capa em n', () => {
+    const r = selecionarCrossSell(new Set<number>(), [c(1, 100), c(2, 90), c(3, 80), c(4, 70)], 2);
+    expect(r.map(x => x.omie_codigo_produto)).toEqual([1, 2]);
+  });
+  it('candidatos vazios → []', () => {
+    expect(selecionarCrossSell(new Set([1]), [], 3)).toEqual([]);
+  });
+});

--- a/src/lib/whatsapp/cross-sell.ts
+++ b/src/lib/whatsapp/cross-sell.ts
@@ -1,0 +1,25 @@
+// Seleciona itens de CROSS-SELL (complementares, NÃO recompra) pra camada "experimente também"
+// da proposta. PURO/testável. Candidatos vêm do engine de recomendação (farmer_recommendations,
+// product_id→omie_products), ranqueados por `lie` (lucro incremental esperado). Exclui o que o
+// cliente já compra/recebe (cesta). Codex adiou pro pós-piloto — degrada honesto (vazio se sem rec).
+
+export interface CrossSellCand {
+  omie_codigo_produto: number;
+  nome: string;
+  lie: number | null; // lucro incremental esperado (rank); null → por último
+}
+
+export function selecionarCrossSell(cestaSkus: Set<number>, candidatos: CrossSellCand[], n: number): CrossSellCand[] {
+  // dedupe por SKU mantendo o de maior lie; exclui o que já está na cesta
+  const melhorPorSku = new Map<number, CrossSellCand>();
+  for (const cand of candidatos) {
+    if (cestaSkus.has(cand.omie_codigo_produto)) continue;
+    const atual = melhorPorSku.get(cand.omie_codigo_produto);
+    if (!atual || (cand.lie ?? -Infinity) > (atual.lie ?? -Infinity)) {
+      melhorPorSku.set(cand.omie_codigo_produto, cand);
+    }
+  }
+  return [...melhorPorSku.values()]
+    .sort((a, b) => (b.lie ?? -Infinity) - (a.lie ?? -Infinity))
+    .slice(0, Math.max(0, n));
+}

--- a/src/lib/whatsapp/proposta-format.test.ts
+++ b/src/lib/whatsapp/proposta-format.test.ts
@@ -70,4 +70,19 @@ describe('formatarPropostaRecompra', () => {
     expect(r.texto).toContain('Posso fechar o pedido?');
     expect(r.texto).not.toContain('entrega de amanhã'); // CTA default substituído
   });
+  it('renderiza a camada de cross-sell ("experimente também") quando passada, antes do CTA', () => {
+    const r = formatarPropostaRecompra(cesta([item(100, 3)]), {
+      nomesPorSku: NOMES,
+      crossSell: [{ nome: 'Lixadeira Orbital' }, { nome: 'Máscara PFF2' }],
+    });
+    expect(r.texto).toContain('Que tal experimentar também:');
+    expect(r.texto).toContain('• Lixadeira Orbital');
+    expect(r.texto).toContain('• Máscara PFF2');
+    // cross-sell vem antes do CTA
+    expect(r.texto.indexOf('Lixadeira Orbital')).toBeLessThan(r.texto.indexOf('entrega de amanhã'));
+  });
+  it('sem cross-sell → não imprime a seção', () => {
+    const r = formatarPropostaRecompra(cesta([item(100, 3)]), { nomesPorSku: NOMES });
+    expect(r.texto).not.toContain('experimentar também');
+  });
 });

--- a/src/lib/whatsapp/proposta-format.ts
+++ b/src/lib/whatsapp/proposta-format.ts
@@ -13,6 +13,8 @@ export interface PropostaOpts {
   introSecundario?: string;
   cta?: string;
   maxSecundarios?: number; // default 3 — não inflar a mensagem (codex: cesta enxuta)
+  crossSell?: { nome: string }[];  // camada "experimente também" (complementar; codex: pós-piloto)
+  introCrossSell?: string;
 }
 export interface PropostaFormatada {
   texto: string;
@@ -46,6 +48,13 @@ export function formatarPropostaRecompra(cesta: CestaResult, opts: PropostaOpts)
   if (sec.length > 0) {
     linhas.push('', introS, ...sec.map(i => formatarLinhaItem(i, opts.nomesPorSku)));
   }
+
+  const cross = opts.crossSell ?? [];
+  if (cross.length > 0) {
+    const introX = opts.introCrossSell ?? 'Que tal experimentar também:';
+    linhas.push('', introX, ...cross.map(x => `• ${x.nome}`));
+  }
+
   linhas.push('', cta);
 
   return { texto: linhas.join('\n'), itensPrincipais: cesta.principal.length, vazia: false };

--- a/src/pages/RotaPropostas.tsx
+++ b/src/pages/RotaPropostas.tsx
@@ -38,6 +38,7 @@ function PropostaRow({ cliente }: { cliente: RouteContactItem }) {
                 <pre className="whitespace-pre-wrap text-sm bg-muted/40 rounded-md p-3 font-sans">{data.proposta.texto}</pre>
                 <div className="flex flex-wrap gap-2 mt-2 text-[11px] text-muted-foreground">
                   <Badge variant="secondary">{data.proposta.itensPrincipais} itens principais</Badge>
+                  {data.crossSellCount > 0 && <Badge variant="outline">+{data.crossSellCount} cross-sell</Badge>}
                   {data.removidosInativos > 0 && <Badge variant="outline">{data.removidosInativos} SKU inativo oculto</Badge>}
                   <span>conta: {data.account}</span>
                   <span>· {data.totalPedidos} pedidos</span>

--- a/src/queries/usePropostaPreview.ts
+++ b/src/queries/usePropostaPreview.ts
@@ -5,6 +5,8 @@ import type { PedidoLine } from '@/lib/whatsapp/cesta-recompra';
 import { filtrarCestaPorAtivos } from '@/lib/whatsapp/cesta-ativos';
 import { formatarPropostaRecompra } from '@/lib/whatsapp/proposta-format';
 import type { PropostaFormatada } from '@/lib/whatsapp/proposta-format';
+import { selecionarCrossSell } from '@/lib/whatsapp/cross-sell';
+import type { CrossSellCand } from '@/lib/whatsapp/cross-sell';
 
 // Status do Omie que NUNCA contam como compra válida (cancelamento/exclusão). Tudo o mais é
 // permissivo no PREVIEW — a whitelist EXATA é decisão do founder no lançamento (surfaçamos os vistos).
@@ -19,13 +21,18 @@ function addDays(iso: string, n: number): string {
 interface OrderRow { id: string; account: string; order_date_kpi: string | null; created_at: string; status: string }
 interface ItemRow { omie_codigo_produto: number | null; quantity: number; unit_price: number; sales_order_id: string }
 interface ProdRow { omie_codigo_produto: number; descricao: string; ativo: boolean }
+interface ProdByIdRow { id: string; omie_codigo_produto: number; descricao: string; ativo: boolean }
+interface RecRow { product_id: string | null; lie: number | null; status: string | null }
 interface ProfileRow { name: string | null; razao_social: string | null }
+
+const MAX_CROSS_SELL = 2;
 
 export interface PropostaPreview {
   proposta: PropostaFormatada;
   account: string | null;
   totalPedidos: number;
   removidosInativos: number;
+  crossSellCount: number;
   statusesVistos: string[];     // ajuda o founder a definir a whitelist real
   nomeCliente: string | null;
   semHistorico: boolean;
@@ -51,7 +58,7 @@ export function usePropostaPreview(customerUserId: string | undefined, opts?: { 
 
       const vazio = (): PropostaPreview => ({
         proposta: { texto: '', itensPrincipais: 0, vazia: true },
-        account: null, totalPedidos: 0, removidosInativos: 0, statusesVistos: [], nomeCliente: null, semHistorico: true,
+        account: null, totalPedidos: 0, removidosInativos: 0, crossSellCount: 0, statusesVistos: [], nomeCliente: null, semHistorico: true,
       });
       if (orders.length === 0) return vazio();
 
@@ -108,6 +115,33 @@ export function usePropostaPreview(customerUserId: string | undefined, opts?: { 
       }
       const { cesta: cestaFiltrada, removidos } = filtrarCestaPorAtivos(cesta, ativos);
 
+      // 4b) cross-sell ("experimente também") — farmer_recommendations → omie_products por id.
+      // Só faz sentido com cesta-base; codex adiou pro pós-piloto → degrada honesto (vazio sem rec).
+      let crossSell: { nome: string }[] = [];
+      if (cestaFiltrada.principal.length > 0) {
+        const cestaSkus = new Set([...cestaFiltrada.principal, ...cestaFiltrada.secundarios].map(i => i.omie_codigo_produto));
+        const { data: recData } = await supabase
+          .from('farmer_recommendations')
+          .select('product_id, lie, status')
+          .eq('customer_user_id', customerUserId!);
+        const recs = ((recData ?? []) as RecRow[]).filter(r => r.product_id && r.status !== 'rejected');
+        if (recs.length > 0) {
+          const recIds = [...new Set(recs.map(r => r.product_id as string))];
+          const { data: prodById } = await supabase
+            .from('omie_products')
+            .select('id, omie_codigo_produto, descricao, ativo')
+            .eq('account', account)
+            .in('id', recIds);
+          const byId = new Map(((prodById ?? []) as ProdByIdRow[]).map(p => [p.id, p]));
+          const candidatos: CrossSellCand[] = [];
+          for (const r of recs) {
+            const prod = byId.get(r.product_id as string);
+            if (prod && prod.ativo) candidatos.push({ omie_codigo_produto: prod.omie_codigo_produto, nome: prod.descricao, lie: r.lie });
+          }
+          crossSell = selecionarCrossSell(cestaSkus, candidatos, MAX_CROSS_SELL).map(x => ({ nome: x.nome }));
+        }
+      }
+
       // 5) nome do cliente + formata
       const { data: prof } = await supabase
         .from('profiles').select('name, razao_social').eq('user_id', customerUserId!).maybeSingle();
@@ -115,11 +149,11 @@ export function usePropostaPreview(customerUserId: string | undefined, opts?: { 
       const nomeCliente = p?.razao_social || p?.name || null;
       const primeiroNome = nomeCliente ? nomeCliente.split(' ')[0] : undefined;
 
-      const proposta = formatarPropostaRecompra(cestaFiltrada, { nomesPorSku, primeiroNome });
+      const proposta = formatarPropostaRecompra(cestaFiltrada, { nomesPorSku, primeiroNome, crossSell });
 
       return {
         proposta, account, totalPedidos: cesta.totalPedidos, removidosInativos: removidos,
-        statusesVistos, nomeCliente, semHistorico: false,
+        crossSellCount: crossSell.length, statusesVistos, nomeCliente, semHistorico: false,
       };
     },
   });


### PR DESCRIPTION
## O que é

Camada de **cross-sell ("experimente também")** na proposta accept-a-proposal — sugere 1-2 itens **complementares** (que o cliente NÃO costuma comprar) além da cesta de recompra, pra puxar **+ticket**. Reusa o engine existente (`farmer_recommendations`, market-basket via `association_rules`). **Frontend-only, phone-free** (lê dado sincronizado).

⚠️ **Ressalva honesta:** o codex **adiou** o cross-sell pro **pós-piloto** (validar a recompra-base antes, risco de a proposta parecer "empurra-empurra"). Construído por escolha do founder, com **degradação honesta** (seção só aparece se houver recomendação; vazia se o engine não rodou) — e o **preview** deixa o founder VER se ficou pesado e dosar (`MAX_CROSS_SELL=2`).

## Como funciona
- Helper puro **`selecionarCrossSell`** (`cross-sell.ts`, 5 testes TDD): exclui SKUs já na cesta, dedupe, ranqueia por **`lie`** (lucro incremental esperado), capa em N.
- `formatarPropostaRecompra` ganha seção opcional **"Que tal experimentar também:"** (antes do CTA; +2 testes) — parametrizável.
- `usePropostaPreview` busca `farmer_recommendations` do cliente → mapeia `product_id` → `omie_products` (id→omie+descrição+ativo) → filtra ativo + não-na-cesta → `selecionarCrossSell` → passa pro formatter. Preview mostra badge "+N cross-sell".

## Verificação
- ✅ helpers 115/115 (bun) — cross-sell 5 + formatter cross-sell 2. typecheck OK; suíte+build no CI (auto-merge só funde no verde).
- ✅ Sem `any`, sem `.or()`. Preço firme nunca na msg (regra Omie). Degrada honesto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
