### PR TITLE
feat(reposicao): entrada de custo de primeira compra no Detalhes (sem SQL)

### DIFF
--- a/src/components/reposicao/pedidos/DetalhesModal.tsx
+++ b/src/components/reposicao/pedidos/DetalhesModal.tsx
@@ -30,6 +30,8 @@ export function DetalhesModal({
     isLoading,
     edits,
     onEditQty,
+    precoEdits,
+    onEditPreco,
     obs,
     setObs,
     condicaoCodigo,
@@ -49,6 +51,7 @@ export function DetalhesModal({
     descontinuarMutation,
     podeEditar,
     podeEditarCondicao,
+    podeEditarPreco,
   } = useDetalhesModal({ pedido, open, onOpenChange, onApproved });
 
   if (!pedido) return null;
@@ -112,6 +115,8 @@ export function DetalhesModal({
             podeEditar={podeEditar}
             totalAtual={totalAtual}
             onEditQty={onEditQty}
+            podeEditarPreco={podeEditarPreco}
+            onEditPreco={onEditPreco}
             onRemover={(l) => setRemoverItem(l)}
             onDescontinuar={(l) => setDescontinuarItem(l)}
             removerPending={removerItemMutation.isPending}
@@ -135,25 +140,25 @@ export function DetalhesModal({
 
         <DialogFooter className="gap-2">
           <Button variant="outline" onClick={() => onOpenChange(false)}>Fechar</Button>
+          {(podeEditar || podeEditarPreco) && (
+            <Button
+              variant="secondary"
+              disabled={(Object.keys(edits).length === 0 && Object.keys(precoEdits).length === 0) || salvarMutation.isPending}
+              onClick={() => salvarMutation.mutate()}
+            >
+              {salvarMutation.isPending && <Loader2 className="w-4 h-4 mr-1 animate-spin" />}
+              Salvar ajustes
+            </Button>
+          )}
           {podeEditar && (
-            <>
-              <Button
-                variant="secondary"
-                disabled={Object.keys(edits).length === 0 || salvarMutation.isPending}
-                onClick={() => salvarMutation.mutate()}
-              >
-                {salvarMutation.isPending && <Loader2 className="w-4 h-4 mr-1 animate-spin" />}
-                Salvar ajustes
-              </Button>
-              <Button
-                disabled={aprovarMutation.isPending || !condicaoSelecionada}
-                onClick={() => aprovarMutation.mutate()}
-                title={!condicaoSelecionada ? 'Selecione a condição de pagamento antes de aprovar' : ''}
-              >
-                {aprovarMutation.isPending && <Loader2 className="w-4 h-4 mr-1 animate-spin" />}
-                ✓ Aprovar e disparar agora
-              </Button>
-            </>
+            <Button
+              disabled={aprovarMutation.isPending || !condicaoSelecionada}
+              onClick={() => aprovarMutation.mutate()}
+              title={!condicaoSelecionada ? 'Selecione a condição de pagamento antes de aprovar' : ''}
+            >
+              {aprovarMutation.isPending && <Loader2 className="w-4 h-4 mr-1 animate-spin" />}
+              ✓ Aprovar e disparar agora
+            </Button>
           )}
         </DialogFooter>
       </DialogContent>

--- a/src/components/reposicao/pedidos/ItensTable.tsx
+++ b/src/components/reposicao/pedidos/ItensTable.tsx
@@ -8,12 +8,15 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@
 import { cn } from '@/lib/utils';
 import { getEstoqueZoneClass, formatBRL } from './shared';
 import { type Linha } from './useDetalhesModal';
+import { precoEditavelDaLinha } from './preco-edit';
 
 interface ItensTableProps {
   linhas: Linha[];
   podeEditar: boolean;
   totalAtual: number;
   onEditQty: (id: number, raw: string) => void;
+  podeEditarPreco: boolean;
+  onEditPreco: (id: number, raw: string) => void;
   onRemover: (l: Linha) => void;
   onDescontinuar: (l: Linha) => void;
   removerPending: boolean;
@@ -25,6 +28,8 @@ export function ItensTable({
   podeEditar,
   totalAtual,
   onEditQty,
+  podeEditarPreco,
+  onEditPreco,
   onRemover,
   onDescontinuar,
   removerPending,
@@ -91,7 +96,21 @@ export function ItensTable({
                 )}>{l._qtd.toFixed(0)}</span>
               )}
             </TableCell>
-            <TableCell className="text-right tabular-nums">{formatBRL(l.preco_unitario)}</TableCell>
+            <TableCell className="text-right">
+              {precoEditavelDaLinha(podeEditarPreco, l) ? (
+                <Input
+                  type="number"
+                  min={0}
+                  step="0.01"
+                  placeholder="custo"
+                  className="h-8 w-24 ml-auto text-right tabular-nums border-status-warning/60"
+                  value={l._preco || ''}
+                  onChange={(e) => onEditPreco(l.id, e.target.value)}
+                />
+              ) : (
+                <span className="tabular-nums">{formatBRL(l._preco)}</span>
+              )}
+            </TableCell>
             <TableCell className="text-right tabular-nums font-medium">{formatBRL(l._valor)}</TableCell>
             {podeEditar && (
               <TableCell className="text-right">

--- a/src/components/reposicao/pedidos/__tests__/ItensTable.test.tsx
+++ b/src/components/reposicao/pedidos/__tests__/ItensTable.test.tsx
@@ -20,6 +20,7 @@ function linha(partial: Partial<Linha>): Linha {
     primeira_compra: null,
     ajustado_humano: null,
     _qtd: 10,
+    _preco: 3,
     _valor: 30,
     ...partial,
   } as Linha;
@@ -31,6 +32,8 @@ function setup(overrides: Partial<React.ComponentProps<typeof ItensTable>> = {})
     podeEditar: true,
     totalAtual: 30,
     onEditQty: vi.fn(),
+    podeEditarPreco: false,
+    onEditPreco: vi.fn(),
     onRemover: vi.fn(),
     onDescontinuar: vi.fn(),
     removerPending: false,
@@ -72,5 +75,23 @@ describe('ItensTable', () => {
     setup({ podeEditar: false, linhas: [linha({ _qtd: 4, qtde_sugerida: 10 })] });
     // 4 (qtd final divergente) é renderizado como span destacado
     expect(screen.getByText('4')).toBeTruthy();
+  });
+
+  it('item sem custo + podeEditarPreco: mostra input de preço e dispara onEditPreco', () => {
+    const onEditPreco = vi.fn();
+    setup({
+      podeEditar: false,
+      podeEditarPreco: true,
+      onEditPreco,
+      linhas: [linha({ preco_unitario: 0, _preco: 0 })],
+    });
+    const precoInput = screen.getByPlaceholderText('custo');
+    fireEvent.change(precoInput, { target: { value: '25.35' } });
+    expect(onEditPreco).toHaveBeenCalledWith(1, '25.35');
+  });
+
+  it('item COM custo válido: preço fica read-only mesmo com podeEditarPreco', () => {
+    setup({ podeEditar: false, podeEditarPreco: true, linhas: [linha({ preco_unitario: 9, _preco: 9 })] });
+    expect(screen.queryByPlaceholderText('custo')).toBeNull();
   });
 });

--- a/src/components/reposicao/pedidos/__tests__/preco-edit.test.ts
+++ b/src/components/reposicao/pedidos/__tests__/preco-edit.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { montarUpdateItem, podeEditarPrecoPedido, precoEditavelDaLinha, precoEditValido } from '../preco-edit';
+
+describe('preco-edit — gating por status do pedido', () => {
+  it('permite editar preço em falha_envio, pendente_aprovacao e bloqueado_guardrail', () => {
+    expect(podeEditarPrecoPedido('falha_envio')).toBe(true);
+    expect(podeEditarPrecoPedido('pendente_aprovacao')).toBe(true);
+    expect(podeEditarPrecoPedido('bloqueado_guardrail')).toBe(true);
+  });
+  it('NÃO permite em estados já disparados/aprovados/cancelados nem em null/undefined', () => {
+    expect(podeEditarPrecoPedido('disparado')).toBe(false);
+    expect(podeEditarPrecoPedido('aprovado_aguardando_disparo')).toBe(false);
+    expect(podeEditarPrecoPedido('cancelado')).toBe(false);
+    expect(podeEditarPrecoPedido(null)).toBe(false);
+    expect(podeEditarPrecoPedido(undefined)).toBe(false);
+  });
+});
+
+describe('preco-edit — qual item ganha input', () => {
+  it('só item SEM custo (preço <= 0 / null) quando o pedido permite', () => {
+    expect(precoEditavelDaLinha(true, { preco_unitario: 0 })).toBe(true);
+    expect(precoEditavelDaLinha(true, { preco_unitario: null })).toBe(true);
+    expect(precoEditavelDaLinha(true, { preco_unitario: -1 })).toBe(true);
+  });
+  it('item com custo válido fica read-only (não editável)', () => {
+    expect(precoEditavelDaLinha(true, { preco_unitario: 25.35 })).toBe(false);
+    expect(precoEditavelDaLinha(true, { preco_unitario: 0.01 })).toBe(false);
+  });
+  it('nunca editável quando o pedido não permite, mesmo com preço 0', () => {
+    expect(precoEditavelDaLinha(false, { preco_unitario: 0 })).toBe(false);
+  });
+});
+
+describe('preco-edit — validação money-path (nunca gravar preço <= 0)', () => {
+  it('aceita só valor finito e > 0', () => {
+    expect(precoEditValido(25.35)).toBe(true);
+    expect(precoEditValido(113.98)).toBe(true);
+  });
+  it('rejeita 0, negativo, NaN e Infinity', () => {
+    expect(precoEditValido(0)).toBe(false);
+    expect(precoEditValido(-5)).toBe(false);
+    expect(precoEditValido(NaN)).toBe(false);
+    expect(precoEditValido(Infinity)).toBe(false);
+  });
+});
+
+describe('preco-edit — montarUpdateItem (money-path: não reescrever preço válido)', () => {
+  const item = { qtde_final: 5, qtde_sugerida: 8, preco_unitario: 20 };
+
+  it('quantity-only: NÃO inclui preco_unitario (preserva o preço válido)', () => {
+    const u = montarUpdateItem(item, 7, undefined);
+    expect(u.qtde_final).toBe(7);
+    expect(u.valor_linha).toBe(7 * 20);
+    expect('preco_unitario' in u).toBe(false);
+  });
+
+  it('price-only: inclui preco_unitario e preserva a quantidade atual', () => {
+    const u = montarUpdateItem({ ...item, preco_unitario: 0 }, undefined, 25.35);
+    expect(u.qtde_final).toBe(5);
+    expect(u.preco_unitario).toBe(25.35);
+    expect(u.valor_linha).toBeCloseTo(5 * 25.35);
+  });
+
+  it('ambos (qtde + preço): inclui preço novo e quantidade nova', () => {
+    const u = montarUpdateItem({ ...item, preco_unitario: 0 }, 3, 25.35);
+    expect(u.qtde_final).toBe(3);
+    expect(u.preco_unitario).toBe(25.35);
+    expect(u.valor_linha).toBeCloseTo(3 * 25.35);
+  });
+
+  it('price-only com qtde_final null usa qtde_sugerida', () => {
+    const u = montarUpdateItem({ qtde_final: null, qtde_sugerida: 8, preco_unitario: 0 }, undefined, 25.35);
+    expect(u.qtde_final).toBe(8);
+    expect(u.preco_unitario).toBe(25.35);
+  });
+});

--- a/src/components/reposicao/pedidos/preco-edit.ts
+++ b/src/components/reposicao/pedidos/preco-edit.ts
@@ -1,0 +1,65 @@
+// Lógica pura da edição de custo de primeira compra no DetalhesModal.
+// Permite definir o preço de itens SEM custo (preco_unitario <= 0) direto na tela,
+// substituindo o flip de status + UPDATE no SQL Editor. Money-path: nunca grava
+// preço <= 0 (o disparo rejeita nValUnit=0 no Omie).
+import type { PedidoItem, Status } from './types';
+
+// Estados em que o custo de um item de primeira compra (preço 0) pode ser definido
+// na tela:
+// - pendente_aprovacao / bloqueado_guardrail: definir ANTES de aprovar (previne a falha).
+// - falha_envio: recuperar o pedido que já falhou por "SKU(s) sem custo (preço 0)".
+// Fora desses (disparado, aprovado_aguardando_disparo, cancelado): read-only.
+const ESTADOS_EDITA_PRECO: ReadonlySet<string> = new Set([
+  'pendente_aprovacao',
+  'bloqueado_guardrail',
+  'falha_envio',
+]);
+
+export function podeEditarPrecoPedido(status: Status | null | undefined): boolean {
+  return !!status && ESTADOS_EDITA_PRECO.has(status);
+}
+
+// Um item só ganha input de preço quando o pedido permite E o item está sem custo
+// (preço <= 0) — exatamente o que trava o disparo. Item com custo válido fica
+// read-only (não arriscar fat-finger num preço bom que já veio do motor/recebimento).
+export function precoEditavelDaLinha(
+  podeEditarPreco: boolean,
+  item: Pick<PedidoItem, 'preco_unitario'>,
+): boolean {
+  return podeEditarPreco && !(Number(item.preco_unitario ?? 0) > 0);
+}
+
+// Valida um valor de preço digitado antes de gravar: finito e > 0.
+export function precoEditValido(v: number): boolean {
+  return Number.isFinite(v) && v > 0;
+}
+
+export interface ItemUpdate {
+  qtde_final: number;
+  valor_linha: number;
+  ajustado_humano: true;
+  // Só presente quando o usuário editou o preço — NUNCA reescrito a partir de um
+  // ajuste só-de-quantidade (senão um quantity-only edit poderia zerar um preço
+  // válido quando o item está fora do cache). Codex review [P1].
+  preco_unitario?: number;
+}
+
+// Monta o patch de um item editado a partir dos ajustes de quantidade (`qtdEdit`)
+// e de preço (`precoEdit`, undefined = sem edição de preço). Money-path: só inclui
+// `preco_unitario` quando houve edição de preço; quantidade-só preserva o preço atual.
+export function montarUpdateItem(
+  item: Pick<PedidoItem, 'qtde_final' | 'qtde_sugerida' | 'preco_unitario'>,
+  qtdEdit: number | undefined,
+  precoEdit: number | undefined,
+): ItemUpdate {
+  const temPrecoEdit = precoEdit !== undefined;
+  const qtd = qtdEdit ?? Number(item.qtde_final ?? item.qtde_sugerida ?? 0);
+  const preco = temPrecoEdit ? (precoEdit as number) : Number(item.preco_unitario ?? 0);
+  const update: ItemUpdate = {
+    qtde_final: qtd,
+    valor_linha: qtd * preco,
+    ajustado_humano: true,
+  };
+  if (temPrecoEdit) update.preco_unitario = preco;
+  return update;
+}

--- a/src/components/reposicao/pedidos/useDetalhesModal.ts
+++ b/src/components/reposicao/pedidos/useDetalhesModal.ts
@@ -8,8 +8,9 @@ import { toast } from 'sonner';
 import { logger } from '@/lib/logger';
 import { PedidoSugerido, PedidoItem, CondicaoPagamento } from './types';
 import { interpretarRespostaDisparo, type RespostaDisparo } from './shared';
+import { montarUpdateItem, podeEditarPrecoPedido, precoEditValido } from './preco-edit';
 
-export type Linha = PedidoItem & { _qtd: number; _valor: number };
+export type Linha = PedidoItem & { _qtd: number; _preco: number; _valor: number };
 
 interface UseDetalhesModalArgs {
   pedido: PedidoSugerido | null;
@@ -22,6 +23,7 @@ export function useDetalhesModal({ pedido, open, onOpenChange, onApproved }: Use
   const { user } = useAuth();
   const queryClient = useQueryClient();
   const [edits, setEdits] = useState<Record<number, number>>({});
+  const [precoEdits, setPrecoEdits] = useState<Record<number, number>>({});
   const [obs, setObs] = useState('');
   const [condicaoCodigo, setCondicaoCodigo] = useState<string>('');
   const [removerItem, setRemoverItem] = useState<PedidoItem | null>(null);
@@ -80,6 +82,7 @@ export function useDetalhesModal({ pedido, open, onOpenChange, onApproved }: Use
   useEffect(() => {
     if (!open) {
       setEdits({});
+      setPrecoEdits({});
       setObs('');
       setCondicaoCodigo('');
     } else if (pedido) {
@@ -90,10 +93,10 @@ export function useDetalhesModal({ pedido, open, onOpenChange, onApproved }: Use
   const linhas = useMemo<Linha[]>(() => {
     return (itens ?? []).map((it) => {
       const qtd = edits[it.id] ?? Number(it.qtde_final ?? it.qtde_sugerida);
-      const preco = Number(it.preco_unitario ?? 0);
-      return { ...it, _qtd: qtd, _valor: qtd * preco };
+      const preco = precoEdits[it.id] ?? Number(it.preco_unitario ?? 0);
+      return { ...it, _qtd: qtd, _preco: preco, _valor: qtd * preco };
     });
-  }, [itens, edits]);
+  }, [itens, edits, precoEdits]);
 
   const totalAtual = useMemo(
     () => linhas.reduce((acc, l) => acc + l._valor, 0),
@@ -103,18 +106,24 @@ export function useDetalhesModal({ pedido, open, onOpenChange, onApproved }: Use
   const salvarMutation = useMutation({
     mutationFn: async () => {
       if (!pedido) return;
-      const updates = Object.entries(edits);
-      for (const [itemId, qtd] of updates) {
-        const item = (itens ?? []).find((i) => i.id === Number(itemId));
-        const preco = Number(item?.preco_unitario ?? 0);
+      // Money-path: nunca gravar preço <= 0 (o disparo rejeita nValUnit=0 no Omie).
+      const precoInvalido = Object.values(precoEdits).find((v) => !precoEditValido(v));
+      if (precoInvalido !== undefined) {
+        throw new Error('Custo inválido: informe um valor maior que zero.');
+      }
+      // União dos itens com ajuste de quantidade OU de preço.
+      const idsEditados = new Set<number>([
+        ...Object.keys(edits).map(Number),
+        ...Object.keys(precoEdits).map(Number),
+      ]);
+      for (const itemId of idsEditados) {
+        const item = (itens ?? []).find((i) => i.id === itemId);
+        if (!item) continue; // item saiu do cache — não grava (evita zerar preço). Codex [P1].
+        const update = montarUpdateItem(item, edits[itemId], precoEdits[itemId]);
         const { error } = await supabase
           .from('pedido_compra_item')
-          .update({
-            qtde_final: qtd,
-            valor_linha: qtd * preco,
-            ajustado_humano: true,
-          })
-          .eq('id', Number(itemId));
+          .update(update)
+          .eq('id', itemId);
         if (error) throw error;
       }
       const novoTotal = linhas.reduce((acc, l) => acc + l._valor, 0);
@@ -129,6 +138,7 @@ export function useDetalhesModal({ pedido, open, onOpenChange, onApproved }: Use
       queryClient.invalidateQueries({ queryKey: ['pedido-itens', pedido?.id] });
       queryClient.invalidateQueries({ queryKey: ['pedidos-ciclo'] });
       setEdits({});
+      setPrecoEdits({});
     },
     onError: (e: Error) => {
       logger.error('Erro ao salvar ajustes', { error: e });
@@ -320,9 +330,25 @@ export function useDetalhesModal({ pedido, open, onOpenChange, onApproved }: Use
     setEdits((prev) => ({ ...prev, [id]: isNaN(v) ? 0 : v }));
   };
 
+  const onEditPreco = (id: number, raw: string) => {
+    setPrecoEdits((prev) => {
+      if (raw.trim() === '') {
+        // Campo vazio: remove o edit (volta ao placeholder), não vira 0. Codex [P2].
+        const next = { ...prev };
+        delete next[id];
+        return next;
+      }
+      const v = Number(raw);
+      return { ...prev, [id]: Number.isNaN(v) ? 0 : v };
+    });
+  };
+
   const podeEditar =
     pedido?.status === 'pendente_aprovacao' || pedido?.status === 'bloqueado_guardrail';
   const podeEditarCondicao = podeEditar || pedido?.status === 'aprovado_aguardando_disparo';
+  // Custo de primeira compra (preço 0): definível na tela tb em falha_envio
+  // (recupera o pedido sem flip de status no SQL). Ver preco-edit.ts.
+  const podeEditarPreco = podeEditarPrecoPedido(pedido?.status);
 
   return {
     condicoes,
@@ -330,6 +356,8 @@ export function useDetalhesModal({ pedido, open, onOpenChange, onApproved }: Use
     isLoading,
     edits,
     onEditQty,
+    precoEdits,
+    onEditPreco,
     obs,
     setObs,
     condicaoCodigo,
@@ -349,5 +377,6 @@ export function useDetalhesModal({ pedido, open, onOpenChange, onApproved }: Use
     descontinuarMutation,
     podeEditar,
     podeEditarCondicao,
+    podeEditarPreco,
   };
 }


### PR DESCRIPTION
## Problema

Item de **primeira compra** (sem `preco_unitario`) trava o disparo: o guard money-path (#422) rejeita `nValUnit=0` no Omie → o pedido fica em `falha_envio` com `"SKU(s) sem custo (preço 0)"`. Definir o custo exigia `UPDATE pedido_compra_item` no SQL Editor — toda vez que um SKU novo entra no motor.

Caso real: os pedidos Sayerlack #324/#325 falharam por 3 SKUs de primeira compra (POLIULACK, BASE TEXT, SELADORA) sem custo.

## Mudança

Permite digitar o custo direto no **Detalhes** do pedido, sem SQL.

- **`preco-edit.ts`** (helper puro, testado) — gating: editável só em `pendente_aprovacao` / `bloqueado_guardrail` / `falha_envio`, e **só para item sem custo** (`preco_unitario <= 0`); validação `> 0`.
- **`useDetalhesModal`** — estado `precoEdits`, `linhas._preco`, `salvarMutation` persiste `preco_unitario` + `valor_linha` + `valor_total`; **bloqueia salvar preço <= 0** (money-path).
- **`ItensTable`** — input de preço (placeholder "custo", borda de alerta) só nos itens/estados permitidos; item com custo válido fica read-only (não arriscar fat-finger num preço bom).
- **`DetalhesModal`** — "Salvar ajustes" passa a aparecer em `falha_envio` (antes só `pendente`/`bloqueado`).
- testes: `preco-edit` (7 casos) + `ItensTable` (mostra input p/ sem-custo, read-only p/ com-custo).

**Fluxo completo (compõe com #558):** abre Detalhes → digita o custo → Salvar → fecha → **Re-disparar**. Quantidade segue read-only em `falha_envio` (só o custo é editável). Sem migration, sem edge.

## Stack

Empilhado no **#558** (base = `claude/reposicao-falha-envio-operavel`; ambos tocam `DetalhesModal.tsx`/`types.ts`). Merge: #558 primeiro, depois este. Quando #558 mergear, o GitHub retargeta a base pra `main`.

## Validação

typecheck strict ✓ · suite ✓ · lint 0 errors ✓ · build ✓ · codex review (money-path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
