### PR TITLE
fix(afiação): liga o botão Aprovar Orçamento (estava morto) (#4)

### DIFF
--- a/src/pages/OrderDetail.tsx
+++ b/src/pages/OrderDetail.tsx
@@ -23,7 +23,18 @@ import { Badge } from '@/components/ui/badge';
 import { Card, CardContent } from '@/components/ui/card';
 import { TOOL_CATEGORIES, SERVICE_TYPES, DELIVERY_OPTIONS } from '@/types';
 import { supabase } from '@/integrations/supabase/client';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
 import { format } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
 
@@ -98,6 +109,29 @@ const OrderDetail = () => {
       };
     },
     enabled: !!id,
+  });
+
+  const queryClient = useQueryClient();
+  const [confirmAprovar, setConfirmAprovar] = useState(false);
+  // Aprovar o orçamento = mover o pedido de afiação pra 'aprovado' (RLS "Users can update their
+  // own orders" permite). É a ação do cliente que destrava a afiação. A criação do pedido no Omie
+  // (Colacor SC / serviços) é integração futura, que dispararia a partir deste status.
+  const aprovarOrcamento = useMutation({
+    mutationFn: async () => {
+      if (!id) throw new Error('pedido inválido');
+      const { error } = await supabase.from('orders').update({ status: 'aprovado' }).eq('id', id);
+      if (error) throw new Error(error.message);
+    },
+    onSuccess: () => {
+      setConfirmAprovar(false);
+      toast.success('Orçamento aprovado!', { description: 'A afiação das suas ferramentas vai começar.' });
+      void queryClient.invalidateQueries({ queryKey: ['order-detail', id] });
+      void queryClient.invalidateQueries({ queryKey: ['orders'] });
+    },
+    onError: (e) =>
+      toast.error('Não foi possível aprovar', {
+        description: e instanceof Error ? e.message : 'Tente novamente.',
+      }),
   });
 
   useEffect(() => {
@@ -202,8 +236,13 @@ const OrderDetail = () => {
                   </p>
                 </div>
                 <div className="flex gap-2">
-                  <Button className="flex-1" size="sm">
-                    Aprovar Orçamento
+                  <Button
+                    className="flex-1"
+                    size="sm"
+                    onClick={() => setConfirmAprovar(true)}
+                    disabled={aprovarOrcamento.isPending}
+                  >
+                    {aprovarOrcamento.isPending ? <Loader2 className="w-4 h-4 animate-spin" /> : 'Aprovar Orçamento'}
                   </Button>
                   <Button
                     variant="outline"
@@ -215,6 +254,31 @@ const OrderDetail = () => {
                     Falar com suporte
                   </Button>
                 </div>
+
+                <AlertDialog open={confirmAprovar} onOpenChange={setConfirmAprovar}>
+                  <AlertDialogContent>
+                    <AlertDialogHeader>
+                      <AlertDialogTitle>
+                        Aprovar orçamento de R$ {order.total.toFixed(2).replace('.', ',')}?
+                      </AlertDialogTitle>
+                      <AlertDialogDescription>
+                        Ao aprovar, a afiação das suas ferramentas será iniciada. Você confirma os itens e o valor.
+                      </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                      <AlertDialogCancel disabled={aprovarOrcamento.isPending}>Cancelar</AlertDialogCancel>
+                      <AlertDialogAction
+                        onClick={(e) => {
+                          e.preventDefault();
+                          aprovarOrcamento.mutate();
+                        }}
+                        disabled={aprovarOrcamento.isPending}
+                      >
+                        {aprovarOrcamento.isPending ? 'Aprovando…' : 'Aprovar'}
+                      </AlertDialogAction>
+                    </AlertDialogFooter>
+                  </AlertDialogContent>
+                </AlertDialog>
               </div>
             </CardContent>
           </Card>


### PR DESCRIPTION
## 🚧 #4 (auditoria) — botão "Aprovar Orçamento" morto

`OrderDetail.tsx:205` era um `<Button>` **sem `onClick`** → o cliente não conseguia aprovar o próprio orçamento de afiação (passo central da jornada; o pedido ficava preso em `orcamento_enviado`).

## Fix (frontend)

Botão → **confirmação** (AlertDialog com o valor) → move o pedido pra `status='aprovado'` (RLS "Users can update their own orders" permite own-update), com loading/otimista (invalida `order-detail` + `orders`) + toast honesto.

## Escopo: o que é e o que NÃO é (ainda)

✅ **Destrava a ação do cliente** (quote → aprovado). É a **fundação** da jornada.

🔜 **NÃO cria o pedido no Omie** — você apontou que a afiação **deveria** integrar com o ICI / **Colacor SC (serviços)**. Isso é uma **integração nova** (não existe hoje: `orders` não tem coluna de empresa, não há edge function de aprovação afiação→Omie). Fica como **feature à parte**, a ser brainstormada — a criação da OS no Omie dispararia a partir DESTE status `aprovado`, então este PR não é jogado fora, é o alicerce.

## Validação

- typecheck (strict) — 0 · lint — 0 erros · test — sem falhas · build — CI valida.

## Test plan (pós-Publish)

- [ ] Cliente com pedido em "Orçamento Enviado" → clica "Aprovar Orçamento" → dialog mostra o valor → confirma → status vira "Aprovado", some o card de aprovação, toast de sucesso.
- [ ] Cancelar no dialog → nada muda.
- [ ] (futuro) ao aprovar, criar a OS no Omie da Colacor SC — feature seguinte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)