### PR TITLE
docs(tarefas): design da Fase 2 (enforcement — recorrência + trava de comprovação)

### DIFF
--- a/docs/superpowers/plans/2026-06-01-tarefas-enforcement-fase2.md
+++ b/docs/superpowers/plans/2026-06-01-tarefas-enforcement-fase2.md
@@ -1,0 +1,438 @@
+# Tarefas — Enforcement de Atividades (Fase 2) — Plano de Implementação
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development (recomendado) ou superpowers:executing-plans. Steps usam checkbox (`- [ ]`).
+
+> 🔴 **GATE DE SEQUÊNCIA (decisão eu+codex):** **NÃO começar a implementação até a Fase 1 ser verificada visualmente em produção** (não empilhar código sobre base não-clicada). Este plano fica pronto pra executar no momento em que a Fase 1 for validada.
+
+**Goal:** Forçar atividades a serem feitas em todas as áreas — **recorrência + trava de comprovação (foto/leitura+faixa) + escalação com janela**, com "anexou = feito + auditoria por exceção". Estende o motor da Fase 1; flagship = operador de tinta.
+
+**Architecture:** Backend SQL puro + pg_cron + 2 RPCs (`concluir_com_comprovacao`/`auditar_tarefa`) + trigger anti-bypass + cron de materialização. Tabela nova `tarefa_templates` (definição recorrente) materializa instâncias na `tarefas` da Fase 1. Frontend: fluxo de prova (PhotoUpload→Storage + leitura validada) no `/tintometrico`, lista de auditoria do gestor, CRUD de templates.
+
+**Tech Stack:** React+TS+Vite+Supabase, pg_cron, Storage. Spec: `docs/superpowers/specs/2026-05-31-tarefas-enforcement-fase2-design.md`.
+
+> ⚠️ **Lovable:** migrations manuais (SQL Editor), edge functions via chat — **mas esta fase não tem edge function nova**. Crons = chamadas SQL locais. Cada Task de backend entrega o bloco inline + validação. Tipos do Supabase: tabela/RPCs novas usam cast `as never` no front até regenerar.
+
+---
+
+## Milestone 1 — Backend (SQL via SQL Editor). Shippable/testável por si.
+
+### Task 1: BLOCO A — `tarefa_templates`
+
+**Files:** Create `supabase/migrations/20260601100000_tarefas_fase2_bloco_a.sql`
+
+- [ ] **Step 1: DDL**
+
+```sql
+-- 20260601100000_tarefas_fase2_bloco_a.sql
+create table if not exists public.tarefa_templates (
+  id uuid primary key default gen_random_uuid(),
+  descricao text not null,
+  categoria text not null check (categoria in ('ligar','oferecer','preco','whatsapp','outro')),
+  area text not null,
+  empresa text not null,
+  assigned_to uuid not null,
+  customer_user_id uuid,                       -- nullable: ops recorrente não tem cliente
+  cadencia text not null check (cadencia in ('diaria','dias_uteis','semanal','dias_especificos')),
+  dias_semana int[],                           -- 0=dom..6=sáb (semanal/dias_especificos)
+  janela_inicio time,
+  janela_fim time,
+  tolerancia_dias int not null default 0,
+  requer_comprovacao boolean not null default false,
+  tipo_comprovacao text not null default 'nenhuma' check (tipo_comprovacao in ('nenhuma','foto','leitura','foto_e_leitura')),
+  leitura_min numeric,
+  leitura_max numeric,
+  leitura_unidade text,
+  alto_risco boolean not null default false,
+  amostra_auditoria_pct int not null default 10 check (amostra_auditoria_pct between 0 and 100),
+  reincidente_limite int not null default 3,
+  supervisor_user_id uuid,
+  ativo boolean not null default true,
+  created_by uuid not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint tt_janela_chk check (janela_inicio is null or janela_fim is null or janela_inicio < janela_fim),
+  constraint tt_dias_chk check (cadencia not in ('semanal','dias_especificos') or (dias_semana is not null and array_length(dias_semana,1) > 0)),
+  constraint tt_altorisco_foto_chk check (not alto_risco or tipo_comprovacao = 'foto_e_leitura' or not requer_comprovacao)
+);
+create index if not exists idx_tt_ativo_assigned on public.tarefa_templates (assigned_to) where ativo;
+```
+> `tt_altorisco_foto_chk`: alto-risco com comprovação exige `foto_e_leitura` (codex P2 #8 — leitura sozinha é auto-atestado).
+
+- [ ] **Step 2: inline + Run** (🟣 Lovable → SQL Editor). **Step 3: validação**
+
+```sql
+select 'F2 BLOCO A OK' as status,
+  to_regclass('public.tarefa_templates') is not null as tbl_ok,
+  (select count(*) from information_schema.columns where table_name='tarefa_templates') as colunas;
+```
+Expected: `tbl_ok=true`, `colunas=26`.
+
+- [ ] **Step 4: commit** `git commit -m "feat(tarefas-f2): BLOCO A — tarefa_templates (migration manual)"`
+
+---
+
+### Task 2: BLOCO B — colunas de prova/auditoria em `tarefas` + nullable customer + CHECK + UNIQUE
+
+**Files:** Create `supabase/migrations/20260601101000_tarefas_fase2_bloco_b.sql`
+
+- [ ] **Step 1: ALTERs**
+
+```sql
+-- 20260601101000_tarefas_fase2_bloco_b.sql
+alter table public.tarefas
+  add column if not exists tipo_comprovacao text,
+  add column if not exists comprovacao_leitura numeric,
+  add column if not exists comprovacao_em timestamptz,
+  add column if not exists janela_fim time,
+  add column if not exists auditoria_status text not null default 'nao_requer'
+    check (auditoria_status in ('nao_requer','dispensada','pendente','aprovada','reprovada')),
+  add column if not exists auditoria_motivo text,
+  add column if not exists auditada_por uuid,
+  add column if not exists auditada_em timestamptz,
+  add column if not exists supervisor_user_id uuid;
+
+-- ops recorrente não tem cliente → customer_user_id passa a ser nullable
+alter table public.tarefas alter column customer_user_id drop not null;
+
+-- estende o CHECK de conclusao_origem c/ 'comprovacao'
+do $$ declare cn text; begin
+  select conname into cn from pg_constraint where conrelid='public.tarefas'::regclass and contype='c'
+    and pg_get_constraintdef(oid) ilike '%conclusao_origem%';
+  if cn is not null then execute format('alter table public.tarefas drop constraint %I', cn); end if;
+end $$;
+alter table public.tarefas add constraint tarefas_conclusao_origem_check
+  check (conclusao_origem is null or conclusao_origem in ('manual','auto_interacao','sugestao_confirmada','whatsapp','comprovacao'));
+
+-- idempotência da materialização (codex P1 #2: inclui assigned_to)
+create unique index if not exists uq_tarefa_template_assignee_dia
+  on public.tarefas (template_id, assigned_to, due_date) where template_id is not null;
+```
+
+- [ ] **Step 2: inline + Run. Step 3: validação**
+
+```sql
+select 'F2 BLOCO B OK' as status,
+  (select is_nullable from information_schema.columns where table_name='tarefas' and column_name='customer_user_id') as customer_nullable,
+  (select count(*) from information_schema.columns where table_name='tarefas' and column_name in
+    ('tipo_comprovacao','comprovacao_leitura','comprovacao_em','janela_fim','auditoria_status','auditoria_motivo','auditada_por','auditada_em','supervisor_user_id')) as cols_novas,
+  (pg_get_constraintdef(oid) ilike '%comprovacao%' from pg_constraint where conrelid='public.tarefas'::regclass and conname='tarefas_conclusao_origem_check') as origem_ok,
+  to_regclass('public.uq_tarefa_template_assignee_dia') is not null as uq_ok;
+```
+Expected: `customer_nullable=YES`, `cols_novas=9`, `origem_ok=true`, `uq_ok=true`.
+
+- [ ] **Step 4: commit** `git commit -m "feat(tarefas-f2): BLOCO B — colunas de prova + customer nullable + CHECK + UNIQUE"`
+
+---
+
+### Task 3: BLOCO C — view `v_tarefas_estado` window-aware + RLS de `tarefa_templates`
+
+**Files:** Create `supabase/migrations/20260601102000_tarefas_fase2_bloco_c.sql`
+
+- [ ] **Step 1: CREATE OR REPLACE da view (janela intradiária) + RLS**
+
+```sql
+-- 20260601102000_tarefas_fase2_bloco_c.sql
+create or replace view public.v_tarefas_estado
+with (security_invoker = on) as
+with base as (
+  select t.*,
+    coalesce(
+      (t.adiada_para at time zone 'America/Sao_Paulo')::date,
+      t.due_date,
+      (t.created_at at time zone 'America/Sao_Paulo')::date + t.backstop_days
+    ) as effective_due,
+    coalesce(
+      (select cc.covering_user_id from public.carteira_coverage cc
+        where cc.covered_user_id = t.assigned_to and cc.active
+          and now() >= cc.valid_from and (cc.valid_until is null or now() <= cc.valid_until)
+        order by cc.valid_from desc limit 1),
+      t.assigned_to
+    ) as responsavel_efetivo
+  from public.tarefas t
+), nowsp as (
+  select (now() at time zone 'America/Sao_Paulo')::date as dia,
+         (now() at time zone 'America/Sao_Paulo')::time as hora
+)
+select b.*,
+  (b.status = 'aberta' and (
+     n.dia > b.effective_due
+     or (n.dia = b.effective_due and b.janela_fim is not null and n.hora > b.janela_fim)
+  )) as atrasada,
+  (b.status = 'aberta' and b.escalado_em is null and (
+     n.dia > (b.effective_due + b.tolerancia_dias)
+     or (b.tolerancia_dias = 0 and n.dia = b.effective_due and b.janela_fim is not null and n.hora > b.janela_fim)
+  )) as escalavel,
+  exists (select 1 from public.tarefa_satisfacao_candidatos c
+          where c.tarefa_id = b.id and c.status = 'pending') as tem_sugestao_pendente,
+  (b.auditoria_status = 'pendente') as requer_auditoria
+from base b cross join nowsp n;
+
+-- RLS de tarefa_templates: operador vê os dele; gestor/master gerencia.
+alter table public.tarefa_templates enable row level security;
+create policy tt_select on public.tarefa_templates for select to authenticated
+using (public.pode_ver_carteira_completa((select auth.uid())) or assigned_to = (select auth.uid()));
+create policy tt_insert on public.tarefa_templates for insert to authenticated
+with check (public.pode_ver_carteira_completa((select auth.uid())) and created_by = (select auth.uid()));
+create policy tt_update on public.tarefa_templates for update to authenticated
+using (public.pode_ver_carteira_completa((select auth.uid())));
+create policy tt_delete on public.tarefa_templates for delete to authenticated
+using (public.pode_ver_carteira_completa((select auth.uid())));
+```
+> ⚠️ A view é window-aware: `escalavel` agora dispara **no mesmo dia** pra tarefa com `janela_fim` e `tolerancia_dias=0` (o cron das 18h pega) — é o que faz "antes das 9h" virar cobrança no dia.
+
+- [ ] **Step 2: inline + Run. Step 3: validação**
+
+```sql
+select 'F2 BLOCO C OK' as status,
+  (select count(*) from pg_views where viewname='v_tarefas_estado' and definition ilike '%janela_fim%') as view_janela_ok,
+  (select count(*) from pg_views where viewname='v_tarefas_estado' and definition ilike '%requer_auditoria%') as view_audit_ok,
+  (select count(*) from pg_policies where tablename='tarefa_templates') as policies;
+```
+Expected: `view_janela_ok=1`, `view_audit_ok=1`, `policies=4`.
+
+- [ ] **Step 4: commit** `git commit -m "feat(tarefas-f2): BLOCO C — view window-aware + RLS de tarefa_templates"`
+
+---
+
+### Task 4: BLOCO D — trigger anti-bypass + RPCs (concluir/auditar) + materialização + cron
+
+**Files:** Create `supabase/migrations/20260601103000_tarefas_fase2_bloco_d.sql`
+
+> ⚠️ O gate anti-bypass depende do **owner das funções SECURITY DEFINER**. No Supabase (SQL Editor), funções nascem owned por `postgres` → dentro do DEFINER `current_user='postgres'`. **Confirme o owner** com `select proowner::regrole from pg_proc where proname='concluir_com_comprovacao';` após criar — se não for `postgres`, ajuste o allowlist do trigger.
+
+- [ ] **Step 1: SQL (trigger + 2 RPCs + materializador + cron)**
+
+```sql
+-- 20260601103000_tarefas_fase2_bloco_d.sql
+
+-- (1) Trigger anti-bypass: conclusão/colunas de prova só via RPC (owner) ou service_role.
+create or replace function public.tarefas_guard_comprovacao()
+returns trigger language plpgsql security invoker as $$
+begin
+  if coalesce(new.requer_comprovacao, false) then
+    if new.status = 'concluida' and old.status is distinct from 'concluida'
+       and current_user not in ('postgres','service_role','supabase_admin') then
+      raise exception 'Tarefa com comprovação só conclui via concluir_com_comprovacao()';
+    end if;
+    if current_user not in ('postgres','service_role','supabase_admin') and (
+         new.comprovacao_url       is distinct from old.comprovacao_url
+      or new.comprovacao_leitura   is distinct from old.comprovacao_leitura
+      or new.comprovacao_em        is distinct from old.comprovacao_em
+      or new.auditoria_status      is distinct from old.auditoria_status
+      or new.auditada_por          is distinct from old.auditada_por
+      or new.requer_comprovacao    is distinct from old.requer_comprovacao
+    ) then
+      raise exception 'Campos de comprovação/auditoria só mudam via RPC';
+    end if;
+  end if;
+  return new;
+end $$;
+drop trigger if exists trg_tarefas_guard_comprovacao on public.tarefas;
+create trigger trg_tarefas_guard_comprovacao
+  before update on public.tarefas
+  for each row execute function public.tarefas_guard_comprovacao();
+
+-- (2) Conclusão com prova (o enforcement). SECURITY DEFINER.
+create or replace function public.concluir_com_comprovacao(p_tarefa_id uuid, p_url text default null, p_leitura numeric default null)
+returns void language plpgsql security definer set search_path = public as $$
+declare t record; tt record; v_uid uuid := auth.uid(); v_audit text := 'nao_requer'; v_reinc int;
+begin
+  select * into t from public.tarefas where id = p_tarefa_id for update;
+  if not found then raise exception 'Tarefa não encontrada'; end if;
+  if not ( t.assigned_to = v_uid
+           or public.pode_ver_carteira_completa(v_uid)
+           or exists (select 1 from public.carteira_coverage cc where cc.covered_user_id=t.assigned_to
+                      and cc.covering_user_id=v_uid and cc.active and now()>=cc.valid_from
+                      and (cc.valid_until is null or now()<=cc.valid_until)) ) then
+    raise exception 'Sem permissão para concluir esta tarefa';
+  end if;
+  if t.status <> 'aberta' then raise exception 'Tarefa não está aberta (status=%)', t.status; end if;
+
+  if coalesce(t.requer_comprovacao,false) then
+    select * into tt from public.tarefa_templates where id = t.template_id;
+    if t.tipo_comprovacao in ('foto','foto_e_leitura') and (p_url is null or btrim(p_url)='') then
+      raise exception 'Foto de comprovação obrigatória';
+    end if;
+    if t.tipo_comprovacao in ('leitura','foto_e_leitura') then
+      if p_leitura is null then raise exception 'Leitura obrigatória'; end if;
+      if (tt.leitura_min is not null and p_leitura < tt.leitura_min)
+         or (tt.leitura_max is not null and p_leitura > tt.leitura_max) then
+        raise exception 'Leitura % fora da faixa [%, %]', p_leitura, tt.leitura_min, tt.leitura_max;
+      end if;
+    end if;
+    -- path-check: a url tem que conter {uid}/{tarefa_id}
+    if p_url is not null and position((v_uid::text || '/' || p_tarefa_id::text) in p_url) = 0 then
+      raise exception 'URL de comprovação não corresponde ao path da tarefa/usuário';
+    end if;
+    -- auditoria por exceção, decidida 1x
+    select count(*) into v_reinc from public.tarefas x
+      where x.template_id = t.template_id and x.assigned_to = t.assigned_to and x.id <> t.id
+        and x.created_at > now() - interval '30 days'
+        and (x.auditoria_status = 'reprovada' or x.status = 'aberta');
+    if coalesce(tt.alto_risco,false)
+       or v_reinc >= coalesce(tt.reincidente_limite, 3)
+       or (random()*100) < coalesce(tt.amostra_auditoria_pct, 10)
+    then v_audit := 'pendente'; else v_audit := 'dispensada'; end if;
+  end if;
+
+  update public.tarefas set
+    status='concluida', conclusao_origem='comprovacao',
+    comprovacao_url = coalesce(p_url, comprovacao_url),
+    comprovacao_leitura = coalesce(p_leitura, comprovacao_leitura),
+    comprovacao_em = now(), concluida_em = now(), concluida_por = v_uid,
+    auditoria_status = v_audit, updated_at = now()
+  where id = p_tarefa_id;
+  insert into public.tarefa_eventos (tarefa_id, tipo_evento, ator, payload)
+  values (p_tarefa_id, 'concluida_comprovacao', v_uid, jsonb_build_object('auditoria', v_audit, 'leitura', p_leitura));
+end $$;
+
+-- (3) Auditoria (gestor/master). Reprovar reabre + zera escalado_em.
+create or replace function public.auditar_tarefa(p_tarefa_id uuid, p_aprovar boolean, p_motivo text default null)
+returns void language plpgsql security definer set search_path = public as $$
+declare v_uid uuid := auth.uid();
+begin
+  if not public.pode_ver_carteira_completa(v_uid) then raise exception 'Só gestor/master audita'; end if;
+  if p_aprovar then
+    update public.tarefas set auditoria_status='aprovada', auditada_por=v_uid, auditada_em=now(), updated_at=now()
+      where id=p_tarefa_id and auditoria_status='pendente';
+    insert into public.tarefa_eventos (tarefa_id,tipo_evento,ator,payload)
+    values (p_tarefa_id,'auditoria_aprovada',v_uid,'{}'::jsonb);
+  else
+    update public.tarefas set auditoria_status='reprovada', auditada_por=v_uid, auditada_em=now(),
+      status='aberta', comprovacao_em=null, escalado_em=null, auditoria_motivo=p_motivo, updated_at=now()
+      where id=p_tarefa_id and auditoria_status='pendente';
+    insert into public.tarefa_eventos (tarefa_id,tipo_evento,ator,payload)
+    values (p_tarefa_id,'auditoria_reprovada',v_uid,jsonb_build_object('motivo',p_motivo));
+  end if;
+end $$;
+
+-- (4) Materialização (backfill 7d, idempotente, pula assignee sem perfil).
+create or replace function public.tarefas_materializar_recorrentes()
+returns void language plpgsql security definer set search_path = public as $$
+declare tpl record; d date; hoje date := (now() at time zone 'America/Sao_Paulo')::date; dispara boolean;
+begin
+  for tpl in select * from public.tarefa_templates where ativo loop
+    if not exists (select 1 from public.profiles p where p.user_id = tpl.assigned_to) then
+      insert into public.tarefa_eventos (tarefa_id, tipo_evento, ator, payload)
+      values (null, 'materializacao_pulada', null, jsonb_build_object('template_id', tpl.id, 'motivo', 'assignee_sem_perfil'));
+      continue;
+    end if;
+    d := hoje - 6;  -- backfill janela 7 dias
+    while d <= hoje loop
+      dispara := case tpl.cadencia
+        when 'diaria' then true
+        when 'dias_uteis' then (extract(dow from d) between 1 and 5)
+                               and not exists (select 1 from public.calendario_feriados f where f.data = d)
+        when 'semanal' then extract(dow from d)::int = any(tpl.dias_semana)
+        when 'dias_especificos' then extract(dow from d)::int = any(tpl.dias_semana)
+        else false end;
+      if dispara then
+        insert into public.tarefas
+          (descricao, categoria, customer_user_id, assigned_to, created_by, empresa, modo, due_date,
+           backstop_days, tolerancia_dias, auto_satisfy_mode, status, template_id,
+           requer_comprovacao, tipo_comprovacao, janela_fim, supervisor_user_id, auditoria_status)
+        select tpl.descricao, tpl.categoria, tpl.customer_user_id, tpl.assigned_to, tpl.created_by, tpl.empresa,
+           'data', d, 7, tpl.tolerancia_dias, 'off', 'aberta', tpl.id,
+           tpl.requer_comprovacao, tpl.tipo_comprovacao, tpl.janela_fim, tpl.supervisor_user_id,
+           case when tpl.requer_comprovacao then 'dispensada' else 'nao_requer' end
+        where not exists (select 1 from public.tarefas t
+                          where t.template_id = tpl.id and t.assigned_to = tpl.assigned_to and t.due_date = d);
+      end if;
+      d := d + 1;
+    end loop;
+  end loop;
+end $$;
+
+-- (5) Cron — chamada SQL local (sem net.http_post). ~06:00 BRT = 09:00 UTC.
+select cron.schedule('tarefas-materializar-recorrentes', '0 9 * * *', $$ select public.tarefas_materializar_recorrentes(); $$);
+```
+> ⚠️ `tarefa_eventos.tarefa_id` é NOT NULL na Fase 1 — o evento `materializacao_pulada` usa `tarefa_id=null` e quebraria. **Resolver no build:** ou logar em outra tabela/`fin_alertas`, ou tornar `tarefa_eventos.tarefa_id` nullable (preferível: a tabela de eventos passa a aceitar eventos de sistema sem tarefa). Incluir o `alter ... drop not null` aqui se for esse o caminho.
+
+- [ ] **Step 2: inline + Run. Step 3: validação estrutural**
+
+```sql
+select 'F2 BLOCO D OK' as status,
+  (select count(*) from pg_proc where proname in ('tarefas_guard_comprovacao','concluir_com_comprovacao','auditar_tarefa','tarefas_materializar_recorrentes')) as funcs,
+  (select count(*) from pg_trigger where tgname='trg_tarefas_guard_comprovacao') as trg,
+  (select count(*) from cron.job where jobname='tarefas-materializar-recorrentes') as cron,
+  (select proowner::regrole::text from pg_proc where proname='concluir_com_comprovacao') as owner_definer;
+```
+Expected: `funcs=4`, `trg=1`, `cron=1`, `owner_definer='postgres'` (confirma o allowlist do trigger).
+
+- [ ] **Step 4: validação FUNCIONAL (smoke):** crie um template `requer_comprovacao` + leitura, rode `select tarefas_materializar_recorrentes();`, confirme a instância criada; tente concluir via `update tarefas set status='concluida'` direto (deve **RAISE** pelo trigger); conclua via `select concluir_com_comprovacao(<id>, '<uid>/<id>/x.jpg', <leitura na faixa>)` (deve concluir); tente leitura fora da faixa (deve RAISE). Cleanup.
+
+- [ ] **Step 5: commit** `git commit -m "feat(tarefas-f2): BLOCO D — trigger anti-bypass + RPCs + materialização + cron"`
+
+---
+
+### Task 5: BLOCO E — bucket de Storage `tarefa-comprovacoes` + policies
+
+**Files:** Create `supabase/migrations/20260601104000_tarefas_fase2_bloco_e.sql`
+
+> Pode precisar ser feito pela UI/chat do Lovable (storage). O SQL abaixo funciona no SQL Editor na maioria dos projetos Supabase.
+
+- [ ] **Step 1: SQL**
+
+```sql
+-- 20260601104000_tarefas_fase2_bloco_e.sql
+insert into storage.buckets (id, name, public)
+values ('tarefa-comprovacoes', 'tarefa-comprovacoes', false)
+on conflict (id) do nothing;
+
+-- path = {auth.uid}/{tarefa_id}/arquivo  → operador escreve só no próprio prefixo
+create policy "tarefa_comprov_insert_own" on storage.objects for insert to authenticated
+with check (bucket_id='tarefa-comprovacoes' and (storage.foldername(name))[1] = (select auth.uid())::text);
+create policy "tarefa_comprov_select_own_ou_gestor" on storage.objects for select to authenticated
+using (bucket_id='tarefa-comprovacoes' and (
+  (storage.foldername(name))[1] = (select auth.uid())::text or public.pode_ver_carteira_completa((select auth.uid()))
+));
+```
+> Bucket **privado** → o front lê a prova pra auditoria via `createSignedUrl`, não `getPublicUrl`.
+
+- [ ] **Step 2: inline + Run. Step 3: validação** `select 'F2 BLOCO E OK' as status, exists(select 1 from storage.buckets where id='tarefa-comprovacoes') as bucket_ok, (select count(*) from pg_policies where tablename='objects' and policyname like 'tarefa_comprov%') as policies;` (Expected: `bucket_ok=true`, `policies=2`.)
+- [ ] **Step 4: commit** `git commit -m "feat(tarefas-f2): BLOCO E — bucket de comprovações + policies"`
+
+> **🟣 Handoff Milestone 1:** entregar A→B→C→D→E (1 bloco/mensagem, validação no fim), abrir PR com "ATENÇÃO: migration manual necessária". Só seguir pro Milestone 2 com A–E confirmados.
+
+---
+
+## Milestone 2 — Frontend (React). Verificação visual no Chrome do founder (o headless não renderiza a SPA).
+
+> Reusa muito da Fase 1 (`src/lib/tarefas/`, `src/hooks/useTarefas.ts`, `src/components/tarefas/MinhasTarefasCard.tsx`). RPC: `supabase.rpc('fn' as never, {...})` (padrão do repo, ex. `useDetalhesModal.ts`). Foto: `PhotoUpload.tsx` + `supabase.storage.from('tarefa-comprovacoes').upload(path,file)` (path `{uid}/{tarefaId}/{ts}.jpg`) + `createSignedUrl` pra ler.
+
+### Task 6: Tipos + hooks da Fase 2 (`useTarefasFase2`)
+**Files:** Create `src/lib/tarefas/templates-types.ts`; Create `src/hooks/useTarefasFase2.ts`
+- Tipos `TarefaTemplate` + `TarefaInstancia` (estende `TarefaEstado` c/ `tipo_comprovacao`/`comprovacao_leitura`/`auditoria_status`/`requer_auditoria`/`janela_fim`).
+- Hooks/mutations (mesmo padrão de `useTarefas.ts`, casts `as never` + sonner + `track`):
+  - `useTemplates()` (lista, gestor/master), `criarTemplate`/`editarTemplate`/`toggleTemplateAtivo`.
+  - `useMinhasRecorrentesHoje()` (instâncias do operador: `v_tarefas_estado` where `template_id is not null` + `responsavel_efetivo=uid` + status aberta/hoje).
+  - `concluirComComprovacao(tarefaId, url, leitura)` → `supabase.rpc('concluir_com_comprovacao' as never, { p_tarefa_id, p_url, p_leitura })`.
+  - `useProvasParaAuditar()` (`requer_auditoria=true`, gestor) + `auditarTarefa(id, aprovar, motivo)` → `supabase.rpc('auditar_tarefa' as never, {...})`.
+- [ ] TDD do que for puro (ex. validação client-side da faixa de leitura, montagem do path do Storage) em `src/lib/tarefas/__tests__/`. Verificação: `bun lint` + `heavy bunx tsc --noEmit -p tsconfig.app.json`. Commit.
+
+### Task 7: Fluxo de prova — `ComprovacaoDialog`
+**Files:** Create `src/components/tarefas/ComprovacaoDialog.tsx`
+- Dialog acionado ao concluir uma tarefa com `requer_comprovacao`. Conforme `tipo_comprovacao`: **foto** (reusa `PhotoUpload`/upload pro bucket no path `{uid}/{tarefaId}/...`) e/ou **leitura** (input numérico mostrando a faixa `[min,max]`+unidade, valida client-side antes de habilitar Salvar). Ao confirmar: faz o upload (se foto) → pega o path → chama `concluirComComprovacao(tarefaId, path, leitura)`. Erros da RPC (faixa/foto faltando) → toast. Verificação: lint+typecheck; manual no device. Commit.
+
+### Task 8: Card do operador em `/tintometrico`
+**Files:** Modify `src/pages/TintDashboard.tsx` (+ um `RecorrentesHojeCard` em `src/components/tarefas/`)
+- Card "Minhas tarefas de hoje" (espelha o `MinhasTarefasCard` da Fase 1): instâncias recorrentes do dia, atrasada (pós-janela) em vermelho, botão **Concluir** → abre `ComprovacaoDialog` (se requer prova) ou conclui direto (se não). Inserir no topo do `TintDashboard`. Verificação: manual no device. Commit.
+
+### Task 9: Auditoria + CRUD de templates (founder/gestor)
+**Files:** Create `src/pages/TarefasTemplates.tsx` + `src/components/tarefas/ProvasParaAuditar.tsx`; Modify `src/App.tsx` (rota `/tarefas/templates`) + `src/components/AppShell.tsx` (nav gated master/gestor)
+- **Provas pra auditar:** lista `requer_auditoria=true` com a foto (via `createSignedUrl`) + leitura + Aprovar/Reprovar (→ `auditarTarefa`) + contagem/idade do backlog (codex P2 #9). Pode viver na página de Tarefas do founder (Fase 1) como uma aba, ou na nova página.
+- **CRUD de templates:** criar atividade recorrente (área, cadência, dias, janela, tipo de prova, faixa+unidade, alto-risco, assignee, supervisor). Gate `isMaster||isGestorComercial`. Verificação: lint+typecheck+manual. Commit.
+
+---
+
+## Self-Review (rodada contra o spec)
+**Cobertura:** §3.2–3.7 (trava/auditoria/recorrência/escalação/persona) → BLOCOS A–E + Tasks 6–9. §4 modelo → A/B. §5 motor → C/D. §6 surfacing → 7/8/9. §7 RLS → C/E. ✅
+**2 furos achados ao planejar (não estavam no spec):** (1) `tarefas.customer_user_id` NOT NULL bloqueava ops sem cliente → BLOCO B torna nullable; (2) `tarefa_eventos.tarefa_id` NOT NULL quebra o evento de sistema "materializacao_pulada" → resolver no BLOCO D (nullable ou outra tabela). **Ambos flagueados nos blocos.**
+**Riscos de build:** owner das funções definer (confirmar `postgres` p/ o trigger anti-bypass); bucket de storage pode exigir o chat do Lovable; a checagem "assignee ativo" usa `profiles` (confirmar a coluna de aprovação/atividade da persona de ops).
+**Placeholder scan:** sem placeholders de lógica; os 2 furos têm resolução escrita. Milestone 2 referencia padrões reais (PhotoUpload, rpc, MinhasTarefasCard) — nível adequado dado o gate de build.
+
+## Execution Handoff
+🔴 **NÃO executar ainda** — o build espera a **verificação visual da Fase 1 em produção** (gate eu+codex). Quando a Fase 1 estiver validada:
+1. **Milestone 1** (você cola A→E no SQL Editor; eu entrego bloco a bloco) — resolver os 2 furos nos blocos A/B/D ao colar.
+2. **Milestone 2** via subagentes (subagent-driven), como na Fase 1.
+3. Verificação visual da Fase 2 no device (operador conclui com foto; gestor audita; tenta burlar via UPDATE direto → trigger bloqueia).

--- a/docs/superpowers/specs/2026-05-31-tarefas-enforcement-fase2-design.md
+++ b/docs/superpowers/specs/2026-05-31-tarefas-enforcement-fase2-design.md
@@ -1,0 +1,178 @@
+# Tarefas — Enforcement de Atividades (Fase 2) — Design
+
+> Status: **desenho aprovado pelo founder** (2026-05-31). Próximo passo: plano de implementação (`writing-plans`) — **mas a implementação só começa depois da Fase 1 ser verificada visualmente em produção** (decisão eu+codex: não empilhar código novo sobre base não-clicada).
+> Validado em 2 consults com o codex (decisão de sequência + menu de mecanismos de enforcement). Estende o motor da Fase 1 (`docs/superpowers/specs/2026-05-28-tarefas-cobranca-vendedoras-design.md`), não é módulo novo.
+
+## 1. Contexto e problema
+
+A Fase 1 entregou o motor de **atribuição + cobrança** de tarefas (founder atribui → lembra → auto-baixa quando há prova determinística → e-mail de cobrança). Pedido da Fase 2, intenção verbatim do founder: **"formas de obrigar as atividades de serem feitas, para todas as áreas"** (vendas, estoque, tinta, produção, compras). Exemplo-âncora: o operador de tinta tem que **regular a máquina todo dia** e **anexar foto da tela** como prova — não pode marcar feito sem isso ("travas / comprovações físicas").
+
+A Fase 1 cobre tarefa pontual atribuída a vendedora. Faltam dois eixos: **recorrência** (atividades que se repetem e não podem "sumir" se ignoradas) e **trava de comprovação** (não conclui sem evidência) — somados a **escalação com janela de tempo** pra fechar o ciclo de enforcement.
+
+## 2. Objetivo da Fase 2
+
+Estender o motor de Tarefas com **enforcement de execução**, geral (todas as áreas), ancorado em **3 mecanismos**:
+1. **Trava de comprovação** (carro-chefe): conclui só anexando prova (foto e/ou leitura validada contra faixa).
+2. **Recorrência + visibilidade do que faltou**: a tarefa reaparece todo período até ser feita; o pulado fica visível.
+3. **Escalação + janela de tempo**: prazo por janela (ex: "antes das 9h") + escalação reusando a Fase 1.
+
+**Modelo de trava (decisão do founder): "anexou = feito + auditoria por exceção"** — a prova destrava a conclusão **na hora** (sem fila de aprovação travando o operador); o sistema marca **pendente de auditoria** e o gestor/founder revê **só** exceções (alto-risco / reincidente / amostra aleatória).
+
+**Flagship = operador de tinta** (acesso já existe via `/tintometrico`). Motor geral; rollout por área conforme o acesso de cada uma for resolvido — igual à Fase 1 (engine + persona-flagship primeiro).
+
+### Não-objetivos (deferidos — codex)
+- **Bloqueio downstream duro** (ex: travar venda de tinta sem a calibração) — poderoso e perigoso; só selecionado, fica pra v2.
+- **Aprovação obrigatória em toda prova** — cria fila/gargalo; rejeitado em favor de auditoria por exceção.
+- **OCR como porteiro** — frágil; v1 usa foto + leitura digitada + faixa. OCR depois como "alerta de divergência", não gate.
+- **Leaderboard / streak / pontuação** — não obrigam nada, soam infantis no chão de fábrica.
+- **Dual-control (4-olhos)** — só pra dinheiro/segurança/crítico; fora da v1.
+- **Supervisor-tier real (por área)** — depende de fundação de acesso por área (greenfield); v1 tem só o **gancho** (coluna), null → founder.
+
+## 3. Decisões de produto (com rationale)
+
+### 3.1 Escopo & arquitetura
+Enforcement geral pra todas as áreas, **estendendo o motor de Tarefas** (mesma `tarefas` + mesma escalação), NÃO um módulo separado. Flagship tinta primeiro. (codex: "extend the existing engine, not a separate module".)
+
+### 3.2 Trava de comprovação — "anexou = feito + auditoria por exceção"
+- Por template: `requer_comprovacao` + `tipo_comprovacao` ∈ (`nenhuma`/`foto`/`leitura`/`foto_e_leitura`).
+- **Foto** → Supabase Storage (bucket dedicado) → `comprovacao_url`.
+- **Leitura** → valor numérico digitado, **validado contra faixa** do template (`leitura_min`/`leitura_max` + `leitura_unidade`) — **server-side** (não dá pra fabricar valor fora da faixa).
+- Concluir uma tarefa com `requer_comprovacao` **exige** a prova; sem ela, a conclusão é bloqueada (a trava). Com ela → `status='concluida'`, `conclusao_origem='comprovacao'`, `comprovacao_em=now()`.
+- **A conclusão NÃO espera aprovação** — destrava na hora. O `auditoria_status` é setado pra `pendente` ou `ok` conforme 3.4.
+
+### 3.3 Tipos de prova na v1
+- **Tinta (flagship):** `foto_e_leitura` — foto da tela + leitura da calibração validada contra a faixa.
+- Outras áreas: `foto` (estado físico) ou `leitura` conforme o template. `nenhuma` = tarefa recorrente sem trava (só recorrência+escalação).
+
+### 3.4 Auditoria por exceção (o que faz "obrigar" funcionar sem gargalo)
+Ao concluir uma tarefa com prova, `auditoria_status`:
+- **`pendente`** (entra na fila de auditoria do gestor/founder) se QUALQUER: template **alto-risco** (`alto_risco=true`), operador **reincidente** (≥ N instâncias recentes do mesmo template **vencidas/atrasadas** numa janela — N default **3** em 30 dias), ou **amostra aleatória** (default **10%**).
+- **`ok`** caso contrário (não precisa revisão).
+- Computado **server-side** no momento da conclusão (RPC `concluir_com_comprovacao`, 3.b do motor) — determinístico + a amostra usa um sorteio estável.
+- O gestor/founder audita: marca `ok` ou `reprovada` (+ motivo). **Reprovada reabre a tarefa** (`status='aberta'`, prova invalidada) e registra evento — é a consequência que combate compliance falsa.
+
+### 3.5 Recorrência
+- `tarefa_templates` define a atividade recorrente: `cadencia` ∈ (`diaria`/`dias_uteis`/`semanal`/`dias_especificos` + `dias_semana int[]`), `janela_inicio`/`janela_fim` (time, opcional), `ativo`.
+- Cron **`tarefas_materializar_recorrentes()`** (madrugada, ~06h BRT): pra cada template ativo cuja cadência **dispara hoje** e que **ainda não tem instância hoje**, cria uma `tarefas` (instância). Idempotente via **UNIQUE(`template_id`, `due_date`)**.
+- A instância é uma `tarefas` normal: `modo='data'`, `due_date=hoje (BRT)`, `janela_fim`, `requer_comprovacao`/`tipo_comprovacao`/faixa copiados do template, `auto_satisfy_mode='off'` (conclusão é por prova, não auto-detecção).
+
+### 3.6 Escalação + janela de tempo
+- **Reusa a escalação da Fase 1** (`tarefas_escalonamento_tick` → `fornecedor_alerta` → e-mail). Instância recorrente vencida + tolerância escala de graça (já é `tarefas`).
+- **Janela de tempo**: `janela_fim` (ex: 09:00) — a instância está "atrasada" se passou do `janela_fim` de hoje (BRT) sem concluir. (Refinamento sobre o `effective_due` da view, que hoje é por dia; ver 4.4.)
+- **Gancho de supervisor**: `tarefa_templates.supervisor_user_id` (nullable). v1: null → escala pro founder (como Fase 1). Quando existir acesso por área, a escalação roteia pro supervisor antes do founder.
+
+### 3.7 Persona / acesso (dependência)
+"Todas as áreas" precisa que os operadores tenham acesso ao app. Hoje: vendedoras (commercial_roles) e **operador de tinta via `/tintometrico`** acessam claramente; outras personas (estoque/produção) = "departamento" greenfield (CLAUDE.md §5). **v1 = flagship tinta** (operador vê suas tarefas recorrentes num card dentro do `/tintometrico`); engine geral; rollout por área conforme o acesso for resolvido.
+
+## 4. Modelo de dados
+
+### 4.1 `tarefa_templates` (definição recorrente — NOVA)
+| coluna | tipo | nota |
+|---|---|---|
+| `id` | uuid PK | (a `tarefas.template_id` já referencia isto — hook da Fase 1) |
+| `descricao` | text NOT NULL | |
+| `categoria` | text NOT NULL | reusa o CHECK de `tarefas.categoria` (+ `outro`) |
+| `area` | text NOT NULL | vendas/estoque/tinta/producao/compras/outro (categorização + futuro roteamento) |
+| `empresa` | text NOT NULL | |
+| `assigned_to` | uuid NOT NULL | operador responsável (v1: usuário específico) |
+| `cadencia` | text NOT NULL CHECK ∈ (diaria, dias_uteis, semanal, dias_especificos) | |
+| `dias_semana` | int[] | usado sse cadencia=dias_especificos/semanal (0=dom..6=sáb) |
+| `janela_inicio` | time | opcional |
+| `janela_fim` | time | opcional — fim da janela do dia (prazo intradiário) |
+| `tolerancia_dias` | int NOT NULL default 0 | recorrente costuma ser tolerância 0 (vence no dia) |
+| `requer_comprovacao` | boolean NOT NULL default false | |
+| `tipo_comprovacao` | text NOT NULL default 'nenhuma' CHECK ∈ (nenhuma, foto, leitura, foto_e_leitura) | |
+| `leitura_min` / `leitura_max` | numeric | faixa válida (sse tipo inclui leitura) |
+| `leitura_unidade` | text | ex: "g/L", "°C" |
+| `alto_risco` | boolean NOT NULL default false | sempre audita |
+| `amostra_auditoria_pct` | int NOT NULL default 10 | % de amostra aleatória |
+| `reincidente_limite` | int NOT NULL default 3 | faltas recentes p/ marcar reincidente |
+| `supervisor_user_id` | uuid | gancho de escalação (null → founder) |
+| `ativo` | boolean NOT NULL default true | |
+| `created_by` / `created_at` / `updated_at` | | |
+
+### 4.2 `tarefas` — colunas novas de prova/auditoria (na instância)
+Já existem (hooks Fase 1): `template_id`, `requer_comprovacao`, `comprovacao_url`. Adicionar:
+| coluna | tipo | nota |
+|---|---|---|
+| `tipo_comprovacao` | text | denormalizado do template na materialização |
+| `comprovacao_leitura` | numeric | valor digitado |
+| `comprovacao_em` | timestamptz | |
+| `janela_fim` | time | denormalizado (prazo intradiário) |
+| `auditoria_status` | text CHECK ∈ (nao_requer, pendente, ok, reprovada) default 'nao_requer' | |
+| `auditoria_motivo` | text | |
+| `auditada_por` | uuid | |
+| `auditada_em` | timestamptz | |
+| `conclusao_origem` | (estende o CHECK da Fase 1 c/ `'comprovacao'`) | |
+
+UNIQUE parcial **(`template_id`, `due_date`) WHERE template_id IS NOT NULL** — idempotência da materialização.
+
+### 4.3 Storage
+Bucket dedicado (ex: `tarefa-comprovacoes`), RLS: operador escreve a prova da própria tarefa; gestor/founder lê pra auditar. (Detalhe de policies no plano.)
+
+### 4.4 View `v_tarefas_estado` — refinar `atrasada` com janela intradiária
+Hoje `atrasada` = `now()::date(BRT) > effective_due`. Estender: se a instância tem `janela_fim`, fica atrasada quando `now()(BRT) > (due_date + janela_fim)` — i.e., passou da hora-limite do dia. Sem `janela_fim`, mantém o comportamento por dia. Adicionar derivados: `requer_auditoria` (auditoria_status='pendente').
+
+## 5. Motor (SQL puro + pg_cron + 1 RPC; sem edge function nova)
+
+### 5.1 Materialização (`tarefas_materializar_recorrentes()`, cron diário ~06h BRT)
+Pra cada `tarefa_templates` ativo cuja `cadencia` dispara **hoje (BRT)** e que **não tem instância com `due_date=hoje`**: INSERT `tarefas` (instância) copiando descricao/categoria/empresa/assigned_to/requer_comprovacao/tipo_comprovacao/janela_fim/tolerancia_dias + `template_id`, `modo='data'`, `due_date=hoje`, `auto_satisfy_mode='off'`, `auditoria_status='nao_requer'`. `on conflict (template_id, due_date) do nothing`. Cadência: diaria=sempre; dias_uteis=seg-sex; semanal/dias_especificos=`extract(dow) = any(dias_semana)`.
+
+### 5.2 Conclusão com prova (RPC `concluir_com_comprovacao(p_tarefa_id, p_url, p_leitura)`, SECURITY DEFINER)
+Ponto de **enforcement** (server-side):
+1. Carrega a tarefa + valida que o caller é o responsável (ou cobertura/gestor).
+2. Se `requer_comprovacao`: exige `comprovacao_url` (se tipo inclui foto) e/ou `comprovacao_leitura` na **faixa** `[leitura_min, leitura_max]` (se tipo inclui leitura) — senão `RAISE` (trava).
+3. Computa `auditoria_status`: `pendente` se `alto_risco` OR reincidente (≥`reincidente_limite` instâncias do template vencidas/atrasadas em 30d) OR amostra (`random()*100 < amostra_auditoria_pct` — sorteio no momento) ; senão `ok`.
+4. UPDATE `tarefas` (status=concluida, conclusao_origem='comprovacao', comprovacao_url/leitura, comprovacao_em, auditoria_status) + evento `concluida_comprovacao`.
+
+### 5.3 Auditoria (RPC `auditar_tarefa(p_tarefa_id, p_aprovar, p_motivo)`, gestor/founder)
+`ok` → `auditoria_status='ok'`, registra auditada_por/em. `reprovada` → `auditoria_status='reprovada'` + **reabre** (`status='aberta'`, limpa comprovacao_em — a prova fica registrada no evento p/ histórico) + evento `auditoria_reprovada`. (Consequência real contra compliance falsa.)
+
+### 5.4 Escalação — reusa a Fase 1
+`tarefas_escalonamento_tick` já escala `tarefas` vencidas+tolerância. Instâncias recorrentes entram de graça. Ajuste mínimo: a view considerar `janela_fim` no `atrasada`/`escalavel` (4.4). Supervisor: quando `template.supervisor_user_id` existir, rotear (v1 null→founder).
+
+## 6. Surfacing
+
+### 6.1 Operador (flagship: card no `/tintometrico`)
+"Minhas tarefas de hoje" (padrão do `MinhasTarefasCard` da Fase 1): instâncias recorrentes do dia, atrasada em vermelho. Concluir abre o **fluxo de prova**: foto (PhotoUpload → Storage) e/ou leitura (input numérico com a faixa visível) → chama `concluir_com_comprovacao`. Sem a prova, o botão Concluir fica desabilitado/explica a trava.
+
+### 6.2 Founder / gestor
+- **"Provas pra auditar"**: lista de `auditoria_status='pendente'` (+ amostra), com a foto/leitura + Aprovar/Reprovar (→ `auditar_tarefa`).
+- **Templates**: CRUD de `tarefa_templates` (criar atividade recorrente: área, cadência, janela, tipo de prova, faixa, alto-risco). Gated master/gestor.
+- Escalações de recorrentes chegam pelo mesmo e-mail da Fase 1.
+
+## 7. RLS
+- `tarefa_templates`: SELECT = gestor/master OR `assigned_to=auth.uid()` (operador vê os templates dele); IUD = gestor/master (`pode_ver_carteira_completa` ou equivalente de gestão — confirmar helper p/ áreas não-comerciais).
+- `tarefas` instâncias: já cobertas pela RLS da Fase 1 (assigned_to / cobertura / gestor).
+- Storage bucket: operador escreve a prova da própria tarefa; gestor/founder lê.
+- RPCs SECURITY DEFINER fazem o gate de quem pode concluir/auditar.
+
+## 8. Composição com a Fase 1
+- Mesma `tarefas` + mesma view + mesma escalação + mesmo e-mail. Fase 2 = `tarefa_templates` + materialização + RPCs de prova/auditoria + colunas de prova/auditoria na instância + janela intradiária na view.
+- Mantém o princípio: conclusão por **ação explícita** (aqui, prova) — nunca auto-close silencioso. Auto-detecção (matcher) **não** se aplica a recorrentes (auto_satisfy_mode='off').
+
+## 9. Edge cases
+- **Operador não fez até o fim do dia**: instância fica atrasada (janela_fim) → escala. No dia seguinte, NOVA instância é materializada (a de ontem continua aberta+atrasada, visível — "o pulado não some").
+- **Reprovada na auditoria**: reabre; se já passou a janela, volta atrasada → re-cobra (mas `escalado_em` fire-once já disparou — decisão: reabrir limpa `escalado_em`? Sim, pra re-escalar se continuar parada. Detalhe no plano.)
+- **Template desativado**: para de materializar; instâncias abertas seguem o ciclo.
+- **Leitura fora da faixa**: RPC `RAISE` → não conclui (a trava).
+- **Foto faltando** (tipo inclui foto): RPC `RAISE`.
+- **Fuso**: materialização + janela + atrasada tudo em `America/Sao_Paulo` (igual Fase 1).
+- **Idempotência**: UNIQUE(template_id, due_date) → cron pode rerodar.
+
+## 10. O que NÃO entra (anti-scope-creep)
+Ver §2 Não-objetivos. Resumo: bloqueio downstream, aprovação-em-tudo, OCR-gate, leaderboard/streak, dual-control, supervisor-tier real — todos deferidos. Fase 2 fica em: **recorrência + trava de prova (foto/leitura+faixa) + auditoria por exceção + escalação com janela**, flagship tinta.
+
+## 11. Trabalho de migração (constraint do Lovable)
+Blocos SQL via SQL Editor (manual), no padrão da Fase 1:
+- **BLOCO A**: `tarefa_templates` + CHECKs + índices.
+- **BLOCO B**: colunas novas em `tarefas` (prova/auditoria/janela) + estende CHECK `conclusao_origem` c/ `'comprovacao'` + UNIQUE parcial (template_id, due_date).
+- **BLOCO C**: refina a view `v_tarefas_estado` (janela intradiária + `requer_auditoria`) + RLS de `tarefa_templates`.
+- **BLOCO D**: RPCs `concluir_com_comprovacao` / `auditar_tarefa` + função/cron `tarefas_materializar_recorrentes` + `cron.schedule`.
+- **BLOCO E (infra)**: bucket de Storage `tarefa-comprovacoes` + policies (provavelmente via chat do Lovable / SQL de storage).
+Cada bloco com query de validação. PR com **"ATENÇÃO: migration manual necessária"**.
+
+## 12. Registro de revisão com o codex
+- **Consult (sequência):** começar pelo **design** da Fase 2 (trabalho reversível) enquanto a Fase 1 aguarda verificação visual; **não implementar código** até a Fase 1 ser clicada (não empilhar sobre base não-verificada). Deferir o fast-follow "editar tarefa" (YAGNI).
+- **Consult (menu de enforcement):** ancorar em 3 mecanismos (trava de prova / recorrência / escalação+janela); **bloqueio downstream** seletivo (deferido v1); **foto = "anexou=feito + auditoria por exceção"** (não aprovação-em-tudo, que vira gargalo); **OCR** deferido (foto+leitura+faixa na v1); **gimmicks** (leaderboard/streak/dual-control) fora; risco-mestre = **compliance falsa** → combater com consequência real (reprovar reabre), visibilidade do pulado, auditoria de exceção, e enforcement só no que importa. Estender o motor da Fase 1, não criar módulo.
+- **Pendente:** passe adversário do codex **neste spec** (como na Fase 1) antes de escrever o plano.

--- a/docs/superpowers/specs/2026-05-31-tarefas-enforcement-fase2-design.md
+++ b/docs/superpowers/specs/2026-05-31-tarefas-enforcement-fase2-design.md
@@ -1,7 +1,7 @@
 # Tarefas — Enforcement de Atividades (Fase 2) — Design
 
 > Status: **desenho aprovado pelo founder** (2026-05-31). Próximo passo: plano de implementação (`writing-plans`) — **mas a implementação só começa depois da Fase 1 ser verificada visualmente em produção** (decisão eu+codex: não empilhar código novo sobre base não-clicada).
-> Validado em 2 consults com o codex (decisão de sequência + menu de mecanismos de enforcement). Estende o motor da Fase 1 (`docs/superpowers/specs/2026-05-28-tarefas-cobranca-vendedoras-design.md`), não é módulo novo.
+> Validado em 3 consults com o codex (decisão de sequência + menu de mecanismos de enforcement + passe adversário neste spec). Estende o motor da Fase 1 (`docs/superpowers/specs/2026-05-28-tarefas-cobranca-vendedoras-design.md`), não é módulo novo.
 
 ## 1. Contexto e problema
 
@@ -64,6 +64,8 @@ Ao concluir uma tarefa com prova, `auditoria_status`:
 ### 3.7 Persona / acesso (dependência)
 "Todas as áreas" precisa que os operadores tenham acesso ao app. Hoje: vendedoras (commercial_roles) e **operador de tinta via `/tintometrico`** acessam claramente; outras personas (estoque/produção) = "departamento" greenfield (CLAUDE.md §5). **v1 = flagship tinta** (operador vê suas tarefas recorrentes num card dentro do `/tintometrico`); engine geral; rollout por área conforme o acesso for resolvido.
 
+> ⚠️ **Risco-mestre (codex): resolução de POSSE, não recorrência.** O difícil de "todas as áreas" não é repetir tarefa — é *quem* recebe a tarefa hoje, quem cobre ausência, quem audita, quem é escalado, e o que acontece quando a atribuição da área muda. A v1 **assume single-assignee** (`tarefa_templates.assigned_to` = um operador) + os ganchos (`supervisor_user_id`, cobertura via `responsavel_efetivo`) — o que é honesto pro flagship tinta (1 operador). **Roteamento real por área/papel** (template → "quem for o operador de tinta hoje", rodízio de turno, supervisor-por-área) é trabalho de produto futuro, dependente da fundação de "departamento". Se isso ficar implícito, o módulo "funciona" mas gera tarefa errada pra pessoa errada quando escalar pra outras áreas. Registrado como a fronteira consciente da v1.
+
 ## 4. Modelo de dados
 
 ### 4.1 `tarefa_templates` (definição recorrente — NOVA)
@@ -99,16 +101,17 @@ Já existem (hooks Fase 1): `template_id`, `requer_comprovacao`, `comprovacao_ur
 | `comprovacao_leitura` | numeric | valor digitado |
 | `comprovacao_em` | timestamptz | |
 | `janela_fim` | time | denormalizado (prazo intradiário) |
-| `auditoria_status` | text CHECK ∈ (nao_requer, pendente, ok, reprovada) default 'nao_requer' | |
+| `auditoria_status` | text CHECK ∈ (nao_requer, dispensada, pendente, aprovada, reprovada) default 'nao_requer' | `nao_requer`=sem prova; `dispensada`=prova exigida mas não sorteada (auto-ok); `pendente`/`aprovada`/`reprovada`=fila de auditoria (codex P3 #15) |
 | `auditoria_motivo` | text | |
 | `auditada_por` | uuid | |
 | `auditada_em` | timestamptz | |
+| `supervisor_user_id` | uuid | **copiado do template na materialização** (codex P3 #16 — se o template mudar depois, a posse histórica não fica ambígua) |
 | `conclusao_origem` | (estende o CHECK da Fase 1 c/ `'comprovacao'`) | |
 
-UNIQUE parcial **(`template_id`, `due_date`) WHERE template_id IS NOT NULL** — idempotência da materialização.
+UNIQUE parcial **(`template_id`, `assigned_to`, `due_date`) WHERE template_id IS NOT NULL** — idempotência da materialização. ⚠️ Inclui `assigned_to` (codex P1 #2): `(template_id, due_date)` sozinho sub-materializaria se um template tiver vários operadores.
 
 ### 4.3 Storage
-Bucket dedicado (ex: `tarefa-comprovacoes`), RLS: operador escreve a prova da própria tarefa; gestor/founder lê pra auditar. (Detalhe de policies no plano.)
+Bucket dedicado (ex: `tarefa-comprovacoes`), **privado**. Convenção de path inclui o id do usuário+tarefa (ex: `{auth.uid}/{tarefa_id}/{arquivo}`) e a policy do bucket valida que o path bate com o caller (codex P2 #12 — senão `comprovacao_url` poderia apontar pro arquivo de outro). RLS: operador escreve só no próprio prefixo; gestor/founder lê pra auditar. A RPC `concluir_com_comprovacao` valida que a `comprovacao_url` aponta pro path da tarefa/usuário (não aceita URL arbitrária). (Detalhe de policies no plano.)
 
 ### 4.4 View `v_tarefas_estado` — refinar `atrasada` com janela intradiária
 Hoje `atrasada` = `now()::date(BRT) > effective_due`. Estender: se a instância tem `janela_fim`, fica atrasada quando `now()(BRT) > (due_date + janela_fim)` — i.e., passou da hora-limite do dia. Sem `janela_fim`, mantém o comportamento por dia. Adicionar derivados: `requer_auditoria` (auditoria_status='pendente').
@@ -116,20 +119,29 @@ Hoje `atrasada` = `now()::date(BRT) > effective_due`. Estender: se a instância 
 ## 5. Motor (SQL puro + pg_cron + 1 RPC; sem edge function nova)
 
 ### 5.1 Materialização (`tarefas_materializar_recorrentes()`, cron diário ~06h BRT)
-Pra cada `tarefa_templates` ativo cuja `cadencia` dispara **hoje (BRT)** e que **não tem instância com `due_date=hoje`**: INSERT `tarefas` (instância) copiando descricao/categoria/empresa/assigned_to/requer_comprovacao/tipo_comprovacao/janela_fim/tolerancia_dias + `template_id`, `modo='data'`, `due_date=hoje`, `auto_satisfy_mode='off'`, `auditoria_status='nao_requer'`. `on conflict (template_id, due_date) do nothing`. Cadência: diaria=sempre; dias_uteis=seg-sex; semanal/dias_especificos=`extract(dow) = any(dias_semana)`.
+Pra cada `tarefa_templates` ativo, gera as instâncias faltantes de cada **dia de disparo** entre `max(last_materialized, hoje - 7d)` e **hoje (BRT)** (⚠️ **backfill** — codex P1 #5: se o cron pular um dia, sem instância não há linha atrasada → o enforcement quebra; janela máx 7d evita explosão). INSERT `tarefas` (instância) copiando descricao/categoria/empresa/assigned_to/requer_comprovacao/tipo_comprovacao/leitura_min/max/janela_fim/tolerancia_dias/**supervisor_user_id** + `template_id`, `modo='data'`, `due_date=<dia>`, `auto_satisfy_mode='off'`, `auditoria_status = case when requer_comprovacao then 'dispensada' else 'nao_requer' end`. `on conflict (template_id, assigned_to, due_date) do nothing` (idempotente). Cadência (em BRT): `diaria`=todo dia; `dias_uteis`=seg-sex **excluindo feriados via `calendario_feriados`** (codex P2 #7 — a tabela + `dias_uteis_entre()` já existem no repo); `semanal`/`dias_especificos`=`extract(dow) = any(dias_semana)`.
+- ⚠️ **Assignee inativo/sem acesso (codex P1 #6):** materializa só se `assigned_to` está ativo (perfil/role válido); senão **pula + registra um evento de exceção** (não cria tarefa impossível que vira só ruído de escalação). Cobertura (`carteira_coverage`) aplica via `responsavel_efetivo` da view pra exibição/escalação, como na Fase 1.
 
 ### 5.2 Conclusão com prova (RPC `concluir_com_comprovacao(p_tarefa_id, p_url, p_leitura)`, SECURITY DEFINER)
 Ponto de **enforcement** (server-side):
 1. Carrega a tarefa + valida que o caller é o responsável (ou cobertura/gestor).
-2. Se `requer_comprovacao`: exige `comprovacao_url` (se tipo inclui foto) e/ou `comprovacao_leitura` na **faixa** `[leitura_min, leitura_max]` (se tipo inclui leitura) — senão `RAISE` (trava).
-3. Computa `auditoria_status`: `pendente` se `alto_risco` OR reincidente (≥`reincidente_limite` instâncias do template vencidas/atrasadas em 30d) OR amostra (`random()*100 < amostra_auditoria_pct` — sorteio no momento) ; senão `ok`.
-4. UPDATE `tarefas` (status=concluida, conclusao_origem='comprovacao', comprovacao_url/leitura, comprovacao_em, auditoria_status) + evento `concluida_comprovacao`.
+2. **Bloqueia re-conclusão (codex P1 #4):** se `status<>'aberta'` → `RAISE` (não dá pra re-chamar numa tarefa já concluída — senão a operadora re-sorteia a amostra até não cair na auditoria).
+3. Se `requer_comprovacao`: exige `comprovacao_url` (se tipo inclui foto) e/ou `comprovacao_leitura` na **faixa** `[leitura_min, leitura_max]` (se tipo inclui leitura) — senão `RAISE` (a trava).
+4. Computa `auditoria_status` **uma única vez** e persiste atômico: `pendente` se `alto_risco` OR **reincidente** OR amostra (`random()*100 < amostra_auditoria_pct`); senão `dispensada`. (Definição **fixa** de reincidente — codex P1 #4/P2 #10: `≥ reincidente_limite` instâncias **deste template + assignee** com `status='aberta' AND atrasada` ou `reprovada` numa janela de 30d; depende do backfill 5.1 manter as faltas como linhas persistidas.)
+5. UPDATE `tarefas` (status=concluida, conclusao_origem='comprovacao', comprovacao_url/leitura, comprovacao_em, auditoria_status) + evento `concluida_comprovacao`.
+> **Leitura na faixa ≠ leitura real (codex P2 #8):** validar `[min,max]` só prova plausibilidade, não que a medição foi feita. Por isso template **alto-risco exige `foto_e_leitura`** (a foto é o cross-check); leitura sozinha é auto-atestado consciente.
 
 ### 5.3 Auditoria (RPC `auditar_tarefa(p_tarefa_id, p_aprovar, p_motivo)`, gestor/founder)
-`ok` → `auditoria_status='ok'`, registra auditada_por/em. `reprovada` → `auditoria_status='reprovada'` + **reabre** (`status='aberta'`, limpa comprovacao_em — a prova fica registrada no evento p/ histórico) + evento `auditoria_reprovada`. (Consequência real contra compliance falsa.)
+`aprovar` → `auditoria_status='aprovada'`, registra auditada_por/em. `reprovar` → `auditoria_status='reprovada'` + **reabre** (`status='aberta'`, limpa comprovacao_em — a prova fica registrada no evento p/ histórico) + **`escalado_em = null`** (⚠️ codex P1 #3: sem zerar, a tarefa reaberta nunca re-escala porque a Fase 1 é fire-once) + evento `auditoria_reprovada`. (A reprovação reabrir = a **consequência real** contra compliance falsa.)
 
 ### 5.4 Escalação — reusa a Fase 1
 `tarefas_escalonamento_tick` já escala `tarefas` vencidas+tolerância. Instâncias recorrentes entram de graça. Ajuste mínimo: a view considerar `janela_fim` no `atrasada`/`escalavel` (4.4). Supervisor: quando `template.supervisor_user_id` existir, rotear (v1 null→founder).
+
+### 5.5 Anti-bypass — a trava forçada NO BANCO (codex P1 #1, crítico)
+A RPC de prova **não basta**: a RLS da Fase 1 permite a `assigned_to` dar `UPDATE` na própria `tarefas` → a operadora poderia `update tarefas set status='concluida'` **direto via PostgREST**, pulando a prova. Enforcement em duas camadas:
+1. **Trigger `BEFORE UPDATE` em `tarefas`** (`SECURITY INVOKER`, roda como o caller): se a transição é `status → 'concluida'` numa tarefa com `requer_comprovacao=true`, **só permite quando `current_user` é o owner da função definer** (no Supabase, `postgres`) **ou `service_role`** — i.e., a conclusão veio de dentro de `concluir_com_comprovacao` (SECURITY DEFINER, roda como `postgres`). UPDATE direto de um usuário `authenticated` → `RAISE` (bloqueado). NÃO usar GUC tipo `app.via_rpc` (cliente pode spoofar — codex); o gate é por `current_user`.
+2. **Travar as colunas sensíveis** de mutação por usuário comum: `comprovacao_url`, `comprovacao_leitura`, `comprovacao_em`, `auditoria_status`, `auditada_por/em`, `requer_comprovacao` — o mesmo trigger rejeita mudança nelas fora do owner/`service_role` (senão a operadora forja os campos de prova e depois conclui). Conclusão **sem** prova (tarefa sem `requer_comprovacao`) segue livre pela RLS normal.
+> Isso fecha o buraco: a única porta pra concluir uma tarefa com-prova é a RPC, que valida a evidência. `service_role` (crons/auditoria) e o owner passam; `authenticated` direto não.
 
 ## 6. Surfacing
 
@@ -137,7 +149,7 @@ Ponto de **enforcement** (server-side):
 "Minhas tarefas de hoje" (padrão do `MinhasTarefasCard` da Fase 1): instâncias recorrentes do dia, atrasada em vermelho. Concluir abre o **fluxo de prova**: foto (PhotoUpload → Storage) e/ou leitura (input numérico com a faixa visível) → chama `concluir_com_comprovacao`. Sem a prova, o botão Concluir fica desabilitado/explica a trava.
 
 ### 6.2 Founder / gestor
-- **"Provas pra auditar"**: lista de `auditoria_status='pendente'` (+ amostra), com a foto/leitura + Aprovar/Reprovar (→ `auditar_tarefa`).
+- **"Provas pra auditar"**: lista de `auditoria_status='pendente'`, com a foto/leitura + Aprovar/Reprovar (→ `auditar_tarefa`). **Visibilidade de backlog (codex P2 #9):** mostrar contagem de pendentes + idade da mais antiga, pra "auditoria por exceção" não virar "auditoria nunca". (Escalar auto a pendente >N dias = v2.)
 - **Templates**: CRUD de `tarefa_templates` (criar atividade recorrente: área, cadência, janela, tipo de prova, faixa, alto-risco). Gated master/gestor.
 - Escalações de recorrentes chegam pelo mesmo e-mail da Fase 1.
 
@@ -168,11 +180,11 @@ Blocos SQL via SQL Editor (manual), no padrão da Fase 1:
 - **BLOCO A**: `tarefa_templates` + CHECKs + índices.
 - **BLOCO B**: colunas novas em `tarefas` (prova/auditoria/janela) + estende CHECK `conclusao_origem` c/ `'comprovacao'` + UNIQUE parcial (template_id, due_date).
 - **BLOCO C**: refina a view `v_tarefas_estado` (janela intradiária + `requer_auditoria`) + RLS de `tarefa_templates`.
-- **BLOCO D**: RPCs `concluir_com_comprovacao` / `auditar_tarefa` + função/cron `tarefas_materializar_recorrentes` + `cron.schedule`.
+- **BLOCO D**: RPCs `concluir_com_comprovacao` / `auditar_tarefa` + função/cron `tarefas_materializar_recorrentes` + `cron.schedule` + **trigger anti-bypass `BEFORE UPDATE` em `tarefas`** (§5.5).
 - **BLOCO E (infra)**: bucket de Storage `tarefa-comprovacoes` + policies (provavelmente via chat do Lovable / SQL de storage).
 Cada bloco com query de validação. PR com **"ATENÇÃO: migration manual necessária"**.
 
 ## 12. Registro de revisão com o codex
 - **Consult (sequência):** começar pelo **design** da Fase 2 (trabalho reversível) enquanto a Fase 1 aguarda verificação visual; **não implementar código** até a Fase 1 ser clicada (não empilhar sobre base não-verificada). Deferir o fast-follow "editar tarefa" (YAGNI).
 - **Consult (menu de enforcement):** ancorar em 3 mecanismos (trava de prova / recorrência / escalação+janela); **bloqueio downstream** seletivo (deferido v1); **foto = "anexou=feito + auditoria por exceção"** (não aprovação-em-tudo, que vira gargalo); **OCR** deferido (foto+leitura+faixa na v1); **gimmicks** (leaderboard/streak/dual-control) fora; risco-mestre = **compliance falsa** → combater com consequência real (reprovar reabre), visibilidade do pulado, auditoria de exceção, e enforcement só no que importa. Estender o motor da Fase 1, não criar módulo.
-- **Pendente:** passe adversário do codex **neste spec** (como na Fase 1) antes de escrever o plano.
+- **Consult (passe adversário no spec):** **P1 incorporados** — (1) **anti-bypass por trigger no banco** (RLS deixava `assigned_to` concluir direto via PostgREST, furando a trava → trigger gate por `current_user`=owner/`service_role` + travar colunas de prova; §5.5); (2) UNIQUE `(template_id, assigned_to, due_date)`; (3) reabrir zera `escalado_em`; (4) amostra decidida 1× + bloqueia re-concluir; (5) materializador **com backfill** (janela 7d) — sem instância não há linha atrasada; (6) assignee inativo → pula+loga, não cria tarefa impossível. **P2/P3 incorporados:** `dias_uteis` via `calendario_feriados` existente; leitura=auto-atestado (alto-risco exige foto+leitura); visibilidade de backlog da auditoria; path do Storage validado por dono; status de auditoria renomeados (nao_requer/dispensada/pendente/aprovada/reprovada); supervisor copiado na instância; janela overnight = constraint. **Risco-mestre registrado:** resolução de POSSE pra "todas as áreas" é o difícil; v1 = single-assignee + ganchos, roteamento por área/papel é futuro (§3.7).


### PR DESCRIPTION
Spec de design da **Fase 2** do módulo Tarefas: enforcement de execução (todas as áreas), ancorado em **recorrência + trava de comprovação + escalação com janela**. Estende o motor da Fase 1 (#545), não é módulo novo.

**Decisões-chave:** trava = 'anexou = feito + auditoria por exceção' (sem fila de aprovação); flagship = operador de tinta; OCR/leaderboard/dual-control/bloqueio-downstream/supervisor-tier-real **deferidos**.

**Hardening (passe adversário do codex):** trigger anti-bypass no banco (RLS deixava concluir direto via PostgREST, furando a trava); UNIQUE (template_id, assigned_to, due_date); reabrir zera escalado_em; amostra decidida 1×; materializador com backfill; assignee inativo pula+loga; dias_uteis via calendario_feriados; storage path validado.

⚠️ **Doc-only** (zero código). Por decisão eu+codex, a **implementação só começa depois da Fase 1 ser verificada visualmente em produção** — não empilhar código sobre base não-clicada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)