### PR TITLE
test(financeiro): mutcheck — 4 contratos money-path + fecha gap de cobertura no funding

### DIFF
--- a/scripts/mutcheck.d/dre-helpers.mut
+++ b/scripts/mutcheck.d/dre-helpers.mut
@@ -1,0 +1,16 @@
+# @src: src/lib/financeiro/dre-helpers.ts
+# @test: src/lib/financeiro/__tests__/dre-helpers.test.ts
+# Invariantes money-path do DRE v2 (Onda 3a, regime-aware; espelhado no engine Deno calcularDRE).
+# Dedução vs imposto sobre lucro, gate de regime (Simples=DAS único / Presumido específico),
+# alíquota efetiva do Simples, janela RBT12, adicional de IRPJ, sinal do resultado, gate de confiança.
+PEGA | montarDRE: DAS entra nas deduções (+ vira -)        | s/t\('deducoes'\) \+ indiretos \+ das/t('deducoes') + indiretos - das/
+PEGA | montarDRE: gate de regime do imposto/lucro (=== -> !==) | s/input\.regime === 'simples' \? 0/input.regime !== 'simples' ? 0/
+PEGA | montarDRE: receita_liquida = bruta − deduções (- vira +) | s/receita_bruta - deducoes/receita_bruta + deducoes/
+PEGA | montarDRE: resultado_liquido = RAI − imposto (- vira +) | s/resultado_antes_impostos - impostoLucro/resultado_antes_impostos + impostoLucro/
+PEGA | aliquotaEfetivaSimples: − parcela a deduzir (- vira +) | s/f\.aliquota - f\.deduzir/f.aliquota + f.deduzir/
+PEGA | aliquotaEfetivaSimples: gate RBT12<=0 (<= vira <)   | s/if \(rbt12 <= 0\) return 0/if (rbt12 < 0) return 0/
+PEGA | impostoTeoricoPresumido: adicional só excedente (max -> min) | s/Math\.max\(0, baseIrpj - PRESUMIDO/Math.min(0, baseIrpj - PRESUMIDO/
+PEGA | impostoPorKeyword: gate regime Simples->DAS (=== -> !==) | s/if \(regime === 'simples'\) \{/if (regime !== 'simples') {/
+PEGA | calcularRBT12: janela 12m anteriores exclusiva (< vira <=) | s/idx < idxApuracao/idx <= idxApuracao/
+PEGA | faixaPorRBT12: 1ª faixa rbt12<=ate (<= vira >=)     | s/if \(rbt12 <= f\.ate\) return f/if (rbt12 >= f.ate) return f/
+PEGA | scoreConfianca: fallback>20% rebaixa p/ baixa (> vira <) | s/input\.fallback_pct > 0\.2\) rebaixar/input.fallback_pct < 0.2) rebaixar/

--- a/scripts/mutcheck.d/funding-helpers.mut
+++ b/scripts/mutcheck.d/funding-helpers.mut
@@ -1,0 +1,23 @@
+# @src: src/lib/financeiro/funding-helpers.ts
+# @test: src/lib/financeiro/__tests__/funding-helpers.test.ts
+# Invariantes money-path do Custo Marginal de Funding (antecipação por título, planejador de
+# cobertura de gap, merit-order em R$). Princípio: tudo em R$ no horizonte; pré-imposto.
+# "ausente -> falta_dado/null" (NUNCA fabrica custo 0). Espelhado VERBATIM na edge fin-funding.
+PEGA | iofCredito parcela DIÁRIA 0,0082%/dia (* vira /)     | s/0\.000082 \* diasCap/0.000082 \/ diasCap/
+PEGA | iofCredito parcela FIXA 0,38% (+ vira -)             | s/diasCap \+ 0\.0038/diasCap - 0.0038/
+PEGA | custoEmReais juro composto (-1 vira +1, infla custo) | s/dias \/ 365\) - 1\)/dias \/ 365) + 1)/
+PEGA | custoAntecipacao v_liq = V−deságio−iof−tarifa (- +)  | s/valor - desagio - iof - tarifa/valor + desagio - iof - tarifa/
+PEGA | custo_rs antecipação = V − v_liq (- vira +)          | s/custo_rs = valor - v_liq/custo_rs = valor + v_liq/
+PEGA | IOF só p/ 'desconto', factoring=0 (=== vira !==)     | s/input\.tipo === 'desconto' \? iofCredito/input.tipo !== 'desconto' ? iofCredito/
+PEGA | custoOportunidadeCaixa pega o MAIOR (max vira min)   | s/Math\.max\(input\.cm_anual, input\.retorno_marginal_a4\)/Math.min(input.cm_anual, input.retorno_marginal_a4)/
+PEGA | classificarContexto gap se saldo<reserva (< vira >)  | s/input\.menor_saldo_ate_n < input\.reserva_rs/input.menor_saldo_ate_n > input.reserva_rs/
+PEGA | checaValeEmT vale se alt<reserva (< vira >)          | s/alt < reserva_rs && base/alt > reserva_rs && base/
+PEGA | decidirTitulo GAP net = custo_alt − custo_antec (- +)| s/const net = melhor\.custo - ant\.custo_rs;/const net = melhor.custo + ant.custo_rs;/
+PEGA | decidirTitulo GAP escolhe a alternativa + BARATA (< >)| s/b\.custo < a\.custo \? b : a/b.custo > a.custo ? b : a/
+PEGA | decidirTitulo SOBRA net = ganho − custo_antec (- +)  | s/const net = ganho - ant\.custo_rs;/const net = ganho + ant.custo_rs;/
+PEGA | identificarGap gap_rs = reserva − piorSaldo (- vira +)| s/input\.reserva_rs - piorSaldo/input.reserva_rs + piorSaldo/
+PEGA | identificarGap horizonte até RECUPERAÇÃO (ultimoAbaixo->piorIdx) | s/\(ultimoAbaixo \+ 1\) \* 7/(piorIdx + 1) * 7/
+PEGA | identificarGap acha o vale + profundo (< vira >)      | s/s\.saldo_final < piorSaldo/s.saldo_final > piorSaldo/
+PEGA | montarPlano usa = min(restante, capacidade) (min max) | s/Math\.min\(restante, f\.capacidade_rs\)/Math.max(restante, f.capacidade_rs)/
+PEGA | montarPlano merit-order por R$ crescente (ca-cb -> cb-ca) | s/return ca - cb;/return cb - ca;/
+PEGA | montarPlano custo_inércia ausente -> null (não fabrica 0) | s/input\.cheque_rate_aa != null \? custoEmReais\(gap_rs, horizonte_dias, input\.cheque_rate_aa\) : null/input.cheque_rate_aa != null ? custoEmReais(gap_rs, horizonte_dias, input.cheque_rate_aa) : 0/

