### PR TITLE
test(rota): launch-readiness drill — composição testada + gate de envio (codex)

### DIFF
--- a/docs/superpowers/plans/2026-05-31-whatsapp-pr2b-send-blueprint.md
+++ b/docs/superpowers/plans/2026-05-31-whatsapp-pr2b-send-blueprint.md
@@ -36,6 +36,19 @@ cron D-1 de manhã (após disparo_inicio) →
 
 **Idempotência:** `route_contact_log` (data_rota, customer_user_id, canal) evita disparo duplo no mesmo dia/rota.
 
+## 2b. ⛔ GATE DE ENVIO — revalidação no último segundo (codex, launch-readiness, P1)
+
+> O preview gera a proposta de **dados sincronizados** (que podem estar velhos no momento do disparo). **Antes de CADA envio**, o edge `route-disparo` DEVE revalidar — **se qualquer item falhar, NÃO envia** (melhor perder um envio do que mandar proposta errada / queimar confiança):
+
+1. **opt-in vigente** — `whatsapp_conversations.opt_in_status != 'opt_out'` (re-leitura; opt-out pode ter chegado depois da geração).
+2. **cliente ainda elegível** na rota — `customer_user_id` ainda na `whatsappQueue` da rota de **amanhã** (re-resolver D-1 na hora; rota/feriado/cidade podem ter mudado).
+3. **não comprou desde a geração** — sem pedido novo do cliente entre a geração e o disparo (senão a cesta está obsoleta / vira spam).
+4. **SKU ainda ativo** — re-check `omie_products.ativo` (item pode ter sido descontinuado).
+5. **preço firme disponível** — preço atual do Omie existe pra TODO item da cesta; sem preço → tira o item (ou não envia se esvaziar). **Preço vem do Omie no envio — nunca do preview.**
+6. **status/janela** — janela 24h / `disparo_inicio`–`disparo_corte` ainda válidos; teto do tier Meta não estourado (`selectDisparoBatch` no momento do envio, não na geração).
+
+**Regra de ouro:** a proposta do preview é **rascunho**; a verdade é revalidada no envio. Tudo o que falhar → pula o cliente e loga o motivo em `route_contact_log` (status='pulado_revalidacao', motivo).
+
 ## 3. O que falta CODAR no phone-day (rápido, sobre o que já existe)
 
 - **Edge `route-disparo`** (ou estende `whatsapp-send`): o orquestrador §2. Espelha `selectDisparoBatch` (já testado) inline (Deno).

