### PR TITLE
feat(rota): #16-full fase 1 — city_norm persistida + SHADOW do filtro server-side da fila de ligação

### DIFF
--- a/db/city-norm-corpus.txt
+++ b/db/city-norm-corpus.txt
@@ -1,0 +1,57 @@
+# Corpus do harness diferencial TS×SQL de route_city_norm / normalizeCityKey.
+# 1 caso por linha (a linha INTEIRA é o input cru). Sem linhas vazias (o caso
+# "só espaços" cobre vazio). Linhas iniciadas em # são puladas nos DOIS lados.
+# ── 24 cidades da rota no formato de prod 'CIDADE (MG)' ──
+FORMIGA (MG)
+PIMENTA (MG)
+PIUMHI (MG)
+CAPITOLIO (MG)
+CLAUDIO (MG)
+ITAGUARA (MG)
+ITAUNA (MG)
+MATEUS LEME (MG)
+PARA DE MINAS (MG)
+BOM DESPACHO (MG)
+ABAETE (MG)
+MARTINHO CAMPOS (MG)
+PITANGUI (MG)
+LUZ (MG)
+NOVA SERRANA (MG)
+POMPEU (MG)
+SAO JOAO DEL REI (MG)
+SANTA CRUZ DE MINAS (MG)
+PRADOS (MG)
+OLIVEIRA (MG)
+TIRADENTES (MG)
+CARMO DA MATA (MG)
+DIVINOPOLIS (MG)
+CARMO DO CAJURU (MG)
+# ── como o cadastro real escreve (acentos + caixa mista) ──
+Divinópolis (MG)
+Itaúna (MG)
+Pará de Minas (MG)
+São João del Rei (MG)
+Cláudio (MG)
+Abaeté (MG)
+Capitólio (MG)
+Pompéu (MG)
+Conceição do Pará (MG)
+piumhi (mg)
+formiga (mg)
+# ── os 3 formatos de UF + variações ──
+Divinópolis/MG
+Divinópolis / MG
+Divinópolis MG
+divinópolis mg
+Divinópolis
+DIVINOPOLIS (TO)
+# ── espaços invisíveis (NBSP/trailing/múltiplos): GERADOS pelo harness ──
+# (db/test-city-norm-paridade.sh apensa esses casos programaticamente — chars
+#  invisíveis em arquivo estático são frágeis a editor/git.)
+# ── bordas do extrator de UF (última palavra de 2 letras) ──
+PASSO SUL
+MG
+X MG
+SETE LAGOAS - MG
+LUZ
+SAO GONCALO DO PARA (MG)

