### PR TITLE
feat(whatsapp): "carregar mensagens anteriores" na thread — fecha a regressão da janela de 100

### DIFF
--- a/src/lib/whatsapp/__tests__/thread-cache.test.ts
+++ b/src/lib/whatsapp/__tests__/thread-cache.test.ts
@@ -3,6 +3,8 @@ import {
   appendRealtimeMessage,
   montarMensagemOtimista,
   isOptimisticMessage,
+  prependOlderMessages,
+  mergeThreadWindow,
 } from '@/lib/whatsapp/thread-cache';
 import type { WaMessage } from '@/queries/useWhatsappInbox';
 
@@ -66,5 +68,109 @@ describe('montarMensagemOtimista', () => {
     expect(m.body).toBe('olá');
     expect(m.status).toBe('enviando');
     expect(m.conversation_id).toBe('c1');
+  });
+});
+
+describe('prependOlderMessages (carregar mensagens anteriores)', () => {
+  it('prepend simples: página antiga entra ANTES do cache', () => {
+    const old = [msg('m3'), msg('m4')];
+    const { next, added } = prependOlderMessages(old, [msg('m1'), msg('m2')]);
+    expect(next?.map((m) => m.id)).toEqual(['m1', 'm2', 'm3', 'm4']);
+    expect(added).toBe(2);
+  });
+
+  it('dedupe por id: a duplicata do cursor (.lte re-baixa) é descartada', () => {
+    const old = [msg('m2'), msg('m3')];
+    const { next, added } = prependOlderMessages(old, [msg('m1'), msg('m2')]);
+    expect(next?.map((m) => m.id)).toEqual(['m1', 'm2', 'm3']);
+    expect(added).toBe(1);
+  });
+
+  it('página só com duplicatas → added=0 e MESMA referência (sem re-render)', () => {
+    const old = [msg('m1'), msg('m2')];
+    const { next, added } = prependOlderMessages(old, [msg('m1'), msg('m2')]);
+    expect(next).toBe(old);
+    expect(added).toBe(0);
+  });
+
+  it('cache ausente → não cria (added=0)', () => {
+    const { next, added } = prependOlderMessages(undefined, [msg('m1')]);
+    expect(next).toBeUndefined();
+    expect(added).toBe(0);
+  });
+});
+
+describe('mergeThreadWindow (refetch não descarta histórico carregado)', () => {
+  const t = (h: string) => `2026-06-10T${h}:00Z`;
+
+  it('preserva mensagens antigas reais ANTES da janela fresca', () => {
+    const prev = [
+      msg('h1', { created_at: t('08:00') }),
+      msg('h2', { created_at: t('09:00') }),
+      msg('m3', { created_at: t('10:00') }),
+    ];
+    const janela = [
+      msg('m3', { created_at: t('10:00') }),
+      msg('m4', { created_at: t('11:00') }),
+    ];
+    expect(mergeThreadWindow(prev, janela).map((m) => m.id)).toEqual(['h1', 'h2', 'm3', 'm4']);
+  });
+
+  it('otimista órfã do cache anterior morre no refetch (comportamento de antes)', () => {
+    const orfa = montarMensagemOtimista('c1', 'falhou?', t('09:30'));
+    const prev = [msg('h1', { created_at: t('08:00') }), orfa];
+    const janela = [msg('m3', { created_at: t('10:00') })];
+    const out = mergeThreadWindow(prev, janela);
+    expect(out.some(isOptimisticMessage)).toBe(false);
+    expect(out.map((m) => m.id)).toEqual(['h1', 'm3']);
+  });
+
+  it('empate de timestamp na borda da janela não some (<= + dedupe)', () => {
+    const prev = [msg('irma', { created_at: t('10:00') }), msg('m3', { created_at: t('10:00') })];
+    const janela = [msg('m3', { created_at: t('10:00') }), msg('m4', { created_at: t('11:00') })];
+    expect(mergeThreadWindow(prev, janela).map((m) => m.id)).toEqual(['irma', 'm3', 'm4']);
+  });
+
+  it('cache vazio/ausente → janela fresca', () => {
+    const janela = [msg('m1')];
+    expect(mergeThreadWindow(undefined, janela)).toBe(janela);
+    expect(mergeThreadWindow([], janela)).toBe(janela);
+  });
+
+  it('janela vazia (servidor diz que não há nada) → vazio, não preserva stale', () => {
+    expect(mergeThreadWindow([msg('h1')], [])).toEqual([]);
+  });
+
+  it('sufixo REAL mais novo que a janela é preservado (inbound do realtime durante o RTT do refetch)', () => {
+    // O cliente respondeu DEPOIS do snapshot do SELECT: o append do realtime
+    // está no cache mas não na janela — descartá-lo sumia com a mensagem.
+    const prev = [
+      msg('m3', { created_at: t('10:00') }),
+      msg('inbound-rtt', { created_at: t('12:00') }),
+    ];
+    const janela = [msg('m3', { created_at: t('10:00') }), msg('m4', { created_at: t('11:00') })];
+    expect(mergeThreadWindow(prev, janela).map((m) => m.id)).toEqual(['m3', 'm4', 'inbound-rtt']);
+  });
+
+  it('otimista mais nova que a janela NÃO entra no sufixo (continua morrendo no refetch)', () => {
+    const orfa = montarMensagemOtimista('c1', 'em voo', t('12:00'));
+    const prev = [msg('m3', { created_at: t('10:00') }), orfa];
+    const janela = [msg('m3', { created_at: t('10:00') }), msg('m4', { created_at: t('11:00') })];
+    expect(mergeThreadWindow(prev, janela).map((m) => m.id)).toEqual(['m3', 'm4']);
+  });
+
+  it('ANTI-BURACO: janela CHEIA sem nenhum overlap com o cache → descarta o cache (sem costura não-contígua)', () => {
+    // Realtime morto perdeu >100 mensagens: cache [A1..] e janela [B...] sem
+    // id em comum — costurar criaria buraco invisível no meio da conversa.
+    const prev = Array.from({ length: 3 }, (_, i) => msg(`A${i}`, { created_at: t('08:00') }));
+    const janela = Array.from({ length: 100 }, (_, i) =>
+      msg(`B${i}`, { created_at: t('10:00') }));
+    expect(mergeThreadWindow(prev, janela)).toBe(janela);
+  });
+
+  it('janela PARCIAL (alcança o início da conversa) sem overlap → merge normal preserva antigas', () => {
+    const prev = [msg('h1', { created_at: t('08:00') })];
+    const janela = [msg('m3', { created_at: t('10:00') })]; // 1 < THREAD_LIMIT
+    expect(mergeThreadWindow(prev, janela).map((m) => m.id)).toEqual(['h1', 'm3']);
   });
 });

