### PR TITLE
fix(financeiro): A4 próxima ação — invariantes "ausente≠0" (revisão adversária Codex)

### DIFF
--- a/scripts/mutcheck.d/next-best-action-helpers.mut
+++ b/scripts/mutcheck.d/next-best-action-helpers.mut
@@ -1,0 +1,11 @@
+# @src: src/lib/financeiro/next-best-action-helpers.ts
+# @test: src/lib/financeiro/__tests__/next-best-action-helpers.test.ts
+# Invariantes money-path do A4 (fila priorizada de alocação de capital que o CFO segue).
+# Inclui as invariantes dos furos corrigidos (Codex 2026-06): "ausente ≠ R$0" na ordenação,
+# crescer nunca-grátis, hurdle ≤0 implausível, confiança do candidato no rollup.
+PEGA | #6 crescer custo ≤0 deixa de cair em falta_dado | s/ \|\| input\.caixa_consumido <= 0//
+PEGA | #7 hurdle aceita ≤0 (> vira >=)                 | s/x > 0/x >= 0/
+PEGA | #7b hurdle de entrada aceita ≤0 (> vira >=)     | s/hurdleRaw > 0 \? hurdleRaw/hurdleRaw >= 0 ? hurdleRaw/
+PEGA | #2 custo null vira "grátis" (bucket 2 -> 0)     | s/\? 1 : 2\)/? 1 : 0)/
+PEGA | #3 EVA null vira ratio 0 (remove guard != null) | s/ && x\.impacto_eva != null//
+PEGA | #9 rollup ignora confiança do candidato         | s/fila\.some\(\(a\) => a\.confianca === 'baixa'\)/false/

--- a/src/lib/financeiro/__tests__/next-best-action-helpers.test.ts
+++ b/src/lib/financeiro/__tests__/next-best-action-helpers.test.ts
@@ -120,3 +120,81 @@ describe('montarFilaAcoes', () => {
     expect(r.fila.find((a) => a.empresa === 'oben' && a.tipo === 'crescer')!.status).toBe('financiar_condicional');
   });
 });
