### PR TITLE
docs(agent): Fase A do refactor do CLAUDE.md (database/sync/money-path)

### DIFF
--- a/docs/agent/database.md
+++ b/docs/agent/database.md
@@ -1,0 +1,60 @@
+# Banco de dados — referência operacional (Afiação/Colacor)
+
+> Lições duráveis de banco. Carregado sob demanda (não fica no `CLAUDE.md`). Narrativa histórica de cada PR em `docs/historico/`. Para mudança de banco use a skill `lovable-db-operator`; para provar SQL money-path use `prove-sql-money-path`; para diagnosticar sync/cron use `diagnose-supabase-sync`.
+
+- **Project ref Supabase:** `fzvklzpomgnyikkfkzai` (região `eu-west-1`, pooler `aws-1`). Project URL: `https://fzvklzpomgnyikkfkzai.supabase.co`. NÃO confundir com `lkotrsfdvnwxqyevhffh` (projeto-teste vazio).
+
+## 1. Acesso ao banco
+
+### Leitura/diagnóstico — DIRETO via `psql-ro` (desde 2026-06-14)
+Há um usuário **read-only** no Postgres de produção (`claude_ro`) acessível por um wrapper local:
+
+```bash
+~/.config/afiacao/psql-ro -c "SELECT ..."     # blindado: SESSION READ ONLY + statement_timeout 30s
+```
+
+- **Eu rodo leitura/diagnóstico sozinho** — sem o founder colar no SQL Editor. Conferir migration aplicada, frescor de dado, audit, `pg_get_functiondef`, `net._http_response`, debugar incidente de sync.
+- **É read-only de verdade:** o wrapper força `SESSION READ ONLY` (via `psqlrc`), que barra escrita **até via RPC `SECURITY DEFINER`** (`cannot execute UPDATE in a read-only transaction`). A credencial vive em `~/.config/afiacao/` (perm 600, **fora do repo** — nunca commitada).
+- **`BYPASSRLS`:** o `claude_ro` lê todos os dados (inclusive sensíveis). É read-only, então zero risco de integridade. Desligar: `DROP ROLE claude_ro;` (founder decide). O pooler ignora `PGOPTIONS` — por isso o read-only vem via `psqlrc`, não startup param.
+- **Como foi montado:** o Lovable NÃO expõe a connection string, mas dá pra montar (ref + user `claude_ro.<ref>` + senha definida no `CREATE ROLE` + região do pooler **descoberta por brute-force**: `aws-1-eu-west-1`). A conexão direta `db.<ref>.supabase.co` NÃO existe (projetos novos só têm o pooler Supavisor).
+
+### Escrita — SOMENTE via SQL Editor do Lovable
+O founder NÃO tem terminal/psql/CLI **de escrita** pro backend. Toda DDL/DML/migration é colada no **SQL Editor do Lovable** → Run. Eu nunca aplico escrita; preparo o material (via `lovable-db-operator`) e o founder cola. Formatar blocos SQL: fenced ` ```sql `, terminando com ` ``` ` numa linha sozinha (o app renderiza o botão Copy), rótulo `🟣 Lovable → SQL Editor → cola → Run`.
+
+## 2. Migrations — Lovable NÃO auto-aplica (a armadilha-mãe)
+
+- **Lovable Cloud NÃO aplica migration de nome custom** (`YYYYMMDDHHMMSS_slug.sql`) commitada em `supabase/migrations/`. Mergear o PR deixa o código no repo, mas o **banco continua sem o objeto** — falha SILENCIOSA (a feature compila, referencia tabela inexistente, quebra em prod). Só migration de nome UUID (builder visual) roda sozinha.
+- **Toda migration custom exige:** (1) o `.sql` idempotente, (2) o bloco pro SQL Editor, (3) uma **query de validação** read-only pós-apply, (4) nota no PR "⚠️ migration manual", (5) `bun run audit:migrations` + commit dos artefatos. A skill `lovable-db-operator` empacota isso.
+- Auditoria de quais migrations estão aplicadas: `scripts/audit-custom-migrations.sql` (cola no SQL Editor) + `docs/migrations-audit.md` (regenera com `bun run audit:migrations`).
+- ⚠️ **Multi-sessão:** timestamps de migration colidem entre worktrees paralelas. É inócuo porque a aplicação é manual (não por ordem de timestamp), mas garanta que o seu ordena depois do último. **Quando 2 migrations recriam a MESMA função, a última a rodar vence** — garanta a ordem OU re-aplique a vencedora por último.
+
+## 3. Schema não-rebuildável + snapshot
+
+As migrations em `supabase/migrations/` **NÃO são uma cadeia restaurável** — ~210 objetos existem em prod sem `CREATE` commitado (módulos criados direto no Lovable; migrations seguintes só `ALTER`am tabelas-fantasma). Um `db reset` quebra.
+- **Fonte de DR/auditoria:** `supabase/schema-snapshot.sql` (`pg_dump` schema-only de prod, gerado pelo chat do Lovable). Ler `supabase/README-schema.md` antes de restaurar.
+- **Validação de restore:** `db/verify-snapshot-replay.sh` (Postgres 17 local + stubs) — prova ordem/dependência/sintaxe + RLS amostrado.
+- ⚠️ **NUNCA mexer em `supabase/migrations/`** (não mover snapshot pra lá, não arquivar) — a pasta é reconhecida pelo ecossistema Lovable.
+
+## 4. RLS (padrões)
+
+- Helpers: `pode_ver_carteira_completa(uid)` (master OU gestor comercial), `carteira_visivel_para(customer)` (carteira + cobertura). `service_role` bypassa (engines).
+- **Hardening de tabela exposta:** `FOR ALL` amplo (`master OR employee`) é BFLA — qualquer staff gerencia tudo via PostgREST. Padrão: split do `FOR ALL` → SELECT (gestor/master OR own OR carteira) + IUD (gestor/master OR own). Assimetria leitura>escrita: cobertura lê, não muta.
+- Tabela nova **sempre** sai com RLS (CLAUDE.md §11). Catálogo de policies no estilo do repo: `references/sql-house-style.md` da skill `lovable-db-operator`.
+
+## 5. Armadilhas caras (todas mordidas em prod)
+
+- **PostgREST quebra `.or()` em UPDATE/PATCH** com `42703` (`column does not exist`) **mesmo a coluna existindo** — o banco puro aceita, só a camada REST quebra; `NOTIFY pgrst reload` não resolve. Diagnóstico: `BEGIN;UPDATE;ROLLBACK` no SQL Editor distingue banco × PostgREST. Fix: **RPC SQL-pura com predicado POSITIVO explícito** (não a tradução do `.or()`).
+- **`.not(col,'ilike',v)` / qualquer negação é NULL-blind** — exclui silenciosamente linhas com a coluna NULL. Para negação tolerante a NULL: `.or('col.is.null,and(col.not.<op>.val,...)')` via função pura (não template no `.or()` cru — a regra ESLint `no-restricted-syntax` barra).
+- **`CREATE OR REPLACE VIEW` só ACRESCENTA coluna no fim** (não reordena) → `cannot change name of view column`. **Sempre `pg_get_viewdef` da prod antes** de um REPLACE de view e case a ordem exata.
+- **Função plpgsql com SQL inválido PASSA no `CREATE`** (late-bound) e só falha ao **EXECUTAR** — atrás de cron/`try-catch` best-effort, falha SILENCIOSA por dias. Prove com `prove-sql-money-path` (PG17 que EXECUTA a função, não só cria).
+- **`CREATE OR REPLACE` manual de função exige pré-flight `pg_get_functiondef`** da prod (o repo pode divergir de prod no apply manual — drift). Hoje dá pra fazer direto via `psql-ro`.
+- **`REVOKE ... FROM PUBLIC` NÃO tira `anon`/`authenticated` no Supabase** — eles têm grant EXPLÍCITO via default privileges. Revogar por nome (`REVOKE ... FROM anon, authenticated, PUBLIC`). Mas `service_role` recebe EXECUTE por default privileges (checar `has_function_privilege` antes de assumir bloqueio).
+- **Sinal money-path NUNCA em coluna jsonb compartilhada por múltiplos writers** — `upsert` é last-writer-wins **destrutivo** no jsonb (sobrescreve o objeto inteiro). Use **coluna dedicada** (cada writer só toca se incluir no payload) + 1 writer autoritativo. Diagnóstico: `metadata ? 'chave'` (operador de existência) distingue "writer omitiu" de "fonte mandou null".
+- **`inventory_position.account` tem 2 convenções:** `omie-analytics-sync` grava `vendas`/`colacor_vendas`/`servicos` (Omie account); `sync-reprocess` grava `oben`/`colacor` (empresa). Unique por `(omie_codigo_produto, account)` → somar por empresa exige eleger a canônica e excluir a crua (senão double-count).
+- **`omie_products.account` é convenção EMPRESA** (`oben`/`colacor`/`colacor_sc`), ≠ `inventory_position`. JOIN account-blind em RPC money-path duplica silenciosamente (sem UNIQUE no item).
+- **Vocabulário de status de título é NATIVO do Omie** (`'A VENCER'`/`'ATRASADO'`/`'VENCE HOJE'`), não `'ABERTO'`/`'VENCIDO'` — usar `OPEN_TITLE_STATUSES` de `src/lib/financeiro/titulo-status.ts`.
+- **`bun run <cmd> | tail` ENGOLE o exit code** (o pipe retorna o status do `tail`) → teste/typecheck que FALHA passa batido. Quando o exit importa: `> log 2>&1; echo $?`.
+
+## 6. Edge functions — deploy via chat do Lovable
+
+Edge functions são criadas/editadas pelo **chat do Lovable** (não pela UI Cloud, que é só logs). Para função grande/edit: instruir o chat a ler `supabase/functions/<nome>/index.ts` do repo e deployar **verbatim** (o Lovable tende a "melhorar" — proibir). Deploy SÓ depois do merge (senão lê a main velha). Verificar por comportamento, não pela palavra do Lovable.

