### PR TITLE
fix(shell): limpa topbar por persona — escudo gestor/master, ajuda se…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,7 +187,7 @@ Seções: Principal · Afiação · Vendas · Estoque · Reposição · Produç�
 
 ### Topbar (`AppShell.tsx`)
 
-Mobile menu (lg:hidden) · **Cmd-K pill central** (`CommandPaletteTrigger`) · **CompanySwitcher** (monograma colorido por empresa) · **NetworkStatusIndicator** (some quando online+fila vazia; shake/pulse quando offline/slow) · **ThemeToggle** · HelpDrawer · dropdown User. O `Bell` ornamental foi removido.
+Mobile menu (lg:hidden) · **Cmd-K pill central** (`CommandPaletteTrigger`) · `ActiveOverrideBadge` · **CompanySwitcher** (monograma colorido por empresa) · **NetworkStatusIndicator** (⚠️ **sempre visível** — sinal contínuo de rede; online = Wi-Fi verde sutil, offline/slow = shake/pulse. A doc antiga dizia "some quando online+fila vazia" — **falso**, renderiza sempre. Popover com **Tipo/RTT só p/ staff** [`displayIsStaff`, lente-aware desde 2026-06-11]; status + fila "Operações pendentes" p/ todos) · **DataHealthBadge** (escudo de saúde de dados; só aparece em vermelho/âmbar — verde não polui — e **só p/ gestor/master** via `useDisplayAccess`, lente-aware; **apertado de `isStaff`→gestor/master em 2026-06-11** junto com o item de menu "Saúde de Dados", senão vendedora sales-only via o atalho sem ver o item) · **ThemeToggle** · botão **Melhorias** (Lightbulb, `displayIsStaff`) · **HelpDrawer** (esconde o "?" em rotas **sem ajuda mapeada** desde 2026-06-11 — antes abria painel "nada encontrado"; X duplicado removido) · dropdown User. O `Bell` ornamental foi removido.
 
 ---
 

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -177,7 +177,7 @@ const unifiedNavSections: { title: string; items: NavItem[] }[] = [
       { icon: Factory, label: 'Processos padrão', path: '/admin/standard-processes' },
       { icon: Shield, label: 'Admin & Relatórios', path: '/gestao/admin', staffOnly: true },
       { icon: Lock, label: 'Governança', path: '/gestao/governanca', staffOnly: true },
-      { icon: ShieldCheck, label: 'Saúde de Dados', path: '/gestao/saude-dados', staffOnly: true },
+      { icon: ShieldCheck, label: 'Saúde de Dados', path: '/gestao/saude-dados', gestorComercialOuMaster: true },
       { icon: MessageCircle, label: 'SLA WhatsApp', path: '/whatsapp/sla', gestorComercialOuMaster: true },
       { icon: Lightbulb, label: 'Melhorias (fila)', path: '/gestao/melhorias', masterOnly: true },
     ],