+
+// ── Correções da revisão adversarial (Codex) — invariante "ausente ≠ R$0" no A4 ──
+describe('A4 — invariantes (revisão adversarial Codex)', () => {
+  // #6 — crescer SEMPRE consome caixa (NCG); custo 0/negativo é dado implausível, não "grátis".
+  it('#6 crescer com custo de caixa 0 → falta_dado (não financia como se fosse grátis)', () => {
+    expect(classificarStatus({ tipo: 'crescer', impacto_eva: 8000, spread_positivo: true, caixa_consumido: 0, caixa_disponivel: 999999, hurdle: 0.2, tem_dado: true })).toBe('falta_dado');
+  });
+  it('#6 crescer com custo de caixa negativo → falta_dado', () => {
+    expect(classificarStatus({ tipo: 'crescer', impacto_eva: 8000, spread_positivo: true, caixa_consumido: -5000, caixa_disponivel: 999999, hurdle: 0.2, tem_dado: true })).toBe('falta_dado');
+  });
+
+  // #7 — hurdle ≤0 é implausível (custo de capital); pula pro próximo fallback (coerência com guards A2/A3).
+  it('#7 WACC 0 → pula pro próximo fallback (não aceita hurdle não-positivo)', () => {
+    const r = hurdleEfetivo({ wacc: 0, custo_divida_pos_imposto: 0.14, retorno_minimo_dono: 0.25, mediana_hurdles: 0.18 });
+    expect(r.hurdle).toBe(0.25); expect(r.fonte).toBe('retorno_dono');
+  });
+  it('#7 WACC negativo → pula pro próximo fallback', () => {
+    const r = hurdleEfetivo({ wacc: -0.05, custo_divida_pos_imposto: null, retorno_minimo_dono: null, mediana_hurdles: 0.18 });
+    expect(r.hurdle).toBe(0.18); expect(r.fonte).toBe('mediana');
+  });
+  it('#7 todos os candidatos a hurdle ≤0 → null/indisponivel (nunca fabrica hurdle não-positivo)', () => {
+    const r = hurdleEfetivo({ wacc: 0, custo_divida_pos_imposto: -0.01, retorno_minimo_dono: 0, mediana_hurdles: 0 });
+    expect(r.hurdle).toBeNull(); expect(r.fonte).toBe('indisponivel');
+  });
+
+  // #7b — a edge NÃO usa hurdleEfetivo (passa o WACC cru). A defesa contra hurdle ≤0 tem de estar na entrada da fila.
+  it('#7b hurdle ≤0 vindo do engine é tratado como ausente → crescer cai em falta_dado', () => {
+    const r = montarFilaAcoes({
+      candidatos: [cand({ empresa: 'oben', tipo: 'crescer', spread_positivo: true, caixa_consumido: 10000 })],
+      caixaPorEmpresa: { oben: { disponivel: 100000, confianca: 'alta' } },
+      hurdlePorEmpresa: { oben: 0 },
+    });
+    const a = r.fila.find((x) => x.empresa === 'oben' && x.tipo === 'crescer')!;
+    expect(a.hurdle).toBeNull();
+    expect(a.status).toBe('falta_dado');
+  });
+
+  // #2 — custo DESCONHECIDO (null) não pode ser ordenado como "grátis/retorno infinito" (ausente ≠ 0).
+  it('#2 crescer com custo null fica APÓS os dimensionados (não vira grátis/Infinity na fila)', () => {
+    const r = montarFilaAcoes({
+      candidatos: [
+        cand({ tipo: 'crescer', descricao: 'custo desconhecido', impacto_eva: null, caixa_consumido: null, spread_positivo: true }),
+        cand({ tipo: 'crescer', descricao: 'dimensionado', impacto_eva: 5000, caixa_consumido: 10000, spread_positivo: true }),
+      ],
+      caixaPorEmpresa: { oben: { disponivel: 200000, confianca: 'alta' } },
+      hurdlePorEmpresa: { oben: 0.2 },
+    });
+    const crescer = r.fila.filter((a) => a.tipo === 'crescer');
+    expect(crescer[0].descricao).toBe('dimensionado');
+    expect(crescer[crescer.length - 1].descricao).toBe('custo desconhecido');
+  });
+
+  // #3 — EVA ausente (null) não pode virar ratio 0 (ficaria à frente de EVA negativo conhecido).
+  it('#3 EVA null não é tratado como 0 no ratio: o de EVA conhecido ordena por ratio, o desconhecido vai ao fim', () => {
+    const r = montarFilaAcoes({
+      candidatos: [
+        cand({ tipo: 'crescer', descricao: 'eva desconhecido', impacto_eva: null, caixa_consumido: 10000, spread_positivo: false }),
+        cand({ tipo: 'crescer', descricao: 'eva negativo', impacto_eva: -1000, caixa_consumido: 10000, spread_positivo: false }),
+      ],
+      caixaPorEmpresa: { oben: { disponivel: 200000, confianca: 'alta' } },
+      hurdlePorEmpresa: { oben: 0.2 },
+    });
+    const crescer = r.fila.filter((a) => a.tipo === 'crescer');
+    // atual (buggy): eva null→0 fica ANTES de -1000. Correto: ratio conhecido (mesmo negativo) ordena; o desconhecido vai ao fim.
+    expect(crescer[0].descricao).toBe('eva negativo');
+    expect(crescer[1].descricao).toBe('eva desconhecido');
+  });
+
+  // #9 — o rollup de confiança diz "pior sinal entre caixa/candidatos" mas ignorava candidato.confianca.
+  it('#9 candidato de confiança baixa rebaixa o rollup da fila (não fica "alta")', () => {
+    const r = montarFilaAcoes({
+      candidatos: [cand({ empresa: 'oben', tipo: 'consertar_valor', descricao: 'sleeve incerto', impacto_eva: 1000, caixa_consumido: 0, confianca: 'baixa' })],
+      caixaPorEmpresa: { oben: { disponivel: 100000, confianca: 'alta' } },
+      hurdlePorEmpresa: { oben: 0.2 },
+    });
+    expect(r.confianca.nivel).not.toBe('alta');
+  });
+});

