### PR TITLE
feat(reposição): tela avulsa de embalagem econômica (consulta de compra manual)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -139,6 +139,7 @@ const AdminReposicaoSessaoHistorico = lazy(() => import("./pages/AdminReposicaoS
 const ReposicaoSessionLayout = lazy(() => import("./components/reposicao/ReposicaoSessionLayout"));
 const LegacyCockpitRedirect = lazy(() => import("./components/reposicao/LegacyCockpitRedirect"));
 const AdminReposicaoCadastros = lazy(() => import("./pages/AdminReposicaoCadastros"));
+const AdminReposicaoEmbalagem = lazy(() => import("./pages/AdminReposicaoEmbalagem"));
 const AdminEstoqueRecebimento = lazy(() => import("./pages/AdminEstoqueRecebimento"));
 const AdminEstoquePicking = lazy(() => import("./pages/AdminEstoquePicking"));
 const TouchPickingView = lazy(() => import("./pages/picking/TouchPickingView"));
@@ -356,6 +357,7 @@ const App = () => (
                 <Route path="admin/reposicao/mercado" element={<Navigate to="/admin/reposicao/sessao/mercado" replace />} />
                 <Route path="admin/reposicao/parametros" element={<Navigate to="/admin/reposicao/sessao/parametros" replace />} />
                 <Route path="admin/reposicao/cadastros" element={<AdminReposicaoCadastros />} />
+                <Route path="admin/reposicao/embalagem" element={<AdminReposicaoEmbalagem />} />
                 <Route path="admin/estoque/recebimento" element={<AdminEstoqueRecebimento />} />
                 <Route path="admin/estoque/picking" element={<AdminEstoquePicking />} />
                 <Route path="admin/estoque/picking/mobile" element={<TouchPickingView />} />

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -105,6 +105,7 @@ const unifiedNavSections: { title: string; items: NavItem[] }[] = [
       { icon: TrendingUp, label: 'Mercado', path: '/admin/reposicao/sessao/mercado', managerOnly: true },
       { icon: Settings, label: 'Parâmetros', path: '/admin/reposicao/sessao/parametros', managerOnly: true },
       { icon: Database, label: 'Cadastros', path: '/admin/reposicao/cadastros', managerOnly: true },
+      { icon: Package, label: 'Embalagem econômica', path: '/admin/reposicao/embalagem', managerOnly: true },
     ],
   },
   {

--- a/src/components/reposicao/embalagem/PrecoEmbalagemDialog.tsx
+++ b/src/components/reposicao/embalagem/PrecoEmbalagemDialog.tsx
@@ -1,0 +1,104 @@
+// Dialog de preço manual de embalagem (do portal Sayerlack).
+// Compartilhado entre o EmbalagemPanel (modal de pedido sugerido) e a tela avulsa
+// de consulta de compra manual (AdminReposicaoEmbalagem).
+// Spec: docs/superpowers/specs/2026-06-04-embalagem-economica-design.md
+import { useState } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Loader2 } from 'lucide-react';
+import { useAuth } from '@/contexts/AuthContext';
+
+export function PrecoEmbalagemDialog({
+  empresa,
+  skus,
+  open,
+  onOpenChange,
+  labels,
+}: {
+  empresa: string;
+  skus: string[];
+  open: boolean;
+  onOpenChange: (o: boolean) => void;
+  /** rótulo amigável por sku (descrição do Omie); fallback = código */
+  labels?: Record<string, string>;
+}) {
+  const { user } = useAuth();
+  const qc = useQueryClient();
+  const [precos, setPrecos] = useState<Record<string, string>>({});
+
+  const salvar = useMutation({
+    mutationFn: async (entries: { sku: string; preco: number }[]) => {
+      const rows = entries.map((e) => ({
+        empresa: empresa.toLowerCase(), // tabela grava minúsculo — leitura usa o mesmo case
+        sku_codigo_omie: e.sku,
+        fornecedor_nome: 'Sayerlack',
+        preco: e.preco,
+        moeda: 'BRL',
+        preco_tipo: 'liquido',
+        fonte: 'manual_usuario',
+        status: 'ok',
+        criado_por: user?.email ?? 'sistema',
+      }));
+      const { error } = await supabase.from('sku_preco_fornecedor_capturado' as never).insert(rows as never);
+      if (error) throw error;
+    },
+    onSuccess: () => {
+      toast.success('Preços atualizados');
+      // cobre os dois consumidores (tela avulsa + card do pedido)
+      qc.invalidateQueries({ queryKey: ['embalagem-consulta'] });
+      qc.invalidateQueries({ queryKey: ['embalagem-pedido'] });
+      onOpenChange(false);
+      setPrecos({});
+    },
+    onError: (e: Error) => toast.error(`Erro ao salvar preços: ${e.message}`),
+  });
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => { if (!o) setPrecos({}); onOpenChange(o); }}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Atualizar preços (do portal)</DialogTitle>
+          <DialogDescription>Cole o preço atual de cada embalagem, consultado no portal Sayerlack.</DialogDescription>
+        </DialogHeader>
+        <div className="space-y-3">
+          {skus.map((sku) => (
+            <div key={sku}>
+              <Label>{labels?.[sku] ?? sku}</Label>
+              <Input
+                type="text"
+                inputMode="decimal"
+                placeholder="Preço atual (R$)"
+                value={precos[sku] ?? ''}
+                onChange={(e) => setPrecos((p) => ({ ...p, [sku]: e.target.value }))}
+              />
+            </div>
+          ))}
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>Cancelar</Button>
+          <Button
+            disabled={salvar.isPending}
+            onClick={() => {
+              const entries = skus
+                .map((sku) => ({ sku, preco: Number(String(precos[sku] ?? '').replace(',', '.')) }))
+                .filter((e) => e.preco > 0);
+              if (entries.length === 0) {
+                toast.error('Informe ao menos um preço > 0');
+                return;
+              }
+              salvar.mutate(entries);
+            }}
+          >
+            {salvar.isPending && <Loader2 className="w-4 h-4 mr-1 animate-spin" />}
+            Salvar
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/reposicao/embalagem/useEmbalagemConsulta.ts
+++ b/src/components/reposicao/embalagem/useEmbalagemConsulta.ts
@@ -1,0 +1,170 @@
+// Hook da tela avulsa de consulta de embalagem econômica (compra manual).
+// Carrega TODOS os grupos de equivalência ativos da empresa (não filtra por pedido)
+// + preços + descrição + demanda/cm, pra a página rodar o helper com a necessidade
+// que o usuário digita. Espelha o carregamento do useEmbalagemPedido, sem o acoplamento
+// aos itens de um pedido sugerido.
+// Spec: docs/superpowers/specs/2026-06-04-embalagem-economica-design.md
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import type { StatusPreco } from '@/lib/reposicao/embalagem-helpers';
+
+interface EquivRow { grupo_id: string; sku_codigo_omie: string; unidade_base: string; fator_para_base: number; }
+interface PrecoRow { sku_codigo_omie: string; preco: number; capturado_em: string; status: StatusPreco; }
+
+export interface MembroEmbalagem {
+  sku_codigo_omie: string;
+  fator_para_base: number;            // QT=1, GL=4
+  preco: number | null;
+  preco_status: StatusPreco | null;
+  descricao: string;                  // descrição do Omie (fallback = código)
+  capturado_em: string | null;
+}
+
+export interface GrupoEmbalagem {
+  grupo_id: string;
+  unidade_base: string;
+  titulo: string;
+  membros: MembroEmbalagem[];         // ordenado por fator ascendente
+  demanda_base: number | null;        // soma da demanda dos membros convertida p/ unidade-base
+  custo_capital_anual: number;        // decimal (0 quando indisponível)
+  cm_disponivel: boolean;
+}
+
+export interface EmbalagemConsultaResult {
+  grupos: GrupoEmbalagem[];
+  limiar: number;
+  isLoading: boolean;
+  isError: boolean;
+}
+
+export function useEmbalagemConsulta(empresa: string): EmbalagemConsultaResult {
+  const emp = (empresa ?? '').toLowerCase();
+
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ['embalagem-consulta', emp],
+    enabled: !!emp,
+    queryFn: async (): Promise<{ grupos: GrupoEmbalagem[]; limiar: number }> => {
+      // 1) Todos os grupos ativos da empresa
+      const equivResp = await supabase
+        .from('sku_embalagem_equivalencia' as never)
+        .select('grupo_id, sku_codigo_omie, unidade_base, fator_para_base')
+        .eq('empresa', emp)
+        .eq('ativo', true);
+      if (equivResp.error) throw equivResp.error; // money-path: não degradar silencioso
+      const equiv = (equivResp.data ?? []) as unknown as EquivRow[];
+      if (equiv.length === 0) return { grupos: [], limiar: 5 };
+
+      const skusGrupo = [...new Set(equiv.map((e) => e.sku_codigo_omie))];
+      const skuNums = skusGrupo.map(Number).filter((n) => Number.isFinite(n));
+
+      // 2) Preço mais recente por SKU
+      const precoResp = await supabase
+        .from('sku_preco_fornecedor_capturado' as never)
+        .select('sku_codigo_omie, preco, capturado_em, status')
+        .eq('empresa', emp)
+        .in('sku_codigo_omie', skusGrupo)
+        .order('capturado_em', { ascending: false });
+      if (precoResp.error) throw precoResp.error;
+      const precoRows = (precoResp.data ?? []) as unknown as PrecoRow[];
+      const precoMap = new Map<string, PrecoRow>();
+      for (const p of precoRows) {
+        const k = String(p.sku_codigo_omie);
+        if (!precoMap.has(k)) precoMap.set(k, p);
+      }
+
+      // 3) Descrição (omie_products) — rótulo legível por SKU
+      const descMap = new Map<string, string>();
+      if (skuNums.length > 0) {
+        const prodResp = await supabase
+          .from('omie_products')
+          .select('omie_codigo_produto, descricao')
+          .in('omie_codigo_produto', skuNums);
+        ((prodResp.data ?? []) as unknown as { omie_codigo_produto: number | string; descricao: string | null }[])
+          .forEach((p) => {
+            const k = String(p.omie_codigo_produto);
+            if (p.descricao && !descMap.has(k)) descMap.set(k, p.descricao);
+          });
+      }
+
+      // 4) Demanda + custo de capital (robustez; itens fora do motor → null/0)
+      const demandaMap = new Map<string, number | null>();
+      const cmMap = new Map<string, number | null>();
+      if (skuNums.length > 0) {
+        const paramResp = await supabase
+          .from('sku_parametros')
+          .select('sku_codigo_omie, demanda_media_diaria')
+          .eq('empresa', emp)
+          .in('sku_codigo_omie', skuNums);
+        ((paramResp.data ?? []) as unknown as { sku_codigo_omie: number; demanda_media_diaria: number | null }[])
+          .forEach((p) => demandaMap.set(String(p.sku_codigo_omie), p.demanda_media_diaria));
+
+        const cmResp = await supabase
+          .from('v_sku_parametros_sugeridos')
+          .select('sku_codigo_omie, custo_capital_efetivo_perc')
+          .eq('empresa', emp)
+          .in('sku_codigo_omie', skuNums);
+        ((cmResp.data ?? []) as unknown as { sku_codigo_omie: number; custo_capital_efetivo_perc: number | null }[])
+          .forEach((p) => cmMap.set(String(p.sku_codigo_omie), p.custo_capital_efetivo_perc));
+      }
+
+      // 5) Config (limiar de economia + janela de stale)
+      const cfgResp = await supabase.from('company_config').select('value').eq('key', 'embalagem_limiar_economia_rs').maybeSingle();
+      const limiar = Number((cfgResp.data?.value as string | undefined) ?? '5') || 5;
+      const staleResp = await supabase.from('company_config').select('value').eq('key', 'embalagem_preco_stale_horas').maybeSingle();
+      const staleHoras = Number((staleResp.data?.value as string | undefined) ?? '24') || 24;
+      const agoraMs = Date.now();
+      const statusComStale = (p: PrecoRow | undefined): StatusPreco | null => {
+        if (!p) return null;
+        if (p.status === 'falhou') return 'falhou';
+        const idadeH = (agoraMs - Date.parse(p.capturado_em)) / 3_600_000;
+        return idadeH > staleHoras ? 'stale' : (p.status ?? 'ok');
+      };
+
+      // 6) Montar grupos (>= 2 membros)
+      const porGrupo = new Map<string, EquivRow[]>();
+      for (const e of equiv) {
+        const a = porGrupo.get(e.grupo_id) ?? [];
+        a.push(e);
+        porGrupo.set(e.grupo_id, a);
+      }
+
+      const grupos: GrupoEmbalagem[] = [];
+      for (const [grupo_id, membrosRaw] of porGrupo) {
+        if (membrosRaw.length < 2) continue; // grupo de 1 → sem decisão de embalagem
+        const membrosOrd = [...membrosRaw].sort((a, b) => Number(a.fator_para_base) - Number(b.fator_para_base));
+        const membros: MembroEmbalagem[] = membrosOrd.map((m) => {
+          const p = precoMap.get(m.sku_codigo_omie);
+          return {
+            sku_codigo_omie: m.sku_codigo_omie,
+            fator_para_base: Number(m.fator_para_base),
+            preco: p ? Number(p.preco) : null,
+            preco_status: statusComStale(p),
+            descricao: descMap.get(m.sku_codigo_omie) ?? m.sku_codigo_omie,
+            capturado_em: p?.capturado_em ?? null,
+          };
+        });
+        // Demanda do conteúdo = soma das demandas dos membros convertidas p/ unidade-base.
+        let demanda_base: number | null = null;
+        for (const m of membros) {
+          const dm = demandaMap.get(m.sku_codigo_omie);
+          if (dm != null) demanda_base = (demanda_base ?? 0) + dm * m.fator_para_base;
+        }
+        const cmRaw = membros.map((m) => cmMap.get(m.sku_codigo_omie)).find((v) => v != null && Number(v) > 0);
+        const cm_disponivel = cmRaw != null;
+        grupos.push({
+          grupo_id,
+          unidade_base: membrosOrd[0].unidade_base,
+          titulo: descMap.get(membrosOrd[0].sku_codigo_omie) ?? `Grupo ${grupo_id.slice(0, 8)}`,
+          membros,
+          demanda_base,
+          custo_capital_anual: cm_disponivel ? Number(cmRaw) / 100 : 0,
+          cm_disponivel,
+        });
+      }
+      grupos.sort((a, b) => a.titulo.localeCompare(b.titulo, 'pt-BR'));
+      return { grupos, limiar };
+    },
+  });
+
+  return { grupos: data?.grupos ?? [], limiar: data?.limiar ?? 5, isLoading, isError };
+}

