### PR TITLE
perf(data-health): índice de expressão mata o nested loop do check sayerlack (94% do custo)

### DIFF
--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,12 +21,12 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **230** custom migrations totais
-- **865** objetos esperados (criados por estas migrations)
+- **231** custom migrations totais
+- **866** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
   - `function`: 239
   - `rls_policy`: 206
-  - `index`: 168
+  - `index`: 169
   - `cron_job`: 105
   - `table`: 98
   - `trigger`: 45
@@ -2023,6 +2023,12 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | `index` | `public.idx_fin_contas_pagar_updated_at` | `fin_contas_pagar` |
 | `index` | `public.idx_farmer_client_scores_calculated_at` | `farmer_client_scores` |
 | `index` | `public.idx_pedido_compra_sugerido_data_ciclo` | `pedido_compra_sugerido` |
+
+### `20260615103111_idx_omie_products_codigo_text_account.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `index` | `public.idx_omie_products_codigo_text_account` | `omie_products` |
 
 ## Próximos passos quando algo der `❌`
 

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 230
+-- Total de custom migrations: 231
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -249,7 +249,8 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260614190000', 'get_preco_cockpit', '20260614190000_get_preco_cockpit.sql'),
   ('20260614231801', 'reposicao_timeout_sync_inventory', '20260614231801_reposicao_timeout_sync_inventory.sql'),
   ('20260615091839', 'retencao_cron_job_run_details', '20260615091839_retencao_cron_job_run_details.sql'),
-  ('20260615095710', 'idx_data_health_freshness_cols', '20260615095710_idx_data_health_freshness_cols.sql')
+  ('20260615095710', 'idx_data_health_freshness_cols', '20260615095710_idx_data_health_freshness_cols.sql'),
+  ('20260615103111', 'idx_omie_products_codigo_text_account', '20260615103111_idx_omie_products_codigo_text_account.sql')
 )
 SELECT
   e.version,
@@ -1132,7 +1133,8 @@ WITH expected_objects (migration, kind, schema_name, object_name, parent_name) A
   ('idx_data_health_freshness_cols', 'index', 'public', 'idx_fin_contas_receber_updated_at', 'fin_contas_receber'),
   ('idx_data_health_freshness_cols', 'index', 'public', 'idx_fin_contas_pagar_updated_at', 'fin_contas_pagar'),
   ('idx_data_health_freshness_cols', 'index', 'public', 'idx_farmer_client_scores_calculated_at', 'farmer_client_scores'),
-  ('idx_data_health_freshness_cols', 'index', 'public', 'idx_pedido_compra_sugerido_data_ciclo', 'pedido_compra_sugerido')
+  ('idx_data_health_freshness_cols', 'index', 'public', 'idx_pedido_compra_sugerido_data_ciclo', 'pedido_compra_sugerido'),
+  ('idx_omie_products_codigo_text_account', 'index', 'public', 'idx_omie_products_codigo_text_account', 'omie_products')
 )
 SELECT
   e.migration,

--- a/supabase/migrations/20260615103111_idx_omie_products_codigo_text_account.sql
+++ b/supabase/migrations/20260615103111_idx_omie_products_codigo_text_account.sql
@@ -1,0 +1,26 @@
+-- ============================================================
+-- idx_omie_products_codigo_text_account — mata o nested loop do check
+-- reposicao_sayerlack_fabricado em _data_health_compute()
+--
+-- Causa-raiz (CONFIRMADA por EXPLAIN ANALYZE, 2026-06-15): o check
+-- reposicao_sayerlack_fabricado faz um EXISTS correlacionado:
+--   EXISTS (SELECT 1 FROM omie_products o
+--           WHERE o.omie_codigo_produto::text = sp.sku_codigo_omie::text
+--             AND lower(o.account) = lower(sp.empresa) ...)
+-- O ::text nos DOIS lados anula qualquer índice em omie_codigo_produto (bigint)
+-- → Nested Loop Semi Join com Seq Scan on omie_products POR linha de
+-- sku_parametros (loops=179). Isso sozinho = 144.990 de 154.175 buffers (94%)
+-- e ~todos os 1.188ms de _data_health_compute() — que roda a cada 30min
+-- (watchdog) + ~860x/dia (badge do front, que recomputa sem cache). Os outros
+-- 17 checks são ruído (~9k buffers / ~30ms).
+--
+-- Fix TRANSPARENTE (sem tocar a função acoplada): índice de EXPRESSÃO que casa
+-- exatamente com o Join Filter — (omie_codigo_produto::text, lower(account)) →
+-- o inner Seq Scan vira Index Scan (1-2 linhas por loop em vez de varrer 7.9k).
+-- Bônus: serve qualquer lookup account-aware por código (ex. o motor de compra
+-- gerar_pedidos_sugeridos_ciclo, que também junta omie_products por código+conta).
+-- Não-concorrente: omie_products é pequena (~6,5MB), build <1s.
+-- ============================================================
+
+CREATE INDEX IF NOT EXISTS idx_omie_products_codigo_text_account
+  ON public.omie_products ((omie_codigo_produto::text), lower(account));


### PR DESCRIPTION
## Causa-raiz CONFIRMADA (EXPLAIN ANALYZE)
O #849 (índices de frescor) **não moveu nada** — medido. A sonda seguinte achou o real culpado: **um único check** do `_data_health_compute()`, o `reposicao_sayerlack_fabricado`, faz um EXISTS correlacionado:

```
Nested Loop Semi Join
  Join Filter: lower(sp.empresa)=lower(o.account) AND (sp.sku_codigo_omie)::text=(o.omie_codigo_produto)::text
  -> Seq Scan on sku_parametros sp   (rows=179)
  -> Seq Scan on omie_products o     (loops=179)   ← Buffers: shared hit=144990
```

O `::text` nos dois lados **anula o índice** em `omie_codigo_produto` (bigint) → varre `omie_products` inteiro **por linha** de `sku_parametros` (179 loops). Isso sozinho = **144.990 de 154.175 buffers (94%)** e ~todos os 1.188ms da função — que roda a cada 30min (watchdog) + ~860×/dia (badge sem cache).

## Fix (transparente, sem tocar a função acoplada)
Índice de **expressão** que casa exatamente com o Join Filter:
```sql
CREATE INDEX IF NOT EXISTS idx_omie_products_codigo_text_account
  ON public.omie_products ((omie_codigo_produto::text), lower(account));
```
→ o inner Seq Scan vira **Index Scan** (1-2 linhas por loop em vez de varrer 7.916). Bônus: serve qualquer lookup account-aware por código (ex.: o motor de compra).

## ⚠️ ATENÇÃO: migration manual necessária
Adiciona `supabase/migrations/20260615103111_idx_omie_products_codigo_text_account.sql`. **Lovable não aplica no merge** — colar no SQL Editor.

Validação + medição depois/antes:
```sql
CREATE INDEX IF NOT EXISTS idx_omie_products_codigo_text_account
  ON public.omie_products ((omie_codigo_produto::text), lower(account));

EXPLAIN (ANALYZE, BUFFERS) SELECT * FROM public._data_health_compute();
```
Esperado: `Execution Time` e `shared hit` despencam (de ~1.188ms / ~154k buffers para dezenas de ms / poucos milhares).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
