### PR TITLE
chore(db): retenção diária de cron.job_run_details — corta disk IO de logs

### DIFF
--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,13 +21,13 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **223** custom migrations totais
-- **840** objetos esperados (criados por estas migrations)
+- **225** custom migrations totais
+- **844** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
-  - `function`: 232
+  - `function`: 235
   - `rls_policy`: 203
   - `index`: 157
-  - `cron_job`: 104
+  - `cron_job`: 105
   - `table`: 96
   - `trigger`: 44
   - `enum_value`: 4
@@ -1957,12 +1957,26 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | `index` | `public.idx_radar_muni_cover` | `radar_empresas` |
 | `function` | `public.radar_contagem_por_municipio` | — |
 
+### `20260614160000_roteirizador_campo_banco.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `public.norm_cidade` | — |
+| `function` | `public.carteira_por_municipio` | — |
+| `function` | `public.radar_prospects_para_rota` | — |
+
 ### `20260614231801_reposicao_timeout_sync_inventory.sql`
 
 | Tipo | Objeto | Parent |
 | --- | --- | --- |
 | `cron_job` | `cron.sync-inventory-vendas-30m` | — |
 | `cron_job` | `cron.sync-inventory-colacor-vendas-1h` | — |
+
+### `20260615091839_retencao_cron_job_run_details.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `cron_job` | `cron.purge-cron-job-run-details` | — |
 
 ## Próximos passos quando algo der `❌`
 

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 223
+-- Total de custom migrations: 225
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -242,7 +242,9 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260613230000', 'roteirizador_prospects', '20260613230000_roteirizador_prospects.sql'),
   ('20260614103251', 'onda1_fase1_farmer_calls_atendimento', '20260614103251_onda1_fase1_farmer_calls_atendimento.sql'),
   ('20260614140000', 'radar_contagem_perf', '20260614140000_radar_contagem_perf.sql'),
-  ('20260614231801', 'reposicao_timeout_sync_inventory', '20260614231801_reposicao_timeout_sync_inventory.sql')
+  ('20260614160000', 'roteirizador_campo_banco', '20260614160000_roteirizador_campo_banco.sql'),
+  ('20260614231801', 'reposicao_timeout_sync_inventory', '20260614231801_reposicao_timeout_sync_inventory.sql'),
+  ('20260615091839', 'retencao_cron_job_run_details', '20260615091839_retencao_cron_job_run_details.sql')
 )
 SELECT
   e.version,
@@ -1099,8 +1101,12 @@ WITH expected_objects (migration, kind, schema_name, object_name, parent_name) A
   ('onda1_fase1_farmer_calls_atendimento', 'index', 'public', 'idx_farmer_calls_atendimento_id', 'farmer_calls'),
   ('radar_contagem_perf', 'index', 'public', 'idx_radar_muni_cover', 'radar_empresas'),
   ('radar_contagem_perf', 'function', 'public', 'radar_contagem_por_municipio', ''),
+  ('roteirizador_campo_banco', 'function', 'public', 'norm_cidade', ''),
+  ('roteirizador_campo_banco', 'function', 'public', 'carteira_por_municipio', ''),
+  ('roteirizador_campo_banco', 'function', 'public', 'radar_prospects_para_rota', ''),
   ('reposicao_timeout_sync_inventory', 'cron_job', 'cron', 'sync-inventory-vendas-30m', ''),
-  ('reposicao_timeout_sync_inventory', 'cron_job', 'cron', 'sync-inventory-colacor-vendas-1h', '')
+  ('reposicao_timeout_sync_inventory', 'cron_job', 'cron', 'sync-inventory-colacor-vendas-1h', ''),
+  ('retencao_cron_job_run_details', 'cron_job', 'cron', 'purge-cron-job-run-details', '')
 )
 SELECT
   e.migration,

