### PR TITLE
feat(reposição): Sayerlack — falha ANTES do "Efetivar" → erro_retenta…

### DIFF
--- a/docs/superpowers/specs/2026-06-15-sayerlack-reclassificacao-finalizacao-design.md
+++ b/docs/superpowers/specs/2026-06-15-sayerlack-reclassificacao-finalizacao-design.md
@@ -1,0 +1,85 @@
+# Sayerlack — reclassificação por finalização: falha ANTES do "Efetivar" → `erro_retentavel` (não `indeterminado`)
+
+**Data:** 2026-06-15 · **Escopo:** edge `enviar-pedido-portal-sayerlack` (money-path) · **Status:** SPEC v3 (2 passes de BLOQUEIO do Codex incorporados) · **Origem:** pedido 355.
+
+## Problema
+Portal Sayerlack = automação Browserless (flaky). Falha → **`indeterminado_requer_conciliacao`** (ação humana; o motor `sayerlack_retry_orfaos` NÃO retenta, por risco de PO duplicado) = reconciliação manual. **Causa do excesso:** a classificação usa `requestSent` (liga em QUALQUER POST de ordem, incl. o de criar o RASCUNHO, cedo) → qualquer falha pós-rascunho vira indeterminado, **mesmo sem pedido finalizado**.
+
+## Evidência (pedido 355)
+10+ itens; 0-8 salvos OK; **travou no item 9** (`validacao-data`, hang >15s); budget sobrando (198s). Trace **sem `efetivar_clicked`** → nunca clicou "Efetivar Pedido" → nenhum pedido colocado, só rascunho parcial → mas virou indeterminado (manual). Era hang transitório → deveria auto-retentar.
+
+## INVARIANTE-MESTRA (money-path)
+`erro_retentavel` → o motor AUTO-RE-DISPARA. Se um pedido pode ter sido colocado e for reclassificado retentável → **DUPLICATA**. ⛔ Só relaxar→`erro_retentavel` quando **PROVADAMENTE não houve pedido**. Desconhecido/ausência de prova → **`indeterminado`** (fail-closed). A camada Deno **só endurece, nunca afrouxa** — jamais rebaixar um `indeterminado`.
+
+## Fronteira de finalização (CONFIRMADA no código)
+`grep` de todos os `page.click`: pedido só é colocado ao clicar **`#btnSalvarNovoPedido` ("Efetivar Pedido")**, L1086, UMA vez. `#btnSalvarProposta` NUNCA é clicado (só debug do DOM). `#btnGravarItem`→`save-tab-preco-session` nem casa `SUSPECT_RE`. Sem Enter/`submit()`/auto-submit. → **clique de Efetivar não ocorreu ⟺ nenhum pedido.** ⚠️ **Confirmação EMPÍRICA do founder (gate de deploy):** "Salvar Proposta" e rascunho abandonado **não** geram PO na Sayerlack.
+
+## Duas camadas de classificação (o Codex pegou — eu via só uma)
+1. **`buildEnvelope`** (DENTRO do Browserless, ~L296-355): produz o `status` do envelope.
+2. **Máquina de estados Deno** (~L1945-2070): recebe o envelope, decide o `status_envio_portal` final + persiste. Inclui a rede de segurança L1978. **Ambas precisam virar `efetivarAttempted`-aware e CONSISTENTES** (mexer só numa é inútil).
+
+## Sinal: `efetivarAttempted` (substitui `requestSent` na decisão de falha)
+**Codex v2 P1.1:** `requestSent` é proxy ruim — ele liga em POST de rascunho (falso-perigo: vira indeterminado à toa) E pode FALHAR de capturar o POST de finalização (recorder perde → falso-seguro: vira retentável após o clique = duplicata). O sinal preciso é **`efetivarAttempted`** = clicou `#btnSalvarNovoPedido`. `requestSent` segue só como evidência/log.
+
+### (A) Flag em closure do Browserless (undefined-safe)
+`let efetivarAttempted = false;` no topo da função Browserless (ao lado de `trace`/`t0`), fora do `runFlow`. `efetivarAttempted = true;` **IMEDIATAMENTE ANTES** de `await page.click('#btnSalvarNovoPedido')` (L1086) — antes, não depois (hang no clique → já `true` → indeterminado). `buildEnvelope` lê do closure (sobrevive aos try/catch interno L1258 e externo L1284 — Codex v2 confirmou) e grava `evidence.efetivarAttempted` (SEMPRE boolean).
+
+### (B) Camada 1 — `buildEnvelope`
+1. `if (data.success === true)` → `sucesso_portal`/`aceito_portal_sem_protocolo` (INALTERADO; success só é setado pós-clique pela lógica de submit → implica efetivarAttempted=true).
+2. `else if (protocoloAutoExtraido && efetivarAttempted === true)` → `sucesso_portal` (**MUDOU de `&& requestSent` p/ `&& efetivarAttempted===true`** — Codex v2 P1.3). Um protocolo extraído de resposta de RASCUNHO é necessariamente pré-clique → `efetivarAttempted=false` → este ramo é pulado → **subsume a checagem de URL `/order-creation/form/add`** que o Codex sugeriu.
+3. `else` (falha) — decisão PURA por `efetivarAttempted` (`requestSent` SAI):
+   - `if (erroLogicoPreSubmit)` → `erro_nao_retentavel` (LOGIN_FAILED/CLIENTE_NOT_FOUND/SKU_NOT_FOUND/GRUPO_LEADTIME_MISMATCH — pré-clique determinístico; Codex P3 confirmou seguro).
+   - `else if (efetivarAttempted === false)` → **`erro_retentavel`** ⭐ (clique nunca ocorreu → nenhum pedido → seguro).
+   - `else` (efetivarAttempted `true` OU `undefined`) → **`indeterminado`** (clicou ou desconhecido → pode ter colocado). **Fecha o P1.1**: clicou-mas-sem-requestSent cai AQUI (indeterminado), não em retentável.
+
+### (C) Camada 2 — rede de segurança Deno L1978 (endurece, undefined-safe)
+```
+if (envStatus === 'erro_retentavel' && evidence?.efetivarAttempted !== false) {
+  envStatus = 'indeterminado_requer_conciliacao';  // só mantém retentável se efetivarAttempted EXPLÍCITO false
+}
+```
+(`requestSent` sai daqui também — coerente com (B).) `undefined`/ausente → endurece p/ indeterminado.
+
+### (D) Deno tempFail 408/5xx/0 → `indeterminado` (Codex P1 v1, confirmado correto v2)
+L1957-1964 hoje → `erro_retentavel` assumindo "não submeteu". O Browserless pode falhar PÓS-clique → desconhecido → **`indeterminado`**. (`httpErr`/abort L1951 já é indeterminado — manter; `401/403` L1830 fica retentável — nenhum browser subiu.) **Tempo decorrido NÃO prova que o clique não ocorreu** (Codex v2) → não usar heurística de tempo.
+
+### (E) Deno — status DESCONHECIDO → `indeterminado` (fail-closed; Codex v2 P1.2)
+A máquina L1984-2070 tem branches p/ sucesso/aceito/indeterminado/erro_nao_retentavel; o `else` final (L2061) é `erro_retentavel` e captura TAMBÉM `envStatus` não-reconhecido (fail-OPEN). Mudar: branch **explícito** `envStatus === 'erro_retentavel'` → retentável; **catch-all (desconhecido) → `indeterminado`**.
+
+### (F) Watchdog L2104-2138 — stub + UPDATE CONDICIONAL (Codex P1-Q3 v1 + P2 v2)
+Ao setar `indeterminado` num pedido travado em `enviando_portal`: **(1)** sobrescrever `portal_resposta` com stub `{phase:'watchdog', efetivarAttempted:null}` (não deixar envelope obsoleto da tentativa anterior dizendo `efetivarAttempted=false` sob um indeterminado de tentativa posterior que talvez efetivou → senão humano lê "false" e re-envia → duplicata); **(2)** o UPDATE deve ser **condicional** `.eq('status_envio_portal','enviando_portal')` — senão uma conclusão concorrente (edge terminando entre o SELECT e o UPDATE do watchdog) seria sobrescrita.
+
+## Por que é seguro (pós-fixes)
+- Pedido só é colocado no clique de Efetivar (ponto único confirmado). `efetivarAttempted===false` ⟺ sem clique ⟺ sem pedido.
+- `erro_retentavel` exige `efetivarAttempted===false` **explícito** nas DUAS camadas. `true`/`undefined`/desconhecido → indeterminado.
+- Flag ANTES do clique → falha no/após clique → indeterminado.
+- Auto-extract de protocolo exige `efetivarAttempted===true` → resposta de rascunho não vira falso-sucesso.
+- 408/5xx/abort sem envelope → indeterminado. Status desconhecido → indeterminado. Watchdog condicional + sem evidência obsoleta.
+
+## Rede de segurança preservada
+- Motor `sayerlack_retry_orfaos` (`*/15`, age-bound 3d, `tentativas<3`, lock + `LIMIT 1` + claim atômico) consome `erro_retentavel`. Sem infra nova.
+- Esgotamento (3ª falha) → a edge grava **`erro_nao_retentavel`** (L2061-2065, NÃO "erro_retentavel esgotado" — correção Codex P3) → coberto pelo check `reposicao_portal_humano` do Sentinela.
+
+## Trade-off conhecido (aceito v1)
+Cada retry abandona o rascunho parcial → **rascunhos órfãos acumulam** na Sayerlack. ⚠️ NÃO totalmente inofensivos (Codex P2): humano pode efetivar um órfão depois. v1 aceita (rascunho ≠ pedido; retry não os retoma); **cleanup de rascunhos órfãos = follow-up nomeado**.
+
+## Teste (TDD)
+Helper puro **`src/lib/reposicao/sayerlack-classificacao.ts`** — `classifyEnvelopeStatus({ success, protocolo, protocoloAutoExtraido, efetivarAttempted, erroTipo }) → { status, ok, safeToRetry, needsReconciliation }` — encoda a Camada 1 (B), **espelhada VERBATIM** no `buildEnvelope`. **A Camada 2 do Deno reusa o MESMO helper de verdade** (Deno importa) pra `decidirStatusDeno(envStatus, efetivarAttempted)` (endurece L1978 + catch-all desconhecido (E)) — **Codex v2 P2: testar a máquina Deno, não só `deno check`**. Casos:
+1. timeout pré-Efetivar + efetivarAttempted=false → `erro_retentavel` (355).
+2. clicou + sem sinal (efetivarAttempted=true) → `indeterminado`.
+3. **clicou + requestSent=false** (efetivarAttempted=true) → `indeterminado` (P1.1).
+4. efetivarAttempted=**undefined** → `indeterminado` (undefined-safety).
+5. success + protocolo → `sucesso_portal`; success sem protocolo → `aceito_portal_sem_protocolo`.
+6. SKU_NOT_FOUND (efetivarAttempted=false) → `erro_nao_retentavel`.
+7. protocoloAutoExtraido + efetivarAttempted=true → `sucesso_portal`; protocoloAutoExtraido + efetivarAttempted=false → NÃO-sucesso (cai em erro_retentavel).
+8. GRUPO_LEADTIME_MISMATCH → `erro_nao_retentavel`.
+9. Deno: envStatus='erro_retentavel' + efetivarAttempted=true → endurece p/ indeterminado; efetivarAttempted=false → mantém retentável.
+10. Deno: envStatus desconhecido → indeterminado (fail-closed).
+
+## Não-objetivos (v1)
+- Reclassificar `bodySuccessFalse` (portal rejeitou pós-submit) — fica `indeterminado`.
+- Cleanup de rascunhos órfãos (follow-up nomeado).
+- Mitigação "retry do passo que trava" (ortogonal).
+
+## Deploy
+Edge **verbatim da main** via chat do Lovable. Sem migration, sem mudança de schema. **Gate final: Codex adversarial no CÓDIGO** (helper + 2 camadas do edge) + **confirmação empírica do founder** (rascunho ≠ PO) antes do deploy.

