### PR TITLE
docs(agent): Fase A do refactor do CLAUDE.md — 5 docs/agent faltantes

### DIFF
--- a/docs/agent/database.md
+++ b/docs/agent/database.md
@@ -40,6 +40,7 @@ As migrations em `supabase/migrations/` **NÃO são uma cadeia restaurável** �
 - Helpers: `pode_ver_carteira_completa(uid)` (master OU gestor comercial), `carteira_visivel_para(customer)` (carteira + cobertura). `service_role` bypassa (engines).
 - **Hardening de tabela exposta:** `FOR ALL` amplo (`master OR employee`) é BFLA — qualquer staff gerencia tudo via PostgREST. Padrão: split do `FOR ALL` → SELECT (gestor/master OR own OR carteira) + IUD (gestor/master OR own). Assimetria leitura>escrita: cobertura lê, não muta.
 - Tabela nova **sempre** sai com RLS (CLAUDE.md §11). Catálogo de policies no estilo do repo: `references/sql-house-style.md` da skill `lovable-db-operator`.
+- **Trigger de auto-atribuição de role é superfície de privilege-escalation.** O `auto_assign_user_role` (AFTER INSERT em `profiles`) concedia **master** quando o `document` batia com o CNPJ da empresa — que é **público** — e a policy `"Users can insert own profile"` deixa qualquer autenticado se auto-inserir → **criar conta + saber o CNPJ = virar master** (achado do Codex retroativo, 2026-06-13, fora do escopo do KB onde apareceu). Fix: removido o ramo master do trigger; **master virou provisionamento MANUAL** (`INSERT INTO user_roles(user_id,role) VALUES(<uid>,'master')`). Lição: validação contra dado público é guardrail de **INTEGRIDADE**, não barreira adversarial — a barreira real é o gate explícito; CNPJ/dado público nunca é segredo de autorização.
 
 ## 5. Armadilhas caras (todas mordidas em prod)
 

--- a/docs/agent/deploy.md
+++ b/docs/agent/deploy.md
@@ -1,0 +1,20 @@
+# Deploy no Lovable — 3 camadas manuais (referência operacional)
+
+> O que NÃO acontece sozinho no merge. Lição durável carregada sob demanda. Runbook passo-a-passo completo: `docs/runbooks/lovable-supabase.md`. Banco/migration: `docs/agent/database.md`. Verificação: skill `lovable-deploy-verify`.
+
+## Merge na `main` ≠ produção — 3 deploys MANUAIS e independentes
+
+1. **Migration** → colar o SQL no **SQL Editor do Lovable** → Run → validar com query de contagem. O Lovable **NÃO** aplica migration de nome custom sozinho (falha SILENCIOSA: a feature compila e quebra em runtime). Detalhe + ritual + skill `lovable-db-operator`: `docs/agent/database.md`.
+2. **Frontend** → **Publish** manual no editor do Lovable. `steu.lovable.app` serve o **build velho** até o Publish (lição 2026-05-31: mergear e achar que foi pro ar é o erro recorrente).
+3. **Edge functions** → criadas/editadas pelo **chat do Lovable** (ele lê `supabase/functions/<nome>/index.ts` do repo e deploya **verbatim**), **NÃO** pela UI Cloud (que só mostra logs).
+
+## Edge — armadilhas
+
+- **Deploy SÓ depois do merge** — o chat lê a `main`; deployar antes pega o código velho.
+- **Proibir "melhorias"** — instrua o chat a deployar **verbatim** o arquivo do repo (o Lovable tende a reescrever a função).
+- **Verificar por comportamento/bytes, não pela palavra do Lovable** — `503 LOAD_FUNCTION_ERROR` + zero `running` no log = a edge não BOOTA → fix é **redeploy**, não código (ver `docs/agent/sync.md`).
+
+## Verificação de deploy
+
+- A skill **`lovable-deploy-verify`** confere se o bundle servido bate com o esperado (bytes/comportamento). Use após Publish/deploy — não confiar cegamente no "deployed" do Lovable.
+- O acesso **read-only** ao banco (`psql-ro`, ver `docs/agent/database.md`) confirma migration aplicada sem depender do founder.

