### PR TITLE
fix(reposição): reescreve aviso 'SKUs sem parâmetro' (não é falha do auto-apply)

### DIFF
--- a/src/components/reposicao/SmartAlertsSection.tsx
+++ b/src/components/reposicao/SmartAlertsSection.tsx
@@ -38,12 +38,15 @@ function useSmartAlerts(): SmartAlert[] {
   return useMemo(() => {
     const list: SmartAlert[] = [];
     if (skusSemParam > 0) {
+      // Informativo (não é falha do auto-apply): são SKUs sem histórico suficiente para o motor
+      // calcular parâmetro (em geral baixo giro / 1ª compra). O auto-apply gere os que TÊM dado;
+      // estes ficam sem número até terem venda — aja só nos "Candidatos a 1ª compra".
       list.push({
         id: "skus-sem-param",
-        level: "red",
-        message: `${skusSemParam} SKU(s) ativos sem parâmetro configurado`,
-        actionLabel: "Configurar",
-        onAction: () => navigate("/admin/reposicao/sessao/parametros"),
+        level: "yellow",
+        message: `${skusSemParam} SKU(s) sem histórico para cálculo automático (baixo giro / 1ª compra)`,
+        actionLabel: "Ver candidatos",
+        onAction: () => navigate("/admin/reposicao/sessao/parametros?tab=ajuste"),
       });
     }
     return list;


### PR DESCRIPTION
O founder leu **'164 SKUs ativos sem parâmetro configurado'** como o auto-apply falhando. São SKUs **sem histórico suficiente** p/ o motor calcular (baixo giro / 1ª compra) — o auto-apply gere os que TÊM dado.

- Mensagem mais clara: 'N SKU(s) sem histórico para cálculo automático (baixo giro / 1ª compra)'.
- Nível **red → yellow** (informativo, não crítico).
- Botão **'Ver candidatos'** → aba Ajuste manual.

Frontend (copy/nível). typecheck/lint/build verdes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)