### PR TITLE
feat(meu-dia): KPIs de nível mundial da farmer + remove visitas do dashboard

### DIFF
--- a/docs/superpowers/specs/2026-06-06-kpis-farmer-meu-dia-design.md
+++ b/docs/superpowers/specs/2026-06-06-kpis-farmer-meu-dia-design.md
@@ -1,0 +1,59 @@
+# KPIs de nível mundial da farmer — Meu Dia (design)
+
+**Data:** 2026-06-06
+**Autor:** Claude (decisão solo; ⚠️ Codex fora por usage limit do Plus — **validação adversária retroativa pendente**, padrão do CLAUDE.md "Caminho B")
+**Status:** aprovado pelo founder pra implementar ("decido você e o Codex... pode ir implementando sem me perguntar")
+
+## Contexto / problema
+
+A lente "Ver como pessoa" expôs que o dashboard "Meu Dia" da **farmer** (account manager de carteira, tipo a Tatyana) mostra cards de **visita** — que não é o trabalho dela (visita é do "closer"). Investigando, achei que:
+
+- **Já existe dashboard por persona** (`CommercialDashboard` roteia por `useMyCommercialRole`, lente-aware): farmer→`FarmerDashboardV2`, hunter→`HunterDashboard`, closer→`CloserDashboard`, master→`MasterDashboard`.
+- Mas os dashboards foram montados **ad-hoc**: o card "Visitas de hoje" (`VisitasHojeCard`) vaza pra farmer/hunter/closer, e a **positivação** (KPI central da farmer) **não está em nenhum dashboard** — só na tela de Ligações (`/farmer/calls`, via `PositivacaoHero`).
+- Não há um modelo de "que KPI cada papel vê".
+
+Esta entrega corrige a **farmer** (1ª persona; hunter/closer/master vêm depois, frente "começar pela farmer e expandir"). Decisão do founder: os KPIs devem ser **base de remuneração variável (OTE) futura** — logo, mensuráveis, auditáveis e por-farmer.
+
+## KPIs de nível mundial da farmer (account management B2B)
+
+Framework: **retenção · penetração · expansão · atividade**. Classificação pensando no OTE (comissionável = output à prova de gaming; higiene = atividade medida mas não paga direto).
+
+| KPI | Mede | Tipo | OTE | Dado |
+|---|---|---|---|---|
+| **Positivação MTD %** ⭐ NORTE | % da carteira elegível que comprou no mês (penetração/active accounts) | output | **comissionável** | `compradores_mtd / total_eligible` ✅ |
+| **Receita da carteira MTD** | faturamento do mês da carteira | output | **comissionável** | `receita_mtd` ✅ |
+| **Win-back** | clientes recuperados (1ª compra/retorno no mês) | output | **comissionável** | `novos_clientes_positivados` ✅ |
+| **Cobertura MTD %** | % da carteira contatada (ligação/WhatsApp) | leading | higiene | `contatados_mtd / total_eligible` ✅ |
+| **Ligações hoje** | pulso de atividade do dia | leading | higiene | `calls_today` (useMyKpis) ✅ |
+| **Clientes a positivar** | quem ainda não comprou (a ação) | acionável | — | `a_positivar[]` ✅ |
+| **Recência crítica** | clientes em risco de churn | acionável | — | `recencia_critica` ✅ |
+| **Mix-gap** | cross-sell (famílias que faltam) | acionável | — | `useMyMixGap` ✅ |
+| **Ticket médio MTD** | valor médio por comprador | output (apoio) | — | `receita_mtd / compradores_mtd` ✅ |
+
+**Anti-gaming:** positivação em **%** (carteira inchada não infla o número absoluto); atividade (cobertura/ligações) é **higiene**, não comissão direta (senão incentiva ligar/contatar sem vender). Win-back e recência balanceiam (não abandonar cliente difícil pra inflar positivação dos fáceis).
+
+**Pro OTE (criar na sessão dedicada futura, NÃO neste escopo):**
+- **Meta de receita por farmer** (não existe) → Receita MTD vira "atingimento %" (o input clássico de OTE).
+- **Margem MTD por carteira** (hoje só há margem do *dia* em `useMyKpis`) → comissão por margem evita premiar desconto.
+- **Retenção de receita (NRR-like)**: receita da carteira vs período anterior (mesma carteira) — métrica de nível mundial, derivável de séries, fica pra v2.
+
+## Mudança no `FarmerDashboardV2` (Meu Dia da farmer)
+
+1. **Trazer a positivação pro topo** — renderizar o `PositivacaoHero` (já existe, já lente-aware via `useMyPositivacao`) no Meu Dia, logo após o header, como o placar do mês.
+2. **Expor 2 KPIs novos no `PositivacaoHero` (farmer):** **Receita MTD** e **Win-back** (output comissionáveis). Requer expor `receitaMtd` no `useMyPositivacao` (o dado já vem, só não é mapeado).
+3. **Remover** o `VisitasHojeCard` do `FarmerDashboardV2` (não é trabalho de farmer).
+4. **Manter** Fila (ação do dia), `KpisToday` (atividade de hoje), `SlaCardMeuDia` (WhatsApp) e o "modo antigo".
+
+`PositivacaoHero` é compartilhado com `/farmer/calls` → a melhoria do placar (receita+win-back) aparece nos dois (consistência desejada). O bloco do hero em `FarmerCalls` continua funcionando (mesmo componente).
+
+## Não-objetivos (v1)
+- OTE/remuneração variável em si (sessão dedicada — o founder vai abrir).
+- Hunter/Closer/Master (próximas levas da frente "expandir").
+- Criar meta de receita / margem MTD por carteira (dependência do OTE).
+- Mexer no roteamento de dashboard (já funciona e é lente-aware).
+
+## Verificação
+- `useMyPositivacao` expõe `receitaMtd` (= `receita_mtd`).
+- `FarmerDashboardV2` não renderiza `VisitasHojeCard` e renderiza o bloco de positivação.
+- Lente: o Meu Dia da farmer reflete a carteira do ALVO (positivação já é lente-aware).
+- typecheck + lint + suite.