--- a/docs/agent/money-path.md
+++ b/docs/agent/money-path.md
@@ -1,0 +1,28 @@
+# Money-path — princípios inegociáveis
+
+> Tudo que mexe com dinheiro (financeiro, reposição/compras, pedido a fornecedor, preço, estoque, positivação/comissão), autorização (RLS/gate) ou automação (sync) segue isto. Detalhe por domínio em `docs/agent/{financeiro,reposicao}.md`.
+
+## Os princípios
+
+1. **Precisão > recall.** Na ambiguidade, NÃO agir / NÃO mostrar — melhor uma ficha a menos que uma errada. Ex.: matching boletim↔SKU só com confirmação humana; a venda mostra ficha só pela view confirmada+aprovada, zero fuzzy em runtime.
+2. **Degradação honesta — ausente ≠ zero.** `Number(null)` é `0`; `cmc` ausente vira `null`, não R$0; NCG/hurdle/capital ausente → `null` + confiança baixa, **nunca** um número fabricado. O usuário vê "—" ou "falta dado", jamais uma recomendação inventada. (Frente inteira de consolidação financeira foi sobre isto: NCG/A2, hurdle/A3, caixa do snapshot.)
+3. **Nunca fabricar número no money-path.** LLM não inventa SKU/preço (pricing determinístico do Omie). A IA conversa/sugere; o número firme passa por gate determinístico/humano. Prosa do LLM é descartável; a evidência é o produto.
+4. **Gate humano na escrita.** O founder no loop pra escrita money-path (migration via SQL Editor; aprovação de compra). Exceção atual: a auto-aprovação Sayerlack (N3, piloto medido por taxa de veto — ver `docs/agent/reposicao.md`).
+
+## Provar antes de aplicar
+
+- **Função/RPC/trigger/policy money-path → `prove-sql-money-path`** (PG17 local com falsificação) ANTES de entregar a migration. plpgsql é late-bound: `CREATE` passa com SQL inválido, só falha ao EXECUTAR. O teste aplica a migração REAL, semeia, faz asserts positivos E negativos (SQLSTATE + re-raise), prova RLS (`SET ROLE` + GUC), e **se sabota de propósito pra provar que os asserts têm dente**.
+- **Assert negativo** captura a `SQLSTATE`/condição ESPERADA e re-lança o resto. `WHEN OTHERS THEN 'OK'` é teatro (engole o erro real). Sentinela do teste nunca contém o texto que o código emite (anti-teatro de ILIKE).
+
+## Segunda opinião adversária (Codex)
+
+- Rodar Codex em cada etapa de trabalho money-path: **metodologia → spec → plano → adversarial no código**. `/codex` (consult/challenge). Modelo `gpt-5.5`, reasoning `high` (consult rotineiro) ou `xhigh` explícito (adversarial money-path).
+- ⚠️ A cota do Codex (ChatGPT Plus) é **janela rolante de 7 dias e ESGOTA**. Fallback = **"Caminho B"**: validação adversária própria (PG17 falsificável + auto-challenge), gravando **`REVISÃO INDEPENDENTE PENDENTE`** — auto-revisão NÃO substitui revisão independente, só cobre o intervalo. Rodar o Codex retroativo quando a cota voltar.
+
+## Helper espelhado
+
+Helper TS puro (testado com vitest) **espelhado verbatim** no edge (Deno não importa de `src/`) e/ou em SQL. Para lógica replicada, **provar paridade** (harness diferencial TS×SQL, ex.: `db/test-city-norm-paridade.sh`) — não institucionalizar "copiar verbatim" como fim.
+
+## Diagnóstico
+
+"Diagnosticado ≠ corrigido" — ver `diagnose-supabase-sync` (estados rígidos de saída; só declara RECUPERADO com novo ciclo + efeito no dado; a ação corretiva é entregue ao humano, nunca aplicada às cegas).

