### PR TITLE
feat(clientes): escopo por carteira em /admin/customers (vendedora vê só a dela + contagem real, lente-aware)

### DIFF
--- a/docs/superpowers/plans/2026-06-11-clientes-escopo-carteira.md
+++ b/docs/superpowers/plans/2026-06-11-clientes-escopo-carteira.md
@@ -1,0 +1,767 @@
+# Clientes — escopo por carteira + contagem real — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fazer `/admin/customers` mostrar só a carteira da vendedora (+ cobertura) com contagem real, lente-aware, sem regredir a visão de gestor/master.
+
+**Architecture:** Dois modos decididos por `useDisplayAccess` (lente-aware): "carteira" (vendedor) busca `carteira_assignments` paginado + `eligible=true` (RLS escopa fora da lente / `.eq(owner)` na lente) e carrega a carteira inteira; "completa" (gestor/master) mantém a paginação de `profiles` + count exato. Scores passam a vir por `customer_user_id` (não `farmer_id`). Toda a lógica não-trivial vai pra helpers puros testáveis em `src/lib/carteira/escopo-clientes.ts`.
+
+**Tech Stack:** React 18, @tanstack/react-query v5, Supabase JS, vitest. Spec: `docs/superpowers/specs/2026-06-11-clientes-escopo-carteira-design.md`.
+
+---
+
+## File Structure
+
+- **Create** `src/lib/carteira/escopo-clientes.ts` — helpers puros (`resolveModoEscopo`, `chunk`, `marcarCobertura`, `ordenarPorNome`), HOFs testáveis (`paginarTudo`, `coletarEmLotes`) e glue Supabase (`fetchCarteiraClientes`, `fetchScoresPorCustomer`).
+- **Create** `src/lib/carteira/__tests__/escopo-clientes.test.ts` — vitest dos puros + HOFs.
+- **Modify** `src/components/adminCustomers/types.ts` — `coberto_de?` no `Customer`.
+- **Modify** `src/components/adminCustomers/useAdminCustomers.ts` — bifurcação de modo, scores por customer, count, reset de lente.
+- **Modify** `src/components/adminCustomers/CustomerListView.tsx` — `total`/`isCarteira` props, label dinâmico, badge N/A, badge cobertura, scroll só no modo completa.
+
+---
+
+## Task 1: Helpers puros + HOFs testáveis (TDD)
+
+**Files:**
+- Modify: `src/components/adminCustomers/types.ts`
+- Create: `src/lib/carteira/escopo-clientes.ts`
+- Test: `src/lib/carteira/__tests__/escopo-clientes.test.ts`
+
+- [ ] **Step 1: Adicionar `coberto_de` ao tipo Customer**
+
+Em `src/components/adminCustomers/types.ts`, dentro de `interface Customer`, após `requires_po?: boolean;` adicionar:
+
+```ts
+  /** dono original quando o cliente vem de cobertura (owner ≠ baseId); null/ausente se for da própria carteira. */
+  coberto_de?: string | null;
+```
+
+- [ ] **Step 2: Escrever o teste falhando dos puros + HOFs**
+
+Criar `src/lib/carteira/__tests__/escopo-clientes.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import {
+  resolveModoEscopo, chunk, marcarCobertura, ordenarPorNome, paginarTudo, coletarEmLotes,
+} from '@/lib/carteira/escopo-clientes';
+
+describe('resolveModoEscopo', () => {
+  it.each([
+    [{ displayIsMaster: true, displayIsGestorComercial: false, displayIsSalesOnly: false }, 'completa'],
+    [{ displayIsMaster: false, displayIsGestorComercial: true, displayIsSalesOnly: false }, 'completa'],
+    [{ displayIsMaster: false, displayIsGestorComercial: false, displayIsSalesOnly: false }, 'carteira'],
+    [{ displayIsMaster: false, displayIsGestorComercial: false, displayIsSalesOnly: true }, 'carteira'],
+    // sales-only é a restrição mais forte: ganha mesmo com role gerencial/master
+    [{ displayIsMaster: true, displayIsGestorComercial: true, displayIsSalesOnly: true }, 'carteira'],
+  ] as const)('flags %o → %s', (flags, esperado) => {
+    expect(resolveModoEscopo(flags)).toBe(esperado);
+  });
+});
+
+describe('chunk', () => {
+  it('divide com resto', () => expect(chunk([1, 2, 3, 4, 5], 2)).toEqual([[1, 2], [3, 4], [5]]));
+  it('lista vazia', () => expect(chunk([], 3)).toEqual([]));
+  it('size maior que a lista', () => expect(chunk([1, 2], 5)).toEqual([[1, 2]]));
+  it('size inválido lança', () => expect(() => chunk([1], 0)).toThrow());
+});
+
+describe('marcarCobertura', () => {
+  it('marca coberto_de quando owner ≠ baseId, null quando =', () => {
+    const profiles = [{ user_id: 'c1', name: 'A' }, { user_id: 'c2', name: 'B' }];
+    const ownerById = new Map([['c1', 'me'], ['c2', 'outro']]);
+    const out = marcarCobertura(profiles, ownerById, 'me');
+    expect(out[0].coberto_de).toBeNull();
+    expect(out[1].coberto_de).toBe('outro');
+  });
+  it('owner ausente no mapa → coberto_de null', () => {
+    const out = marcarCobertura([{ user_id: 'x', name: 'X' }], new Map(), 'me');
+    expect(out[0].coberto_de).toBeNull();
+  });
+});
+
+describe('ordenarPorNome', () => {
+  it('ordena respeitando acento e caixa pt-BR', () => {
+    const out = ordenarPorNome([{ name: 'Bruno' }, { name: 'Ávila' }, { name: 'ana' }]);
+    expect(out.map((x) => x.name)).toEqual(['ana', 'Ávila', 'Bruno']);
+  });
+});
+
+describe('paginarTudo', () => {
+  it('junta páginas até uma incompleta', async () => {
+    const pages = [
+      Array.from({ length: 1000 }, (_, i) => i),
+      Array.from({ length: 1000 }, (_, i) => 1000 + i),
+      [2000, 2001],
+    ];
+    let call = 0;
+    const all = await paginarTudo(async () => pages[call++] ?? [], 1000);
+    expect(all).toHaveLength(2002);
+  });
+  it('para na página vazia quando o total é múltiplo do pageSize', async () => {
+    const pages = [[1, 2], [3, 4], []];
+    let call = 0;
+    const all = await paginarTudo(async () => pages[call++] ?? [], 2);
+    expect(all).toEqual([1, 2, 3, 4]);
+  });
+});
+
+describe('coletarEmLotes', () => {
+  it('divide em lotes e concatena na ordem', async () => {
+    const lotesVistos: number[][] = [];
+    const out = await coletarEmLotes([1, 2, 3, 4, 5], 2, async (lote) => {
+      lotesVistos.push(lote);
+      return lote.map((x) => x * 10);
+    });
+    expect(lotesVistos).toEqual([[1, 2], [3, 4], [5]]);
+    expect(out).toEqual([10, 20, 30, 40, 50]);
+  });
+  it('propaga erro de um lote', async () => {
+    await expect(
+      coletarEmLotes([1, 2, 3], 2, async (lote) => {
+        if (lote.includes(3)) throw new Error('boom');
+        return lote;
+      }),
+    ).rejects.toThrow('boom');
+  });
+  it('lista vazia → []', async () => {
+    expect(await coletarEmLotes([], 2, async () => [99])).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 3: Rodar o teste e confirmar que falha**
+
+Run: `heavy bun run test src/lib/carteira/__tests__/escopo-clientes.test.ts`
+Expected: FAIL — `escopo-clientes` não existe / exports indefinidos.
+
+- [ ] **Step 4: Implementar os puros + HOFs**
+
+Criar `src/lib/carteira/escopo-clientes.ts` (só os puros + HOFs por ora; a glue Supabase vem na Task 2):
+
+```ts
+// Escopo de clientes da tela /admin/customers.
+// PUROS + HOFs testáveis aqui; a glue Supabase fica na 2ª metade (Task 2).
+import { supabase } from '@/integrations/supabase/client';
+import type { Customer, ClientScore } from '@/components/adminCustomers/types';
+
+export interface DisplayFlags {
+  displayIsMaster: boolean;
+  displayIsGestorComercial: boolean;
+  displayIsSalesOnly: boolean;
+}
+
+/** sales-only é a restrição mais forte (CPF de campo nunca vê a base) → sempre carteira. */
+export function resolveModoEscopo(f: DisplayFlags): 'carteira' | 'completa' {
+  if (f.displayIsSalesOnly) return 'carteira';
+  return f.displayIsMaster || f.displayIsGestorComercial ? 'completa' : 'carteira';
+}
+
+export function chunk<T>(arr: T[], size: number): T[][] {
+  if (size <= 0) throw new Error('chunk: size deve ser > 0');
+  const out: T[][] = [];
+  for (let i = 0; i < arr.length; i += size) out.push(arr.slice(i, i + size));
+  return out;
+}
+
+export function marcarCobertura<T extends { user_id: string }>(
+  profiles: T[],
+  ownerById: Map<string, string>,
+  baseId: string | null,
+): (T & { coberto_de: string | null })[] {
+  return profiles.map((p) => {
+    const owner = ownerById.get(p.user_id) ?? null;
+    return { ...p, coberto_de: owner && owner !== baseId ? owner : null };
+  });
+}
+
+export function ordenarPorNome<T extends { name: string }>(items: T[]): T[] {
+  return [...items].sort((a, b) =>
+    (a.name ?? '').localeCompare(b.name ?? '', 'pt-BR', { sensitivity: 'base' }),
+  );
+}
+
+/** Pagina via fetchPage(from,to) até a página vir menor que pageSize. */
+export async function paginarTudo<T>(
+  fetchPage: (from: number, to: number) => Promise<T[]>,
+  pageSize = 1000,
+): Promise<T[]> {
+  const all: T[] = [];
+  let from = 0;
+  for (;;) {
+    const page = await fetchPage(from, from + pageSize - 1);
+    all.push(...page);
+    if (page.length < pageSize) break;
+    from += pageSize;
+  }
+  return all;
+}
+
+/** Quebra ids em lotes e concatena os resultados, em ordem. Propaga erro de qualquer lote. */
+export async function coletarEmLotes<I, O>(
+  ids: I[],
+  size: number,
+  fetchLote: (lote: I[]) => Promise<O[]>,
+): Promise<O[]> {
+  const out: O[] = [];
+  for (const lote of chunk(ids, size)) {
+    out.push(...(await fetchLote(lote)));
+  }
+  return out;
+}
+```
+
+- [ ] **Step 5: Rodar o teste e confirmar PASS**
+
+Run: `heavy bun run test src/lib/carteira/__tests__/escopo-clientes.test.ts`
+Expected: PASS (todos os describes).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/carteira/escopo-clientes.ts src/lib/carteira/__tests__/escopo-clientes.test.ts src/components/adminCustomers/types.ts
+git commit -m "feat(clientes): helpers puros de escopo de carteira (modo/chunk/cobertura/paginação)"
+```
+
+---
+
+## Task 2: Glue Supabase (fetch da carteira + scores por customer)
+
+**Files:**
+- Modify: `src/lib/carteira/escopo-clientes.ts` (append)
+
+- [ ] **Step 1: Adicionar as funções glue ao fim de `escopo-clientes.ts`**
+
+Anexar ao final do arquivo (usam os HOFs acima; importam o `supabase` já importado no topo):
+
+```ts
+const LOTE_IN = 150; // 1000 UUIDs estouram o limite de URL do proxy (≠ cap de linhas do PostgREST)
+
+/**
+ * Clientes da carteira. Fonte = carteira_assignments (eligible=true), paginado
+ * (select puro capa em 1000). Fora da lente a RLS já escopa pra carteira+cobertura;
+ * na lente (sessão é o master → RLS vê tudo) filtra pelo owner do alvo.
+ */
+export async function fetchCarteiraClientes(opts: {
+  isImpersonating: boolean;
+  effectiveUserId: string | null;
+  baseId: string | null;
+}): Promise<{ customers: Customer[]; ids: string[] }> {
+  const assignments = await paginarTudo<{ customer_user_id: string; owner_user_id: string }>(
+    async (from, to) => {
+      let q = supabase
+        .from('carteira_assignments')
+        .select('customer_user_id, owner_user_id')
+        .eq('eligible', true);
+      if (opts.isImpersonating && opts.effectiveUserId) {
+        q = q.eq('owner_user_id', opts.effectiveUserId);
+      }
+      const { data, error } = await q.order('customer_user_id').range(from, to);
+      if (error) throw error;
+      return (data ?? []) as { customer_user_id: string; owner_user_id: string }[];
+    },
+  );
+
+  const ownerById = new Map(assignments.map((a) => [a.customer_user_id, a.owner_user_id]));
+  const ids = [...ownerById.keys()];
+  if (ids.length === 0) return { customers: [], ids };
+
+  const profiles = await coletarEmLotes(ids, LOTE_IN, async (lote) => {
+    const { data, error } = await supabase
+      .from('profiles')
+      .select('user_id, name, email, phone, document, customer_type, created_at, requires_po')
+      .in('user_id', lote)
+      .eq('is_employee', false);
+    if (error) throw error;
+    return (data ?? []) as Customer[];
+  });
+
+  const customers = ordenarPorNome(marcarCobertura(profiles, ownerById, opts.baseId));
+  return { customers, ids };
+}
+
+/**
+ * Scores por customer_user_id (não por farmer_id): UNIQUE(customer_user_id) garante
+ * 1 linha/cliente, conserta scores stale pós-reatribuição e vazios pro gestor/master.
+ * A RLS de farmer_client_scores reforça (pode_ver_carteira_completa OR carteira_visivel_para).
+ */
+export async function fetchScoresPorCustomer(ids: string[]): Promise<Map<string, ClientScore>> {
+  const map = new Map<string, ClientScore>();
+  if (ids.length === 0) return map;
+  const rows = await coletarEmLotes(ids, LOTE_IN, async (lote) => {
+    const { data, error } = await supabase
+      .from('farmer_client_scores')
+      .select('customer_user_id, health_score, health_class, churn_risk, expansion_score, priority_score, avg_monthly_spend_180d, days_since_last_purchase, category_count, gross_margin_pct, avg_repurchase_interval')
+      .in('customer_user_id', lote);
+    if (error) throw error;
+    return data ?? [];
+  });
+  for (const s of rows) {
+    map.set(s.customer_user_id, {
+      customer_user_id: s.customer_user_id,
+      health_score: s.health_score ?? 0,
+      health_class: s.health_class ?? 'critico',
+      churn_risk: s.churn_risk ?? 0,
+      expansion_score: s.expansion_score ?? 0,
+      priority_score: s.priority_score ?? 0,
+      avg_monthly_spend_180d: s.avg_monthly_spend_180d ?? 0,
+      days_since_last_purchase: s.days_since_last_purchase ?? 0,
+      category_count: s.category_count ?? 0,
+      gross_margin_pct: s.gross_margin_pct ?? 0,
+    });
+  }
+  return map;
+}
+```
+
+- [ ] **Step 2: Typecheck (a glue não tem teste unit; a lógica testável está nos HOFs)**
+
+Run: `heavy bun run typecheck`
+Expected: PASS (sem erro novo). Se `farmer_client_scores`/`carteira_assignments` derem erro de tipo gerado, conferir os nomes de coluna contra `src/integrations/supabase/types.ts`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/carteira/escopo-clientes.ts
+git commit -m "feat(clientes): fetch da carteira (assignments paginado) + scores por customer_user_id"
+```
+
+---
+
+## Task 3: Reescrever `useAdminCustomers` (bifurcação de modo)
+
+**Files:**
+- Modify: `src/components/adminCustomers/useAdminCustomers.ts` (substituição integral)
+
+- [ ] **Step 1: Substituir o conteúdo de `useAdminCustomers.ts`**
+
+Conteúdo completo novo do arquivo:
+
+```ts
+// Hook de dados/estado do AdminCustomers.
+// Dois modos (carteira/completa) decididos por useDisplayAccess (lente-aware).
+// Spec: docs/superpowers/specs/2026-06-11-clientes-escopo-carteira-design.md
+import { useState, useEffect, useMemo } from 'react';
+import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
+import { useNavigate, useParams } from 'react-router-dom';
+import { supabase } from '@/integrations/supabase/client';
+import { useAuth } from '@/contexts/AuthContext';
+import { useImpersonation } from '@/contexts/ImpersonationContext';
+import { useDisplayAccess } from '@/hooks/useDisplayAccess';
+import { toast } from 'sonner';
+import {
+  resolveModoEscopo, fetchCarteiraClientes, fetchScoresPorCustomer,
+} from '@/lib/carteira/escopo-clientes';
+import type { Customer, ToolCategory, UserTool, ClientScore, SalesOrder } from './types';
+
+const PAGE_SIZE = 100;
+
+export function useAdminCustomers() {
+  const navigate = useNavigate();
+  const { customerId } = useParams<{ customerId?: string }>();
+  const { user, isStaff, loading: authLoading } = useAuth();
+  const { isImpersonating, effectiveUserId } = useImpersonation();
+  const { displayIsMaster, displayIsGestorComercial, displayIsSalesOnly, displayLoading } = useDisplayAccess();
+
+  const [selectedCustomer, setSelectedCustomer] = useState<Customer | null>(null);
+  const [customerTools, setCustomerTools] = useState<UserTool[]>([]);
+  const [categories, setCategories] = useState<ToolCategory[]>([]);
+  const [orders, setOrders] = useState<SalesOrder[]>([]);
+  const [loadingTools, setLoadingTools] = useState(false);
+  const [loadingOrders, setLoadingOrders] = useState(false);
+  const [addToolDialogOpen, setAddToolDialogOpen] = useState(false);
+
+  const modo = resolveModoEscopo({ displayIsMaster, displayIsGestorComercial, displayIsSalesOnly });
+  const isCarteira = modo === 'carteira';
+  const baseId = isImpersonating ? effectiveUserId : (user?.id ?? null);
+  const queriesReady = isStaff && !displayLoading && !!user;
+
+  useEffect(() => {
+    if (!authLoading && !isStaff) navigate('/', { replace: true });
+  }, [authLoading, isStaff, navigate]);
+
+  // Reset do detalhe ao trocar de lente: A→B não pode deixar o cliente de A na tela.
+  useEffect(() => {
+    setSelectedCustomer(null);
+    setCustomerTools([]);
+    setOrders([]);
+  }, [effectiveUserId]);
+
+  /* ─── MODO CARTEIRA: carteira inteira de uma vez ─── */
+  const carteiraQuery = useQuery({
+    queryKey: ['admin-clientes-carteira', baseId, isImpersonating],
+    enabled: queriesReady && isCarteira && !!baseId,
+    staleTime: 60_000,
+    queryFn: () => fetchCarteiraClientes({ isImpersonating, effectiveUserId, baseId }),
+  });
+
+  /* ─── MODO COMPLETA: base inteira paginada + count exato ─── */
+  const baseQuery = useInfiniteQuery({
+    queryKey: ['admin-clientes-base'],
+    enabled: queriesReady && !isCarteira,
+    initialPageParam: 0,
+    queryFn: async ({ pageParam }) => {
+      const start = (pageParam as number) * PAGE_SIZE;
+      const { data, error } = await supabase
+        .from('profiles')
+        .select('user_id, name, email, phone, document, customer_type, created_at, requires_po')
+        .eq('is_employee', false)
+        .order('name')
+        .range(start, start + PAGE_SIZE - 1);
+      if (error) throw error;
+      return (data || []) as Customer[];
+    },
+    getNextPageParam: (lastPage, allPages) =>
+      lastPage.length === PAGE_SIZE ? allPages.length : undefined,
+  });
+
+  const baseCountQuery = useQuery({
+    queryKey: ['admin-clientes-base-count'],
+    enabled: queriesReady && !isCarteira,
+    staleTime: 60_000,
+    queryFn: async () => {
+      const { count, error } = await supabase
+        .from('profiles')
+        .select('user_id', { count: 'exact', head: true })
+        .eq('is_employee', false);
+      if (error) throw error;
+      return count ?? 0;
+    },
+  });
+
+  const customers = useMemo<Customer[]>(() => {
+    if (isCarteira) return carteiraQuery.data?.customers ?? [];
+    return baseQuery.data?.pages.flat() ?? [];
+  }, [isCarteira, carteiraQuery.data, baseQuery.data]);
+
+  const visibleIds = useMemo(() => customers.map((c) => c.user_id), [customers]);
+
+  /* ─── SCORES por customer_user_id (ambos os modos) ─── */
+  const scoresQuery = useQuery({
+    queryKey: ['admin-clientes-scores', modo, baseId, visibleIds.length],
+    enabled: queriesReady && visibleIds.length > 0,
+    staleTime: 60_000,
+    queryFn: () => fetchScoresPorCustomer(visibleIds),
+  });
+  const scores = useMemo(
+    () => scoresQuery.data ?? new Map<string, ClientScore>(),
+    [scoresQuery.data],
+  );
+
+  const total = isCarteira ? customers.length : (baseCountQuery.data ?? customers.length);
+  const loading = isCarteira ? carteiraQuery.isLoading : baseQuery.isLoading;
+
+  useEffect(() => {
+    if (user && isStaff) loadCategories();
+  }, [user, isStaff]);
+
+  useEffect(() => {
+    if (customerId && customers.length > 0) {
+      const customer = customers.find((c) => c.user_id === customerId);
+      if (customer) {
+        setSelectedCustomer(customer);
+        loadCustomerTools(customerId);
+        loadCustomerOrders(customerId);
+      }
+    }
+  }, [customerId, customers]);
+
+  const loadCategories = async () => {
+    const { data } = await supabase.from('tool_categories').select('*').order('name');
+    if (data) setCategories(data);
+  };
+
+  const loadCustomerTools = async (userId: string) => {
+    setLoadingTools(true);
+    try {
+      const { data } = await supabase
+        .from('user_tools')
+        .select('*, tool_categories (*)')
+        .eq('user_id', userId)
+        .order('created_at', { ascending: false });
+      setCustomerTools((data || []) as unknown as UserTool[]);
+    } catch (error) {
+      console.error('Error loading customer tools:', error);
+    } finally {
+      setLoadingTools(false);
+    }
+  };
+
+  const loadCustomerOrders = async (userId: string) => {
+    setLoadingOrders(true);
+    try {
+      const { data } = await supabase
+        .from('sales_orders')
+        .select('id, total, status, created_at, items')
+        .eq('customer_user_id', userId)
+        .order('created_at', { ascending: false })
+        .limit(20);
+      setOrders((data || []) as SalesOrder[]);
+    } catch (error) {
+      console.error('Error loading orders:', error);
+    } finally {
+      setLoadingOrders(false);
+    }
+  };
+
+  const handleSelectCustomer = (customer: Customer) => {
+    setSelectedCustomer(customer);
+    loadCustomerTools(customer.user_id);
+    loadCustomerOrders(customer.user_id);
+    navigate(`/admin/customers/${customer.user_id}`);
+  };
+
+  const handleDeleteTool = async (toolId: string) => {
+    try {
+      const { error } = await supabase.from('user_tools').delete().eq('id', toolId);
+      if (error) throw error;
+      toast.success('Ferramenta removida');
+      setCustomerTools((prev) => prev.filter((t) => t.id !== toolId));
+    } catch (error) {
+      toast.error('Erro ao remover');
+    }
+  };
+
+  const handleBack = () => {
+    setSelectedCustomer(null);
+    navigate('/admin/customers');
+  };
+
+  const reloadSelectedTools = () => {
+    if (selectedCustomer) loadCustomerTools(selectedCustomer.user_id);
+  };
+
+  return {
+    authLoading,
+    isStaff,
+    loading,
+    customers,
+    scores,
+    categories,
+    total,
+    isCarteira,
+    selectedCustomer,
+    customerTools,
+    orders,
+    loadingTools,
+    loadingOrders,
+    addToolDialogOpen,
+    setAddToolDialogOpen,
+    hasNextPage: isCarteira ? false : !!baseQuery.hasNextPage,
+    isFetchingNextPage: isCarteira ? false : baseQuery.isFetchingNextPage,
+    fetchNextPage: () => { if (!isCarteira) baseQuery.fetchNextPage(); },
+    handleSelectCustomer,
+    handleDeleteTool,
+    handleBack,
+    reloadSelectedTools,
+  };
+}
+```
+
+Notas de mudança vs original: removidos o `employeeIdsQuery` + filtro client-side de employees (o `is_employee=false` do DB é a fonte; remover faz o count exato bater com a lista — achado do Codex) e o `loadScores`/estado `scores` (substituído por `scoresQuery` por customer).
+
+- [ ] **Step 2: Typecheck**
+
+Run: `heavy bun run typecheck`
+Expected: PASS. (`AdminCustomers.tsx` consome o retorno — ele não passa `total`/`isCarteira` ainda, mas isso é prop nova só no CustomerListView, tratado na Task 4.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/adminCustomers/useAdminCustomers.ts
+git commit -m "feat(clientes): useAdminCustomers lente-aware (modo carteira/completa, scores por customer, reset de lente)"
+```
+
+---
+
+## Task 4: `CustomerListView` — label, contagem, badge N/A, cobertura
+
+**Files:**
+- Modify: `src/components/adminCustomers/CustomerListView.tsx`
+- Modify: `src/pages/AdminCustomers.tsx` (passar `total`/`isCarteira`)
+
+- [ ] **Step 1: Adicionar `total`/`isCarteira` às props do `CustomerListView`**
+
+Em `CustomerListView.tsx`, na assinatura do componente, adicionar os dois campos. Trocar o bloco de props (linhas ~25-41):
+
+De:
+```tsx
+export function CustomerListView({
+  customers,
+  scores,
+  loading,
+  onSelect,
+  hasNextPage,
+  isFetchingNextPage,
+  onLoadMore,
+}: {
+  customers: Customer[];
+  scores: Map<string, ClientScore>;
+  loading: boolean;
+  onSelect: (c: Customer) => void;
+  hasNextPage: boolean;
+  isFetchingNextPage: boolean;
+  onLoadMore: () => void;
+}) {
+```
+
+Para:
+```tsx
+export function CustomerListView({
+  customers,
+  scores,
+  loading,
+  total,
+  isCarteira,
+  onSelect,
+  hasNextPage,
+  isFetchingNextPage,
+  onLoadMore,
+}: {
+  customers: Customer[];
+  scores: Map<string, ClientScore>;
+  loading: boolean;
+  total: number;
+  isCarteira: boolean;
+  onSelect: (c: Customer) => void;
+  hasNextPage: boolean;
+  isFetchingNextPage: boolean;
+  onLoadMore: () => void;
+}) {
+```
+
+- [ ] **Step 2: Cabeçalho usa `total` + label honesto por modo**
+
+Trocar (linha ~108):
+```tsx
+          <p className="text-sm text-muted-foreground">{customers.length} clientes na carteira</p>
+```
+Por:
+```tsx
+          <p className="text-sm text-muted-foreground">
+            {total} {isCarteira ? 'clientes na carteira' : 'clientes na base'}
+          </p>
+```
+
+- [ ] **Step 3: Badge de saúde — N/A quando não há score (não fabricar "Crítico")**
+
+Trocar (linhas ~250-251):
+```tsx
+                const score = scores.get(customer.user_id);
+                const healthInfo = HEALTH_CLASSES[score?.health_class || 'critico'];
+```
+Por:
+```tsx
+                const score = scores.get(customer.user_id);
+                const healthInfo = score ? HEALTH_CLASSES[score.health_class] : undefined;
+```
+
+(O JSX `{healthInfo?.label || 'N/A'}` na linha ~279 já cai pra "N/A" quando `healthInfo` é undefined — agora sem score = N/A, não Crítico.)
+
+- [ ] **Step 4: Badge de cobertura ao lado do nome**
+
+No bloco do nome do cliente (logo após o `<p className="font-medium truncate ...">{decodeHtmlEntities(customer.name)}</p>`, linha ~265), adicionar um badge quando `customer.coberto_de`:
+
+De:
+```tsx
+                        <div className="min-w-0">
+                          <p className="font-medium truncate text-foreground">{decodeHtmlEntities(customer.name)}</p>
+                          {customer.phone && (
+                            <p className="text-xs text-muted-foreground">{customer.phone}</p>
+                          )}
+                        </div>
+```
+Para:
+```tsx
+                        <div className="min-w-0">
+                          <p className="font-medium truncate text-foreground flex items-center gap-1.5">
+                            <span className="truncate">{decodeHtmlEntities(customer.name)}</span>
+                            {customer.coberto_de && (
+                              <Badge variant="outline" className="text-[10px] shrink-0 text-status-info border-status-info/40">
+                                cobertura
+                              </Badge>
+                            )}
+                          </p>
+                          {customer.phone && (
+                            <p className="text-xs text-muted-foreground">{customer.phone}</p>
+                          )}
+                        </div>
+```
+
+- [ ] **Step 5: Rodapé "todos carregados" usa `total` e some no modo carteira sem ruído**
+
+Trocar (linhas ~340-344):
+```tsx
+        {!hasNextPage && customers.length > 0 && (
+          <p className="text-center text-xs text-muted-foreground py-4 border-t">
+            Todos os clientes carregados ({customers.length})
+          </p>
+        )}
+```
+Por:
+```tsx
+        {!hasNextPage && customers.length > 0 && !isCarteira && (
+          <p className="text-center text-xs text-muted-foreground py-4 border-t">
+            Todos os clientes carregados ({total})
+          </p>
+        )}
+```
+
+(No modo carteira a lista já é o total; o rodapé "carregados" não agrega — só no modo completa, onde scroll infinito chegou ao fim.)
+
+- [ ] **Step 6: Passar `total`/`isCarteira` em `AdminCustomers.tsx`**
+
+Em `src/pages/AdminCustomers.tsx`, desestruturar `total` e `isCarteira` do hook (no bloco `const { ... } = useAdminCustomers();`) e passá-los ao `<CustomerListView>`:
+
+Adicionar `total,` e `isCarteira,` à desestruturação, e no JSX do `<CustomerListView ...>` adicionar:
+```tsx
+          total={total}
+          isCarteira={isCarteira}
+```
+
+- [ ] **Step 7: Typecheck + lint**
+
+Run: `heavy bun run typecheck && bun lint`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/components/adminCustomers/CustomerListView.tsx src/pages/AdminCustomers.tsx
+git commit -m "feat(clientes): label/contagem por modo, badge N/A sem score, badge de cobertura"
+```
+
+---
+
+## Task 5: Verificação final
+
+- [ ] **Step 1: Suite completa**
+
+Run: `heavy bun run typecheck && heavy bun run test && bun lint`
+Expected: tudo verde (241+ testes, incluindo os novos de escopo-clientes).
+
+- [ ] **Step 2: Build**
+
+Run: `heavy bun build`
+Expected: build sem erro.
+
+- [ ] **Step 3: Revisão de critério de pronto (do spec)**
+
+Conferir mentalmente contra o spec:
+- Vendedora real: carteira + cobertos marcados, contagem real, busca varre tudo.
+- Lente de vendedora: idem, escopado ao alvo (sessão master → `.eq(owner, alvo)`).
+- Gestor/master: base inteira, count exato, label "na base".
+- Sem score → "N/A", não "Crítico".
+
+- [ ] **Step 4: Commit final (se algo sobrou) + resumo**
+
+Nada a commitar se as tasks anteriores fecharam. Resumir o que mudou e as pendências (Publish do front no Lovable pra ir ao ar — é frontend-only, sem migration/edge).
+
+---
+
+## Notas de execução
+
+- `heavy` prefixo nos comandos pesados (M2 8GB, worktrees paralelas) — §2 do CLAUDE.md.
+- **Frontend-only**: sem migration, sem edge, sem deploy de backend. Pra ir ao ar precisa só do **Publish do front no Lovable** (§"Deploy do FRONTEND" do CLAUDE.md).
+- A glue Supabase (`fetchCarteiraClientes`/`fetchScoresPorCustomer`) não tem teste unit (mock do builder é frágil); a lógica testável está nos HOFs `paginarTudo`/`coletarEmLotes` + puros. Verificação real da glue = device/preview do founder.
+- Limitações v1 no spec (cobertura do alvo na lente; `valid_from`; count base aproximado; assignment sem profile).

--- a/docs/superpowers/specs/2026-06-11-clientes-escopo-carteira-design.md
+++ b/docs/superpowers/specs/2026-06-11-clientes-escopo-carteira-design.md
@@ -1,0 +1,116 @@
+# Clientes (`/admin/customers`) — escopo por carteira + contagem real
+
+Data: 2026-06-11 · Frontend-only (sem migration, sem edge function) · Branch: `claude/hardcore-taussig-ffb01b`
+
+## Problema
+
+A tela de Clientes (`/admin/customers`, hook `useAdminCustomers` + `CustomerListView`) tem 3 defeitos quando uma vendedora a usa (ou quando o master a inspeciona pela lente "Ver como pessoa"):
+
+1. **Lista = base inteira.** `customersQuery` busca `profiles` com `.eq('is_employee', false)`, paginado 100/página, **sem nenhum filtro de carteira**. A vendedora (e o master na lente dela) vê todos os clientes do banco, não a carteira dela.
+2. **Scores não são lente-aware.** `loadScores` usa `farmer_client_scores.eq('farmer_id', user.id)` com o `user.id` do **master logado**. Na lente de uma vendedora, os scores mostrados são os da carteira do master (errado). Como a lista é a base inteira mas os scores são de uma carteira pequena, quase tudo cai no fallback ("Crítico/R$0/999d/-").
+3. **Contagem enganosa.** `CustomerListView` mostra `{customers.length} clientes na carteira` = só a 1ª página carregada (100), cresce com o scroll, e o rótulo "na carteira" é falso.
+
+Pedido do founder: (1) a vendedora vê só a carteira dela + cobertura quando cobre alguém de férias; (2) a contagem é o total real da carteira; (3) na lente, reflete a carteira da vendedora vista.
+
+## Decisões (founder + revisão Codex)
+
+- **Escopo por persona** (founder): vendedor escopa pela carteira; gestor comercial e master veem a base inteira; na lente, segue a persona do alvo.
+- **Contagem exata pra todos** (founder): no modo carteira o `length` já é exato; no modo base, `count` no servidor.
+- **Revisão adversária do Codex** (gpt-5.5, consult): 5 P1 + P2 incorporados — paginar a carteira, scores por `customer_user_id`, filtrar `eligible`, reset de detalhe ao trocar de lente, chunk seguro do `.in()`. Detalhe no §"Decisões da revisão".
+
+## Design
+
+### Decisão de modo (lente-aware)
+
+Fonte: `useDisplayAccess()` (espelha o real fora da lente; deriva do perfil do alvo na lente).
+
+```
+podeVerCompleta = (displayIsMaster || displayIsGestorComercial) && !displayIsSalesOnly
+modo = podeVerCompleta ? 'completa' : 'carteira'
+```
+
+Helper puro `resolveModoEscopo({ displayIsMaster, displayIsGestorComercial, displayIsSalesOnly })`.
+
+- `sales-only` força `carteira` mesmo com role gerencial (a restrição mais forte ganha — um CPF de campo nunca vê a base inteira).
+- Gate de execução: `queriesReady = isStaff && !displayLoading && !!user`. Na lente, espera o perfil do alvo resolver antes de decidir o modo (senão pisca o modo errado).
+
+### Modo carteira (vendedor / lente de vendedor)
+
+Fonte da lista = `carteira_assignments` (a posse formal; `UNIQUE(customer_user_id)`, coluna `eligible boolean DEFAULT true`).
+
+`fetchCarteiraClientes(supabase, { isImpersonating, effectiveUserId, baseId })`:
+
+1. **Pagina `carteira_assignments`** (`.select('customer_user_id, owner_user_id').eq('eligible', true).order('customer_user_id').range(from, from+999)` em laço até a página vir incompleta). Uma select pura capa em 1000 → carteira grande ficaria silenciosamente truncada.
+   - **Fora da lente**: sem filtro de `owner_user_id` — a RLS `View carteira por visibilidade` (`USING carteira_visivel_para(customer_user_id, auth.uid())`) já escopa pra carteira da vendedora + cobertura ativa.
+   - **Na lente** (sessão é o master → RLS devolve tudo): `.eq('owner_user_id', effectiveUserId)` pra escopar à carteira-base do alvo.
+2. IDs únicos → **`profiles` em lotes de ~150** (`.in('user_id', chunk).eq('is_employee', false)`), checando erro de cada lote. Lotes pequenos: 1000 UUIDs estouram o limite de URL do proxy (≠ cap de linhas).
+3. Marca `coberto_de = owner_user_id !== baseId ? owner_user_id : null` (`baseId` = `effectiveUserId` na lente, `user.id` fora). Ordena por nome (`localeCompare 'pt-BR'`).
+4. Retorna `{ customers, ids }`. Sem scroll infinito — carrega a carteira inteira → `total = customers.length` (exato) e a busca passa a varrer a carteira toda (hoje a busca só filtra a página de 100 = bug latente).
+
+### Modo completa (gestor/master sem lente, ou lente de gestor)
+
+- `customersQuery` atual (`profiles` paginado 100, scroll infinito) — inalterado.
+- `+ countQuery`: `profiles.select('user_id', { count: 'exact', head: true }).eq('is_employee', false)` → total exato. Rótulo "clientes na base" (não "na carteira").
+
+### Scores (ambos os modos)
+
+Sai do `farmer_id` e passa a buscar por **`customer_user_id` dos clientes visíveis**, em lotes:
+
+```
+farmer_client_scores.in('customer_user_id', chunk(visibleIds, 150))
+```
+
+- `UNIQUE(customer_user_id)` (migration `20260524170000`) → 1 linha por cliente, sem ambiguidade de dono.
+- Conserta os 3 sintomas que o `farmer_id` causava: scores vazios pro gestor/master, scores stale após reatribuição (o rebuild atualiza `carteira_assignments` antes de reconciliar score), e divergência com a lista.
+- Segurança: a RLS de `farmer_client_scores` (#329) é `pode_ver_carteira_completa(uid) OR carteira_visivel_para(customer_user_id, uid)` — **o mesmo predicado** da `carteira_assignments`. O vendedor lê só a carteira dele (a RLS reforça mesmo se a lista mandar id alheio); gestor/master/lente leem tudo. Carteira e scores ficam consistentes por construção.
+- Migra de `useState`+`useEffect` para `useQuery` (sem estado mutável que vaza entre trocas de lente).
+
+### Reset ao trocar de lente
+
+`selectedCustomer`/`customerTools`/`orders` são estado local. Trocar a lente A→B enquanto vê o cliente de A deixa o detalhe de A na tela. `useEffect([effectiveUserId])` reseta o detalhe e volta pra lista. O deep-link `customerId` só abre se o cliente está na lista visível (já é o comportamento do efeito existente; o reset cobre a troca).
+
+### Query keys
+
+Todas incluem `modo` + `baseId` (= `effectiveUserId` na lente). Troca de lente A→B invalida e re-busca. Scores: `['admin-clientes-scores', modo, baseId, visibleIds.length]` (no modo completa cresce por página → re-busca incremental).
+
+### UI (`CustomerListView`)
+
+- Cabeçalho: `{total} clientes na carteira` (carteira) / `{total} clientes na base` (completa).
+- Sem score → badge "N/A" / "—", não "Crítico" (não fabricar saúde inexistente).
+- Modo carteira: sem sentinela de scroll infinito (tudo carregado); rodapé "N na carteira".
+- Badge de cobertura nos clientes com `coberto_de` (reusa a noção de "coberto" dos hooks irmãos).
+
+## Arquivos
+
+- **NOVO** `src/lib/carteira/escopo-clientes.ts` — helpers puros (`resolveModoEscopo`, `chunk`, `marcarCobertura`, `ordenarPorNome`) + as funções de fetch testáveis (`fetchCarteiraClientes`, `fetchProfilesChunked`, `fetchScoresPorCustomer`).
+- **NOVO** `src/lib/carteira/__tests__/escopo-clientes.test.ts` — vitest.
+- **EDIT** `src/components/adminCustomers/useAdminCustomers.ts` — bifurcação de modo, fetch da carteira, scores por `customer_user_id`, count, reset de lente, query keys.
+- **EDIT** `src/components/adminCustomers/CustomerListView.tsx` — label dinâmico, badge N/A, scroll só no modo completa, badge de cobertura.
+- **EDIT** `src/components/adminCustomers/types.ts` — `coberto_de?: string | null` no `Customer`.
+
+## Testes (helpers puros, TDD)
+
+- `resolveModoEscopo`: master→completa, gestor→completa, vendedor→carteira, sales-only→carteira, **sales-only + gestor→carteira** (restrição ganha), displayLoading não decide.
+- `chunk`: vazio, exato, com resto, tamanho 1.
+- `marcarCobertura`: próprio (`coberto_de=null`), coberto (`coberto_de=owner`), na lente (`baseId=alvo`).
+- `ordenarPorNome`: acentos pt-BR ("Á" antes de "B").
+
+## Limitações v1 (registradas, consistentes com `useMyCarteiraScores`)
+
+- Na lente mostro a carteira-**base** do alvo, sem a cobertura que *o alvo* faz. A cobertura da vendedora real logada funciona 100% (via RLS). (Follow-up: buscar `carteira_coverage WHERE covering_user_id=effectiveUserId` na lente.)
+- `valid_from` da cobertura é ignorado pela RLS e por `useMyActiveCoverage` (pré-existente) → cobertura agendada pro futuro aparece já. Fora de escopo (não é meu código).
+- Count do modo completa usa `is_employee=false`; pode divergir levemente do filtro defensivo de `user_roles` (employee com flag stale). Aproximação aceita.
+- Cliente com assignment mas sem `profiles` (raro; a FK aponta `auth.users`, não `profiles`) não renderiza; `total` = clientes renderizados (alinha com a lista).
+
+## Não-objetivos
+
+- Toggle "Minha carteira / Todos" pro gestor (rejeitado pelo founder — gestor vê tudo).
+- Mudar RLS / criar RPC `_for` (o escopo aqui é display-only, igual ao `useMyCarteiraScores`; a RLS existente já faz a fronteira real).
+- Virtualização de tabela (carteira de uma vendedora cabe; se surgir vendedora com >~3000 clientes, reavaliar).
+
+## Critério de pronto
+
+- Vendedora real logada: vê só a carteira dela + cobertos (marcados), contagem = total real, busca varre tudo.
+- Lente de vendedora: mesma coisa, escopada ao alvo.
+- Gestor/master: base inteira, contagem exata, label "na base".
+- `bun run typecheck` + `bun run test` + `bun lint` + `bun build` verdes.

--- a/src/components/adminCustomers/CustomerListView.tsx
+++ b/src/components/adminCustomers/CustomerListView.tsx
@@ -26,6 +26,8 @@ export function CustomerListView({
   customers,
   scores,
   loading,
+  total,
+  isCarteira,
   onSelect,
   hasNextPage,
   isFetchingNextPage,
@@ -34,6 +36,8 @@ export function CustomerListView({
   customers: Customer[];
   scores: Map<string, ClientScore>;
   loading: boolean;
+  total: number;
+  isCarteira: boolean;
   onSelect: (c: Customer) => void;
   hasNextPage: boolean;
   isFetchingNextPage: boolean;
@@ -105,7 +109,9 @@ export function CustomerListView({
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-xl font-semibold text-foreground">Clientes</h1>
-          <p className="text-sm text-muted-foreground">{customers.length} clientes na carteira</p>
+          <p className="text-sm text-muted-foreground">
+            {`${total} ${isCarteira ? 'clientes na carteira' : 'clientes na base'}`}
+          </p>
         </div>
       </div>
 
@@ -248,7 +254,7 @@ export function CustomerListView({
             <tbody>
               {filtered.map((customer) => {
                 const score = scores.get(customer.user_id);
-                const healthInfo = HEALTH_CLASSES[score?.health_class || 'critico'];
+                const healthInfo = score ? HEALTH_CLASSES[score.health_class] : undefined;
 
                 return (
                   <tr
@@ -262,7 +268,14 @@ export function CustomerListView({
                           <User className="w-4 h-4 text-primary" />
                         </div>
                         <div className="min-w-0">
-                          <p className="font-medium truncate text-foreground">{decodeHtmlEntities(customer.name)}</p>
+                          <p className="font-medium truncate text-foreground flex items-center gap-1.5">
+                            <span className="truncate">{decodeHtmlEntities(customer.name)}</span>
+                            {customer.coberto_de && (
+                              <Badge variant="outline" className="text-[10px] shrink-0 text-status-info border-status-info/40">
+                                cobertura
+                              </Badge>
+                            )}
+                          </p>
                           {customer.phone && (
                             <p className="text-xs text-muted-foreground">{customer.phone}</p>
                           )}
@@ -337,9 +350,9 @@ export function CustomerListView({
             )}
           </div>
         )}
-        {!hasNextPage && customers.length > 0 && (
+        {!hasNextPage && customers.length > 0 && !isCarteira && (
           <p className="text-center text-xs text-muted-foreground py-4 border-t">
-            Todos os clientes carregados ({customers.length})
+            Todos os clientes carregados ({total})
           </p>
         )}
       </Card>

--- a/src/components/adminCustomers/__tests__/CustomerListView.test.tsx
+++ b/src/components/adminCustomers/__tests__/CustomerListView.test.tsx
@@ -45,6 +45,8 @@ function setup(overrides: Partial<React.ComponentProps<typeof CustomerListView>>
     customers: [customer],
     scores: new Map([["c1", score]]),
     loading: false,
+    total: 1,
+    isCarteira: true,
     onSelect: vi.fn(),
     hasNextPage: false,
     isFetchingNextPage: false,
@@ -59,7 +61,7 @@ describe("CustomerListView", () => {
   it("mostra skeleton quando loading", () => {
     const { container } = render(
       <MemoryRouter>
-        <CustomerListView customers={[]} scores={new Map()} loading onSelect={vi.fn()} hasNextPage={false} isFetchingNextPage={false} onLoadMore={vi.fn()} />
+        <CustomerListView customers={[]} scores={new Map()} loading total={0} isCarteira onSelect={vi.fn()} hasNextPage={false} isFetchingNextPage={false} onLoadMore={vi.fn()} />
       </MemoryRouter>,
     );
     // PageSkeleton (Skeleton usa animate-shimmer), não mais Loader2 full-page

--- a/src/components/adminCustomers/types.ts
+++ b/src/components/adminCustomers/types.ts
@@ -10,6 +10,8 @@ export interface Customer {
   customer_type: string | null;
   created_at: string;
   requires_po?: boolean;
+  /** dono original quando o cliente vem de cobertura (owner ≠ baseId); null/ausente se for da própria carteira. */
+  coberto_de?: string | null;
 }
 
 export interface ToolCategory {

--- a/src/components/adminCustomers/useAdminCustomers.ts
+++ b/src/components/adminCustomers/useAdminCustomers.ts
@@ -1,26 +1,29 @@
-// Hook de dados/estado do AdminCustomers.
-// Extraído verbatim de src/pages/AdminCustomers.tsx (god-component split):
-// 2 infinite queries (clientes paginados + employee ids), loads (categorias/
-// scores paginados/ferramentas/pedidos) e handlers de seleção/exclusão.
-import { useState, useEffect, useMemo } from 'react';
-import { useInfiniteQuery } from '@tanstack/react-query';
+// Hook de dados/estado do AdminCustomers (orquestrador).
+// A LISTA (lente-aware: carteira/completa) vem de useClientesScope (read-only, isolado
+// p/ não misturar a lente de exibição com mutação — ver guard de impersonação).
+// Aqui: estado de detalhe (cliente selecionado, ferramentas, pedidos) + mutações.
+// Spec: docs/superpowers/specs/2026-06-11-clientes-escopo-carteira-design.md
+import { useState, useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
 import { toast } from 'sonner';
-import type { Customer, ToolCategory, UserTool, ClientScore, SalesOrder } from './types';
-
-const PAGE_SIZE = 100;
+import { useClientesScope } from './useClientesScope';
+import type { Customer, ToolCategory, UserTool, SalesOrder } from './types';
 
 export function useAdminCustomers() {
   const navigate = useNavigate();
   const { customerId } = useParams<{ customerId?: string }>();
   const { user, isStaff, loading: authLoading } = useAuth();
 
+  const {
+    customers, scores, total, isCarteira, loading,
+    hasNextPage, isFetchingNextPage, fetchNextPage, effectiveUserId,
+  } = useClientesScope();
+
   const [selectedCustomer, setSelectedCustomer] = useState<Customer | null>(null);
   const [customerTools, setCustomerTools] = useState<UserTool[]>([]);
   const [categories, setCategories] = useState<ToolCategory[]>([]);
-  const [scores, setScores] = useState<Map<string, ClientScore>>(new Map());
   const [orders, setOrders] = useState<SalesOrder[]>([]);
   const [loadingTools, setLoadingTools] = useState(false);
   const [loadingOrders, setLoadingOrders] = useState(false);
@@ -30,63 +33,21 @@ export function useAdminCustomers() {
     if (!authLoading && !isStaff) navigate('/', { replace: true });
   }, [authLoading, isStaff, navigate]);
 
-  /* ─── Customers: infinite query (100 por página) ─── */
-  // Buscamos employee_ids 1× pra filtrar client-side (defensivo — eq('is_employee', false)
-  // já filtra no DB, mas mantemos a verificação contra user_roles caso o flag esteja stale)
-  const employeeIdsQuery = useInfiniteQuery({
-    queryKey: ['admin-customers-employee-ids'],
-    enabled: isStaff,
-    staleTime: 5 * 60_000,
-    initialPageParam: 0,
-    queryFn: async () => {
-      const { data } = await supabase
-        .from('user_roles')
-        .select('user_id')
-        .in('role', ['master', 'employee']);
-      return new Set((data || []).map((r: { user_id: string }) => r.user_id));
-    },
-    getNextPageParam: () => undefined,
-  });
-  const employeeIds = employeeIdsQuery.data?.pages[0] || new Set<string>();
-
-  const customersQuery = useInfiniteQuery({
-    queryKey: ['admin-customers-paginated'],
-    enabled: isStaff,
-    initialPageParam: 0,
-    queryFn: async ({ pageParam }) => {
-      const start = (pageParam as number) * PAGE_SIZE;
-      const { data, error } = await supabase
-        .from('profiles')
-        .select('user_id, name, email, phone, document, customer_type, created_at, requires_po')
-        .eq('is_employee', false)
-        .order('name')
-        .range(start, start + PAGE_SIZE - 1);
-      if (error) throw error;
-      return (data || []) as Customer[];
-    },
-    getNextPageParam: (lastPage, allPages) =>
-      lastPage.length === PAGE_SIZE ? allPages.length : undefined,
-  });
-
-  // Customers visíveis (filter defensivo de employees depois do fetch — pode reduzir
-  // tamanho da page mas não afeta getNextPageParam que olha o raw 100)
-  const customers = useMemo<Customer[]>(() => {
-    const raw = customersQuery.data?.pages.flat() || [];
-    return raw.filter((p) => !employeeIds.has(p.user_id));
-  }, [customersQuery.data, employeeIds]);
-
-  const loading = customersQuery.isLoading;
+  // Reset do detalhe ao trocar de lente: A→B não pode deixar o cliente de A na tela.
+  // effectiveUserId é só leitura aqui (vem do scope) — nenhuma escrita usa esse id.
+  useEffect(() => {
+    setSelectedCustomer(null);
+    setCustomerTools([]);
+    setOrders([]);
+  }, [effectiveUserId]);
 
   useEffect(() => {
-    if (user && isStaff) {
-      loadCategories();
-      loadScores();
-    }
+    if (user && isStaff) loadCategories();
   }, [user, isStaff]);
 
   useEffect(() => {
     if (customerId && customers.length > 0) {
-      const customer = customers.find(c => c.user_id === customerId);
+      const customer = customers.find((c) => c.user_id === customerId);
       if (customer) {
         setSelectedCustomer(customer);
         loadCustomerTools(customerId);
@@ -98,47 +59,6 @@ export function useAdminCustomers() {
   const loadCategories = async () => {
     const { data } = await supabase.from('tool_categories').select('*').order('name');
     if (data) setCategories(data);
-  };
-
-  const loadScores = async () => {
-    if (!user?.id) return;
-    try {
-      // farmer_client_scores tem ~1 linha por cliente da carteira (milhares).
-      // PostgREST capa em 1000 linhas/request, então paginamos com .range() até
-      // a página vir incompleta (ou bater um teto de segurança) — sem isso, os
-      // scores de clientes além dos 1000 primeiros ficavam silenciosamente vazios.
-      const SCORES_PAGE_SIZE = 1000;
-      const MAX_PAGES = 50; // teto de segurança = 50.000 scores
-      const map = new Map<string, ClientScore>();
-      for (let page = 0; page < MAX_PAGES; page++) {
-        const from = page * SCORES_PAGE_SIZE;
-        const to = from + SCORES_PAGE_SIZE - 1;
-        const { data, error } = await supabase
-          .from('farmer_client_scores')
-          .select('customer_user_id, health_score, health_class, churn_risk, expansion_score, priority_score, avg_monthly_spend_180d, days_since_last_purchase, category_count, gross_margin_pct, avg_repurchase_interval')
-          .eq('farmer_id', user.id)
-          .range(from, to);
-        if (error) throw error;
-        if (!data || data.length === 0) break;
-        // Database row tem fields nullable; normaliza pra non-null com defaults
-        data.forEach((s) => map.set(s.customer_user_id, {
-          customer_user_id: s.customer_user_id,
-          health_score: s.health_score ?? 0,
-          health_class: s.health_class ?? 'critico',
-          churn_risk: s.churn_risk ?? 0,
-          expansion_score: s.expansion_score ?? 0,
-          priority_score: s.priority_score ?? 0,
-          avg_monthly_spend_180d: s.avg_monthly_spend_180d ?? 0,
-          days_since_last_purchase: s.days_since_last_purchase ?? 0,
-          category_count: s.category_count ?? 0,
-          gross_margin_pct: s.gross_margin_pct ?? 0,
-        }));
-        if (data.length < SCORES_PAGE_SIZE) break;
-      }
-      setScores(map);
-    } catch (e) {
-      console.error('Error loading scores:', e);
-    }
   };
 
   const loadCustomerTools = async (userId: string) => {
@@ -186,7 +106,7 @@ export function useAdminCustomers() {
       const { error } = await supabase.from('user_tools').delete().eq('id', toolId);
       if (error) throw error;
       toast.success('Ferramenta removida');
-      setCustomerTools(prev => prev.filter(t => t.id !== toolId));
+      setCustomerTools((prev) => prev.filter((t) => t.id !== toolId));
     } catch (error) {
       toast.error('Erro ao remover');
     }
@@ -208,6 +128,8 @@ export function useAdminCustomers() {
     customers,
     scores,
     categories,
+    total,
+    isCarteira,
     selectedCustomer,
     customerTools,
     orders,
@@ -215,9 +137,9 @@ export function useAdminCustomers() {
     loadingOrders,
     addToolDialogOpen,
     setAddToolDialogOpen,
-    hasNextPage: !!customersQuery.hasNextPage,
-    isFetchingNextPage: customersQuery.isFetchingNextPage,
-    fetchNextPage: () => customersQuery.fetchNextPage(),
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
     handleSelectCustomer,
     handleDeleteTool,
     handleBack,

--- a/src/components/adminCustomers/useClientesScope.ts
+++ b/src/components/adminCustomers/useClientesScope.ts
@@ -1,0 +1,117 @@
+// Escopo de LEITURA da lista de clientes (lente-aware), SEM mutação.
+// Isolado de useAdminCustomers de propósito: o guard display-access-no-write proíbe
+// useDisplayAccess no mesmo arquivo que faz escrita (.insert/.update/.upsert/.delete).
+// Aqui só há leitura — useAdminCustomers consome este scope e detém as mutações.
+// Spec: docs/superpowers/specs/2026-06-11-clientes-escopo-carteira-design.md
+import { useMemo } from 'react';
+import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import { useAuth } from '@/contexts/AuthContext';
+import { useImpersonation } from '@/contexts/ImpersonationContext';
+import { useDisplayAccess } from '@/hooks/useDisplayAccess';
+import {
+  resolveModoEscopo, fetchCarteiraClientes, fetchScoresPorCustomer,
+} from '@/lib/carteira/escopo-clientes';
+import type { Customer, ClientScore } from './types';
+
+const PAGE_SIZE = 100;
+
+export interface ClientesScope {
+  customers: Customer[];
+  scores: Map<string, ClientScore>;
+  total: number;
+  isCarteira: boolean;
+  loading: boolean;
+  hasNextPage: boolean;
+  isFetchingNextPage: boolean;
+  fetchNextPage: () => void;
+  /** id efetivo (alvo na lente, próprio fora dela) — consumido pelo orquestrador p/ reset de detalhe. */
+  effectiveUserId: string | null;
+}
+
+export function useClientesScope(): ClientesScope {
+  const { user, isStaff } = useAuth();
+  const { isImpersonating, effectiveUserId } = useImpersonation();
+  const { displayIsMaster, displayIsGestorComercial, displayIsSalesOnly, displayLoading } = useDisplayAccess();
+
+  const modo = resolveModoEscopo({ displayIsMaster, displayIsGestorComercial, displayIsSalesOnly });
+  const isCarteira = modo === 'carteira';
+  const baseId = isImpersonating ? effectiveUserId : (user?.id ?? null);
+  const queriesReady = isStaff && !displayLoading && !!user;
+
+  /* ─── MODO CARTEIRA: carteira inteira de uma vez ─── */
+  const carteiraQuery = useQuery({
+    queryKey: ['admin-clientes-carteira', baseId, isImpersonating],
+    enabled: queriesReady && isCarteira && !!baseId,
+    staleTime: 60_000,
+    queryFn: () => fetchCarteiraClientes({ isImpersonating, effectiveUserId, baseId }),
+  });
+
+  /* ─── MODO COMPLETA: base inteira paginada + count exato ─── */
+  const baseQuery = useInfiniteQuery({
+    queryKey: ['admin-clientes-base'],
+    enabled: queriesReady && !isCarteira,
+    initialPageParam: 0,
+    queryFn: async ({ pageParam }) => {
+      const start = (pageParam as number) * PAGE_SIZE;
+      const { data, error } = await supabase
+        .from('profiles')
+        .select('user_id, name, email, phone, document, customer_type, created_at, requires_po')
+        .eq('is_employee', false)
+        .order('name')
+        .range(start, start + PAGE_SIZE - 1);
+      if (error) throw error;
+      return (data || []) as Customer[];
+    },
+    getNextPageParam: (lastPage, allPages) =>
+      lastPage.length === PAGE_SIZE ? allPages.length : undefined,
+  });
+
+  const baseCountQuery = useQuery({
+    queryKey: ['admin-clientes-base-count'],
+    enabled: queriesReady && !isCarteira,
+    staleTime: 60_000,
+    queryFn: async () => {
+      const { count, error } = await supabase
+        .from('profiles')
+        .select('user_id', { count: 'exact', head: true })
+        .eq('is_employee', false);
+      if (error) throw error;
+      return count ?? 0;
+    },
+  });
+
+  const customers = useMemo<Customer[]>(() => {
+    if (isCarteira) return carteiraQuery.data?.customers ?? [];
+    return baseQuery.data?.pages.flat() ?? [];
+  }, [isCarteira, carteiraQuery.data, baseQuery.data]);
+
+  const visibleIds = useMemo(() => customers.map((c) => c.user_id), [customers]);
+
+  /* ─── SCORES por customer_user_id (ambos os modos) ─── */
+  const scoresQuery = useQuery({
+    queryKey: ['admin-clientes-scores', isCarteira ? 'carteira' : 'completa', baseId, visibleIds.length],
+    enabled: queriesReady && visibleIds.length > 0,
+    staleTime: 60_000,
+    queryFn: () => fetchScoresPorCustomer(visibleIds),
+  });
+  const scores = useMemo(
+    () => scoresQuery.data ?? new Map<string, ClientScore>(),
+    [scoresQuery.data],
+  );
+
+  const total = isCarteira ? customers.length : (baseCountQuery.data ?? customers.length);
+  const loading = isCarteira ? carteiraQuery.isLoading : baseQuery.isLoading;
+
+  return {
+    customers,
+    scores,
+    total,
+    isCarteira,
+    loading,
+    hasNextPage: isCarteira ? false : !!baseQuery.hasNextPage,
+    isFetchingNextPage: isCarteira ? false : baseQuery.isFetchingNextPage,
+    fetchNextPage: () => { if (!isCarteira) baseQuery.fetchNextPage(); },
+    effectiveUserId,
+  };
+}

--- a/src/lib/carteira/__tests__/escopo-clientes.test.ts
+++ b/src/lib/carteira/__tests__/escopo-clientes.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import {
+  resolveModoEscopo, chunk, marcarCobertura, ordenarPorNome, paginarTudo, coletarEmLotes,
+} from '@/lib/carteira/escopo-clientes';
+
+describe('resolveModoEscopo', () => {
+  it.each([
+    [{ displayIsMaster: true, displayIsGestorComercial: false, displayIsSalesOnly: false }, 'completa'],
+    [{ displayIsMaster: false, displayIsGestorComercial: true, displayIsSalesOnly: false }, 'completa'],
+    [{ displayIsMaster: false, displayIsGestorComercial: false, displayIsSalesOnly: false }, 'carteira'],
+    [{ displayIsMaster: false, displayIsGestorComercial: false, displayIsSalesOnly: true }, 'carteira'],
+    // sales-only é a restrição mais forte: ganha mesmo com role gerencial/master
+    [{ displayIsMaster: true, displayIsGestorComercial: true, displayIsSalesOnly: true }, 'carteira'],
+  ] as const)('flags %o → %s', (flags, esperado) => {
+    expect(resolveModoEscopo(flags)).toBe(esperado);
+  });
+});
+
+describe('chunk', () => {
+  it('divide com resto', () => expect(chunk([1, 2, 3, 4, 5], 2)).toEqual([[1, 2], [3, 4], [5]]));
+  it('lista vazia', () => expect(chunk([], 3)).toEqual([]));
+  it('size maior que a lista', () => expect(chunk([1, 2], 5)).toEqual([[1, 2]]));
+  it('size inválido lança', () => expect(() => chunk([1], 0)).toThrow());
+});
+
+describe('marcarCobertura', () => {
+  it('marca coberto_de quando owner ≠ baseId, null quando =', () => {
+    const profiles = [{ user_id: 'c1', name: 'A' }, { user_id: 'c2', name: 'B' }];
+    const ownerById = new Map([['c1', 'me'], ['c2', 'outro']]);
+    const out = marcarCobertura(profiles, ownerById, 'me');
+    expect(out[0].coberto_de).toBeNull();
+    expect(out[1].coberto_de).toBe('outro');
+  });
+  it('owner ausente no mapa → coberto_de null', () => {
+    const out = marcarCobertura([{ user_id: 'x', name: 'X' }], new Map(), 'me');
+    expect(out[0].coberto_de).toBeNull();
+  });
+});
+
+describe('ordenarPorNome', () => {
+  it('ordena respeitando acento e caixa pt-BR', () => {
+    const out = ordenarPorNome([{ name: 'Bruno' }, { name: 'Ávila' }, { name: 'ana' }]);
+    expect(out.map((x) => x.name)).toEqual(['ana', 'Ávila', 'Bruno']);
+  });
+});
+
+describe('paginarTudo', () => {
+  it('junta páginas até uma incompleta', async () => {
+    const pages = [
+      Array.from({ length: 1000 }, (_, i) => i),
+      Array.from({ length: 1000 }, (_, i) => 1000 + i),
+      [2000, 2001],
+    ];
+    let call = 0;
+    const all = await paginarTudo(async () => pages[call++] ?? [], 1000);
+    expect(all).toHaveLength(2002);
+  });
+  it('para na página vazia quando o total é múltiplo do pageSize', async () => {
+    const pages = [[1, 2], [3, 4], []];
+    let call = 0;
+    const all = await paginarTudo(async () => pages[call++] ?? [], 2);
+    expect(all).toEqual([1, 2, 3, 4]);
+  });
+});
+
+describe('coletarEmLotes', () => {
+  it('divide em lotes e concatena na ordem', async () => {
+    const lotesVistos: number[][] = [];
+    const out = await coletarEmLotes([1, 2, 3, 4, 5], 2, async (lote) => {
+      lotesVistos.push(lote);
+      return lote.map((x) => x * 10);
+    });
+    expect(lotesVistos).toEqual([[1, 2], [3, 4], [5]]);
+    expect(out).toEqual([10, 20, 30, 40, 50]);
+  });
+  it('propaga erro de um lote', async () => {
+    await expect(
+      coletarEmLotes([1, 2, 3], 2, async (lote) => {
+        if (lote.includes(3)) throw new Error('boom');
+        return lote;
+      }),
+    ).rejects.toThrow('boom');
+  });
+  it('lista vazia → []', async () => {
+    expect(await coletarEmLotes([], 2, async () => [99])).toEqual([]);
+  });
+});

--- a/src/lib/carteira/escopo-clientes.ts
+++ b/src/lib/carteira/escopo-clientes.ts
@@ -1,0 +1,68 @@
+// Escopo de clientes da tela /admin/customers.
+// PUROS + HOFs testáveis aqui; a glue Supabase é anexada na 2ª metade (Task 2).
+// Spec: docs/superpowers/specs/2026-06-11-clientes-escopo-carteira-design.md
+
+export interface DisplayFlags {
+  displayIsMaster: boolean;
+  displayIsGestorComercial: boolean;
+  displayIsSalesOnly: boolean;
+}
+
+/** sales-only é a restrição mais forte (CPF de campo nunca vê a base) → sempre carteira. */
+export function resolveModoEscopo(f: DisplayFlags): 'carteira' | 'completa' {
+  if (f.displayIsSalesOnly) return 'carteira';
+  return f.displayIsMaster || f.displayIsGestorComercial ? 'completa' : 'carteira';
+}
+
+export function chunk<T>(arr: T[], size: number): T[][] {
+  if (size <= 0) throw new Error('chunk: size deve ser > 0');
+  const out: T[][] = [];
+  for (let i = 0; i < arr.length; i += size) out.push(arr.slice(i, i + size));
+  return out;
+}
+
+export function marcarCobertura<T extends { user_id: string }>(
+  profiles: T[],
+  ownerById: Map<string, string>,
+  baseId: string | null,
+): (T & { coberto_de: string | null })[] {
+  return profiles.map((p) => {
+    const owner = ownerById.get(p.user_id) ?? null;
+    return { ...p, coberto_de: owner && owner !== baseId ? owner : null };
+  });
+}
+
+export function ordenarPorNome<T extends { name: string }>(items: T[]): T[] {
+  return [...items].sort((a, b) =>
+    (a.name ?? '').localeCompare(b.name ?? '', 'pt-BR', { sensitivity: 'base' }),
+  );
+}
+
+/** Pagina via fetchPage(from,to) até a página vir menor que pageSize. */
+export async function paginarTudo<T>(
+  fetchPage: (from: number, to: number) => Promise<T[]>,
+  pageSize = 1000,
+): Promise<T[]> {
+  const all: T[] = [];
+  let from = 0;
+  for (;;) {
+    const page = await fetchPage(from, from + pageSize - 1);
+    all.push(...page);
+    if (page.length < pageSize) break;
+    from += pageSize;
+  }
+  return all;
+}
+
+/** Quebra ids em lotes e concatena os resultados, em ordem. Propaga erro de qualquer lote. */
+export async function coletarEmLotes<I, O>(
+  ids: I[],
+  size: number,
+  fetchLote: (lote: I[]) => Promise<O[]>,
+): Promise<O[]> {
+  const out: O[] = [];
+  for (const lote of chunk(ids, size)) {
+    out.push(...(await fetchLote(lote)));
+  }
+  return out;
+}

--- a/src/lib/carteira/escopo-clientes.ts
+++ b/src/lib/carteira/escopo-clientes.ts
@@ -1,6 +1,8 @@
 // Escopo de clientes da tela /admin/customers.
 // PUROS + HOFs testáveis aqui; a glue Supabase é anexada na 2ª metade (Task 2).
 // Spec: docs/superpowers/specs/2026-06-11-clientes-escopo-carteira-design.md
+import { supabase } from '@/integrations/supabase/client';
+import type { Customer, ClientScore } from '@/components/adminCustomers/types';
 
 export interface DisplayFlags {
   displayIsMaster: boolean;
@@ -65,4 +67,84 @@ export async function coletarEmLotes<I, O>(
     out.push(...(await fetchLote(lote)));
   }
   return out;
+}
+
+const LOTE_IN = 150; // 1000 UUIDs estouram o limite de URL do proxy (≠ cap de linhas do PostgREST)
+
+/**
+ * Clientes da carteira. Fonte = carteira_assignments (eligible=true), paginado
+ * (select puro capa em 1000). Fora da lente a RLS já escopa pra carteira+cobertura;
+ * na lente (sessão é o master → RLS vê tudo) filtra pelo owner do alvo.
+ */
+export async function fetchCarteiraClientes(opts: {
+  isImpersonating: boolean;
+  effectiveUserId: string | null;
+  baseId: string | null;
+}): Promise<{ customers: Customer[]; ids: string[] }> {
+  const assignments = await paginarTudo<{ customer_user_id: string; owner_user_id: string }>(
+    async (from, to) => {
+      let q = supabase
+        .from('carteira_assignments')
+        .select('customer_user_id, owner_user_id')
+        .eq('eligible', true);
+      if (opts.isImpersonating && opts.effectiveUserId) {
+        q = q.eq('owner_user_id', opts.effectiveUserId);
+      }
+      const { data, error } = await q.order('customer_user_id').range(from, to);
+      if (error) throw error;
+      return data ?? [];
+    },
+  );
+
+  const ownerById = new Map(
+    assignments.map((a) => [a.customer_user_id, a.owner_user_id] as [string, string]),
+  );
+  const ids = [...ownerById.keys()];
+  if (ids.length === 0) return { customers: [], ids };
+
+  const profiles = await coletarEmLotes(ids, LOTE_IN, async (lote) => {
+    const { data, error } = await supabase
+      .from('profiles')
+      .select('user_id, name, email, phone, document, customer_type, created_at, requires_po')
+      .in('user_id', lote)
+      .eq('is_employee', false);
+    if (error) throw error;
+    return (data ?? []) as Customer[];
+  });
+
+  const customers = ordenarPorNome(marcarCobertura(profiles, ownerById, opts.baseId));
+  return { customers, ids };
+}
+
+/**
+ * Scores por customer_user_id (não por farmer_id): UNIQUE(customer_user_id) garante
+ * 1 linha/cliente, conserta scores stale pós-reatribuição e vazios pro gestor/master.
+ * A RLS de farmer_client_scores reforça (pode_ver_carteira_completa OR carteira_visivel_para).
+ */
+export async function fetchScoresPorCustomer(ids: string[]): Promise<Map<string, ClientScore>> {
+  const map = new Map<string, ClientScore>();
+  if (ids.length === 0) return map;
+  const rows = await coletarEmLotes(ids, LOTE_IN, async (lote) => {
+    const { data, error } = await supabase
+      .from('farmer_client_scores')
+      .select('customer_user_id, health_score, health_class, churn_risk, expansion_score, priority_score, avg_monthly_spend_180d, days_since_last_purchase, category_count, gross_margin_pct, avg_repurchase_interval')
+      .in('customer_user_id', lote);
+    if (error) throw error;
+    return data ?? [];
+  });
+  for (const s of rows) {
+    map.set(s.customer_user_id, {
+      customer_user_id: s.customer_user_id,
+      health_score: s.health_score ?? 0,
+      health_class: s.health_class ?? 'critico',
+      churn_risk: s.churn_risk ?? 0,
+      expansion_score: s.expansion_score ?? 0,
+      priority_score: s.priority_score ?? 0,
+      avg_monthly_spend_180d: s.avg_monthly_spend_180d ?? 0,
+      days_since_last_purchase: s.days_since_last_purchase ?? 0,
+      category_count: s.category_count ?? 0,
+      gross_margin_pct: s.gross_margin_pct ?? 0,
+    });
+  }
+  return map;
 }

--- a/src/lib/impersonation/__tests__/no-write-leak.test.ts
+++ b/src/lib/impersonation/__tests__/no-write-leak.test.ts
@@ -46,6 +46,15 @@ const ALLOWED = new Set([
   // useFarmerScoring: effectiveUserId na leitura/cálculo da agenda do alvo; o upsert de scores
   // é PULADO na lente (skip por isImpersonating) — o master não recalcula a carteira do alvo.
   'src/hooks/useFarmerScoring.ts',
+  // Clientes (/admin/customers): useClientesScope escopa a LEITURA da lista pro alvo da lente
+  // (effectiveUserId só filtra carteira_assignments/scores — read-only, é o hook que importa
+  // useDisplayAccess e NÃO tem mutação). useAdminCustomers recebe effectiveUserId do scope
+  // SÓ pra resetar o detalhe ao trocar de lente; a escrita (handleDeleteTool) usa toolId +
+  // sessão real, nunca effectiveUserId. escopo-clientes usa effectiveUserId como filtro de
+  // leitura (.eq owner_user_id na lente), sem mutação.
+  'src/components/adminCustomers/useClientesScope.ts',
+  'src/components/adminCustomers/useAdminCustomers.ts',
+  'src/lib/carteira/escopo-clientes.ts',
 ]);
 
 describe('anti write-leak: effectiveUserId só em leitura', () => {

--- a/src/pages/AdminCustomers.tsx
+++ b/src/pages/AdminCustomers.tsx
@@ -15,6 +15,8 @@ const AdminCustomers = () => {
     customers,
     scores,
     categories,
+    total,
+    isCarteira,
     selectedCustomer,
     customerTools,
     orders,
@@ -69,6 +71,8 @@ const AdminCustomers = () => {
           customers={customers}
           scores={scores}
           loading={loading}
+          total={total}
+          isCarteira={isCarteira}
           onSelect={handleSelectCustomer}
           hasNextPage={hasNextPage}
           isFetchingNextPage={isFetchingNextPage}


### PR DESCRIPTION
## Resumo

A tela de Clientes (`/admin/customers`) mostrava a **base inteira** pra todo staff, com scores **não-lente-aware** (usavam o `farmer_id` do master logado) e contagem enganosa (length da página, ~100). Agora:

- **Vendedor** vê só a **carteira dele + cobertura ativa** (a RLS `carteira_visivel_para` de `carteira_assignments` escopa); **gestor/master** seguem vendo a base inteira.
- **Na lente "Ver como pessoa"**, reflete a carteira da vendedora vista (`.eq('owner_user_id', effectiveUserId)`, já que a sessão é a do master).
- **Contagem real**: no modo carteira carrego a carteira inteira (length exato + busca varre tudo); no modo base, `count` exato no servidor.
- **Scores por `customer_user_id`** (não `farmer_id`): conserta scores vazios pro gestor/master e stale pós-reatribuição; a RLS reforça.
- Reset do detalhe ao **trocar de lente**; badge **N/A** quando não há score; badge de **cobertura**.

**Frontend-only** (sem migration, sem edge). Design revisado pelo **Codex** (5 P1 incorporados: paginar `carteira_assignments`, scores por customer, filtrar `eligible=true`, reset de lente, chunk seguro de `.in()`). Spec + plano em `docs/superpowers/`.

## Arquivos
- `src/lib/carteira/escopo-clientes.ts` (novo) — helpers puros + glue (`fetchCarteiraClientes`/`fetchScoresPorCustomer`).
- `src/components/adminCustomers/useClientesScope.ts` (novo) — leitura lente-aware, **isolada das mutações** p/ o guard `display-access-no-write`.
- `useAdminCustomers.ts` · `CustomerListView.tsx` · `AdminCustomers.tsx` · `types.ts`.

## Test plan
- [x] `bun run test` — **3148/3148** (17 novos + 3 ajustados)
- [x] `bun lint` limpo · `bun run build` ok (48s) · typecheck do meu código **type-clean**
- [ ] **Publish no Lovable** (frontend-only — precisa pra ir ao ar)
- [ ] QA: vendedora → só a carteira dela; lente "Ver como X" → carteira de X; gestor/master → base inteira + "na base"

## ⚠️ Bloqueio de CI PRÉ-EXISTENTE (não deste PR)
O check `validate` falha no **typecheck** por `src/hooks/useMelhorias.ts`: a tabela `melhoria_itens` **não está nos tipos gerados** — nem na `main` HEAD. **Regenerar os tipos no Lovable** destrava. Não é editável na mão (#186 quebrou com `Duplicate identifier`). Afeta o CI de qualquer branch.

## Limitações v1
- Na lente, carteira-**base** do alvo (a cobertura da vendedora real logada funciona 100%).
- 2 P2: `scoresQuery` O(n) no modo completa com scroll profundo (só gestor/master); empty-state title fixo.
- **Codex review do diff pendente** (cota esgotada, volta 12/06) — Caminho B: revisão própria feita, sem P1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)