--- a/src/components/reposicao/pedidos/EmbalagemPanel.tsx
+++ b/src/components/reposicao/pedidos/EmbalagemPanel.tsx
@@ -1,53 +1,20 @@
 // Painel "Embalagem econômica" no modal de pedido: mostra, por SKU multi-embalagem,
 // a recomendação (menor custo por unidade-base) e permite informar o preço manualmente.
+// O dialog de preço é compartilhado com a tela avulsa (PrecoEmbalagemDialog).
 // Spec: docs/superpowers/specs/2026-06-04-embalagem-economica-design.md
 import { useState } from 'react';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { supabase } from '@/integrations/supabase/client';
-import { toast } from 'sonner';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
-import { Package, Loader2 } from 'lucide-react';
-import { useAuth } from '@/contexts/AuthContext';
+import { Package } from 'lucide-react';
 import { formatBRL } from './shared';
 import type { PedidoItem } from './types';
 import { useEmbalagemPedido } from './useEmbalagemPedido';
+import { PrecoEmbalagemDialog } from '@/components/reposicao/embalagem/PrecoEmbalagemDialog';
 
 export function EmbalagemPanel({ empresa, itens }: { empresa: string; itens: PedidoItem[] }) {
   const { porSku, isLoading } = useEmbalagemPedido(empresa, itens);
-  const { user } = useAuth();
-  const qc = useQueryClient();
   const [precoDialog, setPrecoDialog] = useState<null | { skus: string[] }>(null);
-  const [precos, setPrecos] = useState<Record<string, string>>({});
-
-  const salvarPrecos = useMutation({
-    mutationFn: async (entries: { sku: string; preco: number }[]) => {
-      const rows = entries.map((e) => ({
-        empresa,
-        sku_codigo_omie: e.sku,
-        fornecedor_nome: 'Sayerlack',
-        preco: e.preco,
-        moeda: 'BRL',
-        preco_tipo: 'liquido',
-        fonte: 'manual_usuario',
-        status: 'ok',
-        criado_por: user?.email ?? 'sistema',
-      }));
-      const { error } = await supabase.from('sku_preco_fornecedor_capturado' as never).insert(rows as never);
-      if (error) throw error;
-    },
-    onSuccess: () => {
-      toast.success('Preços atualizados');
-      qc.invalidateQueries({ queryKey: ['embalagem-pedido'] });
-      setPrecoDialog(null);
-      setPrecos({});
-    },
-    onError: (e: Error) => toast.error(`Erro ao salvar preços: ${e.message}`),
-  });
 
   const itensComGrupo = (itens ?? []).filter((i) => porSku[String(i.sku_codigo_omie)]);
   if (isLoading || itensComGrupo.length === 0) return null; // só aparece quando há item multi-embalagem
@@ -106,46 +73,12 @@ export function EmbalagemPanel({ empresa, itens }: { empresa: string; itens: Ped
         </CardContent>
       </Card>
 
-      <Dialog open={!!precoDialog} onOpenChange={(o) => !o && setPrecoDialog(null)}>
-        <DialogContent className="max-w-md">
-          <DialogHeader>
-            <DialogTitle>Atualizar preços (do portal)</DialogTitle>
-          </DialogHeader>
-          <div className="space-y-3">
-            {precoDialog?.skus.map((sku) => (
-              <div key={sku}>
-                <Label>{sku}</Label>
-                <Input
-                  type="text"
-                  inputMode="decimal"
-                  placeholder="Preço atual"
-                  value={precos[sku] ?? ''}
-                  onChange={(e) => setPrecos((p) => ({ ...p, [sku]: e.target.value }))}
-                />
-              </div>
-            ))}
-          </div>
-          <DialogFooter>
-            <Button variant="outline" onClick={() => setPrecoDialog(null)}>Cancelar</Button>
-            <Button
-              disabled={salvarPrecos.isPending}
-              onClick={() => {
-                const entries = (precoDialog?.skus ?? [])
-                  .map((sku) => ({ sku, preco: Number(String(precos[sku] ?? '').replace(',', '.')) }))
-                  .filter((e) => e.preco > 0);
-                if (entries.length === 0) {
-                  toast.error('Informe ao menos um preço > 0');
-                  return;
-                }
-                salvarPrecos.mutate(entries);
-              }}
-            >
-              {salvarPrecos.isPending && <Loader2 className="w-4 h-4 mr-1 animate-spin" />}
-              Salvar
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      <PrecoEmbalagemDialog
+        empresa={empresa}
+        skus={precoDialog?.skus ?? []}
+        open={!!precoDialog}
+        onOpenChange={(o) => !o && setPrecoDialog(null)}
+      />
     </>
   );
 }

--- a/src/pages/AdminReposicaoEmbalagem.tsx
+++ b/src/pages/AdminReposicaoEmbalagem.tsx
@@ -1,0 +1,209 @@
+// Tela avulsa "Embalagem econômica" — consulta de compra MANUAL.
+// Para itens comprados fora do ciclo automático de reposição (ex.: concentrados WP
+// da Sayerlack, que existem em quart e galão): informa-se quanto precisa e o app
+// recomenda qual embalagem sai mais barata por unidade-base. É uma calculadora de
+// decisão — a compra é feita no Omie; esta tela não fecha o ciclo (decisão de design,
+// confirmada por consult Codex: não fingir automação que não existe).
+// Spec: docs/superpowers/specs/2026-06-04-embalagem-economica-design.md
+import { useMemo, useState } from 'react';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Package, Info } from 'lucide-react';
+import { PageSkeleton } from '@/components/ui/page-skeleton';
+import { EmptyState } from '@/components/EmptyState';
+import { escolherEmbalagemEconomica } from '@/lib/reposicao/embalagem-helpers';
+import { useEmbalagemConsulta, type GrupoEmbalagem } from '@/components/reposicao/embalagem/useEmbalagemConsulta';
+import { PrecoEmbalagemDialog } from '@/components/reposicao/embalagem/PrecoEmbalagemDialog';
+
+// Feature Oben-only por enquanto (sku_embalagem_equivalencia grava 'oben' minúsculo).
+const EMPRESA = 'oben';
+
+function formatBRL(v: number | null | undefined) {
+  return new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL' }).format(Number(v ?? 0));
+}
+
+function GrupoCard({ grupo, limiar }: { grupo: GrupoEmbalagem; limiar: number }) {
+  const [necessidadeStr, setNecessidadeStr] = useState('1');
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const necessidade = Number(necessidadeStr.replace(',', '.'));
+
+  const descPorSku = useMemo(
+    () => Object.fromEntries(grupo.membros.map((m) => [m.sku_codigo_omie, m.descricao])),
+    [grupo.membros],
+  );
+
+  const decisao = useMemo(
+    () =>
+      escolherEmbalagemEconomica({
+        necessidade_base: Number.isFinite(necessidade) ? necessidade : 0,
+        opcoes: grupo.membros.map((m) => ({
+          sku_codigo_omie: m.sku_codigo_omie,
+          fator_para_base: m.fator_para_base,
+          preco: m.preco,
+          preco_status: m.preco_status,
+        })),
+        params: {
+          custo_capital_anual: grupo.custo_capital_anual,
+          limiar_minimo_economia_rs: limiar,
+          demanda_base_diaria: grupo.cm_disponivel ? grupo.demanda_base : null,
+        },
+      }),
+    [grupo, necessidade, limiar],
+  );
+
+  const recAval = decisao.opcoes.find((o) => o.sku_codigo_omie === decisao.recomendada);
+  const recDesc = decisao.recomendada ? descPorSku[decisao.recomendada] ?? decisao.recomendada : null;
+
+  return (
+    <Card>
+      <CardHeader className="py-3">
+        <CardTitle className="text-base flex items-center gap-2">
+          <Package className="h-4 w-4" /> {grupo.titulo}
+        </CardTitle>
+        <CardDescription>
+          Unidade-base: {grupo.unidade_base} · {grupo.membros.length} embalagens
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {/* Preços atuais por embalagem */}
+        <div className="grid gap-2 sm:grid-cols-2">
+          {grupo.membros.map((m) => (
+            <div key={m.sku_codigo_omie} className="border rounded p-2 text-sm">
+              <div className="font-medium">{m.descricao}</div>
+              <div className="text-muted-foreground text-xs font-tabular">
+                cód {m.sku_codigo_omie} · {m.fator_para_base} {grupo.unidade_base}/embalagem
+              </div>
+              <div className="mt-1">
+                {m.preco != null ? (
+                  <>
+                    {formatBRL(m.preco)} <span className="text-muted-foreground text-xs">/ embalagem</span>
+                  </>
+                ) : (
+                  <span className="text-status-warning">sem preço</span>
+                )}
+                {m.preco_status === 'stale' && <span className="text-status-warning text-xs"> · ⚠ desatualizado</span>}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* Necessidade + atualizar preços */}
+        <div className="flex items-end gap-2 flex-wrap">
+          <div className="flex-1 min-w-[160px] max-w-[220px]">
+            <Label htmlFor={`nec-${grupo.grupo_id}`}>Quanto preciso? (em {grupo.unidade_base})</Label>
+            <Input
+              id={`nec-${grupo.grupo_id}`}
+              type="text"
+              inputMode="decimal"
+              value={necessidadeStr}
+              onChange={(e) => setNecessidadeStr(e.target.value)}
+            />
+          </div>
+          <Button variant="outline" size="sm" onClick={() => setDialogOpen(true)}>
+            Atualizar preços
+          </Button>
+        </div>
+
+        {/* Recomendação */}
+        {decisao.status === 'indisponivel' ? (
+          <div className="text-muted-foreground text-sm">
+            {decisao.flags.includes('necessidade_invalida')
+              ? 'Informe uma quantidade maior que zero.'
+              : 'Informe os preços das duas embalagens pra ver a recomendação.'}
+          </div>
+        ) : (
+          <div className="rounded-md bg-muted/40 border p-3 text-sm space-y-1">
+            <div className="font-medium">
+              Compre {recAval?.qtd_embalagens ?? 1}× {recDesc}
+            </div>
+            <div className="text-muted-foreground">
+              custo {formatBRL(recAval?.custo_direto)}
+              {decisao.economia_vs_alternativa > 0 && <> · economiza {formatBRL(decisao.economia_vs_alternativa)} vs a outra embalagem</>}
+              {decisao.excedente_base > 0 && (
+                <>
+                  {' '}· sobra {decisao.excedente_base} {grupo.unidade_base}
+                </>
+              )}
+            </div>
+            <div className="flex flex-wrap gap-2 pt-1">
+              {decisao.opcoes.map((o) => (
+                <Badge key={o.sku_codigo_omie} variant={o.sku_codigo_omie === decisao.recomendada ? 'default' : 'outline'}>
+                  {descPorSku[o.sku_codigo_omie] ?? o.sku_codigo_omie}: {formatBRL(o.custo_por_base)}/{grupo.unidade_base}
+                  {o.preco_status === 'stale' ? ' ⚠' : ''}
+                </Badge>
+              ))}
+            </div>
+            {decisao.status === 'marginal' && (
+              <div className="text-status-warning text-xs">
+                Ganho marginal — a embalagem maior quase não compensa pra essa quantidade; confira.
+              </div>
+            )}
+            {decisao.flags.includes('preco_desatualizado') && (
+              <div className="text-status-warning text-xs">Preço pode estar desatualizado — confira no portal e atualize.</div>
+            )}
+            {decisao.flags.includes('escoamento_nao_estimado') && (
+              <div className="text-muted-foreground text-xs">
+                Sem giro registrado: o custo de carregar a sobra não foi estimado — a recomendação considera só o preço de compra.
+              </div>
+            )}
+          </div>
+        )}
+      </CardContent>
+
+      <PrecoEmbalagemDialog
+        empresa={EMPRESA}
+        skus={grupo.membros.map((m) => m.sku_codigo_omie)}
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+        labels={descPorSku}
+      />
+    </Card>
+  );
+}
+
+export default function AdminReposicaoEmbalagem() {
+  const { grupos, limiar, isLoading, isError } = useEmbalagemConsulta(EMPRESA);
+
+  return (
+    <div className="space-y-4 p-4 max-w-3xl">
+      <div>
+        <h1 className="text-2xl font-display tracking-tight">Embalagem econômica</h1>
+        <p className="text-muted-foreground text-sm">
+          Compare embalagens (ex.: quart × galão) pelo menor custo por unidade-base. Para a compra manual dos concentrados,
+          fora do ciclo automático de reposição.
+        </p>
+      </div>
+
+      <div className="rounded-md border bg-status-info/5 p-3 text-sm flex gap-2">
+        <Info className="h-4 w-4 mt-0.5 text-status-info shrink-0" />
+        <div>
+          Os preços vêm do <strong>portal Sayerlack</strong> — você atualiza manualmente. A quantidade é sempre em{' '}
+          <strong>unidade-base</strong> (a menor embalagem). A compra é feita no Omie; esta tela só recomenda{' '}
+          <strong>qual embalagem</strong> sai mais barata.
+        </div>
+      </div>
+
+      {isLoading ? (
+        <PageSkeleton variant="list" />
+      ) : isError ? (
+        <div className="text-status-error text-sm">Erro ao carregar os grupos de embalagem. Tente recarregar a página.</div>
+      ) : grupos.length === 0 ? (
+        <EmptyState
+          tone="operational"
+          icon={Package}
+          title="Nenhum grupo de embalagem cadastrado"
+          description="Cadastre pares de embalagem (ex.: quart + galão) em sku_embalagem_equivalencia para comparar custos aqui."
+        />
+      ) : (
+        <div className="space-y-3">
+          {grupos.map((g) => (
+            <GrupoCard key={g.grupo_id} grupo={g} limiar={limiar} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## O problema que o diagnóstico revelou

O founder pediu uma feature pra recomendar **qual embalagem comprar** dos concentrados WP da Sayerlack (existem em **quart/QT** e **galão/GL**; 1 GL = 4 QT) pelo menor custo por unidade-equivalente. A v1 (#611/#613) entregou o cálculo + tabelas + um card `EmbalagemPanel` **dentro do modal de um pedido de compra sugerido**.

Aí o diagnóstico em prod mostrou o furo: os 2 concentrados **não estão em `sku_parametros`** (`situacao = 'FORA do motor (compra manual)'` nas 4 linhas) — o founder os compra **na mão**, fora do ciclo automático. Logo o motor **nunca** gera pedido sugerido pra eles, e o card **nunca aparece** pro seu único caso de uso. A feature estava "armada" mas inacessível.

## A decisão (eu + Codex)

O founder delegou ("decida você e codex"). O consult do Codex confirmou a **Opção A — superfície avulsa de consulta de compra manual**, não card preso ao pedido. Razões: respeita o fluxo real (compra manual, esporádica, sem giro), zero risco no money-path (não mexe no motor nem cria sugestão recorrente fantasma), reusa quase tudo. Os 3 furos que ele apontou foram incorporados:
1. **acesso descoberto** → item na sidebar (Reposição → "Embalagem econômica");
2. **não fingir que fecha o ciclo** (a compra é no Omie) → é uma **calculadora de decisão**, com o histórico de preços já persistido em `sku_preco_fornecedor_capturado`;
3. **deixar explícito que a quantidade é em unidade-base (QT)** → rótulo e nota na tela.

## O que entra

- **Rota** `/admin/reposicao/embalagem` (seção Reposição, `managerOnly`).
- **`useEmbalagemConsulta`** — carrega TODOS os grupos ativos da empresa (não filtra por pedido) + preços + descrição (`omie_products`) + demanda/cm. Espelha o carregamento money-path do `useEmbalagemPedido` revisado: `if (error) throw` nas queries críticas (equivalência/preço), degradação honesta quando demanda/cm faltam (capital **não** estimado + flag, **nunca** zera o freio em silêncio — esperado pros concentrados, que estão fora do motor).
- **`PrecoEmbalagemDialog`** — dialog de preço manual **extraído** do `EmbalagemPanel` e **compartilhado** pelas duas superfícies (DRY); grava/lê no mesmo case (`oben`); invalida as duas query keys.
- **`EmbalagemPanel`** refatorado pra usar o dialog extraído (comportamento **1:1**).
- Reusa o helper `escolherEmbalagemEconomica` (testado 13× + codex-revisado em #613) — **sem novo cálculo financeiro**.

## Escopo / não-objetivos

- **Oben-only** (a tabela grava `oben`; é onde estão os concentrados).
- **Sem migration, sem edge function** — usa as tabelas já em prod (`sku_embalagem_equivalencia` / `sku_preco_fornecedor_capturado`) e o helper já existente.
- Captura de preço por scraping segue **Fase 2** (atrás do kill-switch `embalagem_captura_automatica_habilitada=false`).
- Registro de "consulta" em tabela própria: **não** (YAGNI — o histórico de preços já é persistido).

## Validação

CI local: **typecheck (strict) ✅ · lint 0 erros ✅ · test 2372/2372 ✅ · build ✅**. Rebaseado em base limpa da `main` (stash → branch novo da `origin/main` → typecheck contra a main atualizada, que moveu 13 commits).

⚠️ **Deploy do frontend é Publish manual no Lovable** — mergear não põe no ar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)