### PR TITLE
feat(tarefas-fase2): UI-3 — faixa de leitura na instância (fim do gap de RLS em cobertura)

### DIFF
--- a/db/test-tarefas-leitura-instancia.sh
+++ b/db/test-tarefas-leitura-instancia.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# Valida 20260605130000_tarefas_leitura_na_instancia.sql num Postgres 17 descartável.
+# Prova: (1) a migration APLICA limpa (view DROP+CREATE verbatim + materializador reproduzidos
+# sem typo); (2) o backfill copia a faixa do template p/ a instância aberta; (3) a view EXPÕE
+# leitura_* (b.* re-expandido); (4) o materializador copia leitura_* nas novas instâncias.
+set -euo pipefail
+
+PGVER=17
+PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+PORT=5437
+DATA="$(mktemp -d /tmp/pgtest-leitura.XXXXXX)/data"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+export LC_ALL=C LANG=C
+
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente: brew install postgresql@${PGVER}"; exit 1; }
+CELLAR="$(brew --prefix postgresql@${PGVER})"
+cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
+mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
+cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
+
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+trap cleanup EXIT
+
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l /tmp/pg-leitura.log -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres leitura_test
+P() { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d leitura_test "$@"; }
+
+# 1) Schema mínimo que a migration referencia (estado PRÉ-UI3: tarefas SEM leitura_*)
+P -v ON_ERROR_STOP=1 -q <<'SQL'
+create table public.profiles (user_id uuid primary key);
+create table public.calendario_feriados (data date primary key);
+create table public.carteira_coverage (
+  covered_user_id uuid, covering_user_id uuid, active boolean,
+  valid_from timestamptz, valid_until timestamptz
+);
+create table public.tarefa_eventos (
+  id bigint generated always as identity primary key,
+  tarefa_id bigint, tipo_evento text, ator uuid, payload jsonb
+);
+create table public.tarefa_templates (
+  id bigint primary key,
+  descricao text, categoria text, customer_user_id uuid, assigned_to uuid, created_by uuid,
+  empresa text, cadencia text, dias_semana int[], janela_fim time, tolerancia_dias int,
+  requer_comprovacao boolean, tipo_comprovacao text, leitura_min numeric, leitura_max numeric,
+  leitura_unidade text, supervisor_user_id uuid, ativo boolean
+);
+create table public.tarefas (
+  id bigint generated always as identity primary key,
+  descricao text, categoria text, customer_user_id uuid, assigned_to uuid, created_by uuid,
+  empresa text, modo text, due_date date, backstop_days int default 7, tolerancia_dias int default 0,
+  auto_satisfy_mode text, status text default 'aberta', template_id bigint,
+  requer_comprovacao boolean, tipo_comprovacao text, janela_fim time, supervisor_user_id uuid,
+  auditoria_status text default 'nao_requer', adiada_para timestamptz, escalado_em timestamptz,
+  created_at timestamptz default now()
+);
+create table public.tarefa_satisfacao_candidatos (tarefa_id bigint, status text);
+
+-- assignee com perfil (materializador não pula)
+insert into public.profiles values ('11111111-1111-1111-1111-111111111111');
+
+-- template de LEITURA, diário, ativo, faixa 7,0–7,5 pH
+insert into public.tarefa_templates
+  (id, descricao, categoria, assigned_to, created_by, empresa, cadencia, dias_semana, janela_fim,
+   tolerancia_dias, requer_comprovacao, tipo_comprovacao, leitura_min, leitura_max, leitura_unidade, ativo)
+values
+  (1, 'Medir pH do tanque', 'outro', '11111111-1111-1111-1111-111111111111',
+   '11111111-1111-1111-1111-111111111111', 'oben', 'diaria', null, '17:00', 1,
+   true, 'leitura', 7.0, 7.5, 'pH', true);
+
+-- instância ABERTA de leitura no PASSADO (due_date distinto de hoje), SEM leitura_* (col não existe ainda)
+insert into public.tarefas
+  (descricao, categoria, assigned_to, created_by, empresa, modo, due_date, status, template_id,
+   requer_comprovacao, tipo_comprovacao, janela_fim)
+values
+  ('Medir pH do tanque', 'outro', '11111111-1111-1111-1111-111111111111',
+   '11111111-1111-1111-1111-111111111111', 'oben', 'data', current_date - 3, 'aberta', 1,
+   true, 'leitura', '17:00');
+SQL
+
+echo "=== aplicando a migration UI-3 (20260605130000) ==="
+P -v ON_ERROR_STOP=1 -f "$REPO_ROOT/supabase/migrations/20260605130000_tarefas_leitura_na_instancia.sql"
+
+echo ""
+echo "ASSERTS:"
+P -v ON_ERROR_STOP=1 -q <<'SQL'
+DO $$
+DECLARE n int; mn numeric; un text; vmn numeric;
+BEGIN
+  -- A1: colunas criadas na instância
+  SELECT count(*) INTO n FROM information_schema.columns
+    WHERE table_name='tarefas' AND column_name IN ('leitura_min','leitura_max','leitura_unidade');
+  ASSERT n = 3, format('A1 esperava 3 colunas novas, veio %s', n);
+
+  -- A2: backfill copiou a faixa do template p/ a instância aberta
+  SELECT leitura_min, leitura_unidade INTO mn, un FROM public.tarefas WHERE template_id = 1 AND due_date = current_date - 3;
+  ASSERT mn = 7.0 AND un = 'pH', format('A2 backfill esperava 7.0/pH, veio %s/%s', mn, un);
+
+  -- A3: a view EXPÕE leitura_* (b.* re-expandido)
+  SELECT leitura_min INTO vmn FROM public.v_tarefas_estado WHERE template_id = 1 AND due_date = current_date - 3;
+  ASSERT vmn = 7.0, format('A3 view deveria expor leitura_min=7.0, veio %s', vmn);
+
+  RAISE NOTICE 'A1..A3 OK: colunas + backfill + view expõe a faixa';
+
+  -- A4: materializador copia leitura_* nas instâncias de HOJE
+  PERFORM public.tarefas_materializar_recorrentes();
+  SELECT leitura_min, leitura_unidade INTO mn, un FROM public.tarefas
+    WHERE template_id = 1 AND due_date = current_date;
+  ASSERT mn = 7.0 AND un = 'pH', format('A4 materializador esperava copiar 7.0/pH p/ hoje, veio %s/%s', mn, un);
+
+  -- A5: a instância de hoje também aparece com a faixa na view
+  SELECT leitura_min INTO vmn FROM public.v_tarefas_estado WHERE template_id = 1 AND due_date = current_date;
+  ASSERT vmn = 7.0, format('A5 view (hoje) esperava 7.0, veio %s', vmn);
+
+  RAISE NOTICE 'A4..A5 OK: materializador copia a faixa + view expõe nas novas instâncias';
+END $$;
+SQL
+
+echo ""
+echo "TODOS OS ASSERTS PASSARAM ✅  (UI-3: faixa na instância — sem gap de RLS de cobertura)"

