### PR TITLE
feat(farmer): dashboard lidera com Ligações da rota + relabel Visitas (#2/#3)

### DIFF
--- a/src/components/dashboard/FarmerDashboardV2.tsx
+++ b/src/components/dashboard/FarmerDashboardV2.tsx
@@ -1,5 +1,7 @@
 import { Card } from '@/components/ui/card';
-import { Calendar } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Calendar, Phone } from 'lucide-react';
+import { Link } from 'react-router-dom';
 import { KpisToday } from './KpisToday';
 import { AgendaTodayList } from './AgendaTodayList';
 import { MinhasTarefasCard } from '@/components/tarefas/MinhasTarefasCard';
@@ -26,6 +28,25 @@ export function FarmerDashboardV2() {
       <KpisToday />
 
       <MinhasTarefasCard />
+
+      {/* Ligações da rota — o que as vendedoras (farmer só-ligação) de fato fazem; lista priorizada D-1 em /rota/ligacoes */}
+      <Card className="p-4 border-status-info/40">
+        <div className="flex items-center justify-between gap-3">
+          <div>
+            <div className="flex items-center gap-2">
+              <Phone className="w-4 h-4 text-status-info" />
+              <h2 className="text-sm font-semibold">Ligações da rota</h2>
+            </div>
+            <p className="text-2xs text-muted-foreground mt-1">
+              Sua lista priorizada de quem ligar — clientes nas cidades da rota de amanhã.
+            </p>
+          </div>
+          <Button asChild size="sm">
+            <Link to="/rota/ligacoes">Abrir lista</Link>
+          </Button>
+        </div>
+      </Card>
+
       <VisitasHojeCard />
 
       <Card className="p-3 space-y-1">

--- a/src/components/dashboard/VisitSuggestionsCard.tsx
+++ b/src/components/dashboard/VisitSuggestionsCard.tsx
@@ -56,7 +56,7 @@ export function VisitSuggestionsCard() {
     <Card>
       <CardHeader className="flex flex-row items-center justify-between gap-3 pb-3">
         <div>
-          <h2 className="text-base font-medium">Visitas sugeridas hoje</h2>
+          <h2 className="text-base font-medium">Visitas sugeridas — equipes de campo</h2>
           <p className="text-2xs text-muted-foreground">
             Top {suggestions.length} clientes em {selectedCity} — mix balanceado entre 4 missões
           </p>


### PR DESCRIPTION
Realinha o dashboard das vendedoras (Regina/Tatyana = farmers **só ligação+WhatsApp**, não visitam). Decisão eu+codex = **Opção B** (alinhamento de apresentação, NÃO reconstruir scoring/rota).

- **FarmerDashboardV2**: card **'Ligações da rota'** (CTA → `/rota/ligacoes`, que já prioriza as cidades da rota de amanhã / D-1) como ação líder. `VisitasHojeCard` some sozinho quando não há visita (não-visitante).
- **VisitSuggestionsCard** (Master): título → **'Visitas sugeridas — equipes de campo'** (deixa claro que não é o fluxo das vendedoras só-ligação — era o que o founder via no 'Ver como').
- **#3** (city picker D-1): já satisfeito — `/rota/ligacoes` é D-1 por construção; o picker de todas-as-cidades é do card de visit-scores (equipes de campo), correto manter lá.

**Deferido (follow-up):** tornar `useRouteContactList` impersonation-aware pro 'Ver como farmer' mostrar as ligações DAQUELE farmer (hoje a rota é por usuário logado). No login real da vendedora, já funciona certo.

Typecheck limpo, lint 0 erros.

🤖 Generated with [Claude Code](https://claude.com/claude-code)