### PR TITLE
fix(security): loyalty — auto-crédito, resgate-grátis e débito quebrado

### DIFF
--- a/src/pages/Loyalty.tsx
+++ b/src/pages/Loyalty.tsx
@@ -27,10 +27,10 @@ const TIERS = [
 ];
 
 const REWARDS = [
-  { name: '10% desconto no frete', points: 100, icon: '🚚' },
-  { name: 'Afiação grátis (1 ferramenta)', points: 300, icon: '🔧' },
-  { name: 'Kit de manutenção', points: 500, icon: '🧰' },
-  { name: 'Desconto 20% no próximo pedido', points: 750, icon: '💰' },
+  { key: 'frete_10', name: '10% desconto no frete', points: 100, icon: '🚚' },
+  { key: 'afiacao_gratis', name: 'Afiação grátis (1 ferramenta)', points: 300, icon: '🔧' },
+  { key: 'kit_manutencao', name: 'Kit de manutenção', points: 500, icon: '🧰' },
+  { key: 'desconto_20', name: 'Desconto 20% no próximo pedido', points: 750, icon: '💰' },
 ];
 
 export default function Loyalty() {
@@ -79,27 +79,13 @@ export default function Loyalty() {
 
     setRedeemingReward(reward.name);
     try {
-      // 1. Create redemption record
-      const { error: redemptionError } = await supabase
-        .from('loyalty_redemptions')
-        .insert({
-          user_id: user.id,
-          reward_name: reward.name,
-          points_spent: reward.points,
-          status: 'pendente',
-        });
-      if (redemptionError) throw redemptionError;
-
-      // 2. Deduct points via negative entry
-      const { error: pointsError } = await supabase
-        .from('loyalty_points')
-        .insert({
-          user_id: user.id,
-          points: -reward.points,
-          type: 'resgate',
-          description: `Resgate: ${reward.name}`,
-        });
-      if (pointsError) throw pointsError;
+      // Resgate atômico server-side: a RPC SECURITY DEFINER valida saldo, cria o resgate e debita
+      // os pontos (o preço vem do catálogo no servidor, não do cliente). Substitui os 2 inserts
+      // diretos antigos — o de débito era bloqueado pela RLS (type='earn'-only) → saldo nunca caía.
+      const { error } = await supabase.rpc('resgatar_recompensa' as never, {
+        p_reward_key: reward.key,
+      } as never);
+      if (error) throw error;
 
       toast.success('Resgate realizado!', { description: `${reward.name} resgatado com sucesso. Aguarde processamento.` });
       await loadPoints();

--- a/supabase/migrations/20260604120000_loyalty_rls_hardening.sql
+++ b/supabase/migrations/20260604120000_loyalty_rls_hardening.sql
@@ -1,0 +1,71 @@
+-- Loyalty hardening (#2 auto-crédito + #3 resgate quebrado + resgate-grátis) — auditoria 2026-06-04.
+--
+-- #2 (segurança): "Users can earn points" deixava o CLIENTE inserir loyalty_points type='earn'
+--    de QUALQUER valor pra si (auto-crédito). O ganho legítimo é via trigger award_loyalty_points()
+--    (SECURITY DEFINER, bypassa RLS) → dropar a policy NÃO quebra o earning.
+-- #2b (segurança, achado codex): "Users can create their own redemptions" deixava o cliente
+--    inserir um resgate 'pendente' DIRETO, sem saldo nem débito → "resgate grátis" se o fulfillment
+--    processa a fila. Dropada também — a RPC (definer) é o único caminho de criar resgate.
+-- #3 (money-bug): o resgate em Loyalty.tsx inseria loyalty_points type='resgate' client-side, mas a
+--    RLS só aceitava 'earn' → o débito FALHAVA → saldo nunca caía. Débito passa a ser server-side.
+--
+-- Consumidores não afetados: useAdminLoyalty (staff → "Staff can manage all *"), omie-sync
+-- (service_role), trigger de earn (SECURITY DEFINER). Cliente mantém o SELECT do próprio histórico.
+
+-- 1) Fecha o auto-crédito de pontos e o resgate-grátis (writes diretos do cliente).
+DROP POLICY IF EXISTS "Users can earn points" ON public.loyalty_points;
+DROP POLICY IF EXISTS "Users can create their own redemptions" ON public.loyalty_redemptions;
+
+-- 2) Resgate atômico server-side: pontos resolvidos por CATÁLOGO autoritativo (não vêm do cliente),
+--    valida saldo, cria o resgate e debita. Advisory lock 64-bit anti double-spend na corrida.
+CREATE OR REPLACE FUNCTION public.resgatar_recompensa(p_reward_key text)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_uid uuid := auth.uid();
+  v_points integer;
+  v_name text;
+  v_saldo bigint; -- SUM(points) é bigint (robustez; > int max é irreal mas evita overflow)
+  v_redemption_id uuid;
+BEGIN
+  IF v_uid IS NULL THEN
+    RAISE EXCEPTION 'nao autenticado';
+  END IF;
+
+  -- Catálogo autoritativo (espelha REWARDS do front; o cliente passa só a CHAVE, nunca o preço).
+  CASE p_reward_key
+    WHEN 'frete_10'       THEN v_points := 100; v_name := '10% desconto no frete';
+    WHEN 'afiacao_gratis' THEN v_points := 300; v_name := 'Afiação grátis (1 ferramenta)';
+    WHEN 'kit_manutencao' THEN v_points := 500; v_name := 'Kit de manutenção';
+    WHEN 'desconto_20'    THEN v_points := 750; v_name := 'Desconto 20% no próximo pedido';
+    ELSE RAISE EXCEPTION 'recompensa desconhecida: %', p_reward_key;
+  END CASE;
+
+  -- Serializa resgates concorrentes do MESMO usuário (anti double-spend / double-click).
+  PERFORM pg_advisory_xact_lock(hashtextextended('loyalty_resgate:' || v_uid::text, 0));
+
+  SELECT COALESCE(SUM(points), 0) INTO v_saldo
+  FROM public.loyalty_points
+  WHERE user_id = v_uid;
+
+  IF v_saldo < v_points THEN
+    RAISE EXCEPTION 'saldo insuficiente: % < %', v_saldo, v_points;
+  END IF;
+
+  INSERT INTO public.loyalty_redemptions (user_id, reward_name, points_spent, status)
+  VALUES (v_uid, v_name, v_points, 'pendente')
+  RETURNING id INTO v_redemption_id;
+
+  INSERT INTO public.loyalty_points (user_id, points, type, description)
+  VALUES (v_uid, -v_points, 'resgate', 'Resgate: ' || v_name);
+
+  RETURN v_redemption_id;
+END;
+$$;
+
+-- Só autenticado executa (anon tem grant explícito no Supabase — revogar por nome).
+REVOKE ALL ON FUNCTION public.resgatar_recompensa(text) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.resgatar_recompensa(text) TO authenticated;


### PR DESCRIPTION
## 🔒 3 furos no subsistema de fidelidade (auditoria 2026-06-04, #2+#3 do relatório)

| # | Furo | Onde |
|---|------|------|
| #2 | cliente credita **pontos arbitrários** a si (`type='earn'`, qualquer valor) | RLS `loyalty_points` |
| #2b | cliente cria resgate `pendente` **direto, sem débito** → resgate-grátis (achado codex) | RLS `loyalty_redemptions` |
| #3 | débito do resgate (`type='resgate'`) **bloqueado** pela RLS earn-only → saldo nunca cai | `Loyalty.tsx` + RLS |

## Fix

- **DROP** das 2 policies de write direto do cliente. Earning legítimo segue via trigger `award_loyalty_points()` (SECURITY DEFINER); staff via "Staff can manage all *".
- **RPC `resgatar_recompensa(p_reward_key)`** SECURITY DEFINER: pontos por **catálogo autoritativo server-side** (cliente passa só a chave, nunca o preço), valida saldo, cria resgate + debita atomicamente, **advisory lock 64-bit** anti double-spend.
- `Loyalty.tsx` chama a RPC (REWARDS ganham `key`); removidos os 2 inserts diretos.

**2 passadas codex** (1ª pegou o #2b + catálogo server-side + `hashtextextended`; 2ª limpa, sem P1/P2).

## ⚠️ MIGRATION MANUAL (Lovable SQL Editor)

```sql
-- Loyalty hardening (#2 auto-crédito + #2b resgate-grátis + #3 débito quebrado)
DROP POLICY IF EXISTS "Users can earn points" ON public.loyalty_points;
DROP POLICY IF EXISTS "Users can create their own redemptions" ON public.loyalty_redemptions;

CREATE OR REPLACE FUNCTION public.resgatar_recompensa(p_reward_key text)
RETURNS uuid LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public'
AS $$
DECLARE
  v_uid uuid := auth.uid();
  v_points integer; v_name text; v_saldo bigint; v_redemption_id uuid;
BEGIN
  IF v_uid IS NULL THEN RAISE EXCEPTION 'nao autenticado'; END IF;
  CASE p_reward_key
    WHEN 'frete_10'       THEN v_points := 100; v_name := '10% desconto no frete';
    WHEN 'afiacao_gratis' THEN v_points := 300; v_name := 'Afiação grátis (1 ferramenta)';
    WHEN 'kit_manutencao' THEN v_points := 500; v_name := 'Kit de manutenção';
    WHEN 'desconto_20'    THEN v_points := 750; v_name := 'Desconto 20% no próximo pedido';
    ELSE RAISE EXCEPTION 'recompensa desconhecida: %', p_reward_key;
  END CASE;
  PERFORM pg_advisory_xact_lock(hashtextextended('loyalty_resgate:' || v_uid::text, 0));
  SELECT COALESCE(SUM(points), 0) INTO v_saldo FROM public.loyalty_points WHERE user_id = v_uid;
  IF v_saldo < v_points THEN RAISE EXCEPTION 'saldo insuficiente: % < %', v_saldo, v_points; END IF;
  INSERT INTO public.loyalty_redemptions (user_id, reward_name, points_spent, status)
  VALUES (v_uid, v_name, v_points, 'pendente') RETURNING id INTO v_redemption_id;
  INSERT INTO public.loyalty_points (user_id, points, type, description)
  VALUES (v_uid, -v_points, 'resgate', 'Resgate: ' || v_name);
  RETURN v_redemption_id;
END;
$$;
REVOKE ALL ON FUNCTION public.resgatar_recompensa(text) FROM PUBLIC, anon;
GRANT EXECUTE ON FUNCTION public.resgatar_recompensa(text) TO authenticated;

SELECT 'LOYALTY OK' AS status,
  (SELECT count(*) FROM pg_policies WHERE tablename='loyalty_points' AND policyname='Users can earn points') AS earn_removida_0,
  (SELECT count(*) FROM pg_policies WHERE tablename='loyalty_redemptions' AND policyname='Users can create their own redemptions') AS resgate_direto_removido_0,
  (SELECT count(*) FROM pg_proc WHERE proname='resgatar_recompensa') AS rpc_1,
  has_function_privilege('authenticated','public.resgatar_recompensa(text)','EXECUTE') AS auth_exec_true,
  has_function_privilege('anon','public.resgatar_recompensa(text)','EXECUTE') AS anon_exec_false;
```

**Ordem de rollout:** aplicar a migration **ANTES** do Publish do frontend — o drop já fecha os furos #2/#2b imediatamente, e a RPC precisa existir antes do front novo chamá-la (#3).

## Validação

- typecheck (strict) — 0 · lint — 0 erros · test — **2242** · build — ✓ · **codex review limpo** (2 passadas)

## Test plan (pós-migration + Publish)

- [ ] Cliente NÃO consegue mais `POST /rest/v1/loyalty_points {type:'earn', points:9999}` (policy dropada → 403).
- [ ] Cliente NÃO cria resgate direto via `POST /rest/v1/loyalty_redemptions` (403).
- [ ] Resgate pela tela /loyalty debita o saldo de verdade (cai os pontos); 2º resgate sem saldo → "saldo insuficiente".
- [ ] Ganhar pontos (concluir pedido) ainda credita normal (trigger definer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)