### PR TITLE
perf(venda): Onda 2 — catálogo do wizard em cache + seleção de cliente sem esperar escrita no Omie (#14+#15)

### DIFF
--- a/src/hooks/unifiedOrder/__tests__/ensure-helpers.test.ts
+++ b/src/hooks/unifiedOrder/__tests__/ensure-helpers.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { deveCriarClienteNaConta } from '@/hooks/unifiedOrder/ensure-helpers';
+
+describe('deveCriarClienteNaConta (tri-state do auto-cadastro)', () => {
+  it('cria quando ausência foi CONFIRMADA (lookup ok, sem código, com documento)', () => {
+    expect(
+      deveCriarClienteNaConta({ codigoExistente: null, temDocumento: true, lookupFalhou: false }),
+    ).toBe(true);
+  });
+
+  it('NÃO cria quando o código já existe (found)', () => {
+    expect(
+      deveCriarClienteNaConta({ codigoExistente: 12345, temDocumento: true, lookupFalhou: false }),
+    ).toBe(false);
+  });
+
+  it('NÃO cria quando o lookup FALHOU — ausência não confirmada (anti-duplicação no Omie)', () => {
+    expect(
+      deveCriarClienteNaConta({ codigoExistente: null, temDocumento: true, lookupFalhou: true }),
+    ).toBe(false);
+  });
+
+  it('NÃO cria sem documento (não há como cadastrar)', () => {
+    expect(
+      deveCriarClienteNaConta({ codigoExistente: null, temDocumento: false, lookupFalhou: false }),
+    ).toBe(false);
+  });
+
+  it('undefined conta como não-resolvido (mesma semântica do !codigo original)', () => {
+    expect(
+      deveCriarClienteNaConta({
+        codigoExistente: undefined,
+        temDocumento: true,
+        lookupFalhou: false,
+      }),
+    ).toBe(true);
+  });
+});

--- a/src/hooks/unifiedOrder/__tests__/useProductCatalog.cache.test.tsx
+++ b/src/hooks/unifiedOrder/__tests__/useProductCatalog.cache.test.tsx
@@ -1,0 +1,172 @@
+/**
+ * Testes de comportamento do #14 (Onda 2): catálogo do wizard em React Query.
+ * Travam os 3 contratos da otimização:
+ *  1. reabrir o wizard dentro da janela de staleTime NÃO re-baixa o catálogo
+ *     (a versão useState re-baixava ~8 páginas × 2 contas por mount);
+ *  2. cold-start: catálogo local vazio dispara o sync paginado via edge e
+ *     re-busca;
+ *  3. o sync de estoque roda no máximo 1× por conta por janela POR SESSÃO
+ *     (a versão anterior invocava sync_estoque no Omie a cada abertura).
+ *
+ * vi.resetModules + dynamic import por teste: o módulo guarda estado de
+ * sessão (queue/janela do stock sync) de propósito — cada teste começa limpo
+ * via __resetCatalogSessionStateForTests.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+
+/* ─── Mock do supabase: catálogo (responder configurável) + edge functions ─── */
+type ProductRow = Record<string, unknown>;
+const state: {
+  responder: () => ProductRow[];
+  catalogFetches: number;
+  invokes: Array<{ action: string; account: string }>;
+} = { responder: () => [], catalogFetches: 0, invokes: [] };
+
+vi.mock('@/integrations/supabase/client', () => {
+  const builder = () => {
+    const b = {
+      select: () => b,
+      eq: () => b,
+      or: () => b,
+      not: () => b,
+      order: () => b,
+      range: (_from: number, _to: number) => {
+        state.catalogFetches += 1;
+        return Promise.resolve({ data: state.responder(), error: null });
+      },
+    };
+    return b;
+  };
+  return {
+    supabase: {
+      from: () => builder(),
+      functions: {
+        invoke: (_fn: string, opts: { body: { action: string; account: string } }) => {
+          state.invokes.push({ action: opts.body.action, account: opts.body.account });
+          // 1 página e termina (nextPage null)
+          return Promise.resolve({ data: { nextPage: null }, error: null });
+        },
+      },
+    },
+  };
+});
+
+const PRODUTO: ProductRow = {
+  id: 'p1',
+  codigo: 'PRD1',
+  descricao: 'Produto 1',
+  unidade: 'UN',
+  valor_unitario: 10,
+  estoque: 5,
+  ativo: true,
+  omie_codigo_produto: 111,
+  account: 'oben',
+  is_tintometric: false,
+  tint_type: null,
+  metadata: null,
+  tipo_produto: null,
+};
+
+const OPTS = {
+  enabled: true,
+  customerPricesOben: {},
+  customerPricesColacor: {},
+  customerPurchaseHistory: {},
+};
+
+function makeWrapper(client: QueryClient) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+  };
+}
+
+async function importFresh() {
+  vi.resetModules();
+  const mod = await import('@/hooks/unifiedOrder/useProductCatalog');
+  mod.__resetCatalogSessionStateForTests();
+  return mod;
+}
+
+describe('useProductCatalog (#14 — cache React Query)', () => {
+  beforeEach(() => {
+    state.responder = () => [PRODUTO];
+    state.catalogFetches = 0;
+    state.invokes = [];
+  });
+
+  it('reabrir o wizard dentro da janela usa o CACHE (remount não re-baixa o catálogo)', async () => {
+    const { useProductCatalog } = await importFresh();
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const wrapper = makeWrapper(client);
+
+    const first = renderHook(() => useProductCatalog(OPTS), { wrapper });
+    await waitFor(() => expect(first.result.current.loadingObenProducts).toBe(false));
+    expect(first.result.current.obenProducts.length).toBe(1);
+    first.unmount();
+
+    // Espera o background stock sync (1×/conta) drenar pra contagem ficar estável.
+    await waitFor(() => {
+      expect(state.invokes.filter((i) => i.action === 'sync_estoque').length).toBe(2);
+    });
+    const fetchesAntesDoRemount = state.catalogFetches;
+
+    // Remount (mesma sessão/QueryClient): catálogo fresco no cache → zero fetch.
+    const second = renderHook(() => useProductCatalog(OPTS), { wrapper });
+    await waitFor(() => expect(second.result.current.loadingObenProducts).toBe(false));
+    expect(second.result.current.obenProducts.length).toBe(1);
+    expect(state.catalogFetches).toBe(fetchesAntesDoRemount);
+    second.unmount();
+  });
+
+  it('cold-start: catálogo local vazio dispara sync_products e re-busca', async () => {
+    const { useProductCatalog } = await importFresh();
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+    // 1º fetch de cada conta devolve vazio; após o sync, devolve o produto.
+    let fetches = 0;
+    state.responder = () => {
+      fetches += 1;
+      return fetches <= 2 ? [] : [PRODUTO]; // 2 contas × 1º fetch vazio
+    };
+
+    const { result, unmount } = renderHook(() => useProductCatalog(OPTS), {
+      wrapper: makeWrapper(client),
+    });
+    await waitFor(() => expect(result.current.loadingObenProducts).toBe(false), {
+      timeout: 4000,
+    });
+
+    expect(state.invokes.some((i) => i.action === 'sync_products')).toBe(true);
+    expect(result.current.obenProducts.length).toBe(1);
+    unmount();
+  });
+
+  it('sync de estoque roda no máximo 1×/conta por janela, mesmo com N remounts', async () => {
+    const { useProductCatalog } = await importFresh();
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const wrapper = makeWrapper(client);
+
+    const a = renderHook(() => useProductCatalog(OPTS), { wrapper });
+    await waitFor(() => expect(a.result.current.loadingObenProducts).toBe(false));
+    a.unmount();
+    const b = renderHook(() => useProductCatalog(OPTS), { wrapper });
+    await waitFor(() => expect(b.result.current.loadingObenProducts).toBe(false));
+    b.unmount();
+
+    // Aguarda a queue do background sync drenar.
+    await waitFor(() => {
+      expect(state.invokes.filter((i) => i.action === 'sync_estoque').length).toBeGreaterThan(0);
+    });
+    const syncsOben = state.invokes.filter(
+      (i) => i.action === 'sync_estoque' && i.account === 'oben',
+    );
+    const syncsColacor = state.invokes.filter(
+      (i) => i.action === 'sync_estoque' && i.account === 'colacor',
+    );
+    expect(syncsOben.length).toBe(1);
+    expect(syncsColacor.length).toBe(1);
+  });
+});

