### PR TITLE
feat(dashboard): visão de time no Master (vendedores ativos + receita do time)

### DIFF
--- a/docs/superpowers/specs/2026-06-04-master-visao-time-design.md
+++ b/docs/superpowers/specs/2026-06-04-master-visao-time-design.md
@@ -1,0 +1,42 @@
+# Master dashboard "visão de time" (CEO) — preencher os 3 tiles "—"
+
+**Data:** 2026-06-04 · **Tipo:** front puro, read-only, sem migration/edge/deploy · **Branch:** `claude/master-visao-time`
+
+## Problema
+
+O `MasterDashboard` (do CEO/founder) tem 3 tiles placeholder "—": **Vendedores ativos · Receita time hoje · Pipeline total**. Falta a "visão de time" que o cabeçalho promete. (Os KPIs próprios dele como Closer e as sugestões de visita já existem.)
+
+## Solução (v1 — 3 tiles; ranking fica pra v2)
+
+Preenche os 3 tiles com números reais, read-only, **escopados na empresa ativa** (`CompanyContext`). Cada tile **exibe sua definição/fonte** (não mascara). `Pipeline total` é **morto** (não há tabela de pipeline) e vira **Receita time · mês (MTD)**.
+
+> **Ranking de vendedores fica pra v2** (codex P2): é o real valor de "visão de time" mas tem mais ambiguidade (atribuição por `created_by`, vendedor zerado, bucket "não atribuído"). Ship os tiles primeiro.
+
+## Tiles
+
+1. **Vendedores ativos** = distinct vendedores com atividade HOJE = `sales_orders.created_by` (empresa ativa) ∪ `farmer_calls.farmer_id` ∪ `route_visits.visited_by`. Valor = contagem de hoje; microcopy "**7d: X**" (codex: não trocar o principal por 7d). ⚠️ calls/visits não têm coluna `account` → cross-empresa (métrica de atividade soft, aceitável; sales é company-scoped).
+2. **Receita time · hoje** = Σ `sales_orders.total` de pedidos **válidos** (status ∉ {`cancelado`,`rascunho`}), `account` = empresa ativa, `deleted_at IS NULL`, `order_date_kpi` = hoje (SP). Label "**pedidos Omie · hoje**". **Erro honesto** (falha de query → "—", nunca R$0).
+3. **Receita time · mês** (MTD, substitui Pipeline) = mesma base, `order_date_kpi` ∈ [1º do mês, hoje] (SP). Label "**pedidos Omie · mês**".
+
+## Traps resolvidos (codex P1)
+
+- **Escopo de account:** SEMPRE `.eq('account', companyAtiva)` na receita (senão mistura Oben/Colacor = número politicamente errado). Empresa vem do `useCompany().id` (oben/colacor/colacor_sc — bate com `sales_orders.account`). Limitação: pedido sincronizado com `account` fora desses 3 valores é omitido (degradação honesta > mistura).
+- **Data SP, não UTC:** "hoje" = data de negócio **America/Sao_Paulo** (`Intl.DateTimeFormat('en-CA', {timeZone})`). `order_date_kpi` (date) filtra por string SP; `created_at`/`started_at`/`check_in_at` (timestamp) filtram por **janela UTC derivada de SP** (SP = UTC−3 fixo desde 2019; meia-noite SP = `T03:00:00Z`).
+- **Status válido centralizado:** `ORDER_STATUS_INVALIDOS = ['cancelado','rascunho']` num único helper (todos os 7 demais = real: enviado/faturado/recebido/em_analise/em_producao/pronto/entregue).
+- **Erro honesto:** a query de receita (q1) que falha → `throw` → tile "—"/erro (não R$0). Atividade (q2-q4) é best-effort.
+
+## Implementação
+
+- **`src/lib/dashboard/sp-date.ts`** (puro, TDD): `hojeSP()` (now→SP date), `addDias(iso,n)`, `inicioMes(iso)`, `spMeiaNoiteUTC(iso)`.
+- **`src/lib/dashboard/team-kpis.ts`** (puro, TDD): `isPedidoValido(status)`, `somarReceita(orders, deISO, ateISO)` (válidos, order_date_kpi em [de,ate)), `contarAtivos(linhas, desdeUTC)` (distinct id com ts ≥ desde).
+- **`src/hooks/useTeamKpis.ts`**: 4 queries (sales MTD by order_date_kpi · sales 7d by created_at · calls 7d · visits 7d), compõe receita hoje/mês + ativos hoje/7d. `account`-scoped via `useCompany`. q1 throws; q2-q4 best-effort.
+- **`src/components/dashboard/TeamKpiTiles.tsx`**: 3 tiles + microcopy; loading/erro honestos.
+- Substitui o grid placeholder no `MasterDashboard.tsx`.
+
+## Não-objetivos (v2)
+
+Ranking de vendedores (top por pedidos lançados `created_by`; visitas `visited_by`; conversão fechado÷com-resultado; sem zerados; bucket "não atribuído" p/ `created_by` NULL — codex). Freshness via `fin_sync_log` (hoje só label "Omie" + erro honesto). Activity company-scoped pra calls/visits. Cross-empresa consolidado.
+
+## Codex
+
+Consult adversarial (2026-06-04): matar Pipeline→MTD; receita order-based no time × call-based nos KPIs próprios (menor mal, ambos rotulados); ativos hoje + microcopy 7d; ranking = P2; **4 traps P1** (account scope, data SP, status válido centralizado, erro honesto) incorporados; não bloquear receita (read-only+labels+degradável suficiente).

