### PR TITLE
fix(financeiro): remove getResumoFinanceiro morta do edge omie-financeiro (achado A1 do Codex)

### DIFF
--- a/supabase/functions/omie-financeiro/index.ts
+++ b/supabase/functions/omie-financeiro/index.ts
@@ -309,11 +309,6 @@ interface MovimentoRow {
   updated_at: string;
 }
 
-interface ContaSaldoRow {
-  saldo?: number | null;
-  saldo_atual?: number | null;
-}
-
 interface CategoriaDreMappingRow {
   omie_codigo: string;
   dre_linha: string;
@@ -1721,69 +1716,6 @@ async function calcularDRE(
   return snapshot;
 }
 
-// ═══════════════ RESUMO RÁPIDO (sem sync, direto do DB) ═══════════════
-async function getResumoFinanceiro(
-  db: SupabaseClient,
-  companies: Company[]
-) {
-  const resumo: Record<string, unknown> = {};
-
-  for (const company of companies) {
-    // Saldo total de contas correntes
-    const { data: contas } = await db
-      .from("fin_contas_correntes")
-      .select("descricao, saldo_atual, banco")
-      .eq("company", company)
-      .eq("ativo", true);
-
-    // Totais a receber em aberto
-    const { data: crAberto } = await db
-      .from("fin_contas_receber")
-      .select("saldo")
-      .eq("company", company)
-      .in("status_titulo", ["ABERTO", "VENCIDO", "PARCIAL"]);
-
-    // Totais a pagar em aberto
-    const { data: cpAberto } = await db
-      .from("fin_contas_pagar")
-      .select("saldo")
-      .eq("company", company)
-      .in("status_titulo", ["ABERTO", "VENCIDO", "PARCIAL"]);
-
-    // Vencidos a receber
-    const { data: crVencido } = await db
-      .from("fin_contas_receber")
-      .select("saldo")
-      .eq("company", company)
-      .eq("status_titulo", "VENCIDO");
-
-    // Vencidos a pagar
-    const { data: cpVencido } = await db
-      .from("fin_contas_pagar")
-      .select("saldo")
-      .eq("company", company)
-      .eq("status_titulo", "VENCIDO");
-
-    const sum = (arr: ContaSaldoRow[] | null) =>
-      (arr || []).reduce((s: number, r) => s + (r.saldo || 0), 0);
-
-    resumo[company] = {
-      contas_correntes: contas || [],
-      saldo_total_cc: ((contas as Array<{ saldo_atual?: number | null }> | null) || []).reduce(
-        (s: number, c) => s + (c.saldo_atual || 0),
-        0
-      ),
-      total_a_receber: sum(crAberto),
-      total_a_pagar: sum(cpAberto),
-      total_vencido_receber: sum(crVencido),
-      total_vencido_pagar: sum(cpVencido),
-      posicao_liquida: sum(crAberto) - sum(cpAberto),
-    };
-  }
-
-  return resumo;
-}
-
 // ═══════════════ HELPERS ═══════════════
 function parseOmieDate(dateStr: string | null | undefined): string | null {
   if (!dateStr) return null;
@@ -2169,11 +2101,6 @@ serve(async (req) => {
             }
           }
         }
-        break;
-      }
-
-      case "resumo": {
-        result = await getResumoFinanceiro(supabase, targetCompanies);
         break;
       }
 


### PR DESCRIPTION
## O achado (Codex adversarial retroativo do #720)

O Codex (xhigh) revisou o fix do [#720](https://github.com/LucasSardenbergL/afiacao/pull/720) e achou uma **segunda `getResumoFinanceiro` no edge** `omie-financeiro` (`action:"resumo"`), divergente da fonte canônica client-side, com dois defeitos:

1. **Vocabulário legado**: filtrava `status_titulo IN ("ABERTO","VENCIDO","PARCIAL")` / `= "VENCIDO"` — valores que **nunca existem nos dados**. O [titulo-status.ts](src/lib/financeiro/titulo-status.ts) documenta: o Omie grava `A VENCER`/`ATRASADO`/`VENCE HOJE`. Resultado: somava **~0 → R$0 silencioso** (a armadilha "ausente vira número" que o repo combate).
2. **Sem paginação**: mesmo cap 1000 do PostgREST dos #719/#720 (irrelevante hoje porque o filtro #1 já zera, mas é o mesmo defeito).

## Por que é seguro deletar (varredura exaustiva)

**Código morto — zero callers** do `action:"resumo"`:
- nenhum `functions.invoke` estático;
- nenhum `syncSpecific`/`triggerFinanceiroSync` dinâmico (a tela Sync só expõe `sync_categorias/contas_correntes/contas_receber/contas_pagar/movimentacoes`);
- nenhum cron `net.http_post` (os crons SQL só chamam `sync_*`);
- nenhum script/migration.
- `grep -rnE "['\"]resumo['\"]"` em `src/` = vazio.

O frontend (FinanceiroDashboard/Cockpit) usa a `getResumoFinanceiro` **client-side** (`src/services/financeiroService.ts`), corrigida no #720. O action era gated master/gestor (#327), então nunca foi furo de segurança — era dívida latente money-path.

## Mudança

Removido: o `case "resumo"` no dispatch + a função `getResumoFinanceiro` do edge + o tipo órfão `ContaSaldoRow`. **73 deleções, 1 arquivo.** Sem migration, sem mudança no frontend.

## Validação

- Varredura de callers exaustiva (acima) → zero.
- `bun lint` (gate do CI, cobre `supabase/functions/`) → 0 errors.
- Zero referências órfãs a `getResumoFinanceiro`/`ContaSaldoRow` no edge pós-deleção.

⚠️ **Requer redeploy do `omie-financeiro` via chat do Lovable** pra alinhar repo↔prod. **Sem urgência**: é código morto não-chamado, o que está no ar é inócuo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)