--- a/src/components/tarefas/ProvasParaAuditar.tsx
+++ b/src/components/tarefas/ProvasParaAuditar.tsx
@@ -299,8 +299,14 @@ export function ProvasParaAuditar() {
                       <div className="mt-1.5 flex items-center gap-1.5">
                         <Badge variant="outline" className="text-xs font-mono">
                           {prova.comprovacao_leitura?.toLocaleString('pt-BR')}
+                          {prova.leitura_unidade ? ` ${prova.leitura_unidade}` : ''}
                         </Badge>
-                        <span className="text-xs text-muted-foreground">leitura</span>
+                        <span className="text-xs text-muted-foreground">
+                          leitura
+                          {prova.leitura_min != null && prova.leitura_max != null
+                            ? ` · faixa ${prova.leitura_min.toLocaleString('pt-BR')}–${prova.leitura_max.toLocaleString('pt-BR')}`
+                            : ''}
+                        </span>
                       </div>
                     )}
 

--- a/src/components/tarefas/RecorrentesHojeCard.tsx
+++ b/src/components/tarefas/RecorrentesHojeCard.tsx
@@ -10,10 +10,9 @@
  *   - SEM comprovação → concluir('manual') — update direto, mesma rota da Fase 1;
  *     o trigger anti-bypass não bloqueia pois requer_comprovacao=false.
  *
