### PR TITLE
feat(lente): trocar/sair pelo banner + exclui o master da lista 'Ver como'

### DIFF
--- a/src/components/impersonation/ImpersonationBanner.tsx
+++ b/src/components/impersonation/ImpersonationBanner.tsx
@@ -1,14 +1,22 @@
 import { useEffect } from 'react';
-import { Eye, X } from 'lucide-react';
+import { Eye, X, ChevronDown } from 'lucide-react';
 import { toast } from 'sonner';
 import { useImpersonation } from '@/contexts/ImpersonationContext';
 import { useAuth } from '@/contexts/AuthContext';
 import { useImpersonatedAccessProfile } from '@/hooks/useImpersonatedAccessProfile';
+import { useImpersonationTargets } from '@/hooks/useImpersonationTargets';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 
 export function ImpersonationBanner() {
-  const { isImpersonating, target, stopImpersonation } = useImpersonation();
+  const { isImpersonating, target, startImpersonation, stopImpersonation } = useImpersonation();
   const { user } = useAuth();
   const { data: perfil, isError } = useImpersonatedAccessProfile();
+  const { data: targets = [] } = useImpersonationTargets();
 
   // Auto-saída em falha PERSISTENTE da RPC get_user_access_profile_for: sem o perfil
   // do alvo a lente não reflete o acesso dele (rebaixaria fail-closed e confundiria).
@@ -25,13 +33,30 @@ export function ImpersonationBanner() {
 
   if (!isImpersonating || !target) return null;
   const contexto = [perfil?.commercialRole, perfil?.department].filter(Boolean).join(' · ');
+  // Outras pessoas pra trocar direto pelo banner (a lista já exclui o próprio master).
+  const outros = targets.filter((t) => t.id !== target.id);
   return (
     <div className="fixed top-0 inset-x-0 z-50 h-7 bg-status-warning-bold text-white text-xs flex items-center justify-center gap-3 px-3">
       <Eye className="w-3.5 h-3.5 shrink-0" />
       <span className="truncate">
-        Lente de navegação/leitura como <strong>{target.nome}</strong>
-        {contexto ? ` (${contexto})` : ''} · escritas bloqueadas · RLS continua sendo {user?.email ?? 'master'}
+        Vendo como <strong>{target.nome}</strong>
+        {contexto ? ` (${contexto})` : ''} · somente leitura · RLS: {user?.email ?? 'master'}
       </span>
+      {outros.length > 0 && (
+        <DropdownMenu>
+          <DropdownMenuTrigger className="flex items-center gap-1 underline shrink-0 outline-none">
+            Trocar <ChevronDown className="w-3 h-3" />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="max-h-72 overflow-y-auto">
+            {outros.map((t) => (
+              <DropdownMenuItem key={t.id} onClick={() => startImpersonation(t, 'Troca via banner da lente')}>
+                <span className="truncate">{t.nome}</span>
+                {t.grupo && <span className="ml-2 text-2xs text-muted-foreground shrink-0">{t.grupo}</span>}
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      )}
       <button onClick={() => stopImpersonation()} className="flex items-center gap-1 underline shrink-0">
         <X className="w-3.5 h-3.5" /> Sair
       </button>

--- a/src/hooks/__tests__/useImpersonationTargets.test.tsx
+++ b/src/hooks/__tests__/useImpersonationTargets.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import { useImpersonationTargets } from '@/hooks/useImpersonationTargets';
+
+const authMock = vi.fn();
+const rpcMock = vi.fn();
+vi.mock('@/contexts/AuthContext', () => ({ useAuth: () => authMock() }));
+vi.mock('@/integrations/supabase/client', () => ({ supabase: { rpc: (...a: unknown[]) => rpcMock(...a) } }));
+
+function wrapper({ children }: { children: ReactNode }) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  authMock.mockReturnValue({ isMaster: true, user: { id: 'master-1' } });
+  rpcMock.mockResolvedValue({
+    data: [
+      // a RPC list_impersonation_targets devolve TODOS os donos de carteira — inclusive
+      // o próprio master, que costuma ter carteira própria.
+      { user_id: 'master-1', nome: 'Lucas (master)', commercial_role: 'super_admin' },
+      { user_id: 'regina-1', nome: 'Regina', commercial_role: 'farmer' },
+      { user_id: 'tatiana-1', nome: 'Tatiana', commercial_role: 'hunter' },
+    ],
+    error: null,
+  });
+});
+
+describe('useImpersonationTargets', () => {
+  it('exclui o próprio master da lista (não "ver como você mesmo")', async () => {
+    const { result } = renderHook(() => useImpersonationTargets(), { wrapper });
+    await waitFor(() => expect(result.current.data?.length).toBe(2));
+    const ids = (result.current.data ?? []).map((t) => t.id);
+    expect(ids).not.toContain('master-1'); // o master sumiu da lista
+    expect(ids).toEqual(['regina-1', 'tatiana-1']); // só os outros donos de carteira
+  });
+
+  it('mapeia o grupo (hunter/farmer)', async () => {
+    const { result } = renderHook(() => useImpersonationTargets(), { wrapper });
+    await waitFor(() => expect(result.current.data?.length).toBe(2));
+    const byId = Object.fromEntries((result.current.data ?? []).map((t) => [t.id, t.grupo]));
+    expect(byId['regina-1']).toBe('farmer');
+    expect(byId['tatiana-1']).toBe('hunter');
+  });
+});

--- a/src/hooks/useImpersonationTargets.ts
+++ b/src/hooks/useImpersonationTargets.ts
@@ -4,9 +4,9 @@ import { useAuth } from '@/contexts/AuthContext';
 import type { ImpersonationTarget } from '@/lib/impersonation/types';
 
 export function useImpersonationTargets() {
-  const { isMaster } = useAuth();
+  const { isMaster, user } = useAuth();
   return useQuery({
-    queryKey: ['impersonation-targets'],
+    queryKey: ['impersonation-targets', user?.id],
     enabled: isMaster,
     staleTime: 300_000,
     queryFn: async (): Promise<ImpersonationTarget[]> => {
@@ -17,7 +17,12 @@ export function useImpersonationTargets() {
       const rows = (data ?? []) as Array<{ user_id: string; nome: string; commercial_role: string | null }>;
       const grupo = (cr: string | null): ImpersonationTarget['grupo'] =>
         cr === 'hunter' ? 'hunter' : cr === 'closer' ? 'closer' : cr ? 'farmer' : null;
-      return rows.map((r) => ({ id: r.user_id, nome: r.nome, grupo: grupo(r.commercial_role) }));
+      // Exclui o PRÓPRIO master da lista — a RPC `list_impersonation_targets` devolve todos
+      // os donos de carteira, e o master frequentemente também tem carteira própria; "ver
+      // como você mesmo" não faz sentido (= só sair da lente). Saída é via "Sair" no banner.
+      return rows
+        .filter((r) => r.user_id !== user?.id)
+        .map((r) => ({ id: r.user_id, nome: r.nome, grupo: grupo(r.commercial_role) }));
     },
   });
 }


### PR DESCRIPTION
Sobre a Fase 1+2 (já na main). Dois ajustes pedidos pelo founder no QA:

1. **Trocar pessoa + sair pelo próprio banner.** O chip "Ver como" só vive no MasterDashboard → quando a lente mostra o dashboard de uma vendedora, ele some, e a única saída era o "Sair" do banner. Agora o banner tem um dropdown **"Trocar"** (troca de alvo direto) ao lado do **"Sair"** — a lente fica auto-suficiente, sem depender do dashboard.
2. **Exclui o próprio master da lista "Ver como".** A RPC `list_impersonation_targets` devolve TODOS os donos de carteira; o master costuma ter carteira própria → ele aparecia na lista (e era rotulado "farmer" pelo mapeamento solto do `grupo`). "Ver como você mesmo" = só sair, sem sentido. `useImpersonationTargets` agora filtra `user.id`. + teste de regressão.

**Nota:** o fix de posicionamento do banner (fixed/z-50, que destravou o "Sair") foi no #665, já mergeado. Este PR é só o switcher + exclude-self (rebasado sobre a main com o #665).

typecheck + lint + teste verdes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)