### PR TITLE
fix(financeiro): getCapitalDeGiro e getTopInadimplentes truncados no cap 1000 — linhas paginadas (irmão do #719/#720)

### DIFF
--- a/docs/roadmap-sessao.md
+++ b/docs/roadmap-sessao.md
@@ -6,7 +6,23 @@
 
 ---
 
-## 0. SESSÃO 2026-06-10 — getResumoFinanceiro somava truncado no cap 1000 (irmão do #719)
+## 0. SESSÃO 2026-06-10 (2) — getCapitalDeGiro + getTopInadimplentes truncados no cap 1000 (fecha o follow-up do #720)
+
+> Sessão spawnada pelo chip de follow-up da seção abaixo: as duas funções restantes do
+> `financeiroService` com o MESMO bug dos #719/#720 — queries de linhas de CR/CP sem
+> `.range()` → PostgREST capa em 1000. Diferença: aqui as LINHAS individuais importam
+> (vencimento pra projeção 30d, nome_cliente/fornecedor pro top-5 e ranking) → não basta
+> delegar a `somarSaldoPorStatus`; precisa paginar a busca de linhas.
+
+- ✅ **Fix TDD (RED→GREEN provado)**: helper privado `buscarTodasPaginas` (loop `.range(from, from+999)` + `.order('id')` estável + erro LANÇA); `getCapitalDeGiro` pagina CR/CP (totais, capital de giro, top-5, projeção 30d íntegros; oben ~11k CR), `getTopInadimplentes` pagina o ranking de ATRASADO.
+- ✅ Aproveitados: literal `['A VENCER','ATRASADO','VENCE HOJE']` → `OPEN_TITLE_STATUSES`; `.eq('ATRASADO')` → `VENCIDO_TITLE_STATUSES`; soma por `saldo` (coluna gerada — bate com o resumo do #720); `data_emissao` removido do select (morto desde o #442).
+- ✅ Erro coerente (#720): CR/CP/CC lançam Error real (era R$0/[] silencioso); view de prazos segue degradando pra null ("—", acessório). `useFinanceiroCockpit` ganhou catch-por-fonte no inadimplentes; `usePosicaoAgora` já capturava → tela mostra "Sem dados" honesto.
+- ✅ Gate verde: typecheck 0 · 2975 testes (16 de contrato novos: mock-banco capa janelas em 1000 como o PostgREST real) · lint 0 errors. PR aberto (squash + auto-merge). Sem migration/edge; **vai ao ar no próximo Publish**.
+- ⏸️ **Codex adversarial retroativo** quando a cota voltar (11/06+) — caminho B aplicado (self-review adversarial + testes de contrato).
+
+---
+
+## 0a. SESSÃO 2026-06-10 — getResumoFinanceiro somava truncado no cap 1000 (irmão do #719)
 
 > Mesmo bug do PR #719 (KPIs de /financeiro/gestao), agora no `getResumoFinanceiro`
 > (financeiroService ~182-240, consumido pelo FinanceiroDashboard): somas de CR/CP
@@ -16,7 +32,7 @@
 - ✅ **Fix TDD**: variante paginada `somarSaldoPorStatus(tabela, company, statuses)`; `somarSaldoAberto` delega nela; `getResumoFinanceiro` usa as somas paginadas (padroniza em `saldo`, coluna gerada). RED provado por truncamento exato (2200→2000) antes do fix.
 - ✅ **/review (gstack)**: 2 specialists + adversarial Claude (codex em usage-limit até 11/06 9:24 — retroativo pendente). Achados incorporados: `.order('id')` na paginação (offset sem ORDER BY não é estável; sync grava */10), `throw new Error(...)` em vez de objeto cru (banner mostraria "[object Object]"), CC deixou de engolir erro, `useFinanceiroCockpit` isola o resumo com catch por fonte (sem isso o throw novo derrubava aging/DRE/inadimplentes junto), mock capa `.range()` em 1000 como o PostgREST real + testes de erro do orquestrador.
 - ✅ Gate verde: typecheck 0 · **2959 testes** (16 de contrato novos) · lint 0 errors. PR aberto (squash + auto-merge). Sem migration/edge; **vai ao ar no próximo Publish**.
-- ⏳ **Follow-up (chip spawnado)**: `getCapitalDeGiro` + `getTopInadimplentes` têm o MESMO cap 1000 (achado do specialist — capital_giro/top-5/projeção-30d truncados na oben); precisa paginar a busca de LINHAS (não só somas).
+- ✅ **Follow-up (chip spawnado)**: `getCapitalDeGiro` + `getTopInadimplentes` têm o MESMO cap 1000 (achado do specialist — capital_giro/top-5/projeção-30d truncados na oben); precisa paginar a busca de LINHAS (não só somas). → **ENTREGUE na seção 0 acima.**
 - ⏸️ **Codex adversarial retroativo** do PR quando a cota voltar (11/06+).
 - 📝 Limitação conhecida (nota no PR): o cockpit loga falha do resumo via `logger.warn` mas não tem banner de erro (pré-existente — `getDRE` já lançava no mesmo Promise.all); banner visível = decisão de UX futura.
 

--- a/src/components/financeiro/cockpit/useFinanceiroCockpit.ts
+++ b/src/components/financeiro/cockpit/useFinanceiroCockpit.ts
@@ -55,7 +55,12 @@ export function useFinanceiroCockpit() {
         }),
         getAgingReceber('all'),
         Promise.all(['oben', 'colacor', 'colacor_sc'].map(co => getDRE(co as Company, ano, undefined, regime))).then(r => r.flat()),
-        getTopInadimplentes('all', 5),
+        // getTopInadimplentes agora LANÇA em erro (era [] silencioso = falso
+        // "ninguém inadimplente"); catch por fonte pra não derrubar o resto.
+        getTopInadimplentes('all', 5).catch((e): InadimplenteRow[] => {
+          logger.warn('Top inadimplentes indisponível', { error: e instanceof Error ? e.message : String(e) });
+          return [];
+        }),
         // Projeção 13s + NCG consolidados via snapshot real da engine A1 (não a RPC ingênua)
         getProjecaoSnapshotsCockpit(EMPRESAS_COCKPIT).catch((e) => {
           logger.warn('Snapshots de projeção indisponíveis', { error: e instanceof Error ? e.message : String(e) });

--- a/src/services/__tests__/getCapitalDeGiro.test.ts
+++ b/src/services/__tests__/getCapitalDeGiro.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Teste de contrato do getCapitalDeGiro (tela Posição Agora em /financeiro).
+ * Irmão dos bugs #719/#720: as queries de CR/CP aberto não tinham .range() → o
+ * PostgREST capa em 1000 linhas (a oben tem ~11k CR abertos) e TUDO que deriva
+ * das linhas saía truncado: total_cr/cp_aberto, capital_giro, concentração
+ * top-5 e a projeção 30d (entradas/saidas_30d).
+ *
+ * O mock reproduz o comportamento REAL do PostgREST: query sem .range() devolve
+ * no máximo 1000 linhas; com .range(from, to) devolve a janela (capada em
+ * 1000). Seeds têm valor_documento/valor_recebido/valor_pago/saldo coerentes
+ * (saldo é coluna gerada), então os testes só falham por truncamento/filtro.
+ */
+
+type Row = Record<string, unknown>;
+
+const state: {
+  db: Record<string, Row[]>;
+  errors: Record<string, { message: string } | undefined>;
+} = { db: {}, errors: {} };
+
+function makeBuilder(tabela: string) {
+  const filters: Array<(r: Row) => boolean> = [];
+  let janela: { from: number; to: number } | null = null;
+  let single = false;
+  const builder = {
+    select: (_cols: string) => builder,
+    eq: (col: string, val: unknown) => {
+      filters.push((r) => r[col] === val);
+      return builder;
+    },
+    in: (col: string, vals: unknown[]) => {
+      filters.push((r) => vals.includes(r[col]));
+      return builder;
+    },
+    order: (_col: string) => builder,
+    range: (from: number, to: number) => {
+      janela = { from, to };
+      return builder;
+    },
+    maybeSingle: () => {
+      single = true;
+      return builder;
+    },
+    then: (
+      resolve: (v: { data: Row[] | Row | null; error: { message: string } | null }) => unknown,
+      reject?: (e: unknown) => unknown,
+    ) => {
+      const error = state.errors[tabela];
+      if (error) return Promise.resolve({ data: null, error }).then(resolve, reject);
+      const matched = (state.db[tabela] ?? []).filter((r) => filters.every((f) => f(r)));
+      // PostgREST real: max-rows de 1000 vale SEMPRE — sem range capa em 1000, e
+      // com range a janela nunca passa de 1000 linhas (um `.range(0, 99999)` NÃO
+      // fura o cap; só paginação de verdade soma tudo).
+      const rows = janela
+        ? matched.slice(janela.from, Math.min(janela.to + 1, janela.from + 1000))
+        : matched.slice(0, 1000);
+      const data = single ? (rows[0] ?? null) : rows;
+      return Promise.resolve({ data, error: null }).then(resolve, reject);
+    },
+  };
+  return builder;
+}
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: { from: (tabela: string) => makeBuilder(tabela) },
+}));
+
+import { getCapitalDeGiro } from '@/services/financeiroService';
+
+// Vencimentos relativos (mesmo cálculo UTC do serviço): dentro e fora da janela de 30d.
+const dentroDe30 = new Date(Date.now() + 5 * 86400000).toISOString().slice(0, 10);
+const foraDe30 = new Date(Date.now() + 60 * 86400000).toISOString().slice(0, 10);
+
+const cr = (company: string, saldo: number, venc: string | null, cliente = 'Cliente X'): Row => ({
+  company,
+  status_titulo: 'A VENCER',
+  saldo,
+  valor_documento: saldo,
+  valor_recebido: 0,
+  data_vencimento: venc,
+  nome_cliente: cliente,
+});
+
+const cp = (company: string, saldo: number, venc: string | null, fornecedor = 'Fornecedor X'): Row => ({
+  company,
+  status_titulo: 'A VENCER',
+  saldo,
+  valor_documento: saldo,
+  valor_pago: 0,
+  data_vencimento: venc,
+  nome_fornecedor: fornecedor,
+});
+
+const muitos = (n: number, make: (i: number) => Row): Row[] =>
+  Array.from({ length: n }, (_, i) => make(i));
+
+describe('getCapitalDeGiro (Posição Agora)', () => {
+  beforeEach(() => {
+    state.db = {
+      fin_contas_receber: [],
+      fin_contas_pagar: [],
+      fin_contas_correntes: [],
+      v_capital_giro_prazos: [],
+    };
+    state.errors = {};
+  });
+
+  it('soma TODOS os títulos abertos mesmo acima do cap de 1000 do PostgREST', async () => {
+    state.db.fin_contas_receber = muitos(2500, () => cr('oben', 10, foraDe30));
+    state.db.fin_contas_pagar = muitos(1200, () => cp('oben', 5, foraDe30));
+    state.db.fin_contas_correntes = [{ company: 'oben', ativo: true, saldo_atual: 1000 }];
+
+    const [giro] = await getCapitalDeGiro('oben');
+
+    expect(giro.total_cr_aberto).toBe(2500 * 10);
+    expect(giro.total_cp_aberto).toBe(1200 * 5);
+    expect(giro.capital_giro).toBe(2500 * 10 - 1200 * 5);
+    expect(giro.capital_giro_liquido).toBe(2500 * 10 + 1000 - 1200 * 5);
+    expect(giro.saldo_cc).toBe(1000);
+  });
+
+  it('concentração top-5 enxerga cliente/fornecedor concentrado além da 1ª página', async () => {
+    // 1000 títulos pulverizados (clientes distintos) na frente + o concentrado SÓ depois:
+    // truncado, o top-5 viraria 5/1000 = 0,5% em vez de ~91%.
+    state.db.fin_contas_receber = [
+      ...muitos(1000, (i) => cr('oben', 1, foraDe30, `Cliente ${i}`)),
+      ...muitos(200, () => cr('oben', 50, foraDe30, 'GIGANTE')),
+    ];
+    state.db.fin_contas_pagar = [
+      ...muitos(1000, (i) => cp('oben', 1, foraDe30, `Fornecedor ${i}`)),
+      ...muitos(100, () => cp('oben', 30, foraDe30, 'MEGA FORNECEDOR')),
+    ];
+
+    const [giro] = await getCapitalDeGiro('oben');
+
+    // CR: total 11000; top5 = GIGANTE (10000) + 4 clientes de 1
+    expect(giro.top5_cr_pct).toBeCloseTo((10004 / 11000) * 100, 6);
+    // CP: total 4000; top5 = MEGA (3000) + 4 fornecedores de 1
+    expect(giro.top5_cp_pct).toBeCloseTo((3004 / 4000) * 100, 6);
+  });
+
+  it('projeção 30d soma vencimentos na janela mesmo além da 1ª página', async () => {
+    state.db.fin_contas_receber = [
+      ...muitos(1000, () => cr('oben', 2, foraDe30)),
+      ...muitos(300, () => cr('oben', 7, dentroDe30)),
+    ];
+    state.db.fin_contas_pagar = [
+      ...muitos(1100, () => cp('oben', 3, foraDe30)),
+      ...muitos(50, () => cp('oben', 4, dentroDe30)),
+    ];
+    state.db.fin_contas_correntes = [{ company: 'oben', ativo: true, saldo_atual: 500 }];
+
+    const [giro] = await getCapitalDeGiro('oben');
+
+    expect(giro.entradas_30d).toBe(300 * 7);
+    expect(giro.saidas_30d).toBe(50 * 4);
+    expect(giro.saldo_projetado_30d).toBe(500 + 300 * 7 - 50 * 4);
+  });
+
+  it('abertos = OPEN_TITLE_STATUSES (VENCE HOJE conta; RECEBIDO/CANCELADO não; outra empresa fora)', async () => {
+    state.db.fin_contas_receber = [
+      cr('oben', 10, null),
+      { ...cr('oben', 5, null), status_titulo: 'ATRASADO' },
+      { ...cr('oben', 3, null), status_titulo: 'VENCE HOJE' },
+      { ...cr('oben', 99, null), status_titulo: 'RECEBIDO' },
+      { ...cr('oben', 99, null), status_titulo: 'CANCELADO' },
+      cr('colacor', 77, null),
+    ];
+
+    const [giro] = await getCapitalDeGiro('oben');
+
+    expect(giro.total_cr_aberto).toBe(10 + 5 + 3);
+  });
+
+  it('prazos: cobertura suficiente usa PMR/PMP da view; cobertura baixa vira null (—)', async () => {
+    state.db.v_capital_giro_prazos = [
+      { company: 'oben', pmr: 30, pmp: 10, pmr_cobertura: 0.98, pmp_cobertura: 0.95 },
+      { company: 'colacor', pmr: 20, pmp: 77, pmr_cobertura: 0.1, pmp_cobertura: 0.1 },
+    ];
+
+    const [oben] = await getCapitalDeGiro('oben');
+    expect(oben.pmr).toBe(30);
+    expect(oben.pmp).toBe(10);
+    expect(oben.ciclo_financeiro).toBe(20);
+
+    const [colacor] = await getCapitalDeGiro('colacor');
+    expect(colacor.pmr).toBeNull();
+    expect(colacor.pmp).toBeNull();
+    expect(colacor.ciclo_financeiro).toBeNull();
+  });
+
+  it('all retorna as 3 empresas', async () => {
+    state.db.fin_contas_receber = [cr('oben', 1, null), cr('colacor', 2, null), cr('colacor_sc', 3, null)];
+
+    const giros = await getCapitalDeGiro('all');
+
+    expect(giros.map((g) => g.company)).toEqual(['oben', 'colacor', 'colacor_sc']);
+    expect(giros.map((g) => g.total_cr_aberto)).toEqual([1, 2, 3]);
+  });
+
+  it('erro em CR/CP LANÇA Error real (antes virava R$0 silencioso na tela)', async () => {
+    state.errors.fin_contas_receber = { message: 'RLS negou' };
+    await expect(getCapitalDeGiro('oben')).rejects.toBeInstanceOf(Error);
+
+    state.errors = { fin_contas_pagar: { message: 'timeout' } };
+    await expect(getCapitalDeGiro('oben')).rejects.toBeInstanceOf(Error);
+  });
+
+  it('erro nas contas correntes também LANÇA — caixa R$0 falso engana igual', async () => {
+    state.db.fin_contas_receber = [cr('oben', 10, null)];
+    state.errors.fin_contas_correntes = { message: 'tabela indisponível' };
+    await expect(getCapitalDeGiro('oben')).rejects.toBeInstanceOf(Error);
+  });
+
+  it('erro na view de prazos NÃO derruba a tela — pmr/pmp ficam null (dado acessório)', async () => {
+    state.db.fin_contas_receber = [cr('oben', 10, null)];
+    state.errors.v_capital_giro_prazos = { message: 'view indisponível' };
+
+    const [giro] = await getCapitalDeGiro('oben');
+
+    expect(giro.total_cr_aberto).toBe(10);
+    expect(giro.pmr).toBeNull();
+    expect(giro.pmp).toBeNull();
+  });
+});

--- a/src/services/__tests__/getTopInadimplentes.test.ts
+++ b/src/services/__tests__/getTopInadimplentes.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Teste de contrato do getTopInadimplentes (ranking de inadimplentes do cockpit
+ * /financeiro). Irmão dos bugs #719/#720: a query de títulos ATRASADO não tinha
+ * .range() → o PostgREST capa em 1000 linhas e o ranking considerava só os 1000
+ * primeiros títulos (a oben tem ~11k CR abertos) — um devedor grande com títulos
+ * "depois" da 1ª página sumia do top.
+ *
+ * O mock reproduz o comportamento REAL do PostgREST: query sem .range() devolve
+ * no máximo 1000 linhas; com .range(from, to) devolve a janela (capada em 1000).
+ * Seeds têm valor_documento/valor_recebido/saldo coerentes (saldo é coluna
+ * gerada), então os testes só falham por truncamento/filtro errado.
+ */
+
+type Row = Record<string, unknown>;
+
+const state: {
+  db: Record<string, Row[]>;
+  errors: Record<string, { message: string } | undefined>;
+} = { db: {}, errors: {} };
+
+function makeBuilder(tabela: string) {
+  const filters: Array<(r: Row) => boolean> = [];
+  let janela: { from: number; to: number } | null = null;
+  const builder = {
+    select: (_cols: string) => builder,
+    eq: (col: string, val: unknown) => {
+      filters.push((r) => r[col] === val);
+      return builder;
+    },
+    in: (col: string, vals: unknown[]) => {
+      filters.push((r) => vals.includes(r[col]));
+      return builder;
+    },
+    order: (_col: string) => builder,
+    range: (from: number, to: number) => {
+      janela = { from, to };
+      return builder;
+    },
+    then: (
+      resolve: (v: { data: Row[] | null; error: { message: string } | null }) => unknown,
+      reject?: (e: unknown) => unknown,
+    ) => {
+      const error = state.errors[tabela];
+      if (error) return Promise.resolve({ data: null, error }).then(resolve, reject);
+      const matched = (state.db[tabela] ?? []).filter((r) => filters.every((f) => f(r)));
+      // PostgREST real: max-rows de 1000 vale SEMPRE — sem range capa em 1000, e
+      // com range a janela nunca passa de 1000 linhas (um `.range(0, 99999)` NÃO
+      // fura o cap; só paginação de verdade soma tudo).
+      const rows = janela
+        ? matched.slice(janela.from, Math.min(janela.to + 1, janela.from + 1000))
+        : matched.slice(0, 1000);
+      return Promise.resolve({ data: rows, error: null }).then(resolve, reject);
+    },
+  };
+  return builder;
+}
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: { from: (tabela: string) => makeBuilder(tabela) },
+}));
+
+import { getTopInadimplentes } from '@/services/financeiroService';
+
+const atrasado = (company: string, nome: string, saldo: number, cnpj = ''): Row => ({
+  company,
+  status_titulo: 'ATRASADO',
+  nome_cliente: nome,
+  cnpj_cpf: cnpj,
+  saldo,
+  valor_documento: saldo,
+  valor_recebido: 0,
+});
+
+describe('getTopInadimplentes (ranking de inadimplentes)', () => {
+  beforeEach(() => {
+    state.db = { fin_contas_receber: [] };
+    state.errors = {};
+  });
+
+  it('considera TODOS os títulos ATRASADO mesmo acima do cap de 1000 do PostgREST', async () => {
+    // 1000 títulos pulverizados na 1ª página + o maior devedor SÓ depois dela:
+    // sem paginação o ranking nem enxerga o gigante.
+    state.db.fin_contas_receber = [
+      ...Array.from({ length: 1000 }, (_, i) => atrasado('oben', `Cliente ${i}`, 1)),
+      ...Array.from({ length: 60 }, () => atrasado('oben', 'DEVEDOR GIGANTE', 100, '99888777000166')),
+    ];
+
+    const top = await getTopInadimplentes('oben');
+
+    expect(top[0]).toEqual({
+      nome: 'DEVEDOR GIGANTE',
+      cnpj: '99888777000166',
+      total_vencido: 60 * 100,
+      qtd_titulos: 60,
+    });
+  });
+
+  it('agrupa por cliente somando o saldo e ordena do maior pro menor', async () => {
+    state.db.fin_contas_receber = [
+      atrasado('oben', 'Beta', 50),
+      // saldo (coluna gerada) ≠ valor cheio quando há recebimento parcial
+      { ...atrasado('oben', 'Alfa', 70), valor_documento: 100, valor_recebido: 30 },
+      atrasado('oben', 'Alfa', 30),
+    ];
+
+    const top = await getTopInadimplentes('oben');
+
+    expect(top).toEqual([
+      { nome: 'Alfa', cnpj: '', total_vencido: 100, qtd_titulos: 2 },
+      { nome: 'Beta', cnpj: '', total_vencido: 50, qtd_titulos: 1 },
+    ]);
+  });
+
+  it('só ATRASADO entra no ranking (A VENCER/RECEBIDO ficam fora)', async () => {
+    state.db.fin_contas_receber = [
+      atrasado('oben', 'Alfa', 10),
+      { ...atrasado('oben', 'Alfa', 99), status_titulo: 'A VENCER' },
+      { ...atrasado('oben', 'Alfa', 99), status_titulo: 'RECEBIDO' },
+    ];
+
+    const top = await getTopInadimplentes('oben');
+
+    expect(top).toEqual([{ nome: 'Alfa', cnpj: '', total_vencido: 10, qtd_titulos: 1 }]);
+  });
+
+  it('filtra por empresa quando company != all e agrega tudo em all', async () => {
+    state.db.fin_contas_receber = [
+      atrasado('oben', 'Alfa', 10),
+      atrasado('colacor', 'Beta', 20),
+    ];
+
+    expect(await getTopInadimplentes('oben')).toEqual([
+      { nome: 'Alfa', cnpj: '', total_vencido: 10, qtd_titulos: 1 },
+    ]);
+    expect((await getTopInadimplentes('all')).map((r) => r.nome)).toEqual(['Beta', 'Alfa']);
+  });
+
+  it('identidade: nome vazio cai pro CNPJ; sem ambos vira "Cliente não identificado"', async () => {
+    state.db.fin_contas_receber = [
+      atrasado('oben', '  ', 30, '11222333000144'),
+      atrasado('oben', '', 20),
+    ];
+
+    const top = await getTopInadimplentes('oben');
+
+    expect(top).toEqual([
+      { nome: 'CNPJ: 11222333000144', cnpj: '11222333000144', total_vencido: 30, qtd_titulos: 1 },
+      { nome: 'Cliente não identificado', cnpj: '', total_vencido: 20, qtd_titulos: 1 },
+    ]);
+  });
+
+  it('respeita o limit (default 10)', async () => {
+    state.db.fin_contas_receber = Array.from({ length: 12 }, (_, i) =>
+      atrasado('oben', `Cliente ${i}`, i + 1),
+    );
+
+    expect(await getTopInadimplentes('oben')).toHaveLength(10);
+    expect(await getTopInadimplentes('oben', 3)).toHaveLength(3);
+  });
+
+  it('erro na query LANÇA Error real (ranking [] silencioso parecia "ninguém inadimplente")', async () => {
+    state.errors.fin_contas_receber = { message: 'RLS negou' };
+    await expect(getTopInadimplentes('oben')).rejects.toBeInstanceOf(Error);
+  });
+});

