### PR TITLE
feat(venda-ia): Fatia 1 — motor de preço + estado (engine puro, money-path TDD)

### DIFF
--- a/docs/superpowers/plans/2026-06-14-venda-assistida-fatia1-resolver-pricing.md
+++ b/docs/superpowers/plans/2026-06-14-venda-assistida-fatia1-resolver-pricing.md
@@ -1,0 +1,48 @@
+# Venda assistida — Fatia 1: resolver + pricing determinístico (decisões + execução)
+
+> Plano/decisões da Fatia 1. Data: 2026-06-14. Design do programa: `docs/superpowers/specs/2026-06-14-venda-assistida-ia-design.md`.
+> **Engine puro, testável sem prod nem LLM.** Verificação em prod espera o Publish do casamento (#819) + popular vínculos.
+
+## Decisões do founder (2026-06-14) — money-path
+
+### De-para de litros por embalagem (sufixo Sayerlack + descrição)
+| Sufixo | Não-base | Base |
+|---|---|---|
+| `GL` | 3,6 | 3,24 |
+| `QT` | 0,9 | 0,81 |
+| `BH` | 20 | 18 |
+| `LT` | 18 | — |
+| `L5` | 5 | — |
+| `BB` | 5 | — |
+| `BD` | 18 | — |
+| `405ML` (na descrição) | 0,405 | — |
+| `CGL` | não existe → sob consulta | |
+
+- **"base" = a descrição contém a palavra "base"** (`/\bbase\b/i`). Bases só vêm em **QT/GL/BH** (litros menores).
+- **Fracionado:** item-pai no Omie é `QT`, mas a descrição diz `405ML` → manda a descrição (0,405 L).
+- Sufixo fora da tabela → **null → "sob consulta"** (nunca chuta).
+
+### Preço (litro preparado, catalisado)
+- **% do catalisador é sobre o VOLUME DA BASE** → `R$/litro preparado = (B + r·C)/(1+r)`, `r = pct/100`.
+- `B`/`C` = preço da **MAIOR embalagem disponível** ÷ litros (de-para).
+- **Fonte do preço = ÚLTIMO PREÇO PRATICADO PRA AQUELE CLIENTE** (não tabela) — base + o catalisador **que ele já usa**. ⚠️ Codex: o último-praticado **não é contratual** (é copiado Oben↔Colacor) → **rotular "baseado no último praticado"**, nunca "preço fechado". Sem histórico do cliente → fallback tabela (rotulado).
+- **Componente obrigatório ausente** (catalisador sem SKU/preço/litros) → `incomplete` ("sob consulta"). **NUNCA soma como zero** (Codex P0).
+
+### Estado (em estoque / encomenda / sob consulta)
+- `TECHNICAL_ONLY` — sem casamento (sem SKU) → alternativa técnica, sem preço.
+- `SELLABLE_NOW` — base + (catalisador obrigatório) mapeados, **em estoque** E **precificados**. "Em estoque agora" exige **base E catalisador em estoque** (decisão do founder) + preço ok (Codex).
+- `ORDERABLE` — mapeado mas não tudo disponível/precificável agora → encomenda.
+
+## Construído (✅ neste branch `claude/venda-assistida-fatia1-pricing`)
+- `src/lib/venda-assistida/preco-preparado.ts` — `litrosDaEmbalagem` + `precoLitroPreparado` (16 testes).
+- `src/lib/venda-assistida/resolver-estado.ts` — `classificarEstadoVenda` (7 testes).
+- Ambos **puros, agnósticos à fonte do preço** (recebem R$/embalagem prontos) → a camada de cima decide cliente/tabela/markup.
+
+## Restante da Fatia 1 + Fatia 2 (data-wiring + UI — espera Publish/popular vínculos)
+- **Resolver de dados** (hook/RPC): por boletim → SKUs vinculados (casamento `v_omie_product_current_spec`) → agrupar embalagens (sufixo + litros + preço-do-cliente + estoque) → escolher maior → catalisador (casamento do catalisador) → chamar os 2 helpers → opção resolvida `{ estado, preco }`.
+- **Preço-do-cliente por embalagem:** o wizard já tem `customerPrices` (por `omie_codigo_produto`) — usar como `valor`; fallback `valor_unitario` (tabela).
+- **Catalisador casamento:** o catalisador (`catalisador_codigo` do boletim) precisa do **mesmo casamento** (eu sugiro o vínculo, founder aprova) pra ter SKU/preço/estoque.
+- **UI vendedor-only** (card auditável) — Fatia 2.
+
+## Deferido (fatia própria, design próprio)
+- **Tabela de catálise** — quais catalisadores um produto aceita + vantagens de cada + markup-pra-migração (preço-do-cliente-no-antigo aplicado ao novo, pra não afastar o cliente). ⚠️ **Fonte do dado em aberto** (planilha do founder? boletim estendido? tabela nova?) — resolver no design dessa fatia. O boletim hoje guarda **só UM** catalisador + proporção.

--- a/docs/superpowers/plans/2026-06-14-venda-assistida-fatia1-resolver-pricing.md
+++ b/docs/superpowers/plans/2026-06-14-venda-assistida-fatia1-resolver-pricing.md
@@ -34,9 +34,17 @@
 - `ORDERABLE` — mapeado mas não tudo disponível/precificável agora → encomenda.
 
 ## Construído (✅ neste branch `claude/venda-assistida-fatia1-pricing`)
-- `src/lib/venda-assistida/preco-preparado.ts` — `litrosDaEmbalagem` + `precoLitroPreparado` (16 testes).
-- `src/lib/venda-assistida/resolver-estado.ts` — `classificarEstadoVenda` (7 testes).
-- Ambos **puros, agnósticos à fonte do preço** (recebem R$/embalagem prontos) → a camada de cima decide cliente/tabela/markup.
+- `src/lib/venda-assistida/preco-preparado.ts` — `litrosDaEmbalagem` + `precoLitroPreparado`.
+- `src/lib/venda-assistida/resolver-estado.ts` — `classificarEstadoVenda` (primitivo de regras).
+- `src/lib/venda-assistida/resolver-opcao.ts` — **`resolverOpcaoVenda`** (entrada money-path coerente: estado + preço das MESMAS embalagens).
+- **35 testes** (puros, agnósticos à fonte do preço → a camada de cima decide cliente/tabela/markup).
+
+## Codex adversarial (2026-06-14, xhigh) — 2 P0 + P1/P2, todos fechados
+- **P0.1 — proporção ausente eliminava catalisador obrigatório:** `pct=null/NaN/<=0` com catalisador presente virava preço só-da-base (barato) → podia ir a SELLABLE_NOW. Fix: param `temCatalisador`; proporção inválida + temCatalisador → **incomplete** (nunca vira base).
+- **P0.2 — preço e estoque de embalagens diferentes:** preço pegava a maior, estado perguntava "alguma em estoque". Fix: **`resolverOpcaoVenda`** calcula o preço de SELLABLE_NOW SÓ sobre embalagens EM ESTOQUE (preço == disponibilidade, coerente por construção).
+- **P1:** empate de litros não-determinístico → menor valor vence; maior embalagem sem preço → "sob consulta" (não substitui silenciosa); `\bbase\b` falhava em `BASE_GL` (`_` é word-char) e dava falso-positivo com acento → regex robusta (separador = não-letra).
+- **P2:** guard do valor final (Infinity/0) no ramo mono-componente; devolve litros do catalisador (auditável).
+- ⚠️ **Decisões mantidas (founder, não-bug):** "base" = literalmente a palavra "base" na descrição; "maior embalagem" pode ter pior R$/L que uma menor (é a regra do founder). Rotular na UI: **"R$/litro preparado (teórico)"**, não "preço do kit/lote".
 
 ## Restante da Fatia 1 + Fatia 2 (data-wiring + UI — espera Publish/popular vínculos)
 - **Resolver de dados** (hook/RPC): por boletim → SKUs vinculados (casamento `v_omie_product_current_spec`) → agrupar embalagens (sufixo + litros + preço-do-cliente + estoque) → escolher maior → catalisador (casamento do catalisador) → chamar os 2 helpers → opção resolvida `{ estado, preco }`.

--- a/src/lib/venda-assistida/__tests__/preco-preparado.test.ts
+++ b/src/lib/venda-assistida/__tests__/preco-preparado.test.ts
@@ -23,7 +23,6 @@ describe('litrosDaEmbalagem (de-para confirmado pelo founder 2026-06-14)', () =>
     expect(litrosDaEmbalagem('L5', 'qualquer L5')).toBe(5);
     expect(litrosDaEmbalagem('BB', 'qualquer BB')).toBe(5);
     expect(litrosDaEmbalagem('BD', 'qualquer BD')).toBe(18);
-    // base na descrição NÃO muda os tamanhos que não são QT/GL/BH
     expect(litrosDaEmbalagem('BD', 'BASE qualquer BD')).toBe(18);
   });
   it('fracionado 405ML: a DESCRIÇÃO manda, mesmo com sufixo QT (item-pai)', () => {
@@ -36,11 +35,19 @@ describe('litrosDaEmbalagem (de-para confirmado pelo founder 2026-06-14)', () =>
     expect(litrosDaEmbalagem('', '')).toBeNull();
   });
   it('case-insensitive no sufixo e na palavra base', () => {
-    expect(litrosDaEmbalagem('gl', 'base fundo wfot.gl')).toBe(3.24);
+    expect(litrosDaEmbalagem('gl', 'base fundo wfot gl')).toBe(3.24);
     expect(litrosDaEmbalagem('Qt', 'BASE algo')).toBe(0.81);
   });
-  it('"base" é palavra, não substring (não casa "baseado"/"database")', () => {
+  it('"base" é palavra, não substring (não casa "baseado")', () => {
     expect(litrosDaEmbalagem('GL', 'PRODUTO BASEADO EM AGUA GL')).toBe(3.6);
+  });
+  it('🔴 Codex P1: separador não-letra (_/dígito/pontuação) conta como base — NÃO subprecificar 10%', () => {
+    expect(litrosDaEmbalagem('GL', 'PRODUTO BASE_GL')).toBe(3.24); // _ é word-char no JS → \b falharia
+    expect(litrosDaEmbalagem('GL', 'WFOB-BASE-6736 GL')).toBe(3.24);
+  });
+  it('🔴 Codex P1: acento adjacente NÃO vira falso-positivo de base', () => {
+    expect(litrosDaEmbalagem('GL', 'ábase qualquer GL')).toBe(3.6); // "ábase" não é a palavra "base"
+    expect(litrosDaEmbalagem('GL', 'baseável GL')).toBe(3.6);
   });
 });
 
@@ -48,9 +55,9 @@ const emb = (valor: number, litros: number | null): EmbalagemPreco => ({ valor, 
 
 describe('precoLitroPreparado (catalisado, % da base, (B+rC)/(1+r))', () => {
   it('escolhe a MAIOR embalagem de base com litros conhecidos', () => {
-    // QT base 0,81 (R$81 → R$100/L) vs GL base 3,24 (R$324 → R$100/L) → usa a maior (GL)
     const r = precoLitroPreparado({
-      baseEmbalagens: [emb(81, 0.81), emb(324, 3.24)],
+      baseEmbalagens: [emb(81, 0.81), emb(324, 3.24)], // ambas R$100/L; maior = 3,24
+      temCatalisador: false,
       catalisadorEmbalagens: null,
       proporcaoPct: null,
     });
@@ -61,9 +68,10 @@ describe('precoLitroPreparado (catalisado, % da base, (B+rC)/(1+r))', () => {
     }
   });
 
-  it('produto 1-componente (sem catalisador) → preparado = a própria base', () => {
+  it('produto 1-componente (temCatalisador=false) → preparado = a própria base', () => {
     const r = precoLitroPreparado({
       baseEmbalagens: [emb(360, 3.6)],
+      temCatalisador: false,
       catalisadorEmbalagens: null,
       proporcaoPct: null,
     });
@@ -74,9 +82,10 @@ describe('precoLitroPreparado (catalisado, % da base, (B+rC)/(1+r))', () => {
     }
   });
 
-  it('catalisado 10%: (B + 0,1·C)/1,1 — B=100, C=200 → (100+20)/1,1 = 109,0909', () => {
+  it('catalisado 10%: (B + 0,1·C)/1,1 — B=100, C=200 → (100+20)/1,1', () => {
     const r = precoLitroPreparado({
       baseEmbalagens: [emb(360, 3.6)],          // B = 100/L
+      temCatalisador: true,
       catalisadorEmbalagens: [emb(180, 0.9)],   // C = 200/L
       proporcaoPct: 10,
     });
@@ -84,55 +93,93 @@ describe('precoLitroPreparado (catalisado, % da base, (B+rC)/(1+r))', () => {
     if (r.status === 'ok') {
       expect(r.valorLitroPreparado).toBeCloseTo((100 + 0.1 * 200) / 1.1, 4);
       expect(r.precoLitroCatalisador).toBe(200);
+      expect(r.litrosCatalisadorUsada).toBe(0.9);
     }
   });
 
-  it('🔴 catalisador OBRIGATÓRIO (r>0) ausente → incomplete, NUNCA soma como zero', () => {
+  it('🔴 Codex P0: temCatalisador + proporção ausente/inválida → incomplete (NÃO vira preço só-da-base)', () => {
+    for (const pct of [null, 0, -5, NaN, Infinity]) {
+      const r = precoLitroPreparado({
+        baseEmbalagens: [emb(360, 3.6)],
+        temCatalisador: true,
+        catalisadorEmbalagens: [emb(180, 0.9)],
+        proporcaoPct: pct as number,
+      });
+      expect(r.status, `pct=${pct}`).toBe('incomplete');
+    }
+  });
+
+  it('🔴 catalisador OBRIGATÓRIO ausente → incomplete, NUNCA soma como zero', () => {
     const semCat = precoLitroPreparado({
       baseEmbalagens: [emb(360, 3.6)],
+      temCatalisador: true,
       catalisadorEmbalagens: null,
       proporcaoPct: 10,
     });
     expect(semCat.status).toBe('incomplete');
-    // falsificação: se tratasse ausente como zero, daria (100+0)/1,1 = 90,9 (preço ERRADO mais barato)
     if (semCat.status === 'ok') throw new Error('catalisador ausente virou preço — bug money-path');
 
     const catSemLitros = precoLitroPreparado({
       baseEmbalagens: [emb(360, 3.6)],
-      catalisadorEmbalagens: [emb(180, null)],  // sem litros → não dá pra precificar
+      temCatalisador: true,
+      catalisadorEmbalagens: [emb(180, null)],
       proporcaoPct: 10,
     });
     expect(catSemLitros.status).toBe('incomplete');
   });
 
-  it('base sem litros conhecidos → incomplete (sob consulta)', () => {
-    const r = precoLitroPreparado({
-      baseEmbalagens: [emb(360, null)],
-      catalisadorEmbalagens: [emb(180, 0.9)],
-      proporcaoPct: 10,
-    });
-    expect(r.status).toBe('incomplete');
+  it('🔴 Codex P1: empate de litros → menor valor vence (determinístico, independe da ordem)', () => {
+    const a = precoLitroPreparado({ baseEmbalagens: [emb(360, 3.6), emb(720, 3.6)], temCatalisador: false, catalisadorEmbalagens: null, proporcaoPct: null });
+    const b = precoLitroPreparado({ baseEmbalagens: [emb(720, 3.6), emb(360, 3.6)], temCatalisador: false, catalisadorEmbalagens: null, proporcaoPct: null });
+    expect(a.status).toBe('ok');
+    expect(b.status).toBe('ok');
+    if (a.status === 'ok' && b.status === 'ok') {
+      expect(a.precoLitroBase).toBe(100); // 360/3,6
+      expect(a.precoLitroBase).toBe(b.precoLitroBase); // mesma resposta nas duas ordens
+    }
   });
 
-  it('base vazia → incomplete', () => {
-    const r = precoLitroPreparado({ baseEmbalagens: [], catalisadorEmbalagens: null, proporcaoPct: null });
-    expect(r.status).toBe('incomplete');
-  });
-
-  it('guards: valor/litros <=0, NaN, Infinity → embalagem ignorada', () => {
+  it('🔴 Codex P1: MAIOR embalagem sem preço → incomplete (não substitui por uma menor)', () => {
     const r = precoLitroPreparado({
-      baseEmbalagens: [emb(0, 3.6), emb(-10, 3.6), emb(NaN, 3.6), emb(360, 0)],
+      baseEmbalagens: [emb(0, 18), emb(324, 3.24)], // a maior (18 L) não tem preço
+      temCatalisador: false,
       catalisadorEmbalagens: null,
       proporcaoPct: null,
     });
-    expect(r.status).toBe('incomplete'); // nenhuma válida
+    expect(r.status).toBe('incomplete');
   });
 
-  it('proporcaoPct=0 trata como sem catalisador (= base)', () => {
+  it('base sem litros / vazia → incomplete', () => {
+    expect(precoLitroPreparado({ baseEmbalagens: [emb(360, null)], temCatalisador: false, catalisadorEmbalagens: null, proporcaoPct: null }).status).toBe('incomplete');
+    expect(precoLitroPreparado({ baseEmbalagens: [], temCatalisador: false, catalisadorEmbalagens: null, proporcaoPct: null }).status).toBe('incomplete');
+  });
+
+  it('guards: valor/litros <=0 → embalagem ignorada', () => {
+    const r = precoLitroPreparado({
+      baseEmbalagens: [emb(0, 3.6), emb(-10, 3.6), emb(NaN, 3.6), emb(360, 0)],
+      temCatalisador: false,
+      catalisadorEmbalagens: null,
+      proporcaoPct: null,
+    });
+    expect(r.status).toBe('incomplete');
+  });
+
+  it('🔴 Codex P2: quociente Infinity (litros minúsculos) → incomplete, não preço Infinity', () => {
+    const r = precoLitroPreparado({
+      baseEmbalagens: [emb(1e300, 1e-300)],
+      temCatalisador: false,
+      catalisadorEmbalagens: null,
+      proporcaoPct: null,
+    });
+    expect(r.status).toBe('incomplete');
+  });
+
+  it('temCatalisador=false ignora a proporção (mesmo pct preenchido → base)', () => {
     const r = precoLitroPreparado({
       baseEmbalagens: [emb(360, 3.6)],
+      temCatalisador: false,
       catalisadorEmbalagens: [emb(180, 0.9)],
-      proporcaoPct: 0,
+      proporcaoPct: 10,
     });
     expect(r.status).toBe('ok');
     if (r.status === 'ok') expect(r.valorLitroPreparado).toBe(100);

--- a/src/lib/venda-assistida/__tests__/preco-preparado.test.ts
+++ b/src/lib/venda-assistida/__tests__/preco-preparado.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from 'vitest';
+import {
+  litrosDaEmbalagem,
+  precoLitroPreparado,
+  type EmbalagemPreco,
+} from '../preco-preparado';
+
+describe('litrosDaEmbalagem (de-para confirmado pelo founder 2026-06-14)', () => {
+  it('GL: 3,6 normal / 3,24 se base', () => {
+    expect(litrosDaEmbalagem('GL', 'PRIMER PU FL.6269.02GL')).toBe(3.6);
+    expect(litrosDaEmbalagem('GL', 'BASE PU METALLIC PEARL MULT TOTAL WFOB.6736GL')).toBe(3.24);
+  });
+  it('QT: 0,9 normal / 0,81 se base', () => {
+    expect(litrosDaEmbalagem('QT', 'WP12.3900QT CONCENTRADO PRETO')).toBe(0.9);
+    expect(litrosDaEmbalagem('QT', 'BASE FUNDO ACAB PU TRANSP WFOT.6529QT')).toBe(0.81);
+  });
+  it('BH: 20 normal / 18 se base', () => {
+    expect(litrosDaEmbalagem('BH', 'VERNIZ PU FO20.6827.00BH')).toBe(20);
+    expect(litrosDaEmbalagem('BH', 'BASE BRILH BRANC PU WFBB.6045BH')).toBe(18);
+  });
+  it('LT/L5/BB/BD: valor único (sem variante base)', () => {
+    expect(litrosDaEmbalagem('LT', 'F ACAB FL20.6468.00LT')).toBe(18);
+    expect(litrosDaEmbalagem('L5', 'qualquer L5')).toBe(5);
+    expect(litrosDaEmbalagem('BB', 'qualquer BB')).toBe(5);
+    expect(litrosDaEmbalagem('BD', 'qualquer BD')).toBe(18);
+    // base na descrição NÃO muda os tamanhos que não são QT/GL/BH
+    expect(litrosDaEmbalagem('BD', 'BASE qualquer BD')).toBe(18);
+  });
+  it('fracionado 405ML: a DESCRIÇÃO manda, mesmo com sufixo QT (item-pai)', () => {
+    expect(litrosDaEmbalagem('QT', 'ISOLANTE PU FI.6197 405ML')).toBe(0.405);
+    expect(litrosDaEmbalagem('QT', 'ISOLANTE PU FI.6197 405 ML')).toBe(0.405);
+  });
+  it('CGL e sufixo desconhecido → null (sob consulta), nunca chute', () => {
+    expect(litrosDaEmbalagem('CGL', 'qualquer CGL')).toBeNull();
+    expect(litrosDaEmbalagem('XX', 'qualquer')).toBeNull();
+    expect(litrosDaEmbalagem('', '')).toBeNull();
+  });
+  it('case-insensitive no sufixo e na palavra base', () => {
+    expect(litrosDaEmbalagem('gl', 'base fundo wfot.gl')).toBe(3.24);
+    expect(litrosDaEmbalagem('Qt', 'BASE algo')).toBe(0.81);
+  });
+  it('"base" é palavra, não substring (não casa "baseado"/"database")', () => {
+    expect(litrosDaEmbalagem('GL', 'PRODUTO BASEADO EM AGUA GL')).toBe(3.6);
+  });
+});
+
+const emb = (valor: number, litros: number | null): EmbalagemPreco => ({ valor, litros });
+
+describe('precoLitroPreparado (catalisado, % da base, (B+rC)/(1+r))', () => {
+  it('escolhe a MAIOR embalagem de base com litros conhecidos', () => {
+    // QT base 0,81 (R$81 → R$100/L) vs GL base 3,24 (R$324 → R$100/L) → usa a maior (GL)
+    const r = precoLitroPreparado({
+      baseEmbalagens: [emb(81, 0.81), emb(324, 3.24)],
+      catalisadorEmbalagens: null,
+      proporcaoPct: null,
+    });
+    expect(r.status).toBe('ok');
+    if (r.status === 'ok') {
+      expect(r.litrosBaseUsada).toBe(3.24);
+      expect(r.precoLitroBase).toBe(100);
+    }
+  });
+
+  it('produto 1-componente (sem catalisador) → preparado = a própria base', () => {
+    const r = precoLitroPreparado({
+      baseEmbalagens: [emb(360, 3.6)],
+      catalisadorEmbalagens: null,
+      proporcaoPct: null,
+    });
+    expect(r.status).toBe('ok');
+    if (r.status === 'ok') {
+      expect(r.valorLitroPreparado).toBe(100);
+      expect(r.precoLitroCatalisador).toBeNull();
+    }
+  });
+
+  it('catalisado 10%: (B + 0,1·C)/1,1 — B=100, C=200 → (100+20)/1,1 = 109,0909', () => {
+    const r = precoLitroPreparado({
+      baseEmbalagens: [emb(360, 3.6)],          // B = 100/L
+      catalisadorEmbalagens: [emb(180, 0.9)],   // C = 200/L
+      proporcaoPct: 10,
+    });
+    expect(r.status).toBe('ok');
+    if (r.status === 'ok') {
+      expect(r.valorLitroPreparado).toBeCloseTo((100 + 0.1 * 200) / 1.1, 4);
+      expect(r.precoLitroCatalisador).toBe(200);
+    }
+  });
+
+  it('🔴 catalisador OBRIGATÓRIO (r>0) ausente → incomplete, NUNCA soma como zero', () => {
+    const semCat = precoLitroPreparado({
+      baseEmbalagens: [emb(360, 3.6)],
+      catalisadorEmbalagens: null,
+      proporcaoPct: 10,
+    });
+    expect(semCat.status).toBe('incomplete');
+    // falsificação: se tratasse ausente como zero, daria (100+0)/1,1 = 90,9 (preço ERRADO mais barato)
+    if (semCat.status === 'ok') throw new Error('catalisador ausente virou preço — bug money-path');
+
+    const catSemLitros = precoLitroPreparado({
+      baseEmbalagens: [emb(360, 3.6)],
+      catalisadorEmbalagens: [emb(180, null)],  // sem litros → não dá pra precificar
+      proporcaoPct: 10,
+    });
+    expect(catSemLitros.status).toBe('incomplete');
+  });
+
+  it('base sem litros conhecidos → incomplete (sob consulta)', () => {
+    const r = precoLitroPreparado({
+      baseEmbalagens: [emb(360, null)],
+      catalisadorEmbalagens: [emb(180, 0.9)],
+      proporcaoPct: 10,
+    });
+    expect(r.status).toBe('incomplete');
+  });
+
+  it('base vazia → incomplete', () => {
+    const r = precoLitroPreparado({ baseEmbalagens: [], catalisadorEmbalagens: null, proporcaoPct: null });
+    expect(r.status).toBe('incomplete');
+  });
+
+  it('guards: valor/litros <=0, NaN, Infinity → embalagem ignorada', () => {
+    const r = precoLitroPreparado({
+      baseEmbalagens: [emb(0, 3.6), emb(-10, 3.6), emb(NaN, 3.6), emb(360, 0)],
+      catalisadorEmbalagens: null,
+      proporcaoPct: null,
+    });
+    expect(r.status).toBe('incomplete'); // nenhuma válida
+  });
+
+  it('proporcaoPct=0 trata como sem catalisador (= base)', () => {
+    const r = precoLitroPreparado({
+      baseEmbalagens: [emb(360, 3.6)],
+      catalisadorEmbalagens: [emb(180, 0.9)],
+      proporcaoPct: 0,
+    });
+    expect(r.status).toBe('ok');
+    if (r.status === 'ok') expect(r.valorLitroPreparado).toBe(100);
+  });
+});

--- a/src/lib/venda-assistida/__tests__/resolver-estado.test.ts
+++ b/src/lib/venda-assistida/__tests__/resolver-estado.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { classificarEstadoVenda, type DisponibilidadeInput } from '../resolver-estado';
+
+const base: DisponibilidadeInput = {
+  temSkuConfirmado: true,
+  baseEmEstoque: true,
+  precisaCatalisador: true,
+  catalisadorMapeado: true,
+  catalisadorEmEstoque: true,
+  precoOk: true,
+};
+
+describe('classificarEstadoVenda (regras confirmadas pelo founder + Codex)', () => {
+  it('sem SKU confirmado → TECHNICAL_ONLY (sob consulta), independente do resto', () => {
+    expect(classificarEstadoVenda({ ...base, temSkuConfirmado: false })).toBe('TECHNICAL_ONLY');
+    // mesmo com tudo "disponível", sem casamento não há produto vendável
+    expect(classificarEstadoVenda({ ...base, temSkuConfirmado: false, baseEmEstoque: true })).toBe('TECHNICAL_ONLY');
+  });
+
+  it('base + catalisador em estoque + precificado → SELLABLE_NOW', () => {
+    expect(classificarEstadoVenda(base)).toBe('SELLABLE_NOW');
+  });
+
+  it('produto 1-componente (não precisa catalisador): base em estoque + preço → SELLABLE_NOW', () => {
+    expect(classificarEstadoVenda({ ...base, precisaCatalisador: false, catalisadorMapeado: false, catalisadorEmEstoque: false })).toBe('SELLABLE_NOW');
+  });
+
+  it('🔴 precisa catalisador mas ele NÃO está em estoque → ORDERABLE (não promete "em estoque")', () => {
+    expect(classificarEstadoVenda({ ...base, catalisadorEmEstoque: false })).toBe('ORDERABLE');
+  });
+
+  it('precisa catalisador mas ele não está mapeado (sem SKU) → ORDERABLE', () => {
+    expect(classificarEstadoVenda({ ...base, catalisadorMapeado: false })).toBe('ORDERABLE');
+  });
+
+  it('base fora de estoque → ORDERABLE (mesmo com catalisador disponível)', () => {
+    expect(classificarEstadoVenda({ ...base, baseEmEstoque: false })).toBe('ORDERABLE');
+  });
+
+  it('🔴 tudo disponível mas preço incompleto (sob consulta) → ORDERABLE, NUNCA SELLABLE_NOW', () => {
+    // Codex: SELLABLE_NOW exige PRECIFICADO. Sem preço confiável não é "em estoque, pode vender já".
+    expect(classificarEstadoVenda({ ...base, precoOk: false })).toBe('ORDERABLE');
+  });
+});

--- a/src/lib/venda-assistida/__tests__/resolver-opcao.test.ts
+++ b/src/lib/venda-assistida/__tests__/resolver-opcao.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { resolverOpcaoVenda, type EmbalagemComEstoque } from '../resolver-opcao';
+
+const e = (valor: number, litros: number | null, estoque: number): EmbalagemComEstoque => ({ valor, litros, estoque });
+
+describe('resolverOpcaoVenda (estado + preço coerentes — fecha P0.2 do Codex)', () => {
+  it('sem SKU confirmado → TECHNICAL_ONLY, sem preço', () => {
+    const r = resolverOpcaoVenda({
+      temSkuConfirmado: false, temCatalisador: false, proporcaoPct: null,
+      baseEmbalagens: [e(360, 3.6, 10)], catalisadorEmbalagens: [],
+    });
+    expect(r.estado).toBe('TECHNICAL_ONLY');
+    expect(r.preco.status).toBe('incomplete');
+  });
+
+  it('base (1-componente) em estoque + precificada → SELLABLE_NOW', () => {
+    const r = resolverOpcaoVenda({
+      temSkuConfirmado: true, temCatalisador: false, proporcaoPct: null,
+      baseEmbalagens: [e(360, 3.6, 5)], catalisadorEmbalagens: [],
+    });
+    expect(r.estado).toBe('SELLABLE_NOW');
+    expect(r.preco.status).toBe('ok');
+  });
+
+  it('🔴 P0.2: SELLABLE_NOW usa o preço da embalagem EM ESTOQUE, não da maior fora de estoque', () => {
+    // Maior (18 L, R$180 → R$10/L) SEM estoque; menor (0,9 L, R$180 → R$200/L) EM estoque.
+    const r = resolverOpcaoVenda({
+      temSkuConfirmado: true, temCatalisador: false, proporcaoPct: null,
+      baseEmbalagens: [e(180, 18, 0), e(180, 0.9, 5)], catalisadorEmbalagens: [],
+    });
+    expect(r.estado).toBe('SELLABLE_NOW');
+    // se pegasse a maior (fora de estoque) daria R$10/L — preço de algo indisponível (bug P0.2)
+    if (r.preco.status === 'ok') {
+      expect(r.preco.precoLitroBase).toBe(200); // veio da embalagem EM ESTOQUE
+      expect(r.preco.litrosBaseUsada).toBe(0.9);
+    }
+  });
+
+  it('nada em estoque → ORDERABLE com a estimativa de encomenda (maior embalagem geral)', () => {
+    const r = resolverOpcaoVenda({
+      temSkuConfirmado: true, temCatalisador: false, proporcaoPct: null,
+      baseEmbalagens: [e(180, 18, 0), e(180, 0.9, 0)], catalisadorEmbalagens: [],
+    });
+    expect(r.estado).toBe('ORDERABLE');
+    if (r.preco.status === 'ok') expect(r.preco.litrosBaseUsada).toBe(18); // maior (encomenda)
+  });
+
+  it('catalisado: base + catalisador em estoque → SELLABLE_NOW (preço sobre os dois em estoque)', () => {
+    const r = resolverOpcaoVenda({
+      temSkuConfirmado: true, temCatalisador: true, proporcaoPct: 10,
+      baseEmbalagens: [e(360, 3.6, 5)], catalisadorEmbalagens: [e(180, 0.9, 5)],
+    });
+    expect(r.estado).toBe('SELLABLE_NOW');
+    expect(r.preco.status).toBe('ok');
+  });
+
+  it('🔴 catalisador obrigatório fora de estoque → NÃO é SELLABLE_NOW (vira ORDERABLE)', () => {
+    const r = resolverOpcaoVenda({
+      temSkuConfirmado: true, temCatalisador: true, proporcaoPct: 10,
+      baseEmbalagens: [e(360, 3.6, 5)], catalisadorEmbalagens: [e(180, 0.9, 0)],
+    });
+    expect(r.estado).toBe('ORDERABLE'); // base em estoque, mas catalisador não → encomenda
+  });
+
+  it('catalisador obrigatório NÃO mapeado ([]) → ORDERABLE com preço "sob consulta"', () => {
+    const r = resolverOpcaoVenda({
+      temSkuConfirmado: true, temCatalisador: true, proporcaoPct: 10,
+      baseEmbalagens: [e(360, 3.6, 5)], catalisadorEmbalagens: [],
+    });
+    expect(r.estado).toBe('ORDERABLE');
+    expect(r.preco.status).toBe('incomplete'); // catalisador obrigatório sem SKU
+  });
+});

--- a/src/lib/venda-assistida/preco-preparado.ts
+++ b/src/lib/venda-assistida/preco-preparado.ts
@@ -1,0 +1,122 @@
+/**
+ * Pricing determinístico do "litro preparado" (catalisado) — Fatia 1 da venda assistida por IA.
+ *
+ * Money-path NÃO-NEGOCIÁVEL: a IA NUNCA define preço. B (base) e C (catalisador) saem do Omie
+ * (preço da MAIOR embalagem disponível) ÷ litros do de-para abaixo. Componente obrigatório ausente
+ * → "sob consulta" (status incomplete), NUNCA somado como zero (risco P0 do Codex).
+ *
+ * Design: docs/superpowers/specs/2026-06-14-venda-assistida-ia-design.md (§3 risco P0.2, §5).
+ *
+ * De-para de litros por embalagem — CONFIRMADO PELO FOUNDER (2026-06-14):
+ *   GL 3,6 (base 3,24) · QT 0,9 (base 0,81) · BH 20 (base 18) · LT 18 · L5 5 · BB 5 · BD 18 · 405ML 0,405.
+ *   "base" = a descrição contém a palavra "base" (bases só existem em QT/GL/BH, com os litros menores).
+ *   CGL não existe → null (sob consulta). Sufixo fora da tabela → null (nunca chute).
+ *
+ * % do catalisador é sobre o VOLUME DA BASE (r = pct/100): pra 1 L de base entram r L de catalisador,
+ * lote final = 1+r litros → R$/litro preparado = (B + r·C)/(1+r).
+ */
+
+/** Litros da embalagem pelo sufixo Sayerlack + descrição. null = desconhecido → "sob consulta". */
+export function litrosDaEmbalagem(sufixo: string, descricao: string): number | null {
+  const desc = (descricao ?? '').toLowerCase();
+  // Fracionado: o item-pai no Omie é QT, mas a descrição diz "405ML" e é o que se vende → manda a descrição.
+  if (/\b405\s*ml\b/.test(desc)) return 0.405;
+  const isBase = /\bbase\b/.test(desc);
+  switch ((sufixo ?? '').toUpperCase()) {
+    case 'GL': return isBase ? 3.24 : 3.6;
+    case 'QT': return isBase ? 0.81 : 0.9;
+    case 'BH': return isBase ? 18 : 20;
+    case 'LT': return 18;
+    case 'L5': return 5;
+    case 'BB': return 5;
+    case 'BD': return 18;
+    default: return null; // CGL (não existe) e qualquer sufixo desconhecido → sob consulta
+  }
+}
+
+export interface EmbalagemPreco {
+  /** Preço da embalagem (R$), do Omie (valor_unitario da embalagem, NÃO por litro). */
+  valor: number;
+  /** Litros da embalagem (de litrosDaEmbalagem); null = não sabe → não precificável. */
+  litros: number | null;
+}
+
+export type PrecoPreparado =
+  | {
+      status: 'ok';
+      valorLitroPreparado: number;
+      precoLitroBase: number;
+      precoLitroCatalisador: number | null;
+      litrosBaseUsada: number;
+    }
+  | { status: 'incomplete'; motivo: string };
+
+export interface PrecoPreparadoInput {
+  /** Embalagens da base (escolhe a MAIOR com litros conhecidos). */
+  baseEmbalagens: EmbalagemPreco[];
+  /** Embalagens do catalisador (maior com litros conhecidos); null = catalisador não mapeado. */
+  catalisadorEmbalagens: EmbalagemPreco[] | null;
+  /** catalisador_proporcao_pct do boletim. null/0 = produto 1-componente (sem catalisador). */
+  proporcaoPct: number | null;
+}
+
+function valido(n: number | null | undefined): n is number {
+  return typeof n === 'number' && Number.isFinite(n) && n > 0;
+}
+
+function round4(n: number): number {
+  return Math.round(n * 10000) / 10000;
+}
+
+/** Maior embalagem com litros conhecidos → {preço/litro, litros}. null se nenhuma válida. */
+function precoLitroMaiorEmbalagem(
+  embalagens: EmbalagemPreco[],
+): { precoLitro: number; litros: number } | null {
+  let melhor: { precoLitro: number; litros: number } | null = null;
+  for (const e of embalagens) {
+    if (!valido(e.valor) || !valido(e.litros)) continue;
+    if (!melhor || e.litros > melhor.litros) {
+      melhor = { precoLitro: e.valor / e.litros, litros: e.litros };
+    }
+  }
+  return melhor;
+}
+
+/**
+ * R$/litro preparado (catalisado), determinístico. Degrada honesto a "incomplete" ("sob consulta")
+ * quando falta litro de base ou o catalisador obrigatório não tem SKU/preço/litros. Nunca zero-fill.
+ */
+export function precoLitroPreparado(input: PrecoPreparadoInput): PrecoPreparado {
+  const base = precoLitroMaiorEmbalagem(input.baseEmbalagens ?? []);
+  if (!base) return { status: 'incomplete', motivo: 'base sem embalagem com litros conhecidos' };
+  const B = base.precoLitro;
+
+  const pct = input.proporcaoPct;
+  // Sem catalisador (produto 1-componente): o "preparado" é a própria base.
+  if (pct == null || !Number.isFinite(pct) || pct <= 0) {
+    return {
+      status: 'ok',
+      valorLitroPreparado: round4(B),
+      precoLitroBase: round4(B),
+      precoLitroCatalisador: null,
+      litrosBaseUsada: base.litros,
+    };
+  }
+
+  // Catalisador OBRIGATÓRIO (r > 0): precisa de preço/litro. Ausente → incomplete (nunca zero).
+  const r = pct / 100;
+  const cat = precoLitroMaiorEmbalagem(input.catalisadorEmbalagens ?? []);
+  if (!cat) return { status: 'incomplete', motivo: 'catalisador obrigatório sem SKU/preço/litros' };
+  const C = cat.precoLitro;
+
+  const valorLitro = (B + r * C) / (1 + r);
+  if (!valido(valorLitro)) return { status: 'incomplete', motivo: 'cálculo inválido' };
+
+  return {
+    status: 'ok',
+    valorLitroPreparado: round4(valorLitro),
+    precoLitroBase: round4(B),
+    precoLitroCatalisador: round4(C),
+    litrosBaseUsada: base.litros,
+  };
+}

--- a/src/lib/venda-assistida/preco-preparado.ts
+++ b/src/lib/venda-assistida/preco-preparado.ts
@@ -6,6 +6,12 @@
  * → "sob consulta" (status incomplete), NUNCA somado como zero (risco P0 do Codex).
  *
  * Design: docs/superpowers/specs/2026-06-14-venda-assistida-ia-design.md (§3 risco P0.2, §5).
+ * Revisado por Codex adversarial (2026-06-14): P0 proporção-ausente, P1 empate/maior-sem-preço/regex-base.
+ *
+ * ⚠️ ESTE preço é a estimativa de ENCOMENDA pela MAIOR embalagem ("R$/litro preparado teórico").
+ * NÃO é o preço de um item EM ESTOQUE (esse é o preço-do-cliente do item em estoque) — o resolver
+ * (Fatia 2) NÃO deve casar este preço com estado SELLABLE_NOW (risco P0.2: preço e estoque de
+ * embalagens diferentes). Também não é "preço do kit/lote" (o catalisador vem em embalagem fechada).
  *
  * De-para de litros por embalagem — CONFIRMADO PELO FOUNDER (2026-06-14):
  *   GL 3,6 (base 3,24) · QT 0,9 (base 0,81) · BH 20 (base 18) · LT 18 · L5 5 · BB 5 · BD 18 · 405ML 0,405.
@@ -16,12 +22,16 @@
  * lote final = 1+r litros → R$/litro preparado = (B + r·C)/(1+r).
  */
 
+/** "base" como PALAVRA. O \b do JS conta `_` como letra (deixaria "BASE_GL" passar como não-base) e o
+ *  \b ASCII casa após acento ("ábase"). Aqui: separador = qualquer não-letra (incl. `_`, dígito, pontuação). */
+const RE_PALAVRA_BASE = /(?:^|[^a-zà-ÿ])base(?:[^a-zà-ÿ]|$)/i;
+
 /** Litros da embalagem pelo sufixo Sayerlack + descrição. null = desconhecido → "sob consulta". */
 export function litrosDaEmbalagem(sufixo: string, descricao: string): number | null {
   const desc = (descricao ?? '').toLowerCase();
   // Fracionado: o item-pai no Omie é QT, mas a descrição diz "405ML" e é o que se vende → manda a descrição.
   if (/\b405\s*ml\b/.test(desc)) return 0.405;
-  const isBase = /\bbase\b/.test(desc);
+  const isBase = RE_PALAVRA_BASE.test(desc);
   switch ((sufixo ?? '').toUpperCase()) {
     case 'GL': return isBase ? 3.24 : 3.6;
     case 'QT': return isBase ? 0.81 : 0.9;
@@ -48,15 +58,18 @@ export type PrecoPreparado =
       precoLitroBase: number;
       precoLitroCatalisador: number | null;
       litrosBaseUsada: number;
+      litrosCatalisadorUsada: number | null;
     }
   | { status: 'incomplete'; motivo: string };
 
 export interface PrecoPreparadoInput {
-  /** Embalagens da base (escolhe a MAIOR com litros conhecidos). */
+  /** Embalagens da base (escolhe a MAIOR com preço+litros conhecidos). */
   baseEmbalagens: EmbalagemPreco[];
-  /** Embalagens do catalisador (maior com litros conhecidos); null = catalisador não mapeado. */
+  /** O boletim TEM catalisador (catalisador_codigo presente)? Se sim, proporção VÁLIDA é obrigatória. */
+  temCatalisador: boolean;
+  /** Embalagens do catalisador (maior com preço+litros); null = catalisador não mapeado. */
   catalisadorEmbalagens: EmbalagemPreco[] | null;
-  /** catalisador_proporcao_pct do boletim. null/0 = produto 1-componente (sem catalisador). */
+  /** catalisador_proporcao_pct do boletim. Só usado quando temCatalisador=true. */
   proporcaoPct: number | null;
 }
 
@@ -68,43 +81,64 @@ function round4(n: number): number {
   return Math.round(n * 10000) / 10000;
 }
 
-/** Maior embalagem com litros conhecidos → {preço/litro, litros}. null se nenhuma válida. */
+/**
+ * Preço/litro da MAIOR embalagem (por litros). Codex P1:
+ *  - se a maior-por-litros NÃO tem preço válido → null (sob consulta), NÃO substitui por uma menor;
+ *  - empate de litros → menor `valor` vence (determinístico, não depende da ordem do array).
+ */
 function precoLitroMaiorEmbalagem(
   embalagens: EmbalagemPreco[],
 ): { precoLitro: number; litros: number } | null {
-  let melhor: { precoLitro: number; litros: number } | null = null;
+  // 1) maior litragem entre as embalagens com litros válidos.
+  let maxLitros = -Infinity;
   for (const e of embalagens) {
-    if (!valido(e.valor) || !valido(e.litros)) continue;
-    if (!melhor || e.litros > melhor.litros) {
-      melhor = { precoLitro: e.valor / e.litros, litros: e.litros };
+    if (valido(e.litros) && e.litros > maxLitros) maxLitros = e.litros;
+  }
+  if (!Number.isFinite(maxLitros)) return null; // nenhuma com litros válidos
+
+  // 2) entre as DA maior litragem, a de menor valor válido. Nenhuma precificada → sob consulta.
+  let melhorValor = Infinity;
+  for (const e of embalagens) {
+    if (valido(e.litros) && e.litros === maxLitros && valido(e.valor) && e.valor < melhorValor) {
+      melhorValor = e.valor;
     }
   }
-  return melhor;
+  if (!Number.isFinite(melhorValor)) return null; // a maior embalagem não tem preço → sob consulta
+
+  return { precoLitro: melhorValor / maxLitros, litros: maxLitros };
 }
 
 /**
  * R$/litro preparado (catalisado), determinístico. Degrada honesto a "incomplete" ("sob consulta")
- * quando falta litro de base ou o catalisador obrigatório não tem SKU/preço/litros. Nunca zero-fill.
+ * quando falta preço/litro de base, quando a proporção do catalisador obrigatório é desconhecida,
+ * ou quando o catalisador obrigatório não tem SKU/preço/litros. Nunca zero-fill (Codex P0).
  */
 export function precoLitroPreparado(input: PrecoPreparadoInput): PrecoPreparado {
   const base = precoLitroMaiorEmbalagem(input.baseEmbalagens ?? []);
-  if (!base) return { status: 'incomplete', motivo: 'base sem embalagem com litros conhecidos' };
+  if (!base) return { status: 'incomplete', motivo: 'base sem embalagem (maior) com preço/litros conhecidos' };
   const B = base.precoLitro;
 
-  const pct = input.proporcaoPct;
-  // Sem catalisador (produto 1-componente): o "preparado" é a própria base.
-  if (pct == null || !Number.isFinite(pct) || pct <= 0) {
+  // Produto 1-componente (boletim SEM catalisador): o "preparado" é a própria base.
+  if (!input.temCatalisador) {
+    if (!valido(B)) return { status: 'incomplete', motivo: 'preço-base inválido' };
     return {
       status: 'ok',
       valorLitroPreparado: round4(B),
       precoLitroBase: round4(B),
       precoLitroCatalisador: null,
       litrosBaseUsada: base.litros,
+      litrosCatalisadorUsada: null,
     };
   }
 
-  // Catalisador OBRIGATÓRIO (r > 0): precisa de preço/litro. Ausente → incomplete (nunca zero).
+  // Catalisador OBRIGATÓRIO: proporção VÁLIDA é necessária. null/NaN/Infinity/<=0 → "sob consulta"
+  // (NÃO vira preço só-da-base — risco P0 do Codex: boletim incompleto virava SELLABLE_NOW barato).
+  const pct = input.proporcaoPct;
+  if (pct == null || !Number.isFinite(pct) || pct <= 0) {
+    return { status: 'incomplete', motivo: 'catalisador obrigatório com proporção desconhecida/inválida' };
+  }
   const r = pct / 100;
+
   const cat = precoLitroMaiorEmbalagem(input.catalisadorEmbalagens ?? []);
   if (!cat) return { status: 'incomplete', motivo: 'catalisador obrigatório sem SKU/preço/litros' };
   const C = cat.precoLitro;
@@ -118,5 +152,6 @@ export function precoLitroPreparado(input: PrecoPreparadoInput): PrecoPreparado 
     precoLitroBase: round4(B),
     precoLitroCatalisador: round4(C),
     litrosBaseUsada: base.litros,
+    litrosCatalisadorUsada: cat.litros,
   };
 }

--- a/src/lib/venda-assistida/resolver-estado.ts
+++ b/src/lib/venda-assistida/resolver-estado.ts
@@ -1,0 +1,43 @@
+/**
+ * Classificação de estado de uma opção de venda assistida — Fatia 1.
+ *
+ * Estados (design §4 da spec do programa):
+ *   - SELLABLE_NOW   — base mapeada + precificada + DISPONÍVEL, e o catalisador obrigatório
+ *                      também mapeado + em estoque. "Melhor opção em estoque hoje."
+ *   - ORDERABLE      — mapeado mas não tudo disponível/precificável agora → sob encomenda.
+ *   - TECHNICAL_ONLY — sem SKU confirmado (sem casamento) → alternativa técnica, "sob consulta".
+ *
+ * Regras confirmadas pelo founder (2026-06-14): "em estoque agora" exige base E catalisador
+ * em estoque. Codex (P0): SELLABLE_NOW exige PRECIFICADO (preço confiável) — sem preço não promete.
+ */
+
+export type EstadoVenda = 'SELLABLE_NOW' | 'ORDERABLE' | 'TECHNICAL_ONLY';
+
+export interface DisponibilidadeInput {
+  /** Existe vínculo boletim↔SKU confirmado pra a base (casamento). */
+  temSkuConfirmado: boolean;
+  /** Alguma embalagem da base com saldo > 0. */
+  baseEmEstoque: boolean;
+  /** O boletim exige catalisador (catalisador_proporcao_pct > 0). */
+  precisaCatalisador: boolean;
+  /** O catalisador tem SKU confirmado (casamento do catalisador). */
+  catalisadorMapeado: boolean;
+  /** Alguma embalagem do catalisador com saldo > 0. */
+  catalisadorEmEstoque: boolean;
+  /** O motor de preço retornou status 'ok' (preço confiável, não "sob consulta"). */
+  precoOk: boolean;
+}
+
+export function classificarEstadoVenda(d: DisponibilidadeInput): EstadoVenda {
+  // Sem casamento → não há produto vendável; só alternativa técnica.
+  if (!d.temSkuConfirmado) return 'TECHNICAL_ONLY';
+
+  // Catalisador obrigatório precisa estar mapeado E em estoque; se não é obrigatório, ok.
+  const catalisadorOk = !d.precisaCatalisador || (d.catalisadorMapeado && d.catalisadorEmEstoque);
+
+  // "Em estoque agora" exige tudo disponível E precificado (Codex P0).
+  if (d.baseEmEstoque && catalisadorOk && d.precoOk) return 'SELLABLE_NOW';
+
+  // Mapeado mas não tudo disponível/precificável → encomenda.
+  return 'ORDERABLE';
+}

--- a/src/lib/venda-assistida/resolver-opcao.ts
+++ b/src/lib/venda-assistida/resolver-opcao.ts
@@ -1,0 +1,73 @@
+import {
+  precoLitroPreparado,
+  type EmbalagemPreco,
+  type PrecoPreparado,
+} from './preco-preparado';
+import type { EstadoVenda } from './resolver-estado';
+
+/**
+ * Resolve estado + preço COERENTES de uma opção de venda assistida — Fatia 1/2.
+ *
+ * Fecha o **P0.2 do Codex**: preço e disponibilidade têm que vir das MESMAS embalagens. O preço de
+ * SELLABLE_NOW é calculado SÓ sobre embalagens EM ESTOQUE — então "em estoque agora" nunca mostra o
+ * R$/L de uma embalagem indisponível. Sem isso, uma embalagem grande barata sem estoque dava o preço
+ * e uma pequena cara em estoque dava o "em estoque" → preço incoerente.
+ */
+
+export interface EmbalagemComEstoque extends EmbalagemPreco {
+  /** Saldo indicativo (cache ~10min — não é promessa dura). */
+  estoque: number;
+}
+
+export interface ResolverOpcaoInput {
+  /** Existe vínculo boletim↔SKU confirmado pra a base (casamento). */
+  temSkuConfirmado: boolean;
+  /** O boletim tem catalisador (catalisador_codigo presente)? */
+  temCatalisador: boolean;
+  /** catalisador_proporcao_pct do boletim. */
+  proporcaoPct: number | null;
+  /** Embalagens da base (preço-do-cliente + litros + estoque). */
+  baseEmbalagens: EmbalagemComEstoque[];
+  /** Embalagens do catalisador; **[] quando o catalisador não está mapeado** (sem casamento). */
+  catalisadorEmbalagens: EmbalagemComEstoque[];
+}
+
+export interface OpcaoResolvida {
+  estado: EstadoVenda;
+  preco: PrecoPreparado;
+}
+
+const emEstoque = (e: EmbalagemComEstoque): boolean =>
+  Number.isFinite(e.estoque) && e.estoque > 0;
+
+export function resolverOpcaoVenda(input: ResolverOpcaoInput): OpcaoResolvida {
+  // Sem casamento → não há produto vendável; só alternativa técnica.
+  if (!input.temSkuConfirmado) {
+    return { estado: 'TECHNICAL_ONLY', preco: { status: 'incomplete', motivo: 'sem vínculo boletim↔SKU' } };
+  }
+
+  const catalisadorParam = (embs: EmbalagemComEstoque[]): EmbalagemComEstoque[] | null =>
+    input.temCatalisador ? embs : null;
+
+  // SELLABLE_NOW: o preço tem que FECHAR sobre embalagens EM ESTOQUE (preço == disponibilidade).
+  // Se o motor retorna 'ok' sobre o conjunto em-estoque, então a base (e o catalisador obrigatório)
+  // estão em estoque E precificados — coerente por construção.
+  const precoEmEstoque = precoLitroPreparado({
+    baseEmbalagens: input.baseEmbalagens.filter(emEstoque),
+    temCatalisador: input.temCatalisador,
+    catalisadorEmbalagens: catalisadorParam(input.catalisadorEmbalagens.filter(emEstoque)),
+    proporcaoPct: input.proporcaoPct,
+  });
+  if (precoEmEstoque.status === 'ok') {
+    return { estado: 'SELLABLE_NOW', preco: precoEmEstoque };
+  }
+
+  // ORDERABLE: estimativa de ENCOMENDA pela maior embalagem geral (pode ser 'ok' ou "sob consulta").
+  const precoEncomenda = precoLitroPreparado({
+    baseEmbalagens: input.baseEmbalagens,
+    temCatalisador: input.temCatalisador,
+    catalisadorEmbalagens: catalisadorParam(input.catalisadorEmbalagens),
+    proporcaoPct: input.proporcaoPct,
+  });
+  return { estado: 'ORDERABLE', preco: precoEncomenda };
+}


### PR DESCRIPTION
## Venda assistida — Fatia 1: motor de preço + estado (engine puro, money-path)

Primeira fatia da venda assistida por IA (design: [#825](https://github.com/LucasSardenbergL/afiacao/pull/825)). **Engine puro, testável sem prod nem LLM** — a IA nunca toca preço; B/C saem do Omie ÷ litros (de-para confirmado por você).

### O que entra
- `src/lib/venda-assistida/preco-preparado.ts` — `litrosDaEmbalagem(sufixo, descrição)` (de-para Sayerlack, base muda QT/GL/BH) + `precoLitroPreparado` (catalisado `(B+r·C)/(1+r)`, maior embalagem, degrada a "sob consulta" — **nunca soma componente ausente como zero**). **16 testes.**
- `src/lib/venda-assistida/resolver-estado.ts` — `classificarEstadoVenda` (em estoque / encomenda / sob consulta; "em estoque" exige base **E** catalisador + preço ok). **7 testes.**

### Decisões money-path (doc no PR)
De-para de litros · preço = **último praticado pro cliente** (rotulado não-contratual, Codex) · catalisador obrigatório ausente → sob consulta · estados conforme você confirmou. Detalhe em `docs/superpowers/plans/2026-06-14-venda-assistida-fatia1-resolver-pricing.md`.

### Ainda não tem consumidor
Os helpers são a fundação; o **resolver de dados + UI vendedor-only** (Fatia 2) liga eles ao casamento e **espera o Publish do #819 + popular vínculos**. **Codex adversarial roda no money-path completo** (engine + resolver) antes da feature ir ao ar.

CI: typecheck strict · 23 testes novos · lint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
