### PR TITLE
fix(clientes): conserto do Codex review do #778 — cobertura do alvo na lente (P1) + hash estável na key dos scores (P2)

### DIFF
--- a/src/components/adminCustomers/useClientesScope.ts
+++ b/src/components/adminCustomers/useClientesScope.ts
@@ -10,7 +10,7 @@ import { useAuth } from '@/contexts/AuthContext';
 import { useImpersonation } from '@/contexts/ImpersonationContext';
 import { useDisplayAccess } from '@/hooks/useDisplayAccess';
 import {
-  resolveModoEscopo, fetchCarteiraClientes, fetchScoresPorCustomer,
+  resolveModoEscopo, fetchCarteiraClientes, fetchScoresPorCustomer, hashIds,
 } from '@/lib/carteira/escopo-clientes';
 import type { Customer, ClientScore } from './types';
 
@@ -87,10 +87,13 @@ export function useClientesScope(): ClientesScope {
   }, [isCarteira, carteiraQuery.data, baseQuery.data]);
 
   const visibleIds = useMemo(() => customers.map((c) => c.user_id), [customers]);
+  // Hash estável dos IDs (não só a contagem) p/ a key dos scores não reusar o map de um
+  // conjunto anterior de mesmo tamanho (reatribuição que mantém a length). Codex P2.
+  const idsHash = useMemo(() => hashIds(visibleIds), [visibleIds]);
 
   /* ─── SCORES por customer_user_id (ambos os modos) ─── */
   const scoresQuery = useQuery({
-    queryKey: ['admin-clientes-scores', isCarteira ? 'carteira' : 'completa', baseId, visibleIds.length],
+    queryKey: ['admin-clientes-scores', isCarteira ? 'carteira' : 'completa', baseId, idsHash],
     enabled: queriesReady && visibleIds.length > 0,
     staleTime: 60_000,
     queryFn: () => fetchScoresPorCustomer(visibleIds),

--- a/src/lib/carteira/__tests__/escopo-clientes.test.ts
+++ b/src/lib/carteira/__tests__/escopo-clientes.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   resolveModoEscopo, chunk, marcarCobertura, ordenarPorNome, paginarTudo, coletarEmLotes,
+  hashIds, ownersAtivosDoAlvo,
 } from '@/lib/carteira/escopo-clientes';
 
 describe('resolveModoEscopo', () => {
@@ -83,5 +84,31 @@ describe('coletarEmLotes', () => {
   });
   it('lista vazia → []', async () => {
     expect(await coletarEmLotes([], 2, async () => [99])).toEqual([]);
+  });
+});
+
+describe('hashIds', () => {
+  it('mesmos ids → mesmo hash; um id diferente (mesma length) → hash diferente', () => {
+    expect(hashIds(['a', 'b'])).toBe(hashIds(['a', 'b']));
+    expect(hashIds(['a', 'b'])).not.toBe(hashIds(['a', 'c']));
+  });
+  it('a contagem entra no hash (mesmo prefixo, tamanhos diferentes)', () => {
+    expect(hashIds(['a'])).not.toBe(hashIds(['a', 'a']));
+  });
+  it('lista vazia → "0:0"', () => expect(hashIds([])).toBe('0:0'));
+});
+
+describe('ownersAtivosDoAlvo', () => {
+  const NOW = '2026-06-13T12:00:00Z';
+  it('sem cobertura → só o alvo', () => {
+    expect(ownersAtivosDoAlvo([], 'alvo', NOW)).toEqual(['alvo']);
+  });
+  it('cobertura sem validade e ainda-válida entram; expirada sai', () => {
+    const rows = [
+      { covered_user_id: 'A', valid_until: null },                  // sem validade → entra
+      { covered_user_id: 'B', valid_until: '2026-06-20T00:00:00Z' }, // válida até o futuro → entra
+      { covered_user_id: 'C', valid_until: '2026-06-01T00:00:00Z' }, // já expirou → sai
+    ];
+    expect(ownersAtivosDoAlvo(rows, 'alvo', NOW)).toEqual(['alvo', 'A', 'B']);
   });
 });

--- a/src/lib/carteira/escopo-clientes.ts
+++ b/src/lib/carteira/escopo-clientes.ts
@@ -69,6 +69,33 @@ export async function coletarEmLotes<I, O>(
   return out;
 }
 
+/** Hash estável e barato dos IDs visíveis. A contagem sozinha não pega reatribuição
+ *  que mantém o tamanho (cliente sai/entra, length igual); o hash muda se qualquer id
+ *  mudar. Usado na queryKey dos scores p/ não reusar o map do conjunto anterior. */
+export function hashIds(ids: string[]): string {
+  let h = 0;
+  for (const id of ids) {
+    for (let i = 0; i < id.length; i++) {
+      h = (Math.imul(h, 31) + id.charCodeAt(i)) | 0;
+    }
+  }
+  return `${ids.length}:${h}`;
+}
+
+/** Owners do escopo do ALVO na lente: posse direta + carteiras que ele cobre (ativas e
+ *  dentro da validade). `coverageRows` vêm de carteira_coverage já filtradas por active.
+ *  Reproduz, com a sessão do master, o que a RLS carteira_visivel_para daria ao alvo. */
+export function ownersAtivosDoAlvo(
+  coverageRows: { covered_user_id: string; valid_until: string | null }[],
+  alvoId: string,
+  nowIso: string,
+): string[] {
+  const cobertos = coverageRows
+    .filter((c) => !c.valid_until || c.valid_until > nowIso)
+    .map((c) => c.covered_user_id);
+  return [alvoId, ...cobertos];
+}
+
 const LOTE_IN = 150; // 1000 UUIDs estouram o limite de URL do proxy (≠ cap de linhas do PostgREST)
 
 /**
@@ -81,14 +108,28 @@ export async function fetchCarteiraClientes(opts: {
   effectiveUserId: string | null;
   baseId: string | null;
 }): Promise<{ customers: Customer[]; ids: string[] }> {
+  // Na lente a sessão é a do MASTER (RLS vê tudo), então REPRODUZIMOS o escopo do alvo:
+  // posse direta + carteiras que o alvo cobre. Fora da lente, a RLS carteira_visivel_para
+  // já entrega carteira própria + cobertura — sem filtro de owner aqui.
+  let ownerFilter: string[] | null = null;
+  if (opts.isImpersonating && opts.effectiveUserId) {
+    const { data: cov, error: covErr } = await supabase
+      .from('carteira_coverage')
+      .select('covered_user_id, valid_until')
+      .eq('covering_user_id', opts.effectiveUserId)
+      .eq('active', true);
+    if (covErr) throw covErr;
+    ownerFilter = ownersAtivosDoAlvo(cov ?? [], opts.effectiveUserId, new Date().toISOString());
+  }
+
   const assignments = await paginarTudo<{ customer_user_id: string; owner_user_id: string }>(
     async (from, to) => {
       let q = supabase
         .from('carteira_assignments')
         .select('customer_user_id, owner_user_id')
         .eq('eligible', true);
-      if (opts.isImpersonating && opts.effectiveUserId) {
-        q = q.eq('owner_user_id', opts.effectiveUserId);
+      if (ownerFilter) {
+        q = q.in('owner_user_id', ownerFilter);
       }
       const { data, error } = await q.order('customer_user_id').range(from, to);
       if (error) throw error;


### PR DESCRIPTION
## Resumo

Follow-up do #778 (escopo por carteira em `/admin/customers`), aplicando os **2 achados do Codex review** do diff:

- **[P1] Cobertura do alvo na lente** (`src/lib/carteira/escopo-clientes.ts`): na lente "Ver como pessoa", filtrava só `.eq('owner_user_id', effectiveUserId)`, escondendo as carteiras que o alvo **cobre** — a vendedora vista some os clientes cobertos e o badge "cobertura" ficava **morto** na lente. Agora reproduz o escopo do alvo: busca `carteira_coverage` do alvo + filtra `.in('owner_user_id', [alvo, ...cobertos ativos])`. **Fora da lente** a RLS `carteira_visivel_para` já fazia isso (inalterado).
- **[P2] Key dos scores por hash dos IDs** (`src/components/adminCustomers/useClientesScope.ts`): a `queryKey` usava `visibleIds.length`; reatribuição que mantém o tamanho reusava o score-map do conjunto anterior (cliente novo sem score, removido cacheado). Agora usa `hashIds(visibleIds)` (memoizado).

Helpers puros novos + TDD: `hashIds`, `ownersAtivosDoAlvo` (+5 testes; escopo-clientes 17→22).

**Frontend-only.** `bun run test` **3153/3153**, typecheck limpo, lint ok.

⚠️ **Limitação registrada**: o hook irmão `useMyCarteiraScores` (Meu Dia da Farmer) tem a mesma limitação de cobertura-na-lente do P1 — **não alterado aqui** (follow-up de consistência cross-tela).

🤖 Generated with [Claude Code](https://claude.com/claude-code)