### PR TITLE
fix(sayerlack): claim do portal usa lista positiva (anti-PO-duplicado) — aperta o predicado do #592

### DIFF
--- a/db/test-envio-portal-claim-ids.sh
+++ b/db/test-envio-portal-claim-ids.sh
@@ -1,13 +1,16 @@
 #!/usr/bin/env bash
-# Testa a RPC public.envio_portal_claim_ids (migration 20260604150000) num Postgres 17 local
-# descartável. Ela substitui o claim atômico .update().or().select() da edge
-# enviar-pedido-portal-sayerlack, que o PostgREST quebrava com 42703 "column
-# pedido_compra_sugerido.status_envio_portal does not exist" (travando TODO disparo ao portal).
+# Testa a RPC public.envio_portal_claim_ids num Postgres 17 local descartável.
+# Ela faz o claim atômico do envio ao portal Sayerlack (transição p/ enviando_portal,
+# anti-duplo-envio) — substitui o .update().or().select() que o PostgREST quebrava.
 #
-# Schema MÍNIMO (não o snapshot inteiro): só o que a RPC toca — public.pedido_compra_sugerido
-# (id/status_envio_portal/portal_erro), public.app_role, public.has_role, public.user_roles,
-# auth.uid() lendo GUC de sessão (impersonação de teste). Prova a LÓGICA do claim: trava só os
-# não-em-voo, idempotência, zera portal_erro, ids vazio, e o gate staff/service_role.
+# Aplica as DUAS migrations em sequência (replay realista):
+#   20260604150000 — #592: move o claim p/ a RPC (predicado largo: IS NULL OR <> enviando_portal)
+#   20260604180000 — aperta p/ LISTA POSITIVA (só pendente_envio_portal/erro_retentavel) + guard
+#                    empresa/fornecedor → anti-PO-duplicado (não reivindica estados terminais).
+#
+# Schema MÍNIMO (não o snapshot inteiro): só o que a RPC toca. Prova a LÓGICA final:
+# claim, zera portal_erro, anti-duplo-envio, idempotência, ids vazio, gate, e — o P1 do
+# 20260604180000 — NÃO reivindicar terminais/NULL/fora-de-escopo.
 #
 # Pré-requisitos: brew install postgresql@17   (mesmo boilerplate de db/verify-snapshot-replay.sh)
 set -euo pipefail
@@ -45,83 +48,107 @@ CREATE FUNCTION public.has_role(_uid uuid, _role public.app_role) RETURNS boolea
   $f$ SELECT EXISTS (SELECT 1 FROM public.user_roles WHERE user_id = _uid AND role = _role) $f$;
 CREATE TABLE public.pedido_compra_sugerido (
   id bigint PRIMARY KEY,
+  empresa text,
+  fornecedor_nome text,
   status_envio_portal text,
   portal_erro text
 );
--- service_role precisa existir p/ o GRANT da migration
 DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname='service_role')
   THEN CREATE ROLE service_role; END IF; END $$;
 DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname='authenticated')
   THEN CREATE ROLE authenticated; END IF; END $$;
 DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname='anon')
   THEN CREATE ROLE anon; END IF; END $$;
--- seed: 1 master, 1 vendedor não-staff (customer)
 INSERT INTO public.user_roles VALUES
   ('33333333-3333-3333-3333-333333333333','master'),
   ('44444444-4444-4444-4444-444444444444','customer');
 SQL
 
-# 2) Aplica a migration da RPC (verbatim do repo)
+# 2) Aplica as 2 migrations EM SEQUÊNCIA (a 180000 faz CREATE OR REPLACE da 150000)
 P -v ON_ERROR_STOP=1 -q -f "$REPO_ROOT/supabase/migrations/20260604150000_envio_portal_claim_ids.sql"
+P -v ON_ERROR_STOP=1 -q -f "$REPO_ROOT/supabase/migrations/20260604180000_envio_portal_claim_ids_lista_positiva.sql"
 
-# 3) Seed de pedidos em todos os estados relevantes + asserts
+# 3) Seed + asserts
 echo "ASSERTS:"
 P -v ON_ERROR_STOP=1 -q <<'SQL'
