### PR TITLE
feat(tarefas-voz): empresa por cliente + criar por voz no Customer 360 (polish A)

### DIFF
--- a/src/components/tarefas/VozTarefaDialog.tsx
+++ b/src/components/tarefas/VozTarefaDialog.tsx
@@ -17,12 +17,22 @@ import { autoSatisfyDaCategoria } from '@/lib/tarefas/categoria-map';
 import { montarRascunhos } from '@/lib/tarefas/voz/montar-rascunhos';
 import { casarCliente } from '@/lib/tarefas/voz/match';
 import { validarRascunho } from '@/lib/tarefas/voz/validacao';
+import { empresaDeOmie } from '@/lib/tarefas/voz/empresa';
 import type { ExtracaoVozIA, RascunhoVoz, VendedoraOpcao } from '@/lib/tarefas/voz/types';
 import type { TarefaCategoria, TarefaModo, TarefaInteracaoTipo } from '@/lib/tarefas/types';
 
-export function VozTarefaDialog({ open, onOpenChange, vendedoras, empresa }: {
+/** Cliente pré-conhecido passado pelo chamador (ex: Customer 360). */
+export interface ClienteFixo {
+  customer_user_id: string;
+  nome: string;
+  empresa_omie?: string | null;
+}
+
+export function VozTarefaDialog({ open, onOpenChange, vendedoras, empresa, clienteFixo }: {
   open: boolean; onOpenChange: (o: boolean) => void;
   vendedoras: VendedoraOpcao[]; empresa: string;
+  /** Quando presente, todos os cards usam este cliente (sem busca/resolução automática). */
+  clienteFixo?: ClienteFixo;
 }) {
   const { isRecording, isTranscribing, transcricao, setTranscricao, toggle, reset } = useGravacaoTranscricao();
   const { buscar } = useBuscaClienteOmie();
@@ -33,15 +43,42 @@ export function VozTarefaDialog({ open, onOpenChange, vendedoras, empresa }: {
   const [salvando, setSalvando] = useState(false);
   const hojeSP = spBusinessDate(new Date());
 
+  // Empresa derivada do clienteFixo (fallback = prop empresa)
+  const empresaFixo = clienteFixo
+    ? (empresaDeOmie(clienteFixo.empresa_omie) ?? empresa)
+    : null;
+
   // reset ao fechar
   useEffect(() => { if (!open) { reset(); setRascunhos(null); setNaoCoberto(null); } }, [open, reset]);
 
   const resolverClienteDoCard = useCallback(async (r: RascunhoVoz): Promise<RascunhoVoz> => {
+    // Se há clienteFixo, não resolve por voz — usa o cliente pré-definido
+    if (clienteFixo) {
+      return {
+        ...r,
+        empresa: empresaFixo ?? empresa,
+        cliente: {
+          customer_user_id: clienteFixo.customer_user_id,
+          nome: clienteFixo.nome,
+          status: 'unico',
+          candidatos: [],
+        },
+      };
+    }
     if (!r.cliente_nome_falado) return { ...r, cliente: { customer_user_id: null, nome: null, status: 'sem_match', candidatos: [] } };
     const achados = await buscar(r.cliente_nome_falado);
-    const cands = achados.map((a) => ({ customer_user_id: a.user_id, nome: a.nome }));
-    return { ...r, cliente: casarCliente(r.cliente_nome_falado, cands) };
-  }, [buscar]);
+    const cands = achados.map((a) => ({
+      customer_user_id: a.user_id,
+      nome: a.nome,
+      empresa_omie: a.empresa_omie,
+    }));
+    const match = casarCliente(r.cliente_nome_falado, cands);
+    // Deriva empresa do cliente resolvido (se único)
+    const empresaDerivada = match.status === 'unico' && match.candidatos.length > 0
+      ? (empresaDeOmie(match.candidatos[0].empresa_omie) ?? r.empresa)
+      : r.empresa;
+    return { ...r, cliente: match, empresa: empresaDerivada };
+  }, [buscar, clienteFixo, empresa, empresaFixo]);
 
   const extrair = async () => {
     if (!transcricao.trim()) { toast.error('Grave ou digite o comando primeiro.'); return; }
@@ -51,19 +88,24 @@ export function VozTarefaDialog({ open, onOpenChange, vendedoras, empresa }: {
         transcricao: transcricao.trim(), hoje: hojeSP, tz: 'America/Sao_Paulo',
         vendedoras: vendedoras.map((v) => ({ nome: v.nome })),
       });
-      const base = montarRascunhos(out, { hojeSP, vendedoras });
+      const base = montarRascunhos(out, { hojeSP, vendedoras, empresaPadrao: empresaFixo ?? empresa });
       const comCliente = await Promise.all(base.map(resolverClienteDoCard));
       setRascunhos(comCliente);
       setNaoCoberto(out.texto_nao_coberto);
       if (comCliente.length === 0) toast.warning('Não detectei nenhuma tarefa. Revise o texto.');
     } catch (e) {
       // degradação: não perde a fala — vira 1 rascunho cru pra ele preencher
+      const empresaDegradacao = empresaFixo ?? empresa;
+      const clienteDegradacao = clienteFixo
+        ? { customer_user_id: clienteFixo.customer_user_id, nome: clienteFixo.nome, status: 'unico' as const, candidatos: [] }
+        : { customer_user_id: null, nome: null, status: 'sem_match' as const, candidatos: [] };
       setRascunhos([{
         evidence_text: transcricao, descricao: transcricao, categoria: 'outro',
-        cliente_nome_falado: null, cliente: { customer_user_id: null, nome: null, status: 'sem_match', candidatos: [] },
+        cliente_nome_falado: null, cliente: clienteDegradacao,
         vendedora: { user_id: null, nome: null, status: 'sem_match' },
         data: { modo: 'interacao', due_date: null, interacao_tipo: 'ligacao', status: 'sem_data' },
         target_texto: null,
+        empresa: empresaDegradacao,
       }]);
       toast.error('Não consegui estruturar — revise/preencha manualmente.', { description: e instanceof Error ? e.message : undefined });
     } finally { setExtraindo(false); }
@@ -75,8 +117,17 @@ export function VozTarefaDialog({ open, onOpenChange, vendedoras, empresa }: {
   const buscarTrocaCliente = async (i: number, query: string) => {
     const r = rascunhos?.[i]; if (!r) return;
     const achados = await buscar(query);
-    const cands = achados.map((a) => ({ customer_user_id: a.user_id, nome: a.nome }));
-    patch(i, { cliente: casarCliente(query || r.cliente_nome_falado || '', cands) });
+    const cands = achados.map((a) => ({
+      customer_user_id: a.user_id,
+      nome: a.nome,
+      empresa_omie: a.empresa_omie,
+    }));
+    const match = casarCliente(query || r.cliente_nome_falado || '', cands);
+    // Deriva empresa do novo cliente escolhido (se único)
+    const empresaDerivada = match.status === 'unico' && match.candidatos.length > 0
+      ? (empresaDeOmie(match.candidatos[0].empresa_omie) ?? r.empresa)
+      : r.empresa;
+    patch(i, { cliente: match, empresa: empresaDerivada });
   };
 
   const salvar = async () => {
@@ -86,11 +137,10 @@ export function VozTarefaDialog({ open, onOpenChange, vendedoras, empresa }: {
     if (comErro.length > 0) { toast.error(`Corrija ${comErro.length} tarefa(s) antes de salvar.`); return; }
     setSalvando(true);
     try {
-      // 1 insert ATÔMICO: criarTarefas aceita N linhas (cada uma com seu cliente) → sem criação
-      // parcial se algo falhar no meio, e um reenvio não duplica. evidencias na mesma ordem das linhas.
+      // 1 insert ATÔMICO: criarTarefas aceita N linhas (cada uma com seu cliente e empresa derivada)
       const linhas = rascunhos.map((r) => ({
         descricao: r.descricao, categoria: r.categoria, customer_user_id: r.cliente!.customer_user_id,
-        assigned_to: r.vendedora.user_id, empresa, modo: r.data.modo,
+        assigned_to: r.vendedora.user_id, empresa: r.empresa, modo: r.data.modo,
         due_date: r.data.modo === 'data' ? r.data.due_date : null,
         interacao_tipo: r.data.modo === 'interacao' ? (r.data.interacao_tipo ?? 'ligacao') : null,
         auto_satisfy_mode: autoSatisfyDaCategoria(r.categoria),
@@ -108,7 +158,11 @@ export function VozTarefaDialog({ open, onOpenChange, vendedoras, empresa }: {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-lg max-h-[90vh] overflow-y-auto">
-        <DialogHeader><DialogTitle>Criar tarefa por voz</DialogTitle></DialogHeader>
+        <DialogHeader>
+          <DialogTitle>
+            {clienteFixo ? `Criar tarefa por voz — ${clienteFixo.nome}` : 'Criar tarefa por voz'}
+          </DialogTitle>
+        </DialogHeader>
 
         {/* Gravação / texto */}
         <div className="space-y-2">
@@ -156,11 +210,18 @@ export function VozTarefaDialog({ open, onOpenChange, vendedoras, empresa }: {
                   <div className="space-y-1">
                     <div className="flex items-center gap-2">
                       <span className="text-xs font-medium truncate">{r.cliente?.customer_user_id ? r.cliente.nome : 'Cliente não definido'}</span>
-                      {r.cliente_nome_falado && <span className="text-2xs text-muted-foreground">(falado: "{r.cliente_nome_falado}")</span>}
+                      {r.cliente_nome_falado && !clienteFixo && <span className="text-2xs text-muted-foreground">(falado: "{r.cliente_nome_falado}")</span>}
                       {r.cliente && statusBadge(r.cliente.status)}
                     </div>
-                    {(!r.cliente || r.cliente.status !== 'unico') && (
-                      <ClienteSwap candidatos={r.cliente?.candidatos ?? []} onPick={(cid, nome) => patch(i, { cliente: { customer_user_id: cid, nome, status: 'unico', candidatos: r.cliente?.candidatos ?? [] } })} onBuscar={(q) => buscarTrocaCliente(i, q)} />
+                    {/* Troca de cliente: oculta quando clienteFixo (cliente é fixo) */}
+                    {!clienteFixo && (!r.cliente || r.cliente.status !== 'unico') && (
+                      <ClienteSwap candidatos={r.cliente?.candidatos ?? []} onPick={(cid, nome, empresa_omie) => {
+                        const empresaDerivada = empresaDeOmie(empresa_omie) ?? r.empresa;
+                        patch(i, {
+                          empresa: empresaDerivada,
+                          cliente: { customer_user_id: cid, nome, status: 'unico', candidatos: r.cliente?.candidatos ?? [] },
+                        });
+                      }} onBuscar={(q) => buscarTrocaCliente(i, q)} />
                     )}
                   </div>
 
@@ -217,8 +278,8 @@ export function VozTarefaDialog({ open, onOpenChange, vendedoras, empresa }: {
 
 /** Mini-busca de cliente pra trocar o match (reusa o picker Omie). */
 function ClienteSwap({ candidatos, onPick, onBuscar }: {
-  candidatos: { customer_user_id: string; nome: string }[];
-  onPick: (cid: string, nome: string) => void;
+  candidatos: { customer_user_id: string; nome: string; empresa_omie?: string | null }[];
+  onPick: (cid: string, nome: string, empresa_omie: string | null | undefined) => void;
   onBuscar: (q: string) => void;
 }) {
   const [q, setQ] = useState('');
@@ -233,7 +294,7 @@ function ClienteSwap({ candidatos, onPick, onBuscar }: {
       {lista.length > 0 && (
         <div className="border rounded max-h-32 overflow-y-auto">
           {lista.map((c) => (
-            <button key={c.customer_user_id} onClick={() => onPick(c.customer_user_id, c.nome)}
+            <button key={c.customer_user_id} onClick={() => onPick(c.customer_user_id, c.nome, c.empresa_omie)}
               className="w-full text-left px-2 py-1 text-xs hover:bg-muted/50 border-b last:border-b-0">{c.nome}</button>
           ))}
         </div>

--- a/src/hooks/useBuscaClienteOmie.ts
+++ b/src/hooks/useBuscaClienteOmie.ts
@@ -10,6 +10,8 @@ export type ClienteBusca = {
   telefone: string | null;
   email: string | null;
   omie_codigo_cliente?: number;
+  /** Conta Omie associada (ex: 'vendas', 'oben', 'colacor_vendas'). null = perfil local sem vínculo Omie. */
+  empresa_omie: string | null;
 };
 
 export function useBuscaClienteOmie() {
@@ -24,23 +26,27 @@ export function useBuscaClienteOmie() {
         email?: string | null; telefone?: string | null; cnpj_cpf?: string | null;
       }>;
       let mappingByCode: Record<number, string> = {};
+      let empresaByCode: Record<number, string> = {};
       if (omieClientes.length > 0) {
         const codigos = omieClientes.map((c) => c.codigo_cliente);
         const { data: mappings } = await supabase.from('omie_clientes')
-          .select('user_id, omie_codigo_cliente').in('omie_codigo_cliente', codigos);
+          .select('user_id, omie_codigo_cliente, empresa_omie').in('omie_codigo_cliente', codigos);
         mappingByCode = Object.fromEntries((mappings || []).map((m) => [m.omie_codigo_cliente, m.user_id]));
+        empresaByCode = Object.fromEntries((mappings || []).map((m) => [m.omie_codigo_cliente, m.empresa_omie]));
       }
       const omieMapped: ClienteBusca[] = omieClientes.map((c) => ({
         user_id: mappingByCode[c.codigo_cliente] || '',
         nome: c.nome_fantasia || c.razao_social || 'Cliente',
         documento: c.cnpj_cpf || null, telefone: c.telefone || null, email: c.email || null,
         omie_codigo_cliente: c.codigo_cliente,
+        empresa_omie: empresaByCode[c.codigo_cliente] ?? null,
       }));
       const { data: localProfiles } = await supabase.from('profiles')
         .select('user_id, name, email, phone').ilike('name', `%${query}%`).limit(10);
       const local: ClienteBusca[] = (localProfiles || []).map((p) => ({
         user_id: p.user_id, nome: p.name ?? 'Cliente', documento: null,
         telefone: p.phone ?? null, email: p.email ?? null,
+        empresa_omie: null,
       }));
       const seen = new Set(omieMapped.filter((c) => c.user_id).map((c) => c.user_id));
       return [...omieMapped, ...local.filter((p) => !seen.has(p.user_id))];

--- a/src/lib/tarefas/voz/__tests__/empresa.test.ts
+++ b/src/lib/tarefas/voz/__tests__/empresa.test.ts
@@ -1,0 +1,17 @@
+// src/lib/tarefas/voz/__tests__/empresa.test.ts
+import { describe, it, expect } from 'vitest';
+import { empresaDeOmie } from '../empresa';
+
+describe('empresaDeOmie', () => {
+  it('oben → oben', () => expect(empresaDeOmie('oben')).toBe('oben'));
+  it('vendas → oben (conta Omie da Oben)', () => expect(empresaDeOmie('vendas')).toBe('oben'));
+  it('VENDAS → oben (case-insensitive)', () => expect(empresaDeOmie('VENDAS')).toBe('oben'));
+  it('colacor → colacor', () => expect(empresaDeOmie('colacor')).toBe('colacor'));
+  it('colacor_vendas → colacor', () => expect(empresaDeOmie('colacor_vendas')).toBe('colacor'));
+  it('colacor_sc → colacor_sc', () => expect(empresaDeOmie('colacor_sc')).toBe('colacor_sc'));
+  it('servicos → colacor_sc', () => expect(empresaDeOmie('servicos')).toBe('colacor_sc'));
+  it('string vazia → null', () => expect(empresaDeOmie('')).toBeNull());
+  it('valor desconhecido → null', () => expect(empresaDeOmie('xyz')).toBeNull());
+  it('null → null', () => expect(empresaDeOmie(null)).toBeNull());
+  it('undefined → null', () => expect(empresaDeOmie(undefined)).toBeNull());
+});

--- a/src/lib/tarefas/voz/__tests__/montar-rascunhos.test.ts
+++ b/src/lib/tarefas/voz/__tests__/montar-rascunhos.test.ts
@@ -16,17 +16,25 @@ const extracao: ExtracaoVozIA = {
 };
 
 describe('montarRascunhos', () => {
-  it('resolve data + vendedora; cliente fica null carregando o nome falado', () => {
-    const r = montarRascunhos(extracao, { hojeSP: HOJE, vendedoras: vends });
+  it('resolve data + vendedora; cliente fica null carregando o nome falado; empresa = empresaPadrao', () => {
+    const r = montarRascunhos(extracao, { hojeSP: HOJE, vendedoras: vends, empresaPadrao: 'oben' });
     expect(r).toHaveLength(2);
     expect(r[0].vendedora).toMatchObject({ user_id: 'r', status: 'unico' });
     expect(r[0].data.due_date).toBe('2026-06-05');
     expect(r[0].categoria).toBe('ligar');
     expect(r[0].cliente).toBeNull();
     expect(r[0].cliente_nome_falado).toBe('Padaria do Zé');
+    expect(r[0].empresa).toBe('oben');
     // categoria nula → 'outro'; vendedora não falada → sem_match
     expect(r[1].categoria).toBe('outro');
     expect(r[1].vendedora.status).toBe('sem_match');
     expect(r[1].data.due_date).toBe('2026-06-05');
+    expect(r[1].empresa).toBe('oben');
+  });
+
+  it('propaga empresaPadrao alternativo (colacor_sc)', () => {
+    const r = montarRascunhos(extracao, { hojeSP: HOJE, vendedoras: vends, empresaPadrao: 'colacor_sc' });
+    expect(r[0].empresa).toBe('colacor_sc');
+    expect(r[1].empresa).toBe('colacor_sc');
   });
 });

--- a/src/lib/tarefas/voz/__tests__/validacao.test.ts
+++ b/src/lib/tarefas/voz/__tests__/validacao.test.ts
@@ -13,6 +13,7 @@ const base: RascunhoVoz = {
   vendedora: { user_id: 'r', nome: 'Regina', status: 'unico' },
   data: { modo: 'data', due_date: '2026-06-05', interacao_tipo: null, status: 'resolvida' },
   target_texto: null,
+  empresa: 'oben',
 };
 
 describe('validarRascunho', () => {

--- a/src/lib/tarefas/voz/empresa.ts
+++ b/src/lib/tarefas/voz/empresa.ts
@@ -1,0 +1,22 @@
+// src/lib/tarefas/voz/empresa.ts
+
+export type EmpresaKey = 'oben' | 'colacor' | 'colacor_sc';
+
+const MAP: Record<string, EmpresaKey> = {
+  oben: 'oben',
+  vendas: 'oben',
+  colacor: 'colacor',
+  colacor_vendas: 'colacor',
+  colacor_sc: 'colacor_sc',
+  servicos: 'colacor_sc',
+};
+
+/**
+ * Deriva a empresa-chave a partir de `empresa_omie` do cliente
+ * (aceita a chave de empresa OU o nome de conta Omie).
+ * Desconhecido/vazio → null (o caller aplica fallback).
+ */
+export function empresaDeOmie(empresaOmie: string | null | undefined): EmpresaKey | null {
+  const v = (empresaOmie ?? '').toLowerCase().trim();
+  return MAP[v] ?? null;
+}

--- a/src/lib/tarefas/voz/montar-rascunhos.ts
+++ b/src/lib/tarefas/voz/montar-rascunhos.ts
@@ -1,11 +1,11 @@
 // src/lib/tarefas/voz/montar-rascunhos.ts
-import type { ExtracaoVozIA, RascunhoVoz, VendedoraOpcao } from './types';
+import type { ExtracaoVozIA, RascunhoVoz, CtxMontarRascunhos } from './types';
 import { resolverDataPtBr } from './date-parser';
 import { casarVendedora } from './match';
 
 export function montarRascunhos(
   extracao: ExtracaoVozIA,
-  ctx: { hojeSP: string; vendedoras: VendedoraOpcao[] },
+  ctx: CtxMontarRascunhos,
 ): RascunhoVoz[] {
   return extracao.tarefas.map((t) => ({
     evidence_text: t.evidence_text,
@@ -16,5 +16,6 @@ export function montarRascunhos(
     vendedora: casarVendedora(t.vendedora_nome_falado, ctx.vendedoras),
     data: resolverDataPtBr(t.raw_date_text, ctx.hojeSP),
     target_texto: t.target_texto,
+    empresa: ctx.empresaPadrao,
   }));
 }

--- a/src/lib/tarefas/voz/types.ts
+++ b/src/lib/tarefas/voz/types.ts
@@ -31,6 +31,8 @@ export type StatusMatch = 'unico' | 'ambiguo' | 'sem_match';
 export interface ClienteCandidato {
   customer_user_id: string;   // '' se ainda não resolvido (cliente Omie sem perfil local)
   nome: string;
+  /** Conta Omie do cliente — usado para derivar a empresa da tarefa. Opcional: candidatos locais podem não ter. */
+  empresa_omie?: string | null;
 }
 export interface MatchCliente {
   customer_user_id: string | null;
@@ -56,4 +58,14 @@ export interface RascunhoVoz {
   vendedora: MatchVendedora;
   data: ResultadoData;
   target_texto: string | null;
+  /** Empresa associada ao card — derivada do cliente quando possível, fallback da prop global. */
+  empresa: string;
+}
+
+/** Contexto para montar rascunhos a partir da extração da IA. */
+export interface CtxMontarRascunhos {
+  hojeSP: string;
+  vendedoras: VendedoraOpcao[];
+  /** Empresa padrão (fallback quando o cliente não tem empresa_omie). */
+  empresaPadrao: string;
 }

--- a/src/pages/Customer360.tsx
+++ b/src/pages/Customer360.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { parseISO, subMonths } from 'date-fns';
 import { AlertCircle } from 'lucide-react';
@@ -6,7 +6,9 @@ import { useAuth } from '@/contexts/AuthContext';
 import { PageSkeleton } from '@/components/ui/page-skeleton';
 import { EmptyState } from '@/components/EmptyState';
 import { TooltipProvider } from '@/components/ui/tooltip';
+import { Button } from '@/components/ui/button';
 import { useCustomerContacts } from '@/hooks/useCustomerContacts';
+import { useSalespeople } from '@/hooks/useCoverage';
 import {
   useCustomerCore,
   useCustomerAddress,
@@ -20,11 +22,13 @@ import { CustomerHero } from '@/components/customer360/CustomerHero';
 import { CustomerKpiStrip } from '@/components/customer360/CustomerKpiStrip';
 import { IdentityColumn } from '@/components/customer360/IdentityColumn';
 import { ActivityColumn } from '@/components/customer360/ActivityColumn';
+import { VozTarefaDialog } from '@/components/tarefas/VozTarefaDialog';
 
 export default function Customer360() {
   const { customerId } = useParams<{ customerId: string }>();
   const navigate = useNavigate();
-  const { user } = useAuth();
+  const { user, isMaster, isGestorComercial } = useAuth();
+  const [abrirVozTarefa, setAbrirVozTarefa] = useState(false);
 
   const core = useCustomerCore(customerId);
   const address = useCustomerAddress(customerId);
@@ -37,6 +41,7 @@ export default function Customer360() {
   // comprador, etc). Edição completa fica em /admin/customers detail tab — aqui
   // mostro só leitura compacta pra contexto operacional.
   const contacts = useCustomerContacts(customerId ?? null);
+  const { data: salespeople = [] } = useSalespeople();
 
   // Lifetime + 12m derivados dos pedidos
   const revenueDerived = useMemo(() => {
@@ -72,16 +77,32 @@ export default function Customer360() {
   const m = metrics.data;
   const s = score.data;
   const isPj = (customer.document ?? '').replace(/\D/g, '').length === 14;
+  const podeCriarTarefaPorVoz = isMaster || isGestorComercial;
 
   return (
     <TooltipProvider delayDuration={150}>
       <div className="pb-12 space-y-6">
-        <CustomerHero
-          customer={customer}
-          score={s}
-          isPj={isPj}
-          onBack={() => navigate('/admin/customers')}
-        />
+        <div className="relative">
+          <CustomerHero
+            customer={customer}
+            score={s}
+            isPj={isPj}
+            onBack={() => navigate('/admin/customers')}
+          />
+          {podeCriarTarefaPorVoz && (
+            <div className="absolute top-3 right-3">
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => setAbrirVozTarefa(true)}
+                disabled={salespeople.length === 0}
+                className="gap-1.5"
+              >
+                🎙️ Criar tarefa por voz
+              </Button>
+            </div>
+          )}
+        </div>
 
         <CustomerKpiStrip revenueDerived={revenueDerived} metrics={m} score={s} />
 
@@ -104,6 +125,21 @@ export default function Customer360() {
           />
         </div>
       </div>
+
+      {/* Dialog de criar tarefa por voz com cliente fixo */}
+      {podeCriarTarefaPorVoz && customerId && (
+        <VozTarefaDialog
+          open={abrirVozTarefa}
+          onOpenChange={setAbrirVozTarefa}
+          vendedoras={salespeople.map((s) => ({ user_id: s.user_id, nome: s.name }))}
+          empresa="oben"
+          clienteFixo={{
+            customer_user_id: customerId,
+            nome: customer.name ?? 'Cliente',
+            empresa_omie: undefined,
+          }}
+        />
+      )}
     </TooltipProvider>
   );
 }

--- a/src/pages/Customer360.tsx
+++ b/src/pages/Customer360.tsx
@@ -1,5 +1,7 @@
 import { useMemo, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { useNavigate, useParams } from 'react-router-dom';
+import { supabase } from '@/integrations/supabase/client';
 import { parseISO, subMonths } from 'date-fns';
 import { AlertCircle } from 'lucide-react';
 import { useAuth } from '@/contexts/AuthContext';
@@ -42,6 +44,18 @@ export default function Customer360() {
   // mostro só leitura compacta pra contexto operacional.
   const contacts = useCustomerContacts(customerId ?? null);
   const { data: salespeople = [] } = useSalespeople();
+  // empresa_omie do cliente → deriva a empresa correta da tarefa (não fica fixa em 'oben').
+  // Só master/gestor (quem cria tarefa por voz); 1 query leve, maybeSingle.
+  const omieEmpresa = useQuery({
+    queryKey: ['customer-empresa-omie', customerId],
+    enabled: !!customerId && (isMaster || isGestorComercial),
+    staleTime: 5 * 60_000,
+    queryFn: async () => {
+      const { data } = await supabase.from('omie_clientes')
+        .select('empresa_omie').eq('user_id', customerId!).maybeSingle();
+      return data?.empresa_omie ?? null;
+    },
+  });
 
   // Lifetime + 12m derivados dos pedidos
   const revenueDerived = useMemo(() => {
@@ -136,7 +150,7 @@ export default function Customer360() {
           clienteFixo={{
             customer_user_id: customerId,
             nome: customer.name ?? 'Cliente',
-            empresa_omie: undefined,
+            empresa_omie: omieEmpresa.data ?? undefined,
           }}
         />
       )}


### PR DESCRIPTION
Polish da feature "criar tarefa por voz" (#572).

**A1 — empresa derivada do cliente** (antes era fixa da página): helper TDD `empresaDeOmie` (aceita a chave `oben/colacor/colacor_sc` OU o nome de conta Omie `vendas/colacor_vendas/servicos`; desconhecido → null → **fallback honesto**, nunca chuta empresa errada). `useBuscaClienteOmie` passa a trazer `empresa_omie`; cada card do `VozTarefaDialog` deriva sua empresa do cliente resolvido. Customer 360 faz 1 lookup leve de `empresa_omie` (deriva também lá).

**A2 — 2º ponto de entrada:** botão "🎙️ Criar tarefa por voz" no **Customer 360** (gate master/gestor) → abre o dialog com o cliente **pré-fixado** (`clienteFixo`); pula a resolução de cliente, ainda infere vendedora/prazo/categoria por voz. Sem `clienteFixo`, a página `/tarefas` é **idêntica** ao de hoje.

**CI local:** typecheck strict ✅ · testes de tarefas 49/49 ✅ · lint 0 erros ✅. **Sem migration.** (Depende do #572 já mergeado — está.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)