--- a/src/components/help/HelpDrawer.tsx
+++ b/src/components/help/HelpDrawer.tsx
@@ -1,6 +1,6 @@
 import { lazy, Suspense, useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
-import { HelpCircle, X } from 'lucide-react';
+import { HelpCircle } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from '@/components/ui/sheet';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -52,8 +52,8 @@ export function HelpDrawer({ anchor, module, trigger }: HelpDrawerProps) {
   };
 
   const routeMapping = getHelpMappingForRoute(location.pathname);
-  const resolvedModuleSlug = module ?? routeMapping.module;
-  const resolvedAnchor = anchor ?? routeMapping.anchor;
+  const resolvedModuleSlug = module ?? routeMapping?.module;
+  const resolvedAnchor = anchor ?? routeMapping?.anchor;
 
   // ESC closes (Sheet handles it natively, kept here for completeness)
   useEffect(() => {
@@ -64,6 +64,11 @@ export function HelpDrawer({ anchor, module, trigger }: HelpDrawerProps) {
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
   }, [open]);
+
+  // Sem override de prop e sem ajuda mapeada p/ a rota atual → não há o que
+  // mostrar: esconde o botão "?" em vez de abrir um drawer "nenhuma seção
+  // encontrada". (Vem DEPOIS dos hooks acima p/ não violar as regras de hooks.)
+  if (!resolvedModuleSlug || !resolvedAnchor) return null;
 
   return (
     <Sheet open={open} onOpenChange={handleOpenChange}>
@@ -80,17 +85,10 @@ export function HelpDrawer({ anchor, module, trigger }: HelpDrawerProps) {
         )}
       </SheetTrigger>
       <SheetContent side="right" className="w-full sm:max-w-md md:max-w-lg p-0 flex flex-col">
-        <SheetHeader className="px-6 py-4 border-b border-border flex-row items-center justify-between space-y-0">
+        <SheetHeader className="px-6 py-4 border-b border-border space-y-0">
+          {/* O X de fechar vem do próprio SheetContent (shadcn), no canto
+              superior direito — não duplicar aqui (dava dois "X" sobrepostos). */}
           <SheetTitle className="text-base font-semibold">Ajuda contextual</SheetTitle>
-          <Button
-            variant="ghost"
-            size="icon"
-            className="h-7 w-7"
-            onClick={() => setOpen(false)}
-            aria-label="Fechar"
-          >
-            <X className="h-4 w-4" />
-          </Button>
         </SheetHeader>
 
         {hasOpened && (

--- a/src/components/shell/DataHealthBadge.tsx
+++ b/src/components/shell/DataHealthBadge.tsx
@@ -2,17 +2,24 @@ import { useNavigate } from 'react-router-dom';
 import { ShieldAlert, ShieldQuestion } from 'lucide-react';
 import { useDataHealth } from '@/hooks/useDataHealth';
 import { badgeLevel } from '@/lib/dataHealth/health-helpers';
-import { useAuth } from '@/contexts/AuthContext';
+import { useDisplayAccess } from '@/hooks/useDisplayAccess';
 import { cn } from '@/lib/utils';
 
 export function DataHealthBadge() {
   const navigate = useNavigate();
-  const { isStaff } = useAuth();
-  // Gate na QUERY, não só na UI: sem o `isStaff` aqui, cliente final executava
-  // a RPC get_data_health (14 checks) a cada 2min mesmo sem ver o badge.
-  const { data, isError } = useDataHealth(isStaff);
+  // Saúde de dados é tarefa de quem ADMINISTRA o sistema (master/gestor), não de
+  // qualquer funcionário: uma vendedora não tem o que fazer com "sync stale" nem
+  // com a instrução de TI que a tela exibe ("rode sync_X no chat do Lovable").
+  // Antes o gate era `isStaff` puro — aparecia até p/ vendedora sales-only, que
+  // nem vê o item "Saúde de Dados" no menu (inconsistência). Lente-aware
+  // (useDisplayAccess): some quando o master "vira" vendedora na lente.
+  // Gate na QUERY também, não só na UI: sem ele, o employee executava a RPC
+  // get_data_health (14 checks) a cada 2min sem ver o badge.
+  const { displayIsMaster, displayIsGestorComercial } = useDisplayAccess();
+  const podeVer = displayIsMaster || displayIsGestorComercial;
+  const { data, isError } = useDataHealth(podeVer);
 
-  if (!isStaff) return null;
+  if (!podeVer) return null;
 
   const level = isError ? 'red' : badgeLevel(data ?? []);
   if (level === 'green') return null; // verde não polui o topbar

--- a/src/components/shell/NetworkStatusIndicator.tsx
+++ b/src/components/shell/NetworkStatusIndicator.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { Wifi, WifiOff, Cloud, CloudOff } from 'lucide-react';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { useNetworkStatus } from '@/hooks/useNetworkStatus';
+import { useDisplayAccess } from '@/hooks/useDisplayAccess';
 import { cn } from '@/lib/utils';
 import { getOfflineQueueDepth, subscribeToOfflineQueue } from '@/lib/offline-queue';
 
@@ -19,6 +20,11 @@ import { getOfflineQueueDepth, subscribeToOfflineQueue } from '@/lib/offline-que
  */
 export function NetworkStatusIndicator() {
   const status = useNetworkStatus();
+  // Tipo de conexão (4g) e RTT em ms são jargão de engenharia — úteis p/ staff
+  // diagnosticar, ruído p/ vendedora/cliente. Lente-aware: na lente "como
+  // vendedora", o popover técnico some. O ícone e o status legível (Online /
+  // Offline / fila) ficam p/ todos — a persona offline é justamente a vendedora.
+  const { displayIsStaff } = useDisplayAccess();
   const [queueDepth, setQueueDepth] = useState(0);
 
   useEffect(() => {
@@ -77,20 +83,20 @@ export function NetworkStatusIndicator() {
           {tone.label}
         </div>
         <dl className="text-xs text-muted-foreground space-y-1">
-          {status.effectiveType && (
+          {displayIsStaff && status.effectiveType && (
             <div className="flex justify-between">
               <dt>Tipo</dt>
               <dd className="font-mono text-foreground">{status.effectiveType}</dd>
             </div>
           )}
-          {status.rttMs !== null && (
+          {displayIsStaff && status.rttMs !== null && (
             <div className="flex justify-between">
               <dt>RTT estimado</dt>
               <dd className="font-mono text-foreground">{status.rttMs}ms</dd>
             </div>
           )}
           <div className="flex justify-between">
-            <dt>Mutações na fila</dt>
+            <dt>Operações pendentes</dt>
             <dd className={cn('font-mono', queueDepth > 0 ? 'text-status-warning' : 'text-foreground')}>
               {queueDepth}
             </dd>

--- a/src/lib/__tests__/help-utils.test.ts
+++ b/src/lib/__tests__/help-utils.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { getHelpMappingForRoute, hasHelpForRoute } from '../help-utils';
+
+describe('getHelpMappingForRoute', () => {
+  it('retorna null em rota sem ajuda mapeada (antes caía no fallback genérico → painel "nada encontrado")', () => {
+    expect(getHelpMappingForRoute('/meu-dia')).toBeNull();
+    expect(getHelpMappingForRoute('/financeiro/cockpit')).toBeNull();
+    expect(getHelpMappingForRoute('/sales')).toBeNull();
+    expect(getHelpMappingForRoute('/')).toBeNull();
+  });
+
+  it('casa a regra ESPECÍFICA antes da genérica do mesmo módulo (prioridade por ordem)', () => {
+    expect(getHelpMappingForRoute('/admin/des/trimestre-atual')).toEqual({
+      module: 'avaliacao-trimestral-des',
+      anchor: 'posicao-ao-vivo',
+    });
+    expect(getHelpMappingForRoute('/admin/des/configuracao')).toEqual({
+      module: 'avaliacao-trimestral-des',
+      anchor: 'visao-geral-do-programa-des',
+    });
+    // /admin/des sem sufixo cai na regra genérica do próprio módulo
+    expect(getHelpMappingForRoute('/admin/des')).toEqual({
+      module: 'avaliacao-trimestral-des',
+      anchor: 'visao-geral-do-programa-des',
+    });
+  });
+
+  it('mapeia reposição: a regra específica vence o prefixo /admin/reposicao', () => {
+    expect(getHelpMappingForRoute('/admin/reposicao/negociacao-paralela')).toEqual({
+      module: 'negociacao-paralela',
+      anchor: 'ranking-de-candidatos',
+    });
+    expect(getHelpMappingForRoute('/admin/reposicao/pedidos')).toEqual({
+      module: 'eventos-comerciais',
+      anchor: 'ciclo-de-oportunidade',
+    });
+    expect(getHelpMappingForRoute('/admin/reposicao')).toEqual({
+      module: 'eventos-comerciais',
+      anchor: 'visão-geral',
+    });
+  });
+});
+
+describe('hasHelpForRoute', () => {
+  it('false em rota sem ajuda → o HelpDrawer esconde o botão "?"', () => {
+    expect(hasHelpForRoute('/meu-dia')).toBe(false);
+    expect(hasHelpForRoute('/sales')).toBe(false);
+    expect(hasHelpForRoute('/tools')).toBe(false);
+  });
+
+  it('true em rota com ajuda mapeada', () => {
+    expect(hasHelpForRoute('/admin/reposicao/negociacao-paralela')).toBe(true);
+    expect(hasHelpForRoute('/admin/des/configuracao')).toBe(true);
+    expect(hasHelpForRoute('/admin/reposicao/promocoes')).toBe(true);
+  });
+});

--- a/src/lib/help-utils.ts
+++ b/src/lib/help-utils.ts
@@ -100,49 +100,41 @@ export interface HelpRouteMapping {
   anchor: string;
 }
 
-export function getHelpMappingForRoute(pathname: string): HelpRouteMapping {
-  // Avaliação Trimestral DES module
-  if (pathname.startsWith('/admin/des/trimestre-atual')) {
-    return { module: 'avaliacao-trimestral-des', anchor: 'posicao-ao-vivo' };
-  }
-  if (pathname.startsWith('/admin/des/configuracao')) {
-    return { module: 'avaliacao-trimestral-des', anchor: 'visao-geral-do-programa-des' };
-  }
-  if (pathname.startsWith('/admin/des')) {
-    return { module: 'avaliacao-trimestral-des', anchor: 'visao-geral-do-programa-des' };
-  }
-
-  // Negociação Paralela module
-  if (pathname.startsWith('/admin/reposicao/negociacao-paralela')) {
-    return { module: 'negociacao-paralela', anchor: 'ranking-de-candidatos' };
-  }
-
-  // Eventos Comerciais module (Reposição)
-  if (pathname.startsWith('/admin/reposicao/promocoes')) {
-    return { module: 'eventos-comerciais', anchor: 'promoções' };
-  }
-  if (pathname.startsWith('/admin/reposicao/aumentos')) {
-    return { module: 'eventos-comerciais', anchor: 'aumentos-anunciados' };
-  }
-  if (pathname.startsWith('/admin/reposicao/oportunidades')) {
-    return { module: 'eventos-comerciais', anchor: 'oportunidades-unificadas' };
-  }
-  if (pathname.startsWith('/admin/reposicao/pedidos')) {
-    return { module: 'eventos-comerciais', anchor: 'ciclo-de-oportunidade' };
-  }
-  if (pathname.startsWith('/admin/reposicao')) {
-    return { module: 'eventos-comerciais', anchor: 'visão-geral' };
-  }
-
-  return { module: 'eventos-comerciais', anchor: 'visão-geral' };
+interface HelpRouteRule extends HelpRouteMapping {
+  prefix: string;
 }
 
 /**
- * Backwards-compatible helper that returns just the anchor for a route.
- * @deprecated use getHelpMappingForRoute to get both module and anchor.
+ * Regras de ajuda por prefixo de rota — ESPECÍFICAS antes das genéricas (a ordem
+ * É a prioridade, igual à cascata de `if` que isto substituiu). Rota sem match =
+ * sem ajuda contextual → `getHelpMappingForRoute` devolve `null` e o HelpDrawer
+ * esconde o botão "?" em vez de abrir um painel "nada encontrado".
+ *
+ * ⚠️ Antes havia um fallback genérico (`eventos-comerciais/visão-geral`) que
+ * casava QUALQUER rota → toda tela sem ajuda própria (ex.: /meu-dia) abria a
+ * ajuda de Reposição e mostrava "nenhuma seção encontrada". O fallback foi
+ * removido de propósito.
  */
-export function getHelpAnchorForRoute(pathname: string): string {
-  return getHelpMappingForRoute(pathname).anchor;
+const HELP_ROUTE_RULES: HelpRouteRule[] = [
+  { prefix: '/admin/des/trimestre-atual', module: 'avaliacao-trimestral-des', anchor: 'posicao-ao-vivo' },
+  { prefix: '/admin/des/configuracao', module: 'avaliacao-trimestral-des', anchor: 'visao-geral-do-programa-des' },
+  { prefix: '/admin/des', module: 'avaliacao-trimestral-des', anchor: 'visao-geral-do-programa-des' },
+  { prefix: '/admin/reposicao/negociacao-paralela', module: 'negociacao-paralela', anchor: 'ranking-de-candidatos' },
+  { prefix: '/admin/reposicao/promocoes', module: 'eventos-comerciais', anchor: 'promoções' },
+  { prefix: '/admin/reposicao/aumentos', module: 'eventos-comerciais', anchor: 'aumentos-anunciados' },
+  { prefix: '/admin/reposicao/oportunidades', module: 'eventos-comerciais', anchor: 'oportunidades-unificadas' },
+  { prefix: '/admin/reposicao/pedidos', module: 'eventos-comerciais', anchor: 'ciclo-de-oportunidade' },
+  { prefix: '/admin/reposicao', module: 'eventos-comerciais', anchor: 'visão-geral' },
+];
+
+export function getHelpMappingForRoute(pathname: string): HelpRouteMapping | null {
+  const rule = HELP_ROUTE_RULES.find((r) => pathname.startsWith(r.prefix));
+  return rule ? { module: rule.module, anchor: rule.anchor } : null;
+}
+
+/** True só quando a rota tem ajuda contextual REAL (não o antigo fallback genérico). */
+export function hasHelpForRoute(pathname: string): boolean {
+  return getHelpMappingForRoute(pathname) !== null;
 }
 
 /**


### PR DESCRIPTION
…m fallback, wifi sem jargão

Origem: founder na lente "Ver como vendedora" estranhou utilitários de plataforma (saúde de dados, RTT/Wi-Fi, ajuda vazia) aparecendo p/ quem só vende. O app assumia "staff genérico"; estes controles do topbar tinham gate fraco ou nenhum.

- DataHealthBadge: gate `isStaff` → gestor/master via useDisplayAccess (lente-aware: some quando o master "vira" vendedora). Item de menu "Saúde de Dados" alinhado ao mesmo gate — antes o menu escondia (sales-only) mas o atalho-escudo aparecia (inconsistência).
- HelpDrawer: esconde o "?" em rota SEM ajuda mapeada (ex.: /meu-dia) — antes abria painel "nada encontrado". Remove o X duplicado (fica só o do Sheet shadcn; o custom dava dois X sobrepostos).
- NetworkStatusIndicator: Tipo/RTT só p/ staff (lente-aware); ícone e status legível ficam p/ todos (vendedora é a persona offline). "Mutações na fila" → "Operações pendentes".
- help-utils: getHelpMappingForRoute → HelpRouteMapping | null (remove fallback genérico) + hasHelpForRoute; remove dead getHelpAnchorForRoute; +5 testes TDD.
- CLAUDE.md §4: corrige doc do topbar (o Wi-Fi NÃO some; documenta os gates).

100% frontend (sem migration/edge) → requer Publish no Lovable p/ ir ao ar. CI local 4/4 verde (typecheck/test 3156/lint 0err/build).