### PR TITLE
feat(kpis-hunter): placar de aquisição honesto no Meu Dia do hunter

### DIFF
--- a/docs/superpowers/specs/2026-06-13-kpis-hunter-meu-dia-design.md
+++ b/docs/superpowers/specs/2026-06-13-kpis-hunter-meu-dia-design.md
@@ -1,0 +1,86 @@
+# KPIs de nível mundial do HUNTER — Meu Dia (design)
+
+**Data:** 2026-06-13
+**Autor:** Claude + **Codex (gpt-5.5, consult, reasoning high)** — 2ª opinião conforme CLAUDE.md §12.
+**Status:** aprovado pelo founder pra implementar (frente "começar pela farmer e expandir" — farmer feita em #690; hunter→closer→master em PRs separados).
+
+## Contexto / problema
+
+Continuação da redefinição de KPIs por persona (a farmer foi a 1ª — `docs/superpowers/specs/2026-06-06-kpis-farmer-meu-dia-design.md`). O `/meu-dia` roteia por `commercial_role` (lente-aware) e cada papel tem seu dashboard. Os dashboards foram montados **ad-hoc** e **vazam cards entre personas**.
+
+O **HunterDashboard** hoje tem: `MinhasTarefasCard`, `ChamadasPendentesNudge`, **`VisitasHojeCard`** (← visita é trabalho do CLOSER, não do hunter) e `CacaConteudo` (a fila de caça). **Não tem placar nenhum** — o KPI de aquisição do hunter não aparece em lugar algum do dashboard.
+
+O hunter = **aquisição / new business**: caça clientes NOVOS via a fila de caça (look-alike dos melhores do grupo que ainda não compram na empresa-alvo). Decisão do founder: os KPIs devem ser base de **remuneração variável (OTE) futura** — mensuráveis, auditáveis, por-vendedor, anti-gaming.
+
+## KPIs de nível mundial do hunter (acquisition / new business)
+
+Framework de aquisição B2B: **pipeline → conversão → velocidade → qualidade**. ⚠️ **A 2ª opinião do Codex foi decisiva e mudou a proposta inicial**: o app HOJE quase não instrumenta aquisição por-hunter, então o placar honesto é **enxuto** — e a maior parte do "nível mundial" vira **gap v2 explícito**, não card fabricado.
+
+| KPI | Mede | Tipo | OTE | Dado |
+|---|---|---|---|---|
+| **Novos na sua carteira MTD** ⭐ proxy-norte | clientes da carteira cuja 1ª compra (de toda a história) caiu no mês | output (proxy) | **ainda NÃO comissionável** (atribuição frágil — ver risco) | `novos_clientes_positivados` ✅ |
+| **Receita da carteira MTD** | faturamento total da carteira do hunter no mês | output | candidato (mistura aquisição+retenção; v2 separa "receita dos novos") | `receita_mtd` ✅ |
+| **Participação de novos** | % de novos entre os compradores do mês | diagnóstico | **não** comissionável (sobe artificialmente quando antigos caem) | `novos / positivados` (derivado) ✅ |
+| **Fila de caça** (contexto, não card) | estoque de oportunidade fornecido pelo sistema | acionável | **não** (é input do motor, não esforço/performance do hunter) | `useCaca` ✅ |
+| **Chamadas hoje** | pulso de atividade | leading | higiene | `useMyKpis.calls_today` ✅ |
+
+### Por que enxuto (decisão do Codex — furos da proposta inicial)
+A proposta inicial reusava o ramo `isHunter` atual do `PositivacaoHero`, que mostra **5 cards** (`novos_positivados` / `a_positivar` / `recência crítica` / `ticket médio` / `cobertura`). O Codex apontou que **4 dos 5 vazam de farmer/retenção**:
+- **Recência crítica** = risco de churn → **retenção** (trabalho de farmer). REMOVER do hunter.
+- **Clientes a positivar** = pool da carteira que não comprou no mês → pode incluir **clientes antigos** → farmer. REMOVER.
+- **Cobertura de contato** = % da carteira elegível contatada → não é sobre **alvos de caça**. REMOVER.
+- **Ticket médio MTD** = mistura compradores novos e antigos → não é KPI de aquisição. REMOVER.
+
+Só **"Novos positivados"** sobrevive — e mesmo assim como **proxy**, não como métrica comissionável (ver risco de atribuição). Adicionamos **"Participação de novos"** (derivável hoje, diagnóstico) e mantemos **"Receita da carteira"** (output, com label honesto de que é a carteira toda, não só os novos).
+
+### Risco de atribuição (o furo crítico — registrado, tratado honestamente)
+`novos_clientes_positivados` vem de `get_minha_positivacao()`, escopado por `carteira_assignments.owner_user_id = auth.uid()`. Logo, **só credita o hunter se o cliente conquistado permanecer atribuído a ele**. Se o handoff ao farmer reatribuir a carteira, o número **desaparece retroativamente** do hunter. Por isso:
+- exibido como **proxy** (label "1ª compra neste mês"), com **tooltip honesto** explicando que conta clientes **atualmente atribuídos** a ele;
+- **nunca** rotulado como "pronto pra OTE";
+- v2 (abaixo) resolve com `acquired_by_user_id` imutável.
+
+### Anti-gaming
+- "Novos" em **contagem** incentiva caçar muitos clientes pequenos (pedido de R$1 conta). Mitigação real (**piso de pedido qualificado**) depende de dado que não temos ainda → **v2**. Por ora, o placar **não é comissionável** (o disclaimer evita o incentivo perverso prematuro).
+- "Participação de novos" é **diagnóstico**, explicitamente não-comissionável (sobe quando antigos caem).
+- Fila de caça **não** é KPI (é estoque do sistema) → não premiar.
+
+## Mudanças (100% frontend, sem migration/edge)
+
+### 1. `src/lib/positivacao/format.ts`
+Adicionar `pctNovos` (alias semântico de `pct`, igual a `pctPositivacao`/`pctCobertura`) — `% de novos entre compradores`, 0 quando den ≤ 0. **TDD** (helper puro).
+
+### 2. `src/components/farmer/PositivacaoHero.tsx` — corrigir o ramo `isHunter`
+Trocar os 5 cards atuais pelo conjunto honesto (3 cards), **só no ramo `isHunter`** (o ramo farmer `isHunter={false}` fica **intacto**):
+- ⭐ **Novos na carteira (MTD)** = `novosPositivados` · sub "1ª compra neste mês" · **tooltip** de atribuição (proxy).
+- **Receita da carteira (MTD)** = `receitaMtd` · sub "faturamento total da sua carteira no mês".
+- **Participação de novos** = `pctNovos(novosPositivados, positivados)`% · sub "dos seus compradores do mês".
+
+Adicionar prop opcional `info?: string` ao `KpiCard` interno → ícone `Info` + `Tooltip` (TooltipProvider já é global no `App.tsx`). Telemetria `carteira.positivacao_vista` (com `is_hunter`) **mantida**.
+
+### 3. `src/components/dashboard/HunterDashboard.tsx`
+- **Trazer** `useMyPositivacao` + `PositivacaoHero isHunter={true}` pro **topo** (após o header) — o placar de aquisição que faltava.
+- **REMOVER** `VisitasHojeCard` (vaza closer).
+- **Manter** `MinhasTarefasCard`, `ChamadasPendentesNudge` e `CacaConteudo` (a fila de caça = a ação do dia, o protagonista).
+
+O `PositivacaoHero isHunter` é compartilhado com `FarmerCalls` (quando role=hunter) → a correção do hero melhora os dois (consistência desejada, espelha o #690).
+
+## Não-objetivos (v1)
+- OTE/remuneração variável (sessão dedicada do founder).
+- Re-arquitetar o `FarmerCalls` inteiro: ele ainda renderiza `ClientesAPositivarCard` + `MixGapCard` (cards de farmer) abaixo do hero mesmo pro hunter. **Follow-up** (fora do escopo "dashboards"); o hero em si já fica honesto.
+- Closer/Master (próximos PRs da frente).
+- Qualquer migration/edge.
+
+## Gaps v2 (registrados — o "nível mundial" de verdade do hunter precisa destes dados)
+1. **`acquired_by_user_id` imutável** na 1ª compra (atribuição de aquisição que sobrevive ao handoff → destrava o KPI-norte comissionável de verdade).
+2. **Log de caça com outcome** (análogo ao `route_contact_log`/Radar): alvo trabalhado, 1ª tentativa, 1º contato, status `novo→contatado→qualificado→descartado→convertido`.
+3. **Funil de conversão**: taxa contato→qualificação→1ª compra.
+4. **Velocidade**: tempo até 1º contato e até 1ª compra.
+5. **Qualidade da aquisição**: receita/margem **dos novos** (separada da carteira); 2ª compra / retenção 60–90d.
+6. **Piso de pedido qualificado** (anti-gaming): 1ª compra abaixo de X não conta como "novo cliente".
+
+## Verificação
+- `pctNovos` tem teste (div-zero, arredondamento, casos).
+- `PositivacaoHero isHunter` renderiza 3 cards honestos (sem recência/a-positivar/cobertura/ticket); ramo farmer inalterado.
+- `HunterDashboard` renderiza o hero no topo, **não** renderiza `VisitasHojeCard`, mantém `CacaConteudo`.
+- Lente "Ver como": positivação já é lente-aware (`useMyPositivacao` via `effectiveUserId`).
+- `bun run typecheck` + `bun lint` + `bun run test`.

--- a/src/components/dashboard/HunterDashboard.tsx
+++ b/src/components/dashboard/HunterDashboard.tsx
@@ -1,33 +1,42 @@
 import { MinhasTarefasCard } from '@/components/tarefas/MinhasTarefasCard';
-import { VisitasHojeCard } from './VisitasHojeCard';
 import { CacaConteudo } from '@/components/caca/CacaConteudo';
 import { ChamadasPendentesNudge } from '@/components/farmer/ChamadasPendentesNudge';
+import { PositivacaoHero } from '@/components/farmer/PositivacaoHero';
+import { useMyPositivacao } from '@/hooks/useMyPositivacao';
 
 /**
- * Dashboard Hunter (inbound) — Meu Dia do hunter.
+ * Dashboard Hunter (aquisição) — Meu Dia do hunter.
  *
- * Lidera com tarefas + visitas do dia e a FILA DE CAÇA (clientes parecidos com
- * os melhores que ainda não compram). A caça vive aqui pro hunter trabalhar a
- * fila sem trocar de tela; a página dedicada `/caca` mostra a mesma fila.
+ * Lidera com o PLACAR DE AQUISIÇÃO (PositivacaoHero isHunter) — enxuto e honesto:
+ * "Novos na carteira MTD" (proxy de aquisição), "Receita da carteira MTD" e
+ * "Participação de novos". Os KPIs de retenção/penetração (recência, a-positivar,
+ * cobertura) NÃO entram — são da farmer. A FILA DE CAÇA é a ação do dia (alvos
+ * look-alike que ainda não compram); a página /caca mostra a mesma fila.
+ *
+ * VISITAS foram removidas (era VisitasHojeCard): visita é trabalho do CLOSER.
+ * Ver docs/superpowers/specs/2026-06-13-kpis-hunter-meu-dia-design.md.
  */
 export function HunterDashboard() {
+  const { data: positivacao } = useMyPositivacao();
+
   return (
     <div className="container mx-auto p-4 space-y-4 max-w-5xl">
       <div>
-        <h1 className="text-xl font-semibold">Dashboard Hunter (inbound)</h1>
+        <h1 className="text-xl font-semibold">Meu dia (aquisição)</h1>
         <p className="text-xs text-muted-foreground">
-          Foco em chamadas que chegam de clientes novos e qualificação rápida pra entregar pro Closer ou fechar direto.
+          Seu placar de aquisição e a fila de caça: clientes parecidos com os melhores que ainda não compram.
         </p>
       </div>
+
+      {/* Placar de aquisição — o norte do hunter (proxy honesto, não-OTE ainda) */}
+      {positivacao && <PositivacaoHero kpis={positivacao} isHunter={true} />}
 
       <MinhasTarefasCard />
 
       {/* nudge condicional: ligações registradas sem cliente vinculado (era item do menu Vendas) */}
       <ChamadasPendentesNudge />
 
-      <VisitasHojeCard />
-
-      {/* Fila de caça — look-alike dos melhores que ainda não compram (Frente B) */}
+      {/* Fila de caça — look-alike dos melhores que ainda não compram (Frente B) — a ação do dia */}
       <CacaConteudo />
     </div>
   );

--- a/src/components/farmer/PositivacaoHero.tsx
+++ b/src/components/farmer/PositivacaoHero.tsx
@@ -1,12 +1,27 @@
 import { useEffect, useRef } from 'react';
+import { Info } from 'lucide-react';
 import { Card } from '@/components/ui/card';
+import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip';
 import { track } from '@/lib/analytics';
+import { pctNovos } from '@/lib/positivacao/format';
 import type { PositivacaoKpis } from '@/hooks/useMyPositivacao';
 
-function KpiCard({ label, value, sub }: { label: string; value: string; sub?: string }) {
+function KpiCard({ label, value, sub, info }: { label: string; value: string; sub?: string; info?: string }) {
   return (
     <Card className="p-4">
-      <div className="text-2xs text-muted-foreground">{label}</div>
+      <div className="text-2xs text-muted-foreground flex items-center gap-1">
+        {label}
+        {info && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button type="button" className="inline-flex" aria-label="Mais informação sobre este indicador">
+                <Info className="w-3 h-3 text-muted-foreground/70" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent className="max-w-xs text-2xs">{info}</TooltipContent>
+          </Tooltip>
+        )}
+      </div>
       <div className="kpi-value text-2xl">{value}</div>
       {sub && <div className="text-2xs text-muted-foreground mt-0.5">{sub}</div>}
     </Card>
@@ -29,38 +44,45 @@ export function PositivacaoHero({ kpis, isHunter }: { kpis: PositivacaoKpis; isH
 
   const ticket = `R$ ${kpis.ticketMedio.toLocaleString('pt-BR', { maximumFractionDigits: 0 })}`;
   const receita = `R$ ${kpis.receitaMtd.toLocaleString('pt-BR', { maximumFractionDigits: 0 })}`;
+
+  // ── HUNTER (aquisição) ──────────────────────────────────────────────────────
+  // Placar ENXUTO e honesto: só o que é de aquisição. Os cards de retenção
+  // (recência), penetração (a-positivar/cobertura) e ticket misturado VAZAM de
+  // farmer → não entram aqui (decisão Codex). A fila de caça é a ação do dia
+  // (CacaConteudo no HunterDashboard), não um KPI. Ver
+  // docs/superpowers/specs/2026-06-13-kpis-hunter-meu-dia-design.md.
+  if (isHunter) {
+    const partNovos = `${pctNovos(kpis.novosPositivados, kpis.positivados)}%`;
+    return (
+      <div className="grid grid-cols-2 lg:grid-cols-3 gap-3">
+        <KpiCard
+          label="Novos na carteira (MTD)"
+          value={String(kpis.novosPositivados)}
+          sub="1ª compra neste mês"
+          info="Proxy de aquisição: clientes ATUALMENTE atribuídos a você cuja 1ª compra (de toda a história) caiu neste mês. Pode mudar se a carteira for reatribuída — ainda não é base de comissão."
+        />
+        <KpiCard label="Receita da carteira (MTD)" value={receita} sub="faturamento total da sua carteira no mês" />
+        <KpiCard label="Participação de novos" value={partNovos} sub="dos seus compradores do mês" />
+      </div>
+    );
+  }
+
+  // ── FARMER (retenção · penetração · expansão) ────────────────────────────────
   return (
     <div className="space-y-3">
-      {/* Hero (3 KPIs principais por papel) */}
+      {/* Hero (3 KPIs principais) */}
       <div className="grid grid-cols-2 lg:grid-cols-3 gap-3">
-        {isHunter ? (
-          <>
-            <KpiCard label="Novos clientes positivados" value={String(kpis.novosPositivados)} sub="1ª compra no mês" />
-            <KpiCard label="Clientes a positivar" value={String(kpis.aPositivar.length)} sub="pool sem pedido no mês" />
-            <KpiCard label="Recência crítica" value={String(kpis.recenciaCritica)} sub="risco alto / atrasados" />
-          </>
-        ) : (
-          <>
-            <KpiCard label="Positivação MTD" value={`${kpis.pctPositivacao}%`} sub={`${kpis.positivados}/${kpis.totalEligible} da carteira`} />
-            <KpiCard label="Receita MTD" value={receita} sub="faturamento da carteira no mês" />
-            <KpiCard label="Clientes a positivar" value={String(kpis.aPositivar.length)} sub="sem pedido no mês" />
-          </>
-        )}
+        <KpiCard label="Positivação MTD" value={`${kpis.pctPositivacao}%`} sub={`${kpis.positivados}/${kpis.totalEligible} da carteira`} />
+        <KpiCard label="Receita MTD" value={receita} sub="faturamento da carteira no mês" />
+        <KpiCard label="Clientes a positivar" value={String(kpis.aPositivar.length)} sub="sem pedido no mês" />
       </div>
       {/* Linha secundária (KPIs de apoio) */}
-      {isHunter ? (
-        <div className="grid grid-cols-2 gap-3">
-          <KpiCard label="Ticket médio MTD" value={ticket} sub="receita ÷ compradores no mês" />
-          <KpiCard label="Cobertura de contato" value={`${kpis.pctCobertura}%`} sub="contatados no mês" />
-        </div>
-      ) : (
-        <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
-          <KpiCard label="Cobertura de contato" value={`${kpis.pctCobertura}%`} sub="contatados no mês" />
-          <KpiCard label="Recuperados (win-back)" value={String(kpis.novosPositivados)} sub="voltaram a comprar no mês" />
-          <KpiCard label="Recência crítica" value={String(kpis.recenciaCritica)} sub="risco alto / atrasados" />
-          <KpiCard label="Ticket médio MTD" value={ticket} sub="receita ÷ compradores no mês" />
-        </div>
-      )}
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
+        <KpiCard label="Cobertura de contato" value={`${kpis.pctCobertura}%`} sub="contatados no mês" />
+        <KpiCard label="Recuperados (win-back)" value={String(kpis.novosPositivados)} sub="voltaram a comprar no mês" />
+        <KpiCard label="Recência crítica" value={String(kpis.recenciaCritica)} sub="risco alto / atrasados" />
+        <KpiCard label="Ticket médio MTD" value={ticket} sub="receita ÷ compradores no mês" />
+      </div>
     </div>
   );
 }

--- a/src/lib/positivacao/__tests__/format.test.ts
+++ b/src/lib/positivacao/__tests__/format.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { pctPositivacao, ticketMedio, pctCobertura } from '../format';
+import { pctPositivacao, ticketMedio, pctCobertura, pctNovos } from '../format';
 
 describe('format positivação (null/zero-safe)', () => {
   it('pctPositivacao = positivados/elegiveis*100, arredondado a 1 casa', () => {
@@ -16,5 +16,12 @@ describe('format positivação (null/zero-safe)', () => {
   it('pctCobertura idem pctPositivacao', () => {
     expect(pctCobertura(800, 1890)).toBe(42.3);
     expect(pctCobertura(0, 0)).toBe(0);
+  });
+
+  it('pctNovos = novos/compradores*100; sem comprador → 0 (não NaN)', () => {
+    expect(pctNovos(3, 12)).toBe(25);
+    expect(pctNovos(2, 7)).toBe(28.6); // arredonda a 1 casa
+    expect(pctNovos(0, 0)).toBe(0); // hunter sem carteira ativa → 0, não NaN
+    expect(pctNovos(5, 0)).toBe(0); // den 0 protegido
   });
 });

--- a/src/lib/positivacao/format.ts
+++ b/src/lib/positivacao/format.ts
@@ -6,6 +6,8 @@ function pct(num: number, den: number): number {
 
 export const pctPositivacao = pct;
 export const pctCobertura = pct;
+/** % de clientes novos entre os compradores do mês (diagnóstico do hunter). */
+export const pctNovos = pct;
 
 /** Ticket médio = receita / compradores; 0 quando não há comprador. */
 export function ticketMedio(receita: number, compradores: number): number {


### PR DESCRIPTION
## O quê
Redefine os KPIs de nível mundial do **HUNTER** (aquisição/new business) no `/meu-dia` — 2ª persona da frente "começar pela farmer e expandir" (farmer = #690). 100% frontend.

## Problema
O `HunterDashboard` **não tinha placar nenhum** e vazava o `VisitasHojeCard` (visita é trabalho do closer). O ramo `isHunter` do `PositivacaoHero` mostrava 5 cards, **4 deles de farmer/retenção** (recência, a-positivar, cobertura, ticket).

## Decisão (2ª opinião do Codex — gpt-5.5)
O app hoje quase não instrumenta aquisição por-hunter → placar **enxuto e honesto**:
- ⭐ **Novos na carteira (MTD)** — proxy de aquisição (`novos_clientes_positivados`), com **tooltip de atribuição** explicando que é proxy e **não** base de comissão (o crédito depende de o cliente seguir atribuído ao hunter; v2 = `acquired_by_user_id` imutável).
- **Receita da carteira (MTD)** — output, label honesto (carteira toda, não só novos).
- **Participação de novos** = `novos/compradores` — diagnóstico (não-comissionável).

A **fila de caça** (`CacaConteudo`) segue como a ação do dia (não é KPI — é estoque de oportunidade do sistema). O "nível mundial" de verdade (funil contato→qualificação→1ª compra, velocidade, receita-dos-novos, piso anti-gaming) fica **registrado como gap v2** no spec.

## Mudanças
- `src/lib/positivacao/format.ts` + teste: `pctNovos` (helper puro, div-zero-safe).
- `src/components/farmer/PositivacaoHero.tsx`: corrige o ramo `isHunter` (3 cards honestos + tooltip); ramo farmer **intacto**. Beneficia também o `FarmerCalls` (consistência).
- `src/components/dashboard/HunterDashboard.tsx`: hero no topo + remove `VisitasHojeCard`.

## Verificação
- `bun run typecheck` ✅ · `bun lint` 0 erros ✅ · `bun run test` 3264/3264 ✅
- Lente "Ver como": positivação já é lente-aware (`useMyPositivacao` via `effectiveUserId`).

## Follow-up (fora do escopo "dashboards")
`FarmerCalls` ainda renderiza `ClientesAPositivarCard`+`MixGapCard` (cards de farmer) abaixo do hero mesmo pro hunter.

Spec: `docs/superpowers/specs/2026-06-13-kpis-hunter-meu-dia-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)