### PR TITLE
ci: auto-merge automático de PRs (squash quando o CI passa)

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,35 @@
+# auto-merge.yml — liga o auto-merge (squash) automaticamente em TODO PR.
+#
+# Por que existe: o auto-merge do GitHub é opt-in POR PR — sem habilitar, o PR
+# fica parado esperando clique manual mesmo com o CI verde. Este workflow habilita
+# auto-merge em todo PR não-draft; quando o check required `validate` (ci.yml) passa,
+# o GitHub mergeia sozinho (squash + deleta a branch). Zero clique do founder.
+#
+# Pré-condições (já satisfeitas no repo): allow_auto_merge=true, branch protection
+# exige `validate`, sem review obrigatório, workflow permissions=write.
+#
+# NÃO bypassa o CI: o merge só acontece DEPOIS de `validate` passar (≠ `--admin`,
+# que pula o CI e é proibido por rotina). Pra SEGURAR um PR (não querer que mergeie
+# sozinho), deixe-o como DRAFT — o `if` abaixo pula drafts.
+name: Auto-merge
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review, synchronize]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  enable-auto-merge:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
+    steps:
+      - name: Habilita auto-merge (squash)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.html_url }}
+        run: |
+          gh pr merge --auto --squash "$PR" \
+            || echo "::notice::auto-merge não habilitável agora (conflito/estado não-mergeável) — segue sem bloquear; re-tenta no próximo push"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,8 @@
 
 **Política (mantém enxuto — leia antes de adicionar linha aqui):** o CLAUDE.md guarda só **regras/invariantes que valem sempre**. **Histórico de PR/incidente** vai pra `docs/registro/`; **procedimento operacional** (banco, deploy, cron) pra `docs/runbooks/`; **pendência em voo** pro PR/issue do GitHub. Ao concluir uma entrega, registre em `docs/registro/<modulo>.md` — **NÃO** engorde este arquivo; só acrescente aqui se for uma **REGRA/LIÇÃO** nova. O CI vigia o tamanho (`bun run claude:size`: teto 90 KB / 12k palavras / linha ≤ 2.000 chars).
 
+**Merge (auto, 2026-06-14):** todo PR não-draft **auto-mergeia (squash) quando o CI `validate` passa** — via `.github/workflows/auto-merge.yml` (zero clique do founder; o GitHub espera o check e mergeia + deleta a branch). Pra **segurar** um PR (não querer que mergeie sozinho), deixe-o **DRAFT**. Nunca `gh pr merge --admin` de rotina (bypassa o CI — o auto-merge **não** bypassa, espera o verde).
+
 **Mapa de leitura sob demanda (se for tocar… leia antes):**
 
 | Domínio | Onde |


### PR DESCRIPTION
Resolve o "tenho que entrar toda vez pra mergear, mesmo com a bolinha verde".

**Causa:** o auto-merge do GitHub é **opt-in por PR** — sem habilitar, o PR fica parado mesmo com o CI verde.

**Fix:** `.github/workflows/auto-merge.yml` liga o auto-merge (squash) em **todo PR não-draft**. Quando o check required `validate` passa, o GitHub mergeia sozinho + deleta a branch. **Zero clique.**

- **Não bypassa o CI** — espera o `validate` (≠ `--admin`).
- Pra **segurar** um PR (não mergear sozinho): deixe-o **DRAFT**.
- Pré-condições já no repo: `allow_auto_merge=true`, branch protection exige `validate`, sem review obrigatório, workflow permissions → `write`.

Este próprio PR tem auto-merge habilitado como bootstrap: quando o CI passar, ele entra sozinho e a regra passa a valer pra todos os PRs daí em diante. Registrado no CLAUDE.md §0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)