### PR TITLE
fix(reposição): recalibra o fusível da auto-aplicação de parâmetros (dropa cobertura, no-op antes do fusível) — BLOCO D

### DIFF
--- a/db/seed-param-auto.sql
+++ b/db/seed-param-auto.sql
@@ -1,5 +1,5 @@
--- Seed dos cenários A–G p/ db/test-param-auto.sh (prova PG17 da auto-aplicação de parâmetros).
--- Roda DEPOIS de aplicar o snapshot + foundation + migrations A/B/C.
+-- Seed dos cenários p/ db/test-param-auto.sh (prova PG17 da auto-aplicação de parâmetros).
+-- Roda DEPOIS de aplicar o snapshot + foundation + migrations A/B/C/D.
 --
 -- A view real v_sku_parametros_sugeridos computa EOQ/safety-stock/ABC-XYZ de dezenas de tabelas-base
 -- (impossível dirigir a valores-alvo exatos). Aqui a SUBSTITUÍMOS por uma view controlada apoiada numa
@@ -7,6 +7,11 @@
 -- resolve a view por nome em tempo de chamada → vê a controlada. Os 2 dependentes da view real
 -- (v_oportunidade_economica_hoje / v_promocao_avaliacao_hoje) não são usados pela feature nem pelos
 -- asserts → DROP CASCADE é seguro neste cluster descartável.
+--
+-- ⚠️ CALIBRAÇÃO PÓS-PROD (BLOCO D): o fusível agora é SÓ multiplicador (material + upward-only). O
+-- gatilho de cobertura-absoluto FOI REMOVIDO (segurava 33/33 itens de giro lento — viés sistemático).
+-- Os cenários abaixo provam: no-op NÃO vira falso segurado; giro lento inalterado = sem_mudanca;
+-- salto 3× ainda segura; QUEDA do máximo aplica (assimétrico); base NULL bloqueia (cold-start manual).
 --
 -- sku_codigo_omie é BIGINT na saída da view real (raiz venda_items_history.sku_codigo_omie bigint) e
 -- na sku_parametros → a controlada também expõe bigint p/ casar o JOIN da core (v=sp).
@@ -39,24 +44,28 @@ CREATE TABLE public._param_sug_test (
 
 CREATE VIEW public.v_sku_parametros_sugeridos AS SELECT * FROM public._param_sug_test;
 
--- ── sku_parametros: estado ANTES (todos OBEN, habilitados, automatica) ──
--- A..G cobrem: A normal→aplica · B salto>3x→segura · C cobertura>120d→segura · D máx<pp→bloqueia
---              E pin igual→pina · F pin diferente→aplica+limpa pin · G igual ao atual→sem_mudanca
+-- ── sku_parametros: estado ANTES (todos OBEN, habilitados, automatica salvo I/J) ──
+-- A normal→aplica · B salto>3x→segura · C giro-lento-no-op→sem_mudanca (prova cobertura morta)
+-- D máx<pp→bloqueia · E pin igual→pina · F pin diferente→aplica+limpa pin · G igual ao atual→sem_mudanca
+-- H fusível>pin→segura · I desabilitado→aplica sem logar · J prod_acabado→aplica sem logar
+-- K base NULL→bloqueia (cold-start) · L queda do máximo→aplica (assimétrico)
 INSERT INTO public.sku_parametros
   (empresa, sku_codigo_omie, sku_descricao, fornecedor_nome,
    ponto_pedido, estoque_minimo, estoque_maximo, estoque_seguranca, cobertura_alvo_dias,
    habilitado_reposicao_automatica, tipo_reposicao, ativo)
 VALUES
-  ('OBEN', 1001, 'SKU-A normal',        'FORN-A', 50, 20, 120, 15, 30, true, 'automatica', true),
-  ('OBEN', 1002, 'SKU-B salto>3x',      'FORN-B', 50, 20, 100, 15, 25, true, 'automatica', true),
-  ('OBEN', 1003, 'SKU-C cobertura',     'FORN-C', 50, 20, 100, 15, 25, true, 'automatica', true),
-  ('OBEN', 1004, 'SKU-D max<pp',        'FORN-D', 50, 20, 120, 15, 30, true, 'automatica', true),
-  ('OBEN', 1005, 'SKU-E pin igual',     'FORN-E', 40, 18, 100, 12, 28, true, 'automatica', true),
-  ('OBEN', 1006, 'SKU-F pin diferente', 'FORN-F', 40, 18, 100, 12, 28, true, 'automatica', true),
-  ('OBEN', 1007, 'SKU-G igual ao atual','FORN-G', 50, 20, 120, 15, 30, true, 'automatica', true),
-  ('OBEN', 1008, 'SKU-H fusivel>pin',   'FORN-H', 50, 20, 100, 15, 25, true, 'automatica', true),
-  ('OBEN', 1009, 'SKU-I desabilitado',  'FORN-I', 50, 20, 120, 15, 30, false,'automatica', true),
-  ('OBEN', 1010, 'SKU-J prod_acabado',  'FORN-J', 50, 20, 120, 15, 30, true, 'produto_acabado', true);
+  ('OBEN', 1001, 'SKU-A normal',         'FORN-A', 50, 20, 120, 15, 30, true, 'automatica', true),
+  ('OBEN', 1002, 'SKU-B salto>3x',       'FORN-B', 50, 20, 100, 15, 25, true, 'automatica', true),
+  ('OBEN', 1003, 'SKU-C giro-lento no-op','FORN-C', 30, 20, 200, 15, 25, true, 'automatica', true),
+  ('OBEN', 1004, 'SKU-D max<pp',         'FORN-D', 50, 20, 120, 15, 30, true, 'automatica', true),
+  ('OBEN', 1005, 'SKU-E pin igual',      'FORN-E', 40, 18, 100, 12, 28, true, 'automatica', true),
+  ('OBEN', 1006, 'SKU-F pin diferente',  'FORN-F', 40, 18, 100, 12, 28, true, 'automatica', true),
+  ('OBEN', 1007, 'SKU-G igual ao atual', 'FORN-G', 50, 20, 120, 15, 30, true, 'automatica', true),
+  ('OBEN', 1008, 'SKU-H fusivel>pin',    'FORN-H', 50, 20, 100, 15, 25, true, 'automatica', true),
+  ('OBEN', 1009, 'SKU-I desabilitado',   'FORN-I', 50, 20, 120, 15, 30, false,'automatica', true),
+  ('OBEN', 1010, 'SKU-J prod_acabado',   'FORN-J', 50, 20, 120, 15, 30, true, 'produto_acabado', true),
+  ('OBEN', 1011, 'SKU-K base NULL',      'FORN-K', NULL, NULL, NULL, NULL, NULL, true, 'automatica', true),
+  ('OBEN', 1012, 'SKU-L queda do máximo','FORN-L', 50, 20, 120, 15, 30, true, 'automatica', true);
 
 -- ── Sugestões da view controlada (status já implícito: todos OK = não-NULL) ──
 INSERT INTO public._param_sug_test
@@ -65,13 +74,14 @@ INSERT INTO public._param_sug_test
    cobertura_alvo_dias, demanda_media_diaria, demanda_sigma_diario, coef_variacao_ordem, num_ordens,
    valor_total_90d, lead_time_medio, lead_time_desvio, lt_p95_dias, fonte_leadtime, z_aplicado, classe_consolidada)
 VALUES
-  -- A: pp 50→60, máx 120→140 (≤3×120 e 140/4=35d≤120) → APLICADO
+  -- A: pp 50→60, máx 120→140 (≤3×120) → APLICADO
   ('OBEN',1001,'SKU-A normal','FORN-A',       20, 60, 140, 15, 35, 4, 1.0, 0.25, 12, 5000, 7, 2, 9, 'historico', 1.64, 'AX'),
-  -- B: máx 100→400 (>3×100=300) → SEGURADO (cobertura 400/4=100d≤120, isola o multiplicador)
+  -- B: máx 100→400 (>3×100=300) → SEGURADO (isola o multiplicador, upward)
   ('OBEN',1002,'SKU-B salto>3x','FORN-B',      20, 50, 400, 15, 25, 4, 1.0, 0.25, 12, 5000, 7, 2, 9, 'historico', 1.64, 'AX'),
