### PR TITLE
harden(mutcheck): compila-check + substituição-única (furo achado pelo Codex)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,3 +71,32 @@ jobs:
       # Bloqueia em errors (0 hoje); warnings não falham (eslint default).
       - name: Lint
         run: bun lint
+
+  # ─── Job NÃO-bloqueante (informativo, sinal próprio) ────────────────
+  # Gate de regressão de COBERTURA money-path (≠ os checks do `validate`, que
+  # cobrem tipos/comportamento/build/lint). Roda os contratos scripts/mutcheck.d/*.mut
+  # via scripts/mutcheck.sh — mutation-check: um teste só vale se FALHA quando a
+  # invariante é violada (plantamos o bug, medimos se a suíte o mata).
+  # ⚠️ NÃO é required na branch protection POR ORA: os .mut casam TEXTO EXATO do
+  # helper, então um refactor legítimo pode dessincronizá-los (INVÁLIDO) e travaria
+  # PRs alheias num repo multi-sessão. Promova a required (igual ao lint) quando os
+  # .mut amadurecerem. `--selftest` valida a própria ferramenta. Ver CLAUDE.md §13.
+  mutation-check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install deps
+        run: bun install --frozen-lockfile
+
+      - name: mutcheck — selftest (mecânica da ferramenta, sem vitest)
+        run: bun run mutcheck:selftest
+
+      - name: mutcheck — contratos de cobertura money-path (.mut)
+        run: bun run mutcheck

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "test": "vitest run",
     "typecheck": "tsc --noEmit -p tsconfig.app.json",
     "audit:migrations": "bun scripts/audit-custom-migrations.ts",
