### PR TITLE
feat(tint): mapeamento Omie das bases — busca + ranqueamento + auto-sugestão

### DIFF
--- a/docs/roadmap-sessao.md
+++ b/docs/roadmap-sessao.md
@@ -6,6 +6,22 @@
 
 ---
 
+## 🎨 SESSÃO 2026-06-14 (tint-mapeamento-assistido) — Mapeamento Omie das bases: cobertura + busca + auto-sugestão
+
+> Founder na tela `/tintometrico/catalogo` → Mapeamento → Bases: (1) produto Omie que existe some (WJOB.7796 GL), (2) seletor sem busca digitável, (3) ordenação alfabética cega, (4) sem auto-sugestão ("eu sugiro, você aprova"). Brainstorming → spec aprovada ("pode seguir") + Codex consult no algoritmo. Spec `docs/superpowers/specs/2026-06-14-tint-mapeamento-assistido-design.md`. Execução **inline** (lição #819: subagentes thrasham neste repo).
+
+- ✅ Diagnóstico: causa = **cobertura do sync** (não mismatch da família "Bases MixMachine"). 67 bases (+5 conc.) ativas sem `is_tintometric`. As 80 ATIVAS já 100% mapeadas → o não-mapeado que o founder vê são SKUs **OCULTOS**.
+- ✅ Backfill em prod (SQL Editor): marcou **13 ativos** (8 bases + 5 conc.), incl. WJOB.7796 GL. 59 restantes = `ativo=false` (descontinuados, fora de propósito).
+- ✅ Spec + **Codex consult** (furo principal: `forte` NÃO vem do score — vem da **cardinalidade de chave dura exata** [código-base + embalagem]; parsing exato sem normalizar `.00`; embalagem sem alias implícito; unicidade global; candidato já-mapeado → `revisar`).
+- ✅ Motor puro `src/lib/tint/omie-match.ts` (TDD, **23/23**) — chave dura EXATA (código-base + embalagem), casamento conservador (dúvida = `revisar`); genérico p/ carregar custo/estoque.
+- ✅ Combobox `OmieBaseCombobox` — busca digitável + ranqueamento (`shouldFilter={false}`, "Sugeridos pra esta base" no topo, resto agrupado) — substitui o `<Select>` em `TintMapping.tsx`.
+- ✅ Auto-sugestão + aprovação ("Sugerir mapeamentos" / "Aprovar todas (N)"; aprovar oculto = reativa `ativo=true` + mapeia).
+- ✅ Validado: typecheck strict **0** · lint **0 erros** (76 warnings pré-existentes) · **3481** testes (469 files) · build OK.
+- ⏳ **Founder: mergear o PR + Publish no Lovable** (100% frontend → só vai ao ar após Publish).
+- ⏳ Follow-up (não bloqueia): `tint-omie-sync` robusto à cobertura (senão produto novo volta a escapar e precisa de re-backfill).
+
+---
+
 ## 🧭 SESSÃO 2026-06-14 (roteirizador-visitas-campo) — Tela do hunter separada da equipe
 
 > Founder achou a tela do Roteirizador confusa (5 modos numa tela só, feita pra equipe inteira). Ele é o

--- a/docs/superpowers/specs/2026-06-14-tint-mapeamento-assistido-design.md
+++ b/docs/superpowers/specs/2026-06-14-tint-mapeamento-assistido-design.md
@@ -1,0 +1,93 @@
+# Mapeamento assistido Tintométrico (Bases) — cobertura + auto-sugestão
+
+Data: 2026-06-14
+Status: design aprovado pelo founder ("pode seguir"), pré-implementação.
+
+## Problema (founder, na tela `/tintometrico/catalogo` → Mapeamento → Bases)
+
+Mapear cada base↔produto Omie é lento e incompleto:
+
+1. **Produtos Omie que existem não aparecem pra mapear** (ex.: `WJOB.7796` galão existe no Omie da Oben, mas some da lista).
+2. **O seletor não dá pra digitar** — é um `<Select>` Radix sem busca, lista enorme só rolável.
+3. **Ordenação cega** — alfabética por `descricao` ([TintMapping.tsx:47](../../../src/pages/TintMapping.tsx)), não sabe qual base está sendo mapeada.
+4. **Sem auto-sugestão** — tudo manual. Founder quer "ir com quais eu acredito que sejam, e ele só aprova".
+
+## Diagnóstico (confirmado em prod via SQL Editor)
+
+- A família no banco é **"Bases MixMachine"**, que após `lowercase().trim()` CASA com o filtro do `tint-omie-sync`. **Não é mismatch de string** (hipótese inicial descartada pelo diagnóstico).
+- É **cobertura**: 67 bases (+5 concentrados) com a família certa estavam **sem `is_tintometric`** → fora do dropdown (que filtra `is_tintometric=true AND ativo=true AND tint_type=…`, [TintMapping.tsx:42-46](../../../src/pages/TintMapping.tsx)). Causa provável: teto de 20 páginas / rate-limit do `tint-omie-sync` ([tint-omie-sync:125-138](../../../supabase/functions/tint-omie-sync/index.ts)); produtos novos entram pelo sync geral sem a marca.
+- As **80 bases ATIVAS já estão 100% mapeadas** (`bases_sem_mapa = 0`). As linhas "Selecionar…" que o founder vê são **SKUs OCULTOS** (`ativo=false`) que ele quer **reativar + mapear**.
+
+## Solução
+
+### (a) Cobertura — backfill [FEITO em prod 2026-06-14]
+
+`UPDATE omie_products` marcou `is_tintometric=true` + `tint_type` nos produtos Omie **ativos** com família "Bases/Concentrados MixMachine" que escaparam. Resultado: **13 ativos** marcados (8 bases + 5 concentrados), incl. `WJOB.7796` GL (`PRD03644`) e irmãs 405/810ML. Os 59 restantes são `ativo=false` (descontinuados) → corretamente fora. UPDATE seguro/reversível (só toca classificação tint; não toca preço/estoque/descrição).
+
+### (b) Motor de matching puro — `src/lib/tint/omie-match.ts` (TDD)
+
+Score de relevância entre uma **linha-SKU** (`tint_produtos.descricao` + `tint_bases.descricao` + `tint_embalagens.descricao`/`volume_ml`) e um **produto Omie** (`codigo` + `descricao`):
+
+- **código-base igual** → peso **ALTO**. Ex.: `WJOB.7796` (da `tint_bases.descricao`, que começa com o código) vs `WJOB.7796` extraído de `BASE ACRIL BRANC BRIL 05 WJOB.7796GL`. ⚠️ distingue `WJOB.7796` (branca) de `WJOI.7796` (intermediária) — mesmo número, bases diferentes. Novo helper `extrairCodigoBase` (formato `[A-Z]{2,4}\d{0,2}\.\d{3,4}(\.\d{2,4})?`, **SEM** sufixo de embalagem — o `sayerlack-sku.ts` exige sufixo colado, então não serve direto; reuso a mesma família de regex).
+- **embalagem casa** → peso **MÉDIO**. O trecho da `descricao` Omie depois do código-base (`…7796GL` → `GL`; `…7796 405ML` → `405ML`) comparado, normalizado, com `tint_embalagens.descricao`.
+- **palavras descritivas em comum** (ACRIL, FOSCO, BRANC, INTER…) → peso **BAIXO** (desempate).
+
+**⚠️ Confiança ≠ score (correção Codex 2026-06-14, money-path):** a classificação `forte`/`revisar` vem da **cardinalidade de uma chave estrutural exata**, NUNCA do score. O score (pesos acima) serve **só pra ordenar o combobox** (tela de revisão), nunca pra produzir confiança — senão o desempate por palavras (`+1`) promoveria arbitrariamente um de dois candidatos com a MESMA chave dura a `forte`.
+
+Chave dura = `(código-base exato, embalagem exata)`. `forte` ⟺ existe **exatamente 1** produto Omie elegível (base ativa) cuja chave dura bate **inequivocamente** com a da linha-SKU. `count == 0` ou `> 1` → `revisar`.
+
+Parsing à prova de money-path (Codex):
+- Extrair **exatamente 1** código de cada lado; 0 ou >1 códigos → `revisar` (não chuta). Âncora de posição: **início** na `tint_bases.descricao`, **fim** na `descricao` Omie (anti-substring `XWJOB.7796`/`WJOB.77960`).
+- Comparação **exata, código inteiro**: `WJOB ≠ WJOI`, `JO10 ≠ JO5`, `.7644 ≠ .7644.00`. **Não** remover `.00` nem normalizar pontuação (`4,05L` ≠ `405L`).
+- Embalagem: **igualdade textual exata** (normalizada upper/trim) entre o trecho pós-código da Omie e `tint_embalagens.descricao`. **Sem alias implícito** (`QT` ≠ `810ML`, `GL` ≠ `3600ML`) — casar por volume/alias/inferência ⇒ `revisar`. Fracionado (`405ML`/`450ML`) é embalagem distinta, nunca aproximada. (Se a query de embalagens mostrar que descricao×sufixo divergem sistematicamente, uma **tabela de alias EXPLÍCITA** entra — nunca alias implícito.)
+- **Unicidade GLOBAL** no universo elegível (todas as bases ativas), não só "na mesma família" — duplicata no ERP (2 produtos com a mesma chave dura) ⇒ `revisar`.
+- Candidato cujo produto Omie **já está mapeado a outra base** ⇒ `revisar` (não rouba/duplica vínculo existente).
+
+Funções puras: `extrairCodigoBase`, `embalagemDaDescricaoOmie`, `scoreProduto` (só ordena), `ranquearProdutos(linha, produtos)` (combobox), `sugerirMapeamento(linha, produtos, jaMapeados)` (confiança por cardinalidade de chave dura).
+
+### (c) Seletor (combobox) — substitui o `<Select>`
+
+cmdk `Command` + `Popover` (espelha [CityMultiSelector](../../../src/components/reposicao/routePlanner/CityMultiSelector.tsx) / [PaymentComboboxEdit](../../../src/components/salesOrderEdit/PaymentComboboxEdit.tsx)). Busca digitável (reusa `normalizarBusca` de [cores-do-cliente.ts](../../../src/lib/tint/cores-do-cliente.ts), filtra por `codigo`+`descricao`). Resultados em grupos: **"Sugeridos pra esta base"** no topo (código-base igual, score desc) + resto **agrupado por código-base** (resolve "agrupar nomes parecidos"). Custo/estoque na linha pra ajudar a escolha. Cap de 1000 do PostgREST eliminado (`.range`/paginação — hoje 114 < 1000, preventivo).
+
+### (d) Auto-sugestão + aprovação
+
+Botão **"Sugerir mapeamentos"**: roda o motor sobre as bases **não-mapeadas visíveis** (respeita o filtro de ocultos), pré-preenche cada uma com o melhor palpite em **estado local** (badge "sugestão", **nada salvo**). Founder **aprova em lote** (salva todos) **ou ajusta linha a linha**. Aprovar um SKU oculto **reativa (`ativo=true`) + mapeia** numa mutação otimista. Sugestões `revisar` ficam destacadas mas exigem clique explícito.
+
+## Não-objetivos (v1)
+
+- Abrir o dropdown pra **todo o catálogo Omie** (founder quer curado: só bases/concentrados).
+- Tratar concentrados como foco (founder diz estar ok; o motor cobre, mas tende a 0 pendência).
+- **Reescrever o sync** (follow-up).
+- Reativar SKUs ocultos em massa sem mapear (a reativação acontece *ao aprovar a sugestão*).
+
+## Follow-up (não bloqueia)
+
+- Tornar `tint-omie-sync` robusto à cobertura (paginação completa / filtrar por família na API Omie) pra produtos novos não escaparem e dispensar re-backfill.
+
+## Validação
+
+- Motor: testes vitest com fixtures dos casos **reais** (WJOB/WJOI.7796 em QT/GL/BH/405/810ML; JO10.7644.00; JLO.7581.00) — incl. o caso-borda WJOB vs WJOI.
+- **Codex challenge** no algoritmo de matching (casos-borda de string — é o que ele pega bem).
+- `bun run typecheck` (strict) + `bun lint` + `bun run test` + `bun run build`, via `heavy`.
+- Empírico: founder mapeia a WJOB.7796 galão (que estava escondida) pela tela nova.
+
+## Apêndice — SQL do backfill (rodado em prod 2026-06-14; rastreabilidade)
+
+UPDATE ad-hoc (NÃO virou migration — o conserto durável é o follow-up do sync). Marcou **13 ativos** (8 bases + 5 concentrados), incl. `PRD03644` (WJOB.7796 GL). Os 59 não tocados são `ativo=false`.
+
+```sql
+update omie_products
+set is_tintometric = true,
+    tint_type = case
+      when lower(btrim(coalesce(nullif(btrim(familia),''), metadata->>'descricao_familia'))) = 'bases mixmachine' then 'base'
+      when lower(btrim(coalesce(nullif(btrim(familia),''), metadata->>'descricao_familia'))) = 'concentrados mixmachine' then 'concentrado'
+    end,
+    updated_at = now()
+where account = 'oben'
+  and ativo = true
+  and lower(btrim(coalesce(nullif(btrim(familia),''), metadata->>'descricao_familia'))) in ('bases mixmachine','concentrados mixmachine')
+  and is_tintometric is not true;
+```
+
+Reverter (se preciso): `set is_tintometric=false, tint_type=null` no mesmo filtro — ⚠️ reverteria também os pré-existentes; escopar por `updated_at` se quiser só os do backfill.
+

--- a/src/components/tint/OmieBaseCombobox.tsx
+++ b/src/components/tint/OmieBaseCombobox.tsx
@@ -1,0 +1,146 @@
+// Seletor de produto Omie pra uma base tintométrica: busca digitável +
+// ranqueamento por relevância à base (sugeridos no topo). Substitui o <Select>
+// alfabético-cego de TintMapping. Busca acento-insensitive controlada por nós
+// (shouldFilter={false}) pra preservar a ordem "sugeridos pra esta base".
+import { useMemo, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { ChevronsUpDown, Check, Sparkles } from 'lucide-react';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command';
+import { cn } from '@/lib/utils';
+import { ranquearProdutos, type LinhaSku, type ProdutoOmieMatch } from '@/lib/tint/omie-match';
+import { normalizarBusca } from '@/lib/tint/cores-do-cliente';
+
+export interface ProdutoOmieOption extends ProdutoOmieMatch {
+  valor_unitario: number;
+  estoque: number | null;
+}
+
+type Ranqueado = ProdutoOmieOption & { codigoBateu: boolean; embalagemBateu: boolean; score: number };
+
+interface OmieBaseComboboxProps {
+  produtos: ProdutoOmieOption[];
+  linha: LinhaSku;
+  value: string | null;
+  onChange: (id: string | null) => void;
+  disabled?: boolean;
+}
+
+export function OmieBaseCombobox({ produtos, linha, value, onChange, disabled }: OmieBaseComboboxProps) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState('');
+
+  const selecionado = produtos.find((p) => p.id === value) ?? null;
+
+  const { sugeridos, outros } = useMemo(() => {
+    const q = normalizarBusca(query);
+    const ranqueados = ranquearProdutos(linha, produtos).filter((p) =>
+      q === '' ? true : normalizarBusca(`${p.codigo} ${p.descricao}`).includes(q),
+    );
+    return {
+      sugeridos: ranqueados.filter((p) => p.codigoBateu),
+      outros: ranqueados.filter((p) => !p.codigoBateu),
+    };
+  }, [produtos, linha, query]);
+
+  function pick(id: string | null) {
+    onChange(id);
+    setOpen(false);
+    setQuery('');
+  }
+
+  return (
+    <Popover
+      open={open}
+      onOpenChange={(o) => {
+        setOpen(o);
+        if (!o) setQuery('');
+      }}
+    >
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          disabled={disabled}
+          className="w-full justify-between text-sm h-8 font-normal"
+        >
+          <span className="truncate">
+            {selecionado ? `${selecionado.codigo} — ${selecionado.descricao}` : 'Selecionar…'}
+          </span>
+          <ChevronsUpDown className="ml-2 h-3.5 w-3.5 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-[440px] p-0" align="start">
+        <Command shouldFilter={false}>
+          <CommandInput
+            placeholder="Buscar por código ou descrição…"
+            value={query}
+            onValueChange={setQuery}
+            className="h-9 text-sm"
+          />
+          <CommandList>
+            <CommandEmpty className="py-3 text-center text-xs text-muted-foreground">
+              Nenhum produto encontrado.
+            </CommandEmpty>
+            {value && (
+              <CommandItem
+                value="__limpar__"
+                onSelect={() => pick(null)}
+                className="text-xs text-muted-foreground"
+              >
+                Limpar seleção
+              </CommandItem>
+            )}
+            {sugeridos.length > 0 && (
+              <CommandGroup heading="Sugeridos pra esta base">
+                {sugeridos.map((p) => (
+                  <ProdutoItem key={p.id} p={p} selecionado={value === p.id} onPick={pick} />
+                ))}
+              </CommandGroup>
+            )}
+            {outros.length > 0 && (
+              <CommandGroup heading="Outros produtos">
+                {outros.map((p) => (
+                  <ProdutoItem key={p.id} p={p} selecionado={value === p.id} onPick={pick} />
+                ))}
+              </CommandGroup>
+            )}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+function ProdutoItem({
+  p,
+  selecionado,
+  onPick,
+}: {
+  p: Ranqueado;
+  selecionado: boolean;
+  onPick: (id: string) => void;
+}) {
+  return (
+    <CommandItem value={p.id} onSelect={() => onPick(p.id)} className="text-sm">
+      <Check className={cn('mr-2 h-3.5 w-3.5 shrink-0', selecionado ? 'opacity-100' : 'opacity-0')} />
+      <span className="flex-1 truncate">
+        <span className="font-mono text-xs text-muted-foreground">{p.codigo}</span> {p.descricao}
+      </span>
+      {p.codigoBateu && p.embalagemBateu && (
+        <Sparkles className="ml-1 h-3 w-3 shrink-0 text-status-success" aria-label="casa código + embalagem" />
+      )}
+      <span className="ml-2 shrink-0 text-xs tabular-nums text-muted-foreground">
+        R$ {p.valor_unitario.toFixed(2)}
+      </span>
+    </CommandItem>
+  );
+}

--- a/src/lib/tint/__tests__/omie-match.test.ts
+++ b/src/lib/tint/__tests__/omie-match.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect } from 'vitest';
+import {
+  extrairCodigoBaseInicio,
+  parseDescricaoOmie,
+  casarLinhaProduto,
+  ranquearProdutos,
+  sugerirMapeamento,
+  type LinhaSku,
+  type ProdutoOmieMatch,
+} from '../omie-match';
+
+// ── extração do código-base da tint_bases.descricao (código vem no INÍCIO) ──
+describe('extrairCodigoBaseInicio', () => {
+  it('extrai o código no início, ignorando o resto', () => {
+    expect(extrairCodigoBaseInicio('WJOB.7796 - BASE ACRIL FOSCO BRANCA')).toBe('WJOB.7796');
+  });
+  it('preserva a 2ª parte .00 (não normaliza/remove)', () => {
+    expect(extrairCodigoBaseInicio('JO10.7644.00 - VERNIZ ACRILICO')).toBe('JO10.7644.00');
+  });
+  it('normaliza caixa', () => {
+    expect(extrairCodigoBaseInicio('  wjoi.7796 - base inter')).toBe('WJOI.7796');
+  });
+  it('retorna null quando não há código no início', () => {
+    expect(extrairCodigoBaseInicio('BASE ACRIL FOSCO SEM CODIGO')).toBeNull();
+  });
+  it('não casa código com dígitos a mais na 1ª parte (anti-substring WJOB.77960)', () => {
+    expect(extrairCodigoBaseInicio('WJOB.77960 - X')).toBeNull();
+  });
+  it('lida com null/vazio', () => {
+    expect(extrairCodigoBaseInicio(null)).toBeNull();
+    expect(extrairCodigoBaseInicio('')).toBeNull();
+  });
+});
+
+// ── parse da descricao Omie (código + embalagem colados/separados no FIM) ──
+describe('parseDescricaoOmie', () => {
+  it('código + embalagem colada (GL)', () => {
+    expect(parseDescricaoOmie('BASE ACRIL BRANC BRIL 05 WJOB.7796GL')).toEqual({
+      codigoBase: 'WJOB.7796',
+      embalagem: 'GL',
+    });
+  });
+  it('embalagem separada por espaço (405ML)', () => {
+    expect(parseDescricaoOmie('BASE ACRIL INTER BRIL05 WJOI.7796 405ML')).toEqual({
+      codigoBase: 'WJOI.7796',
+      embalagem: '405ML',
+    });
+  });
+  it('código com 2ª parte .00 + embalagem', () => {
+    expect(parseDescricaoOmie('VERNIZ ACRILICO FOSCO JO10.7644.00GL')).toEqual({
+      codigoBase: 'JO10.7644.00',
+      embalagem: 'GL',
+    });
+  });
+  it('embalagem QT', () => {
+    expect(parseDescricaoOmie('BASE ACRIL BRANC BRIL 05 WJOB.7796QT')).toEqual({
+      codigoBase: 'WJOB.7796',
+      embalagem: 'QT',
+    });
+  });
+  it('anti-substring: código grudado em outra palavra → null', () => {
+    expect(parseDescricaoOmie('PRODUTOWJOB.7796GL')).toBeNull();
+  });
+  it('anti-substring: dígito a mais na 1ª parte → null', () => {
+    expect(parseDescricaoOmie('BASE WJOB.77960GL')).toBeNull();
+  });
+  it('sem código → null', () => {
+    expect(parseDescricaoOmie('PRODUTO GENERICO QUALQUER')).toBeNull();
+  });
+});
+
+// ── casamento estrutural linha×produto (chave dura, igualdade EXATA) ──
+describe('casarLinhaProduto', () => {
+  const linha = (base: string, emb: string): LinhaSku => ({ baseDescricao: base, embalagemDescricao: emb });
+  const prod = (descricao: string): ProdutoOmieMatch => ({ id: 'p', codigo: 'PRD', descricao });
+
+  it('código e embalagem batem', () => {
+    expect(casarLinhaProduto(linha('WJOB.7796 - BASE', 'GL'), prod('BASE ... WJOB.7796GL'))).toEqual({
+      codigoBateu: true,
+      embalagemBateu: true,
+    });
+  });
+  it('WJOB ≠ WJOI: mesmo número, base diferente → código NÃO bate', () => {
+    expect(casarLinhaProduto(linha('WJOB.7796 - BRANCA', 'GL'), prod('BASE INTER WJOI.7796GL')).codigoBateu).toBe(
+      false,
+    );
+  });
+  it('embalagem diferente (QT vs GL) → embalagem NÃO bate', () => {
+    expect(casarLinhaProduto(linha('WJOB.7796 - BASE', 'QT'), prod('BASE ... WJOB.7796GL')).embalagemBateu).toBe(
+      false,
+    );
+  });
+  it('sem alias implícito: QT ≠ 810ML', () => {
+    expect(casarLinhaProduto(linha('WJOI.7796 - BASE', 'QT'), prod('BASE ... WJOI.7796 810ML')).embalagemBateu).toBe(
+      false,
+    );
+  });
+});
+
+// ── sugestão: confiança vem da CARDINALIDADE da chave dura, NÃO do score ──
+describe('sugerirMapeamento', () => {
+  const linha: LinhaSku = { baseDescricao: 'WJOB.7796 - BASE ACRIL', embalagemDescricao: 'GL' };
+  const vazio = new Set<string>();
+
+  it('1 candidato com código+embalagem exatos e único → forte', () => {
+    const produtos: ProdutoOmieMatch[] = [
+      { id: 'a', codigo: 'PRD03644', descricao: 'BASE ACRIL BRANC BRIL 05 WJOB.7796GL' },
+      { id: 'b', codigo: 'PRD03506', descricao: 'BASE ACRIL BRANC BRIL 05 WJOB.7796QT' },
+    ];
+    expect(sugerirMapeamento(linha, produtos, vazio)).toEqual({ tipo: 'forte', produtoId: 'a' });
+  });
+
+  it('FURO CODEX: 2 candidatos com a MESMA chave dura → revisar (score nunca decide forte)', () => {
+    const produtos: ProdutoOmieMatch[] = [
+      { id: 'a', codigo: 'PRD1', descricao: 'BASE ACRIL FOSCO BRANC WJOB.7796GL' }, // + palavras
+      { id: 'b', codigo: 'PRD2', descricao: 'BASE WJOB.7796GL' },
+    ];
+    const r = sugerirMapeamento(linha, produtos, vazio);
+    expect(r.tipo).toBe('revisar');
+  });
+
+  it('código bate mas nenhuma embalagem bate → revisar (não forte)', () => {
+    const produtos: ProdutoOmieMatch[] = [
+      { id: 'a', codigo: 'PRD', descricao: 'BASE ACRIL WJOB.7796QT' }, // só QT, linha é GL
+    ];
+    const r = sugerirMapeamento(linha, produtos, vazio);
+    expect(r.tipo).toBe('revisar');
+    if (r.tipo === 'revisar') expect(r.candidatos).toContain('a');
+  });
+
+  it('CASO-BORDA: número igual mas base diferente (WJOB vs WJOI) → sem_sugestao', () => {
+    const produtos: ProdutoOmieMatch[] = [
+      { id: 'a', codigo: 'PRD', descricao: 'BASE ACRIL INTER WJOI.7796GL' },
+    ];
+    expect(sugerirMapeamento(linha, produtos, vazio)).toEqual({ tipo: 'sem_sugestao' });
+  });
+
+  it('o único candidato forte já está mapeado a OUTRA base → revisar (não rouba vínculo)', () => {
+    const produtos: ProdutoOmieMatch[] = [
+      { id: 'a', codigo: 'PRD03644', descricao: 'BASE ACRIL BRANC BRIL 05 WJOB.7796GL' },
+    ];
+    const r = sugerirMapeamento(linha, produtos, new Set(['a']));
+    expect(r.tipo).toBe('revisar');
+  });
+});
+
+// ── ranqueamento pro combobox (score SÓ ordena a tela) ──
+describe('ranquearProdutos', () => {
+  const linha: LinhaSku = { baseDescricao: 'WJOB.7796 - BASE ACRIL FOSCO', embalagemDescricao: 'GL' };
+
+  it('código+embalagem no topo, depois só-código, depois o resto', () => {
+    const produtos: ProdutoOmieMatch[] = [
+      { id: 'outro', codigo: 'PRD', descricao: 'CONCENTRADO PRETO WP12.3900GL' },
+      { id: 'soCodigo', codigo: 'PRD', descricao: 'BASE ACRIL WJOB.7796QT' },
+      { id: 'exato', codigo: 'PRD', descricao: 'BASE ACRIL FOSCO BRANC WJOB.7796GL' },
+    ];
+    const r = ranquearProdutos(linha, produtos);
+    expect(r.map((p) => p.id)).toEqual(['exato', 'soCodigo', 'outro']);
+    expect(r[0].codigoBateu).toBe(true);
+    expect(r[0].embalagemBateu).toBe(true);
+  });
+});

--- a/src/lib/tint/omie-match.ts
+++ b/src/lib/tint/omie-match.ts
@@ -1,0 +1,137 @@
+/**
+ * Motor de matching base-tintométrica ↔ produto Omie (puro, testável).
+ *
+ * O código da base (ex. WJOB.7796) vem no INÍCIO da `tint_bases.descricao` e
+ * COLADO — ou separado por espaço — no FIM da `descricao` do produto Omie,
+ * seguido da embalagem (GL/QT/BH/405ML…). ⚠️ WJOB.7796 (branca) ≠ WJOI.7796
+ * (intermediária): mesmo número, bases DIFERENTES → casar o código INTEIRO.
+ *
+ * ⚠️ money-path (sugestão errada que o humano aprova = produto errado no pedido).
+ * Regras (Codex 2026-06-14, ver spec):
+ *  - confiança ('forte'/'revisar') vem da CARDINALIDADE de uma chave dura EXATA
+ *    (código-base + embalagem), NUNCA do score. O score só ORDENA o combobox.
+ *  - parsing exato: WJOB ≠ WJOI, JO10 ≠ JO5, .7644 ≠ .7644.00 (não remover .00);
+ *    1 código por lado, ancorado (início na base, fim na Omie); anti-substring.
+ *  - embalagem: igualdade textual EXATA, SEM alias implícito (QT ≠ 810ML).
+ *  - unicidade GLOBAL no universo elegível; candidato já mapeado a outra base → revisar.
+ *
+ * Spec: docs/superpowers/specs/2026-06-14-tint-mapeamento-assistido-design.md
+ */
+
+export interface LinhaSku {
+  baseDescricao: string;
+  embalagemDescricao: string;
+  /** opcional — só entra no desempate por palavras (nunca na confiança). */
+  produtoDescricao?: string;
+}
+
+export interface ProdutoOmieMatch {
+  id: string;
+  codigo: string;
+  descricao: string;
+}
+
+export type Sugestao =
+  | { tipo: 'forte'; produtoId: string }
+  | { tipo: 'revisar'; candidatos: string[] } // ids ranqueados (código bate)
+  | { tipo: 'sem_sugestao' };
+
+// PREFIXO(2-4 letras + 0-2 díg) "." NUM1(3-4 díg) ["." NUM2(2-4 díg)]? — SEM
+// sufixo de embalagem. O lookahead (?![\d.]) impede capturar "WJOB.7796" de
+// "WJOB.77960" (dígito a mais) ou de uma 3ª parte numérica inesperada.
+const CODIGO = String.raw`[A-Z]{2,4}\d{0,2}\.\d{3,4}(?:\.\d{2,4})?`;
+const RE_BASE_INICIO = new RegExp(`^(${CODIGO})(?![\\d.])`);
+const RE_OMIE_FIM = new RegExp(`(?:^|\\s)(${CODIGO})(?![\\d.])\\s*([A-Z0-9]*)\\s*$`);
+const RE_PALAVRA = /[A-Z0-9]+/g;
+
+function norm(s: string | null | undefined): string {
+  return (s ?? '').normalize('NFKC').trim().toUpperCase();
+}
+
+/** Código-base no INÍCIO da descrição da base (ex.: "WJOB.7796 - …" → "WJOB.7796"). */
+export function extrairCodigoBaseInicio(s: string | null | undefined): string | null {
+  return norm(s).match(RE_BASE_INICIO)?.[1] ?? null;
+}
+
+/** Código-base + embalagem no FIM da descrição Omie ("… WJOB.7796GL" → {WJOB.7796, GL}). */
+export function parseDescricaoOmie(
+  s: string | null | undefined,
+): { codigoBase: string; embalagem: string } | null {
+  const m = norm(s).match(RE_OMIE_FIM);
+  if (!m) return null;
+  return { codigoBase: m[1] ?? '', embalagem: m[2] ?? '' };
+}
+
+/** Chave dura: código-base e embalagem batem EXATO (sem alias/inferência). */
+export function casarLinhaProduto(
+  linha: LinhaSku,
+  produto: ProdutoOmieMatch,
+): { codigoBateu: boolean; embalagemBateu: boolean } {
+  const codBase = extrairCodigoBaseInicio(linha.baseDescricao);
+  const omie = parseDescricaoOmie(produto.descricao);
+  if (!codBase || !omie) return { codigoBateu: false, embalagemBateu: false };
+  const embLinha = norm(linha.embalagemDescricao);
+  const embOmie = norm(omie.embalagem);
+  return {
+    codigoBateu: codBase === omie.codigoBase,
+    embalagemBateu: embLinha !== '' && embOmie !== '' && embLinha === embOmie,
+  };
+}
+
+/** Palavras descritivas (sem o código) — só pra desempate visual. */
+function palavrasDescritivas(s: string): Set<string> {
+  const semCodigo = norm(s).replace(new RegExp(CODIGO, 'g'), ' ');
+  return new Set(semCodigo.match(RE_PALAVRA) ?? []);
+}
+
+/** Score de RELEVÂNCIA — usado SÓ pra ordenar o combobox, nunca pra confiança. */
+export function scoreProduto(linha: LinhaSku, produto: ProdutoOmieMatch): number {
+  const { codigoBateu, embalagemBateu } = casarLinhaProduto(linha, produto);
+  let score = (codigoBateu ? 100 : 0) + (embalagemBateu ? 50 : 0);
+  const pl = palavrasDescritivas(`${linha.produtoDescricao ?? ''} ${linha.baseDescricao}`);
+  for (const w of palavrasDescritivas(produto.descricao)) if (pl.has(w)) score += 1;
+  return score;
+}
+
+/**
+ * Lista ranqueada pro combobox (código+embalagem no topo, depois só-código, depois
+ * resto). Genérico em T pra preservar campos extras do produto (custo/estoque).
+ */
+export function ranquearProdutos<T extends ProdutoOmieMatch>(
+  linha: LinhaSku,
+  produtos: T[],
+): Array<T & { score: number; codigoBateu: boolean; embalagemBateu: boolean }> {
+  return produtos
+    .map((p) => {
+      const { codigoBateu, embalagemBateu } = casarLinhaProduto(linha, p);
+      return { ...p, codigoBateu, embalagemBateu, score: scoreProduto(linha, p) };
+    })
+    .sort((a, b) => b.score - a.score);
+}
+
+/**
+ * Sugestão de mapeamento pra UMA base. `produtos` deve ser o universo ELEGÍVEL
+ * COMPLETO (todas as bases ativas) — a unicidade é global. `idsJaMapeados` =
+ * produtos Omie já vinculados a OUTRAS bases (não roubar/duplicar vínculo).
+ *
+ * forte ⟺ existe EXATAMENTE 1 produto com chave dura (código+embalagem) exata,
+ * ainda livre. count 0 ou >1 → revisar. Sem código batendo → sem_sugestao.
+ */
+export function sugerirMapeamento(
+  linha: LinhaSku,
+  produtos: ProdutoOmieMatch[],
+  idsJaMapeados: Set<string>,
+): Sugestao {
+  const casados = produtos.map((p) => ({ p, ...casarLinhaProduto(linha, p) }));
+  const comCodigo = casados.filter((c) => c.codigoBateu);
+  if (comCodigo.length === 0) return { tipo: 'sem_sugestao' };
+
+  const fortes = comCodigo.filter((c) => c.embalagemBateu && !idsJaMapeados.has(c.p.id));
+  if (fortes.length === 1) return { tipo: 'forte', produtoId: fortes[0].p.id };
+
+  const candidatos = ranquearProdutos(
+    linha,
+    comCodigo.map((c) => c.p),
+  ).map((p) => p.id);
+  return { tipo: 'revisar', candidatos };
+}

--- a/src/pages/TintMapping.tsx
+++ b/src/pages/TintMapping.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
 import { Badge } from '@/components/ui/badge';
@@ -10,8 +10,10 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Skeleton } from '@/components/ui/skeleton';
-import { Search, EyeOff, Eye } from 'lucide-react';
+import { Search, EyeOff, Eye, Wand2, Check, X } from 'lucide-react';
 import { toast } from 'sonner';
+import { OmieBaseCombobox, type ProdutoOmieOption } from '@/components/tint/OmieBaseCombobox';
+import { sugerirMapeamento, type LinhaSku } from '@/lib/tint/omie-match';
 
 const ACCOUNT = 'oben';
 
@@ -145,6 +147,79 @@ function SkuTab() {
   });
 
   const omieMap = new Map((omieProducts ?? []).map(p => [p.id, p]));
