### PR TITLE
feat(skills): prove-sql-money-path + diagnose-supabase-sync

### DIFF
--- a/.claude/skills/diagnose-supabase-sync/SKILL.md
+++ b/.claude/skills/diagnose-supabase-sync/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: diagnose-supabase-sync
+description: >-
+  Diagnostica cron/sync/edge quebrado no Supabase deste repo (Afiação/Colacor) RODANDO as queries
+  read-only DIRETO no Postgres de produção via o wrapper ~/.config/afiacao/psql-ro. Use SEMPRE que:
+  o founder disser que "os dados estão velhos/desatualizados", "o sync parou", "não atualizou", "o
+  número está defasado"; chegar email "[Sync parado]" / "[Saúde de dados]" / alerta do Sentinela; um
+  cron parecer não ter rodado; ou um KPI/relatório estiver com dado antigo. Por quê: cron.job_run_details
+  MENTE "succeeded" (só registra o enqueue do net.http_post) — a verdade está em net._http_response +
+  fin_sync_log, e o diagnóstico é MULTI-CAMADA (scheduler → HTTP → handler → cursor → efeito no dado).
+  100% READ-ONLY: eu diagnostico sozinho (sem você colar no SQL Editor) e ENTREGO a ação (redeploy de
+  edge, rotacionar secret, forçar sync, dismiss) empacotada pra você aplicar — nunca aplico. NÃO use
+  para: aplicar a correção (é escrita → SQL Editor / chat do Lovable); bug de LÓGICA numa função SQL
+  (use prove-sql-money-path); erro de frontend/build; ou criar migration (use lovable-db-operator).
+---
+
+# Diagnose Supabase Sync
+
+## Por que esta skill existe
+
+Neste repo, sync de dados quebra **em silêncio** e o founder descobre dias depois (um incidente ficou 8 dias invisível). A causa é uma armadilha de observabilidade documentada no §5 do CLAUDE.md:
+
+> **`cron.job_run_details` reporta `succeeded` mesmo quando a edge respondeu 401/503 ou nem bootou.** Ele só registra que o `net.http_post` foi **enfileirado**, não o resultado HTTP. A verdade está em **`net._http_response`** (`status_code`/`content`/`error_msg`/`timed_out`) cruzada com **`fin_sync_log`** (iniciou/completou/órfã) e o **efeito real no dado**.
+
+Diagnosticar isso é multi-camada (scheduler → transporte HTTP → handler → cursor → efeito) e cheio de falsos sinais (`complete` em rajadas; `created_at` é data comercial, não frescor; ausência ≠ falha). Antes, cada passo exigia o founder colar SQL no SQL Editor e trazer o resultado — lento, e por isso o diagnóstico raramente acontecia a tempo.
+
+**Agora há acesso read-only direto ao banco** (`~/.config/afiacao/psql-ro`, role `claude_ro`), então eu rodo a árvore inteira sozinho, em minutos, e entrego a você só a **conclusão + a ação**. (Se o acesso não existir nesta máquina, a skill cai no modo fallback: gera os blocos read-only pra você colar.)
+
+## A Lei de Ferro (3 regras inegociáveis)
+
+1. **100% read-only — nenhuma escrita, nem "inofensiva".** O wrapper `psql-ro` já força `SESSION READ ONLY` (barra escrita até via RPC `SECURITY DEFINER`). Mesmo assim, **nunca** rode com intenção de escrever. Lista do que parece leitura mas NÃO é: `SELECT net.http_post(...)` (efeito externo + pode **duplicar** uma operação money-path), `SELECT data_health_watchdog()/fin_sync_watchdog_check()` (escrevem `fin_alertas`), `SELECT ...dismiss...` (apaga evidência), qualquer RPC que force sync (mexe em cursor/rate-limit/money-path). A **ação corretiva é do humano** (passo final). Também: **nunca leia nem imprima o Vault** (`vault.decrypted_secrets`) — `BYPASSRLS` é acesso privilegiado; segredo não entra no diagnóstico.
+
+2. **Vigie o EFEITO no dado, não o status técnico.** Um sinal sozinho mente. `job_run_details=succeeded` é só enqueue. `fin_sync_log.complete` ocorre em **rajadas** (idle saudável parece "parado"). `sales_orders.created_at` é a **data do pedido no Omie** (pode ser futura), não frescor. Prove o incidente por **efeito específico do domínio + correlação temporal**, nunca por `MAX(updated_at)` genérico nem por um único sinal.
+
+3. **Diagnosticado ≠ corrigido.** Entregue o veredito nos **estados rígidos** abaixo. A ação (redeploy/secret/trigger/dismiss) sai **empacotada** pro humano, marcada `NÃO EXECUTADO`. Só declare **RECUPERADO** depois que o humano agir **e** um novo ciclo rodar saudável **com efeito no dado** — re-rodando a skill. "Redeploy solicitado" não é "corrigido".
+
+## Como conectar (read-only)
+
+```bash
+RO=~/.config/afiacao/psql-ro      # wrapper blindado: SESSION READ ONLY + statement_timeout 30s
+$RO -c "select now();"            # use o now() do BANCO, nunca o relógio local
+```
+
+Se `~/.config/afiacao/psql-ro` não existir (outra máquina), use o **modo fallback**: entregue cada query do `references/diagnostic-tree.md` como bloco read-only rotulado `🟣 Lovable → SQL Editor → cola → Run` e peça o resultado. O diagnóstico é o mesmo; só muda quem roda.
+
+## O fluxo — 8 passos (detalhe + queries em `references/diagnostic-tree.md`)
+
+Antes da árvore, ancore no **registry do sync** (`references/sync-registry.md`): qual cron → qual edge → qual `action`/empresa → cadência/timezone → semântica do `fin_sync_log` → **probe de efeito**. Sem isso o `net._http_response` é ambíguo (vários crons compartilham minuto/endpoint).
+
+1. **Escopo & expectativa** — sync/empresa/action exatos; cron existe/ativo/`schedule`; **última janela em que DEVERIA ter rodado** (com `now()` do banco). Ausência só é falha se uma execução esperada já passou.
+2. **Confirmar o incidente** — `fin_alertas` ativos vs `dismissed_at`; estado do Sentinela; **probe de efeito** do domínio (não `MAX(updated_at)` genérico).
+3. **Scheduler** — cron ativo, `schedule` certo, e **tem `timeout_milliseconds`** no comando? (sem ele, `pg_net` usa default 5s e mata função >5s, silencioso). `job_run_details` só prova enqueue.
+4. **Transporte HTTP** — `net._http_response` numa **janela estreita** em torno do cron: distribuição de `2xx/401/503/546/NULL`, `content`, `error_msg`, `timed_out`. Não "últimos erros" soltos.
+5. **Handler** — cruza com `fin_sync_log`: iniciou (`running`)? completou (`complete`)? erro? **órfã `running`** antiga? (transforma HTTP em diagnóstico de **camada**).
+6. **Progresso** — `fin_sync_cursor.next_page` pendente e **idade** (>2h = continuação quebrada); resultado parcial/duração.
+7. **Contraprova** — edge **irmã** funciona? `401` **sistêmico** (muitas edges) ou **isolado** (uma)? outras edges também `503`/timeout? repetir em **≥2 janelas** quando aplicável.
+8. **Veredito** — montar o pacote de saída abaixo.
+
+## Atalhos conclusivos (sintoma → causa provável → ação humana)
+
+| Sinal | Causa provável | Ação (do humano) |
+|---|---|---|
+| cron devido + enqueue presente + **401 em muitas edges** | `CRON_SECRET` do Vault divergiu da env das edges | realinhar o secret (Vault + edges) no Lovable |
+| **`503 LOAD_FUNCTION_ERROR` + zero `running`** numa edge | edge não BOOTA (pré-handler) | **redeploy verbatim** dessa edge via chat do Lovable |
+| **`546`/timeout 60s + zero `running` em VÁRIAS edges** | incidente de **plataforma** Supabase | **esperar estabilizar**; NÃO martelar redeploy |
+| `2xx` + **órfã `running`** | kill/catch/finalização (não chamou `completeSync`) | corrigir o handler; o watchdog reclassifica órfã |
+| `2xx` + `complete` + **efeito ausente** | sucesso técnico falso / bug semântico | investigar a lógica (→ `prove-sql-money-path`) |
+| **cursor `next_page` parado >2h** | continuação travada | forçar continuação / investigar budget |
+| cron **sem `timeout_milliseconds`** | `pg_net` default 5s mata função longa | re-agendar o cron com `timeout_milliseconds` |
+
+⚠️ **`401` isolado** (uma edge) pode ser `verify_jwt`/header/gate da própria edge — **não** conclua rotação de secret.
+
+## Pacote de saída (a fronteira da autonomia)
+
+Termine SEMPRE com este formato — é o que impede "diagnosticado" virar "corrigido":
+
+```
+DIAGNÓSTICO: CONFIRMADO | PROVÁVEL | INCONCLUSIVO  — <causa em 1 linha>
+EVIDÊNCIAS: <sinais com timestamp + as queries que rodei>
+AÇÃO HUMANA NECESSÁRIA: <comando/prompt EXATO — redeploy de qual edge / SQL de re-agendar / etc.>
+NÃO EXECUTADO: <o que NÃO fiz por ser escrita: redeploy, secret, trigger, dismiss>
+COMO REVALIDAR: <a query read-only que prova recuperação — efeito + novo ciclo>
+ESTADO: AGUARDANDO AÇÃO HUMANA
+```
+
+Depois que o humano agir, **re-rode a skill**; só então `RECUPERADO` (com novo ciclo saudável + efeito no dado).
+
+## Armadilhas (as que mais causam falso-diagnóstico)
+
+1. **Atribuir `net._http_response` ao sync errado.** Vários crons compartilham endpoint/minuto e a resposta pode não identificar `action`/empresa. Sem correlação temporal + `fin_sync_log`, marque **INCONCLUSIVO** — não chute.
+2. **Staleness sem semântica.** `created_at` é data comercial; tabelas dormem legitimamente; `complete` é em rajadas. Use o **probe registrado por sync**, não `MAX(updated_at)`.
+3. **Ausência tratada como falha.** Cron não-devido, fim de semana, resposta já expurgada do `net._http_response`, par dormente. **Calcule a última execução esperada** antes de gritar.
+4. **Generalizar a assinatura "zero `running` = não bootou".** Só vale pra edges cujo contrato grava `running` logo após o boot. Confirme no registry por edge antes de concluir.
+
+## Arquivos de apoio
+
+- `references/diagnostic-tree.md` — os 8 passos com as queries read-only EXATAS (prontas pro `psql-ro`).
+- `references/sync-registry.md` — catálogo dos syncs money-path (cron → edge → action → cadência → semântica do `fin_sync_log` → probe de efeito) + a query que re-deriva os crons do banco ao vivo.
+- `evals/trigger-eval.json` — casos de disparo.

