### PR TITLE
fix(reposição): fixes do adversarial retroativo do Codex no #711 (3 P1 + bug pré-existente da oportunidade)

### DIFF
--- a/db/test-fixes-codex-711.sh
+++ b/db/test-fixes-codex-711.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# Teste PG17 dos fixes do adversarial retroativo do Codex no #711 (migration 20260611120000).
+# (1) [SIMETRIA-NORMAL] gerar_pedidos_oportunidade_ciclo não oferece SKU já em pedido normal
+#     economicamente ativo (header E itens); SKU livre continua entrando.
+# (2) [CAST-SEGURO] tick do alerta com config malformada não explode (no-op limpo).
+# Técnica: a view v_oportunidade_economica_hoje é substituída por TABELA-fixture homônima
+# (plpgsql resolve nomes em runtime) — testa a LÓGICA da função com dados determinísticos.
+# Base: db/verify-snapshot-replay.sh. Pré-req: brew install postgresql@17 pgvector.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PGVER=17
+PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+PORT=5438
+DATA="$(mktemp -d /tmp/pgtest-fixcodex.XXXXXX)/data"
+export LC_ALL=C LANG=C
+
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente: brew install postgresql@${PGVER} pgvector"; exit 1; }
+
+CELLAR="$(brew --prefix postgresql@${PGVER})"
+cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
+mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
+cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
+
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+trap cleanup EXIT
+
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l /tmp/pg-fixcodex.log -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres fixcodex_verify
+P() { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d fixcodex_verify "$@"; }
+
+RR="$(mktemp /tmp/snap-fixcodex.XXXXXX.sql)"
+sed -E 's/^(CREATE SCHEMA public;)/-- \1/' "$REPO_ROOT/supabase/schema-snapshot.sql" \
+  | grep -vE '^\\(un)?restrict ' > "$RR"
+
+echo "→ stubs + prelude + snapshot…"
+P -v ON_ERROR_STOP=1 -q -f "$REPO_ROOT/db/stubs-supabase.sql"
+P -v ON_ERROR_STOP=1 -q -f "$REPO_ROOT/supabase/schema-extensions-prelude.sql"
+P --single-transaction -v ON_ERROR_STOP=1 -q -f "$RR"
+rm -f "$RR"
+
+echo "→ stub cron.schedule + migrations base (alerta 150000) + fixes (20260611120000)…"
+P -v ON_ERROR_STOP=1 -q <<'SQL'
+CREATE OR REPLACE FUNCTION cron.schedule(p_jobname text, p_schedule text, p_command text)
+RETURNS bigint LANGUAGE plpgsql AS $$
+DECLARE v_id bigint;
+BEGIN
+  SELECT jobid INTO v_id FROM cron.job WHERE jobname = p_jobname;
+  IF v_id IS NULL THEN
+    SELECT COALESCE(MAX(jobid),0)+1 INTO v_id FROM cron.job;
+    INSERT INTO cron.job (jobid, jobname, schedule, command, active)
+    VALUES (v_id, p_jobname, p_schedule, p_command, true);
+  ELSE
+    UPDATE cron.job SET schedule = p_schedule, command = p_command WHERE jobid = v_id;
+  END IF;
+  RETURN v_id;
+END $$;
+SQL
+P -v ON_ERROR_STOP=1 -q -f "$REPO_ROOT/supabase/migrations/20260609150000_reposicao_alerta_pedido_minimo.sql" >/dev/null
+P -v ON_ERROR_STOP=1 -q -f "$REPO_ROOT/supabase/migrations/20260611120000_reposicao_fixes_codex_711.sql" >/dev/null
+
+echo "→ fixture: troca a view v_oportunidade_economica_hoje por tabela determinística…"
+P -v ON_ERROR_STOP=1 -q <<'SQL'
+DROP VIEW IF EXISTS v_oportunidade_economica_hoje CASCADE;
+CREATE TABLE v_oportunidade_economica_hoje (
+  empresa text, cenario text, economia_bruta_estimada numeric, qtde_oportunidade numeric,
+  campanha_id bigint, aumentos_json jsonb, fornecedor_nome text,
+  sku_codigo_omie text, sku_descricao text, preco_item_eoq numeric,
+  desconto_total_perc numeric, promo_item_id bigint
+);
+-- 2 SKUs do MESMO fornecedor/cenário: 5001 (vai estar em pedido normal ativo) e 5002 (livre).
+-- promo_item_id NULL: pedido_compra_item tem FK pra promocao_item (não semeada) — NULL passa.
+INSERT INTO v_oportunidade_economica_hoje VALUES
+  ('OBEN','promo_flat',100,10,77,NULL,'FORN-OPP','5001','SKU 5001',20,10,NULL),
+  ('OBEN','promo_flat',100,10,77,NULL,'FORN-OPP','5002','SKU 5002',20,10,NULL);
+
+-- Pedido NORMAL economicamente ativo (aprovado, dentro de 7d) com o SKU 5001.
+INSERT INTO pedido_compra_sugerido (empresa, fornecedor_nome, grupo_codigo, data_ciclo, valor_total, num_skus, status, tipo_ciclo)
+VALUES ('OBEN','FORN-X',NULL,CURRENT_DATE,500,1,'aprovado_aguardando_disparo','normal');
+INSERT INTO pedido_compra_item (pedido_id, sku_codigo_omie, sku_descricao, qtde_sugerida, qtde_final, preco_unitario, valor_linha)
+SELECT id, '5001', 'SKU 5001', 25, 25, 20, 500 FROM pedido_compra_sugerido WHERE fornecedor_nome='FORN-X';
+SQL
+
+echo "→ roda gerar_pedidos_oportunidade_ciclo + asserts…"
+P -v ON_ERROR_STOP=1 -q <<'SQL'
+DO $$
+DECLARE d int; v numeric;
+BEGIN
+  PERFORM * FROM public.gerar_pedidos_oportunidade_ciclo('OBEN', CURRENT_DATE);
+
+  -- F1: SKU 5001 (em pedido normal ativo) NÃO entrou na oportunidade
+  SELECT count(*) INTO d FROM pedido_compra_item pci
+  JOIN pedido_compra_sugerido pcs ON pcs.id = pci.pedido_id
+  WHERE pcs.tipo_ciclo LIKE 'oportunidade_%' AND pci.sku_codigo_omie='5001';
+  IF d <> 0 THEN RAISE EXCEPTION 'F1 FALHOU: SKU em pedido normal ativo entrou na oportunidade (compra dupla)'; END IF;
+  RAISE NOTICE 'OK F1 — [SIMETRIA-NORMAL] SKU em pedido normal ativo fica fora da oportunidade';
+
+  -- F2: SKU 5002 (livre) ENTROU; header consistente (num_skus=1, valor = 10×20×0.9=180)
+  SELECT count(*) INTO d FROM pedido_compra_item pci
+  JOIN pedido_compra_sugerido pcs ON pcs.id = pci.pedido_id
+  WHERE pcs.tipo_ciclo LIKE 'oportunidade_%' AND pci.sku_codigo_omie='5002';
+  IF d <> 1 THEN RAISE EXCEPTION 'F2 FALHOU: SKU livre não entrou na oportunidade (count=%)', d; END IF;
+  SELECT num_skus INTO d FROM pedido_compra_sugerido WHERE tipo_ciclo LIKE 'oportunidade_%' AND status='pendente_aprovacao';
+  IF d <> 1 THEN RAISE EXCEPTION 'F2 FALHOU: header num_skus=% (esperado 1 — divergência header×itens)', d; END IF;
+  RAISE NOTICE 'OK F2 — SKU livre entra; header e itens consistentes (sem divergência)';
+
+  -- F3: idempotência — re-rodar não duplica (limpeza própria + simetria estável)
+  PERFORM * FROM public.gerar_pedidos_oportunidade_ciclo('OBEN', CURRENT_DATE);
+  SELECT count(*) INTO d FROM pedido_compra_item pci
+  JOIN pedido_compra_sugerido pcs ON pcs.id = pci.pedido_id
+  WHERE pcs.tipo_ciclo LIKE 'oportunidade_%';
+  IF d <> 1 THEN RAISE EXCEPTION 'F3 FALHOU: re-rodada duplicou/perdeu itens (count=%)', d; END IF;
+  RAISE NOTICE 'OK F3 — re-rodada idempotente';
+
+  -- F4: [CAST-SEGURO] config malformada não mata o tick (no-op limpo)
+  UPDATE company_config SET value = 'abc' WHERE key = 'reposicao_alerta_pedido_valor_minimo';
+  PERFORM public.reposicao_alerta_pedido_minimo_tick();  -- não pode lançar exceção
+  SELECT count(*) INTO d FROM fornecedor_alerta WHERE tipo='reposicao_pedido_minimo';
+  IF d <> 0 THEN RAISE EXCEPTION 'F4 FALHOU: config malformada gerou alerta'; END IF;
+  UPDATE company_config SET value = '3000' WHERE key = 'reposicao_alerta_pedido_valor_minimo';
+  RAISE NOTICE 'OK F4 — [CAST-SEGURO] config malformada = no-op limpo (tick sobrevive)';
+
+  -- F5: tick segue FUNCIONANDO depois (regressão do REPLACE) — pedido Sayerlack ≥3k alerta
+  INSERT INTO pedido_compra_sugerido (empresa, fornecedor_nome, grupo_codigo, data_ciclo, valor_total, num_skus, status, tipo_ciclo)
+  VALUES ('OBEN','SAYERLACK DO BRASIL','G1',CURRENT_DATE,3200,5,'pendente_aprovacao','normal');
+  PERFORM public.reposicao_alerta_pedido_minimo_tick();
+  SELECT count(*) INTO d FROM fornecedor_alerta WHERE tipo='reposicao_pedido_minimo';
+  IF d <> 1 THEN RAISE EXCEPTION 'F5 FALHOU: tick não alertou pós-REPLACE (count=%)', d; END IF;
+  RAISE NOTICE 'OK F5 — tick funcional pós-REPLACE (alerta dispara)';
+
+  RAISE NOTICE '✅ TODOS OS 5 ASSERTS DOS FIXES PASSARAM';
+END $$;
+SQL
+
+echo "✅ test-fixes-codex-711: OK"

