### PR TITLE
fix(reposição): persistir qtde inteira no banco antes do portal/Omie (hotfix #663)

### DIFF
--- a/db/test-qtde-inteira-persist.sh
+++ b/db/test-qtde-inteira-persist.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# Teste PG17 — reposicao_persistir_qtde_inteira + backfill (migration 20260606190000).
+# Prova:
+#  - Backfill ceila itens fracionários de pedidos NÃO-disparados + recalcula valor_linha/valor_total.
+#  - NÃO toca pedidos disparado/concluído/cancelado (escopo do backfill).
+#  - PRESERVA valor_linha em linha JÁ inteira (= total capturado do portal não é clobberado).
+#  - ceil (não round): 10,6 → 11.
+#  - Função idempotente (2ª chamada retorna 0 ajustes).
+#  - Conjunto/relacionamento intacto; validação da migração (frac_restantes_nao_disparados=0).
+# Base: db/verify-snapshot-replay.sh + db/test-rpc-account-aware.sh. Pré-req: brew install postgresql@17 pgvector.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PGVER=17
+PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+PORT=5437
+DATA="$(mktemp -d /tmp/pgtest-qtdepersist.XXXXXX)/data"
+export LC_ALL=C LANG=C
+
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente: brew install postgresql@${PGVER} pgvector"; exit 1; }
+
+CELLAR="$(brew --prefix postgresql@${PGVER})"
+cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
+mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
+cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
+
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+trap cleanup EXIT
+
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l /tmp/pg-qtdepersist.log -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres qtdepersist_verify
+P() { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d qtdepersist_verify "$@"; }
+
+RR="$(mktemp /tmp/snap-qtdepersist.XXXXXX.sql)"
+sed -E 's/^(CREATE SCHEMA public;)/-- \1/' "$REPO_ROOT/supabase/schema-snapshot.sql" \
+  | grep -vE '^\\(un)?restrict ' > "$RR"
+
+echo "→ stubs + prelude + snapshot…"
+P -v ON_ERROR_STOP=1 -q -f "$REPO_ROOT/db/stubs-supabase.sql"
+P -v ON_ERROR_STOP=1 -q -f "$REPO_ROOT/supabase/schema-extensions-prelude.sql"
+P --single-transaction -v ON_ERROR_STOP=1 -q -f "$RR"
+rm -f "$RR"
+# service_role precisa existir p/ o GRANT da migração não falhar no replay isolado.
+P -v ON_ERROR_STOP=1 -q -c "DO \$\$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname='service_role') THEN CREATE ROLE service_role; END IF; END \$\$;"
+
+echo "→ seed: pedidos com itens fracionários em vários status (ANTES da migração)…"
+P -v ON_ERROR_STOP=1 -q <<'SQL'
+-- P1 NÃO-disparado (pendente): 2 itens fracionários → backfill ceila
+INSERT INTO public.pedido_compra_sugerido (id, empresa, fornecedor_nome, status, valor_total)
+  VALUES (90001,'OBEN','FORN-A','pendente_aprovacao', 0);
+INSERT INTO public.pedido_compra_item (pedido_id, sku_codigo_omie, qtde_sugerida, qtde_final, preco_unitario, valor_linha) VALUES
+  (90001,'8001', 9.99996, 9.99996, 10, 99.9996),  -- → 10, valor 100
+  (90001,'8002', 10.4,    10.4,    20, 208.0);     -- → 11 (ceil; round daria 10), valor 220
+UPDATE public.pedido_compra_sugerido SET valor_total = 307.9996 WHERE id=90001; -- soma crua (será recomputada)
+
+-- P2 DISPARADO: fracionário + valor_linha "capturado" do portal (≠ qty×preco) → backfill NÃO toca
+INSERT INTO public.pedido_compra_sugerido (id, empresa, fornecedor_nome, status, valor_total)
+  VALUES (90002,'OBEN','FORN-B','disparado', 999);
+INSERT INTO public.pedido_compra_item (pedido_id, sku_codigo_omie, qtde_sugerida, qtde_final, preco_unitario, valor_linha) VALUES
+  (90002,'8003', 5.5, 5.5, 30, 999);  -- intocado (status fora do escopo)
+
+-- P3 NÃO-disparado (aprovado_aguardando_disparo): item JÁ INTEIRO com valor_linha capturado 777
+--    (≠ 5×preco) → função pula (qty já inteira) → 777 PRESERVADO; valor_total NÃO recomputado
+INSERT INTO public.pedido_compra_sugerido (id, empresa, fornecedor_nome, status, valor_total)
+  VALUES (90003,'OBEN','FORN-C','aprovado_aguardando_disparo', 777);
+INSERT INTO public.pedido_compra_item (pedido_id, sku_codigo_omie, qtde_sugerida, qtde_final, preco_unitario, valor_linha) VALUES
+  (90003,'8004', 5, 5, 100, 777);  -- captured total preservado
+
+-- P4 CANCELADO: fracionário → terminal, intocado
+INSERT INTO public.pedido_compra_sugerido (id, empresa, fornecedor_nome, status, valor_total)
+  VALUES (90004,'OBEN','FORN-D','cancelado', 50);
+INSERT INTO public.pedido_compra_item (pedido_id, sku_codigo_omie, qtde_sugerida, qtde_final, preco_unitario, valor_linha) VALUES
+  (90004,'8005', 2.3, 2.3, 25, 57.5);
+SQL
+
+echo "→ aplica a migração 20260606190000 (cria função + roda backfill)…"
+P -v ON_ERROR_STOP=1 -f "$REPO_ROOT/supabase/migrations/20260606190000_reposicao_qtde_inteira_persist.sql"
+
+echo ""
+echo "→ ASSERTS:"
+P -v ON_ERROR_STOP=1 -q <<'SQL'
+DO $$
+DECLARE n int;
+BEGIN
+  -- A. P1 (não-disparado): itens ceilados + valor_linha = ceil(qty)×preco
+  PERFORM 1 FROM pedido_compra_item WHERE pedido_id=90001 AND sku_codigo_omie='8001'
+    AND qtde_final=10 AND qtde_sugerida=10 AND valor_linha=100;
+  IF NOT FOUND THEN RAISE EXCEPTION 'A FALHOU: 8001 não virou 10 / valor 100'; END IF;
+  PERFORM 1 FROM pedido_compra_item WHERE pedido_id=90001 AND sku_codigo_omie='8002'
+    AND qtde_final=11 AND valor_linha=220;  -- ceil(10,4)=11 (round daria 10) → prova ceil, não round
+  IF NOT FOUND THEN RAISE EXCEPTION 'A FALHOU: 8002 não virou 11 (ceil de 10,4) / valor 220'; END IF;
+  RAISE NOTICE 'OK A — P1 itens ceilados + valor_linha recalculado';
+
+  -- A2. P1 valor_total recomputado = soma (100 + 220 = 320)
+  PERFORM 1 FROM pedido_compra_sugerido WHERE id=90001 AND valor_total=320;
+  IF NOT FOUND THEN RAISE EXCEPTION 'A2 FALHOU: P1 valor_total != 320 (= %)', (SELECT valor_total FROM pedido_compra_sugerido WHERE id=90001); END IF;
+  RAISE NOTICE 'OK A2 — P1 valor_total recomputado = Σ valor_linha (320)';
+
+  -- B. P2 (disparado): INTOCADO (qty 5,5; valor_linha capturado 999; valor_total 999)
+  PERFORM 1 FROM pedido_compra_item WHERE pedido_id=90002 AND qtde_final=5.5 AND valor_linha=999;
+  IF NOT FOUND THEN RAISE EXCEPTION 'B FALHOU: P2 disparado foi alterado (devia ficar 5,5 / 999)'; END IF;
+  PERFORM 1 FROM pedido_compra_sugerido WHERE id=90002 AND valor_total=999;
+  IF NOT FOUND THEN RAISE EXCEPTION 'B FALHOU: P2 valor_total mudou'; END IF;
+  RAISE NOTICE 'OK B — P2 (disparado) intocado pelo backfill (escopo correto)';
+
+  -- C. P3 (não-disparado, item JÁ inteiro): valor_linha capturado 777 PRESERVADO; qty 5; total 777
+  PERFORM 1 FROM pedido_compra_item WHERE pedido_id=90003 AND qtde_final=5 AND valor_linha=777;
+  IF NOT FOUND THEN RAISE EXCEPTION 'C FALHOU: P3 valor_linha capturado (777) foi clobberado! (= %)', (SELECT valor_linha FROM pedido_compra_item WHERE pedido_id=90003); END IF;
+  PERFORM 1 FROM pedido_compra_sugerido WHERE id=90003 AND valor_total=777;
+  IF NOT FOUND THEN RAISE EXCEPTION 'C FALHOU: P3 valor_total mudou (item inteiro não devia recomputar)'; END IF;
+  RAISE NOTICE 'OK C — P3 item já inteiro: valor_linha capturado (777) PRESERVADO (não clobbera o total do portal)';
+
+  -- D. P4 (cancelado): INTOCADO
+  PERFORM 1 FROM pedido_compra_item WHERE pedido_id=90004 AND qtde_final=2.3;
+  IF NOT FOUND THEN RAISE EXCEPTION 'D FALHOU: P4 cancelado foi alterado'; END IF;
+  RAISE NOTICE 'OK D — P4 (cancelado) intocado';
+
+  -- E. IDEMPOTÊNCIA: 2ª chamada em P1 retorna 0 ajustes
+  SELECT public.reposicao_persistir_qtde_inteira(90001) INTO n;
+  IF n <> 0 THEN RAISE EXCEPTION 'E FALHOU: 2ª chamada ajustou % (esperado 0 — não idempotente)', n; END IF;
+  RAISE NOTICE 'OK E — função idempotente (2ª passada = 0 ajustes)';
+
+  -- F. Função em pedido só-inteiro retorna 0 e não recomputa (P3 já provou preservação)
+  SELECT public.reposicao_persistir_qtde_inteira(90003) INTO n;
+  IF n <> 0 THEN RAISE EXCEPTION 'F FALHOU: P3 (já inteiro) ajustou % (esperado 0)', n; END IF;
+  RAISE NOTICE 'OK F — pedido já inteiro → 0 ajustes (não toca valor_linha capturado)';
+
+  RAISE NOTICE '──────── TODOS OS ASSERTS SQL OK ────────';
+END $$;
+
+-- G. validação embutida da migração (re-rodada): 0 fracionários nos não-disparados
+SELECT 'frac_nao_disparados' AS check,
+  (SELECT count(*) FROM pedido_compra_item pci JOIN pedido_compra_sugerido pcs ON pcs.id=pci.pedido_id
+    WHERE pcs.status IN ('pendente_aprovacao','bloqueado_guardrail','aprovado_aguardando_disparo','falha_envio')
+      AND (pci.qtde_final IS DISTINCT FROM ceil(pci.qtde_final) OR pci.qtde_sugerida IS DISTINCT FROM ceil(pci.qtde_sugerida))) AS n;
+SQL
+
+echo ""
+echo "✓ db/test-qtde-inteira-persist.sh — PASSOU"

--- a/supabase/functions/disparar-pedidos-aprovados/index.ts
+++ b/supabase/functions/disparar-pedidos-aprovados/index.ts
@@ -569,8 +569,13 @@ async function processarPedido(
       );
     }
     // nQtde <= 0 quebra o Omie com "O preenchimento da tag [nQtde] é obrigatório".