--- a/db/test-city-norm-paridade.sh
+++ b/db/test-city-norm-paridade.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# Harness DIFERENCIAL TS×SQL da normalização de cidade (#16-full):
+# prova que public.route_city_norm (migration 20260611150000) produz, byte a
+# byte, a MESMA cidade normalizada que normalizeCityKey (route-city.ts) — o
+# gate de paridade exigido pelo design (consult Codex 2026-06-11) antes de
+# qualquer corte do filtro client-side da fila de ligação.
+#
+# Corpus = db/city-norm-corpus.txt (casos visíveis) + casos INVISÍVEIS gerados
+# aqui (NBSP, múltiplos espaços, trailing). Também valida a GENERATED column
+# na customer_visit_scores REAL (snapshot de prod) + função aceita em
+# generated (IMMUTABLE de verdade).
+#
+# Corpus de PROD (opcional): se db/city-norm-corpus-prod.txt existir (gerado
+# pelo founder via SQL Editor — ver query no PR), entra no diferencial.
+#
+# Base: db/verify-snapshot-replay.sh. Pré-req: brew install postgresql@17.
+# ⚠️ initdb com locale en_US.UTF-8 (NÃO C): upper() precisa do comportamento
+# unicode de prod (Supabase = en_US.UTF-8); locale=C não converte não-ASCII.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# LC_ALL precisa ser um locale VÁLIDO no processo (postmaster no macOS aborta
+# com "became multithreaded" sem isso). en_US.UTF-8 — o MESMO do cluster
+# (initdb --locale abaixo) e do Supabase de prod (upper() unicode fiel).
+export LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
+PGVER=17
+PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+PORT=5441
+DATA="$(mktemp -d /tmp/pgtest-citynorm.XXXXXX)/data"
+WORK="$(mktemp -d /tmp/citynorm-work.XXXXXX)"
+
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente: brew install postgresql@${PGVER}"; exit 1; }
+
+CELLAR="$(brew --prefix postgresql@${PGVER})"
+cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
+mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
+cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
+
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")" "$WORK"; }
+trap cleanup EXIT
+
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=en_US.UTF-8 >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l /tmp/pg-citynorm.log -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres citynorm_verify
+P() { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d citynorm_verify "$@"; }
+
+RR="$(mktemp /tmp/snap-citynorm.XXXXXX.sql)"
+sed -E 's/^(CREATE SCHEMA public;)/-- \1/' "$REPO_ROOT/supabase/schema-snapshot.sql" \
+  | grep -vE '^\\(un)?restrict ' > "$RR"
+
+echo "→ stubs + prelude + snapshot…"
+P -v ON_ERROR_STOP=1 -q -f "$REPO_ROOT/db/stubs-supabase.sql"
+P -v ON_ERROR_STOP=1 -q -f "$REPO_ROOT/supabase/schema-extensions-prelude.sql"
+P --single-transaction -v ON_ERROR_STOP=1 -q -f "$RR"
+rm -f "$RR"
+
+echo "→ migration 20260611150000 (função + generated column + índice)…"
+P -v ON_ERROR_STOP=1 -q -f "$REPO_ROOT/supabase/migrations/20260611150000_route_city_norm.sql" >/dev/null
+
+# ── corpus EFETIVO = estático + casos invisíveis gerados ─────────────────────
+CORPUS="$WORK/corpus.txt"
+grep -v '^#' "$REPO_ROOT/db/city-norm-corpus.txt" | grep -v '^$' > "$CORPUS"
+# NBSP (U+00A0) no meio · múltiplos espaços + bordas · NBSP nas bordas · só espaços.
+# (TAB fica de fora: é delimitador do COPY text e ambos os lados o tratam via
+#  \s/[[:space:]] igualmente — a divergência que importa é NBSP/unicode.)
+printf 'NOVA\xc2\xa0SERRANA (MG)\n' >> "$CORPUS"
+printf '  Carmo   do  Cajuru  (MG)  \n' >> "$CORPUS"
+printf '\xc2\xa0Divin\xc3\xb3polis\xc2\xa0(MG)\xc2\xa0\n' >> "$CORPUS"
+printf '   \n' >> "$CORPUS"
+
+echo "→ lado TS (bun + normalizeCityKey)…"
+( cd "$REPO_ROOT" && bun scripts/city-norm-print.ts "$CORPUS" ) > "$WORK/ts.out"
+
+echo "→ lado SQL (route_city_norm)…"
+# COPY text interpreta \ como escape — o corpus não tem backslash (assert):
+if grep -q '\\' "$CORPUS"; then echo "FAIL: corpus com backslash (COPY text escaparia)"; exit 1; fi
+P -v ON_ERROR_STOP=1 -q <<SQL
+CREATE TABLE corpus_caso (id bigserial PRIMARY KEY, raw text);
+SQL
+P -v ON_ERROR_STOP=1 -q -c "\\copy corpus_caso(raw) FROM '$CORPUS'"
+P -v ON_ERROR_STOP=1 -qAt -c "SELECT coalesce(public.route_city_norm(raw), '∅') FROM corpus_caso ORDER BY id;" > "$WORK/sql.out"
+
+echo "→ diff TS × SQL (paridade byte a byte)…"
+if ! diff -u "$WORK/ts.out" "$WORK/sql.out"; then
+  echo "FAIL: TS e SQL DIVERGEM no corpus acima"; exit 1
+fi
+N_CASOS=$(wc -l < "$WORK/ts.out" | tr -d ' ')
+echo "   ✓ paridade em $N_CASOS casos"
+
+# ── corpus de PROD (opcional) ────────────────────────────────────────────────
+if [ -f "$REPO_ROOT/db/city-norm-corpus-prod.txt" ]; then
+  echo "→ corpus de PROD detectado — diferencial…"
+  PRODC="$WORK/prod.txt"
+  grep -v '^#' "$REPO_ROOT/db/city-norm-corpus-prod.txt" | grep -v '^$' > "$PRODC"
+  if grep -q '\\' "$PRODC"; then echo "FAIL: corpus de prod com backslash"; exit 1; fi
+  ( cd "$REPO_ROOT" && bun scripts/city-norm-print.ts "$PRODC" ) > "$WORK/ts-prod.out"
+  P -v ON_ERROR_STOP=1 -q -c "TRUNCATE corpus_caso;"
+  P -v ON_ERROR_STOP=1 -q -c "\\copy corpus_caso(raw) FROM '$PRODC'"
+  P -v ON_ERROR_STOP=1 -qAt -c "SELECT coalesce(public.route_city_norm(raw), '∅') FROM corpus_caso ORDER BY id;" > "$WORK/sql-prod.out"
+  if ! diff -u "$WORK/ts-prod.out" "$WORK/sql-prod.out"; then
+    echo "FAIL: TS e SQL divergem no corpus de PROD"; exit 1
+  fi
+  echo "   ✓ paridade no corpus de prod ($(wc -l < "$WORK/ts-prod.out" | tr -d ' ') cidades)"
+else
+  echo "   (corpus de prod ausente — gate final exige rodar com ele antes do corte)"
+fi
+
+# ── generated column na tabela REAL + asserts de comportamento ───────────────
+echo "→ asserts da generated column…"
+P -v ON_ERROR_STOP=1 -qAt <<'SQL'
+DO $$
+DECLARE
+  expr text;
+  got text;
+BEGIN
+  -- 1. coluna existe, é GENERATED STORED e usa a função
+  SELECT pg_get_expr(d.adbin, d.adrelid) INTO expr
+    FROM pg_attribute a
+    JOIN pg_attrdef d ON d.adrelid = a.attrelid AND d.adnum = a.attnum
+   WHERE a.attrelid = 'public.customer_visit_scores'::regclass
+     AND a.attname = 'city_norm' AND a.attgenerated = 's';
+  IF expr IS NULL OR expr NOT LIKE '%route_city_norm%' THEN
+    RAISE EXCEPTION 'FAIL: city_norm não é GENERATED STORED com route_city_norm (expr=%)', expr;
+  END IF;
+
+  -- 2. a coluna COMPUTA num INSERT real (FKs do snapshot não bloqueiam: a
+  --    tabela não tem FK pra profiles no snapshot — uuids sintéticos servem)
+  INSERT INTO public.customer_visit_scores (customer_user_id, farmer_id, city)
+  VALUES (gen_random_uuid(), gen_random_uuid(), 'Divinópolis (MG)');
+  SELECT city_norm INTO got FROM public.customer_visit_scores WHERE city = 'Divinópolis (MG)' LIMIT 1;
+  IF got IS DISTINCT FROM 'DIVINOPOLIS' THEN
+    RAISE EXCEPTION 'FAIL: generated esperava DIVINOPOLIS, veio %', got;
+  END IF;
+
+  -- 3. UF Tocantins produz o MESMO city_norm (a exclusão é client-side, por UF)
+  INSERT INTO public.customer_visit_scores (customer_user_id, farmer_id, city)
+  VALUES (gen_random_uuid(), gen_random_uuid(), 'DIVINOPOLIS (TO)');
+  IF (SELECT count(DISTINCT city_norm) FROM public.customer_visit_scores
+       WHERE city_norm = 'DIVINOPOLIS') = 0 THEN
+    RAISE EXCEPTION 'FAIL: TO deveria normalizar pra DIVINOPOLIS também';
+  END IF;
+
+  -- 4. city NULL / vazia → city_norm NULL (fica fora do índice parcial e do .in())
+  INSERT INTO public.customer_visit_scores (customer_user_id, farmer_id, city)
+  VALUES (gen_random_uuid(), gen_random_uuid(), '   ');
+  IF (SELECT city_norm FROM public.customer_visit_scores WHERE city = '   ') IS NOT NULL THEN
+    RAISE EXCEPTION 'FAIL: city só-espaços deveria dar city_norm NULL';
+  END IF;
+
+  RAISE NOTICE 'asserts generated column: OK';
+END $$;
+SQL
+
+echo ""
+echo "✅ city-norm: paridade TS×SQL + generated column OK"

