### PR TITLE
feat(dashboard): ranking de vendedores do mês no Master (+ fix de paginação)

### DIFF
--- a/docs/superpowers/specs/2026-06-04-master-visao-time-design.md
+++ b/docs/superpowers/specs/2026-06-04-master-visao-time-design.md
@@ -33,9 +33,23 @@ Preenche os 3 tiles com números reais, read-only, **escopados na empresa ativa*
 - **`src/components/dashboard/TeamKpiTiles.tsx`**: 3 tiles + microcopy; loading/erro honestos.
 - Substitui o grid placeholder no `MasterDashboard.tsx`.
 
-## Não-objetivos (v2)
+## Não-objetivos (v1)
 
-Ranking de vendedores (top por pedidos lançados `created_by`; visitas `visited_by`; conversão fechado÷com-resultado; sem zerados; bucket "não atribuído" p/ `created_by` NULL — codex). Freshness via `fin_sync_log` (hoje só label "Omie" + erro honesto). Activity company-scoped pra calls/visits. Cross-empresa consolidado.
+Freshness via `fin_sync_log` (hoje só label "Omie" + erro honesto). Activity company-scoped pra calls/visits. Cross-empresa consolidado.
+
+---
+
+# v2 — Ranking de vendedores do mês (ENTREGUE)
+
+Card read-only no Master, abaixo dos tiles de time. **Ordena por receita R$ MTD** (sinal CEO mais claro; sem score composto). Colunas: `nome · pedidos · receita MTD`. Escopo da empresa do switcher.
+
+- **Atribuição = `created_by`** (quem LANÇOU) filtrado a vendedores reais (`commercial_role ∈ farmer/hunter/closer`, mesma def de `useSalespeople`). Label "por quem lançou o pedido". NÃO usa dono-de-carteira (mudaria a pergunta; precisaria `carteira_assignments`).
+- **Bucket "não atribuído"** (created_by NULL ou não-vendedor) no rodapé — conta no total, fora do ranking (auditoria sync/admin). **"N sem pedido no mês"** (vendedores cadastrados sem pedido).
+- **Conversão de visita FORA** (codex P1): `route_visits` sem `account` → cross-empresa enquanto receita é por-empresa; misturar parece preciso mas não é. v3.
+- **Janela MTD** (alinha com o tile receita-mês; evita 3 janelas mentais).
+- **Paginação** (`fetchPedidosMTD`, `.range`+`order('id')`): receita do mês não trunca no cap 1000 do PostgREST. **Corrigiu a mesma latência no `useTeamKpis`** (tiles de receita do v1 truncavam >1000 pedidos/mês).
+
+Helper `montarRanking` (TDD) em `team-kpis.ts`; `fetchPedidosMTD`; hook `useTeamRanking`; `RankingVendedoresCard`. **v3:** conversão por vendedor (rotulada), dono-de-carteira, freshness.
 
 ## Codex
 

--- a/src/components/dashboard/MasterDashboard.tsx
+++ b/src/components/dashboard/MasterDashboard.tsx
@@ -2,6 +2,7 @@ import { Card } from '@/components/ui/card';
 import { Construction } from 'lucide-react';
 import { KpisToday } from './KpisToday';
 import { TeamKpiTiles } from './TeamKpiTiles';
+import { RankingVendedoresCard } from './RankingVendedoresCard';
 import { VisitSuggestionsCard } from './VisitSuggestionsCard';
 import { ViewAsPicker } from '@/components/impersonation/ViewAsPicker';
 import { MinhasTarefasCard } from '@/components/tarefas/MinhasTarefasCard';
@@ -53,6 +54,7 @@ export function MasterDashboard() {
       <div className="space-y-2">
         <div className="text-xs uppercase tracking-wide text-muted-foreground">Time</div>
         <TeamKpiTiles />
+        <RankingVendedoresCard />
       </div>
     </div>
   );

