### PR TITLE
fix(telefonia): áudio sumia aos ~2min de chamada (stomp de registro) + gravação obrigatória na Central

### DIFF
--- a/src/components/telefonia/DialPad.tsx
+++ b/src/components/telefonia/DialPad.tsx
@@ -20,7 +20,9 @@ export interface DialPadProps {
 
 export function DialPad({ initialPhone = '', onCall, backend, busy = false }: DialPadProps) {
   const [value, setValue] = useState(initialPhone);
-  const [forceRecord, setForceRecord] = useState(false);
+  // Política (founder, 2026-06-09): gravação OBRIGATÓRIA na Central de Telefonia —
+  // o switch é a exceção ("cliente pediu pra não gravar") e re-arma a cada chamada.
+  const [forceRecord, setForceRecord] = useState(true);
   const normalized = normalizeBrPhone(value);
   const valid = normalized.length >= 10;
 
@@ -40,8 +42,8 @@ export function DialPad({ initialPhone = '', onCall, backend, busy = false }: Di
         ))}
       </div>
       <div className="flex items-center justify-between mt-2 text-xs">
-        <span className="text-muted-foreground">Gravar esta chamada</span>
-        <Switch checked={forceRecord} onCheckedChange={setForceRecord} />
+        <span className="text-muted-foreground">Gravação da chamada</span>
+        <Switch checked={forceRecord} onCheckedChange={setForceRecord} aria-label="Gravação da chamada" />
       </div>
       {/* Número fica numa linha NÃO-interativa — fora do label do botão pra não
           virar <a href="tel:"> auto-detectado pelo iOS (abriria o app Telefone do SO). */}
@@ -53,11 +55,15 @@ export function DialPad({ initialPhone = '', onCall, backend, busy = false }: Di
       <Button className="w-full mt-2 h-12 bg-status-success hover:bg-status-success/90"
         disabled={!valid || busy}
         aria-label={valid ? `Ligar para ${formatBrPhone(value)}` : 'Ligar'}
-        onClick={() => onCall(normalized, { forceRecord })}>
+        onClick={() => {
+          onCall(normalized, { forceRecord });
+          // Re-arma: o opt-out vale só pra ESTA chamada — não vaza pra próxima.
+          setForceRecord(true);
+        }}>
         <Phone className="h-4 w-4 mr-1.5" /> {busy ? 'Em chamada…' : 'Ligar'}
       </Button>
       <p className="text-[10px] text-center text-muted-foreground mt-1.5">
-        backend: {backend.toUpperCase()} · cliente/fornecedor grava automático
+        backend: {backend.toUpperCase()} · gravação obrigatória — desligue só a pedido do cliente
       </p>
     </div>
   );

--- a/src/components/telefonia/__tests__/DialPad.test.tsx
+++ b/src/components/telefonia/__tests__/DialPad.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { DialPad } from '../DialPad';
+
+// Política do founder (2026-06-09): gravação OBRIGATÓRIA na Central de Telefonia.
+// O switch existe só como exceção ("cliente pediu pra não gravar") e re-arma a
+// cada chamada — o opt-out de uma ligação não pode vazar pra seguinte.
+describe('DialPad — gravação obrigatória por default', () => {
+  function setup() {
+    const onCall = vi.fn();
+    render(<DialPad onCall={onCall} backend="webrtc" />);
+    const input = screen.getByPlaceholderText('número');
+    fireEvent.change(input, { target: { value: '37999998888' } });
+    return { onCall };
+  }
+
+  it('switch de gravação nasce LIGADO', () => {
+    const onCall = vi.fn();
+    render(<DialPad onCall={onCall} backend="webrtc" />);
+    expect(screen.getByRole('switch')).toHaveAttribute('aria-checked', 'true');
+  });
+
+  it('ligar com o default envia forceRecord: true', () => {
+    const { onCall } = setup();
+    fireEvent.click(screen.getByRole('button', { name: /^ligar para/i }));
+    expect(onCall).toHaveBeenCalledWith('37999998888', { forceRecord: true });
+  });
+
+  it('exceção: cliente pediu pra não gravar → desliga o switch → forceRecord: false', () => {
+    const { onCall } = setup();
+    fireEvent.click(screen.getByRole('switch'));
+    fireEvent.click(screen.getByRole('button', { name: /^ligar para/i }));
+    expect(onCall).toHaveBeenCalledWith('37999998888', { forceRecord: false });
+  });
+
+  it('re-arma: após discar com gravação desligada, o switch volta a LIGADO', () => {
+    const { onCall } = setup();
+    fireEvent.click(screen.getByRole('switch'));
+    fireEvent.click(screen.getByRole('button', { name: /^ligar para/i }));
+    expect(onCall).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole('switch')).toHaveAttribute('aria-checked', 'true');
+  });
+});

