### PR TITLE
feat(carteira): consolidação de clientes duplicados — Fase 1 (mapa clone→gêmeo, inócuo)

### DIFF
--- a/docs/superpowers/specs/2026-06-13-consolidacao-clientes-duplicados-design.md
+++ b/docs/superpowers/specs/2026-06-13-consolidacao-clientes-duplicados-design.md
@@ -1,0 +1,164 @@
+# Consolidação dos clientes duplicados (clones do import de março) — Design
+
+> Data: 2026-06-13. Origem: o backfill de cadastro (spec 2026-06-12) rodou dry-run e revelou que os
+> 1.633 "clientes-fantasma" NÃO precisam de cadastro novo — são **clones** de clientes que já têm
+> profile. Founder decidiu **consolidar** (1 cliente por CNPJ, com nome, na carteira da vendedora certa).
+
+## Causa-raiz (provada por dados, 2026-06-13)
+
+O import de **2026-03-01/02** montou a carteira das vendedoras puxando os clientes do Omie e **casando
+por `omie_codigo_cliente`, não por CNPJ**. Como cada cliente já existia no app (com nome, sob OUTRO
+código Omie), o import não os reconheceu e criou **1.633 clones vazios** (auth.users `@placeholder.local`
++ `omie_clientes` + `carteira_assignments` + scores, **sem profile**).
+
+Evidências:
+- `omie_clientes` 6.909 = 5.276 com profile + 1.633 sem profile (clones). `auth.users` 6.914 ≈ 6.909 + 5 staff.
+- Dry-run do backfill: `com_match=1633`, `ambiguos=0`, **`doc_em_outro_profile=1633`** (100% dos clones têm
+  o CNPJ num profile existente — o gêmeo) e `created_at_recente=0`.
+- Query A (`codigos_com_mais_de_um_vinculo=0`): cada `omie_codigo_cliente` está em 1 só `omie_clientes` →
+  clone e gêmeo têm **códigos diferentes** (X≠Y), mesmo CNPJ.
+- Query B (carteira × profile × source):
+  | source | total | com nome | clone sem nome |
+  |---|---|---|---|
+  | `omie` (vendedor atribuído no Omie) | 1.246 | 8 | **1.238** |
+  | `hunter_orphan` (sem vendedor) | 5.663 | 5.268 | 395 |
+- Datas: os 1.238 + 395 = **1.633 clones** nasceram em 2026-03-01/02 (janela do import). Gêmeos com nome
+  são mais antigos/espalhados (fev–mai).
+- Histórico (onde está o valor):
+  | tipo | clientes | c/ pedido app | faturamento app |
+  |---|---|---|---|
+  | clone `omie` | 1.238 | 26 | R$ 26.259 |
+  | clone `hunter_orphan` | 395 | 5 | R$ 1.296 |
+  | **com nome (gêmeos)** | 5.268 | 539 | **R$ 2.252.820** |
+  → **o gêmeo concentra ~99% do faturamento** + nome + documento + profile. **Sobrevivente = o gêmeo.**
+  (Score ativo cobre todos: vem de `order_items`/analytics, não de `sales_orders`.)
+
+## Decisão
+
+**Consolidar** cada par (clone, gêmeo): o **gêmeo sobrevive** (nome/doc/profile/histórico); a **atribuição
+de carteira do clone** (owner=vendedora, `source='omie'`, `omie_codigo_vendedor`) **migra para o gêmeo**;
+o clone é **absorvido/descartado**. Resultado: a vendedora vê o cliente real com nome+histórico; 1 cliente
+por CNPJ.
+
+## O NÓ central — a CARTEIRA é DERIVADA, e o app espelha o Omie (descoberto 2026-06-13)
+
+**Cadeia de derivação** (a chave de tudo):
+`Omie` → **`syncCustomers`** (`omie-analytics-sync`: casa código/doc → user_id, upsert onConflict user_id,
+grava `omie_codigo_vendedor`) → **`omie_clientes`** (UNIQUE(user_id)) → **`carteira-rebuild`**
+(`supabase/functions/carteira-rebuild/index.ts`: DERIVA `carteira_assignments` de `omie_clientes ×
+omie_vendedor_map` — vendedor mapeado → `source='omie'`/owner=vendedora; sem vendedor →
+`hunter_orphan`/owner=hunter(founder); upsert onConflict `customer_user_id`; **idempotente, roda em cron**)
+→ scores.
+
+**Por isso o clone vai pra vendedora e o gêmeo pro founder:** o clone tem `omie_clientes.omie_codigo_vendedor`
+preenchido (vendedor do Omie) → carteira da vendedora; o gêmeo tem `omie_codigo_vendedor=NULL` →
+hunter_orphan/founder.
+
+**Consequência dura:** **qualquer mudança manual em `carteira_assignments` é DESFEITA pelo próximo
+`carteira-rebuild`** (ele re-deriva de `omie_clientes`). E qualquer mudança em `omie_clientes` é desfeita
+pelo próximo `syncCustomers` (relê do Omie, que ainda tem os 2 cadastros X e Y). **A consolidação só é
+estável se atacar a FONTE (Omie) ou se houver uma camada de override que o sync respeite.** Mover linhas
+no app sem isso = ping-pong a cada cron.
+
+- 1:1 confirmado: `doc_duplicado_no_lote=0` no dry-run → cada clone tem documento único → 1 gêmeo único.
+- Blast radius: **26 tabelas** com `customer_user_id`; UNIQUEs em carteira/scores/contacts/processes; 32 FKs
+  p/ auth.users — re-apontar tudo é pesado e colide com UNIQUE.
+
+**Pergunta aberta (impacta a estratégia):** os 2 códigos (X, Y) são da MESMA conta Omie ou de contas/
+empresas diferentes (Oben×Colacor)? `empresa_omie` no banco é default 'colacor' (não-confiável); só o
+casamento nas 3 contas (backfill) sabe.
+
+## Estratégia DECIDIDA (Codex consult, 2026-06-13): "B-lite" — canonicalização na PROJEÇÃO
+
+**Não fundir fisicamente.** Manter A (clone) e B (gêmeo) em `omie_clientes` (UNIQUE(user_id) não suporta 2
+códigos por user). **NÃO tocar `syncCustomers`** (preservar X→A e Y→B impede recriação/ping-pong; o sync
+segue atualizando cada código normalmente). Canonicalizar **só na derivação da carteira**.
+
+1. **Tabela nova `customer_canonical_alias`** (imutável/auditável): `alias_user_id` (clone A) PK,
+   `canonical_user_id` (gêmeo B), `documento`, `status` (active/inactive), `reason`, `batch_id`, `created_at`.
+   Popular com `status='inactive'` primeiro → zero efeito até ativar (gate do canário).
+2. **`carteira-rebuild` passa a consultar aliases ATIVOS:** calcula carteira bruta de A e B → substitui
+   `A→B` → agrupa por canônico → **prioridade vendedor Omie mapeado vence `hunter_orphan`** → **conflito
+   (2 vendedores p/ o mesmo canônico) = fail-closed (não sobrescreve)** → grava `B eligible=true` e
+   **`A eligible=false` EXPLÍCITO**. A tela já filtra `eligible=true` (`escopo-clientes.ts:84`) → resolve o
+   visual direto, sem deletar nada.
+3. **Scores (fase 2):** preservar a linha rica de B; atualizar só `farmer_id` p/ o novo owner (o repo já
+   reconhece que `calculate-scores` não reconcilia ownership). Filas/caches derivados: recalcular.
+4. **Clone = DESATIVAR, nunca DELETAR.** `ON DELETE CASCADE` apagaria carteira/contatos/processos sem
+   rollback simples. Manter auth placeholder + omie_clientes + alias + `eligible=false` + scores dormentes.
+   Exclusão só depois de zero-referências + backup + estabilização.
+5. **Pedidos/itens/financeiro:** deixar onde estão (B já concentra ~99%). Calls/visitas/contatos/processos:
+   migrar depois, tabela por tabela, com regra explícita p/ cada UNIQUE. **Nunca** num UPDATE genérico das 26.
+
+### Pré-requisito OBRIGATÓRIO (Codex): mesma conta vs cross-account
+- **Mesma conta Omie** (ambos Oben): duplicidade real → após o canário, pode-se corrigir no Omie.
+- **Contas diferentes** (Oben × Colacor): mesmo CNPJ comprando de 2 empresas — **NÃO** é duplicata, **não
+  inativar nada no Omie**; canonicalizar a carteira ainda resolve o visual, mas é multi-identidade.
+- ⚠️ O mapa (Fase 1) DEVE capturar a conta de cada código (X e Y) + detectar conflito de vendedor.
+
+### Bugs estruturais que o Codex achou (relevantes ao plano)
+- `carteira-rebuild` cruza só o **código numérico, ignora a conta** (`omie_vendedor_map` é account-aware,
+  `carteira-rebuild:68` não usa) → ao consertar o rebuild, considerar account-awareness.
+- `carteira-rebuild` **omite `eligible` no upsert** hoje → rollback/reativação ficam incompletos; o rebuild
+  novo PRECISA escrever `eligible=true/false` explícito.
+- `syncCustomers`/`omie-vendas-sync` usam mapa global por código sem conta; cron só sincroniza Oben.
+- Omie `AlterarCliente` tem campo `inativo`, mas a doc não garante que inativos somem de `ListarClientes` (e
+  o código nem lê) → "inativar X" sozinho **não** é trava confiável; mais um motivo pra B-lite na projeção.
+
+### Arquitetura "correta" (médio prazo, NÃO no hotfix): `omie_customer_links`
+Substituir `omie_clientes` por `(omie_account, omie_codigo_cliente, canonical_user_id, omie_codigo_vendedor,
+inativo)` UNIQUE(account, codigo) → vários códigos/contas → 1 cliente. Robusto, mas exige migrar o sync de
+pedidos também. Fica pra depois.
+
+## Fases (revisadas pós-Codex)
+1. **Mapa + alias (Fase 1):** action `mapa_consolidacao` (read do Omie nas 3 contas) → popula
+   `customer_canonical_alias` com `status='inactive'` + captura (conta X, conta Y, vendedor, conflito).
+   Relatório: 1:1, mesma-conta vs cross-account, conflitos de vendedor. **Não afeta nada** (alias inativo).
+2. **Rebuild canônico (Fase 2):** modificar `carteira-rebuild` (consulta aliases ativos, canonicaliza,
+   eligible explícito, conflito fail-closed). Deploy ANTES de ativar qualquer alias.
+3. **Dry-run:** rodar o rebuild novo com 0 aliases ativos → confirma comportamento inalterado.
+4. **Canário:** ativar 10–20 aliases → rodar rebuild → **1 ciclo completo `syncCustomers → carteira-rebuild`**
+   → conferir tela na lente da vendedora + owner dos scores + ausência de clones elegíveis.
+5. **Lote:** ativar o resto em levas.
+6. **Rollback:** `status='inactive'` nos aliases + rerodar rebuild.
+
+## Fase 1 — MAPA (read-only, começa já)
+
+Nova action `mapa_consolidacao` no `omie-analytics-sync` (reusa `fetchAlvosSemProfile` + enumeração das 3
+contas + `fetchProfileDocUserMap`):
+- Para cada clone (omie_clientes sem profile): casa por código nas 3 contas → `{documento, conta_omie}`.
+- Resolve o gêmeo: documento normalizado → `profiles` (user_id + name).
+- (Opcional v1.1) checa se o código do gêmeo (Y) ainda aparece na enumeração do Omie (vivo/morto).
+- Persiste o mapa numa tabela `consolidacao_mapa` (clone_user_id, clone_codigo, clone_conta, documento,
+  gemeo_user_id, gemeo_name, gemeo_codigo, ambiguo, observacao). Migration leve.
+- Relatório: total pares 1:1, clones sem gêmeo (genuínos novos — esperado 0), gêmeos com >1 clone, mesma
+  conta vs contas diferentes (dup pura vs multi-empresa).
+
+## Fase 2 — Design da fusão + trava (Codex)
+
+Para cada par no mapa, gerar (sem executar) os UPDATEs/DELETEs:
+- `carteira_assignments`: migrar a linha do clone (owner=vendedora, source='omie', codigo_vendedor) para
+  o gêmeo; remover/`eligible=false` a do clone. Tratar UNIQUE(customer_user_id) e o caso de o gêmeo já ter
+  linha (hunter_orphan/founder) — decidir se o gêmeo "troca de dono" (founder→vendedora).
+- `sales_orders`, `customer_visit_scores`, `farmer_client_scores`, `farmer_calls`, `route_visits`, etc.:
+  re-apontar `customer_user_id` clone→gêmeo (FK-by-FK; cuidar de UNIQUE em scores → preferir recálculo via
+  cron a mover linha).
+- `omie_clientes`: resolver os 2 códigos (eleger o vivo; trava anti-ping-pong no sync).
+- Clone: descartar `auth.users`/`omie_clientes`/score ao final, OU só desativar (eligible=false) na v1.
+- **Codex valida cada classe de escrita** (money-path: carteira/score/vendas/identidade).
+
+## Fase 3-5 — Dry-run → Canário (10–20) → Lote
+
+- Dry-run: contar exatamente o que muda, sem gravar.
+- Canário: fundir 10–20 pares reais; founder confere a tela da vendedora + scores.
+- Lote: resto em levas, idempotente, com relatório.
+
+## Não-objetivos (v1)
+- Deduplicar no Omie (é ação do founder no ERP; o app pode só travar a recriação).
+- Fundir clientes sem gêmeo (não existem — `doc_em_outro_profile=1633`).
+- Resolver multi-empresa (mesmo CNPJ em Oben + Colacor) como caso especial até o mapa mostrar que existe.
+
+## Estado
+- ✅ Causa-raiz provada · ✅ direção (consolidar) decidida pelo founder · ✅ sobrevivente (gêmeo) definido.
+- 🔄 Fase 1 (mapa) — em construção.
+- ⏳ Fase 2 (Codex) · ⏳ dry-run · ⏳ canário · ⏳ lote. **Nenhuma escrita até o plano da Fase 2 ser aprovado.**

