### PR TITLE
feat(lente): engines de IA da carteira lente-aware (parte 1) — anti-vazamento no "Ver como"

### DIFF
--- a/src/components/farmer/locc/ExperimentCard.tsx
+++ b/src/components/farmer/locc/ExperimentCard.tsx
@@ -7,11 +7,12 @@ import { BarChart3, CheckCircle, Play, XCircle } from 'lucide-react';
 import { type Experiment } from '@/hooks/useFarmerExperiments';
 import { metricLabels, statusColors } from './helpers';
 
-export const ExperimentCard = ({ experiment, onStart, onMeasure, onCancel }: {
+export const ExperimentCard = ({ experiment, onStart, onMeasure, onCancel, disabled }: {
   experiment: Experiment;
   onStart: (id: string) => void;
   onMeasure: (id: string) => void;
   onCancel: (id: string) => void;
+  disabled?: boolean;
 }) => {
   const sc = statusColors[experiment.status] || statusColors.rascunho;
 
@@ -88,16 +89,16 @@ export const ExperimentCard = ({ experiment, onStart, onMeasure, onCancel }: {
         {/* Actions */}
         <div className="flex gap-1">
           {experiment.status === 'rascunho' && (
-            <Button size="sm" className="flex-1 h-7 text-[10px]" onClick={() => onStart(experiment.id)}>
+            <Button size="sm" className="flex-1 h-7 text-[10px]" onClick={() => onStart(experiment.id)} disabled={disabled} title={disabled ? 'Indisponível em modo Ver como' : undefined}>
               <Play className="w-3 h-3 mr-1" /> Iniciar
             </Button>
           )}
           {experiment.status === 'ativo' && (
             <>
-              <Button size="sm" variant="outline" className="flex-1 h-7 text-[10px]" onClick={() => onMeasure(experiment.id)}>
+              <Button size="sm" variant="outline" className="flex-1 h-7 text-[10px]" onClick={() => onMeasure(experiment.id)} disabled={disabled} title={disabled ? 'Indisponível em modo Ver como' : undefined}>
                 <BarChart3 className="w-3 h-3 mr-1" /> Medir
               </Button>
-              <Button size="sm" variant="ghost" className="h-7 text-[10px] px-2" onClick={() => onCancel(experiment.id)}>
+              <Button size="sm" variant="ghost" className="h-7 text-[10px] px-2" onClick={() => onCancel(experiment.id)} disabled={disabled} title={disabled ? 'Indisponível em modo Ver como' : undefined}>
                 <XCircle className="w-3 h-3" />
               </Button>
             </>

--- a/src/components/farmer/locc/ExperimentsTab.tsx
+++ b/src/components/farmer/locc/ExperimentsTab.tsx
@@ -4,12 +4,16 @@ import { memo } from 'react';
 import { Card, CardContent } from '@/components/ui/card';
 import { FlaskConical } from 'lucide-react';
 import { useFarmerExperiments } from '@/hooks/useFarmerExperiments';
+import { useImpersonation } from '@/contexts/ImpersonationContext';
 import { TabSkeleton } from './primitives';
 import { ExperimentCard } from './ExperimentCard';
 import { NewExperimentDialog } from './NewExperimentDialog';
 
 export const ExperimentsTab = memo(() => {
   const { experiments, loading, createExperiment, startExperiment, measureExperiment, cancelExperiment } = useFarmerExperiments();
+  // Lente "Ver como": criar/iniciar/medir/cancelar são writes — desabilitados (o
+  // write-guard já bloqueia; o disable evita o erro/ruído). A lista é só leitura do alvo.
+  const { isImpersonating } = useImpersonation();
 
   if (loading) {
     return <TabSkeleton />;
@@ -19,7 +23,7 @@ export const ExperimentsTab = memo(() => {
     <>
       <div className="flex items-center justify-between">
         <span className="text-sm font-semibold">Motor Experimental</span>
-        <NewExperimentDialog onCreate={createExperiment} />
+        <NewExperimentDialog onCreate={createExperiment} disabled={isImpersonating} />
       </div>
 
       {experiments.length === 0 ? (
@@ -37,6 +41,7 @@ export const ExperimentsTab = memo(() => {
             onStart={startExperiment}
             onMeasure={measureExperiment}
             onCancel={cancelExperiment}
+            disabled={isImpersonating}
           />
         ))
       )}

--- a/src/components/farmer/locc/NewExperimentDialog.tsx
+++ b/src/components/farmer/locc/NewExperimentDialog.tsx
@@ -9,7 +9,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from 
 import { Plus } from 'lucide-react';
 import { type NewExperimentInput } from './types';
 
-export const NewExperimentDialog = ({ onCreate }: { onCreate: (input: NewExperimentInput) => void }) => {
+export const NewExperimentDialog = ({ onCreate, disabled }: { onCreate: (input: NewExperimentInput) => void; disabled?: boolean }) => {
   const [open, setOpen] = useState(false);
   const [form, setForm] = useState({
     title: '',
@@ -36,7 +36,7 @@ export const NewExperimentDialog = ({ onCreate }: { onCreate: (input: NewExperim
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
-        <Button size="sm" className="h-7 text-[10px]">
+        <Button size="sm" className="h-7 text-[10px]" disabled={disabled} title={disabled ? 'Indisponível em modo Ver como' : undefined}>
           <Plus className="w-3 h-3 mr-1" /> Novo
         </Button>
       </DialogTrigger>

--- a/src/hooks/__tests__/lens-engines-ia.test.tsx
+++ b/src/hooks/__tests__/lens-engines-ia.test.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+
+/**
+ * Guard de regressão da lente "Ver como pessoa" nas ENGINES DE IA da carteira
+ * (recomendações cross-sell, experimentos A/B, perguntas diagnósticas). As leituras
+ * que EXIBEM o que já existe devem filtrar pelo id EFETIVO: o ALVO na lente, o próprio
+ * usuário fora dela. Captura todo `.eq(col, valor)` do stub do supabase e verifica que
+ * o id filtrado segue a lente. A persistência das engines (upsert de recomendações)
+ * NÃO roda na lente — o master inspeciona a carteira do alvo, não a recalcula.
+ */
+const eqCalls: Array<[string, unknown]> = [];
+
+function stubChain(): unknown {
+  const chain: Record<string, unknown> = {};
+  const passthrough = [
+    'select', 'gte', 'lt', 'lte', 'gt', 'is', 'not', 'in', 'order',
+    'limit', 'range', 'or', 'neq', 'filter', 'single', 'maybeSingle', 'contains',
+    'upsert', 'insert', 'update', 'delete',
+  ];
+  for (const m of passthrough) chain[m] = () => chain;
+  chain.eq = (col: string, val: unknown) => { eqCalls.push([col, val]); return chain; };
+  // thenable: qualquer `await chain` resolve vazio (a lógica vive em helpers puros já testados)
+  chain.then = (resolve: (v: unknown) => void) => resolve({ data: [], error: null, count: 0 });
+  return chain;
+}
+
+vi.mock('@/integrations/supabase/client', () => ({ supabase: { from: () => stubChain() } }));
+
+const impMock = vi.fn();
+vi.mock('@/contexts/ImpersonationContext', () => ({ useImpersonation: () => impMock() }));
+vi.mock('@/contexts/AuthContext', () => ({ useAuth: () => ({ user: { id: 'master-id' }, isStaff: true }) }));
+
+import { useFarmerExperiments } from '../useFarmerExperiments';
+import { useCrossSellEngine } from '../useCrossSellEngine';
+import { useDiagnosticQuestions } from '../useDiagnosticQuestions';
+
+beforeEach(() => {
+  eqCalls.length = 0;
+});
+
+describe('useFarmerExperiments — lente "Ver como"', () => {
+  it('na lente: loadExperiments filtra pelo ALVO, nunca o master', async () => {
+    impMock.mockReturnValue({ isImpersonating: true, effectiveUserId: 'alvo-id' });
+    renderHook(() => useFarmerExperiments());
+    await waitFor(() => expect(eqCalls.length).toBeGreaterThan(0));
+    const valores = eqCalls.map((c) => c[1]);
+    expect(valores).toContain('alvo-id');
+    expect(valores).not.toContain('master-id');
+  });
+
+  it('fora da lente: filtra pelo próprio usuário', async () => {
+    impMock.mockReturnValue({ isImpersonating: false, effectiveUserId: 'master-id' });
+    renderHook(() => useFarmerExperiments());
+    await waitFor(() => expect(eqCalls.length).toBeGreaterThan(0));
+    expect(eqCalls.map((c) => c[1])).toContain('master-id');
+  });
+});
+
+describe('useCrossSellEngine — lente "Ver como"', () => {
+  it('na lente: lê os scores do ALVO e não cai no fallback super-admin (todos)', async () => {
+    impMock.mockReturnValue({ isImpersonating: true, effectiveUserId: 'alvo-id' });
+    const { result } = renderHook(() => useCrossSellEngine());
+    await act(async () => { await result.current.calculateRecommendations(); });
+    const farmerEq = eqCalls.filter((c) => c[0] === 'farmer_id').map((c) => c[1]);
+    expect(farmerEq).toContain('alvo-id');
+    expect(farmerEq).not.toContain('master-id');
+  });
+
+  it('fora da lente: lê os scores do próprio usuário', async () => {
+    impMock.mockReturnValue({ isImpersonating: false, effectiveUserId: 'master-id' });
+    const { result } = renderHook(() => useCrossSellEngine());
+    await act(async () => { await result.current.calculateRecommendations(); });
+    expect(eqCalls.filter((c) => c[0] === 'farmer_id').map((c) => c[1])).toContain('master-id');
+  });
+});
+
+describe('useDiagnosticQuestions — lente "Ver como"', () => {
+  it('na lente: getEffectivenessStats filtra pelo ALVO, nunca o master', async () => {
+    impMock.mockReturnValue({ isImpersonating: true, effectiveUserId: 'alvo-id' });
+    const { result } = renderHook(() => useDiagnosticQuestions());
+    await act(async () => { await result.current.getEffectivenessStats(); });
+    const valores = eqCalls.map((c) => c[1]);
+    expect(valores).toContain('alvo-id');
+    expect(valores).not.toContain('master-id');
+  });
+
+  it('fora da lente: filtra pelo próprio usuário', async () => {
+    impMock.mockReturnValue({ isImpersonating: false, effectiveUserId: 'master-id' });
+    const { result } = renderHook(() => useDiagnosticQuestions());
+    await act(async () => { await result.current.getEffectivenessStats(); });
+    expect(eqCalls.map((c) => c[1])).toContain('master-id');
+  });
+});

--- a/src/hooks/useCrossSellEngine.ts
+++ b/src/hooks/useCrossSellEngine.ts
@@ -1,6 +1,6 @@
 import { useState, useCallback } from 'react';
 import { supabase } from '@/integrations/supabase/client';
-import { useAuth } from '@/contexts/AuthContext';
+import { useImpersonation } from '@/contexts/ImpersonationContext';
 
 // ─── Types ───────────────────────────────────────────────────────────
 export interface Recommendation {
@@ -107,13 +107,17 @@ const clamp = (v: number, lo: number, hi: number) => Math.max(lo, Math.min(hi, v
 
 // ─── Main Hook ───────────────────────────────────────────────────────
 export const useCrossSellEngine = () => {
-  const { user } = useAuth();
+  // Lente "Ver como": id efetivo = ALVO na lente (lê/recalcula as recomendações DELE
+  // pra inspeção), próprio usuário fora. Na lente a persistência é PULADA (igual
+  // useFarmerScoring): o master inspeciona, não regrava a carteira do alvo. Fora da
+  // lente effectiveUserId === user.id (byte-equivalente, zero regressão).
+  const { effectiveUserId, isImpersonating } = useImpersonation();
   const [recommendations, setRecommendations] = useState<CustomerRecommendations[]>([]);
   const [loading, setLoading] = useState(false);
   const [calculating, setCalculating] = useState(false);
 
   const calculateRecommendations = useCallback(async () => {
-    if (!user?.id) return;
+    if (!effectiveUserId) return;
     setCalculating(true);
     setLoading(true);
 
@@ -134,9 +138,11 @@ export const useCrossSellEngine = () => {
         return all;
       };
 
-      // Try farmer-specific first, fallback to all (for super_admin)
-      let clientScores = await fetchAllScores(user.id);
-      if (!clientScores.length) {
+      // Try farmer-specific first, fallback to all (for super_admin). Na lente NÃO cai
+      // no fallback de "todos os scores" — escopa estritamente ao alvo (degradação
+      // honesta: alvo sem score → lista vazia, nunca a carteira de todo mundo).
+      let clientScores = await fetchAllScores(effectiveUserId);
+      if (!clientScores.length && !isImpersonating) {
         clientScores = await fetchAllScores();
       }
 
@@ -451,7 +457,7 @@ export const useCrossSellEngine = () => {
       // Persist recommendations (batch upsert único — antes era N×M serial)
       const recRows = allRecs.flatMap((cr) =>
         [...cr.crossSell, ...cr.upSell].map((rec) => ({
-          farmer_id: user.id,
+          farmer_id: effectiveUserId,
           customer_user_id: rec.customerId,
           recommendation_type: rec.type,
           product_id: rec.productId,
@@ -465,7 +471,9 @@ export const useCrossSellEngine = () => {
           updated_at: new Date().toISOString(),
         })),
       );
-      if (recRows.length > 0) {
+      // Persistência PULADA na lente "Ver como" (somente leitura: o master inspeciona
+      // as recomendações do alvo sem regravar a carteira dele).
+      if (!isImpersonating && recRows.length > 0) {
         await supabase.from('farmer_recommendations').upsert(recRows);
       }
     } catch (error) {
@@ -474,7 +482,7 @@ export const useCrossSellEngine = () => {
       setCalculating(false);
       setLoading(false);
     }
-  }, [user?.id]);
+  }, [effectiveUserId, isImpersonating]);
 
   // ─── Actions ─────────────────────────────────────────────────────────
   const markAsOffered = useCallback(async (recId: string) => {

--- a/src/hooks/useDiagnosticQuestions.ts
+++ b/src/hooks/useDiagnosticQuestions.ts
@@ -1,6 +1,7 @@
 import { useState, useCallback } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
+import { useImpersonation } from '@/contexts/ImpersonationContext';
 import { toast } from 'sonner';
 import type { CustomerProfile } from '@/hooks/useBundleArguments';
 
@@ -31,6 +32,10 @@ export { typeLabels };
 
 export const useDiagnosticQuestions = () => {
   const { user } = useAuth();
+  // Lente "Ver como": as estatísticas de efetividade exibidas seguem o id efetivo (o
+  // ALVO na lente, o próprio usuário fora). A geração (edge) e o save (insert
+  // farmer_id=user.id) são bloqueados na lente pelo write-guard + botões disabled.
+  const { effectiveUserId } = useImpersonation();
   const [questions, setQuestions] = useState<Record<string, QuestionWithResponse[]>>({});
   const [generating, setGenerating] = useState<Record<string, boolean>>({});
 
@@ -142,12 +147,12 @@ export const useDiagnosticQuestions = () => {
   }, [user?.id, questions]);
 
   const getEffectivenessStats = useCallback(async () => {
-    if (!user?.id) return null;
+    if (!effectiveUserId) return null;
 
     const { data } = await supabase
       .from('farmer_diagnostic_questions')
       .select('question_type, response_type, was_bundle_offered, bundle_result, margin_generated')
-      .eq('farmer_id', user.id);
+      .eq('farmer_id', effectiveUserId);
 
     const rows = (data ?? []) as unknown as Array<{
       question_type: string;
@@ -171,7 +176,7 @@ export const useDiagnosticQuestions = () => {
     }
 
     return stats;
-  }, [user?.id]);
+  }, [effectiveUserId]);
 
   return {
     questions,

--- a/src/hooks/useFarmerExperiments.ts
+++ b/src/hooks/useFarmerExperiments.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
+import { useImpersonation } from '@/contexts/ImpersonationContext';
 import { toast } from 'sonner';
 
 export interface Experiment {
@@ -98,17 +99,22 @@ interface FarmerCallLite {
 
 export const useFarmerExperiments = () => {
   const { user } = useAuth();
+  // Lente "Ver como": a LISTA de experimentos exibida segue o id efetivo (o ALVO na
+  // lente, o próprio usuário fora). As mutações (criar/iniciar/medir/cancelar) usam
+  // user.id (write identity = master real) e são bloqueadas na lente pelo write-guard
+  // + botões disabled. Fora da lente effectiveUserId === user.id (byte-equivalente).
+  const { effectiveUserId } = useImpersonation();
   const [experiments, setExperiments] = useState<Experiment[]>([]);
   const [loading, setLoading] = useState(true);
 
   const loadExperiments = useCallback(async () => {
-    if (!user?.id) return;
+    if (!effectiveUserId) return;
     setLoading(true);
     try {
       const { data } = (await supabase
         .from('farmer_experiments')
         .select('*')
-        .eq('farmer_id', user.id)
+        .eq('farmer_id', effectiveUserId)
         .order('created_at', { ascending: false })) as unknown as { data: ExperimentRow[] | null };
 
       if (data) {
@@ -141,7 +147,7 @@ export const useFarmerExperiments = () => {
     } finally {
       setLoading(false);
     }
-  }, [user?.id]);
+  }, [effectiveUserId]);
 
   useEffect(() => { loadExperiments(); }, [loadExperiments]);
 

--- a/src/lib/impersonation/__tests__/no-write-leak.test.ts
+++ b/src/lib/impersonation/__tests__/no-write-leak.test.ts
@@ -50,6 +50,23 @@ const ALLOWED = new Set([
   // useFarmerScoring: effectiveUserId na leitura/cálculo da agenda do alvo; o upsert de scores
   // é PULADO na lente (skip por isImpersonating) — o master não recalcula a carteira do alvo.
   'src/hooks/useFarmerScoring.ts',
+  // useCrossSellEngine: effectiveUserId escopa a LEITURA/recálculo das recomendações ao
+  // alvo na lente (lê os scores DELE pra inspeção) e NÃO cai no fallback super-admin
+  // ("todos os scores"). A PERSISTÊNCIA (upsert de farmer_recommendations) é PULADA na
+  // lente — o master inspeciona, não regrava a carteira do alvo (igual useFarmerScoring).
+  'src/hooks/useCrossSellEngine.ts',
+  // useFarmerExperiments: effectiveUserId SÓ em loadExperiments (filtra a LISTA exibida
+  // pro alvo na lente). As mutations (criar/iniciar/medir/cancelar) usam user.id (write
+  // identity = master real) e são bloqueadas na lente pelo write-guard + botões disabled.
+  'src/hooks/useFarmerExperiments.ts',
+  // useDiagnosticQuestions: effectiveUserId SÓ em getEffectivenessStats (estatísticas
+  // exibidas seguem o alvo). A geração (edge) e o save (insert farmer_id=user.id) são
+  // bloqueados na lente pelo write-guard.
+  'src/hooks/useDiagnosticQuestions.ts',
+  // FarmerCallsPendingLink: effectiveUserId SÓ na LEITURA da lista de chamadas pendentes
+  // de vínculo (query react-query) pro "Ver como" mostrar as do alvo. O vínculo
+  // (useLinkCallToCustomer) é write — bloqueado na lente + botão "Vincular" disabled.
+  'src/pages/FarmerCallsPendingLink.tsx',
   // Clientes (/admin/customers): useClientesScope escopa a LEITURA da lista pro alvo da lente
   // (effectiveUserId só filtra carteira_assignments/scores — read-only, é o hook que importa
   // useDisplayAccess e NÃO tem mutação). useAdminCustomers recebe effectiveUserId do scope

--- a/src/pages/FarmerCallsPendingLink.tsx
+++ b/src/pages/FarmerCallsPendingLink.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
-import { useAuth } from '@/contexts/AuthContext';
+import { useImpersonation } from '@/contexts/ImpersonationContext';
 import { useLinkCallToCustomer } from '@/hooks/useLinkCallToCustomer';
 import { ilikeOr } from '@/lib/postgrest';
 import { Card } from '@/components/ui/card';
@@ -37,15 +37,18 @@ interface ProfileMatch {
 }
 
 export default function FarmerCallsPendingLink() {
-  const { user } = useAuth();
+  // Lente "Ver como": a lista de chamadas pendentes exibida segue o id efetivo (o ALVO
+  // na lente, o próprio usuário fora). O vínculo (mutation) é write — bloqueado na lente
+  // pelo write-guard + botão "Vincular cliente" disabled.
+  const { effectiveUserId, isImpersonating } = useImpersonation();
   const { data, refetch } = useQuery({
-    queryKey: ['farmer-pending-link', user?.id],
-    enabled: !!user,
+    queryKey: ['farmer-pending-link', effectiveUserId],
+    enabled: !!effectiveUserId,
     queryFn: async (): Promise<Pending[]> => {
-       
+
       const { data, error } = await supabase.from('farmer_calls')
         .select('id, phone_dialed, started_at, duration_seconds')
-        .eq('farmer_id', user!.id)
+        .eq('farmer_id', effectiveUserId!)
         .is('customer_user_id', null)
         .not('transcript', 'is', null)
         .order('started_at', { ascending: false })
@@ -70,7 +73,7 @@ export default function FarmerCallsPendingLink() {
       ) : (
         <div className="space-y-2">
           {data.map((p) => (
-            <PendingRow key={p.id} pending={p} onLinked={refetch} />
+            <PendingRow key={p.id} pending={p} onLinked={refetch} disabled={isImpersonating} />
           ))}
         </div>
       )}
@@ -81,9 +84,11 @@ export default function FarmerCallsPendingLink() {
 function PendingRow({
   pending,
   onLinked,
+  disabled,
 }: {
   pending: Pending;
   onLinked: () => void;
+  disabled?: boolean;
 }) {
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState('');
@@ -119,7 +124,12 @@ function PendingRow({
       </div>
       <Dialog open={open} onOpenChange={setOpen}>
         <DialogTrigger asChild>
-          <Button size="sm" variant="outline">
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={disabled}
+            title={disabled ? 'Indisponível em modo Ver como' : undefined}
+          >
             Vincular cliente
           </Button>
         </DialogTrigger>


### PR DESCRIPTION
## O quê

Continua a camada de exibição da lente **"Ver como pessoa"** (#653/#659/#671/#678): torna as **engines de IA da carteira** lente-aware. Quando o master impersona uma vendedora, as telas paravam de mostrar os **dados do master** vazando — agora as **leituras de exibição** seguem o id **EFETIVO** (o ALVO na lente, o próprio usuário fora).

> Fora da lente `effectiveUserId === user.id` e `!isImpersonating === true` → **byte-idêntico, zero regressão**. A mudança de comportamento só existe **na lente** (que é o objetivo).

## Padrão (validado em prod nos #671/#678)

- **Leitura de exibição** → `useAuth().user.id` → `effectiveUserId` (de `useImpersonation()`). Arquivo entra na allowlist do guardrail `no-write-leak`.
- **Ação de gerar/escrever** → `disabled={isImpersonating}` (o **write-guard** já bloqueia a mutação na lente; o disable evita o erro/ruído).
- **Engine compute+persiste** (cross-sell) → lê com `effectiveUserId` mas **PULA o upsert** na lente (igual `useFarmerScoring`: o master inspeciona, não recalcula/regrava a carteira do alvo) e **não cai no fallback super-admin** ("todos os scores").

## Arquivos

| Arquivo | Mudança |
|---|---|
| `useCrossSellEngine.ts` | read→ALVO, sem fallback super-admin na lente, **persistência pulada na lente** |
| `useFarmerExperiments.ts` | `loadExperiments`→ALVO; mutações em `user.id` + disabled |
| `useDiagnosticQuestions.ts` | `getEffectivenessStats`→ALVO |
| `FarmerCallsPendingLink.tsx` | lista pendente→ALVO; botão "Vincular" disabled |
| `ExperimentsTab/ExperimentCard/NewExperimentDialog` | `disabled={isImpersonating}` em criar/iniciar/medir/cancelar |
| `no-write-leak.test.ts` | +4 arquivos na allowlist (effectiveUserId só em leitura) |
| `lens-engines-ia.test.tsx` | **novo** — na lente o `.eq('farmer_id')` segue o ALVO; fora, o próprio usuário |

## Verificação

- ✅ `bun run typecheck` (strict) — 0 erros
- ✅ `bun lint` — 0 nos arquivos alterados
- ✅ `bun run test` — **453 arquivos de teste, 0 falhas** (inclui os 6 novos de `lens-engines-ia` + o guardrail `no-write-leak`)
- TDD: RED (3 testes "na lente" falhando por filtrar `master-id`) → GREEN.

## Fora de escopo (follow-up registrado)

O fluxo de **BUNDLES** (`useFarmerBundles`/`useBundleEngine`/`useBundleArguments`) está **fora destes 7 arquivos** e ainda exibe dados do master na lente. Por isso **não** desabilitei os botões de gerar argumento/pergunta no `BundleCardFull` (seria meia-medida numa página ainda vazada; o write-guard já bloqueia a escrita). Tornar o fluxo de bundles inteiro lente-aware é PR próprio.

100% frontend — **requer Publish no Lovable** pra ir ao ar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)