### PR TITLE
feat(reposição): esconde "quem aprovou" na coluna de pedidos

### DIFF
--- a/src/components/reposicao/pedidos/PedidoRow.tsx
+++ b/src/components/reposicao/pedidos/PedidoRow.tsx
@@ -62,10 +62,7 @@ export function PedidoRow({
       </TableCell>
       <TableCell className="text-xs">
         {showAprovacao && p.aprovado_em ? (
-          <div>
-            <div className="font-medium tabular-nums">{format(new Date(p.aprovado_em), 'dd/MM HH:mm')}</div>
-            <div className="text-muted-foreground line-clamp-1">{p.aprovado_por ?? '—'}</div>
-          </div>
+          <div className="font-medium tabular-nums">{format(new Date(p.aprovado_em), 'dd/MM HH:mm')}</div>
         ) : (
           <span className="text-muted-foreground">—</span>
         )}

--- a/src/pages/AdminReposicaoPedidos.tsx
+++ b/src/pages/AdminReposicaoPedidos.tsx
@@ -235,7 +235,7 @@ export default function AdminReposicaoPedidos() {
                       <TableHead className="text-right">Δ vs anterior</TableHead>
                       <TableHead className="text-right">Corte</TableHead>
                       <TableHead>Portal</TableHead>
-                      <TableHead>Aprovado em / Por</TableHead>
+                      <TableHead>Aprovado em</TableHead>
                       <TableHead className="text-right">Ações</TableHead>
                     </TableRow>
                   </TableHeader>


### PR DESCRIPTION
Founder: só ele aprova, então o email do aprovador era ruído na tela. Remove o `aprovado_por` da coluna `AdminReposicaoPedidos`/`PedidoRow` e renomeia o header de "Aprovado em / Por" → "Aprovado em" (mantém a data, útil pra rastreio).

Fase 3 da frente do pedido-fantasma (§9 do roadmap). Mudança puramente visual, sem tocar dado/RPC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)