### PR TITLE
test(telefonia): estabiliza Dialer.test.tsx (findBy vs lazy/Suspense sob saturação de CPU)

### DIFF
--- a/src/components/call/__tests__/Dialer.test.tsx
+++ b/src/components/call/__tests__/Dialer.test.tsx
@@ -10,15 +10,26 @@ vi.mock('@/components/call/WebRTCDialer', () => ({
 
 import { Dialer } from '../Dialer';
 
+// O WebRTCDialer é montado via React.lazy + <Suspense fallback={null}> (Dialer.tsx),
+// então o testid só aparece DEPOIS que a promise do lazy resolve e o React re-renderiza
+// — um boundary assíncrono que o mock NÃO remove (o mock troca o chunk real por um stub,
+// mas o lazy() segue resolvendo numa microtask). Na suíte completa (435 arquivos, fork
+// pool) a M2 8GB satura e o worker é descheduled por >1s, então o resolve+re-render passa
+// do teto DEFAULT de 1000ms do findBy → o teste falhava INTERMITENTE com "Unable to find
+// element" + body vazio (isolado sempre passa em ~86ms). Teto generoso (mesma filosofia do
+// testTimeout: 20000 deste projeto) elimina a falha falsa SEM afrouxar a asserção: o findBy
+// retorna assim que o elemento aparece (custo zero no caminho feliz); os 5s só ampliam a
+// janela tolerada sob contenção, e ficam bem abaixo do testTimeout de 20s (preserva a msg).
+const LAZY_RESOLVE_TIMEOUT = 5000;
+
 describe('Dialer', () => {
   it('renderiza SEMPRE o WebRTCDialer (Nvoip click-to-call descontinuado da UI)', async () => {
     render(<Dialer phoneNumber="37999998888" customerName="Cliente" />);
-    // WebRTCDialer é lazy — espera resolver
-    expect(await screen.findByTestId('webrtc-dialer')).toBeTruthy();
+    expect(await screen.findByTestId('webrtc-dialer', {}, { timeout: LAZY_RESOLVE_TIMEOUT })).toBeTruthy();
   });
 
   it('renderiza o WebRTCDialer também com floating=true', async () => {
     render(<Dialer phoneNumber="37999998888" customerName="Cliente" floating />);
-    expect(await screen.findByTestId('webrtc-dialer')).toBeTruthy();
+    expect(await screen.findByTestId('webrtc-dialer', {}, { timeout: LAZY_RESOLVE_TIMEOUT })).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Problema

`src/components/call/__tests__/Dialer.test.tsx` ("renderiza SEMPRE o WebRTCDialer") era **flaky**: passava isolado (`bunx vitest run …`) mas falhava intermitente na suíte completa (`bun run test`, 435+ arquivos) com `TestingLibraryElementError: Unable to find an element by [data-testid="webrtc-dialer"]` e o body vazio. **Não é regressão do PR #738** — só foi exposto por ele rodar a suíte completa (área de telefonia, PR #689).

## Causa-raiz (confirmada deterministicamente)

O testid `webrtc-dialer` fica atrás de um boundary assíncrono **`React.lazy` + `<Suspense fallback={null}>`** (`Dialer.tsx`). Os `vi.mock` já presentes trocam o chunk real por um stub, mas **não removem o `lazy()`** — a promise segue resolvendo numa microtask + re-render. Com o teto **default de 1000ms** do `findBy` (sem `configure` global; fork pool isolado descarta vazamento de mock entre arquivos), a suíte completa na M2 8GB satura, o worker é descheduled por >1s → o resolve+re-render perde a janela → falha com body vazio (o `Suspense fallback={null}`). Isolado resolve em ~86ms.

Prova determinística: um scratch com lazy atrasado em 1500ms reproduziu o sintoma EXATO sob 1000ms e passou sob 5000ms (scratch removido).

## Correção

Ambos os `findByTestId` passam a usar `{ timeout: 5000 }` via `LAZY_RESOLVE_TIMEOUT`, com comentário explicando o porquê (mesma filosofia do `testTimeout: 20000` do projeto).

- **Não afrouxa a asserção** — segue exigindo o testid renderizar; `findBy` retorna assim que o elemento aparece (custo zero no caminho feliz), e 5s fica bem abaixo do `testTimeout` de 20s.
- **Per-call, não `configure` global** — só este arquivo renderiza boundary lazy entre os 4 usos de `findBy` da suíte.
- **Test-only** — nenhum código de produção tocado; sem deploy/Publish.

## Verificação

- Isolado: verde (109ms).
- Suíte completa: **437 arquivos / 3078 testes, exit 0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)