--- a/.claude/skills/diagnose-supabase-sync/evals/trigger-eval.json
+++ b/.claude/skills/diagnose-supabase-sync/evals/trigger-eval.json
@@ -1,0 +1,20 @@
+[
+  { "query": "os dados do financeiro estão desatualizados, parece que o contas a receber parou", "should_trigger": true, "note": "dado velho + sync suspeito — caso canônico" },
+  { "query": "recebi um email '[Sync parado]' das contas a pagar da colacor", "should_trigger": true, "note": "alerta do watchdog por email" },
+  { "query": "chegou '[Saúde de dados] vendas_pedidos degradado', o que houve?", "should_trigger": true, "note": "alerta do Sentinela" },
+  { "query": "a positivação do mês não atualizou hoje, tá com número de ontem", "should_trigger": true, "note": "KPI defasado → diagnóstico de frescor" },
+  { "query": "não apareceu pedido de compra sugerido hoje, acho que o cron de reposição não rodou", "should_trigger": true, "note": "cron suspeito de não ter rodado" },
+  { "query": "o sync do Omie tá quebrado faz dias?", "should_trigger": true, "note": "incidente de sync prolongado" },
+  { "query": "o estoque não está atualizando no app", "should_trigger": true, "note": "frescor de dado de sync" },
+  { "query": "os scores da carteira parecem congelados, calculated_at antigo", "should_trigger": true, "note": "sync de scoring parado" },
+  { "query": "por que o relatório financeiro está com dado de 3 dias atrás?", "should_trigger": true, "note": "frescor → multi-camada (cron/HTTP/handler)" },
+  { "query": "tem cron rodando 'succeeded' mas o dado não muda, confia nisso?", "should_trigger": true, "note": "o exato falso-positivo do job_run_details" },
+
+  { "query": "aplica a correção do sync que você diagnosticou (rotaciona o CRON_SECRET)", "should_trigger": false, "note": "AÇÃO de escrita → SQL Editor / chat Lovable, não esta skill" },
+  { "query": "redeploya a edge omie-financeiro", "should_trigger": false, "note": "deploy = ação humana via chat Lovable; a skill entrega, não executa" },
+  { "query": "consertei a aplicar_promocoes que tinha JOIN inválido, valida a lógica", "should_trigger": false, "note": "bug de lógica SQL → prove-sql-money-path" },
+  { "query": "cria um cron novo pra rodar o sync de estoque às 9h", "should_trigger": false, "note": "criar objeto → lovable-db-operator" },
+  { "query": "o build quebrou com erro de tipo em useOrders", "should_trigger": false, "note": "erro de frontend/build — investigate" },
+  { "query": "roda um SELECT pra exportar os pedidos do mês pro Excel", "should_trigger": false, "note": "leitura comum, não diagnóstico de sync" },
+  { "query": "o login não persiste depois do refresh", "should_trigger": false, "note": "bug de auth no frontend" }
+]