--- a/docs/agent/sync.md
+++ b/docs/agent/sync.md
@@ -1,0 +1,39 @@
+# Sync / cron / Sentinela — referência operacional
+
+> Lições de design e armadilhas de cron/sync. Para **diagnosticar** um incidente, use a skill `diagnose-supabase-sync` (árvore de 8 passos + queries prontas pro `psql-ro`). Histórico de incidentes em `docs/historico/sync.md`.
+
+## A verdade está em `net._http_response`, não no `job_run_details`
+
+`cron.job_run_details` reporta `succeeded` **mesmo quando a edge respondeu 401/503 ou nem bootou** — ele só registra que o `net.http_post` foi **enfileirado**. A verdade HTTP está em **`net._http_response`** (`status_code`/`content`/`error_msg`/`timed_out`), cruzada com `fin_sync_log` (iniciou/completou/órfã) e o **efeito no dado**. `status_code IS NULL` é mudo — sempre trazer `error_msg`/`timed_out` junto.
+
+## Padrão de cron (canônico)
+
+- Auth: header `x-cron-secret` = `(SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name='CRON_SECRET' LIMIT 1)`. O secret já está no Vault.
+- `cron.schedule(nome, schedule, comando)` faz **upsert por nome** → idempotente.
+- **Todo cron `net.http_post` PRECISA de `timeout_milliseconds` explícito** — o default do `pg_net` é **5s** e mata SILENCIOSAMENTE qualquer função >5s (o `job_run_details` ainda diz "succeeded"). Teto padrão da casa: **150000** (150s).
+- **Crons devem ser versionados em migration** — um cron que vive só no banco some sem rastro (já aconteceu: vendas ficou 8 dias morto porque o cron nunca foi versionado).
+
+## Assinaturas de incidente (sintoma → causa → ação)
+
+- **401 em muitas edges** → `CRON_SECRET` do Vault divergiu da env das edges → realinhar (Vault + edges no Lovable). ⚠️ `401` **isolado** (1 edge) pode ser `verify_jwt`/header/gate da própria edge, não secret.
+- **`503 LOAD_FUNCTION_ERROR` + zero `running` no `fin_sync_log`** (1 edge) → a edge não BOOTA (pré-handler) → **redeploy verbatim** (não é código; o watchdog vê o efeito mas é cego pra causa de boot).
+- **`546`/timeout 60s + zero `running` em VÁRIAS edges** → incidente de **plataforma** Supabase → esperar estabilizar, NÃO martelar redeploy.
+- **`2xx` + órfã `running` antiga** → kill/`catch` não chamou `completeSync` (ou kill não passa pelo catch). É o sinal CONFIÁVEL de morte (≠ staleness por tempo).
+- **`2xx` + `complete` + efeito ausente** → sucesso técnico falso / bug semântico → investigar a lógica (`prove-sql-money-path`).
+- **cursor `fin_sync_cursor.next_page` parado >2h** → continuação travada.
+
+## Princípios de diagnóstico
+
+- **Vigie o EFEITO no dado, não o status técnico.** `complete` ocorre em **rajadas** (idle saudável parece "parado" — staleness por tempo-desde-complete é NÃO-confiável). `sales_orders.created_at` é a **data do pedido no Omie** (pode ser futura), NÃO frescor → usar `fin_sync_log` action `sync_pedidos`.
+- **A tripla que desambigua em segundos:** edge irmã OK (200) + zero-401 + zero-`running` ⇒ a edge-alvo não boota.
+- **Ausência ≠ falha.** Cron não-devido, fim de semana, resposta expurgada, par dormente — calcule a **última execução esperada** (com `now()` do BANCO, não relógio local) antes de gritar.
+- ⚠️ A correlação `net._http_response × cron.job_run_details` por tempo é **cara** (a `job_run_details` é grande e sem índice em `start_time`) — preferir correlação por schedule + config + efeito. Considerar um índice em `job_run_details(start_time)` se virar rotina.
+
+## Sentinela (vigia ativo)
+
+- `data_health_watchdog` (cron `*/30`, SQL local) + `fin_sync_watchdog_check` (`*/30`) + `fin_sync_heartbeat` (dead-man-switch) computam saúde e fazem **push** na transição ok→degradado (grava `fin_alertas` + enfileira `fornecedor_alerta` → `dispatch-notifications`). Fonte única: `_data_health_compute()`.
+- ⚠️ `_data_health_compute` é arquivo QUENTE multi-sessão. Ao recriá-lo, **parta da migration de MAIOR timestamp** (nunca de um corpo antigo) e **recrie `data_health_watchdog` + `fin_sync_heartbeat` JUNTO** (os IN-lists referenciam os `source` names; mudar o conjunto de checks sem atualizar os dois desincroniza o push). Pré-flight `pg_get_functiondef` é obrigatório — prod pode ter checks que o repo não tem (drift).
+
+## Incidente em aberto (2026-06-14)
+
+`omie-analytics-sync sync_inventory` das contas pesadas estoura 60s → `inventory_position` defasado (cmc velho). Mitigação aplicada (timeout 60→150s); medição do efeito pendente. Detalhe: `docs/historico/sync.md` + `docs/superpowers/specs/2026-06-14-incidente-sync-inventory-timeout.md`.

