### PR TITLE
fix(reposição): suprime e-mail "[Portal B2B] cole na mão" redundante do Sayerlack (já automatizado)

### DIFF
--- a/src/lib/reposicao/__tests__/omie-disparo-helpers.test.ts
+++ b/src/lib/reposicao/__tests__/omie-disparo-helpers.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { isOmiePedidoJaCadastrado, extrairPedidoOmie, deveCriarPedidoOmie } from '../omie-disparo-helpers';
+import {
+  isOmiePedidoJaCadastrado,
+  extrairPedidoOmie,
+  deveCriarPedidoOmie,
+  portalEnviadoPorAutomacao,
+  deveEnviarEmailPortalManual,
+} from '../omie-disparo-helpers';
 
 describe('isOmiePedidoJaCadastrado', () => {
   it('detecta "já cadastrado" em pt-BR (com acento)', () => {
@@ -74,5 +80,39 @@ describe('deveCriarPedidoOmie (guard anti-PO-duplicado · 3b)', () => {
   it('"0" / 0 representam vazio → criar (não bloqueia criação legítima)', () => {
     expect(deveCriarPedidoOmie('0')).toBe(true);
     expect(deveCriarPedidoOmie(0)).toBe(true);
+  });
+});
+
+describe('portalEnviadoPorAutomacao (Sayerlack/OBEN cola sozinho via Browserless)', () => {
+  it('OBEN + RENNER SAYERLACK → automatizado', () => {
+    expect(portalEnviadoPorAutomacao({ empresa: 'OBEN', fornecedor_nome: 'RENNER SAYERLACK S/A' })).toBe(true);
+  });
+  it('reconhece "sayerlack" em qualquer caixa / posição no nome', () => {
+    expect(portalEnviadoPorAutomacao({ empresa: 'OBEN', fornecedor_nome: 'Sayerlack' })).toBe(true);
+    expect(portalEnviadoPorAutomacao({ empresa: 'oben', fornecedor_nome: 'tintas sayerlack ltda' })).toBe(true);
+  });
+  it('OBEN + fornecedor não-Sayerlack → NÃO automatizado', () => {
+    expect(portalEnviadoPorAutomacao({ empresa: 'OBEN', fornecedor_nome: 'ACRE CAXIAS IND. E COM. DE ABRASIVOS LTDA' })).toBe(false);
+  });
+  it('Sayerlack em outra empresa que não OBEN → NÃO automatizado (automação é OBEN-only)', () => {
+    expect(portalEnviadoPorAutomacao({ empresa: 'COLACOR', fornecedor_nome: 'RENNER SAYERLACK S/A' })).toBe(false);
+  });
+  it('empresa/nome nulos ou vazios → NÃO automatizado', () => {
+    expect(portalEnviadoPorAutomacao({ empresa: null, fornecedor_nome: null })).toBe(false);
+    expect(portalEnviadoPorAutomacao({ empresa: 'OBEN', fornecedor_nome: '' })).toBe(false);
+    expect(portalEnviadoPorAutomacao({})).toBe(false);
+  });
+});
+
+describe('deveEnviarEmailPortalManual (suprime o "[Portal B2B] cole na mão" redundante)', () => {
+  it('Sayerlack/OBEN → NÃO enviar (automação já colou; aviso "insere manualmente" é enganoso)', () => {
+    expect(deveEnviarEmailPortalManual({ empresa: 'OBEN', fornecedor_nome: 'RENNER SAYERLACK S/A' })).toBe(false);
+  });
+  it('portal_b2b SEM automação (não-Sayerlack) → AINDA enviar (staff cola de verdade)', () => {
+    expect(deveEnviarEmailPortalManual({ empresa: 'OBEN', fornecedor_nome: 'OUTRO FORNECEDOR PORTAL' })).toBe(true);
+  });
+  it('conservador: na dúvida (empresa/nome ausentes) → enviar (não suprime sem certeza de automação)', () => {
+    expect(deveEnviarEmailPortalManual({ empresa: null, fornecedor_nome: null })).toBe(true);
+    expect(deveEnviarEmailPortalManual({})).toBe(true);
   });
 });

--- a/src/lib/reposicao/omie-disparo-helpers.ts
+++ b/src/lib/reposicao/omie-disparo-helpers.ts
@@ -56,3 +56,37 @@ export function deveCriarPedidoOmie(
   if (s === '0') return true;
   return false;
 }
+
+/**
+ * O pedido de portal é enviado por AUTOMAÇÃO (Browserless cola sozinho no portal
+ * B2B) e não exige cole manual do staff. Hoje a única automação de portal é o
+ * Sayerlack/OBEN.
+ * ⚠️ Espelha isSayerlackOben() do edge — se outra automação de portal surgir,
+ * estenda os dois lados juntos.
+ */
+export function portalEnviadoPorAutomacao(p: {
+  empresa?: string | null;
+  fornecedor_nome?: string | null;
+}): boolean {
+  return (
+    (p.empresa ?? '').toUpperCase() === 'OBEN' &&
+    /sayerlack/i.test(p.fornecedor_nome ?? '')
+  );
+}
+
+/**
+ * O e-mail "[Portal B2B] pronto para colar no portal" só é útil para portais SEM
+ * automação — onde o staff realmente cola o pedido na mão. Para o Sayerlack/OBEN
+ * (Browserless cola sozinho → "✓ Enviado") esse aviso "insere manualmente" é ruído
+ * enganoso: o pedido já foi enviado, e o e-mail-resumo do ciclo ("Pedidos
+ * disparados: …") já confirma o sucesso.
+ *
+ * Retorna true quando o e-mail manual do portal AINDA deve ser enviado.
+ * Conservador: na dúvida (sem sinal claro de automação) → envia.
+ */
+export function deveEnviarEmailPortalManual(p: {
+  empresa?: string | null;
+  fornecedor_nome?: string | null;
+}): boolean {
+  return !portalEnviadoPorAutomacao(p);
+}

--- a/supabase/functions/disparar-pedidos-aprovados/index.ts
+++ b/supabase/functions/disparar-pedidos-aprovados/index.ts
@@ -928,6 +928,15 @@ async function notificarFornecedor(
   }
 
   if (canal === "portal_b2b") {
+    // Sayerlack/OBEN é colado no portal pela automação (Browserless) → o e-mail
+    // "[Portal B2B] pronto para colar no portal" é ruído enganoso: o pedido JÁ foi
+    // enviado (aparece como "✓ Enviado") e o e-mail-resumo do ciclo já confirma o
+    // sucesso. Mantemos o aviso só p/ um eventual fornecedor portal_b2b SEM automação.
+    // ⚠️ Espelha deveEnviarEmailPortalManual()/isSayerlackOben (a regra é idêntica) —
+    // ver src/lib/reposicao/omie-disparo-helpers.ts.
+    if (isSayerlackOben(pedido)) {
+      return { enviado: false, detalhe: "portal Sayerlack automatizado — e-mail manual suprimido" };
+    }
     const r = await fetch(RESEND_URL, {
       method: "POST",
       headers: {


### PR DESCRIPTION
## Problema (reportado pelo founder)

Na tela de Pedidos de compra da OBEN, os pedidos RENNER SAYERLACK aparecem como **Disparado / ✓ Enviado** (a automação Browserless colou no portal sozinha), mas o founder **ainda recebe** um e-mail `[Portal B2B] … pronto para colar no portal B2B` com a lista de itens e o texto *"Sistema gera lista de itens, você insere manualmente no portal"*.

Esse e-mail é **ruído enganoso**: o pedido **já foi enviado** automaticamente, e o founder **já recebe** o e-mail-resumo do ciclo (`Pedidos disparados: …`) confirmando o sucesso. O texto "insere manualmente" vem das `observacoes_pedido` do cadastro do fornecedor, escrito quando o portal era 100% manual.

## Causa

`notificarFornecedor()` (em `disparar-pedidos-aprovados`) manda o e-mail `[Portal B2B]` pro staff sempre que um pedido com canal `portal_b2b` vira `status='disparado'` no Omie — sem saber que, pro Sayerlack, a automação Browserless já cuidou do portal.

## Fix

Suprime o e-mail `[Portal B2B]` **somente quando o pedido foi enviado por automação de portal** (`isSayerlackOben` — OBEN + nome Sayerlack). Mantém o aviso "cole na mão" para um eventual fornecedor `portal_b2b` **sem** automação.

- O e-mail-resumo do ciclo segue **intacto** → a confirmação de sucesso continua chegando.
- `resposta_canal.fornecedor_notificado`/`notificacao_detalhe` **não são lidos em lugar nenhum** (grep) → suprimir não cria falso alerta.
- Helper puro TDD (`deveEnviarEmailPortalManual`/`portalEnviadoPorAutomacao`, **8 testes novos**) espelhado verbatim no edge (regra idêntica a `isSayerlackOben`).

## Verificação local

- `bun run typecheck` ✅
- `bun run test` ✅ (412 arquivos / 2796 testes)
- `bun lint` ✅

## ⚠️ Deploy manual necessário

Requer **redeploy do edge `disparar-pedidos-aprovados`** via chat do Lovable (ler de `supabase/functions/disparar-pedidos-aprovados/index.ts` na main, deploy **verbatim**) pra valer em prod. Sem migration, sem Publish de frontend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)