### PR TITLE
fix(ui): scroll vertical preso sobre tabelas — overscroll só no eixo X

### DIFF
--- a/src/components/ui/__tests__/table-overscroll.test.ts
+++ b/src/components/ui/__tests__/table-overscroll.test.ts
@@ -1,0 +1,48 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Guarda de regressão do scroll vertical sobre tabelas/scroll-containers.
+ *
+ * Bug (commit e913836a, 2026-05-16): pra bloquear o swipe-back HORIZONTAL do
+ * navegador, foi aplicado `overscroll-behavior: contain` (o shorthand, 2 eixos)
+ * numa regra GLOBAL do index.css + na classe Tailwind `overscroll-contain` do
+ * wrapper do <Table>. O eixo Y do shorthand PRENDE o scroll vertical da página
+ * quando o cursor está sobre uma tabela sem rolagem interna própria (a tabela
+ * cresce até a altura toda → está sempre "no limite" em Y → a roda é consumida
+ * e não propaga pra página). Sintoma: o usuário não conseguia rolar a página
+ * passando o mouse sobre QUALQUER tabela do app.
+ *
+ * Fix: conter só o eixo X (`overscroll-behavior-x: contain`). O swipe-back é
+ * horizontal, então X-only protege os dois objetivos sem prender o Y.
+ *
+ * Estes asserts falham se alguém reintroduzir o shorthand de 2 eixos.
+ */
+const root = resolve(__dirname, "../../../..");
+// strip comentários CSS (/* ... */) — queremos assertar nas DECLARAÇÕES reais,
+// não no texto do comentário que (de propósito) cita o shorthand proibido.
+const indexCss = readFileSync(resolve(root, "src/index.css"), "utf8").replace(/\/\*[\s\S]*?\*\//g, "");
+const tableTsx = readFileSync(resolve(root, "src/components/ui/table.tsx"), "utf8");
+
+describe("overscroll containment — só no eixo X (não prende scroll vertical da página)", () => {
+  it("a regra global do index.css usa overscroll-behavior-x (longhand), não o shorthand de 2 eixos", () => {
+    // escopa ao BLOCO da regra global (do 1º seletor até o primeiro `}`).
+    // Sem escopo, o assert (a) passaria só porque `-x` aparece em outro
+    // seletor qualquer e (b) proibiria um containment Y legítimo/localizado
+    // em outro lugar (ex.: um modal específico). Aqui falha SE alguém reverter
+    // ESTA regra pro shorthand de 2 eixos.
+    const bloco = indexCss.match(/\[class\*="overflow-auto"\][\s\S]*?\}/)?.[0] ?? "";
+    expect(bloco).not.toBe("");
+    expect(bloco).toContain("overscroll-behavior-x: contain");
+    // o shorthand (2 eixos) NESTE bloco reintroduziria o trap vertical
+    expect(bloco).not.toMatch(/overscroll-behavior:\s*contain/);
+  });
+
+  it("o wrapper do <Table> não reaplica overscroll nos 2 eixos via classe Tailwind", () => {
+    // `overscroll-contain` (Tailwind) = overscroll-behavior: contain (X e Y)
+    expect(tableTsx).not.toContain("overscroll-contain");
+    // segue como scroll-container (pra tabelas largas rolarem na horizontal)
+    expect(tableTsx).toContain("overflow-auto");
+  });
+});

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -5,7 +5,7 @@ import { cn } from "@/lib/utils";
 const Table = React.forwardRef<HTMLTableElement, React.HTMLAttributes<HTMLTableElement>>(
   ({ className, ...props }, ref) => {
     return (
-      <div className="relative w-full overflow-auto overscroll-contain rounded-md">
+      <div className="relative w-full overflow-auto rounded-md">
         <table ref={ref} className={cn("w-full caption-bottom text-sm", className)} {...props} />
       </div>
     );

--- a/src/index.css
+++ b/src/index.css
@@ -383,16 +383,27 @@
      Bloqueia o gesto swipe-back do navegador (macOS trackpad / iOS) quando
      o usuário arrasta para a esquerda no início de um scroll horizontal.
      Sem isso, o navegador interpreta o gesto como "voltar página" e
-     recarrega a página anterior. Aplica em qualquer container de scroll
-     da app — tabelas (shadcn <Table>), wrappers .overflow-x-auto legados,
-     ScrollArea, etc. */
+     recarrega a página anterior. Aplica a qualquer elemento cuja CLASSE
+     contém overflow-* — tabelas (shadcn <Table>) e os wrappers
+     .overflow-x-auto legados. (O viewport do Radix ScrollArea NÃO tem
+     classe overflow-* → NÃO é coberto por este seletor; lacuna
+     preexistente, não objetivo deste fix.)
+
+     ⚠️ SÓ no eixo X (overscroll-behavior-X), NUNCA o shorthand
+     `overscroll-behavior: contain`. O shorthand contém também o eixo Y e
+     PRENDE o scroll vertical da página quando o cursor está sobre uma
+     tabela/scroll-container que não tem rolagem interna própria (a tabela
+     cresce até a altura toda → está sempre "no limite" em Y → a roda é
+     consumida e não propaga pra página → o usuário não consegue rolar a
+     página passando o mouse sobre a tabela). O swipe-back que esta regra
+     bloqueia é HORIZONTAL, então conter só X já protege os dois objetivos. */
   [class*="overflow-auto"],
   [class*="overflow-x-auto"],
   [class*="overflow-x-scroll"],
   [class*="overflow-y-auto"],
   [class*="overflow-y-scroll"],
   [class*="overflow-scroll"] {
-    overscroll-behavior: contain;
+    overscroll-behavior-x: contain;
   }
 
   /* ── Body scroll guarantee ──


### PR DESCRIPTION
A regra global de overscroll em index.css usava `overscroll-behavior: contain` (shorthand, 2 eixos) pra bloquear o swipe-back HORIZONTAL, mas o eixo Y prendia o scroll vertical da página quando o cursor estava sobre qualquer tabela sem rolagem interna própria (a tabela cresce até a altura toda → está sempre "no limite" em Y → a roda é consumida e não propaga pra página). Sintoma: não dava pra rolar a página passando o mouse sobre QUALQUER tabela do app.

Fix: longhand `overscroll-behavior-x: contain` (só X) na regra global + removida a classe Tailwind `overscroll-contain` (2 eixos) do wrapper do <Table>. Swipe-back horizontal segue bloqueado; scroll vertical da página restaurado.

Verificado em browser real (estilos computados antes/depois) + teste de regressão escopado ao bloco da regra. Codex review: sem P1; 2 P2 incorporados (teste escopado + comentário honesto sobre ScrollArea = lacuna preexistente).