--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,12 +21,12 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **197** custom migrations totais
-- **752** objetos esperados (criados por estas migrations)
+- **199** custom migrations totais
+- **757** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
-  - `function`: 192
+  - `function`: 196
   - `rls_policy`: 188
-  - `index`: 138
+  - `index`: 139
   - `cron_job`: 102
   - `table`: 88
   - `trigger`: 40
@@ -1745,6 +1745,21 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | --- | --- | --- |
 | `function` | `public.gerar_pedidos_oportunidade_ciclo` | — |
 | `function` | `public.reposicao_alerta_pedido_minimo_tick` | — |
+
+### `20260611140000_data_health_check_estoque_frescor.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `public._data_health_compute` | — |
+| `function` | `public.data_health_watchdog` | — |
+| `function` | `public.fin_sync_heartbeat` | — |
+
+### `20260611150000_route_city_norm.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `index` | `public.idx_cvs_city_norm` | `customer_visit_scores` |
+| `function` | `public.route_city_norm` | — |
 
 ## Próximos passos quando algo der `❌`
 

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 197
+-- Total de custom migrations: 199
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -216,7 +216,9 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260610130000', 'melhorias_canal', '20260610130000_melhorias_canal.sql'),
   ('20260610150000', 'reposicao_auto_aprovacao_piloto', '20260610150000_reposicao_auto_aprovacao_piloto.sql'),
   ('20260610200000', 'push_vendedora', '20260610200000_push_vendedora.sql'),
