### PR TITLE
fix(afiação): QR público de histórico de ferramenta funciona (#6)

### DIFF
--- a/src/pages/ToolPublicHistory.tsx
+++ b/src/pages/ToolPublicHistory.tsx
@@ -50,13 +50,17 @@ const ToolPublicHistory = () => {
 
   const loadData = async () => {
     try {
-      const [toolRes, eventsRes] = await Promise.all([
-        supabase.from('user_tools').select('*, tool_categories(name)').eq('id', toolId!).single(),
-        supabase.from('tool_events').select('id, event_type, description, created_at')
-          .eq('user_tool_id', toolId!).order('created_at', { ascending: false }),
-      ]);
-      if (toolRes.data) setTool(toolRes.data as unknown as ToolData);
-      if (eventsRes.data) setEvents(eventsRes.data as ToolEvent[]);
+      // RPC pública SECURITY DEFINER: funciona pra visitante NÃO-LOGADO (QR) e devolve só campos
+      // seguros (sem user_id do dono). As tabelas user_tools/tool_events não têm policy anon.
+      const { data, error } = await supabase.rpc('get_public_tool_history' as never, {
+        p_tool_id: toolId,
+      } as never);
+      if (error) throw error;
+      const payload = data as unknown as { tool: ToolData; events: ToolEvent[] } | null;
+      if (payload?.tool) {
+        setTool(payload.tool);
+        setEvents(payload.events ?? []);
+      }
     } catch (e) {
       console.error(e);
     } finally {

--- a/supabase/migrations/20260604180000_public_tool_history_rpc.sql
+++ b/supabase/migrations/20260604180000_public_tool_history_rpc.sql
@@ -1,0 +1,65 @@
+-- #6 (auditoria 2026-06-04): QR público de histórico de ferramenta quebrado.
+--
+-- A rota pública /tool/:id (gerada por QR em ToolHistory, "Escaneie para acessar o histórico")
+-- lia user_tools/tool_events DIRETO, mas essas tabelas só têm policy own-scoped/staff (sem anon)
+-- → o visitante NÃO-LOGADO sempre via "Ferramenta não encontrada".
+--
+-- Fix: RPC SECURITY DEFINER escopada por UUID, callable por anon, que devolve SÓ campos seguros
+-- (nome/categoria/datas de afiação/eventos) — NUNCA o user_id (dono) nem as outras ferramentas dele.
+-- Padrão das RPCs públicas do repo (mesma ideia do get_tint_price). O front passa a chamar a RPC.
+
+CREATE OR REPLACE FUNCTION public.get_public_tool_history(p_tool_id uuid)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_tool jsonb;
+  v_events jsonb;
+BEGIN
+  IF p_tool_id IS NULL THEN
+    RETURN NULL;
+  END IF;
+
+  -- Ferramenta: só campos públicos (sem user_id).
+  SELECT jsonb_build_object(
+    'id', ut.id,
+    'internal_code', ut.internal_code,
+    'generated_name', ut.generated_name,
+    'custom_name', ut.custom_name,
+    'specifications', ut.specifications,
+    'last_sharpened_at', ut.last_sharpened_at,
+    'next_sharpening_due', ut.next_sharpening_due,
+    'created_at', ut.created_at,
+    'tool_categories', jsonb_build_object('name', COALESCE(tc.name, ''))
+  ) INTO v_tool
+  FROM public.user_tools ut
+  LEFT JOIN public.tool_categories tc ON tc.id = ut.tool_category_id
+  WHERE ut.id = p_tool_id;
+
+  IF v_tool IS NULL THEN
+    RETURN NULL; -- ferramenta inexistente → front mostra "não encontrada"
+  END IF;
+
+  SELECT COALESCE(
+    jsonb_agg(
+      jsonb_build_object(
+        'id', te.id,
+        'event_type', te.event_type,
+        'description', te.description,
+        'created_at', te.created_at
+      ) ORDER BY te.created_at DESC
+    ),
+    '[]'::jsonb
+  ) INTO v_events
+  FROM public.tool_events te
+  WHERE te.user_tool_id = p_tool_id;
+
+  RETURN jsonb_build_object('tool', v_tool, 'events', v_events);
+END;
+$$;
+
+-- Público (QR sem login).
+REVOKE ALL ON FUNCTION public.get_public_tool_history(uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_public_tool_history(uuid) TO anon, authenticated;


### PR DESCRIPTION
## 🚧 #6 (auditoria) — QR público de histórico quebrado

A rota pública `/tool/:id` (QR "Escaneie para acessar o histórico", gerado em `ToolHistory`) lia `user_tools`/`tool_events` **direto**, mas essas tabelas só têm policy own-scoped/staff (sem anon) → **visitante não-logado sempre via "Ferramenta não encontrada"**.

## Fix (RPC segura)

**RPC `get_public_tool_history(p_tool_id)`** `SECURITY DEFINER`, escopada por UUID, callable por **anon**, que devolve **só campos seguros** (nome/categoria/specs/datas + eventos: tipo/descrição/data) — **NUNCA** o `user_id` do dono nem as outras ferramentas dele. UUID `gen_random_uuid` é não-adivinhável (sem enumeração). Front (`ToolPublicHistory.loadData`) passa a chamar a RPC (mesmo padrão do `get_tint_price`).

⚠️ **codex em limite de uso → revisão de segurança SOLO:** sem PII (user_id fora), escopo por 1 UUID, `search_path` fixo, `REVOKE FROM PUBLIC` + `GRANT anon/authenticated`. Heavy local saturado → **CI valida** typecheck/test/build.

## ⚠️ MIGRATION MANUAL (Lovable SQL Editor) — aplicar ANTES do Publish

```sql
CREATE OR REPLACE FUNCTION public.get_public_tool_history(p_tool_id uuid)
RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public'
AS $$
DECLARE v_tool jsonb; v_events jsonb;
BEGIN
  IF p_tool_id IS NULL THEN RETURN NULL; END IF;
  SELECT jsonb_build_object(
    'id', ut.id, 'internal_code', ut.internal_code, 'generated_name', ut.generated_name,
    'custom_name', ut.custom_name, 'specifications', ut.specifications,
    'last_sharpened_at', ut.last_sharpened_at, 'next_sharpening_due', ut.next_sharpening_due,
    'created_at', ut.created_at, 'tool_categories', jsonb_build_object('name', COALESCE(tc.name, ''))
  ) INTO v_tool
  FROM public.user_tools ut
  LEFT JOIN public.tool_categories tc ON tc.id = ut.tool_category_id
  WHERE ut.id = p_tool_id;
  IF v_tool IS NULL THEN RETURN NULL; END IF;
  SELECT COALESCE(jsonb_agg(jsonb_build_object(
    'id', te.id, 'event_type', te.event_type, 'description', te.description, 'created_at', te.created_at
  ) ORDER BY te.created_at DESC), '[]'::jsonb) INTO v_events
  FROM public.tool_events te WHERE te.user_tool_id = p_tool_id;
  RETURN jsonb_build_object('tool', v_tool, 'events', v_events);
END;
$$;
REVOKE ALL ON FUNCTION public.get_public_tool_history(uuid) FROM PUBLIC;
GRANT EXECUTE ON FUNCTION public.get_public_tool_history(uuid) TO anon, authenticated;

SELECT 'TOOL HISTORY RPC OK' AS status,
  (SELECT count(*) FROM pg_proc WHERE proname='get_public_tool_history') AS rpc_deve_1,
  has_function_privilege('anon','public.get_public_tool_history(uuid)','EXECUTE') AS anon_exec_true;
```

Esperado: `rpc_deve_1=1`, `anon_exec_true=t`.

## Test plan (pós-migration + Publish)

- [ ] **Deslogado** (aba anônima), abrir /tool/<uuid-real> → mostra nome + histórico (não "não encontrada").
- [ ] UUID inexistente → "Ferramenta não encontrada" (honesto).
- [ ] A resposta NÃO traz `user_id` nem dados de outras ferramentas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)