--- a/src/lib/whatsapp/thread-cache.ts
+++ b/src/lib/whatsapp/thread-cache.ts
@@ -1,5 +1,8 @@
 import type { WaMessage } from '@/queries/useWhatsappInbox';
 
+/** Tamanho da janela da thread (fetch inicial e cada página de histórico). */
+export const THREAD_LIMIT = 100;
+
 /** Prefixo das mensagens otimistas injetadas pelo useSendWhatsapp (onMutate). */
 export const OPTIMISTIC_MSG_PREFIX = 'optimistic-';
 
@@ -53,4 +56,73 @@ export function appendRealtimeMessage(
     }
   }
   return [...old, nova];
+}
+
+/**
+ * PREPEND de uma página de histórico ("carregar mensagens anteriores") no
+ * cache da thread. A página chega em ordem ASC (já revertida pelo caller).
+ *
+ * O fetch da página usa `.lte(created_at_da_mais_antiga)` — NÃO `.lt` — pra
+ * não perder mensagens irmãs com o MESMO timestamp do cursor que ficaram fora
+ * da janela anterior; o preço são duplicatas re-baixadas, descartadas aqui
+ * pelo dedupe por id. `added` permite ao caller detectar fim de histórico e
+ * falta de progresso (guard anti-loop do caso patológico de empate em massa).
+ */
+export function prependOlderMessages(
+  old: WaMessage[] | undefined,
+  pagina: WaMessage[],
+): { next: WaMessage[] | undefined; added: number } {
+  if (!old) return { next: undefined, added: 0 };
+  const ids = new Set(old.map((m) => m.id));
+  const novas = pagina.filter((m) => !ids.has(m.id));
+  if (novas.length === 0) return { next: old, added: 0 };
+  return { next: [...novas, ...old], added: novas.length };
+}
+
+/**
+ * Merge do refetch da thread com o cache anterior: o refetch baixa SÓ a
+ * janela recente (últimas THREAD_LIMIT), mas o cache pode conter HISTÓRICO
+ * carregado via "mensagens anteriores" — sem este merge, o invalidate de
+ * reconciliação do envio (useSendWhatsapp.onSuccess) descartaria o histórico
+ * carregado e a tela "pularia" de volta pras últimas 100.
+ *
+ * Mantém do cache anterior só mensagens REAIS (otimista órfã continua
+ * morrendo no refetch, comportamento de antes) anteriores-ou-iguais ao início
+ * da janela (`<=` + dedupe por id: empate de timestamp na borda não some), e
+ * cola a janela fresca por cima. created_at é ISO uniforme do PostgREST →
+ * comparação lexicográfica é segura.
+ */
+export function mergeThreadWindow(
+  prev: WaMessage[] | undefined,
+  janelaRecente: WaMessage[],
+): WaMessage[] {
+  if (!prev || prev.length === 0 || janelaRecente.length === 0) return janelaRecente;
+  const ids = new Set(janelaRecente.map((m) => m.id));
+
+  // Guard anti-buraco (revisão adversarial): janela CHEIA sem NENHUM id em
+  // comum com o cache = impossível provar continuidade — o realtime pode ter
+  // perdido >THREAD_LIMIT mensagens (canal morto, aba suspensa) e costurar
+  // [antigas + janela] renderizaria a conversa com um BURACO invisível no
+  // meio, que nem o botão de histórico cura (o cursor é a mais antiga).
+  // Nesse caso, descarta o cache (comportamento pré-merge: pula pras últimas
+  // 100, sem buraco). Em operação saudável o overlap é sempre ≥1.
+  if (janelaRecente.length >= THREAD_LIMIT && !prev.some((m) => ids.has(m.id))) {
+    return janelaRecente;
+  }
+
+  const inicioJanela = janelaRecente[0].created_at;
+  const fimJanela = janelaRecente[janelaRecente.length - 1].created_at;
+  const antigasReais = prev.filter(
+    (m) => !isOptimisticMessage(m) && !ids.has(m.id) && m.created_at <= inicioJanela,
+  );
+  // Sufixo: mensagens REAIS do cache mais novas que a janela — são appends do
+  // realtime que chegaram DURANTE o RTT do refetch (o SELECT já tinha tirado
+  // o snapshot). Sem isto, o merge descartava a INBOUND do cliente chegada
+  // nessa janela (~100-400ms) e ela sumia da tela até o próximo refetch. A
+  // tabela é append-only → não há risco de ressuscitar mensagem apagada.
+  const novasReais = prev.filter(
+    (m) => !isOptimisticMessage(m) && !ids.has(m.id) && m.created_at > fimJanela,
+  );
+  if (antigasReais.length === 0 && novasReais.length === 0) return janelaRecente;
+  return [...antigasReais, ...janelaRecente, ...novasReais];
 }

