### PR TITLE
fix(rota): classes regex do route_city_norm em escapes \uXXXX ASCII (anti-corrupção no copy-paste do SQL Editor)

### DIFF
--- a/supabase/migrations/20260611150000_route_city_norm.sql
+++ b/supabase/migrations/20260611150000_route_city_norm.sql
@@ -47,10 +47,10 @@ BEGIN
   END IF;
   -- Espacos unicode que o \s do JS reconhece (e o [[:space:]] POSIX nao) ->
   -- espaco ASCII, pra paridade com o split/replace(\s) do TS.
-  s := regexp_replace(raw, '[   -     　﻿]', ' ', 'g');
+  s := regexp_replace(raw, '[\u00A0\u1680\u2000-\u200A\u2028\u2029\u202F\u205F\u3000\uFEFF]', ' ', 'g');
   -- stripAccents (NFD + remove combining marks U+0300..U+036F) -> UPPER ->
   -- trim (ordem identica ao TS).
-  s := btrim(upper(regexp_replace(normalize(s, NFD), '[̀-ͯ]', '', 'g')));
+  s := btrim(upper(regexp_replace(normalize(s, NFD), '[\u0300-\u036F]', '', 'g')));
   IF s = '' THEN
     RETURN NULL;
   END IF;


### PR DESCRIPTION
Fix-forward do #759 (mergeou antes deste commit): as 2 classes de regex tinham caracteres unicode LITERAIS (invisíveis) — copy-paste do bloco pro SQL Editor poderia corrompê-los em silêncio, e esse é o canal de aplicação da migration. Agora são escapes \uXXXX ASCII (o ARE do Postgres interpreta; harness re-validado: paridade TS×SQL 51 casos + generated column OK).

⚠️ O BLOCO A que o founder vai colar é o DESTA versão.

🤖 Generated with [Claude Code](https://claude.com/claude-code)