### PR TITLE
fix(roteirizador): master abre direto no modo Prospecção (sem 'Calculando...')

### DIFF
--- a/src/hooks/useRoutePlanner.ts
+++ b/src/hooks/useRoutePlanner.ts
@@ -61,6 +61,10 @@ export function useRoutePlanner() {
   const [geocoding, setGeocoding] = useState(false);
   const [filterPeriod, setFilterPeriod] = useState<FilterPeriod>('all');
   const [planningMode, setPlanningMode] = useState<PlanningMode>('hibrido');
+  // Gestor/master (que enxerga o modo Prospecção) abre direto nele — é o uso do
+  // hunter (visitar prospects) e evita o "Calculando oportunidades comerciais..."
+  // do Híbrido (scoring pesado) na largada. Setado 1× quando o auth confirma.
+  const modoInicialDefinido = useRef(false);
 
   // Manual mode state
   const [manualCustomers, setManualCustomers] = useState<ManualCustomer[]>([]);
@@ -94,6 +98,15 @@ export function useRoutePlanner() {
       navigate('/', { replace: true });
     }
   }, [authLoading, isStaff, navigate]);
+
+  // O master (founder/hunter) abre direto na Prospecção. Gestores comerciais
+  // mantêm o Híbrido (rota de visitas do dia) e trocam de modo num clique.
+  useEffect(() => {
+    if (!modoInicialDefinido.current && !authLoading && isMaster) {
+      setPlanningMode('prospeccao');
+      modoInicialDefinido.current = true;
+    }
+  }, [authLoading, isMaster]);
 
   // Load logistic stops (existing orders)
   useEffect(() => {


### PR DESCRIPTION
## Fix: master abre o Roteirizador direto no modo Prospecção

**Contexto (reportado pelo founder):** após o fix do spinner (#814), a tela `/admin/route-planner` abre, mas o card **"Calculando oportunidades comerciais..."** fica girando pra sempre.

**Causa:** o modo **Híbrido** (default) dispara `useFarmerScoring`, que carrega **todos** os pedidos e recalcula/upserta **milhares de scores** da carteira a cada abertura. É pesado — no preview do Lovable / device lento, pendura, e o `scoringLoading` nunca vira `false` → "Calculando..." eterno. O `finally` existe (não é bug de loading); é performance.

**Fix:** o **master** (founder/hunter) abre o Roteirizador **já no modo Prospecção**, que **não usa scoring** → sem "Calculando...", direto no seletor de cidade. Um `useEffect` seta o modo 1× quando o auth confirma `isMaster` (ref anti-reset). **Gestor comercial mantém o Híbrido** (rota de visitas do dia) e troca de modo num clique. **Não toca** o `useFarmerScoring` (hook compartilhado, money-path).

**Follow-up (não-bloqueante):** tornar o scoring *lazy* no Roteirizador (só calcular nos modos comercial/híbrido) pra não rodar o upsert pesado à toa — otimização que ataca a raiz, mas mexe no hook compartilhado, então fica para um PR dedicado com validação própria.

### CI
typecheck 0 · lint 0 · 3423 testes · build ok. 100% frontend.

⚠️ **Requer Publish no Lovable.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
