### PR TITLE
fix(reposição): A2 — cmc do pedido account-aware (fecha [P1] do Codex)

### DIFF
--- a/db/test-preco-pedido-cmc-account.sh
+++ b/db/test-preco-pedido-cmc-account.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Testa A2-parte-2 (preco_unitario do pedido = cmc-primeiro) num PG17 descartável.
+# (1) CREATE OR REPLACE da RPC sobre o snapshot → parseia + íntegra (pega erro de transcrição grosso).
+# (2) END-TO-END: semeia 1 SKU OBEN, chama gerar_pedidos_sugeridos_ciclo, confere:
+#     - preco_unitario do item = cmc (536), NÃO a média (436);  ← a mudança
+#     - cmc=0 e cmc<0 caem pra média (não viram 0);             ← guard CASE WHEN cmc>0
+#     - qtde_final = ceil(max - estoque) e filtros sobreviveram à transcrição (prova funcional).
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PGVER=17
+PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+PORT=5436
+DATA="$(mktemp -d /tmp/pgtest-precoped-acc.XXXXXX)/data"
+export LC_ALL=C LANG=C
+MIG="$REPO_ROOT/supabase/migrations/20260606190000_reposicao_preco_pedido_cmc_account.sql"
+
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente"; exit 1; }
+CELLAR="$(brew --prefix postgresql@${PGVER})"
+cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
+mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
+cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+trap cleanup EXIT
+
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l /tmp/pg-precoped-acc.log -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres ppacc_verify
+P() { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d ppacc_verify "$@"; }
+
+RR="$(mktemp /tmp/snap-ppacc.XXXXXX.sql)"
+sed -E 's/^(CREATE SCHEMA public;)/-- \1/' "$REPO_ROOT/supabase/schema-snapshot.sql" \
+  | grep -vE '^\\(un)?restrict ' > "$RR"
+P -v ON_ERROR_STOP=1 -q -f "$REPO_ROOT/db/stubs-supabase.sql"
+P -v ON_ERROR_STOP=1 -q -f "$REPO_ROOT/supabase/schema-extensions-prelude.sql"
+P --single-transaction -v ON_ERROR_STOP=1 -q -f "$RR"
+rm -f "$RR"
+echo "SNAPSHOT OK."
+
+# ⚠️ Snapshot (Jun 5) STALE: faltam colunas recentes que a RPC viva referencia (§6 picking-bridge).
+# Em prod elas EXISTEM (#575 tipo_produto, #608 minimo_forcado_manual). Patch p/ casar prod.
+P -v ON_ERROR_STOP=1 -q <<'SQL'
+ALTER TABLE public.omie_products ADD COLUMN IF NOT EXISTS tipo_produto text;
+ALTER TABLE public.sku_parametros ADD COLUMN IF NOT EXISTS minimo_forcado_manual numeric;
+-- FKs irrelevantes ao que testamos (lógica de preço da RPC) — dropo no PG17 descartável p/ semear livre
+ALTER TABLE public.sku_leadtime_history DROP CONSTRAINT IF EXISTS sku_leadtime_history_tracking_id_fkey;
+SQL
+echo "PATCH colunas stale OK."
+
+# (1) CREATE OR REPLACE → parseia + resolve colunas (transcrição grossa quebraria aqui).
+P -v ON_ERROR_STOP=1 -q -f "$MIG"
+echo "REPLACE OK (RPC parseia + íntegra)."
+P -v ON_ERROR_STOP=1 -tA -c "SELECT 'tem_cmc_account_aware=' || (CASE WHEN pg_get_functiondef('public.gerar_pedidos_sugeridos_ciclo(text,date)'::regprocedure) ILIKE '%ipc.account = ANY%' AND pg_get_functiondef('public.gerar_pedidos_sugeridos_ciclo(text,date)'::regprocedure) ILIKE '%ipc.cmc > 0%' THEN 'sim' ELSE 'NAO' END);"
+
+# (2) END-TO-END
+echo ""
+echo "END-TO-END (asserts):"
+P -v ON_ERROR_STOP=1 -tA <<'SQL'
+-- limpa o que vamos usar
+TRUNCATE pedido_compra_item, pedido_compra_sugerido CASCADE;
+DELETE FROM sku_parametros        WHERE empresa='OBEN' AND sku_codigo_omie::text IN ('100','200','300','500');
+DELETE FROM inventory_position    WHERE omie_codigo_produto::text IN ('100','200','300','500');
+DELETE FROM sku_leadtime_history  WHERE empresa='OBEN' AND sku_codigo_omie::text IN ('100','200','300','500');
+DELETE FROM sku_estoque_atual     WHERE empresa='OBEN' AND sku_codigo_omie::text IN ('100','200','300','500');
+DELETE FROM omie_products         WHERE account='oben' AND omie_codigo_produto::text IN ('100','200','300','500');
+DELETE FROM fornecedor_habilitado_reposicao WHERE empresa='OBEN' AND fornecedor_nome IN ('FORN A');
+
+-- omie_products: 4 SKUs Produto NORMAL ('01'); a presença de tipo_produto NOT NULL satisfaz o guard
+INSERT INTO omie_products (omie_codigo_produto, account, codigo, descricao, ativo, tipo_produto)
+VALUES (100,'oben','PRD100','PROD 100',true,'01'),(200,'oben','PRD200','PROD 200',true,'01'),(300,'oben','PRD300','PROD 300',true,'01'),(500,'oben','PRD500','PROD 500',true,'01')
+ON CONFLICT (omie_codigo_produto, account) DO UPDATE SET tipo_produto=EXCLUDED.tipo_produto, ativo=true, descricao=EXCLUDED.descricao;
+
+-- sku_parametros: habilitados, automatica, fornecedor, ponto_pedido=10, max=100
+INSERT INTO sku_parametros (empresa, sku_codigo_omie, sku_descricao, fornecedor_nome, habilitado_reposicao_automatica, tipo_reposicao, ponto_pedido, estoque_maximo)
+VALUES ('OBEN',100,'PROD 100','FORN A',true,'automatica',10,100),
+       ('OBEN',200,'PROD 200','FORN A',true,'automatica',10,100),
+       ('OBEN',300,'PROD 300','FORN A',true,'automatica',10,100),
+       ('OBEN',500,'PROD 500','FORN A',true,'automatica',10,100);
+
+-- inventory_position: 100 cmc=536 ('oben') ; 200 cmc=0 ; 300 cmc=-5 ; 500 cmc=700 SÓ na 'vendas' (sem 'oben')
+INSERT INTO inventory_position (omie_codigo_produto, account, saldo, cmc, synced_at)
+VALUES (100,'oben',5,536.00,now()),(200,'oben',5,0,now()),(300,'oben',5,-5.00,now()),
+       (500,'vendas',5,700.00,now());   -- [ACCOUNT] cmc só na convenção canônica → motor antigo perdia
+
+-- sku_leadtime_history: média de compras — 100→436,80 ; 200→100 ; 300→200 ; 500→300
+INSERT INTO sku_leadtime_history (tracking_id, empresa, sku_codigo_omie, t1_data_pedido, quantidade_recebida, valor_total)
+VALUES (gen_random_uuid(),'OBEN',100,now(),10,4368.00),
+       (gen_random_uuid(),'OBEN',200,now(),10,1000.00),
+       (gen_random_uuid(),'OBEN',300,now(),10,2000.00),
+       (gen_random_uuid(),'OBEN',500,now(),10,3000.00);
+
+-- sku_estoque_atual: estoque_fisico=5 (<= ponto_pedido 10 → precisa repor)
+INSERT INTO sku_estoque_atual (empresa, sku_codigo_omie, estoque_fisico, estoque_pendente_entrada)
+VALUES ('OBEN',100,5,0),('OBEN',200,5,0),('OBEN',300,5,0),('OBEN',500,5,0);
+
+-- fornecedor habilitado (fornece horario_corte_pedido)
+INSERT INTO fornecedor_habilitado_reposicao (id, empresa, fornecedor_nome, habilitado, horario_corte_pedido)
+VALUES (9001,'OBEN','FORN A',true,'10:00:00');
+
+-- chama o motor
+SELECT * FROM public.gerar_pedidos_sugeridos_ciclo('OBEN', CURRENT_DATE);
+
+-- asserts sobre os itens gerados
+SELECT 'B1 sku100 preco_unitario = cmc 536 (NÃO 436): ' || (preco_unitario = 536.00)
+  FROM pedido_compra_item WHERE sku_codigo_omie::text='100'
+UNION ALL SELECT 'B2 sku200 cmc=0 cai pra média 100: ' || (preco_unitario = 100.00)
+  FROM pedido_compra_item WHERE sku_codigo_omie::text='200'
+UNION ALL SELECT 'B3 sku300 cmc<0 cai pra média 200: ' || (preco_unitario = 200.00)
+  FROM pedido_compra_item WHERE sku_codigo_omie::text='300'
+UNION ALL SELECT 'B4 sku100 qtde_final = ceil(100-5)=95 (qtde-inteira viva): ' || (qtde_final = 95)
+  FROM pedido_compra_item WHERE sku_codigo_omie::text='100'
+UNION ALL SELECT 'B5 sku100 valor_linha = 95*536 = 50920: ' || (valor_linha = 50920.00)
+  FROM pedido_compra_item WHERE sku_codigo_omie::text='100'
+UNION ALL SELECT 'B6 gerou 4 itens (filtros sobreviveram): ' || ((SELECT count(*) FROM pedido_compra_item)=4)
+UNION ALL SELECT 'B7 [ACCOUNT] sku500 cmc SÓ na vendas (700) — motor agora pega (NÃO média 300): ' || (preco_unitario = 700.00)
+  FROM pedido_compra_item WHERE sku_codigo_omie::text='500';
+SQL
+echo ""
+echo "✅ test-preco-pedido-cmc OK"

