### PR TITLE
fix(tarefas-fase2): fecha furo de enforcement no trigger + 2 limpezas P3

### DIFF
--- a/db/test-tarefas-guard-comprovacao.sh
+++ b/db/test-tarefas-guard-comprovacao.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+# Testa o trigger public.tarefas_guard_comprovacao num Postgres 17 local descartável.
+#
+# Prova o FIX do P1 (20260605120000): o guard antigo (bloco_d) só rodava quando
+# coalesce(NEW.requer_comprovacao,false) → um operador podia BURLAR a trava com
+#   UPDATE tarefas SET requer_comprovacao=false, status='concluida'  (num só UPDATE)
+# pois NEW.requer_comprovacao=false fazia o guard pular tudo. O fix adiciona
+# "OR coalesce(OLD.requer_comprovacao,false)" → roda o guard quando a tarefa EXIGIA
+# prova antes, bloqueando o truque.
+#
+# current_user distingue RPC (postgres, allowlist → isenta) de operador (authenticated → enforça).
+# NÃO testo a RLS aqui (a alcançabilidade via policy tarefas_update foi confirmada lendo o código);
+# testo a LÓGICA do trigger: burla bloqueada + fluxos legítimos (adiar/cancelar/RPC/sem-prova) passam.
+#
+# Pré-requisitos: brew install postgresql@17   (mesmo boilerplate de db/verify-snapshot-replay.sh)
+set -euo pipefail
+
+PGVER=17
+PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+PORT=5436
+DATA="$(mktemp -d /tmp/pgtest-guard.XXXXXX)/data"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+export LC_ALL=C LANG=C
+
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente: brew install postgresql@${PGVER}"; exit 1; }
+CELLAR="$(brew --prefix postgresql@${PGVER})"
+cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
+mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
+cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
+
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+trap cleanup EXIT
+
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l /tmp/pg-guard.log -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres guard_test
+P() { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d guard_test "$@"; }
+
+# 1) Schema mínimo que o trigger referencia + role authenticated (simula o operador)
+P -v ON_ERROR_STOP=1 -q <<'SQL'
+DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname='authenticated')
+  THEN CREATE ROLE authenticated; END IF; END $$;
+CREATE TABLE public.tarefas (
+  id bigint PRIMARY KEY,
+  status text NOT NULL DEFAULT 'aberta',
+  requer_comprovacao boolean,
+  comprovacao_url text,
+  comprovacao_leitura numeric,
+  comprovacao_em timestamptz,
+  auditoria_status text NOT NULL DEFAULT 'nao_requer',
+  auditada_por uuid,
+  adiada_para timestamptz,
+  motivo_adiamento text,
+  updated_at timestamptz DEFAULT now()
+);
+GRANT SELECT, UPDATE ON public.tarefas TO authenticated;
+SQL
+
+# 2) FUNÇÃO ANTIGA (com o bug) + trigger — prova que a burla PASSA
+P -v ON_ERROR_STOP=1 -q <<'SQL'
+create or replace function public.tarefas_guard_comprovacao()
+returns trigger language plpgsql security invoker as $$
+begin
+  if coalesce(new.requer_comprovacao, false) then   -- BUG: só NEW
+    if new.status = 'concluida' and old.status is distinct from 'concluida'
+       and current_user not in ('postgres','service_role','supabase_admin') then
+      raise exception 'Tarefa com comprovação só conclui via concluir_com_comprovacao()';
+    end if;
+    if current_user not in ('postgres','service_role','supabase_admin') and (
+         new.comprovacao_url is distinct from old.comprovacao_url
+      or new.requer_comprovacao is distinct from old.requer_comprovacao
+    ) then
+      raise exception 'Campos de comprovação/auditoria só mudam via RPC';
+    end if;
+  end if;
+  return new;
+end $$;
+drop trigger if exists trg_tarefas_guard_comprovacao on public.tarefas;
+create trigger trg_tarefas_guard_comprovacao
+  before update on public.tarefas for each row execute function public.tarefas_guard_comprovacao();
+
+INSERT INTO public.tarefas (id, status, requer_comprovacao) VALUES (1, 'aberta', true);
+
+DO $$
+DECLARE st text;
+BEGIN
+  SET LOCAL ROLE authenticated;
+  -- O1: a BURLA na função antiga — zerar requer_comprovacao + concluir num só UPDATE
+  UPDATE public.tarefas SET requer_comprovacao = false, status = 'concluida' WHERE id = 1;
+  RESET ROLE;
+  SELECT status INTO st FROM public.tarefas WHERE id = 1;
+  ASSERT st = 'concluida', format('O1 esperava bypass passar na fn ANTIGA, status=%L', st);
+  RAISE NOTICE 'O1 OK (fn ANTIGA): burla PASSOU (status=concluida sem prova) — bug reproduzido';
+END $$;
+SQL
+
+echo ""
+echo "=== aplicando a migration do FIX (20260605120000) ==="
+P -v ON_ERROR_STOP=1 -q -f "$REPO_ROOT/supabase/migrations/20260605120000_tarefas_guard_old_requer.sql"
+
+# 3) FUNÇÃO NOVA (fix) — burla bloqueada + fluxos legítimos passam
+echo ""
+echo "ASSERTS (fn NOVA):"
+P -v ON_ERROR_STOP=1 -q <<'SQL'
+-- re-seed (ids distintos por teste p/ isolar estado)
+INSERT INTO public.tarefas (id, status, requer_comprovacao) VALUES
+  (10, 'aberta', true),   -- N1 burla combinada
+  (11, 'aberta', true),   -- N2 concluir deixando requer=true
+  (12, 'aberta', true),   -- N3 zerar requer sozinho
+  (13, 'aberta', true),   -- N4 adiar (legítimo)
+  (14, 'aberta', true),   -- N5 cancelar (legítimo)
+  (15, 'aberta', true),   -- N6 RPC (postgres)
+  (16, 'aberta', false);  -- N7 tarefa sem prova
+
+-- N1: burla combinada (requer=false + concluida) → BLOQUEADA
+DO $$
+BEGIN
+  SET LOCAL ROLE authenticated;
+  BEGIN
+    UPDATE public.tarefas SET requer_comprovacao = false, status = 'concluida' WHERE id = 10;
+    RESET ROLE;
+    RAISE EXCEPTION 'N1_FALHOU_BYPASS_PASSOU';
+  EXCEPTION
+    WHEN sqlstate 'P0001' THEN
+      RESET ROLE;
+      IF SQLERRM LIKE 'N1_FALHOU%' THEN RAISE EXCEPTION 'N1 FALHOU: a burla passou na fn NOVA (deveria bloquear)'; END IF;
+      RAISE NOTICE 'N1 OK: burla combinada BLOQUEADA (%)', SQLERRM;
+  END;
+END $$;
+
+-- N2: concluir deixando requer=true → BLOQUEADA (bloco de conclusão)
+DO $$
+BEGIN
+  SET LOCAL ROLE authenticated;
+  BEGIN
+    UPDATE public.tarefas SET status = 'concluida' WHERE id = 11;
+    RESET ROLE;
+    RAISE EXCEPTION 'N2_FALHOU';
+  EXCEPTION WHEN sqlstate 'P0001' THEN
+    RESET ROLE;
+    IF SQLERRM LIKE 'N2_FALHOU%' THEN RAISE EXCEPTION 'N2 FALHOU: conclusão direta passou'; END IF;
+    RAISE NOTICE 'N2 OK: conclusão direta BLOQUEADA (%)', SQLERRM;
+  END;
+END $$;
+
+-- N3: zerar requer_comprovacao sozinho → BLOQUEADA (bloco de campos)
+DO $$
+BEGIN
+  SET LOCAL ROLE authenticated;
+  BEGIN
+    UPDATE public.tarefas SET requer_comprovacao = false WHERE id = 12;
+    RESET ROLE;
+    RAISE EXCEPTION 'N3_FALHOU';
+  EXCEPTION WHEN sqlstate 'P0001' THEN
+    RESET ROLE;
+    IF SQLERRM LIKE 'N3_FALHOU%' THEN RAISE EXCEPTION 'N3 FALHOU: desligar requer passou'; END IF;
+    RAISE NOTICE 'N3 OK: desligar requer_comprovacao BLOQUEADO (%)', SQLERRM;
+  END;
+END $$;
+
+-- N4: ADIAR (legítimo) → PASSA
+DO $$
+DECLARE d timestamptz;
+BEGIN
+  SET LOCAL ROLE authenticated;
+  UPDATE public.tarefas SET adiada_para = now() + interval '1 day', motivo_adiamento = 'cliente pediu' WHERE id = 13;
+  RESET ROLE;
+  SELECT adiada_para INTO d FROM public.tarefas WHERE id = 13;
+  ASSERT d IS NOT NULL, 'N4 adiar deveria passar';
+  RAISE NOTICE 'N4 OK: adiar (tarefa com prova) PASSOU';
+END $$;
+
+-- N5: CANCELAR (legítimo) → PASSA
+DO $$
+DECLARE st text;
+BEGIN
+  SET LOCAL ROLE authenticated;
+  UPDATE public.tarefas SET status = 'cancelada' WHERE id = 14;
+  RESET ROLE;
+  SELECT status INTO st FROM public.tarefas WHERE id = 14;
+  ASSERT st = 'cancelada', format('N5 cancelar deveria passar, status=%L', st);
+  RAISE NOTICE 'N5 OK: cancelar (tarefa com prova) PASSOU';
+END $$;
+
+-- N6: RPC path (current_user=postgres) → PASSA (concluir com prova)
+DO $$
+DECLARE st text;
+BEGIN
+  -- sem SET ROLE → current_user=postgres (allowlist) = simula SECURITY DEFINER da RPC
+  UPDATE public.tarefas SET status = 'concluida', comprovacao_url = 'uid/15/x.jpg', comprovacao_em = now() WHERE id = 15;
+  SELECT status INTO st FROM public.tarefas WHERE id = 15;
+  ASSERT st = 'concluida', format('N6 RPC deveria concluir, status=%L', st);
+  RAISE NOTICE 'N6 OK: caminho RPC (postgres) concluiu com prova';
+END $$;
+
+-- N7: tarefa SEM prova (requer=false desde sempre) → conclusão direta PASSA
+DO $$
+DECLARE st text;
+BEGIN
+  SET LOCAL ROLE authenticated;
+  UPDATE public.tarefas SET status = 'concluida' WHERE id = 16;
+  RESET ROLE;
+  SELECT status INTO st FROM public.tarefas WHERE id = 16;
+  ASSERT st = 'concluida', format('N7 tarefa sem prova deveria concluir, status=%L', st);
+  RAISE NOTICE 'N7 OK: tarefa sem comprovação conclui direto (guard não interfere)';
+END $$;
+SQL
+
+echo ""
+echo "TODOS OS ASSERTS PASSARAM ✅  (burla bloqueada na fn nova; adiar/cancelar/RPC/sem-prova OK)"