--- a/.claude/skills/diagnose-supabase-sync/references/diagnostic-tree.md
+++ b/.claude/skills/diagnose-supabase-sync/references/diagnostic-tree.md
@@ -1,0 +1,110 @@
+# Árvore de diagnóstico — queries read-only por passo
+
+Todas via `RO=~/.config/afiacao/psql-ro`. Schema validado em prod (colunas reais abaixo).
+Substitua `<sync>` / `<action>` pelo alvo (ver `sync-registry.md`). **Use o `now()` do banco**, nunca o relógio local.
+
+Colunas reais (não erre como `company` vs `companies`):
+- `net._http_response(id, status_code, content_type, headers, content, timed_out, error_msg, created)` — **sem jobid**: correlação cron→resposta é por **tempo** (janela) + `content`.
+- `public.fin_sync_log(id, action, companies[], status, results, error_message, triggered_by, started_at, completed_at, duracao_ms, api_calls, rate_limits_hit)`
+- `public.fin_sync_cursor(company, resource, next_page, updated_at, backfill_desde)`
+- `public.fin_alertas(id, company, tipo, severidade, mensagem, valor, threshold, contexto, criado_em, dismissed_at, dismissed_until, email_enfileirado_em)`
+
+---
+
+## Passo 1 — Escopo & expectativa
+
+```bash
+$RO -tAc "select now() as agora_no_banco;"
+$RO -c "select jobid, jobname, schedule, active from cron.job where jobname ilike '%<sync>%';"
+```
+Calcule a **última janela em que deveria ter rodado** a partir do `schedule` + `now()`. Ausência só é falha se essa janela já passou (cuidado com fim de semana / `1-5` / cadência rara).
+
+## Passo 2 — Confirmar o incidente
+
+```bash
+# alertas ATIVOS (não dismissados) — o que o Sentinela está gritando agora
+$RO -c "select tipo, severidade, left(mensagem,70) msg, to_char(criado_em,'MM-DD HH24:MI') em
+        from public.fin_alertas where dismissed_at is null order by criado_em desc limit 20;"
+```
++ **probe de efeito do domínio** (ver `sync-registry.md` — NÃO `MAX(updated_at)` genérico). Ex.: vendas → última `sync_pedidos` em `fin_sync_log`; financeiro → idem CP/CR/mov.
+
+## Passo 3 — Scheduler
+
+```bash
+# o command tem timeout_milliseconds? (sem ele, pg_net usa default 5s e mata função >5s, silencioso)
+$RO -c "select jobname, active, schedule,
+               (position('timeout_milliseconds' in command) > 0) as tem_timeout
+        from cron.job where jobname ilike '%<sync>%';"
+```
+`job_run_details` só prova **enqueue** — não use como prova de sucesso. (Se quiser ver: `select status, return_message, start_time from cron.job_run_details where jobid=<id> order by start_time desc limit 5;` — mas trate como "foi enfileirado", não "rodou ok".)
+
+## Passo 4 — Transporte HTTP (a verdade que o job_run_details esconde)
+
+```bash
+# janela estreita em torno do horário do cron — distribuição + corpo
+$RO -c "select status_code, timed_out, to_char(created,'MM-DD HH24:MI') t,
+               left(coalesce(content, error_msg, '(vazio)'),80) corpo
+        from net._http_response
+        where created > now() - interval '6 hours'
+        order by created desc limit 30;"
+# distribuição 24h (acha 401/503/546/NULL/timeout em massa):
+$RO -c "select status_code, timed_out, count(*) n
+        from net._http_response where created > now() - interval '24 hours'
+        group by 1,2 order by n desc;"
+```
+⚠️ `status_code IS NULL` é mudo no leitor simples — **sempre** trazer `error_msg` e `timed_out` junto. `LOAD_FUNCTION_ERROR`/`WORKER_RESOURCE_LIMIT` aparecem no `content`.
+
+## Passo 5 — Handler (cruza HTTP com a camada de aplicação)
+
+```bash
+$RO -c "select companies, action, status, left(coalesce(error_message,''),50) erro,
+               to_char(started_at,'MM-DD HH24:MI') ini, to_char(completed_at,'MM-DD HH24:MI') fim
+        from public.fin_sync_log where action ilike '%<action>%'
+        order by started_at desc limit 10;"
+# órfãs 'running' antigas (kill/catch não finalizou) — sinal CONFIÁVEL de morte:
+$RO -c "select companies, action, to_char(started_at,'MM-DD HH24:MI') ini, age(now(), started_at) idade
+        from public.fin_sync_log
+        where status='running' and started_at < now() - interval '30 minutes'
+        order by started_at limit 20;"
+```
+**Zero `running` no `fin_sync_log` + 503/timeout no HTTP = a edge nem bootou** (o `running` é inserido só DEPOIS do boot, no `try`). Mas confirme no registry que a edge grava `running` (nem toda grava).
+
+## Passo 6 — Progresso (cursor)
+
+```bash
+$RO -c "select company, resource, next_page, age(now(), updated_at) idade
+        from public.fin_sync_cursor where next_page is not null order by updated_at;"
+```
+`next_page` parado **>2h** = continuação quebrada (ou backfill saudável demorando — cruze com o HTTP/handler).
+
+## Passo 7 — Contraprova (mata hipóteses)
+
+```bash
+# 401 sistêmico (muitas edges → secret) vs isolado (uma → gate/verify_jwt da própria edge)
+$RO -c "select status_code, count(*) n from net._http_response
+        where created > now() - interval '24 hours' group by 1 order by n desc;"
+# 5xx/NULL/timeout recentes — uma edge (redeploy) ou VÁRIAS (plataforma → não martelar)?
+$RO -c "select to_char(created,'MM-DD HH24:MI') t, status_code, timed_out,
+               left(coalesce(content,error_msg,''),60) corpo
+        from net._http_response
+        where (status_code >= 500 or status_code is null or timed_out)
+          and created > now() - interval '12 hours'
+        order by created desc limit 25;"
+```
+A **tripla** que desambigua em segundos: sync irmão OK (200) + zero-401 + zero-running ⇒ a edge-alvo não boota. Repita em ≥2 janelas quando aplicável.
+
+---
+
+## Atalhos conclusivos (sintoma → causa → ação humana)
+
+| Sinal (cruzado) | Causa provável | Ação (NÃO executo — entrego) |
+|---|---|---|
+| cron devido + enqueue + **401 em muitas edges** | `CRON_SECRET` Vault ≠ env das edges | realinhar secret (Vault + edges) no Lovable |
+| **`503 LOAD_FUNCTION_ERROR` + zero `running`** (1 edge) | edge não BOOTA (pré-handler) | redeploy verbatim dessa edge (chat Lovable) |
+| **`546`/timeout + zero `running` em VÁRIAS edges** | incidente de **plataforma** | esperar estabilizar; NÃO martelar redeploy |
+| `2xx` + **órfã `running`** | catch/kill não finalizou | corrigir handler; watchdog reclassifica |
+| `2xx` + `complete` + **efeito ausente** | bug semântico / sucesso falso | → `prove-sql-money-path` na lógica |
+| cursor `next_page` **>2h** | continuação travada | forçar continuação / investigar budget |
+| cron **sem `timeout_milliseconds`** | `pg_net` default 5s mata função | re-agendar cron com `timeout_milliseconds` |
+
+⚠️ `401` **isolado** (1 edge) ≠ secret → pode ser `verify_jwt`/header/gate da edge.

--- a/.claude/skills/diagnose-supabase-sync/references/sync-registry.md
+++ b/.claude/skills/diagnose-supabase-sync/references/sync-registry.md
@@ -1,0 +1,36 @@
+# Registry dos syncs — o que existe, e como provar o efeito de cada um
+
+Sem ancorar no sync certo, o `net._http_response` é ambíguo (65 crons compartilham minuto/endpoint). Este registry tem os **money-path críticos** curados + a query que **re-deriva do banco ao vivo** (a lista muda; não confie só nesta tabela).
+
+## Derive a lista atual do banco (faça isto primeiro)
+
+```bash
+RO=~/.config/afiacao/psql-ro
+# crons ativos (65 no total em 2026-06)
+$RO -c "select jobname, schedule from cron.job where active order by jobname;"
+# quais syncs logam em fin_sync_log (= rastreáveis por camada) e o frescor de cada um:
+$RO -c "select action, max(started_at) ultimo, count(*) filter (where status='running') rodando_agora
+        from public.fin_sync_log group by action order by ultimo desc;"
+```
+
+## Famílias money-path (curado)
+
+| Família | Cron(s) | Edge → action | `fin_sync_log`? | Cursor? | Probe de EFEITO (não `MAX(updated_at)` genérico) |
+|---|---|---|---|---|---|
+| **Financeiro CP/CR/mov** | `fin-sync-cp-2x` (0 8,14), `-cr-2x` (20 8,14), `-mov-2x` (40 8,14), `fin-sync-continuacao-10min` (*/10) | `omie-financeiro` → `sync_contas_pagar`/`_receber`/`_movimentacoes` | **sim** (`action='sync_contas_*'`) | **sim** (`fin_sync_cursor` CP/CR/mov por empresa) | último `complete` de cada action no `fin_sync_log`; cursor `next_page` deve zerar |
+| **Vendas pedidos** | `vendas-sync-pedidos-oben-2h` (5 */2), `-colacor-2h` (20 */2) | `omie-vendas-sync` → `sync_pedidos` | **sim** | não | último `complete` de `sync_pedidos` no `fin_sync_log`. ⚠️ **NUNCA** use `sales_orders.created_at` (= data do pedido no Omie, pode ser futura) |
+| **Vendas estoque/cadastro** | `omie-sync-estoque-*`, `sync-customers-vendas-daily` (0 5), `omie-sync-metadados-daily` | `omie-vendas-sync` → `sync_estoque`/`sync_customers`/`sync_products` | **sim** | (customers roda em background via waitUntil) | `fin_sync_log`; `product_costs.updated_at`; `omie_products`/`omie_clientes` `max(updated_at)` |
+| **Reposição/compras** | `gerar-pedidos-diario-oben` (15 9), `-intraday-oben`, `disparar-pedidos-aprovados-oben` (0 13), `sayerlack-portal-watchdog` (*/5), `sayerlack-retry-orfaos` (*/15) | `gerar-pedidos-diario`, `disparar-pedidos-aprovados`, `enviar-pedido-portal-sayerlack` | **NÃO** (não logam em `fin_sync_log`) | não | `pedido_compra_sugerido` do dia; `status_envio_portal` preso; checks `reposicao_*` em `fin_alertas` |
+| **Scoring/carteira** | `daily-calculate-scores` (0 6), `scoring-recalc-batch-nightly`, `carteira-rebuild-nightly` | `calculate-scores`, `scoring/*` | não | não | `farmer_client_scores.calculated_at`; `customer_visit_scores` frescor |
+| **Sentinela (vigias)** | `data-health-watchdog` (*/30), `fin-sync-watchdog` (*/30), `fin-sync-heartbeat` (0 11 1-5) | SQL local (sem `net.http_post`) | n/a | n/a | **ler** `fin_alertas` ativos; se o heartbeat sumiu, o próprio vigia morreu |
+| **Notificações** | `afiacao_dispatch_notificacoes_30min` (*/30), `push-sla-tick` (*/15) | `dispatch-notifications`, `enviar-push` | não | não | `fornecedor_alerta` preso em `pendente_notificacao`; check `alert_channel` |
+
+> ⚠️ Antes de aplicar a assinatura "zero `running` = não bootou", confirme que a edge **grava `running`** logo após o boot. As famílias com `fin_sync_log=sim` (financeiro, vendas) gravam. As com `NÃO` (reposição, scoring, notificações) **não** — pra essas, o sinal de morte é o **HTTP** (`net._http_response`) + a **tabela de efeito**, não a ausência de `running`.
+
+## Princípio (Lei #2 da skill)
+
+O probe de efeito é por-sync e **validado ao vivo** (`psql-ro`) — se não souber a coluna certa, descubra com `information_schema.columns` antes (a lição do `company` vs `companies`). Frescor por "tempo desde o último `complete`" é **não-confiável** (loga em rajadas); o sinal de morte confiável é **`running` travado** (onde existe) + **HTTP de erro** + **efeito ausente cruzado com a janela esperada**.
+
+## Manutenção
+
+Registre aqui um sync novo só quando ele tiver **gotcha** (probe não-óbvio, não grava `running`, cadência estranha). O resto deriva da query ao vivo acima. Re-derive sempre que a `main` adicionar cron (as migrations `cron.schedule` em `supabase/migrations/`).

