### PR TITLE
feat(lente): Fase 2 — telas internas refletem o alvo + Dialer read-only

### DIFF
--- a/docs/superpowers/plans/2026-06-06-lente-fase-2-telas-internas.md
+++ b/docs/superpowers/plans/2026-06-06-lente-fase-2-telas-internas.md
@@ -377,7 +377,9 @@ git add src/components/call/CallDialerView.tsx src/components/call/WebRTCDialer.
 git commit -m "feat(lente): bloqueia o Dialer (WebRTC fura o write-guard) na lente"
 ```
 
-> **Verificação:** sem teste unitário automático (montar o `WebRTCCallContext`/JsSIP em jsdom é caro; `CallDialerView` exige muitos props de estado de chamada). O `isLensActive()` da fonte já é coberto pelos testes de `lens-write-guard`. QA manual no Chrome: na lente de uma Farmer, abrir uma tela com o Dialer → botão "Ligar" **disabled**; se forçado, o `onMakeCall` barra com toast e NÃO inicia a chamada.
+> **Verificação:** sem teste unitário automático (montar o `WebRTCCallContext`/JsSIP em jsdom é caro; `CallDialerView` exige muitos props de estado de chamada). O `isLensActive()` da fonte já é coberto pelos testes de `lens-write-guard`. QA manual no Chrome: na lente de uma Farmer, abrir uma tela com o Dialer → botão "Ligar" **disabled**; se forçado, o guard barra com toast e NÃO inicia a chamada.
+
+> ⚠️ **CORREÇÃO P1 do review final (commit `9b1288f5`):** o gate só no `WebRTCDialer.onMakeCall` (Steps 1-2) **era INCOMPLETO**. O review (opus) achou que `useCallBackend()` retorna WebRTC **incondicional** (a nota do CLAUDE.md sobre Nvoip default está stale) e que há **≥3 callsites** que iniciam ligação WebRTC SEM passar pelo `WebRTCDialer`: `AgendaTodayList` (no FarmerDashboardV2 → exposto no `/meu-dia` da Farmer pela própria Task 1!), `Telefonia` (`/telefonia`, sem gate algum) e `NewCallDialog`→`FarmerCalls`. **Fix:** guard na **FONTE** — `isLensActive()` no topo de `WebRTCCallContext.makeCall` (`:320`, a função única por onde `useWebRTCCall`/`useWebRTCCallContext` e portanto TODOS os callsites passam — `useWebRTCCall` é só `return useWebRTCCallContext()`) **+** `acceptIncoming` (`:447`, ligação ENTRANTE = P2). Isso torna os `disabled` dos Steps 1-2 cosméticos (UX) e fecha os 3 callsites + futuros. Verificado: não há SIP invite/call fora dessas 2 funções.
 
 ---
 
@@ -404,7 +406,7 @@ Run: `heavy bun run typecheck` (limpo) + `bun lint` (0 errors).
 - ✅ `/meu-dia` reflete o alvo → Task 1 (cascateia via `useMyCommercialRole`).
 - ✅ `FarmerCalls` `isHunter` reflete o alvo → Task 1 (mesmo hook).
 - ✅ CTAs de escrita dos dashboards da lente viram read-only → Task 2 (`AcaoOutcomeMenu` + `OutcomeMenu`; os demais cards de visita são read-only — só `<Link>`/toggle local; `MinhasTarefasCard`/`MixGapCard`/`RecorrentesHojeCard` JÁ gateiam).
-- ✅ Dialer / "Nova ligação" (WebRTC fura o write-guard) bloqueado na lente → Task 3 (botão `disabled` + barra na fonte com `isLensActive()`).
+- ✅ Dialer / "Nova ligação" (WebRTC fura o write-guard) bloqueado na lente → Task 3 (botões `disabled` em CallDialerView/WebRTCDialer) **+ correção P1 do review:** guard na FONTE em `WebRTCCallContext.makeCall`+`acceptIncoming` (`isLensActive()`) — cobre TODOS os callsites WebRTC (AgendaTodayList/Telefonia/FarmerCalls), não só o WebRTCDialer.
 
 **Placeholder scan:** sem TBD/TODO; todo step tem código exato.
 

--- a/src/components/call/CallDialerView.tsx
+++ b/src/components/call/CallDialerView.tsx
@@ -9,6 +9,7 @@ import {
 import { cn } from '@/lib/utils';
 import { motion, AnimatePresence } from 'framer-motion';
 import { formatBrPhone, normalizeBrPhone } from '@/lib/phone';
+import { useImpersonation } from '@/contexts/ImpersonationContext';
 
 export type CallDialerCallState =
   | 'idle' | 'connecting' | 'calling_origin' | 'calling_destination'
@@ -112,6 +113,7 @@ export function CallDialerView(props: CallDialerViewProps) {
     }
   }, [props.remoteStream]);
 
+  const { isImpersonating } = useImpersonation();
   const displayPhone = formatBrPhone(phoneNumber);
   const hasValidPhone = normalizeBrPhone(phoneNumber).length >= 10;
 
@@ -132,8 +134,8 @@ export function CallDialerView(props: CallDialerViewProps) {
         variant="ghost"
         className="h-8 w-8 text-status-success hover:bg-status-success-bg"
         onClick={() => onMakeCall(phoneNumber)}
-        disabled={!hasValidPhone}
-        title={hasValidPhone ? `Ligar para ${displayPhone}` : 'Telefone inválido'}
+        disabled={!hasValidPhone || isImpersonating}
+        title={isImpersonating ? 'Ligação indisponível em modo Ver como' : (hasValidPhone ? `Ligar para ${displayPhone}` : 'Telefone inválido')}
       >
         <Phone className="w-4 h-4" />
       </Button>
@@ -148,7 +150,8 @@ export function CallDialerView(props: CallDialerViewProps) {
         variant="outline"
         className="gap-1.5 text-xs h-8"
         onClick={() => onMakeCall(phoneNumber)}
-        disabled={!hasValidPhone}
+        disabled={!hasValidPhone || isImpersonating}
+        title={isImpersonating ? 'Ligação indisponível em modo Ver como' : undefined}
       >
         <Phone className="w-3.5 h-3.5" /> Ligar {hasValidPhone ? displayPhone : ''}
       </Button>

--- a/src/components/call/OutcomeMenu.tsx
+++ b/src/components/call/OutcomeMenu.tsx
@@ -10,6 +10,7 @@ import {
   AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle,
 } from '@/components/ui/alert-dialog';
 import { useRegistrarContato, useDesfazerContato } from '@/queries/useRegistrarContato';
+import { useImpersonation } from '@/contexts/ImpersonationContext';
 import type { OutcomeStatus } from '@/lib/route/route-outcome';
 
 const LABEL: Record<OutcomeStatus, string> = {
@@ -31,6 +32,7 @@ interface OutcomeMenuProps {
 export function OutcomeMenu({ customerUserId, customerName, dataRota, bucket, valor }: OutcomeMenuProps) {
   const reg = useRegistrarContato();
   const undo = useDesfazerContato();
+  const { isImpersonating } = useImpersonation();
   const [confirmOptOut, setConfirmOptOut] = useState(false);
 
   const registrar = async (status: OutcomeStatus) => {
@@ -56,7 +58,13 @@ export function OutcomeMenu({ customerUserId, customerName, dataRota, bucket, va
     <>
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
-          <Button variant="ghost" size="icon" className="h-8 w-8" title="Registrar resultado" disabled={reg.isPending}>
+          <Button
+          variant="ghost"
+          size="icon"
+          className="h-8 w-8"
+          title={isImpersonating ? 'Indisponível em modo Ver como' : 'Registrar resultado'}
+          disabled={reg.isPending || isImpersonating}
+        >
             <ClipboardCheck className="w-4 h-4" />
           </Button>
         </DropdownMenuTrigger>

--- a/src/components/call/WebRTCDialer.tsx
+++ b/src/components/call/WebRTCDialer.tsx
@@ -1,5 +1,6 @@
 import { useId } from 'react';
 import { toast } from 'sonner';
+import { isLensActive } from '@/lib/impersonation/lens-write-guard';
 import { useWebRTCCallContextOptional } from '@/contexts/WebRTCCallContext';
 import { CallDialerView, type CallDialerViewProps } from './CallDialerView';
 
@@ -37,6 +38,10 @@ export function WebRTCDialer(props: Props) {
       isFinished={!!owned && owned.isFinished}
       onMakeCall={() => {
         if (!ctx) return;
+        if (isLensActive()) {
+          toast.error('Ligação indisponível na lente (somente leitura). Saia da lente para ligar.');
+          return;
+        }
         // Não rouba uma chamada ativa de OUTRA linha (a sessão é única). Sem isso,
         // clicar outra linha transferia o card e tentava uma 2ª chamada concorrente.
         if (busy && !owned) {

--- a/src/components/fila/AcaoOutcomeMenu.tsx
+++ b/src/components/fila/AcaoOutcomeMenu.tsx
@@ -16,6 +16,7 @@ import {
 import { track } from '@/lib/analytics';
 import { useTarefaMutations } from '@/hooks/useTarefas';
 import { useMarkMixGapFeedback } from '@/hooks/useMarkMixGapFeedback';
+import { useImpersonation } from '@/contexts/ImpersonationContext';
 import { OutcomeMenu } from '@/components/call/OutcomeMenu';
 import type { AcaoSugerida } from '@/lib/fila/types';
 
@@ -33,6 +34,7 @@ interface Props {
 export function AcaoOutcomeMenu({ acao, onNaoUtilAgora }: Props) {
   const tarefas = useTarefaMutations();
   const markGap = useMarkMixGapFeedback();
+  const { isImpersonating } = useImpersonation();
   const p = acao.payload;
 
   const naoUtil = () => {
@@ -44,7 +46,13 @@ export function AcaoOutcomeMenu({ acao, onNaoUtilAgora }: Props) {
     return (
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
-          <Button variant="ghost" size="icon" className="h-8 w-8" title="Opções">
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8"
+            disabled={isImpersonating}
+            title={isImpersonating ? 'Indisponível em modo Ver como' : 'Opções'}
+          >
             <MoreHorizontal className="w-4 h-4" />
           </Button>
         </DropdownMenuTrigger>
@@ -96,7 +104,13 @@ export function AcaoOutcomeMenu({ acao, onNaoUtilAgora }: Props) {
     return (
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
-          <Button variant="ghost" size="icon" className="h-8 w-8" title="Opções">
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8"
+            disabled={isImpersonating}
+            title={isImpersonating ? 'Indisponível em modo Ver como' : 'Opções'}
+          >
             <MoreHorizontal className="w-4 h-4" />
           </Button>
         </DropdownMenuTrigger>

--- a/src/components/fila/__tests__/AcaoOutcomeMenu.test.tsx
+++ b/src/components/fila/__tests__/AcaoOutcomeMenu.test.tsx
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { AcaoOutcomeMenu } from '@/components/fila/AcaoOutcomeMenu';
+import type { AcaoSugerida } from '@/lib/fila/types';
+
+const impMock = vi.fn();
+vi.mock('@/contexts/ImpersonationContext', () => ({ useImpersonation: () => impMock() }));
+vi.mock('@/hooks/useTarefas', () => ({ useTarefaMutations: () => ({ concluir: vi.fn() }) }));
+vi.mock('@/hooks/useMarkMixGapFeedback', () => ({ useMarkMixGapFeedback: () => ({ mutate: vi.fn() }) }));
+vi.mock('@/lib/analytics', () => ({ track: vi.fn() }));
+
+const acaoTarefa = {
+  fonte: 'tarefa', dedupeKey: 'k1', clienteNome: 'Cliente X',
+  payload: { kind: 'tarefa', tarefaId: 't1' },
+} as unknown as AcaoSugerida;
+
+beforeEach(() => { vi.clearAllMocks(); });
+
+describe('AcaoOutcomeMenu — guard de lente', () => {
+  it('na lente: o trigger de opções fica disabled', () => {
+    impMock.mockReturnValue({ isImpersonating: true });
+    render(<AcaoOutcomeMenu acao={acaoTarefa} onNaoUtilAgora={vi.fn()} />);
+    expect(screen.getByTitle(/Ver como/i)).toBeDisabled();
+  });
+
+  it('fora da lente: o trigger de opções fica habilitado', () => {
+    impMock.mockReturnValue({ isImpersonating: false });
+    render(<AcaoOutcomeMenu acao={acaoTarefa} onNaoUtilAgora={vi.fn()} />);
+    expect(screen.getByTitle('Opções')).not.toBeDisabled();
+  });
+});

--- a/src/contexts/WebRTCCallContext.tsx
+++ b/src/contexts/WebRTCCallContext.tsx
@@ -14,6 +14,7 @@ import { resolveCustomerByPhone } from '@/lib/call-session/resolve-customer';
 import { buildSessionPayload } from '@/lib/call-session/build-session-payload';
 import { resolveCallParty, shouldAutoRecord } from '@/lib/call-log/recording-policy';
 import { logCallStart, logAnswered, logClosed, enrichCallLog, markRecorded } from '@/lib/call-log/record';
+import { isLensActive } from '@/lib/impersonation/lens-write-guard';
 
 export type WebRTCCallState =
   | 'idle' | 'connecting' | 'calling_origin' | 'calling_destination'
@@ -318,6 +319,10 @@ export function WebRTCCallProvider({ children }: ProviderProps) {
   }
 
   const makeCall = useCallback(async (phoneNumber: string, opts?: { forceRecord?: boolean }) => {
+    if (isLensActive()) {
+      toast.error('Ligação indisponível na lente (somente leitura). Saia da lente para ligar.');
+      return;
+    }
     setError(null);
     setCallDuration(0);
 
@@ -445,6 +450,10 @@ export function WebRTCCallProvider({ children }: ProviderProps) {
 
   // PR-INBOUND-CALLS: atende chamada pendente. Mesmo setup de áudio do makeCall (mic + preroll).
   const acceptIncoming = useCallback(async () => {
+    if (isLensActive()) {
+      toast.error('Atender chamada indisponível na lente (somente leitura).');
+      return;
+    }
     if (!incomingCall || !clientRef.current) return;
 
     // Reset refs de sessão (mesma lógica do makeCall pro persist funcionar)

--- a/src/hooks/__tests__/useMyCommercialRole.test.tsx
+++ b/src/hooks/__tests__/useMyCommercialRole.test.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import { useMyCommercialRole } from '@/hooks/useMyCommercialRole';
+
+const authMock = vi.fn();
+const impMock = vi.fn();
+const profileMock = vi.fn();
+const maybeSingleMock = vi.fn();
+
+vi.mock('@/contexts/AuthContext', () => ({ useAuth: () => authMock() }));
+vi.mock('@/contexts/ImpersonationContext', () => ({ useImpersonation: () => impMock() }));
+vi.mock('@/hooks/useImpersonatedAccessProfile', () => ({ useImpersonatedAccessProfile: () => profileMock() }));
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: { from: () => ({ select: () => ({ eq: () => ({ maybeSingle: () => maybeSingleMock() }) }) }) },
+}));
+
+function wrapper({ children }: { children: ReactNode }) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  authMock.mockReturnValue({ user: { id: 'master-1' } });
+  impMock.mockReturnValue({ isImpersonating: false });
+  profileMock.mockReturnValue({ data: null, isLoading: false });
+  maybeSingleMock.mockResolvedValue({ data: { commercial_role: 'master' } });
+});
+
+describe('useMyCommercialRole', () => {
+  it('sem lente: retorna o role real consultado', async () => {
+    const { result } = renderHook(() => useMyCommercialRole(), { wrapper });
+    await waitFor(() => expect(result.current.data).toBe('master'));
+  });
+
+  it('na lente: retorna o commercial_role do ALVO sem consultar o do master', async () => {
+    impMock.mockReturnValue({ isImpersonating: true });
+    profileMock.mockReturnValue({ data: { commercialRole: 'farmer' }, isLoading: false });
+    const { result } = renderHook(() => useMyCommercialRole(), { wrapper });
+    expect(result.current.data).toBe('farmer');
+    expect(maybeSingleMock).not.toHaveBeenCalled();
+  });
+
+  it('na lente, perfil do alvo carregando: isLoading=true', () => {
+    impMock.mockReturnValue({ isImpersonating: true });
+    profileMock.mockReturnValue({ data: null, isLoading: true });
+    const { result } = renderHook(() => useMyCommercialRole(), { wrapper });
+    expect(result.current.isLoading).toBe(true);
+  });
+});

--- a/src/hooks/useMyCommercialRole.ts
+++ b/src/hooks/useMyCommercialRole.ts
@@ -1,14 +1,13 @@
 import { useQuery } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
+import { useImpersonation } from '@/contexts/ImpersonationContext';
+import { useImpersonatedAccessProfile } from '@/hooks/useImpersonatedAccessProfile';
 
 /**
- * Role comercial do user logado. PR-MULTIVENDOR-4-ROLES adiciona os 4 novos
- * (farmer/hunter/closer/master) ao lado dos legados (operacional/gerencial/etc).
- *
- * NB: existe um hook legado `useCommercialRole` com API diferente — mantido por
- * compat com 4 valores antigos. Este hook V2 retorna direct query React Query
- * + suporta todos os 8 valores.
+ * Role comercial do "eu efetivo": o user real, ou o ALVO na lente "Ver como".
+ * Os 4 novos (farmer/hunter/closer/master) convivem com os legados.
+ * Read-only + display-only (escolhe dashboard em /meu-dia; isHunter em FarmerCalls).
  */
 export type MyCommercialRole =
   | 'farmer'
@@ -21,15 +20,19 @@ export type MyCommercialRole =
   | 'super_admin'
   | null;
 
-export function useMyCommercialRole() {
+export function useMyCommercialRole(): { data: MyCommercialRole; isLoading: boolean } {
   const { user } = useAuth();
-  return useQuery({
+  const { isImpersonating } = useImpersonation();
+  const { data: targetProfile, isLoading: profileLoading } = useImpersonatedAccessProfile();
+
+  // Sem lente: consulta o role do master. Na lente, `enabled:false` evita consultar
+  // o role do master (que renderizaria o dashboard ERRADO — o do master).
+  const realQuery = useQuery({
     queryKey: ['my-commercial-role', user?.id],
-    enabled: !!user,
+    enabled: !!user && !isImpersonating,
     staleTime: 60_000,
     queryFn: async (): Promise<MyCommercialRole> => {
       if (!user) return null;
-       
       const { data } = await supabase.from('commercial_roles')
         .select('commercial_role')
         .eq('user_id', user.id)
@@ -37,4 +40,15 @@ export function useMyCommercialRole() {
       return (data?.commercial_role ?? null) as MyCommercialRole;
     },
   });
+
+  // Na lente: role do ALVO. Vem do RPC master-only get_user_access_profile_for, que o
+  // useImpersonatedAccessProfile já buscou — sem query nova, sem depender de RLS de
+  // commercial_roles cross-user. É o mesmo perfil que alimenta o useDisplayAccess.
+  if (isImpersonating) {
+    return {
+      data: (targetProfile?.commercialRole ?? null) as MyCommercialRole,
+      isLoading: profileLoading,
+    };
+  }
+  return { data: realQuery.data ?? null, isLoading: realQuery.isLoading };
 }


### PR DESCRIPTION
## O quê (Fase 2 da lente "Ver como pessoa")

Continuação do #653 (Fase 1, já na main). Faz as **telas internas** que o alvo alcança refletirem o acesso/role do ALVO na lente, e fecha o último vetor de escrita externa (ligação).

- **T1 — `/meu-dia` reflete a Farmer** (`f61d4cef`): `useMyCommercialRole` virou lente-aware — na lente retorna o `commercial_role` do ALVO (via `useImpersonatedAccessProfile`, RPC master-only já buscado; `enabled:false` na query do master). Cascateia pros 2 consumidores display (`CommercialDashboard` → mostra o dashboard da Farmer; `FarmerCalls` → `isHunter` do alvo), que **não mudam** — herdam. `RequireCaca` (3º consumidor, gate) segue master-correto: autoriza por `isMaster` REAL.
- **T2 — CTAs de outcome read-only** (`e4650b39`): `AcaoOutcomeMenu` (concluir/markGap) + `OutcomeMenu` (rota; cobre também `/rota/ligacoes`) ficam `disabled` na lente. Padrão do `MinhasTarefasCard`.
- **T3 — Dialer bloqueado** (`5572237b` + `9b1288f5`): botões "Ligar" `disabled` na lente **e — correção P1 do review final — guard na FONTE** em `WebRTCCallContext.makeCall` + `acceptIncoming` (`isLensActive()`).

## Por que o guard na fonte (P1 do review)

O Dialer é **WebRTC** (JsSIP, não passa pelo Supabase → fura o write-guard). O review adversário (opus) achou que gatear só o `WebRTCDialer` era **incompleto**: `useCallBackend()` retorna WebRTC incondicional e há ≥3 callsites que iniciam ligação direto (`AgendaTodayList` — exposto no `/meu-dia` da Farmer pela própria T1 —, `Telefonia`, `NewCallDialog`/`FarmerCalls`). Como `useWebRTCCall` é só `return useWebRTCCallContext()`, **`makeCall` é a fonte única** por onde todos passam → guardar lá (+ `acceptIncoming` p/ ligação entrante) fecha todos + futuros. Os `disabled` de UI viram cosméticos. Verificado: não há SIP invite/call fora dessas 2 funções.

## Segurança / invariante

`useAuth()` segue 100% real (sessão/escrita/identidade/RLS do master). A lente é **master-only** (`isImpersonating` só é true pro master — `startImpersonation` é master-gated) → a mudança lente-aware do role **não concede acesso a não-master** em lugar nenhum. Sem migration, sem edge function.

## Test plan

- [x] `bun run typecheck` (strict) — limpo
- [x] `bun lint` — 0 errors
- [x] Testes das áreas tocadas verdes (useMyCommercialRole 3, AcaoOutcomeMenu 2, lens-write-guard 14, useDisplayAccess 7, guardrails) + suíte sem falhas
- [x] Review final (opus, fresh context) — achou P1 (WebRTC bypass) → corrigido na fonte → re-verificado
- [ ] Publish no Lovable + QA no Chrome: na lente de uma Farmer → `/meu-dia` mostra o dashboard dela; "Ligar"/atender bloqueados (toast); CTAs de outcome disabled; `/telefonia` e a fila não disparam ligação.

⚠️ **Nota:** a nota do CLAUDE.md sobre o Dialer default ser Nvoip está **stale** — `useCallBackend()` retorna WebRTC incondicional (`useCallBackend.ts:20`). Não corrigido aqui (doc do founder).

🤖 Generated with [Claude Code](https://claude.com/claude-code)