### PR TITLE
feat(pedido): abrir detalhe do pedido de venda (painel) + imprimir por pedido

### DIFF
--- a/docs/superpowers/specs/2026-06-06-detalhe-impressao-pedido-venda-design.md
+++ b/docs/superpowers/specs/2026-06-06-detalhe-impressao-pedido-venda-design.md
@@ -1,0 +1,93 @@
+# Detalhe + impressão do pedido de venda (listagem /sales)
+
+**Data:** 2026-06-06
+**Tipo:** melhoria de UX, read-only + impressão. **Sem migration, sem edge, sem money-path.**
+
+## Problema
+
+Na listagem `/sales` (`SalesOrders`), clicar no card de um pedido de **venda**
+(`sales_orders`) não faz nada — embora o card tenha `cursor-pointer` + hover, o
+`onClick` só age para pedidos de afiação (`SalesOrderCard.tsx:49` →
+`isAfiacao ? onNavigate('/orders/:id') : undefined`). Affordance enganoso.
+
+Agravante: o botão de **editar** (lápis) só aparece quando o status NÃO é
+`cancelado`/`entregue`/`faturado` (`SalesOrderCard.tsx:105`). Então um pedido
+cancelado/faturado fica **sem nenhuma forma de ver o conteúdo** — só
+"Compartilhar" e "Excluir".
+
+Não há impressão por-pedido na listagem. A infra existe (`/sales/print`
+`SalesPrintDashboard.printSingle` → `buildPrintData` + `openPrintOrder`), só não
+está exposta aqui.
+
+## Escopo
+
+Apenas pedidos de **venda** (`sales_orders`). Pedidos de **afiação** ficam
+inalterados (clique segue navegando para `/orders/:id`, que tem tela própria).
+
+## Solução
+
+### 1. Painel de detalhe (read-only)
+Novo `SalesOrderDetailSheet.tsx` — `Sheet` (shadcn) deslizando da direita.
+Clicar num card de venda abre o painel (não sai da lista). Conteúdo:
+- Cliente + selos (empresa, status)
+- PV e data
+- Itens: descrição · qtd · valor unitário · valor total
+- Subtotal e Total
+- Observações (se houver)
+- Rodapé: **Imprimir · Compartilhar · Editar** (Editar só quando
+  `!['cancelado','entregue','faturado'].includes(status)` — mesma regra do card).
+
+Sem query nova: todos os campos já vêm no `SalesOrder` da listagem + o
+`customerName` já é passado ao card.
+
+### 2. Impressão por pedido
+- Botão **Imprimir** no painel **+ ícone de impressora no card** (imprime direto).
+- Reusa o **mesmo cupom** de `/sales/print`: `buildPrintData` +
+  `openPrintOrder`. Layout idêntico.
+- Dados: itens / total / observações / `customer_address` / `customer_phone` já
+  estão na linha do pedido (vêm do `select('*')`); nome e CPF/CNPJ do cliente do
+  perfil; logo da empresa via a chamada cacheada que o dashboard já usa
+  (`omie-cliente` `buscar_logos_empresas`). Faltando algum dado, o cupom degrada
+  sem quebrar (igual hoje).
+- Empresa do cupom: `account==='colacor' → 'colacor'`,
+  `account==='colacor_sc' → 'afiacao'` (entidade Colacor S.C.), senão `'oben'`.
+
+### 3. Arquivos
+- **Novo** `src/components/salesOrders/print.ts` — helper puro **testável**:
+  - `resolveCompanyForPrint(account)` → `'oben'|'colacor'|'afiacao'`
+  - `buildSalesOrderPrintRow(order, customerName, document?)` → `SalesOrderRow`
+    (do pipeline de print), preservando os campos do item (codigo/unidade/tint)
+    e os dados da linha (endereço/telefone/omie_payload).
+  - `printSalesOrder(order, customerName, document?, logos?)` → monta + chama
+    `openPrintOrder(buildPrintData(...))`.
+- **Novo** `src/components/salesOrders/SalesOrderDetailSheet.tsx` (apresentacional).
+- **Editar** `SalesOrderCard.tsx` — clique de venda abre o painel; ícone de
+  impressora (`Printer`) ao lado de compartilhar.
+- **Editar** `SalesOrders.tsx` — estado do painel (`openDetail`/`selectedOrder`).
+- **Editar** `useSalesOrders.ts`:
+  - ampliar o tipo `SalesOrder` com os campos opcionais que o `select('*')` já
+    traz: `customer_address?`, `customer_phone?`, `omie_payload?`, `discount?`.
+  - ampliar o `profilesQuery` para trazer `document` além de `name` (mesma query),
+    expor `customerDocs` map.
+  - `useQuery` de logos (cache 24h) reusando `omie-cliente buscar_logos_empresas`.
+  - expor `printOrder(order)` que resolve nome/doc/logos e chama `printSalesOrder`.
+
+## Testes
+
+`print.ts` ganha testes vitest:
+- `resolveCompanyForPrint` cobre oben/colacor/colacor_sc/default.
+- `buildSalesOrderPrintRow` mapeia items (com codigo/unidade preservados),
+  total/subtotal, customer_name/document injetados, customer_address/phone da
+  linha, account. Degrada (items vazio, campos ausentes) sem lançar.
+
+`SalesOrderDetailSheet` e a fiação de card/page são apresentacionais (sem TDD).
+
+## Não-objetivos (v1)
+- Enriquecimento de endereço via Omie (fallback pesado do dashboard) — a
+  impressão rápida usa o endereço da linha; sem ele, sai sem endereço.
+- Mexer no fluxo de afiação.
+- Impressão em lote (já existe em `/sales/print`).
+
+## Risco
+Baixo. Read-only + impressão reusando código existente. Não toca criação/edição/
+envio ao Omie.