-  ('20260611120000', 'reposicao_fixes_codex_711', '20260611120000_reposicao_fixes_codex_711.sql')
+  ('20260611120000', 'reposicao_fixes_codex_711', '20260611120000_reposicao_fixes_codex_711.sql'),
+  ('20260611140000', 'data_health_check_estoque_frescor', '20260611140000_data_health_check_estoque_frescor.sql'),
+  ('20260611150000', 'route_city_norm', '20260611150000_route_city_norm.sql')
 )
 SELECT
   e.version,
@@ -986,7 +988,12 @@ WITH expected_objects (migration, kind, schema_name, object_name, parent_name) A
   ('push_vendedora', 'rls_policy', 'public', 'push_subscriptions_own', 'push_subscriptions'),
   ('push_vendedora', 'rls_policy', 'public', 'push_subscriptions_service', 'push_subscriptions'),
   ('reposicao_fixes_codex_711', 'function', 'public', 'gerar_pedidos_oportunidade_ciclo', ''),
-  ('reposicao_fixes_codex_711', 'function', 'public', 'reposicao_alerta_pedido_minimo_tick', '')
+  ('reposicao_fixes_codex_711', 'function', 'public', 'reposicao_alerta_pedido_minimo_tick', ''),
+  ('data_health_check_estoque_frescor', 'function', 'public', '_data_health_compute', ''),
+  ('data_health_check_estoque_frescor', 'function', 'public', 'data_health_watchdog', ''),
+  ('data_health_check_estoque_frescor', 'function', 'public', 'fin_sync_heartbeat', ''),
+  ('route_city_norm', 'index', 'public', 'idx_cvs_city_norm', 'customer_visit_scores'),
+  ('route_city_norm', 'function', 'public', 'route_city_norm', '')
 )
 SELECT
   e.migration,

