### PR TITLE
fix(sales/print): pedido do sync Omie (data-pura UTC) caía no dia errado da impressão

### DIFF
--- a/docs/roadmap-sessao.md
+++ b/docs/roadmap-sessao.md
@@ -27,6 +27,22 @@
 
 ---
 
+## SESSÃO 2026-06-10 (3) — /sales/print: pedido do sync Omie caía no dia ERRADO (data-pura UTC × janela local)
+
+> Pedido do sync (`omie-vendas-sync sync_pedidos`) tem `created_at` = data PURA gravada
+> como meia-noite UTC → a janela local (BRT) de `/sales/print` começava 03:00Z e o pedido
+> de hoje (00:00Z) aparecia na lista de impressão de ONTEM como "tarde, 21:00" (hora
+> fabricada). Pedido do wizard (created_at real) era filtrado certo. Continuação do
+> diagnóstico da sessão "fix de exibição da data do pedido" (`formatarDataPedido`, PR paralelo).
+
+- ✅ **Fix TDD (RED→GREEN provado)**: helper puro `src/lib/pedido/dia-civil.ts` — `janelaQueryDiaCivil` (query = união do dia local + dia UTC), `pedidoNoDiaCivil` (re-filtro client-side: dia UTC p/ data-pura, dia local p/ timestamp real — cada pedido pertence a exatamente 1 dia civil = sem duplicação na borda) e `horaExibicaoPedido` ("—" p/ data-pura). 9 testes TZ-agnósticos (passam em BRT local e no UTC do CI).
+- ✅ `getPeriod` (print/types.ts) regime-aware: data-pura → relógio UTC (00:00 → manhã; antes fabricava "tarde" via 21:00 local). `OrderGroup` mostra "—" no lugar da hora fabricada.
+- ✅ **Coordenação com o PR paralelo** (`claude/ecstatic-pare-09147a`): `data-pedido.ts` + teste **vendorizados byte-idênticos** (merge limpo em qualquer ordem); o cupom impresso (`buildPrintHtml.ts:44`, mesma hora fabricada) é coberto POR ELES — deliberadamente não tocado aqui.
+- 📌 **Follow-up (chip)**: `useVendasZone` (KPI faturado hoje/ontem do dashboard) tem o MESMO bug de janela local sobre `sales_orders.created_at` — pedido do sync de hoje conta como ontem.
+- ⚠️ **PENDENTE (founder): Publish no Lovable** (100% frontend, sem migration/edge).
+
+---
+
 ## 0. SESSÃO 2026-06-10 (2) — getCapitalDeGiro + getTopInadimplentes truncados no cap 1000 (fecha o follow-up do #720)
 
 > Sessão spawnada pelo chip de follow-up da seção abaixo: as duas funções restantes do

