### PR TITLE
feat(pedido): card "Cores do cliente" no wizard — busca + re-pedido de cor (v1)

### DIFF
--- a/docs/superpowers/specs/2026-06-09-cores-do-cliente-wizard-design.md
+++ b/docs/superpowers/specs/2026-06-09-cores-do-cliente-wizard-design.md
@@ -1,0 +1,66 @@
+# Cores do cliente no wizard de pedido — design (v1)
+
+> Aprovado pelo founder em 2026-06-09 (brainstorm na sessão da cor da tinta).
+
+## Problema
+Cliente liga: "quero mais daquele verde". A vendedora (Regina/Tatiana) não tem onde
+buscar a cor desenvolvida/pedida pelo cliente — precisa abrir pedido antigo por
+pedido. Agora que `sales_orders.items[].tint_nome_cor` existe (Fases 1-2 do programa
+da cor, PR #704 + backfill), dá pra buscar o histórico por cor.
+
+## Decisões (founder)
+- **D1/D2 — v1 = fluxo do wizard** (`/sales/new`): buscar a cor do cliente na hora da
+  venda. O fluxo "do pedido antigo → repetir em pedido novo" é a **fase 2** (registrado
+  em Fora do escopo).
+- Resultado mostra **acabamento/base/embalagem** do que foi pedido (estão na descrição
+  da base, ex.: "BASE **BRILH** BRANC PU WFBB.6045**QT**") e permite **trocar
+  embalagem/acabamento** ao re-pedir — via o `TintColorSelectDialog` existente.
+
+## Design
+**Onde:** card "🎨 Cores do cliente" no `UnifiedOrder`, renderizado quando há cliente
+selecionado **com conta local** (`customerUserId`), entre o `CustomerSearch` e as tabs
+de produtos. Colapsável; some quando o cliente não tem cor no histórico.
+
+**Conteúdo:** busca + lista agrupada **por cor** (não por pedido), ordenada por
+recência. Cada cor: nome + ocorrências (data, descrição da base, quantidade, PV,
+empresa). Busca **acento-insensitive** ("afiacao" acha "afiação"). Sem termo → mostra
+as últimas cores (descoberta passiva).
+
+**Dedup:** o mesmo pedido pode ter 2 linhas (wizard × sync — 172 pares conhecidos);
+dedup por `omie_pedido_id` (fallback id) antes de agrupar.
+
+**Clique (re-pedido):** ocorrência → localizar o `Product` no catálogo carregado por
+`omie_codigo_produto`+account → `addProductToCart(product)` (já abre o
+`TintColorSelectDialog` para base tintométrica) com a **busca do dialog pré-preenchida**
+com o nome da cor (prop nova `initialSearch`; o dialog já permite trocar
+base/embalagem/acabamento e já puxa o último preço praticado do cliente).
+**Degradação honesta:** base fora do catálogo/não-tintométrica → toast informativo +
+pré-preencher a busca de produtos com a descrição (o histórico continua visível;
+só o atalho degrada).
+
+## Arquitetura (100% frontend — sem migration/edge; só Publish)
+- `src/lib/tint/cores-do-cliente.ts` — helpers puros TDD:
+  `extrairCoresDoHistorico(pedidos)` (dedup → extrai itens com `tint_nome_cor` →
+  agrupa por cor normalizada → ordena por recência) e `filtrarCores(cores, termo)`
+  (normalização NFD, acento/caixa-insensitive).
+- `src/hooks/unifiedOrder/useCoresDoCliente.ts` — `useQuery` dos `sales_orders` do
+  cliente (`customer_user_id`, colunas mínimas + `items`), `limit` defensivo,
+  agrupamento via helper.
+- `src/components/unified-order/CoresDoClienteCard.tsx` — card denso B2B (padrão
+  `ProductItemForm`), Collapsible, estados: oculto (sem cliente/sem cores), busca
+  vazia (últimas cores), sem resultado.
+- `TintColorSelectDialog`/`useTintColorSelect` — prop opcional `initialSearch`
+  aplicada no `open` (seta `search` e `debouncedSearch` direto, sem esperar debounce).
+
+## Testes
+Helper puro: dedup wizard×sync; agrupamento por cor com normalização; ordenação por
+recência; filtro com acento ("afiacao"→"afiação"); pedido sem cor ignorado; jsonb
+malformado não quebra. Smoke do componente (estados oculto/lista/sem-resultado).
+
+## Fora do escopo v1 (registrado)
+- Fase 2: "repetir do pedido antigo" (botão no detalhe do pedido → wizard com carrinho
+  pré-carregado).
+- Busca global de cor no Cmd+K (hoje busca só catálogo `tint_formulas`).
+- Recuperar cores antigas da Colacor anotadas fora do padrão `Cor:` (parsing fuzzy).
+- Pré-seleção automática da fórmula no dialog (matching nome↔catálogo é heurístico;
+  v1 pré-preenche a busca).

--- a/src/components/TintColorSelectDialog.tsx
+++ b/src/components/TintColorSelectDialog.tsx
@@ -7,7 +7,7 @@ import { FormulaSearchResults } from './tintColorSelect/FormulaSearchResults';
 import { GlobalColorMatches } from './tintColorSelect/GlobalColorMatches';
 import { SelectedFormulaCard } from './tintColorSelect/SelectedFormulaCard';
 
-export function TintColorSelectDialog({ product, open, onClose, onConfirm, customerUserId }: TintColorSelectDialogProps) {
+export function TintColorSelectDialog({ product, open, onClose, onConfirm, customerUserId, initialSearch }: TintColorSelectDialogProps) {
   const {
     search,
     onSearchChange,
@@ -36,7 +36,7 @@ export function TintColorSelectDialog({ product, open, onClose, onConfirm, custo
     custoCorantes,
     precoSemDesconto,
     precoFinal,
-  } = useTintColorSelect({ product, open, customerUserId });
+  } = useTintColorSelect({ product, open, customerUserId, initialSearch });
 
   return (
     <Dialog open={open} onOpenChange={(o) => !o && onClose()}>

--- a/src/components/tintColorSelect/types.ts
+++ b/src/components/tintColorSelect/types.ts
@@ -8,6 +8,8 @@ export interface TintColorSelectDialogProps {
   onClose: () => void;
   onConfirm: (formulaId: string, corId: string, nomeCor: string, precoFinal: number, custoCorantes: number, alternativeProduct?: Product) => void;
   customerUserId?: string | null;
+  /** Pré-preenche a busca de cor ao abrir (re-pedido via "Cores do cliente"). */
+  initialSearch?: string | null;
 }
 
 export interface FormulaResult {

--- a/src/components/tintColorSelect/useTintColorSelect.ts
+++ b/src/components/tintColorSelect/useTintColorSelect.ts
@@ -12,9 +12,11 @@ interface UseTintColorSelectArgs {
   product: Product;
   open: boolean;
   customerUserId?: string | null;
+  /** Pré-preenche a busca ao abrir (re-pedido via "Cores do cliente"). */
+  initialSearch?: string | null;
 }
 
-export function useTintColorSelect({ product, open, customerUserId }: UseTintColorSelectArgs) {
+export function useTintColorSelect({ product, open, customerUserId, initialSearch }: UseTintColorSelectArgs) {
   const [search, setSearch] = useState('');
   const [debouncedSearch, setDebouncedSearch] = useState('');
   const [selectedFormula, setSelectedFormula] = useState<FormulaResult | null>(null);
@@ -29,6 +31,15 @@ export function useTintColorSelect({ product, open, customerUserId }: UseTintCol
       setPriceSourceOverride(null);
     }
   }, [open]);
+
+  // Re-pedido: abre já filtrado pela cor do histórico (debounced direto,
+  // sem esperar os 300ms — a vendedora vê a lista filtrada na hora).
+  useEffect(() => {
+    if (open && initialSearch) {
+      setSearch(initialSearch);
+      setDebouncedSearch(initialSearch);
+    }
+  }, [open, initialSearch]);
 
   useEffect(() => {
     const t = setTimeout(() => setDebouncedSearch(search), 300);

--- a/src/components/unified-order/CoresDoClienteCard.tsx
+++ b/src/components/unified-order/CoresDoClienteCard.tsx
@@ -1,0 +1,127 @@
+import { useState } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Search, Palette, ChevronDown, ChevronUp, Loader2, Plus } from 'lucide-react';
+import { format } from 'date-fns';
+import type { CorDoCliente, OcorrenciaCor } from '@/lib/tint/cores-do-cliente';
+
+interface CoresDoClienteCardProps {
+  cores: CorDoCliente[];
+  coresFiltradas: CorDoCliente[];
+  busca: string;
+  onBuscaChange: (v: string) => void;
+  isLoading: boolean;
+  /** Re-pedido: clique numa ocorrência (cor + base daquela vez). */
+  onRepetirCor: (cor: CorDoCliente, ocorrencia: OcorrenciaCor) => void;
+}
+
+const empresaLabel = (account: string) =>
+  account === 'colacor' ? 'Colacor' : account === 'colacor_sc' ? 'Colacor SC' : 'Oben';
+
+const fmtData = (iso: string) => {
+  try {
+    return format(new Date(iso), 'dd/MM/yyyy');
+  } catch {
+    return '';
+  }
+};
+
+/**
+ * "🎨 Cores do cliente" — histórico de cores já pedidas pelo cliente selecionado
+ * no wizard. Sem busca mostra as últimas cores (descoberta passiva); a busca é
+ * acento-insensitive. Clique na ocorrência reabre o fluxo de tingir com a base
+ * daquela compra (podendo trocar embalagem/acabamento no dialog).
+ * Não renderiza nada quando o cliente não tem cor no histórico.
+ */
+export function CoresDoClienteCard({
+  cores, coresFiltradas, busca, onBuscaChange, isLoading, onRepetirCor,
+}: CoresDoClienteCardProps) {
+  const [aberto, setAberto] = useState(true);
+
+  if (!isLoading && cores.length === 0) return null;
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <button
+          type="button"
+          className="flex items-center justify-between w-full text-left"
+          onClick={() => setAberto((a) => !a)}
+        >
+          <CardTitle className="text-sm flex items-center gap-2">
+            <Palette className="w-4 h-4" /> Cores do cliente
+            {cores.length > 0 && (
+              <Badge variant="secondary" className="text-[10px] px-1.5 py-0">{cores.length}</Badge>
+            )}
+          </CardTitle>
+          {aberto ? <ChevronUp className="w-4 h-4 text-muted-foreground" /> : <ChevronDown className="w-4 h-4 text-muted-foreground" />}
+        </button>
+      </CardHeader>
+      {aberto && (
+        <CardContent>
+          {isLoading ? (
+            <Loader2 className="w-5 h-5 animate-spin mx-auto" />
+          ) : (
+            <>
+              <div className="relative mb-3">
+                <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
+                <Input
+                  placeholder="Buscar cor já pedida... (ex: verde afiacao)"
+                  value={busca}
+                  onChange={(e) => onBuscaChange(e.target.value)}
+                  className="pl-9 h-9"
+                />
+              </div>
+              <div className="max-h-[320px] overflow-y-auto space-y-2">
+                {coresFiltradas.map((cor) => (
+                  <div key={cor.nome} className="rounded-lg border p-2">
+                    <p className="text-xs font-medium flex items-center gap-1.5">
+                      🎨 {cor.nome}
+                      <span className="text-[10px] text-muted-foreground font-normal">
+                        {cor.ocorrencias.length}× pedida
+                      </span>
+                    </p>
+                    <div className="mt-1 space-y-1">
+                      {cor.ocorrencias.slice(0, 4).map((oc, i) => (
+                        <div key={i} className="flex items-center justify-between gap-2">
+                          <div className="min-w-0 flex-1 text-[11px] text-muted-foreground">
+                            <span className="font-tabular text-foreground">{fmtData(oc.data)}</span>
+                            {' · '}
+                            <span className="truncate">{oc.baseDescricao}</span>
+                            {' · '}{oc.quantidade}un
+                            {oc.pv && <> · PV <span className="font-tabular">{oc.pv}</span></>}
+                            <Badge variant="outline" className="text-[9px] px-1 py-0 ml-1">{empresaLabel(oc.account)}</Badge>
+                          </div>
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            className="h-6 text-[11px] shrink-0 px-2"
+                            onClick={() => onRepetirCor(cor, oc)}
+                          >
+                            <Plus className="w-3 h-3 mr-0.5" /> Pedir de novo
+                          </Button>
+                        </div>
+                      ))}
+                      {cor.ocorrencias.length > 4 && (
+                        <p className="text-[10px] text-muted-foreground">
+                          + {cor.ocorrencias.length - 4} pedidos anteriores
+                        </p>
+                      )}
+                    </div>
+                  </div>
+                ))}
+                {coresFiltradas.length === 0 && (
+                  <p className="text-xs text-muted-foreground py-2">
+                    Nenhuma cor do histórico casa com “{busca}”.
+                  </p>
+                )}
+              </div>
+            </>
+          )}
+        </CardContent>
+      )}
+    </Card>
+  );
+}

--- a/src/hooks/unifiedOrder/useCoresDoCliente.ts
+++ b/src/hooks/unifiedOrder/useCoresDoCliente.ts
@@ -1,0 +1,41 @@
+import { useMemo, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import {
+  extrairCoresDoHistorico,
+  filtrarCores,
+  type CorDoCliente,
+  type PedidoHistorico,
+} from '@/lib/tint/cores-do-cliente';
+
+/**
+ * Cores já pedidas pelo cliente selecionado no wizard ("🎨 Cores do cliente").
+ * Lê os pedidos do cliente (colunas mínimas + items jsonb, onde o sync/backfill
+ * grava `tint_nome_cor`) e agrupa/filtra via helpers puros. Cliente sem conta
+ * local (customerUserId null) → desabilitado (sem histórico pra ler).
+ */
+export function useCoresDoCliente(customerUserId: string | null | undefined) {
+  const [busca, setBusca] = useState('');
+
+  const { data: cores = [], isLoading } = useQuery<CorDoCliente[]>({
+    queryKey: ['cores-do-cliente', customerUserId],
+    enabled: !!customerUserId,
+    staleTime: 5 * 60 * 1000,
+    queryFn: async () => {
+      // Pedidos do cliente são poucas dezenas; trazemos as linhas mais recentes
+      // e filtramos cor em memória (cap defensivo bem acima do caso real).
+      const { data, error } = await supabase
+        .from('sales_orders')
+        .select('id, omie_pedido_id, omie_numero_pedido, created_at, account, items')
+        .eq('customer_user_id', customerUserId!)
+        .order('created_at', { ascending: false })
+        .limit(400);
+      if (error) throw error;
+      return extrairCoresDoHistorico((data ?? []) as PedidoHistorico[]);
+    },
+  });
+
+  const coresFiltradas = useMemo(() => filtrarCores(cores, busca), [cores, busca]);
+
+  return { cores, coresFiltradas, busca, setBusca, isLoading };
+}

--- a/src/lib/tint/__tests__/cores-do-cliente.test.ts
+++ b/src/lib/tint/__tests__/cores-do-cliente.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from 'vitest';
+import { extrairCoresDoHistorico, filtrarCores, normalizarBusca } from '../cores-do-cliente';
+import type { PedidoHistorico } from '../cores-do-cliente';
+
+const pedido = (over: Partial<PedidoHistorico> = {}): PedidoHistorico => ({
+  id: 'p1',
+  omie_pedido_id: 111,
+  omie_numero_pedido: '000000000010736',
+  created_at: '2026-06-01T12:00:00Z',
+  account: 'oben',
+  items: [],
+  ...over,
+});
+
+const itemCor = (nome: string, over: Record<string, unknown> = {}) => ({
+  descricao: 'BASE BRILH BRANC PU WFBB.6045QT',
+  quantidade: 2,
+  valor_unitario: 100,
+  tint_nome_cor: nome,
+  omie_codigo_produto: 4495328577,
+  ...over,
+});
+
+describe('extrairCoresDoHistorico', () => {
+  it('agrupa por cor com ocorrências ordenadas da mais recente pra mais antiga', () => {
+    const pedidos = [
+      pedido({ id: 'a', omie_pedido_id: 1, created_at: '2026-01-10T00:00:00Z', items: [itemCor('VERDE AFIAÇÃO')] }),
+      pedido({ id: 'b', omie_pedido_id: 2, created_at: '2026-03-05T00:00:00Z', items: [itemCor('VERDE AFIAÇÃO', { descricao: 'BASE FOSCO PU WFBB.6045GL' })] }),
+      pedido({ id: 'c', omie_pedido_id: 3, created_at: '2026-02-01T00:00:00Z', items: [itemCor('OVO H101 - BS')] }),
+    ];
+
+    const cores = extrairCoresDoHistorico(pedidos);
+
+    expect(cores).toHaveLength(2);
+    const verde = cores.find((c) => c.nome === 'VERDE AFIAÇÃO')!;
+    expect(verde.ocorrencias).toHaveLength(2);
+    expect(verde.ocorrencias[0].baseDescricao).toBe('BASE FOSCO PU WFBB.6045GL'); // mar > jan
+    expect(verde.ocorrencias[1].baseDescricao).toBe('BASE BRILH BRANC PU WFBB.6045QT');
+  });
+
+  it('ordena as CORES pela ocorrência mais recente', () => {
+    const pedidos = [
+      pedido({ id: 'a', omie_pedido_id: 1, created_at: '2026-01-01T00:00:00Z', items: [itemCor('ANTIGA')] }),
+      pedido({ id: 'b', omie_pedido_id: 2, created_at: '2026-06-01T00:00:00Z', items: [itemCor('RECENTE')] }),
+    ];
+    expect(extrairCoresDoHistorico(pedidos).map((c) => c.nome)).toEqual(['RECENTE', 'ANTIGA']);
+  });
+
+  it('dedup wizard×sync: mesmo omie_pedido_id vira UMA ocorrência', () => {
+    const pedidos = [
+      pedido({ id: 'wizard', omie_pedido_id: 555, items: [itemCor('OVO H101 - BS')] }),
+      pedido({ id: 'sync', omie_pedido_id: 555, items: [itemCor('OVO H101 - BS')] }),
+    ];
+    const cores = extrairCoresDoHistorico(pedidos);
+    expect(cores).toHaveLength(1);
+    expect(cores[0].ocorrencias).toHaveLength(1);
+  });
+
+  it('sem omie_pedido_id (null) NÃO deduplica entre si (fallback id)', () => {
+    const pedidos = [
+      pedido({ id: 'x', omie_pedido_id: null, created_at: '2026-01-01T00:00:00Z', items: [itemCor('AZUL')] }),
+      pedido({ id: 'y', omie_pedido_id: null, created_at: '2026-02-01T00:00:00Z', items: [itemCor('AZUL')] }),
+    ];
+    expect(extrairCoresDoHistorico(pedidos)[0].ocorrencias).toHaveLength(2);
+  });
+
+  it('agrupa a mesma cor com caixa/espacos diferentes; exibe a grafia mais recente', () => {
+    const pedidos = [
+      pedido({ id: 'a', omie_pedido_id: 1, created_at: '2026-01-01T00:00:00Z', items: [itemCor('ovo h101 - bs')] }),
+      pedido({ id: 'b', omie_pedido_id: 2, created_at: '2026-05-01T00:00:00Z', items: [itemCor('OVO H101 - BS ')] }),
+    ];
+    const cores = extrairCoresDoHistorico(pedidos);
+    expect(cores).toHaveLength(1);
+    expect(cores[0].nome).toBe('OVO H101 - BS');
+    expect(cores[0].ocorrencias).toHaveLength(2);
+  });
+
+  it('item sem tint_nome_cor é ignorado; pedido sem nenhum some', () => {
+    const pedidos = [
+      pedido({ id: 'a', omie_pedido_id: 1, items: [{ descricao: 'CATALISADOR', quantidade: 1, valor_unitario: 50 }] }),
+      pedido({ id: 'b', omie_pedido_id: 2, items: [itemCor('VERDE'), { descricao: 'THINNER', quantidade: 1, valor_unitario: 30 }] }),
+    ];
+    const cores = extrairCoresDoHistorico(pedidos);
+    expect(cores).toHaveLength(1);
+    expect(cores[0].ocorrencias).toHaveLength(1);
+  });
+
+  it('ocorrência carrega data, base, quantidade, PV (sem zeros à esquerda), empresa e código do produto', () => {
+    const cores = extrairCoresDoHistorico([
+      pedido({ items: [itemCor('OVO H101 - BS')], omie_numero_pedido: '000000000010736', account: 'oben' }),
+    ]);
+    const oc = cores[0].ocorrencias[0];
+    expect(oc).toMatchObject({
+      data: '2026-06-01T12:00:00Z',
+      baseDescricao: 'BASE BRILH BRANC PU WFBB.6045QT',
+      quantidade: 2,
+      pv: '10736',
+      account: 'oben',
+      omieCodigoProduto: 4495328577,
+    });
+  });
+
+  it('items malformado (null/não-array) não quebra', () => {
+    const pedidos = [
+      pedido({ id: 'a', omie_pedido_id: 1, items: null as unknown as PedidoHistorico['items'] }),
+      pedido({ id: 'b', omie_pedido_id: 2, items: 'lixo' as unknown as PedidoHistorico['items'] }),
+      pedido({ id: 'c', omie_pedido_id: 3, items: [itemCor('VERDE')] }),
+    ];
+    expect(extrairCoresDoHistorico(pedidos)).toHaveLength(1);
+  });
+});
+
+describe('filtrarCores / normalizarBusca', () => {
+  const cores = extrairCoresDoHistorico([
+    pedido({ id: 'a', omie_pedido_id: 1, items: [itemCor('VERDE AFIAÇÃO')] }),
+    pedido({ id: 'b', omie_pedido_id: 2, items: [itemCor('OVO H101 - BS')] }),
+    pedido({ id: 'c', omie_pedido_id: 3, items: [itemCor('CINZA G155 - BS')] }),
+  ]);
+
+  it('busca acento-insensitive: "afiacao" acha "AFIAÇÃO"', () => {
+    expect(filtrarCores(cores, 'verde afiacao').map((c) => c.nome)).toEqual(['VERDE AFIAÇÃO']);
+  });
+
+  it('busca por pedaço do código da cor', () => {
+    expect(filtrarCores(cores, 'h101').map((c) => c.nome)).toEqual(['OVO H101 - BS']);
+  });
+
+  it('termo vazio/espacos retorna tudo', () => {
+    expect(filtrarCores(cores, '')).toHaveLength(3);
+    expect(filtrarCores(cores, '   ')).toHaveLength(3);
+  });
+
+  it('sem match retorna vazio', () => {
+    expect(filtrarCores(cores, 'ROXO INEXISTENTE')).toEqual([]);
+  });
+
+  it('normalizarBusca: minúsculas + sem acento + trim', () => {
+    expect(normalizarBusca('  Afiação ')).toBe('afiacao');
+  });
+});

--- a/src/lib/tint/cores-do-cliente.ts
+++ b/src/lib/tint/cores-do-cliente.ts
@@ -1,0 +1,117 @@
+/**
+ * Helpers puros do card "Cores do cliente" do wizard de pedido: a partir do
+ * histórico de pedidos do cliente (`sales_orders` + `items` jsonb com
+ * `tint_nome_cor`, populado pelo sync/backfill — PR #704), monta a lista de
+ * cores já pedidas, agrupada por cor e ordenada por recência, com busca
+ * acento-insensitive ("afiacao" acha "AFIAÇÃO").
+ *
+ * Spec: docs/superpowers/specs/2026-06-09-cores-do-cliente-wizard-design.md
+ */
+
+/** Linha mínima de sales_orders que o hook busca (colunas enxutas + items). */
+export interface PedidoHistorico {
+  id: string;
+  omie_pedido_id: number | null;
+  omie_numero_pedido: string | null;
+  created_at: string;
+  account: string | null;
+  items: unknown;
+}
+
+export interface OcorrenciaCor {
+  /** created_at do pedido (ISO) — quando a cor foi pedida. */
+  data: string;
+  baseDescricao: string;
+  quantidade: number;
+  /** Nº do PV sem zeros à esquerda ('' quando não há). */
+  pv: string;
+  account: string;
+  /** Código Omie do produto-base — usado pra reabrir a base no catálogo. */
+  omieCodigoProduto: number | null;
+}
+
+export interface CorDoCliente {
+  /** Grafia mais recente da cor (display). */
+  nome: string;
+  /** Ordenadas da mais recente pra mais antiga. */
+  ocorrencias: OcorrenciaCor[];
+}
+
+/** minúsculas + sem acento + trim — base do agrupamento e da busca. */
+export function normalizarBusca(s: string): string {
+  return s
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .toLowerCase()
+    .trim();
+}
+
+interface ItemJson {
+  descricao?: unknown;
+  quantidade?: unknown;
+  tint_nome_cor?: unknown;
+  omie_codigo_produto?: unknown;
+}
+
+/**
+ * Dedup (wizard×sync podem gravar o MESMO pedido em 2 linhas — chave
+ * `omie_pedido_id`, fallback `id`) → extrai itens com cor → agrupa por cor
+ * normalizada → ordena ocorrências e cores por recência.
+ */
+export function extrairCoresDoHistorico(pedidos: PedidoHistorico[]): CorDoCliente[] {
+  const vistos = new Set<string>();
+  const grupos = new Map<string, { nome: string; nomeData: number; ocorrencias: OcorrenciaCor[] }>();
+
+  for (const p of pedidos) {
+    const chave = p.omie_pedido_id != null ? `omie:${p.omie_pedido_id}` : `id:${p.id}`;
+    if (vistos.has(chave)) continue;
+    vistos.add(chave);
+
+    if (!Array.isArray(p.items)) continue;
+    const ts = Date.parse(p.created_at) || 0;
+    const pv = (p.omie_numero_pedido ?? '').replace(/^0+/, '');
+
+    for (const raw of p.items as ItemJson[]) {
+      if (!raw || typeof raw !== 'object') continue;
+      const nomeCor = typeof raw.tint_nome_cor === 'string' ? raw.tint_nome_cor.trim() : '';
+      if (!nomeCor) continue;
+
+      const key = normalizarBusca(nomeCor);
+      let grupo = grupos.get(key);
+      if (!grupo) {
+        grupo = { nome: nomeCor, nomeData: ts, ocorrencias: [] };
+        grupos.set(key, grupo);
+      } else if (ts >= grupo.nomeData) {
+        // exibe a grafia da ocorrência mais recente
+        grupo.nome = nomeCor;
+        grupo.nomeData = ts;
+      }
+
+      grupo.ocorrencias.push({
+        data: p.created_at,
+        baseDescricao: typeof raw.descricao === 'string' ? raw.descricao : '',
+        quantidade: typeof raw.quantidade === 'number' ? raw.quantidade : 0,
+        pv,
+        account: p.account ?? '',
+        omieCodigoProduto: typeof raw.omie_codigo_produto === 'number' ? raw.omie_codigo_produto : null,
+      });
+    }
+  }
+
+  const cores = [...grupos.values()].map((g) => ({
+    nome: g.nome,
+    ocorrencias: g.ocorrencias.sort((a, b) => (Date.parse(b.data) || 0) - (Date.parse(a.data) || 0)),
+  }));
+
+  return cores.sort(
+    (a, b) =>
+      (Date.parse(b.ocorrencias[0]?.data ?? '') || 0) - (Date.parse(a.ocorrencias[0]?.data ?? '') || 0),
+  );
+}
+
+/** Filtro acento/caixa-insensitive sobre o nome da cor. Vazio → tudo. */
+export function filtrarCores(cores: CorDoCliente[], termo: string): CorDoCliente[] {
+  const q = normalizarBusca(termo);
+  if (!q) return cores;
+  return cores.filter((c) => normalizarBusca(c.nome).includes(q));
+}

--- a/src/pages/UnifiedOrder.tsx
+++ b/src/pages/UnifiedOrder.tsx
@@ -19,6 +19,10 @@ import { useNetworkStatus } from '@/hooks/useNetworkStatus';
 import { useOfflineSubmit } from '@/hooks/useOfflineSubmit';
 import { RestoreDraftDialog } from '@/components/unified-order/RestoreDraftDialog';
 import { CustomerSearch } from '@/components/unified-order/CustomerSearch';
+import { CoresDoClienteCard } from '@/components/unified-order/CoresDoClienteCard';
+import { useCoresDoCliente } from '@/hooks/unifiedOrder/useCoresDoCliente';
+import type { CorDoCliente, OcorrenciaCor } from '@/lib/tint/cores-do-cliente';
+import { toast } from 'sonner';
 import { ProductItemForm } from '@/components/unified-order/ProductItemForm';
 import { ServiceItemForm } from '@/components/unified-order/ServiceItemForm';
 import { CartItemList } from '@/components/unified-order/CartItemList';
@@ -48,6 +52,30 @@ const UnifiedOrder = () => {
   const { isCustomerMode } = h;
   const { user } = useAuth();
   const [restoreOpen, setRestoreOpen] = useState(false);
+
+  // "Cores do cliente": histórico de cores + pré-preenchimento do dialog de tingir.
+  const coresDoCliente = useCoresDoCliente(h.customerUserId);
+  const [tintInitialSearch, setTintInitialSearch] = useState<string | null>(null);
+  const handleRepetirCor = (cor: CorDoCliente, oc: OcorrenciaCor) => {
+    const pool = oc.account === 'colacor' ? h.colacorProducts : h.obenProducts;
+    const product =
+      oc.omieCodigoProduto != null
+        ? pool.find((p) => p.omie_codigo_produto === oc.omieCodigoProduto)
+        : undefined;
+    if (product?.is_tintometric && product.tint_type === 'base') {
+      track('pedido.repetir_cor');
+      setTintInitialSearch(cor.nome);
+      h.setTintPendingProduct(product);
+      return;
+    }
+    // Degradação honesta: base fora do catálogo (inativa/outro painel) ou sem
+    // fluxo de cor → pré-preenche a busca de produtos pra ela seguir manualmente.
+    h.setProductSearch(oc.baseDescricao);
+    if (oc.account === 'oben' || oc.account === 'colacor') h.setActiveTab(oc.account);
+    toast.info('Base fora do fluxo automático de cor', {
+      description: 'Pré-preenchi a busca de produtos com a base daquele pedido — adicione manualmente.',
+    });
+  };
 
   const [searchParams] = useSearchParams();
   const preselectCustomerId = searchParams.get('customer');
@@ -207,6 +235,18 @@ const UnifiedOrder = () => {
               loadingCustomer={h.loadingCustomer} validatingVendedor={h.validatingVendedor}
               vendedorDivergencias={h.vendedorDivergencias}
               onSelectCustomer={h.selectCustomer} onClearCustomer={h.clearCustomer}
+            />
+          )}
+
+          {/* Cores já pedidas pelo cliente — busca + re-pedido (staff) */}
+          {showCustomerSearch && customerReady && (
+            <CoresDoClienteCard
+              cores={coresDoCliente.cores}
+              coresFiltradas={coresDoCliente.coresFiltradas}
+              busca={coresDoCliente.busca}
+              onBuscaChange={coresDoCliente.setBusca}
+              isLoading={coresDoCliente.isLoading}
+              onRepetirCor={handleRepetirCor}
             />
           )}
 
@@ -373,10 +413,12 @@ const UnifiedOrder = () => {
         <TintColorSelectDialog
           product={h.tintPendingProduct}
           open={!!h.tintPendingProduct}
-          onClose={() => h.setTintPendingProduct(null)}
+          onClose={() => { h.setTintPendingProduct(null); setTintInitialSearch(null); }}
           customerUserId={h.customerUserId}
+          initialSearch={tintInitialSearch}
           onConfirm={(formulaId, corId, nomeCor, precoFinal, custoCorantes, alternativeProduct) => {
             h.addTintProductToCart(alternativeProduct || h.tintPendingProduct!, formulaId, corId, nomeCor, precoFinal, custoCorantes);
+            setTintInitialSearch(null);
           }}
         />
       )}


### PR DESCRIPTION
## O que é
Pedido do founder: *"ela digitar 'verde afiacao' e já mostrar todos os pedidos que tiveram essa cor, pra ver quando foi pedido"* — e, da conversa de design: ao re-pedir, **mostrar acabamento/base/embalagem** e **permitir trocar**.

Novo card **🎨 Cores do cliente** no wizard (`/sales/new`), visível pra staff após selecionar o cliente:
- Sem digitar nada: **últimas cores pedidas** pelo cliente (descoberta passiva).
- Busca **acento-insensitive** ("verde afiacao" acha "VERDE AFIAÇÃO").
- Agrupado **por cor**; cada ocorrência mostra **data · base · qtd · PV · empresa** (dedup dos pares wizard×sync por `omie_pedido_id` — nunca mostra o mesmo pedido 2×).
- **"Pedir de novo"** → abre o `TintColorSelectDialog` existente com a base daquela compra e a **busca de cor pré-preenchida** (prop nova `initialSearch`); troca de embalagem/acabamento e preço do cliente já eram do dialog.
- **Degradação honesta:** base fora do catálogo → pré-preenche a busca de produtos + toast (histórico continua visível; só o atalho degrada).

## Fonte de dados
`sales_orders.items[].tint_nome_cor` — populado pelo sync (Fase 1) + backfill (Fase 2) do [#704](https://github.com/LucasSardenbergL/afiacao/pull/704). Hoje: 298 pedidos Oben + 5 Colacor com cor (crescendo a cada sync).

## Arquitetura
100% frontend — **sem migration, sem edge**. Helpers puros TDD (`src/lib/tint/cores-do-cliente.ts`, 13 testes) + hook de query enxuta + card denso B2B + prop `initialSearch` no dialog (aplicada no `open`, sem esperar o debounce).

## Gate
✅ typecheck strict (0) · ✅ lint 0 errors · ✅ suíte 2889/2889 (13 novos)

## Spec
[docs/superpowers/specs/2026-06-09-cores-do-cliente-wizard-design.md](docs/superpowers/specs/2026-06-09-cores-do-cliente-wizard-design.md) — fora do escopo v1 (registrado): fase 2 "repetir do pedido antigo → wizard pré-carregado", busca de cor no Cmd+K, parsing fuzzy das cores antigas da Colacor.

## ⚠️ Deploy
**Requer Publish no Lovable** (frontend puro).

🤖 Generated with [Claude Code](https://claude.com/claude-code)