### PR TITLE
feat(reposição): conciliação inline + guard anti-PO-duplo — Fase 3 · sub-PR 3b

### DIFF
--- a/src/components/reposicao/pedidos/PortalDrawer.tsx
+++ b/src/components/reposicao/pedidos/PortalDrawer.tsx
@@ -5,6 +5,8 @@ import { useAuth } from '@/contexts/AuthContext';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle, SheetFooter } from '@/components/ui/sheet';
 import {
   AlertDialog,
@@ -16,12 +18,22 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
 import { toast } from 'sonner';
 import { format, formatDistanceToNow } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
-import { AlertTriangle, Loader2, RotateCw } from 'lucide-react';
+import { AlertTriangle, CheckCircle2, Loader2, RotateCw } from 'lucide-react';
 import { PedidoSugerido, StatusEnvioPortal } from './types';
-import { portalStatusMeta } from './shared';
+import { portalStatusMeta, decidirAcaoPortal } from './shared';
+
+const PROTOCOLO_RE = /^\d{3,12}$/;
 
 export function PortalDrawer({
   pedido,
@@ -35,6 +47,12 @@ export function PortalDrawer({
   const queryClient = useQueryClient();
   const { isAdmin } = useAuth();
   const [confirmReenvio, setConfirmReenvio] = useState(false);
+  const [conciliarOpen, setConciliarOpen] = useState(false);
+  const [conciliarProtocolo, setConciliarProtocolo] = useState('');
+
+  const invalidate = () => {
+    queryClient.invalidateQueries({ queryKey: ['pedidos-ciclo'] });
+  };
 
   const reenviarMutation = useMutation({
     mutationFn: async () => {
@@ -52,15 +70,61 @@ export function PortalDrawer({
     },
     onSuccess: () => {
       toast.success('Pedido marcado para reenvio. O cron / disparo manual fará o envio.');
-      queryClient.invalidateQueries({ queryKey: ['pedidos-ciclo'] });
+      invalidate();
       setConfirmReenvio(false);
       onOpenChange(false);
     },
     onError: (e: Error) => toast.error(`Erro ao marcar reenvio: ${e.message}`),
   });
 
+  // Conciliação inline: reusa a edge `conciliar-pedido-portal` (mesma lógica do
+  // PortalDetailDrawer da tela /admin/portal-sayerlack, que será aposentada no 3c).
+  // A edge marca sucesso_portal + protocolo e dispara o Omie — com guard anti-PO-duplo
+  // (não recria o PO se o pedido já tem omie_pedido_compra_id).
+  const conciliarMutation = useMutation({
+    mutationFn: async () => {
+      if (!pedido) return null;
+      const protocolo = conciliarProtocolo.trim();
+      if (!PROTOCOLO_RE.test(protocolo)) {
+        throw new Error('Protocolo deve ser numérico com 3 a 12 dígitos.');
+      }
+      const { data, error } = await supabase.functions.invoke('conciliar-pedido-portal', {
+        body: { pedido_id: pedido.id, protocolo },
+      });
+      if (error) throw error;
+      return { data, protocolo };
+    },
+    onSuccess: (res) => {
+      if (!res || !pedido) return;
+      const { data, protocolo } = res;
+      const omie = data?.omie as
+        | { ok?: boolean; skipped?: boolean; httpStatus?: number }
+        | undefined;
+      if (data?.already) {
+        toast.success(`Pedido #${pedido.id} já estava conciliado com protocolo ${protocolo}.`);
+      } else if (omie?.skipped) {
+        toast.success(
+          `Pedido #${pedido.id} conciliado com protocolo ${protocolo}. O pedido de compra já existia no Omie — não foi recriado.`,
+        );
+      } else if (omie?.ok === false) {
+        toast.warning(
+          `Pedido #${pedido.id} marcado como enviado, mas o disparo do Omie devolveu HTTP ${omie?.httpStatus}. Confira no Omie.`,
+        );
+      } else {
+        toast.success(`Pedido #${pedido.id} conciliado com protocolo ${protocolo}. Omie disparado.`);
+      }
+      setConciliarOpen(false);
+      setConciliarProtocolo('');
+      invalidate();
+      onOpenChange(false);
+    },
+    onError: (e: Error) => toast.error(`Falha ao conciliar: ${e.message}`),
+  });
+
   if (!pedido) return null;
   const status = (pedido.status_envio_portal ?? 'nao_aplicavel') as StatusEnvioPortal;
+  const acao = decidirAcaoPortal(status);
+  const protocoloValido = PROTOCOLO_RE.test(conciliarProtocolo.trim());
   const tentativas = pedido.portal_tentativas ?? 0;
   const tentativasColor =
     tentativas <= 1 ? 'text-status-success' : tentativas === 2 ? 'text-status-warning' : 'text-destructive';
@@ -109,6 +173,30 @@ export function PortalDrawer({
             </div>
           </div>
 
+          {/* Conciliação: instrução + aviso de risco quando ambíguo. */}
+          {acao.kind === 'conciliar' && (
+            <Alert variant={acao.warn ? 'destructive' : 'default'}>
+              {acao.warn ? <AlertTriangle className="h-4 w-4" /> : <CheckCircle2 className="h-4 w-4" />}
+              <AlertTitle>
+                {acao.warn ? 'Confira no portal ANTES de conciliar' : 'Requer conciliação manual'}
+              </AlertTitle>
+              <AlertDescription>
+                {acao.warn ? (
+                  <>
+                    O resultado do envio ficou <strong>ambíguo</strong> — o pedido <strong>pode já existir</strong> no
+                    portal Sayerlack (risco de duplicar). Confira no portal ANTES de conciliar. Se ele já está lá,
+                    copie o número e concilie abaixo. Se NÃO está, NÃO concilie — use "Forçar reenvio".
+                  </>
+                ) : (
+                  <>
+                    O portal aceitou o pedido mas não devolveu o número automaticamente. Confira no portal Sayerlack,
+                    copie o número e concilie abaixo — isso registra o protocolo e o pedido no Omie.
+                  </>
+                )}
+              </AlertDescription>
+            </Alert>
+          )}
+
           {pedido.portal_screenshot_url && (
             <div>
               <div className="text-muted-foreground text-xs mb-1">Screenshot do portal</div>
@@ -142,7 +230,22 @@ export function PortalDrawer({
 
         <SheetFooter className="gap-2 flex-col sm:flex-row">
           <Button variant="outline" onClick={() => onOpenChange(false)}>Fechar</Button>
-          {isAdmin && status !== 'nao_aplicavel' && (
+
+          {/* Estado de conciliação → Conciliar (NUNCA reenvio cego: risco de PO duplo). */}
+          {acao.kind === 'conciliar' && (
+            <Button
+              variant="default"
+              className="bg-status-warning-bold hover:bg-status-warning-bold/90"
+              onClick={() => setConciliarOpen(true)}
+              disabled={conciliarMutation.isPending}
+            >
+              <CheckCircle2 className="w-4 h-4 mr-1" />
+              Conciliar manualmente
+            </Button>
+          )}
+
+          {/* Erro genuíno sem PO criado → reenvio é seguro (somente admin). */}
+          {acao.kind === 'reenviar' && isAdmin && (
             <Button
               variant="secondary"
               onClick={() => setConfirmReenvio(true)}
@@ -153,6 +256,64 @@ export function PortalDrawer({
             </Button>
           )}
         </SheetFooter>
+
+        {/* Dialog de conciliação inline */}
+        <Dialog
+          open={conciliarOpen}
+          onOpenChange={(o) => {
+            setConciliarOpen(o);
+            if (!o) setConciliarProtocolo('');
+          }}
+        >
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Conciliar pedido #{pedido.id}</DialogTitle>
+              <DialogDescription>
+                Informe o número do pedido como aparece no portal Sayerlack ("Pedido <strong>NNNNN</strong> criado com
+                sucesso"). Após confirmar, o sistema marca como enviado e registra no Omie (sem recriar o pedido se ele
+                já existir lá).
+              </DialogDescription>
+            </DialogHeader>
+            {acao.kind === 'conciliar' && acao.warn && (
+              <Alert variant="destructive">
+                <AlertTriangle className="h-4 w-4" />
+                <AlertDescription>
+                  Confira no portal Sayerlack ANTES de conciliar — o pedido pode já existir lá (risco de duplicar).
+                </AlertDescription>
+              </Alert>
+            )}
+            <div className="space-y-2">
+              <Label htmlFor="conciliar-protocolo">Número do protocolo</Label>
+              <Input
+                id="conciliar-protocolo"
+                inputMode="numeric"
+                pattern="\d*"
+                placeholder="Ex.: 123456"
+                value={conciliarProtocolo}
+                onChange={(e) => setConciliarProtocolo(e.target.value.replace(/\D/g, ''))}
+                disabled={conciliarMutation.isPending}
+                autoFocus
+              />
+              <p className="text-xs text-muted-foreground">Apenas dígitos, entre 3 e 12 caracteres.</p>
+            </div>
+            <DialogFooter>
+              <Button
+                variant="outline"
+                onClick={() => setConciliarOpen(false)}
+                disabled={conciliarMutation.isPending}
+              >
+                Cancelar
+              </Button>
+              <Button
+                onClick={() => conciliarMutation.mutate()}
+                disabled={conciliarMutation.isPending || !protocoloValido}
+              >
+                {conciliarMutation.isPending && <Loader2 className="w-4 h-4 mr-1 animate-spin" />}
+                Confirmar e registrar no Omie
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
 
         <AlertDialog open={confirmReenvio} onOpenChange={setConfirmReenvio}>
           <AlertDialogContent>

--- a/src/components/reposicao/pedidos/__tests__/conciliacao-acao.test.ts
+++ b/src/components/reposicao/pedidos/__tests__/conciliacao-acao.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { decidirAcaoPortal } from '../shared';
+
+describe('decidirAcaoPortal (Fase 3 · 3b)', () => {
+  it('aceito_portal_sem_protocolo → conciliar SEM aviso (PO quase-certamente já existe)', () => {
+    const a = decidirAcaoPortal('aceito_portal_sem_protocolo');
+    expect(a.kind).toBe('conciliar');
+    expect(a).toEqual({ kind: 'conciliar', warn: false });
+  });
+
+  it('indeterminado_requer_conciliacao → conciliar COM aviso (risco de duplicar)', () => {
+    const a = decidirAcaoPortal('indeterminado_requer_conciliacao');
+    expect(a.kind).toBe('conciliar');
+    expect(a).toEqual({ kind: 'conciliar', warn: true });
+  });
+
+  it('erros genuínos (sem PO) → reenviar é seguro', () => {
+    expect(decidirAcaoPortal('erro_retentavel').kind).toBe('reenviar');
+    expect(decidirAcaoPortal('falha_envio_portal').kind).toBe('reenviar');
+    expect(decidirAcaoPortal('erro_nao_retentavel').kind).toBe('reenviar');
+  });
+
+  it('sucesso / em-trânsito / nao_aplicavel → nenhuma ação destrutiva (não oferecer reset = anti-duplicação)', () => {
+    expect(decidirAcaoPortal('sucesso_portal').kind).toBe('nenhuma');
+    expect(decidirAcaoPortal('enviado_portal').kind).toBe('nenhuma');
+    expect(decidirAcaoPortal('enviando_portal').kind).toBe('nenhuma');
+    expect(decidirAcaoPortal('pendente_envio_portal').kind).toBe('nenhuma');
+    expect(decidirAcaoPortal('nao_aplicavel').kind).toBe('nenhuma');
+  });
+
+  it('null/undefined → trata como nao_aplicavel (nenhuma ação)', () => {
+    expect(decidirAcaoPortal(null).kind).toBe('nenhuma');
+    expect(decidirAcaoPortal(undefined).kind).toBe('nenhuma');
+  });
+
+  it('um estado conciliável NUNCA cai em reenviar (não pode resetar conciliação = risco PO duplo)', () => {
+    expect(decidirAcaoPortal('aceito_portal_sem_protocolo').kind).not.toBe('reenviar');
+    expect(decidirAcaoPortal('indeterminado_requer_conciliacao').kind).not.toBe('reenviar');
+  });
+});

--- a/src/components/reposicao/pedidos/shared.ts
+++ b/src/components/reposicao/pedidos/shared.ts
@@ -66,6 +66,52 @@ export function interpretarRespostaDisparo(
   return { tone: 'info', message: `Pedido #${pedidoId}: nada a disparar` };
 }
 
+/* ─── Conciliação inline (Fase 3 · 3b) ─── */
+//
+// O pedido cai num estado de conciliação quando o disparo ao portal Sayerlack termina
+// AMBÍGUO. Dois estados, com risco DIFERENTE de PO duplicado no fornecedor:
+//
+//  - aceito_portal_sem_protocolo → o portal aceitou mas não devolveu o número.
+//    O pedido quase-certamente JÁ EXISTE no fornecedor; conciliar (só registrar o
+//    protocolo) é de baixo risco.
+//  - indeterminado_requer_conciliacao → AMBÍGUO; o pedido pode ou NÃO existir no
+//    portal. Conciliar às cegas pode duplicar → exige conferir no portal ANTES.
+//
+// Estados de erro genuíno (no fluxo portal-first o portal falhou ANTES de obter
+// protocolo, então NÃO há PO no fornecedor) → reenviar é seguro (retry de verdade).
+// Estados de sucesso / em-trânsito → reenviar duplicaria; não oferecer reset.
+
+export type AcaoPortal =
+  | { kind: 'conciliar'; warn: boolean } // warn=true → avisar risco de duplicar antes de conciliar
+  | { kind: 'reenviar' } // erro genuíno sem PO criado → retry seguro
+  | { kind: 'nenhuma' }; // sucesso / em-trânsito / nao_aplicavel → nenhuma ação destrutiva
+
+const STATUS_CONCILIAVEIS_FRONT: ReadonlySet<StatusEnvioPortal> = new Set<StatusEnvioPortal>([
+  'aceito_portal_sem_protocolo',
+  'indeterminado_requer_conciliacao',
+]);
+
+// Erros genuínos onde (no fluxo portal-first) NÃO há PO no fornecedor → reset seguro.
+const STATUS_REENVIO_SEGURO_FRONT: ReadonlySet<StatusEnvioPortal> = new Set<StatusEnvioPortal>([
+  'erro_retentavel',
+  'falha_envio_portal',
+  'erro_nao_retentavel',
+]);
+
+// Decide a ação disponível no PortalDrawer p/ um status de envio ao portal.
+// indeterminado_requer_conciliacao → conciliar com AVISO (risco de duplicar).
+// aceito_portal_sem_protocolo → conciliar sem aviso (PO quase-certamente já existe).
+export function decidirAcaoPortal(status: StatusEnvioPortal | null | undefined): AcaoPortal {
+  const s = (status ?? 'nao_aplicavel') as StatusEnvioPortal;
+  if (STATUS_CONCILIAVEIS_FRONT.has(s)) {
+    return { kind: 'conciliar', warn: s === 'indeterminado_requer_conciliacao' };
+  }
+  if (STATUS_REENVIO_SEGURO_FRONT.has(s)) {
+    return { kind: 'reenviar' };
+  }
+  return { kind: 'nenhuma' };
+}
+
 /* ─── Portal B2B status meta ─── */
 export const portalStatusMeta: Record<StatusEnvioPortal, { label: string; className: string }> = {
   nao_aplicavel: { label: '—', className: 'bg-muted text-muted-foreground border-border' },

--- a/src/lib/reposicao/__tests__/omie-disparo-helpers.test.ts
+++ b/src/lib/reposicao/__tests__/omie-disparo-helpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { isOmiePedidoJaCadastrado, extrairPedidoOmie } from '../omie-disparo-helpers';
+import { isOmiePedidoJaCadastrado, extrairPedidoOmie, deveCriarPedidoOmie } from '../omie-disparo-helpers';
 
 describe('isOmiePedidoJaCadastrado', () => {
   it('detecta "já cadastrado" em pt-BR (com acento)', () => {
@@ -54,5 +54,25 @@ describe('extrairPedidoOmie', () => {
     expect(extrairPedidoOmie({ foo: 'bar' })).toBeNull();
     expect(extrairPedidoOmie(null)).toBeNull();
     expect(extrairPedidoOmie(undefined)).toBeNull();
+  });
+});
+
+describe('deveCriarPedidoOmie (guard anti-PO-duplicado · 3b)', () => {
+  it('PO já existe (id real) → NÃO recriar', () => {
+    expect(deveCriarPedidoOmie('12345')).toBe(false);
+    expect(deveCriarPedidoOmie(12345)).toBe(false);
+    expect(deveCriarPedidoOmie('AFI-130')).toBe(false);
+  });
+  it('sem PO (null/undefined) → criar (comportamento de hoje)', () => {
+    expect(deveCriarPedidoOmie(null)).toBe(true);
+    expect(deveCriarPedidoOmie(undefined)).toBe(true);
+  });
+  it('string vazia / whitespace (o disparo grava "" sem id) → criar', () => {
+    expect(deveCriarPedidoOmie('')).toBe(true);
+    expect(deveCriarPedidoOmie('   ')).toBe(true);
+  });
+  it('"0" / 0 representam vazio → criar (não bloqueia criação legítima)', () => {
+    expect(deveCriarPedidoOmie('0')).toBe(true);
+    expect(deveCriarPedidoOmie(0)).toBe(true);
   });
 });

--- a/src/lib/reposicao/omie-disparo-helpers.ts
+++ b/src/lib/reposicao/omie-disparo-helpers.ts
@@ -32,3 +32,27 @@ export function extrairPedidoOmie(
   const numeroRaw = cab?.cNumero ?? r.cNumero;
   return { id: String(idRaw), numero: numeroRaw != null ? String(numeroRaw) : '' };
 }
+
+/**
+ * Guard anti-PO-duplicado da conciliação manual (Fase 3 · 3b, §4.4).
+ *
+ * O pedido JÁ tem um pedido de compra criado no Omie quando `omie_pedido_compra_id`
+ * está preenchido (qualquer string não-vazia após trim). Nesse caso a conciliação
+ * NÃO deve recriar o PO no Omie — só registrar o protocolo. O dedup por cCodIntPed
+ * do próprio Omie é um backstop, mas este guard evita a chamada por completo.
+ *
+ * Retorna `true` quando o Omie AINDA NÃO tem o PO → seguro disparar a criação.
+ * Conservador: NULL/''/whitespace/0 numérico-como-string == "não tem" → cria
+ * (igual ao comportamento de hoje); só pula quando há um id real.
+ */
+export function deveCriarPedidoOmie(
+  omiePedidoCompraId: string | number | null | undefined,
+): boolean {
+  if (omiePedidoCompraId == null) return true;
+  const s = String(omiePedidoCompraId).trim();
+  if (s === '') return true;
+  // O disparo grava "" quando o Omie não devolveu id; trate strings que representam
+  // "vazio/zero" como ausência de PO (não bloqueia uma criação legítima).
+  if (s === '0') return true;
+  return false;
+}

--- a/supabase/functions/conciliar-pedido-portal/index.ts
+++ b/supabase/functions/conciliar-pedido-portal/index.ts
@@ -29,6 +29,21 @@ interface PedidoCompraSugeridoRow {
   status: string | null;
   status_envio_portal: string | null;
   portal_protocolo: string | null;
+  omie_pedido_compra_id: string | number | null;
+}
+
+// ⚠️ ESPELHADO VERBATIM de src/lib/reposicao/omie-disparo-helpers.ts (Deno não importa de @/).
+// Guard anti-PO-duplicado da conciliação manual (Fase 3 · 3b, §4.4): só dispara a
+// criação do PO no Omie quando o pedido AINDA NÃO tem omie_pedido_compra_id. NULL/''/
+// whitespace/'0' contam como "não tem" → cria (comportamento de hoje). Mudou aqui? Copie lá.
+function deveCriarPedidoOmie(
+  omiePedidoCompraId: string | number | null | undefined,
+): boolean {
+  if (omiePedidoCompraId == null) return true;
+  const s = String(omiePedidoCompraId).trim();
+  if (s === "") return true;
+  if (s === "0") return true;
+  return false;
 }
 
 async function dispararOmie(empresa: string, pedidoId: number) {
@@ -85,7 +100,7 @@ Deno.serve(async (req: Request) => {
   // 1. Buscar pedido e validar estado.
   const { data: pedidoRaw, error: pErr } = await supabase
     .from("pedido_compra_sugerido")
-    .select("id, empresa, fornecedor_nome, status, status_envio_portal, portal_protocolo")
+    .select("id, empresa, fornecedor_nome, status, status_envio_portal, portal_protocolo, omie_pedido_compra_id")
     .eq("id", pedidoId)
     .maybeSingle();
 
@@ -170,8 +185,31 @@ Deno.serve(async (req: Request) => {
     erro: null,
   });
 
-  // 4. Disparar Omie. disparar-pedidos-aprovados vê sucesso_portal + protocolo
-  // como already_sent e cria o pedido de compra no Omie.
+  // 4. Disparar Omie — SÓ se o pedido ainda não tem PO no Omie (guard anti-PO-duplicado,
+  // §4.4). Se omie_pedido_compra_id já está preenchido, o PO já existe (corrida/retry
+  // anterior) → NÃO recriar; a conciliação acima (protocolo + sucesso_portal) basta.
+  // O dedup por cCodIntPed do próprio Omie é backstop; este guard evita a chamada.
+  if (!deveCriarPedidoOmie(pedido.omie_pedido_compra_id)) {
+    return new Response(
+      JSON.stringify({
+        ok: true,
+        pedido_id: pedidoId,
+        protocolo,
+        status_anterior: statusAnterior,
+        status_envio_portal: "sucesso_portal",
+        omie: {
+          ok: true,
+          skipped: true,
+          motivo: "ja_existe",
+          omie_pedido_compra_id: String(pedido.omie_pedido_compra_id),
+        },
+      }),
+      { status: 200, headers: { ...corsHeaders, "Content-Type": "application/json" } },
+    );
+  }
+
+  // disparar-pedidos-aprovados vê sucesso_portal + protocolo como already_sent e
+  // cria o pedido de compra no Omie.
   const omie = await dispararOmie(pedido.empresa, pedidoId);
   const omieOk = omie.httpStatus >= 200 && omie.httpStatus < 300;
 


### PR DESCRIPTION
## Fase 3 · sub-PR 3b (tela única de pedidos de compra)

Traz a **conciliação do portal Sayerlack pra DENTRO da tela de pedidos** (`reposicao/pedidos/PortalDrawer.tsx`), reusando a edge `conciliar-pedido-portal` — pré-requisito pra aposentar o `/admin/portal-sayerlack` no 3c. + fecha um risco de **PO duplicado** e remove um **reset cego perigoso**.

### O que muda
- **T1 — Conciliação inline:** o operador concilia (informa o protocolo) ali mesmo, sem ir pra outra tela. Distingue os 2 estados: `aceito_portal_sem_protocolo` (PO provavelmente existe, baixo risco) × `indeterminado_requer_conciliacao` (**aviso vermelho**: "confira no portal ANTES — risco de duplicar").
- **T2 — Guard anti-PO-duplo (MONEY-PATH):** a edge `conciliar-pedido-portal` agora **pula a criação no Omie** quando o pedido **já tem** `omie_pedido_compra_id` (helper puro `deveCriarPedidoOmie`, espelhado verbatim no edge). A reconciliação (protocolo/sucesso_portal) é persistida mesmo no skip. Backstop: o `cCodIntPed` do Omie.
- **T3 — Remove o "Forçar reenvio" cego:** na main o botão rendava pra QUALQUER status (até `sucesso`!) → reset→re-send = risco de PO duplo. Agora estados de conciliação → **Conciliar** (nunca reset); reset só em erro genuíno (`erro_retentavel`/`falha_envio_portal`/`erro_nao_retentavel`, que no fluxo portal-first não têm PO ainda). Helper puro `decidirAcaoPortal`.

### Revisão (subagent-driven)
spec-review ✅ (**money-path safe**: guard inbypassável, 1 só call-site do `dispararOmie`, reconciliação persiste no skip) + code-quality ✅ (sem Critical/Important). 2 helpers puros + 10 testes; 2479 testes verdes, typecheck strict limpo, lint 0.

### ⚠️ Ação do founder após merge
**Deploy do edge `conciliar-pedido-portal` via chat do Lovable** (verbatim da main) — o guard anti-PO-duplo só vale em prod após o deploy. Até lá o `cCodIntPed` do Omie é o backstop. `portalSayerlack/*` intocado (sai no 3c).

🤖 Generated with [Claude Code](https://claude.com/claude-code)