### PR TITLE
feat(dashboard): KPIs reais de visita no Closer (conversão + ticket médio)

### DIFF
--- a/docs/superpowers/specs/2026-06-04-followups-sugeridos-design.md
+++ b/docs/superpowers/specs/2026-06-04-followups-sugeridos-design.md
@@ -71,3 +71,26 @@ Helper retorna **todos** os itens ordenados (count honesto); o componente render
 ## Codex
 
 Consult adversarial (2026-06-04, `model_reasoning_effort=medium`): validou baixo-risco vs KPI; P1 = nome honesto + de-dup contato + janelas por-resultado; P2 = ordem reagendar>interesse>ausente + última-visita-como-estado; P3 = snippet de notes + limite 5 + Closer-only. Todos incorporados acima.
+
+---
+
+# Apêndice: KPIs de visita do dashboard Closer (mesma sessão, feature irmã)
+
+Os 4 tiles do dashboard Closer eram placeholders "—". Esta feature os preenche com números reais, read-only, own-scoped — **cada tile EXIBE sua definição** (não mascara a métrica; o founder delegou as definições "decida você e o codex"). Sem migration/edge/deploy.
+
+## Definições (validadas com codex — 2 refinamentos)
+
+- **Visitas pendentes** = count de `visitas_agendadas` pendentes (do `useVisitasAgendadas`). Sub "agendadas".
+- **Próxima visita** = a pendente de menor `scheduled_date` (Hoje / Amanhã / DD/MM; "atrasada Nd" se vencida). Sub conforme.
+- **Conversão · 30d** = `fechados ÷ visitas com resultado` (30d). Mesma base do Mapa de Conversão (consistência). Sub literal "fechados ÷ c/ resultado · **N sem resultado**" — codex P1: expor `semResultado` senão quem não registra visita ruim parece melhor (gameável).
+- **Ticket médio · 30d** = `receita ÷ fechados COM valor>0` (não dilui com fechados sem receita) — codex C. Sub "**N c/ valor · M sem valor**" — expõe o buraco de dado em vez de subestimar o ticket.
+
+**Janela:** 30d nos tiles (pulso) × 90d no Mapa de Conversão (distribuição) — ambos rotulados; o Mapa não mostra um % único, então não há colisão de número (codex B: aceitável).
+
+## Implementação
+
+- Helper puro **`src/lib/visitas/kpis.ts`** `montarKpisVisita(rows)` (TDD, 3 testes) → `{ totalVisitas, comResultado, semResultado, fechados, taxaConversao, fechadosComValor, fechadosSemValor, receitaTotal, ticketMedio }`.
+- Hook **`useKpisVisita(30)`** (route_visits 30d own-scoped).
+- **`VisitasKpiTiles`** substitui o grid placeholder no `CloserDashboard`.
+
+**Codex** (2026-06-04): A ok (+ indicador sem-resultado), B ok (30d/90d rotulados), C mudar p/ dividir só por fechados com valor>0 + expor sem-valor. Tudo incorporado.

--- a/src/components/dashboard/CloserDashboard.tsx
+++ b/src/components/dashboard/CloserDashboard.tsx
@@ -1,9 +1,10 @@
 import { Card } from '@/components/ui/card';
-import { Construction, MapPin, Target, TrendingUp } from 'lucide-react';
+import { Construction } from 'lucide-react';
 import { VisitSuggestionsCard } from './VisitSuggestionsCard';
 import { VisitasHojeCard } from './VisitasHojeCard';
 import { MinhasVisitasResultadoCard } from './MinhasVisitasResultadoCard';
 import { FollowupsSugeridosCard } from './FollowupsSugeridosCard';
+import { VisitasKpiTiles } from './VisitasKpiTiles';
 import { MinhasTarefasCard } from '@/components/tarefas/MinhasTarefasCard';
 
 /**
@@ -48,27 +49,8 @@ export function CloserDashboard() {
         </ul>
       </Card>
 
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
-        <Card className="p-3 text-center text-xs text-muted-foreground">
-          <Target className="w-5 h-5 mx-auto mb-1 opacity-40" />
-          Visitas pendentes
-          <div className="text-base font-medium text-foreground mt-1">—</div>
-        </Card>
-        <Card className="p-3 text-center text-xs text-muted-foreground">
-          <MapPin className="w-5 h-5 mx-auto mb-1 opacity-40" />
-          Próxima visita
-          <div className="text-base font-medium text-foreground mt-1">—</div>
-        </Card>
-        <Card className="p-3 text-center text-xs text-muted-foreground">
-          <TrendingUp className="w-5 h-5 mx-auto mb-1 opacity-40" />
-          Win rate
-          <div className="text-base font-medium text-foreground mt-1">—</div>
-        </Card>
-        <Card className="p-3 text-center text-xs text-muted-foreground">
-          Avg deal size
-          <div className="text-base font-medium text-foreground mt-1">—</div>
-        </Card>
-      </div>
+      {/* KPIs reais (read-only, own-scoped); cada tile exibe sua definição */}
+      <VisitasKpiTiles />
     </div>
   );
 }

