### PR TITLE
fix(tintometria): remapeia 4 SKUs oben com vínculo Omie desalinhado (vigia tint_vinculo_omie)

### DIFF
--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,7 +21,7 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **232** custom migrations totais
+- **233** custom migrations totais
 - **869** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
   - `function`: 242
@@ -2037,6 +2037,10 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | `function` | `public._data_health_compute` | — |
 | `function` | `public.data_health_watchdog` | — |
 | `function` | `public.fin_sync_heartbeat` | — |
+
+### `20260615133000_tint_remapeia_skus_omie_desalinhadas.sql`
+
+> _Nenhum objeto extraído via regex._ Migration provavelmente é `ALTER TABLE` / `UPDATE` / `INSERT` / RLS-only. Validar manualmente.
 
 ## Próximos passos quando algo der `❌`
 

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 232
+-- Total de custom migrations: 233
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -251,7 +251,8 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260615091839', 'retencao_cron_job_run_details', '20260615091839_retencao_cron_job_run_details.sql'),
   ('20260615095710', 'idx_data_health_freshness_cols', '20260615095710_idx_data_health_freshness_cols.sql'),
   ('20260615103111', 'idx_omie_products_codigo_text_account', '20260615103111_idx_omie_products_codigo_text_account.sql'),
-  ('20260615130000', 'tint_vigia_cobertura_sentinela', '20260615130000_tint_vigia_cobertura_sentinela.sql')
+  ('20260615130000', 'tint_vigia_cobertura_sentinela', '20260615130000_tint_vigia_cobertura_sentinela.sql'),
+  ('20260615133000', 'tint_remapeia_skus_omie_desalinhadas', '20260615133000_tint_remapeia_skus_omie_desalinhadas.sql')
 )
 SELECT
   e.version,

--- a/supabase/migrations/20260615133000_tint_remapeia_skus_omie_desalinhadas.sql
+++ b/supabase/migrations/20260615133000_tint_remapeia_skus_omie_desalinhadas.sql
@@ -1,0 +1,44 @@
+-- ============================================================
+-- tint_remapeia_skus_omie_desalinhadas
+-- Conserta 4 SKUs de tintometria (account='oben') cujo omie_product_id ficou
+-- desalinhado no seed em lote de 2026-03-23 (casaram o produto Omie errado por
+-- base/embalagem). Resolve os 3 pares ambíguos do vigia `tint_vinculo_omie`
+-- (Sentinela / Saúde de Dados) — cada produto Omie tinha 2 SKUs ativas
+-- apontando pra ele — e de bônus conserta a single mal-vinculada PRD01926.
+--
+-- Todas as 4 SKUs têm venda 0 (tint_vendas_itens) → conserto não-destrutivo.
+-- Prova (dry-run via simulação read-only): 0 pares ambíguos pós-remapeamento.
+--
+-- De-para (SKU → produto Omie correto, casado por base + embalagem):
+--   05f0fb79  base WFOI.6736 INTER / QT  : PRD02224 (WFOB total) → PRD02187 (INTER WFOI.6736QT)
+--   f2e39d17  base WFOT.6501 TRANSP / GL : PRD02378 (QT)         → PRD02364 (WFOT.6501GL)
+--   b850b1d9  base WFOT.6529 TRANSP / GL : PRD01926 (WFOI)       → PRD03657 (WFOT.6529GL)  [libera PRD01926]
+--   8d4493f5  base WFOI.6529 INTER / GL  : PRD01899 (QT)         → PRD01926 (WFOI.6529GL)
+--
+-- Idempotente: a guarda `IS DISTINCT FROM` torna a re-execução um no-op.
+-- Fail-safe: o JOIN em omie_products por (id + codigo esperado + account)
+-- só permite o UPDATE se o UUID de destino corresponder ao código esperado —
+-- se algum UUID estiver errado, aquele UPDATE simplesmente não ocorre (jamais
+-- seta omie_product_id = NULL). Obs.: o código PRD03657 também existe na conta
+-- colacor (uma "CINTA ATX170") — outro registro/empresa do grupo; dentro de oben
+-- o código é único, e o filtro account='oben' já isola o produto base correto.
+-- ============================================================
+
+WITH remap(sku_id, novo_omie_id, codigo_esperado) AS (
+  VALUES
+    ('05f0fb79-c5c4-434a-8f8c-bc5593f9dd4a'::uuid, 'c5e1c71d-634b-404d-86af-e528e9d8d19e'::uuid, 'PRD02187'),
+    ('f2e39d17-6035-4679-92d8-8a3fa030accd'::uuid, '1aee5629-8a99-426c-bb9c-bf808ec86352'::uuid, 'PRD02364'),
+    ('b850b1d9-9464-4ff8-b80b-937bccd4a5aa'::uuid, '81835f3c-e9f7-48d8-aa7e-94bb372f7f93'::uuid, 'PRD03657'),
+    ('8d4493f5-2bed-4793-8a64-8c33a7ce5b1b'::uuid, 'eb7e2fb7-3a77-4331-addc-e7f24bcb7cec'::uuid, 'PRD01926')
+)
+UPDATE public.tint_skus ts
+SET omie_product_id = r.novo_omie_id,
+    updated_at      = now()
+FROM remap r
+JOIN public.omie_products op
+  ON op.id      = r.novo_omie_id
+ AND op.codigo  = r.codigo_esperado
+ AND op.account = 'oben'
+WHERE ts.id = r.sku_id
+  AND ts.account = 'oben'
+  AND ts.omie_product_id IS DISTINCT FROM r.novo_omie_id;


