### PR TITLE
feat(des): aba de configuração de meta trimestral (+rota /admin/des/configuracao)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ deno.lock
 # Serena MCP local project cache
 .serena/
 .superpowers/
+.context/codex-session-id

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -403,6 +403,7 @@ const App = () => (
                 <Route path="gestao/saude-dados" element={<SaudeDados />} />
                 <Route path="admin/ajuda" element={<AdminAjuda />} />
                 <Route path="admin/des/trimestre-atual" element={<AdminDesTrimestreAtual />} />
+                <Route path="admin/des/configuracao" element={<AdminDesTrimestreAtual />} />
                 <Route path="admin/notificacoes" element={<AdminNotificacoes />} />
                 <Route path="admin/portal-sayerlack" element={<AdminPortalSayerlack />} />
                 <Route path="admin/sip-credentials" element={<AdminVendorSipCredentials />} />

--- a/src/components/des/ConfiguracaoTab.tsx
+++ b/src/components/des/ConfiguracaoTab.tsx
@@ -1,0 +1,192 @@
+// Aba de Configuração do DES: cadastra/edita a meta trimestral (des_meta_empresa).
+// Master-only (gate de UI + RLS). Reusa o schema existente — sem migration.
+import { Info, Lock, Save } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import type { Props } from "./configuracao/types";
+import { useConfiguracaoMeta } from "./configuracao/useConfiguracaoMeta";
+
+export function ConfiguracaoTab({ empresa, ano: anoAtual, trimestre: trimestreAtual }: Props) {
+  const {
+    isMaster,
+    ano,
+    setAno,
+    trimestre,
+    setTrimestre,
+    anos,
+    metaInput,
+    setMetaInput,
+    faixaInput,
+    setFaixaInput,
+    observacoes,
+    setObservacoes,
+    metaOk,
+    faixaOk,
+    faixaVazia,
+    periodo,
+    existe,
+    saving,
+    isLoading,
+    salvar,
+  } = useConfiguracaoMeta(empresa, anoAtual, trimestreAtual);
+
+  const editavel = isMaster && !saving;
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-base font-medium">Meta trimestral · {empresa}</CardTitle>
+          <p className="text-xs text-muted-foreground">
+            Meta de faturamento por trimestre. Ancora o gap, o histórico e a posição ao vivo do DES.
+          </p>
+        </CardHeader>
+        <CardContent className="space-y-5">
+          {/* Seletor de período */}
+          <div className="flex flex-wrap items-end gap-3">
+            <div className="space-y-1.5">
+              <Label className="text-xs text-muted-foreground">Ano</Label>
+              <Select value={String(ano)} onValueChange={(v) => setAno(Number(v))}>
+                <SelectTrigger className="w-[110px] h-9">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {anos.map((a) => (
+                    <SelectItem key={a} value={String(a)}>
+                      {a}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-1.5">
+              <Label className="text-xs text-muted-foreground">Trimestre</Label>
+              <Select value={String(trimestre)} onValueChange={(v) => setTrimestre(Number(v))}>
+                <SelectTrigger className="w-[110px] h-9">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {[1, 2, 3, 4].map((t) => (
+                    <SelectItem key={t} value={String(t)}>
+                      T{t}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+
+          {/* Aviso de período não-corrente */}
+          {periodo !== "corrente" && (
+            <div className="flex items-start gap-2 rounded-md border border-status-warning/30 bg-status-warning/5 p-3">
+              <Info className="h-4 w-4 text-status-warning mt-0.5 shrink-0" />
+              <p className="text-xs text-foreground">
+                Editando um trimestre {periodo === "passado" ? "passado" : "futuro"}.
+                {periodo === "passado" &&
+                  " Alterar a meta muda o histórico, os gráficos e a posição derivada."}
+              </p>
+            </div>
+          )}
+
+          {isLoading ? (
+            <Skeleton className="h-48 w-full" />
+          ) : (
+            <>
+              {!isMaster && (
+                <div className="flex items-start gap-2 rounded-md border border-border bg-muted/40 p-3">
+                  <Lock className="h-4 w-4 text-muted-foreground mt-0.5 shrink-0" />
+                  <p className="text-xs text-muted-foreground">
+                    Somente um usuário master pode cadastrar ou editar metas. Você pode visualizar.
+                  </p>
+                </div>
+              )}
+
+              {/* Meta de faturamento */}
+              <div className="space-y-1.5">
+                <Label htmlFor="meta-faturamento">Meta de faturamento (R$)</Label>
+                <Input
+                  id="meta-faturamento"
+                  inputMode="decimal"
+                  placeholder="Ex: 400.840"
+                  value={metaInput}
+                  onChange={(e) => setMetaInput(e.target.value)}
+                  disabled={!editavel}
+                  className="max-w-xs"
+                />
+                {metaInput.trim() !== "" && !metaOk && (
+                  <p className="text-xs text-status-error">
+                    Valor inválido. Use um número maior que zero.
+                  </p>
+                )}
+              </div>
+
+              {/* Faixa-alvo */}
+              <div className="space-y-1.5">
+                <Label htmlFor="faixa-alvo">
+                  Faixa DES-alvo{" "}
+                  <span className="font-normal text-muted-foreground">(opcional)</span>
+                </Label>
+                <Input
+                  id="faixa-alvo"
+                  inputMode="numeric"
+                  placeholder="Ex: 3"
+                  value={faixaInput}
+                  onChange={(e) => setFaixaInput(e.target.value)}
+                  disabled={!editavel}
+                  className="w-[120px]"
+                />
+                {!faixaVazia && !faixaOk && (
+                  <p className="text-xs text-status-error">
+                    Use um número inteiro ≥ 1, ou deixe em branco.
+                  </p>
+                )}
+                <p className="text-xs text-muted-foreground">
+                  Número da faixa que se quer atingir no trimestre.
+                </p>
+              </div>
+
+              {/* Observações */}
+              <div className="space-y-1.5">
+                <Label htmlFor="meta-obs">
+                  Observações <span className="font-normal text-muted-foreground">(opcional)</span>
+                </Label>
+                <Textarea
+                  id="meta-obs"
+                  rows={3}
+                  placeholder="Contexto da meta, premissas, etc."
+                  value={observacoes}
+                  onChange={(e) => setObservacoes(e.target.value)}
+                  disabled={!editavel}
+                  className="max-w-xl"
+                />
+              </div>
+
+              <div className="flex flex-wrap items-center gap-3 pt-1">
+                <Button onClick={salvar} disabled={!editavel || !metaOk || !faixaOk}>
+                  <Save className="h-4 w-4 mr-2" />
+                  {saving ? "Salvando..." : existe ? "Atualizar meta" : "Cadastrar meta"}
+                </Button>
+                {existe && (
+                  <span className="text-xs text-muted-foreground">
+                    Já existe meta para {empresa} · {ano} · T{trimestre}.
+                  </span>
+                )}
+              </div>
+            </>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/des/configuracao/__tests__/format.test.ts
+++ b/src/components/des/configuracao/__tests__/format.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseMetaInput,
+  parseFaixaInput,
+  isMetaValida,
+  classificarPeriodo,
+  anosSelecionaveis,
+  formatMetaParaInput,
+} from "../format";
+
+describe("parseMetaInput", () => {
+  it("parseia inteiro simples", () => {
+    expect(parseMetaInput("400840")).toBe(400840);
+  });
+  it("trata ponto como separador de milhar (pt-BR)", () => {
+    expect(parseMetaInput("400.840")).toBe(400840);
+    expect(parseMetaInput("1.234.567")).toBe(1234567);
+  });
+  it("trata vírgula como separador decimal", () => {
+    expect(parseMetaInput("400.840,50")).toBe(400840.5);
+    expect(parseMetaInput("400840,50")).toBe(400840.5);
+    expect(parseMetaInput("1234,5")).toBe(1234.5);
+  });
+  it("ignora prefixo R$ e espaços", () => {
+    expect(parseMetaInput("R$ 400.840,00")).toBe(400840);
+    expect(parseMetaInput("  400840  ")).toBe(400840);
+  });
+  it("retorna null para vazio, só-símbolo ou não-numérico", () => {
+    expect(parseMetaInput("")).toBeNull();
+    expect(parseMetaInput("   ")).toBeNull();
+    expect(parseMetaInput("abc")).toBeNull();
+    expect(parseMetaInput("R$")).toBeNull();
+  });
+  it("REJEITA formato malformado em vez de corromper (money-safe)", () => {
+    // Casos onde uma 'limpeza' ingênua salvaria OUTRO valor (bug pego pelo codex).
+    expect(parseMetaInput("1.2.3")).toBeNull(); // milhar inválido (viraria 123)
+    expect(parseMetaInput("1e6")).toBeNull(); // notação científica (viraria 16)
+    expect(parseMetaInput("abc400")).toBeNull(); // lixo + dígitos (viraria 400)
+    expect(parseMetaInput("1,2,3")).toBeNull(); // múltiplas vírgulas
+    expect(parseMetaInput("400840.50")).toBeNull(); // ponto decimal en-US (viraria 40084050)
+    expect(parseMetaInput("1.23")).toBeNull(); // ponto não-milhar (3 dígitos exigidos)
+  });
+});
+
+describe("isMetaValida", () => {
+  it("aceita valor positivo", () => {
+    expect(isMetaValida(400840)).toBe(true);
+    expect(isMetaValida(0.01)).toBe(true);
+  });
+  it("rejeita null, zero, negativo e NaN", () => {
+    expect(isMetaValida(null)).toBe(false);
+    expect(isMetaValida(0)).toBe(false);
+    expect(isMetaValida(-5)).toBe(false);
+    expect(isMetaValida(NaN)).toBe(false);
+  });
+});
+
+describe("parseFaixaInput", () => {
+  it("parseia inteiro >= 1", () => {
+    expect(parseFaixaInput("3")).toBe(3);
+    expect(parseFaixaInput("10")).toBe(10);
+  });
+  it("retorna null para vazio (campo opcional)", () => {
+    expect(parseFaixaInput("")).toBeNull();
+    expect(parseFaixaInput("   ")).toBeNull();
+  });
+  it("REJEITA malformado e zero em vez de corromper", () => {
+    expect(parseFaixaInput("abc")).toBeNull();
+    expect(parseFaixaInput("1.5")).toBeNull(); // viraria 15
+    expect(parseFaixaInput("abc3")).toBeNull(); // viraria 3
+    expect(parseFaixaInput("0")).toBeNull(); // faixa < 1 inválida
+    expect(parseFaixaInput("-2")).toBeNull();
+  });
+});
+
+describe("classificarPeriodo", () => {
+  it("identifica o trimestre corrente", () => {
+    expect(classificarPeriodo(2026, 2, 2026, 2)).toBe("corrente");
+  });
+  it("identifica passado (mesmo ano e ano anterior)", () => {
+    expect(classificarPeriodo(2026, 1, 2026, 2)).toBe("passado");
+    expect(classificarPeriodo(2025, 4, 2026, 1)).toBe("passado");
+  });
+  it("identifica futuro (mesmo ano e próximo ano)", () => {
+    expect(classificarPeriodo(2026, 3, 2026, 2)).toBe("futuro");
+    expect(classificarPeriodo(2027, 1, 2026, 4)).toBe("futuro");
+  });
+});
+
+describe("formatMetaParaInput", () => {
+  it("formata número salvo em pt-BR (sem símbolo de moeda)", () => {
+    expect(formatMetaParaInput(400840)).toBe("400.840");
+    expect(formatMetaParaInput(400840.5)).toBe("400.840,5");
+  });
+  it("retorna vazio para null/undefined/NaN", () => {
+    expect(formatMetaParaInput(null)).toBe("");
+    expect(formatMetaParaInput(undefined)).toBe("");
+    expect(formatMetaParaInput(NaN)).toBe("");
+  });
+  it("é o inverso de parseMetaInput (round-trip, até 2 casas)", () => {
+    for (const n of [400840, 1234.56, 1000000, 0.5, 999]) {
+      expect(parseMetaInput(formatMetaParaInput(n))).toBe(n);
+    }
+  });
+});
+
+describe("anosSelecionaveis", () => {
+  it("retorna anoAtual-3 .. anoAtual+1, mais recente primeiro", () => {
+    expect(anosSelecionaveis(2026)).toEqual([2027, 2026, 2025, 2024, 2023]);
+  });
+  it("sempre contém o ano atual", () => {
+    expect(anosSelecionaveis(2030)).toContain(2030);
+  });
+});

--- a/src/components/des/configuracao/format.ts
+++ b/src/components/des/configuracao/format.ts
@@ -1,0 +1,67 @@
+// Helpers puros da aba de Configuração de meta trimestral do DES.
+// Parsing de entrada (moeda pt-BR, faixa), validação e classificação de período.
+// Testados em __tests__/format.test.ts (TDD).
+
+export type Periodo = "corrente" | "passado" | "futuro";
+
+/**
+ * Converte um input de moeda pt-BR para número.
+ * Convenção pt-BR: vírgula = decimal, ponto = separador de milhar.
+ * Ex: "R$ 400.840,50" -> 400840.5 · "1.234.567" -> 1234567.
+ * Retorna null para vazio/só-símbolo/não-numérico.
+ */
+export function parseMetaInput(raw: string): number | null {
+  if (raw == null) return null;
+  // Remove só o prefixo de moeda e espaços; NÃO "limpa" outros caracteres —
+  // limpar transformava lixo em outro número (ex.: "abc400" -> 400, "1.2.3" -> 123).
+  const s = String(raw).trim().replace(/\s/g, "").replace(/R\$/gi, "");
+  if (!s) return null;
+  // Formato pt-BR aceito: dígitos puros, OU milhar agrupado \d{1,3}(.\d{3})+,
+  // com decimal opcional por vírgula (1-2 casas). Qualquer outra coisa é inválida.
+  if (!/^(\d+|\d{1,3}(\.\d{3})+)(,\d{1,2})?$/.test(s)) return null;
+  const n = Number(s.replace(/\./g, "").replace(",", "."));
+  return Number.isFinite(n) ? n : null;
+}
+
+/** Formata um número salvo de volta para o input pt-BR (inverso de parseMetaInput). */
+export function formatMetaParaInput(n: number | null | undefined): string {
+  if (n == null || !Number.isFinite(n)) return "";
+  return n.toLocaleString("pt-BR", { maximumFractionDigits: 2 });
+}
+
+/**
+ * Parseia o nº da faixa-alvo. Retorna um inteiro >= 1, ou null para vazio/malformado/<1.
+ * NÃO limpa lixo (ex.: "abc3" e "1.5" são inválidos, não viram 3/15). O consumidor
+ * distingue "vazio" (opcional, ok) de "malformado" (bloqueia) via o input cru.
+ */
+export function parseFaixaInput(raw: string): number | null {
+  const s = String(raw ?? "").trim();
+  if (!s || !/^\d+$/.test(s)) return null;
+  const n = Number(s);
+  return Number.isInteger(n) && n >= 1 ? n : null;
+}
+
+/** Meta válida = número finito positivo (a coluna é NOT NULL e > 0 faz sentido de negócio). */
+export function isMetaValida(n: number | null): boolean {
+  return n != null && Number.isFinite(n) && n > 0;
+}
+
+/** Classifica o trimestre selecionado relativo ao corrente (para o aviso de edição). */
+export function classificarPeriodo(
+  ano: number,
+  trimestre: number,
+  anoAtual: number,
+  trimestreAtual: number,
+): Periodo {
+  const sel = ano * 4 + trimestre;
+  const atual = anoAtual * 4 + trimestreAtual;
+  if (sel === atual) return "corrente";
+  return sel < atual ? "passado" : "futuro";
+}
+
+/** Anos oferecidos no seletor: anoAtual+1 .. anoAtual-3, do mais recente ao mais antigo. */
+export function anosSelecionaveis(anoAtual: number): number[] {
+  const anos: number[] = [];
+  for (let a = anoAtual + 1; a >= anoAtual - 3; a--) anos.push(a);
+  return anos;
+}

--- a/src/components/des/configuracao/types.ts
+++ b/src/components/des/configuracao/types.ts
@@ -1,0 +1,17 @@
+// Tipos da aba de Configuração de meta trimestral do DES.
+
+export interface Props {
+  empresa: string;
+  ano: number;
+  trimestre: number;
+}
+
+export interface MetaRow {
+  id: number;
+  empresa: string;
+  ano: number;
+  trimestre: number;
+  meta_faturamento: number;
+  faixa_des_objetivo: number | null;
+  observacoes: string | null;
+}

--- a/src/components/des/configuracao/useConfiguracaoMeta.ts
+++ b/src/components/des/configuracao/useConfiguracaoMeta.ts
@@ -1,0 +1,147 @@
+// Lógica da aba de Configuração de meta trimestral do DES.
+// Carrega a meta de (empresa, ano, trimestre), preenche o form, e faz upsert
+// (a unique constraint uq_meta em (empresa, ano, trimestre) torna o upsert idempotente).
+// Master-only no client (a RLS master-only de des_meta_empresa é a autoridade real).
+import { useEffect, useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { supabase } from "@/integrations/supabase/client";
+import { useAuth } from "@/contexts/AuthContext";
+import {
+  parseMetaInput,
+  parseFaixaInput,
+  isMetaValida,
+  classificarPeriodo,
+  anosSelecionaveis,
+  formatMetaParaInput,
+  type Periodo,
+} from "./format";
+import type { MetaRow } from "./types";
+
+export function useConfiguracaoMeta(empresa: string, anoAtual: number, trimestreAtual: number) {
+  const { isMaster } = useAuth();
+  const qc = useQueryClient();
+
+  const [ano, setAno] = useState(anoAtual);
+  const [trimestre, setTrimestre] = useState(trimestreAtual);
+  const [metaInput, setMetaInput] = useState("");
+  const [faixaInput, setFaixaInput] = useState("");
+  const [observacoes, setObservacoes] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  const metaQuery = useQuery({
+    queryKey: ["des-config-meta", empresa, ano, trimestre],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from("des_meta_empresa")
+        .select("id, empresa, ano, trimestre, meta_faturamento, faixa_des_objetivo, observacoes")
+        .eq("empresa", empresa)
+        .eq("ano", ano)
+        .eq("trimestre", trimestre)
+        .maybeSingle();
+      if (error) throw error;
+      return (data ?? null) as MetaRow | null;
+    },
+  });
+
+  const loaded = metaQuery.data ?? null;
+
+  // Preenche (ou limpa) o form a partir da meta carregada para o período selecionado.
+  useEffect(() => {
+    if (metaQuery.isLoading) return;
+    setMetaInput(formatMetaParaInput(loaded?.meta_faturamento));
+    setFaixaInput(loaded?.faixa_des_objetivo != null ? String(loaded.faixa_des_objetivo) : "");
+    setObservacoes(loaded?.observacoes ?? "");
+  }, [loaded, metaQuery.isLoading]);
+
+  const metaParsed = parseMetaInput(metaInput);
+  const faixaVazia = faixaInput.trim() === "";
+  const faixaParsed = parseFaixaInput(faixaInput);
+  const metaOk = isMetaValida(metaParsed);
+  // Faixa é opcional: vazio é ok; se preenchida, precisa parsear para inteiro >= 1.
+  const faixaOk = faixaVazia || faixaParsed != null;
+  const periodo: Periodo = classificarPeriodo(ano, trimestre, anoAtual, trimestreAtual);
+  const existe = !!loaded;
+
+  // Rascunho não salvo (form difere da meta carregada) — guarda a troca de período.
+  const dirty =
+    metaInput !== formatMetaParaInput(loaded?.meta_faturamento) ||
+    faixaInput !== (loaded?.faixa_des_objetivo != null ? String(loaded.faixa_des_objetivo) : "") ||
+    observacoes !== (loaded?.observacoes ?? "");
+
+  function confirmarTroca(): boolean {
+    return !dirty || window.confirm("Há alterações não salvas. Descartá-las e trocar de período?");
+  }
+  function trocarAno(v: number) {
+    if (v !== ano && confirmarTroca()) setAno(v);
+  }
+  function trocarTrimestre(v: number) {
+    if (v !== trimestre && confirmarTroca()) setTrimestre(v);
+  }
+
+  async function salvar() {
+    if (!isMaster) {
+      toast.error("Apenas um usuário master pode cadastrar metas.");
+      return;
+    }
+    if (metaParsed == null || !isMetaValida(metaParsed)) {
+      toast.error("Informe um valor de meta válido (maior que zero).");
+      return;
+    }
+    if (!faixaOk) {
+      toast.error("Faixa-alvo inválida (use um inteiro ≥ 1, ou deixe em branco).");
+      return;
+    }
+    setSaving(true);
+    try {
+      const { error } = await supabase.from("des_meta_empresa").upsert(
+        {
+          empresa,
+          ano,
+          trimestre,
+          meta_faturamento: metaParsed,
+          faixa_des_objetivo: faixaParsed,
+          observacoes: observacoes.trim() || null,
+        },
+        { onConflict: "empresa,ano,trimestre" },
+      );
+      if (error) throw error;
+
+      toast.success(existe ? "Meta atualizada." : "Meta cadastrada.");
+      // Invalida tudo que depende da meta no DES (histórico, posição ao vivo, checkin).
+      qc.invalidateQueries({
+        predicate: (q) =>
+          typeof q.queryKey[0] === "string" && (q.queryKey[0] as string).startsWith("des-"),
+      });
+    } catch (err) {
+      console.error(err);
+      const msg = err instanceof Error ? err.message : "desconhecido";
+      toast.error("Erro ao salvar meta: " + msg);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return {
+    isMaster,
+    ano,
+    setAno: trocarAno,
+    trimestre,
+    setTrimestre: trocarTrimestre,
+    anos: anosSelecionaveis(anoAtual),
+    metaInput,
+    setMetaInput,
+    faixaInput,
+    setFaixaInput,
+    observacoes,
+    setObservacoes,
+    metaOk,
+    faixaOk,
+    faixaVazia,
+    periodo,
+    existe,
+    saving,
+    isLoading: metaQuery.isLoading,
+    salvar,
+  };
+}

--- a/src/pages/AdminDesTrimestreAtual.tsx
+++ b/src/pages/AdminDesTrimestreAtual.tsx
@@ -1,10 +1,12 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { useLocation } from "react-router-dom";
 import { ChevronRight } from "lucide-react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { PosicaoAtualTab } from "@/components/des/PosicaoAtualTab";
 import { CheckinQualitativoTab } from "@/components/des/CheckinQualitativoTab";
 import { SimuladorTab } from "@/components/des/SimuladorTab";
 import { HistoricoTab } from "@/components/des/HistoricoTab";
+import { ConfiguracaoTab } from "@/components/des/ConfiguracaoTab";
 
 const EMPRESA = "OBEN";
 
@@ -17,8 +19,19 @@ function getCurrentQuarter(): { ano: number; trimestre: number } {
 }
 
 export default function AdminDesTrimestreAtual() {
-  const [tab, setTab] = useState("posicao");
+  const location = useLocation();
+  // A rota /admin/des/configuracao é um atalho que abre direto a aba Configuração.
+  const [tab, setTab] = useState(
+    location.pathname.includes("/configuracao") ? "config" : "posicao",
+  );
   const { ano, trimestre } = getCurrentQuarter();
+
+  // Sincroniza a aba com a rota nos dois sentidos, mesmo se o componente não
+  // remontar ao navegar entre /trimestre-atual e /configuracao (mesmo element).
+  // Trocar de aba manualmente não muda o pathname, então não dispara este efeito.
+  useEffect(() => {
+    setTab(location.pathname.includes("/configuracao") ? "config" : "posicao");
+  }, [location.pathname]);
 
   return (
     <div className="container mx-auto p-4 lg:p-6 space-y-6">
@@ -34,11 +47,12 @@ export default function AdminDesTrimestreAtual() {
       </div>
 
       <Tabs value={tab} onValueChange={setTab} className="space-y-6">
-        <TabsList className="grid w-full grid-cols-2 md:grid-cols-4 max-w-2xl">
+        <TabsList className="grid w-full grid-cols-3 md:grid-cols-5 max-w-3xl">
           <TabsTrigger value="posicao">Posição atual</TabsTrigger>
           <TabsTrigger value="checkin">Checkin qualitativo</TabsTrigger>
           <TabsTrigger value="simulador">Simulador</TabsTrigger>
           <TabsTrigger value="historico">Histórico</TabsTrigger>
+          <TabsTrigger value="config">Configuração</TabsTrigger>
         </TabsList>
 
         <TabsContent value="posicao" className="space-y-6 mt-6">
@@ -55,6 +69,10 @@ export default function AdminDesTrimestreAtual() {
 
         <TabsContent value="historico" className="space-y-6 mt-6">
           <HistoricoTab empresa={EMPRESA} ano={ano} trimestre={trimestre} />
+        </TabsContent>
+
+        <TabsContent value="config" className="space-y-6 mt-6">
+          <ConfiguracaoTab empresa={EMPRESA} ano={ano} trimestre={trimestre} />
         </TabsContent>
       </Tabs>
     </div>


### PR DESCRIPTION
## Contexto

O empty-state do `HistoricoTab` (DES) tinha um botão "Cadastrar meta trimestral" apontando para `/admin/des/configuracao` — rota que **nunca existiu** (link morto). Não era rota-errada-para-página-existente: era um fluxo prometido e nunca construído.

A investigação confirmou que o **backend já estava 100% pronto** — tabela `des_meta_empresa` (`meta_faturamento`, `faixa_des_objetivo`, `observacoes`), RLS master-only, unique `uq_meta (empresa, ano, trimestre)`, e a view `v_des_posicao_trimestre_ao_vivo` que calcula gap-vs-meta. Faltava só a tela de escrita (hoje a meta só entra via SQL Editor manual). O `help-utils.ts` já mapeava a rota → era placeholder de feature planejada.

Decisão tomada **eu + codex** (consult): construir, escopo mínimo.

## O que muda

- **5º tab "Configuração"** em `AdminDesTrimestreAtual`; a rota `/admin/des/configuracao` vira um **atalho** que abre esse tab. O link morto passa a funcionar **sem tocar no botão**.
- **Escopo só `des_meta_empresa`** (meta + faixa-alvo + observações). **Nada** do motor de desconto (faixas/critérios = money-path, fora de escopo).
- **`.upsert(onConflict: empresa,ano,trimestre)`** — a constraint `uq_meta` já existe → **ZERO migration, nada a fazer no Lovable**.
- **Master-only** (gate `isMaster` na UI + RLS é a autoridade). **OBEN-only** (espelha todo o DES; o programa é OBEN×Sayerlack).
- Helpers puros com **TDD (19 testes vitest)**: parse de moeda pt-BR money-safe, faixa, classificação de período, round-trip de formatação.
- Guard de **rascunho não-salvo** ao trocar período; aba sincronizada à rota nos dois sentidos.

## Qualidade

- **Codex review do código** pegou 2 P1 reais: os parsers "limpavam" input malformado em vez de rejeitar, salvando **outro valor** no money-path (`"abc400"`→400, `"400840.50"`→40084050). Corrigidos com validação de formato estrita + TDD reproduzindo exatamente os casos.
- typecheck strict **0** · lint **0** · test **2048/2048** · build **OK**.

## Pendências

- ⚠️ **Sem migration / sem deploy** — client-side puro, reusa o schema existente.
- QA visual no device (o headless do projeto não renderiza a SPA).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
