### PR TITLE
fix(radar): filtros CNAE e município da tela /radar (smoke da Fatia 2)

### DIFF
--- a/src/components/radar/RadarFiltros.tsx
+++ b/src/components/radar/RadarFiltros.tsx
@@ -94,8 +94,8 @@ export function RadarFiltros({
         />
 
         <Input
-          className="w-28"
-          placeholder="CNAE"
+          className="w-40"
+          placeholder="CNAE (ex.: 3101-2/00)"
           value={filtros.cnae}
           onChange={(e) => set({ cnae: e.target.value })}
         />

--- a/src/lib/radar/__tests__/ui-helpers.test.ts
+++ b/src/lib/radar/__tests__/ui-helpers.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   ACOES_CONTATO, presetParaParams, idadeEmAnos, rotuloPorte,
-  formatarCapital, formatarCnpj,
+  formatarCapital, formatarCnpj, digitosCnae,
 } from '../ui-helpers';
 
 describe('ACOES_CONTATO', () => {
@@ -56,4 +56,15 @@ describe('formatarCapital', () => {
 describe('formatarCnpj', () => {
   it('aplica a máscara', () => expect(formatarCnpj('11222333000144')).toBe('11.222.333/0001-44'));
   it('tamanho errado → devolve cru', () => expect(formatarCnpj('123')).toBe('123'));
+});
+
+describe('digitosCnae', () => {
+  it('extrai dígitos do CNAE formatado', () => expect(digitosCnae('3101-2/00')).toBe('3101200'));
+  it('preserva dígitos puros', () => expect(digitosCnae('3101200')).toBe('3101200'));
+  it('aceita parcial (prefixo da família)', () => expect(digitosCnae('3101')).toBe('3101'));
+  it('corta acima de 7 dígitos', () => expect(digitosCnae('310120099')).toBe('3101200'));
+  it('vazio/null → vazio', () => {
+    expect(digitosCnae('')).toBe('');
+    expect(digitosCnae(null)).toBe('');
+  });
 });

--- a/src/lib/radar/ui-helpers.ts
+++ b/src/lib/radar/ui-helpers.ts
@@ -64,3 +64,10 @@ export function formatarCnpj(cnpj: string): string {
   if (!/^\d{14}$/.test(cnpj)) return cnpj;
   return cnpj.replace(/^(\d{2})(\d{3})(\d{3})(\d{4})(\d{2})$/, '$1.$2.$3/$4-$5');
 }
+
+/** Extrai só os dígitos de um input de CNAE (até 7). O banco guarda o CNAE como
+ *  7 dígitos puros (`3101200`); o usuário costuma digitar o formato oficial
+ *  (`3101-2/00`). Normaliza p/ a query casar — prefix match permite parcial. */
+export function digitosCnae(input: string | null | undefined): string {
+  return (input ?? '').replace(/\D/g, '').slice(0, 7);
+}

--- a/src/queries/useRadarLista.ts
+++ b/src/queries/useRadarLista.ts
@@ -1,7 +1,7 @@
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
 import { ilikeOr } from '@/lib/postgrest';
-import { presetParaParams, type PresetRadar } from '@/lib/radar/ui-helpers';
+import { presetParaParams, digitosCnae, type PresetRadar } from '@/lib/radar/ui-helpers';
 import type { Database } from '@/integrations/supabase/types';
 
 export type RadarEmpresa = Database['public']['Tables']['radar_empresas']['Row'];
@@ -29,7 +29,12 @@ export function useRadarLista(filtros: RadarFiltros, hojeISO: string) {
       if (filtros.busca.trim()) q = q.or(ilikeOr(['razao_social', 'nome_fantasia'], filtros.busca.trim()));
       if (filtros.uf) q = q.eq('uf', filtros.uf);
       if (filtros.municipio) q = q.eq('municipio_nome', filtros.municipio);
-      if (filtros.cnae) q = q.eq('cnae_principal', filtros.cnae);
+      // CNAE: o banco guarda 7 dígitos puros; o usuário digita o formato oficial
+      // (3101-2/00). Normaliza p/ dígitos. Completo (7) = match exato pelo índice;
+      // parcial = prefix match (a família do CNAE). cnaeDigitos é só-dígitos (seguro).
+      const cnaeDigitos = digitosCnae(filtros.cnae);
+      if (cnaeDigitos.length === 7) q = q.eq('cnae_principal', cnaeDigitos);
+      else if (cnaeDigitos) q = q.like('cnae_principal', `${cnaeDigitos}%`);
       if (filtros.status) q = q.eq('prospeccao_status', filtros.status);
       else q = q.neq('prospeccao_status', 'descartado'); // fila default esconde descartados
       if (!filtros.incluirJaClientes) q = q.eq('ja_cliente', false);

--- a/src/queries/useRadarLista.ts
+++ b/src/queries/useRadarLista.ts
@@ -1,6 +1,6 @@
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
-import { ilikeOr } from '@/lib/postgrest';
+import { ilike, ilikeOr } from '@/lib/postgrest';
 import { presetParaParams, digitosCnae, type PresetRadar } from '@/lib/radar/ui-helpers';
 import type { Database } from '@/integrations/supabase/types';
 
@@ -28,7 +28,10 @@ export function useRadarLista(filtros: RadarFiltros, hojeISO: string) {
 
       if (filtros.busca.trim()) q = q.or(ilikeOr(['razao_social', 'nome_fantasia'], filtros.busca.trim()));
       if (filtros.uf) q = q.eq('uf', filtros.uf);
-      if (filtros.municipio) q = q.eq('municipio_nome', filtros.municipio);
+      // Município: o banco guarda em MAIÚSCULAS (dump RFB, "BELO HORIZONTE"); o usuário
+      // digita como quiser → ilike (case-insensitive + parcial, sanitizado). Limitação
+      // conhecida: ilike não é acento-insensitive ("sao" não casa "SÃO") — v2 com unaccent.
+      if (filtros.municipio.trim()) q = q.or(ilike('municipio_nome', filtros.municipio.trim()));
       // CNAE: o banco guarda 7 dígitos puros; o usuário digita o formato oficial
       // (3101-2/00). Normaliza p/ dígitos. Completo (7) = match exato pelo índice;
       // parcial = prefix match (a família do CNAE). cnaeDigitos é só-dígitos (seguro).


### PR DESCRIPTION
Fix de 2 filtros da tela `/radar` (Fatia 2) pegos no **smoke real** pelo founder — bugs que 3226 testes + 4 reviews não pegaram porque **só aparecem num browser** (valida a decisão de smoke antes da Fatia 3).

## CNAE (o que o founder reportou)
O campo passava o que o usuário digita (`3101-2/00`, formato oficial) cru pro `.eq('cnae_principal', ...)`, mas o banco guarda 7 dígitos puros (`3101200`) → lista vazia. Fix: helper puro `digitosCnae` (TDD) normaliza p/ dígitos; query usa `.eq` no completo (índice) / `.like` prefixo no parcial (= família do CNAE). Placeholder mostra o formato.

## Município (mesmo padrão, proativo)
`.eq('municipio_nome', ...)` exato e case-sensitive não casava "Belo Horizonte" vs "BELO HORIZONTE" (maiúsculo no dump RFB). Fix: `ilike` via helper sanitizado (anti-injeção) — case-insensitive + parcial. Limitação v1: não é acento-insensitive.

## Validação
typecheck strict · 37 testes (radar) · lint 0 errors. Requer Publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
