### PR TITLE
docs(roadmap): sync — Fix #1 + Visitas/Rota #2/#3 concluídos

### DIFF
--- a/docs/roadmap-sessao.md
+++ b/docs/roadmap-sessao.md
@@ -1,4 +1,4 @@
-# Roadmap da Sessão — atualizado 2026-06-01
+# Roadmap da Sessão — atualizado 2026-06-04
 
 > **Documento vivo.** Re-feito sempre que acrescentamos OU concluímos uma atividade, e renderizado no chat quando muda, pra o founder acompanhar. Prática padrão de toda sessão (registrada no CLAUDE.md, topo).
 >
@@ -8,22 +8,23 @@
 
 ## 1. Tarefas — Fase 1 (cobrança das vendedoras)
 - ✅ **Desenho → spec → plano → build → ship.** PRs **#545** (módulo), **#549** (registro CLAUDE.md), **#551** (fix do e-mail de cobrança). Backend vivo em produção (6 migrations + crons + fix do matcher).
-- ⏳ **Verificação visual da Fase 1** (founder) — **GATE** que libera o build da Fase 2. Em andamento (você está testando no preview do Lovable).
-- 🔄 **Fix #1 — card "Minhas tarefas" visível no "Ver como"** (impersonation-aware no `useMinhasTarefas` + render no `MasterDashboard`, somente-leitura quando impersonando). Acordado nesta sessão; **aguardando seu OK pra implementar**.
+- ✅ **Fix #1 — card "Minhas tarefas" visível no "Ver como"** (impersonation-aware no `useMinhasTarefas` + render no `MasterDashboard`, somente-leitura quando impersonando). **PR #559, mergeado.** (Pegou um CI do guard `no-write-leak` — `effectiveUserId` é uso read-only; resolvido com allowlist + justificativa.)
+- ⏳ **Verificação visual da Fase 1** (founder) — **GATE** que libera o build da Fase 2. Depende de **Publish no Lovable** + clicar no preview. **Bola com você.**
 - ⏸️ **Fast-follow — editar tarefa** (cancelar já existe; YAGNI até o uso mostrar necessidade).
 
 ## 2. Tarefas — Fase 2 (enforcement: recorrência + trava de comprovação)
-- ✅ **Desenho → spec (endurecido com passe adversário do codex) → plano.** PR **#553** (doc-only).
-- 🚧 **Build** — **BLOQUEADO** até a Fase 1 ser verificada (decisão eu+codex: não empilhar código sobre base não-clicada).
+- ✅ **Desenho → spec (endurecido com passe adversário do codex) → plano.** PR **#553** (doc-only), mergeado.
+- 🚧 **Build** — **BLOQUEADO** até a Fase 1 ser verificada (decisão eu+codex: não empilhar código sobre base não-clicada). Plano pronto: 5 blocos SQL (A: `tarefa_templates`; B: colunas de comprovação + `customer_user_id` nullable + CHECK + UNIQUE; C: view window-aware + RLS; D: trigger anti-bypass + RPCs + cron de materialização; E: bucket de Storage).
 
 ## 3. Visitas sugeridas / Rota (feature EXISTENTE — feedback desta sessão)
-> Contexto confirmado: **Regina e Tatyana são farmers só de ligação + WhatsApp** (não fazem visita presencial).
-- 🧭 **#2 — realinhar "Visitas sugeridas"** pras vendedoras que só ligam (relabel "Visitas"→"Ligações"? trocar o dashboard pra usar a lista de ligações da rota? ajustar persona/cópia?). **Decisão eu+codex em andamento.**
-- 🧭 **#3 — city picker default só nas cidades da rota do dia (D-1)**, com "ver outras cidades" como opção secundária. **Decisão eu+codex.**
+> Contexto confirmado: **Regina e Tatyana são farmers só de ligação + WhatsApp** (não fazem visita presencial). Decisão eu+codex: o dashboard delas deve liderar com a lista de ligações da rota, não com visitas.
+- ✅ **#2 — dashboard do farmer lidera com "Ligações da rota"** (CTA → `/rota/ligacoes`); card "Visitas sugeridas" renomeado pra **"Visitas sugeridas — equipes de campo"** (só Hunter/Closer visitam presencialmente). **PR #562, mergeado.**
+- ✅ **#3 — lista default só nas cidades da rota (D-1).** A `/rota/ligacoes` **já é D-1 por construção** (`useRouteContactList` usa as cidades da rota de amanhã); o farmer agora é apontado pra ela. **Subsumido por #562 + o programa de rota existente.**
+- ⏸️ **Deferred — `useRouteContactList` impersonation-aware** (pra "Ver como farmer" mostrar as ligações daquele farmer). Follow-up de baixo valor sem demanda concreta.
 
 ---
 
 ### Encerramento da sessão (housekeeping recorrente)
-- Manter este roadmap atualizado a cada mudança.
-- PRs de doc/fix abertos com auto-merge quando o CI passar.
-- Lembrar o founder do que depende dele (verificação visual; deploy/Publish no Lovable; SQL no SQL Editor).
+- Manter este roadmap atualizado a cada mudança (este sync reflete **#559 + #562 mergeados**).
+- PRs de doc/fix abertos com auto-merge quando o CI passar. **Nada meu em voo** — todos os PRs da sessão (#545/#549/#551/#553/#557/#559/#562) mergeados.
+- **O que depende de você:** verificação visual da Fase 1 (libera o build da Fase 2) · Publish no Lovable pro preview · SQL no SQL Editor quando houver migration (a Fase 2 terá).


### PR DESCRIPTION
Sincroniza `docs/roadmap-sessao.md` com o estado real da sessão (prática de roadmap vivo):

- **Fix #1** (card no "Ver como") 🔄→✅ — PR #559 mergeado
- **Visitas/Rota #2 e #3** 🧭→✅ — PR #562 mergeado (farmer lidera com "Ligações da rota"; visitas relabeled "— equipes de campo"; lista já é D-1)

Doc-only. Único item pendente da sessão = **verificação visual da Fase 1** (founder), que destrava o build da Fase 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)