### PR TITLE
fix(tint): re-pedido acha a cor (busca por código + mensagem honesta)

### DIFF
--- a/src/components/TintColorSelectDialog.tsx
+++ b/src/components/TintColorSelectDialog.tsx
@@ -17,6 +17,7 @@ export function TintColorSelectDialog({ product, open, onClose, onConfirm, custo
     loadingFormulas,
     colorNotFoundInBase,
     globalColorMatches,
+    globalColorExists,
     loadingGlobalColors,
     selectedFormula,
     setSelectedFormula,
@@ -77,6 +78,7 @@ export function TintColorSelectDialog({ product, open, onClose, onConfirm, custo
               <GlobalColorMatches
                 product={product}
                 matches={globalColorMatches ?? []}
+                colorExists={globalColorExists}
                 onConfirm={onConfirm}
               />
             )}

--- a/src/components/tintColorSelect/GlobalColorMatches.tsx
+++ b/src/components/tintColorSelect/GlobalColorMatches.tsx
@@ -9,11 +9,31 @@ import type { AlternativePackaging } from './types';
 interface GlobalColorMatchesProps {
   product: Product;
   matches: AlternativePackaging[];
+  /** A cor existe no catálogo, mas sem embalagem vendável p/ esta base (vs. não existir de todo). */
+  colorExists?: boolean;
   onConfirm: (formulaId: string, corId: string, nomeCor: string, precoFinal: number, custoCorantes: number, alternativeProduct?: Product) => void;
 }
 
-export function GlobalColorMatches({ product, matches, onConfirm }: GlobalColorMatchesProps) {
+export function GlobalColorMatches({ product, matches, colorExists, onConfirm }: GlobalColorMatchesProps) {
   if (matches.length === 0) {
+    // Degradação honesta: distingue "existe mas não é vendável nesta base" de
+    // "não existe". O sinal money-path nunca afirma ausência quando a cor está
+    // no catálogo (só falta vincular o produto Omie / é de outra família de base).
+    if (colorExists) {
+      return (
+        <div className="flex items-start gap-2 p-3 rounded-md bg-status-warning-bg border border-status-warning/30">
+          <AlertTriangle className="w-5 h-5 text-status-warning shrink-0 mt-0.5" />
+          <div>
+            <p className="text-sm font-semibold text-status-warning-foreground">
+              Esta cor existe, mas não há embalagem vendável para esta base
+            </p>
+            <p className="text-xs text-status-warning mt-1">
+              A cor está no catálogo, mas nenhuma embalagem dela está vinculada a um produto Omie vendável na família de <strong>{product.descricao}</strong>. Avise o tintométrico para vincular ou cadastrar o produto.
+            </p>
+          </div>
+        </div>
+      );
+    }
     return <p className="text-xs text-muted-foreground text-center py-4">Nenhuma cor encontrada em nenhuma base.</p>;
   }
 

--- a/src/components/tintColorSelect/__tests__/GlobalColorMatches.test.tsx
+++ b/src/components/tintColorSelect/__tests__/GlobalColorMatches.test.tsx
@@ -23,8 +23,20 @@ function alt(partial: Partial<AlternativePackaging>): AlternativePackaging {
 }
 
 describe('GlobalColorMatches', () => {
-  it('mostra mensagem vazia quando não há matches', () => {
+  it('mostra mensagem vazia quando não há matches nem a cor existe', () => {
     render(<GlobalColorMatches product={product} matches={[]} onConfirm={() => {}} />);
+    expect(screen.getByText('Nenhuma cor encontrada em nenhuma base.')).toBeTruthy();
+  });
+
+  it('mensagem honesta: cor existe mas sem embalagem vendável (colorExists)', () => {
+    render(<GlobalColorMatches product={product} matches={[]} colorExists onConfirm={() => {}} />);
+    expect(screen.getByText('Esta cor existe, mas não há embalagem vendável para esta base')).toBeTruthy();
+    // nunca afirma ausência quando a cor está no catálogo
+    expect(screen.queryByText('Nenhuma cor encontrada em nenhuma base.')).toBeNull();
+  });
+
+  it('colorExists=false mantém "nenhuma cor encontrada"', () => {
+    render(<GlobalColorMatches product={product} matches={[]} colorExists={false} onConfirm={() => {}} />);
     expect(screen.getByText('Nenhuma cor encontrada em nenhuma base.')).toBeTruthy();
   });
 

--- a/src/components/tintColorSelect/useTintColorSelect.ts
+++ b/src/components/tintColorSelect/useTintColorSelect.ts
@@ -107,11 +107,13 @@ export function useTintColorSelect({ product, open, customerUserId, initialSearc
   // When color not found in current base, search ALL bases for it
   const colorNotFoundInBase = debouncedSearch.length >= 2 && !loadingFormulas && formulas && formulas.length === 0;
 
-  const { data: globalColorMatches, isLoading: loadingGlobalColors } = useQuery({
+  const { data: globalColorData, isLoading: loadingGlobalColors } = useQuery({
     queryKey: ['tint-global-color-search', debouncedSearch, currentBaseSuffix],
     staleTime: 5 * 60 * 1000,
-    enabled: !!colorNotFoundInBase && !!currentBaseSuffix,
-    queryFn: async (): Promise<AlternativePackaging[]> => {
+    // Roda mesmo sem sufixo (base sem código na descrição): aí não filtra por
+    // família e mostra todas as bases vendáveis — nunca esconde a cor em silêncio.
+    enabled: !!colorNotFoundInBase,
+    queryFn: async (): Promise<{ matches: AlternativePackaging[]; colorExists: boolean }> => {
       // Search formulas across all SKUs
       const { data: globalFormulas } = await supabase
         .from('tint_formulas')
@@ -122,7 +124,8 @@ export function useTintColorSelect({ product, open, customerUserId, initialSearc
         .not('sku_id', 'is', null)
         .limit(50);
 
-      if (!globalFormulas || globalFormulas.length === 0) return [];
+      // Achou fórmula = a cor EXISTE no catálogo (mesmo que nenhuma seja vendável).
+      if (!globalFormulas || globalFormulas.length === 0) return { matches: [], colorExists: false };
 
       // Get SKU details
       const skuIds = [...new Set(globalFormulas.map(f => f.sku_id!))];
@@ -132,7 +135,7 @@ export function useTintColorSelect({ product, open, customerUserId, initialSearc
         .in('id', skuIds)
         .not('omie_product_id', 'is', null);
 
-      if (!skus || skus.length === 0) return [];
+      if (!skus || skus.length === 0) return { matches: [], colorExists: true };
 
       // Filter SKUs to only those with the same base suffix (e.g. ".7666")
       if (currentBaseSuffix) {
@@ -153,7 +156,7 @@ export function useTintColorSelect({ product, open, customerUserId, initialSearc
 
         // Remove SKUs with non-matching bases — filtra skus in-place
         const filteredSkus = skus.filter(s => validBaseIds.has(s.base_id));
-        if (filteredSkus.length === 0) return [];
+        if (filteredSkus.length === 0) return { matches: [], colorExists: true };
         // Replace skus reference
         skus.length = 0;
         skus.push(...filteredSkus);
@@ -166,7 +169,7 @@ export function useTintColorSelect({ product, open, customerUserId, initialSearc
         .select('id, codigo, descricao, unidade, valor_unitario, estoque, ativo, omie_codigo_produto, account, is_tintometric, tint_type')
         .in('id', productIds);
 
-      if (!products) return [];
+      if (!products) return { matches: [], colorExists: true };
 
       const result: AlternativePackaging[] = [];
       for (const gf of globalFormulas) {
@@ -190,9 +193,12 @@ export function useTintColorSelect({ product, open, customerUserId, initialSearc
       }
 
       result.sort((a, b) => a.productDescricao.localeCompare(b.productDescricao));
-      return result;
+      return { matches: result, colorExists: true };
     },
   });
+
+  const globalColorMatches = globalColorData?.matches ?? [];
+  const globalColorExists = globalColorData?.colorExists ?? false;
 
   // Pricing breakdown for selected formula (for informational display)
   const { data: pricing } = useTintPricing(selectedFormula?.id || null);
@@ -349,6 +355,7 @@ export function useTintColorSelect({ product, open, customerUserId, initialSearc
     loadingFormulas,
     colorNotFoundInBase,
     globalColorMatches,
+    globalColorExists,
     loadingGlobalColors,
     selectedFormula,
     setSelectedFormula,

--- a/src/lib/tint/__tests__/cores-do-cliente.test.ts
+++ b/src/lib/tint/__tests__/cores-do-cliente.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { extrairCoresDoHistorico, filtrarCores, normalizarBusca } from '../cores-do-cliente';
+import { extrairCoresDoHistorico, filtrarCores, normalizarBusca, termoBuscaCor } from '../cores-do-cliente';
 import type { PedidoHistorico } from '../cores-do-cliente';
 
 const pedido = (over: Partial<PedidoHistorico> = {}): PedidoHistorico => ({
@@ -136,5 +136,42 @@ describe('filtrarCores / normalizarBusca', () => {
 
   it('normalizarBusca: minúsculas + sem acento + trim', () => {
     expect(normalizarBusca('  Afiação ')).toBe('afiacao');
+  });
+});
+
+describe('termoBuscaCor', () => {
+  it('regressão: rótulo cru com embalagem → código líder (o bug do "Pedir de novo")', () => {
+    // "346J - PLATINA BIANCA 900ML" como busca não casava com cor_id "346J - ACRIL BS"
+    // nem nome_cor "PLATINA BIANCA" → "nenhuma cor encontrada". Agora vira "346J".
+    expect(termoBuscaCor('346J - PLATINA BIANCA 900ML')).toBe('346J');
+  });
+
+  it('código líder em grafias variadas do mesmo histórico', () => {
+    expect(termoBuscaCor('346J - ACRIL BS - PLATINA BIANCA')).toBe('346J');
+    expect(termoBuscaCor('346J ACRIL BS - PLATINA BIANCA')).toBe('346J');
+    expect(termoBuscaCor('339H - ACRIL BS - GRAFITE - BS')).toBe('339H');
+    expect(termoBuscaCor('985H - ACRIL BS - ONIX I - BS')).toBe('985H');
+  });
+
+  it('descarta nota após "|" e embalagem no fim', () => {
+    expect(termoBuscaCor('346J PLATINA BIANCA 900ML QT|TULIO LEVOU ESSA')).toBe('346J');
+  });
+
+  it('cor_id puramente numérico que lidera (RAL etc.)', () => {
+    expect(termoBuscaCor('1247 - AZUL RAL 5010 - QT')).toBe('1247');
+  });
+
+  it('nome-líder com código embutido → pega o código (letra+dígito), não a embalagem', () => {
+    expect(termoBuscaCor('OVO H101 - BS')).toBe('H101');
+    expect(termoBuscaCor('CINZA G155 - BS')).toBe('G155');
+  });
+
+  it('cor só por nome (sem código) → primeira palavra, degradação honesta', () => {
+    expect(termoBuscaCor('VERDE AFIAÇÃO')).toBe('VERDE');
+  });
+
+  it('vazio/espaços não quebra', () => {
+    expect(termoBuscaCor('')).toBe('');
+    expect(termoBuscaCor('   ')).toBe('');
   });
 });

--- a/src/lib/tint/cores-do-cliente.ts
+++ b/src/lib/tint/cores-do-cliente.ts
@@ -115,3 +115,36 @@ export function filtrarCores(cores: CorDoCliente[], termo: string): CorDoCliente
   if (!q) return cores;
   return cores.filter((c) => normalizarBusca(c.nome).includes(q));
 }
+
+const EH_EMBALAGEM = (t: string) => /^\d+(?:[.,]\d+)?ml$/i.test(t) || /^(?:qt|gl|lt)$/i.test(t);
+
+/**
+ * Converte o rótulo livre de uma cor do histórico (`tint_nome_cor`, ex.:
+ * "346J - PLATINA BIANCA 900ML" ou "346J PLATINA BIANCA 900ML QT|TULIO LEVOU ESSA")
+ * num termo que CASA com o catálogo vivo (`tint_formulas.cor_id`/`nome_cor`) ao
+ * pré-preencher o seletor de cor no re-pedido ("Pedir de novo" / "Repetir pedido").
+ *
+ * Por quê: o catálogo guarda `cor_id` = "346J - ACRIL BS" e `nome_cor` =
+ * "PLATINA BIANCA". O rótulo INTEIRO nunca casa (carrega embalagem "900ML",
+ * notas após "|", grafias antigas), então o seletor devolvia "nenhuma cor
+ * encontrada" mesmo a cor existindo na própria base. O código Sayer é o sinal
+ * mais seletivo e casa por ILIKE; extraímos ele:
+ *  1) token líder com dígito (cor_id que lidera: "346J", "1247", "339H");
+ *  2) senão, primeiro código embutido (letra+dígito: "H101", "G155") que não
+ *     seja embalagem;
+ *  3) senão, a primeira palavra (cor só por nome) — degradação honesta, nunca
+ *     o rótulo cru que não casa.
+ */
+export function termoBuscaCor(nome: string): string {
+  const limpo = nome.split('|')[0].trim();
+  if (!limpo) return nome.trim();
+
+  const tokens = limpo.split(/[\s-]+/).filter(Boolean);
+  if (tokens.length === 0) return limpo;
+
+  const lider = tokens[0];
+  if (/\d/.test(lider) && !EH_EMBALAGEM(lider)) return lider;
+
+  const codigo = tokens.find((t) => /\d/.test(t) && /[a-z]/i.test(t) && !EH_EMBALAGEM(t));
+  return codigo ?? lider;
+}

--- a/src/pages/UnifiedOrder.tsx
+++ b/src/pages/UnifiedOrder.tsx
@@ -22,6 +22,7 @@ import { CustomerSearch } from '@/components/unified-order/CustomerSearch';
 import { CoresDoClienteCard } from '@/components/unified-order/CoresDoClienteCard';
 import { useCoresDoCliente } from '@/hooks/unifiedOrder/useCoresDoCliente';
 import type { CorDoCliente, OcorrenciaCor } from '@/lib/tint/cores-do-cliente';
+import { termoBuscaCor } from '@/lib/tint/cores-do-cliente';
 import { montarPlanoReplicacao, type ItemTinta } from '@/lib/pedido/replicar-pedido';
 import { supabase } from '@/integrations/supabase/client';
 import { toast } from 'sonner';
@@ -69,7 +70,9 @@ const UnifiedOrder = () => {
         : undefined;
     if (product?.is_tintometric && product.tint_type === 'base') {
       track('pedido.repetir_cor');
-      setTintInitialSearch(cor.nome);
+      // Busca pelo CÓDIGO da cor, não pelo rótulo cru do histórico ("346J -
+      // PLATINA BIANCA 900ML") — o rótulo não casa com cor_id/nome_cor do catálogo.
+      setTintInitialSearch(termoBuscaCor(cor.nome));
       h.setTintPendingProduct(product);
       return;
     }
@@ -160,7 +163,8 @@ const UnifiedOrder = () => {
     if (h.tintPendingProduct || tintQueue.length === 0) return;
     const [proxima, ...resto] = tintQueue;
     setTintQueue(resto);
-    setTintInitialSearch(proxima.nomeCor);
+    // Mesmo motivo do "Pedir de novo": pré-busca pelo código, não pelo rótulo cru.
+    setTintInitialSearch(proxima.nomeCor ? termoBuscaCor(proxima.nomeCor) : null);
     h.setTintPendingProduct(proxima.product);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [h.tintPendingProduct, tintQueue]);


### PR DESCRIPTION
## Problema

No seletor **Selecionar Cor** da venda (`/sales/new`), buscar uma cor já pedida pelo cliente (ex.: `346J - PLATINA BIANCA`) retornava **"Nenhuma cor encontrada em nenhuma base"** — mesmo a cor existindo, **ativa e vendável**, no próprio SKU da base aberta.

## Causa-raiz (investigada com SQL de produção)

Dois bugs distintos no fluxo tintométrico:

1. **Termo de busca errado.** O "Pedir de novo" / "Repetir pedido" passava o rótulo livre do histórico (`tint_nome_cor`, ex.: `"346J - PLATINA BIANCA 900ML"`) como termo de busca. O catálogo `tint_formulas` guarda `cor_id="346J - ACRIL BS"` e `nome_cor="PLATINA BIANCA"` — o rótulo inteiro (com embalagem/nota) **nunca casa**. No histórico, `tint_cor_id` é NULL nos pedidos importados do Omie, por isso o card só tem o texto sujo.
2. **Mensagem mentirosa.** A busca global de alternativas dizia *"não existe"* quando a cor existe mas (a) só em SKUs sem produto Omie vinculado, ou (b) a base não tinha código na descrição (`sufixo null` → fallback desabilitado **em silêncio**).

## Fix

1. Helper puro **`termoBuscaCor`** ([cores-do-cliente.ts](../blob/claude/gallant-jemison-838bb1/src/lib/tint/cores-do-cliente.ts)) extrai o código Sayer do rótulo (líder com dígito; senão código embutido letra+dígito; senão 1ª palavra). Usado nos dois call sites de re-pedido em `UnifiedOrder.tsx`.
2. A busca global passa a retornar **`{ matches, colorExists }`**; a UI (`GlobalColorMatches`) distingue **"existe mas não há embalagem vendável para esta base"** de **"não existe"**, e o fallback **roda mesmo sem sufixo** — nunca esconde a cor em silêncio.

## Verificação

- ✅ Suíte completa: **3465/3465** · `typecheck` strict: exit 0 · `lint`: 0 erros
- ✅ Testes novos: regressão `"346J - PLATINA BIANCA 900ML"` → `"346J"`; estados honestos do `GlobalColorMatches` (existe-mas-não-vendável vs. não-existe).

## Deploy

**Frontend-only** — sem migration, sem edge function. Após o merge: só **Publish** no Lovable.

## Follow-up

Card aberto: **vincular SKUs tintométricos sem produto Omie** (ex.: `89e822cb`/`4d394d3b` na .7796). A higiene deve **confirmar a existência do produto Omie antes** — provável vínculo faltando (`UPDATE tint_skus SET omie_product_id`), não remoção.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