- * Os limites de leitura (leituraMin/Max/Unidade) que o ComprovacaoDialog exige
- * não estão na TarefaInstancia (a view não expõe os campos do template pai).
- * Solução: buscar o template pelo template_id apenas quando o dialog é aberto
- * (lazy — evita N+1 na listagem). Se não encontrar, passa null (o dialog aceita).
+ * Os limites de leitura (leituraMin/Max/Unidade) vêm da PRÓPRIA instância
+ * (denormalizados do template na materialização — UI-3). Isso evita o gap de
+ * RLS em cobertura/férias, onde a tarefa aparece mas o template não é visível.
  */
 
 import { useState } from 'react';
@@ -21,16 +20,14 @@ import { AlertTriangle, CheckCircle2, Clock, Loader2 } from 'lucide-react';
 import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { useMinhasRecorrentesHoje } from '@/hooks/useTarefasFase2';
-import { useTemplates } from '@/hooks/useTarefasFase2';
 import { useTarefaMutations } from '@/hooks/useTarefas';
 import { useImpersonation } from '@/contexts/ImpersonationContext';
 import { ComprovacaoDialog } from './ComprovacaoDialog';
-import type { TarefaInstancia, TarefaTemplate } from '@/lib/tarefas/templates-types';
+import type { TarefaInstancia } from '@/lib/tarefas/templates-types';
 
 export function RecorrentesHojeCard() {
   const { isImpersonating } = useImpersonation();
   const { data: tarefas = [], isLoading } = useMinhasRecorrentesHoje();
-  const { data: templates = [] } = useTemplates();
   const { concluir } = useTarefaMutations();
 
   // Dialog de comprovação
@@ -41,18 +38,6 @@ export function RecorrentesHojeCard() {
 
   // Retorna null quando não há tarefas (não polui o dashboard)
   if (isLoading || tarefas.length === 0) return null;
-
-  // ---------------------------------------------------------------------------
-  // Resolução dos limites de leitura do template (lazy, só quando dialog abre)
-  // ---------------------------------------------------------------------------
-
-  const templatePorId = new Map<string, TarefaTemplate>(
-    templates.map((t) => [t.id, t]),
-  );
-
-  const templateDoAlvo = dialogAlvo?.template_id
-    ? templatePorId.get(dialogAlvo.template_id) ?? null
-    : null;
 
   // ---------------------------------------------------------------------------
   // Handlers
@@ -155,9 +140,9 @@ export function RecorrentesHojeCard() {
           open={!!dialogAlvo}
           onOpenChange={(o) => { if (!o) setDialogAlvo(null); }}
           tarefa={dialogAlvo}
-          leituraMin={templateDoAlvo?.leitura_min ?? null}
-          leituraMax={templateDoAlvo?.leitura_max ?? null}
-          leituraUnidade={templateDoAlvo?.leitura_unidade ?? null}
+          leituraMin={dialogAlvo.leitura_min ?? null}
+          leituraMax={dialogAlvo.leitura_max ?? null}
+          leituraUnidade={dialogAlvo.leitura_unidade ?? null}
         />
       )}
     </>

--- a/src/lib/tarefas/templates-types.ts
+++ b/src/lib/tarefas/templates-types.ts
@@ -62,6 +62,10 @@ export interface TarefaInstancia extends TarefaEstado {
   auditoria_status: TarefaAuditoriaStatus;
   auditoria_motivo: string | null;
   tipo_comprovacao: TarefaTipoComprovacao | null;
+  /** Faixa de leitura denormalizada do template na instância (UI-3) — sem gap de RLS de cobertura. */
+  leitura_min: number | null;
+  leitura_max: number | null;
+  leitura_unidade: string | null;
   /** Leitura numérica anexada na conclusão */
   comprovacao_leitura: number | null;
   /** Timestamptz de quando a prova foi enviada */

--- a/supabase/migrations/20260605130000_tarefas_leitura_na_instancia.sql
+++ b/supabase/migrations/20260605130000_tarefas_leitura_na_instancia.sql
@@ -1,0 +1,123 @@
+-- 20260605130000_tarefas_leitura_na_instancia.sql
+-- Tarefas Fase 2 — UI-3: denormaliza a faixa de leitura (min/max/unidade) na INSTÂNCIA.
+--
+-- PROBLEMA: o ComprovacaoDialog mostra a faixa lendo o TEMPLATE via useTemplates(), que
+--   depende da RLS tt_select (assigned_to=uid OR gestor). Em COBERTURA/férias a tarefa
+--   aparece (responsavel_efetivo inclui cobertura) mas o template NÃO é visível → a faixa
+--   some do dialog e a validação client vira no-op. O enforcement seguia intacto (a RPC
+--   concluir_com_comprovacao lê tt server-side), mas a UX quebrava (operador só via o erro
+--   no round-trip do servidor). Mesma falta atinge a auditoria (sem a unidade — UI-6).
+--
+-- SOLUÇÃO: copiar leitura_min/max/unidade do template para a instância (colunas em `tarefas`),
+--   expor via b.* na view, e o frontend lê da INSTÂNCIA (sem join ao template → sem gap de RLS).
+--
+-- ATENÇÃO: migration manual necessária (colar no SQL Editor do Lovable).
+
+begin;
+
+-- 1) colunas de faixa na instância (denormalizadas do template)
+alter table public.tarefas
+  add column if not exists leitura_min numeric,
+  add column if not exists leitura_max numeric,
+  add column if not exists leitura_unidade text;
+
+-- 2) backfill das instâncias ABERTAS de leitura a partir do template (idempotente)
+update public.tarefas t set
+  leitura_min     = tpl.leitura_min,
+  leitura_max     = tpl.leitura_max,
+  leitura_unidade = tpl.leitura_unidade
+from public.tarefa_templates tpl
+where t.template_id = tpl.id
+  and t.status = 'aberta'
+  and t.tipo_comprovacao in ('leitura', 'foto_e_leitura')
+  and t.leitura_min is null and t.leitura_max is null and t.leitura_unidade is null;
+
+-- 3) v_tarefas_estado re-expande b.* (agora carrega leitura_*). DROP+CREATE porque
+--    REPLACE não reordena/adiciona colunas de `select t.*`. Corpo VERBATIM da fase2 bloco_c
+--    (20260601102000) — só o conjunto de colunas de `tarefas` mudou (ganhou leitura_*).
+drop view if exists public.v_tarefas_estado;
+create view public.v_tarefas_estado
+with (security_invoker = on) as
+with base as (
+  select t.*,
+    coalesce(
+      (t.adiada_para at time zone 'America/Sao_Paulo')::date,
+      t.due_date,
+      (t.created_at at time zone 'America/Sao_Paulo')::date + t.backstop_days
+    ) as effective_due,
+    coalesce(
+      (select cc.covering_user_id from public.carteira_coverage cc
+        where cc.covered_user_id = t.assigned_to and cc.active
+          and now() >= cc.valid_from and (cc.valid_until is null or now() <= cc.valid_until)
+        order by cc.valid_from desc limit 1),
+      t.assigned_to
+    ) as responsavel_efetivo
+  from public.tarefas t
+), nowsp as (
+  select (now() at time zone 'America/Sao_Paulo')::date as dia,
+         (now() at time zone 'America/Sao_Paulo')::time as hora
+)
+select b.*,
+  (b.status = 'aberta' and (
+     n.dia > b.effective_due
+     or (n.dia = b.effective_due and b.janela_fim is not null and n.hora > b.janela_fim)
+  )) as atrasada,
+  (b.status = 'aberta' and b.escalado_em is null and (
+     n.dia > (b.effective_due + b.tolerancia_dias)
+     or (b.tolerancia_dias = 0 and n.dia = b.effective_due and b.janela_fim is not null and n.hora > b.janela_fim)
+  )) as escalavel,
+  exists (select 1 from public.tarefa_satisfacao_candidatos c
+          where c.tarefa_id = b.id and c.status = 'pending') as tem_sugestao_pendente,
+  (b.auditoria_status = 'pendente') as requer_auditoria
+from base b cross join nowsp n;
+
+commit;
+
+-- 4) materializador copia leitura_* nas novas instâncias. Corpo VERBATIM da bloco_d
+--    (20260601103000) + as 3 colunas de leitura no INSERT/SELECT.
+create or replace function public.tarefas_materializar_recorrentes()
+returns void language plpgsql security definer set search_path = public as $$
+declare tpl record; d date; hoje date := (now() at time zone 'America/Sao_Paulo')::date; dispara boolean;
+begin
+  for tpl in select * from public.tarefa_templates where ativo loop
+    if not exists (select 1 from public.profiles p where p.user_id = tpl.assigned_to) then
+      insert into public.tarefa_eventos (tarefa_id, tipo_evento, ator, payload)
+      values (null, 'materializacao_pulada', null, jsonb_build_object('template_id', tpl.id, 'motivo', 'assignee_sem_perfil'));
+      continue;
+    end if;
+    d := hoje - 6;  -- backfill janela 7 dias
+    while d <= hoje loop
+      dispara := case tpl.cadencia
+        when 'diaria' then true
+        when 'dias_uteis' then (extract(dow from d) between 1 and 5)
+                               and not exists (select 1 from public.calendario_feriados f where f.data = d)
+        when 'semanal' then extract(dow from d)::int = any(tpl.dias_semana)
+        when 'dias_especificos' then extract(dow from d)::int = any(tpl.dias_semana)
+        else false end;
+      if dispara then
+        insert into public.tarefas
+          (descricao, categoria, customer_user_id, assigned_to, created_by, empresa, modo, due_date,
+           backstop_days, tolerancia_dias, auto_satisfy_mode, status, template_id,
+           requer_comprovacao, tipo_comprovacao, janela_fim, supervisor_user_id, auditoria_status,
+           leitura_min, leitura_max, leitura_unidade)
+        select tpl.descricao, tpl.categoria, tpl.customer_user_id, tpl.assigned_to, tpl.created_by, tpl.empresa,
+           'data', d, 7, tpl.tolerancia_dias, 'off', 'aberta', tpl.id,
+           tpl.requer_comprovacao, tpl.tipo_comprovacao, tpl.janela_fim, tpl.supervisor_user_id,
+           case when tpl.requer_comprovacao then 'dispensada' else 'nao_requer' end,
+           tpl.leitura_min, tpl.leitura_max, tpl.leitura_unidade
+        where not exists (select 1 from public.tarefas t
+                          where t.template_id = tpl.id and t.assigned_to = tpl.assigned_to and t.due_date = d);
+      end if;
+      d := d + 1;
+    end loop;
+  end loop;
+end $$;
+
+-- validação
+select 'F2 LEITURA NA INSTANCIA OK' as status,
+  (select count(*) from information_schema.columns
+     where table_name='tarefas' and column_name in ('leitura_min','leitura_max','leitura_unidade')) as cols_inst,
+  (select count(*) from pg_views where viewname='v_tarefas_estado' and definition ilike '%leitura_unidade%') as view_expoe,
+  (select (pg_get_functiondef(oid) ilike '%tpl.leitura_unidade%')
+     from pg_proc where proname='tarefas_materializar_recorrentes') as mat_copia;
+-- Expected: cols_inst=3, view_expoe=1, mat_copia=true