--- a/src/pages/WhatsappInbox.tsx
+++ b/src/pages/WhatsappInbox.tsx
@@ -1,10 +1,10 @@
 import { useMemo, useState } from 'react';
 import { MessageCircle } from 'lucide-react';
-import { useWhatsappConversations, useWhatsappThread } from '@/queries/useWhatsappInbox';
+import { useWhatsappConversations, useWhatsappThread, useLoadOlderWhatsappMessages } from '@/queries/useWhatsappInbox';
 import { useWhatsappSla } from '@/queries/useWhatsappSla';
 import { SlaBadge } from '@/components/whatsapp/SlaBadge';
 import { useSendWhatsapp } from '@/hooks/useSendWhatsapp';
-import { isOptimisticMessage } from '@/lib/whatsapp/thread-cache';
+import { isOptimisticMessage, THREAD_LIMIT } from '@/lib/whatsapp/thread-cache';
 import { formatBrPhone } from '@/lib/phone';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -35,6 +35,26 @@ function ReplyForm({ conversationId }: { conversationId: string }) {
       <Input value={draft} onChange={(e) => setDraft(e.target.value)} placeholder="Responder…" autoFocus />
       <Button type="submit">Enviar</Button>
     </form>
+  );
+}
+
+/**
+ * Botão "carregar mensagens anteriores" no topo da thread. Só aparece quando
+ * a janela está cheia (count >= THREAD_LIMIT = pode haver histórico); some ao
+ * esgotar. Estado local — montar com key={conversationId} pra zerar na troca.
+ * Scroll: navegadores com overflow-anchor (Chrome/Edge/Firefox) mantêm o
+ * ponto de leitura no prepend; no Safari o scroll pode pular (aceito na v1 —
+ * ação manual, o usuário acabou de clicar no topo).
+ */
+function LoadOlderButton({ conversationId, count }: { conversationId: string; count: number }) {
+  const { loadOlder, isLoadingOlder, exhausted } = useLoadOlderWhatsappMessages(conversationId);
+  if (exhausted || count < THREAD_LIMIT) return null;
+  return (
+    <div className="flex justify-center pb-1">
+      <Button variant="ghost" size="sm" disabled={isLoadingOlder} onClick={() => void loadOlder()}>
+        {isLoadingOlder ? 'Carregando…' : 'Carregar mensagens anteriores'}
+      </Button>
+    </div>
   );
 }
 
