### PR TITLE
feat: Meu Dia pilotável — fila é a estrela, cards antigos recolhidos (G2 last-mile)

### DIFF
--- a/src/components/dashboard/FarmerDashboardV2.tsx
+++ b/src/components/dashboard/FarmerDashboardV2.tsx
@@ -1,7 +1,10 @@
+import { useState } from 'react';
 import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { Calendar, Phone } from 'lucide-react';
+import { Calendar, Phone, ChevronDown } from 'lucide-react';
 import { Link } from 'react-router-dom';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
+import { track } from '@/lib/analytics';
 import { KpisToday } from './KpisToday';
 import { AgendaTodayList } from './AgendaTodayList';
 import { MinhasTarefasCard } from '@/components/tarefas/MinhasTarefasCard';
@@ -9,61 +12,76 @@ import { VisitasHojeCard } from './VisitasHojeCard';
 import { FilaDoDia } from '@/components/fila/FilaDoDia';
 
 /**
- * Dashboard Farmer V2 — foco em expansão de carteira existente.
- * Mostra KPIs do dia + agenda priorizada com botão "Ligar agora".
- *
- * NÃO substitui FarmerDashboard.tsx legado (438 LoC com mais features); apenas
- * é a versão "Meu dia" simplificada que aparece como home pro vendedor com
- * commercial_role=farmer. Legado continua acessível via outras rotas.
+ * Dashboard Farmer V2 — a FILA é o dia (G1). Os cards antigos (tarefas, ligações
+ * da rota, agenda) repetem o que a fila já mostra → recolhidos num "modo antigo"
+ * (fallback a 1 clique). Mantém fora do colapso só o que a fila NÃO cobre:
+ * KPIs (informativo) e visitas. Decisão founder + Codex (piloto).
  */
 export function FarmerDashboardV2() {
+  const [modoAntigoAberto, setModoAntigoAberto] = useState(false);
+  const onToggleModoAntigo = (open: boolean) => {
+    setModoAntigoAberto(open);
+    // sinal do piloto: se ela abre o modo antigo todo dia, a fila não está servindo.
+    if (open) track('fila.modo_antigo_expandido', {});
+  };
+
   return (
     <div className="container mx-auto p-4 space-y-4 max-w-5xl">
       <div>
         <h1 className="text-xl font-semibold">Meu dia</h1>
         <p className="text-xs text-muted-foreground">
-          Agenda priorizada da sua carteira. Foque em risco e expansão primeiro.
+          Sua fila priorizada: comece de cima. Tarefas, ligações da rota e oportunidades, do mais urgente ao menos.
         </p>
       </div>
 
-      {/* G1: fila única lidera o dia. Cards individuais abaixo seguem por ora (validação: comparar fila × cards atuais). */}
+      {/* A fila É o dia. */}
       <FilaDoDia />
 
       <KpisToday />
 
-      <MinhasTarefasCard />
-
-      {/* Ligações da rota — o que as vendedoras (farmer só-ligação) de fato fazem; lista priorizada D-1 em /rota/ligacoes */}
-      <Card className="p-4 border-status-info/40">
-        <div className="flex items-center justify-between gap-3">
-          <div>
-            <div className="flex items-center gap-2">
-              <Phone className="w-4 h-4 text-status-info" />
-              <h2 className="text-sm font-semibold">Ligações da rota</h2>
-            </div>
-            <p className="text-2xs text-muted-foreground mt-1">
-              Sua lista priorizada de quem ligar — clientes nas cidades da rota de amanhã.
-            </p>
-          </div>
-          <Button asChild size="sm">
-            <Link to="/rota/ligacoes">Abrir lista</Link>
-          </Button>
-        </div>
-      </Card>
-
       <VisitasHojeCard />
 
-      <Card className="p-3 space-y-1">
-        <div className="flex items-center gap-2">
-          <Calendar className="w-4 h-4 text-status-warning" />
-          <h2 className="text-sm font-semibold">Agenda de hoje (top 10)</h2>
-        </div>
-        <p className="text-2xs text-muted-foreground">
-          Priorizada por priority_score da sua carteira. Clique no nome pra ficha; clique Ligar pra disparar chamada WebRTC.
-        </p>
-      </Card>
+      <Collapsible open={modoAntigoAberto} onOpenChange={onToggleModoAntigo}>
+        <CollapsibleTrigger asChild>
+          <Button variant="ghost" size="sm" className="text-2xs text-muted-foreground gap-1.5">
+            <ChevronDown className={`w-3.5 h-3.5 transition-transform ${modoAntigoAberto ? 'rotate-180' : ''}`} />
+            Ver detalhes do dia (modo antigo)
+          </Button>
+        </CollapsibleTrigger>
+        <CollapsibleContent className="space-y-4 pt-2">
+          <MinhasTarefasCard />
 
-      <AgendaTodayList />
+          {/* Ligações da rota — o que as vendedoras (farmer só-ligação) de fato fazem; lista priorizada D-1 em /rota/ligacoes */}
+          <Card className="p-4 border-status-info/40">
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <div className="flex items-center gap-2">
+                  <Phone className="w-4 h-4 text-status-info" />
+                  <h2 className="text-sm font-semibold">Ligações da rota</h2>
+                </div>
+                <p className="text-2xs text-muted-foreground mt-1">
+                  Sua lista priorizada de quem ligar — clientes nas cidades da rota de amanhã.
+                </p>
+              </div>
+              <Button asChild size="sm">
+                <Link to="/rota/ligacoes">Abrir lista</Link>
+              </Button>
+            </div>
+          </Card>
+
+          <Card className="p-3 space-y-1">
+            <div className="flex items-center gap-2">
+              <Calendar className="w-4 h-4 text-status-warning" />
+              <h2 className="text-sm font-semibold">Agenda de hoje (top 10)</h2>
+            </div>
+            <p className="text-2xs text-muted-foreground">
+              Priorizada por priority_score da sua carteira. Clique no nome pra ficha; clique Ligar pra disparar chamada WebRTC.
+            </p>
+          </Card>
+
+          <AgendaTodayList />
+        </CollapsibleContent>
+      </Collapsible>
     </div>
   );
 }