-INSERT INTO public.pedido_compra_sugerido (id, status_envio_portal, portal_erro) VALUES
-  (901, 'pendente_envio_portal', 'erro antigo a ser limpo'),
-  (902, 'erro_retentavel',       NULL),
-  (903, NULL,                     NULL),               -- fresco
-  (904, 'enviando_portal',        NULL),               -- já em voo
-  (905, 'pendente_envio_portal',  NULL);               -- p/ idempotência
+INSERT INTO public.pedido_compra_sugerido (id, empresa, fornecedor_nome, status_envio_portal, portal_erro) VALUES
+  -- reivindicáveis (Sayerlack/OBEN, estado de fila)
+  (901, 'OBEN', 'RENNER SAYERLACK S/A', 'pendente_envio_portal', 'erro antigo a ser limpo'),
+  (902, 'OBEN', 'RENNER SAYERLACK S/A', 'erro_retentavel',       NULL),
+  (905, 'OBEN', 'RENNER SAYERLACK S/A', 'pendente_envio_portal', NULL),   -- idempotência
+  -- NÃO reivindicáveis
+  (903, 'OBEN', 'RENNER SAYERLACK S/A', NULL,                    NULL),   -- NULL (nova semântica)
+  (904, 'OBEN', 'RENNER SAYERLACK S/A', 'enviando_portal',       NULL),   -- já em voo
+  -- TERMINAIS/ambíguos (P1 — JAMAIS reivindicar: re-envio = PO duplicado)
+  (910, 'OBEN', 'RENNER SAYERLACK S/A', 'sucesso_portal',                NULL),
+  (911, 'OBEN', 'RENNER SAYERLACK S/A', 'indeterminado_requer_conciliacao', NULL),
+  (912, 'OBEN', 'RENNER SAYERLACK S/A', 'aceito_portal_sem_protocolo',   NULL),
+  (913, 'OBEN', 'RENNER SAYERLACK S/A', 'erro_nao_retentavel',           NULL),
+  -- fora de escopo (guard empresa/fornecedor)
+  (930, 'COLACOR', 'RENNER SAYERLACK S/A', 'pendente_envio_portal', NULL),  -- empresa != OBEN
+  (931, 'OBEN',    'OUTRO FORNECEDOR LTDA','pendente_envio_portal', NULL);  -- fornecedor != Sayerlack
 
 DO $$
 DECLARE n int; st text; err text;
 BEGIN
-  -- contexto = service_role (auth.uid() NULL): gate passa
-  PERFORM set_config('test.uid', '', false);
+  PERFORM set_config('test.uid', '', false);  -- service_role: gate passa
 
-  -- A1: claim de pendente + erro_retentavel + NULL → trava os 3, retorna os 3
-  SELECT count(*) INTO n FROM public.envio_portal_claim_ids(ARRAY[901,902,903]::bigint[]);
-  ASSERT n = 3, format('A1 esperava 3 reivindicados, veio %s', n);
+  -- A1: reivindica pendente + erro_retentavel
+  SELECT count(*) INTO n FROM public.envio_portal_claim_ids(ARRAY[901,902]::bigint[]);
+  ASSERT n = 2, format('A1 esperava 2 reivindicados, veio %s', n);
   SELECT count(*) INTO n FROM public.pedido_compra_sugerido
-    WHERE id IN (901,902,903) AND status_envio_portal = 'enviando_portal';
-  ASSERT n = 3, format('A1 esperava 3 em enviando_portal, veio %s', n);
+    WHERE id IN (901,902) AND status_envio_portal = 'enviando_portal';
+  ASSERT n = 2, format('A1 esperava 2 em enviando_portal, veio %s', n);
 
-  -- A2: portal_erro foi ZERADO ao reivindicar (901 tinha "erro antigo")
+  -- A2: portal_erro zerado ao reivindicar
   SELECT portal_erro INTO err FROM public.pedido_compra_sugerido WHERE id = 901;
   ASSERT err IS NULL, format('A2 esperava portal_erro NULL, veio %L', err);
 