@@ -99,14 +119,17 @@ export default function WhatsappInbox() {
                 <EmptyState tone="operational" icon={MessageCircle} title="Não consegui carregar a conversa"
                   description="" actionLabel="Tentar de novo" onAction={() => threadQuery.refetch()} />
               ) : (
-                messages.map((m) => (
-                  <div
-                    key={m.id}
-                    className={`max-w-[70%] rounded p-2 text-sm ${m.direction === 'out' ? 'ml-auto bg-primary text-primary-foreground' : 'bg-muted'} ${isOptimisticMessage(m) ? 'opacity-60' : ''}`}
-                  >
-                    {m.type === 'text' ? m.body : `[${m.type}]`}
-                  </div>
-                ))
+                <>
+                  <LoadOlderButton key={activeId} conversationId={activeId} count={messages.length} />
+                  {messages.map((m) => (
+                    <div
+                      key={m.id}
+                      className={`max-w-[70%] rounded p-2 text-sm ${m.direction === 'out' ? 'ml-auto bg-primary text-primary-foreground' : 'bg-muted'} ${isOptimisticMessage(m) ? 'opacity-60' : ''}`}
+                    >
+                      {m.type === 'text' ? m.body : `[${m.type}]`}
+                    </div>
+                  ))}
+                </>
               )}
             </div>
             {/* key por conversa: troca de conversa zera o draft */}

