### PR TITLE
perf(vendedora): Onda 3 — WhatsApp responsivo + fila de rota paralela + erro ≠ falso "tudo em dia" (B2+B3+#18+#16-lite)

### DIFF
--- a/src/components/fila/FilaDoDia.tsx
+++ b/src/components/fila/FilaDoDia.tsx
@@ -53,7 +53,7 @@ function AcaoCta({ a, temCritica }: { a: AcaoSugerida; temCritica: boolean }) {
  * Fase 3 (flag `filaContextPanel`): clicar no item abre o FilaContextPanel (painel de contexto).
  */
 export function FilaDoDia() {
-  const { acoes, isLoading } = useFilaAcoes();
+  const { acoes, isLoading, isError, retry } = useFilaAcoes();
   const packs = useCriticaFila(acoes);
   const shownRef = useRef<Set<string>>(new Set());
 
@@ -96,6 +96,19 @@ export function FilaDoDia() {
   }
 
   if (visiveis.length === 0) {
+    // Erro ≠ dia limpo: sem isto, RLS negada/rede ruim virava "carteira em
+    // dia" — falso-verde num motor de receita (a vendedora deixava de ligar).
+    if (isError) {
+      return (
+        <Card className="p-6">
+          <p className="text-sm font-medium">Não consegui carregar sua fila.</p>
+          <p className="text-2xs text-muted-foreground mt-1">
+            Falha ao buscar tarefas/rota — isso NÃO significa que a carteira está em dia.
+          </p>
+          <Button size="sm" variant="outline" className="mt-3" onClick={retry}>Tentar de novo</Button>
+        </Card>
+      );
+    }
     return (
       <Card className="p-6">
         <p className="text-sm font-medium">Nada prioritário na fila agora.</p>
@@ -118,6 +131,12 @@ export function FilaDoDia() {
           <p className="text-2xs text-muted-foreground">
             {visiveis.length} ações priorizadas — tarefas, rota e oportunidades, do mais urgente ao menos.
           </p>
+          {isError && (
+            <p className="text-2xs text-status-warning">
+              Uma das fontes falhou ao carregar — a lista pode estar incompleta.{' '}
+              <button type="button" className="underline" onClick={retry}>Tentar de novo</button>
+            </p>
+          )}
         </CardHeader>
         <div className="divide-y divide-border">
           {visiveis.slice(0, 30).map((a, i) => {

--- a/src/components/tarefas/MinhasTarefasCard.tsx
+++ b/src/components/tarefas/MinhasTarefasCard.tsx
@@ -19,6 +19,7 @@ export function MinhasTarefasCard() {
   const [adiarAlvo, setAdiarAlvo] = useState<TarefaEstado | null>(null);
   const [adiarData, setAdiarData] = useState('');
   const [adiarMotivo, setAdiarMotivo] = useState('');
+  const [salvandoAdiar, setSalvandoAdiar] = useState(false);
 
   if (isLoading || tarefas.length === 0) return null; // empty → não polui o topo
 
@@ -80,11 +81,19 @@ export function MinhasTarefasCard() {
             <Textarea placeholder="Motivo (ex: cliente pediu pra semana que vem)" value={adiarMotivo} onChange={(e) => setAdiarMotivo(e.target.value)} />
           </div>
           <DialogFooter>
-            <Button disabled={!adiarData || !adiarMotivo} onClick={async () => {
+            <Button disabled={!adiarData || !adiarMotivo || salvandoAdiar} onClick={async () => {
               if (!adiarAlvo) return;
-              await adiar(adiarAlvo.id, new Date(adiarData + 'T12:00:00').toISOString(), adiarMotivo);
-              setAdiarAlvo(null);
-            }}>Adiar</Button>
+              setSalvandoAdiar(true);
+              try {
+                await adiar(adiarAlvo.id, new Date(adiarData + 'T12:00:00').toISOString(), adiarMotivo);
+                setAdiarAlvo(null);
+              } catch {
+                // o hook já fez rollback otimista + toast; o dialog fica
+                // aberto pro usuário tentar de novo.
+              } finally {
+                setSalvandoAdiar(false);
+              }
+            }}>{salvandoAdiar ? 'Adiando…' : 'Adiar'}</Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>

--- a/src/hooks/useFilaAcoes.ts
+++ b/src/hooks/useFilaAcoes.ts
@@ -13,7 +13,12 @@ import type { AcaoSugerida } from '@/lib/fila/types';
 // falso-negativo (cap 200 do inbox + proxy last_message_at — Codex P1). Lá será
 // reescrita sobre query/RPC de pendentes com last_outbound_at real. O adapter
 // (whatsappPendente.ts) e o hook (useWhatsappPendentes.ts) já existem, prontos.
-export function useFilaAcoes(): { acoes: AcaoSugerida[]; isLoading: boolean } {
+export function useFilaAcoes(): {
+  acoes: AcaoSugerida[];
+  isLoading: boolean;
+  isError: boolean;
+  retry: () => void;
+} {
   const workdayIso = useMemo(() => spBusinessDate(new Date()), []);
 
   const tarefas = useMinhasTarefas();
@@ -29,5 +34,20 @@ export function useFilaAcoes(): { acoes: AcaoSugerida[]; isLoading: boolean } {
     return rankearFila(dedupe(todas));
   }, [tarefas.data, rota.data, mixgap.data]);
 
-  return { acoes, isLoading: tarefas.isLoading || rota.isLoading || mixgap.isLoading };
+  // isError PROPAGADO (antes era descartado): falha de RLS/rede em qualquer
+  // fonte virava lista vazia → a FilaDoDia afirmava "carteira em dia" —
+  // falso-verde num motor de receita. A UI distingue erro de dia limpo.
+  const isError = tarefas.isError || rota.isError || mixgap.isError;
+  const retry = () => {
+    if (tarefas.isError) void tarefas.refetch();
+    if (rota.isError) void rota.refetch();
+    if (mixgap.isError) void mixgap.refetch();
+  };
+
+  return {
+    acoes,
+    isLoading: tarefas.isLoading || rota.isLoading || mixgap.isLoading,
+    isError,
+    retry,
+  };
 }

--- a/src/hooks/useSendWhatsapp.ts
+++ b/src/hooks/useSendWhatsapp.ts
@@ -1,6 +1,8 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
 import { toast } from 'sonner';
+import { montarMensagemOtimista } from '@/lib/whatsapp/thread-cache';
+import type { WaMessage } from '@/queries/useWhatsappInbox';
 
 /** Tenta ler o campo `error` do corpo JSON quando a edge responde não-2xx (invoke lança antes). */
 async function extractEdgeErrorCode(error: unknown): Promise<string> {
@@ -17,6 +19,7 @@ async function extractEdgeErrorCode(error: unknown): Promise<string> {
 
 export function useSendWhatsapp(conversationId: string | undefined) {
   const qc = useQueryClient();
+  const threadKey = ['whatsapp', 'thread', conversationId] as const;
   return useMutation({
     mutationFn: async (text: string) => {
       const { data, error } = await supabase.functions.invoke('whatsapp-send', {
@@ -26,9 +29,39 @@ export function useSendWhatsapp(conversationId: string | undefined) {
       if ((data as { error?: string })?.error) throw new Error((data as { error: string }).error);
       return data;
     },
-    onSuccess: () => qc.invalidateQueries({ queryKey: ['whatsapp', 'thread', conversationId] }),
-    onError: (e: Error) => {
+    // Optimistic: a mensagem aparece na thread NO CLIQUE — antes ela só
+    // surgia após edge (whatsapp-send → 360dialog, 1-3s+) + invalidate +
+    // refetch, parecendo que o envio não funcionou (anti-padrão de chat).
+    onMutate: async (text: string) => {
+      if (!conversationId) return { otimistaId: null as string | null };
+      await qc.cancelQueries({ queryKey: threadKey });
+      const otimista = montarMensagemOtimista(conversationId, text, new Date().toISOString());
+      qc.setQueryData<WaMessage[]>(threadKey, (old) => (old ? [...old, otimista] : [otimista]));
+      return { otimistaId: otimista.id as string | null };
+    },
+    // Rollback CIRÚRGICO por id (NUNCA snapshot-restore): o cache da thread é
+    // alimentado por realtime — restaurar um snapshot apagaria mensagens
+    // INBOUND do cliente chegadas durante o send, e com 2 envios em voo
+    // ressuscitaria a otimista do envio anterior (revisão adversarial).
+    onError: (e: Error, _text, ctx) => {
+      if (ctx?.otimistaId) {
+        qc.setQueryData<WaMessage[]>(threadKey, (old) =>
+          old ? old.filter((m) => m.id !== ctx.otimistaId) : old,
+        );
+      }
       toast.error(e.message === 'window_closed' ? 'Janela de 24h fechada — precisa de template (PR2).' : 'Falha ao enviar.');
+    },
+    onSuccess: (data) => {
+      // A edge envia ao cliente ANTES de persistir e responde persisted:false
+      // se só a persistência falhou — nesse caso NÃO invalidar (o refetch
+      // apagaria a otimista e a vendedora re-enviaria → cliente recebe 2×).
+      if ((data as { persisted?: boolean })?.persisted === false) {
+        toast.warning('Mensagem enviada ao cliente, mas não registrada no histórico.');
+        return;
+      }
+      // Reconciliação: o realtime já costuma trocar a otimista pela mensagem
+      // real (append no cache); o invalidate é a rede pra qualquer divergência.
+      qc.invalidateQueries({ queryKey: threadKey });
     },
   });
 }

--- a/src/hooks/useTarefas.ts
+++ b/src/hooks/useTarefas.ts
@@ -87,6 +87,87 @@ export function useTarefaMutations() {
     qc.invalidateQueries({ queryKey: ['tarefas-badge-count'] });
   };
 
+  /** Remoção OTIMISTA da tarefa de todas as listas ['minhas-tarefas']: a
+   *  vendedora vê o item sumir NO CLIQUE (antes esperava UPDATE + INSERT de
+   *  evento + invalidate + refetch ~1-2s com o botão parado). O rollback é
+   *  CIRÚRGICO (re-insere só o próprio item na posição original) — restaurar
+   *  um snapshot inteiro sobrescreveria mudanças concorrentes de outras
+   *  mutações/refetches. cancelQueries AGUARDADO: um refetch em voo que
+   *  aterrissasse depois ressuscitaria o item. */
+  const removerTarefaOtimista = async (id: string) => {
+    await qc.cancelQueries({ queryKey: ['minhas-tarefas'] });
+    const removidos: Array<[readonly unknown[], number, TarefaEstado]> = [];
+    for (const [key, data] of qc.getQueriesData<TarefaEstado[]>({ queryKey: ['minhas-tarefas'] })) {
+      if (!data) continue;
+      const idx = data.findIndex((t) => t.id === id);
+      if (idx < 0) continue;
+      removidos.push([key, idx, data[idx]]);
+      const next = data.slice();
+      next.splice(idx, 1);
+      qc.setQueryData(key, next);
+    }
+    return () => {
+      for (const [key, idx, item] of removidos) {
+        qc.setQueryData<TarefaEstado[]>(key, (old) => {
+          if (!old) return old;
+          if (old.some((t) => t.id === id)) return old; // já voltou via refetch
+          const next = old.slice();
+          next.splice(Math.min(idx, next.length), 0, item);
+          return next;
+        });
+      }
+    };
+  };
+
+  /** Update OTIMISTA do adiamento: a tarefa adiada NÃO sai da lista (a view
+   *  v_tarefas_estado mantém status='aberta' e só recalcula effective_due) —
+   *  removê-la faria o refetch DEVOLVER o item ("adiei e voltou"). Atualiza
+   *  os campos no lugar; rollback cirúrgico restaura só o item. */
+  const adiarOtimista = async (id: string, novaData: string) => {
+    await qc.cancelQueries({ queryKey: ['minhas-tarefas'] });
+    let original: TarefaEstado | undefined;
+    qc.setQueriesData<TarefaEstado[]>({ queryKey: ['minhas-tarefas'] }, (old) =>
+      old
+        ? old.map((t) => {
+            if (t.id !== id) return t;
+            original ??= t;
+            return { ...t, adiada_para: novaData, effective_due: novaData, atrasada: false };
+          })
+        : old);
+    return () => {
+      if (!original) return;
+      const orig = original;
+      qc.setQueriesData<TarefaEstado[]>({ queryKey: ['minhas-tarefas'] }, (old) =>
+        old ? old.map((t) => (t.id === id ? orig : t)) : old);
+    };
+  };
+
+  /** Remoção otimista de uma sugestão (candidato) — rollback cirúrgico. */
+  const removerSugestaoOtimista = async (candidatoId: string) => {
+    await qc.cancelQueries({ queryKey: ['tarefa-sugestoes'] });
+    const removidos: Array<[readonly unknown[], number, { id: string }]> = [];
+    for (const [key, data] of qc.getQueriesData<Array<{ id: string }>>({ queryKey: ['tarefa-sugestoes'] })) {
+      if (!data) continue;
+      const idx = data.findIndex((s) => s.id === candidatoId);
+      if (idx < 0) continue;
+      removidos.push([key, idx, data[idx]]);
+      const next = data.slice();
+      next.splice(idx, 1);
+      qc.setQueryData(key, next);
+    }
+    return () => {
+      for (const [key, idx, item] of removidos) {
+        qc.setQueryData<Array<{ id: string }>>(key, (old) => {
+          if (!old) return old;
+          if (old.some((s) => s.id === candidatoId)) return old;
+          const next = old.slice();
+          next.splice(Math.min(idx, next.length), 0, item);
+          return next;
+        });
+      }
+    };
+  };
+
   /** Cria N tarefas (cada linha carrega seu próprio cliente). Opcional: auditoria da origem por voz. */
   const criarTarefas = async (
     linhas: Array<Record<string, unknown>>,
@@ -115,12 +196,13 @@ export function useTarefaMutations() {
 
   /** Conclusão manual (inclui o botão WhatsApp, que passa origem='whatsapp'). */
   const concluir = async (id: string, origem: 'manual' | 'whatsapp', nota?: string) => {
+    const rollback = await removerTarefaOtimista(id);
     const { error } = await tarefas()
       .update({ status: 'concluida', concluida_em: new Date().toISOString(),
                 concluida_por: user!.id, conclusao_origem: origem, nota_conclusao: nota ?? null,
                 updated_at: new Date().toISOString() } as never)
       .eq('id', id);
-    if (error) { toast.error('Erro ao concluir'); throw error; }
+    if (error) { rollback(); toast.error('Erro ao concluir'); throw error; }
     await eventos().insert(
       { tarefa_id: id, tipo_evento: origem === 'whatsapp' ? 'concluida_whatsapp' : 'concluida_manual',
         ator: user!.id } as never);
@@ -131,10 +213,17 @@ export function useTarefaMutations() {
 
   /** Confirma/rejeita uma sugestão (1 toque). accepted → conclui a tarefa. */
   const resolverSugestao = async (candidatoId: string, tarefaId: string, aceitar: boolean) => {
+    const rollbackSugestao = await removerSugestaoOtimista(candidatoId);
+    const rollbackTarefa = aceitar ? await removerTarefaOtimista(tarefaId) : null;
     const { error } = await candidatos()
       .update({ status: aceitar ? 'accepted' : 'rejected', resolved_at: new Date().toISOString(),
                 resolved_by: user!.id } as never).eq('id', candidatoId);
-    if (error) { toast.error('Erro ao responder sugestão'); throw error; }
+    if (error) {
+      rollbackSugestao();
+      rollbackTarefa?.();
+      toast.error('Erro ao responder sugestão');
+      throw error;
+    }
     if (aceitar) {
       await tarefas().update(
         { status: 'concluida', concluida_em: new Date().toISOString(), concluida_por: user!.id,
@@ -151,12 +240,14 @@ export function useTarefaMutations() {
     invalidate();
   };
 
-  /** Adiar com motivo (snooze). */
+  /** Adiar com motivo (snooze). Update otimista no lugar (a adiada continua
+   *  listada com a data nova — ver adiarOtimista). */
   const adiar = async (id: string, novaData: string, motivo: string) => {
+    const rollback = await adiarOtimista(id, novaData);
     const { error } = await tarefas()
       .update({ adiada_para: novaData, motivo_adiamento: motivo, updated_at: new Date().toISOString() } as never)
       .eq('id', id);
-    if (error) { toast.error('Erro ao adiar'); throw error; }
+    if (error) { rollback(); toast.error('Erro ao adiar'); throw error; }
     await eventos().insert(
       { tarefa_id: id, tipo_evento: 'adiada', ator: user!.id,
         payload: { adiada_para: novaData, motivo } } as never);

--- a/src/lib/whatsapp/__tests__/thread-cache.test.ts
+++ b/src/lib/whatsapp/__tests__/thread-cache.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import {
+  appendRealtimeMessage,
+  montarMensagemOtimista,
+  isOptimisticMessage,
+} from '@/lib/whatsapp/thread-cache';
+import type { WaMessage } from '@/queries/useWhatsappInbox';
+
+const msg = (id: string, over: Partial<WaMessage> = {}): WaMessage => ({
+  id,
+  conversation_id: 'c1',
+  direction: 'in',
+  type: 'text',
+  body: 'oi',
+  status: null,
+  created_at: '2026-06-10T12:00:00Z',
+  wa_timestamp: null,
+  ...over,
+});
+
+describe('appendRealtimeMessage (cache da thread)', () => {
+  it('cache ausente → não cria (deixa o fetch popular)', () => {
+    expect(appendRealtimeMessage(undefined, msg('m1'))).toBeUndefined();
+  });
+
+  it('append simples de mensagem inbound', () => {
+    const out = appendRealtimeMessage([msg('m1')], msg('m2', { body: 'tudo bem?' }));
+    expect(out?.map((m) => m.id)).toEqual(['m1', 'm2']);
+  });
+
+  it('dedupe por id: replay do realtime não duplica balão', () => {
+    const old = [msg('m1')];
+    const out = appendRealtimeMessage(old, msg('m1'));
+    expect(out).toBe(old); // referência inalterada — sem re-render
+  });
+
+  it('OUT substitui a 1ª otimista de MESMO body (sem balão duplicado)', () => {
+    const otimista = montarMensagemOtimista('c1', 'já te respondo', '2026-06-10T12:01:00Z');
+    const old = [msg('m1'), otimista];
+    const real = msg('m2', { direction: 'out', body: 'já te respondo' });
+    const out = appendRealtimeMessage(old, real);
+    expect(out?.map((m) => m.id)).toEqual(['m1', 'm2']);
+    expect(out?.some(isOptimisticMessage)).toBe(false);
+  });
+
+  it('OUT com body diferente NÃO remove otimista alheia (envios concorrentes)', () => {
+    const otimista = montarMensagemOtimista('c1', 'mensagem A', '2026-06-10T12:01:00Z');
+    const real = msg('m2', { direction: 'out', body: 'mensagem B' });
+    const out = appendRealtimeMessage([otimista], real);
+    expect(out?.length).toBe(2);
+    expect(out?.some(isOptimisticMessage)).toBe(true);
+  });
+
+  it('IN nunca remove otimista (só OUT reconcilia)', () => {
+    const otimista = montarMensagemOtimista('c1', 'oi', '2026-06-10T12:01:00Z');
+    const out = appendRealtimeMessage([otimista], msg('m9', { direction: 'in', body: 'oi' }));
+    expect(out?.length).toBe(2);
+  });
+});
+
+describe('montarMensagemOtimista', () => {
+  it('gera mensagem OUT com prefixo otimista e body/status corretos', () => {
+    const m = montarMensagemOtimista('c1', 'olá', '2026-06-10T12:00:00Z');
+    expect(isOptimisticMessage(m)).toBe(true);
+    expect(m.direction).toBe('out');
+    expect(m.body).toBe('olá');
+    expect(m.status).toBe('enviando');
+    expect(m.conversation_id).toBe('c1');
+  });
+});

--- a/src/lib/whatsapp/thread-cache.ts
+++ b/src/lib/whatsapp/thread-cache.ts
@@ -1,0 +1,56 @@
+import type { WaMessage } from '@/queries/useWhatsappInbox';
+
+/** Prefixo das mensagens otimistas injetadas pelo useSendWhatsapp (onMutate). */
+export const OPTIMISTIC_MSG_PREFIX = 'optimistic-';
+
+export function isOptimisticMessage(m: WaMessage): boolean {
+  return m.id.startsWith(OPTIMISTIC_MSG_PREFIX);
+}
+
+/** Monta a mensagem otimista do envio (aparece na thread na hora do clique). */
+export function montarMensagemOtimista(
+  conversationId: string,
+  body: string,
+  nowIso: string,
+): WaMessage {
+  return {
+    id: `${OPTIMISTIC_MSG_PREFIX}${nowIso}-${Math.floor(Math.random() * 1e6)}`,
+    conversation_id: conversationId,
+    direction: 'out',
+    type: 'text',
+    body,
+    status: 'enviando',
+    created_at: nowIso,
+    wa_timestamp: null,
+  };
+}
+
+/**
+ * Append incremental de uma mensagem vinda do realtime no cache da thread
+ * (substitui o invalidate que re-baixava a conversa INTEIRA a cada mensagem).
+ *
+ * Regras (todas testadas):
+ *  - cache ausente → não cria (o fetch da thread popula quando a tela abrir);
+ *  - dedupe por id (replay/duplicata do realtime não duplica balão);
+ *  - mensagem OUT substitui a 1ª otimista de mesmo body (o INSERT real da
+ *    mensagem que o próprio usuário enviou chega via realtime antes do
+ *    invalidate de reconciliação — sem isso o balão duplicaria por ~1s).
+ */
+export function appendRealtimeMessage(
+  old: WaMessage[] | undefined,
+  nova: WaMessage,
+): WaMessage[] | undefined {
+  if (!old) return undefined;
+  if (old.some((m) => m.id === nova.id)) return old;
+
+  if (nova.direction === 'out') {
+    const idx = old.findIndex((m) => isOptimisticMessage(m) && m.body === nova.body);
+    if (idx >= 0) {
+      const next = old.slice();
+      next.splice(idx, 1);
+      next.push(nova);
+      return next;
+    }
+  }
+  return [...old, nova];
+}

--- a/src/pages/RotaListaLigacao.tsx
+++ b/src/pages/RotaListaLigacao.tsx
@@ -42,7 +42,7 @@ function ResolvidosSection({ itens }: { itens: RouteContactItem[] }) {
 export default function RotaListaLigacao() {
   // data de NEGÓCIO em SP (não UTC — senão das ~21h às 24h locais a data vira o dia seguinte → rota errada).
   const workday = useMemo(() => spBusinessDate(new Date()), []);
-  const { data, isLoading } = useRouteContactList(workday);
+  const { data, isLoading, isError, refetch } = useRouteContactList(workday);
   const { isMaster, isGestorComercial } = useAuth();
 
   // Grava (idempotente, best-effort) a fila de ligação aberta — denominador do painel.
@@ -50,6 +50,25 @@ export default function RotaListaLigacao() {
   useSnapshotRouteQueue(data?.routeDate ?? null, data?.callQueue);
 
   if (isLoading) return <PageSkeleton variant="list" />;
+
+  // Erro ≠ "sem rota": a query falha (após retries) caía no MESMO empty state
+  // de "Sem rota para amanhã" — a vendedora deixava de ligar pros clientes do
+  // dia achando que não havia fila (falso-verde em motor de receita).
+  if (isError) {
+    return (
+      <div className="p-4 space-y-3">
+        <h1 className="font-display text-2xl">Lista de ligação por rota</h1>
+        <EmptyState
+          icon={Phone}
+          tone="operational"
+          title="Não consegui carregar a fila"
+          description="Falha ao buscar a rota — isso NÃO significa que não há clientes pra ligar."
+          actionLabel="Tentar de novo"
+          onAction={() => refetch()}
+        />
+      </div>
+    );
+  }
 
   const cidadesLabel = data?.cidades?.length ? data.cidades.join(', ') : null;
   const routeDate = data?.routeDate ?? workday;

--- a/src/pages/WhatsappInbox.tsx
+++ b/src/pages/WhatsappInbox.tsx
@@ -4,27 +4,75 @@ import { useWhatsappConversations, useWhatsappThread } from '@/queries/useWhatsa
 import { useWhatsappSla } from '@/queries/useWhatsappSla';
 import { SlaBadge } from '@/components/whatsapp/SlaBadge';
 import { useSendWhatsapp } from '@/hooks/useSendWhatsapp';
+import { isOptimisticMessage } from '@/lib/whatsapp/thread-cache';
 import { formatBrPhone } from '@/lib/phone';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { Skeleton } from '@/components/ui/skeleton';
 import { EmptyState } from '@/components/EmptyState';
 
+/**
+ * Form de resposta com estado PRÓPRIO: digitar não re-renderiza a lista de
+ * conversas (até 200 itens) nem a thread — antes o draft vivia na page e cada
+ * tecla re-executava os dois maps. O draft limpa NO CLIQUE (a mensagem
+ * otimista já apareceu na thread via useSendWhatsapp.onMutate) e é restaurado
+ * se o envio falhar (sem sobrescrever o que o usuário já re-digitou).
+ */
+function ReplyForm({ conversationId }: { conversationId: string }) {
+  const send = useSendWhatsapp(conversationId);
+  const [draft, setDraft] = useState('');
+  return (
+    <form
+      className="p-3 border-t flex gap-2"
+      onSubmit={(e) => {
+        e.preventDefault();
+        const t = draft.trim();
+        if (!t) return;
+        setDraft('');
+        send.mutate(t, { onError: () => setDraft((cur) => cur || t) });
+      }}
+    >
+      <Input value={draft} onChange={(e) => setDraft(e.target.value)} placeholder="Responder…" autoFocus />
+      <Button type="submit">Enviar</Button>
+    </form>
+  );
+}
+
+const ConversationsSkeleton = () => (
+  <div className="p-3 space-y-3">
+    {[0, 1, 2, 3, 4].map((i) => (
+      <div key={i} className="space-y-1.5">
+        <Skeleton className="h-4 w-2/3" />
+        <Skeleton className="h-3 w-1/3" />
+      </div>
+    ))}
+  </div>
+);
+
 export default function WhatsappInbox() {
-  const { data: conversations = [] } = useWhatsappConversations();
+  const conversationsQuery = useWhatsappConversations();
+  const conversations = conversationsQuery.data ?? [];
   const { data: slaRows = [] } = useWhatsappSla();
   const slaByConv = useMemo(
     () => new Map(slaRows.map((r) => [r.conversation_id, r])),
     [slaRows],
   );
   const [activeId, setActiveId] = useState<string | undefined>();
-  const { data: messages = [] } = useWhatsappThread(activeId);
-  const send = useSendWhatsapp(activeId);
-  const [draft, setDraft] = useState('');
+  const threadQuery = useWhatsappThread(activeId);
+  const messages = threadQuery.data ?? [];
 
   return (
     <div className="flex h-[calc(100vh-3rem)]">
       <aside className="w-80 border-r overflow-y-auto">
-        {conversations.length === 0 ? (
+        {conversationsQuery.isLoading ? (
+          // Loading ≠ vazio: o "Sem conversas" durante o fetch escondia
+          // cliente esperando resposta (SLA de 15/30min em jogo).
+          <ConversationsSkeleton />
+        ) : conversationsQuery.isError ? (
+          <EmptyState tone="operational" icon={MessageCircle} title="Não consegui carregar"
+            description="Falha ao buscar as conversas — não significa que não há clientes esperando."
+            actionLabel="Tentar de novo" onAction={() => conversationsQuery.refetch()} />
+        ) : conversations.length === 0 ? (
           <EmptyState tone="operational" icon={MessageCircle} title="Sem conversas"
             description="As conversas aparecem quando um cliente responde." />
         ) : conversations.map((c) => {
@@ -47,17 +95,22 @@ export default function WhatsappInbox() {
         ) : (
           <>
             <div className="flex-1 overflow-y-auto p-4 space-y-2">
-              {messages.map((m) => (
-                <div key={m.id} className={`max-w-[70%] rounded p-2 text-sm ${m.direction === 'out' ? 'ml-auto bg-primary text-primary-foreground' : 'bg-muted'}`}>
-                  {m.type === 'text' ? m.body : `[${m.type}]`}
-                </div>
-              ))}
+              {threadQuery.isError ? (
+                <EmptyState tone="operational" icon={MessageCircle} title="Não consegui carregar a conversa"
+                  description="" actionLabel="Tentar de novo" onAction={() => threadQuery.refetch()} />
+              ) : (
+                messages.map((m) => (
+                  <div
+                    key={m.id}
+                    className={`max-w-[70%] rounded p-2 text-sm ${m.direction === 'out' ? 'ml-auto bg-primary text-primary-foreground' : 'bg-muted'} ${isOptimisticMessage(m) ? 'opacity-60' : ''}`}
+                  >
+                    {m.type === 'text' ? m.body : `[${m.type}]`}
+                  </div>
+                ))
+              )}
             </div>
-            <form className="p-3 border-t flex gap-2"
-              onSubmit={(e) => { e.preventDefault(); const t = draft.trim(); if (t) send.mutate(t, { onSuccess: () => setDraft('') }); }}>
-              <Input value={draft} onChange={(e) => setDraft(e.target.value)} placeholder="Responder…" />
-              <Button type="submit" disabled={send.isPending}>Enviar</Button>
-            </form>
+            {/* key por conversa: troca de conversa zera o draft */}
+            <ReplyForm key={activeId} conversationId={activeId} />
           </>
         )}
       </main>

--- a/src/queries/useRouteContactList.ts
+++ b/src/queries/useRouteContactList.ts
@@ -104,12 +104,18 @@ async function fetchContactLog(ids: string[]): Promise<Map<string, ContatoLog[]>
   const rows: ContactLogRow[] = [];
   for (let i = 0; i < ids.length; i += IN_CHUNK) {
     const chunk = ids.slice(i, i + IN_CHUNK);
-    await paginarLog(from => routeFrom('route_contact_log').select(LOG_SEL).eq('canal', 'ligacao')
-      .in('customer_user_id', chunk).eq('status', 'opt_out')
-      .order('created_at', { ascending: true }).range(from, from + PAGE - 1) as PromiseLike<PgRes>, rows);
-    await paginarLog(from => routeFrom('route_contact_log').select(LOG_SEL).eq('canal', 'ligacao')
-      .in('customer_user_id', chunk).gte('created_at', cutoff90)
-      .order('created_at', { ascending: true }).range(from, from + PAGE - 1) as PromiseLike<PgRes>, rows);
+    // Os 2 ramos (opt_out full-history + cadência 90d) são independentes →
+    // PARALELOS por chunk (eram seriais). O sink compartilhado é seguro
+    // (single-thread) e o derivarSinaisContato não depende da ordem global
+    // (já era intercalada por ramo na versão serial); o dedupe abaixo cobre.
+    await Promise.all([
+      paginarLog(from => routeFrom('route_contact_log').select(LOG_SEL).eq('canal', 'ligacao')
+        .in('customer_user_id', chunk).eq('status', 'opt_out')
+        .order('created_at', { ascending: true }).range(from, from + PAGE - 1) as PromiseLike<PgRes>, rows),
+      paginarLog(from => routeFrom('route_contact_log').select(LOG_SEL).eq('canal', 'ligacao')
+        .in('customer_user_id', chunk).gte('created_at', cutoff90)
+        .order('created_at', { ascending: true }).range(from, from + PAGE - 1) as PromiseLike<PgRes>, rows),
+    ]);
   }
   // dedup por (cliente|created_at|status) — opt_out recente aparece nas 2 queries
   const seen = new Set<string>();
@@ -125,20 +131,33 @@ async function fetchContactLog(ids: string[]): Promise<Map<string, ContatoLog[]>
   return byCustomer;
 }
 
-/** Lê TODOS os customer_visit_scores com cidade (pagina o cap de 1000 do PostgREST). */
+/**
+ * Lê TODOS os customer_visit_scores com cidade (~7 páginas de 1000). A 1ª
+ * página traz o count exato e as DEMAIS saem em PARALELO — a versão serial
+ * (7 round-trips encadeados) era o estágio mais lento da fila de ligação,
+ * pago a cada visita à tela (staleTime 60s).
+ */
 async function fetchAllVisitScores(): Promise<VisitScoreRow[]> {
-  const out: VisitScoreRow[] = [];
-  for (let from = 0; ; from += PAGE) {
-    const { data, error } = await supabase
+  const baseSelect = (withCount: boolean) =>
+    supabase
       .from('customer_visit_scores')
-      .select('customer_user_id, farmer_id, city, visit_score')
+      .select('customer_user_id, farmer_id, city, visit_score', withCount ? { count: 'exact' } : undefined)
       .not('city', 'is', null)
-      .order('customer_user_id', { ascending: true })
-      .range(from, from + PAGE - 1);
-    if (error) throw error;
-    const rows = (data ?? []) as VisitScoreRow[];
-    out.push(...rows);
-    if (rows.length < PAGE) break;
+      .order('customer_user_id', { ascending: true });
+
+  const first = await baseSelect(true).range(0, PAGE - 1);
+  if (first.error) throw first.error;
+  const out: VisitScoreRow[] = [...((first.data ?? []) as VisitScoreRow[])];
+  const total = first.count ?? out.length;
+
+  if (total > PAGE) {
+    const ranges: Array<[number, number]> = [];
+    for (let from = PAGE; from < total; from += PAGE) ranges.push([from, from + PAGE - 1]);
+    const pages = await Promise.all(ranges.map(([f, t]) => baseSelect(false).range(f, t)));
+    for (const p of pages) {
+      if (p.error) throw p.error;
+      out.push(...((p.data ?? []) as VisitScoreRow[]));
+    }
   }
   return out;
 }
@@ -196,10 +215,18 @@ export function useRouteContactList(workdayIso: string) {
 
       // 2) candidatos das cidades-alvo (customer_visit_scores é city-aware + RLS por carteira)
       const allScores = await fetchAllVisitScores();
-      const cands0 = allScores.filter(r => {
+      const candsFiltrados = allScores.filter(r => {
         const ck = normalizeCityKey(r.city);
         return ck !== null && prep.cities.some(pc => cityKeyEquals(pc, ck));
       });
+      // Dedupe por cliente: as páginas PARALELAS do fetch podem (raro) trazer
+      // uma linha duplicada em shift de offset — cliente 2× na fila ocuparia
+      // 2 slots de capacidade e geraria 2 ligações.
+      const candByUser = new Map<string, VisitScoreRow>();
+      for (const r of candsFiltrados) {
+        if (!candByUser.has(r.customer_user_id)) candByUser.set(r.customer_user_id, r);
+      }
+      const cands0 = [...candByUser.values()];
       if (cands0.length === 0) return empty;
 
       // 3) métricas econômicas + perfis (nome/telefone) em lote
@@ -207,24 +234,26 @@ export function useRouteContactList(workdayIso: string) {
       const farmerIds = [...new Set(cands0.map(c => c.farmer_id).filter((x): x is string => !!x))];
       const profileIds = [...new Set([...userIds, ...farmerIds])];
 
-      const [metrics, profiles] = await Promise.all([fetchMetrics(userIds), fetchProfiles(profileIds)]);
-      const mByUser = new Map(metrics.map(m => [m.customer_user_id, m]));
-      const pByUser = new Map(profiles.map(p => [p.user_id, p]));
-
-      // cadência ao vivo: lê route_contact_log e deriva os sinais por cliente. Fail-open:
-      // erro de leitura → defaults (fila funciona como antes), NÃO esconde cliente.
+      // Métricas + perfis + log de contato dependem SÓ de userIds → 1 rodada
+      // PARALELA (o log era um await separado DEPOIS de metrics/profiles).
+      // O fail-open do log (erro → defaults, NÃO esconde cliente) é preservado
+      // pelo catch inline — falha do log não derruba os outros dois.
       const hoje = spBusinessDate(new Date());
       // mesmo fallback da UI (RotaListaLigacao grava data_rota = routeDate ?? workday) — senão em dia
       // de diária (routeDate null) o convertido gravado com workday nunca casaria → some de "Resolvidos".
       const dataRotaFila = prep.routeDate ?? workdayIso;
-      let logByCustomer = new Map<string, ContatoLog[]>();
       let cadenciaIndisponivel = false;
-      try {
-        logByCustomer = await fetchContactLog(userIds);
-      } catch (e) {
-        cadenciaIndisponivel = true;
-        logger.warn('Leitura de route_contact_log falhou — cadência ao vivo indisponível', { error: e instanceof Error ? e.message : String(e) });
-      }
+      const [metrics, profiles, logByCustomer] = await Promise.all([
+        fetchMetrics(userIds),
+        fetchProfiles(profileIds),
+        fetchContactLog(userIds).catch((e) => {
+          cadenciaIndisponivel = true;
+          logger.warn('Leitura de route_contact_log falhou — cadência ao vivo indisponível', { error: e instanceof Error ? e.message : String(e) });
+          return new Map<string, ContatoLog[]>();
+        }),
+      ]);
+      const mByUser = new Map(metrics.map(m => [m.customer_user_id, m]));
+      const pByUser = new Map(profiles.map(p => [p.user_id, p]));
       const sinaisByCustomer = new Map<string, SinaisContato>();
       for (const id of userIds) {
         sinaisByCustomer.set(id, derivarSinaisContato(logByCustomer.get(id) ?? [], hoje, dataRotaFila));

--- a/src/queries/useWhatsappInbox.ts
+++ b/src/queries/useWhatsappInbox.ts
@@ -1,6 +1,7 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useEffect } from 'react';
 import { supabase } from '@/integrations/supabase/client';
+import { appendRealtimeMessage } from '@/lib/whatsapp/thread-cache';
 
 export interface WaConversation {
   id: string; phone_e164: string | null; contact_name: string | null;
@@ -52,17 +53,24 @@ export function useWhatsappConversations() {
   return q;
 }
 
+/** Últimas N mensagens da thread (render asc). */
+const THREAD_LIMIT = 100;
+
 export function useWhatsappThread(conversationId: string | undefined) {
   const qc = useQueryClient();
   const q = useQuery({
     queryKey: ['whatsapp', 'thread', conversationId],
     queryFn: async () => {
+      // DESC + limit + reverse: as ÚLTIMAS 100 mensagens. A versão sem limit
+      // em ordem asc estourava o cap de 1000 do PostgREST ficando com as 1000
+      // mais ANTIGAS — em conversa longa, as mensagens novas SUMIAM da tela.
       const res = await (waFrom('whatsapp_messages')
         .select('*')
         .eq('conversation_id', conversationId!)
-        .order('created_at', { ascending: true }) as PromiseLike<{ data: unknown; error: { message: string } | null }>);
+        .order('created_at', { ascending: false })
+        .limit(THREAD_LIMIT) as PromiseLike<{ data: unknown; error: { message: string } | null }>);
       if (res.error) throw new Error(res.error.message);
-      return (res.data ?? []) as WaMessage[];
+      return ((res.data ?? []) as WaMessage[]).reverse();
     },
     enabled: !!conversationId,
   });
@@ -70,7 +78,15 @@ export function useWhatsappThread(conversationId: string | undefined) {
     if (!conversationId) return;
     const channel = supabase.channel(`wa-thread-${conversationId}`)
       .on('postgres_changes', { event: 'INSERT', schema: 'public', table: 'whatsapp_messages', filter: `conversation_id=eq.${conversationId}` },
-        () => qc.invalidateQueries({ queryKey: ['whatsapp', 'thread', conversationId] }))
+        (payload) => {
+          // Append INCREMENTAL (helper testado): era invalidate → re-baixava a
+          // conversa inteira a cada mensagem. Dedupe por id; OUT reconcilia a
+          // otimista do próprio envio (ver thread-cache.ts).
+          qc.setQueryData<WaMessage[]>(
+            ['whatsapp', 'thread', conversationId],
+            (old) => appendRealtimeMessage(old, payload.new as WaMessage),
+          );
+        })
       .subscribe();
     return () => { supabase.removeChannel(channel); };
   }, [conversationId, qc]);

--- a/src/queries/useWhatsappSla.ts
+++ b/src/queries/useWhatsappSla.ts
@@ -34,6 +34,48 @@ export async function fetchWhatsappSla(): Promise<WaSlaRow[]> {
 const SLA_QUERY_KEY = ['whatsapp', 'sla'] as const;
 const REALTIME_THROTTLE_MS = 3000;
 
+/* Canal realtime compartilhado entre TODAS as instâncias do hook (module-level
+   de propósito). refcount: cria no 1º acquire, derruba no último release. O
+   QueryClient é único no app (App.tsx) — capturá-lo no 1º acquire é seguro. */
+let slaRealtimeRefs = 0;
+let slaRealtimeTeardown: (() => void) | null = null;
+// Topic GERACIONAL: o removeChannel é async e o client deduplica canal por
+// topic — recriar 'wa-sla' logo após o teardown (navegação Meu Dia → inbox:
+// refs 2→0→1 no mesmo commit) reusaria a instância em state='leaving', cujo
+// subscribe() é no-op e que sai da lista de roteamento quando o phx_leave
+// confirma → realtime morto silencioso. Com o sufixo de geração, cada
+// criação usa um topic virgem e nunca colide com o canal moribundo.
+let slaRealtimeGen = 0;
+
+function acquireSlaRealtime(qc: ReturnType<typeof useQueryClient>): () => void {
+  slaRealtimeRefs++;
+  if (slaRealtimeRefs === 1) {
+    const throttle = createLeadingTrailingThrottle(() => {
+      qc.invalidateQueries({ queryKey: SLA_QUERY_KEY });
+    }, REALTIME_THROTTLE_MS);
+    const ch = supabase.channel(`wa-sla-${++slaRealtimeGen}`)
+      .on('postgres_changes', { event: '*', schema: 'public', table: 'whatsapp_messages' }, throttle.fire)
+      .on('postgres_changes', { event: '*', schema: 'public', table: 'whatsapp_conversations' }, throttle.fire)
+      .subscribe();
+    slaRealtimeTeardown = () => {
+      // cancel, não flush: sem consumidor montado não há quem precise da
+      // invalidação — o próximo mount refaz a query (staleTime 15s).
+      throttle.cancel();
+      supabase.removeChannel(ch);
+    };
+  }
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+    slaRealtimeRefs--;
+    if (slaRealtimeRefs === 0 && slaRealtimeTeardown) {
+      slaRealtimeTeardown();
+      slaRealtimeTeardown = null;
+    }
+  };
+}
+
 export function useWhatsappSla() {
   const qc = useQueryClient();
   const q = useQuery({
@@ -43,35 +85,14 @@ export function useWhatsappSla() {
     refetchIntervalInBackground: false,
     staleTime: 15000,
   });
-  // Realtime: mensagem/conversa nova revalida o SLA — com throttle
-  // leading+trailing (helper testado): o 1º evento invalida na hora; a rajada
-  // (blast de template, sync em lote) colapsa numa revalidação por janela de
-  // 3s. Sem o throttle, cada mensagem de QUALQUER conversa re-executava a
-  // view scan-heavy inteira, por cliente montado.
-  //
-  // ⚠️ Limitação PRÉ-EXISTENTE (achada na revisão deste PR, não introduzida
-  // por ele): o supabase-js REUSA a instância de canal pelo topic 'wa-sla' —
-  // quando DUAS instâncias deste hook montam juntas (ex.: Meu Dia monta
-  // SlaCardMeuDia + useCriticaFila), o segundo subscribe() é no-op e o match
-  // de bindings por índice pode derrubar o canal inteiro (CHANNEL_ERROR
-  // silencioso). O realtime do SLA nessas telas fica por conta do poll de
-  // 30s. Fix de verdade (canal singleton com refcount) está no mapa da
-  // auditoria de 2026-06-09 — Onda 3, junto do trabalho de WhatsApp.
-  useEffect(() => {
-    const throttle = createLeadingTrailingThrottle(() => {
-      qc.invalidateQueries({ queryKey: SLA_QUERY_KEY });
-    }, REALTIME_THROTTLE_MS);
-    const ch = supabase.channel('wa-sla')
-      .on('postgres_changes', { event: '*', schema: 'public', table: 'whatsapp_messages' }, throttle.fire)
-      .on('postgres_changes', { event: '*', schema: 'public', table: 'whatsapp_conversations' }, throttle.fire)
-      .subscribe();
-    return () => {
-      // cancel, não flush: componente desmontado não precisa invalidar — o
-      // próximo mount refaz a query (staleTime 15s) de qualquer forma.
-      throttle.cancel();
-      supabase.removeChannel(ch);
-    };
-  }, [qc]);
+  // Realtime SINGLETON com refcount (fix da Onda 3): o supabase-js REUSA a
+  // instância de canal pelo topic 'wa-sla' — duas instâncias deste hook
+  // montadas juntas (Meu Dia: SlaCardMeuDia + useCriticaFila) faziam o 2º
+  // subscribe() ser no-op e o match de bindings por índice podia derrubar o
+  // canal inteiro (CHANNEL_ERROR silencioso, realtime morto). O canal nasce
+  // no 1º consumidor e morre no último; o throttle continua colapsando a
+  // rajada (blast/sync em lote) numa revalidação por janela de 3s.
+  useEffect(() => acquireSlaRealtime(qc), [qc]);
   return q;
 }
 


### PR DESCRIPTION
## O que é (Onda 3 da auditoria de 2026-06-09 — o dia a dia da vendedora)

### B2 — bug real da thread do WhatsApp
A thread era `select * ASC` **sem limit**: conversa com >1000 mensagens estourava o cap do PostgREST ficando com as 1000 mais **antigas** — as novas sumiam da tela. Agora: últimas 100 (`desc+limit+reverse`) e o realtime faz **append incremental** (helper puro testado, dedupe por id) em vez de re-baixar a conversa inteira a cada mensagem.

### #18 — feedback imediato nas ações quentes
- **Enviar WhatsApp**: optimistic — mensagem aparece **no clique** (balão "enviando"), draft limpa na hora e restaura em erro. Rollback **cirúrgico por id** (snapshot-restore apagaria mensagens INBOUND do cliente chegadas via realtime durante o send — achado adversarial). `persisted:false` da edge não invalida (evita re-envio duplicado pro cliente). `ReplyForm` com estado próprio (digitar não re-renderiza as 200 conversas).
- **Tarefas**: concluir/adiar/responder-sugestão otimistas com rollback cirúrgico; **adiar é update no lugar** (a view mantém a adiada listada — remover causava "adiei e voltou"); dialog com pending.

### B3 — erro deixa de virar falso-verde em motor de receita
FilaDoDia (*"carteira em dia"*), RotaListaLigacao (*"sem rota"*) e WhatsappInbox (*"sem conversas"* durante loading) ganham estados de loading/erro com **Tentar de novo**; aviso de lista parcial quando só uma fonte falha.

### #16-lite — fila de rota: ~11 → ~4 rodadas de rede
Scores paginados em **paralelo** pós-count (eram 7 round-trips seriais), log de contato junto de metrics/profiles no mesmo `Promise.all` (fail-open preservado), 2 ramos do log paralelos, dedupe por cliente. O **#16-full** (filtro de cidade server-side via `city_key` persistida) fica como follow-up com migration — o modo de falha de um filtro errado ali é cliente sumindo da fila em silêncio, então vai com rito completo.

### Singleton do canal realtime do SLA (fecha o achado da Onda 1)
Canal `wa-sla` com **refcount + topic geracional**: 2 instâncias do hook não quebram mais o canal (binding-mismatch), e a navegação Meu Dia → inbox não reusa canal moribundo (o `removeChannel` é async e o client deduplica por topic — achado adversarial).

## Revisão adversarial (subagente)
3 P2 achados e **corrigidos neste PR** (rollback destrutivo do send · canal moribundo reusado · adiar some-e-volta) + dedupe da fila. 8 verificações explícitas OK (reverse/structural sharing, troca de conversa com send em voo, sends concorrentes mesmo body, RLS no count, fail-open, retry). Follow-ups anotados: paginação reversa da thread ("carregar anteriores", conversas 100-1000 msgs); update de tarefa sem checagem no `resolverSugestao` (pré-existente). Codex indisponível (cota) — retroativo anotado.

## Validação
- Testes novos: `thread-cache` (7) · `bun run typecheck` (strict) ✅ · `bun run test` **2966/2966** ✅ · `bun lint` 0 errors ✅
- Sem migration, sem deploy de edge.

⚠️ Pós-merge: **Publish no Lovable**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)