### PR TITLE
feat(pedido): cor da base (tinta) no detalhe + corrige valor zerado do item

### DIFF
--- a/src/components/salesOrders/SalesOrderDetailSheet.tsx
+++ b/src/components/salesOrders/SalesOrderDetailSheet.tsx
@@ -8,6 +8,7 @@ import { Printer, Share2, Pencil } from 'lucide-react';
 import { format } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
 import { statusLabels, type SalesOrder } from './types';
+import { itemTotal } from './print';
 
 interface SalesOrderDetailSheetProps {
   order: SalesOrder | null;
@@ -76,11 +77,16 @@ export function SalesOrderDetailSheet({
                     <div key={i} className="flex items-start justify-between gap-3 text-sm border-b border-border/50 pb-2 last:border-0">
                       <div className="min-w-0 flex-1">
                         <p className="truncate">{item.descricao || 'Item'}</p>
+                        {item.tint_nome_cor && (
+                          <p className="text-xs text-muted-foreground truncate">
+                            🎨 {item.tint_cor_id} - {item.tint_nome_cor}
+                          </p>
+                        )}
                         <p className="text-xs text-muted-foreground">
                           {item.quantidade} × {fmt(item.valor_unitario)}
                         </p>
                       </div>
-                      <span className="font-medium tabular-nums shrink-0">{fmt(item.valor_total)}</span>
+                      <span className="font-medium tabular-nums shrink-0">{fmt(itemTotal(item))}</span>
                     </div>
                   ))}
                   {(order.items?.length || 0) === 0 && (

--- a/src/components/salesOrders/__tests__/SalesOrderDetailSheet.test.tsx
+++ b/src/components/salesOrders/__tests__/SalesOrderDetailSheet.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { SalesOrderDetailSheet } from '../SalesOrderDetailSheet';
+import type { SalesOrder } from '../types';
+
+function order(p: Partial<SalesOrder> = {}): SalesOrder {
+  return {
+    id: 'o1',
+    customer_user_id: 'u1',
+    items: [
+      // Base com tinta + valor_total zerado (caso do rascunho da foto)
+      { descricao: 'BASE PU ACRI FOSCO', quantidade: 2, valor_unitario: 50, valor_total: 0, tint_cor_id: '1247', tint_nome_cor: 'AZUL RAL 5010' },
+      { descricao: 'CATALISADOR FC', quantidade: 2, valor_unitario: 40, valor_total: 80 },
+    ],
+    subtotal: 180,
+    total: 180,
+    status: 'rascunho',
+    omie_numero_pedido: '0011326',
+    omie_pedido_id: null,
+    created_at: '2026-06-02T21:00:00Z',
+    notes: null,
+    account: 'oben',
+    _source: 'sales',
+    ...p,
+  } as SalesOrder;
+}
+
+function setup(o: SalesOrder | null) {
+  render(
+    <SalesOrderDetailSheet
+      order={o}
+      customerName="DELTA INTERIORES"
+      onClose={vi.fn()}
+      onPrint={vi.fn()}
+      onShare={vi.fn()}
+      onEdit={vi.fn()}
+    />,
+  );
+}
+
+describe('SalesOrderDetailSheet', () => {
+  it('mostra a cor da base (código - nome) quando o item tem tinta', () => {
+    setup(order());
+    expect(screen.getByText(/🎨\s*1247\s*-\s*AZUL RAL 5010/)).toBeTruthy();
+  });
+
+  it('item sem tinta não mostra linha de cor', () => {
+    setup(order({ items: [{ descricao: 'CATALISADOR', quantidade: 1, valor_unitario: 40, valor_total: 40 }] }));
+    expect(screen.queryByText(/🎨/)).toBeNull();
+  });
+
+  it('exibe o total do item calculado (qtd × unit) quando valor_total vem 0', () => {
+    setup(order());
+    // base 2 × R$ 50 → total R$ 100,00 (não R$ 0,00)
+    expect(screen.getByText(/R\$\s*100,00/)).toBeTruthy();
+  });
+
+  it('order null não renderiza conteúdo (painel fechado)', () => {
+    setup(null);
+    expect(screen.queryByText('DELTA INTERIORES')).toBeNull();
+  });
+});

--- a/src/components/salesOrders/__tests__/print.test.ts
+++ b/src/components/salesOrders/__tests__/print.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { resolveCompanyForPrint, buildSalesOrderPrintRow } from '../print';
+import { resolveCompanyForPrint, buildSalesOrderPrintRow, itemTotal } from '../print';
 import { buildPrintData } from '@/components/sales/print/buildPrintHtml';
 import type { SalesOrder } from '../types';
 
@@ -37,6 +37,21 @@ describe('resolveCompanyForPrint', () => {
   });
 });
 
