### PR TITLE
fix(reposicao): timeout 60s→150s nos crons sync-inventory

### DIFF
--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,13 +21,13 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **219** custom migrations totais
-- **833** objetos esperados (criados por estas migrations)
+- **223** custom migrations totais
+- **840** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
-  - `function`: 229
+  - `function`: 232
   - `rls_policy`: 203
-  - `index`: 155
-  - `cron_job`: 102
+  - `index`: 157
+  - `cron_job`: 104
   - `table`: 96
   - `trigger`: 44
   - `enum_value`: 4
@@ -1936,6 +1936,33 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | `index` | `public.idx_radar_lista_novas` | `radar_empresas` |
 | `index` | `public.idx_radar_lista_estab` | `radar_empresas` |
 | `index` | `public.idx_radar_muni` | `radar_empresas` |
+
+### `20260613230000_roteirizador_prospects.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `public.radar_salvar_geocode` | — |
+| `function` | `public.radar_prospects_para_rota` | — |
+
+### `20260614103251_onda1_fase1_farmer_calls_atendimento.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `index` | `public.idx_farmer_calls_atendimento_id` | `farmer_calls` |
+
+### `20260614140000_radar_contagem_perf.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `index` | `public.idx_radar_muni_cover` | `radar_empresas` |
+| `function` | `public.radar_contagem_por_municipio` | — |
+
+### `20260614231801_reposicao_timeout_sync_inventory.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `cron_job` | `cron.sync-inventory-vendas-30m` | — |
+| `cron_job` | `cron.sync-inventory-colacor-vendas-1h` | — |
 
 ## Próximos passos quando algo der `❌`
 

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 219
+-- Total de custom migrations: 223
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -238,7 +238,11 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260613170000', 'fix_auto_assign_master_escalation', '20260613170000_fix_auto_assign_master_escalation.sql'),
   ('20260613180000', 'kb_hardening_codex', '20260613180000_kb_hardening_codex.sql'),
   ('20260613190000', 'radar_fatia3', '20260613190000_radar_fatia3.sql'),
-  ('20260613210000', 'radar_perf_indices', '20260613210000_radar_perf_indices.sql')
+  ('20260613210000', 'radar_perf_indices', '20260613210000_radar_perf_indices.sql'),
+  ('20260613230000', 'roteirizador_prospects', '20260613230000_roteirizador_prospects.sql'),
+  ('20260614103251', 'onda1_fase1_farmer_calls_atendimento', '20260614103251_onda1_fase1_farmer_calls_atendimento.sql'),
+  ('20260614140000', 'radar_contagem_perf', '20260614140000_radar_contagem_perf.sql'),
+  ('20260614231801', 'reposicao_timeout_sync_inventory', '20260614231801_reposicao_timeout_sync_inventory.sql')
 )
 SELECT
   e.version,
@@ -1089,7 +1093,14 @@ WITH expected_objects (migration, kind, schema_name, object_name, parent_name) A
   ('radar_fatia3', 'function', 'public', 'radar_registrar_cadastro_omie', ''),
   ('radar_perf_indices', 'index', 'public', 'idx_radar_lista_novas', 'radar_empresas'),
   ('radar_perf_indices', 'index', 'public', 'idx_radar_lista_estab', 'radar_empresas'),
-  ('radar_perf_indices', 'index', 'public', 'idx_radar_muni', 'radar_empresas')
+  ('radar_perf_indices', 'index', 'public', 'idx_radar_muni', 'radar_empresas'),
+  ('roteirizador_prospects', 'function', 'public', 'radar_salvar_geocode', ''),
+  ('roteirizador_prospects', 'function', 'public', 'radar_prospects_para_rota', ''),
+  ('onda1_fase1_farmer_calls_atendimento', 'index', 'public', 'idx_farmer_calls_atendimento_id', 'farmer_calls'),
+  ('radar_contagem_perf', 'index', 'public', 'idx_radar_muni_cover', 'radar_empresas'),
+  ('radar_contagem_perf', 'function', 'public', 'radar_contagem_por_municipio', ''),
+  ('reposicao_timeout_sync_inventory', 'cron_job', 'cron', 'sync-inventory-vendas-30m', ''),
+  ('reposicao_timeout_sync_inventory', 'cron_job', 'cron', 'sync-inventory-colacor-vendas-1h', '')
 )
 SELECT
   e.migration,

