### PR TITLE
feat(brief): Brief Pré-Visita — contexto consolidado do cliente

### DIFF
--- a/docs/superpowers/specs/2026-06-01-brief-pre-visita-design.md
+++ b/docs/superpowers/specs/2026-06-01-brief-pre-visita-design.md
@@ -1,0 +1,96 @@
+# Brief Pré-Visita — contexto consolidado do cliente
+
+**Data:** 2026-06-01
+**Autor:** Lucas (escolheu no brainstorm) + Claude + codex (ideia #3 do brainstorm)
+**Status:** design cravado (founder escolheu a frente + delegou o design)
+
+---
+
+## 1. Problema / oportunidade
+
+O vendedor chega no cliente (ou agenda uma visita) **sem contexto consolidado** — os dados existem (compras, visitas, ligações) mas espalhados em abas/telas. Codex (brainstorm): *"chegar no cliente com contexto, não de mãos vazias"* — um bloco read-only que mostra o **estado atual** do cliente num glance, no momento de engajar.
+
+> Frente escolhida pelo founder após brainstorm eu+codex. Read-only, sem backend, área fria (sem colisão), alto valor-sentido.
+
+## 2. Escopo v1
+
+Um card compacto **`CustomerBrief`** com **3 facts de recência** consolidadas, mostrado no Customer 360 (acima das abas) e dentro do `AgendarVisitaDialog` (contexto na hora de agendar):
+
+1. **Última compra** — "há X dias · R$ Y" (de `sales_orders`).
+2. **Última visita** — "há X dias · {resultado}" (de `route_visits` via `useCustomerVisits`).
+3. **Última ligação** — "há X dias · {resultado}" (de `farmer_calls` via `useCustomerCalls`).
+
+Cada fact degrada honesto pra "nunca" / "—" quando não há dado (ou RLS não deixa ver).
+
+**NÃO faz (v1, cortado no brainstorm):** score/saúde (já no hero do 360), missão (visit_score é grande), gráficos, IA, pre-call brief com KB, ações no brief, "pedidos recentes" como lista (só o último).
+
+## 3. Dados (read-only, sem backend)
+
+- **Última compra:** `sales_orders` (colunas existentes: `customer_user_id`, `order_date_kpi`, `created_at`, `total`). Query por `customer_user_id`, ordena por `order_date_kpi` desc (fallback `created_at`), limit 1. RLS de sales_orders já permite staff (a página `/sales` lê) — degradação honesta se fora da carteira.
+- **Última visita:** `useCustomerVisits(customerId)[0]` (já entregue no #555). `check_in_at` + `result`.
+- **Última ligação:** `useCustomerCalls(customerId)[0]` (já existente). `started_at` + `call_result`.
+
+⚠️ **"Última compra" = `sales_orders` (venda de produto), NÃO a tabela `orders` (afiação/serviço)** que o `useCustomerOrders` consulta — pro contexto comercial do vendedor, a compra relevante é a venda.
+
+## 4. Arquitetura (helper TDD + hook + componente + 2 placements)
+
+### 4.1 Helper puro `recencia.ts` (TDD) — `src/lib/visitas/recencia.ts`
+```ts
+/** Dias de calendário entre a data de `iso` e `hojeISO` (ambos 'YYYY-MM-DD' ou ISO). null se iso vazio. */
+export function diasDesde(iso: string | null | undefined, hojeISO: string): number | null {
+  if (!iso) return null;
+  const d = iso.slice(0, 10);
+  const h = hojeISO.slice(0, 10);
+  const ms = Date.parse(`${h}T00:00:00Z`) - Date.parse(`${d}T00:00:00Z`);
+  if (Number.isNaN(ms)) return null;
+  return Math.round(ms / 86_400_000);
+}
+
+/** Rótulo de recência: nunca / hoje / ontem / há N dias. Negativo (futuro) → "hoje". */
+export function recenciaLabel(iso: string | null | undefined, hojeISO: string): string {
+  const n = diasDesde(iso, hojeISO);
+  if (n === null) return 'nunca';
+  if (n <= 0) return 'hoje';
+  if (n === 1) return 'ontem';
+  return `há ${n} dias`;
+}
+```
+> Usa a parte de DATA do ISO (UTC, consistente com a convenção do codebase — `hojeISO`). Pra "há X dias" o off-by-one noturno é irrelevante.
+
+### 4.2 Hook `useCustomerLastSalesOrder` — `src/hooks/useCustomerLastSalesOrder.ts`
+```ts
+// useQuery: sales_orders por customer_user_id, ordena order_date_kpi desc (fallback created_at), limit 1.
+// Retorna { date: string | null, total: number | null } | null (null = sem compra / RLS).
+export interface CustomerLastOrder { date: string | null; total: number | null; }
+export function useCustomerLastSalesOrder(customerId: string | null) { /* useQuery enabled:!!customerId, staleTime 60s */ }
+```
+- `.select('order_date_kpi, created_at, total').eq('customer_user_id', customerId).order('order_date_kpi', { ascending: false, nullsFirst: false }).limit(1)`.
+- `date = row.order_date_kpi ?? row.created_at` (a `order_date_kpi` é a data do pedido pra KPI; fallback `created_at`).
+
+### 4.3 Componente `CustomerBrief` — `src/components/customer/CustomerBrief.tsx`
+`{ customerId }`. Self-contained: usa os 3 hooks (`useCustomerLastSalesOrder`, `useCustomerVisits`, `useCustomerCalls`) + os helpers.
+- `hoje = new Date().toISOString().slice(0,10)`.
+- Card compacto (1 linha por fact, ícone + label + valor):
+  - 🛒 **Última compra:** `recenciaLabel(lastOrder?.date)` + (se houver total) `· {formatBRL(total)}`. Sem compra → "nunca comprou".
+  - 📍 **Última visita:** `recenciaLabel(lastVisit?.check_in_at)` + badge `visitResultLabel(lastVisit.result)` (emoji+label, `text-status-{tone}`). Sem visita → "nenhuma".
+  - 📞 **Última ligação:** `recenciaLabel(lastCall?.started_at)` + `call_result` (texto cru/curto). Sem ligação → "nenhuma".
+- Loading (qualquer hook carregando) → skeleton compacto. Tokens do design system, sem cor hardcoded.
+- Título do card: "Resumo pré-visita" (ou só um header discreto).
+
+### 4.4 Placements
+- **Customer360View** (`src/components/adminCustomers/Customer360View.tsx`): `<CustomerBrief customerId={customer.user_id} />` num card proeminente **após os KPI cards de score, antes das abas** (o "estado atual" antes de drillar).
+- **AgendarVisitaDialog** (`src/components/visitas/AgendarVisitaDialog.tsx`): `<CustomerBrief customerId={customerUserId} />` no topo do conteúdo do dialog (contexto na hora de agendar). O dialog já recebe `customerUserId`.
+
+## 5. Testes
+- **Unit (vitest, TDD):** `diasDesde` (null vazio; 0 mesmo dia; 1 ontem; N dias; NaN→null) + `recenciaLabel` (nunca/hoje/ontem/há N dias).
+- Hook/componente/placements → **QA manual** (mock de 3 react-query rende pouco). Documentar no PR: abrir Customer 360 → card "Resumo pré-visita" com as 3 recências; abrir "Agendar visita" → mesmo brief no topo.
+- Suíte + typecheck + lint + build verdes.
+
+## 6. Fora de escopo / limitações
+- **Read-only.** Não toca schema/sales_orders/route_visits/farmer_calls/RLS/backend.
+- **RLS:** mostra só o que o staff logado pode ver (carteira/gestor) — "—"/"nunca" honesto fora disso.
+- **3 facts apenas** (compra/visita/ligação). Score/missão/KB/pedidos-como-lista = fora do v1.
+- O `call_result` tem taxonomia própria (≠ visita) — mostrado como texto cru no v1 (sem mapa de label dedicado; v2 se valer).
+
+## 7. Risco
+Baixo. **Read-only**, reusa 2 hooks já entregues + 1 hook novo trivial (sales_orders por cliente). 1 helper puro testado. 2 placements de um componente isolado e auto-suficiente. Zero escrita, zero backend, zero money-path. RLS já cobre (degradação honesta). O Customer 360 e o dialog são staff-only.

--- a/src/components/adminCustomers/Customer360View.tsx
+++ b/src/components/adminCustomers/Customer360View.tsx
@@ -23,6 +23,7 @@ import { formatBrPhone, whatsappLink } from '@/lib/phone';
 import { CallButton } from '@/components/call/CallButton';
 import { RecommendationsPanel } from '@/components/RecommendationsPanel';
 import { CustomerProfile360Summary } from '@/components/customer/CustomerProfile360Summary';
+import { CustomerBrief } from '@/components/customer/CustomerBrief';
 import { CustomerCallsTab } from '@/components/customer/CustomerCallsTab';
 import { CustomerVisitsTab } from '@/components/customer/CustomerVisitsTab';
 import { CustomerProcessTab } from '@/components/customer/CustomerProcessTab';
@@ -137,6 +138,8 @@ export function Customer360View({
           <MetricCard icon={Package} label="Categorias" value={String(score.category_count)} />
         </div>
       )}
+
+      <CustomerBrief customerId={customer.user_id} />
 
       {/* Contact Info + Details */}
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">

--- a/src/components/customer/CustomerBrief.tsx
+++ b/src/components/customer/CustomerBrief.tsx
@@ -1,0 +1,85 @@
+import { ShoppingCart, MapPin, Phone, Loader2 } from 'lucide-react';
+import { Card } from '@/components/ui/card';
+import { useCustomerLastSalesOrder } from '@/hooks/useCustomerLastSalesOrder';
+import { useCustomerVisits } from '@/hooks/useCustomerVisits';
+import { useCustomerCalls } from '@/hooks/useCustomerCalls';
+import { recenciaLabel } from '@/lib/visitas/recencia';
+import { visitResultLabel } from '@/lib/visitas/visit-result';
+import { formatBRL } from '@/components/customer360/format';
+
+const toneClass: Record<string, string> = {
+  success: 'text-status-success',
+  info: 'text-status-info',
+  error: 'text-status-error',
+  warning: 'text-status-warning',
+  muted: 'text-muted-foreground',
+};
+
+/**
+ * Brief pré-visita: 3 facts de recência consolidadas (última compra / visita / ligação).
+ * Read-only, self-contained (reusa 3 hooks por customerId). Sem backend.
+ */
+export function CustomerBrief({ customerId }: { customerId: string }) {
+  const order = useCustomerLastSalesOrder(customerId);
+  const visits = useCustomerVisits(customerId);
+  const calls = useCustomerCalls(customerId);
+  const hoje = new Date().toISOString().slice(0, 10);
+
+  const loading = order.isLoading || visits.isLoading || calls.isLoading;
+  const lastOrder = order.data;
+  const lastVisit = visits.data?.[0];
+  const lastCall = calls.data?.[0];
+  const vr = lastVisit ? visitResultLabel(lastVisit.result) : null;
+
+  return (
+    <Card className="p-3">
+      <div className="text-xs font-medium text-muted-foreground mb-2">Resumo pré-visita</div>
+      {loading ? (
+        <div className="flex items-center text-xs text-muted-foreground py-1.5">
+          <Loader2 className="w-3.5 h-3.5 animate-spin mr-2" />Carregando…
+        </div>
+      ) : (
+        <div className="space-y-1.5 text-sm">
+          <div className="flex items-center gap-2">
+            <ShoppingCart className="w-3.5 h-3.5 text-muted-foreground shrink-0" />
+            <span className="text-muted-foreground">Última compra:</span>
+            <span className="font-medium">
+              {lastOrder ? recenciaLabel(lastOrder.date, hoje) : 'nunca comprou'}
+              {lastOrder && (lastOrder.total ?? 0) > 0 && (
+                <span className="text-muted-foreground font-normal"> · {formatBRL(lastOrder.total)}</span>
+              )}
+            </span>
+          </div>
+
+          <div className="flex items-center gap-2">
+            <MapPin className="w-3.5 h-3.5 text-muted-foreground shrink-0" />
+            <span className="text-muted-foreground">Última visita:</span>
+            {lastVisit && vr ? (
+              <span className="font-medium">
+                {recenciaLabel(lastVisit.check_in_at, hoje)}{' '}
+                <span className={toneClass[vr.tone]}>· {vr.emoji} {vr.label}</span>
+              </span>
+            ) : (
+              <span className="font-medium text-muted-foreground">nenhuma</span>
+            )}
+          </div>
+
+          <div className="flex items-center gap-2">
+            <Phone className="w-3.5 h-3.5 text-muted-foreground shrink-0" />
+            <span className="text-muted-foreground">Última ligação:</span>
+            {lastCall ? (
+              <span className="font-medium">
+                {recenciaLabel(lastCall.started_at, hoje)}
+                {lastCall.call_result && (
+                  <span className="text-muted-foreground font-normal"> · {lastCall.call_result}</span>
+                )}
+              </span>
+            ) : (
+              <span className="font-medium text-muted-foreground">nenhuma</span>
+            )}
+          </div>
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/src/components/visitas/AgendarVisitaDialog.tsx
+++ b/src/components/visitas/AgendarVisitaDialog.tsx
@@ -8,6 +8,7 @@ import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { useVisitasAgendadas } from '@/hooks/useVisitasAgendadas';
 import { hojeISO } from '@/lib/visitas/today';
+import { CustomerBrief } from '@/components/customer/CustomerBrief';
 
 export function AgendarVisitaDialog({
   customerUserId,
@@ -38,6 +39,7 @@ export function AgendarVisitaDialog({
           <DialogTitle>Agendar visita — {customerName}</DialogTitle>
         </DialogHeader>
         <div className="space-y-3">
+          <CustomerBrief customerId={customerUserId} />
           <div className="space-y-1">
             <Label htmlFor="vag-date">Data</Label>
             <Input id="vag-date" type="date" min={hojeISO()} value={date}

--- a/src/hooks/useCustomerLastSalesOrder.ts
+++ b/src/hooks/useCustomerLastSalesOrder.ts
@@ -1,0 +1,35 @@
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+
+export interface CustomerLastOrder {
+  date: string | null;
+  total: number | null;
+}
+
+/**
+ * Última COMPRA (venda de produto) do cliente — de `sales_orders` por customer_user_id.
+ * NÃO é a tabela `orders` (afiação/serviço). `date` = order_date_kpi (data do pedido pra KPI)
+ * com fallback created_at. RLS de sales_orders filtra carteira/gestor — degradação honesta.
+ * Read-only. Retorna null quando não há compra visível.
+ */
+export function useCustomerLastSalesOrder(customerId: string | null) {
+  return useQuery({
+    queryKey: ['customer-last-sales-order', customerId],
+    enabled: !!customerId,
+    staleTime: 60_000,
+    gcTime: 5 * 60_000,
+    queryFn: async (): Promise<CustomerLastOrder | null> => {
+      if (!customerId) return null;
+      const { data, error } = await supabase
+        .from('sales_orders')
+        .select('order_date_kpi, created_at, total')
+        .eq('customer_user_id', customerId)
+        .order('order_date_kpi', { ascending: false, nullsFirst: false })
+        .limit(1);
+      if (error) throw new Error(error.message);
+      const row = data?.[0];
+      if (!row) return null;
+      return { date: row.order_date_kpi ?? row.created_at, total: row.total ?? null };
+    },
+  });
+}

--- a/src/lib/visitas/__tests__/recencia.test.ts
+++ b/src/lib/visitas/__tests__/recencia.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { diasDesde, recenciaLabel } from '../recencia';
+
+const HOJE = '2026-06-01';
+
+describe('diasDesde', () => {
+  it('null/vazio → null', () => {
+    expect(diasDesde(null, HOJE)).toBeNull();
+    expect(diasDesde(undefined, HOJE)).toBeNull();
+    expect(diasDesde('', HOJE)).toBeNull();
+  });
+  it('mesmo dia → 0', () => {
+    expect(diasDesde('2026-06-01', HOJE)).toBe(0);
+    expect(diasDesde('2026-06-01T23:59:00Z', HOJE)).toBe(0);
+  });
+  it('ontem → 1; N dias atrás → N', () => {
+    expect(diasDesde('2026-05-31', HOJE)).toBe(1);
+    expect(diasDesde('2026-05-20', HOJE)).toBe(12);
+    expect(diasDesde('2026-05-02', HOJE)).toBe(30);
+  });
+  it('data inválida → null', () => {
+    expect(diasDesde('xyz', HOJE)).toBeNull();
+  });
+});
+
+describe('recenciaLabel', () => {
+  it('mapeia recência', () => {
+    expect(recenciaLabel(null, HOJE)).toBe('nunca');
+    expect(recenciaLabel('2026-06-01', HOJE)).toBe('hoje');
+    expect(recenciaLabel('2026-05-31', HOJE)).toBe('ontem');
+    expect(recenciaLabel('2026-05-20', HOJE)).toBe('há 12 dias');
+  });
+  it('data futura → hoje (não negativo)', () => {
+    expect(recenciaLabel('2026-06-05', HOJE)).toBe('hoje');
+  });
+});

--- a/src/lib/visitas/recencia.ts
+++ b/src/lib/visitas/recencia.ts
@@ -1,0 +1,19 @@
+/** Dias de calendário entre a data de `iso` e `hojeISO` (ambos 'YYYY-MM-DD' ou ISO completo).
+ *  null se `iso` vazio/inválido. Usa a parte de DATA (UTC) — consistente com a convenção do codebase. */
+export function diasDesde(iso: string | null | undefined, hojeISO: string): number | null {
+  if (!iso) return null;
+  const d = iso.slice(0, 10);
+  const h = hojeISO.slice(0, 10);
+  const ms = Date.parse(`${h}T00:00:00Z`) - Date.parse(`${d}T00:00:00Z`);
+  if (Number.isNaN(ms)) return null;
+  return Math.round(ms / 86_400_000);
+}
+
+/** Rótulo de recência: nunca / hoje / ontem / há N dias. Data futura (n<0) → "hoje". */
+export function recenciaLabel(iso: string | null | undefined, hojeISO: string): string {
+  const n = diasDesde(iso, hojeISO);
+  if (n === null) return 'nunca';
+  if (n <= 0) return 'hoje';
+  if (n === 1) return 'ontem';
+  return `há ${n} dias`;
+}


### PR DESCRIPTION
## Resumo
Ideia #3 do brainstorm eu+codex, escolhida pelo founder. Um card read-only **"Resumo pré-visita"** que dá ao vendedor o **estado atual do cliente num glance** — *"chegar no cliente com contexto, não de mãos vazias"*. Mostrado no Customer 360 (acima das abas) e dentro do **AgendarVisitaDialog** (o "antes do check-in" do codex).

**3 facts de recência consolidadas:**
- 🛒 **Última compra** — "há X dias · R$ Y" (de `sales_orders` por `customer_user_id`).
- 📍 **Última visita** — "há X dias · {resultado ✅🤔❌🚫📅}" (reusa `useCustomerVisits` do #555).
- 📞 **Última ligação** — "há X dias · {result}" (reusa `useCustomerCalls`).

Cada fact degrada honesto pra "nunca"/"nenhuma" sem dado (ou RLS fora da carteira).

### Read-only, sem backend
Reusa 2 hooks já entregues + 1 hook novo trivial (`useCustomerLastSalesOrder`). Helper puro `recencia` (TDD). **Não toca** schema/sales_orders/route_visits/farmer_calls/RLS/backend. ⚠️ "Última compra" = `sales_orders` (venda), NÃO a tabela `orders` (afiação) — pro contexto do vendedor a compra relevante é a venda.

## Qualidade
typecheck **0** · lint **0 errors** · test **2078** (incl. `recencia`) · build ✓. 5 arquivos de código + spec, escopo limpo. Implementado inline (o subagente rate-limitou; o rito spec→helper-TDD→hook→componente→placements foi seguido).

## Test plan
- [x] TDD `recencia` (diasDesde/recenciaLabel: nunca/hoje/ontem/há N dias).
- [x] typecheck/lint/test/build verdes.
- [ ] QA manual: Customer 360 → card "Resumo pré-visita" com as 3 recências; abrir "Agendar visita" → mesmo brief no topo do dialog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)