### PR TITLE
fix(kb): kb-extract-specs boot (esm.sh→npm) + blinda front contra white-screen

### DIFF
--- a/src/hooks/useBatchExtract.ts
+++ b/src/hooks/useBatchExtract.ts
@@ -2,6 +2,7 @@ import { useState, useCallback } from 'react';
 import { invokeFunction } from '@/lib/invoke-function';
 import type { ResultadoExtracao } from '@/lib/knowledge-base/aprovacao-fila';
 import type { KbExtractedSpec } from '@/lib/knowledge-base/specs-types';
+import { normalizeExtractedSpec } from '@/lib/knowledge-base/specs-types';
 
 /** Erro ocorrido durante a extração de um documento específico. */
 export interface BatchExtractErro {
@@ -92,7 +93,7 @@ export function useBatchExtract(): BatchExtractState & {
 
         try {
           const response = await invokeFunction<ExtractResponse>('kb-extract-specs', { documentId });
-          const resultado: ResultadoExtracao = { documentId, spec: response.specs };
+          const resultado: ResultadoExtracao = { documentId, spec: normalizeExtractedSpec(response.specs) };
           resultadosAcumulados.push(resultado);
 
           setEstado(prev => ({

--- a/src/hooks/useExtractSpecs.ts
+++ b/src/hooks/useExtractSpecs.ts
@@ -2,6 +2,7 @@ import { useMutation } from '@tanstack/react-query';
 import { invokeFunction } from '@/lib/invoke-function';
 import { toast } from 'sonner';
 import type { KbExtractedSpec } from '@/lib/knowledge-base/specs-types';
+import { normalizeExtractedSpec } from '@/lib/knowledge-base/specs-types';
 
 interface ExtractResponse {
   specs: KbExtractedSpec;
@@ -17,7 +18,7 @@ export function useExtractSpecs() {
   return useMutation({
     mutationFn: async (documentId: string): Promise<ExtractResponse> => {
       const response = await invokeFunction<ExtractResponse>('kb-extract-specs', { documentId });
-      return response;
+      return { ...response, specs: normalizeExtractedSpec(response.specs) };
     },
     onError: (err) => {
       toast.error('Erro na extração', { description: err instanceof Error ? err.message : '' });

--- a/src/lib/knowledge-base/__tests__/normalize-extracted-spec.test.ts
+++ b/src/lib/knowledge-base/__tests__/normalize-extracted-spec.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeExtractedSpec } from '@/lib/knowledge-base/specs-types';
+import type { KbExtractedSpec } from '@/lib/knowledge-base/specs-types';
+
+/** Base mínima válida (todos os 7 arrays presentes). */
+function base(over: Partial<KbExtractedSpec> = {}): KbExtractedSpec {
+  return {
+    product_code: 'FO20.6827.00',
+    product_name: 'Verniz PU',
+    supplier: 'sayerlack',
+    product_line: null,
+    product_category: null,
+    densidade_g_cm3: null,
+    solidos_pct: null,
+    viscosidade_aplicacao_s: null,
+    viscosidade_copo: null,
+    brilho_ub: null,
+    dureza: null,
+    rendimento_m2_por_litro: null,
+    demaos_recomendadas: null,
+    gramatura_g_m2_min: null,
+    gramatura_g_m2_max: null,
+    pot_life_horas: null,
+    temp_aplicacao_c_min: null,
+    temp_aplicacao_c_max: null,
+    umidade_aplicacao_pct_min: null,
+    umidade_aplicacao_pct_max: null,
+    catalisador_codigo: null,
+    catalisador_proporcao_pct: null,
+    diluente_codigo: null,
+    equipamentos_aplicacao: [],
+    lixa_recomendada: null,
+    substrato: [],
+    secagem_manuseio_h: null,
+    secagem_empilhamento_h: null,
+    secagem_total_h: null,
+    validade_dias: null,
+    temp_armazenamento_c_min: null,
+    temp_armazenamento_c_max: null,
+    certificacoes_aplicaveis: [],
+    isento_metais_pesados: [],
+    isento_substancias: [],
+    diferenciais_chave: [],
+    uso_recomendado: null,
+    publico_alvo: null,
+    extraction_confidence: 0.9,
+    extraction_gaps: [],
+    ...over,
+  };
+}
+
+describe('normalizeExtractedSpec', () => {
+  it('mantém os arrays já presentes (incl. extraction_gaps)', () => {
+    const r = normalizeExtractedSpec(
+      base({ extraction_gaps: ['densidade'], substrato: ['madeira', 'mdf'] }),
+    );
+    expect(r.extraction_gaps).toEqual(['densidade']);
+    expect(r.substrato).toEqual(['madeira', 'mdf']);
+  });
+
+  it('extraction_gaps AUSENTE (undefined) vira [] — o caso que derrubava a tela', () => {
+    // simula o LLM omitindo o campo required (a API não garante a saída)
+    const raw = base();
+    delete (raw as Partial<KbExtractedSpec>).extraction_gaps;
+    const r = normalizeExtractedSpec(raw);
+    expect(r.extraction_gaps).toEqual([]);
+    // o consumidor (RevisaoItem/KbSpecsForm) faz `.length` sem estourar:
+    expect(() => r.extraction_gaps.length).not.toThrow();
+  });
+
+  it('todos os 7 arrays ausentes viram []', () => {
+    const raw = base();
+    for (const k of [
+      'equipamentos_aplicacao', 'substrato', 'certificacoes_aplicaveis',
+      'isento_metais_pesados', 'isento_substancias', 'diferenciais_chave', 'extraction_gaps',
+    ] as const) {
+      delete (raw as Partial<KbExtractedSpec>)[k];
+    }
+    const r = normalizeExtractedSpec(raw);
+    expect(r.equipamentos_aplicacao).toEqual([]);
+    expect(r.substrato).toEqual([]);
+    expect(r.certificacoes_aplicaveis).toEqual([]);
+    expect(r.isento_metais_pesados).toEqual([]);
+    expect(r.isento_substancias).toEqual([]);
+    expect(r.diferenciais_chave).toEqual([]);
+    expect(r.extraction_gaps).toEqual([]);
+  });
+
+  it('valor não-array (string/objeto) vira [] (defensivo contra LLM)', () => {
+    const raw = base();
+    (raw as unknown as Record<string, unknown>).extraction_gaps = 'densidade';
+    (raw as unknown as Record<string, unknown>).substrato = { a: 1 };
+    const r = normalizeExtractedSpec(raw);
+    expect(r.extraction_gaps).toEqual([]);
+    expect(r.substrato).toEqual([]);
+  });
+
+  it('filtra itens não-string de dentro do array', () => {
+    const raw = base();
+    (raw as unknown as Record<string, unknown>).diferenciais_chave = ['ok', 2, null, 'bom'];
+    const r = normalizeExtractedSpec(raw);
+    expect(r.diferenciais_chave).toEqual(['ok', 'bom']);
+  });
+
+  it('preserva os campos não-array (product_code, confidence, nulls)', () => {
+    const r = normalizeExtractedSpec(base({ product_code: 'WFOT.6529', extraction_confidence: 0.42 }));
+    expect(r.product_code).toBe('WFOT.6529');
+    expect(r.extraction_confidence).toBe(0.42);
+    expect(r.rendimento_m2_por_litro).toBeNull();
+  });
+});

--- a/src/lib/knowledge-base/specs-types.ts
+++ b/src/lib/knowledge-base/specs-types.ts
@@ -90,6 +90,28 @@ export type KbExtractedSpec = Omit<
   | 'updated_at'
 >;
 
+/**
+ * Blinda o spec vindo da edge (LLM) contra campos de array AUSENTES.
+ * A tool `extract_product_specs` marca esses 7 campos como `required`, mas a API não
+ * garante a saída do modelo — se algum vier ausente, `extraction_gaps.length` (e os
+ * `joinTags`) estouram no render e DERRUBAM a tela (white screen). Normaliza na FRONTEIRA
+ * (onde a resposta da edge entra no front) → todo consumidor downstream fica seguro.
+ */
+export function normalizeExtractedSpec(raw: KbExtractedSpec): KbExtractedSpec {
+  const arr = (v: unknown): string[] =>
+    Array.isArray(v) ? v.filter((x): x is string => typeof x === 'string') : [];
+  return {
+    ...raw,
+    equipamentos_aplicacao: arr(raw?.equipamentos_aplicacao),
+    substrato: arr(raw?.substrato),
+    certificacoes_aplicaveis: arr(raw?.certificacoes_aplicaveis),
+    isento_metais_pesados: arr(raw?.isento_metais_pesados),
+    isento_substancias: arr(raw?.isento_substancias),
+    diferenciais_chave: arr(raw?.diferenciais_chave),
+    extraction_gaps: arr(raw?.extraction_gaps),
+  };
+}
+
 export interface KbCompetitor {
   id: string;
   name: string;

--- a/supabase/functions/kb-extract-specs/index.ts
+++ b/supabase/functions/kb-extract-specs/index.ts
@@ -1,5 +1,7 @@
 import Anthropic from "npm:@anthropic-ai/sdk@^0.93.0";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+// ⚠️ usar npm: (igual a tarefa-extrair-voz/melhoria-triagem/etc.). O esm.sh/@supabase/supabase-js
+// falhava em resolver no boot do edge runtime → RUNTIME_ERROR sem linha/stack (módulo não carrega).
+import { createClient } from "npm:@supabase/supabase-js@^2";
 import { authorizeCronOrStaff, corsHeaders } from "../_shared/auth.ts";
 
 const SYSTEM_PROMPT_EXTRACT_SPECS = `Você extrai specs técnicos estruturados de boletins técnicos de tintas industriais para a base de conhecimento da Colacor (distribuidora Sayerlack).


### PR DESCRIPTION
## Fix: edge `kb-extract-specs` falhava no boot + front white-screen na extração de boletim

**Sintoma (prod, após Publish):** `RUNTIME_ERROR` na edge `kb-extract-specs` (`lineno:0`, `stack:not_applicable`, `has_blank_screen:true`) ao extrair specs de boletim. O founder viu "vários erros assim".

### Causa-raiz (2 camadas)
1. **Boot da edge:** `kb-extract-specs` importava o supabase-js do **`esm.sh`** (`https://esm.sh/@supabase/supabase-js@2.45.0`), **fora do try** (linha 104) — enquanto **TODAS as outras edges Anthropic que funcionam** (`tarefa-extrair-voz`, `melhoria-triagem`, …) usam `npm:@supabase/supabase-js@^2`. O `esm.sh` falhando em resolver no boot do edge runtime é exatamente o `RUNTIME_ERROR` **sem linha/stack** (o módulo não carrega — não é um caminho de erro tratado, que retornaria Response normal). → alinhado pro `npm:`.
2. **White screen do front:** mesmo que a edge falhe, o front **não deveria** ficar em branco. A tool `extract_product_specs` marca 7 campos de array como `required`, mas a API **não garante** a saída do LLM — se `extraction_gaps` (etc.) vier ausente, `extraction_gaps.length` (no `RevisaoItem`/`KbSpecsForm`) estoura no render → tela branca. → `normalizeExtractedSpec` blinda na **fronteira** (nos 2 hooks que recebem a resposta da edge): todo array ausente/não-array vira `[]`.

> Nota: o `invokeFunction` THROWA em erro de edge (os hooks pegam no `onError`/try-catch → toast), então o erro de edge sozinho não causa o branco — o branco é render-crash com spec malformado, coberto pela blindagem.

### Mudanças
- `supabase/functions/kb-extract-specs/index.ts`: import `esm.sh` → `npm:` (1 linha). ⚠️ **requer redeploy da edge.**
- `src/lib/knowledge-base/specs-types.ts`: `normalizeExtractedSpec` (+ 6 testes vitest).
- `src/hooks/useExtractSpecs.ts` + `src/hooks/useBatchExtract.ts`: aplicam a normalização na fronteira.

### Validação
typecheck **0** · **3263 testes** (6 novos) · lint **0**.

### ⚠️ Ações do founder
1. **Deploy da edge `kb-extract-specs`** via chat do Lovable (ler de `supabase/functions/kb-extract-specs/index.ts` da main, **verbatim**) — é o que conserta o boot. Confirmar **Active** em Cloud → Edge functions.
2. **Publish** do front (a blindagem do white-screen).
3. Se persistir: me manda o **log real** de Cloud → Edge functions → `kb-extract-specs` (o `[kb-extract-specs]` ou o erro de boot) pra cravar a causa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
