### PR TITLE
fix(reposição): descrição do SKU no motor a partir do catálogo vivo do Omie

### DIFF
--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,13 +21,13 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **141** custom migrations totais
-- **594** objetos esperados (criados por estas migrations)
+- **143** custom migrations totais
+- **597** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
   - `rls_policy`: 160
-  - `function`: 119
+  - `function`: 121
   - `index`: 115
-  - `cron_job`: 92
+  - `cron_job`: 93
   - `table`: 70
   - `trigger`: 34
   - `enum_value`: 4
@@ -1313,6 +1313,19 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | --- | --- | --- |
 | `function` | `public.registrar_contato_rota` | — |
 | `function` | `public.desfazer_contato_rota` | — |
+
+### `20260601000000_tarefas_escalonamento_titulo_mensagem.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `public.tarefas_escalonamento_tick` | — |
+
+### `20260602101856_reposicao_refresh_descricao_sku_parametros.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `public.atualizar_descricao_sku_parametros` | — |
+| `cron_job` | `cron.reposicao-refresh-descricao-diario` | — |
 
 ## Próximos passos quando algo der `❌`
 

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 141
+-- Total de custom migrations: 143
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -160,7 +160,9 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260531150000', 'reposicao_param_limbo_watchdog', '20260531150000_reposicao_param_limbo_watchdog.sql'),
   ('20260531160000', 'reposicao_excluir_fabricado_04', '20260531160000_reposicao_excluir_fabricado_04.sql'),
   ('20260531170000', 'data_health_check_sayerlack_mapeamento_gap', '20260531170000_data_health_check_sayerlack_mapeamento_gap.sql'),
-  ('20260531170000', 'route_contact_log_escrita', '20260531170000_route_contact_log_escrita.sql')
+  ('20260531170000', 'route_contact_log_escrita', '20260531170000_route_contact_log_escrita.sql'),
+  ('20260601000000', 'tarefas_escalonamento_titulo_mensagem', '20260601000000_tarefas_escalonamento_titulo_mensagem.sql'),
+  ('20260602101856', 'reposicao_refresh_descricao_sku_parametros', '20260602101856_reposicao_refresh_descricao_sku_parametros.sql')
 )
 SELECT
   e.version,
@@ -772,7 +774,10 @@ WITH expected_objects (migration, kind, schema_name, object_name, parent_name) A
   ('data_health_check_sayerlack_mapeamento_gap', 'function', 'public', 'data_health_watchdog', ''),
   ('data_health_check_sayerlack_mapeamento_gap', 'function', 'public', 'fin_sync_heartbeat', ''),
   ('route_contact_log_escrita', 'function', 'public', 'registrar_contato_rota', ''),
-  ('route_contact_log_escrita', 'function', 'public', 'desfazer_contato_rota', '')
+  ('route_contact_log_escrita', 'function', 'public', 'desfazer_contato_rota', ''),
+  ('tarefas_escalonamento_titulo_mensagem', 'function', 'public', 'tarefas_escalonamento_tick', ''),
+  ('reposicao_refresh_descricao_sku_parametros', 'function', 'public', 'atualizar_descricao_sku_parametros', ''),
+  ('reposicao_refresh_descricao_sku_parametros', 'cron_job', 'cron', 'reposicao-refresh-descricao-diario', '')
 )
 SELECT
   e.migration,

--- a/src/components/skuMapeamento/types.ts
+++ b/src/components/skuMapeamento/types.ts
@@ -16,11 +16,6 @@ export interface Mapeamento {
   atualizado_em: string;
 }
 