--- a/docs/agent/financeiro.md
+++ b/docs/agent/financeiro.md
@@ -1,0 +1,25 @@
+# Financeiro — referência operacional (engines, money-path)
+
+> Lições do módulo financeiro (CFO mode). Princípios money-path em `docs/agent/money-path.md`. Classificação de confiabilidade + regras de ouro por onda: `docs/FINANCEIRO_CONFIABILIDADE.md`. Specs: `docs/superpowers/specs/2026-05-*financeiro*`. Diário em `docs/historico/bugs-resolvidos.md`.
+
+## Regra-mãe (vale para TODA engine financeira)
+
+- **Direcional ≠ verdade contábil.** As engines melhoram a DECISÃO de alocação de capital; não substituem balanço/valuation/conciliação fiscal. Caveat fixo na UI.
+- **Nunca fabrica número.** Input ausente = `null` + **motivo/confiança**, jamais valor inventado (`Number(null)===0` é fabricação — ver money-path). Guards explícitos: NCG indisponível **≠ R$0** (A2); hurdle indisponível **≠ "20%" fabricado** (A3).
+- **Recomenda, não executa/declara.** O dono decide (trocar regime exige contador + substância econômica; só cresce depois de consertar preço/prazo). Economia < banda de erro → status `empate_tecnico`.
+- **Caixa por-CNPJ, NÃO-fungível** — o caixa de uma empresa nunca cobre o gap de outra (sem mútuo intercompany implícito). Engines escopam por `omie_products.account`/empresa.
+- **CET, não taxa nominal** (dívida/funding: o input já é all-in — TAC/tarifas/seguro/reciprocidade); **coobrigação é campo obrigatório**.
+
+## Engines (mapa)
+
+- **A1** Inteligência de Caixa (projeção 13 semanas, CFO mode). **A2** Retorno & Valor (ROIC/WACC/EVA). **A3** Cockpit de Valor (cliente/produto, escopo Oben). **A4** Próxima Melhor Ação (compõe A1/A2/A3 via `service_role`).
+- **DRE** regime-aware (Onda 3a) + **imposto teórico de conferência** (Onda 3b — plausibilidade, não verdade fiscal; o realizado do Omie continua sendo o número).
+- **Otimizador Tributário** (Simples×Presumido×Real, master-only). **Otimizador de Compras** (net-R$ marginal — helper TS puro + view `v_otimizador_compras_insumos` que só junta fatos, **SEM edge** porque é dado operacional client-readable com RLS de staff). **Funding** (custo marginal de antecipação + planejador de gap, master-only).
+- **Padrão de arquitetura:** **helper TS puro (vitest) espelhado no edge** (Deno não importa de `src/`); engines `fin-*` master-only (algumas gestor+master); tabelas `fin_*` com RLS; `service_role` Bearer para composição interna entre engines.
+
+## Data de baixa / liquidação (DSO/DPO) — a armadilha-raiz
+
+- ⚠️ **`fin_contas_receber.data_recebimento` / `fin_contas_pagar.data_pagamento` (a data de baixa REAL) são SEMPRE NULL** — o endpoint LIST do Omie (`ListarContasReceber/Pagar`) **não retorna a baixa** (só emissão/previsão/registro/vencimento). Não é bug de mapeamento; o dado não vem nessa rota.
+- A baixa real vem da rota **`ListarMovimentos`** → derivada na tabela lateral **`fin_titulo_baixas`** (`data_baixa_final`, `prazo_ponderado_dias`, `confianca`), recalculável de `fin_movimentacoes`.
+- **Cascata:** 5 engines caem no **fallback de vencimento** quando a baixa é NULL — DRE-caixa marca **"estimado"** (degradação honesta, não erro silencioso). PMR/PMP (≈ DSO/DPO) só da baixa derivada **com flag de confiança**; senão degrada. Spec: `docs/superpowers/specs/2026-05-27-omie-baixa-date-root-fix-design.md`.
+- Vocabulário de status de título é **nativo do Omie** — usar `OPEN_TITLE_STATUSES` de `src/lib/financeiro/titulo-status.ts` (ver `docs/agent/database.md`).

