### PR TITLE
harden(lente): 4 endurecimentos do invariante read-only (review final do codex)

### DIFF
--- a/src/components/impersonation/ImpersonationBanner.tsx
+++ b/src/components/impersonation/ImpersonationBanner.tsx
@@ -15,21 +15,21 @@ import {
 export function ImpersonationBanner() {
   const { isImpersonating, target, startImpersonation, stopImpersonation } = useImpersonation();
   const { user } = useAuth();
-  const { data: perfil, isError } = useImpersonatedAccessProfile();
+  const { data: perfil, isError, isSuccess } = useImpersonatedAccessProfile();
   const { data: targets = [] } = useImpersonationTargets();
 
-  // Auto-saída em falha PERSISTENTE da RPC get_user_access_profile_for: sem o perfil
-  // do alvo a lente não reflete o acesso dele (rebaixaria fail-closed e confundiria).
-  // Sai da lente e avisa, em vez de deixar um menu vazio. isError só dispara depois
-  // dos retries do React Query (blip transitório se auto-recupera, não chega aqui).
-  // Mount único (banner no AppShell) → um toast por falha; isImpersonating vira false
-  // no render seguinte, então o guard impede toast duplicado.
+  // Auto-saída quando NÃO HÁ perfil do alvo: (a) erro PERSISTENTE da RPC
+  // get_user_access_profile_for (isError só dispara após os retries do React Query —
+  // blip transitório se auto-recupera) OU (b) resposta BEM-SUCEDIDA vazia (isSuccess +
+  // data:null, ex.: alvo sem perfil). Sem isto, em (b) a lente ficaria num menu rebaixado
+  // indefinidamente, sem o "Sair" automático. Mount único (banner no AppShell) → um toast;
+  // isImpersonating vira false no render seguinte, então o guard impede toast duplicado.
   useEffect(() => {
-    if (isImpersonating && isError) {
+    if (isImpersonating && (isError || (isSuccess && !perfil))) {
       toast.error('Não foi possível carregar a visão dessa pessoa. Saindo da lente.');
       void stopImpersonation();
     }
-  }, [isImpersonating, isError, stopImpersonation]);
+  }, [isImpersonating, isError, isSuccess, perfil, stopImpersonation]);
 
   if (!isImpersonating || !target) return null;
   const contexto = [perfil?.commercialRole, perfil?.department].filter(Boolean).join(' · ');

--- a/src/contexts/ImpersonationContext.tsx
+++ b/src/contexts/ImpersonationContext.tsx
@@ -23,64 +23,87 @@ export function ImpersonationProvider({ children }: { children: ReactNode }) {
   const [auditId, setAuditId] = useState<string | null>(null);
 
   const realUserId = user?.id ?? null;
-  const effectiveUserId = resolveEffectiveUserId(realUserId, target);
+  // A lente é master-only: um `target` só conta se o usuário REAL é master. Se isMaster
+  // virar false (logout/troca de conta/revogação de papel ao vivo), a lente NÃO pode
+  // continuar ativa — `isImpersonating` e `effectiveUserId` derivam de `lensActive`.
+  const lensActive = isMaster && !!target;
+  const effectiveUserId = resolveEffectiveUserId(realUserId, lensActive ? target : null);
 
-  // Hard reload: no mount o `isMaster` ainda é false (auth assíncrono), então o
-  // init do useState acima cai pra null e a impersonação se perderia. Quando o
-  // master é confirmado, restaura do sessionStorage (continuidade entre reloads).
-  // stopImpersonation limpa o sessionStorage antes deste efeito rodar, então não
-  // re-restaura após "Sair".
+  // Hard reload: no mount o `isMaster` ainda é false (auth assíncrono), então o init do
+  // useState cai pra null e a impersonação se perderia. Quando o master é confirmado,
+  // restaura do sessionStorage. Liga o guard ANTES de publicar o target (fecha a
+  // micro-janela em que a UI já está na lente mas o guard ainda não ligou).
   useEffect(() => {
     if (isMaster && !target) {
       const persisted = loadPersistedTarget();
-      if (persisted) setTarget(persisted);
+      if (persisted) {
+        setLensActive(true);
+        setTarget(persisted);
+      }
     }
   }, [isMaster, target]);
 
-  // Sincronização defensiva do write-guard global: start/stopImpersonation já setam
-  // a flag diretamente; este efeito cobre os casos em que `target` muda por outro
-  // caminho (ex.: restauração do sessionStorage no F5).
+  // Deixou de ser master com a lente ativa → derruba tudo (não deixa um não-master
+  // herdar a lente). Cobre revogação de papel ao vivo / troca de sessão sem remount.
   useEffect(() => {
-    setLensActive(!!target);
-    return () => setLensActive(false);
-  }, [target]);
+    if (!isMaster && target) {
+      setLensActive(false);
+      setTarget(null);
+      persistTarget(null);
+      setAuditId(null);
+    }
+  }, [isMaster, target]);
+
+  // Guard global reflete `lensActive`. NÃO desliga no cleanup de cada mudança de target
+  // (isso criava um flicker A→B com o guard off entre o cleanup e o novo setup) — só
+  // sincroniza o estado atual. O desligamento real é no unmount (effect abaixo) e em
+  // start/stop, que setam a flag direto.
+  useEffect(() => {
+    setLensActive(lensActive);
+  }, [lensActive]);
+  // Unmount do provider: garante o guard desligado (evita flag stale num remount).
+  useEffect(() => () => setLensActive(false), []);
 
   const startImpersonation = useCallback(async (t: ImpersonationTarget, reason?: string) => {
     if (!isMaster) return;
     // Auditoria no client SEM guard: log_impersonation_start é write mutante. Se a lente
-    // já estiver ativa (troca direta de alvo A→B pelo chip/picker), o guard de RPC a
+    // já estiver ativa (troca direta de alvo A→B pelo chip/banner), o guard de RPC a
     // bloquearia — por isso supabaseUnguarded. É bookkeeping do próprio master.
     const { data } = await (supabaseUnguarded as unknown as {
       rpc(fn: string, params?: Record<string, unknown>): Promise<{ data: unknown; error: unknown }>;
     }).rpc('log_impersonation_start', { p_target: t.id, p_reason: reason ?? null });
     setAuditId(typeof data === 'string' ? data : null);
-    setLensActive(true);
+    setLensActive(true); // guard ANTES do target — sem janela "UI na lente + guard off"
     setTarget(t);
     persistTarget(t);
     track('carteira.ver_como_iniciado', { grupo: t.grupo });
   }, [isMaster]);
 
   const stopImpersonation = useCallback(async () => {
-    // Guard fica ATIVO durante o await da auditoria: end_impersonation roda no client
-    // SEM guard (não é bloqueado), mas QUALQUER outra escrita (ex.: flush offline que
-    // dispara nesse intervalo) continua bloqueada enquanto target segue setado (UI ainda
-    // na lente). Sem janela "guard off + lente visível". Só ao final desliga o guard e
-    // limpa o target juntos.
-    if (auditId) {
-      await (supabaseUnguarded as unknown as {
-        rpc(fn: string, params?: Record<string, unknown>): Promise<{ data: unknown; error: unknown }>;
-      }).rpc('end_impersonation', { p_audit_id: auditId });
+    // O guard fica ATIVO durante o await (end_impersonation roda no client sem guard, não
+    // é bloqueado). NÃO desligamos o guard explicitamente aqui: ao limpar o target, o
+    // effect de `lensActive` desliga o guard SÓ DEPOIS de a UI sair da lente — sem janela
+    // "guard off + UI ainda na lente". O try/finally garante a saída mesmo se a auditoria
+    // lançar (senão a lente ficaria presa).
+    try {
+      if (auditId) {
+        await (supabaseUnguarded as unknown as {
+          rpc(fn: string, params?: Record<string, unknown>): Promise<{ data: unknown; error: unknown }>;
+        }).rpc('end_impersonation', { p_audit_id: auditId });
+      }
+    } catch {
+      /* falha de auditoria não pode travar a saída da lente */
+    } finally {
+      setAuditId(null);
+      setTarget(null);
+      persistTarget(null);
     }
-    setAuditId(null);
-    setLensActive(false);
-    setTarget(null);
-    persistTarget(null);
   }, [auditId]);
 
   const value = useMemo(() => ({
-    realUserId, target, effectiveUserId, isImpersonating: !!target,
+    realUserId, target, effectiveUserId, isImpersonating: lensActive,
     startImpersonation, stopImpersonation,
-  }), [realUserId, target, effectiveUserId, startImpersonation, stopImpersonation]);
+  }), [realUserId, target, effectiveUserId, lensActive, startImpersonation, stopImpersonation]);
 
   return <Ctx.Provider value={value}>{children}</Ctx.Provider>;
 }