--- a/src/lib/whatsapp/proposta-preview-core.test.ts
+++ b/src/lib/whatsapp/proposta-preview-core.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { assembleLinesEContexto, buildCrossSellCandidatos } from './proposta-preview-core';
+import type { PreviewOrder, PreviewItem, PreviewRec, PreviewProdById } from './proposta-preview-core';
+
+const CANCEL = new Set(['CANCELADO', 'EXCLUIDO']);
+function ord(id: string, account: string, status: string, over: Partial<PreviewOrder> = {}): PreviewOrder {
+  return { id, account, status, order_date_kpi: '2026-03-01', created_at: '2026-03-01T10:00:00Z', ...over };
+}
+function it_(sku: number | null, sales_order_id: string, qty = 2): PreviewItem {
+  return { omie_codigo_produto: sku, quantity: qty, unit_price: 10, sales_order_id };
+}
+
+describe('assembleLinesEContexto (codex Risco 2: join/account/status)', () => {
+  it('infere account predominante (mais pedidos); tie-break determinístico por nome', () => {
+    const r = assembleLinesEContexto(
+      [ord('1', 'oben', 'FAT'), ord('2', 'oben', 'FAT'), ord('3', 'colacor', 'FAT')],
+      [it_(100, '1'), it_(100, '2'), it_(200, '3')], CANCEL);
+    expect(r.account).toBe('oben');
+  });
+  it('order_date usa order_date_kpi; cai pro created_at quando kpi null', () => {
+    const r = assembleLinesEContexto(
+      [ord('1', 'oben', 'FAT', { order_date_kpi: '2026-02-10' }), ord('2', 'oben', 'FAT', { order_date_kpi: null, created_at: '2026-01-05T08:00:00Z' })],
+      [it_(100, '1'), it_(100, '2')], CANCEL);
+    expect(r.lines.find(l => l.order_date === '2026-02-10')).toBeTruthy();
+    expect(r.lines.find(l => l.order_date === '2026-01-05')).toBeTruthy(); // fallback created_at
+  });
+  it('item com sales_order_id órfão (sem pedido) é descartado', () => {
+    const r = assembleLinesEContexto([ord('1', 'oben', 'FAT')], [it_(100, '1'), it_(999, 'ZZZ')], CANCEL);
+    expect(r.lines.map(l => l.omie_codigo_produto)).toEqual([100]);
+  });
+  it('item com SKU null é descartado', () => {
+    const r = assembleLinesEContexto([ord('1', 'oben', 'FAT')], [it_(100, '1'), it_(null, '1')], CANCEL);
+    expect(r.lines.length).toBe(1);
+  });
+  it('statusValidos exclui cancelamento; statusesVistos mostra todos', () => {
+    const r = assembleLinesEContexto(
+      [ord('1', 'oben', 'FATURADO'), ord('2', 'oben', 'CANCELADO')],
+      [it_(100, '1'), it_(200, '2')], new Set(['CANCELADO']));
+    expect(r.statusesVistos).toEqual(['CANCELADO', 'FATURADO']);
+    expect(r.statusValidos).toEqual(['FATURADO']);
+  });
+  it('sem pedidos → vazio/null', () => {
+    const r = assembleLinesEContexto([], [], CANCEL);
+    expect(r.account).toBeNull();
+    expect(r.lines).toEqual([]);
+  });
+});
+
+describe('buildCrossSellCandidatos (codex Risco 2: rec→omie, ativo, órfão)', () => {
+  const prods: PreviewProdById[] = [
+    { id: 'uuid-a', omie_codigo_produto: 500, descricao: 'Verniz', ativo: true },
+    { id: 'uuid-b', omie_codigo_produto: 600, descricao: 'Estopa', ativo: false }, // inativo
+  ];
+  function rec(pid: string | null, lie: number | null, status: string | null = null): PreviewRec {
+    return { product_id: pid, lie, status };
+  }
+  it('mapeia product_id → omie e mantém só ativos', () => {
+    const r = buildCrossSellCandidatos([rec('uuid-a', 50), rec('uuid-b', 90)], prods);
+    expect(r.map(c => c.omie_codigo_produto)).toEqual([500]); // 600 inativo fora
+    expect(r[0].nome).toBe('Verniz');
+  });
+  it('descarta rec órfã (product_id sem produto), rejeitada e null', () => {
+    const r = buildCrossSellCandidatos(
+      [rec('uuid-x', 10), rec('uuid-a', 20, 'rejected'), rec(null, 30)], prods);
+    expect(r).toEqual([]);
+  });
+});

