### PR TITLE
feat(lente): fluxo de bundles da farmer lente-aware ("Ver como") — não vaza dados do master

### DIFF
--- a/docs/roadmap-sessao.md
+++ b/docs/roadmap-sessao.md
@@ -12,13 +12,16 @@
 > ainda exibe os DADOS DO MASTER quando o master impersona uma vendedora. As engines de IA
 > da carteira já viraram lente-aware (#796/#799); os engines de bundles ficaram de fora.
 > Segue o padrão validado em prod (CLAUDE.md §10). 100% frontend.
+> **ENTREGUE** — [PR #804](https://github.com/LucasSardenbergL/afiacao/pull/804) (TDD red→green, sem --admin).
 
-- 🔄 **useBundleEngine** lente-aware (espelha `useCrossSellEngine`): leitura de exibição (`farmer_client_scores`/`farmer_recommendations`) → `effectiveUserId`; SEM fallback super-admin na lente; persistência (`farmer_association_rules` global + `farmer_bundle_recommendations`) PULADA com `if (!isImpersonating)`.
-- 🔄 **BundleCardFull** (leaf, lê `useImpersonation()` direto): "Perguntas SPIN"/"Argumentação"/"Salvar (sem oferta)"/"Salvar (ofertou)" `disabled={isImpersonating}` + title honesto.
-- 🔄 **useBundleArguments**: stateless (não lê carteira) → só os botões acima desabilitam; write-guard já bloqueia edge/insert na fonte → NÃO entra na allowlist.
-- 🔄 **Testes**: bloco `useBundleEngine` no `lens-engines-ia.test.tsx` (na lente lê do ALVO, fora do próprio) + `BundleCardFull.test.tsx` ganha mock de `useImpersonation` + caso "botões disabled na lente".
-- 🔄 **Guardrail** `no-write-leak.test.ts`: `useBundleEngine.ts` na allowlist (leitura justificada).
-- ⏳ Verificação `heavy bun run typecheck` + `bun lint` + `heavy bun run test`. **Publish no Lovable** ao final.
+- ✅ **useBundleEngine** lente-aware (espelha `useCrossSellEngine`): leitura de exibição (`farmer_client_scores`/`farmer_recommendations`) → `effectiveUserId`; SEM fallback super-admin na lente; persistência (`farmer_association_rules` global + `farmer_bundle_recommendations`) PULADA com `if (!isImpersonating)`. `setRules`/`setCustomerBundles` (display) seguem fora do gate — o master inspeciona, não regrava.
+- ✅ **BundleCardFull** (leaf, lê `useImpersonation()` direto): "Perguntas SPIN"/"Argumentação"/"Salvar (sem oferta)"/"Salvar (ofertou)" `disabled={isImpersonating}` + title honesto.
+- ✅ **useBundleArguments**: stateless (não lê carteira) → só os botões acima desabilitam; write-guard já bloqueia edge/insert na fonte → NÃO entrou na allowlist.
+- ✅ **Testes**: bloco `useBundleEngine` no `lens-engines-ia.test.tsx` (na lente lê do ALVO, fora do próprio) + `BundleCardFull.test.tsx` com mock de `useImpersonation` + caso "botões disabled na lente". RED confirmado (`[ 'master-id' ] to include 'alvo-id'`) antes do fix.
+- ✅ **Guardrail** `no-write-leak.test.ts`: `useBundleEngine.ts` na allowlist (leitura justificada).
+- ✅ Verificação: `typecheck` strict **0** · `lint` **0 errors** · `test` **3299/3299**.
+- ⏸️ **Decisão de escopo:** botão "Montar pedido com este bundle" NÃO desabilitado (fora dos 4 botões da tarefa; navegação p/ `/sales/new`, que já tem write-guard no submit).
+- ⏳ **Founder: Publish no Lovable** (100% frontend → só vai ao ar após Publish).
 
 ---
 

--- a/docs/roadmap-sessao.md
+++ b/docs/roadmap-sessao.md
@@ -6,6 +6,22 @@
 
 ---
 
+## 🔭 SESSÃO 2026-06-13 (bundles-lente) — Fluxo de Bundles da farmer lente-aware ("Ver como")
+
+> Pedido do founder: fechar o último vazamento da lente "Ver como" — o fluxo de BUNDLES
+> ainda exibe os DADOS DO MASTER quando o master impersona uma vendedora. As engines de IA
+> da carteira já viraram lente-aware (#796/#799); os engines de bundles ficaram de fora.
+> Segue o padrão validado em prod (CLAUDE.md §10). 100% frontend.
+
+- 🔄 **useBundleEngine** lente-aware (espelha `useCrossSellEngine`): leitura de exibição (`farmer_client_scores`/`farmer_recommendations`) → `effectiveUserId`; SEM fallback super-admin na lente; persistência (`farmer_association_rules` global + `farmer_bundle_recommendations`) PULADA com `if (!isImpersonating)`.
+- 🔄 **BundleCardFull** (leaf, lê `useImpersonation()` direto): "Perguntas SPIN"/"Argumentação"/"Salvar (sem oferta)"/"Salvar (ofertou)" `disabled={isImpersonating}` + title honesto.
+- 🔄 **useBundleArguments**: stateless (não lê carteira) → só os botões acima desabilitam; write-guard já bloqueia edge/insert na fonte → NÃO entra na allowlist.
+- 🔄 **Testes**: bloco `useBundleEngine` no `lens-engines-ia.test.tsx` (na lente lê do ALVO, fora do próprio) + `BundleCardFull.test.tsx` ganha mock de `useImpersonation` + caso "botões disabled na lente".
+- 🔄 **Guardrail** `no-write-leak.test.ts`: `useBundleEngine.ts` na allowlist (leitura justificada).
+- ⏳ Verificação `heavy bun run typecheck` + `bun lint` + `heavy bun run test`. **Publish no Lovable** ao final.
+
+---
+
 ## 📡 SESSÃO 2026-06-10 (radar) — Radar de Clientes: prospecção de empresas novas (estilo Omie)
 
 > Pedido do founder: "funcionalidade similar ao radar de clientes do Omie". Brainstorming

--- a/src/components/farmer/bundles/BundleCardFull.tsx
+++ b/src/components/farmer/bundles/BundleCardFull.tsx
@@ -2,6 +2,7 @@
 // Extraído verbatim de src/pages/FarmerBundles.tsx (god-component split).
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useImpersonation } from '@/contexts/ImpersonationContext';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import {
@@ -40,6 +41,11 @@ export const BundleCardFull = ({
   questions, isQuestionsGenerating, onGenerateQuestions, onSetResponse, onToggleAlt, onSaveQuestions,
 }: BundleCardFullProps) => {
   const navigate = useNavigate();
+  // Lente "Ver como": a geração (perguntas/argumentação via edge) e o save de respostas
+  // são WRITES — bloqueados na fonte pelo write-guard. Desabilitar os botões é UX honesta
+  // (evita o toast de erro do guard). A leitura/inspeção dos bundles do alvo segue normal.
+  const { isImpersonating } = useImpersonation();
+  const lensTitle = isImpersonating ? 'Indisponível em modo Ver como' : undefined;
   const [argTab, setArgTab] = useState<'phone' | 'whatsapp' | 'tecnica'>('phone');
   const [activeSection, setActiveSection] = useState<'none' | 'args' | 'questions'>('none');
   const [copied, setCopied] = useState(false);
@@ -92,6 +98,8 @@ export const BundleCardFull = ({
           size="sm"
           variant={activeSection === 'questions' ? 'default' : 'outline'}
           className="flex-1 h-7 text-[9px] gap-1"
+          disabled={isImpersonating}
+          title={lensTitle}
           onClick={() => {
             if (activeSection === 'questions') { setActiveSection('none'); return; }
             setActiveSection('questions');
@@ -104,6 +112,8 @@ export const BundleCardFull = ({
           size="sm"
           variant={activeSection === 'args' ? 'default' : 'outline'}
           className="flex-1 h-7 text-[9px] gap-1"
+          disabled={isImpersonating}
+          title={lensTitle}
           onClick={() => {
             if (activeSection === 'args') { setActiveSection('none'); return; }
             setActiveSection('args');
@@ -158,6 +168,8 @@ export const BundleCardFull = ({
                   size="sm"
                   variant="outline"
                   className="flex-1 h-7 text-[9px] gap-1"
+                  disabled={isImpersonating}
+                  title={lensTitle}
                   onClick={() => onSaveQuestions(false)}
                 >
                   <Save className="w-3 h-3" /> Salvar (sem oferta)
@@ -165,6 +177,8 @@ export const BundleCardFull = ({
                 <Button
                   size="sm"
                   className="flex-1 h-7 text-[9px] gap-1"
+                  disabled={isImpersonating}
+                  title={lensTitle}
                   onClick={() => onSaveQuestions(true)}
                 >
                   <Save className="w-3 h-3" /> Salvar (ofertou)

--- a/src/components/farmer/bundles/__tests__/BundleCardFull.test.tsx
+++ b/src/components/farmer/bundles/__tests__/BundleCardFull.test.tsx
@@ -1,10 +1,17 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { MemoryRouter } from "react-router-dom";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { BundleCardFull } from "../BundleCardFull";
 import type { BundleRecommendation } from "@/hooks/useBundleEngine";
 import type { CustomerProfile } from "@/hooks/useBundleArguments";
 import type { CustomerCtx } from "../types";
+
+// BundleCardFull lê useImpersonation() direto (leaf) pra desabilitar os botões de
+// gerar/salvar na lente "Ver como". Mock dinâmico: default fora da lente.
+const impMock = vi.fn();
+vi.mock("@/contexts/ImpersonationContext", () => ({ useImpersonation: () => impMock() }));
+
+beforeEach(() => { impMock.mockReturnValue({ isImpersonating: false }); });
 
 const bundle = {
   id: "b1",
@@ -80,5 +87,12 @@ describe("BundleCardFull", () => {
     const props = setup();
     fireEvent.click(screen.getByRole("button", { name: /Argumentação/ }));
     expect(props.onGenerateArg).toHaveBeenCalledTimes(1);
+  });
+
+  it("na lente: os botões de gerar (Perguntas SPIN / Argumentação) ficam disabled", () => {
+    impMock.mockReturnValue({ isImpersonating: true });
+    setup();
+    expect(screen.getByRole("button", { name: /Perguntas SPIN/ })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /Argumentação/ })).toBeDisabled();
   });
 });

--- a/src/hooks/__tests__/lens-engines-ia.test.tsx
+++ b/src/hooks/__tests__/lens-engines-ia.test.tsx
@@ -34,6 +34,7 @@ vi.mock('@/contexts/AuthContext', () => ({ useAuth: () => ({ user: { id: 'master
 import { useFarmerExperiments } from '../useFarmerExperiments';
 import { useCrossSellEngine } from '../useCrossSellEngine';
 import { useDiagnosticQuestions } from '../useDiagnosticQuestions';
+import { useBundleEngine } from '../useBundleEngine';
 
 beforeEach(() => {
   eqCalls.length = 0;
@@ -90,5 +91,23 @@ describe('useDiagnosticQuestions — lente "Ver como"', () => {
     const { result } = renderHook(() => useDiagnosticQuestions());
     await act(async () => { await result.current.getEffectivenessStats(); });
     expect(eqCalls.map((c) => c[1])).toContain('master-id');
+  });
+});
+
+describe('useBundleEngine — lente "Ver como"', () => {
+  it('na lente: lê os scores do ALVO (farmer_id) e não cai no fallback super-admin (todos)', async () => {
+    impMock.mockReturnValue({ isImpersonating: true, effectiveUserId: 'alvo-id' });
+    const { result } = renderHook(() => useBundleEngine());
+    await act(async () => { await result.current.calculateBundles(); });
+    const farmerEq = eqCalls.filter((c) => c[0] === 'farmer_id').map((c) => c[1]);
+    expect(farmerEq).toContain('alvo-id');
+    expect(farmerEq).not.toContain('master-id');
+  });
+
+  it('fora da lente: lê os scores do próprio usuário', async () => {
+    impMock.mockReturnValue({ isImpersonating: false, effectiveUserId: 'master-id' });
+    const { result } = renderHook(() => useBundleEngine());
+    await act(async () => { await result.current.calculateBundles(); });
+    expect(eqCalls.filter((c) => c[0] === 'farmer_id').map((c) => c[1])).toContain('master-id');
   });
 });

--- a/src/hooks/useBundleEngine.ts
+++ b/src/hooks/useBundleEngine.ts
@@ -1,7 +1,7 @@
 import { useState, useCallback } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import type { Json } from '@/integrations/supabase/types';
-import { useAuth } from '@/contexts/AuthContext';
+import { useImpersonation } from '@/contexts/ImpersonationContext';
 import { toast } from 'sonner';
 
 // ─── Types ───────────────────────────────────────────────────────────
@@ -142,14 +142,19 @@ const DEFAULT_CONFIG = {
 
 // ─── Main Hook ───────────────────────────────────────────────────────
 export const useBundleEngine = () => {
-  const { user } = useAuth();
+  // Lente "Ver como": id efetivo = ALVO na lente (lê/recalcula os bundles DELE pra
+  // inspeção), próprio usuário fora. Na lente a persistência (regras + recomendações)
+  // é PULADA (igual useCrossSellEngine/useFarmerScoring): o master inspeciona, não
+  // regrava a carteira do alvo. Fora da lente effectiveUserId === user.id (byte-
+  // equivalente, zero regressão).
+  const { effectiveUserId, isImpersonating } = useImpersonation();
   const [customerBundles, setCustomerBundles] = useState<CustomerBundles[]>([]);
   const [rules, setRules] = useState<AssociationRule[]>([]);
   const [loading, setLoading] = useState(false);
   const [calculating, setCalculating] = useState(false);
 
   const calculateBundles = useCallback(async (config = DEFAULT_CONFIG) => {
-    if (!user?.id) return;
+    if (!effectiveUserId) return;
     setCalculating(true);
     setLoading(true);
 
@@ -170,8 +175,11 @@ export const useBundleEngine = () => {
         return all;
       };
 
-      let clientScores = await fetchAllScores(user.id);
-      if (!clientScores.length) clientScores = await fetchAllScores();
+      // Try farmer-specific first, fallback to all (super_admin). Na lente NÃO cai no
+      // fallback "todos os scores" — escopa estritamente ao alvo (degradação honesta:
+      // alvo sem score → lista vazia, nunca a carteira de todo mundo).
+      let clientScores = await fetchAllScores(effectiveUserId);
+      if (!clientScores.length && !isImpersonating) clientScores = await fetchAllScores();
 
       const [
         { data: products },
@@ -352,19 +360,23 @@ export const useBundleEngine = () => {
       discoveredRules.sort((a, b) => b.lift - a.lift);
       setRules(discoveredRules.slice(0, 50)); // Keep top 50
 
-      // Persist top rules
-      await supabase.from('farmer_association_rules').delete().neq('id', '00000000-0000-0000-0000-000000000000');
-      if (discoveredRules.length > 0) {
-        const rulesToInsert = discoveredRules.slice(0, 50).map(r => ({
-          antecedent_product_ids: r.antecedent,
-          consequent_product_ids: r.consequent,
-          support: Math.round(r.support * 10000) / 10000,
-          confidence: Math.round(r.confidence * 10000) / 10000,
-          lift: Math.round(r.lift * 100) / 100,
-          rule_type: r.type,
-          sample_size: totalBaskets,
-        }));
-        await supabase.from('farmer_association_rules').insert(rulesToInsert);
+      // Persist top rules — PULADO na lente "Ver como" (a tabela é GLOBAL: o delete
+      // apaga as regras de toda a base; o master inspeciona os bundles do alvo sem
+      // recalcular regras/recomendações da carteira dele).
+      if (!isImpersonating) {
+        await supabase.from('farmer_association_rules').delete().neq('id', '00000000-0000-0000-0000-000000000000');
+        if (discoveredRules.length > 0) {
+          const rulesToInsert = discoveredRules.slice(0, 50).map(r => ({
+            antecedent_product_ids: r.antecedent,
+            consequent_product_ids: r.consequent,
+            support: Math.round(r.support * 10000) / 10000,
+            confidence: Math.round(r.confidence * 10000) / 10000,
+            lift: Math.round(r.lift * 100) / 100,
+            rule_type: r.type,
+            sample_size: totalBaskets,
+          }));
+          await supabase.from('farmer_association_rules').insert(rulesToInsert);
+        }
       }
 
       // 5. Generate bundles per customer
@@ -474,7 +486,7 @@ export const useBundleEngine = () => {
         const { data: existingRecs } = (await supabase
           .from('farmer_recommendations')
           .select('product_id, lie, recommendation_type')
-          .eq('farmer_id', user.id)
+          .eq('farmer_id', effectiveUserId)
           .eq('customer_user_id', cid)
           .eq('status', 'pendente')
           .order('lie', { ascending: false })
@@ -521,22 +533,25 @@ export const useBundleEngine = () => {
 
       setCustomerBundles(allCustomerBundles);
 
-      // Persist bundle recommendations
-      for (const cb of allCustomerBundles) {
-        for (const bundle of cb.bundles) {
-          await supabase.from('farmer_bundle_recommendations').insert({
-            farmer_id: user.id,
-            customer_user_id: bundle.customerId,
-            bundle_products: bundle.products as unknown as Json,
-            support: bundle.support,
-            confidence: bundle.confidence,
-            lift: bundle.lift,
-            p_bundle: bundle.pBundle,
-            m_bundle: bundle.mBundle,
-            lie_bundle: bundle.lieBundle,
-            complexity_factor: bundle.complexityFactor,
-            status: 'pendente',
-          });
+      // Persist bundle recommendations — PULADO na lente "Ver como" (só leitura: o
+      // master inspeciona os bundles do alvo sem regravar a carteira dele).
+      if (!isImpersonating) {
+        for (const cb of allCustomerBundles) {
+          for (const bundle of cb.bundles) {
+            await supabase.from('farmer_bundle_recommendations').insert({
+              farmer_id: effectiveUserId,
+              customer_user_id: bundle.customerId,
+              bundle_products: bundle.products as unknown as Json,
+              support: bundle.support,
+              confidence: bundle.confidence,
+              lift: bundle.lift,
+              p_bundle: bundle.pBundle,
+              m_bundle: bundle.mBundle,
+              lie_bundle: bundle.lieBundle,
+              complexity_factor: bundle.complexityFactor,
+              status: 'pendente',
+            });
+          }
         }
       }
 
@@ -548,7 +563,7 @@ export const useBundleEngine = () => {
       setCalculating(false);
       setLoading(false);
     }
-  }, [user?.id]);
+  }, [effectiveUserId, isImpersonating]);
 
   // ─── Actions ─────────────────────────────────────────────────────────
   const markBundleOffered = useCallback(async (bundleId: string) => {

--- a/src/lib/impersonation/__tests__/no-write-leak.test.ts
+++ b/src/lib/impersonation/__tests__/no-write-leak.test.ts
@@ -58,6 +58,11 @@ const ALLOWED = new Set([
   // ("todos os scores"). A PERSISTÊNCIA (upsert de farmer_recommendations) é PULADA na
   // lente — o master inspeciona, não regrava a carteira do alvo (igual useFarmerScoring).
   'src/hooks/useCrossSellEngine.ts',
+  // useBundleEngine: idêntico ao useCrossSellEngine — effectiveUserId escopa a LEITURA
+  // dos scores + do "melhor individual" (farmer_recommendations) ao alvo na lente, sem
+  // cair no fallback super-admin. A PERSISTÊNCIA (farmer_association_rules GLOBAL +
+  // farmer_bundle_recommendations) é PULADA na lente (if !isImpersonating).
+  'src/hooks/useBundleEngine.ts',
   // useFarmerExperiments: effectiveUserId SÓ em loadExperiments (filtra a LISTA exibida
   // pro alvo na lente). As mutations (criar/iniciar/medir/cancelar) usam user.id (write
   // identity = master real) e são bloqueadas na lente pelo write-guard + botões disabled.


### PR DESCRIPTION
## Problema

Ao impersonar uma vendedora pela lente **"Ver como pessoa"**, as telas de **bundles** ainda exibiam os **DADOS DO MASTER** (vazamento). As engines de IA da carteira já viraram lente-aware (cross-sell/experiments/diagnostic/tactical-plan/copilot em #796+#799), mas o fluxo de bundles ficou de fora porque seus engines primários não estavam naquele escopo. Este PR fecha o gap, seguindo o padrão validado em prod (CLAUDE.md §10).

## O que muda (100% frontend)

- **`useBundleEngine`** (espelha `useCrossSellEngine` verbatim):
  - leitura de exibição (`farmer_client_scores` + `farmer_recommendations` p/ o "melhor individual") escopada ao **ALVO** via `effectiveUserId`;
  - **SEM** o fallback super-admin "todos os scores" na lente (`if (!clientScores.length && !isImpersonating)`) — degradação honesta: alvo sem score → lista vazia, nunca a carteira de todo mundo;
  - **persistência PULADA** na lente com `if (!isImpersonating)`: `farmer_association_rules` (tabela **GLOBAL** — o delete apaga as regras de toda a base) **e** `farmer_bundle_recommendations`. O `setRules`/`setCustomerBundles` (display) seguem rodando — o master **inspeciona** os bundles do alvo, não recalcula a carteira dele.
- **`BundleCardFull`** (leaf, lê `useImpersonation()` direto — idioma do `MixGapCard`): botões **"Perguntas SPIN"**, **"Argumentação"**, **"Salvar (sem oferta)"** e **"Salvar (ofertou)"** ficam `disabled={isImpersonating}` + `title` honesto. É UX sobre o write-guard, que já bloqueia o edge/insert na fonte.
- **`useBundleArguments`**: stateless (não lê carteira) → coberto pelos botões acima; não entra na allowlist.

Fora da lente `effectiveUserId === user.id` (byte-equivalente, **zero regressão**).

## Testes (TDD red→green)

- **`lens-engines-ia.test.tsx`**: bloco `useBundleEngine` — na lente o `.eq('farmer_id', …)` usa o id do **ALVO** e nunca o do master; fora, o próprio usuário. (Falhava com `[ 'master-id' ] to include 'alvo-id'` antes do fix.)
- **`BundleCardFull.test.tsx`**: ganha mock de `useImpersonation` + caso "na lente os botões de gerar ficam disabled".
- **Guardrail `no-write-leak.test.ts`**: `useBundleEngine.ts` na allowlist (leitura justificada).

## Verificação

- `bun run typecheck` (strict): **0 erros**
- `bun lint`: **0 errors** (76 warnings pré-existentes de `exhaustive-deps`, nenhum nos arquivos tocados)
- `bun run test`: **3299/3299** passando

## Decisão consciente de escopo

O botão **"Montar pedido com este bundle"** (navega p/ `/sales/new`) **não** foi desabilitado — fora do escopo (a tarefa lista os 4 botões de gerar/salvar); é navegação p/ o fluxo de pedido, que tem suas próprias guardas (o submit é bloqueado pelo write-guard na lente). Trivial adicionar depois se o founder quiser.

## Follow-up do founder

⚠️ **Publish no Lovable** — é 100% frontend, então a feature só vai ao ar após o Publish (mergear na main não basta).

🤖 Generated with [Claude Code](https://claude.com/claude-code)