### PR TITLE
fix(venda): catálogo do wizard capado em 1000 escondia ~65% dos produtos na busca

### DIFF
--- a/src/hooks/unifiedOrder/__tests__/catalog-helpers.test.ts
+++ b/src/hooks/unifiedOrder/__tests__/catalog-helpers.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi } from 'vitest';
+import { paginateAll, filterAndRankProducts } from '../catalog-helpers';
+import type { Product } from '../types';
+
+let idc = 0;
+const mk = (over: Partial<Product> = {}): Product => ({
+  id: `id-${idc++}`,
+  codigo: 'PRD0000',
+  descricao: 'PRODUTO X',
+  unidade: 'UN',
+  valor_unitario: 10,
+  estoque: 0,
+  ativo: true,
+  omie_codigo_produto: 1,
+  ...over,
+});
+
+describe('paginateAll', () => {
+  it('reúne todas as páginas e para na página parcial', async () => {
+    const pagina0 = Array.from({ length: 1000 }, (_, i) => mk({ id: `p0-${i}` }));
+    const pagina1 = Array.from({ length: 7 }, (_, i) => mk({ id: `p1-${i}` }));
+    const fetchPage = vi.fn(async (from: number) => (from === 0 ? pagina0 : pagina1));
+
+    const all = await paginateAll(fetchPage, 1000);
+
+    expect(all).toHaveLength(1007);
+    expect(fetchPage).toHaveBeenCalledTimes(2);
+    expect(fetchPage).toHaveBeenNthCalledWith(1, 0, 999);
+    expect(fetchPage).toHaveBeenNthCalledWith(2, 1000, 1999);
+  });
+
+  it('REGRESSÃO do cap: produto na 2ª página (posição > 1000) é reunido, não perdido', async () => {
+    const pagina0 = Array.from({ length: 1000 }, (_, i) => mk({ id: `p0-${i}`, descricao: `AAA ${i}` }));
+    const primer6264 = mk({ id: 'real-6264', codigo: 'PRD00500', descricao: 'PRIMER PU BRANCO FL.6264.02GL' });
+    const pagina1 = [primer6264, ...Array.from({ length: 4 }, (_, i) => mk({ id: `p1-${i}` }))];
+    const fetchPage = async (from: number) => (from === 0 ? pagina0 : pagina1);
+
+    const all = await paginateAll(fetchPage, 1000);
+
+    expect(all).toHaveLength(1005);
+    expect(all.find((p) => p.id === 'real-6264')).toBeDefined();
+  });
+
+  it('página exatamente cheia seguida de vazia: para corretamente', async () => {
+    const pagina0 = Array.from({ length: 1000 }, (_, i) => mk({ id: `p0-${i}` }));
+    const fetchPage = vi.fn(async (from: number) => (from === 0 ? pagina0 : []));
+
+    const all = await paginateAll(fetchPage, 1000);
+
+    expect(all).toHaveLength(1000);
+    expect(fetchPage).toHaveBeenCalledTimes(2);
+  });
+
+  it('propaga erro de página e NÃO retorna catálogo parcial', async () => {
+    const fetchPage = async (from: number) => {
+      if (from === 0) return Array.from({ length: 1000 }, (_, i) => mk({ id: `p0-${i}` }));
+      throw new Error('falha de rede na página 2');
+    };
+
+    await expect(paginateAll(fetchPage, 1000)).rejects.toThrow('falha de rede');
+  });
+
+  it('guard de maxPages evita loop infinito se a página nunca encolher', async () => {
+    const fetchPage = vi.fn(async () => Array.from({ length: 1000 }, (_, i) => mk({ id: `x-${i}` })));
+
+    const all = await paginateAll(fetchPage, 1000, 3);
+
+    expect(fetchPage).toHaveBeenCalledTimes(3);
+    expect(all).toHaveLength(3000);
+  });
+});
+
+const ctxNoPriority = { isPreviouslyPurchased: () => false, shouldPrioritize: false };
+
+describe('filterAndRankProducts', () => {
+  it('REGRESSÃO 6264: acha o item mesmo na posição alfabética alta da lista completa', () => {
+    const fillers = Array.from({ length: 1500 }, (_, i) =>
+      mk({ id: `f-${i}`, descricao: `ABRASIVO ${String(i).padStart(4, '0')}` }),
+    );
+    const primer = mk({ id: 'real-6264', codigo: 'PRD00500', descricao: 'PRIMER PU BRANCO FL.6264.02GL' });
+    const all = [...fillers, primer];
+
+    const out = filterAndRankProducts(all, '6264', ctxNoPriority);
+
+    expect(out).toHaveLength(1);
+    expect(out[0].id).toBe('real-6264');
+  });
+
+  it('busca casa no código', () => {
+    const all = [mk({ id: 'a', codigo: 'PRD03576', descricao: 'PRIMER PU FL.6264.02KGBH' }), mk({ id: 'b', codigo: 'PRD9999' })];
+    expect(filterAndRankProducts(all, 'PRD03576', ctxNoPriority).map((p) => p.id)).toEqual(['a']);
+  });
+
+  it('busca casa no omie_codigo_produto numérico (digitou o código interno)', () => {
+    const all = [
+      mk({ id: 'a', codigo: 'PRDXXX', descricao: 'SEM NUMERO', omie_codigo_produto: 6264 }),
+      mk({ id: 'b', codigo: 'PRDYYY', descricao: 'OUTRO', omie_codigo_produto: 99 }),
+    ];
+    expect(filterAndRankProducts(all, '6264', ctxNoPriority).map((p) => p.id)).toEqual(['a']);
+  });
+
+  it('busca é case-insensitive', () => {
+    const all = [mk({ id: 'a', descricao: 'Primer PU Branco' })];
+    expect(filterAndRankProducts(all, 'primer', ctxNoPriority).map((p) => p.id)).toEqual(['a']);
+  });
+
+  it('prioriza comprado > ativo > alfabético', () => {
+    const p1 = mk({ id: 'p1', ativo: true, descricao: 'B nao comprado' });
+    const p2 = mk({ id: 'p2', ativo: false, descricao: 'Z comprado inativo' });
+    const p3 = mk({ id: 'p3', ativo: true, descricao: 'Y comprado ativo' });
+    const ctx = { isPreviouslyPurchased: (p: Product) => p.id === 'p2' || p.id === 'p3', shouldPrioritize: true };
+
+    const out = filterAndRankProducts([p1, p2, p3], '', ctx);
+
+    expect(out.map((p) => p.id)).toEqual(['p3', 'p2', 'p1']);
+  });
+
+  it('desempate determinístico por id quando a descrição é idêntica', () => {
+    const a = mk({ id: 'zzz', descricao: 'IGUAL' });
+    const b = mk({ id: 'aaa', descricao: 'IGUAL' });
+    const out = filterAndRankProducts([a, b], '', ctxNoPriority);
+    expect(out.map((p) => p.id)).toEqual(['aaa', 'zzz']);
+  });
+
+  it('busca vazia retorna top-N priorizado respeitando o limite', () => {
+    const all = Array.from({ length: 60 }, (_, i) => mk({ id: `n-${i}`, descricao: `ITEM ${String(i).padStart(3, '0')}` }));
+    expect(filterAndRankProducts(all, '', ctxNoPriority, 50)).toHaveLength(50);
+  });
+});