--- a/scripts/city-norm-print.ts
+++ b/scripts/city-norm-print.ts
@@ -1,0 +1,25 @@
+/**
+ * Lado TS do harness diferencial de paridade city-norm (db/test-city-norm-paridade.sh).
+ * Lê o corpus (1 caso cru por linha; linhas '#' e vazias são puladas) e imprime
+ * UMA linha por caso: a cidade normalizada por normalizeCityKey, ou ∅ pra null.
+ * O lado SQL (route_city_norm) imprime no MESMO formato — diff byte a byte.
+ *
+ * Uso: bun scripts/city-norm-print.ts db/city-norm-corpus.txt
+ */
+import { readFileSync } from 'node:fs';
+import { normalizeCityKey } from '../src/lib/whatsapp/route-city';
+
+const path = process.argv[2];
+if (!path) {
+  console.error('uso: bun scripts/city-norm-print.ts <corpus.txt>');
+  process.exit(1);
+}
+
+// split por \n APENAS (não \r\n — o corpus é LF; um \r entraria como input,
+// o que é desejável: o lado SQL receberia o mesmo \r).
+const lines = readFileSync(path, 'utf8').split('\n');
+for (const line of lines) {
+  if (line === '' || line.startsWith('#')) continue;
+  const k = normalizeCityKey(line);
+  console.log(k?.city ?? '∅');
+}

--- a/src/queries/useRouteContactList.ts
+++ b/src/queries/useRouteContactList.ts
@@ -8,6 +8,7 @@ import type { ContactCandidate, ContactConfig, ScoredCandidate } from '@/lib/wha
 import { spBusinessDate } from '@/lib/time/sp-day';
 import { derivarSinaisContato, type ContatoLog, type OutcomeStatus, type SinaisContato } from '@/lib/route/route-outcome';
 import { logger } from '@/lib/logger';