--- a/src/queries/useWhatsappInbox.ts
+++ b/src/queries/useWhatsappInbox.ts
@@ -1,7 +1,13 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { useEffect } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { supabase } from '@/integrations/supabase/client';
-import { appendRealtimeMessage } from '@/lib/whatsapp/thread-cache';
+import { toast } from 'sonner';
+import {
+  appendRealtimeMessage,
+  mergeThreadWindow,
+  prependOlderMessages,
+  THREAD_LIMIT,
+} from '@/lib/whatsapp/thread-cache';
 
 export interface WaConversation {
   id: string; phone_e164: string | null; contact_name: string | null;
@@ -22,6 +28,7 @@ interface PgConvBuilder {
   order: (col: string, opts: OrderOpts) => PgConvBuilder;
   limit: (n: number) => PromiseLike<{ data: unknown; error: { message: string } | null }>;
   eq: (col: string, val: string) => PgConvBuilder;
+  lte: (col: string, val: string) => PgConvBuilder;
   then: PromiseLike<{ data: unknown; error: { message: string } | null }>['then'];
 }
 
@@ -53,9 +60,6 @@ export function useWhatsappConversations() {
   return q;
 }
 
-/** Últimas N mensagens da thread (render asc). */
-const THREAD_LIMIT = 100;
-
 export function useWhatsappThread(conversationId: string | undefined) {
   const qc = useQueryClient();
   const q = useQuery({
@@ -70,7 +74,15 @@ export function useWhatsappThread(conversationId: string | undefined) {
         .order('created_at', { ascending: false })
         .limit(THREAD_LIMIT) as PromiseLike<{ data: unknown; error: { message: string } | null }>);
       if (res.error) throw new Error(res.error.message);
-      return ((res.data ?? []) as WaMessage[]).reverse();
+      const janela = ((res.data ?? []) as WaMessage[]).reverse();
+      // Merge com o cache anterior (helper testado): o refetch baixa só a
+      // janela recente, mas o cache pode ter HISTÓRICO carregado via
+      // "mensagens anteriores" — sem o merge, o invalidate de reconciliação
+      // do envio descartaria o histórico e a tela pularia pras últimas 100.
+      return mergeThreadWindow(
+        qc.getQueryData<WaMessage[]>(['whatsapp', 'thread', conversationId]),
+        janela,
+      );
     },
     enabled: !!conversationId,
   });
@@ -91,4 +103,56 @@ export function useWhatsappThread(conversationId: string | undefined) {
     return () => { supabase.removeChannel(channel); };
   }, [conversationId, qc]);
   return q;
+}
+
+/**
+ * "Carregar mensagens anteriores": busca a página seguinte do histórico
+ * (mensagens mais antigas que a primeira do cache) e faz PREPEND no cache da
+ * thread — fecha a regressão de produto da janela de 100 (conversas longas
+ * tinham o histórico antigo inacessível na UI).
+ *
+ * Cursor por `.lte(created_at da mais antiga)`: o `lte` (não `lt`) garante que
+ * irmãs com o MESMO timestamp do cursor não se percam; as duplicatas
+ * re-baixadas morrem no dedupe do prependOlderMessages. Fim do histórico =
+ * página crua menor que o limit OU zero mensagens novas após dedupe (guard
+ * anti-loop). Estado é local do hook — monte com key por conversa.
+ */
+export function useLoadOlderWhatsappMessages(conversationId: string | undefined) {
+  const qc = useQueryClient();
+  const [isLoadingOlder, setIsLoadingOlder] = useState(false);
+  const [exhausted, setExhausted] = useState(false);
+
+  const loadOlder = useCallback(async () => {
+    if (!conversationId || isLoadingOlder || exhausted) return;
+    const threadKey = ['whatsapp', 'thread', conversationId];
+    // Lê o cache no CLIQUE (não closure): a mais antiga pode ter mudado após
+    // um prepend anterior. old[0] nunca é otimista (otimista é append no fim).
+    const atual = qc.getQueryData<WaMessage[]>(threadKey);
+    const maisAntiga = atual?.[0];
+    if (!maisAntiga) return;
+    setIsLoadingOlder(true);
+    try {
+      const res = await (waFrom('whatsapp_messages')
+        .select('*')
+        .eq('conversation_id', conversationId)
+        .lte('created_at', maisAntiga.created_at)
+        .order('created_at', { ascending: false })
+        .limit(THREAD_LIMIT) as PromiseLike<{ data: unknown; error: { message: string } | null }>);
+      if (res.error) throw new Error(res.error.message);
+      const pagina = ((res.data ?? []) as WaMessage[]).reverse();
+      let added = 0;
+      qc.setQueryData<WaMessage[]>(threadKey, (old) => {
+        const r = prependOlderMessages(old, pagina);
+        added = r.added;
+        return r.next;
+      });
+      if (pagina.length < THREAD_LIMIT || added === 0) setExhausted(true);
+    } catch {
+      toast.error('Falha ao carregar mensagens anteriores.');
+    } finally {
+      setIsLoadingOlder(false);
+    }
+  }, [conversationId, isLoadingOlder, exhausted, qc]);
+
+  return { loadOlder, isLoadingOlder, exhausted };
 }


