### PR TITLE
fix(sayerlack): claim do portal usa lista positiva .in() (conserta .or()-on-update que travava o disparo)

### DIFF
--- a/supabase/functions/enviar-pedido-portal-sayerlack/index.ts
+++ b/supabase/functions/enviar-pedido-portal-sayerlack/index.ts
@@ -2139,15 +2139,21 @@ Deno.serve(async (req) => {
     // já em voo. Um UPDATE ... RETURNING é atômico (lock de linha + re-avaliação do
     // WHERE após o commit concorrente): se 2 requests competem pelo MESMO pedido
     // (ex.: "aprovar e disparar" + cron de corte no mesmo instante), só um claима;
-    // o outro vê enviando_portal e é EXCLUÍDO do RETURNING. Fecha o duplo-envio ao
-    // portal (2ª sessão no Browserless → PO duplicado no fornecedor). O `is.null`
-    // cobre o pedido fresco (status_envio_portal NULL), que o `neq` sozinho perderia.
+    // o outro vê o estado já mudado e é EXCLUÍDO do RETURNING. Fecha o duplo-envio ao
+    // portal (2ª sessão no Browserless → PO duplicado no fornecedor).
+    // ⚠️ Lista POSITIVA (pendente_envio_portal/erro_retentavel), NÃO `.or(is.null,
+    // neq.enviando_portal)`: (a) o PostgREST rejeita `.or()` aplicado a um UPDATE/PATCH
+    // → falhava com "column ... status_envio_portal does not exist" em prod, travando
+    // TODO disparo Sayerlack; (b) o predicado largo re-reivindicava estados terminais/
+    // ambíguos (sucesso_portal, indeterminado_requer_conciliacao) e os sobrescrevia p/
+    // enviando_portal → risco de re-dirigir o portal num PO duplicado. Espelha o filtro
+    // do modo-lote (candidatos) e do retry motor. (Codex review.)
     const ids = candidatos.map((c) => c.id);
     const { data: claimedRows, error: claimErr } = await supabase
       .from("pedido_compra_sugerido")
       .update({ status_envio_portal: "enviando_portal", portal_erro: null })
       .in("id", ids)
-      .or("status_envio_portal.is.null,status_envio_portal.neq.enviando_portal")
+      .in("status_envio_portal", ["pendente_envio_portal", "erro_retentavel"])
       .select("id");
     if (claimErr) {
       console.error("[envio-portal][async] Erro no claim atomico:", claimErr.message);
@@ -2217,7 +2223,7 @@ Deno.serve(async (req) => {
     .from("pedido_compra_sugerido")
     .update({ status_envio_portal: "enviando_portal", portal_erro: null })
     .in("id", idsSync)
-    .or("status_envio_portal.is.null,status_envio_portal.neq.enviando_portal")
+    .in("status_envio_portal", ["pendente_envio_portal", "erro_retentavel"])
     .select("id");
   if (claimErrSync) {
     return new Response(


### PR DESCRIPTION
## O quê

Conserta o **claim atômico** do envio ao portal Sayerlack, que estava **travando todo disparo** em produção.

## Causa-raiz

O claim fazia `.update({status_envio_portal: "enviando_portal", ...}).in("id", ids).or("status_envio_portal.is.null,status_envio_portal.neq.enviando_portal")`. O **PostgREST rejeita `.or()` aplicado a um UPDATE/PATCH** → respondia `column pedido_compra_sugerido.status_envio_portal does not exist` (a coluna existe; o `.update().eq()` simples e os `.or()` em `.select()` funcionam — era o único `.or()`-em-update do repo). Resultado: pedidos Sayerlack ficavam em `pendente_envio_portal` e o portal nunca rodava.

Diagnóstico confirmado em prod: o `disparar` moveu 340/341 de `nao_aplicavel` → `pendente_envio_portal` (write via PostgREST OK), mas o claim do portal falhava com o erro acima.

## Fix

Lista **positiva** `.in("status_envio_portal", ["pendente_envio_portal", "erro_retentavel"])` nos 2 sites (async + síncrono legado):
- conserta o erro do PostgREST;
- **aperta o predicado** — o `.or()` largo podia re-reivindicar estados terminais/ambíguos (`sucesso_portal`, `indeterminado_requer_conciliacao`) e re-dirigir o portal num **PO duplicado** no fornecedor;
- espelha o filtro que o modo-lote (candidatos) e o retry motor já usam.

Revisado pelo Codex (lista positiva > `.neq()`).

## ⚠️ Pós-merge (founder)

1. **Redeploy** da edge `enviar-pedido-portal-sayerlack` via chat do Lovable (ler de `supabase/functions/enviar-pedido-portal-sayerlack/index.ts` na main, deploy verbatim).
2. **Re-disparar** 340 e 341 pela UI (botão Disparar) — devem subir ao portal agora.

Sem migration. Edge-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
