### PR TITLE
fix(reposição): quantidade de compra sempre inteira (ceil) — fim do 3,99996

### DIFF
--- a/db/test-qtde-inteira.sh
+++ b/db/test-qtde-inteira.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+# Teste PG17 — ceil em qtde_sugerida/qtde_final na RPC gerar_pedidos_sugeridos_ciclo
+# (migration 20260606150000_reposicao_qtde_inteira.sql).
+#
+# Prova, sobre dados semeados com poeira decimal no estoque (tinta em litros):
+#  - ANTES (20260606120000, account-aware SEM ceil): qtde_sugerida/qtde_final FRACIONÁRIAS
+#    (9,99996 / 10,6 / 0,00004 / mínimo forçado fracionário) → o bug existe (teste significativo).
+#  - DEPOIS (20260606150000, +ceil): toda qtde_sugerida e qtde_final é INTEIRA (= ceil do antes).
+#  - O CONJUNTO de itens é IDÊNTICO antes/depois (ceil(x)>0 ⟺ x>0 — só o VALOR muda). [Q5]
+#  - valor_linha = qtde_final(ceil) × cmc; valor_total = Σ; retorno da RPC == persistido.
+#  - GUARD anti-drift: a função DEPOIS preserva TODAS as guardas da base (fail-closed tipo_produto,
+#    account-aware, '04', 405/450ML, fornecedor NOT NULL, gate de necessidade <= ponto_pedido).
+# Base: db/verify-snapshot-replay.sh + db/test-rpc-account-aware.sh. Pré-req: brew install postgresql@17 pgvector.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PGVER=17
+PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+PORT=5436
+DATA="$(mktemp -d /tmp/pgtest-qtdeint.XXXXXX)/data"
+export LC_ALL=C LANG=C
+
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente: brew install postgresql@${PGVER} pgvector"; exit 1; }
+
+CELLAR="$(brew --prefix postgresql@${PGVER})"
+cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
+mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
+cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
+
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+trap cleanup EXIT
+
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l /tmp/pg-qtdeint.log -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres qtdeint_verify
+P() { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d qtdeint_verify "$@"; }
+
+RR="$(mktemp /tmp/snap-qtdeint.XXXXXX.sql)"
+sed -E 's/^(CREATE SCHEMA public;)/-- \1/' "$REPO_ROOT/supabase/schema-snapshot.sql" \
+  | grep -vE '^\\(un)?restrict ' > "$RR"
+
+echo "→ stubs + prelude + snapshot…"
+P -v ON_ERROR_STOP=1 -q -f "$REPO_ROOT/db/stubs-supabase.sql"
+P -v ON_ERROR_STOP=1 -q -f "$REPO_ROOT/supabase/schema-extensions-prelude.sql"
+P --single-transaction -v ON_ERROR_STOP=1 -q -f "$RR"
+rm -f "$RR"
+
+echo "→ foundation (omie_products.tipo_produto — stale no snapshot)…"
+P -v ON_ERROR_STOP=1 -q -c "ALTER TABLE public.omie_products ADD COLUMN IF NOT EXISTS tipo_produto text;"
+
+echo "→ base coluna minimo_forcado_manual: 20260604190000…"
+P -v ON_ERROR_STOP=1 -q -f "$REPO_ROOT/supabase/migrations/20260604190000_reposicao_minimo_forcado.sql" >/dev/null
+
+echo "→ ANTES: 20260606120000 (account-aware, SEM ceil)…"
+P -v ON_ERROR_STOP=1 -q -f "$REPO_ROOT/supabase/migrations/20260606120000_reposicao_rpc_account_aware.sql" >/dev/null
+
+echo "→ seed: estoque com poeira decimal (tinta em litros). pp=100, emax=100 → natural = 100 − estoque…"
+P -v ON_ERROR_STOP=1 -q <<'SQL'
+-- omie_products: account lowercase, ativo, tipo '00' (comprável), familia neutra. codigo+descricao NOT NULL.
+INSERT INTO public.omie_products (omie_codigo_produto, codigo, descricao, account, ativo, familia, tipo_produto) VALUES
+  (8001,'8001','POEIRA 9,99996','oben',true,'F1','00'),   -- estoque 90,00004 → natural 9,99996
+  (8002,'8002','FRACAO 10,6','oben',true,'F1','00'),       -- estoque 89,4     → natural 10,6
+  (8003,'8003','MIN-FORCADO INT','oben',true,'F1','00'),   -- estoque 95,5 (nat 4,5), min 8     → final 8
+  (8004,'8004','MIN-FORCADO FRAC','oben',true,'F1','00'),  -- estoque 95,5 (nat 4,5), min 7,5   → final ceil 8
+  (8005,'8005','INTEIRO EXATO','oben',true,'F1','00'),      -- estoque 90 exato → natural 10 (ceil no-op)
+  (8006,'8006','LIMIAR ZERO','oben',true,'F1','00'),        -- estoque 100 = pp, natural 0 → EXCLUÍDO (ambos)
+  (8007,'8007','POEIRA POSITIVA','oben',true,'F1','00');    -- estoque 99,99996 → natural 0,00004 → INCLUÍDO ambos
+
+INSERT INTO public.sku_parametros
+  (empresa, sku_codigo_omie, sku_descricao, fornecedor_nome, ponto_pedido, estoque_maximo,
+   habilitado_reposicao_automatica, tipo_reposicao, minimo_forcado_manual, ativo) VALUES
+  ('OBEN',8001,'SKU 8001','FORN-8001',100,100,true,'automatica',NULL,true),
+  ('OBEN',8002,'SKU 8002','FORN-8002',100,100,true,'automatica',NULL,true),
+  ('OBEN',8003,'SKU 8003','FORN-8003',100,100,true,'automatica',8,  true),
+  ('OBEN',8004,'SKU 8004','FORN-8004',100,100,true,'automatica',7.5,true),
+  ('OBEN',8005,'SKU 8005','FORN-8005',100,100,true,'automatica',NULL,true),
+  ('OBEN',8006,'SKU 8006','FORN-8006',100,100,true,'automatica',NULL,true),
+  ('OBEN',8007,'SKU 8007','FORN-8007',100,100,true,'automatica',NULL,true);
+
+-- estoque com a poeira decimal exata de cada cenário (estoque_efetivo <= pp=100 → entra no gate)
+INSERT INTO public.sku_estoque_atual (empresa, sku_codigo_omie, estoque_fisico, estoque_pendente_entrada) VALUES
+  ('OBEN','8001',90.00004,0),
+  ('OBEN','8002',89.4,    0),
+  ('OBEN','8003',95.5,    0),
+  ('OBEN','8004',95.5,    0),
+  ('OBEN','8005',90,      0),
+  ('OBEN','8006',100,     0),
+  ('OBEN','8007',99.99996,0);
+
+-- preço determinístico via inventory_position.cmc=10 (account = empresa).
+INSERT INTO public.inventory_position (omie_codigo_produto, account, cmc)
+SELECT sku_codigo_omie, 'oben', 10 FROM public.sku_parametros WHERE empresa='OBEN';
+
+CREATE TABLE scratch_antes  (sku text, qtde_sugerida numeric, qtde_final numeric, valor_linha numeric);
+CREATE TABLE scratch_depois (sku text, qtde_sugerida numeric, qtde_final numeric, valor_linha numeric);
+CREATE TABLE scratch_ret    (fase text, pedidos int, skus int, valor numeric, bloqueados int);
+SQL
+
+echo "→ RODA ANTES (sem ceil)…"
+P -v ON_ERROR_STOP=1 -q <<'SQL'
+INSERT INTO scratch_ret SELECT 'antes', g.* FROM public.gerar_pedidos_sugeridos_ciclo('OBEN', CURRENT_DATE) g;
+INSERT INTO scratch_antes
+  SELECT pci.sku_codigo_omie, pci.qtde_sugerida, pci.qtde_final, pci.valor_linha
+  FROM pedido_compra_item pci JOIN pedido_compra_sugerido pcs ON pcs.id = pci.pedido_id
+  WHERE pcs.data_ciclo = CURRENT_DATE AND pcs.status = 'pendente_aprovacao';
+SQL
+
+echo "→ aplica a migration: 20260606150000_reposicao_qtde_inteira.sql (+ceil)…"
+P -v ON_ERROR_STOP=1 -f "$REPO_ROOT/supabase/migrations/20260606150000_reposicao_qtde_inteira.sql"
+
+echo "→ RODA DEPOIS (com ceil)…"
+P -v ON_ERROR_STOP=1 -q <<'SQL'
+INSERT INTO scratch_ret SELECT 'depois', g.* FROM public.gerar_pedidos_sugeridos_ciclo('OBEN', CURRENT_DATE) g;
+INSERT INTO scratch_depois
+  SELECT pci.sku_codigo_omie, pci.qtde_sugerida, pci.qtde_final, pci.valor_linha
+  FROM pedido_compra_item pci JOIN pedido_compra_sugerido pcs ON pcs.id = pci.pedido_id
+  WHERE pcs.data_ciclo = CURRENT_DATE AND pcs.status = 'pendente_aprovacao';
+SQL
+
+echo ""
+echo "→ ASSERTS:"
+P -v ON_ERROR_STOP=1 -q <<'SQL'
+DO $$
+DECLARE d int; fdef text;
+BEGIN
+  -- 0. SANIDADE: o teste é significativo? ANTES deve ter qtde FRACIONÁRIA (senão não prova nada).
+  SELECT count(*) INTO d FROM scratch_antes WHERE qtde_final <> trunc(qtde_final) OR qtde_sugerida <> trunc(qtde_sugerida);
+  IF d = 0 THEN RAISE EXCEPTION '0 FALHOU: ANTES não tem nenhuma fração — seed/base inválido, teste não prova o fix'; END IF;
+  RAISE NOTICE 'OK 0 — ANTES tem % linha(s) fracionária(s) (o bug existe; teste é significativo)', d;
+
+  -- 0b. casos pontuais ANTES (a fração exata)
+  PERFORM 1 FROM scratch_antes WHERE sku='8001' AND qtde_final = 9.99996 AND qtde_sugerida = 9.99996;
+  IF NOT FOUND THEN RAISE EXCEPTION '0b FALHOU: 8001 ANTES != 9,99996'; END IF;
+  PERFORM 1 FROM scratch_antes WHERE sku='8004' AND qtde_final = 7.5;  -- min forçado fracionário cru
+  IF NOT FOUND THEN RAISE EXCEPTION '0b FALHOU: 8004 ANTES (min forçado 7,5) != 7,5'; END IF;
+  PERFORM 1 FROM scratch_antes WHERE sku='8007' AND qtde_final = 0.00004;  -- poeira positiva
+  IF NOT FOUND THEN RAISE EXCEPTION '0b FALHOU: 8007 ANTES != 0,00004'; END IF;
+  RAISE NOTICE 'OK 0b — frações exatas ANTES (8001=9,99996; 8004=7,5; 8007=0,00004)';
+
+  -- A. DEPOIS: NENHUMA fração — toda qtde_sugerida e qtde_final é inteira.
+  SELECT count(*) INTO d FROM scratch_depois WHERE qtde_final <> trunc(qtde_final) OR qtde_sugerida <> trunc(qtde_sugerida);
+  IF d <> 0 THEN RAISE EXCEPTION 'A FALHOU: DEPOIS ainda tem % linha(s) fracionária(s)', d; END IF;
+  RAISE NOTICE 'OK A — DEPOIS: zero fração (toda qtde inteira)';
+
+  -- B. DEPOIS = ceil(ANTES) em ambas as colunas (valor exato, item a item).
+  SELECT count(*) INTO d FROM scratch_antes a JOIN scratch_depois p ON p.sku = a.sku
+   WHERE p.qtde_final <> ceil(a.qtde_final) OR p.qtde_sugerida <> ceil(a.qtde_sugerida);
+  IF d <> 0 THEN RAISE EXCEPTION 'B FALHOU: % linha(s) DEPOIS != ceil(ANTES)', d; END IF;
+  RAISE NOTICE 'OK B — DEPOIS = ceil(ANTES) em qtde_sugerida e qtde_final (item a item)';
+
+  -- B2. casos pontuais DEPOIS
+  PERFORM 1 FROM scratch_depois WHERE sku='8001' AND qtde_final=10 AND qtde_sugerida=10; -- 9,99996→10
+  IF NOT FOUND THEN RAISE EXCEPTION 'B2 FALHOU: 8001 DEPOIS != 10'; END IF;
+  PERFORM 1 FROM scratch_depois WHERE sku='8002' AND qtde_final=11;                       -- 10,6→11 (ceil, não round)
+  IF NOT FOUND THEN RAISE EXCEPTION 'B2 FALHOU: 8002 DEPOIS != 11 (ceil de 10,6)'; END IF;
+  PERFORM 1 FROM scratch_depois WHERE sku='8003' AND qtde_final=8 AND qtde_sugerida=5;     -- min8 vence nat4,5; sugerida ceil(4,5)=5
+  IF NOT FOUND THEN RAISE EXCEPTION 'B2 FALHOU: 8003 DEPOIS (final=8, sugerida=5)'; END IF;
+  PERFORM 1 FROM scratch_depois WHERE sku='8004' AND qtde_final=8;                         -- ceil(GREATEST(4,5; 7,5))=ceil(7,5)=8
+  IF NOT FOUND THEN RAISE EXCEPTION 'B2 FALHOU: 8004 DEPOIS != 8 (ceil do min forçado 7,5)'; END IF;
+  PERFORM 1 FROM scratch_depois WHERE sku='8005' AND qtde_final=10 AND qtde_sugerida=10;   -- inteiro exato: ceil no-op
+  IF NOT FOUND THEN RAISE EXCEPTION 'B2 FALHOU: 8005 DEPOIS != 10 (ceil de inteiro deve ser no-op)'; END IF;
+  PERFORM 1 FROM scratch_depois WHERE sku='8007' AND qtde_final=1;                         -- poeira 0,00004 → ceil 1
+  IF NOT FOUND THEN RAISE EXCEPTION 'B2 FALHOU: 8007 DEPOIS != 1 (ceil de 0,00004)'; END IF;
+  RAISE NOTICE 'OK B2 — casos: 8001→10, 8002→11(ceil≠round), 8003(min8/sug5), 8004→8(ceil min frac), 8005=10(no-op), 8007→1';
+
+  -- C. [Q5] CONJUNTO de itens IDÊNTICO antes/depois (ceil só muda valor, não inclusão).
+  --     8006 (natural 0) excluído em AMBOS; 8007 (0,00004) incluído em AMBOS.
+  SELECT count(*) INTO d FROM (
+    (SELECT sku FROM scratch_antes EXCEPT SELECT sku FROM scratch_depois)
+    UNION ALL
+    (SELECT sku FROM scratch_depois EXCEPT SELECT sku FROM scratch_antes)
+  ) x;
+  IF d <> 0 THEN RAISE EXCEPTION 'C FALHOU: conjunto de itens MUDOU (% SKU divergente) — ceil não pode mudar inclusão', d; END IF;
+  PERFORM 1 FROM scratch_antes WHERE sku='8006'; IF FOUND THEN RAISE EXCEPTION 'C FALHOU: 8006 (nat 0) não devia entrar ANTES'; END IF;
+  PERFORM 1 FROM scratch_depois WHERE sku='8006'; IF FOUND THEN RAISE EXCEPTION 'C FALHOU: 8006 (nat 0) não devia entrar DEPOIS'; END IF;
+  PERFORM 1 FROM scratch_antes WHERE sku='8007'; IF NOT FOUND THEN RAISE EXCEPTION 'C FALHOU: 8007 (0,00004) devia entrar ANTES'; END IF;
+  PERFORM 1 FROM scratch_depois WHERE sku='8007'; IF NOT FOUND THEN RAISE EXCEPTION 'C FALHOU: 8007 devia entrar DEPOIS'; END IF;
+  RAISE NOTICE 'OK C [Q5] — conjunto idêntico (6 itens; 8006 fora dos dois; 8007 dentro dos dois)';
+
+  -- D. valor_linha DEPOIS = qtde_final(inteira) × cmc(10); valor_total do header = Σ valor_linha.
+  SELECT count(*) INTO d FROM scratch_depois WHERE valor_linha <> qtde_final * 10;
+  IF d <> 0 THEN RAISE EXCEPTION 'D FALHOU: % valor_linha != qtde_final*cmc', d; END IF;
+  SELECT count(*) INTO d FROM (
+    SELECT pcs.id FROM pedido_compra_sugerido pcs JOIN pedido_compra_item pci ON pci.pedido_id=pcs.id
+    WHERE pcs.data_ciclo=CURRENT_DATE AND pcs.status='pendente_aprovacao'
+    GROUP BY pcs.id, pcs.valor_total HAVING pcs.valor_total IS DISTINCT FROM sum(pci.valor_linha)
+  ) x;
+  IF d <> 0 THEN RAISE EXCEPTION 'D FALHOU: % header(s) com valor_total != Σ valor_linha', d; END IF;
+  RAISE NOTICE 'OK D — valor_linha = qtde_final×cmc; valor_total = Σ valor_linha';
+
+  -- E. retorno da RPC DEPOIS == agregado persistido; bloqueados=0.
+  DECLARE rped int; rskus int; rval numeric; bloq int; aped int; askus int; aval numeric;
+  BEGIN
+    SELECT pedidos, skus, valor, bloqueados INTO rped, rskus, rval, bloq FROM scratch_ret WHERE fase='depois';
+    SELECT count(*), COALESCE(sum(num_skus),0), COALESCE(sum(valor_total),0) INTO aped, askus, aval
+      FROM pedido_compra_sugerido WHERE empresa='OBEN' AND data_ciclo=CURRENT_DATE AND status='pendente_aprovacao';
+    IF bloq <> 0 THEN RAISE EXCEPTION 'E FALHOU: bloqueados=% (esperado 0)', bloq; END IF;
+    IF rped<>aped OR rskus<>askus OR rval IS DISTINCT FROM aval THEN
+      RAISE EXCEPTION 'E FALHOU: retorno(%,%,%) <> persistido(%,%,%)', rped,rskus,rval, aped,askus,aval; END IF;
+  END;
+  RAISE NOTICE 'OK E — retorno da RPC == persistido; bloqueados=0';
+
+  -- F. GUARD anti-drift: a função DEPOIS preservou TODAS as guardas da base (não dropei nada ao editar).
+  fdef := pg_get_functiondef('public.gerar_pedidos_sugeridos_ciclo(text,date)'::regprocedure);
+  IF fdef NOT LIKE '%tipo_produto_unhealthy%'        THEN RAISE EXCEPTION 'F FALHOU: perdeu fail-closed tipo_produto'; END IF;
+  IF fdef NOT LIKE '%op.account = lower(p_empresa)%'  THEN RAISE EXCEPTION 'F FALHOU: perdeu account-aware'; END IF;
+  IF fdef NOT LIKE '%405ML%' OR fdef NOT LIKE '%450ML%' THEN RAISE EXCEPTION 'F FALHOU: perdeu exclusão 405/450ML'; END IF;
+  IF fdef NOT LIKE '%btrim(sp.fornecedor_nome)%'      THEN RAISE EXCEPTION 'F FALHOU: perdeu guarda fornecedor NOT NULL/vazio'; END IF;
+  IF fdef NOT LIKE '%<= sp.ponto_pedido%'             THEN RAISE EXCEPTION 'F FALHOU: perdeu gate de necessidade estoque<=ponto_pedido'; END IF;
+  IF fdef NOT LIKE '%minimo_forcado_manual%'          THEN RAISE EXCEPTION 'F FALHOU: perdeu mínimo forçado'; END IF;
+  -- e os 3 ceil entraram (qtde_sugerida + os 2 do qtde_final)
+  d := (length(fdef) - length(replace(lower(fdef),'ceil(',''))) / length('ceil(');
+  IF d <> 3 THEN RAISE EXCEPTION 'F FALHOU: esperava 3 ceil( na função, achei %', d; END IF;
+  RAISE NOTICE 'OK F — todas as guardas preservadas + exatamente 3 ceil( na função';
+
+  RAISE NOTICE '──────── TODOS OS ASSERTS SQL OK ────────';
+END $$;
+SELECT 'ASSERTS SQL PASSARAM ✓' AS resultado;
+SQL
+
+echo ""
+echo "✓ db/test-qtde-inteira.sh — PASSOU"