--- a/src/lib/reposicao/sayerlack-classificacao.test.ts
+++ b/src/lib/reposicao/sayerlack-classificacao.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect } from "vitest";
+import {
+  classifyEnvelopeStatus,
+  decidirStatusDeno,
+  type ClassifyInput,
+} from "./sayerlack-classificacao";
+
+const base: ClassifyInput = {
+  success: false,
+  protocolo: null,
+  protocoloAutoExtraido: false,
+  efetivarAttempted: false,
+  erroTipo: null,
+};
+
+describe("classifyEnvelopeStatus — Camada 1 (Browserless)", () => {
+  it("caso 355: timeout PRÉ-Efetivar (efetivarAttempted=false) → erro_retentavel (auto-retry)", () => {
+    const r = classifyEnvelopeStatus({ ...base, efetivarAttempted: false, erroTipo: "EXCEPTION" });
+    expect(r.status).toBe("erro_retentavel");
+    expect(r.safeToRetry).toBe(true);
+    expect(r.needsReconciliation).toBe(false);
+    expect(r.ok).toBe(false);
+  });
+
+  it("clicou Efetivar + sem sinal (efetivarAttempted=true) → indeterminado", () => {
+    const r = classifyEnvelopeStatus({ ...base, efetivarAttempted: true, erroTipo: "EXCEPTION" });
+    expect(r.status).toBe("indeterminado_requer_conciliacao");
+    expect(r.safeToRetry).toBe(false);
+    expect(r.needsReconciliation).toBe(true);
+  });
+
+  it("P1.1 Codex: clicou Efetivar mas recorder perdeu o POST (efetivarAttempted=true) → indeterminado, NÃO retentável", () => {
+    // requestSent não existe mais na decisão; o que importa é efetivarAttempted.
+    const r = classifyEnvelopeStatus({ ...base, efetivarAttempted: true, erroTipo: "EXCEPTION" });
+    expect(r.status).toBe("indeterminado_requer_conciliacao");
+    expect(r.safeToRetry).toBe(false);
+  });
+
+  it("undefined-safety: efetivarAttempted ausente (undefined) → indeterminado (fail-closed), nunca retentável", () => {
+    const r = classifyEnvelopeStatus({ ...base, efetivarAttempted: undefined, erroTipo: "EXCEPTION" });
+    expect(r.status).toBe("indeterminado_requer_conciliacao");
+    expect(r.safeToRetry).toBe(false);
+  });
+
+  it("success=true com protocolo → sucesso_portal", () => {
+    const r = classifyEnvelopeStatus({ ...base, success: true, protocolo: "123456", efetivarAttempted: true });
+    expect(r.status).toBe("sucesso_portal");
+    expect(r.ok).toBe(true);
+    expect(r.needsReconciliation).toBe(false);
+  });
+
+  it("success=true SEM protocolo → aceito_portal_sem_protocolo (precisa conciliar)", () => {
+    const r = classifyEnvelopeStatus({ ...base, success: true, protocolo: null, efetivarAttempted: true });
+    expect(r.status).toBe("aceito_portal_sem_protocolo");
+    expect(r.ok).toBe(true);
+    expect(r.needsReconciliation).toBe(true);
+  });
+
+  it("P1.3 Codex: protocolo auto-extraído + efetivarAttempted=true → sucesso_portal", () => {
+    const r = classifyEnvelopeStatus({
+      ...base,
+      protocolo: "999",
+      protocoloAutoExtraido: true,
+      efetivarAttempted: true,
+    });
+    expect(r.status).toBe("sucesso_portal");
+    expect(r.ok).toBe(true);
+  });
+
+  it("P1.3 Codex: protocolo auto-extraído de resposta de RASCUNHO (efetivarAttempted=false) → NÃO vira sucesso (cai em erro_retentavel)", () => {
+    const r = classifyEnvelopeStatus({
+      ...base,
+      protocolo: "999",
+      protocoloAutoExtraido: true,
+      efetivarAttempted: false,
+    });
+    expect(r.status).toBe("erro_retentavel");
+    expect(r.ok).toBe(false);
+  });
+
+  it("P1.3 borda: protocolo auto-extraído MAS efetivarAttempted undefined → NÃO sucesso → indeterminado (fail-closed)", () => {
+    const r = classifyEnvelopeStatus({
+      ...base,
+      protocolo: "999",
+      protocoloAutoExtraido: true,
+      efetivarAttempted: undefined,
+    });
+    expect(r.status).toBe("indeterminado_requer_conciliacao");
+    expect(r.ok).toBe(false);
+  });
+
+  it("SKU_NOT_FOUND (erro lógico pré-submit) → erro_nao_retentavel, mesmo com efetivarAttempted=false", () => {
+    const r = classifyEnvelopeStatus({ ...base, erroTipo: "SKU_NOT_FOUND", efetivarAttempted: false });
+    expect(r.status).toBe("erro_nao_retentavel");
+    expect(r.safeToRetry).toBe(false);
+    expect(r.needsReconciliation).toBe(false);
+  });
+
+  it("GRUPO_LEADTIME_MISMATCH → erro_nao_retentavel", () => {
+    const r = classifyEnvelopeStatus({ ...base, erroTipo: "GRUPO_LEADTIME_MISMATCH", efetivarAttempted: false });
+    expect(r.status).toBe("erro_nao_retentavel");
+  });
+
+  it("LOGIN_FAILED / CLIENTE_NOT_FOUND → erro_nao_retentavel", () => {
+    expect(classifyEnvelopeStatus({ ...base, erroTipo: "LOGIN_FAILED" }).status).toBe("erro_nao_retentavel");
+    expect(classifyEnvelopeStatus({ ...base, erroTipo: "CLIENTE_NOT_FOUND" }).status).toBe("erro_nao_retentavel");
+  });
+
+  it("erro genérico (NAVIGATION_FAILED) pré-rascunho, efetivarAttempted=false → erro_retentavel", () => {
+    const r = classifyEnvelopeStatus({ ...base, erroTipo: "NAVIGATION_FAILED", efetivarAttempted: false });
+    expect(r.status).toBe("erro_retentavel");
+    expect(r.safeToRetry).toBe(true);
+  });
+
+  it("erro lógico pré-submit precede a checagem de efetivarAttempted (ordem importa)", () => {
+    // Mesmo se por algum motivo efetivarAttempted=true, um erro lógico determinístico continua não-retentável.
+    const r = classifyEnvelopeStatus({ ...base, erroTipo: "SKU_NOT_FOUND", efetivarAttempted: true });
+    expect(r.status).toBe("erro_nao_retentavel");
+  });
+});
+
+describe("decidirStatusDeno — Camada 2 (rede de segurança Deno)", () => {
+  it("erro_retentavel + efetivarAttempted=true → ENDURECE para indeterminado", () => {
+    expect(decidirStatusDeno("erro_retentavel", true)).toBe("indeterminado_requer_conciliacao");
+  });
+
+  it("erro_retentavel + efetivarAttempted=false EXPLÍCITO → mantém erro_retentavel (auto-retry)", () => {
+    expect(decidirStatusDeno("erro_retentavel", false)).toBe("erro_retentavel");
+  });
+
+  it("erro_retentavel + efetivarAttempted=undefined → ENDURECE para indeterminado (undefined-safety)", () => {
+    expect(decidirStatusDeno("erro_retentavel", undefined)).toBe("indeterminado_requer_conciliacao");
+  });
+
+  it("P1.2 Codex: status DESCONHECIDO → indeterminado (fail-closed), nunca passa adiante como retentável", () => {
+    expect(decidirStatusDeno("estado_invemtado", false)).toBe("indeterminado_requer_conciliacao");
+    expect(decidirStatusDeno("", false)).toBe("indeterminado_requer_conciliacao");
+  });
+
+  it("NUNCA rebaixa: indeterminado/sucesso/aceito/erro_nao_retentavel passam intactos", () => {
+    expect(decidirStatusDeno("indeterminado_requer_conciliacao", false)).toBe("indeterminado_requer_conciliacao");
+    expect(decidirStatusDeno("indeterminado_requer_conciliacao", true)).toBe("indeterminado_requer_conciliacao");
+    expect(decidirStatusDeno("sucesso_portal", true)).toBe("sucesso_portal");
+    expect(decidirStatusDeno("aceito_portal_sem_protocolo", true)).toBe("aceito_portal_sem_protocolo");
+    expect(decidirStatusDeno("erro_nao_retentavel", false)).toBe("erro_nao_retentavel");
+  });
+});
+
+describe("consistência entre as duas camadas", () => {
+  it("355 ponta-a-ponta: Camada 1 → erro_retentavel; Camada 2 (efetivarAttempted=false) mantém retentável", () => {
+    const c1 = classifyEnvelopeStatus({ ...base, efetivarAttempted: false, erroTipo: "EXCEPTION" });
+    expect(c1.status).toBe("erro_retentavel");
+    expect(decidirStatusDeno(c1.status, false)).toBe("erro_retentavel");
+  });
+
+  it("clicou ponta-a-ponta: Camada 1 → indeterminado; Camada 2 não afrouxa", () => {
+    const c1 = classifyEnvelopeStatus({ ...base, efetivarAttempted: true, erroTipo: "EXCEPTION" });
+    expect(c1.status).toBe("indeterminado_requer_conciliacao");
+    expect(decidirStatusDeno(c1.status, true)).toBe("indeterminado_requer_conciliacao");
+  });
+});

