### PR TITLE
feat(kpis-closer): placar de visitas MTD no Meu Dia do closer

### DIFF
--- a/docs/superpowers/specs/2026-06-13-kpis-closer-meu-dia-design.md
+++ b/docs/superpowers/specs/2026-06-13-kpis-closer-meu-dia-design.md
@@ -1,0 +1,65 @@
+# KPIs de nível mundial do CLOSER — Meu Dia (design)
+
+**Data:** 2026-06-13
+**Autor:** Claude + **Codex (gpt-5.5, consult, web search — citou IFRS 15)** — 2ª opinião conforme CLAUDE.md §12.
+**Status:** aprovado pelo founder pra implementar (frente "expandir"; farmer #690, hunter #795).
+
+## Contexto / problema
+
+3ª persona da redefinição de KPIs por papel no `/meu-dia`. O **closer** = visita presencial / outbound / fechamento (≠ hunter inbound, ≠ farmer account-management por ligação).
+
+O `CloserDashboard` **já tem KPIs reais de visita** (`VisitasKpiTiles`: conversão/ticket 30d, helper puro `montarKpisVisita` validado com Codex) — mas eles estão **no FIM**, depois de um **card "Em construção — PR-VISIT-INTELLIGENCE"** (placeholder com lista de features futuras). O dashboard **não lidera com placar nenhum** e tem o trabalho dirigido (tarefas) + higiene (nudge de chamadas) no topo.
+
+## KPIs de nível mundial do closer (field sales / outbound)
+
+Framework: **atividade de visita → conversão → valor gerado → ação**. ⚠️ A 2ª opinião do Codex foi decisiva em **honestidade do dado** e **janela**.
+
+| KPI | Mede | Janela | Tipo | OTE | Dado |
+|---|---|---|---|---|---|
+| **Valor informado em pedidos fechados** ⭐ | Σ `revenue_generated` dos fechados no mês | **MTD** | output | **NÃO comissionável** (auto-reportado, não-ERP) | `montarKpisVisita.receitaTotal` ✅ |
+| **Fechamentos** | nº de visitas `result='pedido_fechado'` | **MTD** | output | secundário (isolado incentiva deal pequeno) | `.fechados` ✅ |
+| **Visitas registradas** | atividade do mês | **MTD** | leading | higiene | `.totalVisitas` ✅ |
+| **Conversão de visita** | fechados ÷ visitas com resultado | **30d rolling** | eficiência | — (gameável; ver nota) | `.taxaConversao` ✅ |
+| **Ticket médio de visita** | receita ÷ fechados com valor | **30d rolling** | eficiência | — | `.ticketMedio` ✅ |
+| **Visitas pendentes / Próxima** | compromissos firmes | — | acionável | — | `useVisitasAgendadas` ✅ |
+
+### Decisões do Codex (incorporadas)
+1. **`revenue_generated` NÃO é "receita"** — é **valor de pedido autodeclarado pelo vendedor** (não conciliado, não vem do ERP; ≠ receita reconhecida IFRS 15). → label honesto **"informado pelo vendedor · não conciliado"** + **nunca** rotular "comissionável". OTE real exige vínculo imutável visita→pedido, valor líquido do ERP, cancelamentos/devoluções, atribuição — tudo **v2**.
+2. **Janela**: outputs (valor/fechamentos/visitas) = **MTD** (alinha ao ciclo mensal de quota/OTE); eficiência (conversão/ticket) = **30d rolling** (estável — no início do mês o MTD oscila demais). **Não duplicar** a mesma métrica nas duas janelas.
+3. **Sem meta por vendedor, isto é relatório, não placar** — o placar de verdade (% da meta, ritmo, projeção) é **v2** (depende de meta cadastrada). Por isso o hero MTD é honesto: mostra o realizado, não atingimento.
+4. **Qualidade do dado visível**: ao lado do valor, expor **fechamentos sem valor** e **visitas sem resultado** (`montarKpisVisita` já os calcula) — anti-mascaramento.
+5. **Conversão é gameável** (`÷ com resultado` → não registrar visita ruim some do denominador). Melhoria (`÷ visitas realizadas` via `check_in_at` + janela de maturação, porque um deal pode fechar dias depois da visita) é **v2** — não regredir o helper validado sem o cuidado da maturação.
+
+### Anti-gaming
+- Valor/fechamentos **não-comissionáveis** por ora (o disclaimer "auto-reportado" evita o incentivo a inflar antes de haver conciliação com ERP).
+- "Fechamentos" é secundário a "valor" (isolado premia deal pequeno).
+- Conversão expõe `semResultado` (não registrar visita ruim fica visível).
+
+## Mudanças (100% frontend, sem migration/edge)
+
+### 1. `src/hooks/useKpisVisitaMtd.ts` (novo)
+Reusa `montarKpisVisita` numa janela **MTD** (`visit_date >= inicioMes(hojeSP())`, helpers já existentes e testados em `src/lib/dashboard/sp-date.ts`). Lente-aware (`effectiveUserId`, igual a `useKpisVisita`). Não toca o `useKpisVisita` (30d) existente.
+
+### 2. `src/components/dashboard/ClosersMtdHero.tsx` (novo)
+Placar do mês (output): **Valor informado** (MTD, label honesto + tooltip "auto-reportado, não conciliado") · **Fechamentos** (MTD) · **Visitas registradas** (MTD). Linha de **qualidade do dado**: `N fechamentos sem valor` / `M visitas sem resultado` quando > 0 (self-explain, como o `VisitasKpiTiles`). Self-hide se não há visita no mês.
+
+### 3. `src/components/dashboard/CloserDashboard.tsx` (reordenar + remover placeholder)
+Ordem nova (Codex): **header → `ClosersMtdHero` (placar do mês) → `VisitasKpiTiles` (atividade + eficiência 30d) → `VisitasHojeCard` → `VisitSuggestionsCard` → `FollowupsSugeridosCard` → `MinhasVisitasResultadoCard` (histórico 90d) → `MinhasTarefasCard` → `ChamadasPendentesNudge`**. **REMOVER** o card "Em construção — PR-VISIT-INTELLIGENCE". Tarefas/nudge descem do topo pro fim (trabalho dirigido + higiene, não placar).
+
+## Não-objetivos (v1)
+- Meta por vendedor / % de atingimento / projeção (placar OTE real) — v2.
+- Conciliação `revenue_generated` × ERP (`sales_orders`), valor líquido, margem, cancelamentos — v2.
+- Mexer no helper `montarKpisVisita` (conversão `÷ realizadas` + maturação) — v2.
+- Master (próximo PR).
+
+## Gaps v2 (registrados — o "nível mundial" real do closer precisa destes dados)
+1. **Meta por vendedor/período** → KPI-norte vira `% da meta` + ritmo + projeção (= placar de verdade).
+2. **Vínculo imutável visita→pedido** + valor líquido do ERP + margem + cancelamentos/devoluções + regra de atribuição/split + auditoria (destrava valor comissionável real).
+3. **Conversão honesta**: `fechados ÷ visitas realizadas` (check_in) + janela de **maturação** (deal fecha dias depois) + completude de resultado.
+4. **Ciclo de fechamento** (visit-to-close), **estágios de oportunidade**, **cobertura de carteira por visita** — não deriváveis hoje (visita futura ≠ pipeline).
+5. **Mediana do ticket** (menos sensível a outlier que a média).
+
+## Verificação
+- `useKpisVisitaMtd` filtra `visit_date >= inicioMes(hojeSP())` e segue o ALVO na lente (teste seguindo o padrão `lens-atividade-vendedor`).
+- `CloserDashboard` lidera com `ClosersMtdHero`, não renderiza o card "Em construção", mantém os demais cards de visita.
+- `bun run typecheck` + `bun lint` + `bun run test`.

--- a/src/components/dashboard/CloserDashboard.tsx
+++ b/src/components/dashboard/CloserDashboard.tsx
@@ -1,60 +1,53 @@
-import { Card } from '@/components/ui/card';
-import { Construction } from 'lucide-react';
-import { VisitSuggestionsCard } from './VisitSuggestionsCard';
-import { VisitasHojeCard } from './VisitasHojeCard';
-import { MinhasVisitasResultadoCard } from './MinhasVisitasResultadoCard';
-import { FollowupsSugeridosCard } from './FollowupsSugeridosCard';
+import { ClosersMtdHero } from './ClosersMtdHero';
 import { VisitasKpiTiles } from './VisitasKpiTiles';
+import { VisitasHojeCard } from './VisitasHojeCard';
+import { VisitSuggestionsCard } from './VisitSuggestionsCard';
+import { FollowupsSugeridosCard } from './FollowupsSugeridosCard';
+import { MinhasVisitasResultadoCard } from './MinhasVisitasResultadoCard';
 import { MinhasTarefasCard } from '@/components/tarefas/MinhasTarefasCard';
 import { ChamadasPendentesNudge } from '@/components/farmer/ChamadasPendentesNudge';
 
 /**
- * Dashboard Closer — placeholder rico até PR-VISIT-INTELLIGENCE implementar
- * algoritmo de sugestão de visita + rota geo + 4 tipos de missão.
+ * Dashboard Closer (visitas / outbound presencial) — lidera com o PLACAR DO MÊS
+ * (output, MTD), depois eficiência recente (30d), depois ação (visitas de hoje,
+ * sugestões, follow-ups) e histórico. Tarefas (trabalho dirigido) e o nudge de
+ * chamadas (higiene) ficam abaixo, fora do placar.
+ *
+ * Ordem e definições validadas com Codex
+ * (docs/superpowers/specs/2026-06-13-kpis-closer-meu-dia-design.md). O antigo card
+ * "Em construção — PR-VISIT-INTELLIGENCE" foi removido: o placar real já está aqui.
  */
 export function CloserDashboard() {
   return (
     <div className="container mx-auto p-4 space-y-4 max-w-5xl">
       <div>
-        <h1 className="text-xl font-semibold">Dashboard Closer (outbound presencial)</h1>
+        <h1 className="text-xl font-semibold">Meu dia (visitas)</h1>
         <p className="text-xs text-muted-foreground">
-          Foco em visitas de alto valor — fechar deals complexos pro Hunter, expansão pra Farmer, recovery de churn, relationship pra clientes VIP.
+          Seu placar de visitas do mês e a eficiência recente. Visitas de alto valor: fechar, expandir, recuperar.
         </p>
       </div>
 
-      <MinhasTarefasCard />
+      {/* Placar do mês (output, MTD) — o norte do closer */}
+      <ClosersMtdHero />
 
-      {/* nudge condicional: ligações registradas sem cliente vinculado (era item do menu Vendas) */}
-      <ChamadasPendentesNudge />
+      {/* Atividade + eficiência recente (30d): pendentes · próxima · conversão · ticket */}
+      <VisitasKpiTiles />
 
+      {/* Visitas firmes de hoje */}
       <VisitasHojeCard />
 
-      {/* Sugestões de visita — PR-VISIT-INTELLIGENCE Sub-PR A */}
+      {/* Sugestões de visita — ação (PR-VISIT-INTELLIGENCE Sub-PR A) */}
       <VisitSuggestionsCard />
 
       {/* Follow-ups pós-visita: visitas mornas que pedem retorno (read-only, deep-link) */}
       <FollowupsSugeridosCard />
 
+      {/* Breakdown histórico por resultado (90d) */}
       <MinhasVisitasResultadoCard />
 
-      <Card className="p-4 border-dashed border-2 border-status-warning/30 bg-status-warning-bg/20">
-        <div className="flex items-center gap-2 mb-2">
-          <Construction className="w-4 h-4 text-status-warning" />
-          <span className="text-sm font-medium">Em construção — PR-VISIT-INTELLIGENCE</span>
-        </div>
-        <p className="text-2xs text-muted-foreground">Próximas features:</p>
-        <ul className="text-2xs text-muted-foreground space-y-1 mt-2 ml-4 list-disc">
-          <li>4 tipos de missão: 🎯 Closing / 🌟 Expansion / 🚨 Recovery / 🤝 Relationship</li>
-          <li>Algoritmo de visit_score (potencial × probabilidade × urgência × proximidade)</li>
-          <li>Rota geográfica eficiente (visitas agrupadas por região)</li>
-          <li>Pre-call brief incrível antes de cada visita (consome PR-P3 + PR-CAPTURE + KB)</li>
-          <li>Registro de resultado da visita + métricas (Visit Conversion, ROI por visita)</li>
-          <li>Fila de pedidos vindos de Farmer/Hunter (&quot;solicitar visita&quot;)</li>
-        </ul>
-      </Card>
-
-      {/* KPIs reais (read-only, own-scoped); cada tile exibe sua definição */}
-      <VisitasKpiTiles />
+      {/* Trabalho dirigido + higiene — abaixo do placar */}
+      <MinhasTarefasCard />
+      <ChamadasPendentesNudge />
     </div>
   );
 }

--- a/src/components/dashboard/ClosersMtdHero.tsx
+++ b/src/components/dashboard/ClosersMtdHero.tsx
@@ -1,0 +1,63 @@
+import { Card } from '@/components/ui/card';
+import { Info } from 'lucide-react';
+import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip';
+import { useKpisVisitaMtd } from '@/hooks/useKpisVisitaMtd';
+import { formatBRL } from '@/components/customer360/format';
+
+function KpiCard({ label, value, sub, info }: { label: string; value: string; sub?: string; info?: string }) {
+  return (
+    <Card className="p-4">
+      <div className="text-2xs text-muted-foreground flex items-center gap-1">
+        {label}
+        {info && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button type="button" className="inline-flex" aria-label="Mais informação sobre este indicador">
+                <Info className="w-3 h-3 text-muted-foreground/70" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent className="max-w-xs text-2xs">{info}</TooltipContent>
+          </Tooltip>
+        )}
+      </div>
+      <div className="kpi-value text-2xl">{value}</div>
+      {sub && <div className="text-2xs text-muted-foreground mt-0.5">{sub}</div>}
+    </Card>
+  );
+}
+
+/**
+ * Placar do mês do CLOSER (output, MTD) — o norte do dashboard de visitas.
+ *
+ * ⚠️ "Valor informado" = `revenue_generated` que o vendedor digita ao registrar a
+ * visita; NÃO é conciliado com o ERP → não é receita reconhecida nem base de comissão
+ * (decisão Codex; ver docs/superpowers/specs/2026-06-13-kpis-closer-meu-dia-design.md).
+ * A qualidade do dado é exposta (fechamentos sem valor, visitas sem resultado) pra não
+ * mascarar subnotificação. Self-hide quando não há visita no mês.
+ */
+export function ClosersMtdHero() {
+  const { data: k, isLoading } = useKpisVisitaMtd();
+  if (isLoading || !k || k.totalVisitas === 0) return null; // self-hide
+
+  const qualidade: string[] = [];
+  if (k.fechadosSemValor > 0) qualidade.push(`${k.fechadosSemValor} fechamento${k.fechadosSemValor > 1 ? 's' : ''} sem valor`);
+  if (k.semResultado > 0) qualidade.push(`${k.semResultado} visita${k.semResultado > 1 ? 's' : ''} sem resultado`);
+
+  return (
+    <div className="space-y-2">
+      <div className="grid grid-cols-2 lg:grid-cols-3 gap-3">
+        <KpiCard
+          label="Valor informado (mês)"
+          value={formatBRL(k.receitaTotal)}
+          sub="pedidos fechados em visita"
+          info="Valor INFORMADO pelo vendedor ao registrar a visita — não conciliado com o ERP. Não é receita reconhecida nem base de comissão."
+        />
+        <KpiCard label="Fechamentos (mês)" value={String(k.fechados)} sub="visitas que viraram pedido" />
+        <KpiCard label="Visitas registradas (mês)" value={String(k.totalVisitas)} sub="atividade do mês" />
+      </div>
+      {qualidade.length > 0 && (
+        <p className="text-2xs text-muted-foreground">Qualidade do dado: {qualidade.join(' · ')}.</p>
+      )}
+    </div>
+  );
+}