--- a/scripts/mutcheck.d/valor-cockpit-helpers.mut
+++ b/scripts/mutcheck.d/valor-cockpit-helpers.mut
@@ -1,0 +1,12 @@
+# @src: src/lib/financeiro/valor-cockpit-helpers.ts
+# @test: src/lib/financeiro/__tests__/valor-cockpit-helpers.test.ts
+# Invariantes money-path do A3 (Cockpit de Valor: EVP por cliente/SKU + recomendação de preço/prazo).
+# Identidade contábil (Σcliente=Σsku=empresa), "ausente ≠ R$0" (hurdle/custo), direção das recomendações.
+PEGA | margemContribuicao receita − custo (- vira +)     | s/receita_liquida - input\.custo_unitario/receita_liquida + input.custo_unitario/
+PEGA | identidade evp = cm − encargo (- vira +)          | s/null : cm - encargo/null : cm + encargo/
+PEGA | encargo: hurdle k=null coage p/ 0 (ausente≠R$0)   | s/input\.k == null \? null :/input.k == null ? 0 :/
+PEGA | alocação AR por receita (denominador rc -> qs)    | s/c\.receita_liquida \/ rc/c.receita_liquida \/ qs/
+PEGA | resolverHurdle soma>0 vira >=0 (0% capital grátis)| s/soma > 0 \? soma/soma >= 0 ? soma/
+PEGA | recomendação "subir preço" direção (< vira >)     | s/cmPct < c\.margem_minima_pct/cmPct > c.margem_minima_pct/
+PEGA | recomendação "cortar desconto" direção (> vira <) | s/descontoPct > c\.desconto_max_pct/descontoPct < c.desconto_max_pct/
+PEGA | gate evpConhecivel (remove o ! da negação)        | s/= !input\.hurdle_indisponivel/= input.hurdle_indisponivel/

