### PR TITLE
fix(reposição): aposenta a aprovação no stepper + alertas da sessão (fix-forward #642, via codex)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -115,7 +115,6 @@ const FinanceiroFunding = lazy(() => import("./pages/FinanceiroFunding"));
 const Recebimento = lazy(() => import("./pages/Recebimento"));
 const RecebimentoConferencia = lazy(() => import("./pages/RecebimentoConferencia"));
 const ProductionOrders = lazy(() => import("./pages/ProductionOrders"));
-const AdminReposicaoRevisao = lazy(() => import("./pages/AdminReposicaoRevisao"));
 const AdminReposicaoHistorico = lazy(() => import("./pages/AdminReposicaoHistorico"));
 const AdminReposicaoAlertas = lazy(() => import("./pages/AdminReposicaoAlertas"));
 const AdminReposicaoGruposProducao = lazy(() => import("./pages/AdminReposicaoGruposProducao"));
@@ -328,7 +327,7 @@ const App = () => (
                 <Route path="recebimento" element={<Recebimento />} />
                 <Route path="recebimento/:id" element={<RecebimentoConferencia />} />
                 <Route path="producao" element={<ProductionOrders />} />
-                <Route path="admin/reposicao/revisao" element={<AdminReposicaoRevisao />} />
+                <Route path="admin/reposicao/revisao" element={<Navigate to="/admin/reposicao/sessao/parametros?tab=ajuste" replace />} />
                 <Route path="admin/reposicao/historico" element={<AdminReposicaoHistorico />} />
                 <Route path="admin/reposicao/alertas" element={<AdminReposicaoAlertas />} />
                 <Route path="admin/reposicao/aplicacao" element={<Navigate to="/admin/reposicao/sessao/aplicacao" replace />} />

--- a/src/components/reposicao/EtapaChecklist.tsx
+++ b/src/components/reposicao/EtapaChecklist.tsx
@@ -36,15 +36,12 @@ export function buildEtapaChecklist(step: number, s: ReposicaoStatus): Checklist
       };
     case 2:
       return {
-        title: "Para concluir a Etapa 2: Parâmetros",
+        title: "Etapa 2: Parâmetros (automático)",
         items: [
           {
-            label: `Aprovar ${s.parametrosPendentesCount} parâmetro(s) pendente(s)`,
-            done: s.parametrosPendentesCount === 0,
-            cta:
-              s.parametrosPendentesCount > 0
-                ? { label: "Abrir revisão", to: "/admin/reposicao/revisao" }
-                : undefined,
+            // Aprovação manual aposentada — os parâmetros são ajustados todo dia.
+            label: "Parâmetros ajustados automaticamente todo dia",
+            done: true,
           },
         ],
       };

--- a/src/components/reposicao/EtapasGrid.tsx
+++ b/src/components/reposicao/EtapasGrid.tsx
@@ -14,9 +14,7 @@ function describe(step: number, s: ReposicaoStatus): string {
         ? `${s.oportunidadesCount} oportunidade(s) ativa(s)`
         : "Sem oportunidades pendentes";
     case 2:
-      return s.parametrosPendentesCount > 0
-        ? `${s.parametrosPendentesCount} parâmetro(s) pendente(s)`
-        : "Sem parâmetros pendentes";
+      return "Ajustados automaticamente";
     case 3:
       if (s.pedidosTotal === 0) return "Nenhum pedido gerado";
       return s.pedidosPendentes > 0

--- a/src/components/reposicao/SmartAlertsSection.tsx
+++ b/src/components/reposicao/SmartAlertsSection.tsx
@@ -20,22 +20,8 @@ type SmartAlert = {
 function useSmartAlerts(): SmartAlert[] {
   const navigate = useNavigate();
 
-  const { data: paramsPendentes = 0 } = useQuery({
-    queryKey: ["cockpit-alert-params-pendentes", REPOSICAO_EMPRESA],
-    queryFn: async () => {
-      const cutoff = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
-      const { count, error } = await supabase
-        .from("sku_parametros")
-        .select("*", { count: "exact", head: true })
-        .eq("empresa", REPOSICAO_EMPRESA)
-        .eq("ativo", true)
-        .is("aprovado_em", null)
-        .lt("ultima_atualizacao_calculo", cutoff);
-      if (error) throw error;
-      return count ?? 0;
-    },
-    staleTime: 60_000,
-  });
+  // Alerta de "parâmetros aguardando aprovação" foi aposentado junto com a aprovação
+  // manual (o motor/auto-apply ignoram aprovado_em; o alerta nunca resolveria).
 
   const { data: skusSemParam = 0 } = useQuery({
     queryKey: ["cockpit-alert-sem-parametro", REPOSICAO_EMPRESA],
@@ -54,15 +40,6 @@ function useSmartAlerts(): SmartAlert[] {
 
   return useMemo(() => {
     const list: SmartAlert[] = [];
-    if (paramsPendentes > 0) {
-      list.push({
-        id: "params-24h",
-        level: "yellow",
-        message: `${paramsPendentes} parâmetro(s) aguardam aprovação há mais de 24h`,
-        actionLabel: "Ver parâmetros",
-        onAction: () => navigate("/admin/reposicao/sessao/parametros"),
-      });
-    }
     const now = new Date();
     const cutoff = new Date(now);
     cutoff.setHours(CUTOFF_HOUR, CUTOFF_MIN, 0, 0);
@@ -86,7 +63,7 @@ function useSmartAlerts(): SmartAlert[] {
       });
     }
     return list;
-  }, [paramsPendentes, skusSemParam, navigate]);
+  }, [skusSemParam, navigate]);
 }
 
 export function SmartAlertsSection() {

--- a/src/components/reposicao/__tests__/EtapaChecklist.test.ts
+++ b/src/components/reposicao/__tests__/EtapaChecklist.test.ts
@@ -5,7 +5,6 @@ import type { ReposicaoStatus } from "@/hooks/useReposicaoSessao";
 const baseStatus: ReposicaoStatus = {
   current: 3,
   oportunidadesCount: 0,
-  parametrosPendentesCount: 0,
   pedidosTotal: 0,
   pedidosPendentes: 0,
   pedidosBloqueados: 0,
@@ -28,11 +27,11 @@ describe("buildEtapaChecklist", () => {
     expect(def.items[0].cta?.to).toBe("/admin/reposicao/oportunidades");
   });
 
-  it("Etapa 2: pending when params await approval", () => {
-    const def = buildEtapaChecklist(2, { ...baseStatus, parametrosPendentesCount: 7 });
-    expect(def.items[0].done).toBe(false);
-    expect(def.items[0].label).toMatch(/7 par[aâ]metro/);
-    expect(def.items[0].cta?.to).toBe("/admin/reposicao/revisao");
+  it("Etapa 2: auto-managed — done, sem ação de aprovação", () => {
+    const def = buildEtapaChecklist(2, baseStatus);
+    expect(def.title).toMatch(/autom/i);
+    expect(def.items[0].done).toBe(true);
+    expect(def.items[0].cta).toBeUndefined();
   });
 
   it("Etapa 3: not done while no pedidos generated", () => {

--- a/src/components/reposicao/revisao/SkuRow.tsx
+++ b/src/components/reposicao/revisao/SkuRow.tsx
@@ -95,7 +95,9 @@ export function SkuRow({ row: r, onOpenDetail, onPromover, promovendo }: SkuRowP
           >
             Aguardando fornecedor
           </Badge>
-        ) : null}
+        ) : (
+          <span className="text-muted-foreground">—</span>
+        )}
       </TableCell>
       <TableCell>
         <div className="flex items-center justify-end gap-1">

--- a/src/hooks/__tests__/useReposicaoSessao.test.ts
+++ b/src/hooks/__tests__/useReposicaoSessao.test.ts
@@ -10,7 +10,6 @@ import {
 const baseStatus: ReposicaoStatus = {
   current: 3,
   oportunidadesCount: 0,
-  parametrosPendentesCount: 0,
   pedidosTotal: 0,
   pedidosPendentes: 0,
   pedidosBloqueados: 0,
@@ -21,20 +20,19 @@ const baseStatus: ReposicaoStatus = {
 describe("deriveCurrentStep", () => {
   const m = {
     oportunidadesCount: 0,
-    parametrosPendentesCount: 0,
     pedidosPendentes: 0,
     pedidosAprovados: 0,
     pedidosDisparados: 0,
   };
 
   it("returns 1 when there are open opportunities (highest priority)", () => {
-    expect(
-      deriveCurrentStep({ ...m, oportunidadesCount: 5, parametrosPendentesCount: 9 }),
-    ).toBe(1);
+    expect(deriveCurrentStep({ ...m, oportunidadesCount: 5 })).toBe(1);
   });
 
-  it("returns 2 when params pending and no opportunities", () => {
-    expect(deriveCurrentStep({ ...m, parametrosPendentesCount: 3 })).toBe(2);
+  it("does NOT force step 2 — params are auto-managed (no approval gate)", () => {
+    // Pré-aposentadoria, params pendentes forçavam a etapa 2. Agora a etapa 2 é
+    // automática e nada de params afeta a derivação → cai no default 3.
+    expect(deriveCurrentStep({ ...m })).toBe(3);
   });
 
   it("returns 3 when pedidos pending and earlier steps clear", () => {
@@ -57,7 +55,6 @@ describe("deriveCurrentStep", () => {
     expect(
       deriveCurrentStep({
         oportunidadesCount: 1,
-        parametrosPendentesCount: 1,
         pedidosPendentes: 1,
         pedidosAprovados: 1,
         pedidosDisparados: 1,

--- a/src/hooks/useReposicaoSessao.ts
+++ b/src/hooks/useReposicaoSessao.ts
@@ -55,7 +55,6 @@ export function useItensDoDia() {
 export type ReposicaoStatus = {
   current: number;
   oportunidadesCount: number;
-  parametrosPendentesCount: number;
   pedidosTotal: number;
   pedidosPendentes: number;
   pedidosBloqueados: number;
@@ -66,7 +65,6 @@ export type ReposicaoStatus = {
 const DEFAULT: ReposicaoStatus = {
   current: 3,
   oportunidadesCount: 0,
-  parametrosPendentesCount: 0,
   pedidosTotal: 0,
   pedidosPendentes: 0,
   pedidosBloqueados: 0,
@@ -77,16 +75,18 @@ const DEFAULT: ReposicaoStatus = {
 /**
  * Pure derivation of the "current step" from cycle metrics. Extracted so it can
  * be unit-tested independently of the Supabase query.
+ *
+ * A Etapa 2 (Parâmetros) NÃO entra mais na derivação: os parâmetros são ajustados
+ * automaticamente todo dia (aprovação manual aposentada) — nunca é uma tarefa humana
+ * que trava o progresso da sessão. A etapa segue navegável (ajuste manual opcional).
  */
 export function deriveCurrentStep(m: {
   oportunidadesCount: number;
-  parametrosPendentesCount: number;
   pedidosPendentes: number;
   pedidosAprovados: number;
   pedidosDisparados: number;
 }): number {
   if (m.oportunidadesCount > 0) return 1;
-  if (m.parametrosPendentesCount > 0) return 2;
   if (m.pedidosPendentes > 0) return 3;
   if (m.pedidosAprovados > 0) return 4;
   if (m.pedidosDisparados > 0) return 5;
@@ -105,13 +105,7 @@ export function useReposicaoStatus() {
         .eq("empresa", REPOSICAO_EMPRESA);
       if (oport.error) throw oport.error;
 
-      const params = await supabase
-        .from("sku_parametros")
-        .select("*", { count: "exact", head: true })
-        .eq("empresa", REPOSICAO_EMPRESA)
-        .eq("ativo", true)
-        .is("aprovado_em", null);
-      if (params.error) throw params.error;
+      // Etapa 2 (Parâmetros) é automática — sem contagem de "pendentes de aprovação".
 
       const pedidos = await supabase
         .from("pedido_compra_sugerido")
@@ -131,11 +125,9 @@ export function useReposicaoStatus() {
       const pedidosDisparados = statuses.filter((s) => s === "disparado").length;
 
       const oportunidadesCount = oport.count ?? 0;
-      const parametrosPendentesCount = params.count ?? 0;
 
       const current = deriveCurrentStep({
         oportunidadesCount,
-        parametrosPendentesCount,
         pedidosPendentes,
         pedidosAprovados,
         pedidosDisparados,
@@ -144,7 +136,6 @@ export function useReposicaoStatus() {
       return {
         current,
         oportunidadesCount,
-        parametrosPendentesCount,
         pedidosTotal: statuses.length,
         pedidosPendentes,
         pedidosBloqueados,

--- a/src/pages/AdminReposicaoRevisao.tsx
+++ b/src/pages/AdminReposicaoRevisao.tsx
@@ -1,11 +1,11 @@
-import { Link } from "react-router-dom";
-import { Button } from "@/components/ui/button";
-import { History } from "lucide-react";
 import { SkuDetailSheet } from "@/components/reposicao/SkuDetailSheet";
 import { useRevisaoParametros } from "@/components/reposicao/revisao/useRevisaoParametros";
 import { FiltrosCard } from "@/components/reposicao/revisao/FiltrosCard";
 import { RevisaoTable } from "@/components/reposicao/revisao/RevisaoTable";
 
+// "Ajuste manual" — conteúdo da aba de Parâmetros (AdminReposicaoParametros) e alvo do
+// redirect /admin/reposicao/revisao. Sem chrome de página própria (container/h1/Histórico):
+// o cockpit já fornece título + pointer card; "Histórico" é uma aba do cockpit.
 export default function AdminReposicaoRevisao() {
   const {
     empresa,
@@ -30,28 +30,18 @@ export default function AdminReposicaoRevisao() {
   } = useRevisaoParametros();
 
   return (
-    <div className="container mx-auto p-6 space-y-6">
-      <div className="flex items-center justify-between flex-wrap gap-3">
-        <div>
-          <h1 className="text-2xl font-semibold">Ajuste manual de parâmetros</h1>
-          <p className="text-sm text-muted-foreground">
-            O sistema ajusta os parâmetros automaticamente. Use esta tela só pra travar um mínimo de compra
-            por SKU, editar valores na mão ou promover um candidato de 1ª compra.
-          </p>
-          {statusFilter === "primeira_compra" && (
-            <p className="text-sm text-status-info mt-1">
-              Itens que vendem com recorrência mas estão fora da reposição automática. Revise a recorrência
-              e clique em <strong>Promover</strong> — entram no fluxo normal de compra com uma quantidade-teste
-              capada (o motor só compra se o estoque estiver baixo).
-            </p>
-          )}
-        </div>
-        <Button asChild variant="outline" size="sm">
-          <Link to="/admin/reposicao/historico">
-            <History className="mr-2 h-4 w-4" /> Histórico
-          </Link>
-        </Button>
-      </div>
+    <div className="space-y-4">
+      <p className="text-sm text-muted-foreground">
+        Os parâmetros são ajustados automaticamente todo dia. Use esta tela pra travar um mínimo de
+        compra por SKU, editar valores na mão ou promover um candidato de 1ª compra.
+      </p>
+      {statusFilter === "primeira_compra" && (
+        <p className="text-sm text-status-info">
+          Itens que vendem com recorrência mas estão fora da reposição automática. Revise a recorrência
+          e clique em <strong>Promover</strong> — entram no fluxo normal de compra com uma quantidade-teste
+          capada (o motor só compra se o estoque estiver baixo).
+        </p>
+      )}
 
       <FiltrosCard
         empresa={empresa}


### PR DESCRIPTION
## Por quê (codex challenge no #642)

Rodei `/codex challenge` no #642. Ele achou que a "aprovação" de parâmetros **ainda vivia em superfícies fora da tela de Revisão** — e que remover só o botão de aprovar deixava becos sem saída. Este PR fecha isso.

## Achados corrigidos

- **[P1] Stepper da sessão.** `useReposicaoSessao` contava `parametrosPendentesCount` via `aprovado_em IS NULL` e `deriveCurrentStep` **travava na Etapa 2** — com `EtapaChecklist` mandando "Aprovar N parâmetros" + link pra tela que **não tem mais botão de aprovar**. Agora a **Etapa 2 é automática** (nunca trava o progresso; segue navegável pra ajuste manual). `EtapasGrid`/`EtapaChecklist` reescritos pra "ajustados automaticamente".
- **[P1] Rota standalone.** `/admin/reposicao/revisao` renderizava `AdminReposicaoRevisao` **sem `ReposicaoEmpresaProvider`** → caía no default OBEN sem seletor (não dava pra editar COLACOR). Agora **redireciona pro tab do cockpit** (`?tab=ajuste`), que tem o provider + seletor OBEN/COLACOR.
- **[P2] SmartAlertsSection.** Alerta "N parâmetros aguardam aprovação há +24h" **nunca resolveria** (`aprovado_em` não é mais setado) → removido. O alerta "SKUs ativos sem parâmetro" (real) fica.
- **[P2] Header duplicado / coluna vazia.** `AdminReposicaoRevisao` perdeu o container/h1/Histórico próprios (só roda embutido na aba agora → some a hierarquia duplicada e o "Histórico" que saía do cockpit). `SkuRow`: coluna Status mostra "—" em linha normal (era vazia).

2º codex challenge neste diff: **0 P1**.

## ⚠️ Deploy

- **Sem migration. Sem edge.** Frontend puro.
- **Requer Publish no Lovable** (junto com #639/#642).

## Qualidade

- typecheck strict **0** · lint **0 errors** · build (vite) **0** · **2475 testes** passando.
- Testes do `deriveCurrentStep`/`buildEtapaChecklist` atualizados pro novo comportamento (Etapa 2 auto).

🤖 Generated with [Claude Code](https://claude.com/claude-code)