### PR TITLE
fix(pedido): submit fail-closed — preflight de identidade por-conta (Etapa 2a)

### DIFF
--- a/docs/superpowers/specs/2026-06-06-preco-realtime-selectCustomer-design.md
+++ b/docs/superpowers/specs/2026-06-06-preco-realtime-selectCustomer-design.md
@@ -1,6 +1,6 @@
 # Preço em tempo real lento na seleção de cliente (`/sales/new`) — diagnóstico + plano faseado
 
-**Data:** 2026-06-06 · **Status:** Etapa 1 entregue (frontend); Etapas 2-4 aguardando aval do founder.
+**Data:** 2026-06-06 · **Status:** Etapa 1 (PR #656) + Etapa 2a entregues (frontend, só Publish); Etapa 2b-4 (backend/edge) aguardando deploy + Codex.
 **Origem:** founder reportou "a atualização de preço em tempo real está demorando muito" ao selecionar cliente no Novo Pedido. **2 consults Codex** (gpt-5.5 xhigh) — direção confirmada e vários bugs money-path descobertos junto.
 
 ## Sintoma
@@ -39,14 +39,19 @@ Em `selectCustomer`:
 - **Preço/parcela publicados ANTES do `autoCreateInMissingAccounts`** → o badge aparece logo após os lookups; o WRITE de cadastro sai do caminho crítico (segue awaited por ora).
 - **Não** mexe no submit, **não** muda comportamento do auto-cadastro (ainda awaited), **não** bloqueia Add/Enviar. Risco money-path: nulo.
 
-### ⏳ Etapa 2 — Backend de integridade (precisa redeploy de edge via Lovable + aval)
-- Lookups tri-state (`found`/`absent`/`error`); corrigir transient-error→`null` na Colacor.
-- Action `ensure_cliente` **idempotente** (código de integração determinístico, não `Date.now()`).
-- Corrigir o **código Colacor** nas chamadas de preço/parcela (lookup primeiro, ou resolver por documento no edge).
+### ✅ Etapa 2a — Submit fail-closed (frontend; só Publish, sem deploy de edge)
+Antecipada da Etapa 3 por ser frontend-only e o maior ganho de integridade (acaba com pedido na conta errada). **Não depende do edge.**
+- **Preflight `missingAccountIdentities`** (helper puro TDD em `helpers.ts`): antes de QUALQUER insert, se uma conta COM itens não tem código de cliente próprio válido → bloqueia o envio **inteiro** com erro claro (`step:'validate_identity'`, surface em toast `'Erro ao criar pedido'`). Não envia pela metade num pedido multi-conta.
+- **Removido o fallback cross-account de CLIENTE** no POST Colacor e no staffContext Afiação (`|| customer.codigo_cliente`) — preflight garante presença, usa `!`.
+- **NÃO incluído (fica na 2b):** fallback de **vendedor** (`?? codigo_vendedor`) — exige checar se o `criarPedidoVenda` tolera vendedor nulo; risco de quebrar PV se removido às cegas.
 
-### ⏳ Etapa 3 — Background seguro + submit fail-closed (money-path; aval)
-- Auto-cadastro vira **promise retida** (não fire-and-forget); `ensure` só para contas no carrinho (itens Oben→oben, Colacor→colacor, serviços→afiação).
-- **Submit aguarda os ensures ANTES do primeiro insert** em `sales_orders` ([submitOrder.ts:70](../../../src/services/orderSubmission/submitOrder.ts:70)); **remover todos os fallbacks cross-account** (cliente e vendedor); bloquear envio com erro claro quando identidade por-conta indisponível.
+### ⏳ Etapa 2b — Backend de integridade (precisa redeploy de edge via Lovable + aval)
+- Lookups **tri-state** (`found`/`absent`/`error`) — fecha o buraco: `callOmieVendasApi` retorna `null` no transitório-esgotado ([omie-vendas-sync:249](../../../supabase/functions/omie-vendas-sync/index.ts:249)) e `buscar_cliente_por_documento` engole erro em `200/null` ([omie-sync:910](../../../supabase/functions/omie-sync/index.ts:910)) → erro vira "ausente" → duplica. Design opt-in `throwOnTransient` (default = comportamento atual → 26 callers intactos). Plano em [plans/2026-06-06-preco-realtime-etapa2-plan.md](../plans/2026-06-06-preco-realtime-etapa2-plan.md).
+- Action `ensure_cliente` **idempotente** (código de integração determinístico, não `Date.now()`); guard "só cria em `absent`".
+- Corrigir o **código Colacor** nas chamadas de preço/parcela + remover o fallback de **vendedor**.
+
+### ⏳ Etapa 3 — Background seguro (money-path; aval)
+- Auto-cadastro vira **promise retida** (não fire-and-forget); `ensure` só para contas no carrinho; submit **aguarda os ensures** (com o preflight da 2a já no lugar como rede).
 - Re-precificar itens **não-editados** do carrinho quando o mapa de preço chega (ou bloquear Add até resolver) — decisão de UX do balcão.
 
 ### ⏳ Etapa 4 — Otimização (aval)

--- a/src/services/orderSubmission/__tests__/helpers.test.ts
+++ b/src/services/orderSubmission/__tests__/helpers.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { missingAccountIdentities } from '../helpers';
+
+describe('missingAccountIdentities (preflight fail-closed)', () => {
+  it('todas as contas com itens têm código → vazio', () => {
+    expect(missingAccountIdentities({
+      hasOben: true, hasColacor: true, hasAfiacao: true,
+      codigoCliente: 100, codigoClienteColacor: 200, codigoClienteAfiacao: 300,
+    })).toEqual([]);
+  });
+
+  it('Colacor com itens sem código → Colacor faltando', () => {
+    expect(missingAccountIdentities({
+      hasOben: false, hasColacor: true, hasAfiacao: false,
+      codigoCliente: 100, codigoClienteColacor: null, codigoClienteAfiacao: null,
+    })).toEqual(['Colacor']);
+  });
+
+  it('Afiação com serviços sem código → Afiação faltando', () => {
+    expect(missingAccountIdentities({
+      hasOben: false, hasColacor: false, hasAfiacao: true,
+      codigoCliente: 100, codigoClienteColacor: null, codigoClienteAfiacao: undefined,
+    })).toEqual(['Afiação']);
+  });
+
+  it('Oben com itens sem código → Oben faltando', () => {
+    expect(missingAccountIdentities({
+      hasOben: true, hasColacor: false, hasAfiacao: false,
+      codigoCliente: null, codigoClienteColacor: null, codigoClienteAfiacao: null,
+    })).toEqual(['Oben']);
+  });
+
+  it('conta SEM itens não é checada mesmo sem código', () => {
+    // Só Oben tem itens; Colacor/Afiação sem código mas também sem itens.
+    expect(missingAccountIdentities({
+      hasOben: true, hasColacor: false, hasAfiacao: false,
+      codigoCliente: 100, codigoClienteColacor: null, codigoClienteAfiacao: null,
+    })).toEqual([]);
+  });
+
+  it('código 0 é inválido (não é código Omie real) → faltando', () => {
+    expect(missingAccountIdentities({
+      hasOben: false, hasColacor: true, hasAfiacao: false,
+      codigoCliente: 100, codigoClienteColacor: 0, codigoClienteAfiacao: null,
+    })).toEqual(['Colacor']);
+  });
+
+  it('multi-conta: Oben+Colacor com itens, só Colacor sem código → só Colacor', () => {
+    expect(missingAccountIdentities({
+      hasOben: true, hasColacor: true, hasAfiacao: false,
+      codigoCliente: 100, codigoClienteColacor: null, codigoClienteAfiacao: null,
+    })).toEqual(['Colacor']);
+  });
+
+  it('todas com itens e nenhuma com código → as três, na ordem', () => {
+    expect(missingAccountIdentities({
+      hasOben: true, hasColacor: true, hasAfiacao: true,
+      codigoCliente: null, codigoClienteColacor: null, codigoClienteAfiacao: null,
+    })).toEqual(['Oben', 'Colacor', 'Afiação']);
+  });
+});

--- a/src/services/orderSubmission/__tests__/submitOrder.test.ts
+++ b/src/services/orderSubmission/__tests__/submitOrder.test.ts
@@ -6,13 +6,19 @@ vi.mock('@/services/omieService', () => ({
   syncOrderToOmie: vi.fn().mockResolvedValue({ success: true, omie_os: { cNumOS: 'OS1' } }),
 }));
 vi.mock('../buildPrintData', () => ({ buildPrintData: vi.fn().mockReturnValue([]) }));
-vi.mock('../helpers', () => ({
-  formatCustomerAddress: vi.fn().mockReturnValue('Rua X, 1'),
-  resolveCustomerPhone: vi.fn().mockResolvedValue('11999999999'),
-  buildToolInfo: vi.fn().mockReturnValue(''),
-  getToolName: vi.fn().mockReturnValue('Tool'),
-  findParcelaDesc: vi.fn().mockReturnValue(''),
-}));
+// Mantém o `missingAccountIdentities` REAL (o preflight do submit roda com lógica
+// de verdade); só as funções de I/O/format são stubadas.
+vi.mock('../helpers', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../helpers')>();
+  return {
+    ...actual,
+    formatCustomerAddress: vi.fn().mockReturnValue('Rua X, 1'),
+    resolveCustomerPhone: vi.fn().mockResolvedValue('11999999999'),
+    buildToolInfo: vi.fn().mockReturnValue(''),
+    getToolName: vi.fn().mockReturnValue('Tool'),
+    findParcelaDesc: vi.fn().mockReturnValue(''),
+  };
+});
 vi.mock('@/lib/logger', () => ({
   logger: { info: vi.fn(), error: vi.fn(), critical: vi.fn(), warn: vi.fn() },
 }));
