### PR TITLE
feat(dashboard): Follow-ups sugeridos — próxima ação pós-visita no Closer

### DIFF
--- a/docs/superpowers/specs/2026-06-04-followups-sugeridos-design.md
+++ b/docs/superpowers/specs/2026-06-04-followups-sugeridos-design.md
@@ -1,0 +1,73 @@
+# "Follow-ups sugeridos" — card read-only pós-visita (dashboard Closer)
+
+**Data:** 2026-06-04 · **Tipo:** front puro, read-only, sem migration/edge/deploy · **Branch:** `claude/next-best-action-visita`
+
+## Problema
+
+O check-out de visita (`CheckoutDialog`) grava `result`/`revenue`/`notes` e **acaba ali** — não há nenhum prompt de "e agora?". Resultados **mornos** (`reagendar`/`interesse`/`ausente`) decaem sem follow-up: o vendedor esquece de voltar/ligar. Não há superfície que diga "essas visitas pedem retorno".
+
+## Solução (v1)
+
+Card **"Follow-ups sugeridos"** no dashboard Closer. Lista as visitas do vendedor logado cujo **estado atual** pede uma próxima ação, com deep-link pro fluxo existente (agendar/abrir cliente). **Read-only**: clicar NÃO grava nada — abre o fluxo já existente. Quando o vendedor age (agenda retorno / liga), a regra de de-dup tira o item no próximo refetch.
+
+> **Nome deliberado** (codex P1): "Follow-ups sugeridos", NÃO "Next Best Action" / "Próxima melhor ação" — não prometer ranking inteligente sobre uma heurística client-side. É sugestão, não verdade.
+
+### Por que é baixo-risco (vs. um KPI)
+
+As sugestões são **hints não-vinculantes** — errar "aproximadamente" é barato (≠ um win-rate oficial, que vira número que o gestor age em cima). O único dano possível é o vendedor confiar e contatar um cliente já resolvido por outro canal → mitigado pelo **de-dup contra agenda pendente + contato recente** (abaixo) e pela moldura honesta ("sugestão").
+
+## Dado (tudo já existe; RLS own-scoped; 3 queries leves)
+
+1. **`route_visits`** (`visited_by = eu`, `check_in_at >= hoje−45d`): `customer_user_id, result, notes, check_in_at, visit_date, revenue_generated`. (45d = a janela mais larga; o helper aplica a janela por-resultado.)
+2. **`visitas_agendadas`** (`scheduled_by = eu`, `status = pendente`, `scheduled_date >= hoje`): `customer_user_id` → Set "já agendei retorno".
+3. **`farmer_calls`** (`farmer_id = eu`, `started_at >= hoje−45d`): `customer_user_id, started_at` → Map "último contato meu por cliente". (Sem filtro de transcript — qualquer contato conta.)
+
+Enriquecimento de nome: `profiles.select('user_id, name')` pelos `customer_user_id` dos itens finais.
+
+## Regra de geração (helper PURO testável — `src/lib/visitas/followups.ts`)
+
+`montarFollowups({ visitas, agendadasPendentes, ultimoContatoPorCliente, hojeISO }) → FollowupItem[]`
+
+1. Agrupa `visitas` por `customer_user_id`; fica com a **mais recente** (por `check_in_at ?? visit_date`).
+2. Inclui só se `result ∈ {reagendar, interesse, ausente}` (mornos que decaem). Dropa `pedido_fechado` (ganho, sem ação pendente — pós-venda é outro produto), `sem_interesse` e `null`.
+3. **De-dup agenda:** dropa se `customer_user_id ∈ agendadasPendentes`.
+4. **De-dup contato** (codex P1): dropa se `ultimoContatoPorCliente.get(cid) > lastVisitAt` (já liguei/contatei DEPOIS da visita). Sem isso, o card "nunca limpa" pra quem resolve por telefone.
+5. **Janela por-resultado** (codex P1; `diasDesde(lastVisitAt, hojeISO)`): `reagendar ≤ 45d`, `interesse ≤ 30d`, `ausente ≤ 21d`. Fora da janela → dropa (lead frio vira ruído; não mostrar "60d esfriando" na v1 — isso seria CRM de recuperação, outro produto).
+6. **Ordena** (codex P2): `reagendar (0) > interesse (1) > ausente (2)` — interesse é oportunidade, ausente é logística; dentro de cada, **mais recente primeiro** (`diasDesde` asc).
+
+`FollowupItem = { customerUserId, result: 'reagendar'|'interesse'|'ausente', lastVisitAt: string, diasDesde: number, notes: string | null }`.
+
+Helper retorna **todos** os itens ordenados (count honesto); o componente renderiza os primeiros 5.
+
+## UI (`FollowupsSugeridosCard` + hook `useFollowupsVisita`)
+
+- **Self-hide** quando 0 itens.
+- Header: "Follow-ups sugeridos" + subtítulo "Visitas que pedem retorno" + count total. Se total > 5, "+N mais" mudo (sem destino dedicado na v1 — codex).
+- Cada linha (até 5):
+  - **Nome do cliente** = `<Link to="/customer/:id">` (Customer360 → ligar/WhatsApp/pedido/histórico; afordância universal).
+  - Badge do resultado (`visitResultLabel`) + "há N dias" (`recenciaLabel`).
+  - **Snippet de `notes`** truncado em 1 linha, se houver (codex P3 — contexto reduz ação errada).
+  - **Ação primária por resultado** (deep-link, não muta):
+    - `reagendar`, `interesse` → "Agendar retorno" → `AgendarVisitaDialog` (cliente preselecionado).
+    - `ausente` → "Tentar de novo" → `AgendarVisitaDialog` (agendar nova tentativa). Pra ligar antes, o nome-link leva ao Customer360.
+- **Placement:** dashboard **Closer** (outbound presencial), após `VisitSuggestionsCard` e antes do `MinhasVisitasResultadoCard` (agenda → sugestões do motor → follow-ups concretos → estatística de conversão). **NÃO** estender a Farmer/Hunter na v1 (semânticas diferentes — codex P3).
+
+## Não-objetivos (v1) / v2
+
+- Deep-link inline de **Ligar/WhatsApp** e **Pedido** por-resultado (precisa do telefone do cliente / mais botões) → v2; hoje o nome-link cobre via Customer360.
+- Microfrase de **histórico morno anterior** ("interesse anterior há 10d") — codex P2, cheap mas adia (o snippet de notes já dá contexto).
+- Mostrar `revenue_generated > 0` sem pedido como "potencial".
+- Janela única "esfriando" (60d+) / CRM de recuperação.
+- `pedido_fechado` → follow-up de pós-venda (retenção/CS) — outro produto.
+
+## Tarefas
+
+1. Helper `src/lib/visitas/followups.ts` + testes (`__tests__/followups.test.ts`) — TDD. Reusa `diasDesde` de `recencia.ts`.
+2. Hook `src/hooks/useFollowupsVisita.ts` — 3 queries own-scoped + enrich nome + `montarFollowups`.
+3. Componente `src/components/dashboard/FollowupsSugeridosCard.tsx`.
+4. Placement no `CloserDashboard.tsx`.
+5. Validação: typecheck (strict) + lint + test + build (todos verdes).
+
+## Codex
+
+Consult adversarial (2026-06-04, `model_reasoning_effort=medium`): validou baixo-risco vs KPI; P1 = nome honesto + de-dup contato + janelas por-resultado; P2 = ordem reagendar>interesse>ausente + última-visita-como-estado; P3 = snippet de notes + limite 5 + Closer-only. Todos incorporados acima.