--- a/src/components/dashboard/VisitasKpiTiles.tsx
+++ b/src/components/dashboard/VisitasKpiTiles.tsx
@@ -1,0 +1,65 @@
+/**
+ * 4 KPIs de visita no dashboard Closer (substituem os placeholders "—").
+ * Read-only. Cada tile EXIBE sua definição no subtítulo (não mascara a métrica):
+ *  - Conversão · 30d = fechados ÷ visitas com resultado (+ "N sem resultado").
+ *  - Ticket médio · 30d = receita ÷ fechados COM valor (+ "M sem valor").
+ * Janela 30d (pulso); o Mapa de Conversão fica 90d (distribuição) — ambos rotulados.
+ * Definições validadas com codex (ver spec).
+ */
+import { Card } from '@/components/ui/card';
+import { CalendarClock, MapPin, TrendingUp, Receipt, type LucideIcon } from 'lucide-react';
+import { useKpisVisita } from '@/hooks/useKpisVisita';
+import { useVisitasAgendadas } from '@/hooks/useVisitasAgendadas';
+import { diasDesde } from '@/lib/visitas/recencia';
+import { hojeISO } from '@/lib/visitas/today';
+import { formatBRL, formatPctMaybe } from '@/components/customer360/format';
+
+function Tile({ icon: Icon, label, value, sub }: { icon: LucideIcon; label: string; value: string; sub?: string }) {
+  return (
+    <Card className="p-3 text-center text-xs text-muted-foreground">
+      <Icon className="w-5 h-5 mx-auto mb-1 opacity-40" />
+      {label}
+      <div className="text-base font-medium text-foreground mt-1 tabular-nums">{value}</div>
+      {sub && <div className="text-2xs text-muted-foreground/70 mt-0.5 leading-tight">{sub}</div>}
+    </Card>
+  );
+}
+
+function rotuloProxima(dateISO: string | undefined, hoje: string): { value: string; sub: string } {
+  if (!dateISO) return { value: '—', sub: 'nenhuma agendada' };
+  const n = diasDesde(dateISO, hoje); // hoje − data: futuro negativo, atrasada positivo
+  const dm = `${dateISO.slice(8, 10)}/${dateISO.slice(5, 7)}`;
+  if (n === 0) return { value: 'Hoje', sub: 'agendada' };
+  if (n === -1) return { value: 'Amanhã', sub: 'agendada' };
+  if (n != null && n > 0) return { value: dm, sub: `atrasada ${n}d` };
+  return { value: dm, sub: 'agendada' };
+}
+
+export function VisitasKpiTiles() {
+  const { data: kpis, isLoading } = useKpisVisita(30);
+  const { proximas } = useVisitasAgendadas();
+
+  const carregando = isLoading || proximas.isLoading;
+  const dash = carregando ? '…' : '—';
+  const lista = proximas.data ?? [];
+  const prox = rotuloProxima(lista[0]?.scheduled_date, hojeISO());
+
+  const conversao = carregando || !kpis ? dash : formatPctMaybe(kpis.taxaConversao);
+  const conversaoSub = kpis && kpis.semResultado > 0
+    ? `fechados ÷ c/ resultado · ${kpis.semResultado} sem resultado`
+    : 'fechados ÷ c/ resultado';
+
+  const ticket = carregando || !kpis || kpis.ticketMedio == null ? dash : formatBRL(kpis.ticketMedio);
+  const ticketSub = kpis && kpis.fechadosComValor > 0
+    ? `${kpis.fechadosComValor} c/ valor${kpis.fechadosSemValor > 0 ? ` · ${kpis.fechadosSemValor} sem valor` : ''}`
+    : 'nenhum fechado c/ valor';
+
+  return (
+    <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+      <Tile icon={CalendarClock} label="Visitas pendentes" value={carregando ? dash : String(lista.length)} sub="agendadas" />
+      <Tile icon={MapPin} label="Próxima visita" value={carregando ? dash : prox.value} sub={carregando ? undefined : prox.sub} />
+      <Tile icon={TrendingUp} label="Conversão · 30d" value={conversao} sub={conversaoSub} />
+      <Tile icon={Receipt} label="Ticket médio · 30d" value={ticket} sub={ticketSub} />
+    </div>
+  );
+}