+  const omieOptions = (omieProducts ?? []) as ProdutoOmieOption[];
+
+  // Auto-sugestão de mapeamento (eu sugiro, você aprova). As 'forte' ficam em
+  // estado local até aprovar; aprovar reativa o SKU se estiver oculto.
+  const [sugestoes, setSugestoes] = useState<Map<string, string>>(new Map());
+  const idsJaMapeados = useMemo(
+    () =>
+      new Set(
+        ((skus ?? []) as SkuRow[]).map((s) => s.omie_product_id).filter((x): x is string => !!x),
+      ),
+    [skus],
+  );
+  function linhaDoSku(s: SkuRow): LinhaSku {
+    return {
+      baseDescricao: s.tint_bases?.descricao ?? '',
+      embalagemDescricao: s.tint_embalagens?.descricao ?? '',
+      produtoDescricao: s.tint_produtos?.descricao ?? '',
+    };
+  }
+  function gerarSugestoes() {
+    const novas = new Map<string, string>();
+    for (const s of filtered) {
+      if (s.omie_product_id) continue;
+      const sug = sugerirMapeamento(linhaDoSku(s), omieOptions, idsJaMapeados);
+      if (sug.tipo === 'forte') novas.set(s.id, sug.produtoId);
+    }
+    setSugestoes(novas);
+    toast[novas.size ? 'success' : 'info'](
+      novas.size
+        ? `${novas.size} sugestão(ões) forte(s) — revise e aprove`
+        : 'Nenhuma sugestão forte encontrada (os ambíguos ficam pra você escolher no seletor)',
+    );
+  }
+  function descartarSugestao(skuId: string) {
+    setSugestoes((prev) => {
+      const m = new Map(prev);
+      m.delete(skuId);
+      return m;
+    });
+  }
+  async function aprovarSugestao(skuId: string, omieProductId: string) {
+    const { error } = await supabase
+      .from('tint_skus')
+      .update({ omie_product_id: omieProductId, ativo: true, updated_at: new Date().toISOString() })
+      .eq('id', skuId);
+    if (error) {
+      toast.error(error.message);
+      return;
+    }
+    descartarSugestao(skuId);
+    queryClient.invalidateQueries({ queryKey: ['tint-skus-mapping'] });
+    queryClient.invalidateQueries({ queryKey: ['tint-dashboard-metrics'] });
+    toast.success('Mapeamento aprovado');
+  }
+  async function aprovarTodas() {
+    const entries = [...sugestoes.entries()];
+    let ok = 0;
+    for (const [skuId, pid] of entries) {
+      const { error } = await supabase
+        .from('tint_skus')
+        .update({ omie_product_id: pid, ativo: true, updated_at: new Date().toISOString() })
+        .eq('id', skuId);
+      if (error) {
+        toast.error(error.message);
+        break;
+      }
+      ok++;
+    }
+    setSugestoes(new Map());
+    queryClient.invalidateQueries({ queryKey: ['tint-skus-mapping'] });
+    queryClient.invalidateQueries({ queryKey: ['tint-dashboard-metrics'] });
+    if (ok) toast.success(`${ok} mapeamento(s) aprovado(s)`);
+  }
 
   const totalSkus = skus?.length ?? 0;
   const activeSkus = ((skus ?? []) as SkuRow[]).filter((s) => s.ativo !== false).length;
