### PR TITLE
feat(pedido): Fase 2 backend — action consolidada (1 ListarPedidos/conta) + helper de merge por data

### DIFF
--- a/src/lib/omie/__tests__/ultimo-preco.test.ts
+++ b/src/lib/omie/__tests__/ultimo-preco.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import { parseDataFlexivel, mergeUltimoPreco } from '../ultimo-preco';
+
+describe('parseDataFlexivel', () => {
+  it('DD/MM/YYYY (Omie dInc) → ms comparável', () => {
+    expect(parseDataFlexivel('28/05/2026')).toBe(Date.UTC(2026, 4, 28));
+  });
+  it('YYYY-MM-DD (order_date_kpi local) → ms', () => {
+    expect(parseDataFlexivel('2026-05-28')).toBe(Date.UTC(2026, 4, 28));
+  });
+  it('ISO completo (com hora) → ms do dia', () => {
+    expect(parseDataFlexivel('2026-05-28T13:00:00Z')).toBe(Date.UTC(2026, 4, 28));
+  });
+  it('formatos comparáveis: DD/MM/YYYY == YYYY-MM-DD do mesmo dia', () => {
+    expect(parseDataFlexivel('28/05/2026')).toBe(parseDataFlexivel('2026-05-28'));
+  });
+  it('vazio/null/lixo → null', () => {
+    expect(parseDataFlexivel('')).toBeNull();
+    expect(parseDataFlexivel(null)).toBeNull();
+    expect(parseDataFlexivel('xx/yy/zzzz')).toBeNull();
+    expect(parseDataFlexivel('2026-13-40')).toBeNull(); // mês/dia inválidos
+  });
+});
+
+describe('mergeUltimoPreco (precedência por data; empate → Omie)', () => {
+  it('Omie mais recente → ganha o Omie', () => {
+    const r = mergeUltimoPreco(
+      { 100: { price: 540, date: '2026-05-01' } },
+      { 100: { price: 605, date: '2026-05-28' } },
+    );
+    expect(r[100]).toEqual({ price: 605, fonte: 'omie' });
+  });
+
+  it('local mais recente → ganha o local (pedido novo ainda não no Omie)', () => {
+    const r = mergeUltimoPreco(
+      { 100: { price: 700, date: '2026-06-02' } },
+      { 100: { price: 605, date: '2026-05-28' } },
+    );
+    expect(r[100]).toEqual({ price: 700, fonte: 'local' });
+  });
+
+  it('empate de data → Omie (confirmado no ERP ganha)', () => {
+    const r = mergeUltimoPreco(
+      { 100: { price: 540, date: '2026-05-28' } },
+      { 100: { price: 605, date: '28/05/2026' } },
+    );
+    expect(r[100]).toEqual({ price: 605, fonte: 'omie' });
+  });
+
+  it('só local → usa local', () => {
+    const r = mergeUltimoPreco({ 100: { price: 540, date: '2026-05-01' } }, {});
+    expect(r[100]).toEqual({ price: 540, fonte: 'local' });
+  });
+
+  it('só Omie → usa Omie', () => {
+    const r = mergeUltimoPreco({}, { 100: { price: 605, date: '28/05/2026' } });
+    expect(r[100]).toEqual({ price: 605, fonte: 'omie' });
+  });
+
+  it('datas ambas nulas/ilegíveis → Omie ganha (desempate determinístico)', () => {
+    const r = mergeUltimoPreco(
+      { 100: { price: 540, date: null } },
+      { 100: { price: 605, date: '' } },
+    );
+    expect(r[100]).toEqual({ price: 605, fonte: 'omie' });
+  });
+
+  it('data do vencedor nula mas do outro válida → ganha o que TEM data', () => {
+    const r = mergeUltimoPreco(
+      { 100: { price: 540, date: '2026-05-28' } },
+      { 100: { price: 605, date: null } },
+    );
+    expect(r[100]).toEqual({ price: 540, fonte: 'local' });
+  });
+
+  it('preço <= 0 é ignorado (cai pro outro lado se válido; senão omitido)', () => {
+    const r = mergeUltimoPreco(
+      { 100: { price: 0, date: '2026-06-10' }, 200: { price: 0, date: '2026-06-10' } },
+      { 100: { price: 605, date: '2026-05-28' }, 300: { price: 90, date: '2026-05-28' } },
+    );
+    expect(r[100]).toEqual({ price: 605, fonte: 'omie' }); // local 0 ignorado, usa Omie
+    expect(r[200]).toBeUndefined();                         // ambos inválidos → fora
+    expect(r[300]).toEqual({ price: 90, fonte: 'omie' });
+  });
+});

