### PR TITLE
perf(tint): índices da promoção (aplicados) + plano de reescrita set-based

### DIFF
--- a/docs/superpowers/plans/2026-06-15-tint-promote-set-based.md
+++ b/docs/superpowers/plans/2026-06-15-tint-promote-set-based.md
@@ -1,0 +1,66 @@
+# Plano — reescrever a promoção tintométrica para set-based (eliminar timeout/lock no bootstrap)
+
+## Contexto / diagnóstico (15/06, flip ao vivo)
+- Sync validado 100% (corantes 14/14, cores 8238, bases 56, emb 4, produtos 20, regra de 3 exata, blast 3,2%).
+- Flip pra `automatic_primary` revelou bug de PERFORMANCE na `tint_promote_sync_run`:
+  1. 1ª manifestação: `statement timeout` (57014) → **resolvido em parte** com índices
+     (`20260615140000_tint_promote_indices_timeout.sql`: idx em `tint_staging_formula_itens(staging_formula_id)`
+     etc. + `ALTER FUNCTION ... statement_timeout='300s'`). Os índices FICAM (ajudam o delta também).
+  2. 2ª manifestação (pós-índices): `lock timeout` + `upstream request timeout`. Causa: a promoção
+     ainda demora > timeout do GATEWAY (~30-60s) no full re-scan; o conector dá retry; as invocações
+     concorrentes brigam pelo `pg_advisory_xact_lock` → lock timeout em cascata → sobrecarga.
+- **Estado estabilizado**: revertido pra `shadow_mode` (travado no banco) + 251 cores reativadas
+  (`UPDATE tint_formulas SET desativada_em=NULL`). Oficial = CSV puro (481.721 ativas). Venda 100% normal.
+  `tint_formulas_backup_preflip` existe como rede.
+
+## Causa-raiz
+`tint_promote_sync_run` seção E2/E3: `FOR r IN _formulas_latest LOOP` (cada fórmula) → inner
+`FOR v_emb_id,v_fator IN (embalagens vendáveis) LOOP` → por iteração: lookup produto/base, ensure
+subcoleção, `tint_calc_preco_final` (subqueries), upsert `tint_formulas`, delete+insert
+`tint_formula_itens`. É O(fórmulas × embalagens) PROCEDURAL. Pro bootstrap (~121k fontes → ~481k
+expansões) é inviável dentro de um request. Foi desenhada pra DELTAS pequenos (poucos pares/cores).
+
+## Solução
+Trocar o motor da seção E2/E3 por **set-based** (mantendo TODA a regra de negócio idêntica):
+1. `_expand` = `_formulas_latest` ⨝ `tint_skus` (vendáveis: `volume_ml>0`) ⨝ `tint_embalagens`
+   → 1 linha por (fórmula, embalagem destino) com `fator = e.volume_ml / volume_final_ml`. Set-based.
+2. Resolver FK produto/base via join (não SELECT por linha). Pares sem produto/base/zero-vendáveis/
+   volume<=0 → logar em `tint_sync_errors` em massa (INSERT...SELECT dos descartados) — preserva a
+   degradação honesta atual.
+3. Preço set-based: `tint_calc_preco_final` vira um CTE agregado (base × imposto × margem + Σ
+   corantes ⨝ staging por fator). **NULL-honesto preservado**: faltou custo/precos_base → NULL
+   (nunca 0). Hoje `precos_base` vazio → preço NULL em tudo (correto; venda usa Omie).
+4. Upsert `tint_formulas` em massa: `INSERT...SELECT FROM _expand ON CONFLICT (chave) DO UPDATE`
+   (mesma uq_tint_formulas_chave; `desativada_em=NULL` reativa).
+5. Itens em massa: após upsert, `DELETE ... WHERE formula_id IN (afetadas)` + `INSERT...SELECT`
+   join `_expand` × `tint_staging_formula_itens` × `tint_corantes` (resolve corante_id). Em massa.
+6. Manter S1 (advisory lock), soft-delete (keys-snapshot) e o E4 (recalc por insumo) — só o motor de
+   fórmulas muda.
+
+## Decisão de arquitetura a confirmar na implementação
+- **Opção A (preferida):** reescrever a seção E2/E3 da própria `tint_promote_sync_run` set-based →
+  cada chamada por lote fica rápida (cabe no gateway) → o flip volta a funcionar pelo fluxo normal.
+- **Opção B (fallback):** função `tint_promote_bootstrap(account,store)` separada (promove TODOS os
+  pares de uma vez, set-based), rodada 1× pelo founder no SQL Editor pra carga inicial; depois o
+  delta diário usa a função atual. Menor risco (não toca o caminho do delta) mas exige passo manual.
+  → Decidir A vs B no início da implementação (provável A, com o oráculo TS atualizado).
+
+## Validação (obrigatória — money-path)
+- Helper TS `src/lib/tint/sync-promote.ts` é o oráculo — manter espelhado.
+- PG17 `db/test-tint-promote.sh` (já existe, 17 grupos C1-C12b): re-rodar + adicionar cenário de
+  VOLUME (centenas de fórmulas × N embalagens) provando que o set-based dá o MESMO resultado do loop
+  (identidade contábil) e roda rápido.
+- Reconciliação: após re-flip, `BLOCO 4` deve mostrar `publicadas_30min` alto + cores novas entrando.
+- Codex adversarial (se cota disponível) no diff SQL antes de aplicar.
+
+## Rollout
+1. Aplicar migration nova (CREATE OR REPLACE da função) no SQL Editor.
+2. `sc stop` → apagar `state.json` → trocar pra `automatic_primary` → `sc start` (full re-scan limpo).
+   Promoção set-based publica em segundos.
+3. `BLOCO 4` confirma. Critério de pronto: altera preço/fórmula no SayerSystem → app reflete ≤15 min.
+4. CSV aposentado.
+
+## Nota
+Esta sessão (15/06) ficou MUITO longa (dia inteiro de flip). A IMPLEMENTAÇÃO da função (money-path)
+deve ser feita com contexto fresco (/compact ou nova sessão) pra evitar erro. Os índices já estão no
+ar; o balcão está seguro em shadow. Sem pressa.

