### PR TITLE
feat(lente): tactical-plan + copilot lente-aware (parte 2) — anti-vazamento no "Ver como"

### DIFF
--- a/src/components/farmer/copilot/SessionStartCard.tsx
+++ b/src/components/farmer/copilot/SessionStartCard.tsx
@@ -15,6 +15,7 @@ interface SessionStartCardProps {
   customers: { id: string; name: string }[];
   isConnecting: boolean;
   onStart: () => void;
+  disabled?: boolean;
 }
 
 export function SessionStartCard({
@@ -25,6 +26,7 @@ export function SessionStartCard({
   customers,
   isConnecting,
   onStart,
+  disabled,
 }: SessionStartCardProps) {
   return (
     <Card className="border-primary/20">
@@ -85,7 +87,8 @@ export function SessionStartCard({
 
         <Button
           onClick={onStart}
-          disabled={isConnecting}
+          disabled={isConnecting || disabled}
+          title={disabled ? 'Indisponível em modo Ver como' : undefined}
           className="w-full gap-2"
         >
           {isConnecting ? (

--- a/src/components/farmer/copilot/useFarmerCopilot.ts
+++ b/src/components/farmer/copilot/useFarmerCopilot.ts
@@ -4,6 +4,7 @@ import { useState, useCallback, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useScribe, CommitStrategy } from '@elevenlabs/react';
 import { useAuth } from '@/contexts/AuthContext';
+import { useImpersonation } from '@/contexts/ImpersonationContext';
 import { useCopilotEngine, type CopilotContext } from '@/hooks/useCopilotEngine';
 import { useTacticalPlan, type TacticalPlan } from '@/hooks/useTacticalPlan';
 import { supabase } from '@/integrations/supabase/client';
@@ -15,6 +16,10 @@ import type { InputMode } from './types';
 export function useFarmerCopilot() {
   const navigate = useNavigate();
   const { user, isStaff } = useAuth();
+  // Lente "Ver como": o dropdown de clientes da carteira segue o id efetivo (o ALVO na
+  // lente, o próprio usuário fora). Iniciar a sessão (startSession persiste + invoca
+  // edge) é write — bloqueado na lente pelo write-guard + botão "Iniciar" disabled.
+  const { effectiveUserId, isImpersonating } = useImpersonation();
   const copilot = useCopilotEngine();
   const { getActivePlan } = useTacticalPlan();
   const [selectedCustomer, setSelectedCustomer] = useState<string>('');
@@ -43,14 +48,14 @@ export function useFarmerCopilot() {
     },
   });
 
-  // Load customers
+  // Load customers (dropdown da carteira — segue o id efetivo na lente)
   useEffect(() => {
-    if (!user?.id || !isStaff) return;
+    if (!effectiveUserId || !isStaff) return;
     (async () => {
       const { data: scores } = await supabase
         .from('farmer_client_scores')
         .select('customer_user_id')
-        .eq('farmer_id', user.id);
+        .eq('farmer_id', effectiveUserId);
       if (!scores?.length) return;
       const ids = scores.map((s) => s.customer_user_id).filter((id): id is string => id !== null);
       const { data: profiles } = await supabase
@@ -61,7 +66,7 @@ export function useFarmerCopilot() {
         setCustomers(profiles.map((p) => ({ id: p.user_id, name: p.name ?? '' })));
       }
     })();
-  }, [user, isStaff]);
+  }, [effectiveUserId, isStaff]);
 
   // Auto-scroll transcript
   useEffect(() => {
@@ -241,6 +246,7 @@ export function useFarmerCopilot() {
   return {
     navigate,
     isStaff,
+    isImpersonating,
     copilot,
     selectedCustomer,
     setSelectedCustomer,

--- a/src/components/farmer/tacticalPlan/GerarPlanoCard.tsx
+++ b/src/components/farmer/tacticalPlan/GerarPlanoCard.tsx
@@ -4,6 +4,7 @@ import { Plus, Loader2, Zap, Layers } from 'lucide-react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
+import { useImpersonation } from '@/contexts/ImpersonationContext';
 import type { PlanType } from '@/hooks/useTacticalPlan';
 import type { CustomerLite } from './types';
 
@@ -22,6 +23,9 @@ export function GerarPlanoCard({
   generating,
   onGenerate,
 }: GerarPlanoCardProps) {
+  // Lente "Ver como": gerar plano é write (insert) — desabilitado (o write-guard já
+  // bloqueia; o disable evita o erro/ruído).
+  const { isImpersonating } = useImpersonation();
   return (
     <Card>
       <CardHeader className="p-3 pb-2">
@@ -52,7 +56,8 @@ export function GerarPlanoCard({
                   size="sm"
                   variant="outline"
                   className="h-6 text-[8px] px-2"
-                  disabled={generating === c.id}
+                  disabled={generating === c.id || isImpersonating}
+                  title={isImpersonating ? 'Indisponível em modo Ver como' : undefined}
                   onClick={() => onGenerate(c.id, 'essencial')}
                 >
                   {generating === c.id ? <Loader2 className="w-3 h-3 animate-spin" /> : <><Zap className="w-2.5 h-2.5 mr-0.5" />Essencial</>}
@@ -61,7 +66,8 @@ export function GerarPlanoCard({
                   size="sm"
                   variant="default"
                   className="h-6 text-[8px] px-2"
-                  disabled={generating === c.id}
+                  disabled={generating === c.id || isImpersonating}
+                  title={isImpersonating ? 'Indisponível em modo Ver como' : undefined}
                   onClick={() => onGenerate(c.id, 'estrategico')}
                 >
                   {generating === c.id ? <Loader2 className="w-3 h-3 animate-spin" /> : <><Layers className="w-2.5 h-2.5 mr-0.5" />Estratégico</>}

--- a/src/components/farmer/tacticalPlan/RecordResultDialog.tsx
+++ b/src/components/farmer/tacticalPlan/RecordResultDialog.tsx
@@ -9,6 +9,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Switch } from '@/components/ui/switch';
 import { Label } from '@/components/ui/label';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
+import { useImpersonation } from '@/contexts/ImpersonationContext';
 import type { RecordResultPayload } from './types';
 
 export const RecordResultDialog = ({
@@ -18,6 +19,8 @@ export const RecordResultDialog = ({
   planId: string;
   onRecord: (planId: string, result: RecordResultPayload) => Promise<void>;
 }) => {
+  // Lente "Ver como": registrar resultado é write (update) — desabilitado.
+  const { isImpersonating } = useImpersonation();
   const [open, setOpen] = useState(false);
   const [planFollowed, setPlanFollowed] = useState(true);
   const [callResult, setCallResult] = useState('');
@@ -44,7 +47,13 @@ export const RecordResultDialog = ({
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
-        <Button variant="outline" size="sm" className="w-full text-[10px] gap-1">
+        <Button
+          variant="outline"
+          size="sm"
+          className="w-full text-[10px] gap-1"
+          disabled={isImpersonating}
+          title={isImpersonating ? 'Indisponível em modo Ver como' : undefined}
+        >
           <FileText className="w-3 h-3" /> Registrar Resultado
         </Button>
       </DialogTrigger>

--- a/src/components/farmer/tacticalPlan/__tests__/GerarPlanoCard.test.tsx
+++ b/src/components/farmer/tacticalPlan/__tests__/GerarPlanoCard.test.tsx
@@ -3,6 +3,10 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import { GerarPlanoCard } from "../GerarPlanoCard";
 import type { CustomerLite } from "../types";
 
+// GerarPlanoCard lê useImpersonation pra desabilitar a geração na lente "Ver como".
+// Fora da lente (isImpersonating=false) os botões seguem habilitados — comportamento testado aqui.
+vi.mock("@/contexts/ImpersonationContext", () => ({ useImpersonation: vi.fn(() => ({ isImpersonating: false })) }));
+
 const customers: CustomerLite[] = [
   { id: "c1", name: "Marcenaria Alfa", healthScore: 80, churnRisk: 10 },
   { id: "c2", name: "Móveis Beta", healthScore: 30, churnRisk: 60 },

--- a/src/components/farmer/tacticalPlan/__tests__/PlanCard.test.tsx
+++ b/src/components/farmer/tacticalPlan/__tests__/PlanCard.test.tsx
@@ -3,6 +3,10 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import { PlanCard } from "../PlanCard";
 import type { TacticalPlan } from "@/hooks/useTacticalPlan";
 
+// PlanCard → RecordResultDialog lê useImpersonation pra desabilitar o registro na lente
+// "Ver como". Fora da lente (isImpersonating=false) o botão segue habilitado — testado aqui.
+vi.mock("@/contexts/ImpersonationContext", () => ({ useImpersonation: vi.fn(() => ({ isImpersonating: false })) }));
+
 function makePlan(overrides: Partial<TacticalPlan> = {}): TacticalPlan {
   return {
     id: "p1",

--- a/src/components/farmer/tacticalPlan/useFarmerTacticalPlan.ts
+++ b/src/components/farmer/tacticalPlan/useFarmerTacticalPlan.ts
@@ -3,12 +3,17 @@
 // state, carregamento de clientes, geração com checagem de eficiência e handlers.
 import { useState, useEffect } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
+import { useImpersonation } from '@/contexts/ImpersonationContext';
 import { useTacticalPlan, type PlanType } from '@/hooks/useTacticalPlan';
 import { supabase } from '@/integrations/supabase/client';
 import type { FarmerClientScoreRow, ProfileRow, CustomerLite } from './types';
 
 export function useFarmerTacticalPlan() {
   const { user, isStaff } = useAuth();
+  // Lente "Ver como": o dropdown de clientes da carteira segue o id efetivo (o ALVO na
+  // lente, o próprio usuário fora). A geração de plano (botões em GerarPlanoCard) é write
+  // — bloqueada na lente pelo write-guard + disabled. Fora da lente effectiveUserId === user.id.
+  const { effectiveUserId } = useImpersonation();
   const { plans, loading, generating, loadPlans, generatePlan, checkEfficiency, recordResult } = useTacticalPlan();
   const [customers, setCustomers] = useState<CustomerLite[]>([]);
   const [expandedPlan, setExpandedPlan] = useState<string | null>(null);
@@ -21,14 +26,16 @@ export function useFarmerTacticalPlan() {
       loadPlans();
       loadCustomers();
     }
-  }, [user, isStaff]);
+    // effectiveUserId na dep: ao entrar/sair da lente, recarrega planos + dropdown do alvo.
+
+  }, [user, isStaff, effectiveUserId]);
 
   const loadCustomers = async () => {
-    if (!user?.id) return;
+    if (!effectiveUserId) return;
     const { data: scoresData } = await supabase
       .from('farmer_client_scores')
       .select('customer_user_id, health_score, churn_risk')
-      .eq('farmer_id', user.id)
+      .eq('farmer_id', effectiveUserId)
       .order('priority_score', { ascending: false });
     const scores = (scoresData ?? []) as FarmerClientScoreRow[];
     if (!scores.length) return;

--- a/src/hooks/__tests__/lens-tactical-plan.test.tsx
+++ b/src/hooks/__tests__/lens-tactical-plan.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+
+/**
+ * Guard de regressão da lente "Ver como pessoa" no PLANO TÁTICO (engine de IA).
+ * As leituras que EXIBEM o que já existe (planos do vendedor, dropdown de clientes da
+ * carteira, estatísticas de efetividade) devem filtrar pelo id EFETIVO: o ALVO na lente,
+ * o próprio usuário fora. A geração de plano e o registro de resultado são writes —
+ * bloqueados na lente pelo write-guard + botões disabled (não exercidos aqui).
+ */
+const eqCalls: Array<[string, unknown]> = [];
+
+function stubChain(): unknown {
+  const chain: Record<string, unknown> = {};
+  const passthrough = [
+    'select', 'gte', 'lt', 'lte', 'gt', 'is', 'not', 'in', 'order',
+    'limit', 'range', 'or', 'neq', 'filter', 'single', 'maybeSingle', 'contains',
+  ];
+  for (const m of passthrough) chain[m] = () => chain;
+  chain.eq = (col: string, val: unknown) => { eqCalls.push([col, val]); return chain; };
+  chain.then = (resolve: (v: unknown) => void) => resolve({ data: [], error: null, count: 0 });
+  return chain;
+}
+
+vi.mock('@/integrations/supabase/client', () => ({ supabase: { from: () => stubChain() } }));
+
+const impMock = vi.fn();
+vi.mock('@/contexts/ImpersonationContext', () => ({ useImpersonation: () => impMock() }));
+vi.mock('@/contexts/AuthContext', () => ({ useAuth: () => ({ user: { id: 'master-id' }, isStaff: true }) }));
+
+import { useTacticalPlan } from '../useTacticalPlan';
+import { useFarmerTacticalPlan } from '@/components/farmer/tacticalPlan/useFarmerTacticalPlan';
+
+beforeEach(() => {
+  eqCalls.length = 0;
+});
+
+describe('useTacticalPlan — lente "Ver como"', () => {
+  it('na lente: loadPlans filtra pelo ALVO, nunca o master', async () => {
+    impMock.mockReturnValue({ isImpersonating: true, effectiveUserId: 'alvo-id' });
+    const { result } = renderHook(() => useTacticalPlan());
+    await act(async () => { await result.current.loadPlans(); });
+    const valores = eqCalls.map((c) => c[1]);
+    expect(valores).toContain('alvo-id');
+    expect(valores).not.toContain('master-id');
+  });
+
+  it('na lente: getEffectivenessStats filtra pelo ALVO', async () => {
+    impMock.mockReturnValue({ isImpersonating: true, effectiveUserId: 'alvo-id' });
+    const { result } = renderHook(() => useTacticalPlan());
+    await act(async () => { await result.current.getEffectivenessStats(); });
+    const valores = eqCalls.map((c) => c[1]);
+    expect(valores).toContain('alvo-id');
+    expect(valores).not.toContain('master-id');
+  });
+
+  it('fora da lente: filtra pelo próprio usuário', async () => {
+    impMock.mockReturnValue({ isImpersonating: false, effectiveUserId: 'master-id' });
+    const { result } = renderHook(() => useTacticalPlan());
+    await act(async () => { await result.current.loadPlans(); });
+    expect(eqCalls.map((c) => c[1])).toContain('master-id');
+  });
+});
+
+describe('useFarmerTacticalPlan — lente "Ver como"', () => {
+  it('na lente: o dropdown de clientes (loadCustomers) filtra pelo ALVO, nunca o master', async () => {
+    impMock.mockReturnValue({ isImpersonating: true, effectiveUserId: 'alvo-id' });
+    renderHook(() => useFarmerTacticalPlan());
+    await waitFor(() => expect(eqCalls.length).toBeGreaterThan(0));
+    const valores = eqCalls.map((c) => c[1]);
+    expect(valores).toContain('alvo-id');
+    expect(valores).not.toContain('master-id');
+  });
+
+  it('fora da lente: filtra pelo próprio usuário', async () => {
+    impMock.mockReturnValue({ isImpersonating: false, effectiveUserId: 'master-id' });
+    renderHook(() => useFarmerTacticalPlan());
+    await waitFor(() => expect(eqCalls.length).toBeGreaterThan(0));
+    expect(eqCalls.map((c) => c[1])).toContain('master-id');
+  });
+});

--- a/src/hooks/useTacticalPlan.ts
+++ b/src/hooks/useTacticalPlan.ts
@@ -2,6 +2,7 @@ import { useState, useCallback } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import type { Json } from '@/integrations/supabase/types';
 import { useAuth } from '@/contexts/AuthContext';
+import { useImpersonation } from '@/contexts/ImpersonationContext';
 import { toast } from 'sonner';
 
 // ─── Types ───────────────────────────────────────────────────────────
@@ -198,6 +199,12 @@ const PROFIT_PER_HOUR_THRESHOLD = 50; // R$/h configurable threshold
 
 export const useTacticalPlan = () => {
   const { user } = useAuth();
+  // Lente "Ver como": as leituras de EXIBIÇÃO (planos do vendedor, plano ativo do
+  // cliente, estatísticas de efetividade) seguem o id efetivo — o ALVO na lente, o
+  // próprio usuário fora. A GERAÇÃO de plano (checkEfficiency/generatePlan) e o registro
+  // de resultado seguem user.id (write identity = master real) e são bloqueados na lente
+  // pelo write-guard + botões disabled. Fora da lente effectiveUserId === user.id.
+  const { effectiveUserId } = useImpersonation();
   const [plans, setPlans] = useState<TacticalPlan[]>([]);
   const [loading, setLoading] = useState(false);
   const [generating, setGenerating] = useState<string | null>(null);
@@ -261,13 +268,13 @@ export const useTacticalPlan = () => {
 
   // Load existing plans
   const loadPlans = useCallback(async () => {
-    if (!user?.id) return;
+    if (!effectiveUserId) return;
     setLoading(true);
     try {
       const { data } = (await supabase
         .from('farmer_tactical_plans')
         .select('*')
-        .eq('farmer_id', user.id)
+        .eq('farmer_id', effectiveUserId)
         .order('created_at', { ascending: false })
         .limit(50)) as unknown as { data: TacticalPlanRow[] | null };
 
@@ -290,7 +297,7 @@ export const useTacticalPlan = () => {
     } finally {
       setLoading(false);
     }
-  }, [user]);
+  }, [effectiveUserId]);
 
   // Check efficiency before generating
   const checkEfficiency = useCallback(async (customerId: string): Promise<EfficiencyCheck> => {
@@ -472,12 +479,12 @@ export const useTacticalPlan = () => {
 
   // Get latest active plan for a customer (used by Copilot integration)
   const getActivePlan = useCallback(async (customerId: string): Promise<TacticalPlan | null> => {
-    if (!user?.id) return null;
+    if (!effectiveUserId) return null;
 
     const { data } = (await supabase
       .from('farmer_tactical_plans')
       .select('*')
-      .eq('farmer_id', user.id)
+      .eq('farmer_id', effectiveUserId)
       .eq('customer_user_id', customerId)
       .eq('status', 'gerado')
       .order('created_at', { ascending: false })
@@ -493,7 +500,7 @@ export const useTacticalPlan = () => {
 
     const profileMap = new Map<string, string>([[customerId, profile?.name || 'Cliente']]);
     return parsePlan(data[0], profileMap);
-  }, [user]);
+  }, [effectiveUserId]);
 
   // Record post-call results
   const recordResult = useCallback(async (planId: string, result: {
@@ -528,12 +535,12 @@ export const useTacticalPlan = () => {
 
   // Get effectiveness stats
   const getEffectivenessStats = useCallback(async () => {
-    if (!user?.id) return null;
+    if (!effectiveUserId) return null;
 
     const { data } = (await supabase
       .from('farmer_tactical_plans')
       .select('strategic_objective, plan_followed, actual_margin, call_duration_seconds, plan_type')
-      .eq('farmer_id', user.id)
+      .eq('farmer_id', effectiveUserId)
       .eq('status', 'concluido')) as unknown as { data: EffectivenessRow[] | null };
 
     if (!data?.length) return null;
@@ -567,7 +574,7 @@ export const useTacticalPlan = () => {
       }));
 
     return { byObjective: mapStats(byObjective), byType: mapStats(byType) };
-  }, [user]);
+  }, [effectiveUserId]);
 
   return {
     plans,

--- a/src/lib/impersonation/__tests__/no-write-leak.test.ts
+++ b/src/lib/impersonation/__tests__/no-write-leak.test.ts
@@ -67,6 +67,18 @@ const ALLOWED = new Set([
   // de vínculo (query react-query) pro "Ver como" mostrar as do alvo. O vínculo
   // (useLinkCallToCustomer) é write — bloqueado na lente + botão "Vincular" disabled.
   'src/pages/FarmerCallsPendingLink.tsx',
+  // useTacticalPlan: effectiveUserId nas leituras de EXIBIÇÃO (loadPlans / getActivePlan /
+  // getEffectivenessStats — planos/efetividade do alvo). A geração (generatePlan/
+  // checkEfficiency) e o recordResult usam user.id (write identity) e são bloqueados na
+  // lente pelo write-guard + botões disabled.
+  'src/hooks/useTacticalPlan.ts',
+  // useFarmerTacticalPlan: effectiveUserId SÓ em loadCustomers (dropdown da carteira do
+  // alvo) + na dep do effect (recarrega ao entrar/sair da lente). Geração = disabled.
+  'src/components/farmer/tacticalPlan/useFarmerTacticalPlan.ts',
+  // useFarmerCopilot: effectiveUserId SÓ no "load customers" (dropdown da carteira do
+  // alvo). Iniciar a sessão (startSession persiste + invoca edge) é write — bloqueado na
+  // lente pelo write-guard + botão "Iniciar" disabled (isImpersonating exposto pro card).
+  'src/components/farmer/copilot/useFarmerCopilot.ts',
   // Clientes (/admin/customers): useClientesScope escopa a LEITURA da lista pro alvo da lente
   // (effectiveUserId só filtra carteira_assignments/scores — read-only, é o hook que importa
   // useDisplayAccess e NÃO tem mutação). useAdminCustomers recebe effectiveUserId do scope

--- a/src/pages/FarmerCopilot.tsx
+++ b/src/pages/FarmerCopilot.tsx
@@ -15,6 +15,7 @@ const FarmerCopilot = () => {
   const {
     navigate,
     isStaff,
+    isImpersonating,
     copilot,
     selectedCustomer,
     setSelectedCustomer,
@@ -57,6 +58,7 @@ const FarmerCopilot = () => {
             customers={customers}
             isConnecting={isConnecting}
             onStart={handleStart}
+            disabled={isImpersonating}
           />
         ) : (
           <>


### PR DESCRIPTION
## O quê

**Parte 2 / final** da frente de tornar as **engines de IA da carteira** lente-aware (parte 1 = #796). Quando o master impersona uma vendedora via **"Ver como pessoa"**, o **plano tático** e o **copiloto** paravam de mostrar os **dados do master** vazando — agora as **leituras de exibição** seguem o id **EFETIVO** (o ALVO na lente, o próprio usuário fora).

> Fora da lente `effectiveUserId === user.id` → **byte-idêntico, zero regressão**. A mudança só existe **na lente**.

## Arquivos

| Arquivo | Mudança |
|---|---|
| `useTacticalPlan.ts` | `loadPlans` / `getActivePlan` / `getEffectivenessStats` → ALVO; geração + recordResult em `user.id` |
| `useFarmerTacticalPlan.ts` | `loadCustomers` (dropdown da carteira) → ALVO; recarrega ao trocar de lente |
| `useFarmerCopilot.ts` | dropdown de clientes → ALVO; expõe `isImpersonating` |
| `GerarPlanoCard` / `RecordResultDialog` / `SessionStartCard` | `disabled={isImpersonating}` (gerar plano / registrar resultado / iniciar sessão) |
| `FarmerCopilot.tsx` | passa `disabled={isImpersonating}` ao card de início |
| `no-write-leak.test.ts` | +3 hooks na allowlist (effectiveUserId só em leitura) |
| `lens-tactical-plan.test.tsx` | **novo** — na lente o `.eq('farmer_id')` segue o ALVO |
| `GerarPlanoCard.test.tsx` / `PlanCard.test.tsx` | +mock de `useImpersonation` (idioma do codebase, ex. `AcaoOutcomeMenu.test`) |

## Padrão (validado em prod nos #671/#678/#796)

- **Leitura de exibição** (`loadPlans`/`loadCustomers`/stats) → `effectiveUserId`.
- **Ação de gerar/escrever** → `disabled={isImpersonating}` (o **write-guard** já bloqueia a mutação; o disable evita o erro/ruído). A leitura que **alimenta a geração** (`checkEfficiency`, `prepareSessionContext`) fica em `user.id` — a escrita nunca persiste na lente.

## Verificação

- ✅ `bun run typecheck` (strict) — 0 erros
- ✅ `bun lint` — 0 erros (2 warnings `exhaustive-deps` **pré-existentes**, não introduzidas aqui)
- ✅ `bun run test` — **454 arquivos de teste, 0 falhas** (lens-tactical-plan 5 + guardrail + os 19 de componentes)
- TDD: RED (3 "na lente" falhando por filtrar `master-id`) → GREEN.

Com isso, **as 7 engines de IA mapeadas estão lente-aware** (cross-sell, experiments, diagnostic, pending-link [#796] + tactical-plan, useFarmerTacticalPlan, copilot [aqui]).

100% frontend — **requer Publish no Lovable** pra ir ao ar.

### Fora de escopo (follow-up, herdado do #796)

O fluxo de **BUNDLES** (`useFarmerBundles`/`useBundleEngine`/`useBundleArguments`) ainda exibe dados do master na lente — tornar esse fluxo inteiro lente-aware é PR próprio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)