### PR TITLE
feat(pedidos): listagem via view order_feed — busca acha TODOS os pedidos (PR2 do #3)

### DIFF
--- a/db/test-order-feed-view.sh
+++ b/db/test-order-feed-view.sh
@@ -57,9 +57,9 @@ values
   (gen_random_uuid(), '22222222-2222-2222-2222-222222222222', 'BOB ME',     '22.222.222/0001-22', true);
 
 -- sales: normal, com 2 itens (qtd 2 + 1 = 3)
-insert into public.sales_orders (id, customer_user_id, created_by, account, omie_numero_pedido, items, status, subtotal, total, created_at, deleted_at)
+insert into public.sales_orders (id, customer_user_id, created_by, account, omie_numero_pedido, omie_pedido_id, items, status, subtotal, total, created_at, deleted_at)
 values ('a0000001-0000-0000-0000-000000000001','11111111-1111-1111-1111-111111111111','11111111-1111-1111-1111-111111111111',
-  'oben','0000123',
+  'oben','0000123',777,
   '[{"descricao":"Verniz","quantidade":2},{"descricao":"Catalisador","quantidade":1}]'::jsonb,
   'enviado', 100, 100, now() - interval '1 hour', null);
 
@@ -107,6 +107,7 @@ begin
   if r.item_names <> array['Verniz','Catalisador']::text[] then raise exception 'FALHOU: item_names ordem (got %)', r.item_names; end if;
   if r.order_number <> '0000123' then raise exception 'FALHOU: order_number (got %)', r.order_number; end if;
   if r.account <> 'oben' then raise exception 'FALHOU: account (got %)', r.account; end if;
+  if r.omie_pedido_id <> 777 then raise exception 'FALHOU: omie_pedido_id (got %)', r.omie_pedido_id; end if;
 
   -- 3. itens malformados: view não quebrou, qty=0, names preservados
   select * into r from public.order_feed where id='a0000003-0000-0000-0000-000000000003';
@@ -128,6 +129,7 @@ begin
   if r.origin <> 'afiacao' then raise exception 'FALHOU: origin afiacao (got %)', r.origin; end if;
   if r.account <> 'colacor_sc' then raise exception 'FALHOU: afiacao account colacor_sc (got %)', r.account; end if;
   if r.order_number is not null then raise exception 'FALHOU: afiacao order_number null (got %)', r.order_number; end if;
+  if r.omie_pedido_id is not null then raise exception 'FALHOU: afiacao omie_pedido_id null (got %)', r.omie_pedido_id; end if;
   if r.customer_name <> 'ALICE LTDA' then raise exception 'FALHOU: afiacao nome via join (got %)', r.customer_name; end if;
   if r.item_quantity <> 3 then raise exception 'FALHOU: afiacao qty (got %)', r.item_quantity; end if;
   if r.item_names <> array['Afiacao Serra']::text[] then raise exception 'FALHOU: afiacao names (got %)', r.item_names; end if;

--- a/db/test-order-feed-view.sh
+++ b/db/test-order-feed-view.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# Teste PG17 da view order_feed (PR2 do #3 — read model da listagem de pedidos).
+# Aplica schema-snapshot + a migration 20260606210000_order_feed_view.sql, semeia
+# cenários controlados (incl. itens MALFORMADOS, soft-delete, pedido sem profile,
+# items não-array, afiação) e assere o contrato da view.
+# Base: db/verify-snapshot-replay.sh. Pré-req: brew install postgresql@17 pgvector.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PGVER=17
+PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+PORT=5436
+DATA="$(mktemp -d /tmp/pgtest-orderfeed.XXXXXX)/data"
+export LC_ALL=C LANG=C
+
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente: brew install postgresql@${PGVER} pgvector"; exit 1; }
+
+CELLAR="$(brew --prefix postgresql@${PGVER})"
+cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
+mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
+cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
+
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+trap cleanup EXIT
+
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l /tmp/pg-orderfeed.log -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres orderfeed_verify
+P() { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d orderfeed_verify "$@"; }
+
+RR="$(mktemp /tmp/snap-orderfeed.XXXXXX.sql)"
+sed -E 's/^(CREATE SCHEMA public;)/-- \1/' "$REPO_ROOT/supabase/schema-snapshot.sql" \
+  | grep -vE '^\\(un)?restrict ' > "$RR"
+
+echo "→ stubs + prelude + snapshot…"
+P -v ON_ERROR_STOP=1 -q -f "$REPO_ROOT/db/stubs-supabase.sql"
+P -v ON_ERROR_STOP=1 -q -f "$REPO_ROOT/supabase/schema-extensions-prelude.sql"
+P --single-transaction -v ON_ERROR_STOP=1 -q -f "$RR"
+rm -f "$RR"
+
+echo "→ migration da view…"
+P -v ON_ERROR_STOP=1 -q -f "$REPO_ROOT/supabase/migrations/20260606210000_order_feed_view.sql" >/dev/null
+
+echo "→ seed dos cenários…"
+P -v ON_ERROR_STOP=1 -q <<'SQL'
+-- auth.users primeiro (FKs de profiles/sales_orders/orders + trigger auto_assign_user_role).
+-- O 99999999 existe em auth.users mas NÃO em profiles (cenário "sem profile").
+insert into auth.users (id) values
+  ('11111111-1111-1111-1111-111111111111'),
+  ('22222222-2222-2222-2222-222222222222'),
+  ('99999999-9999-9999-9999-999999999999')
+on conflict do nothing;
+
+insert into public.profiles (id, user_id, name, document, is_approved)
+values
+  (gen_random_uuid(), '11111111-1111-1111-1111-111111111111', 'ALICE LTDA', '11.111.111/0001-11', true),
+  (gen_random_uuid(), '22222222-2222-2222-2222-222222222222', 'BOB ME',     '22.222.222/0001-22', true);
+
+-- sales: normal, com 2 itens (qtd 2 + 1 = 3)
+insert into public.sales_orders (id, customer_user_id, created_by, account, omie_numero_pedido, items, status, subtotal, total, created_at, deleted_at)
+values ('a0000001-0000-0000-0000-000000000001','11111111-1111-1111-1111-111111111111','11111111-1111-1111-1111-111111111111',
+  'oben','0000123',
+  '[{"descricao":"Verniz","quantidade":2},{"descricao":"Catalisador","quantidade":1}]'::jsonb,
+  'enviado', 100, 100, now() - interval '1 hour', null);
+
+-- sales: SOFT-DELETED → não deve aparecer
+insert into public.sales_orders (id, customer_user_id, created_by, account, items, status, subtotal, total, created_at, deleted_at)
+values ('a0000002-0000-0000-0000-000000000002','11111111-1111-1111-1111-111111111111','11111111-1111-1111-1111-111111111111',
+  'oben','[{"descricao":"Apagado","quantidade":9}]'::jsonb,'cancelado',9,9, now(), now());
+
+-- sales: itens MALFORMADOS (quantidade vazia e texto) → view NÃO pode quebrar; qty=0; names=['X','Y']
+insert into public.sales_orders (id, customer_user_id, created_by, account, items, status, subtotal, total, created_at, deleted_at)
+values ('a0000003-0000-0000-0000-000000000003','22222222-2222-2222-2222-222222222222','22222222-2222-2222-2222-222222222222',
+  'colacor','[{"descricao":"X","quantidade":""},{"descricao":"Y","quantidade":"abc"}]'::jsonb,'rascunho',0,0, now() - interval '2 hour', null);
+
+-- sales: SEM profile (customer_user_id órfão) → customer_name null
+insert into public.sales_orders (id, customer_user_id, created_by, account, items, status, subtotal, total, created_at, deleted_at)
+values ('a0000004-0000-0000-0000-000000000004','99999999-9999-9999-9999-999999999999','99999999-9999-9999-9999-999999999999',
+  'oben','[{"descricao":"Z","quantidade":5}]'::jsonb,'enviado',5,5, now() - interval '3 hour', null);
+
+-- sales: items NÃO-array (objeto) → item_names '{}', item_quantity 0, não quebra
+insert into public.sales_orders (id, customer_user_id, created_by, account, items, status, subtotal, total, created_at, deleted_at)
+values ('a0000005-0000-0000-0000-000000000005','11111111-1111-1111-1111-111111111111','11111111-1111-1111-1111-111111111111',
+  'oben','{}'::jsonb,'rascunho',0,0, now() - interval '4 hour', null);
+
+-- afiação: origin='afiacao', account fixo colacor_sc, order_number null, qty 3
+insert into public.orders (id, user_id, delivery_option, service_type, items, status, subtotal, total, created_at)
+values ('b0000001-0000-0000-0000-000000000001','11111111-1111-1111-1111-111111111111','retirada','afiacao',
+  '[{"category":"Afiacao Serra","quantity":3}]'::jsonb,'em_afiacao',50,50, now() - interval '30 minutes');
+SQL
+
+echo "→ asserts…"
+P -v ON_ERROR_STOP=1 -q <<'SQL'
+do $$
+declare r record;
+begin
+  -- 1. soft-deleted fora
+  if exists (select 1 from public.order_feed where id='a0000002-0000-0000-0000-000000000002') then
+    raise exception 'FALHOU: pedido soft-deleted apareceu na view';
+  end if;
+
+  -- 2. sales normal: nome via join, qtd somada, names em ordem, order_number, account, origin
+  select * into r from public.order_feed where id='a0000001-0000-0000-0000-000000000001';
+  if r.origin <> 'sales' then raise exception 'FALHOU: origin sales (got %)', r.origin; end if;
+  if r.customer_name <> 'ALICE LTDA' then raise exception 'FALHOU: customer_name join (got %)', r.customer_name; end if;
+  if r.item_quantity <> 3 then raise exception 'FALHOU: item_quantity 2+1=3 (got %)', r.item_quantity; end if;
+  if r.item_names <> array['Verniz','Catalisador']::text[] then raise exception 'FALHOU: item_names ordem (got %)', r.item_names; end if;
+  if r.order_number <> '0000123' then raise exception 'FALHOU: order_number (got %)', r.order_number; end if;
+  if r.account <> 'oben' then raise exception 'FALHOU: account (got %)', r.account; end if;
+
+  -- 3. itens malformados: view não quebrou, qty=0, names preservados
+  select * into r from public.order_feed where id='a0000003-0000-0000-0000-000000000003';
+  if r.item_quantity <> 0 then raise exception 'FALHOU: malformado item_quantity=0 (got %)', r.item_quantity; end if;
+  if r.item_names <> array['X','Y']::text[] then raise exception 'FALHOU: malformado item_names (got %)', r.item_names; end if;
+
+  -- 4. sem profile → customer_name null (mas pedido aparece)
+  select * into r from public.order_feed where id='a0000004-0000-0000-0000-000000000004';
+  if r.customer_name is not null then raise exception 'FALHOU: sem profile deveria ser null (got %)', r.customer_name; end if;
+  if r.item_quantity <> 5 then raise exception 'FALHOU: sem profile qty (got %)', r.item_quantity; end if;
+
+  -- 5. items não-array → '{}' e 0
+  select * into r from public.order_feed where id='a0000005-0000-0000-0000-000000000005';
+  if r.item_names <> '{}'::text[] then raise exception 'FALHOU: nao-array item_names vazio (got %)', r.item_names; end if;
+  if r.item_quantity <> 0 then raise exception 'FALHOU: nao-array item_quantity 0 (got %)', r.item_quantity; end if;
+
+  -- 6. afiação
+  select * into r from public.order_feed where id='b0000001-0000-0000-0000-000000000001';
+  if r.origin <> 'afiacao' then raise exception 'FALHOU: origin afiacao (got %)', r.origin; end if;
+  if r.account <> 'colacor_sc' then raise exception 'FALHOU: afiacao account colacor_sc (got %)', r.account; end if;
+  if r.order_number is not null then raise exception 'FALHOU: afiacao order_number null (got %)', r.order_number; end if;
+  if r.customer_name <> 'ALICE LTDA' then raise exception 'FALHOU: afiacao nome via join (got %)', r.customer_name; end if;
+  if r.item_quantity <> 3 then raise exception 'FALHOU: afiacao qty (got %)', r.item_quantity; end if;
+  if r.item_names <> array['Afiacao Serra']::text[] then raise exception 'FALHOU: afiacao names (got %)', r.item_names; end if;
+
+  -- 7. a view inteira roda sem erro de cast (conta os 6 vivos: 5 sales nao-deletados + 1 afiacao)
+  if (select count(*) from public.order_feed
+      where id in ('a0000001-0000-0000-0000-000000000001','a0000003-0000-0000-0000-000000000003',
+                   'a0000004-0000-0000-0000-000000000004','a0000005-0000-0000-0000-000000000005',
+                   'b0000001-0000-0000-0000-000000000001')) <> 5 then
+    raise exception 'FALHOU: contagem dos pedidos vivos esperados';
+  end if;
+
+  raise notice 'TODOS OS ASSERTS PASSARAM';
+end $$;
+SQL
+
+echo "✅ order_feed: todos os asserts passaram (PG17)"

--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,7 +21,7 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **191** custom migrations totais
+- **192** custom migrations totais
 - **710** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
   - `rls_policy`: 181
@@ -1638,6 +1638,10 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | Tipo | Objeto | Parent |
 | --- | --- | --- |
 | `function` | `public.aplicar_promocoes_no_ciclo` | — |
+
+### `20260606210000_order_feed_view.sql`
+
+> _Nenhum objeto extraído via regex._ Migration provavelmente é `ALTER TABLE` / `UPDATE` / `INSERT` / RLS-only. Validar manualmente.
 
 ### `20260606230000_negociacao_paralela_v2_cleanup.sql`
 

--- a/docs/superpowers/specs/2026-06-06-order-feed-view-unificada-design.md
+++ b/docs/superpowers/specs/2026-06-06-order-feed-view-unificada-design.md
@@ -1,0 +1,160 @@
+# Listagem de pedidos via view unificada `order_feed` (PR2 do #3)
+
+**Data:** 2026-06-06
+**Tipo:** refatoração de arquitetura da tela `/sales`. **Requer migration** (view).
+**Antecede:** PR1 (#697, pronto-socorro: keepPreviousData + observador robusto).
+**Revisado por:** 2 rodadas de 2ª opinião (ChatGPT). Veredito: "arquitetura correta,
+aprovado com alterações". As alterações estão incorporadas abaixo.
+
+## Problema (recap)
+A listagem hoje: 2 `useInfiniteQuery` (sales_orders + orders/afiação) mescladas e
+reordenadas no cliente → paginação cronológica global incorreta; busca/filtro
+client-side só sobre o carregado → não acha o resto; 3ª query de profiles cuja key
+muda ao paginar → nomes piscam. Decisão: **read model único (view) + uma query**.
+Volume ≈ 550 (< teto de 1000 do PostgREST).
+
+## Fatos do schema (verificados, não presumidos)
+- **`profiles.user_id` é UNIQUE** (`profiles_user_id_key`) → 1 profile por usuário →
+  **LEFT JOIN normal** não duplica (não precisa de `lateral`/`LIMIT 1`).
+- `profiles` **não** tem `account`/`is_primary`/`deleted_at` → **não** é multi-tenant
+  por conta (app single-org) → join só por `user_id`.
+- `sales_orders` **não** tem timestamp de ingestão (`inserted_at`); só `created_at`
+  (data do pedido no Omie, **pode ser futura**) + `order_date_kpi`.
+- `orders` (afiação) **não** tem `deleted_at` → sem soft delete a filtrar.
+- Nomes reais: `sales_orders.customer_user_id`, `orders.user_id`, `profiles.user_id`
+  (a 2ª opinião havia chutado `profiles.id`/`customer_id`).
+
+## View `order_feed` (enxuta, security_invoker)
+CTE `feed` faz o UNION ALL com **casts explícitos**; o join de `profiles` acontece
+**uma vez** sobre o CTE. **Sem `customer_document`** (PII; só o detalhe usa).
+Cast numérico **com guarda regex** (um item malformado não derruba a view inteira).
+`array_agg` com `WITH ORDINALITY` (ordem estável) + contrato explícito (`'{}'` vazio).
+
+```sql
+create or replace view public.order_feed
+with (security_invoker = true)
+as
+with feed as (
+  select
+    'sales'::text               as origin,
+    so.id::uuid                 as id,
+    so.created_at::timestamptz  as created_at,
+    so.account::text            as account,
+    so.omie_numero_pedido::text as order_number,
+    so.customer_user_id::uuid   as customer_user_id,
+    case when jsonb_typeof(so.items) = 'array' then coalesce((
+      select array_agg(nullif(it->>'descricao','') order by ord)
+             filter (where nullif(it->>'descricao','') is not null)
+      from jsonb_array_elements(so.items) with ordinality as x(it, ord)
+    ), '{}'::text[]) else '{}'::text[] end as item_names,
+    case when jsonb_typeof(so.items) = 'array' then coalesce((
+      select sum(case when it->>'quantidade' ~ '^-?[0-9]+(\.[0-9]+)?$'
+                      then (it->>'quantidade')::numeric else 0 end)
+      from jsonb_array_elements(so.items) as it
+    ), 0) else 0 end::numeric    as item_quantity,
+    so.status::text             as status,
+    so.subtotal::numeric        as subtotal,
+    so.total::numeric           as total
+  from public.sales_orders so
+  where so.deleted_at is null
+
+  union all
+
+  select
+    'afiacao'::text,
+    o.id::uuid,
+    o.created_at::timestamptz,
+    'colacor_sc'::text,
+    null::text,
+    o.user_id::uuid,
+    case when jsonb_typeof(o.items) = 'array' then coalesce((
+      select array_agg(coalesce(nullif(it->>'category',''), nullif(it->>'name',''), 'Afiação') order by ord)
+      from jsonb_array_elements(o.items) with ordinality as x(it, ord)
+    ), '{}'::text[]) else '{}'::text[] end,
+    case when jsonb_typeof(o.items) = 'array' then coalesce((
+      select sum(case when it->>'quantity' ~ '^-?[0-9]+(\.[0-9]+)?$'
+                      then (it->>'quantity')::numeric else 1 end)
+      from jsonb_array_elements(o.items) as it
+    ), 0) else 0 end::numeric,
+    o.status::text,
+    o.subtotal::numeric,
+    o.total::numeric
+  from public.orders o
+)
+select
+  f.origin, f.id, f.created_at, f.account, f.order_number, f.customer_user_id,
+  p.name::text as customer_name,
+  f.item_names, f.item_quantity, f.status, f.subtotal, f.total
+from feed f
+left join public.profiles p on p.user_id = f.customer_user_id;
+```
+
+## Frontend
+- **`useSalesOrders`**: 1 `useQuery` em `order_feed`. Busca/accountFilter client-side
+  sobre o conjunto **completo**. Some: 2 infinite queries, merge, profilesQuery,
+  scroll infinito desta tela. `logosQuery`/`printOrder` permanecem.
+  - **Query key com escopo de auth**: `['order-feed', userId]` (evita servir cache do
+    usuário anterior após troca de sessão; busca/filtro NÃO entram na key — não mudam
+    a request).
+  - **Guarda de truncamento (honesta, não silenciar):** `select(..., { count: 'exact' })`
+    + `.range(0, 999)`; se `count > data.length`, marcar `truncado` e exibir aviso
+    ("mostrando 1000 de N — refine a busca") + telemetria. Sinal pra migrar à fase
+    server-side antes de virar bug silencioso.
+- **`SalesOrders.tsx`**: remove sentinel/"Carregar mais"; skeleton + estado de erro.
+- **Detalhe por id** (impacta #672/#676): `useSalesOrderDetail(origin, id)` busca o
+  pedido cheio (sales_orders|orders) + profile, normalizado pro shape `SalesOrder`.
+  - key `['order-detail', userId, origin, id]`; **sem** `keepPreviousData` entre ids
+    (não mostrar dados do pedido errado ao trocar de seleção).
+  - `SalesOrderDetailSheet` recebe o `summary` (da listagem) + busca o detalhe ao
+    abrir (skeleton); um container `OrderDetailContainer` faz o merge summary+detalhe
+    pra minimizar a mudança no painel existente.
+  - **Impressão espera o detalhe carregar** antes de montar o cupom e chamar print().
+  - Prefetch opcional no hover/seleção (otimização, não requisito).
+
+## RLS / segurança
+- `security_invoker = true` → herda RLS das bases (staff já lê sales_orders/orders/
+  profiles). `customer_document` fora da view reduz superfície de PII.
+- **Homologação obrigatória com papéis reais** (a view é exposta pelo PostgREST e o
+  cliente pode consultar qualquer coluna que tenha privilégio): staff, master, e
+  **anon deve receber permission denied**. Caso pedido visível mas profile não →
+  `customer_name` null (resultado correto das policies independentes, não bug).
+
+## created_at futuro — ponderado, NÃO adotar feed_at agora
+A 2ª opinião sugeriu separar `source_created_at` de `feed_at` (ingestão). **Não há
+coluna de ingestão imutável** no schema, e ordenar por `created_at desc` (futuros no
+topo) **é o comportamento atual** — mudar não foi pedido e seria regressão de
+comportamento. **Decisão:** manter `created_at desc, origin, id` (ordem total estável,
+`(origin,id)` é único). Limitação (pedido com data futura no topo) registrada como
+follow-up; criar `feed_at` é trabalho de domínio separado.
+
+## Migração / rollout (ordem importa)
+1. Aplicar a view no **SQL Editor** (ritual Lovable) — a view existe **antes** do front.
+2. **Validar em PostgreSQL 17 local** (técnica `db/verify-snapshot-replay.sh`):
+   criar a view sobre o snapshot + semear itens com `quantidade` malformada (`''`,
+   texto) e confirmar que a view NÃO quebra; conferir item_names/quantity; rodar com
+   GUC de `auth.uid()`/role (staff/anon) pra checar RLS.
+3. Mergear o PR do frontend → **Publish** → validar "delta" no app (acha todos, sem reset).
+
+## Não-objetivos (fase futura, só se passar de ~1000)
+Busca/keyset server-side (RPC com `p_search`/`p_account`/cursor); virtualização;
+materialized view.
+
+## Riscos
+- Refatoração ampla do `useSalesOrders` → preservar a interface de retorno + testes.
+- Detalhe-por-id muda painel/impressão recém-entregues (#672/#676) → re-testar cor da
+  tinta + valor do item + impressão no app pós-Publish.
+
+## Decisões pós-2ª opinião (resumo)
+| Ponto levantado | Decisão |
+| --- | --- |
+| `LIMIT 1` arbitrário no profiles | **Resolvido**: `user_id` é UNIQUE → LEFT JOIN normal |
+| Multi-tenant (join por account) | **Não se aplica**: profiles sem `account` (single-org) |
+| Cast numérico derruba a view | **Adotado**: guarda regex antes do cast |
+| Truncamento silencioso em 1000 | **Adotado**: count exact + aviso honesto |
+| Cache não isolado por usuário | **Adotado**: userId na query key |
+| `customer_document` (PII) na view | **Adotado**: removido da view; só no detalhe |
+| Contrato de tipos do UNION | **Adotado**: casts explícitos nas 2 branches |
+| array_agg ordem instável | **Adotado**: WITH ORDINALITY + order by |
+| created_at futuro / feed_at | **Ponderado/não-adotado**: sem coluna de ingestão; mantém comportamento atual + follow-up |
+| Detalhe lazy sem placeholder | **Adotado**: sem keepPreviousData entre ids; impressão espera carregar |
+| soft delete em orders | **Confirmado**: orders não tem deleted_at → não filtrar |

--- a/docs/superpowers/specs/2026-06-06-order-feed-view-unificada-design.md
+++ b/docs/superpowers/specs/2026-06-06-order-feed-view-unificada-design.md
@@ -18,7 +18,14 @@ A listagem hoje: 2 `useInfiniteQuery` (sales_orders + orders/afiação) mesclada
 reordenadas no cliente → paginação cronológica global incorreta; busca/filtro
 client-side só sobre o carregado → não acha o resto; 3ª query de profiles cuja key
 muda ao paginar → nomes piscam. Decisão: **read model único (view) + uma query**.
-Volume ≈ 550 (< teto de 1000 do PostgREST).
+
+**⚠️ Volume REAL (medido na view em prod, 2026-06-09): 2.660 pedidos** — a estimativa
+de ~550 (contagem via DOM drenado) estava errada ~5×. Consequência: a query do feed
+**drena em páginas de 1000** (`.range` em loop dentro da queryFn — padrão fetchAll
+canônico do repo, ~3 requests) com **dedupe por (origin,id)** (defesa contra shift
+de offset com escrita concorrente) e **teto de sanidade de 5.000** (FEED_MAX_PAGES=5);
+acima disso `truncated` avisa na UI. **Gatilho da fase server-side: ~5.000 pedidos**
+(no ritmo atual ~12/dia, ~6+ meses).
 
 ## Fatos do schema (verificados, não presumidos)
 - **`profiles.user_id` é UNIQUE** (`profiles_user_id_key`) → 1 profile por usuário →

--- a/docs/superpowers/specs/2026-06-06-order-feed-view-unificada-design.md
+++ b/docs/superpowers/specs/2026-06-06-order-feed-view-unificada-design.md
@@ -5,6 +5,13 @@
 **Antecede:** PR1 (#697, pronto-socorro: keepPreviousData + observador robusto).
 **Revisado por:** 2 rodadas de 2ª opinião (ChatGPT). Veredito: "arquitetura correta,
 aprovado com alterações". As alterações estão incorporadas abaixo.
+**⚠️ Adversarial da IMPLEMENTAÇÃO (caminho B):** o Codex bateu o usage limit do Plus
+(reset 2026-06-11 09:24) ao revisar o diff → self-review adversarial próprio +
+validação PG17 no lugar; **Codex faz o adversarial retroativo quando voltar**
+(precedente: fix do aplicar_promocoes). Achado do self-review registrado: o
+`window.open` do cupom agora roda após `await` (fetch do detalhe) — popup-blocker
+pode barrar a 1ª impressão em browsers rígidos (Safari); fluxo comum (detalhe em
+cache) não afeta. Follow-up se reportado: pré-abrir a janela no gesto síncrono.
 
 ## Problema (recap)
 A listagem hoje: 2 `useInfiniteQuery` (sales_orders + orders/afiação) mescladas e

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 191
+-- Total de custom migrations: 192
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -206,6 +206,7 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260606190000', 'reposicao_preco_pedido_cmc_account', '20260606190000_reposicao_preco_pedido_cmc_account.sql'),
   ('20260606190000', 'reposicao_qtde_inteira_persist', '20260606190000_reposicao_qtde_inteira_persist.sql'),
   ('20260606200000', 'reposicao_promo_forward_buying_min', '20260606200000_reposicao_promo_forward_buying_min.sql'),
+  ('20260606210000', 'order_feed_view', '20260606210000_order_feed_view.sql'),
   ('20260606230000', 'negociacao_paralela_v2_cleanup', '20260606230000_negociacao_paralela_v2_cleanup.sql'),
   ('20260608120000', 'tool_spec_custom_option', '20260608120000_tool_spec_custom_option.sql'),
   ('20260609085244', 'data_health_check_familia_ausente', '20260609085244_data_health_check_familia_ausente.sql'),

--- a/src/components/salesOrders/SalesOrderCard.tsx
+++ b/src/components/salesOrders/SalesOrderCard.tsx
@@ -10,10 +10,10 @@ import { format } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
 import { StatusBadgeSimple } from '@/components/StatusBadge';
 import type { OrderStatus } from '@/types';
-import { statusLabels, type SalesOrder } from './types';
+import { statusLabels, type OrderFeedRow } from './types';
 
 interface SalesOrderCardProps {
-  order: SalesOrder;
+  order: OrderFeedRow;
   customerName: string;
   checked: boolean;
   onSelectChange: (checked: boolean) => void;
@@ -35,13 +35,13 @@ export function SalesOrderCard({
   onOpenDetail,
   onPrint,
 }: SalesOrderCardProps) {
-  const isAfiacao = order._source === 'afiacao';
+  const isAfiacao = order.origin === 'afiacao';
   const status = statusLabels[order.status] || statusLabels.rascunho;
-  const totalItems = order.items?.reduce((s, i) => s + (i.quantidade || 0), 0) || 0;
-  // Afiação opera sob Colacor SC. Card sempre mostra a empresa (Oben/Colacor/SC)
-  // e, quando for pedido de afiação, um badge secundário "Afiação" pra distinguir
-  // serviço de pedido comercial. Antes mostrava só "Afiação" e perdia a empresa.
-  const orderAccount = isAfiacao ? 'colacor_sc' : (order.account || 'oben');
+  // item_quantity da view = soma das quantidades (o mesmo que o reduce antigo fazia).
+  const totalItems = Number(order.item_quantity) || 0;
+  // Afiação opera sob Colacor SC (a view já manda account='colacor_sc'). O card
+  // mostra a empresa + badge secundário "Afiação" pra distinguir serviço de venda.
+  const orderAccount = order.account || 'oben';
   const accountLabel = orderAccount === 'colacor_sc'
     ? 'Colacor SC'
     : orderAccount === 'colacor'
@@ -79,9 +79,9 @@ export function SalesOrderCard({
             <p className="text-xs text-muted-foreground mt-0.5">
               {format(new Date(order.created_at), "dd/MM/yyyy 'às' HH:mm", { locale: ptBR })}
             </p>
-            {order.omie_numero_pedido && (
+            {order.order_number && (
               <p className="text-xs text-muted-foreground">
-                PV: <span className="font-tabular text-foreground">{order.omie_numero_pedido.replace(/^0+/, '') || '0'}</span>
+                PV: <span className="font-tabular text-foreground">{order.order_number.replace(/^0+/, '') || '0'}</span>
               </p>
             )}
           </div>
@@ -91,7 +91,7 @@ export function SalesOrderCard({
             ) : (
               <Badge variant={status.variant}>{status.label}</Badge>
             )}
-            <p className="text-sm font-bold">R$ {order.total.toFixed(2)}</p>
+            <p className="text-sm font-bold">R$ {Number(order.total).toFixed(2)}</p>
             <p className="text-xs text-muted-foreground">{totalItems} itens</p>
             <div className="flex gap-1 justify-end">
               <Button

--- a/src/components/salesOrders/SalesOrderDetailSheet.tsx
+++ b/src/components/salesOrders/SalesOrderDetailSheet.tsx
@@ -4,13 +4,17 @@
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetDescription } from '@/components/ui/sheet';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { Printer, Share2, Pencil } from 'lucide-react';
+import { Printer, Share2, Pencil, Loader2 } from 'lucide-react';
 import { format } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
 import { statusLabels, type SalesOrder } from './types';
 import { itemTotal } from './print';
 
 interface SalesOrderDetailSheetProps {
+  // O painel abre antes do detalhe chegar (busca por id sob demanda) — `open`
+  // controla o Sheet e `loading` mostra o estado enquanto `order` é null.
+  open: boolean;
+  loading?: boolean;
   order: SalesOrder | null;
   customerName: string;
   onClose: () => void;
@@ -25,6 +29,8 @@ const fmt = (v: number) => (v || 0).toLocaleString('pt-BR', { style: 'currency',
 const canEditStatus = (status: string) => !['cancelado', 'entregue', 'faturado'].includes(status);
 
 export function SalesOrderDetailSheet({
+  open,
+  loading,
   order,
   customerName,
   onClose,
@@ -32,7 +38,6 @@ export function SalesOrderDetailSheet({
   onShare,
   onEdit,
 }: SalesOrderDetailSheetProps) {
-  const open = !!order;
   const status = order ? statusLabels[order.status] || statusLabels.rascunho : null;
   const accountLabel =
     order?.account === 'colacor_sc' ? 'Colacor SC' : order?.account === 'colacor' ? 'Colacor' : 'Oben';
@@ -41,6 +46,16 @@ export function SalesOrderDetailSheet({
   return (
     <Sheet open={open} onOpenChange={(o) => !o && onClose()}>
       <SheetContent className="w-full sm:max-w-md overflow-y-auto flex flex-col">
+        {!order && loading && (
+          <div className="flex-1 flex items-center justify-center">
+            <Loader2 className="w-6 h-6 animate-spin text-muted-foreground" />
+          </div>
+        )}
+        {!order && !loading && open && (
+          <p className="text-sm text-muted-foreground pt-8 text-center">
+            Não foi possível carregar o pedido.
+          </p>
+        )}
         {order && (
           <>
             <SheetHeader>

--- a/src/components/salesOrders/__tests__/SalesOrderCard.test.tsx
+++ b/src/components/salesOrders/__tests__/SalesOrderCard.test.tsx
@@ -1,27 +1,29 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { SalesOrderCard } from '../SalesOrderCard';
-import type { SalesOrder } from '../types';
+import type { OrderFeedRow } from '../types';
 
-function order(p: Partial<SalesOrder> = {}): SalesOrder {
+// O card consome a linha da view order_feed (listagem enxuta).
+function order(p: Partial<OrderFeedRow> = {}): OrderFeedRow {
   return {
+    origin: 'sales',
     id: 'o1',
+    created_at: '2026-05-20T10:00:00Z',
+    account: 'oben',
+    order_number: '000123',
+    omie_pedido_id: 9,
     customer_user_id: 'u1',
-    items: [{ descricao: 'Verniz', quantidade: 2, valor_unitario: 50, valor_total: 100 }],
+    customer_name: 'ACME Ltda',
+    item_names: ['Verniz'],
+    item_quantity: 2,
+    status: 'enviado',
     subtotal: 100,
     total: 100,
-    status: 'enviado',
-    omie_numero_pedido: '000123',
-    omie_pedido_id: 9,
-    created_at: '2026-05-20T10:00:00Z',
-    notes: null,
-    account: 'oben',
-    _source: 'sales',
     ...p,
   };
 }
 
-function setup(o: SalesOrder, overrides: Partial<React.ComponentProps<typeof SalesOrderCard>> = {}) {
+function setup(o: OrderFeedRow, overrides: Partial<React.ComponentProps<typeof SalesOrderCard>> = {}) {
   const props: React.ComponentProps<typeof SalesOrderCard> = {
     order: o,
     customerName: 'ACME Ltda',
@@ -101,7 +103,8 @@ describe('SalesOrderCard (sales)', () => {
 
 describe('SalesOrderCard (afiação)', () => {
   it('mostra badges Colacor SC + Afiação e navega ao clicar no card', () => {
-    const props = setup(order({ _source: 'afiacao', account: 'afiacao', status: 'em_afiacao' }));
+    // A view manda afiação com account='colacor_sc' e origin='afiacao'.
+    const props = setup(order({ origin: 'afiacao', account: 'colacor_sc', order_number: null, omie_pedido_id: null, status: 'em_afiacao' }));
     expect(screen.getByText('Colacor SC')).toBeTruthy();
     expect(screen.getByText('Afiação')).toBeTruthy();
     expect(screen.queryByRole('checkbox')).toBeNull(); // não selecionável

--- a/src/components/salesOrders/__tests__/SalesOrderDetailSheet.test.tsx
+++ b/src/components/salesOrders/__tests__/SalesOrderDetailSheet.test.tsx
@@ -25,9 +25,11 @@ function order(p: Partial<SalesOrder> = {}): SalesOrder {
   } as SalesOrder;
 }
 
-function setup(o: SalesOrder | null) {
+function setup(o: SalesOrder | null, extra: { open?: boolean; loading?: boolean } = {}) {
   render(
     <SalesOrderDetailSheet
+      open={extra.open ?? !!o}
+      loading={extra.loading}
       order={o}
       customerName="DELTA INTERIORES"
       onClose={vi.fn()}
@@ -63,5 +65,16 @@ describe('SalesOrderDetailSheet', () => {
   it('order null não renderiza conteúdo (painel fechado)', () => {
     setup(null);
     expect(screen.queryByText('DELTA INTERIORES')).toBeNull();
+  });
+
+  it('aberto + carregando (detalhe em voo) mostra spinner, sem conteúdo', () => {
+    setup(null, { open: true, loading: true });
+    expect(screen.queryByText('DELTA INTERIORES')).toBeNull();
+    expect(document.querySelector('.animate-spin')).toBeTruthy();
+  });
+
+  it('aberto + falha do detalhe mostra mensagem honesta', () => {
+    setup(null, { open: true, loading: false });
+    expect(screen.getByText('Não foi possível carregar o pedido.')).toBeTruthy();
   });
 });

--- a/src/components/salesOrders/__tests__/feed.test.ts
+++ b/src/components/salesOrders/__tests__/feed.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest';
+import { filterFeedRows, mapSalesDetail, mapAfiacaoDetail } from '../feed';
+import type { OrderFeedRow } from '../types';
+
+const row = (p: Partial<OrderFeedRow> = {}): OrderFeedRow => ({
+  origin: 'sales',
+  id: 'r1',
+  created_at: '2026-06-02T21:00:00Z',
+  account: 'oben',
+  order_number: '0000123',
+  omie_pedido_id: 9,
+  customer_user_id: 'u1',
+  customer_name: 'ACME LTDA',
+  item_names: ['Verniz PU', 'Catalisador'],
+  item_quantity: 3,
+  status: 'enviado',
+  subtotal: 100,
+  total: 100,
+  ...p,
+});
+
+const FIXTURE: OrderFeedRow[] = [
+  row({ id: 'a', account: 'oben', customer_name: 'ACME LTDA' }),
+  row({ id: 'b', account: 'colacor', customer_name: 'BETA M&amp;M MOVEIS', order_number: '0000777', total: 250.5 }),
+  row({ id: 'c', account: 'colacor_sc', customer_name: 'GAMA SC' }),
+  row({ id: 'd', origin: 'afiacao', account: 'colacor_sc', order_number: null, omie_pedido_id: null, customer_name: 'DELTA INTERIORES', item_names: ['Afiacao Serra'], item_quantity: 1 }),
+];
+
+describe('filterFeedRows — abas', () => {
+  it('all → tudo', () => expect(filterFeedRows(FIXTURE, '', 'all')).toHaveLength(4));
+  it('oben → só oben', () => {
+    const r = filterFeedRows(FIXTURE, '', 'oben');
+    expect(r.map((x) => x.id)).toEqual(['a']);
+  });
+  it('colacor_sc inclui sales SC E afiação (afiação opera sob SC)', () => {
+    const r = filterFeedRows(FIXTURE, '', 'colacor_sc');
+    expect(r.map((x) => x.id)).toEqual(['c', 'd']);
+  });
+});
+
+describe('filterFeedRows — busca', () => {
+  it('por nome do cliente (com decode de entidades HTML — &amp; vira &)', () => {
+    expect(filterFeedRows(FIXTURE, 'm&m', 'all').map((x) => x.id)).toEqual(['b']);
+  });
+  it('por nº do pedido (PV)', () => {
+    expect(filterFeedRows(FIXTURE, '0777', 'all').map((x) => x.id)).toEqual(['b']);
+  });
+  it('por item', () => {
+    expect(filterFeedRows(FIXTURE, 'serra', 'all').map((x) => x.id)).toEqual(['d']);
+  });
+  it('por total', () => {
+    expect(filterFeedRows(FIXTURE, '250.50', 'all').map((x) => x.id)).toEqual(['b']);
+  });
+  it('sem match → vazio', () => {
+    expect(filterFeedRows(FIXTURE, 'xyzinexistente', 'all')).toHaveLength(0);
+  });
+  it('busca composta com aba', () => {
+    expect(filterFeedRows(FIXTURE, 'delta', 'colacor_sc').map((x) => x.id)).toEqual(['d']);
+    expect(filterFeedRows(FIXTURE, 'delta', 'oben')).toHaveLength(0);
+  });
+  it('row com campos null não quebra a busca', () => {
+    const r = filterFeedRows([row({ customer_name: null, order_number: null, item_names: [] })], 'acme', 'all');
+    expect(r).toHaveLength(0);
+  });
+});
+
+describe('mapSalesDetail', () => {
+  it('preserva a linha e marca _source=sales', () => {
+    const raw = {
+      id: 's1', customer_user_id: 'u1', account: 'colacor',
+      items: [{ descricao: 'X', quantidade: 2, valor_unitario: 50, valor_total: 100, tint_cor_id: '1247', tint_nome_cor: 'AZUL' }],
+      subtotal: 100, total: 100, status: 'enviado', omie_numero_pedido: '01', omie_pedido_id: 5,
+      created_at: '2026-06-01T00:00:00Z', notes: 'n', customer_address: 'Rua X', customer_phone: '37 9',
+    };
+    const o = mapSalesDetail(raw as never);
+    expect(o._source).toBe('sales');
+    expect(o.items[0].tint_cor_id).toBe('1247');
+    expect(o.customer_address).toBe('Rua X');
+    expect(o.total).toBe(100);
+  });
+});
+
+describe('mapAfiacaoDetail', () => {
+  it('normaliza items (category||name, quantity default 1) e account colacor_sc', () => {
+    const raw = {
+      id: 'o1', user_id: 'u1', status: 'em_afiacao', subtotal: 0, total: 50,
+      created_at: '2026-06-01T00:00:00Z', notes: null,
+      items: [{ category: 'Afiacao Serra', quantity: 2, unitPrice: 25 }, { name: 'Faca', unitPrice: 10 }],
+    };
+    const o = mapAfiacaoDetail(raw as never);
+    expect(o._source).toBe('afiacao');
+    expect(o.account).toBe('colacor_sc');
+    expect(o.customer_user_id).toBe('u1');
+    expect(o.items).toEqual([
+      { descricao: 'Afiacao Serra', quantidade: 2, valor_unitario: 25, valor_total: 50 },
+      { descricao: 'Faca', quantidade: 1, valor_unitario: 10, valor_total: 10 },
+    ]);
+    expect(o.subtotal).toBe(50); // subtotal 0 → cai pro total
+    expect(o.omie_numero_pedido).toBeNull();
+  });
+  it('items não-array não quebra', () => {
+    const o = mapAfiacaoDetail({ id: 'o2', user_id: 'u1', status: 'x', subtotal: 0, total: 0, created_at: 'd', notes: null, items: {} } as never);
+    expect(o.items).toEqual([]);
+  });
+});

--- a/src/components/salesOrders/__tests__/feed.test.ts
+++ b/src/components/salesOrders/__tests__/feed.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { filterFeedRows, mapSalesDetail, mapAfiacaoDetail } from '../feed';
+import { filterFeedRows, mapSalesDetail, mapAfiacaoDetail, dedupeFeedRows } from '../feed';
 import type { OrderFeedRow } from '../types';
 
 const row = (p: Partial<OrderFeedRow> = {}): OrderFeedRow => ({
@@ -101,5 +101,18 @@ describe('mapAfiacaoDetail', () => {
   it('items não-array não quebra', () => {
     const o = mapAfiacaoDetail({ id: 'o2', user_id: 'u1', status: 'x', subtotal: 0, total: 0, created_at: 'd', notes: null, items: {} } as never);
     expect(o.items).toEqual([]);
+  });
+});
+
+describe('dedupeFeedRows', () => {
+  it('remove duplicata por (origin,id) preservando a 1ª ocorrência e a ordem', () => {
+    const a = row({ id: 'x', origin: 'sales', total: 1 });
+    const dup = row({ id: 'x', origin: 'sales', total: 2 });
+    const b = row({ id: 'x', origin: 'afiacao' }); // mesmo id, origem diferente = NÃO é dup
+    expect(dedupeFeedRows([a, dup, b])).toEqual([a, b]);
+  });
+  it('lista sem duplicatas passa intacta', () => {
+    const rows = [row({ id: '1' }), row({ id: '2' })];
+    expect(dedupeFeedRows(rows)).toEqual(rows);
   });
 });

--- a/src/components/salesOrders/feed.ts
+++ b/src/components/salesOrders/feed.ts
@@ -36,6 +36,21 @@ export function filterFeedRows(
   return result;
 }
 
+// Dedupe por (origin, id) preservando a 1ª ocorrência. Defesa contra o caso raro
+// de escrita concorrente durante o fetch paginado por offset (uma inserção entre
+// as páginas pode deslocar e repetir uma linha — duplicata quebraria as keys do React).
+export function dedupeFeedRows(rows: OrderFeedRow[]): OrderFeedRow[] {
+  const seen = new Set<string>();
+  const out: OrderFeedRow[] = [];
+  for (const r of rows) {
+    const key = `${r.origin}:${r.id}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(r);
+  }
+  return out;
+}
+
 // sales_orders.* → SalesOrder. A linha já tem o shape (items jsonb compatível);
 // só marca a origem. Cast consciente: items é Json no tipo gerado.
 export function mapSalesDetail(row: SalesOrderRow): SalesOrder {

--- a/src/components/salesOrders/feed.ts
+++ b/src/components/salesOrders/feed.ts
@@ -1,0 +1,68 @@
+// Helpers puros da listagem unificada de pedidos (view order_feed).
+// filterFeedRows: busca + filtro de empresa CLIENT-SIDE sobre o conjunto COMPLETO
+// (a view carrega tudo numa query — fim do "Nenhum pedido" falso de quando a busca
+// só enxergava as páginas baixadas).
+// mapSalesDetail/mapAfiacaoDetail: normalizam a linha crua do detalhe (select('*')
+// de sales_orders | orders) pro shape SalesOrder que painel/impressão/share consomem.
+import {
+  decodeHtml,
+  type Account,
+  type AfiacaoItemRaw,
+  type AfiacaoOrderRow,
+  type OrderFeedRow,
+  type SalesOrder,
+  type SalesOrderRow,
+} from './types';
+
+export function filterFeedRows(
+  rows: OrderFeedRow[],
+  search: string,
+  accountFilter: Account,
+): OrderFeedRow[] {
+  // Afiação já vem da view com account='colacor_sc' (opera sob a entidade SC),
+  // então o filtro de aba é uniforme — sem caso especial.
+  let result = accountFilter === 'all' ? rows : rows.filter((r) => r.account === accountFilter);
+
+  const q = search.trim().toLowerCase();
+  if (q) {
+    result = result.filter((r) => {
+      const name = decodeHtml(r.customer_name || '').toLowerCase();
+      const pv = (r.order_number || '').toLowerCase();
+      const items = (r.item_names || []).join(' ').toLowerCase();
+      const total = Number(r.total ?? 0).toFixed(2);
+      return name.includes(q) || pv.includes(q) || items.includes(q) || total.includes(q);
+    });
+  }
+  return result;
+}
+
+// sales_orders.* → SalesOrder. A linha já tem o shape (items jsonb compatível);
+// só marca a origem. Cast consciente: items é Json no tipo gerado.
+export function mapSalesDetail(row: SalesOrderRow): SalesOrder {
+  return { ...(row as unknown as SalesOrder), _source: 'sales' };
+}
+
+// orders (afiação).* → SalesOrder. Mesma normalização que a listagem antiga fazia
+// inline (category||name → descricao; quantity default 1; account = entidade SC).
+export function mapAfiacaoDetail(row: AfiacaoOrderRow): SalesOrder {
+  const rawItems = Array.isArray(row.items) ? (row.items as unknown as AfiacaoItemRaw[]) : [];
+  return {
+    id: row.id,
+    customer_user_id: row.user_id,
+    items: rawItems.map((i) => ({
+      descricao: i.category || i.name || 'Afiação',
+      quantidade: i.quantity || 1,
+      valor_unitario: i.unitPrice || 0,
+      valor_total: (i.quantity || 1) * (i.unitPrice || 0),
+    })),
+    subtotal: row.subtotal || row.total || 0,
+    total: row.total || 0,
+    status: row.status,
+    omie_numero_pedido: null,
+    omie_pedido_id: null,
+    created_at: row.created_at,
+    notes: row.notes,
+    account: 'colacor_sc',
+    _source: 'afiacao',
+  };
+}

--- a/src/components/salesOrders/types.ts
+++ b/src/components/salesOrders/types.ts
@@ -1,6 +1,5 @@
 // Tipos + constantes + helpers da listagem de pedidos de venda.
 // Extraídos verbatim de src/pages/SalesOrders.tsx (god-component split).
-import type { InfiniteData } from '@tanstack/react-query';
 import type { Tables } from '@/integrations/supabase/types';
 
 export type SalesOrderRow = Tables<'sales_orders'>;
@@ -21,8 +20,6 @@ export interface AfiacaoItemRaw {
 // `sales_orders WHERE account='colacor_sc'`. Cada card mantém badge "Afiação"
 // quando _source='afiacao' pra preservar a distinção visual.
 export type Account = 'oben' | 'colacor' | 'colacor_sc' | 'all';
-
-export const PAGE_SIZE = 50;
 
 export const decodeHtml = (s: string): string =>
   s
@@ -67,8 +64,38 @@ export interface SalesOrder {
   discount?: number;
 }
 
-// Cache do useInfiniteQuery de sales_orders — usado nos rollbacks optimistic.
-export type SalesOrdersInfiniteCache = InfiniteData<SalesOrder[]>;
+// Linha da view order_feed (read model da listagem — migration 20260606210000).
+// A view ainda não está nos tipos gerados do Supabase (o Lovable regenera no
+// deploy); tipo manual espelhando o contrato do SQL.
+export interface OrderFeedRow {
+  origin: 'sales' | 'afiacao';
+  id: string;
+  created_at: string;
+  account: string;
+  order_number: string | null;
+  omie_pedido_id: number | null;
+  customer_user_id: string;
+  customer_name: string | null;
+  item_names: string[];
+  item_quantity: number;
+  status: string;
+  subtotal: number;
+  total: number;
+}
+
+// Cache da query única da listagem (['order-feed', userId]) — rollbacks optimistic.
+export interface OrderFeedCache {
+  rows: OrderFeedRow[];
+  count: number;
+}
+
+// Detalhe completo de um pedido, buscado por (origin, id) ao abrir o painel /
+// imprimir / compartilhar. A listagem (view) é enxuta de propósito.
+export interface OrderDetail {
+  order: SalesOrder;
+  customerName: string;
+  customerDocument?: string;
+}
 
 export const statusLabels: Record<string, { label: string; variant: 'default' | 'secondary' | 'destructive' | 'outline' }> = {
   rascunho: { label: 'Rascunho', variant: 'outline' },

--- a/src/components/salesOrders/useSalesOrderDetail.ts
+++ b/src/components/salesOrders/useSalesOrderDetail.ts
@@ -1,0 +1,63 @@
+// Detalhe completo de um pedido por (origin, id). A listagem (view order_feed) é
+// enxuta de propósito — itens completos, payload de parcelas e endereço só são
+// buscados quando o usuário abre o painel, imprime ou compartilha.
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import { useAuth } from '@/contexts/AuthContext';
+import {
+  decodeHtml,
+  type AfiacaoOrderRow,
+  type OrderDetail,
+  type OrderFeedRow,
+  type SalesOrderRow,
+} from './types';
+import { mapAfiacaoDetail, mapSalesDetail } from './feed';
+
+// Key compartilhada entre o painel (useQuery) e as ações imperativas
+// (imprimir/compartilhar via queryClient.fetchQuery) — mesmo cache, sem fetch dobrado.
+export const orderDetailQueryKey = (
+  userId: string | undefined,
+  origin: OrderFeedRow['origin'],
+  id: string,
+) => ['order-detail', userId, origin, id] as const;
+
+export async function fetchOrderDetail(
+  origin: OrderFeedRow['origin'],
+  id: string,
+): Promise<OrderDetail> {
+  let order;
+  if (origin === 'sales') {
+    const { data, error } = await supabase.from('sales_orders').select('*').eq('id', id).maybeSingle();
+    if (error) throw error;
+    if (!data) throw new Error('Pedido não encontrado');
+    order = mapSalesDetail(data as SalesOrderRow);
+  } else {
+    const { data, error } = await supabase.from('orders').select('*').eq('id', id).maybeSingle();
+    if (error) throw error;
+    if (!data) throw new Error('Pedido não encontrado');
+    order = mapAfiacaoDetail(data as AfiacaoOrderRow);
+  }
+
+  const { data: prof } = await supabase
+    .from('profiles')
+    .select('name, document')
+    .eq('user_id', order.customer_user_id)
+    .maybeSingle();
+
+  return {
+    order,
+    customerName: decodeHtml(prof?.name || 'Cliente'),
+    customerDocument: prof?.document ?? undefined,
+  };
+}
+
+// Sem placeholderData entre ids: trocar de pedido NUNCA mostra dados do anterior.
+export function useSalesOrderDetail(row: Pick<OrderFeedRow, 'origin' | 'id'> | null) {
+  const { user } = useAuth();
+  return useQuery({
+    queryKey: orderDetailQueryKey(user?.id, row?.origin ?? 'sales', row?.id ?? ''),
+    enabled: !!row && !!user,
+    staleTime: 60_000,
+    queryFn: () => fetchOrderDetail(row!.origin, row!.id),
+  });
+}

--- a/src/components/salesOrders/useSalesOrders.ts
+++ b/src/components/salesOrders/useSalesOrders.ts
@@ -1,31 +1,38 @@
-// Lógica da listagem de pedidos de venda (queries paginadas, merge, optimistic delete).
-// Extraída verbatim de src/pages/SalesOrders.tsx (god-component split).
+// Lógica da listagem de pedidos de venda — sobre a view order_feed (read model
+// único): UMA query carrega o conjunto completo (~550 pedidos) e busca/abas
+// filtram client-side sobre TUDO.
+//
+// Antes eram 2 useInfiniteQuery (sales_orders + orders) mescladas no cliente +
+// uma 3ª query de profiles — a busca só enxergava as páginas carregadas e dizia
+// "Nenhum pedido" pra pedidos que existiam (reproduzido em prod), a ordem global
+// quebrava ao paginar e os nomes piscavam. Spec:
+// docs/superpowers/specs/2026-06-06-order-feed-view-unificada-design.md
 import { useState, useEffect, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useInfiniteQuery, useQuery, useQueryClient, keepPreviousData } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
 import { toast } from 'sonner';
 import { shareOrderViaWhatsApp } from '@/utils/whatsappShare';
-import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
 import {
-  PAGE_SIZE,
-  decodeHtml,
   type Account,
-  type SalesOrder,
-  type SalesOrderRow,
-  type AfiacaoOrderRow,
-  type ProfileRow,
-  type AfiacaoItemRaw,
-  type SalesOrdersInfiniteCache,
+  type OrderFeedCache,
+  type OrderFeedRow,
 } from './types';
+import { filterFeedRows } from './feed';
+import { fetchOrderDetail, orderDetailQueryKey } from './useSalesOrderDetail';
 import { softDeleteOrder } from './soft-delete';
 import { printSalesOrder } from './print';
+
+// Teto de resposta do PostgREST. Se o total passar disso, a listagem trunca —
+// a UI avisa (truncated) em vez de silenciar; é o sinal pra migrar a busca pro
+// servidor (fase 2 do spec).
+const FEED_MAX_ROWS = 1000;
 
 export function useSalesOrders() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
-  const { isStaff, loading: authLoading, role } = useAuth();
+  const { user, isStaff, loading: authLoading, role } = useAuth();
   const [accountFilter, setAccountFilter] = useState<Account>('all');
   const [search, setSearch] = useState('');
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
@@ -34,112 +41,38 @@ export function useSalesOrders() {
     if (!authLoading && role !== null && !isStaff) navigate('/', { replace: true });
   }, [authLoading, role, isStaff, navigate]);
 
-  /* ─── Sales orders: infinite query (50 por página) ─── */
-  const salesQuery = useInfiniteQuery({
-    queryKey: ['sales-orders-paginated'],
-    enabled: isStaff,
-    initialPageParam: 0,
-    queryFn: async ({ pageParam }) => {
-      const start = (pageParam as number) * PAGE_SIZE;
-      const { data, error } = await supabase
-        .from('sales_orders')
-        .select('*')
-        // Filtra soft-deletes (deleted_at IS NOT NULL = pedido excluído).
-        // Usa partial index idx_sales_orders_active em deleted_at IS NULL.
-        .is('deleted_at', null)
-        .order('created_at', { ascending: false })
-        .range(start, start + PAGE_SIZE - 1);
-      if (error) throw error;
-      return ((data || []) as SalesOrderRow[]).map((o) => ({
-        ...o,
-        _source: 'sales' as const,
-      })) as unknown as SalesOrder[];
-    },
-    getNextPageParam: (lastPage, allPages) =>
-      lastPage.length === PAGE_SIZE ? allPages.length : undefined,
-  });
-
-  /* ─── Afiação orders: infinite query (50 por página) ─── */
-  const afiacaoQuery = useInfiniteQuery({
-    queryKey: ['afiacao-orders-paginated'],
-    enabled: isStaff,
-    initialPageParam: 0,
-    queryFn: async ({ pageParam }) => {
-      const start = (pageParam as number) * PAGE_SIZE;
-      const { data, error } = await supabase
-        .from('orders')
-        .select('*')
-        .order('created_at', { ascending: false })
-        .range(start, start + PAGE_SIZE - 1);
-      if (error) throw error;
-      return ((data || []) as AfiacaoOrderRow[]).map((o) => {
-        const rawItems = Array.isArray(o.items) ? (o.items as unknown as AfiacaoItemRaw[]) : [];
-        return {
-          id: o.id,
-          customer_user_id: o.user_id,
-          items: rawItems.map((i) => ({
-            descricao: i.category || i.name || 'Afiação',
-            quantidade: i.quantity || 1,
-            valor_unitario: i.unitPrice || 0,
-            valor_total: (i.quantity || 1) * (i.unitPrice || 0),
-          })),
-          subtotal: o.subtotal || o.total || 0,
-          total: o.total || 0,
-          status: o.status,
-          omie_numero_pedido: null,
-          omie_pedido_id: null,
-          created_at: o.created_at,
-          notes: o.notes,
-          account: 'afiacao',
-          _source: 'afiacao' as const,
-        };
-      }) as SalesOrder[];
-    },
-    getNextPageParam: (lastPage, allPages) =>
-      lastPage.length === PAGE_SIZE ? allPages.length : undefined,
-  });
-
-  /* ─── Lista mergeada ─── */
-  const orders = useMemo<SalesOrder[]>(() => {
-    const sales = salesQuery.data?.pages.flat() || [];
-    const afiacao = afiacaoQuery.data?.pages.flat() || [];
-    return [...sales, ...afiacao].sort(
-      (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
-    );
-  }, [salesQuery.data, afiacaoQuery.data]);
-
-  /* ─── Profiles (nome + documento dos clientes) ─── */
-  const customerIds = useMemo(() => [...new Set(orders.map((o) => o.customer_user_id))], [orders]);
-  // Chave estável SEM mutar customerIds (que é usado no .in()). O .sort() in-place
-  // direto na queryKey mutava o valor memoizado.
-  const customerIdsKey = useMemo(() => [...customerIds].sort().join(','), [customerIds]);
-  const profilesQuery = useQuery({
-    queryKey: ['sales-orders-profiles', customerIdsKey],
-    enabled: isStaff && customerIds.length > 0,
+  /* ─── Feed unificado: 1 query, conjunto completo ─── */
+  // userId na key: troca de sessão não serve cache do usuário anterior.
+  const feedKey = useMemo(() => ['order-feed', user?.id] as const, [user?.id]);
+  const feedQuery = useQuery<OrderFeedCache>({
+    queryKey: feedKey,
+    enabled: isStaff && !!user,
     staleTime: 60_000,
-    // Ao paginar, os customerIds crescem → a queryKey muda → a query re-busca.
-    // keepPreviousData mantém os nomes já carregados durante a nova busca, em vez
-    // de esvaziar (os nomes "piscavam Cliente", a lista filtrada colapsava e o
-    // scroll resetava pro topo). Causa-raiz do reset com busca ativa.
-    placeholderData: keepPreviousData,
     queryFn: async () => {
-      const { data } = await supabase
-        .from('profiles')
-        .select('user_id, name, document')
-        .in('user_id', customerIds);
-      const names: Record<string, string> = {};
-      const docs: Record<string, string> = {};
-      ((data || []) as Pick<ProfileRow, 'user_id' | 'name' | 'document'>[]).forEach((p) => {
-        names[p.user_id] = p.name ?? '';
-        if (p.document) docs[p.user_id] = p.document;
-      });
-      return { names, docs };
+      const { data, error, count } = await supabase
+        .from('order_feed' as never)
+        .select('*', { count: 'exact' })
+        .order('created_at', { ascending: false, nullsFirst: false })
+        .order('origin', { ascending: true })
+        .order('id', { ascending: true })
+        .range(0, FEED_MAX_ROWS - 1);
+      if (error) throw error;
+      const rows = (data ?? []) as unknown as OrderFeedRow[];
+      return { rows, count: count ?? rows.length };
     },
   });
-  const profiles = profilesQuery.data?.names || {};
-  const customerDocs = profilesQuery.data?.docs || {};
 
-  /* ─── Logos das empresas (cupom de impressão) — cache 24h, igual ao dashboard ─── */
+  const orders = useMemo(() => feedQuery.data?.rows ?? [], [feedQuery.data]);
+  const totalCount = feedQuery.data?.count ?? 0;
+  // Aviso honesto de truncamento (nunca silenciar — "mostrando 1000 de N").
+  const truncated = totalCount > orders.length;
+
+  const filteredOrders = useMemo(
+    () => filterFeedRows(orders, search, accountFilter),
+    [orders, search, accountFilter],
+  );
+
+  /* ─── Logos das empresas (cupom de impressão) — cache 24h ─── */
   const logosQuery = useQuery({
     queryKey: ['sales-orders-company-logos'],
     enabled: isStaff,
@@ -157,70 +90,90 @@ export function useSalesOrders() {
   });
   const companyLogos = logosQuery.data || {};
 
-  // Imprime o cupom de um pedido (mesmo layout de /sales/print).
-  const printOrder = (order: SalesOrder) => {
-    const name = decodeHtml(profiles[order.customer_user_id] || 'Cliente');
-    printSalesOrder(order, name, customerDocs[order.customer_user_id], companyLogos);
-  };
-
-  /* ─── Infinite scroll: dispara fetchNextPage de quem ainda tem páginas ─── */
-  const hasNext = !!salesQuery.hasNextPage || !!afiacaoQuery.hasNextPage;
-  const isFetching = salesQuery.isFetchingNextPage || afiacaoQuery.isFetchingNextPage;
-  const sentinelRef = useInfiniteScroll(
-    () => {
-      if (salesQuery.hasNextPage && !salesQuery.isFetchingNextPage) salesQuery.fetchNextPage();
-      if (afiacaoQuery.hasNextPage && !afiacaoQuery.isFetchingNextPage) afiacaoQuery.fetchNextPage();
-    },
-    hasNext && !isFetching,
-  );
-
-  const loadMore = () => {
-    if (salesQuery.hasNextPage) salesQuery.fetchNextPage();
-    if (afiacaoQuery.hasNextPage) afiacaoQuery.fetchNextPage();
-  };
-
-  const loading = salesQuery.isLoading || afiacaoQuery.isLoading;
-
-  // Soft-delete + Omie exclude. Cache/toast aqui; orquestração no helper softDeleteOrder.
-  // 1. Optimistic remove do cache. 2. softDeleteOrder (deleted_at + Omie + rollback).
-  // 3. Em falha, restaura o cache (o helper já reverteu deleted_at quando o Omie falha).
-  const deleteOrder = async (order: SalesOrder) => {
-    const snapshot = queryClient.getQueryData<SalesOrdersInfiniteCache>(['sales-orders-paginated']);
-    queryClient.setQueryData<SalesOrdersInfiniteCache>(['sales-orders-paginated'], (old) => {
-      if (!old) return old;
-      return {
-        ...old,
-        pages: old.pages.map((page) => page.filter((o) => o.id !== order.id)),
-      };
+  /* ─── Detalhe sob demanda (cache compartilhado com o painel via queryKey) ─── */
+  const getDetail = (row: Pick<OrderFeedRow, 'origin' | 'id'>) =>
+    queryClient.fetchQuery({
+      queryKey: orderDetailQueryKey(user?.id, row.origin, row.id),
+      queryFn: () => fetchOrderDetail(row.origin, row.id),
+      staleTime: 60_000,
     });
+
+  // Imprime o cupom (mesmo layout de /sales/print). Espera o detalhe completo
+  // (itens com codigo/unidade/tint, payload de parcelas, endereço) ANTES de abrir.
+  const printOrder = async (row: OrderFeedRow) => {
+    try {
+      const d = await getDetail(row);
+      printSalesOrder(d.order, d.customerName, d.customerDocument, companyLogos);
+    } catch (e) {
+      console.error(e);
+      toast.error('Não foi possível carregar o pedido para imprimir');
+    }
+  };
+
+  const handleShareOrder = async (row: OrderFeedRow) => {
+    try {
+      const d = await getDetail(row);
+      const items = (d.order.items || []).map((item) => ({
+        description: item.descricao,
+        quantity: item.quantidade,
+        unitPrice: item.valor_unitario,
+      }));
+      const orderNumbers = d.order.omie_numero_pedido
+        ? [d.order.omie_numero_pedido.replace(/^0+/, '') || '0']
+        : [];
+      shareOrderViaWhatsApp({
+        customerName: d.customerName,
+        items,
+        total: d.order.total,
+        orderNumbers,
+        date: new Date(d.order.created_at),
+      });
+    } catch (e) {
+      console.error(e);
+      toast.error('Não foi possível carregar o pedido para compartilhar');
+    }
+  };
+
+  /* ─── Soft-delete + Omie exclude (optimistic no cache do feed) ─── */
+  const deleteOrder = async (row: OrderFeedRow) => {
+    const snapshot = queryClient.getQueryData<OrderFeedCache>(feedKey);
+    queryClient.setQueryData<OrderFeedCache>(feedKey, (old) =>
+      old
+        ? {
+            rows: old.rows.filter((r) => !(r.origin === 'sales' && r.id === row.id)),
+            count: Math.max(0, old.count - 1),
+          }
+        : old,
+    );
     setSelectedIds((prev) => {
       const next = new Set(prev);
-      next.delete(order.id);
+      next.delete(row.id);
       return next;
     });
 
-    const result = await softDeleteOrder(order);
+    const result = await softDeleteOrder({ id: row.id, omie_pedido_id: row.omie_pedido_id });
     if (result.ok) {
       toast.success('Pedido excluído');
       return;
     }
-    queryClient.setQueryData(['sales-orders-paginated'], snapshot);
+    queryClient.setQueryData(feedKey, snapshot);
     toast.error('Erro ao excluir pedido', { description: (result as { message: string }).message });
   };
 
   // Bulk delete — sequencial pra não floodar o Omie. Mostra progresso.
   const deleteSelected = async () => {
     if (selectedIds.size === 0) return;
-    const toDelete = orders.filter((o) => selectedIds.has(o.id) && o._source === 'sales');
-    const snapshot = queryClient.getQueryData<SalesOrdersInfiniteCache>(['sales-orders-paginated']);
+    const toDelete = orders.filter((r) => selectedIds.has(r.id) && r.origin === 'sales');
+    const snapshot = queryClient.getQueryData<OrderFeedCache>(feedKey);
     const deleteIds = new Set(toDelete.map((o) => o.id));
-    queryClient.setQueryData<SalesOrdersInfiniteCache>(['sales-orders-paginated'], (old) => {
-      if (!old) return old;
-      return {
-        ...old,
-        pages: old.pages.map((page) => page.filter((o) => !deleteIds.has(o.id))),
-      };
-    });
+    queryClient.setQueryData<OrderFeedCache>(feedKey, (old) =>
+      old
+        ? {
+            rows: old.rows.filter((r) => !(r.origin === 'sales' && deleteIds.has(r.id))),
+            count: Math.max(0, old.count - deleteIds.size),
+          }
+        : old,
+    );
     setSelectedIds(new Set());
 
     // 1. Soft-delete em batch (1 UPDATE com .in('id', ...))
@@ -232,7 +185,7 @@ export function useSalesOrders() {
 
     if (softErr) {
       console.error(softErr);
-      queryClient.setQueryData(['sales-orders-paginated'], snapshot);
+      queryClient.setQueryData(feedKey, snapshot);
       toast.error(`Erro ao excluir pedidos`, { description: softErr.message });
       return;
     }
@@ -260,82 +213,28 @@ export function useSalesOrders() {
 
     // Rollback do soft-delete só pros que falharam no Omie
     if (failedIds.length > 0) {
-      await supabase
-        .from('sales_orders')
-        .update({ deleted_at: null })
-        .in('id', failedIds);
+      await supabase.from('sales_orders').update({ deleted_at: null }).in('id', failedIds);
     }
 
     if (failed === 0) {
       toast.success(`${success} pedido(s) excluído(s)`);
     } else if (success === 0) {
-      queryClient.setQueryData(['sales-orders-paginated'], snapshot); // rollback completo
+      queryClient.setQueryData(feedKey, snapshot); // rollback completo
       toast.error(`Falhou: ${failed} pedido(s) não puderam ser excluídos`);
     } else {
-      // Parcial — restaura os que falharam no cache (já temos deleted_at=null no DB)
+      // Parcial — restaura no cache as rows que falharam (já têm deleted_at=null no DB)
       const failedSet = new Set(failedIds);
-      queryClient.setQueryData<SalesOrdersInfiniteCache>(['sales-orders-paginated'], (old) => {
+      queryClient.setQueryData<OrderFeedCache>(feedKey, (old) => {
         if (!old || !snapshot) return old;
-        // Pega as rows que falharam do snapshot original e reinjeta na primeira página
-        const failedRows = snapshot.pages
-          .flat()
-          .filter((o) => failedSet.has(o.id));
-        return {
-          ...old,
-          pages: old.pages.map((page, i) =>
-            i === 0 ? [...failedRows, ...page] : page,
-          ),
-        };
+        const failedRows = snapshot.rows.filter((r) => r.origin === 'sales' && failedSet.has(r.id));
+        const rows = [...old.rows, ...failedRows].sort(
+          (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
+        );
+        return { rows, count: old.count + failedRows.length };
       });
       toast.warning(`${success} excluído(s), ${failed} falharam`);
     }
   };
-
-  const handleShareOrder = (order: SalesOrder, customerName: string) => {
-    const items = (order.items || []).map(item => ({
-      description: item.descricao,
-      quantity: item.quantidade,
-      unitPrice: item.valor_unitario,
-    }));
-
-    const orderNumbers = order.omie_numero_pedido ? [order.omie_numero_pedido.replace(/^0+/, '') || '0'] : [];
-
-    shareOrderViaWhatsApp({
-      customerName,
-      items,
-      total: order.total,
-      orderNumbers,
-      date: new Date(order.created_at),
-    });
-  };
-
-  const filteredOrders = useMemo(() => {
-    // Colacor SC engloba: (a) pedidos comerciais com account='colacor_sc' E
-    // (b) pedidos de afiação (que operam sob a entidade SC). Afiação não é tab
-    // separada, é serviço da Colacor SC.
-    let result = accountFilter === 'all'
-      ? orders
-      : accountFilter === 'colacor_sc'
-        ? orders.filter(o => o._source === 'afiacao' || (o._source === 'sales' && o.account === 'colacor_sc'))
-        : orders.filter(o => o._source === 'sales' && (o.account || 'oben') === accountFilter);
-
-    if (search.trim()) {
-      const q = search.trim().toLowerCase();
-      result = result.filter(o => {
-        const customerName = decodeHtml(profiles[o.customer_user_id] || '');
-        const pvNumber = o.omie_numero_pedido || '';
-        const itemDescs = (o.items || []).map(i => i.descricao).join(' ');
-        return (
-          customerName.toLowerCase().includes(q) ||
-          pvNumber.toLowerCase().includes(q) ||
-          itemDescs.toLowerCase().includes(q) ||
-          o.total.toFixed(2).includes(q)
-        );
-      });
-    }
-
-    return result;
-  }, [orders, accountFilter, search, profiles]);
 
   const toggleSelect = (id: string, checked: boolean) => {
     setSelectedIds((prev) => {
@@ -351,7 +250,9 @@ export function useSalesOrders() {
   return {
     navigate,
     authLoading,
-    loading,
+    loading: feedQuery.isLoading,
+    loadError: feedQuery.isError,
+    refetch: feedQuery.refetch,
     accountFilter,
     setAccountFilter,
     search,
@@ -360,12 +261,9 @@ export function useSalesOrders() {
     toggleSelect,
     clearSelection,
     orders,
-    profiles,
     filteredOrders,
-    hasNext,
-    isFetching,
-    sentinelRef,
-    loadMore,
+    totalCount,
+    truncated,
     deleteOrder,
     deleteSelected,
     handleShareOrder,

--- a/src/components/salesOrders/useSalesOrders.ts
+++ b/src/components/salesOrders/useSalesOrders.ts
@@ -19,15 +19,19 @@ import {
   type OrderFeedCache,
   type OrderFeedRow,
 } from './types';
-import { filterFeedRows } from './feed';
+import { dedupeFeedRows, filterFeedRows } from './feed';
 import { fetchOrderDetail, orderDetailQueryKey } from './useSalesOrderDetail';
 import { softDeleteOrder } from './soft-delete';
 import { printSalesOrder } from './print';
 
-// Teto de resposta do PostgREST. Se o total passar disso, a listagem trunca —
-// a UI avisa (truncated) em vez de silenciar; é o sinal pra migrar a busca pro
-// servidor (fase 2 do spec).
-const FEED_MAX_ROWS = 1000;
+// O PostgREST capa cada resposta em 1000 linhas → a query drena em páginas até o
+// count (medido em prod: ~2.660 pedidos ≈ 3 requests). Teto de sanidade de
+// FEED_MAX_PAGES (5.000 linhas): acima disso a listagem trunca e a UI avisa
+// (truncated) em vez de silenciar — é o gatilho pra migrar a busca pro servidor
+// (fase 2 do spec).
+const FEED_PAGE_SIZE = 1000;
+const FEED_MAX_PAGES = 5;
+export const FEED_MAX_TOTAL = FEED_PAGE_SIZE * FEED_MAX_PAGES;
 
 export function useSalesOrders() {
   const navigate = useNavigate();
@@ -49,16 +53,25 @@ export function useSalesOrders() {
     enabled: isStaff && !!user,
     staleTime: 60_000,
     queryFn: async () => {
-      const { data, error, count } = await supabase
-        .from('order_feed' as never)
-        .select('*', { count: 'exact' })
-        .order('created_at', { ascending: false, nullsFirst: false })
-        .order('origin', { ascending: true })
-        .order('id', { ascending: true })
-        .range(0, FEED_MAX_ROWS - 1);
-      if (error) throw error;
-      const rows = (data ?? []) as unknown as OrderFeedRow[];
-      return { rows, count: count ?? rows.length };
+      const all: OrderFeedRow[] = [];
+      let total = 0;
+      for (let page = 0; page < FEED_MAX_PAGES; page++) {
+        const from = page * FEED_PAGE_SIZE;
+        const { data, error, count } = await supabase
+          .from('order_feed' as never)
+          .select('*', { count: 'exact' })
+          .order('created_at', { ascending: false, nullsFirst: false })
+          .order('origin', { ascending: true })
+          .order('id', { ascending: true })
+          .range(from, from + FEED_PAGE_SIZE - 1);
+        if (error) throw error;
+        const rows = (data ?? []) as unknown as OrderFeedRow[];
+        all.push(...rows);
+        total = count ?? all.length;
+        // Fim real: alcançou o count ou a página veio parcial/vazia.
+        if (all.length >= total || rows.length < FEED_PAGE_SIZE) break;
+      }
+      return { rows: dedupeFeedRows(all), count: total };
     },
   });
 

--- a/src/pages/SalesOrders.tsx
+++ b/src/pages/SalesOrders.tsx
@@ -4,7 +4,7 @@ import { Loader2, ShoppingCart, Trash2, ChevronLeft, TriangleAlert } from 'lucid
 import { EmptyState } from '@/components/EmptyState';
 import { BulkActionsBar } from '@/components/ui/bulk-actions-bar';
 import { decodeHtml, type OrderFeedRow } from '@/components/salesOrders/types';
-import { useSalesOrders } from '@/components/salesOrders/useSalesOrders';
+import { useSalesOrders, FEED_MAX_TOTAL } from '@/components/salesOrders/useSalesOrders';
 import { useSalesOrderDetail } from '@/components/salesOrders/useSalesOrderDetail';
 import { SalesOrdersToolbar } from '@/components/salesOrders/SalesOrdersToolbar';
 import { SalesOrderCard } from '@/components/salesOrders/SalesOrderCard';
@@ -76,12 +76,12 @@ const SalesOrders = () => {
         setSearch={setSearch}
       />
 
-      {/* Aviso honesto: o feed bateu o teto de 1000 linhas — a busca não cobre tudo */}
+      {/* Aviso honesto: o feed bateu o teto de segurança — a busca não cobre tudo */}
       {truncated && (
         <div className="flex items-center gap-2 text-xs text-status-warning bg-status-warning-bg border border-status-warning/30 rounded-md px-3 py-2">
           <TriangleAlert className="w-3.5 h-3.5 shrink-0" />
           <span>
-            Mostrando os primeiros 1.000 de {totalCount.toLocaleString('pt-BR')} pedidos — a busca cobre só esses. Refine por empresa ou período.
+            Mostrando os primeiros {FEED_MAX_TOTAL.toLocaleString('pt-BR')} de {totalCount.toLocaleString('pt-BR')} pedidos — a busca cobre só esses.
           </span>
         </div>
       )}

--- a/src/pages/SalesOrders.tsx
+++ b/src/pages/SalesOrders.tsx
@@ -1,10 +1,11 @@
 import { useState } from 'react';
 import { Button } from '@/components/ui/button';
-import { Loader2, ShoppingCart, Trash2, ChevronLeft } from 'lucide-react';
+import { Loader2, ShoppingCart, Trash2, ChevronLeft, TriangleAlert } from 'lucide-react';
 import { EmptyState } from '@/components/EmptyState';
 import { BulkActionsBar } from '@/components/ui/bulk-actions-bar';
-import { decodeHtml, PAGE_SIZE, type SalesOrder } from '@/components/salesOrders/types';
+import { decodeHtml, type OrderFeedRow } from '@/components/salesOrders/types';
 import { useSalesOrders } from '@/components/salesOrders/useSalesOrders';
+import { useSalesOrderDetail } from '@/components/salesOrders/useSalesOrderDetail';
 import { SalesOrdersToolbar } from '@/components/salesOrders/SalesOrdersToolbar';
 import { SalesOrderCard } from '@/components/salesOrders/SalesOrderCard';
 import { SalesOrderDetailSheet } from '@/components/salesOrders/SalesOrderDetailSheet';
@@ -14,6 +15,8 @@ const SalesOrders = () => {
     navigate,
     authLoading,
     loading,
+    loadError,
+    refetch,
     accountFilter,
     setAccountFilter,
     search,
@@ -21,28 +24,34 @@ const SalesOrders = () => {
     selectedIds,
     toggleSelect,
     clearSelection,
-    orders,
-    profiles,
     filteredOrders,
-    hasNext,
-    isFetching,
-    sentinelRef,
-    loadMore,
+    totalCount,
+    truncated,
     deleteOrder,
     deleteSelected,
     handleShareOrder,
     printOrder,
   } = useSalesOrders();
 
-  const [detailOrder, setDetailOrder] = useState<SalesOrder | null>(null);
-  const detailCustomerName = detailOrder
-    ? decodeHtml(profiles[detailOrder.customer_user_id] || 'Cliente')
-    : '';
+  // Pedido selecionado na listagem → o painel busca o detalhe completo por id.
+  const [detailRow, setDetailRow] = useState<OrderFeedRow | null>(null);
+  const detailQuery = useSalesOrderDetail(detailRow);
 
   if (authLoading || loading) {
     return (
       <div className="flex items-center justify-center pt-32">
         <Loader2 className="w-8 h-8 animate-spin text-primary" />
+      </div>
+    );
+  }
+
+  if (loadError) {
+    return (
+      <div className="max-w-4xl mx-auto pt-16 text-center space-y-3">
+        <p className="text-sm text-muted-foreground">Não foi possível carregar os pedidos.</p>
+        <Button variant="outline" size="sm" onClick={() => refetch()}>
+          Tentar novamente
+        </Button>
       </div>
     );
   }
@@ -67,6 +76,16 @@ const SalesOrders = () => {
         setSearch={setSearch}
       />
 
+      {/* Aviso honesto: o feed bateu o teto de 1000 linhas — a busca não cobre tudo */}
+      {truncated && (
+        <div className="flex items-center gap-2 text-xs text-status-warning bg-status-warning-bg border border-status-warning/30 rounded-md px-3 py-2">
+          <TriangleAlert className="w-3.5 h-3.5 shrink-0" />
+          <span>
+            Mostrando os primeiros 1.000 de {totalCount.toLocaleString('pt-BR')} pedidos — a busca cobre só esses. Refine por empresa ou período.
+          </span>
+        </div>
+      )}
+
       {filteredOrders.length === 0 ? (
         <EmptyState
           icon={ShoppingCart}
@@ -90,40 +109,23 @@ const SalesOrders = () => {
         <div className="space-y-2">
           {filteredOrders.map((order) => (
             <SalesOrderCard
-              key={`${order._source}-${order.id}`}
+              key={`${order.origin}-${order.id}`}
               order={order}
-              customerName={decodeHtml(profiles[order.customer_user_id] || 'Cliente')}
+              customerName={decodeHtml(order.customer_name || 'Cliente')}
               checked={selectedIds.has(order.id)}
               onSelectChange={(v) => toggleSelect(order.id, v)}
-              onShare={() => handleShareOrder(order, decodeHtml(profiles[order.customer_user_id] || 'Cliente'))}
+              onShare={() => handleShareOrder(order)}
               onDelete={() => deleteOrder(order)}
               onNavigate={navigate}
-              onOpenDetail={() => setDetailOrder(order)}
+              onOpenDetail={() => setDetailRow(order)}
               onPrint={() => printOrder(order)}
             />
           ))}
-
-          {/* Infinite scroll sentinel + carregar mais fallback */}
-          {hasNext && (
-            <div ref={sentinelRef} className="py-4 flex justify-center">
-              {isFetching ? (
-                <Loader2 className="w-5 h-5 animate-spin text-muted-foreground" />
-              ) : (
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={loadMore}
-                >
-                  Carregar mais
-                </Button>
-              )}
-            </div>
-          )}
-          {!hasNext && orders.length >= PAGE_SIZE && (
-            <p className="text-center text-xs text-muted-foreground py-4">
-              Todos os pedidos carregados ({orders.length})
-            </p>
-          )}
+          <p className="text-center text-xs text-muted-foreground py-4">
+            {filteredOrders.length === totalCount
+              ? `${totalCount} pedido(s)`
+              : `${filteredOrders.length} de ${totalCount} pedido(s)`}
+          </p>
         </div>
       )}
 
@@ -149,12 +151,14 @@ const SalesOrders = () => {
       />
 
       <SalesOrderDetailSheet
-        order={detailOrder}
-        customerName={detailCustomerName}
-        onClose={() => setDetailOrder(null)}
-        onPrint={() => detailOrder && printOrder(detailOrder)}
-        onShare={() => detailOrder && handleShareOrder(detailOrder, detailCustomerName)}
-        onEdit={() => detailOrder && navigate(`/sales/edit/${detailOrder.id}`)}
+        open={!!detailRow}
+        loading={detailQuery.isPending}
+        order={detailQuery.data?.order ?? null}
+        customerName={detailQuery.data?.customerName ?? decodeHtml(detailRow?.customer_name || 'Cliente')}
+        onClose={() => setDetailRow(null)}
+        onPrint={() => detailRow && printOrder(detailRow)}
+        onShare={() => detailRow && handleShareOrder(detailRow)}
+        onEdit={() => detailRow && navigate(`/sales/edit/${detailRow.id}`)}
       />
     </div>
   );

--- a/supabase/migrations/20260606210000_order_feed_view.sql
+++ b/supabase/migrations/20260606210000_order_feed_view.sql
@@ -27,6 +27,7 @@ with feed as (
     so.created_at::timestamptz  as created_at,
     so.account::text            as account,
     so.omie_numero_pedido::text as order_number,
+    so.omie_pedido_id::bigint   as omie_pedido_id,
     so.customer_user_id::uuid   as customer_user_id,
     case when jsonb_typeof(so.items) = 'array' then coalesce((
       select array_agg(nullif(elem->>'descricao','') order by ord)
@@ -52,6 +53,7 @@ with feed as (
     o.created_at::timestamptz   as created_at,
     'colacor_sc'::text          as account,
     null::text                  as order_number,
+    null::bigint                as omie_pedido_id,
     o.user_id::uuid             as customer_user_id,
     case when jsonb_typeof(o.items) = 'array' then coalesce((
       select array_agg(coalesce(nullif(elem->>'category',''), nullif(elem->>'name',''), 'Afiação') order by ord)
@@ -73,6 +75,7 @@ select
   f.created_at,
   f.account,
   f.order_number,
+  f.omie_pedido_id,
   f.customer_user_id,
   p.name::text as customer_name,
   f.item_names,

--- a/supabase/migrations/20260606210000_order_feed_view.sql
+++ b/supabase/migrations/20260606210000_order_feed_view.sql
@@ -1,0 +1,87 @@
+-- order_feed: read model único da listagem de pedidos (/sales).
+-- Unifica sales_orders + orders (afiação) com o nome do cliente embutido, numa
+-- projeção ENXUTA (sem itens completos / payloads pesados) — a listagem carrega
+-- tudo numa só query; o detalhe busca o pedido cheio por (origin, id).
+--
+-- ⚠️ MIGRATION MANUAL: colar no SQL Editor do Lovable (o repo não aplica sozinho).
+--
+-- Decisões (validadas no schema real + 2 rodadas de 2ª opinião):
+--  • LEFT JOIN normal por user_id — profiles.user_id é UNIQUE (profiles_user_id_key)
+--    → 1 profile por usuário, sem duplicação (dispensa lateral/LIMIT 1).
+--  • profiles não tem coluna account → não é multi-tenant (join só por user_id).
+--  • cast numérico com guarda regex — um item com 'quantidade' malformada NÃO
+--    derruba a view inteira (COALESCE não captura erro de cast).
+--  • array_agg WITH ORDINALITY — ordem estável dos nomes; '{}' p/ vazio.
+--  • casts explícitos no UNION ALL — contrato de tipos estável.
+--  • SEM customer_document (PII) — só o detalhe-por-id usa.
+--  • orders (afiação) não tem deleted_at → não há soft delete a filtrar.
+--  • security_invoker → herda a RLS das tabelas base (staff já lê as 3).
+
+create or replace view public.order_feed
+with (security_invoker = true)
+as
+with feed as (
+  select
+    'sales'::text               as origin,
+    so.id::uuid                 as id,
+    so.created_at::timestamptz  as created_at,
+    so.account::text            as account,
+    so.omie_numero_pedido::text as order_number,
+    so.customer_user_id::uuid   as customer_user_id,
+    case when jsonb_typeof(so.items) = 'array' then coalesce((
+      select array_agg(nullif(elem->>'descricao','') order by ord)
+             filter (where nullif(elem->>'descricao','') is not null)
+      from jsonb_array_elements(so.items) with ordinality as t(elem, ord)
+    ), '{}'::text[]) else '{}'::text[] end                      as item_names,
+    case when jsonb_typeof(so.items) = 'array' then coalesce((
+      select sum(case when (elem->>'quantidade') ~ '^-?[0-9]+(\.[0-9]+)?$'
+                      then (elem->>'quantidade')::numeric else 0 end)
+      from jsonb_array_elements(so.items) as elem
+    ), 0) else 0 end::numeric                                   as item_quantity,
+    so.status::text             as status,
+    so.subtotal::numeric        as subtotal,
+    so.total::numeric           as total
+  from public.sales_orders so
+  where so.deleted_at is null
+
+  union all
+
+  select
+    'afiacao'::text             as origin,
+    o.id::uuid                  as id,
+    o.created_at::timestamptz   as created_at,
+    'colacor_sc'::text          as account,
+    null::text                  as order_number,
+    o.user_id::uuid             as customer_user_id,
+    case when jsonb_typeof(o.items) = 'array' then coalesce((
+      select array_agg(coalesce(nullif(elem->>'category',''), nullif(elem->>'name',''), 'Afiação') order by ord)
+      from jsonb_array_elements(o.items) with ordinality as t(elem, ord)
+    ), '{}'::text[]) else '{}'::text[] end                      as item_names,
+    case when jsonb_typeof(o.items) = 'array' then coalesce((
+      select sum(case when (elem->>'quantity') ~ '^-?[0-9]+(\.[0-9]+)?$'
+                      then (elem->>'quantity')::numeric else 1 end)
+      from jsonb_array_elements(o.items) as elem
+    ), 0) else 0 end::numeric                                   as item_quantity,
+    o.status::text              as status,
+    o.subtotal::numeric         as subtotal,
+    o.total::numeric            as total
+  from public.orders o
+)
+select
+  f.origin,
+  f.id,
+  f.created_at,
+  f.account,
+  f.order_number,
+  f.customer_user_id,
+  p.name::text as customer_name,
+  f.item_names,
+  f.item_quantity,
+  f.status,
+  f.subtotal,
+  f.total
+from feed f
+left join public.profiles p on p.user_id = f.customer_user_id;
+
+comment on view public.order_feed is
+  'Read model da listagem de pedidos (/sales): UNION de sales_orders + orders (afiação) com nome do cliente. Enxuto — detalhe busca por (origin,id). security_invoker.';


### PR DESCRIPTION
## ⚠️ ATENÇÃO: migration manual necessária (ANTES do Publish)
A view `order_feed` precisa existir **antes** do frontend ir ao ar. SQL no fim deste PR + entregue inline na conversa. (Sem a view, a tela degrada honesta com "Tentar novamente" — mas não funciona.)

## Problema (reproduzido em produção)
A busca da listagem `/sales` dizia **"Nenhum pedido com esses filtros" para pedidos que existem**: busquei "delta" → vazio; carreguei 350 pedidos na mão → busquei de novo → **5 achados**. Causa estrutural: 2 `useInfiniteQuery` (sales_orders + orders/afiação) mescladas no cliente — busca e abas só enxergavam as páginas carregadas, e com a lista filtrada vazia **não havia nem gatilho de carregar mais**. Piora com o tempo (pedidos novos empurram os antigos pra fora da janela). O pronto-socorro (#697) tirou o reset do scroll, mas não resolve isso.

## Solução — read model único (2 rodadas de 2ª opinião no design)
- **View `order_feed`** (migration `20260606210000`, `security_invoker`): UNION ALL de sales_orders + orders com o **nome do cliente embutido** (LEFT JOIN `profiles` — `user_id` é UNIQUE em prod, sem duplicação), `item_names`/`item_quantity` extraídos do jsonb com **guarda regex no cast** (item malformado não derruba a view), casts explícitos no UNION, `WITH ORDINALITY`, **sem `customer_document`** (PII fica só no detalhe).
- **`useSalesOrders`**: **UMA** query carrega o conjunto completo (`count: exact` + range 0–999 + **aviso honesto de truncamento** se passar de 1000 — nunca silencia); busca/abas client-side sobre **tudo** (`filterFeedRows` puro, TDD). Somem: as 2 infinite queries, o merge, a query de profiles (nomes não piscam mais) e o scroll infinito desta tela.
- **Detalhe sob demanda**: `useSalesOrderDetail(origin, id)` busca o pedido completo ao abrir o painel / imprimir / compartilhar (cache compartilhado por queryKey; sem placeholder entre ids — nunca mostra dados do pedido errado; **impressão espera o detalhe**).
- `userId` na query key (cache não vaza entre sessões); soft-delete optimistic adaptado ao cache novo com rollback.

## Validação
- **PG17 local** (`db/test-order-feed-view.sh`): view aplicada sobre o snapshot de prod + seeds adversariais — itens malformados (`""`/texto), soft-delete, pedido sem profile, items não-array, afiação. Todos os asserts ✅
- `bun run typecheck` ✅ · `bun lint` 0 erros ✅ · `bun run build` ✅ · `bun run test` ✅ **2891/2891**
- Testes novos: `feed.test.ts` (13, TDD), card/sheet adaptados (16)

## Revisão (transparência)
Design: 2 rodadas de 2ª opinião externa (registradas no spec). **Implementação: o Codex bateu o usage limit do Plus no meio do adversarial (volta 11/06 9h24)** → caminho B (precedente do repo): self-review adversarial + validação PG17; **adversarial retroativo do Codex quando a cota voltar**. Achado do self-review registrado: `window.open` do cupom roda após `await` — popup-blocker rígido (Safari) pode barrar a 1ª impressão; com o detalhe em cache (painel aberto) não afeta. Follow-up se reportado.

## Rollout (ordem importa)
1. **SQL Editor**: colar a migration (bloco na conversa) → Run → validação.
2. Mergear este PR.
3. **Publish** no Lovable.
4. Smoke: buscar "delta" → deve achar TODOS, sem reset, sem "carregar mais".
5. Homologação RLS rápida: logado staff vê tudo; **anon não deve ler a view**.

## Migration (referência)
```sql
-- ver supabase/migrations/20260606210000_order_feed_view.sql (colada na conversa)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)