### PR TITLE
fix(lente): Central de Telefonia respeita "Ver como" — histórico/badge/aba Time do ALVO

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -359,7 +359,7 @@ function AppSidebar({ collapsed, onToggle }: { collapsed: boolean; onToggle: () 
   const { isStaff, user } = useAuth();
   const isSalesOnly = useSalesOnlyRestriction();
   const { displayIsStaff, displayIsMaster, displayIsGestorComercial, displayIsSalesOnly, displayLoading } = useDisplayAccess();
-  const { isImpersonating } = useImpersonation();
+  const { isImpersonating, effectiveUserId } = useImpersonation();
   const { favorites, isFavorite, toggle: toggleFavorite } = useSidebarFavorites();
 
   // Os 6 contadores de badges abaixo são todos da seção Reposição. Não fazem
@@ -474,8 +474,10 @@ function AppSidebar({ collapsed, onToggle }: { collapsed: boolean; onToggle: () 
   const { data: financeiroAtrasados } = useFinanceiroAlertas();
   const { data: tintErros } = useTintAlertas();
 
-  // Badge de perdidas não-lidas na Central de Telefonia (refetch a cada 30s)
-  const { data: missedCallsCount } = useMissedCount(user?.id);
+  // Badge de perdidas não-lidas na Central de Telefonia (refetch a cada 30s).
+  // Na lente "Ver como", conta as do ALVO (effectiveUserId) — coerente com o
+  // histórico da própria tela; fora da lente é o próprio usuário.
+  const { data: missedCallsCount } = useMissedCount(effectiveUserId ?? undefined);
 
   // Badge de tarefas abertas da vendedora (reusa useMinhasTarefas → mesmo
   // cache do card de "Meu dia": 1 request, 2 consumidores; refetch 60s +

--- a/src/components/telefonia/CallHistoryTabs.tsx
+++ b/src/components/telefonia/CallHistoryTabs.tsx
@@ -3,6 +3,7 @@ import { useMemo, useEffect } from 'react';
 import { Phone } from 'lucide-react';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import { useCallLog, useAcknowledgeMissed, type CallLogTab } from '@/hooks/useCallLog';
+import { useImpersonation } from '@/contexts/ImpersonationContext';
 import { CallHistoryRow } from './CallHistoryRow';
 import { EmptyState } from '@/components/EmptyState';
 
@@ -19,12 +20,15 @@ export function CallHistoryTabs({
   userId: string | undefined; tab: CallLogTab; onTabChange: (t: CallLogTab) => void;
   onCallBack: (phone: string, name?: string) => void; isManager: boolean;
 }) {
+  const { isImpersonating } = useImpersonation();
   const { data: rows = [], isLoading } = useCallLog(tab, userId);
   const ack = useAcknowledgeMissed(userId);
 
-  // Ao abrir a aba Perdidas, marca como lidas (zera badge)
+  // Ao abrir a aba Perdidas, marca como lidas (zera badge). Na lente "Ver como"
+  // (somente leitura) NÃO marca — seria mutar o estado do alvo, e o write-guard
+  // bloquearia gerando ruído. O master inspeciona as perdidas do alvo sem alterá-las.
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  useEffect(() => { if (tab === 'perdidas') ack.mutate(); }, [tab]);
+  useEffect(() => { if (tab === 'perdidas' && !isImpersonating) ack.mutate(); }, [tab]);
 
   const allTabs = useMemo(() => isManager ? [...TABS, { id: 'time' as CallLogTab, label: 'Time' }] : TABS, [isManager]);
 

--- a/src/hooks/__tests__/useIsTelefoniaManager.test.tsx
+++ b/src/hooks/__tests__/useIsTelefoniaManager.test.tsx
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+// A aba "Time" deve seguir o acesso de EXIBIÇÃO (lente-aware), não o papel real do
+// master logado: na lente "Ver como" um farmer impersonado não pode ver a aba Time.
+const displayMock = vi.fn();
+vi.mock('@/hooks/useDisplayAccess', () => ({ useDisplayAccess: () => displayMock() }));
+
+import { useIsTelefoniaManager } from '@/hooks/useIsTelefoniaManager';
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('useIsTelefoniaManager — aba "Time" lente-aware', () => {
+  it('gestor comercial (display) → true', () => {
+    displayMock.mockReturnValue({ displayIsMaster: false, displayIsGestorComercial: true });
+    const { result } = renderHook(() => useIsTelefoniaManager());
+    expect(result.current).toBe(true);
+  });
+
+  it('master (display) → true', () => {
+    displayMock.mockReturnValue({ displayIsMaster: true, displayIsGestorComercial: false });
+    const { result } = renderHook(() => useIsTelefoniaManager());
+    expect(result.current).toBe(true);
+  });
+
+  it('farmer/não-gestor (display) → false, sem aba Time', () => {
+    displayMock.mockReturnValue({ displayIsMaster: false, displayIsGestorComercial: false });
+    const { result } = renderHook(() => useIsTelefoniaManager());
+    expect(result.current).toBe(false);
+  });
+});

--- a/src/hooks/useIsTelefoniaManager.ts
+++ b/src/hooks/useIsTelefoniaManager.ts
@@ -1,18 +1,14 @@
 // src/hooks/useIsTelefoniaManager.ts
-import { useQuery } from '@tanstack/react-query';
-import { supabase } from '@/integrations/supabase/client';
-import { useAuth } from '@/contexts/AuthContext';
+import { useDisplayAccess } from '@/hooks/useDisplayAccess';
 
+/**
+ * A aba "Time" do histórico de chamadas é para gestores comerciais/master.
+ * Usa o acesso de EXIBIÇÃO (useDisplayAccess): fora da lente espelha o usuário
+ * real (master OU commercial_role em gerencial/estrategico/super_admin — o mesmo
+ * critério de antes); na lente "Ver como", reflete o cargo do ALVO, então um
+ * farmer impersonado não vê a aba Time (como ele de fato não vê no app dele).
+ */
 export function useIsTelefoniaManager(): boolean {
-  const { user, isMaster } = useAuth();
-  const { data } = useQuery({
-    queryKey: ['commercial_role', user?.id], enabled: !!user?.id,
-    queryFn: async () => {
-       
-      const { data } = await supabase.from('commercial_roles')
-        .select('commercial_role').eq('user_id', user!.id).maybeSingle();
-      return data?.commercial_role as string | undefined;
-    },
-  });
-  return isMaster || ['gerencial', 'estrategico', 'super_admin'].includes(data ?? '');
+  const { displayIsMaster, displayIsGestorComercial } = useDisplayAccess();
+  return displayIsMaster || displayIsGestorComercial;
 }

--- a/src/lib/impersonation/__tests__/no-write-leak.test.ts
+++ b/src/lib/impersonation/__tests__/no-write-leak.test.ts
@@ -27,6 +27,13 @@ const ALLOWED = new Set([
   // useCriticaFila: effectiveUserId SÓ como filtro de LEITURA (owner_user_id === donoEfetivo no slaQ.data);
   // sem mutation alguma neste hook — é read-only (crítica da fila).
   'src/hooks/useCriticaFila.ts',
+  // Telefonia: effectiveUserId SÓ alimenta o filtro de LEITURA do histórico de chamadas
+  // (useCallLog via CallHistoryTabs) pro "Ver como" mostrar as ligações do ALVO. A ligação
+  // em si (call.makeCall) é bloqueada na FONTE (WebRTCCallContext) na lente; nenhum write usa effectiveUserId.
+  'src/pages/Telefonia.tsx',
+  // AppShell: effectiveUserId SÓ no badge de perdidas não-lidas (useMissedCount = count/LEITURA)
+  // pro "Ver como" refletir o alvo; nenhuma mutation no shell usa effectiveUserId.
+  'src/components/AppShell.tsx',
 ]);
 
 describe('anti write-leak: effectiveUserId só em leitura', () => {

--- a/src/pages/Telefonia.tsx
+++ b/src/pages/Telefonia.tsx
@@ -1,7 +1,7 @@
 // src/pages/Telefonia.tsx
 import { useState, useCallback } from 'react';
 import { toast } from 'sonner';
-import { useAuth } from '@/contexts/AuthContext';
+import { useImpersonation } from '@/contexts/ImpersonationContext';
 import { DialPad } from '@/components/telefonia/DialPad';
 import { CallHistoryTabs } from '@/components/telefonia/CallHistoryTabs';
 import { CallDialerView } from '@/components/call/CallDialerView';
@@ -11,7 +11,10 @@ import { normalizeBrPhone, formatBrPhone } from '@/lib/phone';
 import type { CallLogTab } from '@/hooks/useCallLog';
 
 export default function Telefonia() {
-  const { user } = useAuth();
+  // Lente "Ver como": o histórico de chamadas é escopado por usuário. effectiveUserId
+  // é o id do ALVO na lente e o do próprio usuário fora dela (resolveEffectiveUserId),
+  // então a lista reflete as ligações de quem o master inspeciona, não as dele.
+  const { effectiveUserId } = useImpersonation();
   const [tab, setTab] = useState<CallLogTab>('recentes');
   const [dialPrefill, setDialPrefill] = useState('');
   const [activePhone, setActivePhone] = useState('');
@@ -93,7 +96,7 @@ export default function Telefonia() {
         </div>
         <div className="flex-1 rounded-lg border border-border bg-card p-3">
           <CallHistoryTabs
-            userId={user?.id} tab={tab} onTabChange={setTab}
+            userId={effectiveUserId ?? undefined} tab={tab} onTabChange={setTab}
             isManager={isManager}
             onCallBack={(phone, name) => { setDialPrefill(phone); startCall(phone, undefined, name); }}
           />

--- a/src/pages/__tests__/Telefonia.test.tsx
+++ b/src/pages/__tests__/Telefonia.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+
+// Hooks/contextos mockados na borda — o objetivo é capturar QUAL userId a página
+// repassa ao histórico de chamadas. Na lente "Ver como", deve ser o id do ALVO
+// (effectiveUserId), nunca o do master logado.
+const authMock = vi.fn();
+const impMock = vi.fn();
+const callBackendMock = vi.fn();
+
+vi.mock('@/contexts/AuthContext', () => ({ useAuth: () => authMock() }));
+vi.mock('@/contexts/ImpersonationContext', () => ({ useImpersonation: () => impMock() }));
+vi.mock('@/hooks/useCallBackend', () => ({ useCallBackend: () => callBackendMock() }));
+vi.mock('@/hooks/useIsTelefoniaManager', () => ({ useIsTelefoniaManager: () => false }));
+vi.mock('@/components/telefonia/DialPad', () => ({ DialPad: () => <div data-testid="dialpad" /> }));
+
+// CallHistoryTabs mockado: registra o userId recebido a cada render.
+const recebidoUserIds: (string | undefined)[] = [];
+vi.mock('@/components/telefonia/CallHistoryTabs', () => ({
+  CallHistoryTabs: ({ userId }: { userId: string | undefined }) => {
+    recebidoUserIds.push(userId);
+    return <div data-testid="call-history" data-userid={userId ?? ''} />;
+  },
+}));
+
+import Telefonia from '@/pages/Telefonia';
+
+const backendIdle = {
+  backend: 'webrtc' as const,
+  callState: 'idle',
+  isActive: false,
+  isConnecting: false,
+  isRinging: false,
+  isEstablished: false,
+  isFinished: false,
+  callDuration: 0,
+  audioLink: null,
+  error: null,
+  makeCall: vi.fn(),
+  endCall: vi.fn(),
+  toggleMute: vi.fn(),
+  isMuted: false,
+  remoteStream: null,
+  prerollPlaying: false,
+  prerollEndsAt: null,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  recebidoUserIds.length = 0;
+  callBackendMock.mockReturnValue(backendIdle);
+});
+
+describe('Telefonia — histórico respeita a lente "Ver como"', () => {
+  it('na lente: passa o id do ALVO (effectiveUserId), não o do master logado', () => {
+    authMock.mockReturnValue({ user: { id: 'master-id' } });
+    impMock.mockReturnValue({ effectiveUserId: 'tatyana-id', isImpersonating: true });
+    render(<Telefonia />);
+    expect(recebidoUserIds.at(-1)).toBe('tatyana-id');
+  });
+
+  it('fora da lente: passa o id do próprio usuário', () => {
+    authMock.mockReturnValue({ user: { id: 'master-id' } });
+    impMock.mockReturnValue({ effectiveUserId: 'master-id', isImpersonating: false });
+    render(<Telefonia />);
+    expect(recebidoUserIds.at(-1)).toBe('master-id');
+  });
+});


### PR DESCRIPTION
## Bug reportado
Na lente **"Ver como pessoa"** (master inspecionando uma vendedora, ex.: Tatyana), a **Central de Telefonia** (`/telefonia`) mostrava o histórico de chamadas **do master**, não o do alvo. Deveria mostrar para quais números o usuário inspecionado ligou.

## Causa raiz
A telefonia lia o id do usuário via `useAuth().user.id` — que é **sempre o real (master)** por design da lente (`useAuth` nunca muda na impersonação). A lista (`useCallLog`) filtra `farmer_id = userId`, e como o RLS de `call_log` (`"call_log team select"`, migration `20260523120000`) deixa o **master ler todas as linhas**, o filtro `= master` trazia as ligações do próprio master. A lente (`effectiveUserId`) nunca era consultada nessa tela.

## Mudanças (mesma raiz: "a telefonia ignorava a lente")
| # | Arquivo | O quê |
|---|---------|-------|
| 1 | `src/pages/Telefonia.tsx` | **A lista** filtra por `effectiveUserId` (o bug reportado) |
| 2 | `src/components/AppShell.tsx` | Badge de "perdidas" na sidebar usa `effectiveUserId` |
| 3 | `src/hooks/useIsTelefoniaManager.ts` | Aba "Time" via `useDisplayAccess` → reflete o cargo do **alvo** (some p/ farmer na lente) |
| 4 | `src/components/telefonia/CallHistoryTabs.tsx` | Na lente (read-only) **não** marca perdidas como lidas (evita o erro do write-guard) |

**Fora da lente é byte-equivalente:** `effectiveUserId === user.id` (`resolveEffectiveUserId`) e `displayIsMaster`/`displayIsGestorComercial` espelham o real (trio `gerencial/estrategico/super_admin` idêntico ao `AuthContext.isGestorComercial`).

## Verificação
- ✅ TDD: teste RED→GREEN em `src/pages/__tests__/Telefonia.test.tsx` (na lente passa o id do **alvo**; fora, o do próprio usuário)
- ✅ `src/hooks/__tests__/useIsTelefoniaManager.test.tsx` (aba Time lente-aware)
- ✅ Guardrails de impersonação (5 arquivos / 20 testes) — allowlist do `no-write-leak` +2 (`effectiveUserId` só em LEITURA)
- ✅ Suite completa, `typecheck` strict, `lint`

## Deploy
**100% frontend** — sem migration, sem edge function. ⚠️ Requer **Publish no Lovable** após o merge (o merge na main não publica sozinho).

🤖 Generated with [Claude Code](https://claude.com/claude-code)