### PR TITLE
feat(customer360): aba Visitas — histórico de visitas com resultado

### DIFF
--- a/docs/superpowers/plans/2026-06-01-customer360-aba-visitas.md
+++ b/docs/superpowers/plans/2026-06-01-customer360-aba-visitas.md
@@ -1,0 +1,377 @@
+# Aba "Visitas" no Customer 360 — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Aba "Visitas" no Customer 360 (`Customer360View`) mostrando o histórico de visitas do cliente (`route_visits`) com resultado/receita/notas + um resumo (total · conversão · receita). Read-only, sem backend.
+
+**Architecture:** Helpers puros `visitResultLabel`/`resumoVisitas` (TDD) → hook `useCustomerVisits` (mirror `useCustomerCalls`) → `CustomerVisitsTab` (mirror `CustomerCallsTab`) → aba no `Customer360View`. Reusa `route_visits` (colunas já existentes, RLS já endurecida no #340).
+
+**Tech Stack:** React, @tanstack/react-query, Supabase JS, shadcn/ui, date-fns, vitest.
+
+**Spec:** `docs/superpowers/specs/2026-06-01-customer360-aba-visitas-design.md`
+
+---
+
+## File Structure
+- **Create:** `src/lib/visitas/visit-result.ts` + teste `src/lib/visitas/__tests__/visit-result.test.ts`.
+- **Create:** `src/hooks/useCustomerVisits.ts`.
+- **Create:** `src/components/customer/CustomerVisitsTab.tsx`.
+- **Modify:** `src/components/adminCustomers/Customer360View.tsx` — adicionar a aba.
+
+---
+
+## Task 1: Helpers puros `visitResultLabel` + `resumoVisitas` (TDD)
+
+**Files:**
+- Create: `src/lib/visitas/visit-result.ts`
+- Test: `src/lib/visitas/__tests__/visit-result.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// src/lib/visitas/__tests__/visit-result.test.ts
+import { describe, it, expect } from 'vitest';
+import { visitResultLabel, resumoVisitas } from '../visit-result';
+
+describe('visitResultLabel', () => {
+  it('mapeia cada código da taxonomia', () => {
+    expect(visitResultLabel('pedido_fechado')).toEqual({ label: 'Pedido fechado', emoji: '✅', tone: 'success' });
+    expect(visitResultLabel('interesse').tone).toBe('info');
+    expect(visitResultLabel('sem_interesse').tone).toBe('error');
+    expect(visitResultLabel('ausente').tone).toBe('warning');
+    expect(visitResultLabel('reagendar').emoji).toBe('📅');
+  });
+  it('null/desconhecido → "Sem resultado"/muted', () => {
+    expect(visitResultLabel(null)).toEqual({ label: 'Sem resultado', emoji: '—', tone: 'muted' });
+    expect(visitResultLabel('xyz').tone).toBe('muted');
+  });
+});
+
+describe('resumoVisitas', () => {
+  it('total, comResultado, fechados, taxa (fechados/comResultado), receita', () => {
+    const r = resumoVisitas([
+      { result: 'pedido_fechado', revenue_generated: 1000 },
+      { result: 'pedido_fechado', revenue_generated: 500 },
+      { result: 'sem_interesse', revenue_generated: null },
+      { result: null, revenue_generated: null },
+    ]);
+    expect(r).toEqual({ total: 4, comResultado: 3, fechados: 2, taxaConversao: 2 / 3, receitaTotal: 1500 });
+  });
+  it('sem visitas com resultado → taxa null', () => {
+    expect(resumoVisitas([{ result: null, revenue_generated: null }]).taxaConversao).toBeNull();
+  });
+  it('lista vazia → zeros e taxa null', () => {
+    expect(resumoVisitas([])).toEqual({ total: 0, comResultado: 0, fechados: 0, taxaConversao: null, receitaTotal: 0 });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/lucassardenberg/Projetos/afiacao/.claude/worktrees/customer360-visitas && heavy bun run test -- visit-result`
+Expected: FAIL — `Cannot find module '../visit-result'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+// src/lib/visitas/visit-result.ts
+export type VisitResultTone = 'success' | 'info' | 'error' | 'warning' | 'muted';
+export interface VisitResultLabel {
+  label: string;
+  emoji: string;
+  tone: VisitResultTone;
+}
+
+/** Código de `route_visits.result` → rótulo + emoji + tom (tokens text-status-*). */
+export function visitResultLabel(result: string | null): VisitResultLabel {
+  switch (result) {
+    case 'pedido_fechado': return { label: 'Pedido fechado', emoji: '✅', tone: 'success' };
+    case 'interesse':      return { label: 'Interesse',      emoji: '🤔', tone: 'info' };
+    case 'sem_interesse':  return { label: 'Sem interesse',  emoji: '❌', tone: 'error' };
+    case 'ausente':        return { label: 'Ausente',        emoji: '🚫', tone: 'warning' };
+    case 'reagendar':      return { label: 'Reagendar',      emoji: '📅', tone: 'warning' };
+    default:               return { label: 'Sem resultado',  emoji: '—',  tone: 'muted' };
+  }
+}
+
+export interface VisitResumoRow {
+  result: string | null;
+  revenue_generated: number | null;
+}
+export interface VisitResumo {
+  total: number;
+  comResultado: number;
+  fechados: number;
+  taxaConversao: number | null;
+  receitaTotal: number;
+}
+
+/** Resumo do histórico. taxaConversao = fechados ÷ visitas COM resultado (null se base 0). */
+export function resumoVisitas(rows: VisitResumoRow[]): VisitResumo {
+  const total = rows.length;
+  const comResultado = rows.filter((r) => r.result != null).length;
+  const fechados = rows.filter((r) => r.result === 'pedido_fechado').length;
+  const taxaConversao = comResultado > 0 ? fechados / comResultado : null;
+  const receitaTotal = rows.reduce((s, r) => s + (r.revenue_generated ?? 0), 0);
+  return { total, comResultado, fechados, taxaConversao, receitaTotal };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /Users/lucassardenberg/Projetos/afiacao/.claude/worktrees/customer360-visitas && heavy bun run test -- visit-result`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/visitas/visit-result.ts src/lib/visitas/__tests__/visit-result.test.ts
+git commit -m "feat(customer360-visitas): helpers visitResultLabel + resumoVisitas (TDD)"
+```
+
+---
+
+## Task 2: Hook `useCustomerVisits`
+
+**Files:**
+- Create: `src/hooks/useCustomerVisits.ts`
+
+Espelha `src/hooks/useCustomerCalls.ts` (useQuery + colunas específicas + enriquecimento de nomes).
+
+- [ ] **Step 1: Escrever o hook**
+
+```ts
+// src/hooks/useCustomerVisits.ts
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+
+export interface CustomerVisitRow {
+  id: string;
+  visited_by: string;
+  visit_date: string;
+  check_in_at: string | null;
+  check_out_at: string | null;
+  result: string | null;
+  notes: string | null;
+  revenue_generated: number | null;
+  order_created: boolean | null;
+  visitedByName: string;
+}
+
+/**
+ * Histórico de visitas (route_visits) de um cliente, com resultado/receita/notas.
+ * RLS de route_visits (endurecida no #340) filtra own/carteira/gestor — degradação honesta.
+ * Read-only.
+ */
+export function useCustomerVisits(customerId: string | null) {
+  return useQuery({
+    queryKey: ['customer-visits', customerId],
+    enabled: !!customerId,
+    staleTime: 60_000,
+    gcTime: 5 * 60_000,
+    queryFn: async (): Promise<CustomerVisitRow[]> => {
+      if (!customerId) return [];
+      const { data, error } = await supabase
+        .from('route_visits')
+        .select('id, visited_by, visit_date, check_in_at, check_out_at, result, notes, revenue_generated, order_created')
+        .eq('customer_user_id', customerId)
+        .order('check_in_at', { ascending: false })
+        .limit(50);
+      if (error) throw new Error(error.message);
+
+      const rows = data ?? [];
+      if (rows.length === 0) return [];
+
+      const ids = [...new Set(rows.map((r) => r.visited_by).filter(Boolean))];
+      const { data: profs } = await supabase
+        .from('profiles')
+        .select('user_id, name')
+        .in('user_id', ids);
+      const nameMap = new Map((profs ?? []).map((p) => [p.user_id, p.name]));
+
+      return rows.map((r) => ({ ...r, visitedByName: nameMap.get(r.visited_by) || 'Vendedor' }));
+    },
+  });
+}
+```
+
+- [ ] **Step 2: Verificar typecheck**
+
+Run: `cd /Users/lucassardenberg/Projetos/afiacao/.claude/worktrees/customer360-visitas && heavy bun run typecheck`
+Expected: exit 0. (Confirma o `.select(...)` contra `route_visits` e o shape de `CustomerVisitRow`.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/hooks/useCustomerVisits.ts
+git commit -m "feat(customer360-visitas): hook useCustomerVisits (route_visits por cliente + nomes)"
+```
+
+---
+
+## Task 3: Componente `CustomerVisitsTab`
+
+**Files:**
+- Create: `src/components/customer/CustomerVisitsTab.tsx`
+
+- [ ] **Step 1: Escrever o componente**
+
+```tsx
+// src/components/customer/CustomerVisitsTab.tsx
+import { Loader2 } from 'lucide-react';
+import { useCustomerVisits } from '@/hooks/useCustomerVisits';
+import { visitResultLabel, resumoVisitas } from '@/lib/visitas/visit-result';
+import { formatBRL, formatPctMaybe } from '@/components/customer360/format';
+
+const toneClass: Record<string, string> = {
+  success: 'text-status-success',
+  info: 'text-status-info',
+  error: 'text-status-error',
+  warning: 'text-status-warning',
+  muted: 'text-muted-foreground',
+};
+
+export function CustomerVisitsTab({ customerId }: { customerId: string }) {
+  const { data, isLoading } = useCustomerVisits(customerId);
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-8 text-xs text-muted-foreground">
+        <Loader2 className="w-3.5 h-3.5 animate-spin mr-2" />Carregando…
+      </div>
+    );
+  }
+
+  if (!data || data.length === 0) {
+    return (
+      <div className="text-center py-8 text-xs text-muted-foreground">
+        Nenhuma visita registrada. As visitas com check-out no planejador de rotas aparecem aqui.
+      </div>
+    );
+  }
+
+  const resumo = resumoVisitas(data);
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground border-b pb-2">
+        <span><strong className="text-foreground">{resumo.total}</strong> visita{resumo.total > 1 ? 's' : ''}</span>
+        <span>Conversão: <strong className="text-foreground">{formatPctMaybe(resumo.taxaConversao)}</strong></span>
+        <span>Receita: <strong className="text-foreground">{formatBRL(resumo.receitaTotal)}</strong></span>
+      </div>
+
+      <div className="space-y-2">
+        {data.map((v) => {
+          const r = visitResultLabel(v.result);
+          const dia = v.check_in_at ? new Date(v.check_in_at).toLocaleDateString('pt-BR') : v.visit_date;
+          return (
+            <div key={v.id} className="border rounded-md p-2.5 text-sm space-y-1">
+              <div className="flex items-center justify-between gap-2">
+                <span className={`font-medium ${toneClass[r.tone]}`}>{r.emoji} {r.label}</span>
+                <span className="text-xs text-muted-foreground font-tabular">{dia}</span>
+              </div>
+              <div className="flex items-center justify-between gap-2 text-xs text-muted-foreground">
+                <span className="truncate">por {v.visitedByName}</span>
+                {v.result === 'pedido_fechado' && (v.revenue_generated ?? 0) > 0 && (
+                  <span className="text-status-success font-medium">{formatBRL(v.revenue_generated)}</span>
+                )}
+              </div>
+              {v.notes && <p className="text-xs text-muted-foreground whitespace-pre-wrap">{v.notes}</p>}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Verificar typecheck + lint**
+
+Run: `cd /Users/lucassardenberg/Projetos/afiacao/.claude/worktrees/customer360-visitas && heavy bun run typecheck && heavy bun run lint`
+Expected: typecheck 0; lint 0 errors. (Confirma imports de `format` + helpers + tokens.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/customer/CustomerVisitsTab.tsx
+git commit -m "feat(customer360-visitas): CustomerVisitsTab (resumo + histórico com resultado)"
+```
+
+---
+
+## Task 4: Adicionar a aba no `Customer360View`
+
+**Files:**
+- Modify: `src/components/adminCustomers/Customer360View.tsx`
+
+Referência: o `CustomerCallsTab` é montado em `<TabsContent value="calls">` (~linha 331) e tem `<TabsTrigger value="calls">` na `TabsList`. Adicionar "visits" análogo.
+
+- [ ] **Step 1: Import do componente + ícone**
+
+Junto aos imports de tab (perto do `import { CustomerCallsTab } ...`):
+```tsx
+import { CustomerVisitsTab } from '@/components/customer/CustomerVisitsTab';
+```
+Garantir que `MapPin` está importado de `lucide-react` (a linha de imports do lucide já tem vários ícones — adicionar `MapPin` se não estiver).
+
+- [ ] **Step 2: Adicionar o `<TabsTrigger>`**
+
+Na `TabsList`, **após** o trigger de `calls` (Chamadas):
+```tsx
+          <TabsTrigger value="visits" className="gap-1.5">
+            <MapPin className="w-3.5 h-3.5" /> Visitas
+          </TabsTrigger>
+```
+
+- [ ] **Step 3: Adicionar o `<TabsContent>`**
+
+**Após** o `<TabsContent value="calls" ...>...</TabsContent>` (~linha 333):
+```tsx
+        <TabsContent value="visits" className="mt-3">
+          <CustomerVisitsTab customerId={customer.user_id} />
+        </TabsContent>
+```
+
+- [ ] **Step 4: Verificar typecheck + lint**
+
+Run: `cd /Users/lucassardenberg/Projetos/afiacao/.claude/worktrees/customer360-visitas && heavy bun run typecheck && heavy bun run lint`
+Expected: typecheck 0; lint 0 errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/adminCustomers/Customer360View.tsx
+git commit -m "feat(customer360-visitas): aba Visitas no Customer360View"
+```
+
+---
+
+## Task 5: Validação final
+
+**Files:** nenhum (só validação)
+
+- [ ] **Step 1: Suíte completa**
+
+Run: `cd /Users/lucassardenberg/Projetos/afiacao/.claude/worktrees/customer360-visitas && heavy bun run typecheck && heavy bun run lint && heavy bun run test && heavy bun run build`
+Expected: typecheck 0 · lint 0 errors · test todos passando (incl. os novos de visit-result) · build ✓.
+
+- [ ] **Step 2: Confirmar escopo**
+
+Run: `git diff --stat $(git merge-base HEAD origin/main)`
+Expected: só os 4 arquivos de código (2 em `src/lib/visitas/`... na verdade `visit-result.ts` + teste, `useCustomerVisits.ts`, `CustomerVisitsTab.tsx`, `Customer360View.tsx`) + os 2 docs. NÃO toca `route_visits` (schema), `useRoutePlanner`, `CheckoutDialog`, RLS, backend.
+
+---
+
+## Self-Review (autor do plano)
+
+**Spec coverage:**
+- §4.1 helpers `visitResultLabel`/`resumoVisitas` → Task 1 ✓
+- §4.2 hook `useCustomerVisits` (route_visits por cliente + nomes) → Task 2 ✓
+- §4.3 `CustomerVisitsTab` (resumo + lista, badge de resultado, receita, notas) → Task 3 ✓
+- §4.4 aba no Customer360View → Task 4 ✓
+- §6 fora de escopo (read-only, não toca route_visits/route planner/RLS) → confirmado Task 5 Step 2 ✓
+
+**Placeholder scan:** nenhum TBD; todo passo com código real. `MapPin` confirmado como ícone lucide (verificar se já importado).
+
+**Type consistency:** `visitResultLabel(result: string|null)` e `resumoVisitas(rows)` idênticos em Task 1 (def) e Task 3 (uso). `CustomerVisitRow` (Task 2) consumido na Task 3 (`v.result`, `v.revenue_generated`, `v.visitedByName`, `v.check_in_at`, `v.notes`). `useCustomerVisits` retorna `UseQueryResult<CustomerVisitRow[]>` → `{data, isLoading}` na Task 3. Prop `customerId={customer.user_id}` igual ao `CustomerCallsTab`. `formatBRL`/`formatPctMaybe` de `@/components/customer360/format`.

--- a/docs/superpowers/specs/2026-06-01-customer360-aba-visitas-design.md
+++ b/docs/superpowers/specs/2026-06-01-customer360-aba-visitas-design.md
@@ -1,0 +1,98 @@
+# Aba "Visitas" no Customer 360 — histórico de visitas com resultado
+
+**Data:** 2026-06-01
+**Autor:** Lucas (escolheu "surfaçar os resultados" + delegou o design) + Claude
+**Status:** design cravado (founder delegou; PR pronto pra revisar)
+
+---
+
+## 1. Problema
+
+A captura de resultado de visita **já existe e funciona** (route planner → check-out → `CheckoutDialog` grava `result`/`revenue_generated`/`order_created`/`notes` em `route_visits`). Mas os resultados **quase não são surfaçados** — só aparecem no card de hoje do route planner. **Não há onde rever** o histórico de visitas de um cliente nem o resultado delas. Os dados estão em `route_visits`, faltando o lugar de ver.
+
+> Frente escolhida pelo founder ("surfaçar os resultados") após descobrir que a captura já existe. Decisão de ONDE (Customer 360) delegada a mim.
+
+## 2. Escopo v1
+
+Uma **aba "Visitas"** no `Customer360View` (ao lado de "Chamadas"), espelhando o `CustomerCallsTab`, mostrando o **histórico de visitas daquele cliente** com resultado/receita/notas + um **resumo** (total · taxa de conversão · receita gerada).
+
+**NÃO faz (v1):** editar/excluir visita no histórico, filtros, gráficos, ações (re-check-out), paginação (limita às últimas N). Não toca a captura (já existe) nem o route planner.
+
+## 3. Dados (read-only, sem backend)
+
+`route_visits` (colunas já existentes): `id, customer_user_id, visited_by, visit_date, visit_type, check_in_at, check_out_at, result, notes, revenue_generated, order_created, created_at`.
+
+**RLS já cobre** (endurecida no #340): SELECT de `route_visits` = gestor/master OR own (`visited_by`) OR carteira/cobertura (`carteira_visivel_para`). Logo a aba mostra **as visitas que o staff logado tem permissão de ver** desse cliente (próprias + carteira; gestor vê tudo) — degradação honesta automática, sem mudança de RLS. (O Customer 360 já é staff-only via gating.)
+
+Taxonomia de `result` (do `CheckoutDialog` existente): `pedido_fechado`, `interesse`, `sem_interesse`, `ausente`, `reagendar` (+ `null` = sem resultado / visita sem check-out).
+
+## 4. Arquitetura (3 peças + 1 aba; sem backend)
+
+### 4.1 Helpers puros (TDD) — `src/lib/visitas/visit-result.ts`
+```ts
+export type VisitResultTone = 'success' | 'info' | 'error' | 'warning' | 'muted';
+export interface VisitResultLabel { label: string; emoji: string; tone: VisitResultTone; }
+
+/** Mapeia o código de result (route_visits) → rótulo + emoji + tom (tokens text-status-*). */
+export function visitResultLabel(result: string | null): VisitResultLabel {
+  switch (result) {
+    case 'pedido_fechado': return { label: 'Pedido fechado', emoji: '✅', tone: 'success' };
+    case 'interesse':      return { label: 'Interesse',      emoji: '🤔', tone: 'info' };
+    case 'sem_interesse':  return { label: 'Sem interesse',  emoji: '❌', tone: 'error' };
+    case 'ausente':        return { label: 'Ausente',        emoji: '🚫', tone: 'warning' };
+    case 'reagendar':      return { label: 'Reagendar',      emoji: '📅', tone: 'warning' };
+    default:               return { label: 'Sem resultado',  emoji: '—',  tone: 'muted' };
+  }
+}
+
+export interface VisitResumoRow { result: string | null; revenue_generated: number | null; }
+export interface VisitResumo { total: number; comResultado: number; fechados: number; taxaConversao: number | null; receitaTotal: number; }
+
+/** Resumo do histórico: total, quantos tiveram resultado, fechados, taxa (fechados/comResultado) e receita somada. */
+export function resumoVisitas(rows: VisitResumoRow[]): VisitResumo {
+  const total = rows.length;
+  const comResultado = rows.filter(r => r.result != null).length;
+  const fechados = rows.filter(r => r.result === 'pedido_fechado').length;
+  const taxaConversao = comResultado > 0 ? fechados / comResultado : null; // null = sem base
+  const receitaTotal = rows.reduce((s, r) => s + (r.revenue_generated ?? 0), 0);
+  return { total, comResultado, fechados, taxaConversao, receitaTotal };
+}
+```
+> `taxaConversao` = fechados ÷ visitas COM resultado (não ÷ total) — honesto: visitas sem check-out não diluem. `null` quando não há base.
+
+### 4.2 Hook `useCustomerVisits` — `src/hooks/useCustomerVisits.ts`
+Espelha `useCustomerCalls`. Query `route_visits` por `customer_user_id` + enriquece `visited_by`→nome (`profiles`).
+- `useQuery({ queryKey: ['customer-visits', customerId], enabled: !!customerId, staleTime: 60_000 })`.
+- Query A: `route_visits.select('id, visited_by, visit_date, check_in_at, check_out_at, result, notes, revenue_generated, order_created').eq('customer_user_id', customerId).order('check_in_at', { ascending: false }).limit(50)`.
+- Query B (enriquecimento): `profiles.select('user_id, name').in('user_id', <visited_by únicos>)` → `Map`. Só roda se houver linhas.
+- Retorna `CustomerVisitRow[]` (cada row + `visitedByName: string`).
+- Tipo `CustomerVisitRow` exportado pra UI.
+
+### 4.3 Componente `CustomerVisitsTab` — `src/components/customer/CustomerVisitsTab.tsx`
+Espelha `CustomerCallsTab`. `{ customerId }`.
+- `const { data, isLoading } = useCustomerVisits(customerId)`.
+- `isLoading` → spinner (mesmo padrão do CustomerCallsTab). `!data?.length` → empty state ("Nenhuma visita registrada. As visitas com check-out no planejador de rotas aparecem aqui.").
+- **Resumo** (topo): `resumoVisitas(data)` → "N visitas · X% conversão · R$ Y" (taxaConversao null → "—"; formatar R$ com o helper de format existente). Card compacto.
+- **Lista:** cada visita → linha com: data (`check_in_at` formatado), **badge de resultado** (`visitResultLabel` → emoji+label, classe `text-status-{tone}`), receita (se `pedido_fechado` e >0), `visitedByName`, notas (truncadas/expand). Tokens do design system, sem cor hardcoded.
+
+### 4.4 Aba no `Customer360View`
+`src/components/adminCustomers/Customer360View.tsx`:
+- Import `CustomerVisitsTab` + um ícone lucide (`MapPin` ou `CalendarCheck`).
+- `<TabsTrigger value="visits">` na `TabsList` (após "calls"/Chamadas).
+- `<TabsContent value="visits"><CustomerVisitsTab customerId={customer.user_id} /></TabsContent>`.
+- (Usar o mesmo `customerId`/prop que o `CustomerCallsTab` recebe — confirmar o nome da prop no plano.)
+
+## 5. Testes
+- **Unit (vitest, TDD):** `visitResultLabel` (cada código → label/emoji/tone; null/desconhecido → "Sem resultado"/muted); `resumoVisitas` (total, comResultado, fechados, taxaConversao = fechados/comResultado, null quando comResultado=0, receitaTotal soma ignorando null).
+- A fiação hook/tab/aba → **QA manual** (mock de react-query rende pouco). Documentar no PR: abrir Customer 360 de cliente com visita registrada → aba "Visitas" mostra histórico + resumo.
+- Suíte + typecheck + lint + build verdes.
+
+## 6. Fora de escopo / limitações
+- **Read-only:** não edita/exclui/re-faz check-out (a captura é no route planner).
+- **RLS:** mostra só as visitas visíveis ao staff logado (own/carteira/gestor) — by design.
+- **Limita às últimas 50** (sem paginação no v1).
+- Não toca `route_visits` (schema), `useRoutePlanner`, `CheckoutDialog`, RLS, backend.
+- **KPIs agregados de equipe** (dashboard de conversão de visitas por vendedor) = futuro; este v1 é por-cliente no 360.
+
+## 7. Risco
+Baixo. **Read-only** sobre `route_visits` (RLS já endurecida no #340). Aba nova e isolada, espelhando o `CustomerCallsTab` já existente. Zero escrita, zero money-path, zero backend. O Customer 360 é staff-only (gating). Se não houver visitas visíveis → empty state honesto.

--- a/src/components/adminCustomers/Customer360View.tsx
+++ b/src/components/adminCustomers/Customer360View.tsx
@@ -13,7 +13,7 @@ import {
   ChevronLeft, Mail, ShoppingCart, TrendingUp,
   AlertTriangle, MoreHorizontal,
   MessageSquare, Calendar, DollarSign, Package, Activity, Sparkles,
-  Factory, Contact,
+  Factory, Contact, MapPin,
 } from 'lucide-react';
 import { format } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
@@ -24,6 +24,7 @@ import { CallButton } from '@/components/call/CallButton';
 import { RecommendationsPanel } from '@/components/RecommendationsPanel';
 import { CustomerProfile360Summary } from '@/components/customer/CustomerProfile360Summary';
 import { CustomerCallsTab } from '@/components/customer/CustomerCallsTab';
+import { CustomerVisitsTab } from '@/components/customer/CustomerVisitsTab';
 import { CustomerProcessTab } from '@/components/customer/CustomerProcessTab';
 import { CustomerContactsTab } from '@/components/customer/CustomerContactsTab';
 import { fmt, HEALTH_CLASSES, formatDocument } from './config';
@@ -217,6 +218,9 @@ export function Customer360View({
           <TabsTrigger value="calls" className="gap-1.5">
             <Phone className="w-3.5 h-3.5" /> Chamadas
           </TabsTrigger>
+          <TabsTrigger value="visits" className="gap-1.5">
+            <MapPin className="w-3.5 h-3.5" /> Visitas
+          </TabsTrigger>
           <TabsTrigger value="process" className="gap-1.5">
             <Factory className="w-3.5 h-3.5" /> Processo
           </TabsTrigger>
@@ -330,6 +334,10 @@ export function Customer360View({
 
         <TabsContent value="calls" className="mt-3">
           <CustomerCallsTab customerId={customer.user_id} />
+        </TabsContent>
+
+        <TabsContent value="visits" className="mt-3">
+          <CustomerVisitsTab customerId={customer.user_id} />
         </TabsContent>
 
         <TabsContent value="process" className="mt-3">

--- a/src/components/customer/CustomerVisitsTab.tsx
+++ b/src/components/customer/CustomerVisitsTab.tsx
@@ -1,0 +1,66 @@
+import { Loader2 } from 'lucide-react';
+import { useCustomerVisits } from '@/hooks/useCustomerVisits';
+import { visitResultLabel, resumoVisitas } from '@/lib/visitas/visit-result';
+import { formatBRL, formatPctMaybe } from '@/components/customer360/format';
+
+const toneClass: Record<string, string> = {
+  success: 'text-status-success',
+  info: 'text-status-info',
+  error: 'text-status-error',
+  warning: 'text-status-warning',
+  muted: 'text-muted-foreground',
+};
+
+export function CustomerVisitsTab({ customerId }: { customerId: string }) {
+  const { data, isLoading } = useCustomerVisits(customerId);
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-8 text-xs text-muted-foreground">
+        <Loader2 className="w-3.5 h-3.5 animate-spin mr-2" />Carregando…
+      </div>
+    );
+  }
+
+  if (!data || data.length === 0) {
+    return (
+      <div className="text-center py-8 text-xs text-muted-foreground">
+        Nenhuma visita registrada. As visitas com check-out no planejador de rotas aparecem aqui.
+      </div>
+    );
+  }
+
+  const resumo = resumoVisitas(data);
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground border-b pb-2">
+        <span><strong className="text-foreground">{resumo.total}</strong> visita{resumo.total > 1 ? 's' : ''}</span>
+        <span>Conversão: <strong className="text-foreground">{formatPctMaybe(resumo.taxaConversao)}</strong></span>
+        <span>Receita: <strong className="text-foreground">{formatBRL(resumo.receitaTotal)}</strong></span>
+      </div>
+
+      <div className="space-y-2">
+        {data.map((v) => {
+          const r = visitResultLabel(v.result);
+          const dia = v.check_in_at ? new Date(v.check_in_at).toLocaleDateString('pt-BR') : v.visit_date;
+          return (
+            <div key={v.id} className="border rounded-md p-2.5 text-sm space-y-1">
+              <div className="flex items-center justify-between gap-2">
+                <span className={`font-medium ${toneClass[r.tone]}`}>{r.emoji} {r.label}</span>
+                <span className="text-xs text-muted-foreground font-tabular">{dia}</span>
+              </div>
+              <div className="flex items-center justify-between gap-2 text-xs text-muted-foreground">
+                <span className="truncate">por {v.visitedByName}</span>
+                {v.result === 'pedido_fechado' && (v.revenue_generated ?? 0) > 0 && (
+                  <span className="text-status-success font-medium">{formatBRL(v.revenue_generated)}</span>
+                )}
+              </div>
+              {v.notes && <p className="text-xs text-muted-foreground whitespace-pre-wrap">{v.notes}</p>}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useCustomerVisits.ts
+++ b/src/hooks/useCustomerVisits.ts
@@ -1,0 +1,51 @@
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+
+export interface CustomerVisitRow {
+  id: string;
+  visited_by: string;
+  visit_date: string;
+  check_in_at: string | null;
+  check_out_at: string | null;
+  result: string | null;
+  notes: string | null;
+  revenue_generated: number | null;
+  order_created: boolean | null;
+  visitedByName: string;
+}
+
+/**
+ * Histórico de visitas (route_visits) de um cliente, com resultado/receita/notas.
+ * RLS de route_visits (endurecida no #340) filtra own/carteira/gestor — degradação honesta.
+ * Read-only.
+ */
+export function useCustomerVisits(customerId: string | null) {
+  return useQuery({
+    queryKey: ['customer-visits', customerId],
+    enabled: !!customerId,
+    staleTime: 60_000,
+    gcTime: 5 * 60_000,
+    queryFn: async (): Promise<CustomerVisitRow[]> => {
+      if (!customerId) return [];
+      const { data, error } = await supabase
+        .from('route_visits')
+        .select('id, visited_by, visit_date, check_in_at, check_out_at, result, notes, revenue_generated, order_created')
+        .eq('customer_user_id', customerId)
+        .order('check_in_at', { ascending: false })
+        .limit(50);
+      if (error) throw new Error(error.message);
+
+      const rows = data ?? [];
+      if (rows.length === 0) return [];
+
+      const ids = [...new Set(rows.map((r) => r.visited_by).filter(Boolean))];
+      const { data: profs } = await supabase
+        .from('profiles')
+        .select('user_id, name')
+        .in('user_id', ids);
+      const nameMap = new Map((profs ?? []).map((p) => [p.user_id, p.name]));
+
+      return rows.map((r) => ({ ...r, visitedByName: nameMap.get(r.visited_by) || 'Vendedor' }));
+    },
+  });
+}

--- a/src/lib/visitas/__tests__/visit-result.test.ts
+++ b/src/lib/visitas/__tests__/visit-result.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { visitResultLabel, resumoVisitas } from '../visit-result';
+
+describe('visitResultLabel', () => {
+  it('mapeia cada código da taxonomia', () => {
+    expect(visitResultLabel('pedido_fechado')).toEqual({ label: 'Pedido fechado', emoji: '✅', tone: 'success' });
+    expect(visitResultLabel('interesse').tone).toBe('info');
+    expect(visitResultLabel('sem_interesse').tone).toBe('error');
+    expect(visitResultLabel('ausente').tone).toBe('warning');
+    expect(visitResultLabel('reagendar').emoji).toBe('📅');
+  });
+  it('null/desconhecido → "Sem resultado"/muted', () => {
+    expect(visitResultLabel(null)).toEqual({ label: 'Sem resultado', emoji: '—', tone: 'muted' });
+    expect(visitResultLabel('xyz').tone).toBe('muted');
+  });
+});
+
+describe('resumoVisitas', () => {
+  it('total, comResultado, fechados, taxa (fechados/comResultado), receita', () => {
+    const r = resumoVisitas([
+      { result: 'pedido_fechado', revenue_generated: 1000 },
+      { result: 'pedido_fechado', revenue_generated: 500 },
+      { result: 'sem_interesse', revenue_generated: null },
+      { result: null, revenue_generated: null },
+    ]);
+    expect(r).toEqual({ total: 4, comResultado: 3, fechados: 2, taxaConversao: 2 / 3, receitaTotal: 1500 });
+  });
+  it('sem visitas com resultado → taxa null', () => {
+    expect(resumoVisitas([{ result: null, revenue_generated: null }]).taxaConversao).toBeNull();
+  });
+  it('lista vazia → zeros e taxa null', () => {
+    expect(resumoVisitas([])).toEqual({ total: 0, comResultado: 0, fechados: 0, taxaConversao: null, receitaTotal: 0 });
+  });
+});

--- a/src/lib/visitas/visit-result.ts
+++ b/src/lib/visitas/visit-result.ts
@@ -1,0 +1,40 @@
+export type VisitResultTone = 'success' | 'info' | 'error' | 'warning' | 'muted';
+export interface VisitResultLabel {
+  label: string;
+  emoji: string;
+  tone: VisitResultTone;
+}
+
+/** Código de `route_visits.result` → rótulo + emoji + tom (tokens text-status-*). */
+export function visitResultLabel(result: string | null): VisitResultLabel {
+  switch (result) {
+    case 'pedido_fechado': return { label: 'Pedido fechado', emoji: '✅', tone: 'success' };
+    case 'interesse':      return { label: 'Interesse',      emoji: '🤔', tone: 'info' };
+    case 'sem_interesse':  return { label: 'Sem interesse',  emoji: '❌', tone: 'error' };
+    case 'ausente':        return { label: 'Ausente',        emoji: '🚫', tone: 'warning' };
+    case 'reagendar':      return { label: 'Reagendar',      emoji: '📅', tone: 'warning' };
+    default:               return { label: 'Sem resultado',  emoji: '—',  tone: 'muted' };
+  }
+}
+
+export interface VisitResumoRow {
+  result: string | null;
+  revenue_generated: number | null;
+}
+export interface VisitResumo {
+  total: number;
+  comResultado: number;
+  fechados: number;
+  taxaConversao: number | null;
+  receitaTotal: number;
+}
+
+/** Resumo do histórico. taxaConversao = fechados ÷ visitas COM resultado (null se base 0). */
+export function resumoVisitas(rows: VisitResumoRow[]): VisitResumo {
+  const total = rows.length;
+  const comResultado = rows.filter((r) => r.result != null).length;
+  const fechados = rows.filter((r) => r.result === 'pedido_fechado').length;
+  const taxaConversao = comResultado > 0 ? fechados / comResultado : null;
+  const receitaTotal = rows.reduce((s, r) => s + (r.revenue_generated ?? 0), 0);
+  return { total, comResultado, fechados, taxaConversao, receitaTotal };
+}


### PR DESCRIPTION
## Resumo
Surfaça os resultados de visita que **já eram capturados** (route planner → check-out grava `result`/`revenue_generated`/`notes` em `route_visits`) mas só apareciam no card de hoje. Nova aba **"Visitas"** no Customer 360 (`Customer360View`, ao lado de "Chamadas") com o **histórico de visitas do cliente** + um **resumo** (total · taxa de conversão · receita gerada).

Frente escolhida pelo founder ("surfaçar os resultados") após descobrir que a captura já existe — então este PR é **só leitura**, não duplica a captura.

### O que entrou
- `visitResultLabel` / `resumoVisitas` — helpers puros (TDD): taxonomia → label+emoji+tom; resumo (conversão = fechados ÷ visitas com resultado).
- `useCustomerVisits` — query `route_visits` por cliente + enriquece `visited_by`→nome (espelha `useCustomerCalls`).
- `CustomerVisitsTab` — resumo + lista (data, badge de resultado ✅🤔❌🚫📅, receita se fechou, notas, quem visitou).
- Aba "Visitas" no `Customer360View`.

### Read-only, sem backend
`route_visits` já tem as colunas e a **RLS já endurecida (#340)** filtra own/carteira/gestor → a aba mostra só as visitas visíveis ao staff logado (degradação honesta). **Não toca** schema/route_visits/CheckoutDialog/useRoutePlanner/RLS/backend.

## Qualidade
typecheck **0** · lint **0 errors** · test **2034** (incl. os novos de `visit-result`) · build ✓. Revisão: 4 arquivos batem com o plano, escopo nos 4 arquivos de código, edge da conversão (`formatPctMaybe` normaliza fração) verificado.

> ⚠️ O subagente implementador rate-limitou no fim (erro de servidor); finalizei e revisei inline. Tasks 1-3 são commits dele; Task 4 (aba) commitei após verificar o diff.

## Test plan
- [x] TDD `visit-result` (taxonomia + resumo: conversão null sem base, soma de receita).
- [x] typecheck/lint/test/build verdes.
- [ ] QA manual: abrir Customer 360 de cliente com visita registrada → aba "Visitas" mostra histórico + resumo; sem visita → empty state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)