-  -- A3: claim de 904 (já em voo) → 0 reivindicados, status inalterado (anti-duplo-envio)
+  -- A3: já em voo (enviando_portal) → 0, status inalterado
   SELECT count(*) INTO n FROM public.envio_portal_claim_ids(ARRAY[904]::bigint[]);
   ASSERT n = 0, format('A3 esperava 0 (já em voo), veio %s', n);
-  SELECT status_envio_portal INTO st FROM public.pedido_compra_sugerido WHERE id = 904;
-  ASSERT st = 'enviando_portal', format('A3 status do 904 mudou p/ %L', st);
 
-  -- A4: idempotência — reivindicar 905 duas vezes; 2ª vez retorna 0 (já travado pela 1ª)
+  -- A4: idempotência
   SELECT count(*) INTO n FROM public.envio_portal_claim_ids(ARRAY[905]::bigint[]);
-  ASSERT n = 1, format('A4 1ª chamada esperava 1, veio %s', n);
+  ASSERT n = 1, format('A4 1ª esperava 1, veio %s', n);
   SELECT count(*) INTO n FROM public.envio_portal_claim_ids(ARRAY[905]::bigint[]);
-  ASSERT n = 0, format('A4 2ª chamada (idempotente) esperava 0, veio %s', n);
+  ASSERT n = 0, format('A4 2ª (idempotente) esperava 0, veio %s', n);
 
-  -- A5: ids vazio → 0, sem erro
+  -- A5: ids vazio
   SELECT count(*) INTO n FROM public.envio_portal_claim_ids(ARRAY[]::bigint[]);
-  ASSERT n = 0, format('A5 ids vazio esperava 0, veio %s', n);
+  ASSERT n = 0, format('A5 vazio esperava 0, veio %s', n);
 
-  RAISE NOTICE 'A1..A5 OK (service_role): claim, zera erro, anti-duplo-envio, idempotência, vazio';
+  RAISE NOTICE 'A1..A5 OK: claim, zera erro, anti-duplo-envio, idempotência, vazio';
+
+  -- A7 (P1): TERMINAIS/ambíguos JAMAIS reivindicados (anti-PO-duplicado)
+  SELECT count(*) INTO n FROM public.envio_portal_claim_ids(ARRAY[910,911,912,913]::bigint[]);
+  ASSERT n = 0, format('A7 esperava 0 (terminais protegidos), veio %s — RISCO DE PO DUPLICADO', n);
+  SELECT count(*) INTO n FROM public.pedido_compra_sugerido
+    WHERE id IN (910,911,912,913) AND status_envio_portal = 'enviando_portal';
+  ASSERT n = 0, format('A7 terminais NÃO podem virar enviando_portal, %s viraram', n);
+
+  -- A8: NULL não reivindicado (nova semântica, sem OR IS NULL)
+  SELECT count(*) INTO n FROM public.envio_portal_claim_ids(ARRAY[903]::bigint[]);
+  ASSERT n = 0, format('A8 NULL esperava 0, veio %s', n);
+
+  -- A9: guard empresa/fornecedor
+  SELECT count(*) INTO n FROM public.envio_portal_claim_ids(ARRAY[930,931]::bigint[]);
+  ASSERT n = 0, format('A9 fora-de-escopo esperava 0, veio %s', n);
+
+  RAISE NOTICE 'A7..A9 OK: terminais/NULL/fora-de-escopo NÃO reivindicados (P1 anti-PO-duplicado)';
 END $$;
 
--- A6: gate — usuário NÃO-staff levanta exceção; master passa
+-- A6: gate — não-staff levanta exceção; master passa
 DO $$
 DECLARE ok boolean;
 BEGIN
   PERFORM set_config('test.uid', '44444444-4444-4444-4444-444444444444', false); -- customer
   BEGIN
     PERFORM * FROM public.envio_portal_claim_ids(ARRAY[902]::bigint[]);
-    ASSERT false, 'A6 esperava exceção p/ não-staff, não levantou';
+    ASSERT false, 'A6 esperava exceção p/ não-staff';
   EXCEPTION WHEN insufficient_privilege THEN
     RAISE NOTICE 'A6 OK: não-staff barrado (42501)';
   END;
