### PR TITLE
perf(data-health): índices nas colunas de frescor — corta seq scan do _data_health_compute

### DIFF
--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,15 +21,15 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **225** custom migrations totais
-- **844** objetos esperados (criados por estas migrations)
+- **230** custom migrations totais
+- **865** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
-  - `function`: 235
-  - `rls_policy`: 203
-  - `index`: 157
+  - `function`: 239
+  - `rls_policy`: 206
+  - `index`: 168
   - `cron_job`: 105
-  - `table`: 96
-  - `trigger`: 44
+  - `table`: 98
+  - `trigger`: 45
   - `enum_value`: 4
 
 ## Inventário por migration
@@ -1965,6 +1965,40 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | `function` | `public.carteira_por_municipio` | — |
 | `function` | `public.radar_prospects_para_rota` | — |
 
+### `20260614170000_cmc_ledger.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `table` | `public.cmc_ledger` | — |
+| `index` | `public.idx_cmc_ledger_lookup` | `cmc_ledger` |
+| `function` | `public.cmc_ledger_capture` | — |
+| `trigger` | `public.trg_cmc_ledger_capture` | `inventory_position` |
+| `rls_policy` | `public.cmc_ledger_select_staff` | `cmc_ledger` |
+
+### `20260614170000_roteirizador_campo_carteira_sufixo_uf.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `public.carteira_por_municipio` | — |
+
+### `20260614180000_markup_policy.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `table` | `public.markup_policy` | — |
+| `index` | `public.uq_markup_policy_conta` | `markup_policy` |
+| `index` | `public.uq_markup_policy_fam` | `markup_policy` |
+| `index` | `public.uq_markup_policy_sku` | `markup_policy` |
+| `function` | `public.resolve_markup_policy` | — |
+| `rls_policy` | `public.markup_policy_select_staff` | `markup_policy` |
+| `rls_policy` | `public.markup_policy_write_master` | `markup_policy` |
+
+### `20260614190000_get_preco_cockpit.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `public.get_preco_cockpit` | — |
+
 ### `20260614231801_reposicao_timeout_sync_inventory.sql`
 
 | Tipo | Objeto | Parent |
@@ -1977,6 +2011,18 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | Tipo | Objeto | Parent |
 | --- | --- | --- |
 | `cron_job` | `cron.purge-cron-job-run-details` | — |
+
+### `20260615095710_idx_data_health_freshness_cols.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `index` | `public.idx_inventory_position_synced_at` | `inventory_position` |
+| `index` | `public.idx_omie_products_updated_at` | `omie_products` |
+| `index` | `public.idx_product_costs_updated_at` | `product_costs` |
+| `index` | `public.idx_fin_contas_receber_updated_at` | `fin_contas_receber` |
+| `index` | `public.idx_fin_contas_pagar_updated_at` | `fin_contas_pagar` |
+| `index` | `public.idx_farmer_client_scores_calculated_at` | `farmer_client_scores` |
+| `index` | `public.idx_pedido_compra_sugerido_data_ciclo` | `pedido_compra_sugerido` |
 
 ## Próximos passos quando algo der `❌`
 

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 225
+-- Total de custom migrations: 230
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -243,8 +243,13 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260614103251', 'onda1_fase1_farmer_calls_atendimento', '20260614103251_onda1_fase1_farmer_calls_atendimento.sql'),
   ('20260614140000', 'radar_contagem_perf', '20260614140000_radar_contagem_perf.sql'),
   ('20260614160000', 'roteirizador_campo_banco', '20260614160000_roteirizador_campo_banco.sql'),
+  ('20260614170000', 'cmc_ledger', '20260614170000_cmc_ledger.sql'),
+  ('20260614170000', 'roteirizador_campo_carteira_sufixo_uf', '20260614170000_roteirizador_campo_carteira_sufixo_uf.sql'),
+  ('20260614180000', 'markup_policy', '20260614180000_markup_policy.sql'),
+  ('20260614190000', 'get_preco_cockpit', '20260614190000_get_preco_cockpit.sql'),
   ('20260614231801', 'reposicao_timeout_sync_inventory', '20260614231801_reposicao_timeout_sync_inventory.sql'),
-  ('20260615091839', 'retencao_cron_job_run_details', '20260615091839_retencao_cron_job_run_details.sql')
+  ('20260615091839', 'retencao_cron_job_run_details', '20260615091839_retencao_cron_job_run_details.sql'),
+  ('20260615095710', 'idx_data_health_freshness_cols', '20260615095710_idx_data_health_freshness_cols.sql')
 )
 SELECT
   e.version,
@@ -1104,9 +1109,30 @@ WITH expected_objects (migration, kind, schema_name, object_name, parent_name) A
   ('roteirizador_campo_banco', 'function', 'public', 'norm_cidade', ''),
   ('roteirizador_campo_banco', 'function', 'public', 'carteira_por_municipio', ''),
   ('roteirizador_campo_banco', 'function', 'public', 'radar_prospects_para_rota', ''),