--- a/scripts/mutcheck.d/valor-helpers.mut
+++ b/scripts/mutcheck.d/valor-helpers.mut
@@ -1,0 +1,18 @@
+# @src: src/lib/financeiro/valor-helpers.ts
+# @test: src/lib/financeiro/__tests__/valor-helpers.test.ts
+# Invariantes money-path do A2 (Retorno & Valor: ROIC / WACC / EVA / spread / NCG guard).
+# NOPAT = EBIT − imposto ABSOLUTO (presumido: IRPJ+CSLL; simples: 0 — NUNCA ×(1−t)); EBIT op PURO
+# (sem resultado financeiro); capital = NCG + ativo fixo − ajustes; "ausente ≠ R$0" no NCG; frescor.
+# Substituições aplicadas via `perl -i -pe` (mutcheck.sh) — escape estilo perl regex.
+PEGA | EBIT op puro: − recfin vira + recfin               | s/resultado_operacional_ttm - input\.receitas_financeiras_ttm/resultado_operacional_ttm + input.receitas_financeiras_ttm/
+PEGA | imposto NOPAT presumido irpj+csll (+ vira −)       | s/'presumido' \? input\.irpj_ttm \+ input\.csll_ttm/'presumido' ? input.irpj_ttm - input.csll_ttm/
+PEGA | NOPAT = EBIT − imposto absoluto (− vira +)         | s/const nopat = ebit - imposto_operacional_nopat/const nopat = ebit + imposto_operacional_nopat/
+PEGA | capital = giro + ativo − ajustes (− vira +)        | s/\+ ativo_fixo - ajustes/+ ativo_fixo + ajustes/
+PEGA | NCG ausente≠R$0: giro==null vira !=null            | s/const giro_indisponivel = input\.capital_giro == null/const giro_indisponivel = input.capital_giro != null/
+PEGA | roic null p/ capital ≤0 (<= vira <)                | s/input\.capital_investido <= 0/input.capital_investido < 0/
+PEGA | spread = roic − wacc (− vira +)                    | s/return input\.roic - input\.wacc/return input.roic + input.wacc/
+PEGA | eva = spread × capital (* vira \/)                 | s/return input\.spread \* input\.capital_investido/return input.spread \/ input.capital_investido/
+PEGA | wacc = we·Ke + wd·Kd (+ vira −)                    | s/peso_equity \* input\.ke \+ peso_divida \* kd/peso_equity * input.ke - peso_divida * kd/
+PEGA | roicIncremental gate Δcapital < limiar (< vira >)  | s/if \(delta_capital < limiar\)/if (delta_capital > limiar)/
+PEGA | frescor stale: dias > limiar (> vira <)            | s/stale: dias > limiarStaleDias/stale: dias < limiarStaleDias/
+PEGA | normalizar pró-labore real − mercado (− vira +)    | s/input\.prolabore_real_ttm - input\.prolabore_mercado_ttm/input.prolabore_real_ttm + input.prolabore_mercado_ttm/

--- a/src/lib/financeiro/__tests__/funding-helpers.test.ts
+++ b/src/lib/financeiro/__tests__/funding-helpers.test.ts
@@ -128,6 +128,23 @@ describe('decidirTitulo', () => {
     expect(d.recomendacao).toBe('nao_antecipar');
     expect(d.net_rs!).toBeLessThan(0);
   });