--- a/src/components/dashboard/MasterDashboard.tsx
+++ b/src/components/dashboard/MasterDashboard.tsx
@@ -1,6 +1,7 @@
 import { Card } from '@/components/ui/card';
-import { Construction, BarChart3, Users, Briefcase } from 'lucide-react';
+import { Construction } from 'lucide-react';
 import { KpisToday } from './KpisToday';
+import { TeamKpiTiles } from './TeamKpiTiles';
 import { VisitSuggestionsCard } from './VisitSuggestionsCard';
 import { ViewAsPicker } from '@/components/impersonation/ViewAsPicker';
 import { MinhasTarefasCard } from '@/components/tarefas/MinhasTarefasCard';
@@ -48,22 +49,10 @@ export function MasterDashboard() {
         <KpisToday />
       </div>
 
-      <div className="grid grid-cols-3 gap-3">
-        <Card className="p-3 text-center text-xs text-muted-foreground">
-          <Users className="w-5 h-5 mx-auto mb-1 opacity-40" />
-          Vendedores ativos
-          <div className="text-base font-medium text-foreground mt-1">—</div>
-        </Card>
-        <Card className="p-3 text-center text-xs text-muted-foreground">
-          <Briefcase className="w-5 h-5 mx-auto mb-1 opacity-40" />
-          Receita time hoje
-          <div className="text-base font-medium text-foreground mt-1">—</div>
-        </Card>
-        <Card className="p-3 text-center text-xs text-muted-foreground">
-          <BarChart3 className="w-5 h-5 mx-auto mb-1 opacity-40" />
-          Pipeline total
-          <div className="text-base font-medium text-foreground mt-1">—</div>
-        </Card>
+      {/* KPIs de time (read-only, escopo da empresa ativa do CompanySwitcher) */}
+      <div className="space-y-2">
+        <div className="text-xs uppercase tracking-wide text-muted-foreground">Time</div>
+        <TeamKpiTiles />
       </div>
     </div>
   );

