### PR TITLE
fix(reposição): remove alerta 'janela de compra fecha em X min'

### DIFF
--- a/src/components/reposicao/SmartAlertsSection.tsx
+++ b/src/components/reposicao/SmartAlertsSection.tsx
@@ -6,9 +6,6 @@ import { Button } from "@/components/ui/button";
 import { supabase } from "@/integrations/supabase/client";
 import { REPOSICAO_EMPRESA } from "@/hooks/useReposicaoSessao";
 
-const CUTOFF_HOUR = 9;
-const CUTOFF_MIN = 30;
-
 type SmartAlert = {
   id: string;
   level: "yellow" | "orange" | "red";
@@ -40,19 +37,6 @@ function useSmartAlerts(): SmartAlert[] {
 
   return useMemo(() => {
     const list: SmartAlert[] = [];
-    const now = new Date();
-    const cutoff = new Date(now);
-    cutoff.setHours(CUTOFF_HOUR, CUTOFF_MIN, 0, 0);
-    const minutes = (cutoff.getTime() - now.getTime()) / 60_000;
-    if (minutes > 0 && minutes < 60) {
-      list.push({
-        id: "janela-1h",
-        level: "orange",
-        message: `Janela de compra fecha em ${Math.ceil(minutes)} minutos`,
-        actionLabel: "Ver cockpit",
-        onAction: () => navigate("/admin/reposicao/sessao/pedidos"),
-      });
-    }
     if (skusSemParam > 0) {
       list.push({
         id: "skus-sem-param",


### PR DESCRIPTION
Remove o alerta "Janela de compra fecha em X minutos" (corte 09:30) do `SmartAlertsSection`.

**Por quê (founder):** com **aprovar=dispara** (3a), ele recebe o e-mail de manhã e já dispara — a contagem regressiva de "janela fechando" virou pressão inútil, não muda nada no fluxo.

**Mudança:** remove o alerta `janela-1h` + os helpers `CUTOFF_HOUR`/`CUTOFF_MIN` + o cálculo de minutos. O framework de alerta genérico (tone/Icon/dismiss) fica intacto, ainda servindo o alerta "SKUs sem parâmetro configurado" (e futuros). typecheck strict + lint + 2474 testes verdes.

100% frontend — entra no mesmo Publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