-  -- C: máx 100→200 (≤3×100) mas 200/1=200d>120 → SEGURADO (isola a cobertura)
-  ('OBEN',1003,'SKU-C cobertura','FORN-C',     20, 50, 200, 15, 25, 1, 0.5, 0.30, 12, 3000, 7, 2, 9, 'historico', 1.64, 'AX'),
-  -- D: máx 40 < pp 60 → BLOQUEADO_VALIDACAO (validação vence fusível/pin)
+  -- C: GIRO LENTO. demanda 1/dia, máx 200 INALTERADO (200/1=200d de cobertura). Antes seguraria por
+  --    cobertura (>120d); agora máx==antes e ≤3× → SEM_MUDANCA. Prova que o gatilho de cobertura morreu.
+  ('OBEN',1003,'SKU-C giro-lento no-op','FORN-C', 20, 30, 200, 15, 25, 1, 0.5, 0.30, 12, 3000, 7, 2, 9, 'historico', 1.64, 'CZ'),
+  -- D: máx 40 < pp 60 → BLOQUEADO_VALIDACAO (validação vence base/fusível/pin)
   ('OBEN',1004,'SKU-D max<pp','FORN-D',         20, 60, 40, 15, 30, 4, 1.0, 0.25, 12, 5000, 7, 2, 9, 'historico', 1.64, 'AX'),
   -- E: sug pp 50/máx 120 == pin rejeitado (50/120) → PINADO (antes 40/100 difere, mas o pin segura)
   ('OBEN',1005,'SKU-E pin igual','FORN-E',      20, 50, 120, 15, 30, 4, 1.0, 0.25, 12, 5000, 7, 2, 9, 'historico', 1.64, 'AX'),
@@ -79,19 +89,23 @@ VALUES
   ('OBEN',1006,'SKU-F pin diferente','FORN-F',  18, 70, 150, 12, 30, 4, 1.0, 0.25, 12, 5000, 7, 2, 9, 'historico', 1.64, 'AX'),
   -- G: sug pp 50/máx 120 == antes (50/120) → SEM_MUDANCA (não loga)
   ('OBEN',1007,'SKU-G igual ao atual','FORN-G', 20, 50, 120, 15, 30, 4, 1.0, 0.25, 12, 5000, 7, 2, 9, 'historico', 1.64, 'AX'),
-  -- H: máx 100→400 (>3×100) E pin bate (50/400) → fusível VENCE o pin → SEGURADO (não pinado)
+  -- H: máx 100→400 (>3×100) E pin bate (50/400) → pin VENCE o fusível (precedência nova) → PINADO
   ('OBEN',1008,'SKU-H fusivel>pin','FORN-H',     20, 50, 400, 15, 25, 4, 1.0, 0.25, 12, 5000, 7, 2, 9, 'historico', 1.64, 'AX'),
   -- I: aplica config (sug != antes) MAS habilitado=false → NÃO loga (escopo do log = elegível ao motor)
   ('OBEN',1009,'SKU-I desabilitado','FORN-I',    20, 65, 145, 15, 35, 4, 1.0, 0.25, 12, 5000, 7, 2, 9, 'historico', 1.64, 'AX'),
   -- J: aplica config MAS tipo_reposicao=produto_acabado → NÃO loga
-  ('OBEN',1010,'SKU-J prod_acabado','FORN-J',    20, 65, 145, 15, 35, 4, 1.0, 0.25, 12, 5000, 7, 2, 9, 'historico', 1.64, 'AX');
+  ('OBEN',1010,'SKU-J prod_acabado','FORN-J',    20, 65, 145, 15, 35, 4, 1.0, 0.25, 12, 5000, 7, 2, 9, 'historico', 1.64, 'AX'),
+  -- K: base NULL (primeira parametrização). Sugestão coerente → BLOQUEADO_VALIDACAO (cold-start manual).
+  ('OBEN',1011,'SKU-K base NULL','FORN-K',       20, 60, 140, 15, 35, 4, 1.0, 0.25, 12, 5000, 7, 2, 9, 'historico', 1.64, 'AX'),
+  -- L: QUEDA do máximo 120→4 (pp 50→2). Fusível é upward-only → não segura → APLICADO (assimétrico).
+  ('OBEN',1012,'SKU-L queda do máximo','FORN-L',  1,  2,   4,  1, 30, 4, 1.0, 0.25, 12, 5000, 7, 2, 9, 'historico', 1.64, 'AX');
 
--- ── Pins para E (igual) e F (diferente) ──
+-- ── Pins para E (igual), F (diferente) e H (bate, mas pin agora vence o fusível) ──
 INSERT INTO public.reposicao_param_pin (empresa, sku_codigo_omie, ponto_pedido_rejeitado, estoque_maximo_rejeitado)
 VALUES
   ('OBEN', '1005', 50, 120),   -- E: bate com a sugestão → pina
   ('OBEN', '1006', 50, 120),   -- F: NÃO bate (sug 70/150) → aplica e este pin é apagado
-  ('OBEN', '1008', 50, 400);   -- H: bate (50/400) MAS o fusível decide ANTES → segurado (pin fica)
+  ('OBEN', '1008', 50, 400);   -- H: bate (50/400) e o pin decide ANTES do fusível → pinado (pin fica)
 
 -- ── Posição de estoque + custo p/ o impacto (best-effort). account canônico OBEN = 'oben'. ──
 -- A: posição 30 (<= pp_antes 50 e pp_depois 60) → qtde_antes=120-30=90, qtde_depois=140-30=110, Δ20×cmc10=200
