### PR TITLE
fix(lente): telas de "minha atividade" do vendedor respeitam "Ver como" (PR1/3)

### DIFF
--- a/src/hooks/__tests__/lens-atividade-vendedor.test.tsx
+++ b/src/hooks/__tests__/lens-atividade-vendedor.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+
+/**
+ * Guard de regressão da lente "Ver como pessoa" nas telas de ATIVIDADE do vendedor
+ * (cards do dashboard "Meu Dia"). Estas leituras devem filtrar pelo id EFETIVO:
+ * o ALVO na lente, o próprio usuário fora dela. Captura todo `.eq(col, valor)` do
+ * stub do supabase e verifica que o id filtrado segue a lente.
+ */
+const eqCalls: Array<[string, unknown]> = [];
+
+function stubChain(): unknown {
+  const chain: Record<string, unknown> = {};
+  const passthrough = [
+    'select', 'gte', 'lt', 'lte', 'gt', 'is', 'not', 'in', 'order',
+    'limit', 'range', 'or', 'neq', 'filter', 'single', 'maybeSingle', 'contains',
+  ];
+  for (const m of passthrough) chain[m] = () => chain;
+  chain.eq = (col: string, val: unknown) => { eqCalls.push([col, val]); return chain; };
+  // thenable: qualquer `await chain` resolve vazio (a lógica vive em helpers puros já testados)
+  chain.then = (resolve: (v: unknown) => void) => resolve({ data: [], error: null, count: 0 });
+  return chain;
+}
+
+vi.mock('@/integrations/supabase/client', () => ({ supabase: { from: () => stubChain() } }));
+
+const impMock = vi.fn();
+vi.mock('@/contexts/ImpersonationContext', () => ({ useImpersonation: () => impMock() }));
+vi.mock('@/contexts/AuthContext', () => ({ useAuth: () => ({ user: { id: 'master-id' } }) }));
+
+import { useKpisVisita } from '../useKpisVisita';
+import { useMyKpis } from '../useMyKpis';
+import { useFollowupsVisita } from '../useFollowupsVisita';
+import { useMinhasVisitasResultado } from '../useMinhasVisitasResultado';
+
+let qc: QueryClient;
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+);
+
+beforeEach(() => {
+  eqCalls.length = 0;
+  qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+});
+
+// Os hooks são chamados via renderHook (contexto de render válido); o lint não enxerga
+// a indireção `run`, então desligamos a regra localmente neste array de casos.
+/* eslint-disable react-hooks/rules-of-hooks */
+const hooks: Array<{ name: string; run: () => unknown }> = [
+  { name: 'useKpisVisita', run: () => useKpisVisita(30) },
+  { name: 'useMyKpis', run: () => useMyKpis() },
+  { name: 'useFollowupsVisita', run: () => useFollowupsVisita() },
+  { name: 'useMinhasVisitasResultado', run: () => useMinhasVisitasResultado(30) },
+];
+/* eslint-enable react-hooks/rules-of-hooks */
+
+for (const h of hooks) {
+  describe(`${h.name} — lente "Ver como"`, () => {
+    it('na lente: filtra pelo id do ALVO, nunca o do master', async () => {
+      impMock.mockReturnValue({ isImpersonating: true, effectiveUserId: 'alvo-id' });
+      renderHook(h.run, { wrapper });
+      await waitFor(() => expect(eqCalls.length).toBeGreaterThan(0));
+      const valores = eqCalls.map((c) => c[1]);
+      expect(valores).toContain('alvo-id');
+      expect(valores).not.toContain('master-id');
+    });
+
+    it('fora da lente: filtra pelo próprio usuário', async () => {
+      impMock.mockReturnValue({ isImpersonating: false, effectiveUserId: 'master-id' });
+      renderHook(h.run, { wrapper });
+      await waitFor(() => expect(eqCalls.length).toBeGreaterThan(0));
+      expect(eqCalls.map((c) => c[1])).toContain('master-id');
+    });
+  });
+}

--- a/src/hooks/useFarmerScoring.ts
+++ b/src/hooks/useFarmerScoring.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect, useMemo, useCallback } from 'react';
 import { supabase } from '@/integrations/supabase/client';
-import { useAuth } from '@/contexts/AuthContext';
+import { useImpersonation } from '@/contexts/ImpersonationContext';
 import type { Tables, TablesInsert } from '@/integrations/supabase/types';
 
 type AlgorithmConfigRow = Pick<Tables<'farmer_algorithm_config'>, 'key' | 'value'>;
