### PR TITLE
fix(sayerlack): claim atômico via .neq() em vez de .or() (bug do supabase-js 2.45.0)

### DIFF
--- a/supabase/functions/enviar-pedido-portal-sayerlack/index.ts
+++ b/supabase/functions/enviar-pedido-portal-sayerlack/index.ts
@@ -2140,14 +2140,20 @@ Deno.serve(async (req) => {
     // WHERE após o commit concorrente): se 2 requests competem pelo MESMO pedido
     // (ex.: "aprovar e disparar" + cron de corte no mesmo instante), só um claима;
     // o outro vê enviando_portal e é EXCLUÍDO do RETURNING. Fecha o duplo-envio ao
-    // portal (2ª sessão no Browserless → PO duplicado no fornecedor). O `is.null`
-    // cobre o pedido fresco (status_envio_portal NULL), que o `neq` sozinho perderia.
+    // portal (2ª sessão no Browserless → PO duplicado no fornecedor).
+    // Filtro via .neq() (não .or(is.null,neq)): o .or() em UPDATE+RETURNING no
+    // supabase-js 2.45.0 desta edge gera "column status_envio_portal does not exist"
+    // (bug de serialização do .or() sobre mutation no postgrest-js antigo — a coluna
+    // EXISTE; o .select() logo acima a lê no mesmo request). status_envio_portal tem
+    // DEFAULT 'nao_aplicavel' e nunca é NULL, então o is.null era só teórico (mesmo
+    // comportamento). Follow-up: mover o claim p/ RPC com IS DISTINCT FROM + whitelist
+    // de estados elegíveis (hoje só barra 'enviando_portal').
     const ids = candidatos.map((c) => c.id);
     const { data: claimedRows, error: claimErr } = await supabase
       .from("pedido_compra_sugerido")
       .update({ status_envio_portal: "enviando_portal", portal_erro: null })
       .in("id", ids)
-      .or("status_envio_portal.is.null,status_envio_portal.neq.enviando_portal")
+      .neq("status_envio_portal", "enviando_portal")
       .select("id");
     if (claimErr) {
       console.error("[envio-portal][async] Erro no claim atomico:", claimErr.message);
@@ -2217,7 +2223,9 @@ Deno.serve(async (req) => {
     .from("pedido_compra_sugerido")
     .update({ status_envio_portal: "enviando_portal", portal_erro: null })
     .in("id", idsSync)
-    .or("status_envio_portal.is.null,status_envio_portal.neq.enviando_portal")
+    // .neq() em vez de .or(is.null,neq) — ver claim async acima (bug do .or() em
+    // UPDATE no supabase-js 2.45.0; status_envio_portal nunca é NULL, mesmo comportamento).
+    .neq("status_envio_portal", "enviando_portal")
     .select("id");
   if (claimErrSync) {
     return new Response(


### PR DESCRIPTION
## Problema

O claim atômico do envio ao portal Sayerlack (`enviar-pedido-portal-sayerlack`) falhava com:

```
column pedido_compra_sugerido.status_envio_portal does not exist
```

**mesmo a coluna existindo.** Travou todos os disparos ao portal desde 02/06 — pedidos 324/325 (Oben, ~R$10k) presos em `pendente_envio_portal`/`falha_envio`, re-tentando em loop, e o alerta do Sentinela `reposicao_portal_pipeline` disparou.

## Causa real (NÃO era cache nem migration faltando)

O `.or("status_envio_portal.is.null,...neq.enviando_portal")` em `UPDATE+RETURNING` é serializado errado pelo **`supabase-js@2.45.0`** desta edge (bug do postgrest-js antigo em mutation). Provas de que a coluna existe e o problema é o `.or()`:

- O `.select("...status_envio_portal...")` da **mesma coluna no mesmo request** funciona (`candidatos: 1` no log) — se a coluna não estivesse no schema cache, daria 400/404.
- `information_schema` lista a coluna; `EXPLAIN UPDATE ... WHERE (status_envio_portal IS NULL OR status_envio_portal <> 'enviando_portal')` retorna plano normal.
- `NOTIFY pgrst, 'reload schema'` **não mudou nada**; os event triggers `pgrst_ddl_watch`/`pgrst_drop_watch` estão `ENABLED` (auto-reload vivo).
- A edge usa `supabase-js@2.45.0`; o frontend (`^2.95.3`) filtra `.in('status_envio_portal',...)` sem problema.

## Fix

Troca `.or()` por `.neq("status_envio_portal","enviando_portal")` nos **dois** claims (async + síncrono). Vira filtro simples na URL (`status_envio_portal=neq.enviando_portal`), escapa do caminho bugado do `.or()` em mutation, e **preserva atomicidade/idempotência** (`UPDATE...WHERE...RETURNING`; concorrente reavalia o WHERE). A coluna tem `DEFAULT 'nao_aplicavel'` e nunca é NULL (validado: **0 linhas** com `status_envio_portal IS NULL` em prod), então o `.is.null` descartado era só teórico — mesmo comportamento.

Diagnóstico eu + codex (2 consults).

## Deploy

- **Sem migration.** Só código.
- ⚠️ **Requer redeploy manual da edge `enviar-pedido-portal-sayerlack`** via chat do Lovable (ler de `supabase/functions/enviar-pedido-portal-sayerlack/index.ts` da `main`, deploy verbatim) **após o merge**.
- Validação pós-deploy: re-disparar 324/325 → log do claim sem erro → `enviando_portal` → `sucesso_portal` + protocolo.

## Follow-up (não bloqueia)

- Mover o claim p/ RPC `SECURITY`-aware com `IS DISTINCT FROM 'enviando_portal'` + **whitelist de estados elegíveis** (o filtro atual só barra `enviando_portal`; um pedido já enviado entrando por ID poderia ser re-reivindicado).
- Documentar a armadilha no §5 do CLAUDE.md (`.or()` em mutation no supabase-js antigo dá `column does not exist` enganoso; `SELECT`/`select('*')` mascaram; fix = `.neq()` ou RPC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)