### PR TITLE
fix(reposição): embalagem econômica v1.1 — sobra do galão vira crédit…

### DIFF
--- a/docs/roadmap-sessao.md
+++ b/docs/roadmap-sessao.md
@@ -6,6 +6,24 @@
 
 ---
 
+## 🧮 SESSÃO 2026-06-10 (3) — Embalagem econômica indicava QT com GL mais barato/litro (WP01/WP87/WP04)
+
+> Queixa do founder: preencheu os preços manualmente, o GL ficou mais barato por
+> QT-equivalente (WP01: R$76,62 vs R$81,71), mas o pedido indicou comprar QT. Mesmo
+> padrão em WP87 e WP04. **Diagnóstico (confirmado com os números reais):** a v1
+> compara o custo de atender SÓ a necessidade do pedido — a sobra do galão é custo
+> morto (nunca credita que ela evita a próxima compra). Com spread de ~6%/litro, o GL
+> só vencia em necessidade múltiplo exato de 4. Carrego era centavos (sobra escoa em
+> ~9-13 dias); guard marginal não disparou — mecanismo dominante = custo direto.
+
+- ✅ Investigação root-cause (`/investigate`): helper `embalagem-helpers.ts` + hooks + spec §5.2 vs §2 (tensão real: spec verbalizou "tolera arredondar quando custo/un-base compensa", lógica implementou frame míope)
+- ✅ **Fix de metodologia v1.1 — crédito de reposição da sobra** (spec §14): `custo_total = custo_direto + carrego − sobra × melhor_custo_por_base` (sobra escoável vira antecipação da próxima compra; gates honestos: sem demanda/cm → crédito 0 = comportamento v1; carrego come o crédito quando o escoamento é lento — autorregulável; guard marginal R$5 preservado; invariante custo_total ≥ nec×custo_base testado). TDD com os números reais do WP01 (22 testes no helper; nec 1→QT marginal R$2,56 · nec 2→GL R$9,04 · nec 3→GL · nec 4→GL R$20,33). 2 testes da v1 reescritos (eram artefatos do frame míope).
+- ✅ UI: sobra explicada como estoque ("sobra N un-base — vira estoque, escoa em ~Xd") nas 2 superfícies (painel do pedido + tela avulsa)
+- ✅ CI local verde (typecheck strict · 3014/3014 testes · lint 0 errors) — 100% frontend (sem migration, sem edge; painel é recomendação visual, NÃO altera o pedido automático). ⚠️ Publish no Lovable pendente pra ir ao ar.
+- ⏳ **Codex adversarial retroativo** quando a cota voltar (~11/06 9h24): metodologia v1.1 (valoração da sobra ao min do grupo, double-count crédito×carrego, gate sem-demanda) — Caminho B nesta rodada foi auto-challenge + TDD exaustivo.
+
+---
+
 ## ⚡ SESSÃO 2026-06-09/10 — Auditoria de velocidade & usabilidade: 24 itens mapeados, 4 ondas COMPLETAS
 
 > Pedido do founder: "revisite o código todo e procure brechas para deixar ele mais rápido

--- a/docs/superpowers/specs/2026-06-04-embalagem-economica-design.md
+++ b/docs/superpowers/specs/2026-06-04-embalagem-economica-design.md
@@ -204,3 +204,33 @@ Consult Codex (gpt-5.5) gerou os P1 que moldaram este desenho:
 ## 13. Relação com o item 2 original (sucessão de giro)
 
 A primitiva `sku_embalagem_equivalencia` (vínculo de SKUs + fator) é a mesma fundação que a **sucessão de giro** precisa (transpor o histórico de um SKU descontinuado para o sucessor — investigação do "item 1" provou que o "Transferir" atual só copia parâmetros, e o recálculo diário os sobrescreve). A sucessão é um projeto seguinte que reusa esta base, com a diferença de que lá o vínculo é **temporal** (antigo→sucessor, fator ~1) e a demanda **é** transposta. Não faz parte deste spec.
