### PR TITLE
fix(financeiro): KPI A Receber/Pagar de /financeiro/gestao somava errado (status + truncamento no cap 1000)

### DIFF
--- a/src/pages/FinanceiroGestao.tsx
+++ b/src/pages/FinanceiroGestao.tsx
@@ -2,6 +2,8 @@ import { lazy, Suspense, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
+import { somarSaldoAberto } from "@/services/financeiroService";
+import type { Company } from "@/contexts/CompanyContext";
 import {
   Wallet,
   Loader2,
@@ -38,50 +40,42 @@ const fmtBRL = (v: number) =>
   v.toLocaleString("pt-BR", { style: "currency", currency: "BRL" });
 
 function KpiCards({ empresa }: { empresa: string }) {
+  // O Select acima só produz "OBEN"/"COLACOR" → lowercase casa o Company do service.
+  const company = empresa.toLowerCase() as Company;
+
+  // Σ saldo dos títulos EM ABERTO via somarSaldoAberto — a mesma fonte do DSO:
+  // OPEN_TITLE_STATUSES (vocabulário nativo do Omie) + paginação do cap de
+  // 1000 + throw em erro. A versão anterior fazia .neq('status_titulo','PAGO')
+  // — que INCLUÍA RECEBIDO/LIQUIDADO (saldo cheio por causa do #396, com
+  // fallback pro valor_documento) e até CANCELADO — e sem .limit() truncava a
+  // soma nas 1000 primeiras linhas (a oben tem ~12k títulos de CR): o número
+  // exibido era errado nos dois sentidos.
   const { data: receber } = useQuery({
-    queryKey: ["fin-gestao-receber", empresa],
-    queryFn: async () => {
-      const { data } = await supabase
-        .from("fin_contas_receber")
-        .select("saldo, valor_documento, status_titulo")
-        .eq("company", empresa.toLowerCase())
-        .neq("status_titulo", "PAGO");
-      return (data ?? []).reduce(
-        (acc: number, r: { saldo: number | null; valor_documento: number | null }) =>
-          acc + Number(r.saldo ?? r.valor_documento ?? 0),
-        0,
-      );
-    },
-    refetchInterval: 60000,
+    queryKey: ["fin-gestao-receber", company],
+    queryFn: () => somarSaldoAberto("fin_contas_receber", company),
+    // Posição de carteira (não muda por minuto) e a query pagina ~12 requests
+    // na oben — 5min em vez do 60s da versão truncada.
+    refetchInterval: 300_000,
+    staleTime: 240_000,
   });
 
   const { data: pagar } = useQuery({
-    queryKey: ["fin-gestao-pagar", empresa],
-    queryFn: async () => {
-      const { data } = await supabase
-        .from("fin_contas_pagar")
-        .select("saldo, valor_documento, status_titulo")
-        .eq("company", empresa.toLowerCase())
-        .neq("status_titulo", "PAGO");
-      return (data ?? []).reduce(
-        (acc: number, r: { saldo: number | null; valor_documento: number | null }) =>
-          acc + Number(r.saldo ?? r.valor_documento ?? 0),
-        0,
-      );
-    },
-    refetchInterval: 60000,
+    queryKey: ["fin-gestao-pagar", company],
+    queryFn: () => somarSaldoAberto("fin_contas_pagar", company),
+    refetchInterval: 300_000,
+    staleTime: 240_000,
   });
 
   // TODO: tabela fin_saldo_bancario ainda não existe — exibir 0 até ser criada.
   const saldoBancario = 0;
 
   const { data: inadimplencia } = useQuery({
-    queryKey: ["fin-gestao-inadimp", empresa],
+    queryKey: ["fin-gestao-inadimp", company],
     queryFn: async () => {
       const { data } = await supabase
         .from("fin_aging_receber")
         .select("*")
-        .eq("company", empresa.toLowerCase())
+        .eq("company", company)
         .maybeSingle();
       if (!data) return 0;
       const vencido =
@@ -92,7 +86,9 @@ function KpiCards({ empresa }: { empresa: string }) {
       const total = vencido + Number(data.a_vencer_valor ?? 0);
       return total > 0 ? (vencido / total) * 100 : 0;
     },
-    refetchInterval: 60000,
+    // Alinhado aos KPIs de CR/CP: posição, não tempo-real.
+    refetchInterval: 300_000,
+    staleTime: 240_000,
   });
 
   const cards = [

--- a/src/services/__tests__/somarSaldoAberto.test.ts
+++ b/src/services/__tests__/somarSaldoAberto.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { OPEN_TITLE_STATUSES } from '@/lib/financeiro/titulo-status';
+
+/**
+ * Teste de contrato da somarSaldoAberto — a fonte canônica de "total a
+ * receber/pagar em aberto" (DSO + KPIs de /financeiro/gestao). Trava os 4
+ * contratos que o bug do KPI violava (B1 da auditoria 2026-06-09):
+ *  1. filtra por OPEN_TITLE_STATUSES (vocabulário NATIVO do Omie) — o KPI
+ *     antigo usava .neq('PAGO'), que incluía RECEBIDO/LIQUIDADO (saldo cheio
+ *     por causa do #396) e até CANCELADO;
+ *  2. pagina além do cap de 1000 do PostgREST — o KPI antigo truncava a soma;
+ *  3. soma `saldo ?? 0` (sem fallback pro valor_documento);
+ *  4. erro de QUALQUER página LANÇA — nunca soma parcial silenciosa.
+ */
+
+type Row = { saldo: number | null };
+
+const state: {
+  pages: Array<{ data: Row[] | null; error: { message: string } | null }>;
+  calls: Array<{ tabela: string; company: string; statuses: string[]; from: number; to: number }>;
+} = { pages: [], calls: [] };
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    from: (tabela: string) => ({
+      select: (_cols: string) => ({
+        eq: (_col: string, company: string) => ({
+          in: (_col2: string, statuses: string[]) => ({
+            range: (from: number, to: number) => {
+              const idx = Math.floor(from / 1000);
+              state.calls.push({ tabela, company, statuses, from, to });
+              return Promise.resolve(
+                state.pages[idx] ?? { data: [], error: null },
+              );
+            },
+          }),
+        }),
+      }),
+    }),
+  },
+}));
+
+import { somarSaldoAberto } from '@/services/financeiroService';
+
+const page = (n: number, saldo = 10): { data: Row[]; error: null } => ({
+  data: Array.from({ length: n }, () => ({ saldo })),
+  error: null,
+});
+
+describe('somarSaldoAberto (contrato do B1)', () => {
+  beforeEach(() => {
+    state.pages = [];
+    state.calls = [];
+  });
+
+  it('filtra pelos status NATIVOS de aberto (A VENCER/ATRASADO/VENCE HOJE), na tabela e empresa pedidas', async () => {
+    state.pages = [page(3)];
+    await somarSaldoAberto('fin_contas_receber', 'oben');
+    expect(state.calls).toHaveLength(1);
+    expect(state.calls[0].tabela).toBe('fin_contas_receber');
+    expect(state.calls[0].company).toBe('oben');
+    expect(state.calls[0].statuses).toEqual([...OPEN_TITLE_STATUSES]);
+    expect(state.calls[0].statuses).toEqual(['A VENCER', 'ATRASADO', 'VENCE HOJE']);
+  });
+
+  it('pagina além do cap de 1000 e soma TODAS as páginas (o KPI antigo truncava)', async () => {
+    state.pages = [page(1000, 2), page(234, 1)];
+    const total = await somarSaldoAberto('fin_contas_receber', 'oben');
+    expect(total).toBe(1000 * 2 + 234 * 1);
+    expect(state.calls).toHaveLength(2);
+    expect(state.calls[0]).toMatchObject({ from: 0, to: 999 });
+    expect(state.calls[1]).toMatchObject({ from: 1000, to: 1999 });
+  });
+
+  it('para na primeira página parcial (não faz request à toa)', async () => {
+    state.pages = [page(3, 5)];
+    const total = await somarSaldoAberto('fin_contas_pagar', 'colacor');
+    expect(total).toBe(15);
+    expect(state.calls).toHaveLength(1);
+  });
+
+  it('saldo null contribui 0 — sem fallback pro valor_documento', async () => {
+    state.pages = [{ data: [{ saldo: null }, { saldo: 7 }, { saldo: 0 }], error: null }];
+    const total = await somarSaldoAberto('fin_contas_receber', 'oben');
+    expect(total).toBe(7);
+  });
+
+  it('erro de página LANÇA (nunca devolve soma parcial silenciosa)', async () => {
+    state.pages = [page(1000, 2), { data: null, error: { message: 'RLS negou' } }];
+    await expect(somarSaldoAberto('fin_contas_receber', 'oben')).rejects.toBeTruthy();
+  });
+});

--- a/src/services/financeiroService.ts
+++ b/src/services/financeiroService.ts
@@ -810,8 +810,14 @@ export async function getLastSyncTime(): Promise<string | null> {
 
 // ═══════════════ Lente contábil agregada — DSO/DPO (colacor) ═══════════════
 
-/** Soma paginada do `saldo` dos títulos ABERTOS (robusto vs cap 1000 do PostgREST). */
-async function somarSaldoAberto(
+/**
+ * Soma paginada do `saldo` dos títulos EM ABERTO (OPEN_TITLE_STATUSES, robusto
+ * vs cap 1000 do PostgREST). Fonte canônica de "total a receber/pagar aberto":
+ * consumida pelo DSO (getDsoDpoColacor) e pelos KPIs de /financeiro/gestao.
+ * Erro de qualquer página LANÇA — nunca devolve soma parcial silenciosa.
+ * Contrato travado em src/services/__tests__/somarSaldoAberto.test.ts.
+ */
+export async function somarSaldoAberto(
   tabela: 'fin_contas_receber' | 'fin_contas_pagar',
   company: Company,
 ): Promise<number> {


### PR DESCRIPTION
## O bug (B1 da auditoria de 2026-06-09 — money-path)

Os cards "Total a Receber"/"Total a Pagar" de `/financeiro/gestao` exibiam um número **errado nos dois sentidos**:

1. **Status**: `.neq('status_titulo','PAGO')` incluía `RECEBIDO`/`LIQUIDADO` — que têm `saldo` CHEIO (#396: `valor_recebido` é sempre 0 no banco) e ainda caíam no fallback `valor_documento` — e até `CANCELADO`. **Inflava.**
2. **Truncamento**: sem `.limit()`, o PostgREST capa em 1000 linhas (a oben tem ~12k títulos de CR) e o `reduce` somava só a 1ª página. **Deflacionava.**

## O fix

Os KPIs passam a usar **`somarSaldoAberto`** (agora exportada do `financeiroService`) — a **mesma fonte do DSO**, já validada em produção: `OPEN_TITLE_STATUSES` (vocabulário nativo do Omie) + paginação do cap + **throw em erro** (nunca soma parcial silenciosa). Cadência 60s → 5min (posição de carteira; a query pagina ~12 requests na oben).

## Validação

- **Teste de contrato novo** (`somarSaldoAberto.test.ts`, 5 casos): trava o vocabulário de status, a paginação além do cap, `saldo null → 0` (sem fallback bogus), parada na página parcial e throw em erro.
- `bun run typecheck` (strict) ✅ · `bun run test` **2926/2926** ✅ · `bun lint` 0 errors ✅
- Sem migration, sem edge function — 100% frontend.

⚠️ O número exibido VAI MUDAR após o Publish — é o correto agora (antes era soma truncada de um conjunto poluído).

🤖 Generated with [Claude Code](https://claude.com/claude-code)