### PR TITLE
feat(tarefas): card 'Minhas tarefas' no 'Ver como' (impersonation-aware, read-only)

### DIFF
--- a/src/components/dashboard/MasterDashboard.tsx
+++ b/src/components/dashboard/MasterDashboard.tsx
@@ -3,6 +3,7 @@ import { Construction, BarChart3, Users, Briefcase } from 'lucide-react';
 import { KpisToday } from './KpisToday';
 import { VisitSuggestionsCard } from './VisitSuggestionsCard';
 import { ViewAsPicker } from '@/components/impersonation/ViewAsPicker';
+import { MinhasTarefasCard } from '@/components/tarefas/MinhasTarefasCard';
 
 /**
  * Dashboard Master (CEO) — visão consolidada do time + KPIs próprios (você
@@ -24,6 +25,9 @@ export function MasterDashboard() {
 
       {/* Ver como — master entra na visão de um vendedor (somente leitura) */}
       <ViewAsPicker />
+
+      {/* Tarefas do vendedor sendo visto via "Ver como" (somente leitura; some sem impersonação) */}
+      <MinhasTarefasCard />
 
       <Card className="p-4 border-dashed border-2 border-status-warning/30 bg-status-warning-bg/20">
         <div className="flex items-center gap-2 mb-2">

--- a/src/components/tarefas/MinhasTarefasCard.tsx
+++ b/src/components/tarefas/MinhasTarefasCard.tsx
@@ -7,9 +7,11 @@ import { Textarea } from '@/components/ui/textarea';
 import { Check, MessageSquare, Clock, AlertTriangle } from 'lucide-react';
 import { useMinhasTarefas, useTarefaSugestoes, useTarefaMutations } from '@/hooks/useTarefas';
 import { buildWhatsappTaskMessage, buildWaMeUrl } from '@/lib/tarefas/whatsapp';