-export interface DescricaoLookup {
-  sku_codigo_omie: string;
-  sku_descricao: string;
-}
-
 export interface ValidacaoResult {
   faltantes: { empresa: string; fornecedor_nome: string; sku_codigo_omie: string; sku_descricao: string }[]; // do histórico de pedidos
   faltantesMotor: { empresa: string; fornecedor_nome: string; sku_codigo_omie: string; sku_descricao: string }[]; // risco real: o motor pode pedir e o portal recusa

--- a/src/components/skuMapeamento/useSkuMapeamento.ts
+++ b/src/components/skuMapeamento/useSkuMapeamento.ts
@@ -7,7 +7,7 @@ import { supabase } from '@/integrations/supabase/client';
 import { toast } from 'sonner';
 import { EMPTY_FORM } from './config';
 import { dividirSegurosParaGravar } from './grava-seguros';
-import type { Mapeamento, DescricaoLookup, ValidacaoResult } from './types';
+import type { Mapeamento, ValidacaoResult } from './types';
 import { validarGabarito, sugerirMapeamentos, ehProdutoFracionado, PARSER_VERSION, type SugestaoSegura } from '@/lib/reposicao/sayerlack-sku';
 
 export function useSkuMapeamento() {
@@ -37,23 +37,28 @@ export function useSkuMapeamento() {
     },
   });
 