--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,11 +21,11 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **194** custom migrations totais
-- **730** objetos esperados (criados por estas migrations)
+- **195** custom migrations totais
+- **734** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
+  - `function`: 187
   - `rls_policy`: 183
-  - `function`: 183
   - `index`: 134
   - `cron_job`: 102
   - `table`: 85
@@ -1699,6 +1699,8 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | --- | --- | --- |
 | `table` | `public.push_subscriptions` | — |
 | `index` | `public.idx_push_subscriptions_user` | `push_subscriptions` |
+| `function` | `public.upsert_push_subscription` | — |
+| `function` | `public.delete_push_subscription` | — |
 | `function` | `public._push_enviar` | — |
 | `function` | `public.push_whatsapp_inbound` | — |
 | `function` | `public.push_tarefa_nova` | — |
@@ -1708,6 +1710,13 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | `cron_job` | `cron.push-sla-tick` | — |
 | `rls_policy` | `public.push_subscriptions_own` | `push_subscriptions` |
 | `rls_policy` | `public.push_subscriptions_service` | `push_subscriptions` |
+
+### `20260611120000_reposicao_fixes_codex_711.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `public.gerar_pedidos_oportunidade_ciclo` | — |
+| `function` | `public.reposicao_alerta_pedido_minimo_tick` | — |
 
 ## Próximos passos quando algo der `❌`
 