--- a/src/components/salesOrders/SalesOrderCard.tsx
+++ b/src/components/salesOrders/SalesOrderCard.tsx
@@ -5,7 +5,7 @@ import { Badge } from '@/components/ui/badge';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Button } from '@/components/ui/button';
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, AlertDialogTrigger } from '@/components/ui/alert-dialog';
-import { Trash2, Share2, Pencil } from 'lucide-react';
+import { Trash2, Share2, Pencil, Printer } from 'lucide-react';
 import { format } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
 import { StatusBadgeSimple } from '@/components/StatusBadge';
@@ -20,6 +20,8 @@ interface SalesOrderCardProps {
   onShare: () => void;
   onDelete: () => void;
   onNavigate: (path: string) => void;
+  onOpenDetail: () => void;
+  onPrint: () => void;
 }
 
 export function SalesOrderCard({
@@ -30,6 +32,8 @@ export function SalesOrderCard({
   onShare,
   onDelete,
   onNavigate,
+  onOpenDetail,
+  onPrint,
 }: SalesOrderCardProps) {
   const isAfiacao = order._source === 'afiacao';
   const status = statusLabels[order.status] || statusLabels.rascunho;
@@ -46,7 +50,7 @@ export function SalesOrderCard({
   const isSelectable = !isAfiacao; // só sales_orders são bulk-deletáveis
 
   return (
-    <Card className={`cursor-pointer hover:bg-muted/30 transition-colors ${checked ? 'ring-2 ring-foreground/20' : ''}`} onClick={() => isAfiacao ? onNavigate(`/orders/${order.id}`) : undefined}>
+    <Card className={`cursor-pointer hover:bg-muted/30 transition-colors ${checked ? 'ring-2 ring-foreground/20' : ''}`} onClick={() => (isAfiacao ? onNavigate(`/orders/${order.id}`) : onOpenDetail())}>
       <CardContent className="p-3">
         <div className="flex items-start justify-between gap-2">
           {isSelectable && (
@@ -102,6 +106,20 @@ export function SalesOrderCard({
               >
                 <Share2 className="w-3.5 h-3.5" />
               </Button>
+              {!isAfiacao && (
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-7 w-7"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onPrint();
+                  }}
+                  title="Imprimir pedido"
+                >
+                  <Printer className="w-3.5 h-3.5" />
+                </Button>
+              )}
               {!isAfiacao && !['cancelado', 'entregue', 'faturado'].includes(order.status) && (
                 <Button
                   variant="ghost"

--- a/src/components/salesOrders/SalesOrderDetailSheet.tsx
+++ b/src/components/salesOrders/SalesOrderDetailSheet.tsx
@@ -1,0 +1,136 @@
+// Painel lateral (read-only) com o conteúdo de um pedido de venda.
+// Abre ao clicar no card da listagem — ver itens/valores/observações sem sair
+// da lista, e disparar Imprimir / Compartilhar / Editar.
+import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetDescription } from '@/components/ui/sheet';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Printer, Share2, Pencil } from 'lucide-react';
+import { format } from 'date-fns';
+import { ptBR } from 'date-fns/locale';
+import { statusLabels, type SalesOrder } from './types';
+
+interface SalesOrderDetailSheetProps {
+  order: SalesOrder | null;
+  customerName: string;
+  onClose: () => void;
+  onPrint: () => void;
+  onShare: () => void;
+  onEdit: () => void;
+}
+
+const fmt = (v: number) => (v || 0).toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
+
+// Pedido cancelado/entregue/faturado não é editável (mesma regra do card).
+const canEditStatus = (status: string) => !['cancelado', 'entregue', 'faturado'].includes(status);
+
+export function SalesOrderDetailSheet({
+  order,
+  customerName,
+  onClose,
+  onPrint,
+  onShare,
+  onEdit,
+}: SalesOrderDetailSheetProps) {
+  const open = !!order;
+  const status = order ? statusLabels[order.status] || statusLabels.rascunho : null;
+  const accountLabel =
+    order?.account === 'colacor_sc' ? 'Colacor SC' : order?.account === 'colacor' ? 'Colacor' : 'Oben';
+  const pv = order?.omie_numero_pedido ? order.omie_numero_pedido.replace(/^0+/, '') || '0' : null;
+
+  return (
+    <Sheet open={open} onOpenChange={(o) => !o && onClose()}>
+      <SheetContent className="w-full sm:max-w-md overflow-y-auto flex flex-col">
+        {order && (
+          <>
+            <SheetHeader>
+              <SheetTitle className="flex items-center gap-2 flex-wrap text-base">
+                <span className="truncate">{customerName}</span>
+                <Badge variant="outline" className="text-[10px] px-1.5 py-0 shrink-0">
+                  {accountLabel}
+                </Badge>
+                {status && (
+                  <Badge variant={status.variant} className="shrink-0">
+                    {status.label}
+                  </Badge>
+                )}
+              </SheetTitle>
+              <SheetDescription className="text-xs">
+                {pv && (
+                  <>
+                    PV <span className="font-tabular text-foreground">{pv}</span>
+                    {' · '}
+                  </>
+                )}
+                {format(new Date(order.created_at), "dd/MM/yyyy 'às' HH:mm", { locale: ptBR })}
+              </SheetDescription>
+            </SheetHeader>
+
+            <div className="flex-1 space-y-4 py-4">
+              {/* Itens */}
+              <div>
+                <p className="text-xs font-medium text-muted-foreground mb-2 uppercase tracking-wide">
+                  Itens ({order.items?.length || 0})
+                </p>
+                <div className="space-y-2">
+                  {(order.items || []).map((item, i) => (
+                    <div key={i} className="flex items-start justify-between gap-3 text-sm border-b border-border/50 pb-2 last:border-0">
+                      <div className="min-w-0 flex-1">
+                        <p className="truncate">{item.descricao || 'Item'}</p>
+                        <p className="text-xs text-muted-foreground">
+                          {item.quantidade} × {fmt(item.valor_unitario)}
+                        </p>
+                      </div>
+                      <span className="font-medium tabular-nums shrink-0">{fmt(item.valor_total)}</span>
+                    </div>
+                  ))}
+                  {(order.items?.length || 0) === 0 && (
+                    <p className="text-sm text-muted-foreground">Sem itens neste pedido.</p>
+                  )}
+                </div>
+              </div>
+
+              {/* Totais */}
+              <div className="space-y-1 text-sm border-t border-border pt-3">
+                <div className="flex justify-between text-muted-foreground">
+                  <span>Subtotal</span>
+                  <span className="tabular-nums">{fmt(order.subtotal)}</span>
+                </div>
+                <div className="flex justify-between font-semibold text-base">
+                  <span>Total</span>
+                  <span className="tabular-nums">{fmt(order.total)}</span>
+                </div>
+              </div>
+
+              {/* Observações */}
+              {order.notes && (
+                <div>
+                  <p className="text-xs font-medium text-muted-foreground mb-1 uppercase tracking-wide">
+                    Observações
+                  </p>
+                  <p className="text-sm whitespace-pre-wrap">{order.notes}</p>
+                </div>
+              )}
+            </div>
+
+            {/* Ações */}
+            <div className="flex gap-2 border-t border-border pt-4">
+              <Button onClick={onPrint} className="flex-1 gap-2">
+                <Printer className="w-4 h-4" />
+                Imprimir
+              </Button>
+              <Button variant="outline" onClick={onShare} className="gap-2">
+                <Share2 className="w-4 h-4" />
+                Compartilhar
+              </Button>
+              {canEditStatus(order.status) && (
+                <Button variant="outline" onClick={onEdit} className="gap-2" title="Editar pedido">
+                  <Pencil className="w-4 h-4" />
+                </Button>
+              )}
+            </div>
+          </>
+        )}
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/src/components/salesOrders/__tests__/SalesOrderCard.test.tsx
+++ b/src/components/salesOrders/__tests__/SalesOrderCard.test.tsx
@@ -30,6 +30,8 @@ function setup(o: SalesOrder, overrides: Partial<React.ComponentProps<typeof Sal
     onShare: vi.fn(),
     onDelete: vi.fn(),
     onNavigate: vi.fn(),
+    onOpenDetail: vi.fn(),
+    onPrint: vi.fn(),
     ...overrides,
   };
   render(<SalesOrderCard {...props} />);
@@ -60,6 +62,26 @@ describe('SalesOrderCard (sales)', () => {
     fireEvent.click(screen.getByTitle('Editar pedido'));
     expect(props.onShare).toHaveBeenCalledTimes(1);
     expect(props.onNavigate).toHaveBeenCalledWith('/sales/edit/o1');
+  });
+
+  it('clicar no card (venda) abre o detalhe — não navega', () => {
+    const props = setup(order());
+    fireEvent.click(screen.getByText('ACME Ltda'));
+    expect(props.onOpenDetail).toHaveBeenCalledTimes(1);
+    expect(props.onNavigate).not.toHaveBeenCalled();
+  });
+
+  it('botão imprimir dispara onPrint sem abrir o detalhe', () => {
+    const props = setup(order());
+    fireEvent.click(screen.getByTitle('Imprimir pedido'));
+    expect(props.onPrint).toHaveBeenCalledTimes(1);
+    expect(props.onOpenDetail).not.toHaveBeenCalled();
+  });
+
+  it('mostra imprimir mesmo em pedido faturado (vê e imprime, sem editar)', () => {
+    setup(order({ status: 'faturado' }));
+    expect(screen.getByTitle('Imprimir pedido')).toBeTruthy();
+    expect(screen.queryByTitle('Editar pedido')).toBeNull();
   });
 
   it('confirmar exclusão dispara onDelete', () => {

--- a/src/components/salesOrders/__tests__/print.test.ts
+++ b/src/components/salesOrders/__tests__/print.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import { resolveCompanyForPrint, buildSalesOrderPrintRow } from '../print';
+import { buildPrintData } from '@/components/sales/print/buildPrintHtml';
+import type { SalesOrder } from '../types';
+
+// Um pedido de venda como ele chega na listagem (select('*') + _source).
+// Em runtime os itens trazem codigo/unidade/tint além de descricao/qtd/valores.
+const baseOrder = (overrides: Partial<SalesOrder> = {}): SalesOrder =>
+  ({
+    id: 'ord-1',
+    customer_user_id: 'user-1',
+    items: [
+      { codigo: 'PRD01', descricao: 'Verniz PU', quantidade: 2, unidade: 'GL', valor_unitario: 50, valor_total: 100 },
+    ],
+    subtotal: 100,
+    total: 100,
+    status: 'cancelado',
+    omie_numero_pedido: '0000011104',
+    omie_pedido_id: null,
+    created_at: '2026-06-02T21:00:00Z',
+    notes: 'obs teste',
+    account: 'oben',
+    customer_address: 'Rua X, 10 - Centro',
+    customer_phone: '37999999999',
+    _source: 'sales',
+    ...overrides,
+  }) as unknown as SalesOrder;
+
+describe('resolveCompanyForPrint', () => {
+  it('oben → oben', () => expect(resolveCompanyForPrint('oben')).toBe('oben'));
+  it('colacor → colacor', () => expect(resolveCompanyForPrint('colacor')).toBe('colacor'));
+  it('colacor_sc → afiacao (entidade Colacor S.C.)', () =>
+    expect(resolveCompanyForPrint('colacor_sc')).toBe('afiacao'));
+  it('undefined/desconhecido → oben (default)', () => {
+    expect(resolveCompanyForPrint(undefined)).toBe('oben');
+    expect(resolveCompanyForPrint('xpto')).toBe('oben');
+  });
+});
+
+describe('buildSalesOrderPrintRow', () => {
+  it('injeta nome e documento do cliente', () => {
+    const row = buildSalesOrderPrintRow(baseOrder(), 'ACME LTDA', '12.345.678/0001-99');
+    expect(row.customer_name).toBe('ACME LTDA');
+    expect(row.customer_document).toBe('12.345.678/0001-99');
+  });
+
+  it('preserva os campos do item (codigo/unidade), não só descricao/qtd', () => {
+    const row = buildSalesOrderPrintRow(baseOrder(), 'ACME', '');
+    expect(row.items).toHaveLength(1);
+    expect(row.items[0].codigo).toBe('PRD01');
+    expect(row.items[0].unidade).toBe('GL');
+    expect(row.items[0].valor_total).toBe(100);
+  });
+
+  it('traz endereço e telefone da linha do pedido', () => {
+    const row = buildSalesOrderPrintRow(baseOrder(), 'ACME', '');
+    expect(row.customer_address).toBe('Rua X, 10 - Centro');
+    expect(row.customer_phone).toBe('37999999999');
+  });
+
+  it('preserva total/subtotal/account/PV/observações', () => {
+    const row = buildSalesOrderPrintRow(baseOrder(), 'ACME', '');
+    expect(row.total).toBe(100);
+    expect(row.subtotal).toBe(100);
+    expect(row.account).toBe('oben');
+    expect(row.omie_numero_pedido).toBe('0000011104');
+    expect(row.notes).toBe('obs teste');
+  });
+
+  it('degrada sem lançar quando items ausente e document omitido', () => {
+    const row = buildSalesOrderPrintRow(baseOrder({ items: undefined as unknown as SalesOrder['items'] }), 'ACME');
+    expect(row.items).toEqual([]);
+    expect(row.customer_document).toBeUndefined();
+  });
+});
+
+describe('integração com o pipeline de impressão real (buildPrintData)', () => {
+  it('produz PrintOrderData fiel: empresa, cliente, codigo do item e nº do pedido', () => {
+    const order = baseOrder({ account: 'colacor_sc' });
+    const data = buildPrintData(
+      buildSalesOrderPrintRow(order, 'ACME LTDA', '12.345.678/0001-99'),
+      resolveCompanyForPrint(order.account),
+    );
+    expect(data.companyName).toBe('COLACOR S.C LTDA');
+    expect(data.customerName).toBe('ACME LTDA');
+    expect(data.customerDocument).toBe('12.345.678/0001-99');
+    expect(data.items[0].codigo).toBe('PRD01');
+    expect(data.items[0].unidade).toBe('GL');
+    expect(data.orderNumber).toBe('11104'); // strip de zeros à esquerda
+  });
+});

--- a/src/components/salesOrders/print.ts
+++ b/src/components/salesOrders/print.ts
@@ -1,0 +1,54 @@
+// Impressão por pedido a partir da listagem de vendas.
+// Reusa o MESMO cupom de /sales/print (buildPrintData + openPrintOrder) — layout idêntico.
+import { buildPrintData } from '@/components/sales/print/buildPrintHtml';
+import { openPrintOrder } from '@/components/OrderPrintLayout';
+import type { CompanyFilter, OmiePayload, OrderItem, SalesOrderRow } from '@/components/sales/print/types';
+import type { SalesOrder } from './types';
+
+// sales_orders.account → empresa do cupom. colacor_sc é a entidade Colacor S.C.
+// (mesma chave 'afiacao' do companyMap em buildPrintData).
+export function resolveCompanyForPrint(account?: string): CompanyFilter {
+  if (account === 'colacor') return 'colacor';
+  if (account === 'colacor_sc') return 'afiacao';
+  return 'oben';
+}
+
+// Adapta o pedido da listagem para o shape do pipeline de impressão. Preserva o
+// array de itens cru (codigo/unidade/tint vêm do jsonb em runtime) e injeta
+// nome/documento do cliente, que não vivem na linha de sales_orders.
+export function buildSalesOrderPrintRow(
+  order: SalesOrder,
+  customerName: string,
+  customerDocument?: string,
+): SalesOrderRow {
+  return {
+    id: order.id,
+    customer_user_id: order.customer_user_id,
+    items: (order.items ?? []) as unknown as OrderItem[],
+    subtotal: order.subtotal ?? 0,
+    total: order.total ?? 0,
+    desconto: order.discount ?? 0,
+    status: order.status,
+    omie_numero_pedido: order.omie_numero_pedido,
+    created_at: order.created_at,
+    notes: order.notes,
+    account: order.account,
+    customer_name: customerName,
+    customer_document: customerDocument || undefined,
+    customer_phone: order.customer_phone ?? undefined,
+    customer_address: order.customer_address ?? undefined,
+    omie_payload: (order.omie_payload as OmiePayload | null) ?? undefined,
+  };
+}
+
+// Abre a janela de impressão do cupom para um pedido de venda.
+export function printSalesOrder(
+  order: SalesOrder,
+  customerName: string,
+  customerDocument?: string,
+  logos?: Record<string, string | null>,
+): void {
+  const company = resolveCompanyForPrint(order.account);
+  const row = buildSalesOrderPrintRow(order, customerName, customerDocument);
+  openPrintOrder(buildPrintData(row, company, logos));
+}

--- a/src/components/salesOrders/types.ts
+++ b/src/components/salesOrders/types.ts
@@ -45,6 +45,13 @@ export interface SalesOrder {
   notes: string | null;
   account?: string;
   _source?: 'sales' | 'afiacao';
+  // Campos que o select('*') de sales_orders já traz em runtime — consumidos
+  // pela impressão do pedido (buildSalesOrderPrintRow). Opcionais: os pedidos
+  // de afiação (montados à mão no hook) não os têm.
+  customer_address?: string | null;
+  customer_phone?: string | null;
+  omie_payload?: unknown;
+  discount?: number;
 }
 
 // Cache do useInfiniteQuery de sales_orders — usado nos rollbacks optimistic.

--- a/src/components/salesOrders/useSalesOrders.ts
+++ b/src/components/salesOrders/useSalesOrders.ts
@@ -20,6 +20,7 @@ import {
   type SalesOrdersInfiniteCache,
 } from './types';
 import { softDeleteOrder } from './soft-delete';
+import { printSalesOrder } from './print';
 
 export function useSalesOrders() {
   const navigate = useNavigate();
@@ -107,7 +108,7 @@ export function useSalesOrders() {
     );
   }, [salesQuery.data, afiacaoQuery.data]);
 
-  /* ─── Profiles (nomes dos clientes) ─── */
+  /* ─── Profiles (nome + documento dos clientes) ─── */
   const customerIds = useMemo(() => [...new Set(orders.map((o) => o.customer_user_id))], [orders]);
   const profilesQuery = useQuery({
     queryKey: ['sales-orders-profiles', customerIds.sort().join(',')],
@@ -116,16 +117,43 @@ export function useSalesOrders() {
     queryFn: async () => {
       const { data } = await supabase
         .from('profiles')
-        .select('user_id, name')
+        .select('user_id, name, document')
         .in('user_id', customerIds);
-      const map: Record<string, string> = {};
-      ((data || []) as Pick<ProfileRow, 'user_id' | 'name'>[]).forEach((p) => {
-        map[p.user_id] = p.name ?? '';
+      const names: Record<string, string> = {};
+      const docs: Record<string, string> = {};
+      ((data || []) as Pick<ProfileRow, 'user_id' | 'name' | 'document'>[]).forEach((p) => {
+        names[p.user_id] = p.name ?? '';
+        if (p.document) docs[p.user_id] = p.document;
       });
-      return map;
+      return { names, docs };
     },
   });
-  const profiles = profilesQuery.data || {};
+  const profiles = profilesQuery.data?.names || {};
+  const customerDocs = profilesQuery.data?.docs || {};
+
+  /* ─── Logos das empresas (cupom de impressão) — cache 24h, igual ao dashboard ─── */
+  const logosQuery = useQuery({
+    queryKey: ['sales-orders-company-logos'],
+    enabled: isStaff,
+    staleTime: 1000 * 60 * 60 * 24,
+    queryFn: async () => {
+      try {
+        const { data } = await supabase.functions.invoke('omie-cliente', {
+          body: { action: 'buscar_logos_empresas' },
+        });
+        return (data?.logos || {}) as Record<string, string | null>;
+      } catch {
+        return {};
+      }
+    },
+  });
+  const companyLogos = logosQuery.data || {};
+
+  // Imprime o cupom de um pedido (mesmo layout de /sales/print).
+  const printOrder = (order: SalesOrder) => {
+    const name = decodeHtml(profiles[order.customer_user_id] || 'Cliente');
+    printSalesOrder(order, name, customerDocs[order.customer_user_id], companyLogos);
+  };
 
   /* ─── Infinite scroll: dispara fetchNextPage de quem ainda tem páginas ─── */
   const hasNext = !!salesQuery.hasNextPage || !!afiacaoQuery.hasNextPage;
@@ -333,5 +361,6 @@ export function useSalesOrders() {
     deleteOrder,
     deleteSelected,
     handleShareOrder,
+    printOrder,
   };
 }

--- a/src/pages/SalesOrders.tsx
+++ b/src/pages/SalesOrders.tsx
@@ -1,11 +1,13 @@
+import { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Loader2, ShoppingCart, Trash2, ChevronLeft } from 'lucide-react';
 import { EmptyState } from '@/components/EmptyState';
 import { BulkActionsBar } from '@/components/ui/bulk-actions-bar';
-import { decodeHtml, PAGE_SIZE } from '@/components/salesOrders/types';
+import { decodeHtml, PAGE_SIZE, type SalesOrder } from '@/components/salesOrders/types';
 import { useSalesOrders } from '@/components/salesOrders/useSalesOrders';
 import { SalesOrdersToolbar } from '@/components/salesOrders/SalesOrdersToolbar';
 import { SalesOrderCard } from '@/components/salesOrders/SalesOrderCard';
+import { SalesOrderDetailSheet } from '@/components/salesOrders/SalesOrderDetailSheet';
 
 const SalesOrders = () => {
   const {
@@ -29,7 +31,13 @@ const SalesOrders = () => {
     deleteOrder,
     deleteSelected,
     handleShareOrder,
+    printOrder,
   } = useSalesOrders();
+
+  const [detailOrder, setDetailOrder] = useState<SalesOrder | null>(null);
+  const detailCustomerName = detailOrder
+    ? decodeHtml(profiles[detailOrder.customer_user_id] || 'Cliente')
+    : '';
 
   if (authLoading || loading) {
     return (
@@ -90,6 +98,8 @@ const SalesOrders = () => {
               onShare={() => handleShareOrder(order, decodeHtml(profiles[order.customer_user_id] || 'Cliente'))}
               onDelete={() => deleteOrder(order)}
               onNavigate={navigate}
+              onOpenDetail={() => setDetailOrder(order)}
+              onPrint={() => printOrder(order)}
             />
           ))}
 
@@ -136,6 +146,15 @@ const SalesOrders = () => {
             },
           },
         ]}
+      />
+
+      <SalesOrderDetailSheet
+        order={detailOrder}
+        customerName={detailCustomerName}
+        onClose={() => setDetailOrder(null)}
+        onPrint={() => detailOrder && printOrder(detailOrder)}
+        onShare={() => detailOrder && handleShareOrder(detailOrder, detailCustomerName)}
+        onEdit={() => detailOrder && navigate(`/sales/edit/${detailOrder.id}`)}
       />
     </div>
   );


### PR DESCRIPTION
## Problema (reportado pelo founder)

Na listagem `/sales`, **clicar no card de um pedido de venda não abria nada** —
apesar do cursor de mãozinha e do hover, dando a impressão de ser clicável. O
`onClick` do card só agia para pedidos de **afiação** (`SalesOrderCard.tsx:49`);
para `sales_orders` era `undefined`.

Agravante: o lápis de **editar** só aparece quando o status permite, então
pedidos **cancelados/faturados** (o caso da tela do founder) ficavam **sem
nenhuma forma de ver o conteúdo** — só "Compartilhar" e "Excluir".

E não havia **impressão por pedido** na listagem (a infra existe em
`/sales/print`, só não estava exposta aqui).

## Solução

**1. Painel lateral (read-only)** — clicar no card de venda abre um `Sheet`
deslizando da direita, sem sair da lista: cliente, empresa, status, PV, data,
itens (descrição · qtd · vlr unit · vlr total), subtotal/total, observações.
Rodapé: **Imprimir · Compartilhar · Editar** (Editar só quando o status permite;
cancelado/faturado você ainda vê e imprime).

**2. Impressão por pedido** — ícone de impressora no card **+** botão no painel,
reusando o **mesmo cupom** de `/sales/print` (`buildPrintData` + `openPrintOrder`),
layout idêntico. Empresa do cupom: `colacor`→Colacor, `colacor_sc`→Colacor S.C.,
senão Oben. Dados ausentes (ex.: endereço) degradam sem quebrar.

Pedidos de **afiação ficam inalterados** (clique segue para `/orders/:id`).

## Arquivos
- **novo** `salesOrders/print.ts` — helper puro testável (10 testes, TDD)
- **novo** `salesOrders/SalesOrderDetailSheet.tsx` — o painel
- `useSalesOrders.ts` — `document` do perfil + logos cacheados (24h) + `printOrder`
- `SalesOrderCard.tsx` — clique abre painel + ícone imprimir (3 testes novos)
- `SalesOrders.tsx` — estado do painel + render
- spec em `docs/superpowers/specs/2026-06-06-detalhe-impressao-pedido-venda-design.md`

## Risco
Baixo. Read-only + impressão reusando código existente. **Não toca o caminho do
dinheiro** (criação/edição/envio ao Omie intactos). Sem migration, sem edge function.

## Validação
- `bun run typecheck` ✅
- `bun run test` ✅ **2698/2698** (401 arquivos)
- `bun lint` ✅ 0 erros
- `bun run build` ✅

⚠️ Frontend: lembrar de dar **Publish** no Lovable para ir ao ar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)