### PR TITLE
feat(reposicao): pedido de compra entra aprovado no Omie (cEmailAprovador)

### DIFF
--- a/docs/superpowers/specs/2026-06-04-auto-aprovacao-pedido-compra-omie-design.md
+++ b/docs/superpowers/specs/2026-06-04-auto-aprovacao-pedido-compra-omie-design.md
@@ -1,0 +1,65 @@
+# Auto-aprovação do pedido de compra no Omie
+
+**Data:** 2026-06-04
+**Status:** desenho aprovado pelo founder (aguardando implementação)
+
+## Problema
+
+Quando o app dispara um pedido de compra ao Omie (`disparar-pedidos-aprovados` → `IncluirPedCompra`), ele entra na etapa **pendente/cotação** do Omie. O founder precisa abrir o Omie e clicar "Aprovar Pedido" pra mover o card pra a coluna "aprovados" do kanban do Omie — um passo manual repetido, **independente do fornecedor**.
+
+⚠️ **Não confundir** com a aprovação no NOSSO app (Reposição): essa continua existindo (o gate humano `pendente_aprovacao → aprovado_aguardando_disparo` antes do disparo). Esta feature elimina a **segunda** aprovação, a que acontece **dentro do Omie**.
+
+## Decisão (mecanismo)
+
+A API do Omie expõe, no `IncluirPedCompra`/`UpsertPedCompra`, o campo opcional **`cEmailAprovador`**. Doc oficial: quando preenchido, *"o pedido de compra será atribuído à etapa de aprovação com o status de aprovado"*. É o caminho oficial e granular pra criar o pedido **já aprovado**, em nome de um usuário.
+
+Por que o email: no Omie, aprovação tem responsável (trava de auditoria/permissão). `cEmailAprovador` informa **quem aprovou** — equivalente a clicar "Aprovar" logado como aquele usuário. Tem que ser um usuário **real do Omie com permissão de aprovar** naquela conta.
+
+**Alternativa descartada:** desligar a exigência de aprovação na config do Omie — afeta TODOS os pedidos da conta (não só os do app) e remove o controle. Pior.
+
+## Design
+
+Adicionar `cEmailAprovador` ao `cabecalho_incluir` do `IncluirPedCompra` em
+`supabase/functions/disparar-pedidos-aprovados/index.ts` (~linha 652).
+
+- **Fonte do email:** env var, lida por empresa com fallback global:
+  `OMIE_<EMPRESA>_EMAIL_APROVADOR` (ex.: `OMIE_OBEN_EMAIL_APROVADOR`) **ou** `OMIE_EMAIL_APROVADOR`.
+  Segue o padrão de `getOmieCreds` (credenciais do Omie já são env var por empresa). O founder
+  seta **uma** env var global (`OMIE_EMAIL_APROVADOR = lucascoelhosardenberg@gmail.com`) e vale
+  pra todas; se uma conta precisar de outro aprovador, seta a específica.
+- **Escopo:** TODOS os fornecedores. `disparar-pedidos-aprovados` é o **único** ponto que cria
+  PC no Omie (`IncluirPedCompra`, único `grep`), então o campo no cabeçalho cobre tudo.
+- **Incluído em produção e dry-run** (o dry-run também cria o pedido no Omie; deve refletir o
+  comportamento real).
+- **Degradação honesta:** se NENHUMA env var estiver setada, o campo **não** é adicionado e o
+  pedido entra como hoje (pendente). Não quebra o disparo — só não auto-aprova até a env var existir.
+
+## Validação
+
+A doc confirma o campo e o comportamento, mas **não mostra um exemplo de payload** com ele. Então,
+após implementar e deployar:
+
+1. Disparar **1 pedido real** (ou dry-run que cria no Omie).
+2. Conferir no Omie que o pedido entrou na coluna **"aprovados"** do kanban (não "pendente").
+3. Se o Omie **recusar** o campo ou ignorá-lo: plano B — checar formato/nome exato do campo,
+   testar via `UpsertPedCompra`, ou capturar a resposta do Omie pra ajustar. **Não dar como
+   certo sem essa confirmação visual no Omie.**
+
+## Não-objetivos
+
+- Não mexe no gate de aprovação do nosso app (Reposição) — continua igual.
+- Não mexe na config de permissões/etapas do Omie.
+- Não faz 2ª chamada de API (não há método dedicado de aprovação; o `cEmailAprovador` no Incluir resolve).
+
+## Riscos
+
+- **Omie rejeitar/ignorar o campo** (doc sem exemplo de payload) → mitigado pela validação com
+  pedido real antes de dar como pronto + degradação honesta (sem env var = comportamento atual).
+- **Email inválido na conta Omie** → o Omie pode recusar a criação. O founder confirma que o
+  email é um usuário real com permissão de aprovar.
+
+## Apply (founder)
+
+- **Setar a env var** no Lovable: `OMIE_EMAIL_APROVADOR = lucascoelhosardenberg@gmail.com`.
+- **Redeploy** da edge `disparar-pedidos-aprovados` (verbatim da main, após merge).
+- **Sem migration** (mudança só de edge).