--- a/supabase/migrations/20260614231801_reposicao_timeout_sync_inventory.sql
+++ b/supabase/migrations/20260614231801_reposicao_timeout_sync_inventory.sql
@@ -1,0 +1,37 @@
+-- ============================================================
+-- reposicao_timeout_sync_inventory — sobe timeout_milliseconds 60000→150000
+-- nos 2 crons sync-inventory pesados (omie-analytics-sync), alinhando com os outros
+-- 23 crons que já usam 150000 (padrão da casa pós-incidente de 27/05).
+--
+-- Motivo: o omie-analytics-sync action sync_inventory das contas pesadas (vendas/oben,
+-- colacor_vendas) estoura o timeout de 60s e deixa o inventory_position defasado (cmc
+-- velho → NCG/otimizador/preço-de-pedido cmc-first). A conta leve (servicos, :25) completa.
+-- Diagnóstico: docs/superpowers/specs/2026-06-14-incidente-sync-inventory-timeout.md
+--
+-- ⚠️ EXPERIMENTO MEDÍVEL, não correção confirmada: só resolve se a edge terminar entre
+-- 60-150s. Se a edge tiver budget interno < 150s ou demorar mais, o fix real é paginar/
+-- waitUntil a edge (deploy via Lovable). Revalidar via: select account, min(updated_at)
+-- from inventory_position group by account; (vendas/colacor_vendas devem sair de 05-25/06-03).
+--
+-- cron.schedule faz upsert por nome → idempotente (re-rodar é seguro). Schedule e command
+-- idênticos aos atuais; SÓ o timeout_milliseconds muda (60000 → 150000).
+-- ============================================================
+
+SELECT cron.schedule(
+  'sync-inventory-vendas-30m',
+  '*/30 * * * *',
+  $cron$SELECT net.http_post(
+    url:='https://fzvklzpomgnyikkfkzai.supabase.co/functions/v1/omie-analytics-sync',
+    headers:=jsonb_build_object('Content-Type','application/json','x-cron-secret',(SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name='CRON_SECRET' LIMIT 1)),
+    body:='{"action": "sync_inventory", "account": "vendas"}'::jsonb,
+    timeout_milliseconds := 150000
+  );$cron$
+);
+
+SELECT cron.schedule(
+  'sync-inventory-colacor-vendas-1h',
+  '15 * * * *',
+  $cron$SELECT net.http_post(url:='https://fzvklzpomgnyikkfkzai.supabase.co/functions/v1/omie-analytics-sync',
+    headers:=jsonb_build_object('Content-Type','application/json','x-cron-secret',(SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name='CRON_SECRET' LIMIT 1)),
+    body:='{"action":"sync_inventory","account":"colacor_vendas"}'::jsonb, timeout_milliseconds:=150000);$cron$
+);


### PR DESCRIPTION
## ⚠️ ATENÇÃO: migration manual necessária

Re-agenda 2 crons (`cron.schedule`, upsert idempotente) subindo `timeout_milliseconds` de **60000→150000**. Mergear **não** aplica no banco — precisa colar no SQL Editor do Lovable.

**Motivo:** `omie-analytics-sync sync_inventory` das contas pesadas (`vendas`/oben, `colacor_vendas`) estoura os 60s e morre antes de terminar → `inventory_position` defasado (SKUs presos há 12-20 dias) → `cmc` velho alimenta NCG/otimizador/preço-de-pedido cmc-first. A conta leve (`servicos`, :25) completa. Diagnosticado via `diagnose-supabase-sync` + acesso read-only. Alinha com os **23 crons que já usam 150000**.

⚠️ **Experimento medível, NÃO correção confirmada** (Codex): só resolve se a edge terminar entre 60-150s. Se a edge tiver budget interno < 150s, o fix real é paginar/`waitUntil` a edge. **Eu revalido via `psql-ro`** após os crons rodarem (`select account, min(updated_at) from inventory_position` — `vendas`/`colacor_vendas` devem sair de 05-25/06-03).

Detalhe completo: `docs/superpowers/specs/2026-06-14-incidente-sync-inventory-timeout.md` (#838).

🤖 Generated with [Claude Code](https://claude.com/claude-code)