### PR TITLE
fix(roteirizador): carteira casa city 'NOME (UF)' — corrige zero-clientes em prod

### DIFF
--- a/db/test-roteirizador-campo-banco.sh
+++ b/db/test-roteirizador-campo-banco.sh
@@ -19,6 +19,7 @@ DB_DIR="$(mktemp -d)"; PORT=55478
 trap '"$PGBIN/pg_ctl" -D "$DB_DIR" stop -m immediate >/dev/null 2>&1; rm -rf "$DB_DIR"' EXIT
 P=("$PGBIN/psql" -h "$DB_DIR" -p "$PORT" -U postgres -d postgres -v ON_ERROR_STOP=1 -q)
 MIG="$(cd "$(dirname "$0")/.." && pwd)/supabase/migrations/20260614160000_roteirizador_campo_banco.sql"
+MIG2="$(cd "$(dirname "$0")/.." && pwd)/supabase/migrations/20260614170000_roteirizador_campo_carteira_sufixo_uf.sql"
 
 echo "=== schema mínimo + stubs + seed ==="
 "${P[@]}" <<'SQL'
@@ -56,16 +57,16 @@ INSERT INTO public.radar_empresas (cnpj, municipio_codigo, municipio_nome, uf, p
   SELECT lpad((100+g)::text,14,'0'),'3122306','DIVINÓPOLIS','MG','a_contatar',false, date '2020-01-01'+g
   FROM generate_series(1,250) g;
 
--- clientes:
--- b1 city sem acento 'Divinopolis' MG (A1) + visita há 10d (A5)
--- b2 city caixa alta 'DIVINÓPOLIS' mg (A2) sem visita (A5 NULL)
--- b3 'Divinópolis' SP homônimo outra uf (A3) — NÃO casa
--- b4 'Divinopolis' MG mas is_employee=true (A4) — NÃO casa
+-- clientes (city no formato REAL de prod: 'NOME (UF)' embutido, geralmente sem acento):
+-- b1 'DIVINOPOLIS (MG)' sem acento + sufixo UF (A1) + visita há 10d (A5)
+-- b2 'DIVINÓPOLIS (MG)' com acento + sufixo, mg minúsculo (A2) sem visita (A5 NULL)
+-- b3 'DIVINOPOLIS (SP)' SP homônimo outra uf (A3) — NÃO casa
+-- b4 'DIVINOPOLIS (MG)' MG mas is_employee=true (A4) — NÃO casa
 INSERT INTO public.addresses (user_id, street, city, state, is_default) VALUES
-  ('00000000-0000-0000-0000-0000000000b1'::uuid,'Rua A','Divinopolis','MG',true),
-  ('00000000-0000-0000-0000-0000000000b2'::uuid,'Rua B','DIVINÓPOLIS','mg',true),
-  ('00000000-0000-0000-0000-0000000000b3'::uuid,'Rua C','Divinópolis','SP',true),
-  ('00000000-0000-0000-0000-0000000000b4'::uuid,'Rua D','Divinopolis','MG',true);
+  ('00000000-0000-0000-0000-0000000000b1'::uuid,'Rua A','DIVINOPOLIS (MG)','MG',true),
+  ('00000000-0000-0000-0000-0000000000b2'::uuid,'Rua B','DIVINÓPOLIS (MG)','mg',true),
+  ('00000000-0000-0000-0000-0000000000b3'::uuid,'Rua C','DIVINOPOLIS (SP)','SP',true),
+  ('00000000-0000-0000-0000-0000000000b4'::uuid,'Rua D','DIVINOPOLIS (MG)','MG',true);
 INSERT INTO public.profiles (user_id, name, is_employee) VALUES
   ('00000000-0000-0000-0000-0000000000b1'::uuid,'Cliente Um',false),
   ('00000000-0000-0000-0000-0000000000b2'::uuid,'Cliente Dois',false),
@@ -75,8 +76,9 @@ INSERT INTO public.route_visits (customer_user_id, check_in_at) VALUES
   ('00000000-0000-0000-0000-0000000000b1'::uuid, now() - interval '10 days');
 SQL
 
-echo "=== aplica a migration ==="
-"${P[@]}" -f "$MIG" | grep -E "ROTEIRIZADOR CAMPO BANCO|funcoes_3" || true
+echo "=== aplica as migrations (160000 + 170000 fix sufixo UF) ==="
+"${P[@]}" -f "$MIG"  | grep -E "ROTEIRIZADOR CAMPO BANCO|funcoes_3" || true
+"${P[@]}" -f "$MIG2" | grep -E "CARTEIRA SUFIXO UF|divinopolis" || true
 
 echo "=== asserts ==="
 "${P[@]}" <<'SQL'

--- a/supabase/migrations/20260614170000_roteirizador_campo_carteira_sufixo_uf.sql
+++ b/supabase/migrations/20260614170000_roteirizador_campo_carteira_sufixo_uf.sql
@@ -1,0 +1,77 @@
+-- =============================================================================
+-- REDESIGN "VISITAS EM CAMPO" — Sub-PR 1 (fix): carteira casa city no formato
+-- "NOME (UF)". Os endereços gravam a cidade como 'DIVINOPOLIS (MG)' (UF embutido
+-- entre parênteses, sem acento) — o cruzamento da 20260614160000 normalizava
+-- acento/caixa mas mantinha o sufixo ' (MG)', então não casava o município RFB
+-- ('DIVINÓPOLIS') → 0 clientes em prod (smoke real). Aqui o cruzamento remove o
+-- sufixo ' (…)' final antes de normalizar (idempotente: city sem parênteses não muda).
+-- Spec: docs/superpowers/specs/2026-06-14-roteirizador-visitas-campo-redesign-design.md
+-- ⚠️ APLICAÇÃO MANUAL: colar no SQL Editor do Lovable. CREATE OR REPLACE — a última
+-- recriação vence; norm_cidade e radar_prospects_para_rota (160000) ficam como estão.
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION public.carteira_por_municipio(p_municipio_codigo text)
+RETURNS TABLE(
+  user_id uuid, name text, phone text,
+  street text, number text, neighborhood text, city text, state text, zip_code text, complement text,
+  business_hours_open text, business_hours_close text,
+  ultima_visita timestamptz, dias_desde_visita integer
+) LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path = public AS $$
+#variable_conflict use_column
+DECLARE
+  v_nome text;
+  v_uf   text;
+BEGIN
+  IF NOT COALESCE(public.pode_ver_carteira_completa((SELECT auth.uid())), false) THEN
+    RAISE EXCEPTION 'forbidden: gestor/master only';
+  END IF;
+  IF p_municipio_codigo IS NULL OR btrim(p_municipio_codigo) = '' THEN
+    RAISE EXCEPTION 'municipio_codigo obrigatório';
+  END IF;
+
+  SELECT re.municipio_nome, re.uf INTO v_nome, v_uf
+    FROM public.radar_empresas re
+   WHERE re.municipio_codigo = p_municipio_codigo
+   LIMIT 1;
+  IF v_nome IS NULL THEN RETURN; END IF;
+
+  RETURN QUERY
+  WITH alvo AS (
+    SELECT a.user_id, a.street, a.number, a.neighborhood, a.city, a.state,
+           a.zip_code, a.complement, a.is_default
+      FROM public.addresses a
+     WHERE public.norm_cidade(regexp_replace(a.city, '\s*\([^)]*\)\s*$', '')) = public.norm_cidade(v_nome)
+       AND upper(btrim(a.state)) = upper(btrim(v_uf))
+  ),
+  ende AS (
+    SELECT DISTINCT ON (user_id)
+           user_id, street, number, neighborhood, city, state, zip_code, complement
+      FROM alvo
+     ORDER BY user_id, is_default DESC NULLS LAST
+  ),
+  ult AS (
+    SELECT rv.customer_user_id, max(rv.check_in_at) AS ultima
+      FROM public.route_visits rv
+     WHERE rv.customer_user_id IN (SELECT e.user_id FROM ende e)
+       AND rv.check_in_at IS NOT NULL
+     GROUP BY rv.customer_user_id
+  )
+  SELECT e.user_id, p.name, p.phone,
+         e.street, e.number, e.neighborhood, e.city, e.state, e.zip_code, e.complement,
+         p.business_hours_open, p.business_hours_close,
+         u.ultima,
+         CASE WHEN u.ultima IS NULL THEN NULL
+              ELSE floor(extract(epoch FROM (now() - u.ultima)) / 86400)::int END
+    FROM ende e
+    JOIN public.profiles p ON p.user_id = e.user_id
+    LEFT JOIN ult u ON u.customer_user_id = e.user_id
+   WHERE COALESCE(p.is_employee, false) = false;
+END $$;
+
+REVOKE ALL ON FUNCTION public.carteira_por_municipio(text) FROM PUBLIC, anon;
+GRANT  EXECUTE ON FUNCTION public.carteira_por_municipio(text) TO authenticated;
+
+-- Validação pós-apply (colar junto; cliente_norm e rfb_norm devem ser 'divinopolis')
+SELECT 'CARTEIRA SUFIXO UF OK' AS status,
+  public.norm_cidade(regexp_replace('DIVINOPOLIS (MG)', '\s*\([^)]*\)\s*$', '')) AS cliente_norm,
+  public.norm_cidade('DIVINÓPOLIS') AS rfb_norm;


### PR DESCRIPTION
Smoke em prod do Sub-PR 1 (#841) deu **0**: os endereços gravam o `city` como `DIVINOPOLIS (MG)` (UF embutido), e o cruzamento não removia o sufixo ` (…)`. Esta migration incremental (`CREATE OR REPLACE`) tira o sufixo antes de normalizar — resolve a carteira inteira (todas as cidades seguem `NOME (UF)`). ⚠️ migration MANUAL no SQL Editor. PG17 verde + falsificação da regex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)