### PR TITLE
feat(reposição): alerta R$3k Sayerlack + ciclo intra-day (motor 2/2h) + gate de mínimo de faturamento

### DIFF
--- a/db/test-alerta-pedido-minimo.sh
+++ b/db/test-alerta-pedido-minimo.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# Teste PG17 do alerta "pedido Sayerlack atingiu o mínimo de faturamento (R$3k)" — PR1.
+# Aplica schema-snapshot + a migration 20260609150000 e valida o tick em 11 asserts:
+# transição (1 e-mail), anti-spam (tick 2×), valor cresce sem re-spam (valor_ultimo),
+# aprovação resolve, re-arma com pedido novo, fornecedor fora do pattern, abaixo da régua,
+# config inválida não explode, grupo NULL × '' não duplica, CHECK aceita o tipo novo.
+# Base: db/verify-snapshot-replay.sh. Pré-req: brew install postgresql@17 pgvector.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PGVER=17
+PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+PORT=5436
+DATA="$(mktemp -d /tmp/pgtest-alerta3k.XXXXXX)/data"
+export LC_ALL=C LANG=C
+
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente: brew install postgresql@${PGVER} pgvector"; exit 1; }
+
+CELLAR="$(brew --prefix postgresql@${PGVER})"
+cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
+mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
+cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
+
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+trap cleanup EXIT
+
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l /tmp/pg-alerta3k.log -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres alerta3k_verify
+P() { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d alerta3k_verify "$@"; }
+
+RR="$(mktemp /tmp/snap-alerta3k.XXXXXX.sql)"
+sed -E 's/^(CREATE SCHEMA public;)/-- \1/' "$REPO_ROOT/supabase/schema-snapshot.sql" \
+  | grep -vE '^\\(un)?restrict ' > "$RR"
+
+echo "→ stubs + prelude + snapshot…"
+P -v ON_ERROR_STOP=1 -q -f "$REPO_ROOT/db/stubs-supabase.sql"
+P -v ON_ERROR_STOP=1 -q -f "$REPO_ROOT/supabase/schema-extensions-prelude.sql"
+P --single-transaction -v ON_ERROR_STOP=1 -q -f "$RR"
+rm -f "$RR"
+
+echo "→ stub cron.schedule (a migration agenda o tick; pg_cron não roda no PG local)…"
+P -v ON_ERROR_STOP=1 -q <<'SQL'
+CREATE OR REPLACE FUNCTION cron.schedule(p_jobname text, p_schedule text, p_command text)
+RETURNS bigint LANGUAGE plpgsql AS $$
+DECLARE v_id bigint;
+BEGIN
+  SELECT jobid INTO v_id FROM cron.job WHERE jobname = p_jobname;
+  IF v_id IS NULL THEN
+    SELECT COALESCE(MAX(jobid),0)+1 INTO v_id FROM cron.job;
+    INSERT INTO cron.job (jobid, jobname, schedule, command, active)
+    VALUES (v_id, p_jobname, p_schedule, p_command, true);
+  ELSE
+    UPDATE cron.job SET schedule = p_schedule, command = p_command WHERE jobid = v_id;
+  END IF;
+  RETURN v_id;
+END $$;
+SQL
+
+echo "→ aplica a migration 20260609150000 (alerta R\$3k)…"
+P -v ON_ERROR_STOP=1 -q -f "$REPO_ROOT/supabase/migrations/20260609150000_reposicao_alerta_pedido_minimo.sql" >/dev/null
+
+echo "→ cenários + asserts…"
+P -v ON_ERROR_STOP=1 -q <<'SQL'
+DO $$
+DECLARE d int; v numeric; pid bigint;
+BEGIN
+  -- ── A1: transição — pedido Sayerlack pendente ≥ régua → 1 alerta ativo + 1 e-mail ──
+  INSERT INTO pedido_compra_sugerido (empresa, fornecedor_nome, grupo_codigo, data_ciclo, valor_total, num_skus, status, tipo_ciclo)
+  VALUES ('OBEN','SAYERLACK DO BRASIL LTDA','G1',CURRENT_DATE,3200,5,'pendente_aprovacao','normal')
+  RETURNING id INTO pid;
+  PERFORM public.reposicao_alerta_pedido_minimo_tick();
+
+  SELECT count(*) INTO d FROM reposicao_alerta_pedido_minimo WHERE resolvido_em IS NULL;
+  IF d <> 1 THEN RAISE EXCEPTION 'A1 FALHOU: % alertas ativos, esperado 1', d; END IF;
+  SELECT count(*) INTO d FROM fornecedor_alerta WHERE tipo='reposicao_pedido_minimo' AND status='pendente_notificacao';
+  IF d <> 1 THEN RAISE EXCEPTION 'A1 FALHOU: % e-mails enfileirados, esperado 1', d; END IF;
+  RAISE NOTICE 'OK A1 — transição: 1 alerta ativo + 1 e-mail (CHECK aceita o tipo novo)';
+
+  -- ── A2: anti-spam — tick de novo NÃO re-enfileira ──
+  PERFORM public.reposicao_alerta_pedido_minimo_tick();
+  SELECT count(*) INTO d FROM fornecedor_alerta WHERE tipo='reposicao_pedido_minimo';
+  IF d <> 1 THEN RAISE EXCEPTION 'A2 FALHOU: % e-mails, esperado 1 (anti-spam)', d; END IF;
+  RAISE NOTICE 'OK A2 — anti-spam: tick repetido não re-enfileira';
+
+  -- ── A3: valor cresce 3.2k→10k → valor_ultimo atualiza, SEM novo e-mail ──
+  UPDATE pedido_compra_sugerido SET valor_total = 10000 WHERE id = pid;
+  PERFORM public.reposicao_alerta_pedido_minimo_tick();
+  SELECT valor_ultimo INTO v FROM reposicao_alerta_pedido_minimo WHERE resolvido_em IS NULL;
+  IF v <> 10000 THEN RAISE EXCEPTION 'A3 FALHOU: valor_ultimo=%, esperado 10000', v; END IF;
+  SELECT count(*) INTO d FROM fornecedor_alerta WHERE tipo='reposicao_pedido_minimo';
+  IF d <> 1 THEN RAISE EXCEPTION 'A3 FALHOU: % e-mails, esperado 1', d; END IF;
+  RAISE NOTICE 'OK A3 — valor cresce sem re-spam (valor_ultimo=10000)';
+
+  -- ── A4: aprovação resolve (re-arma) ──
+  UPDATE pedido_compra_sugerido SET status = 'aprovado_aguardando_disparo' WHERE id = pid;
+  PERFORM public.reposicao_alerta_pedido_minimo_tick();
+  SELECT count(*) INTO d FROM reposicao_alerta_pedido_minimo WHERE resolvido_em IS NULL;
+  IF d <> 0 THEN RAISE EXCEPTION 'A4 FALHOU: % alertas ativos pós-aprovação, esperado 0', d; END IF;
+  RAISE NOTICE 'OK A4 — aprovação resolve o alerta';
+
+  -- ── A5: re-arma — pedido NOVO do mesmo fornecedor/grupo cruza a régua → e-mail NOVO ──
+  INSERT INTO pedido_compra_sugerido (empresa, fornecedor_nome, grupo_codigo, data_ciclo, valor_total, num_skus, status, tipo_ciclo)
+  VALUES ('OBEN','SAYERLACK DO BRASIL LTDA','G1',CURRENT_DATE,3100,4,'pendente_aprovacao','normal');
+  PERFORM public.reposicao_alerta_pedido_minimo_tick();
+  SELECT count(*) INTO d FROM reposicao_alerta_pedido_minimo WHERE resolvido_em IS NULL;
+  IF d <> 1 THEN RAISE EXCEPTION 'A5 FALHOU: % ativos, esperado 1', d; END IF;
+  SELECT count(*) INTO d FROM fornecedor_alerta WHERE tipo='reposicao_pedido_minimo';
+  IF d <> 2 THEN RAISE EXCEPTION 'A5 FALHOU: % e-mails, esperado 2 (re-armou)', d; END IF;
+  RAISE NOTICE 'OK A5 — re-arma: pedido novo do grupo gera e-mail novo';
+
+  -- ── A6: fornecedor fora do pattern não alerta ──
+  INSERT INTO pedido_compra_sugerido (empresa, fornecedor_nome, grupo_codigo, data_ciclo, valor_total, num_skus, status, tipo_ciclo)
+  VALUES ('OBEN','ACRE CAXIAS','',CURRENT_DATE,5000,3,'pendente_aprovacao','normal');
+  PERFORM public.reposicao_alerta_pedido_minimo_tick();
+  SELECT count(*) INTO d FROM reposicao_alerta_pedido_minimo a WHERE a.fornecedor_nome='ACRE CAXIAS';
+  IF d <> 0 THEN RAISE EXCEPTION 'A6 FALHOU: fornecedor fora do pattern alertou'; END IF;
+  RAISE NOTICE 'OK A6 — fornecedor fora do pattern não alerta';
+
+  -- ── A7: Sayerlack abaixo da régua não alerta ──
+  INSERT INTO pedido_compra_sugerido (empresa, fornecedor_nome, grupo_codigo, data_ciclo, valor_total, num_skus, status, tipo_ciclo)
+  VALUES ('OBEN','SAYERLACK DO BRASIL LTDA','G2',CURRENT_DATE,2000,2,'pendente_aprovacao','normal');
+  PERFORM public.reposicao_alerta_pedido_minimo_tick();
+  SELECT count(*) INTO d FROM reposicao_alerta_pedido_minimo a WHERE a.grupo_codigo='G2' AND a.resolvido_em IS NULL;
+  IF d <> 0 THEN RAISE EXCEPTION 'A7 FALHOU: pedido abaixo da régua alertou'; END IF;
+  RAISE NOTICE 'OK A7 — abaixo da régua não alerta';
+
+  -- ── A8: config inválida → tick vira no-op limpo (nada novo, nada explode) ──
+  UPDATE company_config SET value = '0' WHERE key = 'reposicao_alerta_pedido_valor_minimo';
+  PERFORM public.reposicao_alerta_pedido_minimo_tick();
+  SELECT count(*) INTO d FROM fornecedor_alerta WHERE tipo='reposicao_pedido_minimo';
+  IF d <> 2 THEN RAISE EXCEPTION 'A8 FALHOU: config inválida gerou e-mail'; END IF;
+  UPDATE company_config SET value = '3000' WHERE key = 'reposicao_alerta_pedido_valor_minimo';
+  RAISE NOTICE 'OK A8 — config inválida desliga o alerta sem erro';
+
+  -- ── A9: grupo NULL × '' são a MESMA identidade (não duplica alerta/e-mail) ──
+  -- (G2 de 2k continua pendente; criamos NULL 3500 e '' 3600 — devem virar UM alerta só.)
+  INSERT INTO pedido_compra_sugerido (empresa, fornecedor_nome, grupo_codigo, data_ciclo, valor_total, num_skus, status, tipo_ciclo)
+  VALUES ('OBEN','SAYERLACK DO BRASIL LTDA',NULL,CURRENT_DATE,3500,3,'pendente_aprovacao','normal'),
+         ('OBEN','SAYERLACK DO BRASIL LTDA','',CURRENT_DATE,3600,3,'pendente_aprovacao','normal');
+  PERFORM public.reposicao_alerta_pedido_minimo_tick();
+  SELECT count(*) INTO d FROM reposicao_alerta_pedido_minimo a
+  WHERE a.grupo_codigo='' AND a.resolvido_em IS NULL;
+  IF d <> 1 THEN RAISE EXCEPTION 'A9 FALHOU: % alertas pra identidade NULL/vazio, esperado 1', d; END IF;
+  SELECT valor_ultimo INTO v FROM reposicao_alerta_pedido_minimo a
+  WHERE a.grupo_codigo='' AND a.resolvido_em IS NULL;
+  IF v <> 3600 THEN RAISE EXCEPTION 'A9 FALHOU: valor_ultimo=% (esperado MAX=3600)', v; END IF;
+  RAISE NOTICE 'OK A9 — grupo NULL e vazio = mesma identidade (1 alerta, MAX valor)';
+
+  -- ── A10: resolve quando o valor CAI abaixo da régua ──
+  UPDATE pedido_compra_sugerido SET valor_total = 2900
+  WHERE fornecedor_nome='SAYERLACK DO BRASIL LTDA' AND COALESCE(grupo_codigo,'')='' AND status='pendente_aprovacao';
+  PERFORM public.reposicao_alerta_pedido_minimo_tick();
+  SELECT count(*) INTO d FROM reposicao_alerta_pedido_minimo a
+  WHERE a.grupo_codigo='' AND a.resolvido_em IS NULL;
+  IF d <> 0 THEN RAISE EXCEPTION 'A10 FALHOU: alerta não resolveu quando caiu da régua'; END IF;
+  RAISE NOTICE 'OK A10 — valor caiu da régua → resolve (re-arma)';
+
+  -- ── A11: cron agendado ──
+  SELECT count(*) INTO d FROM cron.job WHERE jobname='reposicao-alerta-pedido-minimo';
+  IF d <> 1 THEN RAISE EXCEPTION 'A11 FALHOU: cron não agendado'; END IF;
+  RAISE NOTICE 'OK A11 — cron reposicao-alerta-pedido-minimo agendado';
+
+  RAISE NOTICE '✅ TODOS OS 11 ASSERTS DO ALERTA R$3K PASSARAM';
+END $$;
+SQL
+
+echo "✅ test-alerta-pedido-minimo: OK"