@@ -99,11 +113,9 @@ INSERT INTO public.sku_estoque_atual (empresa, sku_codigo_omie, estoque_fisico, 
 VALUES
   ('OBEN','1001', 30, 0),
   ('OBEN','1002', 30, 0),
-  ('OBEN','1003', 30, 0),
   ('OBEN','1006', 30, 0);
 INSERT INTO public.inventory_position (omie_codigo_produto, account, cmc, preco_medio)
 VALUES
   (1001,'oben', 10, 8),   -- A: cmc=10 → impacto 200
   (1002,'oben', 10, 8),   -- B segurado: Δ0 → impacto 0
-  (1003,'oben',  0, 9),   -- C segurado: cmc=0 → custo_fonte=preco_medio
   (1006,'oben', 10, 8);   -- F: custo presente

--- a/db/test-param-auto.sh
+++ b/db/test-param-auto.sh
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
 # Prova PG17 da auto-aplicação de parâmetros da Reposição (money-path).
 # Aplica o schema-snapshot + foundation (pode_ver_carteira_completa + stub cron.schedule, ambos
-# ausentes/parciais no snapshot) + as 3 migrations A/B/C, substitui v_sku_parametros_sugeridos por
-# uma view controlada (db/seed-param-auto.sql), roda o wrapper e assere:
-#   A aplica · B segura (>3x) · C segura (cobertura) · D bloqueia (máx<pp) · E pina · F aplica+limpa pin
-#   · G sem_mudanca (não loga) · impacto best-effort · idempotência (2º run/dia = no-op) · revert
+# ausentes/parciais no snapshot) + as 4 migrations A/B/C/D, substitui v_sku_parametros_sugeridos por
+# uma view controlada (db/seed-param-auto.sql), roda o wrapper e assere o FUSÍVEL RECALIBRADO (BLOCO D):
+#   A/F/L aplicam · B segura (salto 3×) · C giro-lento no-op = sem_mudanca (PROVA cobertura removida)
+#   · D bloqueia (máx<pp) · E/H pinam (pin vence o fusível) · G sem_mudanca · I/J aplicam config sem logar
+#   · K bloqueia cold-start (base NULL) · L queda do máximo = aplicado (assimétrico)
+#   · impacto best-effort (L sem custo = desconhecido) · idempotência (2º run/dia = no-op) · revert
 #   restaura+pina · conflito (estado divergente) · despinar.
 # Base: db/verify-snapshot-replay.sh + db/test-minimo-forcado.sh. Pré-req: brew install postgresql@17 pgvector.
 set -euo pipefail
@@ -86,6 +88,8 @@ echo "→ migration B (core instrumentada)…"
 P -v ON_ERROR_STOP=1 -f "$REPO_ROOT/supabase/migrations/20260605130000_param_auto_core.sql"
 echo "→ migration C (wrapper + revert/pin + cron)…"
 P -v ON_ERROR_STOP=1 -f "$REPO_ROOT/supabase/migrations/20260605140000_param_auto_wrapper_revert_cron.sql"
+echo "→ migration D (recalibra fusível: dropa cobertura, no-op antes do fusível, guard de base)…"
+P -v ON_ERROR_STOP=1 -f "$REPO_ROOT/supabase/migrations/20260605150000_param_auto_fusivel_calibracao.sql"
 
 echo "→ seed dos cenários (view controlada + sku_parametros + pins + estoque/custo)…"
 P -v ON_ERROR_STOP=1 -q -f "$REPO_ROOT/db/seed-param-auto.sql"
@@ -118,11 +122,13 @@ BEGIN
   SELECT estoque_maximo INTO r FROM public.sku_parametros WHERE sku_codigo_omie=1002;
   ASSERT r.estoque_maximo=100, format('B preservou FALHOU: max=% (esperado 100, não 400)', r.estoque_maximo);
 
-  -- C: segurado (cobertura); config preservada
-  SELECT status INTO r FROM public.reposicao_param_auto_log WHERE sku_codigo_omie='1003';
-  ASSERT r.status='segurado', format('C FALHOU: status=% (esperado segurado)', r.status);
+  -- C: GIRO LENTO inalterado → sem_mudanca (NÃO loga). Prova que o gatilho de cobertura morreu:
+  --    demanda 1/dia + máx 200 daria 200d de cobertura (>120) → a versão antiga seguraria; agora
+  --    máx==antes e ≤3× → no-op. config preservada (200).
+  SELECT count(*) INTO n FROM public.reposicao_param_auto_log WHERE sku_codigo_omie='1003';
+  ASSERT n=0, 'C FALHOU: giro lento no-op NÃO deve logar (cobertura removida → sem_mudanca, não segurado)';
   SELECT estoque_maximo INTO r FROM public.sku_parametros WHERE sku_codigo_omie=1003;
-  ASSERT r.estoque_maximo=100, format('C preservou FALHOU: max=%', r.estoque_maximo);
+  ASSERT r.estoque_maximo=200, format('C preservou FALHOU: max=% (esperado 200)', r.estoque_maximo);
 
   -- D: bloqueado_validacao (máx<pp); config preservada (120, não 40)
   SELECT status INTO r FROM public.reposicao_param_auto_log WHERE sku_codigo_omie='1004';
@@ -153,11 +159,12 @@ BEGIN
   SELECT count(*) INTO n FROM public.reposicao_param_auto_log WHERE sku_codigo_omie='1007';
   ASSERT n=0, 'G FALHOU: sem_mudanca NÃO deve gerar linha de log';
 
-  -- H: fusível VENCE o pin (jump>3x E pin bate) → segurado (não pinado); pin permanece
+  -- H: pin bate (50/400) E salto>3x. Precedência nova: PIN (passo 4) vem ANTES do fusível (passo 6)
+  --    → pinado (não segurado). Pin permanece (pinado não limpa pin).
   SELECT status INTO r FROM public.reposicao_param_auto_log WHERE sku_codigo_omie='1008';
-  ASSERT r.status='segurado', format('H FALHOU: status=% (esperado segurado: fusível vence o pin)', r.status);
+  ASSERT r.status='pinado', format('H FALHOU: status=% (esperado pinado: pin vence o fusível na nova precedência)', r.status);
   SELECT count(*) INTO n FROM public.reposicao_param_pin WHERE sku_codigo_omie='1008';
-  ASSERT n=1, 'H pin FALHOU: pin de H deveria permanecer (segurado não limpa pin)';
+  ASSERT n=1, 'H pin FALHOU: pin de H deveria permanecer (pinado não limpa pin)';
 
   -- I: habilitado=false → config aplicada (sug != antes) MAS NÃO logado (escopo do log = motor)
   SELECT count(*) INTO n FROM public.reposicao_param_auto_log WHERE sku_codigo_omie='1009';
@@ -171,31 +178,45 @@ BEGIN
   SELECT estoque_maximo INTO r FROM public.sku_parametros WHERE sku_codigo_omie=1010;
   ASSERT r.estoque_maximo=145, format('J config FALHOU: max=% (esperado 145)', r.estoque_maximo);
 
+  -- K: BASE NULL (primeira parametrização) + sugestão coerente → bloqueado_validacao (cold-start manual).
+  --    config preservada (NULL — não auto-aplica primeiro parâmetro sem baseline pra checar).
+  SELECT status INTO r FROM public.reposicao_param_auto_log WHERE sku_codigo_omie='1011';
+  ASSERT r.status='bloqueado_validacao', format('K FALHOU: status=% (esperado bloqueado_validacao: base NULL = cold-start)', r.status);
+  SELECT estoque_maximo INTO r FROM public.sku_parametros WHERE sku_codigo_omie=1011;
+  ASSERT r.estoque_maximo IS NULL, format('K preservou FALHOU: max=% (esperado NULL — não aplica cold-start)', r.estoque_maximo);
+
+  -- L: QUEDA do máximo 120→4 (pp 50→2) → APLICADO (fusível é upward-only; queda nunca segura).
+  SELECT status INTO r FROM public.reposicao_param_auto_log WHERE sku_codigo_omie='1012';
+  ASSERT r.status='aplicado', format('L FALHOU: status=% (esperado aplicado: queda do máximo não é segurada)', r.status);
+  SELECT ponto_pedido, estoque_maximo INTO r FROM public.sku_parametros WHERE sku_codigo_omie=1012;
+  ASSERT r.ponto_pedido=2 AND r.estoque_maximo=4, format('L config FALHOU: pp=% max=% (esperado 2/4)', r.ponto_pedido, r.estoque_maximo);
+
   -- IMPACTO best-effort:
   -- A: Δqtde 20 × cmc 10 = 200, custo_fonte=cmc
   SELECT impacto_rs, custo_fonte, qtde_compra_antes, qtde_compra_depois INTO r FROM public.reposicao_param_auto_log WHERE sku_codigo_omie='1001';
   ASSERT r.impacto_rs=200, format('A impacto FALHOU: impacto=% (esperado 200)', r.impacto_rs);
   ASSERT r.custo_fonte='cmc', format('A custo_fonte FALHOU: % (esperado cmc)', r.custo_fonte);
   ASSERT r.qtde_compra_antes=90 AND r.qtde_compra_depois=110, format('A qtde FALHOU: antes=% depois=%', r.qtde_compra_antes, r.qtde_compra_depois);
-  -- C: cmc=0 → custo via preco_medio (fallback)
-  SELECT custo_fonte INTO r FROM public.reposicao_param_auto_log WHERE sku_codigo_omie='1003';
-  ASSERT r.custo_fonte='preco_medio', format('C custo_fonte FALHOU: % (esperado preco_medio fallback)', r.custo_fonte);
   -- B: segurado → Δqtde 0 → impacto 0 (com custo presente)
   SELECT impacto_rs INTO r FROM public.reposicao_param_auto_log WHERE sku_codigo_omie='1002';
   ASSERT r.impacto_rs=0, format('B impacto FALHOU: % (esperado 0; segurado não muda a compra)', r.impacto_rs);
+  -- L: aplicado sem inventory_position/estoque → custo ausente → impacto_rs NULL (desconhecido, não 0)
+  SELECT impacto_rs INTO r FROM public.reposicao_param_auto_log WHERE sku_codigo_omie='1012';
+  ASSERT r.impacto_rs IS NULL, format('L impacto FALHOU: % (esperado NULL — custo ausente = desconhecido)', r.impacto_rs);
 
   -- Totais do run: log escopado ao motor (I/J aplicam config mas NÃO contam aqui).
   SELECT total_aplicados, total_segurados, total_pinados, impacto_total_rs, impacto_desconhecido_n
     INTO r FROM public.reposicao_param_auto_run WHERE id=v_run;
-  ASSERT r.total_aplicados=2, format('total_aplicados FALHOU: % (esperado 2: A,F — I/J aplicam mas não logam)', r.total_aplicados);
-  ASSERT r.total_segurados=3, format('total_segurados FALHOU: % (esperado 3: B,C,H)', r.total_segurados);
-  ASSERT r.total_pinados=1, format('total_pinados FALHOU: % (esperado 1: E)', r.total_pinados);
+  ASSERT r.total_aplicados=3, format('total_aplicados FALHOU: % (esperado 3: A,F,L — I/J aplicam mas não logam)', r.total_aplicados);
+  ASSERT r.total_segurados=1, format('total_segurados FALHOU: % (esperado 1: B — cobertura removida, C virou no-op)', r.total_segurados);
+  ASSERT r.total_pinados=2, format('total_pinados FALHOU: % (esperado 2: E,H — pin vence o fusível)', r.total_pinados);
   -- impacto_total_rs = soma dos impactos conhecidos: A=200, F=? (pos 30<=70→qtde_depois 150-30=120;
-  --   antes pp 40, máx 100 → 30<=40→qtde_antes 100-30=70; Δ50×cmc10=500) → 200+500=700; B=0(segurado).
+  --   antes pp 40, máx 100 → 30<=40→qtde_antes 100-30=70; Δ50×cmc10=500) → 200+500=700; B=0(segurado);
+  --   L=NULL (não soma).
   ASSERT r.impacto_total_rs=700, format('impacto_total_rs FALHOU: % (esperado 700: A 200 + F 500)', r.impacto_total_rs);
-  ASSERT COALESCE(r.impacto_desconhecido_n,0)=0, format('impacto_desconhecido_n FALHOU: % (esperado 0: A,F têm custo)', r.impacto_desconhecido_n);
+  ASSERT COALESCE(r.impacto_desconhecido_n,0)=1, format('impacto_desconhecido_n FALHOU: % (esperado 1: L aplica sem custo)', r.impacto_desconhecido_n);
 
-  RAISE NOTICE 'OK status/impacto/totais (A aplica · B/C/H seguram · D bloqueia · E pina · F aplica+limpa pin · G sem_mudanca · I/J aplicam sem logar)';
+  RAISE NOTICE 'OK status/impacto/totais (A/F/L aplicam · B segura (3×) · C giro-lento no-op · D bloqueia · E/H pinam · G sem_mudanca · I/J aplicam sem logar · K bloqueia cold-start · L queda aplica)';
 END $$;
 SQL
 