--- a/src/components/dashboard/CloserDashboard.tsx
+++ b/src/components/dashboard/CloserDashboard.tsx
@@ -3,6 +3,7 @@ import { Construction, MapPin, Target, TrendingUp } from 'lucide-react';
 import { VisitSuggestionsCard } from './VisitSuggestionsCard';
 import { VisitasHojeCard } from './VisitasHojeCard';
 import { MinhasVisitasResultadoCard } from './MinhasVisitasResultadoCard';
+import { FollowupsSugeridosCard } from './FollowupsSugeridosCard';
 import { MinhasTarefasCard } from '@/components/tarefas/MinhasTarefasCard';
 
 /**
@@ -25,6 +26,9 @@ export function CloserDashboard() {
 
       {/* Sugestões de visita — PR-VISIT-INTELLIGENCE Sub-PR A */}
       <VisitSuggestionsCard />
+
+      {/* Follow-ups pós-visita: visitas mornas que pedem retorno (read-only, deep-link) */}
+      <FollowupsSugeridosCard />
 
       <MinhasVisitasResultadoCard />
 

--- a/src/components/dashboard/FollowupsSugeridosCard.tsx
+++ b/src/components/dashboard/FollowupsSugeridosCard.tsx
@@ -1,0 +1,100 @@
+/**
+ * Card "Follow-ups sugeridos" no dashboard Closer.
+ * Lista as visitas do vendedor cujo estado atual pede retorno (mornas, sem agenda nem
+ * contato posterior), com deep-link pro fluxo existente. Read-only / heurística — sugestão,
+ * não "next best action inteligente". Self-hide quando vazio.
+ * Spec: docs/superpowers/specs/2026-06-04-followups-sugeridos-design.md
+ */
+import { Link } from 'react-router-dom';
+import { Card, CardHeader } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { CalendarClock, Flame, UserX, Loader2, ListTodo, type LucideIcon } from 'lucide-react';
+import { useFollowupsVisita } from '@/hooks/useFollowupsVisita';
+import { AgendarVisitaDialog } from '@/components/visitas/AgendarVisitaDialog';
+import { recenciaLabel } from '@/lib/visitas/recencia';
+import { hojeISO } from '@/lib/visitas/today';
+import type { FollowupResult } from '@/lib/visitas/followups';
+
+const LIMITE = 5;
+
+const META: Record<FollowupResult, { label: string; icon: LucideIcon; box: string; text: string; acao: string }> = {
+  reagendar: { label: 'Reagendar', icon: CalendarClock, box: 'bg-status-warning-bg', text: 'text-status-warning', acao: 'Agendar retorno' },
+  interesse: { label: 'Interesse', icon: Flame, box: 'bg-status-info-bg', text: 'text-status-info', acao: 'Agendar retorno' },
+  ausente: { label: 'Ausente', icon: UserX, box: 'bg-status-warning-bg', text: 'text-status-warning', acao: 'Tentar de novo' },
+};
+
+export function FollowupsSugeridosCard() {
+  const { data, isLoading } = useFollowupsVisita();
+
+  if (isLoading) {
+    return (
+      <Card className="p-6 flex justify-center">
+        <Loader2 className="w-5 h-5 animate-spin text-muted-foreground" />
+      </Card>
+    );
+  }
+
+  const items = data?.items ?? [];
+  if (items.length === 0) return null; // self-hide
+
+  const hoje = hojeISO();
+  const visiveis = items.slice(0, LIMITE);
+  const restante = items.length - visiveis.length;
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between gap-3 pb-3">
+        <div className="flex items-center gap-2">
+          <ListTodo className="w-4 h-4 text-muted-foreground" />
+          <div>
+            <h2 className="text-base font-medium">Follow-ups sugeridos</h2>
+            <p className="text-2xs text-muted-foreground">Visitas que pedem retorno</p>
+          </div>
+        </div>
+        <Badge variant="outline" className="text-2xs">{items.length}</Badge>
+      </CardHeader>
+
+      <div className="divide-y divide-border">
+        {visiveis.map((it) => {
+          const meta = META[it.result];
+          const Icon = meta.icon;
+          const nome = data?.nomePorCliente.get(it.customerUserId) || 'Cliente';
+          return (
+            <div key={it.customerUserId} className="p-3 flex items-center gap-3 hover:bg-muted/30">
+              <div className={`p-1.5 rounded ${meta.box} ${meta.text} shrink-0`}>
+                <Icon className="w-4 h-4" />
+              </div>
+
+              <Link to={`/admin/customers/${it.customerUserId}/360`} className="flex-1 min-w-0">
+                <div className="text-sm font-medium truncate">{nome}</div>
+                <div className="text-2xs text-muted-foreground flex items-center gap-2 flex-wrap">
+                  <Badge variant="outline" className={`${meta.text} text-2xs`}>{meta.label}</Badge>
+                  <span>{recenciaLabel(it.lastVisitAt, hoje)}</span>
+                </div>
+                {it.notes && (
+                  <div className="text-2xs text-muted-foreground/80 truncate mt-0.5 italic">&ldquo;{it.notes}&rdquo;</div>
+                )}
+              </Link>
+
+              <AgendarVisitaDialog
+                customerUserId={it.customerUserId}
+                customerName={nome}
+                trigger={
+                  <Button size="sm" variant="outline" className="shrink-0">
+                    <CalendarClock className="w-3.5 h-3.5 mr-1" />
+                    {meta.acao}
+                  </Button>
+                }
+              />
+            </div>
+          );
+        })}
+      </div>
+
+      {restante > 0 && (
+        <div className="px-3 pb-3 pt-1 text-2xs text-muted-foreground">+{restante} mais</div>
+      )}
+    </Card>
+  );
+}

