### PR TITLE
chore(caca): remove telLink — helper sem consumidor após o BotaoLigar

### DIFF
--- a/src/lib/caca/__tests__/apresentacao.test.ts
+++ b/src/lib/caca/__tests__/apresentacao.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { labelSabor, faixaConfianca, classeSabor, telLink, agruparPorDocumento } from '../apresentacao';
+import { labelSabor, faixaConfianca, classeSabor, agruparPorDocumento } from '../apresentacao';
 import type { SaborCaca, CacaCandidatoDisplay } from '../types';
 
 // ─── labelSabor ────────────────────────────────────────────────────────────────
@@ -111,51 +111,6 @@ describe('classeSabor', () => {
     for (const s of sabores) {
       expect(classeSabor(s).length).toBeGreaterThan(0);
     }
-  });
-});
-
-// ─── telLink ───────────────────────────────────────────────────────────────────
-
-describe('telLink', () => {
-  it('null → null', () => {
-    expect(telLink(null)).toBeNull();
-  });
-
-  it('string vazia → null', () => {
-    expect(telLink('')).toBeNull();
-  });
-
-  it('string só de espaços → null', () => {
-    expect(telLink('   ')).toBeNull();
-  });
-
-  it('string com hífens e espaços → tel: com apenas dígitos', () => {
-    expect(telLink('(31) 99999-8888')).toBe('tel:31999998888');
-  });
-
-  it('E.164 → preserva dígitos', () => {
-    expect(telLink('+5531999998888')).toBe('tel:5531999998888');
-  });
-
-  it('só dígitos → prefixo tel: adicionado', () => {
-    expect(telLink('31999998888')).toBe('tel:31999998888');
-  });
-
-  it('telefone com pontos e parênteses → só dígitos no href', () => {
-    expect(telLink('(31) 3333-4444')).toBe('tel:3133334444');
-  });
-
-  it('retorna string começando com "tel:" quando não nulo', () => {
-    const resultado = telLink('31999998888');
-    expect(resultado).toMatch(/^tel:/);
-  });
-
-  it('não contém caracteres não-dígitos após o prefixo tel:', () => {
-    const resultado = telLink('(11) 98765-4321');
-    expect(resultado).toBe('tel:11987654321');
-    // confirma que só há dígitos depois do "tel:"
-    const semPrefixo = resultado!.replace('tel:', '');
-    expect(semPrefixo).toMatch(/^\d+$/);
   });
 });
 

--- a/src/lib/caca/apresentacao.ts
+++ b/src/lib/caca/apresentacao.ts
@@ -49,19 +49,6 @@ export function classeSabor(s: SaborCaca): string {
   }
 }
 
-/**
- * Monta um href `tel:` para o telefone fornecido.
- *
- * Retorna `null` se o telefone for null, vazio ou contiver apenas espaços.
- * Mantém apenas os dígitos no href para compatibilidade máxima com apps nativos.
- */
-export function telLink(tel: string | null): string | null {
-  if (tel === null) return null;
-  const digitos = tel.replace(/\D/g, '');
-  if (digitos.length === 0) return null;
-  return `tel:${digitos}`;
-}
-
 // ─── Agrupamento por documento ────────────────────────────────────────────────
 
 import type { CacaCandidatoDisplay } from './types';


### PR DESCRIPTION
Follow-up de [#859](https://github.com/LucasSardenbergL/afiacao/pull/859).

O `BotaoLigar` passou a montar o `tel:` com `normalizeBrPhone`, deixando o helper `telLink` (de `src/lib/caca/apresentacao.ts`) **sem consumidor de produção** — só o próprio teste o usava. Remove a função e o bloco de teste correspondente.

## Verificação
- ✅ `telLink` com zero referências em `src/`
- ✅ typecheck strict (garante que nenhum outro ponto referenciava)
- ✅ testes do módulo caça: 9 arquivos / 137 testes
- ✅ lint 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)