+  it('GAP: com AS DUAS alternativas, faz benchmark contra a MAIS BARATA (capital de giro < cheque)', () => {
+    // gap real com linha de capital de giro (10% a.a.) E cheque especial (200% a.a.) disponíveis:
+    // o benchmark da antecipação tem de ser a fonte MAIS BARATA, não a mais cara (senão o net infla e
+    // enviesa pra "antecipar"). Fecha o gap de cobertura: os outros casos GAP passam 1 alternativa só.
+    const d = decidirTitulo({
+      titulo: baseTitulo, antecipacao: baseAnt,
+      alternativas: { capital_giro_cet: 0.10, cheque_cet: 2.0 },
+      cm_anual: 0.18, retorno_marginal_a4: null, contexto: 'gap', flags_extra: [],
+    });
+    expect(d.benchmark_fonte).toBe('capital_giro'); // a mais barata, não 'cheque_especial'
+    const soCheque = decidirTitulo({
+      titulo: baseTitulo, antecipacao: baseAnt,
+      alternativas: { capital_giro_cet: null, cheque_cet: 2.0 },
+      cm_anual: 0.18, retorno_marginal_a4: null, contexto: 'gap', flags_extra: [],
+    });
+    expect(d.custo_rs_benchmark!).toBeLessThan(soCheque.custo_rs_benchmark!); // pegou o barato (giro), não o caro (cheque)
+  });
   it('SOBRA: deságio > cm_anual e sem uso A4 → não antecipar', () => {
     const d = decidirTitulo({
       titulo: baseTitulo, antecipacao: baseAnt, alternativas: {},


### PR DESCRIPTION
## Contexto

Continuação da frente de **mutation testing** (poder de teste) da sessão. Com o Codex temporariamente sem cota (reset Jun 11), troquei o adversário LLM pelo **adversário mecânico** que esta sessão construiu — o `mutcheck`. Em vez de achar bugs no *código*, ele acha buracos nos *testes*: planta bugs nas invariantes money-path e vê se os testes falham (pegam). **Sobrevivente = gap de cobertura num cálculo que move dinheiro.**

## 4 helpers money-path, antes sem contrato `.mut`

| Helper | Mutações | Resultado |
|---|---|---|
| **valor-cockpit (A3)** | 8 | **8/8 PEGA** — identidade contábil `Σcliente=Σsku=empresa`, `ausente≠0` (hurdle/custo), direção das recomendações |
| **dre-helpers** | 11 | **11/11 PEGA** — dedução×imposto, gate de regime, alíquota efetiva, janela RBT12, sinal |
| **valor-helpers (A2)** | 12 | **12/12 PEGA** — NOPAT absoluto, ROIC/WACC/EVA/spread, NCG guard, frescor |
| **funding-helpers** | 18 | 17/18 → **achou 1 gap** → +1 teste → **18/18** |

3 dos 4 já tinham testes **fortes** (assertam valores exatos + cobrem os dois regimes) — os contratos viram regressão executável (o CI pega se alguém enfraquecer um teste).

## O gap achado (funding — money-path)

No `decidirTitulo` (caminho **GAP**), a antecipação é comparada contra a **fonte de funding mais barata** entre capital de giro e cheque especial:
```ts
const melhor = cands.reduce((a, b) => (b.custo < a.custo ? b : a));
```
**Todos os testes do GAP passavam UMA alternativa por vez** (a outra `null`) → com 1 candidato, o `reduce` retorna o único elemento e **a direção do `<` fica invisível**. A mutação `<→>` (pegar a **mais cara**) sobrevivia. Num gap real com **ambas** as linhas disponíveis, um bug ali tornaria o benchmark a fonte cara → o `net` infla → enviesa para **`antecipar`** indevidamente, **sem nenhum teste falhar**.

**O código está correto; o teste é que era fraco.** Adicionei o caso com as duas alternativas (capital de giro 10% a.a. + cheque 200% a.a.) assertando que o benchmark é a **mais barata** (`capital_giro`, não `cheque_especial`). Agora `18/18`.

## Validação

- `mutcheck-all`: **9 contratos honrados, 0 regressão de cobertura**
- funding: **18/18 PEGA** (gap fechado) · typecheck strict **0** · baseline de cada contrato verde
- Os `.mut` ficam versionados como contratos executáveis das invariantes (CI: `mutation-check`)

## Nota

`mutcheck.sh` aplica as mutações via `perl -i -pe` (não `sed`) — os contratos usam regex perl; substituição-única validada por contrato.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
