### PR TITLE
fix(reposição): Codex review da embalagem econômica — demanda do grupo + capital honesto (segue #611)

### DIFF
--- a/src/components/reposicao/pedidos/EmbalagemPanel.tsx
+++ b/src/components/reposicao/pedidos/EmbalagemPanel.tsx
@@ -116,7 +116,7 @@ export function EmbalagemPanel({ empresa, itens }: { empresa: string; itens: Ped
               <div key={sku}>
                 <Label>{sku}</Label>
                 <Input
-                  type="number"
+                  type="text"
                   inputMode="decimal"
                   placeholder="Preço atual"
                   value={precos[sku] ?? ''}
@@ -131,7 +131,7 @@ export function EmbalagemPanel({ empresa, itens }: { empresa: string; itens: Ped
               disabled={salvarPrecos.isPending}
               onClick={() => {
                 const entries = (precoDialog?.skus ?? [])
-                  .map((sku) => ({ sku, preco: Number(precos[sku]) }))
+                  .map((sku) => ({ sku, preco: Number(String(precos[sku] ?? '').replace(',', '.')) }))
                   .filter((e) => e.preco > 0);
                 if (entries.length === 0) {
                   toast.error('Informe ao menos um preço > 0');

--- a/src/components/reposicao/pedidos/useEmbalagemPedido.ts
+++ b/src/components/reposicao/pedidos/useEmbalagemPedido.ts
@@ -46,6 +46,7 @@ export function useEmbalagemPedido(
         .eq('empresa', empresa)
         .eq('ativo', true)
         .in('sku_codigo_omie', skus);
+      if (equivResp.error) throw equivResp.error; // money-path: não degradar silencioso [codex P2]
       const equivDoPedido = (equivResp.data ?? []) as unknown as EquivRow[];
       const gruposEnvolvidos = [...new Set(equivDoPedido.map((e) => e.grupo_id))];
       if (gruposEnvolvidos.length === 0) return {};
@@ -57,6 +58,7 @@ export function useEmbalagemPedido(
         .eq('empresa', empresa)
         .eq('ativo', true)
         .in('grupo_id', gruposEnvolvidos);
+      if (membrosResp.error) throw membrosResp.error;
       const membros = (membrosResp.data ?? []) as unknown as EquivRow[];
       const skusGrupo = [...new Set(membros.map((m) => m.sku_codigo_omie))];
 
@@ -67,6 +69,7 @@ export function useEmbalagemPedido(
         .eq('empresa', empresa)
         .in('sku_codigo_omie', skusGrupo)
         .order('capturado_em', { ascending: false });
+      if (precoResp.error) throw precoResp.error; // senão "sem preço" mascara falha de query [codex P2]
       const precoRows = (precoResp.data ?? []) as unknown as PrecoRow[];
       const precoMap = new Map<string, PrecoRow>();
       for (const p of precoRows) {
@@ -131,14 +134,29 @@ export function useEmbalagemPedido(
         const fator = Number(membro.fator_para_base);
         const qtdItem = Number(item.qtde_final ?? item.qtde_sugerida ?? 0);
         const necessidade_base = qtdItem * fator; // converte a qtd do SKU p/ unidade-base
-        const demanda = demandaMap.get(sku) ?? null;
-        const demanda_base = demanda != null ? demanda * fator : null;
-        const cmPerc = cmMap.get(sku);
-        const custo_capital_anual = cmPerc != null ? Number(cmPerc) / 100 : 0;
+        // Demanda do CONTEÚDO = soma da demanda de cada membro do grupo convertida p/
+        // unidade-base. QT e GL têm giro partido; usar só o SKU do item enviesa o capital
+        // de carrego (rejeitaria GL que na verdade gira como GL). [codex P1]
+        let demanda_base: number | null = null;
+        for (const o of opcoes) {
+          const dm = demandaMap.get(o.sku_codigo_omie);
+          if (dm != null) demanda_base = (demanda_base ?? 0) + dm * o.fator_para_base;
+        }
+        // Custo de capital: qualquer membro do grupo com cm válido serve (≈ da empresa).
+        const cmPercRaw = opcoes
+          .map((o) => cmMap.get(o.sku_codigo_omie))
+          .find((v) => v != null && Number(v) > 0);
+        const cmDisponivel = cmPercRaw != null;
+        // Capital de carrego só é estimável com demanda E custo de capital. Faltando
+        // qualquer um, NÃO zerar o freio: passa demanda null → capital null + flag. [codex P1]
         const decisao = escolherEmbalagemEconomica({
           necessidade_base,
           opcoes,
-          params: { custo_capital_anual, limiar_minimo_economia_rs: limiar, demanda_base_diaria: demanda_base },
+          params: {
+            custo_capital_anual: cmDisponivel ? Number(cmPercRaw) / 100 : 0,
+            limiar_minimo_economia_rs: limiar,
+            demanda_base_diaria: cmDisponivel ? demanda_base : null,
+          },
         });
         result[sku] = { decisao, skusGrupo: opcoes.map((o) => o.sku_codigo_omie) };
       }

--- a/src/lib/reposicao/embalagem-helpers.test.ts
+++ b/src/lib/reposicao/embalagem-helpers.test.ts
@@ -160,4 +160,17 @@ describe('escolherEmbalagemEconomica', () => {
     expect(normal.recomendada).toBe('GL');
     expect(normal.economia_vs_alternativa).toBeGreaterThan(0);
   });
+
+  it('necessidade_base 0 ou negativa → indisponivel', () => {
+    const mk = (n: number) => escolherEmbalagemEconomica({
+      necessidade_base: n,
+      opcoes: [
+        { sku_codigo_omie: 'QT', fator_para_base: 1, preco: 10, preco_status: 'ok' },
+        { sku_codigo_omie: 'GL', fator_para_base: 4, preco: 30, preco_status: 'ok' },
+      ],
+      params: params(),
+    });
+    expect(mk(0).status).toBe('indisponivel');
+    expect(mk(-5).status).toBe('indisponivel');
+  });
 });

--- a/src/lib/reposicao/embalagem-helpers.ts
+++ b/src/lib/reposicao/embalagem-helpers.ts
@@ -87,6 +87,15 @@ export function escolherEmbalagemEconomica(input: {
   const { necessidade_base, opcoes, params } = input;
   const flags: string[] = [];
 
+  // necessidade_base inválida (0/negativa/não-finita) → sem decisão. [codex P2]
+  if (!(necessidade_base > 0) || !Number.isFinite(necessidade_base)) {
+    return {
+      status: 'indisponivel', recomendada: null, opcoes: [],
+      excedente_base: 0, capital_estimado: null, economia_vs_alternativa: 0,
+      flags: ['necessidade_invalida'],
+    };
+  }
+
   // Só preço informado + fator válido contam. < 2 → indisponível.
   const validas = opcoes.filter((o) => o.preco != null && o.fator_para_base > 0 && o.preco_status !== 'falhou');
   if (validas.length < 2) {


### PR DESCRIPTION
## Fix-forward do Codex review — embalagem econômica (segue #611)

O review adversário do Codex (rodado após o merge do #611, quando o limite do Plus resetou) achou 5 itens acionáveis, todos corrigidos aqui. Não muda o caso feliz; endurece os edge cases money-path.

### Corrigido
- **[P1] Capital de carrego usava a demanda do SKU isolado** (`useEmbalagemPedido`). Como QT e GL têm giro partido, isso enviesava o guard de overbuy — podia **rejeitar GL quando ele compensa** (decisão de compra errada). Agora soma a demanda de TODOS os membros do grupo, convertida pra unidade-base (= demanda do conteúdo).
- **[P1] Custo de capital ausente virava `0`** (removia o freio do overbuy sem avisar). Agora: cm ausente → capital `null` + flag `escoamento_nao_estimado` (degradação honesta).
- **[P2] `necessidade_base <= 0`** (item com qtd 0) recomendava arbitrário → agora `indisponivel`. +1 teste.
- **[P2] Erro de query Supabase ignorado** (`data ?? []`) mascarava falha de RLS/tabela como "sem preço". Agora `if (error) throw` nas 3 queries críticas (equivalência, membros, preço).
- **[P3] Vírgula decimal BR** — `Number("12,34")` virava `NaN` e o preço era silenciosamente rejeitado. Input agora aceita vírgula (`type="text"` + `inputMode="decimal"`) e normaliza `,`→`.` no parse.

### Não-objetivos (registrados, fora do escopo)
- Vigência de preço por `(sku, fonte)` — é **Fase 2** (na v1 só existe fonte manual; o "mais recente" funciona).
- Constraint "1 `unidade_base` por grupo" — baixo risco: o cálculo usa o **fator**, não a `unidade_base` (rótulo); cadastro manual de ~12 pares é controlado.

### Validação
helper **13 testes** ✅ · typecheck ✅ · lint ✅ (0 erros) · build ✅.

Sem migration nova (só código). Nenhuma pendência de banco.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