--- a/src/components/dashboard/TeamKpiTiles.tsx
+++ b/src/components/dashboard/TeamKpiTiles.tsx
@@ -1,0 +1,42 @@
+/**
+ * 3 KPIs de time no dashboard Master (substituem os placeholders "—").
+ * Read-only, escopados na empresa do CompanySwitcher. Cada tile exibe fonte/escopo.
+ * Receita = pedidos válidos do Omie; erro de query → "—" honesto (não R$0).
+ * Definições validadas com codex (ver spec).
+ */
+import { Card } from '@/components/ui/card';
+import { Users, Briefcase, CalendarRange, type LucideIcon } from 'lucide-react';
+import { useTeamKpis } from '@/hooks/useTeamKpis';
+import { useCompany } from '@/contexts/CompanyContext';
+import { formatBRL } from '@/components/customer360/format';
+
+function Tile({ icon: Icon, label, value, sub }: { icon: LucideIcon; label: string; value: string; sub?: string }) {
+  return (
+    <Card className="p-3 text-center text-xs text-muted-foreground">
+      <Icon className="w-5 h-5 mx-auto mb-1 opacity-40" />
+      {label}
+      <div className="text-base font-medium text-foreground mt-1 tabular-nums">{value}</div>
+      {sub && <div className="text-2xs text-muted-foreground/70 mt-0.5 leading-tight">{sub}</div>}
+    </Card>
+  );
+}
+
+export function TeamKpiTiles() {
+  const { data, isLoading, isError } = useTeamKpis();
+  const { selection, companyInfo } = useCompany();
+  const escopo = selection === 'all' ? 'todas as empresas' : companyInfo.shortName;
+
+  const receita = (v: number | undefined): string =>
+    isError ? '—' : isLoading || v === undefined ? '…' : formatBRL(v);
+  const ativos = isError || isLoading || !data ? (isError ? '—' : '…') : String(data.ativosHoje);
+  const ativosSub = isError ? 'indisponível' : data ? `ativos hoje · 7d: ${data.ativos7d}` : 'ativos hoje';
+  const receitaSub = isError ? 'indisponível' : `pedidos Omie · ${escopo}`;
+
+  return (
+    <div className="grid grid-cols-3 gap-3">
+      <Tile icon={Users} label="Vendedores ativos" value={ativos} sub={isLoading && !isError ? undefined : ativosSub} />
+      <Tile icon={Briefcase} label="Receita time · hoje" value={receita(data?.receitaHoje)} sub={receitaSub} />
+      <Tile icon={CalendarRange} label="Receita time · mês" value={receita(data?.receitaMes)} sub={receitaSub} />
+    </div>
+  );
+}

--- a/src/hooks/useTeamKpis.ts
+++ b/src/hooks/useTeamKpis.ts
@@ -1,0 +1,80 @@
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import { useCompany } from '@/contexts/CompanyContext';
+import { hojeSP, addDias, inicioMes, spMeiaNoiteUTC } from '@/lib/dashboard/sp-date';
+import { somarReceita, contarAtivos, type OrderRow, type AtividadeRow } from '@/lib/dashboard/team-kpis';
+
+export interface TeamKpis {
+  receitaHoje: number;
+  receitaMes: number;
+  ativosHoje: number;
+  ativos7d: number;
+}
+
+/**
+ * KPIs de time pro dashboard Master. Escopo de `account` segue o CompanySwitcher
+ * (single → .eq; 'all' → grupo inteiro). Receita = sales_orders válidos (staff lê todos).
+ * A query de receita (money) LANÇA em erro → tile "—" honesto (nunca R$0 falso);
+ * atividade (calls/visits, sem account) é best-effort. Read-only.
+ * Spec: docs/superpowers/specs/2026-06-04-master-visao-time-design.md
+ */
+export function useTeamKpis() {
+  const { selection } = useCompany();
+  return useQuery({
+    queryKey: ['team-kpis', selection],
+    staleTime: 60_000,
+    gcTime: 5 * 60_000,
+    queryFn: async (): Promise<TeamKpis> => {
+      const hoje = hojeSP();
+      const amanha = addDias(hoje, 1);
+      const mesInicio = inicioMes(hoje);
+      const inicioHojeUTC = spMeiaNoiteUTC(hoje);
+      const inicio7dUTC = spMeiaNoiteUTC(addDias(hoje, -6)); // hoje + 6 dias atrás
+
+      // q1 — receita do mês por order_date_kpi (deriva hoje + mês). Money → throw em erro.
+      let qRev = supabase
+        .from('sales_orders')
+        .select('total, status, order_date_kpi')
+        .is('deleted_at', null)
+        .gte('order_date_kpi', mesInicio)
+        .lt('order_date_kpi', amanha);
+      if (selection !== 'all') qRev = qRev.eq('account', selection);
+
+      // q2 — vendedores que lançaram pedido nos últimos 7d (escopo de empresa).
+      let qSales = supabase
+        .from('sales_orders')
+        .select('created_by, created_at')
+        .is('deleted_at', null)
+        .gte('created_at', inicio7dUTC);
+      if (selection !== 'all') qSales = qSales.eq('account', selection);
+
+      const [revRes, salesRes, callsRes, visitsRes] = await Promise.all([
+        qRev,
+        qSales,
+        supabase.from('farmer_calls').select('farmer_id, started_at').gte('started_at', inicio7dUTC),
+        supabase.from('route_visits').select('visited_by, check_in_at').gte('check_in_at', inicio7dUTC),
+      ]);
+
+      if (revRes.error) throw new Error(revRes.error.message); // dinheiro: erro honesto, não R$0
+
+      const orders: OrderRow[] = (revRes.data ?? []).map((o) => ({
+        total: o.total,
+        status: o.status,
+        order_date_kpi: o.order_date_kpi,
+      }));
+      const receitaHoje = somarReceita(orders, hoje, amanha);
+      const receitaMes = somarReceita(orders, mesInicio, amanha);
+
+      // Atividade best-effort (erro → []): sales(empresa) ∪ calls ∪ visits.
+      const atividade: AtividadeRow[] = [
+        ...(salesRes.data ?? []).map((r) => ({ id: r.created_by, ts: r.created_at })),
+        ...(callsRes.data ?? []).map((r) => ({ id: r.farmer_id, ts: r.started_at })),
+        ...(visitsRes.data ?? []).map((r) => ({ id: r.visited_by, ts: r.check_in_at })),
+      ];
+      const ativosHoje = contarAtivos(atividade, inicioHojeUTC);
+      const ativos7d = contarAtivos(atividade, inicio7dUTC);
+
+      return { receitaHoje, receitaMes, ativosHoje, ativos7d };
+    },
+  });
+}

