### PR TITLE
fix(financeiro): getResumoFinanceiro somava truncado no cap 1000 — somas paginadas em saldo (irmão do #719)

### DIFF
--- a/docs/roadmap-sessao.md
+++ b/docs/roadmap-sessao.md
@@ -1,4 +1,4 @@
-# Roadmap da Sessão — atualizado 2026-06-09
+# Roadmap da Sessão — atualizado 2026-06-10
 
 > **Documento vivo.** Re-feito sempre que acrescentamos OU concluímos uma atividade, e renderizado no chat quando muda, pra o founder acompanhar. Prática padrão de toda sessão (registrada no CLAUDE.md, topo).
 >
@@ -6,7 +6,19 @@
 
 ---
 
-## 0. SESSÃO 2026-06-09 — Reposição intra-day + alerta R$3k Sayerlack + dente de serra
+## 0. SESSÃO 2026-06-10 — getResumoFinanceiro somava truncado no cap 1000 (irmão do #719)
+
+> Mesmo bug do PR #719 (KPIs de /financeiro/gestao), agora no `getResumoFinanceiro`
+> (financeiroService ~182-240, consumido pelo FinanceiroDashboard): somas de CR/CP
+> aberto+vencido client-side SEM `.range()` → PostgREST capa em 1000 linhas → com
+> ~11k títulos de CR aberto na oben, `total_a_receber`/`total_vencido_*` saem errados.
+
+- 🔄 **Fix TDD**: variante paginada `somarSaldoPorStatus(tabela, company, statuses)`; `somarSaldoAberto` delega nela; `getResumoFinanceiro` passa a usar as somas paginadas (padroniza em `saldo`, coluna gerada = documento − recebido/pago). Testes de contrato com mock do supabase que reproduz o cap 1000.
+- ⏳ `heavy bun run typecheck` + `heavy bun run test` + `bun lint` → PR pequeno e isolado (sem migration/edge; vai ao ar no próximo Publish).
+
+---
+
+## 0b. SESSÃO 2026-06-09 — Reposição intra-day + alerta R$3k Sayerlack + dente de serra
 
 > Pedido do founder: (1) e-mail toda vez que um pedido sugerido der R$3.000+ (mínimo de faturamento
 > da Sayerlack — pode acontecer várias vezes ao dia, pedidos diferentes); (2) motor de sugestões

--- a/docs/roadmap-sessao.md
+++ b/docs/roadmap-sessao.md
@@ -13,8 +13,12 @@
 > aberto+vencido client-side SEM `.range()` → PostgREST capa em 1000 linhas → com
 > ~11k títulos de CR aberto na oben, `total_a_receber`/`total_vencido_*` saem errados.
 
-- 🔄 **Fix TDD**: variante paginada `somarSaldoPorStatus(tabela, company, statuses)`; `somarSaldoAberto` delega nela; `getResumoFinanceiro` passa a usar as somas paginadas (padroniza em `saldo`, coluna gerada = documento − recebido/pago). Testes de contrato com mock do supabase que reproduz o cap 1000.
-- ⏳ `heavy bun run typecheck` + `heavy bun run test` + `bun lint` → PR pequeno e isolado (sem migration/edge; vai ao ar no próximo Publish).
+- ✅ **Fix TDD**: variante paginada `somarSaldoPorStatus(tabela, company, statuses)`; `somarSaldoAberto` delega nela; `getResumoFinanceiro` usa as somas paginadas (padroniza em `saldo`, coluna gerada). RED provado por truncamento exato (2200→2000) antes do fix.
+- ✅ **/review (gstack)**: 2 specialists + adversarial Claude (codex em usage-limit até 11/06 9:24 — retroativo pendente). Achados incorporados: `.order('id')` na paginação (offset sem ORDER BY não é estável; sync grava */10), `throw new Error(...)` em vez de objeto cru (banner mostraria "[object Object]"), CC deixou de engolir erro, `useFinanceiroCockpit` isola o resumo com catch por fonte (sem isso o throw novo derrubava aging/DRE/inadimplentes junto), mock capa `.range()` em 1000 como o PostgREST real + testes de erro do orquestrador.
+- ✅ Gate verde: typecheck 0 · **2959 testes** (16 de contrato novos) · lint 0 errors. PR aberto (squash + auto-merge). Sem migration/edge; **vai ao ar no próximo Publish**.
+- ⏳ **Follow-up (chip spawnado)**: `getCapitalDeGiro` + `getTopInadimplentes` têm o MESMO cap 1000 (achado do specialist — capital_giro/top-5/projeção-30d truncados na oben); precisa paginar a busca de LINHAS (não só somas).
+- ⏸️ **Codex adversarial retroativo** do PR quando a cota voltar (11/06+).
+- 📝 Limitação conhecida (nota no PR): o cockpit loga falha do resumo via `logger.warn` mas não tem banner de erro (pré-existente — `getDRE` já lançava no mesmo Promise.all); banner visível = decisão de UX futura.
 
 ---
 

--- a/src/components/financeiro/cockpit/useFinanceiroCockpit.ts
+++ b/src/components/financeiro/cockpit/useFinanceiroCockpit.ts
@@ -47,7 +47,12 @@ export function useFinanceiroCockpit() {
     setLoading(true);
     try {
       const [res, ag, dr, inad, snaps] = await Promise.all([
-        getResumoFinanceiro(['oben', 'colacor', 'colacor_sc']),
+        // getResumoFinanceiro agora LANÇA em erro de query (era swallow→R$0); o catch
+        // por fonte impede que uma falha do resumo derrube aging/DRE/inadimplentes junto.
+        getResumoFinanceiro(['oben', 'colacor', 'colacor_sc']).catch((e): Record<string, FinResumo> => {
+          logger.warn('Resumo financeiro indisponível', { error: e instanceof Error ? e.message : String(e) });
+          return {};
+        }),
         getAgingReceber('all'),
         Promise.all(['oben', 'colacor', 'colacor_sc'].map(co => getDRE(co as Company, ano, undefined, regime))).then(r => r.flat()),
         getTopInadimplentes('all', 5),

--- a/src/services/__tests__/getResumoFinanceiro.test.ts
+++ b/src/services/__tests__/getResumoFinanceiro.test.ts
@@ -16,7 +16,10 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 type Row = Record<string, unknown>;
 
-const state: { db: Record<string, Row[]> } = { db: {} };
+const state: {
+  db: Record<string, Row[]>;
+  errors: Record<string, { message: string } | undefined>;
+} = { db: {}, errors: {} };
 
 function makeBuilder(tabela: string) {
   const filters: Array<(r: Row) => boolean> = [];
@@ -31,17 +34,24 @@ function makeBuilder(tabela: string) {
       filters.push((r) => vals.includes(r[col]));
       return builder;
     },
+    order: (_col: string) => builder,
     range: (from: number, to: number) => {
       janela = { from, to };
       return builder;
     },
     then: (
-      resolve: (v: { data: Row[]; error: null }) => unknown,
+      resolve: (v: { data: Row[] | null; error: { message: string } | null }) => unknown,
       reject?: (e: unknown) => unknown,
     ) => {
+      const error = state.errors[tabela];
+      if (error) return Promise.resolve({ data: null, error }).then(resolve, reject);
       const matched = (state.db[tabela] ?? []).filter((r) => filters.every((f) => f(r)));
-      // PostgREST real: cap default de 1000 sem range; janela com range.
-      const rows = janela ? matched.slice(janela.from, janela.to + 1) : matched.slice(0, 1000);
+      // PostgREST real: max-rows de 1000 vale SEMPRE — sem range capa em 1000, e
+      // com range a janela devolvida nunca passa de 1000 linhas (um `.range(0,
+      // 99999)` NÃO fura o cap; só paginação de verdade soma tudo).
+      const rows = janela
+        ? matched.slice(janela.from, Math.min(janela.to + 1, janela.from + 1000))
+        : matched.slice(0, 1000);
       return Promise.resolve({ data: rows, error: null }).then(resolve, reject);
     },
   };
@@ -69,6 +79,7 @@ const muitos = (n: number, company: string, status: string, saldo: number): Row[
 describe('getResumoFinanceiro (contrato do resumo do dashboard)', () => {
   beforeEach(() => {
     state.db = { fin_contas_correntes: [], fin_contas_receber: [], fin_contas_pagar: [] };
+    state.errors = {};
   });
 
   it('soma TODOS os títulos abertos mesmo acima do cap de 1000 do PostgREST (CR e CP)', async () => {
@@ -133,5 +144,16 @@ describe('getResumoFinanceiro (contrato do resumo do dashboard)', () => {
       { descricao: 'Itaú', saldo_atual: 100, banco: '341' },
       { descricao: '', saldo_atual: 0, banco: '' },
     ]);
+  });
+
+  it('erro nos títulos LANÇA um Error real (nunca resumo parcial silencioso, nem "[object Object]" no banner)', async () => {
+    state.db.fin_contas_receber = muitos(10, 'oben', 'A VENCER', 1);
+    state.errors.fin_contas_pagar = { message: 'RLS negou' };
+    await expect(getResumoFinanceiro(['oben'])).rejects.toBeInstanceOf(Error);
+  });
+
+  it('erro nas contas correntes também LANÇA — caixa R$0 falso é tão ruim quanto total truncado', async () => {
+    state.errors.fin_contas_correntes = { message: 'tabela indisponível' };
+    await expect(getResumoFinanceiro(['oben'])).rejects.toBeInstanceOf(Error);
   });
 });

--- a/src/services/__tests__/getResumoFinanceiro.test.ts
+++ b/src/services/__tests__/getResumoFinanceiro.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Teste de contrato do getResumoFinanceiro (resumo do FinanceiroDashboard /
+ * Cockpit). Irmão do bug do KPI de /financeiro/gestao (#719): as somas de CR/CP
+ * aberto+vencido eram reduce client-side SEM paginação → o PostgREST capa em
+ * 1000 linhas e `total_a_receber`/`total_vencido_*` saíam truncados (oben tem
+ * ~11k títulos de CR aberto).
+ *
+ * O mock abaixo reproduz o comportamento REAL do PostgREST: query sem .range()
+ * devolve no máximo 1000 linhas; com .range(from, to) devolve a janela. Os
+ * títulos do seed têm valor_documento/valor_recebido/valor_pago/saldo coerentes
+ * (saldo é coluna gerada = documento − recebido/pago), então estes testes só
+ * falham por truncamento/filtro errado — não por forma de coluna.
+ */
+
+type Row = Record<string, unknown>;
+
+const state: { db: Record<string, Row[]> } = { db: {} };
+
+function makeBuilder(tabela: string) {
+  const filters: Array<(r: Row) => boolean> = [];
+  let janela: { from: number; to: number } | null = null;
+  const builder = {
+    select: (_cols: string) => builder,
+    eq: (col: string, val: unknown) => {
+      filters.push((r) => r[col] === val);
+      return builder;
+    },
+    in: (col: string, vals: unknown[]) => {
+      filters.push((r) => vals.includes(r[col]));
+      return builder;
+    },
+    range: (from: number, to: number) => {
+      janela = { from, to };
+      return builder;
+    },
+    then: (
+      resolve: (v: { data: Row[]; error: null }) => unknown,
+      reject?: (e: unknown) => unknown,
+    ) => {
+      const matched = (state.db[tabela] ?? []).filter((r) => filters.every((f) => f(r)));
+      // PostgREST real: cap default de 1000 sem range; janela com range.
+      const rows = janela ? matched.slice(janela.from, janela.to + 1) : matched.slice(0, 1000);
+      return Promise.resolve({ data: rows, error: null }).then(resolve, reject);
+    },
+  };
+  return builder;
+}
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: { from: (tabela: string) => makeBuilder(tabela) },
+}));
+
+import { getResumoFinanceiro } from '@/services/financeiroService';
+
+const titulo = (company: string, status: string, saldo: number): Row => ({
+  company,
+  status_titulo: status,
+  saldo,
+  valor_documento: saldo,
+  valor_recebido: 0,
+  valor_pago: 0,
+});
+
+const muitos = (n: number, company: string, status: string, saldo: number): Row[] =>
+  Array.from({ length: n }, () => titulo(company, status, saldo));
+
+describe('getResumoFinanceiro (contrato do resumo do dashboard)', () => {
+  beforeEach(() => {
+    state.db = { fin_contas_correntes: [], fin_contas_receber: [], fin_contas_pagar: [] };
+  });
+
+  it('soma TODOS os títulos abertos mesmo acima do cap de 1000 do PostgREST (CR e CP)', async () => {
+    state.db.fin_contas_receber = muitos(1500, 'oben', 'A VENCER', 10);
+    state.db.fin_contas_pagar = muitos(1200, 'oben', 'A VENCER', 5);
+
+    const resumo = await getResumoFinanceiro(['oben']);
+
+    expect(resumo.oben.total_a_receber).toBe(1500 * 10);
+    expect(resumo.oben.total_a_pagar).toBe(1200 * 5);
+    expect(resumo.oben.posicao_liquida).toBe(1500 * 10 - 1200 * 5);
+  });
+
+  it('soma TODOS os vencidos (ATRASADO) mesmo acima do cap de 1000', async () => {
+    state.db.fin_contas_receber = [
+      ...muitos(1100, 'oben', 'ATRASADO', 2),
+      ...muitos(50, 'oben', 'A VENCER', 3),
+    ];
+    state.db.fin_contas_pagar = muitos(1050, 'oben', 'ATRASADO', 4);
+
+    const resumo = await getResumoFinanceiro(['oben']);
+
+    expect(resumo.oben.total_vencido_receber).toBe(1100 * 2);
+    expect(resumo.oben.total_vencido_pagar).toBe(1050 * 4);
+    // ATRASADO também é aberto → compõe o total a receber junto com A VENCER
+    expect(resumo.oben.total_a_receber).toBe(1100 * 2 + 50 * 3);
+  });
+
+  it('ignora liquidados/cancelados (saldo bogus do #396) e títulos de outra empresa', async () => {
+    state.db.fin_contas_receber = [
+      titulo('oben', 'A VENCER', 10),
+      titulo('oben', 'VENCE HOJE', 7),
+      titulo('oben', 'RECEBIDO', 99), // liquidado: saldo cheio por causa do #396 — fora
+      titulo('oben', 'CANCELADO', 50),
+      titulo('colacor', 'A VENCER', 77), // outra empresa — fora
+    ];
+    state.db.fin_contas_pagar = [
+      titulo('oben', 'ATRASADO', 6),
+      titulo('oben', 'PAGO', 88),
+    ];
+
+    const resumo = await getResumoFinanceiro(['oben']);
+
+    expect(resumo.oben.total_a_receber).toBe(10 + 7);
+    expect(resumo.oben.total_a_pagar).toBe(6);
+    expect(resumo.oben.total_vencido_receber).toBe(0);
+    expect(resumo.oben.total_vencido_pagar).toBe(6);
+  });
+
+  it('contas correntes: soma só as ativas da empresa e normaliza campos null', async () => {
+    state.db.fin_contas_correntes = [
+      { company: 'oben', ativo: true, descricao: 'Itaú', saldo_atual: 100, banco: '341' },
+      { company: 'oben', ativo: true, descricao: null, saldo_atual: null, banco: null },
+      { company: 'oben', ativo: false, descricao: 'Encerrada', saldo_atual: 999, banco: '237' },
+      { company: 'colacor', ativo: true, descricao: 'Outra', saldo_atual: 55, banco: '001' },
+    ];
+
+    const resumo = await getResumoFinanceiro(['oben']);
+
+    expect(resumo.oben.saldo_total_cc).toBe(100);
+    expect(resumo.oben.contas_correntes).toEqual([
+      { descricao: 'Itaú', saldo_atual: 100, banco: '341' },
+      { descricao: '', saldo_atual: 0, banco: '' },
+    ]);
+  });
+});

--- a/src/services/__tests__/somarSaldoAberto.test.ts
+++ b/src/services/__tests__/somarSaldoAberto.test.ts
@@ -40,7 +40,7 @@ vi.mock('@/integrations/supabase/client', () => ({
   },
 }));
 
-import { somarSaldoAberto } from '@/services/financeiroService';
+import { somarSaldoAberto, somarSaldoPorStatus } from '@/services/financeiroService';
 
 const page = (n: number, saldo = 10): { data: Row[]; error: null } => ({
   data: Array.from({ length: n }, () => ({ saldo })),
@@ -88,5 +88,45 @@ describe('somarSaldoAberto (contrato do B1)', () => {
   it('erro de página LANÇA (nunca devolve soma parcial silenciosa)', async () => {
     state.pages = [page(1000, 2), { data: null, error: { message: 'RLS negou' } }];
     await expect(somarSaldoAberto('fin_contas_receber', 'oben')).rejects.toBeTruthy();
+  });
+});
+
+/**
+ * Variante genérica por status (getResumoFinanceiro usa com ['ATRASADO'] pros
+ * vencidos). Mesmos contratos de paginação/erro da somarSaldoAberto — que
+ * delega nela (os testes acima provam que a delegação preserva o contrato).
+ */
+describe('somarSaldoPorStatus (contrato dos vencidos do resumo)', () => {
+  beforeEach(() => {
+    state.pages = [];
+    state.calls = [];
+  });
+
+  it('filtra EXATAMENTE pelos status pedidos (vencido = só ATRASADO), na tabela e empresa pedidas', async () => {
+    state.pages = [page(2)];
+    await somarSaldoPorStatus('fin_contas_pagar', 'colacor', ['ATRASADO']);
+    expect(state.calls).toHaveLength(1);
+    expect(state.calls[0].tabela).toBe('fin_contas_pagar');
+    expect(state.calls[0].company).toBe('colacor');
+    expect(state.calls[0].statuses).toEqual(['ATRASADO']);
+  });
+
+  it('pagina além do cap de 1000 e soma TODAS as páginas', async () => {
+    state.pages = [page(1000, 3), page(1000, 2), page(10, 1)];
+    const total = await somarSaldoPorStatus('fin_contas_receber', 'oben', ['ATRASADO']);
+    expect(total).toBe(1000 * 3 + 1000 * 2 + 10 * 1);
+    expect(state.calls).toHaveLength(3);
+    expect(state.calls[2]).toMatchObject({ from: 2000, to: 2999 });
+  });
+
+  it('saldo null contribui 0 e erro de página LANÇA', async () => {
+    state.pages = [{ data: [{ saldo: null }, { saldo: 4 }], error: null }];
+    expect(await somarSaldoPorStatus('fin_contas_receber', 'oben', ['ATRASADO'])).toBe(4);
+
+    state.pages = [page(1000), { data: null, error: { message: 'boom' } }];
+    state.calls = [];
+    await expect(
+      somarSaldoPorStatus('fin_contas_receber', 'oben', ['ATRASADO']),
+    ).rejects.toBeTruthy();
   });
 });

--- a/src/services/__tests__/somarSaldoAberto.test.ts
+++ b/src/services/__tests__/somarSaldoAberto.test.ts
@@ -17,7 +17,7 @@ type Row = { saldo: number | null };
 
 const state: {
   pages: Array<{ data: Row[] | null; error: { message: string } | null }>;
-  calls: Array<{ tabela: string; company: string; statuses: string[]; from: number; to: number }>;
+  calls: Array<{ tabela: string; company: string; statuses: string[]; order: string; from: number; to: number }>;
 } = { pages: [], calls: [] };
 
 vi.mock('@/integrations/supabase/client', () => ({
@@ -26,13 +26,15 @@ vi.mock('@/integrations/supabase/client', () => ({
       select: (_cols: string) => ({
         eq: (_col: string, company: string) => ({
           in: (_col2: string, statuses: string[]) => ({
-            range: (from: number, to: number) => {
-              const idx = Math.floor(from / 1000);
-              state.calls.push({ tabela, company, statuses, from, to });
-              return Promise.resolve(
-                state.pages[idx] ?? { data: [], error: null },
-              );
-            },
+            order: (orderCol: string) => ({
+              range: (from: number, to: number) => {
+                const idx = Math.floor(from / 1000);
+                state.calls.push({ tabela, company, statuses, order: orderCol, from, to });
+                return Promise.resolve(
+                  state.pages[idx] ?? { data: [], error: null },
+                );
+              },
+            }),
           }),
         }),
       }),
@@ -63,6 +65,19 @@ describe('somarSaldoAberto (contrato do B1)', () => {
     expect(state.calls[0].statuses).toEqual(['A VENCER', 'ATRASADO', 'VENCE HOJE']);
   });
 
+  it('pagina ORDENADO por id — offset sem ORDER BY não é estável entre páginas (sync grava a cada 10min)', async () => {
+    state.pages = [page(3)];
+    await somarSaldoAberto('fin_contas_receber', 'oben');
+    expect(state.calls[0].order).toBe('id');
+  });
+
+  it('última página exatamente cheia (múltiplo de 1000): faz a request extra vazia e encerra', async () => {
+    state.pages = [page(1000, 2)];
+    const total = await somarSaldoAberto('fin_contas_receber', 'oben');
+    expect(total).toBe(2000);
+    expect(state.calls).toHaveLength(2);
+  });
+
   it('pagina além do cap de 1000 e soma TODAS as páginas (o KPI antigo truncava)', async () => {
     state.pages = [page(1000, 2), page(234, 1)];
     const total = await somarSaldoAberto('fin_contas_receber', 'oben');
@@ -85,9 +100,11 @@ describe('somarSaldoAberto (contrato do B1)', () => {
     expect(total).toBe(7);
   });
 
-  it('erro de página LANÇA (nunca devolve soma parcial silenciosa)', async () => {
+  it('erro de página LANÇA um Error real (consumidores fazem `e instanceof Error ? e.message : ...`)', async () => {
     state.pages = [page(1000, 2), { data: null, error: { message: 'RLS negou' } }];
-    await expect(somarSaldoAberto('fin_contas_receber', 'oben')).rejects.toBeTruthy();
+    await expect(somarSaldoAberto('fin_contas_receber', 'oben')).rejects.toBeInstanceOf(Error);
+    state.pages = [page(1000, 2), { data: null, error: { message: 'RLS negou' } }];
+    await expect(somarSaldoAberto('fin_contas_receber', 'oben')).rejects.toThrow(/RLS negou/);
   });
 });
 

--- a/src/services/financeiroService.ts
+++ b/src/services/financeiroService.ts
@@ -179,6 +179,9 @@ export async function triggerFinanceiroSync(
 
 // ═══════════════ QUERIES LOCAIS ═══════════════
 
+// Vencidos = só 'ATRASADO' (vocabulário nativo do Omie; subconjunto de OPEN_TITLE_STATUSES).
+const VENCIDO_TITLE_STATUSES = ['ATRASADO'] as const;
+
 export async function getResumoFinanceiro(companies: Company[]): Promise<Record<string, FinResumo>> {
   const resumo: Record<string, FinResumo> = {};
 
@@ -190,37 +193,15 @@ export async function getResumoFinanceiro(companies: Company[]): Promise<Record<
       .eq("company", company)
       .eq("ativo", true);
 
-    // Totais a receber aberto (Omie uses: A VENCER, ATRASADO, VENCE HOJE)
-    const { data: crAberto } = await supabase
-      .from("fin_contas_receber")
-      .select("valor_documento, valor_recebido")
-      .eq("company", company)
-      .in("status_titulo", ["A VENCER", "ATRASADO", "VENCE HOJE"]);
-
-    // Totais a pagar aberto
-    const { data: cpAberto } = await supabase
-      .from("fin_contas_pagar")
-      .select("valor_documento, valor_pago")
-      .eq("company", company)
-      .in("status_titulo", ["A VENCER", "ATRASADO", "VENCE HOJE"]);
-
-    // Vencidos (ATRASADO in Omie)
-    const { data: crVencido } = await supabase
-      .from("fin_contas_receber")
-      .select("valor_documento, valor_recebido")
-      .eq("company", company)
-      .eq("status_titulo", "ATRASADO");
-
-    const { data: cpVencido } = await supabase
-      .from("fin_contas_pagar")
-      .select("valor_documento, valor_pago")
-      .eq("company", company)
-      .eq("status_titulo", "ATRASADO");
-
-    const sumCR = (arr: { valor_documento: number | null; valor_recebido: number | null }[] | null) =>
-      (arr || []).reduce((s, r) => s + ((r.valor_documento || 0) - (r.valor_recebido || 0)), 0);
-    const sumCP = (arr: { valor_documento: number | null; valor_pago: number | null }[] | null) =>
-      (arr || []).reduce((s, r) => s + ((r.valor_documento || 0) - (r.valor_pago || 0)), 0);
+    // Abertos + vencidos: soma paginada do `saldo` — o reduce client-side sem
+    // .range() somava só a 1ª página de 1000 do PostgREST (oben tem ~11k títulos
+    // de CR aberto → totais truncados; mesmo bug do KPI de /financeiro/gestao, #719).
+    const [totalAReceber, totalAPagar, vencidoReceber, vencidoPagar] = await Promise.all([
+      somarSaldoAberto("fin_contas_receber", company),
+      somarSaldoAberto("fin_contas_pagar", company),
+      somarSaldoPorStatus("fin_contas_receber", company, VENCIDO_TITLE_STATUSES),
+      somarSaldoPorStatus("fin_contas_pagar", company, VENCIDO_TITLE_STATUSES),
+    ]);
 
     const contasNorm = (contas || []).map((c) => ({
       descricao: c.descricao ?? "",
@@ -231,11 +212,11 @@ export async function getResumoFinanceiro(companies: Company[]): Promise<Record<
     resumo[company] = {
       contas_correntes: contasNorm,
       saldo_total_cc: contasNorm.reduce((s, c) => s + c.saldo_atual, 0),
-      total_a_receber: sumCR(crAberto),
-      total_a_pagar: sumCP(cpAberto),
-      total_vencido_receber: sumCR(crVencido),
-      total_vencido_pagar: sumCP(cpVencido),
-      posicao_liquida: sumCR(crAberto) - sumCP(cpAberto),
+      total_a_receber: totalAReceber,
+      total_a_pagar: totalAPagar,
+      total_vencido_receber: vencidoReceber,
+      total_vencido_pagar: vencidoPagar,
+      posicao_liquida: totalAReceber - totalAPagar,
     };
   }
 
@@ -811,18 +792,19 @@ export async function getLastSyncTime(): Promise<string | null> {
 // ═══════════════ Lente contábil agregada — DSO/DPO (colacor) ═══════════════
 
 /**
- * Soma paginada do `saldo` dos títulos EM ABERTO (OPEN_TITLE_STATUSES, robusto
- * vs cap 1000 do PostgREST). Fonte canônica de "total a receber/pagar aberto":
- * consumida pelo DSO (getDsoDpoColacor) e pelos KPIs de /financeiro/gestao.
+ * Soma paginada do `saldo` dos títulos da empresa nos `statuses` pedidos
+ * (robusto vs cap 1000 do PostgREST). `saldo` é coluna GERADA
+ * (valor_documento − COALESCE(valor_recebido/pago, 0)) — equivalente à
+ * subtração client-side, sem depender de baixar as duas colunas.
  * Erro de qualquer página LANÇA — nunca devolve soma parcial silenciosa.
  * Contrato travado em src/services/__tests__/somarSaldoAberto.test.ts.
  */
-export async function somarSaldoAberto(
+export async function somarSaldoPorStatus(
   tabela: 'fin_contas_receber' | 'fin_contas_pagar',
   company: Company,
+  statuses: readonly string[],
 ): Promise<number> {
   const PAGE = 1000;
-  const statuses = [...OPEN_TITLE_STATUSES];
   let from = 0;
   let total = 0;
   for (;;) {
@@ -830,7 +812,7 @@ export async function somarSaldoAberto(
       .from(tabela)
       .select('saldo')
       .eq('company', company)
-      .in('status_titulo', statuses)
+      .in('status_titulo', [...statuses])
       .range(from, from + PAGE - 1);
     if (error) throw error;
     const rows = (data ?? []) as Array<{ saldo: number | null }>;
@@ -839,6 +821,18 @@ export async function somarSaldoAberto(
     from += PAGE;
   }
   return total;
+}
+
+/**
+ * Soma paginada do `saldo` dos títulos EM ABERTO (OPEN_TITLE_STATUSES). Fonte
+ * canônica de "total a receber/pagar aberto": consumida pelo DSO
+ * (getDsoDpoColacor), pelos KPIs de /financeiro/gestao e pelo getResumoFinanceiro.
+ */
+export async function somarSaldoAberto(
+  tabela: 'fin_contas_receber' | 'fin_contas_pagar',
+  company: Company,
+): Promise<number> {
+  return somarSaldoPorStatus(tabela, company, OPEN_TITLE_STATUSES);
 }
 
 /**

--- a/src/services/financeiroService.ts
+++ b/src/services/financeiroService.ts
@@ -186,12 +186,13 @@ export async function getResumoFinanceiro(companies: Company[]): Promise<Record<
   const resumo: Record<string, FinResumo> = {};
 
   for (const company of companies) {
-    // Saldos CC
-    const { data: contas } = await supabase
+    // Saldos CC — erro LANÇA: caixa R$0 falso engana tanto quanto total truncado
+    const { data: contas, error: ccError } = await supabase
       .from("fin_contas_correntes")
       .select("descricao, saldo_atual, banco")
       .eq("company", company)
       .eq("ativo", true);
+    if (ccError) throw new Error(`Falha ao carregar contas correntes (${company}): ${ccError.message}`);
 
     // Abertos + vencidos: soma paginada do `saldo` — o reduce client-side sem
     // .range() somava só a 1ª página de 1000 do PostgREST (oben tem ~11k títulos
@@ -796,7 +797,10 @@ export async function getLastSyncTime(): Promise<string | null> {
  * (robusto vs cap 1000 do PostgREST). `saldo` é coluna GERADA
  * (valor_documento − COALESCE(valor_recebido/pago, 0)) — equivalente à
  * subtração client-side, sem depender de baixar as duas colunas.
- * Erro de qualquer página LANÇA — nunca devolve soma parcial silenciosa.
+ * Pagina ORDENADO por id: offset sem ORDER BY não é estável entre páginas
+ * (o sync de CR/CP grava a cada 10min → linha pulada/duplicada silenciosa).
+ * Erro de qualquer página LANÇA Error real — nunca soma parcial silenciosa,
+ * e os consumidores exibem `e.message` (objeto cru viraria "[object Object]").
  * Contrato travado em src/services/__tests__/somarSaldoAberto.test.ts.
  */
 export async function somarSaldoPorStatus(
@@ -813,8 +817,9 @@ export async function somarSaldoPorStatus(
       .select('saldo')
       .eq('company', company)
       .in('status_titulo', [...statuses])
+      .order('id')
       .range(from, from + PAGE - 1);
-    if (error) throw error;
+    if (error) throw new Error(`Falha ao somar saldo (${tabela}/${company}): ${error.message}`);
     const rows = (data ?? []) as Array<{ saldo: number | null }>;
     for (const r of rows) total += r.saldo ?? 0;
     if (rows.length < PAGE) break;


### PR DESCRIPTION
## O bug

As 4 queries de CR/CP do `getResumoFinanceiro` (`financeiroService.ts` ~182-240, consumido pelo **FinanceiroDashboard** e pelo **Cockpit**) não tinham `.range()` → o PostgREST capa em **1000 linhas** e o reduce client-side somava só a primeira página. A oben tem **~11k títulos de CR aberto** → `total_a_receber`/`total_vencido_receber`/`posicao_liquida` saíam truncados/errados. Mesmo bug corrigido no #719 pros KPIs de `/financeiro/gestao`.

## O fix

- **`somarSaldoPorStatus(tabela, company, statuses)`** — soma paginada do `saldo` (coluna gerada = `valor_documento − valor_recebido/pago`, equivalente à subtração client-side), **ordenada por `id`** (offset sem ORDER BY não é estável entre páginas; o sync de CR/CP grava a cada 10min), erro de qualquer página **lança `Error` real** (nunca soma parcial silenciosa, nem `[object Object]` no banner).
- **`somarSaldoAberto` delega** nela (contrato do #719 preservado — provado pelos testes existentes).
- **`getResumoFinanceiro`** usa as somas paginadas; vencidos = `['ATRASADO']`; a query de contas correntes **deixou de engolir erro** (caixa R$0 falso engana tanto quanto total truncado).
- **`useFinanceiroCockpit`** isola o resumo com catch por fonte (padrão já usado pro snapshot): o throw novo não derruba aging/DRE/inadimplentes junto.

## Validação

- TDD: RED provado por truncamento exato (`expected 2200 to be 2000`) antes do fix; **16 testes de contrato** com mock fiel ao PostgREST (cap de 1000 vale TAMBÉM com `.range()` gigante — só paginação de verdade passa).
- `/review` (gstack): 2 specialists + adversarial — achados incorporados no 2º commit. Codex em usage-limit até 11/06 (adversarial retroativo pendente).
- Gate: typecheck 0 · 2959 testes verdes · lint 0 errors.

**Sem migration/edge** — client-side puro; vai ao ar no próximo **Publish**.

## Notas pro reviewer

- Limitação conhecida (pré-existente): o cockpit loga falha de fonte via `logger.warn`/`console.error` mas não tem banner de erro visível (`getDRE` já lançava no mesmo `Promise.all`). Banner = decisão de UX futura.
- Follow-up spawnado: `getCapitalDeGiro` + `getTopInadimplentes` têm o MESMO cap 1000 (precisam paginar a busca de **linhas**, não só somas).

🤖 Generated with [Claude Code](https://claude.com/claude-code)