### PR TITLE
feat(reposição): scraping do pedido Sayerlack — valida grupo (Prz Ent) + captura custo

### DIFF
--- a/docs/superpowers/plans/2026-06-04-sayerlack-scraping-pedido.md
+++ b/docs/superpowers/plans/2026-06-04-sayerlack-scraping-pedido.md
@@ -1,0 +1,575 @@
+# Scraping do pedido Sayerlack (valida grupo + captura custo) — Plano de Implementação
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Num único scraping do `#datatable_itens` antes do Efetivar, validar o grupo (Prz Ent do portal `==` `lt_producao_dias`, bloqueia o pedido em mismatch confirmado) e capturar o custo real (`total_linha/qtde_final → preco_unitario`, pro Omie bater com a NF-e).
+
+**Architecture:** O fluxo do browser (`BROWSERLESS_FUNCTION`, string template em `index.ts:32`) roda **dentro do Browserless** — sem DB/imports. Logo: (1) o **gate B** roda **inline na string**, com `ltEsperado` passado via `context`, e bloqueia ANTES do Efetivar; (2) a **captura de custo** roda no **Deno**, depois do retorno, no `sucesso_portal`, com um helper puro espelhado. A lógica testável (parse/match/validação/derivação) vive num helper puro vitest (`src/lib/reposicao/`) que é o oráculo das duas pontas.
+
+**Tech Stack:** Deno (edge function), Browserless `/function` (Puppeteer), Supabase (PostgREST), vitest (helper puro). Tabelas: `fornecedor_grupo_producao.lt_producao_dias`, `pedido_compra_item`, `pedido_compra_sugerido`.
+
+**Pré-requisito (fora deste plano):** o claim do portal foi consertado no PR #592 (RPC `envio_portal_claim_ids`, migration `20260604150000`). A edge `enviar-pedido-portal-sayerlack` **precisa estar redeployada** com essa main, senão nada vai ao portal.
+
+**⚠️ Limites de teste:** o helper puro (Fase 1) é 100% TDD. As Fases 2-4 (string do Browserless + wiring Deno + seletores DOM) **não têm teste unitário local** — o `/browse` headless não renderiza, e o fluxo só roda contra o portal real. Verificação dessas fases = `deno check` + lint + um **run real** disparado pelo founder (logs da edge no Lovable). Isso é honesto, não preguiça.
+
+---
+
+## File Structure
+
+- **Create:** `src/lib/reposicao/sayerlack-scraping-pedido.ts` — helper puro (parse, match, validação, derivação de custo). Oráculo testável.
+- **Create:** `src/lib/reposicao/__tests__/sayerlack-scraping-pedido.test.ts` — vitest.
+- **Modify:** `supabase/functions/enviar-pedido-portal-sayerlack/index.ts`:
+  - `BROWSERLESS_FUNCTION` string (`:32`): destructure `ltEsperado`; scrape + gate B + block antes do Efetivar (~`:942`); retornar `itens_capturados`.
+  - `buildEnvelope` (`:335`): `GRUPO_LEADTIME_MISMATCH` vira `erro_nao_retentavel`.
+  - itensList fetch (`:1450-1535`): incluir `preco_unitario`.
+  - context (`:1640`): passar `ltEsperado`.
+  - `sucesso_portal` (`:1814-1818`): captura de custo (helper espelhado inline Deno) antes do `registrarPedidoOmieAposPortal`.
+
+---
+
+## Fase 1 — Helper puro (TDD)
+
+### Task 1: Parsers `parseBRL` + `parseDiasPrzEnt`
+
+**Files:**
+- Create: `src/lib/reposicao/sayerlack-scraping-pedido.ts`
+- Test: `src/lib/reposicao/__tests__/sayerlack-scraping-pedido.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { parseBRL, parseDiasPrzEnt } from '../sayerlack-scraping-pedido';
+
+describe('parseBRL', () => {
+  it('parseia formato pt-BR (ponto=milhar, vírgula=decimal)', () => {
+    expect(parseBRL('1.234,56')).toBe(1234.56);
+    expect(parseBRL('R$ 90,21')).toBe(90.21);
+    expect(parseBRL('408,36')).toBe(408.36);
+    expect(parseBRL('0,00')).toBe(0);
+  });
+  it('retorna null pra lixo', () => {
+    expect(parseBRL('')).toBeNull();
+    expect(parseBRL('abc')).toBeNull();
+    expect(parseBRL(null as unknown as string)).toBeNull();
+  });
+});
+
+describe('parseDiasPrzEnt', () => {
+  it('extrai o inteiro de dias', () => {
+    expect(parseDiasPrzEnt('8')).toBe(8);
+    expect(parseDiasPrzEnt('8 dias')).toBe(8);
+    expect(parseDiasPrzEnt('12')).toBe(12);
+  });
+  it('retorna null pra vazio/sem número', () => {
+    expect(parseDiasPrzEnt('')).toBeNull();
+    expect(parseDiasPrzEnt('—')).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run test, verify FAIL**
+
+Run: `bun run test -- sayerlack-scraping-pedido`
+Expected: FAIL ("parseBRL is not a function" / module not found).
+
+- [ ] **Step 3: Implement the parsers**
+
+```ts
+// src/lib/reposicao/sayerlack-scraping-pedido.ts
+// Helpers puros do scraping do pedido Sayerlack (valida grupo via Prz Ent + captura custo).
+// ⚠️ A captura de custo (derivarCustos/casar) é espelhada VERBATIM no Deno da edge
+// enviar-pedido-portal-sayerlack (Deno não importa de src/). Mantenha as duas em sincronia.
+
+export function parseBRL(s: string): number | null {
+  if (typeof s !== 'string') return null;
+  const limpo = s.replace(/[^\d,.-]/g, '').trim();
+  if (!limpo) return null;
+  const normal = limpo.replace(/\./g, '').replace(',', '.'); // pt-BR
+  const n = Number(normal);
+  return Number.isFinite(n) ? n : null;
+}
+
+export function parseDiasPrzEnt(s: string): number | null {
+  if (typeof s !== 'string') return null;
+  const m = s.match(/-?\d+/);
+  if (!m) return null;
+  const n = Number(m[0]);
+  return Number.isInteger(n) ? n : null;
+}
+```
+
+- [ ] **Step 4: Run test, verify PASS**
+
+Run: `bun run test -- sayerlack-scraping-pedido`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/reposicao/sayerlack-scraping-pedido.ts src/lib/reposicao/__tests__/sayerlack-scraping-pedido.test.ts
+git commit -m "feat(sayerlack-scraping): parsers BRL + Prz Ent (TDD)"
+```
+
+### Task 2: `casarLinhasComItens` (match + guarda de ambiguidade)
+
+**Files:**
+- Modify: `src/lib/reposicao/sayerlack-scraping-pedido.ts`
+- Test: `src/lib/reposicao/__tests__/sayerlack-scraping-pedido.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { casarLinhasComItens, type ItemPedido, type LinhaPortal } from '../sayerlack-scraping-pedido';
+
+const item = (o: Partial<ItemPedido>): ItemPedido => ({
+  item_id: 1, sku_codigo_omie: 'OMIE1', sku_descricao: 'd', sku_portal: 'P1', qtde_final: 2, preco_atual: 10, ...o,
+});
+const linha = (o: Partial<LinhaPortal>): LinhaPortal => ({ sku_portal: 'P1', prz_ent_raw: '8', total_raw: '20,00', ...o });
+
+describe('casarLinhasComItens', () => {
+  it('casa por sku_portal e parseia prz/total', () => {
+    const r = casarLinhasComItens([linha({})], [item({})]);
+    expect(r.casados).toHaveLength(1);
+    expect(r.casados[0].prz_ent).toBe(8);
+    expect(r.casados[0].total_linha).toBe(20);
+    expect(r.naoCasados).toHaveLength(0);
+    expect(r.ambiguos).toHaveLength(0);
+  });
+  it('item sem linha no portal vira naoCasado', () => {
+    const r = casarLinhasComItens([], [item({})]);
+    expect(r.naoCasados).toHaveLength(1);
+    expect(r.casados).toHaveLength(0);
+  });
+  it('sku_portal em 2 itens vira ambíguo (de-para não é único por sku_portal)', () => {
+    const r = casarLinhasComItens([linha({})], [item({ item_id: 1 }), item({ item_id: 2, sku_codigo_omie: 'OMIE2' })]);
+    expect(r.ambiguos).toHaveLength(2);
+    expect(r.casados).toHaveLength(0);
+  });
+  it('sku_portal em 2 linhas vira ambíguo', () => {
+    const r = casarLinhasComItens([linha({}), linha({ total_raw: '99,00' })], [item({})]);
+    expect(r.ambiguos).toHaveLength(1);
+    expect(r.casados).toHaveLength(0);
+  });
+  it('item com sku_portal nulo vira naoCasado', () => {
+    const r = casarLinhasComItens([linha({})], [item({ sku_portal: null })]);
+    expect(r.naoCasados).toHaveLength(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run test, verify FAIL**
+
+Run: `bun run test -- sayerlack-scraping-pedido`
+Expected: FAIL ("casarLinhasComItens is not a function").
+
+- [ ] **Step 3: Implement**
+
+```ts
+export interface LinhaPortal { sku_portal: string; prz_ent_raw: string; total_raw: string; }
+export interface ItemPedido {
+  item_id: number; sku_codigo_omie: string; sku_descricao: string | null;
+  sku_portal: string | null; qtde_final: number; preco_atual: number;
+}
+export interface Casado { item: ItemPedido; prz_ent: number | null; total_linha: number | null; }
+export interface ResultadoMatch { casados: Casado[]; naoCasados: ItemPedido[]; ambiguos: ItemPedido[]; }
+
+function normPortal(s: string | null): string { return (s ?? '').trim().toUpperCase(); }
+
+export function casarLinhasComItens(linhas: LinhaPortal[], itens: ItemPedido[]): ResultadoMatch {
+  const casados: Casado[] = [];
+  const naoCasados: ItemPedido[] = [];
+  const ambiguos: ItemPedido[] = [];
+
+  const itensPorSku = new Map<string, ItemPedido[]>();
+  for (const it of itens) {
+    const k = normPortal(it.sku_portal);
+    if (!k) { naoCasados.push(it); continue; }
+    const arr = itensPorSku.get(k) ?? [];
+    arr.push(it); itensPorSku.set(k, arr);
+  }
+  const linhasPorSku = new Map<string, LinhaPortal[]>();
+  for (const ln of linhas) {
+    const k = normPortal(ln.sku_portal);
+    if (!k) continue;
+    const arr = linhasPorSku.get(k) ?? [];
+    arr.push(ln); linhasPorSku.set(k, arr);
+  }
+  for (const [k, its] of itensPorSku) {
+    const lns = linhasPorSku.get(k) ?? [];
+    if (its.length > 1 || lns.length > 1) { ambiguos.push(...its); continue; }
+    if (lns.length === 0) { naoCasados.push(its[0]); continue; }
+    casados.push({ item: its[0], prz_ent: parseDiasPrzEnt(lns[0].prz_ent_raw), total_linha: parseBRL(lns[0].total_raw) });
+  }
+  return { casados, naoCasados, ambiguos };
+}
+```
+
+- [ ] **Step 4: Run test, verify PASS**
+
+Run: `bun run test -- sayerlack-scraping-pedido`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -u && git commit -m "feat(sayerlack-scraping): casar linhas do portal com itens + guarda de ambiguidade (TDD)"
+```
+
+### Task 3: `validarGrupoLeadtime` (compara exato; só mismatch confirmado bloqueia)
+
+**Files:**
+- Modify: `src/lib/reposicao/sayerlack-scraping-pedido.ts`
+- Test: idem
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { validarGrupoLeadtime } from '../sayerlack-scraping-pedido';
+
+describe('validarGrupoLeadtime', () => {
+  const casados = (arr: Array<{ sku?: string; prz: number | null }>) =>
+    ({ casados: arr.map((a, i) => ({ item: item({ item_id: i, sku_codigo_omie: a.sku ?? 'O' + i }), prz_ent: a.prz, total_linha: 1 })), naoCasados: [], ambiguos: [] });
+
+  it('ok quando todos os prz batem o esperado', () => {
+    const r = validarGrupoLeadtime(casados([{ prz: 8 }, { prz: 8 }]), 8);
+    expect(r.status).toBe('ok');
+    expect(r.mismatches).toHaveLength(0);
+  });
+  it('mismatch quando ≥1 prz difere', () => {
+    const r = validarGrupoLeadtime(casados([{ prz: 8 }, { sku: 'X', prz: 12 }]), 8);
+    expect(r.status).toBe('mismatch');
+    expect(r.mismatches).toEqual([{ sku_codigo_omie: 'X', prz_ent: 12, lt_esperado: 8 }]);
+  });
+  it('indisponivel quando ltEsperado é null (sem config de grupo)', () => {
+    expect(validarGrupoLeadtime(casados([{ prz: 8 }]), null).status).toBe('indisponivel');
+  });
+  it('indisponivel quando nada parseável (prz null)', () => {
+    expect(validarGrupoLeadtime(casados([{ prz: null }]), 8).status).toBe('indisponivel');
+  });
+  it('prz null não conta como mismatch — só pulado', () => {
+    const r = validarGrupoLeadtime(casados([{ prz: 8 }, { sku: 'N', prz: null }]), 8);
+    expect(r.status).toBe('ok');
+    expect(r.pulados).toContain('N');
+  });
+});
+```
+
+- [ ] **Step 2: Run test, verify FAIL**
+
+Run: `bun run test -- sayerlack-scraping-pedido` → FAIL.
+
+- [ ] **Step 3: Implement**
+
+```ts
+export interface ResultadoValidacao {
+  status: 'ok' | 'mismatch' | 'indisponivel';
+  mismatches: { sku_codigo_omie: string; prz_ent: number; lt_esperado: number }[];
+  pulados: string[];
+}
+
+export function validarGrupoLeadtime(res: ResultadoMatch, ltEsperado: number | null): ResultadoValidacao {
+  const mismatches: ResultadoValidacao['mismatches'] = [];
+  const pulados: string[] = [];
+  const pularTudo = () => {
+    for (const c of res.casados) pulados.push(c.item.sku_codigo_omie);
+    for (const i of res.naoCasados) pulados.push(i.sku_codigo_omie);
+    for (const i of res.ambiguos) pulados.push(i.sku_codigo_omie);
+  };
+  if (ltEsperado == null || !Number.isInteger(ltEsperado)) {
+    pularTudo();
+    return { status: 'indisponivel', mismatches, pulados };
+  }
+  let validados = 0;
+  for (const c of res.casados) {
+    if (c.prz_ent == null) { pulados.push(c.item.sku_codigo_omie); continue; }
+    validados++;
+    if (c.prz_ent !== ltEsperado) {
+      mismatches.push({ sku_codigo_omie: c.item.sku_codigo_omie, prz_ent: c.prz_ent, lt_esperado: ltEsperado });
+    }
+  }
+  for (const i of res.naoCasados) pulados.push(i.sku_codigo_omie);
+  for (const i of res.ambiguos) pulados.push(i.sku_codigo_omie);
+  if (mismatches.length > 0) return { status: 'mismatch', mismatches, pulados };
+  if (validados > 0) return { status: 'ok', mismatches, pulados };
+  return { status: 'indisponivel', mismatches, pulados };
+}
+```
+
+- [ ] **Step 4: Run test, verify PASS** → `bun run test -- sayerlack-scraping-pedido`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -u && git commit -m "feat(sayerlack-scraping): validação exata de grupo via Prz Ent (mismatch bloqueia, incerteza=indisponivel) (TDD)"
+```
+
+### Task 4: `derivarCustos` + `round2` (tolerância no total da linha)
+
+**Files:**
+- Modify: `src/lib/reposicao/sayerlack-scraping-pedido.ts`
+- Test: idem
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { derivarCustos } from '../sayerlack-scraping-pedido';
+
+describe('derivarCustos', () => {
+  const casadoCom = (o: { qtde: number; preco_atual: number; total: number | null }) =>
+    ({ casados: [{ item: item({ item_id: 7, qtde_final: o.qtde, preco_atual: o.preco_atual }), prz_ent: 8, total_linha: o.total }], naoCasados: [], ambiguos: [] });
+
+  it('deriva unitário = total/qtde e sobrescreve quando difere', () => {
+    const r = derivarCustos(casadoCom({ qtde: 4, preco_atual: 100, total: 1633.45 }));
+    expect(r.updates).toHaveLength(1);
+    expect(r.updates[0].item_id).toBe(7);
+    expect(r.updates[0].valor_linha).toBe(1633.45);
+    expect(r.updates[0].preco_unitario).toBeCloseTo(408.3625, 4);
+  });
+  it('mantém (não sobrescreve) quando o total da linha bate ao centavo', () => {
+    const r = derivarCustos(casadoCom({ qtde: 4, preco_atual: 408.36, total: 1633.44 })); // 4*408.36=1633.44
+    expect(r.updates).toHaveLength(0);
+    expect(r.pulados[0]).toMatchObject({ motivo: 'sem_mudanca' });
+  });
+  it('pula total inválido (<=0 ou null) sem fabricar custo', () => {
+    expect(derivarCustos(casadoCom({ qtde: 4, preco_atual: 1, total: 0 })).updates).toHaveLength(0);
+    expect(derivarCustos(casadoCom({ qtde: 4, preco_atual: 1, total: null })).updates).toHaveLength(0);
+  });
+  it('pula qtde inválida', () => {
+    expect(derivarCustos(casadoCom({ qtde: 0, preco_atual: 1, total: 10 })).updates).toHaveLength(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run test, verify FAIL** → FAIL.
+
+- [ ] **Step 3: Implement**
+
+```ts
+export interface CustoUpdate { item_id: number; preco_unitario: number; valor_linha: number; }
+export function round2(n: number): number { return Math.round((n + Number.EPSILON) * 100) / 100; }
+
+export function derivarCustos(res: ResultadoMatch): { updates: CustoUpdate[]; pulados: { sku_codigo_omie: string; motivo: string }[] } {
+  const updates: CustoUpdate[] = [];
+  const pulados: { sku_codigo_omie: string; motivo: string }[] = [];
+  for (const c of res.casados) {
+    const total = c.total_linha; const qtde = c.item.qtde_final;
+    if (total == null || !(total > 0)) { pulados.push({ sku_codigo_omie: c.item.sku_codigo_omie, motivo: 'total_invalido' }); continue; }
+    if (!(qtde > 0)) { pulados.push({ sku_codigo_omie: c.item.sku_codigo_omie, motivo: 'qtde_invalida' }); continue; }
+    if (round2(total) === round2(qtde * c.item.preco_atual)) { pulados.push({ sku_codigo_omie: c.item.sku_codigo_omie, motivo: 'sem_mudanca' }); continue; }
+    updates.push({ item_id: c.item.item_id, preco_unitario: total / qtde, valor_linha: total }); // precisão cheia, sem round
+  }
+  return { updates, pulados };
+}
+```
+
+- [ ] **Step 4: Run test, verify PASS** → `bun run test -- sayerlack-scraping-pedido`.
+
+- [ ] **Step 5: typecheck + lint + commit**
+
+```bash
+bun run typecheck && bun lint
+git add -u && git commit -m "feat(sayerlack-scraping): derivar custo (total/qtde) com tolerância no total da linha (TDD)"
+```
+
+---
+
+## Fase 2 — Wiring Deno (edge)
+
+### Task 5: incluir `preco_unitario` no fetch de itensList
+
+**Files:** Modify `supabase/functions/enviar-pedido-portal-sayerlack/index.ts` (`:1450-1535`).
+
+- [ ] **Step 1:** No fallback direto (`:1464-1473`), adicionar `preco_unitario` ao `.select(...)`. No tipo `ItemMapeado`/`PedidoItemDireto` e no map de `itensList` (`:1523-1535`), incluir `preco_unitario: Number(i.preco_unitario ?? 0)`. Na RPC `envio_portal_itens_mapeados` (Step 2 abaixo), garantir que ela também retorne `preco_unitario` (se não retornar, o fallback cobre).
+- [ ] **Step 2:** `deno check supabase/functions/enviar-pedido-portal-sayerlack/index.ts` — sem novos erros (set inalterado).
+- [ ] **Step 3:** Commit: `git commit -am "feat(sayerlack-scraping): itensList carrega preco_unitario (base da tolerância de custo)"`
+
+> ⚠️ Se a RPC `envio_portal_itens_mapeados` não trouxer `preco_unitario`, o caminho RPC perde a tolerância. Decisão: ou estender a RPC (migration), ou **forçar o fallback** lendo `preco_unitario` numa query extra leve. Para o v1, ler `preco_unitario` numa query dedicada `pedido_compra_item(id, preco_unitario)` por `pedido_id` e mesclar por `item_id` — independe da RPC. Implementar essa query no Step 1.
+
+### Task 6: buscar `ltEsperado` + passar via `context`
+
+**Files:** Modify `index.ts` (antes do fetch ao Browserless, perto de `:1603`; e o `context` em `:1635-1641`).
+
+- [ ] **Step 1:** Antes de montar `itemsPortal`, buscar o lead time do grupo:
+
+```ts
+// lead time esperado do grupo (validação de Prz Ent). Null = sem config → gate fica indisponível (fail-open).
+let ltEsperado: number | null = null;
+if (pedido.grupo_codigo) {
+  const { data: grp } = await supabase
+    .from("fornecedor_grupo_producao")
+    .select("lt_producao_dias, lt_producao_unidade")
+    .eq("empresa", pedido.empresa)
+    .eq("fornecedor_nome", pedido.fornecedor_nome)
+    .eq("grupo_codigo", pedido.grupo_codigo)
+    .maybeSingle();
+  // só compara em dias úteis (o founder confirmou "exatamente igual" na mesma unidade)
+  if (grp && (grp.lt_producao_unidade ?? 'uteis') === 'uteis' && Number.isInteger(grp.lt_producao_dias)) {
+    ltEsperado = grp.lt_producao_dias as number;
+  }
+}
+```
+
+- [ ] **Step 2:** No `context` (`:1640`), adicionar `ltEsperado,` ao objeto.
+- [ ] **Step 3:** `deno check` (set inalterado). Commit: `git commit -am "feat(sayerlack-scraping): busca lt do grupo e passa ltEsperado pro Browserless"`
+
+### Task 7: espelhar o helper de custo inline no Deno
+
+**Files:** Modify `index.ts` (perto do topo das funções utilitárias Deno, fora do `BROWSERLESS_FUNCTION`).
+
+- [ ] **Step 1:** Copiar **verbatim** `parseBRL`, `normPortal`, `casarLinhasComItens`, `round2`, `derivarCustos` + os tipos `LinhaPortal/ItemPedido/Casado/ResultadoMatch/CustoUpdate` do helper pra dentro do `index.ts` (escopo Deno, não na string). Comentar `// ESPELHO VERBATIM de src/lib/reposicao/sayerlack-scraping-pedido.ts — manter em sincronia`. (Não precisa de `validarGrupoLeadtime`/`parseDiasPrzEnt` no Deno: o gate roda no browser; mas copiar tudo é mais simples e barato.)
+- [ ] **Step 2:** `deno check` — sem novos erros.
+- [ ] **Step 3:** Commit: `git commit -am "feat(sayerlack-scraping): espelha helper de custo no Deno da edge"`
+
+### Task 8: `GRUPO_LEADTIME_MISMATCH` → `erro_nao_retentavel`
+
+**Files:** Modify `index.ts` `buildEnvelope` (`:335`).
+
+- [ ] **Step 1:** Na linha do `erroLogicoPreSubmit` (`:335-336`), adicionar `|| tipo === 'GRUPO_LEADTIME_MISMATCH'`. Assim o bloqueio do gate vira `erro_nao_retentavel` (sem POST, `requestSent=false`), que o motor de retry exclui e o Sentinela `reposicao_portal_humano` mostra. O `data.erro` (montado no browser com a lista de suspeitos) já vai pro `portal_erro` pela maquinaria existente.
+- [ ] **Step 2:** `deno check`. Commit: `git commit -am "feat(sayerlack-scraping): bloqueio de grupo vira erro_nao_retentavel (triagem humana)"`
+
+### Task 9: captura de custo no `sucesso_portal`
+
+**Files:** Modify `index.ts` (`:1814-1818`, dentro do `if (envStatus === "sucesso_portal")`, ANTES de `registrarPedidoOmieAposPortal`).
+
+- [ ] **Step 1:** Após `aplicarTransicao("sucesso_portal", ...)` e ANTES de `await registrarPedidoOmieAposPortal(pedido)`, inserir:
+
+```ts
+// Captura de custo: portal devolveu itens_capturados [{sku_portal, total_raw}]. Idempotente:
+// só grava se o Omie ainda não foi criado (evita retry/watchdog reaplicarem).
+try {
+  const capturados = (envelope?.data?.itens_capturados ?? []) as Array<{ sku_portal: string; total_raw: string; prz_ent_raw?: string }>;
+  const jaTemOmie = !!(pedido as { omie_pedido_compra_numero?: string }).omie_pedido_compra_numero;
+  if (capturados.length > 0 && !jaTemOmie) {
+    const itensParaCusto: ItemPedido[] = itensList.map((i) => ({
+      item_id: i.item_id, sku_codigo_omie: i.sku_codigo_omie, sku_descricao: i.sku_descricao,
+      sku_portal: i.sku_portal, qtde_final: Number(i.qtde_final), preco_atual: Number(i.preco_unitario ?? 0),
+    }));
+    const linhas: LinhaPortal[] = capturados.map((c) => ({ sku_portal: c.sku_portal, prz_ent_raw: c.prz_ent_raw ?? '', total_raw: c.total_raw }));
+    const match = casarLinhasComItens(linhas, itensParaCusto);
+    const { updates, pulados } = derivarCustos(match);
+    for (const u of updates) {
+      await supabase.from("pedido_compra_item").update({ preco_unitario: u.preco_unitario, valor_linha: u.valor_linha }).eq("id", u.item_id);
+    }
+    const novoTotal = match.casados.reduce((s, c) => s + (c.total_linha ?? (c.item.qtde_final * c.item.preco_atual)), 0);
+    await supabase.from("pedido_compra_sugerido").update({
+      valor_total: novoTotal,
+      portal_resposta: { ...(pedido.portal_resposta ?? {}), custos_capturados: { aplicados: updates.length, pulados, capturados } },
+    }).eq("id", pedido.id);
+    console.log(`[envio-portal] Pedido #${pedido.id}: custo capturado — ${updates.length} atualizados, ${pulados.length} pulados`);
+  }
+} catch (e) {
+  console.error(`[envio-portal] Pedido #${pedido.id}: falha best-effort na captura de custo:`, e instanceof Error ? e.message : String(e));
+}
+```
+
+> Ajustar o acesso a `pedido.portal_resposta`/`omie_pedido_compra_numero` ao shape real do tipo `pedido` no escopo (ler o tipo no `index.ts`). Best-effort: a falha aqui **nunca** derruba o `sucesso_portal` nem o Omie.
+
+- [ ] **Step 2:** `deno check` — sem novos erros.
+- [ ] **Step 3:** Commit: `git commit -am "feat(sayerlack-scraping): grava custo do portal no pedido antes do Omie (idempotente, best-effort)"`
+
+---
+
+## Fase 3 — Browser-side (BROWSERLESS_FUNCTION) — scrape + gate
+
+### Task 10: scrape `#datatable_itens` + gate B + retornar totais (na string `:32`)
+
+**Files:** Modify `index.ts` `BROWSERLESS_FUNCTION` (`:32` em diante; destructure em `:33`; inserir após o settle de validação `~:942`, antes do scroll/efetivar `~:944`).
+
+- [ ] **Step 1 (descobrir seletores — run de debug):** Adicionar, logo após `trace.push({ step: 'validacao_data_entrega_ok_pre_efetivar' ...})`, um dump do layout da tabela:
+
+```js
+const debugTabela = await page.evaluate(function() {
+  const rows = Array.from(document.querySelectorAll('#datatable_itens tbody tr'));
+  return rows.slice(0, 2).map(function(tr) {
+    return Array.from(tr.querySelectorAll('td')).map(function(td, i) {
+      return { i: i + 1, text: (td.innerText || '').trim().substring(0, 30) };
+    });
+  });
+});
+console.log('[DEBUG_TABELA_ITENS]', JSON.stringify(debugTabela));
+```
+
+Disparar um pedido real (founder) e ler `[DEBUG_TABELA_ITENS]` nos logs da edge no Lovable. **Anotar o índice da coluna do código (sku_portal), do `Prz Ent` e do total (última).** Sabe-se já: a qtde é input em `td:nth-of-type(7)` (`:832`), e o total é a **última** coluna (founder).
+
+- [ ] **Step 2 (scrape real):** Trocar o debug pelo scrape (substituir `<COL_CODIGO>`/`<COL_PRZ>` pelos índices confirmados no Step 1; o total é `td:last-child`):
+
+```js
+const linhasPortal = await page.evaluate(function() {
+  const rows = Array.from(document.querySelectorAll('#datatable_itens tbody tr'));
+  return rows.map(function(tr) {
+    const tds = tr.querySelectorAll('td');
+    const cell = function(n) { const el = tds[n - 1]; return el ? (el.innerText || '').trim() : ''; };
+    return {
+      sku_portal: cell(<COL_CODIGO>),
+      prz_ent_raw: cell(<COL_PRZ>),
+      total_raw: tds.length ? (tds[tds.length - 1].innerText || '').trim() : '',
+    };
+  });
+}).catch(function() { return []; });
+trace.push({ step: 'scrape_datatable', n: linhasPortal.length, t: Date.now() - t0 });
+```
+
+- [ ] **Step 3 (gate B inline — bloqueia antes do Efetivar):** Logo após o scrape:
+
+```js
+// Gate de grupo: Prz Ent (inteiro) == ltEsperado, exato. Fail-OPEN na incerteza (não trava por bug de seletor).
+if (typeof ltEsperado === 'number' && Number.isInteger(ltEsperado) && linhasPortal.length > 0) {
+  const mismatches = [];
+  let validados = 0;
+  for (const ln of linhasPortal) {
+    const m = (ln.prz_ent_raw || '').match(/-?\\d+/);
+    if (!m) continue; // não parseou → pulado (fail-open)
+    validados++;
+    const prz = Number(m[0]);
+    if (prz !== ltEsperado) mismatches.push({ sku_portal: ln.sku_portal, prz_ent: prz, lt_esperado: ltEsperado });
+  }
+  if (mismatches.length > 0) {
+    const lista = mismatches.map(function(x) { return x.sku_portal + ' (Prz ' + x.prz_ent + ' ≠ ' + x.lt_esperado + ')'; }).join('; ');
+    return {
+      data: {
+        success: false,
+        erro: 'Grupo errado (Prz Ent ≠ lead time do grupo): ' + lista + '. Confira o de-para/grupo.',
+        erroTipo: 'GRUPO_LEADTIME_MISMATCH',
+        mismatches: mismatches,
+        trace,
+      },
+      type: 'application/json',
+    };
+  }
+  trace.push({ step: 'gate_grupo_ok', validados: validados, t: Date.now() - t0 });
+}
+```
+
+> ⚠️ A string é template literal — escapar `\\d` (vira `\d` no código gerado). Conferir no `index.ts` gerado que o regex saiu certo.
+
+- [ ] **Step 4 (destructure + retornar totais):** No destructuring (`:33`): `const { user, pass, portalUrl, clienteCodigo, items, ltEsperado } = context;`. No **retorno de sucesso** (onde monta `data: { success: true, protocolo, portal_data_entrega, ... }`), **incluir** `itens_capturados: linhasPortal.map(function(l){ return { sku_portal: l.sku_portal, total_raw: l.total_raw, prz_ent_raw: l.prz_ent_raw }; })`.
+
+- [ ] **Step 5:** `deno check` + lint do arquivo (`bunx eslint supabase/functions/enviar-pedido-portal-sayerlack/index.ts`).
+- [ ] **Step 6:** Commit: `git commit -am "feat(sayerlack-scraping): scrape #datatable_itens + gate de grupo (bloqueia antes do Efetivar) + retorna totais"`
+
+---
+
+## Fase 4 — Revisão + deploy + verificação real
+
+### Task 11: revisão adversária do Codex (money-path)
+
+- [ ] **Step 1:** `git diff origin/main...HEAD` e rodar `/codex challenge` (ou `codex exec` adversarial) focado em: double-count de custo, idempotência do write, escape do regex na string, fail-open vs fail-closed, e o gate não bloquear pedido correto. Corrigir P1.
+- [ ] **Step 2:** Rodar `bun run test`, `bun run typecheck`, `bun lint`, `deno check` no arquivo — tudo verde.
+
+### Task 12: deploy + verificação no portal real
+
+- [ ] **Step 1:** Abrir PR, mergear na main (CI verde; `--squash`, não `--admin`).
+- [ ] **Step 2:** Redeploy da edge `enviar-pedido-portal-sayerlack` via chat do Lovable (ler da main, verbatim).
+- [ ] **Step 3 (verificação por comportamento):** Founder dispara:
+  - um pedido **com 1 item de grupo errado** (Prz Ent ≠ lt) → deve **não efetivar**, virar `erro_nao_retentavel` com a lista no `portal_erro`. Nada no fornecedor.
+  - um pedido **100% correto** → efetiva, e `pedido_compra_item.preco_unitario` reflete `total_linha/qtde_final` (conferir no SQL Editor: `SELECT sku_codigo_omie, qtde_final, preco_unitario, qtde_final*preco_unitario AS linha FROM pedido_compra_item WHERE pedido_id = <id>` → soma das linhas == total do portal). O Omie sai com esses custos.
+
+---
+
+## Self-Review (preenchido)
+
+- **Cobertura do spec:** B (gate Prz Ent, bloqueia mismatch, fail-open na incerteza) = Tasks 6,8,10. A (custo total/qtde, tolerância no total, idempotência, mapeamento seguro) = Tasks 1-4,5,7,9. Pré-req (claim #592) = nota no header. Não-objetivos respeitados (sem auditoria global, sem UI, sem status dedicado).
+- **Placeholders:** os `<COL_CODIGO>`/`<COL_PRZ>` na Task 10 são **deliberados** (índice empírico, descoberto no Step 1 do mesmo task via run de debug) — não é "TODO", é uma etapa de descoberta com método. Resto sem placeholder.
+- **Consistência de tipos:** `ItemPedido`/`LinhaPortal`/`Casado`/`ResultadoMatch`/`CustoUpdate` definidos na Task 2/4 e reusados nas Tasks 7,9. `itens_capturados` (browser, Task 10) ↔ `LinhaPortal` (Deno, Task 9) batem (`sku_portal`/`total_raw`/`prz_ent_raw`).
+- **Risco residual:** a sincronia "helper src/ ↔ espelho Deno" é manual (sem guard automático). Mitigar com o comentário de sincronia + a revisão do Codex. O gate inline no browser duplica a lógica de comparação (simples: parse int + `!==`), tendo `validarGrupoLeadtime` como oráculo testado.

--- a/docs/superpowers/specs/2026-06-04-sayerlack-scraping-pedido-design.md
+++ b/docs/superpowers/specs/2026-06-04-sayerlack-scraping-pedido-design.md
@@ -1,0 +1,111 @@
+# Scraping do pedido Sayerlack: valida grupo (Prz Ent) + captura custo
+
+**Data:** 2026-06-04
+**Status:** design (aguardando revisão do founder → writing-plans)
+**Módulo:** reposição / portal Sayerlack
+**Arquivos-alvo:** `supabase/functions/enviar-pedido-portal-sayerlack/index.ts`, `supabase/functions/disparar-pedidos-aprovados/index.ts`, novo helper puro em `src/lib/reposicao/`.
+
+## Problema
+
+Quando a automação lança um pedido no portal Sayerlack, dois buracos money-path:
+
+1. **Grupo/mapeamento errado vira compra do produto errado.** A automação digita o `sku_portal` (do de-para `sku_fornecedor_externo`) no select2 e clica **na primeira opção** do resultado, **sem conferir** que o produto é o esperado (`index.ts:815` → `:830`). Um de-para errado → compra o produto errado, sem rede. O founder pegou na mão: o **"Prz Ent" (Prazo de Entrega)** que o portal mostra por item não batia com o lead time que ele setou no grupo do produto.
+
+2. **Custo do pedido não reflete o custo real do fornecedor.** O `preco_unitario` vem do motor de geração (`COALESCE(preco_medio, inventory_position.cmc, 0)`) — uma estimativa. O pedido no Omie sai com essa estimativa; quando a NF-e é faturada, o pedido de compra não bate com a nota (sem conferência 3-way confiável). O portal **mostra o custo real** por item (o founder hoje copia à mão).
+
+Ambos os sinais já existem no portal e aparecem **por produto, assim que o item é salvo** (antes do Efetivar). Logo, um único passe de scraping no `#datatable_itens` resolve os dois.
+
+## Objetivo
+
+No run do portal, **antes de efetivar**, ler `#datatable_itens` uma vez (por linha: `sku_portal`, `prz_ent`, `total_linha`) e:
+
+- **B (trava de segurança):** validar `prz_ent == lt_producao_dias` do grupo, exato. Qualquer divergência → **bloquear o pedido inteiro** (não efetivar), marcar os itens suspeitos, avisar. Nada é comprado.
+- **A (enriquecimento de custo):** se B passar e o Efetivar suceder, derivar `preco_unitario = total_linha / qtde_final` e sobrescrever os itens, pra o pedido no Omie sair com o custo do portal (== NF-e futura).
+
+## Pré-requisito
+
+O disparo ao portal precisa estar funcionando. O claim atômico estava quebrado (`.update().or()` no PostgREST → `42703`), consertado na main pelo **PR #592** (RPC `envio_portal_claim_ids`, migration `20260604150000`). **Requer redeploy da edge** `enviar-pedido-portal-sayerlack`. Sem isso, nenhum pedido vai ao portal e nada deste spec roda.
+
+## Modelo de dados (já existe)
+
+- `pedido_compra_sugerido.grupo_codigo` — o grupo do pedido (um por pedido).
+- `fornecedor_grupo_producao(empresa, fornecedor_nome, grupo_codigo)` → **`lt_producao_dias` (int)** + `lt_producao_unidade` (default `'uteis'`). É o lead time que o founder edita na tela de Grupos de Produção.
+- `sku_grupo_producao(empresa, sku_codigo_omie)` → `grupo_codigo` (assignment do SKU ao grupo).
+- `sku_fornecedor_externo(empresa, fornecedor_nome, sku_omie)` → `sku_portal`, `fator_conversao`, `unidade_portal`, `ativo`. De-para. **Único por `sku_omie`, NÃO por `sku_portal`.**
+- `pedido_compra_item(pedido_id, sku_codigo_omie, sku_descricao, qtde_final, preco_unitario, valor_linha)`.
+- `pedido_compra_sugerido`: `status_envio_portal`, `portal_erro`, `portal_resposta` (jsonb), `omie_pedido_compra_numero`, `valor_total`.
+- No run, a função já carrega `itensList` (`index.ts:1448-1599`): por item já tem `item_id ↔ sku_codigo_omie ↔ sku_portal ↔ qtde_final`. **Reusar isso** — é o lado "esperado" do match.
+
+## Arquitetura — onde encaixa
+
+Fluxo atual do `runFlow` (browser): adiciona cada item (`#btnGravarItem` → `save-tab-preco-session`, a linha aparece em `#datatable_itens`) → espera "Validando data de entrega" assentar (`index.ts:929-942`) → clica **Efetivar** (`#btnSalvarNovoPedido`) → protocolo. Na máquina de estados, `sucesso_portal` (`index.ts:1814`) chama `registrarPedidoOmieAposPortal(pedido)` (`:1817`), que re-invoca o `disparar` pra criar o pedido no Omie lendo `pedido_compra_item`.
+
+Novo fluxo:
+
+1. **Adiciona todos os itens** (loop atual, intocado).
+2. Espera a validação de data assentar (atual).
+3. **Scraping único do `#datatable_itens`** → `linhasPortal: [{ sku_portal, prz_ent, total_linha }]`. (Por produto, já presente — confirmado pelo founder.)
+4. **🚦 Gate B (validação de grupo):** para cada item de `itensList`, casa com a linha do portal por `sku_portal` e checa `prz_ent === ltEsperado`. `ltEsperado` = `lt_producao_dias` do `pedido.grupo_codigo` (lookup único em `fornecedor_grupo_producao`). Se **qualquer** item divergir (ou não casar):
+   - **NÃO clica Efetivar.** Retorna envelope `success:false`, `erroTipo:'GRUPO_LEADTIME_MISMATCH'`, `requestSent:false`, com a lista de suspeitos (`sku_codigo_omie`, `sku_descricao`, `prz_ent_portal`, `lt_esperado`).
+   - `buildEnvelope` mapeia erro lógico pré-submit (igual `SKU_NOT_FOUND`) → **`status_envio_portal='erro_nao_retentavel'`** + `portal_erro="Grupo errado (Prz Ent ≠ lead time do grupo): <lista>"`. O motor de retry já exclui `erro_nao_retentavel`; o Sentinela `reposicao_portal_humano` já o mostra → o founder é avisado, e o pedido **não** é re-disparado sozinho.
+   - **Nada é comprado** (requestSent=false). O founder corrige o de-para/grupo e re-dispara.
+   - **Bloqueia SÓ em divergência CONFIRMADA** (`prz_ent` parseado, inteiro, `!=` `ltEsperado`). Quando **não dá pra validar** o gate é **fail-OPEN com flag alto** (não bloqueia), pra um bug de seletor ou config faltante não travar TODO pedido (DoS no founder):
+     - `pedido.grupo_codigo` null ou sem `lt_producao_dias` configurado → não há "esperado" → não valida, registra `validacao_grupo_pulada` em `portal_resposta`, segue pro Efetivar.
+     - Scraping não leu nenhuma linha / não conseguiu parsear o `Prz Ent` (seletor mudou) → checagem **indisponível**, não bloqueia, registra `validacao_grupo_indisponivel` (alto, pra o founder saber que a trava não rodou).
+     - Item que não casou no portal (`naoCasado`) ou `sku_portal` ambíguo → trata como **indisponível pra aquele item** (flag), não como mismatch confirmado — não bloqueia o pedido por incerteza de tooling.
+5. Se o gate **passa** (ou foi indisponível) → clica **Efetivar** → protocolo → `sucesso_portal`.
+6. **Captura de custo A:** no `sucesso_portal`, **antes** de `registrarPedidoOmieAposPortal`, com as `linhasPortal` do passo 3:
+   - por item, `precoNovo = total_linha / qtde_final` (qtde_final = qtde Omie, inalterada — confirmado);
+   - **tolerância no TOTAL da linha:** se `round(total_linha, 2) === round(qtde_final * preco_atual, 2)` → **mantém** o atual (não sobrescreve); senão sobrescreve `preco_unitario = precoNovo` (precisão cheia, sem arredondar pra 2 casas) + `valor_linha = total_linha`;
+   - recalcula `pedido.valor_total = Σ total_linha`;
+   - guarda `portal_resposta.custos_capturados` (totais crus + custo anterior por item) pra auditoria.
+7. `registrarPedidoOmieAposPortal → disparar` lê `pedido_compra_item` já atualizado → Omie sai com o custo do portal.
+
+**B é trava dura ANTES do Efetivar; A só roda DEPOIS que o Efetivar sucedeu.** Os dois comem do mesmo scraping (passo 3). Se B bloqueia, A nunca roda (não há pedido).
+
+## Helper puro (TDD) — `src/lib/reposicao/sayerlack-scraping-pedido.ts`
+
+Oráculo que a edge espelha. Sem I/O.
+
+- `casarLinhasComItens(linhasPortal, itens)` → `{ casados: [{item, linha}], naoCasados: item[], sku_portal_ambiguo: [...] }`. **Itera os ITENS** e busca a linha por `sku_portal` (não reverte por `sku_portal`, que não é único). Se um `sku_portal` casar com >1 item OU >1 linha → marca ambíguo e **não** aplica (nem custo, nem validação confiante naquele).
+- `validarGrupoLeadtime(casados, ltEsperado)` → `{ status: 'ok' | 'mismatch' | 'indisponivel', mismatches: [{ sku, prz_ent, lt_esperado }], pulados }`. Igualdade **exata** de inteiro. **Só `mismatch` bloqueia** (≥1 item parseado com `prz_ent != ltEsperado`). `ltEsperado` ausente, nenhum item parseável, `naoCasados`/`ambiguos` → `indisponivel`/`pulado` (flag, **não** bloqueia — ver "fail-OPEN" no gate). Distinguir incerteza de tooling de divergência real é o ponto central.
+- `derivarCustos(casados)` → `{ updates: [{ item_id, preco_unitario, valor_linha }], pulados }`. Aplica a tolerância de total-da-linha; guarda contra `qtde_final<=0`/`total_linha<=0` (pula + flag). Precisão cheia.
+- `parseBRL(str)` / `parseDiasPrzEnt(str)` — parsing robusto do texto do portal (BRL pt-BR `1.234,56`; Prz Ent inteiro de dias).
+
+Edge importa nada de `src/` (Deno) → o helper é espelhado **verbatim** na edge, e os testes vitest cobrem o oráculo.
+
+## Tratamento de falha (A)
+
+Best-effort, anti-órfão (o pedido já foi efetivado quando A roda):
+- Linha sem total parseável → mantém o custo atual + flag em `portal_resposta`. **Nunca** segura o Omie se os custos forem `>0`.
+- Item de primeira compra que ficou em 0 (não capturou) → cai no guard de preço-0 que já existe no `disparar` → recuperação manual de hoje (founder define custo + re-dispara; o `already_sent` pula o portal).
+- **Idempotência:** se `omie_pedido_compra_numero` já existe (Omie já criado), **não** regrava custo — protege contra retry/re-disparo/watchdog reaplicarem.
+
+## Não-objetivos (v1)
+
+- Auditoria periódica de TODO o de-para (a checagem é no pedido, on-demand — o Prz Ent vem de graça no run).
+- Status dedicado pro bloqueio de grupo (reusa `erro_nao_retentavel` + mensagem clara; status próprio = migration + UI + Sentinela, fica pra v2 se o bucket confundir).
+- UI nova de comparação estimado×portal×NF-e (o dado fica em `portal_resposta` pra auditoria; diff visual é v2).
+- Validar por descrição/categoria (o Prz Ent é o sinal limpo e exato).
+- Capturar quantidade (o founder confirmou que não muda).
+- `lt_producao_unidade` ≠ `'uteis'`: assume úteis (o founder confirmou "exatamente igual" na mesma unidade); grupo com unidade diferente → flag de "unidade inesperada", não compara às cegas.
+
+## Detalhes a confirmar na implementação (empírico, num run de teste)
+
+- Seletores exatos das colunas `Prz Ent` e total no `#datatable_itens` (índice da coluna), e o seletor do `sku_portal`/código por linha. Verificar lendo o DOM num run real (o `/browse` headless não renderiza; usar os logs/trace da edge ou um run de teste).
+- Confirmar que `prz_ent` e `total_linha` estão na MESMA linha que o código do produto (pra casar com `sku_portal`).
+
+## Critério de pronto
+
+- Gate B: pedido com 1 item de Prz Ent divergente **não efetiva**, vira `erro_nao_retentavel` com a lista de suspeitos; pedido 100% correto efetiva normal.
+- Captura A: com snapshot válido, `pedido_compra_item.preco_unitario` reflete `total_linha/qtde_final`; `Σ qtde_final*preco_unitario == Σ total_linha` (fecha com o portal); o Omie sai com esses custos.
+- Helper puro com testes vitest (casamento, ambiguidade, validação exata, tolerância, parsing).
+- Codex adversarial no código antes do merge (money-path).
+
+## Refinos do Codex (consult 2026-06-04, já incorporados em A)
+
+- Mapear iterando os itens (de-para não é único por `sku_portal`) + guarda de ambiguidade/duplicado.
+- Não arredondar o unitário pra 2 casas (precisão pro total fechar); tolerância no total da linha, não no unitário.
+- Idempotência (não regravar após `omie_pedido_compra_numero`).
+- `fator_conversao` fora da divisão (só afeta a qtde do portal; dividir pela qtde Omie fecha o total).
+- Sequenciar separado do hotfix do claim (já feito: #592 na main).

--- a/src/lib/reposicao/__tests__/sayerlack-scraping-pedido.test.ts
+++ b/src/lib/reposicao/__tests__/sayerlack-scraping-pedido.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseBRL, parseDiasPrzEnt, casarLinhasComItens, validarGrupoLeadtime, derivarCustos,
+  type ItemPedido, type LinhaPortal,
+} from '../sayerlack-scraping-pedido';
+
+const item = (o: Partial<ItemPedido> = {}): ItemPedido => ({
+  item_id: 1, sku_codigo_omie: 'OMIE1', sku_descricao: 'd', sku_portal: 'P1', qtde_final: 2, preco_atual: 10, ...o,
+});
+const linha = (o: Partial<LinhaPortal> = {}): LinhaPortal => ({ sku_portal: 'P1', prz_ent_raw: '8', total_raw: '20,00', ...o });
+
+describe('parseBRL', () => {
+  it('parseia formato pt-BR (ponto=milhar, vírgula=decimal)', () => {
+    expect(parseBRL('1.234,56')).toBe(1234.56);
+    expect(parseBRL('R$ 90,21')).toBe(90.21);
+    expect(parseBRL('408,36')).toBe(408.36);
+    expect(parseBRL('0,00')).toBe(0);
+  });
+  it('retorna null pra lixo', () => {
+    expect(parseBRL('')).toBeNull();
+    expect(parseBRL('abc')).toBeNull();
+    expect(parseBRL(null as unknown as string)).toBeNull();
+  });
+});
+
+describe('parseDiasPrzEnt', () => {
+  it('extrai o inteiro de dias', () => {
+    expect(parseDiasPrzEnt('8')).toBe(8);
+    expect(parseDiasPrzEnt('8 dias')).toBe(8);
+    expect(parseDiasPrzEnt('12')).toBe(12);
+  });
+  it('retorna null pra vazio/sem número', () => {
+    expect(parseDiasPrzEnt('')).toBeNull();
+    expect(parseDiasPrzEnt('—')).toBeNull();
+  });
+});
+
+describe('casarLinhasComItens', () => {
+  it('casa por sku_portal e parseia prz/total', () => {
+    const r = casarLinhasComItens([linha()], [item()]);
+    expect(r.casados).toHaveLength(1);
+    expect(r.casados[0].prz_ent).toBe(8);
+    expect(r.casados[0].total_linha).toBe(20);
+    expect(r.naoCasados).toHaveLength(0);
+    expect(r.ambiguos).toHaveLength(0);
+  });
+  it('item sem linha no portal vira naoCasado', () => {
+    const r = casarLinhasComItens([], [item()]);
+    expect(r.naoCasados).toHaveLength(1);
+    expect(r.casados).toHaveLength(0);
+  });
+  it('sku_portal em 2 itens vira ambíguo (de-para não é único por sku_portal)', () => {
+    const r = casarLinhasComItens([linha()], [item({ item_id: 1 }), item({ item_id: 2, sku_codigo_omie: 'OMIE2' })]);
+    expect(r.ambiguos).toHaveLength(2);
+    expect(r.casados).toHaveLength(0);
+  });
+  it('sku_portal em 2 linhas vira ambíguo', () => {
+    const r = casarLinhasComItens([linha(), linha({ total_raw: '99,00' })], [item()]);
+    expect(r.ambiguos).toHaveLength(1);
+    expect(r.casados).toHaveLength(0);
+  });
+  it('item com sku_portal nulo vira naoCasado', () => {
+    const r = casarLinhasComItens([linha()], [item({ sku_portal: null })]);
+    expect(r.naoCasados).toHaveLength(1);
+  });
+});
+
+describe('validarGrupoLeadtime', () => {
+  const matchDe = (arr: Array<{ sku?: string; prz: number | null }>) => ({
+    casados: arr.map((a, i) => ({ item: item({ item_id: i, sku_codigo_omie: a.sku ?? 'O' + i }), prz_ent: a.prz, total_linha: 1 })),
+    naoCasados: [], ambiguos: [],
+  });
+  it('ok quando todos os prz batem o esperado', () => {
+    const r = validarGrupoLeadtime(matchDe([{ prz: 8 }, { prz: 8 }]), 8);
+    expect(r.status).toBe('ok');
+    expect(r.mismatches).toHaveLength(0);
+  });
+  it('mismatch quando ≥1 prz difere', () => {
+    const r = validarGrupoLeadtime(matchDe([{ prz: 8 }, { sku: 'X', prz: 12 }]), 8);
+    expect(r.status).toBe('mismatch');
+    expect(r.mismatches).toEqual([{ sku_codigo_omie: 'X', prz_ent: 12, lt_esperado: 8 }]);
+  });
+  it('indisponivel quando ltEsperado é null (sem config de grupo)', () => {
+    expect(validarGrupoLeadtime(matchDe([{ prz: 8 }]), null).status).toBe('indisponivel');
+  });
+  it('indisponivel quando nada parseável (prz null)', () => {
+    expect(validarGrupoLeadtime(matchDe([{ prz: null }]), 8).status).toBe('indisponivel');
+  });
+  it('prz null não conta como mismatch — só pulado', () => {
+    const r = validarGrupoLeadtime(matchDe([{ prz: 8 }, { sku: 'N', prz: null }]), 8);
+    expect(r.status).toBe('ok');
+    expect(r.pulados).toContain('N');
+  });
+});
+
+describe('derivarCustos', () => {
+  const matchCusto = (o: { qtde: number; preco_atual: number; total: number | null }) => ({
+    casados: [{ item: item({ item_id: 7, qtde_final: o.qtde, preco_atual: o.preco_atual }), prz_ent: 8, total_linha: o.total }],
+    naoCasados: [], ambiguos: [],
+  });
+  it('deriva unitário = total/qtde e sobrescreve quando difere', () => {
+    const r = derivarCustos(matchCusto({ qtde: 4, preco_atual: 100, total: 1633.45 }));
+    expect(r.updates).toHaveLength(1);
+    expect(r.updates[0].item_id).toBe(7);
+    expect(r.updates[0].valor_linha).toBe(1633.45);
+    expect(r.updates[0].preco_unitario).toBeCloseTo(408.3625, 4);
+  });
+  it('mantém (não sobrescreve) quando o total da linha bate ao centavo', () => {
+    const r = derivarCustos(matchCusto({ qtde: 4, preco_atual: 408.36, total: 1633.44 })); // 4*408.36=1633.44
+    expect(r.updates).toHaveLength(0);
+    expect(r.pulados[0]).toMatchObject({ motivo: 'sem_mudanca' });
+  });
+  it('pula total inválido (<=0 ou null) sem fabricar custo', () => {
+    expect(derivarCustos(matchCusto({ qtde: 4, preco_atual: 1, total: 0 })).updates).toHaveLength(0);
+    expect(derivarCustos(matchCusto({ qtde: 4, preco_atual: 1, total: null })).updates).toHaveLength(0);
+  });
+  it('pula qtde inválida', () => {
+    expect(derivarCustos(matchCusto({ qtde: 0, preco_atual: 1, total: 10 })).updates).toHaveLength(0);
+  });
+});

--- a/src/lib/reposicao/sayerlack-scraping-pedido.ts
+++ b/src/lib/reposicao/sayerlack-scraping-pedido.ts
@@ -1,0 +1,107 @@
+// Helpers puros do scraping do pedido Sayerlack (valida grupo via Prz Ent + captura custo).
+// ⚠️ A captura de custo (casarLinhasComItens/derivarCustos) é espelhada VERBATIM no Deno da
+// edge enviar-pedido-portal-sayerlack (Deno não importa de src/). Mantenha as duas em sincronia.
+
+export function parseBRL(s: string): number | null {
+  if (typeof s !== 'string') return null;
+  const limpo = s.replace(/[^\d,.-]/g, '').trim();
+  if (!limpo) return null;
+  const normal = limpo.replace(/\./g, '').replace(',', '.'); // pt-BR: ponto=milhar, vírgula=decimal
+  const n = Number(normal);
+  return Number.isFinite(n) ? n : null;
+}
+
+export function parseDiasPrzEnt(s: string): number | null {
+  if (typeof s !== 'string') return null;
+  const m = s.match(/-?\d+/);
+  if (!m) return null;
+  const n = Number(m[0]);
+  return Number.isInteger(n) ? n : null;
+}
+
+export interface LinhaPortal { sku_portal: string; prz_ent_raw: string; total_raw: string; }
+export interface ItemPedido {
+  item_id: number; sku_codigo_omie: string; sku_descricao: string | null;
+  sku_portal: string | null; qtde_final: number; preco_atual: number;
+}
+export interface Casado { item: ItemPedido; prz_ent: number | null; total_linha: number | null; }
+export interface ResultadoMatch { casados: Casado[]; naoCasados: ItemPedido[]; ambiguos: ItemPedido[]; }
+
+function normPortal(s: string | null): string { return (s ?? '').trim().toUpperCase(); }
+
+export function casarLinhasComItens(linhas: LinhaPortal[], itens: ItemPedido[]): ResultadoMatch {
+  const casados: Casado[] = [];
+  const naoCasados: ItemPedido[] = [];
+  const ambiguos: ItemPedido[] = [];
+
+  const itensPorSku = new Map<string, ItemPedido[]>();
+  for (const it of itens) {
+    const k = normPortal(it.sku_portal);
+    if (!k) { naoCasados.push(it); continue; }
+    const arr = itensPorSku.get(k) ?? [];
+    arr.push(it); itensPorSku.set(k, arr);
+  }
+  const linhasPorSku = new Map<string, LinhaPortal[]>();
+  for (const ln of linhas) {
+    const k = normPortal(ln.sku_portal);
+    if (!k) continue;
+    const arr = linhasPorSku.get(k) ?? [];
+    arr.push(ln); linhasPorSku.set(k, arr);
+  }
+  for (const [k, its] of itensPorSku) {
+    const lns = linhasPorSku.get(k) ?? [];
+    if (its.length > 1 || lns.length > 1) { ambiguos.push(...its); continue; }
+    if (lns.length === 0) { naoCasados.push(its[0]); continue; }
+    casados.push({ item: its[0], prz_ent: parseDiasPrzEnt(lns[0].prz_ent_raw), total_linha: parseBRL(lns[0].total_raw) });
+  }
+  return { casados, naoCasados, ambiguos };
+}
+
+export interface ResultadoValidacao {
+  status: 'ok' | 'mismatch' | 'indisponivel';
+  mismatches: { sku_codigo_omie: string; prz_ent: number; lt_esperado: number }[];
+  pulados: string[];
+}
+
+export function validarGrupoLeadtime(res: ResultadoMatch, ltEsperado: number | null): ResultadoValidacao {
+  const mismatches: ResultadoValidacao['mismatches'] = [];
+  const pulados: string[] = [];
+  const pularTudo = () => {
+    for (const c of res.casados) pulados.push(c.item.sku_codigo_omie);
+    for (const i of res.naoCasados) pulados.push(i.sku_codigo_omie);
+    for (const i of res.ambiguos) pulados.push(i.sku_codigo_omie);
+  };
+  if (ltEsperado == null || !Number.isInteger(ltEsperado)) {
+    pularTudo();
+    return { status: 'indisponivel', mismatches, pulados };
+  }
+  let validados = 0;
+  for (const c of res.casados) {
+    if (c.prz_ent == null) { pulados.push(c.item.sku_codigo_omie); continue; }
+    validados++;
+    if (c.prz_ent !== ltEsperado) {
+      mismatches.push({ sku_codigo_omie: c.item.sku_codigo_omie, prz_ent: c.prz_ent, lt_esperado: ltEsperado });
+    }
+  }
+  for (const i of res.naoCasados) pulados.push(i.sku_codigo_omie);
+  for (const i of res.ambiguos) pulados.push(i.sku_codigo_omie);
+  if (mismatches.length > 0) return { status: 'mismatch', mismatches, pulados };
+  if (validados > 0) return { status: 'ok', mismatches, pulados };
+  return { status: 'indisponivel', mismatches, pulados };
+}
+
+export interface CustoUpdate { item_id: number; preco_unitario: number; valor_linha: number; }
+export function round2(n: number): number { return Math.round((n + Number.EPSILON) * 100) / 100; }
+
+export function derivarCustos(res: ResultadoMatch): { updates: CustoUpdate[]; pulados: { sku_codigo_omie: string; motivo: string }[] } {
+  const updates: CustoUpdate[] = [];
+  const pulados: { sku_codigo_omie: string; motivo: string }[] = [];
+  for (const c of res.casados) {
+    const total = c.total_linha; const qtde = c.item.qtde_final;
+    if (total == null || !(total > 0)) { pulados.push({ sku_codigo_omie: c.item.sku_codigo_omie, motivo: 'total_invalido' }); continue; }
+    if (!(qtde > 0)) { pulados.push({ sku_codigo_omie: c.item.sku_codigo_omie, motivo: 'qtde_invalida' }); continue; }
+    if (round2(total) === round2(qtde * c.item.preco_atual)) { pulados.push({ sku_codigo_omie: c.item.sku_codigo_omie, motivo: 'sem_mudanca' }); continue; }
+    updates.push({ item_id: c.item.item_id, preco_unitario: total / qtde, valor_linha: total }); // precisão cheia
+  }
+  return { updates, pulados };
+}

--- a/supabase/functions/enviar-pedido-portal-sayerlack/index.ts
+++ b/supabase/functions/enviar-pedido-portal-sayerlack/index.ts
@@ -31,7 +31,7 @@ const MAX_TENTATIVAS = 3;
 // Ref: https://docs.browserless.io/rest-apis/function
 const BROWSERLESS_FUNCTION = `
 export default async ({ page, context }) => {
-  const { user, pass, portalUrl, clienteCodigo, items } = context;
+  const { user, pass, portalUrl, clienteCodigo, items, ltEsperado } = context;
   const trace = [];
   const t0 = Date.now();
   // Não usamos timeout interno menor que o Browserless: em 14/05, o pedido #116
@@ -945,6 +945,53 @@ export default async ({ page, context }) => {
     }, { timeout: budgetFor('validacao-pre-efetivar', 15_000), polling: 250 });
     trace.push({ step: 'validacao_data_entrega_ok_pre_efetivar', t: Date.now() - t0, remaining: remainingMs() });
 
+    // === Scrape #datatable_itens (custo + Prz Ent) — header/value matching, robusto a layout ===
+    const skusConhecidos = items.map(function(it){ return (it.sku_portal || '').trim().toUpperCase(); }).filter(Boolean);
+    const scrape = await page.evaluate(function(skus) {
+      function norm(s){ return (s || '').trim().toUpperCase(); }
+      var table = document.querySelector('#datatable_itens');
+      if (!table) return { ok: false, motivo: 'sem_tabela', headers: [], przIdx: -1, rows: [] };
+      var ths = Array.from(table.querySelectorAll('thead th')).map(function(th){ return (th.innerText || '').trim(); });
+      var przIdx = ths.findIndex(function(h){ return /prz|prazo/i.test(h); });
+      var rows = Array.from(table.querySelectorAll('tbody tr')).map(function(tr){
+        var tds = Array.from(tr.querySelectorAll('td'));
+        var texts = tds.map(function(td){ return (td.innerText || '').trim(); });
+        var skuCell = texts.find(function(t){ return skus.indexOf(norm(t)) !== -1; }) || '';
+        return {
+          sku_portal: norm(skuCell),
+          prz_ent_raw: (przIdx >= 0 && texts[przIdx] != null) ? texts[przIdx] : '',
+          total_raw: texts.length ? texts[texts.length - 1] : '',
+        };
+      });
+      return { ok: true, przIdx: przIdx, headers: ths, rows: rows };
+    }, skusConhecidos);
+    console.log('[DEBUG_SCRAPE_ITENS]', JSON.stringify({ ok: scrape.ok, przIdx: scrape.przIdx, headers: scrape.headers, n: (scrape.rows || []).length, amostra: (scrape.rows || []).slice(0, 3) }));
+    trace.push({ step: 'scrape_datatable', n: (scrape.rows || []).length, przIdx: scrape.przIdx, t: Date.now() - t0 });
+    var linhasPortal = scrape.rows || [];
+
+    // === Gate de grupo: Prz Ent (inteiro) === ltEsperado, EXATO. Fail-OPEN na incerteza (bug de seletor/sem config NÃO trava). ===
+    if (typeof ltEsperado === 'number' && Number.isInteger(ltEsperado) && scrape.ok && scrape.przIdx >= 0 && linhasPortal.length > 0) {
+      var mismatches = [];
+      var validados = 0;
+      for (var li = 0; li < linhasPortal.length; li++) {
+        var mm = (linhasPortal[li].prz_ent_raw || '').match(/-?\\d+/);
+        if (!mm) continue;
+        validados++;
+        var prz = Number(mm[0]);
+        if (prz !== ltEsperado) {
+          mismatches.push({ sku_portal: linhasPortal[li].sku_portal || ('linha ' + (li + 1)), prz_ent: prz, lt_esperado: ltEsperado });
+        }
+      }
+      if (mismatches.length > 0) {
+        var listaMm = mismatches.map(function(x){ return x.sku_portal + ' (Prz ' + x.prz_ent + ' != ' + x.lt_esperado + ')'; }).join('; ');
+        return {
+          data: { success: false, erro: 'Grupo errado (Prz Ent != lead time do grupo): ' + listaMm + '. Confira o de-para/grupo.', erroTipo: 'GRUPO_LEADTIME_MISMATCH', mismatches: mismatches, trace: trace },
+          type: 'application/json',
+        };
+      }
+      trace.push({ step: 'gate_grupo_ok', validados: validados, t: Date.now() - t0 });
+    }
+
     // PR13: scroll do botão "Efetivar Pedido" pra dentro da viewport ANTES do
     // click. O navbar sticky do portal Sayerlack cobre o topo da página; quando
     // há vários itens no formulário, a rolagem deixa o botão atrás do navbar
@@ -1178,6 +1225,7 @@ export default async ({ page, context }) => {
           protocolo,
           protocoloSource,
           portal_data_entrega: portalDataEntrega,
+          itens_capturados: linhasPortal.map(function(l){ return { sku_portal: l.sku_portal, total_raw: l.total_raw, prz_ent_raw: l.prz_ent_raw }; }),
           firstSignal: { kind: firstSignal.kind },
           responseInfo,
           successText: protocolo ? ('Pedido ' + protocolo + ' criado com sucesso') : null,

--- a/supabase/functions/enviar-pedido-portal-sayerlack/index.ts
+++ b/supabase/functions/enviar-pedido-portal-sayerlack/index.ts
@@ -1250,6 +1250,83 @@ export default async ({ page, context }) => {
 };
 `;
 
+// ============================================================================
+// Captura de custo do portal (Deno scope — NÃO roda dentro do Browserless).
+// ESPELHO VERBATIM de src/lib/reposicao/sayerlack-scraping-pedido.ts — manter
+// em sincronia. (parseDiasPrzEnt é dependência de casarLinhasComItens; o gate
+// de grupo roda no browser, então validarGrupoLeadtime fica fora daqui.)
+// ============================================================================
+function parseBRL(s: string): number | null {
+  if (typeof s !== 'string') return null;
+  const limpo = s.replace(/[^\d,.-]/g, '').trim();
+  if (!limpo) return null;
+  const normal = limpo.replace(/\./g, '').replace(',', '.'); // pt-BR: ponto=milhar, vírgula=decimal
+  const n = Number(normal);
+  return Number.isFinite(n) ? n : null;
+}
+
+function parseDiasPrzEnt(s: string): number | null {
+  if (typeof s !== 'string') return null;
+  const m = s.match(/-?\d+/);
+  if (!m) return null;
+  const n = Number(m[0]);
+  return Number.isInteger(n) ? n : null;
+}
+
+interface LinhaPortal { sku_portal: string; prz_ent_raw: string; total_raw: string; }
+interface ItemPedido {
+  item_id: number; sku_codigo_omie: string; sku_descricao: string | null;
+  sku_portal: string | null; qtde_final: number; preco_atual: number;
+}
+interface Casado { item: ItemPedido; prz_ent: number | null; total_linha: number | null; }
+interface ResultadoMatch { casados: Casado[]; naoCasados: ItemPedido[]; ambiguos: ItemPedido[]; }
+
+function normPortal(s: string | null): string { return (s ?? '').trim().toUpperCase(); }
+
+function casarLinhasComItens(linhas: LinhaPortal[], itens: ItemPedido[]): ResultadoMatch {
+  const casados: Casado[] = [];
+  const naoCasados: ItemPedido[] = [];
+  const ambiguos: ItemPedido[] = [];
+
+  const itensPorSku = new Map<string, ItemPedido[]>();
+  for (const it of itens) {
+    const k = normPortal(it.sku_portal);
+    if (!k) { naoCasados.push(it); continue; }
+    const arr = itensPorSku.get(k) ?? [];
+    arr.push(it); itensPorSku.set(k, arr);
+  }
+  const linhasPorSku = new Map<string, LinhaPortal[]>();
+  for (const ln of linhas) {
+    const k = normPortal(ln.sku_portal);
+    if (!k) continue;
+    const arr = linhasPorSku.get(k) ?? [];
+    arr.push(ln); linhasPorSku.set(k, arr);
+  }
+  for (const [k, its] of itensPorSku) {
+    const lns = linhasPorSku.get(k) ?? [];
+    if (its.length > 1 || lns.length > 1) { ambiguos.push(...its); continue; }
+    if (lns.length === 0) { naoCasados.push(its[0]); continue; }
+    casados.push({ item: its[0], prz_ent: parseDiasPrzEnt(lns[0].prz_ent_raw), total_linha: parseBRL(lns[0].total_raw) });
+  }
+  return { casados, naoCasados, ambiguos };
+}
+
+interface CustoUpdate { item_id: number; preco_unitario: number; valor_linha: number; }
+function round2(n: number): number { return Math.round((n + Number.EPSILON) * 100) / 100; }
+
+function derivarCustos(res: ResultadoMatch): { updates: CustoUpdate[]; pulados: { sku_codigo_omie: string; motivo: string }[] } {
+  const updates: CustoUpdate[] = [];
+  const pulados: { sku_codigo_omie: string; motivo: string }[] = [];
+  for (const c of res.casados) {
+    const total = c.total_linha; const qtde = c.item.qtde_final;
+    if (total == null || !(total > 0)) { pulados.push({ sku_codigo_omie: c.item.sku_codigo_omie, motivo: 'total_invalido' }); continue; }
+    if (!(qtde > 0)) { pulados.push({ sku_codigo_omie: c.item.sku_codigo_omie, motivo: 'qtde_invalida' }); continue; }
+    if (round2(total) === round2(qtde * c.item.preco_atual)) { pulados.push({ sku_codigo_omie: c.item.sku_codigo_omie, motivo: 'sem_mudanca' }); continue; }
+    updates.push({ item_id: c.item.item_id, preco_unitario: total / qtde, valor_linha: total }); // precisão cheia
+  }
+  return { updates, pulados };
+}
+
 interface PedidoCandidato {
   id: number;
   empresa: string;
@@ -1268,6 +1345,8 @@ interface ItemMapeado {
   unidade_portal: string | null;
   fator_conversao: number;
   mapeamento_ativo: boolean | null;
+  // preço unitário atual do item (base da tolerância na captura de custo do portal)
+  preco_atual?: number;
 }
 
 interface ProcessResult {
@@ -1598,6 +1677,41 @@ async function processarPedido(
     return result;
   }
 
+  // preco_unitario atual (base da tolerância de custo na captura). Independe da RPC trazer ou não.
+  {
+    const ids = itensList.map((i) => i.item_id);
+    if (ids.length > 0) {
+      const { data: precos } = await supabase.from("pedido_compra_item").select("id, preco_unitario").in("id", ids);
+      const pm = new Map<number, number>((precos ?? []).map((p) => [Number((p as { id: number }).id), Number((p as { preco_unitario: number | null }).preco_unitario ?? 0)]));
+      for (const it of itensList) (it as { preco_atual?: number }).preco_atual = pm.get(it.item_id) ?? 0;
+    }
+  }
+
+  // lead time esperado do grupo (validação de Prz Ent). Null = sem config → gate fica indisponível (fail-open).
+  // grupo_codigo não vem no PedidoCandidato (select enxuto) — buscamos a config direto por empresa+fornecedor+grupo.
+  let ltEsperado: number | null = null;
+  {
+    const { data: pedRow } = await supabase
+      .from("pedido_compra_sugerido")
+      .select("grupo_codigo")
+      .eq("id", pedido.id)
+      .maybeSingle();
+    const grupoCodigo = (pedRow as { grupo_codigo?: string | null } | null)?.grupo_codigo ?? null;
+    if (grupoCodigo) {
+      const { data: grp } = await supabase
+        .from("fornecedor_grupo_producao")
+        .select("lt_producao_dias, lt_producao_unidade")
+        .eq("empresa", pedido.empresa)
+        .eq("fornecedor_nome", pedido.fornecedor_nome)
+        .eq("grupo_codigo", grupoCodigo)
+        .maybeSingle();
+      if (grp && ((grp as { lt_producao_unidade?: string }).lt_producao_unidade ?? 'uteis') === 'uteis'
+          && Number.isInteger((grp as { lt_producao_dias?: number }).lt_producao_dias)) {
+        ltEsperado = (grp as { lt_producao_dias: number }).lt_producao_dias;
+      }
+    }
+  }
+
   // 3. Calcular qtde portal
   // Portal Sayerlack só aceita unidades inteiras: arredondar SEMPRE para cima.
   const itemsPortal = itensList.map((i) => ({
@@ -1638,6 +1752,7 @@ async function processarPedido(
             portalUrl: SAYERLACK_PORTAL_URL,
             clienteCodigo: SAYERLACK_PORTAL_CLIENTE_CODIGO,
             items: itemsPortal,
+            ltEsperado,
           },
         }),
       },

--- a/supabase/functions/enviar-pedido-portal-sayerlack/index.ts
+++ b/supabase/functions/enviar-pedido-portal-sayerlack/index.ts
@@ -956,9 +956,11 @@ export default async ({ page, context }) => {
       var rows = Array.from(table.querySelectorAll('tbody tr')).map(function(tr){
         var tds = Array.from(tr.querySelectorAll('td'));
         var texts = tds.map(function(td){ return (td.innerText || '').trim(); });
-        var skuCell = texts.find(function(t){ return skus.indexOf(norm(t)) !== -1; }) || '';
+        // código: SÓ identifica se EXATAMENTE 1 célula bate (igualdade) um sku conhecido — evita
+        // atribuir o sku errado a uma linha por colisão de célula; 0 ou >1 → sku vazio = naoCasado (seguro).
+        var cellsSku = texts.filter(function(t){ return skus.indexOf(norm(t)) !== -1; });
         return {
-          sku_portal: norm(skuCell),
+          sku_portal: cellsSku.length === 1 ? norm(cellsSku[0]) : '',
           prz_ent_raw: (przIdx >= 0 && texts[przIdx] != null) ? texts[przIdx] : '',
           total_raw: texts.length ? texts[texts.length - 1] : '',
         };
@@ -989,7 +991,8 @@ export default async ({ page, context }) => {
           type: 'application/json',
         };
       }
-      trace.push({ step: 'gate_grupo_ok', validados: validados, t: Date.now() - t0 });
+      // validados < total = tabela parcialmente validada (linhas com Prz Ent ilegível foram puladas, fail-open).
+      trace.push({ step: 'gate_grupo_ok', validados: validados, total: linhasPortal.length, t: Date.now() - t0 });
     }
 
     // PR13: scroll do botão "Efetivar Pedido" pra dentro da viewport ANTES do
@@ -2001,7 +2004,11 @@ async function processarPedido(
           await supabase.from("pedido_compra_item").update({ preco_unitario: u.preco_unitario, valor_linha: u.valor_linha }).eq("id", u.item_id);
         }
         if (updates.length > 0) {
-          const novoTotal = match.casados.reduce((s, c) => s + (c.total_linha ?? (c.item.qtde_final * c.item.preco_atual)), 0);
+          // valor_total = Σ TODOS os itens (casados pelo total capturado; não-casados/ambíguos pelo valor atual)
+          // — não subconta itens que o scrape não casou (Codex P1).
+          const totalCasados = match.casados.reduce((s, c) => s + (c.total_linha ?? (c.item.qtde_final * c.item.preco_atual)), 0);
+          const totalOutros = [...match.naoCasados, ...match.ambiguos].reduce((s, it) => s + (it.qtde_final * it.preco_atual), 0);
+          const novoTotal = totalCasados + totalOutros;
           await supabase.from("pedido_compra_sugerido").update({ valor_total: novoTotal }).eq("id", pedido.id);
         }
         console.log(`[envio-portal] Pedido #${pedido.id}: custo capturado — ${updates.length} atualizados, ${pulados.length} pulados`);

--- a/supabase/functions/enviar-pedido-portal-sayerlack/index.ts
+++ b/supabase/functions/enviar-pedido-portal-sayerlack/index.ts
@@ -333,7 +333,8 @@ export default async ({ page, context }) => {
       ok = false;
       const tipo = data.erroTipo || 'UNKNOWN';
       const erroLogicoPreSubmit =
-        tipo === 'LOGIN_FAILED' || tipo === 'CLIENTE_NOT_FOUND' || tipo === 'SKU_NOT_FOUND';
+        tipo === 'LOGIN_FAILED' || tipo === 'CLIENTE_NOT_FOUND' || tipo === 'SKU_NOT_FOUND'
+        || tipo === 'GRUPO_LEADTIME_MISMATCH';
       if (requestSent) {
         // Houve POST: independente do tipo de erro, só conciliação resolve.
         status = 'indeterminado_requer_conciliacao';
@@ -363,6 +364,9 @@ export default async ({ page, context }) => {
         status,
         protocolo,
         portal_data_entrega: data.portal_data_entrega || null,
+        // Totais capturados do #datatable_itens (custo). Propaga o que o runFlow
+        // anexou em raw.data.itens_capturados pro Deno casar com os itens.
+        itens_capturados: Array.isArray(data.itens_capturados) ? data.itens_capturados : [],
         safeToRetry,
         needsReconciliation,
         evidence: {
@@ -1932,6 +1936,31 @@ async function processarPedido(
       protocolo: envelope.protocolo ?? null,
       enviadoPortalEm: true,
     });
+    // Captura de custo do portal: itens_capturados [{sku_portal, total_raw}]. Idempotente (só antes do Omie existir). Best-effort.
+    // (envelope === bResp.data já é o envelope achatado do buildEnvelope; itens_capturados é top-level, não envelope.data.)
+    try {
+      const capturados = ((envelope?.itens_capturados ?? []) as Array<{ sku_portal: string; total_raw: string; prz_ent_raw?: string }>);
+      const jaTemOmie = !!(pedido as { omie_pedido_compra_numero?: string | null }).omie_pedido_compra_numero;
+      if (capturados.length > 0 && !jaTemOmie) {
+        const itensParaCusto: ItemPedido[] = itensList.map((i) => ({
+          item_id: i.item_id, sku_codigo_omie: i.sku_codigo_omie, sku_descricao: i.sku_descricao,
+          sku_portal: i.sku_portal, qtde_final: Number(i.qtde_final), preco_atual: Number((i as { preco_atual?: number }).preco_atual ?? 0),
+        }));
+        const linhas: LinhaPortal[] = capturados.map((c) => ({ sku_portal: c.sku_portal, prz_ent_raw: c.prz_ent_raw ?? '', total_raw: c.total_raw }));
+        const match = casarLinhasComItens(linhas, itensParaCusto);
+        const { updates, pulados } = derivarCustos(match);
+        for (const u of updates) {
+          await supabase.from("pedido_compra_item").update({ preco_unitario: u.preco_unitario, valor_linha: u.valor_linha }).eq("id", u.item_id);
+        }
+        if (updates.length > 0) {
+          const novoTotal = match.casados.reduce((s, c) => s + (c.total_linha ?? (c.item.qtde_final * c.item.preco_atual)), 0);
+          await supabase.from("pedido_compra_sugerido").update({ valor_total: novoTotal }).eq("id", pedido.id);
+        }
+        console.log(`[envio-portal] Pedido #${pedido.id}: custo capturado — ${updates.length} atualizados, ${pulados.length} pulados`);
+      }
+    } catch (e) {
+      console.error(`[envio-portal] Pedido #${pedido.id}: falha best-effort na captura de custo:`, e instanceof Error ? e.message : String(e));
+    }
     await registrarPedidoOmieAposPortal(pedido);
     return r;
   }


### PR DESCRIPTION
## O quê

Scraping do pedido Sayerlack, num único passe no `#datatable_itens` **antes do Efetivar**:
- **(B) Valida grupo:** `Prz Ent` (prazo do portal) `==` `lt_producao_dias` do grupo, EXATO. Mismatch confirmado → **bloqueia o pedido inteiro** (não efetiva, vira `erro_nao_retentavel` com a lista de suspeitos). **Fail-open na incerteza** (sem config / scrape falhou / Prz Ent ilegível → NÃO bloqueia, pra um bug de seletor não travar todo pedido).
- **(A) Captura custo:** `preco_unitario = total_linha / qtde_final` (precisão cheia, tolerância no total ao centavo), grava no pedido **antes** do Omie → pedido de compra == NF-e futura. Idempotente + best-effort.

Scrape robusto a layout: acha a coluna `Prz Ent` por **header**, casa código **por valor** (só identifica se exatamente 1 célula bate). Helper puro TDD (`src/lib/reposicao/sayerlack-scraping-pedido.ts`, 18 testes) espelhado verbatim no Deno da edge; o gate roda inline no `BROWSERLESS_FUNCTION` (string).

Specs/plano: `docs/superpowers/specs/2026-06-04-sayerlack-scraping-pedido-design.md`, `docs/superpowers/plans/2026-06-04-sayerlack-scraping-pedido.md`.

## Revisão

Passe adversário do **Codex** no money-path → 2 P1 corrigidos (match de código "exatamente 1 célula"; `valor_total` soma TODOS os itens, não só os casados). Escaping `\\d`→`\d` na string template confirmado correto. Helper: 18 testes + lint verdes.

## ⚠️ NÃO MERGEAR/DEPLOYAR até verificação em runtime

A feature **nunca rodou contra o portal real**. O 1º disparo real é a verificação: o log `DEBUG_SCRAPE_ITENS` mostra os headers + as linhas raspadas.
**Confirmar antes de deployar:** o "Prz Ent" do portal é um inteiro limpo (`8`)? Se vier range/data (`8-10`), o regex pega o 1º inteiro → o gate pode bloquear pedido certo (Codex P2). 

Plano de deploy: merge → **redeploy da edge `enviar-pedido-portal-sayerlack`** via Lovable (verbatim da main) → 1 disparo de teste controlado (verificar o gate barrando um grupo errado + o custo capturado num pedido certo). **Sem migration** (lê `fornecedor_grupo_producao`, que já existe). A edge desta branch já inclui o #592 (claim RPC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
