### PR TITLE
feat(tarefas-f2): enforcement — Milestone 1 (migrations: templates, prova, trigger anti-bypass, materialização, storage)

### DIFF
--- a/supabase/migrations/20260601100000_tarefas_fase2_bloco_a.sql
+++ b/supabase/migrations/20260601100000_tarefas_fase2_bloco_a.sql
@@ -1,0 +1,37 @@
+-- 20260601100000_tarefas_fase2_bloco_a.sql
+create table if not exists public.tarefa_templates (
+  id uuid primary key default gen_random_uuid(),
+  descricao text not null,
+  categoria text not null check (categoria in ('ligar','oferecer','preco','whatsapp','outro')),
+  area text not null,
+  empresa text not null,
+  assigned_to uuid not null,
+  customer_user_id uuid,                       -- nullable: ops recorrente não tem cliente
+  cadencia text not null check (cadencia in ('diaria','dias_uteis','semanal','dias_especificos')),
+  dias_semana int[],                           -- 0=dom..6=sáb (semanal/dias_especificos)
+  janela_inicio time,
+  janela_fim time,
+  tolerancia_dias int not null default 0,
+  requer_comprovacao boolean not null default false,
+  tipo_comprovacao text not null default 'nenhuma' check (tipo_comprovacao in ('nenhuma','foto','leitura','foto_e_leitura')),
+  leitura_min numeric,
+  leitura_max numeric,
+  leitura_unidade text,
+  alto_risco boolean not null default false,
+  amostra_auditoria_pct int not null default 10 check (amostra_auditoria_pct between 0 and 100),
+  reincidente_limite int not null default 3,
+  supervisor_user_id uuid,
+  ativo boolean not null default true,
+  created_by uuid not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint tt_janela_chk check (janela_inicio is null or janela_fim is null or janela_inicio < janela_fim),
+  constraint tt_dias_chk check (cadencia not in ('semanal','dias_especificos') or (dias_semana is not null and array_length(dias_semana,1) > 0)),
+  constraint tt_altorisco_foto_chk check (not alto_risco or tipo_comprovacao = 'foto_e_leitura' or not requer_comprovacao)
+);
+create index if not exists idx_tt_ativo_assigned on public.tarefa_templates (assigned_to) where ativo;
+
+select 'F2 BLOCO A OK' as status,
+  to_regclass('public.tarefa_templates') is not null as tbl_ok,
+  (select count(*) from information_schema.columns where table_name='tarefa_templates') as colunas;
+-- Expected: tbl_ok=true, colunas=26