--- a/src/components/tarefas/ProvasParaAuditar.tsx
+++ b/src/components/tarefas/ProvasParaAuditar.tsx
@@ -299,7 +299,6 @@ export function ProvasParaAuditar() {
                       <div className="mt-1.5 flex items-center gap-1.5">
                         <Badge variant="outline" className="text-xs font-mono">
                           {prova.comprovacao_leitura?.toLocaleString('pt-BR')}
-                          {prova.tipo_comprovacao?.includes('leitura') && ''}
                         </Badge>
                         <span className="text-xs text-muted-foreground">leitura</span>
                       </div>

--- a/src/pages/TarefasTemplates.tsx
+++ b/src/pages/TarefasTemplates.tsx
@@ -167,6 +167,11 @@ function formParaPayload(
   f: FormValues,
   userId: string,
 ): Omit<TarefaTemplate, 'id' | 'created_at' | 'updated_at'> {
+  // Tipo efetivo: 'nenhuma' quando não exige comprovação.
+  const tipoEfetivo = f.requer_comprovacao ? f.tipo_comprovacao : 'nenhuma';
+  // Só grava faixa de leitura quando o tipo efetivamente inclui leitura — senão
+  // um template que trocou de 'leitura'→'foto' carregaria faixa órfã (UI-5).
+  const incluiLeitura = tipoEfetivo === 'leitura' || tipoEfetivo === 'foto_e_leitura';
   return {
     descricao: f.descricao.trim(),
     categoria: f.categoria,
@@ -180,10 +185,10 @@ function formParaPayload(
     janela_fim: f.janela_fim || null,
     tolerancia_dias: Math.max(0, parseInt(f.tolerancia_dias, 10) || 0),
     requer_comprovacao: f.requer_comprovacao,
-    tipo_comprovacao: f.requer_comprovacao ? f.tipo_comprovacao : 'nenhuma',
-    leitura_min: f.leitura_min.trim() !== '' ? parseFloat(f.leitura_min) : null,
-    leitura_max: f.leitura_max.trim() !== '' ? parseFloat(f.leitura_max) : null,
-    leitura_unidade: f.leitura_unidade.trim() || null,
+    tipo_comprovacao: tipoEfetivo,
+    leitura_min: incluiLeitura && f.leitura_min.trim() !== '' ? parseFloat(f.leitura_min) : null,
+    leitura_max: incluiLeitura && f.leitura_max.trim() !== '' ? parseFloat(f.leitura_max) : null,
+    leitura_unidade: incluiLeitura ? (f.leitura_unidade.trim() || null) : null,
     alto_risco: f.alto_risco,
     amostra_auditoria_pct: Math.min(100, Math.max(0, parseInt(f.amostra_auditoria_pct, 10) || 10)),
     reincidente_limite: Math.max(1, parseInt(f.reincidente_limite, 10) || 3),

--- a/supabase/migrations/20260605120000_tarefas_guard_old_requer.sql
+++ b/supabase/migrations/20260605120000_tarefas_guard_old_requer.sql
@@ -1,0 +1,53 @@
+-- 20260605120000_tarefas_guard_old_requer.sql
+-- Tarefas Fase 2 — FECHA FURO DE ENFORCEMENT (P1) no trigger anti-bypass.
+--
+-- BUG: tarefas_guard_comprovacao (bloco_d) só executava o corpo quando
+--   `coalesce(NEW.requer_comprovacao, false)`. A policy `tarefas_update` (bloco_c)
+--   deixa o assigned_to dar UPDATE na própria tarefa via PostgREST SEM with-check.
+--   Logo um operador podia BURLAR a trava com:
+--     PATCH /rest/v1/tarefas?id=eq.X  { requer_comprovacao:false, status:'concluida' }
+--   → NEW.requer_comprovacao=false → o guard pulava TUDO → tarefa concluída SEM foto/leitura.
+--
+-- FIX: o guard passa a rodar quando NEW **ou** OLD exigem comprovação. Assim, se a
+--   tarefa HOJE exige prova (OLD=true), qualquer tentativa de (a) concluí-la fora da RPC
+--   ou (b) mudar/zerar os campos de comprovação/auditoria (incl. requer_comprovacao) é
+--   bloqueada — mesmo que o UPDATE tente desligar requer_comprovacao na mesma operação.
+--
+-- NÃO afeta fluxos legítimos: adiar/cancelar (status≠concluida, sem mexer em campos de prova)
+--   continuam passando; as RPCs concluir_com_comprovacao/auditar_tarefa rodam como postgres
+--   (SECURITY DEFINER) → current_user na allowlist → seguem isentas. Materialização é INSERT
+--   (trigger é BEFORE UPDATE) → não afetada.
+--
+-- ATENÇÃO: migration manual necessária (CREATE OR REPLACE — colar no SQL Editor do Lovable).
+
+create or replace function public.tarefas_guard_comprovacao()
+returns trigger language plpgsql security invoker as $$
+begin
+  -- roda quando a tarefa exige prova AGORA (new) OU exigia antes (old) — fecha o
+  -- truque de zerar requer_comprovacao no mesmo UPDATE que conclui.
+  if coalesce(new.requer_comprovacao, false) or coalesce(old.requer_comprovacao, false) then
+    if new.status = 'concluida' and old.status is distinct from 'concluida'
+       and current_user not in ('postgres','service_role','supabase_admin') then
+      raise exception 'Tarefa com comprovação só conclui via concluir_com_comprovacao()';
+    end if;
+    if current_user not in ('postgres','service_role','supabase_admin') and (
+         new.comprovacao_url       is distinct from old.comprovacao_url
+      or new.comprovacao_leitura   is distinct from old.comprovacao_leitura
+      or new.comprovacao_em        is distinct from old.comprovacao_em
+      or new.auditoria_status      is distinct from old.auditoria_status
+      or new.auditada_por          is distinct from old.auditada_por
+      or new.requer_comprovacao    is distinct from old.requer_comprovacao
+    ) then
+      raise exception 'Campos de comprovação/auditoria só mudam via RPC';
+    end if;
+  end if;
+  return new;
+end $$;
+
+-- validação: o corpo da função agora referencia old.requer_comprovacao (= fix aplicado)
+select 'F2 GUARD OLD-REQUER OK' as status,
+  (select count(*) from pg_proc where proname='tarefas_guard_comprovacao') as func,
+  (select (pg_get_functiondef(oid) ilike '%old.requer_comprovacao, false%')
+     from pg_proc where proname='tarefas_guard_comprovacao') as fix_aplicado,
+  (select count(*) from pg_trigger where tgname='trg_tarefas_guard_comprovacao') as trg;
+-- Expected: func=1, fix_aplicado=true, trg=1


### PR DESCRIPTION
## ⚠️ ATENÇÃO: migration manual necessária

`supabase/migrations/20260605120000_tarefas_guard_old_requer.sql` — **colar no SQL Editor do Lovable** (idempotente, `CREATE OR REPLACE`). O bloco SQL foi entregue na conversa.

## Contexto
Revisão adversária **pré-QA** da Fase 2 (workflow de reviewers paralelos + verificação manual do SQL). Achou 1 P1 de enforcement + 2 limpezas P3.

## 🔴 P1 — furo de enforcement no trigger
`tarefas_guard_comprovacao` só executava o corpo quando `coalesce(NEW.requer_comprovacao,false)`. A policy `tarefas_update` (Fase 1, bloco_c) permite ao `assigned_to` dar UPDATE na própria tarefa via PostgREST **sem with-check** → um operador podia **burlar a trava**:

```
PATCH /rest/v1/tarefas?id=eq.X  { requer_comprovacao:false, status:'concluida' }
```

→ `NEW.requer_comprovacao=false` fazia o guard pular tudo → tarefa concluída **sem foto/leitura**. Derrota o anti-burla que é a razão da Fase 2 existir.

**Fix:** o guard passa a rodar quando `NEW` **OU** `OLD` exigem comprovação. Se a tarefa exige prova hoje (`OLD=true`), qualquer tentativa de concluir fora da RPC ou mexer nos campos de prova/requer é bloqueada — mesmo zerando `requer_comprovacao` no mesmo UPDATE.

**Provado em PG17** (`db/test-tarefas-guard-comprovacao.sh`): burla **passa** na fn antiga (bug reproduzido), é **bloqueada** na nova (N1/N2/N3); adiar/cancelar/RPC/tarefa-sem-prova **seguem passando** (N4–N7). RPCs rodam como `postgres` (SECURITY DEFINER, allowlist) → isentas.

## ⚪ P3 (frontend, baixo impacto)
- **UI-5** — `formParaPayload` gravava faixa de leitura mesmo em template tipo 'foto' (faixa órfã se o gestor trocasse o tipo depois). Agora gated por tipo efetivo (espelha o que já se faz com `dias_semana`).
- **UI-6** — removido JSX morto `{... && ''}` no badge de leitura da auditoria.

## Não incluído (follow-up proposto)
- **UI-3 (P2-UX):** faixa de leitura some no dialog em cobertura/férias (RLS de `tarefa_templates` não inclui cobertura). **Enforcement intacto** (RPC trava no servidor); caminho-feliz normal mostra a faixa. Fix robusto = denormalizar `leitura_min/max/unidade` na instância — apresentado ao founder pra decisão.

Typecheck 0 erros · lint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)