### PR TITLE
feat(pedido): cor da tinta no detalhe — Fase 1 (sync extrai) + Fase 2 (backfill com probe)

### DIFF
--- a/docs/superpowers/plans/2026-06-09-cor-tinta-detalhe-pedido-plano.md
+++ b/docs/superpowers/plans/2026-06-09-cor-tinta-detalhe-pedido-plano.md
@@ -1,0 +1,58 @@
+# Plano — Cor da tinta no detalhe do pedido + reforma de identidade do sync de vendas
+
+> Status: **aguardando aprovação do founder**. Money-path (sync de pedidos de venda). Investigação + design (Codex) concluídos.
+
+## Problema
+A cor da tinta (`tint_nome_cor`) não aparece no detalhe do pedido de venda. O display (PR #676) está correto; o **dado** não está no jsonb `sales_orders.items`.
+
+## Root cause (confirmado em prod)
+- Na venda, a cor é gravada no jsonb local **e** no Omie como observação do item (`obs_item`/`dados_adicionais_item` = `"Cor: 1247 - AZUL RAL 5010 - QT"`).
+- O sync de entrada (`omie-vendas-sync` → `sync_pedidos`, `ListarPedidos`, index.ts:1089-1101) remonta os itens com só `produto` e **descarta** `det.observacao`/`det.inf_adic` → jsonb sem a cor.
+- O submit **não grava `hash_payload`**; o sync filtra por `hash = omie_{account}_{codigoPedido}` e não reconhece o pedido do wizard → cria um **registro paralelo seco**.
+
+## Estado medido (prod, 2026-06-09)
+- 2.603 registros / **2.431 pedidos distintos** por `(account, omie_pedido_id)`.
+- **172 duplicados** (7%): par wizard (status local + cor) × sync (status Omie, sem cor).
+- **0 registros sem `omie_pedido_id`** → chave canônica cobre 100%.
+- Só **7** pedidos têm cor hoje (registros do wizard sobreviventes).
+- FK → `sales_orders`: `order_items` **CASCADE**; `picking_tasks`/`farmer_calls`/`recommendation_log` **RESTRICT**; `production_orders`/`sales_price_history` **SET NULL**.
+
+## Gate de viabilidade (Fase 0 — antes de codar)
+**Probe no Omie** (read-only): confirmar que `ListarPedidos`/`ConsultarPedido` devolve `det.observacao.obs_item`/`det.inf_adic.dados_adicionais_item` com `"Cor: ..."` num pedido tintométrico tingido. A doc oficial do Omie (Codex) diz que sim; o probe elimina a incerteza antes do deploy. Se NÃO vier no list → cair pra `ConsultarPedido` por pedido (job rate-limited) no backfill.
+
+## Fases (ordem de valor → risco crescente)
+
+### Fase 1 — Cor no pipeline (BAIXO risco, valor pra frente)
+- Helper puro TDD `parseCorObs(obs)` → extrai `{ tint_cor_id?, tint_nome_cor }` de `"Cor: X - Y - emb"` (parsing **conservador**: remove sufixo de embalagem conhecido primeiro; não quebra nome com hífen; guarda bruto).
+- `sync_pedidos` (entrada) lê `det.observacao?.obs_item ?? det.inf_adic?.dados_adicionais_item`; se `"Cor: "`, popula `tint_nome_cor`/`tint_cor_id` no `itemsJson`. **Defensivo**: sem obs → comportamento atual (zero regressão).
+- Estender `OrderItemPayload` com os campos tint.
+- Drawer (`SalesOrderDetailSheet`): mostrar `{cor_id ? cor_id+' - ' : ''}{nome}` (não quebra com cor_id vazio).
+- Deploy edge (Lovable) + Publish frontend.
+- **Resultado:** pedidos novos/re-sincronizados passam a mostrar a cor. (Antigos: Fase 2.)
+
+### Fase 2 — Backfill da cor nos existentes (MÉDIO risco, NÃO destrutivo)
+- Action nova `backfill_tint_cor` (checkpointed + rate-limited): por pedido (com base tintométrica, sem cor), busca a obs no Omie e dá **UPDATE no jsonb** `items` por `omie_pedido_id` (sem mexer no hash, sem deletar nada).
+- **Resultado:** os pedidos antigos com cor no Omie passam a mostrar. **Aqui o founder vê a cor em massa.**
+
+### Fase 3 — Identidade canônica / upsert (MÉDIO risco)
+- `sync_pedidos` passa a **upsert/merge por `(account, omie_pedido_id)`** em vez de skip-by-hash: encontra o existente, faz UPDATE (status/valores/cor), **preserva a cor local** quando o Omie não devolver.
+- `hash_payload` deixa de ser identidade.
+- Centralizar **um** mapa de status (resolver o conflito `sync_pedidos` 50=separacao × `sync-reprocess` 50=faturado).
+- **Resultado:** o sync **para de criar novas duplicatas**.
+
+### Fase 4 — Dedup dos 172 + unicidade (ALTO risco, DESTRUTIVO — por último, com validação)
+- Migration de reparo: por par, escolher o canônico (merge: status mais avançado do sync + cor do wizard), **migrar referências** (`order_items`/`picking_tasks`/`farmer_calls`/`recommendation_log`/`production_orders`/`sales_price_history`) pro canônico, deletar o outro.
+- Índice único parcial `(account, omie_pedido_id)`.
+- **Dry-run + contagens antes/depois + backup**. Codex no design desta migration.
+
+## Riscos transversais (Codex) — endereçar no caminho
+- **OC elimina a cor no Omie**: `if (ordemCompra) ... else if (cor)` (index.ts:1364, 1819) são mutuamente exclusivos → pedido com ordem de compra **não** grava a cor no Omie. Gravar `numero_pedido_compra` **e** `Cor:` juntos (Fase 1 ou nota).
+- **Idempotência**: `codigo_pedido_integracao` usa `Date.now()` → retry pode duplicar no Omie. Derivar do `salesOrderId` (separado).
+- **Update local pós-Omie ignora erro**: Omie cria mas Supabase falha → órfão. Reconciliar (separado).
+
+## Decisões em aberto (resolver com diagnóstico na hora)
+- Fase 4: qual registro do par é o canônico (o que tem mais referências?) — medir antes.
+- Fase 2 vs 3: se a Fase 3 (upsert) já recupera a cor num re-sync controlado, a Fase 2 pode virar parte dela. Decidir após a Fase 1.
+
+## Não-objetivos
+- Reescrever todo o sync. Tabela lateral de cor (opção C) descartada (chave colide com SKU repetido; mais infra).

--- a/src/components/salesOrders/SalesOrderDetailSheet.tsx
+++ b/src/components/salesOrders/SalesOrderDetailSheet.tsx
@@ -79,7 +79,7 @@ export function SalesOrderDetailSheet({
                         <p className="truncate">{item.descricao || 'Item'}</p>
                         {item.tint_nome_cor && (
                           <p className="text-xs text-muted-foreground truncate">
-                            🎨 {item.tint_cor_id} - {item.tint_nome_cor}
+                            🎨 {item.tint_cor_id ? `${item.tint_cor_id} - ` : ''}{item.tint_nome_cor}
                           </p>
                         )}
                         <p className="text-xs text-muted-foreground">

--- a/src/components/salesOrders/__tests__/SalesOrderDetailSheet.test.tsx
+++ b/src/components/salesOrders/__tests__/SalesOrderDetailSheet.test.tsx
@@ -44,6 +44,11 @@ describe('SalesOrderDetailSheet', () => {
     expect(screen.getByText(/🎨\s*1247\s*-\s*AZUL RAL 5010/)).toBeTruthy();
   });
 
+  it('cor sem cor_id (vinda do sync do Omie) mostra só o nome, sem hífen órfão', () => {
+    setup(order({ items: [{ descricao: 'BASE BRILH BRANC PU', quantidade: 1, valor_unitario: 86, valor_total: 86, tint_nome_cor: 'AZUL RAL 5010' }] }));
+    expect(screen.getByText('🎨 AZUL RAL 5010')).toBeTruthy();
+  });
+
   it('item sem tinta não mostra linha de cor', () => {
     setup(order({ items: [{ descricao: 'CATALISADOR', quantidade: 1, valor_unitario: 40, valor_total: 40 }] }));
     expect(screen.queryByText(/🎨/)).toBeNull();

--- a/src/lib/tint/__tests__/parse-cor-obs.test.ts
+++ b/src/lib/tint/__tests__/parse-cor-obs.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { parseCorObs } from '../parse-cor-obs';
+
+describe('parseCorObs', () => {
+  it('extrai cor_id + nome + embalagem → mantém label, tira embalagem', () => {
+    expect(parseCorObs('Cor: 1247 - AZUL RAL 5010 - QT')).toEqual({ tint_nome_cor: '1247 - AZUL RAL 5010' });
+  });
+
+  it('nome sem cor_id separado + embalagem', () => {
+    expect(parseCorObs('Cor: AZUL RAL 5010 - QT')).toEqual({ tint_nome_cor: 'AZUL RAL 5010' });
+  });
+
+  it('sem embalagem mantém o label inteiro', () => {
+    expect(parseCorObs('Cor: 1247 - AZUL RAL 5010')).toEqual({ tint_nome_cor: '1247 - AZUL RAL 5010' });
+  });
+
+  it('só nome', () => {
+    expect(parseCorObs('Cor: AZUL RAL 5010')).toEqual({ tint_nome_cor: 'AZUL RAL 5010' });
+  });
+
+  it('embalagem em ML (com e sem espaço)', () => {
+    expect(parseCorObs('Cor: BRANCO - 450ML')).toEqual({ tint_nome_cor: 'BRANCO' });
+    expect(parseCorObs('Cor: VERDE - 405 ML')).toEqual({ tint_nome_cor: 'VERDE' });
+  });
+
+  it('NÃO quebra nome com hífen quando o sufixo não é embalagem conhecida', () => {
+    expect(parseCorObs('Cor: AZUL - VERDE')).toEqual({ tint_nome_cor: 'AZUL - VERDE' });
+    expect(parseCorObs('Cor: AZUL - 5010')).toEqual({ tint_nome_cor: 'AZUL - 5010' });
+  });
+
+  it('só remove embalagem no FIM (não no meio/começo)', () => {
+    expect(parseCorObs('Cor: 450ML AZUL')).toEqual({ tint_nome_cor: '450ML AZUL' });
+  });
+
+  it('prefixo case-insensitive + trim de espaços', () => {
+    expect(parseCorObs('cor:   AZUL  ')).toEqual({ tint_nome_cor: 'AZUL' });
+  });
+
+  it('ordem de compra (não é cor) → null', () => {
+    expect(parseCorObs('AFI-12345')).toBeNull();
+    expect(parseCorObs('Pedido compra 998')).toBeNull();
+  });
+
+  it('vazio/null/undefined → null', () => {
+    expect(parseCorObs('')).toBeNull();
+    expect(parseCorObs(null)).toBeNull();
+    expect(parseCorObs(undefined)).toBeNull();
+  });
+
+  it('só "Cor:" sem conteúdo (ou só embalagem) → null', () => {
+    expect(parseCorObs('Cor:')).toBeNull();
+    expect(parseCorObs('Cor:  - QT')).toBeNull();
+  });
+});

--- a/src/lib/tint/parse-cor-obs.ts
+++ b/src/lib/tint/parse-cor-obs.ts
@@ -1,0 +1,32 @@
+/**
+ * Extrai a cor da observação do item vinda do Omie.
+ *
+ * Na venda, o submit grava a cor como `obs_item`/`dados_adicionais_item` no
+ * formato `"Cor: <label> - <embalagem>"` (ex.: `"Cor: 1247 - AZUL RAL 5010 - QT"`,
+ * onde `<label>` = `"<cor_id> - <nome>"` ou só `"<nome>"`). Aqui fazemos o
+ * caminho inverso ao sincronizar o pedido de volta do Omie, para remontar
+ * `tint_nome_cor` no jsonb `sales_orders.items` (que o sync hoje descarta).
+ *
+ * Conservador (de propósito):
+ * - só reconhece o prefixo `Cor:` (case-insensitive);
+ * - remove o sufixo de embalagem conhecido (QT/GL/LT/<n>ML) só quando no FIM e
+ *   precedido de `" - "` — nunca quebra o nome da cor (que pode ter hífen);
+ * - mantém o label inteiro (código + nome) em `tint_nome_cor`, que já é legível;
+ * - retorna `null` quando não há cor (item comum / ordem de compra) — degradação
+ *   honesta, sem fabricar.
+ *
+ * ⚠️ Espelhado VERBATIM no edge `supabase/functions/omie-vendas-sync/index.ts`
+ * (Deno não importa de `src/`). Mantenha os dois em sincronia.
+ */
+export interface CorParseada {
+  tint_nome_cor: string;
+}
+
+export function parseCorObs(obs: string | null | undefined): CorParseada | null {
+  if (!obs) return null;
+  const m = /^\s*cor:\s*(.+)$/i.exec(obs);
+  if (!m) return null;
+  const label = m[1].replace(/\s*-\s*(?:QT|GL|LT|\d+(?:[.,]\d+)?\s*ML)\s*$/i, '').trim();
+  if (!label) return null;
+  return { tint_nome_cor: label };
+}

--- a/supabase/functions/omie-vendas-sync/index.ts
+++ b/supabase/functions/omie-vendas-sync/index.ts
@@ -77,6 +77,25 @@ interface OmieDetalheItem {
     cfop?: string;
   };
   imposto?: { cfop?: string };
+  // Observação/dados adicionais do item — o submit grava a cor da tinta aqui
+  // ("Cor: ..."). O sync de entrada extrai de volta (ver parseCorObs).
+  observacao?: { obs_item?: string };
+  inf_adic?: { dados_adicionais_item?: string };
+}
+
+/**
+ * Extrai a cor da tinta da observação do item do Omie. Espelho VERBATIM de
+ * `src/lib/tint/parse-cor-obs.ts` (Deno não importa de src/). Formato gravado
+ * pelo submit: "Cor: <label> - <embalagem>". Conservador: só prefixo "Cor:",
+ * remove embalagem conhecida no fim, não quebra nome com hífen, null sem cor.
+ */
+function parseCorObs(obs: string | null | undefined): { tint_nome_cor: string } | null {
+  if (!obs) return null;
+  const m = /^\s*cor:\s*(.+)$/i.exec(obs);
+  if (!m) return null;
+  const label = m[1].replace(/\s*-\s*(?:QT|GL|LT|\d+(?:[.,]\d+)?\s*ML)\s*$/i, '').trim();
+  if (!label) return null;
+  return { tint_nome_cor: label };
 }
 
 interface OmiePedidoCabecalho {
@@ -112,6 +131,8 @@ interface OrderItemPayload {
   quantidade: number;
   valor_unitario: number;
   desconto?: number;
+  tint_cor_id?: string;
+  tint_nome_cor?: string;
 }
 
 interface OrderBatchRow {
@@ -1092,12 +1113,17 @@ async function syncPedidos(
         const price = prod.valor_unitario || 0;
         const desc = prod.desconto || 0;
         subtotal += qty * price * (1 - desc / 100);
+        // Cor da tinta: preferimos obs_item (onde a cor sempre vai); o
+        // dados_adicionais_item pode conter ordem de compra (parseCorObs filtra
+        // por "Cor:", então não confunde). Sem cor → item comum.
+        const cor = parseCorObs(det.observacao?.obs_item ?? det.inf_adic?.dados_adicionais_item);
         itemsJson.push({
           omie_codigo_produto: prod.codigo_produto,
           descricao: prod.descricao || '',
           quantidade: qty,
           valor_unitario: price,
           desconto: desc,
+          ...(cor ? { tint_nome_cor: cor.tint_nome_cor } : {}),
         });
       }
 

--- a/supabase/functions/omie-vendas-sync/index.ts
+++ b/supabase/functions/omie-vendas-sync/index.ts
@@ -1607,6 +1607,95 @@ serve(async (req) => {
         break;
       }
 
+      case "backfill_tint_cor": {
+        // Fase 2 — backfill da cor da tinta nos pedidos JÁ sincronizados: re-lê a
+        // observação do item no Omie (que o sync de entrada descartava) e popula
+        // tint_nome_cor no jsonb `sales_orders.items`.
+        //   dry_run=true  → PROBE: amostra o que o Omie devolve (obs crua + cor
+        //                   parseada), NÃO altera nada. Use p/ confirmar a fonte.
+        //   dry_run=false → atualiza SÓ registros sem cor (idempotente, não toca
+        //                   o registro do wizard que já tem cor; não-destrutivo).
+        // Cursor por `start_page`; retorna `next_page` p/ retomar. Rate-limit via callOmie.
+        const bfDryRun = params.dry_run === true;
+        const bfNumeroPedido = params.numero_pedido ? Number(params.numero_pedido) : undefined;
+        let bfPagina = Number(params.start_page) || 1;
+        const bfMaxPages = Number(params.max_pages) || 5;
+        let bfTotalPaginas = 1;
+        let bfPages = 0;
+        let bfPedidosComCor = 0;
+        let bfPedidosAtualizados = 0;
+        const bfAmostra: Array<Record<string, unknown>> = [];
+
+        while ((bfPagina <= bfTotalPaginas || bfPages === 0) && bfPages < bfMaxPages) {
+          const bfParams: Record<string, unknown> = { pagina: bfPagina, registros_por_pagina: 50, filtrar_apenas_inclusao: "N" };
+          if (bfNumeroPedido) { bfParams.numero_pedido_de = bfNumeroPedido; bfParams.numero_pedido_ate = bfNumeroPedido; }
+          const bfRes = (await callOmieVendasApi("produtos/pedido/", "ListarPedidos", bfParams, account)) as OmieListarPedidosResponse | null;
+          if (!bfRes) break; // rate limit → retoma na próxima invocação
+          bfTotalPaginas = bfRes.total_de_paginas || 1;
+          const bfPedidos = bfRes.pedido_venda_produto || [];
+
+          for (const bfPedido of bfPedidos) {
+            const bfCab = bfPedido.cabecalho || {};
+            const bfCodigoPedido = bfCab.codigo_pedido;
+            if (!bfCodigoPedido) continue;
+            const bfDet: OmieDetalheItem[] = bfPedido.det || [];
+            let bfTemCor = false;
+            const bfItems: OrderItemPayload[] = bfDet.map((d) => {
+              const prod = d.produto || {};
+              const obsItem = d.observacao?.obs_item ?? d.inf_adic?.dados_adicionais_item;
+              const cor = parseCorObs(obsItem);
+              if (cor) bfTemCor = true;
+              // amostra do probe: só itens com observação preenchida (mostra a fonte crua).
+              if (bfDryRun && bfAmostra.length < 25 && obsItem) {
+                bfAmostra.push({
+                  numero_pedido: bfCab.numero_pedido,
+                  descricao: prod.descricao ?? null,
+                  obs_item: d.observacao?.obs_item ?? null,
+                  dados_adicionais_item: d.inf_adic?.dados_adicionais_item ?? null,
+                  cor_parseada: cor?.tint_nome_cor ?? null,
+                });
+              }
+              return {
+                omie_codigo_produto: prod.codigo_produto,
+                descricao: prod.descricao || '',
+                quantidade: prod.quantidade || 1,
+                valor_unitario: prod.valor_unitario || 0,
+                desconto: prod.desconto || 0,
+                ...(cor ? { tint_nome_cor: cor.tint_nome_cor } : {}),
+              };
+            });
+            if (bfTemCor) bfPedidosComCor++;
+            if (!bfDryRun && bfTemCor) {
+              // UPDATE só registros SEM cor (idempotente; não toca o do wizard que já tem).
+              const { data: bfRows } = await supabaseAdmin
+                .from('sales_orders')
+                .select('id, items')
+                .eq('account', account)
+                .eq('omie_pedido_id', bfCodigoPedido);
+              for (const bfRow of bfRows || []) {
+                const jaTemCor = JSON.stringify(bfRow.items ?? []).includes('tint_nome_cor');
+                if (!jaTemCor) {
+                  const { error: bfUpErr } = await supabaseAdmin.from('sales_orders').update({ items: bfItems }).eq('id', bfRow.id);
+                  if (!bfUpErr) bfPedidosAtualizados++;
+                }
+              }
+            }
+          }
+          bfPages++;
+          bfPagina++;
+        }
+        result = {
+          success: true,
+          dry_run: bfDryRun,
+          account,
+          pedidos_com_cor: bfPedidosComCor,
+          pedidos_atualizados: bfPedidosAtualizados,
+          next_page: bfPagina <= bfTotalPaginas ? bfPagina : null,
+          ...(bfDryRun ? { amostra: bfAmostra } : {}),
+        };
+        break;
+      }
+
       case "listar_clientes": {
         const { search } = params;
         if (!search || String(search).length < 2) throw new Error("Busca deve ter ao menos 2 caracteres");


### PR DESCRIPTION
## Contexto
A cor da tinta não aparecia no detalhe do pedido (PV 21755 etc.). Investigação confirmou: o display (PR #676) está correto, mas o **sync de entrada do Omie descarta a observação do item** onde a cor é gravada (`"Cor: 1247 - AZUL RAL 5010 - QT"`). Só **7 de 2603** pedidos têm a cor hoje.

Esta é a **Fase 1** de um plano de 4 fases ([plano completo](docs/superpowers/plans/2026-06-09-cor-tinta-detalhe-pedido-plano.md)), priorizado por valor → risco. O founder aprovou o caminho estrutural; esta fase é a de **menor risco** (entrada + display, defensivo).

## O que muda
- **`parseCorObs`** (helper puro TDD, `src/lib/tint/`, 11 testes): extrai a cor da observação (`"Cor: <label> - <embalagem>"`) de forma **conservadora** — só prefixo `Cor:`, remove embalagem conhecida (QT/GL/LT/ML) só no fim, **não quebra nome com hífen**, retorna `null` sem cor (degradação honesta). Espelhado **verbatim** no edge (Deno não importa de `src/`).
- **`omie-vendas-sync` (`sync_pedidos`):** lê `det.observacao.obs_item ?? det.inf_adic.dados_adicionais_item` e popula `tint_nome_cor` no jsonb `sales_orders.items`. **Defensivo:** sem obs → comportamento atual, **zero regressão**.
- **Drawer (`SalesOrderDetailSheet`):** `🎨 {cor_id ? cor_id+' - ' : ''}{nome}` — não mostra hífen órfão quando o `cor_id` vem vazio (pedidos do sync vêm só com o nome).

## Gate
- ✅ typecheck strict (0) · lint 0 errors · suíte 2800/2800 (16 novos: 11 parseCorObs + 5 drawer)

## ⚠️ Escopo desta fase
Faz **pedidos novos/re-sincronizados** mostrarem a cor. Os **pedidos já existentes** (como o PV 21755) só ganham a cor na **Fase 2 (backfill)** — esta fase não os altera.

## Deploy
- **Edge:** deploy do `omie-vendas-sync` via chat do Lovable (verbatim da main).
- **Frontend:** Publish (pro ajuste do drawer).

## Próximas fases (plano)
- **F2** backfill da cor nos existentes (não-destrutivo) → cor em massa.
- **F3** identidade canônica `(account, omie_pedido_id)` → sync para de duplicar (172 duplicados medidos).
- **F4** dedup destrutiva + índice único (por último, com Codex + dry-run).