--- a/src/lib/whatsapp/proposta-preview-core.ts
+++ b/src/lib/whatsapp/proposta-preview-core.ts
@@ -1,0 +1,62 @@
+// Composição PURA do preview da proposta (extraída de usePropostaPreview). Isola o join order×item,
+// a inferência de account predominante e o status (codex Risco 2: helpers puros podem estar certos e
+// a COMPOSIÇÃO errar por join key/dedupe/dados sujos). Testável sem mockar Supabase.
+
+import type { PedidoLine } from './cesta-recompra';
+import type { CrossSellCand } from './cross-sell';
+
+export interface PreviewOrder { id: string; account: string; order_date_kpi: string | null; created_at: string; status: string }
+export interface PreviewItem { omie_codigo_produto: number | null; quantity: number; unit_price: number; sales_order_id: string }
+export interface PreviewRec { product_id: string | null; lie: number | null; status: string | null }
+export interface PreviewProdById { id: string; omie_codigo_produto: number; descricao: string; ativo: boolean }
+
+export interface LinesContexto {
+  lines: PedidoLine[];
+  account: string | null;
+  statusesVistos: string[];
+  statusValidos: string[];
+}
+
+/** order×item → PedidoLine[] + account predominante (tie-break determinístico) + status. */
+export function assembleLinesEContexto(orders: PreviewOrder[], items: PreviewItem[], statusCancelamento: Set<string>): LinesContexto {
+  if (orders.length === 0) return { lines: [], account: null, statusesVistos: [], statusValidos: [] };
+
+  const porAccount = new Map<string, number>();
+  const statusSet = new Set<string>();
+  for (const o of orders) {
+    porAccount.set(o.account, (porAccount.get(o.account) ?? 0) + 1);
+    if (o.status) statusSet.add(o.status);
+  }
+  // predominante: mais pedidos; empate → nome asc (determinístico)
+  const account = [...porAccount.entries()].sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))[0][0];
+  const statusesVistos = [...statusSet].sort();
+  const statusValidos = statusesVistos.filter(s => !statusCancelamento.has(s.toUpperCase()));
+
+  const orderById = new Map(orders.map(o => [o.id, o]));
+  const lines: PedidoLine[] = [];
+  for (const it of items) {
+    const ord = orderById.get(it.sales_order_id);
+    if (!ord || it.omie_codigo_produto == null) continue; // órfão ou SKU nulo → fora
+    lines.push({
+      omie_codigo_produto: it.omie_codigo_produto,
+      quantity: it.quantity,
+      unit_price: it.unit_price,
+      order_date: (ord.order_date_kpi ?? ord.created_at).slice(0, 10),
+      account: ord.account,
+      status: ord.status,
+    });
+  }
+  return { lines, account, statusesVistos, statusValidos };
+}
+
+/** farmer_recommendations × omie_products(by id) → candidatos de cross-sell (só ativos, não-rejeitados). */
+export function buildCrossSellCandidatos(recs: PreviewRec[], prodById: PreviewProdById[]): CrossSellCand[] {
+  const byId = new Map(prodById.map(p => [p.id, p]));
+  const out: CrossSellCand[] = [];
+  for (const r of recs) {
+    if (!r.product_id || r.status === 'rejected') continue;
+    const prod = byId.get(r.product_id);
+    if (prod && prod.ativo) out.push({ omie_codigo_produto: prod.omie_codigo_produto, nome: prod.descricao, lie: r.lie });
+  }
+  return out;
+}

--- a/src/queries/usePropostaPreview.ts
+++ b/src/queries/usePropostaPreview.ts
@@ -1,31 +1,26 @@
 import { useQuery } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
 import { montarCestaRecompra } from '@/lib/whatsapp/cesta-recompra';
-import type { PedidoLine } from '@/lib/whatsapp/cesta-recompra';
 import { filtrarCestaPorAtivos } from '@/lib/whatsapp/cesta-ativos';
 import { formatarPropostaRecompra } from '@/lib/whatsapp/proposta-format';
 import type { PropostaFormatada } from '@/lib/whatsapp/proposta-format';
 import { selecionarCrossSell } from '@/lib/whatsapp/cross-sell';
-import type { CrossSellCand } from '@/lib/whatsapp/cross-sell';
+import { assembleLinesEContexto, buildCrossSellCandidatos } from '@/lib/whatsapp/proposta-preview-core';
+import type { PreviewOrder, PreviewItem, PreviewRec, PreviewProdById } from '@/lib/whatsapp/proposta-preview-core';
 
-// Status do Omie que NUNCA contam como compra válida (cancelamento/exclusão). Tudo o mais é
-// permissivo no PREVIEW — a whitelist EXATA é decisão do founder no lançamento (surfaçamos os vistos).
+// Status do Omie que NUNCA contam como compra válida. Permissivo no PREVIEW — a whitelist EXATA é
+// decisão do founder no lançamento (surfaçamos os status vistos pra ele definir).
 const STATUS_CANCELAMENTO = new Set(['CANCELADO', 'CANCELADA', 'EXCLUIDO', 'EXCLUÍDO', 'CANCELED']);
 const JANELA_FETCH_DIAS = 365;
+const MAX_CROSS_SELL = 2;
 
 function hojeIso(): string { return new Date().toISOString().slice(0, 10); }
 function addDays(iso: string, n: number): string {
   const d = new Date(iso + 'T12:00:00Z'); d.setUTCDate(d.getUTCDate() + n); return d.toISOString().slice(0, 10);
 }
 
-interface OrderRow { id: string; account: string; order_date_kpi: string | null; created_at: string; status: string }
-interface ItemRow { omie_codigo_produto: number | null; quantity: number; unit_price: number; sales_order_id: string }
 interface ProdRow { omie_codigo_produto: number; descricao: string; ativo: boolean }
-interface ProdByIdRow { id: string; omie_codigo_produto: number; descricao: string; ativo: boolean }
-interface RecRow { product_id: string | null; lie: number | null; status: string | null }
 interface ProfileRow { name: string | null; razao_social: string | null }
