### PR TITLE
harden(mutcheck): compila-check + substituição-única (furo achado pelo Codex)

### DIFF
--- a/scripts/mutcheck.sh
+++ b/scripts/mutcheck.sh
@@ -15,6 +15,9 @@
 #   - backup-por-cópia + trap: NUNCA deixa o arquivo de produção mutado, nem em Ctrl-C.
 #   - baseline-check: se a suíte já está vermelha, aborta (resultado seria lixo).
 #   - guard anti-não-aplicação: perl que não casou = INVÁLIDO, não falso "sobrevive".
+#   - substituição única: mutação que toca >1 linha = regex largo (nó incerto) → INVÁLIDO.
+#   - compila-check: mutante que NÃO compila = morto pelo COMPILADOR, não por um teste →
+#     INVÁLIDO, não falso-PEGA (senão o poder aparente da suíte fica inflado). [achado do Codex]
 #   - controle+ : exige ≥1 mutação EXPECT=PEGA que de fato pegue, senão o harness é suspeito.
 #
 # Uso:
@@ -41,7 +44,11 @@ if [[ "${1:-}" == "--selftest" ]]; then
   tmp=$(mktemp -d)
   trap 'rm -rf "$tmp"' EXIT
   src="$tmp/fixture.ts"; test="$tmp/fixture.runner"; mut="$tmp/fixture.mut"
-  printf 'export const pick = (xs)=> Math.min(...xs); // anchor\n' > "$src"
+  cat > "$src" <<'EOF'
+export const pick = (xs)=> Math.min(...xs); // anchor
+let a = 1;
+let b = 2;
+EOF
   # runner FAKE: recebe o TEST (como o vitest) e inspeciona o SRC vizinho (como um
   # import faria) — NÃO a si mesmo. "passa" só se o SRC ainda contém Math.min.
   cat > "$test" <<'EOF'
@@ -50,9 +57,11 @@ grep -q 'Math.min' "$(dirname "$1")/fixture.ts" && exit 0 || exit 1
 EOF
   chmod +x "$test"
   cat > "$mut" <<'EOF'
