### PR TITLE
fix(reposição): auto-resolve alertas 'SKU sem grupo' velhos + esconde '04' da tela de grupo

### DIFF
--- a/src/pages/AdminReposicaoGruposProducao.tsx
+++ b/src/pages/AdminReposicaoGruposProducao.tsx
@@ -96,13 +96,34 @@ export default function AdminReposicaoGruposProducao() {
         });
       }
 
-      const rows: SkuRow[] = rawRows.map((r) => ({
-        empresa: r.empresa,
-        sku_codigo_omie: Number(r.sku_codigo_omie),
-        sku_descricao: r.sku_descricao,
-        fornecedor_nome: r.fornecedor_nome,
-        grupo_codigo: assocMap[String(r.sku_codigo_omie)] || null,
-      }));
+      // Esconde Produto Acabado ('04' = fabricado, não comprado → não precisa de grupo de produção).
+      // Sinal CANÔNICO = omie_products.tipo_produto (account 'oben') — o MESMO do motor e do
+      // gerador de alerta no backend (evita divergência tipo_reposicao×tipo_produto).
+      const set04 = new Set<string>();
+      if (skuCodes.length > 0) {
+        const codigos = skuCodes.map(Number).filter(Number.isFinite);
+        if (codigos.length > 0) {
+          const { data: prod } = await supabase
+            .from("omie_products")
+            .select("omie_codigo_produto, tipo_produto")
+            .eq("account", "oben")
+            .in("omie_codigo_produto", codigos)
+            .in("tipo_produto", ["04", "4"]);
+          ((prod || []) as Array<{ omie_codigo_produto: number }>).forEach((p) =>
+            set04.add(String(p.omie_codigo_produto)),
+          );
+        }
+      }
+
+      const rows: SkuRow[] = rawRows
+        .filter((r) => !set04.has(String(r.sku_codigo_omie)))
+        .map((r) => ({
+          empresa: r.empresa,
+          sku_codigo_omie: Number(r.sku_codigo_omie),
+          sku_descricao: r.sku_descricao,
+          fornecedor_nome: r.fornecedor_nome,
+          grupo_codigo: assocMap[String(r.sku_codigo_omie)] || null,
+        }));
 
       // Filtro por grupo (client-side, aplicado depois do fetch da página)
       const filtered = filtroGrupo === ALL

