### PR TITLE
fix(lente): banner 'Ver como' fixo no topo (não fica coberto pelo topbar)

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -552,7 +552,8 @@ function AppSidebar({ collapsed, onToggle }: { collapsed: boolean; onToggle: () 
   return (
     <aside
       className={cn(
-        'fixed left-0 top-0 bottom-0 z-40 flex flex-col overflow-hidden bg-sidebar border-r border-sidebar-border transition-all duration-200',
+        'fixed left-0 bottom-0 z-40 flex flex-col overflow-hidden bg-sidebar border-r border-sidebar-border transition-all duration-200',
+        isImpersonating ? 'top-7' : 'top-0',
         collapsed ? 'w-sidebar-collapsed' : 'w-sidebar'
       )}
     >
@@ -670,12 +671,14 @@ function AppSidebar({ collapsed, onToggle }: { collapsed: boolean; onToggle: () 
 function AppTopbar({ sidebarCollapsed, onMobileMenuToggle }: { sidebarCollapsed: boolean; onMobileMenuToggle: () => void }) {
   const navigate = useNavigate();
   const { signOut } = useAuth();
+  const { isImpersonating } = useImpersonation();
 
   return (
     <header
       className={cn(
-        'fixed top-0 right-0 z-30 h-topbar border-b border-border bg-card/80 backdrop-blur-sm flex items-center justify-between px-4 transition-all duration-200',
+        'fixed right-0 z-30 h-topbar border-b border-border bg-card/80 backdrop-blur-sm flex items-center justify-between px-4 transition-all duration-200',
         'left-0 lg:left-sidebar',
+        isImpersonating ? 'top-7' : 'top-0',
         sidebarCollapsed && 'lg:left-sidebar-collapsed'
       )}
     >
@@ -806,6 +809,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
   useOfflineFlush();
   const [collapsed, setCollapsed] = useState(false);
   const [mobileOpen, setMobileOpen] = useState(false);
+  const { isImpersonating } = useImpersonation();
 
   // Aplica .legacy-visual no <html> quando feature flag newVisual = false
   useFeatureFlagBodyClass('newVisual', 'legacy-visual', /* invert */ true);
@@ -814,7 +818,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
     <AppShellProvider>
       <ShortcutsRegistryProvider>
         <CommandsRegistryProvider>
-          <div className="min-h-screen bg-background density-compact">
+          <div className={cn('min-h-screen bg-background density-compact', isImpersonating && 'pt-7')}>
             <ImpersonationBanner />
             {/* Desktop sidebar */}
             <div className="hidden lg:block">

--- a/src/components/impersonation/ImpersonationBanner.tsx
+++ b/src/components/impersonation/ImpersonationBanner.tsx
@@ -26,7 +26,7 @@ export function ImpersonationBanner() {
   if (!isImpersonating || !target) return null;
   const contexto = [perfil?.commercialRole, perfil?.department].filter(Boolean).join(' · ');
   return (
-    <div className="w-full bg-status-warning-bold text-white text-xs flex items-center justify-center gap-3 py-1 px-3">
+    <div className="fixed top-0 inset-x-0 z-50 h-7 bg-status-warning-bold text-white text-xs flex items-center justify-center gap-3 px-3">
       <Eye className="w-3.5 h-3.5 shrink-0" />
       <span className="truncate">
         Lente de navegação/leitura como <strong>{target.nome}</strong>


### PR DESCRIPTION
## Bug (QA do founder pegou no Preview)
Na lente, o menu encolhia certo, MAS o banner "Ver como X · Sair" ficava **coberto pela barra superior fixa** — só a faixa laranja aparecia, sem texto nem botão "Sair" clicável → **o master ficava preso na lente** (o chip "Ver como" também some quando a lente mostra o dashboard da vendedora, então não havia outra saída além de fechar a aba).

## Causa
O `ImpersonationBanner` estava em **fluxo normal**, mas `AppTopbar` (`fixed top-0 z-30`) e `AppSidebar` (`fixed top-0 z-40`) são fixos no topo → cobriam o banner.

## Fix
- Banner → `fixed top-0 inset-x-0 z-50 h-7` (acima do topbar e do sidebar). "Sair" volta a ser visível/clicável.
- `AppShell` root → `pt-7` quando impersonando (empurra o conteúdo em fluxo 28px).
- `AppTopbar` + `AppSidebar` → `top-7` (em vez de `top-0`) quando impersonando.
- **Fora da lente: idêntico a antes** (banner retorna null; sem `pt-7`/`top-7`).

typecheck + lint limpos. (Layout CSS — verificação é visual no Chrome; o headless não renderiza a SPA.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)