--- a/src/lib/omie/ultimo-preco.ts
+++ b/src/lib/omie/ultimo-preco.ts
@@ -1,0 +1,82 @@
+// Fase 2 — resolução do "último preço praticado" combinando LOCAL × OMIE por DATA.
+//
+// Fonte LOCAL (rápida/estável, mas pode defasar se a última compra foi fora do app):
+//   `sales_orders.items[].valor_unitario` datado por `order_date_kpi`.
+// Fonte OMIE (completa/fresca, mas lenta — vem da chamada consolidada da Fase 2):
+//   último `ListarPedidos` datado por `infoCadastro.dInc` (data de INCLUSÃO real,
+//   NÃO `data_previsao`).
+//
+// Regra (Codex): por (cliente × conta × produto), o de MAIOR data ganha; empate ou
+// data ilegível → OMIE (confirmado no ERP). Determinístico → não pula. O resultado
+// deve ser CONGELADO no snapshot do pedido (a UI não muda preço sozinha depois).
+//
+// Puro/testável; será consumido pelo frontend (não há espelho em edge — o edge só
+// devolve os dados; o merge local×omie acontece no cliente, que tem as duas fontes).
+
+/** Parseia DD/MM/YYYY (Omie) ou YYYY-MM-DD[THH:..] (local) → ms UTC do dia, ou null. */
+export function parseDataFlexivel(s: string | null | undefined): number | null {
+  if (!s || typeof s !== 'string') return null;
+  const str = s.trim();
+  let y: number, mo: number, d: number;
+  const br = str.match(/^(\d{2})\/(\d{2})\/(\d{4})$/);
+  if (br) {
+    d = Number(br[1]); mo = Number(br[2]); y = Number(br[3]);
+  } else {
+    const iso = str.match(/^(\d{4})-(\d{2})-(\d{2})/);
+    if (!iso) return null;
+    y = Number(iso[1]); mo = Number(iso[2]); d = Number(iso[3]);
+  }
+  if (mo < 1 || mo > 12 || d < 1 || d > 31) return null;
+  const ms = Date.UTC(y, mo - 1, d);
+  // Guarda contra rollover (ex.: 31 num mês de 30 dias → JS empurra pro mês seguinte).
+  const chk = new Date(ms);
+  if (chk.getUTCFullYear() !== y || chk.getUTCMonth() !== mo - 1 || chk.getUTCDate() !== d) return null;
+  return ms;
+}
+
+export interface PrecoPonto {
+  price: number;
+  /** ISO (`order_date_kpi`) no local; DD/MM/YYYY (`dInc`) no Omie. */
+  date: string | null;
+}
+export type FontePreco = 'local' | 'omie';
+export interface PrecoResolvido {
+  price: number;
+  fonte: FontePreco;
+}
+
+/**
+ * Combina os mapas de último preço LOCAL e OMIE (por omie_codigo_produto), escolhendo
+ * por DATA o mais recente. Empate ou data ilegível → Omie. Preço <= 0 é inválido
+ * (cai pro outro lado se válido; senão o produto fica de fora → preço de tabela).
+ * Local só vence se ESTRITAMENTE mais recente (empate é do Omie, por construção).
+ */
+export function mergeUltimoPreco(
+  local: Record<number, PrecoPonto>,
+  omie: Record<number, PrecoPonto>,
+): Record<number, PrecoResolvido> {
+  const out: Record<number, PrecoResolvido> = {};
+  const codes = new Set<number>(
+    [...Object.keys(local), ...Object.keys(omie)].map(Number).filter((n) => Number.isFinite(n)),
+  );
+  for (const code of codes) {
+    const l = local[code];
+    const o = omie[code];
+    const lValid = !!l && typeof l.price === 'number' && l.price > 0;
+    const oValid = !!o && typeof o.price === 'number' && o.price > 0;
+    if (!lValid && !oValid) continue;
+    if (lValid && !oValid) { out[code] = { price: l.price, fonte: 'local' }; continue; }
+    if (!lValid && oValid) { out[code] = { price: o.price, fonte: 'omie' }; continue; }
+
+    const lMs = parseDataFlexivel(l.date);
+    const oMs = parseDataFlexivel(o.date);
+    let fonte: FontePreco;
+    if (lMs != null && oMs == null) fonte = 'local';      // só o local tem data
+    else if (lMs != null && oMs != null && lMs > oMs) fonte = 'local'; // local estritamente mais novo
+    else fonte = 'omie';                                  // empate / só Omie tem data / ambas nulas → Omie
+    out[code] = fonte === 'local'
+      ? { price: l.price, fonte: 'local' }
+      : { price: o.price, fonte: 'omie' };
+  }
+  return out;
+}

