### PR TITLE
feat(farmer): home por persona (vendedora aterrissa no Meu Dia) + men…

### DIFF
--- a/docs/roadmap-sessao.md
+++ b/docs/roadmap-sessao.md
@@ -6,6 +6,21 @@
 
 ---
 
+## 🧑‍🌾 SESSÃO 2026-06-10 (3) — UX da Farmer: home errada, menu e gaps de ferramenta
+
+> Pedido do founder (via lente "Ver como tatyanamartins2002"): (1) por que a tela inicial
+> das farmers é o cockpit de 6 módulos? (2) otimizar o menu lateral delas; (3) opinião
+> sobre ferramentas que ainda faltam pra farmer.
+
+- ✅ **Diagnóstico da home** — `/` → `Index.tsx` decide só por `isStaff` binário → toda staff cai no `CockpitGrid` de 6 zonas; a persona `vendedor` só REORDENA os cards, não esconde nenhum. O dashboard sob medida (`/meu-dia` → `FarmerDashboardV2`) existe mas não é a home.
+- ✅ **Diagnóstico do menu** — sales-only esconde todas as seções exceto "Vendas" (`AppShell.tsx:628`) → "Meu dia" e "Clientes" (seção Principal) ficam INALCANÇÁVEIS pela farmer; `managerOnly` na verdade significa "qualquer staff" (nome mentiroso).
+- ✅ **Founder aprovou as 3 frentes** na ordem sugerida: (1) home+menu → (2) push pra vendedora → (3) ficha pré-contato.
+- ✅ **Frente 1 — home por persona + menu (PR aberto)**: helper puro TDD `src/lib/nav/home-por-persona.ts` (19 testes) — `resolverHomeStaff` (farmer/hunter/closer/operacional ou sales-only → `/meu-dia`; gestão/master/staff genérico → cockpit) + `itemVisivelParaSalesOnly` (allowlist: seção Vendas + Meu dia + Clientes). `Index.tsx` redireciona com gate anti-flash (espera o cargo) e gate `displayIsStaff` anti-loop na lente. AppShell: seção Vendas reordenada pelo fluxo do dia (Lista de ligação → WhatsApp → Novo Pedido → Pedidos → Telefonia → housekeeping no fim), filtro sales-only por ITEM nos 2 navs (desktop+mobile), badge SLA WhatsApp religado pra sales-only (`isStaff`, era `enableStaffPolls` que a excluía do próprio SLA), rename `managerOnly`→`staffOnly` (nome honesto). **Revisão adversarial (subagente, Caminho B — Codex sem cota): 0 P1; P2.1 loop-na-lente e P2.3 badge-SLA corrigidos; P2.2 flash sales-only-sem-cargo aceito documentado.** CI local: typecheck 0 · 3024 testes · lint 0 · build vite 0. ⚠️ Publish no Lovable pendente após merge.
+- ⏳ **Frente 2 — push/notificação pra vendedora** (tarefa nova, SLA estourando, cliente respondeu).
+- ⏳ **Frente 3 — ficha de 30s pré-contato** (últimas compras, preço praticado, títulos abertos, cores, última conversa).
+
+---
+
 ## ⚡ SESSÃO 2026-06-09/10 — Auditoria de velocidade & usabilidade: 24 itens mapeados, 4 ondas COMPLETAS
 
 > Pedido do founder: "revisite o código todo e procure brechas para deixar ele mais rápido

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -41,6 +41,7 @@ import { useFeatureFlagBodyClass } from '@/hooks/useFeatureFlag';
 import { useSidebarFavorites } from '@/hooks/useSidebarFavorites';
 import { useSalesOnlyRestriction } from '@/hooks/useSalesOnlyRestriction';
 import { useDisplayAccess } from '@/hooks/useDisplayAccess';
+import { itemVisivelParaSalesOnly, SECAO_VENDAS } from '@/lib/nav/home-por-persona';
 import { useImpersonation } from '@/contexts/ImpersonationContext';
 import { useRouteTracker } from '@/lib/dashboard/route-tracker';
 import { useOfflineFlush } from '@/hooks/useOfflineFlush';
