### PR TITLE
fix(pedido): toast de carga parcial → warning + hint de preço carregando

### DIFF
--- a/src/components/unified-order/ProductItemForm.tsx
+++ b/src/components/unified-order/ProductItemForm.tsx
@@ -19,11 +19,16 @@ interface ProductItemFormProps {
   productItems: ProductCartItem[];
   onAddProduct: (p: Product, qty?: number) => void;
   customerPurchaseHistory?: Record<string, string>;
+  /** True enquanto os preços do contrato do cliente ainda estão carregando
+   *  (logo após selecionar o cliente). Mostra que os valores exibidos são de
+   *  tabela e ainda vão atualizar — evita a percepção de "travado". */
+  customerPricesLoading?: boolean;
 }
 
 export function ProductItemForm({
   title, products, prices, loading, productSearch, onSearchChange,
   productItems, onAddProduct, customerPurchaseHistory = {},
+  customerPricesLoading = false,
 }: ProductItemFormProps) {
   const [quantities, setQuantities] = useState<Record<string, number>>({});
 
@@ -51,6 +56,11 @@ export function ProductItemForm({
           <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
           <Input placeholder="Buscar produto..." value={productSearch} onChange={e => onSearchChange(e.target.value)} className="pl-9 h-9" />
         </div>
+        {customerPricesLoading && (
+          <div className="flex items-center gap-1.5 mb-2 text-[11px] text-muted-foreground" role="status">
+            <Loader2 className="w-3 h-3 animate-spin" /> Carregando preços do contrato…
+          </div>
+        )}
         {loading ? (
           <Loader2 className="w-5 h-5 animate-spin mx-auto" />
         ) : (

--- a/src/hooks/unifiedOrder/useCustomerSelection.ts
+++ b/src/hooks/unifiedOrder/useCustomerSelection.ts
@@ -482,7 +482,8 @@ export function useCustomerSelection({
       }>(6);
 
       if (failedParts.length > 0) {
-        toast.success('Alguns dados do cliente não foram carregados', {
+        // É um aviso (carga parcial), não um sucesso — não usar o ✓ verde de success.
+        toast.warning('Alguns dados do cliente não foram carregados', {
           description: `Falharam: ${failedParts.join(', ')}. Você pode continuar, mas preços/parcelas podem não refletir o contrato.`,
         });
       }

--- a/src/pages/UnifiedOrder.tsx
+++ b/src/pages/UnifiedOrder.tsx
@@ -234,13 +234,13 @@ const UnifiedOrder = () => {
                     <ProductItemForm title="Produtos Oben" products={h.filteredObenProducts} prices={h.customerPricesOben}
                       loading={h.loadingObenProducts} productSearch={h.productSearch} onSearchChange={h.setProductSearch}
                       productItems={h.productItems} onAddProduct={h.addProductToCart}
-                      customerPurchaseHistory={h.customerPurchaseHistory} />
+                      customerPurchaseHistory={h.customerPurchaseHistory} customerPricesLoading={h.loadingCustomer} />
                   </TabsContent>
                   <TabsContent value="colacor">
                     <ProductItemForm title="Produtos Colacor" products={h.filteredColacorProducts} prices={h.customerPricesColacor}
                       loading={h.loadingColacorProducts} productSearch={h.productSearch} onSearchChange={h.setProductSearch}
                       productItems={h.productItems} onAddProduct={h.addProductToCart}
-                      customerPurchaseHistory={h.customerPurchaseHistory} />
+                      customerPurchaseHistory={h.customerPurchaseHistory} customerPricesLoading={h.loadingCustomer} />
                   </TabsContent>
                   <TabsContent value="services">
                     <ServiceItemForm


### PR DESCRIPTION
## Dois polimentos não-money-path no Novo Pedido (complementam a Etapa 1)

1. **Toast honesto:** o aviso "Alguns dados do cliente não foram carregados" usava `toast.success` (✓ verde numa mensagem de **falha** — visível no print do founder). Vira `toast.warning` (é carga parcial, "você pode continuar").
2. **Indicador de carregamento de preço:** `ProductItemForm` mostra um hint sutil **"Carregando preços do contrato…"** enquanto `loadingCustomer` é true (logo após selecionar o cliente). Deixa explícito que os valores exibidos são de tabela e ainda vão atualizar — ataca a percepção de "travado" durante o carregamento do preço-cliente (a própria dor reportada).

Puro visual — **não muda nenhum preço nem o envio**. `customerPricesLoading` é prop opcional (default false) → backward-compatible.

## Verificação
`typecheck` ✓ · `test` 2671/2671 ✓ · `build` ✓ · `lint` 0 errors.

## Deploy
Frontend — requer **Publish no Lovable** após o merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