--- a/src/hooks/useFollowupsVisita.ts
+++ b/src/hooks/useFollowupsVisita.ts
@@ -1,0 +1,86 @@
+import { useQuery } from '@tanstack/react-query';
+import { useAuth } from '@/contexts/AuthContext';
+import { supabase } from '@/integrations/supabase/client';
+import { hojeISO } from '@/lib/visitas/today';
+import {
+  montarFollowups,
+  type FollowupItem,
+  type VisitaFollowupRow,
+} from '@/lib/visitas/followups';
+
+const JANELA_DIAS = 45; // janela mais larga (reagendar); o helper aplica a por-resultado
+
+export interface FollowupsVisita {
+  items: FollowupItem[];
+  nomePorCliente: Map<string, string>;
+}
+
+/**
+ * Follow-ups sugeridos do vendedor logado: visitas mornas (route_visits, visited_by=eu)
+ * sem retorno agendado nem contato posterior. RLS own-scoped (#340) — degradação honesta.
+ * As 3 queries são own-scoped; agenda/ligações são auxiliares de de-dup (vazio não derruba o card).
+ * Read-only.
+ */
+export function useFollowupsVisita() {
+  const { user } = useAuth();
+  const uid = user?.id;
+  return useQuery({
+    queryKey: ['followups-visita', uid],
+    enabled: !!uid,
+    staleTime: 60_000,
+    gcTime: 5 * 60_000,
+    queryFn: async (): Promise<FollowupsVisita> => {
+      if (!uid) return { items: [], nomePorCliente: new Map() };
+      const hoje = hojeISO();
+      const desdeData = new Date(Date.now() - JANELA_DIAS * 86_400_000).toISOString().slice(0, 10);
+      const desdeISO = new Date(Date.now() - JANELA_DIAS * 86_400_000).toISOString();
+
+      const [visRes, agRes, callRes] = await Promise.all([
+        supabase
+          .from('route_visits')
+          .select('customer_user_id, result, notes, check_in_at, visit_date, revenue_generated')
+          .eq('visited_by', uid)
+          .gte('visit_date', desdeData),
+        supabase
+          .from('visitas_agendadas')
+          .select('customer_user_id')
+          .eq('scheduled_by', uid)
+          .eq('status', 'pendente')
+          .gte('scheduled_date', hoje),
+        supabase
+          .from('farmer_calls')
+          .select('customer_user_id, started_at')
+          .eq('farmer_id', uid)
+          .gte('started_at', desdeISO),
+      ]);
+      if (visRes.error) throw new Error(visRes.error.message);
+      const visitas = (visRes.data ?? []) as VisitaFollowupRow[];
+
+      const agendadasPendentes = new Set<string>(
+        (agRes.data ?? []).map((a) => a.customer_user_id).filter((x): x is string => !!x),
+      );
+
+      const ultimoContatoPorCliente = new Map<string, string>();
+      for (const c of callRes.data ?? []) {
+        if (!c.customer_user_id || !c.started_at) continue;
+        const cur = ultimoContatoPorCliente.get(c.customer_user_id);
+        if (!cur || c.started_at > cur) ultimoContatoPorCliente.set(c.customer_user_id, c.started_at);
+      }
+
+      const items = montarFollowups({ visitas, agendadasPendentes, ultimoContatoPorCliente, hojeISO: hoje });
+
+      // Enriquece nome só dos clientes que sobraram.
+      const ids = [...new Set(items.map((i) => i.customerUserId))];
+      const nomePorCliente = new Map<string, string>();
+      if (ids.length > 0) {
+        const { data: profs } = await supabase
+          .from('profiles')
+          .select('user_id, name')
+          .in('user_id', ids);
+        for (const p of profs ?? []) nomePorCliente.set(p.user_id, p.name);
+      }
+
+      return { items, nomePorCliente };
+    },
+  });
+}

