### PR TITLE
chore(omie-financeiro): remove getResumoFinanceiro morta do edge

### DIFF
--- a/supabase/functions/omie-financeiro/index.ts
+++ b/supabase/functions/omie-financeiro/index.ts
@@ -309,11 +309,6 @@ interface MovimentoRow {
   updated_at: string;
 }
 
-interface ContaSaldoRow {
-  saldo?: number | null;
-  saldo_atual?: number | null;
-}
-
 interface CategoriaDreMappingRow {
   omie_codigo: string;
   dre_linha: string;
@@ -1721,69 +1716,6 @@ async function calcularDRE(
   return snapshot;
 }
 
-// ═══════════════ RESUMO RÁPIDO (sem sync, direto do DB) ═══════════════
-async function getResumoFinanceiro(
-  db: SupabaseClient,
-  companies: Company[]
-) {
-  const resumo: Record<string, unknown> = {};
-
-  for (const company of companies) {
-    // Saldo total de contas correntes
-    const { data: contas } = await db
-      .from("fin_contas_correntes")
-      .select("descricao, saldo_atual, banco")
-      .eq("company", company)
-      .eq("ativo", true);
-
-    // Totais a receber em aberto
-    const { data: crAberto } = await db
-      .from("fin_contas_receber")
-      .select("saldo")
-      .eq("company", company)
-      .in("status_titulo", ["ABERTO", "VENCIDO", "PARCIAL"]);
-
-    // Totais a pagar em aberto
-    const { data: cpAberto } = await db
-      .from("fin_contas_pagar")
-      .select("saldo")
-      .eq("company", company)
-      .in("status_titulo", ["ABERTO", "VENCIDO", "PARCIAL"]);
-
-    // Vencidos a receber
-    const { data: crVencido } = await db
-      .from("fin_contas_receber")
-      .select("saldo")
-      .eq("company", company)
-      .eq("status_titulo", "VENCIDO");
-
-    // Vencidos a pagar
-    const { data: cpVencido } = await db
-      .from("fin_contas_pagar")
-      .select("saldo")
-      .eq("company", company)
-      .eq("status_titulo", "VENCIDO");
-
-    const sum = (arr: ContaSaldoRow[] | null) =>
-      (arr || []).reduce((s: number, r) => s + (r.saldo || 0), 0);
-
-    resumo[company] = {
-      contas_correntes: contas || [],
-      saldo_total_cc: ((contas as Array<{ saldo_atual?: number | null }> | null) || []).reduce(
-        (s: number, c) => s + (c.saldo_atual || 0),
-        0
-      ),
-      total_a_receber: sum(crAberto),
-      total_a_pagar: sum(cpAberto),
-      total_vencido_receber: sum(crVencido),
-      total_vencido_pagar: sum(cpVencido),
-      posicao_liquida: sum(crAberto) - sum(cpAberto),
-    };
-  }
-
-  return resumo;
-}
-
 // ═══════════════ HELPERS ═══════════════
 function parseOmieDate(dateStr: string | null | undefined): string | null {
   if (!dateStr) return null;
@@ -2172,11 +2104,6 @@ serve(async (req) => {
         break;
       }
 
-      case "resumo": {
-        result = await getResumoFinanceiro(supabase, targetCompanies);
-        break;
-      }
-
       // Debug: retorna JSON raw do Omie sem transformação (para validação Onda 1)
       case "debug_raw": {
         const _hoje = new Date();
@@ -2225,7 +2152,7 @@ serve(async (req) => {
             acoes_disponiveis: [
               "sync_all", "sync_categorias", "sync_contas_correntes",
               "sync_contas_pagar", "sync_contas_receber", "sync_movimentacoes",
-              "calcular_dre", "calcular_dre_year", "resumo", "debug_raw",
+              "calcular_dre", "calcular_dre_year", "debug_raw",
             ],
           }),
           { status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" } }


### PR DESCRIPTION
## O quê

Remove a função **`getResumoFinanceiro` morta** do edge `supabase/functions/omie-financeiro/index.ts` (achado do Codex).

## Por quê

O action `resumo` do edge era **código morto** — zero callers. A fonte canônica do resumo é a `getResumoFinanceiro` **client-side** em `src/services/financeiroService.ts` (já corrigida no #720 e testada). A função morta carregava **2 bugs latentes money-path**:

1. **Vocabulário de status inexistente** — filtrava `status_titulo` por `['ABERTO','VENCIDO','PARCIAL']` e `='VENCIDO'`, valores que **nunca existem nos dados** (o Omie grava `A VENCER`/`ATRASADO`/`VENCE HOJE`, ver `src/lib/financeiro/titulo-status.ts`) → todos os totais a receber/pagar/vencidos davam **R$0 silencioso** (a mesma armadilha do bug histórico do NCG=0).
2. **Sem paginação** — cap 1000 do PostgREST.

Manter uma 2ª implementação money-path divergente é a própria armadilha que o repo combate, então: deletar.

## Mudança

`1 insertion(+), 74 deletions(-)` — deleção pura de:
- a função `getResumoFinanceiro` (+ comentário de cabeçalho);
- o `case "resumo"` no dispatch;
- a string `"resumo"` na lista `acoes_disponiveis` (resposta 400);
- a interface órfã `ContaSaldoRow` (usada **só** pela função morta).

O `resumo` do **sync de movimentações** (`OmieMovimentoResumo`, `buildSyntheticMovementId`) é independente e **permanece intacto**.

## Risco de produção: nenhum

O action `resumo` nunca foi invocado → comportamento em prod **não muda**. Sem migration.

## Validação

- ✅ **Lint** (`exit 0`) — o CI linta `supabase/functions/`, então cobre o edge editado
- ✅ **Typecheck** (`tsc -p tsconfig.app.json`, `exit 0`)
- ✅ **`deno check` net-zero** — 10 erros pré-existentes idênticos antes/depois (typing do `supabase-js` + `result:unknown` em handlers `calcular_dre_year`/`debug_raw` não tocados); zero erro de sintaxe/símbolo
- ✅ **Caminho B** (review adversário próprio — cota do Codex esgotada): zero callers do action `resumo` repo-wide (frontend, outras edges, crons SQL, testes); `ContaSaldoRow` exclusiva; integridade estrutural confirmada

## ⚠️ Pós-merge

- **Redeploy do `omie-financeiro` via chat do Lovable** (verbatim da main) — **não urgente** (remoção de código morto, sem efeito observável); pode pegar carona no próximo deploy do edge por outro motivo.
- **Codex adversarial retroativo pendente** — a cota do Plus esgotou (3º strike, volta ~18:05); rodar o `/codex review` quando voltar para fechar o protocolo do CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)