--- a/src/lib/dashboard/__tests__/sp-date.test.ts
+++ b/src/lib/dashboard/__tests__/sp-date.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { hojeSP, addDias, inicioMes, spMeiaNoiteUTC } from '../sp-date';
+
+describe('sp-date', () => {
+  it('addDias atravessa fronteira de mês/ano', () => {
+    expect(addDias('2026-06-30', 1)).toBe('2026-07-01');
+    expect(addDias('2026-06-04', -6)).toBe('2026-05-29');
+    expect(addDias('2026-01-01', -1)).toBe('2025-12-31');
+    expect(addDias('2026-06-04', 0)).toBe('2026-06-04');
+  });
+
+  it('inicioMes → primeiro dia do mês', () => {
+    expect(inicioMes('2026-06-15')).toBe('2026-06-01');
+    expect(inicioMes('2026-12-31')).toBe('2026-12-01');
+  });
+
+  it('spMeiaNoiteUTC → T03:00Z (SP = UTC−3 fixo)', () => {
+    expect(spMeiaNoiteUTC('2026-06-04')).toBe('2026-06-04T03:00:00.000Z');
+  });
+
+  it('hojeSP → string YYYY-MM-DD', () => {
+    expect(hojeSP()).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+});

--- a/src/lib/dashboard/__tests__/team-kpis.test.ts
+++ b/src/lib/dashboard/__tests__/team-kpis.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { isPedidoValido, somarReceita, contarAtivos, type OrderRow, type AtividadeRow } from '../team-kpis';
+
+describe('team-kpis', () => {
+  it('isPedidoValido: cancelado/rascunho/null inválidos, resto válido', () => {
+    expect(isPedidoValido('enviado')).toBe(true);
+    expect(isPedidoValido('faturado')).toBe(true);
+    expect(isPedidoValido('entregue')).toBe(true);
+    expect(isPedidoValido('cancelado')).toBe(false);
+    expect(isPedidoValido('rascunho')).toBe(false);
+    expect(isPedidoValido(null)).toBe(false);
+  });
+
+  it('somarReceita: só pedidos válidos com order_date_kpi na janela [de, ate)', () => {
+    const orders: OrderRow[] = [
+      { total: 1000, status: 'faturado', order_date_kpi: '2026-06-04' },
+      { total: 500, status: 'cancelado', order_date_kpi: '2026-06-04' }, // inválido
+      { total: 300, status: 'enviado', order_date_kpi: '2026-06-03' }, // fora da janela "hoje"
+      { total: 999, status: 'rascunho', order_date_kpi: '2026-06-04' }, // inválido
+      { total: 42, status: 'faturado', order_date_kpi: null }, // sem data → fora
+    ];
+    expect(somarReceita(orders, '2026-06-04', '2026-06-05')).toBe(1000); // só o faturado de hoje
+    expect(somarReceita(orders, '2026-06-01', '2026-06-05')).toBe(1300); // faturado + enviado (mês)
+  });
+
+  it('contarAtivos: distinct id com ts ≥ desde; ignora id/ts nulos', () => {
+    const linhas: AtividadeRow[] = [
+      { id: 'A', ts: '2026-06-04T12:00:00Z' },
+      { id: 'A', ts: '2026-06-04T15:00:00Z' }, // mesmo A
+      { id: 'B', ts: '2026-06-04T12:00:00Z' },
+      { id: 'C', ts: '2026-06-01T12:00:00Z' }, // antes da janela "hoje"
+      { id: null, ts: '2026-06-04T12:00:00Z' }, // sem id
+      { id: 'D', ts: null }, // sem ts
+    ];
+    expect(contarAtivos(linhas, '2026-06-04T03:00:00.000Z')).toBe(2); // A, B
+    expect(contarAtivos(linhas, '2026-05-28T03:00:00.000Z')).toBe(3); // A, B, C
+  });
+});

--- a/src/lib/dashboard/sp-date.ts
+++ b/src/lib/dashboard/sp-date.ts
@@ -1,0 +1,27 @@
+/**
+ * Datas de negócio no fuso America/Sao_Paulo (SP = UTC−3 fixo desde 2019, sem horário de verão).
+ * Usado por métricas de "hoje/mês" onde UTC vazaria o dia à noite. Helpers puros (input-driven)
+ * testáveis; só `hojeSP` depende do relógio.
+ */
+
+/** Data de hoje em SP, 'YYYY-MM-DD'. */
+export function hojeSP(): string {
+  return new Intl.DateTimeFormat('en-CA', { timeZone: 'America/Sao_Paulo' }).format(new Date());
+}
+
+/** Soma `n` dias (pode ser negativo) a uma data 'YYYY-MM-DD'. Puro. */
+export function addDias(iso: string, n: number): string {
+  const d = new Date(`${iso.slice(0, 10)}T00:00:00Z`);
+  d.setUTCDate(d.getUTCDate() + n);
+  return d.toISOString().slice(0, 10);
+}
+
+/** Primeiro dia do mês de `iso` ('YYYY-MM-01'). Puro. */
+export function inicioMes(iso: string): string {
+  return `${iso.slice(0, 7)}-01`;
+}
+
+/** Instante UTC da meia-noite de SP do dia `iso` (UTC−3 → T03:00:00Z). Puro. */
+export function spMeiaNoiteUTC(iso: string): string {
+  return `${iso.slice(0, 10)}T03:00:00.000Z`;
+}

--- a/src/lib/dashboard/team-kpis.ts
+++ b/src/lib/dashboard/team-kpis.ts
@@ -1,0 +1,48 @@
+/**
+ * KPIs agregados de time pro dashboard Master (CEO). Puros e testáveis.
+ * Definições validadas com codex (ver spec):
+ *  - pedido válido = status ∉ {cancelado, rascunho};
+ *  - receita = Σ total de válidos com order_date_kpi na janela (escopo de account/data feito na query);
+ *  - vendedores ativos = distinct de quem teve atividade desde um instante UTC.
+ * Spec: docs/superpowers/specs/2026-06-04-master-visao-time-design.md
+ */
+
+/** Status que NÃO contam como receita realizada (rascunho = draft; cancelado = anulado). */
+export const ORDER_STATUS_INVALIDOS: string[] = ['cancelado', 'rascunho'];
+
+export function isPedidoValido(status: string | null | undefined): boolean {
+  return status != null && !ORDER_STATUS_INVALIDOS.includes(status);
+}
+
+export interface OrderRow {
+  total: number | null;
+  status: string | null;
+  order_date_kpi: string | null;
+}
+
+/** Σ `total` dos pedidos válidos com `order_date_kpi` em [deISO, ateISO). Comparação de string ('YYYY-MM-DD'). */
+export function somarReceita(orders: OrderRow[], deISO: string, ateISO: string): number {
+  return orders
+    .filter(
+      (o) =>
+        isPedidoValido(o.status) &&
+        o.order_date_kpi != null &&
+        o.order_date_kpi >= deISO &&
+        o.order_date_kpi < ateISO,
+    )
+    .reduce((s, o) => s + (o.total ?? 0), 0);
+}
+
+export interface AtividadeRow {
+  id: string | null;
+  ts: string | null;
+}
+
+/** Contagem distinct de `id` cujo `ts` (ISO) é ≥ `desdeUTC`. Ignora id/ts nulos. */
+export function contarAtivos(linhas: AtividadeRow[], desdeUTC: string): number {
+  const set = new Set<string>();
+  for (const l of linhas) {
+    if (l.id && l.ts && l.ts >= desdeUTC) set.add(l.id);
+  }
+  return set.size;
+}


### PR DESCRIPTION
## O que

Preenche os **3 tiles placeholder ("—")** do dashboard Master (CEO) com números reais, read-only, **escopados na empresa do CompanySwitcher**. Mata o **"Pipeline total"** (não há tabela de pipeline) → vira **Receita time · mês**.

| Tile | Definição (exibida no tile) |
|---|---|
| **Vendedores ativos** | distinct com atividade hoje (pedido ∪ ligação ∪ visita) + microcopy "7d: X" |
| **Receita time · hoje** | Σ `sales_orders.total` válidos (status ∉ cancelado/rascunho), `order_date_kpi`=hoje SP, por empresa · "pedidos Omie" |
| **Receita time · mês** | idem, MTD (no lugar do pipeline) |

## Traps P1 resolvidos (codex)

- **Escopo de account** — sempre `.eq('account', empresaAtiva)` na receita (senão mistura Oben/Colacor = número politicamente errado). `'all'` → grupo, label "todas as empresas".
- **Data de negócio São Paulo, não UTC** — senão "receita de hoje" vaza à noite (UTC−3). `order_date_kpi` por data SP; timestamps por janela UTC derivada de SP.
- **Status válido centralizado** — `ORDER_STATUS_INVALIDOS = [cancelado, rascunho]`; os 7 demais = real.
- **Erro honesto** — a query de receita lança em falha → tile "—" (nunca R$0 falso). Atividade é best-effort.
- **Lente coerente** — own-KPI segue call-based (farmer_calls), team é order-based (sales_orders); ambos rotulados (o CEO quer a receita real de pedido).

## Como

- Helpers puros `sp-date` + `team-kpis` (TDD, **7 testes**).
- Hook `useTeamKpis` (4 queries; receita throw / atividade best-effort; `account`-scoped via CompanyContext).
- `TeamKpiTiles` substitui o grid placeholder no `MasterDashboard`.

**Read-only — sem migration/edge/deploy.** Nada pra rodar no Lovable.

## Validação

- typecheck (strict) — 0 · lint — 0 erros · test — **2126** (+7) · build — ✓

## Não-objetivos (v2)

Ranking de vendedores (top por pedidos `created_by`, conversão por visita, bucket "não atribuído"); freshness via `fin_sync_log`; activity company-scoped p/ calls/visits.

## Test plan (QA no device, pós-Publish)

- [ ] Tiles mostram números reais p/ a empresa selecionada; trocar empresa no switcher muda os valores.
- [ ] "Receita time · hoje/mês" bate com os pedidos válidos do Omie da empresa (excluir cancelado/rascunho).
- [ ] "Vendedores ativos" reflete quem trabalhou hoje; "7d" maior ou igual.
- [ ] Sem pedidos hoje → R$ 0,00 honesto; falha de carga → "—" (não R$0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)