### PR TITLE
fix(pedido): aviso de seleção só p/ falha que afeta o preço (silencia 'cliente Afiação' em pedido Oben)

### DIFF
--- a/docs/superpowers/specs/2026-06-06-cockpit-vendas-jornada-comercial-BRIEF.md
+++ b/docs/superpowers/specs/2026-06-06-cockpit-vendas-jornada-comercial-BRIEF.md
@@ -1,0 +1,26 @@
+# BRIEF — Cockpit de Vendas / Jornada Comercial do Vendedor (sessão futura de brainstorming)
+
+**Status:** VISÃO capturada (2026-06-06) — **NÃO implementar agora**; é tema de uma sessão dedicada com `brainstorming`. Pré-requisito entregue: preço-cliente já é o **último preço praticado** (local, rápido, estável — Fase 1, PR #682).
+
+## A visão do founder (verbatim do intent)
+Redesenhar **todo o caminho comercial** pra facilitar a vida do vendedor. Hoje o vendedor faz o pedido por **duas origens**:
+1. **Liga pro cliente** e faz o pedido.
+2. Vem pelo **WhatsApp** e faz o pedido.
+
+> "Tudo que precisamos é **definir as origens dos pedidos** pra entregar o máximo de informação. Misturar isso com a **transcrição da IA em tempo real**, com **upsell, cross-sell**, com **aumento de preço** (aumentou o preço da tabela → o cliente está com preço defasado → ele tem que repassar o aumento). Precisamos redefinir todo esse caminho comercial."
+
+## Eixos a explorar no brainstorming
+1. **Origem do pedido (telemetria/contexto):** marcar cada pedido com a origem (ligação / WhatsApp / balcão) → personalizar a tela e medir conversão por canal. Conecta com o motor de rota/ligação (`/rota/ligacoes`) e o inbox WhatsApp já existentes.
+2. **Transcrição IA em tempo real:** durante a ligação (WebRTC/Nvoip já existe — §5), transcrever e sugerir ao vivo (itens mencionados, objeções, oportunidades). Já há base: `tarefa-extrair-voz`, `@elevenlabs/react`.
+3. **Cockpit na linha do preço** (minha sugestão, deferida): Δ vs tabela (desconto/margem na cara), recência ("há Xd"), última quantidade, trava de margem (anti-subprecificação), sinal de recompra/win-back.
+4. **Repasse de aumento de preço (o ponto forte do founder):** quando a TABELA subiu desde a última compra do cliente, sinalizar "preço defasado — repassar aumento" + de quanto, e dar ao vendedor o argumento/cálculo. Money-path direto (recupera margem).
+5. **Upsell / cross-sell:** já há engines (`useCrossSellEngine`, `FarmerBundles`) — integrar na jornada do pedido conforme a origem + o que o cliente comprou.
+
+## Dados/infra que já temos (pontos de partida)
+- `sales_price_history` (último preço praticado, com data) · `sales_orders.items` (qtd/histórico) · `order_date_kpi`.
+- Tabela do produto (`omie_products.valor_unitario`) pra o Δ vs tabela.
+- Motor de rota/ligação + inbox WhatsApp + WebRTC/Nvoip + cross-sell/bundles engines.
+- ⚠️ Origem do pedido **ainda não é registrada** — provável 1ª fundação (coluna/telemetria).
+
+## Não-objetivos desta nota
+Não é um plano nem implementação — é o brief pra abrir a sessão de brainstorming. Quando for, começar pelo `brainstorming` (superpowers) pra desenhar a jornada antes de qualquer código.

--- a/src/hooks/unifiedOrder/useCustomerSelection.ts
+++ b/src/hooks/unifiedOrder/useCustomerSelection.ts
@@ -458,10 +458,16 @@ export function useCustomerSelection({
         codigo_vendedor?: number | null;
       }>(4);
 
-      if (failedParts.length > 0) {
-        // É um aviso (carga parcial), não um sucesso — não usar o ✓ verde de success.
-        toast.warning('Alguns dados do cliente não foram carregados', {
-          description: `Falharam: ${failedParts.join(', ')}. Você pode continuar, mas preços/parcelas podem não refletir o contrato.`,
+      // Aviso SÓ pra falha que afeta o preço na tela agora. As falhas dos lookups de
+      // CÓDIGO por-conta ('cliente Colacor'/'cliente Afiação') NÃO alarmam na seleção:
+      //  • o preço-cliente vem do histórico LOCAL (não dessas chamadas);
+      //  • o submit fail-closed (Etapa 2a) bloqueia com mensagem PRECISA se você fechar
+      //    pedido NAQUELA conta sem a identidade resolvida (é onde o aviso é acionável).
+      // 'última parcela ...' também não alarma — a sugestão de prazo cai no padrão, e o
+      // vendedor confirma o prazo no fluxo do pedido. (Todas as falhas seguem logadas.)
+      if (failedParts.includes('histórico de preço local')) {
+        toast.warning('Histórico de preço não carregou', {
+          description: 'Usando o preço de tabela. Re-selecione o cliente para tentar de novo.',
         });
       }
 


### PR DESCRIPTION
## Problema
A toast da seleção de cliente — *"Alguns dados não foram carregados — Falharam: cliente Afiação. ...preços/parcelas podem não refletir o contrato"* — **exagerava o impacto** e assustava num pedido Oben. Depois da Fase 1 (#682), o **preço vem do histórico LOCAL**, não dessas chamadas Omie; e a falha do lookup de **código por-conta** (Colacor/Afiação) só importa se o pedido for **naquela conta**, onde o **submit fail-closed (Etapa 2a)** já bloqueia com mensagem **precisa e acionável**.

## Fix
A toast da seleção agora **só dispara se o histórico de preço LOCAL** (a fonte do preço-cliente) não carregar — caso raro e relevante (o preço cai pra tabela). Silenciadas (mas **seguem logadas**):
- `cliente Colacor` / `cliente Afiação` (código por-conta) → o guard real é o submit fail-closed (2a), acionável só quando você fecha pedido naquela conta.
- `última parcela ...` → a sugestão de prazo cai no padrão; o vendedor confirma no fluxo.

Resultado: **sem o aviso assustador da Afiação em pedido Oben**; o aviso aparece onde é acionável (envio).

## + Brief da visão futura
Capturei a visão do **cockpit de vendas / jornada comercial** (origens do pedido ligação×WhatsApp, transcrição IA em tempo real, upsell/cross-sell, **repasse de aumento de preço**) em `docs/superpowers/specs/2026-06-06-cockpit-vendas-jornada-comercial-BRIEF.md` — pra uma sessão dedicada de brainstorming.

## Verificação
`typecheck` ✓ · `lint` 0 ✓ · `build` ✓ · `test` 2722/2722 ✓.

## Deploy
Frontend — **Publish no Lovable** após o merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
