### PR TITLE
feat(reposição): passo 3 do wizard enxuto (fim da tela única) — Fase 3 · sub-PR 3c-2

### DIFF
--- a/src/components/reposicao/CicloHojePanel.tsx
+++ b/src/components/reposicao/CicloHojePanel.tsx
@@ -1,4 +1,3 @@
-import { lazy, Suspense } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
@@ -19,8 +18,6 @@ import { BatchActionsBar } from "./cicloHoje/BatchActionsBar";
 
 // Re-exporta ALL para preservar o import existente (AdminReposicaoSessaoPedidos).
 export { ALL } from "./cicloHoje/types";
-
-const AdminReposicaoPedidos = lazy(() => import("@/pages/AdminReposicaoPedidos"));
 
 export function CicloHojePanel({
   user,
@@ -140,10 +137,6 @@ export function CicloHojePanel({
         busy={busy}
         onConfirm={runAutoApprove}
       />
-
-      <Suspense fallback={<TabFallback />}>
-        <AdminReposicaoPedidos />
-      </Suspense>
 
       {reviewMode && selected.size > 0 && (
         <BatchActionsBar

--- a/src/pages/AdminReposicaoSessaoPedidos.tsx
+++ b/src/pages/AdminReposicaoSessaoPedidos.tsx
@@ -1,6 +1,8 @@
 import { useMemo, useState } from "react";
-import { ClipboardCheck } from "lucide-react";
+import { Link } from "react-router-dom";
+import { ClipboardCheck, ExternalLink } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext";
+import { Button } from "@/components/ui/button";
 import { CicloHojePanel, ALL } from "@/components/reposicao/CicloHojePanel";
 import { useColumnConfig } from "@/components/reposicao/ColumnConfig";
 import { useItensDoDia } from "@/hooks/useReposicaoSessao";
@@ -48,6 +50,14 @@ export default function AdminReposicaoSessaoPedidos() {
         icon={ClipboardCheck}
         title="Pedidos"
         subtitle="Revisão e aprovação dos pedidos sugeridos para o ciclo de hoje"
+        actions={
+          <Button asChild variant="outline" size="sm">
+            <Link to="/admin/reposicao/pedidos">
+              Gerir pedidos (detalhes · conciliar · disparar)
+              <ExternalLink className="h-3.5 w-3.5 ml-1.5" />
+            </Link>
+          </Button>
+        }
       />
       <EtapaChecklist step={3} />
       <CicloHojePanel


### PR DESCRIPTION
## Fase 3 · sub-PR 3c-2 (tela única — parte FINAL: passo 3 enxuto)

Fecha a tela única — mata a **queixa principal do founder**: as 2 tabelas empilhadas no passo 3 do wizard.

### O que muda
- **`CicloHojePanel` para de embutir o `AdminReposicaoPedidos`** (removido o `<Suspense><AdminReposicaoPedidos/></Suspense>` + o lazy import). O passo 3 agora mostra UMA tabela só — a de revisar/aprovar (lote, auto-approve, edição de qtd, confiança).
- **CTA "Gerir pedidos (detalhes · conciliar · disparar)"** no header do passo → `/admin/reposicao/pedidos` (a gestão completa, 1 clique). Decisão do founder: passo 3 enxuto/focado; gestão profunda na tela de Pedidos.

### Fluxo preservado (verificado)
- Pedidos `bloqueado_guardrail`/`falha_envio` **ainda APARECEM** na tabela enxuta (`useItensDoDia` traz o ciclo inteiro, sem filtro de status; coluna de status renderiza) — só não são acionáveis ali (ação profunda na tela de Pedidos).
- **Stepper intocado**: deriva de query separada (`useReposicaoStatus`/`cockpit-current-step`), que o embed nunca alimentava; as ações de aprovar já invalidam essa key → o passo avança normal.

### Trade-off consciente (founder escolheu lean)
Migram pra tela de Pedidos: ações por linha, deep-link, PortalDrawer (conciliação), "rodar geração", banners de bloqueados/SKU-sem-fornecedor, fila "precisa de atenção", ciclos anteriores.

### Revisão
Verificação do controller (mudança minúscula: remoção + link). typecheck strict + build + 2463 testes verdes, lint 0, zero refs dangling.

### Ação do founder
100% frontend — só Publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