--- a/src/components/dashboard/FarmerDashboardV2.tsx
+++ b/src/components/dashboard/FarmerDashboardV2.tsx
@@ -8,18 +8,25 @@ import { track } from '@/lib/analytics';
 import { KpisToday } from './KpisToday';
 import { AgendaTodayList } from './AgendaTodayList';
 import { MinhasTarefasCard } from '@/components/tarefas/MinhasTarefasCard';
-import { VisitasHojeCard } from './VisitasHojeCard';
 import { SlaCardMeuDia } from '@/components/whatsapp/SlaCardMeuDia';
 import { FilaDoDia } from '@/components/fila/FilaDoDia';
+import { PositivacaoHero } from '@/components/farmer/PositivacaoHero';
+import { useMyPositivacao } from '@/hooks/useMyPositivacao';
 
 /**
- * Dashboard Farmer V2 — a FILA é o dia (G1). Os cards antigos (tarefas, ligações
- * da rota, agenda) repetem o que a fila já mostra → recolhidos num "modo antigo"
- * (fallback a 1 clique). Mantém fora do colapso só o que a fila NÃO cobre:
- * KPIs (informativo) e visitas. Decisão founder + Codex (piloto).
+ * Dashboard Farmer V2 — placar do mês (positivação) + a FILA é o dia (G1).
+ *
+ * O bloco de positivação (PositivacaoHero) é o NORTE da farmer: positivação MTD,
+ * receita MTD, win-back, cobertura — KPIs comerciais que também serão base do OTE
+ * (ver docs/superpowers/specs/2026-06-06-kpis-farmer-meu-dia-design.md). A fila é
+ * a ação do dia. Os cards antigos (tarefas, ligações da rota, agenda) repetem a
+ * fila → recolhidos num "modo antigo" (1 clique). VISITAS foram removidas: não são
+ * o trabalho da farmer (isso é o CloserDashboard). isHunter=false: hunter tem o
+ * próprio dashboard (HunterDashboard), não chega aqui pelo CommercialDashboard.
  */
 export function FarmerDashboardV2() {
   const [modoAntigoAberto, setModoAntigoAberto] = useState(false);
+  const { data: positivacao } = useMyPositivacao();
   const onToggleModoAntigo = (open: boolean) => {
     setModoAntigoAberto(open);
     // sinal do piloto: se ela abre o modo antigo todo dia, a fila não está servindo.
@@ -31,19 +38,21 @@ export function FarmerDashboardV2() {
       <div>
         <h1 className="text-xl font-semibold">Meu dia</h1>
         <p className="text-xs text-muted-foreground">
-          Sua fila priorizada: comece de cima. Tarefas, ligações da rota e oportunidades, do mais urgente ao menos.
+          Seu placar do mês e a fila priorizada: olhe a positivação, depois trabalhe a fila de cima pra baixo.
         </p>
       </div>
+
+      {/* Placar do mês (KPIs da carteira) — o norte da farmer */}
+      {positivacao && <PositivacaoHero kpis={positivacao} isHunter={false} />}
 
       {/* A fila É o dia. */}
       <FilaDoDia />
 
+      {/* Atividade de hoje */}
       <KpisToday />
 
       {/* nudge saliente: clientes sem resposta no WhatsApp — fica FORA do "modo antigo" recolhido */}
       <SlaCardMeuDia />
-
-      <VisitasHojeCard />
 
       <Collapsible open={modoAntigoAberto} onOpenChange={onToggleModoAntigo}>
         <CollapsibleTrigger asChild>

--- a/src/components/farmer/PositivacaoHero.tsx
+++ b/src/components/farmer/PositivacaoHero.tsx
@@ -28,6 +28,7 @@ export function PositivacaoHero({ kpis, isHunter }: { kpis: PositivacaoKpis; isH
   }, [kpis, isHunter]);
 
   const ticket = `R$ ${kpis.ticketMedio.toLocaleString('pt-BR', { maximumFractionDigits: 0 })}`;
+  const receita = `R$ ${kpis.receitaMtd.toLocaleString('pt-BR', { maximumFractionDigits: 0 })}`;
   return (
     <div className="space-y-3">
       {/* Hero (3 KPIs principais por papel) */}
@@ -41,20 +42,25 @@ export function PositivacaoHero({ kpis, isHunter }: { kpis: PositivacaoKpis; isH
         ) : (
           <>
             <KpiCard label="Positivação MTD" value={`${kpis.pctPositivacao}%`} sub={`${kpis.positivados}/${kpis.totalEligible} da carteira`} />
+            <KpiCard label="Receita MTD" value={receita} sub="faturamento da carteira no mês" />
             <KpiCard label="Clientes a positivar" value={String(kpis.aPositivar.length)} sub="sem pedido no mês" />
-            <KpiCard label="Cobertura de contato" value={`${kpis.pctCobertura}%`} sub="contatados no mês" />
           </>
         )}
       </div>
       {/* Linha secundária (KPIs de apoio) */}
-      <div className="grid grid-cols-2 gap-3">
-        <KpiCard label="Ticket médio MTD" value={ticket} sub="receita ÷ compradores no mês" />
-        {isHunter ? (
+      {isHunter ? (
+        <div className="grid grid-cols-2 gap-3">
+          <KpiCard label="Ticket médio MTD" value={ticket} sub="receita ÷ compradores no mês" />
           <KpiCard label="Cobertura de contato" value={`${kpis.pctCobertura}%`} sub="contatados no mês" />
-        ) : (
+        </div>
+      ) : (
+        <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
+          <KpiCard label="Cobertura de contato" value={`${kpis.pctCobertura}%`} sub="contatados no mês" />
+          <KpiCard label="Recuperados (win-back)" value={String(kpis.novosPositivados)} sub="voltaram a comprar no mês" />
           <KpiCard label="Recência crítica" value={String(kpis.recenciaCritica)} sub="risco alto / atrasados" />
-        )}
-      </div>
+          <KpiCard label="Ticket médio MTD" value={ticket} sub="receita ÷ compradores no mês" />
+        </div>
+      )}
     </div>
   );
 }

--- a/src/hooks/useMyPositivacao.ts
+++ b/src/hooks/useMyPositivacao.ts
@@ -12,6 +12,7 @@ export interface PositivacaoKpis {
   positivados: number;
   pctPositivacao: number;
   ticketMedio: number;
+  receitaMtd: number;
   pctCobertura: number;
   recenciaCritica: number;
   novosPositivados: number;
@@ -48,6 +49,7 @@ export function useMyPositivacao() {
         positivados: r.positivados,
         pctPositivacao: pctPositivacao(r.positivados, r.total_eligible),
         ticketMedio: ticketMedio(r.receita_mtd, r.compradores_mtd),
+        receitaMtd: r.receita_mtd,
         pctCobertura: pctCobertura(r.contatados_mtd, r.total_eligible),
         recenciaCritica: r.recencia_critica,
         novosPositivados: r.novos_clientes_positivados,


### PR DESCRIPTION
## Contexto
A lente "Ver como pessoa" expôs que o **Meu Dia da farmer** mostrava o card **"Visitas de hoje"** (trabalho do *closer*, não da farmer) e **não** mostrava **positivação** (o KPI central da farmer — só existia em `/farmer/calls`). Investigando, há dashboards por persona (`CommercialDashboard` roteia por cargo, lente-aware), mas montados ad-hoc: visita vazava pra quase todos e positivação não estava em nenhum.

Esta entrega repensa os KPIs da **farmer** (1ª persona; hunter/closer/master vêm depois). Decisão **eu + Codex** — ⚠️ **Codex em usage limit do Plus (volta 17:59) → validação adversária retroativa pendente** ("Caminho B" do CLAUDE.md).

## KPIs de nível mundial da farmer (account management B2B)
Classificados pensando na **remuneração variável (OTE) futura**:

| KPI | Tipo | OTE |
|---|---|---|
| **Positivação MTD %** ⭐ NORTE | output | **comissionável** |
| **Receita da carteira MTD** | output | **comissionável** |
| **Win-back** (recuperados) | output | **comissionável** |
| Cobertura MTD % · Ligações hoje | leading | higiene (não pagar direto) |
| Clientes a positivar · Recência crítica · Mix-gap | acionável | guia a fila |

**Anti-gaming:** positivação em **%** (carteira inchada não infla); atividade é higiene (não premiar volume vazio). **Pro OTE (sessão futura, fora deste escopo):** criar **meta de receita por farmer** e **margem MTD por carteira** (hoje só há margem do dia).

## Mudança (100% frontend, reusa componentes lente-aware)
- **`useMyPositivacao`**: expõe `receitaMtd` (o dado já vinha da RPC `get_minha_positivacao`, só não era mapeado).
- **`PositivacaoHero`** (farmer): + **Receita MTD** (hero) + **Recuperados/win-back** (apoio). Hunter intacto. Componente compartilhado → melhora também `/farmer/calls`.
- **`FarmerDashboardV2`**: lidera com o **placar de positivação** + **remove `VisitasHojeCard`**; mantém Fila + atividade de hoje + WhatsApp.

Como o dashboard é escolhido por `useMyCommercialRole` (lente-aware) e a positivação por `useMyPositivacao` (lente-aware), na lente o Meu Dia reflete a carteira do **alvo**.

## Verificação
- ✅ Typecheck strict, lint, suite completa (2722 testes).
- Não há lógica nova no money-path (reorganização + 1 campo exposto) → sem teste unitário novo; typecheck cobre o campo, revisão cobre o layout.

## Deploy
**100% frontend** — sem migration/edge. ⚠️ Requer **Publish no Lovable**.

Spec: `docs/superpowers/specs/2026-06-06-kpis-farmer-meu-dia-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)