--- a/src/contexts/WebRTCCallContext.tsx
+++ b/src/contexts/WebRTCCallContext.tsx
@@ -262,7 +262,12 @@ export function WebRTCCallProvider({ children }: ProviderProps) {
   // idempotente (.neq('status','ended')). Inbound não passa por aqui (dialedSipCallIdRef fica null).
   useEffect(() => {
     const TERMINAL: WebRTCCallState[] = ['finished', 'noanswer', 'busy', 'failed', 'error'];
-    if (TERMINAL.includes(callState) && dialedSipCallIdRef.current) {
+    if (!TERMINAL.includes(callState)) return;
+    // LGPD: libera mic/preroll também quando o fim veio do lado REMOTO (BYE do
+    // cliente, falha) — sem isso o rawMic ficava capturado (red dot aceso) até a
+    // próxima ação do vendedor. Idempotente com o cleanup do endCall.
+    cleanupAudioResources();
+    if (dialedSipCallIdRef.current) {
       const sid = dialedSipCallIdRef.current;
       dialedSipCallIdRef.current = null;
       const durationSeconds = clientRef.current?.getCallDurationSeconds() ?? 0;

--- a/src/contexts/__tests__/WebRTCCallContext.test.tsx
+++ b/src/contexts/__tests__/WebRTCCallContext.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { renderHook, waitFor } from '@testing-library/react';
+import { renderHook, waitFor, act } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { expectRenderToThrow } from '@/test/render-throws';
 
@@ -42,6 +42,28 @@ vi.mock('@/hooks/useSpinAnalysis', () => ({
     analysis: null,
     error: null,
   }),
+}));
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
+}));
+
+vi.mock('@/lib/call-log/recording-policy', () => ({
+  resolveCallParty: vi.fn(async (raw: string) => ({
+    kind: 'desconhecido' as const,
+    customerUserId: null,
+    matchConfidence: 'none' as const,
+    phoneNormalized: raw.replace(/\D/g, ''),
+  })),
+  shouldAutoRecord: () => false,
+}));
+
+vi.mock('@/lib/call-log/record', () => ({
+  logCallStart: vi.fn(async () => {}),
+  logAnswered: vi.fn(async () => {}),
+  logClosed: vi.fn(async () => {}),
+  enrichCallLog: vi.fn(async () => {}),
+  markRecorded: vi.fn(async () => {}),
 }));
 
 import { WebRTCCallProvider, useWebRTCCallContext } from '../WebRTCCallContext';
@@ -128,5 +150,34 @@ describe('WebRTCCallProvider', () => {
     expect(result.current.spinAnalysisStatus).toBe('idle');
     expect(result.current.spinAnalysis).toBeNull();
     expect(result.current.spinAnalysisError).toBeNull();
+  });
+
+  // Incidente 2026-06-09 (LGPD): após hangup REMOTO o rawMic ficava capturado
+  // (red dot aceso, cliente seguia ouvindo a vendedora) até a próxima ação.
+  // Estado terminal deve liberar os recursos de áudio imediatamente.
+  it('estado terminal libera o microfone (rawMic) após fim remoto da chamada', async () => {
+    const stopMock = vi.fn();
+    const fakeMic = { getTracks: () => [{ kind: 'audio', stop: stopMock }] } as unknown as MediaStream;
+    Object.defineProperty(navigator, 'mediaDevices', {
+      value: { getUserMedia: vi.fn(async () => fakeMic) },
+      configurable: true,
+    });
+
+    const { result } = renderHook(() => useWebRTCCallContext(), { wrapper });
+    await waitFor(() => expect(SipClient).toHaveBeenCalledTimes(1));
+
+    await act(async () => {
+      await result.current.makeCall('37999998888');
+    });
+    expect(sipClientMock.makeCall).toHaveBeenCalled();
+    expect(stopMock).not.toHaveBeenCalled();
+
+    const stateHandler = sipClientMock.on.mock.calls.find((c) => c[0] === 'stateChange')?.[1];
+    expect(stateHandler).toBeDefined();
+    act(() => stateHandler('established'));
+    // Cliente desligou (BYE remoto) — nenhum clique em "Encerrar" acontece
+    act(() => stateHandler('ended'));
+
+    await waitFor(() => expect(stopMock).toHaveBeenCalled());
   });
 });

