### PR TITLE
feat(reposição): A2 — cmc do Omie como base de custo (R$ compra + EOQ)

### DIFF
--- a/db/test-a2-cmc-view.sh
+++ b/db/test-a2-cmc-view.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Testa o A2 (cmc como base de custo na v_sku_parametros_sugeridos) num PG17 descartável.
+# (1) Aplica a VIEW DE PROD (snapshot) primeiro, depois o REPLACE da migration por cima —
+#     prova que o CREATE OR REPLACE NÃO quebra por reorder/coluna (a armadilha que mordeu 3×)
+#     e que a view continua consultável (lista de colunas preservada).
+# (2) Testa a LÓGICA do cmc em isolado (mesma expressão da view): mapeamento account→empresa,
+#     DISTINCT ON (cmc>0 + mais fresco), e COALESCE(NULLIF(cmc,0), media_compras, venda*0.55).
+# Base: db/verify-snapshot-replay.sh (mesmo setup keg-only do brew).
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PGVER=17
+PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+PORT=5434
+DATA="$(mktemp -d /tmp/pgtest-a2.XXXXXX)/data"
+export LC_ALL=C LANG=C
+MIG="$REPO_ROOT/supabase/migrations/20260606150000_a2_cmc_base_custo_view.sql"
+
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente: brew install postgresql@${PGVER} pgvector"; exit 1; }
+CELLAR="$(brew --prefix postgresql@${PGVER})"
+cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
+mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
+cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
+
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+trap cleanup EXIT
+
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l /tmp/pg-a2.log -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres a2_verify
+P() { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d a2_verify "$@"; }
+
+RR="$(mktemp /tmp/snap-a2.XXXXXX.sql)"
+sed -E 's/^(CREATE SCHEMA public;)/-- \1/' "$REPO_ROOT/supabase/schema-snapshot.sql" \
+  | grep -vE '^\\(un)?restrict ' > "$RR"
+P -v ON_ERROR_STOP=1 -q -f "$REPO_ROOT/db/stubs-supabase.sql"
+P -v ON_ERROR_STOP=1 -q -f "$REPO_ROOT/supabase/schema-extensions-prelude.sql"
+P --single-transaction -v ON_ERROR_STOP=1 -q -f "$RR"
+rm -f "$RR"
+echo "SNAPSHOT OK (view de prod aplicada)."
+
+# (1) REPLACE por cima da view de prod — pega reorder/coluna. ON_ERROR_STOP aborta se quebrar.
+P -v ON_ERROR_STOP=1 -q -f "$MIG"
+echo "REPLACE OK (sem erro de reorder/coluna)."
+
+# View continua consultável + tem a fonte 'cmc' no def + as colunas-chave preservadas.
+P -v ON_ERROR_STOP=1 -tA <<'SQL'
+SELECT 'view_consultavel=' || (SELECT count(*) FROM (SELECT * FROM public.v_sku_parametros_sugeridos LIMIT 0) z)::text;
+SELECT 'tem_fonte_cmc=' || (CASE WHEN pg_get_viewdef('public.v_sku_parametros_sugeridos') ILIKE '%''cmc''::text%' THEN 'sim' ELSE 'NAO' END);
+SELECT 'tem_precos_cmc=' || (CASE WHEN pg_get_viewdef('public.v_sku_parametros_sugeridos') ILIKE '%precos_cmc%' THEN 'sim' ELSE 'NAO' END);
+SELECT 'colunas_saida=' || count(*)::text FROM information_schema.columns WHERE table_schema='public' AND table_name='v_sku_parametros_sugeridos';
+SQL
+
+# (2) LÓGICA do cmc em isolado (mesma CTE + COALESCE da view), com inventory_position semeado.
+echo ""
+echo "LÓGICA (asserts):"
+P -v ON_ERROR_STOP=1 -tA <<'SQL'
+-- seed: SKU 100 (OBEN) cmc em 2 accounts (vendas mais fresco) ; SKU 200 cmc=0 (cai pra media) ; SKU 300 sem cmc
+TRUNCATE public.inventory_position;
+INSERT INTO public.inventory_position(omie_codigo_produto, account, saldo, cmc, preco_medio, synced_at) VALUES
+ (100,'oben',  2, 530.00, 0, now() - interval '1 hour'),
+ (100,'vendas',2, 536.48, 0, now()),                 -- mais fresco → ganha
+ (200,'vendas',0, 0,      0, now()),                 -- cmc=0 → excluído (cmc>0) → cai pro fallback
+ (300,'colacor_vendas',5, 99.00, 0, now()),          -- empresa COLACOR
+ (400,'vendas',1, -5.00,  0, now());                 -- cmc NEGATIVO → excluído → cai pro fallback
+
+WITH precos_cmc AS (
+  SELECT DISTINCT ON (m.empresa, m.sku_codigo_omie) m.empresa, m.sku_codigo_omie, m.cmc
+  FROM ( SELECT CASE
+                  WHEN ip.account = ANY (ARRAY['vendas','oben']) THEN 'OBEN'
+                  WHEN ip.account = ANY (ARRAY['colacor_vendas','colacor']) THEN 'COLACOR'
+                  WHEN ip.account = ANY (ARRAY['servicos','colacor_sc']) THEN 'COLACOR_SC'
+                  ELSE NULL END AS empresa,
+                (ip.omie_codigo_produto)::text AS sku_codigo_omie, ip.cmc, ip.synced_at
+         FROM public.inventory_position ip WHERE ip.cmc > 0 ) m
+  WHERE m.empresa IS NOT NULL
+  ORDER BY m.empresa, m.sku_codigo_omie, ((m.cmc > 0)) DESC, m.synced_at DESC NULLS LAST
+),
+cenarios(empresa, sku, media_compras, venda) AS (
+  VALUES ('OBEN','100', 436.84::numeric, 769.54::numeric),  -- tem cmc → usa 536.48
+         ('OBEN','200', 436.84::numeric, 769.54::numeric),  -- cmc=0 → usa media 436.84
+         ('OBEN','999', NULL::numeric,   100.00::numeric),  -- sem cmc, sem media → venda*0.55=55
+         ('OBEN','400', 300.00::numeric, 500.00::numeric),  -- cmc negativo → usa media 300
+         ('COLACOR','300', 80.00::numeric, 200.00::numeric) -- cmc 99 → usa 99
+)
+SELECT
+  'A1 sku100 usa cmc fresco 536.48: ' || (COALESCE(NULLIF((SELECT cmc FROM precos_cmc WHERE empresa=c.empresa AND sku_codigo_omie=c.sku),0), c.media_compras, c.venda*0.55)=536.48)
+  FROM cenarios c WHERE c.sku='100'
+UNION ALL SELECT
+  'A2 sku200 cmc=0 cai pra media 436.84: ' || (COALESCE(NULLIF((SELECT cmc FROM precos_cmc WHERE empresa=c.empresa AND sku_codigo_omie=c.sku),0), c.media_compras, c.venda*0.55)=436.84)
+  FROM cenarios c WHERE c.sku='200'
+UNION ALL SELECT
+  'A3 sku999 sem cmc/media cai pra venda*0.55=55: ' || (COALESCE(NULLIF((SELECT cmc FROM precos_cmc WHERE empresa=c.empresa AND sku_codigo_omie=c.sku),0), c.media_compras, c.venda*0.55)=55.00)
+  FROM cenarios c WHERE c.sku='999'
+UNION ALL SELECT
+  'A4 colacor sku300 usa cmc 99 (mapeou colacor_vendas): ' || (COALESCE(NULLIF((SELECT cmc FROM precos_cmc WHERE empresa=c.empresa AND sku_codigo_omie=c.sku),0), c.media_compras, c.venda*0.55)=99.00)
+  FROM cenarios c WHERE c.sku='300'
+UNION ALL SELECT
+  'A5 fonte_preco sku100 = cmc: ' || ((CASE WHEN NULLIF((SELECT cmc FROM precos_cmc WHERE empresa='OBEN' AND sku_codigo_omie='100'),0) IS NOT NULL THEN 'cmc' ELSE 'outro' END)='cmc')
+UNION ALL SELECT
+  'A6 precos_cmc 1 linha por (empresa,sku) p/ sku100: ' || ((SELECT count(*) FROM precos_cmc WHERE empresa='OBEN' AND sku_codigo_omie='100')=1)
+UNION ALL SELECT
+  'A7 sku400 cmc NEGATIVO cai pra media 300: ' || (COALESCE(NULLIF((SELECT cmc FROM precos_cmc WHERE empresa=c.empresa AND sku_codigo_omie=c.sku),0), c.media_compras, c.venda*0.55)=300.00)
+  FROM cenarios c WHERE c.sku='400';
+SQL
+echo ""
+echo "✅ test-a2-cmc-view OK"