--- a/src/hooks/unifiedOrder/catalog-helpers.ts
+++ b/src/hooks/unifiedOrder/catalog-helpers.ts
@@ -1,0 +1,76 @@
+import type { Product } from './types';
+
+/**
+ * Pagina uma fonte até esgotá-la, contornando o cap default do PostgREST (1000
+ * linhas por request). `fetchPage(from, to)` recebe o range INCLUSIVO de cada
+ * página (compatível com `.range()` do supabase-js). Para quando uma página vem
+ * com menos que `pageSize` (= última página) ou ao atingir `maxPages` (guard
+ * defensivo contra loop infinito caso a fonte nunca encolha).
+ *
+ * Erro em qualquer página PROPAGA (rejeita) — o chamador NÃO deve publicar um
+ * catálogo parcial por cima de um bom (senão o cap volta disfarçado de "sumiu").
+ */
+export async function paginateAll<T>(
+  fetchPage: (from: number, to: number) => Promise<T[]>,
+  pageSize = 1000,
+  maxPages = 100,
+): Promise<T[]> {
+  const all: T[] = [];
+  let from = 0;
+  for (let page = 0; page < maxPages; page++) {
+    const rows = await fetchPage(from, from + pageSize - 1);
+    all.push(...rows);
+    if (rows.length < pageSize) break;
+    from += pageSize;
+  }
+  return all;
+}
+
+export interface RankContext {
+  /** True se o produto já foi comprado pelo cliente (preço de contrato ou histórico). */
+  isPreviouslyPurchased: (p: Product) => boolean;
+  /** Só prioriza "comprado antes" quando há dados de cliente carregados. */
+  shouldPrioritize: boolean;
+}
+
+/**
+ * Filtra + ordena o catálogo para exibição/busca. Função pura (extraída do
+ * `buildFilteredList` do `useProductCatalog`) para ser testável e garantir que a
+ * busca varre a lista COMPLETA — não uma fatia capada.
+ *
+ * Ordenação: comprado-antes (se priorizar) → ativo → alfabético por descrição →
+ * desempate determinístico por `id` (evita ordem instável entre descrições iguais).
+ * Busca (quando há termo): substring case-insensitive em `descricao`, `codigo` e
+ * no `omie_codigo_produto` (cobre quem digita o código interno do Omie).
+ */
+export function filterAndRankProducts(
+  products: Product[],
+  term: string,
+  ctx: RankContext,
+  limit = 50,
+): Product[] {
+  const sorted = [...products].sort((a, b) => {
+    if (ctx.shouldPrioritize) {
+      const aPrev = ctx.isPreviouslyPurchased(a);
+      const bPrev = ctx.isPreviouslyPurchased(b);
+      if (aPrev && !bPrev) return -1;
+      if (!aPrev && bPrev) return 1;
+    }
+    if (a.ativo && !b.ativo) return -1;
+    if (!a.ativo && b.ativo) return 1;
+    const byDesc = a.descricao.localeCompare(b.descricao);
+    if (byDesc !== 0) return byDesc;
+    return a.id.localeCompare(b.id);
+  });
+
+  if (!term) return sorted.slice(0, limit);
+  const q = term.toLowerCase();
+  return sorted
+    .filter(
+      (p) =>
+        p.descricao.toLowerCase().includes(q) ||
+        p.codigo.toLowerCase().includes(q) ||
+        String(p.omie_codigo_produto).includes(q),
+    )
+    .slice(0, limit);
+}

