### PR TITLE
refactor(seg): escapeHtml canônico único + fecha XSS do PDF do Cockpit

### DIFF
--- a/src/components/GamificationCertificate.tsx
+++ b/src/components/GamificationCertificate.tsx
@@ -4,6 +4,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from 
 import { Download } from 'lucide-react';
 import { format } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
+import { escapeHtml } from '@/lib/escape-html';
 
 interface CertificateProps {
   userName: string;
@@ -23,11 +24,6 @@ export function GamificationCertificate({ userName, levelName, level, totalScore
     if (!printWindow) return;
 
     const certDate = date || format(new Date(), "dd 'de' MMMM 'de' yyyy", { locale: ptBR });
-
-    function escapeHtml(s: string | undefined | null): string {
-      if (!s) return '';
-      return s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;');
-    }
 
     printWindow.document.write(`
       <!DOCTYPE html>

--- a/src/components/OrderPrintLayout.tsx
+++ b/src/components/OrderPrintLayout.tsx
@@ -1,10 +1,6 @@
 import { format, addDays } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
-
-function escapeHtml(s: string | undefined | null): string {
-  if (!s) return '';
-  return s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;');
-}
+import { escapeHtml } from '@/lib/escape-html';
 
 export interface PrintOrderData {
   companyName: string;

--- a/src/components/sales/print/__tests__/buildPrintHtml.test.ts
+++ b/src/components/sales/print/__tests__/buildPrintHtml.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildPrintData, escapeHtml, buildSingleOrderHtml, buildPrintDocument } from '../buildPrintHtml';
+import { buildPrintData, buildSingleOrderHtml, buildPrintDocument } from '../buildPrintHtml';
 import type { SalesOrderRow } from '../types';
 
 const order: SalesOrderRow = {
@@ -17,14 +17,6 @@ const order: SalesOrderRow = {
   customer_name: 'João Cliente',
   customer_document: '123',
 };
-
-describe('escapeHtml', () => {
-  it('escapa caracteres especiais HTML', () => {
-    expect(escapeHtml('<b>"a" & \'b\'>')).toBe('&lt;b&gt;&quot;a&quot; &amp; &#39;b&#39;&gt;');
-    expect(escapeHtml(null)).toBe('');
-    expect(escapeHtml(undefined)).toBe('');
-  });
-});
 
 describe('buildPrintData', () => {
   it('mapeia pedido para PrintOrderData (oben) com número sem zeros à esquerda', () => {

--- a/src/components/sales/print/buildPrintHtml.ts
+++ b/src/components/sales/print/buildPrintHtml.ts
@@ -2,6 +2,7 @@
 // Extraído de src/pages/SalesPrintDashboard.tsx (god-component split).
 import { addDays } from 'date-fns';
 import { formatarDataPedido } from '@/lib/pedido/data-pedido';
+import { escapeHtml } from '@/lib/escape-html';
 import { type PrintOrderData } from '@/components/OrderPrintLayout';
 import type { CompanyFilter, SalesOrderRow } from './types';
 
@@ -68,11 +69,6 @@ export function buildPrintData(order: SalesOrderRow, company: CompanyFilter, log
     observacoes: order.notes || undefined,
     isOben: isOben,
   };
-}
-
-export function escapeHtml(s: string | undefined | null): string {
-  if (!s) return '';
-  return s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;');
 }
 
 // Build HTML for a single order page (without <html>/<body> wrappers)

--- a/src/lib/escape-html.test.ts
+++ b/src/lib/escape-html.test.ts
@@ -33,4 +33,13 @@ describe('escapeHtml', () => {
     expect(escapeHtml('Rua das Flores, 123')).toBe('Rua das Flores, 123');
     expect(escapeHtml('')).toBe('');
   });
+
+  it('trata null/undefined como string vazia (canônico p/ os call-sites de print)', () => {
+    expect(escapeHtml(null)).toBe('');
+    expect(escapeHtml(undefined)).toBe('');
+  });
+
+  it('caso composto — paridade com os print-layouts consolidados', () => {
+    expect(escapeHtml('<b>"a" & \'b\'>')).toBe('&lt;b&gt;&quot;a&quot; &amp; &#39;b&#39;&gt;');
+  });
 });

--- a/src/lib/escape-html.ts
+++ b/src/lib/escape-html.ts
@@ -1,17 +1,19 @@
 /**
- * Escapa os 5 caracteres especiais de HTML para suas entidades.
+ * Escapa os 5 caracteres especiais de HTML para suas entidades. Helper CANÔNICO
+ * de escape do app — use SEMPRE que interpolar dado em string que vira HTML cru.
  *
- * Necessário porque o Leaflet renderiza `divIcon({ html })` e `bindPopup(html)`
- * como HTML cru (equivalente a `dangerouslySetInnerHTML`). Interpolar dado de
- * cliente/prospect (profiles.name, razão social de radar_empresas) direto na
- * string vira XSS stored — um `<img onerror=…>` no nome executa quando o gestor
- * abre o popup. Escapar antes de interpolar neutraliza o HTML embutido sem
- * alterar o texto visível.
+ * Vale para todo sink que monta HTML sem o React no meio (o React já escapa):
+ *  - Leaflet `divIcon({ html })` / `bindPopup(html)` (mapas: Roteirizador, Radar);
+ *  - `el.innerHTML = …` / `printWindow.document.write(…)` (layouts de impressão:
+ *    pedido, venda, certificado, QR, cockpit de reposição).
+ * Interpolar dado de cliente/fornecedor cru (profiles.name, razão social,
+ * nome de fornecedor) vira XSS stored — um `<img onerror=…>` executa ao renderizar.
  *
- * O `&` é trocado PRIMEIRO; senão o `&` das demais entidades (`&lt;`…) seria
- * re-escapado para `&amp;lt;`.
+ * `null`/`undefined` → '' (drop-in para campos opcionais). O `&` é trocado
+ * PRIMEIRO; senão o `&` das demais entidades (`&lt;`…) seria re-escapado.
  */
-export function escapeHtml(input: string): string {
+export function escapeHtml(input: string | null | undefined): string {
+  if (!input) return '';
   return input
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')

--- a/src/pages/AdminReposicaoCockpit.tsx
+++ b/src/pages/AdminReposicaoCockpit.tsx
@@ -22,6 +22,7 @@ import {
 } from "@/hooks/useReposicaoSessao";
 import { downloadCsv, formatBRL, formatDate, logAudit } from "@/lib/reposicao";
 import { createLeadingTrailingThrottle } from "@/lib/leading-trailing-throttle";
+import { escapeHtml } from "@/lib/escape-html";
 import { ContinuarBanner } from "@/components/reposicao/ContinuarBanner";
 import { EtapasGrid } from "@/components/reposicao/EtapasGrid";
 import { SmartAlertsSection } from "@/components/reposicao/SmartAlertsSection";
@@ -226,12 +227,12 @@ export default function AdminReposicaoCockpit() {
     const rowsHtml = itensDia
       .map(
         (r) => `<tr>
-        <td>${r.grupo_codigo ?? "—"}</td>
-        <td>${r.fornecedor_nome ?? "—"}</td>
+        <td>${escapeHtml(r.grupo_codigo ?? "—")}</td>
+        <td>${escapeHtml(r.fornecedor_nome ?? "—")}</td>
         <td class="right">${r.num_skus ?? 0}</td>
         <td class="right">${r.aprovado_em ? (r.num_skus ?? 0) : ""}</td>
         <td class="right">${formatBRL(r.valor_total)}</td>
-        <td>${r.status ?? "—"}</td>
+        <td>${escapeHtml(r.status ?? "—")}</td>
       </tr>`,
       )
       .join("");

--- a/src/pages/ToolHistory.tsx
+++ b/src/pages/ToolHistory.tsx
@@ -15,6 +15,7 @@ import { format, differenceInDays } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
 import { QRCodeSVG } from 'qrcode.react';
 import { cn } from '@/lib/utils';
+import { escapeHtml } from '@/lib/escape-html';
 
 /* ─── Types ─── */
 
@@ -151,11 +152,6 @@ const ToolHistory = () => {
       setLoading(false);
     }
   };
-
-function escapeHtml(s: string | undefined | null): string {
-  if (!s) return '';
-  return s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;');
-}
 
   const handlePrintQR = () => {
     if (!qrRef.current || !tool) return;


### PR DESCRIPTION
## Contexto

Follow-up do [#862](https://github.com/LucasSardenbergL/afiacao/pull/862) (XSS nos popups Leaflet). Ao auditar a classe inteira encontrei **5 cópias** de `escapeHtml` espalhadas (4 locais byte-idênticas + a que o #862 criou em `@/lib`), e que o PDF do **Cockpit de Reposição** ainda **não escapava** — XSS stored via nome de fornecedor ao gerar o PDF (`document.body.appendChild`).

## Mudanças

- **`@/lib/escape-html` vira o único `escapeHtml` do app** (ponto de verdade), agora **null-safe** (`string | null | undefined` → `''`) — drop-in para os call-sites de impressão.
- **Removidas as 4 cópias locais** (byte-idênticas), passam a importar o canônico:
  - `OrderPrintLayout.tsx`, `sales/print/buildPrintHtml.ts`, `GamificationCertificate.tsx`, `pages/ToolHistory.tsx`
- **Cockpit de Reposição** (`AdminReposicaoCockpit.tsx`): escapa `fornecedor_nome` / `grupo_codigo` / `status` no HTML do PDF. A semântica do `?? "—"` foi preservada (`escapeHtml(x ?? "—")`).
- Teste do `escapeHtml` unificado em `src/lib/escape-html.test.ts` (+ casos `null`/`undefined` + caso composto); removido o `describe` duplicado de `buildPrintHtml.test.ts`.

## Paridade (telas de impressão são money-path)

As 4 cópias eram idênticas entre si (mesma ordem `&`-first, mesmas entidades `&#39;`, guard `if(!s) return ''`) → o canônico produz **saída idêntica**. **Sem mudança visual** em nenhum layout de impressão; só o Cockpit muda comportamento (passa a neutralizar HTML embutido).

## Verificação

- `bun run typecheck` (strict): **0**
- `bun run test` (escape-html + buildPrintHtml + route): **verde** (helper null-safe RED→GREEN observado)
- `bunx eslint`: **0 errors** (1 warning pré-existente em `ToolHistory:139`, não relacionado)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