--- a/src/components/dashboard/RankingVendedoresCard.tsx
+++ b/src/components/dashboard/RankingVendedoresCard.tsx
@@ -1,0 +1,91 @@
+/**
+ * Ranking de vendedores do mês (MTD) no dashboard Master. Read-only, escopo da empresa
+ * do switcher. Ordena por receita de pedidos válidos, atribuído por quem LANÇOU (created_by);
+ * rodapé expõe "não atribuído" e "sem pedido no mês". Self-hide sem pedidos.
+ * Conversão de visita fica fora (route_visits não tem account → seria cross-empresa). v2.
+ * Spec: docs/superpowers/specs/2026-06-04-master-visao-time-design.md
+ */
+import { Card, CardHeader } from '@/components/ui/card';
+import { Trophy, Loader2 } from 'lucide-react';
+import { useTeamRanking } from '@/hooks/useTeamRanking';
+import { useCompany } from '@/contexts/CompanyContext';
+import { formatBRL } from '@/components/customer360/format';
+
+const TOP = 8;
+
+export function RankingVendedoresCard() {
+  const { data, isLoading, isError } = useTeamRanking();
+  const { selection, companyInfo } = useCompany();
+  const escopo = selection === 'all' ? 'todas as empresas' : companyInfo.shortName;
+
+  if (isLoading) {
+    return (
+      <Card className="p-6 flex justify-center">
+        <Loader2 className="w-5 h-5 animate-spin text-muted-foreground" />
+      </Card>
+    );
+  }
+  if (isError) {
+    return (
+      <Card className="p-4 text-xs text-muted-foreground">
+        <div className="flex items-center gap-2">
+          <Trophy className="w-4 h-4" />
+          Ranking de vendedores
+        </div>
+        <p className="mt-2">Indisponível no momento.</p>
+      </Card>
+    );
+  }
+  if (!data) return null;
+
+  const { ranking, naoAtribuido, semAtividade } = data;
+  if (ranking.length === 0 && naoAtribuido.pedidos === 0) return null; // sem pedidos no mês
+
+  const visiveis = ranking.slice(0, TOP);
+  const restante = ranking.length - visiveis.length;
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between gap-3 pb-3">
+        <div className="flex items-center gap-2">
+          <Trophy className="w-4 h-4 text-muted-foreground" />
+          <div>
+            <h2 className="text-base font-medium">Ranking de vendedores · mês</h2>
+            <p className="text-2xs text-muted-foreground">por quem lançou o pedido · {escopo}</p>
+          </div>
+        </div>
+      </CardHeader>
+
+      <div className="divide-y divide-border">
+        {visiveis.map((v, i) => (
+          <div key={v.id} className="px-4 py-2.5 flex items-center gap-3">
+            <div className="w-5 text-center text-xs font-medium text-muted-foreground tabular-nums">{i + 1}</div>
+            <div className="flex-1 min-w-0 text-sm font-medium truncate">{v.nome}</div>
+            <div className="text-2xs text-muted-foreground tabular-nums">{v.pedidos} ped.</div>
+            <div className="text-sm font-medium tabular-nums w-28 text-right">{formatBRL(v.receita)}</div>
+          </div>
+        ))}
+      </div>
+
+      {(restante > 0 || naoAtribuido.pedidos > 0 || semAtividade > 0) && (
+        <div className="px-4 pb-3 pt-2 space-y-0.5 text-2xs text-muted-foreground">
+          {restante > 0 && (
+            <div>
+              +{restante} vendedor{restante > 1 ? 'es' : ''} com pedido
+            </div>
+          )}
+          {naoAtribuido.pedidos > 0 && (
+            <div>
+              Sem vendedor atribuído: {formatBRL(naoAtribuido.receita)} · {naoAtribuido.pedidos} ped.
+            </div>
+          )}
+          {semAtividade > 0 && (
+            <div>
+              {semAtividade} vendedor{semAtividade > 1 ? 'es' : ''} sem pedido no mês
+            </div>
+          )}
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/src/hooks/useTeamKpis.ts
+++ b/src/hooks/useTeamKpis.ts
@@ -2,7 +2,8 @@ import { useQuery } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
 import { useCompany } from '@/contexts/CompanyContext';
 import { hojeSP, addDias, inicioMes, spMeiaNoiteUTC } from '@/lib/dashboard/sp-date';
-import { somarReceita, contarAtivos, type OrderRow, type AtividadeRow } from '@/lib/dashboard/team-kpis';
+import { somarReceita, contarAtivos, type AtividadeRow } from '@/lib/dashboard/team-kpis';
+import { fetchPedidosMTD } from '@/lib/dashboard/fetch-pedidos-mtd';
 
 export interface TeamKpis {
   receitaHoje: number;
@@ -31,15 +32,6 @@ export function useTeamKpis() {
       const inicioHojeUTC = spMeiaNoiteUTC(hoje);
       const inicio7dUTC = spMeiaNoiteUTC(addDias(hoje, -6)); // hoje + 6 dias atrás
 
-      // q1 — receita do mês por order_date_kpi (deriva hoje + mês). Money → throw em erro.
-      let qRev = supabase
-        .from('sales_orders')
-        .select('total, status, order_date_kpi')
-        .is('deleted_at', null)
-        .gte('order_date_kpi', mesInicio)
-        .lt('order_date_kpi', amanha);
-      if (selection !== 'all') qRev = qRev.eq('account', selection);
-
       // q2 — vendedores que lançaram pedido nos últimos 7d (escopo de empresa).
       let qSales = supabase
         .from('sales_orders')
@@ -48,20 +40,14 @@ export function useTeamKpis() {
         .gte('created_at', inicio7dUTC);
       if (selection !== 'all') qSales = qSales.eq('account', selection);
 
-      const [revRes, salesRes, callsRes, visitsRes] = await Promise.all([
-        qRev,
+      const [orders, salesRes, callsRes, visitsRes] = await Promise.all([
+        // Receita do mês paginada (deriva hoje + mês); lança em erro (money honesto, não R$0).
+        fetchPedidosMTD(selection, mesInicio, amanha),
         qSales,
         supabase.from('farmer_calls').select('farmer_id, started_at').gte('started_at', inicio7dUTC),
         supabase.from('route_visits').select('visited_by, check_in_at').gte('check_in_at', inicio7dUTC),
       ]);
 
-      if (revRes.error) throw new Error(revRes.error.message); // dinheiro: erro honesto, não R$0
-
-      const orders: OrderRow[] = (revRes.data ?? []).map((o) => ({
-        total: o.total,
-        status: o.status,
-        order_date_kpi: o.order_date_kpi,
-      }));
       const receitaHoje = somarReceita(orders, hoje, amanha);
       const receitaMes = somarReceita(orders, mesInicio, amanha);
 

--- a/src/hooks/useTeamRanking.ts
+++ b/src/hooks/useTeamRanking.ts
@@ -1,0 +1,55 @@
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import { useCompany } from '@/contexts/CompanyContext';
+import { hojeSP, addDias, inicioMes } from '@/lib/dashboard/sp-date';
+import { fetchPedidosMTD } from '@/lib/dashboard/fetch-pedidos-mtd';
+import { montarRanking, type RankingResult } from '@/lib/dashboard/team-kpis';
+
+/** commercial_roles que vendem (donos de carteira) — mesma definição de useSalespeople. */
+const ROLES_VENDEDOR = ['farmer', 'hunter', 'closer'] as const;
+
+/**
+ * Ranking de vendedores do mês (MTD) pro dashboard Master, escopado na empresa do switcher.
+ * Atribuição por `created_by` ∈ vendedores reais (commercial_role farmer/hunter/closer);
+ * o resto vira bucket "não atribuído". Receita = pedidos válidos do Omie, paginada (não trunca).
+ * Read-only; lança em erro (money honesto). Spec: docs/.../2026-06-04-master-visao-time-design.md
+ */
+export function useTeamRanking() {
+  const { selection } = useCompany();
+  return useQuery({
+    queryKey: ['team-ranking', selection],
+    staleTime: 60_000,
+    gcTime: 5 * 60_000,
+    queryFn: async (): Promise<RankingResult> => {
+      const hoje = hojeSP();
+      const amanha = addDias(hoje, 1);
+      const mesInicio = inicioMes(hoje);
+
+      // Vendedores reais + nomes.
+      const { data: roles, error: rErr } = await supabase
+        .from('commercial_roles')
+        .select('user_id, commercial_role')
+        .in('commercial_role', ROLES_VENDEDOR);
+      if (rErr) throw new Error(rErr.message);
+      const ids = [...new Set((roles ?? []).map((r) => r.user_id).filter(Boolean))];
+
+      const nomes = new Map<string, string>();
+      if (ids.length > 0) {
+        const { data: profs } = await supabase
+          .from('profiles')
+          .select('user_id, name, razao_social')
+          .in('user_id', ids);
+        for (const p of profs ?? []) nomes.set(p.user_id, p.razao_social || p.name || 'Sem nome');
+      }
+      const vendedores = new Map<string, string>();
+      for (const id of ids) vendedores.set(id, nomes.get(id) ?? 'Sem nome');
+
+      // Pedidos MTD (paginado, lança em erro).
+      const orders = await fetchPedidosMTD(selection, mesInicio, amanha);
+      return montarRanking(
+        orders.map((o) => ({ total: o.total, status: o.status, created_by: o.created_by })),
+        vendedores,
+      );
+    },
+  });
+}

--- a/src/lib/dashboard/__tests__/team-kpis.test.ts
+++ b/src/lib/dashboard/__tests__/team-kpis.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect } from 'vitest';
-import { isPedidoValido, somarReceita, contarAtivos, type OrderRow, type AtividadeRow } from '../team-kpis';
+import {
+  isPedidoValido,
+  somarReceita,
+  contarAtivos,
+  montarRanking,
+  type OrderRow,
+  type AtividadeRow,
+  type OrderRankRow,
+} from '../team-kpis';
 
 describe('team-kpis', () => {
   it('isPedidoValido: cancelado/rascunho/null inválidos, resto válido', () => {
@@ -34,5 +42,31 @@ describe('team-kpis', () => {
     ];
     expect(contarAtivos(linhas, '2026-06-04T03:00:00.000Z')).toBe(2); // A, B
     expect(contarAtivos(linhas, '2026-05-28T03:00:00.000Z')).toBe(3); // A, B, C
+  });
+
+  it('montarRanking: atribui por created_by, ordena por receita, bucket não-atribuído, semAtividade', () => {
+    const orders: OrderRankRow[] = [
+      { total: 1000, status: 'faturado', created_by: 'A' },
+      { total: 500, status: 'enviado', created_by: 'A' },
+      { total: 9999, status: 'cancelado', created_by: 'A' }, // inválido → ignorado
+      { total: 300, status: 'faturado', created_by: 'B' },
+      { total: 200, status: 'faturado', created_by: 'X' }, // X não é vendedor → não atribuído
+      { total: 150, status: 'faturado', created_by: null }, // sem autor → não atribuído
+    ];
+    const vendedores = new Map([['A', 'Ana'], ['B', 'Bia'], ['C', 'Cris']]); // C é vendedor sem pedido
+    const r = montarRanking(orders, vendedores);
+    expect(r.ranking).toEqual([
+      { id: 'A', nome: 'Ana', receita: 1500, pedidos: 2 },
+      { id: 'B', nome: 'Bia', receita: 300, pedidos: 1 },
+    ]);
+    expect(r.naoAtribuido).toEqual({ receita: 350, pedidos: 2 });
+    expect(r.semAtividade).toBe(1); // C
+  });
+
+  it('montarRanking: vazio → ranking vazio, sem atribuído zerado, semAtividade = todos', () => {
+    const r = montarRanking([], new Map([['A', 'Ana'], ['B', 'Bia']]));
+    expect(r.ranking).toEqual([]);
+    expect(r.naoAtribuido).toEqual({ receita: 0, pedidos: 0 });
+    expect(r.semAtividade).toBe(2);
   });
 });

--- a/src/lib/dashboard/fetch-pedidos-mtd.ts
+++ b/src/lib/dashboard/fetch-pedidos-mtd.ts
@@ -1,0 +1,41 @@
+import { supabase } from '@/integrations/supabase/client';
+import type { CompanySelection } from '@/contexts/CompanyContext';
+
+export interface PedidoMTDRow {
+  total: number | null;
+  status: string | null;
+  created_by: string | null;
+  order_date_kpi: string | null;
+}
+
+const PAGE = 1000;
+
+/**
+ * Busca TODOS os pedidos com `order_date_kpi` em [deISO, ateISO), escopados na empresa
+ * (selection single → `.eq('account')`; 'all' → grupo). **Paginado** (`.range` + `order('id')`)
+ * pra furar o cap de 1000 do PostgREST — a receita do mês NÃO pode truncar (money). Lança em erro.
+ */
+export async function fetchPedidosMTD(
+  selection: CompanySelection,
+  deISO: string,
+  ateISO: string,
+): Promise<PedidoMTDRow[]> {
+  const out: PedidoMTDRow[] = [];
+  for (let from = 0; ; from += PAGE) {
+    let q = supabase
+      .from('sales_orders')
+      .select('total, status, created_by, order_date_kpi')
+      .is('deleted_at', null)
+      .gte('order_date_kpi', deISO)
+      .lt('order_date_kpi', ateISO)
+      .order('id', { ascending: true })
+      .range(from, from + PAGE - 1);
+    if (selection !== 'all') q = q.eq('account', selection);
+    const { data, error } = await q;
+    if (error) throw new Error(error.message);
+    const rows = (data ?? []) as PedidoMTDRow[];
+    out.push(...rows);
+    if (rows.length < PAGE) break;
+  }
+  return out;
+}

--- a/src/lib/dashboard/team-kpis.ts
+++ b/src/lib/dashboard/team-kpis.ts
@@ -46,3 +46,59 @@ export function contarAtivos(linhas: AtividadeRow[], desdeUTC: string): number {
   }
   return set.size;
 }
+
+// ---------------------------------------------------------------------------
+// Ranking de vendedores (Master v2)
+// ---------------------------------------------------------------------------
+
+export interface OrderRankRow {
+  total: number | null;
+  status: string | null;
+  created_by: string | null;
+}
+export interface RankingVendedor {
+  id: string;
+  nome: string;
+  receita: number;
+  pedidos: number;
+}
+export interface RankingResult {
+  ranking: RankingVendedor[];
+  /** Pedidos válidos sem vendedor atribuído (created_by NULL ou não-vendedor). Conta no total, fora do ranking. */
+  naoAtribuido: { receita: number; pedidos: number };
+  /** Vendedores cadastrados sem nenhum pedido válido na janela. */
+  semAtividade: number;
+}
+
+/**
+ * Ranking de vendedores por receita de pedidos válidos, ATRIBUÍDO por `created_by`
+ * (quem lançou o pedido). `vendedores` = Map<userId, nome> dos vendedores reais
+ * (commercial_role farmer/hunter/closer). created_by fora desse set → bucket "não atribuído".
+ * Ordena por receita desc. Não lista vendedor sem pedido (entra em `semAtividade`).
+ */
+export function montarRanking(orders: OrderRankRow[], vendedores: Map<string, string>): RankingResult {
+  const acc = new Map<string, { receita: number; pedidos: number }>();
+  let naoR = 0;
+  let naoP = 0;
+  for (const o of orders) {
+    if (!isPedidoValido(o.status)) continue;
+    const v = o.total ?? 0;
+    if (o.created_by && vendedores.has(o.created_by)) {
+      const cur = acc.get(o.created_by) ?? { receita: 0, pedidos: 0 };
+      cur.receita += v;
+      cur.pedidos += 1;
+      acc.set(o.created_by, cur);
+    } else {
+      naoR += v;
+      naoP += 1;
+    }
+  }
+  const ranking = [...acc.entries()]
+    .map(([id, a]) => ({ id, nome: vendedores.get(id) ?? 'Vendedor', receita: a.receita, pedidos: a.pedidos }))
+    .sort((a, b) => b.receita - a.receita);
+  return {
+    ranking,
+    naoAtribuido: { receita: naoR, pedidos: naoP },
+    semAtividade: vendedores.size - ranking.length,
+  };
+}


### PR DESCRIPTION
## O que

Card read-only **"Ranking de vendedores · mês"** abaixo dos tiles de time (Master/CEO). Ordena vendedores por **receita de pedidos válidos do mês (MTD)**, escopado na empresa do switcher.

- **Atribuição = quem lançou o pedido** (`created_by` ∈ vendedores reais `farmer/hunter/closer`). Label honesto "por quem lançou o pedido". O resto (NULL ou não-vendedor) → **bucket "não atribuído"** no rodapé (auditoria de sync/admin).
- Colunas: `nome · pedidos · receita`. Rodapé: "sem vendedor atribuído: R$X" + "N sem pedido no mês". Self-hide sem pedidos.
- **Ordena por R$** (sinal CEO mais claro; sem score composto).

## Decisões (codex, 2ª consult)

- **Conversão de visita FORA do ranking** — `route_visits` não tem `account`, então conversão seria cross-empresa enquanto a receita é por-empresa; misturar parece preciso mas não é. Fica pra v3 (rotulada).
- **Janela MTD** (não 30d) — alinha com o tile de receita-mês; evita 3 janelas mentais no painel.
- **Atribuição por `created_by`, não dono-de-carteira** — honesto p/ v1; carteira mudaria a pergunta ("quem possui" ≠ "quem lançou") e precisaria `carteira_assignments`.

## 🐛 Fix junto (paginação — money)

`fetchPedidosMTD` pagina os pedidos do mês (`.range` + `order('id')`) — a receita do mês **não pode truncar** no cap de 1000 do PostgREST. **Corrige a mesma latência no `useTeamKpis`**: os tiles de receita do #571 truncavam silenciosamente acima de 1000 pedidos/mês (Oben pode passar disso). Agora ambos somam o mês completo.

## Como

- helper puro `montarRanking` (TDD, +2 testes) em `team-kpis.ts` · `fetchPedidosMTD` · hook `useTeamRanking` · `RankingVendedoresCard`.
- **Read-only — sem migration/edge/deploy.**

## Validação

- typecheck (strict) — 0 · lint — 0 erros · test — **2157** (+2) · build — ✓

## Test plan (QA no device, pós-Publish)

- [ ] Ranking lista vendedores por receita MTD da empresa selecionada; trocar empresa muda os valores.
- [ ] Receita por vendedor exclui cancelado/rascunho; soma bate com o tile "Receita time · mês".
- [ ] Pedido lançado por admin/sync (não-vendedor) ou sem autor cai em "sem vendedor atribuído".
- [ ] Vendedor sem pedido no mês não aparece na lista, mas conta em "N sem pedido no mês".
- [ ] (paginação) empresa com >1000 pedidos/mês → receita não trunca.

## v3

Conversão por vendedor (rotulada cross-empresa), atribuição por dono-de-carteira, freshness via `fin_sync_log`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)