### PR TITLE
fix(kb): aprovar lote não apaga as fichas 'a revisar' (re-extração à toa)

### DIFF
--- a/src/components/knowledge-base/ApprovalQueueSection.tsx
+++ b/src/components/knowledge-base/ApprovalQueueSection.tsx
@@ -158,9 +158,14 @@ export function ApprovalQueueSection() {
     toast.success(
       `${resultado.ok} ficha${resultado.ok !== 1 ? 's' : ''} aprovada${resultado.ok !== 1 ? 's' : ''}${errosStr}`,
     );
-    // Reseta o estado de extração; a fila vai recarregar via invalidate do useBulkApproveSpecs
-    extract.reset();
-    setRevisadosIds(new Set());
+    // Remove SÓ as fichas auto-aprovadas COM SUCESSO do estado; mantém as 'a revisar' (e as que
+    // falharam, pra retry). ⚠️ Antes era extract.reset() — apagava TUDO, e as fichas a revisar
+    // sumiam ao aprovar o lote, forçando re-extração (gasto de API à toa). A fila recarrega via
+    // invalidate do useBulkApproveSpecs.
+    const falharam = new Set(resultado.erros.map((e) => e.documentId));
+    extract.removerResultados(
+      auto.filter((a) => !falharam.has(a.documentId)).map((a) => a.documentId),
+    );
   }
 
   // ── Renderização: carregando ──

--- a/src/hooks/useBatchExtract.ts
+++ b/src/hooks/useBatchExtract.ts
@@ -51,11 +51,25 @@ const ESTADO_INICIAL: BatchExtractState = {
 export function useBatchExtract(): BatchExtractState & {
   run: (documentIds: string[]) => Promise<ResultadoExtracao[]>;
   reset: () => void;
+  removerResultados: (documentIds: string[]) => void;
 } {
   const [estado, setEstado] = useState<BatchExtractState>(ESTADO_INICIAL);
 
   const reset = useCallback(() => {
     setEstado(ESTADO_INICIAL);
+  }, []);
+
+  /**
+   * Remove resultados específicos do estado (ex.: os aprovados em lote) SEM apagar os demais.
+   * ⚠️ Diferente de `reset()`, que zerava TUDO — incluindo as fichas 'a revisar' ainda não
+   * salvas, que sumiam ao aprovar o lote e exigiam re-extração (gasto de API à toa).
+   */
+  const removerResultados = useCallback((documentIds: string[]) => {
+    const ids = new Set(documentIds);
+    setEstado((prev) => ({
+      ...prev,
+      resultados: prev.resultados.filter((r) => !ids.has(r.documentId)),
+    }));
   }, []);
 
   const run = useCallback(async (documentIds: string[]): Promise<ResultadoExtracao[]> => {
@@ -124,5 +138,5 @@ export function useBatchExtract(): BatchExtractState & {
     return resultadosAcumulados;
   }, []);
 
-  return { ...estado, run, reset };
+  return { ...estado, run, reset, removerResultados };
 }


### PR DESCRIPTION
## Fix: aprovar o lote apagava as fichas "a revisar" (forçava re-extração + gasto de API)

**Sintoma (founder):** extraiu ~297 boletins, aprovou o lote de alta confiança (deu certo), e **as fichas que precisava revisar SUMIRAM** → teria que re-extrair (gasta saldo da Anthropic à toa).

**Causa-raiz:** `ApprovalQueueSection.handleAprovarLote` chamava **`extract.reset()`** após aprovar o lote, que **zera o estado INTEIRO da extração** — incluindo as fichas `revisar` (baixa confiança) que ainda estavam só em memória (não salvas). Elas sumiam da tela. (Os **documentos nunca estiveram em risco** — continuam na fila; só o **resultado da extração**, que é efêmero no client, era apagado.)

**Fix:** novo `useBatchExtract.removerResultados(ids)` remove SÓ as fichas indicadas, sem tocar nas demais. `handleAprovarLote` passa a remover **apenas as auto-aprovadas com sucesso** (mantém as `a revisar` + as que falharam, pra retry). Sem mais `reset()` ao aprovar lote.

**Validação:** typecheck **0** · lint **0**.

⚠️ **Requer Publish** do front no Lovable pra valer.

> Nota: as fichas que JÁ sumiram nesta sessão precisam ser re-extraídas uma vez (o resultado se perdeu). Este fix impede que aconteça de novo. (A persistência das extrações — pra nunca re-extrair entre sessões — é um follow-up à parte, em discussão.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