--- a/src/hooks/useKpisVisita.ts
+++ b/src/hooks/useKpisVisita.ts
@@ -1,0 +1,30 @@
+import { useQuery } from '@tanstack/react-query';
+import { useAuth } from '@/contexts/AuthContext';
+import { supabase } from '@/integrations/supabase/client';
+import { montarKpisVisita, type KpisVisita, type KpiVisitaRow } from '@/lib/visitas/kpis';
+
+/**
+ * KPIs das visitas do vendedor logado numa janela (default 30d). route_visits own-scoped
+ * (visited_by=eu, RLS #340). Read-only. Definições em src/lib/visitas/kpis.ts.
+ */
+export function useKpisVisita(janelaDias = 30) {
+  const { user } = useAuth();
+  const uid = user?.id;
+  return useQuery({
+    queryKey: ['kpis-visita', uid, janelaDias],
+    enabled: !!uid,
+    staleTime: 60_000,
+    gcTime: 5 * 60_000,
+    queryFn: async (): Promise<KpisVisita> => {
+      if (!uid) return montarKpisVisita([]);
+      const desde = new Date(Date.now() - janelaDias * 86_400_000).toISOString().slice(0, 10);
+      const { data, error } = await supabase
+        .from('route_visits')
+        .select('result, revenue_generated')
+        .eq('visited_by', uid)
+        .gte('visit_date', desde);
+      if (error) throw new Error(error.message);
+      return montarKpisVisita((data ?? []) as KpiVisitaRow[]);
+    },
+  });
+}

--- a/src/lib/visitas/__tests__/kpis.test.ts
+++ b/src/lib/visitas/__tests__/kpis.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { montarKpisVisita } from '../kpis';
+
+describe('montarKpisVisita', () => {
+  it('deriva conversão, sem-resultado, ticket médio só de fechados COM valor', () => {
+    const k = montarKpisVisita([
+      { result: 'pedido_fechado', revenue_generated: 1000 },
+      { result: 'pedido_fechado', revenue_generated: null }, // fechado SEM valor → fora do ticket
+      { result: 'interesse', revenue_generated: null },
+      { result: 'ausente', revenue_generated: null },
+      { result: null, revenue_generated: null }, // sem resultado registrado
+    ]);
+    expect(k.totalVisitas).toBe(5);
+    expect(k.comResultado).toBe(4);
+    expect(k.semResultado).toBe(1);
+    expect(k.fechados).toBe(2);
+    expect(k.taxaConversao).toBe(0.5); // 2 ÷ 4
+    expect(k.fechadosComValor).toBe(1);
+    expect(k.fechadosSemValor).toBe(1);
+    expect(k.receitaTotal).toBe(1000); // só dos fechados com valor
+    expect(k.ticketMedio).toBe(1000); // 1000 ÷ 1
+  });
+
+  it('sem fechados (só mornos) → conversão 0 (não null), ticket null', () => {
+    const k = montarKpisVisita([
+      { result: 'interesse', revenue_generated: null },
+      { result: 'ausente', revenue_generated: null },
+    ]);
+    expect(k.taxaConversao).toBe(0);
+    expect(k.fechados).toBe(0);
+    expect(k.ticketMedio).toBeNull();
+  });
+
+  it('lista vazia → zeros e null nas razões', () => {
+    const k = montarKpisVisita([]);
+    expect(k).toMatchObject({
+      totalVisitas: 0, comResultado: 0, semResultado: 0, fechados: 0,
+      taxaConversao: null, fechadosComValor: 0, receitaTotal: 0, ticketMedio: null,
+    });
+  });
+});

