### PR TITLE
feat(visitas-hoje): card também no Hunter e Closer dashboard (fast-follow #547)

### DIFF
--- a/src/components/dashboard/CloserDashboard.tsx
+++ b/src/components/dashboard/CloserDashboard.tsx
@@ -1,6 +1,7 @@
 import { Card } from '@/components/ui/card';
 import { Construction, MapPin, Target, TrendingUp } from 'lucide-react';
 import { VisitSuggestionsCard } from './VisitSuggestionsCard';
+import { VisitasHojeCard } from './VisitasHojeCard';
 import { MinhasTarefasCard } from '@/components/tarefas/MinhasTarefasCard';
 
 /**
@@ -18,6 +19,8 @@ export function CloserDashboard() {
       </div>
 
       <MinhasTarefasCard />
+
+      <VisitasHojeCard />
 
       {/* Sugestões de visita — PR-VISIT-INTELLIGENCE Sub-PR A */}
       <VisitSuggestionsCard />

--- a/src/components/dashboard/HunterDashboard.tsx
+++ b/src/components/dashboard/HunterDashboard.tsx
@@ -1,6 +1,7 @@
 import { Card } from '@/components/ui/card';
 import { Phone, PhoneIncoming, UserPlus, Construction } from 'lucide-react';
 import { MinhasTarefasCard } from '@/components/tarefas/MinhasTarefasCard';
+import { VisitasHojeCard } from './VisitasHojeCard';
 
 /**
  * Dashboard Hunter — placeholder rico até PR-MULTIVENDOR-V2 implementar
@@ -17,6 +18,8 @@ export function HunterDashboard() {
       </div>
 
       <MinhasTarefasCard />
+
+      <VisitasHojeCard />
 
       <Card className="p-4 border-dashed border-2 border-status-warning/30 bg-status-warning-bg/20">
         <div className="flex items-center gap-2 mb-2">


### PR DESCRIPTION
## Resumo
Fast-follow do #547 (que entregou o card "Visitas de hoje" só no FarmerDashboardV2). Hunter e Closer também são personas de vendedor que agendam visitas → ganham o **mesmo lembrete** no home. Posicionado após `MinhasTarefasCard`, antes das sugestões de visita (compromisso firme antes de sugestão), consistente com o Farmer.

- **+6 linhas** (import + 1 render em cada dashboard). Reusa o `VisitasHojeCard` já entregue e revisado no #547 — sem lógica nova.
- **Self-hide** quando não há visita hoje → zero impacto no layout quando vazio.
- **Master fica fora** (dashboard exec/gestor; o card "agendadas por você" não é a persona de campo — trivial adicionar se quiser).

## Sem backend
Front puro, placement de componente existente. Reusa o hook/query já validados.

## Test plan
- [x] typecheck **0** · lint **0 errors** · test **2029** · build ✓.
- [ ] QA manual: logar como Hunter/Closer com visita agendada pra hoje → card aparece; sem visita → some.

🤖 Generated with [Claude Code](https://claude.com/claude-code)