--- a/src/hooks/unifiedOrder/ensure-helpers.ts
+++ b/src/hooks/unifiedOrder/ensure-helpers.ts
@@ -1,0 +1,38 @@
+/**
+ * Tri-state do auto-cadastro de cliente por conta Omie (spec
+ * 2026-06-06-preco-realtime-selectCustomer — Etapas 2b/3).
+ *
+ * O lookup de cliente por conta tem TRÊS desfechos, não dois:
+ *   found  → código preenchido → não criar;
+ *   absent → lookup respondeu "não existe" → criar;
+ *   error  → o lookup FALHOU → ausência NÃO confirmada → NÃO criar às cegas
+ *            (criar em cima de falha de leitura duplicaria no Omie um cliente
+ *            que já existe). Nesse caso o preflight fail-closed do submit
+ *            bloqueia a conta, se usada — com mensagem acionável.
+ *
+ * ⚠️ Limite conhecido (Etapa 2b pendente): este guard cobre falha do INVOKE
+ * (rede, 5xx, throw). O edge `buscar_cliente` ainda MASCARA erro transitório/
+ * rate-limit esgotado como `{ success: true, cliente: null }` — que daqui
+ * parece "absent". Fechar esse canal exige o `throwOnTransient` do edge
+ * (Etapa 2b do spec, aguardando deploy); até lá o re-check de existência do
+ * próprio `criar_cliente` é o mitigante.
+ */
+export interface EnsureContaInput {
+  /** Código do cliente naquela conta (null/undefined = não resolvido). */
+  codigoExistente: number | null | undefined;
+  /** Cliente tem CNPJ/CPF (sem documento não há como cadastrar). */
+  temDocumento: boolean;
+  /** O lookup daquela conta FALHOU (erro/reject — ausência não confirmada). */
+  lookupFalhou: boolean;
+}
+
+export function deveCriarClienteNaConta({
+  codigoExistente,
+  temDocumento,
+  lookupFalhou,
+}: EnsureContaInput): boolean {
+  if (codigoExistente) return false;
+  if (!temDocumento) return false;
+  if (lookupFalhou) return false;
+  return true;
+}