--- a/docs/historico/README.md
+++ b/docs/historico/README.md
@@ -1,0 +1,10 @@
+# docs/historico — diário de PR (movido do CLAUDE.md)
+
+Aqui vive a **narrativa íntegra dos PRs** (problema → diagnóstico → fix → lição), movida das §5/§10 do `CLAUDE.md` no refactor da frente 1 (decisão do founder 2026-06-14: **mover íntegro, zero descarte**).
+
+- **Lições duráveis reutilizáveis** ficam em `docs/agent/<dominio>.md` (carregadas sob demanda).
+- **A narrativa histórica completa** fica aqui, por domínio (`financeiro.md`, `reposicao.md`, `sync.md`, `kb.md`, `radar.md`, `vendas.md`, `ux.md`, …) — fora do contexto automático de toda sessão.
+
+Plano completo: `docs/superpowers/plans/2026-06-14-refactor-claude-md.md`.
+
+> Status: **Fase A em andamento.** Os `docs/agent/*` dos domínios trabalhados em 2026-06-14 (database, sync, money-path) já existem. O restante (financeiro, reposicao, impersonation, knowledge-base, deploy) + o **movimento do diário pra cá** + a **Fase B** (esvaziar o `CLAUDE.md` + CI de budget) ficam pra uma **sessão dedicada de contexto limpo** (o refactor exige precisão pra não perder lição).


