### PR TITLE
feat(reposição): override por pedido do gate de mínimo de faturamento Sayerlack

### DIFF
--- a/src/components/reposicao/pedidos/OverrideMinimoButton.tsx
+++ b/src/components/reposicao/pedidos/OverrideMinimoButton.tsx
@@ -1,0 +1,61 @@
+import { Button } from '@/components/ui/button';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog';
+import { Loader2, ShieldAlert } from 'lucide-react';
+import { formatBRL } from './shared';
+
+// Botão "Disparar mesmo assim" — override consciente do gate de mínimo de faturamento
+// Sayerlack, por pedido. Quem decide MOSTRAR (só gestor/master, só falha_envio+gate) é o
+// caller; aqui é só o controle com a confirmação (AlertDialog) explicando o risco de o
+// fornecedor não faturar. Compartilhado entre a lista de pedidos e a fila de atenção.
+export function OverrideMinimoButton({
+  fornecedorNome,
+  valorTotal,
+  onConfirm,
+  disabled,
+}: {
+  fornecedorNome: string | null;
+  valorTotal: number | null;
+  onConfirm: () => void;
+  disabled?: boolean;
+}) {
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>
+        <Button
+          size="sm"
+          variant="outline"
+          disabled={disabled}
+          className="border-status-warning/40 text-status-warning hover:bg-status-warning/10 hover:text-status-warning"
+        >
+          {disabled ? <Loader2 className="w-4 h-4 mr-1 animate-spin" /> : <ShieldAlert className="w-4 h-4 mr-1" />}
+          Disparar mesmo assim
+        </Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Disparar abaixo do mínimo de faturamento?</AlertDialogTitle>
+          <AlertDialogDescription>
+            O pedido para <strong>{fornecedorNome ?? 'este fornecedor'}</strong> ({formatBRL(valorTotal)}) está
+            abaixo do mínimo de faturamento da Sayerlack. Abaixo desse valor o fornecedor pode
+            <strong> não faturar</strong> o pedido — ele fica parado lá até acumular mais itens.
+            Confirme só se tiver certeza de que vale enviar assim mesmo.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancelar</AlertDialogCancel>
+          <AlertDialogAction onClick={() => onConfirm()}>Confirmar e disparar</AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/components/reposicao/pedidos/PedidoRow.tsx
+++ b/src/components/reposicao/pedidos/PedidoRow.tsx
@@ -3,8 +3,9 @@ import { TableCell, TableRow } from '@/components/ui/table';
 import { Eye, ExternalLink, Loader2, XCircle, Zap } from 'lucide-react';
 import { format } from 'date-fns';
 import { PedidoSugerido } from './types';
-import { formatBRL } from './shared';
+import { formatBRL, ehGateMinimoFaturamento } from './shared';
 import { StatusComMotivo, SplitInfo, PortalBadge } from './badges';
+import { OverrideMinimoButton } from './OverrideMinimoButton';
 
 export function PedidoRow({
   p,
@@ -12,6 +13,7 @@ export function PedidoRow({
   onCancelar,
   onVerPortal,
   onDisparar,
+  onDispararIgnorandoMinimo,
   disparando,
 }: {
   p: PedidoSugerido;
@@ -19,14 +21,22 @@ export function PedidoRow({
   onCancelar: () => void;
   onVerPortal: () => void;
   onDisparar: () => void;
+  // Override do gate de mínimo de faturamento. A página só passa este callback p/
+  // gestor/master (isMaster||isGestorComercial) — quando ausente, o botão "Disparar
+  // mesmo assim" nem aparece (não-gestor cai no "Re-disparar" normal, que re-bate no gate).
+  onDispararIgnorandoMinimo?: () => void;
   disparando: boolean;
 }) {
   const podeAprovar = p.status === 'pendente_aprovacao' || p.status === 'bloqueado_guardrail';
   const podeCancelar = ['pendente_aprovacao', 'bloqueado_guardrail', 'aprovado_aguardando_disparo'].includes(p.status);
+  // Pedido preso ESPECIFICAMENTE pelo gate de mínimo de faturamento + caller pode overridar
+  // → oferece "Disparar mesmo assim" NO LUGAR do "Re-disparar" (que só re-bateria no gate).
+  const mostrarOverride = ehGateMinimoFaturamento(p) && !!onDispararIgnorandoMinimo;
   // Re-disparo: a edge disparar-pedidos-aprovados aceita pedido em falha_envio via
   // pedido_id (index.ts:1005). Sem isso, falha_envio só tinha "Detalhes" — não havia
-  // como re-disparar pela UI (precisava flip de status no banco).
-  const podeReDisparar = p.status === 'falha_envio';
+  // como re-disparar pela UI (precisava flip de status no banco). Suprimido quando o
+  // override está disponível (senão 2 botões de disparo confusos na mesma linha).
+  const podeReDisparar = p.status === 'falha_envio' && !mostrarOverride;
   const podeDisparar = p.status === 'aprovado_aguardando_disparo' || podeReDisparar;
   // Guard de concorrência: enquanto o envio ao portal está em voo (após "aprovar e
   // disparar" ou um disparo manual), trava o botão pra não abrir uma 2ª sessão no
@@ -72,6 +82,14 @@ export function PedidoRow({
               {(disparando || enviandoPortal) ? <Loader2 className="w-4 h-4 mr-1 animate-spin" /> : <Zap className="w-4 h-4 mr-1" />}
               {enviandoPortal ? 'Enviando…' : (podeReDisparar ? 'Re-disparar' : 'Disparar')}
             </Button>
+          )}
+          {mostrarOverride && (
+            <OverrideMinimoButton
+              fornecedorNome={p.fornecedor_nome}
+              valorTotal={p.valor_total}
+              onConfirm={() => onDispararIgnorandoMinimo?.()}
+              disabled={disparando || enviandoPortal}
+            />
           )}
           {podeCancelar && (
             <Button size="sm" variant="outline" onClick={onCancelar}>

--- a/src/components/reposicao/pedidos/__tests__/PedidoRow.test.tsx
+++ b/src/components/reposicao/pedidos/__tests__/PedidoRow.test.tsx
@@ -7,8 +7,12 @@ function ped(partial: Partial<PedidoSugerido>): PedidoSugerido {
   return partial as unknown as PedidoSugerido;
 }
 
-function renderRow(p: PedidoSugerido) {
+function renderRow(
+  p: PedidoSugerido,
+  opts?: { onDispararIgnorandoMinimo?: () => void },
+) {
   const onDisparar = vi.fn();
+  const onOverride = opts?.onDispararIgnorandoMinimo;
   const utils = render(
     <table>
       <tbody>
@@ -18,6 +22,7 @@ function renderRow(p: PedidoSugerido) {
           onCancelar={() => {}}
           onVerPortal={() => {}}
           onDisparar={onDisparar}
+          onDispararIgnorandoMinimo={onOverride}
           disparando={false}
         />
       </tbody>
@@ -96,5 +101,56 @@ describe('PedidoRow — tooltip de motivo (bloqueio / falha)', () => {
   it('status normal → nenhum ícone de motivo', () => {
     renderRow(ped({ id: 14, status: 'aprovado_aguardando_disparo', fornecedor_nome: 'X', num_skus: 3, valor_total: 50 }));
     expect(screen.queryByRole('button', { name: /Motivo/i })).toBeNull();
+  });
+});
+
+describe('PedidoRow — override do mínimo de faturamento ("Disparar mesmo assim")', () => {
+  const gateMin = (over?: () => void) =>
+    renderRow(
+      ped({
+        id: 20,
+        status: 'falha_envio',
+        fornecedor_nome: 'RENNER SAYERLACK S/A',
+        num_skus: 4,
+        valor_total: 1800,
+        resposta_canal: { erro: 'abaixo do mínimo de faturamento', gate: 'minimo_faturamento' },
+      }),
+      over ? { onDispararIgnorandoMinimo: over } : undefined,
+    );
+
+  it('gate-min + gestor (callback): mostra "Disparar mesmo assim" no lugar de "Re-disparar"', () => {
+    gateMin(vi.fn());
+    expect(screen.getByRole('button', { name: /Disparar mesmo assim/i })).toBeTruthy();
+    expect(screen.queryByRole('button', { name: /Re-disparar/i })).toBeNull();
+  });
+
+  it('gate-min SEM callback (não-gestor): cai no "Re-disparar" normal, sem override', () => {
+    gateMin(undefined);
+    expect(screen.getByRole('button', { name: /Re-disparar/i })).toBeTruthy();
+    expect(screen.queryByRole('button', { name: /Disparar mesmo assim/i })).toBeNull();
+  });
+
+  it('falha_envio por OUTRO motivo + callback: NÃO oferece override (só "Re-disparar")', () => {
+    renderRow(
+      ped({
+        id: 21,
+        status: 'falha_envio',
+        fornecedor_nome: 'RENNER SAYERLACK S/A',
+        num_skus: 4,
+        valor_total: 1800,
+        resposta_canal: { erro: 'SKU(s) sem custo (preço unitário 0)' },
+      }),
+      { onDispararIgnorandoMinimo: vi.fn() },
+    );
+    expect(screen.getByRole('button', { name: /Re-disparar/i })).toBeTruthy();
+    expect(screen.queryByRole('button', { name: /Disparar mesmo assim/i })).toBeNull();
+  });
+
+  it('confirmar no diálogo chama onDispararIgnorandoMinimo uma vez', () => {
+    const over = vi.fn();
+    gateMin(over);
+    fireEvent.click(screen.getByRole('button', { name: /Disparar mesmo assim/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Confirmar e disparar/i }));
+    expect(over).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/reposicao/pedidos/__tests__/gate-minimo-override.test.ts
+++ b/src/components/reposicao/pedidos/__tests__/gate-minimo-override.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { ehGateMinimoFaturamento } from '../shared';
+
+// Detecta o pedido preso ESPECIFICAMENTE pelo gate de mínimo de faturamento Sayerlack
+// (falha_envio + resposta_canal.gate==='minimo_faturamento'). É o único estado em que o
+// botão "Disparar mesmo assim" (override) faz sentido — uma falha por OUTRO motivo (SKU
+// sem custo etc.) NÃO deve oferecer override (não adianta, e mascararia o erro real).
+describe('ehGateMinimoFaturamento', () => {
+  it('true quando falha_envio + gate=minimo_faturamento', () => {
+    expect(
+      ehGateMinimoFaturamento({
+        status: 'falha_envio',
+        resposta_canal: { erro: 'abaixo do mínimo', gate: 'minimo_faturamento' },
+      }),
+    ).toBe(true);
+  });
+
+  it('false quando falha_envio por OUTRO motivo (sem gate)', () => {
+    expect(
+      ehGateMinimoFaturamento({
+        status: 'falha_envio',
+        resposta_canal: { erro: 'SKU(s) sem custo (preço unitário 0)' },
+      }),
+    ).toBe(false);
+  });
+
+  it('false quando o gate é outro valor', () => {
+    expect(
+      ehGateMinimoFaturamento({
+        status: 'falha_envio',
+        resposta_canal: { gate: 'outro_qualquer' },
+      }),
+    ).toBe(false);
+  });
+
+  it('false quando não é falha_envio (mesmo com o gate marcado)', () => {
+    expect(
+      ehGateMinimoFaturamento({
+        status: 'aprovado_aguardando_disparo',
+        resposta_canal: { gate: 'minimo_faturamento' },
+      }),
+    ).toBe(false);
+  });
+
+  it('false quando resposta_canal é null', () => {
+    expect(ehGateMinimoFaturamento({ status: 'falha_envio', resposta_canal: null })).toBe(false);
+  });
+});

--- a/src/components/reposicao/pedidos/shared.ts
+++ b/src/components/reposicao/pedidos/shared.ts
@@ -143,6 +143,24 @@ export function pedidoPrecisaAtencao(p: {
   return STATUS_PORTAL_PRECISA_ATENCAO.has((p.status_envio_portal ?? 'nao_aplicavel') as StatusEnvioPortal);
 }
 
+/* ─── Override do gate de mínimo de faturamento Sayerlack ─── */
+//
+// O gate [GATE-MIN-FATURAMENTO] da edge marca falha_envio + resposta_canal.gate=
+// 'minimo_faturamento' quando um pedido Sayerlack fica abaixo da régua (R$3k = mínimo de
+// faturamento do fornecedor; abaixo disso ele não fatura, o pedido fica parado lá). O botão
+// "Re-disparar" re-bate no gate → loop sem saída. A exceção é o override consciente por
+// pedido ("Disparar mesmo assim"), só pra gestor/master.
+//
+// Este predicado detecta SÓ esse estado: falha_envio cuja causa É o gate. Uma falha_envio
+// por OUTRO motivo (SKU sem custo, qtde 0, erro do Omie) NÃO casa — oferecer override ali
+// seria inútil (não há régua a pular) e mascararia o erro real.
+export function ehGateMinimoFaturamento(p: {
+  status: string;
+  resposta_canal: { gate?: unknown; [key: string]: unknown } | null | undefined;
+}): boolean {
+  return p.status === 'falha_envio' && p.resposta_canal?.gate === 'minimo_faturamento';
+}
+
 /* ─── Split (PR5) — esconder o pai da lista ─── */
 //
 // Quando um pedido grande é dividido em chunks, o PAI vira status='split_em_filhos':

--- a/src/lib/reposicao/__tests__/disparo-gate-helpers.test.ts
+++ b/src/lib/reposicao/__tests__/disparo-gate-helpers.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   deveBloquearPorMinimoFaturamento,
+  overridePermitidoNoModo,
   type GateConfig,
 } from "../disparo-gate-helpers";
 
@@ -143,5 +144,88 @@ describe("deveBloquearPorMinimoFaturamento", () => {
         fornecedorPattern: "%%",
       }).bloquear,
     ).toBe(false);
+  });
+});
+
+// Override por pedido (ignorar_minimo) — a "exceção consciente" do gestor/master no
+// re-disparo individual. O helper só DECIDE; quem garante "só modo individual + gestor"
+// é o caller (edge/UI). `overridden:true` = o gate IA barrar e a flag liberou (audit);
+// quando não havia bloqueio, a flag é no-op (overridden ausente/falsy).
+describe("deveBloquearPorMinimoFaturamento — override ignorarMinimo", () => {
+  it("ignorarMinimo libera pedido que SERIA barrado, marcando overridden", () => {
+    const r = deveBloquearPorMinimoFaturamento(base, cfg, { ignorarMinimo: true });
+    expect(r.bloquear).toBe(false);
+    expect(r.overridden).toBe(true);
+  });
+
+  it("sem a flag, o pedido abaixo da régua segue barrado (override é opt-in)", () => {
+    const semFlag = deveBloquearPorMinimoFaturamento(base, cfg);
+    expect(semFlag.bloquear).toBe(true);
+    expect(semFlag.overridden).toBeFalsy();
+    const flagFalsa = deveBloquearPorMinimoFaturamento(base, cfg, { ignorarMinimo: false });
+    expect(flagFalsa.bloquear).toBe(true);
+    expect(flagFalsa.overridden).toBeFalsy();
+  });
+
+  it("ignorarMinimo em pedido que NÃO seria barrado é no-op (overridden falsy)", () => {
+    // Acima da régua: nada a overridar.
+    const acima = deveBloquearPorMinimoFaturamento(
+      { ...base, valor_total: 5000 },
+      cfg,
+      { ignorarMinimo: true },
+    );
+    expect(acima.bloquear).toBe(false);
+    expect(acima.overridden).toBeFalsy();
+
+    // Fornecedor fora do pattern: o gate nem se aplica.
+    const outroForn = deveBloquearPorMinimoFaturamento(
+      { ...base, fornecedor_nome: "ACRE CAXIAS" },
+      cfg,
+      { ignorarMinimo: true },
+    );
+    expect(outroForn.bloquear).toBe(false);
+    expect(outroForn.overridden).toBeFalsy();
+
+    // Filho de split: já isento.
+    const filho = deveBloquearPorMinimoFaturamento(
+      { ...base, split_parent_id: 99 },
+      cfg,
+      { ignorarMinimo: true },
+    );
+    expect(filho.bloquear).toBe(false);
+    expect(filho.overridden).toBeFalsy();
+  });
+
+  it("ignorarMinimo com gate DESLIGADO (régua ausente) não inventa override", () => {
+    const r = deveBloquearPorMinimoFaturamento(
+      base,
+      { valorMinimo: null, fornecedorPattern: "%SAYERLACK%" },
+      { ignorarMinimo: true },
+    );
+    expect(r.bloquear).toBe(false);
+    expect(r.overridden).toBeFalsy();
+  });
+});
+
+// O override só pode valer no disparo INDIVIDUAL (pedido_id de um pedido REAL = positivo). O
+// ternário da query na edge (pedidoId ? individual : lote) trata pedido_id=0 como LOTE; sem
+// este predicado, {pedido_id:0, ignorar_minimo:true} de um gestor caía no LOTE COM override
+// = bypass do gate em todos os aprovados do dia (achado P1 do Codex). pedido_id ausente/0/
+// negativo/NaN → modo lote/cron → override NUNCA.
+describe("overridePermitidoNoModo", () => {
+  it("true só para pedido_id POSITIVO (disparo individual real)", () => {
+    expect(overridePermitidoNoModo(5)).toBe(true);
+    expect(overridePermitidoNoModo(409)).toBe(true);
+  });
+
+  it("false para pedido_id=0 (o bypass de lote do Codex)", () => {
+    expect(overridePermitidoNoModo(0)).toBe(false);
+  });
+
+  it("false para ausente/negativo/NaN (modo lote/cron ou inválido)", () => {
+    expect(overridePermitidoNoModo(null)).toBe(false);
+    expect(overridePermitidoNoModo(undefined)).toBe(false);
+    expect(overridePermitidoNoModo(-1)).toBe(false);
+    expect(overridePermitidoNoModo(Number.NaN)).toBe(false);
   });
 });

--- a/src/lib/reposicao/disparo-gate-helpers.ts
+++ b/src/lib/reposicao/disparo-gate-helpers.ts
@@ -41,7 +41,26 @@ function fornecedorCasaPattern(nome: string, pattern: string): boolean {
   return nome.toUpperCase().includes(alvo);
 }
 
-export function deveBloquearPorMinimoFaturamento(
+/** Opções do gate. `ignorarMinimo` = override consciente por pedido (re-disparo individual). */
+export interface GateOpts {
+  /**
+   * Pula o mínimo de faturamento neste pedido. O HELPER só decide; quem garante que isso
+   * só vale em modo individual + caller gestor/master é o CALLER (edge/UI). Quando o gate
+   * IA barrar e a flag libera, o resultado vem com `overridden:true` (rastro de auditoria);
+   * quando não havia bloqueio, a flag é no-op (`overridden` ausente).
+   */
+  ignorarMinimo?: boolean;
+}
+
+export interface GateResult {
+  bloquear: boolean;
+  motivo?: string;
+  /** true só quando o gate IA barrar e `ignorarMinimo` liberou (sinaliza o caller a logar). */
+  overridden?: boolean;
+}
+
+// Decisão-base do gate, SEM override — a regra pura de barrar (ou não) um pedido.
+function decisaoBaseMinimoFaturamento(
   pedido: PedidoParaGate,
   cfg: GateConfig,
 ): { bloquear: boolean; motivo?: string } {
@@ -86,4 +105,27 @@ export function deveBloquearPorMinimoFaturamento(
       `faturamento (R$ ${Math.round(minimo)}) — aguarde o ciclo acumular mais itens ou ` +
       `cancele o pedido.`,
   };
+}
+
+export function deveBloquearPorMinimoFaturamento(
+  pedido: PedidoParaGate,
+  cfg: GateConfig,
+  opts?: GateOpts,
+): GateResult {
+  const base = decisaoBaseMinimoFaturamento(pedido, cfg);
+  // Override só importa quando o gate IA barrar. Se já passava (split/portal/fora-do-pattern/
+  // ≥régua/gate-off), a flag é no-op — não marca `overridden` (não houve nada a liberar).
+  if (base.bloquear && opts?.ignorarMinimo === true) {
+    return { bloquear: false, overridden: true };
+  }
+  return base;
+}
+
+// O override do mínimo só pode valer no disparo INDIVIDUAL (pedido_id de um pedido REAL =
+// positivo). O ternário da query na edge (`pedidoId ? individual : lote`) trata pedido_id=0 como
+// LOTE — então pedido_id ausente/0/negativo/NaN é modo lote/cron e o override NUNCA se aplica
+// (senão `{pedido_id:0, ignorar_minimo:true}` de um gestor viraria override no LOTE inteiro do
+// dia — bypass do isolamento de lote). NÃO decide autorização (isso é do edge: gestor/master).
+export function overridePermitidoNoModo(pedidoId: number | null | undefined): boolean {
+  return pedidoId != null && Number.isFinite(pedidoId) && pedidoId > 0;
 }

--- a/src/pages/AdminReposicaoPedidos.tsx
+++ b/src/pages/AdminReposicaoPedidos.tsx
@@ -32,6 +32,9 @@ import { DetalhesModal } from '@/components/reposicao/pedidos/DetalhesModal';
 import { CancelarModal } from '@/components/reposicao/pedidos/CancelarModal';
 import { PortalDrawer } from '@/components/reposicao/pedidos/PortalDrawer';
 import { CiclosAnteriores } from '@/components/reposicao/pedidos/CiclosAnteriores';
+import { OverrideMinimoButton } from '@/components/reposicao/pedidos/OverrideMinimoButton';
+import { ehGateMinimoFaturamento } from '@/components/reposicao/pedidos/shared';
+import { useAuth } from '@/contexts/AuthContext';
 
 type SkuSemFornecedor = {
   sku_codigo_omie: string;
@@ -43,6 +46,10 @@ type SkuSemFornecedor = {
 /* ─── Página principal ─── */
 export default function AdminReposicaoPedidos() {
   const queryClient = useQueryClient();
+  // Override do mínimo de faturamento é privilegiado: só gestor comercial/master. A tela é
+  // RequireStaff (employee|master), então gateamos o botão aqui (o edge reforça no servidor).
+  const { isMaster, isGestorComercial } = useAuth();
+  const podeOverride = isMaster || isGestorComercial;
   const [searchParams, setSearchParams] = useSearchParams();
   const [now, setNow] = useState(new Date());
   const [detalhesPedido, setDetalhesPedido] = useState<PedidoSugerido | null>(null);
@@ -233,6 +240,35 @@ export default function AdminReposicaoPedidos() {
     },
   });
 
+  // Override do gate de mínimo de faturamento (gestor/master). Mesma edge, com ignorar_minimo.
+  // Separada da dispararMutation pra não confundir o estado de loading por linha; o edge
+  // reforça gestor/master no servidor (403 se não autorizado → cai no onError).
+  const dispararOverrideMutation = useMutation({
+    mutationFn: async (pedidoId: number) => {
+      const { data, error } = await supabase.functions.invoke('disparar-pedidos-aprovados', {
+        body: { empresa: EMPRESA, pedido_id: pedidoId, ignorar_minimo: true },
+      });
+      if (error) throw error;
+      return data;
+    },
+    onSuccess: (data, pedidoId) => {
+      const { tone, message } = interpretarRespostaDisparo(data as RespostaDisparo, pedidoId);
+      if (tone === 'error') toast.error(message);
+      else if (tone === 'info') toast.info(message);
+      else toast.success(message);
+      queryClient.invalidateQueries({ queryKey: ['pedidos-ciclo'] });
+    },
+    onError: (e: Error) => {
+      toast.error(`Erro ao disparar: ${e.message}`);
+    },
+  });
+
+  // Estado de disparo por linha cobre AMBAS as mutações (normal + override) — o botão da
+  // linha trava enquanto qualquer disparo daquele pedido está em voo.
+  const disparandoLinha = (pedidoId: number) =>
+    (dispararMutation.isPending && dispararMutation.variables === pedidoId) ||
+    (dispararOverrideMutation.isPending && dispararOverrideMutation.variables === pedidoId);
+
   const bloqueados = (pedidos ?? []).filter((p) => p.status === 'bloqueado_guardrail');
 
   // SKUs abaixo do ponto que NÃO geram pedido por falta de fornecedor cadastrado.
@@ -391,17 +427,26 @@ export default function AdminReposicaoPedidos() {
                         <Button size="sm" variant="ghost" onClick={() => setDetalhesPedido(p)}>
                           <Eye className="w-4 h-4 mr-1" />Detalhes
                         </Button>
-                        {(p.status === 'aprovado_aguardando_disparo' || p.status === 'falha_envio') && (
+                        {podeOverride && ehGateMinimoFaturamento(p) ? (
+                          // Preso pelo gate de mínimo de faturamento → "Disparar mesmo assim"
+                          // no lugar do "Re-disparar" (que só re-bateria no gate).
+                          <OverrideMinimoButton
+                            fornecedorNome={p.fornecedor_nome}
+                            valorTotal={p.valor_total}
+                            onConfirm={() => dispararOverrideMutation.mutate(p.id)}
+                            disabled={disparandoLinha(p.id) || p.status_envio_portal === 'enviando_portal'}
+                          />
+                        ) : (p.status === 'aprovado_aguardando_disparo' || p.status === 'falha_envio') ? (
                           <Button
                             size="sm"
                             variant={p.status === 'falha_envio' ? 'outline' : 'default'}
                             onClick={() => dispararMutation.mutate(p.id)}
                             disabled={
-                              (dispararMutation.isPending && dispararMutation.variables === p.id) ||
+                              disparandoLinha(p.id) ||
                               p.status_envio_portal === 'enviando_portal'
                             }
                           >
-                            {(dispararMutation.isPending && dispararMutation.variables === p.id) ||
+                            {disparandoLinha(p.id) ||
                             p.status_envio_portal === 'enviando_portal' ? (
                               <Loader2 className="w-4 h-4 mr-1 animate-spin" />
                             ) : (
@@ -409,7 +454,7 @@ export default function AdminReposicaoPedidos() {
                             )}
                             {p.status === 'falha_envio' ? 'Re-disparar' : 'Disparar'}
                           </Button>
-                        )}
+                        ) : null}
                       </div>
                     </TableCell>
                   </TableRow>
@@ -464,7 +509,8 @@ export default function AdminReposicaoPedidos() {
                         onCancelar={() => setCancelarPedido(p)}
                         onVerPortal={() => setPortalPedido(p)}
                         onDisparar={() => dispararMutation.mutate(p.id)}
-                        disparando={dispararMutation.isPending && dispararMutation.variables === p.id}
+                        onDispararIgnorandoMinimo={podeOverride ? () => dispararOverrideMutation.mutate(p.id) : undefined}
+                        disparando={disparandoLinha(p.id)}
                       />
                     ))}
                   </TableBody>
@@ -507,7 +553,8 @@ export default function AdminReposicaoPedidos() {
                             onCancelar={() => setCancelarPedido(p)}
                             onVerPortal={() => setPortalPedido(p)}
                             onDisparar={() => dispararMutation.mutate(p.id)}
-                            disparando={dispararMutation.isPending && dispararMutation.variables === p.id}
+                            onDispararIgnorandoMinimo={podeOverride ? () => dispararOverrideMutation.mutate(p.id) : undefined}
+                            disparando={disparandoLinha(p.id)}
                           />
                         ))}
                       </TableBody>

--- a/supabase/functions/disparar-pedidos-aprovados/index.ts
+++ b/supabase/functions/disparar-pedidos-aprovados/index.ts
@@ -48,6 +48,11 @@ interface PedidoRow {
   // (barrar depois do portal criaria órfão pior — PO no fornecedor sem Omie).
   portal_protocolo?: string | null;
   status_envio_portal?: string | null;
+  // Marcado no gate quando o disparo individual passou por OVERRIDE consciente (gestor/master
+  // mandou ignorar_minimo). Flui pro resposta_canal + ProcessResult (auditoria), com o user.id
+  // do autorizador. Propagado aos filhos no split (senão o override do pai some na auditoria).
+  override_minimo?: boolean;
+  override_minimo_por?: string | null;
 }
 
 // PR5: tamanho máximo de cada chunk no split. Calibração:
@@ -269,6 +274,11 @@ interface ProcessResult {
   // Reconciliado = o PV já existia no Omie ("já cadastrado"); marcamos disparado
   // sem re-criar. O caller NÃO deve re-notificar o fornecedor (evita e-mail duplicado).
   reconciliado?: boolean;
+  // Disparo individual liberado por override do mínimo de faturamento (gestor/master).
+  // Persistido em sync_reprocess_log.metadata.resultados[] = trilha de auditoria durável,
+  // com o user.id do autorizador.
+  override_minimo?: boolean;
+  override_minimo_por?: string | null;
 }
 
 // ── [GATE-MIN-FATURAMENTO] espelho VERBATIM de src/lib/reposicao/disparo-gate-helpers.ts ──
@@ -304,7 +314,21 @@ function fornecedorCasaPattern(nome: string, pattern: string): boolean {
   return nome.toUpperCase().includes(alvo);
 }
 
-function deveBloquearPorMinimoFaturamento(
+// `ignorarMinimo` = override consciente por pedido (re-disparo individual por gestor/master).
+// O helper só DECIDE; quem garante "só modo individual + gestor/master" é o handler abaixo.
+interface GateOpts {
+  ignorarMinimo?: boolean;
+}
+
+interface GateResult {
+  bloquear: boolean;
+  motivo?: string;
+  // true só quando o gate IA barrar e `ignorarMinimo` liberou (sinaliza o caller a logar).
+  overridden?: boolean;
+}
+
+// Decisão-base do gate, SEM override — a regra pura de barrar (ou não) um pedido.
+function decisaoBaseMinimoFaturamento(
   pedido: PedidoParaGate,
   cfg: GateConfig,
 ): { bloquear: boolean; motivo?: string } {
@@ -338,6 +362,28 @@ function deveBloquearPorMinimoFaturamento(
       `faturamento (R$ ${Math.round(minimo)}) — aguarde o ciclo acumular mais itens ou ` +
       `cancele o pedido.`,
   };
+}
+
+function deveBloquearPorMinimoFaturamento(
+  pedido: PedidoParaGate,
+  cfg: GateConfig,
+  opts?: GateOpts,
+): GateResult {
+  const base = decisaoBaseMinimoFaturamento(pedido, cfg);
+  // Override só importa quando o gate IA barrar. Se já passava (split/portal/fora-do-pattern/
+  // ≥régua/gate-off), a flag é no-op — não marca `overridden` (não houve nada a liberar).
+  if (base.bloquear && opts?.ignorarMinimo === true) {
+    return { bloquear: false, overridden: true };
+  }
+  return base;
+}
+
+// O override do mínimo só pode valer no disparo INDIVIDUAL (pedido_id de um pedido REAL =
+// positivo). O ternário da query (`pedidoId ? individual : lote`) trata pedido_id=0 como LOTE —
+// então pedido_id ausente/0/negativo/NaN é modo lote/cron e o override NUNCA se aplica (senão
+// `{pedido_id:0, ignorar_minimo:true}` viraria override no LOTE inteiro do dia). Não autoriza.
+function overridePermitidoNoModo(pedidoId: number | null | undefined): boolean {
+  return pedidoId != null && Number.isFinite(pedidoId) && pedidoId > 0;
 }
 
 type PortalDispatchResult =
@@ -487,6 +533,13 @@ async function dividirPedidosGrandesSayerlack(
         .eq("fornecedor_nome", fr.fornecedor_nome)
         .maybeSingle();
       if (fh) Object.assign(fr, fh);
+      // Propaga a marca de override do PAI pros filhos (Codex P2): o pai virou split_em_filhos e
+      // sai da lista; sem isto, o disparo dos filhos (que SÓ aconteceu graças ao override) não
+      // ficaria registrado em lugar nenhum (resposta_canal nem sync_reprocess_log).
+      if (pedido.override_minimo) {
+        fr.override_minimo = true;
+        fr.override_minimo_por = pedido.override_minimo_por ?? null;
+      }
     }
 
     console.log(`[disparar-pedidos] Pedido ${pedido.id} → ${filhoIds.length} filhos: [${filhoIds.join(", ")}]`);
@@ -613,6 +666,20 @@ async function processarPedido(
       ? "DRY_RUN_OMIE_APENAS"
       : (pedido.canal_pedido ?? "—"),
   };
+  // Auditoria do override (disparo individual que ignorou o mínimo de faturamento, gestor/master):
+  // - DURÁVEL: `result.override_minimo` → sync_reprocess_log.metadata.resultados[] (append-only,
+  //   NUNCA sobrescrito) = a trilha de auditoria autoritativa.
+  // - BEST-EFFORT: `overrideTag` no resposta_canal dos writes terminais — visível na linha do
+  //   pedido, mas TRANSITÓRIO: o portal async / conciliação podem reescrever resposta_canal e
+  //   apagar a marca (por isso o sync_reprocess_log é a fonte de verdade). Ausente em pedido
+  //   normal (sem ruído de `false`).
+  if (pedido.override_minimo) {
+    result.override_minimo = true;
+    result.override_minimo_por = pedido.override_minimo_por ?? null;
+  }
+  const overrideTag = pedido.override_minimo
+    ? { override_minimo: true, override_minimo_por: pedido.override_minimo_por ?? null }
+    : {};
 
   try {
     // a. Items
@@ -708,6 +775,7 @@ async function processarPedido(
           .update({
             canal_usado: "portal_sayerlack",
             resposta_canal: {
+              ...overrideTag,
               modo,
               portal_async: true,
               fornecedor_notificado: false,
@@ -727,6 +795,7 @@ async function processarPedido(
           .update({
             canal_usado: "portal_sayerlack",
             resposta_canal: {
+              ...overrideTag,
               modo,
               portal_async: false,
               fornecedor_notificado: false,
@@ -842,6 +911,7 @@ async function processarPedido(
         horario_disparo_real: new Date().toISOString(),
         canal_usado: result.canal,
         resposta_canal: {
+          ...overrideTag,
           modo,
           omie_resposta: resp,
           fornecedor_notificado: modo === "producao",
@@ -891,6 +961,7 @@ async function processarPedido(
             omie_registrado_em: new Date().toISOString(),
             status: "disparado",
             resposta_canal: {
+              ...overrideTag,
               reconciliado: true,
               motivo: "ja_cadastrado_omie",
               erro_original: msg,
@@ -917,7 +988,7 @@ async function processarPedido(
       .from("pedido_compra_sugerido")
       .update({
         status: "falha_envio",
-        resposta_canal: { erro: msg, modo, ts: new Date().toISOString() },
+        resposta_canal: { ...overrideTag, erro: msg, modo, ts: new Date().toISOString() },
         atualizado_em: new Date().toISOString(),
       })
       .eq("id", pedido.id);
@@ -1158,6 +1229,52 @@ async function authorizeCronOrStaff(req: Request): Promise<boolean> {
   } catch { return false; }
 }
 
+// Override do gate de mínimo de faturamento = decisão HUMANA privilegiada (money-path).
+// Exige token de USUÁRIO que seja master (user_roles) OU gestor comercial (commercial_roles
+// ∈ gerencial/estrategico/super_admin) — o gate é reforçado no SERVIDOR, não só na UI: a tela
+// de pedidos é RequireStaff (employee|master), então um employee a enxerga e poderia chamar o
+// edge direto. Cron/service_role NÃO overridam (o motor/cron nunca manda a flag; o service_role
+// é barrado por garantia — override é ato humano).
+const GESTOR_COMERCIAL_ROLES = new Set(["gerencial", "estrategico", "super_admin"]);
+// Retorna o user.id do autorizador (string) quando o caller PODE overridar (master OU gestor
+// comercial), ou null caso contrário. O id vai pra auditoria (override_minimo_por) — registrar
+// QUEM bypassou o mínimo de faturamento, não só QUE houve bypass.
+async function callerPodeIgnorarMinimo(req: Request): Promise<string | null> {
+  const SUPA_URL = Deno.env.get("SUPABASE_URL")!;
+  const SVC_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+  const authHeader = req.headers.get("Authorization");
+  if (!authHeader?.startsWith("Bearer ")) return null;
+  const token = authHeader.slice(7);
+  if (token === SVC_KEY) return null; // service_role não é humano → sem override
+  try {
+    const userRes = await fetch(`${SUPA_URL}/auth/v1/user`, {
+      headers: { Authorization: authHeader, apikey: SVC_KEY },
+    });
+    if (!userRes.ok) return null;
+    const user = await userRes.json();
+    const userId = typeof user?.id === "string" ? user.id : null;
+    if (!userId) return null;
+    const svcHeaders = { apikey: SVC_KEY, Authorization: `Bearer ${SVC_KEY}` };
+    const roleRes = await fetch(
+      `${SUPA_URL}/rest/v1/user_roles?user_id=eq.${userId}&select=role`,
+      { headers: svcHeaders },
+    );
+    if (roleRes.ok) {
+      const roles = (await roleRes.json()) as Array<{ role: string }>;
+      if (roles.some((r) => r.role === "master")) return userId;
+    }
+    const crRes = await fetch(
+      `${SUPA_URL}/rest/v1/commercial_roles?user_id=eq.${userId}&select=commercial_role`,
+      { headers: svcHeaders },
+    );
+    if (crRes.ok) {
+      const crs = (await crRes.json()) as Array<{ commercial_role: string }>;
+      if (crs.some((c) => GESTOR_COMERCIAL_ROLES.has(c.commercial_role))) return userId;
+    }
+    return null;
+  } catch { return null; }
+}
+
 Deno.serve(async (req: Request) => {
   if (req.method === "OPTIONS") {
     return new Response("ok", { headers: corsHeaders });
@@ -1180,6 +1297,7 @@ Deno.serve(async (req: Request) => {
   let empresa = "OBEN";
   let dataCiclo = new Date().toISOString().slice(0, 10);
   let pedidoId: number | null = null;
+  let ignorarMinimo = false;
 
   try {
     if (req.method === "POST") {
@@ -1190,9 +1308,37 @@ Deno.serve(async (req: Request) => {
         const parsedPedidoId = Number(body.pedido_id);
         if (Number.isFinite(parsedPedidoId)) pedidoId = parsedPedidoId;
       }
+      if (body.ignorar_minimo === true) ignorarMinimo = true;
     }
 
-    console.log(`[disparar-pedidos] Início ${empresa} ${dataCiclo}${pedidoId ? ` pedido=${pedidoId}` : ""}`);
+    // Override do gate de mínimo de faturamento: SÓ vale no disparo individual (pedido_id POSITIVO
+    // de um pedido real) E por gestor/master. Nunca no corte em lote/cron nem pro motor de retry
+    // (sayerlack-retry-orfaos manda só {empresa, pedido_id}, sem a flag → ignorarMinimoEfetivo
+    // fica false). ⚠️ overridePermitidoNoModo exige pedido_id>0: pedido_id=0 cai no LOTE pelo
+    // ternário da query (`pedidoId ?`) — sem essa checagem, {pedido_id:0, ignorar_minimo:true}
+    // viraria override no lote inteiro (Codex P1). Pedido a mais: barrar service_role/cron
+    // (callerPodeIgnorarMinimo exige token de USER gestor/master).
+    let ignorarMinimoEfetivo = false;
+    let overrideMinimoPor: string | null = null; // user.id do autorizador (auditoria)
+    if (ignorarMinimo) {
+      if (!overridePermitidoNoModo(pedidoId)) {
+        console.warn("[disparar-pedidos] ignorar_minimo IGNORADO: só vale no disparo individual (sem pedido_id positivo = modo lote/cron)");
+      } else {
+        const autorizadorId = await callerPodeIgnorarMinimo(req);
+        if (!autorizadorId) {
+          console.warn(`[disparar-pedidos] ignorar_minimo NEGADO p/ pedido=${pedidoId}: caller não é gestor comercial/master`);
+          return new Response(
+            JSON.stringify({ error: "Override do mínimo de faturamento requer gestor comercial ou master." }),
+            { status: 403, headers: { ...corsHeaders, "Content-Type": "application/json" } },
+          );
+        }
+        ignorarMinimoEfetivo = true;
+        overrideMinimoPor = autorizadorId;
+        console.warn(`[disparar-pedidos] OVERRIDE de mínimo de faturamento AUTORIZADO p/ pedido=${pedidoId} por user=${autorizadorId}`);
+      }
+    }
+
+    console.log(`[disparar-pedidos] Início ${empresa} ${dataCiclo}${pedidoId ? ` pedido=${pedidoId}` : ""}${ignorarMinimoEfetivo ? " [OVERRIDE-MIN]" : ""}`);
 
     // 1. Config (modo + email)
     const { data: cfg, error: cfgErr } = await db
@@ -1254,8 +1400,15 @@ Deno.serve(async (req: Request) => {
 
       const liberados: PedidoRow[] = [];
       for (const p of aprovados) {
-        const gate = deveBloquearPorMinimoFaturamento(p, gateCfg);
+        const gate = deveBloquearPorMinimoFaturamento(p, gateCfg, { ignorarMinimo: ignorarMinimoEfetivo });
         if (!gate.bloquear) {
+          if (gate.overridden) {
+            // O gate IA barrar e o override liberou — marca p/ auditoria (resposta_canal +
+            // ProcessResult), incl. QUEM autorizou. NÃO escreve falha_envio; segue pro disparo.
+            p.override_minimo = true;
+            p.override_minimo_por = overrideMinimoPor;
+            console.warn(`[disparar-pedidos] OVERRIDE mínimo de faturamento APLICADO em #${p.id} (${p.fornecedor_nome}, R$ ${p.valor_total}) por user=${overrideMinimoPor}`);
+          }
           liberados.push(p);
           continue;
         }
@@ -1376,23 +1529,31 @@ Deno.serve(async (req: Request) => {
     let emailStatus: "sent" | "skipped" | "failed" = "skipped";
     let emailDetail: string | null = null;
     if (resendKey && staffEmail) {
-      const { subject, html } = buildResumoEmail(empresa, modo, resultados, expirados);
-      const r = await fetch(RESEND_URL, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${resendKey}`,
-        },
-        body: JSON.stringify({
-          from: FROM_EMAIL,
-          to: [staffEmail],
-          subject,
-          html,
-        }),
-      });
-      const txt = await r.text();
-      emailStatus = r.ok ? "sent" : "failed";
-      emailDetail = `[${r.status}] ${txt.slice(0, 200)}`;
+      // try/catch: um throw do fetch (rede) NÃO pode propagar pro catch externo — senão a
+      // gravação do sync_reprocess_log abaixo (a auditoria durável, incl. override_minimo) seria
+      // pulada e o catch só logaria {data_ciclo}. O e-mail é secundário; a auditoria é o que importa.
+      try {
+        const { subject, html } = buildResumoEmail(empresa, modo, resultados, expirados);
+        const r = await fetch(RESEND_URL, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${resendKey}`,
+          },
+          body: JSON.stringify({
+            from: FROM_EMAIL,
+            to: [staffEmail],
+            subject,
+            html,
+          }),
+        });
+        const txt = await r.text();
+        emailStatus = r.ok ? "sent" : "failed";
+        emailDetail = `[${r.status}] ${txt.slice(0, 200)}`;
+      } catch (e) {
+        emailStatus = "failed";
+        emailDetail = `fetch erro: ${e instanceof Error ? e.message : String(e)}`;
+      }
     } else {
       emailDetail = !staffEmail
         ? "Sem email_notificacoes"
@@ -1406,7 +1567,7 @@ Deno.serve(async (req: Request) => {
     ).length;
     const duration = Date.now() - startedAt;
 
-    await db.from("sync_reprocess_log").insert({
+    const { error: logErr } = await db.from("sync_reprocess_log").insert({
       entity_type: "pedidos_compra_disparo",
       account: empresa,
       reprocess_type: "disparo_diario",
@@ -1427,6 +1588,8 @@ Deno.serve(async (req: Request) => {
         resultados,
       },
     });
+    // Insert da auditoria não pode falhar em silêncio (sucesso HTTP sem trilha persistida).
+    if (logErr) console.error(`[disparar-pedidos] FALHA ao gravar sync_reprocess_log (auditoria): ${logErr.message}`);
 
     return new Response(
       JSON.stringify({


### PR DESCRIPTION
## Override por pedido do gate de mínimo de faturamento Sayerlack

**Problema** (caso real 2026-06-10): pedidos Sayerlack abaixo de R$3k (mínimo de **faturamento**
do fornecedor — abaixo disso ele não fatura, o pedido fica parado lá) são barrados pelo gate
`[GATE-MIN-FATURAMENTO]` → `status='falha_envio'` + `resposta_canal.gate='minimo_faturamento'`.
O botão **"Re-disparar"** re-bate no gate → loop sem saída na UI. O founder precisou de `UPDATE`
manual na `company_config` (régua→0, dispara, régua→3000) pra enviar os pedidos 406 e 409.

**Solução**: override **consciente por pedido** ("Disparar mesmo assim"), só pra gestor/master.

### Mudanças
- **Helper** `src/lib/reposicao/disparo-gate-helpers.ts` — `deveBloquearPorMinimoFaturamento(p, cfg,
  {ignorarMinimo})` → `{bloquear, motivo?, overridden?}`. `overridden:true` só quando o gate IA
  barrar e a flag liberou (preserva as isenções de split/portal-já-tocado/fora-do-pattern: nesses
  casos a flag é no-op). Espelhado VERBATIM no edge.
- **Edge** `disparar-pedidos-aprovados` — aceita `{pedido_id, ignorar_minimo:true}`. Honrado **só**
  se `pedido_id` definido (modo individual) **E** caller gestor/master (`callerPodeIgnorarMinimo`:
  master via `user_roles` OU gestor comercial via `commercial_roles`; service_role/cron barrados;
  403 se não autorizado). **Nunca** no corte em lote/cron nem no motor `sayerlack_retry_orfaos`
  (manda só `{empresa, pedido_id}`). Auditoria: `override_minimo:true` em `resposta_canal` +
  `sync_reprocess_log.metadata.resultados[]`.
- **UI** — botão "Disparar mesmo assim" (AlertDialog explicando o risco) no lugar do "Re-disparar"
  quando `falha_envio` + gate, gated `isMaster||isGestorComercial`. Em `PedidoRow` (lista) **e** na
  fila "precisa de atenção" cross-ciclo (onde pedido de ciclo passado aparece). Componente novo
  reutilizável `OverrideMinimoButton`.

### Testes (TDD)
- `disparo-gate-helpers.test.ts` — +4 casos do override (com/sem flag, no-op quando já passava, gate off).
- `gate-minimo-override.test.ts` (novo) — `ehGateMinimoFaturamento` (detecta só falha por gate).
- `PedidoRow.test.tsx` — +4 casos (override no lugar de re-disparar; sem callback = re-disparar;
  falha por outro motivo ≠ override; confirmar no diálogo chama o callback).

### Codex review adversarial (xhigh, money-path, §12)
- 🔴 **P1 — bypass do isolamento de lote via `pedido_id=0`**: o parse aceitava `0`
  (`Number.isFinite(0)`), o check `pedidoId == null` é `false` pra `0`, mas o ternário da query
  (`pedidoId ? individual : lote`) trata `0` como **falsy → LOTE**. Logo `{pedido_id:0,
  ignorar_minimo:true}` de um gestor caía no LOTE **com** override → gate bypassado em TODOS os
  aprovados do dia. **Corrigido**: predicado puro `overridePermitidoNoModo(pedidoId)` (exige
  `>0`), testado (pedido_id 0/null/negativo/NaN → override ignorado), espelhado no edge.
- 🟡 **P2 — marca `override_minimo` no `resposta_canal` é transitória** (portal async/conciliação
  reescrevem). **Mitigado/por-design**: a trilha durável é `sync_reprocess_log.metadata.
  resultados[]` (append-only); o `resposta_canal` é best-effort/visual. Documentado no código.
- ✅ Sem bypass de PO-duplicado (proteções de portal-já-tocado + claim atômico intactas); sem
  furo no auth de employee (`callerPodeIgnorarMinimo` reforça gestor/master no servidor).

### Validação
- `deno check` do edge: **0 erros**.
- Testes afetados: **41/41** (helper 24 · gate-minimo 5 · PedidoRow 12). tsc strict + suíte completa: verdes.
- **Sem migration** (gate lê `company_config` existente; override é flag de body).

### ⚠️ Deploy manual (pós-merge)
1. **Edge** `disparar-pedidos-aprovados` → deploy VERBATIM da main via chat do Lovable.
2. **Frontend** → **Publish** no Lovable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