--- a/src/lib/sip/sip-client.test.ts
+++ b/src/lib/sip/sip-client.test.ts
@@ -246,6 +246,224 @@ describe('SipClient — hangUp cleanup', () => {
   });
 });
 
+// Incidente 2026-06-09 (Regina): eventos de REGISTRO compartilhavam a state machine
+// da CHAMADA — um 'unregistered' (queda do WSS / re-REGISTER falho) no meio da
+// conversa estampava o estado pra 'idle', a UI desmontava o <audio> e a vendedora
+// parava de ouvir, enquanto a sessão SIP + mic continuavam vivos (cliente seguia
+// ouvindo ela). Estes testes garantem que registro NUNCA mexe no estado da chamada.
+describe('SipClient — eventos de registro durante chamada ativa (anti-stomp)', () => {
+  const cfg = {
+    wsUri: 'wss://sip.nvoip.com.br:7443/ws',
+    sipDomain: 'sip.nvoip.com.br',
+    username: '1234567',
+    password: 'abc',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    uaMock.isRegistered.mockReturnValue(true);
+  });
+
+  const uaHandler = (name: string) =>
+    uaMock.on.mock.calls.find((c) => c[0] === name)?.[1];
+
+  function setupEstablishedCall() {
+    const session = {
+      on: vi.fn(),
+      terminate: vi.fn(),
+      connection: { getReceivers: vi.fn(() => []) },
+    };
+    uaMock.call.mockReturnValue(session);
+    const client = new SipClient(cfg);
+    client.connect();
+    const states: string[] = [];
+    client.on('stateChange', (s) => states.push(s));
+    const errorSpy = vi.fn();
+    client.on('error', errorSpy);
+    const stopMock = vi.fn();
+    const mic = { getTracks: () => [{ kind: 'audio', stop: stopMock }] } as unknown as MediaStream;
+    client.makeCall('37999998888', mic);
+    const accepted = session.on.mock.calls.find((c) => c[0] === 'accepted')?.[1];
+    accepted();
+    expect(states.at(-1)).toBe('established');
+    return { client, session, states, errorSpy, stopMock };
+  }
+
+  it("'unregistered' no meio da chamada NÃO derruba o estado pra idle", () => {
+    const { states } = setupEstablishedCall();
+    uaHandler('unregistered')();
+    expect(states.at(-1)).toBe('established');
+    expect(states).not.toContain('idle');
+  });
+
+  it("'registered' (re-REGISTER pós-reconexão) no meio da chamada não mexe no estado", () => {
+    const { states } = setupEstablishedCall();
+    uaHandler('registered')();
+    expect(states.at(-1)).toBe('established');
+  });
+
+  it("'registrationFailed' no meio da chamada não estampa estado nem emite error", () => {
+    const { states, errorSpy } = setupEstablishedCall();
+    uaHandler('registrationFailed')({ cause: 'Connection Error' });
+    expect(states.at(-1)).toBe('established');
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it('eventos de registro voltam ao normal depois do hangUp', () => {
+    const { client, states } = setupEstablishedCall();
+    client.hangUp();
+    uaHandler('unregistered')();
+    expect(states.at(-1)).toBe('idle');
+  });
+});
+
+describe('SipClient — duração não vaza entre chamadas', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    uaMock.isRegistered.mockReturnValue(true);
+  });
+
+  // Incidente 2026-06-09: rediscagens NÃO atendidas eram logadas como 'ended' com
+  // duração fantasma (130s/155s) medida do accept da chamada ANTERIOR.
+  it('getCallDurationSeconds zera ao iniciar nova chamada (sem accept ainda)', () => {
+    const session = { on: vi.fn(), terminate: vi.fn(), connection: { getReceivers: () => [] } };
+    uaMock.call.mockReturnValue(session);
+    const client = new SipClient({
+      wsUri: 'wss://sip.nvoip.com.br:7443/ws',
+      sipDomain: 'sip.nvoip.com.br',
+      username: '1234567',
+      password: 'abc',
+    });
+    client.connect();
+
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(1_000_000);
+    const mic = { getTracks: () => [{ kind: 'audio', stop: vi.fn() }] } as unknown as MediaStream;
+    client.makeCall('37999998888', mic);
+    session.on.mock.calls.find((c) => c[0] === 'accepted')?.[1]();
+
+    nowSpy.mockReturnValue(1_130_000); // +130s de conversa
+    expect(client.getCallDurationSeconds()).toBe(130);
+    client.hangUp();
+
+    // Nova chamada, ainda NÃO atendida: duração deve ser 0, não 130
+    client.makeCall('37999998888', mic);
+    expect(client.getCallDurationSeconds()).toBe(0);
+    nowSpy.mockRestore();
+  });
+});
+
+describe('SipClient — fim remoto libera recursos da chamada', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    uaMock.isRegistered.mockReturnValue(true);
+  });
+
+  function setupCall() {
+    const session = {
+      on: vi.fn(),
+      terminate: vi.fn(),
+      connection: { getReceivers: vi.fn(() => []) },
+    };
+    uaMock.call.mockReturnValue(session);
+    const client = new SipClient({
+      wsUri: 'wss://sip.nvoip.com.br:7443/ws',
+      sipDomain: 'sip.nvoip.com.br',
+      username: '1234567',
+      password: 'abc',
+    });
+    client.connect();
+    const stopMock = vi.fn();
+    const mic = { getTracks: () => [{ kind: 'audio', stop: stopMock }] } as unknown as MediaStream;
+    client.makeCall('37999998888', mic);
+    const fire = (ev: string, arg?: unknown) =>
+      session.on.mock.calls.find((c) => c[0] === ev)?.[1](arg);
+    return { client, fire, stopMock };
+  }
+
+  it("'ended' remoto (cliente desligou) para as tracks do stream da chamada", () => {
+    const { fire, stopMock } = setupCall();
+    fire('accepted');
+    fire('ended');
+    expect(stopMock).toHaveBeenCalled();
+  });
+
+  it("'failed' (não atendida/ocupado) também libera o stream", () => {
+    const { fire, stopMock } = setupCall();
+    fire('failed', { cause: 'Busy' });
+    expect(stopMock).toHaveBeenCalled();
+  });
+});
+
+describe('SipClient — queda do WebSocket SIP (sinalização)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    uaMock.isRegistered.mockReturnValue(true);
+  });
+
+  const uaHandler = (name: string) =>
+    uaMock.on.mock.calls.find((c) => c[0] === name)?.[1];
+
+  it("avisa (error) quando o WSS cai DURANTE uma chamada ativa", () => {
+    const session = { on: vi.fn(), terminate: vi.fn(), connection: { getReceivers: () => [] } };
+    uaMock.call.mockReturnValue(session);
+    const client = new SipClient({
+      wsUri: 'wss://sip.nvoip.com.br:7443/ws',
+      sipDomain: 'sip.nvoip.com.br',
+      username: '1234567',
+      password: 'abc',
+    });
+    client.connect();
+    const errorSpy = vi.fn();
+    client.on('error', errorSpy);
+    const mic = { getTracks: () => [{ kind: 'audio', stop: vi.fn() }] } as unknown as MediaStream;
+    client.makeCall('37999998888', mic);
+
+    const disconnected = uaHandler('disconnected');
+    expect(disconnected).toBeDefined();
+    disconnected!();
+
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy.mock.calls[0][0].message).toMatch(/conexão sip caiu/i);
+  });
+
+  it("'disconnected' SEM chamada ativa não emite error (reconexão silenciosa)", () => {
+    const client = new SipClient({
+      wsUri: 'wss://sip.nvoip.com.br:7443/ws',
+      sipDomain: 'sip.nvoip.com.br',
+      username: '1234567',
+      password: 'abc',
+    });
+    client.connect();
+    const errorSpy = vi.fn();
+    client.on('error', errorSpy);
+
+    uaHandler('disconnected')?.();
+
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('SipClient — keepalive de registro (anti idle-timeout do WSS)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // Durante chamada estabelecida ZERO tráfego SIP flui; com o register_expires
+  // default do JsSIP (600s) o 1º re-REGISTER só viria aos ~5-9min — middlebox com
+  // idle-timeout de ~100-120s matava o socket aos ~2min de conversa.
+  it('configura register_expires curto (90s) pra manter o WSS vivo', () => {
+    new SipClient({
+      wsUri: 'wss://sip.nvoip.com.br:7443/ws',
+      sipDomain: 'sip.nvoip.com.br',
+      username: '1234567',
+      password: 'abc',
+    });
+    expect(JsSIP.UA).toHaveBeenCalledWith(
+      expect.objectContaining({ register_expires: 90 })
+    );
+  });
+});
+
 describe('SipClient — mute control', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/src/lib/sip/sip-client.ts
+++ b/src/lib/sip/sip-client.ts
@@ -26,15 +26,41 @@ export class SipClient {
       register: true,
       // RFC 4028 session timers off — Nvoip server doesn't require them and they add re-INVITE churn
       session_timers: false,
+      // Keepalive: durante chamada estabelecida ZERO tráfego SIP flui no WSS; com o
+      // default do JsSIP (600s) o 1º re-REGISTER só viria aos ~5-9min e middleboxes
+      // com idle-timeout (~100-120s) matavam o socket aos ~2min de conversa
+      // (incidente 2026-06-09). O servidor pode sobrescrever via expires da resposta.
+      register_expires: 90,
     });
 
-    this.ua.on('registered', () => this.setState('registered'));
-    this.ua.on('unregistered', () => this.setState('idle'));
+    // ⚠️ Eventos de REGISTRO nunca tocam o estado quando há CHAMADA ativa: a sessão
+    // SIP estabelecida sobrevive à perda de registro/transporte (JsSIP não a termina),
+    // e estampar 'idle'/'register_failed' aqui desmontava o <audio> da UI no meio da
+    // conversa — a vendedora parava de ouvir com o mic ainda aberto (LGPD).
+    this.ua.on('registered', () => {
+      if (this.hasActiveCall()) return;
+      this.setState('registered');
+    });
+    this.ua.on('unregistered', () => {
+      if (this.hasActiveCall()) return;
+      this.setState('idle');
+    });
     // JsSIP event payload typed loosely — only `cause` is consumed here
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     this.ua.on('registrationFailed', (e: any) => {
+      if (this.hasActiveCall()) {
+        console.warn('[sip] registro falhou durante chamada ativa — estado da chamada preservado:', e?.cause);
+        return;
+      }
       this.setState('register_failed');
       this.emit('error', new Error(`SIP registration failed: ${e.cause}`));
+    });
+    // Queda do WebSocket de sinalização: o JsSIP reconecta sozinho e a mídia
+    // (RTCPeerConnection) costuma continuar — só avisa quando há chamada em curso.
+    this.ua.on('disconnected', () => {
+      if (this.hasActiveCall()) {
+        this.emit('error', new Error('Conexão SIP caiu durante a chamada — reconectando. O áudio pode continuar; se ficar mudo, encerre e religue.'));
+      }
     });
 
     // PR-INBOUND-CALLS: handler de chamada inbound
@@ -96,6 +122,10 @@ export class SipClient {
     }
 
     const target = `sip:${phoneE164}@${this.config.sipDomain}`;
+    // Zera a âncora de duração da chamada ANTERIOR: sem isso, uma rediscagem que
+    // falha antes do accept reportava duração fantasma (medida do accept antigo)
+    // e era logada como 'ended' atendida no call_log (incidente 2026-06-09).
+    this.callStartedAt = null;
     this.setState('calling');
     this.emit('localStream', micStream);
     this.currentLocalStream = micStream;
@@ -118,10 +148,14 @@ export class SipClient {
     // JsSIP event payload typed loosely — only `cause` is consumed here
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     this.currentSession.on('failed', (e: any) => {
+      this.releaseCallResources();
       this.setState('failed');
       this.emit('error', new Error(`Call failed: ${e.cause}`));
     });
     this.currentSession.on('ended', () => {
+      // Fim REMOTO (cliente desligou): libera o stream da chamada na hora — sem
+      // isso as tracks seguiam transmitindo até a próxima ação do vendedor.
+      this.releaseCallResources();
       this.setState('ended');
     });
   }
@@ -152,13 +186,17 @@ export class SipClient {
     session.on('confirmed', () => this.extractRemoteStream());
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     session.on('failed', (e: any) => {
+      const durationSeconds = this.getCallDurationSeconds();
+      this.releaseCallResources();
       this.setState('failed');
-      this.emit('incomingClosed', { sipCallId, answered: true, durationSeconds: this.getCallDurationSeconds() });
+      this.emit('incomingClosed', { sipCallId, answered: true, durationSeconds });
       this.emit('error', new Error(`Inbound call failed: ${e?.cause ?? 'unknown'}`));
     });
     session.on('ended', () => {
+      const durationSeconds = this.getCallDurationSeconds();
+      this.releaseCallResources();
       this.setState('ended');
-      this.emit('incomingClosed', { sipCallId, answered: true, durationSeconds: this.getCallDurationSeconds() });
+      this.emit('incomingClosed', { sipCallId, answered: true, durationSeconds });
     });
   }
 
@@ -179,18 +217,29 @@ export class SipClient {
       } catch {
         // session já encerrada — ok
       }
-      this.currentSession = null;
     }
