### PR TITLE
fix(reposição): otimizador de compras — bugs money-path achados por revisão adversária (Codex)

### DIFF
--- a/scripts/mutcheck.d/compras-otimizador-helpers.mut
+++ b/scripts/mutcheck.d/compras-otimizador-helpers.mut
@@ -3,7 +3,7 @@
 # Invariantes money-path do otimizador de compras ("comprar mais?" net-R$ marginal por SKU).
 # Inclui as invariantes dos 2 bugs corrigidos (Codex 2026-06): prazo da faixa aplicável e frete-só-%.
 PEGA | descontoAplicavel pega o MAIOR (> -> <)        | s/f\.desconto_promo_perc > best/f.desconto_promo_perc < best/
-PEGA | prazoAplicavel faixa de MAIOR volume (bug 3)    | s/f\.volume_minimo > bestVol/f.volume_minimo < bestVol/
+PEGA | prazoAplicavel faixa de MAIOR volume (bug 3)    | s/f.volume_minimo > melhorVol/f.volume_minimo < melhorVol/
 PEGA | aplicarMinimoForcado piso (max -> min)          | s/Math\.max\(qtdeNatural, minimoForcado\)/Math.min(qtdeNatural, minimoForcado)/
 PEGA | quantidadeCompraInteira ceil -> floor           | s/Math\.ceil\(v\)/Math.floor(v)/
 PEGA | aumentoEvitado janela dias <=0 -> <0            | s/input\.dias_ate_aumento <= 0/input.dias_ate_aumento < 0/

