### PR TITLE
fix(sayersync): v0.1.5 — payload de produto derrubava o lote inteiro na staging (campo 'ativo')

### DIFF
--- a/connector/sayersync/sync.go
+++ b/connector/sayersync/sync.go
@@ -1319,10 +1319,13 @@ func mapProduto(row map[string]any) map[string]any {
 	if ident == "" {
 		ident = id
 	}
+	// ⚠️ NÃO mandar campo que a staging não tem: a edge espalha TODOS os campos
+	// do item no INSERT de tint_staging_produtos (cod_produto/descricao/raw_data...);
+	// um campo extra ("ativo") derruba o LOTE INTEIRO com erro de coluna — visto em
+	// CAMPO (12/06): "sendInBatches produto: 20 erro(s) de item no lote 0-20".
 	return map[string]any{
 		"cod_produto": ident,
 		"descricao":   toString(row["descricao"]),
-		"ativo":       true,
 	}
 }
 

--- a/connector/sayersync/sync_test.go
+++ b/connector/sayersync/sync_test.go
@@ -1379,8 +1379,10 @@ func TestMapProduto_validRow(t *testing.T) {
 	if m["cod_produto"] != "P001" {
 		t.Errorf("cod_produto esperado 'P001', got %v", m["cod_produto"])
 	}
-	if m["ativo"] != true {
-		t.Errorf("ativo esperado true, got %v", m["ativo"])
+	// Regressão de CAMPO (12/06): "ativo" NÃO existe em tint_staging_produtos e a
+	// edge espalha todos os campos no INSERT → campo extra derruba o lote inteiro.
+	if _, has := m["ativo"]; has {
+		t.Errorf("payload de produto NÃO pode ter 'ativo' (derruba o lote na staging), got %v", m["ativo"])
 	}
 }
 


### PR DESCRIPTION
## Bug REAL do 1º ciclo em campo (foto do founder)

`sendInBatches produto: 20 erro(s) de item no lote 0-20` — a edge espalha TODOS os campos do item no INSERT de `tint_staging_produtos`; o payload mandava `ativo`, coluna que a tabela NÃO tem → o chunk inteiro morria. **Sweep payload×staging completo: era o único mismatch** (corantes `custo`/`volume_ml` existem em prod via `20260609150000`; o schema-snapshot local é que está stale).

Fix: remove `ativo` do `mapProduto` + teste de regressão (payload NÃO pode ter o campo).

**Bônus do 1º ciclo (sem código):** `schema OK shape=flat` 🎉 e a heurística `litrosLimiar` salvou — a origem grava **810 (ml)**, não 0.810 (a UI do SayerSystem é que formata em litros); o guard interpretou certo sozinho.

⚠️ Branch nasceu de origin/main STALE (pré-#773, sem o sufixo BS) — **rebasado** na main real antes da release; binário recompilado com BS+fix juntos (201 testes).

Release `sayersync-v0.1.5` sai junto; v0.1.4 será deletada (página fica só com a atual).

🤖 Generated with [Claude Code](https://claude.com/claude-code)