### PR TITLE
perf(sync): syncInventory N+1 → upsert em lote — destrava disk IO

### DIFF
--- a/supabase/functions/omie-analytics-sync/index.ts
+++ b/supabase/functions/omie-analytics-sync/index.ts
@@ -694,13 +694,24 @@ async function syncOrdersIncremental(db: SupabaseClient, account: OmieAccount) {
 
 // ======== SYNC INVENTORY ========
 
+// Divide um array em lotes de tamanho fixo (para upsert/insert/IN em massa).
+function chunked<T>(arr: T[], size: number): T[][] {
+  const out: T[][] = [];
+  for (let i = 0; i < arr.length; i += size) out.push(arr.slice(i, i + size));
+  return out;
+}
+
 async function syncInventory(db: SupabaseClient, account: OmieAccount) {
   await updateSyncState(db, "inventory", account, { status: "running", error_message: null });
   let pagina = 1;
   let totalPaginas = 1;
-  let totalSynced = 0;
+  const nowIso = new Date().toISOString();
 
   try {
+    // 1) COLETA todas as páginas do Omie em memória (dedupe last-wins por código).
+    //    Antes: ~4 writes PostgREST POR produto (N+1) → ~3M statements e saturava o disk IO.
+    //    Agora: acumula e escreve em LOTE (upsert chunked), o padrão que o resto deste arquivo já usa.
+    const posicoes = new Map<number, { saldo: number; cmc: number; precoMedio: number }>();
     while (pagina <= totalPaginas) {
       const result = (await callOmie(account, "estoque/consulta/", "ListarPosEstoque", {
         nPagina: pagina,
@@ -714,70 +725,118 @@ async function syncInventory(db: SupabaseClient, account: OmieAccount) {
       for (const prod of produtos) {
         const codProd = prod.nCodProd;
         if (!codProd) continue;
-
-        const saldo = prod.nSaldo ?? 0;
-        const cmc = prod.nCMC ?? 0;
-        const precoMedio = prod.nPrecoMedio ?? 0;
-
-        // Find product_id
-        const { data: product } = await db
-          .from("omie_products")
-          .select("id")
-          .eq("omie_codigo_produto", codProd)
-          .maybeSingle();
-
-        // Upsert inventory_position
-        await db.from("inventory_position").upsert({
-          omie_codigo_produto: codProd,
-          product_id: product?.id || null,
-          saldo,
-          cmc,
-          preco_medio: precoMedio,
-          account,
-          synced_at: new Date().toISOString(),
-        }, { onConflict: "omie_codigo_produto,account" });
-
-        // Update omie_products stock
-        if (product?.id) {
-          await db.from("omie_products")
-            .update({ estoque: saldo, updated_at: new Date().toISOString() })
-            .eq("id", product.id);
-        }
-
-        // Update product_costs with CMC if available
-        if (product?.id && cmc > 0) {
-          const { data: existingCost } = await db
-            .from("product_costs")
-            .select("id, cost_price")
-            .eq("product_id", product.id)
-            .maybeSingle();
-
-          if (existingCost) {
-            await db.from("product_costs")
-              .update({ cmc, updated_at: new Date().toISOString() })
-              .eq("id", existingCost.id);
-          } else {
-            await db.from("product_costs").insert({
-              product_id: product.id,
-              cost_price: cmc,
-              cmc,
-              cost_source: "CMC",
-              cost_confidence: 0.7,
-            });
-          }
-        }
-
-        totalSynced++;
+        posicoes.set(codProd, {
+          saldo: prod.nSaldo ?? 0,
+          cmc: prod.nCMC ?? 0,
+          precoMedio: prod.nPrecoMedio ?? 0,
+        });
       }
 
-      console.log(`[Sync ${account}] Estoque página ${pagina}/${totalPaginas}`);
+      console.log(`[Sync ${account}] Estoque página ${pagina}/${totalPaginas} (${produtos.length})`);
       pagina++;
+    }
+
+    const codProds = [...posicoes.keys()];
+    const totalSynced = codProds.length;
+
+    if (totalSynced === 0) {
+      await updateSyncState(db, "inventory", account, {
+        status: "complete",
+        total_synced: 0,
+        last_sync_at: nowIso,
+        last_page: totalPaginas,
+      });
+      return { totalSynced: 0 };
+    }
+
+    // 2) RESOLVE product_id em LOTE. Preserva a semântica do .maybeSingle() anterior:
+    //    exatamente 1 match → id; 0 ou 2+ (ambíguo — omie_products é UNIQUE por (código,account)) → null.
+    const idByCod = new Map<number, string | null>();
+    for (const chunk of chunked(codProds, 300)) {
+      const { data, error } = await db
+        .from("omie_products")
+        .select("id, omie_codigo_produto")
+        .in("omie_codigo_produto", chunk);
+      if (error) {
+        console.error(`[Sync ${account}] resolve product_id:`, error);
+        continue;
+      }
+      for (const r of data || []) {
+        const cod = r.omie_codigo_produto as number;
+        idByCod.set(cod, idByCod.has(cod) ? null : (r.id as string)); // 2+ ocorrências → null (ambíguo)
+      }
+    }
+
+    // 3) inventory_position — upsert em LOTE (onConflict (omie_codigo_produto, account)).
+    const invRows = codProds.map((cod) => {
+      const p = posicoes.get(cod)!;
+      return {
+        omie_codigo_produto: cod,
+        product_id: idByCod.get(cod) ?? null,
+        saldo: p.saldo,
+        cmc: p.cmc,
+        preco_medio: p.precoMedio,
+        account,
+        synced_at: nowIso,
+      };
+    });
+    for (const chunk of chunked(invRows, 500)) {
+      const { error } = await db
+        .from("inventory_position")
+        .upsert(chunk, { onConflict: "omie_codigo_produto,account" });
+      if (error) console.error(`[Sync ${account}] upsert inventory_position:`, error);
+    }
+
+    // 4) omie_products.estoque — upsert em LOTE pela PK id (só estoque+updated_at).
+    //    Todos os ids vieram de linhas existentes → ON CONFLICT sempre faz UPDATE, nunca INSERT.
+    const stockRows = codProds
+      .map((cod) => ({ id: idByCod.get(cod), saldo: posicoes.get(cod)!.saldo }))
+      .filter((x): x is { id: string; saldo: number } => !!x.id)
+      .map((x) => ({ id: x.id, estoque: x.saldo, updated_at: nowIso }));
+    for (const chunk of chunked(stockRows, 500)) {
+      const { error } = await db.from("omie_products").upsert(chunk, { onConflict: "id" });
+      if (error) console.error(`[Sync ${account}] upsert estoque omie_products:`, error);
+    }
+
+    // 5) product_costs — só onde há product_id E cmc>0. Preserva a semântica anterior:
+    //    já existe → atualiza SÓ cmc+updated_at (não toca cost_price/source/confidence);
+    //    novo → insere linha completa (cost_source='CMC', cost_confidence=0.7).
+    const costCandidatos = codProds
+      .map((cod) => ({ id: idByCod.get(cod), cmc: posicoes.get(cod)!.cmc }))
+      .filter((x): x is { id: string; cmc: number } => !!x.id && x.cmc > 0);
+
+    if (costCandidatos.length > 0) {
+      const jaTemCusto = new Set<string>();
+      for (const chunk of chunked(costCandidatos.map((x) => x.id), 300)) {
+        const { data, error } = await db.from("product_costs").select("product_id").in("product_id", chunk);
+        if (error) {
+          console.error(`[Sync ${account}] resolve product_costs:`, error);
+          continue;
+        }
+        for (const r of data || []) jaTemCusto.add(r.product_id as string);
+      }
+
+      const aAtualizar = costCandidatos
+        .filter((x) => jaTemCusto.has(x.id))
+        .map((x) => ({ product_id: x.id, cmc: x.cmc, updated_at: nowIso }));
+      const aInserir = costCandidatos
+        .filter((x) => !jaTemCusto.has(x.id))
+        .map((x) => ({ product_id: x.id, cost_price: x.cmc, cmc: x.cmc, cost_source: "CMC", cost_confidence: 0.7 }));
+
+      for (const chunk of chunked(aAtualizar, 500)) {
+        const { error } = await db.from("product_costs").upsert(chunk, { onConflict: "product_id" });
+        if (error) console.error(`[Sync ${account}] upsert cmc product_costs:`, error);
+      }
+      for (const chunk of chunked(aInserir, 500)) {
+        const { error } = await db.from("product_costs").insert(chunk);
+        if (error) console.error(`[Sync ${account}] insert product_costs:`, error);
+      }
     }
 
     await updateSyncState(db, "inventory", account, {
       status: "complete",
       total_synced: totalSynced,
-      last_sync_at: new Date().toISOString(),
+      last_sync_at: nowIso,
       last_page: totalPaginas,
     });
     return { totalSynced };


### PR DESCRIPTION
## Problema
Instância Lovable (tier **Tiny**) em **100% do disk IO budget** → timeouts de conexão. Diagnóstico via `pg_stat_statements`: o topo de I/O eram **~1M `calls`** em cada um de `UPDATE omie_products SET estoque`, `INSERT inventory_position`, `UPDATE product_costs SET cmc` (~3M statements/janela).

## Causa-raiz
`syncInventory` (`omie-analytics-sync`) fazia **~4 writes PostgREST por produto**, num loop sobre todo o catálogo, a cada 30min/1h (crons `sync-inventory-*`). N+1 clássico — a armadilha que o CLAUDE.md já cita ("enumeração pesada nunca N+1").

## Fix
Acumula as páginas do Omie em memória (dedupe last-wins) e escreve em **lote**: resolução de `product_id` via `.in()` chunked + upsert/insert chunked nas 3 tabelas — o padrão que `syncCustomers`/`syncProducts` já usam neste mesmo arquivo. Colapsa ~3M statements → centenas de upserts/janela.

## Comportamento preservado (money-path)
- `product_id`: mesma semântica do `.maybeSingle()` (1 match→id; 0/ambíguo→null)
- `inventory_position`, `omie_products.estoque`: idênticos
- `product_costs`: mantém "existe→atualiza só `cmc`+`updated_at` (não toca `cost_price`/`source`/`confidence`) / novo→insere linha completa (`cost_source='CMC'`, `cost_confidence=0.7`)"

## Verificação
- ✅ `deno check` limpo na função alterada (os 3 `TS18048` que sobram são **pré-existentes** em `computeCosts` — provado via `git stash`)
- ℹ️ CI (`validate`) cobre só `src/`, não `supabase/functions` — o `deno check` local é o gate
- ⏳ **Pós-deploy:** após o próximo `sync-inventory-vendas-30m`, confirmar no `pg_stat_statements` que os `calls` desses statements **param de crescer** e o disk IO budget recupera

## ⚠️ Deploy MANUAL (não acontece no merge)
Edge function → deploy pelo **chat do Lovable** (lê `supabase/functions/omie-analytics-sync/index.ts` do repo). Mergear na main **NÃO** deploya.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