--- a/scripts/mutcheck.d/compras-otimizador-helpers.mut
+++ b/scripts/mutcheck.d/compras-otimizador-helpers.mut
@@ -1,0 +1,13 @@
+# @src: src/lib/reposicao/compras-otimizador-helpers.ts
+# @test: src/lib/reposicao/__tests__/compras-otimizador-helpers.test.ts
+# Invariantes money-path do otimizador de compras ("comprar mais?" net-R$ marginal por SKU).
+# Inclui as invariantes dos 2 bugs corrigidos (Codex 2026-06): prazo da faixa aplicável e frete-só-%.
+PEGA | descontoAplicavel pega o MAIOR (> -> <)        | s/f\.desconto_promo_perc > best/f.desconto_promo_perc < best/
+PEGA | prazoAplicavel faixa de MAIOR volume (bug 3)    | s/f\.volume_minimo > bestVol/f.volume_minimo < bestVol/
+PEGA | aplicarMinimoForcado piso (max -> min)          | s/Math\.max\(qtdeNatural, minimoForcado\)/Math.min(qtdeNatural, minimoForcado)/
+PEGA | quantidadeCompraInteira ceil -> floor           | s/Math\.ceil\(v\)/Math.floor(v)/
+PEGA | aumentoEvitado janela dias <=0 -> <0            | s/input\.dias_ate_aumento <= 0/input.dias_ate_aumento < 0/
+PEGA | aumentoEvitado qElegivel max -> min             | s/Math\.max\(0, input\.q_cand - Math\.max/Math.min(0, input.q_cand - Math.max/
+PEGA | capitalExtra tempo do extra (0.5 -> 1.0)        | s/0\.5 \* \(input\.q_extra/1.0 * (input.q_extra/
+PEGA | frete só-% (remove /100 incremental)            | s/\(input\.frete_perc_valor \?\? 0\) \/ 100/(input.frete_perc_valor ?? 0) * 1/
+PEGA | recomendacao escopo sku (=== -> !==)            | s/ins\.escopo === 'sku' \? 'comprar_mais'/ins.escopo !== 'sku' ? 'comprar_mais'/

--- a/src/lib/reposicao/__tests__/compras-otimizador-helpers.test.ts
+++ b/src/lib/reposicao/__tests__/compras-otimizador-helpers.test.ts
@@ -13,10 +13,15 @@ describe('qtdMinimaEfetiva', () => {
 });
 
 describe('qtdBase', () => {
-  it('= max(qtde_base operacional, mínimo efetivo)', () => {
+  it('= max(qtde_base operacional, mínimo efetivo), arredondado ao lote', () => {
     expect(qtdBase({ qtde_base: 100, lote_minimo_fornecedor: 50, minimo_forcado_manual: null })).toBe(100);
     expect(qtdBase({ qtde_base: 100, lote_minimo_fornecedor: 50, minimo_forcado_manual: 200 })).toBe(200);
     expect(qtdBase({ qtde_base: 30, lote_minimo_fornecedor: 50, minimo_forcado_manual: null })).toBe(50);
+  });
+  it('arredonda ao múltiplo do lote (spec §2/§8; a RPC entrega qtde não-arredondada — re-Codex)', () => {
+    expect(qtdBase({ qtde_base: 101, lote_minimo_fornecedor: 50, minimo_forcado_manual: null })).toBe(150); // ceil(101/50)×50
+    expect(qtdBase({ qtde_base: 110, lote_minimo_fornecedor: 50, minimo_forcado_manual: null })).toBe(150);
+    expect(qtdBase({ qtde_base: 101, lote_minimo_fornecedor: null, minimo_forcado_manual: null })).toBe(101); // sem lote → ceil só
   });
 });
 
@@ -57,6 +62,16 @@ describe('prazoAplicavel — prazo da faixa de MAIOR volume aplicável (não a p
   it('q só na faixa baixa → prazo da baixa (0)', () => { expect(prazoAplicavel(curva, 150)).toBe(0); });
   it('q abaixo de tudo → null (cai no padrão no caller)', () => { expect(prazoAplicavel(curva, 50)).toBeNull(); });
   it('nenhuma faixa com prazo_perc → null', () => { expect(prazoAplicavel([{ volume_minimo: 100, desconto_promo_perc: 5 }], 200)).toBeNull(); });
+  it('faixa aplicável (maior volume) SEM prazo → null, NÃO herda o prazo de uma faixa menor (re-Codex)', () => {
+    const c = [{ volume_minimo: 100, desconto_promo_perc: 0, prazo_perc: 12 }, { volume_minimo: 300, desconto_promo_perc: 10 }];
+    expect(prazoAplicavel(c, 300)).toBeNull(); // faixa 300 (aplicável) não tem prazo → padrão, não o 12 da faixa 100
+  });
+  it('empate de volume → maior prazo (conservador, determinístico, independe da ordem)', () => {
+    const c1 = [{ volume_minimo: 300, desconto_promo_perc: 5, prazo_perc: 2 }, { volume_minimo: 300, desconto_promo_perc: 5, prazo_perc: 7 }];
+    const c2 = [{ volume_minimo: 300, desconto_promo_perc: 5, prazo_perc: 7 }, { volume_minimo: 300, desconto_promo_perc: 5, prazo_perc: 2 }];
+    expect(prazoAplicavel(c1, 300)).toBe(7);
+    expect(prazoAplicavel(c2, 300)).toBe(7);
+  });
 });
 
 describe('gerarCandidatos — q_base + thresholds + limites de aumento/ruptura, arredondados ao lote', () => {
@@ -192,10 +207,10 @@ describe('avaliarComprarMais — correções do review adversarial (Codex)', () 
     expect(r.q_candidata).toBe(300);
     expect(r.impacto_prazo_rs).toBeCloseTo(1800, 0); // (12−0)% × 15000 (faixa 300), NÃO 0 (faixa 100)
   });
-  it('flag defensiva: cm_anual ≤ 0 → flag + confiança não-alta (não assume custo de capital 0 calado)', () => {
+  it('cm_anual ≤ 0 → falta_dado (sem custo de capital não neta o carregamento; não assume custo 0)', () => {
     const r = avaliarComprarMais({ ...base, cm_anual: 0 });
+    expect(r.recomendacao).toBe('falta_dado');
     expect(r.flags.join(' ')).toMatch(/capital/i);
-    expect(r.confianca.nivel).not.toBe('alta');
   });
 });
 

--- a/src/lib/reposicao/__tests__/compras-otimizador-helpers.test.ts
+++ b/src/lib/reposicao/__tests__/compras-otimizador-helpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { qtdMinimaEfetiva, qtdBase, aplicarMinimoForcado, quantidadeCompraInteira, descontoAplicavel, gerarCandidatos } from '../compras-otimizador-helpers';
+import { qtdMinimaEfetiva, qtdBase, aplicarMinimoForcado, quantidadeCompraInteira, descontoAplicavel, prazoAplicavel, gerarCandidatos } from '../compras-otimizador-helpers';
 import { capitalExtra, aumentoEvitadoRs, impactoPrazoRs, freteIncrementalRs, descontoIncrementalRs } from '../compras-otimizador-helpers';
 import { avaliarComprarMais } from '../compras-otimizador-helpers';
 import type { InsumoSku } from '../compras-otimizador-helpers';
@@ -49,6 +49,14 @@ describe('descontoAplicavel — melhor faixa cujo volume_minimo ≤ q', () => {
   it('q abaixo de tudo → 0', () => { expect(descontoAplicavel(curva, 50)).toBe(0); });
   it('q na 1ª faixa → 5', () => { expect(descontoAplicavel(curva, 150)).toBe(5); });
   it('q na 2ª faixa → 8 (melhor)', () => { expect(descontoAplicavel(curva, 400)).toBe(8); });
+});
+
+describe('prazoAplicavel — prazo da faixa de MAIOR volume aplicável (não a primeira)', () => {
+  const curva = [{ volume_minimo: 100, desconto_promo_perc: 0, prazo_perc: 0 }, { volume_minimo: 300, desconto_promo_perc: 10, prazo_perc: 12 }];
+  it('q atinge a faixa alta → prazo dela (12), não o da primeira (0)', () => { expect(prazoAplicavel(curva, 300)).toBe(12); });
+  it('q só na faixa baixa → prazo da baixa (0)', () => { expect(prazoAplicavel(curva, 150)).toBe(0); });
+  it('q abaixo de tudo → null (cai no padrão no caller)', () => { expect(prazoAplicavel(curva, 50)).toBeNull(); });
+  it('nenhuma faixa com prazo_perc → null', () => { expect(prazoAplicavel([{ volume_minimo: 100, desconto_promo_perc: 5 }], 200)).toBeNull(); });
 });
 
 describe('gerarCandidatos — q_base + thresholds + limites de aumento/ruptura, arredondados ao lote', () => {
@@ -102,10 +110,12 @@ describe('impactoPrazoRs — (prazo_cand% − prazo_padrão%) × valor_candidato
   });
 });
 
-describe('freteIncrementalRs — % valor + fixo + taxa de pedido sobre o incremento', () => {
-  it('soma as 3 formas sobre o valor extra', () => {
-    const r = freteIncrementalRs({ valor_extra: 10000, frete_perc_valor: 2, frete_fixo: 0, frete_taxa_pedido: 0 });
-    expect(r).toBeCloseTo(200, 2);
+describe('freteIncrementalRs — só o % do valor (fixo/taxa por-pedido são SUNK no mesmo pedido)', () => {
+  it('% sobre o valor extra', () => {
+    expect(freteIncrementalRs({ valor_extra: 10000, frete_perc_valor: 2 })).toBeCloseTo(200, 2);
+  });
+  it('frete_perc nulo → 0', () => {
+    expect(freteIncrementalRs({ valor_extra: 10000, frete_perc_valor: null })).toBe(0);
   });
 });
 
@@ -162,6 +172,30 @@ describe('avaliarComprarMais — oportunidade só de aumento', () => {
     expect(r.q_candidata).toBe(400);
     expect(r.aumento_evitado_rs).toBeGreaterThan(0);
     expect(r.recomendacao).toBe('comprar_mais');
+  });
+});
+
+// Correções do adversarial review (Codex, 2026-06) — bugs em caminhos NÃO-testados.
+// (Confirmados no spec 2026-05-25-otimizador-compras-design.md; semântica "comprar mais = aumentar
+// o MESMO pedido" confirmada pelo founder → frete fixo/taxa por-pedido são SUNK, não incrementais.)
+describe('avaliarComprarMais — correções do review adversarial (Codex)', () => {
+  it('bug 1: frete fixo/taxa NÃO rebaixa comprar_mais (mesmo pedido → sunk, não incremental)', () => {
+    // o frete_fixo/taxa seria pago no pedido base de qualquer forma → não é custo marginal de comprar mais.
+    const r = avaliarComprarMais({ ...base, frete_fixo: 999999, frete_taxa_pedido: 999999 });
+    expect(r.recomendacao).toBe('comprar_mais');
+    expect(r.frete_incremental_rs).toBe(0); // só o % do valor entra; aqui frete_perc=0
+  });
+  it('bug 3: prazo da faixa de MAIOR volume aplicável, não a primeira (.find pegava a 1ª)', () => {
+    // curva: 100→prazo 0, 300→prazo 12 (encargo). Comprando 300 o prazo aplicável é 12, não 0.
+    const r = avaliarComprarMais({ ...base, prazo_padrao_perc: 0,
+      curva_desconto: [{ volume_minimo: 100, desconto_promo_perc: 0, prazo_perc: 0 }, { volume_minimo: 300, desconto_promo_perc: 50, prazo_perc: 12 }] });
+    expect(r.q_candidata).toBe(300);
+    expect(r.impacto_prazo_rs).toBeCloseTo(1800, 0); // (12−0)% × 15000 (faixa 300), NÃO 0 (faixa 100)
+  });
+  it('flag defensiva: cm_anual ≤ 0 → flag + confiança não-alta (não assume custo de capital 0 calado)', () => {
+    const r = avaliarComprarMais({ ...base, cm_anual: 0 });
+    expect(r.flags.join(' ')).toMatch(/capital/i);
+    expect(r.confianca.nivel).not.toBe('alta');
   });
 });
 

--- a/src/lib/reposicao/compras-otimizador-helpers.ts
+++ b/src/lib/reposicao/compras-otimizador-helpers.ts
@@ -12,7 +12,10 @@ export function qtdMinimaEfetiva(lote: number | null, forcado: number | null): n
 }
 
 export function qtdBase(input: { qtde_base: number | null; lote_minimo_fornecedor: number | null; minimo_forcado_manual: number | null }): number {
-  return Math.max(input.qtde_base ?? 0, qtdMinimaEfetiva(input.lote_minimo_fornecedor, input.minimo_forcado_manual));
+  // Spec §2/§8: q_base arredondado ao múltiplo do lote. A RPC entrega a qtde do ciclo via EOQ+ceil
+  // SEM arredondar ao lote do fornecedor (re-Codex verificou a RPC) → arredondamos aqui. Sem lote → só ceil.
+  const bruto = Math.max(input.qtde_base ?? 0, qtdMinimaEfetiva(input.lote_minimo_fornecedor, input.minimo_forcado_manual));
+  return arredondaLote(bruto, input.lote_minimo_fornecedor);
 }
 
 // Piso de quantidade por "mínimo de compra forçado" por SKU (a "R" pedida pelo founder).
@@ -53,12 +56,17 @@ export function descontoAplicavel(curva: FaixaDesconto[], q: number): number {
 // (a de menor volume) e subestimava o encargo de prazo em curvas progressivas (achado do Codex).
 // null = nenhuma faixa com prazo aplicável (cai no prazo_padrao no caller).
 export function prazoAplicavel(curva: FaixaDesconto[], q: number): number | null {
-  let best: number | null = null;
-  let bestVol = -1;
+  // Prazo da faixa de MAIOR volume aplicável (≤ q) — o prazo é o DELA (ou null se ela não tem prazo).
+  // NÃO herda o prazo de uma faixa de volume MENOR (re-Codex: faixa-aplicável-sem-prazo → cai no padrão,
+  // não no prazo de uma faixa abaixo). Empate de volume → maior prazo_perc (conservador, determinístico).
+  let melhorVol = -1;
+  for (const f of curva) { if (q >= f.volume_minimo && f.volume_minimo > melhorVol) melhorVol = f.volume_minimo; }
+  if (melhorVol < 0) return null;
+  let prazo: number | null = null;
   for (const f of curva) {
-    if (q >= f.volume_minimo && f.prazo_perc != null && f.volume_minimo > bestVol) { best = f.prazo_perc; bestVol = f.volume_minimo; }
+    if (f.volume_minimo === melhorVol && f.prazo_perc != null && (prazo == null || f.prazo_perc > prazo)) prazo = f.prazo_perc;
   }
-  return best;
+  return prazo;
 }
 
 function arredondaLote(q: number, lote: number | null): number {
@@ -175,21 +183,22 @@ export function avaliarComprarMais(ins: InsumoSku): DecisaoCompra {
   const motivos: string[] = [];
   const q_base = qtdBase(ins);
 
-  if ((ins.demanda_diaria ?? 0) <= 0 || (ins.qtde_base ?? 0) <= 0) {
+  // Custo de capital ausente/≤0 NÃO é "capital grátis" — é config faltando. Sem ele não dá pra netar o
+  // carregamento → falta_dado (re-Codex; alinha com o A4 "nunca assume custo 0"), não recomenda às cegas.
+  const semCapital = !Number.isFinite(ins.cm_anual) || ins.cm_anual <= 0;
+  if ((ins.demanda_diaria ?? 0) <= 0 || (ins.qtde_base ?? 0) <= 0 || semCapital) {
     return {
       empresa: ins.empresa, sku: ins.sku, fornecedor: ins.fornecedor, q_base, q_candidata: q_base, q_extra: 0,
       dias_cobertura_extra: 0, desconto_rs: 0, aumento_evitado_rs: 0, ruptura_evitada_rs: 0, capital_extra_rs: 0,
       impacto_prazo_rs: 0, frete_incremental_rs: 0, beneficio_liquido_rs: 0, recomendacao: 'falta_dado',
       escopo: ins.escopo, eoq_recalculo_ignorado: true,
-      flags: [...flags, 'Sem demanda/qtde de ciclo — não dá pra dimensionar.'],
-      confianca: { nivel: 'baixa', motivos: ['Faltam demanda/qtde base.'] },
+      flags: [...flags, semCapital ? 'Custo de capital ausente/≤0 — sem custo de carregamento não dá pra netar.' : 'Sem demanda/qtde de ciclo — não dá pra dimensionar.'],
+      confianca: { nivel: 'baixa', motivos: [semCapital ? 'Custo de capital não configurado.' : 'Faltam demanda/qtde base.'] },
     };
   }
 
   if (ins.ruptura_valor_estimado != null) motivos.push('Benefício de ruptura não estimado (conservador = 0).');
   flags.push('Benefício de ruptura não estimado (conservador, fase 1).');
-  // Degradação honesta: custo de capital ausente/zerado NÃO é "capital grátis" — é config faltando.
-  if (ins.cm_anual <= 0) { flags.push('Custo de capital ≤ 0 — capital extra não penalizado (config ausente?).'); motivos.push('Custo de capital não configurado.'); }
   // Frete fixo/taxa por-pedido são SUNK (mesmo pedido) → fora do net marginal; sinaliza pro comprador.
   if ((ins.frete_fixo ?? 0) > 0 || (ins.frete_taxa_pedido ?? 0) > 0) flags.push('Frete fixo/taxa de pedido no fornecedor — SUNK no mesmo pedido, fora da decisão marginal.');
 

--- a/src/lib/reposicao/compras-otimizador-helpers.ts
+++ b/src/lib/reposicao/compras-otimizador-helpers.ts
@@ -48,6 +48,19 @@ export function descontoAplicavel(curva: FaixaDesconto[], q: number): number {
   return best;
 }
 
+// Prazo da faixa de MAIOR volume aplicável (≤ q) com prazo_perc definido — espelha descontoAplicavel
+// (a faixa que você ATINGE é a de maior volume). NÃO o antigo `.find`, que pegava a 1ª faixa com prazo
+// (a de menor volume) e subestimava o encargo de prazo em curvas progressivas (achado do Codex).
+// null = nenhuma faixa com prazo aplicável (cai no prazo_padrao no caller).
+export function prazoAplicavel(curva: FaixaDesconto[], q: number): number | null {
+  let best: number | null = null;
+  let bestVol = -1;
+  for (const f of curva) {
+    if (q >= f.volume_minimo && f.prazo_perc != null && f.volume_minimo > bestVol) { best = f.prazo_perc; bestVol = f.volume_minimo; }
+  }
+  return best;
+}
+
 function arredondaLote(q: number, lote: number | null): number {
   if (!lote || lote <= 0) return Math.ceil(q);
   return Math.ceil(q / lote) * lote;
@@ -100,9 +113,12 @@ export function impactoPrazoRs(input: { prazo_cand_perc: number | null; prazo_pa
   return (cand - padrao) / 100 * input.valor_candidato; // + = encargo (custo); − = desconto (benefício)
 }
 
-export function freteIncrementalRs(input: { valor_extra: number; frete_perc_valor: number | null; frete_fixo: number | null; frete_taxa_pedido: number | null }): number {
-  const perc = (input.frete_perc_valor ?? 0) / 100 * input.valor_extra;
-  return perc + (input.frete_fixo ?? 0) + (input.frete_taxa_pedido ?? 0);
+// Frete INCREMENTAL de comprar mais. Como "comprar mais" = aumentar o MESMO pedido (não um pedido
+// separado — semântica confirmada pelo founder 2026-06), só o frete % do valor escala com a qtd extra.
+// Frete FIXO e TAXA DE PEDIDO são por-pedido → o pedido base já os paga → SUNK, não incrementais
+// (achado do Codex; o spec §2/§8 "modela os 3" era impreciso). Eles viram flag informativa, não custo.
+export function freteIncrementalRs(input: { valor_extra: number; frete_perc_valor: number | null }): number {
+  return (input.frete_perc_valor ?? 0) / 100 * input.valor_extra;
 }
 
 export function descontoIncrementalRs(input: { curva: FaixaDesconto[]; q_cand: number; q_base: number; preco_unit: number }): number {
@@ -172,6 +188,10 @@ export function avaliarComprarMais(ins: InsumoSku): DecisaoCompra {
 
   if (ins.ruptura_valor_estimado != null) motivos.push('Benefício de ruptura não estimado (conservador = 0).');
   flags.push('Benefício de ruptura não estimado (conservador, fase 1).');
+  // Degradação honesta: custo de capital ausente/zerado NÃO é "capital grátis" — é config faltando.
+  if (ins.cm_anual <= 0) { flags.push('Custo de capital ≤ 0 — capital extra não penalizado (config ausente?).'); motivos.push('Custo de capital não configurado.'); }
+  // Frete fixo/taxa por-pedido são SUNK (mesmo pedido) → fora do net marginal; sinaliza pro comprador.
+  if ((ins.frete_fixo ?? 0) > 0 || (ins.frete_taxa_pedido ?? 0) > 0) flags.push('Frete fixo/taxa de pedido no fornecedor — SUNK no mesmo pedido, fora da decisão marginal.');
 
   const candidatos = gerarCandidatos({ q_base, lote: ins.lote_minimo_fornecedor, demanda_diaria: ins.demanda_diaria,
     curva: ins.curva_desconto, dias_ate_aumento: ins.dias_ate_aumento, ruptura_dias: ins.ruptura_dias,
@@ -187,10 +207,9 @@ export function avaliarComprarMais(ins: InsumoSku): DecisaoCompra {
     const aumento_evitado_rs = aumentoEvitadoRs({ q_cand, q_base, demanda_diaria: ins.demanda_diaria, dias_ate_aumento: ins.dias_ate_aumento, aumento_perc: ins.aumento_evitado_perc, preco_unit: ins.preco_unit });
     const ruptura_evitada_rs = 0;
     const capital_extra_rs = capitalExtra({ valor_extra, cm_anual: ins.cm_anual, demanda_diaria: ins.demanda_diaria, q_base, q_extra });
-    const faixaCand = ins.curva_desconto.find((f) => q_cand >= f.volume_minimo && f.prazo_perc != null);
-    const prazo_cand_perc = faixaCand?.prazo_perc ?? ins.prazo_padrao_perc;
+    const prazo_cand_perc = prazoAplicavel(ins.curva_desconto, q_cand) ?? ins.prazo_padrao_perc;
     const impacto_prazo_rs = impactoPrazoRs({ prazo_cand_perc, prazo_padrao_perc: ins.prazo_padrao_perc, valor_candidato });
-    const frete_incremental_rs = freteIncrementalRs({ valor_extra, frete_perc_valor: ins.frete_perc_valor, frete_fixo: ins.frete_fixo, frete_taxa_pedido: ins.frete_taxa_pedido });
+    const frete_incremental_rs = freteIncrementalRs({ valor_extra, frete_perc_valor: ins.frete_perc_valor });
     const beneficio_liquido_rs = desconto_rs + aumento_evitado_rs + ruptura_evitada_rs - capital_extra_rs - impacto_prazo_rs - frete_incremental_rs;
     const cand: DecisaoCompra = {
       empresa: ins.empresa, sku: ins.sku, fornecedor: ins.fornecedor, q_base, q_candidata: q_cand, q_extra,


### PR DESCRIPTION
Sessão com o Codex num helper money-path real (decisão "comprar mais?" net-R$ marginal → dispara compra ao fornecedor). Dois passes adversariais + confirmação no spec + TDD + mutcheck.

## Como foi (o método)
1. **Codex passe 1** rodou o helper de verdade (`bun -e`) e achou **5 candidatos** de bug.
2. **Confirmei no spec** (`2026-05-25-otimizador-compras-design.md`) + com o founder → separou bug de modelagem: 2 reais, 1 flag, **2 não-bugs** (corrigir teria quebrado a modelagem correta).
3. **TDD** (RED→GREEN) + **mutcheck** (9/9 invariantes com poder de teste).
4. **Codex passe 2 (sobre o fix)** achou **+4 furos no próprio fix** — incl. 1 que eu havia **refutado errado**.

## Bugs corrigidos
- **Frete fixo/taxa** eram somados ao net marginal como incrementais. Sendo o **mesmo pedido**, são **SUNK** → penalizavam o net e **recusavam compras vantajosas**. Fix: `frete_incremental = só % do valor`.
- **`faixaCand` (`.find`)** pegava a 1ª faixa com prazo (menor volume) → subestimava o encargo de prazo → recomendava **comprar demais**. Fix: nova `prazoAplicavel` (faixa de maior volume aplicável).
- **`prazoAplicavel` (passe 2)** herdava o prazo de uma faixa **menor** quando a faixa aplicável não tinha prazo. Fix: prazo **da** faixa aplicável (ou padrão); empate determinístico.
- **`qtdBase` não arredondava ao lote** (passe 2 — eu refutei como "a RPC já arredonda"; o Codex **leu a RPC** e provou que não). Spec §2/§8 exige. Fix: arredonda.
- **`cm_anual ≤ 0`** → `falta_dado` (não recomenda sem custo de capital; "nunca assume custo 0").

## Não-bugs (confirmados no spec, deixados intactos)
- `impacto_prazo` usa `(cand−padrão)×valor_candidato` **de propósito** (o extra seria comprado depois a prazo padrão). Corrigir teria quebrado.

## Validação
- TDD: testes RED→GREEN por bug + unit de `prazoAplicavel`/`qtdBase`. Helper **42/42**, projeto **2799/2799**, `typecheck` 0.
- `mutcheck` **9/9** invariantes (`scripts/mutcheck.d/compras-otimizador-helpers.mut`) — trava o poder-de-teste contra regressão.
- **Sem migration / edge / deploy** (helper client-side puro). Frontend ainda não injeta `prazo_perc` → os fixes de prazo são corretos-preventivos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