--- a/supabase/functions/omie-analytics-sync/index.ts
+++ b/supabase/functions/omie-analytics-sync/index.ts
@@ -1313,6 +1313,163 @@ async function syncBackfillCadastro(db: SupabaseClient, dryRun: boolean, limite:
   }
 }
 
+// ======== MAPA DE CONSOLIDAÇÃO — popula customer_canonical_alias (clone → gêmeo) ========
+// Fase 1 da consolidação (estratégia "B-lite", spec 2026-06-13). Casa cada clone (omie_clientes SEM
+// profile) ao gêmeo (profile com o mesmo CNPJ) e grava o apelido com status='inactive' (INERTE: só o
+// carteira-rebuild da Fase 2 lê aliases ATIVOS; até ativar, NÃO afeta carteira/tela). Captura a conta
+// Omie de cada código (clone X e gêmeo Y) p/ revelar mesma-conta (duplicata real) vs cross-account
+// (mesmo CNPJ em empresas diferentes — NÃO é duplicata). NÃO toca omie_clientes/carteira/scores.
+
+interface AliasRow {
+  alias_user_id: string;
+  canonical_user_id: string;
+  documento: string | null;
+  alias_omie_codigo: number | null;
+  alias_conta: string | null;
+  canonical_omie_codigo: number | null;
+  canonical_conta: string | null;
+  status: "inactive" | "conflict";
+  reason: string | null;
+  batch_id: string;
+}
+
+// Map<doc_normalizado, {userId, name}> de profiles (resolve o gêmeo por documento; 1º vence).
+async function fetchProfileDocNameMap(
+  db: SupabaseClient,
+): Promise<Map<string, { userId: string; name: string | null }>> {
+  const map = new Map<string, { userId: string; name: string | null }>();
+  for (let from = 0; ; from += 1000) {
+    const { data, error } = await db
+      .from("profiles").select("user_id, name, document").not("document", "is", null).range(from, from + 999);
+    if (error) throw new Error(`fetch profiles doc/name: ${error.message}`);
+    const rows = (data ?? []) as { user_id: string; name: string | null; document: string | null }[];
+    for (const r of rows) {
+      const d = (r.document ?? "").replace(/\D/g, "");
+      if (d && r.user_id && !map.has(d)) map.set(d, { userId: r.user_id, name: r.name });
+    }
+    if (rows.length < 1000) break;
+  }
+  return map;
+}
+
+// Map<user_id, omie_codigo_cliente> (p/ achar o código Y do gêmeo).
+async function fetchOmieCodigoPorUser(db: SupabaseClient): Promise<Map<string, number>> {
+  const map = new Map<string, number>();
+  for (let from = 0; ; from += 1000) {
+    const { data, error } = await db
+      .from("omie_clientes").select("user_id, omie_codigo_cliente").range(from, from + 999);
+    if (error) throw new Error(`fetch omie_clientes codigo: ${error.message}`);
+    const rows = (data ?? []) as { user_id: string; omie_codigo_cliente: number | null }[];
+    for (const r of rows) if (r.user_id && r.omie_codigo_cliente != null) map.set(r.user_id, Number(r.omie_codigo_cliente));
+    if (rows.length < 1000) break;
+  }
+  return map;
+}
+
+async function mapaConsolidacao(db: SupabaseClient, dryRun: boolean, batchId: string) {
+  const startedAt = new Date().toISOString();
+  await updateSyncState(db, "mapa_consolidacao", "all", {
+    status: "running", error_message: null, metadata: { dry_run: dryRun, batch_id: batchId, started_at: startedAt },
+  });
+  try {
+    // 1. clones (omie sem profile): user → código (omie_clientes é UNIQUE(user_id) → 1 código/user);
+    //    código com >1 user (ambíguo) fica de fora — não dá p/ apelidar com segurança.
+    const alvosPorCodigo = await fetchAlvosSemProfile(db);
+    const codigoPorCloneUser = new Map<string, number>();
+    let ambiguos = 0;
+    for (const [codigo, lista] of alvosPorCodigo) {
+      if (lista.length > 1) { ambiguos += lista.length; continue; }
+      codigoPorCloneUser.set(lista[0].userId, codigo);
+    }
+    const codigosClone = new Set(codigoPorCloneUser.values());
+
+    // 2. gêmeo por documento + código Y do gêmeo.
+    const gemeoPorDoc = await fetchProfileDocNameMap(db);
+    const codigoPorUser = await fetchOmieCodigoPorUser(db);
+
+    // 3. enumera as 3 contas: doc por código (só clones) + conta por código (todos, p/ achar a conta de Y).
+    const docPorCodigo = new Map<number, string | null>();
+    const contaPorCodigo = new Map<number, string>();
+    const codigoMultiConta = new Set<number>();
+    const contasProcessadas: OmieAccount[] = [];
+    const contasSemCredencial: OmieAccount[] = [];
+    for (const account of ["vendas", "colacor_vendas", "servicos"] as OmieAccount[]) {
+      const creds = getCredentials(account);
+      if (!creds.key || !creds.secret) { contasSemCredencial.push(account); continue; }
+      contasProcessadas.push(account);
+      let pagina = 1, totalPaginas = 1;
+      while (pagina <= totalPaginas) {
+        const result = (await callOmie(account, "geral/clientes/", "ListarClientes", {
+          pagina, registros_por_pagina: 100, apenas_importado_api: "N",
+        })) as unknown as OmieListarClientesResponse;
+        totalPaginas = result.total_de_paginas || 1;
+        for (const c of result.clientes_cadastro || []) {
+          if (c.codigo_cliente_omie == null) continue;
+          const codigo = Number(c.codigo_cliente_omie);
+          const prev = contaPorCodigo.get(codigo);
+          if (prev && prev !== account) codigoMultiConta.add(codigo);
+          contaPorCodigo.set(codigo, account);
+          if (codigosClone.has(codigo)) docPorCodigo.set(codigo, normalizarDocumento(c.cnpj_cpf ?? null));
+        }
+        pagina++;
+      }
+      console.log(`[MapaConsolidacao] ${account}: ${totalPaginas} páginas`);
+    }
+
+    // 4. monta os apelidos (clone → gêmeo) + classifica mesma-conta vs cross-account.
+    const aliases: AliasRow[] = [];
+    const stats = { mesma_conta: 0, cross_account: 0, conta_indefinida: 0, sem_gemeo: 0, conta_multipla: 0 };
+    for (const [cloneUserId, codigoX] of codigoPorCloneUser) {
+      const doc = docPorCodigo.get(codigoX) ?? null;
+      const gemeo = doc ? gemeoPorDoc.get(doc) : undefined;
+      if (!gemeo) { stats.sem_gemeo++; continue; }
+      const codigoY = codigoPorUser.get(gemeo.userId) ?? null;
+      const contaX = contaPorCodigo.get(codigoX) ?? null;
+      const contaY = codigoY != null ? (contaPorCodigo.get(codigoY) ?? null) : null;
+      if (codigoMultiConta.has(codigoX) || (codigoY != null && codigoMultiConta.has(codigoY))) stats.conta_multipla++;
+      if (contaY == null) stats.conta_indefinida++;
+      else if (contaX === contaY) stats.mesma_conta++;
+      else stats.cross_account++;
+      aliases.push({
+        alias_user_id: cloneUserId, canonical_user_id: gemeo.userId, documento: doc,
+        alias_omie_codigo: codigoX, alias_conta: contaX,
+        canonical_omie_codigo: codigoY, canonical_conta: contaY,
+        status: "inactive", reason: null, batch_id: batchId,
+      });
+    }
+
+    // 5. persiste com status='inactive' (inerte). Upsert por alias_user_id (idempotente).
+    let gravados = 0;
+    if (!dryRun) {
+      for (let i = 0; i < aliases.length; i += 500) {
+        const chunk = aliases.slice(i, i + 500);
+        const { error } = await db.from("customer_canonical_alias").upsert(chunk, { onConflict: "alias_user_id" });
+        if (error) throw new Error(`upsert customer_canonical_alias: ${error.message}`);
+        gravados += chunk.length;
+      }
+    }
+
+    const relatorio = {
+      dry_run: dryRun, batch_id: batchId,
+      contas_processadas: contasProcessadas, contas_sem_credencial: contasSemCredencial,
+      clones_total: codigoPorCloneUser.size, ambiguos, aliases: aliases.length, gravados,
+      mesma_conta: stats.mesma_conta, cross_account: stats.cross_account,
+      conta_indefinida: stats.conta_indefinida, conta_multipla: stats.conta_multipla, sem_gemeo: stats.sem_gemeo,
+      amostra: aliases.slice(0, 10).map((a) => ({
+        alias: a.alias_user_id, canonical: a.canonical_user_id, doc: a.documento,
+        contaX: a.alias_conta, contaY: a.canonical_conta,
+      })),
+      finished_at: new Date().toISOString(),
+    };
+    await updateSyncState(db, "mapa_consolidacao", "all", { status: "complete", total_synced: gravados, metadata: relatorio });
+    console.log(`[MapaConsolidacao] ${JSON.stringify(relatorio)}`);
+    return relatorio;
+  } catch (error) {
+    await updateSyncState(db, "mapa_consolidacao", "all", { status: "error", error_message: String(error) });
+    throw error;
+  }
+}
+
 // ======== MAIN HANDLER ========
 
 serve(async (req) => {
@@ -1329,7 +1486,7 @@ serve(async (req) => {
       Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!
     );
 
-    const { action, account = "vendas", start_page, max_pages, dry_run, limite } = await req.json();
+    const { action, account = "vendas", start_page, max_pages, dry_run, limite, batch_id } = await req.json();
     let result: unknown;
 
     switch (action) {
@@ -1467,6 +1624,42 @@ serve(async (req) => {
           EdgeRuntime.waitUntil(bgTask);
         }
         return new Response(JSON.stringify({ accepted: true, dry_run: dryRun, limite: limiteNum }), {
+          status: 202, headers: { ...corsHeaders, "Content-Type": "application/json" },
+        });
+      }
+      case "mapa_consolidacao": {
+        // Fase 1 da consolidação (B-lite). Casa clone→gêmeo, popula customer_canonical_alias com
+        // status='inactive' (INERTE até o canário). dry_run=true só conta (não grava). Reporta
+        // mesma-conta vs cross-account. Gate master/gestor; background.
+        const dryRun = dry_run === true; // padrão: GRAVA (alias inativo é inerte); dry_run=true só conta.
+        const batchId = typeof batch_id === "string" && batch_id.trim() ? batch_id.trim() : "mapa-inicial";
+        if (auth.via === "staff") {
+          const { data: pode } = await supabaseAdmin.rpc("pode_ver_carteira_completa", { _uid: auth.userId });
+          if (!pode) {
+            return new Response(JSON.stringify({ error: "Forbidden: requer master ou gestor comercial" }), {
+              status: 403, headers: { ...corsHeaders, "Content-Type": "application/json" },
+            });
+          }
+        }
+        const stMapa = await getSyncState(supabaseAdmin, "mapa_consolidacao", "all");
+        const runningMapa = stMapa?.status === "running" && stMapa?.updated_at &&
+          (Date.now() - new Date(stMapa.updated_at as string).getTime() < 15 * 60 * 1000);
+        if (runningMapa) {
+          return new Response(JSON.stringify({ accepted: false, already_running: true }), {
+            status: 202, headers: { ...corsHeaders, "Content-Type": "application/json" },
+          });
+        }
+        const bgTask = mapaConsolidacao(supabaseAdmin, dryRun, batchId).catch((e) => {
+          console.error("[mapa_consolidacao][bg]", e instanceof Error ? e.message : e);
+        });
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore - EdgeRuntime existe no runtime do Supabase Edge
+        if (typeof EdgeRuntime !== "undefined" && typeof EdgeRuntime.waitUntil === "function") {
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
+          EdgeRuntime.waitUntil(bgTask);
+        }
+        return new Response(JSON.stringify({ accepted: true, dry_run: dryRun, batch_id: batchId }), {
           status: 202, headers: { ...corsHeaders, "Content-Type": "application/json" },
         });
       }

--- a/supabase/migrations/20260613120000_customer_canonical_alias.sql
+++ b/supabase/migrations/20260613120000_customer_canonical_alias.sql
@@ -1,0 +1,43 @@
+-- Consolidação dos clientes duplicados (clones do import de março) — Fase 1: tabela de apelidos.
+-- Spec: docs/superpowers/specs/2026-06-13-consolidacao-clientes-duplicados-design.md
+-- Estratégia "B-lite" (validada pelo Codex): NÃO funde fisicamente. Mapeia o clone vazio (alias) → o
+-- cliente real com nome (canonical). Só o carteira-rebuild (Fase 2) lê esta tabela p/ canonicalizar a
+-- projeção da carteira. Esta migration SÓ CRIA a tabela — vazia e inerte; nada muda até a action popular
+-- (status='inactive') e a Fase 2 começar a ler aliases ATIVOS.
+--
+-- ⚠️ Migration manual: colar no SQL Editor do Lovable → Run.
+
+create table if not exists public.customer_canonical_alias (
+  alias_user_id          uuid primary key,        -- clone (omie_clientes SEM profile)
+  canonical_user_id      uuid not null,           -- gêmeo (com profile/nome/histórico) — sobrevivente
+  documento              text,                    -- CNPJ/CPF normalizado (auditoria do casamento)
+  alias_omie_codigo      bigint,                  -- código Omie do clone (X)
+  alias_conta            text,                    -- conta Omie onde o clone casou (vendas/colacor_vendas/servicos)
+  canonical_omie_codigo  bigint,                  -- código Omie do gêmeo (Y), se conhecido
+  canonical_conta        text,                    -- conta Omie do gêmeo (p/ mesma-conta vs cross-account)
+  status                 text not null default 'inactive'
+                           check (status in ('active','inactive','conflict')),
+  reason                 text,                    -- por que inativo/conflito (auditoria)
+  batch_id               text,                    -- lote de geração (canário/levas)
+  created_at             timestamptz not null default now(),
+  updated_at             timestamptz not null default now(),
+  constraint cca_no_self check (alias_user_id <> canonical_user_id)
+);
+
+-- Agrupar por canônico (o rebuild substitui alias→canonical e agrupa) e filtrar ativos rápido.
+create index if not exists idx_cca_canonical on public.customer_canonical_alias (canonical_user_id);
+create index if not exists idx_cca_status_active on public.customer_canonical_alias (status) where status = 'active';
+
+alter table public.customer_canonical_alias enable row level security;
+
+-- Leitura: gestor/master (mesma régua da carteira). Escrita: só service_role (a action de mapa e o
+-- carteira-rebuild rodam como service_role e bypassam a RLS) — humano nunca grava o apelido à mão.
+drop policy if exists "cca_select_gestor_master" on public.customer_canonical_alias;
+create policy "cca_select_gestor_master" on public.customer_canonical_alias
+  for select to authenticated
+  using ((select public.pode_ver_carteira_completa((select auth.uid()))));
+
+-- Validação (colar junto):
+-- select 'cca_ok' as check, count(*) as linhas,
+--        (select count(*) from pg_policies where tablename='customer_canonical_alias') as policies
+-- from public.customer_canonical_alias;


### PR DESCRIPTION
## Contexto

O dry-run do backfill (#772) revelou que os 1.633 "clientes-fantasma" **não precisam de cadastro** — são **clones** de clientes que já têm profile. O import de 2026-03-01 montou a carteira das vendedoras casando por **código Omie em vez de CNPJ** → cada cliente que já existia virou um clone vazio na carteira da vendedora, enquanto o cadastro com nome ficou na carteira do founder. Por isso `/admin/customers` mostra a carteira da vendedora quase vazia (clones sem profile somem do INNER JOIN).

Causa provada por SQL: `omie_clientes` 6.909 = 5.276 com profile + 1.633 clones; `doc_em_outro_profile=1633` (todos os clones têm o CNPJ num profile existente); todos criados em 01-02/03; carteira `source='omie'` (com vendedor) = 1.238 clones, `hunter_orphan` = 5.268 com nome; o gêmeo concentra ~99% do faturamento.

## Estratégia "B-lite" (validada por consult Codex)

**Não fundir fisicamente** (`omie_clientes` é UNIQUE(user_id) → não suporta 2 códigos/cliente; e o app re-deriva a carteira do Omie via `carteira-rebuild` → mexer no app é desfeito pelo sync). Em vez disso, **canonicalizar só na projeção da carteira**: uma tabela de apelidos `clone → gêmeo` que o `carteira-rebuild` (Fase 2) consulta pra mostrar o cliente real (com nome) na carteira da vendedora e esconder o clone. Reversível (liga/desliga), contido (1 tabela + 1 função), não deleta nada, não luta com o sync.

## O que entra (Fase 1 — INÓCUA, nada muda na tela)

- **migration `20260613120000`**: cria `customer_canonical_alias` (`alias_user_id`→`canonical_user_id`, `status`, conta de X e Y, RLS gestor/master). Tabela **vazia e inerte**. Validada em PG17 (12 colunas, RLS on, CHECKs de `status` + no-self).
- **edge**: action `mapa_consolidacao` — casa clone→gêmeo via Omie (3 contas), popula a tabela com **`status='inactive'`** (só o rebuild da Fase 2 lê aliases ATIVOS) + captura a **conta Omie de cada código** → revela **mesma-conta** (duplicata real) vs **cross-account** (mesmo CNPJ em empresas diferentes — NÃO é duplicata). **Não toca** `omie_clientes`/carteira/scores. `deno check` net-zero.

Codex achou de brinde 2 bugs no `carteira-rebuild` atual (ignora a conta ao cruzar vendedor; omite `eligible` no upsert) — a corrigir na **Fase 2**.

## ⚠️ Pendências do founder (após merge)

1. **Migration** `20260613120000` no SQL Editor (cria a tabela vazia).
2. **Deploy** do `omie-analytics-sync` via Lovable (verbatim, **após** merge).
3. **Rodar o mapa**: invocar `mapa_consolidacao` (popula a tabela inativa + reporta mesma-conta vs cross-account) → me cola o relatório de `sync_state`.

**Nenhuma escrita em carteira/score nesta fase.** A Fase 2 (rebuild canônico) + canário ficam pendentes de aprovação, com Codex validando o money-path antes de qualquer ativação.

Spec: `docs/superpowers/specs/2026-06-13-consolidacao-clientes-duplicados-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
