### PR TITLE
feat(reposicao): torna falha_envio operável no cockpit (mostra erro + re-disparar)

### DIFF
--- a/src/components/reposicao/pedidos/DetalhesModal.tsx
+++ b/src/components/reposicao/pedidos/DetalhesModal.tsx
@@ -92,6 +92,16 @@ export function DetalhesModal({
           </Alert>
         )}
 
+        {pedido.status === 'falha_envio' && pedido.resposta_canal?.erro && (
+          <Alert variant="destructive">
+            <AlertTriangle className="h-4 w-4" />
+            <AlertTitle>Falha no disparo</AlertTitle>
+            <AlertDescription className="whitespace-pre-wrap break-words">
+              {pedido.resposta_canal.erro}
+            </AlertDescription>
+          </Alert>
+        )}
+
         {isLoading ? (
           <div className="flex items-center justify-center py-12">
             <Loader2 className="w-6 h-6 animate-spin text-muted-foreground" />

--- a/src/components/reposicao/pedidos/PedidoRow.tsx
+++ b/src/components/reposicao/pedidos/PedidoRow.tsx
@@ -23,7 +23,11 @@ export function PedidoRow({
 }) {
   const podeAprovar = p.status === 'pendente_aprovacao' || p.status === 'bloqueado_guardrail';
   const podeCancelar = ['pendente_aprovacao', 'bloqueado_guardrail', 'aprovado_aguardando_disparo'].includes(p.status);
-  const podeDisparar = p.status === 'aprovado_aguardando_disparo';
+  // Re-disparo: a edge disparar-pedidos-aprovados aceita pedido em falha_envio via
+  // pedido_id (index.ts:1005). Sem isso, falha_envio só tinha "Detalhes" — não havia
+  // como re-disparar pela UI (precisava flip de status no banco).
+  const podeReDisparar = p.status === 'falha_envio';
+  const podeDisparar = p.status === 'aprovado_aguardando_disparo' || podeReDisparar;
   // Guard de concorrência: enquanto o envio ao portal está em voo (após "aprovar e
   // disparar" ou um disparo manual), trava o botão pra não abrir uma 2ª sessão no
   // Browserless e gerar PO duplicado no fornecedor.
@@ -75,9 +79,9 @@ export function PedidoRow({
             <Button size="sm" variant="default" onClick={onVerDetalhes}>Aprovar</Button>
           )}
           {podeDisparar && (
-            <Button size="sm" variant="default" onClick={onDisparar} disabled={disparando || enviandoPortal}>
+            <Button size="sm" variant={podeReDisparar ? 'outline' : 'default'} onClick={onDisparar} disabled={disparando || enviandoPortal}>
               {(disparando || enviandoPortal) ? <Loader2 className="w-4 h-4 mr-1 animate-spin" /> : <Zap className="w-4 h-4 mr-1" />}
-              {enviandoPortal ? 'Enviando…' : 'Disparar'}
+              {enviandoPortal ? 'Enviando…' : (podeReDisparar ? 'Re-disparar' : 'Disparar')}
             </Button>
           )}
           {podeCancelar && (

--- a/src/components/reposicao/pedidos/__tests__/PedidoRow.test.tsx
+++ b/src/components/reposicao/pedidos/__tests__/PedidoRow.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { PedidoRow } from '../PedidoRow';
+import type { PedidoSugerido } from '../types';
+
+function ped(partial: Partial<PedidoSugerido>): PedidoSugerido {
+  return partial as unknown as PedidoSugerido;
+}
+
+function renderRow(p: PedidoSugerido) {
+  const onDisparar = vi.fn();
+  const utils = render(
+    <table>
+      <tbody>
+        <PedidoRow
+          p={p}
+          onVerDetalhes={() => {}}
+          onCancelar={() => {}}
+          onVerPortal={() => {}}
+          onDisparar={onDisparar}
+          disparando={false}
+        />
+      </tbody>
+    </table>,
+  );
+  return { onDisparar, ...utils };
+}
+
+describe('PedidoRow — re-disparo de falha_envio', () => {
+  it('mostra "Re-disparar" e chama onDisparar quando status é falha_envio', () => {
+    const { onDisparar } = renderRow(
+      ped({ id: 1, status: 'falha_envio', fornecedor_nome: 'RENNER SAYERLACK S/A', num_skus: 18, valor_total: 7716.34 }),
+    );
+    const btn = screen.getByRole('button', { name: /Re-disparar/i });
+    fireEvent.click(btn);
+    expect(onDisparar).toHaveBeenCalledTimes(1);
+  });
+
+  it('mostra "Disparar" (não "Re-disparar") quando status é aprovado_aguardando_disparo', () => {
+    renderRow(ped({ id: 2, status: 'aprovado_aguardando_disparo', fornecedor_nome: 'X', num_skus: 3, valor_total: 50 }));
+    expect(screen.getByRole('button', { name: /^Disparar$/i })).toBeTruthy();
+    expect(screen.queryByRole('button', { name: /Re-disparar/i })).toBeNull();
+  });
+
+  it('não mostra botão de disparo quando status é disparado', () => {
+    renderRow(
+      ped({ id: 3, status: 'disparado', fornecedor_nome: 'X', num_skus: 3, valor_total: 50, omie_pedido_compra_numero: '123' }),
+    );
+    expect(screen.queryByRole('button', { name: /disparar/i })).toBeNull();
+  });
+});

--- a/src/components/reposicao/pedidos/types.ts
+++ b/src/components/reposicao/pedidos/types.ts
@@ -52,6 +52,10 @@ export interface PedidoSugerido {
   portal_tentativas: number | null;
   portal_proximo_retry_em: string | null;
   portal_erro: string | null;
+  // Resposta do disparo (edge disparar-pedidos-aprovados). Em status='falha_envio',
+  // resposta_canal.erro carrega o MOTIVO real da falha (ex.: "SKU(s) sem custo (preço
+  // unitário 0)..."). Antes só era visível no banco — não aparecia na UI.
+  resposta_canal: { erro?: string; [key: string]: unknown } | null;
   criado_em?: string | null;
   cancelado_em?: string | null;
   cancelado_por?: string | null;


### PR DESCRIPTION
## Problema

No cockpit de Reposição (`/admin/reposicao/pedidos`), um pedido em `status=falha_envio`:
- só mostrava **"Detalhes"** — **sem botão de re-disparo** (a edge `disparar-pedidos-aprovados` já aceita por `pedido_id`, mas a UI não expunha; re-disparar exigia flip de status no SQL);
- o **motivo real** da falha vive em `pedido_compra_sugerido.resposta_canal.erro` e **não aparecia em lugar nenhum da UI** (o painel só mostra `portal_erro`, que fica vazio quando a falha é **pré-portal**). Diagnóstico exigia query no banco.

**Origem:** dois pedidos Sayerlack (#324/#325) falharam com `SKU(s) sem custo (preço unitário 0)` (SKUs de **primeira compra** sem CMC) — e o founder não tinha como ver o porquê nem re-disparar pela tela. Assinatura: `falha_envio` + Portal `—` (`nao_aplicavel`) = guard money-path (#422/#433) disparando **antes** do passo do portal.

## Mudança (só frontend)

- **`types.ts`** — tipa `resposta_canal` no `PedidoSugerido`.
- **`DetalhesModal`** — Alert "Falha no disparo" exibindo `resposta_canal.erro` (espelha o alert de `bloqueado_guardrail`). Fim da cegueira.
- **`PedidoRow`** — botão **"Re-disparar"** (outline) para `falha_envio` → reusa `onDisparar` → `dispararMutation` invoca a edge com `{pedido_id}` (já aceita `falha_envio`, `disparar-pedidos-aprovados/index.ts:1005`). Guard de concorrência (`enviandoPortal`) preservado — não abre 2ª sessão no Browserless.
- **teste** `PedidoRow.test.tsx` (3 casos: "Re-disparar" em `falha_envio`, "Disparar" em `aprovado_aguardando_disparo`, sem botão em `disparado`).

Sem migration, sem edge nova — a query da página já é `select('*')`, então `resposta_canal` já vinha. Nenhuma lógica de disparo/edge alterada (só expõe um caminho já suportado + exibe um campo já existente).

## Validação

typecheck strict ✓ · 2075 testes ✓ · lint 0 errors ✓ · build ✓ (worktree isolado de `origin/main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