--- a/src/components/reposicao/pedidos/preco-edit.ts
+++ b/src/components/reposicao/pedidos/preco-edit.ts
@@ -3,6 +3,7 @@
 // substituindo o flip de status + UPDATE no SQL Editor. Money-path: nunca grava
 // preço <= 0 (o disparo rejeita nValUnit=0 no Omie).
 import type { PedidoItem, Status } from './types';
+import { quantidadeCompraInteira } from '@/lib/reposicao/compras-otimizador-helpers';
 
 // Estados em que o custo de um item de primeira compra (preço 0) pode ser definido
 // na tela:
@@ -53,7 +54,9 @@ export function montarUpdateItem(
   precoEdit: number | undefined,
 ): ItemUpdate {
   const temPrecoEdit = precoEdit !== undefined;
-  const qtd = qtdEdit ?? Number(item.qtde_final ?? item.qtde_sugerida ?? 0);
+  // [QTDE-INTEIRA] grava sempre quantidade inteira (ceil): nem a edição humana nem o fallback
+  // do qtde_final legado (poeira decimal do estoque do Omie) podem persistir fração no pedido.
+  const qtd = quantidadeCompraInteira(qtdEdit ?? Number(item.qtde_final ?? item.qtde_sugerida ?? 0));
   const preco = temPrecoEdit ? (precoEdit as number) : Number(item.preco_unitario ?? 0);
   const update: ItemUpdate = {
     qtde_final: qtd,

--- a/src/components/reposicao/pedidos/useDetalhesModal.ts
+++ b/src/components/reposicao/pedidos/useDetalhesModal.ts
@@ -9,6 +9,7 @@ import { logger } from '@/lib/logger';
 import { PedidoSugerido, PedidoItem, CondicaoPagamento } from './types';
 import { aprovarEDisparar } from './aprovar-disparar';
 import { montarUpdateItem, podeEditarPrecoPedido, precoEditValido } from './preco-edit';
+import { quantidadeCompraInteira } from '@/lib/reposicao/compras-otimizador-helpers';
 
 export type Linha = PedidoItem & { _qtd: number; _preco: number; _valor: number };
 
@@ -92,7 +93,9 @@ export function useDetalhesModal({ pedido, open, onOpenChange, onApproved }: Use
 
   const linhas = useMemo<Linha[]>(() => {
     return (itens ?? []).map((it) => {
-      const qtd = edits[it.id] ?? Number(it.qtde_final ?? it.qtde_sugerida);
+      // [QTDE-INTEIRA] default exibido sempre inteiro: ceila a poeira decimal do estoque do Omie
+      // em linhas legadas (ex.: qtde_final 3,99996 → 4). edits[] já vem inteiro do onEditQty.
+      const qtd = edits[it.id] ?? quantidadeCompraInteira(it.qtde_final ?? it.qtde_sugerida);
       const preco = precoEdits[it.id] ?? Number(it.preco_unitario ?? 0);
       return { ...it, _qtd: qtd, _preco: preco, _valor: qtd * preco };
     });
@@ -308,8 +311,8 @@ export function useDetalhesModal({ pedido, open, onOpenChange, onApproved }: Use
   });
 
   const onEditQty = (id: number, raw: string) => {
-    const v = Number(raw);
-    setEdits((prev) => ({ ...prev, [id]: isNaN(v) ? 0 : v }));
+    // [QTDE-INTEIRA] quantidade de pedido é sempre inteira (ceil; nunca fração). Campo vazio/NaN → 0.
+    setEdits((prev) => ({ ...prev, [id]: quantidadeCompraInteira(Number(raw)) }));
   };
 
   const onEditPreco = (id: number, raw: string) => {

--- a/src/lib/reposicao/__tests__/compras-otimizador-helpers.test.ts
+++ b/src/lib/reposicao/__tests__/compras-otimizador-helpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { qtdMinimaEfetiva, qtdBase, aplicarMinimoForcado, descontoAplicavel, gerarCandidatos } from '../compras-otimizador-helpers';
+import { qtdMinimaEfetiva, qtdBase, aplicarMinimoForcado, quantidadeCompraInteira, descontoAplicavel, gerarCandidatos } from '../compras-otimizador-helpers';
 import { capitalExtra, aumentoEvitadoRs, impactoPrazoRs, freteIncrementalRs, descontoIncrementalRs } from '../compras-otimizador-helpers';
 import { avaliarComprarMais } from '../compras-otimizador-helpers';
 import type { InsumoSku } from '../compras-otimizador-helpers';
@@ -162,5 +162,30 @@ describe('avaliarComprarMais — oportunidade só de aumento', () => {
     expect(r.q_candidata).toBe(400);
     expect(r.aumento_evitado_rs).toBeGreaterThan(0);
     expect(r.recomendacao).toBe('comprar_mais');
+  });
+});
+
+describe('quantidadeCompraInteira', () => {
+  it('arredonda PRA CIMA a poeira decimal do estoque (o bug 3,99996 → 4)', () => {
+    expect(quantidadeCompraInteira(3.99996)).toBe(4);
+    expect(quantidadeCompraInteira(9.99996)).toBe(10);
+  });
+  it('inteiro permanece inteiro (idempotente)', () => {
+    expect(quantidadeCompraInteira(4)).toBe(4);
+    expect(quantidadeCompraInteira(18)).toBe(18);
+  });
+  it('fração genuína também sobe (nunca sub-pedir)', () => {
+    expect(quantidadeCompraInteira(3.01)).toBe(4);
+    expect(quantidadeCompraInteira(0.0001)).toBe(1);
+  });
+  it('zero/negativo/limpo → 0 (linha zerada, sem fração)', () => {
+    expect(quantidadeCompraInteira(0)).toBe(0);
+    expect(quantidadeCompraInteira(-0.5)).toBe(0);
+    expect(quantidadeCompraInteira(null)).toBe(0);
+    expect(quantidadeCompraInteira(undefined)).toBe(0);
+  });
+  it('NaN/Infinity → 0 (degradação honesta, nunca propaga lixo)', () => {
+    expect(quantidadeCompraInteira(NaN)).toBe(0);
+    expect(quantidadeCompraInteira(Infinity)).toBe(0);
   });
 });

--- a/src/lib/reposicao/compras-otimizador-helpers.ts
+++ b/src/lib/reposicao/compras-otimizador-helpers.ts
@@ -29,6 +29,18 @@ export function aplicarMinimoForcado(qtdeNatural: number, minimoForcado: number 
   return qtdeNatural;
 }
 
+// Integeriza uma quantidade de COMPRA: arredonda PRA CIMA (nunca sub-pedir) e nunca negativa.
+// Motivo: o estoque do Omie vem com poeira decimal (tinta medida em litros) → a RPC faz
+// estoque_maximo(inteiro) − estoque(6,00004) = 3,99996; sem ceil isso vira quantidade fracionária
+// no pedido e chega ao fornecedor (Omie IncluirPedCompra). Nenhum item de pedido pode ser fracionário.
+// Espelho EXATO desta regra: `ceil(...)` na RPC gerar_pedidos_sugeridos_ciclo e `Math.ceil(...)` no
+// disparo (disparar-pedidos-aprovados). Entrada não-finita/≤0 → 0 (campo limpo / linha zerada).
+export function quantidadeCompraInteira(n: number | null | undefined): number {
+  const v = Number(n ?? 0);
+  if (!Number.isFinite(v)) return 0;
+  return Math.max(0, Math.ceil(v));
+}
+
 // Melhor desconto cujo volume_minimo ≤ q (curva progressiva → pega o maior aplicável).
 export function descontoAplicavel(curva: FaixaDesconto[], q: number): number {
   let best = 0;

--- a/supabase/functions/disparar-pedidos-aprovados/index.ts
+++ b/supabase/functions/disparar-pedidos-aprovados/index.ts
@@ -658,7 +658,11 @@ async function processarPedido(
     const produtos_incluir = (items as ItemRow[]).map((it, idx) => ({
       cCodIntItem: `ITEM${String(idx + 1).padStart(3, "0")}`,
       nCodProd: Number(it.sku_codigo_omie),
-      nQtde: Number(it.qtde_final),
+      // [QTDE-INTEIRA] backstop universal: nenhum item de pedido pode ser fracionário. O estoque
+      // do Omie vem com poeira decimal (tinta em litros) → qtde_final pode ser 3,99996. ceil aqui
+      // pega qualquer fonte (linha legada, edição humana, promo, cold-start), mesmo que a RPC já
+      // ceile na origem. Math.ceil (não round) = nunca sub-pedir. O guard nQtde>0 acima já barrou ≤0.
+      nQtde: Math.ceil(Number(it.qtde_final)),
       nValUnit: Number(it.preco_unitario),
     }));
 
@@ -844,7 +848,7 @@ async function notificarFornecedor(
   const linhas = items
     .map(
       (it) =>
-        `${it.sku_codigo_omie} — ${it.sku_descricao ?? ""} — Qtde: ${it.qtde_final} — ${
+        `${it.sku_codigo_omie} — ${it.sku_descricao ?? ""} — Qtde: ${Math.ceil(Number(it.qtde_final))} — ${
           fmtBRL(it.preco_unitario)
         }/un`,
     )

--- a/supabase/migrations/20260606150000_reposicao_qtde_inteira.sql
+++ b/supabase/migrations/20260606150000_reposicao_qtde_inteira.sql
@@ -1,0 +1,225 @@
+-- Quantidade de compra SEMPRE inteira — ceil em qtde_sugerida/qtde_final da RPC
+-- ============================================================================
+-- BUG: a tela /admin/reposicao/pedidos mostrava quantidade fracionária (ex.: 3,99996)
+-- num item de pedido. NENHUM item de pedido pode ser fracionário (founder).
+--
+-- CAUSA-RAIZ: a RPC computa qtde_sugerida = estoque_maximo − (estoque_fisico + pendente +
+-- em_transito) e qtde_final = GREATEST(natural, minimo_forcado), AMBOS como numeric SEM
+-- arredondar. Os parâmetros são inteiros (a view v_sku_parametros_sugeridos faz ceil em
+-- ss/pp/EOQ; minimo_operacional é 0/1/2), MAS o estoque vem do Omie com poeira decimal
+-- (tinta medida em litros; omie-sync-estoque grava o saldo cru somado entre depósitos).
+-- Ex.: estoque_maximo 10 − estoque_fisico 6,00004 = 3,99996. Nada no pipeline integerizava:
+-- o front mascarava com .toFixed(0) mas gravava o valor cru, e o disparo mandava nQtde cru
+-- ao Omie (IncluirPedCompra) → compra fracionária chegaria ao fornecedor.
+--
+-- FIX (layer 1 de 3 — a origem): envolve qtde_sugerida e qtde_final em ceil(...). ARREDONDA
+-- PRA CIMA (nunca sub-pedir; coerente com o picking-bridge que já faz ceil). Layer 2 = ceil
+-- no disparo (disparar-pedidos-aprovados, backstop universal p/ linhas legadas/edição humana/
+-- promo/cold-start); layer 3 = ceil no front (ItensTable/useDetalhesModal). Helper espelho:
+-- src/lib/reposicao/compras-otimizador-helpers.ts → quantidadeCompraInteira.
+--
+-- POR QUE NÃO MUDA O CONJUNTO DE ITENS (só o valor): a inclusão é estoque_efetivo<=ponto_pedido
+-- (gate de necessidade real) E qtde_sugerida>0. Como ceil(x)>0 ⟺ x>0 p/ todo real, o filtro
+-- WHERE qtde_sugerida>0 (no header e no insert de itens) fica IDÊNTICO. ceil só eleva o VALOR.
+-- Auditoria preservada: o natural cru é reconstruível por estoque_maximo − estoque_atual (ambos
+-- gravados na linha de pedido_compra_item). Sem backfill aqui (os layers 2+3 cobrem as linhas
+-- já gravadas: o front mostra ceil e o disparo ceila ao mandar pro Omie).
+--
+-- ESCOPO: corpo VERBATIM da 20260606120000 (account-aware + mínimo forçado + blindagem
+-- fornecedor + fail-closed tipo_produto + guarda '04') + ceil em EXATAMENTE qtde_sugerida e
+-- qtde_final. Nenhuma outra linha muda. Validado em PG17: db/test-qtde-inteira.sh.
+--
+-- ⚠️ RUNBOOK DE APPLY (manual via SQL Editor; anti-drift repo×prod):
+--   1. Aplicar APÓS 20260606120000 (esta é o corpo dela + ceil).
+--   2. PREFLIGHT: SELECT pg_get_functiondef('public.gerar_pedidos_sugeridos_ciclo(text,date)'::regprocedure);
+--      comparar com o corpo-base 20260606120000. Mismatch → ABORTAR e rebasear esta migration
+--      sobre o corpo de produção (cumulativa: corpo de prod + os 2 ceil).
+--   3. Aplicar em transação, FORA da janela do cron diário (15 9 * * *).
+--   4. Guardar a definição anterior (rollback) + verificar a definição pós-apply.
+--   Sem deploy de edge nesta migration; mas o FIX COMPLETO exige deploy do edge
+--   disparar-pedidos-aprovados (layer 2) e Publish do frontend (layer 3) — ver PR.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.gerar_pedidos_sugeridos_ciclo(
+  p_empresa text DEFAULT 'OBEN'::text,
+  p_data_ciclo date DEFAULT CURRENT_DATE
+)
+RETURNS TABLE(pedidos_gerados integer, skus_incluidos integer, valor_total_ciclo numeric, bloqueados integer)
+LANGUAGE plpgsql
+SET search_path TO 'public', 'pg_temp'
+SET statement_timeout TO '120s'
+AS $function$
+DECLARE
+  v_pedidos INT := 0;
+  v_skus INT := 0;
+  v_valor NUMERIC := 0;
+  v_bloqueados INT := 0;
+BEGIN
+  -- [fail-closed 2026-06-04] Se o sinal de classificação está ausente para a empresa
+  -- (0 produtos com tipo_produto), RECUSA gerar compras — em vez de tratar todos os NULL
+  -- como compráveis e arriscar comprar fabricado. (O incidente de 2026-06-04: sinal zerado
+  -- por colisão de sync.) O vigia omie_tipo_produto_oben (Migration 2b) detecta e alerta.
+  IF (SELECT count(*) FILTER (WHERE tipo_produto IS NOT NULL)
+        FROM public.omie_products WHERE account = lower(p_empresa)) = 0 THEN
+    RAISE EXCEPTION 'tipo_produto_unhealthy: sinal de classificação ausente em omie_products(account=%) — recusando gerar compras p/ não tratar Produto Acabado como comprável', lower(p_empresa);
+  END IF;
+
+  DELETE FROM pedido_compra_sugerido
+  WHERE empresa = p_empresa
+    AND data_ciclo = p_data_ciclo
+    AND status = 'pendente_aprovacao';
+
+  WITH em_transito AS (
+    SELECT pcs2.empresa, pci.sku_codigo_omie::text AS sku_codigo_omie, SUM(pci.qtde_final) AS qtde
+    FROM pedido_compra_item pci
+    JOIN pedido_compra_sugerido pcs2 ON pcs2.id = pci.pedido_id
+    WHERE pcs2.empresa = p_empresa
+      AND (
+        -- fluxo normal (janela de 7 dias)
+        (pcs2.status IN ('aprovado_aguardando_disparo','disparado','concluido_recebido')
+         AND pcs2.data_ciclo >= (p_data_ciclo - INTERVAL '7 days'))
+        OR
+        -- Fix B: pedido confirmado no portal (fornecedor vai entregar) mas
+        -- ainda sem registro no Omie. Conta independente da janela, até o Omie
+        -- ser criado (omie_pedido_compra_numero) ou o pedido ser cancelado.
+        (pcs2.status_envio_portal IN ('sucesso_portal','enviado_portal')
+         AND pcs2.portal_protocolo IS NOT NULL
+         AND pcs2.omie_pedido_compra_numero IS NULL
+         AND pcs2.status NOT IN ('cancelado','expirado_sem_aprovacao'))
+      )
+    GROUP BY pcs2.empresa, pci.sku_codigo_omie
+  ),
+  preco_medio AS (
+    SELECT slh.empresa::text AS empresa, slh.sku_codigo_omie::text AS sku_codigo_omie,
+           AVG(slh.valor_total / NULLIF(slh.quantidade_recebida, 0)) AS preco_unitario, COUNT(*) AS n
+    FROM sku_leadtime_history slh
+    WHERE slh.quantidade_recebida > 0 AND slh.valor_total > 0
+    GROUP BY slh.empresa, slh.sku_codigo_omie
+  ),
+  skus_necessitando AS (
+    SELECT sp.empresa, sp.sku_codigo_omie::text AS sku_codigo_omie, sp.sku_descricao,
+      sp.fornecedor_nome, sg.grupo_codigo, sp.ponto_pedido, sp.estoque_maximo,
+      COALESCE(sea.estoque_fisico, 0) AS estoque_fisico,
+      COALESCE(sea.estoque_pendente_entrada, 0) AS estoque_pendente,
+      COALESCE(et.qtde, 0) AS qtde_em_transito_recente,
+      (COALESCE(sea.estoque_fisico, 0) + COALESCE(sea.estoque_pendente_entrada, 0) + COALESCE(et.qtde, 0)) AS estoque_efetivo,
+      -- [QTDE-INTEIRA] arredonda pra cima: o estoque vem do Omie com poeira decimal → max − estoque
+      -- seria fracionário (3,99996). Arredondar pra cima preserva o sinal >0, então o filtro de
+      -- necessidade abaixo fica idêntico (inclusão inalterada; só o valor muda).
+      ceil(sp.estoque_maximo - (COALESCE(sea.estoque_fisico, 0) + COALESCE(sea.estoque_pendente_entrada, 0) + COALESCE(et.qtde, 0))) AS qtde_sugerida,
+      -- [MIN-FORCADO 1/3] qtde_final = piso(natural, mínimo forçado). Espelha o helper puro
+      -- aplicarMinimoForcado: CASE WHEN min>0 THEN GREATEST(natural, min) ELSE natural END.
+      -- Sem piso-0 fantasma (ELSE devolve o natural intocado). A guarda "só item que precisa
+      -- repor" é o filtro qtde_sugerida > 0 abaixo (sobre o NATURAL), inalterado.
+      -- [QTDE-INTEIRA] ceil envolve o piso E o natural: nenhuma quantidade fracionária (do
+      -- estoque com poeira decimal OU de um mínimo forçado fracionário) chega ao pedido.
+      CASE WHEN sp.minimo_forcado_manual IS NOT NULL AND sp.minimo_forcado_manual > 0
+           THEN ceil(GREATEST(
+                  (sp.estoque_maximo - (COALESCE(sea.estoque_fisico, 0) + COALESCE(sea.estoque_pendente_entrada, 0) + COALESCE(et.qtde, 0))),
+                  sp.minimo_forcado_manual))
+           ELSE ceil(sp.estoque_maximo - (COALESCE(sea.estoque_fisico, 0) + COALESCE(sea.estoque_pendente_entrada, 0) + COALESCE(et.qtde, 0)))
+      END AS qtde_final,
+      -- Fix A: preco_medio (histórico de recebimento) → fallback p/ custo médio
+      -- contábil do Omie (inventory_position.cmc) → 0 (guard no disparo barra).
+      COALESCE(pm.preco_unitario, ip.cmc, 0) AS preco_unitario,
+      (pm.n IS NULL) AS primeira_compra,
+      fh.horario_corte_pedido, fh.valor_maximo_mensal, fh.delta_max_perc
+    FROM sku_parametros sp
+    LEFT JOIN sku_grupo_producao sg ON sg.empresa = sp.empresa AND sg.sku_codigo_omie = sp.sku_codigo_omie::text
+    LEFT JOIN sku_estoque_atual sea ON sea.empresa = sp.empresa AND sea.sku_codigo_omie = sp.sku_codigo_omie::text
+    LEFT JOIN fornecedor_habilitado_reposicao fh ON fh.empresa = sp.empresa AND fh.fornecedor_nome = sp.fornecedor_nome
+    LEFT JOIN omie_products op ON op.omie_codigo_produto::text = sp.sku_codigo_omie::text
+      AND op.account = lower(p_empresa)
+    LEFT JOIN familia_nao_comprada fnc ON fnc.empresa = sp.empresa AND fnc.familia = op.familia
+    LEFT JOIN em_transito et ON et.empresa = sp.empresa AND et.sku_codigo_omie = sp.sku_codigo_omie::text
+    LEFT JOIN preco_medio pm ON pm.empresa = sp.empresa AND pm.sku_codigo_omie = sp.sku_codigo_omie::text
+    LEFT JOIN inventory_position ip ON ip.omie_codigo_produto::text = sp.sku_codigo_omie::text AND ip.account = lower(p_empresa)
+    LEFT JOIN sku_status_omie sso ON sso.empresa = sp.empresa AND sso.sku_codigo_omie = sp.sku_codigo_omie::text
+    WHERE sp.empresa = p_empresa
+      AND sp.habilitado_reposicao_automatica = TRUE
+      AND COALESCE(sp.tipo_reposicao, 'automatica') = 'automatica'
+      -- [sem-fornecedor 2026-06-04] SKU sem fornecedor NÃO gera pedido (ver cabeçalho:
+      -- o GROUP BY criava o cabeçalho mas o JOIN NULL=NULL dos itens não casava → fantasma).
+      -- Os excluídos aqui aparecem na view v_reposicao_sku_sem_fornecedor (não somem mudos).
+      AND sp.fornecedor_nome IS NOT NULL
+      AND btrim(sp.fornecedor_nome) <> ''
+      AND fnc.id IS NULL
+      AND COALESCE(op.ativo, true) = true
+      AND COALESCE(sso.ativo_no_omie, true) = true
+      AND COALESCE(op.descricao, '') NOT ILIKE '%450ML'
+      AND COALESCE(op.descricao, '') NOT ILIKE '%405ML'
+      -- [04-fabricado] guarda na fonte: Produto Acabado ('04') = fabricado, nunca comprar.
+      -- Subquery account-aware lê a COLUNA tipo_produto (ponte: fallback ao metadata legado).
+      AND COALESCE((
+        SELECT COALESCE(op04.tipo_produto, op04.metadata->>'tipo_produto')
+        FROM omie_products op04
+        WHERE op04.omie_codigo_produto::text = sp.sku_codigo_omie::text
+          AND op04.account = lower(p_empresa)
+        LIMIT 1
+      ), '') <> '04'
+      AND sp.ponto_pedido IS NOT NULL
+      AND sp.estoque_maximo IS NOT NULL
+      AND (COALESCE(sea.estoque_fisico, 0) + COALESCE(sea.estoque_pendente_entrada, 0) + COALESCE(et.qtde, 0)) <= sp.ponto_pedido
+  ),
+  pedidos_por_fornecedor_grupo AS (
+    INSERT INTO pedido_compra_sugerido (
+      empresa, fornecedor_nome, grupo_codigo, data_ciclo,
+      horario_corte_planejado, valor_total, num_skus, status,
+      condicao_pagamento_codigo, condicao_pagamento_descricao,
+      num_parcelas, dias_parcelas, condicao_origem
+    )
+    SELECT sn.empresa, sn.fornecedor_nome, sn.grupo_codigo, p_data_ciclo,
+      (p_data_ciclo + MAX(sn.horario_corte_pedido))::timestamptz,
+      -- [MIN-FORCADO 2/3] valor_total do header usa a quantidade FORÇADA (qtde_final).
+      SUM(sn.qtde_final * sn.preco_unitario), COUNT(*),
+      'pendente_aprovacao', '000', 'À Vista', 1, NULL, 'default_a_vista'
+    FROM skus_necessitando sn
+    -- Filtro de necessidade sobre o NATURAL (qtde_sugerida), inalterado: o mínimo forçado
+    -- NÃO ativa item sobre-estocado — só eleva a quantidade de quem já ia ser comprado.
+    WHERE sn.qtde_sugerida > 0
+    GROUP BY sn.empresa, sn.fornecedor_nome, sn.grupo_codigo
+    RETURNING id, fornecedor_nome, grupo_codigo
+  )
+  INSERT INTO pedido_compra_item (
+    pedido_id, sku_codigo_omie, sku_descricao,
+    estoque_atual, ponto_pedido, estoque_maximo,
+    qtde_sugerida, qtde_final, preco_unitario, valor_linha, primeira_compra
+  )
+  -- [MIN-FORCADO 3/3] qtde_sugerida = natural (referência/audit); qtde_final = forçada (dispara
+  -- ao Omie); valor_linha pela forçada. Quando minimo_forcado_manual é NULL, qtde_final = natural
+  -- = comportamento atual idêntico.
+  SELECT pfg.id, sn.sku_codigo_omie, sn.sku_descricao,
+    sn.estoque_efetivo, sn.ponto_pedido, sn.estoque_maximo,
+    sn.qtde_sugerida, sn.qtde_final, sn.preco_unitario,
+    sn.qtde_final * sn.preco_unitario, sn.primeira_compra
+  FROM skus_necessitando sn
+  JOIN pedidos_por_fornecedor_grupo pfg
+    ON pfg.fornecedor_nome = sn.fornecedor_nome
+   AND COALESCE(pfg.grupo_codigo,'') = COALESCE(sn.grupo_codigo,'')
+  -- [MIN-FORCADO 4/4] Espelha NESTE insert de itens o filtro qtde_sugerida>0 que o header já tem.
+  -- Na base, o item era inserido só por JOIN com o header (fornecedor,grupo), SEM filtro próprio →
+  -- um item com natural<=0 que compartilha fornecedor/grupo com um válido era inserido. Sem mínimo
+  -- isso é só lixo que o guard nQtde>0 do disparo barraria; COM mínimo forçado, o GREATEST elevaria
+  -- esse item sobre-estocado a `min` (gatilho indevido). Este WHERE garante PISO, NÃO GATILHO. No
+  -- caso normal (estoque_maximo>ponto_pedido) todos têm natural>0 → não exclui nada (idêntico).
+  WHERE sn.qtde_sugerida > 0;
+
+  SELECT COUNT(*), COALESCE(SUM(num_skus),0), COALESCE(SUM(valor_total),0)
+  INTO v_pedidos, v_skus, v_valor
+  FROM pedido_compra_sugerido
+  WHERE empresa = p_empresa AND data_ciclo = p_data_ciclo AND status = 'pendente_aprovacao';
+
+  RETURN QUERY SELECT v_pedidos, v_skus, v_valor, v_bloqueados;
+END;
+$function$;
+
+-- ─── Validação ───
+SELECT 'MIGRATION qtde_inteira OK' AS status,
+  (SELECT count(*) FROM pg_proc WHERE proname = 'gerar_pedidos_sugeridos_ciclo') AS rpc,
+  -- preservou o account-aware da 20260606120000 (não regrediu)
+  (pg_get_functiondef('public.gerar_pedidos_sugeridos_ciclo(text,date)'::regprocedure)
+     ILIKE '%op.account = lower(p_empresa)%') AS tem_account_aware,
+  -- os 3 ceil( entraram: qtde_sugerida + qtde_final(THEN ceil(GREATEST) + ELSE ceil)
+  (length(pg_get_functiondef('public.gerar_pedidos_sugeridos_ciclo(text,date)'::regprocedure))
+     - length(replace(lower(pg_get_functiondef('public.gerar_pedidos_sugeridos_ciclo(text,date)'::regprocedure)), 'ceil(', '')))
+     / length('ceil(') AS n_ceil;


### PR DESCRIPTION
## Problema

A tela `/admin/reposicao/pedidos` mostrava **quantidade de compra fracionária** num item (ex.: `3,99996`). Nenhum item de pedido pode ser fracionário.

## Causa-raiz

`3,99996 = 10 − 6,00004`. A RPC `gerar_pedidos_sugeridos_ciclo` computa `qtde = estoque_maximo − estoque_efetivo` **sem arredondar**. Os parâmetros são inteiros (a view `v_sku_parametros_sugeridos` faz `ceil` em ss/pp/EOQ; `minimo_operacional` é 0/1/2), **mas o estoque vem do Omie com poeira decimal** — `omie-sync-estoque` grava `estoque_fisico` = saldo cru somado entre depósitos (tinta é medida em litros). O front mascarava com `.toFixed(0)` mas gravava o valor cru, e o disparo mandava `nQtde` cru ao Omie (`IncluirPedCompra`) → compra fracionária chegaria ao fornecedor.

## Fix — defesa em 3 camadas + helper puro

| Camada | Arquivo | Mudança |
|---|---|---|
| **Origem** | migração `20260606150000` | `ceil` em `qtde_sugerida` e `qtde_final` na RPC |
| **Chokepoint** | `disparar-pedidos-aprovados/index.ts` | `Math.ceil(Number(it.qtde_final))` no `nQtde` (backstop universal: legado/edição humana/promo/cold-start) |
| **Tela** | `useDetalhesModal.ts` + `preco-edit.ts` | `ceil` no exibido, editado e gravado |
| Helper | `compras-otimizador-helpers.ts` | `quantidadeCompraInteira` (espelho TS do `ceil` do SQL) + 5 testes |

`ceil` (não round) = **nunca sub-pedir** (coerente com o picking-bridge). `ceil(x)>0 ⟺ x>0` → **o conjunto de itens não muda**, só o valor. Auditoria preservada (o natural cru é reconstruível por `estoque_maximo − estoque_atual`, ambos gravados na linha). **Sem backfill**: as camadas 2+3 cobrem as linhas já gravadas (a tela mostra `ceil` e o disparo ceila ao mandar pro Omie).

## ⚠️ ATENÇÃO: migration manual necessária — **JÁ APLICADA em prod**

`supabase/migrations/20260606150000_reposicao_qtde_inteira.sql` foi colada no SQL Editor e validada: `status = MIGRATION qtde_inteira OK`, `n_ceil = 3`, `tem_account_aware = true`. (SQL completo no arquivo / `<details>` abaixo.)

## Passos de deploy restantes (a ordem importa)

1. **Mergear este PR** (leva o edge + frontend + migração + teste pra `main`).
2. **Depois** pedir o deploy do edge `disparar-pedidos-aprovados` no chat do Lovable (lê da `main` já atualizada — deployar antes pegaria o código velho sem o `ceil`).
3. **Publish** do frontend no editor do Lovable.

## Validação

- **PG17** (`db/test-qtde-inteira.sh`): ANTES fracionário (9,99996 / 7,5 / 0,00004) → DEPOIS inteiro = `ceil(ANTES)`; `8002` (10,6) → **11** (prova ceil≠round); **conjunto de itens idêntico**; todas as guardas preservadas; exatamente 3 `ceil(`.
- **CI local**: typecheck ✓ · **2671/2671 testes** ✓ · lint 0 erros ✓ · build ✓.

<details>
<summary>SQL da migração (já aplicado)</summary>

Ver `supabase/migrations/20260606150000_reposicao_qtde_inteira.sql` no diff deste PR — corpo VERBATIM da `20260606120000` (account-aware + mínimo forçado + fail-closed tipo_produto + guarda '04') + `ceil` em exatamente `qtde_sugerida` e `qtde_final`.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
