### PR TITLE
perf(boot+pwa): Onda 4 — jssip fora do entry (−56%) + precache PWA enxuto (−21%) (#17+#20)

### DIFF
--- a/src/components/call/IncomingCallModal.tsx
+++ b/src/components/call/IncomingCallModal.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useWebRTCCallContextOptional } from '@/contexts/WebRTCCallContext';
+import { useWebRTCCallContextOptional } from '@/contexts/webrtc-call-context';
 import {
   Dialog,
   DialogContent,

--- a/src/components/call/TransferSpikePanel.tsx
+++ b/src/components/call/TransferSpikePanel.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useFeatureFlag } from '@/hooks/useFeatureFlag';
-import { useWebRTCCallContextOptional } from '@/contexts/WebRTCCallContext';
+import { useWebRTCCallContextOptional } from '@/contexts/webrtc-call-context';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 

--- a/src/components/call/WebRTCDialer.tsx
+++ b/src/components/call/WebRTCDialer.tsx
@@ -1,7 +1,7 @@
 import { useId } from 'react';
 import { toast } from 'sonner';
 import { isLensActive } from '@/lib/impersonation/lens-write-guard';
-import { useWebRTCCallContextOptional } from '@/contexts/WebRTCCallContext';
+import { useWebRTCCallContextOptional } from '@/contexts/webrtc-call-context';
 import { CallDialerView, type CallDialerViewProps } from './CallDialerView';
 
 type Props = Pick<CallDialerViewProps, 'phoneNumber' | 'customerName' | 'onCallEnd' | 'compact' | 'floating'>;

--- a/src/components/call/__tests__/WebRTCDialer.test.tsx
+++ b/src/components/call/__tests__/WebRTCDialer.test.tsx
@@ -8,7 +8,7 @@ const makeCall = vi.fn();
 // contexto (ocioso × ocupado) entre os testes.
 const h = vi.hoisted(() => ({ ctx: null as unknown }));
 