--- a/src/lib/visitas/__tests__/followups.test.ts
+++ b/src/lib/visitas/__tests__/followups.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { montarFollowups, type VisitaFollowupRow } from '../followups';
+
+const HOJE = '2026-06-04';
+const vazio = { agendadasPendentes: new Set<string>(), ultimoContatoPorCliente: new Map<string, string>(), hojeISO: HOJE };
+
+function visita(p: Partial<VisitaFollowupRow> & { customer_user_id: string; result: string | null; check_in_at: string }): VisitaFollowupRow {
+  return { notes: null, visit_date: p.check_in_at.slice(0, 10), revenue_generated: null, ...p };
+}
+
+describe('montarFollowups', () => {
+  it('usa a visita MAIS RECENTE por cliente, filtra mornos, aplica janela por-resultado', () => {
+    const r = montarFollowups({
+      ...vazio,
+      visitas: [
+        // C1: interesse 10d atrás, depois ausente 3d atrás → estado atual = ausente (3d ≤ 21) → incluído
+        visita({ customer_user_id: 'C1', result: 'interesse', check_in_at: '2026-05-25T10:00:00Z' }),
+        visita({ customer_user_id: 'C1', result: 'ausente', check_in_at: '2026-06-01T10:00:00Z', notes: 'portão fechado' }),
+        // C2: pedido_fechado → não-morno → dropado
+        visita({ customer_user_id: 'C2', result: 'pedido_fechado', check_in_at: '2026-06-02T10:00:00Z' }),
+        // C3: reagendar 34d atrás → janela 45 → incluído
+        visita({ customer_user_id: 'C3', result: 'reagendar', check_in_at: '2026-05-01T10:00:00Z' }),
+        // C4: interesse 34d atrás → janela 30 → dropado (frio)
+        visita({ customer_user_id: 'C4', result: 'interesse', check_in_at: '2026-05-01T10:00:00Z' }),
+        // C5: ausente 25d atrás → janela 21 → dropado
+        visita({ customer_user_id: 'C5', result: 'ausente', check_in_at: '2026-05-10T10:00:00Z' }),
+      ],
+    });
+    expect(r.map((i) => i.customerUserId).sort()).toEqual(['C1', 'C3']);
+    const c1 = r.find((i) => i.customerUserId === 'C1')!;
+    expect(c1).toMatchObject({ result: 'ausente', diasDesde: 3, notes: 'portão fechado' });
+  });
+
+  it('de-dup: dropa cliente com visita agendada pendente, ou contatado APÓS a visita (mas não ANTES)', () => {
+    const r = montarFollowups({
+      hojeISO: HOJE,
+      agendadasPendentes: new Set(['C6']),
+      ultimoContatoPorCliente: new Map([
+        ['C7', '2026-06-03T09:00:00Z'], // contato 1d DEPOIS da visita → dropa
+        ['C8', '2026-06-01T09:00:00Z'], // contato ANTES da visita → mantém
+      ]),
+      visitas: [
+        visita({ customer_user_id: 'C6', result: 'reagendar', check_in_at: '2026-06-03T10:00:00Z' }),
+        visita({ customer_user_id: 'C7', result: 'interesse', check_in_at: '2026-06-02T10:00:00Z' }),
+        visita({ customer_user_id: 'C8', result: 'interesse', check_in_at: '2026-06-02T10:00:00Z' }),
+      ],
+    });
+    expect(r.map((i) => i.customerUserId)).toEqual(['C8']);
+  });
+
+  it('ordena reagendar > interesse > ausente; dentro de cada, mais recente primeiro', () => {
+    const r = montarFollowups({
+      ...vazio,
+      visitas: [
+        visita({ customer_user_id: 'AUS', result: 'ausente', check_in_at: '2026-06-01T10:00:00Z' }),   // 3d
+        visita({ customer_user_id: 'REAG_VELHO', result: 'reagendar', check_in_at: '2026-05-01T10:00:00Z' }), // 34d
+        visita({ customer_user_id: 'INT', result: 'interesse', check_in_at: '2026-06-03T10:00:00Z' }),  // 1d
+        visita({ customer_user_id: 'REAG_NOVO', result: 'reagendar', check_in_at: '2026-05-30T10:00:00Z' }), // 5d
+      ],
+    });
+    expect(r.map((i) => i.customerUserId)).toEqual(['REAG_NOVO', 'REAG_VELHO', 'INT', 'AUS']);
+  });
+
+  it('lista vazia → []', () => {
+    expect(montarFollowups({ ...vazio, visitas: [] })).toEqual([]);
+  });
+});

