### PR TITLE
fix(pedidos): scroll que resetava pro topo na busca + auto-load travado

### DIFF
--- a/src/components/salesOrders/useSalesOrders.ts
+++ b/src/components/salesOrders/useSalesOrders.ts
@@ -2,7 +2,7 @@
 // Extraída verbatim de src/pages/SalesOrders.tsx (god-component split).
 import { useState, useEffect, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useInfiniteQuery, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useInfiniteQuery, useQuery, useQueryClient, keepPreviousData } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
 import { toast } from 'sonner';
@@ -110,10 +110,18 @@ export function useSalesOrders() {
 
   /* ─── Profiles (nome + documento dos clientes) ─── */
   const customerIds = useMemo(() => [...new Set(orders.map((o) => o.customer_user_id))], [orders]);
+  // Chave estável SEM mutar customerIds (que é usado no .in()). O .sort() in-place
+  // direto na queryKey mutava o valor memoizado.
+  const customerIdsKey = useMemo(() => [...customerIds].sort().join(','), [customerIds]);
   const profilesQuery = useQuery({
-    queryKey: ['sales-orders-profiles', customerIds.sort().join(',')],
+    queryKey: ['sales-orders-profiles', customerIdsKey],
     enabled: isStaff && customerIds.length > 0,
     staleTime: 60_000,
+    // Ao paginar, os customerIds crescem → a queryKey muda → a query re-busca.
+    // keepPreviousData mantém os nomes já carregados durante a nova busca, em vez
+    // de esvaziar (os nomes "piscavam Cliente", a lista filtrada colapsava e o
+    // scroll resetava pro topo). Causa-raiz do reset com busca ativa.
+    placeholderData: keepPreviousData,
     queryFn: async () => {
       const { data } = await supabase
         .from('profiles')

--- a/src/hooks/__tests__/useInfiniteScroll.test.ts
+++ b/src/hooks/__tests__/useInfiniteScroll.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useInfiniteScroll } from '../useInfiniteScroll';
+
+// Mock de IntersectionObserver (jsdom não implementa) — captura instâncias e
+// deixa simular interseção / inspecionar observe/disconnect.
+class MockIO {
+  static instances: MockIO[] = [];
+  cb: IntersectionObserverCallback;
+  observed: Element[] = [];
+  disconnected = false;
+  constructor(cb: IntersectionObserverCallback) {
+    this.cb = cb;
+    MockIO.instances.push(this);
+  }
+  observe(el: Element) { this.observed.push(el); }
+  disconnect() { this.disconnected = true; }
+  unobserve() {}
+  takeRecords() { return []; }
+  // simula o sentinel entrando/saindo da viewport
+  trigger(isIntersecting: boolean) {
+    this.cb([{ isIntersecting } as IntersectionObserverEntry], this as unknown as IntersectionObserver);
+  }
+  // o último observer ainda "vivo" (não desconectado) que observa algo
+  static live() { return MockIO.instances.filter((i) => !i.disconnected && i.observed.length); }
+}
+
+beforeEach(() => {
+  MockIO.instances = [];
+  (globalThis as unknown as { IntersectionObserver: unknown }).IntersectionObserver = MockIO;
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('useInfiniteScroll', () => {
+  it('dispara onLoadMore quando o sentinel intersecta', () => {
+    const onLoadMore = vi.fn();
+    const { result } = renderHook(() => useInfiniteScroll(onLoadMore, true));
+    const node = document.createElement('div');
+    act(() => result.current(node));
+    const io = MockIO.live().at(-1)!;
+    expect(io.observed[0]).toBe(node);
+    act(() => io.trigger(true));
+    expect(onLoadMore).toHaveBeenCalledTimes(1);
+  });
+
+  it('NÃO dispara quando o sentinel sai da viewport', () => {
+    const onLoadMore = vi.fn();
+    const { result } = renderHook(() => useInfiniteScroll(onLoadMore, true));
+    act(() => result.current(document.createElement('div')));
+    act(() => MockIO.live().at(-1)!.trigger(false));
+    expect(onLoadMore).not.toHaveBeenCalled();
+  });
+
+  it('não cria observer quando enabled=false', () => {
+    const onLoadMore = vi.fn();
+    const { result } = renderHook(() => useInfiniteScroll(onLoadMore, false));
+    act(() => result.current(document.createElement('div')));
+    expect(MockIO.live().length).toBe(0);
+  });
+
+  // Bug do auto-load "parar": quando o sentinel é re-montado (novo nó), o
+  // observer precisa re-vincular ao nó atual — senão o gatilho automático solta.
+  it('re-observa quando o sentinel é re-montado (não solta do alvo)', () => {
+    const onLoadMore = vi.fn();
+    const { result } = renderHook(() => useInfiniteScroll(onLoadMore, true));
+    const node1 = document.createElement('div');
+    act(() => result.current(node1));
+    // sentinel re-monta: React chama a ref com null e depois com o novo nó
+    const node2 = document.createElement('div');
+    act(() => {
+      result.current(null);
+      result.current(node2);
+    });
+    const io = MockIO.live().at(-1)!;
+    expect(io.observed.at(-1)).toBe(node2);
+    act(() => io.trigger(true));
+    expect(onLoadMore).toHaveBeenCalled();
+  });
+
+  it('usa o onLoadMore mais recente sem recriar o observer a cada render', () => {
+    const cb1 = vi.fn();
+    const cb2 = vi.fn();
+    const { result, rerender } = renderHook(({ cb }) => useInfiniteScroll(cb, true), {
+      initialProps: { cb: cb1 as () => void },
+    });
+    const node = document.createElement('div');
+    act(() => result.current(node));
+    const observersAposMount = MockIO.instances.length;
+    rerender({ cb: cb2 }); // onLoadMore muda de identidade
+    // observer NÃO é recriado só porque o callback mudou
+    expect(MockIO.instances.length).toBe(observersAposMount);
+    act(() => MockIO.live().at(-1)!.trigger(true));
+    expect(cb2).toHaveBeenCalledTimes(1);
+    expect(cb1).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useInfiniteScroll.ts
+++ b/src/hooks/useInfiniteScroll.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useCallback, useRef } from 'react';
 
 /**
  * IntersectionObserver-based infinite scroll trigger.
@@ -11,28 +11,42 @@ import { useEffect, useRef } from 'react';
  *   ...
  *   <div ref={sentinelRef} />   // sentinela invisível no fim da lista
  *
- * O `rootMargin: '200px'` antecipa o load — o trigger dispara 200px ANTES da
- * sentinela entrar no viewport, fica fluido sem "barrar" o scroll.
+ * Retorna uma **callback ref**: o React a chama com o nó quando o sentinel
+ * monta/desmonta. Assim o observer sempre fica vinculado ao nó ATUAL — quando
+ * o sentinel é re-montado (ele alterna conteúdo entre spinner e "Carregar mais"
+ * conforme pagina), o gatilho não "solta" do alvo e o auto-load não trava.
+ *
+ * - `onLoadMore` vive numa ref → trocar o callback NÃO recria o observer.
+ * - o observer só é (re)criado quando `enabled` muda ou o nó troca.
+ * - `rootMargin: '200px'` antecipa o load 200px antes do sentinel aparecer.
  */
 export function useInfiniteScroll(
   onLoadMore: () => void,
   enabled: boolean,
-): React.RefObject<HTMLDivElement> {
-  const sentinelRef = useRef<HTMLDivElement>(null);
+): (node: HTMLDivElement | null) => void {
+  const cbRef = useRef(onLoadMore);
+  cbRef.current = onLoadMore;
 
-  useEffect(() => {
-    const el = sentinelRef.current;
-    if (!enabled || !el) return;
+  const observerRef = useRef<IntersectionObserver | null>(null);
 
-    const observer = new IntersectionObserver(
-      (entries) => {
-        if (entries[0]?.isIntersecting) onLoadMore();
-      },
-      { rootMargin: '200px' },
-    );
-    observer.observe(el);
-    return () => observer.disconnect();
-  }, [enabled, onLoadMore]);
+  return useCallback(
+    (node: HTMLDivElement | null) => {
+      // Desliga o observer anterior (nó desmontado, enabled mudou, ou re-mount).
+      observerRef.current?.disconnect();
+      observerRef.current = null;
 
-  return sentinelRef;
+      if (!node || !enabled) return;
+      if (typeof IntersectionObserver === 'undefined') return; // SSR / ambiente sem IO
+
+      const observer = new IntersectionObserver(
+        (entries) => {
+          if (entries[0]?.isIntersecting) cbRef.current();
+        },
+        { root: null, rootMargin: '200px', threshold: 0 },
+      );
+      observer.observe(node);
+      observerRef.current = observer;
+    },
+    [enabled],
+  );
 }


### PR DESCRIPTION
**Pronto-socorro do #3** (scroll dos pedidos) — 1º de 2 PRs. A solução definitiva
(view unificada `order_feed`) vem em PR separado; este resolve o sintoma agora,
sem migration. Diagnóstico validado **no app real** (reproduzido no browser) + 2ª
opinião externa.

## 1. Reset do scroll com busca ativa ("volta pro primeiro pedido")
Reproduzido: buscar "delta" → ao carregar a próxima página, `window.scrollY` ia
de **342 → 0**.

**Causa-raiz:** ao paginar, os `customerIds` mudam → a `queryKey` da query de
`profiles` muda → os nomes **piscam "Cliente"** por um instante → a lista filtrada
(ex.: "delta") **colapsa pra ~zero** → a altura da página encolhe → o navegador
**clampa o scroll pro topo**. O flicker "Cliente" era a pista.

**Fix:**
- `placeholderData: keepPreviousData` na query de `profiles` — mantém os nomes já
  carregados durante a re-busca, a lista não colapsa, o scroll não reseta.
- `queryKey` estável **sem mutar** `customerIds` (o `.sort()` in-place mutava o
  array memoizado que também alimenta o `.in()`).

## 2. Auto-load do scroll infinito travava
Reproduzido: a lista parava com botão "Carregar mais" e o gatilho automático não
disparava mais, mesmo rolando.

**Causa:** `useInfiniteScroll` recriava o `IntersectionObserver` a cada render
(`onLoadMore` arrow inline instável nas deps) e usava um ref object que **não
re-vinculava** quando o sentinel re-montava.

**Fix:** reescrito com **callback ref + ref estável pro callback** (deps só
`[enabled]`) → re-observa o nó atual no (re)mount; troca de callback não recria o
observer. + guard de `IntersectionObserver` indefinido (SSR) e `root`/`threshold`
explícitos. **Beneficia também a lista de Clientes** (mesmo hook).

## Arquivos
- `src/hooks/useInfiniteScroll.ts` — callback ref robusto
- `src/hooks/__tests__/useInfiniteScroll.test.ts` — **novo**, 5 testes (mock de IntersectionObserver)
- `src/components/salesOrders/useSalesOrders.ts` — keepPreviousData + IDs normalizados

## Não resolve (fica pro PR2 — view unificada)
A busca ainda enxerga só os pedidos carregados (com o auto-load consertado +
keepPreviousData, rolar/buscar carrega o resto sem resetar, mas não é instantâneo).
A solução limpa é a view `order_feed` + carregar tudo numa query — PR separado.

## Validação
- `bun run typecheck` ✅
- `bun run test` ✅ **2741/2741**
- `bun lint` ✅ 0 erros
- `bun run build` ✅
- ⚠️ Validação visual do reset depende de **Publish** (app publicado roda o build antigo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)