+    "mutcheck": "bash scripts/mutcheck-all.sh",
+    "mutcheck:selftest": "bash scripts/mutcheck.sh --selftest",
     "wt": "bash scripts/new-worktree.sh"
   },
   "dependencies": {

--- a/scripts/mutcheck-all.sh
+++ b/scripts/mutcheck-all.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+#
+# mutcheck-all — roda TODOS os contratos de cobertura money-path e agrega.
+#
+# Descobre scripts/mutcheck.d/*.mut, lê o alvo de cada um (diretivas '# @src:' e
+# '# @test:' no topo — ignoradas pelo mutcheck.sh por serem comentário) e roda
+# scripts/mutcheck.sh por contrato. Exit != 0 se QUALQUER contrato:
+#   - divergir (EXPECT != obtido → regressão de cobertura: um teste perdeu poder), ou
+#   - ficar dessincronizado (perl não casa = INVÁLIDO → o .mut está stale após um
+#     refactor do helper; atualize o .mut pro novo texto).
+#
+# Uso:  bash scripts/mutcheck-all.sh    (ou: bun run mutcheck)
+# CI:   job 'mutation-check' (não-required por ora — ver .github/workflows/ci.yml).
+#
+set -uo pipefail
+
+cd "$(git rev-parse --show-toplevel 2>/dev/null || echo .)" || { echo "mutcheck-all: não consegui ir pra raiz do repo" >&2; exit 2; }
+MUTCHECK="scripts/mutcheck.sh"
+
+shopt -s nullglob
+muts=(scripts/mutcheck.d/*.mut)
+if [[ ${#muts[@]} -eq 0 ]]; then
+  echo "mutcheck-all: nenhum contrato em scripts/mutcheck.d/ — nada a fazer."
+  exit 0
+fi
+
+failed=()
+for mut in "${muts[@]}"; do
+  src=$(sed -n 's/^#[[:space:]]*@src:[[:space:]]*//p' "$mut" | head -1)
+  tst=$(sed -n 's/^#[[:space:]]*@test:[[:space:]]*//p' "$mut" | head -1)
+  if [[ -z "$src" || -z "$tst" ]]; then
+    echo "✗ $mut — falta diretiva '# @src:' ou '# @test:'"
+    failed+=("$mut (sem alvo)"); continue
+  fi
+  echo "──────────────────────────────────────────────────────────"
+  if bash "$MUTCHECK" "$src" "$tst" "$mut"; then :; else
+    failed+=("$mut (exit $?)")
+  fi
+done
+
+echo "══════════════════════════════════════════════════════════"
+if [[ ${#failed[@]} -eq 0 ]]; then
+  echo "mutcheck-all: ✓ ${#muts[@]} contrato(s) honrado(s) — nenhuma regressão de cobertura."
+  exit 0
+fi
+echo "mutcheck-all: ✗ ${#failed[@]}/${#muts[@]} contrato(s) com problema:"
+printf '  - %s\n' "${failed[@]}"
+echo "(divergência = teste perdeu poder; INVÁLIDO = .mut stale após refactor — atualize o .mut)"
+exit 1

--- a/scripts/mutcheck.d/aging-helpers.mut
+++ b/scripts/mutcheck.d/aging-helpers.mut
@@ -1,4 +1,6 @@
 # Invariantes money-path de src/lib/financeiro/aging-helpers.ts (curvas de aging, projeção 13s de caixa).
+# @src: src/lib/financeiro/aging-helpers.ts
+# @test: src/lib/financeiro/__tests__/aging-helpers.test.ts
 # Rode: scripts/mutcheck.sh src/lib/financeiro/aging-helpers.ts src/lib/financeiro/__tests__/aging-helpers.test.ts scripts/mutcheck.d/aging-helpers.mut
 PEGA      | valorPagoEfetivo recebido >0 -> >=0   | s/t\.valor_recebido > 0/t.valor_recebido >= 0/
 PEGA      | prazoComGate cobertura >= -> >        | s/\(cobertura \?\? 0\) >= min/(cobertura ?? 0) > min/

--- a/scripts/mutcheck.d/aging-helpers.mut
+++ b/scripts/mutcheck.d/aging-helpers.mut
@@ -1,0 +1,10 @@
+# Invariantes money-path de src/lib/financeiro/aging-helpers.ts (curvas de aging, projeção 13s de caixa).
+# Rode: scripts/mutcheck.sh src/lib/financeiro/aging-helpers.ts src/lib/financeiro/__tests__/aging-helpers.test.ts scripts/mutcheck.d/aging-helpers.mut
+PEGA      | valorPagoEfetivo recebido >0 -> >=0   | s/t\.valor_recebido > 0/t.valor_recebido >= 0/
+PEGA      | prazoComGate cobertura >= -> >        | s/\(cobertura \?\? 0\) >= min/(cobertura ?? 0) > min/
+PEGA      | faixaAging <=30 -> <30                | s/diasAtraso <= 30/diasAtraso < 30/
+PEGA      | mediana ramo par/impar trocado        | s/s\.length % 2 \?/!(s.length % 2) ?/
+PEGA      | diasCobertura piso >0.01->>0 (fechado)| s/saidaDiaria > 0\.01/saidaDiaria > 0/
+PEGA      | calibrar cobertura empresa >=->> (fechado) | s/coberturaEmpresa >= coberturaMinEmpresa/coberturaEmpresa > coberturaMinEmpresa/
+SOBREVIVE | concentracao <=0.6 (borda heuristica) | s/<= 0\.6/< 0.6/
+SOBREVIVE | daysBetween round->trunc (UTC)        | s/return Math\.round\(/return Math.trunc(/

--- a/scripts/mutcheck.d/regime-tributario-helpers.mut
+++ b/scripts/mutcheck.d/regime-tributario-helpers.mut
@@ -1,4 +1,6 @@
 # Invariantes money-path de src/lib/financeiro/regime-tributario-helpers.ts (otimizador tributário Simples×Presumido×Real).
+# @src: src/lib/financeiro/regime-tributario-helpers.ts
+# @test: src/lib/financeiro/__tests__/regime-tributario-helpers.test.ts
 # Rode: scripts/mutcheck.sh src/lib/financeiro/regime-tributario-helpers.ts src/lib/financeiro/__tests__/regime-tributario-helpers.test.ts scripts/mutcheck.d/regime-tributario-helpers.mut
 PEGA      | sort: recomendaria o regime MAIS caro   | s/a\.total_federal_cpp - b\.total_federal_cpp/b.total_federal_cpp - a.total_federal_cpp/
 PEGA      | recomendar: melhor=elegiveis[1]         | s/const melhor = elegiveis\[0\]/const melhor = elegiveis[1]/

--- a/scripts/mutcheck.d/regime-tributario-helpers.mut
+++ b/scripts/mutcheck.d/regime-tributario-helpers.mut
@@ -1,0 +1,11 @@
+# Invariantes money-path de src/lib/financeiro/regime-tributario-helpers.ts (otimizador tributário Simples×Presumido×Real).
+# Rode: scripts/mutcheck.sh src/lib/financeiro/regime-tributario-helpers.ts src/lib/financeiro/__tests__/regime-tributario-helpers.test.ts scripts/mutcheck.d/regime-tributario-helpers.mut
+PEGA      | sort: recomendaria o regime MAIS caro   | s/a\.total_federal_cpp - b\.total_federal_cpp/b.total_federal_cpp - a.total_federal_cpp/
+PEGA      | recomendar: melhor=elegiveis[1]         | s/const melhor = elegiveis\[0\]/const melhor = elegiveis[1]/
+PEGA      | fatorR inverte anexo III/V (>= -> <)    | s/fr >= FATOR_R_LIMIAR/fr < FATOR_R_LIMIAR/
+PEGA      | elegib teto invertido (> -> <)          | s/rba > TETO_RBA/rba < TETO_RBA/
+PEGA      | fatorR borda 0.28 (>= -> >) [fechado]   | s/fr >= FATOR_R_LIMIAR/fr > FATOR_R_LIMIAR/
+PEGA      | elegib borda 4.8M (> -> >=) [fechado]   | s/rba > TETO_RBA/rba >= TETO_RBA/
+PEGA      | elegib borda 3.6M (> -> >=) [fechado]   | s/rba > SUBLIMITE_RBA/rba >= SUBLIMITE_RBA/
+SOBREVIVE | banda erro < -> <= (borda heuristica)   | s/< opts\.bandaErro/<= opts.bandaErro/
+SOBREVIVE | real lt <= 0 -> < 0 (lt=0 da imposto 0) | s/if \(lt <= 0\) continue/if (lt < 0) continue/

--- a/scripts/mutcheck.d/route-outcome.mut
+++ b/scripts/mutcheck.d/route-outcome.mut
@@ -1,4 +1,6 @@
 # Invariantes money-path de src/lib/route/route-outcome.ts (closed-loop da lista de ligação).
+# @src: src/lib/route/route-outcome.ts
+# @test: src/lib/route/route-outcome.test.ts
 # Rode: scripts/mutcheck.sh src/lib/route/route-outcome.ts src/lib/route/route-outcome.test.ts scripts/mutcheck.d/route-outcome.mut
 # PEGA = a suíte DEVE matar (gate de cobertura). SOBREVIVE = benigno conhecido. ? = exploratório.
 PEGA      | opt_out sticky->com janela          | s/r\.status === .opt_out./r.status === "opt_out" && diasEntreIso(hoje, r.dataNegocio) <= 7/

--- a/scripts/mutcheck.d/route-outcome.mut
+++ b/scripts/mutcheck.d/route-outcome.mut
@@ -1,0 +1,13 @@
+# Invariantes money-path de src/lib/route/route-outcome.ts (closed-loop da lista de ligação).
+# Rode: scripts/mutcheck.sh src/lib/route/route-outcome.ts src/lib/route/route-outcome.test.ts scripts/mutcheck.d/route-outcome.mut
+# PEGA = a suíte DEVE matar (gate de cobertura). SOBREVIVE = benigno conhecido. ? = exploratório.
+PEGA      | opt_out sticky->com janela          | s/r\.status === .opt_out./r.status === "opt_out" && diasEntreIso(hoje, r.dataNegocio) <= 7/
+PEGA      | jaConvertido dataRota->dataNegocio  | s/r\.dataRota === dataRotaFila/r.dataNegocio === dataRotaFila/
+PEGA      | cadencia dias->linhas               | s/new Set\(semRespNaJanela\.map\(r => r\.dataNegocio\)\)\.size/semRespNaJanela.length/
+PEGA      | limiar >= -> >                      | s/semRespostaRecenteN >= cfg\.limiarSemResposta/semRespostaRecenteN > cfg.limiarSemResposta/
+PEGA      | gate min->max                       | s/Math\.min\(\.\.\.candidatos\)/Math.max(...candidatos)/
+PEGA      | reais min->max (buraco fechado)     | s/Math\.min\(\.\.\.reaisDias\)/Math.max(...reaisDias)/
+PEGA      | ultimaSemResp min->max              | s/Math\.min\(\.\.\.semRespDias\)/Math.max(...semRespDias)/
+PEGA      | futuros reais (d>=0 removido)       | s/\.filter\(d => d >= 0\);/.filter(d => d >= -9999);/
+PEGA      | janela <= -> <                      | s/d >= 0 && d <= cfg\.janelaCadenciaDias/d >= 0 && d < cfg.janelaCadenciaDias/
+SOBREVIVE | diasEntreIso round->trunc (UTC)     | s/Math\.round\(/Math.trunc(/

--- a/scripts/mutcheck.sh
+++ b/scripts/mutcheck.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+#
+# mutcheck — mutation-check disciplinado pra UM helper puro money-path.
+#
+# Por que existe: a suíte passar não prova que ela tem PODER. Um teste só vale se
+# FALHA quando a invariante é violada. Esta ferramenta planta bugs conhecidos
+# (mutações) num helper e mede quais SOBREVIVEM (nenhum teste falha = teatro).
+# Achou 3 buracos reais em suítes "robustas + Codex" no Afiação (route-outcome,
+# aging-helpers) — ver scripts/mutcheck.d/*.mut e a skill auto-ensino.
+#
+# Não substitui Stryker (mutador genérico): aqui as mutações são ESCOLHIDAS e
+# versionadas — viram o CONTRATO executável das invariantes que importam.
+#
+# Disciplina embutida (os guards que separam medição de sensação):
+#   - backup-por-cópia + trap: NUNCA deixa o arquivo de produção mutado, nem em Ctrl-C.
+#   - baseline-check: se a suíte já está vermelha, aborta (resultado seria lixo).
+#   - guard anti-não-aplicação: perl que não casou = INVÁLIDO, não falso "sobrevive".
+#   - controle+ : exige ≥1 mutação EXPECT=PEGA que de fato pegue, senão o harness é suspeito.
+#
+# Uso:
+#   scripts/mutcheck.sh <src.ts> <test.ts> <mutations.mut>
+#   scripts/mutcheck.sh --selftest      # auto-valida a mecânica (sem vitest, ~1s)
+#
+# Formato do .mut (separador '|', 3 campos; '#'/vazias ignoradas):
+#   EXPECT | LABEL | <expressão perl -pe>
+#   EXPECT ∈ PEGA | SOBREVIVE | ?     (? = exploratório: reportado, não falha o gate)
+#   ex:  PEGA | faixaAging <=30->>30 | s/diasAtraso <= 30/diasAtraso < 30/
+#   '|' pode aparecer no perl (regex alternation) — é sempre o 3º campo (o resto).
+#
+# Exit code = nº de PROBLEMAS (divergência EXPECT≠obtido + inválidas + baseline/controle).
+#   0 = todas as mutações com EXPECT bateram, controle+ ok → a suíte honra o contrato.
+#   N = N problemas (use pra gate em CI; sobreviventes '?' NÃO contam como problema).
+#
+# Tuning (env):
+#   MUTCHECK_TEST_CMD   runner (default 'bunx vitest run'); recebe <test.ts> ao fim.
+#
+set -euo pipefail
+
+# ───────────────────────── self-test (mecânica pura, sem vitest) ─────────────────────────
+if [[ "${1:-}" == "--selftest" ]]; then
+  tmp=$(mktemp -d)
+  trap 'rm -rf "$tmp"' EXIT
+  src="$tmp/fixture.ts"; test="$tmp/fixture.runner"; mut="$tmp/fixture.mut"
+  printf 'export const pick = (xs)=> Math.min(...xs); // anchor\n' > "$src"
+  # runner FAKE: recebe o TEST (como o vitest) e inspeciona o SRC vizinho (como um
+  # import faria) — NÃO a si mesmo. "passa" só se o SRC ainda contém Math.min.
+  cat > "$test" <<'EOF'
+#!/usr/bin/env bash
+grep -q 'Math.min' "$(dirname "$1")/fixture.ts" && exit 0 || exit 1
+EOF
+  chmod +x "$test"
+  cat > "$mut" <<'EOF'
+PEGA      | min->max (coberto)      | s/Math\.min/Math.max/
+SOBREVIVE | comentario (inerte)     | s/anchor/ANCHOR/
+?         | inexistente (nao casa)  | s/NAO_EXISTE_XYZ/z/
+EOF
+  out=$(MUTCHECK_TEST_CMD="$test" "$0" "$src" "$test" "$mut" 2>&1) || true
+  fail=0
+  grep -q "PEGA" <<<"$out" || { echo "selftest: FALHOU — não reportou PEGA"; fail=1; }
+  grep -qE "min->max.*✓ PEGA|min->max.*PEGA" <<<"$out" || { echo "selftest: FALHOU — controle+ não pegou"; fail=1; }
+  grep -qE "comentario.*SOBREVIVE" <<<"$out" || { echo "selftest: FALHOU — mutação inerte devia sobreviver"; fail=1; }
+  grep -qiE "inexistente.*(INVÁLID|INVALID)" <<<"$out" || { echo "selftest: FALHOU — mutação que não casa devia ser INVÁLIDA"; fail=1; }
+  # revert: o fixture tem que voltar ao original (com Math.min)
+  grep -q 'Math.min(...xs)' "$src" || { echo "selftest: FALHOU — backup/revert não restaurou o arquivo"; fail=1; }
+  if [[ $fail -eq 0 ]]; then echo "selftest: ✓ mecânica ok (PEGA/SOBREVIVE/INVÁLIDO/revert)"; exit 0; fi
+  echo "--- saída do mutcheck sob teste ---"; echo "$out"; exit 1
+fi
+
+# ───────────────────────── args ─────────────────────────
+if [[ $# -ne 3 ]]; then
+  echo "uso: $0 <src.ts> <test.ts> <mutations.mut>   (ou --selftest)" >&2
+  exit 2
+fi
+SRC="$1"; TEST="$2"; MUT="$3"
+for f in "$SRC" "$TEST" "$MUT"; do
+  [[ -f "$f" ]] || { echo "erro: arquivo não encontrado: $f" >&2; exit 2; }
+done
+
+read -ra TEST_CMD <<< "${MUTCHECK_TEST_CMD:-bunx vitest run}"
+
+# ───────────────────────── backup + revert garantido ─────────────────────────
+BACKUP=$(mktemp)
+cp "$SRC" "$BACKUP"
+restore() { cp "$BACKUP" "$SRC"; }
+trap 'restore; rm -f "$BACKUP"' EXIT INT TERM
+
+run_tests() { "${TEST_CMD[@]}" "$TEST" >/dev/null 2>&1; }  # exit code é a verdade
+
+trim() { local s="$1"; s="${s#"${s%%[![:space:]]*}"}"; s="${s%"${s##*[![:space:]]}"}"; printf '%s' "$s"; }
+
+echo "mutcheck: $SRC × $TEST"
+
+# ───────────────────────── baseline ─────────────────────────
+if run_tests; then
+  echo "  baseline: ✓ verde"
+else
+  echo "  baseline: ✗ VERMELHO — a suíte já falha sem mutação. Resultados seriam lixo. Abortando." >&2
+  exit 1
+fi
+
+# ───────────────────────── loop de mutações ─────────────────────────
+problems=0; n=0; pegas=0; sobrev=0; invalid=0; ctrl_total=0; ctrl_ok=0
+printf "  %-9s %-40s %s\n" "EXPECT" "LABEL" "RESULTADO"
+while IFS='|' read -r c_expect c_label c_expr || [[ -n "${c_expect:-}" ]]; do
+  c_expect=$(trim "${c_expect:-}")
+  [[ -z "$c_expect" || "$c_expect" == \#* ]] && continue
+  c_label=$(trim "${c_label:-}")
+  c_expr=$(trim "${c_expr:-}")
+  n=$((n+1))
+
+  perl -i -pe "$c_expr" "$SRC"
+  if cmp -s "$SRC" "$BACKUP"; then
+    printf "  %-9s %-40s %s\n" "$c_expect" "$c_label" "⚠ INVÁLIDO (perl não casou)"
+    invalid=$((invalid+1)); problems=$((problems+1))
+    continue
+  fi
+  if run_tests; then got="SOBREVIVE"; else got="PEGA"; fi
+  restore
+
+  local_flag=""
+  if [[ "$c_expect" == "PEGA" || "$c_expect" == "SOBREVIVE" ]]; then
+    [[ "$c_expect" != "$got" ]] && local_flag="  ← DIVERGE" && problems=$((problems+1))
+  fi
+  [[ "$c_expect" == "PEGA" ]] && { ctrl_total=$((ctrl_total+1)); [[ "$got" == "PEGA" ]] && ctrl_ok=$((ctrl_ok+1)); }
+
+  if [[ "$got" == "PEGA" ]]; then
+    pegas=$((pegas+1)); mark="✓ PEGA"
+  else
+    sobrev=$((sobrev+1)); mark="⚠ SOBREVIVE"
+  fi
+  printf "  %-9s %-40s %s%s\n" "$c_expect" "$c_label" "$mark" "$local_flag"
+done < "$MUT"
+
+# ───────────────────────── controle+ ─────────────────────────
+ctrl_msg="n/d"
+if [[ $ctrl_total -gt 0 ]]; then
+  if [[ $ctrl_ok -eq $ctrl_total ]]; then ctrl_msg="✓ ($ctrl_ok/$ctrl_total)"; else ctrl_msg="✗ ($ctrl_ok/$ctrl_total)"; fi
+else
+  ctrl_msg="⚠ NENHUM controle+ (suspeite do harness)"; problems=$((problems+1))
+fi
+
+echo "sumário: $n mutações · $pegas pegas · $sobrev sobreviventes · $invalid inválidas · controle+ $ctrl_msg · $problems problema(s)"
+exit "$problems"

--- a/scripts/mutcheck.sh
+++ b/scripts/mutcheck.sh
@@ -15,6 +15,9 @@
 #   - backup-por-cópia + trap: NUNCA deixa o arquivo de produção mutado, nem em Ctrl-C.
 #   - baseline-check: se a suíte já está vermelha, aborta (resultado seria lixo).
 #   - guard anti-não-aplicação: perl que não casou = INVÁLIDO, não falso "sobrevive".
+#   - substituição única: mutação que toca >1 linha = regex largo (nó incerto) → INVÁLIDO.
+#   - compila-check: mutante que NÃO compila = morto pelo COMPILADOR, não por um teste →
+#     INVÁLIDO, não falso-PEGA (senão o poder aparente da suíte fica inflado). [achado do Codex]
 #   - controle+ : exige ≥1 mutação EXPECT=PEGA que de fato pegue, senão o harness é suspeito.
 #
 # Uso:
@@ -41,7 +44,11 @@ if [[ "${1:-}" == "--selftest" ]]; then
   tmp=$(mktemp -d)
   trap 'rm -rf "$tmp"' EXIT
   src="$tmp/fixture.ts"; test="$tmp/fixture.runner"; mut="$tmp/fixture.mut"
-  printf 'export const pick = (xs)=> Math.min(...xs); // anchor\n' > "$src"
+  cat > "$src" <<'EOF'
+export const pick = (xs)=> Math.min(...xs); // anchor
+let a = 1;
+let b = 2;
+EOF
   # runner FAKE: recebe o TEST (como o vitest) e inspeciona o SRC vizinho (como um
   # import faria) — NÃO a si mesmo. "passa" só se o SRC ainda contém Math.min.
   cat > "$test" <<'EOF'
@@ -50,9 +57,11 @@ grep -q 'Math.min' "$(dirname "$1")/fixture.ts" && exit 0 || exit 1
 EOF
   chmod +x "$test"
   cat > "$mut" <<'EOF'
-PEGA      | min->max (coberto)      | s/Math\.min/Math.max/
-SOBREVIVE | comentario (inerte)     | s/anchor/ANCHOR/
-?         | inexistente (nao casa)  | s/NAO_EXISTE_XYZ/z/
+PEGA      | min->max (coberto)        | s/Math\.min/Math.max/
+SOBREVIVE | comentario (inerte)       | s/anchor/ANCHOR/
+?         | inexistente (nao casa)    | s/NAO_EXISTE_XYZ/z/
+?         | multi-linha (regex largo) | s/let /const /
+?         | quebra sintaxe            | s/Math\.min\(/Math.min((/
 EOF
   out=$(MUTCHECK_TEST_CMD="$test" "$0" "$src" "$test" "$mut" 2>&1) || true
   fail=0
@@ -60,9 +69,14 @@ EOF
   grep -qE "min->max.*✓ PEGA|min->max.*PEGA" <<<"$out" || { echo "selftest: FALHOU — controle+ não pegou"; fail=1; }
   grep -qE "comentario.*SOBREVIVE" <<<"$out" || { echo "selftest: FALHOU — mutação inerte devia sobreviver"; fail=1; }
   grep -qiE "inexistente.*(INVÁLID|INVALID)" <<<"$out" || { echo "selftest: FALHOU — mutação que não casa devia ser INVÁLIDA"; fail=1; }
-  # revert: o fixture tem que voltar ao original (com Math.min)
-  grep -q 'Math.min(...xs)' "$src" || { echo "selftest: FALHOU — backup/revert não restaurou o arquivo"; fail=1; }
-  if [[ $fail -eq 0 ]]; then echo "selftest: ✓ mecânica ok (PEGA/SOBREVIVE/INVÁLIDO/revert)"; exit 0; fi
+  grep -qiE "multi-linha.*(INVÁLID|INVALID).*linhas" <<<"$out" || { echo "selftest: FALHOU — multi-linha (regex largo) devia ser INVÁLIDA"; fail=1; }
+  grep -qiE "quebra sintaxe.*(INVÁLID|INVALID).*compila" <<<"$out" || { echo "selftest: FALHOU — mutante que não compila devia ser INVÁLIDO"; fail=1; }
+  # ancora na MARCA "✓ PEGA", não na substring "PEGA" (a própria mensagem INVÁLIDO diz "seria falso-PEGA")
+  if grep -qE "quebra sintaxe.*✓ PEGA" <<<"$out"; then echo "selftest: FALHOU — mutante que não compila virou FALSO-PEGA"; fail=1; fi
+  # revert: o fixture tem que voltar ao original (Math.min E os `let` que a mutação multi-linha tocou)
+  grep -q 'Math.min(...xs)' "$src" || { echo "selftest: FALHOU — backup/revert não restaurou Math.min"; fail=1; }
+  grep -q 'let a = 1' "$src" || { echo "selftest: FALHOU — revert não restaurou a mutação multi-linha"; fail=1; }
+  if [[ $fail -eq 0 ]]; then echo "selftest: ✓ mecânica ok (PEGA/SOBREVIVE/INVÁLIDO[não-casou·multi-linha·não-compila]/revert)"; exit 0; fi
   echo "--- saída do mutcheck sob teste ---"; echo "$out"; exit 1
 fi
 
@@ -77,6 +91,11 @@ for f in "$SRC" "$TEST" "$MUT"; do
 done
 
 read -ra TEST_CMD <<< "${MUTCHECK_TEST_CMD:-bunx vitest run}"
+# Compila-check: distingue "morto por TESTE" (PEGA real) de "morto pelo COMPILADOR"
+# (mutante com sintaxe inválida — sem isso vira falso-PEGA, inflando o poder aparente
+# da suíte). Default bun build (esbuild: pega SINTAXE, não tipos — coerente com o vitest,
+# que roda via esbuild). MUTCHECK_COMPILE_CMD="" desliga o check (degrada honesto).
+read -ra COMPILE_CMD <<< "${MUTCHECK_COMPILE_CMD-bun build --target node --outfile /dev/null}"
 
 # ───────────────────────── backup + revert garantido ─────────────────────────
 BACKUP=$(mktemp)
@@ -85,6 +104,8 @@ restore() { cp "$BACKUP" "$SRC"; }
 trap 'restore; rm -f "$BACKUP"' EXIT INT TERM
 
 run_tests() { "${TEST_CMD[@]}" "$TEST" >/dev/null 2>&1; }  # exit code é a verdade
+compila() { [[ ${#COMPILE_CMD[@]} -eq 0 ]] && return 0; "${COMPILE_CMD[@]}" "$SRC" >/dev/null 2>&1; }
+linhas_mudadas() { diff "$BACKUP" "$SRC" | grep -cE '^> ' || true; }  # nº de linhas novas (1 = subst. única)
 
 trim() { local s="$1"; s="${s#"${s%%[![:space:]]*}"}"; s="${s%"${s##*[![:space:]]}"}"; printf '%s' "$s"; }
 
@@ -109,11 +130,23 @@ while IFS='|' read -r c_expect c_label c_expr || [[ -n "${c_expect:-}" ]]; do
   n=$((n+1))
 
   perl -i -pe "$c_expr" "$SRC"
+  # guard 1: a mutação aplicou? (não-casou = perl errado / .mut stale após refactor)
   if cmp -s "$SRC" "$BACKUP"; then
-    printf "  %-9s %-40s %s\n" "$c_expect" "$c_label" "⚠ INVÁLIDO (perl não casou)"
-    invalid=$((invalid+1)); problems=$((problems+1))
-    continue
+    printf "  %-9s %-40s %s\n" "$c_expect" "$c_label" "⚠ INVÁLIDO (não casou)"
+    invalid=$((invalid+1)); problems=$((problems+1)); restore; continue
   fi
+  # guard 2: substituição ÚNICA? (mutação de operador toca 1 linha; >1 = regex largo, nó incerto)
+  nl=$(linhas_mudadas)
+  if [[ "$nl" -ne 1 ]]; then
+    printf "  %-9s %-40s %s\n" "$c_expect" "$c_label" "⚠ INVÁLIDO (tocou $nl linhas — regex largo)"
+    invalid=$((invalid+1)); problems=$((problems+1)); restore; continue
+  fi
+  # guard 3: o mutante COMPILA? senão "morto pelo compilador" seria falso-PEGA (poder inflado)
+  if ! compila; then
+    printf "  %-9s %-40s %s\n" "$c_expect" "$c_label" "⚠ INVÁLIDO (não compila — seria falso-PEGA)"
+    invalid=$((invalid+1)); problems=$((problems+1)); restore; continue
+  fi
+  # sinal limpo: compila + única → o teste MATA o mutante?
   if run_tests; then got="SOBREVIVE"; else got="PEGA"; fi
   restore
 

--- a/src/lib/financeiro/__tests__/aging-helpers.test.ts
+++ b/src/lib/financeiro/__tests__/aging-helpers.test.ts
@@ -113,6 +113,13 @@ describe('diasCoberturaProjetado (caixa operacional projetado)', () => {
     expect(r).toBe(1);
     expect(Number.isFinite(r as number)).toBe(true);
   });
+  // Mutation-check (auto-ensino 2026-06-06): o teste de "sem base" usa saidas=0 exato, que
+  // `> 0` também pega — o PISO 0.01 (saída diária minúscula mas não-zero) nunca era exercitado.
+  // Sem o piso, saldo/0.0055 dá milhões de dias e DESLIGA o alerta "caixa cobre só X dias".
+  it('saída diária abaixo do piso (entre 0 e 0.01/dia) → null, não cobertura "quase infinita"', () => {
+    // 0.5 em 13 sem (91 dias) → ~0.0055/dia < piso 0.01 → null (guard money-path explícito)
+    expect(diasCoberturaProjetado(30000, 0.5, 13)).toBe(null);
+  });
 });
 
 describe('calibrarCurvas (por exposição, baixa derivada + status)', () => {
@@ -167,6 +174,23 @@ describe('calibrarCurvas (por exposição, baixa derivada + status)', () => {
     const curvas = calibrarCurvas(titulos, hoje, 1, 1, 1);
     expect(curvas['31-60'].confianca).toBe('baixa');
     expect(curvas['31-60'].taxa_recebimento).toBe(CURVA_DEFAULT['31-60'].taxa_recebimento);
+  });
+
+  // Mutation-check (auto-ensino 2026-06-06): prazoComGate testa a borda exata 0.40, mas
+  // calibrarCurvas (mesma constante COBERTURA_MIN_EMPRESA) não — a mutação `>=`→`>` sobrevivia.
+  // O limiar de 40% é INCLUSIVO: exatamente 40% de cobertura ainda calibra.
+  it('GATE EMPRESA na BORDA: cobertura == 40% (limiar exato) ainda calibra (>=, não >)', () => {
+    const titulos = [
+      // 2 liquidados-COM-data na 31-60 (entram na calibração)
+      { valor_documento: 100000, valor_recebido: 100000, saldo: 0, data_vencimento: '2026-03-20', data_baixa_derivada: '2026-04-24', status_titulo: 'RECEBIDO' },
+      { valor_documento: 100000, valor_recebido: 100000, saldo: 0, data_vencimento: '2026-03-20', data_baixa_derivada: '2026-04-24', status_titulo: 'RECEBIDO' },
+      // 3 liquidados-SEM-data → cobertura = 2/5 = 0.40 EXATO (só contam no denominador)
+      { valor_documento: 100000, valor_recebido: 100000, saldo: 0, data_vencimento: '2026-03-20', data_baixa_derivada: null, status_titulo: 'RECEBIDO' },
+      { valor_documento: 100000, valor_recebido: 100000, saldo: 0, data_vencimento: '2026-03-20', data_baixa_derivada: null, status_titulo: 'LIQUIDADO' },
+      { valor_documento: 100000, valor_recebido: 100000, saldo: 0, data_vencimento: '2026-03-20', data_baixa_derivada: null, status_titulo: 'PAGO' },
+    ];
+    const curvas = calibrarCurvas(titulos, hoje, 1, 1, 1); // gates de faixa frouxos → só a cobertura (0.40) decide
+    expect(curvas['31-60'].confianca).toBe('alta'); // 0.40 >= 0.40 inclui o limiar
   });
 
   it('GATE FAIXA: com empresa calibrável, faixa sem liquidado-datado cai no default', () => {

--- a/src/lib/financeiro/__tests__/regime-tributario-helpers.test.ts
+++ b/src/lib/financeiro/__tests__/regime-tributario-helpers.test.ts
@@ -48,6 +48,13 @@ describe('elegibilidadeSimples — usa RBA (ano-calendário), não RBT12', () =>
     expect(r.status_elegibilidade).toBe('inelegivel');
     expect(r.motivo_inelegivel).toContain('4,8');
   });
+  // Mutation-check (auto-ensino 2026-06-06): a LC 123 diz "receita SUPERIOR a" (>, não >=).
+  // RBA no teto/sublimite EXATO ainda é elegível/sublimite; os testes usavam 3M/4M/5M, nunca as
+  // bordas exatas → as mutações '>'->'>=' (teto e sublimite) sobreviviam.
+  it('RBA EXATO no teto/sublimite ainda é elegível ("superior a", não ">=")', () => {
+    expect(elegibilidadeSimples(4_800_000).status_elegibilidade).toBe('sublimite_excedido'); // 4,8M exato NÃO inelegível
+    expect(elegibilidadeSimples(3_600_000).status_elegibilidade).toBe('elegivel');           // 3,6M exato NÃO sublimite
+  });
 });
 
 describe('impostoAnualPresumido — anualizado, adicional por trimestre, receitas financeiras integrais', () => {
@@ -92,6 +99,14 @@ describe('anexoEfetivoFatorR', () => {
   it('massa/receita ≥ 28% → III', () => { expect(anexoEfetivoFatorR(300000, 1e6).anexo).toBe('III'); });
   it('< 28% → V', () => { expect(anexoEfetivoFatorR(100000, 1e6).anexo).toBe('V'); });
   it('massa null → banda (ambos)', () => { expect(anexoEfetivoFatorR(null, 1e6).banda).toBe(true); });
+  // Mutation-check (auto-ensino 2026-06-06): testes cobriam 0.30 e 0.10, não a BORDA 0.28.
+  // O limiar do fator-r é INCLUSIVO (LC 123: fator-r >= 28% → anexo III). fr==0.28 exato é
+  // alcançável (280k/1M) e decide anexo III vs V (impostos bem diferentes). A mutação >=->>  sobrevivia.
+  it('fator-r EXATAMENTE 28% → anexo III (limiar inclusivo, >=, não >)', () => {
+    const r = anexoEfetivoFatorR(280000, 1_000_000); // 280000/1e6 === 0.28 (exato em double)
+    expect(r.fator_r).toBe(0.28);
+    expect(r.anexo).toBe('III');
+  });
 });
 
 describe('breakEvenMargemReal', () => {

--- a/src/lib/route/route-outcome.test.ts
+++ b/src/lib/route/route-outcome.test.ts
@@ -50,6 +50,16 @@ describe('derivarSinaisContato', () => {
     expect(s.cadenciaBloqueadaPor).toBe('real');
   });
 
+  // Mutation-check (auto-ensino 2026-06-06): com 1 só real, Math.min==Math.max — a mutação
+  // min->max em `ultimoContatoRealHaDias` sobrevivia. Com 2+ reais em dias distintos, o gate
+  // DEVE herdar o MAIS RECENTE (Math.min); o mais antigo liberaria re-ligação cedo demais.
+  it('múltiplos contatos reais → usa o MAIS RECENTE, não o mais antigo (Math.min)', () => {
+    const s = derivarSinaisContato([reg('respondido', '2026-05-19'), reg('respondido', '2026-05-29')], HOJE, ROTA); // 12d e 2d
+    expect(s.ultimoContatoRealHaDias).toBe(2);
+    expect(s.contatadoHaDiasParaGate).toBe(2);
+    expect(s.cadenciaBloqueadaPor).toBe('real');
+  });
+
   it('sem_resposta ISOLADO (N<3) NÃO bloqueia — só badge', () => {
     const s = derivarSinaisContato([reg('sem_resposta', '2026-05-30')], HOJE, ROTA); // ontem
     expect(s.semRespostaRecenteN).toBe(1);


### PR DESCRIPTION
Follow-up de #692 (mergeado). A 2ª opinião adversária (Codex) achou um **furo técnico real** no harness do `mutcheck.sh` que minha auto-validação por 4 ângulos não pegou.

## O furo
Um mutante que **não compila** era morto pelo **compilador** (o vitest falha ao *importar* o arquivo com sintaxe quebrada), não por um teste — e o harness contava isso como `PEGA`, **inflando o poder aparente** da suíte. "O teste falhou" ≠ "um teste matou o mutante".

## Fix (2 guards novos)
- **compila-check** (`bun build`, ~20ms): mutante que não compila = `INVÁLIDO`, não `PEGA`. esbuild pega **sintaxe** (não tipos) — coerente com o vitest, que roda via esbuild e ignora tipos. Parametrizável (`MUTCHECK_COMPILE_CMD=""` desliga).
- **substituição única**: mutação que toca >1 linha = regex largo (nó incerto) = `INVÁLIDO` (o `cmp` antigo só via que *algo* mudou, não que mudou 1 lugar).

## Prova antes/depois (helper real)
Mutação `= =` (1 linha, quebra sintaxe) em `route-outcome.ts`:
- **com** compila-check → `INVÁLIDO (não compila — seria falso-PEGA)`
- **sem** (`MUTCHECK_COMPILE_CMD=""`) → `✓ PEGA` (falso)

## Validação
- `--selftest` estendido prova multi-linha e não-compila como `INVÁLIDO`, e que não-compila **não** vira falso-PEGA.
  - (a asserção do selftest tinha o mesmo pecado de teste-casa-a-si-mesmo: `PEGA` casava dentro de `"falso-PEGA"` → ancorada em `✓ PEGA`.)
- Os 3 contratos `.mut` seguem **verdes** (são ancorados, mutam 1 linha, compilam) — sem regressão.
- shellcheck limpo.

Zero mudança na lógica de produção (só `scripts/mutcheck.sh`).

Lição de processo: mesmo uma ferramenta auto-validada por N ângulos pode ter um furo que **só um adversário externo** enxerga — a 2ª opinião paga até quando você está confiante.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