+import { track } from '@/lib/analytics';
 
 interface VisitScoreRow {
   customer_user_id: string;
@@ -162,6 +163,40 @@ async function fetchAllVisitScores(): Promise<VisitScoreRow[]> {
   return out;
 }
 
+/**
+ * #16-full (fase 1, SHADOW): candidatos filtrados NO SERVIDOR pela coluna
+ * persistida city_norm (migration 20260611150000 — generated column que
+ * espelha a parte-cidade do normalizeCityKey; paridade provada pelo harness
+ * db/test-city-norm-paridade.sh). O filtro server é um SUPERSET seguro: só
+ * cidade, NUNCA UF — quem julga a UF segue sendo o cityKeyEquals no client
+ * (semântica assimétrica: cadastro sem UF casa por cidade). Durante o shadow
+ * (7 dias úteis), o resultado EXIBIDO continua vindo do full-fetch legado;
+ * esta query roda em paralelo só pra telemetria de divergência.
+ */
+async function fetchVisitScoresByCityNorm(cityNorms: string[]): Promise<VisitScoreRow[]> {
+  const baseSelect = (withCount: boolean) =>
+    supabase
+      .from('customer_visit_scores')
+      .select('customer_user_id, farmer_id, city, visit_score', withCount ? { count: 'exact' } : undefined)
+      .in('city_norm' as never, cityNorms)
+      .order('customer_user_id', { ascending: true });
+
+  const first = await baseSelect(true).range(0, PAGE - 1);
+  if (first.error) throw first.error;
+  const out: VisitScoreRow[] = [...((first.data ?? []) as VisitScoreRow[])];
+  const total = first.count ?? out.length;
+  if (total > PAGE) {
+    const ranges: Array<[number, number]> = [];
+    for (let from = PAGE; from < total; from += PAGE) ranges.push([from, from + PAGE - 1]);
+    const pages = await Promise.all(ranges.map(([f, t]) => baseSelect(false).range(f, t)));
+    for (const p of pages) {
+      if (p.error) throw p.error;
+      out.push(...((p.data ?? []) as VisitScoreRow[]));
+    }
+  }
+  return out;
+}
+
 async function fetchMetrics(ids: string[]): Promise<MetricRow[]> {
   const out: MetricRow[] = [];
   for (let i = 0; i < ids.length; i += IN_CHUNK) {
@@ -214,7 +249,16 @@ export function useRouteContactList(workdayIso: string) {
       if (prep.cities.length === 0) return empty;
 
       // 2) candidatos das cidades-alvo (customer_visit_scores é city-aware + RLS por carteira)
-      const allScores = await fetchAllVisitScores();
+      // SHADOW #16-full: a query server-side (city_norm) roda em PARALELO ao
+      // full-fetch legado, com fail-open TOTAL — erro (ex.: migration ainda
+      // não aplicada → coluna inexistente) vira telemetria, nunca afeta a fila.
+      const cityNorms = [...new Set(prep.cities.map(c => c.city))];
+      const [allScores, shadowRes] = await Promise.all([
+        fetchAllVisitScores(),
+        fetchVisitScoresByCityNorm(cityNorms)
+          .then(rows => ({ ok: true as const, rows }))
+          .catch((e: unknown) => ({ ok: false as const, err: e instanceof Error ? e.message : String(e) })),
+      ]);
       const candsFiltrados = allScores.filter(r => {
         const ck = normalizeCityKey(r.city);
         return ck !== null && prep.cities.some(pc => cityKeyEquals(pc, ck));
@@ -227,6 +271,37 @@ export function useRouteContactList(workdayIso: string) {
         if (!candByUser.has(r.customer_user_id)) candByUser.set(r.customer_user_id, r);
       }
       const cands0 = [...candByUser.values()];
+
+      // Telemetria do shadow: aplica o MESMO filtro client (cityKeyEquals) ao
+      // resultado do servidor e compara os conjuntos de clientes. Só
+      // contagens/direção — sem IDs (PII). Critério de corte (Codex): 7 dias
+      // úteis com faltando_no_novo=0 nas cidades exercitadas → aí o
+      // full-fetch sai e o .in(city_norm) vira a fonte (PR futuro).
+      if (shadowRes.ok) {
+        const novoIds = new Set(
+          shadowRes.rows
+            .filter(r => {
+              const ck = normalizeCityKey(r.city);
+              return ck !== null && prep.cities.some(pc => cityKeyEquals(pc, ck));
+            })
+            .map(r => r.customer_user_id),
+        );
+        const legacyIds = new Set(cands0.map(c => c.customer_user_id));
+        let faltandoNoNovo = 0;
+        for (const id of legacyIds) if (!novoIds.has(id)) faltandoNoNovo++;
+        let sobrandoNoNovo = 0;
+        for (const id of novoIds) if (!legacyIds.has(id)) sobrandoNoNovo++;
+        track('rota.city_shadow', {
+          legacy: legacyIds.size,
+          novo: novoIds.size,
+          faltando_no_novo: faltandoNoNovo,
+          sobrando_no_novo: sobrandoNoNovo,
+          cidades: prep.cities.length,
+        });
+      } else {
+        track('rota.city_shadow', { erro: true, mensagem: shadowRes.err.slice(0, 120) });
+      }
+
       if (cands0.length === 0) return empty;
 
       // 3) métricas econômicas + perfis (nome/telefone) em lote

--- a/supabase/migrations/20260611150000_route_city_norm.sql
+++ b/supabase/migrations/20260611150000_route_city_norm.sql
@@ -1,0 +1,92 @@
+-- ============================================================================
+-- #16-full (fase 1, SHADOW): cidade normalizada PERSISTIDA em
+-- customer_visit_scores — pré-requisito do filtro server-side da fila de
+-- ligação por rota (/rota/ligacoes), que hoje baixa ~7k linhas e filtra
+-- cidade no client (normalizeCityKey/cityKeyEquals).
+--
+-- Desenho (consult Codex 2026-06-11, gpt-5.5):
+--   - city_norm = GENERATED ALWAYS ... STORED: sem trigger, sem backfill
+--     (o ALTER calcula as linhas existentes), sem writers a mudar.
+--   - A funcao route_city_norm e IMMUTABLE e espelha SO a parte CIDADE do
+--     normalizeCityKey TS (src/lib/whatsapp/route-city.ts). A UF continua
+--     sendo julgada no CLIENT (cityKeyEquals, semantica assimetrica
+--     deliberada: cadastro sem UF casa por cidade) -- o filtro server e um
+--     SUPERSET seguro (.in('city_norm', cidades)), nunca exclui por UF.
+--   - SEM unaccent(): a extensao e STABLE no PG17, inelegivel pra generated
+--     column. O strip de acentos usa normalize(s, NFD) (core, IMMUTABLE) +
+--     remocao dos combining marks U+0300..U+036F -- paridade com o TS.
+--   - Paridade TS x SQL provada por harness diferencial em PG17
+--     (db/test-city-norm-paridade.sh) sobre corpus de cidades reais +
+--     adversariais. O corte do full-fetch so apos 7 dias uteis de SHADOW
+--     (o frontend roda as 2 queries, EXIBE a legada e loga divergencia).
+--
+-- ATENCAO Lovable: migration MANUAL -- colar este bloco no SQL Editor + Run.
+-- ============================================================================
+
+-- Espelho da parte-cidade de normalizeCityKey (route-city.ts). Ordem IDENTICA:
+-- espacos-unicode -> ASCII | NFD + strip combining | UPPER | trim | extrai UF
+-- ("(MG)" | "/MG" | ultima palavra de 2 letras) so pra REMOVE-LA | colapsa
+-- espacos. Editar AQUI exige editar o TS, re-rodar o harness de paridade e
+-- RECOMPUTAR a coluna (DROP COLUMN + ADD COLUMN -- generated nao re-deriva
+-- sozinha quando a funcao muda).
+-- Os \uXXXX abaixo sao interpretados pelo motor de regex ARE do Postgres
+-- (string sem E'' passa o texto cru pro regex) -- deliberadamente NAO usamos
+-- os caracteres literais (invisiveis, frageis a editor/copy-paste).
+CREATE OR REPLACE FUNCTION public.route_city_norm(raw text)
+RETURNS text
+LANGUAGE plpgsql
+IMMUTABLE
+PARALLEL SAFE
+SET search_path = ''
+AS $func$
+DECLARE
+  s text;
+BEGIN
+  IF raw IS NULL THEN
+    RETURN NULL;
+  END IF;
+  -- Espacos unicode que o \s do JS reconhece (e o [[:space:]] POSIX nao) ->
+  -- espaco ASCII, pra paridade com o split/replace(\s) do TS.
+  s := regexp_replace(raw, '[   -     　﻿]', ' ', 'g');
+  -- stripAccents (NFD + remove combining marks U+0300..U+036F) -> UPPER ->
+  -- trim (ordem identica ao TS).
+  s := btrim(upper(regexp_replace(normalize(s, NFD), '[̀-ͯ]', '', 'g')));
+  IF s = '' THEN
+    RETURN NULL;
+  END IF;
+  -- Extracao de UF (mesma precedencia do TS) -- descartada: city_norm e so a cidade.
+  IF s ~ '\([A-Z]{2}\)\s*$' THEN
+    s := btrim(regexp_replace(s, '\([A-Z]{2}\)\s*$', ''));
+  ELSIF s ~ '/\s*[A-Z]{2}\s*$' THEN
+    s := btrim(regexp_replace(s, '/\s*[A-Z]{2}\s*$', ''));
+  ELSIF s ~ '\s[A-Z]{2}$' THEN
+    s := btrim(regexp_replace(s, '\s+[A-Z]{2}$', ''));
+  END IF;
+  s := btrim(regexp_replace(s, '\s+', ' ', 'g'));
+  RETURN nullif(s, '');
+END
+$func$;
+
+-- anon/authenticated nao precisam executar a funcao diretamente (a coluna
+-- gerada e computada pelo dono da tabela); revogar reduz superficie.
+REVOKE EXECUTE ON FUNCTION public.route_city_norm(text) FROM PUBLIC, anon, authenticated;
+
+ALTER TABLE public.customer_visit_scores
+  ADD COLUMN IF NOT EXISTS city_norm text
+  GENERATED ALWAYS AS (public.route_city_norm(city)) STORED;
+
+CREATE INDEX IF NOT EXISTS idx_cvs_city_norm
+  ON public.customer_visit_scores (city_norm)
+  WHERE city_norm IS NOT NULL;
+
+-- Validacao (esperado: func_ok=1 | col_ok=1 | idx_ok=1 | norm_null_com_city=0)
+SELECT 'BLOCO A OK' AS status,
+  (SELECT count(*) FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public' AND p.proname = 'route_city_norm') AS func_ok,
+  (SELECT count(*) FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'customer_visit_scores'
+      AND column_name = 'city_norm') AS col_ok,
+  (SELECT count(*) FROM pg_indexes
+    WHERE schemaname = 'public' AND indexname = 'idx_cvs_city_norm') AS idx_ok,
+  (SELECT count(*) FROM public.customer_visit_scores
+    WHERE city IS NOT NULL AND btrim(city) <> '' AND city_norm IS NULL) AS norm_null_com_city;


### PR DESCRIPTION
## #16-full fase 1 — `city_norm` persistida + SHADOW do filtro server-side da fila de ligação

Desenho do **consult Codex** (2026-06-11): `GENERATED ALWAYS STORED` (sem trigger, sem backfill, sem `uf_norm`) com função `route_city_norm` IMMUTABLE espelhando a parte-cidade do `normalizeCityKey` — **sem `unaccent()`** (STABLE no PG17, inelegível); NFD via `normalize()` core + strip de combining marks, escapes `\uXXXX` explícitos. O filtro server `.in('city_norm', cidades)` é **superset seguro**: a UF segue sendo julgada no client (`cityKeyEquals` assimétrico — cadastro sem UF casa por cidade; DIVINÓPOLIS/TO segue excluída no client).

**Paridade TS×SQL provada**: harness diferencial PG17 (`db/test-city-norm-paridade.sh`) — **51 casos byte a byte** (24 cidades no formato de prod, acentuadas, 3 formatos de UF, NBSP/espaços gerados programaticamente, bordas do extrator) + asserts da generated column na `customer_visit_scores` real. Cluster e processo em `en_US.UTF-8` (upper() unicode fiel a prod).

**SHADOW (7 dias úteis, fail-open total)**: o hook roda as DUAS queries em paralelo, **exibe a fila legada** (o desenho "servidor filtra e cliente loga" não detecta falso negativo — pegou no consult) e manda `rota.city_shadow` pro PostHog (contagens + direção, sem PII). Erro da query nova (ex.: migration ainda não aplicada) vira telemetria, nunca toca a fila — **o front pode ir ao ar antes da migration**.

**Critério de corte** (PR futuro): `faltando_no_novo=0` por 7 dias úteis + paridade no corpus de PROD (`db/city-norm-corpus-prod.txt`, gerado pelo founder — query no comentário do PR).

## ⚠️ Migration manual (founder)
`supabase/migrations/20260611150000_route_city_norm.sql` — colar no SQL Editor → Run → conferir `BLOCO A OK | 1 | 1 | 1 | 0`.

Validação: typecheck strict + vitest **3151/3151** + lint + audit regenerado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