### PR DESCRIPTION
Início da **Fase A** (aditiva, zero conflito) do refactor do `CLAUDE.md` — plano em `docs/superpowers/plans/2026-06-14-refactor-claude-md.md`. Só docs novos; não toca o `CLAUDE.md` (isso é a Fase B).

Extrai as **lições duráveis** dos 3 domínios trabalhados na sessão de hoje pra `docs/agent/` (carregado sob demanda, não infla o contexto de toda sessão):
- **`database.md`** — ritual Lovable migration, acesso read-only (`claude_ro`/`psql-ro`), drift/snapshot, RLS, e as armadilhas caras (PostgREST `.or()` em UPDATE, view coluna-no-fim, plpgsql late-bound, REVOKE/anon, jsonb compartilhado).
- **`sync.md`** — `job_run_details` mente, `timeout_milliseconds` obrigatório, assinaturas de incidente, Sentinela.
- **`money-path.md`** — precisão>recall, degradação honesta, `prove-sql-money-path`, Codex/Caminho B.

`docs/historico/README.md` marca o destino do diário de PR (movido íntegro na sessão dedicada).

**Restante** (financeiro/reposicao/impersonation/kb/deploy + mover o diário + **Fase B**: esvaziar o `CLAUDE.md` + CI de budget) fica pra **sessão dedicada de contexto limpo** — o refactor exige precisão pra não perder lição, e a Fase B toca o arquivo mais quente do repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)