@@ -95,8 +95,9 @@ function percentile(arr: number[], p: number): number {
 
 // ─── Main Hook ───────────────────────────────────────────────────────
 export const useFarmerScoring = (farmerId?: string) => {
-  const { user } = useAuth();
-  const targetFarmerId = farmerId || user?.id;
+  // Lente "Ver como": id efetivo = ALVO na lente (lê/exibe a agenda dele), próprio usuário fora.
+  const { isImpersonating, effectiveUserId } = useImpersonation();
+  const targetFarmerId = farmerId || effectiveUserId;
 
   const [config, setConfig] = useState<AlgorithmConfig>(DEFAULT_CONFIG);
   const [clientScores, setClientScores] = useState<ClientScore[]>([]);
@@ -414,8 +415,9 @@ export const useFarmerScoring = (farmerId?: string) => {
 
       setAgenda(agendaItems);
 
-      // 9. Persist scores to DB
-      for (const s of scores) {
+      // 9. Persist scores to DB — pulado na lente "Ver como" (somente leitura: o master
+      // inspeciona a agenda do alvo sem recalcular/persistir a carteira dele).
+      if (!isImpersonating) for (const s of scores) {
         const scoreUpsert: TablesInsert<'farmer_client_scores'> = {
           customer_user_id: s.customer_user_id,
           farmer_id: targetFarmerId,
@@ -449,7 +451,7 @@ export const useFarmerScoring = (farmerId?: string) => {
       setCalculating(false);
       setLoading(false);
     }
-  }, [targetFarmerId, config]);
+  }, [targetFarmerId, config, isImpersonating]);
 
   useEffect(() => {
     if (targetFarmerId) calculateScores();

--- a/src/hooks/useFollowupsVisita.ts
+++ b/src/hooks/useFollowupsVisita.ts
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { useAuth } from '@/contexts/AuthContext';
+import { useImpersonation } from '@/contexts/ImpersonationContext';
 import { supabase } from '@/integrations/supabase/client';
 import { hojeISO } from '@/lib/visitas/today';
 import {
@@ -22,8 +22,8 @@ export interface FollowupsVisita {
  * Read-only.
  */
 export function useFollowupsVisita() {
-  const { user } = useAuth();
-  const uid = user?.id;
+  // Lente "Ver como": id efetivo = ALVO na lente, próprio usuário fora dela.
+  const { effectiveUserId: uid } = useImpersonation();
   return useQuery({
     queryKey: ['followups-visita', uid],
     enabled: !!uid,

--- a/src/hooks/useKpisVisita.ts
+++ b/src/hooks/useKpisVisita.ts
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { useAuth } from '@/contexts/AuthContext';
+import { useImpersonation } from '@/contexts/ImpersonationContext';
 import { supabase } from '@/integrations/supabase/client';
 import { montarKpisVisita, type KpisVisita, type KpiVisitaRow } from '@/lib/visitas/kpis';
 
@@ -8,8 +8,8 @@ import { montarKpisVisita, type KpisVisita, type KpiVisitaRow } from '@/lib/visi
  * (visited_by=eu, RLS #340). Read-only. Definições em src/lib/visitas/kpis.ts.
  */
 export function useKpisVisita(janelaDias = 30) {
-  const { user } = useAuth();
-  const uid = user?.id;
+  // Lente "Ver como": id efetivo = ALVO na lente, próprio usuário fora dela.
+  const { effectiveUserId: uid } = useImpersonation();
   return useQuery({
     queryKey: ['kpis-visita', uid, janelaDias],
     enabled: !!uid,

--- a/src/hooks/useMinhasVisitasResultado.ts
+++ b/src/hooks/useMinhasVisitasResultado.ts
@@ -1,26 +1,28 @@
 import { useQuery } from '@tanstack/react-query';
-import { useAuth } from '@/contexts/AuthContext';
+import { useImpersonation } from '@/contexts/ImpersonationContext';
 import { supabase } from '@/integrations/supabase/client';
 import type { VisitaConversaoRow } from '@/lib/visitas/conversao';
 
 /**
- * Visitas do vendedor logado (route_visits onde visited_by = eu) numa janela de dias,
- * só os campos pro breakdown de conversão (result + revenue). RLS own-scoped (#340). Read-only.
+ * Visitas do vendedor numa janela (route_visits onde visited_by = id efetivo), só os
+ * campos pro breakdown de conversão (result + revenue). RLS #340: own + branch
+ * gestor/master (este cobre a leitura do ALVO na lente "Ver como"). Read-only.
  */
 export function useMinhasVisitasResultado(janelaDias: number) {
-  const { user } = useAuth();
+  // Lente "Ver como": id efetivo = ALVO na lente, próprio usuário fora dela.
+  const { effectiveUserId: uid } = useImpersonation();
   return useQuery({
-    queryKey: ['minhas-visitas-resultado', user?.id, janelaDias],
-    enabled: !!user?.id,
+    queryKey: ['minhas-visitas-resultado', uid, janelaDias],
+    enabled: !!uid,
     staleTime: 60_000,
     gcTime: 5 * 60_000,
     queryFn: async (): Promise<VisitaConversaoRow[]> => {
-      if (!user?.id) return [];
+      if (!uid) return [];
       const desde = new Date(Date.now() - janelaDias * 86_400_000).toISOString();
       const { data, error } = await supabase
         .from('route_visits')
         .select('result, revenue_generated')
-        .eq('visited_by', user.id)
+        .eq('visited_by', uid)
         .gte('check_in_at', desde);
       if (error) throw new Error(error.message);
       return (data ?? []) as VisitaConversaoRow[];

--- a/src/hooks/useMyKpis.ts
+++ b/src/hooks/useMyKpis.ts
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
-import { useAuth } from '@/contexts/AuthContext';
+import { useImpersonation } from '@/contexts/ImpersonationContext';
 import { spDayRangeUtc } from '@/lib/time/sp-day';
 
 export interface FarmerKpis {
@@ -12,16 +12,17 @@ export interface FarmerKpis {
 }
 
 /**
- * KPIs do dia pro vendedor logado, agregados de farmer_calls.
+ * KPIs do dia pro vendedor, agregados de farmer_calls.
+ * Lente "Ver como": id efetivo = ALVO na lente, próprio usuário fora dela.
  */
 export function useMyKpis() {
-  const { user } = useAuth();
+  const { effectiveUserId } = useImpersonation();
   return useQuery({
-    queryKey: ['my-kpis', user?.id],
-    enabled: !!user,
+    queryKey: ['my-kpis', effectiveUserId],
+    enabled: !!effectiveUserId,
     staleTime: 30_000,
     queryFn: async (): Promise<FarmerKpis> => {
-      if (!user) {
+      if (!effectiveUserId) {
         return { calls_today: 0, revenue_today: 0, margin_today: 0, avg_ticket_today: 0, pending_link_count: 0 };
       }
       // Janela do dia no fuso de São Paulo, como instantes UTC. Sem isto, a data UTC
@@ -30,7 +31,7 @@ export function useMyKpis() {
 
       const { data: calls } = await supabase.from('farmer_calls')
         .select('revenue_generated, margin_generated')
-        .eq('farmer_id', user.id)
+        .eq('farmer_id', effectiveUserId)
         .gte('started_at', startUtc)
         .lt('started_at', endUtc);
 
@@ -39,10 +40,9 @@ export function useMyKpis() {
       const margin = callsArr.reduce((s, c) => s + Number(c.margin_generated ?? 0), 0);
       const withRevenue = callsArr.filter((c) => Number(c.revenue_generated ?? 0) > 0);
 
-       
       const { count: pending } = await supabase.from('farmer_calls')
         .select('id', { count: 'exact', head: true })
-        .eq('farmer_id', user.id)
+        .eq('farmer_id', effectiveUserId)
         .is('customer_user_id', null)
         .not('transcript', 'is', null);
 

--- a/src/lib/impersonation/__tests__/no-write-leak.test.ts
+++ b/src/lib/impersonation/__tests__/no-write-leak.test.ts
@@ -34,6 +34,18 @@ const ALLOWED = new Set([
   // AppShell: effectiveUserId SÓ no badge de perdidas não-lidas (useMissedCount = count/LEITURA)
   // pro "Ver como" refletir o alvo; nenhuma mutation no shell usa effectiveUserId.
   'src/components/AppShell.tsx',
+  // Cards de "minha atividade" do dashboard (Meu Dia): leitura escopada pelo id efetivo
+  // da lente (KPIs do dia, KPIs/follow-ups/resultado de visitas). Read-only, sem mutation.
+  'src/hooks/useMyKpis.ts',
+  'src/hooks/useKpisVisita.ts',
+  'src/hooks/useFollowupsVisita.ts',
+  'src/hooks/useMinhasVisitasResultado.ts',
+  // FarmerCalls: effectiveUserId SÓ na leitura da lista de ligações (loadCallLogs); a escrita
+  // (handleSaveCall, farmer_id=user.id) é write-identity e o botão "Nova ligação" é disabled na lente.
+  'src/pages/FarmerCalls.tsx',
+  // useFarmerScoring: effectiveUserId na leitura/cálculo da agenda do alvo; o upsert de scores
+  // é PULADO na lente (skip por isImpersonating) — o master não recalcula a carteira do alvo.
+  'src/hooks/useFarmerScoring.ts',
 ]);
 
 describe('anti write-leak: effectiveUserId só em leitura', () => {

--- a/src/pages/FarmerCalls.tsx
+++ b/src/pages/FarmerCalls.tsx
@@ -32,7 +32,7 @@ const FarmerCalls = () => {
   const { data: positivacao } = useMyPositivacao();
   const { data: commercialRole } = useMyCommercialRole();
   const isHunter = commercialRole === 'hunter';
-  const { isImpersonating } = useImpersonation();
+  const { isImpersonating, effectiveUserId } = useImpersonation();
 
   // Real Nvoip call integration for the dialog timer
   const {
@@ -87,7 +87,8 @@ const FarmerCalls = () => {
 
   useEffect(() => {
     if (isStaff) loadCallLogs();
-  }, [isStaff]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isStaff, effectiveUserId]);
 
   useEffect(() => {
     return () => {
@@ -122,12 +123,13 @@ const FarmerCalls = () => {
   }, [nvoipState]);
 
   const loadCallLogs = async () => {
-    if (!user?.id) return;
+    // Lente "Ver como": lista as ligações do ALVO (effectiveUserId), não as do master.
+    if (!effectiveUserId) return;
     try {
       const { data } = await supabase
         .from('farmer_calls')
         .select('*')
-        .eq('farmer_id', user.id)
+        .eq('farmer_id', effectiveUserId)
         .order('created_at', { ascending: false })
         .limit(100);
 


### PR DESCRIPTION
## Contexto
Continuação de [#671](https://github.com/LucasSardenbergL/afiacao/pull/671) (Telefonia). Auditei a feature **"Ver como pessoa"** (lente read-only do master sobre uma vendedora) e achei uma classe de telas que leem a atividade do vendedor por `useAuth().user.id` — **sempre o master real** — então na lente mostravam os dados do master, não do alvo. Este é o **PR1 de 3**: a família "minha atividade" (leituras puras, baixo risco).

## Por que o fix de front basta
O RLS das tabelas de carteira (`farmer_calls`, `route_visits` — #329/#340) tem branch **gestor/master**, então o master lê os dados do alvo ao filtrar por `effectiveUserId`. Fora da lente, `effectiveUserId === user.id` (`resolveEffectiveUserId`), então é **byte-equivalente** ao comportamento atual.

## Mudanças (leitura → id efetivo)
| Hook / tela | Card no "Meu Dia" |
|---|---|
| `useMyKpis` | KPIs do dia (KpisToday) |
| `useKpisVisita` | KPIs de visita (VisitasKpiTiles) |
| `useFollowupsVisita` | Follow-ups sugeridos |
| `useMinhasVisitasResultado` | Conversão de visitas |
| `FarmerCalls.loadCallLogs` | Lista + stats de ligações (`/farmer/calls`) |
| `useFarmerScoring` | Agenda/scores — ver nota |

**`useFarmerScoring` (engine):** a leitura/cálculo da agenda segue o alvo, mas o **upsert de scores é pulado na lente** (`if (!isImpersonating)`) — o master inspeciona, não recalcula/persiste a carteira do alvo. A escrita já era barrada pelo write-guard; o skip é defesa dupla + evita o erro de guard.

`FarmerCalls.handleSaveCall` (nova ligação) **não muda**: é write-identity (`user.id`) e o botão já é `disabled` na lente.

## Verificação
- ✅ TDD: `lens-atividade-vendedor.test.tsx` — stub captura o `.eq()` de cada hook; na lente o filtro usa o **alvo** e nunca o master; fora, o próprio usuário.
- ✅ Suite completa (2698), typecheck strict, lint, guardrails de impersonação (allowlist `no-write-leak` +6 — `effectiveUserId` só em LEITURA).

## Próximos PRs da frente
- **PR2** — engines/planos (`useTacticalPlan`, `useFarmerTacticalPlan`, `useFarmerCopilot`, `useFarmerExperiments`, `useCrossSellEngine`, `useDiagnosticQuestions`, `FarmerCallsPendingLink`): leitura do que já existe → alvo; ações de gerar → `disabled` na lente.
- **PR3** — dúvidas de alcançabilidade (`AdminCustomers` está no menu sem gating; `RoutePlanner`/`Intelligence` são gestor-only).

## Deploy
**100% frontend** — sem migration/edge. ⚠️ Requer **Publish no Lovable** após o merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)