### PR TITLE
docs: roadmap vivo da sessão + prática padrão

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,8 @@
 
 > **🪟 Gestão de contexto (preferência do Lucas, 2026-05-30):** em sessões longas, **sugira `/compact` proativamente** quando perceber sinais de contexto cheio (é lembrete, não automação — não tenho leitura contínua da % da janela). ⚠️ **Auto-compactar em 60% NÃO é viável e não deve ser re-tentado:** não existe setting de threshold (o auto-compact nativo só dispara perto do *limite*), nenhum hook dispara por % de contexto, e hook não invoca slash command (`/compact` não é programaticamente acionável — nem por hook, nem por mim). Quem quer "compactar cedo" usa: `/compact <foco>` manual + `/context` pra medir + subagentes (janela própria, não incham a sessão principal).
 
+> **🧭 Roadmap da sessão (preferência do Lucas, 2026-06-01):** manter um **roadmap vivo** de todas as atividades acordadas na sessão em **`docs/roadmap-sessao.md`** — **re-fazer/atualizar** sempre que uma atividade for acrescentada ou concluída, e **renderizar o roadmap no chat** quando mudar, pra o founder acompanhar. **Prática padrão de TODA sessão** (nova ou spawnada): no começo, montar/retomar o roadmap; ao longo, manter em dia; no fim, refletir o estado real. Legenda: ✅ feito · 🔄 em andamento · ⏳ pendente · 🚧 bloqueado · ⏸️ adiado · 🧭 aguardando decisão.
+
 ---
 
 ## 1. Produto

--- a/docs/roadmap-sessao.md
+++ b/docs/roadmap-sessao.md
@@ -1,0 +1,29 @@
+# Roadmap da Sessão — atualizado 2026-06-01
+
+> **Documento vivo.** Re-feito sempre que acrescentamos OU concluímos uma atividade, e renderizado no chat quando muda, pra o founder acompanhar. Prática padrão de toda sessão (registrada no CLAUDE.md, topo).
+>
+> **Legenda:** ✅ feito · 🔄 em andamento · ⏳ pendente · 🚧 bloqueado · ⏸️ adiado (decisão consciente) · 🧭 aguardando decisão (eu+codex)
+
+---
+
+## 1. Tarefas — Fase 1 (cobrança das vendedoras)
+- ✅ **Desenho → spec → plano → build → ship.** PRs **#545** (módulo), **#549** (registro CLAUDE.md), **#551** (fix do e-mail de cobrança). Backend vivo em produção (6 migrations + crons + fix do matcher).
+- ⏳ **Verificação visual da Fase 1** (founder) — **GATE** que libera o build da Fase 2. Em andamento (você está testando no preview do Lovable).
+- 🔄 **Fix #1 — card "Minhas tarefas" visível no "Ver como"** (impersonation-aware no `useMinhasTarefas` + render no `MasterDashboard`, somente-leitura quando impersonando). Acordado nesta sessão; **aguardando seu OK pra implementar**.
+- ⏸️ **Fast-follow — editar tarefa** (cancelar já existe; YAGNI até o uso mostrar necessidade).
+
+## 2. Tarefas — Fase 2 (enforcement: recorrência + trava de comprovação)
+- ✅ **Desenho → spec (endurecido com passe adversário do codex) → plano.** PR **#553** (doc-only).
+- 🚧 **Build** — **BLOQUEADO** até a Fase 1 ser verificada (decisão eu+codex: não empilhar código sobre base não-clicada).
+
+## 3. Visitas sugeridas / Rota (feature EXISTENTE — feedback desta sessão)
+> Contexto confirmado: **Regina e Tatyana são farmers só de ligação + WhatsApp** (não fazem visita presencial).
+- 🧭 **#2 — realinhar "Visitas sugeridas"** pras vendedoras que só ligam (relabel "Visitas"→"Ligações"? trocar o dashboard pra usar a lista de ligações da rota? ajustar persona/cópia?). **Decisão eu+codex em andamento.**
+- 🧭 **#3 — city picker default só nas cidades da rota do dia (D-1)**, com "ver outras cidades" como opção secundária. **Decisão eu+codex.**
+
+---
+
+### Encerramento da sessão (housekeeping recorrente)
+- Manter este roadmap atualizado a cada mudança.
+- PRs de doc/fix abertos com auto-merge quando o CI passar.
+- Lembrar o founder do que depende dele (verificação visual; deploy/Publish no Lovable; SQL no SQL Editor).


### PR DESCRIPTION
Cria `docs/roadmap-sessao.md` (roadmap vivo das atividades acordadas, atualizado a cada mudança + renderizado no chat) e registra a **prática padrão de toda sessão** no topo do CLAUDE.md (preferência do Lucas, 2026-06-01).

🤖 Generated with [Claude Code](https://claude.com/claude-code)