### PR DESCRIPTION
## O que é

Follow-up da Onda 3: a janela de 100 mensagens (fix do bug das "1000 mais antigas") deixou o **histórico antigo inacessível** na UI. Agora a thread tem o botão **"Carregar mensagens anteriores"** no topo — cada clique busca a página anterior e faz prepend no cache, sem mexer no realtime nem no envio otimista.

### Decisões de design (todas em helper puro testado)
- **Cursor `.lte` (não `.lt`)**: re-baixa o cursor de propósito pra não perder mensagens irmãs com timestamp empatado; as duplicatas morrem no dedupe por id (`prependOlderMessages`). Fim do histórico = página < 100 **ou** zero novas após dedupe (guard anti-loop).
- **`mergeThreadWindow` na queryFn**: o invalidate de reconciliação do envio refetcha só a janela recente e **descartava o histórico carregado** (a tela pulava de volta pras últimas 100). O merge preserva as antigas reais — otimista órfã continua morrendo no refetch, como antes.

### Revisão adversarial (subagente) — 2 achados fechados no próprio PR
1. **Anti-buraco** (P2 novo): com o realtime morto por tempo suficiente (>100 mensagens perdidas), o merge podia costurar cache antigo + janela nova **sem continuidade** = conversa com buraco invisível no meio, que nem o botão cura. Guard: janela cheia sem nenhum id em comum com o cache → descarta o cache (comportamento antigo, sem buraco).
2. **Inbound do RTT** (P2 pré-existente da Onda 3, fix barato): a mensagem do cliente que chega via realtime **durante** o RTT do refetch era descartada pelo merge e sumia da tela (~100-400ms de janela, num inbox de SLA). Agora o sufixo real do cache é preservado (tabela append-only — sem risco de ressuscitar mensagem apagada).

O adversarial também **provou limpos** (com trace no source do React Query 5.83.0): concorrência loadOlder×invalidate em todas as ordens, unicidade de id no render, `exhausted` correto (100/150/250 msgs), cursor nunca otimista. P3s anotados no commit.

### Rito
Sem Codex (cota esgotada, volta ~11/06) — **acordado com o founder**: este item é frontend puro sem money-path, validado por TDD + adversarial; o Codex faz o retroativo junto das Ondas 1-4. O #16-full (filtro de cidade server-side, com migration) **ficou esperando o Codex** de propósito.

## Validação
- `thread-cache`: **20 testes** (7 antigos + 13 novos) · typecheck strict ✅ · suíte **3003/3003** ✅ · lint ✅
- Sem migration, sem deploy de edge.

⚠️ Pós-merge: **Publish no Lovable**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)