--- a/src/lib/visitas/kpis.ts
+++ b/src/lib/visitas/kpis.ts
@@ -1,0 +1,53 @@
+/**
+ * KPIs de visita do vendedor (dashboard Closer). Puro e testável.
+ * Definições deliberadas (validadas com codex — ver spec):
+ *  - taxaConversao = fechados ÷ visitas COM resultado (expõe `semResultado` p/ não mascarar
+ *    quem não registra visita ruim);
+ *  - ticketMedio = receita ÷ fechados COM valor>0 (não dilui com fechados sem receita;
+ *    expõe `fechadosSemValor` como buraco de dado).
+ * Spec: docs/superpowers/specs/2026-06-04-followups-sugeridos-design.md (seção KPIs).
+ */
+export interface KpiVisitaRow {
+  result: string | null;
+  revenue_generated: number | null;
+}
+
+export interface KpisVisita {
+  totalVisitas: number;
+  comResultado: number;
+  semResultado: number;
+  fechados: number;
+  taxaConversao: number | null; // fração 0..1; null se não há visita com resultado
+  fechadosComValor: number;
+  fechadosSemValor: number;
+  receitaTotal: number; // soma da receita dos fechados COM valor
+  ticketMedio: number | null; // receitaTotal ÷ fechadosComValor; null se nenhum
+}
+
+export function montarKpisVisita(rows: KpiVisitaRow[]): KpisVisita {
+  const totalVisitas = rows.length;
+  const comResultado = rows.filter((r) => r.result != null).length;
+  const semResultado = totalVisitas - comResultado;
+
+  const fechadosRows = rows.filter((r) => r.result === 'pedido_fechado');
+  const fechados = fechadosRows.length;
+  const taxaConversao = comResultado > 0 ? fechados / comResultado : null;
+
+  const comValor = fechadosRows.filter((r) => (r.revenue_generated ?? 0) > 0);
+  const fechadosComValor = comValor.length;
+  const fechadosSemValor = fechados - fechadosComValor;
+  const receitaTotal = comValor.reduce((s, r) => s + (r.revenue_generated ?? 0), 0);
+  const ticketMedio = fechadosComValor > 0 ? receitaTotal / fechadosComValor : null;
+
+  return {
+    totalVisitas,
+    comResultado,
+    semResultado,
+    fechados,
+    taxaConversao,
+    fechadosComValor,
+    fechadosSemValor,
+    receitaTotal,
+    ticketMedio,
+  };
+}


### PR DESCRIPTION
## O que

Preenche os **4 tiles placeholder ("—")** do dashboard Closer com números reais — read-only, own-scoped. **Cada tile exibe sua definição** no subtítulo (não mascara a métrica).

| Tile | Definição (visível no tile) |
|---|---|
| Visitas pendentes | count de `visitas_agendadas` pendentes |
| Próxima visita | a pendente mais próxima (Hoje / Amanhã / DD/MM · "atrasada Nd") |
| **Conversão · 30d** | `fechados ÷ visitas com resultado` + **"N sem resultado"** |
| **Ticket médio · 30d** | `receita ÷ fechados COM valor>0` + **"M sem valor"** |

## Por que essas definições

O founder delegou ("decida você e o codex"). Decididas com o codex (#1 risco = "definição de negócio disfarçada de KPI"):

- **Conversão = fechados ÷ com-resultado** — mesma base do card Mapa de Conversão (consistência); expõe **"N sem resultado"** senão quem não registra visita ruim parece melhor (gameável — codex P1).
- **Ticket médio = só fechados com valor>0** — não dilui com fechados sem receita; expõe **"M sem valor"** como buraco de dado em vez de subestimar (codex P1).
- **Janela 30d** (pulso) ao lado do Mapa 90d (distribuição) — ambos rotulados; o Mapa não mostra um % único → sem colisão de número (codex P2).

## Como

- Helper puro **`montarKpisVisita`** (TDD, 3 testes).
- Hook **`useKpisVisita(30)`** (`route_visits` own-scoped, RLS #340).
- **`VisitasKpiTiles`** substitui o grid placeholder no `CloserDashboard`.

**Read-only — sem migration/edge/deploy.** Nada pra rodar no Lovable.

## Validação

- typecheck (strict) — 0 · lint — 0 erros · test — **2088** (+3) · build — ✓

## Test plan (QA no device, pós-Publish)

- [ ] Tiles mostram números reais (não "—") pra vendedor com visitas/agenda.
- [ ] Conversão = fechados ÷ visitas-com-resultado dos últimos 30d; subtítulo mostra "N sem resultado".
- [ ] Ticket médio divide só pelos fechados com receita; "M sem valor" aparece quando há fechado sem revenue.
- [ ] Próxima visita: Hoje/Amanhã/DD-MM; "atrasada Nd" se vencida.
- [ ] Sem dados → "—" honesto (não 0 falso onde não cabe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)