--- a/src/components/fila/FilaDoDia.tsx
+++ b/src/components/fila/FilaDoDia.tsx
@@ -71,8 +71,15 @@ export function FilaDoDia() {
 
   if (visiveis.length === 0) {
     return (
-      <Card className="p-6 text-2xs text-muted-foreground">
-        Nada na fila agora — sua carteira está em dia. 🎯
+      <Card className="p-6">
+        <p className="text-sm font-medium">Nada prioritário na fila agora.</p>
+        <p className="text-2xs text-muted-foreground mt-1">
+          Sua carteira está em dia. Se quiser adiantar, veja a lista completa de ligações da rota ou seus clientes.
+        </p>
+        <div className="flex gap-2 mt-3">
+          <Button asChild size="sm" variant="outline"><Link to="/rota/ligacoes">Ver rota completa</Link></Button>
+          <Button asChild size="sm" variant="ghost"><Link to="/admin/customers">Ver clientes</Link></Button>
+        </div>
       </Card>
     );
   }


### PR DESCRIPTION
## Last mile do piloto — Meu Dia "pilotável" (fila é a estrela)

Prepara o Meu Dia da vendedora **farmer** pra o piloto começar bem na segunda. Decisão tomada em **challenge com o Codex** (veredito **A**): a fila vira a estrela e os cards antigos que repetem os mesmos dados (tarefas, ligações da rota, agenda) vão pra um **"modo antigo" recolhido** — fallback a 1 clique, sem competir pela atenção.

> Por quê: com os cards antigos expostos, o piloto não testa "a vendedora usa a fila" — testa se ela muda de hábito apesar de a interface ainda oferecer o jeito antigo logo abaixo (falso negativo). B (remover de vez) foi descartado: sem rede de segurança num piloto de 1 pessoa. C (manter tudo) "mata o experimento".

### O que muda
- **`FarmerDashboardV2`**: ordem vira **Fila (topo, dominante) → KPIs → Visitas → `Collapsible` "Ver detalhes do dia (modo antigo)"** (fechado por padrão, discreto). Dentro do colapso, **verbatim**: `MinhasTarefasCard`, card "Ligações da rota", card "Agenda de hoje" + `AgendaTodayList`. KPIs e Visitas ficam fora (a fila não cobre).
- **Telemetria `fila.modo_antigo_expandido`** ao abrir o colapso — se ela abre todo dia, é sinal de que a fila não está servindo (combinar com observação no piloto).
- **Empty-state operacional da fila**: "Nada prioritário na fila agora." + caminhos seguros (**Ver rota completa** → `/rota/ligacoes`, **Ver clientes** → `/admin/customers`) — pra ela não travar se segunda de manhã abrir vazio (Codex P1).

### Validação local
- `typecheck` → **0 erros** · `test` → **2229/2229** · `build` → ok · `lint` → **0 errors** (82 warnings = baseline)

### ⚠️ Pós-merge (sem migration/edge)
- **Publish no Lovable** (cobre este PR + o #580 que já está na main).
- Validar `/meu-dia` logado como **vendedora** (farmer com carteira): fila no topo, "modo antigo" recolhido, loop de feedback funcionando.

### Follow-up (não bloqueia segunda — P2 do Codex)
- "Fazer" de tarefa de **ligar/whatsapp** hoje cai em "Abrir cliente" (a tarefa não carrega o telefone). Resolver com enriquecimento (join de profile) **se** o uso real mostrar que é comum na carteira dela.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