+    // [QTDE-INTEIRA P3] Number.isFinite rejeita Infinity/NaN também — senão Infinity passa
+    // o `> 0` e vira null no JSON.stringify do payload (Codex).
     const itensSemQtde = (items as ItemRow[]).filter(
-      (it) => !(Number(it.qtde_final) > 0),
+      (it) => {
+        const q = Number(it.qtde_final);
+        return !(Number.isFinite(q) && q > 0);
+      },
     );
     if (itensSemQtde.length > 0) {
       const lista = itensSemQtde
@@ -579,6 +584,18 @@ async function processarPedido(
       throw new Error(
         `SKU(s) com quantidade 0: ${lista}. Ajuste a quantidade ou remova o item antes de disparar.`,
       );
+    }
+
+    // a.2 [QTDE-INTEIRA] Persiste a quantidade INTEIRA (ceil) no banco ANTES do portal/Omie.
+    // É a fonte da verdade: o portal Sayerlack deriva o custo de qtde_final, e em_transito/
+    // valor_total/embalagem leem qtde_final. Persistir aqui cobre QUALQUER origem de fração
+    // (RPC, promoção, edição humana, legado) num único ponto, no momento do dinheiro.
+    // Idempotente (ceil de inteiro = no-op). Só em produção (dry_run não muta).
+    if (modo === "producao") {
+      const { error: ceilErr } = await db.rpc("reposicao_persistir_qtde_inteira", {
+        p_pedido_id: pedido.id,
+      });
+      if (ceilErr) throw new Error(`Persistir qtde inteira: ${ceilErr.message}`);
     }
 
     // b. Resolver código do fornecedor

--- a/supabase/migrations/20260606190000_reposicao_qtde_inteira_persist.sql
+++ b/supabase/migrations/20260606190000_reposicao_qtde_inteira_persist.sql
@@ -1,0 +1,86 @@
+-- Quantidade inteira PERSISTIDA no banco — função + backfill (hotfix do #663)
+-- ============================================================================
+-- POR QUÊ (revisão adversária Codex no #663): o ceil só na RPC + nos consumidores
+-- (disparo Omie, front) era CAÇA AOS RATOS e deixou furos money-path:
+--   • Portal Sayerlack: pede ceil ao fornecedor (enviar-pedido-portal-sayerlack:1774)
+--     mas DERIVA o custo dividindo o total capturado pela qtde_final CRUA (:1376) →
+--     preço unitário inflado → total do Omie diverge do portal (ex.: q=10,6 → +3,77%).
+--   • em_transito (RPC :73), valor_total, embalagem (useEmbalagemPedido:135) leem qtde_final CRU.
+--   • Promoção (aplicar_promocoes_no_ciclo) faz qtde_final = qtde_com_desconto → pode
+--     reintroduzir fração DEPOIS da RPC, sem passar por nenhum ceil.
+-- A fonte da verdade é o qtde_final NO BANCO. Tem que ser inteiro lá — aí TODOS os
+-- consumidores (portal, Omie, em_transito, valor, embalagem) leem inteiro de graça.
+--
+-- ESTA MIGRAÇÃO:
+--  1. Função reposicao_persistir_qtde_inteira(pedido_id): ceila qtde_sugerida/qtde_final
+--     (só linhas fracionárias — preserva valor_linha capturado do portal em linhas já
+--     inteiras) + recalcula valor_linha = ceil(qtde)×preco + valor_total do pedido.
+--     O disparo (disparar-pedidos-aprovados) chama ANTES do portal/Omie → source-agnostic
+--     (cobre RPC, promo, edição, legado). Idempotente (ceil de inteiro = no-op → 0 linhas).
+--  2. Backfill one-time: aplica a função nos pedidos NÃO-disparados (a qtde ainda não foi
+--     ao fornecedor; valor_linha é custo, não total capturado). Conserta os pendentes de hoje.
+--     EXCLUI disparado/concluído (já foram ao fornecedor; rewrite desincronizaria do Omie e
+--     CLOBBERIA o valor_linha capturado do portal) e cancelado/expirado (terminais).
+--
+-- NÃO toca a RPC (ceil já está nela via #663) nem a promo (território de outra sessão;
+-- a persistência no disparo cobre a fração da promo sem reescrever a função).
+-- Validado em PG17: db/test-qtde-inteira-persist.sh.
+--
+-- ⚠️ Migração manual (SQL Editor). Backfill roda 1×; a função fica p/ o disparo chamar.
+-- Requer deploy do edge disparar-pedidos-aprovados (que passa a chamar a função) — ver PR.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.reposicao_persistir_qtde_inteira(p_pedido_id bigint)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_ajustados integer;
+BEGIN
+  -- Ceila só as linhas REALMENTE fracionárias. Em linha já inteira, NÃO toca valor_linha —
+  -- isso preserva o valor_linha = total capturado que o portal grava (preço cheio).
+  UPDATE pedido_compra_item
+    SET qtde_sugerida = ceil(qtde_sugerida),
+        qtde_final    = ceil(qtde_final),
+        valor_linha   = ceil(qtde_final) * preco_unitario
+  WHERE pedido_id = p_pedido_id
+    AND (qtde_final    IS DISTINCT FROM ceil(qtde_final)
+      OR qtde_sugerida IS DISTINCT FROM ceil(qtde_sugerida));
+  GET DIAGNOSTICS v_ajustados = ROW_COUNT;
+
+  -- Só recomputa o total do pedido se algo mudou (idempotente; não reescreve à toa).
+  IF v_ajustados > 0 THEN
+    UPDATE pedido_compra_sugerido
+      SET valor_total = (
+        SELECT COALESCE(sum(valor_linha), 0)
+        FROM pedido_compra_item WHERE pedido_id = p_pedido_id
+      )
+    WHERE id = p_pedido_id;
+  END IF;
+
+  RETURN v_ajustados;
+END;
+$function$;
+
+-- Trava: só o service_role (edge de disparo) executa. Não é dado sensível, mas é money-path.
+REVOKE EXECUTE ON FUNCTION public.reposicao_persistir_qtde_inteira(bigint) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.reposicao_persistir_qtde_inteira(bigint) TO service_role;
+
+-- ─── Backfill one-time: pedidos NÃO-disparados ───
+SELECT public.reposicao_persistir_qtde_inteira(id)
+FROM public.pedido_compra_sugerido
+WHERE status IN ('pendente_aprovacao','bloqueado_guardrail','aprovado_aguardando_disparo','falha_envio');
+
+-- ─── Validação ───
+SELECT 'MIGRATION qtde_inteira_persist OK' AS status,
+  (SELECT count(*) FROM pg_proc WHERE proname = 'reposicao_persistir_qtde_inteira') AS func,
+  -- 0 = nenhum item fracionário restante nos pedidos NÃO-disparados
+  (SELECT count(*)
+     FROM public.pedido_compra_item pci
+     JOIN public.pedido_compra_sugerido pcs ON pcs.id = pci.pedido_id
+    WHERE pcs.status IN ('pendente_aprovacao','bloqueado_guardrail','aprovado_aguardando_disparo','falha_envio')
+      AND (pci.qtde_final    IS DISTINCT FROM ceil(pci.qtde_final)
+        OR pci.qtde_sugerida IS DISTINCT FROM ceil(pci.qtde_sugerida))
+  ) AS frac_restantes_nao_disparados;


### PR DESCRIPTION
## Contexto — hotfix do [#663](https://github.com/LucasSardenbergL/afiacao/pull/663)

A revisão adversária do **Codex** no #663 (rodada depois do merge, a pedido do founder) achou que o `ceil` só na RPC + nos consumidores (disparo Omie, front) era **caça aos ratos** e deixou furos money-path. Confirmados no código:

- **P1 (real):** o portal Sayerlack pede `ceil` ao fornecedor ([`enviar-pedido-portal-sayerlack:1774`](supabase/functions/enviar-pedido-portal-sayerlack/index.ts:1774)) mas **deriva o custo dividindo o total capturado pela `qtde_final` CRUA** ([:1376](supabase/functions/enviar-pedido-portal-sayerlack/index.ts:1376)) → preço unitário inflado → **total do Omie diverge do portal** (ex.: q=10,6 → +3,77%). E `em_transito`, `valor_total` e embalagem ([`useEmbalagemPedido:135`](src/components/reposicao/pedidos/useEmbalagemPedido.ts:135)) leem `qtde_final` cru.
- **P1c:** a promoção (`aplicar_promocoes_no_ciclo`) faz `qtde_final = qtde_com_desconto` → pode reintroduzir fração **depois** da RPC.
- **P3:** `Infinity` passa o guard `nQtde>0` e vira `null` no payload.

## A correção — persistir o inteiro no banco (fonte da verdade)

O `qtde_final` **no banco** é o que todos os consumidores leem. Tem que ser inteiro lá.

| Mudança | O quê |
|---|---|
| Função `reposicao_persistir_qtde_inteira(pedido_id)` | ceila `qtde_sugerida`/`qtde_final` **só de linhas fracionárias** (preserva `valor_linha` capturado do portal em linhas já inteiras) + recalcula `valor_linha` + `valor_total`. `SECURITY DEFINER`, `service_role`-only. Idempotente. |
| Disparo (`disparar-pedidos-aprovados`) | chama a função **antes do portal/Omie** → source-agnostic (cobre RPC, **promoção**, edição humana, legado) no momento do dinheiro. |
| Backfill one-time | aplica a função nos pedidos **NÃO-disparados** (`pendente_aprovacao`/`bloqueado_guardrail`/`aprovado_aguardando_disparo`/`falha_envio`). Conserta os pendentes de hoje. Exclui disparado/concluído (já foram ao fornecedor; rewrite desincronizaria do Omie e clobberia o `valor_linha` capturado) e cancelado/expirado. |
| P3 | guard do disparo endurecido com `Number.isFinite`. |

**Não toca** a RPC (o `ceil` do #663 fica) nem a promo (a persistência no disparo cobre a fração dela sem reescrever a função — território de outra sessão).

## ⚠️ ATENÇÃO: migration manual + deploy de edge

1. **SQL Editor**: aplicar `supabase/migrations/20260606190000_reposicao_qtde_inteira_persist.sql` (cria a função + roda o backfill 1×). Esperado: `func=1`, `frac_restantes_nao_disparados=0`.
2. **Deploy do edge** `disparar-pedidos-aprovados` (chat do Lovable, da `main` após o merge): passa a chamar a função + guard `Number.isFinite`.

## Validação (PG17 — `db/test-qtde-inteira-persist.sh`)

- Backfill ceila não-disparados + recomputa `valor_total`; ceil≠round (10,4 → 11).
- **P2 (disparado) e P4 (cancelado) intocados** (escopo correto).
- **P3: `valor_linha` capturado do portal (777) PRESERVADO** em linha já inteira (não clobbera o total real).
- Função **idempotente** (2ª passada = 0 ajustes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