+    this.releaseCallResources();
+    if (this.state === 'calling' || this.state === 'ringing' || this.state === 'established') {
+      this.setState('ended');
+    }
+  }
+
+  /** Libera os recursos da chamada corrente (stream local + slot da sessão).
+   *  Chamado no hangUp local E nos fins remotos ('ended'/'failed'). NÃO zera
+   *  callStartedAt — a duração ainda é lida pelos consumidores no estado terminal. */
+  private releaseCallResources(): void {
     if (this.currentLocalStream) {
       for (const track of this.currentLocalStream.getTracks()) {
         track.stop();
       }
       this.currentLocalStream = null;
     }
-    if (this.state === 'calling' || this.state === 'ringing' || this.state === 'established') {
-      this.setState('ended');
-    }
+    this.currentSession = null;
     this.muted = false; // reset pra próxima chamada
+  }
+
+  private hasActiveCall(): boolean {
+    return !!(this.currentSession || this.pendingIncoming);
   }
 
   /**


### PR DESCRIPTION
## Incidente (2026-06-09)

Regina ligou pela Central de Telefonia, o cliente atendeu e **ela parou de ouvir aos ~2 minutos** — enquanto **o cliente continuava ouvindo ela** (confirmado pelo próprio cliente depois). O `call_log` confirmou a assinatura: linha presa em `status='answered'` com `ended_at NULL`, e rediscagens com durações fantasma (130s/155s) medidas do accept da chamada **anterior**.

## Causa raiz

O `SipClient` compartilha **uma única state machine entre REGISTRO SIP e CHAMADA**. Quando o WebSocket de sinalização cai (ou um re-REGISTER falha) no meio da conversa, o JsSIP emite `unregistered` — que estampava o estado pra `idle`. Na Telefonia, `callState !== 'idle'` desmonta o card inteiro → o `<audio>` desmonta → o áudio morre. A sessão SIP + RTCPeerConnection **continuam vivas** (JsSIP não termina sessão estabelecida na queda de transporte) → chamada-zumbi com **mic aberto** (risco LGPD).

O gatilho dos ~2min: durante chamada estabelecida **zero tráfego SIP flui** no WSS (re-REGISTER default = 600s → 1º refresh só aos ~5-9min); qualquer middlebox com idle-timeout de ~100-120s mata o socket aos ~2min de conversa.

## Fixes

1. **Anti-stomp**: handlers de `registered`/`unregistered`/`registrationFailed` ganham guard de chamada ativa — registro nunca mais toca o estado da chamada (o áudio continua tocando mesmo se a sinalização cair).
2. **`ua.on('disconnected')`**: aviso honesto quando o WSS cai durante a chamada (antes: silêncio total).
3. **Keepalive**: `register_expires: 90` mantém tráfego no WSS através de middleboxes (o servidor pode sobrescrever via `expires`).
4. **Duração fantasma**: `callStartedAt` zerado em `makeCall` — rediscagem não-atendida não vira mais `'ended'` com 130s no `call_log`.
5. **LGPD/mic quente**: `releaseCallResources()` nos fins remotos (`ended`/`failed`) + `cleanupAudioResources()` no estado terminal do contexto — o mic é liberado na hora (red dot apaga; cliente para de ouvir o vendedor).
6. **Gravação obrigatória na Central** (política do founder): o switch do DialPad nasce **LIGADO**, vira exceção ("cliente pediu pra não gravar") e **re-arma a cada chamada**. Antes nascia desligado e número não-cadastrado ficava sem Sara/sem gravação.

## Evidência

- TDD: 13 testes novos (RED verificado antes do GREEN) — anti-stomp ×4, duração ×1, release remoto ×2, disconnected ×2, keepalive ×1, mic-terminal ×1, DialPad ×4 (um já-passante de regressão do escape hatch).
- Suíte completa: **2859/2859** · typecheck ✅ · lint 0 errors ✅.

## Deploy

**Frontend-only** — sem migration, sem edge function. ⚠️ **Requer Publish no Lovable** após o merge.

Follow-ups registrados (não bloqueiam): monitoramento de `oniceconnectionstatechange` (mídia), perguntar à Nvoip o idle-timeout do WSS + se há TURN, e `.limit(1)` no fallback de `profiles` do `resolveCustomerByPhone` (colisão de last-8 derruba o match).

🤖 Generated with [Claude Code](https://claude.com/claude-code)