--- a/.claude/skills/prove-sql-money-path/SKILL.md
+++ b/.claude/skills/prove-sql-money-path/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: prove-sql-money-path
+description: >-
+  Prova uma mudança de SQL de risco num PostgreSQL 17 LOCAL descartável, com falsificação,
+  ANTES de entregar a migration. Use SEMPRE que a tarefa criar/alterar migration, função
+  SQL/RPC, trigger, RLS policy, view, constraint (CHECK/UNIQUE) ou cron que toque (a) DINHEIRO
+  (financeiro/DRE/projeção de caixa, reposição/compras, pedido a fornecedor, preço, estoque,
+  positivação/comissão), (b) AUTORIZAÇÃO (RLS, gate de staff/master, SECURITY DEFINER, REVOKE),
+  ou (c) AUTOMAÇÃO (sync do Omie, geração de pedido, cron). Vale mesmo quando o usuário não diz
+  "teste" e só descreve o objetivo ("cria a RPC que aprova o pedido", "RLS pra vendedor não ver
+  custo", "trigger que enfileira o recálculo", "CHECK pra não comprar abaixo do mínimo"). Por quê:
+  uma função plpgsql com SQL inválido PASSA no CREATE (late-bound) e só falha ao EXECUTAR — atrás
+  de um cron/try-catch, falha SILENCIOSA por dias; e o founder não tem terminal pro backend, então
+  o único teste possível ANTES de aplicar em produção é o PG17 local que EU rodo. Esta skill empacota
+  o ritual: monta o harness PG17 a partir do template, aplica a migration REAL, semeia, escreve
+  asserts positivos E negativos (com SQLSTATE + re-raise), prova RLS com SET ROLE, e FALSIFICA (sabota
+  a migração → exige vermelho). É a contraparte da lovable-db-operator (que entrega o handoff + valida
+  pós-apply); esta PROVA antes. NÃO use para: SELECT read-only, mudança só de frontend, edge function
+  sem SQL novo, migração trivial sem money-path/auth (ex.: índice puro de performance), ou regenerar
+  tipos TS. Quando o Codex estiver fora (cota do Plus), o PG17 falsificável é o "Caminho B" — o oráculo
+  que substitui a 2ª opinião no caminho do dinheiro.
+---
+
+# Prove SQL Money-Path
+
+## Por que esta skill existe (leia antes de qualquer coisa)
+
+Duas verdades deste repo se combinam num risco silencioso:
+
+1. **plpgsql é *late-bound*.** Uma função/RPC/trigger com SQL inválido (coluna ambígua, JOIN que referencia a tabela-alvo, `SUM` que colide com coluna OUT do `RETURNS TABLE`) **passa no `CREATE OR REPLACE`** — o Postgres só resolve os nomes ao **EXECUTAR**. Se essa função roda atrás de um cron ou de um `try/catch` best-effort, ela falha **silenciosamente por tempo indefinido**. Já aconteceu aqui ≥3 vezes (`aplicar_promocoes_no_ciclo` quebrada em prod por um JOIN inválido; `gerar_pedidos_oportunidade_ciclo` por `SUM` ambíguo; ambas atrás de chamador silencioso — o §10 do CLAUDE.md tem o histórico).
+
+2. **O founder não tem terminal pro backend.** Ele aplica SQL colando no SQL Editor do Lovable. Não há staging. O **único** teste possível **antes** de o SQL tocar produção é o que **eu** rodo num PostgreSQL 17 local descartável.
+
+Logo: pra qualquer SQL que mexe com dinheiro, autorização ou automação, **o PG17 local com falsificação é a rede de segurança**. Ele roda a função **de verdade** (pega o bug late-bound), prova os invariantes do money-path, prova que o gate/RLS **nega** quem deve negar, e — o passo que separa teste real de teatro — **se sabota de propósito pra provar que os asserts têm dente**.
+
+Esta skill não fabrica a prova. Ela resolve o boilerplate PG17 chato (initdb descartável, contorno do keg-only do brew, stubs do Supabase, GUC pra impersonar RLS) e **impõe a disciplina** que faz o teste valer. Os asserts e a falsificação você escreve pensando em cada caso — auto-gerá-los recriaria exatamente o teatro que a falsificação existe pra matar.
+
+## A Lei de Ferro (3 regras inegociáveis)
+
+Quebrar qualquer uma recria o bug que esta skill previne.
+
+1. **Aplique a migração REAL, nunca um stub da lógica.** O `.sql` commitado é o que roda (`psql -f supabase/migrations/<arquivo>.sql`). Stubar a função e testar o stub não pega o bug late-bound — que é o motivo nº 1 da skill. Se a migração depende de tabelas/funções que ainda não existem no PG limpo, crie os **pré-requisitos** (stub das tabelas que ela lê, ou o snapshot inteiro), mas **a função sob teste é a real**.
+
+2. **Todo assert negativo captura a `SQLSTATE`/condição ESPERADA e re-lança o resto.** Um gate que deve dar `RAISE EXCEPTION`, um CHECK que deve rejeitar, um REVOKE que deve dar `permission denied` — o teste prova que o erro **certo** acontece. `WHEN OTHERS THEN 'OK'` é **teatro**: engole qualquer erro (inclusive um erro de digitação no seu próprio teste) e pinta verde. Capture a SQLSTATE esperada; no `WHEN OTHERS`, **`RAISE`** (relança). Ver `references/assert-patterns.md`.
+
+3. **Falsificação obrigatória no que importa.** Pra cada invariante que o money-path/gate depende: **sabota a migração de propósito** (recria a policy furada, dropa o trigger, troca o gate por `IF false`) e **exija que o assert correspondente fique VERMELHO**. Se sabotar e o teste seguir verde, o assert não tem dente — conserte o assert. Depois **restaure** a versão verdadeira. Regra anti-teatro: a **sentinela** do teste (a string que você procura pra decidir pass/fail num caminho negativo) **nunca pode conter o texto que o próprio código emite** — senão um `ILIKE`/`position()` casa a própria sentinela e o assert mente. (Isto já mordeu: ver a lição do `test-melhorias-rpcs.sh` no §10.)
+
+## Quando NÃO usar
+
+- **SELECT read-only / export** — não muda estado, não há invariante pra provar.
+- **Mudança só de frontend** (React/TS) — use os testes vitest do helper puro.
+- **Edge function sem SQL novo** — a lógica Deno se testa pelo helper espelhado (vitest); só entre aqui pela parte SQL (RPC/migration) que a edge chama.
+- **Migração trivial sem money-path nem auth** — ex.: índice puro de performance, `COMMENT ON`, rename cosmético. (Mas: `UNIQUE`/`CHECK` que protege o money-path, ou índice que muda o resultado de uma RPC, **valem** o teste.)
+- **Regenerar tipos TS** — não toca o banco.
+
+Na dúvida entre "trivial" e "money-path": se um bug naquele SQL faria o app **comprar errado, cobrar errado, vazar dado entre usuários, ou recomendar número fabricado** — é money-path, teste.
+
+## O ritual — 6 passos
+
+Quando a tarefa exigir provar SQL de risco, siga em ordem. Os passos 4 (negativos) e 5 (falsificação) são onde o teste deixa de ser teatro — não pule.
+
+### Passo 1 — Listar o que provar (antes de escrever uma linha)
+
+Escreva, em prosa curta, os **invariantes** e os **caminhos negativos**. Pense em 3 famílias:
+
+- **Positivo (caminho feliz):** o efeito pretendido acontece. Ex.: "aprovar o pedido seta `status='aprovado'` e grava `aprovado_por`"; "a RPC valoriza `preco_unitario` pelo cmc quando há cmc".
+- **Negativo (a defesa morde):** quem/o-que deve ser barrado é barrado. Ex.: "não-master chamando a RPC → `RAISE forbidden`"; "CHECK rejeita `minimo <= 0`"; "REVOKE → `authenticated` não executa"; "RLS → vendedor não vê custo de outro".
+- **Money-path específico:** o número certo. Ex.: "GREATEST eleva ao piso mas NUNCA vira gatilho de compra"; "dedupe não double-conta"; "ausente vira NULL, não R$0".
+
+Cada item vira 1 assert. Se um item não dá pra falsificar (não dá pra sabotar a migração e ver vermelho), provavelmente não é um invariante de verdade — reconsidere.
+
+### Passo 2 — Montar o harness a partir do template
+
+Copie o esqueleto e nomeie pelo slug da migration:
+
+```bash
+cp .claude/skills/prove-sql-money-path/references/harness-template.sh db/test-<slug>.sh
+chmod +x db/test-<slug>.sh
+```
+
+O template já resolve: PG17 descartável (initdb em tmpdir + trap cleanup), contorno do keg-only do brew, `LC_ALL=C` (sem isso o postmaster aborta), `db/stubs-supabase.sql` (roles `anon`/`authenticated`/`service_role`, schema `auth`, `auth.users`), `auth.uid()`/`auth.role()` lendo GUC de sessão (pra impersonar RLS), e `service_role` com `BYPASSRLS`. Você preenche 4 zonas marcadas `[[...]]`: pré-requisitos de schema, a migration a aplicar, os seeds, os asserts/falsificação.
+
+### Passo 3 — Pré-requisitos + aplicar a migration REAL (Lei #1)
+
+Na **ZONA 1**, crie o que a migração **lê/altera mas não cria**. Dois caminhos:
+
+- **Mínimo (rápido):** `CREATE TABLE` stub só das tabelas que a migração toca, com as colunas que ela usa. Bom quando a migração é auto-contida.
+- **Fiel (mais lento):** aplique o `supabase/schema-snapshot.sql` inteiro (o template tem o `sed`/`grep` de restore-ready comentado). Use quando a migração depende de muitas tabelas/funções reais. ⚠️ O snapshot pode estar **stale** (ver §5/§6 do CLAUDE.md — já faltou `order_date_kpi`, `tipo_produto`, `minimo_forcado_manual`); se faltar uma coluna recente, adicione um `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` antes de aplicar a migração.
+
+Na **ZONA 2**, aplique a migração real. Se a função recriada também existe em prod, faça o **pré-flight** mental do §10: o corpo que você testa deve ser o corpo que vai pra prod (cuidado com drift repo×prod em `CREATE OR REPLACE`).
+
+### Passo 4 — Asserts positivos, negativos e RLS (Lei #2)
+
+Use `references/assert-patterns.md`. Resumo:
+- **Positivo:** rode a função/insira a linha, leia o efeito, compare (`eq`).
+- **Negativo:** bloco `DO $$ ... EXCEPTION WHEN <sqlstate_esperada> THEN ... WHEN OTHERS THEN RAISE; END $$` — passa só se o erro **esperado** veio; qualquer outro relança.
+- **RLS:** `SET test.uid='<uuid>'; SET ROLE authenticated; SELECT count(*) ...` (own-scope, staff, anon-deny). `service_role` (BYPASSRLS) pra semear.
+
+### Passo 5 — Falsificação (Lei #3)
+
+Pra cada assert que protege dinheiro/autorização: sabota a migração na sessão de teste (recria a policy/trigger/função **na versão furada**), **re-roda só aquele assert** e **exija que ele falhe**; se passar, o assert é fraco. Restaure a versão verdadeira (cirurgicamente — só o que sabotou). Sentinela **anti-teatro** (não contém o texto do código). Ver o padrão completo em `references/assert-patterns.md`.
+
+### Passo 6 — Rodar até verde-real, reportar e commitar
+
+```bash
+bash db/test-<slug>.sh   # NÃO pipe pra tail — engole o exit code (§2 do CLAUDE.md); redirecione e cheque $?
+echo "exit=$?"
+```
+
+Itere até: **verde com a migração real** E **vermelho com cada sabotagem** (durante o desenvolvimento da falsificação). Reporte ao usuário: quantos asserts, o que cada um prova (1 linha), e que a falsificação confirmou o dente. Commite o `db/test-<slug>.sh` junto com a migração — vira regressão executável e evidência pro PR.
+
+> ⚠️ **`bash db/test-*.sh | tail -N` ENGOLE o exit≠0** (o pipe retorna o status do `tail`). Já mordeu (§10, fixes-codex-711). Quando o exit importa: `> /tmp/log 2>&1; echo $?` e leia o log.
+
+## Relação com as outras skills
+
+- **`lovable-db-operator`** — composição. Fluxo money-path: desenhar SQL → **`prove-sql-money-path`** (testa local, falsifica) → **`lovable-db-operator`** (empacota o handoff "cole no SQL Editor" + a query de validação pós-apply) → founder aplica. A `db-operator` valida que o objeto **existe** após o Run; esta prova que ele **funciona** antes.
+- **`/codex` (challenge/consult)** — o adversarial do Codex e o PG17 são complementares. Quando o Codex está fora (cota do Plus esgota em janela rolante de 7d), o PG17 falsificável é o **"Caminho B"** registrado no §5/§10: o oráculo que substitui a 2ª opinião no caminho do dinheiro. Marque `REVISÃO INDEPENDENTE PENDENTE` e rode o Codex retroativo quando a cota voltar — auto-prova não substitui revisão independente, só cobre o intervalo.
+
+## Arquivos de apoio desta skill
+
+- `references/harness-template.sh` — o esqueleto PG17 descartável pronto (copie pra `db/test-<slug>.sh` e preencha as 4 zonas).
+- `references/assert-patterns.md` — padrões prontos: assert positivo, negativo (SQLSTATE + re-raise), RLS (SET ROLE + GUC), e o padrão de falsificação anti-teatro.
+- `evals/trigger-eval.json` — casos `should_trigger` true/false pra calibrar o disparo da skill.
+
+## Pré-requisitos da máquina
+
+`brew install postgresql@17 pgvector`. O template contorna o keg-only do brew (copia `share`/`lib` do Cellar) e usa `LC_ALL=C`. Roda em ~2-5s por harness. Se rodar vários em paralelo (40 worktrees), ajuste a `PORT` no topo do harness pra não colidir.

--- a/.claude/skills/prove-sql-money-path/evals/trigger-eval.json
+++ b/.claude/skills/prove-sql-money-path/evals/trigger-eval.json
@@ -1,0 +1,23 @@
+[
+  { "query": "escrevi a RPC que aprova o pedido de compra e dispara pro fornecedor, quero garantir antes de mandar pro Lovable", "should_trigger": true, "note": "RPC money-path — prova antes de aplicar em prod" },
+  { "query": "cria a função gerar_pedidos_sugeridos_ciclo valorizando o preço pelo cmc em vez da média de compras", "should_trigger": true, "note": "RPC money-path (preço do pedido) — bug aqui = compra com valor errado" },
+  { "query": "RLS nova na fin_contas_pagar pra vendedor não enxergar o custo do fornecedor", "should_trigger": true, "note": "autorização — provar own/staff/anon com SET ROLE" },
+  { "query": "trigger que enfileira o recálculo de score quando o pedido muda de status", "should_trigger": true, "note": "trigger de automação — late-bound, roda atrás de cron" },
+  { "query": "CHECK pra não deixar comprar abaixo do mínimo de faturamento da Sayerlack", "should_trigger": true, "note": "constraint que protege o money-path" },
+  { "query": "UNIQUE(pedido_id, sku_codigo_omie) pra não duplicar item de compra silenciosamente", "should_trigger": true, "note": "constraint anti-compra-dupla = money-path, vale provar" },
+  { "query": "REVOKE da função de claim pra só service_role poder executar", "should_trigger": true, "note": "autorização — provar permission denied (42501) pra authenticated" },
+  { "query": "cria a SECURITY DEFINER que confirma o vínculo do boletim, só master pode", "should_trigger": true, "note": "gate master + SECDEF — provar que nega não-master e que valida a entrada" },
+  { "query": "view que decide quem positivou no mês pra base de comissão da vendedora", "should_trigger": true, "note": "view money-path (comissão) — provar a regra de elegibilidade + RLS" },
+  { "query": "migration que muda o gate da auto-aprovação de compra Sayerlack", "should_trigger": true, "note": "money-path + autorização — o caso mais sensível, falsificação obrigatória" },
+  { "query": "consertei a aplicar_promocoes_no_ciclo que estava com JOIN inválido, roda local pra confirmar", "should_trigger": true, "note": "bug late-bound de plpgsql — exatamente o que o PG17 pega" },
+
+  { "query": "roda uma query pra ver quantos pedidos a oben fechou esse mês", "should_trigger": false, "note": "SELECT read-only — não muda estado, nada a provar" },
+  { "query": "o login não persiste depois do refresh, o supabase client perde a sessão", "should_trigger": false, "note": "bug de frontend/auth — investigate/supabase, não SQL de banco" },
+  { "query": "edge function nova pro webhook de status da nvoip", "should_trigger": false, "note": "edge sem SQL novo — testa pelo helper espelhado (vitest)" },
+  { "query": "regenera os tipos TypeScript do supabase depois das tabelas novas", "should_trigger": false, "note": "regen de tipos TS — não toca o banco" },
+  { "query": "adiciona um índice em sales_orders(created_at) pra acelerar a listagem", "should_trigger": false, "note": "índice puro de performance — não muda resultado nem money-path" },
+  { "query": "adiciona uma coluna observacao text na customer_contacts, sem lógica nenhuma", "should_trigger": false, "note": "coluna pura sem trigger/RLS/CHECK — db-operator basta; nada a 'provar' rodando" },
+  { "query": "muda o staleTime do react-query pra 30s nas queries de pedidos", "should_trigger": false, "note": "config frontend, mesmo citando 'pedidos'" },
+  { "query": "COMMENT ON na tabela radar_empresas explicando os campos", "should_trigger": false, "note": "cosmético — sem invariante" },
+  { "query": "revisa as RLS que já existem na fin_contas_receber e me diz se tem buraco", "should_trigger": false, "note": "auditoria de policy existente ≠ provar mudança nova — security-review/codex" }
+]

--- a/.claude/skills/prove-sql-money-path/references/assert-patterns.md
+++ b/.claude/skills/prove-sql-money-path/references/assert-patterns.md
@@ -1,0 +1,175 @@
+# Padrões de assert — prove-sql-money-path
+
+Padrões copiáveis pras 3 famílias de assert + a falsificação. Todos assumem o `harness-template.sh`
+(funções `P`/`Pq`/`ok`/`bad`/`eq` e `auth.uid()` lendo o GUC `test.uid`).
+
+> **Lei #2:** todo caminho negativo captura a `SQLSTATE` ESPERADA e re-lança o resto. `WHEN OTHERS THEN 'OK'` é teatro.
+
+---
+
+## 1. Assert POSITIVO (o caminho feliz produz o efeito)
+
+Rode/insira → leia o efeito → compare.
+
+```bash
+# RPC produz o estado esperado
+Pq -c "SELECT public.aprovar_pedido_sugerido('PED-1'::uuid);" >/dev/null
+V=$(Pq -c "SELECT status FROM public.pedido_compra_sugerido WHERE id='PED-1';")
+eq "A1 aprovar seta status" "$V" "aprovado"
+
+# money-path: o número certo
+V=$(Pq -c "SELECT preco_unitario FROM public.pedido_compra_item WHERE pedido_id='PED-1' LIMIT 1;")
+eq "A2 preco vem do cmc" "$V" "536.48"
+```
+
+---
+
+## 2. Assert NEGATIVO (a defesa morde) — SQLSTATE + re-raise
+
+O padrão de ouro: bloco `DO` que espera UMA condição de erro e relança qualquer outra. O `RAISE NOTICE`
+final só roda se o erro **esperado** veio; se veio outro, o `WHEN OTHERS THEN RAISE` propaga e o
+`ON_ERROR_STOP=1` derruba o harness.
+
+> ⚠️ **Capture o stderr (`2>&1`).** O `RAISE NOTICE` da sentinela sai no **stderr** — sem `2>&1`, `$R`
+> pega só os command tags (`SET`/`DO`) e a sentinela nunca casa (assert sempre vermelho). Pego rodando
+> o smoke desta skill.
+
+```bash
+# Gate master nega employee (a RPC faz: RAISE EXCEPTION 'forbidden ...' → SQLSTATE P0001)
+R=$(P -tA 2>&1 <<'SQL'
+SET test.uid='22222222-2222-2222-2222-222222222222';  -- employee, não master
+SET ROLE authenticated;
+DO $$
+BEGIN
+  PERFORM public.aprovar_versao_boletim('FO20.6827.00', '{}'::jsonb);
+  RAISE EXCEPTION 'GATE_NAO_BARROU';            -- chegou aqui = não barrou = BUG
+EXCEPTION
+  WHEN insufficient_privilege OR raise_exception THEN  -- 42501 / P0001 = o erro ESPERADO
+    RAISE NOTICE 'GATE_OK';
+  WHEN OTHERS THEN
+    RAISE;                                       -- qualquer outro erro: RELANÇA (não engole)
+END $$;
+SQL
+)
+case "$R" in *GATE_OK*) ok "A3 gate nega employee" ;; *) bad "A3 gate — veio: $R" ;; esac
+```
+
+> ⚠️ **Sentinela anti-teatro:** a string que você procura (`GATE_OK`) NÃO pode ser o texto que o
+> código emite. Se o `RAISE EXCEPTION` do código diz `'forbidden: somente master'` e você grepa por
+> `'forbidden'`, um `RAISE` espúrio em qualquer ponto casaria. Use uma sentinela **sua** (`GATE_OK`),
+> emitida só no ramo `EXCEPTION` da condição certa.
+
+**SQLSTATEs comuns no repo** (use o nome da condição, é mais legível que o código):
+
+| Defesa | Condição (`WHEN ...`) | Código |
+|---|---|---|
+| `RAISE EXCEPTION 'forbidden'` (gate) | `raise_exception` | `P0001` |
+| CHECK (`minimo > 0`, status válido) | `check_violation` | `23514` |
+| UNIQUE (1 vínculo/1 versão viva) | `unique_violation` | `23505` |
+| NOT NULL | `not_null_violation` | `23502` |
+| FK | `foreign_key_violation` | `23503` |
+| REVOKE/grant (`permission denied`) | `insufficient_privilege` | `42501` |
+| coluna/função inexistente (drift) | `undefined_column`/`undefined_function` | `42703`/`42883` |
+
+Variante grossa (quando só importa "falhou", sem distinguir o erro): use `must_fail "<sql>" "<rótulo>"`
+do template. **Prefira o bloco DO** quando o erro específico importa (quase sempre, no money-path).
+
+---
+
+## 3. Assert RLS (own-scope / staff / anon-deny)
+
+`auth.uid()` lê o GUC `test.uid`; `SET ROLE authenticated` aplica as policies; `service_role` (BYPASSRLS)
+semeia. Seed em ZONA 3 com `SET ROLE service_role`.
+
+```bash
+# Seed como postgres (superuser ignora RLS e TEM privilégio nas tabelas). NÃO use SET ROLE
+# service_role p/ semear: BYPASSRLS ignora a RLS mas NÃO concede GRANT → "permission denied".
+P -q <<'SQL'
+INSERT INTO auth.users(id) VALUES
+  ('11111111-1111-1111-1111-111111111111'),
+  ('22222222-2222-2222-2222-222222222222'),
+  ('33333333-3333-3333-3333-333333333333') ON CONFLICT DO NOTHING;
+INSERT INTO public.user_roles(user_id, role) VALUES
+  ('33333333-3333-3333-3333-333333333333','master') ON CONFLICT DO NOTHING;
+INSERT INTO public.minha_tabela(owner, valor) VALUES
+  ('11111111-1111-1111-1111-111111111111', 10),
+  ('22222222-2222-2222-2222-222222222222', 20);
+-- migration do repo é --no-privileges (Supabase concede em runtime) → conceda p/ os asserts de RLS
+-- lerem; a RLS filtra por cima. ⚠️ a policy é avaliada com os privilégios do CALLER: se ela faz
+-- subselect noutra tabela (ex.: user_roles), conceda SELECT nela TAMBÉM, senão dá permission denied.
+GRANT SELECT ON public.minha_tabela, public.user_roles TO authenticated, anon;
+SQL
+
+# tail -1: psql ecoa "SET" por cada SET → a contagem é a ÚLTIMA linha
+OWN=$(Pq  -c "SET test.uid='11111111-1111-1111-1111-111111111111'; SET ROLE authenticated; SELECT count(*) FROM public.minha_tabela;" | tail -1)
+STAFF=$(Pq -c "SET test.uid='33333333-3333-3333-3333-333333333333'; SET ROLE authenticated; SELECT count(*) FROM public.minha_tabela;" | tail -1)
+ANON=$(Pq -c "SET ROLE anon; SELECT count(*) FROM public.minha_tabela;" | tail -1)
+eq "A4 own-scope (cliente vê só a própria)" "$OWN"   "1"
+eq "A5 staff vê tudo"                       "$STAFF" "2"
+eq "A6 anon não vê nada"                    "$ANON"  "0"
+```
+
+> ⚠️ O psql é **superuser** — sem `SET ROLE`, ele BYPASSA a RLS e o teste vira teatro (vê tudo sempre).
+> Prove RLS SEMPRE com `SET ROLE authenticated`/`anon` + GUC `test.uid`. (§10: a falsificação B3/A9 do
+> KB existe porque sem o `SET ROLE` o assert de RLS não tinha dente.)
+
+---
+
+## 4. FALSIFICAÇÃO (Lei #3) — sabota → exija vermelho → restaura
+
+A prova de que o assert tem dente: quebra a migração de propósito e mostra que o assert **pega**.
+Padrão de 4 tempos.
+
+```bash
+echo "── falsificação ──"
+# 1) SABOTA: recria a defesa NA VERSÃO FURADA (aqui: gate que sempre passa)
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION public.aprovar_versao_boletim(p_code text, p_payload jsonb)
+RETURNS void LANGUAGE plpgsql SECURITY DEFINER AS $fn$
+BEGIN
+  -- GATE SABOTADO: removido o IF NOT is_master THEN RAISE
+  INSERT INTO public.kb_product_spec_versions(product_code) VALUES (p_code);
+END $fn$;
+SQL
+
+# 2+3) RE-RODA o MESMO assert A3 e EXIGE que agora ele FALHE (gate não barra mais)
+R=$(P -tA 2>&1 <<'SQL'
+SET test.uid='22222222-2222-2222-2222-222222222222'; SET ROLE authenticated;
+DO $$ BEGIN
+  PERFORM public.aprovar_versao_boletim('X', '{}'::jsonb);
+  RAISE NOTICE 'SABOTAGEM_PASSOU';        -- com o gate furado, chega aqui (2>&1: NOTICE é stderr)
+EXCEPTION WHEN OTHERS THEN RAISE NOTICE 'AINDA_BARRA'; END $$;
+SQL
+)
+case "$R" in
+  *SABOTAGEM_PASSOU*) ok "F1 falsificação: gate furado deixou employee passar (A3 tem dente)" ;;
+  *) bad "F1 sabotei o gate e o teste NÃO mudou → A3 é fraco, conserte o assert" ;;
+esac
+
+# 4) RESTAURA a versão verdadeira (cirurgicamente — re-aplica só o que sabotou)
+P -q -f "$REPO_ROOT/supabase/migrations/[[seu_slug]].sql"
+# limpa a linha que a sabotagem inseriu, se poluir:
+P -q -c "DELETE FROM public.kb_product_spec_versions WHERE product_code='X';" >/dev/null 2>&1 || true
+```
+
+**Regras da falsificação:**
+- Sabota **uma defesa por vez** e exija que **o assert daquela defesa** vire vermelho. Não sabota tudo de uma vez.
+- A sentinela (`SABOTAGEM_PASSOU`) é **sua**, nunca o texto do código (anti-teatro de ILIKE/position).
+- **Restaure cirurgicamente** — re-aplicar a migração inteira costuma bastar; se a migração não for
+  idempotente nesse ponto, recrie só o objeto sabotado na versão certa.
+- ⚠️ **Ordem importa** ao restaurar trigger + dado: reverta o dado que a sabotagem inseriu ANTES de
+  recriar um trigger append-only (senão o trigger barra a própria limpeza). (§10, lição do KB.)
+
+### Falsificação para append-only / trigger
+
+```bash
+# DROPA o trigger guardião → EXIGE que o DELETE/UPDATE proibido agora PASSE (prova que o trigger guardava)
+P -q -c "DROP TRIGGER IF EXISTS kbv_block_mutation ON public.kb_product_spec_versions;"
+if P -q -c "DELETE FROM public.kb_product_spec_versions WHERE id='...';" >/dev/null 2>&1; then
+  ok "F2 sem o trigger o DELETE passa (o trigger append-only tinha dente)"
+else
+  bad "F2 droppei o trigger e o DELETE AINDA falhou → o assert não provava o trigger"
+fi
+# restaura re-aplicando a migração
+P -q -f "$REPO_ROOT/supabase/migrations/[[seu_slug]].sql"
+```

--- a/.claude/skills/prove-sql-money-path/references/harness-template.sh
+++ b/.claude/skills/prove-sql-money-path/references/harness-template.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# ╔══════════════════════════════════════════════════════════════════════════════╗
+# ║  HARNESS PG17 — PROVA de migration money-path/auth com FALSIFICAÇÃO            ║
+# ║  Copie p/ db/test-<slug>.sh, preencha as ZONAS [[...]], rode:                  ║
+# ║      bash db/test-<slug>.sh > /tmp/t.log 2>&1; echo "exit=$?"                  ║
+# ║  (NÃO pipe pra tail — engole o exit≠0; §2 do CLAUDE.md.)                       ║
+# ║                                                                                ║
+# ║  Lei de Ferro (skill prove-sql-money-path):                                    ║
+# ║   1. Aplica a migration REAL (psql -f), não um stub da lógica.                 ║
+# ║   2. Assert negativo captura a SQLSTATE esperada e RE-LANÇA o resto.           ║
+# ║   3. Falsificação obrigatória: sabota a migração → exija VERMELHO → restaura.  ║
+# ╚══════════════════════════════════════════════════════════════════════════════╝
+set -euo pipefail
+
+# ── arranque PG17 descartável (idêntico em todos os harnesses; contorna keg-only do brew) ──
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PGVER=17
+PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+PORT="${PGPORT_TEST:-5455}"     # mude se rodar em paralelo com outro harness (40 worktrees)
+SLUG="prove"                    # [[ troque pelo slug da sua migration, p/ nomear tmp/log ]]
+DATA="$(mktemp -d "/tmp/pgtest-${SLUG}.XXXXXX")/data"
+export LC_ALL=C LANG=C          # sem isso o postmaster aborta ("became multithreaded during startup")
+
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente: brew install postgresql@${PGVER} pgvector"; exit 1; }
+
+# keg-only do brew: share/lib do postgresql@17 podem não estar linkados → initdb/server falham. Copia do Cellar (idempotente).
+CELLAR="$(brew --prefix "postgresql@${PGVER}")"
+cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
+mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
+cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
+
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+trap cleanup EXIT
+
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l "/tmp/pg-${SLUG}.log" -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres prove
+P()  { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d prove -v ON_ERROR_STOP=1 "$@"; }
+Pq() { P -tA "$@"; }   # tuples-only, unaligned (pra capturar 1 valor)
+
+# ── base mínima do Supabase: roles, schema auth, auth.uid()/role() via GUC (impersonação de RLS) ──
+P -q -f "$REPO_ROOT/db/stubs-supabase.sql"
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION auth.uid()  RETURNS uuid LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.uid',  true), '')::uuid $f$;
+CREATE OR REPLACE FUNCTION auth.role() RETURNS text LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.role', true), '') $f$;
+ALTER ROLE service_role BYPASSRLS;   -- espelha o admin role do Supabase (semear sem esbarrar em RLS)
+SQL
+
+# ── helpers de assert (pass/fail contados; exit 1 no fim se houve fail) ──
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  ✅ $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  ❌ $1"; }
+eq()  { if [ "$2" = "$3" ]; then ok "$1 (=$2)"; else bad "$1 — esperado [$3], veio [$2]"; fi; }
+# exige que um comando SQL FALHE (caminho negativo grosso). Pra checar a SQLSTATE exata, use o
+# padrão DO/EXCEPTION de references/assert-patterns.md (preferível — Lei #2).
+must_fail() { if P -q -c "$1" >/dev/null 2>&1; then bad "$2 — devia ter falhado e PASSOU"; else ok "$2 (rejeitado)"; fi; }
+
+echo "═══ setup pronto (PG17 :$PORT) ═══"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 1 — PRÉ-REQUISITOS DE SCHEMA (o que a migração LÊ/ALTERA mas não cria)
+# ══════════════════════════════════════════════════════════════════════════════
+# Opção (a) MÍNIMO — stub só das tabelas/colunas que a migração toca:
+# P -q <<'SQL'
+# CREATE TABLE IF NOT EXISTS public.user_roles (user_id uuid, role text);
+# CREATE TABLE IF NOT EXISTS public.[[tabela_que_a_migracao_le]] ( ... colunas usadas ... );
+# SQL
+#
+# Opção (b) FIEL — aplica o snapshot inteiro (pega dependências reais; mais lento):
+# RR="$(mktemp /tmp/snap-rr.XXXXXX.sql)"
+# sed -E 's/^(CREATE SCHEMA public;)/-- \1/' "$REPO_ROOT/supabase/schema-snapshot.sql" \
+#   | grep -vE '^\\(un)?restrict ' > "$RR"
+# P -q -f "$REPO_ROOT/supabase/schema-extensions-prelude.sql"
+# P --single-transaction -q -f "$RR"; rm -f "$RR"
+# ⚠️ snapshot pode estar STALE — se faltar coluna recente, ALTER TABLE ... ADD COLUMN IF NOT EXISTS antes.
+#
+# [[ PREENCHA OS PRÉ-REQUISITOS AQUI ]]
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 2 — APLICAR A MIGRATION REAL (Lei #1: o .sql commitado, não um stub)
+# ══════════════════════════════════════════════════════════════════════════════
+MIG="$REPO_ROOT/supabase/migrations/[[20260000000000_seu_slug]].sql"
+P -q -f "$MIG"
+echo "migration aplicada: $(basename "$MIG")"
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 3 — SEED + GRANTs (semeie como postgres; conceda privilégio p/ os asserts de RLS)
+# ══════════════════════════════════════════════════════════════════════════════
+# Semeie como postgres (superuser ignora RLS e TEM privilégio). NÃO use SET ROLE service_role p/
+# semear: BYPASSRLS ignora a RLS mas NÃO concede GRANT → "permission denied" na tabela.
+# A migration do repo é --no-privileges (Supabase concede em runtime); aqui você concede p/ que os
+# asserts de RLS (SET ROLE authenticated/anon) leiam — a RLS filtra por cima.
+# ⚠️ a policy é avaliada com os privilégios do CALLER: se faz subselect noutra tabela (ex.: user_roles),
+#    conceda SELECT nela TAMBÉM, senão a própria policy dá permission denied.
+# P -q <<'SQL'
+# INSERT INTO auth.users(id) VALUES ('11111111-1111-1111-1111-111111111111') ON CONFLICT DO NOTHING;
+# INSERT INTO public.[[tabela]] (...) VALUES (...);
+# GRANT SELECT ON public.[[tabela]], public.user_roles TO authenticated, anon;
+# SQL
+#
+# [[ PREENCHA OS SEEDS + GRANTS AQUI ]]
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 4 — ASSERTS (positivo / negativo-com-SQLSTATE / RLS) — ver assert-patterns.md
+# ══════════════════════════════════════════════════════════════════════════════
+echo "── asserts ──"
+# POSITIVO:
+#   V=$(Pq -c "SELECT status FROM public.[[...]] WHERE id='...';"); eq "A1 efeito" "$V" "aprovado"
+# NEGATIVO (gate/CHECK rejeita — captura a SQLSTATE esperada e re-lança o resto):
+#   R=$(P -tA 2>&1 <<'SQL' ... SQL )  ← 2>&1 ESSENCIAL: o RAISE NOTICE da sentinela sai no STDERR
+#   ver references/assert-patterns.md (bloco DO ... EXCEPTION WHEN <sqlstate> ... WHEN OTHERS THEN RAISE)
+# RLS (own-scope / staff / anon-deny):
+#   OWN=$(Pq -c "SET test.uid='11111111-1111-1111-1111-111111111111'; SET ROLE authenticated; SELECT count(*) FROM public.[[...]];" | tail -1)
+#   eq "A2 own-scope" "$OWN" "1"
+#
+# [[ PREENCHA OS ASSERTS AQUI ]]
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 5 — FALSIFICAÇÃO (Lei #3: sabota a migração → exija VERMELHO → restaura)
+# ══════════════════════════════════════════════════════════════════════════════
+# Padrão (ver assert-patterns.md p/ a versão completa, incl. sentinela anti-teatro):
+#   1. sabota:   recria a policy/trigger/função NA VERSÃO FURADA
+#   2. re-roda:  o MESMO assert do passo 4
+#   3. exige:    que ele agora FALHE (se passar → assert fraco → conserte)
+#   4. restaura: a versão verdadeira (cirurgicamente, só o que sabotou)
+#
+# [[ PREENCHA A FALSIFICAÇÃO AQUI ]]
+
+
+# ── veredito ──
+echo "──────────────────────────────"
+echo "RESULTADO: $PASS ok / $FAIL fail"
+[ "$FAIL" = "0" ] || { echo "❌ HARNESS VERMELHO"; exit 1; }
+echo "✅ HARNESS VERDE"


### PR DESCRIPTION
Duas skills de operação de banco (project-scoped em `.claude/skills/`), desenhadas com 2ª opinião do **Codex** e validadas de verdade. **Aditivas** — arquivos novos, zero conflito com as worktrees ativas; auto-descobertas pelo Claude Code (não tocam o `CLAUDE.md`; o registro na tabela §12 entra no refactor do CLAUDE.md, frente 1 do programa).

## `prove-sql-money-path`
Empacota o ritual de **provar** mudança SQL money-path/autorização num **PostgreSQL 17 local descartável com falsificação**, antes de entregar a migration (contraparte da `lovable-db-operator`, que entrega + valida pós-apply).
- **Lei de Ferro**: aplica a migração REAL (pega bug *late-bound* de plpgsql) · assert negativo captura `SQLSTATE` e re-lança · falsificação obrigatória (sabota → exige vermelho).
- `references/harness-template.sh` (esqueleto PG17 pronto) + `references/assert-patterns.md` (positivo/negativo/RLS/falsificação) + `evals/trigger-eval.json`.
- **Provada**: smoke 7/7 verde incl. falsificação. Rodar de verdade pegou 2 bugs nos próprios padrões (`GRANT`≠`BYPASSRLS`; `RAISE NOTICE` vai pro stderr → precisa `2>&1`) — corrigidos.

## `diagnose-supabase-sync`
Árvore de diagnóstico de cron/sync/edge quebrado, **rodando read-only direto no banco** (via wrapper local; fallback de blocos pro SQL Editor).
- 8 passos (registry → incidente → scheduler → HTTP → handler → cursor → contraprova → veredito) + atalhos sintoma→causa→ação + **estados de saída rígidos** ("diagnosticado" nunca vira "corrigido").
- **100% read-only** (barra escrita até via RPC `SECURITY DEFINER`); entrega a ação pro humano, nunca aplica.
- **Validada**: queries conferidas contra o schema real; árvore rodada ponta-a-ponta contra produção (money-path são; detectou timeouts 60s residuais já conhecidos).

## Teste
- `bash db/test-*.sh` continua o canônico pra SQL; estas skills são meta (não alteram CI).
- Evals de disparo: 20 casos (prove-sql) + 17 casos (diagnose).

🤖 Generated with [Claude Code](https://claude.com/claude-code)