--- a/src/lib/financeiro/next-best-action-helpers.ts
+++ b/src/lib/financeiro/next-best-action-helpers.ts
@@ -22,10 +22,13 @@ export function hurdleEfetivo(input: {
   retorno_minimo_dono: number | null;
   mediana_hurdles: number | null;
 }): { hurdle: number | null; fonte: FonteHurdle } {
-  if (input.wacc != null) return { hurdle: input.wacc, fonte: 'wacc' };
-  if (input.retorno_minimo_dono != null) return { hurdle: input.retorno_minimo_dono, fonte: 'retorno_dono' };
-  if (input.custo_divida_pos_imposto != null) return { hurdle: input.custo_divida_pos_imposto, fonte: 'custo_divida' };
-  if (input.mediana_hurdles != null) return { hurdle: input.mediana_hurdles, fonte: 'mediana' };
+  // hurdle ≤0 é implausível (custo de capital nunca é não-positivo) → trata como ausente e pula pro próximo
+  // fallback. Coerente com os guards do A2/A3 ("soma ≤0 = capital grátis → null"). "ausente ≠ R$0".
+  const ok = (x: number | null): x is number => x != null && Number.isFinite(x) && x > 0;
+  if (ok(input.wacc)) return { hurdle: input.wacc, fonte: 'wacc' };
+  if (ok(input.retorno_minimo_dono)) return { hurdle: input.retorno_minimo_dono, fonte: 'retorno_dono' };
+  if (ok(input.custo_divida_pos_imposto)) return { hurdle: input.custo_divida_pos_imposto, fonte: 'custo_divida' };
+  if (ok(input.mediana_hurdles)) return { hurdle: input.mediana_hurdles, fonte: 'mediana' };
   return { hurdle: null, fonte: 'indisponivel' };
 }
 
