### PR TITLE
perf(tint): tint_staging_* UNLOGGED — corta o WAL do maior escritor do banco

### DIFF
--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,7 +21,7 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **231** custom migrations totais
+- **232** custom migrations totais
 - **866** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
   - `function`: 239
@@ -2029,6 +2029,10 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | Tipo | Objeto | Parent |
 | --- | --- | --- |
 | `index` | `public.idx_omie_products_codigo_text_account` | `omie_products` |
+
+### `20260615104342_tint_staging_unlogged.sql`
+
+> _Nenhum objeto extraído via regex._ Migration provavelmente é `ALTER TABLE` / `UPDATE` / `INSERT` / RLS-only. Validar manualmente.
 
 ## Próximos passos quando algo der `❌`
 

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 231
+-- Total de custom migrations: 232
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -250,7 +250,8 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260614231801', 'reposicao_timeout_sync_inventory', '20260614231801_reposicao_timeout_sync_inventory.sql'),
   ('20260615091839', 'retencao_cron_job_run_details', '20260615091839_retencao_cron_job_run_details.sql'),
   ('20260615095710', 'idx_data_health_freshness_cols', '20260615095710_idx_data_health_freshness_cols.sql'),
-  ('20260615103111', 'idx_omie_products_codigo_text_account', '20260615103111_idx_omie_products_codigo_text_account.sql')
+  ('20260615103111', 'idx_omie_products_codigo_text_account', '20260615103111_idx_omie_products_codigo_text_account.sql'),
+  ('20260615104342', 'tint_staging_unlogged', '20260615104342_tint_staging_unlogged.sql')
 )
 SELECT
   e.version,

--- a/supabase/migrations/20260615104342_tint_staging_unlogged.sql
+++ b/supabase/migrations/20260615104342_tint_staging_unlogged.sql
@@ -1,0 +1,42 @@
+-- ============================================================
+-- tint_staging_unlogged — torna as tabelas de staging do tint UNLOGGED
+--
+-- Dor (medido 2026-06-15): os INSERT em tint_staging_formula_itens (1,77M
+-- blocos escritos) e tint_staging_formulas (806k) são o #1/#2 em escrita do
+-- banco inteiro, e CRESCERAM durante a sessão (+2.317 / +1.165 calls) → dreno
+-- de write-IO ATIVO. O connector externo empurra o catálogo em lote (já é bulk,
+-- chunks de 500/1000 — não é N+1), promove pras tabelas reais (tint_formulas/
+-- tint_formula_itens, essas LOGGED/duráveis) e TRUNCA a staging.
+--
+-- Fix: as staging são SCRATCH (preenche → promove → trunca). UNLOGGED elimina o
+-- WAL dessas escritas (parte grande do IO de escrita) sem tocar lógica nenhuma.
+-- SEGURO: no crash/restart, a UNLOGGED zera — e o connector re-empurra (ele só
+-- avança o high-water mark no sucesso da promoção; ver comentário em
+-- tint-sync-agent/index.ts:165). A verdade durável vive nas tabelas tint_*
+-- promovidas, não na staging. Parte do plano de otimização de disk IO.
+--
+-- Idempotente: só altera a tabela que ainda NÃO é unlogged (relpersistence<>'u');
+-- tabela ausente é pulada. ALTER ... SET UNLOGGED reescreve a tabela (lock breve);
+-- a staging fica vazia entre syncs, então o rewrite é instantâneo. Aplicar quando
+-- não houver sync tint em andamento (senão espera o lock por instantes).
+-- ============================================================
+
+DO $$
+DECLARE
+  t text;
+BEGIN
+  FOREACH t IN ARRAY ARRAY[
+    'tint_staging_produtos','tint_staging_bases','tint_staging_embalagens',
+    'tint_staging_corantes','tint_staging_skus','tint_staging_formulas',
+    'tint_staging_formula_itens','tint_staging_precos_base'
+  ]
+  LOOP
+    IF EXISTS (
+      SELECT 1 FROM pg_class c
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+      WHERE n.nspname = 'public' AND c.relname = t AND c.relpersistence <> 'u'
+    ) THEN
+      EXECUTE format('ALTER TABLE public.%I SET UNLOGGED', t);
+    END IF;
+  END LOOP;
+END $$;


### PR DESCRIPTION
## Objetivo
Item **#2** (último) do plano de otimização de disk IO. Os `INSERT` em `tint_staging_*` são o **#1/#2 em blocos escritos** do banco inteiro.

## Diagnóstico (medido)
| statement | calls (início sessão) | calls (agora) | blocos escritos |
|---|---|---|---|
| `INSERT tint_staging_formula_itens` | 10.062 | **12.379** (+2.317) | 1,77M |
| `INSERT tint_staging_formulas` | 5.052 | **6.217** (+1.165) | 806k |

Crescimento durante a sessão = **dreno ATIVO** (connector externo re-empurrando o catálogo). Diferente do #1: **já é bulk** (chunks de 500/1000, não N+1). O custo é **volume de WAL** repetido em tabelas que são **scratch**: o fluxo é *push → staging → promove pras tabelas reais (`tint_*`, duráveis) → `TRUNCATE` staging*.

## Fix
`ALTER TABLE ... SET UNLOGGED` nas 8 `tint_staging_*` → **elimina o WAL** dessas escritas (parte grande do IO de escrita) sem tocar lógica. **Seguro**: são scratch; no crash a UNLOGGED zera e o connector re-empurra (só avança o high-water mark no sucesso da promoção — `tint-sync-agent/index.ts:165`). A verdade durável vive nas tabelas `tint_*` promovidas, não na staging.

## ⚠️ ATENÇÃO: migration manual necessária
Adiciona `supabase/migrations/20260615104342_tint_staging_unlogged.sql`. **Lovable não aplica no merge** — colar no SQL Editor. Rodar **fora de um sync tint ativo** (o `ALTER` reescreve com lock breve; staging vazia entre syncs = instantâneo).

<details><summary>SQL pra aplicar</summary>

```sql
DO $$
DECLARE t text;
BEGIN
  FOREACH t IN ARRAY ARRAY[
    'tint_staging_produtos','tint_staging_bases','tint_staging_embalagens',
    'tint_staging_corantes','tint_staging_skus','tint_staging_formulas',
    'tint_staging_formula_itens','tint_staging_precos_base'
  ] LOOP
    IF EXISTS (SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace
               WHERE n.nspname='public' AND c.relname=t AND c.relpersistence <> 'u') THEN
      EXECUTE format('ALTER TABLE public.%I SET UNLOGGED', t);
    END IF;
  END LOOP;
END $$;
```
</details>

Validação pós-apply:
```sql
SELECT relname, CASE relpersistence WHEN 'u' THEN '✅ unlogged' ELSE '❌ ainda logged' END AS status
FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace
WHERE n.nspname='public' AND relname LIKE 'tint_staging_%' ORDER BY relname;
```
Esperado: as 8 `✅ unlogged`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