--- a/db/test-rpc-intraday.sh
+++ b/db/test-rpc-intraday.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+# Teste PG17 do ciclo INTRA-DAY — PR2 (migration 20260609160000).
+# Aplica schema-snapshot + a def viva da RPC (20260606190000) + a migration intra-day, semeia
+# cenários e valida as 4 marcas [INTRADAY] em 8 asserts: limpeza preserva oportunidade pendente,
+# limpeza apaga bloqueado_guardrail normal do dia (e o SKU renasce 1×, não 2), zumbi de ontem
+# expira, NOT EXISTS exclui SKU de oportunidade, aprovado intacto, comportamento base inalterado,
+# crons agendados, marcas presentes na def.
+# Base: db/test-rpc-account-aware.sh. Pré-req: brew install postgresql@17 pgvector.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PGVER=17
+PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+PORT=5437
+DATA="$(mktemp -d /tmp/pgtest-intraday.XXXXXX)/data"
+export LC_ALL=C LANG=C
+
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente: brew install postgresql@${PGVER} pgvector"; exit 1; }
+
+CELLAR="$(brew --prefix postgresql@${PGVER})"
+cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
+mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
+cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
+
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+trap cleanup EXIT
+
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l /tmp/pg-intraday.log -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres intraday_verify
+P() { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d intraday_verify "$@"; }
+
+RR="$(mktemp /tmp/snap-intraday.XXXXXX.sql)"
+sed -E 's/^(CREATE SCHEMA public;)/-- \1/' "$REPO_ROOT/supabase/schema-snapshot.sql" \
+  | grep -vE '^\\(un)?restrict ' > "$RR"
+
+echo "→ stubs + prelude + snapshot…"
+P -v ON_ERROR_STOP=1 -q -f "$REPO_ROOT/db/stubs-supabase.sql"
+P -v ON_ERROR_STOP=1 -q -f "$REPO_ROOT/supabase/schema-extensions-prelude.sql"
+P --single-transaction -v ON_ERROR_STOP=1 -q -f "$RR"
+rm -f "$RR"
+
+echo "→ foundation (colunas stale no snapshot) + stub cron.schedule…"
+P -v ON_ERROR_STOP=1 -q <<'SQL'
+ALTER TABLE public.omie_products ADD COLUMN IF NOT EXISTS tipo_produto text;
+ALTER TABLE public.sku_parametros ADD COLUMN IF NOT EXISTS minimo_forcado_manual numeric;
+CREATE OR REPLACE FUNCTION cron.schedule(p_jobname text, p_schedule text, p_command text)
+RETURNS bigint LANGUAGE plpgsql AS $$
+DECLARE v_id bigint;
+BEGIN
+  SELECT jobid INTO v_id FROM cron.job WHERE jobname = p_jobname;
+  IF v_id IS NULL THEN
+    SELECT COALESCE(MAX(jobid),0)+1 INTO v_id FROM cron.job;
+    INSERT INTO cron.job (jobid, jobname, schedule, command, active)
+    VALUES (v_id, p_jobname, p_schedule, p_command, true);
+  ELSE
+    UPDATE cron.job SET schedule = p_schedule, command = p_command WHERE jobid = v_id;
+  END IF;
+  RETURN v_id;
+END $$;
+SQL
+
+echo "→ base: 20260606190000 (def VIVA da RPC, A2-CMC-ACCOUNT)…"
+P -v ON_ERROR_STOP=1 -q -f "$REPO_ROOT/supabase/migrations/20260606190000_reposicao_preco_pedido_cmc_account.sql" >/dev/null
+
+echo "→ aplica a migration INTRA-DAY: 20260609160000…"
+P -v ON_ERROR_STOP=1 -q -f "$REPO_ROOT/supabase/migrations/20260609160000_reposicao_ciclo_intraday.sql" >/dev/null
+
+echo "→ seed…"
+P -v ON_ERROR_STOP=1 -q <<'SQL'
+-- 3 SKUs OBEN que PRECISAM repor (estoque 90 ≤ pp 100; natural = 100-90 = 10) + 1 que não.
+INSERT INTO public.omie_products (omie_codigo_produto, codigo, descricao, account, ativo, familia, tipo_produto) VALUES
+  (4001,'4001','PROD 4001','oben',true,'F1','00'),
+  (4002,'4002','PROD 4002','oben',true,'F1','00'),
+  (4003,'4003','PROD 4003','oben',true,'F1','00'),
+  (4004,'4004','PROD 4004','oben',true,'F1','00');
+INSERT INTO public.sku_parametros
+  (empresa, sku_codigo_omie, sku_descricao, fornecedor_nome, ponto_pedido, estoque_maximo,
+   habilitado_reposicao_automatica, tipo_reposicao, minimo_forcado_manual, ativo) VALUES
+  ('OBEN',4001,'SKU 4001','FORN-A',100,100,true,'automatica',NULL,true),
+  ('OBEN',4002,'SKU 4002','FORN-B',100,100,true,'automatica',NULL,true),
+  ('OBEN',4003,'SKU 4003','FORN-C',100,100,true,'automatica',NULL,true),
+  ('OBEN',4004,'SKU 4004','FORN-D',100,100,true,'automatica',NULL,true);
+INSERT INTO public.sku_estoque_atual (empresa, sku_codigo_omie, estoque_fisico, estoque_pendente_entrada) VALUES
+  ('OBEN','4001',90,0), ('OBEN','4002',90,0), ('OBEN','4003',90,0),
+  ('OBEN','4004',200,0); -- 4004 NÃO precisa (acima do ponto)
+INSERT INTO public.inventory_position (omie_codigo_produto, account, cmc) VALUES
+  (4001,'vendas',10),(4002,'vendas',10),(4003,'vendas',10),(4004,'vendas',10);
+
+-- Cenário A (tipo-aware + NOT EXISTS): pedido de OPORTUNIDADE pendente do dia contendo o SKU 4001.
+INSERT INTO public.pedido_compra_sugerido (empresa, fornecedor_nome, grupo_codigo, data_ciclo, valor_total, num_skus, status, tipo_ciclo)
+VALUES ('OBEN','FORN-A',NULL,CURRENT_DATE,500,1,'pendente_aprovacao','oportunidade_promo');
+INSERT INTO public.pedido_compra_item (pedido_id, sku_codigo_omie, sku_descricao, qtde_sugerida, qtde_final, preco_unitario, valor_linha)
+SELECT id, '4001', 'SKU 4001', 50, 50, 10, 500 FROM public.pedido_compra_sugerido WHERE tipo_ciclo='oportunidade_promo';
+
+-- Cenário B (bloqueado do dia entra na limpeza): pedido NORMAL bloqueado_guardrail do dia com SKU 4002.
+INSERT INTO public.pedido_compra_sugerido (empresa, fornecedor_nome, grupo_codigo, data_ciclo, valor_total, num_skus, status, tipo_ciclo)
+VALUES ('OBEN','FORN-B',NULL,CURRENT_DATE,999,1,'bloqueado_guardrail','normal');
+INSERT INTO public.pedido_compra_item (pedido_id, sku_codigo_omie, sku_descricao, qtde_sugerida, qtde_final, preco_unitario, valor_linha)
+SELECT id, '4002', 'SKU 4002', 99, 99, 10, 999 FROM public.pedido_compra_sugerido WHERE status='bloqueado_guardrail';
+
+-- Cenário C (zumbi): pendente NORMAL de ONTEM.
+INSERT INTO public.pedido_compra_sugerido (empresa, fornecedor_nome, grupo_codigo, data_ciclo, valor_total, num_skus, status, tipo_ciclo)
+VALUES ('OBEN','FORN-Z',NULL,CURRENT_DATE - 1,777,1,'pendente_aprovacao','normal');
+
+-- Cenário D (intacto): pedido APROVADO de hoje (não pode ser tocado pela limpeza).
+INSERT INTO public.pedido_compra_sugerido (empresa, fornecedor_nome, grupo_codigo, data_ciclo, valor_total, num_skus, status, tipo_ciclo)
+VALUES ('OBEN','FORN-APR',NULL,CURRENT_DATE,1234,1,'aprovado_aguardando_disparo','normal');
+
+-- Zumbi de OPORTUNIDADE de ontem: NÃO deve ser expirado pela RPC normal (território do outro ciclo).
+INSERT INTO public.pedido_compra_sugerido (empresa, fornecedor_nome, grupo_codigo, data_ciclo, valor_total, num_skus, status, tipo_ciclo)
+VALUES ('OBEN','FORN-OPP-Z',NULL,CURRENT_DATE - 1,333,1,'pendente_aprovacao','oportunidade_aumento');
+SQL
+
+echo "→ roda a RPC (rodada intra-day simulada)…"
+P -v ON_ERROR_STOP=1 -q -c "SELECT * FROM public.gerar_pedidos_sugeridos_ciclo('OBEN', CURRENT_DATE);" >/dev/null
+
+echo "→ asserts…"
+P -v ON_ERROR_STOP=1 -q <<'SQL'
+DO $$
+DECLARE d int; s text;
+BEGIN
+  -- I1: oportunidade pendente do dia PRESERVADA (limpeza tipo-aware)
+  SELECT count(*) INTO d FROM pedido_compra_sugerido
+  WHERE tipo_ciclo='oportunidade_promo' AND status='pendente_aprovacao' AND data_ciclo=CURRENT_DATE;
+  IF d <> 1 THEN RAISE EXCEPTION 'I1 FALHOU: oportunidade do dia foi apagada (count=%)', d; END IF;
+  RAISE NOTICE 'OK I1 — limpeza preserva pedido de oportunidade pendente do dia';
+
+  -- I2: SKU 4001 (na oportunidade pendente) NÃO re-sugerido no ciclo normal (NOT EXISTS)
+  SELECT count(*) INTO d FROM pedido_compra_item pci
+  JOIN pedido_compra_sugerido pcs ON pcs.id = pci.pedido_id
+  WHERE pci.sku_codigo_omie='4001' AND pcs.status='pendente_aprovacao'
+    AND COALESCE(pcs.tipo_ciclo,'normal')='normal' AND pcs.data_ciclo=CURRENT_DATE;
+  IF d <> 0 THEN RAISE EXCEPTION 'I2 FALHOU: SKU da oportunidade re-sugerido no normal (compra dupla)'; END IF;
+  RAISE NOTICE 'OK I2 — NOT EXISTS: SKU em oportunidade pendente não nasce no ciclo normal';
+
+  -- I3: bloqueado_guardrail NORMAL do dia foi APAGADO e o SKU 4002 renasceu pendente 1× (não 2)
+  SELECT count(*) INTO d FROM pedido_compra_sugerido WHERE status='bloqueado_guardrail';
+  IF d <> 0 THEN RAISE EXCEPTION 'I3 FALHOU: bloqueado_guardrail do dia sobreviveu à limpeza'; END IF;
+  SELECT count(*) INTO d FROM pedido_compra_item pci
+  JOIN pedido_compra_sugerido pcs ON pcs.id = pci.pedido_id
+  WHERE pci.sku_codigo_omie='4002' AND pcs.status='pendente_aprovacao' AND pcs.data_ciclo=CURRENT_DATE;
+  IF d <> 1 THEN RAISE EXCEPTION 'I3 FALHOU: SKU 4002 aparece %× pendente (esperado 1 — anti compra dupla)', d; END IF;
+  RAISE NOTICE 'OK I3 — bloqueado normal do dia re-avaliado (apagado + SKU renasce 1×)';
+
+  -- I4: zumbi pendente NORMAL de ontem EXPIRADO
+  SELECT status INTO s FROM pedido_compra_sugerido WHERE fornecedor_nome='FORN-Z';
+  IF s <> 'expirado_sem_aprovacao' THEN RAISE EXCEPTION 'I4 FALHOU: zumbi de ontem status=%', s; END IF;
+  RAISE NOTICE 'OK I4 — pendente normal de ontem expirado pela rodada de hoje';
+
+  -- I5: zumbi de OPORTUNIDADE de ontem NÃO tocado (território do outro ciclo)
+  SELECT status INTO s FROM pedido_compra_sugerido WHERE fornecedor_nome='FORN-OPP-Z';
+  IF s <> 'pendente_aprovacao' THEN RAISE EXCEPTION 'I5 FALHOU: oportunidade de ontem foi tocada (status=%)', s; END IF;
+  RAISE NOTICE 'OK I5 — oportunidade de ontem intocada (fora do território da RPC normal)';
+
+  -- I6: aprovado de hoje INTACTO + comportamento base (4003 abaixo do ponto vira pendente; 4004 não)
+  SELECT status INTO s FROM pedido_compra_sugerido WHERE fornecedor_nome='FORN-APR';
+  IF s <> 'aprovado_aguardando_disparo' THEN RAISE EXCEPTION 'I6 FALHOU: aprovado foi tocado (%)', s; END IF;
+  SELECT count(*) INTO d FROM pedido_compra_item pci
+  JOIN pedido_compra_sugerido pcs ON pcs.id = pci.pedido_id
+  WHERE pci.sku_codigo_omie='4003' AND pcs.status='pendente_aprovacao' AND pcs.data_ciclo=CURRENT_DATE;
+  IF d <> 1 THEN RAISE EXCEPTION 'I6 FALHOU: SKU 4003 (necessita) não gerou pedido'; END IF;
+  SELECT count(*) INTO d FROM pedido_compra_item pci
+  JOIN pedido_compra_sugerido pcs ON pcs.id = pci.pedido_id
+  WHERE pci.sku_codigo_omie='4004' AND pcs.status='pendente_aprovacao';
+  IF d <> 0 THEN RAISE EXCEPTION 'I6 FALHOU: SKU 4004 (sobra de estoque) gerou pedido'; END IF;
+  RAISE NOTICE 'OK I6 — aprovado intacto; base inalterada (4003 entra, 4004 não)';
+
+  -- I7: re-rodada idempotente (mesmo dia, 2ª vez) mantém as invariantes I1/I2/I5
+  PERFORM public.gerar_pedidos_sugeridos_ciclo('OBEN', CURRENT_DATE);
+  SELECT count(*) INTO d FROM pedido_compra_sugerido
+  WHERE tipo_ciclo LIKE 'oportunidade%' AND status='pendente_aprovacao';
+  IF d <> 2 THEN RAISE EXCEPTION 'I7 FALHOU: re-rodada mexeu nas oportunidades (count=%)', d; END IF;
+  SELECT count(*) INTO d FROM pedido_compra_item pci
+  JOIN pedido_compra_sugerido pcs ON pcs.id = pci.pedido_id
+  WHERE pci.sku_codigo_omie IN ('4002','4003') AND pcs.status='pendente_aprovacao' AND pcs.data_ciclo=CURRENT_DATE;
+  IF d <> 2 THEN RAISE EXCEPTION 'I7 FALHOU: re-rodada duplicou/perdeu SKUs (count=%)', d; END IF;
+  RAISE NOTICE 'OK I7 — re-rodada no mesmo dia: idempotente, sem duplicação';
+
+  -- I8: crons agendados + marcas na def viva
+  SELECT count(*) INTO d FROM cron.job WHERE jobname IN ('gerar-pedidos-intraday-oben','omie-sync-estoque-intraday-oben');
+  IF d <> 2 THEN RAISE EXCEPTION 'I8 FALHOU: crons intraday ausentes (%)', d; END IF;
+  SELECT schedule INTO s FROM cron.job WHERE jobname='omie-sync-estoque-diario';
+  IF s <> '0 9 * * *' THEN RAISE EXCEPTION 'I8 FALHOU: omie-sync-estoque-diario não reagendado (%)', s; END IF;
+  SELECT count(*) INTO d FROM pg_proc WHERE proname='gerar_pedidos_sugeridos_ciclo'
+    AND pg_get_functiondef(oid) LIKE '%INTRADAY 4/4%' AND pg_get_functiondef(oid) LIKE '%pg_advisory_xact_lock%';
+  IF d <> 1 THEN RAISE EXCEPTION 'I8 FALHOU: marcas INTRADAY ausentes na def'; END IF;
+  RAISE NOTICE 'OK I8 — crons agendados (diário reagendado 0 9) + marcas na def';
+
+  RAISE NOTICE '✅ TODOS OS 8 ASSERTS DO INTRA-DAY PASSARAM';
+END $$;
+SQL
+
+echo "✅ test-rpc-intraday: OK"