-PEGA      | min->max (coberto)      | s/Math\.min/Math.max/
-SOBREVIVE | comentario (inerte)     | s/anchor/ANCHOR/
-?         | inexistente (nao casa)  | s/NAO_EXISTE_XYZ/z/
+PEGA      | min->max (coberto)        | s/Math\.min/Math.max/
+SOBREVIVE | comentario (inerte)       | s/anchor/ANCHOR/
+?         | inexistente (nao casa)    | s/NAO_EXISTE_XYZ/z/
+?         | multi-linha (regex largo) | s/let /const /
+?         | quebra sintaxe            | s/Math\.min\(/Math.min((/
 EOF
   out=$(MUTCHECK_TEST_CMD="$test" "$0" "$src" "$test" "$mut" 2>&1) || true
   fail=0
@@ -60,9 +69,14 @@ EOF
   grep -qE "min->max.*✓ PEGA|min->max.*PEGA" <<<"$out" || { echo "selftest: FALHOU — controle+ não pegou"; fail=1; }
   grep -qE "comentario.*SOBREVIVE" <<<"$out" || { echo "selftest: FALHOU — mutação inerte devia sobreviver"; fail=1; }
   grep -qiE "inexistente.*(INVÁLID|INVALID)" <<<"$out" || { echo "selftest: FALHOU — mutação que não casa devia ser INVÁLIDA"; fail=1; }
-  # revert: o fixture tem que voltar ao original (com Math.min)
-  grep -q 'Math.min(...xs)' "$src" || { echo "selftest: FALHOU — backup/revert não restaurou o arquivo"; fail=1; }
-  if [[ $fail -eq 0 ]]; then echo "selftest: ✓ mecânica ok (PEGA/SOBREVIVE/INVÁLIDO/revert)"; exit 0; fi
+  grep -qiE "multi-linha.*(INVÁLID|INVALID).*linhas" <<<"$out" || { echo "selftest: FALHOU — multi-linha (regex largo) devia ser INVÁLIDA"; fail=1; }
+  grep -qiE "quebra sintaxe.*(INVÁLID|INVALID).*compila" <<<"$out" || { echo "selftest: FALHOU — mutante que não compila devia ser INVÁLIDO"; fail=1; }
+  # ancora na MARCA "✓ PEGA", não na substring "PEGA" (a própria mensagem INVÁLIDO diz "seria falso-PEGA")
+  if grep -qE "quebra sintaxe.*✓ PEGA" <<<"$out"; then echo "selftest: FALHOU — mutante que não compila virou FALSO-PEGA"; fail=1; fi
+  # revert: o fixture tem que voltar ao original (Math.min E os `let` que a mutação multi-linha tocou)
+  grep -q 'Math.min(...xs)' "$src" || { echo "selftest: FALHOU — backup/revert não restaurou Math.min"; fail=1; }
+  grep -q 'let a = 1' "$src" || { echo "selftest: FALHOU — revert não restaurou a mutação multi-linha"; fail=1; }
+  if [[ $fail -eq 0 ]]; then echo "selftest: ✓ mecânica ok (PEGA/SOBREVIVE/INVÁLIDO[não-casou·multi-linha·não-compila]/revert)"; exit 0; fi
   echo "--- saída do mutcheck sob teste ---"; echo "$out"; exit 1
 fi
 
@@ -77,6 +91,11 @@ for f in "$SRC" "$TEST" "$MUT"; do
 done
 
 read -ra TEST_CMD <<< "${MUTCHECK_TEST_CMD:-bunx vitest run}"
+# Compila-check: distingue "morto por TESTE" (PEGA real) de "morto pelo COMPILADOR"
+# (mutante com sintaxe inválida — sem isso vira falso-PEGA, inflando o poder aparente
+# da suíte). Default bun build (esbuild: pega SINTAXE, não tipos — coerente com o vitest,
+# que roda via esbuild). MUTCHECK_COMPILE_CMD="" desliga o check (degrada honesto).
+read -ra COMPILE_CMD <<< "${MUTCHECK_COMPILE_CMD-bun build --target node --outfile /dev/null}"
 
 # ───────────────────────── backup + revert garantido ─────────────────────────
 BACKUP=$(mktemp)
@@ -85,6 +104,8 @@ restore() { cp "$BACKUP" "$SRC"; }
 trap 'restore; rm -f "$BACKUP"' EXIT INT TERM
 
 run_tests() { "${TEST_CMD[@]}" "$TEST" >/dev/null 2>&1; }  # exit code é a verdade
+compila() { [[ ${#COMPILE_CMD[@]} -eq 0 ]] && return 0; "${COMPILE_CMD[@]}" "$SRC" >/dev/null 2>&1; }
+linhas_mudadas() { diff "$BACKUP" "$SRC" | grep -cE '^> ' || true; }  # nº de linhas novas (1 = subst. única)
 
 trim() { local s="$1"; s="${s#"${s%%[![:space:]]*}"}"; s="${s%"${s##*[![:space:]]}"}"; printf '%s' "$s"; }
 
@@ -109,11 +130,23 @@ while IFS='|' read -r c_expect c_label c_expr || [[ -n "${c_expect:-}" ]]; do
   n=$((n+1))
 
   perl -i -pe "$c_expr" "$SRC"
+  # guard 1: a mutação aplicou? (não-casou = perl errado / .mut stale após refactor)
   if cmp -s "$SRC" "$BACKUP"; then
-    printf "  %-9s %-40s %s\n" "$c_expect" "$c_label" "⚠ INVÁLIDO (perl não casou)"
-    invalid=$((invalid+1)); problems=$((problems+1))
-    continue
+    printf "  %-9s %-40s %s\n" "$c_expect" "$c_label" "⚠ INVÁLIDO (não casou)"
+    invalid=$((invalid+1)); problems=$((problems+1)); restore; continue
   fi
+  # guard 2: substituição ÚNICA? (mutação de operador toca 1 linha; >1 = regex largo, nó incerto)
+  nl=$(linhas_mudadas)
+  if [[ "$nl" -ne 1 ]]; then
+    printf "  %-9s %-40s %s\n" "$c_expect" "$c_label" "⚠ INVÁLIDO (tocou $nl linhas — regex largo)"
+    invalid=$((invalid+1)); problems=$((problems+1)); restore; continue
+  fi
+  # guard 3: o mutante COMPILA? senão "morto pelo compilador" seria falso-PEGA (poder inflado)
+  if ! compila; then
+    printf "  %-9s %-40s %s\n" "$c_expect" "$c_label" "⚠ INVÁLIDO (não compila — seria falso-PEGA)"
+    invalid=$((invalid+1)); problems=$((problems+1)); restore; continue
+  fi
+  # sinal limpo: compila + única → o teste MATA o mutante?
   if run_tests; then got="SOBREVIVE"; else got="PEGA"; fi
   restore
 


### PR DESCRIPTION
Follow-up de #692 (squash-merged). A 2ª opinião adversária (Codex) achou um **furo técnico real** no harness do `mutcheck.sh` que minha auto-validação por 4 ângulos não pegou.

## O furo
Um mutante que **não compila** era morto pelo **compilador** (o vitest falha ao *importar* o arquivo com sintaxe quebrada), não por um teste — e o harness contava isso como `PEGA`, **inflando o poder aparente** da suíte. "O teste falhou" ≠ "um teste matou o mutante".

## Fix (2 guards novos)
- **compila-check** (`bun build`, ~20ms): mutante que não compila = `INVÁLIDO`, não `PEGA`. esbuild pega **sintaxe** (não tipos) — coerente com o vitest, que roda via esbuild e ignora tipos. Parametrizável (`MUTCHECK_COMPILE_CMD=""` desliga).
- **substituição única**: mutação que toca >1 linha = regex largo (nó incerto) = `INVÁLIDO` (o `cmp` antigo só via que *algo* mudou, não que mudou 1 lugar).

## Prova antes/depois (helper real)
Mutação `= =` (1 linha, quebra sintaxe) em `route-outcome.ts`:
- **com** compila-check → `INVÁLIDO (não compila — seria falso-PEGA)`
- **sem** (`MUTCHECK_COMPILE_CMD=""`) → `✓ PEGA` (falso)

## Validação
- `--selftest` estendido prova multi-linha e não-compila como `INVÁLIDO`, e que não-compila **não** vira falso-PEGA (a asserção tinha o mesmo pecado de teste-casa-a-si-mesmo: `PEGA` casava dentro de `"falso-PEGA"` → ancorada em `✓ PEGA`).
- Os 3 contratos `.mut` da main seguem **verdes** (ancorados, mutam 1 linha, compilam) — o job de CI `mutation-check` confirma.
- shellcheck limpo. Zero mudança na lógica de produção (só `scripts/mutcheck.sh`).

Lição de processo: mesmo uma ferramenta auto-validada por N ângulos pode ter um furo que **só um adversário externo** enxerga.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
