### PR TITLE
feat(telefonia): botão Ligar híbrido — softphone no desktop, discador do aparelho no celular

### DIFF
--- a/src/components/caca/FilaDeCaca.tsx
+++ b/src/components/caca/FilaDeCaca.tsx
@@ -11,7 +11,6 @@ import { useMemo } from 'react';
 import { Link } from 'react-router-dom';
 import {
   MoreHorizontal,
-  Phone,
   UserRound,
   CheckCircle2,
   XCircle,
@@ -30,12 +29,12 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { track } from '@/lib/analytics';
+import { BotaoLigar } from '@/components/call/BotaoLigar';
 import type { CacaCandidatoDisplay } from '@/lib/caca/types';
 import {
   labelSabor,
   faixaConfianca,
   classeSabor,
-  telLink,
   agruparPorDocumento,
 } from '@/lib/caca/apresentacao';
 
@@ -147,7 +146,6 @@ interface CandidatoCardProps {
 function CandidatoCard({ documento, empresasAlvo, display, onOcultar }: CandidatoCardProps) {
   const faixa = faixaConfianca(display.confianca);
   const conf = CONFIANCA_UI[faixa];
-  const tel = telLink(display.telefone);
   const fichaHref = display.clienteUserId
     ? `/admin/customers/${display.clienteUserId}/360`
     : null;
@@ -206,18 +204,12 @@ function CandidatoCard({ documento, empresasAlvo, display, onOcultar }: Candidat
 
       {/* Ações à direita */}
       <div className="shrink-0 flex items-center gap-1">
-        {tel && (
-          <Button
-            asChild
-            size="sm"
-            variant="outline"
-            onClick={() => track('caca.acao', { ...eventoBase(display), cta: 'ligar' })}
-          >
-            <a href={tel} aria-label="Ligar para o cliente">
-              <Phone className="w-3.5 h-3.5 mr-1" />
-              Ligar
-            </a>
-          </Button>
+        {display.telefone && (
+          <BotaoLigar
+            telefone={display.telefone}
+            nomeCliente={nomeExibido}
+            onLigar={() => track('caca.acao', { ...eventoBase(display), cta: 'ligar' })}
+          />
         )}
         {fichaHref && (
           <Button

--- a/src/components/caca/__tests__/FilaDeCaca.test.tsx
+++ b/src/components/caca/__tests__/FilaDeCaca.test.tsx
@@ -18,6 +18,13 @@ import type { CacaCandidatoDisplay } from '@/lib/caca/types';
 
 vi.mock('@/lib/analytics', () => ({ track: vi.fn() }));
 
+// BotaoLigar carrega a árvore de telefonia (softphone WebRTC, lazy) e tem teste
+// dedicado (call/__tests__/BotaoLigar.test.tsx). Stub aqui mantém o foco no
+// FilaDeCaca: o botão "Ligar" só monta quando há telefone (condicionado no call-site).
+vi.mock('@/components/call/BotaoLigar', () => ({
+  BotaoLigar: () => <button type="button">Ligar</button>,
+}));
+
 // ─── Helpers de fixture ────────────────────────────────────────────────────────
 
 function makeDisplay(overrides: {

--- a/src/components/call/BotaoLigar.tsx
+++ b/src/components/call/BotaoLigar.tsx
@@ -1,0 +1,87 @@
+import { Smartphone } from 'lucide-react';
+import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import { useIsTouchDevice } from '@/hooks/useIsTouchDevice';
+import { isLensActive } from '@/lib/impersonation/lens-write-guard';
+import { normalizeBrPhone } from '@/lib/phone';
+import { Dialer } from './Dialer';
+
+interface BotaoLigarProps {
+  telefone: string | null | undefined;
+  nomeCliente: string;
+  /** 'full' = botão "Ligar"; 'icon' = ícone compacto. Default 'full'. */
+  variant?: 'full' | 'icon';
+  /** Analytics do call-site. Disparado quando a ligação é INICIADA pelo discador do
+   *  aparelho (caminho mobile). No desktop a chamada é registrada pela própria
+   *  telefonia WebRTC, então o call-site não precisa rastrear o clique. */
+  onLigar?: () => void;
+  className?: string;
+}
+
+/**
+ * Botão "Ligar" híbrido por plataforma — fonte ÚNICA da ação "ligar" nas telas de
+ * campo/lista (route-planner, fila, caça, radar). A intenção é deixar CLARO e
+ * CONSISTENTE, em todo o app, o que acontece ao ligar em cada dispositivo:
+ *
+ * - DESKTOP (não-touch): softphone WebRTC in-app (reusa <Dialer>) — grava + copiloto,
+ *   igual ao resto do app de vendas. Resolve "no notebook o botão não puxa o WebRTC".
+ * - CELULAR/TABLET (touch, via useIsTouchDevice): discador do APARELHO (tel:) — liga
+ *   pela operadora, SEM gravação. Sinaliza com o ícone Smartphone (≠ do softphone) e
+ *   avisa no toque (toast). Bloqueia na lente "Ver como" (o tel: furaria o write-guard).
+ *
+ * Não estende o CallButton de propósito: ele é "WebRTC sempre" (a tela de Telefonia
+ * depende disso). Este é o modo híbrido, separado — um propósito por componente.
+ */
+export function BotaoLigar({ telefone, nomeCliente, variant = 'full', onLigar, className }: BotaoLigarProps) {
+  const isTouch = useIsTouchDevice();
+
+  const digitos = normalizeBrPhone(telefone);
+  if (digitos.length < 10) return null; // sem DDD+número válido: esconde (não fabrica link quebrado)
+
+  // DESKTOP → softphone in-app. O <Dialer> já trata o gate da lente internamente.
+  if (!isTouch) {
+    return <Dialer phoneNumber={telefone as string} customerName={nomeCliente} compact={variant === 'icon'} />;
+  }
+
+  const isIcon = variant === 'icon';
+  const classes = cn(isIcon ? 'h-8 w-8' : 'h-8 text-xs gap-1.5', className);
+  const conteudo = (
+    <>
+      <Smartphone className={isIcon ? 'w-4 h-4' : 'w-3.5 h-3.5'} />
+      {!isIcon && 'Ligar'}
+    </>
+  );
+
+  // CELULAR sob a lente "Ver como": o tel: navega direto e furaria o write-guard → bloqueia.
+  if (isLensActive()) {
+    return (
+      <Button
+        size={isIcon ? 'icon' : 'sm'}
+        variant="ghost"
+        disabled
+        className={classes}
+        title="Ligação indisponível em modo Ver como"
+        aria-label="Ligar"
+      >
+        {conteudo}
+      </Button>
+    );
+  }
+
+  return (
+    <Button asChild size={isIcon ? 'icon' : 'sm'} variant="ghost" className={classes}>
+      <a
+        href={`tel:${digitos}`}
+        aria-label="Ligar pelo celular"
+        title="Abre o discador do seu celular — ligação pelo aparelho, sem gravação"
+        onClick={() => {
+          onLigar?.();
+          toast.info('Ligando pelo seu celular — chamada pelo aparelho, sem gravação.');
+        }}
+      >
+        {conteudo}
+      </a>
+    </Button>
+  );
+}

--- a/src/components/call/__tests__/BotaoLigar.test.tsx
+++ b/src/components/call/__tests__/BotaoLigar.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+// Holder hoisted pra variar plataforma (touch) e lente entre os testes.
+const h = vi.hoisted(() => ({ isTouch: false, isImpersonating: false }));
+const onLigar = vi.fn();
+const toastInfo = vi.fn();
+
+vi.mock('@/hooks/useIsTouchDevice', () => ({ useIsTouchDevice: () => h.isTouch }));
+vi.mock('@/lib/impersonation/lens-write-guard', () => ({ isLensActive: () => h.isImpersonating }));
+vi.mock('sonner', () => ({ toast: { info: (...a: unknown[]) => toastInfo(...a), success: vi.fn(), error: vi.fn() } }));
+
+// Mock do softphone WebRTC (Dialer): não puxa a árvore de telefonia (jssip/supabase) no teste.
+vi.mock('../Dialer', () => ({
+  Dialer: (props: { phoneNumber: string; customerName: string; compact?: boolean }) => (
+    <div data-testid="inapp-dialer" data-phone={props.phoneNumber} data-compact={String(!!props.compact)}>
+      softphone in-app
+    </div>
+  ),
+}));
+
+import { BotaoLigar } from '../BotaoLigar';
+
+describe('BotaoLigar — híbrido: desktop(softphone) × celular(aparelho)', () => {
+  beforeEach(() => {
+    h.isTouch = false;
+    h.isImpersonating = false;
+    onLigar.mockClear();
+    toastInfo.mockClear();
+  });
+
+  it('no DESKTOP renderiza o softphone WebRTC in-app e NUNCA um link tel: (resolve "não puxa o WebRTC")', () => {
+    h.isTouch = false;
+    const { container } = render(<BotaoLigar telefone="37999998888" nomeCliente="Cliente X" />);
+    expect(screen.getByTestId('inapp-dialer')).toBeInTheDocument();
+    expect(container.querySelector('a[href^="tel:"]')).toBeNull();
+  });
+
+  it('no CELULAR/tablet renderiza link tel: com os dígitos normalizados (liga pelo aparelho)', () => {
+    h.isTouch = true;
+    const { container } = render(<BotaoLigar telefone="(37) 99999-8888" nomeCliente="Cliente X" />);
+    const link = container.querySelector('a[href^="tel:"]');
+    expect(link).not.toBeNull();
+    expect(link!.getAttribute('href')).toBe('tel:37999998888');
+    expect(screen.queryByTestId('inapp-dialer')).toBeNull();
+  });
+
+  it('no CELULAR, tocar Ligar avisa que é pelo aparelho (sem gravação) e dispara onLigar', () => {
+    h.isTouch = true;
+    const { container } = render(
+      <BotaoLigar telefone="37999998888" nomeCliente="Cliente X" onLigar={onLigar} />,
+    );
+    const link = container.querySelector('a[href^="tel:"]')!;
+    // jsdom não implementa navegação de protocolo (tel:) e logaria um stderr ruidoso —
+    // previne a ação default sem afetar o onClick do React (preventDefault ≠ stopHandler).
+    link.addEventListener('click', (e) => e.preventDefault());
+    fireEvent.click(link);
+    expect(onLigar).toHaveBeenCalledTimes(1);
+    expect(toastInfo).toHaveBeenCalledTimes(1);
+    expect(String(toastInfo.mock.calls[0][0]).toLowerCase()).toContain('celular');
+  });
+
+  it('no CELULAR sob a lente "Ver como", NÃO oferece link tel: clicável (bloqueia a ligação real)', () => {
+    h.isTouch = true;
+    h.isImpersonating = true;
+    const { container } = render(<BotaoLigar telefone="37999998888" nomeCliente="Cliente X" />);
+    expect(container.querySelector('a[href^="tel:"]')).toBeNull();
+  });
+
+  it('telefone inválido (curto/ausente) não renderiza nada — não fabrica link quebrado', () => {
+    h.isTouch = true;
+    const { container } = render(<BotaoLigar telefone="123" nomeCliente="Cliente X" />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('variant="icon" no desktop passa compact=true pro softphone', () => {
+    h.isTouch = false;
+    render(<BotaoLigar telefone="37999998888" nomeCliente="Cliente X" variant="icon" />);
+    expect(screen.getByTestId('inapp-dialer').getAttribute('data-compact')).toBe('true');
+  });
+});

--- a/src/components/fila/FilaContextPanel.tsx
+++ b/src/components/fila/FilaContextPanel.tsx
@@ -5,8 +5,9 @@ import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sh
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Link } from 'react-router-dom';
-import { Phone, ExternalLink } from 'lucide-react';
+import { ExternalLink } from 'lucide-react';
 import { track } from '@/lib/analytics';
+import { BotaoLigar } from '@/components/call/BotaoLigar';
 import { AcaoOutcomeMenu } from './AcaoOutcomeMenu';
 import type { AcaoSugerida, CategoriaAcao } from '@/lib/fila/types';
 
@@ -36,11 +37,11 @@ export function FilaContextPanel({ acao, onClose, onNaoUtilAgora }: Props) {
             </SheetHeader>
             <div className="mt-4 space-y-4">
               {acao.telefone && (
-                <Button asChild variant="outline" className="w-full justify-start gap-2">
-                  <a href={`tel:${acao.telefone.replace(/\D/g, '')}`}>
-                    <Phone className="w-4 h-4" /> Ligar para {acao.clienteNome ?? 'cliente'}
-                  </a>
-                </Button>
+                <BotaoLigar
+                  telefone={acao.telefone}
+                  nomeCliente={acao.clienteNome ?? 'cliente'}
+                  className="w-full justify-start"
+                />
               )}
 
               {acao.payload.kind === 'mixgap' && (

--- a/src/components/fila/FilaDoDia.tsx
+++ b/src/components/fila/FilaDoDia.tsx
@@ -5,6 +5,7 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { track } from '@/lib/analytics';
+import { BotaoLigar } from '@/components/call/BotaoLigar';
 import { useFilaAcoes, type FonteFila } from '@/hooks/useFilaAcoes';
 import { useCriticaFila } from '@/hooks/useCriticaFila';
 import { PorQueAgora } from '@/components/fila/PorQueAgora';
@@ -42,7 +43,7 @@ function AcaoCta({ a, temCritica }: { a: AcaoSugerida; temCritica: boolean }) {
   };
   const tel = a.telefone?.replace(/\D/g, '');
   if (a.cta === 'ligar' && tel) {
-    return <Button asChild size="sm" variant="outline"><a href={`tel:${tel}`} onClick={onClick}>Ligar</a></Button>;
+    return <BotaoLigar telefone={a.telefone} nomeCliente={a.clienteNome ?? a.titulo} onLigar={onClick} />;
   }
   if (a.cta === 'whatsapp' && tel) {
     return <Button asChild size="sm" variant="outline"><a href={`https://wa.me/${tel}`} target="_blank" rel="noopener noreferrer" onClick={onClick}>WhatsApp</a></Button>;

--- a/src/components/radar/RadarDetailSheet.tsx
+++ b/src/components/radar/RadarDetailSheet.tsx
@@ -1,9 +1,10 @@
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet';
 import { Badge } from '@/components/ui/badge';
-import { MapPin, Phone, Mail, MessageSquare } from 'lucide-react';
+import { MapPin, Mail, MessageSquare } from 'lucide-react';
 import { RadarOutcomeMenu } from './RadarOutcomeMenu';
 import { RadarAcoesLead } from './RadarAcoesLead';
 import { isCellphone, whatsappLink } from '@/lib/phone';
+import { BotaoLigar } from '@/components/call/BotaoLigar';
 import {
   formatarCnpj,
   formatarCapital,
@@ -75,13 +76,14 @@ export function RadarDetailSheet({
           <Linha label="Capital">{formatarCapital(empresa.capital_social)}</Linha>
           <Linha label="Telefone">
             {empresa.telefone1 ? (
-              <a
-                className="inline-flex items-center gap-1 underline"
-                href={`tel:${empresa.telefone1}`}
-              >
-                <Phone className="w-3 h-3" />
-                {empresa.telefone1}
-              </a>
+              <span className="inline-flex items-center gap-1.5">
+                <span className="font-tabular">{empresa.telefone1}</span>
+                <BotaoLigar
+                  telefone={empresa.telefone1}
+                  nomeCliente={empresa.razao_social || empresa.cnpj}
+                  variant="icon"
+                />
+              </span>
             ) : (
               '—'
             )}

--- a/src/components/reposicao/routePlanner/FieldTargetCard.tsx
+++ b/src/components/reposicao/routePlanner/FieldTargetCard.tsx
@@ -1,9 +1,10 @@
 // Linha de um alvo (cliente da carteira OU prospect do Radar) no universo de
 // alvos do contexto campo. Botão "Adicionar à rota" / "Na rota ✓" (toggle).
-import { Plus, Check, Phone } from 'lucide-react';
+import { Plus, Check } from 'lucide-react';
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { BotaoLigar } from '@/components/call/BotaoLigar';
 import type { RouteStop } from './types';
 import { STOP_CONFIG } from './constants';
 
@@ -32,11 +33,7 @@ export function FieldTargetCard({
             </p>
           </div>
           {stop.phone && (
-            <Button size="icon" variant="ghost" className="h-8 w-8 shrink-0" asChild>
-              <a href={`tel:${stop.phone}`} aria-label="Ligar">
-                <Phone className="w-3.5 h-3.5" />
-              </a>
-            </Button>
+            <BotaoLigar telefone={stop.phone} nomeCliente={stop.customerName} variant="icon" className="shrink-0" />
           )}
           <Button
             size="sm"

--- a/src/components/reposicao/routePlanner/RouteStopCard.tsx
+++ b/src/components/reposicao/routePlanner/RouteStopCard.tsx
@@ -1,7 +1,7 @@
 // Card de uma parada na rota otimizada (planejador de rotas).
 // Extraído de src/pages/AdminRoutePlanner.tsx (god-component split).
 // Presentational: recebe a parada + estado de check-in/timer já resolvidos + callbacks.
-import { Clock, Phone, CheckCircle2, XCircle, ExternalLink } from 'lucide-react';
+import { Clock, CheckCircle2, XCircle, ExternalLink } from 'lucide-react';
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -15,6 +15,7 @@ import type { RouteStop } from './types';
 import { STOP_CONFIG, STOP_DURATION_MIN, PRIORITY_CONFIG } from './constants';
 import { getStopIcon, getCTALabel } from './renderHelpers';
 import { RadarOutcomeMenu } from '@/components/radar/RadarOutcomeMenu';
+import { BotaoLigar } from '@/components/call/BotaoLigar';
 
 export function RouteStopCard({
   stop,
@@ -97,11 +98,7 @@ export function RouteStopCard({
                 </Button>
               )}
               {stop.phone && (
-                <Button size="sm" variant="ghost" className="h-7 text-xs gap-1" asChild>
-                  <a href={`tel:${stop.phone}`}>
-                    <Phone className="w-3 h-3" /> Ligar
-                  </a>
-                </Button>
+                <BotaoLigar telefone={stop.phone} nomeCliente={stop.customerName} />
               )}
               {stop.stopType === 'prospect_visit' ? (
                 stop.radarCnpj ? <RadarOutcomeMenu cnpj={stop.radarCnpj} /> : null


### PR DESCRIPTION
## Problema

O botão "Ligar" das telas de campo usava `<a href="tel:">` cru — confusão recorrente (2ª vez relatada):
- **No notebook:** o `tel:` não abre o softphone WebRTC (o SO tenta um handler de protocolo tipo Skype/Teams, ou não faz nada). Daí "não puxa pelo WebRTC".
- **No celular:** abre o discador do aparelho, mas sem deixar claro que a ligação é pelo telefone e **não é gravada**.

## Solução

Novo `BotaoLigar` — **fonte única** da ação "ligar" nas telas de campo/lista. Decide por plataforma via `useIsTouchDevice` (hook que já existia pra isso e nunca tinha sido ligado):

| Plataforma | Comportamento | Sinalização |
|---|---|---|
| Desktop | Softphone WebRTC in-app (reusa `Dialer`) — grava + copiloto | card de chamada in-app |
| Celular/tablet | Discador do aparelho (`tel:`) | ícone `Smartphone` + toast "sem gravação" |

- Bloqueia a ligação na lente "Ver como" (`isLensActive`) — o `tel:` fura o write-guard.
- 6 call-sites migrados: route-planner (`RouteStopCard`, `FieldTargetCard`), fila do dia (`FilaDoDia`, `FilaContextPanel`), caça (`FilaDeCaca`), radar (`RadarDetailSheet`). Telas do cliente (Suporte/pedido) mantêm `tel:` de propósito.

## Verificação

- ✅ typecheck (strict) · lint 0 errors
- ✅ suíte completa: 475 arquivos, 3547 testes
- ✅ TDD: `BotaoLigar.test` (6 testes) — bifurcação por plataforma + gates da lente
- knip sem regressão (a dívida reportada é pré-existente ao PR)

## Deploy

Mudança **só de frontend** — sem edge function, sem migration. Basta o **Publish do frontend** no Lovable.

## Notas

- Caso de borda (pré-existente): staff num notebook **sem ramal SIP** verá o softphone falhar com erro no card — melhor que o silêncio do `tel:` anterior.
- `telLink` (helper da caça) ficou sem consumidor de produção; mantido (testado, knip não reclama). Limpeza opcional num follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)