--- a/supabase/migrations/20260601101000_tarefas_fase2_bloco_b.sql
+++ b/supabase/migrations/20260601101000_tarefas_fase2_bloco_b.sql
@@ -1,0 +1,36 @@
+-- 20260601101000_tarefas_fase2_bloco_b.sql
+alter table public.tarefas
+  add column if not exists tipo_comprovacao text,
+  add column if not exists comprovacao_leitura numeric,
+  add column if not exists comprovacao_em timestamptz,
+  add column if not exists janela_fim time,
+  add column if not exists auditoria_status text not null default 'nao_requer'
+    check (auditoria_status in ('nao_requer','dispensada','pendente','aprovada','reprovada')),
+  add column if not exists auditoria_motivo text,
+  add column if not exists auditada_por uuid,
+  add column if not exists auditada_em timestamptz,
+  add column if not exists supervisor_user_id uuid;
+
+-- ops recorrente não tem cliente → customer_user_id passa a ser nullable
+alter table public.tarefas alter column customer_user_id drop not null;
+
+-- estende o CHECK de conclusao_origem c/ 'comprovacao'
+do $$ declare cn text; begin
+  select conname into cn from pg_constraint where conrelid='public.tarefas'::regclass and contype='c'
+    and pg_get_constraintdef(oid) ilike '%conclusao_origem%';
+  if cn is not null then execute format('alter table public.tarefas drop constraint %I', cn); end if;
+end $$;
+alter table public.tarefas add constraint tarefas_conclusao_origem_check
+  check (conclusao_origem is null or conclusao_origem in ('manual','auto_interacao','sugestao_confirmada','whatsapp','comprovacao'));
+
+-- idempotência da materialização (codex P1 #2: inclui assigned_to)
+create unique index if not exists uq_tarefa_template_assignee_dia
+  on public.tarefas (template_id, assigned_to, due_date) where template_id is not null;
+
+select 'F2 BLOCO B OK' as status,
+  (select is_nullable from information_schema.columns where table_name='tarefas' and column_name='customer_user_id') as customer_nullable,
+  (select count(*) from information_schema.columns where table_name='tarefas' and column_name in
+    ('tipo_comprovacao','comprovacao_leitura','comprovacao_em','janela_fim','auditoria_status','auditoria_motivo','auditada_por','auditada_em','supervisor_user_id')) as cols_novas,
+  (pg_get_constraintdef(oid) ilike '%comprovacao%' from pg_constraint where conrelid='public.tarefas'::regclass and conname='tarefas_conclusao_origem_check') as origem_ok,
+  to_regclass('public.uq_tarefa_template_assignee_dia') is not null as uq_ok;
+-- Expected: customer_nullable=YES, cols_novas=9, origem_ok=true, uq_ok=true

--- a/supabase/migrations/20260601102000_tarefas_fase2_bloco_c.sql
+++ b/supabase/migrations/20260601102000_tarefas_fase2_bloco_c.sql
@@ -1,0 +1,59 @@
+-- 20260601102000_tarefas_fase2_bloco_c.sql
+-- FIX 1: DROP + CREATE dentro de transação (evita falha de REPLACE quando BLOCO B adicionou
+-- colunas em `tarefas` — o `select t.*` da view desloca colunas derivadas e o REPLACE falha).
+
+begin;
+drop view if exists public.v_tarefas_estado;
+create view public.v_tarefas_estado
+with (security_invoker = on) as
+with base as (
+  select t.*,
+    coalesce(
+      (t.adiada_para at time zone 'America/Sao_Paulo')::date,
+      t.due_date,
+      (t.created_at at time zone 'America/Sao_Paulo')::date + t.backstop_days
+    ) as effective_due,
+    coalesce(
+      (select cc.covering_user_id from public.carteira_coverage cc
+        where cc.covered_user_id = t.assigned_to and cc.active
+          and now() >= cc.valid_from and (cc.valid_until is null or now() <= cc.valid_until)
+        order by cc.valid_from desc limit 1),
+      t.assigned_to
+    ) as responsavel_efetivo
+  from public.tarefas t
+), nowsp as (
+  select (now() at time zone 'America/Sao_Paulo')::date as dia,
+         (now() at time zone 'America/Sao_Paulo')::time as hora
+)
+select b.*,
+  (b.status = 'aberta' and (
+     n.dia > b.effective_due
+     or (n.dia = b.effective_due and b.janela_fim is not null and n.hora > b.janela_fim)
+  )) as atrasada,
+  (b.status = 'aberta' and b.escalado_em is null and (
+     n.dia > (b.effective_due + b.tolerancia_dias)
+     or (b.tolerancia_dias = 0 and n.dia = b.effective_due and b.janela_fim is not null and n.hora > b.janela_fim)
+  )) as escalavel,
+  exists (select 1 from public.tarefa_satisfacao_candidatos c
+          where c.tarefa_id = b.id and c.status = 'pending') as tem_sugestao_pendente,
+  (b.auditoria_status = 'pendente') as requer_auditoria
+from base b cross join nowsp n;
+commit;
+
+-- RLS de tarefa_templates: operador vê os dele; gestor/master gerencia.
+-- (Policies ficam fora da transação — ddl sobre tabela nova, sem dependência da view)
+alter table public.tarefa_templates enable row level security;
+create policy tt_select on public.tarefa_templates for select to authenticated
+using (public.pode_ver_carteira_completa((select auth.uid())) or assigned_to = (select auth.uid()));
+create policy tt_insert on public.tarefa_templates for insert to authenticated
+with check (public.pode_ver_carteira_completa((select auth.uid())) and created_by = (select auth.uid()));
+create policy tt_update on public.tarefa_templates for update to authenticated
+using (public.pode_ver_carteira_completa((select auth.uid())));
+create policy tt_delete on public.tarefa_templates for delete to authenticated
+using (public.pode_ver_carteira_completa((select auth.uid())));
+
+select 'F2 BLOCO C OK' as status,
+  (select count(*) from pg_views where viewname='v_tarefas_estado' and definition ilike '%janela_fim%') as view_janela_ok,
+  (select count(*) from pg_views where viewname='v_tarefas_estado' and definition ilike '%requer_auditoria%') as view_audit_ok,
+  (select count(*) from pg_policies where tablename='tarefa_templates') as policies;
+-- Expected: view_janela_ok=1, view_audit_ok=1, policies=4

--- a/supabase/migrations/20260601103000_tarefas_fase2_bloco_d.sql
+++ b/supabase/migrations/20260601103000_tarefas_fase2_bloco_d.sql
@@ -1,0 +1,153 @@
+-- 20260601103000_tarefas_fase2_bloco_d.sql
+
+-- FIX 2: tarefa_eventos.tarefa_id passa a aceitar NULL (eventos de SISTEMA sem tarefa, ex. materializacao_pulada).
+-- O materializador é SECURITY DEFINER (owner postgres) → bypassa a RLS de tarefa_eventos; ator já é nullable.
+alter table public.tarefa_eventos alter column tarefa_id drop not null;
+
+-- (1) Trigger anti-bypass: conclusão/colunas de prova só via RPC (owner) ou service_role.
+create or replace function public.tarefas_guard_comprovacao()
+returns trigger language plpgsql security invoker as $$
+begin
+  if coalesce(new.requer_comprovacao, false) then
+    if new.status = 'concluida' and old.status is distinct from 'concluida'
+       and current_user not in ('postgres','service_role','supabase_admin') then
+      raise exception 'Tarefa com comprovação só conclui via concluir_com_comprovacao()';
+    end if;
+    if current_user not in ('postgres','service_role','supabase_admin') and (
+         new.comprovacao_url       is distinct from old.comprovacao_url
+      or new.comprovacao_leitura   is distinct from old.comprovacao_leitura
+      or new.comprovacao_em        is distinct from old.comprovacao_em
+      or new.auditoria_status      is distinct from old.auditoria_status
+      or new.auditada_por          is distinct from old.auditada_por
+      or new.requer_comprovacao    is distinct from old.requer_comprovacao
+    ) then
+      raise exception 'Campos de comprovação/auditoria só mudam via RPC';
+    end if;
+  end if;
+  return new;
+end $$;
+drop trigger if exists trg_tarefas_guard_comprovacao on public.tarefas;
+create trigger trg_tarefas_guard_comprovacao
+  before update on public.tarefas
+  for each row execute function public.tarefas_guard_comprovacao();
+
+-- (2) Conclusão com prova (o enforcement). SECURITY DEFINER.
+create or replace function public.concluir_com_comprovacao(p_tarefa_id uuid, p_url text default null, p_leitura numeric default null)
+returns void language plpgsql security definer set search_path = public as $$
+declare t record; tt record; v_uid uuid := auth.uid(); v_audit text := 'nao_requer'; v_reinc int;
+begin
+  select * into t from public.tarefas where id = p_tarefa_id for update;
+  if not found then raise exception 'Tarefa não encontrada'; end if;
+  if not ( t.assigned_to = v_uid
+           or public.pode_ver_carteira_completa(v_uid)
+           or exists (select 1 from public.carteira_coverage cc where cc.covered_user_id=t.assigned_to
+                      and cc.covering_user_id=v_uid and cc.active and now()>=cc.valid_from
+                      and (cc.valid_until is null or now()<=cc.valid_until)) ) then
+    raise exception 'Sem permissão para concluir esta tarefa';
+  end if;
+  if t.status <> 'aberta' then raise exception 'Tarefa não está aberta (status=%)', t.status; end if;
+
+  if coalesce(t.requer_comprovacao,false) then
+    select * into tt from public.tarefa_templates where id = t.template_id;
+    if t.tipo_comprovacao in ('foto','foto_e_leitura') and (p_url is null or btrim(p_url)='') then
+      raise exception 'Foto de comprovação obrigatória';
+    end if;
+    if t.tipo_comprovacao in ('leitura','foto_e_leitura') then
+      if p_leitura is null then raise exception 'Leitura obrigatória'; end if;
+      if (tt.leitura_min is not null and p_leitura < tt.leitura_min)
+         or (tt.leitura_max is not null and p_leitura > tt.leitura_max) then
+        raise exception 'Leitura % fora da faixa [%, %]', p_leitura, tt.leitura_min, tt.leitura_max;
+      end if;
+    end if;
+    -- path-check: a url tem que conter {uid}/{tarefa_id}
+    if p_url is not null and position((v_uid::text || '/' || p_tarefa_id::text) in p_url) = 0 then
+      raise exception 'URL de comprovação não corresponde ao path da tarefa/usuário';
+    end if;
+    -- auditoria por exceção, decidida 1x
+    select count(*) into v_reinc from public.tarefas x
+      where x.template_id = t.template_id and x.assigned_to = t.assigned_to and x.id <> t.id
+        and x.created_at > now() - interval '30 days'
+        and (x.auditoria_status = 'reprovada' or x.status = 'aberta');
+    if coalesce(tt.alto_risco,false)
+       or v_reinc >= coalesce(tt.reincidente_limite, 3)
+       or (random()*100) < coalesce(tt.amostra_auditoria_pct, 10)
+    then v_audit := 'pendente'; else v_audit := 'dispensada'; end if;
+  end if;
+
+  update public.tarefas set
+    status='concluida', conclusao_origem='comprovacao',
+    comprovacao_url = coalesce(p_url, comprovacao_url),
+    comprovacao_leitura = coalesce(p_leitura, comprovacao_leitura),
+    comprovacao_em = now(), concluida_em = now(), concluida_por = v_uid,
+    auditoria_status = v_audit, updated_at = now()
+  where id = p_tarefa_id;
+  insert into public.tarefa_eventos (tarefa_id, tipo_evento, ator, payload)
+  values (p_tarefa_id, 'concluida_comprovacao', v_uid, jsonb_build_object('auditoria', v_audit, 'leitura', p_leitura));
+end $$;
+
+-- (3) Auditoria (gestor/master). Reprovar reabre + zera escalado_em.
+create or replace function public.auditar_tarefa(p_tarefa_id uuid, p_aprovar boolean, p_motivo text default null)
+returns void language plpgsql security definer set search_path = public as $$
+declare v_uid uuid := auth.uid();
+begin
+  if not public.pode_ver_carteira_completa(v_uid) then raise exception 'Só gestor/master audita'; end if;
+  if p_aprovar then
+    update public.tarefas set auditoria_status='aprovada', auditada_por=v_uid, auditada_em=now(), updated_at=now()
+      where id=p_tarefa_id and auditoria_status='pendente';
+    insert into public.tarefa_eventos (tarefa_id,tipo_evento,ator,payload)
+    values (p_tarefa_id,'auditoria_aprovada',v_uid,'{}'::jsonb);
+  else
+    update public.tarefas set auditoria_status='reprovada', auditada_por=v_uid, auditada_em=now(),
+      status='aberta', comprovacao_em=null, escalado_em=null, auditoria_motivo=p_motivo, updated_at=now()
+      where id=p_tarefa_id and auditoria_status='pendente';
+    insert into public.tarefa_eventos (tarefa_id,tipo_evento,ator,payload)
+    values (p_tarefa_id,'auditoria_reprovada',v_uid,jsonb_build_object('motivo',p_motivo));
+  end if;
+end $$;
+
+-- (4) Materialização (backfill 7d, idempotente, pula assignee sem perfil).
+create or replace function public.tarefas_materializar_recorrentes()
+returns void language plpgsql security definer set search_path = public as $$
+declare tpl record; d date; hoje date := (now() at time zone 'America/Sao_Paulo')::date; dispara boolean;
+begin
+  for tpl in select * from public.tarefa_templates where ativo loop
+    if not exists (select 1 from public.profiles p where p.user_id = tpl.assigned_to) then
+      insert into public.tarefa_eventos (tarefa_id, tipo_evento, ator, payload)
+      values (null, 'materializacao_pulada', null, jsonb_build_object('template_id', tpl.id, 'motivo', 'assignee_sem_perfil'));
+      continue;
+    end if;
+    d := hoje - 6;  -- backfill janela 7 dias
+    while d <= hoje loop
+      dispara := case tpl.cadencia
+        when 'diaria' then true
+        when 'dias_uteis' then (extract(dow from d) between 1 and 5)
+                               and not exists (select 1 from public.calendario_feriados f where f.data = d)
+        when 'semanal' then extract(dow from d)::int = any(tpl.dias_semana)
+        when 'dias_especificos' then extract(dow from d)::int = any(tpl.dias_semana)
+        else false end;
+      if dispara then
+        insert into public.tarefas
+          (descricao, categoria, customer_user_id, assigned_to, created_by, empresa, modo, due_date,
+           backstop_days, tolerancia_dias, auto_satisfy_mode, status, template_id,
+           requer_comprovacao, tipo_comprovacao, janela_fim, supervisor_user_id, auditoria_status)
+        select tpl.descricao, tpl.categoria, tpl.customer_user_id, tpl.assigned_to, tpl.created_by, tpl.empresa,
+           'data', d, 7, tpl.tolerancia_dias, 'off', 'aberta', tpl.id,
+           tpl.requer_comprovacao, tpl.tipo_comprovacao, tpl.janela_fim, tpl.supervisor_user_id,
+           case when tpl.requer_comprovacao then 'dispensada' else 'nao_requer' end
+        where not exists (select 1 from public.tarefas t
+                          where t.template_id = tpl.id and t.assigned_to = tpl.assigned_to and t.due_date = d);
+      end if;
+      d := d + 1;
+    end loop;
+  end loop;
+end $$;
+
+-- (5) Cron — chamada SQL local (sem net.http_post). ~06:00 BRT = 09:00 UTC.
+select cron.schedule('tarefas-materializar-recorrentes', '0 9 * * *', $$ select public.tarefas_materializar_recorrentes(); $$);
+
+select 'F2 BLOCO D OK' as status,
+  (select count(*) from pg_proc where proname in ('tarefas_guard_comprovacao','concluir_com_comprovacao','auditar_tarefa','tarefas_materializar_recorrentes')) as funcs,
+  (select count(*) from pg_trigger where tgname='trg_tarefas_guard_comprovacao') as trg,
+  (select count(*) from cron.job where jobname='tarefas-materializar-recorrentes') as cron,
+  (select proowner::regrole::text from pg_proc where proname='concluir_com_comprovacao') as owner_definer;
+-- Expected: funcs=4, trg=1, cron=1, owner_definer='postgres'

--- a/supabase/migrations/20260601104000_tarefas_fase2_bloco_e.sql
+++ b/supabase/migrations/20260601104000_tarefas_fase2_bloco_e.sql
@@ -1,0 +1,15 @@
+-- 20260601104000_tarefas_fase2_bloco_e.sql
+insert into storage.buckets (id, name, public)
+values ('tarefa-comprovacoes', 'tarefa-comprovacoes', false)
+on conflict (id) do nothing;
+
+-- path = {auth.uid}/{tarefa_id}/arquivo  → operador escreve só no próprio prefixo
+create policy "tarefa_comprov_insert_own" on storage.objects for insert to authenticated
+with check (bucket_id='tarefa-comprovacoes' and (storage.foldername(name))[1] = (select auth.uid())::text);
+create policy "tarefa_comprov_select_own_ou_gestor" on storage.objects for select to authenticated
+using (bucket_id='tarefa-comprovacoes' and (
+  (storage.foldername(name))[1] = (select auth.uid())::text or public.pode_ver_carteira_completa((select auth.uid()))
+));
+
+select 'F2 BLOCO E OK' as status, exists(select 1 from storage.buckets where id='tarefa-comprovacoes') as bucket_ok, (select count(*) from pg_policies where tablename='objects' and policyname like 'tarefa_comprov%') as policies;
+-- Expected: bucket_ok=true, policies=2


### PR DESCRIPTION
**Fase 2 das Tarefas (enforcement) — Milestone 1 (backend SQL).** Founder liberou o gate da Fase 1 explicitamente. Spec/plano: #553 (`docs/superpowers/{specs,plans}/...-fase2*`).

5 BLOCOS (apply MANUAL no SQL Editor):
- **A** `tarefa_templates` (definição recorrente: cadência, janela, tipo de prova, faixa de leitura, alto-risco, % auditoria).
- **B** colunas de prova/auditoria em `tarefas` + `customer_user_id` nullable (ops sem cliente) + CHECK `conclusao_origem` += 'comprovacao' + UNIQUE de idempotência.
- **C** view `v_tarefas_estado` **window-aware** (escalável intradiário por `janela_fim`) + `requer_auditoria` + RLS de `tarefa_templates`.
- **D** **trigger anti-bypass** (conclusão/prova só via RPC owner/service_role) + RPCs `concluir_com_comprovacao`/`auditar_tarefa` + materializador recorrente + cron `0 9 * * *`.
- **E** bucket privado `tarefa-comprovacoes` + policies (operador escreve só no próprio prefixo; gestor lê via signed URL).

**2 fixes meus vs o plano (validados contra o schema real da Fase 1):** (1) BLOCO C usa **DROP+CREATE em transação** (o `CREATE OR REPLACE` falharia — o BLOCO B desloca o `select t.*` da view); (2) BLOCO D torna **`tarefa_eventos.tarefa_id` nullable** (evento de sistema `materializacao_pulada` sem tarefa).

⚠️ **ATENÇÃO: migrations manuais** — entrego os 5 blocos inline na conversa (1 por mensagem, A→E, com validação). **Milestone 2 (frontend: prova no /tintometrico, auditoria, CRUD de templates) vem em PR separado, DEPOIS de A–E aplicados+confirmados** (o frontend chama as RPCs; o smoke do BLOCO D valida o anti-bypass antes). Sem edge function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)