--- a/supabase/migrations/20260606140000_detectar_skus_sem_grupo_self_heal.sql
+++ b/supabase/migrations/20260606140000_detectar_skus_sem_grupo_self_heal.sql
@@ -1,0 +1,105 @@
+-- (2+3 backend) detectar_skus_sem_grupo — limpeza do ruído de alerta "SKU sem grupo".
+-- SUPERSEDE a 20260606130000 (B): redefine a função completa e adiciona SELF-HEAL.
+--   - Exclusão de Produto Acabado ('04'): subquery account-aware em omie_products.tipo_produto
+--     (sinal CANÔNICO, espelha o motor 20260604170000). Fabricado não é comprado → sem grupo.
+--   - SELF-HEAL: a cada run, resolve ('excluido') os alertas pendentes que não fazem mais
+--     sentido — SKU que JÁ ganhou grupo (o alerta velho nunca se auto-resolvia) ou que é '04'.
+--     Era a causa do descasamento (alertas mostram dezenas; a tela de grupo, 1).
+-- NÃO usa 450/405ML aqui: é regra de fracionado específica do motor de COMPRA; aplicá-la ao
+-- alerta de grupo poderia suprimir um item comprável legítimo (decisão eu+Codex). O '04' é o
+-- sinal seguro/universal de "não comprado". Gerador de ALERTA — NÃO toca compra/money-path.
+
+CREATE OR REPLACE FUNCTION public.detectar_skus_sem_grupo(p_empresa text DEFAULT 'OBEN'::text)
+RETURNS integer
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_inseridos integer := 0;
+BEGIN
+  -- SELF-HEAL: resolve alertas pendentes que deixaram de fazer sentido (já agrupado ou '04').
+  UPDATE eventos_outlier eo
+  SET status = 'excluido',
+      decidido_em = now(),
+      decidido_por = 'sistema (auto-resolve sku_sem_grupo)',
+      justificativa_decisao = 'SKU já tem grupo ou é Produto Acabado (04) fabricado — não precisa de grupo de produção.'
+  WHERE eo.tipo = 'sku_sem_grupo'
+    AND eo.status = 'pendente'
+    AND eo.empresa = p_empresa
+    AND (
+      EXISTS (
+        SELECT 1 FROM sku_grupo_producao sg
+        WHERE sg.empresa = eo.empresa AND sg.sku_codigo_omie = eo.sku_codigo_omie
+      )
+      OR COALESCE((
+        SELECT COALESCE(op.tipo_produto, op.metadata->>'tipo_produto')
+        FROM omie_products op
+        WHERE op.omie_codigo_produto::text = eo.sku_codigo_omie AND op.account = lower(eo.empresa)
+        LIMIT 1
+      ), '') = '04'
+    );
+
+  -- Geração: só SKU comprável sem grupo (exclui Produto Acabado '04').
+  WITH fornecedores_com_grupos AS (
+    SELECT DISTINCT fornecedor_nome
+    FROM fornecedor_grupo_producao
+    WHERE empresa = p_empresa
+  ),
+  inseridos AS (
+    INSERT INTO eventos_outlier (
+      empresa, sku_codigo_omie, sku_descricao,
+      tipo, severidade, data_evento, detalhes
+    )
+    SELECT
+      sp.empresa, sp.sku_codigo_omie::text, sp.sku_descricao,
+      'sku_sem_grupo', 'atencao', CURRENT_DATE,
+      jsonb_build_object(
+        'fornecedor', sp.fornecedor_nome,
+        'mensagem', 'SKU novo detectado. Classifique em um grupo de produção antes do próximo ciclo de reposição.'
+      )
+    FROM sku_parametros sp
+    JOIN fornecedores_com_grupos fcg ON fcg.fornecedor_nome = sp.fornecedor_nome
+    WHERE sp.empresa = p_empresa
+      AND NOT EXISTS (
+        SELECT 1 FROM sku_grupo_producao sg
+        WHERE sg.empresa = sp.empresa AND sg.sku_codigo_omie = sp.sku_codigo_omie::text
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM eventos_outlier eo
+        WHERE eo.empresa = sp.empresa AND eo.sku_codigo_omie = sp.sku_codigo_omie::text
+          AND eo.tipo = 'sku_sem_grupo' AND eo.status = 'pendente'
+      )
+      AND COALESCE((
+        SELECT COALESCE(op04.tipo_produto, op04.metadata->>'tipo_produto')
+        FROM omie_products op04
+        WHERE op04.omie_codigo_produto::text = sp.sku_codigo_omie::text AND op04.account = lower(p_empresa)
+        LIMIT 1
+      ), '') <> '04'
+    RETURNING 1
+  )
+  SELECT COUNT(*) INTO v_inseridos FROM inseridos;
+
+  RETURN v_inseridos;
+END;
+$$;
+
+-- Cleanup imediato dos alertas velhos (não espera o próximo run do cron). Todas as empresas.
+UPDATE public.eventos_outlier eo
+SET status = 'excluido',
+    decidido_em = now(),
+    decidido_por = 'sistema (auto-resolve sku_sem_grupo)',
+    justificativa_decisao = 'SKU já tem grupo ou é Produto Acabado (04) fabricado — não precisa de grupo de produção.'
+WHERE eo.tipo = 'sku_sem_grupo'
+  AND eo.status = 'pendente'
+  AND (
+    EXISTS (
+      SELECT 1 FROM sku_grupo_producao sg
+      WHERE sg.empresa = eo.empresa AND sg.sku_codigo_omie = eo.sku_codigo_omie
+    )
+    OR COALESCE((
+      SELECT COALESCE(op.tipo_produto, op.metadata->>'tipo_produto')
+      FROM omie_products op
+      WHERE op.omie_codigo_produto::text = eo.sku_codigo_omie AND op.account = lower(eo.empresa)
+      LIMIT 1
+    ), '') = '04'
+  );


### PR DESCRIPTION
## O quê
Limpa o ruído do alerta **"SKU sem grupo"** (a foto do founder: dezenas de alertas que não casavam com a tela de grupo).

**Diagnóstico:** alertas velhos (13/05) **nunca se auto-resolviam** quando o SKU ganhava grupo depois + **Produto Acabado ('04', fabricado)** era flagado sem precisar de grupo.

## Backend (migration, supersede a #654/B)
- `detectar_skus_sem_grupo` ganha **SELF-HEAL**: a cada run resolve (`excluido`) alertas pendentes de SKU que **já tem grupo** ou é **'04'** (sinal canônico `omie_products.tipo_produto`, account-aware, espelha o motor #20260604170000).
- Geração exclui '04'. + **cleanup imediato** dos pendentes (já agrupado / '04').
- **Sem 450/405ML** (Codex P2: poderia suprimir item comprável legítimo; '04' é o sinal seguro de "não comprado").

## Frontend (tela Associação SKU → Grupo)
Esconde '04' pelo **mesmo sinal canônico** (`omie_products.tipo_produto`, account 'oben') — alinhado ao backend (mata a divergência `tipo_reposicao`×`tipo_produto` que o Codex apontou).

## Codex challenge
**0 P1.** Os 4 P2 (450/405ML global · divergência de sinal · NULL no .not ilike · desc histórica) **resolvidos** largando 450/405ML + alinhando ao '04' canônico.

Gerador de **ALERTA** — não toca compra/money-path. typecheck/lint/393 testes/build verdes.

## ⚠️ Migration manual
`20260606140000_detectar_skus_sem_grupo_self_heal.sql` — colar no SQL Editor. **Supersede o B (#654): aplica SÓ esta** (ela já inclui a guarda '04').

🤖 Generated with [Claude Code](https://claude.com/claude-code)