### PR DESCRIPTION
## ✅ STATUS: conserto JÁ aplicado no banco — vigia verde

As 4 SKUs já estão nos destinos corretos (`updated_at` 2026-06-15 ~14:11–14:15Z, **UPDATEs manuais individuais** — não esta migration, que faria 1 transação só). Check completo do vigia **`tint_vinculo_omie`** confirmado via `psql-ro`: **`morto=0` + `ambiguo=0` → VERDE**. Esta migration fica como **registro versionado idempotente** (DR-safe: reaplica o conserto se o snapshot for restaurado; re-rodar é no-op pela guarda `IS DISTINCT FROM`).

## Contexto

O vigia `tint_vinculo_omie` (Sentinela, #851) sinalizou 3 produtos Omie de tintometria (`oben`) com **2 SKUs ativas no mesmo `omie_product_id`** (vínculo ambíguo). Causa raiz (diagnóstico via `psql-ro`): **desalinhamento no seed em lote de 2026-03-23** — SKUs casaram o produto Omie errado por base/embalagem. Os 3 pares + 1 single (`PRD01926`) eram sintomas. `useTintColorSelect` lê Omie→SKU com `.limit(1).maybeSingle()` → escolhia 1 das 2 arbitrariamente.

## O que faz — remapeia 4 SKUs pro produto Omie correto (casado por base+embalagem)

| SKU | de (errado) | para (correto) |
|---|---|---|
| `05f0fb79` | PRD02224 (WFOB total) | **PRD02187** INTER WFOI.6736QT |
| `f2e39d17` | PRD02378 (QT) | **PRD02364** WFOT.6501GL |
| `b850b1d9` | PRD01926 (WFOI) | **PRD03657** WFOT.6529GL *(libera PRD01926)* |
| `8d4493f5` | PRD01899 (QT) | **PRD01926** WFOI.6529GL |

Remapeia (não desativa) → preserva as variantes vendáveis. Todas com **venda 0** (`tint_vendas_itens`) → não-destrutivo. UPDATE **idempotente** + **fail-safe** (JOIN por `id+codigo+account`; nunca seta NULL). Destinos verificados: todos `ativo=true`, `account=oben` → **não criam `morto`**.

## Provas

- **Dry-run** (simulação read-only): `morto_pos=0, ambiguo_pos=0` pós-remapeamento.
- **Validação falsificada**: dava `❌` no estado pré-conserto → não é falso-verde.
- **Pós-conserto (real, no banco)**: `morto=0, ambiguo=0`; 4/4 SKUs no destino correto.

## Validação fiel ao vigia (rodar no SQL Editor) — esperado `✅`

```sql
WITH chk AS (
  SELECT
    (SELECT count(*) FROM public.tint_skus ts JOIN public.omie_products op ON op.id=ts.omie_product_id
       WHERE ts.account='oben' AND ts.ativo IS NOT FALSE
         AND (op.ativo IS NOT TRUE OR op.account IS DISTINCT FROM ts.account)) AS morto,
    (SELECT count(*) FROM (SELECT ts.omie_product_id FROM public.tint_skus ts
       WHERE ts.account='oben' AND ts.ativo IS NOT FALSE AND ts.omie_product_id IS NOT NULL
       GROUP BY ts.omie_product_id HAVING count(*)>1) d) AS ambiguo
)
SELECT CASE WHEN morto+ambiguo=0
            THEN '✅ vigia tint_vinculo_omie VERDE (morto=0, ambiguo=0)'
            ELSE '❌ morto='||morto||' ambiguo='||ambiguo END AS status
FROM chk;
```

## Achados adjacentes (registrados)

- **Código Omie é único por conta** (verificado: `0` duplicados dentro de qualquer `account`). `PRD03657` existe em `oben` (base) e `colacor` (CINTA) — empresas distintas → by-design. O UPDATE filtra `account='oben'`.
- **`PRD01919`** estava mal-vinculado no início da sessão; foi corrigido em paralelo; agora limpo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