--- a/src/lib/visitas/followups.ts
+++ b/src/lib/visitas/followups.ts
@@ -1,0 +1,70 @@
+/**
+ * "Follow-ups sugeridos" — deriva, das visitas do vendedor, quais clientes pedem
+ * uma próxima ação (estado morno sem retorno agendado/contatado). Puro e testável.
+ *
+ * Read-only / heurística — NÃO é "next best action inteligente"; é sugestão.
+ * Spec: docs/superpowers/specs/2026-06-04-followups-sugeridos-design.md
+ */
+import { diasDesde } from './recencia';
+
+export interface VisitaFollowupRow {
+  customer_user_id: string;
+  result: string | null;
+  notes: string | null;
+  check_in_at: string | null;
+  visit_date: string;
+  revenue_generated: number | null;
+}
+
+export type FollowupResult = 'reagendar' | 'interesse' | 'ausente';
+
+export interface FollowupItem {
+  customerUserId: string;
+  result: FollowupResult;
+  lastVisitAt: string; // check_in_at ?? visit_date
+  diasDesde: number;
+  notes: string | null;
+}
+
+/** Janela de relevância por resultado (dias). Fora dela = lead frio → ruído (dropa). */
+const JANELA: Record<FollowupResult, number> = { reagendar: 45, interesse: 30, ausente: 21 };
+/** Prioridade: reagendar (pediram retorno) > interesse (oportunidade) > ausente (logística). */
+const RANK: Record<FollowupResult, number> = { reagendar: 0, interesse: 1, ausente: 2 };
+
+function isWarm(r: string | null): r is FollowupResult {
+  return r === 'reagendar' || r === 'interesse' || r === 'ausente';
+}
+
+export function montarFollowups(input: {
+  visitas: VisitaFollowupRow[];
+  agendadasPendentes: Set<string>;
+  ultimoContatoPorCliente: Map<string, string>;
+  hojeISO: string;
+}): FollowupItem[] {
+  const { visitas, agendadasPendentes, ultimoContatoPorCliente, hojeISO } = input;
+
+  // 1. Visita MAIS RECENTE por cliente (estado atual). Compara ISO/data lexicograficamente.
+  const maisRecente = new Map<string, VisitaFollowupRow>();
+  for (const v of visitas) {
+    const t = v.check_in_at ?? v.visit_date;
+    const cur = maisRecente.get(v.customer_user_id);
+    const curT = cur ? (cur.check_in_at ?? cur.visit_date) : '';
+    if (!cur || t > curT) maisRecente.set(v.customer_user_id, v);
+  }
+
+  const items: FollowupItem[] = [];
+  for (const [cid, v] of maisRecente) {
+    if (!isWarm(v.result)) continue; // 2. só mornos
+    if (agendadasPendentes.has(cid)) continue; // 3. de-dup: já agendei retorno
+    const lastVisitAt = v.check_in_at ?? v.visit_date;
+    const contato = ultimoContatoPorCliente.get(cid);
+    if (contato && contato > lastVisitAt) continue; // 4. de-dup: já contatei DEPOIS da visita
+    const dias = diasDesde(lastVisitAt, hojeISO);
+    if (dias == null || dias > JANELA[v.result]) continue; // 5. janela por-resultado
+    items.push({ customerUserId: cid, result: v.result, lastVisitAt, diasDesde: dias, notes: v.notes });
+  }
+
+  // 6. ordena por prioridade, depois mais recente primeiro
+  items.sort((a, b) => RANK[a.result] - RANK[b.result] || a.diasDesde - b.diasDesde);
+  return items;
+}


