### PR TITLE
fix(pedido): preço do cliente antes do auto-cadastro + guard de seleção (Etapa 1)

### DIFF
--- a/docs/superpowers/plans/2026-06-06-preco-realtime-etapa2-plan.md
+++ b/docs/superpowers/plans/2026-06-06-preco-realtime-etapa2-plan.md
@@ -1,0 +1,50 @@
+# Plano — Etapa 2: identidade de cliente por-conta confiável + tri-state
+
+**Pré-req:** [spec](../specs/2026-06-06-preco-realtime-selectCustomer-design.md) · Etapa 1 (PR #656) no ar.
+**Status:** rascunho — **aguarda challenge do Codex** (cota reseta ~12:56) antes de implementar (money-path).
+**Objetivo:** tornar a identidade do cliente por-conta (oben/colacor/afiação) **confiável e tri-state**, base para a Etapa 3 (submit fail-closed) sem risco de pedido na conta errada nem cliente duplicado.
+
+## Problema que resolve
+Hoje o lookup de cliente colapsa **erro** e **ausência** no mesmo `null` (`getResult` no frontend; `callOmieVendasApi`→null; `omie-sync` retorna 200 com `codigo_cliente:null`). Consequências:
+- Erro transitório do Omie (Colacor) vira "ausente" → `IncluirCliente` cria **duplicado**.
+- O submit faz fallback pro código oben quando o por-conta falta → **pedido na conta errada**.
+
+## Mudanças (todas money-path → Codex challenge antes de implementar; deploy de edge via Lovable)
+
+### 2.1 — Lookup tri-state no edge
+- `buscarClienteVendas` (omie-vendas-sync) e `buscar_cliente_por_documento` (omie-sync): retornar discriminador
+  `{ status: 'found'|'absent'|'error', codigo_cliente?, codigo_vendedor? }`.
+- Distinguir na origem: `callOmieVendasApi`/`callOmieApi` precisa **lançar** em erro/fault (após retries) em vez de retornar `null`; "lista vazia limpa" = `absent`; exceção/fault = `error`.
+- Contrato HTTP segue 200 (o discriminador vai no corpo) → o `Promise.allSettled` do frontend continua tolerante.
+
+### 2.2 — `ensure_cliente` idempotente (substitui `criar_cliente`/`criar_cliente_afiacao` no caminho de ensure)
+- Uma action por conta: lookup por documento → `found`→retorna código; `absent`→cria; `error`→**não cria**, retorna `error`.
+- **Código de integração determinístico** `APP_<doc>` (não `APP_<doc>_<Date.now()>`) → retry/concorrência dedupe (Omie rejeita integração duplicada → tratar "duplicado" como `found`).
+- Idempotência validada: 2 ensures concorrentes do mesmo doc ⇒ no máximo 1 cliente.
+
+### 2.3 — Preço/parcela Colacor com o código certo
+- Hoje `buscar_precos_cliente`/`buscar_ultima_parcela` colacor recebem o código **oben** → resultado errado.
+- **Decisão:** entregar junto da action consolidada da Etapa 4 (`contexto_comercial_cliente`, que recebe `document`, resolve o código por-conta internamente e devolve preços+parcela numa `ListarPedidos`). Evita patchar as actions antigas 2×. Se precisar antes, fix mínimo = frontend sequencia (lookup colacor → preço/parcela com o código colacor), com custo de +1 hop serial no colacor.
+
+### 2.4 — Frontend: fiação tri-state
+- `getResult` para de colapsar erro/ausência; rastrear status por-conta.
+- Auto-cadastro (→ `ensure_cliente`) só em `absent`. Em `error`, marcar identidade-desconhecida da conta (consumido pela Etapa 3).
+
+## Testes (TDD, helper puro espelhado no edge — padrão do repo)
+- Classificador de resposta Omie: fault/exception→`error`; `clientes_cadastro:[]`→`absent`; com cliente→`found` (+ código). Casos: faultstring presente; HTTP ok com array vazio; null cru; retry esgotado.
+- `ensure`: found→não cria; absent→cria 1×; 2 concorrentes→1; error→0 criações.
+
+## Validação (sem terminal de backend; deploy+smoke via Lovable)
+- Bloquear request do `omie-sync` (DevTools): lookup deve voltar `status:'error'`, **zero** criação.
+- Cliente novo de verdade: exatamente 1 criação; re-selecionar não cria 2º.
+- Erro transitório simulado no Colacor: nenhuma duplicata.
+
+## Sequência de deploy (founder)
+1. Edge `omie-vendas-sync` + `omie-sync` (verbatim da main) via chat do Lovable.
+2. Smoke dos 3 casos acima no preview.
+3. Só então a Etapa 3 (submit fail-closed) pode assumir identidade confiável.
+
+## Aberto p/ o Codex challenge
+- `callOmieVendasApi` lançar em erro quebra outros callers que hoje toleram `null`? (auditar os consumidores antes).
+- `ensure_cliente` deve viver nas 2 edges (oben/colacor em omie-vendas-sync; afiação em omie-sync) ou unificar? (Deno não compartilha helper entre edges → espelho verbatim).
+- Tratar "integração duplicada" do Omie como `found` exige re-consultar pra pegar o código — custo aceitável?

--- a/docs/superpowers/specs/2026-06-06-preco-realtime-selectCustomer-design.md
+++ b/docs/superpowers/specs/2026-06-06-preco-realtime-selectCustomer-design.md
@@ -1,0 +1,64 @@
+# Preço em tempo real lento na seleção de cliente (`/sales/new`) — diagnóstico + plano faseado
+
+**Data:** 2026-06-06 · **Status:** Etapa 1 entregue (frontend); Etapas 2-4 aguardando aval do founder.
+**Origem:** founder reportou "a atualização de preço em tempo real está demorando muito" ao selecionar cliente no Novo Pedido. **2 consults Codex** (gpt-5.5 xhigh) — direção confirmada e vários bugs money-path descobertos junto.
+
+## Sintoma
+Ao selecionar o cliente, os produtos só trocam do preço-tabela para o "Preço cliente" depois de ~2-4s. O badge é só `prices[product.omie_codigo_produto]` ([ProductItemForm.tsx:60](../../../src/components/unified-order/ProductItemForm.tsx:60)) — render instantâneo. Toda a latência é a cadeia de fetch em `selectCustomer` ([useCustomerSelection.ts](../../../src/hooks/unifiedOrder/useCustomerSelection.ts)).
+
+## Causa-raiz (a lentidão é a ponta visível de um fluxo com bugs money-path)
+Cadeia original, **toda em série**, com o preço aplicado só no fim:
+1. `await resolveLocalUserId` — 1 query DB.
+2. `await Promise.allSettled([7])` — 6 chamadas Omie + 1 DB, em paralelo, mas com **contenção por conta** (colacor dispara 3 ListarPedidos/ListarClientes simultâneos).
+3. `await autoCreateInMissingAccounts` ← **bloqueava o preço**. Quando o lookup de cliente falha (toast "Falharam: cliente Afiação"), o código por-conta fica `null` e o auto-cadastro dispara um **WRITE no Omie** (~2s) — no caminho crítico do badge.
+4. `await resolveLocalPricesByOmieCode` — 1 query DB.
+5. `setCustomerPricesOben/Colacor` ← preço aparece.
+6. (depois de tudo) `validar_vendedor` — spinner "Validando nos 3 Omies", até 9 chamadas Omie.
+
+### Bugs money-path achados junto (Codex)
+- **Preço Colacor com código ERRADO:** `buscar_precos_cliente`/`buscar_ultima_parcela` para `account:'colacor'` recebem `cust.codigo_cliente` (código **oben**). Código de cliente é por-conta → preço/parcela Colacor saem errados/vazios. ([useCustomerSelection.ts:408,414](../../../src/hooks/unifiedOrder/useCustomerSelection.ts:408))
+- **Chamada `ListarPedidos` duplicada:** `buscar_precos_cliente` e `buscar_ultima_parcela` fazem a mesma chamada Omie (mesmos params) — 4 quando 2 bastam; as duplicadas ao mesmo método podem acionar o **retry de 5-15s** do edge.
+- **Fan-out oculto:** a query react-query `customer-purchase-history` re-dispara quando `customerUserId` e o código Colacor mudam de key → até **5 ListarPedidos por conta** (`historico_produtos_cliente`), competindo com preço/parcela.
+- **Corrida A→B:** seleção não cancela a anterior; preços/`customerUserId` do cliente antigo não eram limpos → trocar de cliente podia misturar dados.
+- **Carrinho não re-precifica:** `useCart` captura `unit_price` e não atualiza quando o mapa chega ([useCart.ts:107](../../../src/hooks/unifiedOrder/useCart.ts:107)) → adicionar produto antes do preço resolver grava **preço-tabela no pedido**.
+- **Submit faz fallback cross-account:** `codigo_cliente_colacor || codigo_cliente` e `codigo_cliente_afiacao || codigo_cliente` ([submitOrder.ts:198,326](../../../src/services/orderSubmission/submitOrder.ts:198)) → pedido pode ir pro **cliente errado** no Omie.
+- **Duplicação de cliente:** no caminho Colacor, erro transitório do Omie vira `null` interpretado como "ausente" → `IncluirCliente` cria duplicado. (Na Afiação o risco é menor — o `catch` da criação não cria.)
+- **Estado de preço binário:** falha de preço Omie vira mapa vazio, indistinguível de "cliente sem histórico" — money-path precisa de `ready-empty` vs `error`.
+- `validar_vendedor` **não** deve começar no início (Codex corrigiu minha ideia): competiria com os lookups e poderia validar antes da criação (resultado stale). Se é gate, o submit deveria aguardá-lo (hoje não aguarda).
+- `codigo_cliente_integracao` usa `Date.now()` ([omie-vendas-sync:1526](../../../supabase/functions/omie-vendas-sync/index.ts:1526)) → não-idempotente.
+
+## Veredito do Codex (incorporado)
+Preço sai do caminho crítico, **mas identidade por-conta vira pré-condição do submit, nunca fallback.** Desenho final: **ensure especulativo em background + join obrigatório no submit, por conta usada** (não fire-and-forget puro). Lookup tri-state (`found`/`absent`/`error`): só cria quando ausência **confirmada**; em `error`, criação e submit **bloqueados**.
+
+## Plano faseado
+
+### ✅ Etapa 1 — Frontend, fail-soft (entregue; só Publish, zero efeito externo)
+Em `selectCustomer`:
+- Limpa estado do cliente anterior no início (preços/parcelas/`customerUserId`/ranking).
+- **Token de geração** (`selectionTokenRef`): conclusões de uma seleção vencida (A→B) são descartadas — guard `isStale()` antes de cada `setState`, no `finally` (só apaga loading se corrente) e antes do `validar_vendedor`.
+- **Preço/parcela publicados ANTES do `autoCreateInMissingAccounts`** → o badge aparece logo após os lookups; o WRITE de cadastro sai do caminho crítico (segue awaited por ora).
+- **Não** mexe no submit, **não** muda comportamento do auto-cadastro (ainda awaited), **não** bloqueia Add/Enviar. Risco money-path: nulo.
+
+### ⏳ Etapa 2 — Backend de integridade (precisa redeploy de edge via Lovable + aval)
+- Lookups tri-state (`found`/`absent`/`error`); corrigir transient-error→`null` na Colacor.
+- Action `ensure_cliente` **idempotente** (código de integração determinístico, não `Date.now()`).
+- Corrigir o **código Colacor** nas chamadas de preço/parcela (lookup primeiro, ou resolver por documento no edge).
+
+### ⏳ Etapa 3 — Background seguro + submit fail-closed (money-path; aval)
+- Auto-cadastro vira **promise retida** (não fire-and-forget); `ensure` só para contas no carrinho (itens Oben→oben, Colacor→colacor, serviços→afiação).
+- **Submit aguarda os ensures ANTES do primeiro insert** em `sales_orders` ([submitOrder.ts:70](../../../src/services/orderSubmission/submitOrder.ts:70)); **remover todos os fallbacks cross-account** (cliente e vendedor); bloquear envio com erro claro quando identidade por-conta indisponível.
+- Re-precificar itens **não-editados** do carrinho quando o mapa de preço chega (ou bloquear Add até resolver) — decisão de UX do balcão.
+
+### ⏳ Etapa 4 — Otimização (aval)
+- Action consolidada preço+parcela (mesma `ListarPedidos` retorna ambos) → 4 chamadas viram 2; **aditiva** (não muda contratos antigos → rollback só no frontend).
+- Suspender/deduplicar `historico_produtos_cliente` durante a seleção.
+
+## Validação (preview do Lovable — SPA não renderiza headless, §5 CLAUDE.md)
+- Slow 3G: cronometrar clique → 1º badge Oben (deve cair vs. hoje).
+- Selecionar A, trocar rápido para B: nenhum estado final pode conter dados de A.
+- Adicionar produto logo após selecionar: receber o preço correto (ou estar bloqueado).
+- (Etapa 3) bloquear request `omie-sync`: pedido com Afiação deve falhar ANTES de qualquer insert; lookup com erro → zero criação e submit bloqueado; cliente ausente → exatamente 1 criação.
+
+## Não-objetivos / decisões em aberto (founder)
+- Bloquear o botão Add enquanto o preço não resolve = decisão de UX do operador de balcão (Codex recomenda; alternativa menos intrusiva = re-precificar item não-editado).
+- Etapas 2-4 mexem em writes no Omie e exigem o ritual de deploy do Lovable → não tocadas sem aval.

--- a/src/hooks/unifiedOrder/useCustomerSelection.ts
+++ b/src/hooks/unifiedOrder/useCustomerSelection.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
 import { toast } from 'sonner';
@@ -58,6 +58,11 @@ export function useCustomerSelection({
   reloadPriceHistory,
 }: UseCustomerSelectionArgs = {}) {
   const queryClient = useQueryClient();
+
+  /* Token de geração: descarta conclusões de uma seleção antiga quando o
+     usuário troca de cliente no meio (corrida A→B). Cada selectCustomer
+     incrementa o token; awaits que voltam com token vencido não setam estado. */
+  const selectionTokenRef = useRef(0);
 
   /* ─── State ─── */
   const [customerSearch, setCustomerSearch] = useState('');
@@ -362,16 +367,31 @@ export function useCustomerSelection({
   /* ─── Public actions ─── */
 
   const selectCustomer = useCallback(async (cust: OmieCustomer) => {
+    // Token desta seleção. Se o usuário trocar de cliente no meio, conclusões
+    // atrasadas desta chamada são descartadas (não sobrescrevem o cliente novo).
+    const myToken = ++selectionTokenRef.current;
+    const isStale = () => selectionTokenRef.current !== myToken;
+
     setLoadingCustomer(true);
     setCustomerSearch('');
     setCustomers([]);
     setVendedorDivergencias([]);
     setSelectedAddress('');
     setRequiresPo(false);
+    // Limpa estado do cliente ANTERIOR — não deve aparecer preço/parcela/vínculo
+    // do cliente antigo enquanto os dados do novo carregam.
+    setCustomerUserId(null);
+    setCustomerPricesOben({});
+    setCustomerPricesColacor({});
+    setSelectedParcelaOben('999');
+    setSelectedParcelaColacor('999');
+    setCustomerParcelaRankingOben([]);
+    setCustomerParcelaRankingColacor([]);
     try {
       setSelectedCustomer(cust);
 
       const localUserId = await resolveLocalUserId(cust);
+      if (isStale()) return;
 
       if (localUserId) {
         setCustomerUserId(localUserId);
@@ -408,6 +428,7 @@ export function useCustomerSelection({
             })
           : Promise.resolve({ data: null }),
       ]);
+      if (isStale()) return;
 
       const labels = [
         'preços Oben',
@@ -475,30 +496,11 @@ export function useCustomerSelection({
         cust.codigo_vendedor_afiacao = afiacaoClientResult.data.codigo_vendedor || null;
       }
 
-      await autoCreateInMissingAccounts(cust);
-
-      setSelectedCustomer({ ...cust });
-
-      // Save customer segment/tags to DB in background
-      if (cust.codigo_cliente && (cust.tags?.length || cust.atividade)) {
-        supabase.functions.invoke('omie-vendas-sync', {
-          body: {
-            action: 'salvar_segmento_cliente',
-            codigo_cliente: cust.codigo_cliente,
-            account: 'oben',
-            tags: cust.tags || [],
-            atividade: cust.atividade || '',
-          },
-        }).catch(() => {});
-      }
-
-      // Purchase history (local + Omie) é carregado pelo useQuery acima.
-      // Ao atualizar selectedCustomer com codigo_cliente_colacor preenchido pelo
-      // autoCreateInMissingAccounts, a query refaz o fetch automaticamente.
-
-
-      // Merge local "last-practiced" prices into Omie pricing maps
+      // ── Publica preços/parcelas ANTES do auto-cadastro ──
+      // O badge "Preço cliente" depende só destes dados; não deve esperar o WRITE
+      // de criação de cliente no Omie (que antes bloqueava o preço no caminho crítico).
       const localPricesByOmie = await resolveLocalPricesByOmieCode(localPriceResult.data || null);
+      if (isStale()) return;
 
       const mergedOben: Record<number, number> = { ...localPricesByOmie };
       if (priceOben.data?.precos) {
@@ -520,19 +522,46 @@ export function useCustomerSelection({
       if (parcelaOben.data?.parcela_ranking) setCustomerParcelaRankingOben(parcelaOben.data.parcela_ranking.map((r: ParcelaRankingItem) => r.codigo));
       if (parcelaColacor.data?.ultima_parcela) setSelectedParcelaColacor(parcelaColacor.data.ultima_parcela);
       if (parcelaColacor.data?.parcela_ranking) setCustomerParcelaRankingColacor(parcelaColacor.data.parcela_ranking.map((r: ParcelaRankingItem) => r.codigo));
+
+      // Reflete os códigos por-conta já resolvidos pelos lookups (preço já visível).
+      setSelectedCustomer({ ...cust });
+
+      // Save customer segment/tags to DB in background (fire-and-forget)
+      if (cust.codigo_cliente && (cust.tags?.length || cust.atividade)) {
+        supabase.functions.invoke('omie-vendas-sync', {
+          body: {
+            action: 'salvar_segmento_cliente',
+            codigo_cliente: cust.codigo_cliente,
+            account: 'oben',
+            tags: cust.tags || [],
+            atividade: cust.atividade || '',
+          },
+        }).catch(() => {});
+      }
+
+      // Auto-cadastro nas contas faltantes roda DEPOIS do preço já visível.
+      // Mantido awaited por ora; a Etapa 2/3 (ver spec) troca por ensure idempotente
+      // + join no submit. Conclusão atrasada não sobrescreve um cliente novo (guard).
+      await autoCreateInMissingAccounts(cust);
+      if (isStale()) return;
+      // Reflete códigos recém-criados pelo auto-cadastro (purchase-history reage à key).
+      setSelectedCustomer({ ...cust });
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Erro desconhecido';
-      toast.error('Erro', { description: message });
+      if (!isStale()) toast.error('Erro', { description: message });
     } finally {
-      setLoadingCustomer(false);
+      // Só apaga o "Buscando…" se esta ainda é a seleção corrente.
+      if (!isStale()) setLoadingCustomer(false);
     }
 
+    if (isStale()) return;
     if (cust.cnpj_cpf) {
       setValidatingVendedor(true);
       try {
         const { data: validacao, error } = await supabase.functions.invoke('omie-cliente', {
           body: { action: 'validar_vendedor', cnpj_cpf: cust.cnpj_cpf },
         });
+        if (isStale()) return;
         if (!error && validacao && !validacao.consistente) {
           setVendedorDivergencias(validacao.divergencias || []);
         }
@@ -544,7 +573,7 @@ export function useCustomerSelection({
           error: err,
         });
       } finally {
-        setValidatingVendedor(false);
+        if (!isStale()) setValidatingVendedor(false);
       }
     }
   }, [
@@ -553,7 +582,13 @@ export function useCustomerSelection({
   ]);
 
   const clearCustomer = useCallback(() => {
+    // Invalida qualquer selectCustomer em voo: suas conclusões viram stale e não
+    // ressuscitam o cliente que estamos limpando. Como o finally da seleção pula
+    // o setLoadingCustomer(false) quando stale, zeramos os flags de loading aqui.
+    selectionTokenRef.current++;
     setSelectedCustomer(null);
+    setLoadingCustomer(false);
+    setValidatingVendedor(false);
     setCustomerUserId(null);
     setCustomerPricesOben({});
     setCustomerPricesColacor({});


### PR DESCRIPTION
## Problema
No Novo Pedido (`/sales/new`), ao selecionar o cliente o badge "Preço cliente" demorava ~2-4s pra aparecer. Toda a latência estava na cadeia serial de `selectCustomer` — e, no pior caso (lookup de cliente falhando, toast "Falharam: cliente Afiação"), o preço ficava preso atrás do **WRITE de auto-cadastro do cliente no Omie**.

## Etapa 1 — frontend, fail-soft (esta PR)
- **Preço/parcela publicados ANTES do `autoCreateInMissingAccounts`** → o badge aparece logo após os lookups; o auto-cadastro segue awaited, fora do caminho crítico.
- **Limpa estado do cliente anterior** no início da seleção (preço/parcela/vínculo não vazam pro novo cliente enquanto carrega) — corrige também associação errada de histórico que existia com `customerUserId` retido.
- **Token de geração** (`selectionTokenRef`): descarta conclusões de uma seleção vencida (corrida A→B) e invalida seleção em voo no `clearCustomer` ("Trocar" durante o load agora gruda).

Não toca `submitOrder` nem backend → **risco money-path nulo**.

## NÃO incluído (Etapas 2-4 — próximas PRs, com deploy de edge)
Diagnóstico do Codex achou bugs money-path no mesmo fluxo, fora do escopo desta etapa: preço Colacor consultado com código oben; carrinho não re-precifica; submit faz fallback cross-account; duplicação de cliente em erro transitório. Plano completo em [`docs/superpowers/specs/2026-06-06-preco-realtime-selectCustomer-design.md`](docs/superpowers/specs/2026-06-06-preco-realtime-selectCustomer-design.md).

## Verificação
`bun run typecheck` ✓ · `bun run test` 2643/2643 ✓ · `bun run build` ✓ · `bun lint` 0 errors.

## Deploy
Frontend: requer **Publish no Lovable** após o merge para o preview pegar o build novo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