--- a/src/hooks/__tests__/lens-atividade-vendedor.test.tsx
+++ b/src/hooks/__tests__/lens-atividade-vendedor.test.tsx
@@ -34,6 +34,7 @@ import { useKpisVisita } from '../useKpisVisita';
 import { useMyKpis } from '../useMyKpis';
 import { useFollowupsVisita } from '../useFollowupsVisita';
 import { useMinhasVisitasResultado } from '../useMinhasVisitasResultado';
+import { useKpisVisitaMtd } from '../useKpisVisitaMtd';
 
 let qc: QueryClient;
 const wrapper = ({ children }: { children: ReactNode }) => (
@@ -50,6 +51,7 @@ beforeEach(() => {
 /* eslint-disable react-hooks/rules-of-hooks */
 const hooks: Array<{ name: string; run: () => unknown }> = [
   { name: 'useKpisVisita', run: () => useKpisVisita(30) },
+  { name: 'useKpisVisitaMtd', run: () => useKpisVisitaMtd() },
   { name: 'useMyKpis', run: () => useMyKpis() },
   { name: 'useFollowupsVisita', run: () => useFollowupsVisita() },
   { name: 'useMinhasVisitasResultado', run: () => useMinhasVisitasResultado(30) },

--- a/src/hooks/useKpisVisitaMtd.ts
+++ b/src/hooks/useKpisVisitaMtd.ts
@@ -1,0 +1,33 @@
+import { useQuery } from '@tanstack/react-query';
+import { useImpersonation } from '@/contexts/ImpersonationContext';
+import { supabase } from '@/integrations/supabase/client';
+import { hojeSP, inicioMes } from '@/lib/dashboard/sp-date';
+import { montarKpisVisita, type KpisVisita, type KpiVisitaRow } from '@/lib/visitas/kpis';
+
+/**
+ * KPIs de visita do vendedor no MÊS corrente (MTD, fuso SP) — o PLACAR do closer.
+ * Distinto do useKpisVisita (30d rolling, eficiência): aqui a janela é o mês
+ * calendário (alinha ao ciclo de quota/OTE). Mesma fonte (route_visits own-scoped,
+ * visited_by=eu, RLS #340) e o MESMO helper puro montarKpisVisita.
+ * Lente "Ver como": id efetivo = ALVO na lente, próprio usuário fora dela. Read-only.
+ */
+export function useKpisVisitaMtd() {
+  const { effectiveUserId: uid } = useImpersonation();
+  const desde = inicioMes(hojeSP()); // 1º dia do mês corrente em SP
+  return useQuery({
+    queryKey: ['kpis-visita-mtd', uid, desde],
+    enabled: !!uid,
+    staleTime: 60_000,
+    gcTime: 5 * 60_000,
+    queryFn: async (): Promise<KpisVisita> => {
+      if (!uid) return montarKpisVisita([]);
+      const { data, error } = await supabase
+        .from('route_visits')
+        .select('result, revenue_generated')
+        .eq('visited_by', uid)
+        .gte('visit_date', desde);
+      if (error) throw new Error(error.message);
+      return montarKpisVisita((data ?? []) as KpiVisitaRow[]);
+    },
+  });
+}

--- a/src/lib/impersonation/__tests__/no-write-leak.test.ts
+++ b/src/lib/impersonation/__tests__/no-write-leak.test.ts
@@ -42,6 +42,9 @@ const ALLOWED = new Set([
   // da lente (KPIs do dia, KPIs/follow-ups/resultado de visitas). Read-only, sem mutation.
   'src/hooks/useMyKpis.ts',
   'src/hooks/useKpisVisita.ts',
+  // useKpisVisitaMtd: igual ao useKpisVisita, mas janela MTD (placar do closer). effectiveUserId
+  // SÓ filtra a LEITURA de route_visits pro alvo na lente (.eq visited_by); read-only, sem mutation.
+  'src/hooks/useKpisVisitaMtd.ts',
   'src/hooks/useFollowupsVisita.ts',
   'src/hooks/useMinhasVisitasResultado.ts',
   // FarmerCalls: effectiveUserId SÓ na leitura da lista de ligações (loadCallLogs); a escrita


### PR DESCRIPTION
## O quê
Redefine os KPIs de nível mundial do **CLOSER** (visita presencial / outbound) no `/meu-dia` — 3ª persona da frente (farmer #690, hunter #795). 100% frontend.

## Problema
O `CloserDashboard` **já tinha KPIs reais** (`VisitasKpiTiles`: conversão/ticket 30d), mas estavam **no fim**, depois de um card **"Em construção — PR-VISIT-INTELLIGENCE"** (placeholder). Não liderava com placar; tarefas/higiene ficavam no topo.

## Decisão (2ª opinião do Codex — gpt-5.5, citou IFRS 15)
- **`revenue_generated` NÃO é "receita"** — é **valor de pedido autodeclarado** pelo vendedor (não conciliado, não-ERP). Rotulado **"informado pelo vendedor · não conciliado"**, com tooltip; **nunca** "comissionável".
- **Janela**: outputs (valor/fechamentos/visitas) = **MTD** (alinha ao ciclo de quota/OTE); eficiência (conversão/ticket) = **30d rolling** (estável no início do mês). Sem duplicar métrica entre janelas.
- **Sem meta por vendedor, é relatório, não placar** — % da meta/ritmo é v2.
- **Qualidade do dado visível**: fechamentos sem valor / visitas sem resultado (anti-mascaramento).

## Mudanças
- `src/hooks/useKpisVisitaMtd.ts` (novo): reusa o helper puro `montarKpisVisita` numa janela **MTD** (`inicioMes(hojeSP())`, já testado), lente-aware. Adicionado à allowlist do guardrail `no-write-leak` (leitura own-scoped) + ao teste `lens-atividade-vendedor` (não vaza master→alvo).
- `src/components/dashboard/ClosersMtdHero.tsx` (novo): **Valor informado** (mês, label honesto + tooltip) · **Fechamentos** (mês) · **Visitas registradas** (mês) + linha de qualidade do dado. Self-hide sem visita.
- `src/components/dashboard/CloserDashboard.tsx`: reordena (hero MTD → eficiência 30d → visitas hoje → sugestões → follow-ups → histórico → tarefas/nudge) e **remove o card "Em construção"**.

## Verificação
- `bun run typecheck` ✅ · `bun lint` 0 erros ✅ · suite local 3265 ✅ (o guardrail `no-write-leak` pegou o novo hook → corrigido na allowlist; CI revalida a suite completa).

## Gaps v2 (no spec)
Conversão honesta (`÷realizadas` + maturação), meta/% atingimento, conciliação `revenue_generated`×ERP (valor líquido/margem/cancelamentos), ciclo de fechamento.

Spec: `docs/superpowers/specs/2026-06-13-kpis-closer-meu-dia-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)