### PR DESCRIPTION
## O que

Card **read-only** "Follow-ups sugeridos" no dashboard Closer. Lista as visitas do vendedor cujo **estado atual pede retorno** (resultado morno: `reagendar`/`interesse`/`ausente`) e que ainda **não têm retorno agendado nem contato posterior**, com deep-link pro fluxo existente (agendar retorno / abrir Customer360).

Fecha o gap pós-check-out: hoje o `CheckoutDialog` grava o resultado e **acaba ali** — nada lembra o vendedor de voltar/ligar, e os leads mornos decaem.

> **Honesto por design:** é heurística client-side, nomeada "Follow-ups **sugeridos**" — NÃO "Next Best Action inteligente". As sugestões são hints não-vinculantes (baixo risco vs. um KPI).

## Como

- **Helper puro `montarFollowups` (TDD, 4 testes):** visita-mais-recente-por-cliente → filtro morno → de-dup (agenda pendente + contato APÓS a visita) → janela por-resultado (`reagendar 45d / interesse 30d / ausente 21d`) → ordem `reagendar > interesse > ausente`, mais recente primeiro.
- **Hook `useFollowupsVisita`:** 3 queries own-scoped (`route_visits` / `visitas_agendadas` / `farmer_calls`, RLS #340) + enrich de nome via `profiles`.
- **`FollowupsSugeridosCard`:** self-hide quando vazio, até 5 linhas + "+N mais", nome→Customer360, badge do resultado, "há N dias", snippet de `notes`, botão "Agendar retorno"/"Tentar de novo" (abre `AgendarVisitaDialog`). Colocado no `CloserDashboard` após `VisitSuggestionsCard`.

**Read-only — sem migration, sem edge function, sem deploy de backend.** Nada pra rodar no Lovable.

## Revisão codex (adversarial)

Incorporado: nome honesto (não "NBA"); de-dup de contato (senão o card "nunca limpa" pra quem resolve por telefone — P1); janelas por-resultado (P1); ordem reagendar>interesse>ausente, pois interesse é oportunidade e ausente é logística (P2); última-visita-como-estado-atual (P2); snippet de notes + limite 5 + Closer-only (P3).

## Validação

- typecheck (strict) — 0
- lint — 0 erros (81 warnings pré-existentes)
- test — 2085 passando (+4 novos)
- build — ✓

## Test plan (QA no device, pós-Publish)

- [ ] Vendedor com visitas mornas recentes vê o card no /meu-dia (Closer); ordem reagendar→interesse→ausente.
- [ ] Agendar retorno por um item → no refetch o item some (de-dup agenda).
- [ ] Cliente com visita agendada pendente OU ligação após a visita NÃO aparece.
- [ ] Sem follow-ups → card some (self-hide).
- [ ] Nome → abre Customer360; "Agendar retorno" → AgendarVisitaDialog preselecionado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)