--- a/src/components/sales/print/OrderGroup.tsx
+++ b/src/components/sales/print/OrderGroup.tsx
@@ -4,7 +4,7 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Sun, Sunset, Printer } from 'lucide-react';
-import { format } from 'date-fns';
+import { horaExibicaoPedido } from '@/lib/pedido/dia-civil';
 import type { CompanyFilter, EnrichedOrder } from './types';
 
 export function OrderGroup({ company, period, orders, selectedOrders, onToggleOrder, onPrintSingle }: {
@@ -44,7 +44,7 @@ export function OrderGroup({ company, period, orders, selectedOrders, onToggleOr
                   {order.omie_numero_pedido ? `#${order.omie_numero_pedido.replace(/^0+/, '')}` : order.id.slice(0, 8).toUpperCase()}
                 </span>
                 <span className="text-xs text-muted-foreground">
-                  {format(new Date(order.created_at), 'HH:mm')}
+                  {horaExibicaoPedido(order.created_at)}
                 </span>
               </div>
               <div className="text-sm text-muted-foreground truncate">{order.customer_name}</div>

--- a/src/components/sales/print/__tests__/OrderGroup.test.tsx
+++ b/src/components/sales/print/__tests__/OrderGroup.test.tsx
@@ -38,6 +38,17 @@ describe('OrderGroup', () => {
     expect(screen.getByText(/100,00/)).toBeTruthy();
   });
 
+  it('hora: wizard (timestamp real) mostra HH:mm; sync (data-pura UTC) mostra "—" em vez de hora fabricada', () => {
+    const sync: EnrichedOrder = { ...order, id: 'ord-2', omie_numero_pedido: '000046', created_at: '2026-06-10T00:00:00.000Z' };
+    render(
+      <OrderGroup company="oben" period="manha" orders={[order, sync]} selectedOrders={new Set()} onToggleOrder={noop} onPrintSingle={noop} />
+    );
+    expect(screen.getByText('09:30')).toBeTruthy();
+    expect(screen.getByText('—')).toBeTruthy();
+    // a hora local fabricada (21:00 em BRT) não pode aparecer
+    expect(screen.queryByText('21:00')).toBeNull();
+  });
+
   it('clique na linha chama onToggleOrder; botão imprimir chama onPrintSingle', () => {
     const onToggleOrder = vi.fn();
     const onPrintSingle = vi.fn();

--- a/src/components/sales/print/__tests__/types.test.ts
+++ b/src/components/sales/print/__tests__/types.test.ts
@@ -8,6 +8,16 @@ describe('getPeriod', () => {
     expect(getPeriod('2026-01-15T12:00:00')).toBe('tarde');
     expect(getPeriod('2026-01-15T18:30:00')).toBe('tarde');
   });
+
+  it('data-pura do sync (meia-noite UTC) → manha pelo relógio UTC, não "tarde" fabricada pelo fuso local', () => {
+    // Em BRT, 00:00Z é 21:00 local do dia anterior — o relógio local fabricaria "tarde".
+    expect(getPeriod('2026-06-10T00:00:00.000Z')).toBe('manha');
+  });
+
+  it('meia-noite com offset local (instante real, não data-pura) segue o relógio local', () => {
+    const meiaNoiteLocal = new Date(2026, 0, 15, 0, 30).toISOString();
+    expect(getPeriod(meiaNoiteLocal)).toBe('manha');
+  });
 });
 
 describe('constantes de empresa', () => {

--- a/src/components/sales/print/types.ts
+++ b/src/components/sales/print/types.ts
@@ -1,5 +1,6 @@
 // Tipos, constantes e helpers da Impressão de Pedidos (SalesPrintDashboard).
 // Extraídos de src/pages/SalesPrintDashboard.tsx (god-component split).
+import { ehDataPuraUtc } from '@/lib/pedido/data-pedido';
 
 export type CompanyFilter = 'oben' | 'colacor' | 'afiacao';
 
@@ -89,6 +90,10 @@ export interface FormaPagamento {
 export type EnrichedOrder = SalesOrderRow & { _company: CompanyFilter };
 
 export function getPeriod(dateStr: string): 'manha' | 'tarde' {
-  const h = new Date(dateStr).getHours();
+  const d = new Date(dateStr);
+  // Data-pura do sync Omie (meia-noite UTC, sem hora real): o relógio local fabricaria
+  // "21:00 → tarde" em BRT. Classifica pelo relógio UTC (00:00 → manhã), coerente com
+  // o dia civil UTC usado no filtro do dia (pedidoNoDiaCivil).
+  const h = ehDataPuraUtc(d) ? d.getUTCHours() : d.getHours();
   return h < 12 ? 'manha' : 'tarde';
 }

--- a/src/lib/pedido/__tests__/data-pedido.test.ts
+++ b/src/lib/pedido/__tests__/data-pedido.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { format } from 'date-fns';
+import { ptBR } from 'date-fns/locale';
+import { ehDataPuraUtc, formatarDataPedido } from '../data-pedido';
+
+describe('formatarDataPedido', () => {
+  it('data-pura do sync (meia-noite UTC) → só a data, no dia UTC correto (não escorrega pro dia anterior)', () => {
+    // omie-vendas-sync grava data_previsao "10/06/2026" como new Date('2026-06-10') = 00:00 UTC.
+    // Formatar no fuso local (BRT, UTC-3) mostraria "09/06/2026 às 21:00" — hora fabricada + dia errado.
+    expect(formatarDataPedido('2026-06-10T00:00:00+00:00')).toBe('10/06/2026');
+    expect(formatarDataPedido('2026-06-10T00:00:00.000Z')).toBe('10/06/2026');
+  });
+
+  it('timestamp com hora real (pedido do wizard) → data + hora local, comportamento atual preservado', () => {
+    const iso = '2026-06-09T17:32:45.123Z';
+    const esperado = format(new Date(iso), "dd/MM/yyyy 'às' HH:mm", { locale: ptBR });
+    expect(formatarDataPedido(iso)).toBe(esperado);
+    expect(formatarDataPedido(iso)).toContain(' às ');
+  });
+
+  it('meia-noite com offset local (não-UTC) tem hora real → mantém hora', () => {
+    // 00:00 -03:00 = 03:00 UTC — não é o padrão do sync, é um instante real.
+    expect(formatarDataPedido('2026-06-10T00:00:00-03:00')).toContain(' às ');
+  });
+
+  it('milissegundo ≠ 0 à meia-noite UTC não é data-pura → mantém hora', () => {
+    expect(formatarDataPedido('2026-06-10T00:00:00.500Z')).toContain(' às ');
+  });
+
+  it('entrada inválida → "—" (nunca quebra o card)', () => {
+    expect(formatarDataPedido('lixo')).toBe('—');
+    expect(formatarDataPedido('')).toBe('—');
+  });
+
+  it('formato com-hora customizável (cupom de impressão usa "dd/MM/yyyy HH:mm", sem o "às")', () => {
+    const iso = '2026-06-09T17:32:45.123Z';
+    const esperado = format(new Date(iso), 'dd/MM/yyyy HH:mm', { locale: ptBR });
+    expect(formatarDataPedido(iso, 'dd/MM/yyyy HH:mm')).toBe(esperado);
+    // data-pura ignora o formato com-hora: sai só a data UTC
+    expect(formatarDataPedido('2026-06-10T00:00:00Z', 'dd/MM/yyyy HH:mm')).toBe('10/06/2026');
+  });
+});
+
+describe('ehDataPuraUtc', () => {
+  it('detecta só meia-noite UTC exata (00:00:00.000)', () => {
+    expect(ehDataPuraUtc(new Date('2026-06-10T00:00:00.000Z'))).toBe(true);
+    expect(ehDataPuraUtc(new Date('2026-06-10T00:00:01.000Z'))).toBe(false);
+    expect(ehDataPuraUtc(new Date('2026-06-10T21:00:00.000Z'))).toBe(false);
+  });
+});

--- a/src/lib/pedido/__tests__/dia-civil.test.ts
+++ b/src/lib/pedido/__tests__/dia-civil.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { endOfDay, format, startOfDay } from 'date-fns';
+import { janelaQueryDiaCivil, pedidoNoDiaCivil, horaExibicaoPedido } from '../dia-civil';
+
+// Convenção dos cenários (TZ-agnóstico — roda igual em BRT local e UTC do CI):
+// - pedido do SYNC Omie: created_at data-pura = meia-noite UTC exata (ISO com Z);
+// - pedido do WIZARD: created_at real construído em hora LOCAL via new Date(y,m,d,h,min).
+const dia09 = new Date(2026, 5, 9);
+const dia10 = new Date(2026, 5, 10);
+const dia11 = new Date(2026, 5, 11);
+
+describe('janelaQueryDiaCivil', () => {
+  it('cobre a união dos dois regimes: sync (meia-noite UTC) e wizard (bordas do dia local)', () => {
+    const { inicioIso, fimIso } = janelaQueryDiaCivil(dia10);
+    const dentro = (iso: string) => inicioIso <= iso && iso <= fimIso;
+
+    // Pedido do sync de 10/06 (era o bug: ficava FORA da janela local em BRT)
+    expect(dentro('2026-06-10T00:00:00.000Z')).toBe(true);
+    // Pedidos do wizard nas bordas do dia local
+    expect(dentro(new Date(2026, 5, 10, 0, 1).toISOString())).toBe(true);
+    expect(dentro(new Date(2026, 5, 10, 23, 59).toISOString())).toBe(true);
+  });
+
+  it('é exatamente [min(início local, início UTC), max(fim local, fim UTC)] — sem folga além da necessária', () => {
+    const { inicioIso, fimIso } = janelaQueryDiaCivil(dia10);
+    const inicioUtc = Date.UTC(2026, 5, 10, 0, 0, 0, 0);
+    const fimUtc = Date.UTC(2026, 5, 10, 23, 59, 59, 999);
+    expect(inicioIso).toBe(new Date(Math.min(startOfDay(dia10).getTime(), inicioUtc)).toISOString());
+    expect(fimIso).toBe(new Date(Math.max(endOfDay(dia10).getTime(), fimUtc)).toISOString());
+  });
+});
+
+describe('pedidoNoDiaCivil', () => {
+  it('pedido do sync de hoje (meia-noite UTC) aparece HOJE — não no dia anterior', () => {
+    const syncHoje = '2026-06-10T00:00:00.000Z';
+    expect(pedidoNoDiaCivil(syncHoje, dia10)).toBe(true);
+    // Era o bug: em BRT esse instante é 09/06 21:00 local e caía na lista de ontem
+    expect(pedidoNoDiaCivil(syncHoje, dia09)).toBe(false);
+    expect(pedidoNoDiaCivil(syncHoje, dia11)).toBe(false);
+  });
+
+  it('pedido do wizard às 23h30 local não vaza pro dia seguinte', () => {
+    const wizardNoite = new Date(2026, 5, 10, 23, 30).toISOString();
+    expect(pedidoNoDiaCivil(wizardNoite, dia10)).toBe(true);
+    // Em BRT esse instante entra na JANELA DE QUERY do dia 11 (overlap da união) —
+    // é este re-filtro client-side que impede a duplicação.
+    expect(pedidoNoDiaCivil(wizardNoite, dia11)).toBe(false);
+  });
+
+  it('sem duplicação na borda: cada pedido pertence a exatamente 1 dia civil', () => {
+    const pedidos = [
+      '2026-06-10T00:00:00.000Z', // sync de 10/06
+      '2026-06-11T00:00:00.000Z', // sync de 11/06 (entra na janela de query do dia 10 em BRT)
+      new Date(2026, 5, 10, 23, 30).toISOString(), // wizard noite de 10/06
+      new Date(2026, 5, 11, 0, 5).toISOString(), // wizard madrugada de 11/06
+    ];
+    const dias = [dia09, dia10, dia11, new Date(2026, 5, 12)];
+    for (const createdAt of pedidos) {
+      const aparicoes = dias.filter(d => pedidoNoDiaCivil(createdAt, d)).length;
+      expect(aparicoes).toBe(1);
+    }
+  });
+
+  it('created_at inválido → false (não polui nenhuma lista)', () => {
+    expect(pedidoNoDiaCivil('lixo', dia10)).toBe(false);
+    expect(pedidoNoDiaCivil('', dia10)).toBe(false);
+  });
+});
+
+describe('horaExibicaoPedido', () => {
+  it('data-pura do sync → "—" (não existe hora real; HH:mm local fabricaria "21:00")', () => {
+    expect(horaExibicaoPedido('2026-06-10T00:00:00.000Z')).toBe('—');
+  });
+
+  it('timestamp real do wizard → HH:mm local (comportamento atual preservado)', () => {
+    const iso = new Date(2026, 5, 10, 9, 30).toISOString();
+    expect(horaExibicaoPedido(iso)).toBe(format(new Date(iso), 'HH:mm'));
+  });
+
+  it('entrada inválida → "—"', () => {
+    expect(horaExibicaoPedido('lixo')).toBe('—');
+  });
+});

--- a/src/lib/pedido/data-pedido.ts
+++ b/src/lib/pedido/data-pedido.ts
@@ -1,0 +1,36 @@
+// Data de exibição de pedido (sales_orders.created_at).
+//
+// Pedidos importados do Omie (omie-vendas-sync, sync_pedidos) têm created_at
+// derivado de data_previsao — uma data PURA (DD/MM/YYYY, sem hora) que o sync
+// grava como meia-noite UTC. Formatar esse timestamp com hora no fuso local
+// fabrica "às 21:00" e escorrega o dia (10/06 00:00 UTC → 09/06 21:00 em BRT).
+// Pedidos criados pelo wizard têm created_at real (now() do banco) e mantêm
+// data + hora locais.
+import { format } from 'date-fns';
+import { ptBR } from 'date-fns/locale';
+
+// Meia-noite UTC exata = data-pura (o Omie não fornece hora). Um pedido do
+// wizard criado exatamente em 00:00:00.000Z perderia a hora na exibição —
+// 1 instante em 86,4 milhões por dia, aceitável.
+export function ehDataPuraUtc(d: Date): boolean {
+  return (
+    d.getUTCHours() === 0 &&
+    d.getUTCMinutes() === 0 &&
+    d.getUTCSeconds() === 0 &&
+    d.getUTCMilliseconds() === 0
+  );
+}
+
+export function formatarDataPedido(
+  createdAt: string,
+  formatoComHora: string = "dd/MM/yyyy 'às' HH:mm",
+): string {
+  const d = new Date(createdAt);
+  if (Number.isNaN(d.getTime())) return '—';
+  if (ehDataPuraUtc(d)) {
+    const dia = String(d.getUTCDate()).padStart(2, '0');
+    const mes = String(d.getUTCMonth() + 1).padStart(2, '0');
+    return `${dia}/${mes}/${d.getUTCFullYear()}`;
+  }
+  return format(d, formatoComHora, { locale: ptBR });
+}

--- a/src/lib/pedido/dia-civil.ts
+++ b/src/lib/pedido/dia-civil.ts
@@ -1,0 +1,59 @@
+// Dia civil de um pedido (sales_orders/orders.created_at) — DOIS regimes coexistem:
+// - sync Omie (omie-vendas-sync sync_pedidos): created_at é data PURA gravada como
+//   meia-noite UTC (o Omie não fornece hora) → o dia civil correto é o dia UTC;
+// - wizard/app: created_at real (now() do banco) → o dia civil é o dia LOCAL.
+// Filtrar por janela local pura (startOfDay/endOfDay) joga o pedido do sync no dia
+// anterior em BRT (10/06 00:00Z = 09/06 21:00 local). A solução: a QUERY usa a união
+// das duas janelas e o pertencimento ao dia é re-decidido client-side por regime.
+import { endOfDay, format, startOfDay } from 'date-fns';
+import { ehDataPuraUtc } from './data-pedido';
+
+/**
+ * Janela [inicio, fim] pra query de created_at: união do dia civil LOCAL com o dia
+ * civil UTC da data selecionada. Mais larga que cada regime sozinho — pode incluir
+ * pedidos de dias vizinhos; quem decide o dia é `pedidoNoDiaCivil` (client-side).
+ */
+export function janelaQueryDiaCivil(dataSelecionada: Date): { inicioIso: string; fimIso: string } {
+  const ano = dataSelecionada.getFullYear();
+  const mes = dataSelecionada.getMonth();
+  const dia = dataSelecionada.getDate();
+  const inicioUtc = Date.UTC(ano, mes, dia, 0, 0, 0, 0);
+  const fimUtc = Date.UTC(ano, mes, dia, 23, 59, 59, 999);
+  return {
+    inicioIso: new Date(Math.min(startOfDay(dataSelecionada).getTime(), inicioUtc)).toISOString(),
+    fimIso: new Date(Math.max(endOfDay(dataSelecionada).getTime(), fimUtc)).toISOString(),
+  };
+}
+
+/**
+ * O pedido pertence ao dia civil da data selecionada? Data-pura (sync) compara o
+ * calendário UTC; timestamp real (wizard) compara o calendário local. Cada pedido
+ * pertence a exatamente UM dia — é o que evita duplicação na borda entre dias
+ * adjacentes quando a janela de query (união) se sobrepõe.
+ */
+export function pedidoNoDiaCivil(createdAt: string, dataSelecionada: Date): boolean {
+  const d = new Date(createdAt);
+  if (Number.isNaN(d.getTime())) return false;
+  if (ehDataPuraUtc(d)) {
+    return (
+      d.getUTCFullYear() === dataSelecionada.getFullYear() &&
+      d.getUTCMonth() === dataSelecionada.getMonth() &&
+      d.getUTCDate() === dataSelecionada.getDate()
+    );
+  }
+  return (
+    d.getFullYear() === dataSelecionada.getFullYear() &&
+    d.getMonth() === dataSelecionada.getMonth() &&
+    d.getDate() === dataSelecionada.getDate()
+  );
+}
+
+/**
+ * Hora pra exibição em lista: data-pura não tem hora real (HH:mm local fabricaria
+ * "21:00" em BRT) → "—"; timestamp real mantém HH:mm local.
+ */
+export function horaExibicaoPedido(createdAt: string): string {
+  const d = new Date(createdAt);
+  if (Number.isNaN(d.getTime()) || ehDataPuraUtc(d)) return '—';
+  return format(d, 'HH:mm');
+}

--- a/src/pages/SalesPrintDashboard.tsx
+++ b/src/pages/SalesPrintDashboard.tsx
@@ -6,7 +6,8 @@ import { Badge } from '@/components/ui/badge';
 import { supabase } from '@/integrations/supabase/client';
 import { useQuery } from '@tanstack/react-query';
 import { Loader2, Printer, ArrowLeft } from 'lucide-react';
-import { format, startOfDay, endOfDay } from 'date-fns';
+import { format } from 'date-fns';
+import { janelaQueryDiaCivil, pedidoNoDiaCivil } from '@/lib/pedido/dia-civil';
 import { openPrintOrder } from '@/components/OrderPrintLayout';
 import {
   COMPANY_LABELS, COMPANY_COLORS, getPeriod,
@@ -24,8 +25,10 @@ const SalesPrintDashboard = () => {
   const [selectedPeriod, setSelectedPeriod] = useState<'all' | 'manha' | 'tarde'>('all');
   const [selectedOrders, setSelectedOrders] = useState<Set<string>>(new Set());
 
-  const dayStart = startOfDay(selectedDate).toISOString();
-  const dayEnd = endOfDay(selectedDate).toISOString();
+  // Janela de query = união do dia local (pedidos do wizard) com o dia UTC (pedidos do
+  // sync Omie, created_at data-pura à meia-noite UTC). Mais larga que o dia exibido —
+  // o pertencimento real é re-decidido em filteredOrders via pedidoNoDiaCivil.
+  const { inicioIso: dayStart, fimIso: dayEnd } = janelaQueryDiaCivil(selectedDate);
 
   // Fetch company logos from Omie
   const { data: companyLogos = {} } = useQuery({
@@ -265,6 +268,9 @@ const SalesPrintDashboard = () => {
   // Enriched and filtered orders
   const filteredOrders = useMemo(() => {
     return allOrdersRaw
+      // A janela de query é a união dos dois regimes (pega pedidos de dias vizinhos
+      // na borda) — aqui cada pedido é atribuído ao SEU dia civil, sem duplicação.
+      .filter(o => pedidoNoDiaCivil(o.created_at, selectedDate))
       .filter(o => selectedCompanies.includes(o._company))
       .filter(o => {
         if (selectedPeriod === 'all') return true;
@@ -292,7 +298,7 @@ const SalesPrintDashboard = () => {
           cond_pagamento: condPagamento,
         };
       });
-  }, [allOrdersRaw, selectedCompanies, selectedPeriod, profileMap, addressMap, formasMap]);
+  }, [allOrdersRaw, selectedDate, selectedCompanies, selectedPeriod, profileMap, addressMap, formasMap]);
 
   // Group by company then period
   const grouped = useMemo(() => {


### PR DESCRIPTION
## Bug

Pedido importado do Omie (`omie-vendas-sync sync_pedidos`) tem `created_at` = **data PURA gravada como meia-noite UTC** (o Omie só fornece a data). A tela `/sales/print` filtrava o dia com `startOfDay/endOfDay` **locais** (BRT = 03:00Z..02:59Z do dia seguinte) → o pedido do sync de hoje (`2026-06-10T00:00:00Z`) ficava **fora da janela** e aparecia na lista de impressão de **ontem**, classificado como "tarde" com hora fabricada "21:00". Pedidos do wizard (created_at real, `now()` do banco) eram filtrados corretamente.

## Fix (helper puro TDD — `src/lib/pedido/dia-civil.ts`)

- **`janelaQueryDiaCivil`**: a query passa a usar a **união** do dia civil local (regime wizard) com o dia civil UTC (regime sync) — em BRT vira `[D 00:00Z, D+1 02:59:59.999Z]`. Mais larga que o dia exibido, por construção pega pedidos de dias vizinhos na borda…
- **`pedidoNoDiaCivil`**: …e o pertencimento é re-decidido client-side por regime: **dia UTC** para data-pura (via `ehDataPuraUtc`), **dia local** para timestamp real. Cada pedido pertence a exatamente **1** dia civil → sem duplicação entre dias adjacentes (ex.: wizard 23h30 local entra na janela de query do dia seguinte, mas só aparece no seu dia; sync de amanhã 00:00Z entra na janela de hoje, mas só aparece amanhã).
- **`getPeriod` regime-aware**: data-pura → relógio UTC (00:00 → **manhã**; antes o relógio local fabricava "tarde" via 21:00). Operacionalmente importa: o lote de impressão da manhã passa a incluir os pedidos do sync.
- **`OrderGroup`**: hora vira `horaExibicaoPedido` → **"—"** para data-pura (não existe hora real), HH:mm local preservado para o wizard.

## Coordenação com o PR paralelo (`claude/ecstatic-pare-09147a`)

- `src/lib/pedido/data-pedido.ts` + teste **vendorizados byte-idênticos** daquele branch (provado por diff) → merge limpo em qualquer ordem; depois de ambos mergearem fica UM arquivo só.
- O cupom impresso (`buildPrintHtml.ts:44`, mesma hora fabricada) **é coberto por aquele PR** — deliberadamente não tocado aqui para não conflitar.

## Validação

- **TDD RED→GREEN provado**: 9 testes novos TZ-agnósticos (instantes locais via `new Date(y,m,d,h,m)`, UTC via ISO Z — passam em BRT local e no UTC do CI) cobrindo: sync de hoje aparece hoje (e não ontem), wizard 23h30 não vaza pro dia seguinte, **sem duplicação na borda** (cada pedido em exatamente 1 dia), janela exata min/max, hora "—"/HH:mm/inválida.
- Extensões nos testes existentes: `getPeriod` data-pura → manhã; `OrderGroup` renderiza "—" e nunca "21:00".
- Gates: `bun run typecheck` 0 · `bun run test` **3024/3024** · lint **0 errors** (nenhum warning nos arquivos tocados).

## Follow-up registrado (chip spawnado)

`useVendasZone` (KPI "faturado hoje/ontem" do dashboard) tem o MESMO bug de janela local sobre `sales_orders.created_at` — fora do escopo desta tela, chip criado reusando o helper novo.

⚠️ **Sem migration, sem edge** — 100% frontend; **requer Publish no Lovable** para ir ao ar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