--- a/supabase/functions/disparar-pedidos-aprovados/index.ts
+++ b/supabase/functions/disparar-pedidos-aprovados/index.ts
@@ -105,6 +105,18 @@ function getOmieCreds(empresa: string): { app_key: string; app_secret: string } 
   return { app_key, app_secret };
 }
 
+// Email do aprovador p/ o cEmailAprovador do IncluirPedCompra (auto-aprovação no Omie).
+// Por empresa (OMIE_<EMPRESA>_EMAIL_APROVADOR) com fallback global (OMIE_EMAIL_APROVADOR).
+// Sem env var setada → null (degradação honesta: o campo não é enviado e o pedido entra pendente,
+// como hoje). Espelha o padrão por-empresa de getOmieCreds.
+function getEmailAprovador(empresa: string): string | null {
+  const up = empresa.toUpperCase();
+  const email = Deno.env.get(`OMIE_${up}_EMAIL_APROVADOR`) ??
+    Deno.env.get("OMIE_EMAIL_APROVADOR");
+  const trimmed = email?.trim();
+  return trimmed ? trimmed : null;
+}
+
 function diasUteisFromHoje(diasUteis: number): string {
   // soma dias úteis (seg-sex) ao dia de hoje, retorna DD/MM/YYYY
   const d = new Date();
@@ -665,6 +677,15 @@ async function processarPedido(
         }`,
       cObsInt: modo === "dry_run" ? "DRY-RUN Afiação" : "Disparo Afiação",
     };
+
+    // Auto-aprovação no Omie: cEmailAprovador faz o PC entrar JÁ na etapa "aprovado" do kanban
+    // do Omie (em nome do aprovador), sem o clique manual de "Aprovar Pedido" lá dentro. Doc Omie:
+    // preenchido → "o pedido de compra será atribuído a etapa de aprovação com o status de aprovado".
+    // Vale p/ qualquer fornecedor. Sem env var → campo omitido, pedido entra pendente (como hoje).
+    const emailAprovador = getEmailAprovador(pedido.empresa);
+    if (emailAprovador) {
+      cabecalho_incluir.cEmailAprovador = emailAprovador;
+    }
 
     const param = { cabecalho_incluir, produtos_incluir };
 


### PR DESCRIPTION
## O quê

Faz o pedido de compra **entrar já aprovado no Omie** (coluna "aprovados" do kanban do Omie), sem o founder ter que abrir o Omie e clicar "Aprovar Pedido" — pra **qualquer fornecedor**.

## Contexto

Hoje o `disparar-pedidos-aprovados` cria o PC no Omie via `IncluirPedCompra` **sem definir etapa**, então ele entra na etapa pendente/cotação e exige aprovação manual dentro do Omie. (Isso é separado e **não** mexe no gate de aprovação do nosso app/Reposição — aquele continua.)

## Fix

Adiciona o campo **oficial** `cEmailAprovador` ao cabeçalho do `IncluirPedCompra` ([disparar-pedidos-aprovados:652](supabase/functions/disparar-pedidos-aprovados/index.ts)). Doc Omie: preenchido → *"o pedido de compra será atribuído a etapa de aprovação com o status de aprovado"*.

- **Email:** env var por empresa `OMIE_<EMPRESA>_EMAIL_APROVADOR` com fallback global `OMIE_EMAIL_APROVADOR` (espelha `getOmieCreds`).
- **Degradação honesta:** sem env var → campo omitido, pedido entra pendente (como hoje). Não quebra o disparo.
- **Escopo:** todos os fornecedores (`disparar-pedidos-aprovados` é o **único** ponto que cria PC no Omie).

## ⚠️ Validação pendente (importante)

A doc confirma o campo e o comportamento, mas **não mostra um payload de exemplo** com ele. Então a confirmação final é empírica: após deploy, disparar 1 pedido e conferir no Omie que ele entrou na coluna "aprovados". Se o Omie recusar/ignorar → plano B (`UpsertPedCompra` ou ajuste de nome/formato do campo). **Não considerar 100% pronto até essa conferência visual.**

## Apply (founder, após merge)

1. **Setar a env var** no Lovable: `OMIE_EMAIL_APROVADOR = lucascoelhosardenberg@gmail.com`.
2. **Redeploy** da edge `disparar-pedidos-aprovados` (verbatim da main).
3. Disparar 1 pedido e conferir no Omie que entrou aprovado.

**Sem migration.** Spec: `docs/superpowers/specs/2026-06-04-auto-aprovacao-pedido-compra-omie-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
