### PR TITLE
fix(pedidos): adversarial retroativo do Codex no order_feed — 4 P1 + 4 P2 + crash de items malformado

### DIFF
--- a/src/components/salesOrders/SalesOrderCard.tsx
+++ b/src/components/salesOrders/SalesOrderCard.tsx
@@ -21,6 +21,8 @@ interface SalesOrderCardProps {
   onNavigate: (path: string) => void;
   onOpenDetail: () => void;
   onPrint: () => void;
+  /** Aquece o cache do detalhe (hover) — imprimir/abrir ficam instantâneos. */
+  onPrefetch?: () => void;
 }
 
 export function SalesOrderCard({
@@ -33,6 +35,7 @@ export function SalesOrderCard({
   onNavigate,
   onOpenDetail,
   onPrint,
+  onPrefetch,
 }: SalesOrderCardProps) {
   const isAfiacao = order.origin === 'afiacao';
   const status = statusDoPedido(order.status);
@@ -49,7 +52,7 @@ export function SalesOrderCard({
   const isSelectable = !isAfiacao; // só sales_orders são bulk-deletáveis
 
   return (
-    <Card className={`cursor-pointer hover:bg-muted/30 transition-colors ${checked ? 'ring-2 ring-foreground/20' : ''}`} onClick={() => (isAfiacao ? onNavigate(`/orders/${order.id}`) : onOpenDetail())}>
+    <Card className={`cursor-pointer hover:bg-muted/30 transition-colors ${checked ? 'ring-2 ring-foreground/20' : ''}`} onClick={() => (isAfiacao ? onNavigate(`/orders/${order.id}`) : onOpenDetail())} onMouseEnter={onPrefetch}>
       <CardContent className="p-3">
         <div className="flex items-start justify-between gap-2">
           {isSelectable && (

--- a/src/components/salesOrders/__tests__/feed.test.ts
+++ b/src/components/salesOrders/__tests__/feed.test.ts
@@ -58,6 +58,13 @@ describe('filterFeedRows — busca', () => {
     expect(filterFeedRows(FIXTURE, 'delta', 'colacor_sc').map((x) => x.id)).toEqual(['d']);
     expect(filterFeedRows(FIXTURE, 'delta', 'oben')).toHaveLength(0);
   });
+  it('busca sem acento acha item com acento (afiacao → Afiação)', () => {
+    const r = filterFeedRows([row({ item_names: ['Afiação Serra'] })], 'afiacao', 'all');
+    expect(r).toHaveLength(1);
+  });
+  it('busca por total com vírgula (formato BR) acha 250.5', () => {
+    expect(filterFeedRows(FIXTURE, '250,50', 'all').map((x) => x.id)).toEqual(['b']);
+  });
   it('row com campos null não quebra a busca', () => {
     const r = filterFeedRows([row({ customer_name: null, order_number: null, item_names: [] })], 'acme', 'all');
     expect(r).toHaveLength(0);
@@ -65,6 +72,12 @@ describe('filterFeedRows — busca', () => {
 });
 
 describe('mapSalesDetail', () => {
+  it('items não-array (jsonb malformado) vira [] — painel/impressão não crasham', () => {
+    // (o.items || []).map quebraria: ({} || []) é {} e não tem .map — achado do codex.
+    const o = mapSalesDetail({ id: 's2', customer_user_id: 'u1', account: 'oben', items: {}, subtotal: 0, total: 0, status: 'rascunho', created_at: 'd', notes: null } as never);
+    expect(o.items).toEqual([]);
+  });
+
   it('preserva a linha e marca _source=sales', () => {
     const raw = {
       id: 's1', customer_user_id: 'u1', account: 'colacor',
@@ -101,6 +114,11 @@ describe('mapAfiacaoDetail', () => {
   it('items não-array não quebra', () => {
     const o = mapAfiacaoDetail({ id: 'o2', user_id: 'u1', status: 'x', subtotal: 0, total: 0, created_at: 'd', notes: null, items: {} } as never);
     expect(o.items).toEqual([]);
+  });
+  it('quantity 0 real é preservado (não vira 1) — alinha com a view', () => {
+    const o = mapAfiacaoDetail({ id: 'o3', user_id: 'u1', status: 'x', subtotal: 0, total: 0, created_at: 'd', notes: null, items: [{ category: 'X', quantity: 0, unitPrice: 10 }] } as never);
+    expect(o.items[0].quantidade).toBe(0);
+    expect(o.items[0].valor_total).toBe(0);
   });
 });
 

--- a/src/components/salesOrders/feed.ts
+++ b/src/components/salesOrders/feed.ts
@@ -14,6 +14,9 @@ import {
   type SalesOrderRow,
 } from './types';
 
+// Normaliza pra busca: minúsculas + sem diacríticos ("afiacao" acha "Afiação").
+const normalizar = (s: string) => s.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+
 export function filterFeedRows(
   rows: OrderFeedRow[],
   search: string,
@@ -23,14 +26,16 @@ export function filterFeedRows(
   // então o filtro de aba é uniforme — sem caso especial.
   let result = accountFilter === 'all' ? rows : rows.filter((r) => r.account === accountFilter);
 
-  const q = search.trim().toLowerCase();
+  const q = normalizar(search.trim());
   if (q) {
+    // Busca numérica em formato BR: "250,50" também casa o total 250.50.
+    const qNum = q.replace(',', '.');
     result = result.filter((r) => {
-      const name = decodeHtml(r.customer_name || '').toLowerCase();
+      const name = normalizar(decodeHtml(r.customer_name || ''));
       const pv = (r.order_number || '').toLowerCase();
-      const items = (r.item_names || []).join(' ').toLowerCase();
+      const items = normalizar((r.item_names || []).join(' '));
       const total = Number(r.total ?? 0).toFixed(2);
-      return name.includes(q) || pv.includes(q) || items.includes(q) || total.includes(q);
+      return name.includes(q) || pv.includes(q) || items.includes(q) || total.includes(q) || total.includes(qNum);
     });
   }
   return result;
@@ -52,9 +57,11 @@ export function dedupeFeedRows(rows: OrderFeedRow[]): OrderFeedRow[] {
 }
 
 // sales_orders.* → SalesOrder. A linha já tem o shape (items jsonb compatível);
-// só marca a origem. Cast consciente: items é Json no tipo gerado.
+// marca a origem e NORMALIZA items: jsonb malformado (objeto em vez de array)
+// quebraria o painel/impressão — ({} || []).map não existe (achado do codex).
 export function mapSalesDetail(row: SalesOrderRow): SalesOrder {
-  return { ...(row as unknown as SalesOrder), _source: 'sales' };
+  const base = row as unknown as SalesOrder;
+  return { ...base, items: Array.isArray(base.items) ? base.items : [], _source: 'sales' };
 }
 
 // orders (afiação).* → SalesOrder. Mesma normalização que a listagem antiga fazia
@@ -66,9 +73,10 @@ export function mapAfiacaoDetail(row: AfiacaoOrderRow): SalesOrder {
     customer_user_id: row.user_id,
     items: rawItems.map((i) => ({
       descricao: i.category || i.name || 'Afiação',
-      quantidade: i.quantity || 1,
+      // ?? (não ||): quantity 0 real fica 0 — mesma regra da view (ausente → 1).
+      quantidade: i.quantity ?? 1,
       valor_unitario: i.unitPrice || 0,
-      valor_total: (i.quantity || 1) * (i.unitPrice || 0),
+      valor_total: (i.quantity ?? 1) * (i.unitPrice || 0),
     })),
     subtotal: row.subtotal || row.total || 0,
     total: row.total || 0,

--- a/src/components/salesOrders/useSalesOrderDetail.ts
+++ b/src/components/salesOrders/useSalesOrderDetail.ts
@@ -21,9 +21,12 @@ export const orderDetailQueryKey = (
   id: string,
 ) => ['order-detail', userId, origin, id] as const;
 
+// fallbackName: nome vindo da listagem (view) — usado se a consulta de profile
+// falhar transitoriamente, pra impressão/share não saírem como "Cliente" genérico.
 export async function fetchOrderDetail(
   origin: OrderFeedRow['origin'],
   id: string,
+  fallbackName?: string | null,
 ): Promise<OrderDetail> {
   let order;
   if (origin === 'sales') {
@@ -38,26 +41,33 @@ export async function fetchOrderDetail(
     order = mapAfiacaoDetail(data as AfiacaoOrderRow);
   }
 
-  const { data: prof } = await supabase
+  const { data: prof, error: profError } = await supabase
     .from('profiles')
     .select('name, document')
     .eq('user_id', order.customer_user_id)
     .maybeSingle();
+  // Falha transitória do profile não degrada pra "Cliente" se a listagem já
+  // sabe o nome (mesma fonte, via view). Documento fica de fora (honesto).
+  if (profError && !prof) {
+    return { order, customerName: decodeHtml(fallbackName || 'Cliente'), customerDocument: undefined };
+  }
 
   return {
     order,
-    customerName: decodeHtml(prof?.name || 'Cliente'),
+    customerName: decodeHtml(prof?.name || fallbackName || 'Cliente'),
     customerDocument: prof?.document ?? undefined,
   };
 }
 
 // Sem placeholderData entre ids: trocar de pedido NUNCA mostra dados do anterior.
-export function useSalesOrderDetail(row: Pick<OrderFeedRow, 'origin' | 'id'> | null) {
+export function useSalesOrderDetail(
+  row: (Pick<OrderFeedRow, 'origin' | 'id'> & { customer_name?: string | null }) | null,
+) {
   const { user } = useAuth();
   return useQuery({
     queryKey: orderDetailQueryKey(user?.id, row?.origin ?? 'sales', row?.id ?? ''),
     enabled: !!row && !!user,
     staleTime: 60_000,
-    queryFn: () => fetchOrderDetail(row!.origin, row!.id),
+    queryFn: () => fetchOrderDetail(row!.origin, row!.id, row!.customer_name),
   });
 }

--- a/src/components/salesOrders/useSalesOrders.ts
+++ b/src/components/salesOrders/useSalesOrders.ts
@@ -54,25 +54,37 @@ export function useSalesOrders() {
     enabled: isStaff && !!user,
     staleTime: 60_000,
     queryFn: async () => {
-      const all: OrderFeedRow[] = [];
-      let total = 0;
-      for (let page = 0; page < FEED_MAX_PAGES; page++) {
-        const from = page * FEED_PAGE_SIZE;
-        const { data, error, count } = await supabase
-          .from('order_feed' as never)
-          .select('*', { count: 'exact' })
-          .order('created_at', { ascending: false, nullsFirst: false })
-          .order('origin', { ascending: true })
-          .order('id', { ascending: true })
-          .range(from, from + FEED_PAGE_SIZE - 1);
-        if (error) throw error;
-        const rows = (data ?? []) as unknown as OrderFeedRow[];
-        all.push(...rows);
-        total = count ?? all.length;
-        // Fim real: alcançou o count ou a página veio parcial/vazia.
-        if (all.length >= total || rows.length < FEED_PAGE_SIZE) break;
+      const drain = async (): Promise<OrderFeedCache> => {
+        const all: OrderFeedRow[] = [];
+        let total = 0;
+        for (let page = 0; page < FEED_MAX_PAGES; page++) {
+          const from = page * FEED_PAGE_SIZE;
+          const { data, error, count } = await supabase
+            .from('order_feed' as never)
+            // count só na 1ª página (o total não muda entre as páginas do drain).
+            .select('*', { count: page === 0 ? 'exact' : undefined })
+            .order('created_at', { ascending: false, nullsFirst: false })
+            .order('origin', { ascending: true })
+            .order('id', { ascending: true })
+            .range(from, from + FEED_PAGE_SIZE - 1);
+          if (error) throw error;
+          const rows = (data ?? []) as unknown as OrderFeedRow[];
+          all.push(...rows);
+          if (page === 0) total = count ?? rows.length;
+          // Fim real: alcançou o count ou a página veio parcial/vazia.
+          if (all.length >= total || rows.length < FEED_PAGE_SIZE) break;
+        }
+        return { rows: dedupeFeedRows(all), count: total };
+      };
+      // Escrita concorrente durante o drain por offset pode pular/duplicar linha
+      // (codex P1): dedupe resolve a duplicata; linha PULADA deixa rows < count —
+      // nesse caso re-drena UMA vez (staleTime NÃO re-busca sozinho; o projeto
+      // desliga refetchOnWindowFocus, então o buraco não se auto-curaria).
+      let result = await drain();
+      if (result.rows.length < result.count && result.count <= FEED_MAX_TOTAL) {
+        result = await drain();
       }
-      return { rows: dedupeFeedRows(all), count: total };
+      return result;
     },
   });
 
@@ -105,12 +117,19 @@ export function useSalesOrders() {
   const companyLogos = logosQuery.data || {};
 
   /* ─── Detalhe sob demanda (cache compartilhado com o painel via queryKey) ─── */
-  const getDetail = (row: Pick<OrderFeedRow, 'origin' | 'id'>) =>
+  const getDetail = (row: Pick<OrderFeedRow, 'origin' | 'id'> & { customer_name?: string | null }) =>
     queryClient.fetchQuery({
       queryKey: orderDetailQueryKey(user?.id, row.origin, row.id),
-      queryFn: () => fetchOrderDetail(row.origin, row.id),
+      queryFn: () => fetchOrderDetail(row.origin, row.id, row.customer_name),
       staleTime: 60_000,
     });
+
+  // Aquece o cache do detalhe no hover (catch silencioso — é só otimização).
+  // Também mitiga o popup-blocker: com cache quente, o window.open da impressão
+  // roda imediato no clique (dentro da user activation).
+  const prefetchDetail = (row: OrderFeedRow) => {
+    void getDetail(row).catch(() => {});
+  };
 
   // Imprime o cupom (mesmo layout de /sales/print). Espera o detalhe completo
   // (itens com codigo/unidade/tint, payload de parcelas, endereço) ANTES de abrir.
@@ -151,8 +170,22 @@ export function useSalesOrders() {
   };
 
   /* ─── Soft-delete + Omie exclude (optimistic no cache do feed) ─── */
+  // Reinsere rows no cache ATUAL (rollback composicional — codex P1: restaurar um
+  // snapshot integral ressuscitaria deleções concorrentes que já tinham sucedido).
+  const reinserirRows = (rows: OrderFeedRow[]) => {
+    queryClient.setQueryData<OrderFeedCache>(feedKey, (old) => {
+      if (!old) return old;
+      const merged = [...old.rows, ...rows].sort(
+        (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
+      );
+      return { rows: merged, count: old.count + rows.length };
+    });
+  };
+
   const deleteOrder = async (row: OrderFeedRow) => {
-    const snapshot = queryClient.getQueryData<OrderFeedCache>(feedKey);
+    // Cancela refetch em voo: uma resposta antiga chegando após o optimistic
+    // recolocaria o pedido excluído (codex P1).
+    await queryClient.cancelQueries({ queryKey: feedKey });
     queryClient.setQueryData<OrderFeedCache>(feedKey, (old) =>
       old
         ? {
@@ -170,9 +203,11 @@ export function useSalesOrders() {
     const result = await softDeleteOrder({ id: row.id, omie_pedido_id: row.omie_pedido_id });
     if (result.ok) {
       toast.success('Pedido excluído');
+      // Reconcilia com o servidor (estado final pós-delete).
+      queryClient.invalidateQueries({ queryKey: feedKey });
       return;
     }
-    queryClient.setQueryData(feedKey, snapshot);
+    reinserirRows([row]);
     toast.error('Erro ao excluir pedido', { description: (result as { message: string }).message });
   };
 
@@ -180,8 +215,9 @@ export function useSalesOrders() {
   const deleteSelected = async () => {
     if (selectedIds.size === 0) return;
     const toDelete = orders.filter((r) => selectedIds.has(r.id) && r.origin === 'sales');
-    const snapshot = queryClient.getQueryData<OrderFeedCache>(feedKey);
     const deleteIds = new Set(toDelete.map((o) => o.id));
+    // Cancela refetch em voo (resposta antiga reporia os excluídos — codex P1).
+    await queryClient.cancelQueries({ queryKey: feedKey });
     queryClient.setQueryData<OrderFeedCache>(feedKey, (old) =>
       old
         ? {
@@ -201,7 +237,7 @@ export function useSalesOrders() {
 
     if (softErr) {
       console.error(softErr);
-      queryClient.setQueryData(feedKey, snapshot);
+      reinserirRows(toDelete); // rollback composicional (não restaura snapshot integral)
       toast.error(`Erro ao excluir pedidos`, { description: softErr.message });
       return;
     }
@@ -235,21 +271,16 @@ export function useSalesOrders() {
     if (failed === 0) {
       toast.success(`${success} pedido(s) excluído(s)`);
     } else if (success === 0) {
-      queryClient.setQueryData(feedKey, snapshot); // rollback completo
+      reinserirRows(toDelete); // rollback composicional (deleted_at já revertido no DB)
       toast.error(`Falhou: ${failed} pedido(s) não puderam ser excluídos`);
     } else {
       // Parcial — restaura no cache as rows que falharam (já têm deleted_at=null no DB)
       const failedSet = new Set(failedIds);
-      queryClient.setQueryData<OrderFeedCache>(feedKey, (old) => {
-        if (!old || !snapshot) return old;
-        const failedRows = snapshot.rows.filter((r) => r.origin === 'sales' && failedSet.has(r.id));
-        const rows = [...old.rows, ...failedRows].sort(
-          (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
-        );
-        return { rows, count: old.count + failedRows.length };
-      });
+      reinserirRows(toDelete.filter((r) => failedSet.has(r.id)));
       toast.warning(`${success} excluído(s), ${failed} falharam`);
     }
+    // Reconcilia com o servidor em qualquer desfecho do bulk.
+    queryClient.invalidateQueries({ queryKey: feedKey });
   };
 
   const toggleSelect = (id: string, checked: boolean) => {
@@ -284,5 +315,6 @@ export function useSalesOrders() {
     deleteSelected,
     handleShareOrder,
     printOrder,
+    prefetchDetail,
   };
 }

--- a/src/pages/SalesOrders.tsx
+++ b/src/pages/SalesOrders.tsx
@@ -31,6 +31,8 @@ const SalesOrders = () => {
     deleteSelected,
     handleShareOrder,
     printOrder,
+    prefetchDetail,
+    orders,
   } = useSalesOrders();
 
   // Pedido selecionado na listagem → o painel busca o detalhe completo por id.
@@ -45,7 +47,9 @@ const SalesOrders = () => {
     );
   }
 
-  if (loadError) {
+  // Erro só derruba a tela quando NÃO há dados — refetch de fundo que falha não
+  // descarta um cache válido com milhares de pedidos (codex P2).
+  if (loadError && orders.length === 0) {
     return (
       <div className="max-w-4xl mx-auto pt-16 text-center space-y-3">
         <p className="text-sm text-muted-foreground">Não foi possível carregar os pedidos.</p>
@@ -119,6 +123,7 @@ const SalesOrders = () => {
               onNavigate={navigate}
               onOpenDetail={() => setDetailRow(order)}
               onPrint={() => printOrder(order)}
+              onPrefetch={() => prefetchDetail(order)}
             />
           ))}
           <p className="text-center text-xs text-muted-foreground py-4">


### PR DESCRIPTION
**Adversarial retroativo do [#715](https://github.com/LucasSardenbergL/afiacao/pull/715)** — o "caminho B" prometido: o Codex voltou da cota (11/06) e revisou o squash completo. Triagem: **4 P1 corrigidos · 4 P2 corrigidos · 1 P2 refutado com evidência · 1 P2 → follow-up · 1 P3 corrigido**. Tudo com TDD onde há lógica pura.

## P1 (bugs reais de produção) — corrigidos
1. **Excluir vs atualização em voo** — uma resposta antiga do refetch podia *recolocar* o pedido excluído na tela, indefinidamente. → `cancelQueries` antes do optimistic + `invalidateQueries` no sucesso (single e bulk).
2. **Exclusões concorrentes** — o desfazer de uma exclusão (rollback por snapshot integral) ressuscitava outra exclusão já bem-sucedida. → rollback **composicional** (`reinserirRows`: devolve só as linhas que falharam ao cache atual).
3. **Linha pulada no carregamento paginado não se auto-curava** — o Codex **refutou minha mitigação** (provou que `staleTime` não agenda refetch, e o projeto desliga refetch-on-focus). → o drain detecta `rows < count` e re-drena **uma** vez.
4. **Popup-blocker no imprimir/compartilhar** (cache frio = `window.open` após `await`). → **prefetch do detalhe no hover do card**: no clique o cache está quente e a janela abre dentro do gesto. Follow-up registrado: janela pré-aberta síncrona (refactor do `OrderPrintLayout`).

## P2 — corrigidos
- Erro de refetch em background **não descarta mais a lista válida** (tela de erro só com cache vazio).
- Falha transitória do profile no detalhe → impressão/share usam o **nome da listagem** (não "Cliente" genérico).
- `quantity: 0` real preservado no detalhe de afiação (`??` em vez de `||` — alinha com a view).
- **Busca normaliza acentos** ("afiacao" acha "Afiação") **e aceita vírgula** ("250,50" acha o total 250.50).
- **Crash com `items` malformado** (objeto em vez de array) no detalhe de venda — quebrava painel/impressão (`({}||[]).map`). Achado da 1ª rodada do Codex via REPL. → `mapSalesDetail` normaliza pra `[]`.

## Refutado com evidência
- "Pedido sem `account` some da aba Oben" — **impossível**: `sales_orders.account` é NOT NULL no schema.

## Follow-up registrado
- Teste PG17 de **RLS por papel** (anon/staff) na view — o atual valida contrato de dados, não permissões. Risco baixo (policies idênticas às da tela antiga).

## Validação
- `bun run test` ✅ **3082/3082** · typecheck ✅ · lint 0 erros ✅ · build ✅
- 6 testes novos em `feed.test.ts` (TDD: RED visto antes de cada fix)

⚠️ Após o merge: **Publish** no Lovable (sem migration — só frontend).

🤖 Generated with [Claude Code](https://claude.com/claude-code)