-vi.mock('@/contexts/WebRTCCallContext', () => ({
+vi.mock('@/contexts/webrtc-call-context', () => ({
   useWebRTCCallContextOptional: () => h.ctx,
 }));
 

--- a/src/components/dashboard/AgendaTodayList.tsx
+++ b/src/components/dashboard/AgendaTodayList.tsx
@@ -6,7 +6,7 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Phone, AlertTriangle, TrendingUp, Clock, Loader2 } from 'lucide-react';
 import { useMyAgendaToday, type AgendaItem } from '@/hooks/useMyAgendaToday';
-import { useWebRTCCallContext } from '@/contexts/WebRTCCallContext';
+import { useWebRTCCallContext } from '@/contexts/webrtc-call-context';
 import { toast } from 'sonner';
 import { SignalModifierBadge } from './SignalModifierBadge';
 

--- a/src/contexts/WebRTCCallContext.tsx
+++ b/src/contexts/WebRTCCallContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useEffect, useRef, useState, useCallback, type ReactNode } from 'react';
+import { useEffect, useRef, useState, useCallback, type ReactNode } from 'react';
 import { SipClient } from '@/lib/sip/sip-client';
 import type { SipCallState, IncomingCallInfo } from '@/lib/sip/types';
 import { invokeFunction } from '@/lib/invoke-function';
@@ -7,18 +7,23 @@ import { toast } from 'sonner';
 import { normalizeBrPhone, formatBrPhone } from '@/lib/phone';
 import { mixPrerollWithMic } from '@/lib/sip/audio-preroll';
 import { useTranscription } from '@/hooks/useTranscription';
-import type { TranscriptTurn, TranscriptionStatus } from '@/lib/transcription/types';
+import type { TranscriptTurn } from '@/lib/transcription/types';
 import { useSpinAnalysis } from '@/hooks/useSpinAnalysis';
-import type { SpinAnalysis, SpinAnalysisStatus } from '@/lib/spin/types';
+import type { SpinAnalysis } from '@/lib/spin/types';
 import { resolveCustomerByPhone } from '@/lib/call-session/resolve-customer';
 import { buildSessionPayload } from '@/lib/call-session/build-session-payload';
 import { resolveCallParty, shouldAutoRecord } from '@/lib/call-log/recording-policy';
 import { logCallStart, logAnswered, logClosed, enrichCallLog, markRecorded } from '@/lib/call-log/record';
 import { isLensActive } from '@/lib/impersonation/lens-write-guard';
-
-export type WebRTCCallState =
-  | 'idle' | 'connecting' | 'calling_origin' | 'calling_destination'
-  | 'established' | 'finished' | 'noanswer' | 'busy' | 'failed' | 'error';
+// O context OBJECT + hooks + types vivem no módulo LEVE webrtc-call-context.ts
+// (sem jssip). Este .tsx é o Provider PESADO — só o ConditionalWebRTCProvider
+// pode importá-lo (via dynamic import); consumidores usam o módulo leve.
+// Guardrail: src/contexts/__tests__/webrtc-context-split.test.ts.
+import {
+  WebRTCCallContext,
+  type WebRTCCallContextValue,
+  type WebRTCCallState,
+} from './webrtc-call-context';
 
 const SIP_TO_PUBLIC: Record<SipCallState, WebRTCCallState> = {
   idle: 'idle',
@@ -32,57 +37,6 @@ const SIP_TO_PUBLIC: Record<SipCallState, WebRTCCallState> = {
   ended: 'finished',
   failed: 'failed',
 };
-
-export interface WebRTCCallContextValue {
-  callState: WebRTCCallState;
-  callId: string | null;
-  callDuration: number;
-  audioLink: string | null;
-  makeCall: (phoneNumber: string, opts?: { forceRecord?: boolean }) => Promise<void>;
-  endCall: () => Promise<void>;
-  /** Ownership de UI: id do <WebRTCDialer> que iniciou a chamada atual (via claimCall).
-   *  Em telas com VÁRIOS dialers (listas), só o dono reflete o estado ativo — os
-   *  demais ficam idle. Sem isso, todos mostrariam o card e disparariam onCallEnd
-   *  (a sessão WebRTC é única/global), registrando a chamada na linha errada. */
-  callOwnerId: string | null;
-  claimCall: (ownerId: string) => void;
-  isActive: boolean;
-  isConnecting: boolean;
-  isRinging: boolean;
-  isEstablished: boolean;
-  isFinished: boolean;
-  error: string | null;
-  localStream: MediaStream | null;
-  remoteStream: MediaStream | null;
-  // NEW in PR1.6:
-  isMuted: boolean;
-  toggleMute: () => void;
-  /** SPIKE (flag telefoniaTransferSpike): dispara transferência da chamada ativa p/ um ramal. */
-  spikeTransfer?: (extension: string, method: 'dtmf' | 'refer') => void;
-  /** true durante reprodução do pre-roll LGPD; false antes/depois */
-  prerollPlaying: boolean;
-  /** timestamp (Date.now()) em que o preroll termina; null se sem preroll */
-  prerollEndsAt: number | null;
-  /** Stream raw do mic do vendedor (sem preroll mixado).
-   *  Exposto pra TranscriptionEngine usar como canal "vendedor". */
-  vendorMicStream: MediaStream | null;
-  /** Status da transcrição ao vivo (idle/connecting/active/error) */
-  transcriptionStatus: TranscriptionStatus;
-  /** Turnos de transcrição em ordem cronológica */
-  transcriptionTurns: TranscriptTurn[];
-  /** Mensagem de erro da transcrição, se houver */
-  transcriptionError: string | null;
-  /** Análise SPIN ao vivo da conversa atual. null se ainda não rodou. */
-  spinAnalysis: SpinAnalysis | null;
-  spinAnalysisStatus: SpinAnalysisStatus;
-  spinAnalysisError: string | null;
-  /** PR-INBOUND-CALLS: chamada inbound pendente esperando accept/reject */
-  incomingCall: IncomingCallInfo | null;
-  acceptIncoming: () => Promise<void>;
-  rejectIncoming: () => void;
-}
-
-const WebRTCCallContext = createContext<WebRTCCallContextValue | null>(null);
 
 /**
  * Persiste a sessão de chamada em `farmer_calls` ao final.
@@ -599,23 +553,4 @@ export function WebRTCCallProvider({ children }: ProviderProps) {
   };
 
   return <WebRTCCallContext.Provider value={value}>{children}</WebRTCCallContext.Provider>;
-}
-
-// Provider + hook colocados no mesmo arquivo por design (acoplamento forte:
-// hook só faz sentido com o Provider que define a shape). Splitting iria
-// adicionar indireção sem valor. Fast refresh ainda funciona pro Provider.
-// eslint-disable-next-line react-refresh/only-export-components
-export function useWebRTCCallContext(): WebRTCCallContextValue {
-  const ctx = useContext(WebRTCCallContext);
-  if (!ctx) {
-    throw new Error('useWebRTCCallContext must be used within a WebRTCCallProvider');
-  }
-  return ctx;
-}
-
-// Safe variant — retorna null se não houver Provider (ex: customer, ou enquanto
-// o ConditionalWebRTCProvider ainda está carregando via Suspense).
-// eslint-disable-next-line react-refresh/only-export-components
-export function useWebRTCCallContextOptional(): WebRTCCallContextValue | null {
-  return useContext(WebRTCCallContext);
 }

--- a/src/contexts/__tests__/WebRTCCallContext.test.tsx
+++ b/src/contexts/__tests__/WebRTCCallContext.test.tsx
@@ -66,7 +66,8 @@ vi.mock('@/lib/call-log/record', () => ({
   markRecorded: vi.fn(async () => {}),
 }));
 
-import { WebRTCCallProvider, useWebRTCCallContext } from '../WebRTCCallContext';
+import { WebRTCCallProvider } from '../WebRTCCallContext';
+import { useWebRTCCallContext } from '../webrtc-call-context';
 import { SipClient } from '@/lib/sip/sip-client';
 
 const wrapper = ({ children }: { children: ReactNode }) => (

--- a/src/contexts/__tests__/webrtc-context-split.test.ts
+++ b/src/contexts/__tests__/webrtc-context-split.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { execSync } from 'node:child_process';
+
+/**
+ * Guardrail do split do contexto WebRTC (Onda 4 da auditoria de velocidade).
+ *
+ * O WebRTCCallContext.tsx (Provider) importa SipClient → jssip (~250KB) de
+ * forma ESTÁTICA. Qualquer import estático dele a partir de um módulo
+ * alcançável pelo entry (ex.: IncomingCallModal, montado no AppShellLayout)
+ * arrasta o jssip pro main bundle e ANULA o lazy do ConditionalWebRTCProvider
+ * — o Rollup não splitta módulo que também é alcançável estaticamente. Foi
+ * exatamente assim que o jssip voltou pro entry (medido em 2026-06-10).
+ *
+ * Regra: consumidores importam o módulo LEVE '@/contexts/webrtc-call-context'
+ * (context object + hooks + types). O .tsx pesado só pode ser referenciado:
+ *   - pelo ConditionalWebRTCProvider (via DYNAMIC import);
+ *   - por testes (__tests__), que não entram no bundle.
+ */
+describe('guardrail: split do WebRTCCallContext (jssip fora do entry)', () => {
+  it("nenhum módulo de produção importa '@/contexts/WebRTCCallContext' estaticamente", () => {
+    let out = '';
+    try {
+      // -l: só nomes de arquivo. Cobre o alias (@/contexts/...) E imports
+      // RELATIVOS (./WebRTCCallContext, ../contexts/WebRTCCallContext) — um
+      // vizinho em src/contexts/ importando relativo furaria o guard só-alias.
+      out = execSync(
+        `grep -rlnE "from ['\\"][^'\\"]*WebRTCCallContext['\\"]" src --include='*.ts' --include='*.tsx'`,
+        { encoding: 'utf8', cwd: process.cwd() },
+      );
+    } catch {
+      // grep exit 1 = zero matches → perfeito.
+      out = '';
+    }
+    const offenders = out
+      .split('\n')
+      .filter(Boolean)
+      .filter((f) => !f.includes('__tests__'));
+    expect(
+      offenders,
+      `Import ESTÁTICO do Provider pesado detectado (arrasta jssip pro entry). ` +
+        `Importe '@/contexts/webrtc-call-context' (módulo leve) em vez disso. Arquivos: ${offenders.join(', ')}`,
+    ).toEqual([]);
+  });
+
+  it('o ConditionalWebRTCProvider continua carregando o Provider via dynamic import', () => {
+    const src = execSync('cat src/contexts/ConditionalWebRTCProvider.tsx', {
+      encoding: 'utf8',
+      cwd: process.cwd(),
+    });
+    expect(src).toMatch(/import\(['"]\.\/WebRTCCallContext['"]\)/);
+  });
+});

--- a/src/contexts/webrtc-call-context.ts
+++ b/src/contexts/webrtc-call-context.ts
@@ -1,0 +1,89 @@
+import { createContext, useContext } from 'react';
+import type { IncomingCallInfo } from '@/lib/sip/types';
+import type { TranscriptTurn, TranscriptionStatus } from '@/lib/transcription/types';
+import type { SpinAnalysis, SpinAnalysisStatus } from '@/lib/spin/types';
+
+/**
+ * Context OBJECT + hooks do WebRTC — módulo LEVE, separado de propósito do
+ * WebRTCCallContext.tsx (o Provider pesado, que importa SipClient → jssip,
+ * ~250KB). Consumidores de UI (IncomingCallModal, WebRTCDialer,
+ * TransferSpikePanel, AgendaTodayList, useWebRTCCall) importam DAQUI: como o
+ * IncomingCallModal monta no AppShellLayout (grafo estático do entry), um
+ * import do .tsx arrastava o jssip inteiro pro main bundle — medido no build
+ * de 2026-06-10 — e anulava o lazy do ConditionalWebRTCProvider (o Rollup não
+ * splitta módulo alcançável estaticamente). Os imports acima são type-only
+ * (apagados na compilação) — este módulo custa ~zero bytes.
+ *
+ * ⛔ NÃO importe '@/contexts/WebRTCCallContext' (o .tsx) fora do
+ * ConditionalWebRTCProvider (que o carrega via dynamic import) — guardrail de
+ * CI em src/contexts/__tests__/webrtc-context-split.test.ts.
+ */
+
+export type WebRTCCallState =
+  | 'idle' | 'connecting' | 'calling_origin' | 'calling_destination'
+  | 'established' | 'finished' | 'noanswer' | 'busy' | 'failed' | 'error';
+
+export interface WebRTCCallContextValue {
+  callState: WebRTCCallState;
+  callId: string | null;
+  callDuration: number;
+  audioLink: string | null;
+  makeCall: (phoneNumber: string, opts?: { forceRecord?: boolean }) => Promise<void>;
+  endCall: () => Promise<void>;
+  /** Ownership de UI: id do <WebRTCDialer> que iniciou a chamada atual (via claimCall).
+   *  Em telas com VÁRIOS dialers (listas), só o dono reflete o estado ativo — os
+   *  demais ficam idle. Sem isso, todos mostrariam o card e disparariam onCallEnd
+   *  (a sessão WebRTC é única/global), registrando a chamada na linha errada. */
+  callOwnerId: string | null;
+  claimCall: (ownerId: string) => void;
+  isActive: boolean;
+  isConnecting: boolean;
+  isRinging: boolean;
+  isEstablished: boolean;
+  isFinished: boolean;
+  error: string | null;
+  localStream: MediaStream | null;
+  remoteStream: MediaStream | null;
+  // NEW in PR1.6:
+  isMuted: boolean;
+  toggleMute: () => void;
+  /** SPIKE (flag telefoniaTransferSpike): dispara transferência da chamada ativa p/ um ramal. */
+  spikeTransfer?: (extension: string, method: 'dtmf' | 'refer') => void;
+  /** true durante reprodução do pre-roll LGPD; false antes/depois */
+  prerollPlaying: boolean;
+  /** timestamp (Date.now()) em que o preroll termina; null se sem preroll */
+  prerollEndsAt: number | null;
+  /** Stream raw do mic do vendedor (sem preroll mixado).
+   *  Exposto pra TranscriptionEngine usar como canal "vendedor". */
+  vendorMicStream: MediaStream | null;
+  /** Status da transcrição ao vivo (idle/connecting/active/error) */
+  transcriptionStatus: TranscriptionStatus;
+  /** Turnos de transcrição em ordem cronológica */
+  transcriptionTurns: TranscriptTurn[];
+  /** Mensagem de erro da transcrição, se houver */
+  transcriptionError: string | null;
+  /** Análise SPIN ao vivo da conversa atual. null se ainda não rodou. */
+  spinAnalysis: SpinAnalysis | null;
+  spinAnalysisStatus: SpinAnalysisStatus;
+  spinAnalysisError: string | null;
+  /** PR-INBOUND-CALLS: chamada inbound pendente esperando accept/reject */
+  incomingCall: IncomingCallInfo | null;
+  acceptIncoming: () => Promise<void>;
+  rejectIncoming: () => void;
+}
+
+export const WebRTCCallContext = createContext<WebRTCCallContextValue | null>(null);
+
+export function useWebRTCCallContext(): WebRTCCallContextValue {
+  const ctx = useContext(WebRTCCallContext);
+  if (!ctx) {
+    throw new Error('useWebRTCCallContext must be used within a WebRTCCallProvider');
+  }
+  return ctx;
+}
+
+/** Safe variant — retorna null se não houver Provider (ex: customer, ou enquanto
+ *  o ConditionalWebRTCProvider ainda está carregando via Suspense). */
+export function useWebRTCCallContextOptional(): WebRTCCallContextValue | null {
+  return useContext(WebRTCCallContext);
+}

--- a/src/hooks/useWebRTCCall.ts
+++ b/src/hooks/useWebRTCCall.ts
@@ -1,4 +1,4 @@
-import { useWebRTCCallContext, type WebRTCCallContextValue, type WebRTCCallState } from '@/contexts/WebRTCCallContext';
+import { useWebRTCCallContext, type WebRTCCallContextValue, type WebRTCCallState } from '@/contexts/webrtc-call-context';
 
 export type { WebRTCCallState };
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -53,6 +53,28 @@ export default defineConfig(({ mode }) => ({
       },
       workbox: {
         globPatterns: ["**/*.{js,css,html,ico,png,svg,woff2}"],
+        // Precache ENXUTO: o SW baixava TODOS os ~250 chunks (~6.2MB) na 1ª
+        // instalação e revalidava a cada deploy — custo real no 4G da
+        // vendedora. Ficam FORA do precache só chunks de telas INERENTEMENTE
+        // online (IA/voz, mapa com tiles de rede, session replay, docs
+        // internas de dev) — offline nelas não funcionaria de qualquer jeito.
+        // Telas operacionais (picking/recebimento/pedido/Meu Dia/rota) e
+        // todos os vendors continuam precacheados (offline-first, §6.1).
+        // Quem sai do precache ganha cobertura PROGRESSIVA pelo runtime
+        // caching de /assets/ (CacheFirst) abaixo: visitou 1× online, fica.
+        globIgnores: [
+          "**/FarmerCopilot-*.js", // ~465KB — copilot de voz (ElevenLabs), exige rede
+          "**/AdminRoutePlanner-*.js", // ~188KB — Leaflet; tiles do mapa exigem rede
+          "**/AdminRoutePlanner-*.css", // CSS do Leaflet (único ignorado com CSS próprio)
+          "**/vendor-posthog-*.js", // ~186KB — posthog-js core (analytics; lazy via analytics.ts)
+          "**/TechnicalDocs-*.js", // ~74KB — documentação interna de dev
+          "**/DesignSystem-*.js", // docs internas de design
+          "**/DesignPreview-*.js",
+          // ⚠️ Case EXATO do chunk (UXRules.tsx): glob é case-insensitive no
+          // macOS (nocase default do darwin) mas case-SENSITIVE no Linux do
+          // builder de produção — grafia errada = ignore morto só em prod.
+          "**/UXRules-*.js",
+        ],
         maximumFileSizeToCacheInBytes: 5 * 1024 * 1024, // 5MB
         skipWaiting: true,
         clientsClaim: true,
@@ -150,6 +172,24 @@ export default defineConfig(({ mode }) => ({
             urlPattern: /^https:\/\/.*\.supabase\.co\/(auth|realtime)/i,
             handler: "NetworkOnly",
           },
+          // ─── Chunks fora do precache: cache progressivo ─────────────
+          // Assets do Vite têm hash no nome (immutable) → CacheFirst é
+          // seguro por construção (conteúdo novo = URL nova). Cobre os
+          // chunks dos globIgnores acima (e qualquer futuro): a 1ª visita
+          // online grava no cache e a tela passa a abrir offline também.
+          // same-origin only (o pattern casa pathname em same-origin).
+          {
+            urlPattern: /\/assets\/.*\.(?:js|css)$/i,
+            handler: "CacheFirst",
+            options: {
+              cacheName: "app-assets-progressive",
+              expiration: {
+                maxEntries: 100,
+                maxAgeSeconds: 30 * 24 * 60 * 60, // 30 dias
+                purgeOnQuotaError: true,
+              },
+            },
+          },
         ],
       },
       devOptions: {
@@ -189,6 +229,11 @@ export default defineConfig(({ mode }) => ({
             if (id.includes('@tanstack/react-query')) return 'vendor-query';
             if (id.includes('@supabase/supabase-js')) return 'vendor-supabase';
             if (id.includes('recharts') || id.includes('d3-')) return 'vendor-charts';
+            // Nome explícito: sem isto o chunk do posthog-js (dynamic import
+            // em analytics.ts) nasce como "module-<hash>.js" (basename do
+            // entry ESM do pacote) — nome genérico que o globIgnores do
+            // precache não consegue mirar com segurança.
+            if (id.includes('posthog-js')) return 'vendor-posthog';
             if (id.includes('framer-motion')) return 'vendor-motion';
             if (id.includes('@radix-ui/')) return 'vendor-ui';
             if (id.includes('lucide-react')) return 'vendor-icons';


### PR DESCRIPTION
## O que é (Onda 4 — última da auditoria de velocidade de 2026-06-09)

### #17 — jssip estava DENTRO do main bundle (entry 472KB → **209KB**, −56%)
O `IncomingCallModal`/`TransferSpikePanel` (montados no AppShellLayout = grafo estático do entry) importavam os hooks do `WebRTCCallContext.tsx`, que importa `SipClient` → **jssip (~250KB) estático** — o Rollup punha o jssip inteiro no entry e **anulava o lazy** do `ConditionalWebRTCProvider` (módulo alcançável estaticamente não splitta; o dynamic import só deduplicava).

**Fix:** context object + hooks + types extraídos pro módulo leve `src/contexts/webrtc-call-context.ts` (imports type-only, ~zero bytes); o `.tsx` vira Provider-only; 5 consumidores migrados; **guardrail de CI** novo proíbe import estático do `.tsx` (alias e relativo) fora de testes. Medido no build: **JsSIP 0× no entry**; foi pro chunk lazy de 261KB (staff-only, pós-boot). A lente "Ver como" segue guardada **na fonte** (`isLensActive` em makeCall/spikeTransfer/acceptIncoming — verificado).

### #20 — primeira instalação do PWA: 6.2MB → **4.88MB** (−21% no 4G da vendedora)
O SW precacheava TODOS os ~260 chunks. Saíram **só** telas inerentemente online: FarmerCopilot (465KB voz/IA), AdminRoutePlanner (Leaflet — tiles exigem rede), posthog core (186KB), docs internas de dev. **Offline-first preservado** (§6.1): picking, recebimento, pedido, Meu Dia e rota verificados DENTRO do manifest. Novo runtimeCaching `CacheFirst` de `/assets/` (hash no nome = immutable) dá cobertura offline **progressiva** pro que saiu: visitou 1× online, fica.

### Decisões registradas
- **#19 (prefetch) não implementado de propósito**: com o precache operacional mantido, o SW já é o prefetch — seria código morto.
- **#17b e B4 já estavam na main** (lazy do provider + `vite:preloadError`/watchdog de boot).

## Revisão adversarial (subagente)
Split **aprovado com prova no build** (context object 1× no dist — sem dupla instância; 37/37 guardrails da lente). 3 achados corrigidos no PR: glob `UxRules` com case errado (`nocase` só no macOS — **no Linux do builder de produção o ignore morria silencioso**); chunk genérico `module-*` → `vendor-posthog` nomeado via manualChunks; guardrail ampliado pra import relativo. Rebuild + manifest re-verificado pós-fixes. Codex retroativo pendente (cota).

## Validação
- `bun run typecheck` ✅ · `bun run test` **2985/2985** ✅ (guardrail novo + teste do dialer com mock migrado) · `bun lint` ✅
- Build real verificado nos bytes: entry sem JsSIP, manifest do sw.js sem vazamentos, críticos offline dentro.
- Sem migration, sem deploy de edge.

⚠️ Pós-merge: **Publish no Lovable**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)