### PR TITLE
feat(carteira): backfill de cadastro Omie → profiles dos clientes-fantasma (corrige /admin/customers na lente)

### DIFF
--- a/docs/superpowers/specs/2026-06-12-clientes-cadastro-backfill-design.md
+++ b/docs/superpowers/specs/2026-06-12-clientes-cadastro-backfill-design.md
@@ -1,0 +1,132 @@
+# Backfill de cadastro Omie → profiles (clientes-fantasma da carteira) — Design
+
+> Data: 2026-06-12. Origem: founder viu `/admin/customers` na lente mostrar 1 cliente (Tatiana) / 7 (Regina), quando a carteira é 571 / 674.
+
+## Problema (root cause confirmado por dados)
+
+A tela `/admin/customers` (modo carteira, PR #763) lista a carteira cruzando `carteira_assignments` (`customer_user_id` → `auth.users`) com `profiles` via **INNER JOIN** (`.in('user_id', ids).eq('is_employee', false)` em `src/lib/carteira/escopo-clientes.ts`). A carteira da vendedora é majoritariamente de **clientes-só-Omie**: têm `auth.users` + `omie_clientes` + `carteira_assignments` + scores, mas **não têm `profiles`**. O join derruba 571→1 / 674→7.
+
+`eligible` (rebuild nunca seta `false`) e `owner` (lente usa o próprio `owner_user_id`) descartados por código. O nome/telefone/documento do cliente vem de `profiles` em **todo** o app (até `customer_metrics_mv` deriva `razao_social` de `p.name`); nenhuma tabela Omie sincronizada guarda a razão social dos vinculados — só o Omie (`ListarClientes`).
+
+## Dados (dry-run em prod, 2026-06-12)
+
+- `omie_clientes` sem `profiles` = **1.633** (não os ~6.900 estimados — a maioria da carteira já tem profile, são os ~5.273 do balde Hunter).
+- Desses 1.633: **100% têm email + senha**, mas domínio único **`placeholder.local`**, **`ja_logou=0`**, **`banidos=0`**, todos criados em **2026-03-01** (um import em massa), **`com_role_nao_customer=0`**.
+- Leitura: são **contas-fantasma de import** (esqueleto auth+omie_clientes+carteira+score, sem cadastro). Email placeholder não recebe → senha aleatória inalcançável → **login inviável**. Criar profile é seguro (não dá senha, não muda email; só dá nome e torna visível na carteira).
+
+## Decisão
+
+Popular `profiles` para os clientes vinculados (`omie_clientes`) sem profile, puxando o cadastro do Omie (`ListarClientes`). Conserta a tela **e** o app todo (scores/positivação/rota/Customer360 deixam de cair no fallback "Cliente"). Backfill **desacoplado** (só escreve `profiles`; não toca `omie_clientes`/carteira/scores).
+
+Validado com Codex (consult 2026-06-12): direção aprovada, 4 P1 incorporados abaixo.
+
+## Salvaguardas (Codex P1 + dados)
+
+1. **`created_at` = `auth.users.created_at` (março), nunca `now()`.** O `visit-score-recalc-client` trata profile < 30 dias como "prospecção recente" e dá bônus; com `now()` os 1.633 virariam prospect quente falso na rota. Usar a data real (março → > 30d → neutro).
+2. **Filtrar `prospect_source='omie_import'` da fila/KPI de aprovação** (`AdminApprovals` + `useSistemaZone`) **antes** do backfill. Senão `is_approved=false` joga 1.633 pendências falsas na fila — e "rejeitar" lá apaga só o profile, deixando auth/carteira/score órfãos. Fase 1 = front-only.
+3. **Pular documento == `master_cnpj`.** O trigger `auto_assign_user_role` (AFTER INSERT em `profiles`) cria role `master` se `document` normalizado == `company_config.master_cnpj`. O edge lê `master_cnpj` e **exclui** esses do lote (não toco o trigger money-path). `com_role_nao_customer=0` hoje → o único vetor é esse.
+4. **Casar por `(conta, código)`, processar uma conta por vez.** `omie_codigo_cliente` repete entre Oben/Colacor/Colacor SC. `ListarClientes` é por conta → o cadastro de cada conta casa só com clientes daquela conta. Vínculo ambíguo (mesmo código em mais de uma conta apontando user_ids diferentes) → reportar, não adivinhar.
+
+Outras decisões:
+- **Colisão de documento:** se o documento já existe em **outro** profile → **pular e reportar** (reapontar carteira/omie_clientes criaria split-brain de identidade — fora de escopo). Dedup também **intra-lote**.
+- **Documento inválido/vazio → `NULL`** (nunca `''` nem máscara; não inventar identidade fiscal). `NULL ≠ master_cnpj` no trigger → cai em `customer` corretamente.
+- **`is_approved=false`** (defesa em profundidade; o controle real é o email inalcançável). `is_employee=false`, `prospect_source='omie_import'`.
+- **Insert-only, `ON CONFLICT DO NOTHING`.** Nunca atualiza profile existente. Idempotente (re-run só insere o que falta).
+
+## Arquitetura
+
+- **Helper puro TDD** `src/lib/clientes-cadastro/backfill-helpers.ts` (espelhado verbatim no edge — Deno não importa de `src/`):
+  - `normalizarDocumento(raw): string | null` — só dígitos; 11 (CPF) ou 14 (CNPJ); rejeita todos-iguais; senão `null`.
+  - `decidirLinhaProfile(args): { acao: 'inserir', row } | { acao: 'pular', motivo }` — aplica master_cnpj, dedup (existentes + intra-lote via Set acumulado), monta a linha (`name: nome_fantasia||razao_social||'Cliente'`, `phone`, `document`, `customer_type`, `prospect_source:'omie_import'`, `is_employee:false`, `is_approved:false`, `created_at`).
+  - `classificarTelefone(ddd, numero): string | null`.
+- **Edge** = nova action `start_backfill_cadastro` no `omie-analytics-sync` (reusa `callOmie`/`getCredentials`/`accountToEmpresa`/paginação; desacoplado, igual ao `syncNaoVinculados`):
+  1. Por conta: `ListarClientes` todas as páginas → mapa `codigo → cadastro`.
+  2. Carrega `omie_clientes` (user_id, codigo) sem profile + `auth.users.created_at` (admin) + `master_cnpj`.
+  3. Carrega documentos de `profiles` existentes (dedup).
+  4. `decidirLinhaProfile` por user_id → bulk insert `ON CONFLICT DO NOTHING`.
+  5. **`dry_run`**: conta inseríveis / pulados-por-motivo / ambíguos, sem escrever.
+  6. Lock de execução (não rodar 2x). Relatório de pulados.
+
+## Fases
+
+- **Fase 1 (front):** filtro `omie_import` em `AdminApprovals` + `useSistemaZone`. Sem migration.
+- **Fase 2 (edge):** helper TDD + action `start_backfill_cadastro` com `dry_run`.
+- **Fase 3 (canário):** `dry_run` → conferir números → 100 → comparar scores/contagens → resto + 1 refresh da `customer_metrics_mv`.
+- **Fase 4 (cron):** noturno após o sync do Omie (clientes novos ganham profile). Migration leve do cron.
+- **Codex adversarial retroativo** no edge antes do canário (precedente money-path do CLAUDE.md §10).
+
+## Não-objetivos (v1)
+
+- Reapontar `carteira_assignments`/`omie_clientes` em colisão (split-brain — exige merge de identidade).
+- Criar `auth.users` (já existem).
+- Mexer no trigger `auto_assign_user_role` (blindagem é no edge).
+- Atualizar profiles existentes (insert-only).
+- Telefone/cidade como fonte canônica (best-effort do cadastro Omie).
+
+## Correções pós-Codex adversarial (2026-06-12) — ✅ APLICADAS
+
+Codex deu **Gate FAIL** no edge v1. As 7 correções abaixo foram aplicadas; CI local verde
+(typecheck strict EXIT 0 · 3194 testes vitest · lint 0 errors · `deno check` net-zero = só os 3 erros
+pré-existentes `cost_price`/`saldo` em `computeCosts`/`syncInventory`, nenhum nas funções de backfill).
+Codex output completo em `/tmp/codex-challenge-out.txt`.
+
+**P1 (bloqueantes) — feitos:**
+1. **Casamento por código reescrito** (`fetchAlvosSemProfile` + `syncBackfillCadastro`). `fetchAlvosSemProfile`
+   agora retorna `Map<codigo, {userId,createdAt}[]>` (**lista, nunca last-wins**). `syncBackfillCadastro`
+   enumera as **3 contas Omie numa invocação** (sem param `account`), monta `candidatosPorUser: Map<userId,
+   {account,cadastro}[]>` e decide por user: **0 candidatos → `sem_match`**; **candidatos de >1 conta distinta
+   → `ambiguos` (tipo A)**; **código com >1 user_id (`codigosAmbiguos`) → `ambiguos` (tipo B)**; senão decide
+   com `cands[0]`. `omie_clientes` é UNIQUE(user_id) → 1 código por user (simplifica). `sync_state` virou
+   estado único `account="all"`.
+2. **`master_cnpj` fail-CLOSED.** Leitura com `error` capturado → `throw`; normaliza (tira aspas jsonb + só
+   dígitos) e **`throw` se length ∉ {11,14}** (ausente/inválido aborta o backfill). + migration
+   `20260612120000_auto_assign_role_omie_import_guard.sql`: `CREATE OR REPLACE auto_assign_user_role`
+   **verbatim do corpo vivo do snapshot** + `AND COALESCE(NEW.prospect_source,'') <> 'omie_import'` no ramo
+   master. (CHECK de `prospect_source` JÁ inclui `'omie_import'` em prod → sem migration de CHECK.)
+3. **Canário determinístico.** Action aceita `limite` (validado `>0`, `Math.floor`); `rows` ordenadas por
+   `user_id` antes do `slice(0, limite)`. Relatório expõe `seriam_inseridos` vs `inseridos`.
+4. **Fila de aprovação server-side** (`AdminApprovals.tsx`). Filtro movido pro PostgREST
+   `.or('prospect_source.is.null,prospect_source.neq.omie_import')` (string literal estática → passa o
+   `no-restricted-syntax`); removido o filtro client-side `prospect_source` (só sobrou `!employeeIds.has`).
+
+**P2 (importantes) — feitos:**
+5. **DV real de CPF/CNPJ** (`cpfDvValido`/`cnpjDvValido` mod 11) no `normalizarDocumento` (helper + espelho
+   verbatim no edge). DV inválido → `null` → `document=NULL` (não inventa identidade). Testes: trocados os
+   docs por DV-válidos (`123.456.789-09`, `11.222.333/0001-81`) + casos DV-inválido→null; `masterCnpj` de
+   teste `99887766000155` (era DV-inválido) → `11222333000181`. 17→19 testes.
+6. **Fallback linha-a-linha** (`inserirProfilesComFallback`). Chunk falho (conflito do
+   `idx_profiles_document_unique`, não coberto por `ON CONFLICT(user_id)`) → re-insere linha-a-linha,
+   conta `conflitos_documento` (23505) sem abortar; erro ≠ 23505 → `throw`.
+7. **Relatório rico** — `alvos_total`, `total_omie`, `com_match`, `sem_match`, `ambiguos`, `inseriveis`,
+   `seriam_inseridos`, `inseridos`, `conflitos_documento`, `pulados{}`, `created_at_recente` (<35d, sinaliza
+   relink), `contas_processadas`/`contas_sem_credencial`, `amostra` (5× `{user_id, document, name}`).
+
+**Aceitos/documentados (não-bloqueantes):** `created_at = omie_clientes.created_at` é OK pro lote de março
+(Codex concordou); Fase 4 (cron) deve usar `LEAST(auth.users.created_at, omie_clientes.created_at)` via RPC.
+Lock não-atômico/15min é o padrão do repo (`start_nao_vinculados`). `updateSyncState` best-effort.
+
+⚠️ **Pendências do founder após o merge:** (1) **deploy** do `omie-analytics-sync` via chat do Lovable
+(verbatim da main, **só após mergear** — senão pega a main velha e responde "Ação desconhecida"); (2) colar a
+migration `20260612120000` no **SQL Editor** (defesa em profundidade — não bloqueia o dry_run, mas aplicar
+antes da escrita real); (3) rodar o **canário** (dry_run → `sync_state` relatório → `limite:100` → conferir →
+lote inteiro), comandos abaixo.
+
+### Comandos de operação (SQL Editor → `net.http_post`, header `x-cron-secret` do Vault)
+
+```sql
+-- DRY-RUN (não escreve; lê o relatório em sync_state):
+select net.http_post(
+  url := 'https://fzvklzpomgnyikkfkzai.supabase.co/functions/v1/omie-analytics-sync',
+  headers := jsonb_build_object('Content-Type','application/json',
+    'x-cron-secret', (select decrypted_secret from vault.decrypted_secrets where name='CRON_SECRET' limit 1)),
+  body := jsonb_build_object('action','start_backfill_cadastro','dry_run',true),
+  timeout_milliseconds := 150000);
+-- aguardar ~1-2 min, então:
+select status, metadata from sync_state where entity_type='backfill_cadastro' and account='all';
+```
+Canário 100: trocar o `body` por `'dry_run',false,'limite',100`. Lote inteiro: `'dry_run',false` (sem limite).
+Após o lote: 1 refresh da `customer_metrics_mv` (Fase 3).
+
+## Critério de pronto
+
+`/admin/customers` na lente da Tatiana/Regina mostra a carteira com **nome** (não "1"/"7"); os scores de visita **não** ganham bônus de "prospect recente" falso (created_at preservado); a fila de aprovação **não** mostra os 1.633.

--- a/src/hooks/dashboard/useSistemaZone.ts
+++ b/src/hooks/dashboard/useSistemaZone.ts
@@ -38,6 +38,8 @@ export function useSistemaZone() {
           .from('profiles')
           .select('user_id, name, created_at', { count: 'exact' })
           .eq('is_approved', false)
+          // Exclui clientes-fantasma importados do Omie (nunca pediram conta) do KPI de pendências.
+          .or('prospect_source.is.null,prospect_source.neq.omie_import')
           .order('created_at', { ascending: true })
           .limit(3);
         aprovacoesPendentes = count ?? 0;

--- a/src/lib/clientes-cadastro/__tests__/backfill-helpers.test.ts
+++ b/src/lib/clientes-cadastro/__tests__/backfill-helpers.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from 'vitest';
+import {
+  normalizarDocumento,
+  montarTelefone,
+  decidirLinhaProfile,
+} from '@/lib/clientes-cadastro/backfill-helpers';
+
+describe('normalizarDocumento', () => {
+  it('aceita CPF DV-válido (11 dígitos) e remove máscara', () => {
+    expect(normalizarDocumento('123.456.789-09')).toBe('12345678909');
+    expect(normalizarDocumento('111.444.777-35')).toBe('11144477735');
+  });
+  it('aceita CNPJ DV-válido (14 dígitos) e remove máscara', () => {
+    expect(normalizarDocumento('12.345.678/0001-95')).toBe('12345678000195');
+    expect(normalizarDocumento('11.222.333/0001-81')).toBe('11222333000181');
+  });
+  it('rejeita CPF com dígito verificador inválido → null', () => {
+    expect(normalizarDocumento('123.456.789-00')).toBeNull(); // DV errado
+    expect(normalizarDocumento('12345678901')).toBeNull();
+  });
+  it('rejeita CNPJ com dígito verificador inválido → null', () => {
+    expect(normalizarDocumento('12.345.678/0001-99')).toBeNull(); // DV errado
+    expect(normalizarDocumento('11222333000180')).toBeNull();
+  });
+  it('rejeita comprimento inválido → null', () => {
+    expect(normalizarDocumento('123')).toBeNull();
+    expect(normalizarDocumento('123456789012')).toBeNull(); // 12 dígitos
+  });
+  it('rejeita todos os dígitos iguais (sentinela) → null', () => {
+    expect(normalizarDocumento('00000000000')).toBeNull();
+    expect(normalizarDocumento('11111111111111')).toBeNull();
+  });
+  it('vazio / null / undefined / só letras → null', () => {
+    expect(normalizarDocumento('')).toBeNull();
+    expect(normalizarDocumento(null)).toBeNull();
+    expect(normalizarDocumento(undefined)).toBeNull();
+    expect(normalizarDocumento('ABC')).toBeNull();
+  });
+});
+
+describe('montarTelefone', () => {
+  it('junta ddd + numero (só dígitos)', () => {
+    expect(montarTelefone('(31)', '3333-4444')).toBe('3133334444');
+  });
+  it('só número, sem ddd', () => {
+    expect(montarTelefone(null, '33334444')).toBe('33334444');
+  });
+  it('vazio / curto demais → null', () => {
+    expect(montarTelefone('', '')).toBeNull();
+    expect(montarTelefone(null, '123')).toBeNull();
+  });
+});
+
+const baseArgs = () => ({
+  userId: 'u1',
+  authCreatedAt: '2026-03-01T00:00:00Z',
+  cadastro: {
+    razao_social: 'INDUSTRIA MOVELEIRA LTDA',
+    nome_fantasia: 'MoveBem',
+    cnpj_cpf: '12.345.678/0001-95',
+    telefone_ddd: '31',
+    telefone_numero: '3333-4444',
+  },
+  masterCnpj: '11222333000181', // CNPJ DV-válido ≠ documento-base
+  docsExistentes: new Set<string>(),
+  docsNoLote: new Set<string>(),
+});
+
+describe('decidirLinhaProfile — inserção', () => {
+  it('monta a linha com nome_fantasia preferido e created_at preservado (NÃO now())', () => {
+    const d = decidirLinhaProfile(baseArgs());
+    expect(d.acao).toBe('inserir');
+    if (d.acao !== 'inserir') return;
+    expect(d.row).toMatchObject({
+      user_id: 'u1',
+      name: 'MoveBem',
+      phone: '3133334444',
+      document: '12345678000195',
+      customer_type: null,
+      prospect_source: 'omie_import',
+      is_employee: false,
+      is_approved: false,
+      created_at: '2026-03-01T00:00:00Z', // não a data do backfill
+    });
+  });
+
+  it('cai pra razao_social quando não há nome_fantasia', () => {
+    const a = baseArgs();
+    a.cadastro.nome_fantasia = null as unknown as string;
+    const d = decidirLinhaProfile(a);
+    expect(d.acao === 'inserir' && d.row.name).toBe('INDUSTRIA MOVELEIRA LTDA');
+  });
+
+  it("usa 'Cliente' quando não há nome nenhum", () => {
+    const a = baseArgs();
+    a.cadastro.nome_fantasia = null as unknown as string;
+    a.cadastro.razao_social = '   ' as unknown as string;
+    const d = decidirLinhaProfile(a);
+    expect(d.acao === 'inserir' && d.row.name).toBe('Cliente');
+  });
+
+  it('documento inválido → insere com document NULL (não pula)', () => {
+    const a = baseArgs();
+    a.cadastro.cnpj_cpf = '000' as unknown as string;
+    const d = decidirLinhaProfile(a);
+    expect(d.acao).toBe('inserir');
+    expect(d.acao === 'inserir' && d.row.document).toBeNull();
+  });
+});
+
+describe('decidirLinhaProfile — bloqueios de segurança e dedup', () => {
+  it('documento == master_cnpj → pula (trigger promoveria a master); compara normalizado', () => {
+    const a = baseArgs();
+    a.cadastro.cnpj_cpf = '11.222.333/0001-81'; // == masterCnpj com máscara
+    const d = decidirLinhaProfile(a);
+    expect(d).toEqual({ acao: 'pular', motivo: 'master_cnpj' });
+  });
+
+  it('documento já existe em outro profile → pula', () => {
+    const a = baseArgs();
+    a.docsExistentes = new Set(['12345678000195']);
+    const d = decidirLinhaProfile(a);
+    expect(d).toEqual({ acao: 'pular', motivo: 'doc_em_outro_profile' });
+  });
+
+  it('documento duplicado dentro do próprio lote → pula', () => {
+    const a = baseArgs();
+    a.docsNoLote = new Set(['12345678000195']);
+    const d = decidirLinhaProfile(a);
+    expect(d).toEqual({ acao: 'pular', motivo: 'doc_duplicado_no_lote' });
+  });
+
+  it('master_cnpj só bloqueia com documento; doc inválido NÃO vira master por coincidência vazia', () => {
+    const a = baseArgs();
+    a.cadastro.cnpj_cpf = 'XYZ' as unknown as string; // normaliza p/ null
+    a.masterCnpj = '' as unknown as string;            // master vazio
+    const d = decidirLinhaProfile(a);
+    expect(d.acao).toBe('inserir'); // null != '' → não bloqueia; document NULL
+    expect(d.acao === 'inserir' && d.row.document).toBeNull();
+  });
+
+  it('dedup tem precedência sobre inserção, mas master_cnpj tem precedência sobre dedup', () => {
+    const a = baseArgs();
+    a.cadastro.cnpj_cpf = '11222333000181';     // == master
+    a.docsExistentes = new Set(['11222333000181']); // e também já existe
+    const d = decidirLinhaProfile(a);
+    expect(d).toEqual({ acao: 'pular', motivo: 'master_cnpj' }); // master ganha
+  });
+});

--- a/src/lib/clientes-cadastro/backfill-helpers.ts
+++ b/src/lib/clientes-cadastro/backfill-helpers.ts
@@ -1,0 +1,132 @@
+// Helpers puros do backfill de cadastro Omie → profiles (clientes-fantasma da carteira).
+// ESPELHADO verbatim na action `start_backfill_cadastro` do edge omie-analytics-sync
+// (Deno não importa de src/). Spec: docs/superpowers/specs/2026-06-12-clientes-cadastro-backfill-design.md
+//
+// Princípio: o backfill só dá NOME a contas que já existem (auth.users + omie_clientes).
+// Nunca cria auth, nunca reaponta carteira, nunca atualiza profile existente.
+
+/** DV de CPF (mod 11). Recebe 11 dígitos já sem sentinela. */
+function cpfDvValido(cpf: string): boolean {
+  let soma = 0;
+  for (let i = 0; i < 9; i++) soma += Number(cpf[i]) * (10 - i);
+  let resto = soma % 11;
+  const dv1 = resto < 2 ? 0 : 11 - resto;
+  if (dv1 !== Number(cpf[9])) return false;
+  soma = 0;
+  for (let i = 0; i < 10; i++) soma += Number(cpf[i]) * (11 - i);
+  resto = soma % 11;
+  const dv2 = resto < 2 ? 0 : 11 - resto;
+  return dv2 === Number(cpf[10]);
+}
+
+/** DV de CNPJ (mod 11, pesos padrão). Recebe 14 dígitos já sem sentinela. */
+function cnpjDvValido(cnpj: string): boolean {
+  const p1 = [5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2];
+  const p2 = [6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2];
+  let soma = 0;
+  for (let i = 0; i < 12; i++) soma += Number(cnpj[i]) * p1[i];
+  let resto = soma % 11;
+  const dv1 = resto < 2 ? 0 : 11 - resto;
+  if (dv1 !== Number(cnpj[12])) return false;
+  soma = 0;
+  for (let i = 0; i < 13; i++) soma += Number(cnpj[i]) * p2[i];
+  resto = soma % 11;
+  const dv2 = resto < 2 ? 0 : 11 - resto;
+  return dv2 === Number(cnpj[13]);
+}
+
+/**
+ * Só dígitos; aceita CPF (11) ou CNPJ (14) com DÍGITO VERIFICADOR válido; rejeita sentinela
+ * (todos iguais). Documento com DV inválido (erro de digitação no Omie) → null: o backfill o trata
+ * como ausência (document=NULL), nunca como identidade fiscal real (evita colisão falsa e lixo).
+ */
+export function normalizarDocumento(raw: string | null | undefined): string | null {
+  const d = (raw ?? '').replace(/\D/g, '');
+  if (d.length !== 11 && d.length !== 14) return null;
+  if (/^(\d)\1+$/.test(d)) return null; // 000…/111… = lixo de cadastro, nunca identidade real
+  if (d.length === 11 && !cpfDvValido(d)) return null;
+  if (d.length === 14 && !cnpjDvValido(d)) return null;
+  return d;
+}
+
+/** Junta DDD + número (só dígitos). Curto demais (< 8) → null. */
+export function montarTelefone(
+  ddd: string | null | undefined,
+  numero: string | null | undefined,
+): string | null {
+  const full = ((ddd ?? '') + (numero ?? '')).replace(/\D/g, '');
+  return full.length >= 8 ? full : null;
+}
+
+export interface CadastroOmie {
+  razao_social?: string | null;
+  nome_fantasia?: string | null;
+  cnpj_cpf?: string | null;
+  telefone_ddd?: string | null;
+  telefone_numero?: string | null;
+}
+
+export interface ProfileRow {
+  user_id: string;
+  name: string;
+  phone: string | null;
+  document: string | null;
+  customer_type: string | null;
+  prospect_source: 'omie_import';
+  is_employee: false;
+  is_approved: false;
+  created_at: string;
+}
+
+export type MotivoPular =
+  | 'master_cnpj'
+  | 'doc_em_outro_profile'
+  | 'doc_duplicado_no_lote';
+
+export type DecisaoBackfill =
+  | { acao: 'inserir'; row: ProfileRow }
+  | { acao: 'pular'; motivo: MotivoPular };
+
+export interface DecidirArgs {
+  userId: string;
+  /** auth.users.created_at — preservar a data REAL (março), nunca a do backfill (distorceria o score de visita). */
+  authCreatedAt: string;
+  cadastro: CadastroOmie;
+  /** company_config.master_cnpj — documento que o trigger promove a master. */
+  masterCnpj: string | null;
+  /** documentos normalizados que JÁ existem em profiles (dedup vs base). */
+  docsExistentes: Set<string>;
+  /** documentos normalizados já decididos NESTE lote (dedup intra-lote; o chamador adiciona após cada 'inserir'). */
+  docsNoLote: Set<string>;
+}
+
+/**
+ * Decide a linha de profile de UM cliente-fantasma. Precedência:
+ *   master_cnpj (segurança) > dedup-existente > dedup-lote > inserir.
+ * Documento inválido NÃO bloqueia: insere com document=NULL (o vínculo canônico é user_id+omie_clientes).
+ */
+export function decidirLinhaProfile(args: DecidirArgs): DecisaoBackfill {
+  const { userId, authCreatedAt, cadastro, masterCnpj, docsExistentes, docsNoLote } = args;
+  const doc = normalizarDocumento(cadastro.cnpj_cpf);
+
+  if (doc) {
+    const masterNorm = (masterCnpj ?? '').replace(/\D/g, '');
+    if (masterNorm && doc === masterNorm) return { acao: 'pular', motivo: 'master_cnpj' };
+    if (docsExistentes.has(doc)) return { acao: 'pular', motivo: 'doc_em_outro_profile' };
+    if (docsNoLote.has(doc)) return { acao: 'pular', motivo: 'doc_duplicado_no_lote' };
+  }
+
+  const nome = (cadastro.nome_fantasia?.trim() || cadastro.razao_social?.trim() || '').trim();
+  const row: ProfileRow = {
+    user_id: userId,
+    name: nome || 'Cliente',
+    phone: montarTelefone(cadastro.telefone_ddd, cadastro.telefone_numero),
+    document: doc,
+    customer_type: null, // app infere PJ/PF do documento; não inventar 'industrial'
+    prospect_source: 'omie_import',
+    is_employee: false,
+    is_approved: false,
+    created_at: authCreatedAt,
+  };
+  return { acao: 'inserir', row };
+}

--- a/src/pages/AdminApprovals.tsx
+++ b/src/pages/AdminApprovals.tsx
@@ -49,8 +49,13 @@ const AdminApprovals = () => {
 
       const { data, error } = await supabase
         .from('profiles')
-        .select('id, user_id, name, email, phone, document, customer_type, created_at')
+        .select('id, user_id, name, email, phone, document, customer_type, created_at, prospect_source')
         .eq('is_approved', false)
+        // Clientes-fantasma importados do Omie (prospect_source='omie_import') nunca pediram conta:
+        // exclui-los NO SERVIDOR (antes do cap de 1000 do PostgREST) é obrigatório — com 1.633 imports,
+        // filtrar só no cliente truncaria as pendências REAIS fora da janela
+        // (ver docs/superpowers/specs/2026-06-12-clientes-cadastro-backfill-design.md).
+        .or('prospect_source.is.null,prospect_source.neq.omie_import')
         .order('created_at', { ascending: false });
 
       if (error) throw error;

--- a/supabase/functions/omie-analytics-sync/index.ts
+++ b/supabase/functions/omie-analytics-sync/index.ts
@@ -1030,6 +1030,289 @@ async function computeAssociationRules(db: SupabaseClient) {
   return { rules_generated: inserted, total_transactions: totalTx, frequent_items: frequentItems.size };
 }
 
+// ======== BACKFILL DE CADASTRO — profiles dos clientes-fantasma da carteira ========
+// Dá NOME (do Omie) aos clientes vinculados (omie_clientes) que têm auth.users mas não têm profile,
+// fazendo /admin/customers mostrar a carteira inteira da vendedora. DESACOPLADO: só escreve profiles
+// (não toca omie_clientes/carteira/scores). Insert-only. Spec:
+// docs/superpowers/specs/2026-06-12-clientes-cadastro-backfill-design.md
+// Os 3 helpers abaixo são ESPELHO VERBATIM de src/lib/clientes-cadastro/backfill-helpers.ts.
+
+function cpfDvValido(cpf: string): boolean {
+  let soma = 0;
+  for (let i = 0; i < 9; i++) soma += Number(cpf[i]) * (10 - i);
+  let resto = soma % 11;
+  const dv1 = resto < 2 ? 0 : 11 - resto;
+  if (dv1 !== Number(cpf[9])) return false;
+  soma = 0;
+  for (let i = 0; i < 10; i++) soma += Number(cpf[i]) * (11 - i);
+  resto = soma % 11;
+  const dv2 = resto < 2 ? 0 : 11 - resto;
+  return dv2 === Number(cpf[10]);
+}
+
+function cnpjDvValido(cnpj: string): boolean {
+  const p1 = [5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2];
+  const p2 = [6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2];
+  let soma = 0;
+  for (let i = 0; i < 12; i++) soma += Number(cnpj[i]) * p1[i];
+  let resto = soma % 11;
+  const dv1 = resto < 2 ? 0 : 11 - resto;
+  if (dv1 !== Number(cnpj[12])) return false;
+  soma = 0;
+  for (let i = 0; i < 13; i++) soma += Number(cnpj[i]) * p2[i];
+  resto = soma % 11;
+  const dv2 = resto < 2 ? 0 : 11 - resto;
+  return dv2 === Number(cnpj[13]);
+}
+
+function normalizarDocumento(raw: string | null | undefined): string | null {
+  const d = (raw ?? "").replace(/\D/g, "");
+  if (d.length !== 11 && d.length !== 14) return null;
+  if (/^(\d)\1+$/.test(d)) return null;
+  if (d.length === 11 && !cpfDvValido(d)) return null;
+  if (d.length === 14 && !cnpjDvValido(d)) return null;
+  return d;
+}
+
+function montarTelefone(ddd: string | null | undefined, numero: string | null | undefined): string | null {
+  const full = ((ddd ?? "") + (numero ?? "")).replace(/\D/g, "");
+  return full.length >= 8 ? full : null;
+}
+
+interface BackfillCadastro {
+  razao_social?: string | null;
+  nome_fantasia?: string | null;
+  cnpj_cpf?: string | null;
+  telefone_ddd?: string | null;
+  telefone_numero?: string | null;
+}
+interface BackfillProfileRow {
+  user_id: string; name: string; phone: string | null; document: string | null;
+  customer_type: string | null; prospect_source: "omie_import";
+  is_employee: false; is_approved: false; created_at: string;
+}
+type BackfillDecisao =
+  | { acao: "inserir"; row: BackfillProfileRow }
+  | { acao: "pular"; motivo: "master_cnpj" | "doc_em_outro_profile" | "doc_duplicado_no_lote" };
+
+function decidirLinhaProfile(args: {
+  userId: string; authCreatedAt: string; cadastro: BackfillCadastro;
+  masterCnpj: string | null; docsExistentes: Set<string>; docsNoLote: Set<string>;
+}): BackfillDecisao {
+  const { userId, authCreatedAt, cadastro, masterCnpj, docsExistentes, docsNoLote } = args;
+  const doc = normalizarDocumento(cadastro.cnpj_cpf);
+  if (doc) {
+    const masterNorm = (masterCnpj ?? "").replace(/\D/g, "");
+    if (masterNorm && doc === masterNorm) return { acao: "pular", motivo: "master_cnpj" };
+    if (docsExistentes.has(doc)) return { acao: "pular", motivo: "doc_em_outro_profile" };
+    if (docsNoLote.has(doc)) return { acao: "pular", motivo: "doc_duplicado_no_lote" };
+  }
+  const nome = (cadastro.nome_fantasia?.trim() || cadastro.razao_social?.trim() || "").trim();
+  const row: BackfillProfileRow = {
+    user_id: userId, name: nome || "Cliente",
+    phone: montarTelefone(cadastro.telefone_ddd, cadastro.telefone_numero),
+    document: doc, customer_type: null, prospect_source: "omie_import",
+    is_employee: false, is_approved: false, created_at: authCreatedAt,
+  };
+  return { acao: "inserir", row };
+}
+
+// Mapa codigo_cliente_omie → [{ userId, createdAt }] dos clientes SEM profile (carteira-fantasma).
+// É LISTA, não last-wins: o mesmo código pode apontar p/ >1 user_id (vínculo bagunçado) → ambíguo,
+// nunca sobrescreve silenciosamente. createdAt = omie_clientes.created_at (data REAL do vínculo, ~março)
+// — preservar evita que o backfill marque os profiles como "criados hoje" e o visit-score os trate como
+// prospecção recente.
+async function fetchAlvosSemProfile(
+  db: SupabaseClient,
+): Promise<Map<number, { userId: string; createdAt: string }[]>> {
+  const comProfile = new Set<string>();
+  for (let from = 0; ; from += 1000) {
+    const { data, error } = await db.from("profiles").select("user_id").range(from, from + 999);
+    if (error) throw new Error(`fetch profiles user_id: ${error.message}`);
+    const rows = (data ?? []) as { user_id: string }[];
+    for (const r of rows) comProfile.add(r.user_id);
+    if (rows.length < 1000) break;
+  }
+  const map = new Map<number, { userId: string; createdAt: string }[]>();
+  for (let from = 0; ; from += 1000) {
+    const { data, error } = await db
+      .from("omie_clientes")
+      .select("user_id, omie_codigo_cliente, created_at")
+      .range(from, from + 999);
+    if (error) throw new Error(`fetch omie_clientes: ${error.message}`);
+    const rows = (data ?? []) as { user_id: string; omie_codigo_cliente: number | null; created_at: string }[];
+    for (const r of rows) {
+      if (r.omie_codigo_cliente == null || !r.user_id || comProfile.has(r.user_id)) continue;
+      const codigo = Number(r.omie_codigo_cliente);
+      const arr = map.get(codigo) ?? [];
+      arr.push({ userId: r.user_id, createdAt: r.created_at });
+      map.set(codigo, arr);
+    }
+    if (rows.length < 1000) break;
+  }
+  return map;
+}
+
+// Insere um chunk de profiles. ON CONFLICT(user_id) DO NOTHING cobre o profiles_user_id_key, MAS não o
+// idx_profiles_document_unique (UNIQUE parcial em document) — um documento que colidiu entre o fetch e o
+// insert (corrida/profile criado no meio) abortaria o chunk inteiro. Em erro, cai p/ linha-a-linha: conta
+// inseridos, registra conflito de documento (23505) e segue; só erro inesperado aborta o run.
+async function inserirProfilesComFallback(
+  db: SupabaseClient,
+  chunk: BackfillProfileRow[],
+): Promise<{ inseridos: number; conflitosDocumento: number }> {
+  const { data, error } = await db
+    .from("profiles")
+    .upsert(chunk, { onConflict: "user_id", ignoreDuplicates: true })
+    .select("user_id");
+  if (!error) return { inseridos: data?.length ?? 0, conflitosDocumento: 0 };
+  let inseridos = 0, conflitosDocumento = 0;
+  for (const row of chunk) {
+    const { data: d, error: e } = await db
+      .from("profiles")
+      .upsert([row], { onConflict: "user_id", ignoreDuplicates: true })
+      .select("user_id");
+    if (e) {
+      if (e.code === "23505") { conflitosDocumento++; continue; } // doc duplicado (índice parcial) — esperado
+      throw new Error(`insert profile (linha-a-linha): ${e.message}`);
+    }
+    inseridos += d?.length ?? 0;
+  }
+  return { inseridos, conflitosDocumento };
+}
+
+// Backfill de cadastro Omie → profiles dos clientes-fantasma da carteira. Enumera as 3 contas Omie numa
+// invocação (casa por código em TODAS) p/ NUNCA pegar cadastro da conta errada por last-wins; clientes
+// ambíguos (mesmo código em >1 conta, ou >1 user_id no mesmo código) são PULADOS+reportados, nunca
+// adivinhados. dryRun só conta. limite (canário) insere no máx N, ordenado por user_id (determinístico).
+async function syncBackfillCadastro(db: SupabaseClient, dryRun: boolean, limite: number | null) {
+  const startedAt = new Date().toISOString();
+  await updateSyncState(db, "backfill_cadastro", "all", {
+    status: "running", error_message: null,
+    metadata: { dry_run: dryRun, limite, started_at: startedAt },
+  });
+  try {
+    // master_cnpj FAIL-CLOSED: sem ele (erro de leitura OU ausente/inválido) o guard que impede promover
+    // a master não funcionaria → abortar em vez de arriscar. Não confiar em null silencioso do maybeSingle.
+    const { data: cfg, error: cfgErr } = await db
+      .from("company_config").select("value").eq("key", "master_cnpj").maybeSingle();
+    if (cfgErr) throw new Error(`master_cnpj read: ${cfgErr.message}`);
+    const masterCnpj = ((cfg?.value as string | null) ?? "").replace(/^"|"$/g, "").replace(/\D/g, "");
+    if (masterCnpj.length !== 11 && masterCnpj.length !== 14) {
+      throw new Error("master_cnpj ausente/inválido em company_config — backfill abortado (fail-closed: evita promover cliente a master)");
+    }
+
+    const alvosPorCodigo = await fetchAlvosSemProfile(db);
+    const docsExistentes = await fetchAllProfileDocs(db);
+
+    // userId → { codigo, createdAt } (omie_clientes é UNIQUE(user_id) → 1 código por user); e códigos com
+    // >1 user_id = ambíguos (não dá p/ saber qual auth.user é qual cliente).
+    const alvoPorUser = new Map<string, { codigo: number; createdAt: string }>();
+    const codigosAmbiguos = new Set<number>();
+    for (const [codigo, lista] of alvosPorCodigo) {
+      if (lista.length > 1) codigosAmbiguos.add(codigo);
+      for (const a of lista) alvoPorUser.set(a.userId, { codigo, createdAt: a.createdAt });
+    }
+    const alvosTotal = alvoPorUser.size;
+
+    // Enumera as contas COM credencial → candidatos POR user (1 por conta onde o código existe).
+    const candidatosPorUser = new Map<string, { account: OmieAccount; cadastro: BackfillCadastro }[]>();
+    const contasProcessadas: OmieAccount[] = [];
+    const contasSemCredencial: OmieAccount[] = [];
+    let totalOmie = 0;
+    for (const account of ["vendas", "colacor_vendas", "servicos"] as OmieAccount[]) {
+      const creds = getCredentials(account);
+      if (!creds.key || !creds.secret) { contasSemCredencial.push(account); continue; }
+      contasProcessadas.push(account);
+      let pagina = 1, totalPaginas = 1;
+      while (pagina <= totalPaginas) {
+        const result = (await callOmie(account, "geral/clientes/", "ListarClientes", {
+          pagina, registros_por_pagina: 100, apenas_importado_api: "N",
+        })) as unknown as OmieListarClientesResponse;
+        totalPaginas = result.total_de_paginas || 1;
+        for (const c of result.clientes_cadastro || []) {
+          totalOmie++;
+          if (c.codigo_cliente_omie == null) continue;
+          const alvos = alvosPorCodigo.get(Number(c.codigo_cliente_omie));
+          if (!alvos) continue;
+          const raw = c as unknown as { telefone1_ddd?: string | null; telefone1_numero?: string | null };
+          const cadastro: BackfillCadastro = {
+            razao_social: c.razao_social ?? null,
+            nome_fantasia: c.nome_fantasia ?? null,
+            cnpj_cpf: c.cnpj_cpf ?? null,
+            telefone_ddd: raw.telefone1_ddd ?? null,
+            telefone_numero: raw.telefone1_numero ?? null,
+          };
+          for (const a of alvos) {
+            const arr = candidatosPorUser.get(a.userId) ?? [];
+            arr.push({ account, cadastro });
+            candidatosPorUser.set(a.userId, arr);
+          }
+        }
+        pagina++;
+      }
+      console.log(`[BackfillCadastro] ${account}: ${totalPaginas} páginas`);
+    }
+
+    // Decide por user (ordem determinística). Ambíguo = candidatos de >1 conta OU código com >1 user_id.
+    const docsNoLote = new Set<string>();
+    const rows: BackfillProfileRow[] = [];
+    const pulados = { master_cnpj: 0, doc_em_outro_profile: 0, doc_duplicado_no_lote: 0 };
+    let semMatch = 0, ambiguos = 0, comMatch = 0;
+    for (const userId of [...alvoPorUser.keys()].sort()) {
+      const info = alvoPorUser.get(userId)!;
+      const cands = candidatosPorUser.get(userId) ?? [];
+      if (cands.length === 0) { semMatch++; continue; }
+      comMatch++;
+      const contasDistintas = new Set(cands.map((c) => c.account));
+      if (contasDistintas.size > 1 || codigosAmbiguos.has(info.codigo)) { ambiguos++; continue; }
+      const d = decidirLinhaProfile({
+        userId, authCreatedAt: info.createdAt, cadastro: cands[0].cadastro,
+        masterCnpj, docsExistentes, docsNoLote,
+      });
+      if (d.acao === "pular") { pulados[d.motivo]++; continue; }
+      rows.push(d.row);
+      if (d.row.document) docsNoLote.add(d.row.document);
+    }
+
+    // Ordena por user_id (determinismo do canário) e aplica o limite.
+    rows.sort((a, b) => (a.user_id < b.user_id ? -1 : a.user_id > b.user_id ? 1 : 0));
+    const rowsAlvo = limite && limite > 0 ? rows.slice(0, limite) : rows;
+
+    let inseridos = 0, conflitosDocumento = 0;
+    if (!dryRun) {
+      for (let i = 0; i < rowsAlvo.length; i += 500) {
+        const r = await inserirProfilesComFallback(db, rowsAlvo.slice(i, i + 500));
+        inseridos += r.inseridos;
+        conflitosDocumento += r.conflitosDocumento;
+      }
+    }
+
+    // created_at recente (< 35d) sinaliza vínculo novo (relink) — improvável no lote de março; se aparecer
+    // é alerta p/ revisar antes de confiar no created_at preservado.
+    const limiteRecente = Date.now() - 35 * 24 * 60 * 60 * 1000;
+    const createdAtRecente = rows.filter((r) => new Date(r.created_at).getTime() > limiteRecente).length;
+
+    const relatorio = {
+      dry_run: dryRun, limite,
+      contas_processadas: contasProcessadas, contas_sem_credencial: contasSemCredencial,
+      alvos_total: alvosTotal, total_omie: totalOmie, com_match: comMatch, sem_match: semMatch,
+      ambiguos, inseriveis: rows.length, seriam_inseridos: rowsAlvo.length, inseridos,
+      conflitos_documento: conflitosDocumento, pulados, created_at_recente: createdAtRecente,
+      amostra: rowsAlvo.slice(0, 5).map((r) => ({ user_id: r.user_id, document: r.document, name: r.name })),
+      finished_at: new Date().toISOString(),
+    };
+    await updateSyncState(db, "backfill_cadastro", "all", {
+      status: "complete", total_synced: inseridos, metadata: relatorio,
+    });
+    console.log(`[BackfillCadastro] ${JSON.stringify(relatorio)}`);
+    return relatorio;
+  } catch (error) {
+    await updateSyncState(db, "backfill_cadastro", "all", { status: "error", error_message: String(error) });
+    throw error;
+  }
+}
+
 // ======== MAIN HANDLER ========
 
 serve(async (req) => {
@@ -1046,7 +1329,7 @@ serve(async (req) => {
       Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!
     );
 
-    const { action, account = "vendas", start_page, max_pages } = await req.json();
+    const { action, account = "vendas", start_page, max_pages, dry_run, limite } = await req.json();
     let result: unknown;
 
     switch (action) {
@@ -1145,6 +1428,45 @@ serve(async (req) => {
           EdgeRuntime.waitUntil(bgTask);
         }
         return new Response(JSON.stringify({ accepted: true }), {
+          status: 202, headers: { ...corsHeaders, "Content-Type": "application/json" },
+        });
+      }
+      case "start_backfill_cadastro": {
+        // Backfill de cadastro Omie → profiles (clientes-fantasma da carteira). Enumera as 3 contas numa
+        // invocação (não recebe `account`). dry_run default TRUE: só conta/relata (em sync_state.metadata),
+        // nunca escreve sem pedir. `limite` (canário): insere no máximo N, ordenado por user_id.
+        const dryRun = dry_run !== false;
+        const limiteNum =
+          typeof limite === "number" && Number.isFinite(limite) && limite > 0 ? Math.floor(limite) : null;
+        // Gate master/gestor server-side (mesmo do start_nao_vinculados; cron/service_role passam).
+        if (auth.via === "staff") {
+          const { data: pode } = await supabaseAdmin.rpc("pode_ver_carteira_completa", { _uid: auth.userId });
+          if (!pode) {
+            return new Response(JSON.stringify({ error: "Forbidden: requer master ou gestor comercial" }), {
+              status: 403, headers: { ...corsHeaders, "Content-Type": "application/json" },
+            });
+          }
+        }
+        // Guard "já em andamento" (não duplicar trabalho). Estado único (account="all").
+        const stBf = await getSyncState(supabaseAdmin, "backfill_cadastro", "all");
+        const runningBf = stBf?.status === "running" && stBf?.updated_at &&
+          (Date.now() - new Date(stBf.updated_at as string).getTime() < 15 * 60 * 1000);
+        if (runningBf) {
+          return new Response(JSON.stringify({ accepted: false, already_running: true }), {
+            status: 202, headers: { ...corsHeaders, "Content-Type": "application/json" },
+          });
+        }
+        const bgTask = syncBackfillCadastro(supabaseAdmin, dryRun, limiteNum).catch((e) => {
+          console.error("[backfill_cadastro][bg]", e instanceof Error ? e.message : e);
+        });
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore - EdgeRuntime existe no runtime do Supabase Edge
+        if (typeof EdgeRuntime !== "undefined" && typeof EdgeRuntime.waitUntil === "function") {
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
+          EdgeRuntime.waitUntil(bgTask);
+        }
+        return new Response(JSON.stringify({ accepted: true, dry_run: dryRun, limite: limiteNum }), {
           status: 202, headers: { ...corsHeaders, "Content-Type": "application/json" },
         });
       }

--- a/supabase/migrations/20260612120000_auto_assign_role_omie_import_guard.sql
+++ b/supabase/migrations/20260612120000_auto_assign_role_omie_import_guard.sql
@@ -1,0 +1,43 @@
+-- Defesa em profundidade do backfill de cadastro Omie → profiles (clientes-fantasma da carteira).
+-- Spec: docs/superpowers/specs/2026-06-12-clientes-cadastro-backfill-design.md
+--
+-- O trigger auto_assign_user_role (AFTER INSERT em profiles) promove a 'master' qualquer profile cujo
+-- documento normalizado == company_config.master_cnpj. O backfill JÁ pula esses no edge (lê master_cnpj
+-- fail-closed e descarta o documento coincidente), mas isso é blindagem só no caminho do edge.
+--
+-- Esta migration adiciona a MESMA garantia no banco: um profile com prospect_source='omie_import'
+-- NUNCA vira master, independente do documento e independente de quem inseriu. Se um import coincidir
+-- com o master_cnpj, cai em 'customer' (is_employee=false p/ import). É CREATE OR REPLACE verbatim do
+-- corpo vivo de produção (supabase/schema-snapshot.sql) + UMA cláusula no ramo master.
+--
+-- ⚠️ Migration manual: colar no SQL Editor do Lovable → Run.
+
+CREATE OR REPLACE FUNCTION public.auto_assign_user_role() RETURNS trigger
+    LANGUAGE plpgsql SECURITY DEFINER
+    SET search_path TO 'public'
+    AS $$
+DECLARE
+  master_cnpj_value TEXT;
+  profile_doc TEXT;
+  existing_role app_role;
+BEGIN
+  IF TG_OP = 'UPDATE' THEN RETURN NEW; END IF;
+  SELECT role INTO existing_role FROM public.user_roles WHERE user_id = NEW.user_id LIMIT 1;
+  IF existing_role IS NOT NULL THEN RETURN NEW; END IF;
+  SELECT value INTO master_cnpj_value FROM public.company_config WHERE key = 'master_cnpj';
+  profile_doc := REGEXP_REPLACE(NEW.document, '\D', '', 'g');
+  -- Guard: clientes importados do Omie (carteira-fantasma) jamais viram master por coincidência de CNPJ.
+  IF profile_doc = master_cnpj_value AND COALESCE(NEW.prospect_source, '') <> 'omie_import' THEN
+    INSERT INTO public.user_roles (user_id, role) VALUES (NEW.user_id, 'master') ON CONFLICT (user_id, role) DO NOTHING;
+  ELSIF NEW.is_employee = true THEN
+    INSERT INTO public.user_roles (user_id, role) VALUES (NEW.user_id, 'employee') ON CONFLICT (user_id, role) DO NOTHING;
+  ELSE
+    INSERT INTO public.user_roles (user_id, role) VALUES (NEW.user_id, 'customer') ON CONFLICT (user_id, role) DO NOTHING;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+-- Validação (colar junto p/ ver o guard no corpo):
+-- SELECT 'guard presente' AS check,
+--        position('omie_import' in pg_get_functiondef('public.auto_assign_user_role()'::regprocedure)) > 0 AS ok;


### PR DESCRIPTION
## Problema (root cause confirmado por dados)

`/admin/customers` (modo carteira, #763) lista a carteira cruzando `carteira_assignments` com `profiles` via **INNER JOIN**. A carteira da vendedora é majoritariamente de **clientes-só-Omie** (têm `auth.users` + `omie_clientes` + `carteira_assignments` + scores, mas **não têm `profiles`**) → o join derruba **571→1 (Tatiana) / 674→7 (Regina)**.

Dry-run em prod: **1.633** `omie_clientes` sem `profiles` — todos `@placeholder.local`, `ja_logou=0`, criados num único import de 2026-03-01, **0 roles** → **login inviável** → criar profile é seguro (não dá senha, não muda email; só dá nome e torna visível na carteira). Conserta a tela **e** o app todo (scores/positivação/rota/Customer360 deixam de cair no fallback "Cliente").

## O que entra

- **Fase 1 (front):** filtro `prospect_source='omie_import'` **server-side** em `AdminApprovals` + `useSistemaZone` (`.or('prospect_source.is.null,prospect_source.neq.omie_import')`) — antes do cap de 1.000 do PostgREST, senão as pendências reais truncariam.
- **Fase 2 (edge):** action `start_backfill_cadastro` no `omie-analytics-sync` (`dry_run` default, gate master/gestor server-side, background via `waitUntil`) + helper puro TDD `src/lib/clientes-cadastro/backfill-helpers.ts` (DV de CPF/CNPJ mod 11, `master_cnpj`, dedup; **19 testes**, espelhado verbatim no edge). Insert-only, `created_at` preservado.
- **Migration `20260612120000`:** trigger guard `auto_assign_user_role` — `omie_import` nunca vira master (defesa em profundidade).

## Salvaguardas (Codex)

Codex no **design** (4 P1 incorporados) + **adversarial no código** (Gate FAIL → 7 correções incorporadas):

1. **Casamento por código sem last-wins** — enumera as **3 contas Omie numa invocação**, casa por código em todas; ambíguo (mesmo código em >1 conta, ou >1 user_id no código) → **pula+reporta**, nunca adivinha.
2. **`master_cnpj` fail-CLOSED** — erro de leitura ou ausente/inválido → `throw` (aborta) + o trigger guard.
3. **Canário determinístico** — param `limite` (ordena por `user_id`, `slice`).
4. **Fila de aprovação server-side** (acima).
5. **DV real de CPF/CNPJ** — DV inválido → `document=NULL` (não inventa identidade).
6. **Fallback linha-a-linha** — conflito do `idx_profiles_document_unique` (não coberto por `ON CONFLICT(user_id)`) não aborta o chunk; conta `conflitos_documento`.
7. **Relatório rico** no `sync_state` (`alvos_total`/`com_match`/`sem_match`/`ambiguos`/`created_at_recente`/amostra…).

`created_at = omie_clientes.created_at` (lote de março, Codex concordou) — Fase 4 (cron) usará `LEAST(auth, omie)`.

## CI local

✅ typecheck strict (EXIT 0) · ✅ 3194 testes vitest · ✅ lint 0 errors · ✅ `deno check` net-zero (3 erros pré-existentes `cost_price`/`saldo`, nenhum nas funções de backfill).

## ⚠️ Pendências do founder (APÓS merge — não mergeie por mim)

1. **Deploy** do `omie-analytics-sync` via chat do Lovable (verbatim, **só após mergear** — senão pega a main velha → "Ação desconhecida").
2. **Migration manual** `20260612120000` no SQL Editor (defesa em profundidade; não bloqueia o dry_run).
3. **Operar o backfill:** `dry_run` (lê relatório em `sync_state`) → `dry_run:false, limite:100` (canário) → conferir → lote inteiro → 1 refresh da `customer_metrics_mv`. Comandos no spec `docs/superpowers/specs/2026-06-12-clientes-cadastro-backfill-design.md`.

## Critério de pronto

`/admin/customers` na lente da Tatiana/Regina mostra a carteira com **nome** (não "1"/"7"); visit-score sem bônus de "prospect recente" falso (created_at preservado); fila de aprovação **não** mostra os 1.633.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
