### PR TITLE
fix(pedido): hotfix 2a — preflight só staff (não quebra autoatendimento) + vendedor por-conta

### DIFF
--- a/src/hooks/useUnifiedOrder.ts
+++ b/src/hooks/useUnifiedOrder.ts
@@ -654,6 +654,7 @@ export function useUnifiedOrder() {
         defaultProductionAssigneeId,
         getServicePrice,
         supabase,
+        isCustomerMode,
       });
       if (result.success && result.lastOrderData) {
         setLastOrderData(result.lastOrderData);
@@ -685,7 +686,7 @@ export function useUnifiedOrder() {
     deliveryOption, addresses, selectedAddress,
     notes, readyByDate, ordemCompra,
     companyProfiles, defaultProductionAssigneeId,
-    getServicePrice, clearCart,
+    getServicePrice, clearCart, isCustomerMode,
   ]);
 
   // clearCustomer defined earlier (wraps useCustomerSelection.clearCustomer + clears cart/ordemCompra/userTools)

--- a/src/services/orderSubmission/__tests__/submitOrder.test.ts
+++ b/src/services/orderSubmission/__tests__/submitOrder.test.ts
@@ -24,8 +24,9 @@ vi.mock('@/lib/logger', () => ({
 }));
 
 import { submitOrder } from '../submitOrder';
+import { syncOrderToOmie } from '@/services/omieService';
 import type { SubmitOrderParams, SubmitClient } from '../types';
-import type { OmieCustomer, ProductCartItem } from '@/hooks/unifiedOrder/types';
+import type { OmieCustomer, ProductCartItem, ServiceCartItem } from '@/hooks/unifiedOrder/types';
 
 // ─── Mock supabase (injetado via params) ───
 interface MakeSupabaseOpts {
@@ -79,6 +80,21 @@ function colacorAcabadoColuna(): ProductCartItem {
     product: { id: 'p3', omie_codigo_produto: 'COL2', codigo: 'C3', descricao: 'Disco acabado coluna', unidade: 'UN', tipo_produto: '04' },
   } as unknown as ProductCartItem;
 }
+function serviceItem(): ServiceCartItem {
+  return {
+    type: 'service', quantity: 1, notes: '', photos: [],
+    servico: { descricao: 'Afiação padrão', omie_codigo_servico: 'SVC1' },
+    userTool: { id: 't1', tool_category_id: 'tc1', specifications: {} },
+  } as unknown as ServiceCartItem;
+}
+// Cliente sintético do autoatendimento (isCustomerMode): codigo_cliente=0, SEM código por-conta.
+const customerSintetico = {
+  codigo_cliente: 0,
+  codigo_vendedor: null,
+  razao_social: 'Cliente Final',
+  nome_fantasia: '',
+  cnpj_cpf: '11122233344',
+} as OmieCustomer;
 
 function makeParams(over: Partial<SubmitOrderParams> & { supabase: SubmitClient }): SubmitOrderParams {
   return {
@@ -220,5 +236,54 @@ describe('submitOrder', () => {
     // nunca chamou criar_ordem_producao (sem responsável)
     const opCalls = invoke.mock.calls.filter((c) => (c[1] as { body: { action?: string } }).body.action === 'criar_ordem_producao');
     expect(opCalls).toHaveLength(0);
+  });
+
+  it('Modo cliente (autoatendimento): OS de afiação NÃO é bloqueada pelo preflight (cliente sintético code 0)', async () => {
+    const { client } = makeSupabase();
+    const r = await submitOrder(makeParams({
+      supabase: client,
+      customer: customerSintetico,           // codigo_cliente=0, sem código afiação
+      isCustomerMode: true,
+      cart: { obenProductItems: [], colacorProductItems: [], serviceItems: [serviceItem()] },
+      subtotals: { oben: 0, colacor: 0, service: 30 },
+    }));
+    // Não pode ser bloqueado por identidade — o edge resolve por user/documento.
+    expect(r.errors.some((e) => e.step === 'validate_identity')).toBe(false);
+    // Mantém o comportamento antigo: customerOmieCode cai no codigo_cliente (0), não vira undefined.
+    expect(syncOrderToOmie).toHaveBeenCalled();
+    const staffCtx = vi.mocked(syncOrderToOmie).mock.calls[0][4];
+    expect(staffCtx).toMatchObject({ customerOmieCode: 0 });
+  });
+
+  it('Staff: OS de afiação SEM código afiação → fail-closed (não chama o Omie)', async () => {
+    const { client } = makeSupabase();
+    // `customer` (staff) tem oben+colacor mas NÃO tem codigo_cliente_afiacao.
+    const r = await submitOrder(makeParams({
+      supabase: client,
+      cart: { obenProductItems: [], colacorProductItems: [], serviceItems: [serviceItem()] },
+      subtotals: { oben: 0, colacor: 0, service: 30 },
+    }));
+    expect(r.success).toBe(false);
+    expect(r.errors[0].step).toBe('validate_identity');
+    expect(r.errors[0].message).toContain('Afiação');
+    expect(syncOrderToOmie).not.toHaveBeenCalled();
+  });
+
+  it('Colacor: PV usa o cliente E o vendedor POR-CONTA (200/6), nunca o Oben (100/5)', async () => {
+    const { client, invoke } = makeSupabase({ insertId: 'so-col' });
+    await submitOrder(makeParams({
+      supabase: client,
+      cart: { obenProductItems: [], colacorProductItems: [colacorAcabado()], serviceItems: [] },
+      subtotals: { oben: 0, colacor: 50, service: 0 },
+      defaultProductionAssigneeId: 'assignee-1',
+    }));
+    const colacorPedido = invoke.mock.calls.find((c) => {
+      const b = (c[1] as { body: { action?: string; account?: string } }).body;
+      return b.action === 'criar_pedido' && b.account === 'colacor';
+    });
+    expect(colacorPedido).toBeDefined();
+    const body = (colacorPedido![1] as { body: { codigo_cliente?: number; codigo_vendedor?: number } }).body;
+    expect(body.codigo_cliente).toBe(200);   // colacor, não 100 (oben)
+    expect(body.codigo_vendedor).toBe(6);    // colacor, não 5 (oben)
   });
 });

