### PR TITLE
feat(rota-painel): gap acionável — lista de clientes valiosos sem contato (B)

### DIFF
--- a/src/lib/route/painel/__tests__/agregar.test.ts
+++ b/src/lib/route/painel/__tests__/agregar.test.ts
@@ -5,7 +5,8 @@ import type { SnapshotRow, ContatoRow } from '../types';
 
 const snap = (over: Partial<SnapshotRow>): SnapshotRow => ({
   data_rota: '2026-06-03', farmer_id: 'r', customer_user_id: 'c1',
-  cidade: 'DIVINOPOLIS (MG)', bucket: 'top', valor_da_ligacao: 100, rank: 1, ...over,
+  cidade: 'DIVINOPOLIS (MG)', bucket: 'top', valor_da_ligacao: 100, rank: 1,
+  cliente_nome: null, ...over,
 });
 const ct = (over: Partial<ContatoRow>): ContatoRow => ({
   data_rota: '2026-06-03', farmer_id: 'r', customer_user_id: 'c1',
@@ -24,6 +25,28 @@ describe('agregarPainel', () => {
     expect(r.elegiveis_valor).toBe(160);
     expect(r.contatados_valor).toBe(100);
     expect(r.gap_valor).toBe(60);   // c2 não contatado
+    // gap acionável: apenas c2 não-contatado
+    expect(r.gap_clientes_total).toBe(1);
+    expect(r.gap_clientes).toHaveLength(1);
+    expect(r.gap_clientes[0].customer_user_id).toBe('c2');
+    expect(r.gap_clientes[0].valor).toBe(60);
+  });
+
+  it('gap_clientes: ordena por valor desc, exclui contatados, top 15', () => {
+    // c1 (contatado, valor 100), c2 (não contatado, valor 60), c3 (não contatado, valor 200)
+    const snaps = [
+      snap({ customer_user_id: 'c1', valor_da_ligacao: 100, cliente_nome: 'Alfa' }),
+      snap({ customer_user_id: 'c2', valor_da_ligacao: 60,  cliente_nome: 'Beta' }),
+      snap({ customer_user_id: 'c3', valor_da_ligacao: 200, cliente_nome: 'Gama' }),
+    ];
+    const contatos = [ct({ customer_user_id: 'c1' })];
+    const r = agregarPainel(snaps, contatos);
+    expect(r.gap_clientes_total).toBe(2);
+    expect(r.gap_clientes[0].customer_user_id).toBe('c3');  // 200, maior valor primeiro
+    expect(r.gap_clientes[0].cliente_nome).toBe('Gama');
+    expect(r.gap_clientes[1].customer_user_id).toBe('c2');  // 60
+    // c1 (contatado) NÃO aparece
+    expect(r.gap_clientes.find((g) => g.customer_user_id === 'c1')).toBeUndefined();
   });
 
   it('eficácia global: conversão/resposta/optout sobre contatos de ligação', () => {
@@ -74,5 +97,7 @@ describe('agregarPainel', () => {
     expect(r.gap_valor).toBe(0);
     expect(r.contatos_por_dia).toBe(0);
     expect(r.global.conversao.valor).toBeNull();
+    expect(r.gap_clientes).toHaveLength(0);
+    expect(r.gap_clientes_total).toBe(0);
   });
 });

--- a/src/lib/route/painel/agregar.ts
+++ b/src/lib/route/painel/agregar.ts
@@ -1,5 +1,5 @@
 // src/lib/route/painel/agregar.ts
-import type { SnapshotRow, ContatoRow, PainelAgregado, GrupoEficacia } from './types';
+import type { SnapshotRow, ContatoRow, PainelAgregado, GrupoEficacia, GapCliente } from './types';
 import { taxaComGating } from './gating';
 
 const key = (d: string, f: string | null, c: string | null) => `${d}|${f ?? ''}|${c ?? ''}`;
@@ -50,6 +50,23 @@ export function agregarPainel(snapshots: SnapshotRow[], contatos: ContatoRow[]):
     .reduce((s, e) => s + num(e.valor_da_ligacao), 0);
   const gap_valor = elegiveis_valor - contatados_valor;
 
+  // gap acionável: não-contatados ordenados por valor desc, top 15
+  const naoContatados = snapshots.filter(
+    (s) => !contatadasKeys.has(key(s.data_rota, s.farmer_id, s.customer_user_id)),
+  );
+  const gap_clientes_total = naoContatados.length;
+  const gap_clientes: GapCliente[] = naoContatados
+    .map((s) => ({
+      customer_user_id: s.customer_user_id,
+      cliente_nome: s.cliente_nome ?? null,
+      cidade: s.cidade,
+      farmer_id: s.farmer_id,
+      valor: num(s.valor_da_ligacao),
+      data_rota: s.data_rota,
+    }))
+    .sort((a, b) => b.valor - a.valor)
+    .slice(0, 15);
+
   // dias com snapshot (denominador disponível) vs dias com contato-de-ligação sem snapshot
   const diasComSnapshot = new Set(snapshots.map((s) => s.data_rota));
   const diasContatoLigacao = new Set(ligacoes.map((c) => c.data_rota));
@@ -67,6 +84,8 @@ export function agregarPainel(snapshots: SnapshotRow[], contatos: ContatoRow[]):
     elegiveis_valor,
     contatados_valor,
     gap_valor,
+    gap_clientes,
+    gap_clientes_total,
     contatos_total,
     dias_com_dado,
     contatos_por_dia,

--- a/src/lib/route/painel/types.ts
+++ b/src/lib/route/painel/types.ts
@@ -9,6 +9,7 @@ export interface SnapshotRow {
   bucket: string | null;
   valor_da_ligacao: number | null;
   rank: number | null;
+  cliente_nome?: string | null;
 }
 
 /** Linha de route_contact_log relevante ao painel. */
@@ -39,6 +40,16 @@ export interface GrupoEficacia {
   valor_capturado: number;       // Σ valor das convertidas (score esperado, NÃO R$)
 }
 
+/** Cliente de alto valor que ficou sem contato na janela analisada. */
+export interface GapCliente {
+  customer_user_id: string;
+  cliente_nome: string | null;
+  cidade: string | null;
+  farmer_id: string;
+  valor: number;
+  data_rota: string;
+}
+
 export interface PainelAgregado {
   // cobertura (ligação): elegíveis = snapshot; contatados = elegíveis com contato
   elegiveis_n: number;
@@ -47,6 +58,9 @@ export interface PainelAgregado {
   elegiveis_valor: number;
   contatados_valor: number;
   gap_valor: number;             // Σ valor dos elegíveis NÃO contatados (headline)
+  // gap acionável: quem não foi contatado (top por valor)
+  gap_clientes: GapCliente[];
+  gap_clientes_total: number;    // total de elegíveis sem contato (antes do top 15)
   // capacidade
   contatos_total: number;
   dias_com_dado: number;

--- a/src/pages/RotaPainelLigacoes.tsx
+++ b/src/pages/RotaPainelLigacoes.tsx
@@ -8,7 +8,7 @@ import { PageSkeleton } from '@/components/ui/page-skeleton';
 import { Card } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import type { GrupoEficacia, TaxaGated } from '@/lib/route/painel/types';
+import type { GrupoEficacia, TaxaGated, GapCliente } from '@/lib/route/painel/types';
 
 const fmtBRL = (n: number) => n.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL', maximumFractionDigits: 0 });
 const fmtTaxa = (t: TaxaGated) => t.exibivel && t.valor != null
@@ -74,6 +74,15 @@ export default function RotaPainelLigacoes() {
             </Card>
           </div>
 
+          {/* Gap acionável: clientes de alto valor sem contato */}
+          {p.gap_clientes.length > 0 && (
+            <GapClientesCard
+              clientes={p.gap_clientes}
+              total={p.gap_clientes_total}
+              nomeVend={nomeVend}
+            />
+          )}
+
           {/* Eficácia global */}
           <Card className="p-4">
             <div className="text-sm font-semibold mb-2">Eficácia das ligações (reportada pela vendedora)</div>
@@ -92,6 +101,39 @@ export default function RotaPainelLigacoes() {
         </>
       )}
     </div>
+  );
+}
+
+function GapClientesCard({ clientes, total, nomeVend }: {
+  clientes: GapCliente[];
+  total: number;
+  nomeVend: (id: string) => string;
+}) {
+  return (
+    <Card className="p-4 border-status-warning/40">
+      <div className="text-sm font-semibold mb-1">
+        Clientes valiosos sem contato
+        {' '}
+        <span className="font-normal text-muted-foreground">
+          (top {clientes.length}{total > clientes.length ? ` de ${total}` : ''})
+        </span>
+      </div>
+      <div className="text-2xs text-muted-foreground mb-2">
+        Elegíveis não contatados na janela — ordenados por valor esperado.
+      </div>
+      <div className="divide-y divide-border">
+        {clientes.map((g) => (
+          <div key={`${g.data_rota}|${g.farmer_id}|${g.customer_user_id}`}
+            className="py-2 flex items-center justify-between gap-2">
+            <div className="min-w-0">
+              <div className="text-sm font-medium truncate">{g.cliente_nome ?? '(sem nome)'}</div>
+              <div className="text-2xs text-muted-foreground">{g.cidade ?? '—'} · {nomeVend(g.farmer_id)} · {g.data_rota}</div>
+            </div>
+            <div className="text-sm font-tabular text-status-warning shrink-0">{fmtBRL(g.valor)}</div>
+          </div>
+        ))}
+      </div>
+    </Card>
   );
 }
 

--- a/src/queries/useRoutePanel.ts
+++ b/src/queries/useRoutePanel.ts
@@ -33,7 +33,7 @@ export function useRoutePanel(dias = 30) {
       d.setUTCDate(d.getUTCDate() - (dias - 1));
       const desde = spBusinessDate(d);
       const [snaps, contatos] = await Promise.all([
-        lerTudo<SnapshotRow>('route_queue_snapshot', 'data_rota, farmer_id, customer_user_id, cidade, bucket, valor_da_ligacao, rank', desde),
+        lerTudo<SnapshotRow>('route_queue_snapshot', 'data_rota, farmer_id, customer_user_id, cliente_nome, cidade, bucket, valor_da_ligacao, rank', desde),
         lerTudo<ContatoRow>('route_contact_log', 'data_rota, farmer_id, customer_user_id, canal, status, valor_da_ligacao, bucket', desde),
       ]);
       return agregarPainel(snaps, contatos);

--- a/src/queries/useSnapshotRouteQueue.ts
+++ b/src/queries/useSnapshotRouteQueue.ts
@@ -17,6 +17,7 @@ export function useSnapshotRouteQueue(routeDate: string | null, callQueue: Route
       data_rota: routeDate,
       farmer_id: user.id,
       customer_user_id: it.customerUserId,
+      cliente_nome: it.name,
       cidade: it.cityKey?.city ?? null,
       bucket: it.bucket,
       valor_da_ligacao: it.valorDaLigacao,

--- a/supabase/migrations/20260604160000_route_queue_snapshot_nome.sql
+++ b/supabase/migrations/20260604160000_route_queue_snapshot_nome.sql
@@ -1,0 +1,6 @@
+-- Gap acionável: guarda o nome do cliente no snapshot da fila (pra listar quem ficou sem contato).
+ALTER TABLE public.route_queue_snapshot ADD COLUMN IF NOT EXISTS cliente_nome text;
+
+SELECT 'route_queue_snapshot.cliente_nome OK' AS status,
+       (SELECT count(*) FROM information_schema.columns
+        WHERE table_name='route_queue_snapshot' AND column_name='cliente_nome') AS coluna;


### PR DESCRIPTION
Extensão do painel das ligações (#577): o **gap de valor** (um número) vira uma **lista acionável** — quais clientes de alto valor ficaram sem contato (nome, cidade, vendedora, valor), top 15 por valor.

- **Migration** `20260604160000_route_queue_snapshot_nome.sql`: `ALTER TABLE route_queue_snapshot ADD COLUMN cliente_nome` (o nome que a vendedora viu, pra a lista ser legível). `useSnapshotRouteQueue` passa a gravar `cliente_nome: it.name`.
- `agregarPainel` retorna `gap_clientes` (não-contatados ordenados por valor desc, top 15) + `gap_clientes_total`. +2 testes (6/6).
- `RotaPainelLigacoes` renderiza o `GapClientesCard` quando há gap.

**Honesto:** snapshots gravados ANTES da migration não têm nome → "(sem nome)" na janela histórica (nullable, sem recuperação retroativa — esperado). Depende do #577 (mergeado).

**CI local:** typecheck strict ✅ · testes do agregar 6/6 ✅ · lint 0 erros ✅.

---
⚠️ **ATENÇÃO: migration manual** (pós-merge): colar `supabase/migrations/20260604160000_route_queue_snapshot_nome.sql` no SQL Editor (entrego o bloco na conversa). Sem edge function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)