### PR TITLE
feat(recebimento): closed-loop honesto PR1 (A0 — fundação + diagnóstico read-only)

### DIFF
--- a/docs/superpowers/specs/2026-06-04-recebimento-closed-loop-design.md
+++ b/docs/superpowers/specs/2026-06-04-recebimento-closed-loop-design.md
@@ -1,0 +1,141 @@
+# Recebimento closed-loop honesto (Oben) — Design
+
+> Data: 2026-06-04 · Frente do programa autônomo (pós Picking #567). Metodologia validada em 2 rodadas de Codex (gpt-5.5, xhigh). Mesmo padrão de "ciclo que mente sobre conclusão" do picking.
+
+## 1. Problema
+
+O módulo de Recebimento de NF-e dá entrada de mercadoria comprada (importa NF-e do Omie → confere no celular → **efetiva**, que escreve no Omie pra dar entrada de estoque). A efetivação (edge `omie-nfe-recebimento`) **mente sobre conclusão**:
+
+- **`nfe_recebimentos.status='efetivado'` é INCONDICIONAL** (`index.ts:390-394`) — marca efetivado mesmo se:
+  - `AlterarRecebimento` (Passo A, a entrada no Omie) **falhou** → `index.ts:309` só `console.error` + *"Continue anyway"*.
+  - `IncluirAjusteEstoque` (Passo B, ajuste de estoque do item convertido tipo Sayerlack) **falhou** → `index.ts:345` só `console.error`.
+  → **entrada de estoque fantasma** (status diz efetivado, Omie não recebeu).
+- O edge sempre devolve **HTTP 200 + `{success:true}`** → o front (`Recebimento.tsx:163`, `RecebimentoConferencia.tsx:389`) **sempre mostra toast de sucesso**.
+- **`AlterarRecebimento` sozinho pode nem efetivar** — o edge irmão `process-nfe` (aba "Manual", fail-closed correto) mostra o fluxo completo do Omie: `AlterarRecebimento → AlterarEtapaRecebimento → ConcluirRecebimento`. O edge ativo **só faz `AlterarRecebimento`**.
+- **KPI "Efetivadas Hoje"** (`AdminEstoqueRecebimento.tsx:92`) filtra por `data_emissao=today` (data de emissão da nota pelo fornecedor), não `efetivado_at`.
+- **Furo #1 (Codex):** o edge classifica sucesso por `res.ok` (HTTP). Mas o Omie retorna **HTTP 200 com `faultstring`** em erro de negócio (padrão confirmado no repo: `omie-sync:127` faz `if (result.faultstring) throw`). **Sucesso HTTP ≠ sucesso Omie.**
+
+## 2. Escopo — v1 = honestidade operacional, SEM mudar a coreografia Omie
+
+A v1 **mantém exatamente as chamadas Omie que o edge já faz** (não adiciona `ConcluirRecebimento`). Só passa a **respeitar o resultado real** delas. Decisão eu+Codex: tornar honesto é baixo risco; completar o fluxo (Hipótese B) é money-path do Omie sem poder testar → v2, só com evidência de produção.
+
+**Entregas v1:**
+1. **Critério de sucesso real por operação** — parsear o corpo do Omie (`faultstring`/`codigo_status`), não só HTTP.
+2. **Fail-closed:** se `AlterarRecebimento` falha → **não** roda ajustes/CT-e, marca `falha_efetivacao`, retorna erro honesto.
+3. **Ledger de efeitos externos** (resolve o bloqueio metodológico) → retry sem duplicar estoque.
+4. **2 status de falha:** `falha_efetivacao` (Passo A falhou, nada confirmado) · `efetivacao_parcial` (A ok, algum ajuste B falhou).
+5. **Retry seguro** (botão "Reprocessar"): re-chama só o que **não** teve sucesso registrado (pula `AlterarRecebimento` se já ok, pula ajuste de item já ok).
+6. **Toasts honestos** (sucesso só em sucesso real).
+7. **KPIs honestos:** "Efetivadas Hoje" por `efetivado_at::date`; card de falhas; "Recebidos hoje" do cockpit renomeado pra não confundir conferência com entrada efetiva.
+
+**NÃO-objetivos (v2, cortados pelo Codex):**
+- Adicionar `AlterarEtapaRecebimento` + `ConcluirRecebimento` (completar a coreografia) — só após evidência de produção (Hipótese B).
+- Reconciliação automática via `ConsultarRecebimento(nIdReceb)`.
+- Retomada granular item-a-item com UX detalhada.
+- Unificar/aposentar o `process-nfe` (caminho paralelo — fica intacto; registrado como divergência técnica).
+
+## 3. A tensão A/B (decisão registrada)
+
+Como o edge ativo só faz `AlterarRecebimento`, há 2 hipóteses sobre a produção hoje (founder confirma via logs/Omie):
+- **Hipótese A:** `AlterarRecebimento` conclui/efetiva (ou o estoque entra OK) → o bug é só "não respeita falha" → a v1 resolve.
+- **Hipótese B:** `AlterarRecebimento` NÃO conclui → o app marca efetivado mas o Omie nunca dá entrada (mesmo no caminho feliz) → a v1 deixa o app **honesto sobre o fluxo atual**, mas a completude vira v2.
+
+A v1 é **segura por construção em ambas**: ela só marca `falha_efetivacao` quando há **erro inequívoco** (HTTP≥400 ou `faultstring`/`codigo_status≠0`). Se hoje o caminho feliz retorna 200 sem `faultstring`, a v1 **não muda** o caminho feliz — só captura as falhas reais. Não inventa falha.
+
+**Perguntas factuais ao founder (gatilho de v2):**
+1. Ao "efetivar" uma NF normal (sem Sayerlack) hoje, o estoque sobe no Omie? Recebimento fica "concluído" ou em etapa intermediária?
+2. Nos logs do edge, o `operations[0]` (`AlterarRecebimento`) costuma vir `error:true` ou `false`?
+3. Há NF marcada "efetivado" no app mas ainda aberta/sem estoque no Omie?
+
+## 4. Modelo de estado e ledger
+
+`nfe_recebimentos.status` é `character varying(20)` → os 2 nomes cabem (`falha_efetivacao`=16, `efetivacao_parcial`=18).
+
+**Reuso o `status` existente** pro estado de efetivação (`efetivado` já é um status hoje; adiciono `falha_efetivacao`/`efetivacao_parcial`). Ledger em colunas + tabela append-only:
+
+**`nfe_recebimentos`** (estado de tela + idempotência do Passo A):
+- `efetivacao_erro text` — resumo do último erro (pra tela).
+- `efetivacao_tentativas integer DEFAULT 0` — contador.
+- `alterar_recebimento_ok boolean DEFAULT false` — idempotência do `AlterarRecebimento` (não re-chamar se já passou).
+- `omie_alterar_at timestamptz` — quando o Passo A teve sucesso.
+- (`efetivado_at` já existe — só seta quando vira `efetivado`.)
+
+**`nfe_recebimento_itens`** (idempotência do `IncluirAjusteEstoque`, que é NÃO-idempotente):
+- `ajuste_estoque_ok boolean DEFAULT false` — item já ajustado (retry pula).
+- `ajuste_estoque_omie_id text` — id do lançamento de ajuste no Omie.
+- `ajuste_estoque_at timestamptz`.
+
+**`nfe_efetivacao_tentativas`** (append-only, auditoria por operação — o "ledger de efeitos externos"):
+- `id uuid pk`, `nfe_recebimento_id uuid` (FK), `tentativa int`, `operacao text` (`alterar_recebimento`/`ajuste_estoque`/`importar_cte`), `item_id uuid null`, `sucesso boolean`, `erro text`, `omie_status text`, `created_at timestamptz`.
+- RLS: SELECT staff (employee/master); escrita só `service_role` (o edge usa service_role → bypassa RLS). Index por `nfe_recebimento_id`.
+
+## 5. Helper puro (oráculo TDD) — `src/lib/recebimento/efetivacao-helpers.ts`
+
+Espelhado **verbatim** no edge Deno (Edge não importa de `src/`). Funções puras, testadas com vitest:
+
+1. **`classificarRespostaOmie(r: { httpOk: boolean; status?: number; body: unknown }): { sucesso: boolean; erro: string | null; omieStatus: string | null }`**
+   - `!httpOk` → falha (`erro = "HTTP {status}"` + faultstring se houver).
+   - `body.faultstring` (string não-vazia) → falha (`erro = faultstring`).
+   - `body.codigo_status`/`cCodStatus` presente e ≠ `"0"`/`0` → falha (`erro = descricao_status`/`cDescStatus`).
+   - senão → sucesso. Robusto a `body` null/array/string/number.
+
+2. **`decidirStatusEfetivacao(p: { alterarOk: boolean; ajustesTentados: number; ajustesOk: number }): { status: 'efetivado' | 'falha_efetivacao' | 'efetivacao_parcial'; }`**
+   - `!alterarOk` → `falha_efetivacao`.
+   - `alterarOk && ajustesTentados === ajustesOk` (inclui 0 ajustes) → `efetivado`.
+   - `alterarOk && ajustesOk < ajustesTentados` → `efetivacao_parcial`.
+   - CT-e falho **não** degrada o status (frete é fiscal, não estoque; tem `cte_associados.status` próprio); só registra no ledger.
+
+3. **`selecionarAjustesPendentes(itens: { id: string; quantidade_convertida: number | null; produto_omie_id: number | null; ajuste_estoque_ok: boolean }[]): string[]`** — ids dos itens com `quantidade_convertida>0 && produto_omie_id && !ajuste_estoque_ok` (idempotência: pula já-feitos).
+
+4. **`podeReprocessar(status: string): boolean`** — `true` só pra `falha_efetivacao`/`efetivacao_parcial`.
+
+5. **`resumirErros(falhas: { operacao: string; erro: string }[]): string`** — concatena, trunca pra caber em `efetivacao_erro` (limite ~500 chars).
+
+## 6. Edge `omie-nfe-recebimento` reescrito (fail-closed)
+
+Após fetch (nfe/itens/lotes/conversões), incrementa `efetivacao_tentativas`. Espelha o helper verbatim.
+
+1. **Passo A — `AlterarRecebimento`** (só se `!alterar_recebimento_ok`): chama, `classificarRespostaOmie`. Registra tentativa.
+   - **Falha** → persiste `status='falha_efetivacao'` + `efetivacao_erro` + tentativas; retorna `{success:false, status, erro}` (HTTP 200). **Aborta B e C** (nada mais roda — sem entrada parcial).
+   - **Sucesso** → `alterar_recebimento_ok=true`, `omie_alterar_at=now`.
+2. **Passo B — ajustes** (`selecionarAjustesPendentes`): pra cada item, `IncluirAjusteEstoque`, classifica, registra tentativa. Sucesso → marca item `ajuste_estoque_ok=true` + `omie_id` + `at`. Falha → acumula erro (não aborta os outros — tenta todos).
+3. **Passo C — CT-e**: como hoje (por-item, marca `cte_associados.status='efetivado'` só em sucesso). Registra tentativa. Falha não degrada o status da NF.
+4. **Status final** — `decidirStatusEfetivacao`. `efetivado` → `status='efetivado'` + `efetivado_at=now` + `efetivacao_erro=null`. `efetivacao_parcial` → `status` + `efetivacao_erro`. Persiste.
+5. Retorna `{success: status==='efetivado', status, erro, ctes_processed, operations}`.
+
+**Idempotência do retry:** tentativa 2 pula `AlterarRecebimento` (já ok) e os ajustes de itens já-ok → re-faz só o que faltou → vira `efetivado` sem duplicar estoque.
+
+**Postura conservadora (Codex Q3):** `IncluirAjusteEstoque` e `AlterarRecebimento` tratados como NÃO-idempotentes (só re-chamam se nenhum sucesso registrado). Se o founder confirmar que `AlterarRecebimento` é overwrite-seguro, relaxa depois.
+
+## 7. Frontend honesto
+
+- **`Recebimento.tsx`:** tipo `NfeStatus` + `STATUS_CONFIG` ganham `falha_efetivacao` (status-error) e `efetivacao_parcial` (status-warning). `handleEfetivar` inspeciona `res.data.status`: toast de sucesso **só** se `efetivado`; senão `toast.error`/`toast.warning` com `res.data.erro`. Botão "Reprocessar" nos cards `falha_efetivacao`/`efetivacao_parcial` (re-invoca o edge). Filtros das abas incluem os novos status no histórico/pendências.
+- **`RecebimentoConferencia.tsx`:** `handleFinalize` inspeciona o resultado real (igual). Em falha: toast honesto + **não** declara efetivado (a NF aparece como falha na lista pra reprocessar).
+- **KPIs `AdminEstoqueRecebimento.tsx`:** "Efetivadas Hoje" → `efetivado_at >= início do dia` (gte/lt, não `data_emissao`). Novo card/contagem **"Falhas de efetivação"** (`status in (falha_efetivacao, efetivacao_parcial)`).
+- **`useEstoqueZone.ts` (cockpit):** "Recebidos hoje" (conta `conferido`) → renomear label **"Conferidas hoje"** (a métrica é trabalho do conferente, não entrada efetiva). Adicionar `priority`/topItem quando houver NF em `falha_efetivacao` (alerta o gestor: entrada de estoque travada).
+
+## 8. process-nfe (divergência técnica registrada)
+
+`process-nfe` está **vivo** (rota `/nfe-receipt` + aba "Manual" do admin via `NfeReceipt`) e é fail-closed correto (cada passo dá `return` no erro; faz o fluxo completo). **Intacto na v1** — não é o caminho do bug. Risco de longo prazo: 2 fluxos de efetivação com contratos diferentes. Consolidar/aposentar = decisão pós-v1 (não misturar com a correção de honestidade).
+
+## 9. Testes (helper puro, vitest)
+
+- `classificarRespostaOmie`: 200 sem fault → sucesso; `faultstring` → falha; HTTP 500 → falha; `codigo_status:"0"` → sucesso; `codigo_status:"101"` → falha; body null/array/string → robusto (sucesso só com sinal claro de ok; sem fabricar).
+- `decidirStatusEfetivacao`: alterar falha → `falha_efetivacao`; alterar ok + 0 ajustes → `efetivado`; alterar ok + 2/2 ajustes → `efetivado`; alterar ok + 1/2 ajustes → `efetivacao_parcial`.
+- `selecionarAjustesPendentes`: pula `ajuste_estoque_ok`; inclui `quantidade_convertida>0 && produto_omie_id`; ignora sem conversão.
+- `podeReprocessar`: true pra falha/parcial; false pra efetivado/pendente/conferido.
+- `resumirErros`: trunca/concatena.
+
+## 10. Validação
+
+- Helper puro: vitest (todos verdes).
+- Edge: `deno check` (erro-set inalterado vs main, padrão do repo).
+- CI `validate`: typecheck (strict) + test + lint + build.
+- ⚠️ **Sem teste contra o Omie** (sem acesso). O fail-closed se baseia no sinal honesto que o Omie devolve. Founder monitora o 1º dia pós-deploy (se muitas NFs viram `falha_efetivacao` → Hipótese B se revelando → dispara a v2).
+
+## 11. Entregáveis / operações Lovable
+
+- **Migration** `20260604140000_recebimento_efetivacao_ledger.sql` (idempotente: `ADD COLUMN IF NOT EXISTS`, `CREATE TABLE IF NOT EXISTS`, RLS) → **colar no SQL Editor** (manual).
+- **Deploy do edge** `omie-nfe-recebimento` **verbatim da main** via chat do Lovable (após merge).
+- **Publish** do frontend.
+- Registrar no CLAUDE.md (§6 ou §10) + nota de migration manual no PR.

--- a/docs/superpowers/specs/2026-06-04-recebimento-closed-loop-design.md
+++ b/docs/superpowers/specs/2026-06-04-recebimento-closed-loop-design.md
@@ -1,141 +1,119 @@
 # Recebimento closed-loop honesto (Oben) — Design
 
-> Data: 2026-06-04 · Frente do programa autônomo (pós Picking #567). Metodologia validada em 2 rodadas de Codex (gpt-5.5, xhigh). Mesmo padrão de "ciclo que mente sobre conclusão" do picking.
+> Data: 2026-06-04 · Frente do programa autônomo (pós Picking #567). Metodologia validada em 3 rodadas de Codex (gpt-5.5, xhigh): honestidade pura → veredito → **Fase A (completar a coreografia)**. O founder ampliou o escopo: não basta "parar de mentir" — a efetivação precisa **levar a NF até "Concluído" no Omie e movimentar o estoque**.
 
 ## 1. Problema
 
-O módulo de Recebimento de NF-e dá entrada de mercadoria comprada (importa NF-e do Omie → confere no celular → **efetiva**, que escreve no Omie pra dar entrada de estoque). A efetivação (edge `omie-nfe-recebimento`) **mente sobre conclusão**:
+A efetivação da conferência mobile (edge `omie-nfe-recebimento`) **mente sobre conclusão E está funcionalmente incompleta**:
 
-- **`nfe_recebimentos.status='efetivado'` é INCONDICIONAL** (`index.ts:390-394`) — marca efetivado mesmo se:
-  - `AlterarRecebimento` (Passo A, a entrada no Omie) **falhou** → `index.ts:309` só `console.error` + *"Continue anyway"*.
-  - `IncluirAjusteEstoque` (Passo B, ajuste de estoque do item convertido tipo Sayerlack) **falhou** → `index.ts:345` só `console.error`.
-  → **entrada de estoque fantasma** (status diz efetivado, Omie não recebeu).
-- O edge sempre devolve **HTTP 200 + `{success:true}`** → o front (`Recebimento.tsx:163`, `RecebimentoConferencia.tsx:389`) **sempre mostra toast de sucesso**.
-- **`AlterarRecebimento` sozinho pode nem efetivar** — o edge irmão `process-nfe` (aba "Manual", fail-closed correto) mostra o fluxo completo do Omie: `AlterarRecebimento → AlterarEtapaRecebimento → ConcluirRecebimento`. O edge ativo **só faz `AlterarRecebimento`**.
-- **KPI "Efetivadas Hoje"** (`AdminEstoqueRecebimento.tsx:92`) filtra por `data_emissao=today` (data de emissão da nota pelo fornecedor), não `efetivado_at`.
-- **Furo #1 (Codex):** o edge classifica sucesso por `res.ok` (HTTP). Mas o Omie retorna **HTTP 200 com `faultstring`** em erro de negócio (padrão confirmado no repo: `omie-sync:127` faz `if (result.faultstring) throw`). **Sucesso HTTP ≠ sucesso Omie.**
+- `nfe_recebimentos.status='efetivado'` é **incondicional** (`index.ts:390-394`) mesmo se `AlterarRecebimento` falha (linha 309 só loga *"Continue anyway"*) ou o ajuste Sayerlack falha (345 só loga). O edge devolve **HTTP 200 + `success:true`** → front sempre dá toast de sucesso.
+- **Não envia a quantidade recebida** ao Omie — o payload é `det:[{nItem,nCodProd,lote_validade}]`, **sem `nQtdeRecebida`**. Não confronta/atualiza a quantidade no Omie.
+- **Não conclui** — não chama `AlterarEtapaRecebimento` nem `ConcluirRecebimento` → a NF **não vai pra "Recebido"/"Concluído"** sozinha.
+- **Furo central (Codex):** classifica sucesso por `res.ok` (HTTP). Mas o Omie retorna **HTTP 200 com `faultstring`** em erro de negócio (padrão do repo: `omie-sync:127`, `process-nfe:115` fazem `if (data.faultstring) throw`). **Sucesso HTTP ≠ sucesso Omie.**
 
-## 2. Escopo — v1 = honestidade operacional, SEM mudar a coreografia Omie
+**Mapa comprovado — `process-nfe`** (aba "Manual", vivo via `/nfe-receipt` + aba do admin, fail-closed correto): faz a coreografia que funciona — `ListarRecebimentos → ConsultarRecebimento → AlterarRecebimento`(com `nQtdeRecebida`+departamento) `→ AlterarEtapaRecebimento`(`cEtapa:"40"`) `→ ConcluirRecebimento`. Não envia lote/validade nem trata CT-e/data de registro. **Nenhum dos 2 edges é completo.**
 
-A v1 **mantém exatamente as chamadas Omie que o edge já faz** (não adiciona `ConcluirRecebimento`). Só passa a **respeitar o resultado real** delas. Decisão eu+Codex: tornar honesto é baixo risco; completar o fluxo (Hipótese B) é money-path do Omie sem poder testar → v2, só com evidência de produção.
+## 2. Escopo — Fase A (completar a coreografia COM honestidade)
 
-**Entregas v1:**
-1. **Critério de sucesso real por operação** — parsear o corpo do Omie (`faultstring`/`codigo_status`), não só HTTP.
-2. **Fail-closed:** se `AlterarRecebimento` falha → **não** roda ajustes/CT-e, marca `falha_efetivacao`, retorna erro honesto.
-3. **Ledger de efeitos externos** (resolve o bloqueio metodológico) → retry sem duplicar estoque.
-4. **2 status de falha:** `falha_efetivacao` (Passo A falhou, nada confirmado) · `efetivacao_parcial` (A ok, algum ajuste B falhou).
-5. **Retry seguro** (botão "Reprocessar"): re-chama só o que **não** teve sucesso registrado (pula `AlterarRecebimento` se já ok, pula ajuste de item já ok).
-6. **Toasts honestos** (sucesso só em sucesso real).
-7. **KPIs honestos:** "Efetivadas Hoje" por `efetivado_at::date`; card de falhas; "Recebidos hoje" do cockpit renomeado pra não confundir conferência com entrada efetiva.
+A efetivação da conferência mobile passa a fazer o **fluxo completo** do Omie:
+1. **Data de registro** = dia do recebimento no app.
+2. **Atualizar a quantidade recebida** de cada item no Omie.
+3. **Lote/validade** (já capturado via OCR).
+4. Mover kanban **"Recebido" → "Concluído"**.
+5. **CT-e** atrelado: concluir e mover pra "Concluído".
+6. **Honestidade:** critério de sucesso real (`faultstring`), fail-closed, ledger por passo, status de falha, toasts honestos, KPIs por `efetivado_at`.
 
-**NÃO-objetivos (v2, cortados pelo Codex):**
-- Adicionar `AlterarEtapaRecebimento` + `ConcluirRecebimento` (completar a coreografia) — só após evidência de produção (Hipótese B).
-- Reconciliação automática via `ConsultarRecebimento(nIdReceb)`.
-- Retomada granular item-a-item com UX detalhada.
-- Unificar/aposentar o `process-nfe` (caminho paralelo — fica intacto; registrado como divergência técnica).
+**Fase B (cortada, sub-frente futura):** itens NOVOS — criar produto no Omie + associar de-para ao item da nota (senão o estoque não movimenta). Mais complexo (criação de cadastro), validado à parte.
 
-## 3. A tensão A/B (decisão registrada)
+## 3. RESTRIÇÃO CRÍTICA → entrega em 2 sub-fases
 
-Como o edge ativo só faz `AlterarRecebimento`, há 2 hipóteses sobre a produção hoje (founder confirma via logs/Omie):
-- **Hipótese A:** `AlterarRecebimento` conclui/efetiva (ou o estoque entra OK) → o bug é só "não respeita falha" → a v1 resolve.
-- **Hipótese B:** `AlterarRecebimento` NÃO conclui → o app marca efetivado mas o Omie nunca dá entrada (mesmo no caminho feliz) → a v1 deixa o app **honesto sobre o fluxo atual**, mas a completude vira v2.
+**Eu não tenho acesso ao Omie** (nem teste nem prod). Não posso validar payloads, nem o nome do campo "data de registro", nem o shape de lote no `AlterarRecebimento`, nem o que é "2353". A única validação é o founder no Omie real. **Codex: nunca pôr campo "provável" em payload de estoque real.** Daí o de-risk **diagnóstico-first** e a entrega faseada:
 
-A v1 é **segura por construção em ambas**: ela só marca `falha_efetivacao` quando há **erro inequívoco** (HTTP≥400 ou `faultstring`/`codigo_status≠0`). Se hoje o caminho feliz retorna 200 sem `faultstring`, a v1 **não muda** o caminho feliz — só captura as falhas reais. Não inventa falha.
+### Sub-fase A0 — Fundação + Diagnóstico (PR1, 100% aditivo, ZERO risco de estoque)
+- **Migration do ledger** (idempotente): flags por passo + tabela append-only de tentativas + status novos.
+- **Helper puro TDD** (`classificarRespostaOmie`, `decidirStatusEfetivacao`, `selecionarPassosPendentes`) — espelhado no edge.
+- **Modo diagnóstico read-only** no edge: `{diagnostico:true, nfe_recebimento_id}` → chama só `ConsultarRecebimento(nIdReceb)` (+ `ListarRecebimentos` se faltar `nIdReceb`) e retorna o **JSON cru** (etapa atual, itens, datas, lote, CT-e). **Não escreve nada.**
+- **Frontend:** botão "Diagnosticar" (staff) que mostra/baixa o JSON; status/KPIs honestos preparados.
+- **O fluxo de efetivação atual fica INTACTO** (não regride). PR1 destrava o founder pra me colar o JSON real.
 
-**Perguntas factuais ao founder (gatilho de v2):**
-1. Ao "efetivar" uma NF normal (sem Sayerlack) hoje, o estoque sobe no Omie? Recebimento fica "concluído" ou em etapa intermediária?
-2. Nos logs do edge, o `operations[0]` (`AlterarRecebimento`) costuma vir `error:true` ou `false`?
-3. Há NF marcada "efetivado" no app mas ainda aberta/sem estoque no Omie?
+### Sub-fase A1 — Coreografia completa (PR2, validado pelo founder)
+- O edge ativo absorve a coreografia comprovada do `process-nfe` + lote/validade + data/CT-e **com os campos confirmados pelo diagnóstico**.
+- Fail-closed por passo + ledger + **lock atômico** + retry que retoma só o passo pendente.
+- Founder testa **1 NF de baixo valor** → ajusto.
+- **Guard:** se um campo obrigatório da Fase A não estiver com mapeamento confirmado, o edge retorna erro operacional (`falha_efetivacao` + motivo "campo X não mapeado") — **não efetiva às cegas** (default desligado, fail-closed; Codex Q4).
 
-## 4. Modelo de estado e ledger
+## 4. Modelo de estado e ledger (por passo)
 
-`nfe_recebimentos.status` é `character varying(20)` → os 2 nomes cabem (`falha_efetivacao`=16, `efetivacao_parcial`=18).
+`nfe_recebimentos.status` é `varchar(20)` → cabem `falha_efetivacao`(16), `efetivacao_parcial`(18). Reuso o `status` (já tem `efetivado`).
 
-**Reuso o `status` existente** pro estado de efetivação (`efetivado` já é um status hoje; adiciono `falha_efetivacao`/`efetivacao_parcial`). Ledger em colunas + tabela append-only:
-
-**`nfe_recebimentos`** (estado de tela + idempotência do Passo A):
-- `efetivacao_erro text` — resumo do último erro (pra tela).
-- `efetivacao_tentativas integer DEFAULT 0` — contador.
-- `alterar_recebimento_ok boolean DEFAULT false` — idempotência do `AlterarRecebimento` (não re-chamar se já passou).
-- `omie_alterar_at timestamptz` — quando o Passo A teve sucesso.
+**`nfe_recebimentos`** — flags de idempotência por passo + estado de tela:
+- `alterar_recebimento_ok boolean DEFAULT false`, `alterar_etapa_ok boolean DEFAULT false`, `concluir_recebimento_ok boolean DEFAULT false`, `cte_ok boolean DEFAULT false`
+- `efetivacao_erro text`, `efetivacao_tentativas integer DEFAULT 0`, `efetivacao_lock_at timestamptz` (claim atômico)
 - (`efetivado_at` já existe — só seta quando vira `efetivado`.)
 
-**`nfe_recebimento_itens`** (idempotência do `IncluirAjusteEstoque`, que é NÃO-idempotente):
-- `ajuste_estoque_ok boolean DEFAULT false` — item já ajustado (retry pula).
-- `ajuste_estoque_omie_id text` — id do lançamento de ajuste no Omie.
-- `ajuste_estoque_at timestamptz`.
+**`nfe_recebimento_itens`** — idempotência do `IncluirAjusteEstoque` (NÃO-idempotente):
+- `ajuste_estoque_ok boolean DEFAULT false`, `ajuste_estoque_omie_id text`, `ajuste_estoque_at timestamptz`
 
-**`nfe_efetivacao_tentativas`** (append-only, auditoria por operação — o "ledger de efeitos externos"):
-- `id uuid pk`, `nfe_recebimento_id uuid` (FK), `tentativa int`, `operacao text` (`alterar_recebimento`/`ajuste_estoque`/`importar_cte`), `item_id uuid null`, `sucesso boolean`, `erro text`, `omie_status text`, `created_at timestamptz`.
-- RLS: SELECT staff (employee/master); escrita só `service_role` (o edge usa service_role → bypassa RLS). Index por `nfe_recebimento_id`.
+**`nfe_efetivacao_tentativas`** (append-only, auditoria por operação):
+- `id uuid pk`, `nfe_recebimento_id uuid` (FK), `tentativa int`, `operacao text` (`diagnostico`/`alterar_recebimento`/`alterar_etapa`/`concluir_recebimento`/`ajuste_estoque`/`importar_cte`), `item_id uuid null`, `sucesso boolean`, `erro text`, `omie_status text`, `created_at timestamptz`. RLS: SELECT staff; escrita só `service_role`. Index por `nfe_recebimento_id`.
+
+**Lock atômico (Codex Q5):** claim via `UPDATE nfe_recebimentos SET efetivacao_lock_at=now() WHERE id=$1 AND (efetivacao_lock_at IS NULL OR efetivacao_lock_at < now()-interval '2 min') RETURNING id`. Se 0 linhas → outro request está processando → 409. Libera no fim (lock_at=null). Padrão do claim do Sayerlack.
 
 ## 5. Helper puro (oráculo TDD) — `src/lib/recebimento/efetivacao-helpers.ts`
 
-Espelhado **verbatim** no edge Deno (Edge não importa de `src/`). Funções puras, testadas com vitest:
+Espelhado **verbatim** no edge Deno. Funções puras (vitest):
 
-1. **`classificarRespostaOmie(r: { httpOk: boolean; status?: number; body: unknown }): { sucesso: boolean; erro: string | null; omieStatus: string | null }`**
-   - `!httpOk` → falha (`erro = "HTTP {status}"` + faultstring se houver).
-   - `body.faultstring` (string não-vazia) → falha (`erro = faultstring`).
-   - `body.codigo_status`/`cCodStatus` presente e ≠ `"0"`/`0` → falha (`erro = descricao_status`/`cDescStatus`).
-   - senão → sucesso. Robusto a `body` null/array/string/number.
+1. **`classificarRespostaOmie(r: { httpOk: boolean; status?: number; body: unknown }): { sucesso: boolean; erro: string | null; omieStatus: string | null }`** — `!httpOk` → falha; `body.faultstring` (string ≠ vazio) → falha; `codigo_status`/`cCodStatus` ≠ `"0"`/`0` → falha; senão sucesso. Robusto a body null/array/string/number.
+2. **`erroBenigno(faultstring, operacao): boolean`** — reconhece mensagens explícitas ("já concluíd", "já está na etapa", "já efetivad") por operação → trata como sucesso benigno (Codex Q2/Q3). **Allowlist conservadora** (só strings conhecidas; desconhecido = falha real).
+3. **`decidirStatusEfetivacao(flags: { alterarOk; etapaOk; concluirOk; cteOk; ajustesTentados; ajustesOk }): 'efetivado' | 'falha_efetivacao' | 'efetivacao_parcial'`** — `efetivado` só com todos os passos OBRIGATÓRIOS ok (alterar+etapa+concluir + ajustes todos ok; CT-e e Sayerlack conforme aplicável); nenhum efeito crítico → `falha_efetivacao`; algum efeito ok + outro pendente → `efetivacao_parcial`.
+4. **`selecionarPassosPendentes(flags): string[]`** — lista de passos a executar no retry (pula os `ok`). Ajustes: itens com `quantidade_convertida>0 && !ajuste_estoque_ok`.
+5. **`podeReprocessar(status): boolean`** — `falha_efetivacao`/`efetivacao_parcial`.
+6. **`resumirErros(falhas): string`** — concatena, trunca ~500 chars.
 
-2. **`decidirStatusEfetivacao(p: { alterarOk: boolean; ajustesTentados: number; ajustesOk: number }): { status: 'efetivado' | 'falha_efetivacao' | 'efetivacao_parcial'; }`**
-   - `!alterarOk` → `falha_efetivacao`.
-   - `alterarOk && ajustesTentados === ajustesOk` (inclui 0 ajustes) → `efetivado`.
-   - `alterarOk && ajustesOk < ajustesTentados` → `efetivacao_parcial`.
-   - CT-e falho **não** degrada o status (frete é fiscal, não estoque; tem `cte_associados.status` próprio); só registra no ledger.
+## 6. Edge `omie-nfe-recebimento` (A0: diagnóstico · A1: coreografia)
 
-3. **`selecionarAjustesPendentes(itens: { id: string; quantidade_convertida: number | null; produto_omie_id: number | null; ajuste_estoque_ok: boolean }[]): string[]`** — ids dos itens com `quantidade_convertida>0 && produto_omie_id && !ajuste_estoque_ok` (idempotência: pula já-feitos).
-
-4. **`podeReprocessar(status: string): boolean`** — `true` só pra `falha_efetivacao`/`efetivacao_parcial`.
-
-5. **`resumirErros(falhas: { operacao: string; erro: string }[]): string`** — concatena, trunca pra caber em `efetivacao_erro` (limite ~500 chars).
-
-## 6. Edge `omie-nfe-recebimento` reescrito (fail-closed)
-
-Após fetch (nfe/itens/lotes/conversões), incrementa `efetivacao_tentativas`. Espelha o helper verbatim.
-
-1. **Passo A — `AlterarRecebimento`** (só se `!alterar_recebimento_ok`): chama, `classificarRespostaOmie`. Registra tentativa.
-   - **Falha** → persiste `status='falha_efetivacao'` + `efetivacao_erro` + tentativas; retorna `{success:false, status, erro}` (HTTP 200). **Aborta B e C** (nada mais roda — sem entrada parcial).
-   - **Sucesso** → `alterar_recebimento_ok=true`, `omie_alterar_at=now`.
-2. **Passo B — ajustes** (`selecionarAjustesPendentes`): pra cada item, `IncluirAjusteEstoque`, classifica, registra tentativa. Sucesso → marca item `ajuste_estoque_ok=true` + `omie_id` + `at`. Falha → acumula erro (não aborta os outros — tenta todos).
-3. **Passo C — CT-e**: como hoje (por-item, marca `cte_associados.status='efetivado'` só em sucesso). Registra tentativa. Falha não degrada o status da NF.
-4. **Status final** — `decidirStatusEfetivacao`. `efetivado` → `status='efetivado'` + `efetivado_at=now` + `efetivacao_erro=null`. `efetivacao_parcial` → `status` + `efetivacao_erro`. Persiste.
-5. Retorna `{success: status==='efetivado', status, erro, ctes_processed, operations}`.
-
-**Idempotência do retry:** tentativa 2 pula `AlterarRecebimento` (já ok) e os ajustes de itens já-ok → re-faz só o que faltou → vira `efetivado` sem duplicar estoque.
-
-**Postura conservadora (Codex Q3):** `IncluirAjusteEstoque` e `AlterarRecebimento` tratados como NÃO-idempotentes (só re-chamam se nenhum sucesso registrado). Se o founder confirmar que `AlterarRecebimento` é overwrite-seguro, relaxa depois.
+- **A0 — `{diagnostico:true, nfe_recebimento_id}`:** valida staff + lê `nfe`+`omie_id_receb`; chama `ConsultarRecebimento({nIdReceb})` (read-only); registra tentativa `operacao='diagnostico'`; retorna `{ok:true, diagnostico: <JSON cru>}`. Sem escrita.
+- **A1 — efetivação:** claim atômico (lock). Incrementa tentativas. Ordem fail-closed, cada passo só se `!flag_ok`, `classificarRespostaOmie` + `erroBenigno`, registra tentativa, persiste flag ao suceder **antes do próximo passo** (Codex furo #3):
+  1. `AlterarRecebimento` (qtd + lote/data confirmados) → `alterar_recebimento_ok`.
+  2. ajustes Sayerlack pendentes → `ajuste_estoque_ok` por item.
+  3. `AlterarEtapaRecebimento` (cEtapa 40) → `alterar_etapa_ok` (tolera benigno "já na etapa").
+  4. `ConcluirRecebimento` → `concluir_recebimento_ok` (tolera benigno "já concluído").
+  5. CT-e → `cte_ok`.
+  - Qualquer passo obrigatório falha → para, `decidirStatusEfetivacao`, persiste status+erro, libera lock, retorna `{success:false,status,erro}`.
+  - Todos ok → `status='efetivado'` + `efetivado_at`, libera lock, `{success:true}`.
+  - **Guard de campo não-mapeado:** se `data_registro`/lote/`2353` exigidos e não confirmados → não chama escrita, retorna `falha_efetivacao` + motivo.
 
 ## 7. Frontend honesto
 
-- **`Recebimento.tsx`:** tipo `NfeStatus` + `STATUS_CONFIG` ganham `falha_efetivacao` (status-error) e `efetivacao_parcial` (status-warning). `handleEfetivar` inspeciona `res.data.status`: toast de sucesso **só** se `efetivado`; senão `toast.error`/`toast.warning` com `res.data.erro`. Botão "Reprocessar" nos cards `falha_efetivacao`/`efetivacao_parcial` (re-invoca o edge). Filtros das abas incluem os novos status no histórico/pendências.
-- **`RecebimentoConferencia.tsx`:** `handleFinalize` inspeciona o resultado real (igual). Em falha: toast honesto + **não** declara efetivado (a NF aparece como falha na lista pra reprocessar).
-- **KPIs `AdminEstoqueRecebimento.tsx`:** "Efetivadas Hoje" → `efetivado_at >= início do dia` (gte/lt, não `data_emissao`). Novo card/contagem **"Falhas de efetivação"** (`status in (falha_efetivacao, efetivacao_parcial)`).
-- **`useEstoqueZone.ts` (cockpit):** "Recebidos hoje" (conta `conferido`) → renomear label **"Conferidas hoje"** (a métrica é trabalho do conferente, não entrada efetiva). Adicionar `priority`/topItem quando houver NF em `falha_efetivacao` (alerta o gestor: entrada de estoque travada).
+- **`Recebimento.tsx`:** `NfeStatus` + `STATUS_CONFIG` ganham `falha_efetivacao` (error) / `efetivacao_parcial` (warning). `handleEfetivar` inspeciona `res.data.status` (toast de sucesso só se `efetivado`; senão error/warning com `res.data.erro`). Botão **"Reprocessar"** (falha/parcial) + **"Diagnosticar"** (staff, qualquer status). Abas incluem os novos status.
+- **`RecebimentoConferencia.tsx`:** `handleFinalize` inspeciona o resultado real (sem declarar efetivado em falha).
+- **KPIs `AdminEstoqueRecebimento.tsx`:** "Efetivadas Hoje" → `efetivado_at >= início do dia`; novo contador **"Falhas de efetivação"** (`status in (falha_efetivacao, efetivacao_parcial)`).
+- **`useEstoqueZone.ts`:** "Recebidos hoje" (conta `conferido`) → label **"Conferidas hoje"**; `priority`/topItem quando há NF em `falha_efetivacao`.
 
-## 8. process-nfe (divergência técnica registrada)
+## 8. Testes (helper puro, vitest)
 
-`process-nfe` está **vivo** (rota `/nfe-receipt` + aba "Manual" do admin via `NfeReceipt`) e é fail-closed correto (cada passo dá `return` no erro; faz o fluxo completo). **Intacto na v1** — não é o caminho do bug. Risco de longo prazo: 2 fluxos de efetivação com contratos diferentes. Consolidar/aposentar = decisão pós-v1 (não misturar com a correção de honestidade).
+- `classificarRespostaOmie`: 200 sem fault → sucesso; `faultstring` → falha; HTTP 500 → falha; `codigo_status:"0"` → sucesso; `"101"` → falha; null/array/string robusto.
+- `erroBenigno`: "já concluído"/"já está na etapa" conhecidos → benigno; string desconhecida → falha real.
+- `decidirStatusEfetivacao`: matriz de flags (todos ok → efetivado; alterar ok + concluir falha → parcial; nada → falha).
+- `selecionarPassosPendentes`: pula `ok`; ajustes só itens com conversão pendente.
+- `podeReprocessar`, `resumirErros`.
 
-## 9. Testes (helper puro, vitest)
+## 9. Validação + loop com o founder
 
-- `classificarRespostaOmie`: 200 sem fault → sucesso; `faultstring` → falha; HTTP 500 → falha; `codigo_status:"0"` → sucesso; `codigo_status:"101"` → falha; body null/array/string → robusto (sucesso só com sinal claro de ok; sem fabricar).
-- `decidirStatusEfetivacao`: alterar falha → `falha_efetivacao`; alterar ok + 0 ajustes → `efetivado`; alterar ok + 2/2 ajustes → `efetivado`; alterar ok + 1/2 ajustes → `efetivacao_parcial`.
-- `selecionarAjustesPendentes`: pula `ajuste_estoque_ok`; inclui `quantidade_convertida>0 && produto_omie_id`; ignora sem conversão.
-- `podeReprocessar`: true pra falha/parcial; false pra efetivado/pendente/conferido.
-- `resumirErros`: trunca/concatena.
+- Helper puro: vitest. Edge: `deno check` (erro-set inalterado). CI `validate`.
+- **Sem teste local contra o Omie.** PR1 (diagnóstico/infra) entregue com confiança. Entre PR1 e PR2: founder **roda o diagnóstico numa NF real** + responde as factuais → eu confirmo os campos. PR2: founder testa **1 NF de baixo valor** → ajusto. Ledger + lock garantem que re-testar **não duplica** estoque/conclusão.
 
-## 10. Validação
+## 10. Perguntas factuais ao founder (entre PR1 e PR2)
+1. A aba "Manual" (`process-nfe`) leva a NF até "Concluído" e movimenta estoque hoje? (valida o mapa)
+2. "2353" — que campo/valor é e onde vai?
+3. Data de registro — automática na conclusão (= hoje) ou manual? + o JSON do diagnóstico (campos reais).
 
-- Helper puro: vitest (todos verdes).
-- Edge: `deno check` (erro-set inalterado vs main, padrão do repo).
-- CI `validate`: typecheck (strict) + test + lint + build.
-- ⚠️ **Sem teste contra o Omie** (sem acesso). O fail-closed se baseia no sinal honesto que o Omie devolve. Founder monitora o 1º dia pós-deploy (se muitas NFs viram `falha_efetivacao` → Hipótese B se revelando → dispara a v2).
+## 11. Entregáveis / Lovable
+- **PR1:** migration `20260604140000_recebimento_efetivacao_ledger.sql` (SQL Editor) + deploy do edge (diagnóstico) via Lovable + Publish.
+- **PR2:** deploy do edge (coreografia) via Lovable + Publish + teste do founder.
+- Registrar no CLAUDE.md + nota de migration manual no PR.
 
-## 11. Entregáveis / operações Lovable
-
-- **Migration** `20260604140000_recebimento_efetivacao_ledger.sql` (idempotente: `ADD COLUMN IF NOT EXISTS`, `CREATE TABLE IF NOT EXISTS`, RLS) → **colar no SQL Editor** (manual).
-- **Deploy do edge** `omie-nfe-recebimento` **verbatim da main** via chat do Lovable (após merge).
-- **Publish** do frontend.
-- Registrar no CLAUDE.md (§6 ou §10) + nota de migration manual no PR.
+## 12. Riscos (Codex)
+1. **Double-count de estoque por retry/paralelismo** → lock atômico + flags por passo (obrigatório).
+2. **Payload errado em campo de estoque real** → data/lote/2353 nunca inferidos; diagnóstico-first + guard.
+3. **Beco de parcial sem retomada** → flag persistida antes do próximo passo + `podeReprocessar` + (v2) consulta de estado antes do retry.

--- a/src/hooks/dashboard/useEstoqueZone.ts
+++ b/src/hooks/dashboard/useEstoqueZone.ts
@@ -120,7 +120,9 @@ export function useEstoqueZone() {
     return [
       { label: 'NF pendentes', value: formatCount(data.nfPendentes) },
       { label: 'Picking abertos', value: formatCount(data.pickingAbertos) },
-      { label: 'Recebidos hoje', value: formatCount(data.recebimentosHoje) },
+      // "Conferidas hoje" (status='conferido') é trabalho do conferente, NÃO entrada de
+      // estoque efetiva — rótulo honesto pra não confundir com efetivação no Omie.
+      { label: 'Conferidas hoje', value: formatCount(data.recebimentosHoje) },
     ];
   }, [data]);
 

--- a/src/lib/recebimento/efetivacao-helpers.test.ts
+++ b/src/lib/recebimento/efetivacao-helpers.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect } from 'vitest';
+import {
+  classificarRespostaOmie,
+  erroBenigno,
+  decidirStatusEfetivacao,
+  selecionarPassosPendentes,
+  podeReprocessar,
+  resumirErros,
+  type PassoFlags,
+} from './efetivacao-helpers';
+
+describe('classificarRespostaOmie', () => {
+  it('HTTP 200 sem faultstring → sucesso', () => {
+    const r = classificarRespostaOmie({ httpOk: true, status: 200, body: { nIdReceb: 42 } });
+    expect(r.sucesso).toBe(true);
+    expect(r.erro).toBeNull();
+  });
+
+  it('HTTP 200 com faultstring → falha (sucesso HTTP ≠ sucesso Omie)', () => {
+    const r = classificarRespostaOmie({
+      httpOk: true,
+      status: 200,
+      body: { faultstring: 'O preenchimento da tag [nValUnit] é obrigatório', faultcode: 'SOAP-ENV:Client-101' },
+    });
+    expect(r.sucesso).toBe(false);
+    expect(r.erro).toContain('nValUnit');
+  });
+
+  it('HTTP 500 → falha mesmo sem faultstring', () => {
+    const r = classificarRespostaOmie({ httpOk: false, status: 500, body: { raw: 'erro interno' } });
+    expect(r.sucesso).toBe(false);
+    expect(r.erro).toContain('HTTP 500');
+  });
+
+  it('HTTP 500 com faultstring → usa a faultstring no erro', () => {
+    const r = classificarRespostaOmie({ httpOk: false, status: 500, body: { faultstring: 'Consumo redundante' } });
+    expect(r.sucesso).toBe(false);
+    expect(r.erro).toBe('Consumo redundante');
+  });
+
+  it('codigo_status "0" → sucesso', () => {
+    const r = classificarRespostaOmie({ httpOk: true, body: { codigo_status: '0', descricao_status: 'OK' } });
+    expect(r.sucesso).toBe(true);
+    expect(r.omieStatus).toBe('0');
+  });
+
+  it('codigo_status "101" → falha com descricao_status', () => {
+    const r = classificarRespostaOmie({ httpOk: true, body: { codigo_status: '101', descricao_status: 'Produto não encontrado' } });
+    expect(r.sucesso).toBe(false);
+    expect(r.erro).toBe('Produto não encontrado');
+    expect(r.omieStatus).toBe('101');
+  });
+
+  it('cCodStatus numérico ≠ 0 → falha', () => {
+    const r = classificarRespostaOmie({ httpOk: true, body: { cCodStatus: 5, cDescStatus: 'Falhou' } });
+    expect(r.sucesso).toBe(false);
+    expect(r.erro).toBe('Falhou');
+  });
+
+  it('ausência de codigo_status NÃO é falha', () => {
+    const r = classificarRespostaOmie({ httpOk: true, body: { nIdReceb: 1, cChaveNfe: 'x' } });
+    expect(r.sucesso).toBe(true);
+  });
+
+  it('body null/array/string → robusto (sucesso só com httpOk e sem sinal de erro)', () => {
+    expect(classificarRespostaOmie({ httpOk: true, body: null }).sucesso).toBe(true);
+    expect(classificarRespostaOmie({ httpOk: true, body: [1, 2, 3] }).sucesso).toBe(true);
+    expect(classificarRespostaOmie({ httpOk: true, body: 'texto solto' }).sucesso).toBe(true);
+    expect(classificarRespostaOmie({ httpOk: false, status: 404, body: 'not found' }).sucesso).toBe(false);
+  });
+
+  it('faultstring só com espaços → tratada como ausente', () => {
+    const r = classificarRespostaOmie({ httpOk: true, body: { faultstring: '   ' } });
+    expect(r.sucesso).toBe(true);
+  });
+});
+
+describe('erroBenigno', () => {
+  it('"já está na etapa" em alterar_etapa → benigno', () => {
+    expect(erroBenigno('Recebimento já está na etapa informada', 'alterar_etapa')).toBe(true);
+  });
+  it('"já concluído" em concluir_recebimento → benigno', () => {
+    expect(erroBenigno('Recebimento já concluído anteriormente', 'concluir_recebimento')).toBe(true);
+    expect(erroBenigno('Nota já foi efetivada', 'concluir_recebimento')).toBe(true);
+  });
+  it('faultstring desconhecida → NÃO benigno (falha real)', () => {
+    expect(erroBenigno('Produto não encontrado', 'concluir_recebimento')).toBe(false);
+    expect(erroBenigno('Erro de validação X', 'alterar_etapa')).toBe(false);
+  });
+  it('operação sem allowlist → nunca benigno', () => {
+    expect(erroBenigno('já concluído', 'alterar_recebimento')).toBe(false);
+  });
+  it('faultstring vazia → não benigno', () => {
+    expect(erroBenigno('', 'concluir_recebimento')).toBe(false);
+    expect(erroBenigno(null, 'concluir_recebimento')).toBe(false);
+  });
+});
+
+describe('decidirStatusEfetivacao', () => {
+  // base = NF SEM CT-e aplicável (cteAplicavel:false), nada concretizado.
+  const base: PassoFlags = { alterarOk: false, etapaOk: false, concluirOk: false, cteAplicavel: false, cteOk: false, ajustesTentados: 0, ajustesOk: 0 };
+
+  it('todos os obrigatórios ok (sem CT-e) + sem ajustes → efetivado', () => {
+    expect(decidirStatusEfetivacao({ ...base, alterarOk: true, etapaOk: true, concluirOk: true })).toBe('efetivado');
+  });
+  it('todos ok + CT-e aplicável concluído + ajustes 2/2 → efetivado', () => {
+    expect(
+      decidirStatusEfetivacao({ alterarOk: true, etapaOk: true, concluirOk: true, cteAplicavel: true, cteOk: true, ajustesTentados: 2, ajustesOk: 2 }),
+    ).toBe('efetivado');
+  });
+  it('nada concretizado (sem CT-e) → falha_efetivacao', () => {
+    expect(decidirStatusEfetivacao(base)).toBe('falha_efetivacao');
+  });
+  it('CT-e não-aplicável NÃO conta como efeito → ainda falha_efetivacao', () => {
+    expect(decidirStatusEfetivacao({ ...base, cteAplicavel: false, cteOk: false })).toBe('falha_efetivacao');
+  });
+  it('alterar ok mas concluir pendente → parcial', () => {
+    expect(decidirStatusEfetivacao({ ...base, alterarOk: true })).toBe('efetivacao_parcial');
+  });
+  it('alterar+etapa+concluir ok mas CT-e aplicável falhou → parcial', () => {
+    expect(
+      decidirStatusEfetivacao({ alterarOk: true, etapaOk: true, concluirOk: true, cteAplicavel: true, cteOk: false, ajustesTentados: 0, ajustesOk: 0 }),
+    ).toBe('efetivacao_parcial');
+  });
+  it('alterar+etapa+concluir ok mas 1/2 ajustes → parcial', () => {
+    expect(
+      decidirStatusEfetivacao({ alterarOk: true, etapaOk: true, concluirOk: true, cteAplicavel: false, cteOk: false, ajustesTentados: 2, ajustesOk: 1 }),
+    ).toBe('efetivacao_parcial');
+  });
+  it('só ajuste concretizado (passos NF pendentes) → parcial, não falha', () => {
+    expect(
+      decidirStatusEfetivacao({ alterarOk: false, etapaOk: false, concluirOk: false, cteAplicavel: false, cteOk: false, ajustesTentados: 1, ajustesOk: 1 }),
+    ).toBe('efetivacao_parcial');
+  });
+});
+
+describe('selecionarPassosPendentes', () => {
+  it('lista só os passos sem ok (CT-e aplicável já ok não entra)', () => {
+    expect(selecionarPassosPendentes({ alterarOk: true, etapaOk: false, concluirOk: false, cteAplicavel: true, cteOk: true })).toEqual([
+      'alterar_etapa',
+      'concluir_recebimento',
+    ]);
+  });
+  it('tudo ok → vazio', () => {
+    expect(selecionarPassosPendentes({ alterarOk: true, etapaOk: true, concluirOk: true, cteAplicavel: true, cteOk: true })).toEqual([]);
+  });
+  it('nada ok + CT-e aplicável → todos incluindo cte', () => {
+    expect(selecionarPassosPendentes({ alterarOk: false, etapaOk: false, concluirOk: false, cteAplicavel: true, cteOk: false })).toEqual([
+      'alterar_recebimento',
+      'alterar_etapa',
+      'concluir_recebimento',
+      'cte',
+    ]);
+  });
+  it('sem CT-e aplicável → cte não entra mesmo com cteOk false', () => {
+    expect(selecionarPassosPendentes({ alterarOk: false, etapaOk: false, concluirOk: false, cteAplicavel: false, cteOk: false })).toEqual([
+      'alterar_recebimento',
+      'alterar_etapa',
+      'concluir_recebimento',
+    ]);
+  });
+});
+
+describe('podeReprocessar', () => {
+  it('falha/parcial → true; demais → false', () => {
+    expect(podeReprocessar('falha_efetivacao')).toBe(true);
+    expect(podeReprocessar('efetivacao_parcial')).toBe(true);
+    expect(podeReprocessar('efetivado')).toBe(false);
+    expect(podeReprocessar('conferido')).toBe(false);
+    expect(podeReprocessar('pendente')).toBe(false);
+  });
+});
+
+describe('resumirErros', () => {
+  it('concatena operação: erro', () => {
+    expect(resumirErros([{ operacao: 'alterar_recebimento', erro: 'X' }, { operacao: 'cte', erro: 'Y' }])).toBe(
+      'alterar_recebimento: X | cte: Y',
+    );
+  });
+  it('trunca acima do limite', () => {
+    const out = resumirErros([{ operacao: 'op', erro: 'a'.repeat(1000) }], 50);
+    expect(out.length).toBe(50);
+    expect(out.endsWith('…')).toBe(true);
+  });
+});

--- a/src/lib/recebimento/efetivacao-helpers.ts
+++ b/src/lib/recebimento/efetivacao-helpers.ts
@@ -1,0 +1,139 @@
+/**
+ * Helpers puros da efetivação de NF-e de recebimento (Fase A — closed-loop honesto).
+ *
+ * Oráculo testável (vitest) ESPELHADO VERBATIM no edge `omie-nfe-recebimento` (Deno).
+ * O edge não importa de `src/` — qualquer mudança aqui precisa ser copiada lá.
+ *
+ * Princípios (metodologia Codex, 3 rodadas):
+ * - Sucesso HTTP ≠ sucesso Omie: o Omie devolve HTTP 200 com `faultstring` em erro
+ *   de negócio (padrão do repo: omie-sync / process-nfe fazem `if (faultstring) throw`).
+ * - Passos NÃO-idempotentes até prova: o retry só roda o passo sem `ok`.
+ * - "Já concluído"/"já na etapa" só viram sucesso benigno se a faultstring for conhecida.
+ * - efetivado só com TODOS os passos obrigatórios ok; algum efeito + pendência = parcial.
+ */
+
+export interface OmieRespInput {
+  /** `res.ok` do fetch (HTTP < 400). */
+  httpOk: boolean;
+  /** Status HTTP, se houver. */
+  status?: number;
+  /** Corpo já parseado (objeto/array/string/null) da resposta do Omie. */
+  body: unknown;
+}
+
+export interface OmieClassificacao {
+  sucesso: boolean;
+  erro: string | null;
+  /** `codigo_status`/`cCodStatus` do Omie, se presente (diagnóstico). */
+  omieStatus: string | null;
+}
+
+function asRecord(v: unknown): Record<string, unknown> {
+  return v && typeof v === 'object' && !Array.isArray(v) ? (v as Record<string, unknown>) : {};
+}
+
+/**
+ * Decide se uma resposta do Omie é sucesso REAL (não só HTTP 200).
+ * Falha quando: HTTP≥400, `faultstring` presente, ou `codigo_status`/`cCodStatus` ≠ "0".
+ * Ausência de `codigo_status` NÃO é falha (muitos endpoints não retornam).
+ */
+export function classificarRespostaOmie(r: OmieRespInput): OmieClassificacao {
+  const obj = asRecord(r.body);
+  const faultstring = typeof obj.faultstring === 'string' ? obj.faultstring.trim() : '';
+  const codRaw = obj.codigo_status ?? obj.cCodStatus;
+  const omieStatus = codRaw == null ? null : String(codRaw).trim();
+  const desc =
+    (typeof obj.descricao_status === 'string' && obj.descricao_status.trim()) ||
+    (typeof obj.cDescStatus === 'string' && obj.cDescStatus.trim()) ||
+    '';
+
+  if (!r.httpOk) {
+    return { sucesso: false, erro: faultstring || `HTTP ${r.status ?? '???'}`, omieStatus };
+  }
+  if (faultstring) {
+    return { sucesso: false, erro: faultstring, omieStatus };
+  }
+  if (omieStatus != null && omieStatus !== '' && omieStatus !== '0') {
+    return { sucesso: false, erro: desc || `status ${omieStatus}`, omieStatus };
+  }
+  return { sucesso: true, erro: null, omieStatus };
+}
+
+/**
+ * Allowlist conservadora de faultstrings benignas POR operação (Codex Q2/Q3):
+ * "já concluído"/"já está na etapa"/"já efetivado" → o efeito JÁ existe no Omie,
+ * então tratar como sucesso do passo. Qualquer string fora da allowlist = falha real.
+ */
+const BENIGNOS: Record<string, RegExp[]> = {
+  alterar_etapa: [/j[áa]\s+est[áa]\s+(na|nesta|nessa)?\s*etapa/i, /mesma\s+etapa/i, /etapa\s+(atual|j[áa])/i],
+  concluir_recebimento: [/j[áa]\s+(foi\s+)?conclu/i, /j[áa]\s+(foi\s+)?efetiv/i, /recebimento\s+conclu/i],
+};
+
+export function erroBenigno(faultstring: string | null | undefined, operacao: string): boolean {
+  const fs = (faultstring ?? '').trim();
+  if (!fs) return false;
+  const pats = BENIGNOS[operacao];
+  return pats ? pats.some((re) => re.test(fs)) : false;
+}
+
+export interface PassoFlags {
+  alterarOk: boolean;
+  etapaOk: boolean;
+  concluirOk: boolean;
+  /** Há CT-e a concluir nesta NF? Quando `false`, o CT-e não é passo obrigatório nem conta como efeito. */
+  cteAplicavel: boolean;
+  /** CT-e concluído (só relevante quando `cteAplicavel`). */
+  cteOk: boolean;
+  ajustesTentados: number;
+  ajustesOk: number;
+}
+
+export type EfetivacaoStatus = 'efetivado' | 'falha_efetivacao' | 'efetivacao_parcial';
+
+/**
+ * Status final a partir das flags por passo.
+ * `efetivado` só com todos os obrigatórios ok (alterar+etapa+concluir + CT-e se aplicável + ajustes completos);
+ * nenhum efeito externo concretizado → `falha_efetivacao`; algum efeito + pendência → `efetivacao_parcial`.
+ * CT-e não-aplicável NÃO conta como efeito (senão NF sem CT-e nunca cairia em `falha_efetivacao`).
+ */
+export function decidirStatusEfetivacao(f: PassoFlags): EfetivacaoStatus {
+  const ajustesCompletos = f.ajustesOk >= f.ajustesTentados;
+  const cteCompleto = !f.cteAplicavel || f.cteOk;
+  const todosOk = f.alterarOk && f.etapaOk && f.concluirOk && cteCompleto && ajustesCompletos;
+  if (todosOk) return 'efetivado';
+  const algumEfeito = f.alterarOk || f.etapaOk || f.concluirOk || (f.cteAplicavel && f.cteOk) || f.ajustesOk > 0;
+  return algumEfeito ? 'efetivacao_parcial' : 'falha_efetivacao';
+}
+
+export interface PassosOkFlags {
+  alterarOk: boolean;
+  etapaOk: boolean;
+  concluirOk: boolean;
+  cteAplicavel: boolean;
+  cteOk: boolean;
+}
+
+/**
+ * Passos de NF (não-item) a executar no retry — só os que ainda não têm `ok`.
+ * O passo `cte` só entra se houver CT-e aplicável. Ajustes de estoque são por-item
+ * (selecionados à parte por `ajuste_estoque_ok`).
+ */
+export function selecionarPassosPendentes(f: PassosOkFlags): string[] {
+  const p: string[] = [];
+  if (!f.alterarOk) p.push('alterar_recebimento');
+  if (!f.etapaOk) p.push('alterar_etapa');
+  if (!f.concluirOk) p.push('concluir_recebimento');
+  if (f.cteAplicavel && !f.cteOk) p.push('cte');
+  return p;
+}
+
+export function podeReprocessar(status: string): boolean {
+  return status === 'falha_efetivacao' || status === 'efetivacao_parcial';
+}
+
+/** Concatena erros por operação num resumo truncado pra caber em `efetivacao_erro`. */
+export function resumirErros(falhas: { operacao: string; erro: string }[], max = 500): string {
+  const txt = falhas.map((f) => `${f.operacao}: ${f.erro}`).join(' | ');
+  if (txt.length <= max) return txt;
+  return txt.slice(0, Math.max(0, max - 1)) + '…';
+}

--- a/src/pages/AdminEstoqueRecebimento.tsx
+++ b/src/pages/AdminEstoqueRecebimento.tsx
@@ -1,7 +1,8 @@
-import { lazy, Suspense, useState, useMemo } from "react";
+import { lazy, Suspense, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
+import { spDayRangeUtc } from "@/lib/time/sp-day";
 import {
   PackageCheck,
   Loader2,
@@ -38,12 +39,6 @@ const TabFallback = () => (
 
 function KpiCards({ empresa }: { empresa: string }) {
   const warehouseId = WAREHOUSE_BY_EMPRESA[empresa];
-  // Início do dia LOCAL (fuso do operador) — base honesta pro KPI de efetivação.
-  const startOfDay = useMemo(() => {
-    const d = new Date();
-    d.setHours(0, 0, 0, 0);
-    return d.toISOString();
-  }, []);
 
   const { data: pendentes } = useQuery({
     queryKey: ["estoque-receb-pendentes", warehouseId],
@@ -88,15 +83,18 @@ function KpiCards({ empresa }: { empresa: string }) {
   });
 
   const { data: efetivadasHoje } = useQuery({
-    queryKey: ["estoque-receb-efetivadas-hoje", warehouseId, startOfDay],
+    queryKey: ["estoque-receb-efetivadas-hoje", warehouseId],
     queryFn: async () => {
       // Por efetivado_at (momento da efetivação), não data_emissao (data da nota no fornecedor).
+      // Janela [início, fim) do dia em America/Sao_Paulo (recalculada a cada refetch → robusta à virada de dia).
+      const { startUtc, endUtc } = spDayRangeUtc();
       const { count } = await supabase
         .from("nfe_recebimentos")
         .select("*", { count: "exact", head: true })
         .eq("warehouse_id", warehouseId)
         .eq("status", "efetivado")
-        .gte("efetivado_at", startOfDay);
+        .gte("efetivado_at", startUtc)
+        .lt("efetivado_at", endUtc);
       return count ?? 0;
     },
     refetchInterval: 60000,
@@ -202,7 +200,8 @@ export default function AdminEstoqueRecebimento() {
 
         <TabsContent value="nfes" className="m-0">
           <Suspense fallback={<TabFallback />}>
-            <Recebimento statusFilter={['pendente', 'divergencia']} />
+            {/* falha_efetivacao/efetivacao_parcial entram aqui (NFs que precisam de ação) — A1 as produz */}
+            <Recebimento statusFilter={['pendente', 'divergencia', 'falha_efetivacao', 'efetivacao_parcial']} />
           </Suspense>
         </TabsContent>
 

--- a/src/pages/AdminEstoqueRecebimento.tsx
+++ b/src/pages/AdminEstoqueRecebimento.tsx
@@ -38,7 +38,12 @@ const TabFallback = () => (
 
 function KpiCards({ empresa }: { empresa: string }) {
   const warehouseId = WAREHOUSE_BY_EMPRESA[empresa];
-  const today = useMemo(() => new Date().toISOString().slice(0, 10), []);
+  // Início do dia LOCAL (fuso do operador) — base honesta pro KPI de efetivação.
+  const startOfDay = useMemo(() => {
+    const d = new Date();
+    d.setHours(0, 0, 0, 0);
+    return d.toISOString();
+  }, []);
 
   const { data: pendentes } = useQuery({
     queryKey: ["estoque-receb-pendentes", warehouseId],
@@ -83,14 +88,15 @@ function KpiCards({ empresa }: { empresa: string }) {
   });
 
   const { data: efetivadasHoje } = useQuery({
-    queryKey: ["estoque-receb-efetivadas-hoje", warehouseId, today],
+    queryKey: ["estoque-receb-efetivadas-hoje", warehouseId, startOfDay],
     queryFn: async () => {
+      // Por efetivado_at (momento da efetivação), não data_emissao (data da nota no fornecedor).
       const { count } = await supabase
         .from("nfe_recebimentos")
         .select("*", { count: "exact", head: true })
         .eq("warehouse_id", warehouseId)
         .eq("status", "efetivado")
-        .eq("data_emissao", today);
+        .gte("efetivado_at", startOfDay);
       return count ?? 0;
     },
     refetchInterval: 60000,

--- a/src/pages/Recebimento.tsx
+++ b/src/pages/Recebimento.tsx
@@ -472,7 +472,7 @@ export default function Recebimento({ statusFilter }: { statusFilter?: string[] 
           </DialogHeader>
           <div className="space-y-2 py-1">
             <p className="text-xs text-muted-foreground">
-              Estado real do recebimento no Omie (read-only — nada foi escrito). Copie e cole pra mapear os campos da efetivação completa.
+              Estado real do recebimento no Omie (read-only — não alterou Omie, estoque, NF-e nem itens; só registrou auditoria). Copie e cole pra mapear os campos da efetivação completa.
             </p>
             <pre className="text-xs bg-muted rounded p-3 max-h-[50vh] overflow-auto font-mono whitespace-pre-wrap break-words">
               {diagResult}

--- a/src/pages/Recebimento.tsx
+++ b/src/pages/Recebimento.tsx
@@ -3,7 +3,7 @@ import { decodeHtmlEntities } from '@/lib/utils';
 import { useNavigate } from 'react-router-dom';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
-import { FileCheck, Truck, Plus, Loader2, PackageCheck, RefreshCw } from 'lucide-react';
+import { FileCheck, Truck, Plus, Loader2, PackageCheck, RefreshCw, Stethoscope } from 'lucide-react';
 import { EmptyState } from '@/components/EmptyState';
 import { PageSkeleton } from '@/components/ui/page-skeleton';
 import { Button } from '@/components/ui/button';
@@ -22,7 +22,7 @@ import {
 } from '@/components/ui/dialog';
 import type { Tables } from '@/integrations/supabase/types';
 
-type NfeStatus = 'pendente' | 'em_conferencia' | 'divergencia' | 'conferido' | 'efetivado';
+type NfeStatus = 'pendente' | 'em_conferencia' | 'divergencia' | 'conferido' | 'efetivado' | 'falha_efetivacao' | 'efetivacao_parcial';
 
 type Warehouse = Tables<'warehouses'>;
 type NfeRecebimento = Tables<'nfe_recebimentos'>;
@@ -49,6 +49,8 @@ const STATUS_CONFIG: Record<NfeStatus, { label: string; className: string }> = {
   divergencia: { label: 'Divergência', className: 'bg-status-error-bg text-status-error-foreground' },
   conferido: { label: 'Conferido', className: 'bg-status-success-bg text-status-success-foreground' },
   efetivado: { label: 'Efetivado', className: 'bg-muted text-muted-foreground' },
+  falha_efetivacao: { label: 'Falha na efetivação', className: 'bg-status-error-bg text-status-error-foreground' },
+  efetivacao_parcial: { label: 'Efetivação parcial', className: 'bg-status-warning-bg text-status-warning-foreground' },
 };
 
 function formatCurrency(value: number | null) {
@@ -70,6 +72,11 @@ export default function Recebimento({ statusFilter }: { statusFilter?: string[] 
   const [importing, setImporting] = useState(false);
   const [efetivando, setEfetivando] = useState<string | null>(null);
   const [syncing, setSyncing] = useState(false);
+  // A0 — diagnóstico read-only do estado real no Omie (destrava o mapeamento de campos da Fase A1)
+  const [diagnosticando, setDiagnosticando] = useState<string | null>(null);
+  const [diagOpen, setDiagOpen] = useState(false);
+  const [diagResult, setDiagResult] = useState('');
+  const [diagTitle, setDiagTitle] = useState('');
 
   // Fetch warehouses
   const { data: warehouses } = useQuery({
@@ -168,6 +175,28 @@ export default function Recebimento({ statusFilter }: { statusFilter?: string[] 
       toast.error('Erro ao efetivar: ' + (message || 'Tente novamente'));
     } finally {
       setEfetivando(null);
+    }
+  };
+
+  // Diagnóstico read-only: lê o estado real do recebimento no Omie (ConsultarRecebimento)
+  // sem escrever nada. Pro founder me colar o JSON e eu mapear os campos da Fase A1.
+  const handleDiagnosticar = async (nfeId: string, numero: string) => {
+    setDiagnosticando(nfeId);
+    try {
+      const { data: { session } } = await supabase.auth.getSession();
+      const res = await supabase.functions.invoke('omie-nfe-recebimento', {
+        body: { nfe_recebimento_id: nfeId, diagnostico: true },
+        headers: { Authorization: `Bearer ${session?.access_token}` },
+      });
+      if (res.error) throw res.error;
+      setDiagTitle(`Diagnóstico — NF-e ${numero}`);
+      setDiagResult(JSON.stringify(res.data, null, 2));
+      setDiagOpen(true);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      toast.error('Erro no diagnóstico: ' + (message || 'Tente novamente'));
+    } finally {
+      setDiagnosticando(null);
     }
   };
 
@@ -355,21 +384,39 @@ export default function Recebimento({ statusFilter }: { statusFilter?: string[] 
                       </div>
                     </div>
 
-                    {/* Efetivar button */}
-                    {isConferido && (
-                      <Button
-                        size="sm"
-                        onClick={(e) => { e.stopPropagation(); handleEfetivar(nfe.id); }}
-                        disabled={efetivando === nfe.id}
-                        className="shrink-0"
-                      >
-                        {efetivando === nfe.id ? (
-                          <Loader2 className="h-4 w-4 animate-spin" />
-                        ) : (
-                          'Efetivar'
-                        )}
-                      </Button>
-                    )}
+                    {/* Ações */}
+                    <div className="flex items-center gap-1.5 shrink-0">
+                      {/* Diagnosticar (read-only) — disponível assim que houver vínculo Omie */}
+                      {nfe.omie_id_receb != null && (
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          onClick={(e) => { e.stopPropagation(); handleDiagnosticar(nfe.id, nfe.numero_nfe); }}
+                          disabled={diagnosticando === nfe.id}
+                          title="Diagnosticar no Omie (read-only)"
+                          aria-label="Diagnosticar no Omie"
+                        >
+                          {diagnosticando === nfe.id ? (
+                            <Loader2 className="h-4 w-4 animate-spin" />
+                          ) : (
+                            <Stethoscope className="h-4 w-4" />
+                          )}
+                        </Button>
+                      )}
+                      {isConferido && (
+                        <Button
+                          size="sm"
+                          onClick={(e) => { e.stopPropagation(); handleEfetivar(nfe.id); }}
+                          disabled={efetivando === nfe.id}
+                        >
+                          {efetivando === nfe.id ? (
+                            <Loader2 className="h-4 w-4 animate-spin" />
+                          ) : (
+                            'Efetivar'
+                          )}
+                        </Button>
+                      )}
+                    </div>
                   </div>
                 </CardContent>
               </Card>
@@ -413,6 +460,32 @@ export default function Recebimento({ statusFilter }: { statusFilter?: string[] 
               {importing ? <Loader2 className="h-4 w-4 animate-spin mr-2" /> : null}
               Importar
             </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Diagnóstico read-only do Omie (Fase A0) */}
+      <Dialog open={diagOpen} onOpenChange={setDiagOpen}>
+        <DialogContent className="max-w-2xl">
+          <DialogHeader>
+            <DialogTitle>{diagTitle}</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-2 py-1">
+            <p className="text-xs text-muted-foreground">
+              Estado real do recebimento no Omie (read-only — nada foi escrito). Copie e cole pra mapear os campos da efetivação completa.
+            </p>
+            <pre className="text-xs bg-muted rounded p-3 max-h-[50vh] overflow-auto font-mono whitespace-pre-wrap break-words">
+              {diagResult}
+            </pre>
+          </div>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => { navigator.clipboard?.writeText(diagResult); toast.success('JSON copiado'); }}
+            >
+              Copiar JSON
+            </Button>
+            <Button onClick={() => setDiagOpen(false)}>Fechar</Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>

--- a/supabase/functions/omie-nfe-recebimento/index.ts
+++ b/supabase/functions/omie-nfe-recebimento/index.ts
@@ -1,4 +1,4 @@
-import { createClient } from "npm:@supabase/supabase-js@2";
+import { createClient, type SupabaseClient } from "npm:@supabase/supabase-js@2";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -68,6 +68,47 @@ function jsonRes(body: Record<string, unknown>, status = 200) {
     status,
     headers: { ...corsHeaders, "Content-Type": "application/json" },
   });
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// LEDGER / honestidade — ESPELHO VERBATIM de src/lib/recebimento/efetivacao-helpers.ts
+// (Edge Functions não importam de src/; manter sincronizado.) Apenas o que o A0
+// (diagnóstico) usa; o restante do helper entra no A1 (coreografia de escrita).
+// ════════════════════════════════════════════════════════════════════════════
+interface OmieClassificacao { sucesso: boolean; erro: string | null; omieStatus: string | null; }
+
+function asRecord(v: unknown): Record<string, unknown> {
+  return v && typeof v === "object" && !Array.isArray(v) ? (v as Record<string, unknown>) : {};
+}
+
+/** Sucesso HTTP ≠ sucesso Omie: 200 com `faultstring`/`codigo_status≠0` é falha. */
+function classificarRespostaOmie(r: { httpOk: boolean; status?: number; body: unknown }): OmieClassificacao {
+  const obj = asRecord(r.body);
+  const faultstring = typeof obj.faultstring === "string" ? obj.faultstring.trim() : "";
+  const codRaw = obj.codigo_status ?? obj.cCodStatus;
+  const omieStatus = codRaw == null ? null : String(codRaw).trim();
+  const desc =
+    (typeof obj.descricao_status === "string" && obj.descricao_status.trim()) ||
+    (typeof obj.cDescStatus === "string" && obj.cDescStatus.trim()) ||
+    "";
+  if (!r.httpOk) return { sucesso: false, erro: faultstring || `HTTP ${r.status ?? "???"}`, omieStatus };
+  if (faultstring) return { sucesso: false, erro: faultstring, omieStatus };
+  if (omieStatus != null && omieStatus !== "" && omieStatus !== "0") {
+    return { sucesso: false, erro: desc || `status ${omieStatus}`, omieStatus };
+  }
+  return { sucesso: true, erro: null, omieStatus };
+}
+
+/** Registra uma tentativa no ledger append-only (best-effort: nunca derruba o fluxo). */
+async function registrarTentativa(
+  supabase: SupabaseClient,
+  row: { nfe_recebimento_id: string; tentativa: number; operacao: string; item_id?: string | null; sucesso: boolean; erro?: string | null; omie_status?: string | null },
+): Promise<void> {
+  try {
+    await supabase.from("nfe_efetivacao_tentativas").insert(row);
+  } catch (e) {
+    console.error("[omie-nfe-recebimento] falha ao registrar tentativa no ledger:", e);
+  }
 }
 
 // ── Retry with exponential backoff ──
@@ -187,6 +228,63 @@ Deno.serve(async (req) => {
     const nfeRecebimentoId: string = body.nfe_recebimento_id;
     if (!nfeRecebimentoId) {
       return jsonRes({ error: "nfe_recebimento_id obrigatório" }, 400);
+    }
+
+    // ── A0: modo DIAGNÓSTICO read-only ──
+    // Lê o estado real do recebimento no Omie (ConsultarRecebimento) SEM escrever nada.
+    // Pro founder ver os campos reais (etapa/kanban, itens, datas, lote, CT-e) antes de
+    // qualquer efetivação (Fase A1). É o de-risk "diagnóstico-first" (Codex).
+    if (body.diagnostico === true) {
+      const { data: nfeDiag, error: nfeDiagErr } = await supabase
+        .from("nfe_recebimentos")
+        .select("omie_id_receb, numero_nfe, status, efetivacao_tentativas, warehouses(code)")
+        .eq("id", nfeRecebimentoId)
+        .single();
+      if (nfeDiagErr || !nfeDiag) {
+        return jsonRes({ error: "NF-e não encontrada" }, 404);
+      }
+      if (!nfeDiag.omie_id_receb) {
+        return jsonRes({ error: "omie_id_receb ausente — NF-e não importada pelo Omie" }, 400);
+      }
+      const whCode = (nfeDiag.warehouses as WarehouseJoin | null)?.code ?? "OB";
+      const credD = getOmieCredentials(whCode);
+      if (!credD.appKey || !credD.appSecret) {
+        return jsonRes({ error: `Credenciais Omie não configuradas para warehouse ${whCode}` }, 500);
+      }
+      console.log(`[omie-nfe-recebimento] DIAGNÓSTICO read-only nIdReceb=${nfeDiag.omie_id_receb}`);
+      const consultaRes = await omieCall(
+        "https://app.omie.com.br/api/v1/produtos/recebimentonfe/",
+        {
+          call: "ConsultarRecebimento",
+          app_key: credD.appKey,
+          app_secret: credD.appSecret,
+          param: [{ nIdReceb: nfeDiag.omie_id_receb }],
+        },
+      );
+      const cls = classificarRespostaOmie({
+        httpOk: !consultaRes.error,
+        status: consultaRes.error ? consultaRes.status : 200,
+        body: consultaRes.data,
+      });
+      await registrarTentativa(supabase, {
+        nfe_recebimento_id: nfeRecebimentoId,
+        tentativa: (nfeDiag.efetivacao_tentativas as number) ?? 0,
+        operacao: "diagnostico",
+        sucesso: cls.sucesso,
+        erro: cls.erro,
+        omie_status: cls.omieStatus,
+      });
+      return jsonRes({
+        ok: cls.sucesso,
+        modo: "diagnostico",
+        nfe_recebimento_id: nfeRecebimentoId,
+        numero_nfe: nfeDiag.numero_nfe,
+        status_app: nfeDiag.status,
+        warehouse: whCode,
+        omie_id_receb: nfeDiag.omie_id_receb,
+        classificacao: cls,
+        consultar_recebimento: consultaRes.data, // JSON CRU do Omie (campos reais)
+      });
     }
 
     console.log(`[omie-nfe-recebimento] Iniciando efetivação: ${nfeRecebimentoId}`);

--- a/supabase/functions/omie-nfe-recebimento/index.ts
+++ b/supabase/functions/omie-nfe-recebimento/index.ts
@@ -105,9 +105,10 @@ async function registrarTentativa(
   row: { nfe_recebimento_id: string; tentativa: number; operacao: string; item_id?: string | null; sucesso: boolean; erro?: string | null; omie_status?: string | null },
 ): Promise<void> {
   try {
-    await supabase.from("nfe_efetivacao_tentativas").insert(row);
+    const { error } = await supabase.from("nfe_efetivacao_tentativas").insert(row);
+    if (error) console.error("[omie-nfe-recebimento] erro PostgREST ao registrar tentativa no ledger:", error);
   } catch (e) {
-    console.error("[omie-nfe-recebimento] falha ao registrar tentativa no ledger:", e);
+    console.error("[omie-nfe-recebimento] exceção ao registrar tentativa no ledger:", e);
   }
 }
 

--- a/supabase/migrations/20260604140000_recebimento_efetivacao_ledger.sql
+++ b/supabase/migrations/20260604140000_recebimento_efetivacao_ledger.sql
@@ -1,0 +1,71 @@
+-- ════════════════════════════════════════════════════════════════════════════
+-- Recebimento closed-loop honesto — Fase A0: LEDGER de efetivação (por passo)
+-- ════════════════════════════════════════════════════════════════════════════
+-- Frente do programa autônomo (pós Picking #567). A efetivação de NF-e mente
+-- sobre conclusão (marca status='efetivado' incondicional mesmo se a escrita no
+-- Omie falha) e está incompleta (não envia quantidade, não conclui o recebimento).
+--
+-- Esta migration é 100% ADITIVA (zero risco): cria o LEDGER de efeitos externos
+-- que torna o retry seguro (não duplica estoque/conclusão). O fluxo de escrita
+-- completo entra no PR2 (A1), depois do diagnóstico do Omie real.
+--
+-- Idempotente: ADD COLUMN IF NOT EXISTS / CREATE TABLE IF NOT EXISTS / DROP+CREATE
+-- POLICY. Pode rerodar. Status novos ('falha_efetivacao'/'efetivacao_parcial')
+-- NÃO precisam de DDL — nfe_recebimentos.status é varchar(20) livre.
+-- ════════════════════════════════════════════════════════════════════════════
+
+-- ── 1. nfe_recebimentos: flags de idempotência por passo + estado de tela + lock ──
+ALTER TABLE public.nfe_recebimentos
+  ADD COLUMN IF NOT EXISTS alterar_recebimento_ok  boolean     NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS alterar_etapa_ok        boolean     NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS concluir_recebimento_ok boolean     NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS cte_ok                  boolean     NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS efetivacao_erro         text,
+  ADD COLUMN IF NOT EXISTS efetivacao_tentativas   integer     NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS efetivacao_lock_at      timestamptz;
+
+-- ── 2. nfe_recebimento_itens: idempotência do IncluirAjusteEstoque (NÃO-idempotente) ──
+ALTER TABLE public.nfe_recebimento_itens
+  ADD COLUMN IF NOT EXISTS ajuste_estoque_ok      boolean      NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS ajuste_estoque_omie_id text,
+  ADD COLUMN IF NOT EXISTS ajuste_estoque_at      timestamptz;
+
+-- ── 3. nfe_efetivacao_tentativas: ledger append-only (auditoria por operação) ──
+CREATE TABLE IF NOT EXISTS public.nfe_efetivacao_tentativas (
+  id                 uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  nfe_recebimento_id uuid        NOT NULL REFERENCES public.nfe_recebimentos(id) ON DELETE CASCADE,
+  tentativa          integer     NOT NULL DEFAULT 1,
+  operacao           text        NOT NULL,  -- diagnostico|alterar_recebimento|alterar_etapa|concluir_recebimento|ajuste_estoque|importar_cte
+  item_id            uuid        REFERENCES public.nfe_recebimento_itens(id) ON DELETE SET NULL,
+  sucesso            boolean     NOT NULL,
+  erro               text,
+  omie_status        text,
+  created_at         timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_nfe_efetivacao_tentativas_receb
+  ON public.nfe_efetivacao_tentativas (nfe_recebimento_id, created_at DESC);
+
+-- RLS: SELECT só staff (employee/master). Escrita = service_role (o edge), que
+-- bypassa RLS — nenhuma policy de INSERT/UPDATE pra authenticated (append-only do server).
+ALTER TABLE public.nfe_efetivacao_tentativas ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "staff_select_nfe_efetivacao_tentativas" ON public.nfe_efetivacao_tentativas;
+CREATE POLICY "staff_select_nfe_efetivacao_tentativas"
+  ON public.nfe_efetivacao_tentativas
+  FOR SELECT TO authenticated
+  USING (has_role(auth.uid(), 'employee'::app_role) OR has_role(auth.uid(), 'master'::app_role));
+
+-- ── 4. Validação (cole no SQL Editor e confira o resultado) ──
+SELECT
+  'BLOCO RECEBIMENTO LEDGER OK' AS status,
+  (SELECT count(*) FROM information_schema.columns
+     WHERE table_schema='public' AND table_name='nfe_recebimentos'
+       AND column_name IN ('alterar_recebimento_ok','alterar_etapa_ok','concluir_recebimento_ok','cte_ok','efetivacao_erro','efetivacao_tentativas','efetivacao_lock_at')) AS cols_recebimentos_esperado_7,
+  (SELECT count(*) FROM information_schema.columns
+     WHERE table_schema='public' AND table_name='nfe_recebimento_itens'
+       AND column_name IN ('ajuste_estoque_ok','ajuste_estoque_omie_id','ajuste_estoque_at')) AS cols_itens_esperado_3,
+  (SELECT count(*) FROM information_schema.tables
+     WHERE table_schema='public' AND table_name='nfe_efetivacao_tentativas') AS tabela_esperado_1,
+  (SELECT count(*) FROM pg_policies
+     WHERE schemaname='public' AND tablename='nfe_efetivacao_tentativas') AS policies_esperado_1;


### PR DESCRIPTION
## Recebimento closed-loop honesto — PR1 (Fase A0: fundação + diagnóstico)

Primeiro PR da frente que torna a **efetivação de NF-e honesta e completa**. A efetivação (`omie-nfe-recebimento`) hoje **mente sobre conclusão** (marca `status='efetivado'` incondicional mesmo se a escrita no Omie falha → entrada de estoque fantasma) e está **incompleta** (não envia quantidade, não conclui o recebimento no Omie). O founder ampliou o escopo: a efetivação precisa levar a NF até **"Concluído"** no Omie e movimentar estoque.

Como **não há acesso ao Omie pra testar localmente**, a entrega é faseada (metodologia: 3 rodadas de Codex gpt-5.5 xhigh):

### Este PR (A0) — 100% ADITIVO, zero risco de estoque
- **Migration do ledger por passo** (`20260604140000`): flags `alterar_recebimento_ok`/`alterar_etapa_ok`/`concluir_recebimento_ok`/`cte_ok` + `efetivacao_erro`/`efetivacao_tentativas`/`efetivacao_lock_at` em `nfe_recebimentos`; `ajuste_estoque_ok`/`omie_id`/`at` em `nfe_recebimento_itens`; tabela append-only `nfe_efetivacao_tentativas` (+RLS staff). É a infra que torna o retry seguro (não duplica estoque) — usada de fato no PR2.
- **Helper puro TDD** `src/lib/recebimento/efetivacao-helpers.ts` (30 testes): `classificarRespostaOmie` (sucesso HTTP ≠ sucesso Omie — detecta `faultstring`/`codigo_status≠0`), `erroBenigno`, `decidirStatusEfetivacao`, `selecionarPassosPendentes`, `podeReprocessar`, `resumirErros`. Espelhado no edge.
- **Modo diagnóstico read-only no edge** (`{diagnostico:true}`): chama só `ConsultarRecebimento` e retorna o **JSON cru** do Omie (etapa/kanban, itens, datas, lote, CT-e). **Não escreve nada.** Destrava o mapeamento dos campos da Fase A1.
- **Frontend:** botão "Diagnosticar" (ícone, por NF) + dialog com o JSON e "Copiar"; status novos `falha_efetivacao`/`efetivacao_parcial` no config; KPIs honestos — "Efetivadas Hoje" por `efetivado_at` (não `data_emissao`) e "Recebidos hoje" → "Conferidas hoje".
- **O fluxo de efetivação atual fica INTACTO** (sem regressão).

### Próximo PR (A1) — coreografia completa, validado pelo founder
Liga `AlterarRecebimento`(qtd+lote+data) → `AlterarEtapaRecebimento` → `ConcluirRecebimento` → CT-e (campos confirmados pelo diagnóstico) + fail-closed por passo + lock atômico. Founder testa 1 NF de baixo valor.

## ⚠️ Migration manual necessária
Aplicar `supabase/migrations/20260604140000_recebimento_efetivacao_ledger.sql` no **SQL Editor do Lovable** (idempotente; validada em Postgres 17 local). Deploy do edge `omie-nfe-recebimento` via chat do Lovable (verbatim da main, p/ o diagnóstico valer).

## Validação
- Helper: 30 testes vitest ✅
- Migration: PG17 local (idempotente + asserts de default/FK/RLS) ✅
- Edge: `deno check` net-zero vs main ✅
- Lint ✅ · typecheck strict ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**Codex adversarial no código: sem P1.** P2/P3 incorporados (ledger não-silencioso, status nas abas, KPI fuso SP, texto honesto).
