### PR TITLE
feat(kpis): dashboard master + coerência com o OTE (banner de dados parciais)

### DIFF
--- a/docs/superpowers/specs/2026-06-06-kpis-farmer-meu-dia-design.md
+++ b/docs/superpowers/specs/2026-06-06-kpis-farmer-meu-dia-design.md
@@ -4,6 +4,13 @@
 **Autor:** Claude (decisão solo; ⚠️ Codex fora por usage limit do Plus — **validação adversária retroativa pendente**, padrão do CLAUDE.md "Caminho B")
 **Status:** aprovado pelo founder pra implementar ("decido você e o Codex... pode ir implementando sem me perguntar")
 
+## ⚠️ Coerência com o OTE (atualização 2026-06-13, eu+Codex)
+
+Estes KPIs são **placar de visibilidade (gestão)**, NÃO a engine de comissão. A elegibilidade pra remuneração é definida **exclusivamente** pelo spec vigente de OTE (`2026-06-13-ote-remuneracao-variavel-farmer-design.md`) — qualquer rótulo "comissionável/output/higiene" abaixo é classificação de **design de dashboard**, não de pagamento. O OTE está em DESIGN (não-pronto pra virar folha). Divergências a reconciliar quando ele virar implementação:
+- **Dados parciais:** receita/positivação vêm de `sales_orders`, que cobre só uma fração do faturamento da Oben (backfill histórico pendente) → `DadosVendaParciaisBanner` avisa no dashboard; **não usar pra comissão até reconciliar**.
+- **Janela:** aqui é MTD (operacional); o OTE usa **quota trimestral cumulativa** (anti-Parkinson). A copy "do mês" é descritiva, não imperativa — migrar pra trimestral quando houver quota no sistema.
+- **Específico farmer:** **win-back** é placar de gestão (o OTE só talvez paga em V3); a **positivação** aqui **não tem ticket mínimo** (o OTE exige — pedido de R$1 não conta); **Receita MTD** é observação, não base (o OTE paga receita-vs-quota na V1 / margem-padrão na V2). A classificação "comissionável" da tabela abaixo é superseded por este aviso.
+
 ## Contexto / problema
 
 A lente "Ver como pessoa" expôs que o dashboard "Meu Dia" da **farmer** (account manager de carteira, tipo a Tatyana) mostra cards de **visita** — que não é o trabalho dela (visita é do "closer"). Investigando, achei que:

