### PR TITLE
feat(tarefas-f2): enforcement — Milestone 2 (frontend: prova no /tintometrico, auditoria, CRUD de templates)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -60,6 +60,7 @@ const SalesQuotes = lazy(() => import("./pages/SalesQuotes"));
 const FarmerDashboard = lazy(() => import("./pages/FarmerDashboard"));
 const MeuDia = lazy(() => import("./pages/MeuDia"));
 const Tarefas = lazy(() => import("./pages/Tarefas"));
+const TarefasTemplates = lazy(() => import("./pages/TarefasTemplates"));
 const FarmerCalls = lazy(() => import("./pages/FarmerCalls"));
 const FarmerCallsPendingLink = lazy(() => import("./pages/FarmerCallsPendingLink"));
 const FarmerGovernance = lazy(() => import("./pages/FarmerGovernance"));
@@ -235,6 +236,7 @@ const App = () => (
                   Cada rota de staff agora existe SÓ dentro do <RequireStaff> (fail-closed).
                   O teste src/__tests__/app-route-dedupe.test.ts impede a duplicação voltar. */}
               <Route path="tarefas" element={<Tarefas />} />
+              <Route path="tarefas/templates" element={<TarefasTemplates />} />
               <Route path="admin/calculadora" element={<AdminCalculadora />} />
 
               {/* ─── Financeiro (gate próprio: permite não-staff com permissão) ─── */}

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -82,6 +82,7 @@ const unifiedNavSections: { title: string; items: NavItem[] }[] = [
       { icon: ShoppingCart, label: 'Pedidos', path: '/sales' },
       { icon: PlusCircle, label: 'Novo Pedido', path: '/sales/new' },
       { icon: ClipboardList, label: 'Tarefas', path: '/tarefas', gestorComercialOuMaster: true },
+      { icon: ListChecks, label: 'Tarefas recorrentes', path: '/tarefas/templates', gestorComercialOuMaster: true },
       { icon: Wrench, label: 'Ferramentas de Venda', path: '/vendas/ferramentas' },
       { icon: Link2, label: 'Chamadas pendentes', path: '/farmer/calls/pending-link' },
       { icon: Phone, label: 'Telefonia', path: '/telefonia' },

--- a/src/components/tarefas/ComprovacaoDialog.tsx
+++ b/src/components/tarefas/ComprovacaoDialog.tsx
@@ -1,0 +1,353 @@
+/**
+ * ComprovacaoDialog — fluxo de prova do operador (Fase 2, Task 7).
+ *
+ * Acionado ao concluir uma tarefa com `requer_comprovacao=true`.
+ * Conforme `tipo_comprovacao`:
+ *   - 'foto':           upload de imagem → path no bucket tarefa-comprovacoes
+ *   - 'leitura':        input numérico validado client-side (faixa min/max)
+ *   - 'foto_e_leitura': ambos obrigatórios
+ *
+ * Os limites de leitura (leituraMin / leituraMax / leituraUnidade) chegam via
+ * prop — quem abre o dialog já tem a instância da tarefa, que carrega esses
+ * valores herdados do template no momento da materialização (campos opcionais
+ * em TarefaInstancia não existem ainda, mas o dialog aceita null graciosamente).
+ *
+ * Upload: supabase.storage.from('tarefa-comprovacoes').upload(path, file)
+ * Path:   montarPathComprovacao(uid, tarefaId, ext, ts) → {uid}/{tarefaId}/{ts}.ext
+ *         (RPC verifica que a URL contém '{uid}/{tarefaId}')
+ */
+
+import { useRef, useState } from 'react';
+import { Camera, CheckCircle2, Loader2, X } from 'lucide-react';
+import { toast } from 'sonner';
+
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { supabase } from '@/integrations/supabase/client';
+import { useAuth } from '@/contexts/AuthContext';
+import { montarPathComprovacao, validarLeitura } from '@/lib/tarefas/comprovacao';
+import { useConcluirComComprovacao } from '@/hooks/useTarefasFase2';
+import type { TarefaInstancia } from '@/lib/tarefas/templates-types';
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+export interface ComprovacaoDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  tarefa: TarefaInstancia;
+  /**
+   * Limites de leitura provenientes do template.
+   * Passados explicitamente para desacoplar o dialog do carregamento do template.
+   */
+  leituraMin?: number | null;
+  leituraMax?: number | null;
+  leituraUnidade?: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers de UI
+// ---------------------------------------------------------------------------
+
+/** Extrai a extensão do nome de arquivo sem o ponto. Ex.: 'foto.JPG' → 'jpg' */
+function extDoArquivo(file: File): string {
+  const partes = file.name.split('.');
+  if (partes.length < 2) return 'jpg';
+  return partes[partes.length - 1].toLowerCase();
+}
+
+/** Descrição legível da faixa de leitura. Ex.: '7,0 – 7,5 pH' */
+function descricaoFaixa(
+  min: number | null | undefined,
+  max: number | null | undefined,
+  unidade: string | null | undefined,
+): string | null {
+  const u = unidade ?? '';
+  if (min != null && max != null)
+    return `${min.toLocaleString('pt-BR')} – ${max.toLocaleString('pt-BR')}${u ? ' ' + u : ''}`;
+  if (min != null) return `≥ ${min.toLocaleString('pt-BR')}${u ? ' ' + u : ''}`;
+  if (max != null) return `≤ ${max.toLocaleString('pt-BR')}${u ? ' ' + u : ''}`;
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Componente
+// ---------------------------------------------------------------------------
+
+export function ComprovacaoDialog({
+  open,
+  onOpenChange,
+  tarefa,
+  leituraMin,
+  leituraMax,
+  leituraUnidade,
+}: ComprovacaoDialogProps) {
+  const { user } = useAuth();
+  const { concluirComComprovacao } = useConcluirComComprovacao();
+
+  const tipo = tarefa.tipo_comprovacao ?? 'nenhuma';
+  const precisaFoto = tipo === 'foto' || tipo === 'foto_e_leitura';
+  const precisaLeitura = tipo === 'leitura' || tipo === 'foto_e_leitura';
+
+  // ---- estado de foto ----
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [arquivoSelecionado, setArquivoSelecionado] = useState<File | null>(null);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const [uploading, setUploading] = useState(false);
+
+  // ---- estado de leitura ----
+  const [leituraRaw, setLeituraRaw] = useState('');
+
+  // ---- estado de envio ----
+  const [salvando, setSalvando] = useState(false);
+
+  // ---------------------------------------------------------------------------
+  // Seleção de arquivo
+  // ---------------------------------------------------------------------------
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0] ?? null;
+    if (!file) return;
+
+    if (!file.type.startsWith('image/')) {
+      toast.error('Arquivo inválido', { description: 'Apenas imagens são permitidas.' });
+      return;
+    }
+    if (file.size > 10 * 1024 * 1024) {
+      toast.error('Arquivo muito grande', { description: 'Tamanho máximo: 10 MB.' });
+      return;
+    }
+
+    setArquivoSelecionado(file);
+    const url = URL.createObjectURL(file);
+    setPreviewUrl(url);
+  };
+
+  const removerFoto = () => {
+    setArquivoSelecionado(null);
+    if (previewUrl) {
+      URL.revokeObjectURL(previewUrl);
+      setPreviewUrl(null);
+    }
+    if (fileInputRef.current) fileInputRef.current.value = '';
+  };
+
+  // ---------------------------------------------------------------------------
+  // Validação client-side do botão Salvar
+  // ---------------------------------------------------------------------------
+
+  const leituraNumero = leituraRaw.trim() === '' ? null : Number(leituraRaw.replace(',', '.'));
+  const leituraInvalida = isNaN(leituraNumero as number) && leituraRaw.trim() !== '';
+
+  const validacaoLeitura = precisaLeitura
+    ? validarLeitura(
+        leituraRaw.trim() === '' ? null : (leituraInvalida ? null : leituraNumero),
+        leituraMin ?? null,
+        leituraMax ?? null,
+      )
+    : { ok: true, erro: null };
+
+  const podeConfirmar =
+    !salvando &&
+    !uploading &&
+    (!precisaFoto || arquivoSelecionado !== null) &&
+    (!precisaLeitura || (validacaoLeitura.ok && leituraRaw.trim() !== ''));
+
+  // ---------------------------------------------------------------------------
+  // Submissão
+  // ---------------------------------------------------------------------------
+
+  const handleConfirmar = async () => {
+    if (!user) return;
+    setSalvando(true);
+
+    try {
+      let pathComprovacao: string | null = null;
+
+      // 1. Upload da foto (se necessário)
+      if (precisaFoto && arquivoSelecionado) {
+        setUploading(true);
+        const ext = extDoArquivo(arquivoSelecionado);
+        const path = montarPathComprovacao(user.id, tarefa.id, ext, Date.now());
+
+        const { data: uploadData, error: uploadError } = await supabase.storage
+          .from('tarefa-comprovacoes')
+          .upload(path, arquivoSelecionado, { upsert: false });
+
+        setUploading(false);
+
+        if (uploadError) {
+          toast.error('Erro ao enviar foto', { description: uploadError.message });
+          setSalvando(false);
+          return;
+        }
+
+        pathComprovacao = uploadData.path;
+      }
+
+      // 2. Chamar a RPC de conclusão
+      const leituraFinal =
+        precisaLeitura && leituraRaw.trim() !== ''
+          ? Number(leituraRaw.replace(',', '.'))
+          : null;
+
+      await concluirComComprovacao(tarefa.id, pathComprovacao, leituraFinal);
+
+      // Sucesso — o hook já exibe o toast e invalida as queries
+      fechar();
+    } catch {
+      // Erros da RPC (faixa inválida, foto obrigatória, etc.) já são
+      // exibidos via toast dentro do hook useConcluirComComprovacao.
+      // Mantemos o dialog aberto para o operador corrigir.
+    } finally {
+      setSalvando(false);
+      setUploading(false);
+    }
+  };
+
+  // ---------------------------------------------------------------------------
+  // Fechar + limpar
+  // ---------------------------------------------------------------------------
+
+  const fechar = () => {
+    removerFoto();
+    setLeituraRaw('');
+    setSalvando(false);
+    setUploading(false);
+    onOpenChange(false);
+  };
+
+  // ---------------------------------------------------------------------------
+  // Render
+  // ---------------------------------------------------------------------------
+
+  const faixaDescricao = descricaoFaixa(leituraMin, leituraMax, leituraUnidade);
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => { if (!o) fechar(); }}>
+      <DialogContent className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle>Comprovação de tarefa</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4 py-1">
+          <p className="text-sm text-muted-foreground line-clamp-2">{tarefa.descricao}</p>
+
+          {/* ---- Seção de foto ---- */}
+          {precisaFoto && (
+            <div className="space-y-2">
+              <Label>
+                Foto
+                <span className="text-status-error ml-1">*</span>
+              </Label>
+
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="image/*"
+                capture="environment"
+                className="hidden"
+                onChange={handleFileChange}
+                disabled={salvando}
+              />
+
+              {previewUrl ? (
+                <div className="relative rounded-md overflow-hidden border border-border">
+                  <img
+                    src={previewUrl}
+                    alt="Prévia da comprovação"
+                    className="w-full max-h-52 object-contain bg-muted"
+                  />
+                  {!salvando && (
+                    <button
+                      type="button"
+                      onClick={removerFoto}
+                      className="absolute top-1.5 right-1.5 w-7 h-7 rounded-full bg-destructive text-destructive-foreground flex items-center justify-center"
+                      aria-label="Remover foto"
+                    >
+                      <X className="w-3.5 h-3.5" />
+                    </button>
+                  )}
+                </div>
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => fileInputRef.current?.click()}
+                  disabled={salvando}
+                  className="w-full rounded-md border-2 border-dashed border-border p-6 text-center hover:border-primary/50 hover:bg-primary/5 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  <Camera className="w-8 h-8 text-muted-foreground mx-auto mb-2" />
+                  <p className="text-sm text-muted-foreground">
+                    Toque para tirar ou escolher foto
+                  </p>
+                </button>
+              )}
+            </div>
+          )}
+
+          {/* ---- Seção de leitura ---- */}
+          {precisaLeitura && (
+            <div className="space-y-2">
+              <Label htmlFor="leitura-input">
+                {leituraUnidade ? `Leitura (${leituraUnidade})` : 'Leitura'}
+                <span className="text-status-error ml-1">*</span>
+                {faixaDescricao && (
+                  <span className="ml-1 font-normal text-muted-foreground">
+                    — faixa: {faixaDescricao}
+                  </span>
+                )}
+              </Label>
+
+              <Input
+                id="leitura-input"
+                type="text"
+                inputMode="decimal"
+                placeholder={faixaDescricao ?? 'Ex.: 7.2'}
+                value={leituraRaw}
+                onChange={(e) => setLeituraRaw(e.target.value)}
+                disabled={salvando}
+                className={
+                  leituraRaw.trim() !== '' && !validacaoLeitura.ok
+                    ? 'border-status-error focus-visible:ring-status-error/30'
+                    : ''
+                }
+              />
+
+              {leituraRaw.trim() !== '' && !validacaoLeitura.ok && validacaoLeitura.erro && (
+                <p className="text-xs text-status-error">{validacaoLeitura.erro}</p>
+              )}
+            </div>
+          )}
+        </div>
+
+        <DialogFooter className="gap-2">
+          <Button variant="ghost" onClick={fechar} disabled={salvando}>
+            Cancelar
+          </Button>
+          <Button onClick={handleConfirmar} disabled={!podeConfirmar}>
+            {(salvando || uploading) ? (
+              <>
+                <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                {uploading ? 'Enviando foto…' : 'Salvando…'}
+              </>
+            ) : (
+              <>
+                <CheckCircle2 className="w-4 h-4 mr-2" />
+                Concluir
+              </>
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/tarefas/ProvasParaAuditar.tsx
+++ b/src/components/tarefas/ProvasParaAuditar.tsx
@@ -1,0 +1,326 @@
+/**
+ * ProvasParaAuditar — lista de instâncias aguardando auditoria (Fase 2, Task 9).
+ *
+ * Exibe comprovações pendentes de revisão do gestor/master:
+ *   - descrição + vendedora responsável
+ *   - leitura (se houver) + foto (signed URL via tarefa-comprovacoes)
+ *   - botões Aprovar / Reprovar (reprovar pede motivo via textarea inline)
+ *
+ * Contagem + idade do backlog no topo (ex.: "3 provas aguardando · mais antiga há 2d").
+ * Estado vazio → mensagem amigável.
+ *
+ * Gate: master ou gestor comercial (verificado pelo pai — esta componente não
+ * redireciona, só não renderiza sem dados).
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+import { CheckCircle2, XCircle, Clock, Loader2, ImageOff, Camera } from 'lucide-react';
+import { formatDistanceToNow, parseISO } from 'date-fns';
+import { ptBR } from 'date-fns/locale';
+
+import { Card } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Textarea } from '@/components/ui/textarea';
+import { supabase } from '@/integrations/supabase/client';
+import { useProvasParaAuditar, useAuditarTarefa } from '@/hooks/useTarefasFase2';
+import { useSalespeople } from '@/hooks/useCoverage';
+import type { TarefaInstancia } from '@/lib/tarefas/templates-types';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Gera signed URL de 60s para path no bucket tarefa-comprovacoes. */
+async function gerarSignedUrl(path: string): Promise<string | null> {
+  const { data, error } = await supabase.storage
+    .from('tarefa-comprovacoes')
+    .createSignedUrl(path, 60);
+  if (error || !data?.signedUrl) return null;
+  return data.signedUrl;
+}
+
+/** Exibe a distância do timestamp em pt-BR. Ex.: "há 2 dias" */
+function idadeTexto(iso: string | null | undefined): string {
+  if (!iso) return '';
+  try {
+    return formatDistanceToNow(parseISO(iso), { addSuffix: true, locale: ptBR });
+  } catch {
+    return '';
+  }
+}
+
+/** Determina a prova mais antiga para o badge de backlog. */
+function maisAntiga(provas: TarefaInstancia[]): TarefaInstancia | null {
+  return (
+    provas.reduce<TarefaInstancia | null>((acc, p) => {
+      if (!p.comprovacao_em) return acc;
+      if (!acc || !acc.comprovacao_em) return p;
+      return p.comprovacao_em < acc.comprovacao_em ? p : acc;
+    }, null) ?? null
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Sub-componente: thumbnail da foto com signed URL
+// ---------------------------------------------------------------------------
+
+function FotoProva({ path }: { path: string }) {
+  const [url, setUrl] = useState<string | null>(null);
+  const [erro, setErro] = useState(false);
+  const [carregando, setCarregando] = useState(true);
+
+  useEffect(() => {
+    let cancelado = false;
+    gerarSignedUrl(path)
+      .then((u) => {
+        if (!cancelado) {
+          setUrl(u);
+          if (!u) setErro(true);
+        }
+      })
+      .catch(() => {
+        if (!cancelado) setErro(true);
+      })
+      .finally(() => {
+        if (!cancelado) setCarregando(false);
+      });
+    return () => { cancelado = true; };
+  }, [path]);
+
+  if (carregando) {
+    return (
+      <div className="w-20 h-20 rounded-md border border-border bg-muted flex items-center justify-center shrink-0">
+        <Loader2 className="w-4 h-4 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (erro || !url) {
+    return (
+      <div className="w-20 h-20 rounded-md border border-border bg-muted flex flex-col items-center justify-center shrink-0 gap-1">
+        <ImageOff className="w-5 h-5 text-muted-foreground" />
+        <span className="text-2xs text-muted-foreground">Indisponível</span>
+      </div>
+    );
+  }
+
+  return (
+    <a href={url} target="_blank" rel="noopener noreferrer" className="shrink-0">
+      <img
+        src={url}
+        alt="Comprovação"
+        className="w-20 h-20 rounded-md border border-border object-cover hover:opacity-90 transition-opacity"
+      />
+    </a>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Sub-componente: controles de auditoria de um item
+// ---------------------------------------------------------------------------
+
+interface ControlesAuditoriaProps {
+  prova: TarefaInstancia;
+  auditarTarefa: (id: string, aprovar: boolean, motivo: string) => Promise<void>;
+}
+
+function ControlesAuditoria({ prova, auditarTarefa }: ControlesAuditoriaProps) {
+  const [reprovar, setReprovar] = useState(false);
+  const [motivo, setMotivo] = useState('');
+  const [salvando, setSalvando] = useState(false);
+
+  const handleAprovar = async () => {
+    setSalvando(true);
+    try {
+      await auditarTarefa(prova.id, true, '');
+    } finally {
+      setSalvando(false);
+    }
+  };
+
+  const handleReprovarConfirmar = async () => {
+    if (!motivo.trim()) return;
+    setSalvando(true);
+    try {
+      await auditarTarefa(prova.id, false, motivo.trim());
+    } finally {
+      setSalvando(false);
+      setReprovar(false);
+      setMotivo('');
+    }
+  };
+
+  if (reprovar) {
+    return (
+      <div className="space-y-2 mt-2">
+        <Textarea
+          placeholder="Motivo da reprovação…"
+          value={motivo}
+          onChange={(e) => setMotivo(e.target.value)}
+          rows={2}
+          className="text-sm"
+          disabled={salvando}
+          autoFocus
+        />
+        <div className="flex items-center gap-2">
+          <Button
+            size="sm"
+            variant="destructive"
+            disabled={!motivo.trim() || salvando}
+            onClick={handleReprovarConfirmar}
+          >
+            {salvando ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : 'Confirmar reprovação'}
+          </Button>
+          <Button
+            size="sm"
+            variant="ghost"
+            disabled={salvando}
+            onClick={() => { setReprovar(false); setMotivo(''); }}
+          >
+            Cancelar
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-2 mt-2">
+      <Button
+        size="sm"
+        variant="outline"
+        className="text-status-success border-status-success/40 hover:bg-status-success-bg"
+        disabled={salvando}
+        onClick={handleAprovar}
+      >
+        {salvando ? (
+          <Loader2 className="w-3.5 h-3.5 animate-spin" />
+        ) : (
+          <>
+            <CheckCircle2 className="w-3.5 h-3.5 mr-1" />
+            Aprovar
+          </>
+        )}
+      </Button>
+      <Button
+        size="sm"
+        variant="outline"
+        className="text-status-error border-status-error/40 hover:bg-status-error-bg"
+        disabled={salvando}
+        onClick={() => setReprovar(true)}
+      >
+        <XCircle className="w-3.5 h-3.5 mr-1" />
+        Reprovar
+      </Button>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Componente principal
+// ---------------------------------------------------------------------------
+
+export function ProvasParaAuditar() {
+  const { data: provas = [], isLoading } = useProvasParaAuditar();
+  const { auditarTarefa } = useAuditarTarefa();
+  const { data: salespeople = [] } = useSalespeople();
+
+  const resolverNome = useCallback(
+    (userId: string) => salespeople.find((s) => s.user_id === userId)?.name ?? userId.slice(0, 8),
+    [salespeople],
+  );
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center gap-2 text-sm text-muted-foreground py-4">
+        <Loader2 className="w-4 h-4 animate-spin" />
+        Carregando provas…
+      </div>
+    );
+  }
+
+  if (provas.length === 0) {
+    return (
+      <div className="rounded-lg border border-dashed border-border p-6 text-center">
+        <Camera className="w-8 h-8 text-muted-foreground mx-auto mb-2" />
+        <p className="text-sm font-medium">Nenhuma prova aguardando auditoria</p>
+        <p className="text-xs text-muted-foreground mt-1">
+          Quando uma tarefa for concluída com comprovação e sorteada para auditoria, ela aparece aqui.
+        </p>
+      </div>
+    );
+  }
+
+  // Badge de backlog
+  const antiga = maisAntiga(provas);
+  const idadeAntiga = antiga?.comprovacao_em ? idadeTexto(antiga.comprovacao_em) : null;
+
+  return (
+    <div className="space-y-3">
+      {/* Cabeçalho com contagem + idade */}
+      <div className="flex items-center gap-2">
+        <Clock className="w-4 h-4 text-status-warning" />
+        <span className="text-sm font-medium">
+          {provas.length} {provas.length === 1 ? 'prova aguardando' : 'provas aguardando'}
+        </span>
+        {idadeAntiga && (
+          <span className="text-xs text-muted-foreground">· mais antiga {idadeAntiga}</span>
+        )}
+      </div>
+
+      {/* Lista de provas */}
+      <ul className="space-y-3">
+        {provas.map((prova) => {
+          const temFoto = !!prova.comprovacao_url;
+          const temLeitura = prova.comprovacao_leitura != null;
+
+          return (
+            <li key={prova.id}>
+              <Card className="p-3">
+                <div className="flex items-start gap-3">
+                  {/* Foto (se houver) */}
+                  {temFoto && prova.comprovacao_url && (
+                    <FotoProva path={prova.comprovacao_url} />
+                  )}
+
+                  {/* Informações da prova */}
+                  <div className="min-w-0 flex-1">
+                    <p className="text-sm font-medium leading-snug">{prova.descricao}</p>
+                    <p className="text-xs text-muted-foreground mt-0.5">
+                      {resolverNome(prova.assigned_to)}
+                      {prova.comprovacao_em && (
+                        <span className="ml-1">· enviada {idadeTexto(prova.comprovacao_em)}</span>
+                      )}
+                    </p>
+
+                    {/* Leitura numérica */}
+                    {temLeitura && (
+                      <div className="mt-1.5 flex items-center gap-1.5">
+                        <Badge variant="outline" className="text-xs font-mono">
+                          {prova.comprovacao_leitura?.toLocaleString('pt-BR')}
+                          {prova.tipo_comprovacao?.includes('leitura') && ''}
+                        </Badge>
+                        <span className="text-xs text-muted-foreground">leitura</span>
+                      </div>
+                    )}
+
+                    {/* Tipo de comprovação */}
+                    {!temFoto && !temLeitura && (
+                      <p className="text-xs text-muted-foreground mt-1 italic">
+                        Sem foto nem leitura registrados
+                      </p>
+                    )}
+                  </div>
+                </div>
+
+                {/* Botões de auditoria */}
+                <ControlesAuditoria prova={prova} auditarTarefa={auditarTarefa} />
+              </Card>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/src/components/tarefas/RecorrentesHojeCard.tsx
+++ b/src/components/tarefas/RecorrentesHojeCard.tsx
@@ -1,0 +1,165 @@
+/**
+ * RecorrentesHojeCard — card das tarefas recorrentes do operador (Fase 2, Task 8).
+ *
+ * Exibe as instâncias materializadas hoje (template_id not null) para o operador
+ * logado. Espelha o visual do MinhasTarefasCard da Fase 1.
+ *
+ * Concluir:
+ *   - COM comprovação (requer_comprovacao=true) → abre ComprovacaoDialog
+ *     → concluirComComprovacao (RPC SECURITY DEFINER)
+ *   - SEM comprovação → concluir('manual') — update direto, mesma rota da Fase 1;
+ *     o trigger anti-bypass não bloqueia pois requer_comprovacao=false.
+ *
+ * Os limites de leitura (leituraMin/Max/Unidade) que o ComprovacaoDialog exige
+ * não estão na TarefaInstancia (a view não expõe os campos do template pai).
+ * Solução: buscar o template pelo template_id apenas quando o dialog é aberto
+ * (lazy — evita N+1 na listagem). Se não encontrar, passa null (o dialog aceita).
+ */
+
+import { useState } from 'react';
+import { AlertTriangle, CheckCircle2, Clock, Loader2 } from 'lucide-react';
+import { Card } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { useMinhasRecorrentesHoje } from '@/hooks/useTarefasFase2';
+import { useTemplates } from '@/hooks/useTarefasFase2';
+import { useTarefaMutations } from '@/hooks/useTarefas';
+import { useImpersonation } from '@/contexts/ImpersonationContext';
+import { ComprovacaoDialog } from './ComprovacaoDialog';
+import type { TarefaInstancia, TarefaTemplate } from '@/lib/tarefas/templates-types';
+
+export function RecorrentesHojeCard() {
+  const { isImpersonating } = useImpersonation();
+  const { data: tarefas = [], isLoading } = useMinhasRecorrentesHoje();
+  const { data: templates = [] } = useTemplates();
+  const { concluir } = useTarefaMutations();
+
+  // Dialog de comprovação
+  const [dialogAlvo, setDialogAlvo] = useState<TarefaInstancia | null>(null);
+
+  // Estado de loading por tarefa (conclusão direta sem prova)
+  const [concluidoPor, setConcluidoPor] = useState<string | null>(null);
+
+  // Retorna null quando não há tarefas (não polui o dashboard)
+  if (isLoading || tarefas.length === 0) return null;
+
+  // ---------------------------------------------------------------------------
+  // Resolução dos limites de leitura do template (lazy, só quando dialog abre)
+  // ---------------------------------------------------------------------------
+
+  const templatePorId = new Map<string, TarefaTemplate>(
+    templates.map((t) => [t.id, t]),
+  );
+
+  const templateDoAlvo = dialogAlvo?.template_id
+    ? templatePorId.get(dialogAlvo.template_id) ?? null
+    : null;
+
+  // ---------------------------------------------------------------------------
+  // Handlers
+  // ---------------------------------------------------------------------------
+
+  const handleConcluir = async (tarefa: TarefaInstancia) => {
+    if (tarefa.requer_comprovacao) {
+      // Abre o dialog; a conclusão real acontece lá dentro
+      setDialogAlvo(tarefa);
+      return;
+    }
+
+    // Sem comprovação: conclusão direta (mesma rota do MinhasTarefasCard)
+    setConcluidoPor(tarefa.id);
+    try {
+      await concluir(tarefa.id, 'manual');
+    } finally {
+      setConcluidoPor(null);
+    }
+  };
+
+  // ---------------------------------------------------------------------------
+  // Render
+  // ---------------------------------------------------------------------------
+
+  return (
+    <>
+      <Card className="p-4 border-status-info/40">
+        <div className="flex items-center gap-2 mb-3">
+          <Clock className="w-4 h-4 text-status-info" />
+          <h2 className="font-display text-lg">Tarefas de hoje</h2>
+          <span className="text-2xs text-muted-foreground">{tarefas.length}</span>
+          {isImpersonating && (
+            <span className="ml-auto text-2xs text-muted-foreground">
+              Somente leitura (Ver como)
+            </span>
+          )}
+        </div>
+
+        <ul className="space-y-2">
+          {tarefas.map((t) => {
+            const atrasada = t.atrasada;
+            const estaConcluidoPor = concluidoPor === t.id;
+
+            return (
+              <li
+                key={t.id}
+                className={
+                  `rounded-md border p-3 ` +
+                  (atrasada
+                    ? 'border-status-error/40 bg-status-error-bg'
+                    : 'border-border')
+                }
+              >
+                <div className="flex items-start justify-between gap-2">
+                  <div className="min-w-0">
+                    <p className="text-sm font-medium leading-snug">{t.descricao}</p>
+                    <p className="text-2xs text-muted-foreground mt-0.5">
+                      {atrasada && (
+                        <AlertTriangle className="inline w-3 h-3 text-status-error mr-1" />
+                      )}
+                      {t.categoria}
+                      {t.janela_fim && (
+                        <span className="ml-1">
+                          · até {t.janela_fim.slice(0, 5)}
+                        </span>
+                      )}
+                      {t.requer_comprovacao && (
+                        <span className="ml-1 text-muted-foreground/70">· prova exigida</span>
+                      )}
+                    </p>
+                  </div>
+
+                  <Button
+                    size="sm"
+                    variant={atrasada ? 'destructive' : 'outline'}
+                    disabled={isImpersonating || estaConcluidoPor}
+                    onClick={() => handleConcluir(t)}
+                    className="shrink-0"
+                  >
+                    {estaConcluidoPor ? (
+                      <Loader2 className="w-3 h-3 animate-spin" />
+                    ) : (
+                      <>
+                        <CheckCircle2 className="w-3 h-3 mr-1" />
+                        Concluir
+                      </>
+                    )}
+                  </Button>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      </Card>
+
+      {/* Dialog de comprovação — montado fora da lista pra não re-renderizar */}
+      {dialogAlvo && (
+        <ComprovacaoDialog
+          open={!!dialogAlvo}
+          onOpenChange={(o) => { if (!o) setDialogAlvo(null); }}
+          tarefa={dialogAlvo}
+          leituraMin={templateDoAlvo?.leitura_min ?? null}
+          leituraMax={templateDoAlvo?.leitura_max ?? null}
+          leituraUnidade={templateDoAlvo?.leitura_unidade ?? null}
+        />
+      )}
+    </>
+  );
+}

--- a/src/hooks/useTarefasFase2.ts
+++ b/src/hooks/useTarefasFase2.ts
@@ -1,0 +1,236 @@
+/**
+ * Hooks da Fase 2 das Tarefas (enforcement: recorrência + trava de comprovação).
+ *
+ * Padrão: mesmo estilo de `useTarefas.ts`:
+ *   - supabase.from('tabela' as never) as any — tabelas ainda não estão nos tipos gerados
+ *   - supabase.rpc('fn' as never, {...} as never) — RPCs idem
+ *   - toast de sonner + track de analytics + invalidação de query
+ */
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import { useAuth } from '@/contexts/AuthContext';
+import { useImpersonation } from '@/contexts/ImpersonationContext';
+import { toast } from 'sonner';
+import { track } from '@/lib/analytics';
+import type { TarefaTemplate, TarefaInstancia } from '@/lib/tarefas/templates-types';
+
+// ---------------------------------------------------------------------------
+// Helpers de acesso (casts necessários até os tipos gerados serem regenerados)
+// ---------------------------------------------------------------------------
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const selView = () => (supabase.from('v_tarefas_estado' as never) as any);
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const selTemplates = () => (supabase.from('tarefa_templates' as never) as any);
+
+// Chaves de query compartilhadas com useTarefas para invalidação cruzada
+const QUERY_KEYS = {
+  templates: 'tarefa-templates',
+  minhasRecorrentes: 'tarefas-recorrentes-hoje',
+  provasAuditar: 'tarefas-provas-auditar',
+  // Chaves da Fase 1 que invalidamos quando concluímos / auditamos
+  minhasTarefas: 'minhas-tarefas',
+  tarefasQueCriei: 'tarefas-que-criei',
+  badgeCount: 'tarefas-badge-count',
+} as const;
+
+// ---------------------------------------------------------------------------
+// useTemplates — lista templates (RLS já filtra: gestor vê todos, operador vê os seus)
+// ---------------------------------------------------------------------------
+
+export function useTemplates() {
+  const { user } = useAuth();
+  return useQuery({
+    queryKey: [QUERY_KEYS.templates, user?.id],
+    enabled: !!user,
+    staleTime: 60_000,
+    queryFn: async (): Promise<TarefaTemplate[]> => {
+      const { data, error } = await selTemplates()
+        .select('*')
+        .order('ativo', { ascending: false })
+        .order('descricao', { ascending: true });
+      if (error) throw error;
+      return (data ?? []) as TarefaTemplate[];
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// useTemplateMutations — CRUD de templates (gestor/master)
+// ---------------------------------------------------------------------------
+
+export function useTemplateMutations() {
+  const qc = useQueryClient();
+  const { user } = useAuth();
+
+  const invalidate = () => {
+    qc.invalidateQueries({ queryKey: [QUERY_KEYS.templates] });
+    qc.invalidateQueries({ queryKey: [QUERY_KEYS.minhasRecorrentes] });
+  };
+
+  const criarTemplate = async (row: Omit<TarefaTemplate, 'id' | 'created_at' | 'updated_at'>) => {
+    const { data, error } = await selTemplates()
+      .insert({ ...row, created_by: user!.id } as never)
+      .select('id')
+      .single();
+    if (error) {
+      toast.error('Erro ao criar template', { description: error.message });
+      throw error;
+    }
+    track('tarefas.template_criado', { area: row.area, cadencia: row.cadencia });
+    toast.success('Template criado');
+    invalidate();
+    return (data as { id: string }).id;
+  };
+
+  const editarTemplate = async (id: string, patch: Partial<TarefaTemplate>) => {
+    const { error } = await selTemplates()
+      .update({ ...patch, updated_at: new Date().toISOString() } as never)
+      .eq('id', id);
+    if (error) {
+      toast.error('Erro ao editar template', { description: error.message });
+      throw error;
+    }
+    track('tarefas.template_editado', {});
+    toast.success('Template atualizado');
+    invalidate();
+  };
+
+  const toggleTemplateAtivo = async (id: string, ativo: boolean) => {
+    const { error } = await selTemplates()
+      .update({ ativo, updated_at: new Date().toISOString() } as never)
+      .eq('id', id);
+    if (error) {
+      toast.error(`Erro ao ${ativo ? 'ativar' : 'desativar'} template`, { description: error.message });
+      throw error;
+    }
+    track('tarefas.template_toggle', { ativo });
+    toast.success(ativo ? 'Template ativado' : 'Template desativado');
+    invalidate();
+  };
+
+  return { criarTemplate, editarTemplate, toggleTemplateAtivo };
+}
+
+// ---------------------------------------------------------------------------
+// useMinhasRecorrentesHoje — instâncias do operador logado (or impersonated)
+// Filtra: template_id not null + status aberta + responsavel_efetivo = uid
+// ---------------------------------------------------------------------------
+
+export function useMinhasRecorrentesHoje() {
+  const { user } = useAuth();
+  const { isImpersonating, effectiveUserId } = useImpersonation();
+  const targetId = isImpersonating && effectiveUserId ? effectiveUserId : (user?.id ?? null);
+
+  return useQuery({
+    queryKey: [QUERY_KEYS.minhasRecorrentes, isImpersonating ? `as:${effectiveUserId}` : user?.id],
+    enabled: !!targetId,
+    staleTime: 30_000,
+    refetchInterval: 60_000,
+    refetchIntervalInBackground: false,
+    queryFn: async (): Promise<TarefaInstancia[]> => {
+      const { data, error } = await selView()
+        .select('*')
+        .eq('status', 'aberta')
+        .not('template_id', 'is', null)
+        .order('atrasada', { ascending: false })
+        .order('effective_due', { ascending: true });
+      if (error) throw error;
+      // Filtro client-side de responsavel_efetivo (mesma lógica de useMinhasTarefas)
+      return ((data ?? []) as TarefaInstancia[]).filter(
+        (t) => t.responsavel_efetivo === targetId,
+      );
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// concluirComComprovacao — chama o RPC com url + leitura
+// ---------------------------------------------------------------------------
+
+export function useConcluirComComprovacao() {
+  const qc = useQueryClient();
+
+  const invalidate = () => {
+    qc.invalidateQueries({ queryKey: [QUERY_KEYS.minhasRecorrentes] });
+    qc.invalidateQueries({ queryKey: [QUERY_KEYS.provasAuditar] });
+    qc.invalidateQueries({ queryKey: [QUERY_KEYS.minhasTarefas] });
+    qc.invalidateQueries({ queryKey: [QUERY_KEYS.tarefasQueCriei] });
+    qc.invalidateQueries({ queryKey: [QUERY_KEYS.badgeCount] });
+  };
+
+  const concluirComComprovacao = async (
+    tarefaId: string,
+    url: string | null,
+    leitura: number | null,
+  ) => {
+    const { error } = await supabase.rpc('concluir_com_comprovacao' as never, {
+      p_tarefa_id: tarefaId,
+      p_url: url,
+      p_leitura: leitura,
+    } as never);
+    if (error) {
+      toast.error('Erro ao concluir tarefa', { description: error.message });
+      throw error;
+    }
+    track('tarefas.concluida_comprovacao', { com_leitura: leitura !== null, com_foto: url !== null });
+    toast.success('Tarefa concluída');
+    invalidate();
+  };
+
+  return { concluirComComprovacao };
+}
+
+// ---------------------------------------------------------------------------
+// useProvasParaAuditar — tarefas aguardando auditoria (gestor/master)
+// ---------------------------------------------------------------------------
+
+export function useProvasParaAuditar() {
+  const { user } = useAuth();
+  return useQuery({
+    queryKey: [QUERY_KEYS.provasAuditar, user?.id],
+    enabled: !!user,
+    staleTime: 30_000,
+    refetchInterval: 120_000,
+    refetchIntervalInBackground: false,
+    queryFn: async (): Promise<TarefaInstancia[]> => {
+      const { data, error } = await selView()
+        .select('*')
+        .eq('requer_auditoria', true)
+        .order('comprovacao_em', { ascending: true });
+      if (error) throw error;
+      return (data ?? []) as TarefaInstancia[];
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// useAuditarTarefa — aprovar / reprovar prova (gestor/master)
+// ---------------------------------------------------------------------------
+
+export function useAuditarTarefa() {
+  const qc = useQueryClient();
+
+  const invalidate = () => {
+    qc.invalidateQueries({ queryKey: [QUERY_KEYS.provasAuditar] });
+    qc.invalidateQueries({ queryKey: [QUERY_KEYS.tarefasQueCriei] });
+    qc.invalidateQueries({ queryKey: [QUERY_KEYS.badgeCount] });
+  };
+
+  const auditarTarefa = async (tarefaId: string, aprovar: boolean, motivo: string) => {
+    const { error } = await supabase.rpc('auditar_tarefa' as never, {
+      p_tarefa_id: tarefaId,
+      p_aprovar: aprovar,
+      p_motivo: motivo,
+    } as never);
+    if (error) {
+      toast.error('Erro ao auditar tarefa', { description: error.message });
+      throw error;
+    }
+    track('tarefas.auditada', { aprovar });
+    toast.success(aprovar ? 'Prova aprovada' : 'Prova reprovada — tarefa reaberta');
+    invalidate();
+  };
+
+  return { auditarTarefa };
+}

--- a/src/lib/impersonation/__tests__/no-write-leak.test.ts
+++ b/src/lib/impersonation/__tests__/no-write-leak.test.ts
@@ -21,6 +21,9 @@ const ALLOWED = new Set([
   // useTarefas: effectiveUserId SÓ em useMinhasTarefas (filtra a LEITURA pro alvo no "Ver como");
   // as mutations (criar/concluir/resolverSugestao/adiar/cancelar) usam user.id (o master real), nunca effectiveUserId.
   'src/hooks/useTarefas.ts',
+  // useTarefasFase2: effectiveUserId SÓ em useMinhasRecorrentesHoje (filtro + queryKey de LEITURA, espelha useMinhasTarefas);
+  // writes (criar/editar/toggle template) usam created_by=user.id e as RPCs (concluir_com_comprovacao/auditar_tarefa) usam auth.uid() server-side.
+  'src/hooks/useTarefasFase2.ts',
 ]);
 
 describe('anti write-leak: effectiveUserId só em leitura', () => {

--- a/src/lib/tarefas/__tests__/comprovacao.test.ts
+++ b/src/lib/tarefas/__tests__/comprovacao.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from 'vitest';
+import { validarLeitura, montarPathComprovacao } from '../comprovacao';
+
+// ---------------------------------------------------------------------------
+// validarLeitura
+// ---------------------------------------------------------------------------
+
+describe('validarLeitura', () => {
+  describe('valor ausente', () => {
+    it('null → inválido', () => {
+      const r = validarLeitura(null, null, null);
+      expect(r.ok).toBe(false);
+      expect(r.erro).toBeTruthy();
+    });
+  });
+
+  describe('sem faixa (min e max null)', () => {
+    it('qualquer número positivo → ok', () => {
+      expect(validarLeitura(42, null, null)).toEqual({ ok: true, erro: null });
+    });
+    it('zero → ok', () => {
+      expect(validarLeitura(0, null, null)).toEqual({ ok: true, erro: null });
+    });
+    it('negativo → ok (sem restrição)', () => {
+      expect(validarLeitura(-5, null, null)).toEqual({ ok: true, erro: null });
+    });
+  });
+
+  describe('só min definido', () => {
+    it('valor igual ao min → ok (borda inclusiva)', () => {
+      expect(validarLeitura(5, 5, null)).toEqual({ ok: true, erro: null });
+    });
+    it('valor acima do min → ok', () => {
+      expect(validarLeitura(6, 5, null)).toEqual({ ok: true, erro: null });
+    });
+    it('valor abaixo do min → erro sem mencionar max', () => {
+      const r = validarLeitura(3, 5, null);
+      expect(r.ok).toBe(false);
+      expect(r.erro).toContain('3');
+      expect(r.erro).toContain('5');
+      expect(r.erro).not.toContain('undefined');
+      expect(r.erro).not.toContain('null');
+    });
+  });
+
+  describe('só max definido', () => {
+    it('valor igual ao max → ok (borda inclusiva)', () => {
+      expect(validarLeitura(10, null, 10)).toEqual({ ok: true, erro: null });
+    });
+    it('valor abaixo do max → ok', () => {
+      expect(validarLeitura(9, null, 10)).toEqual({ ok: true, erro: null });
+    });
+    it('valor acima do max → erro sem mencionar min', () => {
+      const r = validarLeitura(11, null, 10);
+      expect(r.ok).toBe(false);
+      expect(r.erro).toContain('11');
+      expect(r.erro).toContain('10');
+      expect(r.erro).not.toContain('undefined');
+      expect(r.erro).not.toContain('null');
+    });
+  });
+
+  describe('faixa completa [min, max]', () => {
+    it('dentro da faixa → ok', () => {
+      expect(validarLeitura(7, 5, 10)).toEqual({ ok: true, erro: null });
+    });
+    it('no min → ok', () => {
+      expect(validarLeitura(5, 5, 10)).toEqual({ ok: true, erro: null });
+    });
+    it('no max → ok', () => {
+      expect(validarLeitura(10, 5, 10)).toEqual({ ok: true, erro: null });
+    });
+    it('abaixo do min → erro menciona faixa', () => {
+      const r = validarLeitura(3, 5, 10);
+      expect(r.ok).toBe(false);
+      expect(r.erro).toContain('5');
+      expect(r.erro).toContain('10');
+    });
+    it('acima do max → erro menciona faixa', () => {
+      const r = validarLeitura(15, 5, 10);
+      expect(r.ok).toBe(false);
+      expect(r.erro).toContain('5');
+      expect(r.erro).toContain('10');
+    });
+    it('faixa de ponto (min === max): valor exato → ok', () => {
+      expect(validarLeitura(7, 7, 7)).toEqual({ ok: true, erro: null });
+    });
+    it('faixa de ponto (min === max): valor diferente → erro', () => {
+      const r = validarLeitura(7.1, 7, 7);
+      expect(r.ok).toBe(false);
+    });
+  });
+
+  describe('decimais', () => {
+    it('valor decimal dentro da faixa → ok', () => {
+      expect(validarLeitura(5.5, 5.0, 6.0)).toEqual({ ok: true, erro: null });
+    });
+    it('valor decimal abaixo → erro', () => {
+      expect(validarLeitura(4.99, 5.0, 6.0).ok).toBe(false);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// montarPathComprovacao
+// ---------------------------------------------------------------------------
+
+describe('montarPathComprovacao', () => {
+  const UID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+  const TAREFA_ID = '11111111-2222-3333-4444-555555555555';
+  const TS = 1717200000000;
+
+  it('formato correto: uid/tarefaId/ts.ext', () => {
+    expect(montarPathComprovacao(UID, TAREFA_ID, 'jpg', TS))
+      .toBe(`${UID}/${TAREFA_ID}/${TS}.jpg`);
+  });
+
+  it('inicia exatamente com uid/tarefaId (requisito do RPC)', () => {
+    const path = montarPathComprovacao(UID, TAREFA_ID, 'png', TS);
+    expect(path.startsWith(`${UID}/${TAREFA_ID}/`)).toBe(true);
+  });
+
+  it('extensão png preservada', () => {
+    const path = montarPathComprovacao(UID, TAREFA_ID, 'png', TS);
+    expect(path.endsWith('.png')).toBe(true);
+  });
+
+  it('extensão heic preservada', () => {
+    const path = montarPathComprovacao(UID, TAREFA_ID, 'heic', TS);
+    expect(path.endsWith('.heic')).toBe(true);
+  });
+
+  it('timestamps distintos geram paths distintos', () => {
+    const p1 = montarPathComprovacao(UID, TAREFA_ID, 'jpg', 1000);
+    const p2 = montarPathComprovacao(UID, TAREFA_ID, 'jpg', 2000);
+    expect(p1).not.toBe(p2);
+  });
+
+  it('usuários distintos geram paths distintos', () => {
+    const p1 = montarPathComprovacao('user-a', TAREFA_ID, 'jpg', TS);
+    const p2 = montarPathComprovacao('user-b', TAREFA_ID, 'jpg', TS);
+    expect(p1).not.toBe(p2);
+  });
+
+  it('tarefas distintas geram paths distintos', () => {
+    const p1 = montarPathComprovacao(UID, 'tarefa-x', 'jpg', TS);
+    const p2 = montarPathComprovacao(UID, 'tarefa-y', 'jpg', TS);
+    expect(p1).not.toBe(p2);
+  });
+});

--- a/src/lib/tarefas/comprovacao.ts
+++ b/src/lib/tarefas/comprovacao.ts
@@ -1,0 +1,78 @@
+/**
+ * Helpers puros para o fluxo de comprovação de tarefas (Fase 2).
+ *
+ * São espelhos client-side das validações que o RPC `concluir_com_comprovacao`
+ * já faz no banco — permitem feedback imediato antes de chamar o servidor.
+ * Sem efeitos colaterais; totalmente testáveis.
+ */
+
+// ---------------------------------------------------------------------------
+// validarLeitura
+// ---------------------------------------------------------------------------
+
+export interface ValidacaoLeitura {
+  ok: boolean;
+  erro: string | null;
+}
+
+/**
+ * Valida se `valor` está dentro da faixa `[min, max]`.
+ *
+ * Regras:
+ * - `valor === null` → inválido (leitura obrigatória quando chamado)
+ * - `min` e/ou `max` ausentes → sem restrição naquele lado
+ * - Fora da faixa → retorna mensagem descritiva
+ */
+export function validarLeitura(
+  valor: number | null,
+  min: number | null,
+  max: number | null,
+): ValidacaoLeitura {
+  if (valor === null || valor === undefined) {
+    return { ok: false, erro: 'Informe o valor da leitura' };
+  }
+  if (min !== null && valor < min) {
+    return {
+      ok: false,
+      erro: max !== null
+        ? `Valor ${valor} abaixo do mínimo ${min} (faixa: ${min}–${max})`
+        : `Valor ${valor} abaixo do mínimo ${min}`,
+    };
+  }
+  if (max !== null && valor > max) {
+    return {
+      ok: false,
+      erro: min !== null
+        ? `Valor ${valor} acima do máximo ${max} (faixa: ${min}–${max})`
+        : `Valor ${valor} acima do máximo ${max}`,
+    };
+  }
+  return { ok: true, erro: null };
+}
+
+// ---------------------------------------------------------------------------
+// montarPathComprovacao
+// ---------------------------------------------------------------------------
+
+/**
+ * Monta o path do arquivo no bucket `tarefa-comprovacoes`.
+ *
+ * Formato: `{uid}/{tarefaId}/{ts}.{ext}`
+ *
+ * O RPC verifica que a URL contém `{uid}/{tarefaId}` → manter exatamente esse
+ * prefixo. O parâmetro `ts` é aceito explicitamente para facilitar testes;
+ * o caller passa `Date.now()`.
+ *
+ * @param uid       UUID do usuário autenticado (auth.uid())
+ * @param tarefaId  UUID da tarefa
+ * @param ext       Extensão do arquivo sem ponto (ex: 'jpg', 'png')
+ * @param ts        Timestamp em ms (use Date.now() na produção)
+ */
+export function montarPathComprovacao(
+  uid: string,
+  tarefaId: string,
+  ext: string,
+  ts: number,
+): string {
+  return `${uid}/${tarefaId}/${ts}.${ext}`;
+}

--- a/src/lib/tarefas/templates-types.ts
+++ b/src/lib/tarefas/templates-types.ts
@@ -1,0 +1,70 @@
+import type { TarefaCategoria, TarefaEstado } from './types';
+
+// ---------------------------------------------------------------------------
+// Cadência / comprovação — tipos literais
+// ---------------------------------------------------------------------------
+export type TarefaTemplateCadencia = 'diaria' | 'dias_uteis' | 'semanal' | 'dias_especificos';
+export type TarefaTipoComprovacao = 'nenhuma' | 'foto' | 'leitura' | 'foto_e_leitura';
+export type TarefaAuditoriaStatus =
+  | 'nao_requer'
+  | 'dispensada'
+  | 'pendente'
+  | 'aprovada'
+  | 'reprovada';
+
+// ---------------------------------------------------------------------------
+// TarefaTemplate — espelha `tarefa_templates` no banco
+// ---------------------------------------------------------------------------
+export interface TarefaTemplate {
+  id: string;
+  descricao: string;
+  categoria: TarefaCategoria;
+  area: string;
+  empresa: string;
+  assigned_to: string;
+  customer_user_id: string | null;
+  cadencia: TarefaTemplateCadencia;
+  /** 0 = domingo … 6 = sábado */
+  dias_semana: number[] | null;
+  /** HH:MM:SS (time do Postgres) */
+  janela_inicio: string | null;
+  janela_fim: string | null;
+  tolerancia_dias: number;
+  requer_comprovacao: boolean;
+  tipo_comprovacao: TarefaTipoComprovacao;
+  leitura_min: number | null;
+  leitura_max: number | null;
+  leitura_unidade: string | null;
+  alto_risco: boolean;
+  /** 0–100 */
+  amostra_auditoria_pct: number;
+  reincidente_limite: number;
+  supervisor_user_id: string | null;
+  ativo: boolean;
+  created_by: string;
+  created_at: string;
+  updated_at: string;
+}
+
+// ---------------------------------------------------------------------------
+// TarefaInstancia — estende TarefaEstado com campos novos da Fase 2
+//
+// Os campos abaixo são retornados por v_tarefas_estado após o BLOCO B/C
+// do Milestone 1. Campos da Fase 1 já estão em TarefaEstado.
+// ---------------------------------------------------------------------------
+export interface TarefaInstancia extends TarefaEstado {
+  /** Derivado da view: `auditoria_status = 'pendente'` */
+  requer_auditoria: boolean;
+  auditoria_status: TarefaAuditoriaStatus;
+  auditoria_motivo: string | null;
+  tipo_comprovacao: TarefaTipoComprovacao | null;
+  /** Leitura numérica anexada na conclusão */
+  comprovacao_leitura: number | null;
+  /** Timestamptz de quando a prova foi enviada */
+  comprovacao_em: string | null;
+  /** URL assinada (ou path) da foto no bucket tarefa-comprovacoes */
+  comprovacao_url: string | null;
+  /** Janela de prazo intradiária (HH:MM:SS) */
+  janela_fim: string | null;
+  supervisor_user_id: string | null;
+}

--- a/src/lib/tarefas/templates-types.ts
+++ b/src/lib/tarefas/templates-types.ts
@@ -53,6 +53,10 @@ export interface TarefaTemplate {
 // do Milestone 1. Campos da Fase 1 já estão em TarefaEstado.
 // ---------------------------------------------------------------------------
 export interface TarefaInstancia extends TarefaEstado {
+  /** UUID do template de origem (null para tarefas manuais). */
+  template_id: string | null;
+  /** Copiado do template na materialização; false para tarefas manuais. */
+  requer_comprovacao: boolean;
   /** Derivado da view: `auditoria_status = 'pendente'` */
   requer_auditoria: boolean;
   auditoria_status: TarefaAuditoriaStatus;

--- a/src/pages/TarefasTemplates.tsx
+++ b/src/pages/TarefasTemplates.tsx
@@ -1,0 +1,853 @@
+/**
+ * TarefasTemplates — CRUD de templates de tarefas recorrentes + auditoria de provas.
+ *
+ * Gated: isMaster || isGestorComercial.
+ *
+ * Estrutura:
+ *   - Aba "Templates": lista dos templates com toggle ativo/inativo + botão Editar.
+ *     Botão "Novo template" abre o dialog de criação.
+ *   - Aba "Provas pendentes": lista do ProvasParaAuditar.
+ *
+ * Validação client-side de alto_risco:
+ *   - alto_risco + requer_comprovacao → tipo_comprovacao DEVE ser 'foto_e_leitura'
+ *     (o CHECK do banco `tt_altorisco_foto_chk` rejeita no INSERT/UPDATE;
+ *     validamos aqui para exibir uma mensagem clara em vez de "database error").
+ */
+
+import { useState, useEffect } from 'react';
+import { Navigate } from 'react-router-dom';
+import { PlusCircle, Pencil, ToggleLeft, ToggleRight, ChevronDown, Loader2 } from 'lucide-react';
+
+import { useAuth } from '@/contexts/AuthContext';
+import { useTemplates, useTemplateMutations } from '@/hooks/useTarefasFase2';
+import { useSalespeople } from '@/hooks/useCoverage';
+import { ProvasParaAuditar } from '@/components/tarefas/ProvasParaAuditar';
+
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Card } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Switch } from '@/components/ui/switch';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Checkbox } from '@/components/ui/checkbox';
+
+import type { TarefaTemplate, TarefaTemplateCadencia, TarefaTipoComprovacao } from '@/lib/tarefas/templates-types';
+import type { TarefaCategoria } from '@/lib/tarefas/types';
+
+// ---------------------------------------------------------------------------
+// Tipos locais
+// ---------------------------------------------------------------------------
+
+/** Dados do formulário (tudo string pra bind fácil; coergimos na submissão). */
+interface FormValues {
+  descricao: string;
+  categoria: TarefaCategoria;
+  area: string;
+  empresa: string;
+  assigned_to: string;
+  cadencia: TarefaTemplateCadencia;
+  dias_semana: number[];
+  janela_inicio: string;
+  janela_fim: string;
+  tolerancia_dias: string;
+  requer_comprovacao: boolean;
+  tipo_comprovacao: TarefaTipoComprovacao;
+  leitura_min: string;
+  leitura_max: string;
+  leitura_unidade: string;
+  alto_risco: boolean;
+  amostra_auditoria_pct: string;
+  reincidente_limite: string;
+  supervisor_user_id: string;
+  ativo: boolean;
+}
+
+const FORM_VAZIO: FormValues = {
+  descricao: '',
+  categoria: 'outro',
+  area: '',
+  empresa: 'oben',
+  assigned_to: '',
+  cadencia: 'diaria',
+  dias_semana: [],
+  janela_inicio: '',
+  janela_fim: '',
+  tolerancia_dias: '0',
+  requer_comprovacao: false,
+  tipo_comprovacao: 'nenhuma',
+  leitura_min: '',
+  leitura_max: '',
+  leitura_unidade: '',
+  alto_risco: false,
+  amostra_auditoria_pct: '10',
+  reincidente_limite: '3',
+  supervisor_user_id: '',
+  ativo: true,
+};
+
+// Dias da semana (0 = dom, 6 = sáb)
+const DIAS_SEMANA = [
+  { val: 0, label: 'Dom' },
+  { val: 1, label: 'Seg' },
+  { val: 2, label: 'Ter' },
+  { val: 3, label: 'Qua' },
+  { val: 4, label: 'Qui' },
+  { val: 5, label: 'Sex' },
+  { val: 6, label: 'Sáb' },
+];
+
+const CATEGORIAS: { val: TarefaCategoria; label: string }[] = [
+  { val: 'ligar', label: 'Ligar' },
+  { val: 'oferecer', label: 'Oferecer' },
+  { val: 'preco', label: 'Preço' },
+  { val: 'whatsapp', label: 'WhatsApp' },
+  { val: 'outro', label: 'Outro' },
+];
+
+const CADENCIAS: { val: TarefaTemplateCadencia; label: string }[] = [
+  { val: 'diaria', label: 'Diária (todos os dias)' },
+  { val: 'dias_uteis', label: 'Dias úteis (seg–sex)' },
+  { val: 'semanal', label: 'Semanal (escolher dia)' },
+  { val: 'dias_especificos', label: 'Dias específicos' },
+];
+
+const TIPOS_COMPROVACAO: { val: TarefaTipoComprovacao; label: string }[] = [
+  { val: 'nenhuma', label: 'Nenhuma' },
+  { val: 'foto', label: 'Foto' },
+  { val: 'leitura', label: 'Leitura numérica' },
+  { val: 'foto_e_leitura', label: 'Foto + leitura' },
+];
+
+// ---------------------------------------------------------------------------
+// Helpers de conversão
+// ---------------------------------------------------------------------------
+
+function templateParaForm(t: TarefaTemplate): FormValues {
+  return {
+    descricao: t.descricao,
+    categoria: t.categoria,
+    area: t.area,
+    empresa: t.empresa,
+    assigned_to: t.assigned_to,
+    cadencia: t.cadencia,
+    dias_semana: t.dias_semana ?? [],
+    janela_inicio: t.janela_inicio?.slice(0, 5) ?? '',
+    janela_fim: t.janela_fim?.slice(0, 5) ?? '',
+    tolerancia_dias: String(t.tolerancia_dias),
+    requer_comprovacao: t.requer_comprovacao,
+    tipo_comprovacao: t.tipo_comprovacao,
+    leitura_min: t.leitura_min != null ? String(t.leitura_min) : '',
+    leitura_max: t.leitura_max != null ? String(t.leitura_max) : '',
+    leitura_unidade: t.leitura_unidade ?? '',
+    alto_risco: t.alto_risco,
+    amostra_auditoria_pct: String(t.amostra_auditoria_pct),
+    reincidente_limite: String(t.reincidente_limite),
+    supervisor_user_id: t.supervisor_user_id ?? '',
+    ativo: t.ativo,
+  };
+}
+
+function formParaPayload(
+  f: FormValues,
+  userId: string,
+): Omit<TarefaTemplate, 'id' | 'created_at' | 'updated_at'> {
+  return {
+    descricao: f.descricao.trim(),
+    categoria: f.categoria,
+    area: f.area.trim(),
+    empresa: f.empresa,
+    assigned_to: f.assigned_to,
+    customer_user_id: null,
+    cadencia: f.cadencia,
+    dias_semana: ['semanal', 'dias_especificos'].includes(f.cadencia) ? f.dias_semana : null,
+    janela_inicio: f.janela_inicio || null,
+    janela_fim: f.janela_fim || null,
+    tolerancia_dias: Math.max(0, parseInt(f.tolerancia_dias, 10) || 0),
+    requer_comprovacao: f.requer_comprovacao,
+    tipo_comprovacao: f.requer_comprovacao ? f.tipo_comprovacao : 'nenhuma',
+    leitura_min: f.leitura_min.trim() !== '' ? parseFloat(f.leitura_min) : null,
+    leitura_max: f.leitura_max.trim() !== '' ? parseFloat(f.leitura_max) : null,
+    leitura_unidade: f.leitura_unidade.trim() || null,
+    alto_risco: f.alto_risco,
+    amostra_auditoria_pct: Math.min(100, Math.max(0, parseInt(f.amostra_auditoria_pct, 10) || 10)),
+    reincidente_limite: Math.max(1, parseInt(f.reincidente_limite, 10) || 3),
+    supervisor_user_id: f.supervisor_user_id || null,
+    ativo: f.ativo,
+    created_by: userId,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Validação client-side
+// ---------------------------------------------------------------------------
+
+function validarForm(f: FormValues): string | null {
+  if (!f.descricao.trim()) return 'Descrição é obrigatória.';
+  if (!f.area.trim()) return 'Área é obrigatória.';
+  if (!f.assigned_to) return 'Selecione a vendedora responsável.';
+
+  if (['semanal', 'dias_especificos'].includes(f.cadencia) && f.dias_semana.length === 0) {
+    return 'Selecione pelo menos um dia da semana.';
+  }
+
+  if (f.janela_inicio && f.janela_fim && f.janela_inicio >= f.janela_fim) {
+    return 'Janela de início deve ser antes da janela de fim.';
+  }
+
+  if (f.requer_comprovacao && f.tipo_comprovacao === 'nenhuma') {
+    return 'Selecione o tipo de comprovação quando "Exigir comprovação" está ativo.';
+  }
+
+  // CHECK do banco: alto_risco + requer_comprovacao → tipo_comprovacao = 'foto_e_leitura'
+  if (f.alto_risco && f.requer_comprovacao && f.tipo_comprovacao !== 'foto_e_leitura') {
+    return 'Tarefa de alto risco com comprovação exige o tipo "Foto + leitura".';
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Dialog de criação/edição
+// ---------------------------------------------------------------------------
+
+interface TemplateDialogProps {
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+  templateEditando: TarefaTemplate | null;
+}
+
+function TemplateDialog({ open, onOpenChange, templateEditando }: TemplateDialogProps) {
+  const { user } = useAuth();
+  const { criarTemplate, editarTemplate } = useTemplateMutations();
+  const { data: salespeople = [] } = useSalespeople();
+
+  const [form, setForm] = useState<FormValues>(FORM_VAZIO);
+  const [erro, setErro] = useState<string | null>(null);
+  const [salvando, setSalvando] = useState(false);
+  const [mostraAvancado, setMostraAvancado] = useState(false);
+
+  // Preenche o form ao editar
+  useEffect(() => {
+    if (templateEditando) {
+      setForm(templateParaForm(templateEditando));
+    } else {
+      setForm(FORM_VAZIO);
+    }
+    setErro(null);
+    setMostraAvancado(false);
+  }, [templateEditando, open]);
+
+  const set = <K extends keyof FormValues>(key: K, val: FormValues[K]) => {
+    setForm((prev) => ({ ...prev, [key]: val }));
+    setErro(null);
+  };
+
+  const toggleDia = (dia: number) => {
+    set(
+      'dias_semana',
+      form.dias_semana.includes(dia)
+        ? form.dias_semana.filter((d) => d !== dia)
+        : [...form.dias_semana, dia].sort(),
+    );
+  };
+
+  const handleSalvar = async () => {
+    const erroValidacao = validarForm(form);
+    if (erroValidacao) { setErro(erroValidacao); return; }
+    if (!user) return;
+
+    setSalvando(true);
+    try {
+      const payload = formParaPayload(form, user.id);
+      if (templateEditando) {
+        await editarTemplate(templateEditando.id, payload);
+      } else {
+        await criarTemplate(payload);
+      }
+      onOpenChange(false);
+    } finally {
+      setSalvando(false);
+    }
+  };
+
+  const mostrarDiasSemana = ['semanal', 'dias_especificos'].includes(form.cadencia);
+  const mostrarLeitura =
+    form.requer_comprovacao &&
+    ['leitura', 'foto_e_leitura'].includes(form.tipo_comprovacao);
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => { if (!v && !salvando) onOpenChange(false); }}>
+      <DialogContent className="max-w-lg max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>
+            {templateEditando ? 'Editar template' : 'Novo template de tarefa recorrente'}
+          </DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4 py-1">
+          {/* Descrição */}
+          <div className="space-y-1.5">
+            <Label htmlFor="tt-descricao">Descrição <span className="text-status-error">*</span></Label>
+            <Textarea
+              id="tt-descricao"
+              placeholder="Ex.: Verificar pH do banho de tinta"
+              rows={2}
+              value={form.descricao}
+              onChange={(e) => set('descricao', e.target.value)}
+              disabled={salvando}
+            />
+          </div>
+
+          {/* Categoria + Área */}
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-1.5">
+              <Label>Categoria <span className="text-status-error">*</span></Label>
+              <Select value={form.categoria} onValueChange={(v) => set('categoria', v as TarefaCategoria)}>
+                <SelectTrigger disabled={salvando}>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {CATEGORIAS.map((c) => (
+                    <SelectItem key={c.val} value={c.val}>{c.label}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="tt-area">Área <span className="text-status-error">*</span></Label>
+              <Input
+                id="tt-area"
+                placeholder="Ex.: Tintométrico"
+                value={form.area}
+                onChange={(e) => set('area', e.target.value)}
+                disabled={salvando}
+              />
+            </div>
+          </div>
+
+          {/* Empresa + Vendedora */}
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-1.5">
+              <Label>Empresa <span className="text-status-error">*</span></Label>
+              <Select value={form.empresa} onValueChange={(v) => set('empresa', v)}>
+                <SelectTrigger disabled={salvando}>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="oben">Oben Comercial</SelectItem>
+                  <SelectItem value="colacor">Colacor</SelectItem>
+                  <SelectItem value="colacor_sc">Colacor SC</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-1.5">
+              <Label>Responsável <span className="text-status-error">*</span></Label>
+              <Select value={form.assigned_to} onValueChange={(v) => set('assigned_to', v)}>
+                <SelectTrigger disabled={salvando}>
+                  <SelectValue placeholder="Selecione…" />
+                </SelectTrigger>
+                <SelectContent>
+                  {salespeople.map((s) => (
+                    <SelectItem key={s.user_id} value={s.user_id}>{s.name}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+
+          {/* Cadência */}
+          <div className="space-y-1.5">
+            <Label>Cadência <span className="text-status-error">*</span></Label>
+            <Select value={form.cadencia} onValueChange={(v) => set('cadencia', v as TarefaTemplateCadencia)}>
+              <SelectTrigger disabled={salvando}>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {CADENCIAS.map((c) => (
+                  <SelectItem key={c.val} value={c.val}>{c.label}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {/* Seletor de dias da semana (semanal / dias_especificos) */}
+          {mostrarDiasSemana && (
+            <div className="space-y-2">
+              <Label>Dias da semana <span className="text-status-error">*</span></Label>
+              <div className="flex flex-wrap gap-2">
+                {DIAS_SEMANA.map((d) => (
+                  <button
+                    key={d.val}
+                    type="button"
+                    disabled={salvando}
+                    onClick={() => toggleDia(d.val)}
+                    className={[
+                      'px-3 py-1.5 rounded-md text-xs font-medium border transition-colors',
+                      form.dias_semana.includes(d.val)
+                        ? 'bg-primary text-primary-foreground border-primary'
+                        : 'border-border hover:bg-muted',
+                    ].join(' ')}
+                  >
+                    {d.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Janela de horário */}
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-1.5">
+              <Label htmlFor="tt-janela-ini">Janela início (opcional)</Label>
+              <Input
+                id="tt-janela-ini"
+                type="time"
+                value={form.janela_inicio}
+                onChange={(e) => set('janela_inicio', e.target.value)}
+                disabled={salvando}
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="tt-janela-fim">Janela fim (opcional)</Label>
+              <Input
+                id="tt-janela-fim"
+                type="time"
+                value={form.janela_fim}
+                onChange={(e) => set('janela_fim', e.target.value)}
+                disabled={salvando}
+              />
+            </div>
+          </div>
+
+          {/* Tolerância */}
+          <div className="space-y-1.5">
+            <Label htmlFor="tt-tolerancia">Tolerância (dias após vencimento)</Label>
+            <Input
+              id="tt-tolerancia"
+              type="number"
+              min={0}
+              max={30}
+              value={form.tolerancia_dias}
+              onChange={(e) => set('tolerancia_dias', e.target.value)}
+              disabled={salvando}
+              className="w-24"
+            />
+          </div>
+
+          {/* Comprovação */}
+          <div className="space-y-3 rounded-md border border-border p-3">
+            <div className="flex items-center justify-between">
+              <div>
+                <Label>Exigir comprovação</Label>
+                <p className="text-xs text-muted-foreground">Operador deve annexar prova ao concluir.</p>
+              </div>
+              <Switch
+                checked={form.requer_comprovacao}
+                onCheckedChange={(v) => {
+                  set('requer_comprovacao', v);
+                  if (!v) set('tipo_comprovacao', 'nenhuma');
+                }}
+                disabled={salvando}
+              />
+            </div>
+
+            {form.requer_comprovacao && (
+              <div className="space-y-3 pt-1">
+                <div className="space-y-1.5">
+                  <Label>Tipo de comprovação</Label>
+                  <Select
+                    value={form.tipo_comprovacao}
+                    onValueChange={(v) => set('tipo_comprovacao', v as TarefaTipoComprovacao)}
+                  >
+                    <SelectTrigger disabled={salvando}>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {TIPOS_COMPROVACAO.filter((t) => t.val !== 'nenhuma').map((t) => (
+                        <SelectItem key={t.val} value={t.val}>{t.label}</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                {/* Campos de leitura */}
+                {mostrarLeitura && (
+                  <div className="space-y-2">
+                    <Label className="text-sm">Faixa de leitura (opcional)</Label>
+                    <div className="grid grid-cols-3 gap-2">
+                      <div className="space-y-1">
+                        <Label htmlFor="tt-lmin" className="text-xs text-muted-foreground">Mínimo</Label>
+                        <Input
+                          id="tt-lmin"
+                          type="number"
+                          placeholder="Ex.: 7.0"
+                          value={form.leitura_min}
+                          onChange={(e) => set('leitura_min', e.target.value)}
+                          disabled={salvando}
+                        />
+                      </div>
+                      <div className="space-y-1">
+                        <Label htmlFor="tt-lmax" className="text-xs text-muted-foreground">Máximo</Label>
+                        <Input
+                          id="tt-lmax"
+                          type="number"
+                          placeholder="Ex.: 7.5"
+                          value={form.leitura_max}
+                          onChange={(e) => set('leitura_max', e.target.value)}
+                          disabled={salvando}
+                        />
+                      </div>
+                      <div className="space-y-1">
+                        <Label htmlFor="tt-lunidade" className="text-xs text-muted-foreground">Unidade</Label>
+                        <Input
+                          id="tt-lunidade"
+                          placeholder="Ex.: pH"
+                          value={form.leitura_unidade}
+                          onChange={(e) => set('leitura_unidade', e.target.value)}
+                          disabled={salvando}
+                        />
+                      </div>
+                    </div>
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+
+          {/* Alto risco */}
+          <div className="flex items-start gap-3">
+            <Checkbox
+              id="tt-altorisco"
+              checked={form.alto_risco}
+              onCheckedChange={(v) => set('alto_risco', !!v)}
+              disabled={salvando}
+              className="mt-0.5"
+            />
+            <div>
+              <Label htmlFor="tt-altorisco" className="font-medium cursor-pointer">Alto risco</Label>
+              <p className="text-xs text-muted-foreground">
+                Exige "Foto + leitura" quando comprovação estiver ativa (restrição do banco).
+              </p>
+            </div>
+          </div>
+
+          {/* Configurações avançadas (collapsible) */}
+          <button
+            type="button"
+            onClick={() => setMostraAvancado((v) => !v)}
+            className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+          >
+            <ChevronDown
+              className={[
+                'w-3.5 h-3.5 transition-transform',
+                mostraAvancado ? 'rotate-180' : '',
+              ].join(' ')}
+            />
+            Configurações avançadas
+          </button>
+
+          {mostraAvancado && (
+            <div className="space-y-3 pt-1">
+              {/* Amostra de auditoria */}
+              <div className="space-y-1.5">
+                <Label htmlFor="tt-auditoria">% para auditoria aleatória</Label>
+                <div className="flex items-center gap-2">
+                  <Input
+                    id="tt-auditoria"
+                    type="number"
+                    min={0}
+                    max={100}
+                    value={form.amostra_auditoria_pct}
+                    onChange={(e) => set('amostra_auditoria_pct', e.target.value)}
+                    disabled={salvando}
+                    className="w-24"
+                  />
+                  <span className="text-sm text-muted-foreground">%</span>
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  Das provas enviadas, essa % será sorteada para revisão manual.
+                </p>
+              </div>
+
+              {/* Limite de reincidência */}
+              <div className="space-y-1.5">
+                <Label htmlFor="tt-reincidente">Limite de reincidência (vezes)</Label>
+                <Input
+                  id="tt-reincidente"
+                  type="number"
+                  min={1}
+                  max={30}
+                  value={form.reincidente_limite}
+                  onChange={(e) => set('reincidente_limite', e.target.value)}
+                  disabled={salvando}
+                  className="w-24"
+                />
+              </div>
+
+              {/* Supervisor */}
+              <div className="space-y-1.5">
+                <Label>Supervisor (opcional)</Label>
+                <Select
+                  value={form.supervisor_user_id}
+                  onValueChange={(v) => set('supervisor_user_id', v === '_nenhum' ? '' : v)}
+                >
+                  <SelectTrigger disabled={salvando}>
+                    <SelectValue placeholder="Nenhum" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="_nenhum">Nenhum</SelectItem>
+                    {salespeople.map((s) => (
+                      <SelectItem key={s.user_id} value={s.user_id}>{s.name}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              {/* Ativo/inativo (só no modo de edição) */}
+              {templateEditando && (
+                <div className="flex items-center gap-3">
+                  <Switch
+                    id="tt-ativo"
+                    checked={form.ativo}
+                    onCheckedChange={(v) => set('ativo', v)}
+                    disabled={salvando}
+                  />
+                  <Label htmlFor="tt-ativo" className="cursor-pointer">
+                    {form.ativo ? 'Template ativo' : 'Template inativo'}
+                  </Label>
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Erro de validação */}
+          {erro && (
+            <p className="text-sm text-status-error border border-status-error/30 bg-status-error-bg rounded-md px-3 py-2">
+              {erro}
+            </p>
+          )}
+        </div>
+
+        <DialogFooter className="gap-2">
+          <Button variant="ghost" disabled={salvando} onClick={() => onOpenChange(false)}>
+            Cancelar
+          </Button>
+          <Button disabled={salvando} onClick={handleSalvar}>
+            {salvando ? (
+              <>
+                <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                Salvando…
+              </>
+            ) : templateEditando ? 'Salvar alterações' : 'Criar template'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Card de template na lista
+// ---------------------------------------------------------------------------
+
+interface TemplateCardProps {
+  template: TarefaTemplate;
+  nomeAssignee: string;
+  onEditar: () => void;
+  onToggleAtivo: () => void;
+  toggling: boolean;
+}
+
+function TemplateCard({
+  template: t,
+  nomeAssignee,
+  onEditar,
+  onToggleAtivo,
+  toggling,
+}: TemplateCardProps) {
+  const cadenciaLabel = CADENCIAS.find((c) => c.val === t.cadencia)?.label ?? t.cadencia;
+
+  return (
+    <Card
+      className={[
+        'p-3 flex items-start justify-between gap-3',
+        !t.ativo ? 'opacity-60' : '',
+      ].join(' ')}
+    >
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2 flex-wrap">
+          <p className="text-sm font-medium">{t.descricao}</p>
+          {t.alto_risco && (
+            <Badge variant="destructive" className="text-2xs">alto risco</Badge>
+          )}
+          {!t.ativo && (
+            <Badge variant="outline" className="text-2xs">inativo</Badge>
+          )}
+        </div>
+        <p className="text-xs text-muted-foreground mt-0.5">
+          {t.area} · {nomeAssignee} · {cadenciaLabel}
+          {t.requer_comprovacao && ` · ${TIPOS_COMPROVACAO.find((tp) => tp.val === t.tipo_comprovacao)?.label ?? t.tipo_comprovacao}`}
+        </p>
+      </div>
+      <div className="flex items-center gap-1 shrink-0">
+        <Button size="sm" variant="ghost" onClick={onEditar} title="Editar template">
+          <Pencil className="w-3.5 h-3.5" />
+        </Button>
+        <Button
+          size="sm"
+          variant="ghost"
+          onClick={onToggleAtivo}
+          disabled={toggling}
+          title={t.ativo ? 'Desativar template' : 'Ativar template'}
+        >
+          {toggling ? (
+            <Loader2 className="w-3.5 h-3.5 animate-spin" />
+          ) : t.ativo ? (
+            <ToggleRight className="w-4 h-4 text-status-success" />
+          ) : (
+            <ToggleLeft className="w-4 h-4 text-muted-foreground" />
+          )}
+        </Button>
+      </div>
+    </Card>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Página principal
+// ---------------------------------------------------------------------------
+
+export default function TarefasTemplates() {
+  const { isMaster, isGestorComercial } = useAuth();
+  const podeGerir = isMaster || isGestorComercial;
+
+  const { data: templates = [], isLoading } = useTemplates();
+  const { toggleTemplateAtivo } = useTemplateMutations();
+  const { data: salespeople = [] } = useSalespeople();
+
+  const [dialogAberto, setDialogAberto] = useState(false);
+  const [editando, setEditando] = useState<TarefaTemplate | null>(null);
+  const [togglingId, setTogglingId] = useState<string | null>(null);
+
+  if (!podeGerir) return <Navigate to="/" replace />;
+
+  const resolverNome = (userId: string) =>
+    salespeople.find((s) => s.user_id === userId)?.name ?? userId.slice(0, 8);
+
+  const abrirNovo = () => {
+    setEditando(null);
+    setDialogAberto(true);
+  };
+
+  const abrirEditar = (t: TarefaTemplate) => {
+    setEditando(t);
+    setDialogAberto(true);
+  };
+
+  const handleToggle = async (t: TarefaTemplate) => {
+    setTogglingId(t.id);
+    try {
+      await toggleTemplateAtivo(t.id, !t.ativo);
+    } finally {
+      setTogglingId(null);
+    }
+  };
+
+  // Contagem de provas para badge da aba (meramente indicativa — o hook está no filho)
+  const ativos = templates.filter((t) => t.ativo).length;
+
+  return (
+    <div className="container py-6 space-y-4">
+      {/* Cabeçalho */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="font-display text-2xl">Tarefas recorrentes</h1>
+          <p className="text-sm text-muted-foreground mt-0.5">
+            Templates de atividades + auditoria de comprovações
+          </p>
+        </div>
+        <Button onClick={abrirNovo}>
+          <PlusCircle className="w-4 h-4 mr-2" />
+          Novo template
+        </Button>
+      </div>
+
+      <Tabs defaultValue="templates">
+        <TabsList>
+          <TabsTrigger value="templates">
+            Templates
+            {templates.length > 0 && (
+              <span className="ml-1.5 text-xs tabular-nums text-muted-foreground">
+                ({ativos}/{templates.length})
+              </span>
+            )}
+          </TabsTrigger>
+          <TabsTrigger value="provas">Provas pendentes</TabsTrigger>
+        </TabsList>
+
+        {/* Aba: lista de templates */}
+        <TabsContent value="templates" className="mt-4">
+          {isLoading ? (
+            <div className="flex items-center gap-2 text-sm text-muted-foreground py-4">
+              <Loader2 className="w-4 h-4 animate-spin" />
+              Carregando templates…
+            </div>
+          ) : templates.length === 0 ? (
+            <div className="rounded-lg border border-dashed border-border p-8 text-center">
+              <p className="text-sm font-medium">Nenhum template criado</p>
+              <p className="text-xs text-muted-foreground mt-1">
+                Clique em "Novo template" para definir uma atividade recorrente.
+              </p>
+              <Button className="mt-4" onClick={abrirNovo}>
+                <PlusCircle className="w-4 h-4 mr-2" />
+                Novo template
+              </Button>
+            </div>
+          ) : (
+            <ul className="space-y-2">
+              {templates.map((t) => (
+                <li key={t.id}>
+                  <TemplateCard
+                    template={t}
+                    nomeAssignee={resolverNome(t.assigned_to)}
+                    onEditar={() => abrirEditar(t)}
+                    onToggleAtivo={() => handleToggle(t)}
+                    toggling={togglingId === t.id}
+                  />
+                </li>
+              ))}
+            </ul>
+          )}
+        </TabsContent>
+
+        {/* Aba: provas aguardando auditoria */}
+        <TabsContent value="provas" className="mt-4">
+          <ProvasParaAuditar />
+        </TabsContent>
+      </Tabs>
+
+      {/* Dialog de criar/editar */}
+      <TemplateDialog
+        open={dialogAberto}
+        onOpenChange={setDialogAberto}
+        templateEditando={editando}
+      />
+    </div>
+  );
+}

--- a/src/pages/TintDashboard.tsx
+++ b/src/pages/TintDashboard.tsx
@@ -4,6 +4,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Beaker, Package, Droplets, FileUp, AlertTriangle } from 'lucide-react';
 import { Skeleton } from '@/components/ui/skeleton';
+import { RecorrentesHojeCard } from '@/components/tarefas/RecorrentesHojeCard';
 
 const ACCOUNT = 'oben';
 
@@ -63,6 +64,9 @@ export default function TintDashboard() {
   return (
     <div className="space-y-6">
       <h1 className="text-2xl font-bold">Tintométrico — Dashboard</h1>
+
+      {/* Tarefas recorrentes do operador — exibe só se houver instâncias abertas hoje */}
+      <RecorrentesHojeCard />
 
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
         <Card>


### PR DESCRIPTION
**Fase 2 das Tarefas (enforcement) — Milestone 2 (frontend).** Backend (Milestone 1, #590) já aplicado em produção. Spec/plano: #553.

- **Task 6** — `templates-types` + helper puro `comprovacao` (`validarLeitura`/`montarPathComprovacao`, **26 testes TDD**) + hooks `useTarefasFase2` (templates CRUD, recorrentes de hoje, `concluir_com_comprovacao`, provas a auditar, `auditar_tarefa`).
- **Task 7** — `ComprovacaoDialog`: foto (upload pro bucket `tarefa-comprovacoes`, path `{uid}/{tarefaId}/...`) e/ou leitura (valida faixa client-side antes de chamar a RPC).
- **Task 8** — `RecorrentesHojeCard` no `/tintometrico` (instâncias do dia, atrasada pós-janela em vermelho, Concluir → dialog se requer prova, senão conclusão simples).
- **Task 9** — página `/tarefas/templates` (CRUD de recorrentes, gate master/gestor) + `ProvasParaAuditar` (foto via signed URL + Aprovar/Reprovar) + rota + nav.

**Segurança server-side:** o enforcement vive no backend (trigger anti-bypass + RPC `security definer`). O frontend só chama as RPCs — mesmo com bug de UI, o banco enforça.

**CI local (por subagente):** typecheck strict ✅ · helper 26/26 ✅ · lint 0 erros ✅ (gate completo da suíte rodando; CI do PR confirma).

⚠️ **Sem migration** (Milestone 1 já trouxe). Depende de #590 (mergeado). **Publish** no Lovable + **QA no device** (operador conclui com foto → gestor audita → tentar burlar via console = trigger bloqueia).
**Follow-up (não-bloqueante):** `TarefasTemplates.tsx` (853 LoC) → split do form quando tocado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)