--- a/docs/roadmap-sessao.md
+++ b/docs/roadmap-sessao.md
@@ -161,7 +161,9 @@
 - ✅ **Validação PG17 local** — `db/test-alerta-pedido-minimo.sh` (11 asserts) + `db/test-rpc-intraday.sh` (8 asserts, migrations reais sobre o snapshot). CI: typecheck + 2861 testes + lint + build verdes.
 - ✅ **Análise dente de serra entregue** — fase 1 = intra-day (adianta disparo ~0,5–1d) + alerta R$3k (lote ótimo ≈ mínimo de faturamento); fase 2 (recalibrar ponto_pedido/cobertura/SS com R=2h via esteira `param_auto`) **gated em 2–4 semanas de medição**.
 - ✅ **Rollout em prod concluído (2026-06-09):** BLOCOS A+B aplicados e validados no SQL Editor + edges `gerar-pedidos-diario` e `disparar-pedidos-aprovados` deployadas verbatim (Active, diff vazio vs main). **Pacote 100% no ar** — 1ª rodada intra-day 7h15 BRT do dia seguinte.
-- ⏸️ **Codex adversarial retroativo** (quando a cota voltar, 11/06+) — revisar o #711.
+- ✅ **Codex adversarial retroativo RODOU (2026-06-11, xhigh)** — caminho B fechado. Confirmou meu achado do corte (com refinamento: expirar SÓ oportunidades, senão zumbi de oportunidade bloquearia SKU pra sempre no NOT EXISTS) + 2 P1 novos (simetria na `gerar_pedidos_oportunidade_ciclo`; gate fail-closed em erro de leitura de config) + validou guardrail/tick/gate. Fixes na migration `20260611120000` + edge `disparar-pedidos-aprovados` (PG17 5 asserts).
+- ⏳ **Founder:** colar `20260611120000` no SQL Editor (com pré-flight) + redeploy da `disparar-pedidos-aprovados` via Lovable.
+- ⏸️ **P2 do Codex (follow-ups com gatilho):** gate no modo individual da edge do portal (rota dormente); corte×runAutoApprove transacional (coberto pelo Sentinela 48h).
 
 ---
 

--- a/docs/superpowers/specs/2026-06-09-reposicao-intraday-alerta-3k-design.md
+++ b/docs/superpowers/specs/2026-06-09-reposicao-intraday-alerta-3k-design.md
@@ -165,6 +165,47 @@ Estoque médio = lote/2 (ciclo) + estoque de segurança. O pacote ataca:
 - Mínimo de faturamento por fornecedor além da Sayerlack (config single-pattern v1; extensível).
 - Recalibração de parâmetros (fase 2, gated em medição).
 
+## Pós-review — adversarial retroativo do Codex (2026-06-11, xhigh, caminho B fechado)
+
+O Codex revisou o #711 mergeado + meu achado novo (corte das 13h UTC expirava pendentes no meio
+do dia intra-day → churn + e-mail duplicado do alerta). Veredito e destino:
+
+**P1 (corrigidos na migration `20260611120000` + edge `disparar-pedidos-aprovados`):**
+1. **Corte expira SÓ `oportunidade_%`** (`.lte` data como backstop): meu fix original (`.lt`
+   cego) criaria zumbi de oportunidade → SKU bloqueado pra sempre no NOT EXISTS da RPC normal —
+   o Codex pegou a interação. Pendentes normais agora vivem o dia todo; oportunidade mantém a
+   vida curta original.
+2. **[SIMETRIA-NORMAL]** em `gerar_pedidos_oportunidade_ciclo`: a proteção do #711 era
+   unilateral; a oportunidade agora desvia de SKU em pedido normal economicamente ativo
+   (pendente/bloqueado/aprovado/falha_envio/disparado/concluído ≤7d), nos DOIS WHEREs (CTE +
+   INSERT de itens — só no CTE divergiria header×itens). Semântica validada: SKU que precisa
+   repor E tem campanha já ganha o desconto via `aplicar_promocoes` no pedido normal.
+3. **Gate fail-closed em ERRO de leitura da config** (≠ config ausente, que segue = desligado).
+
+**P3 incorporado:** `[CAST-SEGURO]` no tick (config malformada vira no-op, não mata o cron).
+
+**Achado-BÔNUS do PG17 (ao EXECUTAR a função, não só criar):** `[FIX-AMBIGUIDADE]` — o corpo do
+snapshot de `gerar_pedidos_oportunidade_ciclo` tem `SUM(valor_total)` sem qualificar no agregado
+final, ambíguo com a coluna OUT homônima do `RETURNS TABLE` → **erro de RUNTIME** (CREATE passa,
+late-bound). O wrapper `ciclo_oportunidade_do_dia` só chama a inner em dia de corte de campanha/
+véspera de aumento e não tem exception handler → se prod == snapshot, a geração de oportunidades
+**falhava silenciosamente exatamente nos dias com evento** (rollback no cron; pedido de
+oportunidade nunca nascia). Mesmo modo-de-falha do incidente `aplicar_promocoes` (§10 do
+CLAUDE.md). Fix na mesma migration (qualificação `pcs0.*`); aplicar pode LIGAR a feature →
+founder revisa a 1ª rodada com evento; pré-flight pede o functiondef VIVO de prod.
+
+**Validados pelo Codex (sem mudança):** guardrail×promoções na mesma transação (sem janela de
+infla); resolve sem filtro de pattern (necessário); tick×tick e tick×RPC seguros; gate pré-split
+sem escape nas rotas do `disparar` (incl. <R$3k com >20 itens).
+
+**P2 registrados (follow-ups, com gatilho):**
+- Gate no modo individual `{pedido_id}` da edge `enviar-pedido-portal-sayerlack` (rota dormente,
+  sem chamador ativo no frontend; acessível a staff). Gatilho: se algum fluxo passar a chamá-la.
+- Corte × `runAutoApprove` transacional (corrida rara "aprovado e não disparado"; já coberta
+  pelo check `reposicao_disparo` do Sentinela em 48h).
+- P3 cosmético não-feito: linha representativa determinística no e-mail agregado (MAX/SUM
+  transitório, sem alerta falso).
+
 ## Riscos aceitos / registrados
 
 - Race aprovar-durante-regeneração: janela pequena; aprovação falha limpa (0 rows) — nada

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 194
+-- Total de custom migrations: 195
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -213,7 +213,8 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260609150000', 'reposicao_alerta_pedido_minimo', '20260609150000_reposicao_alerta_pedido_minimo.sql'),
   ('20260609150000', 'tint_sync_promote', '20260609150000_tint_sync_promote.sql'),
   ('20260609160000', 'reposicao_ciclo_intraday', '20260609160000_reposicao_ciclo_intraday.sql'),