--- a/supabase/migrations/20260606190000_reposicao_preco_pedido_cmc_account.sql
+++ b/supabase/migrations/20260606190000_reposicao_preco_pedido_cmc_account.sql
@@ -1,0 +1,159 @@
+-- A2 (parte 2b, money-path): conserta o [P1] do Codex challenge — o cmc do PEDIDO ficava
+-- INCONSISTENTE com a tela. A view (A2 parte 1) busca o cmc nas DUAS convenções de account
+-- (vendas|oben→OBEN etc.); o motor buscava só `ip.account = lower(p_empresa)` ('oben') → se um
+-- SKU tivesse cmc só na conta canônica 'vendas' (o feed do omie-analytics-sync), o pedido caía
+-- pra média enquanto a TELA mostrava cmc. Com o cmc-first (parte 2a, #669) isso virou divergência.
+--
+-- FIX: o cmc do preco_unitario vem de um SUBQUERY que espelha a CTE precos_cmc da view —
+-- account = ANY(['vendas','oben'] etc.), cmc>0, synced_at mais fresco, LIMIT 1 (subquery e não
+-- join p/ não multiplicar a linha quando os 2 accounts existem). preco_unitario =
+-- COALESCE(cmc_2convencoes, média, 0). Agora motor.cmc == view.cmc por construção.
+--
+-- ⚠️ Base = a def VIVA (20260606180000, já em prod = "cmc-primeiro ativo") + a troca do cmc.
+-- O LEFT JOIN `ip` antigo fica intacto (inócuo, ≤1 linha por account='oben') p/ não mexer nos
+-- parênteses da cadeia; o cmc agora vem do subquery `ipc`. NÃO rebasear de migration antiga (§10).
+-- Validar: PG17 end-to-end (incl. SKU com cmc só na 'vendas' → motor agora pega).
+
+CREATE OR REPLACE FUNCTION public.gerar_pedidos_sugeridos_ciclo(p_empresa text DEFAULT 'OBEN'::text, p_data_ciclo date DEFAULT CURRENT_DATE)
+ RETURNS TABLE(pedidos_gerados integer, skus_incluidos integer, valor_total_ciclo numeric, bloqueados integer)
+ LANGUAGE plpgsql
+ SET search_path TO 'public', 'pg_temp'
+ SET statement_timeout TO '120s'
+AS $function$
+DECLARE
+  v_pedidos INT := 0;
+  v_skus INT := 0;
+  v_valor NUMERIC := 0;
+  v_bloqueados INT := 0;
+BEGIN
+  IF (SELECT count(*) FILTER (WHERE tipo_produto IS NOT NULL) FROM public.omie_products WHERE account = lower(p_empresa)) = 0 THEN
+    RAISE EXCEPTION 'tipo_produto_unhealthy: sinal de classificação ausente em omie_products(account=%) — recusando gerar compras p/ não tratar Produto Acabado como comprável', lower(p_empresa);
+  END IF;
+
+  DELETE FROM pedido_compra_sugerido
+  WHERE empresa = p_empresa AND data_ciclo = p_data_ciclo AND status = 'pendente_aprovacao';
+
+  WITH em_transito AS (
+    SELECT pcs2.empresa, pci.sku_codigo_omie::text AS sku_codigo_omie, SUM(pci.qtde_final) AS qtde
+    FROM pedido_compra_item pci
+    JOIN pedido_compra_sugerido pcs2 ON pcs2.id = pci.pedido_id
+    WHERE pcs2.empresa = p_empresa
+      AND (
+        (pcs2.status IN ('aprovado_aguardando_disparo','disparado','concluido_recebido') AND pcs2.data_ciclo >= (p_data_ciclo - INTERVAL '7 days'))
+        OR (pcs2.status_envio_portal IN ('sucesso_portal','enviado_portal') AND pcs2.portal_protocolo IS NOT NULL AND pcs2.omie_pedido_compra_numero IS NULL AND pcs2.status NOT IN ('cancelado','expirado_sem_aprovacao'))
+      )
+    GROUP BY pcs2.empresa, pci.sku_codigo_omie
+  ),
+  preco_medio AS (
+    SELECT slh.empresa::text AS empresa, slh.sku_codigo_omie::text AS sku_codigo_omie,
+           AVG(slh.valor_total / NULLIF(slh.quantidade_recebida, 0)) AS preco_unitario, COUNT(*) AS n
+    FROM sku_leadtime_history slh
+    WHERE slh.quantidade_recebida > 0 AND slh.valor_total > 0
+    GROUP BY slh.empresa, slh.sku_codigo_omie
+  ),
+  skus_necessitando AS (
+    SELECT sp.empresa, sp.sku_codigo_omie::text AS sku_codigo_omie, sp.sku_descricao, sp.fornecedor_nome,
+           sg.grupo_codigo, sp.ponto_pedido, sp.estoque_maximo,
+           COALESCE(sea.estoque_fisico, 0) AS estoque_fisico,
+           COALESCE(sea.estoque_pendente_entrada, 0) AS estoque_pendente,
+           COALESCE(et.qtde, 0) AS qtde_em_transito_recente,
+           (COALESCE(sea.estoque_fisico, 0) + COALESCE(sea.estoque_pendente_entrada, 0) + COALESCE(et.qtde, 0)) AS estoque_efetivo,
+           -- [QTDE-INTEIRA] arredonda pra cima: o estoque vem do Omie com poeira decimal → max − estoque
+           -- seria fracionário (3,99996). Arredondar pra cima preserva o sinal >0, então o filtro de
+           -- necessidade abaixo fica idêntico (inclusão inalterada; só o valor muda).
+           ceil(sp.estoque_maximo - (COALESCE(sea.estoque_fisico, 0) + COALESCE(sea.estoque_pendente_entrada, 0) + COALESCE(et.qtde, 0))) AS qtde_sugerida,
+           -- [MIN-FORCADO 1/3] qtde_final = piso(natural, mínimo forçado). Espelha o helper puro
+           -- aplicarMinimoForcado: CASE WHEN min>0 THEN GREATEST(natural, min) ELSE natural END.
+           -- Sem piso-0 fantasma (ELSE devolve o natural intocado). A guarda "só item que precisa
+           -- repor" é o filtro qtde_sugerida > 0 abaixo (sobre o NATURAL), inalterado.
+           -- [QTDE-INTEIRA] ceil envolve o piso E o natural: nenhuma quantidade fracionária (do
+           -- estoque com poeira decimal OU de um mínimo forçado fracionário) chega ao pedido.
+           CASE WHEN sp.minimo_forcado_manual IS NOT NULL AND sp.minimo_forcado_manual > 0
+                THEN ceil(GREATEST(
+                       (sp.estoque_maximo - (COALESCE(sea.estoque_fisico, 0) + COALESCE(sea.estoque_pendente_entrada, 0) + COALESCE(et.qtde, 0))),
+                       sp.minimo_forcado_manual))
+                ELSE ceil(sp.estoque_maximo - (COALESCE(sea.estoque_fisico, 0) + COALESCE(sea.estoque_pendente_entrada, 0) + COALESCE(et.qtde, 0)))
+           END AS qtde_final,
+           -- [A2-CMC-PEDIDO] cmc-PRIMEIRO (>0), senão média, senão 0. Espelha a view (preco_item_eoq):
+           -- cmc=0/negativo/null não vira preço 0 (CASE devolve NULL → COALESCE cai pra média).
+           -- [A2-CMC-ACCOUNT] cmc das 2 convenções de account (espelha a view precos_cmc): pra OBEN
+           -- olha 'vendas' E 'oben' (o feed canônico grava 'vendas'); cmc>0 mais fresco; senão média; senão 0.
+           COALESCE(
+             ( SELECT ipc.cmc FROM inventory_position ipc
+               WHERE ipc.omie_codigo_produto::text = sp.sku_codigo_omie::text
+                 AND ipc.account = ANY (CASE lower(p_empresa)
+                       WHEN 'oben' THEN ARRAY['vendas'::text,'oben'::text]
+                       WHEN 'colacor' THEN ARRAY['colacor_vendas'::text,'colacor'::text]
+                       WHEN 'colacor_sc' THEN ARRAY['servicos'::text,'colacor_sc'::text]
+                       ELSE ARRAY[lower(p_empresa)] END)
+                 AND ipc.cmc > 0
+               ORDER BY ipc.synced_at DESC NULLS LAST
+               LIMIT 1 ),
+             pm.preco_unitario, 0) AS preco_unitario,
+           (pm.n IS NULL) AS primeira_compra,
+           fh.horario_corte_pedido, fh.valor_maximo_mensal, fh.delta_max_perc
+    FROM sku_parametros sp
+    LEFT JOIN sku_grupo_producao sg ON sg.empresa = sp.empresa AND sg.sku_codigo_omie = sp.sku_codigo_omie::text
+    LEFT JOIN sku_estoque_atual sea ON sea.empresa = sp.empresa AND sea.sku_codigo_omie = sp.sku_codigo_omie::text
+    LEFT JOIN fornecedor_habilitado_reposicao fh ON fh.empresa = sp.empresa AND fh.fornecedor_nome = sp.fornecedor_nome
+    LEFT JOIN omie_products op ON op.omie_codigo_produto::text = sp.sku_codigo_omie::text AND op.account = lower(p_empresa)
+    LEFT JOIN familia_nao_comprada fnc ON fnc.empresa = sp.empresa AND fnc.familia = op.familia
+    LEFT JOIN em_transito et ON et.empresa = sp.empresa AND et.sku_codigo_omie = sp.sku_codigo_omie::text
+    LEFT JOIN preco_medio pm ON pm.empresa = sp.empresa AND pm.sku_codigo_omie = sp.sku_codigo_omie::text
+    LEFT JOIN inventory_position ip ON ip.omie_codigo_produto::text = sp.sku_codigo_omie::text AND ip.account = lower(p_empresa)
+    LEFT JOIN sku_status_omie sso ON sso.empresa = sp.empresa AND sso.sku_codigo_omie = sp.sku_codigo_omie::text
+    WHERE sp.empresa = p_empresa
+      AND sp.habilitado_reposicao_automatica = TRUE
+      AND COALESCE(sp.tipo_reposicao, 'automatica') = 'automatica'
+      AND sp.fornecedor_nome IS NOT NULL
+      AND btrim(sp.fornecedor_nome) <> ''
+      AND fnc.id IS NULL
+      AND COALESCE(op.ativo, true) = true
+      AND COALESCE(sso.ativo_no_omie, true) = true
+      AND COALESCE(op.descricao, '') NOT ILIKE '%450ML'
+      AND COALESCE(op.descricao, '') NOT ILIKE '%405ML'
+      AND COALESCE((
+            SELECT COALESCE(op04.tipo_produto, op04.metadata->>'tipo_produto')
+            FROM omie_products op04
+            WHERE op04.omie_codigo_produto::text = sp.sku_codigo_omie::text
+              AND op04.account = lower(p_empresa)
+            LIMIT 1
+          ), '') <> '04'
+      AND sp.ponto_pedido IS NOT NULL
+      AND sp.estoque_maximo IS NOT NULL
+      AND (COALESCE(sea.estoque_fisico, 0) + COALESCE(sea.estoque_pendente_entrada, 0) + COALESCE(et.qtde, 0)) <= sp.ponto_pedido
+  ),
+  pedidos_por_fornecedor_grupo AS (
+    INSERT INTO pedido_compra_sugerido (
+      empresa, fornecedor_nome, grupo_codigo, data_ciclo, horario_corte_planejado,
+      valor_total, num_skus, status, condicao_pagamento_codigo, condicao_pagamento_descricao,
+      num_parcelas, dias_parcelas, condicao_origem
+    )
+    SELECT sn.empresa, sn.fornecedor_nome, sn.grupo_codigo, p_data_ciclo,
+           (p_data_ciclo + MAX(sn.horario_corte_pedido))::timestamptz,
+           SUM(sn.qtde_final * sn.preco_unitario), COUNT(*),
+           'pendente_aprovacao', '000', 'À Vista', 1, NULL, 'default_a_vista'
+    FROM skus_necessitando sn
+    WHERE sn.qtde_sugerida > 0
+    GROUP BY sn.empresa, sn.fornecedor_nome, sn.grupo_codigo
+    RETURNING id, fornecedor_nome, grupo_codigo
+  )
+  INSERT INTO pedido_compra_item (
+    pedido_id, sku_codigo_omie, sku_descricao, estoque_atual, ponto_pedido, estoque_maximo,
+    qtde_sugerida, qtde_final, preco_unitario, valor_linha, primeira_compra
+  )
+  SELECT pfg.id, sn.sku_codigo_omie, sn.sku_descricao, sn.estoque_efetivo, sn.ponto_pedido, sn.estoque_maximo,
+         sn.qtde_sugerida, sn.qtde_final, sn.preco_unitario, sn.qtde_final * sn.preco_unitario, sn.primeira_compra
+  FROM skus_necessitando sn
+  JOIN pedidos_por_fornecedor_grupo pfg
+    ON pfg.fornecedor_nome = sn.fornecedor_nome AND COALESCE(pfg.grupo_codigo,'') = COALESCE(sn.grupo_codigo,'')
+  WHERE sn.qtde_sugerida > 0;
+
+  SELECT COUNT(*), COALESCE(SUM(num_skus),0), COALESCE(SUM(valor_total),0)
+  INTO v_pedidos, v_skus, v_valor
+  FROM pedido_compra_sugerido
+  WHERE empresa = p_empresa AND data_ciclo = p_data_ciclo AND status = 'pendente_aprovacao';
+
+  RETURN QUERY SELECT v_pedidos, v_skus, v_valor, v_bloqueados;
+END;
+$function$;


### PR DESCRIPTION
Codex challenge retroativo achou **[P1]**: a view busca cmc nas 2 convenções de account (`vendas|oben`→OBEN etc.), o motor só em `account=lower(empresa)` ('oben'). SKU com cmc só na canônica 'vendas' → pedido caía pra média enquanto a tela mostrava cmc.

**Fix:** o cmc do `preco_unitario` vem de um subquery espelhando a CTE `precos_cmc` da view (account = ANY por empresa, cmc>0, freshest, LIMIT 1). `motor.cmc == view.cmc` por construção.

**PG17** (`db/test-preco-pedido-cmc-account.sh`, 7 asserts): SKU com cmc só na 'vendas' → motor pega 700 (não média 300); sem regressão. ⚠️ Challenge do PR2a pendente (codex bateu limite; ~17:59) — mas é a própria recomendação dele + PG17 + auto-review.

⚠️ **Migration manual** (CREATE OR REPLACE FUNCTION). Sem edge, sem Publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)