--- a/src/services/financeiroService.ts
+++ b/src/services/financeiroService.ts
@@ -182,6 +182,34 @@ export async function triggerFinanceiroSync(
 // Vencidos = só 'ATRASADO' (vocabulário nativo do Omie; subconjunto de OPEN_TITLE_STATUSES).
 const VENCIDO_TITLE_STATUSES = ['ATRASADO'] as const;
 
+type PaginaResult<T> = { data: T[] | null; error: { message: string } | null };
+
+/**
+ * Busca TODAS as linhas de uma query paginando em janelas de 1000 — sem
+ * `.range()` o PostgREST capa em 1000 linhas e tudo que deriva delas sai
+ * truncado silenciosamente (bug #719/#720; a oben tem ~11k títulos de CR
+ * aberto). Para somas puras use somarSaldoPorStatus; este helper é pra quando
+ * as LINHAS individuais importam (vencimento pra projeção, nome pra ranking).
+ * O callback DEVE aplicar `.order()` estável (id) + `.range(from, to)`: offset
+ * sem ORDER BY pula/duplica linha entre páginas (o sync de CR/CP grava a cada
+ * 10min). Erro de qualquer página LANÇA Error real — nunca lista parcial.
+ */
+async function buscarTodasPaginas<T>(
+  contexto: string,
+  fetchPage: (from: number, to: number) => PromiseLike<PaginaResult<T>>,
+): Promise<T[]> {
+  const PAGE = 1000;
+  const out: T[] = [];
+  for (let from = 0; ; from += PAGE) {
+    const { data, error } = await fetchPage(from, from + PAGE - 1);
+    if (error) throw new Error(`Falha ao carregar ${contexto}: ${error.message}`);
+    const rows = data ?? [];
+    out.push(...rows);
+    if (rows.length < PAGE) break;
+  }
+  return out;
+}
+
 export async function getResumoFinanceiro(companies: Company[]): Promise<Record<string, FinResumo>> {
   const resumo: Record<string, FinResumo> = {};
 
@@ -432,25 +460,28 @@ export async function getTopInadimplentes(
   company: Company | 'all',
   limit = 10
 ): Promise<{ nome: string; cnpj: string; total_vencido: number; qtd_titulos: number }[]> {
-  let query = supabase
-    .from("fin_contas_receber")
-    .select("nome_cliente, cnpj_cpf, valor_documento, valor_recebido")
-    .eq("status_titulo", "ATRASADO");
-
-  if (company !== 'all') query = query.eq("company", company);
-
-  const { data, error } = await query;
-  if (error) return [];
+  // Linhas individuais (o ranking precisa de nome/cnpj por título), paginadas:
+  // truncado em 1000 pelo PostgREST, um devedor grande "depois" da 1ª página
+  // sumia do top. Erro LANÇA (era [] silencioso = falso "ninguém inadimplente").
+  const data = await buscarTodasPaginas(`inadimplentes (${company})`, (from, to) => {
+    let query = supabase
+      .from("fin_contas_receber")
+      .select("nome_cliente, cnpj_cpf, saldo")
+      .in("status_titulo", [...VENCIDO_TITLE_STATUSES]);
+    if (company !== 'all') query = query.eq("company", company);
+    return query.order("id").range(from, to);
+  });
 
   // Agrupar por cliente (nome_cliente como chave primária; cnpj_cpf como fallback)
   const map = new Map<string, { nome: string; cnpj: string; total: number; qtd: number }>();
-  for (const r of data || []) {
+  for (const r of data) {
     const nomeRaw = (r.nome_cliente ?? '').trim();
     const cnpjRaw = (r.cnpj_cpf ?? '').trim();
     const key = nomeRaw || cnpjRaw || '__unknown__';
     const displayNome = nomeRaw
       || (cnpjRaw ? `CNPJ: ${cnpjRaw}` : 'Cliente não identificado');
-    const saldo = (r.valor_documento || 0) - (r.valor_recebido || 0);
+    // `saldo` é coluna gerada (documento − recebido) — mesma fonte do resumo (#720).
+    const saldo = r.saldo ?? 0;
     const existing = map.get(key) || {
       nome: displayNome,
       cnpj: cnpjRaw,
@@ -510,48 +541,56 @@ export async function getCapitalDeGiro(company: Company | 'all'): Promise<Capita
   const in30 = d30.toISOString().slice(0, 10);
 
   for (const co of companies) {
-    // CR aberto
-    const { data: crAberto } = await supabase
-      .from("fin_contas_receber")
-      .select("valor_documento, valor_recebido, data_emissao, data_vencimento, nome_cliente")
-      .eq("company", co)
-      .in("status_titulo", ["A VENCER", "ATRASADO", "VENCE HOJE"]);
+    // CR/CP abertos: linhas individuais (vencimento pra projeção 30d + nome pro
+    // top-5 — soma pura seria somarSaldoPorStatus) paginadas: sem .range() o
+    // PostgREST capa em 1000 e totais/concentração/projeção saíam truncados
+    // (irmão do #719/#720). `saldo` é coluna gerada (documento − recebido/pago)
+    // — mesma fonte do resumo, então total_cr/cp_aberto bate com o cockpit.
+    const [crAberto, cpAberto] = await Promise.all([
+      buscarTodasPaginas(`CR aberto (${co})`, (from, to) =>
+        supabase
+          .from("fin_contas_receber")
+          .select("saldo, data_vencimento, nome_cliente")
+          .eq("company", co)
+          .in("status_titulo", [...OPEN_TITLE_STATUSES])
+          .order("id")
+          .range(from, to),
+      ),
+      buscarTodasPaginas(`CP aberto (${co})`, (from, to) =>
+        supabase
+          .from("fin_contas_pagar")
+          .select("saldo, data_vencimento, nome_fornecedor")
+          .eq("company", co)
+          .in("status_titulo", [...OPEN_TITLE_STATUSES])
+          .order("id")
+          .range(from, to),
+      ),
+    ]);
 
-    // CP aberto
-    const { data: cpAberto } = await supabase
-      .from("fin_contas_pagar")
-      .select("valor_documento, valor_pago, data_emissao, data_vencimento, nome_fornecedor")
-      .eq("company", co)
-      .in("status_titulo", ["A VENCER", "ATRASADO", "VENCE HOJE"]);
-
-    // Saldo CC
-    const { data: ccs } = await supabase
+    // Saldo CC — erro LANÇA: caixa R$0 falso engana tanto quanto total truncado
+    const { data: ccs, error: ccError } = await supabase
       .from("fin_contas_correntes")
       .select("saldo_atual")
       .eq("company", co)
       .eq("ativo", true);
+    if (ccError) throw new Error(`Falha ao carregar contas correntes (${co}): ${ccError.message}`);
 
     // PMR/PMP: baixa derivada das movimentações (view v_capital_giro_prazos), porque
     // o Omie NÃO traz data de baixa no LIST de títulos (data_recebimento/pagamento
     // sempre NULL — ver v_titulo_baixas). A view agrega PMR/PMP ponderado por valor +
     // a cobertura (fração dos liquidados com baixa derivável) por empresa.
     const COBERTURA_MIN = 0.4;
-    // view nova ainda não nos tipos gerados → `as never` (padrão do repo p/ views)
+    // view nova ainda não nos tipos gerados → `as never` (padrão do repo p/ views).
+    // Erro aqui NÃO lança (≠ CR/CP/CC): prazo é acessório e null = "—" na UI,
+    // que é degradação honesta — não fabrica número.
     const { data: prazos } = await supabase
       .from("v_capital_giro_prazos" as never)
       .select("pmr, pmp, pmr_cobertura, pmp_cobertura")
       .eq("company", co)
       .maybeSingle();
 
-    type CrRow = { valor_documento: number | null; valor_recebido: number | null };
-    type CpRow = { valor_documento: number | null; valor_pago: number | null };
-    const calcSaldoCR = (arr: CrRow[] | null) =>
-      (arr || []).reduce((s, r) => s + ((r.valor_documento || 0) - (r.valor_recebido || 0)), 0);
-    const calcSaldoCP = (arr: CpRow[] | null) =>
-      (arr || []).reduce((s, r) => s + ((r.valor_documento || 0) - (r.valor_pago || 0)), 0);
-
-    const totalCR = calcSaldoCR(crAberto as CrRow[] | null);
-    const totalCP = calcSaldoCP(cpAberto as CpRow[] | null);
+    const totalCR = crAberto.reduce((s, r) => s + (r.saldo ?? 0), 0);
+    const totalCP = cpAberto.reduce((s, r) => s + (r.saldo ?? 0), 0);
     const totalCC = (ccs || []).reduce((s, c) => s + (c.saldo_atual || 0), 0);
 
     // Gate de confiança por empresa: prazo só quando a cobertura é suficiente.
@@ -565,28 +604,28 @@ export async function getCapitalDeGiro(company: Company | 'all'): Promise<Capita
 
     // Concentração top 5
     const crByClient = new Map<string, number>();
-    for (const r of crAberto || []) {
+    for (const r of crAberto) {
       const key = r.nome_cliente || 'Outros';
-      crByClient.set(key, (crByClient.get(key) || 0) + ((r.valor_documento || 0) - (r.valor_recebido || 0)));
+      crByClient.set(key, (crByClient.get(key) || 0) + (r.saldo ?? 0));
     }
     const top5CR = Array.from(crByClient.values()).sort((a, b) => b - a).slice(0, 5);
     const top5CRSum = top5CR.reduce((s, v) => s + v, 0);
 
     const cpByFornecedor = new Map<string, number>();
-    for (const p of cpAberto || []) {
+    for (const p of cpAberto) {
       const key = p.nome_fornecedor || 'Outros';
-      cpByFornecedor.set(key, (cpByFornecedor.get(key) || 0) + ((p.valor_documento || 0) - (p.valor_pago || 0)));
+      cpByFornecedor.set(key, (cpByFornecedor.get(key) || 0) + (p.saldo ?? 0));
     }
     const top5CP = Array.from(cpByFornecedor.values()).sort((a, b) => b - a).slice(0, 5);
     const top5CPSum = top5CP.reduce((s, v) => s + v, 0);
 
     // Projeção 30 dias: CR vencendo nos próx 30d + CP vencendo nos próx 30d
-    const entradas30 = (crAberto || [])
+    const entradas30 = crAberto
       .filter((r) => r.data_vencimento && r.data_vencimento >= today && r.data_vencimento <= in30)
-      .reduce((s, r) => s + ((r.valor_documento || 0) - (r.valor_recebido || 0)), 0);
-    const saidas30 = (cpAberto || [])
+      .reduce((s, r) => s + (r.saldo ?? 0), 0);
+    const saidas30 = cpAberto
       .filter((p) => p.data_vencimento && p.data_vencimento >= today && p.data_vencimento <= in30)
-      .reduce((s, p) => s + ((p.valor_documento || 0) - (p.valor_pago || 0)), 0);
+      .reduce((s, p) => s + (p.saldo ?? 0), 0);
 
     results.push({
       company: co,


### PR DESCRIPTION
## O bug (mesma família dos #719/#720)

As duas funções restantes do `financeiroService.ts` com queries de linhas de CR/CP **sem `.range()`** → o PostgREST capa em **1000 linhas** (a oben tem ~11k títulos de CR aberto):

- **`getCapitalDeGiro`** (tela **Posição Agora** em `/financeiro`): `total_cr_aberto`/`total_cp_aberto`/`capital_giro`/`capital_giro_liquido`, concentração top-5 e a projeção 30d (`entradas_30d`/`saidas_30d`/`saldo_projetado_30d`) consideravam só os 1000 primeiros títulos.
- **`getTopInadimplentes`** (cockpit, Meu Dia/zona financeira, aba Inadimplentes): o ranking só via os primeiros 1000 títulos ATRASADO — um devedor grande "depois" da 1ª página **sumia do top**.

Diferença vs #720: aqui as **linhas individuais** importam (data de vencimento pra projeção 30d, nome_cliente/nome_fornecedor pro top-5 e ranking) → não basta delegar a `somarSaldoPorStatus`; é paginar a busca de linhas.

## O fix

- Helper privado **`buscarTodasPaginas`**: loop `.range(from, from+999)` com **`.order('id')`** (offset sem ORDER BY pula/duplica linha entre páginas — o sync de CR/CP grava a cada 10min) e **erro LANÇA Error real** (nunca lista parcial silenciosa).
- `getCapitalDeGiro`: CR/CP paginados (em paralelo); **soma por `saldo`** (coluna gerada — mesma fonte do resumo #720, então `total_cr_aberto` bate com o cockpit); literal `['A VENCER','ATRASADO','VENCE HOJE']` → **`OPEN_TITLE_STATUSES`**; `data_emissao` removida do select (morta desde o #442 — o PMR/PMP vem da view); erro de CC também lança (caixa R$0 falso engana igual); **view de prazos segue degradando pra null** ("—" na UI — acessório, não fabrica número).
- `getTopInadimplentes`: ranking paginado; `.eq('ATRASADO')` → **`VENCIDO_TITLE_STATUSES`**; soma por `saldo`; erro **lança** (era `[]` silencioso = falso "ninguém inadimplente").
- Consumidores: `useFinanceiroCockpit` ganhou **catch-por-fonte** no inadimplentes (sem isso o throw novo derrubaria aging/DRE juntos no `Promise.all`); `usePosicaoAgora` já capturava (erro agora vira "Sem dados" honesto em vez de R$0 truncado); `useFinanceiro` já converte pra banner; `useFinanceiroZone` já tem try/catch.

## Validação (TDD, RED→GREEN provado)

- **16 testes de contrato novos** (`getCapitalDeGiro.test.ts` + `getTopInadimplentes.test.ts`) com mock-banco que reproduz o PostgREST real: **capa janelas em 1000 mesmo com `.range()` gigante**. RED confirmado nos 7 testes do bug (totais 10000≠25000, top-5 0,5%≠90,9%, projeção 0, erros resolvendo silenciosos) antes do fix.
- `heavy bun run typecheck` ✅ · `heavy bun run test` **2975/2975** ✅ · `bun lint` 0 errors ✅.

Sem migration/edge — 100% frontend; **vai ao ar no próximo Publish**.

⏸️ Codex adversarial retroativo quando a cota voltar (11/06+) — caminho B aplicado (self-review adversarial + testes de contrato).

🤖 Generated with [Claude Code](https://claude.com/claude-code)