--- a/supabase/migrations/20260615140000_tint_promote_indices_timeout.sql
+++ b/supabase/migrations/20260615140000_tint_promote_indices_timeout.sql
@@ -1,0 +1,39 @@
+-- tint_promote_sync_run estourava o statement_timeout no FULL RE-SCAN inicial
+-- (carga de ~121k fórmulas). Causa: tint_calc_preco_final e o insert de itens
+-- filtram tint_staging_formula_itens por staging_formula_id, mas NÃO havia índice
+-- nessa coluna (a FK não cria índice automaticamente) → full scan de ~732k linhas
+-- por chamada, milhares de vezes por run. Idem nas demais staging filtradas por
+-- chave/sync_run_id. Em shadow_mode a promoção nunca roda, por isso o gargalo
+-- ficou latente até o flip pra automatic_primary.
+--
+-- Fix: índices (zero mudança de lógica — só velocidade) + margem de statement_timeout
+-- na função de promoção (carga inicial é pesada por natureza; deltas diários são leves).
+-- CREATE INDEX IF NOT EXISTS = idempotente. Aplicar com o serviço PARADO (sc stop)
+-- para evitar lock contention com a escrita do conector no staging.
+
+-- ── Índice CRÍTICO: itens da fórmula por staging_formula_id ──────────────────
+CREATE INDEX IF NOT EXISTS idx_tsfi_staging_formula_id
+  ON public.tint_staging_formula_itens (staging_formula_id);
+
+-- ── Corantes por chave (lookup no cálculo de preço) ─────────────────────────
+CREATE INDEX IF NOT EXISTS idx_tsc_acct_corante
+  ON public.tint_staging_corantes (account, id_corante_sayersystem);
+
+-- ── Fórmulas: join por par (produto,base) e filtro por run ──────────────────
+CREATE INDEX IF NOT EXISTS idx_tsf_acct_par
+  ON public.tint_staging_formulas (account, cod_produto, id_base);
+CREATE INDEX IF NOT EXISTS idx_tsf_run
+  ON public.tint_staging_formulas (sync_run_id);
+
+-- ── Demais staging filtradas por sync_run_id (montagem dos _tp_*/_pares) ─────
+CREATE INDEX IF NOT EXISTS idx_tss_run    ON public.tint_staging_skus (sync_run_id);
+CREATE INDEX IF NOT EXISTS idx_tsprod_run ON public.tint_staging_produtos (sync_run_id);
+CREATE INDEX IF NOT EXISTS idx_tsbase_run ON public.tint_staging_bases (sync_run_id);
+CREATE INDEX IF NOT EXISTS idx_tsemb_run  ON public.tint_staging_embalagens (sync_run_id);
+
+-- ── Margem de tempo pra promoção da carga inicial ───────────────────────────
+-- (SECURITY DEFINER; o SET é aplicado ao entrar na função e re-arma o timeout
+--  do statement para este escopo — padrão Supabase para RPC pesada.)
+ALTER FUNCTION public.tint_promote_sync_run(uuid) SET statement_timeout = '300s';
+
+SELECT 'INDICES + TIMEOUT OK' AS status;


### PR DESCRIPTION
Registro do gargalo de performance achado no flip ao vivo (15/06) e do caminho de correção.

- **Migration `20260615140000` (JÁ aplicada em prod):** índices nas tabelas de staging (o crítico: `tint_staging_formula_itens(staging_formula_id)`, que faltava → full scan de 732k por cálculo de preço) + `statement_timeout=300s`. Zero mudança de lógica.
- **Plano de reescrita set-based:** trocar o `FOR LOOP` procedural da seção E2/E3 da `tint_promote_sync_run` por `INSERT...SELECT` em massa — mesma regra de negócio, mas roda em segundos (hoje estoura o gateway no bootstrap de 481k linhas).

**Estado:** balcão seguro (revertido pra shadow_mode + 251 cores reativadas; oficial = CSV puro, venda normal). Sync validado 100%. Falta só o motor de publicação eficiente — implementação numa sessão dedicada (money-path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)