--- a/docs/agent/impersonation.md
+++ b/docs/agent/impersonation.md
@@ -1,0 +1,22 @@
+# Lente "Ver como pessoa" — impersonação (referência operacional)
+
+> Como a lente separa LEITURA de ESCRITA/identidade. Lição durável carregada sob demanda. Specs: `docs/superpowers/specs/2026-05-25-ver-como-persona-impersonacao-design.md` + `2026-06-05-lente-ver-como-pessoa-*` + `2026-06-06-lente-fase-*`. Diário em `docs/historico/bugs-resolvidos.md`.
+
+## O princípio (a regra-mãe)
+
+- A lente deixa um **master "ver o app como" outra pessoa** (vendedor, gestor) para suporte/QA. É **leitura aumentada**, NUNCA troca de identidade.
+- **`useAuth()` é SEMPRE o usuário REAL** — sessão, escrita, identidade e RLS são do master logado. Só **LEITURA** usa `effectiveUserId` / `display*` (`displayIsStaff`, `useDisplayAccess`).
+- **Nunca decidir escrita ou identidade com `display*`.** Quem grava/autoriza é o `useAuth()` real. Decidir mutação com `display*` = vazamento (gravar como a persona impersonada, ou a persona enxergar escrita que não é dela).
+
+## Write-guard + furos (a armadilha cara)
+
+- O **write-guard** do client bloqueia mutação Supabase enquanto a lente está ativa (`isImpersonating` / `isLensActive()`).
+- ⚠️ **Todo caminho que escapa do Supabase client fura o write-guard** e precisa gatear a lente **NA FONTE**:
+  - **WebRTC** (a ligação não passa pelo Supabase) → `WebRTCCallContext.makeCall`/`acceptIncoming` guardam com `isLensActive()` na própria fonte.
+  - mesma regra para `fetch` direto / edge invocada client-side / qualquer side-effect externo.
+- UI mutante sob a lente fica **`disabled`** (ex.: painel de vínculo KB master-only → `disabled` quando `isImpersonating`), mas `disabled` é **cosmético**: a fronteira REAL é o gate no banco/fonte (RPC master-only, RLS), nunca a UI.
+
+## UI lente-aware (topbar)
+
+- `ActiveOverrideBadge` sinaliza a lente ativa.
+- `DataHealthBadge` e `NetworkStatusIndicator` (Tipo/RTT) usam `displayIsStaff`/`useDisplayAccess` → respeitam a persona vista (ex.: "ver como" vendedora sales-only esconde o que ela não veria, senão a lente vaza acesso que a persona real não tem).

--- a/docs/agent/knowledge-base.md
+++ b/docs/agent/knowledge-base.md
@@ -1,0 +1,30 @@
+# Base de Conhecimento (KB) — boletins↔SKU (referência operacional, money-path)
+
+> Programa que faz a IA conhecer os boletins técnicos (rendimento/catalisador/demãos/validade) e sugerir produto na venda/copilot. Princípios em `docs/agent/money-path.md`. Specs: `docs/superpowers/specs/2026-06-1*-kb-*`. Diário em `docs/historico/bugs-resolvidos.md`.
+
+## Casamento boletim↔SKU (a chave)
+
+- **O boletim traz o código-BASE da fórmula** (`FO20.6827.00`); **o item de venda é a EMBALAGEM com sufixo colado** (`FO20.6827.00GL`, `WFOT.6529QT`). Casa **base↔base** (1 boletim → N embalagens) via `src/lib/knowledge-base/code-normalize.ts` (reusa `extrairCodigosSayerlack`/`sufixoSayerlack` de `sayerlack-sku.ts`). De quebra blinda contra casar o catalisador (citado sem embalagem).
+- O código vive na **DESCRIÇÃO** do SKU Omie, não no `codigo`.
+
+## Money-path: precisão > recall
+
+- **Ambiguidade ⇒ NENHUMA ficha.** Regex/IA só **SUGEREM**; humano **confirma** (master-gated). A venda mostra ficha SÓ pela **view `v_omie_product_current_spec`** (`security_invoker`, **dupla-trava `confirmed` + `approved_at`**) — **zero matching fuzzy em runtime**, nunca reconstrói.
+- ⚠️ **A venda lê a VIEW, NUNCA o hook singular `useKbProductSpecs`** (admin-only — ler o hook na venda fura a dupla-trava). Guardrail por doc-comment no hook.
+
+## Escrita = master-only (a fronteira é a RPC, não a UI)
+
+- Aprovação de spec é **master-only no banco** (RLS INSERT/UPDATE master; `REVOKE INSERT/UPDATE/DELETE FROM authenticated` — só RPC `SECURITY DEFINER` escreve). O `disabled` da UI é cosmético.
+- RPCs: `confirmar_vinculo_boletim` (valida `(account, omie_codigo_produto)` EXISTS em `omie_products` → mata vínculo-fantasma), `desvincular_boletim` (expected-id anti-stale-delete), **`aprovar_versao_boletim`** (único caminho de escrita de spec).
+
+## Versionamento (append-only)
+
+- **`kb_product_spec_versions`** append-only, imutável por trigger **`kbv_block_mutation`** (`BEFORE UPDATE OR DELETE`; só `superseded_at` pode mudar). Índice parcial `kbv_uma_viva` (1 versão viva por produto). Re-aprovar boletim novo do mesmo produto = **nova versão**, não sobrescreve (a Sayerlack muda boletins → não perder conhecimento, ex.: catalisador removido).
+
+## Extração paga (anti-re-pagamento)
+
+- A edge `kb-extract-specs` extrai ~40 campos via Claude (**custa $**). Persistência em **`kb_extraction_drafts`** (⚠️ coluna **`spec` SINGULAR** — a edge responde `specs` plural; NÃO confundir, já mordeu).
+- **Claim atômico** (RPC `kb_extraction_draft_claim`) ANTES da chamada paga = **anti-duplo-pagamento**: o `UPSERT` resolve a corrida de LINHA, **não** a de CUSTO (2 abas/duplo-clique pagariam 2×). **Cache-first**: draft `ready` + não-force → devolve o salvo, **sem chamar o Claude**.
+- Gate **master-only** (`authorizeMaster`, não `authorizeCronOrStaff` — que deixava qualquer staff disparar custo). A RPC de claim é INVOKER + `REVOKE` de anon/authenticated (só `service_role`).
+
+> ⚠️ Lição app-wide nascida do Codex retroativo neste programa (privilege escalation via trigger de role) está em `docs/agent/database.md` §4.