--- a/src/services/orderSubmission/submitOrder.ts
+++ b/src/services/orderSubmission/submitOrder.ts
@@ -29,7 +29,7 @@ export async function submitOrder(params: SubmitOrderParams): Promise<SubmitOrde
   const {
     customer, customerUserId, user, cart, subtotals, volumes,
     payment, delivery, meta, companyProfiles, defaultProductionAssigneeId,
-    getServicePrice, supabase,
+    getServicePrice, supabase, isCustomerMode = false,
   } = params;
   const { obenProductItems, colacorProductItems, serviceItems } = cart;
   const errors: SubmitErrorEntry[] = [];
@@ -45,31 +45,36 @@ export async function submitOrder(params: SubmitOrderParams): Promise<SubmitOrde
     };
   }
 
-  // ── Preflight de identidade por-conta (fail-closed) ──
+  // ── Preflight de identidade por-conta (fail-closed) — APENAS staff ──
   // Cada conta Omie tem código de cliente próprio; NUNCA enviar o código de uma
-  // conta para outra (fallback antigo `|| codigo_cliente` registrava o pedido no
-  // cliente errado). Se uma conta COM itens não tem identidade resolvida, bloqueia
-  // o envio INTEIRO antes de qualquer insert — não enviar pela metade num pedido
-  // multi-conta nem registrar na conta errada.
-  const missingIdentities = missingAccountIdentities({
-    hasOben: obenProductItems.length > 0,
-    hasColacor: colacorProductItems.length > 0,
-    hasAfiacao: serviceItems.length > 0,
-    codigoCliente: customer.codigo_cliente,
-    codigoClienteColacor: customer.codigo_cliente_colacor,
-    codigoClienteAfiacao: customer.codigo_cliente_afiacao,
-  });
-  if (missingIdentities.length > 0) {
-    return {
-      success: false,
-      results: [],
-      printDataList: [],
-      lastOrderData: null,
-      errors: [{
-        step: 'validate_identity',
-        message: `Cliente sem identidade na(s) conta(s): ${missingIdentities.join(', ')}. Selecione o cliente novamente (ou aguarde o cadastro concluir) e tente de novo — o pedido NÃO foi enviado, para não registrar na conta errada.`,
-      }],
-    };
+  // conta para outra (o fallback antigo `|| codigo_cliente` registrava o pedido
+  // no cliente errado). Se uma conta COM itens não tem identidade resolvida,
+  // bloqueia o envio INTEIRO antes de qualquer insert — não enviar pela metade
+  // num pedido multi-conta nem registrar na conta errada.
+  // Modo cliente (autoatendimento) usa cliente sintético (codigo_cliente=0, sem
+  // código por-conta) e só tem itens de afiação; lá o edge resolve a identidade
+  // por user/documento → não aplicar o preflight (senão bloquearia toda OS).
+  if (!isCustomerMode) {
+    const missingIdentities = missingAccountIdentities({
+      hasOben: obenProductItems.length > 0,
+      hasColacor: colacorProductItems.length > 0,
+      hasAfiacao: serviceItems.length > 0,
+      codigoCliente: customer.codigo_cliente,
+      codigoClienteColacor: customer.codigo_cliente_colacor,
+      codigoClienteAfiacao: customer.codigo_cliente_afiacao,
+    });
+    if (missingIdentities.length > 0) {
+      return {
+        success: false,
+        results: [],
+        printDataList: [],
+        lastOrderData: null,
+        errors: [{
+          step: 'validate_identity',
+          message: `Não foi possível confirmar o cadastro do cliente na(s) conta(s): ${missingIdentities.join(', ')} (provável falha temporária do Omie). O pedido NÃO foi enviado — evita registrar na conta errada. Para revalidar, re-selecione o cliente (atenção: isso limpa o carrinho).`,
+        }],
+      };
+    }
   }
 
   const storedAddress = formatCustomerAddress(delivery.selectedAddress, customer);
@@ -223,9 +228,10 @@ export async function submitOrder(params: SubmitOrderParams): Promise<SubmitOrde
       const { data: omieResult, error: omieError } = await supabase.functions.invoke('omie-vendas-sync', {
         body: {
           action: 'criar_pedido', account: 'colacor', sales_order_id: salesOrderId,
-          // Identidade Colacor garantida pelo preflight (fail-closed); NUNCA cair no código Oben.
+          // Identidade Colacor garantida pelo preflight (staff; Colacor não existe em modo cliente).
           codigo_cliente: customer.codigo_cliente_colacor!,
-          codigo_vendedor: customer.codigo_vendedor_colacor ?? customer.codigo_vendedor,
+          // Vendedor é por-conta: NUNCA cair no vendedor Oben (comissão na conta errada). Ausente = null (edge tolera).
+          codigo_vendedor: customer.codigo_vendedor_colacor ?? null,
           items: colacorProductItems.map(c => ({
             omie_codigo_produto: c.product.omie_codigo_produto,
             quantidade: c.quantity,
@@ -352,10 +358,14 @@ export async function submitOrder(params: SubmitOrderParams): Promise<SubmitOrde
         document: customer.cnpj_cpf || undefined,
       };
       const staffContext = {
-        // Identidade Afiação garantida pelo preflight (fail-closed); NUNCA cair no código Oben.
-        customerOmieCode: customer.codigo_cliente_afiacao!,
+        // Staff: identidade Afiação garantida pelo preflight. Modo cliente (autoatendimento):
+        // cliente sintético sem código afiação → mantém o fallback (o edge resolve por user/doc).
+        customerOmieCode: isCustomerMode
+          ? (customer.codigo_cliente_afiacao || customer.codigo_cliente)
+          : customer.codigo_cliente_afiacao!,
         customerUserId: customerUserId || null,
-        customerCodigoVendedor: customer.codigo_vendedor_afiacao ?? customer.codigo_vendedor ?? null,
+        // Vendedor é por-conta: NUNCA cair no vendedor Oben (comissão errada). Ausente = null (edge tolera).
+        customerCodigoVendedor: customer.codigo_vendedor_afiacao ?? null,
       };
       const result = await syncOrderToOmie(orderId, orderData, profileData, addressPayload, staffContext);
       if (result.success) {

--- a/src/services/orderSubmission/types.ts
+++ b/src/services/orderSubmission/types.ts
@@ -63,6 +63,11 @@ export interface SubmitOrderParams {
   defaultProductionAssigneeId: string | null;
   getServicePrice: (item: ServiceCartItem) => number | null;
   supabase: SubmitClient;
+  /** True em autoatendimento (cliente não-staff): cliente sintético
+   *  (codigo_cliente=0, sem código por-conta), só itens de afiação; o edge
+   *  resolve a identidade por user/documento. Desliga o preflight de identidade
+   *  por-conta (que é regra de pedido STAFF multi-conta). Default: false. */
+  isCustomerMode?: boolean;
 }
 
 export interface SubmitErrorEntry {


### PR DESCRIPTION
## Hotfix da Etapa 2a (correções P2 do Codex que não entraram no #660)

O [#660](https://github.com/LucasSardenbergL/afiacao/pull/660) foi mergeado com **apenas o commit original**, antes de eu aplicar as correções do challenge do Codex. Resultado: a main ficou com o preflight de identidade **sem o gate de modo cliente** → **regressão**: toda OS de **autoatendimento** (cliente não-staff, cliente sintético `codigo_cliente=0` sem código por-conta) seria **bloqueada**. Este PR completa a 2a.

### Correções
- **Preflight só em modo staff.** Modo cliente usa cliente sintético + só itens de afiação; o edge resolve identidade por user/documento → não aplicar o preflight (novo param `isCustomerMode`).
- **`customerOmieCode` da afiação customer-mode-aware:** staff usa o código afiação (garantido pelo preflight); modo cliente mantém o fallback p/ `codigo_cliente` (0), preservando o comportamento antigo.
- **Remove o fallback de VENDEDOR cross-account** (colacor + afiação): vendedor é por-conta; cair no vendedor Oben erra a comissão. Ausente = null (edges toleram).
- **Mensagem de bloqueio honesta** (re-selecionar o cliente limpa o carrinho).

### Testes (+3)
modo cliente não-bloqueado (`customerOmieCode=0`); staff afiação sem código bloqueia sem chamar o Omie; PV Colacor usa cliente **e** vendedor por-conta (200/6, não 100/5).

### Codex
"sem P1 novo" no diff base; estes são os P2 dele. P3.1 (TOCTOU snapshot) adiado — `customer` não é mutado durante o submit.

### Verificação
`typecheck` ✓ · `test` 34/34 orderSubmission (2678 total) ✓ · `build` ✓ · `lint` 0.

### Deploy
Frontend — **Publish no Lovable** (junto com a 2a-original já na main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