+describe('itemTotal', () => {
+  it('usa valor_total quando presente', () => {
+    expect(itemTotal({ valor_total: 100, quantidade: 2, valor_unitario: 50 })).toBe(100);
+  });
+  it('calcula qtd × unit quando valor_total vem 0 (rascunho sem total gravado)', () => {
+    expect(itemTotal({ valor_total: 0, quantidade: 2, valor_unitario: 50 })).toBe(100);
+  });
+  it('calcula qtd × unit quando valor_total ausente', () => {
+    expect(itemTotal({ quantidade: 3, valor_unitario: 10 })).toBe(30);
+  });
+  it('zero quando não há dados', () => {
+    expect(itemTotal({})).toBe(0);
+  });
+});
+
 describe('buildSalesOrderPrintRow', () => {
   it('injeta nome e documento do cliente', () => {
     const row = buildSalesOrderPrintRow(baseOrder(), 'ACME LTDA', '12.345.678/0001-99');
@@ -65,6 +80,14 @@ describe('buildSalesOrderPrintRow', () => {
     expect(row.account).toBe('oben');
     expect(row.omie_numero_pedido).toBe('0000011104');
     expect(row.notes).toBe('obs teste');
+  });
+
+  it('preenche valor_total do item a partir de qtd × unit quando vem zerado (rascunho)', () => {
+    const o = baseOrder({
+      items: [{ descricao: 'X', quantidade: 2, valor_unitario: 50, valor_total: 0 }] as unknown as SalesOrder['items'],
+    });
+    const row = buildSalesOrderPrintRow(o, 'ACME', '');
+    expect(row.items[0].valor_total).toBe(100);
   });
 
   it('degrada sem lançar quando items ausente e document omitido', () => {

--- a/src/components/salesOrders/print.ts
+++ b/src/components/salesOrders/print.ts
@@ -5,6 +5,17 @@ import { openPrintOrder } from '@/components/OrderPrintLayout';
 import type { CompanyFilter, OmiePayload, OrderItem, SalesOrderRow } from '@/components/sales/print/types';
 import type { SalesOrder } from './types';
 
+// Total da linha do item. Alguns pedidos (ex.: rascunho) gravam valor_total = 0
+// no item embora o valor_unitario esteja preenchido — nesse caso calculamos
+// quantidade × valor_unitário para não exibir/imprimir R$ 0,00.
+export function itemTotal(item: {
+  valor_total?: number | null;
+  quantidade?: number | null;
+  valor_unitario?: number | null;
+}): number {
+  return item.valor_total || (item.quantidade || 0) * (item.valor_unitario || 0);
+}
+
 // sales_orders.account → empresa do cupom. colacor_sc é a entidade Colacor S.C.
 // (mesma chave 'afiacao' do companyMap em buildPrintData).
 export function resolveCompanyForPrint(account?: string): CompanyFilter {
@@ -24,7 +35,8 @@ export function buildSalesOrderPrintRow(
   return {
     id: order.id,
     customer_user_id: order.customer_user_id,
-    items: (order.items ?? []) as unknown as OrderItem[],
+    // valor_total por item recalculado quando vem zerado (rascunhos).
+    items: (order.items ?? []).map((it) => ({ ...it, valor_total: itemTotal(it) })) as unknown as OrderItem[],
     subtotal: order.subtotal ?? 0,
     total: order.total ?? 0,
     desconto: order.discount ?? 0,

--- a/src/components/salesOrders/types.ts
+++ b/src/components/salesOrders/types.ts
@@ -32,10 +32,23 @@ export const decodeHtml = (s: string): string =>
     .replace(/&lt;/g, '<')
     .replace(/&gt;/g, '>');
 
+// Item do pedido como vive no jsonb sales_orders.items. Os campos extras
+// (codigo/unidade/tint) só aparecem em alguns itens (ex.: bases tintométricas).
+export interface SalesOrderItem {
+  descricao: string;
+  quantidade: number;
+  valor_unitario: number;
+  valor_total: number;
+  codigo?: string;
+  unidade?: string;
+  tint_cor_id?: string;
+  tint_nome_cor?: string;
+}
+
 export interface SalesOrder {
   id: string;
   customer_user_id: string;
-  items: Array<{ descricao: string; quantidade: number; valor_unitario: number; valor_total: number }>;
+  items: SalesOrderItem[];
   subtotal: number;
   total: number;
   status: string;


### PR DESCRIPTION
Dois ajustes no painel de detalhe do pedido de venda (segue o #672), reportados pelo founder.

## 1. Cor da base (tinta) no detalhe
Itens de base tintométrica agora mostram a cor usada — `🎨 {código} - {nome}` —
no **mesmo formato da tela de edição** ([OrderItemCard.tsx:23](https://github.com/LucasSardenbergL/afiacao/blob/main/src/components/salesOrderEdit/OrderItemCard.tsx#L23)).
O dado (`tint_cor_id`/`tint_nome_cor`) já vinha gravado no item do pedido
([submitOrder.ts:94](https://github.com/LucasSardenbergL/afiacao/blob/main/src/services/orderSubmission/submitOrder.ts#L94)); o painel só não o exibia.
`SalesOrderItem` passa a declarar os campos opcionais (`tint_cor_id`, `tint_nome_cor`, `codigo`, `unidade`).

## 2. Valor zerado do item
Alguns pedidos (ex.: rascunho) gravam `valor_total = 0` em cada item embora o
`valor_unitario` esteja correto — o painel mostrava "R$ 0,00" na lateral mesmo
com "1 × R$ 511,15" embaixo. Fix: novo helper puro `itemTotal()` que, quando
`valor_total` vem 0, calcula `quantidade × valor_unitário`. Aplicado **no painel
e no cupom** (`buildSalesOrderPrintRow`) para o impresso também sair certo.
O Total do pedido já estava correto (é coluna própria de `sales_orders`).

## Arquivos
- `salesOrders/types.ts` — `SalesOrderItem` com campos de tinta/código/unidade
- `salesOrders/print.ts` — helper `itemTotal` + uso em `buildSalesOrderPrintRow`
- `salesOrders/SalesOrderDetailSheet.tsx` — linha da cor + `itemTotal` no display
- testes: `print.test.ts` (+5) e novo `SalesOrderDetailSheet.test.tsx` (+4)

## Risco
Baixo. Read-only + display/impressão. Não toca criação/edição/envio ao Omie.

## Validação
- `bun run typecheck` ✅
- `bun run test` ✅ **2717/2717**
- `bun lint` ✅ 0 erros
- `bun run build` ✅

⚠️ Frontend: dar **Publish** no Lovable após o merge.

> Obs.: o 3º ponto reportado (scroll infinito que "volta pro início") é um bug
> pré-existente da lista, área diferente — será tratado em PR separado após investigação.

🤖 Generated with [Claude Code](https://claude.com/claude-code)