--- a/docs/agent/reposicao.md
+++ b/docs/agent/reposicao.md
@@ -1,0 +1,31 @@
+# Reposição / Compras — referência operacional (money-path)
+
+> Motor de pedidos sugeridos + portal Sayerlack. Princípios em `docs/agent/money-path.md`. Specs: `docs/superpowers/specs/2026-0*-reposicao-*` e `*sayerlack*`. Diário em `docs/historico/bugs-resolvidos.md`.
+
+## Motor de pedidos de compra
+
+- RPC **`gerar_pedidos_sugeridos_ciclo`** gera as sugestões do ciclo. **JOIN `omie_products` account-aware** — `omie_products.account` é convenção EMPRESA (`oben`/`colacor`/`colacor_sc`); JOIN account-blind **duplica silenciosamente** (sem UNIQUE no item) — ver `docs/agent/database.md`.
+- **Ciclo INTRA-DAY**: o motor roda a cada **2h** (não só 1×/dia) + alerta R$3k Sayerlack + gate de mínimo de compra.
+- **`aplicar_promocoes_no_ciclo`** é função QUENTE/money-path — já quebrou em prod (parse error, falha silenciosa atrás de chamador) e sofreu **colisão multi-sessão** (PR duplicado). Pré-flight `pg_get_functiondef` da prod + cuidado com ordem de migrations (a última a recriar vence — ver `docs/agent/database.md`).
+- Tela de pedidos do ciclo: **idempotente** + tela única (Reposição/Oben), botões à prova de erro.
+
+## cmc-first (base de custo)
+
+- **`cmc` (Custo Médio Contábil do Omie)** é a base de custo **de ponta a ponta**, inclusive na primeira compra. cmc ausente → `null`, **nunca** R$0 (money-path: ausente ≠ zero).
+- ⚠️ Após corrigir a FONTE do cmc, **os snapshots derivados NÃO se regeneram sozinhos** — re-invocar o recompute.
+
+## Mínimo forçado + auto-aprovação
+
+- **Mínimo de compra forçado por SKU** (a "R") — override por SKU que força a quantidade mínima do pedido (ponto de extensão `minimo_forcado_manual` no otimizador de compras).
+- **N3 — auto-aprovação Sayerlack** (piloto): a ÚNICA exceção ao gate humano de escrita money-path, **medida por taxa de veto** (ver `docs/agent/money-path.md`). "Aprovar = disparar na hora".
+
+## Portal Sayerlack (scraping / pedido)
+
+- **Claim atômico em SQL-puro** — o PostgREST quebra `.or()` em UPDATE (`42703`, mesmo a coluna existindo) → claim via **RPC com predicado POSITIVO**, não a tradução do `.or()` (ver `docs/agent/database.md`). Ciclo de retry do portal fechado.
+- **De-para Sayerlack:** parser `sayerlack-sku` v2 lê o código com **separador-ESPAÇO**; **`tipo_produto` virou COLUNA dedicada** de `omie_products`, alimentada por **`tipoItem` no lote** do Omie (NÃO de outra rota); tingidores desenvolvidos internamente ficam fora do motor (backfill).
+- **`em_transito` conta portal-confirmado**; on-order tem **fonte única** (não somar duplicado).
+
+## Outras frentes
+
+- **Reativar SKU descontinuado** (filtro na Revisão) · **Painel de baixo giro** · **Cold-start** (primeira compra sem histórico).
+- Os **god-components da Reposição** foram quebrados (<1000 LoC) — ao mexer, usar `vercel-composition-patterns` + `vercel-react-best-practices`.