--- a/src/contexts/__tests__/ImpersonationContext.test.tsx
+++ b/src/contexts/__tests__/ImpersonationContext.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import { ImpersonationProvider, useImpersonation } from '@/contexts/ImpersonationContext';
+
+const authMock = vi.fn();
+const setLensActiveSpy = vi.fn();
+const persistTargetSpy = vi.fn();
+const loadPersistedSpy = vi.fn();
+
+vi.mock('@/contexts/AuthContext', () => ({ useAuth: () => authMock() }));
+vi.mock('@/lib/impersonation/lens-write-guard', () => ({ setLensActive: (v: boolean) => setLensActiveSpy(v) }));
+vi.mock('@/lib/impersonation/effective-user', () => ({
+  loadPersistedTarget: () => loadPersistedSpy(),
+  persistTarget: (t: unknown) => persistTargetSpy(t),
+  resolveEffectiveUserId: (real: string | null, target: { id: string } | null) => target?.id ?? real,
+}));
+vi.mock('@/integrations/supabase/client', () => ({
+  supabaseUnguarded: { rpc: vi.fn().mockResolvedValue({ data: 'audit-1', error: null }) },
+}));
+vi.mock('@/lib/analytics', () => ({ track: vi.fn() }));
+
+function View() {
+  const { isImpersonating, effectiveUserId } = useImpersonation();
+  return (
+    <div>
+      <span data-testid="imp">{String(isImpersonating)}</span>
+      <span data-testid="eff">{effectiveUserId ?? ''}</span>
+    </div>
+  );
+}
+
+const TARGET = { id: 'regina-1', nome: 'Regina', grupo: 'farmer' as const };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  loadPersistedSpy.mockReturnValue(TARGET);
+});
+
+describe('ImpersonationProvider — lente é master-only', () => {
+  it('master com target persistido → impersonando (effectiveUserId = alvo)', () => {
+    authMock.mockReturnValue({ user: { id: 'master-1' }, isMaster: true });
+    render(<ImpersonationProvider><View /></ImpersonationProvider>);
+    expect(screen.getByTestId('imp').textContent).toBe('true');
+    expect(screen.getByTestId('eff').textContent).toBe('regina-1');
+  });
+
+  it('não-master com target persistido → NÃO impersona, e effectiveUserId não vaza pro alvo', () => {
+    authMock.mockReturnValue({ user: { id: 'someone' }, isMaster: false });
+    render(<ImpersonationProvider><View /></ImpersonationProvider>);
+    expect(screen.getByTestId('imp').textContent).toBe('false');
+    expect(screen.getByTestId('eff').textContent).toBe('someone');
+  });
+
+  it('deixar de ser master com a lente ativa → derruba a lente (guard off + persist limpo)', () => {
+    authMock.mockReturnValue({ user: { id: 'master-1' }, isMaster: true });
+    const { rerender } = render(<ImpersonationProvider><View /></ImpersonationProvider>);
+    expect(screen.getByTestId('imp').textContent).toBe('true');
+    // revogação de papel ao vivo / troca de sessão sem remount:
+    authMock.mockReturnValue({ user: { id: 'master-1' }, isMaster: false });
+    act(() => { rerender(<ImpersonationProvider><View /></ImpersonationProvider>); });
+    expect(screen.getByTestId('imp').textContent).toBe('false');
+    expect(setLensActiveSpy).toHaveBeenCalledWith(false);
+    expect(persistTargetSpy).toHaveBeenCalledWith(null);
+  });
+});


