### PR TITLE
fix(roteirizador): tela não trava mais no spinner eterno

### DIFF
--- a/src/pages/AdminRoutePlanner.tsx
+++ b/src/pages/AdminRoutePlanner.tsx
@@ -91,7 +91,9 @@ const AdminRoutePlanner = () => {
     }).addTo(leafletMap.current);
     markersRef.current = L.layerGroup().addTo(leafletMap.current);
     return () => { leafletMap.current?.remove(); leafletMap.current = null; };
-  }, [loading]);
+    // Inicializa o mapa quando a tela renderiza (auth pronto), NÃO quando a carga
+    // logística termina — senão uma query pendurada travava o mapa junto com a tela.
+  }, [authLoading]);
 
   // Update map markers
   useEffect(() => {
@@ -141,7 +143,10 @@ const AdminRoutePlanner = () => {
     leafletMap.current.fitBounds(bounds, { padding: [40, 40] });
   }, [optimizedRoute]);
 
-  const isLoading = authLoading || loading;
+  // Só o auth bloqueia a tela inteira. A carga logística (`loading`) e as demais
+  // cargas (scoring/prospects) têm loading INLINE por seção — uma query pendurada
+  // (ex.: pedidos) não pode mais travar a tela toda no spinner eterno.
+  const isLoading = authLoading;
 
   if (isLoading) {
     return (
@@ -236,8 +241,16 @@ const AdminRoutePlanner = () => {
               </CardContent>
             </Card>
           )}
+          {loading && planningMode !== 'prospeccao' && (
+            <Card>
+              <CardContent className="py-6 flex items-center justify-center gap-3">
+                <Loader2 className="w-5 h-5 animate-spin text-primary" />
+                <span className="text-sm text-muted-foreground">Carregando paradas...</span>
+              </CardContent>
+            </Card>
+          )}
 
-          {optimizedRoute.length === 0 && !scoringLoading && !loadingProspects ? (
+          {optimizedRoute.length === 0 && !scoringLoading && !loadingProspects && !loading ? (
             <Card>
               <CardContent className="py-8 text-center text-muted-foreground">
                 {planningMode === 'logistica' ? 'Nenhum pedido com coleta/entrega pendente.'


### PR DESCRIPTION
## Fix: o Roteirizador travava no spinner eterno

**Bug reportado pelo founder:** `/admin/route-planner` ficava "apenas girando (carregando)" e era impossível chegar aos botões (inclusive o de abrir no Google Maps).

**Causa:** o spinner de tela cheia dependia de `authLoading || loading`, e `loading` só virava `false` quando a **carga logística** (`loadLogisticStops` → query `orders`) completava. Se essa query pendura no device, a tela inteira trava — mesmo no modo **Prospecção**, que nem usa pedidos.

**Fix:** `isLoading = authLoading` (só o login bloqueia a tela). A carga logística e as demais (scoring/prospects) já têm loading **inline** por seção. O mapa Leaflet passa a inicializar quando a tela renderiza (dep `[authLoading]`, não `[loading]`). Uma query pendurada de pedidos não trava mais a tela nem o mapa.

Com isso, a tela abre, o modo Prospecção é acessível, e o botão **"Google Maps"** (`RouteActionButtons` — abre a rota inteira no Google Maps com a localização como origem) volta a aparecer assim que há paradas com coordenadas.

### CI
typecheck 0 · lint 0 · 3423 testes · build ok. 100% frontend (sem migration/edge).

⚠️ **Requer Publish no Lovable** pra ir ao ar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