-  ('20260610200000', 'push_vendedora', '20260610200000_push_vendedora.sql')
+  ('20260610200000', 'push_vendedora', '20260610200000_push_vendedora.sql'),
+  ('20260611120000', 'reposicao_fixes_codex_711', '20260611120000_reposicao_fixes_codex_711.sql')
 )
 SELECT
   e.version,
@@ -953,6 +954,8 @@ WITH expected_objects (migration, kind, schema_name, object_name, parent_name) A
   ('reposicao_ciclo_intraday', 'cron_job', 'cron', 'omie-sync-estoque-diario', ''),
   ('push_vendedora', 'table', 'public', 'push_subscriptions', ''),
   ('push_vendedora', 'index', 'public', 'idx_push_subscriptions_user', 'push_subscriptions'),
+  ('push_vendedora', 'function', 'public', 'upsert_push_subscription', ''),
+  ('push_vendedora', 'function', 'public', 'delete_push_subscription', ''),
   ('push_vendedora', 'function', 'public', '_push_enviar', ''),
   ('push_vendedora', 'function', 'public', 'push_whatsapp_inbound', ''),
   ('push_vendedora', 'function', 'public', 'push_tarefa_nova', ''),
@@ -961,7 +964,9 @@ WITH expected_objects (migration, kind, schema_name, object_name, parent_name) A
   ('push_vendedora', 'trigger', 'public', 'trg_push_tarefa_nova', 'tarefas'),
   ('push_vendedora', 'cron_job', 'cron', 'push-sla-tick', ''),
   ('push_vendedora', 'rls_policy', 'public', 'push_subscriptions_own', 'push_subscriptions'),
-  ('push_vendedora', 'rls_policy', 'public', 'push_subscriptions_service', 'push_subscriptions')
+  ('push_vendedora', 'rls_policy', 'public', 'push_subscriptions_service', 'push_subscriptions'),
+  ('reposicao_fixes_codex_711', 'function', 'public', 'gerar_pedidos_oportunidade_ciclo', ''),
+  ('reposicao_fixes_codex_711', 'function', 'public', 'reposicao_alerta_pedido_minimo_tick', '')
 )
 SELECT
   e.migration,