--- a/supabase/functions/omie-vendas-sync/index.ts
+++ b/supabase/functions/omie-vendas-sync/index.ts
@@ -754,6 +754,92 @@ async function buscarUltimaParcela(codigoCliente: number, account: Account = "ob
   }
 }
 
+// Fase 2: CONTEXTO COMERCIAL do cliente numa ÚNICA passada de ListarPedidos.
+// Substitui buscar_precos_cliente + buscar_ultima_parcela + buscar_cliente (colacor) +
+// historico_produtos_cliente, que disparavam VÁRIAS ListarPedidos concorrentes na mesma
+// conta → rate-limit do Omie ("Já existe uma requisição desse método") → retries 5-15s×3
+// → ~40s. Aqui: 1 ListarPedidos/conta (ordenar_por DATA_INCLUSAO) devolve preço + dInc
+// por produto + parcela + ranking. Para colacor (sem código conhecido), resolve o código
+// por documento ANTES (ListarClientes → ListarPedidos, SERIAL → métodos diferentes, sem
+// colisão). dInc (inclusão) é a data de precedência — NÃO data_previsao.
+async function buscarContextoComercialCliente(
+  opts: { codigoCliente?: number | null; document?: string | null },
+  account: Account = "oben",
+) {
+  let codigoCliente = opts.codigoCliente ?? null;
+  let codigoVendedor: number | null = null;
+
+  if (!codigoCliente && opts.document) {
+    const cli = await buscarClienteVendas(opts.document, account);
+    if (cli?.codigo_cliente) {
+      codigoCliente = cli.codigo_cliente;
+      codigoVendedor = cli.codigo_vendedor ?? null;
+    }
+  }
+
+  const empty = {
+    codigo_cliente: codigoCliente,
+    codigo_vendedor: codigoVendedor,
+    precos: {} as Record<number, number>,
+    datas: {} as Record<number, string>,
+    ultima_parcela: null as string | null,
+    parcela_ranking: [] as Array<{ codigo: string; count: number }>,
+  };
+  if (!codigoCliente) return empty;
+
+  const result = await callOmieVendasApi(
+    "produtos/pedido/",
+    "ListarPedidos",
+    {
+      pagina: 1,
+      registros_por_pagina: 50,
+      filtrar_por_cliente: codigoCliente,
+      filtrar_apenas_inclusao: "N",
+      ordenar_por: "DATA_INCLUSAO",
+    },
+    account,
+  );
+
+  const pedidos: OmiePedidoVendaProduto[] =
+    (result?.pedido_venda_produto as OmiePedidoVendaProduto[] | undefined) || [];
+
+  const precos: Record<number, number> = {};
+  const datas: Record<number, string> = {};
+  const parcelaCount: Record<string, number> = {};
+  let ultimaParcela: string | null = null;
+
+  // Pedidos vêm do mais recente ao mais antigo (DATA_INCLUSAO) → o 1º por produto é o último.
+  for (const pedido of pedidos) {
+    const dataInc = pedido.infoCadastro?.dInc || pedido.cabecalho?.data_previsao || "";
+    const parcela = pedido.cabecalho?.codigo_parcela;
+    if (parcela) {
+      if (!ultimaParcela) ultimaParcela = parcela;
+      parcelaCount[parcela] = (parcelaCount[parcela] || 0) + 1;
+    }
+    for (const item of pedido.det || []) {
+      const cod = item.produto?.codigo_produto;
+      const val = item.produto?.valor_unitario;
+      if (cod && val && val > 0 && precos[cod] === undefined) {
+        precos[cod] = val;
+        datas[cod] = dataInc;
+      }
+    }
+  }
+
+  const parcela_ranking = Object.entries(parcelaCount)
+    .sort((a, b) => b[1] - a[1])
+    .map(([codigo, count]) => ({ codigo, count }));
+
+  return {
+    codigo_cliente: codigoCliente,
+    codigo_vendedor: codigoVendedor,
+    precos,
+    datas,
+    ultima_parcela: ultimaParcela,
+    parcela_ranking,
+  };
+}
+
 // Sincronizar pedidos de venda do Omie para o banco local (OPTIMIZED)
 async function syncPedidos(
   supabase: SupabaseClient,
@@ -1590,6 +1676,19 @@ serve(async (req) => {
         if (!codCli) throw new Error("Código do cliente é obrigatório");
         const parcelaData = await buscarUltimaParcela(codCli, account);
         result = { success: true, ...parcelaData };
+        break;
+      }
+
+      // Fase 2: 1 chamada consolidada (preço+dInc por produto + parcela + ranking +
+      // código resolvido p/ colacor). Substitui as ListarPedidos concorrentes que
+      // colidiam no rate-limit (~40s). codigo_cliente p/ oben; document p/ colacor.
+      case "buscar_contexto_comercial_cliente": {
+        const { codigo_cliente: ctxCod, document: ctxDoc } = params;
+        const ctx = await buscarContextoComercialCliente(
+          { codigoCliente: ctxCod ?? null, document: ctxDoc ?? null },
+          account,
+        );
+        result = { success: true, ...ctx };
         break;
       }
 


### PR DESCRIPTION
## Fase 2 — backend (deploy-first, per Codex)

Mata a causa-raiz do 40s na origem: em vez de **várias `ListarPedidos` concorrentes na mesma conta** (preço + parcela + histórico×5), **1 chamada consolidada por conta**.

### `buscar_contexto_comercial_cliente` (omie-vendas-sync)
1 `ListarPedidos` (`ordenar_por DATA_INCLUSAO`) → numa passada: **preço + `dInc` (data de inclusão) por produto + última parcela + ranking + (colacor) código resolvido por documento**. Substitui `buscar_precos_cliente` + `buscar_ultima_parcela` + `buscar_cliente` (colacor) + `historico_produtos_cliente`.
- **Colacor:** resolve o código por documento ANTES (ListarClientes → ListarPedidos, **serial** = métodos diferentes, sem colisão). Oben: só ListarPedidos.
- **`dInc`** é a data de precedência (não `data_previsao` — bug do código antigo).
- **Aditiva:** não toca nas actions antigas (rollback = não usar).

### Helper de merge (já testado, p/ a PR do frontend)
`src/lib/omie/ultimo-preco.ts` (13 testes): `mergeUltimoPreco` (local×Omie por data, mais recente ganha; empate→Omie) + `parseDataFlexivel` (DD/MM/YYYY × ISO).

## ⚠️ Gates antes de ir ao ar
1. **Codex challenge** no edge (cota ~17:59) — edge money-path, não-testável aqui.
2. **Deploy do edge** via chat do Lovable (verbatim da main) — ANTES do frontend.
3. **PR do frontend (B):** consome a action + deriva o local de `sales_orders` (`order_date_kpi`) + faz o merge via o helper + cache por cliente + account-aware → aí o preço fica fresco/completo.

## Verificação possível agora
`typecheck` (app) ✓ · `lint` (inclui `supabase/functions/`) 0 ✓ · `test` 2749/2749 ✓ · `build` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