-
   PERFORM set_config('test.uid', '33333333-3333-3333-3333-333333333333', false); -- master
   SELECT count(*) >= 0 INTO ok FROM public.envio_portal_claim_ids(ARRAY[902]::bigint[]);
   ASSERT ok, 'A6 master deveria passar o gate';

--- a/supabase/migrations/20260604180000_envio_portal_claim_ids_lista_positiva.sql
+++ b/supabase/migrations/20260604180000_envio_portal_claim_ids_lista_positiva.sql
@@ -1,0 +1,78 @@
+-- Aperta o predicado do claim atômico do portal Sayerlack: lista POSITIVA (não "qualquer != enviando_portal").
+-- ============================================================================
+-- Segue o #592 (que moveu o claim p/ a RPC envio_portal_claim_ids em SQL puro, consertando o
+-- .or()-em-UPDATE que o PostgREST rejeitava com 42703). Uma revisão paralela (#598) + um consult
+-- adversário ao Codex apontaram um P1 que o #592 HERDOU do `.or()` original ao reativá-lo:
+--
+--   P1 (PO DUPLICADO na Renner): o predicado largo "status_envio_portal IS NULL OR <> 'enviando_portal'"
+--   reivindica QUALQUER estado != enviando_portal — inclusive TERMINAIS/ambíguos:
+--   indeterminado_requer_conciliacao, aceito_portal_sem_protocolo, sucesso_portal, erro_nao_retentavel.
+--   O modo INDIVIDUAL (DispararAgoraButton → enviar-pedido-portal-sayerlack {pedido_id}) busca o
+--   candidato por id SEM filtro de status (index.ts:2075) e PULA o pré-check de
+--   iniciarEnvioPortalSayerlack (disparar-pedidos-aprovados:409-426, que barraria os ambíguos).
+--   processCandidatos NÃO tem guard pós-claim (index.ts:1952) → um pedido indeterminado/
+--   aceito_sem_protocolo reivindicado é RE-ENVIADO ao Browserless = 2º PO no fornecedor. (sucesso_portal
+--   não re-POSTa por idempotência em index.ts:1433, mas o claim já corrompe o estado p/ enviando_portal.)
+--   O `.or()` quebrado nunca exerceu isso; o #592, ao consertá-lo, reativou o risco latente.
+--
+-- FIX: lista POSITIVA — só pendente_envio_portal/erro_retentavel (os 2 estados que DEVEM ir ao portal),
+--   espelhando exatamente envio_portal_lock_candidatos (lote, 20260530230000) e sayerlack_retry_orfaos
+--   (motor, 20260528040000). + guard empresa='OBEN'/fornecedor ILIKE '%SAYERLACK%' (defense-in-depth:
+--   o modo individual passa ids sem filtrar fornecedor; alinha com lote/motor/watchdog, todos Sayerlack-OBEN).
+--
+-- DECISÕES (Codex + análise de fluxo):
+--   • SEM "OR IS NULL": a coluna tem default 'nao_aplicavel' e o trigger set_status_envio_portal_on_disparo
+--     força 'pendente_envio_portal' no disparo Sayerlack; o fluxo (disparar-pedidos-aprovados:428) também
+--     seta 'pendente' antes da edge. NULL no claim seria higiene/backfill, NÃO candidato de money-path.
+--   • NÃO guardo por `status` (aprovado_aguardando_disparo/disparado/falha_envio): os caminhos DIVERGEM —
+--     o motor dispara 'falha_envio' (foi o status dos pedidos 324/325/340/341 travados); um guard de status
+--     a la envio_portal_lock_candidatos ('aprovado_aguardando_disparo','disparado') OMITIRIA 'falha_envio'
+--     e re-quebraria o disparo. O discriminador correto é status_envio_portal.
+--
+-- ATOMICIDADE preservada (idêntica ao #592): UPDATE...WHERE...RETURNING sob READ COMMITTED — row-lock +
+--   re-avaliação do predicado após commit concorrente → 2 requests pelo mesmo id, só um reivindica.
+--
+-- ⚠️ Follow-up SEPARADO (NÃO neste PR — Codex): o modo LOTE faz double-claim. envio_portal_lock_candidatos
+--   já marca os candidatos como enviando_portal; este claim (lista positiva) os EXCLUIRIA → lote vira no-op.
+--   Hoje inócuo (cron sayerlack-portal-lote-retry removido em 20260530170000; o money-path é o individual);
+--   quando o lote voltar, tratar os retornados pela lock_candidatos como JÁ reivindicados e pular este claim.
+--
+-- CREATE OR REPLACE move por OID (preserva grants); reafirmo os grants no fim por idempotência.
+
+CREATE OR REPLACE FUNCTION public.envio_portal_claim_ids(p_ids bigint[])
+RETURNS TABLE(id bigint)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+BEGIN
+  -- Libera service_role (uid NULL); exige staff só p/ usuário autenticado (espelha
+  -- public.envio_portal_lock_candidatos). A edge usa SERVICE_ROLE_KEY → passa.
+  IF auth.uid() IS NOT NULL
+     AND NOT (public.has_role(auth.uid(), 'employee'::app_role)
+              OR public.has_role(auth.uid(), 'master'::app_role)) THEN
+    RAISE EXCEPTION 'Acesso negado: requer perfil staff' USING ERRCODE = '42501';
+  END IF;
+
+  RETURN QUERY
+  UPDATE public.pedido_compra_sugerido p
+     SET status_envio_portal = 'enviando_portal',
+         portal_erro = NULL
+   WHERE p.id = ANY(p_ids)
+     AND p.empresa = 'OBEN'
+     AND p.fornecedor_nome ILIKE '%SAYERLACK%'
+     -- lista POSITIVA (espelha lote + motor): SÓ os 2 estados que devem ir ao portal.
+     -- Exclui TERMINAIS/ambíguos (indeterminado/aceito_sem_protocolo/sucesso_portal/
+     -- erro_nao_retentavel) → anti-PO-duplicado. Sem IS NULL (não é money-path).
+     AND p.status_envio_portal IN ('pendente_envio_portal', 'erro_retentavel')
+  RETURNING p.id;
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public.envio_portal_claim_ids(bigint[]) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.envio_portal_claim_ids(bigint[]) FROM anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.envio_portal_claim_ids(bigint[]) TO service_role;
+
+SELECT 'envio_portal_claim_ids (lista positiva) OK' AS status,
+       count(*) AS existe
+FROM pg_proc WHERE proname = 'envio_portal_claim_ids';


### PR DESCRIPTION
## Problema

Segue o **#592** (que moveu o claim atômico do envio ao portal Sayerlack para a RPC SQL-pura `envio_portal_claim_ids`, consertando o `.or()`-em-UPDATE que o PostgREST rejeitava). Uma revisão paralela (**#598**) + um consult adversário ao Codex apontaram um **P1 que o #592 herdou** do `.or()` original ao reativá-lo:

**P1 — PO DUPLICADO na Renner.** O predicado largo `status_envio_portal IS NULL OR <> 'enviando_portal'` reivindica **qualquer** estado ≠ `enviando_portal` — inclusive **terminais/ambíguos**: `indeterminado_requer_conciliacao`, `aceito_portal_sem_protocolo`, `sucesso_portal`, `erro_nao_retentavel`. O modo individual (`DispararAgoraButton` → `enviar-pedido-portal-sayerlack {pedido_id}`) busca o candidato por id **sem filtro de status** ([index.ts:2075](supabase/functions/enviar-pedido-portal-sayerlack/index.ts:2075)) e **pula** o pré-check de `iniciarEnvioPortalSayerlack`; o `processCandidatos` **não tem guard pós-claim** ([index.ts:1952](supabase/functions/enviar-pedido-portal-sayerlack/index.ts:1952)) → um pedido `indeterminado`/`aceito_sem_protocolo` reivindicado é **re-enviado ao Browserless = 2º PO no fornecedor**. O `.or()` quebrado nunca exerceu isso; o #592, ao consertá-lo, reativou o risco latente.

## Fix

Lista **positiva** no predicado da RPC: `status_envio_portal IN ('pendente_envio_portal','erro_retentavel')` — espelhando `envio_portal_lock_candidatos` (lote) e `sayerlack_retry_orfaos` (motor) — + guard `empresa='OBEN'`/`fornecedor_nome ILIKE '%SAYERLACK%'`. Mantém a RPC SQL-pura do #592 (não reverte). Atomicidade anti-duplo-envio idêntica (`UPDATE...WHERE...RETURNING` sob READ COMMITTED).

**Decisões (consult Codex):**
- **Sem `OR IS NULL`**: a coluna tem default `nao_aplicavel` e o trigger/fluxo forçam `pendente_envio_portal` no disparo Sayerlack; `NULL` no claim seria higiene/backfill, não money-path.
- **Não guardo por `status`**: os caminhos divergem — o motor dispara `falha_envio` (status dos 324/325/340/341 travados); um guard `status IN ('aprovado_aguardando_disparo','disparado')` à la lote **omitiria `falha_envio`** e re-quebraria o disparo. O discriminador correto é `status_envio_portal`.

## Validação
- `db/test-envio-portal-claim-ids.sh` (PG17, **9 asserts**) — A7/A8/A9 **novos** provam que **terminais / `NULL` / fora-de-escopo NÃO são reivindicados** (o P1). Decisão de design por consult Codex + challenge no diff.

## Relação com outros PRs
- **Segue o #592** (mergeado). Mantém a RPC SQL-pura; só aperta o predicado.
- **Substitui o #598** (mesma semântica de lista positiva, mas implementada na RPC SQL-pura do #592 em vez de `.in()` via PostgREST — mais robusto/versionado). Vou fechar o #598 apontando pra cá.

## Follow-up SEPARADO (Codex, não neste PR)
O modo **lote** faz *double-claim* (`envio_portal_lock_candidatos` já marca `enviando_portal`; este claim com lista positiva excluiria esses → lote vira no-op). **Inócuo hoje** (cron `sayerlack-portal-lote-retry` removido em `20260530170000`; o money-path é o individual). Quando o lote voltar: tratar os retornados pela `lock_candidatos` como já-reivindicados e pular este claim.

## ⚠️ ATENÇÃO: migration manual (após merge) — redeploy NÃO necessário

A edge na main **já chama** `.rpc("envio_portal_claim_ids", ...)` (do #592), então **só a migration** muda a RPC. 🟣 Lovable → SQL Editor → cola → Run:

```sql
CREATE OR REPLACE FUNCTION public.envio_portal_claim_ids(p_ids bigint[])
RETURNS TABLE(id bigint)
LANGUAGE plpgsql
SECURITY DEFINER
SET search_path TO 'public'
AS $function$
BEGIN
  IF auth.uid() IS NOT NULL
     AND NOT (public.has_role(auth.uid(), 'employee'::app_role)
              OR public.has_role(auth.uid(), 'master'::app_role)) THEN
    RAISE EXCEPTION 'Acesso negado: requer perfil staff' USING ERRCODE = '42501';
  END IF;

  RETURN QUERY
  UPDATE public.pedido_compra_sugerido p
     SET status_envio_portal = 'enviando_portal',
         portal_erro = NULL
   WHERE p.id = ANY(p_ids)
     AND p.empresa = 'OBEN'
     AND p.fornecedor_nome ILIKE '%SAYERLACK%'
     AND p.status_envio_portal IN ('pendente_envio_portal', 'erro_retentavel')
  RETURNING p.id;
END;
$function$;

REVOKE ALL ON FUNCTION public.envio_portal_claim_ids(bigint[]) FROM PUBLIC;
REVOKE EXECUTE ON FUNCTION public.envio_portal_claim_ids(bigint[]) FROM anon, authenticated;
GRANT EXECUTE ON FUNCTION public.envio_portal_claim_ids(bigint[]) TO service_role;

SELECT 'envio_portal_claim_ids (lista positiva) OK' AS status,
       count(*) AS existe
FROM pg_proc WHERE proname = 'envio_portal_claim_ids';
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
