### PR TITLE
feat(fornecedores): fatia fina — captura de tags do Omie (provar a fonte) [Fase 1]

### DIFF
--- a/docs/superpowers/plans/2026-06-06-fornecedores-fora-da-carteira.md
+++ b/docs/superpowers/plans/2026-06-06-fornecedores-fora-da-carteira.md
@@ -1,0 +1,377 @@
+# Fornecedores fora da carteira — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Tirar fornecedores/transportadoras (tag do Omie) da carteira comercial — eles deixam de aparecer em sugestão de visita, lista de ligação, positivação e KPIs — de forma reversível e curada pelo founder.
+
+**Architecture:** Captura a tag do cadastro Omie (`c.tags`) → tabela `cliente_classificacao` (por `user_id`). Uma RPC deriva `excluir_da_carteira = tem tag {Fornecedor,Transportadora} AND NOT exceção curada`. O corte usa `carteira_assignments.eligible=false` (já respeitado pela positivação, reversível) + DELETE dos scores; todos os escritores de score que não partem da carteira ganham o filtro. Rollout manual no Lovable, filtros no ar **antes** de marcar.
+
+**Tech Stack:** Supabase (Postgres + RLS + RPC `plpgsql` + Edge Deno), React + TanStack Query, vitest (helpers puros), validação SQL local em PostgreSQL 17 (`db/test-*.sh`).
+
+> **Spec:** [docs/superpowers/specs/2026-06-06-fornecedores-fora-da-carteira-design.md](../specs/2026-06-06-fornecedores-fora-da-carteira-design.md). **Contexto Lovable (CLAUDE.md §5):** migrations aplicadas **manualmente** no SQL Editor; edges deployadas **via chat do Lovable**; frontend via **Publish**. NENHUMA acontece no merge.
+
+---
+
+## File Structure
+
+| Arquivo | Resp. | Ação |
+|---|---|---|
+| `src/lib/fornecedores/classificacao.ts` | regra pura de tag→exclusão (oráculo do SQL) | criar |
+| `src/lib/fornecedores/__tests__/classificacao.test.ts` | testes vitest | criar |
+| `supabase/migrations/20260606170000_fornecedores_classificacao_schema.sql` | 3 tabelas + RLS | criar |
+| `supabase/migrations/20260606170100_fornecedores_classificacao_rpcs.sql` | RPCs classificar/reverter + trigger | criar |
+| `supabase/functions/omie-analytics-sync/index.ts` | capturar `c.tags` no `syncCustomers` → `cliente_classificacao` | modificar |
+| `supabase/functions/scoring-recalc-client/index.ts` | filtrar `excluir_da_carteira` antes do upsert | modificar |
+| `supabase/functions/scoring-recalc-batch/index.ts` | pular flaggeds na enumeração | modificar |
+| `supabase/functions/visit-score-recalc-client/index.ts` | filtrar flaggeds (single/drain) | modificar |
+| `supabase/functions/visit-score-recalc-batch/index.ts` | pular sem assignment elegível | modificar |
+| `supabase/functions/calculate-scores/index.ts` | seed só de `eligible` | modificar |
+| `supabase/functions/carteira-rebuild/index.ts` | `eligible = NOT excluir_da_carteira` + aplicar a cada run | modificar |
+| `src/hooks/useFarmerScoring.ts` | filtrar universo (`sales_orders`) antes do cálculo | modificar |
+| `db/test-fornecedores-classificacao.sh` | validação PG17 das RPCs/cleanup/reversão | criar |
+| `docs/superpowers/plans/_diagnostico-fornecedores.sql` | query de curadoria + blocos de cleanup | criar |
+
+**Constante compartilhada:** `TAGS_NAO_CLIENTE = ['fornecedor','transportadora']` (comparação **case/acento-insensível**: `lower(trim(...))`). Espelhada no TS e no SQL — lição do projeto: case-mismatch morde (`'OBEN'` vs `'oben'`).
+
+---
+
+## Task 1: Helper puro de classificação (TDD)
+
+**Files:**
+- Create: `src/lib/fornecedores/classificacao.ts`
+- Test: `src/lib/fornecedores/__tests__/classificacao.test.ts`
+
+- [ ] **Step 1: Escrever o teste falhando**
+
+```ts
+// src/lib/fornecedores/__tests__/classificacao.test.ts
+import { describe, it, expect } from 'vitest';
+import { TAGS_NAO_CLIENTE, temTagNaoCliente, deveExcluirDaCarteira } from '../classificacao';
+
+describe('temTagNaoCliente', () => {
+  it('detecta Fornecedor com case/acento variável', () => {
+    expect(temTagNaoCliente(['Fornecedor'])).toBe(true);
+    expect(temTagNaoCliente(['FORNECEDOR'])).toBe(true);
+    expect(temTagNaoCliente([' transportadora '])).toBe(true);
+  });
+  it('cliente comum não tem tag', () => {
+    expect(temTagNaoCliente(['Cliente VIP', 'Moveleiro'])).toBe(false);
+    expect(temTagNaoCliente([])).toBe(false);
+    expect(temTagNaoCliente(null as unknown as string[])).toBe(false);
+  });
+  it('TAGS_NAO_CLIENTE é a lista canônica', () => {
+    expect(TAGS_NAO_CLIENTE).toEqual(['fornecedor', 'transportadora']);
+  });
+});
+
+describe('deveExcluirDaCarteira', () => {
+  it('fornecedor sem exceção → exclui', () => {
+    expect(deveExcluirDaCarteira({ tags: ['Fornecedor'], isExcecao: false })).toBe(true);
+  });
+  it('fornecedor COM exceção (cliente real) → mantém', () => {
+    expect(deveExcluirDaCarteira({ tags: ['Fornecedor'], isExcecao: true })).toBe(false);
+  });
+  it('não-fornecedor → mantém (independe de exceção)', () => {
+    expect(deveExcluirDaCarteira({ tags: ['Cliente'], isExcecao: false })).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Rodar e ver falhar** — `heavy bun run test src/lib/fornecedores` → FAIL ("Cannot find module '../classificacao'").
+
+- [ ] **Step 3: Implementar**
+
+```ts
+// src/lib/fornecedores/classificacao.ts
+/** Tags do Omie que marcam "não é cliente de venda". Comparação case/acento-insensível. */
+export const TAGS_NAO_CLIENTE = ['fornecedor', 'transportadora'] as const;
+
+export function temTagNaoCliente(tags: string[] | null | undefined): boolean {
+  if (!tags) return false;
+  return tags.some((t) => (TAGS_NAO_CLIENTE as readonly string[]).includes(t.trim().toLowerCase()));
+}
+
+export function deveExcluirDaCarteira(input: { tags: string[] | null | undefined; isExcecao: boolean }): boolean {
+  return temTagNaoCliente(input.tags) && !input.isExcecao;
+}
+```
+
+- [ ] **Step 4: Rodar e ver passar** — `heavy bun run test src/lib/fornecedores` → PASS.
+
+- [ ] **Step 5: Commit** — `git add src/lib/fornecedores && git commit -m "feat(fornecedores): helper puro de classificação por tag (TDD)"`
+
+---
+
+## Task 2: Migration A — schema (3 tabelas + RLS)
+
+**Files:** Create `supabase/migrations/20260606170000_fornecedores_classificacao_schema.sql`
+
+- [ ] **Step 1: Escrever a migration**
+
+```sql
+-- cliente_classificacao: fonte da verdade reversível, por user_id (não por empresa — omie_clientes é mal-modelado)
+CREATE TABLE IF NOT EXISTS public.cliente_classificacao (
+  user_id uuid PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  tags_omie text[] NOT NULL DEFAULT '{}',
+  is_fornecedor boolean NOT NULL DEFAULT false,
+  excluir_da_carteira boolean NOT NULL DEFAULT false,
+  tem_venda_real boolean NOT NULL DEFAULT false,
+  tags_synced_at timestamptz,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+ALTER TABLE public.cliente_classificacao ENABLE ROW LEVEL SECURITY;
+-- leitura: staff; escrita: só service_role/RPC (employee NÃO mexe na flag — P1 Codex)
+CREATE POLICY "staff read classificacao" ON public.cliente_classificacao
+  FOR SELECT TO authenticated
+  USING (public.has_role(auth.uid(),'master') OR public.has_role(auth.uid(),'employee'));
+CREATE POLICY "service_role manage classificacao" ON public.cliente_classificacao
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+-- fornecedor_excecao: curadoria do founder (fornecedor que É cliente real → fica)
+CREATE TABLE IF NOT EXISTS public.fornecedor_excecao (
+  user_id uuid PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  motivo text,
+  criado_por uuid,
+  criado_em timestamptz NOT NULL DEFAULT now()
+);
+ALTER TABLE public.fornecedor_excecao ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "staff read excecao" ON public.fornecedor_excecao
+  FOR SELECT TO authenticated
+  USING (public.has_role(auth.uid(),'master') OR public.has_role(auth.uid(),'employee'));
+CREATE POLICY "master manage excecao" ON public.fornecedor_excecao
+  FOR ALL TO authenticated
+  USING (public.has_role(auth.uid(),'master')) WITH CHECK (public.has_role(auth.uid(),'master'));
+CREATE POLICY "service_role manage excecao" ON public.fornecedor_excecao
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+SELECT 'MIGRATION A OK' AS status,
+  (SELECT count(*) FROM information_schema.tables WHERE table_name IN ('cliente_classificacao','fornecedor_excecao')) AS tabelas;
+```
+
+- [ ] **Step 2: Validar em PG17** (parte do `db/test-*.sh` da Task 5) — aplica limpo, `tabelas = 2`.
+- [ ] **Step 3: Commit** — `git commit -m "feat(fornecedores): migration A — schema cliente_classificacao + fornecedor_excecao + RLS"`
+- [ ] **Step 4 (rollout, manual):** colar no SQL Editor do Lovable → "Success" + `tabelas = 2`.
+
+---
+
+## Task 3: Migration B — RPCs (classificar + reverter) + trigger de recorrência
+
+**Files:** Create `supabase/migrations/20260606170100_fornecedores_classificacao_rpcs.sql`
+
+- [ ] **Step 1: Escrever a migration**
+
+```sql
+-- Classifica todos os cadastros. Regra espelha o helper TS (Task 1).
+CREATE OR REPLACE FUNCTION public.classificar_clientes_fornecedores()
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE v_classificados int; v_excluidos int;
+BEGIN
+  UPDATE public.cliente_classificacao cc SET
+    is_fornecedor = EXISTS (
+      SELECT 1 FROM unnest(cc.tags_omie) t
+      WHERE lower(trim(t)) = ANY (ARRAY['fornecedor','transportadora'])
+    ),
+    tem_venda_real = EXISTS (
+      SELECT 1 FROM public.sales_orders so
+      WHERE so.customer_user_id = cc.user_id
+        AND so.status NOT IN ('cancelado','rascunho','pendente')
+    ),
+    excluir_da_carteira = (
+      EXISTS (SELECT 1 FROM unnest(cc.tags_omie) t
+              WHERE lower(trim(t)) = ANY (ARRAY['fornecedor','transportadora']))
+      AND NOT EXISTS (SELECT 1 FROM public.fornecedor_excecao e WHERE e.user_id = cc.user_id)
+    ),
+    updated_at = now();
+  GET DIAGNOSTICS v_classificados = ROW_COUNT;
+  SELECT count(*) INTO v_excluidos FROM public.cliente_classificacao WHERE excluir_da_carteira;
+  RETURN jsonb_build_object('classificados', v_classificados, 'excluidos', v_excluidos);
+END $$;
+REVOKE ALL ON FUNCTION public.classificar_clientes_fornecedores() FROM anon, authenticated;
+
+-- Reverter (adiciona exceção + traz o cadastro de volta à carteira E aos scores — P1 reversibilidade).
+CREATE OR REPLACE FUNCTION public.reverter_exclusao_fornecedor(p_user_id uuid, p_motivo text DEFAULT 'reversão manual')
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+BEGIN
+  IF NOT (public.has_role(auth.uid(),'master')) THEN
+    RAISE EXCEPTION 'apenas master pode reverter';
+  END IF;
+  INSERT INTO public.fornecedor_excecao (user_id, motivo, criado_por)
+  VALUES (p_user_id, p_motivo, auth.uid())
+  ON CONFLICT (user_id) DO NOTHING;
+  UPDATE public.cliente_classificacao SET excluir_da_carteira = false, updated_at = now() WHERE user_id = p_user_id;
+  UPDATE public.carteira_assignments SET eligible = true, updated_at = now() WHERE customer_user_id = p_user_id;
+  -- backfill dos scores: enfileira visit recalc p/ cada owner do cliente
+  INSERT INTO public.visit_score_recalc_pending (customer_user_id, farmer_id)
+  SELECT customer_user_id, owner_user_id FROM public.carteira_assignments WHERE customer_user_id = p_user_id
+  ON CONFLICT DO NOTHING;
+  RETURN jsonb_build_object('revertido', p_user_id);
+END $$;
+REVOKE ALL ON FUNCTION public.reverter_exclusao_fornecedor(uuid, text) FROM anon;
+
+-- Recorrência: cadastro novo (NF de devolução futura) nasce com a classificação correta.
+-- Linha nova em cliente_classificacao → re-deriva is_fornecedor/excluir (default false até o sync trazer tags).
+-- A classificação real roda após cada sync (Task 4); o trigger garante consistência em insert manual.
+CREATE OR REPLACE FUNCTION public.cliente_classificacao_after_write()
+RETURNS trigger LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+BEGIN
+  NEW.is_fornecedor := EXISTS (SELECT 1 FROM unnest(NEW.tags_omie) t WHERE lower(trim(t)) = ANY (ARRAY['fornecedor','transportadora']));
+  NEW.excluir_da_carteira := NEW.is_fornecedor AND NOT EXISTS (SELECT 1 FROM public.fornecedor_excecao e WHERE e.user_id = NEW.user_id);
+  RETURN NEW;
+END $$;
+CREATE TRIGGER trg_cliente_classificacao_derive
+  BEFORE INSERT OR UPDATE OF tags_omie ON public.cliente_classificacao
+  FOR EACH ROW EXECUTE FUNCTION public.cliente_classificacao_after_write();
+
+SELECT 'MIGRATION B OK' AS status,
+  (SELECT count(*) FROM pg_proc WHERE proname IN ('classificar_clientes_fornecedores','reverter_exclusao_fornecedor')) AS funcs;
+```
+
+- [ ] **Step 2: Validar em PG17** (Task 5).
+- [ ] **Step 3: Commit** — `git commit -m "feat(fornecedores): migration B — RPCs classificar/reverter + trigger de derivação"`
+- [ ] **Step 4 (rollout, manual):** colar no SQL Editor → "Success" + `funcs = 2`.
+
+---
+
+## Task 4: Captura das tags no sync (edge `omie-analytics-sync`)
+
+**Files:** Modify `supabase/functions/omie-analytics-sync/index.ts` (função `syncCustomers`, ~linhas 296-367, e o tipo `OmieListarClientesResponse`)
+
+**Abordagem:** o `syncCustomers` JÁ enumera `ListarClientes` e resolve `userId`. Adicionar: (a) ler `c.tags` (array `[{tag}|string]`, mesmo shape do `omie-vendas-sync:536`); (b) acumular `Map<user_id, string[]>`; (c) ao fim, **upsert** em `cliente_classificacao` (`tags_omie`, `tags_synced_at`). Não tocar a lógica de `omie_clientes`. A derivação `is_fornecedor`/`excluir_da_carteira` vem do trigger (Task 3) no upsert.
+
+- [ ] **Step 1:** No tipo do cliente, incluir `tags?: Array<{ tag?: string } | string>`.
+- [ ] **Step 2:** No laço de páginas, após resolver `userId`, extrair `const tags = (c.tags || []).map(t => typeof t === 'string' ? t : (t.tag ?? '')).filter(Boolean);` e guardar `tagsByUser.set(userId, tags)`.
+- [ ] **Step 3:** Após o upsert de `omie_clientes`, fazer o upsert das tags em chunks:
+
+```ts
+const nowIso = new Date().toISOString();
+const tagRows = Array.from(tagsByUser.entries()).map(([user_id, tags_omie]) => ({ user_id, tags_omie, tags_synced_at: nowIso }));
+for (let i = 0; i < tagRows.length; i += 500) {
+  const { error } = await db.from('cliente_classificacao').upsert(tagRows.slice(i, i + 500), { onConflict: 'user_id' });
+  if (error) throw new Error(`upsert cliente_classificacao: ${error.message}`);
+}
+```
+
+- [ ] **Step 4: Verificação de comportamento** (não há teste unitário de edge): o sub-PR cita que o upsert é idempotente (onConflict user_id) e que carga parcial é **fail-safe** (ausência de tag = não-fornecedor = fica na carteira). Documentar no PR.
+- [ ] **Step 5: Commit** — `git commit -m "feat(fornecedores): syncCustomers captura tags do Omie → cliente_classificacao"`
+- [ ] **Step 6 (rollout, manual):** deploy do `omie-analytics-sync` via chat do Lovable (verbatim da main) — **só depois** das migrations A/B aplicadas.
+
+---
+
+## Task 5: Validação SQL local (PG17) — RPCs, cleanup, reversão, multi-linha
+
+**Files:** Create `db/test-fornecedores-classificacao.sh` (base `db/verify-snapshot-replay.sh`)
+
+- [ ] **Step 1:** Script PG17 que: aplica migrations A+B sobre stubs (`auth.users`, `sales_orders`, `carteira_assignments`, `visit_score_recalc_pending`), semeia cenários, e roda asserts:
+
+```
+A1  fornecedor (tag) sem exceção → classificar → excluir_da_carteira=true
+A2  fornecedor COM exceção → excluir_da_carteira=false (curadoria vence)
+A3  cliente comum (sem tag) → excluir_da_carteira=false
+A4  tag 'FORNECEDOR' maiúscula e ' Transportadora ' → detectadas (case/trim)
+A5  cleanup: eligible=false para flaggeds; eligible permanece true p/ não-flaggeds
+A6  multi-linha por user (mesmo user_id em 2 linhas de carteira) → ambas eligible=false
+A7  reverter_exclusao_fornecedor → exceção criada, excluir=false, eligible=true, fila visit_recalc tem a linha
+A8  tem_venda_real reflete sales_orders válido (informativo, NÃO altera excluir)
+A9  trigger: UPDATE de tags_omie re-deriva is_fornecedor/excluir sem chamar a RPC
+```
+
+- [ ] **Step 2: Rodar** — `heavy bash db/test-fornecedores-classificacao.sh` → todos os asserts PASS.
+- [ ] **Step 3: Commit** — `git commit -m "test(fornecedores): validação PG17 das RPCs/cleanup/reversão"`
+
+---
+
+## Task 6: Filtro nos escritores que NÃO partem da carteira
+
+**Files:** Modify `scoring-recalc-client/index.ts`, `scoring-recalc-batch/index.ts`, `visit-score-recalc-client/index.ts`
+
+**Abordagem:** antes do upsert de score (ou na resolução do conjunto a processar), checar `cliente_classificacao.excluir_da_carteira` e **pular** o cliente flaggeado. Padrão: pré-carregar `Set<user_id>` dos flaggeds (1 query paginada) e `if (flaggeds.has(customer_user_id)) continue;`.
+
+- [ ] **Step 1:** `scoring-recalc-client`: na função que faz upsert em `farmer_client_scores` (~linha 277), pular se o `customer_user_id` estiver em `cliente_classificacao` com `excluir_da_carteira=true`.
+- [ ] **Step 2:** `scoring-recalc-batch`: ao enumerar clientes com atividade (fallback no ator), excluir os flaggeds do conjunto.
+- [ ] **Step 3:** `visit-score-recalc-client`: no single E no drain da fila, pular flaggeds.
+- [ ] **Step 4: Verificação:** sub-PR documenta que um registro de contato num fornecedor NÃO recria score (era o vazamento P1).
+- [ ] **Step 5: Commit** — `git commit -m "fix(fornecedores): scoring/visit recalc respeitam excluir_da_carteira (anti-ressurreição)"`
+- [ ] **Step 6 (rollout):** deploy dos 3 edges via Lovable — **antes** de marcar a flag (passo 2 do rollout).
+
+---
+
+## Task 7: Filtro nos escritores que partem da carteira
+
+**Files:** Modify `carteira-rebuild/index.ts`, `calculate-scores/index.ts`, `visit-score-recalc-batch/index.ts`
+
+- [ ] **Step 1:** `carteira-rebuild`: após computar assignments, setar `eligible = NOT (customer_user_id ∈ flaggeds)` no upsert; e a cada run, `UPDATE carteira_assignments SET eligible=false WHERE customer_user_id ∈ flaggeds` (aplica mesmo a quem já estava). Pré-carregar `flaggeds` (paginado).
+- [ ] **Step 2:** `calculate-scores` (auto-seed ~linha 185-226): ao enumerar `omie_clientes`/`carteira_assignments` para seed, considerar só `eligible=true` (ou excluir flaggeds).
+- [ ] **Step 3:** `visit-score-recalc-batch`: ao resolver owner via `carteira_assignments`, pular quem não tem assignment **elegível**.
+- [ ] **Step 4: Commit** — `git commit -m "fix(fornecedores): carteira-rebuild/calculate-scores/visit-batch respeitam eligible"`
+- [ ] **Step 5 (rollout):** deploy via Lovable — junto da Task 6 (antes da flag).
+
+---
+
+## Task 8: Front — `useFarmerScoring` filtra o universo
+
+**Files:** Modify `src/hooks/useFarmerScoring.ts`
+
+- [ ] **Step 1:** Após carregar `sales_orders` e ANTES do cálculo/upsert (~linha 131 e 418), carregar os flaggeds (`select user_id from cliente_classificacao where excluir_da_carteira`) e **remover** esses `customer_user_id` do universo. (Filtra antes de calcular, não só no upsert — P1 Codex.)
+- [ ] **Step 2: Verificação:** abrir `/farmer/calls` não recria score de fornecedor.
+- [ ] **Step 3: Commit** — `git commit -m "fix(fornecedores): useFarmerScoring filtra fornecedores do universo"`
+- [ ] **Step 4 (rollout):** **Publish** do frontend.
+
+---
+
+## Task 9: Diagnóstico + curadoria + cleanup (operacional, SQL Editor)
+
+**Files:** Create `docs/superpowers/plans/_diagnostico-fornecedores.sql`
+
+- [ ] **Step 1: Query de diagnóstico/curadoria** (founder cola, revisa, decide exceções):
+
+```sql
+-- Candidatos: tem tag Fornecedor/Transportadora E está na carteira de alguém.
+SELECT cc.user_id, p.razao_social, p.name, a.city, a.state,
+       cc.tags_omie, cc.tem_venda_real,
+       (SELECT count(*) FROM sales_orders so WHERE so.customer_user_id = cc.user_id
+          AND so.status NOT IN ('cancelado','rascunho','pendente')) AS vendas_validas,
+       (SELECT max(coalesce(order_date_kpi, created_at::date)) FROM sales_orders so WHERE so.customer_user_id = cc.user_id) AS ultima_compra,
+       owner.name AS vendedor
+FROM cliente_classificacao cc
+JOIN carteira_assignments ca ON ca.customer_user_id = cc.user_id AND ca.eligible = true
+LEFT JOIN profiles p ON p.user_id = cc.user_id
+LEFT JOIN profiles owner ON owner.user_id = ca.owner_user_id
+LEFT JOIN addresses a ON a.user_id = cc.user_id AND a.is_default = true
+WHERE cc.is_fornecedor
+ORDER BY vendas_validas ASC, ultima_compra ASC NULLS FIRST;  -- prováveis fornecedor-puro primeiro; quem tem venda = "revise"
+```
+
+- [ ] **Step 2: Curadoria** (founder): para cada cliente real, `INSERT INTO fornecedor_excecao (user_id, motivo) VALUES (...);`
+- [ ] **Step 3: Classificar + cleanup (sob lock, após curadoria)**:
+
+```sql
+SELECT classificar_clientes_fornecedores();  -- seta excluir_da_carteira
+-- cleanup reversível:
+UPDATE carteira_assignments SET eligible = false, updated_at = now()
+ WHERE customer_user_id IN (SELECT user_id FROM cliente_classificacao WHERE excluir_da_carteira);
+DELETE FROM customer_visit_scores WHERE customer_user_id IN (SELECT user_id FROM cliente_classificacao WHERE excluir_da_carteira);
+DELETE FROM farmer_client_scores  WHERE customer_user_id IN (SELECT user_id FROM cliente_classificacao WHERE excluir_da_carteira);
+```
+
+- [ ] **Step 4: Verificação antes/depois**: contar fornecedores na carteira antes/depois; conferir que Caxias do Sul esvaziou; reverter 1 caso de teste com `reverter_exclusao_fornecedor()` e confirmar volta.
+- [ ] **Step 5: Commit** — `git commit -m "docs(fornecedores): diagnóstico + curadoria + cleanup SQL"`
+
+---
+
+## ROLLOUT (ordem manual no Lovable — filtros ANTES da flag)
+
+1. **Migrations A + B** no SQL Editor (Tasks 2, 3). Flags nascem `false` (no-op).
+2. **Deploy** dos consumidores COM filtro (Tasks 6, 7) — enquanto tudo é `false` (zero efeito).
+3. **Deploy + rodar** o `omie-analytics-sync` (Task 4) → popula `cliente_classificacao.tags_omie`.
+4. **Diagnóstico** (Task 9 Step 1) → founder cura exceções (Step 2).
+5. **Classificar + cleanup** (Task 9 Step 3) — sob lock, após curadoria.
+6. **Publish** do front (Task 8) + **verificação** (Step 4).
+
+---
+
+## Self-Review
+
+- **Spec coverage:** §4.1→T2; §4.2→T4; §4.3→T3; §4.4→T6/T7/T8; §4.5→T9; §4.6→T3 (reverter); §4.7→T9; §6 rollout→seção ROLLOUT; §8 RLS→T2; §10 testes→T1/T5. ✅
+- **Placeholders:** as RPCs e o helper têm código real; os edges descrevem o filtro exato + arquivo/região (o subagente lê o arquivo pro diff). `tem_venda_real` não distingue devolução na v1 (informativo) — registrado.
+- **Type consistency:** `excluir_da_carteira`/`is_fornecedor`/`tags_omie`/`tem_venda_real` idênticos em TS, SQL e queries. `TAGS_NAO_CLIENTE` = `['fornecedor','transportadora']` em TS e SQL (lower).
+- **Risco aberto p/ a execução:** confirmar em prod (diagnóstico) que `ListarClientes` realmente retorna `tags` populadas (o app lê na busca pontual; o batch pode diferir) — se vier vazio, a captura é no-op e o sinal precisa de outra rota. **Validar com 1 cadastro conhecido (JAMEF) antes do cleanup.**

--- a/docs/superpowers/specs/2026-06-06-fornecedores-fora-da-carteira-design.md
+++ b/docs/superpowers/specs/2026-06-06-fornecedores-fora-da-carteira-design.md
@@ -1,0 +1,158 @@
+# Fornecedores fora da carteira — Fase 1 (limpar a fila de visita/ligação)
+
+> Spec de design **v2** (tag-based, pós-Codex). Data: 2026-06-06. Origem: brainstorming a partir do card "Visitas sugeridas" (`/meu-dia`), que sugeria **visitar fornecedores** e mostrava "Cliente sem nome".
+>
+> **v1 → v2:** a v1 assumia um sync de `ListarFornecedores` + flag por empresa. O passe adversário do Codex (gpt-5.5) derrubou as duas premissas. v2 usa **tag do cadastro** (o sinal real do Omie) + identidade por **CNPJ/usuário** + os 9 P1 resolvidos. O histórico está em §11.
+
+---
+
+## 1. Problema
+
+No Omie **um cadastro pode ser cliente E fornecedor (mesmo registro)**. Quando há **NF de devolução** para um fornecedor, o Omie **marca o cadastro também como cliente**. Consequência:
+
+- Fornecedores e transportadoras (ex.: **JAMEF**) entram como clientes, caem na **carteira**, ganham `visit_score` (missão **Prospecção 70**, porque `sales_orders_count = 0` — [missions.ts:65](../../../src/lib/visit-scoring/missions.ts)) e aparecem como **"Cliente sem nome"** (profile sem `razao_social` — [useMyVisitSuggestions.ts:129](../../../src/hooks/useMyVisitSuggestions.ts)).
+- Poluem **Sugestões de visita**, **Lista de ligação**, **positivação MTD** e KPIs.
+- **Hipótese forte:** **Caxias do Sul (RS)** aparece por concentrar **fornecedores** (polo do RS), não clientes da Oben (MG). "Tirar fornecedor" ≈ "tirar Caxias".
+
+## 2. Decisões do founder (fixas)
+
+1. **Sinal** = **tag do cadastro do Omie** ∈ `{Fornecedor, Transportadora}` *(confirmado pelo founder; lista extensível — ver §9)*. O Omie é cadastro unificado (`geral/clientes`), e o app **já lê** `c.tags` na busca; só não persiste.
+2. **Critério** = **curadoria humana**. O assistente gera a lista de quem tem a tag **E** está na carteira; o founder marca as **exceções** (fornecedor que é cliente real). O resto sai. *(Critério automático de recorrência rejeitado — mas a curadoria é informada: §4.8.)*
+3. **Profundidade** = não entra na carteira de **nenhum** vendedor (raiz). Cascateia para visita → ligação → positivação → KPIs.
+4. **Aplicação** = **reversível**, respeitada por todos. Não deletar o cadastro; remover a exceção reverte.
+
+## 3. Estado atual (como a carteira nasce)
+
+```
+omie_clientes ─(carteira-rebuild, cron)─▶ carteira_assignments(eligible) ─seed─▶ farmer_client_scores ─▶ customer_visit_scores
+                                                  │                                                              │            │
+                                       (get_minha_positivacao)                              (useMyVisitSuggestions)   (useRouteContactList)
+```
+
+- **`carteira-rebuild`**: enumera `omie_clientes`, resolve dono por `omie_codigo_vendedor × omie_vendedor_map` senão `hunter_orphan`; **UPSERT** por `customer_user_id`. **Nunca DELETA**; tem coluna **`eligible`** (default true).
+- **`get_minha_positivacao`** (RPC, [migration 20260525120000](../../../supabase/migrations/20260525120000_positivacao_kpis.sql)): elegíveis vêm **100% de `carteira_assignments.eligible = true`** — *não* de scores/omie_clientes. ✅ Por isso o corte usa **`eligible = false`** (já respeitado, reversível), não DELETE.
+- **Escritores de score** (precisam respeitar o corte): `calculate-scores` (seed de `farmer_client_scores`, só se a tabela estiver vazia), `scoring-recalc-client` + `scoring-recalc-batch` (upsert em `farmer_client_scores`, **fallback no ator** quando não há assignment), `visit-score-recalc-batch` (resolve dono via carteira) + `visit-score-recalc-client` (drain da fila `visit_score_recalc_pending`).
+- **`useFarmerScoring`** ([hook](../../../src/hooks/useFarmerScoring.ts)): calcula de **todos os `sales_orders`** (sem carteira) e **persiste** `farmer_client_scores` (upsert, quando `!isImpersonating`). Ressuscita fornecedor se não filtrar o **universo**.
+- **`omie_clientes` é mal-modelado** (Codex P1): o sync faz `upsert` por `user_id`, **não grava `empresa_omie`** (default `colacor`), PK só em `id`. → **a identidade do nosso corte é por `user_id`/CNPJ**, não por `(empresa, código)`.
+
+## 4. Desenho v2
+
+### 4.1 Onde guardar (schema novo — migration manual)
+
+- **`cliente_classificacao`** — fonte da verdade reversível, **por `user_id`**.
+  - `user_id uuid PK`, `tags_omie text[]`, `is_fornecedor boolean`, `excluir_da_carteira boolean DEFAULT false`, `tem_venda_real boolean`, `fonte text`, `updated_at timestamptz`.
+  - RLS: SELECT staff; **escrita só `service_role`/RPC curada** (resolve o P1 de segurança — employee não mexe na flag).
+- **`fornecedor_excecao`** — exceções curadas: `user_id PK`, `motivo`, `criado_por`, `criado_em`. RLS: escrita master, leitura staff.
+- **`cliente_tags_staging`** — staging do sync: `(run_id, user_id, cnpj, tags_omie)`. Promoção atômica só quando o run completa (P1 idempotência).
+
+*Por que tabela nova e não coluna em `omie_clientes`:* `omie_clientes` é mal-modelado (§3) e tem RLS aberta a employee. Uma tabela por `user_id` dá identidade limpa + RLS própria.
+
+### 4.2 Sync das tags (edge)
+
+- Reusar a enumeração que **já existe** no `syncNaoVinculados` (`omie-analytics-sync`) — ela já varre `ListarClientes` de **todas as contas**; adicionar a captura de `c.tags`. (Alternativa: edge dedicada `omie-tags-sync`. Decidir no plano; preferência por reusar a varredura.)
+- Background + retry/backoff (o `callOmie*` já trata "SOAP broken response") + paginação **data-driven** (até página vazia; não confiar em `total_de_paginas`; `registros_por_pagina` capa em 100).
+- Grava em `cliente_tags_staging(run_id, ...)`; **promoção atômica** para `cliente_classificacao` (`tags_omie`/`is_fornecedor`) só quando o run completa. Identidade `user_id` resolvida por CNPJ (`profiles.document`).
+- Cron leve diário.
+
+### 4.3 Classificação (RPC idempotente + recorrente)
+
+`classificar_clientes_fornecedores()` (SECURITY DEFINER; service_role/master):
+
+```
+is_fornecedor        = tags_omie && ARRAY['Fornecedor','Transportadora']   -- overlap
+tem_venda_real       = EXISTS sales_orders válido (não-cancelado, não-devolução)
+excluir_da_carteira  = is_fornecedor AND NOT EXISTS (fornecedor_excecao por user_id)
+```
+
+- **Recorrência (P1):** roda **após cada promoção de sync** e por **trigger** no insert/update de vínculo (NF de devolução futura cria cadastro novo → re-classifica). Não é one-time.
+- `tem_venda_real` é **informativo** (alimenta o diagnóstico/curadoria, §4.8) — **não** altera a exclusão automaticamente (respeita a decisão do founder; é a rede de segurança contra excluir cliente real).
+
+### 4.4 Filtro nos escritores (lista COMPLETA — Codex)
+
+| Escritor | Parte da carteira? | Ação |
+|---|---|---|
+| `carteira-rebuild` | — | `eligible = NOT excluir_da_carteira` (não some da tabela; só vira inelegível). |
+| `calculate-scores` (seed) | sim | Enumera só `eligible`. |
+| `visit-score-recalc-batch` | sim | Pula quem não tem assignment elegível (evita fallback no ator). |
+| `scoring-recalc-batch`/`-client` | **não** (fallback ator) | **Filtro explícito** por `excluir_da_carteira` antes do upsert. |
+| `visit-score-recalc-client` (drain) | **não** | **Filtro explícito** — um único contato não ressuscita. |
+| `useFarmerScoring` (front) | **não** | Filtrar o **universo** (`sales_orders`) **antes** do cálculo, não só o upsert. |
+
+- **`customer_metrics_mv`**: sem ação (enriquecimento, não universo da fila).
+
+### 4.5 Cleanup (reversível, por `user_id`)
+
+- **`carteira_assignments.eligible = false`** para os flaggeds → a **positivação some** (ela filtra `eligible`) e é **reversível** (a coluna já existe). Não DELETE em `carteira_assignments`.
+- **DELETE** em `customer_visit_scores` e `farmer_client_scores` dos flaggeds (derivadas reconstruíveis) → some da visita/ligação.
+- Identidade **por `user_id`** (não empresa). O `carteira-rebuild` aplica o `eligible` a cada execução (não só na 1ª vez).
+
+### 4.6 Reversão com backfill (P1)
+
+Remover a exceção **não basta** — `calculate-scores` só faz seed com a tabela vazia, e sem atividade `customer_visit_scores` não nasce. A transição `excluir → manter` precisa, explicitamente: re-classificar → `carteira-rebuild` (volta `eligible=true`) → **enfileirar** `visit_score_recalc_pending` + **forçar seed** de `farmer_client_scores` para aquele `user_id`. Encapsular numa RPC `reverter_exclusao_fornecedor(user_id)`.
+
+### 4.7 Diagnóstico + curadoria informada
+
+Query (SQL Editor): candidatos = `user` com tag ∈ {Fornecedor, Transportadora} **E** na carteira, com **nome, cidade/UF, vendedor dono, nº de vendas reais, última compra, receita 12m**. Ordena prováveis-fornecedor-puro (zero venda) primeiro; **quem tem venda recente vem pré-marcado "revise antes de excluir"**. Confirma com número a hipótese "Caxias = fornecedores".
+
+## 5. Fluxo
+
+```
+ListarClientes (tags, 3 contas) ─▶ cliente_tags_staging ─(promote)─▶ cliente_classificacao
+                                          fornecedor_excecao (curadoria) ─┘
+                                                       │ classificar_clientes_fornecedores()
+                                                       ▼
+              carteira_assignments.eligible=false + DELETE scores  ─▶  visita/ligação/positivação limpas
+              (escritores que não partem da carteira filtram a flag)
+```
+
+## 6. Ordem de rollout (corrigida — filtros ANTES da flag)
+
+1. **Migrations** (SQL Editor): `cliente_classificacao` + `fornecedor_excecao` + `cliente_tags_staging` + `classificar_clientes_fornecedores()` + `reverter_exclusao_fornecedor()`. Flags nascem todas `false` (no-op).
+2. **Deploy dos consumidores COM o filtro** (carteira-rebuild, calculate-scores, scoring-recalc-*, visit-score-recalc-*) — **primeiro**, enquanto tudo é `false` (zero efeito).
+3. **Deploy + rodar** o sync de tags → popula `cliente_classificacao` (`is_fornecedor`).
+4. **Diagnóstico** (query) → founder revisa → insere exceções.
+5. **Classificar + cleanup** juntos, sob lock (seta `excluir_da_carteira`, `eligible=false`, DELETE scores).
+6. **Verificação** (antes/depois; Caxias; reversão de um caso).
+7. **(Front)** `useFarmerScoring` + Publish.
+
+## 7. Não-objetivos (v1)
+
+- Critério automático de exclusão por recorrência (rejeitado).
+- Tela de gestão de exceções (curadoria via lista/SQL por ora).
+- "Cliente sem nome" que **não** é fornecedor (cadastro incompleto) — qualidade de dado, follow-up.
+- Curadoria de cidade (consequência; retoque à parte se sobrar).
+- `omie_clientes_nao_vinculados` (Codex P2 — fornecedor sem profile ainda polui essa tela de gestão; follow-up).
+- Reescrever a modelagem de `omie_clientes` (mal-modelado, mas fora do escopo — contornado pela identidade por `user_id`).
+
+## 8. Segurança / RLS
+
+- `cliente_classificacao` e `fornecedor_excecao`: escrita **master/`service_role`** apenas; leitura staff. A flag **não** é editável por vendedor (corrige o P1 de RLS aberta de `omie_clientes`).
+- Lente "ver como pessoa": read-only, sem novo vazamento (já filtra na fonte limpa).
+
+## 9. A confirmar / parametrizável
+
+- **Lista de tags de "não-cliente"**: hoje `{Fornecedor, Transportadora}`. Há outras a incluir (ex.: Funcionário, Contador)? — parametrizado na classificação, fácil de estender.
+- **Disciplina da marcação**: o diagnóstico revela quantos fornecedores conhecidos têm a tag (cobertura). Quem não tiver tag escapa até ser marcado no Omie — aceitável (curadoria pega o resto).
+
+## 10. Testes / verificação
+
+- **Helpers puros TS** (overlap de tags; regra de `excluir_da_carteira`) com vitest.
+- **Validação SQL local (PG17)**: `classificar_clientes_fornecedores()`, cleanup (multi-linha por user, `eligible=false`), `reverter_exclusao_fornecedor()` (scores renascem) — padrão `db/test-*.sh`.
+- **Aceitação = diagnóstico com número real**: antes/depois (quantos saíram; Caxias esvaziou?), reversão (exceção → cadastro + scores voltam).
+
+## 11. Histórico da revisão
+
+### 11a. Crítica solo (v1, antes do Codex)
+Apontou: ressurreição por escritores de score; cleanup por flag (não "deixar o recalc limpar"); flag em `omie_clientes`; cruzamento por `(empresa,código)`; reversão; 3 contas; curadoria informada; rollout filtro-antes-do-cleanup.
+
+### 11b. Codex adversarial (gpt-5.5, high) — 9 P1 que geraram a v2
+1. **Fonte não existe** (`ListarFornecedores`) → tag no cadastro unificado → **§2/§4.1-4.2**.
+2. **`omie_clientes` não é multiempresa** → identidade por `user_id`/CNPJ → **§3/§4.1**.
+3. **Escritor omitido** `scoring-recalc-client` → **§4.4**.
+4. **`useFarmerScoring`** filtra universo, não só upsert → **§4.4**.
+5. **Reversibilidade quebrada** (scores não renascem) → **§4.6**.
+6. **Recorrência** (fornecedor novo entra) → classificação pós-sync + trigger → **§4.3**.
+7. **Idempotência/staging** → **§4.1/§4.2**.
+8. **Rollout invertido** → filtros antes da flag → **§6**.
+9. **RLS aberta** da flag → tabela própria service_role → **§4.1/§8**.
+P2: rebuild last-write-wins em múltiplas linhas/user; vazamentos laterais (`nao_vinculados`, snapshots de positivação) → **§7**.

--- a/src/lib/fornecedores/__tests__/classificacao.test.ts
+++ b/src/lib/fornecedores/__tests__/classificacao.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { TAGS_NAO_CLIENTE, temTagNaoCliente, deveExcluirDaCarteira } from '../classificacao';
+
+describe('temTagNaoCliente', () => {
+  it('detecta Fornecedor com case/acento variável', () => {
+    expect(temTagNaoCliente(['Fornecedor'])).toBe(true);
+    expect(temTagNaoCliente(['FORNECEDOR'])).toBe(true);
+    expect(temTagNaoCliente([' transportadora '])).toBe(true);
+  });
+  it('cliente comum não tem tag', () => {
+    expect(temTagNaoCliente(['Cliente VIP', 'Moveleiro'])).toBe(false);
+    expect(temTagNaoCliente([])).toBe(false);
+    expect(temTagNaoCliente(null as unknown as string[])).toBe(false);
+  });
+  it('TAGS_NAO_CLIENTE é a lista canônica', () => {
+    expect(TAGS_NAO_CLIENTE).toEqual(['fornecedor', 'transportadora']);
+  });
+});
+
+describe('deveExcluirDaCarteira', () => {
+  it('fornecedor sem exceção → exclui', () => {
+    expect(deveExcluirDaCarteira({ tags: ['Fornecedor'], isExcecao: false })).toBe(true);
+  });
+  it('fornecedor COM exceção (cliente real) → mantém', () => {
+    expect(deveExcluirDaCarteira({ tags: ['Fornecedor'], isExcecao: true })).toBe(false);
+  });
+  it('não-fornecedor → mantém (independe de exceção)', () => {
+    expect(deveExcluirDaCarteira({ tags: ['Cliente'], isExcecao: false })).toBe(false);
+  });
+});

--- a/src/lib/fornecedores/classificacao.ts
+++ b/src/lib/fornecedores/classificacao.ts
@@ -1,0 +1,11 @@
+/** Tags do Omie que marcam "não é cliente de venda". Comparação case/acento-insensível. */
+export const TAGS_NAO_CLIENTE = ['fornecedor', 'transportadora'] as const;
+
+export function temTagNaoCliente(tags: string[] | null | undefined): boolean {
+  if (!tags) return false;
+  return tags.some((t) => (TAGS_NAO_CLIENTE as readonly string[]).includes(t.trim().toLowerCase()));
+}
+
+export function deveExcluirDaCarteira(input: { tags: string[] | null | undefined; isExcecao: boolean }): boolean {
+  return temTagNaoCliente(input.tags) && !input.isExcecao;
+}

--- a/supabase/functions/omie-analytics-sync/index.ts
+++ b/supabase/functions/omie-analytics-sync/index.ts
@@ -65,6 +65,7 @@ interface OmieClienteCadastro {
   nome_fantasia?: string;
   cidade?: string;
   estado?: string;
+  tags?: Array<{ tag?: string } | string>;
 }
 
 interface OmieListarClientesResponse {
@@ -311,6 +312,7 @@ async function syncCustomers(db: SupabaseClient, account: OmieAccount) {
       omie_codigo_vendedor: number | null;
       updated_at: string;
     }>();
+    const tagsByUser = new Map<string, string[]>();
     let pagina = 1;
     let totalPaginas = 1;
 
@@ -336,6 +338,11 @@ async function syncCustomers(db: SupabaseClient, account: OmieAccount) {
           omie_codigo_vendedor: c.codigo_vendedor || null,
           updated_at: new Date().toISOString(),
         });
+        // Captura tags do cadastro Omie para derivar is_fornecedor / excluir_da_carteira depois.
+        const tags = (c.tags || [])
+          .map((t) => (typeof t === "string" ? t : (t.tag ?? "")))
+          .filter((t) => t.length > 0);
+        tagsByUser.set(userId, tags);
       }
 
       console.log(`[Sync ${account}] Clientes página ${pagina}/${totalPaginas}`);
@@ -352,6 +359,23 @@ async function syncCustomers(db: SupabaseClient, account: OmieAccount) {
       if (upErr) throw new Error(`upsert omie_clientes: ${upErr.message}`);
       totalSynced += chunk.length;
     }
+
+    // Upsert das tags em cliente_classificacao (prova se o ListarClientes em lote retorna tags).
+    // Grava user_id + tags_omie + tags_synced_at; as colunas derivadas (is_fornecedor,
+    // excluir_da_carteira) ficam com o default da tabela e serão calculadas em outra tarefa.
+    const tagsNowIso = new Date().toISOString();
+    const tagRows = Array.from(tagsByUser.entries()).map(([user_id, tags_omie]) => ({
+      user_id,
+      tags_omie,
+      tags_synced_at: tagsNowIso,
+    }));
+    for (let i = 0; i < tagRows.length; i += 500) {
+      const { error: tagErr } = await db
+        .from("cliente_classificacao")
+        .upsert(tagRows.slice(i, i + 500), { onConflict: "user_id" });
+      if (tagErr) throw new Error(`upsert cliente_classificacao: ${tagErr.message}`);
+    }
+    console.log(`[Sync ${account}] tags gravadas em cliente_classificacao: ${tagRows.length} clientes`);
 
     await updateSyncState(db, "customers", account, {
       status: "complete",

--- a/supabase/migrations/20260606170000_fornecedores_classificacao_schema.sql
+++ b/supabase/migrations/20260606170000_fornecedores_classificacao_schema.sql
@@ -1,0 +1,63 @@
+-- Fase 1 — Fornecedores fora da carteira: schema de classificação + exceções (curadoria).
+-- Identidade por user_id (omie_clientes é mal-modelado — não guarda empresa de forma confiável).
+-- RLS: leitura staff; escrita da FLAG só service_role/RPC (employee NÃO altera a flag — P1 do Codex).
+-- Idempotente (re-rodável): CREATE TABLE IF NOT EXISTS + DROP POLICY IF EXISTS antes de cada CREATE.
+
+-- ============================================================
+-- cliente_classificacao — fonte da verdade reversível (por user_id)
+-- ============================================================
+CREATE TABLE IF NOT EXISTS public.cliente_classificacao (
+  user_id              uuid PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  tags_omie            text[]      NOT NULL DEFAULT '{}',
+  is_fornecedor        boolean     NOT NULL DEFAULT false,
+  excluir_da_carteira  boolean     NOT NULL DEFAULT false,
+  tem_venda_real       boolean     NOT NULL DEFAULT false,
+  tags_synced_at       timestamptz,
+  updated_at           timestamptz NOT NULL DEFAULT now()
+);
+ALTER TABLE public.cliente_classificacao ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "staff read classificacao" ON public.cliente_classificacao;
+CREATE POLICY "staff read classificacao" ON public.cliente_classificacao
+  FOR SELECT TO authenticated
+  USING (public.has_role(auth.uid(), 'master'::public.app_role)
+      OR public.has_role(auth.uid(), 'employee'::public.app_role));
+
+DROP POLICY IF EXISTS "service_role manage classificacao" ON public.cliente_classificacao;
+CREATE POLICY "service_role manage classificacao" ON public.cliente_classificacao
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+-- ============================================================
+-- fornecedor_excecao — curadoria do founder (fornecedor que É cliente real → fica)
+-- ============================================================
+CREATE TABLE IF NOT EXISTS public.fornecedor_excecao (
+  user_id     uuid PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  motivo      text,
+  criado_por  uuid,
+  criado_em   timestamptz NOT NULL DEFAULT now()
+);
+ALTER TABLE public.fornecedor_excecao ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "staff read excecao" ON public.fornecedor_excecao;
+CREATE POLICY "staff read excecao" ON public.fornecedor_excecao
+  FOR SELECT TO authenticated
+  USING (public.has_role(auth.uid(), 'master'::public.app_role)
+      OR public.has_role(auth.uid(), 'employee'::public.app_role));
+
+DROP POLICY IF EXISTS "master manage excecao" ON public.fornecedor_excecao;
+CREATE POLICY "master manage excecao" ON public.fornecedor_excecao
+  FOR ALL TO authenticated
+  USING (public.has_role(auth.uid(), 'master'::public.app_role))
+  WITH CHECK (public.has_role(auth.uid(), 'master'::public.app_role));
+
+DROP POLICY IF EXISTS "service_role manage excecao" ON public.fornecedor_excecao;
+CREATE POLICY "service_role manage excecao" ON public.fornecedor_excecao
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+-- ============================================================
+-- Validação (cole no SQL Editor e confira: tabelas = 2)
+-- ============================================================
+SELECT 'MIGRATION A OK' AS status,
+  (SELECT count(*) FROM information_schema.tables
+     WHERE table_schema = 'public'
+       AND table_name IN ('cliente_classificacao', 'fornecedor_excecao')) AS tabelas;


### PR DESCRIPTION
## Fase 1 — Fornecedores fora da carteira (fatia fina: provar a fonte)

Tira fornecedores/transportadoras (tag do Omie) da carteira comercial — eles deixam de poluir sugestão de visita, lista de ligação, positivação e KPIs. Esta é a **fatia fina** que prova a fonte do sinal **antes** de construir o resto (decisão: validar que o `ListarClientes` em lote retorna `tags`).

### O que entra
- `src/lib/fornecedores/classificacao.ts` — helper puro (tag → exclusão), 6 testes. Oráculo do SQL.
- migration `20260606170000` — `cliente_classificacao` + `fornecedor_excecao` + RLS (escrita da flag só `service_role`/master).
- `omie-analytics-sync` (`syncCustomers`) — captura `c.tags` do `ListarClientes` → grava `cliente_classificacao.tags_omie`. **Aditivo**; degrada para `tags_omie=[]` se a fonte falhar.

### ⚠️ ATENÇÃO: migration manual necessária
Aplicar o BLOCO A no SQL Editor **ANTES** de deployar o `omie-analytics-sync` (senão o sync quebra ao gravar numa tabela inexistente).

```sql
CREATE TABLE IF NOT EXISTS public.cliente_classificacao (
  user_id              uuid PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
  tags_omie            text[]      NOT NULL DEFAULT '{}',
  is_fornecedor        boolean     NOT NULL DEFAULT false,
  excluir_da_carteira  boolean     NOT NULL DEFAULT false,
  tem_venda_real       boolean     NOT NULL DEFAULT false,
  tags_synced_at       timestamptz,
  updated_at           timestamptz NOT NULL DEFAULT now()
);
ALTER TABLE public.cliente_classificacao ENABLE ROW LEVEL SECURITY;
DROP POLICY IF EXISTS "staff read classificacao" ON public.cliente_classificacao;
CREATE POLICY "staff read classificacao" ON public.cliente_classificacao
  FOR SELECT TO authenticated
  USING (public.has_role(auth.uid(), 'master'::public.app_role)
      OR public.has_role(auth.uid(), 'employee'::public.app_role));
DROP POLICY IF EXISTS "service_role manage classificacao" ON public.cliente_classificacao;
CREATE POLICY "service_role manage classificacao" ON public.cliente_classificacao
  FOR ALL TO service_role USING (true) WITH CHECK (true);

CREATE TABLE IF NOT EXISTS public.fornecedor_excecao (
  user_id     uuid PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
  motivo      text,
  criado_por  uuid,
  criado_em   timestamptz NOT NULL DEFAULT now()
);
ALTER TABLE public.fornecedor_excecao ENABLE ROW LEVEL SECURITY;
DROP POLICY IF EXISTS "staff read excecao" ON public.fornecedor_excecao;
CREATE POLICY "staff read excecao" ON public.fornecedor_excecao
  FOR SELECT TO authenticated
  USING (public.has_role(auth.uid(), 'master'::public.app_role)
      OR public.has_role(auth.uid(), 'employee'::public.app_role));
DROP POLICY IF EXISTS "master manage excecao" ON public.fornecedor_excecao;
CREATE POLICY "master manage excecao" ON public.fornecedor_excecao
  FOR ALL TO authenticated
  USING (public.has_role(auth.uid(), 'master'::public.app_role))
  WITH CHECK (public.has_role(auth.uid(), 'master'::public.app_role));
DROP POLICY IF EXISTS "service_role manage excecao" ON public.fornecedor_excecao;
CREATE POLICY "service_role manage excecao" ON public.fornecedor_excecao
  FOR ALL TO service_role USING (true) WITH CHECK (true);
```

### Validar a fonte (após merge)
1. SQL Editor → BLOCO A → `tabelas=2`.
2. Chat do Lovable → deploy `omie-analytics-sync` (**após** BLOCO A).
3. Invocar `{ "action": "sync_customers", "account": "vendas" }` (Oben).
4. Conferir `cliente_classificacao`: `com_alguma_tag > 0` e JAMEF com `{Transportadora}` = fonte provada.

### Contexto
- Spec: `docs/superpowers/specs/2026-06-06-fornecedores-fora-da-carteira-design.md`
- Plano: `docs/superpowers/plans/2026-06-06-fornecedores-fora-da-carteira.md`
- Validado por Codex adversarial (9 P1 incorporados na v2). O resto (RPCs, filtros nos escritores, cleanup) só vem **depois** da fonte confirmada.
- CI local: test 2728/2728 · typecheck 0 · lint 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