--- a/docs/roadmap-sessao.md
+++ b/docs/roadmap-sessao.md
@@ -128,6 +128,7 @@
 - ✅ **Brainstorm → codex consult (xhigh, 11 P1) → spec → plano → BUILD subagent-driven (Tasks 1-8) → codex challenge no diff (4 P1: casing `OBEN`/`oben` que subiria a feature MORTA + guard de revert nos 5 campos + hardening) → todos resolvidos + re-provados.** Helper TDD (24 testes) oráculo da SQL · 3 migrations **provadas em PG17** (`db/test-param-auto.sh`) · edge swap · hook + tela `/admin/reposicao/mudancas-automaticas`. Gate verde (typecheck/2413 testes/build/lint).
 - ✅ **Migrations APLICADAS em prod** (founder, SQL Editor): BLOCO A (`tabelas=3·seeds=2`) · B (`pronargs=2`) · C (`funcs=5·crons=1`).
 - ⏳ **Rollout restante (após merge do #632):** redeploy `omie-cron-diario` (chat Lovable, verbatim da main — liga o log diário) → **Publish** (a tela). 1ª foto rica = amanhã de manhã. ⚠️ Branch forkou de `07f7a21f`; merge é aditivo.
+- 🔧 **Calibração pós-prod do fusível (BLOCO D, eu+codex):** prod segurou **33/33** de giro lento → o gatilho de **cobertura-absoluto** (`máx/demanda>120d`) era viés sistemático (em demanda baixa o máximo é dominado pelo SS) → **removido**; fusível agora só `máx>3×` material + **upward-only** (queda nunca segura); **no-op avaliado ANTES do fusível** (mata falso segurado); **guard de base NULL** (cold-start é manual → bloqueado_validacao). Helper+SQL 1:1, re-provado em PG17 (`db/test-param-auto.sh`). Migration `20260605150000` (manual, SQL Editor) + drop do seed morto `param_auto_fusivel_cobertura_dias`.
 
 ---
 

--- a/docs/superpowers/specs/2026-06-05-reposicao-param-auto-aplicacao-design.md
+++ b/docs/superpowers/specs/2026-06-05-reposicao-param-auto-aplicacao-design.md
@@ -172,11 +172,15 @@ Falhou → **não aplica** (preserva o valor anterior), `status='bloqueado_valid
 > Observação: o COALESCE atual já preserva quando o sugerido é NULL (status ≠ OK). A validação dura amplia isso para "OK porém incoerente".
 
 ### 6.2 Fusível (decisão 7) — contenção de input corrompido, por-SKU
-Calcula o salto vs o valor **anterior** (não-nulo). Segura o SKU **inteiro** (não aplica nenhum dos 5; mantém os anteriores) se **qualquer** gatilho disparar:
-- `estoque_maximo_sugerido > FUSIVEL_MULT × estoque_maximo_anterior` (anterior não-nulo e > 0), **default `FUSIVEL_MULT = 3`**; ou
-- cobertura implícita do máximo > `FUSIVEL_COBERTURA_DIAS`, i.e. `estoque_maximo_sugerido / NULLIF(demanda_media_diaria,0) > FUSIVEL_COBERTURA_DIAS`, **default `120` dias**.
+> ⚠️ **Recalibrado pós-prod (BLOCO D, `20260605150000`).** A v1 segurava por `máx > 3×` **OU** cobertura `máx/demanda > 120d`. Em produção o gatilho de **cobertura segurou 33/33** itens de giro lento — **não era corrupção**: pra demanda baixa o máximo é dominado pelo estoque de segurança, então `máx/demanda` é estruturalmente enorme (viés sistemático contra giro lento). O gatilho de cobertura **foi removido**. Além disso o fusível passou a ser avaliado **depois** do "mudou?" (mata o falso `segurado` em no-op).
 
-Segurado → `status='segurado'`, valor anterior preservado, entra no resumo na seção "segurei, confira". Limiares em `company_config` (ajustáveis pelo founder sem deploy). SKU **sem valor anterior** (primeira parametrização) **não** é segurado por multiplicador (não há base) — mas é coberto pelo gatilho de cobertura.
+Segura o SKU **inteiro** (não aplica nenhum dos 5; mantém os anteriores) **apenas** quando o salto do máximo é **material e para cima**:
+- `round(estoque_maximo_sugerido) > FUSIVEL_MULT × round(estoque_maximo_anterior)`, com `estoque_maximo_anterior` não-nulo e **> 0**, **default `FUSIVEL_MULT = 3`**.
+
+**Assimétrico:** uma **queda** do máximo nunca é segurada (só o salto pra cima é suspeito). **Material:** comparação arredondada (elimina ruído decimal da view que recomputa ao vivo). Segurado → `status='segurado'`, valor anterior preservado, entra no resumo na seção "segurei, confira". Limiar em `company_config` (`param_auto_fusivel_mult`, ajustável sem deploy). SKU **sem base válida** (`estoque_maximo_anterior` NULL ou ≤ 0 — primeira parametrização) **não** chega ao fusível: é bloqueado antes (cold-start é manual — ver §6.1b).
+
+### 6.1b Guard de base NULL — cold-start é manual
+Se `estoque_maximo_anterior` é NULL ou ≤ 0, **não há baseline pra sanity-check** → `status='bloqueado_validacao'` (não auto-aplica o primeiro parâmetro). O primeiro valor de um SKU novo é decisão humana; a automação só ajusta o que já tem histórico aplicado.
 
 ### 6.3 Trava de reversão (decisão 6, codex P1 #3) — fingerprint material
 Se existe pin ativo para o SKU:
@@ -187,7 +191,9 @@ Se existe pin ativo para o SKU:
 Arredondamento para inteiro (quantidades) elimina o ruído decimal que tornaria "mudou" sempre verdadeiro na view que recomputa ao vivo.
 
 ### 6.4 Aplicação + log
-Passou por 6.1–6.3 e o valor difere do atual (arredondado) → aplica os 5 campos (como hoje) e `status='aplicado'`. Igual ao atual (arredondado) → **não gera linha de log** (contado apenas em `total_avaliados` do run); evita inflar o log com milhares de SKUs inalterados. Métricas derivadas (demanda/lt/z) seguem sempre frescas (não são config — comportamento atual preservado).
+> ⚠️ **Ordem (BLOCO D):** o "sem mudança material" (igual ao atual, arredondado) é avaliado **ANTES** do fusível (passo 5 < passo 6 em §13). Sem isso, um no-op cujo máximo já era alto virava falso `segurado`. Igual ao atual → `sem_mudanca` (**não chega ao fusível**).
+
+Passou por 6.1b/6.3 e o valor difere do atual (arredondado): se o salto não dispara o fusível (§6.2) → aplica os 5 campos (como hoje) e `status='aplicado'`. Igual ao atual (arredondado) → `sem_mudanca` e **não gera linha de log** (contado apenas em `total_avaliados` do run); evita inflar o log com milhares de SKUs inalterados. Métricas derivadas (demanda/lt/z) seguem sempre frescas (não são config — comportamento atual preservado).
 
 ### 6.5 Impacto da compra simulada (codex P1 #7)
 Para cada SKU aplicado/segurado, calcula o impacto = **Δ da compra que o ciclo geraria agora**:
@@ -272,8 +278,9 @@ Reverter é **por run_id** (não data) — codex P1 #4/#5. Reverter "dias depois
 
 ## 13. Limiares do fusível (defaults, ajustáveis em `company_config`)
 
-- `param_auto_fusivel_mult = 3` (estoque_máximo novo > 3× o anterior).
-- `param_auto_fusivel_cobertura_dias = 120` (máximo implica > 120 dias de cobertura).
+- `param_auto_fusivel_mult = 3` (estoque_máximo novo arredondado > 3× o anterior arredondado, **upward-only**).
+- ~~`param_auto_fusivel_cobertura_dias`~~ **REMOVIDO** (BLOCO D, `20260605150000`): o gatilho de cobertura-absoluto segurava 33/33 itens de giro lento em prod (viés sistemático — em demanda baixa o máximo é dominado pelo SS → `máx/demanda` é estruturalmente alto, não corrupção). O seed morto foi apagado (`DELETE FROM company_config WHERE key='param_auto_fusivel_cobertura_dias'`).
+- **Precedência da decisão (7 passos, SQL ↔ helper 1:1):** (1) sugerido NULL → `sem_mudanca`; (2) incoerente → `bloqueado_validacao`; (3) base NULL/≤0 → `bloqueado_validacao` (cold-start manual); (4) pin bate → `pinado`; (5) sem mudança material → `sem_mudanca` (**antes** do fusível); (6) fusível (`máx_antes>0 e round(máx_sug) > mult×round(máx_antes)`) → `segurado`; (7) else → `aplicado`.
 - Horário do resumo: fixo no cron `reposicao-param-auto-resumo` (18h BRT). Pra mudar, re-agende o cron — não há config key.
 
 ## 14. Rollout

--- a/src/lib/reposicao/__tests__/param-auto-helpers.test.ts
+++ b/src/lib/reposicao/__tests__/param-auto-helpers.test.ts
@@ -5,7 +5,7 @@ import {
   impactoSimulado, decideStatus, type SugestaoParam, type LimiaresFusivel,
 } from '@/lib/reposicao/param-auto-helpers';
 
-const LIM: LimiaresFusivel = { mult: 3, coberturaDias: 120 };
+const LIM: LimiaresFusivel = { mult: 3 };
 const ok: SugestaoParam = { ponto_pedido: 50, estoque_minimo: 20, estoque_maximo: 120, estoque_seguranca: 15, cobertura_alvo_dias: 30 };
 
 describe('passaValidacao', () => {
@@ -18,22 +18,29 @@ describe('passaValidacao', () => {
   it('rejeita cobertura <= 0', () => { expect(passaValidacao({ ...ok, cobertura_alvo_dias: 0 }).ok).toBe(false); });
 });
 
-describe('disparaFusivel', () => {
+describe('disparaFusivel (só multiplicador, material + upward-only)', () => {
   it('não segura mudança normal', () => {
-    expect(disparaFusivel(100, { ...ok, estoque_maximo: 150 }, 4, LIM).segurado).toBe(false);
+    expect(disparaFusivel(100, { ...ok, estoque_maximo: 150 }, LIM).segurado).toBe(false);
   });
   it('segura salto > 3x do anterior', () => {
-    expect(disparaFusivel(100, { ...ok, estoque_maximo: 301 }, 4, LIM).segurado).toBe(true);
+    expect(disparaFusivel(100, { ...ok, estoque_maximo: 301 }, LIM).segurado).toBe(true);
   });
-  it('segura cobertura implícita > 120 dias', () => {
-    expect(disparaFusivel(100, { ...ok, estoque_maximo: 200 }, 1, LIM).segurado).toBe(true);
+  it('NÃO segura por cobertura (gatilho removido): demanda baixa + máx ≤ 3× passa', () => {
+    // máx 200 ≤ 3×100 → não segura, mesmo que 200/1=200d de cobertura (antes seguraria).
+    expect(disparaFusivel(100, { ...ok, estoque_maximo: 200 }, LIM).segurado).toBe(false);
   });
-  it('sem anterior não dispara por multiplicador (mas dispara por cobertura)', () => {
-    expect(disparaFusivel(null, { ...ok, estoque_maximo: 9999 }, 100, LIM).segurado).toBe(false);
-    expect(disparaFusivel(null, { ...ok, estoque_maximo: 9999 }, 1, LIM).segurado).toBe(true);
+  it('QUEDA do máximo nunca é segurada (assimétrico)', () => {
+    expect(disparaFusivel(100, { ...ok, estoque_maximo: 4 }, LIM).segurado).toBe(false);
   });
-  it('demanda nula não divide por zero', () => {
-    expect(() => disparaFusivel(100, { ...ok, estoque_maximo: 150 }, null, LIM)).not.toThrow();
+  it('sem anterior não dispara (não há base pra medir o salto)', () => {
+    expect(disparaFusivel(null, { ...ok, estoque_maximo: 9999 }, LIM).segurado).toBe(false);
+  });
+  it('máx_antes <= 0 não dispara (não há base)', () => {
+    expect(disparaFusivel(0, { ...ok, estoque_maximo: 9999 }, LIM).segurado).toBe(false);
+  });
+  it('material: 3× exato NÃO segura (precisa > mult, arredondado)', () => {
+    expect(disparaFusivel(100, { ...ok, estoque_maximo: 300 }, LIM).segurado).toBe(false);
+    expect(disparaFusivel(100, { ...ok, estoque_maximo: 301 }, LIM).segurado).toBe(true);
   });
 });
 
@@ -64,23 +71,47 @@ describe('impactoSimulado', () => {
   });
 });
 
-describe('decideStatus (precedência validação → fusível → pin → aplicado)', () => {
+describe('decideStatus (precedência: NULL → validação → base → pin → no-op → fusível → aplicado)', () => {
   it('bloqueado_validacao vence tudo', () => {
-    expect(decideStatus({ antes: ok, sugestao: { ...ok, estoque_maximo: 10 }, demandaMediaDiaria: 4, pin: null, limiares: LIM })).toBe('bloqueado_validacao');
+    expect(decideStatus({ antes: ok, sugestao: { ...ok, estoque_maximo: 10 }, pin: null, limiares: LIM })).toBe('bloqueado_validacao');
   });
-  it('segurado vence pin e aplicado', () => {
-    expect(decideStatus({ antes: { ...ok, estoque_maximo: 100 }, sugestao: { ...ok, estoque_maximo: 400 }, demandaMediaDiaria: 4, pin: { pp: 50, max: 400 }, limiares: LIM })).toBe('segurado');
+  it('sem base válida (max_antes NULL) + sugestão OK → bloqueado_validacao (cold-start é manual)', () => {
+    expect(decideStatus({ antes: { ...ok, estoque_maximo: null }, sugestao: ok, pin: null, limiares: LIM })).toBe('bloqueado_validacao');
+  });
+  it('sem base válida (max_antes <= 0) → bloqueado_validacao', () => {
+    expect(decideStatus({ antes: { ...ok, estoque_maximo: 0 }, sugestao: ok, pin: null, limiares: LIM })).toBe('bloqueado_validacao');
+  });
+  it('segurado vence aplicado quando salta > 3×', () => {
+    expect(decideStatus({ antes: { ...ok, estoque_maximo: 100 }, sugestao: { ...ok, estoque_maximo: 400 }, pin: null, limiares: LIM })).toBe('segurado');
+  });
+  it('pin vence o fusível (pin bate mesmo com salto > 3×) → pinado', () => {
+    expect(decideStatus({ antes: { ...ok, estoque_maximo: 100 }, sugestao: { ...ok, estoque_maximo: 400 }, pin: { pp: 50, max: 400 }, limiares: LIM })).toBe('pinado');
   });
   it('pinado quando sugestão == rejeitada', () => {
-    expect(decideStatus({ antes: ok, sugestao: { ...ok, ponto_pedido: 50, estoque_maximo: 120 }, demandaMediaDiaria: 4, pin: { pp: 50, max: 120 }, limiares: LIM })).toBe('pinado');
+    expect(decideStatus({ antes: { ...ok, ponto_pedido: 40, estoque_maximo: 100 }, sugestao: { ...ok, ponto_pedido: 50, estoque_maximo: 120 }, pin: { pp: 50, max: 120 }, limiares: LIM })).toBe('pinado');
   });
   it('aplicado quando difere do atual e do rejeitado', () => {
-    expect(decideStatus({ antes: { ...ok, ponto_pedido: 40, estoque_maximo: 100 }, sugestao: ok, demandaMediaDiaria: 4, pin: { pp: 50, max: 999 }, limiares: LIM })).toBe('aplicado');
+    expect(decideStatus({ antes: { ...ok, ponto_pedido: 40, estoque_maximo: 100 }, sugestao: ok, pin: { pp: 50, max: 999 }, limiares: LIM })).toBe('aplicado');
   });
   it('sem_mudanca quando igual ao atual (arredondado)', () => {
-    expect(decideStatus({ antes: ok, sugestao: { ...ok }, demandaMediaDiaria: 4, pin: null, limiares: LIM })).toBe('sem_mudanca');
+    expect(decideStatus({ antes: ok, sugestao: { ...ok }, pin: null, limiares: LIM })).toBe('sem_mudanca');
+  });
+  it('no-op vence o fusível: sugestão == atual NÃO é falso segurado (cobertura alta era o bug)', () => {
+    // máx 200 igual ao atual 200 (giro lento: demanda baixa, máx dominado por SS) → sem_mudanca, não segurado.
+    const slow = { ...ok, ponto_pedido: 30, estoque_maximo: 200 };
+    expect(decideStatus({ antes: slow, sugestao: { ...slow }, pin: null, limiares: LIM })).toBe('sem_mudanca');
+  });
+  it('giro lento com máx pequeno inalterado → sem_mudanca (prova que cobertura não dispara)', () => {
+    const slow = { ...ok, estoque_minimo: 5, ponto_pedido: 10, estoque_maximo: 30 };
+    expect(decideStatus({ antes: slow, sugestao: { ...slow }, pin: null, limiares: LIM })).toBe('sem_mudanca');
+  });
+  it('QUEDA do máximo (100→4) → aplicado (não segurado: fusível é upward-only)', () => {
+    expect(decideStatus({ antes: { ...ok, ponto_pedido: 3, estoque_maximo: 100 }, sugestao: { ...ok, ponto_pedido: 2, estoque_minimo: 1, estoque_maximo: 4 }, pin: null, limiares: LIM })).toBe('aplicado');
+  });
+  it('salto 3× upward ainda → segurado', () => {
+    expect(decideStatus({ antes: { ...ok, estoque_maximo: 100 }, sugestao: { ...ok, estoque_maximo: 301 }, pin: null, limiares: LIM })).toBe('segurado');
   });
   it('sem_mudanca quando a sugestão tem campo NULL (status != OK → mantém anterior)', () => {
-    expect(decideStatus({ antes: ok, sugestao: { ...ok, estoque_maximo: null }, demandaMediaDiaria: 4, pin: null, limiares: LIM })).toBe('sem_mudanca');
+    expect(decideStatus({ antes: ok, sugestao: { ...ok, estoque_maximo: null }, pin: null, limiares: LIM })).toBe('sem_mudanca');
   });
 });

--- a/src/lib/reposicao/param-auto-helpers.ts
+++ b/src/lib/reposicao/param-auto-helpers.ts
@@ -6,7 +6,7 @@ export interface SugestaoParam {
   estoque_seguranca: number | null;
   cobertura_alvo_dias: number | null;
 }
-export interface LimiaresFusivel { mult: number; coberturaDias: number; }
+export interface LimiaresFusivel { mult: number; }
 export type StatusAuto = 'bloqueado_validacao' | 'segurado' | 'pinado' | 'aplicado' | 'sem_mudanca';
 
 const arred = (n: number) => Math.round(n);
@@ -21,16 +21,17 @@ export function passaValidacao(s: SugestaoParam): { ok: boolean; motivo: string 
   return { ok: true, motivo: null };
 }
 
+// Fusível recalibrado (pós-prod: 33/33 falso-segurado). SÓ o multiplicador, material + upward-only:
+// segura quando o MÁXIMO sugerido (arredondado) salta > mult× o máximo anterior (arredondado, >0).
+// QUEDA do máximo NUNCA é segurada (assimétrico). Cobertura-absoluto removido — penalizava giro lento
+// (em demanda baixa o máximo é dominado pelo estoque de segurança → max/demanda é estruturalmente alto,
+// não corrupção). Sem base anterior → não há salto a medir (o guard de base NULL no decideStatus bloqueia).
 export function disparaFusivel(
-  maxAntes: number | null, s: SugestaoParam, demandaMediaDiaria: number | null, lim: LimiaresFusivel,
+  maxAntes: number | null, s: SugestaoParam, lim: LimiaresFusivel,
 ): { segurado: boolean; motivo: string | null } {
   if (typeof s.estoque_maximo !== 'number' || !Number.isFinite(s.estoque_maximo)) return { segurado: false, motivo: null };
-  if (typeof maxAntes === 'number' && maxAntes > 0 && s.estoque_maximo > lim.mult * maxAntes) {
-    return { segurado: true, motivo: `máximo ${s.estoque_maximo} > ${lim.mult}× anterior ${maxAntes}` };
-  }
-  if (typeof demandaMediaDiaria === 'number' && demandaMediaDiaria > 0) {
-    const coberturaDias = s.estoque_maximo / demandaMediaDiaria;
-    if (coberturaDias > lim.coberturaDias) return { segurado: true, motivo: `cobertura ${Math.round(coberturaDias)}d > ${lim.coberturaDias}d` };
+  if (typeof maxAntes === 'number' && maxAntes > 0 && arred(s.estoque_maximo) > lim.mult * arred(maxAntes)) {
+    return { segurado: true, motivo: `máximo ${arred(s.estoque_maximo)} > ${lim.mult}× anterior ${arred(maxAntes)}` };
   }
   return { segurado: false, motivo: null };
 }
@@ -56,20 +57,37 @@ export function impactoSimulado(args: {
   return { impactoRs, qtdeAntes, qtdeDepois };
 }
 
+// Precedência (7 passos, calibração pós-prod) — a SQL espelha 1:1 (money-path):
+//   1. qualquer campo sugerido NULL → sem_mudanca (COALESCE preserva o anterior; status != OK)
+//   2. sugestão incoerente (NaN/neg/max<pp/pp<min/cob<=0) → bloqueado_validacao
+//   3. SEM base válida (max_antes NULL ou <=0) → bloqueado_validacao (cold-start é manual: não
+//      auto-aplica primeiro parâmetro sem baseline pra sanity-check)
+//   4. pin bate (pp+máx arredondados == rejeitado) → pinado
+//   5. SEM mudança material (pp+máx arredondados == anterior) → sem_mudanca  ← ANTES do fusível
+//      (mata o falso 'segurado' em no-op)
+//   6. fusível (máx_antes>0 e round(máx_sug) > mult×round(máx_antes)) → segurado
+//   7. else → aplicado
 export function decideStatus(args: {
-  antes: SugestaoParam; sugestao: SugestaoParam; demandaMediaDiaria: number | null;
+  antes: SugestaoParam; sugestao: SugestaoParam;
   pin: { pp: number; max: number } | null; limiares: LimiaresFusivel;
 }): StatusAuto {
-  const { antes, sugestao, demandaMediaDiaria, pin, limiares } = args;
-  // (0) status != OK (qualquer campo NULL) → COALESCE preserva o anterior = 'sem_mudanca'.
-  //     Espelha o ramo (0) do SQL (money-path): NULL não é incoerente, é "manter o atual".
+  const { antes, sugestao, pin, limiares } = args;
+  // (1) status != OK (qualquer campo NULL) → COALESCE preserva o anterior = 'sem_mudanca'.
   const semSugestao = [sugestao.ponto_pedido, sugestao.estoque_minimo, sugestao.estoque_maximo, sugestao.estoque_seguranca, sugestao.cobertura_alvo_dias].some((v) => v == null);
   if (semSugestao) return 'sem_mudanca';
+  // (2) validação dura (incoerência).
   if (!passaValidacao(sugestao).ok) return 'bloqueado_validacao';
-  if (disparaFusivel(antes.estoque_maximo, sugestao, demandaMediaDiaria, limiares).segurado) return 'segurado';
+  // (3) sem base válida → não auto-aplica o primeiro parâmetro (sem baseline pra checar).
+  if (!(typeof antes.estoque_maximo === 'number' && Number.isFinite(antes.estoque_maximo) && antes.estoque_maximo > 0)) return 'bloqueado_validacao';
+  // (4) trava de reversão.
   if (pin && pinBloqueia(pin.pp, pin.max, sugestao)) return 'pinado';
-  const difere =
-    arred(sugestao.ponto_pedido!) !== arred(antes.ponto_pedido ?? Number.NEGATIVE_INFINITY) ||
-    arred(sugestao.estoque_maximo!) !== arred(antes.estoque_maximo ?? Number.NEGATIVE_INFINITY);
-  return difere ? 'aplicado' : 'sem_mudanca';
+  // (5) sem mudança material (pp+máx arredondados iguais ao anterior) → ANTES do fusível.
+  const semMudanca =
+    arred(sugestao.ponto_pedido!) === arred(antes.ponto_pedido ?? Number.NEGATIVE_INFINITY) &&
+    arred(sugestao.estoque_maximo!) === arred(antes.estoque_maximo!);
+  if (semMudanca) return 'sem_mudanca';
+  // (6) fusível.
+  if (disparaFusivel(antes.estoque_maximo, sugestao, limiares).segurado) return 'segurado';
+  // (7) aplica.
+  return 'aplicado';
 }

--- a/supabase/migrations/20260605150000_param_auto_fusivel_calibracao.sql
+++ b/supabase/migrations/20260605150000_param_auto_fusivel_calibracao.sql
@@ -1,0 +1,223 @@
+-- Reposição — BLOCO D: recalibra o fusível da core (calibração pós-prod).
+-- ============================================================================
+-- Spec §6.2/§13; oráculo TS: src/lib/reposicao/param-auto-helpers.ts (decideStatus + disparaFusivel).
+-- Money-path. CREATE OR REPLACE de atualizar_parametros_numericos_skus(text, uuid) — corpo VERBATIM
+-- da versão viva (20260605130000_param_auto_core.sql) EXCETO o bloco de decisão (CASE).
+--
+-- POR QUÊ (feedback de produção + codex):
+--   A 1ª versão segurava se max_sug > 3×max_antes (multiplicador) OU max_sug/demanda > 120 (cobertura).
+--   Em prod o gatilho de COBERTURA segurou 33/33 itens de giro lento — NÃO é corrupção: pra demanda
+--   baixa, o máximo é dominado pelo estoque de segurança → max/demanda é estruturalmente enorme. O
+--   gatilho penalizava o giro lento (viés sistemático). Além disso o fusível era avaliado ANTES do
+--   "mudou?", então um no-op (sugestão == atual) podia virar falso 'segurado'.
+--
+-- MUDANÇAS (e SÓ estas) vs a função viva:
+--   • Removida a DECLARE v_cob (config param_auto_fusivel_cobertura_dias) — gatilho de cobertura morto.
+--   • Decisão passa à precedência de 7 passos (espelha decideStatus do helper):
+--       (1) sugerido NULL          → sem_mudanca
+--       (2) incoerente             → bloqueado_validacao
+--       (3) SEM base (max_antes NULL ou <=0) → bloqueado_validacao  [NOVO: cold-start é manual]
+--       (4) pin bate               → pinado
+--       (5) SEM mudança material   → sem_mudanca   [MOVIDO: antes do fusível, mata o falso 'segurado']
+--       (6) fusível (máx_antes>0 e round(máx_sug) > mult×round(máx_antes)) → segurado  [só multiplicador,
+--           material/arredondado, upward-only — QUEDA do máximo nunca é segurada]
+--       (7) else                   → aplicado
+--   • DROP do seed morto company_config 'param_auto_fusivel_cobertura_dias'.
+--
+-- VERBATIM da função viva (NÃO mexido): UPDATE de config + métricas derivadas, gating só-aplicado,
+-- DELETE-do-pin no aplicado, INSERT no log, UPDATE de impacto best-effort.
+-- Validado em PostgreSQL 17 local (db/test-param-auto.sh).
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.atualizar_parametros_numericos_skus(p_empresa text, p_run_id uuid DEFAULT NULL)
+  RETURNS integer
+  LANGUAGE plpgsql
+  SET search_path TO 'public', 'pg_temp'
+  AS $$
+DECLARE
+  atualizados int := 0;
+  -- Default DEVE coincidir com o seed de 20260605120000 (company_config é a fonte canônica).
+  v_mult numeric := COALESCE((SELECT value::numeric FROM public.company_config WHERE key='param_auto_fusivel_mult'), 3);
+BEGIN
+  -- Rótulo de sessão p/ um futuro trigger de histórico distinguir automação de edição humana.
+  -- Hoje registrar_historico_sku_parametros() NÃO lê este GUC (usa deltas de aprovado_em) → inócuo,
+  -- mas barato e forward-compatible. set_config(..., true) = transação-local.
+  PERFORM set_config('app.param_auto', CASE WHEN p_run_id IS NULL THEN 'manual' ELSE 'auto' END, true);
+
+  -- ── Decisão por SKU numa tabela temporária (compartilhada por UPDATE / DELETE-pin / log / impacto) ──
+  -- DROP defensivo: se a core for chamada >1× na mesma transação, a temp anterior some.
+  DROP TABLE IF EXISTS tmp_param_decidido;
+  CREATE TEMP TABLE tmp_param_decidido ON COMMIT DROP AS
+  WITH base AS (
+    SELECT sp.id, sp.empresa, sp.sku_codigo_omie,
+           sp.ponto_pedido AS pp_antes, sp.estoque_minimo AS min_antes, sp.estoque_maximo AS max_antes,
+           sp.estoque_seguranca AS ss_antes, sp.cobertura_alvo_dias AS cob_antes,
+           sp.habilitado_reposicao_automatica AS habilitado,
+           COALESCE(sp.tipo_reposicao,'automatica') AS tipo,
+           v.sku_descricao, v.fornecedor_nome,
+           v.estoque_minimo_sugerido AS min_sug, v.ponto_pedido_sugerido AS pp_sug,
+           v.estoque_maximo_sugerido AS max_sug, v.estoque_seguranca_sugerido AS ss_sug,
+           v.cobertura_alvo_dias AS cob_sug,
+           -- métricas derivadas (verbatim da função viva; nem todas são AS-aliased na view, mas existem)
+           v.demanda_media_diaria, v.demanda_sigma_diario, v.coef_variacao_ordem, v.num_ordens,
+           v.valor_total_90d, v.lead_time_medio, v.lead_time_desvio, v.lt_p95_dias, v.fonte_leadtime,
+           v.z_aplicado, v.classe_consolidada,
+           pin.ponto_pedido_rejeitado, pin.estoque_maximo_rejeitado
+    FROM public.sku_parametros sp
+    JOIN public.v_sku_parametros_sugeridos v
+      ON v.empresa = sp.empresa AND v.sku_codigo_omie = sp.sku_codigo_omie
+    LEFT JOIN public.reposicao_param_pin pin
+      ON pin.empresa = sp.empresa AND pin.sku_codigo_omie = sp.sku_codigo_omie::text
+    WHERE sp.empresa = p_empresa
+  )
+  SELECT b.*,
+    CASE
+      -- (1) status != OK (sugerido NULL): COALESCE preserva o anterior → não é mudança.
+      --     Espelha o "sugerido NULL → keep anterior" da função viva (não é 'incoerente').
+      WHEN b.pp_sug IS NULL OR b.max_sug IS NULL OR b.min_sug IS NULL
+           OR b.ss_sug IS NULL OR b.cob_sug IS NULL THEN 'sem_mudanca'
+      -- (2) VALIDAÇÃO DURA (OK porém incoerente): mirror de passaValidacao — finito, não-negativo,
+      --     max>=pp>=min, cobertura>0. (numeric pode carregar 'NaN' do cast → rejeitar.)
+      WHEN b.pp_sug = 'NaN'::numeric OR b.max_sug = 'NaN'::numeric OR b.min_sug = 'NaN'::numeric
+           OR b.ss_sug = 'NaN'::numeric OR b.cob_sug = 'NaN'::numeric
+           OR b.min_sug < 0 OR b.pp_sug < 0 OR b.max_sug < 0 OR b.ss_sug < 0
+           OR b.max_sug < b.pp_sug OR b.pp_sug < b.min_sug OR b.cob_sug <= 0 THEN 'bloqueado_validacao'
+      -- (3) SEM BASE VÁLIDA: máx anterior NULL ou <= 0 → não auto-aplica o primeiro parâmetro
+      --     (sem baseline pra sanity-check; cold-start é manual). Mirror do passo (3) do helper.
+      WHEN b.max_antes IS NULL OR b.max_antes <= 0 THEN 'bloqueado_validacao'
+      -- (4) TRAVA DE REVERSÃO: fingerprint material (PP+máx arredondados) igual ao rejeitado.
+      WHEN b.ponto_pedido_rejeitado IS NOT NULL
+           AND round(b.pp_sug) = round(b.ponto_pedido_rejeitado)
+           AND round(b.max_sug) = round(b.estoque_maximo_rejeitado) THEN 'pinado'
+      -- (5) SEM MUDANÇA MATERIAL (PP+máx arredondados iguais ao anterior) → ANTES do fusível.
+      --     Mata o falso 'segurado' no no-op (sugestão == atual). max_antes aqui é garantido > 0 (passo 3).
+      WHEN round(b.pp_sug) = round(b.pp_antes) AND round(b.max_sug) = round(b.max_antes) THEN 'sem_mudanca'
+      -- (6) FUSÍVEL: só multiplicador, material (arredondado) + upward-only. QUEDA do máximo nunca segura.
+      WHEN b.max_antes > 0 AND round(b.max_sug) > v_mult * round(b.max_antes) THEN 'segurado'
+      -- (7) APLICA.
+      ELSE 'aplicado'
+    END AS status
+  FROM base b;
+
+  -- ── Aplica a CONFIG só no 'aplicado'; métricas derivadas SEMPRE frescas (verbatim da função viva) ──
+  UPDATE public.sku_parametros sp SET
+    sku_descricao = COALESCE(d.sku_descricao, sp.sku_descricao),
+    fornecedor_nome = COALESCE(d.fornecedor_nome, sp.fornecedor_nome),
+    demanda_media_diaria = d.demanda_media_diaria,
+    demanda_desvio_padrao = d.demanda_sigma_diario,
+    demanda_coef_variacao = d.coef_variacao_ordem,
+    demanda_dias_com_movimento = d.num_ordens,
+    valor_vendido_90d = d.valor_total_90d,
+    lt_medio_dias_uteis = d.lead_time_medio,
+    lt_desvio_padrao_dias = d.lead_time_desvio,
+    lt_p95_dias = d.lt_p95_dias,
+    fonte_leadtime = d.fonte_leadtime,
+    z_score = d.z_aplicado,
+    -- CONFIG: só sobrescreve no 'aplicado'; senão PRESERVA o anterior.
+    -- (sem_mudanca/segurado/pinado/bloqueado_validacao mantêm o valor atual — equivale ao
+    --  COALESCE-quando-NULL da função viva, ampliado p/ os casos de proteção.)
+    estoque_seguranca   = CASE WHEN d.status='aplicado' THEN d.ss_sug  ELSE sp.estoque_seguranca END,
+    ponto_pedido        = CASE WHEN d.status='aplicado' THEN d.pp_sug  ELSE sp.ponto_pedido END,
+    estoque_minimo      = CASE WHEN d.status='aplicado' THEN d.min_sug ELSE sp.estoque_minimo END,
+    cobertura_alvo_dias = CASE WHEN d.status='aplicado' THEN d.cob_sug ELSE sp.cobertura_alvo_dias END,
+    estoque_maximo      = CASE WHEN d.status='aplicado' THEN d.max_sug ELSE sp.estoque_maximo END,
+    ultima_atualizacao_calculo = NOW()
+  FROM tmp_param_decidido d WHERE sp.id = d.id;
+
+  SELECT count(*) FILTER (WHERE status='aplicado') INTO atualizados FROM tmp_param_decidido;
+
+  -- ── Limpa o pin quando a sugestão mudou materialmente e foi aplicada (§6.3) ──
+  -- A trava só vale para o valor que o founder recusou; se a sugestão muda e aplica, o pin sai.
+  DELETE FROM public.reposicao_param_pin p
+  USING tmp_param_decidido d
+  WHERE p.empresa = d.empresa AND p.sku_codigo_omie = d.sku_codigo_omie::text
+    AND d.status = 'aplicado' AND d.ponto_pedido_rejeitado IS NOT NULL;
+
+  -- ── LOG (só no run automático; só SKUs elegíveis ao motor; só status relevantes) ──
+  IF p_run_id IS NOT NULL THEN
+    INSERT INTO public.reposicao_param_auto_log (
+      run_id, empresa, sku_codigo_omie, sku_descricao, status,
+      ponto_pedido_antes, ponto_pedido_depois, estoque_minimo_antes, estoque_minimo_depois,
+      estoque_maximo_antes, estoque_maximo_depois, estoque_seguranca_antes, estoque_seguranca_depois,
+      cobertura_antes, cobertura_depois,
+      demanda_media_diaria, lt_medio_dias_uteis, classe_consolidada, z_score
+    )
+    SELECT p_run_id, d.empresa, d.sku_codigo_omie::text, d.sku_descricao, d.status,
+      d.pp_antes,  CASE WHEN d.status='aplicado' THEN d.pp_sug  ELSE d.pp_antes END,
+      d.min_antes, CASE WHEN d.status='aplicado' THEN d.min_sug ELSE d.min_antes END,
+      d.max_antes, CASE WHEN d.status='aplicado' THEN d.max_sug ELSE d.max_antes END,
+      d.ss_antes,  CASE WHEN d.status='aplicado' THEN d.ss_sug  ELSE d.ss_antes END,
+      d.cob_antes, CASE WHEN d.status='aplicado' THEN d.cob_sug ELSE d.cob_antes END,
+      d.demanda_media_diaria, d.lead_time_medio, d.classe_consolidada, d.z_aplicado
+    FROM tmp_param_decidido d
+    WHERE d.status IN ('aplicado','segurado','pinado','bloqueado_validacao')
+      AND d.habilitado = true AND d.tipo = 'automatica';
+
+    -- ── IMPACTO (§6.5) — BEST-EFFORT / DISPLAY-ONLY ──────────────────────────
+    -- Δ da compra que o ciclo geraria AGORA: qtde(param)=posição<=pp ? max(0,max-posição):0.
+    -- posição = estoque_fisico + pendente + em_transito (espelha gerar_pedidos_sugeridos_ciclo);
+    -- custo = inventory_position.cmc (conta canônica OBEN) fallback preco_medio; ausente/<=0 → NULL.
+    -- NUNCA bloqueia nem corrompe o apply: se algo faltar, impacto_rs fica NULL (degrada honesto).
+    WITH em_transito AS (
+      SELECT pcs2.empresa, pci.sku_codigo_omie::text AS sku_codigo_omie, SUM(pci.qtde_final) AS qtde
+      FROM public.pedido_compra_item pci
+      JOIN public.pedido_compra_sugerido pcs2 ON pcs2.id = pci.pedido_id
+      WHERE pcs2.empresa = p_empresa
+        AND pcs2.status IN ('aprovado_aguardando_disparo','disparado','concluido_recebido')
+        AND pcs2.data_ciclo >= (CURRENT_DATE - INTERVAL '7 days')
+      GROUP BY pcs2.empresa, pci.sku_codigo_omie
+    ),
+    posicao AS (
+      SELECT l.id AS log_id,
+             (COALESCE(sea.estoque_fisico,0) + COALESCE(sea.estoque_pendente_entrada,0)
+                + COALESCE(et.qtde,0)) AS pos,
+             ip.custo, ip.custo_fonte
+      FROM public.reposicao_param_auto_log l
+      LEFT JOIN public.sku_estoque_atual sea
+        ON sea.empresa = l.empresa AND sea.sku_codigo_omie = l.sku_codigo_omie
+      LEFT JOIN em_transito et
+        ON et.empresa = l.empresa AND et.sku_codigo_omie = l.sku_codigo_omie
+      LEFT JOIN LATERAL (
+        -- custo do par SKU×conta-canônica-OBEN: cmc preferido, preco_medio fallback (>0 only)
+        SELECT CASE WHEN ip0.cmc > 0 THEN ip0.cmc
+                    WHEN ip0.preco_medio > 0 THEN ip0.preco_medio
+                    ELSE NULL END AS custo,
+               CASE WHEN ip0.cmc > 0 THEN 'cmc'
+                    WHEN ip0.preco_medio > 0 THEN 'preco_medio'
+                    ELSE NULL END AS custo_fonte
+        FROM public.inventory_position ip0
+        WHERE ip0.omie_codigo_produto::text = l.sku_codigo_omie
+          AND ip0.account = lower(p_empresa)
+        LIMIT 1
+      ) ip ON true
+      WHERE l.run_id = p_run_id
+        AND l.status IN ('aplicado','segurado')
+    )
+    UPDATE public.reposicao_param_auto_log l SET
+      custo_unitario   = p.custo,
+      custo_fonte      = p.custo_fonte,
+      qtde_compra_antes  = CASE WHEN p.pos <= l.ponto_pedido_antes  THEN GREATEST(0, l.estoque_maximo_antes  - p.pos) ELSE 0 END,
+      qtde_compra_depois = CASE WHEN p.pos <= l.ponto_pedido_depois THEN GREATEST(0, l.estoque_maximo_depois - p.pos) ELSE 0 END,
+      impacto_rs = CASE WHEN p.custo IS NULL THEN NULL ELSE
+        ( (CASE WHEN p.pos <= l.ponto_pedido_depois THEN GREATEST(0, l.estoque_maximo_depois - p.pos) ELSE 0 END)
+        - (CASE WHEN p.pos <= l.ponto_pedido_antes  THEN GREATEST(0, l.estoque_maximo_antes  - p.pos) ELSE 0 END)
+        ) * p.custo END
+    FROM posicao p
+    WHERE l.id = p.log_id;
+  END IF;
+
+  RETURN atualizados;
+END;
+$$;
+
+-- Seed morto: o gatilho de cobertura foi removido → a config key não é mais lida.
+DELETE FROM public.company_config WHERE key='param_auto_fusivel_cobertura_dias';
+
+COMMIT;
+
+SELECT 'BLOCO D OK' AS status, proname, pronargs
+FROM pg_proc WHERE proname='atualizar_parametros_numericos_skus';
+
+-- Validação: o seed morto da cobertura sumiu (esperado n=0).
+SELECT 'cobertura seed removido' AS check, count(*) AS n
+FROM public.company_config WHERE key='param_auto_fusivel_cobertura_dias';


### PR DESCRIPTION
## O que é
Recalibração do **fusível** da auto-aplicação de parâmetros (follow-up do #632), após o teste em prod do founder mostrar **33/33 SKUs falsamente "segurados"**.

## Causa-raiz (eu + codex)
- O gatilho **"cobertura > 120 dias"** (`max_sug/demanda`) é estruturalmente errado pro catálogo: em giro lento o `max` é dominado pelo estoque de segurança (mín. prático ~4 un.), então `max/demanda` é enorme mesmo com valor são e **inalterado** → detectava giro lento, não corrupção.
- O fusível disparava **antes** de checar se houve mudança → SKU com sugestão = valor atual (no-op) virava "segurado".

## Fix
- **Dropa o gatilho de cobertura. Mantém só o "saltou >3×"**, material + só pra cima: `max_antes>0 AND round(max_sug) > 3*round(max_antes)`.
- **Nova precedência** (SQL CASE ↔ helper `decideStatus` 1:1): NULL → validação → **base NULL/≤0 → bloqueado** (cold-start manual) → pin → **não-mudou → sem_mudança** → fusível → aplicado.
- Remove o seed morto `param_auto_fusivel_cobertura_dias`.

## ⚠️ Migration — aplicar no SQL Editor (BLOCO D)
`supabase/migrations/20260605150000_param_auto_fusivel_calibracao.sql` (`CREATE OR REPLACE` da core — body verbatim do `20260605130000` exceto o CASE + DECLARE + DELETE do seed).

## Qualidade
- Helper TDD (33 testes) ↔ SQL 1:1. **Provado em PG17** (`db/test-param-auto.sh`): no-op→sem_mudança, base NULL→bloqueado, queda→aplicado, 3×→segurado, pin→pinado.
- Decisão eu+codex (consult). Revisão de correção opus: verbatim-exceto-o-pretendido, CASE=helper, gating de config intacto, zero P1.
- Gate: typecheck 0 · 2462 testes · build (vite) 0 · lint 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