--- a/supabase/migrations/20260615091839_retencao_cron_job_run_details.sql
+++ b/supabase/migrations/20260615091839_retencao_cron_job_run_details.sql
@@ -1,0 +1,29 @@
+-- ============================================================
+-- retencao_cron_job_run_details — purga diária do histórico do pg_cron
+--
+-- Dor: cron.job_run_details cresce SEM retenção. O repo tem ~60 cron jobs,
+-- um deles a cada minuto (call-log-missed-backstop) + dezenas a cada 5–30min
+-- → milhares de linhas/dia acumulando pra sempre. A tabela incha e vários
+-- checks de data-health fazem seq scan nela a cada 30min → disk IO
+-- desperdiçado. Parte do plano de otimização de disk IO (a instância Lovable
+-- chegou a 100% do disk IO budget; ver PR do refactor syncInventory N+1→bulk).
+--
+-- Mantém ~7 dias de histórico (suficiente pra debugar cron) e descarta o
+-- resto, diariamente às 04:00 (janela de baixo tráfego, sem colisão com os
+-- outros crons). A 1ª execução limpa o backlog acumulado.
+--
+-- net._http_response NÃO é tocado aqui de propósito: o pg_net já expira as
+-- respostas via TTL próprio. A query de validação abaixo reporta o tamanho
+-- das duas tabelas pra confirmar; se net._http_response estiver grande,
+-- aí sim agenda-se uma purga dedicada num passo seguinte.
+-- ============================================================
+
+-- Idempotente: remove o job antes de re-criar (house style do repo).
+SELECT cron.unschedule('purge-cron-job-run-details')
+  WHERE EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'purge-cron-job-run-details');
+
+SELECT cron.schedule(
+  'purge-cron-job-run-details',
+  '0 4 * * *',  -- todo dia 04:00 (horário do servidor)
+  $$ DELETE FROM cron.job_run_details WHERE start_time < now() - interval '7 days' $$
+);


### PR DESCRIPTION
## Objetivo
Item **#4** do plano de otimização de disk IO (a instância Lovable bateu **100% do disk IO budget**). O #1 (PR #843) já matou o N+1 de escrita do `syncInventory`; este corta um desperdício de IO secundário: **logs de cron sem retenção**.

## O quê
`cron.job_run_details` cresce **sem nenhuma retenção** — o repo tem ~60 cron jobs (um a cada minuto + dezenas a cada 5–30min), ou seja milhares de linhas/dia acumulando pra sempre. A tabela incha e vários checks de **data-health fazem seq scan** nela a cada 30min → IO jogado fora.

Agenda uma **purga diária às 04:00** mantendo ~7 dias de histórico (`cron.unschedule` idempotente + `cron.schedule`, house style do repo). A 1ª execução limpa o backlog.

`net._http_response` **não** é tocado de propósito (o pg_net expira respostas via TTL próprio) — a validação reporta o tamanho das duas tabelas; se a do pg_net estiver grande, aí sim entra uma purga dedicada depois.

## ⚠️ ATENÇÃO: migration manual necessária

Este PR adiciona `supabase/migrations/20260615091839_retencao_cron_job_run_details.sql`. **Lovable não aplica automaticamente** — mergear NÃO toca o banco. Precisa colar no SQL Editor do Lovable e rodar.

<details><summary>SQL pra aplicar</summary>

```sql
-- Idempotente: remove o job antes de re-criar (house style do repo).
SELECT cron.unschedule('purge-cron-job-run-details')
  WHERE EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'purge-cron-job-run-details');

SELECT cron.schedule(
  'purge-cron-job-run-details',
  '0 4 * * *',  -- todo dia 04:00 (horário do servidor)
  $$ DELETE FROM cron.job_run_details WHERE start_time < now() - interval '7 days' $$
);
```
</details>

Validação pós-apply (+ diagnóstico de tamanho dos logs):

```sql
SELECT
  CASE WHEN EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'purge-cron-job-run-details')
       THEN '✅ cron purge-cron-job-run-details agendado'
       ELSE '❌ FALTANDO — migration não aplicada' END AS status;

SELECT 'cron.job_run_details' AS tabela,
       (SELECT count(*) FROM cron.job_run_details) AS linhas,
       pg_size_pretty(pg_total_relation_size('cron.job_run_details')) AS tamanho
UNION ALL
SELECT 'net._http_response',
       (SELECT count(*) FROM net._http_response),
       pg_size_pretty(pg_total_relation_size('net._http_response'));
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