+  ('cmc_ledger', 'table', 'public', 'cmc_ledger', ''),
+  ('cmc_ledger', 'index', 'public', 'idx_cmc_ledger_lookup', 'cmc_ledger'),
+  ('cmc_ledger', 'function', 'public', 'cmc_ledger_capture', ''),
+  ('cmc_ledger', 'trigger', 'public', 'trg_cmc_ledger_capture', 'inventory_position'),
+  ('cmc_ledger', 'rls_policy', 'public', 'cmc_ledger_select_staff', 'cmc_ledger'),
+  ('roteirizador_campo_carteira_sufixo_uf', 'function', 'public', 'carteira_por_municipio', ''),
+  ('markup_policy', 'table', 'public', 'markup_policy', ''),
+  ('markup_policy', 'index', 'public', 'uq_markup_policy_conta', 'markup_policy'),
+  ('markup_policy', 'index', 'public', 'uq_markup_policy_fam', 'markup_policy'),
+  ('markup_policy', 'index', 'public', 'uq_markup_policy_sku', 'markup_policy'),
+  ('markup_policy', 'function', 'public', 'resolve_markup_policy', ''),
+  ('markup_policy', 'rls_policy', 'public', 'markup_policy_select_staff', 'markup_policy'),
+  ('markup_policy', 'rls_policy', 'public', 'markup_policy_write_master', 'markup_policy'),
+  ('get_preco_cockpit', 'function', 'public', 'get_preco_cockpit', ''),
   ('reposicao_timeout_sync_inventory', 'cron_job', 'cron', 'sync-inventory-vendas-30m', ''),
   ('reposicao_timeout_sync_inventory', 'cron_job', 'cron', 'sync-inventory-colacor-vendas-1h', ''),
-  ('retencao_cron_job_run_details', 'cron_job', 'cron', 'purge-cron-job-run-details', '')
+  ('retencao_cron_job_run_details', 'cron_job', 'cron', 'purge-cron-job-run-details', ''),
+  ('idx_data_health_freshness_cols', 'index', 'public', 'idx_inventory_position_synced_at', 'inventory_position'),
+  ('idx_data_health_freshness_cols', 'index', 'public', 'idx_omie_products_updated_at', 'omie_products'),
+  ('idx_data_health_freshness_cols', 'index', 'public', 'idx_product_costs_updated_at', 'product_costs'),
+  ('idx_data_health_freshness_cols', 'index', 'public', 'idx_fin_contas_receber_updated_at', 'fin_contas_receber'),
+  ('idx_data_health_freshness_cols', 'index', 'public', 'idx_fin_contas_pagar_updated_at', 'fin_contas_pagar'),
+  ('idx_data_health_freshness_cols', 'index', 'public', 'idx_farmer_client_scores_calculated_at', 'farmer_client_scores'),
+  ('idx_data_health_freshness_cols', 'index', 'public', 'idx_pedido_compra_sugerido_data_ciclo', 'pedido_compra_sugerido')
 )
 SELECT
   e.migration,