--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,14 +21,14 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **189** custom migrations totais
-- **702** objetos esperados (criados por estas migrations)
+- **191** custom migrations totais
+- **710** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
   - `rls_policy`: 181
-  - `function`: 172
-  - `index`: 130
-  - `cron_job`: 97
-  - `table`: 81
+  - `function`: 174
+  - `index`: 131
+  - `cron_job`: 101
+  - `table`: 82
   - `trigger`: 37
   - `enum_value`: 4
 
@@ -1656,6 +1656,24 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | `function` | `public._data_health_compute` | — |
 | `function` | `public.data_health_watchdog` | — |
 | `function` | `public.fin_sync_heartbeat` | — |
+
+### `20260609150000_reposicao_alerta_pedido_minimo.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `table` | `public.reposicao_alerta_pedido_minimo` | — |
+| `index` | `public.reposicao_alerta_pedido_minimo_ativo` | `reposicao_alerta_pedido_minimo` |
+| `function` | `public.reposicao_alerta_pedido_minimo_tick` | — |
+| `cron_job` | `cron.reposicao-alerta-pedido-minimo` | — |
+
+### `20260609160000_reposicao_ciclo_intraday.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `public.gerar_pedidos_sugeridos_ciclo` | — |
+| `cron_job` | `cron.gerar-pedidos-intraday-oben` | — |
+| `cron_job` | `cron.omie-sync-estoque-intraday-oben` | — |
+| `cron_job` | `cron.omie-sync-estoque-diario` | — |
 
 ## Próximos passos quando algo der `❌`
 

--- a/docs/roadmap-sessao.md
+++ b/docs/roadmap-sessao.md
@@ -1,8 +1,29 @@
-# Roadmap da Sessão — atualizado 2026-06-06
+# Roadmap da Sessão — atualizado 2026-06-09
 
 > **Documento vivo.** Re-feito sempre que acrescentamos OU concluímos uma atividade, e renderizado no chat quando muda, pra o founder acompanhar. Prática padrão de toda sessão (registrada no CLAUDE.md, topo).
 >
 > **Legenda:** ✅ feito · 🔄 em andamento · ⏳ pendente · 🚧 bloqueado · ⏸️ adiado (decisão consciente) · 🧭 aguardando decisão (eu+codex)
+
+---
+
+## 0. SESSÃO 2026-06-09 — Reposição intra-day + alerta R$3k Sayerlack + dente de serra
+
+> Pedido do founder: (1) e-mail toda vez que um pedido sugerido der R$3.000+ (mínimo de faturamento
+> da Sayerlack — pode acontecer várias vezes ao dia, pedidos diferentes); (2) motor de sugestões
+> rodando com maior frequência ao longo do dia (reduzir lead time); (3) formas de reduzir o período
+> de estoque ("dente de serra") em compras.
+
+- ✅ **Exploração do terreno** — crons/cadências (estoque do motor `sku_estoque_atual` = 3×/dia via `omie-sync-estoque`; motor 1×/dia 9h15 UTC; `inventory_position` já 30min), RPC vigente (`20260606190000`), infra de alerta (`fornecedor_alerta` + dispatch */30 + padrão transição).
+- ✅ **Decisões do founder (AskUserQuestion)** — gatilho = **por pedido sugerido Sayerlack ≥ R$3k** (mínimo de faturamento; vários e-mails/dia ok, pedidos diferentes); cadência = **a cada 2h em horário comercial**.
+- ✅ **Passe adversarial** — Codex em usage-limit até 11/06 → caminho B (eu + PG17). Furos achados: bloqueado_guardrail do dia precisa entrar na limpeza (senão re-gen duplica SKUs); NOT EXISTS contra oportunidade pendente; zumbis de data_ciclo anterior; grupo NULL na identidade do alerta; deep-link com id morre no re-gen.
+- 🔄 **Design apresentado ao founder** — aguardando GO.
+- ⏳ Spec em `docs/superpowers/specs/2026-06-09-reposicao-intraday-alerta-3k-design.md`
+- ⏳ **PR1 — alerta R$3k Sayerlack** (migration SQL pura: tabela de estado + tipo no CHECK + tick + cron */30 + hook na edge de geração)
+- ⏳ **PR2 — ciclo intra-day** (RPC: limpeza tipo-aware + bloqueados do dia + expiração de zumbis + advisory lock + NOT EXISTS oportunidade; crons 2/2h; edge flag digest)
+- ⏳ **Validação PG17 local** (scripts `db/test-*.sh` aplicando as migrations reais)
+- ⏳ **Análise dente de serra** — fase 1 = intra-day (adianta disparo ~0,5–1d) + alerta R$3k (lote ótimo ≈ mínimo de faturamento); fase 2 (recalibrar ponto_pedido/cobertura/SS com R=2h via esteira `param_auto`) gated em 2–4 semanas de medição.
+- ⏳ **Founder (pós-merge):** colar blocos SQL no SQL Editor + deploy da `gerar-pedidos-diario` via chat do Lovable.
+- ⏸️ **Codex adversarial retroativo** (quando a cota voltar, 11/06+) — revisar PR1+PR2.
 
 ---
 

