### PR TITLE
feat(reposição): reativar SKU descontinuado (filtro na Revisão)

### DIFF
--- a/docs/superpowers/plans/2026-06-06-reposicao-reativar-sku-descontinuado.md
+++ b/docs/superpowers/plans/2026-06-06-reposicao-reativar-sku-descontinuado.md
@@ -1,0 +1,489 @@
+# Reativar SKU descontinuado (filtro na Revisão) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Dar à tela de Revisão (`/admin/reposicao/revisao`) um filtro "Descontinuados" que lista os SKUs desligados de propósito pelo botão "descontinuar SKU" dos Pedidos, com uma ação inline "Reativar" que os religa à reposição automática.
+
+**Architecture:** 100% frontend. Reusa o padrão da Revisão (troca de fonte de dados por `statusFilter` + ação inline no `SkuRow`, espelhando o "Promover"). "Reativar" = `UPDATE sku_parametros SET habilitado_reposicao_automatica=true, tipo_reposicao='automatica'` via PostgREST — a mesma escrita que a tela já usa pra editar parâmetros. Bônus: o branch "Todos" deixa de vazar descontinuados.
+
+**Tech Stack:** React + TypeScript, @tanstack/react-query, Supabase JS (PostgREST), shadcn/ui (Select, AlertDialog), vitest. Sem migration, sem edge function. Deploy = Publish do front no Lovable.
+
+**Spec:** `docs/superpowers/specs/2026-06-06-reposicao-reativar-sku-descontinuado-design.md`
+
+---
+
+## File Structure
+
+- `src/lib/reposicao/sku-param.ts` — **modify**: `tipo_reposicao` no tipo `SkuParam`; `'descontinuados'` no `StatusFilterValue`; helpers `isDescontinuado` + `reativarPayload`.
+- `src/lib/reposicao/__tests__/skuParam.test.ts` — **modify**: testes dos 2 helpers novos.
+- `src/components/reposicao/revisao/useRevisaoParametros.ts` — **modify**: branch "descontinuados" + exclusão de descontinuados do "Todos" + `reativarMutation`.
+- `src/components/reposicao/revisao/FiltrosCard.tsx` — **modify**: opção "Descontinuados" no seletor.
+- `src/components/reposicao/revisao/SkuRow.tsx` — **modify**: badge "Descontinuado" + botão "Reativar" (AlertDialog).
+- `src/components/reposicao/revisao/RevisaoTable.tsx` — **modify**: repassa `onReativar`/`reativando` ao `SkuRow`.
+- `src/pages/AdminReposicaoRevisao.tsx` — **modify**: liga `reativarMutation` + aviso contextual.
+
+**Gate de acesso:** herdado da rota `/admin/reposicao/revisao` (comprador/gestor/master). A escrita reusa a RLS de `sku_parametros`. Nada a adicionar.
+
+---
+
+## Task 1: Tipo + helpers puros (TDD)
+
+**Files:**
+- Modify: `src/lib/reposicao/sku-param.ts`
+- Test: `src/lib/reposicao/__tests__/skuParam.test.ts`
+
+- [ ] **Step 1: Escrever os testes que falham**
+
+Em `src/lib/reposicao/__tests__/skuParam.test.ts`, adicione `isDescontinuado, reativarPayload` ao import existente de `'../sku-param'`:
+
+```ts
+import {
+  fonteBadgeVariant,
+  fonteBadgeLabel,
+  classBadge,
+  fmt,
+  fmtBRL,
+  isDescontinuado,
+  reativarPayload,
+} from '../sku-param';
+```
+
+E adicione ao **fim** do arquivo:
+
+```ts
+describe('isDescontinuado', () => {
+  it('true só para tipo_reposicao === "descontinuado"', () => {
+    expect(isDescontinuado({ tipo_reposicao: 'descontinuado' })).toBe(true);
+  });
+  it('false para automatica / null / undefined / produto_acabado', () => {
+    expect(isDescontinuado({ tipo_reposicao: 'automatica' })).toBe(false);
+    expect(isDescontinuado({ tipo_reposicao: null })).toBe(false);
+    expect(isDescontinuado({})).toBe(false);
+    expect(isDescontinuado({ tipo_reposicao: 'produto_acabado' })).toBe(false);
+  });
+});
+
+describe('reativarPayload', () => {
+  it('religa AMBOS os campos (habilitado=true E tipo=automatica)', () => {
+    // Trava contra religar só metade: deixar tipo='descontinuado' faria o motor
+    // continuar barrando o SKU mesmo com habilitado=true.
+    expect(reativarPayload()).toEqual({
+      habilitado_reposicao_automatica: true,
+      tipo_reposicao: 'automatica',
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Rodar e confirmar que falha**
+
+Run: `bun run test src/lib/reposicao/__tests__/skuParam.test.ts`
+Expected: FAIL — `isDescontinuado is not a function` / `reativarPayload is not a function`.
+
+- [ ] **Step 3: Implementar no `sku-param.ts`**
+
+(a) No tipo `SkuParam`, logo após `ultima_atualizacao_calculo: string | null;` (linha ~43), adicione:
+
+```ts
+  // Estado de reposição: 'automatica'/null = no motor; 'produto_acabado' = fabricado ('04');
+  // 'descontinuado' = desligado de propósito pelo humano (botão "descontinuar SKU" nos Pedidos).
+  // Opcional no tipo (os literais de view não o fornecem); o select('*') o traz em runtime.
+  tipo_reposicao?: string | null;
+```
+
+(b) Estenda `StatusFilterValue`:
+
+```ts
+export type StatusFilterValue = 'pendente' | 'aprovado' | 'aguardando_fornecedor' | 'primeira_compra' | 'todos' | 'descontinuados';
+```
+
+(c) No **fim** do arquivo, adicione os helpers:
+
+```ts
+/** SKU desligado de propósito pelo humano (botão "descontinuar SKU" nos Pedidos). */
+export const isDescontinuado = (row: { tipo_reposicao?: string | null }): boolean =>
+  row.tipo_reposicao === 'descontinuado';
+
+/**
+ * Campos que religam um SKU descontinuado ao motor de reposição automática.
+ * tipo='automatica' é seguro mesmo num fabricado '04' — a guarda do motor barra '04'
+ * independentemente (#527/#529). Religar SÓ `habilitado` deixaria tipo='descontinuado'
+ * e o motor seguiria barrando; por isso o payload reseta os DOIS campos.
+ */
+export const reativarPayload = (): { habilitado_reposicao_automatica: true; tipo_reposicao: 'automatica' } => ({
+  habilitado_reposicao_automatica: true,
+  tipo_reposicao: 'automatica',
+});
+```
+
+- [ ] **Step 4: Rodar e confirmar que passa**
+
+Run: `bun run test src/lib/reposicao/__tests__/skuParam.test.ts`
+Expected: PASS (todos, incluindo os testes pré-existentes).
+
+- [ ] **Step 5: Typecheck (este arquivo compila sozinho)**
+
+Run: `heavy bun run typecheck`
+Expected: sem novos erros (o `tipo_reposicao?` opcional não quebra os literais de view do hook).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/reposicao/sku-param.ts src/lib/reposicao/__tests__/skuParam.test.ts
+git commit -m "feat(reposicao): tipo_reposicao + helpers isDescontinuado/reativarPayload (reativar SKU)"
+```
+
+---
+
+## Task 2: Hook — branch "Descontinuados" + esconder do "Todos" + reativarMutation
+
+**Files:**
+- Modify: `src/components/reposicao/revisao/useRevisaoParametros.ts`
+
+- [ ] **Step 1: Import do `reativarPayload`**
+
+Na linha de import de `@/lib/reposicao/sku-param` (linha 9), adicione `reativarPayload`:
+
+```ts
+import { type SkuParam, type RowWithPrice, type StatusFilterValue, reativarPayload } from "@/lib/reposicao/sku-param";
+```
+
+- [ ] **Step 2: Bifurcar o fall-through (default vs descontinuados)**
+
+Substitua o bloco atual (linhas 167-179) — da declaração `let q = supabase.from("sku_parametros")...` até `.or("tipo_reposicao.is.null,tipo_reposicao.neq.produto_acabado");` — por:
+
+```ts
+      // Fall-through: branch "Todos" (default) E branch "Descontinuados" — mesma tabela
+      // (sku_parametros), mesmo enriquecimento de preço e mapeamento abaixo; só o predicado muda.
+      let q = supabase
+        .from("sku_parametros")
+        .select("*", { count: "exact" })
+        .eq("empresa", empresa);
+
+      if (statusFilter === "descontinuados") {
+        // SKUs desligados de propósito pelo humano (botão "descontinuar SKU" nos Pedidos).
+        // Sem filtro de ativo/estoque_minimo: mostra tudo que o humano descontinuou, com preço
+        // (o gatilho de reativar é "o preço voltou a ser competitivo").
+        q = q.eq("tipo_reposicao", "descontinuado");
+      } else {
+        // "Todos": esconde Produto Acabado ('04', fabricado) E descontinuados, preservando os NULL
+        // (ainda não classificados). Antes, descontinuado VAZAVA aqui (só tipo='produto_acabado' saía).
+        // String estática (sem interpolação) → não dispara a regra no-restricted-syntax do .or().
+        q = q
+          .eq("ativo", true)
+          .not("estoque_minimo", "is", null)
+          .or("tipo_reposicao.is.null,and(tipo_reposicao.neq.produto_acabado,tipo_reposicao.neq.descontinuado)");
+      }
+```
+
+O restante do bloco (a partir de `if (classes.length > 0) q = q.in(...)`, a ordenação, o `range`, e todo o enriquecimento de preço via `v_sku_parametros_sugeridos`) permanece **idêntico** — vale para os dois branches.
+
+- [ ] **Step 3: Adicionar a `reativarMutation`**
+
+Logo após o bloco `promoverMutation` (termina na linha ~278, antes de `const toggleClasse`), adicione:
+
+```ts
+  // Reativa um SKU descontinuado: religa a reposição automática (espelho do "descontinuar SKU"
+  // dos Pedidos). Update direto — a mesma escrita PostgREST que a tela já usa pra editar
+  // parâmetros (updateMutation). Por empresa+sku, simétrico ao descontinuarMutation.
+  const reativarMutation = useMutation({
+    mutationFn: async (sku: number) => {
+      const { error } = await supabase
+        .from("sku_parametros")
+        .update(reativarPayload())
+        .eq("empresa", empresa)
+        .eq("sku_codigo_omie", sku);
+      if (error) throw error;
+    },
+    onSuccess: () => {
+      toast.success("SKU reativado — volta a ser sugerido no próximo ciclo");
+      queryClient.invalidateQueries({ queryKey: ["sku_parametros_revisao"] });
+    },
+    onError: (e: Error) => toast.error("Falha ao reativar: " + e.message),
+  });
+```
+
+- [ ] **Step 4: Expor no return**
+
+No objeto de retorno do hook (linhas 298-318), adicione `reativarMutation` logo após `promoverMutation,`:
+
+```ts
+    updateMutation,
+    promoverMutation,
+    reativarMutation,
+  };
+```
+
+- [ ] **Step 5: Typecheck**
+
+Run: `heavy bun run typecheck`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/reposicao/revisao/useRevisaoParametros.ts
+git commit -m "feat(reposicao): filtro Descontinuados na Revisao + reativarMutation (esconde do Todos)"
+```
+
+---
+
+## Task 3: UI — opção de filtro, badge, botão Reativar e wiring
+
+**Files:**
+- Modify: `src/components/reposicao/revisao/FiltrosCard.tsx`
+- Modify: `src/components/reposicao/revisao/SkuRow.tsx`
+- Modify: `src/components/reposicao/revisao/RevisaoTable.tsx`
+- Modify: `src/pages/AdminReposicaoRevisao.tsx`
+
+- [ ] **Step 1: `FiltrosCard` — opção "Descontinuados"**
+
+No `<SelectContent>` (após o `<SelectItem value="primeira_compra">…</SelectItem>`, linha ~74), adicione:
+
+```tsx
+                <SelectItem value="descontinuados">
+                  Descontinuados
+                </SelectItem>
+```
+
+- [ ] **Step 2: `SkuRow` — imports (helper + AlertDialog)**
+
+(a) Adicione `isDescontinuado` ao import de `@/lib/reposicao/sku-param`:
+
+```tsx
+import {
+  type RowWithPrice,
+  fonteBadgeVariant,
+  fonteBadgeLabel,
+  classBadge,
+  fmt,
+  fmtBRL,
+  isDescontinuado,
+} from "@/lib/reposicao/sku-param";
+```
+
+(b) Adicione o import do AlertDialog (após o import de `Button`):
+
+```tsx
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+```
+
+- [ ] **Step 3: `SkuRow` — props e flag**
+
+Estenda a interface:
+
+```tsx
+interface SkuRowProps {
+  row: RowWithPrice;
+  onOpenDetail: (row: RowWithPrice) => void;
+  onPromover?: (sku: number) => void;
+  promovendo?: boolean;
+  onReativar?: (sku: number) => void;
+  reativando?: boolean;
+}
+```
+
+Atualize a assinatura e adicione a flag no topo do componente:
+
+```tsx
+export function SkuRow({ row: r, onOpenDetail, onPromover, promovendo, onReativar, reativando }: SkuRowProps) {
+  const isCandidato = r.status_sugestao === "CANDIDATO_PRIMEIRA_COMPRA";
+  const umClienteSo = isCandidato && r.recorrencia_clientes_180d === 1;
+  const descontinuado = isDescontinuado(r);
+```
+
+- [ ] **Step 4: `SkuRow` — badge "Descontinuado" na coluna Status**
+
+Substitua a coluna Status (o `<TableCell>` que começa em `isCandidato ? (` … até o `</TableCell>` antes da coluna de ações, linhas 81-101) por:
+
+```tsx
+      <TableCell>
+        {descontinuado ? (
+          <Badge
+            variant="secondary"
+            className="bg-muted text-muted-foreground border-muted-foreground/20"
+            title="SKU descontinuado — fora da reposição automática. Reative quando voltar a comprar."
+          >
+            Descontinuado
+          </Badge>
+        ) : isCandidato ? (
+          <Badge
+            variant="secondary"
+            className="bg-status-info-bg text-status-info border-status-info/20"
+            title="Vende com recorrência mas está fora da reposição automática. Revise e promova: entra no fluxo normal de compra (qtde-teste capada)."
+          >
+            Candidato 1ª compra
+          </Badge>
+        ) : r.read_only ? (
+          <Badge
+            variant="secondary"
+            className="bg-muted text-muted-foreground border-muted-foreground/20"
+            title="SKU bloqueado: fornecedor ainda não habilitado para reposição automática"
+          >
+            Aguardando fornecedor
+          </Badge>
+        ) : (
+          <span className="text-muted-foreground">—</span>
+        )}
+      </TableCell>
+```
+
+- [ ] **Step 5: `SkuRow` — botão "Reativar" na coluna de ações**
+
+Na coluna de ações (o `<div className="flex items-center justify-end gap-1">`), adicione o bloco abaixo **logo antes** do botão "Detalhes" (`<Button size="sm" variant="ghost" onClick={() => onOpenDetail(r)}>`):
+
+```tsx
+          {descontinuado && onReativar && (
+            <AlertDialog>
+              <AlertDialogTrigger asChild>
+                <Button size="sm" variant="outline" disabled={reativando}>
+                  {reativando ? <Loader2 className="h-4 w-4 animate-spin" /> : "Reativar"}
+                </Button>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>Reativar SKU?</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    <span className="font-mono">{r.sku_codigo_omie}</span> — {r.sku_descricao ?? "—"}.
+                    <br />
+                    Volta para a reposição automática e passa a ser sugerido no próximo ciclo
+                    (só se o estoque estiver no ponto de pedido). Os parâmetros antigos são preservados.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel disabled={reativando}>Voltar</AlertDialogCancel>
+                  <AlertDialogAction onClick={() => onReativar(r.sku_codigo_omie)} disabled={reativando}>
+                    Reativar
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+          )}
+```
+
+- [ ] **Step 6: `RevisaoTable` — repassar props**
+
+Estenda a interface `RevisaoTableProps` (adicione após `promovendo?: boolean;`):
+
+```tsx
+  onReativar?: (sku: number) => void;
+  reativando?: boolean;
+```
+
+Adicione ao destructuring de props da função (após `promovendo,`):
+
+```tsx
+  onReativar,
+  reativando,
+```
+
+E repasse ao `<SkuRow>` no `.map` (após `promovendo={promovendo}`):
+
+```tsx
+                <SkuRow
+                  key={r.id}
+                  row={r}
+                  onOpenDetail={onOpenDetail}
+                  onPromover={onPromover}
+                  promovendo={promovendo}
+                  onReativar={onReativar}
+                  reativando={reativando}
+                />
+```
+
+- [ ] **Step 7: `AdminReposicaoRevisao` — ligar a mutation + aviso contextual**
+
+(a) No destructuring do hook (após `promoverMutation,`), adicione:
+
+```tsx
+    promoverMutation,
+    reativarMutation,
+  } = useRevisaoParametros();
+```
+
+(b) No `<RevisaoTable>`, adicione (após `promovendo={promoverMutation.isPending}`):
+
+```tsx
+        onPromover={(sku) => promoverMutation.mutate(sku)}
+        promovendo={promoverMutation.isPending}
+        onReativar={(sku) => reativarMutation.mutate(sku)}
+        reativando={reativarMutation.isPending}
+      />
+```
+
+(c) Adicione o aviso contextual logo após o bloco `{statusFilter === "primeira_compra" && (…)}` (antes do `<FiltrosCard>`):
+
+```tsx
+      {statusFilter === "descontinuados" && (
+        <p className="text-sm text-muted-foreground">
+          SKUs que você descontinuou de propósito (fora da reposição automática). Clique em
+          <strong> Reativar</strong> quando o preço voltar a ser competitivo — o item volta ao fluxo
+          normal de compra a partir do próximo ciclo (o motor só compra se o estoque estiver baixo).
+        </p>
+      )}
+```
+
+- [ ] **Step 8: Typecheck + lint**
+
+Run: `heavy bun run typecheck && bun lint`
+Expected: typecheck PASS; lint sem novos erros (em especial, sem `no-restricted-syntax` — o `.or()` novo é string estática).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/components/reposicao/revisao/FiltrosCard.tsx src/components/reposicao/revisao/SkuRow.tsx src/components/reposicao/revisao/RevisaoTable.tsx src/pages/AdminReposicaoRevisao.tsx
+git commit -m "feat(reposicao): UI do filtro Descontinuados + botao Reativar na Revisao"
+```
+
+---
+
+## Task 4: Verificação integrada + atualização do SkuRow.test (se existir)
+
+**Files:**
+- Possivelmente: `src/components/reposicao/revisao/__tests__/SkuRow.test.tsx` (já existe)
+
+- [ ] **Step 1: Conferir o teste do SkuRow**
+
+Run: `bun run test src/components/reposicao/revisao/__tests__/SkuRow.test.tsx`
+Expected: PASS. As props novas (`onReativar`/`reativando`) são opcionais → o render existente não quebra. Se algum teste construir `row` sem `tipo_reposicao`, segue válido (`isDescontinuado` → false). **Não** adicionar teste novo de UI a menos que a suíte quebre; a lógica testável já está no helper puro (Task 1).
+
+- [ ] **Step 2: Suíte completa + build**
+
+Run: `heavy bun run test`
+Expected: PASS (a CLAUDE.md cita baseline 241/241; deve subir com os 2 testes novos do helper).
+
+Run: `heavy bun run build`
+Expected: build OK (sem PWA em dev é `build:dev`; aqui valide o `build`).
+
+- [ ] **Step 3: Commit (se houve ajuste de teste)**
+
+```bash
+git add -A
+git commit -m "test(reposicao): valida SkuRow com filtro Descontinuados"
+```
+
+Se nada mudou neste passo, pule o commit.
+
+---
+
+## Verificação manual (critério de pronto — pós-Publish no Lovable)
+
+1. Em `/admin/reposicao/pedidos`, descontinuar um SKU de teste (botão 🚫).
+2. Em `/admin/reposicao/revisao`, filtro **"Todos"**: o SKU **não** aparece mais (antes vazava).
+3. Filtro **"Descontinuados"**: o SKU aparece, com badge "Descontinuado" e preço de compra/venda visível.
+4. Clicar **"Reativar"** → confirmar → toast "SKU reativado…" → o SKU some da lista de descontinuados.
+5. Conferir no banco (SQL Editor, read-only): `SELECT tipo_reposicao, habilitado_reposicao_automatica FROM sku_parametros WHERE empresa='OBEN' AND sku_codigo_omie=<sku>` → `automatica` / `true`.
+
+## Deploy
+
+- **Só Publish do frontend no Lovable.** Sem SQL Editor, sem deploy de edge function.

--- a/docs/superpowers/specs/2026-06-06-reposicao-reativar-sku-descontinuado-design.md
+++ b/docs/superpowers/specs/2026-06-06-reposicao-reativar-sku-descontinuado-design.md
@@ -1,0 +1,97 @@
+# Reposição — Reativar SKU descontinuado (filtro na Revisão)
+
+**Data:** 2026-06-06
+**Empresa-alvo:** OBEN (mas o mecanismo é por-empresa, agnóstico)
+**Tipo:** feature de UI, **100% frontend** — sem migration, sem edge function, sem deploy de backend (só Publish do front)
+
+## Problema
+
+Na tela de Pedidos (`/admin/reposicao/pedidos`), o botão 🚫 **"Remover linha + descontinuar SKU"** (`descontinuarMutation` em `src/components/reposicao/pedidos/useDetalhesModal.ts:277`) marca o SKU como descontinuado:
+
+```sql
+UPDATE sku_parametros
+SET tipo_reposicao = 'descontinuado',
+    habilitado_reposicao_automatica = false
+WHERE empresa = <emp> AND sku_codigo_omie = <sku>;
+-- + DELETE da linha do pedido atual
+```
+
+A ação é **mão única**: não há nenhum lugar na interface para ver os SKUs descontinuados nem para religá-los. Hoje a única forma de voltar a comprar é um `UPDATE` manual no SQL Editor do Lovable.
+
+**Caso de uso do founder:** descontinuar itens cujo **preço deixou de ser competitivo**; quando o preço voltar, **reativar** para o motor de reposição voltar a sugeri-los.
+
+**Bug correlato encontrado:** descontinuar só toca `tipo_reposicao` e `habilitado_reposicao_automatica` — **não** mexe em `ativo` nem `estoque_minimo`. O branch default ("Todos") da Revisão filtra por `ativo=true` + `estoque_minimo IS NOT NULL` + `.or("tipo_reposicao.is.null,tipo_reposicao.neq.produto_acabado")` — e `'descontinuado'` passa nesse `.or()`. Logo **os descontinuados vazam hoje na lista "Todos"** sem nenhum indicativo de estado. Corrigir junto.
+
+## Objetivo
+
+Um lugar na tela de **Revisão** (`/admin/reposicao/revisao`) para (a) **listar** os SKUs descontinuados de propósito e (b) **reativá-los** com um toque. Decisão de produto já tomada: mora como **filtro na Revisão** (não tela dedicada).
+
+## Por que "filtro na Revisão" é o encaixe natural
+
+A Revisão já troca a fonte de dados por valor de `statusFilter` (branches `aguardando_fornecedor` e `primeira_compra` em `useRevisaoParametros.ts`), e já tem uma ação inline no `SkuRow` que **habilita** um SKU ("Promover" candidato → `promoverMutation`). "Descontinuados" é mais um branch de fonte; "Reativar" é o espelho de "Promover".
+
+`tipo_reposicao='descontinuado'` é exatamente o marcador que distingue **"descontinuei de propósito pelo botão"** de desligado por outros motivos (ex.: `produto_acabado`, desligado pelo Sentinela). É a chave de listagem.
+
+## Solução (abordagem escolhida)
+
+100% frontend, reusando o padrão da tela. Reativar = a mesma escrita PostgREST que a Revisão **já** usa para editar parâmetros money-path (ponto de pedido, mínimo forçado via `updateMutation`). Descartada a alternativa de RPC `SECURITY DEFINER` dedicada: seria inconsistente (a edição de parâmetros já é PostgREST direto) e custaria o ritual de migration manual do Lovable sem ganho real de segurança.
+
+### Mudanças
+
+1. **`StatusFilterValue`** (`src/lib/reposicao/sku-param.ts`): adicionar `'descontinuados'` à união
+   (`'pendente' | 'aprovado' | 'aguardando_fornecedor' | 'primeira_compra' | 'todos' | 'descontinuados'`).
+
+2. **`FiltrosCard.tsx`**: nova opção **"Descontinuados"** no seletor de status.
+
+3. **`useRevisaoParametros.ts` — branch novo** `if (statusFilter === 'descontinuados')`:
+   - Query: `sku_parametros` da empresa com `tipo_reposicao = 'descontinuado'` (sem `habilitado`/`ativo` no filtro — mostra tudo que o humano descontinuou).
+   - Busca + classes reaproveitam o mesmo padrão dos outros branches.
+   - **Enriquecer com preço de compra atual** (`preco_compra_real` / `preco_venda_medio` via `v_sku_parametros_sugeridos.in(codes)`, igual ao branch default) — o gatilho de reativar é "o preço voltou a ser competitivo", então o preço precisa estar visível. Se a view não tiver linha para o SKU desligado, degrada para `—` (não bloqueia).
+   - Linhas marcadas com flag de estado para o `SkuRow` decidir renderizar "Reativar".
+
+4. **`useRevisaoParametros.ts` — branch default ("Todos") deixa de vazar descontinuados:**
+   - Estender o filtro para excluir `'descontinuado'` **preservando os NULL**:
+     `.or("tipo_reposicao.is.null,and(tipo_reposicao.neq.produto_acabado,tipo_reposicao.neq.descontinuado)")`.
+   - **String estática** (sem interpolação) → não dispara a regra ESLint `no-restricted-syntax` do `.or()`.
+
+5. **`reativarMutation`** no hook (espelha `promoverMutation`):
+   - `UPDATE sku_parametros SET habilitado_reposicao_automatica = true, tipo_reposicao = 'automatica' WHERE id = <id>`.
+   - `onSuccess`: toast `"SKU reativado — volta a ser sugerido no próximo ciclo"` + `invalidateQueries(['sku_parametros_revisao'])` (o SKU sai da lista de descontinuados).
+   - O payload e a predicate de estado saem de um **helper puro** (testável), não inline.
+
+6. **`SkuRow.tsx`**: botão **"Reativar"** inline (espelha o "Promover" do candidato) quando `tipo_reposicao === 'descontinuado'`, com `AlertDialog` de confirmação → chama `onReativar(row)`.
+
+### Helper puro (testável, vitest)
+
+Em `src/lib/reposicao/sku-param.ts` (ou módulo irmão):
+- `isDescontinuado(row): boolean` — `row.tipo_reposicao === 'descontinuado'`.
+- `reativarPayload(): { habilitado_reposicao_automatica: true; tipo_reposicao: 'automatica' }`.
+
+Testes: `isDescontinuado` distingue `'descontinuado'` de `'automatica'`/`null`/`'produto_acabado'`; `reativarPayload` retorna exatamente os 2 campos esperados (trava contra alguém "religar" só uma metade).
+
+## Comportamento de "Reativar" (e ressalvas)
+
+- **Não recria** a linha no pedido de onde o SKU foi removido (ela já foi apagada). O SKU volta a ser **sugerido no próximo ciclo** (cron `gerar-pedidos-diario` ~9h15) e **só se** `estoque_efetivo <= ponto_pedido`. Para comprar na hora, é compra manual no Omie.
+- **Parâmetros preservados:** descontinuar não apagou `ponto_pedido`/`estoque_maximo`/`estoque_minimo`/`minimo_forcado_manual` → reativar não precisa reconfigurar nada.
+- **`tipo_reposicao='automatica'` é seguro universalmente:** se o SKU for, por engano, um fabricado `'04'` (Produto Acabado), a guarda do motor (`metadata->>'tipo_produto' <> '04'` na RPC `gerar_pedidos_sugeridos_ciclo`, #527/#529) o barra independentemente. Por isso não é preciso preservar/repor o `tipo_reposicao` original (que o descontinuar sobrescreveu e não guardou).
+
+## Não-objetivos (YAGNI)
+
+- **Não** recriar a sugestão no ciclo de hoje (só religa; o cron diário resolve).
+- **Não** preservar o `tipo_reposicao` anterior (sempre `'automatica'`; a guarda do '04' cobre o único caso de risco).
+- **Não** criar RPC nem migration (a escrita já é PostgREST direto, coberta pela RLS de `sku_parametros`).
+- **Não** criar permissão nova: herda o gate da tela de Revisão (gestor comercial / master).
+- **Não** mexer no botão de descontinuar (continua como está) nem no fluxo de Pedidos.
+
+## Gate de acesso
+
+Herdado da tela de Revisão (`/admin/reposicao/revisao`), já restrita a comprador/gestor/master. A escrita reusa a RLS de `sku_parametros` (mesma que autoriza editar ponto de pedido hoje).
+
+## Teste / verificação
+
+- Helper puro com vitest (acima).
+- Sem backend para validar; o critério de pronto é o fluxo manual: descontinuar um SKU de teste em Pedidos → ele some de "Todos" e aparece em "Descontinuados" com preço → "Reativar" → some de "Descontinuados" e volta a `habilitado=true`/`tipo='automatica'`.
+
+## Deploy
+
+- **Só Publish do frontend no Lovable.** Sem SQL Editor, sem deploy de edge function.

--- a/src/components/reposicao/revisao/FiltrosCard.tsx
+++ b/src/components/reposicao/revisao/FiltrosCard.tsx
@@ -72,6 +72,9 @@ export function FiltrosCard({
                 <SelectItem value="primeira_compra">
                   Candidatos a 1ª compra
                 </SelectItem>
+                <SelectItem value="descontinuados">
+                  Descontinuados
+                </SelectItem>
               </SelectContent>
             </Select>
           </div>

--- a/src/components/reposicao/revisao/RevisaoTable.tsx
+++ b/src/components/reposicao/revisao/RevisaoTable.tsx
@@ -26,6 +26,8 @@ interface RevisaoTableProps {
   onNextPage: () => void;
   onPromover?: (sku: number) => void;
   promovendo?: boolean;
+  onReativar?: (sku: number) => void;
+  reativando?: boolean;
 }
 
 export function RevisaoTable({
@@ -39,6 +41,8 @@ export function RevisaoTable({
   onNextPage,
   onPromover,
   promovendo,
+  onReativar,
+  reativando,
 }: RevisaoTableProps) {
   return (
     <Card>
@@ -80,6 +84,8 @@ export function RevisaoTable({
                   onOpenDetail={onOpenDetail}
                   onPromover={onPromover}
                   promovendo={promovendo}
+                  onReativar={onReativar}
+                  reativando={reativando}
                 />
               ))}
               {rows.length === 0 && (

--- a/src/components/reposicao/revisao/SkuRow.tsx
+++ b/src/components/reposicao/revisao/SkuRow.tsx
@@ -11,7 +11,19 @@ import {
   classBadge,
   fmt,
   fmtBRL,
+  isDescontinuado,
 } from "@/lib/reposicao/sku-param";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
 import { type BadgeVariant } from "./types";
 
 interface SkuRowProps {
@@ -19,11 +31,14 @@ interface SkuRowProps {
   onOpenDetail: (row: RowWithPrice) => void;
   onPromover?: (sku: number) => void;
   promovendo?: boolean;
+  onReativar?: (sku: number) => void;
+  reativando?: boolean;
 }
 
-export function SkuRow({ row: r, onOpenDetail, onPromover, promovendo }: SkuRowProps) {
+export function SkuRow({ row: r, onOpenDetail, onPromover, promovendo, onReativar, reativando }: SkuRowProps) {
   const isCandidato = r.status_sugestao === "CANDIDATO_PRIMEIRA_COMPRA";
   const umClienteSo = isCandidato && r.recorrencia_clientes_180d === 1;
+  const descontinuado = isDescontinuado(r);
   return (
     <TableRow className={r.read_only ? "bg-muted/30" : undefined}>
       <TableCell className="font-mono text-xs align-top">{r.sku_codigo_omie}</TableCell>
@@ -79,7 +94,15 @@ export function SkuRow({ row: r, onOpenDetail, onPromover, promovendo }: SkuRowP
       <TableCell className="text-right">{fmt(r.ponto_pedido, 0)}</TableCell>
       <TableCell className="text-right">{fmt(r.estoque_maximo, 0)}</TableCell>
       <TableCell>
-        {isCandidato ? (
+        {descontinuado ? (
+          <Badge
+            variant="secondary"
+            className="bg-muted text-muted-foreground border-muted-foreground/20"
+            title="SKU descontinuado — fora da reposição automática. Reative quando voltar a comprar."
+          >
+            Descontinuado
+          </Badge>
+        ) : isCandidato ? (
           <Badge
             variant="secondary"
             className="bg-status-info-bg text-status-info border-status-info/20"
@@ -110,6 +133,32 @@ export function SkuRow({ row: r, onOpenDetail, onPromover, promovendo }: SkuRowP
             >
               {promovendo ? <Loader2 className="h-4 w-4 animate-spin" /> : "Promover"}
             </Button>
+          )}
+          {descontinuado && onReativar && (
+            <AlertDialog>
+              <AlertDialogTrigger asChild>
+                <Button size="sm" variant="outline" disabled={reativando}>
+                  {reativando ? <Loader2 className="h-4 w-4 animate-spin" /> : "Reativar"}
+                </Button>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>Reativar SKU?</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    <span className="font-mono">{r.sku_codigo_omie}</span> — {r.sku_descricao ?? "—"}.
+                    <br />
+                    Volta para a reposição automática e passa a ser sugerido no próximo ciclo
+                    (só se o estoque estiver no ponto de pedido). Os parâmetros antigos são preservados.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel disabled={reativando}>Voltar</AlertDialogCancel>
+                  <AlertDialogAction onClick={() => onReativar(r.sku_codigo_omie)} disabled={reativando}>
+                    Reativar
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
           )}
           <Button size="sm" variant="ghost" onClick={() => onOpenDetail(r)}>
             Detalhes

--- a/src/components/reposicao/revisao/useRevisaoParametros.ts
+++ b/src/components/reposicao/revisao/useRevisaoParametros.ts
@@ -6,7 +6,7 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
 import { useReposicaoEmpresa } from "@/contexts/ReposicaoEmpresaContext";
 import { toast } from "sonner";
-import { type SkuParam, type RowWithPrice, type StatusFilterValue } from "@/lib/reposicao/sku-param";
+import { type SkuParam, type RowWithPrice, type StatusFilterValue, reativarPayload } from "@/lib/reposicao/sku-param";
 import { PAGE_SIZE, type SkuSugeridoView } from "./types";
 
 export function useRevisaoParametros() {
@@ -164,19 +164,27 @@ export function useRevisaoParametros() {
         return { rows: priced, total: count ?? 0 };
       }
 
+      // Fall-through: branch "Todos" (default) E branch "Descontinuados" — mesma tabela
+      // (sku_parametros), mesmo enriquecimento de preço e mapeamento abaixo; só o predicado muda.
       let q = supabase
         .from("sku_parametros")
         .select("*", { count: "exact" })
-        .eq("empresa", empresa)
-        .eq("ativo", true)
-        .not("estoque_minimo", "is", null)
-        // Esconde Produto Acabado ('04' = fabricado internamente). O motor de compra
-        // já os ignora (gerar_pedidos_sugeridos_ciclo exige tipo_reposicao='automatica');
-        // na fila de aprovação de parâmetros eles eram só ruído (não há o que comprar).
-        // A cláusula is.null preserva quem ainda não tem tipo classificado (NULL/automatica/
-        // sob_encomenda ficam — só produto_acabado sai). String estática → não dispara a
-        // regra no-restricted-syntax do .or(). Ver #527/#529 (guarda do '04' no motor).
-        .or("tipo_reposicao.is.null,tipo_reposicao.neq.produto_acabado");
+        .eq("empresa", empresa);
+
+      if (statusFilter === "descontinuados") {
+        // SKUs desligados de propósito pelo humano (botão "descontinuar SKU" nos Pedidos).
+        // Sem filtro de ativo/estoque_minimo: mostra tudo que o humano descontinuou, com preço
+        // (o gatilho de reativar é "o preço voltou a ser competitivo").
+        q = q.eq("tipo_reposicao", "descontinuado");
+      } else {
+        // "Todos": esconde Produto Acabado ('04', fabricado) E descontinuados, preservando os NULL
+        // (ainda não classificados). Antes, descontinuado VAZAVA aqui (só tipo='produto_acabado' saía).
+        // String estática (sem interpolação) → não dispara a regra no-restricted-syntax do .or().
+        q = q
+          .eq("ativo", true)
+          .not("estoque_minimo", "is", null)
+          .or("tipo_reposicao.is.null,and(tipo_reposicao.neq.produto_acabado,tipo_reposicao.neq.descontinuado)");
+      }
 
       if (classes.length > 0) q = q.in("classe_consolidada", classes);
       if (search.trim()) {
@@ -277,6 +285,25 @@ export function useRevisaoParametros() {
     onError: (e: Error) => toast.error("Falha ao promover: " + e.message),
   });
 
+  // Reativa um SKU descontinuado: religa a reposição automática (espelho do "descontinuar SKU"
+  // dos Pedidos). Update direto — a mesma escrita PostgREST que a tela já usa pra editar
+  // parâmetros (updateMutation). Por empresa+sku, simétrico ao descontinuarMutation.
+  const reativarMutation = useMutation({
+    mutationFn: async (sku: number) => {
+      const { error } = await supabase
+        .from("sku_parametros")
+        .update(reativarPayload())
+        .eq("empresa", empresa)
+        .eq("sku_codigo_omie", sku);
+      if (error) throw error;
+    },
+    onSuccess: () => {
+      toast.success("SKU reativado — volta a ser sugerido no próximo ciclo");
+      queryClient.invalidateQueries({ queryKey: ["sku_parametros_revisao"] });
+    },
+    onError: (e: Error) => toast.error("Falha ao reativar: " + e.message),
+  });
+
   const toggleClasse = (c: string) => {
     setPage(0);
     setClasses((prev) => (prev.includes(c) ? prev.filter((x) => x !== c) : [...prev, c]));
@@ -315,5 +342,6 @@ export function useRevisaoParametros() {
     nextPage,
     updateMutation,
     promoverMutation,
+    reativarMutation,
   };
 }

--- a/src/lib/reposicao/__tests__/skuParam.test.ts
+++ b/src/lib/reposicao/__tests__/skuParam.test.ts
@@ -5,6 +5,8 @@ import {
   classBadge,
   fmt,
   fmtBRL,
+  isDescontinuado,
+  reativarPayload,
 } from '../sku-param';
 
 describe('fonteBadgeVariant', () => {
@@ -124,5 +126,28 @@ describe('fmtBRL', () => {
     const out = fmtBRL(1234.5);
     expect(out).toContain('R$');
     expect(out).toContain('1.234,50');
+  });
+});
+
+describe('isDescontinuado', () => {
+  it('true só para tipo_reposicao === "descontinuado"', () => {
+    expect(isDescontinuado({ tipo_reposicao: 'descontinuado' })).toBe(true);
+  });
+  it('false para automatica / null / undefined / produto_acabado', () => {
+    expect(isDescontinuado({ tipo_reposicao: 'automatica' })).toBe(false);
+    expect(isDescontinuado({ tipo_reposicao: null })).toBe(false);
+    expect(isDescontinuado({})).toBe(false);
+    expect(isDescontinuado({ tipo_reposicao: 'produto_acabado' })).toBe(false);
+  });
+});
+
+describe('reativarPayload', () => {
+  it('religa AMBOS os campos (habilitado=true E tipo=automatica)', () => {
+    // Trava contra religar só metade: deixar tipo='descontinuado' faria o motor
+    // continuar barrando o SKU mesmo com habilitado=true.
+    expect(reativarPayload()).toEqual({
+      habilitado_reposicao_automatica: true,
+      tipo_reposicao: 'automatica',
+    });
   });
 });

--- a/src/lib/reposicao/sku-param.ts
+++ b/src/lib/reposicao/sku-param.ts
@@ -41,6 +41,10 @@ export type SkuParam = {
   aprovado_por: string | null;
   justificativa_aprovacao: string | null;
   ultima_atualizacao_calculo: string | null;
+  // Estado de reposição: 'automatica'/null = no motor; 'produto_acabado' = fabricado ('04');
+  // 'descontinuado' = desligado de propósito pelo humano (botão "descontinuar SKU" nos Pedidos).
+  // Opcional no tipo (os literais de view não o fornecem); o select('*') o traz em runtime.
+  tipo_reposicao?: string | null;
 };
 
 export type ViewStats = {
@@ -80,7 +84,7 @@ export type RowWithPrice = SkuParam & {
   ja_habilitado?: boolean | null;
 };
 
-export type StatusFilterValue = 'pendente' | 'aprovado' | 'aguardando_fornecedor' | 'primeira_compra' | 'todos';
+export type StatusFilterValue = 'pendente' | 'aprovado' | 'aguardando_fornecedor' | 'primeira_compra' | 'todos' | 'descontinuados';
 
 export const fonteBadgeVariant = (
   fonte: string | null | undefined,
@@ -117,3 +121,18 @@ export const fmt = (v: number | null | undefined, dec = 2): string =>
 
 export const fmtBRL = (v: number | null | undefined): string =>
   v == null ? '—' : Number(v).toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
+
+/** SKU desligado de propósito pelo humano (botão "descontinuar SKU" nos Pedidos). */
+export const isDescontinuado = (row: { tipo_reposicao?: string | null }): boolean =>
+  row.tipo_reposicao === 'descontinuado';
+
+/**
+ * Campos que religam um SKU descontinuado ao motor de reposição automática.
+ * tipo='automatica' é seguro mesmo num fabricado '04' — a guarda do motor barra '04'
+ * independentemente (#527/#529). Religar SÓ `habilitado` deixaria tipo='descontinuado'
+ * e o motor seguiria barrando; por isso o payload reseta os DOIS campos.
+ */
+export const reativarPayload = (): { habilitado_reposicao_automatica: true; tipo_reposicao: 'automatica' } => ({
+  habilitado_reposicao_automatica: true,
+  tipo_reposicao: 'automatica',
+});

--- a/src/pages/AdminReposicaoRevisao.tsx
+++ b/src/pages/AdminReposicaoRevisao.tsx
@@ -27,6 +27,7 @@ export default function AdminReposicaoRevisao() {
     nextPage,
     updateMutation,
     promoverMutation,
+    reativarMutation,
   } = useRevisaoParametros();
 
   return (
@@ -40,6 +41,13 @@ export default function AdminReposicaoRevisao() {
           Itens que vendem com recorrência mas estão fora da reposição automática. Revise a recorrência
           e clique em <strong>Promover</strong> — entram no fluxo normal de compra com uma quantidade-teste
           capada (o motor só compra se o estoque estiver baixo).
+        </p>
+      )}
+      {statusFilter === "descontinuados" && (
+        <p className="text-sm text-muted-foreground">
+          SKUs que você descontinuou de propósito (fora da reposição automática). Clique em
+          <strong> Reativar</strong> quando o preço voltar a ser competitivo — o item volta ao fluxo
+          normal de compra a partir do próximo ciclo (o motor só compra se o estoque estiver baixo).
         </p>
       )}
 
@@ -65,6 +73,8 @@ export default function AdminReposicaoRevisao() {
         onNextPage={nextPage}
         onPromover={(sku) => promoverMutation.mutate(sku)}
         promovendo={promoverMutation.isPending}
+        onReativar={(sku) => reativarMutation.mutate(sku)}
+        reativando={reativarMutation.isPending}
       />
 
       <SkuDetailSheet


### PR DESCRIPTION
## Resumo

Fecha o caminho de volta do botão **"Remover linha + descontinuar SKU"** (tela de Pedidos): hoje descontinuar é mão única — não havia onde ver nem religar um SKU descontinuado (só `UPDATE` manual no SQL Editor).

- **Filtro "Descontinuados"** na tela de Revisão (`/admin/reposicao/revisao`): lista os SKUs com `tipo_reposicao='descontinuado'` (desligados de propósito pelo humano), com **preço de compra/venda à vista** (o gatilho de reativar é "o preço voltou a ser competitivo").
- **Botão "Reativar"** inline (com confirmação), espelhando o "Promover": religa o SKU à reposição automática (`habilitado_reposicao_automatica=true`, `tipo_reposicao='automatica'`). Volta a ser sugerido **no próximo ciclo** (e só se o estoque estiver no ponto de pedido).
- **Bugfix de brinde:** descontinuados deixam de **vazar na lista "Todos"** (antes apareciam lá sem indicação, porque descontinuar não mexe em `ativo`/`estoque_minimo`).

Reusa o padrão da tela (troca de fonte por `statusFilter` + a mesma escrita PostgREST que o editor de parâmetros já usa). Helper puro testado (`isDescontinuado`/`reativarPayload` — trava contra "religar só metade", que deixaria o motor barrando o SKU). `tipo_reposicao='automatica'` é seguro mesmo num fabricado '04' (a guarda do motor barra '04' independentemente).

## Sem backend

Sem migration, sem edge function. Deploy = **Publish do frontend no Lovable**.

## Test plan

- [x] Suíte completa: **2674/2674** verde
- [x] typecheck (strict) + lint (0 errors) + build OK
- [ ] Manual (pós-Publish): descontinuar um SKU em `/admin/reposicao/pedidos` → some de **Todos** → aparece em **Descontinuados** com preço → **Reativar** → some da lista → conferir no banco `tipo_reposicao='automatica'` / `habilitado_reposicao_automatica=true`.

Spec/plano: `docs/superpowers/specs/2026-06-06-reposicao-reativar-sku-descontinuado-design.md` · `docs/superpowers/plans/2026-06-06-reposicao-reativar-sku-descontinuado.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)