--- a/docs/superpowers/specs/2026-06-13-kpis-closer-meu-dia-design.md
+++ b/docs/superpowers/specs/2026-06-13-kpis-closer-meu-dia-design.md
@@ -4,6 +4,12 @@
 **Autor:** Claude + **Codex (gpt-5.5, consult, web search — citou IFRS 15)** — 2ª opinião conforme CLAUDE.md §12.
 **Status:** aprovado pelo founder pra implementar (frente "expandir"; farmer #690, hunter #795).
 
+## ⚠️ Coerência com o OTE (atualização 2026-06-13, eu+Codex)
+
+Estes KPIs são **placar de visibilidade (gestão)**, NÃO a engine de comissão. A elegibilidade pra remuneração é definida **exclusivamente** pelo spec vigente de OTE (`2026-06-13-ote-remuneracao-variavel-farmer-design.md`). O OTE está em DESIGN. Notas:
+- **Específico closer:** o OTE atual cobre **só farmers** — o closer ainda não tem modelo de comissão. O placar aqui é **valor auto-reportado** (`route_visits.revenue_generated`, não-ERP) → já é não-comissionável por construção, e **não** depende de `sales_orders` (logo, não leva o `DadosVendaParciaisBanner`).
+- **Janela:** MTD (operacional) × quota trimestral cumulativa que o OTE usará quando expandir pro closer (mesma filosofia: margem>receita, liberação no recebimento).
+
 ## Contexto / problema
 
 3ª persona da redefinição de KPIs por papel no `/meu-dia`. O **closer** = visita presencial / outbound / fechamento (≠ hunter inbound, ≠ farmer account-management por ligação).

--- a/docs/superpowers/specs/2026-06-13-kpis-hunter-meu-dia-design.md
+++ b/docs/superpowers/specs/2026-06-13-kpis-hunter-meu-dia-design.md
@@ -4,6 +4,13 @@
 **Autor:** Claude + **Codex (gpt-5.5, consult, reasoning high)** — 2ª opinião conforme CLAUDE.md §12.
 **Status:** aprovado pelo founder pra implementar (frente "começar pela farmer e expandir" — farmer feita em #690; hunter→closer→master em PRs separados).
 
+## ⚠️ Coerência com o OTE (atualização 2026-06-13, eu+Codex)
+
+Estes KPIs são **placar de visibilidade (gestão)**, NÃO a engine de comissão. A elegibilidade pra remuneração é definida **exclusivamente** pelo spec vigente de OTE (`2026-06-13-ote-remuneracao-variavel-farmer-design.md`) — os rótulos abaixo são design de dashboard, não pagamento. O OTE está em DESIGN. Divergências a reconciliar:
+- **Dados parciais:** receita/novos vêm de `sales_orders`, hoje parcial (backfill pendente) → `DadosVendaParciaisBanner` avisa; **não usar pra comissão**.
+- **Janela:** MTD (operacional) × quota trimestral cumulativa do OTE.
+- **Específico hunter:** o KPI-norte (novos na carteira) já é **proxy não-comissionável** — coerente com o OTE. O OTE trata aquisição como **bounty por cliente** (50/25/25, V2/V3), não % perpétuo — alinha com o `acquired_by_user_id` imutável já registrado nos gaps v2.
+
 ## Contexto / problema
 
 Continuação da redefinição de KPIs por persona (a farmer foi a 1ª — `docs/superpowers/specs/2026-06-06-kpis-farmer-meu-dia-design.md`). O `/meu-dia` roteia por `commercial_role` (lente-aware) e cada papel tem seu dashboard. Os dashboards foram montados **ad-hoc** e **vazam cards entre personas**.

--- a/docs/superpowers/specs/2026-06-13-kpis-master-meu-dia-design.md
+++ b/docs/superpowers/specs/2026-06-13-kpis-master-meu-dia-design.md
@@ -4,6 +4,14 @@
 **Autor:** Claude + **Codex (gpt-5.5, consult)** — 2ª opinião conforme CLAUDE.md §12.
 **Status:** aprovado pelo founder pra implementar (frente "expandir"; farmer #690, hunter #795, closer #797).
 
+## ⚠️ Coerência com o OTE (atualização 2026-06-13, eu+Codex)
+
+Estes KPIs são **placar de visibilidade (gestão)**, NÃO a engine de comissão. A elegibilidade pra remuneração é definida **exclusivamente** pelo spec vigente de OTE (`2026-06-13-ote-remuneracao-variavel-farmer-design.md`). O OTE está em DESIGN. Divergências a reconciliar:
+- **Dados parciais:** "Receita do time" e o ranking vêm de `sales_orders`, hoje parcial (backfill pendente) → `DadosVendaParciaisBanner` avisa; **não usar pra comissão/decisão dura até reconciliar**.
+- **Trend MoM (`TeamKpiTiles`):** ⚠️ suspeito sob cobertura parcial — comparar duas janelas (mês atual × anterior) com coberturas diferentes distorce a tendência. **NÃO removido aqui** (é trabalho recém-mergeado da frente `master-receita-trend`; remover unilateralmente = treadmill/conflito multi-sessão). O banner mitiga; aquela frente deve **condicionar/ocultar o MoM** quando o backfill rodar. (Divergência fundamentada com o Codex, que sugeria remover o MoM já.)
+- **Painel de saúde do OTE:** o OTE §14 prevê % batendo quota / CCOS / distribuição de atingimento (saúde do MODELO, não KPI do vendedor) → entra no master **quando o OTE rodar**, não agora.
+- **Janela:** MTD (operacional) × quota trimestral cumulativa do OTE.
+
 ## Contexto / problema
 
 Última persona da redefinição de KPIs por papel no `/meu-dia`. O **master** é o founder/CEO (também atua como vendedor de campo). Trabalho-norte = **gerir o time** (visão consolidada + gestão por exceção) + as próprias vendas.

--- a/docs/superpowers/specs/2026-06-13-kpis-master-meu-dia-design.md
+++ b/docs/superpowers/specs/2026-06-13-kpis-master-meu-dia-design.md
@@ -1,0 +1,63 @@
+# KPIs de nível mundial do MASTER — Meu Dia (design)
+
+**Data:** 2026-06-13
+**Autor:** Claude + **Codex (gpt-5.5, consult)** — 2ª opinião conforme CLAUDE.md §12.
+**Status:** aprovado pelo founder pra implementar (frente "expandir"; farmer #690, hunter #795, closer #797).
+
+## Contexto / problema
+
+Última persona da redefinição de KPIs por papel no `/meu-dia`. O **master** é o founder/CEO (também atua como vendedor de campo). Trabalho-norte = **gerir o time** (visão consolidada + gestão por exceção) + as próprias vendas.
+
+O `MasterDashboard` **já tem os componentes certos** (validados em specs anteriores — `2026-06-04-master-visao-time-design.md`): `TeamKpiTiles` (receita do time MTD + trend MoM, ativos), `RankingVendedoresCard` (ranking MTD), `GestorExcecoes` (Buddy v2 — gestão por exceção), `ViewAsPicker` ("Ver como"). Mas a **ordem está errada**: lidera com `AtivarNotificacoesCard` (push opt-in) + `VisitSuggestionsCard` (sugestão de visita — trabalho de closer) + `ViewAsPicker`, e o **placar de time + exceções** (o trabalho diário do CEO) ficam no meio/fim. O comentário "Placeholder rico até PR-MULTIVENDOR-V2" está **stale** (o ranking já existe). E "Meus KPIs (como Closer)" usa `KpisToday`, que mede **ligações** (`farmer_calls`), não visitas.
+
+## KPIs de nível mundial do master (sales management)
+
+Framework do Codex: **"Estamos ganhando?" → "O que exige ação?" → "Quem/onde explica o resultado?" → "minha operação"**.
+
+| Bloco | Papel | Tipo | Observação |
+|---|---|---|---|
+| **Receita do time MTD (+ trend MoM)** ⭐ | "estamos ganhando?" | output | `TeamKpiTiles` (já existe) — escopo do CompanySwitcher |
+| **Exceções** (`GestorExcecoes`) | "o que exige ação?" | acionável | Buddy v2 — transforma diagnóstico em ação; lidera com Dados quebrados |
+| **Ranking + ativos** | "quem/onde explica?" | diagnóstico | `RankingVendedoresCard` — decomposição do placar |
+| **Ver como** (`ViewAsPicker`) | ferramenta de investigação | — | após exceções/ranking |
+| **Minha operação** (`ClosersMtdHero`) | vendas próprias do master-como-closer | output (próprio) | visitas MTD; abaixo da gestão |
+| Caça / Push | atalho / config | — | fim |
+
+### Decisões do Codex (incorporadas)
+1. **Ordem**: placar de receita (compacto) → exceções → ranking/ativos (decomposição) → Ver como → "Minha operação" → ferramentas/config. "Vendedores ativos" é **saúde**, não norte; **ranking é diagnóstico, não placar** → ambos abaixo do placar de receita.
+2. **`VisitSuggestionsCard`: REMOVER** da visão master padrão (não só descer — descer mantém ruído + mistura papéis). Continua no `CloserDashboard`.
+3. **"Minha operação" usa `ClosersMtdHero`** (visitas MTD), não `KpisToday`: o master-como-closer é VISITA, e o `KpisToday` mede ligações (rótulo "como Closer" era enganoso). **Não misturar** os dois (recriaria dashboard genérico de atividade). → remover `KpisToday` do master.
+4. **Comentário stale** atualizado.
+5. **Dados quebrados crítico**: o `GestorExcecoes` já lidera por dependência com "Dados quebrados" (Sentinela) — ao colocá-lo logo após o placar, o alerta de dado quebrado fica imediatamente abaixo dos números (sinaliza que o placar pode estar comprometido). O ideal do Codex (alerta ACIMA do placar) fica como refinamento v2 (exigiria extrair o grupo de dados do `GestorExcecoes`).
+
+### Anti-gaming / honestidade (registrado, não-bloqueante)
+- **`created_by` mede quem LANÇOU o pedido, não quem vendeu.** O `RankingVendedoresCard` já rotula "por quem lançou o pedido" (honesto). O `TeamKpiTiles` "Receita time" é agregado (não atribuído a vendedor) → menos crítico. **Não comissionável** até existir `sold_by`/`owner_id` (v2).
+- **Ranking self-hide sem pedidos**: pro gestor, zero pedido no mês é INFO CRÍTICA, não ausência. Hoje o card some quando não há pedido. → registrado como refinamento v2 (mostrar "nenhum pedido no mês" em vez de sumir).
+
+## Mudanças (100% frontend, sem migration/edge)
+
+### `src/components/dashboard/MasterDashboard.tsx` (reordenar + trocar/remover)
+Ordem nova: **header → `TeamKpiTiles` (placar) → `GestorExcecoes` (exceções) → `RankingVendedoresCard` (decomposição) → `ViewAsPicker` (+ `MinhasTarefasCard` da lente) → "Minha operação" (`ClosersMtdHero`) → link Caça → `AtivarNotificacoesCard` (push, fim)**. **REMOVER** `VisitSuggestionsCard`. **TROCAR** `KpisToday` ("Meus KPIs como Closer") por `ClosersMtdHero` ("Minha operação"). Atualizar o comentário stale do componente.
+
+⚠️ **NÃO tocar** `TeamKpiTiles`/`RankingVendedoresCard`/`useTeamKpis` (validados no spec 2026-06-04; evita colisão com a frente MoM já mergeada). As notas anti-gaming/ranking-self-hide ficam como v2.
+
+`ClosersMtdHero` é reusado do PR do closer (#797) — por isso o master mergeia DEPOIS do closer.
+
+## Não-objetivos (v1)
+- Meta do time / % de atingimento / forecast / pipeline coverage — "precisão teatral" sem meta/pipeline/snapshots (v2).
+- `sold_by` separado de `created_by` — v2.
+- Refatorar `TeamKpiTiles`/`RankingVendedoresCard` (anti-gaming labels, ranking self-hide) — v2.
+- Extrair "Dados quebrados" pra um alerta acima do placar — v2.
+
+## Gaps v2 (registrados)
+1. **`sold_by` ≠ `created_by`** (atribuição de venda real, base de OTE).
+2. **Metas por empresa/vendedor/período** → receita MTD vs meta + ritmo projetado (o placar de gestão de verdade).
+3. **Regra explícita do founder dentro/fora da receita do "time".**
+4. **Pipeline (estágio/valor/data) + snapshots** → forecast accuracy, coverage.
+5. **Política de cancelamento/devolução** na receita; timezone/data de receita auditável.
+6. **Definição auditável de "vendedor ativo"** (hoje qualquer atividade conta).
+7. **Ranking não-some sem pedidos** (zero é info crítica pro gestor).
+
+## Verificação
+- `MasterDashboard` lidera com `TeamKpiTiles` + `GestorExcecoes`; não renderiza `VisitSuggestionsCard` nem `KpisToday`; renderiza `ClosersMtdHero` em "Minha operação".
+- `bun run typecheck` + `bun lint` + `bun run test` (inclui o guardrail no-write-leak).

--- a/src/components/dashboard/DadosVendaParciaisBanner.tsx
+++ b/src/components/dashboard/DadosVendaParciaisBanner.tsx
@@ -1,0 +1,32 @@
+import { AlertTriangle } from 'lucide-react';
+import { Card } from '@/components/ui/card';
+
+/**
+ * Aviso de dados de venda parciais.
+ *
+ * Os números de venda/positivação destes dashboards vêm de `sales_orders`/`order_items`,
+ * que hoje cobrem só uma fração do faturamento real (o `sync_pedidos` roda em janela
+ * rolante curta, sem backfill histórico — gap mapeado no CLAUDE.md / sessão push-vendedora
+ * e confirmado pelo spec de OTE). Logo, receita, positivação, novos clientes e ticket
+ * aparecem SUBESTIMADOS até o backfill concluir.
+ *
+ * Honestidade > precisão falsa: o banner avisa que é visão operacional, NÃO base de
+ * comissão (a remuneração é definida pelo spec vigente de OTE, sobre dado reconciliado).
+ * NÃO fixa o "%" de cobertura (envelhece) — é qualitativo e reversível: quando o backfill
+ * rodar e houver uma métrica de cobertura, remover/condicionar este componente.
+ */
+export function DadosVendaParciaisBanner() {
+  return (
+    <Card className="p-3 border-status-warning/40 bg-status-warning-bg/40">
+      <div className="flex items-start gap-2.5">
+        <AlertTriangle className="w-4 h-4 text-status-warning shrink-0 mt-0.5" />
+        <div className="text-2xs text-muted-foreground leading-relaxed">
+          <span className="font-medium text-status-warning">Dados de venda parciais.</span>{' '}
+          Os números de venda e positivação consideram apenas pedidos já sincronizados no app,
+          que ainda não cobrem todo o faturamento (backfill pendente) — então aparecem
+          subestimados. Use como visão operacional, <span className="font-medium">não como base de comissão</span>.
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/src/components/dashboard/FarmerDashboardV2.tsx
+++ b/src/components/dashboard/FarmerDashboardV2.tsx
@@ -12,6 +12,7 @@ import { SlaCardMeuDia } from '@/components/whatsapp/SlaCardMeuDia';
 import { FilaDoDia } from '@/components/fila/FilaDoDia';
 import { PositivacaoHero } from '@/components/farmer/PositivacaoHero';
 import { useMyPositivacao } from '@/hooks/useMyPositivacao';
+import { DadosVendaParciaisBanner } from './DadosVendaParciaisBanner';
 import { AtivarNotificacoesCard } from '@/components/push/AtivarNotificacoesCard';
 import { ChamadasPendentesNudge } from '@/components/farmer/ChamadasPendentesNudge';
 
@@ -46,6 +47,9 @@ export function FarmerDashboardV2() {
 
       {/* Opt-in de Web Push — some quando ativo/negado/sem suporte/dispensado */}
       <AtivarNotificacoesCard />
+
+      {/* Receita/positivação vêm de sales_orders, hoje parcial (backfill pendente) → aviso honesto */}
+      <DadosVendaParciaisBanner />
 
       {/* Placar do mês (KPIs da carteira) — o norte da farmer */}
       {positivacao && <PositivacaoHero kpis={positivacao} isHunter={false} />}

--- a/src/components/dashboard/HunterDashboard.tsx
+++ b/src/components/dashboard/HunterDashboard.tsx
@@ -3,6 +3,7 @@ import { CacaConteudo } from '@/components/caca/CacaConteudo';
 import { ChamadasPendentesNudge } from '@/components/farmer/ChamadasPendentesNudge';
 import { PositivacaoHero } from '@/components/farmer/PositivacaoHero';
 import { useMyPositivacao } from '@/hooks/useMyPositivacao';
+import { DadosVendaParciaisBanner } from './DadosVendaParciaisBanner';
 
 /**
  * Dashboard Hunter (aquisição) — Meu Dia do hunter.
@@ -27,6 +28,9 @@ export function HunterDashboard() {
           Seu placar de aquisição e a fila de caça: clientes parecidos com os melhores que ainda não compram.
         </p>
       </div>
+
+      {/* Receita/novos vêm de sales_orders, hoje parcial (backfill pendente) → aviso honesto */}
+      <DadosVendaParciaisBanner />
 
       {/* Placar de aquisição — o norte do hunter (proxy honesto, não-OTE ainda) */}
       {positivacao && <PositivacaoHero kpis={positivacao} isHunter={true} />}

--- a/src/components/dashboard/MasterDashboard.tsx
+++ b/src/components/dashboard/MasterDashboard.tsx
@@ -1,19 +1,25 @@
 import { Link } from 'react-router-dom';
 import { Target, ChevronRight } from 'lucide-react';
 import { Card } from '@/components/ui/card';
-import { KpisToday } from './KpisToday';
 import { TeamKpiTiles } from './TeamKpiTiles';
 import { RankingVendedoresCard } from './RankingVendedoresCard';
-import { VisitSuggestionsCard } from './VisitSuggestionsCard';
+import { GestorExcecoes } from './GestorExcecoes';
+import { ClosersMtdHero } from './ClosersMtdHero';
+import { DadosVendaParciaisBanner } from './DadosVendaParciaisBanner';
 import { ViewAsPicker } from '@/components/impersonation/ViewAsPicker';
 import { MinhasTarefasCard } from '@/components/tarefas/MinhasTarefasCard';
-import { GestorExcecoes } from './GestorExcecoes';
 import { AtivarNotificacoesCard } from '@/components/push/AtivarNotificacoesCard';
 
 /**
- * Dashboard Master (CEO) — visão consolidada do time + KPIs próprios (você
- * também é Closer). Placeholder rico até PR-MULTIVENDOR-V2 implementar ranking
- * de vendedores + métricas agregadas.
+ * Dashboard Master (CEO) — lidera com a VISÃO DE TIME e a GESTÃO POR EXCEÇÃO (o
+ * trabalho diário do founder), depois ranking (decomposição do placar), a
+ * ferramenta "Ver como", e por fim a operação PRÓPRIA do master-como-closer.
+ *
+ * Ordem validada com Codex (docs/superpowers/specs/2026-06-13-kpis-master-meu-dia-design.md):
+ * "estamos ganhando? → o que exige ação? → quem/onde explica? → minha operação".
+ * O VisitSuggestionsCard (sugestão de visita) saiu — é trabalho de closer, não
+ * gestão. O KpisToday saiu de "como Closer" (mede LIGAÇÕES): "Minha operação" usa
+ * ClosersMtdHero (visitas MTD), coerente com o papel.
  */
 export function MasterDashboard() {
   return (
@@ -21,22 +27,34 @@ export function MasterDashboard() {
       <div>
         <h1 className="text-xl font-semibold">Dashboard Master (CEO)</h1>
         <p className="text-xs text-muted-foreground">
-          Visão consolidada do time. KPIs agregados, ranking de vendedores, alertas estratégicos.
+          Visão consolidada do time, gestão por exceção e ranking. O escopo segue a empresa do seletor.
         </p>
       </div>
 
-      {/* Opt-in de Web Push — master também recebe (e é o device do smoke);
-          some quando ativo/negado/sem suporte/dispensado */}
-      <AtivarNotificacoesCard />
+      {/* Receita/positivação vêm de sales_orders, hoje parcial (backfill pendente) → aviso honesto */}
+      <DadosVendaParciaisBanner />
 
-      {/* Sugestões de visita — PR-VISIT-INTELLIGENCE Sub-PR A */}
-      <VisitSuggestionsCard />
+      {/* "Estamos ganhando?" — placar de time (receita MTD + trend, ativos) */}
+      <TeamKpiTiles />
 
-      {/* Ver como — master entra na visão de um vendedor (somente leitura) */}
+      {/* "O que exige ação?" — gestão por exceção (Buddy v2). Lidera por dependência com
+          Dados quebrados, que invalidam o placar acima. */}
+      <GestorExcecoes />
+
+      {/* "Quem/onde explica?" — ranking de vendedores do mês (decomposição do placar) */}
+      <RankingVendedoresCard />
+
+      {/* Ferramenta de investigação: master entra na visão de um vendedor (somente leitura) */}
       <ViewAsPicker />
 
       {/* Tarefas do vendedor sendo visto via "Ver como" (somente leitura; some sem impersonação) */}
       <MinhasTarefasCard />
+
+      {/* "Minha operação" — o master também é Closer (suas visitas do mês) */}
+      <div className="space-y-2">
+        <div className="text-xs uppercase tracking-wide text-muted-foreground">Minha operação</div>
+        <ClosersMtdHero />
+      </div>
 
       {/* Atalho discreto pra fila de caça (Frente B) — master acessa sem trocar de papel */}
       <Link to="/caca" className="block">
@@ -52,21 +70,8 @@ export function MasterDashboard() {
         </Card>
       </Link>
 
-      {/* GestorBuddy — console de exceções (Buddy v2) */}
-      <GestorExcecoes />
-
-      {/* KPIs do próprio Master (também é Closer) */}
-      <div className="space-y-2">
-        <div className="text-xs uppercase tracking-wide text-muted-foreground">Meus KPIs (como Closer)</div>
-        <KpisToday />
-      </div>
-
-      {/* KPIs de time (read-only, escopo da empresa ativa do CompanySwitcher) */}
-      <div className="space-y-2">
-        <div className="text-xs uppercase tracking-wide text-muted-foreground">Time</div>
-        <TeamKpiTiles />
-        <RankingVendedoresCard />
-      </div>
+      {/* Opt-in de Web Push (config) — some quando ativo/negado/sem suporte/dispensado */}
+      <AtivarNotificacoesCard />
     </div>
   );
 }


### PR DESCRIPTION
## O quê
Fecha a frente de redefinição de KPIs por persona (farmer #690, hunter #795, closer #797) com o **dashboard do MASTER** + uma passada de **coerência com a sessão paralela de OTE** (remuneração variável). 100% frontend.

## Master (2ª opinião do Codex)
Lidera com a **visão de time** e a **gestão por exceção** (trabalho do CEO): `TeamKpiTiles` → `GestorExcecoes` → `RankingVendedoresCard` → `ViewAsPicker` → **"Minha operação"** (`ClosersMtdHero`) → Caça → Push. **Remove** `VisitSuggestionsCard` (trabalho de closer) e troca `KpisToday` ("como Closer", que mede **ligações**) por `ClosersMtdHero` (visitas). Atualiza o comentário stale ("placeholder até PR-MULTIVENDOR-V2" — o ranking já existe).

## Coerência com o OTE (decisão eu + Codex)
Descobri a sessão paralela de OTE (`docs/superpowers/specs/2026-06-13-ote-remuneracao-variavel-farmer-design.md`). **Princípio:** dashboard = visibilidade; **spec de OTE = única fonte de verdade de remuneração**. Não implementei trimestre/margem/CCOS (OTE em design, não-pronto).
- 🔴 **Banner "Dados de venda parciais"** (componente novo, âmbar, sem fixar "%") nos 3 dashboards que leem `sales_orders` (master/farmer/hunter): receita/positivação aparecem **subestimadas até o backfill histórico da Oben**; "não usar pra comissão". O **closer não leva** (lê `route_visits` auto-reportado).
- 📝 **4 specs** ganham seção "Coerência com o OTE" — rótulos aqui são visibilidade, não pagamento; divergências registradas (win-back=gestão, ticket mínimo na positivação, receita-vs-quota, janela MTD×trimestral).

### 2 divergências fundamentadas com o Codex (nos specs)
1. **Não removi o MoM** do `TeamKpiTiles` — é trabalho recém-mergeado de outra frente (`master-receita-trend`); remover unilateralmente = treadmill multi-sessão. O banner mitiga; aquela frente condiciona quando o backfill rodar.
2. **Não renomeei "Receita"→"Pedidos sincronizados"** — o banner já contextualiza; rename é churn reversível desnecessário.

## Verificação
- `bun run typecheck` ✅ · `bun lint` 0 erros ✅ · `bun run test` **3272/3272** ✅

## Adiado (registrado nos specs, depende do OTE virar implementação)
Janela trimestral cumulativa, margem em shadow, painel de saúde do OTE no master (% batendo quota/CCOS). **Backfill** (raiz dos dados parciais) é da frente push-vendedora/sync.

Specs: `docs/superpowers/specs/2026-06-13-kpis-master-meu-dia-design.md` (+ farmer/hunter/closer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)