### PR TITLE
refactor(tint): consolida telas duplicadas + mata KPIs fake (#8)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -92,15 +92,9 @@ const GovernanceCompanies = lazy(() => import("./pages/GovernanceCompanies"));
 const AIops = lazy(() => import("./pages/AIops"));
 const NfeReceipt = lazy(() => import("./pages/NfeReceipt"));
 const TintDashboard = lazy(() => import("./pages/TintDashboard"));
-const TintImport = lazy(() => import("./pages/TintImport"));
-const TintMapping = lazy(() => import("./pages/TintMapping"));
-const TintPricing = lazy(() => import("./pages/TintPricing"));
-const TintFormulas = lazy(() => import("./pages/TintFormulas"));
-const TintCorantes = lazy(() => import("./pages/TintCorantes"));
-const TintIntegrations = lazy(() => import("./pages/TintIntegrations"));
-const TintReconciliation = lazy(() => import("./pages/TintReconciliation"));
-const TintSyncRuns = lazy(() => import("./pages/TintSyncRuns"));
-const TintApiContract = lazy(() => import("./pages/TintApiContract"));
+// Tint standalone (TintImport/Mapping/Pricing/Formulas/Corantes/Integrations/Reconciliation/
+// SyncRuns/ApiContract): import só dentro dos wrappers TintCatalogo/TintIntegracao (abas).
+// As rotas /tintometrico/<tela> antigas viraram redirect pros wrappers (#8).
 const FinanceiroDashboard = lazy(() => import("./pages/FinanceiroDashboard"));
 const FinanceiroSync = lazy(() => import("./pages/FinanceiroSync"));
 const FinanceiroMapping = lazy(() => import("./pages/FinanceiroMapping"));
@@ -317,15 +311,18 @@ const App = () => (
                 <Route path="ai-ops" element={<AIops />} />
                 <Route path="nfe-receipt" element={<NfeReceipt />} />
                 <Route path="tintometrico" element={<TintDashboard />} />
-                <Route path="tintometrico/importar" element={<TintImport />} />
-                <Route path="tintometrico/mapeamento" element={<TintMapping />} />
-                <Route path="tintometrico/precos" element={<TintPricing />} />
-                <Route path="tintometrico/formulas" element={<TintFormulas />} />
-                <Route path="tintometrico/corantes" element={<TintCorantes />} />
-                <Route path="tintometrico/integracoes" element={<TintIntegrations />} />
-                <Route path="tintometrico/reconciliacao" element={<TintReconciliation />} />
-                <Route path="tintometrico/sync-runs" element={<TintSyncRuns />} />
-                <Route path="tintometrico/api-contract" element={<TintApiContract />} />
+                {/* #8: rotas tint standalone consolidadas → abas dos wrappers (Catálogo/Integração).
+                    As telas seguem existindo como abas dos wrappers; aqui só redirecionamos a URL
+                    antiga (preserva bookmark, mata a duplicação de telas). */}
+                <Route path="tintometrico/formulas" element={<Navigate to="/tintometrico/catalogo?tab=formulas" replace />} />
+                <Route path="tintometrico/corantes" element={<Navigate to="/tintometrico/catalogo?tab=corantes" replace />} />
+                <Route path="tintometrico/mapeamento" element={<Navigate to="/tintometrico/catalogo?tab=mapeamento" replace />} />
+                <Route path="tintometrico/precos" element={<Navigate to="/tintometrico/catalogo?tab=precificacao" replace />} />
+                <Route path="tintometrico/importar" element={<Navigate to="/tintometrico/integracao?tab=importar" replace />} />
+                <Route path="tintometrico/integracoes" element={<Navigate to="/tintometrico/integracao?tab=integracoes" replace />} />
+                <Route path="tintometrico/reconciliacao" element={<Navigate to="/tintometrico/integracao?tab=reconciliacao" replace />} />
+                <Route path="tintometrico/sync-runs" element={<Navigate to="/tintometrico/integracao?tab=sync-runs" replace />} />
+                <Route path="tintometrico/api-contract" element={<Navigate to="/tintometrico/integracao?tab=api-contract" replace />} />
                 <Route path="recebimento" element={<Recebimento />} />
                 <Route path="recebimento/:id" element={<RecebimentoConferencia />} />
                 <Route path="producao" element={<ProductionOrders />} />

--- a/src/pages/TintCatalogo.tsx
+++ b/src/pages/TintCatalogo.tsx
@@ -1,24 +1,9 @@
-import { lazy, Suspense, useState } from "react";
+import { lazy, Suspense } from "react";
 import { useSearchParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
-import {
-  Palette,
-  Loader2,
-  FlaskConical,
-  Package,
-  Droplet,
-  Clock,
-  Building2,
-} from "lucide-react";
+import { Palette, Loader2, FlaskConical, Package, Droplet } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { supabase } from "@/integrations/supabase/client";
 
 const TintFormulas = lazy(() => import("./TintFormulas"));
@@ -33,11 +18,9 @@ const TabFallback = () => (
   </div>
 );
 
-function KpiCards({ empresa }: { empresa: string }) {
-  void empresa;
-
+function KpiCards() {
   const { data } = useQuery({
-    queryKey: ["tint-catalogo-kpis", empresa],
+    queryKey: ["tint-catalogo-kpis"],
     queryFn: async () => {
       const [formulas, skusTotal, skusMapeados, corantes] = await Promise.all([
         supabase.from("tint_formulas").select("id", { count: "exact", head: true }).eq("account", "oben"),
@@ -49,45 +32,27 @@ function KpiCards({ empresa }: { empresa: string }) {
           .not("omie_product_id", "is", null),
         supabase.from("tint_corantes").select("id", { count: "exact", head: true }).eq("account", "oben"),
       ]);
-      // TODO: tabela tint_import_runs nao existe ainda; usando "—"
       return {
         formulas: formulas.count ?? 0,
         skusTotal: skusTotal.count ?? 0,
         skusMapeados: skusMapeados.count ?? 0,
         corantes: corantes.count ?? 0,
-        ultimaImport: "—",
       };
     },
   });
 
   const cards = [
-    {
-      label: "Fórmulas Importadas",
-      value: data?.formulas ?? 0,
-      icon: FlaskConical,
-    },
+    { label: "Fórmulas Importadas", value: data?.formulas ?? 0, icon: FlaskConical },
     {
       label: "SKUs Mapeados",
-      value:
-        data === undefined
-          ? 0
-          : `${data.skusMapeados}/${data.skusTotal}`,
+      value: data === undefined ? "…" : `${data.skusMapeados}/${data.skusTotal}`,
       icon: Package,
     },
-    {
-      label: "Corantes",
-      value: data?.corantes ?? 0,
-      icon: Droplet,
-    },
-    {
-      label: "Última Importação",
-      value: data?.ultimaImport ?? "—",
-      icon: Clock,
-    },
+    { label: "Corantes", value: data?.corantes ?? 0, icon: Droplet },
   ];
 
   return (
-    <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+    <div className="grid grid-cols-2 lg:grid-cols-3 gap-4">
       {cards.map((c) => (
         <Card key={c.label} className="border-border">
           <CardContent className="pt-4 flex items-center justify-between">
@@ -106,7 +71,6 @@ function KpiCards({ empresa }: { empresa: string }) {
 export default function TintCatalogo() {
   const [params, setParams] = useSearchParams();
   const tab = params.get("tab") ?? "formulas";
-  const [empresa, setEmpresa] = useState("OBEN");
 
   const handleTab = (v: string) => {
     const next = new URLSearchParams(params);
@@ -126,21 +90,9 @@ export default function TintCatalogo() {
             </p>
           </div>
         </div>
-        <div className="flex items-center gap-2">
-          <Building2 className="h-4 w-4 text-muted-foreground" />
-          <Select value={empresa} onValueChange={setEmpresa}>
-            <SelectTrigger className="w-[140px]">
-              <SelectValue placeholder="Empresa" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="OBEN">OBEN</SelectItem>
-              <SelectItem value="COLACOR">COLACOR</SelectItem>
-            </SelectContent>
-          </Select>
-        </div>
       </header>
 
-      <KpiCards empresa={empresa} />
+      <KpiCards />
 
       <Tabs value={tab} onValueChange={handleTab} className="space-y-4">
         <TabsList className="grid grid-cols-2 sm:grid-cols-4 w-full">

--- a/src/pages/TintIntegracao.tsx
+++ b/src/pages/TintIntegracao.tsx
@@ -1,24 +1,9 @@
-import { lazy, Suspense, useState } from "react";
+import { lazy, Suspense } from "react";
 import { useSearchParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
-import {
-  Plug,
-  Loader2,
-  RefreshCw,
-  CheckCircle2,
-  AlertCircle,
-  Store,
-  Building2,
-} from "lucide-react";
+import { Plug, Loader2, RefreshCw, CheckCircle2, AlertCircle } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { supabase } from "@/integrations/supabase/client";
 
 const TintImport = lazy(() => import("./TintImport"));
@@ -34,11 +19,9 @@ const TabFallback = () => (
   </div>
 );
 
-function KpiCards({ empresa }: { empresa: string }) {
-  void empresa;
-
+function KpiCards() {
   const { data } = useQuery({
-    queryKey: ["tint-integracao-kpis", empresa],
+    queryKey: ["tint-integracao-kpis"],
     queryFn: async () => {
       const [total, completos, erros] = await Promise.all([
         supabase.from("tint_sync_runs").select("id", { count: "exact", head: true }),
@@ -51,12 +34,10 @@ function KpiCards({ empresa }: { empresa: string }) {
           .select("id", { count: "exact", head: true })
           .eq("status", "error"),
       ]);
-      // TODO: tabela tint_integrations nao existe ainda; lojas ativas zerada
       return {
         total: total.count ?? 0,
         completos: completos.count ?? 0,
         erros: erros.count ?? 0,
-        lojasAtivas: 0,
       };
     },
   });
@@ -65,11 +46,10 @@ function KpiCards({ empresa }: { empresa: string }) {
     { label: "Total Sync Runs", value: data?.total ?? 0, icon: RefreshCw },
     { label: "Completos", value: data?.completos ?? 0, icon: CheckCircle2 },
     { label: "Erros", value: data?.erros ?? 0, icon: AlertCircle },
-    { label: "Lojas Ativas", value: data?.lojasAtivas ?? 0, icon: Store },
   ];
 
   return (
-    <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+    <div className="grid grid-cols-2 lg:grid-cols-3 gap-4">
       {cards.map((c) => (
         <Card key={c.label} className="border-border">
           <CardContent className="pt-4 flex items-center justify-between">
@@ -88,7 +68,6 @@ function KpiCards({ empresa }: { empresa: string }) {
 export default function TintIntegracao() {
   const [params, setParams] = useSearchParams();
   const tab = params.get("tab") ?? "importar";
-  const [empresa, setEmpresa] = useState("OBEN");
 
   const handleTab = (v: string) => {
     const next = new URLSearchParams(params);
@@ -108,21 +87,9 @@ export default function TintIntegracao() {
             </p>
           </div>
         </div>
-        <div className="flex items-center gap-2">
-          <Building2 className="h-4 w-4 text-muted-foreground" />
-          <Select value={empresa} onValueChange={setEmpresa}>
-            <SelectTrigger className="w-[140px]">
-              <SelectValue placeholder="Empresa" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="OBEN">OBEN</SelectItem>
-              <SelectItem value="COLACOR">COLACOR</SelectItem>
-            </SelectContent>
-          </Select>
-        </div>
       </header>
 
-      <KpiCards empresa={empresa} />
+      <KpiCards />
 
       <Tabs value={tab} onValueChange={handleTab} className="space-y-4">
         <TabsList className="grid grid-cols-2 sm:grid-cols-5 w-full">


### PR DESCRIPTION
## Contexto (auditoria 2026-06-04, achado #8)

O módulo tintométrico tinha **10 telas standalone** (rotas órfãs alcançáveis só por URL direta) **+ 2 wrappers** (`TintCatalogo`/`TintIntegracao`) que a sidebar de fato usa e que embutem as standalone **como abas** via `?tab=X`. Além disso, os wrappers exibiam **KPIs fake** e **seletores de empresa decorativos**.

## O que muda

### (a) Honestidade de dado nos wrappers
- ❌ removidos 2 KPI cards **FAKE**: "Última Importação" (`="—"`, TODO de `tint_import_runs` inexistente) e "Lojas Ativas" (`=0`, TODO de `tint_integrations` inexistente).
- ✅ sobram só os KPIs **reais** (`tint_formulas`/`tint_skus`/`tint_corantes`/`tint_sync_runs`). "SKUs Mapeados" mostra `…` no loading (não `0`).
- ❌ removidos os 2 **seletores de empresa decorativos** (`empresa` era `void`; as queries já hardcodam `'oben'`).

### (b) Consolidação de telas (`App.tsx`)
- as **9 rotas standalone órfãs** viraram `<Navigate>` pros wrappers com `?tab=X` (preserva bookmark, mata a duplicação). As telas seguem existindo **como abas** dos wrappers — nenhum componente fica órfão.
- removidos os **9 imports lazy órfãos** do `App.tsx` (os wrappers já os importam).

## Validação
- typecheck (strict) **EXIT=0** · lint **0 errors** · suíte **2334 passed** (375 files) · build ✓ · teste `app-route-dedupe` passa (sem dup de `path` reintroduzida).
- **codex review limpo** (sem P1/P2): redirects corretos, gate `RequireStaff` intacto (fail-closed), KPIs restantes todos reais.

Sem migration, sem edge function — front puro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)