--- a/supabase/functions/disparar-pedidos-aprovados/index.ts
+++ b/supabase/functions/disparar-pedidos-aprovados/index.ts
@@ -1123,7 +1123,7 @@ function buildResumoEmail(
     <a href="${APP_URL}/admin/reposicao/pedidos" style="display:inline-block;background:#111827;color:#fff;padding:12px 28px;border-radius:8px;text-decoration:none;font-size:14px;font-weight:600;">Ver todos no app</a>
   </div>
 
-  ${expirados > 0 ? `<p style="margin-top:20px;font-size:11px;color:#9ca3af;text-align:center;">${expirados} pedido(s) não aprovado(s) até as 10:00 foram marcados como expirado_sem_aprovacao.</p>` : ""}
+  ${expirados > 0 ? `<p style="margin-top:20px;font-size:11px;color:#9ca3af;text-align:center;">${expirados} pedido(s) de OPORTUNIDADE não aprovado(s) até as 10:00 foram marcados como expirado_sem_aprovacao. Pedidos normais pendentes seguem vivos (o ciclo intra-day os atualiza ao longo do dia).</p>` : ""}
 </div>
 </body></html>`;
 
@@ -1239,13 +1239,20 @@ Deno.serve(async (req: Request) => {
     // disparo (corte em lote, aprovar-e-disparar, re-disparo individual, motor de retry).
     const barradosGate: ProcessResult[] = [];
     {
-      const { data: gateCfgRows } = await db
+      const { data: gateCfgRows, error: gateCfgErr } = await db
         .from("company_config")
         .select("key, value")
         .in("key", [
           "reposicao_alerta_pedido_valor_minimo",
           "reposicao_alerta_pedido_fornecedor_ilike",
         ]);
+      // Fail-CLOSED em erro de LEITURA (Codex P1.3): erro de rede/RLS aqui não pode virar
+      // "config ausente" (que desliga o gate e deixa pedido <R$3k disparar). Aborta o run
+      // inteiro ANTES de qualquer envio — o retry/cron seguinte tenta de novo. Config
+      // genuinamente ausente (query ok, 0 linhas) continua = gate desligado, por design.
+      if (gateCfgErr) {
+        throw new Error(`Config do gate de mínimo de faturamento: ${gateCfgErr.message}`);
+      }
       const cfgMap = new Map((gateCfgRows ?? []).map((r) => [r.key, r.value]));
       const gateCfg: GateConfig = {
         valorMinimo: Number(cfgMap.get("reposicao_alerta_pedido_valor_minimo") ?? NaN),
@@ -1288,7 +1295,15 @@ Deno.serve(async (req: Request) => {
     // independente no banco e segue o caminho normal (portal → Omie).
     aprovados = await dividirPedidosGrandesSayerlack(db, aprovados, modo);
 
-    // 3. Expirar não aprovados
+    // 3. Expirar OPORTUNIDADES não aprovadas (Codex P1.1 pós-intra-day).
+    // Antes expirava TODOS os pendentes do dia — no mundo intra-day isso virou contraproducente:
+    // a rodada das 12h15 UTC gerava pendentes que o corte expirava 45min depois e a rodada das
+    // 14h15 regenerava (churn + o alerta R$3k re-armava = e-mail duplicado no mesmo dia).
+    // Pendentes NORMAIS agora vivem o dia todo (a RPC os regenera a cada rodada e expira os de
+    // data_ciclo < hoje na 1ª rodada de amanhã). A oportunidade mantém a vida curta original
+    // (decisão na janela da manhã) — e NÃO pode virar zumbi: pendente eterno de oportunidade
+    // bloquearia o SKU pra sempre no NOT EXISTS da RPC normal. O .lte é backstop pra
+    // oportunidades de dias anteriores (ex.: corte que falhou).
     let expirados = 0;
     if (!pedidoId) {
       const { data: expRows, error: expErr } = await db
@@ -1298,8 +1313,9 @@ Deno.serve(async (req: Request) => {
           atualizado_em: new Date().toISOString(),
         })
         .eq("empresa", empresa)
-        .eq("data_ciclo", dataCiclo)
+        .lte("data_ciclo", dataCiclo)
         .eq("status", "pendente_aprovacao")
+        .like("tipo_ciclo", "oportunidade_%")
         .select("id");
       if (expErr) console.error("[disparar-pedidos] expirar erro:", expErr.message);
       expirados = expRows?.length ?? 0;

--- a/supabase/migrations/20260611120000_reposicao_fixes_codex_711.sql
+++ b/supabase/migrations/20260611120000_reposicao_fixes_codex_711.sql
@@ -1,0 +1,312 @@
+-- Reposição — fixes do adversarial retroativo do Codex no #711 (P1.2 + P3.2)
+-- ============================================================================
+-- Spec: docs/superpowers/specs/2026-06-09-reposicao-intraday-alerta-3k-design.md (seção pós-review)
+-- Codex xhigh 2026-06-11 (revisão retroativa, caminho B do #711). Dois fixes SQL:
+--
+-- (1) [SIMETRIA-NORMAL] gerar_pedidos_oportunidade_ciclo: a proteção anti-compra-dupla do #711
+--     era UNILATERAL — a RPC normal não re-sugere SKU em oportunidade pendente (NOT EXISTS 4/4),
+--     mas a oportunidade nascia COM SKU já presente em pedido normal economicamente ativo →
+--     janela de ~70min/dia (11h05→12h15 UTC) onde aprovar os dois = compra dupla. Agora a
+--     oportunidade DESVIA de SKU em pedido normal ativo (pendente/bloqueado/aprovado/falha_envio/
+--     disparado/concluído ≤7d — espelha a janela do em_transito). Semanticamente correto: SKU que
+--     precisa repor E tem campanha já ganha o desconto via aplicar_promocoes_no_ciclo NO pedido
+--     normal; a oportunidade é pro SKU que NÃO está em compra. O NOT EXISTS vai nos DOIS WHEREs
+--     (CTE oportunidades + INSERT de itens, que re-lê a view) — só no CTE divergiria
+--     header.num_skus × itens. Corpo = VERBATIM do schema-snapshot + as 2 marcas.
+--
+-- (2) [CAST-SEGURO] reposicao_alerta_pedido_minimo_tick: `value::numeric` com config malformada
+--     (ex.: 'abc') derrubava o tick com exceção → o alerta morria silenciosamente até alguém
+--     consertar a config. Agora cast com EXCEPTION handler → config malformada = alerta
+--     desligado (mesmo tratamento de config ausente), sem matar o cron.
+--
+-- (3) [FIX-AMBIGUIDADE] BÔNUS achado pelo PG17 ao EXECUTAR a função: o agregado final do corpo
+--     do snapshot tem `SUM(valor_total)` ambíguo com a coluna OUT homônima do RETURNS TABLE →
+--     erro de RUNTIME (o CREATE passa, late-bound). Se a def viva de prod == snapshot, a
+--     geração de oportunidades FALHAVA silenciosamente em todo dia com evento (o wrapper
+--     ciclo_oportunidade_do_dia só a chama em dia de corte de campanha/véspera de aumento;
+--     a exceção propagava e o cron dava rollback). ⚠️ Aplicar esta migration pode LIGAR a
+--     feature de pedidos de oportunidade (precedente: aplicar_promocoes, §10) — revisar a
+--     1ª rodada com evento. Por isso o pré-flight pede o functiondef VIVO de prod.
+--
+-- ⚠️ Migration MANUAL (Lovable): colar no SQL Editor → Run. PRÉ-FLIGHT (anti-drift §10): a def
+-- viva de prod de gerar_pedidos_oportunidade_ciclo deve conter 'Remove pedidos oportunidade
+-- pendentes' e NÃO conter 'SIMETRIA-NORMAL' (ver query no fim). Divergência = ABORTAR.
+-- ⚠️ REQUER redeploy da edge disparar-pedidos-aprovados (P1.1 corte expira só oportunidades +
+-- P1.3 gate fail-closed em erro de leitura da config) via chat do Lovable.
+
+BEGIN;
+
+-- ── (1) gerar_pedidos_oportunidade_ciclo com [SIMETRIA-NORMAL] ───────────────
+CREATE OR REPLACE FUNCTION public.gerar_pedidos_oportunidade_ciclo(p_empresa text DEFAULT 'OBEN'::text, p_data_ciclo date DEFAULT CURRENT_DATE, p_cenarios text[] DEFAULT ARRAY['promo_flat'::text, 'promo_volume'::text, 'promo_e_aumento'::text, 'aumento_apenas'::text]) RETURNS TABLE(pedidos_gerados integer, skus_incluidos integer, valor_total numeric, economia_bruta numeric, cenarios_cobertos text[])
+    LANGUAGE plpgsql
+    SET search_path TO 'public', 'pg_temp'
+    AS $$
+DECLARE
+  v_pedidos int := 0;
+  v_skus int := 0;
+  v_valor numeric := 0;
+  v_economia numeric := 0;
+  v_cenarios_encontrados text[];
+BEGIN
+  -- Remove pedidos oportunidade pendentes do mesmo ciclo (idempotente)
+  DELETE FROM pedido_compra_sugerido
+  WHERE empresa = p_empresa
+    AND data_ciclo = p_data_ciclo
+    AND tipo_ciclo LIKE 'oportunidade_%'
+    AND status = 'pendente_aprovacao';
+
+  -- Identifica cenários presentes
+  SELECT array_agg(DISTINCT cenario) INTO v_cenarios_encontrados
+  FROM v_oportunidade_economica_hoje
+  WHERE empresa = p_empresa
+    AND cenario = ANY(p_cenarios)
+    AND economia_bruta_estimada > 0;
+
+  -- Gera um pedido por (fornecedor, cenário_tipo)
+  -- cenário_tipo: 'promo' (inclui flat, volume, promo_e_aumento) ou 'aumento'
+  WITH oportunidades AS (
+    SELECT *,
+      CASE
+        WHEN cenario IN ('promo_flat', 'promo_volume', 'promo_e_aumento')
+          THEN 'oportunidade_promo'
+        ELSE 'oportunidade_aumento'
+      END AS tipo_ciclo_dest,
+      CASE
+        WHEN cenario IN ('promo_flat', 'promo_volume', 'promo_e_aumento')
+          THEN campanha_id
+        ELSE NULL
+      END AS evento_promo_id,
+      CASE
+        WHEN cenario = 'aumento_apenas'
+          THEN (aumentos_json -> 0 -> 0 ->> 'aumento_id')::bigint
+        ELSE NULL
+      END AS evento_aumento_id
+    FROM v_oportunidade_economica_hoje voeh
+    WHERE voeh.empresa = p_empresa
+      AND voeh.cenario = ANY(p_cenarios)
+      AND voeh.economia_bruta_estimada > 0
+      AND voeh.qtde_oportunidade > 0
+      -- [SIMETRIA-NORMAL] não oferecer SKU que JÁ está em pedido NORMAL economicamente ativo
+      -- (espelha o NOT EXISTS 4/4 da RPC normal, na direção inversa — anti compra dupla).
+      AND NOT EXISTS (
+            SELECT 1
+            FROM pedido_compra_item pcin
+            JOIN pedido_compra_sugerido pcsn ON pcsn.id = pcin.pedido_id
+            WHERE pcsn.empresa = p_empresa
+              AND COALESCE(pcsn.tipo_ciclo, 'normal') = 'normal'
+              AND pcsn.status IN ('pendente_aprovacao','bloqueado_guardrail','aprovado_aguardando_disparo','falha_envio','disparado','concluido_recebido')
+              AND pcsn.data_ciclo >= (p_data_ciclo - INTERVAL '7 days')
+              AND pcin.sku_codigo_omie = voeh.sku_codigo_omie::text
+          )
+  ),
+  pedidos_criados AS (
+    INSERT INTO pedido_compra_sugerido (
+      empresa, fornecedor_nome, grupo_codigo, data_ciclo,
+      horario_corte_planejado, valor_total, num_skus, status,
+      tipo_ciclo, origem_evento_id, origem_evento_tipo
+    )
+    SELECT
+      o.empresa,
+      o.fornecedor_nome,
+      NULL,  -- oportunidade não respeita grupo; é um pedido único por fornecedor
+      p_data_ciclo,
+      (p_data_ciclo + TIME '18:00')::timestamptz,
+      SUM(o.qtde_oportunidade * o.preco_item_eoq),
+      COUNT(*),
+      'pendente_aprovacao',
+      o.tipo_ciclo_dest,
+      COALESCE(o.evento_promo_id, o.evento_aumento_id),
+      CASE WHEN o.evento_promo_id IS NOT NULL THEN 'campanha_promocao' ELSE 'aumento_anunciado' END
+    FROM oportunidades o
+    GROUP BY o.empresa, o.fornecedor_nome, o.tipo_ciclo_dest, o.evento_promo_id, o.evento_aumento_id
+    RETURNING id, fornecedor_nome, tipo_ciclo, origem_evento_id, origem_evento_tipo
+  )
+  INSERT INTO pedido_compra_item (
+    pedido_id, sku_codigo_omie, sku_descricao,
+    estoque_atual, ponto_pedido, estoque_maximo,
+    qtde_sugerida, qtde_final, preco_unitario, valor_linha, primeira_compra,
+    modo_promocao, promocao_item_id, preco_sem_desconto, desconto_perc_aplicado,
+    economia_estimada_valor
+  )
+  SELECT
+    pc.id,
+    o.sku_codigo_omie,
+    o.sku_descricao,
+    NULL, NULL, NULL,  -- não aplicável em oportunidade
+    o.qtde_oportunidade,
+    o.qtde_oportunidade,
+    o.preco_item_eoq * (1 - o.desconto_total_perc / 100),
+    o.qtde_oportunidade * o.preco_item_eoq * (1 - o.desconto_total_perc / 100),
+    false,
+    CASE
+      WHEN o.cenario IN ('promo_flat') THEN 'flat'
+      WHEN o.cenario IN ('promo_volume', 'promo_e_aumento') THEN 'forward_buying'
+      ELSE NULL
+    END,
+    o.promo_item_id,
+    o.preco_item_eoq,
+    o.desconto_total_perc,
+    o.economia_bruta_estimada
+  FROM v_oportunidade_economica_hoje o
+  JOIN pedidos_criados pc ON (
+    pc.fornecedor_nome = o.fornecedor_nome
+    AND pc.tipo_ciclo = CASE
+      WHEN o.cenario IN ('promo_flat', 'promo_volume', 'promo_e_aumento')
+        THEN 'oportunidade_promo'
+      ELSE 'oportunidade_aumento'
+    END
+  )
+  WHERE o.empresa = p_empresa
+    AND o.cenario = ANY(p_cenarios)
+    AND o.economia_bruta_estimada > 0
+    AND o.qtde_oportunidade > 0
+    -- [SIMETRIA-NORMAL] mesmo filtro do CTE — o INSERT de itens re-lê a view; sem o espelho,
+    -- um SKU excluído do header entraria como item de pedido criado por outros SKUs.
+    AND NOT EXISTS (
+          SELECT 1
+          FROM pedido_compra_item pcin
+          JOIN pedido_compra_sugerido pcsn ON pcsn.id = pcin.pedido_id
+          WHERE pcsn.empresa = p_empresa
+            AND COALESCE(pcsn.tipo_ciclo, 'normal') = 'normal'
+            AND pcsn.status IN ('pendente_aprovacao','bloqueado_guardrail','aprovado_aguardando_disparo','falha_envio','disparado','concluido_recebido')
+            AND pcsn.data_ciclo >= (p_data_ciclo - INTERVAL '7 days')
+            AND pcin.sku_codigo_omie = o.sku_codigo_omie::text
+        );
+
+  -- Agrega retorno
+  -- [FIX-AMBIGUIDADE] o corpo do snapshot fazia SUM(valor_total) sem qualificar — colide com a
+  -- coluna OUT homônima do RETURNS TABLE → "column reference valor_total is ambiguous" em
+  -- RUNTIME (late-bound; o CREATE passa). Como o wrapper ciclo_oportunidade_do_dia só chama
+  -- esta função em dia de corte de campanha/véspera de aumento, a falha era SILENCIOSA e
+  -- ocorria exatamente nos dias com evento (rollback no cron — pedido de oportunidade nunca
+  -- nascia). Mesmo modo-de-falha do incidente aplicar_promocoes (§10). Pego pelo PG17 que
+  -- EXECUTA a função, não só a cria.
+  SELECT
+    COUNT(*),
+    COALESCE(SUM(pcs0.num_skus), 0),
+    COALESCE(SUM(pcs0.valor_total), 0)
+  INTO v_pedidos, v_skus, v_valor
+  FROM pedido_compra_sugerido pcs0
+  WHERE pcs0.empresa = p_empresa
+    AND pcs0.data_ciclo = p_data_ciclo
+    AND pcs0.tipo_ciclo LIKE 'oportunidade_%'
+    AND pcs0.status = 'pendente_aprovacao';
+
+  SELECT COALESCE(SUM(economia_estimada_valor), 0)
+  INTO v_economia
+  FROM pedido_compra_item pci
+  JOIN pedido_compra_sugerido pcs ON pcs.id = pci.pedido_id
+  WHERE pcs.empresa = p_empresa
+    AND pcs.data_ciclo = p_data_ciclo
+    AND pcs.tipo_ciclo LIKE 'oportunidade_%'
+    AND pcs.status = 'pendente_aprovacao';
+
+  RETURN QUERY SELECT v_pedidos, v_skus, v_valor, v_economia, v_cenarios_encontrados;
+END;
+$$;
+
+-- ── (2) Tick do alerta com cast seguro ───────────────────────────────────────
+-- Idêntico à 20260609150000, exceto o bloco de leitura da config ([CAST-SEGURO]).
+CREATE OR REPLACE FUNCTION public.reposicao_alerta_pedido_minimo_tick()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $$
+DECLARE
+  v_threshold numeric;
+  v_fornecedor text;
+  r RECORD;
+BEGIN
+  -- [CAST-SEGURO] config malformada (value não-numérico) não pode MATAR o tick — vira alerta
+  -- desligado, igual a config ausente (o cron continua saudável; quem mexeu na config vê o
+  -- alerta parar e conserta).
+  BEGIN
+    SELECT value::numeric INTO v_threshold
+    FROM public.company_config WHERE key = 'reposicao_alerta_pedido_valor_minimo';
+  EXCEPTION WHEN others THEN
+    v_threshold := NULL;
+  END;
+  SELECT value INTO v_fornecedor
+  FROM public.company_config WHERE key = 'reposicao_alerta_pedido_fornecedor_ilike';
+
+  IF v_threshold IS NULL OR v_threshold <= 0
+     OR v_fornecedor IS NULL OR btrim(v_fornecedor) = '' THEN
+    RETURN;
+  END IF;
+
+  FOR r IN
+    SELECT pcs.empresa, pcs.fornecedor_nome,
+           COALESCE(pcs.grupo_codigo, '') AS grupo_codigo,
+           MAX(pcs.valor_total) AS valor,
+           SUM(COALESCE(pcs.num_skus, 0)) AS num_skus,
+           MAX(pcs.id) AS pedido_id
+    FROM public.pedido_compra_sugerido pcs
+    WHERE pcs.status = 'pendente_aprovacao'
+      AND pcs.fornecedor_nome ILIKE v_fornecedor
+      AND pcs.valor_total >= v_threshold
+    GROUP BY 1, 2, 3
+  LOOP
+    INSERT INTO public.reposicao_alerta_pedido_minimo
+      (empresa, fornecedor_nome, grupo_codigo, pedido_id, valor_alertado, valor_ultimo)
+    VALUES (r.empresa, r.fornecedor_nome, r.grupo_codigo, r.pedido_id, r.valor, r.valor)
+    ON CONFLICT (empresa, fornecedor_nome, grupo_codigo) WHERE resolvido_em IS NULL
+    DO NOTHING;
+
+    IF FOUND THEN
+      INSERT INTO public.fornecedor_alerta (empresa, tipo, severidade, titulo, mensagem, status)
+      VALUES (
+        lower(r.empresa),
+        'reposicao_pedido_minimo',
+        'atencao',
+        '[Compras] Pedido ' || r.fornecedor_nome || ' atingiu R$ ' || round(r.valor)::text
+          || ' — pronto pra aprovar',
+        'O pedido sugerido de ' || r.fornecedor_nome
+          || CASE WHEN r.grupo_codigo <> '' THEN ' (grupo ' || r.grupo_codigo || ')' ELSE '' END
+          || ' acumulou R$ ' || round(r.valor)::text
+          || ' (' || r.num_skus::text || ' SKUs) — acima do mínimo de faturamento (R$ '
+          || round(v_threshold)::text || '). Aprovar dispara na hora: '
+          || 'Reposição → Pedidos (https://steu.lovable.app/admin/reposicao/pedidos). '
+          || 'Quando você aprovar (ou o pedido sair da régua), este aviso re-arma sozinho.',
+        'pendente_notificacao'
+      );
+    ELSE
+      UPDATE public.reposicao_alerta_pedido_minimo a
+      SET valor_ultimo = r.valor, pedido_id = r.pedido_id
+      WHERE a.empresa = r.empresa AND a.fornecedor_nome = r.fornecedor_nome
+        AND a.grupo_codigo = r.grupo_codigo AND a.resolvido_em IS NULL;
+    END IF;
+  END LOOP;
+
+  UPDATE public.reposicao_alerta_pedido_minimo a
+  SET resolvido_em = now()
+  WHERE a.resolvido_em IS NULL
+    AND NOT EXISTS (
+      SELECT 1 FROM public.pedido_compra_sugerido pcs
+      WHERE pcs.empresa = a.empresa
+        AND pcs.fornecedor_nome = a.fornecedor_nome
+        AND COALESCE(pcs.grupo_codigo, '') = a.grupo_codigo
+        AND pcs.status = 'pendente_aprovacao'
+        AND pcs.valor_total >= v_threshold
+    );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.reposicao_alerta_pedido_minimo_tick() FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.reposicao_alerta_pedido_minimo_tick() TO service_role;
+
+COMMIT;
+
+-- PRÉ-FLIGHT (rodar ANTES de aplicar; esperado: base_ok=true, ja_aplicada=false):
+-- SELECT
+--   (pg_get_functiondef('public.gerar_pedidos_oportunidade_ciclo(text,date,text[])'::regprocedure)
+--      LIKE '%Remove pedidos oportunidade pendentes%') AS base_ok,
+--   (pg_get_functiondef('public.gerar_pedidos_oportunidade_ciclo(text,date,text[])'::regprocedure)
+--      LIKE '%SIMETRIA-NORMAL%') AS ja_aplicada;
+--
+-- Validação (rodar após o COMMIT):
+-- SELECT 'FIXES CODEX OK' AS status,
+--   (SELECT count(*) FROM pg_proc WHERE proname='gerar_pedidos_oportunidade_ciclo'
+--     AND pg_get_functiondef(oid) LIKE '%SIMETRIA-NORMAL%') AS simetria_1,
+--   (SELECT count(*) FROM pg_proc WHERE proname='reposicao_alerta_pedido_minimo_tick'
+--     AND pg_get_functiondef(oid) LIKE '%CAST-SEGURO%') AS cast_seguro_1;


### PR DESCRIPTION
## O quê

Revisão adversarial retroativa do Codex (xhigh) no [#711](https://github.com/LucasSardenbergL/afiacao/pull/711) — fecha o "caminho B" registrado (Codex estava em usage-limit no merge). **3 P1 + 1 robustez + 1 bug pré-existente achado pelo PG17:**

1. **Corte das 13h UTC expira SÓ `oportunidade_%`** (edge `disparar-pedidos-aprovados`): no mundo intra-day, expirar pendentes normais no meio do dia criava churn (rodada 12h15 gera → corte 13h expira → rodada 14h15 regenera) + **e-mail duplicado do alerta R$3k** (resolve no gap, re-alerta depois). Pendentes normais agora vivem o dia; a RPC já os expira na 1ª rodada de amanhã. `.lte` = backstop pra oportunidades atrasadas. ⚠️ O Codex refinou meu fix original (`.lt` cego): oportunidade-zumbi bloquearia o SKU pra sempre no NOT EXISTS da RPC normal.
2. **[SIMETRIA-NORMAL]** na `gerar_pedidos_oportunidade_ciclo` (migration `20260611120000`): a proteção anti-compra-dupla do #711 era unilateral — a oportunidade nascia com SKU já em pedido normal ativo (janela ~70min/dia). Agora desvia (pendente/bloqueado/aprovado/falha_envio/disparado/concluído ≤7d), nos **2 WHEREs** (CTE + INSERT de itens — só no CTE divergiria header×itens).
3. **Gate fail-CLOSED em erro de leitura da config** (≠ ausência, que segue = gate desligado por design).
4. **[CAST-SEGURO]** no tick do alerta: config malformada não mata mais o cron (no-op limpo).

## 🔴 Bônus: bug PRÉ-EXISTENTE achado ao EXECUTAR a função no PG17

`gerar_pedidos_oportunidade_ciclo` (corpo do snapshot) tem `SUM(valor_total)` **ambíguo** com a coluna OUT do `RETURNS TABLE` → **erro de RUNTIME** (CREATE passa, late-bound). O wrapper `ciclo_oportunidade_do_dia` não tem exception handler e só chama a inner **em dia de corte de campanha/véspera de aumento** → se prod == snapshot, a geração de oportunidades **falhava silenciosamente exatamente nos dias com evento** (rollback no cron). Mesmo modo-de-falha do incidente `aplicar_promocoes` (§10). Fix: qualificação `pcs0.*` no agregado.

## Validação

- PG17: `db/test-fixes-codex-711.sh` (**5 asserts**; a view `v_oportunidade_economica_hoje` é substituída por tabela-fixture homônima — plpgsql resolve em runtime). O teste **pegou o bug da ambiguidade** justamente por executar a função.
- Lint verde (cobre as edges). Helper do gate inalterado (17 testes existentes).

## ⚠️ ATENÇÃO: migration manual + redeploy de 1 edge

1. **PRÉ-FLIGHT reforçado**: founder cola `SELECT pg_get_functiondef('public.gerar_pedidos_oportunidade_ciclo(text,date,text[])'::regprocedure);` e me manda ANTES de aplicar (se prod divergir do snapshot — ex.: Lovable já corrigiu — eu rebaseio).
2. `20260611120000_reposicao_fixes_codex_711.sql` no SQL Editor.
3. Redeploy verbatim da `disparar-pedidos-aprovados` via chat do Lovable.

⚠️ Aplicar pode **LIGAR a feature de pedidos de oportunidade** (se ela estava quebrada) — revisar a 1ª rodada com evento de campanha/aumento.

🤖 Generated with [Claude Code](https://claude.com/claude-code)