--- a/src/hooks/unifiedOrder/useProductCatalog.ts
+++ b/src/hooks/unifiedOrder/useProductCatalog.ts
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import { logger } from '@/lib/logger';
 import { buildExclusionQuery } from './types';
+import { paginateAll, filterAndRankProducts } from './catalog-helpers';
 import type { Product, ProductAccount } from './types';
 
 const PRODUCT_COLUMNS =
@@ -19,12 +20,21 @@ interface UseProductCatalogOptions {
  * Helper: busca produtos de uma conta com os filtros de família já aplicados.
  */
 async function fetchProductsForAccount(account: ProductAccount): Promise<Product[]> {
-  const baseQuery = supabase
-    .from('omie_products')
-    .select(PRODUCT_COLUMNS)
-    .eq('account', account);
-  const { data } = await buildExclusionQuery(baseQuery).order('descricao');
-  return (data || []) as Product[];
+  // Pagina o catálogo inteiro: sem isto o PostgREST devolve só as 1000 primeiras
+  // descrições (cap default) e ~65% do catálogo OBEN fica invisível pra venda.
+  // `error` é propagado (não engolido) para nunca publicar catálogo parcial.
+  return paginateAll(async (from, to) => {
+    const baseQuery = supabase
+      .from('omie_products')
+      .select(PRODUCT_COLUMNS)
+      .eq('account', account);
+    const { data, error } = await buildExclusionQuery(baseQuery)
+      .order('descricao')
+      .order('id')
+      .range(from, to);
+    if (error) throw error;
+    return (data || []) as Product[];
+  });
 }
 
 /**
@@ -176,23 +186,15 @@ export function useProductCatalog({
       const hasPurchaseHistory = Object.keys(customerPurchaseHistory).length > 0;
       const shouldPrioritize = hasCustomerPrices || hasPurchaseHistory;
 
-      const sorted = [...products].sort((a, b) => {
-        if (shouldPrioritize) {
-          const aPrev = isProductPreviouslyPurchased(a, account);
-          const bPrev = isProductPreviouslyPurchased(b, account);
-          if (aPrev && !bPrev) return -1;
-          if (!aPrev && bPrev) return 1;
-        }
-        if (a.ativo && !b.ativo) return -1;
-        if (!a.ativo && b.ativo) return 1;
-        return a.descricao.localeCompare(b.descricao);
-      });
-
-      if (!productSearch) return sorted.slice(0, 50);
-      const q = productSearch.toLowerCase();
-      return sorted
-        .filter((p) => p.descricao.toLowerCase().includes(q) || p.codigo.toLowerCase().includes(q))
-        .slice(0, 50);
+      return filterAndRankProducts(
+        products,
+        productSearch,
+        {
+          isPreviouslyPurchased: (p) => isProductPreviouslyPurchased(p, account),
+          shouldPrioritize,
+        },
+        50,
+      );
     },
     [
       productSearch,


### PR DESCRIPTION
## Sintoma
A vendedora (Regina), tirando pedido pra **ART MOVEIS PLANEJADOS** (OBEN), digitou **6264** na busca de produto do wizard e o item não apareceu — apesar de existir, estar ativo e o "6264" estar na descrição.

## Causa-raiz (confirmada por SQL em prod)
`useProductCatalog.fetchProductsForAccount` carregava o catálogo client-side **sem paginação** → o PostgREST devolve no máximo **1000 linhas** (cap default), ordenadas por `descricao`. A busca é um filtro **em memória** sobre essa fatia.

Diagnóstico em produção:
- Catálogo OBEN vendável (pós-exclusões de família): **2883** produtos.
- `PRIMER PU ... FL.6264.02*` cai na **posição alfabética ~2420** → fora das 1000 carregadas → **invisível**.
- **~1883 produtos OBEN (65%)** estão invisíveis pra venda hoje. Não é o 6264 — é a classe inteira.

O cap não cegava só a busca: o assistente de IA **"Identificar Itens do Pedido"** e o deep-link resolvem o produto via `allProducts.find(p => p.id === ...)` na mesma lista capada → item identificado pela IA além da posição 1000 **some do pedido sem aviso**.

## Fix (Opção B — decidida com o Codex: conserta a FONTE)
- **`paginateAll`** (`catalog-helpers.ts`): pagina o load até esgotar (`.range()` + tie-break `.order('id')`), **propagando erro** de página (nunca publica catálogo parcial por cima de um bom). Aplicado nos 3 callsites do hook.
- Trata o `error` antes **engolido** (`const { data } = await ...`).
- **`filterAndRankProducts`** (helper puro extraído do `buildFilteredList`): mesma ordenação (comprado > ativo > alfabético) + **desempate determinístico por `id`** + busca agora também no **`omie_codigo_produto`**.
- **12 testes de regressão**: paginador com 2 páginas (6264 na pág 2 → reunido, não perdido) + filtro acha o item em qualquer posição da lista completa + priorização/desempate.

Por que B e não busca server-side (A): A consertaria só a caixa de busca; o assistente de IA continuaria cego. B conserta a fonte e a busca fica **instantânea** (em memória), sem debounce/race no money-path.

## Gate
- ✅ `typecheck` strict (0)
- ✅ `test` 2788/2788 (incl. os 12 novos)
- ✅ `lint` 0 errors

## Divergências conscientes do Codex (contexto que ele não tinha)
1. **Mantive `metadata` no select** (Codex sugeriu dropar): o submit lê `tipo_produto ?? metadata.tipo_produto` e a coluna `tipo_produto` do **Colacor está ~14% coberta** (CLAUDE.md #575) → dropar regrediria a auto-OP de produto acabado.
2. **Família NULL ficou de fora deste PR** (Codex sugeriu bundlar): não foi o gatilho do 6264 (família = "Primer PU"), tem **risco de ampliar visibilidade de produtos indesejados**, e eu não sei a contagem sem o DB.

## Follow-ups (não neste PR)
- **Família NULL**: `familia NOT ILIKE x` descarta produto com `familia` NULL. Rodar a contagem antes de decidir se devem aparecer:
  ```sql
  SELECT account, count(*) FROM omie_products WHERE familia IS NULL GROUP BY account;
  ```
- Popular `tipo_produto` do Colacor → aí dá pra dropar `metadata` e enxugar o payload.
- Migrar `useState` → React Query (cache/invalidação); keyset pagination se houver sintoma de concorrência.

## ⚠️ Deploy
100% frontend (sem migration/edge). **Requer Publish no Lovable** pra ir ao ar.