--- a/docs/superpowers/specs/2026-06-09-reposicao-intraday-alerta-3k-design.md
+++ b/docs/superpowers/specs/2026-06-09-reposicao-intraday-alerta-3k-design.md
@@ -1,0 +1,179 @@
+# Reposição intra-day + alerta R$3k Sayerlack + gate de mínimo de faturamento — design
+
+> 2026-06-09. Pedido do founder: (1) e-mail toda vez que um pedido sugerido der R$3.000+ no cockpit
+> — **R$3.000 é o mínimo de faturamento da Sayerlack**; pode acontecer várias vezes ao dia, com
+> pedidos diferentes; (2) motor de sugestões rodando com maior frequência ao longo do dia, pra
+> reduzir lead time (pedido que sairia amanhã sai hoje); (3) reduzir o período de estoque ("dente
+> de serra") em compras. Decisões do founder (AskUserQuestion): gatilho **por pedido** ≥ R$3k;
+> cadência **a cada 2h em horário comercial**; **GATE no disparo** barrando pedido Sayerlack
+> < R$3k (que a Sayerlack não fatura).
+
+## Contexto descoberto (o que muda o desenho)
+
+- O estoque que o **motor lê** (`sku_estoque_atual.estoque_fisico/estoque_pendente_entrada`, edge
+  `omie-sync-estoque`) sincroniza **3×/dia** (9, 14, 19 UTC). O `inventory_position` (cmc) já
+  sincroniza a cada 30min. O **motor** (`gerar_pedidos_sugeridos_ciclo` via edge
+  `gerar-pedidos-diario`) roda **1×/dia** (9h15 UTC). O gargalo é o motor, não a consulta ao Omie.
+- A **limpeza** da RPC vigente (`20260606190000`) é `DELETE ... WHERE empresa AND data_ciclo=hoje
+  AND status='pendente_aprovacao'` — **tipo_ciclo-blind** (apagaria oportunidades pendentes das
+  11h05 UTC), não toca `bloqueado_guardrail`, sem advisory lock.
+- O **corte** (`disparar-pedidos-aprovados`, 13h UTC) expira pendentes com `.eq('data_ciclo',
+  hoje)` — rodadas pós-corte criariam **zumbis** (pendentes de data_ciclo antigo que nada expira e
+  o cockpit, que filtra hoje, não mostra).
+- Aprovação manual **já dispara na hora** (#638). `runAutoApprove` é client-side (só ao abrir o
+  painel). O `ciclo_oportunidade_do_dia` (11h05 UTC) tem limpeza própria **tipo-aware** (apaga só
+  os pendentes `oportunidade_%` do dia) — falta a simetria no motor normal.
+- O split Sayerlack (`dividirPedidosGrandesSayerlack`, >4 itens) roda **dentro do disparo**, marca
+  filhos com `split_parent_id`. Um pai ≥R$3k pode virar filhos <R$3k cada — o mínimo de
+  faturamento vale pro **valor aprovado**, não pro filho.
+- Infra de e-mail: `fornecedor_alerta` (CHECK de tipo vigente na `20260605120000`, 11 valores) →
+  `dispatch-notifications` cron `*/30`. Padrão anti-spam de transição: UNIQUE parcial
+  `WHERE dismissed/resolvido IS NULL` + `ON CONFLICT DO NOTHING` + `IF FOUND → enfileira`.
+- ⚠️ Codex em usage-limit até 11/06 → **caminho B** (acordado em precedente): passe adversarial
+  próprio + validação PG17 exaustiva; Codex retroativo quando voltar.
+
+## PR1 — Alerta "pedido Sayerlack atingiu R$3k" (SQL puro)
+
+Migration `20260609150000_reposicao_alerta_pedido_minimo.sql`:
+
+1. **CHECK** de `fornecedor_alerta.tipo` estendido (lista vigente + `reposicao_pedido_minimo`).
+2. **Config** em `company_config`: `reposicao_alerta_pedido_valor_minimo` = `'3000'`,
+   `reposicao_alerta_pedido_fornecedor_ilike` = `'%SAYERLACK%'` (a régua é UMA — alerta e gate
+   leem as mesmas keys).
+3. **Tabela de estado** `reposicao_alerta_pedido_minimo` (empresa, fornecedor_nome,
+   `grupo_codigo text NOT NULL DEFAULT ''` — NULL e '' são a MESMA identidade, senão o UNIQUE
+   parcial com NULL deixa duplicar; pedido_id informativo — o id morre na regeneração;
+   valor_alertado/valor_ultimo; alertado_em/resolvido_em). UNIQUE parcial
+   `(empresa, fornecedor_nome, grupo_codigo) WHERE resolvido_em IS NULL`. RLS: SELECT staff;
+   escrita só definer/service_role.
+4. **Tick** `reposicao_alerta_pedido_minimo_tick()` (SECURITY DEFINER, REVOKE de
+   anon/authenticated/PUBLIC, GRANT service_role — a edge de geração chama via `.rpc`):
+   - Config ausente/inválida → RETURN (alerta desligado; é régua comercial, não segurança).
+   - **Novos**: pendente_aprovacao com `fornecedor_nome ILIKE pattern` e `valor_total ≥ régua`,
+     agrupado por (empresa, fornecedor, COALESCE(grupo,'')) → INSERT estado `ON CONFLICT ... DO
+     NOTHING`; `IF FOUND` → enfileira `fornecedor_alerta` (1 e-mail por transição). Alerta já
+     ativo → só atualiza `valor_ultimo` (3.2k→10k não re-spamma; o valor vivo está no cockpit).
+   - **Resolve**: ativo sem pendente ≥ régua correspondente → `resolvido_em=now()` (re-arma: o
+     próximo pedido do grupo que cruzar R$3k gera e-mail novo — "aprovei → quando acumular de
+     novo, me avisa").
+   - E-mail: título `[Compras] Pedido SAYERLACK atingiu R$ X — pronto pra aprovar`; corpo com
+     grupo, nº SKUs e link **genérico** pra `/admin/reposicao/pedidos` (deep-link `?id=` morreria
+     na regeneração seguinte).
+5. **Cron** `reposicao-alerta-pedido-minimo` `*/30 * * * *` (SQL local, sem `net.http_post` —
+   sem armadilha de timeout). Latência pior-caso ~60min (tick + dispatch); com o hook do PR2 na
+   edge, cai pra ≤30min (só o dispatch).
+
+Por que por-pedido e não saldo total: R$3k é mínimo de **faturamento por pedido** na Sayerlack —
+o founder aprova pedido a pedido, e o pedido sugerido (fornecedor+grupo) é a unidade que vira PO.
+
+## PR2 — Ciclo intra-day + gate de disparo
+
+### Migration `20260609160000_reposicao_ciclo_intraday.sql`
+
+RPC `gerar_pedidos_sugeridos_ciclo` = corpo **VERBATIM** da `20260606190000` + 4 marcas
+`[INTRADAY]` (pré-requisitos de segurança pra regeneração 6×/dia):
+
+1. **Advisory lock** `pg_advisory_xact_lock(hashtext('gerar_pedidos_sugeridos_ciclo:'||
+   lower(p_empresa)))` — serializa cron × botão manual × retry (a RPC não tinha proteção; com
+   1×/dia nunca colidia).
+2. **Expira zumbis**: `UPDATE → expirado_sem_aprovacao` de pendentes **normais** com
+   `data_ciclo < p_data_ciclo` (rodadas pós-corte criam pendentes que o corte `.eq` nunca expira;
+   dentro da RPC cobre cron E botão manual). Oportunidade fica fora (território do
+   `ciclo_oportunidade_do_dia`); `bloqueado_guardrail` antigo fica (status quo, chip de atenção).
+3. **Limpeza do dia tipo-aware + bloqueados**: `DELETE ... status IN ('pendente_aprovacao',
+   'bloqueado_guardrail') AND COALESCE(tipo_ciclo,'normal')='normal'`.
+   (a) tipo-aware: sem isso, toda rodada pós-11h05 apagaria as oportunidades pendentes do dia —
+   com motor 1×/dia às 9h15 isso nunca se manifestou (roda ANTES delas).
+   (b) bloqueados do dia entram: sem isso, a rodada seguinte re-sugere os MESMOS SKUs num pedido
+   pendente novo ao lado do bloqueado (em_transito não conta bloqueado) → aprovar os dois =
+   **compra dupla**. O `aplicar_promocoes_no_ciclo` da mesma rodada re-bloqueia se a condição
+   persistir; se ele falhar (best-effort), não há promoção aplicada → não há infla → o guardrail
+   não seria necessário naquela rodada (consistente).
+4. **NOT EXISTS anti-oportunidade** no `skus_necessitando`: não re-sugerir SKU presente em pedido
+   pendente/bloqueado de `tipo_ciclo <> 'normal'` — anti compra dupla na janela 11h05→13h UTC; se
+   a oportunidade for rejeitada/expirar, a rodada seguinte (≤2h) re-sugere no ciclo normal.
+
+Crons:
+- `gerar-pedidos-intraday-oben` `15 10,12,14,16,18,20 * * *` (7h–17h BRT, 6 rodadas), body
+  `{"empresa":"OBEN","intraday":true}`.
+- `omie-sync-estoque-intraday-oben` `40 9,11,13,15,17,19 * * *` (estoque fresco ~35min antes de
+  cada rodada).
+- `omie-sync-estoque-diario` reagendado `0 9,14,19` → `0 9 * * *` (o 14/19 vira redundante com o
+  intraday; o 9h serve a rodada matinal das 9h15 que continua intacta, com digest).
+
+### Edge `gerar-pedidos-diario` (deploy manual via Lovable)
+
+- `body.intraday === true` → **suprime o digest** de e-mail (senão 6 digests/dia matariam o valor
+  do alerta R$3k); rodada matinal continua com digest. `metadata.intraday` no log.
+- **Hook do tick** (best-effort, try/catch): `db.rpc('reposicao_alerta_pedido_minimo_tick')` após
+  a RPC+promoções — derruba a latência do alerta pra "próximo dispatch".
+
+### Edge `disparar-pedidos-aprovados` — GATE de mínimo de faturamento (deploy manual)
+
+Helper puro TDD `src/lib/reposicao/disparo-gate-helpers.ts` (`deveBloquearPorMinimoFaturamento`),
+espelhado **verbatim** no Deno. Roda **ANTES do split** (sobre os pedidos aprovados originais),
+barrando com `falha_envio` + motivo claro (padrão do guard de custo/qtde #422/#433; o erro fica
+em `resposta_canal.erro`). Isenções (a ordem importa):
+
+1. Config ausente/inválida → gate desligado (fail-open deliberado: régua comercial).
+2. `split_parent_id` preenchido → **isento** (filho herda a aprovação do pai que passou no gate;
+   um pai de R$10k vira filhos de ~R$2k — barrá-los re-quebra o split; e o gate pré-split também
+   evita o furo de pedido <R$3k com >4 itens escapar via filhos).
+3. Fornecedor não casa o pattern → isento.
+4. **Já tocou o fornecedor** (`portal_protocolo` não-nulo OU `status_envio_portal` ∈
+   {sucesso_portal, enviado_portal, aceito_portal_sem_protocolo, indeterminado_requer_conciliacao})
+   → isento — barrar agora criaria órfão pior (PO no portal sem Omie); o fluxo de
+   reconciliação/idempotência segue.
+5. `valor_total ≥ régua` → passa. Senão → **barra**: "abaixo do mínimo de faturamento Sayerlack
+   (R$3.000) — aguarde o ciclo acumular mais itens ou cancele o pedido".
+
+Cobre TODOS os caminhos de disparo (cron de corte, aprovar-e-disparar manual, re-disparo
+individual, motor de retry) — todos passam pela edge. Escape hatch v1: ajustar a config.
+
+## Validação (PG17 local, padrão `db/test-*.sh`)
+
+- `db/test-alerta-pedido-minimo.sh`: transição (1 e-mail), anti-spam (tick 2× sem novo e-mail),
+  valor cresce sem re-spam (valor_ultimo atualiza), aprovação resolve, re-arma com pedido novo,
+  fornecedor fora do pattern não alerta, < régua não alerta, config inválida não explode,
+  grupo NULL × '' não duplica.
+- `db/test-rpc-intraday.sh` (base: harness do `test-rpc-account-aware.sh`): re-rodada preserva
+  oportunidade pendente; apaga e regenera bloqueado normal do dia; expira pendente normal de
+  ontem; NOT EXISTS exclui SKU de oportunidade; aprovado/disparado intactos; comportamento base
+  (gera pro SKU abaixo do ponto) inalterado.
+- Gate: vitest no helper puro (split filho, portal-tocado, pattern, régua, config ausente).
+
+## Dente de serra (análise — fase 2 NÃO construída agora)
+
+Estoque médio = lote/2 (ciclo) + estoque de segurança. O pacote ataca:
+- **Adiantar o disparo** ~0,5–1 dia (venda da manhã vira pedido à tarde) → lead time efetivo ↓.
+- **Lote ótimo Sayerlack**: com custo de transação ~zero (motor → 1 clique → portal → Omie), o
+  lote ideal é o MENOR que o fornecedor fatura = R$3k. Alerta (pede assim que dá) + gate (nunca
+  pede o que não fatura) = o menor dente possível dado o mínimo de faturamento.
+- **Fase 2 (gated em 2–4 semanas de medição)**: recalibrar `ponto_pedido`/`estoque_seguranca`/
+  `cobertura_alvo_dias` com período de revisão 24h→2h, via esteira `param_auto` existente
+  (fusível/pin/log). Recalibrar sem medir = risco de ruptura. Custos honestos do dente menor:
+  mais recebimentos físicos (conferência), pisos de frete/faturamento de outros fornecedores.
+
+## Não-objetivos (v1)
+
+- Mexer no fluxo do `ciclo_oportunidade_do_dia` (incl. o fato de o corte das 13h UTC expirar
+  oportunidades ~2h após nascerem — comportamento pré-existente, fora do escopo).
+- Preservar ajustes manuais em pendentes através da regeneração (preservar criaria double-count
+  de SKU: em_transito não conta pendente → o SKU preservado renasceria no pedido novo). Regra
+  operacional: ajustou → aprova (dispara na hora). Trade-off aceito pelo founder no design.
+- Gate por valor agregado do dia (a régua é por PO; o split prova que a Sayerlack agrupa).
+- Mínimo de faturamento por fornecedor além da Sayerlack (config single-pattern v1; extensível).
+- Recalibração de parâmetros (fase 2, gated em medição).
+
+## Riscos aceitos / registrados
+
+- Race aprovar-durante-regeneração: janela pequena; aprovação falha limpa (0 rows) — nada
+  dispara errado. UX de erro do front já existe.
+- Deep-link `?id=` de qualquer e-mail antigo pode morrer na regeneração (link genérico no novo
+  alerta; o digest matinal já era assim).
+- Oscilação do valor em torno da régua (2.9k↔3.1k) re-armaria o alerta — raro (valor cresce
+  monotonicamente com vendas; cai com recebimento/aprovação), aceito.
+- `omie-sync-estoque` 3→7×/dia e motor 1→7×/dia: carga Omie marginal (sync de pedidos já é 12×,
+  inventory 48×/dia); edges idempotentes.
+- Pendência pós-merge (founder): colar 2 migrations no SQL Editor + deploy de 2 edges via chat
+  do Lovable + Publish não necessário (sem mudança de frontend).

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 189
+-- Total de custom migrations: 191
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -208,7 +208,9 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260606200000', 'reposicao_promo_forward_buying_min', '20260606200000_reposicao_promo_forward_buying_min.sql'),
   ('20260606230000', 'negociacao_paralela_v2_cleanup', '20260606230000_negociacao_paralela_v2_cleanup.sql'),
   ('20260608120000', 'tool_spec_custom_option', '20260608120000_tool_spec_custom_option.sql'),
-  ('20260609085244', 'data_health_check_familia_ausente', '20260609085244_data_health_check_familia_ausente.sql')
+  ('20260609085244', 'data_health_check_familia_ausente', '20260609085244_data_health_check_familia_ausente.sql'),
+  ('20260609150000', 'reposicao_alerta_pedido_minimo', '20260609150000_reposicao_alerta_pedido_minimo.sql'),
+  ('20260609160000', 'reposicao_ciclo_intraday', '20260609160000_reposicao_ciclo_intraday.sql')
 )
 SELECT
   e.version,
@@ -928,7 +930,15 @@ WITH expected_objects (migration, kind, schema_name, object_name, parent_name) A
   ('tool_spec_custom_option', 'function', 'public', 'adicionar_opcao_tool_spec', ''),
   ('data_health_check_familia_ausente', 'function', 'public', '_data_health_compute', ''),
   ('data_health_check_familia_ausente', 'function', 'public', 'data_health_watchdog', ''),
-  ('data_health_check_familia_ausente', 'function', 'public', 'fin_sync_heartbeat', '')
+  ('data_health_check_familia_ausente', 'function', 'public', 'fin_sync_heartbeat', ''),
+  ('reposicao_alerta_pedido_minimo', 'table', 'public', 'reposicao_alerta_pedido_minimo', ''),
+  ('reposicao_alerta_pedido_minimo', 'index', 'public', 'reposicao_alerta_pedido_minimo_ativo', 'reposicao_alerta_pedido_minimo'),
+  ('reposicao_alerta_pedido_minimo', 'function', 'public', 'reposicao_alerta_pedido_minimo_tick', ''),
+  ('reposicao_alerta_pedido_minimo', 'cron_job', 'cron', 'reposicao-alerta-pedido-minimo', ''),
+  ('reposicao_ciclo_intraday', 'function', 'public', 'gerar_pedidos_sugeridos_ciclo', ''),
+  ('reposicao_ciclo_intraday', 'cron_job', 'cron', 'gerar-pedidos-intraday-oben', ''),
+  ('reposicao_ciclo_intraday', 'cron_job', 'cron', 'omie-sync-estoque-intraday-oben', ''),
+  ('reposicao_ciclo_intraday', 'cron_job', 'cron', 'omie-sync-estoque-diario', '')
 )
 SELECT
   e.migration,