### PR DESCRIPTION
Passada final do codex no invariante read-only da lente. O codex **validou a arquitetura** (sem furo fundamental; o read-only se sustenta nos caminhos reais — a lente é master-only e o write-guard é defesa-em-profundidade, não barreira) e rendeu 4 hardenings baratos e corretos, landados aqui:

1. **Master-only robusto.** `isImpersonating` e `effectiveUserId` agora derivam de `lensActive = isMaster && !!target` (antes era só `!!target`); + effect que **derruba a lente se `isMaster` virar false** (logout/troca/revogação de papel ao vivo). Um não-master nunca herda a lente. + teste.
2. **Banner sai em perfil-null bem-sucedido.** A auto-saída só disparava em `isError`; se a RPC `get_user_access_profile_for` retorna `data:null` sem erro, a lente ficava num menu rebaixado indefinidamente. Agora sai também em `isSuccess && !perfil`.
3. **`stopImpersonation` com try/finally.** Falha da RPC de auditoria não trava a saída (antes, se `end_impersonation` lançasse, o `setTarget(null)` não rodava → lente presa).
4. **Timing do guard nas transições.** Liga o guard ANTES de publicar o target (start/restore — fecha a micro-janela "UI na lente + guard off"); o effect dirige pelo `lensActive` (sem flicker A→B do cleanup); no stop, o guard só desliga DEPOIS de a UI sair da lente (sem janela "guard off + UI na lente"); cleanup só no unmount.

**Achados do codex NÃO acionados (com justificativa):**
- ⚪ *Por design (defesa em profundidade, não barreira):* `.schema().from()`, storage admin, `auth.updateUser`, realtime `.send()`, `fetch` cru escapam do guard client-side — verdade, mas nenhum é alcançável nas telas da lente nem money-path; barreira client-side completa é impossível (token é do master). A proteção real é menu/rota gateado.
- 🟢 *Já coberto (o codex não tinha o repo todo):* `supabaseUnguarded` é contido por guardrail de CI; o guard do WebRTC está no topo do `makeCall` (= antes do discar).
- ⏸️ *Menor (anotado):* allowlist de RPC explícita vs prefixo `get_`/`list_` (preventivo — nenhum RPC `get_/list_` do inventário atual muta); higiene de auditoria (fechar sessão A ao trocar/reload); rótulo "farmer" genérico (cosmético).

typecheck + lint + 32 testes verdes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)