--- a/src/lib/reposicao/sayerlack-classificacao.ts
+++ b/src/lib/reposicao/sayerlack-classificacao.ts
@@ -1,0 +1,118 @@
+// Classificação do resultado do envio ao portal Sayerlack (money-path).
+//
+// ⚠️ ESPELHO VERBATIM dentro de `supabase/functions/enviar-pedido-portal-sayerlack/index.ts`
+// (o edge não importa de src/ — Deno). Manter as DUAS cópias em sincronia:
+//   - `classifyEnvelopeStatus` → inlinado no `buildEnvelope` (roda no Browserless).
+//   - `decidirStatusDeno`      → inlinado na máquina de estados do Deno (~L1978).
+//
+// Spec: docs/superpowers/specs/2026-06-15-sayerlack-reclassificacao-finalizacao-design.md
+//
+// INVARIANTE-MESTRA: `erro_retentavel` faz o motor AUTO-RE-DISPARAR. Se um pedido
+// PODE ter sido colocado e cair em retentável → DUPLICATA no fornecedor. Só relaxar
+// para `erro_retentavel` quando PROVADAMENTE não houve pedido — i.e. o clique de
+// "Efetivar Pedido" (#btnSalvarNovoPedido) NUNCA ocorreu (`efetivarAttempted === false`
+// EXPLÍCITO). Desconhecido / `undefined` / clicou → `indeterminado` (fail-closed).
+
+export type EnvelopeStatus =
+  | "sucesso_portal"
+  | "aceito_portal_sem_protocolo"
+  | "indeterminado_requer_conciliacao"
+  | "erro_nao_retentavel"
+  | "erro_retentavel";
+
+export interface ClassifyInput {
+  /** O script do portal determinou sucesso explícito (data.success === true). */
+  success: boolean;
+  /** Protocolo do pedido (número), se capturado. */
+  protocolo: string | null;
+  /** Um protocolo foi auto-extraído do recorder (recuperação PR1.5). */
+  protocoloAutoExtraido: boolean;
+  /**
+   * O clique em "Efetivar Pedido" (#btnSalvarNovoPedido) foi disparado.
+   * É o ÚNICO ponto que coloca o pedido na Sayerlack. `false` EXPLÍCITO = prova
+   * de que nenhum pedido foi colocado. `undefined` (envelope velho/parcial) =
+   * desconhecido → tratado como NÃO-prova (fail-closed → indeterminado).
+   */
+  efetivarAttempted: boolean | undefined;
+  /** erroTipo do envelope (EXCEPTION, LOGIN_FAILED, etc.) ou null. */
+  erroTipo: string | null;
+}
+
+export interface ClassifyResult {
+  status: EnvelopeStatus;
+  ok: boolean;
+  safeToRetry: boolean;
+  needsReconciliation: boolean;
+}
+
+// Erros lógicos exclusivamente PRÉ-clique: retentar não resolve (de-para/login/grupo).
+// Todos ocorrem antes do "Efetivar" → nunca implicam pedido colocado.
+const ERROS_LOGICOS_PRE_SUBMIT: ReadonlySet<string> = new Set([
+  "LOGIN_FAILED",
+  "CLIENTE_NOT_FOUND",
+  "SKU_NOT_FOUND",
+  "GRUPO_LEADTIME_MISMATCH",
+]);
+
+const STATUS_CONHECIDOS: ReadonlySet<string> = new Set<EnvelopeStatus>([
+  "sucesso_portal",
+  "aceito_portal_sem_protocolo",
+  "indeterminado_requer_conciliacao",
+  "erro_nao_retentavel",
+  "erro_retentavel",
+]);
+
+/**
+ * Camada 1 — classificação dentro do Browserless (espelha o `buildEnvelope`).
+ * A decisão de FALHA é PURA por `efetivarAttempted` — `requestSent` NÃO entra
+ * (era proxy ruim: falso-perigo no rascunho + falso-seguro quando o recorder
+ * perde o POST de finalização).
+ */
+export function classifyEnvelopeStatus(input: ClassifyInput): ClassifyResult {
+  const { success, protocolo, protocoloAutoExtraido, efetivarAttempted, erroTipo } = input;
+
+  // 1. Sucesso explícito do script (só setado pós-clique pela lógica de submit).
+  if (success === true) {
+    const status: EnvelopeStatus = protocolo ? "sucesso_portal" : "aceito_portal_sem_protocolo";
+    return { status, ok: true, safeToRetry: false, needsReconciliation: !protocolo };
+  }
+
+  // 2. Recuperação PR1.5: protocolo auto-extraído SÓ vira sucesso se o Efetivar
+  //    foi REALMENTE clicado. Protocolo de resposta de rascunho é pré-clique
+  //    (efetivarAttempted=false) → este ramo é pulado → não vira falso-sucesso.
+  if (protocoloAutoExtraido && efetivarAttempted === true) {
+    return { status: "sucesso_portal", ok: true, safeToRetry: false, needsReconciliation: false };
+  }
+
+  // 3. Falha.
+  if (erroTipo !== null && ERROS_LOGICOS_PRE_SUBMIT.has(erroTipo)) {
+    return { status: "erro_nao_retentavel", ok: false, safeToRetry: false, needsReconciliation: false };
+  }
+  if (efetivarAttempted === false) {
+    // Provadamente sem clique de Efetivar → nenhum pedido colocado → seguro retentar.
+    return { status: "erro_retentavel", ok: false, safeToRetry: true, needsReconciliation: false };
+  }
+  // efetivarAttempted === true (clicou → pode ter colocado) OU undefined (desconhecido).
+  return { status: "indeterminado_requer_conciliacao", ok: false, safeToRetry: false, needsReconciliation: true };
+}
+
+/**
+ * Camada 2 — rede de segurança do Deno sobre o `status` do envelope.
+ * Só ENDURECE, nunca afrouxa:
+ *   - status desconhecido → indeterminado (fail-closed);
+ *   - `erro_retentavel` só sobrevive com `efetivarAttempted === false` EXPLÍCITO;
+ *     true/undefined → endurece para indeterminado.
+ * NUNCA rebaixa indeterminado/erro_nao_retentavel/sucesso.
+ */
+export function decidirStatusDeno(
+  envStatus: string,
+  efetivarAttempted: boolean | undefined,
+): EnvelopeStatus {
+  if (!STATUS_CONHECIDOS.has(envStatus)) {
+    return "indeterminado_requer_conciliacao";
+  }
+  if (envStatus === "erro_retentavel" && efetivarAttempted !== false) {
+    return "indeterminado_requer_conciliacao";
+  }
+  return envStatus as EnvelopeStatus;
+}