-
-const MAX_CROSS_SELL = 2;
 
 export interface PropostaPreview {
   proposta: PropostaFormatada;
@@ -38,6 +33,11 @@ export interface PropostaPreview {
   semHistorico: boolean;
 }
 
+const VAZIO: PropostaPreview = {
+  proposta: { texto: '', itensPrincipais: 0, vazia: true },
+  account: null, totalPedidos: 0, removidosInativos: 0, crossSellCount: 0, statusesVistos: [], nomeCliente: null, semHistorico: true,
+};
+
 export function usePropostaPreview(customerUserId: string | undefined, opts?: { enabled?: boolean }) {
   return useQuery<PropostaPreview>({
     queryKey: ['proposta-preview', customerUserId],
@@ -47,59 +47,32 @@ export function usePropostaPreview(customerUserId: string | undefined, opts?: { 
       const hoje = hojeIso();
       const desde = addDays(hoje, -JANELA_FETCH_DIAS);
 
-      // 1) pedidos recentes do cliente (data canônica + account + status)
+      // 1) pedidos + itens recentes do cliente
       const { data: ordersData, error: oErr } = await supabase
         .from('sales_orders')
         .select('id, account, order_date_kpi, created_at, status')
         .eq('customer_user_id', customerUserId!)
         .gte('created_at', desde);
       if (oErr) throw oErr;
-      const orders = (ordersData ?? []) as OrderRow[];
+      const orders = (ordersData ?? []) as PreviewOrder[];
+      if (orders.length === 0) return VAZIO;
 
-      const vazio = (): PropostaPreview => ({
-        proposta: { texto: '', itensPrincipais: 0, vazia: true },
-        account: null, totalPedidos: 0, removidosInativos: 0, crossSellCount: 0, statusesVistos: [], nomeCliente: null, semHistorico: true,
-      });
-      if (orders.length === 0) return vazio();
-
-      // account predominante + status vistos
-      const porAccount = new Map<string, number>();
-      const statusSet = new Set<string>();
-      for (const o of orders) {
-        porAccount.set(o.account, (porAccount.get(o.account) ?? 0) + 1);
-        if (o.status) statusSet.add(o.status);
-      }
-      const account = [...porAccount.entries()].sort((a, b) => b[1] - a[1])[0][0];
-      const statusesVistos = [...statusSet].sort();
-      const statusValidos = statusesVistos.filter(s => !STATUS_CANCELAMENTO.has(s.toUpperCase()));
-      const orderById = new Map(orders.map(o => [o.id, o]));
-
-      // 2) itens dos pedidos do cliente
       const { data: itemsData, error: iErr } = await supabase
         .from('order_items')
         .select('omie_codigo_produto, quantity, unit_price, sales_order_id')
         .eq('customer_user_id', customerUserId!);
       if (iErr) throw iErr;
 
-      const lines: PedidoLine[] = [];
-      for (const it of (itemsData ?? []) as ItemRow[]) {
-        const ord = orderById.get(it.sales_order_id);
-        if (!ord || it.omie_codigo_produto == null) continue;
-        lines.push({
-          omie_codigo_produto: it.omie_codigo_produto,
-          quantity: it.quantity,
-          unit_price: it.unit_price,
-          order_date: (ord.order_date_kpi ?? ord.created_at).slice(0, 10),
-          account: ord.account,
-          status: ord.status,
-        });
-      }
+      // 2) composição PURA (join + account predominante + status) — testada
+      const ctx = assembleLinesEContexto(orders, (itemsData ?? []) as PreviewItem[], STATUS_CANCELAMENTO);
+      if (!ctx.account) return VAZIO;
+      const { lines, account, statusesVistos, statusValidos } = ctx;
 
-      // 3) cesta
+      // 3) cesta de recompra
       const cesta = montarCestaRecompra(lines, { account, hoje, statusValidos });
       const skus = [...new Set([...cesta.principal, ...cesta.secundarios].map(i => i.omie_codigo_produto))];
 
-      // 4) nomes + ativos (omie_products, dado sincronizado)
+      // 4) nomes + ativos (omie_products por omie_codigo_produto) → filtra SKU inativo
       const nomesPorSku: Record<number, string> = {};
       const ativos = new Set<number>();
       if (skus.length > 0) {
@@ -115,8 +88,7 @@ export function usePropostaPreview(customerUserId: string | undefined, opts?: { 
       }
       const { cesta: cestaFiltrada, removidos } = filtrarCestaPorAtivos(cesta, ativos);
 
-      // 4b) cross-sell ("experimente também") — farmer_recommendations → omie_products por id.
-      // Só faz sentido com cesta-base; codex adiou pro pós-piloto → degrada honesto (vazio sem rec).
+      // 4b) cross-sell ("experimente também") — só com cesta-base; degrada honesto (vazio sem rec)
       let crossSell: { nome: string }[] = [];
       if (cestaFiltrada.principal.length > 0) {
         const cestaSkus = new Set([...cestaFiltrada.principal, ...cestaFiltrada.secundarios].map(i => i.omie_codigo_produto));
@@ -124,20 +96,15 @@ export function usePropostaPreview(customerUserId: string | undefined, opts?: { 
           .from('farmer_recommendations')
           .select('product_id, lie, status')
           .eq('customer_user_id', customerUserId!);
-        const recs = ((recData ?? []) as RecRow[]).filter(r => r.product_id && r.status !== 'rejected');
-        if (recs.length > 0) {
-          const recIds = [...new Set(recs.map(r => r.product_id as string))];
+        const recs = (recData ?? []) as PreviewRec[];
+        const recIds = [...new Set(recs.map(r => r.product_id).filter((x): x is string => !!x))];
+        if (recIds.length > 0) {
           const { data: prodById } = await supabase
             .from('omie_products')
             .select('id, omie_codigo_produto, descricao, ativo')
             .eq('account', account)
             .in('id', recIds);
-          const byId = new Map(((prodById ?? []) as ProdByIdRow[]).map(p => [p.id, p]));
-          const candidatos: CrossSellCand[] = [];
-          for (const r of recs) {
-            const prod = byId.get(r.product_id as string);
-            if (prod && prod.ativo) candidatos.push({ omie_codigo_produto: prod.omie_codigo_produto, nome: prod.descricao, lie: r.lie });
-          }
+          const candidatos = buildCrossSellCandidatos(recs, (prodById ?? []) as PreviewProdById[]);
           crossSell = selecionarCrossSell(cestaSkus, candidatos, MAX_CROSS_SELL).map(x => ({ nome: x.nome }));
         }
       }


### PR DESCRIPTION
## O que é

**Launch-readiness drill** (decisão eu + codex — escopo fechado, sem feature nova). O codex apontou que o motor já passou do ponto em que mais lógica ajuda; o risco agora é **composição + dado real + envio**. Este PR ataca isso:

**Risco 2 (composição) — extração + testes:** a lógica de composição do `usePropostaPreview` (join order×item, account predominante, status; e o mapeamento rec→omie do cross-sell) estava **inline e não-testada**. Extraí pra funções PURAS testadas:
- **`assembleLinesEContexto`** (`proposta-preview-core.ts`): order×item → `PedidoLine[]` + account predominante (tie-break determinístico) + status. Testa casos sujos do codex: account misto, `order_date_kpi` null→`created_at`, item órfão (sem pedido), SKU null, status de cancelamento.
- **`buildCrossSellCandidatos`**: `farmer_recommendations` × `omie_products(by id)` → candidatos (só ativos, não-rejeitados, órfão fora).
- `usePropostaPreview` refatorado pra USAR as funções puras (vira fetch-then-compose; composição agora coberta). **8 testes novos.**

**Risco 1 (preview ≠ envio real) — travado no blueprint:** adicionei o **§2b GATE DE ENVIO** no blueprint do PR2b-send (#526) — antes de CADA envio o edge DEVE revalidar (opt-out recente, ainda na rota de amanhã, não comprou desde a geração, SKU ativo, **preço firme do Omie**, janela/tier). Se falhar → **não envia** (loga o motivo). Regra de ouro: a proposta do preview é **rascunho**; a verdade é revalidada no envio.

## Decisão de escopo (codex)
Corrigir só P0/P1 que afetam envio correto/confiança, e **CONGELAR** o motor até o phone-day. Não ampliar escopo. Próximo passo real é a lição de casa do founder (copy + whitelist + 360dialog).

## Verificação
- ✅ helpers 123/123 (bun) — +8 da composição. typecheck OK; suíte+build no CI.
- ✅ Sem `any`, sem `.or()`. Refactor é comportamento-preservando (hook chama as puras).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
