### PR TITLE
fix(reposição): migration #608 PARTE C — coluna minimo_forcado_manual no fim da view

### DIFF
--- a/supabase/migrations/20260604190000_reposicao_minimo_forcado.sql
+++ b/supabase/migrations/20260604190000_reposicao_minimo_forcado.sql
@@ -211,7 +211,11 @@ END;
 $function$;
 
 -- ─── PARTE C — Otimizador "comprar mais?" enxerga o mínimo forçado ───
--- CORPO VERBATIM de 20260530143818 (PARTE 2) + a coluna sp.minimo_forcado_manual.
+-- CORPO VERBATIM de 20260530143818 (PARTE 2) + a coluna sp.minimo_forcado_manual
+-- ANEXADA NO FIM do SELECT. ⚠️ CREATE OR REPLACE VIEW só permite ACRESCENTAR coluna
+-- no fim (Postgres não reordena/insere no meio) — inserir entre lote_minimo_fornecedor
+-- e fornecedor_codigo_omie falharia em prod com "cannot change name of view column".
+-- A view é lida por NOME no front (AdminReposicaoOportunidades) → posição é indiferente.
 -- security_invoker=on e os filtros 405ML/450ML preservados.
 CREATE OR REPLACE VIEW v_otimizador_compras_insumos
 WITH (security_invoker = on) AS
@@ -238,12 +242,12 @@ prazo AS (
 SELECT
   o.*,
   sp.lote_minimo_fornecedor,
-  sp.minimo_forcado_manual,
   sp.fornecedor_codigo_omie,
   p.prazo_padrao_perc,
   f.frete_perc_valor,
   f.frete_fixo,
-  f.frete_taxa_pedido
+  f.frete_taxa_pedido,
+  sp.minimo_forcado_manual
 FROM v_oportunidade_economica_hoje o
 LEFT JOIN sku_parametros sp
   ON sp.empresa = o.empresa AND sp.sku_codigo_omie = o.sku_codigo_omie


### PR DESCRIPTION
## O que

Move `minimo_forcado_manual` para o **fim** do `SELECT` da view `v_otimizador_compras_insumos` na migration `20260604190000_reposicao_minimo_forcado.sql` (PARTE C). Antes a coluna era inserida no **meio** (entre `lote_minimo_fornecedor` e `fornecedor_codigo_omie`).

## Por quê

`CREATE OR REPLACE VIEW` só permite **acrescentar** coluna no fim — Postgres não reordena/insere no meio. Aplicar a versão antiga contra a view **viva em prod** (criada pela `20260530143818`) falharia com `cannot change name of view column "fornecedor_codigo_omie"`. A view é lida **por nome** no front (`AdminReposicaoOportunidades`), então a posição da coluna é indiferente ao consumidor.

3ª ocorrência do padrão view-reorder no repo (lição §5/§10: `pg_get_viewdef` da prod antes de `REPLACE` de view).

## Estado em produção

✅ **Já aplicada** (o apply usou a versão corrigida; validação retornou `MIGRATION minimo_forcado OK · coluna=1 · check_constraint=1 · rpc=1 · view_otimizador=1`). Este PR **reconcilia o arquivo do repo com prod** — não há migration nova pra rodar.

A RPC `gerar_pedidos_sugeridos_ciclo` (PARTE B) foi confirmada como **superset estrito** da versão viva por um safety pass adversário (dump `pg_get_functiondef` de prod × repo, linha a linha) — zero guarda removida (fornecedor NOT NULL/btrim, fail-closed `tipo_produto_unhealthy`, 450ML/405ML, '04' fabricado, em_transito Fix B, fallback cmc). As mudanças `[MIN-FORCADO]` são aditivas/fortalecedoras; com `minimo_forcado_manual` NULL o comportamento é idêntico ao anterior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)