### PR TITLE
fix(security): tint — catálogo staff-only (tint_formulas/tint_skus) (#5)

### DIFF
--- a/supabase/migrations/20260604170000_tint_catalog_rls_hardening.sql
+++ b/supabase/migrations/20260604170000_tint_catalog_rls_hardening.sql
@@ -1,0 +1,17 @@
+-- #5 (auditoria 2026-06-04): catálogo tint legível por qualquer autenticado (defesa em profundidade).
+--
+-- tint_formulas / tint_skus tinham SELECT "Authenticated can view ... USING(true)" → qualquer
+-- cliente logado lia o catálogo inteiro de cores + preço final + estrutura de SKU via PostgREST
+-- (scraping de catálogo). A receita sensível (custo/margem via tint_formula_itens) JÁ está fechada
+-- (RPC get_tint_price, #384); aqui é o catálogo em si.
+--
+-- Consumidores confirmados TODOS staff:
+--   - useTintColorSelect (picker de cor): abre só ao adicionar produto tintométrico base, que só
+--     existe no modo STAFF do wizard (Novo Pedido com abas de produto). O modo CLIENTE é Ordem de
+--     Serviço de afiação (sem abas de produto) → nunca lê tint_formulas/tint_skus.
+--   - useDirectTintImport, useTintometricoZone, TintCatalogo (staff/gated #1), useGlobalSearch (isStaff).
+-- Logo, basta remover o SELECT aberto: o staff mantém leitura pela policy "Staff can manage *"
+-- (FOR ALL, master/employee); o cliente passa a NÃO ter policy de SELECT → negado (fail-closed).
+
+DROP POLICY IF EXISTS "Authenticated can view tint_formulas" ON public.tint_formulas;
+DROP POLICY IF EXISTS "Authenticated can view tint_skus" ON public.tint_skus;


### PR DESCRIPTION
## 🔒 #5 (auditoria) — catálogo tint legível por cliente (defesa em profundidade)

`tint_formulas`/`tint_skus` tinham `SELECT "Authenticated can view ... USING(true)"` → qualquer cliente logado lia o **catálogo inteiro de cores + preço final + estrutura de SKU** via PostgREST (scraping de catálogo/concorrência). A receita sensível (custo/margem via `tint_formula_itens`) **já estava fechada** (#384) — aqui é o catálogo em si.

## Fix (migration-only, sem frontend)

`DROP` das 2 policies `"Authenticated can view"`. Staff mantém leitura via `"Staff can manage *"` (`FOR ALL`, master/employee); cliente fica **sem policy de SELECT → negado** (fail-closed).

**Por que não precisa de RPC nem mudança de front** (≠ a receita do #384): todos os consumidores de `tint_formulas`/`tint_skus` são **staff**:
- `useTintColorSelect` (picker de cor) abre só ao adicionar `product.is_tintometric && tint_type='base'`, que só ocorre no **modo STAFF** do wizard (Novo Pedido c/ abas de produto). O modo **CLIENTE** é Ordem de Serviço de afiação (sem abas) → nunca lê.
- `useDirectTintImport` (import), `useGlobalSearch` (gated `isStaff`), `useTintometricoZone` (dashboard staff), `TintCatalogo` (página staff, gated pelo #1).

**codex review:** lógica limpa, `FOR ALL` cobre o SELECT do staff, nenhum consumidor não-staff quebra. (Achado do codex: timestamp colidia com migrations paralelas → renomeado p/ slot único.)

## ⚠️ MIGRATION MANUAL (Lovable SQL Editor)

```sql
-- #5 catálogo tint staff-only
DROP POLICY IF EXISTS "Authenticated can view tint_formulas" ON public.tint_formulas;
DROP POLICY IF EXISTS "Authenticated can view tint_skus" ON public.tint_skus;

SELECT 'TINT CATALOG OK' AS status,
  (SELECT count(*) FROM pg_policies WHERE tablename='tint_formulas' AND policyname='Authenticated can view tint_formulas') AS formulas_aberta_deve_0,
  (SELECT count(*) FROM pg_policies WHERE tablename='tint_skus' AND policyname='Authenticated can view tint_skus') AS skus_aberta_deve_0,
  (SELECT count(*) FROM pg_policies WHERE tablename='tint_formulas' AND policyname='Staff can manage tint_formulas') AS staff_formulas_mantida_deve_1,
  (SELECT count(*) FROM pg_policies WHERE tablename='tint_skus' AND policyname='Staff can manage tint_skus') AS staff_skus_mantida_deve_1;
```

Esperado: `formulas_aberta_deve_0=0`, `skus_aberta_deve_0=0`, `staff_*_mantida_deve_1=1`.

## Test plan (pós-migration)

- [ ] Cliente: `GET /rest/v1/tint_formulas` → 0 linhas (negado). Staff: lê normal.
- [ ] **Wizard de pedido STAFF** (Novo Pedido → adicionar base tintométrica → escolher cor) **continua funcionando** (staff lê via FOR ALL).
- [ ] Telas tintométricas (catálogo, import, dashboard) seguem normais pra staff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)