--- a/src/lib/reposicao/__tests__/disparo-gate-helpers.test.ts
+++ b/src/lib/reposicao/__tests__/disparo-gate-helpers.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "vitest";
+import {
+  deveBloquearPorMinimoFaturamento,
+  type GateConfig,
+} from "../disparo-gate-helpers";
+
+const cfg: GateConfig = { valorMinimo: 3000, fornecedorPattern: "%SAYERLACK%" };
+
+const base = {
+  fornecedor_nome: "SAYERLACK DO BRASIL LTDA",
+  valor_total: 2000,
+  split_parent_id: null,
+  portal_protocolo: null,
+  status_envio_portal: null,
+};
+
+describe("deveBloquearPorMinimoFaturamento", () => {
+  it("barra pedido Sayerlack abaixo da régua, com motivo legível", () => {
+    const r = deveBloquearPorMinimoFaturamento(base, cfg);
+    expect(r.bloquear).toBe(true);
+    expect(r.motivo).toContain("mínimo de faturamento");
+    expect(r.motivo).toContain("3000");
+  });
+
+  it("passa pedido exatamente NA régua (>= passa)", () => {
+    expect(
+      deveBloquearPorMinimoFaturamento({ ...base, valor_total: 3000 }, cfg)
+        .bloquear,
+    ).toBe(false);
+  });
+
+  it("passa pedido acima da régua", () => {
+    expect(
+      deveBloquearPorMinimoFaturamento({ ...base, valor_total: 3500.5 }, cfg)
+        .bloquear,
+    ).toBe(false);
+  });
+
+  it("isenta filho de split (herda a aprovação do pai)", () => {
+    expect(
+      deveBloquearPorMinimoFaturamento({ ...base, split_parent_id: 99 }, cfg)
+        .bloquear,
+    ).toBe(false);
+  });
+
+  it("isenta fornecedor fora do pattern", () => {
+    expect(
+      deveBloquearPorMinimoFaturamento(
+        { ...base, fornecedor_nome: "ACRE CAXIAS" },
+        cfg,
+      ).bloquear,
+    ).toBe(false);
+  });
+
+  it("casa o pattern sem case-sensitivity", () => {
+    expect(
+      deveBloquearPorMinimoFaturamento(
+        { ...base, fornecedor_nome: "Sayerlack do Brasil" },
+        cfg,
+      ).bloquear,
+    ).toBe(true);
+  });
+
+  it("isenta pedido que já tocou o portal (protocolo)", () => {
+    expect(
+      deveBloquearPorMinimoFaturamento(
+        { ...base, portal_protocolo: "2100743" },
+        cfg,
+      ).bloquear,
+    ).toBe(false);
+  });
+
+  it.each([
+    "sucesso_portal",
+    "enviado_portal",
+    "aceito_portal_sem_protocolo",
+    "indeterminado_requer_conciliacao",
+  ])("isenta status_envio_portal pós-envio: %s", (s) => {
+    expect(
+      deveBloquearPorMinimoFaturamento(
+        { ...base, status_envio_portal: s },
+        cfg,
+      ).bloquear,
+    ).toBe(false);
+  });
+
+  it.each(["pendente_envio_portal", "erro_retentavel", "falha_envio_portal"])(
+    "NÃO isenta portal que não chegou ao fornecedor: %s",
+    (s) => {
+      expect(
+        deveBloquearPorMinimoFaturamento(
+          { ...base, status_envio_portal: s },
+          cfg,
+        ).bloquear,
+      ).toBe(true);
+    },
+  );
+
+  it("barra valor_total nulo/NaN (pedido Sayerlack sem valor não fatura)", () => {
+    expect(
+      deveBloquearPorMinimoFaturamento({ ...base, valor_total: null }, cfg)
+        .bloquear,
+    ).toBe(true);
+  });
+
+  it("gate desligado quando a régua está ausente/inválida", () => {
+    expect(
+      deveBloquearPorMinimoFaturamento(base, {
+        valorMinimo: null,
+        fornecedorPattern: "%SAYERLACK%",
+      }).bloquear,
+    ).toBe(false);
+    expect(
+      deveBloquearPorMinimoFaturamento(base, {
+        valorMinimo: 0,
+        fornecedorPattern: "%SAYERLACK%",
+      }).bloquear,
+    ).toBe(false);
+    expect(
+      deveBloquearPorMinimoFaturamento(base, {
+        valorMinimo: Number.NaN,
+        fornecedorPattern: "%SAYERLACK%",
+      }).bloquear,
+    ).toBe(false);
+  });
+
+  it("gate desligado quando o pattern está ausente/vazio (incl. só %)", () => {
+    expect(
+      deveBloquearPorMinimoFaturamento(base, {
+        valorMinimo: 3000,
+        fornecedorPattern: null,
+      }).bloquear,
+    ).toBe(false);
+    expect(
+      deveBloquearPorMinimoFaturamento(base, {
+        valorMinimo: 3000,
+        fornecedorPattern: "  ",
+      }).bloquear,
+    ).toBe(false);
+    expect(
+      deveBloquearPorMinimoFaturamento(base, {
+        valorMinimo: 3000,
+        fornecedorPattern: "%%",
+      }).bloquear,
+    ).toBe(false);
+  });
+});

--- a/src/lib/reposicao/disparo-gate-helpers.ts
+++ b/src/lib/reposicao/disparo-gate-helpers.ts
@@ -1,0 +1,89 @@
+// Gate de mínimo de faturamento no disparo de pedidos de compra (pacote intra-day, PR2).
+// R$3.000 é o mínimo de faturamento da Sayerlack: pedido abaixo disso não fatura (fica parado
+// no fornecedor). O gate barra o disparo ANTES do split e de qualquer envio (portal/Omie),
+// marcando falha_envio com motivo claro — mesmo caminho do guard de custo/qtde zero (#422/#433).
+//
+// A régua vem de company_config (reposicao_alerta_pedido_valor_minimo +
+// reposicao_alerta_pedido_fornecedor_ilike) — a MESMA do alerta R$3k: uma régua, dois usos
+// (alertar quando atinge; barrar quando não atinge).
+//
+// ⚠️ Espelhado VERBATIM em supabase/functions/disparar-pedidos-aprovados/index.ts (Deno não
+// importa de src/) — mudou aqui, mudou lá. Spec:
+// docs/superpowers/specs/2026-06-09-reposicao-intraday-alerta-3k-design.md
+
+export interface PedidoParaGate {
+  fornecedor_nome: string | null;
+  valor_total: number | string | null;
+  split_parent_id?: number | null;
+  portal_protocolo?: string | null;
+  status_envio_portal?: string | null;
+}
+
+export interface GateConfig {
+  /** Régua em R$ (company_config: reposicao_alerta_pedido_valor_minimo). */
+  valorMinimo: number | null;
+  /** Pattern ILIKE simples, ex. '%SAYERLACK%' — o espelho TS suporta só a forma %TEXTO%. */
+  fornecedorPattern: string | null;
+}
+
+// Estados em que o fornecedor PODE já ter recebido o PO via portal — barrar agora criaria
+// órfão pior (PO no portal sem Omie); o fluxo de reconciliação/idempotência segue.
+const PORTAL_JA_TOCADO = new Set([
+  "sucesso_portal",
+  "enviado_portal",
+  "aceito_portal_sem_protocolo",
+  "indeterminado_requer_conciliacao",
+]);
+
+function fornecedorCasaPattern(nome: string, pattern: string): boolean {
+  const alvo = pattern.replace(/%/g, "").trim().toUpperCase();
+  if (!alvo) return false;
+  return nome.toUpperCase().includes(alvo);
+}
+
+export function deveBloquearPorMinimoFaturamento(
+  pedido: PedidoParaGate,
+  cfg: GateConfig,
+): { bloquear: boolean; motivo?: string } {
+  // Config ausente/inválida = gate DESLIGADO (fail-open deliberado: régua comercial, não
+  // barreira de segurança — sem config não se inventa régua).
+  const minimo = Number(cfg.valorMinimo);
+  if (!Number.isFinite(minimo) || minimo <= 0) return { bloquear: false };
+  if (!cfg.fornecedorPattern || !cfg.fornecedorPattern.replace(/%/g, "").trim()) {
+    return { bloquear: false };
+  }
+
+  // Filho de split herda a aprovação do pai (um pai ≥ régua vira filhos menores; barrá-los
+  // re-quebraria o split). O gate roda ANTES do split — filho só chega aqui via re-disparo
+  // individual.
+  if (pedido.split_parent_id != null) return { bloquear: false };
+
+  if (
+    !pedido.fornecedor_nome ||
+    !fornecedorCasaPattern(pedido.fornecedor_nome, cfg.fornecedorPattern)
+  ) {
+    return { bloquear: false };
+  }
+
+  if (pedido.portal_protocolo != null && pedido.portal_protocolo !== "") {
+    return { bloquear: false };
+  }
+  if (
+    pedido.status_envio_portal &&
+    PORTAL_JA_TOCADO.has(pedido.status_envio_portal)
+  ) {
+    return { bloquear: false };
+  }
+
+  const valor = Number(pedido.valor_total);
+  if (Number.isFinite(valor) && valor >= minimo) return { bloquear: false };
+
+  // Valor nulo/NaN também barra: pedido Sayerlack sem valor não fatura.
+  return {
+    bloquear: true,
+    motivo:
+      `Pedido R$ ${Math.round(Number.isFinite(valor) ? valor : 0)} abaixo do mínimo de ` +
+      `faturamento (R$ ${Math.round(minimo)}) — aguarde o ciclo acumular mais itens ou ` +
+      `cancele o pedido.`,
+  };
+}

--- a/supabase/functions/disparar-pedidos-aprovados/index.ts
+++ b/supabase/functions/disparar-pedidos-aprovados/index.ts
@@ -44,6 +44,10 @@ interface PedidoRow {
   split_parent_id?: number | null;
   split_lote?: number | null;
   split_total?: number | null;
+  // [GATE-MIN-FATURAMENTO] usados pra isentar pedido que já tocou o fornecedor via portal
+  // (barrar depois do portal criaria órfão pior — PO no fornecedor sem Omie).
+  portal_protocolo?: string | null;
+  status_envio_portal?: string | null;
 }
 
 // PR5: tamanho máximo de cada chunk no split. Calibração:
@@ -265,6 +269,75 @@ interface ProcessResult {
   // Reconciliado = o PV já existia no Omie ("já cadastrado"); marcamos disparado
   // sem re-criar. O caller NÃO deve re-notificar o fornecedor (evita e-mail duplicado).
   reconciliado?: boolean;
+}
+
+// ── [GATE-MIN-FATURAMENTO] espelho VERBATIM de src/lib/reposicao/disparo-gate-helpers.ts ──
+// (Deno não importa de src/ — mudou lá, mudou aqui.) R$3.000 é o mínimo de faturamento da
+// Sayerlack: pedido abaixo não fatura (fica parado no fornecedor). Régua = company_config
+// (reposicao_alerta_pedido_valor_minimo + reposicao_alerta_pedido_fornecedor_ilike) — a MESMA
+// do alerta R$3k. O gate roda ANTES do split (um pai ≥ régua vira filhos menores; e pedido
+// <régua com >4 itens não pode escapar via filhos isentos).
+
+interface PedidoParaGate {
+  fornecedor_nome: string | null;
+  valor_total: number | string | null;
+  split_parent_id?: number | null;
+  portal_protocolo?: string | null;
+  status_envio_portal?: string | null;
+}
+
+interface GateConfig {
+  valorMinimo: number | null;
+  fornecedorPattern: string | null;
+}
+
+const PORTAL_JA_TOCADO = new Set([
+  "sucesso_portal",
+  "enviado_portal",
+  "aceito_portal_sem_protocolo",
+  "indeterminado_requer_conciliacao",
+]);
+
+function fornecedorCasaPattern(nome: string, pattern: string): boolean {
+  const alvo = pattern.replace(/%/g, "").trim().toUpperCase();
+  if (!alvo) return false;
+  return nome.toUpperCase().includes(alvo);
+}
+
+function deveBloquearPorMinimoFaturamento(
+  pedido: PedidoParaGate,
+  cfg: GateConfig,
+): { bloquear: boolean; motivo?: string } {
+  const minimo = Number(cfg.valorMinimo);
+  if (!Number.isFinite(minimo) || minimo <= 0) return { bloquear: false };
+  if (!cfg.fornecedorPattern || !cfg.fornecedorPattern.replace(/%/g, "").trim()) {
+    return { bloquear: false };
+  }
+  if (pedido.split_parent_id != null) return { bloquear: false };
+  if (
+    !pedido.fornecedor_nome ||
+    !fornecedorCasaPattern(pedido.fornecedor_nome, cfg.fornecedorPattern)
+  ) {
+    return { bloquear: false };
+  }
+  if (pedido.portal_protocolo != null && pedido.portal_protocolo !== "") {
+    return { bloquear: false };
+  }
+  if (
+    pedido.status_envio_portal &&
+    PORTAL_JA_TOCADO.has(pedido.status_envio_portal)
+  ) {
+    return { bloquear: false };
+  }
+  const valor = Number(pedido.valor_total);
+  if (Number.isFinite(valor) && valor >= minimo) return { bloquear: false };
+  return {
+    bloquear: true,
+    motivo:
+      `Pedido R$ ${Math.round(Number.isFinite(valor) ? valor : 0)} abaixo do mínimo de ` +
+      `faturamento (R$ ${Math.round(minimo)}) — aguarde o ciclo acumular mais itens ou ` +
+      `cancele o pedido.`,
+  };
 }
 
 type PortalDispatchResult =