--- a/src/components/reposicao/SkuDetailSheet.tsx
+++ b/src/components/reposicao/SkuDetailSheet.tsx
@@ -247,7 +247,14 @@ function SkuDetailSheetImpl({
           <section>
             <h3 className="font-semibold mb-2">Preço e custo</h3>
             <dl className="grid grid-cols-2 gap-x-4 gap-y-1">
-              <dt className="text-muted-foreground">Preço de compra médio</dt>
+              <dt className="text-muted-foreground">Custo usado (conta)</dt>
+              <dd className="flex items-center gap-2 font-medium">
+                {fmtBRL(stats?.preco_item_eoq)}
+                <Badge variant={fonteBadgeVariant(stats?.fonte_preco) as BadgeVariant}>
+                  {fonteBadgeLabel(stats?.fonte_preco)}
+                </Badge>
+              </dd>
+              <dt className="text-muted-foreground">Preço de compra médio (histórico)</dt>
               <dd className="flex items-center gap-2">
                 {fmtBRL(stats?.preco_compra_real)}
                 <span className="text-xs text-muted-foreground">

--- a/src/components/reposicao/revisao/SkuRow.tsx
+++ b/src/components/reposicao/revisao/SkuRow.tsx
@@ -67,7 +67,7 @@ export function SkuRow({ row: r, onOpenDetail, onPromover, promovendo }: SkuRowP
         </Badge>
       </TableCell>
       <TableCell className="text-right">{fmt(r.demanda_media_diaria)}</TableCell>
-      <TableCell className="text-right">{fmtBRL(r.preco_compra_real)}</TableCell>
+      <TableCell className="text-right">{fmtBRL(r.preco_item_eoq ?? r.preco_compra_real)}</TableCell>
       <TableCell className="text-right">{fmtBRL(r.preco_venda_medio)}</TableCell>
       <TableCell>
         <Badge variant={fonteBadgeVariant(r.fonte_preco) as BadgeVariant}>

--- a/src/components/reposicao/revisao/useRevisaoParametros.ts
+++ b/src/components/reposicao/revisao/useRevisaoParametros.ts
@@ -210,13 +210,13 @@ export function useRevisaoParametros() {
         const codes = baseRows.map((r) => r.sku_codigo_omie);
         const { data: vrows } = await supabase
           .from("v_sku_parametros_sugeridos")
-          .select("sku_codigo_omie, preco_compra_real, preco_venda_medio, fonte_preco, fornecedor_habilitado, status_sugestao")
+          .select("sku_codigo_omie, preco_compra_real, preco_venda_medio, preco_item_eoq, fonte_preco, fornecedor_habilitado, status_sugestao")
           .eq("empresa", empresa)
           .in("sku_codigo_omie", codes);
 
         type SkuPriceRow = Pick<
           SkuSugeridoView,
-          "sku_codigo_omie" | "preco_compra_real" | "preco_venda_medio" | "fonte_preco" | "fornecedor_habilitado" | "status_sugestao"
+          "sku_codigo_omie" | "preco_compra_real" | "preco_venda_medio" | "preco_item_eoq" | "fonte_preco" | "fornecedor_habilitado" | "status_sugestao"
         >;
         const map = new Map<number, SkuPriceRow>();
         ((vrows ?? []) as SkuPriceRow[]).forEach((row) => map.set(Number(row.sku_codigo_omie), row));
@@ -226,6 +226,7 @@ export function useRevisaoParametros() {
             ...r,
             preco_compra_real: v?.preco_compra_real ?? null,
             preco_venda_medio: v?.preco_venda_medio ?? null,
+            preco_item_eoq: v?.preco_item_eoq ?? null,
             fonte_preco: v?.fonte_preco ?? null,
             status_sugestao: v?.status_sugestao ?? null,
             fornecedor_habilitado: v?.fornecedor_habilitado ?? null,

--- a/src/lib/reposicao/sku-param.ts
+++ b/src/lib/reposicao/sku-param.ts
@@ -67,6 +67,7 @@ export type ViewStats = {
 export type RowWithPrice = SkuParam & {
   preco_compra_real: number | null;
   preco_venda_medio: number | null;
+  preco_item_eoq?: number | null; // custo USADO na conta (cmc do Omie quando há; senão média/estimado)
   fonte_preco: string | null;
   status_sugestao?: string | null;
   fornecedor_habilitado?: boolean | null;
@@ -87,6 +88,7 @@ export const fonteBadgeVariant = (
 ): 'success' | 'warning' | 'danger' | 'outline' => {
   if (!fonte) return 'danger';
   const f = fonte.toLowerCase();
+  if (f === 'cmc') return 'success';
   if (f.includes('compra') && f.includes('real')) return 'success';
   if (f.includes('estim')) return 'warning';
   if (f.includes('sem')) return 'danger';
@@ -96,6 +98,7 @@ export const fonteBadgeVariant = (
 export const fonteBadgeLabel = (fonte: string | null | undefined): string => {
   if (!fonte) return 'Sem preço';
   const f = fonte.toLowerCase();
+  if (f === 'cmc') return 'Custo Omie';
   if (f.includes('compra') && f.includes('real')) return 'Compra real';
   if (f.includes('estim')) return 'Estimado';
   if (f.includes('sem')) return 'Sem preço';

--- a/supabase/migrations/20260606150000_a2_cmc_base_custo_view.sql
+++ b/supabase/migrations/20260606150000_a2_cmc_base_custo_view.sql
@@ -1,0 +1,335 @@
+-- A2 (money-path): base de custo da reposição passa a usar o cmc (Custo Médio Contábil
+-- do Omie, de inventory_position) em vez da média de compras passadas. Afeta preco_item_eoq
+-- (entra no EOQ → estoque_maximo_sugerido) e a fonte_preco. SEM nova coluna de saída
+-- (uso o preco_item_eoq existente) → CREATE OR REPLACE não muda a lista/ordem de colunas.
+--
+-- Mudanças vs a view de prod (snapshot 2026-06-05):
+--   (1) nova CTE precos_cmc: cmc por (empresa, sku), mapeando account→empresa (ambas as
+--       convenções: vendas/oben, colacor_vendas/colacor, servicos/colacor_sc), preferindo
+--       cmc>0 e o synced_at mais recente (DISTINCT ON);
+--   (2) base: LEFT JOIN precos_cmc + preco_item_eoq = COALESCE(NULLIF(cmc,0), media_compras,
+--       venda*0.55) + fonte_preco ganha 'cmc' (primeiro). R$ venda (preco_venda_medio) intacto.
+-- Corpo = verbatim do snapshot + essas edições. Validar: PG17 (REPLACE sem reorder) + lógica.
+
+CREATE OR REPLACE VIEW public.v_sku_parametros_sugeridos WITH (security_invoker='on') AS
+ WITH minimo_operacional AS (
+         SELECT 'A'::text AS letra_abc,
+            2 AS min_op
+        UNION ALL
+         SELECT 'B'::text AS text,
+            1
+        UNION ALL
+         SELECT 'C'::text AS text,
+            0
+        ), config_efetiva AS (
+         SELECT empresa_configuracao_custos.empresa,
+            (((empresa_configuracao_custos.selic_anual + empresa_configuracao_custos.spread_oportunidade) + empresa_configuracao_custos.armazenagem_fisica) / 100.0) AS cm_anual,
+                CASE
+                    WHEN (empresa_configuracao_custos.modo_pedido = 'api'::text) THEN empresa_configuracao_custos.custo_pedido_api
+                    ELSE empresa_configuracao_custos.custo_pedido_manual
+                END AS cp,
+            empresa_configuracao_custos.z_classe_a,
+            empresa_configuracao_custos.z_classe_b,
+            empresa_configuracao_custos.z_classe_c,
+            empresa_configuracao_custos.modo_pedido
+           FROM public.empresa_configuracao_custos
+        ), precos_compra AS (
+         SELECT (v_sku_leadtime_history_normal.empresa)::text AS empresa,
+            (v_sku_leadtime_history_normal.sku_codigo_omie)::text AS sku_codigo_omie,
+            avg((v_sku_leadtime_history_normal.valor_total / NULLIF(v_sku_leadtime_history_normal.quantidade_recebida, (0)::numeric))) AS preco_compra_real,
+            count(*) AS n_compras
+           FROM public.v_sku_leadtime_history_normal
+          WHERE ((v_sku_leadtime_history_normal.quantidade_recebida > (0)::numeric) AND (v_sku_leadtime_history_normal.valor_total > (0)::numeric))
+          GROUP BY (v_sku_leadtime_history_normal.empresa)::text, (v_sku_leadtime_history_normal.sku_codigo_omie)::text
+        ), precos_venda AS (
+         SELECT venda_items_history.empresa,
+            (venda_items_history.sku_codigo_omie)::text AS sku_codigo_omie,
+            avg((venda_items_history.valor_total / NULLIF(venda_items_history.quantidade, (0)::numeric))) AS preco_venda_medio
+           FROM public.venda_items_history
+          WHERE ((venda_items_history.data_emissao >= (CURRENT_DATE - '180 days'::interval)) AND (venda_items_history.quantidade > (0)::numeric))
+          GROUP BY venda_items_history.empresa, (venda_items_history.sku_codigo_omie)::text
+        ), precos_cmc AS (
+         SELECT DISTINCT ON (m.empresa, m.sku_codigo_omie)
+            m.empresa, m.sku_codigo_omie, m.cmc
+           FROM ( SELECT
+                    CASE
+                        WHEN (ip.account = ANY (ARRAY['vendas'::text, 'oben'::text])) THEN 'OBEN'::text
+                        WHEN (ip.account = ANY (ARRAY['colacor_vendas'::text, 'colacor'::text])) THEN 'COLACOR'::text
+                        WHEN (ip.account = ANY (ARRAY['servicos'::text, 'colacor_sc'::text])) THEN 'COLACOR_SC'::text
+                        ELSE NULL::text
+                    END AS empresa,
+                    (ip.omie_codigo_produto)::text AS sku_codigo_omie,
+                    ip.cmc,
+                    ip.synced_at
+                   FROM public.inventory_position ip
+                  WHERE (ip.cmc > (0)::numeric)) m  -- só cmc positivo (exclui 0 e negativo/erro de dado)
+          WHERE (m.empresa IS NOT NULL)
+          ORDER BY m.empresa, m.sku_codigo_omie, ((m.cmc > (0)::numeric)) DESC, m.synced_at DESC NULLS LAST
+        ), base AS (
+         SELECT c.empresa,
+            c.sku_codigo_omie,
+            c.sku_descricao,
+            c.valor_total_90d,
+            c.num_ordens,
+            c.demanda_media_diaria AS d,
+            c.qtde_media_por_ordem,
+            c.qtde_desvio_por_ordem,
+            c.coef_variacao_ordem,
+            c.classe_abc_proposta,
+            c.classe_xyz_proposta,
+            c.classe_consolidada_proposta AS classe,
+            r.p90_diario,
+            r.p95_diario,
+            r.p99_diario,
+            r.p90_quando_vende,
+            r.p95_quando_vende,
+            r.pico_maximo_dia,
+            r.dias_com_movimento,
+            r.valor_total_180d,
+            COALESCE(sd.sigma_demanda_diaria, (c.demanda_media_diaria * 0.5)) AS sigma_d,
+            GREATEST((lts.lt_total_teorico_dias_uteis)::numeric, lt.lt_medio_dias_uteis) AS lt,
+            COALESCE(lt.lt_desvio_padrao_dias, lt.lt_fornecedor_desvio, ((COALESCE(lts.lt_total_teorico_dias_uteis, (10)::bigint))::numeric * 0.3)) AS sigma_lt,
+            lts.lt_total_teorico_dias_uteis,
+            lt.lt_medio_dias_uteis AS lt_historico_medio,
+                CASE
+                    WHEN ((lts.lt_total_teorico_dias_uteis IS NULL) AND (lt.lt_medio_dias_uteis IS NULL)) THEN 'sem_dados'::text
+                    WHEN (lts.lt_total_teorico_dias_uteis IS NULL) THEN 'historico_medio'::text
+                    WHEN (lt.lt_medio_dias_uteis IS NULL) THEN 'sla_teorico'::text
+                    WHEN (lt.lt_medio_dias_uteis > (lts.lt_total_teorico_dias_uteis)::numeric) THEN 'historico_sobrepos_teorico'::text
+                    ELSE 'sla_teorico'::text
+                END AS fonte_lt,
+            lts.grupo_codigo,
+            lt.lt_p95_dias,
+            lt.fonte_leadtime,
+            COALESCE(lt.fornecedor_nome, fgp.fornecedor_nome) AS fornecedor_nome,
+                CASE
+                    WHEN (lt.fornecedor_nome IS NOT NULL) THEN 'historico_compras'::text
+                    WHEN (fgp.fornecedor_nome IS NOT NULL) THEN 'grupo_producao'::text
+                    ELSE NULL::text
+                END AS fonte_fornecedor,
+            pv.preco_venda_medio,
+            pc.preco_compra_real,
+            pc.n_compras,
+            COALESCE(NULLIF(( SELECT pcc.cmc FROM precos_cmc pcc WHERE ((pcc.empresa = c.empresa) AND (pcc.sku_codigo_omie = (c.sku_codigo_omie)::text))), (0)::numeric), pc.preco_compra_real, (pv.preco_venda_medio * 0.55)) AS preco_item_eoq,
+                CASE
+                    WHEN (NULLIF(( SELECT pcc.cmc FROM precos_cmc pcc WHERE ((pcc.empresa = c.empresa) AND (pcc.sku_codigo_omie = (c.sku_codigo_omie)::text))), (0)::numeric) IS NOT NULL) THEN 'cmc'::text
+                    WHEN (pc.preco_compra_real IS NOT NULL) THEN 'compra_real'::text
+                    WHEN (pv.preco_venda_medio IS NOT NULL) THEN 'venda_estimado'::text
+                    ELSE 'sem_preco'::text
+                END AS fonte_preco,
+            COALESCE(fh.habilitado, false) AS fornecedor_habilitado,
+            cfg.cm_anual,
+            cfg.cp,
+            cfg.z_classe_a,
+            cfg.z_classe_b,
+            cfg.z_classe_c,
+            cfg.modo_pedido,
+            mop.min_op AS minimo_operacional,
+                CASE c.classe_abc_proposta
+                    WHEN 'A'::text THEN cfg.z_classe_a
+                    WHEN 'B'::text THEN cfg.z_classe_b
+                    ELSE cfg.z_classe_c
+                END AS z_aplicado
+           FROM ((((((((((public.v_sku_classificacao_abc_xyz c
+             LEFT JOIN public.v_sku_demanda_rajada r ON (((c.empresa = r.empresa) AND (c.sku_codigo_omie = r.sku_codigo_omie))))
+             LEFT JOIN public.v_sku_leadtime_estatisticas lt ON (((c.empresa = lt.empresa) AND (c.sku_codigo_omie = lt.sku_codigo_omie))))
+             LEFT JOIN public.v_sku_lt_teorico lts ON (((c.empresa = lts.empresa) AND ((c.sku_codigo_omie)::text = lts.sku_codigo_omie))))
+             LEFT JOIN public.v_sku_sigma_demanda sd ON (((c.empresa = sd.empresa) AND ((c.sku_codigo_omie)::text = sd.sku_codigo_omie))))
+             LEFT JOIN precos_venda pv ON (((c.empresa = pv.empresa) AND ((c.sku_codigo_omie)::text = pv.sku_codigo_omie))))
+             LEFT JOIN precos_compra pc ON (((c.empresa = pc.empresa) AND ((c.sku_codigo_omie)::text = pc.sku_codigo_omie))))
+             LEFT JOIN config_efetiva cfg ON ((c.empresa = cfg.empresa)))
+             LEFT JOIN minimo_operacional mop ON ((c.classe_abc_proposta = mop.letra_abc)))
+             LEFT JOIN public.fornecedor_grupo_producao fgp ON (((fgp.empresa = c.empresa) AND (fgp.grupo_codigo = lts.grupo_codigo))))
+             LEFT JOIN public.fornecedor_habilitado_reposicao fh ON (((c.empresa = fh.empresa) AND (fh.fornecedor_nome = COALESCE(lt.fornecedor_nome, fgp.fornecedor_nome)))))
+        ), com_calculos AS (
+         SELECT base.empresa,
+            base.sku_codigo_omie,
+            base.sku_descricao,
+            base.valor_total_90d,
+            base.num_ordens,
+            base.d,
+            base.qtde_media_por_ordem,
+            base.qtde_desvio_por_ordem,
+            base.coef_variacao_ordem,
+            base.classe_abc_proposta,
+            base.classe_xyz_proposta,
+            base.classe,
+            base.p90_diario,
+            base.p95_diario,
+            base.p99_diario,
+            base.p90_quando_vende,
+            base.p95_quando_vende,
+            base.pico_maximo_dia,
+            base.dias_com_movimento,
+            base.valor_total_180d,
+            base.sigma_d,
+            base.lt,
+            base.sigma_lt,
+            base.lt_total_teorico_dias_uteis,
+            base.lt_historico_medio,
+            base.fonte_lt,
+            base.grupo_codigo,
+            base.lt_p95_dias,
+            base.fonte_leadtime,
+            base.fornecedor_nome,
+            base.fonte_fornecedor,
+            base.preco_venda_medio,
+            base.preco_compra_real,
+            base.n_compras,
+            base.preco_item_eoq,
+            base.fonte_preco,
+            base.fornecedor_habilitado,
+            base.cm_anual,
+            base.cp,
+            base.z_classe_a,
+            base.z_classe_b,
+            base.z_classe_c,
+            base.modo_pedido,
+            base.minimo_operacional,
+            base.z_aplicado,
+            sqrt(((COALESCE(base.lt, (10)::numeric) * power(COALESCE(base.sigma_d, (0)::numeric), (2)::numeric)) + (power(COALESCE(base.d, (0)::numeric), (2)::numeric) * power(COALESCE(base.sigma_lt, (0)::numeric), (2)::numeric)))) AS sigma_lt_d,
+                CASE
+                    WHEN (base.num_ordens < 2) THEN 'AGUARDANDO_SEGUNDA_ORDEM'::text
+                    WHEN (base.lt IS NULL) THEN 'SEM_LEADTIME_DEFINIDO'::text
+                    WHEN (base.fornecedor_nome IS NULL) THEN 'SEM_FORNECEDOR_IDENTIFICADO'::text
+                    WHEN (NOT base.fornecedor_habilitado) THEN 'AGUARDANDO_HABILITACAO_FORNECEDOR'::text
+                    WHEN ((base.grupo_codigo IS NULL) AND (base.fornecedor_nome = 'RENNER SAYERLACK S/A'::text)) THEN 'AGUARDANDO_CLASSIFICACAO_GRUPO'::text
+                    WHEN ((base.preco_item_eoq IS NULL) OR (base.preco_item_eoq = (0)::numeric)) THEN 'SEM_PRECO'::text
+                    ELSE 'OK'::text
+                END AS status_sugestao
+           FROM base
+        ), com_formulas AS (
+         SELECT com_calculos.empresa,
+            com_calculos.sku_codigo_omie,
+            com_calculos.sku_descricao,
+            com_calculos.valor_total_90d,
+            com_calculos.num_ordens,
+            com_calculos.d,
+            com_calculos.qtde_media_por_ordem,
+            com_calculos.qtde_desvio_por_ordem,
+            com_calculos.coef_variacao_ordem,
+            com_calculos.classe_abc_proposta,
+            com_calculos.classe_xyz_proposta,
+            com_calculos.classe,
+            com_calculos.p90_diario,
+            com_calculos.p95_diario,
+            com_calculos.p99_diario,
+            com_calculos.p90_quando_vende,
+            com_calculos.p95_quando_vende,
+            com_calculos.pico_maximo_dia,
+            com_calculos.dias_com_movimento,
+            com_calculos.valor_total_180d,
+            com_calculos.sigma_d,
+            com_calculos.lt,
+            com_calculos.sigma_lt,
+            com_calculos.lt_total_teorico_dias_uteis,
+            com_calculos.lt_historico_medio,
+            com_calculos.fonte_lt,
+            com_calculos.grupo_codigo,
+            com_calculos.lt_p95_dias,
+            com_calculos.fonte_leadtime,
+            com_calculos.fornecedor_nome,
+            com_calculos.fonte_fornecedor,
+            com_calculos.preco_venda_medio,
+            com_calculos.preco_compra_real,
+            com_calculos.n_compras,
+            com_calculos.preco_item_eoq,
+            com_calculos.fonte_preco,
+            com_calculos.fornecedor_habilitado,
+            com_calculos.cm_anual,
+            com_calculos.cp,
+            com_calculos.z_classe_a,
+            com_calculos.z_classe_b,
+            com_calculos.z_classe_c,
+            com_calculos.modo_pedido,
+            com_calculos.minimo_operacional,
+            com_calculos.z_aplicado,
+            com_calculos.sigma_lt_d,
+            com_calculos.status_sugestao,
+            ceil((com_calculos.z_aplicado * com_calculos.sigma_lt_d)) AS ss_calculado,
+            ceil(((COALESCE(com_calculos.d, (0)::numeric) * COALESCE(com_calculos.lt, (10)::numeric)) + (com_calculos.z_aplicado * com_calculos.sigma_lt_d))) AS pp_calculado,
+                CASE
+                    WHEN ((com_calculos.preco_item_eoq > (0)::numeric) AND (com_calculos.cm_anual > (0)::numeric) AND (com_calculos.d > (0)::numeric)) THEN ceil(sqrt((((2.0 * (COALESCE(com_calculos.d, (0)::numeric) * (252)::numeric)) * com_calculos.cp) / (com_calculos.cm_anual * com_calculos.preco_item_eoq))))
+                    ELSE (1)::numeric
+                END AS qc_eoq
+           FROM com_calculos
+        )
+ SELECT empresa,
+    sku_codigo_omie,
+    sku_descricao,
+    fornecedor_nome,
+    fornecedor_habilitado,
+    fonte_fornecedor,
+    grupo_codigo,
+    classe_abc_proposta,
+    classe_xyz_proposta,
+    classe AS classe_consolidada,
+    num_ordens,
+    d AS demanda_media_diaria,
+    qtde_media_por_ordem,
+    qtde_desvio_por_ordem,
+    coef_variacao_ordem,
+    p90_diario,
+    p95_diario,
+    p99_diario,
+    p90_quando_vende,
+    p95_quando_vende,
+    pico_maximo_dia,
+    dias_com_movimento,
+    valor_total_180d,
+    sigma_d AS demanda_sigma_diario,
+    lt AS lead_time_medio,
+    lt_total_teorico_dias_uteis,
+    lt_historico_medio,
+    fonte_lt,
+    sigma_lt AS lead_time_desvio,
+    lt_p95_dias,
+    fonte_leadtime,
+    sigma_lt_d,
+    z_aplicado,
+    minimo_operacional,
+    preco_venda_medio,
+    preco_compra_real,
+    preco_item_eoq,
+    fonte_preco,
+    n_compras,
+    (cm_anual * (100)::numeric) AS custo_capital_efetivo_perc,
+    cp AS custo_pedido_aplicado,
+    modo_pedido,
+    status_sugestao,
+        CASE
+            WHEN (status_sugestao = 'OK'::text) THEN GREATEST(ss_calculado, (COALESCE(minimo_operacional, 0))::numeric)
+            ELSE NULL::numeric
+        END AS estoque_minimo_sugerido,
+        CASE
+            WHEN (status_sugestao = 'OK'::text) THEN GREATEST(pp_calculado, (GREATEST(ss_calculado, (COALESCE(minimo_operacional, 0))::numeric) + (1)::numeric))
+            ELSE NULL::numeric
+        END AS ponto_pedido_sugerido,
+        CASE
+            WHEN (status_sugestao = 'OK'::text) THEN GREATEST(qc_eoq, (1)::numeric)
+            ELSE NULL::numeric
+        END AS qtde_compra_ciclo_sugerida,
+        CASE
+            WHEN (status_sugestao = 'OK'::text) THEN (GREATEST(pp_calculado, (GREATEST(ss_calculado, (COALESCE(minimo_operacional, 0))::numeric) + (1)::numeric)) + GREATEST(qc_eoq, (1)::numeric))
+            ELSE NULL::numeric
+        END AS estoque_maximo_sugerido,
+        CASE
+            WHEN ((status_sugestao = 'OK'::text) AND (d > (0)::numeric)) THEN (ceil((GREATEST(qc_eoq, (1)::numeric) / d)))::integer
+            ELSE NULL::integer
+        END AS cobertura_alvo_dias,
+    COALESCE(valor_total_90d, valor_total_180d) AS valor_total_90d,
+    CURRENT_DATE AS calculado_em,
+        CASE
+            WHEN (status_sugestao = 'OK'::text) THEN ss_calculado
+            ELSE NULL::numeric
+        END AS estoque_seguranca_sugerido
+   FROM com_formulas
+  ORDER BY
+        CASE status_sugestao
+            WHEN 'OK'::text THEN 1
+            WHEN 'AGUARDANDO_CLASSIFICACAO_GRUPO'::text THEN 2
+            WHEN 'AGUARDANDO_HABILITACAO_FORNECEDOR'::text THEN 3
+            WHEN 'SEM_LEADTIME_DEFINIDO'::text THEN 4
+            WHEN 'SEM_PRECO'::text THEN 5
+            ELSE 6
+        END, valor_total_180d DESC NULLS LAST;


### PR DESCRIPTION
## O quê
A base de custo da reposição deixa de usar a **média de compras passadas** e passa a usar o **cmc** (Custo Médio Contábil do Omie, de `inventory_position`, sync 30min). O founder via **R$436** na tela mas **R$536** no Omie — a média lag; o cmc é o custo real atual.

## View `v_sku_parametros_sugeridos` (CREATE OR REPLACE)
- Nova CTE `precos_cmc`: `cmc>0` por (empresa,sku), mapeando account→empresa (`vendas`/`oben`→OBEN, `colacor_vendas`/`colacor`→COLACOR, `servicos`/`colacor_sc`→COLACOR_SC), `DISTINCT ON` preferindo o mais fresco.
- `preco_item_eoq = COALESCE(cmc, media_compras, venda*0.55)` → entra no EOQ → `estoque_maximo`.
- `fonte_preco` ganha **'cmc'**. **R$ venda** (preco_venda_medio) **intacto**.
- **SEM nova coluna de saída** (51 colunas preservadas) → CREATE OR REPLACE sem risco de reorder.

## Frontend
"R$ compra" mostra o **custo usado** (`preco_item_eoq`=cmc) + badge **"Custo Omie"**; `SkuDetailSheet` mostra o custo usado **e** a média histórica (referência).

## Validação (PG17, `db/test-a2-cmc-view.sh`, 7 asserts)
REPLACE da view de prod + o REPLACE por cima → **sem erro de reorder** (51 colunas). Lógica: cmc fresco vence o 'oben' velho · cmc=0 → média · **cmc negativo → média** · sem cmc/média → venda×0.55 · COLACOR mapeia colacor_vendas · fonte='cmc' · 1 linha/sku. typecheck/lint/**399 testes**/build verdes.

⚠️ **Codex challenge indisponível** (CLI pendurando no stdin hoje) → revisão adversária própria + PG17. Re-rodo o challenge quando o codex recuperar.

## Efeito (money-path)
Custo real (maior) → **EOQ/lote de compra um pouco menor**; ponto de pedido e segurança (em unidades) **não mudam**. O disparo (nValUnit) já usava cmc — alinha.

## ⚠️ Deploy
- **Migration manual** (`20260606150000`, CREATE OR REPLACE VIEW) — colar no SQL Editor.
- **Publish** (frontend).

🤖 Generated with [Claude Code](https://claude.com/claude-code)