### PR DESCRIPTION
## ⚠️ ATENÇÃO: migration manual necessária
`supabase/migrations/20260605130000_tarefas_leitura_na_instancia.sql` — **colar no SQL Editor do Lovable**. Bloco entregue na conversa.

## Problema (UI-3, achado na revisão pré-QA)
O `ComprovacaoDialog` mostra a faixa de leitura (ex.: 7,0–7,5 pH) lendo o **template** via `useTemplates()`, que depende da RLS `tt_select` (assigned_to=uid OR gestor). Em **cobertura/férias** (a vendedora cobre a carteira de outra) ou **reatribuição** de template, a tarefa aparece (`responsavel_efetivo` inclui cobertura) mas o template **não** é visível → a faixa some do dialog e a validação client vira no-op. O enforcement seguia intacto (a RPC `concluir_com_comprovacao` lê o template server-side), mas a UX quebrava (o operador só via o erro no round-trip do servidor). A auditoria também não mostrava a unidade (UI-6).

## Fix
Denormaliza `leitura_min/max/unidade` na **própria instância** (`tarefas`), expõe via `b.*` na `v_tarefas_estado`, e o frontend lê da **instância** — sem join ao template, **sem gap de RLS**.

- **Migration** `20260605130000`: `ALTER tarefas` + backfill das abertas a partir do template + `v_tarefas_estado` DROP+CREATE (corpo **verbatim** da fase2 bloco_c — `b.*` re-expande com as novas colunas) + materializador copia `leitura_*` nas novas instâncias.
- **Provado em PG17** (`db/test-tarefas-leitura-instancia.sh`, A1–A5): aplica limpa · backfill copia · view expõe · materializador copia.
- **TarefaInstancia** += `leitura_min/max/unidade`.
- **RecorrentesHojeCard** lê da instância (dropa a dependência de `useTemplates`).
- **ProvasParaAuditar** mostra a unidade + a faixa na auditoria (completa o **UI-6**).

Typecheck 0 erros. Test+build no CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)