### PR TITLE
feat(dashboard): Mapa de Conversão — resultado das visitas no Closer

### DIFF
--- a/src/components/dashboard/CloserDashboard.tsx
+++ b/src/components/dashboard/CloserDashboard.tsx
@@ -2,6 +2,7 @@ import { Card } from '@/components/ui/card';
 import { Construction, MapPin, Target, TrendingUp } from 'lucide-react';
 import { VisitSuggestionsCard } from './VisitSuggestionsCard';
 import { VisitasHojeCard } from './VisitasHojeCard';
+import { MinhasVisitasResultadoCard } from './MinhasVisitasResultadoCard';
 import { MinhasTarefasCard } from '@/components/tarefas/MinhasTarefasCard';
 
 /**
@@ -24,6 +25,8 @@ export function CloserDashboard() {
 
       {/* Sugestões de visita — PR-VISIT-INTELLIGENCE Sub-PR A */}
       <VisitSuggestionsCard />
+
+      <MinhasVisitasResultadoCard />
 
       <Card className="p-4 border-dashed border-2 border-status-warning/30 bg-status-warning-bg/20">
         <div className="flex items-center gap-2 mb-2">

--- a/src/components/dashboard/MinhasVisitasResultadoCard.tsx
+++ b/src/components/dashboard/MinhasVisitasResultadoCard.tsx
@@ -1,0 +1,78 @@
+import { Loader2, BarChart3 } from 'lucide-react';
+import { Card } from '@/components/ui/card';
+import { useMinhasVisitasResultado } from '@/hooks/useMinhasVisitasResultado';
+import { agruparVisitasPorResultado } from '@/lib/visitas/conversao';
+import { visitResultLabel } from '@/lib/visitas/visit-result';
+import { formatBRL, formatPctMaybe } from '@/components/customer360/format';
+
+const JANELA_DIAS = 90;
+
+const toneBar: Record<string, string> = {
+  success: 'bg-status-success',
+  info: 'bg-status-info',
+  error: 'bg-status-error',
+  warning: 'bg-status-warning',
+  muted: 'bg-muted-foreground/40',
+};
+const toneText: Record<string, string> = {
+  success: 'text-status-success',
+  info: 'text-status-info',
+  error: 'text-status-error',
+  warning: 'text-status-warning',
+  muted: 'text-muted-foreground',
+};
+
+/**
+ * Breakdown das visitas do vendedor logado por resultado (últimos 90 dias) + receita.
+ * Read-only, own-scoped. Self-hide quando não há visita na janela.
+ */
+export function MinhasVisitasResultadoCard() {
+  const { data, isLoading } = useMinhasVisitasResultado(JANELA_DIAS);
+
+  if (isLoading) {
+    return (
+      <Card className="p-3 flex items-center text-xs text-muted-foreground">
+        <Loader2 className="w-3.5 h-3.5 animate-spin mr-2" />Carregando resultado das visitas…
+      </Card>
+    );
+  }
+
+  const resumo = agruparVisitasPorResultado(data ?? []);
+  if (resumo.total === 0) return null; // self-hide
+
+  return (
+    <Card className="p-3 space-y-2">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2 text-sm font-medium">
+          <BarChart3 className="w-4 h-4 text-muted-foreground" />
+          Resultado das suas visitas
+          <span className="text-2xs text-muted-foreground font-normal">· {JANELA_DIAS} dias</span>
+        </div>
+        <div className="text-xs text-muted-foreground">
+          {resumo.total} visita{resumo.total > 1 ? 's' : ''}
+          {resumo.receitaTotal > 0 && <span className="text-status-success font-medium"> · {formatBRL(resumo.receitaTotal)}</span>}
+        </div>
+      </div>
+
+      <div className="space-y-1.5">
+        {resumo.buckets.map((b) => {
+          const r = visitResultLabel(b.result === 'sem_resultado' ? null : b.result);
+          return (
+            <div key={b.result} className="space-y-0.5">
+              <div className="flex items-center justify-between text-xs">
+                <span className={`font-medium ${toneText[r.tone]}`}>{r.emoji} {r.label}</span>
+                <span className="text-muted-foreground">
+                  {b.count} ({formatPctMaybe(b.pct)})
+                  {b.revenue > 0 && <span className="text-status-success"> · {formatBRL(b.revenue)}</span>}
+                </span>
+              </div>
+              <div className="h-1.5 rounded-full bg-muted overflow-hidden">
+                <div className={`h-full ${toneBar[r.tone]}`} style={{ width: `${Math.round(b.pct * 100)}%` }} />
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </Card>
+  );
+}

--- a/src/hooks/useMinhasVisitasResultado.ts
+++ b/src/hooks/useMinhasVisitasResultado.ts
@@ -1,0 +1,29 @@
+import { useQuery } from '@tanstack/react-query';
+import { useAuth } from '@/contexts/AuthContext';
+import { supabase } from '@/integrations/supabase/client';
+import type { VisitaConversaoRow } from '@/lib/visitas/conversao';
+
+/**
+ * Visitas do vendedor logado (route_visits onde visited_by = eu) numa janela de dias,
+ * só os campos pro breakdown de conversão (result + revenue). RLS own-scoped (#340). Read-only.
+ */
+export function useMinhasVisitasResultado(janelaDias: number) {
+  const { user } = useAuth();
+  return useQuery({
+    queryKey: ['minhas-visitas-resultado', user?.id, janelaDias],
+    enabled: !!user?.id,
+    staleTime: 60_000,
+    gcTime: 5 * 60_000,
+    queryFn: async (): Promise<VisitaConversaoRow[]> => {
+      if (!user?.id) return [];
+      const desde = new Date(Date.now() - janelaDias * 86_400_000).toISOString();
+      const { data, error } = await supabase
+        .from('route_visits')
+        .select('result, revenue_generated')
+        .eq('visited_by', user.id)
+        .gte('check_in_at', desde);
+      if (error) throw new Error(error.message);
+      return (data ?? []) as VisitaConversaoRow[];
+    },
+  });
+}

--- a/src/lib/visitas/__tests__/conversao.test.ts
+++ b/src/lib/visitas/__tests__/conversao.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { agruparVisitasPorResultado } from '../conversao';
+
+describe('agruparVisitasPorResultado', () => {
+  it('agrupa por resultado, soma receita, calcula pct e ordena (fechado primeiro)', () => {
+    const r = agruparVisitasPorResultado([
+      { result: 'pedido_fechado', revenue_generated: 1000 },
+      { result: 'pedido_fechado', revenue_generated: 500 },
+      { result: 'interesse', revenue_generated: null },
+      { result: 'ausente', revenue_generated: null },
+    ]);
+    expect(r.total).toBe(4);
+    expect(r.receitaTotal).toBe(1500);
+    expect(r.buckets.map((b) => b.result)).toEqual(['pedido_fechado', 'interesse', 'ausente']);
+    const fechado = r.buckets[0];
+    expect(fechado).toEqual({ result: 'pedido_fechado', count: 2, revenue: 1500, pct: 0.5 });
+  });
+
+  it('result null → bucket sem_resultado, por último', () => {
+    const r = agruparVisitasPorResultado([
+      { result: null, revenue_generated: null },
+      { result: 'interesse', revenue_generated: null },
+    ]);
+    expect(r.buckets.map((b) => b.result)).toEqual(['interesse', 'sem_resultado']);
+  });
+
+  it('lista vazia → total 0, receita 0, buckets vazio', () => {
+    expect(agruparVisitasPorResultado([])).toEqual({ total: 0, receitaTotal: 0, buckets: [] });
+  });
+});

--- a/src/lib/visitas/conversao.ts
+++ b/src/lib/visitas/conversao.ts
@@ -1,0 +1,50 @@
+/** Agrupa visitas por resultado (route_visits) num breakdown ordenado, com receita por bucket. Puro. */
+
+export interface VisitaConversaoRow {
+  result: string | null;
+  revenue_generated: number | null;
+}
+export interface ConversaoBucket {
+  result: string; // código (pedido_fechado/.../sem_resultado)
+  count: number;
+  revenue: number;
+  pct: number; // count / total (0..1); 0 se total 0
+}
+export interface ConversaoResumo {
+  total: number;
+  receitaTotal: number;
+  buckets: ConversaoBucket[];
+}
+
+const ORDEM = ['pedido_fechado', 'interesse', 'reagendar', 'sem_interesse', 'ausente'];
+
+function rank(k: string): number {
+  const i = ORDEM.indexOf(k);
+  if (i !== -1) return i;
+  return k === 'sem_resultado' ? 99 : 50; // outros no meio; sem_resultado por último
+}
+
+export function agruparVisitasPorResultado(rows: VisitaConversaoRow[]): ConversaoResumo {
+  const total = rows.length;
+  const receitaTotal = rows.reduce((s, r) => s + (r.revenue_generated ?? 0), 0);
+
+  const counts = new Map<string, { count: number; revenue: number }>();
+  for (const r of rows) {
+    const key = r.result ?? 'sem_resultado';
+    const cur = counts.get(key) ?? { count: 0, revenue: 0 };
+    cur.count += 1;
+    cur.revenue += r.revenue_generated ?? 0;
+    counts.set(key, cur);
+  }
+
+  const buckets: ConversaoBucket[] = [...counts.entries()]
+    .sort(([a], [b]) => rank(a) - rank(b))
+    .map(([result, c]) => ({
+      result,
+      count: c.count,
+      revenue: c.revenue,
+      pct: total > 0 ? c.count / total : 0,
+    }));
+
+  return { total, receitaTotal, buckets };
+}


### PR DESCRIPTION
## Resumo
Idea #2 do brainstorm eu+codex. Card **"Resultado das suas visitas"** no dashboard do Closer (área fria — placeholder PR-VISIT-INTELLIGENCE): o **breakdown** das visitas do vendedor (últimos 90d) **por resultado** (✅ Pedido fechado / 🤔 Interesse / 📅 Reagendar / ❌ Sem interesse / 🚫 Ausente) com **count · % · receita por bucket** + totais. Transforma a captura de resultado em aprendizado ("visitamos o cliente certo ou só rodamos de carro?").

**Por que este e não os KPIs (codex #1):** os KPIs (win rate, avg deal) precisam você cravar 5 definições de negócio (codex flagou como o maior risco). O Mapa é o **breakdown cru** — sem métrica derivada ambígua, nenhuma definição necessária. Os KPIs ficam na fila pra quando você confirmar o contrato.

### Read-only, own-scoped, sem backend
`useMinhasVisitasResultado` lê `route_visits` (`visited_by = você`, janela 90d) — RLS own-scoped (#340). Helper puro `agruparVisitasPorResultado` (TDD). Card **self-hide** quando não há visita na janela. Reusa `visitResultLabel` (#555). **Não toca** schema/route_visits/RLS/backend.

## Qualidade
typecheck **0** · lint **0 errors** · test **2081** (incl. `conversao`) · build ✓. Read-only.

## Test plan
- [x] TDD `agruparVisitasPorResultado` (agrupa, soma receita, pct, ordena fechado→ausente, sem_resultado por último, vazio).
- [x] typecheck/lint/test/build verdes.
- [ ] QA manual: logar como Closer com visitas concluídas → card mostra o breakdown; sem visitas → some.

## Follow-up (da fila do brainstorm)
- KPIs de visita (win rate/avg deal) — pendente do contrato de 5 definições.
- Estender o card a Farmer/Hunter (trivial, mesmo componente).
- Versão gestor/master (team-wide) — precisa de RLS gestor + agregação cross-vendedor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)