@@ -99,6 +105,23 @@ describe('submitOrder', () => {
     expect(r.success).toBe(false);
     expect(r.errors[0]).toEqual({ step: 'validate', message: 'Carrinho vazio' });
     expect(insert).not.toHaveBeenCalled();
+  });
+
+  it('Oben+Colacor com itens mas SEM código Colacor → fail-closed: bloqueia TUDO antes de qualquer insert', async () => {
+    const { client, insert, invoke } = makeSupabase();
+    const custSemColacor = { ...customer, codigo_cliente_colacor: null } as OmieCustomer;
+    const r = await submitOrder(makeParams({
+      supabase: client,
+      customer: custSemColacor,
+      cart: { obenProductItems: [obenItem()], colacorProductItems: [colacorAcabado()], serviceItems: [] },
+      subtotals: { oben: 20, colacor: 50, service: 0 },
+    }));
+    expect(r.success).toBe(false);
+    expect(r.errors[0].step).toBe('validate_identity');
+    expect(r.errors[0].message).toContain('Colacor');
+    // Invariante: não insere NADA (nem o Oben válido) nem chama o Omie — não enviar pela metade.
+    expect(insert).not.toHaveBeenCalled();
+    expect(invoke).not.toHaveBeenCalled();
   });
 
   it('Oben: insert ok + Omie ok → success + PV no results', async () => {

--- a/src/services/orderSubmission/helpers.ts
+++ b/src/services/orderSubmission/helpers.ts
@@ -11,6 +11,31 @@ import type { SubmitClient } from './types';
 export const getToolName = (t: UserTool): string =>
   t.generated_name || t.custom_name || t.tool_categories?.name || 'Ferramenta';
 
+/** Entrada do preflight de identidade por-conta do submit. */
+export interface AccountIdentityCheck {
+  hasOben: boolean;
+  hasColacor: boolean;
+  hasAfiacao: boolean;
+  codigoCliente?: number | null;
+  codigoClienteColacor?: number | null;
+  codigoClienteAfiacao?: number | null;
+}
+
+/**
+ * Preflight fail-closed: nomes das contas que TÊM itens mas NÃO têm um código de
+ * cliente válido próprio (cada conta Omie tem código de cliente distinto — nunca
+ * cair no código de outra conta). Vazio = todas as contas usadas têm identidade.
+ * Código <= 0 ou ausente é inválido (não é código Omie real).
+ */
+export function missingAccountIdentities(input: AccountIdentityCheck): string[] {
+  const valid = (c?: number | null): boolean => typeof c === 'number' && c > 0;
+  const missing: string[] = [];
+  if (input.hasOben && !valid(input.codigoCliente)) missing.push('Oben');
+  if (input.hasColacor && !valid(input.codigoClienteColacor)) missing.push('Colacor');
+  if (input.hasAfiacao && !valid(input.codigoClienteAfiacao)) missing.push('Afiação');
+  return missing;
+}
+
 export function findParcelaDesc(codigo: string, formas: FormaPagamento[]): string {
   const found = formas.find(f => f.codigo === codigo);
   return found?.descricao || codigo;

--- a/src/services/orderSubmission/submitOrder.ts
+++ b/src/services/orderSubmission/submitOrder.ts
@@ -12,6 +12,7 @@ import {
   buildToolInfo,
   formatCustomerAddress,
   getToolName,
+  missingAccountIdentities,
   resolveCustomerPhone,
 } from './helpers';
 import { buildPrintData } from './buildPrintData';
@@ -41,6 +42,33 @@ export async function submitOrder(params: SubmitOrderParams): Promise<SubmitOrde
       printDataList: [],
       lastOrderData: null,
       errors: [{ step: 'validate', message: 'Carrinho vazio' }],
+    };
+  }
+
+  // ── Preflight de identidade por-conta (fail-closed) ──
+  // Cada conta Omie tem código de cliente próprio; NUNCA enviar o código de uma
+  // conta para outra (fallback antigo `|| codigo_cliente` registrava o pedido no
+  // cliente errado). Se uma conta COM itens não tem identidade resolvida, bloqueia
+  // o envio INTEIRO antes de qualquer insert — não enviar pela metade num pedido
+  // multi-conta nem registrar na conta errada.
+  const missingIdentities = missingAccountIdentities({
+    hasOben: obenProductItems.length > 0,
+    hasColacor: colacorProductItems.length > 0,
+    hasAfiacao: serviceItems.length > 0,
+    codigoCliente: customer.codigo_cliente,
+    codigoClienteColacor: customer.codigo_cliente_colacor,
+    codigoClienteAfiacao: customer.codigo_cliente_afiacao,
+  });
+  if (missingIdentities.length > 0) {
+    return {
+      success: false,
+      results: [],
+      printDataList: [],
+      lastOrderData: null,
+      errors: [{
+        step: 'validate_identity',
+        message: `Cliente sem identidade na(s) conta(s): ${missingIdentities.join(', ')}. Selecione o cliente novamente (ou aguarde o cadastro concluir) e tente de novo — o pedido NÃO foi enviado, para não registrar na conta errada.`,
+      }],
     };
   }
 
@@ -195,7 +223,8 @@ export async function submitOrder(params: SubmitOrderParams): Promise<SubmitOrde
       const { data: omieResult, error: omieError } = await supabase.functions.invoke('omie-vendas-sync', {
         body: {
           action: 'criar_pedido', account: 'colacor', sales_order_id: salesOrderId,
-          codigo_cliente: customer.codigo_cliente_colacor || customer.codigo_cliente,
+          // Identidade Colacor garantida pelo preflight (fail-closed); NUNCA cair no código Oben.
+          codigo_cliente: customer.codigo_cliente_colacor!,
           codigo_vendedor: customer.codigo_vendedor_colacor ?? customer.codigo_vendedor,
           items: colacorProductItems.map(c => ({
             omie_codigo_produto: c.product.omie_codigo_produto,
@@ -323,7 +352,8 @@ export async function submitOrder(params: SubmitOrderParams): Promise<SubmitOrde
         document: customer.cnpj_cpf || undefined,
       };
       const staffContext = {
-        customerOmieCode: customer.codigo_cliente_afiacao || customer.codigo_cliente,
+        // Identidade Afiação garantida pelo preflight (fail-closed); NUNCA cair no código Oben.
+        customerOmieCode: customer.codigo_cliente_afiacao!,
         customerUserId: customerUserId || null,
         customerCodigoVendedor: customer.codigo_vendedor_afiacao ?? customer.codigo_vendedor ?? null,
       };


### PR DESCRIPTION
## Problema (money-path)
Cada conta Omie (oben/colacor/afiação) tem **código de cliente próprio**. O `submitOrder` fazia `customer.codigo_cliente_colacor || customer.codigo_cliente` (e idem afiação) → quando a identidade por-conta não estava resolvida, o pedido era registrado com o **código Oben na conta errada** (cliente/CNPJ errado no PV/OS). Achado pelo Codex no diagnóstico do fluxo de preço.

## Etapa 2a — submit fail-closed (frontend, só Publish)
- **`missingAccountIdentities`** (helper puro TDD): contas COM itens que não têm código de cliente próprio válido.
- **Preflight** em `submitOrder` antes de QUALQUER insert: falta identidade de conta com itens → bloqueia o envio **inteiro** (não envia pela metade num multi-conta), `step:'validate_identity'` → toast `'Erro ao criar pedido'` com mensagem acionável ("Selecione o cliente novamente…").
- **Removido o fallback cross-account de CLIENTE** (POST Colacor + staffContext Afiação).

## NÃO incluído (Etapa 2b — edge, próximo PR)
Fallback de **vendedor** (`?? codigo_vendedor` — precisa checar se `criarPedidoVenda` tolera vendedor nulo), **tri-state** nos lookups (`callOmieVendasApi` retorna `null` no transitório-esgotado; `buscar_cliente_por_documento` engole erro em `200/null`) e `ensure_cliente` idempotente. `submitQuote` intacto (não envia ao Omie).

## ⚠️ Mudança de comportamento
O envio agora **bloqueia** quando a identidade por-conta de uma conta com itens não resolveu (antes ia **silenciosamente pra conta errada**). É o comportamento correto; o operador re-seleciona o cliente e reenvia. Caso raro (só quando lookup+auto-cadastro falham, ex. Omie transitório).

## Verificação
`typecheck` ✓ · `test` 2675/2675 (helper 8 + fail-closed multi-conta novo) ✓ · `build` ✓ · `lint` 0.

## Gate
**Money-path → aguardando challenge do Codex no diff antes do merge** (cota reseta ~12:56). Depois do merge: **Publish no Lovable**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
