### PR TITLE
fix(rota): useRouteContactList lente-aware — resolve a causa-raiz do erro da fila (follow-up #771)

### DIFF
--- a/src/lib/impersonation/__tests__/no-write-leak.test.ts
+++ b/src/lib/impersonation/__tests__/no-write-leak.test.ts
@@ -27,6 +27,10 @@ const ALLOWED = new Set([
   // useCriticaFila: effectiveUserId SÓ como filtro de LEITURA (owner_user_id === donoEfetivo no slaQ.data);
   // sem mutation alguma neste hook — é read-only (crítica da fila).
   'src/hooks/useCriticaFila.ts',
+  // useRouteContactList: effectiveUserId SÓ escopa a LEITURA da fila de ligação à carteira do ALVO no
+  // "Ver como" (.eq('farmer_id', …) em customer_visit_scores, no servidor) — conserta a fidelidade da
+  // lente E corta o volume que estourava. Hook 100% read-only (só SELECTs), sem mutation alguma.
+  'src/queries/useRouteContactList.ts',
   // Telefonia: effectiveUserId SÓ alimenta o filtro de LEITURA do histórico de chamadas
   // (useCallLog via CallHistoryTabs) pro "Ver como" mostrar as ligações do ALVO. A ligação
   // em si (call.makeCall) é bloqueada na FONTE (WebRTCCallContext) na lente; nenhum write usa effectiveUserId.

--- a/src/queries/useRouteContactList.ts
+++ b/src/queries/useRouteContactList.ts
@@ -9,6 +9,7 @@ import { spBusinessDate } from '@/lib/time/sp-day';
 import { derivarSinaisContato, type ContatoLog, type OutcomeStatus, type SinaisContato } from '@/lib/route/route-outcome';
 import { logger } from '@/lib/logger';
 import { track } from '@/lib/analytics';
+import { useImpersonation } from '@/contexts/ImpersonationContext';
 
 interface VisitScoreRow {
   customer_user_id: string;
@@ -138,13 +139,20 @@ async function fetchContactLog(ids: string[]): Promise<Map<string, ContatoLog[]>
  * (7 round-trips encadeados) era o estágio mais lento da fila de ligação,
  * pago a cada visita à tela (staleTime 60s).
  */
-async function fetchAllVisitScores(): Promise<VisitScoreRow[]> {
-  const baseSelect = (withCount: boolean) =>
-    supabase
+async function fetchAllVisitScores(farmerId: string | null): Promise<VisitScoreRow[]> {
+  const baseSelect = (withCount: boolean) => {
+    let q = supabase
       .from('customer_visit_scores')
       .select('customer_user_id, farmer_id, city, visit_score', withCount ? { count: 'exact' } : undefined)
-      .not('city', 'is', null)
-      .order('customer_user_id', { ascending: true });
+      .not('city', 'is', null);
+    // Lente "Ver como": escopa à carteira do ALVO NO SERVIDOR. O master lê
+    // customer_visit_scores sem o filtro de RLS → sem isto a rota traria TODAS
+    // as carteiras (infiel ao alvo) e baixaria ~12× mais linhas em ~7 páginas
+    // (provável causa do erro "uma das fontes falhou" na lente). Fora da lente
+    // farmerId=null → query IDÊNTICA à anterior; a RLS escopa a vendedora real.
+    if (farmerId) q = q.eq('farmer_id', farmerId);
+    return q.order('customer_user_id', { ascending: true });
+  };
 
   const first = await baseSelect(true).range(0, PAGE - 1);
   if (first.error) throw first.error;
@@ -173,13 +181,16 @@ async function fetchAllVisitScores(): Promise<VisitScoreRow[]> {
  * (7 dias úteis), o resultado EXIBIDO continua vindo do full-fetch legado;
  * esta query roda em paralelo só pra telemetria de divergência.
  */
-async function fetchVisitScoresByCityNorm(cityNorms: string[]): Promise<VisitScoreRow[]> {
-  const baseSelect = (withCount: boolean) =>
-    supabase
+async function fetchVisitScoresByCityNorm(cityNorms: string[], farmerId: string | null): Promise<VisitScoreRow[]> {
+  const baseSelect = (withCount: boolean) => {
+    let q = supabase
       .from('customer_visit_scores')
       .select('customer_user_id, farmer_id, city, visit_score', withCount ? { count: 'exact' } : undefined)
-      .in('city_norm' as never, cityNorms)
-      .order('customer_user_id', { ascending: true });
+      .in('city_norm' as never, cityNorms);
+    // Lente: mesmo escopo do full-fetch acima (mantém a telemetria do shadow válida).
+    if (farmerId) q = q.eq('farmer_id', farmerId);
+    return q.order('customer_user_id', { ascending: true });
+  };
 
   const first = await baseSelect(true).range(0, PAGE - 1);
   if (first.error) throw first.error;
@@ -224,8 +235,12 @@ async function fetchProfiles(ids: string[]): Promise<ProfileRow[]> {
 }
 
 export function useRouteContactList(workdayIso: string) {
+  const { isImpersonating, effectiveUserId } = useImpersonation();
+  // Na lente "Ver como", escopa a fila à carteira do ALVO (ver fetchAllVisitScores).
+  // Fora da lente: null → a RLS escopa a vendedora real, comportamento INALTERADO.
+  const lensFarmerId = isImpersonating && effectiveUserId ? effectiveUserId : null;
   return useQuery<RouteContactListData>({
-    queryKey: ['route-contact-list', workdayIso],
+    queryKey: ['route-contact-list', workdayIso, lensFarmerId],
     staleTime: 60_000,
     queryFn: async () => {
       // 1) agenda + override + config → cidades D-1
@@ -254,8 +269,8 @@ export function useRouteContactList(workdayIso: string) {
       // não aplicada → coluna inexistente) vira telemetria, nunca afeta a fila.
       const cityNorms = [...new Set(prep.cities.map(c => c.city))];
       const [allScores, shadowRes] = await Promise.all([
-        fetchAllVisitScores(),
-        fetchVisitScoresByCityNorm(cityNorms)
+        fetchAllVisitScores(lensFarmerId),
+        fetchVisitScoresByCityNorm(cityNorms, lensFarmerId)
           .then(rows => ({ ok: true as const, rows }))
           .catch((e: unknown) => ({ ok: false as const, err: e instanceof Error ? e.message : String(e) })),
       ]);


### PR DESCRIPTION
## Contexto

Follow-up do #771 (que **instrumentou** o erro _"uma das fontes falhou"_ na FilaDoDia — já mergeado). Este PR **resolve a causa-raiz**.

## O problema

A fila do Meu Dia agrega 3 fontes (tarefas / rota / mix-gap). Tarefas e mix-gap respeitam a lente "Ver como" (filtram pelo alvo). A **rota** (`useRouteContactList`) **não** — lia `customer_visit_scores` direto. Pra vendedora real a RLS escopa à carteira dela (~571 linhas, 1 requisição); mas **na lente do master**, que lê sem o filtro de RLS, ela:
- trazia clientes de **todas as carteiras** das cidades de amanhã (infiel ao alvo), e
- baixava ~12× mais linhas em ~7 requisições paginadas → frágil sob instabilidade de plataforma (a causa provável de o erro aparecer "na lente").

## O fix

Na lente, a query de `customer_visit_scores` passa a filtrar `farmer_id = <alvo>` **no servidor**:
- **Fidelidade:** a rota mostra a carteira do alvo, não a de todas as vendedoras.
- **Causa do erro:** corta o volume de ~6.900 → ~571 linhas (1 requisição em vez de ~7).
- **Vendedora real intocada:** fora da lente `farmerId=null` → a query é **byte-idêntica** à anterior (a RLS já escopava). Zero mudança pra quem usa de verdade.
- A `queryKey` ganha o alvo (invalida o cache ao entrar/sair da lente).

`effectiveUserId` é usado **só em leitura** (filtro de `SELECT`). O guardrail de CI `no-write-leak` pegou o uso novo; o arquivo foi adicionado à allowlist com justificativa (hook 100% read-only, sem mutation) — o sistema funcionou como projetado.

## Validação

- typecheck 0 · lint 0 erros · vitest **3229/3229** (na base da main atual).
- 100% frontend — sem migration, sem edge.

A instrumentação do #771 segue de rede de segurança: se ainda restar algum erro, o card agora nomeia a fonte.

⚠️ **Publish no Lovable** pra ir ao ar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)