--- a/docs/agent/sync.md
+++ b/docs/agent/sync.md
@@ -1,6 +1,6 @@
 # Sync / cron / Sentinela — referência operacional
 
-> Lições de design e armadilhas de cron/sync. Para **diagnosticar** um incidente, use a skill `diagnose-supabase-sync` (árvore de 8 passos + queries prontas pro `psql-ro`). Histórico de incidentes em `docs/historico/sync.md`.
+> Lições de design e armadilhas de cron/sync. Para **diagnosticar** um incidente, use a skill `diagnose-supabase-sync` (árvore de 8 passos + queries prontas pro `psql-ro`). Histórico de incidentes em `docs/historico/bugs-resolvidos.md` (bullets de sync) + os specs de incidente.
 
 ## A verdade está em `net._http_response`, não no `job_run_details`
 
@@ -36,4 +36,4 @@
 
 ## Incidente em aberto (2026-06-14)
 
-`omie-analytics-sync sync_inventory` das contas pesadas estoura 60s → `inventory_position` defasado (cmc velho). Mitigação aplicada (timeout 60→150s); medição do efeito pendente. Detalhe: `docs/historico/sync.md` + `docs/superpowers/specs/2026-06-14-incidente-sync-inventory-timeout.md`.
+`omie-analytics-sync sync_inventory` das contas pesadas estoura 60s → `inventory_position` defasado (cmc velho). Mitigação aplicada (timeout 60→150s); medição do efeito pendente. Detalhe: `docs/superpowers/specs/2026-06-14-incidente-sync-inventory-timeout.md` + diário em `docs/historico/bugs-resolvidos.md`.


### PR DESCRIPTION
## Frente 1 — refactor do CLAUDE.md (Fase A, aditiva)

O CLAUDE.md (~68 KB / 8,7k palavras) é carregado em **toda sessão + subagente** → subagentes nascem perto do limite e **thrashar de contexto** (registrado em #819). Esta frente o enxuga, movendo lição durável → `docs/agent/*` e diário → `docs/historico/*`, **zero descarte** (decisão do founder). Plano: `docs/superpowers/plans/2026-06-14-refactor-claude-md.md`.

### O que este PR faz (Fase A — só adiciona, não toca o arquivo quente)
Cria os **5 `docs/agent/*` faltantes** (os 3 primeiros — database/sync/money-path — vieram no #840):

| doc | lições destiladas |
|---|---|
| `financeiro.md` | direcional≠verdade contábil · ausente≠R$0 · recomenda≠executa · caixa por-CNPJ · engines A1–A4/DRE/otimizadores/funding · **cascata da data de baixa NULL** (DSO/DPO via `fin_titulo_baixas`) |
| `reposicao.md` | motor `gerar_pedidos_sugeridos_ciclo` account-aware · **cmc-first** · mínimo forçado/auto-aprovação N3 · portal Sayerlack (claim SQL-puro, de-para `tipoItem`) |
| `impersonation.md` | lente "Ver como" (`useAuth` real vs `display*`) · write-guard · **WebRTC fura o guard → gatear na fonte** · no-write-leak |
| `knowledge-base.md` | casamento boletim↔SKU base↔base · precisão>recall (view dupla-trava) · escrita master-only · versionamento append-only · claim anti-duplo-pagamento |
| `deploy.md` | 3 camadas Lovable (Publish/edge-chat/migration) · verificação por bytes |

Também: **+ lição app-wide** no `database.md` §4 (privilege-escalation via trigger `auto_assign_user_role` + CNPJ público, achado do Codex retroativo); refs do `sync.md` ajustadas pro diário consolidado.

### Não toca
- ❌ CLAUDE.md · ❌ `docs/registro/` · ❌ código · ❌ migrations

A **Fase B** (enxugar o CLAUDE.md + consolidar `registro→historico` + `check-claude-md-budget.sh` no CI) vem num PR cirúrgico em seguida — mantém a remoção/reescrita concentrada e o arquivo quente sempre com links válidos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)