@@ -49,8 +52,9 @@ export function classificarStatus(input: {
   if (input.tipo === 'crescer') {
     if (input.spread_positivo !== true) return 'nao_financiar';
     // Sem custo estimado (ex.: sleeve company-level ou "crescer" do cockpit sem ticket) → precisa
-    // dimensionar antes de financiar. NÃO assume custo 0 (crescer consome caixa via NCG).
-    if (input.caixa_consumido == null) return 'falta_dado';
+    // dimensionar antes de financiar. NÃO assume custo 0/negativo: crescer SEMPRE consome caixa via
+    // NCG, então custo ≤0 é dado implausível, não "grátis". "ausente ≠ R$0".
+    if (input.caixa_consumido == null || input.caixa_consumido <= 0) return 'falta_dado';
     return input.caixa_consumido <= input.caixa_disponivel ? 'financiar_ja' : 'financiar_condicional';
   }
   return 'falta_dado';
@@ -86,7 +90,10 @@ export function montarFilaAcoes(input: {
   candidatos.push({ empresa: '—', descricao: 'Não fazer nada / pagar dívida / distribuir ao dono (benchmark do hurdle)', tipo: 'benchmark', impacto_eva: null, caixa_consumido: 0, payback_meses: null, spread_positivo: null, confianca: 'alta' });
 
   const fila: AcaoFila[] = candidatos.map((c) => {
-    const hurdle = c.empresa in input.hurdlePorEmpresa ? input.hurdlePorEmpresa[c.empresa] : null;
+    // A edge passa o WACC cru (não chama hurdleEfetivo) → a defesa contra hurdle ≤0 tem de estar aqui:
+    // hurdle implausível (≤0) é tratado como ausente → crescer cai em falta_dado (não financia no escuro).
+    const hurdleRaw = c.empresa in input.hurdlePorEmpresa ? input.hurdlePorEmpresa[c.empresa] : null;
+    const hurdle = hurdleRaw != null && Number.isFinite(hurdleRaw) && hurdleRaw > 0 ? hurdleRaw : null;
     const caixaDisp = input.caixaPorEmpresa[c.empresa]?.disponivel ?? 0;
     // tem_dado: crescer precisa de hurdle + sinal de spread; consertar/liberar/benchmark sempre têm.
     const tem_dado = c.tipo === 'crescer' ? (hurdle != null && c.spread_positivo != null) : true;
@@ -94,15 +101,22 @@ export function montarFilaAcoes(input: {
     return { ...c, hurdle, status };
   });
 
-  // Ordena: por prioridade de tipo; dentro do tipo, sem-caixa antes; depois EVA/caixa desc; payback asc.
+  // Ordena: por prioridade de tipo; dentro do tipo, por bucket de custo; depois EVA/caixa desc; payback asc.
+  // "ausente ≠ R$0": custo null NÃO é tratado como grátis (0) e EVA null NÃO vira ratio 0 — ambos vão
+  // para o fim do seu critério em vez de fabricar um número que reordenaria a fila.
   fila.sort((a, b) => {
     if (PRIORIDADE_TIPO[a.tipo] !== PRIORIDADE_TIPO[b.tipo]) return PRIORIDADE_TIPO[a.tipo] - PRIORIDADE_TIPO[b.tipo];
-    const semCaixaA = (a.caixa_consumido ?? 0) === 0 ? 0 : 1;
-    const semCaixaB = (b.caixa_consumido ?? 0) === 0 ? 0 : 1;
-    if (semCaixaA !== semCaixaB) return semCaixaA - semCaixaB;
-    const ratioA = a.caixa_consumido && a.caixa_consumido > 0 ? (a.impacto_eva ?? 0) / a.caixa_consumido : Infinity;
-    const ratioB = b.caixa_consumido && b.caixa_consumido > 0 ? (b.impacto_eva ?? 0) / b.caixa_consumido : Infinity;
-    if (ratioA !== ratioB) return ratioB - ratioA;
+    // bucket de custo: 0 = grátis genuíno (preço/prazo, "retorno infinito" — vem primeiro) · 1 = dimensionado
+    // (caixa>0) · 2 = custo ausente/inválido (null/≤0 — desconhecido, vai por último; ausente ≠ grátis).
+    const custoBucket = (x: AcaoFila) => x.caixa_consumido === 0 ? 0 : (x.caixa_consumido != null && x.caixa_consumido > 0 ? 1 : 2);
+    const cbA = custoBucket(a), cbB = custoBucket(b);
+    if (cbA !== cbB) return cbA - cbB;
+    // ratio EVA/caixa (desc) só para dimensionados COM eva conhecido; sem ratio (null) → depois do que tem.
+    const ratio = (x: AcaoFila) => x.caixa_consumido != null && x.caixa_consumido > 0 && x.impacto_eva != null ? x.impacto_eva / x.caixa_consumido : null;
+    const rA = ratio(a), rB = ratio(b);
+    if (rA != null && rB != null) { if (rA !== rB) return rB - rA; }
+    else if (rA != null) return -1;
+    else if (rB != null) return 1;
     return (a.payback_meses ?? Infinity) - (b.payback_meses ?? Infinity);
   });
 
@@ -111,6 +125,8 @@ export function montarFilaAcoes(input: {
   let nivel: 'alta' | 'media' | 'baixa' = 'alta';
   const rebaixa = (n: 'media' | 'baixa', m: string) => { if (n === 'baixa' || nivel === 'alta') nivel = n; motivos.push(m); };
   if (fila.some((a) => a.status === 'falta_dado')) rebaixa('media', 'Algumas ações sem hurdle/cockpit (Falta dado).');
+  // pior sinal entre os CANDIDATOS também conta (antes era ignorado): ex. sleeve company-level sem cockpit granular.
+  if (fila.some((a) => a.confianca === 'baixa')) rebaixa('media', 'Inclui ação de confiança baixa (ex.: sleeve company-level sem cockpit granular).');
   if (Object.values(input.caixaPorEmpresa).some((c) => c.confianca === 'baixa')) rebaixa('baixa', 'Projeção de caixa de alguma empresa com confiança baixa.');
 
   return { fila, caixa_por_empresa: input.caixaPorEmpresa, confianca: { nivel, motivos }, gerado_em: new Date().toISOString() };

--- a/supabase/functions/fin-next-best-action/index.ts
+++ b/supabase/functions/fin-next-best-action/index.ts
@@ -51,7 +51,7 @@ function classificarStatus(input: { tipo: TipoAcao; impacto_eva: number | null; 
   if (input.tipo === "consertar_valor" || input.tipo === "liberar_caixa") return "consertar_antes";
   if (input.tipo === "crescer") {
     if (input.spread_positivo !== true) return "nao_financiar";
-    if (input.caixa_consumido == null) return "falta_dado"; // sem custo estimado → precisa dimensionar o ticket
+    if (input.caixa_consumido == null || input.caixa_consumido <= 0) return "falta_dado"; // crescer SEMPRE consome caixa (NCG): custo ≤0 é dado implausível, não "grátis"
     return input.caixa_consumido <= input.caixa_disponivel ? "financiar_ja" : "financiar_condicional";
   }
   return "falta_dado";
@@ -63,7 +63,8 @@ function montarFilaAcoes(input: { candidatos: AcaoCandidata[]; caixaPorEmpresa: 
   const candidatos = [...input.candidatos];
   candidatos.push({ empresa: "—", descricao: "Não fazer nada / pagar dívida / distribuir ao dono (benchmark do hurdle)", tipo: "benchmark", impacto_eva: null, caixa_consumido: 0, payback_meses: null, spread_positivo: null, confianca: "alta" });
   const fila: AcaoFila[] = candidatos.map((c) => {
-    const hurdle = c.empresa in input.hurdlePorEmpresa ? input.hurdlePorEmpresa[c.empresa] : null;
+    const hurdleRaw = c.empresa in input.hurdlePorEmpresa ? input.hurdlePorEmpresa[c.empresa] : null;
+    const hurdle = hurdleRaw != null && Number.isFinite(hurdleRaw) && hurdleRaw > 0 ? hurdleRaw : null; // hurdle ≤0 implausível → tratado como ausente (crescer cai em falta_dado)
     const caixaDisp = input.caixaPorEmpresa[c.empresa]?.disponivel ?? 0;
     const tem_dado = c.tipo === "crescer" ? (hurdle != null && c.spread_positivo != null) : true;
     const status = classificarStatus({ tipo: c.tipo, impacto_eva: c.impacto_eva, spread_positivo: c.spread_positivo, caixa_consumido: c.caixa_consumido, caixa_disponivel: caixaDisp, hurdle, tem_dado });
@@ -71,16 +72,21 @@ function montarFilaAcoes(input: { candidatos: AcaoCandidata[]; caixaPorEmpresa: 
   });
   fila.sort((a, b) => {
     if (PRIORIDADE_TIPO[a.tipo] !== PRIORIDADE_TIPO[b.tipo]) return PRIORIDADE_TIPO[a.tipo] - PRIORIDADE_TIPO[b.tipo];
-    const scA = (a.caixa_consumido ?? 0) === 0 ? 0 : 1; const scB = (b.caixa_consumido ?? 0) === 0 ? 0 : 1;
-    if (scA !== scB) return scA - scB;
-    const rA = a.caixa_consumido && a.caixa_consumido > 0 ? (a.impacto_eva ?? 0) / a.caixa_consumido : Infinity;
-    const rB = b.caixa_consumido && b.caixa_consumido > 0 ? (b.impacto_eva ?? 0) / b.caixa_consumido : Infinity;
-    if (rA !== rB) return rB - rA;
+    // "ausente ≠ R$0": custo null não é grátis (bucket 2, por último) e EVA null não vira ratio 0.
+    const custoBucket = (x: AcaoFila) => x.caixa_consumido === 0 ? 0 : (x.caixa_consumido != null && x.caixa_consumido > 0 ? 1 : 2);
+    const cbA = custoBucket(a), cbB = custoBucket(b);
+    if (cbA !== cbB) return cbA - cbB;
+    const ratio = (x: AcaoFila) => x.caixa_consumido != null && x.caixa_consumido > 0 && x.impacto_eva != null ? x.impacto_eva / x.caixa_consumido : null;
+    const rA = ratio(a), rB = ratio(b);
+    if (rA != null && rB != null) { if (rA !== rB) return rB - rA; }
+    else if (rA != null) return -1;
+    else if (rB != null) return 1;
     return (a.payback_meses ?? Infinity) - (b.payback_meses ?? Infinity);
   });
   const motivos: string[] = []; let nivel: "alta" | "media" | "baixa" = "alta";
   const rebaixa = (n: "media" | "baixa", m: string) => { if (n === "baixa" || nivel === "alta") nivel = n; motivos.push(m); };
   if (fila.some((a) => a.status === "falta_dado")) rebaixa("media", "Algumas ações sem hurdle/cockpit (Falta dado).");
+  if (fila.some((a) => a.confianca === "baixa")) rebaixa("media", "Inclui ação de confiança baixa (ex.: sleeve company-level sem cockpit granular).");
   if (Object.values(input.caixaPorEmpresa).some((c) => c.confianca === "baixa")) rebaixa("baixa", "Projeção de caixa de alguma empresa com confiança baixa.");
   return { fila, caixa_por_empresa: input.caixaPorEmpresa, confianca: { nivel: nivel as "alta" | "media" | "baixa", motivos }, gerado_em: new Date().toISOString() };
 }


### PR DESCRIPTION
## Contexto

Continuação da caça a bugs money-path com o Codex como adversário (após o #705, compras-otimizador). Alvo: **A4 — Próxima Melhor Ação** (`next-best-action-helpers.ts` + edge `fin-next-best-action`), a **fila priorizada que o CFO segue para alocar capital** (compõe A1/A2/A3).

O Codex achou **10 furos**; cruzei TODOS com a fonte (UI / edge / spec) — exatamente o passo que separa bug de modelagem.

## Veredito cruzado (Codex × fonte)

| Achado | Fonte | Veredito |
|---|---|---|
| #6 crescer custo ≤0 → financiável | viola invariante CLAUDE.md ("crescer NUNCA assume custo 0") | 🟠 **corrigido** |
| #7/#7b hurdle ≤0 aceito | incoerente com guards A2/A3 (soma≤0→null) | 🟠 **corrigido** |
| #2/#3 ordenação `null→0/Infinity` | viola spec §3 ("0 ≠ null") + "ausente≠0" | 🟠 **corrigido** |
| #9 rollup ignora `candidato.confianca` | viola spec §9 / comentário "pior sinal entre caixa/candidatos" | 🟠 **corrigido** |
| **#8 `hurdleEfetivo` órfão** | edge L135 só usa WACC; ninguém chama os fallbacks do §6 | 🔴 **deferido** (feature desligada — produto+deploy) |
| #4 caixa não-consumido sequencial | spec §1/§12: fila "greedy/owner-decide", não plano | 🟡 **deferido** (modelagem) |
| #1 status não ordena | **a UI agrupa por status** (`FinanceiroProximaAcao` L62) → re-bucketiza | ⚪ **refutado** (cosmético; Codex não viu a UI) |
| #5/#10 granularidade/params mortos | parcial | ⚪ nit |

## Corrigido (helper + engine espelhados)

- **#6** crescer com `caixa_consumido ≤ 0` (não só `null`) → `falta_dado`
- **#7** `hurdleEfetivo` só aceita finito `>0`; **#7b** a entrada da fila valida hurdle `>0` (a edge passa o WACC cru → a defesa real é aqui)
- **#2/#3** ordenação **null-aware**: bucket de custo `[0=grátis · >0=dimensionado · null/≤0=desconhecido-por-último]`; ratio só com caixa>0 **e** eva≠null (sem `0`/`Infinity` fabricados)
- **#9** rollup considera o pior `candidato.confianca` (conservador: `baixa`→rebaixa `media`)

## Severidade honesta

**Impacto-zero hoje** (a UI agrupa por status; o engine manda "crescer" sempre com `null` e WACC>0) — são **invariantes preventivas** que armam regressão silenciosa quando a feature evoluir. É o mesmo **"ausente ≠ R$0"** dos guards de NCG/hurdle/cockpit da frente de valor. Diferente do #705 (bugs **atuais**), aqui o helper estava majoritariamente correto.

## Deferido (decisão de produto, não fix de helper)

- **#8 `hurdleEfetivo` ÓRFÃO** — o fallback de hurdle que o **spec §6 promete** (custo de dívida / retorno do dono / mediana) foi **escrito, testado e nunca ligado**: a edge só usa WACC. Sem WACC (inputs ainda não cadastrados) **toda ação "crescer" cai em `falta_dado`** em produção — o fallback existiria justo pra evitar. Ligá-lo depende de inputs do founder + deploy.
- **#4 consumo sequencial de caixa** — duas ações `financiar_já` podem somar > caixa; o spec modela "fila greedy/owner-decide", não plano cumulativo executável.

## Método

Codex (correção da lógica de domínio) + cruzamento com a fonte (separa bug de modelagem) + **TDD RED→GREEN** + **mutcheck 6/6 PEGA** (poder de teste). Os dois gates da sessão num caso real.

## ⚠️ Deploy

Engine `fin-next-best-action` espelhado (4 trechos verbatim) → **requer deploy via chat do Lovable**. Como os furos são **latentes**, sem urgência — pode ir junto do próximo deploy do engine.

## Validação

- helper **30/30** (9 RED→GREEN) · suíte **2835/2835** (415 files) · typecheck strict **0** · mutcheck **6/6 PEGA** (controle+ ✓) · paridade helper×engine **verbatim**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