@@ -57,7 +58,8 @@ interface NavItem {
   path: string;
   badge?: number;
   badgeVariant?: 'default' | 'destructive';
-  managerOnly?: boolean;
+  /** Visível a QUALQUER staff (employee/master). Era `managerOnly` — nome mentiroso. */
+  staffOnly?: boolean;
   masterOnly?: boolean;
   /** Visível apenas a gestor comercial (gerencial/estrategico/super_admin) OU master. */
   gestorComercialOuMaster?: boolean;
@@ -80,18 +82,20 @@ const unifiedNavSections: { title: string; items: NavItem[] }[] = [
     ],
   },
   {
-    title: 'Vendas',
+    title: SECAO_VENDAS,
+    // Ordem = fluxo do dia da vendedora: ligar (rota D-1) → responder (WhatsApp) →
+    // vender (pedido) → falar (telefonia). Housekeeping e hubs esporádicos no fim.
     items: [
-      { icon: ShoppingCart, label: 'Pedidos', path: '/sales' },
+      { icon: ListChecks, label: 'Lista de ligação', path: '/rota/ligacoes', staffOnly: true },
+      { icon: MessageCircle, label: 'WhatsApp', path: '/whatsapp', staffOnly: true },
       { icon: PlusCircle, label: 'Novo Pedido', path: '/sales/new' },
+      { icon: ShoppingCart, label: 'Pedidos', path: '/sales' },
+      { icon: Phone, label: 'Telefonia', path: '/telefonia' },
       { icon: ClipboardList, label: 'Tarefas', path: '/tarefas', gestorComercialOuMaster: true },
       { icon: ListChecks, label: 'Tarefas recorrentes', path: '/tarefas/templates', gestorComercialOuMaster: true },
-      { icon: Wrench, label: 'Ferramentas de Venda', path: '/vendas/ferramentas' },
       { icon: Link2, label: 'Chamadas pendentes', path: '/farmer/calls/pending-link' },
-      { icon: Phone, label: 'Telefonia', path: '/telefonia' },
-      { icon: MessageCircle, label: 'WhatsApp', path: '/whatsapp', managerOnly: true },
-      { icon: ListChecks, label: 'Lista de ligação', path: '/rota/ligacoes', managerOnly: true },
-      { icon: MessageSquareText, label: 'Preview propostas', path: '/rota/propostas', managerOnly: true },
+      { icon: Wrench, label: 'Ferramentas de Venda', path: '/vendas/ferramentas' },
+      { icon: MessageSquareText, label: 'Preview propostas', path: '/rota/propostas', staffOnly: true },
     ],
   },
   {
@@ -104,12 +108,12 @@ const unifiedNavSections: { title: string; items: NavItem[] }[] = [
   {
     title: 'Reposição',
     items: [
-      { icon: LayoutDashboard, label: 'Cockpit', path: '/admin/reposicao/sessao', managerOnly: true },
-      { icon: TrendingUp, label: 'Mercado', path: '/admin/reposicao/sessao/mercado', managerOnly: true },
-      { icon: Settings, label: 'Parâmetros', path: '/admin/reposicao/sessao/parametros', managerOnly: true },
-      { icon: Database, label: 'Cadastros', path: '/admin/reposicao/cadastros', managerOnly: true },
-      { icon: Package, label: 'Embalagem econômica', path: '/admin/reposicao/embalagem', managerOnly: true },
-      { icon: History, label: 'Mudanças automáticas', path: '/admin/reposicao/mudancas-automaticas', managerOnly: true },
+      { icon: LayoutDashboard, label: 'Cockpit', path: '/admin/reposicao/sessao', staffOnly: true },
+      { icon: TrendingUp, label: 'Mercado', path: '/admin/reposicao/sessao/mercado', staffOnly: true },
+      { icon: Settings, label: 'Parâmetros', path: '/admin/reposicao/sessao/parametros', staffOnly: true },
+      { icon: Database, label: 'Cadastros', path: '/admin/reposicao/cadastros', staffOnly: true },
+      { icon: Package, label: 'Embalagem econômica', path: '/admin/reposicao/embalagem', staffOnly: true },
+      { icon: History, label: 'Mudanças automáticas', path: '/admin/reposicao/mudancas-automaticas', staffOnly: true },
     ],
   },
   {
@@ -134,10 +138,10 @@ const unifiedNavSections: { title: string; items: NavItem[] }[] = [
   {
     title: 'Financeiro',
     items: [
-      { icon: Shield, label: 'Cockpit CFO', path: '/financeiro/cockpit', managerOnly: true },
-      { icon: DollarSign, label: 'Gestão Financeira', path: '/financeiro/gestao', managerOnly: true },
-      { icon: BarChart3, label: 'Análise e Config', path: '/financeiro/analise', managerOnly: true },
-      { icon: Target, label: 'Orçamento', path: '/financeiro/orcamento', managerOnly: true },
+      { icon: Shield, label: 'Cockpit CFO', path: '/financeiro/cockpit', staffOnly: true },
+      { icon: DollarSign, label: 'Gestão Financeira', path: '/financeiro/gestao', staffOnly: true },
+      { icon: BarChart3, label: 'Análise e Config', path: '/financeiro/analise', staffOnly: true },
+      { icon: Target, label: 'Orçamento', path: '/financeiro/orcamento', staffOnly: true },
       { icon: TrendingUp, label: 'Retorno & Valor', path: '/financeiro/valor', masterOnly: true },
       { icon: Percent, label: 'Regime Tributário', path: '/financeiro/regime-tributario', masterOnly: true },
       { icon: Landmark, label: 'Custo de Funding', path: '/financeiro/funding', masterOnly: true },
@@ -148,29 +152,29 @@ const unifiedNavSections: { title: string; items: NavItem[] }[] = [
   {
     title: 'Tintométrico',
     items: [
-      { icon: BarChart3, label: 'Dashboard', path: '/tintometrico', managerOnly: true },
-      { icon: Palette, label: 'Catálogo e Preços', path: '/tintometrico/catalogo', managerOnly: true },
-      { icon: Settings, label: 'Integração e Sync', path: '/tintometrico/integracao', managerOnly: true },
+      { icon: BarChart3, label: 'Dashboard', path: '/tintometrico', staffOnly: true },
+      { icon: Palette, label: 'Catálogo e Preços', path: '/tintometrico/catalogo', staffOnly: true },
+      { icon: Settings, label: 'Integração e Sync', path: '/tintometrico/integracao', staffOnly: true },
     ],
   },
   {
     title: 'Automação',
     items: [
-      { icon: Bell, label: 'Notificações', path: '/admin/notificacoes', managerOnly: true },
+      { icon: Bell, label: 'Notificações', path: '/admin/notificacoes', staffOnly: true },
     ],
   },
   {
     title: 'Gestão',
     items: [
-      { icon: UserCheck, label: 'Liberar Acessos', path: '/admin/approvals', managerOnly: true },
-      { icon: Users, label: 'Departamentos', path: '/admin/departments', managerOnly: true },
+      { icon: UserCheck, label: 'Liberar Acessos', path: '/admin/approvals', staffOnly: true },
+      { icon: Users, label: 'Departamentos', path: '/admin/departments', staffOnly: true },
       { icon: UserX, label: 'Clientes não-vinculados', path: '/admin/clientes-nao-vinculados', gestorComercialOuMaster: true },
-      { icon: Library, label: 'Base de conhecimento', path: '/admin/knowledge-base', managerOnly: true },
+      { icon: Library, label: 'Base de conhecimento', path: '/admin/knowledge-base', staffOnly: true },
       { icon: Calculator, label: 'Calculadora de rendimento', path: '/admin/calculadora' },
       { icon: Factory, label: 'Processos padrão', path: '/admin/standard-processes' },
-      { icon: Shield, label: 'Admin & Relatórios', path: '/gestao/admin', managerOnly: true },
-      { icon: Lock, label: 'Governança', path: '/gestao/governanca', managerOnly: true },
-      { icon: ShieldCheck, label: 'Saúde de Dados', path: '/gestao/saude-dados', managerOnly: true },
+      { icon: Shield, label: 'Admin & Relatórios', path: '/gestao/admin', staffOnly: true },
+      { icon: Lock, label: 'Governança', path: '/gestao/governanca', staffOnly: true },
+      { icon: ShieldCheck, label: 'Saúde de Dados', path: '/gestao/saude-dados', staffOnly: true },
       { icon: MessageCircle, label: 'SLA WhatsApp', path: '/whatsapp/sla', gestorComercialOuMaster: true },
     ],
   },
@@ -489,10 +493,11 @@ function AppSidebar({ collapsed, onToggle }: { collapsed: boolean; onToggle: () 
 
   // Badge vermelho de WhatsApp: clientes MEUS com SLA vencido (vermelho).
   // Compartilha a queryKey/cache do useWhatsappSla (dado consistente com o
-  // card/inbox; realtime das telas ricas atualiza o badge). Gate
-  // enableStaffPolls: o item de nav é managerOnly — sales-only não o vê e
-  // não deve pagar o poll da view scan-heavy.
-  const { data: waSlaMeusVermelhos } = useWhatsappSlaBadge(user?.id, enableStaffPolls);
+  // card/inbox; realtime das telas ricas atualiza o badge). Gate `isStaff`
+  // SEM o !isSalesOnly do enableStaffPolls: a vendedora sales-only VÊ o item
+  // /whatsapp (allowlist) e é justamente o público-alvo do SLA (#587) — o
+  // poll dela é 1 view/60s que ela já paga ao abrir o inbox.
+  const { data: waSlaMeusVermelhos } = useWhatsappSlaBadge(user?.id, isStaff);
 
   const sectionsWithBadges = React.useMemo(
     () => [...unifiedNavSections, docNavSection].map((s) => ({
@@ -615,7 +620,7 @@ function AppSidebar({ collapsed, onToggle }: { collapsed: boolean; onToggle: () 
               sectionsWithBadges
                 .flatMap((s) => s.items)
                 .filter((item) => favorites.includes(item.path))
-                .filter((item) => (!item.managerOnly || displayIsStaff) && (!item.masterOnly || displayIsMaster) && (!item.gestorComercialOuMaster || displayIsMaster || displayIsGestorComercial))
+                .filter((item) => (!item.staffOnly || displayIsStaff) && (!item.masterOnly || displayIsMaster) && (!item.gestorComercialOuMaster || displayIsMaster || displayIsGestorComercial))
             }
             onToggleFavorite={toggleFavorite}
             isFavorite={isFavorite}
@@ -623,9 +628,11 @@ function AppSidebar({ collapsed, onToggle }: { collapsed: boolean; onToggle: () 
         )}
 
         {sectionsWithBadges.map((section) => {
-          if (displayIsSalesOnly && section.title !== 'Vendas') return null;
-
-          const visibleItems = section.items.filter(item => (!item.managerOnly || displayIsStaff) && (!item.masterOnly || displayIsMaster) && (!item.gestorComercialOuMaster || displayIsMaster || displayIsGestorComercial));
+          // Sales-only filtra por ITEM (allowlist: seção Vendas + Meu dia + Clientes),
+          // não mais por título de seção — senão o Meu Dia ficava inalcançável.
+          const visibleItems = section.items.filter(item =>
+            (!displayIsSalesOnly || itemVisivelParaSalesOnly(section.title, item.path)) &&
+            (!item.staffOnly || displayIsStaff) && (!item.masterOnly || displayIsMaster) && (!item.gestorComercialOuMaster || displayIsMaster || displayIsGestorComercial));
           if (visibleItems.length === 0) return null;
 
           const isSecondary = SECONDARY_SECTIONS.includes(section.title);
@@ -760,8 +767,10 @@ function MobileNav({ open, onClose }: { open: boolean; onClose: () => void }) {
             </div>
           ) : (
           [...unifiedNavSections, docNavSection].map((section) => {
-            if (isSalesOnly && section.title !== 'Vendas') return null;
-            const visibleItems = section.items.filter(item => (!item.managerOnly || isStaff) && (!item.masterOnly || isMaster) && (!item.gestorComercialOuMaster || isMaster || isGestorComercial));
+            // Espelha o filtro do desktop: sales-only por ITEM (allowlist), não por seção.
+            const visibleItems = section.items.filter(item =>
+              (!isSalesOnly || itemVisivelParaSalesOnly(section.title, item.path)) &&
+              (!item.staffOnly || isStaff) && (!item.masterOnly || isMaster) && (!item.gestorComercialOuMaster || isMaster || isGestorComercial));
             if (visibleItems.length === 0) return null;
             return (
               <div key={section.title} className="mb-1">

--- a/src/lib/nav/home-por-persona.test.ts
+++ b/src/lib/nav/home-por-persona.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { resolverHomeStaff, itemVisivelParaSalesOnly } from './home-por-persona';
+
+describe('resolverHomeStaff', () => {
+  it.each(['farmer', 'hunter', 'closer', 'operacional'])(
+    'cargo %s (vendedora) → /meu-dia',
+    (cargo) => {
+      expect(resolverHomeStaff({ commercialRole: cargo, isSalesOnly: false })).toBe('/meu-dia');
+    },
+  );
+
+  it.each(['gerencial', 'estrategico', 'super_admin', 'master'])(
+    'cargo %s (gestão) mantém o cockpit',
+    (cargo) => {
+      expect(resolverHomeStaff({ commercialRole: cargo, isSalesOnly: false })).toBeNull();
+    },
+  );
+
+  it('sales-only sem cargo comercial → /meu-dia', () => {
+    expect(resolverHomeStaff({ commercialRole: null, isSalesOnly: true })).toBe('/meu-dia');
+  });
+
+  it('sales-only domina mesmo com cargo de gestão (o menu dela já é só-Vendas)', () => {
+    expect(resolverHomeStaff({ commercialRole: 'gerencial', isSalesOnly: true })).toBe('/meu-dia');
+  });
+
+  it('staff sem cargo e sem sales-only mantém o cockpit', () => {
+    expect(resolverHomeStaff({ commercialRole: null, isSalesOnly: false })).toBeNull();
+  });
+
+  it('cargo desconhecido não redireciona (conservador)', () => {
+    expect(resolverHomeStaff({ commercialRole: 'estagiario', isSalesOnly: false })).toBeNull();
+  });
+});
+
+describe('itemVisivelParaSalesOnly', () => {
+  it('toda a seção Vendas é visível', () => {
+    expect(itemVisivelParaSalesOnly('Vendas', '/sales')).toBe(true);
+    expect(itemVisivelParaSalesOnly('Vendas', '/rota/ligacoes')).toBe(true);
+  });
+
+  it('Meu dia e Clientes (seção Principal) entram pela allowlist', () => {
+    expect(itemVisivelParaSalesOnly('Principal', '/meu-dia')).toBe(true);
+    expect(itemVisivelParaSalesOnly('Principal', '/admin/customers')).toBe(true);
+  });
+
+  it('Dashboard (/) continua escondido pra sales-only', () => {
+    expect(itemVisivelParaSalesOnly('Principal', '/')).toBe(false);
+  });
+
+  it.each([
+    ['Reposição', '/admin/reposicao/sessao'],
+    ['Financeiro', '/financeiro/cockpit'],
+    ['Estoque', '/admin/estoque/picking'],
+    ['Documentação', '/docs'],
+  ])('seção %s segue invisível pra sales-only', (secao, path) => {
+    expect(itemVisivelParaSalesOnly(secao, path)).toBe(false);
+  });
+});

--- a/src/lib/nav/home-por-persona.ts
+++ b/src/lib/nav/home-por-persona.ts
@@ -1,0 +1,46 @@
+/**
+ * Decisões de navegação por persona comercial — helpers puros (TDD).
+ *
+ * `resolverHomeStaff`: pra onde a home `/` deve levar um STAFF. Vendedora
+ * (farmer/hunter/closer/operacional, ou CPF sales-only) trabalha no Meu Dia
+ * (fila do dia, positivação, SLA WhatsApp, tarefas, agenda) — o cockpit de
+ * 6 módulos da empresa é a home de gestor/master/staff genérico.
+ *
+ * `itemVisivelParaSalesOnly`: substitui a regra antiga do AppShell que
+ * filtrava por TÍTULO de seção (`section.title !== 'Vendas'`) e tornava o
+ * Meu Dia e a carteira de Clientes (seção Principal) INALCANÇÁVEIS pela
+ * vendedora sales-only.
+ */
+
+/** Cargos comerciais que vivem no Meu Dia (dashboards de vendedora do CommercialDashboard). */
+const CARGOS_VENDEDORA = new Set(['farmer', 'hunter', 'closer', 'operacional']);
+
+export interface SinaisHomeStaff {
+  /** commercial_role efetivo (real, ou do alvo na lente "Ver como"). Vem CRU do banco
+   *  em runtime — pode conter valores fora do union TS legado (farmer/hunter/closer). */
+  commercialRole: string | null;
+  /** CPF na lista company_config.sales_only_cpfs (efetivo: real ou do alvo na lente). */
+  isSalesOnly: boolean;
+}
+
+/** Destino da home pra staff: '/meu-dia' (vendedora) ou null (mantém o cockpit). */
+export function resolverHomeStaff({ commercialRole, isSalesOnly }: SinaisHomeStaff): '/meu-dia' | null {
+  // Sales-only domina: o menu dela esconde os outros módulos — home cockpit é incoerente.
+  if (isSalesOnly) return '/meu-dia';
+  if (commercialRole && CARGOS_VENDEDORA.has(commercialRole)) return '/meu-dia';
+  // gerencial/estrategico/super_admin/master, sem cargo ou cargo desconhecido → cockpit.
+  return null;
+}
+
+/** Título da seção de Vendas no nav — contrato entre o AppShell e o filtro sales-only.
+ *  Renomear a seção SÓ por aqui (string solta nos dois lados quebraria o menu mudo). */
+export const SECAO_VENDAS = 'Vendas';
+
+/** Paths fora da seção Vendas que a vendedora sales-only PRECISA alcançar. */
+export const PATHS_EXTRAS_SALES_ONLY: readonly string[] = ['/meu-dia', '/admin/customers'];
+
+/** Item de nav visível pra sales-only? Toda a seção Vendas + allowlist de extras. */
+export function itemVisivelParaSalesOnly(sectionTitle: string, path: string): boolean {
+  if (sectionTitle === SECAO_VENDAS) return true;
+  return PATHS_EXTRAS_SALES_ONLY.includes(path);
+}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,10 +1,14 @@
 import { lazy, Suspense } from 'react';
+import { Navigate } from 'react-router-dom';
 import { useAuth } from '@/contexts/AuthContext';
 import { Skeleton } from '@/components/ui/skeleton';
 
 import { useBasicProfile } from '@/queries/useProfile';
 import { useCustomerPendingOrders } from '@/queries/useOrders';
 import { useUserToolsSummary } from '@/queries/useUserTools';
+import { useMyCommercialRole } from '@/hooks/useMyCommercialRole';
+import { useDisplayAccess } from '@/hooks/useDisplayAccess';
+import { resolverHomeStaff } from '@/lib/nav/home-por-persona';
 
 // Lazy POR PAPEL: o cliente não baixa o cockpit drag-and-drop do staff (~95KB
 // de dnd) e o staff não baixa o framer-motion do dashboard do cliente (~124KB).
@@ -34,6 +38,12 @@ const Index = () => {
   const { data: userTools = [] } =
     useUserToolsSummary(!isStaff ? user?.id : undefined, !isStaff && !roleLoading);
 
+  // Home por persona: vendedora (farmer/hunter/closer/operacional ou sales-only)
+  // aterrissa no Meu Dia — o cockpit de 6 módulos é home de gestor/master/staff
+  // genérico. Ambos os hooks são lente-aware ("Ver como" testa o fluxo do alvo).
+  const { data: roleComercial, isLoading: roleComercialLoading } = useMyCommercialRole();
+  const { displayIsStaff, displayIsSalesOnly, displayLoading } = useDisplayAccess();
+
   const getGreeting = () => {
     const hour = new Date().getHours();
     if (hour < 12) return 'Bom dia';
@@ -56,6 +66,26 @@ const Index = () => {
         />
       </Suspense>
     );
+  }
+
+  // Segura o skeleton até saber o cargo comercial — sem isso a vendedora COM cargo
+  // veria o cockpit por um instante (e dispararia os fetches das 6 zonas) antes do
+  // redirect. Limitação aceita: sales-only SEM cargo cadastrado ainda flasha o
+  // cockpit (useSalesOnlyRestriction retorna false enquanto carrega, sem loading
+  // exposto) — caso teórico, toda vendedora real tem commercial_role.
+  if (roleComercialLoading || displayLoading) {
+    return <HomeSkeleton />;
+  }
+
+  // `displayIsStaff` no gate: fora da lente é o próprio isStaff (equivalente); NA
+  // lente evita loop com alvo de perfil inconsistente (commercial_role de vendedora
+  // mas app_role não-staff → RequireStaff de /meu-dia rebateria pra cá eternamente).
+  const homeStaff = resolverHomeStaff({
+    commercialRole: roleComercial,
+    isSalesOnly: displayIsSalesOnly,
+  });
+  if (homeStaff && displayIsStaff) {
+    return <Navigate to={homeStaff} replace />;
   }
 
   return (


### PR DESCRIPTION
## O problema (visto pela lente "Ver como tatyanamartins2002")

A vendedora logava no **cockpit de 6 módulos da empresa** (Vendas, Sistema, Reposição, Estoque, Financeiro, Tintométrico) — a persona `vendedor` do dashboard só REORDENAVA os cards, não escondia nenhum. Enquanto isso, o dashboard construído PRA ela (`/meu-dia` → FarmerDashboardV2: fila do dia com crítica, positivação MTD, SLA WhatsApp, tarefas, agenda) era **inalcançável pelo menu**: a regra sales-only escondia toda seção `!= 'Vendas'`, inclusive a Principal onde moram "Meu dia" e "Clientes".

## O que muda

1. **Home por persona** — `Index.tsx`: staff com cargo de vendedora (`farmer/hunter/closer/operacional`) ou CPF sales-only → `<Navigate to="/meu-dia" replace>`. Gestão (`gerencial/estrategico/super_admin/master`), staff genérico e clientes: comportamento idêntico ao atual. Gates: skeleton até o cargo resolver (anti-flash) + `displayIsStaff` (anti-loop na lente com alvo de perfil inconsistente).
2. **Menu sales-only por allowlist de ITEM** (desktop + mobile): seção Vendas inteira + `/meu-dia` + `/admin/customers`. A vendedora ganha **Meu dia** e **Clientes**; "Dashboard" (`/`) e as demais seções continuam fora.
3. **Seção Vendas reordenada pelo fluxo do dia**: Lista de ligação → WhatsApp → Novo Pedido → Pedidos → Telefonia → Tarefas (gestor) → housekeeping (Chamadas pendentes, Ferramentas de Venda, Preview propostas) no fim.
4. **Badge SLA WhatsApp religado pra sales-only**: o gate `enableStaffPolls` excluía a vendedora do badge do PRÓPRIO SLA dela (#587). Agora `isStaff`.
5. **Rename `managerOnly` → `staffOnly`** (AppShell-only, semântica inalterada — a flag sempre significou "qualquer staff").

Helper puro TDD `src/lib/nav/home-por-persona.ts` (**19 testes**) é a fonte das duas decisões.

## Revisão adversarial (subagente — Caminho B, Codex sem cota)

**0 P1.** Corrigidos: **P2.1** loop de Navigate na lente com alvo `commercial_role` de vendedora mas `app_role` não-staff (gate `displayIsStaff`); **P2.3** badge SLA morto pro público-alvo + comentário stale. **Aceitos documentados:** P2.2 flash do cockpit pra sales-only SEM cargo cadastrado (caso teórico); P3.1 item "Dashboard" vira alias da home pra vendedora não-sales-only; P3.4 pageview duplo `/`→`/meu-dia` no PostHog.

## Validação

- typecheck (strict) ✅ · **3061/3061 testes** (pós-merge da main) ✅ · lint ✅ · build vite ✅
- Sem migration, sem edge function. **⚠️ Requer Publish no Lovable após o merge.**
- QA sugerido na lente: "Ver como tatyanamartins2002" → a raiz `/` deve cair no Meu Dia; menu deve mostrar Principal (Meu dia, Clientes) + Vendas reordenada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
