### PR TITLE
feat(visitas): card "Visitas de hoje" no dashboard do vendedor

### DIFF
--- a/docs/superpowers/plans/2026-05-31-lembrete-visitas-hoje.md
+++ b/docs/superpowers/plans/2026-05-31-lembrete-visitas-hoje.md
@@ -1,0 +1,349 @@
+# Lembrete "Visitas de hoje" — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Card "Visitas de hoje" no dashboard do vendedor (FarmerDashboardV2) mostrando as visitas pendentes agendadas por ele para hoje (count + até 3 nomes + CTA "Ver rota"), self-hide quando vazio.
+
+**Architecture:** Helper puro `montarVisitasHoje` (TDD) → hook `useVisitasHoje` (query `visitas_agendadas` de hoje + enriquece nomes via `profiles`) → componente `VisitasHojeCard` (self-hide) → inserção no `FarmerDashboardV2`. Read-only, sem backend. `hojeISO()` (UTC) por consistência com o route planner.
+
+**Tech Stack:** React, @tanstack/react-query, Supabase JS, react-router-dom, shadcn/ui, vitest.
+
+**Spec:** `docs/superpowers/specs/2026-05-31-lembrete-visitas-hoje-design.md`
+
+---
+
+## File Structure
+- **Create:** `src/lib/visitas/visitas-hoje.ts` + teste `src/lib/visitas/__tests__/visitas-hoje.test.ts` — helper puro `montarVisitasHoje`.
+- **Create:** `src/hooks/useVisitasHoje.ts` — hook (query hoje + nomes).
+- **Create:** `src/components/dashboard/VisitasHojeCard.tsx` — o card.
+- **Modify:** `src/components/dashboard/FarmerDashboardV2.tsx` — inserir o card após `<KpisToday />`.
+
+---
+
+## Task 1: Helper puro `montarVisitasHoje` (TDD)
+
+**Files:**
+- Create: `src/lib/visitas/visitas-hoje.ts`
+- Test: `src/lib/visitas/__tests__/visitas-hoje.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// src/lib/visitas/__tests__/visitas-hoje.test.ts
+import { describe, it, expect } from 'vitest';
+import { montarVisitasHoje } from '../visitas-hoje';
+
+const rows = [
+  { id: 'v1', customer_user_id: 'u1' },
+  { id: 'v2', customer_user_id: 'u2' },
+  { id: 'v3', customer_user_id: 'u3' },
+  { id: 'v4', customer_user_id: 'u4' },
+];
+const nomes = new Map([['u1', 'ACME'], ['u2', 'Beta'], ['u3', 'Gama']]);
+
+describe('montarVisitasHoje', () => {
+  it('total = todas as linhas; preview limitado a 3 por padrão', () => {
+    const r = montarVisitasHoje(rows, nomes);
+    expect(r.total).toBe(4);
+    expect(r.preview).toHaveLength(3);
+    expect(r.preview.map(p => p.nome)).toEqual(['ACME', 'Beta', 'Gama']);
+  });
+
+  it('resolve nome pelo Map e cai pra "Cliente" quando ausente', () => {
+    const r = montarVisitasHoje([{ id: 'v4', customer_user_id: 'u4' }], nomes);
+    expect(r.preview[0]).toEqual({ id: 'v4', customer_user_id: 'u4', nome: 'Cliente' });
+  });
+
+  it('lista vazia → total 0, preview vazio', () => {
+    expect(montarVisitasHoje([], nomes)).toEqual({ total: 0, preview: [] });
+  });
+
+  it('respeita limit custom', () => {
+    expect(montarVisitasHoje(rows, nomes, 2).preview).toHaveLength(2);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/lucassardenberg/Projetos/afiacao/.claude/worktrees/lembrete-visitas && heavy bun run test -- visitas-hoje`
+Expected: FAIL — `Cannot find module '../visitas-hoje'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+// src/lib/visitas/visitas-hoje.ts
+export interface VisitaHojeRow {
+  id: string;
+  customer_user_id: string;
+}
+
+export interface VisitaHojePreview {
+  id: string;
+  customer_user_id: string;
+  nome: string;
+}
+
+export interface VisitasHojeResumo {
+  total: number;
+  preview: VisitaHojePreview[];
+}
+
+/**
+ * Resumo do card "Visitas de hoje": total = todas as linhas (já filtradas por hoje),
+ * preview = até `limit` enriquecidas com nome (fallback 'Cliente', espelha loadTodayVisits).
+ * Puro, sem I/O.
+ */
+export function montarVisitasHoje(
+  rows: VisitaHojeRow[],
+  nomePorUsuario: Map<string, string>,
+  limit = 3,
+): VisitasHojeResumo {
+  const preview = rows.slice(0, limit).map((r) => ({
+    id: r.id,
+    customer_user_id: r.customer_user_id,
+    nome: nomePorUsuario.get(r.customer_user_id) || 'Cliente',
+  }));
+  return { total: rows.length, preview };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /Users/lucassardenberg/Projetos/afiacao/.claude/worktrees/lembrete-visitas && heavy bun run test -- visitas-hoje`
+Expected: PASS (4 testes).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/visitas/visitas-hoje.ts src/lib/visitas/__tests__/visitas-hoje.test.ts
+git commit -m "feat(visitas-hoje): helper puro montarVisitasHoje (TDD)"
+```
+
+---
+
+## Task 2: Hook `useVisitasHoje`
+
+**Files:**
+- Create: `src/hooks/useVisitasHoje.ts`
+
+Referência de padrão: `src/hooks/useVisitasAgendadas.ts` (useQuery + useAuth + supabase + visitasAgendadasTable). Aqui usamos `supabase.from('visitas_agendadas')` direto (a tabela já está tipada em `types.ts`).
+
+- [ ] **Step 1: Escrever o hook**
+
+```ts
+// src/hooks/useVisitasHoje.ts
+import { useQuery } from '@tanstack/react-query';
+import { useAuth } from '@/contexts/AuthContext';
+import { supabase } from '@/integrations/supabase/client';
+import { hojeISO } from '@/lib/visitas/today';
+import { montarVisitasHoje, type VisitasHojeResumo } from '@/lib/visitas/visitas-hoje';
+
+/**
+ * Visitas de `visitas_agendadas` pendentes, agendadas pelo usuário logado, para HOJE.
+ * "Hoje" = hojeISO() (UTC), consistente com loadScheduledVisits do route planner.
+ * Enriquece com o nome do cliente (profiles). Read-only.
+ */
+export function useVisitasHoje(): { resumo: VisitasHojeResumo; isLoading: boolean } {
+  const { user } = useAuth();
+  const uid = user?.id;
+
+  const query = useQuery({
+    queryKey: ['visitas-hoje', uid],
+    enabled: !!uid,
+    queryFn: async (): Promise<VisitasHojeResumo> => {
+      const { data: rows, error } = await supabase
+        .from('visitas_agendadas')
+        .select('id, customer_user_id')
+        .eq('scheduled_by', uid!)
+        .eq('status', 'pendente')
+        .eq('scheduled_date', hojeISO())
+        .order('scheduled_date', { ascending: true });
+      if (error) throw new Error(error.message);
+
+      const lista = rows ?? [];
+      if (lista.length === 0) return { total: 0, preview: [] };
+
+      const ids = [...new Set(lista.map((r) => r.customer_user_id))];
+      const { data: profs } = await supabase
+        .from('profiles')
+        .select('user_id, name')
+        .in('user_id', ids);
+      const nameMap = new Map((profs ?? []).map((p) => [p.user_id, p.name]));
+
+      return montarVisitasHoje(lista, nameMap);
+    },
+  });
+
+  return { resumo: query.data ?? { total: 0, preview: [] }, isLoading: query.isLoading };
+}
+```
+
+- [ ] **Step 2: Verificar typecheck**
+
+Run: `cd /Users/lucassardenberg/Projetos/afiacao/.claude/worktrees/lembrete-visitas && heavy bun run typecheck`
+Expected: exit 0. (Confirma que o `.select('id, customer_user_id')` tipa contra `visitas_agendadas` e que as linhas batem com `VisitaHojeRow`.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/hooks/useVisitasHoje.ts
+git commit -m "feat(visitas-hoje): hook useVisitasHoje (query hoje + nomes)"
+```
+
+---
+
+## Task 3: Componente `VisitasHojeCard`
+
+**Files:**
+- Create: `src/components/dashboard/VisitasHojeCard.tsx`
+
+- [ ] **Step 1: Escrever o card**
+
+```tsx
+// src/components/dashboard/VisitasHojeCard.tsx
+import { Link } from 'react-router-dom';
+import { CalendarCheck } from 'lucide-react';
+import { Card } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { track } from '@/lib/analytics';
+import { useVisitasHoje } from '@/hooks/useVisitasHoje';
+
+/**
+ * Card "Visitas de hoje" — compromissos FIRMES (visitas_agendadas) que o vendedor
+ * agendou para hoje. Distinto do AgendaTodayList (sugestões de ligação priorizadas).
+ * Self-hide quando não há visita hoje.
+ */
+export function VisitasHojeCard() {
+  const { resumo, isLoading } = useVisitasHoje();
+
+  if (isLoading || resumo.total === 0) return null;
+
+  const restantes = resumo.total - resumo.preview.length;
+
+  return (
+    <Card className="p-3 space-y-2">
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <CalendarCheck className="w-4 h-4 text-status-info" />
+          <div>
+            <h2 className="text-sm font-semibold leading-none">Visitas de hoje</h2>
+            <p className="text-xs text-muted-foreground">agendadas por você</p>
+          </div>
+        </div>
+        <Badge variant="secondary">{resumo.total}</Badge>
+      </div>
+
+      <ul className="text-sm space-y-0.5">
+        {resumo.preview.map((v) => (
+          <li key={v.id} className="truncate">{v.nome}</li>
+        ))}
+      </ul>
+      {restantes > 0 && (
+        <p className="text-xs text-muted-foreground">+{restantes} restante{restantes > 1 ? 's' : ''}</p>
+      )}
+
+      <Button asChild size="sm" variant="outline" className="w-full">
+        <Link to="/admin/route-planner" onClick={() => track('visitas_hoje.ver_rota')}>
+          Ver rota
+        </Link>
+      </Button>
+    </Card>
+  );
+}
+```
+
+- [ ] **Step 2: Verificar typecheck + lint**
+
+Run: `cd /Users/lucassardenberg/Projetos/afiacao/.claude/worktrees/lembrete-visitas && heavy bun run typecheck && heavy bun run lint`
+Expected: typecheck 0; lint 0 errors. (Confirma os imports shadcn + `track` + tokens `text-status-info`.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/dashboard/VisitasHojeCard.tsx
+git commit -m "feat(visitas-hoje): VisitasHojeCard (self-hide, count + nomes + Ver rota)"
+```
+
+---
+
+## Task 4: Inserir no `FarmerDashboardV2`
+
+**Files:**
+- Modify: `src/components/dashboard/FarmerDashboardV2.tsx`
+
+- [ ] **Step 1: Adicionar o import**
+
+No topo de `src/components/dashboard/FarmerDashboardV2.tsx`, junto aos outros imports de `./`:
+
+```tsx
+import { VisitasHojeCard } from './VisitasHojeCard';
+```
+
+- [ ] **Step 2: Inserir o card após `<KpisToday />`**
+
+Localizar o bloco (linhas ~24-25):
+
+```tsx
+      <KpisToday />
+
+      <Card className="p-3 space-y-1">
+```
+
+Inserir `<VisitasHojeCard />` entre eles:
+
+```tsx
+      <KpisToday />
+
+      <VisitasHojeCard />
+
+      <Card className="p-3 space-y-1">
+```
+
+> Ordem: "Meu dia" → KpisToday → **Visitas de hoje (firmes)** → Agenda de hoje (sugestões). O card self-hide quando vazio.
+
+- [ ] **Step 3: Verificar typecheck + lint**
+
+Run: `cd /Users/lucassardenberg/Projetos/afiacao/.claude/worktrees/lembrete-visitas && heavy bun run typecheck && heavy bun run lint`
+Expected: typecheck 0; lint 0 errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/dashboard/FarmerDashboardV2.tsx
+git commit -m "feat(visitas-hoje): monta VisitasHojeCard no FarmerDashboardV2"
+```
+
+---
+
+## Task 5: Validação final
+
+**Files:** nenhum (só validação)
+
+- [ ] **Step 1: Suíte completa**
+
+Run: `cd /Users/lucassardenberg/Projetos/afiacao/.claude/worktrees/lembrete-visitas && heavy bun run typecheck && heavy bun run lint && heavy bun run test && heavy bun run build`
+Expected: typecheck 0 · lint 0 errors · test todos passando (incl. os 4 novos do montarVisitasHoje) · build ✓.
+
+- [ ] **Step 2: Confirmar escopo**
+
+Run: `git diff --stat $(git merge-base HEAD origin/main)`
+Expected: só os 4 arquivos de código (2 em `src/lib/visitas/`, `useVisitasHoje.ts`, `VisitasHojeCard.tsx`, `FarmerDashboardV2.tsx`) + os 2 docs (spec/plano). NÃO toca `useVisitasAgendadas`, `AgendarVisitaDialog`, `useRoutePlanner`, RLS, backend.
+
+---
+
+## Self-Review (autor do plano)
+
+**Spec coverage:**
+- §4.1 helper `montarVisitasHoje` → Task 1 ✓
+- §4.2 hook `useVisitasHoje` (query hoje UTC + nomes + helper) → Task 2 ✓
+- §4.3 card (self-hide, título+subtítulo desambiguante, count, até 3 nomes, +N, "Ver rota") → Task 3 ✓
+- §4.4 inserção após KpisToday, antes do AgendaTodayList → Task 4 ✓
+- §3 timezone (hojeISO UTC) → usado no hook (Task 2) ✓
+- §5 testes (helper TDD; fiação → QA) → Task 1 + nota Task 5 ✓
+- §6 fora de escopo (não toca agendar/rota/RLS) → confirmado Task 5 Step 2 ✓
+
+**Placeholder scan:** nenhum TBD; todo passo com código real.
+
+**Type consistency:** `montarVisitasHoje(rows, nameMap, limit?)` idêntico em Task 1 (def) e Task 2 (uso). `VisitaHojeRow {id, customer_user_id}` bate com `.select('id, customer_user_id')`. `VisitasHojeResumo {total, preview}` consumido no card (Task 3: `resumo.total`, `resumo.preview`). `useVisitasHoje()` retorna `{resumo, isLoading}` — consumido exatamente assim no card. `hojeISO` importado de `@/lib/visitas/today`.

--- a/docs/superpowers/specs/2026-05-31-lembrete-visitas-hoje-design.md
+++ b/docs/superpowers/specs/2026-05-31-lembrete-visitas-hoje-design.md
@@ -65,11 +65,12 @@ export function montarVisitasHoje(
 ### 4.3 Card `VisitasHojeCard`
 `src/components/dashboard/VisitasHojeCard.tsx`.
 - Chama `useVisitasHoje()`. **Self-hide:** se `isLoading` → null (ou skeleton mínimo); se `total === 0` → **return null** (não polui o dashboard).
-- Renderiza: título "Visitas de hoje" + badge com `total`; lista os `preview` (nomes); se `total > preview.length`, "+N" ; CTA `<Link to="/admin/route-planner">Ver rota</Link>` (Button). Usa tokens do design system (Card shadcn, sem cores hardcoded).
+- Renderiza: título **"Visitas de hoje"** + subtítulo de desambiguação **"agendadas por você"** + badge com `total`; lista os `preview` (nomes); se `total > preview.length`, "+N restantes" ; CTA `<Link to="/admin/route-planner">Ver rota</Link>` (Button). Usa tokens do design system (Card shadcn, ícone `CalendarCheck` lucide, sem cores hardcoded).
+- **Desambiguação obrigatória:** este card mostra VISITAS AGENDADAS (compromissos firmes de `visitas_agendadas`), distinto do `AgendaTodayList` ("Agenda de hoje (top 10)", logo abaixo no mesmo dashboard) que mostra SUGESTÕES de ligação priorizadas de `farmer_client_scores`. O subtítulo "agendadas por você" deixa isso claro.
 - Evento de analytics opcional `track('visitas_hoje.ver_rota')` no CTA (convenção `<area>.<action>`). **Cortável** se rende pouco — manter simples.
 
 ### 4.4 Inserção
-`src/components/dashboard/FarmerDashboardV2.tsx`: inserir `<VisitasHojeCard />` como **primeiro card** dentro do `<div className="container mx-auto p-4 space-y-4 max-w-5xl">`. (Hunter/Closer = fast-follow, mesma 1 linha.)
+`src/components/dashboard/FarmerDashboardV2.tsx`: inserir `<VisitasHojeCard />` **após `<KpisToday />` e ANTES do card "Agenda de hoje (top 10)"** (o `AgendaTodayList`). Ordem resultante: título "Meu dia" → KpisToday → **Visitas de hoje (compromissos firmes)** → Agenda de hoje (sugestões de ligação). Compromisso firme vem antes da sugestão. Self-hide quando vazio → não desloca o layout quando não há visita. (Hunter/Closer = fast-follow, mesma 1 linha.)
 
 ## 5. Testes
 - **Unit (vitest, TDD)** de `montarVisitasHoje`: total reflete todas as linhas; preview limitado a `limit` (3); nome resolvido pelo Map; fallback 'Cliente' quando ausente; lista vazia → `{total:0, preview:[]}`.

--- a/docs/superpowers/specs/2026-05-31-lembrete-visitas-hoje-design.md
+++ b/docs/superpowers/specs/2026-05-31-lembrete-visitas-hoje-design.md
@@ -1,0 +1,87 @@
+# Lembrete de "Visitas de hoje" no dashboard do vendedor
+
+**Data:** 2026-05-31
+**Autor:** Lucas (delegou "decida você + codex") + Claude
+**Status:** decisão cravada (codex confirmou a frente + o escopo v1)
+
+---
+
+## 1. Problema
+
+A "Agendar visita" entregou a fila de visitas + o painel "Próximas visitas" **dentro do route planner** (`/admin/route-planner`). Mas não há **nudge proativo**: o vendedor só vê o que agendou se navegar até lá. Resultado: visita agendada pode ser esquecida. Falta fechar o loop **agendou → lembra → age**.
+
+> Frente escolhida via "decida você + codex". Codex confirmou: maior valor×menor-risco agora (transforma a feature recém-entregue em comportamento operacional diário; PR pequeno; baixa colisão com financeiro/reposição que têm sessões paralelas; sem backend novo).
+
+## 2. Escopo v1 (mínimo, codex-afiado)
+
+**Faz:** um card "Visitas de hoje" no home do vendedor mostrando as visitas **pendentes agendadas por mim para hoje** — count + até 3 nomes de cliente + 1 CTA "Ver rota".
+
+**NÃO faz (cortado do v1):** push/notificação, sino global, captura de resultado/notas, editar/reagendar no card, endereços, horários (o schema `visitas_agendadas` é **date-only** — não há hora). Cobertura de carteira de outro vendedor (`scheduled_by = eu` only — ver §6).
+
+## 3. Decisão não-óbvia: timezone ("hoje")
+
+Codex flagou timezone como o maior risco. **Decisão: usar `hojeISO()` (UTC, o helper existente em `src/lib/visitas/today.ts`), NÃO um "hoje Brasil" novo.**
+
+Razão — **consistência > correção isolada**:
+- A `AgendarVisitaDialog` **armazena** `scheduled_date` via `<input type="date">` com default/`min` = `hojeISO()` (UTC).
+- O **`loadScheduledVisits` (Fase 2) do route planner já filtra `visitas_agendadas` por `scheduled_date = new Date().toISOString().split('T')[0]` (UTC)** e mostra como parada.
+- O card de lembrete deve mostrar **exatamente o mesmo conjunto** que o route planner. Se o card usasse "hoje Brasil" e a rota usa UTC, eles **divergiriam** na janela noturna (21h–24h BRT): card mostraria visita que a rota não mostra, ou vice-versa. Pior UX que o bug teórico.
+
+O bug UTC×Brasil **existe** mas é **sistêmico** (afeta dialog + route planner + card juntos) e de **baixo impacto prático** (vendedor checa de manhã, quando UTC = data Brasil; a divergência é só 21h–24h, quando o vendedor já encerrou o dia). **Follow-up registrado:** um PR dedicado que troca `hojeISO` + as cópias inline de `new Date().toISOString()` no `useRoutePlanner` para `America/Sao_Paulo` **juntas** (consertar pela metade quebraria a consistência). Fora do escopo deste v1.
+
+`hojeISO()` e o `new Date().toISOString().split('T')[0]` inline do `loadScheduledVisits` computam **o mesmo valor** (data UTC) → o card reusando `hojeISO()` bate 1:1 com a rota.
+
+## 4. Arquitetura (3 peças + 1 inserção; sem backend)
+
+### 4.1 Helper puro `montarVisitasHoje` (TDD)
+`src/lib/visitas/visitas-hoje.ts`. Junta as linhas de `visitas_agendadas` (já filtradas por hoje) com um mapa de nomes (`customer_user_id → name`), e produz o resumo do card.
+```ts
+export interface VisitaHojeRow { id: string; customer_user_id: string; }
+export interface VisitaHojePreview { id: string; customer_user_id: string; nome: string; }
+export interface VisitasHojeResumo { total: number; preview: VisitaHojePreview[]; }
+
+export function montarVisitasHoje(
+  rows: VisitaHojeRow[],
+  nomePorUsuario: Map<string, string>,
+  limit = 3,
+): VisitasHojeResumo {
+  const preview = rows.slice(0, limit).map(r => ({
+    id: r.id,
+    customer_user_id: r.customer_user_id,
+    nome: nomePorUsuario.get(r.customer_user_id) || 'Cliente',
+  }));
+  return { total: rows.length, preview };
+}
+```
+> Puro, testável: total = todas as de hoje; preview = até `limit`; nome com fallback 'Cliente' (espelha o `loadTodayVisits` do route planner, que usa o mesmo fallback).
+
+### 4.2 Hook `useVisitasHoje`
+`src/hooks/useVisitasHoje.ts`. Faz o I/O e chama o helper.
+- Query A: `visitas_agendadas` `.select('id, customer_user_id').eq('scheduled_by', uid).eq('status','pendente').eq('scheduled_date', hojeISO()).order('scheduled_date')`.
+- Query B (enriquecimento): `profiles` `.select('user_id, name').in('user_id', <customer_user_ids>)` → monta o `Map`. Só roda se houver linhas (senão `Map` vazio).
+- Retorna `montarVisitasHoje(rows, nameMap)` + `isLoading`. `enabled: !!uid`.
+- Usa `useQuery` (react-query), `queryKey: ['visitas-hoje', uid]`. Reaproveita o `supabase` client + `useAuth` + `hojeISO`.
+
+### 4.3 Card `VisitasHojeCard`
+`src/components/dashboard/VisitasHojeCard.tsx`.
+- Chama `useVisitasHoje()`. **Self-hide:** se `isLoading` → null (ou skeleton mínimo); se `total === 0` → **return null** (não polui o dashboard).
+- Renderiza: título "Visitas de hoje" + badge com `total`; lista os `preview` (nomes); se `total > preview.length`, "+N" ; CTA `<Link to="/admin/route-planner">Ver rota</Link>` (Button). Usa tokens do design system (Card shadcn, sem cores hardcoded).
+- Evento de analytics opcional `track('visitas_hoje.ver_rota')` no CTA (convenção `<area>.<action>`). **Cortável** se rende pouco — manter simples.
+
+### 4.4 Inserção
+`src/components/dashboard/FarmerDashboardV2.tsx`: inserir `<VisitasHojeCard />` como **primeiro card** dentro do `<div className="container mx-auto p-4 space-y-4 max-w-5xl">`. (Hunter/Closer = fast-follow, mesma 1 linha.)
+
+## 5. Testes
+- **Unit (vitest, TDD)** de `montarVisitasHoje`: total reflete todas as linhas; preview limitado a `limit` (3); nome resolvido pelo Map; fallback 'Cliente' quando ausente; lista vazia → `{total:0, preview:[]}`.
+- A fiação do card/hook (query + render + self-hide) → **QA manual** (mock de react-query+router rende pouco). Documentar no PR: logar como vendedor com visita agendada pra hoje → card aparece com count+nomes; sem visita → card some; "Ver rota" navega pro route planner.
+- Suíte + typecheck + lint + build verdes.
+
+## 6. Fora de escopo / limitações conscientes
+- **`scheduled_by = eu` only:** um vendedor que cobre a carteira de outro (férias) NÃO vê as visitas agendadas pelo titular. Codex: **não resolver no v1** sem sinal de produto (exigiria decidir o modelo de cobertura, espelhando `carteira_visivel_para`). Limitação registrada.
+- **Timezone UTC** (ver §3): follow-up sistêmico.
+- **Só FarmerDashboardV2** no v1: Hunter/Closer/Master são fast-follow (card é self-contained, self-hide → adicionar é 1 import + 1 linha).
+- **Sem endereços/horários** (schema date-only; endereço exigiria lookup extra).
+- Não toca `useVisitasAgendadas`, `AgendarVisitaDialog`, `useRoutePlanner`, RLS, nem o backend.
+
+## 7. Risco
+Baixo. Feature **aditiva e read-only** sobre dados **já validados em produção** (a migration `visitas_agendadas` passou 8/8 checks). O card self-hide → zero impacto quando não há visita. Nenhuma escrita, nenhum money-path. O único ponto de atenção (timezone) é uma escolha consciente de consistência, documentada, com follow-up.

--- a/src/components/dashboard/FarmerDashboardV2.tsx
+++ b/src/components/dashboard/FarmerDashboardV2.tsx
@@ -2,6 +2,7 @@ import { Card } from '@/components/ui/card';
 import { Calendar } from 'lucide-react';
 import { KpisToday } from './KpisToday';
 import { AgendaTodayList } from './AgendaTodayList';
+import { VisitasHojeCard } from './VisitasHojeCard';
 
 /**
  * Dashboard Farmer V2 — foco em expansão de carteira existente.
@@ -22,6 +23,8 @@ export function FarmerDashboardV2() {
       </div>
 
       <KpisToday />
+
+      <VisitasHojeCard />
 
       <Card className="p-3 space-y-1">
         <div className="flex items-center gap-2">

--- a/src/components/dashboard/VisitasHojeCard.tsx
+++ b/src/components/dashboard/VisitasHojeCard.tsx
@@ -1,0 +1,50 @@
+import { Link } from 'react-router-dom';
+import { CalendarCheck } from 'lucide-react';
+import { Card } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { track } from '@/lib/analytics';
+import { useVisitasHoje } from '@/hooks/useVisitasHoje';
+
+/**
+ * Card "Visitas de hoje" — compromissos FIRMES (visitas_agendadas) que o vendedor
+ * agendou para hoje. Distinto do AgendaTodayList (sugestões de ligação priorizadas).
+ * Self-hide quando não há visita hoje.
+ */
+export function VisitasHojeCard() {
+  const { resumo, isLoading } = useVisitasHoje();
+
+  if (isLoading || resumo.total === 0) return null;
+
+  const restantes = resumo.total - resumo.preview.length;
+
+  return (
+    <Card className="p-3 space-y-2">
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <CalendarCheck className="w-4 h-4 text-status-info" />
+          <div>
+            <h2 className="text-sm font-semibold leading-none">Visitas de hoje</h2>
+            <p className="text-xs text-muted-foreground">agendadas por você</p>
+          </div>
+        </div>
+        <Badge variant="secondary">{resumo.total}</Badge>
+      </div>
+
+      <ul className="text-sm space-y-0.5">
+        {resumo.preview.map((v) => (
+          <li key={v.id} className="truncate">{v.nome}</li>
+        ))}
+      </ul>
+      {restantes > 0 && (
+        <p className="text-xs text-muted-foreground">+{restantes} restante{restantes > 1 ? 's' : ''}</p>
+      )}
+
+      <Button asChild size="sm" variant="outline" className="w-full">
+        <Link to="/admin/route-planner" onClick={() => track('visitas_hoje.ver_rota')}>
+          Ver rota
+        </Link>
+      </Button>
+    </Card>
+  );
+}

--- a/src/hooks/useVisitasHoje.ts
+++ b/src/hooks/useVisitasHoje.ts
@@ -1,0 +1,44 @@
+import { useQuery } from '@tanstack/react-query';
+import { useAuth } from '@/contexts/AuthContext';
+import { supabase } from '@/integrations/supabase/client';
+import { hojeISO } from '@/lib/visitas/today';
+import { montarVisitasHoje, type VisitasHojeResumo } from '@/lib/visitas/visitas-hoje';
+
+/**
+ * Visitas de `visitas_agendadas` pendentes, agendadas pelo usuário logado, para HOJE.
+ * "Hoje" = hojeISO() (UTC), consistente com loadScheduledVisits do route planner.
+ * Enriquece com o nome do cliente (profiles). Read-only.
+ */
+export function useVisitasHoje(): { resumo: VisitasHojeResumo; isLoading: boolean } {
+  const { user } = useAuth();
+  const uid = user?.id;
+
+  const query = useQuery({
+    queryKey: ['visitas-hoje', uid],
+    enabled: !!uid,
+    queryFn: async (): Promise<VisitasHojeResumo> => {
+      const { data: rows, error } = await supabase
+        .from('visitas_agendadas')
+        .select('id, customer_user_id')
+        .eq('scheduled_by', uid!)
+        .eq('status', 'pendente')
+        .eq('scheduled_date', hojeISO())
+        .order('scheduled_date', { ascending: true });
+      if (error) throw new Error(error.message);
+
+      const lista = rows ?? [];
+      if (lista.length === 0) return { total: 0, preview: [] };
+
+      const ids = [...new Set(lista.map((r) => r.customer_user_id))];
+      const { data: profs } = await supabase
+        .from('profiles')
+        .select('user_id, name')
+        .in('user_id', ids);
+      const nameMap = new Map((profs ?? []).map((p) => [p.user_id, p.name]));
+
+      return montarVisitasHoje(lista, nameMap);
+    },
+  });
+
+  return { resumo: query.data ?? { total: 0, preview: [] }, isLoading: query.isLoading };
+}

--- a/src/lib/visitas/__tests__/visitas-hoje.test.ts
+++ b/src/lib/visitas/__tests__/visitas-hoje.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { montarVisitasHoje } from '../visitas-hoje';
+
+const rows = [
+  { id: 'v1', customer_user_id: 'u1' },
+  { id: 'v2', customer_user_id: 'u2' },
+  { id: 'v3', customer_user_id: 'u3' },
+  { id: 'v4', customer_user_id: 'u4' },
+];
+const nomes = new Map([['u1', 'ACME'], ['u2', 'Beta'], ['u3', 'Gama']]);
+
+describe('montarVisitasHoje', () => {
+  it('total = todas as linhas; preview limitado a 3 por padrão', () => {
+    const r = montarVisitasHoje(rows, nomes);
+    expect(r.total).toBe(4);
+    expect(r.preview).toHaveLength(3);
+    expect(r.preview.map(p => p.nome)).toEqual(['ACME', 'Beta', 'Gama']);
+  });
+
+  it('resolve nome pelo Map e cai pra "Cliente" quando ausente', () => {
+    const r = montarVisitasHoje([{ id: 'v4', customer_user_id: 'u4' }], nomes);
+    expect(r.preview[0]).toEqual({ id: 'v4', customer_user_id: 'u4', nome: 'Cliente' });
+  });
+
+  it('lista vazia → total 0, preview vazio', () => {
+    expect(montarVisitasHoje([], nomes)).toEqual({ total: 0, preview: [] });
+  });
+
+  it('respeita limit custom', () => {
+    expect(montarVisitasHoje(rows, nomes, 2).preview).toHaveLength(2);
+  });
+});

--- a/src/lib/visitas/visitas-hoje.ts
+++ b/src/lib/visitas/visitas-hoje.ts
@@ -1,0 +1,33 @@
+export interface VisitaHojeRow {
+  id: string;
+  customer_user_id: string;
+}
+
+export interface VisitaHojePreview {
+  id: string;
+  customer_user_id: string;
+  nome: string;
+}
+
+export interface VisitasHojeResumo {
+  total: number;
+  preview: VisitaHojePreview[];
+}
+
+/**
+ * Resumo do card "Visitas de hoje": total = todas as linhas (já filtradas por hoje),
+ * preview = até `limit` enriquecidas com nome (fallback 'Cliente', espelha loadTodayVisits).
+ * Puro, sem I/O.
+ */
+export function montarVisitasHoje(
+  rows: VisitaHojeRow[],
+  nomePorUsuario: Map<string, string>,
+  limit = 3,
+): VisitasHojeResumo {
+  const preview = rows.slice(0, limit).map((r) => ({
+    id: r.id,
+    customer_user_id: r.customer_user_id,
+    nome: nomePorUsuario.get(r.customer_user_id) || 'Cliente',
+  }));
+  return { total: rows.length, preview };
+}


### PR DESCRIPTION
## Resumo
A "Agendar visita" guardava as visitas só dentro do route planner — sem **nudge proativo**, o vendedor podia esquecer o que agendou. Este card **"Visitas de hoje"** no home do vendedor (FarmerDashboardV2) fecha o loop **agendou → lembra → age**: mostra as visitas pendentes que ele agendou para hoje (count + até 3 nomes + CTA "Ver rota"). **Self-hide** quando não há visita.

Frente escolhida via "decida você + codex" (codex confirmou: maior valor×menor-risco; PR pequeno; sem colisão com financeiro/reposição).

### Peças (4 commits)
1. **`montarVisitasHoje`** — helper puro (TDD, 4 testes): total + preview (≤3) + nomes.
2. **`useVisitasHoje`** — query `visitas_agendadas` de hoje (`scheduled_by=eu`, `pendente`, `scheduled_date=hojeISO()`) + enriquece nomes via `profiles`. Read-only.
3. **`VisitasHojeCard`** — self-hide; "Visitas de hoje · agendadas por você" + count + nomes + "Ver rota". Desambiguado do `AgendaTodayList` (que mostra **sugestões de ligação**, não visitas agendadas).
4. **Inserção** no FarmerDashboardV2, após KpisToday.

### Decisão não-óbvia: timezone
Usa **`hojeISO()` (UTC)** de propósito — **paridade exata** com o `loadScheduledVisits` do route planner (mesmos 3 predicados). Card e rota mostram **o mesmo conjunto 1:1**; usar "hoje Brasil" só aqui criaria divergência na janela noturna. O bug UTC×Brasil é **sistêmico** (dialog+rota+card) → follow-up dedicado registrado no spec §3, não consertado pela metade.

## Sem backend
Front puro, read-only sobre dados **já validados em prod** (migration `visitas_agendadas` passou 8/8). Sem migration/SQL/edge.

## Qualidade
- Subagent-driven: implementação + review (spec ✅ + qualidade ✅, zero P1/P2). Codex no design.
- typecheck **0** · lint **0 errors** · test **2005** (incl. 4 novos) · build ✓.

## Limitações conscientes (v1, no spec §6)
- `scheduled_by=eu` only (cobertura de carteira de outro = futuro, sem sinal de produto).
- Só FarmerDashboardV2 (Hunter/Closer/Master = fast-follow, card é self-contained).
- Timezone UTC (follow-up sistêmico).

## Test plan
- [x] TDD `montarVisitasHoje` (4 testes) + suíte/typecheck/lint/build verdes.
- [ ] **QA manual** (fiação card/hook): logar como vendedor com visita agendada pra hoje → card aparece (count+nomes); sem visita → card some; "Ver rota" → route planner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)