### PR TITLE
feat(push): card de ativação de notificações também no MasterDashboard

### DIFF
--- a/src/components/dashboard/MasterDashboard.tsx
+++ b/src/components/dashboard/MasterDashboard.tsx
@@ -8,6 +8,7 @@ import { VisitSuggestionsCard } from './VisitSuggestionsCard';
 import { ViewAsPicker } from '@/components/impersonation/ViewAsPicker';
 import { MinhasTarefasCard } from '@/components/tarefas/MinhasTarefasCard';
 import { GestorExcecoes } from './GestorExcecoes';
+import { AtivarNotificacoesCard } from '@/components/push/AtivarNotificacoesCard';
 
 /**
  * Dashboard Master (CEO) — visão consolidada do time + KPIs próprios (você
@@ -23,6 +24,10 @@ export function MasterDashboard() {
           Visão consolidada do time. KPIs agregados, ranking de vendedores, alertas estratégicos.
         </p>
       </div>
+
+      {/* Opt-in de Web Push — master também recebe (e é o device do smoke);
+          some quando ativo/negado/sem suporte/dispensado */}
+      <AtivarNotificacoesCard />
 
       {/* Sugestões de visita — PR-VISIT-INTELLIGENCE Sub-PR A */}
       <VisitSuggestionsCard />


### PR DESCRIPTION
O card de opt-in do Web Push ([#736](https://github.com/LucasSardenbergL/afiacao/pull/736)) montava só no `FarmerDashboardV2` — o master não tinha onde ativar o push no próprio device. Necessário pro smoke ao vivo da feature (founder ativa no celular e dispara push de teste) e útil de produto (pushes futuros mirando o master). 3 linhas, componente auto-suficiente (some quando ativo/negado/dispensado).

⚠️ Requer Publish no Lovable após o merge (junto com #734/#736 — 1 Publish cobre tudo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)