@@ -1136,7 +1209,7 @@ Deno.serve(async (req: Request) => {
     // 2. Pedidos aprovados (com dados do fornecedor)
     let aprovadosQuery = db
       .from("pedido_compra_sugerido")
-      .select("id, empresa, fornecedor_nome, grupo_codigo, data_ciclo, valor_total, num_skus, status, condicao_pagamento_codigo, condicao_pagamento_descricao, num_parcelas, portal_data_entrega, split_parent_id, split_lote, split_total")
+      .select("id, empresa, fornecedor_nome, grupo_codigo, data_ciclo, valor_total, num_skus, status, condicao_pagamento_codigo, condicao_pagamento_descricao, num_parcelas, portal_data_entrega, split_parent_id, split_lote, split_total, portal_protocolo, status_envio_portal")
       .eq("empresa", empresa);
 
     aprovadosQuery = pedidoId
@@ -1157,6 +1230,57 @@ Deno.serve(async (req: Request) => {
         .eq("fornecedor_nome", p.fornecedor_nome)
         .maybeSingle();
       if (fh) Object.assign(p, fh);
+    }
+
+    // [GATE-MIN-FATURAMENTO] barra pedido Sayerlack abaixo do mínimo de faturamento (R$3k)
+    // ANTES do split e de qualquer envio. Pré-split de propósito: (a) pai ≥ régua vira filhos
+    // menores que NÃO podem ser barrados (split_parent_id isenta no re-disparo individual);
+    // (b) pedido < régua com >4 itens não escapa via filhos. Cobre todos os caminhos de
+    // disparo (corte em lote, aprovar-e-disparar, re-disparo individual, motor de retry).
+    const barradosGate: ProcessResult[] = [];
+    {
+      const { data: gateCfgRows } = await db
+        .from("company_config")
+        .select("key, value")
+        .in("key", [
+          "reposicao_alerta_pedido_valor_minimo",
+          "reposicao_alerta_pedido_fornecedor_ilike",
+        ]);
+      const cfgMap = new Map((gateCfgRows ?? []).map((r) => [r.key, r.value]));
+      const gateCfg: GateConfig = {
+        valorMinimo: Number(cfgMap.get("reposicao_alerta_pedido_valor_minimo") ?? NaN),
+        fornecedorPattern: cfgMap.get("reposicao_alerta_pedido_fornecedor_ilike") ?? null,
+      };
+
+      const liberados: PedidoRow[] = [];
+      for (const p of aprovados) {
+        const gate = deveBloquearPorMinimoFaturamento(p, gateCfg);
+        if (!gate.bloquear) {
+          liberados.push(p);
+          continue;
+        }
+        console.warn(`[disparar-pedidos] GATE mínimo de faturamento barrou #${p.id} (${p.fornecedor_nome}, R$ ${p.valor_total}): ${gate.motivo}`);
+        if (modo === "producao") {
+          const { error: gateErr } = await db
+            .from("pedido_compra_sugerido")
+            .update({
+              status: "falha_envio",
+              resposta_canal: { erro: gate.motivo, modo, ts: new Date().toISOString(), gate: "minimo_faturamento" },
+              atualizado_em: new Date().toISOString(),
+            })
+            .eq("id", p.id);
+          if (gateErr) console.error(`[disparar-pedidos] gate update erro #${p.id}: ${gateErr.message}`);
+        }
+        barradosGate.push({
+          pedido_id: p.id,
+          fornecedor: p.fornecedor_nome,
+          status_final: "falha_envio",
+          valor: p.valor_total,
+          canal: modo === "dry_run" ? "DRY_RUN_OMIE_APENAS" : (p.canal_pedido ?? "—"),
+          erro: gate.motivo,
+        });
+      }
+      aprovados = liberados;
     }
 
     // PR5: divide pedidos Sayerlack/OBEN com >4 itens em filhos menores que
@@ -1184,7 +1308,7 @@ Deno.serve(async (req: Request) => {
 
     // 4. Processar cada aprovado
     const creds = getOmieCreds(empresa);
-    const resultados: ProcessResult[] = [];
+    const resultados: ProcessResult[] = [...barradosGate];
     for (const p of aprovados) {
       const r = await processarPedido(db, p, modo, creds);
 

--- a/supabase/functions/gerar-pedidos-diario/index.ts
+++ b/supabase/functions/gerar-pedidos-diario/index.ts
@@ -247,15 +247,20 @@ Deno.serve(async (req: Request) => {
 
   let empresa = "OBEN";
   let dataCiclo = new Date().toISOString().slice(0, 10);
+  // [INTRADAY] rodadas extras (cron gerar-pedidos-intraday-oben, 2/2h em horário comercial):
+  // mesma orquestração (RPC + promoções + tick do alerta), mas SEM o digest de e-mail — senão
+  // seriam 6 digests/dia. O digest fica só na rodada matinal (9h15 UTC, body sem a flag).
+  let intraday = false;
 
   try {
     if (req.method === "POST") {
       const body = await req.json().catch(() => ({}));
       if (body.empresa) empresa = body.empresa;
       if (body.data_ciclo) dataCiclo = body.data_ciclo;
+      if (body.intraday === true) intraday = true;
     }
 
-    console.log(`[gerar-pedidos-diario] Iniciando ciclo ${empresa} ${dataCiclo}`);
+    console.log(`[gerar-pedidos-diario] Iniciando ciclo ${empresa} ${dataCiclo}${intraday ? " (intraday)" : ""}`);
 
     // 1. RPC de geração
     const { data: rpcRows, error: rpcErr } = await db.rpc(
@@ -292,6 +297,18 @@ Deno.serve(async (req: Request) => {
       console.error(`[gerar-pedidos-diario] promo throw:`, e);
     }
 
+    // 1.7. Tick do alerta de pedido mínimo (R$3k Sayerlack) — best-effort. O cron */30 já roda
+    // o tick sozinho; chamar aqui derruba a latência do e-mail pra "próximo dispatch" (≤30min)
+    // logo após a rodada que criou/encheu o pedido.
+    try {
+      const { error: tickErr } = await db.rpc("reposicao_alerta_pedido_minimo_tick");
+      if (tickErr) {
+        console.error(`[gerar-pedidos-diario] tick alerta pedido mínimo falhou: ${tickErr.message}`);
+      }
+    } catch (e) {
+      console.error(`[gerar-pedidos-diario] tick alerta throw:`, e);
+    }
+
     // 2. Detalhes dos pedidos do ciclo
     const { data: pedidos, error: pedErr } = await db
       .from("pedido_compra_sugerido")
@@ -317,7 +334,7 @@ Deno.serve(async (req: Request) => {
     let emailStatus: "sent" | "skipped" | "failed" = "skipped";
     let emailDetail: string | null = null;
 
-    if (recipient && resendKey) {
+    if (recipient && resendKey && !intraday) {
       const html = buildEmailHtml(empresa, dataCiclo, rpc, pedidosList);
       const subject = rpc.bloqueados > 0
         ? `⚠ ${empresa} — ${rpc.pedidos_gerados} pedidos (${rpc.bloqueados} bloqueados) — ${dataCiclo}`
@@ -347,7 +364,9 @@ Deno.serve(async (req: Request) => {
         console.error(`[gerar-pedidos-diario] Resend erro:`, emailDetail);
       }
     } else {
-      emailDetail = !recipient
+      emailDetail = intraday
+        ? "Rodada intraday (digest suprimido — alerta R$3k cobre o intra-day)"
+        : !recipient
         ? "Sem email_notificacoes cadastrado"
         : "RESEND_API_KEY ausente";
       console.warn(`[gerar-pedidos-diario] Email pulado: ${emailDetail}`);
@@ -367,6 +386,7 @@ Deno.serve(async (req: Request) => {
       duration_ms: duration,
       metadata: {
         data_ciclo: dataCiclo,
+        intraday,
         skus_incluidos: rpc.skus_incluidos,
         valor_total: rpc.valor_total_ciclo,
         email_status: emailStatus,

--- a/supabase/migrations/20260609150000_reposicao_alerta_pedido_minimo.sql
+++ b/supabase/migrations/20260609150000_reposicao_alerta_pedido_minimo.sql
@@ -1,0 +1,176 @@
+-- Reposição — alerta "pedido Sayerlack atingiu o mínimo de faturamento (R$3k)" (PR1)
+-- ============================================================================
+-- Spec: docs/superpowers/specs/2026-06-09-reposicao-intraday-alerta-3k-design.md
+--
+-- R$3.000 é o MÍNIMO DE FATURAMENTO da Sayerlack: pedido sugerido abaixo disso não fatura.
+-- O founder quer 1 e-mail POR PEDIDO sugerido (identidade fornecedor+grupo) que atinja a régua
+-- em pendente_aprovacao — várias vezes ao dia, pedidos diferentes. Anti-spam por TRANSIÇÃO
+-- (padrão fin_sync_watchdog): UNIQUE parcial WHERE resolvido_em IS NULL + ON CONFLICT DO
+-- NOTHING + IF FOUND → enfileira fornecedor_alerta (dispatch-notifications */30 já manda).
+-- Re-arma quando o pedido sai de pendente (aprovado/cancelado/expirado) ou cai abaixo da régua.
+--
+-- SQL puro (sem edge nova). O tick roda por cron */30 E (PR2) ao fim da edge gerar-pedidos-diario.
+-- A MESMA config (company_config) alimenta o GATE de disparo <R$3k do PR2 — uma régua, dois usos.
+--
+-- ⚠️ Migration MANUAL (Lovable): colar no SQL Editor → Run. Ver bloco de validação no fim.
+
+BEGIN;
+
+-- ── A) CHECK de fornecedor_alerta.tipo estendido ─────────────────────────────
+-- Lista VIGENTE = 20260605120000 (11 tipos; o schema-snapshot está stale com 7) + o novo.
+ALTER TABLE public.fornecedor_alerta DROP CONSTRAINT IF EXISTS fornecedor_alerta_tipo_check;
+ALTER TABLE public.fornecedor_alerta ADD CONSTRAINT fornecedor_alerta_tipo_check
+  CHECK (tipo IN ('promocao_suspensa','aumento_anunciado','promocao_nova','polling_erro',
+    'mapeamento_pendente','oportunidade_calculada','tarefa_atrasada','whatsapp_sla',
+    'erro_app','outro','param_auto_resumo','reposicao_pedido_minimo'));
+
+-- ── B) Config: a régua e o fornecedor (text key/value, cast na leitura) ──────
+INSERT INTO public.company_config (key, value) VALUES
+  ('reposicao_alerta_pedido_valor_minimo', '3000'),
+  ('reposicao_alerta_pedido_fornecedor_ilike', '%SAYERLACK%')
+ON CONFLICT (key) DO NOTHING;
+
+-- ── C) Tabela de estado (1 alerta ativo por empresa+fornecedor+grupo) ────────
+-- grupo_codigo NOT NULL DEFAULT '': NULL e '' são a MESMA identidade — UNIQUE parcial com
+-- coluna NULL deixaria duplicar (NULL <> NULL). pedido_id é só informativo: a regeneração
+-- intra-day apaga/recria os pedidos (id novo), a identidade estável é (fornecedor, grupo).
+CREATE TABLE IF NOT EXISTS public.reposicao_alerta_pedido_minimo (
+  id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  empresa text NOT NULL,
+  fornecedor_nome text NOT NULL,
+  grupo_codigo text NOT NULL DEFAULT '',
+  pedido_id bigint,
+  valor_alertado numeric NOT NULL,
+  valor_ultimo numeric NOT NULL,
+  alertado_em timestamptz NOT NULL DEFAULT now(),
+  resolvido_em timestamptz
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS reposicao_alerta_pedido_minimo_ativo
+  ON public.reposicao_alerta_pedido_minimo (empresa, fornecedor_nome, grupo_codigo)
+  WHERE resolvido_em IS NULL;
+
+ALTER TABLE public.reposicao_alerta_pedido_minimo ENABLE ROW LEVEL SECURITY;
+
+-- Staff lê (diagnóstico); escrita SÓ pelo tick (SECURITY DEFINER) / service_role (bypassa RLS).
+DROP POLICY IF EXISTS "Staff lê alertas de pedido mínimo" ON public.reposicao_alerta_pedido_minimo;
+CREATE POLICY "Staff lê alertas de pedido mínimo" ON public.reposicao_alerta_pedido_minimo
+  FOR SELECT TO authenticated
+  USING (EXISTS (
+    SELECT 1 FROM public.user_roles ur
+    WHERE ur.user_id = (SELECT auth.uid()) AND ur.role IN ('employee','master')
+  ));
+
+-- ── D) Tick: detecta transição, enfileira e-mail, resolve/re-arma ────────────
+CREATE OR REPLACE FUNCTION public.reposicao_alerta_pedido_minimo_tick()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $$
+DECLARE
+  v_threshold numeric;
+  v_fornecedor text;
+  r RECORD;
+BEGIN
+  SELECT value::numeric INTO v_threshold
+  FROM public.company_config WHERE key = 'reposicao_alerta_pedido_valor_minimo';
+  SELECT value INTO v_fornecedor
+  FROM public.company_config WHERE key = 'reposicao_alerta_pedido_fornecedor_ilike';
+
+  -- Config ausente/inválida = alerta DESLIGADO (régua comercial, não segurança). Sem alerta
+  -- fabricado com régua 0.
+  IF v_threshold IS NULL OR v_threshold <= 0
+     OR v_fornecedor IS NULL OR btrim(v_fornecedor) = '' THEN
+    RETURN;
+  END IF;
+
+  -- 1) NOVOS: pedido pendente ≥ régua do fornecedor configurado, sem alerta ativo → grava
+  -- estado + enfileira e-mail (só na transição). Agrupo por (empresa, fornecedor, grupo)
+  -- por defesa (a identidade pode ter 2 linhas transitórias: zumbi de ontem + hoje, pré-PR2).
+  FOR r IN
+    SELECT pcs.empresa, pcs.fornecedor_nome,
+           COALESCE(pcs.grupo_codigo, '') AS grupo_codigo,
+           MAX(pcs.valor_total) AS valor,
+           SUM(COALESCE(pcs.num_skus, 0)) AS num_skus,
+           MAX(pcs.id) AS pedido_id
+    FROM public.pedido_compra_sugerido pcs
+    WHERE pcs.status = 'pendente_aprovacao'
+      AND pcs.fornecedor_nome ILIKE v_fornecedor
+      AND pcs.valor_total >= v_threshold
+    GROUP BY 1, 2, 3
+  LOOP
+    INSERT INTO public.reposicao_alerta_pedido_minimo
+      (empresa, fornecedor_nome, grupo_codigo, pedido_id, valor_alertado, valor_ultimo)
+    VALUES (r.empresa, r.fornecedor_nome, r.grupo_codigo, r.pedido_id, r.valor, r.valor)
+    ON CONFLICT (empresa, fornecedor_nome, grupo_codigo) WHERE resolvido_em IS NULL
+    DO NOTHING;
+
+    IF FOUND THEN
+      -- Transição: 1 e-mail. Link GENÉRICO pra tela (deep-link ?id= morreria na regeneração).
+      INSERT INTO public.fornecedor_alerta (empresa, tipo, severidade, titulo, mensagem, status)
+      VALUES (
+        lower(r.empresa),
+        'reposicao_pedido_minimo',
+        'atencao',
+        '[Compras] Pedido ' || r.fornecedor_nome || ' atingiu R$ ' || round(r.valor)::text
+          || ' — pronto pra aprovar',
+        'O pedido sugerido de ' || r.fornecedor_nome
+          || CASE WHEN r.grupo_codigo <> '' THEN ' (grupo ' || r.grupo_codigo || ')' ELSE '' END
+          || ' acumulou R$ ' || round(r.valor)::text
+          || ' (' || r.num_skus::text || ' SKUs) — acima do mínimo de faturamento (R$ '
+          || round(v_threshold)::text || '). Aprovar dispara na hora: '
+          || 'Reposição → Pedidos (https://steu.lovable.app/admin/reposicao/pedidos). '
+          || 'Quando você aprovar (ou o pedido sair da régua), este aviso re-arma sozinho.',
+        'pendente_notificacao'
+      );
+    ELSE
+      -- Alerta já ativo: só atualiza o último valor visto (3.2k→10k NÃO re-spamma; o valor
+      -- vivo está no cockpit).
+      UPDATE public.reposicao_alerta_pedido_minimo a
+      SET valor_ultimo = r.valor, pedido_id = r.pedido_id
+      WHERE a.empresa = r.empresa AND a.fornecedor_nome = r.fornecedor_nome
+        AND a.grupo_codigo = r.grupo_codigo AND a.resolvido_em IS NULL;
+    END IF;
+  END LOOP;
+
+  -- 2) RESOLVE (re-arma): alerta ativo sem pedido pendente ≥ régua correspondente — o founder
+  -- aprovou/cancelou, o corte expirou, ou o valor caiu. O próximo pedido do grupo que cruzar a
+  -- régua gera e-mail NOVO. (Sem filtro de fornecedor aqui de propósito: se o pattern da config
+  -- mudar, alertas órfãos do pattern antigo resolvem sozinhos.)
+  UPDATE public.reposicao_alerta_pedido_minimo a
+  SET resolvido_em = now()
+  WHERE a.resolvido_em IS NULL
+    AND NOT EXISTS (
+      SELECT 1 FROM public.pedido_compra_sugerido pcs
+      WHERE pcs.empresa = a.empresa
+        AND pcs.fornecedor_nome = a.fornecedor_nome
+        AND COALESCE(pcs.grupo_codigo, '') = a.grupo_codigo
+        AND pcs.status = 'pendente_aprovacao'
+        AND pcs.valor_total >= v_threshold
+    );
+END;
+$$;
+
+-- Trava de execução: cron SQL local roda como owner; a edge chama via service_role.
+-- (Lição §10: REVOKE de PUBLIC não basta — anon/authenticated têm grant explícito no Supabase.)
+REVOKE ALL ON FUNCTION public.reposicao_alerta_pedido_minimo_tick() FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.reposicao_alerta_pedido_minimo_tick() TO service_role;
+
+-- ── E) Cron */30 — SQL LOCAL (sem net.http_post → sem armadilha do timeout 5s) ───────────────
+SELECT cron.schedule(
+  'reposicao-alerta-pedido-minimo',
+  '*/30 * * * *',
+  $$SELECT public.reposicao_alerta_pedido_minimo_tick()$$
+);
+
+COMMIT;
+
+-- Validação (rodar após o COMMIT):
+-- SELECT 'ALERTA R$3K OK' AS status,
+--   (SELECT count(*) FROM pg_constraint WHERE conname='fornecedor_alerta_tipo_check'
+--     AND pg_get_constraintdef(oid) LIKE '%reposicao_pedido_minimo%') AS check_ok,
+--   (SELECT count(*) FROM company_config WHERE key LIKE 'reposicao_alerta_pedido%') AS configs_2,
+--   (SELECT count(*) FROM pg_tables WHERE tablename='reposicao_alerta_pedido_minimo') AS tabela_1,
+--   (SELECT count(*) FROM pg_proc WHERE proname='reposicao_alerta_pedido_minimo_tick') AS tick_1,
+--   (SELECT count(*) FROM cron.job WHERE jobname='reposicao-alerta-pedido-minimo') AS cron_1;

--- a/supabase/migrations/20260609160000_reposicao_ciclo_intraday.sql
+++ b/supabase/migrations/20260609160000_reposicao_ciclo_intraday.sql
@@ -1,0 +1,243 @@
+-- Reposição — ciclo INTRA-DAY: motor a cada 2h em horário comercial (PR2)
+-- ============================================================================
+-- Spec: docs/superpowers/specs/2026-06-09-reposicao-intraday-alerta-3k-design.md
+--
+-- O motor rodava 1×/dia (9h15 UTC). O founder quer sugestões ao longo do dia (venda faturada de
+-- manhã vira pedido à tarde → lead time ↓ ~0,5–1 dia). A RPC foi desenhada pra 1×/dia; regenerar
+-- 6×/dia SEM proteção cria risco de COMPRA DUPLA. Corpo = VERBATIM da def viva (20260606190000,
+-- A2-CMC-ACCOUNT) + 4 marcas [INTRADAY] (NÃO rebasear de migration antiga — §10):
+--
+--   [INTRADAY 1/4] advisory lock por empresa — serializa cron 2/2h × botão manual × retry.
+--   [INTRADAY 2/4] expira pendentes NORMAIS de ciclos anteriores — rodadas pós-corte criam
+--       pendentes que o corte (.eq data_ciclo=hoje) nunca expiraria → zumbis invisíveis no
+--       cockpit (filtra hoje) e fora do alerta R$3k. Dentro da RPC = cobre cron E botão manual.
+--   [INTRADAY 3/4] limpeza do dia tipo-aware + bloqueados: (a) só tipo_ciclo normal — antes era
+--       tipo-blind e apagaria as OPORTUNIDADES pendentes (geradas 11h05 UTC; com motor 1×/dia às
+--       9h15 nunca se manifestou — o intra-day roda DEPOIS delas); (b) bloqueado_guardrail do
+--       dia ENTRA — senão a rodada seguinte re-sugere os MESMOS SKUs num pedido pendente novo ao
+--       lado do bloqueado (em_transito não conta bloqueado) → aprovar os dois = compra dupla.
+--       O aplicar_promocoes_no_ciclo da MESMA rodada re-bloqueia se a condição persistir.
+--   [INTRADAY 4/4] NOT EXISTS anti-oportunidade no skus_necessitando — não re-sugerir SKU que
+--       está em pedido pendente/bloqueado de tipo_ciclo <> normal (a limpeza 3/4 preserva esses
+--       pedidos; sem a guarda o mesmo SKU nasceria TAMBÉM no pedido normal). Se a oportunidade
+--       for rejeitada/expirar, a rodada seguinte (≤2h) re-sugere no ciclo normal.
+--
+-- Crons: motor intra-day 6×/dia (10–20 UTC = 7h–17h BRT, :15) com body {"intraday":true} (a edge
+-- suprime o digest); omie-sync-estoque encadeado ~35min antes de cada rodada; o sync diário
+-- existente (0 9,14,19) vira só 0 9 (14/19 ficam redundantes; o 9h serve a rodada matinal 9h15,
+-- que continua com digest).
+--
+-- ⚠️ Migration MANUAL (Lovable): colar no SQL Editor → Run. PRÉ-FLIGHT (lição §10): conferir
+-- `SELECT pg_get_functiondef('public.gerar_pedidos_sugeridos_ciclo(text,date)'::regprocedure)`
+-- == corpo da 20260606190000 antes de aplicar; divergência = ABORTAR e rebasear sobre prod.
+-- ⚠️ REQUER deploy da edge gerar-pedidos-diario (flag intraday + tick do alerta) via Lovable.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.gerar_pedidos_sugeridos_ciclo(p_empresa text DEFAULT 'OBEN'::text, p_data_ciclo date DEFAULT CURRENT_DATE)
+ RETURNS TABLE(pedidos_gerados integer, skus_incluidos integer, valor_total_ciclo numeric, bloqueados integer)
+ LANGUAGE plpgsql
+ SET search_path TO 'public', 'pg_temp'
+ SET statement_timeout TO '120s'
+AS $function$
+DECLARE
+  v_pedidos INT := 0;
+  v_skus INT := 0;
+  v_valor NUMERIC := 0;
+  v_bloqueados INT := 0;
+BEGIN
+  -- [INTRADAY 1/4] serializa execuções concorrentes (cron 2/2h × botão "Recalcular" × retry).
+  -- xact-lock: solta sozinho no fim da transação. Por empresa (a expiração 2/4 cruza datas).
+  PERFORM pg_advisory_xact_lock(hashtext('gerar_pedidos_sugeridos_ciclo:' || lower(p_empresa)));
+
+  IF (SELECT count(*) FILTER (WHERE tipo_produto IS NOT NULL) FROM public.omie_products WHERE account = lower(p_empresa)) = 0 THEN
+    RAISE EXCEPTION 'tipo_produto_unhealthy: sinal de classificação ausente em omie_products(account=%) — recusando gerar compras p/ não tratar Produto Acabado como comprável', lower(p_empresa);
+  END IF;
+
+  -- [INTRADAY 2/4] expira pendentes NORMAIS de ciclos anteriores (zumbis pós-corte). Oportunidade
+  -- fica fora (território do ciclo_oportunidade_do_dia); bloqueado_guardrail antigo fica (status
+  -- quo: chip "precisam de atenção").
+  UPDATE pedido_compra_sugerido
+  SET status = 'expirado_sem_aprovacao', atualizado_em = now()
+  WHERE empresa = p_empresa
+    AND data_ciclo < p_data_ciclo
+    AND status = 'pendente_aprovacao'
+    AND COALESCE(tipo_ciclo, 'normal') = 'normal';
+
+  -- [INTRADAY 3/4] limpeza do dia: só ciclo NORMAL (preserva oportunidade/promoção pendentes) e
+  -- INCLUI bloqueado_guardrail do dia (re-avaliado a cada rodada; anti compra dupla).
+  DELETE FROM pedido_compra_sugerido
+  WHERE empresa = p_empresa AND data_ciclo = p_data_ciclo
+    AND status IN ('pendente_aprovacao', 'bloqueado_guardrail')
+    AND COALESCE(tipo_ciclo, 'normal') = 'normal';
+
+  WITH em_transito AS (
+    SELECT pcs2.empresa, pci.sku_codigo_omie::text AS sku_codigo_omie, SUM(pci.qtde_final) AS qtde
+    FROM pedido_compra_item pci
+    JOIN pedido_compra_sugerido pcs2 ON pcs2.id = pci.pedido_id
+    WHERE pcs2.empresa = p_empresa
+      AND (
+        (pcs2.status IN ('aprovado_aguardando_disparo','disparado','concluido_recebido') AND pcs2.data_ciclo >= (p_data_ciclo - INTERVAL '7 days'))
+        OR (pcs2.status_envio_portal IN ('sucesso_portal','enviado_portal') AND pcs2.portal_protocolo IS NOT NULL AND pcs2.omie_pedido_compra_numero IS NULL AND pcs2.status NOT IN ('cancelado','expirado_sem_aprovacao'))
+      )
+    GROUP BY pcs2.empresa, pci.sku_codigo_omie
+  ),
+  preco_medio AS (
+    SELECT slh.empresa::text AS empresa, slh.sku_codigo_omie::text AS sku_codigo_omie,
+           AVG(slh.valor_total / NULLIF(slh.quantidade_recebida, 0)) AS preco_unitario, COUNT(*) AS n
+    FROM sku_leadtime_history slh
+    WHERE slh.quantidade_recebida > 0 AND slh.valor_total > 0
+    GROUP BY slh.empresa, slh.sku_codigo_omie
+  ),
+  skus_necessitando AS (
+    SELECT sp.empresa, sp.sku_codigo_omie::text AS sku_codigo_omie, sp.sku_descricao, sp.fornecedor_nome,
+           sg.grupo_codigo, sp.ponto_pedido, sp.estoque_maximo,
+           COALESCE(sea.estoque_fisico, 0) AS estoque_fisico,
+           COALESCE(sea.estoque_pendente_entrada, 0) AS estoque_pendente,
+           COALESCE(et.qtde, 0) AS qtde_em_transito_recente,
+           (COALESCE(sea.estoque_fisico, 0) + COALESCE(sea.estoque_pendente_entrada, 0) + COALESCE(et.qtde, 0)) AS estoque_efetivo,
+           -- [QTDE-INTEIRA] arredonda pra cima: o estoque vem do Omie com poeira decimal → max − estoque
+           -- seria fracionário (3,99996). Arredondar pra cima preserva o sinal >0, então o filtro de
+           -- necessidade abaixo fica idêntico (inclusão inalterada; só o valor muda).
+           ceil(sp.estoque_maximo - (COALESCE(sea.estoque_fisico, 0) + COALESCE(sea.estoque_pendente_entrada, 0) + COALESCE(et.qtde, 0))) AS qtde_sugerida,
+           -- [MIN-FORCADO 1/3] qtde_final = piso(natural, mínimo forçado). Espelha o helper puro
+           -- aplicarMinimoForcado: CASE WHEN min>0 THEN GREATEST(natural, min) ELSE natural END.
+           -- Sem piso-0 fantasma (ELSE devolve o natural intocado). A guarda "só item que precisa
+           -- repor" é o filtro qtde_sugerida > 0 abaixo (sobre o NATURAL), inalterado.
+           -- [QTDE-INTEIRA] ceil envolve o piso E o natural: nenhuma quantidade fracionária (do
+           -- estoque com poeira decimal OU de um mínimo forçado fracionário) chega ao pedido.
+           CASE WHEN sp.minimo_forcado_manual IS NOT NULL AND sp.minimo_forcado_manual > 0
+                THEN ceil(GREATEST(
+                       (sp.estoque_maximo - (COALESCE(sea.estoque_fisico, 0) + COALESCE(sea.estoque_pendente_entrada, 0) + COALESCE(et.qtde, 0))),
+                       sp.minimo_forcado_manual))
+                ELSE ceil(sp.estoque_maximo - (COALESCE(sea.estoque_fisico, 0) + COALESCE(sea.estoque_pendente_entrada, 0) + COALESCE(et.qtde, 0)))
+           END AS qtde_final,
+           -- [A2-CMC-PEDIDO] cmc-PRIMEIRO (>0), senão média, senão 0. Espelha a view (preco_item_eoq):
+           -- cmc=0/negativo/null não vira preço 0 (CASE devolve NULL → COALESCE cai pra média).
+           -- [A2-CMC-ACCOUNT] cmc das 2 convenções de account (espelha a view precos_cmc): pra OBEN
+           -- olha 'vendas' E 'oben' (o feed canônico grava 'vendas'); cmc>0 mais fresco; senão média; senão 0.
+           COALESCE(
+             ( SELECT ipc.cmc FROM inventory_position ipc
+               WHERE ipc.omie_codigo_produto::text = sp.sku_codigo_omie::text
+                 AND ipc.account = ANY (CASE lower(p_empresa)
+                       WHEN 'oben' THEN ARRAY['vendas'::text,'oben'::text]
+                       WHEN 'colacor' THEN ARRAY['colacor_vendas'::text,'colacor'::text]
+                       WHEN 'colacor_sc' THEN ARRAY['servicos'::text,'colacor_sc'::text]
+                       ELSE ARRAY[lower(p_empresa)] END)
+                 AND ipc.cmc > 0
+               ORDER BY ipc.synced_at DESC NULLS LAST
+               LIMIT 1 ),
+             pm.preco_unitario, 0) AS preco_unitario,
+           (pm.n IS NULL) AS primeira_compra,
+           fh.horario_corte_pedido, fh.valor_maximo_mensal, fh.delta_max_perc
+    FROM sku_parametros sp
+    LEFT JOIN sku_grupo_producao sg ON sg.empresa = sp.empresa AND sg.sku_codigo_omie = sp.sku_codigo_omie::text
+    LEFT JOIN sku_estoque_atual sea ON sea.empresa = sp.empresa AND sea.sku_codigo_omie = sp.sku_codigo_omie::text
+    LEFT JOIN fornecedor_habilitado_reposicao fh ON fh.empresa = sp.empresa AND fh.fornecedor_nome = sp.fornecedor_nome
+    LEFT JOIN omie_products op ON op.omie_codigo_produto::text = sp.sku_codigo_omie::text AND op.account = lower(p_empresa)
+    LEFT JOIN familia_nao_comprada fnc ON fnc.empresa = sp.empresa AND fnc.familia = op.familia
+    LEFT JOIN em_transito et ON et.empresa = sp.empresa AND et.sku_codigo_omie = sp.sku_codigo_omie::text
+    LEFT JOIN preco_medio pm ON pm.empresa = sp.empresa AND pm.sku_codigo_omie = sp.sku_codigo_omie::text
+    LEFT JOIN inventory_position ip ON ip.omie_codigo_produto::text = sp.sku_codigo_omie::text AND ip.account = lower(p_empresa)
+    LEFT JOIN sku_status_omie sso ON sso.empresa = sp.empresa AND sso.sku_codigo_omie = sp.sku_codigo_omie::text
+    WHERE sp.empresa = p_empresa
+      AND sp.habilitado_reposicao_automatica = TRUE
+      AND COALESCE(sp.tipo_reposicao, 'automatica') = 'automatica'
+      AND sp.fornecedor_nome IS NOT NULL
+      AND btrim(sp.fornecedor_nome) <> ''
+      AND fnc.id IS NULL
+      AND COALESCE(op.ativo, true) = true
+      AND COALESCE(sso.ativo_no_omie, true) = true
+      AND COALESCE(op.descricao, '') NOT ILIKE '%450ML'
+      AND COALESCE(op.descricao, '') NOT ILIKE '%405ML'
+      AND COALESCE((
+            SELECT COALESCE(op04.tipo_produto, op04.metadata->>'tipo_produto')
+            FROM omie_products op04
+            WHERE op04.omie_codigo_produto::text = sp.sku_codigo_omie::text
+              AND op04.account = lower(p_empresa)
+            LIMIT 1
+          ), '') <> '04'
+      -- [INTRADAY 4/4] não re-sugerir SKU presente em pedido pendente/bloqueado de OPORTUNIDADE/
+      -- promoção (a limpeza 3/4 os preserva; sem esta guarda o mesmo SKU nasceria também no
+      -- pedido normal → aprovar os dois = compra dupla).
+      AND NOT EXISTS (
+            SELECT 1
+            FROM pedido_compra_item pci9
+            JOIN pedido_compra_sugerido pcs9 ON pcs9.id = pci9.pedido_id
+            WHERE pcs9.empresa = p_empresa
+              AND pcs9.status IN ('pendente_aprovacao', 'bloqueado_guardrail')
+              AND COALESCE(pcs9.tipo_ciclo, 'normal') <> 'normal'
+              AND pci9.sku_codigo_omie = sp.sku_codigo_omie::text
+          )
+      AND sp.ponto_pedido IS NOT NULL
+      AND sp.estoque_maximo IS NOT NULL
+      AND (COALESCE(sea.estoque_fisico, 0) + COALESCE(sea.estoque_pendente_entrada, 0) + COALESCE(et.qtde, 0)) <= sp.ponto_pedido
+  ),
+  pedidos_por_fornecedor_grupo AS (
+    INSERT INTO pedido_compra_sugerido (
+      empresa, fornecedor_nome, grupo_codigo, data_ciclo, horario_corte_planejado,
+      valor_total, num_skus, status, condicao_pagamento_codigo, condicao_pagamento_descricao,
+      num_parcelas, dias_parcelas, condicao_origem
+    )
+    SELECT sn.empresa, sn.fornecedor_nome, sn.grupo_codigo, p_data_ciclo,
+           (p_data_ciclo + MAX(sn.horario_corte_pedido))::timestamptz,
+           SUM(sn.qtde_final * sn.preco_unitario), COUNT(*),
+           'pendente_aprovacao', '000', 'À Vista', 1, NULL, 'default_a_vista'
+    FROM skus_necessitando sn
+    WHERE sn.qtde_sugerida > 0
+    GROUP BY sn.empresa, sn.fornecedor_nome, sn.grupo_codigo
+    RETURNING id, fornecedor_nome, grupo_codigo
+  )
+  INSERT INTO pedido_compra_item (
+    pedido_id, sku_codigo_omie, sku_descricao, estoque_atual, ponto_pedido, estoque_maximo,
+    qtde_sugerida, qtde_final, preco_unitario, valor_linha, primeira_compra
+  )
+  SELECT pfg.id, sn.sku_codigo_omie, sn.sku_descricao, sn.estoque_efetivo, sn.ponto_pedido, sn.estoque_maximo,
+         sn.qtde_sugerida, sn.qtde_final, sn.preco_unitario, sn.qtde_final * sn.preco_unitario, sn.primeira_compra
+  FROM skus_necessitando sn
+  JOIN pedidos_por_fornecedor_grupo pfg
+    ON pfg.fornecedor_nome = sn.fornecedor_nome AND COALESCE(pfg.grupo_codigo,'') = COALESCE(sn.grupo_codigo,'')
+  WHERE sn.qtde_sugerida > 0;
+
+  SELECT COUNT(*), COALESCE(SUM(num_skus),0), COALESCE(SUM(valor_total),0)
+  INTO v_pedidos, v_skus, v_valor
+  FROM pedido_compra_sugerido
+  WHERE empresa = p_empresa AND data_ciclo = p_data_ciclo AND status = 'pendente_aprovacao';
+
+  RETURN QUERY SELECT v_pedidos, v_skus, v_valor, v_bloqueados;
+END;
+$function$;
+
+-- ── Crons ────────────────────────────────────────────────────────────────────
+-- Motor intra-day: 6 rodadas, 7h–17h BRT (10–20 UTC), :15. Body intraday:true → edge suprime o
+-- digest. A rodada matinal (gerar-pedidos-diario-oben, 15 9 UTC) continua INTACTA, com digest.
+SELECT cron.schedule(
+  'gerar-pedidos-intraday-oben',
+  '15 10,12,14,16,18,20 * * *',
+  ' SELECT net.http_post( url := ''https://fzvklzpomgnyikkfkzai.supabase.co/functions/v1/gerar-pedidos-diario'', headers := jsonb_build_object( ''Content-Type'', ''application/json'', ''x-cron-secret'', (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name=''CRON_SECRET'' LIMIT 1) ), body := ''{"empresa":"OBEN","intraday":true}''::jsonb, timeout_milliseconds := 150000 ) AS request_id; '
+);
+
+-- Estoque fresco ~35min antes de cada rodada intra-day (o motor lê sku_estoque_atual).
+SELECT cron.schedule(
+  'omie-sync-estoque-intraday-oben',
+  '40 9,11,13,15,17,19 * * *',
+  ' SELECT net.http_post( url := ''https://fzvklzpomgnyikkfkzai.supabase.co/functions/v1/omie-sync-estoque'', headers := jsonb_build_object( ''Content-Type'', ''application/json'', ''x-cron-secret'', (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name=''CRON_SECRET'' LIMIT 1) ), body := ''{"empresa": "OBEN"}''::jsonb, timeout_milliseconds := 90000 ) AS request_id; '
+);
+
+-- O sync diário existente (0 9,14,19) fica só com o 9h UTC (serve a rodada matinal das 9h15);
+-- 14/19 viram redundantes com o intraday (13h40–19h40). cron.schedule = upsert por nome.
+SELECT cron.schedule(
+  'omie-sync-estoque-diario',
+  '0 9 * * *',
+  ' SELECT net.http_post( url := ''https://fzvklzpomgnyikkfkzai.supabase.co/functions/v1/omie-sync-estoque'', headers := jsonb_build_object( ''Content-Type'', ''application/json'', ''x-cron-secret'', (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name=''CRON_SECRET'' LIMIT 1) ), body := ''{"empresa": "OBEN"}''::jsonb, timeout_milliseconds := 90000 ) AS request_id; '
+);
+
+COMMIT;
+
+-- Validação (rodar após o COMMIT):
+-- SELECT 'INTRADAY OK' AS status,
+--   (SELECT count(*) FROM pg_proc p WHERE p.proname='gerar_pedidos_sugeridos_ciclo'
+--     AND pg_get_functiondef(p.oid) LIKE '%INTRADAY 4/4%') AS rpc_com_marcas,
+--   (SELECT count(*) FROM cron.job WHERE jobname='gerar-pedidos-intraday-oben') AS cron_motor,
+--   (SELECT count(*) FROM cron.job WHERE jobname='omie-sync-estoque-intraday-oben') AS cron_estoque,
+--   (SELECT schedule FROM cron.job WHERE jobname='omie-sync-estoque-diario') AS diario_so_9h;


### PR DESCRIPTION
## O quê

Pacote "compras intra-day" pedido pelo founder (3 frentes):

1. **Alerta por e-mail — pedido Sayerlack atingiu R$3.000** (mínimo de faturamento da Sayerlack). Tick SQL puro no padrão watchdog de transição: pedido sugerido `pendente_aprovacao` ≥ régua → 1 e-mail por (fornecedor, grupo); re-arma quando o founder aprova ou o pedido sai da régua. Vários e-mails/dia com pedidos diferentes, zero spam do mesmo pedido. Cron `*/30` SQL local + hook best-effort na edge de geração.
2. **Ciclo intra-day**: motor de sugestões 1×/dia → 7×/dia (matinal 9h15 UTC com digest + 6 rodadas 10–20 UTC sem digest), `omie-sync-estoque` encadeado ~35min antes de cada rodada. Venda faturada de manhã vira sugestão à tarde; aprovação manual já dispara na hora → lead time ↓ ~0,5–1 dia.
3. **Gate de disparo**: pedido Sayerlack abaixo de R$3k não dispara (a Sayerlack não fatura) — `falha_envio` com motivo claro, PRÉ-split, isentando filho de split e pedido que já tocou o portal. Mesma config do alerta (uma régua, dois usos).

## Segurança money-path (as 4 marcas [INTRADAY] na RPC)

A RPC foi desenhada pra rodar 1×/dia; regenerar 6×/dia sem proteção cria **compra dupla**:
- **advisory lock** (cron × botão manual × retry);
- **expiração de pendentes-zumbis** de ciclos anteriores (o corte `.eq data_ciclo` nunca os expiraria);
- **limpeza tipo-aware** (não apaga oportunidades pendentes das 11h05 UTC) **+ bloqueado_guardrail do dia entra** (senão a rodada seguinte re-sugere os mesmos SKUs ao lado do bloqueado);
- **NOT EXISTS anti-oportunidade** (SKU em oportunidade pendente não renasce no ciclo normal).

Corpo verbatim da def viva (`20260606190000`) + marcas. Codex em usage-limit até 11/06 → **caminho B** (precedente registrado): passe adversarial próprio + PG17 exaustivo; Codex retroativo quando voltar.

## Validação

- PG17 local: `db/test-alerta-pedido-minimo.sh` (**11 asserts**) + `db/test-rpc-intraday.sh` (**8 asserts**, aplica as migrations reais sobre o snapshot)
- vitest: 17 testes do helper do gate (espelhado verbatim no Deno) — suíte completa 2861/2861
- typecheck strict + lint (0 errors) + build ✓

## ⚠️ ATENÇÃO: migration manual necessária (2) + deploy de 2 edges

**Nada vai ao ar no merge.** Founder precisa colar no SQL Editor (blocos na conversa):
1. `20260609150000_reposicao_alerta_pedido_minimo.sql` (BLOCO A)
2. `20260609160000_reposicao_ciclo_intraday.sql` (BLOCO B — **pré-flight**: conferir `pg_get_functiondef` da RPC == `20260606190000` antes; divergência = abortar)

E pedir no chat do Lovable o deploy **verbatim da main** de: `gerar-pedidos-diario` + `disparar-pedidos-aprovados`. Sem Publish de frontend (nada de UI mudou).

Spec: `docs/superpowers/specs/2026-06-09-reposicao-intraday-alerta-3k-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)