--- a/supabase/functions/enviar-pedido-portal-sayerlack/index.ts
+++ b/supabase/functions/enviar-pedido-portal-sayerlack/index.ts
@@ -42,6 +42,14 @@ export default async ({ page, context }) => {
   // nunca lançar ReferenceError (que mascararia o envelope estruturado).
   let preLoginScreenshot = null;
 
+  // Flag de finalização (money-path). Setado IMEDIATAMENTE ANTES do clique em
+  // "Efetivar Pedido" (#btnSalvarNovoPedido) — o ÚNICO ponto que coloca o pedido
+  // na Sayerlack. Em closure (fora do runFlow) p/ sobreviver aos try/catch e ser
+  // lido pelo buildEnvelope. false EXPLÍCITO = prova de que nenhum pedido foi
+  // colocado → falha vira erro_retentavel; true/desconhecido → indeterminado.
+  // Ver src/lib/reposicao/sayerlack-classificacao.ts (espelho).
+  let efetivarAttempted = false;
+
   // === PR2: Budget management (deadline global) ===
   // O Browserless mata a função em ~60s. Em vez de esperar isso acontecer com
   // um waitFor pendurado (cenário do bug original — "Waiting failed: 7000ms"
@@ -101,9 +109,10 @@ export default async ({ page, context }) => {
 
   // === PR1: Network Recorder ===
   // Listener global armado ANTES de qualquer navegação. Captura todo POST que
-  // bate em endpoints suspeitos de efetivação. É a fonte primária de evidência
-  // para classificação: se um POST saiu, o pedido NUNCA é tratado como
-  // retentável — vai para conciliação.
+  // bate em endpoints suspeitos de efetivação (campo requestSent). ATENCAO:
+  // requestSent hoje é só EVIDENCIA/log — NAO mais a regra de classificação. A
+  // regra usa efetivarAttempted (o clique do Efetivar); ver buildEnvelope +
+  // src/lib/reposicao/sayerlack-classificacao.ts.
   const installOrderNetworkRecorder = (pg) => {
     const SUSPECT_RE = /pedido|efetivar|salvar|criar|order|novo[-_]?pedido/i;
     const events = [];
@@ -291,14 +300,14 @@ export default async ({ page, context }) => {
 
   // === PR1: Envelope estruturado ===
   // Traduz o resultado bruto do runFlow (legado: { data: {...} }) + a evidência
-  // do recorder na máquina de estados. Regra de ouro: requestSent === true
-  // jamais resulta em estado retentável.
+  // do recorder na máquina de estados. Regra de ouro (efetivarAttempted): só
+  // relaxa pra retentável quando o clique do Efetivar NAO ocorreu
+  // (efetivarAttempted === false). Ver src/lib/reposicao/sayerlack-classificacao.ts.
   const buildEnvelope = (raw, evidence) => {
     const elapsedMs = Date.now() - t0;
     const data = (raw && raw.data) ? raw.data : {};
     const screenshot = raw ? (raw.screenshot || null) : null;
     const preLogin = raw ? (raw.preLoginScreenshot || null) : null;
-    const requestSent = !!(evidence && evidence.requestSent);
     let protocolo = data.protocolo || null;
 
     // PR1.5: se a runFlow não capturou protocolo, tenta extrair do recorder.
@@ -311,47 +320,51 @@ export default async ({ page, context }) => {
       }
     }
 
+    // ESPELHO VERBATIM de classifyEnvelopeStatus (src/lib/reposicao/sayerlack-classificacao.ts).
+    // Decisão de FALHA é PURA por efetivarAttempted (closure); requestSent NÃO entra
+    // (era proxy ruim: falso-perigo no rascunho + falso-seguro quando o recorder perde
+    // o POST de finalização). Manter as duas cópias em sincronia.
     let status;
     let ok;
     let safeToRetry;
     let needsReconciliation;
+
+    const tipo = data.erroTipo || 'UNKNOWN';
+    const erroLogicoPreSubmit =
+      tipo === 'LOGIN_FAILED' || tipo === 'CLIENTE_NOT_FOUND' || tipo === 'SKU_NOT_FOUND'
+      || tipo === 'GRUPO_LEADTIME_MISMATCH';
 
     if (data.success === true) {
       ok = true;
       status = protocolo ? 'sucesso_portal' : 'aceito_portal_sem_protocolo';
       safeToRetry = false;
       needsReconciliation = !protocolo;
-    } else if (protocoloAutoExtraido && requestSent) {
-      // PR1.5: recuperação automática. O script morreu (timeout do Browserless)
-      // mas o portal já respondeu OK ao POST e conseguimos extrair o protocolo
-      // do corpo. Trata como sucesso completo.
+    } else if (protocoloAutoExtraido && efetivarAttempted === true) {
+      // PR1.5: protocolo auto-extraído SÓ vira sucesso se o Efetivar foi REALMENTE
+      // clicado. Protocolo de resposta de rascunho é pré-clique (efetivarAttempted
+      // false) → este ramo é pulado → não vira falso-sucesso.
       ok = true;
       status = 'sucesso_portal';
       safeToRetry = false;
       needsReconciliation = false;
-    } else {
+    } else if (erroLogicoPreSubmit) {
+      // Erro lógico pré-submit (login/cliente/sku/grupo) — retentar não adianta.
       ok = false;
-      const tipo = data.erroTipo || 'UNKNOWN';
-      const erroLogicoPreSubmit =
-        tipo === 'LOGIN_FAILED' || tipo === 'CLIENTE_NOT_FOUND' || tipo === 'SKU_NOT_FOUND'
-        || tipo === 'GRUPO_LEADTIME_MISMATCH';
-      if (requestSent) {
-        // Houve POST: independente do tipo de erro, só conciliação resolve.
-        status = 'indeterminado_requer_conciliacao';
-        safeToRetry = false;
-        needsReconciliation = true;
-      } else if (erroLogicoPreSubmit) {
-        // Erro lógico antes de qualquer submit — retentar não adianta.
-        status = 'erro_nao_retentavel';
-        safeToRetry = false;
-        needsReconciliation = false;
-      } else {
-        // NAVIGATION_FAILED / INCLUIR_ITEM_NOT_FOUND / EXCEPTION (inclui o
-        // timeout do Browserless) / UNKNOWN, sem POST capturado.
-        status = 'erro_retentavel';
-        safeToRetry = true;
-        needsReconciliation = false;
-      }
+      status = 'erro_nao_retentavel';
+      safeToRetry = false;
+      needsReconciliation = false;
+    } else if (efetivarAttempted === false) {
+      // Clique de Efetivar NUNCA ocorreu → nenhum pedido colocado → seguro retentar.
+      ok = false;
+      status = 'erro_retentavel';
+      safeToRetry = true;
+      needsReconciliation = false;
+    } else {
+      // efetivarAttempted true (clicou → pode ter colocado) OU desconhecido.
+      ok = false;
+      status = 'indeterminado_requer_conciliacao';
+      safeToRetry = false;
+      needsReconciliation = true;
     }
 
     // Mantém a forma externa { data, type, screenshot, preLoginScreenshot } que
@@ -370,6 +383,7 @@ export default async ({ page, context }) => {
         safeToRetry,
         needsReconciliation,
         evidence: {
+          efetivarAttempted,
           requestSent: evidence ? evidence.requestSent : false,
           requestCount: evidence ? evidence.requestCount : 0,
           responseCount: evidence ? evidence.responseCount : 0,
@@ -1083,6 +1097,11 @@ export default async ({ page, context }) => {
     const postSubmitBudget = budgetFor('submit-pedido', 60_000, { reserveSubmit: false, minMs: 2_000 });
     const signalPromise = waitForPositiveSubmitSignal(page, postSubmitBudget);
 
+    // Fronteira money-path: a partir DAQUI o pedido pode ter sido colocado na
+    // Sayerlack. Setar ANTES do click (não depois): se o próprio click pendurar
+    // ou lançar, efetivarAttempted já é true → classificação cai em indeterminado
+    // (conservador), nunca em retentável.
+    efetivarAttempted = true;
     await page.click('#btnSalvarNovoPedido');
     trace.push({ step: 'efetivar_clicked', t: Date.now() - t0, postSubmitBudget, remaining: remainingMs() });
 
@@ -1193,16 +1212,16 @@ export default async ({ page, context }) => {
     const screenshot = await page.screenshot({ type: 'jpeg', quality: 70, fullPage: false, encoding: 'base64' }).catch(() => null);
 
     // Decisão final (alinhada com a cascata de classifySubmitResult do doc):
-    //  - Portal devolveu success:false explícito → falha; buildEnvelope vê
-    //    requestSent e classifica como indeterminado (operador concilia).
+    //  - Portal devolveu success:false explícito → falha; aqui o Efetivar JÁ foi
+    //    clicado (efetivarAttempted=true) → buildEnvelope classifica indeterminado.
     //  - Sinal positivo (network/banner/modal) OU protocolo extraído de
     //    qualquer fonte → success:true; buildEnvelope mapeia para
     //    sucesso_portal (com protocolo) ou aceito_portal_sem_protocolo.
     //  - firstSignal === 'url' (só URL change, sem nada mais) → success:false
     //    com erroTipo AMBIGUO_URL_ONLY → indeterminado.
     //  - firstSignal === 'none' → success:false com erroTipo NO_POSITIVE_SIGNAL
-    //    → buildEnvelope decide via requestSent (POST capturado → indeterminado;
-    //    sem POST → erro_retentavel).
+    //    → buildEnvelope decide via efetivarAttempted (aqui clicou=true →
+    //    indeterminado; NUNCA retentável após o clique do Efetivar).
     if (bodySuccessFalse) {
       return {
         data: {
@@ -1862,7 +1881,11 @@ async function processarPedido(
   const screenshotB64: string | null = bResp?.screenshot ?? null;
   const preLoginScreenshotB64: string | null = bResp?.preLoginScreenshot ?? null;
   const evidence: Record<string, unknown> = (envelope?.evidence ?? {}) as Record<string, unknown>;
-  const requestSent = evidence?.requestSent === true;
+  // Sinal money-path: o clique de "Efetivar Pedido" foi disparado? `false`
+  // EXPLÍCITO = prova de que nenhum pedido foi colocado; `undefined` (envelope
+  // velho/parcial) = desconhecido → fail-closed (indeterminado). Substitui o
+  // antigo `requestSent` (proxy ruim — ver sayerlack-classificacao.ts).
+  const efetivarAttempted = evidence?.efetivarAttempted as boolean | undefined;
 
   // Upload de screenshots (instrumentacao — comportamento inalterado)
   if (screenshotB64) {
@@ -1952,16 +1975,13 @@ async function processarPedido(
         erro: `Browserless sem resposta (ambiguo): ${erroMsg}`,
       });
     }
-    // Status HTTP de erro do Browserless (>=500 / 0 / 408): a camada HTTP
-    // respondeu erro, o script nao chegou a submeter. Retentavel.
-    const esgotado = novasTentativas >= MAX_TENTATIVAS;
-    return await aplicarTransicao(
-      esgotado ? "erro_nao_retentavel" : "erro_retentavel",
-      {
-        erro: erroMsg,
-        proximoRetryEm: esgotado ? null : new Date(Date.now() + 15 * 60 * 1000).toISOString(),
-      },
-    );
+    // Status HTTP de erro do Browserless (>=500 / 0 / 408): SEM envelope
+    // estruturado, NAO da pra provar que o script nao clicou "Efetivar" antes do
+    // erro HTTP. Estado desconhecido → conciliacao (money-path: nunca retentar um
+    // pedido talvez-colocado; tempo decorrido nao prova ausencia de clique).
+    return await aplicarTransicao("indeterminado_requer_conciliacao", {
+      erro: `Browserless erro HTTP sem envelope (ambiguo): ${erroMsg}`,
+    });
   }
 
   // HTTP 200 mas sem envelope estruturado inteligivel — nao da pra descartar
@@ -1972,11 +1992,21 @@ async function processarPedido(
     });
   }
 
-  // Rede de seguranca: se o recorder viu um POST sair, o pedido NUNCA pode
-  // terminar em estado retentavel, ainda que o envelope diga o contrario.
+  // Rede de seguranca (efetivarAttempted-aware) — ESPELHO de decidirStatusDeno
+  // (src/lib/reposicao/sayerlack-classificacao.ts). So' ENDURECE, nunca afrouxa.
+  const STATUS_CONHECIDOS = [
+    "sucesso_portal", "aceito_portal_sem_protocolo", "indeterminado_requer_conciliacao",
+    "erro_nao_retentavel", "erro_retentavel",
+  ];
   let envStatus: string = envelope.status;
-  if (requestSent && envStatus === "erro_retentavel") {
-    console.warn(`[envio-portal] Pedido #${pedido.id}: requestSent=true mas envelope=erro_retentavel — forcando indeterminado`);
+  if (STATUS_CONHECIDOS.indexOf(envStatus) === -1) {
+    // Status desconhecido (envelope corrompido / formato futuro) → fail-closed.
+    console.warn(`[envio-portal] Pedido #${pedido.id}: envelope.status desconhecido ("${envStatus}") — forcando indeterminado`);
+    envStatus = "indeterminado_requer_conciliacao";
+  } else if (envStatus === "erro_retentavel" && efetivarAttempted !== false) {
+    // So' mantem retentavel com efetivarAttempted EXPLICITO false (prova de que o
+    // Efetivar nunca foi clicado). true/undefined → conciliacao (pode ter colocado).
+    console.warn(`[envio-portal] Pedido #${pedido.id}: erro_retentavel mas efetivarAttempted!==false (${String(efetivarAttempted)}) — forcando indeterminado`);
     envStatus = "indeterminado_requer_conciliacao";
   }
 
@@ -2058,7 +2088,9 @@ async function processarPedido(
     return r;
   }
 
-  // erro_retentavel (default): POST comprovadamente nunca saiu, seguro retentar.
+  // erro_retentavel (default): só chega aqui com efetivarAttempted === false
+  // (Efetivar nunca clicado → nenhum pedido colocado), seguro retentar. Status
+  // desconhecido já foi endurecido pra indeterminado na rede de segurança acima.
   const erroMsg: string = evidence?.erro ?? "Falha do automador (retentavel)";
   const esgotado = novasTentativas >= MAX_TENTATIVAS;
   return await aplicarTransicao(
@@ -2122,7 +2154,14 @@ async function runWatchdog(supabase: SupabaseClient, minutos = 5) {
       status_envio_portal: "indeterminado_requer_conciliacao",
       portal_erro: erroMsg,
       portal_proximo_retry_em: null,
-    }).eq("id", p.id);
+      // Sobrescreve evidencia OBSOLETA: a tentativa ANTERIOR pode ter gravado
+      // efetivarAttempted=false; esta interrupcao e' de uma tentativa que talvez
+      // efetivou → marca desconhecido (null) pra nenhum leitor concluir "sem
+      // pedido" e re-enviar (duplicata).
+      portal_resposta: { phase: "watchdog", motivo: "travado_em_enviando_portal", efetivarAttempted: null },
+    })
+      .eq("id", p.id)
+      .eq("status_envio_portal", "enviando_portal"); // condicional: nao pisa conclusao concorrente
     await gravarTentativa(supabase, p.id, {
       iniciadoEm: agora,
       statusResultado: "indeterminado_requer_conciliacao",


### PR DESCRIPTION
…vel (não indeterminado)

Reduz reconciliação manual no portal Sayerlack: falha da automação Browserless ANTES do clique de "Efetivar Pedido" (efetivarAttempted===false) → erro_retentavel (auto-retry pelo motor sayerlack_retry_orfaos) em vez de indeterminado (manual). NUNCA torna retentável um pedido que pode ter sido colocado — a fronteira é o clique único #btnSalvarNovoPedido. Origem: pedido 355 (hang transitório no item 9, nunca finalizou, virava ação-humana à toa).

- Helper puro TDD src/lib/reposicao/sayerlack-classificacao.ts (classifyEnvelopeStatus
  + decidirStatusDeno; 21 testes) espelhado VERBATIM nas 2 camadas do edge (buildEnvelope no Browserless + máquina de estados do Deno).
- requestSent (proxy ruim) → efetivarAttempted como sinal; undefined-safe (fail-closed).
- 408/5xx sem envelope → indeterminado; status de envelope desconhecido → indeterminado.
- watchdog: stub anti-evidência-obsoleta + UPDATE condicional (não pisa conclusão concorrente).

Gate: Codex xhigh — 2 BLOQUEIOS na spec incorporados; LIBERAR no código (zero P1/P2, paridade executável helper×edge 168/168). typecheck · lint 0-err · suíte 3444 · TS-parse do edge OK.

⚠️ Requer deploy do edge verbatim via chat do Lovable + confirmação empírica do founder (rascunho abandonado / "Salvar Proposta" ≠ PO na Sayerlack). Sem migration, sem schema.

Spec: docs/superpowers/specs/2026-06-15-sayerlack-reclassificacao-finalizacao-design.md