--- a/src/hooks/unifiedOrder/useCustomerSelection.ts
+++ b/src/hooks/unifiedOrder/useCustomerSelection.ts
@@ -5,6 +5,7 @@ import { toast } from 'sonner';
 import { logger } from '@/lib/logger';
 import { maskDocument } from '@/lib/format';
 import { eqText, orFilter } from '@/lib/postgrest';
+import { deveCriarClienteNaConta } from './ensure-helpers';
 import type {
   OmieCustomer,
   AddressData,
@@ -59,6 +60,22 @@ export function useCustomerSelection({
      usuário troca de cliente no meio (corrida A→B). Cada selectCustomer
      incrementa o token; awaits que voltam com token vencido não setam estado. */
   const selectionTokenRef = useRef(0);
+
+  /* Promise RETIDA do auto-cadastro em background (Etapa 3 do spec
+     preco-realtime): a seleção dispara o ensure SEM esperar (o spinner do
+     cliente não paga mais ~2-4s de WRITE no Omie) e o submit faz JOIN nela
+     via waitForAccountEnsure — recebendo o cliente PÓS-ensure (a closure de
+     selectedCustomer pode ser a cópia anterior aos códigos criados). O
+     preflight fail-closed do submit (Etapa 2a) segue como rede.
+     TOKEN-STAMP (revisão adversarial): a retenção carrega o token da seleção
+     que a criou — o join só devolve o cliente se ele ainda é a seleção
+     CORRENTE. Identidade por documento NÃO serve de guard aqui: existem
+     duplicatas mesmo-CNPJ em prod (plantadas pelo bug histórico de
+     auto-criação) e o AI-flow monta cliente com documento vazio. */
+  const ensureAccountsRef = useRef<{ token: number; promise: Promise<OmieCustomer | null> }>({
+    token: 0,
+    promise: Promise.resolve(null),
+  });
 
   /* ─── State ─── */
   const [customerSearch, setCustomerSearch] = useState('');
@@ -250,8 +267,14 @@ export function useCustomerSelection({
     return localUserId;
   }, []);
 
-  /** Auto-create customer in Colacor and Afiação if missing. Mutates `cust` in place. */
-  const autoCreateInMissingAccounts = useCallback(async (cust: OmieCustomer) => {
+  /** Auto-create customer in Colacor and Afiação if missing. Mutates `cust` in place.
+   *  Tri-state (deveCriarClienteNaConta): conta cujo LOOKUP falhou NÃO cria às
+   *  cegas — ausência não confirmada; criar em cima de erro de leitura
+   *  duplicaria no Omie um cliente que já existe. */
+  const autoCreateInMissingAccounts = useCallback(async (
+    cust: OmieCustomer,
+    lookupFailed: { colacor: boolean; afiacao: boolean },
+  ) => {
     const customerPayload = {
       document: cust.cnpj_cpf,
       razao_social: cust.razao_social,
@@ -268,7 +291,13 @@ export function useCustomerSelection({
 
     const promises: Promise<unknown>[] = [];
 
-    if (!cust.codigo_cliente_colacor && cust.cnpj_cpf) {
+    if (
+      deveCriarClienteNaConta({
+        codigoExistente: cust.codigo_cliente_colacor,
+        temDocumento: !!cust.cnpj_cpf,
+        lookupFalhou: lookupFailed.colacor,
+      })
+    ) {
       promises.push(
         supabase.functions.invoke('omie-vendas-sync', {
           body: { action: 'criar_cliente', account: 'colacor', ...customerPayload },
@@ -290,7 +319,13 @@ export function useCustomerSelection({
       );
     }
 
-    if (!cust.codigo_cliente_afiacao && cust.cnpj_cpf) {
+    if (
+      deveCriarClienteNaConta({
+        codigoExistente: cust.codigo_cliente_afiacao,
+        temDocumento: !!cust.cnpj_cpf,
+        lookupFalhou: lookupFailed.afiacao,
+      })
+    ) {
       promises.push(
         supabase.functions.invoke('omie-sync', {
           body: { action: 'criar_cliente_afiacao', ...customerPayload },
@@ -348,6 +383,12 @@ export function useCustomerSelection({
     // atrasadas desta chamada são descartadas (não sobrescrevem o cliente novo).
     const myToken = ++selectionTokenRef.current;
     const isStale = () => selectionTokenRef.current !== myToken;
+
+    // Fecha a janela da seleção ANTERIOR: até esta seleção reter o próprio
+    // ensure (após os lookups, ~1-10s), o join do submit NÃO pode devolver o
+    // ensure do cliente antigo — devolve null e o submit usa o preflight
+    // fail-closed como rede.
+    ensureAccountsRef.current = { token: myToken, promise: Promise.resolve(null) };
 
     setLoadingCustomer(true);
     setCustomerSearch('');
@@ -419,6 +460,11 @@ export function useCustomerSelection({
         'cliente Afiação',
       ];
       const failedParts: string[] = [];
+      // Índices falhos registrados À PARTE dos labels: o tri-state do
+      // auto-cadastro deriva DAQUI (por posição no allSettled), não das
+      // strings de log — renomear um label não pode desarmar o guard
+      // anti-duplicação silenciosamente (revisão adversarial).
+      const failedIdxs = new Set<number>();
       const getResult = <T = unknown>(idx: number): FunctionInvokeResult<T> => {
         const r = settledResults[idx];
         if (r.status === 'fulfilled') {
@@ -432,6 +478,7 @@ export function useCustomerSelection({
               error: val.error,
             });
             failedParts.push(labels[idx]);
+            failedIdxs.add(idx);
             return { data: null };
           }
           return val ?? { data: null };
@@ -444,6 +491,7 @@ export function useCustomerSelection({
           error: r.reason,
         });
         failedParts.push(labels[idx]);
+        failedIdxs.add(idx);
         return { data: null };
       };
 
@@ -512,13 +560,38 @@ export function useCustomerSelection({
         }).catch(() => {});
       }
 
-      // Auto-cadastro nas contas faltantes roda DEPOIS do preço já visível.
-      // Mantido awaited por ora; a Etapa 2/3 (ver spec) troca por ensure idempotente
-      // + join no submit. Conclusão atrasada não sobrescreve um cliente novo (guard).
-      await autoCreateInMissingAccounts(cust);
-      if (isStale()) return;
-      // Reflete códigos recém-criados pelo auto-cadastro (purchase-history reage à key).
-      setSelectedCustomer({ ...cust });
+      // ── Etapa 3 (spec preco-realtime): auto-cadastro em BACKGROUND ──
+      // A promise fica retida em ensureAccountsRef e o submit faz join nela —
+      // a seleção não espera mais o WRITE no Omie (~2-4s no caminho do
+      // spinner). Tri-state: conta cujo lookup FALHOU não cria às cegas (o
+      // preflight fail-closed do submit bloqueia a conta, se usada).
+      // Índices 3/4 = posições dos lookups de cliente no Promise.allSettled acima.
+      const LOOKUP_IDX_CLIENTE_COLACOR = 3;
+      const LOOKUP_IDX_CLIENTE_AFIACAO = 4;
+      const lookupFailed = {
+        colacor: failedIdxs.has(LOOKUP_IDX_CLIENTE_COLACOR),
+        afiacao: failedIdxs.has(LOOKUP_IDX_CLIENTE_AFIACAO),
+      };
+      ensureAccountsRef.current = {
+        token: myToken,
+        promise: autoCreateInMissingAccounts(cust, lookupFailed)
+          .then(() => {
+            // Reflete códigos recém-criados (purchase-history reage à key);
+            // conclusão atrasada de cliente trocado não sobrescreve (guard).
+            if (!isStale()) setSelectedCustomer({ ...cust });
+            return cust;
+          })
+          .catch((e) => {
+            // autoCreate já isola falhas por conta; este catch é só pra ref
+            // nunca rejeitar sem handler (o join do submit trata null).
+            logger.warn('Ensure de cadastro em background falhou', {
+              stage: 'ensure_accounts_background',
+              customerCnpjCpf: maskDocument(cust.cnpj_cpf),
+              error: e,
+            });
+            return cust;
+          }),
+      };
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Erro desconhecido';
       if (!isStale()) toast.error('Erro', { description: message });
@@ -554,11 +627,22 @@ export function useCustomerSelection({
     onLocalUserResolved, reloadPriceHistory,
   ]);
 
+  /** Join da Etapa 3: o submit espera o ensure em background terminar e
+   *  recebe o cliente com os códigos por-conta atualizados — SÓ se a retenção
+   *  ainda é da seleção corrente (token-stamp); senão null (e o preflight
+   *  fail-closed do submit cobre). */
+  const waitForAccountEnsure = useCallback(async (): Promise<OmieCustomer | null> => {
+    const retained = ensureAccountsRef.current;
+    const cliente = await retained.promise;
+    return retained.token === selectionTokenRef.current ? cliente : null;
+  }, []);
+
   const clearCustomer = useCallback(() => {
     // Invalida qualquer selectCustomer em voo: suas conclusões viram stale e não
     // ressuscitam o cliente que estamos limpando. Como o finally da seleção pula
     // o setLoadingCustomer(false) quando stale, zeramos os flags de loading aqui.
     selectionTokenRef.current++;
+    ensureAccountsRef.current = { token: selectionTokenRef.current, promise: Promise.resolve(null) };
     setSelectedCustomer(null);
     setLoadingCustomer(false);
     setValidatingVendedor(false);
@@ -603,6 +687,6 @@ export function useCustomerSelection({
     // Vendedor
     vendedorDivergencias, validatingVendedor,
     // Actions
-    selectCustomer, clearCustomer,
+    selectCustomer, clearCustomer, waitForAccountEnsure,
   };
 }

--- a/src/hooks/unifiedOrder/useProductCatalog.ts
+++ b/src/hooks/unifiedOrder/useProductCatalog.ts
@@ -1,4 +1,5 @@
-import { useState, useEffect, useCallback, useMemo, useRef, useDeferredValue } from 'react';
+import { useState, useEffect, useCallback, useMemo, useDeferredValue } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
 import { logger } from '@/lib/logger';
 import { buildExclusionQuery } from './types';
@@ -7,6 +8,33 @@ import type { Product, ProductAccount } from './types';
 
 const PRODUCT_COLUMNS =
   'id, codigo, descricao, unidade, valor_unitario, estoque, ativo, omie_codigo_produto, account, is_tintometric, tint_type, metadata, tipo_produto';
+
+/**
+ * Catálogo em cache React Query por 10min: reabrir o wizard dentro da janela
+ * = ZERO requests (a versão anterior, useState+useEffect, re-baixava ~8
+ * páginas × 2 contas A CADA abertura de /sales/new e ainda disparava o sync
+ * de estoque no Omie por mount). O estoque exibido é indicativo — atualizado
+ * pelo sync em background abaixo (1×/janela) e pelos crons server-side.
+ */
+const CATALOG_STALE_MS = 10 * 60_000;
+const CATALOG_GC_MS = 30 * 60_000;
+/** Janela do sync de estoque por conta: 1× a cada 10min por sessão. */
+const STOCK_SYNC_WINDOW_MS = 10 * 60_000;
+
+const catalogKey = (account: ProductAccount) => ['product-catalog', account] as const;
+
+/* Module-level DE PROPÓSITO (sobrevivem a remounts do wizard na mesma sessão):
+   a queue serializa o sync de estoque entre as contas (rate limit do Omie) e
+   o timestamp por conta impede martelar o sync a cada mount. */
+let stockSyncQueue: Promise<void> = Promise.resolve();
+const lastStockSyncAt: Partial<Record<ProductAccount, number>> = {};
+
+/** test-only: zera o estado de sessão do sync (queue + janela por conta). */
+export function __resetCatalogSessionStateForTests(): void {
+  stockSyncQueue = Promise.resolve();
+  delete lastStockSyncAt.oben;
+  delete lastStockSyncAt.colacor;
+}
 
 interface UseProductCatalogOptions {
   /** Só carrega o catálogo quando true (typically `isStaff`). */
@@ -38,10 +66,80 @@ async function fetchProductsForAccount(account: ProductAccount): Promise<Product
 }
 
 /**
+ * Carga com cold-start: catálogo local vazio → roda o sync paginado completo
+ * via edge function e re-busca (1ª vez numa instalação nova). Vazio PÓS-sync
+ * LANÇA — não cachear catálogo vazio como sucesso (a query fica em erro e o
+ * próximo mount re-tenta, como a versão useState fazia por remount).
+ */
+async function loadCatalogWithColdStart(account: ProductAccount): Promise<Product[]> {
+  let products = await fetchProductsForAccount(account);
+
+  if (products.length === 0) {
+    let nextPage: number | null = 1;
+    while (nextPage) {
+      const syncRes: { data: unknown; error: unknown } = await supabase.functions.invoke(
+        'omie-vendas-sync',
+        { body: { action: 'sync_products', start_page: nextPage, account } },
+      );
+      if (syncRes.error) throw syncRes.error;
+      nextPage = (syncRes.data as { nextPage?: number | null } | null)?.nextPage ?? null;
+    }
+    products = await fetchProductsForAccount(account);
+    if (products.length === 0) {
+      throw new Error(`Catálogo ${account} vazio mesmo após sync de produtos`);
+    }
+  }
+
+  return products;
+}
+
+/**
+ * Sincroniza o estoque da conta no Omie em background, no máximo 1× por
+ * janela (por sessão), e publica o catálogo re-baixado via `publishFresh`
+ * (→ setQueryData — atualiza o cache sem refetch extra dos consumidores).
+ */
+function scheduleStockSyncOnce(
+  account: ProductAccount,
+  publishFresh: (products: Product[]) => void,
+): void {
+  const last = lastStockSyncAt[account] ?? 0;
+  if (Date.now() - last < STOCK_SYNC_WINDOW_MS) return;
+  // Claim ANTES de entrar na queue: dois mounts concorrentes não duplicam o sync.
+  lastStockSyncAt[account] = Date.now();
+  stockSyncQueue = stockSyncQueue.then(async () => {
+    try {
+      let nextPage: number | null = 1;
+      while (nextPage) {
+        const result: { data: unknown; error: unknown } = await supabase.functions.invoke(
+          'omie-vendas-sync',
+          { body: { action: 'sync_estoque', start_page: nextPage, account } },
+        );
+        if (result.error) break;
+        nextPage = (result.data as { nextPage?: number | null } | null)?.nextPage ?? null;
+      }
+      const refreshed = await fetchProductsForAccount(account);
+      if (refreshed.length > 0) publishFresh(refreshed);
+    } catch (e) {
+      // Falhou → libera a janela pra próxima abertura re-tentar.
+      lastStockSyncAt[account] = 0;
+      logger.error('Background stock sync error', {
+        account,
+        stage: 'background_stock_sync',
+        error: e,
+      });
+    }
+  });
+}
+
+/** Referência estável pro estado "sem dados" (não dispara re-rank por identidade). */
+const EMPTY_PRODUCTS: Product[] = [];
+
+/**
  * Encapsula o catálogo de produtos (Oben + Colacor):
- * - Carregamento inicial via Supabase (com fallback de sync via edge function)
- * - Sincronização de estoque em background (queue serializada compartilhada
- *   entre as duas contas para não estourar rate limit do Omie)
+ * - Carregamento via React Query (cache 10min entre aberturas do wizard) com
+ *   fallback de cold-start via edge function
+ * - Sincronização de estoque em background (1×/janela; queue serializada
+ *   compartilhada entre as duas contas para não estourar rate limit do Omie)
  * - Filtros + ordenação memoizados (priorizando produtos previamente comprados)
  */
 export function useProductCatalog({
@@ -50,92 +148,51 @@ export function useProductCatalog({
   customerPricesColacor,
   customerPurchaseHistory,
 }: UseProductCatalogOptions) {
-  const [obenProducts, setObenProducts] = useState<Product[]>([]);
-  const [colacorProducts, setColacorProducts] = useState<Product[]>([]);
-  const [loadingObenProducts, setLoadingObenProducts] = useState(true);
-  const [loadingColacorProducts, setLoadingColacorProducts] = useState(true);
+  const queryClient = useQueryClient();
   const [productSearch, setProductSearch] = useState('');
 
-  // Queue compartilhada: ambas as contas usam a mesma chain para evitar rate limit no Omie.
-  const stockSyncQueue = useRef<Promise<void>>(Promise.resolve());
+  const obenQuery = useQuery({
+    queryKey: catalogKey('oben'),
+    queryFn: () => loadCatalogWithColdStart('oben'),
+    enabled,
+    staleTime: CATALOG_STALE_MS,
+    gcTime: CATALOG_GC_MS,
+    retry: 1, // o cold-start embute um sync caro — 1 retry basta (mount seguinte re-tenta)
+  });
 
-  const syncStockInBackground = useCallback(
-    (account: ProductAccount, setProds: React.Dispatch<React.SetStateAction<Product[]>>) => {
-      stockSyncQueue.current = stockSyncQueue.current.then(async () => {
-        try {
-          let nextPage: number | null = 1;
-          while (nextPage) {
-            const result: { data: unknown; error: unknown } = await supabase.functions.invoke('omie-vendas-sync', {
-              body: { action: 'sync_estoque', start_page: nextPage, account },
-            });
-            if (result.error) break;
-            nextPage = (result.data as { nextPage?: number | null } | null)?.nextPage ?? null;
-          }
-          const refreshed = await fetchProductsForAccount(account);
-          if (refreshed.length > 0) setProds(refreshed);
-        } catch (e) {
-          logger.error('Background stock sync error', {
-            account,
-            stage: 'background_stock_sync',
-            error: e,
-          });
-        }
-      });
-    },
-    [],
-  );
+  const colacorQuery = useQuery({
+    queryKey: catalogKey('colacor'),
+    queryFn: () => loadCatalogWithColdStart('colacor'),
+    enabled,
+    staleTime: CATALOG_STALE_MS,
+    gcTime: CATALOG_GC_MS,
+    retry: 1,
+  });
 
+  const obenProducts = obenQuery.data ?? EMPTY_PRODUCTS;
+  const colacorProducts = colacorQuery.data ?? EMPTY_PRODUCTS;
+
+  // Sync de estoque em background quando o catálogo da conta resolve.
+  // A janela (module-level) garante 1×/10min mesmo com N aberturas do wizard.
+  useEffect(() => {
+    if (!enabled || !obenQuery.isSuccess) return;
+    scheduleStockSyncOnce('oben', (fresh) => queryClient.setQueryData(catalogKey('oben'), fresh));
+  }, [enabled, obenQuery.isSuccess, queryClient]);
+
+  useEffect(() => {
+    if (!enabled || !colacorQuery.isSuccess) return;
+    scheduleStockSyncOnce('colacor', (fresh) =>
+      queryClient.setQueryData(catalogKey('colacor'), fresh),
+    );
+  }, [enabled, colacorQuery.isSuccess, queryClient]);
+
+  // Reload manual (exposto p/ edge cases — era o loadProductsForAccount imperativo).
   const loadProductsForAccount = useCallback(
     async (account: ProductAccount) => {
-      const setLoading = account === 'oben' ? setLoadingObenProducts : setLoadingColacorProducts;
-      const setProds = account === 'oben' ? setObenProducts : setColacorProducts;
-      setLoading(true);
-      try {
-        let products = await fetchProductsForAccount(account);
-
-        // Catálogo vazio → dispara sync paginado completo via edge function
-        if (products.length === 0) {
-          try {
-            let nextPage: number | null = 1;
-            while (nextPage) {
-              const syncRes: { data: unknown; error: unknown } = await supabase.functions.invoke(
-                'omie-vendas-sync',
-                { body: { action: 'sync_products', start_page: nextPage, account } },
-              );
-              if (syncRes.error) throw syncRes.error;
-              nextPage = (syncRes.data as { nextPage?: number | null } | null)?.nextPage ?? null;
-            }
-            products = await fetchProductsForAccount(account);
-          } catch (syncErr) {
-            logger.error('Catalog sync error (empty catalog fallback)', {
-              account,
-              stage: 'fallback_sync',
-              error: syncErr,
-            });
-          }
-        }
-
-        setProds(products);
-        syncStockInBackground(account, setProds);
-      } catch (e) {
-        logger.error('loadProductsForAccount failed', {
-          account,
-          stage: 'initial_load',
-          error: e,
-        });
-      } finally {
-        setLoading(false);
-      }
+      await queryClient.refetchQueries({ queryKey: catalogKey(account) });
     },
-    [syncStockInBackground],
+    [queryClient],
   );
-
-  // Bootstrap: carrega ambas as contas em paralelo (mas estoque é serializado pela queue).
-  useEffect(() => {
-    if (!enabled) return;
-    loadProductsForAccount('oben');
-    loadProductsForAccount('colacor');
-  }, [enabled, loadProductsForAccount]);
 
   /**
    * Um produto é "previamente comprado" se há preço específico do cliente
@@ -181,6 +238,8 @@ export function useProductCatalog({
   // ~4,2k Colacor, com localeCompare + lookups de "comprado antes" por
   // comparação) dentro dos dois memos de filtro: era o custo dominante da
   // busca do wizard, sentido como tranco no celular do vendedor externo.
+  // Com o React Query, refetch que devolve dado igual preserva a referência
+  // (structural sharing) → o rank nem re-executa.
   const rankedObenProducts = useMemo(() => {
     const shouldPrioritize =
       Object.keys(customerPricesOben).length > 0 || Object.keys(customerPurchaseHistory).length > 0;
@@ -215,8 +274,10 @@ export function useProductCatalog({
     // State
     obenProducts,
     colacorProducts,
-    loadingObenProducts,
-    loadingColacorProducts,
+    // isPending preserva a semântica da versão useState: loading inicia true e,
+    // com enabled=false, permanece true (o original nunca chegava ao finally).
+    loadingObenProducts: obenQuery.isPending,
+    loadingColacorProducts: colacorQuery.isPending,
     productSearch,
     setProductSearch,
     // Derived

--- a/src/hooks/useUnifiedOrder.ts
+++ b/src/hooks/useUnifiedOrder.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
@@ -161,6 +161,10 @@ export function useUnifiedOrder() {
   // Cart state lives in useCart hook (declared after pricing helpers below)
   const [notes, setNotes] = useState('');
   const [submitting, setSubmitting] = useState(false);
+  // Guard re-entrante do submit por REF (não state): double-tap entre o clique
+  // e o re-render do disabled veria a MESMA closure com submitting=false e
+  // dispararia 2 fluxos completos (= 2 PVs cobrados no Omie).
+  const submittingRef = useRef(false);
   // activeTab moved into useCart hook below
   const [readyByDate, setReadyByDate] = useState<string>('');
   const [defaultProductionAssigneeId, setDefaultProductionAssigneeId] = useState<string | null>(null);
@@ -206,6 +210,7 @@ export function useUnifiedOrder() {
     customerPurchaseHistory,
     vendedorDivergencias, validatingVendedor,
     selectCustomer, clearCustomer: clearCustomerInternal,
+    waitForAccountEnsure,
   } = customerSel;
 
   // User tools (afiação) — react-query, 2min stale; auto-loads quando customerUserId muda
@@ -629,10 +634,21 @@ export function useUnifiedOrder() {
 
   const submitOrder = useCallback(async () => {
     if (!selectedCustomer || cart.length === 0 || !user) return;
+    if (submittingRef.current) return; // re-entrância: ver comentário na declaração
+    submittingRef.current = true;
     setSubmitting(true);
     try {
+      // Etapa 3 (spec preco-realtime): a seleção dispara o auto-cadastro em
+      // BACKGROUND; o join é AQUI — garante os códigos por-conta antes do
+      // envio, sem segurar o spinner da seleção. O retorno é o cliente
+      // PÓS-ensure DA SELEÇÃO CORRENTE (token-stamp; null se a retenção é de
+      // outra seleção) — a closure de selectedCustomer pode ser a cópia
+      // anterior aos códigos criados. O preflight fail-closed do
+      // submitOrderService segue como rede pra conta sem identidade.
+      const ensuredCustomer = await waitForAccountEnsure();
+      const effectiveCustomer = ensuredCustomer ?? selectedCustomer;
       const result = await submitOrderService({
-        customer: selectedCustomer,
+        customer: effectiveCustomer,
         customerUserId,
         user,
         cart: { obenProductItems, colacorProductItems, serviceItems },
@@ -674,6 +690,7 @@ export function useUnifiedOrder() {
     } catch (error) {
       toast.error('Erro ao criar pedido', { description: error instanceof Error ? error.message : String(error) });
     } finally {
+      submittingRef.current = false;
       setSubmitting(false);
     }
   }, [
@@ -687,6 +704,7 @@ export function useUnifiedOrder() {
     notes, readyByDate, ordemCompra,
     companyProfiles, defaultProductionAssigneeId,
     getServicePrice, clearCart, isCustomerMode,
+    waitForAccountEnsure,
   ]);
 
   // clearCustomer defined earlier (wraps useCustomerSelection.clearCustomer + clears cart/ordemCompra/userTools)


### PR DESCRIPTION
## O que é (Onda 2 da auditoria de 2026-06-09 — wizard de pedido, money-path)

### #14 — Catálogo em cache (maior ganho percebido da vendedora)
O catálogo era `useState`+`useEffect`: **cada abertura de `/sales/new` re-baixava ~7.900 produtos × 2 contas (~16 requests) e disparava o sync de estoque no Omie em loop**. Quem faz 10 pedidos/dia pagava 10×. Agora:
- React Query com `staleTime` 10min / `gcTime` 30min → reabrir o wizard dentro da janela = **zero requests** (abre instantâneo).
- Sync de estoque em background **1×/conta por janela de 10min por sessão** (claim module-level; queue serializada anti-rate-limit preservada), publicando o catálogo fresco via `setQueryData`.
- Cold-start preservado (catálogo vazio → sync paginado via edge → re-busca; vazio pós-sync **lança** — nunca cacheia vazio como sucesso).
- O preço-cliente **não** vem do catálogo (vem do `sales_price_history`/customerPrices) — staleness de 10min afeta só preço de tabela/estoque indicativo (verificado na revisão).

### #15 — Etapa 3 do spec `2026-06-06-preco-realtime-selectCustomer`
O `selectCustomer` segurava o spinner esperando **2 edge functions de ESCRITA no Omie** (auto-cadastro nas contas faltantes, ~2-4s). Agora:
- Auto-cadastro vira **promise retida com token-stamp**; a seleção libera na hora.
- O `submitOrder` faz **join** (`waitForAccountEnsure`) e usa o cliente **pós-ensure da seleção corrente** (token divergente → null → o preflight fail-closed da Etapa 2a, já em prod, cobre).
- **Tri-state** novo (`deveCriarClienteNaConta`, testado): lookup da conta que **falhou** não cria às cegas — anti-duplicação de cliente no Omie. Derivado por índice do `allSettled`, não por string de label.
- Guard re-entrante de **double-submit por ref** (double-tap não dispara 2 PVs).

## Revisão adversarial (subagente, money-path)
3 P2 achados e **corrigidos neste PR**: janela entre seleções deixava o ensure do cliente anterior joinável (guard por CNPJ colidia em duplicatas mesmo-documento que existem em prod) → reset da ref no início da seleção + token-stamp; tri-state acoplado a label de log → índices; comentário prometia garantia da Etapa 2b → limite documentado. Verificados sem achado: clearCustomer durante ensure, ensure falhado → preflight bloqueia, modo customer, submitQuote (write local, sem join necessário), mutação in-place × structural sharing. Codex indisponível (cota) — adversarial retroativo anotado.

## Validação
- Testes novos: `ensure-helpers` (5) + `useProductCatalog.cache` (3 — cache entre remounts, cold-start, sync 1×/janela)
- `bun run typecheck` (strict) ✅ · `bun run test` **2951/2951** ✅ · `bun lint` 0 errors ✅
- Sem migration, sem deploy de edge (a Etapa 2b do spec — `throwOnTransient` no edge — segue pendente e documentada).

⚠️ Pós-merge: **Publish no Lovable**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)