### PR TITLE
fix(retroativo-codex): 1 P1 + 5 P2 do adversarial retroativo das Ondas 1-4 — anti-duplicata no Omie + KPI não engole título sem status

### DIFF
--- a/src/components/unified-order/ProductItemForm.tsx
+++ b/src/components/unified-order/ProductItemForm.tsx
@@ -122,7 +122,11 @@ export function ProductItemForm({
                       size="sm"
                       variant={isInCart ? 'secondary' : 'default'}
                       className="h-7 text-xs flex-1"
+                      disabled={!product.ativo}
                       onClick={() => {
+                        // Inativo no Omie era só badge — continuava adicionável
+                        // e o pedido iria com item desativado (retroativo Codex).
+                        if (!product.ativo) return;
                         onAddProduct(product, qty);
                         setQty(product.id, 1);
                       }}

--- a/src/hooks/unifiedOrder/useProductCatalog.ts
+++ b/src/hooks/unifiedOrder/useProductCatalog.ts
@@ -107,6 +107,7 @@ function scheduleStockSyncOnce(
   // Claim ANTES de entrar na queue: dois mounts concorrentes não duplicam o sync.
   lastStockSyncAt[account] = Date.now();
   stockSyncQueue = stockSyncQueue.then(async () => {
+    let completed = false;
     try {
       let nextPage: number | null = 1;
       while (nextPage) {
@@ -114,19 +115,28 @@ function scheduleStockSyncOnce(
           'omie-vendas-sync',
           { body: { action: 'sync_estoque', start_page: nextPage, account } },
         );
-        if (result.error) break;
-        nextPage = (result.data as { nextPage?: number | null } | null)?.nextPage ?? null;
+        if (result.error) break; // incompleto — o finally libera a janela
+        const proposed = (result.data as { nextPage?: number | null } | null)?.nextPage ?? null;
+        // Guard anti-loop (retroativo Codex): a edge sob rate-limit pode
+        // devolver a MESMA página — sem progresso estrito, este while
+        // re-invocaria a edge indefinidamente.
+        if (proposed !== null && proposed <= nextPage) break;
+        nextPage = proposed;
       }
+      completed = nextPage === null;
       const refreshed = await fetchProductsForAccount(account);
       if (refreshed.length > 0) publishFresh(refreshed);
     } catch (e) {
-      // Falhou → libera a janela pra próxima abertura re-tentar.
-      lastStockSyncAt[account] = 0;
       logger.error('Background stock sync error', {
         account,
         stage: 'background_stock_sync',
         error: e,
       });
+    } finally {
+      // Sync INCOMPLETO (erro ou sem progresso) não consome a janela de 10min
+      // — antes, um break por erro mantinha o claim e bloqueava o retry da
+      // próxima abertura do wizard (retroativo Codex).
+      if (!completed) lastStockSyncAt[account] = 0;
     }
   });
 }

--- a/src/hooks/useTarefas.ts
+++ b/src/hooks/useTarefas.ts
@@ -225,15 +225,28 @@ export function useTarefaMutations() {
       throw error;
     }
     if (aceitar) {
-      await tarefas().update(
+      const { error: tarefaErr } = await tarefas().update(
         { status: 'concluida', concluida_em: new Date().toISOString(), concluida_por: user!.id,
           conclusao_origem: 'sugestao_confirmada', updated_at: new Date().toISOString() } as never)
         .eq('id', tarefaId);
-      await eventos().insert(
+      if (tarefaErr) {
+        // O candidato JÁ está accepted no servidor (não reverter a sugestão);
+        // a TAREFA não concluiu — devolve o item otimista e avisa. Antes este
+        // erro era engolido: sugestão sumia, tarefa seguia aberta e a UI dizia
+        // "Confirmada" (retroativo Codex). Transação de verdade = follow-up
+        // de RPC (migration).
+        rollbackTarefa?.();
+        toast.error('Sugestão registrada, mas não consegui concluir a tarefa — use o botão Feito.');
+        invalidate();
+        throw tarefaErr;
+      }
+      const { error: evErr } = await eventos().insert(
         { tarefa_id: tarefaId, tipo_evento: 'sugestao_confirmada', ator: user!.id } as never);
+      if (evErr) console.warn('[tarefas] evento sugestao_confirmada falhou (trilha de auditoria):', evErr.message);
     } else {
-      await eventos().insert(
+      const { error: evErr } = await eventos().insert(
         { tarefa_id: tarefaId, tipo_evento: 'sugestao_rejeitada', ator: user!.id } as never);
+      if (evErr) console.warn('[tarefas] evento sugestao_rejeitada falhou (trilha de auditoria):', evErr.message);
     }
     track('tarefas.suggestion_resolved', { aceitar });
     toast.success(aceitar ? 'Confirmada' : 'Ok, segue aberta');

--- a/src/hooks/useUnifiedOrder.ts
+++ b/src/hooks/useUnifiedOrder.ts
@@ -634,6 +634,13 @@ export function useUnifiedOrder() {
 
   const submitOrder = useCallback(async () => {
     if (!selectedCustomer || cart.length === 0 || !user) return;
+    // Seleção em andamento: o ensure desta seleção ainda nem foi retido (a ref
+    // tem a promise placeholder) — o preflight fail-closed do service já
+    // bloquearia, mas barrar aqui dá feedback melhor que o erro do preflight.
+    if (loadingCustomer) {
+      toast.info('Aguarde — ainda carregando os dados do cliente.');
+      return;
+    }
     if (submittingRef.current) return; // re-entrância: ver comentário na declaração
     submittingRef.current = true;
     setSubmitting(true);
@@ -704,7 +711,7 @@ export function useUnifiedOrder() {
     notes, readyByDate, ordemCompra,
     companyProfiles, defaultProductionAssigneeId,
     getServicePrice, clearCart, isCustomerMode,
-    waitForAccountEnsure,
+    waitForAccountEnsure, loadingCustomer,
   ]);
 
   // clearCustomer defined earlier (wraps useCustomerSelection.clearCustomer + clears cart/ordemCompra/userTools)

--- a/src/lib/financeiro/__tests__/titulo-status.test.ts
+++ b/src/lib/financeiro/__tests__/titulo-status.test.ts
@@ -27,10 +27,15 @@ describe('isOpenTitleStatus', () => {
     expect(isOpenTitleStatus('STATUS_NOVO_DO_OMIE')).toBe(false);
   });
 
-  it('🔒 NÃO casa os valores LEGADO errados (ABERTO/PARCIAL/VENCIDO) — o bug que originou tudo', () => {
-    expect(isOpenTitleStatus('ABERTO')).toBe(false);
-    expect(isOpenTitleStatus('PARCIAL')).toBe(false);
-    expect(isOpenTitleStatus('VENCIDO')).toBe(false);
+  it('🔒 casa também os FALLBACKS do ingest (ABERTO/VENCIDO/PARCIAL) — defesa em profundidade', () => {
+    // Decisão revisada no retroativo Codex 2026-06-11: o ingest grava
+    // `status_titulo || 'ABERTO'` (e 'VENCIDO' quando já venceu) — sem
+    // incluí-los, título sem status some do KPI/DSO/capital de giro em
+    // silêncio. O bug HISTÓRICO era filtrar SÓ por eles (0 match) — o guard
+    // que permanece é a disjunção com liquidados (teste abaixo).
+    expect(isOpenTitleStatus('ABERTO')).toBe(true);
+    expect(isOpenTitleStatus('PARCIAL')).toBe(true);
+    expect(isOpenTitleStatus('VENCIDO')).toBe(true);
   });
 });
 
@@ -61,15 +66,15 @@ describe('classifyTituloStatus (telemetria de qualidade de dado)', () => {
 
   it('status novo do Omie / nulo → unknown (vira sinal de data-quality, não conta como aberto)', () => {
     expect(classifyTituloStatus('EM ANALISE')).toBe('unknown');
-    expect(classifyTituloStatus('ABERTO')).toBe('unknown'); // valor legado: não existe nos dados
+    expect(classifyTituloStatus('ABERTO')).toBe('open'); // fallback do ingest: conta como aberto
     expect(classifyTituloStatus(null)).toBe('unknown');
     expect(classifyTituloStatus('')).toBe('unknown');
   });
 });
 
 describe('invariantes do conjunto', () => {
-  it('OPEN_TITLE_STATUSES é exatamente os 3 nativos de aberto', () => {
-    expect([...OPEN_TITLE_STATUSES]).toEqual(['A VENCER', 'ATRASADO', 'VENCE HOJE']);
+  it('OPEN_TITLE_STATUSES = 3 nativos + 3 fallbacks do ingest', () => {
+    expect([...OPEN_TITLE_STATUSES]).toEqual(['A VENCER', 'ATRASADO', 'VENCE HOJE', 'ABERTO', 'VENCIDO', 'PARCIAL']);
   });
 
   it('nenhum status liquidado é também aberto (disjunção)', () => {

--- a/src/lib/financeiro/titulo-status.ts
+++ b/src/lib/financeiro/titulo-status.ts
@@ -22,11 +22,21 @@
  * Ao editar aqui, edite lá também.
  */
 
-/** Títulos EM ABERTO (compõem AR/AP: NCG, projeção). Valores nativos do Omie. */
-export const OPEN_TITLE_STATUSES = ['A VENCER', 'ATRASADO', 'VENCE HOJE'] as const;
+/**
+ * Títulos EM ABERTO (compõem AR/AP: NCG, projeção). Valores nativos do Omie
+ * + os FALLBACKS que o próprio ingest pode gravar (retroativo Codex 2026-06-11):
+ * o omie-financeiro faz `status_titulo || 'ABERTO'` quando o Omie não manda
+ * status e converte 'ABERTO' já vencido em 'VENCIDO'; 'PARCIAL' = baixa
+ * parcial. Investigação anterior não achou esses valores em prod (o Omie
+ * sempre manda 'A VENCER' etc.), mas o caminho de código EXISTE — sem eles
+ * aqui, um título sem status sumiria do KPI/DSO/capital de giro em silêncio.
+ * `saldo` é coluna gerada (doc − recebido) → correto pros 3 (PARCIAL conta o
+ * remanescente quando houver valor_recebido).
+ */
+export const OPEN_TITLE_STATUSES = ['A VENCER', 'ATRASADO', 'VENCE HOJE', 'ABERTO', 'VENCIDO', 'PARCIAL'] as const;
 
-/** Aberto mas NÃO vencido (exclui 'ATRASADO'). Usado só p/ adiantamentos. */
-export const OPEN_NOT_OVERDUE_TITLE_STATUSES = ['A VENCER', 'VENCE HOJE'] as const;
+/** Aberto mas NÃO vencido (exclui 'ATRASADO'/'VENCIDO'). Usado só p/ adiantamentos. */
+export const OPEN_NOT_OVERDUE_TITLE_STATUSES = ['A VENCER', 'VENCE HOJE', 'ABERTO'] as const;
 
 /** Liquidados (NÃO entram em aberto — saldo é bogus por causa do #396). */
 export const SETTLED_TITLE_STATUSES = ['RECEBIDO', 'PAGO', 'LIQUIDADO'] as const;

--- a/src/queries/useWhatsappInbox.ts
+++ b/src/queries/useWhatsappInbox.ts
@@ -99,7 +99,16 @@ export function useWhatsappThread(conversationId: string | undefined) {
             (old) => appendRealtimeMessage(old, payload.new as WaMessage),
           );
         })
-      .subscribe();
+      .subscribe((status) => {
+        // Fecha a janela SELECT→SUBSCRIBED e cobre RECONEXÕES (retroativo
+        // Codex): INSERTs antes do canal assinar (ou durante uma queda) não
+        // são retroentregues pelo realtime — sem este refetch, a mensagem
+        // ficava ausente até a próxima invalidação. O mergeThreadWindow da
+        // queryFn preserva o histórico carregado (sem flicker).
+        if (status === 'SUBSCRIBED') {
+          qc.invalidateQueries({ queryKey: ['whatsapp', 'thread', conversationId] });
+        }
+      });
     return () => { supabase.removeChannel(channel); };
   }, [conversationId, qc]);
   return q;

--- a/src/services/__tests__/somarSaldoAberto.test.ts
+++ b/src/services/__tests__/somarSaldoAberto.test.ts
@@ -62,7 +62,8 @@ describe('somarSaldoAberto (contrato do B1)', () => {
     expect(state.calls[0].tabela).toBe('fin_contas_receber');
     expect(state.calls[0].company).toBe('oben');
     expect(state.calls[0].statuses).toEqual([...OPEN_TITLE_STATUSES]);
-    expect(state.calls[0].statuses).toEqual(['A VENCER', 'ATRASADO', 'VENCE HOJE']);
+    // 3 nativos + 3 fallbacks do ingest (retroativo Codex 2026-06-11)
+    expect(state.calls[0].statuses).toEqual(['A VENCER', 'ATRASADO', 'VENCE HOJE', 'ABERTO', 'VENCIDO', 'PARCIAL']);
   });
 
   it('pagina ORDENADO por id — offset sem ORDER BY não é estável entre páginas (sync grava a cada 10min)', async () => {

--- a/supabase/functions/fin-cashflow-engine/index.ts
+++ b/supabase/functions/fin-cashflow-engine/index.ts
@@ -76,8 +76,10 @@ type Company = 'oben' | 'colacor' | 'colacor_sc';
 // NÃO incluir liquidados em "aberto": saldo é coluna gerada e valor_recebido=0
 // (#396) → liquidado tem saldo cheio → contá-lo infla o NCG em dezenas de milhões.
 // Editou aqui? Edite lá também.
-const OPEN_TITLE_STATUSES = ['A VENCER', 'ATRASADO', 'VENCE HOJE'] as const;
-const OPEN_NOT_OVERDUE_TITLE_STATUSES = ['A VENCER', 'VENCE HOJE'] as const;
+// + fallbacks do ingest ('ABERTO'/'VENCIDO' quando o Omie não manda status;
+// 'PARCIAL' = baixa parcial) — espelho de src/lib/financeiro/titulo-status.ts.
+const OPEN_TITLE_STATUSES = ['A VENCER', 'ATRASADO', 'VENCE HOJE', 'ABERTO', 'VENCIDO', 'PARCIAL'] as const;
+const OPEN_NOT_OVERDUE_TITLE_STATUSES = ['A VENCER', 'VENCE HOJE', 'ABERTO'] as const;
 const SETTLED_TITLE_STATUSES = ['RECEBIDO', 'PAGO', 'LIQUIDADO'] as const;
 const OPEN_SET = new Set<string>(OPEN_TITLE_STATUSES);
 const OPEN_NOT_OVERDUE_SET = new Set<string>(OPEN_NOT_OVERDUE_TITLE_STATUSES);

--- a/supabase/functions/omie-vendas-sync/index.ts
+++ b/supabase/functions/omie-vendas-sync/index.ts
@@ -224,7 +224,13 @@ async function callOmieVendasApi(
   endpoint: string,
   call: string,
   params: Record<string, unknown>,
-  account: Account = "oben"
+  account: Account = "oben",
+  // throwOnTransient: erro transitório que ESGOTOU os retries vira THROW em
+  // vez de null. Sem isso, o null é AMBÍGUO ("não existe" × "Omie fora do
+  // ar") — e no caminho de criação de cliente a ambiguidade vira DUPLICATA
+  // no ERP (lookup falho lido como ausência → IncluirCliente). Usar nos
+  // lookups de identidade; syncs paginados continuam tratando null como fim.
+  opts?: { throwOnTransient?: boolean },
 ): Promise<OmieGenericResponse | null> {
   const { APP_KEY, APP_SECRET } = getCredentials(account);
 
@@ -266,6 +272,9 @@ async function callOmieVendasApi(
           console.log(`[Omie Vendas][${account}] ${isRateLimit ? 'Rate limit' : 'Transient error'}, waiting ${delay/1000}s (attempt ${attempt + 1}/${maxRetries})`);
           await new Promise(r => setTimeout(r, delay));
           continue;
+        }
+        if (opts?.throwOnTransient) {
+          throw new Error(`OMIE_TRANSIENT (${account}): ${isRateLimit ? 'rate limit' : 'erro transitório'} persistiu após ${maxRetries} tentativas — não dá pra afirmar ausência`);
         }
         console.log(`[Omie Vendas][${account}] ${isRateLimit ? 'Rate limit' : 'Transient error'} persists after ${maxRetries} retries, returning null`);
         return null;
@@ -613,8 +622,15 @@ async function listarClientesVendas(searchTerm: string, account: Account = "oben
   return results;
 }
 
-// Buscar cliente na empresa de vendas pelo CPF/CNPJ
-async function buscarClienteVendas(document: string, account: Account = "oben") {
+// Buscar cliente na empresa de vendas pelo CPF/CNPJ.
+// opts.throwOnTransient: falha transitória do Omie LANÇA em vez de retornar
+// null (null = ausência CONFIRMADA) — obrigatório nos caminhos de decisão de
+// criação (anti-duplicata); enriquecimentos best-effort ficam sem.
+async function buscarClienteVendas(
+  document: string,
+  account: Account = "oben",
+  opts?: { throwOnTransient?: boolean },
+) {
   const documentClean = document.replace(/\D/g, "");
 
   const result = await callOmieVendasApi(
@@ -625,7 +641,8 @@ async function buscarClienteVendas(document: string, account: Account = "oben") 
       registros_por_pagina: 1,
       clientesFiltro: { cnpj_cpf: documentClean },
     },
-    account
+    account,
+    opts
   );
 
   const clientesArr = result?.clientes_cadastro as OmieClienteCadastro[] | undefined;
@@ -1727,7 +1744,10 @@ serve(async (req) => {
       case "buscar_cliente": {
         const { document } = params;
         if (!document) throw new Error("Documento é obrigatório");
-        const cliente = await buscarClienteVendas(document, account);
+        // Estrito: transient esgotado vira ERRO da action (o invoke do client
+        // rejeita → o tri-state marca lookupFalhou e NÃO cria às cegas) em vez
+        // de 200 com null, que o client lia como "não existe".
+        const cliente = await buscarClienteVendas(document, account, { throwOnTransient: true });
         result = { success: true, cliente };
         break;
       }
@@ -1736,15 +1756,21 @@ serve(async (req) => {
         const { document: docCriar, razao_social, nome_fantasia, endereco, endereco_numero, bairro, cidade, estado, cep, telefone, contato } = params;
         if (!docCriar || !razao_social) throw new Error("Documento e razão social são obrigatórios");
         const docClean = String(docCriar).replace(/\D/g, "");
-        // First check if already exists
-        const existingCliente = await buscarClienteVendas(docCriar, account);
+        // Lookup anti-duplicação ESTRITO (retroativo Codex): com o null
+        // ambíguo, um flake do Omie pós-retries era lido como "não existe" e
+        // o IncluirCliente abaixo criava DUPLICATA no ERP. Transient → throw
+        // → a action falha honesta e o client não cria.
+        const existingCliente = await buscarClienteVendas(docCriar, account, { throwOnTransient: true });
         if (existingCliente) {
           result = { success: true, ...existingCliente, created: false };
           break;
         }
-        // Create the client
+        // Create the client. Chave de integração DETERMINÍSTICA por
+        // conta+documento (era Date.now()): se dois caminhos tentarem criar o
+        // mesmo cliente, o Omie rejeita a 2ª por integração duplicada
+        // ("já cadastrado") em vez de aceitar uma duplicata.
         const clienteParams: Record<string, unknown> = {
-          codigo_cliente_integracao: `APP_${docClean}_${Date.now()}`,
+          codigo_cliente_integracao: `APP_${account.toUpperCase()}_${docClean}`,
           razao_social,
           nome_fantasia: nome_fantasia || razao_social,
           cnpj_cpf: docClean,


### PR DESCRIPTION
Triagem validada dos 2 passes do adversarial retroativo do Codex (gpt-5.5 high) sobre os 6 squashes da auditoria de velocidade.

**1 P1 confirmado e corrigido** — edge `omie-vendas-sync`: o `null` de "transient esgotou retries" era idêntico ao de "não existe" e o `criar_cliente` o usava como anti-duplicação antes do `IncluirCliente` → **flake do Omie virava cliente duplicado no ERP**. Fix: `throwOnTransient` nos lookups de identidade (era a Etapa 2b especada no #721) + chave de integração determinística `APP_<CONTA>_<doc>` (o Omie rejeita a 2ª criação). Syncs paginados intactos.

**5 P2 corrigidos**: `OPEN_TITLE_STATUSES` ganha os fallbacks do ingest `ABERTO`/`VENCIDO`/`PARCIAL` (título sem status sumia do KPI/DSO/capital de giro em silêncio; espelho no fin-cashflow-engine); claim do stock sync não consome a janela em erro + guard anti-loop de página; produto inativo no Omie bloqueado no carrinho (era só badge); thread do WhatsApp invalida no `SUBSCRIBED` (mensagem da janela de subscribe/reconexão não some mais); `resolverSugestao` não engole o erro do UPDATE da tarefa (rollback + toast honesto; RPC transacional = follow-up).

**2 "P1" do wizard DOWNGRADED com prova** — o preflight fail-closed do `submitOrderService` (da própria Onda 2) bloqueia conta sem identidade; ficou o guard de `loadingCustomer` como UX. Registrados: RPC SUM (offset×concorrência), keyset da thread (inalcançável), append-only por RLS, revalidação de preço no preflight.

Validação: typecheck strict + vitest **3151/3151** + lint. Sem migration.

⚠️ Pós-merge (founder): **deploy do `omie-vendas-sync` via chat do Lovable (é o P1)**; `fin-cashflow-engine` opcional; Publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
