### PR TITLE
fix(security): restaura o gate de rota de staff (44 rotas estavam abertas a cliente)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -225,51 +225,15 @@ const App = () => (
               <Route path="loyalty" element={<Loyalty />} />
               <Route path="gamification" element={<Gamification />} />
               <Route path="training" element={<Training />} />
-              <Route path="sales" element={<SalesOrders />} />
-              <Route path="sales/products" element={<SalesProducts />} />
-              <Route path="sales/new" element={<UnifiedOrder />} />
-              <Route path="sales/print" element={<SalesPrintDashboard />} />
-              <Route path="sales/quotes" element={<SalesQuotes />} />
-              <Route path="sales/edit/:id" element={<SalesOrderEdit />} />
-              <Route path="unified-order" element={<Navigate to="/sales/new" replace />} />
-              <Route path="farmer" element={<FarmerDashboard />} />
-              <Route path="meu-dia" element={<MeuDia />} />
+              {/* `tarefas` + `admin/calculadora` ficam abertas de propósito (cliente/staff).
+                  ⚠️ As demais rotas de staff (sales, farmer, governance, ai-ops, tint, intelligence,
+                  executive, settings, docs, design-system, coaching, ux-rules, nfe) foram REMOVIDAS daqui:
+                  estavam DUPLICADAS com as cópias gated do bloco <RequireStaff> abaixo, e a cópia
+                  aberta (1ª no source) vencia o match do react-router → o gate ficava MORTO
+                  (regressão do #508, que adicionou o RequireStaff mas não removeu as flat antigas).
+                  Cada rota de staff agora existe SÓ dentro do <RequireStaff> (fail-closed).
+                  O teste src/__tests__/app-route-dedupe.test.ts impede a duplicação voltar. */}
               <Route path="tarefas" element={<Tarefas />} />
-              <Route path="farmer/calls" element={<FarmerCalls />} />
-              <Route path="farmer/calls/pending-link" element={<FarmerCallsPendingLink />} />
-              <Route path="farmer/governance" element={<FarmerGovernance />} />
-              <Route path="farmer/recommendations" element={<FarmerRecommendations />} />
-              <Route path="farmer/locc" element={<FarmerLOCC />} />
-              <Route path="farmer/bundles" element={<FarmerBundles />} />
-              <Route path="farmer/copilot" element={<FarmerCopilot />} />
-              <Route path="farmer/tactical-plan" element={<FarmerTacticalPlan />} />
-              <Route path="farmer/ipf" element={<FarmerIPFDashboard />} />
-              <Route path="executive/dashboard" element={<ExecutiveDashboard />} />
-              <Route path="design-system" element={<DesignSystem />} />
-              <Route path="design-preview" element={<DesignPreview />} />
-              <Route path="ux-rules" element={<UXRules />} />
-              <Route path="coaching" element={<CoachingSPIN />} />
-              <Route path="settings" element={<SettingsConfig />} />
-              <Route path="docs" element={<TechnicalDocs />} />
-              <Route path="intelligence" element={<IntelligenceDashboard />} />
-              <Route path="governance/users" element={<GovernanceUsers />} />
-              <Route path="governance/permissions" element={<GovernancePermissions />} />
-              <Route path="governance/math" element={<GovernanceMathParams />} />
-              <Route path="governance/audit" element={<GovernanceAudit />} />
-              <Route path="governance/settings" element={<GovernanceSettings />} />
-              <Route path="governance/companies" element={<GovernanceCompanies />} />
-              <Route path="ai-ops" element={<AIops />} />
-              <Route path="nfe-receipt" element={<NfeReceipt />} />
-              <Route path="tintometrico" element={<TintDashboard />} />
-              <Route path="tintometrico/importar" element={<TintImport />} />
-              <Route path="tintometrico/mapeamento" element={<TintMapping />} />
-              <Route path="tintometrico/precos" element={<TintPricing />} />
-              <Route path="tintometrico/formulas" element={<TintFormulas />} />
-              <Route path="tintometrico/corantes" element={<TintCorantes />} />
-              <Route path="tintometrico/integracoes" element={<TintIntegrations />} />
-              <Route path="tintometrico/reconciliacao" element={<TintReconciliation />} />
-              <Route path="tintometrico/sync-runs" element={<TintSyncRuns />} />
-              <Route path="tintometrico/api-contract" element={<TintApiContract />} />
               <Route path="admin/calculadora" element={<AdminCalculadora />} />
 
               {/* ─── Financeiro (gate próprio: permite não-staff com permissão) ─── */}

--- a/src/__tests__/app-route-dedupe.test.ts
+++ b/src/__tests__/app-route-dedupe.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
+
+/**
+ * Guard de segurança: uma rota declarada DUAS vezes (uma aberta + uma dentro de <RequireStaff>)
+ * faz o react-router servir a 1ª (aberta) e o gate de staff fica MORTO — foi exatamente a
+ * regressão do #508 (todas as rotas de staff duplicadas → governance/financeiro/sales/tint
+ * acessíveis por qualquer cliente logado). Este teste falha se qualquer path voltar a duplicar.
+ */
+const appTsx = readFileSync(resolve(dirname(fileURLToPath(import.meta.url)), '../App.tsx'), 'utf-8');
+
+describe('App.tsx — paths de rota únicos (gate fail-closed)', () => {
+  it('nenhum path é declarado mais de uma vez', () => {
+    const paths = [...appTsx.matchAll(/<Route\s+path="([^"]+)"/g)].map((m) => m[1]);
+    const contagem = new Map<string, number>();
+    for (const p of paths) contagem.set(p, (contagem.get(p) ?? 0) + 1);
+    const duplicados = [...contagem.entries()].filter(([, n]) => n > 1).map(([p]) => p);
+    expect(duplicados).toEqual([]);
+  });
+});


### PR DESCRIPTION
## 🔒 Regressão crítica de segurança (do #508, desta sessão)

Ao reestruturar o `App.tsx` em 3 grupos (abertas / financeiro / `<RequireStaff>`), o #508 **adicionou** as rotas de staff dentro do `RequireStaff` mas **não removeu** as cópias do bloco aberto antigo → ficaram **DUPLICADAS**. No react-router v6, com paths idênticos a **1ª declaração (a aberta) vence o match** → o `RequireStaff` ficou **morto**.

**Resultado:** qualquer cliente logado alcançava, por URL direta, toda a superfície de staff — `governance/*`, `sales/*`, `farmer/*`, `intelligence`, `ai-ops`, `nfe-receipt`, `tintometrico/*` (catálogo de fórmulas, custo Omie, margem). A RLS protege os **dados**, mas a **UI de staff renderizava pra cliente**.

O `path-diff` do #508 viu "154 rotas idênticas" e não pegou que as de staff ficaram **em dobro**.

## Fix

Removidas as **44 rotas de staff duplicadas** do bloco aberto — cada uma já existe (idêntica) dentro do `<RequireStaff>`, que volta a valer (fail-closed). **Zero rota perdida** (verificado por `comm`: 44/46 do bloco aberto têm cópia gated).

Mantidas abertas só:
- `tarefas` — tem gate próprio (`isMaster || isGestorComercial` em `Tarefas.tsx:26` + RLS `pode_ver_carteira_completa`); codex confirmou sem exposição.
- `admin/calculadora` — aberta por design (calculadora p/ todos).

## Guard de regressão

`src/__tests__/app-route-dedupe.test.ts` — falha se **qualquer** path voltar a ser declarado 2×. Teria pego esta regressão.

## Validação

- typecheck (strict) — 0 · lint — 0 erros · test — **2230** (+1) · build — ✓
- **codex review: limpo** (P1 nenhum achado; verificou independentemente "no duplicates", nenhuma rota perdida, gate restaurado).

## Test plan (QA no device, pós-Publish)

- [ ] Logar como **customer** e tentar `/governance/users`, `/tintometrico`, `/ai-ops`, `/sales` por URL → deve redirecionar pra `/` (RequireStaff).
- [ ] Logar como **staff** → todas as telas de staff continuam abertas normalmente (sem mudança).
- [ ] `/tarefas` e `/admin/calculadora` seguem acessíveis conforme antes.

⚠️ **Nota:** este é o **#1** do relatório de auditoria (era reportado como "tint sem gate"; na verdade o gate inteiro estava morto). Próximo: pacote loyalty (#2 auto-crédito de pontos + #3 resgate quebrado), que precisa de migration via Lovable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)