### PR TITLE
fix(dashboard): KPIs de vendas — pedido do sync Omie (data-pura UTC) caía em "ontem"

### DIFF
--- a/docs/roadmap-sessao.md
+++ b/docs/roadmap-sessao.md
@@ -6,6 +6,20 @@
 
 ---
 
+## 📊 SESSÃO 2026-06-10 (4) — KPIs do cockpit de vendas: pedido do sync Omie (data-pura UTC) caía em "ontem"
+
+> Mesmo bug do `/sales/print` (#733), agora nos KPIs "Faturado hoje/ontem" e "Pedidos
+> hoje" do `useVendasZone`: janela de dia LOCAL (`.gte/.lt` em `created_at`) × pedido do
+> sync com `created_at` = meia-noite UTC → em BRT a janela de hoje começa às 03:00Z e o
+> pedido do sync de hoje caía em "ontem" (subconta o KPI de hoje, infla o de ontem e
+> distorce o delta %).
+
+- ✅ Fix: query única com `janelaQueryHojeOntem` (união dos dias civis de ontem+hoje, local∪UTC) + re-filtro client-side `agregarVendasPorDiaCivil` — cada pedido conta em **exatamente 1 dia** via `pedidoNoDiaCivil` (reusa os helpers do #733). Helper novo `src/lib/dashboard/vendas-dia-civil.ts` (TDD, 10 testes TZ-agnósticos — instantes locais via `new Date(y,m,d,h,m)`, UTC via ISO Z; passa em BRT e no UTC do CI). De quebra: 2 queries → 1.
+- ✅ CI local verde (typecheck strict · 3047/3047 testes · lint 0 errors nos arquivos tocados) — 100% frontend (sem migration, sem edge). PR aberto na sequência (auto-merge no `validate`).
+- ⚠️ Publish no Lovable pendente pra ir ao ar.
+
+---
+
 ## 🧮 SESSÃO 2026-06-10 (3) — Embalagem econômica indicava QT com GL mais barato/litro (WP01/WP87/WP04)
 
 > Queixa do founder: preencheu os preços manualmente, o GL ficou mais barato por

--- a/src/hooks/dashboard/useVendasZone.ts
+++ b/src/hooks/dashboard/useVendasZone.ts
@@ -6,6 +6,11 @@ import { useDashboardCompany } from '@/hooks/useDashboardCompany';
 import { useCockpitChannel } from '@/hooks/dashboard/useCockpitChannel';
 import { variantFromScore, type PriorityCandidate } from '@/lib/dashboard/priority-rules';
 import { formatCount } from '@/lib/dashboard/format';
+import {
+  agregarVendasPorDiaCivil,
+  janelaQueryHojeOntem,
+  type PedidoVendasDia,
+} from '@/lib/dashboard/vendas-dia-civil';
 import type { KpiSpec } from '@/components/dashboard/cockpit/CockpitKpiRow';
 import type { TopListItem } from '@/components/dashboard/cockpit/CockpitTopList';
 
@@ -28,10 +33,7 @@ export function useVendasZone() {
   const { data, isLoading, isError, refetch } = useQuery({
     queryKey,
     queryFn: async () => {
-      const startOfDay = new Date();
-      startOfDay.setHours(0, 0, 0, 0);
-      const yesterdayStart = new Date(startOfDay);
-      yesterdayStart.setDate(yesterdayStart.getDate() - 1);
+      const agora = new Date();
 
       let faturadoHoje = 0;
       let faturadoOntem = 0;
@@ -39,26 +41,20 @@ export function useVendasZone() {
       let orcamentosAguardando = 0;
 
       try {
-        // sales_orders hoje
-        const { data: hoje } = await supabase
+        // Janela = união dos dias civis local+UTC de ontem e hoje: pedidos do sync
+        // Omie têm created_at data-pura à meia-noite UTC e caíam no dia errado com a
+        // janela local pura. O dia de cada pedido é re-decidido client-side.
+        const { inicioIso, fimIso } = janelaQueryHojeOntem(agora);
+        const { data: pedidos } = await supabase
           .from('sales_orders')
-          .select('total')
-          .gte('created_at', startOfDay.toISOString());
-        if (hoje) {
-          const rows = hoje as Array<{ total?: number | string | null }>;
-          pedidosHoje = rows.length;
-          faturadoHoje = rows.reduce((s, r) => s + Number(r.total ?? 0), 0);
-        }
-
-        // sales_orders ontem
-        const { data: ontem } = await supabase
-          .from('sales_orders')
-          .select('total')
-          .gte('created_at', yesterdayStart.toISOString())
-          .lt('created_at', startOfDay.toISOString());
-        if (ontem) {
-          const rows = ontem as Array<{ total?: number | string | null }>;
-          faturadoOntem = rows.reduce((s, r) => s + Number(r.total ?? 0), 0);
+          .select('total, created_at')
+          .gte('created_at', inicioIso)
+          .lte('created_at', fimIso);
+        if (pedidos) {
+          const agg = agregarVendasPorDiaCivil(pedidos as PedidoVendasDia[], agora);
+          faturadoHoje = agg.faturadoHoje;
+          pedidosHoje = agg.pedidosHoje;
+          faturadoOntem = agg.faturadoOntem;
         }
       } catch { /* tabela ausente — devolve 0 */ }
 

--- a/src/lib/dashboard/__tests__/vendas-dia-civil.test.ts
+++ b/src/lib/dashboard/__tests__/vendas-dia-civil.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest';
+import { janelaQueryDiaCivil } from '@/lib/pedido/dia-civil';
+import { agregarVendasPorDiaCivil, janelaQueryHojeOntem } from '../vendas-dia-civil';
+
+// Convenção dos cenários (TZ-agnóstico — roda igual em BRT local e UTC do CI):
+// - pedido do SYNC Omie: created_at data-pura = meia-noite UTC exata (ISO com Z);
+// - pedido do WIZARD: created_at real construído em hora LOCAL via new Date(y,m,d,h,min).
+// "hoje" com hora do meio do dia: o hook chama com new Date() ao vivo, nunca à meia-noite.
+const hoje = new Date(2026, 5, 10, 14, 30);
+const dia09 = new Date(2026, 5, 9);
+const dia10 = new Date(2026, 5, 10);
+
+describe('janelaQueryHojeOntem', () => {
+  it('é a união exata das janelas de dia civil de ONTEM e de HOJE', () => {
+    const { inicioIso, fimIso } = janelaQueryHojeOntem(hoje);
+    expect(inicioIso).toBe(janelaQueryDiaCivil(dia09).inicioIso);
+    expect(fimIso).toBe(janelaQueryDiaCivil(dia10).fimIso);
+  });
+
+  it('contém os pedidos do sync (meia-noite UTC) de ontem e de hoje + as bordas locais dos 2 dias', () => {
+    const { inicioIso, fimIso } = janelaQueryHojeOntem(hoje);
+    const dentro = (iso: string) => inicioIso <= iso && iso <= fimIso;
+    expect(dentro('2026-06-09T00:00:00.000Z')).toBe(true); // sync de ontem (era o bug: fora da janela local em BRT)
+    expect(dentro('2026-06-10T00:00:00.000Z')).toBe(true); // sync de hoje
+    expect(dentro(new Date(2026, 5, 9, 0, 1).toISOString())).toBe(true); // wizard abertura de ontem
+    expect(dentro(new Date(2026, 5, 10, 23, 59).toISOString())).toBe(true); // wizard fechamento de hoje
+  });
+
+  it('atravessa virada de mês: hoje = dia 1º → ontem = último dia do mês anterior', () => {
+    const primeiroJulho = new Date(2026, 6, 1, 9, 0);
+    const { inicioIso, fimIso } = janelaQueryHojeOntem(primeiroJulho);
+    expect(inicioIso).toBe(janelaQueryDiaCivil(new Date(2026, 5, 30)).inicioIso);
+    expect(fimIso).toBe(janelaQueryDiaCivil(new Date(2026, 6, 1)).fimIso);
+  });
+});
+
+describe('agregarVendasPorDiaCivil', () => {
+  it('pedido do sync de HOJE (meia-noite UTC) conta em HOJE — não infla ontem (o bug do cockpit)', () => {
+    const agg = agregarVendasPorDiaCivil(
+      [{ created_at: '2026-06-10T00:00:00.000Z', total: 1500 }],
+      hoje,
+    );
+    expect(agg).toEqual({ faturadoHoje: 1500, pedidosHoje: 1, faturadoOntem: 0 });
+  });
+
+  it('pedido do sync de ONTEM conta em faturadoOntem e não em hoje', () => {
+    const agg = agregarVendasPorDiaCivil(
+      [{ created_at: '2026-06-09T00:00:00.000Z', total: 700 }],
+      hoje,
+    );
+    expect(agg).toEqual({ faturadoHoje: 0, pedidosHoje: 0, faturadoOntem: 700 });
+  });
+
+  it('wizard de hoje conta hoje; wizard de ontem à noite conta ontem (mesmo caindo no dia UTC de hoje em BRT)', () => {
+    const agg = agregarVendasPorDiaCivil(
+      [
+        { created_at: new Date(2026, 5, 10, 9, 15).toISOString(), total: 200 },
+        { created_at: new Date(2026, 5, 9, 23, 30).toISOString(), total: 50 },
+      ],
+      hoje,
+    );
+    expect(agg).toEqual({ faturadoHoje: 200, pedidosHoje: 1, faturadoOntem: 50 });
+  });
+
+  it('fora dos 2 dias (anteontem, amanhã) não conta em nenhum — mesmo que a janela larga os traga', () => {
+    const agg = agregarVendasPorDiaCivil(
+      [
+        { created_at: '2026-06-08T00:00:00.000Z', total: 999 }, // sync anteontem
+        { created_at: '2026-06-11T00:00:00.000Z', total: 999 }, // sync amanhã (entra na janela de query em BRT)
+        { created_at: new Date(2026, 5, 8, 10, 0).toISOString(), total: 999 }, // wizard anteontem
+      ],
+      hoje,
+    );
+    expect(agg).toEqual({ faturadoHoje: 0, pedidosHoje: 0, faturadoOntem: 0 });
+  });
+
+  it('cada pedido conta em exatamente 1 dia: Σ(hoje+ontem) nunca duplica um pedido da borda', () => {
+    const rows = [
+      { created_at: '2026-06-09T00:00:00.000Z', total: 100 }, // sync ontem
+      { created_at: '2026-06-10T00:00:00.000Z', total: 100 }, // sync hoje
+      { created_at: new Date(2026, 5, 9, 23, 59).toISOString(), total: 100 }, // wizard borda ontem
+      { created_at: new Date(2026, 5, 10, 0, 1).toISOString(), total: 100 }, // wizard borda hoje
+    ];
+    const agg = agregarVendasPorDiaCivil(rows, hoje);
+    expect(agg.faturadoHoje + agg.faturadoOntem).toBe(400);
+    expect(agg).toEqual({ faturadoHoje: 200, pedidosHoje: 2, faturadoOntem: 200 });
+  });
+
+  it('total como string numérica (numeric do Postgres) e null/ausente somam como o hook antigo', () => {
+    const agg = agregarVendasPorDiaCivil(
+      [
+        { created_at: '2026-06-10T00:00:00.000Z', total: '150.5' },
+        { created_at: '2026-06-10T00:00:00.000Z', total: null },
+        { created_at: '2026-06-10T00:00:00.000Z' },
+      ],
+      hoje,
+    );
+    expect(agg).toEqual({ faturadoHoje: 150.5, pedidosHoje: 3, faturadoOntem: 0 });
+  });
+
+  it('created_at inválido não conta em dia nenhum', () => {
+    const agg = agregarVendasPorDiaCivil([{ created_at: 'lixo', total: 100 }], hoje);
+    expect(agg).toEqual({ faturadoHoje: 0, pedidosHoje: 0, faturadoOntem: 0 });
+  });
+});

--- a/src/lib/dashboard/vendas-dia-civil.ts
+++ b/src/lib/dashboard/vendas-dia-civil.ts
@@ -1,0 +1,57 @@
+// KPIs "faturado hoje/ontem" e "pedidos hoje" do cockpit de vendas (useVendasZone).
+// Pedidos do sync Omie têm created_at data-pura (meia-noite UTC) e pedidos do wizard
+// têm timestamp real — filtrar por janela de dia LOCAL joga o pedido do sync de hoje
+// em "ontem" em BRT. A query usa a UNIÃO das janelas de ontem+hoje e o pertencimento
+// é re-decidido por pedido via pedidoNoDiaCivil (cada pedido conta em exatamente 1 dia).
+import { janelaQueryDiaCivil, pedidoNoDiaCivil } from '@/lib/pedido/dia-civil';
+
+export interface PedidoVendasDia {
+  created_at: string;
+  total?: number | string | null;
+}
+
+export interface VendasPorDiaCivil {
+  faturadoHoje: number;
+  pedidosHoje: number;
+  faturadoOntem: number;
+}
+
+function ontemDe(hoje: Date): Date {
+  const ontem = new Date(hoje);
+  ontem.setDate(ontem.getDate() - 1);
+  return ontem;
+}
+
+/** Janela única de query cobrindo a união dos dias civis de ontem e de hoje. */
+export function janelaQueryHojeOntem(hoje: Date): { inicioIso: string; fimIso: string } {
+  const jHoje = janelaQueryDiaCivil(hoje);
+  const jOntem = janelaQueryDiaCivil(ontemDe(hoje));
+  return {
+    inicioIso: jOntem.inicioIso <= jHoje.inicioIso ? jOntem.inicioIso : jHoje.inicioIso,
+    fimIso: jHoje.fimIso >= jOntem.fimIso ? jHoje.fimIso : jOntem.fimIso,
+  };
+}
+
+/**
+ * Classifica cada pedido em exatamente um dia civil (hoje × ontem × fora) e agrega.
+ * O else-if garante a exclusividade mesmo na borda em que a janela de query (união)
+ * traz pedidos de dias vizinhos.
+ */
+export function agregarVendasPorDiaCivil(
+  rows: PedidoVendasDia[],
+  hoje: Date,
+): VendasPorDiaCivil {
+  const ontem = ontemDe(hoje);
+  let faturadoHoje = 0;
+  let pedidosHoje = 0;
+  let faturadoOntem = 0;
+  for (const r of rows) {
+    if (pedidoNoDiaCivil(r.created_at, hoje)) {
+      pedidosHoje += 1;
+      faturadoHoje += Number(r.total ?? 0);
+    } else if (pedidoNoDiaCivil(r.created_at, ontem)) {
+      faturadoOntem += Number(r.total ?? 0);
+    }
+  }
+  return { faturadoHoje, pedidosHoje, faturadoOntem };
+}


### PR DESCRIPTION
## Bug

Os KPIs **"Faturado hoje/ontem"** e **"Pedidos hoje"** do cockpit de vendas (`useVendasZone.ts`) filtravam `sales_orders` por janela de dia **LOCAL** (`startOfDay.setHours(0,0,0,0)` + `.gte/.lt created_at`). Pedidos importados pelo `omie-vendas-sync` (action `sync_pedidos`) têm `created_at` = **data pura gravada como meia-noite UTC** (ex.: pedido de 10/06 → `2026-06-10T00:00:00Z`).

Em BRT (UTC-3) a janela local de hoje começa às **03:00Z** → o pedido do sync de hoje caía em "ontem": **subconta o KPI de hoje, infla o de ontem e distorce o delta %**.

Mesmo bug já corrigido na tela `/sales/print` (#733) — este PR aplica o mesmo padrão no cockpit.

## Fix

- **Query única** com a janela **UNIÃO** dos dias civis de ontem+hoje (`janelaQueryHojeOntem` — local ∪ UTC, via `janelaQueryDiaCivil` do #733), substituindo as 2 queries por janela local.
- **Re-filtro client-side por regime** (`agregarVendasPorDiaCivil` → `pedidoNoDiaCivil`): data-pura (sync) pertence ao dia **UTC**; timestamp real (wizard) ao dia **local**. O `else-if` garante que **cada pedido conta em exatamente 1 dia** — sem sobreposição no resultado, mesmo onde as janelas de query se sobrepõem.
- Helper puro novo `src/lib/dashboard/vendas-dia-civil.ts` (sem mudança nos helpers do #733).

## Testes (TDD)

- 10 testes TZ-agnósticos em `src/lib/dashboard/__tests__/vendas-dia-civil.test.ts` (instantes locais via `new Date(y,m,d,h,m)`, UTC via ISO Z — passam em BRT local e no UTC do CI). RED verificado antes do helper existir.
- Cobrem: o bug (sync de hoje conta HOJE, não ontem), sync de ontem, wizard na borda noturna, exclusividade na borda (Σ não duplica), vizinhos fora dos 2 dias descartados, virada de mês, `total` string/null, `created_at` inválido.
- `heavy bun run test`: **3047/3047** · `heavy bun run typecheck` (strict): limpo · lint nos arquivos tocados: 0 errors.

## Deploy

100% frontend — **sem migration, sem edge function**. ⚠️ Requer **Publish no Lovable** pra ir ao ar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
