### PR TITLE
feat(reposição): trilha de aprovação canônica (aprovar=dispara) — Fase 3 · sub-PR 3a

### DIFF
--- a/src/components/reposicao/cicloHoje/PedidoRow.tsx
+++ b/src/components/reposicao/cicloHoje/PedidoRow.tsx
@@ -13,6 +13,8 @@ import { supabase } from "@/integrations/supabase/client";
 import { formatBRL, logAudit } from "@/lib/reposicao";
 import { calcApprovalSuggestion } from "@/lib/reposicao/approvalSuggestion";
 import type { ColKey, PedidoItem } from "@/types/reposicao";
+import { aprovarEDisparar } from "../pedidos/aprovar-disparar";
+import { EMPRESA } from "../pedidos/shared";
 import { PrecoCell, ConfiancaBadge } from "./PedidoRowCells";
 
 export function PedidoRow({
@@ -57,32 +59,54 @@ export function PedidoRow({
     const nowIso = new Date().toISOString();
     const who = user?.email ?? user?.id ?? "cockpit";
     try {
-      const patch =
-        kind === "approve"
-          ? {
-              aprovado_em: nowIso,
-              aprovado_por: who,
-              status: "aprovado_aguardando_disparo" as const,
-              num_skus: qty,
-            }
-          : {
-              cancelado_em: nowIso,
-              cancelado_por: who,
-              status: "cancelado" as const,
-              justificativa_cancelamento: "Rejeitado inline no Cockpit",
-            };
+      if (kind === "approve") {
+        // O edit on-the-spot da quantidade (num_skus) vai ANTES — a trilha canônica
+        // (RPC aprovar_pedido_sugerido) não toca num_skus, então gravamos aqui primeiro.
+        if (qty !== Number(row.num_skus ?? 0)) {
+          const { error: qtyErr } = await supabase
+            .from("pedido_compra_sugerido")
+            .update({ num_skus: qty })
+            .eq("id", row.id);
+          if (qtyErr) throw qtyErr;
+        }
+        // Trilha canônica: APROVAR = DISPARAR NA HORA (não mais só UPDATE + esperar o cron).
+        const r = await aprovarEDisparar({
+          pedidoId: row.id,
+          empresa: EMPRESA, // cockpit da Reposição é OBEN-scoped
+          usuario: who,
+        });
+        await logAudit({
+          userId: user?.id ?? null,
+          action: "Aprovação inline",
+          result: r.ok ? "Sucesso" : `Erro: ${r.mensagem}`,
+          metadata: { id: row.id, qty },
+        });
+        if (!r.ok || r.tipo === "error") toast.error(r.mensagem);
+        else if (r.tipo === "warning") toast.warning(r.mensagem);
+        else if (r.tipo === "info") toast.info(r.mensagem);
+        else toast.success(r.mensagem);
+        onChanged();
+        return;
+      }
+
+      // Rejeição: UPDATE direto (não passa pela trilha de disparo).
       const { error } = await supabase
         .from("pedido_compra_sugerido")
-        .update(patch)
+        .update({
+          cancelado_em: nowIso,
+          cancelado_por: who,
+          status: "cancelado" as const,
+          justificativa_cancelamento: "Rejeitado inline no Cockpit",
+        })
         .eq("id", row.id);
       if (error) throw error;
       await logAudit({
         userId: user?.id ?? null,
-        action: kind === "approve" ? "Aprovação inline" : "Rejeição inline",
+        action: "Rejeição inline",
         result: "Sucesso",
         metadata: { id: row.id, qty },
       });
-      toast.success(kind === "approve" ? "Pedido aprovado" : "Pedido rejeitado");
+      toast.success("Pedido rejeitado");
       onChanged();
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);

--- a/src/components/reposicao/cicloHoje/useCicloHoje.ts
+++ b/src/components/reposicao/cicloHoje/useCicloHoje.ts
@@ -101,29 +101,39 @@ export function useCicloHoje({ user, reviewMode, filteredItems, setFilters }: Us
       // inclusive os auto-aprovados que devem esperar o cron (runAutoApprove). Aqui
       // disparamos exatamente o lote que o operador marcou. Sequencial: não martelar
       // a edge/Browserless em paralelo. Best-effort por item: um erro não aborta os demais.
-      let aprovados = 0;
+      // Apura por `tipo`, NÃO por `r.ok`: aprovar=disparar significa que um pedido pode
+      // aprovar e o disparo falhar (best-effort) — `{ok:true, tipo:'warning'}` (edge não saiu;
+      // rede de segurança assume) ou `{ok:true, tipo:'error'}` (edge retornou 200 com falha
+      // síncrona do Omie → o pedido fica `falha_envio` na lista). Contar isso como
+      // "disparado" no resumo enganaria o operador no money-path.
+      let disparados = 0;
+      let comAviso = 0;
       let comErro = 0;
       for (const id of ids) {
         try {
           const r = await aprovarEDisparar({ pedidoId: id, empresa: EMPRESA, usuario: who });
-          if (r.ok) aprovados += 1;
-          else comErro += 1;
+          if (!r.ok || r.tipo === "error") comErro += 1;
+          else if (r.tipo === "warning") comAviso += 1; // aprovado; disparo ficou p/ a rede de segurança
+          else disparados += 1; // success / info (disparado ou nada a disparar)
         } catch {
           comErro += 1;
         }
       }
+      const tudoOk = comErro === 0 && comAviso === 0;
       await logAudit({
         userId: user?.id ?? null,
         action: "Aprovação em lote",
-        result: comErro === 0 ? "Sucesso" : `Parcial: ${aprovados} ok, ${comErro} com erro`,
-        metadata: { ids, count: ids.length, aprovados, comErro },
+        result: tudoOk
+          ? "Sucesso"
+          : `Parcial: ${disparados} disparado(s), ${comAviso} aguardando, ${comErro} com falha`,
+        metadata: { ids, count: ids.length, disparados, comAviso, comErro },
       });
-      if (comErro === 0) {
-        toast.success(`${aprovados} pedido(s) aprovado(s) e disparado(s)`);
-      } else if (aprovados > 0) {
-        toast.warning(`${aprovados} aprovado(s); ${comErro} com erro. Reveja os que falharam.`);
+      if (tudoOk) {
+        toast.success(`${disparados} pedido(s) aprovado(s) e disparado(s)`);
       } else {
-        toast.error("Falha na operação em lote");
+        const resumo = `${disparados} disparado(s), ${comAviso} aguardando, ${comErro} com falha — reveja`;
+        if (comErro > 0) toast.error(resumo);
+        else toast.warning(resumo);
       }
       setSelected(new Set());
       invalidate();

--- a/src/components/reposicao/cicloHoje/useCicloHoje.ts
+++ b/src/components/reposicao/cicloHoje/useCicloHoje.ts
@@ -7,6 +7,8 @@ import { supabase } from "@/integrations/supabase/client";
 import { logAudit } from "@/lib/reposicao";
 import { calcApprovalSuggestion } from "@/lib/reposicao/approvalSuggestion";
 import type { PedidoItem } from "@/types/reposicao";
+import { aprovarEDisparar } from "../pedidos/aprovar-disparar";
+import { EMPRESA } from "../pedidos/shared";
 import { ALL, type CicloFilters } from "./types";
 
 export interface AutoApprovalGroup {
@@ -91,42 +93,71 @@ export function useCicloHoje({ user, reviewMode, filteredItems, setFilters }: Us
     const ids = Array.from(selected);
     const nowIso = new Date().toISOString();
     const who = user?.email ?? user?.id ?? "cockpit";
+
+    if (kind === "approve") {
+      // APROVAR = DISPARAR NA HORA, por pedido SELECIONADO. Loop da trilha canônica
+      // (RPC + edge { empresa, pedido_id }) em vez de um invoke empresa-wide:
+      // o { empresa } sozinho varreria TODO aprovado_aguardando_disparo do ciclo —
+      // inclusive os auto-aprovados que devem esperar o cron (runAutoApprove). Aqui
+      // disparamos exatamente o lote que o operador marcou. Sequencial: não martelar
+      // a edge/Browserless em paralelo. Best-effort por item: um erro não aborta os demais.
+      let aprovados = 0;
+      let comErro = 0;
+      for (const id of ids) {
+        try {
+          const r = await aprovarEDisparar({ pedidoId: id, empresa: EMPRESA, usuario: who });
+          if (r.ok) aprovados += 1;
+          else comErro += 1;
+        } catch {
+          comErro += 1;
+        }
+      }
+      await logAudit({
+        userId: user?.id ?? null,
+        action: "Aprovação em lote",
+        result: comErro === 0 ? "Sucesso" : `Parcial: ${aprovados} ok, ${comErro} com erro`,
+        metadata: { ids, count: ids.length, aprovados, comErro },
+      });
+      if (comErro === 0) {
+        toast.success(`${aprovados} pedido(s) aprovado(s) e disparado(s)`);
+      } else if (aprovados > 0) {
+        toast.warning(`${aprovados} aprovado(s); ${comErro} com erro. Reveja os que falharam.`);
+      } else {
+        toast.error("Falha na operação em lote");
+      }
+      setSelected(new Set());
+      invalidate();
+      setBusy(false);
+      return;
+    }
+
+    // Rejeição em lote: UPDATE direto (não passa pela trilha de disparo).
     try {
-      const patch =
-        kind === "approve"
-          ? {
-              aprovado_em: nowIso,
-              aprovado_por: who,
-              status: "aprovado_aguardando_disparo" as const,
-            }
-          : {
-              cancelado_em: nowIso,
-              cancelado_por: who,
-              status: "cancelado" as const,
-              justificativa_cancelamento: "Rejeitado em lote no Cockpit",
-            };
       const { error } = await supabase
         .from("pedido_compra_sugerido")
-        .update(patch)
+        .update({
+          cancelado_em: nowIso,
+          cancelado_por: who,
+          status: "cancelado" as const,
+          justificativa_cancelamento: "Rejeitado em lote no Cockpit",
+        })
         .in("id", ids);
       if (error) throw error;
 
       await logAudit({
         userId: user?.id ?? null,
-        action: kind === "approve" ? "Aprovação em lote" : "Rejeição em lote",
+        action: "Rejeição em lote",
         result: "Sucesso",
         metadata: { ids, count: ids.length },
       });
-      toast.success(
-        `${ids.length} pedido(s) ${kind === "approve" ? "aprovado(s)" : "rejeitado(s)"}`,
-      );
+      toast.success(`${ids.length} pedido(s) rejeitado(s)`);
       setSelected(new Set());
       invalidate();
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       await logAudit({
         userId: user?.id ?? null,
-        action: kind === "approve" ? "Aprovação em lote" : "Rejeição em lote",
+        action: "Rejeição em lote",
         result: `Erro: ${msg}`,
         metadata: { ids },
       });

--- a/src/components/reposicao/pedidos/__tests__/aprovar-disparar.test.ts
+++ b/src/components/reposicao/pedidos/__tests__/aprovar-disparar.test.ts
@@ -93,6 +93,21 @@ describe('aprovarEDisparar', () => {
     expect(r.mensagem.length).toBeGreaterThan(0);
   });
 
+  it('falha SÍNCRONA do disparo (edge 200 com { disparados:0, falhas:1 }): aprovado, mas { ok:true, tipo:"error" }', async () => {
+    // A edge respondeu 200 (sem error de transporte), mas o Omie rejeitou o disparo
+    // (ex.: guard nValUnit<=0/nQtde<=0). O pedido aprovou; o disparo falhou de verdade.
+    // O lote apura por `tipo` justamente p/ não contar isto como sucesso.
+    mockedRpc.mockResolvedValue({ data: null, error: null } as never);
+    mockedInvoke.mockResolvedValue({ data: { disparados: 0, falhas: 1 }, error: null } as never);
+
+    const r = await aprovarEDisparar(params);
+
+    expect(r.ok).toBe(true);
+    expect(r.tipo).toBe('error');
+    expect(r.mensagem).toContain('#130');
+    expect(r.mensagem).toContain('falha');
+  });
+
   it('disparo retorna portal Sayerlack em background → success "iniciado"', async () => {
     mockedRpc.mockResolvedValue({ data: null, error: null } as never);
     mockedInvoke.mockResolvedValue({ data: { aguardando_portal_sayerlack: 1 }, error: null } as never);

--- a/src/components/reposicao/pedidos/__tests__/aprovar-disparar.test.ts
+++ b/src/components/reposicao/pedidos/__tests__/aprovar-disparar.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: { rpc: vi.fn(), functions: { invoke: vi.fn() } },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+import { supabase } from '@/integrations/supabase/client';
+import { aprovarEDisparar } from '../aprovar-disparar';
+
+const mockedRpc = vi.mocked(supabase.rpc);
+const mockedInvoke = vi.mocked(supabase.functions.invoke);
+
+const params = { pedidoId: 130, empresa: 'OBEN', usuario: 'lucas@x.com' };
+
+beforeEach(() => {
+  mockedRpc.mockReset();
+  mockedInvoke.mockReset();
+});
+
+describe('aprovarEDisparar', () => {
+  it('happy path: RPC ok → invoca a edge → retorna o resultado interpretado (Omie)', async () => {
+    mockedRpc.mockResolvedValue({ data: { ok: true }, error: null } as never);
+    mockedInvoke.mockResolvedValue({ data: { disparados: 1 }, error: null } as never);
+
+    const r = await aprovarEDisparar(params);
+
+    // chamou o RPC com os args canônicos
+    expect(mockedRpc).toHaveBeenCalledWith('aprovar_pedido_sugerido', {
+      p_pedido_id: 130,
+      p_usuario: 'lucas@x.com',
+    });
+    // chamou a edge com empresa + pedido_id
+    expect(mockedInvoke).toHaveBeenCalledWith('disparar-pedidos-aprovados', {
+      body: { empresa: 'OBEN', pedido_id: 130 },
+    });
+    // resultado interpretado (disparados>0 = Omie direto)
+    expect(r.ok).toBe(true);
+    expect(r.tipo).toBe('success');
+    expect(r.mensagem).toContain('#130');
+    expect(r.mensagem).toContain('Omie');
+  });
+
+  it('ordem: RPC é chamado ANTES da edge', async () => {
+    const order: string[] = [];
+    mockedRpc.mockImplementation((() => {
+      order.push('rpc');
+      return Promise.resolve({ data: null, error: null });
+    }) as never);
+    mockedInvoke.mockImplementation((() => {
+      order.push('edge');
+      return Promise.resolve({ data: { disparados: 1 }, error: null });
+    }) as never);
+
+    await aprovarEDisparar(params);
+    expect(order).toEqual(['rpc', 'edge']);
+  });
+
+  it('erro de transporte do RPC (PostgREST error) → curto-circuito: NÃO invoca a edge, retorna erro', async () => {
+    mockedRpc.mockResolvedValue({ data: null, error: { message: 'rls negou' } } as never);
+
+    const r = await aprovarEDisparar(params);
+
+    expect(mockedInvoke).not.toHaveBeenCalled();
+    expect(r.ok).toBe(false);
+    expect(r.tipo).toBe('error');
+    expect(r.mensagem).toContain('rls negou');
+  });
+
+  it('erro jsonb do RPC ({ error }) → curto-circuito: NÃO invoca a edge, retorna erro', async () => {
+    mockedRpc.mockResolvedValue({ data: { error: 'pedido não está pendente' }, error: null } as never);
+
+    const r = await aprovarEDisparar(params);
+
+    expect(mockedInvoke).not.toHaveBeenCalled();
+    expect(r.ok).toBe(false);
+    expect(r.tipo).toBe('error');
+    expect(r.mensagem).toContain('pedido não está pendente');
+  });
+
+  it('falha do disparo (edge error): best-effort — aprovado, mas avisa (warning), NÃO lança', async () => {
+    mockedRpc.mockResolvedValue({ data: null, error: null } as never);
+    mockedInvoke.mockResolvedValue({ data: null, error: { message: 'edge 500' } } as never);
+
+    const r = await aprovarEDisparar(params);
+
+    // a aprovação valeu (RPC ok); o disparo é a rede de segurança do cron
+    expect(r.ok).toBe(true);
+    expect(r.tipo).toBe('warning');
+    expect(r.mensagem.length).toBeGreaterThan(0);
+  });
+
+  it('disparo retorna portal Sayerlack em background → success "iniciado"', async () => {
+    mockedRpc.mockResolvedValue({ data: null, error: null } as never);
+    mockedInvoke.mockResolvedValue({ data: { aguardando_portal_sayerlack: 1 }, error: null } as never);
+
+    const r = await aprovarEDisparar(params);
+    expect(r.ok).toBe(true);
+    expect(r.tipo).toBe('success');
+    expect(r.mensagem).toContain('iniciado');
+  });
+});

--- a/src/components/reposicao/pedidos/aprovar-disparar.ts
+++ b/src/components/reposicao/pedidos/aprovar-disparar.ts
@@ -74,6 +74,11 @@ export async function aprovarEDisparar(
     });
     if (de) throw de;
     const feedback = interpretarRespostaDisparo(dd as RespostaDisparo, pedidoId);
+    // feedback.tone === 'info' ("nada a disparar") é DE PROPÓSITO um desfecho ok:true:
+    // a aprovação valeu e re-disparar algo já enviado é idempotente (no-op seguro).
+    // Só feedback.tone === 'error' (disparados:0 + falhas>0, ex.: rejeição do Omie) é
+    // falha síncrona do disparo — propagada como { ok:true, tipo:'error' } (aprovado, mas o
+    // envio falhou; o lote conta isso como erro, não como sucesso).
     return { ok: true, tipo: feedback.tone, mensagem: feedback.message };
   } catch (e) {
     logger.error('Pedido aprovado, mas o disparo imediato falhou (cron de corte assume)', { error: e, pedidoId });

--- a/src/components/reposicao/pedidos/aprovar-disparar.ts
+++ b/src/components/reposicao/pedidos/aprovar-disparar.ts
@@ -1,0 +1,87 @@
+// Trilha de aprovação canônica da Reposição: APROVAR = DISPARAR NA HORA.
+//
+// Único ponto que encapsula a sequência "aprovar e disparar" — antes inline no
+// useDetalhesModal.aprovarMutation e divergente nos caminhos inline (PedidoRow do
+// ciclo) e em lote (useCicloHoje), que só faziam UPDATE status='aprovado_aguardando_disparo'
+// e ESPERAVAM o cron de corte (o operador achava que tinha disparado; o pedido ficava parado).
+//
+// Sequência:
+//   1. RPC aprovar_pedido_sugerido (flip de status + carimbo de quem aprovou).
+//   2. Se a aprovação falha (erro de transporte OU { error } no jsonb de retorno) → curto-circuito,
+//      NÃO dispara, retorna erro.
+//   3. Invoca a edge disparar-pedidos-aprovados { empresa, pedido_id }.
+//      Best-effort: a falha do disparo NÃO reverte a aprovação — o cron de corte (rede de
+//      segurança) pega depois e o motor de retry */15 cobre falha transitória do portal.
+//      Aprovar e disparar são estados distintos (codex).
+//   4. Traduz a resposta da edge com interpretarRespostaDisparo (helper puro existente).
+//
+// Idempotência do disparo já é tratada upstream (cCodIntPed no Omie + claim do portal):
+// re-disparar um pedido já disparado é seguro.
+import { supabase as defaultClient } from '@/integrations/supabase/client';
+import { logger } from '@/lib/logger';
+import { interpretarRespostaDisparo, type RespostaDisparo } from './shared';
+
+export interface AprovarDispararParams {
+  pedidoId: number;
+  empresa: string;
+  usuario: string;
+}
+
+export interface AprovarDispararResult {
+  ok: boolean;
+  tipo: 'success' | 'info' | 'warning' | 'error';
+  mensagem: string;
+}
+
+// Cliente mínimo injetável (testabilidade). O default é o supabase real.
+type AprovarDispararClient = Pick<typeof defaultClient, 'rpc' | 'functions'>;
+
+// Extrai um erro de negócio do jsonb retornado pelo RPC (Returns: Json).
+// O RPC pode sinalizar falha de regra de negócio devolvendo { error: '...' } no payload,
+// além do erro de transporte do PostgREST.
+function erroDoJsonb(data: unknown): string | null {
+  if (data && typeof data === 'object' && 'error' in data) {
+    const e = (data as { error?: unknown }).error;
+    if (e == null) return null;
+    return typeof e === 'string' ? e : JSON.stringify(e);
+  }
+  return null;
+}
+
+export async function aprovarEDisparar(
+  { pedidoId, empresa, usuario }: AprovarDispararParams,
+  client: AprovarDispararClient = defaultClient,
+): Promise<AprovarDispararResult> {
+  // 1. Aprovação (flip de status). Falha aqui = não dispara.
+  const { data: rpcData, error: rpcError } = await client.rpc('aprovar_pedido_sugerido', {
+    p_pedido_id: pedidoId,
+    p_usuario: usuario,
+  });
+  if (rpcError) {
+    logger.error('Erro ao aprovar pedido (RPC)', { error: rpcError, pedidoId });
+    return { ok: false, tipo: 'error', mensagem: `Erro ao aprovar: ${rpcError.message}` };
+  }
+  const erroNegocio = erroDoJsonb(rpcData);
+  if (erroNegocio) {
+    logger.error('Aprovação recusada pela regra de negócio (jsonb error)', { erro: erroNegocio, pedidoId });
+    return { ok: false, tipo: 'error', mensagem: `Erro ao aprovar: ${erroNegocio}` };
+  }
+
+  // 2. APROVAR = DISPARAR NA HORA. Best-effort: falha do disparo não reverte a aprovação.
+  try {
+    const { data: dd, error: de } = await client.functions.invoke('disparar-pedidos-aprovados', {
+      body: { empresa, pedido_id: pedidoId },
+    });
+    if (de) throw de;
+    const feedback = interpretarRespostaDisparo(dd as RespostaDisparo, pedidoId);
+    return { ok: true, tipo: feedback.tone, mensagem: feedback.message };
+  } catch (e) {
+    logger.error('Pedido aprovado, mas o disparo imediato falhou (cron de corte assume)', { error: e, pedidoId });
+    return {
+      ok: true,
+      tipo: 'warning',
+      mensagem:
+        'Pedido aprovado. O envio automático não saiu agora — será reprocessado pela rede de segurança (ou use "Disparar").',
+    };
+  }
+}

--- a/src/components/reposicao/pedidos/shared.ts
+++ b/src/components/reposicao/pedidos/shared.ts
@@ -14,6 +14,8 @@ export const statusMeta: Record<string, { label: string; variant: 'default' | 's
   aprovado_aguardando_disparo: { label: 'Aprovado', variant: 'secondary', className: 'bg-status-info/15 text-status-info border-status-info/30' },
   bloqueado_guardrail: { label: 'Bloqueado', variant: 'destructive' },
   disparado: { label: 'Disparado', variant: 'secondary', className: 'bg-status-success/15 text-status-success border-status-success/30' },
+  disparado_simulado: { label: 'Disparo simulado', variant: 'secondary', className: 'bg-muted text-muted-foreground border-border' },
+  falha_envio: { label: 'Falha no envio', variant: 'destructive' },
   cancelado: { label: 'Cancelado', variant: 'outline' },
   cancelado_humano: { label: 'Cancelado (vazio)', variant: 'outline' },
   expirado_sem_aprovacao: { label: 'Expirado sem aprovação', variant: 'secondary', className: 'bg-muted text-muted-foreground border-border' },

--- a/src/components/reposicao/pedidos/useDetalhesModal.ts
+++ b/src/components/reposicao/pedidos/useDetalhesModal.ts
@@ -7,7 +7,7 @@ import { useAuth } from '@/contexts/AuthContext';
 import { toast } from 'sonner';
 import { logger } from '@/lib/logger';
 import { PedidoSugerido, PedidoItem, CondicaoPagamento } from './types';
-import { interpretarRespostaDisparo, type RespostaDisparo } from './shared';
+import { aprovarEDisparar } from './aprovar-disparar';
 import { montarUpdateItem, podeEditarPrecoPedido, precoEditValido } from './preco-edit';
 
 export type Linha = PedidoItem & { _qtd: number; _preco: number; _valor: number };
@@ -192,38 +192,20 @@ export function useDetalhesModal({ pedido, open, onOpenChange, onApproved }: Use
       if (condicaoMudou) {
         await salvarCondicaoMutation.mutateAsync();
       }
-      const { error } = await supabase.rpc('aprovar_pedido_sugerido', {
-        p_pedido_id: pedido.id,
-        p_usuario: user?.email ?? 'sistema',
+      // Trilha canônica: APROVAR = DISPARAR NA HORA (RPC + edge + feedback).
+      return aprovarEDisparar({
+        pedidoId: pedido.id,
+        empresa: pedido.empresa,
+        usuario: user?.email ?? 'sistema',
       });
-      if (error) throw error; // falha de aprovação → onError (correto)
-
-      // APROVAR = DISPARAR NA HORA. Em vez de esperar o cron de corte, dispara já.
-      // Best-effort: a falha do disparo NÃO reverte a aprovação — o cron de corte
-      // (rede de segurança) pega depois, e o motor de retry */15 cobre falha
-      // transitória do portal. Aprovar e disparar são estados distintos (codex).
-      const pedidoId = pedido.id;
-      try {
-        const { data: dd, error: de } = await supabase.functions.invoke('disparar-pedidos-aprovados', {
-          body: { empresa: pedido.empresa, pedido_id: pedidoId },
-        });
-        if (de) throw de;
-        return { disparoOk: true as const, feedback: interpretarRespostaDisparo(dd as RespostaDisparo, pedidoId) };
-      } catch (e) {
-        logger.error('Pedido aprovado, mas o disparo imediato falhou (cron de corte assume)', { error: e, pedidoId });
-        return { disparoOk: false as const, feedback: null };
-      }
     },
     onSuccess: (result) => {
       if (result) {
-        if (result.disparoOk && result.feedback) {
-          const { tone, message } = result.feedback;
-          if (tone === 'error') toast.error(message);
-          else if (tone === 'info') toast.info(message);
-          else toast.success(message);
-        } else {
-          toast.warning('Pedido aprovado. O envio automático não saiu agora — será reprocessado pela rede de segurança (ou use "Disparar").');
-        }
+        const { ok, tipo, mensagem } = result;
+        if (!ok || tipo === 'error') toast.error(mensagem);
+        else if (tipo === 'warning') toast.warning(mensagem);
+        else if (tipo === 'info') toast.info(mensagem);
+        else toast.success(mensagem);
       }
       queryClient.invalidateQueries({ queryKey: ['pedidos-ciclo'] });
       onApproved();


### PR DESCRIPTION
## Fase 3 · sub-PR 3a (tela única de pedidos de compra)

Primeiro sub-PR da tela única. Unifica os **3 caminhos MANUAIS de "Aprovar"** de `pedido_compra_sugerido` (Reposição/OBEN) por um helper compartilhado **`aprovarEDisparar`** (RPC `aprovar_pedido_sugerido` → edge `disparar-pedidos-aprovados` → `interpretarRespostaDisparo`). Conserta o §1.2: hoje o **✓ inline** e o **lote** fazem `UPDATE` direto e **NÃO disparam** (ficam parados até o cron) → o operador acha que disparou. Agora **aprovar = dispara** consistente.

### O que muda
- **Helper** `src/components/reposicao/pedidos/aprovar-disparar.ts` (novo, com client injetável + 7 testes TDD). Short-circuita em erro de aprovação (transport **e** `{error}` jsonb da RPC) sem disparar; disparo best-effort.
- **✓ inline** (`cicloHoje/PedidoRow.tsx`): edição de `num_skus` ANTES da RPC, depois o helper; `logAudit` preservado.
- **lote** (`cicloHoje/useCicloHoje.ts`): loop por pedido selecionado (não varre os autônomos); o resumo distingue **disparado × aguardando × com falha** (não conta disparo-falho como sucesso — money-path).
- **modal**: delega o core ao helper (pré-passos do modal preservados).
- **Labels**: `falha_envio` ("Falha no envio") + `disparado_simulado` ("Disparo simulado").

### Fora de escopo (deliberado)
- `runAutoApprove` (autônomo) **intocado** — aprova só, o cron dispara (mantém janela de revisão).
- **SEM gate de condição** (feature dropada — à vista universal).
- Idempotência já vive upstream (#628: Omie `cCodIntPed` + claim do portal).

### Revisão
Subagent-driven: spec-review ✅ + code-quality-review ✅ (1 fix Important do resumo do lote aplicado). 2460 testes verdes, typecheck strict limpo, lint 0 erros.

⚠️ A reconciliação cosmética ("já cadastrado"→disparado) depende do smoke do #628; o **dup-prevention** (money-path) já está vivo, independente do smoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)