--- a/supabase/migrations/20260615095710_idx_data_health_freshness_cols.sql
+++ b/supabase/migrations/20260615095710_idx_data_health_freshness_cols.sql
@@ -1,0 +1,47 @@
+-- ============================================================
+-- idx_data_health_freshness_cols — índices p/ baratear _data_health_compute()
+--
+-- Dor: _data_health_compute() (chamado pelo cron data-health-watchdog a cada
+-- 30min + ~860x/dia pelo badge do front via get_data_health) faz 18 checks em
+-- UNION ALL; vários são max(<coluna_de_data>) sobre tabelas grandes/churnadas
+-- SEM índice → seq scan a cada check, a cada chamada. No pg_stat_statements o
+-- watchdog acumulou ~3.116s e o get_data_health ~3.470s, com muito
+-- shared_blks_written (eviction de buffer durante os scans). Parte do plano de
+-- otimização de disk IO (a instância Lovable chegou a 100% do budget).
+--
+-- Fix TRANSPARENTE: índice btree em cada coluna de frescor → max() vira index
+-- scan (lê ~1 página) em vez de seq scan. NÃO toca o conjunto acoplado
+-- (_data_health_compute/data_health_watchdog/fin_sync_heartbeat) — o planner
+-- passa a usar sozinho. Não-concorrente de propósito: tabelas pequenas/médias,
+-- build <1s, lock desprezível (os syncs são periódicos, não contínuos). Os
+-- checks de count(*) FILTER (tipo_produto/família/status do portal) seguem
+-- fazendo scan — não é o alvo aqui; este passo cobre só os max(_at).
+-- ============================================================
+
+-- max(synced_at) — check estoque_inventario (tabela mais churnada; pós-bulk do #843 a escrita caiu)
+CREATE INDEX IF NOT EXISTS idx_inventory_position_synced_at
+  ON public.inventory_position (synced_at);
+
+-- max(updated_at) — check vendas_cadastros (omie_products é varrido em vários checks)
+CREATE INDEX IF NOT EXISTS idx_omie_products_updated_at
+  ON public.omie_products (updated_at);
+
+-- max(updated_at) — check custos_produtos
+CREATE INDEX IF NOT EXISTS idx_product_costs_updated_at
+  ON public.product_costs (updated_at);
+
+-- max(updated_at) — check contas_receber (tabela financeira, tende a crescer)
+CREATE INDEX IF NOT EXISTS idx_fin_contas_receber_updated_at
+  ON public.fin_contas_receber (updated_at);
+
+-- max(updated_at) — check contas_pagar
+CREATE INDEX IF NOT EXISTS idx_fin_contas_pagar_updated_at
+  ON public.fin_contas_pagar (updated_at);
+
+-- max(calculated_at) — check carteira_scores
+CREATE INDEX IF NOT EXISTS idx_farmer_client_scores_calculated_at
+  ON public.farmer_client_scores (calculated_at);
+
+-- max(data_ciclo) — check reposicao_sugestoes
+CREATE INDEX IF NOT EXISTS idx_pedido_compra_sugerido_data_ciclo
+  ON public.pedido_compra_sugerido (data_ciclo);


### PR DESCRIPTION
## Objetivo
Item **#3** do plano de otimização de disk IO. O #1 (PR #843) matou o N+1 de escrita do `syncInventory`; este ataca o **maior lever de IO restante**: o sistema de data-health.

## Diagnóstico
`_data_health_compute()` roda **18 checks em UNION ALL** e é chamado:
- a cada **30 min** pelo cron `data-health-watchdog` (SQL puro no pg_cron);
- **~860×/dia** pelo badge do topbar (front → `get_data_health` → `_data_health_compute`).

Vários checks fazem `max(<coluna_de_data>)` sobre tabelas grandes/churnadas **sem índice** → **seq scan** a cada check, a cada chamada. No `pg_stat_statements`: `data_health_watchdog` acumulou **~3.116s** e `get_data_health` **~3.470s**, com muito `shared_blks_written` (eviction de buffer durante os scans).

## Fix (transparente, zero mudança na função acoplada)
7 índices btree nas colunas de frescor → `max()` vira **index scan** (lê ~1 página) em vez de seq scan. **NÃO toca** o conjunto acoplado `_data_health_compute`/`data_health_watchdog`/`fin_sync_heartbeat` (arquivo quente, já reverteu checks 5×) — o planner passa a usar os índices sozinho.

| índice | check que acelera |
|---|---|
| `inventory_position(synced_at)` | estoque_inventario |
| `omie_products(updated_at)` | vendas_cadastros |
| `product_costs(updated_at)` | custos_produtos |
| `fin_contas_receber(updated_at)` | contas_receber |
| `fin_contas_pagar(updated_at)` | contas_pagar |
| `farmer_client_scores(calculated_at)` | carteira_scores |
| `pedido_compra_sugerido(data_ciclo)` | reposicao_sugestoes |

> Os checks de `count(*) FILTER` (tipo_produto/família/status do portal) seguem fazendo scan — não são o alvo aqui; este passo cobre os `max(_at)`, que são os ganhos limpos e sem risco.

## ⚠️ ATENÇÃO: migration manual necessária
Adiciona `supabase/migrations/20260615095710_idx_data_health_freshness_cols.sql`. **Lovable não aplica no merge** — colar no SQL Editor e rodar.

<details><summary>SQL pra aplicar</summary>

```sql
CREATE INDEX IF NOT EXISTS idx_inventory_position_synced_at ON public.inventory_position (synced_at);
CREATE INDEX IF NOT EXISTS idx_omie_products_updated_at ON public.omie_products (updated_at);
CREATE INDEX IF NOT EXISTS idx_product_costs_updated_at ON public.product_costs (updated_at);
CREATE INDEX IF NOT EXISTS idx_fin_contas_receber_updated_at ON public.fin_contas_receber (updated_at);
CREATE INDEX IF NOT EXISTS idx_fin_contas_pagar_updated_at ON public.fin_contas_pagar (updated_at);
CREATE INDEX IF NOT EXISTS idx_farmer_client_scores_calculated_at ON public.farmer_client_scores (calculated_at);
CREATE INDEX IF NOT EXISTS idx_pedido_compra_sugerido_data_ciclo ON public.pedido_compra_sugerido (data_ciclo);
```
</details>

Validação + medição antes/depois:

```sql
-- 1) confirma os 7 índices
SELECT count(*) || ' de 7 índices criados' AS status
FROM pg_indexes WHERE schemaname='public' AND indexname IN (
  'idx_inventory_position_synced_at','idx_omie_products_updated_at','idx_product_costs_updated_at',
  'idx_fin_contas_receber_updated_at','idx_fin_contas_pagar_updated_at',
  'idx_farmer_client_scores_calculated_at','idx_pedido_compra_sugerido_data_ciclo');

-- 2) tempo de uma chamada do compute (rode ANTES e DEPOIS de criar os índices)
EXPLAIN (ANALYZE, BUFFERS) SELECT * FROM public._data_health_compute();
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