@@ -177,6 +252,22 @@ function SkuTab() {
             Mostrar ocultos ({inactiveSkus})
           </Label>
         </div>
+
+        <div className="ml-auto flex items-center gap-2">
+          <Button variant="outline" size="sm" className="h-9 gap-1.5" onClick={gerarSugestoes}>
+            <Wand2 className="h-4 w-4" /> Sugerir mapeamentos
+          </Button>
+          {sugestoes.size > 0 && (
+            <>
+              <Button size="sm" className="h-9 gap-1.5" onClick={aprovarTodas}>
+                <Check className="h-4 w-4" /> Aprovar todas ({sugestoes.size})
+              </Button>
+              <Button variant="ghost" size="sm" className="h-9" onClick={() => setSugestoes(new Map())}>
+                Descartar
+              </Button>
+            </>
+          )}
+        </div>
       </div>
 
       <p className="text-sm text-muted-foreground">
@@ -206,21 +297,45 @@ function SkuTab() {
                   <TableCell className="text-sm max-w-[200px] truncate">{sku.tint_bases?.descricao}</TableCell>
                   <TableCell className="text-sm">{sku.tint_embalagens?.descricao} ({sku.tint_embalagens?.volume_ml}ml)</TableCell>
                   <TableCell>
-                    <Select
-                      value={sku.omie_product_id || ''}
-                      onValueChange={val => mutation.mutate({ skuId: sku.id, omieProductId: val || null })}
-                    >
-                      <SelectTrigger className="text-sm h-8">
-                        <SelectValue placeholder="Selecionar..." />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {(omieProducts ?? []).map(p => (
-                          <SelectItem key={p.id} value={p.id} className="text-sm">
-                            {p.codigo} — {p.descricao}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
+                    {(() => {
+                      const sugId = sugestoes.get(sku.id);
+                      const sug = sugId ? omieMap.get(sugId) : null;
+                      return (
+                        <div className="space-y-1.5">
+                          {sug && sugId && (
+                            <div className="flex items-center gap-1.5 rounded-md border border-status-warning/40 bg-status-warning-bg px-2 py-1">
+                              <span className="flex-1 truncate text-xs">
+                                <span className="font-medium text-status-warning">Sugestão:</span>{' '}
+                                <span className="font-mono">{sug.codigo}</span> — {sug.descricao}
+                              </span>
+                              <Button
+                                size="sm"
+                                className="h-6 px-2"
+                                onClick={() => aprovarSugestao(sku.id, sugId)}
+                                title="Aprovar (mapeia e reativa o SKU)"
+                              >
+                                <Check className="h-3.5 w-3.5" />
+                              </Button>
+                              <Button
+                                variant="ghost"
+                                size="sm"
+                                className="h-6 px-2"
+                                onClick={() => descartarSugestao(sku.id)}
+                                title="Descartar sugestão"
+                              >
+                                <X className="h-3.5 w-3.5" />
+                              </Button>
+                            </div>
+                          )}
+                          <OmieBaseCombobox
+                            produtos={omieOptions}
+                            linha={linhaDoSku(sku)}
+                            value={sku.omie_product_id}
+                            onChange={(id) => mutation.mutate({ skuId: sku.id, omieProductId: id })}
+                          />
+                        </div>
+                      );
+                    })()}
                   </TableCell>
                   <TableCell className="text-sm">{linked ? `R$ ${linked.valor_unitario.toFixed(2)}` : '—'}</TableCell>
                   <TableCell className="text-sm">{linked?.estoque ?? '—'}</TableCell>


### PR DESCRIPTION
## Mapeamento Omie das bases tintométricas — busca + ranqueamento + auto-sugestão + cobertura

Tela `/tintometrico/catalogo` → Mapeamento → **Bases**.

### Problema (founder)
1. Produto Omie que existe some da lista (ex. WJOB.7796 galão).
2. Seletor sem busca digitável + ordenação alfabética cega.
3. Sem auto-sugestão ("eu sugiro, você aprova").
4. Base nova precisa de backfill manual a cada vez.

### Diagnóstico
Não era mismatch de família — era **cobertura do sync**: 67 bases (+5 concentrados) ativas com família "Bases MixMachine" estavam sem `is_tintometric` → fora do dropdown. As 80 bases ATIVAS já estavam 100% mapeadas; o não-mapeado visível são SKUs **OCULTOS**.

### O que entra
- **Motor puro** `src/lib/tint/omie-match.ts` (23 testes) — chave dura EXATA (código-base + embalagem). Regras money-path do Codex: confiança por **cardinalidade**, nunca score; sem alias implícito (QT ≠ 810ML); `WJOB.7796` ≠ `WJOI.7796`; anti-substring; candidato já-mapeado → revisar.
- **Combobox** `OmieBaseCombobox` — busca digitável + "Sugeridos pra esta base" no topo (resto agrupado), custo na linha.
- **Auto-sugestão** em `TintMapping.tsx` — "Sugerir mapeamentos" / "Aprovar todas (N)"; aprovar um SKU oculto **reativa + mapeia**.
- **Cobertura automatizada** (follow-up) — função `tint_marcar_bases_mixmachine()` + cron diário marcam `is_tintometric`/`tint_type` por família, idempotente/aditivo, **sem tocar o edge** de sync. Dispensa backfill manual quando entra base nova. Fixes do Codex: corrige drift de `tint_type`; usa `familia` autoritativa. PG17 `db/test-tint-cobertura.sh` (A1-A4).

### ⚠️ Migration MANUAL (SQL Editor) — `20260614210000_tint_cobertura_bases_mixmachine.sql`
Cria a função + o cron. Sem ela, a cobertura automática não roda (a tela nova funciona mesmo assim, mas base nova futura voltaria a precisar de backfill). SQL entregue na conversa.

### Backfill (já rodado em prod 2026-06-14)
`UPDATE` marcou 13 produtos ativos (8 bases + 5 concentrados) que o sync não pegou — incl. a WJOB.7796 GL. SQL no apêndice da spec.

### Validação
typecheck strict **0** · lint **0 erros** · **3481 testes** · build OK · PG17 da função `db/test-tint-cobertura.sh` A1-A4.

### Pendências do founder
1. **Aplicar a migration** `20260614210000_…` no SQL Editor (cobertura automática).
2. **Mergear este PR + Publish no Lovable** (frontend → só vai ao ar após Publish).

### Não-feito (registrado na spec, decisão consciente)
Vigia no Sentinela (bases não-marcadas / tipo divergente / vínculo inativo) · desmarcar drift (perigoso) · aposentar `tint-omie-sync` · desenho "ideal" do Codex (candidatos por família sem marcar até a aprovação).

Spec: `docs/superpowers/specs/2026-06-14-tint-mapeamento-assistido-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