+
+---
+
+## 14. v1.1 — Crédito de reposição da sobra (fix de metodologia, 2026-06-10)
+
+**Caso real que expôs o problema (founder, WP01/WP87/WP04):** preços preenchidos manualmente; WP01 QT R$81,7068 × GL R$306,4977 → custo/QT-equiv **GL R$76,62 < QT R$81,71** (6,2% mais barato). Mesmo assim o pedido indicou QT. Com o spread de ~6%, o frame v1 só recomendava GL quando a necessidade caía num **múltiplo exato de 4** — a sobra do galão entrava como custo morto integral no `custo_direto`, e o "freio do capital parado" (§3.3) nunca era o decisor de fato (sobra escoa em ~9–13 dias → carrego de centavos vs R$143–225 de diferença de custo direto).
+
+**Bug de metodologia, não de código:** a implementação divergia da intenção da spec — §2 ("tolera arredondar pra cima quando o custo por unidade-base compensa"), §3.3 ("o único freio do overbuy é o capital parado") e §6 bullet 4 ("sem demanda confiável: recomenda pela comparação de preço/unidade-base") descrevem um modelo onde a sobra é **antecipação de estoque**, não desperdício. O `custo_total_ajustado = custo_direto + carrego` penalizava a sobra pelo valor integral hoje e nunca creditava que ela **evita a próxima compra**.
+
+**Modelo v1.1 (crédito de reposição):**
+
+```
+preco_reposicao_por_base = min(custo_por_base) entre as opções válidas do grupo
+credito_reposicao        = sobra_escoavel ? excedente_base × preco_reposicao_por_base : 0
+custo_total_ajustado     = custo_direto + (carrego ?? 0) − credito_reposicao
+```
+
+- `sobra_escoavel` = demanda do grupo disponível e > 0 (mesmo gate do carrego; o hook já só passa demanda quando o cm existe — codex P1 do #613 preservado). **Sem demanda/cm → crédito 0 = comportamento v1 (conservador) + flag `escoamento_nao_estimado`.**
+- O crédito valoriza a sobra ao **menor custo/base do grupo** (a próxima compra ótima seria feita a esse custo — é exatamente a compra que a sobra evita).
+- **Invariante (testado):** `custo_total ≥ necessidade × custo_por_base_da_opção ≥ 0` — o crédito nunca deixa custo negativo, pois `preco_reposicao ≤ custo_por_base` da própria opção.
+- **Freios preservados:** o carrego segue somando (escoamento lento → carrego come o crédito → conservadora volta a ganhar — autorregulável, sem teto arbitrário de dias); guard de **ganho marginal** (limiar R$5) intacto — WP01 com necessidade 1 QT: GL ganha por R$2,56 < R$5 → recomenda QT com aviso.
+- Campos novos: `AvaliacaoOpcao.credito_reposicao`; `DecisaoEmbalagem.dias_escoamento_sobra` (p/ UI explicar "sobra escoa em ~Xd"); flag `sobra_antecipa_compra`.
+
+**Efeito no WP01 (números reais, demanda do grupo 0,2244 QT-eq/dia, cm 30%):** nec 1 → QT (marginal R$2,56); nec 2 → **GL** (economia R$9,04); nec 3 → **GL** (R$14,96); nec 4 → **GL** (R$20,33). Antes: QT, QT, QT, GL.
+
+**Dois testes da v1 reescritos** (eram artefatos do frame míope): "capital come a economia" usava GL R$9 < QT R$10 absoluto — compra dominante (4 unidades por menos dinheiro) que o frame antigo rejeitava; refeito com escoamento genuinamente lento. "Marginal" usava o mesmo padrão; refeito com spread pequeno por base (GL 39,60 vs QT 10).
+
+**Limitação registrada:** grupo sem demanda registrada nenhuma (ex.: consumo 100% interno da tintometria, invisível em `venda_items_history` — §3.1) continua caindo no conservador. A solução real é dar fonte de demanda interna ao motor (fora deste escopo); a tela avulsa mostra o custo/base nos badges pro founder decidir no olho.
+
+**Escopo:** 100% frontend (helper puro + textos de UI nas 2 superfícies). Sem migration, sem edge. O painel é recomendação visual — **não** altera `qtde_final` nem o pedido automático. ⚠️ Codex fora (cota Plus até ~11/06) → Caminho B: auto-challenge + TDD com números reais; **adversarial retroativo do Codex pendente**.

--- a/src/components/reposicao/pedidos/EmbalagemPanel.tsx
+++ b/src/components/reposicao/pedidos/EmbalagemPanel.tsx
@@ -48,7 +48,14 @@ export function EmbalagemPanel({ empresa, itens }: { empresa: string; itens: Ped
                     <div className="text-muted-foreground">
                       Recomendado: <span className="font-medium text-foreground">{d.recomendada}</span>
                       {d.economia_vs_alternativa > 0 && <> · economia {formatBRL(d.economia_vs_alternativa)}</>}
-                      {d.excedente_base > 0 && <> · excedente {d.excedente_base} un-base</>}
+                      {d.excedente_base > 0 && (
+                        <>
+                          {' '}· sobra {d.excedente_base} un-base
+                          {d.flags.includes('sobra_antecipa_compra') && d.dias_escoamento_sobra != null
+                            ? ` — vira estoque, escoa em ~${Math.ceil(d.dias_escoamento_sobra)}d`
+                            : ''}
+                        </>
+                      )}
                       {d.status === 'marginal' && <> · <span className="text-status-warning">ganho marginal — confira</span></>}
                     </div>
                     {d.flags.includes('preco_desatualizado') && (

--- a/src/lib/reposicao/embalagem-helpers.test.ts
+++ b/src/lib/reposicao/embalagem-helpers.test.ts
@@ -71,24 +71,27 @@ describe('escolherEmbalagemEconomica', () => {
     expect(r.recomendada).toBe('GL');
   });
 
-  it('GL barato/unidade mas necessidade pequena: o capital come a economia → QT', () => {
+  it('escoamento lento: o carrego come o crédito da sobra → QT', () => {
+    // GL absoluto mais barato (9 < 10), MAS demanda quase nula → a sobra leva ~3000
+    // dias a escoar → carrego (R$27,7) engole o crédito (R$6,75) → conservador.
     const r = escolherEmbalagemEconomica({
       necessidade_base: 1,
       opcoes: [
         { sku_codigo_omie: 'QT', fator_para_base: 1, preco: 10, preco_status: 'ok' },
         { sku_codigo_omie: 'GL', fator_para_base: 4, preco: 9, preco_status: 'ok' },
       ],
-      params: params({ custo_capital_anual: 0.5, demanda_base_diaria: 0.02 }),
+      params: params({ custo_capital_anual: 0.5, demanda_base_diaria: 0.001 }),
     });
     expect(r.recomendada).toBe('QT');
   });
 
   it('economia abaixo do limiar não empurra overbuy (marginal → recomenda a sem excedente)', () => {
+    // GL R$39,60 = R$9,90/un-base vs QT R$10: ganho efetivo no ciclo = R$0,10 < limiar 1.
     const r = escolherEmbalagemEconomica({
       necessidade_base: 1,
       opcoes: [
         { sku_codigo_omie: 'QT', fator_para_base: 1, preco: 10, preco_status: 'ok' },
-        { sku_codigo_omie: 'GL', fator_para_base: 4, preco: 9.9, preco_status: 'ok' },
+        { sku_codigo_omie: 'GL', fator_para_base: 4, preco: 39.6, preco_status: 'ok' },
       ],
       params: params({ demanda_base_diaria: 1000, limiar_minimo_economia_rs: 1 }),
     });
@@ -142,7 +145,7 @@ describe('escolherEmbalagemEconomica', () => {
       necessidade_base: 1,
       opcoes: [
         { sku_codigo_omie: 'QT', fator_para_base: 1, preco: 10, preco_status: 'ok' },
-        { sku_codigo_omie: 'GL', fator_para_base: 4, preco: 9.9, preco_status: 'ok' },
+        { sku_codigo_omie: 'GL', fator_para_base: 4, preco: 39.6, preco_status: 'ok' },
       ],
       params: params({ demanda_base_diaria: 1000, limiar_minimo_economia_rs: 1 }),
     });
@@ -172,5 +175,130 @@ describe('escolherEmbalagemEconomica', () => {
     });
     expect(mk(0).status).toBe('indisponivel');
     expect(mk(-5).status).toBe('indisponivel');
+  });
+});
+
+// ─── v1.1 — crédito de reposição da sobra (spec §14) ───────────────────────────
+// Caso real do founder (WP01): GL 6,2% mais barato por QT-equivalente, mas a v1
+// indicava QT pra toda necessidade não-múltipla de 4 (sobra = custo morto integral).
+const QT_WP01: OpcaoEmbalagem = { sku_codigo_omie: 'QT_WP01', fator_para_base: 1, preco: 81.7068, preco_status: 'ok' };
+const GL_WP01: OpcaoEmbalagem = { sku_codigo_omie: 'GL_WP01', fator_para_base: 4, preco: 306.4977, preco_status: 'ok' };
+const BASE_GL = 306.4977 / 4; // 76.624425 = melhor custo/base do grupo
+const paramsWP01 = (over: Partial<ParamsEmbalagem> = {}): ParamsEmbalagem =>
+  ({ custo_capital_anual: 0.3, limiar_minimo_economia_rs: 5, demanda_base_diaria: 0.2244, ...over });
+const carrego = (exc: number, custoBase: number, cm: number, demanda: number) =>
+  exc * custoBase * cm * ((exc / demanda) / 365);
+
+describe('v1.1 — crédito de reposição da sobra', () => {
+  it('WP01 real, necessidade 2: GL vence (sobra de 2 QT antecipa a próxima compra)', () => {
+    const r = escolherEmbalagemEconomica({
+      necessidade_base: 2,
+      opcoes: [QT_WP01, GL_WP01],
+      params: paramsWP01(),
+    });
+    expect(r.recomendada).toBe('GL_WP01');
+    expect(r.status).toBe('ok');
+    expect(r.flags).toContain('sobra_antecipa_compra');
+    const totalGL = 306.4977 + carrego(2, BASE_GL, 0.3, 0.2244) - 2 * BASE_GL;
+    expect(r.economia_vs_alternativa).toBeCloseTo(2 * 81.7068 - totalGL, 4); // ≈ R$9,04
+  });
+
+  it('WP01 real, necessidade 1: ganho de ~R$2,56 fica abaixo do limiar → marginal → QT', () => {
+    const r = escolherEmbalagemEconomica({
+      necessidade_base: 1,
+      opcoes: [QT_WP01, GL_WP01],
+      params: paramsWP01(),
+    });
+    expect(r.status).toBe('marginal');
+    expect(r.recomendada).toBe('QT_WP01');
+    expect(r.flags).toContain('overbuy_marginal');
+  });
+
+  it('WP01 real, necessidade 4: GL sem sobra, economia direta de ~R$20,33', () => {
+    const r = escolherEmbalagemEconomica({
+      necessidade_base: 4,
+      opcoes: [QT_WP01, GL_WP01],
+      params: paramsWP01(),
+    });
+    expect(r.recomendada).toBe('GL_WP01');
+    expect(r.excedente_base).toBe(0);
+    expect(r.economia_vs_alternativa).toBeCloseTo(4 * 81.7068 - 306.4977, 4);
+    expect(r.flags).not.toContain('sobra_antecipa_compra');
+    expect(r.dias_escoamento_sobra).toBeNull();
+  });
+
+  it('crédito é gated pela demanda: sem demanda, comportamento v1 (custo direto) preservado', () => {
+    const r = escolherEmbalagemEconomica({
+      necessidade_base: 1,
+      opcoes: [QT_WP01, GL_WP01],
+      params: paramsWP01({ demanda_base_diaria: null }),
+    });
+    expect(r.recomendada).toBe('QT_WP01'); // 81,71 < 306,50 — sem crédito sem evidência de escoamento
+    expect(r.flags).toContain('escoamento_nao_estimado');
+  });
+
+  it('necessidade fracionária: ambas as opções têm sobra com crédito (sem guard marginal aplicável)', () => {
+    const r = escolherEmbalagemEconomica({
+      necessidade_base: 2.5,
+      opcoes: [QT_WP01, GL_WP01],
+      params: paramsWP01(),
+    });
+    expect(r.recomendada).toBe('GL_WP01');
+    expect(r.status).toBe('ok');
+  });
+
+  it('dias_escoamento_sobra exposto quando a recomendada tem sobra; null no marginal', () => {
+    const comSobra = escolherEmbalagemEconomica({
+      necessidade_base: 2,
+      opcoes: [QT_WP01, GL_WP01],
+      params: paramsWP01(),
+    });
+    expect(comSobra.dias_escoamento_sobra).toBeCloseTo(2 / 0.2244, 4);
+
+    const marginal = escolherEmbalagemEconomica({
+      necessidade_base: 1,
+      opcoes: [QT_WP01, GL_WP01],
+      params: paramsWP01(),
+    });
+    expect(marginal.dias_escoamento_sobra).toBeNull(); // recomendada (QT) não tem sobra
+  });
+
+  it('invariante: custo_total ≥ necessidade × custo/base da opção (crédito nunca negativa o custo)', () => {
+    // GL absoluto mais barato que QT (promoção): compra dominante, crédito grande.
+    const r = escolherEmbalagemEconomica({
+      necessidade_base: 1,
+      opcoes: [
+        { sku_codigo_omie: 'QT', fator_para_base: 1, preco: 10, preco_status: 'ok' },
+        { sku_codigo_omie: 'GL', fator_para_base: 4, preco: 9, preco_status: 'ok' },
+      ],
+      params: params({ demanda_base_diaria: 1000 }),
+    });
+    expect(r.recomendada).toBe('GL');
+    for (const o of r.opcoes) {
+      expect(o.custo_total_ajustado).toBeGreaterThanOrEqual(1 * o.custo_por_base - 1e-9);
+      expect(o.custo_total_ajustado).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it('avaliarOpcao: crédito = excedente × preço de reposição, capado no custo/base da própria opção', () => {
+    const gl: OpcaoEmbalagem = { sku_codigo_omie: 'GL1', fator_para_base: 4, preco: 30, preco_status: 'ok' };
+    const p: ParamsEmbalagem = { custo_capital_anual: 0.5, limiar_minimo_economia_rs: 5, demanda_base_diaria: 0.02 };
+    const a = avaliarOpcao(1, gl, p, 7.5);
+    expect(a!.credito_reposicao).toBeCloseTo(3 * 7.5, 6);
+    expect(a!.custo_total_ajustado).toBeCloseTo(30 + carrego(3, 7.5, 0.5, 0.02) - 3 * 7.5, 4);
+
+    // caller passando preço de reposição acima do custo/base da opção → capado (defesa do invariante)
+    const capado = avaliarOpcao(1, gl, { ...p, demanda_base_diaria: 2 }, 99);
+    expect(capado!.credito_reposicao).toBeCloseTo(3 * 7.5, 6);
+  });
+
+  it('avaliarOpcao: sem o preço de reposição (compat) ou sem demanda → crédito 0', () => {
+    const gl: OpcaoEmbalagem = { sku_codigo_omie: 'GL1', fator_para_base: 4, preco: 30, preco_status: 'ok' };
+    const semArg = avaliarOpcao(1, gl, params());
+    expect(semArg!.credito_reposicao).toBe(0);
+
+    const semDem = avaliarOpcao(1, gl, params({ demanda_base_diaria: null }), 7.5);
+    expect(semDem!.credito_reposicao).toBe(0);
+    expect(semDem!.custo_total_ajustado).toBe(30);
   });
 });

--- a/src/lib/reposicao/embalagem-helpers.ts
+++ b/src/lib/reposicao/embalagem-helpers.ts
@@ -27,6 +27,7 @@ export interface AvaliacaoOpcao {
   excedente_base: number;
   custo_direto: number;
   capital_carrego: number | null;     // null quando demanda ausente
+  credito_reposicao: number;          // v1.1: sobra escoável valorizada ao melhor custo/base do grupo (0 sem demanda)
   custo_total_ajustado: number;
   preco_status: StatusPreco;
 }
@@ -35,6 +36,7 @@ export function avaliarOpcao(
   necessidadeBase: number,
   opcao: OpcaoEmbalagem,
   params: ParamsEmbalagem,
+  precoReposicaoPorBase?: number | null, // v1.1: menor custo/base do grupo (a compra futura que a sobra evita)
 ): AvaliacaoOpcao | null {
   if (opcao.preco == null || opcao.fator_para_base <= 0) return null;
   const fator = opcao.fator_para_base;
@@ -45,14 +47,22 @@ export function avaliarOpcao(
   const custo_direto = qtd_embalagens * opcao.preco;
 
   const d = params.demanda_base_diaria ?? 0;
+  const temEscoamento = params.demanda_base_diaria != null && d > 0;
   let capital_carrego: number | null;
-  if (params.demanda_base_diaria != null && d > 0) {
+  if (temEscoamento) {
     const dias_escoa = excedente_base / d;
     capital_carrego = excedente_base * custo_por_base * params.custo_capital_anual * (dias_escoa / 365);
   } else {
     capital_carrego = null;
   }
-  const custo_total_ajustado = custo_direto + (capital_carrego ?? 0);
+  // v1.1 (spec §14): a sobra ESCOÁVEL antecipa a próxima compra — crédito ao melhor
+  // custo/base do grupo, capado no custo/base da própria opção (invariante:
+  // custo_total ≥ necessidade × custo_por_base, nunca negativo). Sem demanda/cm não
+  // há evidência de escoamento → crédito 0 = comportamento conservador da v1.
+  const credito_reposicao = temEscoamento && precoReposicaoPorBase != null && precoReposicaoPorBase > 0
+    ? excedente_base * Math.min(precoReposicaoPorBase, custo_por_base)
+    : 0;
+  const custo_total_ajustado = custo_direto + (capital_carrego ?? 0) - credito_reposicao;
 
   return {
     sku_codigo_omie: opcao.sku_codigo_omie,
@@ -62,6 +72,7 @@ export function avaliarOpcao(
     excedente_base,
     custo_direto,
     capital_carrego,
+    credito_reposicao,
     custo_total_ajustado,
     preco_status: opcao.preco_status ?? 'ok',
   };
@@ -75,6 +86,7 @@ export interface DecisaoEmbalagem {
   opcoes: AvaliacaoOpcao[];
   excedente_base: number;              // da opção recomendada
   capital_estimado: number | null;     // da opção recomendada
+  dias_escoamento_sobra: number | null; // v1.1: tempo p/ a sobra da recomendada virar consumo (null sem sobra/demanda)
   economia_vs_alternativa: number;     // R$ entre a mais barata e a 2ª (>= 0)
   flags: string[];
 }
@@ -91,8 +103,8 @@ export function escolherEmbalagemEconomica(input: {
   if (!(necessidade_base > 0) || !Number.isFinite(necessidade_base)) {
     return {
       status: 'indisponivel', recomendada: null, opcoes: [],
-      excedente_base: 0, capital_estimado: null, economia_vs_alternativa: 0,
-      flags: ['necessidade_invalida'],
+      excedente_base: 0, capital_estimado: null, dias_escoamento_sobra: null,
+      economia_vs_alternativa: 0, flags: ['necessidade_invalida'],
     };
   }
 
@@ -101,16 +113,19 @@ export function escolherEmbalagemEconomica(input: {
   if (validas.length < 2) {
     return {
       status: 'indisponivel', recomendada: null, opcoes: [],
-      excedente_base: 0, capital_estimado: null, economia_vs_alternativa: 0,
-      flags: ['preco_indisponivel'],
+      excedente_base: 0, capital_estimado: null, dias_escoamento_sobra: null,
+      economia_vs_alternativa: 0, flags: ['preco_indisponivel'],
     };
   }
 
   if (validas.some((o) => o.preco_status === 'stale')) flags.push('preco_desatualizado');
   if (params.demanda_base_diaria == null || params.demanda_base_diaria <= 0) flags.push('escoamento_nao_estimado');
 
+  // v1.1: preço de reposição = melhor custo/base do grupo (a compra que a sobra evita).
+  const precoReposicaoPorBase = Math.min(...validas.map((o) => (o.preco as number) / o.fator_para_base));
+
   const avals = validas
-    .map((o) => avaliarOpcao(necessidade_base, o, params))
+    .map((o) => avaliarOpcao(necessidade_base, o, params, precoReposicaoPorBase))
     .filter((a): a is AvaliacaoOpcao => a !== null)
     .sort((a, b) => a.custo_total_ajustado - b.custo_total_ajustado);
 
@@ -140,10 +155,18 @@ export function escolherEmbalagemEconomica(input: {
     ? Math.max(0, Math.min(...outras.map((a) => a.custo_total_ajustado)) - recAval.custo_total_ajustado)
     : 0;
 
+  // v1.1: sobra da recomendada tratada como antecipação de compra (p/ a UI explicar).
+  if (recAval.excedente_base > 0 && recAval.credito_reposicao > 0) flags.push('sobra_antecipa_compra');
+  const d = params.demanda_base_diaria ?? 0;
+  const dias_escoamento_sobra = recAval.excedente_base > 0 && params.demanda_base_diaria != null && d > 0
+    ? recAval.excedente_base / d
+    : null;
+
   return {
     status, recomendada, opcoes: avals,
     excedente_base: recAval.excedente_base,
     capital_estimado: recAval.capital_carrego,
+    dias_escoamento_sobra,
     economia_vs_alternativa,
     flags,
   };

--- a/src/pages/AdminReposicaoEmbalagem.tsx
+++ b/src/pages/AdminReposicaoEmbalagem.tsx
@@ -125,6 +125,9 @@ function GrupoCard({ grupo, limiar }: { grupo: GrupoEmbalagem; limiar: number })
               {decisao.excedente_base > 0 && (
                 <>
                   {' '}· sobra {decisao.excedente_base} {grupo.unidade_base}
+                  {decisao.flags.includes('sobra_antecipa_compra') && decisao.dias_escoamento_sobra != null
+                    ? ` — vira estoque, escoa em ~${Math.ceil(decisao.dias_escoamento_sobra)}d`
+                    : ''}
                 </>
               )}
             </div>


### PR DESCRIPTION
…o de reposição (WP01/WP87/WP04)

A v1 comparava o custo de atender SÓ a necessidade do pedido: a sobra do GL entrava como custo morto integral, então um GL 6% mais barato por QT-equivalente (WP01 real: R$76,62 vs R$81,71) só era recomendado em necessidade múltiplo exato de 4. Divergia da intenção da própria spec (§2/§3.3/§6: único freio do overbuy = capital parado).

v1.1 (spec §14): custo_total = custo_direto + carrego − sobra × min(custo/base do grupo) quando a sobra é escoável (demanda+cm presentes; senão crédito 0 = comportamento v1 + flag). Carrego segue comendo o crédito em escoamento lento (autorregulável); guard marginal R$5 intacto; invariante custo_total ≥ necessidade × custo/base testado. UI explica a sobra como estoque que escoa.

WP01 real: nec 1→QT (marginal R$2,56) · nec 2→GL (R$9,04) · nec 3→GL · nec
4→GL (R$20,33). Antes: QT/QT/QT/GL.

100% frontend; painel é recomendação visual (não altera qtde_final). Codex sem cota (Caminho B: auto-challenge + TDD com números reais; adversarial retroativo pendente).