+import { useImpersonation } from '@/contexts/ImpersonationContext';
 import type { TarefaEstado } from '@/lib/tarefas/types';
 
 export function MinhasTarefasCard() {
+  const { isImpersonating } = useImpersonation();  // "Ver como" = somente leitura
   const { data: tarefas = [], isLoading } = useMinhasTarefas();
   const ids = useMemo(() => tarefas.map(t => t.id), [tarefas]);
   const { data: sugestoes = [] } = useTarefaSugestoes(ids);
@@ -34,6 +36,7 @@ export function MinhasTarefasCard() {
         <Clock className="w-4 h-4" />
         <h2 className="font-display text-lg">Minhas tarefas</h2>
         <span className="text-2xs text-muted-foreground">{tarefas.length}</span>
+        {isImpersonating && <span className="ml-auto text-2xs text-muted-foreground">Somente leitura (Ver como)</span>}
       </div>
       <ul className="space-y-2">
         {tarefas.map(t => {
@@ -50,17 +53,17 @@ export function MinhasTarefasCard() {
                 </div>
                 <div className="flex gap-1 shrink-0">
                   {t.categoria === 'whatsapp'
-                    ? <Button size="sm" variant="outline" onClick={() => onWhats(t)}><MessageSquare className="w-3 h-3 mr-1" />Mandar</Button>
-                    : <Button size="sm" variant="outline" onClick={() => concluir(t.id, 'manual')}><Check className="w-3 h-3 mr-1" />Feito</Button>}
-                  <Button size="sm" variant="ghost" onClick={() => { setAdiarAlvo(t); setAdiarData(''); setAdiarMotivo(''); }}>Adiar</Button>
+                    ? <Button size="sm" variant="outline" disabled={isImpersonating} onClick={() => onWhats(t)}><MessageSquare className="w-3 h-3 mr-1" />Mandar</Button>
+                    : <Button size="sm" variant="outline" disabled={isImpersonating} onClick={() => concluir(t.id, 'manual')}><Check className="w-3 h-3 mr-1" />Feito</Button>}
+                  <Button size="sm" variant="ghost" disabled={isImpersonating} onClick={() => { setAdiarAlvo(t); setAdiarData(''); setAdiarMotivo(''); }}>Adiar</Button>
                 </div>
               </div>
               {sug && (
                 <div className="mt-2 rounded-md bg-status-info-bg border border-status-info/40 p-2">
                   <p className="text-2xs">{sug.motivo ?? 'Possível cumprimento detectado'} — confirma?</p>
                   <div className="flex gap-1 mt-1">
-                    <Button size="sm" onClick={() => resolverSugestao(sug.id, t.id, true)}>Sim, fiz</Button>
-                    <Button size="sm" variant="ghost" onClick={() => resolverSugestao(sug.id, t.id, false)}>Não</Button>
+                    <Button size="sm" disabled={isImpersonating} onClick={() => resolverSugestao(sug.id, t.id, true)}>Sim, fiz</Button>
+                    <Button size="sm" variant="ghost" disabled={isImpersonating} onClick={() => resolverSugestao(sug.id, t.id, false)}>Não</Button>
                   </div>
                 </div>
               )}

--- a/src/hooks/useTarefas.ts
+++ b/src/hooks/useTarefas.ts
@@ -1,6 +1,7 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
+import { useImpersonation } from '@/contexts/ImpersonationContext';
 import { toast } from 'sonner';
 import { track } from '@/lib/analytics';
 import type { TarefaEstado } from '@/lib/tarefas/types';
@@ -14,9 +15,12 @@ const sel = () => (supabase.from('v_tarefas_estado' as never) as any);
 /** Tarefas da vendedora logada (do responsável efetivo: assigned_to OU cobertura). A RLS já filtra. */
 export function useMinhasTarefas() {
   const { user } = useAuth();
+  const { isImpersonating, effectiveUserId } = useImpersonation();
+  // Impersonation-aware: no "Ver como", o master lê (RLS permite) e filtramos pro alvo.
+  const targetId = isImpersonating && effectiveUserId ? effectiveUserId : (user?.id ?? null);
   return useQuery({
-    queryKey: ['minhas-tarefas', user?.id],
-    enabled: !!user,
+    queryKey: ['minhas-tarefas', isImpersonating ? `as:${effectiveUserId}` : user?.id],
+    enabled: !!targetId,
     staleTime: 30_000,
     refetchInterval: 60_000,
     refetchIntervalInBackground: false,
@@ -27,7 +31,7 @@ export function useMinhasTarefas() {
         .order('atrasada', { ascending: false })
         .order('effective_due', { ascending: true });
       if (error) throw error;
-      return ((data ?? []) as TarefaEstado[]).filter(t => t.responsavel_efetivo === user!.id);
+      return ((data ?? []) as TarefaEstado[]).filter(t => t.responsavel_efetivo === targetId);
     },
   });
 }

--- a/src/lib/impersonation/__tests__/no-write-leak.test.ts
+++ b/src/lib/impersonation/__tests__/no-write-leak.test.ts
@@ -18,6 +18,9 @@ const ALLOWED = new Set([
   // useMarkMixGapFeedback usa effectiveUserId SÓ na queryKey de leitura/cache;
   // o write (mark_mixgap_feedback) é seller=auth.uid() server-side, sem effectiveUserId.
   'src/hooks/useMarkMixGapFeedback.ts',
+  // useTarefas: effectiveUserId SÓ em useMinhasTarefas (filtra a LEITURA pro alvo no "Ver como");
+  // as mutations (criar/concluir/resolverSugestao/adiar/cancelar) usam user.id (o master real), nunca effectiveUserId.
+  'src/hooks/useTarefas.ts',
 ]);
 
 describe('anti write-leak: effectiveUserId só em leitura', () => {


### PR DESCRIPTION
Fix #1 da verificação da Fase 1: o card 'Minhas tarefas' não aparecia no **'Ver como'** (a impersonação é data-only e mantém o layout do Master; o card vivia só nos dashboards de vendedora; e o `useMinhasTarefas` usava o id do master).

**Fix:** `useMinhasTarefas` agora é **impersonation-aware** (usa `effectiveUserId` quando impersonando; o master lê via RLS e filtra pro alvo) + o card é renderizado no **MasterDashboard** (some quando não impersonando — master não tem tarefas) + **somente-leitura quando impersonando** (botões Feito/WhatsApp/Adiar/confirmar desabilitados, coerente com a impersonação read-only).

Agora: founder cria tarefa pra vendedora X em `/tarefas` → 'Ver como X' → vê o card com as tarefas dela.

Typecheck limpo, lint 0 erros.

🤖 Generated with [Claude Code](https://claude.com/claude-code)