-  // Lookup de descrições do Omie a partir de pedido_compra_item (último valor visto)
+  // Lookup de descrições a partir do catálogo VIVO do Omie (omie_products.descricao), keyed pelo
+  // código numérico. Antes lia pedido_compra_item (foto da última compra) → divergia do Omie quando o
+  // produto era renomeado no ERP. omie_products.descricao atualiza no sync → a tela reflete o nome ATUAL.
   const skusOmie = useMemo(() => (mapeamentos ?? []).map((m) => m.sku_omie), [mapeamentos]);
 
   const { data: descricoes } = useQuery({
-    queryKey: ['sku-descricoes', skusOmie],
+    queryKey: ['sku-descricoes-omie', skusOmie],
     enabled: skusOmie.length > 0,
     queryFn: async () => {
-      const { data, error } = await supabase
-        .from('pedido_compra_item')
-        .select('sku_codigo_omie, sku_descricao')
-        .in('sku_codigo_omie', skusOmie);
-      if (error) throw error;
       const map = new Map<string, string>();
-      (data as DescricaoLookup[]).forEach((d) => {
-        if (!map.has(d.sku_codigo_omie) && d.sku_descricao) {
-          map.set(d.sku_codigo_omie, d.sku_descricao);
-        }
+      const codigos = skusOmie.map((s) => Number(s)).filter((n) => Number.isFinite(n));
+      if (codigos.length === 0) return map;
+      const { data, error } = await supabase
+        .from('omie_products')
+        .select('omie_codigo_produto, descricao, ativo')
+        .in('omie_codigo_produto', codigos);
+      if (error) throw error;
+      (data as Array<{ omie_codigo_produto: number; descricao: string | null; ativo: boolean }>).forEach((d) => {
+        if (!d.descricao) return;
+        const k = String(d.omie_codigo_produto);
+        // prefere a linha ATIVA do account (ignora duplicata inativa de outra empresa)
+        if (!map.has(k) || d.ativo) map.set(k, d.descricao);
       });
       return map;
     },

--- a/supabase/migrations/20260602101856_reposicao_refresh_descricao_sku_parametros.sql
+++ b/supabase/migrations/20260602101856_reposicao_refresh_descricao_sku_parametros.sql
@@ -1,0 +1,65 @@
+-- Reposição — refresh do RÓTULO sku_parametros.sku_descricao a partir do catálogo VIVO do Omie
+-- ============================================================================
+-- CAUSA-RAIZ (confirmada no código + em prod): sku_parametros.sku_descricao é semeado de
+-- max(venda_items_history.sku_descricao) dos ÚLTIMOS 90 DIAS — atualizar_classificacao_skus() no
+-- INSERT da linha nova; atualizar_parametros_numericos_skus() no UPDATE via COALESCE(v.sku_descricao,
+-- sp.sku_descricao). SKU sem venda em 90d NÃO entra em v_sku_parametros_sugeridos → o COALESCE preserva
+-- o nome ANTIGO de NF-e indefinidamente. NENHUM caminho lê omie_products.descricao (catálogo vivo) →
+-- quando o produto é RENOMEADO no Omie, o motor de reposição fica preso no nome velho.
+-- Caso real: CONCENTRADO AMARELO LIMAO WP07.3900QT (8689783095) e CONCENTRADO AZUL WP04.3900QT
+-- (8689733271) — Omie renomeou pondo o código na frente (WP07.3900QT CONCENTRADO ...); última venda
+-- 22/01/26 (>90d) → motor congelado no nome com o código no fim.
+--
+-- FIX (cirúrgico, money-path-SAFE): função dedicada que reabastece SÓ o rótulo a partir do catálogo
+-- vivo. Decoupled da view de vendas → alcança também SKU SEM venda em 90d (que é exatamente o caso que
+-- as funções existentes não alcançam, pois iteram só sobre v_sku_parametros_sugeridos).
+--
+-- GUARD-RAILS (revisão adversária):
+--  • Join autoritativo do money-path: omie_products.account = lower(sku_parametros.empresa) AND ativo
+--    = true. É o MESMO join que a RPC gerar_pedidos_sugeridos_ciclo usa em prod (omie_products é
+--    UNIQUE(omie_codigo_produto, account) → casa ≤1 linha → UPDATE...FROM determinístico, sem DISTINCT ON).
+--    op.ativo=true pega a linha ATIVA do account (ignora a linha duplicada inativa de outra empresa,
+--    ex.: a do colacor). Sem linha omie ativa → não casa → PRESERVA o valor atual (nunca apaga/nula).
+--  • Só toca a coluna sku_descricao. NÃO toca params numéricos (ponto_pedido/estoque_maximo/...) nem
+--    chaves de join → ZERO risco à matemática do pedido.
+--  • O trigger de auditoria trg_historico_sku_parametros IGNORA mudança de sku_descricao (só loga
+--    estoque_minimo/ponto_pedido/estoque_maximo/aprovado_em/aplicar_no_omie) → ZERO churn de histórico.
+--  • IS DISTINCT FROM + length(trim)>0: só atualiza quando muda E quando o nome vivo é não-vazio
+--    (nunca sobrescreve um rótulo bom com vazio). Idempotente (re-rodar = no-op quando já alinhado).
+--  • NÃO há caminho manual que edite sku_parametros.sku_descricao (verificado: nenhum UPDATE no front,
+--    sem coluna de override de descrição) → não clobbera correção humana. fornecedor_nome NÃO é tocado.
+--  • De-para do fornecedor é keyed por código NUMÉRICO (sku_fornecedor_externo.sku_omie); o parser
+--    Sayerlack usa sku_descricao só p/ SUGERIR de-para novo + detectar fracionado — o de-para REAL não
+--    muda. Trocar pro nome vivo é igual-ou-mais-correto (e o nome vivo já vem padronizado com o código).
+-- Reversível: DROP FUNCTION + cron.unschedule; reescrita não-destrutiva (nome antigo segue em
+-- venda_items_history / pedido_compra_item).
+
+CREATE OR REPLACE FUNCTION public.atualizar_descricao_sku_parametros(p_empresa text)
+RETURNS integer
+LANGUAGE plpgsql
+SET search_path TO 'public', 'pg_temp'
+AS $$
+DECLARE
+  v_atualizados int := 0;
+BEGIN
+  UPDATE sku_parametros sp
+  SET sku_descricao = trim(op.descricao)
+  FROM omie_products op
+  WHERE op.omie_codigo_produto::text = sp.sku_codigo_omie::text
+    AND op.account = lower(sp.empresa)
+    AND op.ativo = true
+    AND op.descricao IS NOT NULL
+    AND length(trim(op.descricao)) > 0
+    AND trim(op.descricao) IS DISTINCT FROM sp.sku_descricao
+    AND sp.empresa = p_empresa;
+  GET DIAGNOSTICS v_atualizados = ROW_COUNT;
+  RETURN v_atualizados;
+END;
+$$;
+
+-- Cron diário: reabastece o rótulo a partir do catálogo vivo do Omie. Roda 08:45 UTC — depois do sync
+-- de catálogo (omie-cron-diario, a cada 2h às :15) e ANTES do ciclo de geração de pedidos das 09:15
+-- (gerar-pedidos-diario-oben), pra que os PVs futuros já carreguem o nome vivo. SQL-local (sem
+-- net.http_post → sem a armadilha do timeout 5s do pg_net). Idempotente (upsert por nome).
+SELECT cron.schedule('reposicao-refresh-descricao-diario', '45 8 * * *',
+  $cron$ SELECT public.atualizar_descricao_sku_parametros('OBEN'); $cron$);


### PR DESCRIPTION
## Summary

Conserto **estrutural** da divergência entre a descrição do produto no app e no Omie (reportado nos SKUs `CONCENTRADO AMARELO LIMAO WP07.3900QT` / `CONCENTRADO AZUL WP04.3900QT`).

**Causa-raiz:** `sku_parametros.sku_descricao` (rótulo do motor de reposição) era semeado de `max(venda_items_history.sku_descricao)` dos últimos 90d + `COALESCE` — congelava no nome de NF-e e **nenhum caminho lia o catálogo vivo** `omie_products.descricao`. Quando o produto era renomeado no Omie (ex.: código movido pro começo do nome), o motor ficava preso no nome antigo. SKU sem venda em 90d nunca era reavaliado.

**Parte A — banco** (`supabase/migrations/20260602101856_...`): nova função `atualizar_descricao_sku_parametros(p_empresa)` + cron diário `reposicao-refresh-descricao-diario` (08:45 UTC, SQL-local). Reabastece **só o rótulo** a partir de `omie_products.descricao` (join account-aware `account=lower(empresa)`+`ativo`, idempotente, só quando muda). Alcança SKU sem venda em 90d. **Money-path-safe:** não toca params numéricos nem chaves de join; o trigger de auditoria ignora `sku_descricao`.

**Parte B — frontend** (`useSkuMapeamento`): a tela Mapeamento SKU passa a ler a descrição de `omie_products` (vivo) em vez de `pedido_compra_item` (foto da última compra).

## ⚠️ Migration — JÁ APLICADA em produção

`supabase/migrations/20260602101856_reposicao_refresh_descricao_sku_parametros.sql`. Lovable não aplica no merge, mas **esta já foi colada no SQL Editor e validada em produção**: função criada, backfill rodado (os 2 SKUs realinhados ao Omie), cron agendado (`45 8 * * *`). O arquivo está no PR pro registro do repo.

<details><summary>SQL aplicado</summary>

```sql
CREATE OR REPLACE FUNCTION public.atualizar_descricao_sku_parametros(p_empresa text)
RETURNS integer LANGUAGE plpgsql SET search_path TO 'public', 'pg_temp' AS $$
DECLARE v_atualizados int := 0;
BEGIN
  UPDATE sku_parametros sp
  SET sku_descricao = trim(op.descricao)
  FROM omie_products op
  WHERE op.omie_codigo_produto::text = sp.sku_codigo_omie::text
    AND op.account = lower(sp.empresa) AND op.ativo = true
    AND op.descricao IS NOT NULL AND length(trim(op.descricao)) > 0
    AND trim(op.descricao) IS DISTINCT FROM sp.sku_descricao
    AND sp.empresa = p_empresa;
  GET DIAGNOSTICS v_atualizados = ROW_COUNT;
  RETURN v_atualizados;
END; $$;

SELECT cron.schedule('reposicao-refresh-descricao-diario', '45 8 * * *',
  $cron$ SELECT public.atualizar_descricao_sku_parametros('OBEN'); $cron$);
```
</details>

> **Frontend (Parte B) precisa de Publish no Lovable após o merge** pra ir ao ar.

## Pre-Landing Review (auto)

Diff pequeno (frontend ~16 linhas + SQL). Auto-revisão: swap de query keyed por código numérico, prefere linha `ativo` (códigos são account-específicos → sem colisão cross-account), degrada limpo. SQL money-path-safe (não toca a matemática do pedido; de-para casa por código numérico). Sem injeção (função parametrizada). Codex adversarial indisponível (conta ChatGPT rejeita os modelos do CLI) — revisão adversária feita solo.

## Test plan
- [x] typecheck strict (`tsc -p tsconfig.app.json`) limpo no estado mergeado
- [x] suite completa: **2072 testes, 345 arquivos, todos passando**
- [x] build (vite) ok
- [x] lint 0 errors
- [x] Parte A validada em produção (backfill realinhou os 2 SKUs; cron agendado)

🤖 Generated with [Claude Code](https://claude.com/claude-code)