### PR TITLE
feat(melhorias): toggle no topo (popover + badge) substitui item do menu lateral

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -21,7 +21,7 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip';
 import { HelpDrawer } from '@/components/help/HelpDrawer';
-import { MelhoriaDialog } from '@/components/melhorias/MelhoriaDialog';
+import { MelhoriasPopover } from '@/components/melhorias/MelhoriasPopover';
 import { useMelhoriasBadge } from '@/hooks/useMelhorias';
 import { useAlertasCriticos } from '@/hooks/useAlertasCriticos';
 import { useFinanceiroAlertas } from '@/hooks/useFinanceiroAlertas';
@@ -74,7 +74,6 @@ const unifiedNavSections: { title: string; items: NavItem[] }[] = [
       { icon: LayoutDashboard, label: 'Dashboard', path: '/' },
       { icon: Target, label: 'Meu dia', path: '/meu-dia' },
       { icon: Users, label: 'Clientes', path: '/admin/customers' },
-      { icon: Lightbulb, label: 'Melhorias', path: '/melhorias', staffOnly: true },
     ],
   },
   {
@@ -696,7 +695,6 @@ function AppTopbar({ sidebarCollapsed, onMobileMenuToggle }: { sidebarCollapsed:
   const { signOut } = useAuth();
   const { isImpersonating } = useImpersonation();
   const { displayIsStaff } = useDisplayAccess();
-  const [melhoriaOpen, setMelhoriaOpen] = useState(false);
 
   return (
     <header
@@ -727,22 +725,7 @@ function AppTopbar({ sidebarCollapsed, onMobileMenuToggle }: { sidebarCollapsed:
         <NetworkStatusIndicator />
         <DataHealthBadge />
         <ThemeToggle />
-        {displayIsStaff && (
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="h-8 w-8 text-muted-foreground"
-                onClick={() => setMelhoriaOpen(true)}
-                aria-label="Sugerir melhoria ou reportar problema"
-              >
-                <Lightbulb className="w-4 h-4" />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>Sugerir melhoria · reportar problema</TooltipContent>
-          </Tooltip>
-        )}
+        {displayIsStaff && <MelhoriasPopover />}
         <HelpDrawer />
 
         <DropdownMenu>
@@ -763,7 +746,6 @@ function AppTopbar({ sidebarCollapsed, onMobileMenuToggle }: { sidebarCollapsed:
         </DropdownMenu>
       </div>
 
-      <MelhoriaDialog open={melhoriaOpen} onOpenChange={setMelhoriaOpen} />
     </header>
   );
 }

--- a/src/components/melhorias/MelhoriaStatusBadge.tsx
+++ b/src/components/melhorias/MelhoriaStatusBadge.tsx
@@ -1,0 +1,39 @@
+// src/components/melhorias/MelhoriaStatusBadge.tsx
+// Pílula de status de melhoria — compartilhada entre a página /melhorias e o
+// popover "Minhas melhorias" do topo (fonte única das cores/labels de status).
+import { cn } from '@/lib/utils';
+import type { MelhoriaStatus } from '@/lib/melhorias/types';
+
+const STATUS_LABEL: Record<MelhoriaStatus, string> = {
+  aberto: 'Aberto',
+  em_andamento: 'Em andamento',
+  resolvido: 'Resolvido',
+  descartado: 'Descartado',
+};
+
+const STATUS_CLASSES: Record<MelhoriaStatus, string> = {
+  aberto: 'bg-status-info-bg text-status-info border-transparent',
+  em_andamento: 'bg-status-warning-bg text-status-warning border-transparent',
+  resolvido: 'bg-status-success-bg text-status-success border-transparent',
+  descartado: 'bg-muted text-muted-foreground border-transparent',
+};
+
+export function MelhoriaStatusBadge({
+  status,
+  className,
+}: {
+  status: MelhoriaStatus;
+  className?: string;
+}) {
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-semibold',
+        STATUS_CLASSES[status],
+        className,
+      )}
+    >
+      {STATUS_LABEL[status]}
+    </span>
+  );
+}

--- a/src/components/melhorias/MelhoriasPopover.tsx
+++ b/src/components/melhorias/MelhoriasPopover.tsx
@@ -1,0 +1,140 @@
+// src/components/melhorias/MelhoriasPopover.tsx
+// Toggle "Minhas melhorias" no topo: badge de não-resolvidos + popover com a
+// lista enxuta, atalho de Reportar (MelhoriaDialog) e "Ver todas" (/melhorias).
+// Substituiu o item do menu lateral + a lâmpada solta da topbar (decisão Lucas, 2026-06-15).
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Lightbulb, Plus, Loader2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover';
+import { MelhoriaDialog } from '@/components/melhorias/MelhoriaDialog';
+import { MelhoriaStatusBadge } from '@/components/melhorias/MelhoriaStatusBadge';
+import { useMeusMelhoriaItens } from '@/hooks/useMelhorias';
+import { contarMelhoriasNaoResolvidas } from '@/lib/melhorias/badge-helpers';
+
+const MAX_LISTA = 6;
+
+function fmtData(iso: string): string {
+  return new Date(iso).toLocaleDateString('pt-BR', { day: '2-digit', month: '2-digit' });
+}
+
+export function MelhoriasPopover() {
+  const navigate = useNavigate();
+  const [open, setOpen] = useState(false);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const { data: itens, isLoading } = useMeusMelhoriaItens();
+
+  const naoResolvidos = contarMelhoriasNaoResolvidas(itens ?? []);
+  const recentes = (itens ?? []).slice(0, MAX_LISTA);
+
+  const abrirReportar = () => {
+    setOpen(false);
+    setDialogOpen(true);
+  };
+
+  const irParaPagina = () => {
+    setOpen(false);
+    navigate('/melhorias');
+  };
+
+  return (
+    <>
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="relative h-8 w-8 text-muted-foreground"
+            aria-label={
+              naoResolvidos > 0
+                ? `Minhas melhorias — ${naoResolvidos} em aberto`
+                : 'Minhas melhorias'
+            }
+          >
+            <Lightbulb className="w-4 h-4" />
+            {naoResolvidos > 0 && (
+              <span className="absolute -top-0.5 -right-0.5 flex h-4 min-w-[1rem] items-center justify-center rounded-full bg-primary px-1 text-[10px] font-semibold leading-none text-primary-foreground">
+                {naoResolvidos > 9 ? '9+' : naoResolvidos}
+              </span>
+            )}
+          </Button>
+        </PopoverTrigger>
+
+        <PopoverContent align="end" className="w-80 p-2">
+          {/* Cabeçalho */}
+          <div className="flex items-center justify-between gap-2 border-b px-1 pb-2">
+            <p className="text-sm font-semibold">Minhas melhorias</p>
+            <Button
+              size="sm"
+              variant="ghost"
+              className="h-7 px-2 text-xs"
+              onClick={abrirReportar}
+            >
+              <Plus className="mr-1 h-3.5 w-3.5" />
+              Reportar
+            </Button>
+          </div>
+
+          {/* Conteúdo */}
+          <div className="py-1">
+            {isLoading ? (
+              <div className="flex items-center gap-2 px-1 py-6 text-sm text-muted-foreground">
+                <Loader2 className="h-4 w-4 animate-spin" /> Carregando…
+              </div>
+            ) : recentes.length === 0 ? (
+              <div className="px-2 py-6 text-center">
+                <Lightbulb className="mx-auto mb-2 h-6 w-6 text-muted-foreground" />
+                <p className="text-sm font-medium">Nenhuma melhoria ainda</p>
+                <p className="mt-0.5 text-xs text-muted-foreground">
+                  Reporte um problema ou sugestão — a IA avalia e o Lucas recebe na hora.
+                </p>
+              </div>
+            ) : (
+              <ul className="space-y-0.5">
+                {recentes.map((item) => (
+                  <li key={item.id}>
+                    <button
+                      type="button"
+                      onClick={irParaPagina}
+                      className="flex w-full items-start gap-2 rounded-md p-2 text-left transition-colors hover:bg-muted/60"
+                    >
+                      <div className="min-w-0 flex-1">
+                        <p className="truncate text-sm font-medium text-foreground">
+                          {item.titulo ?? 'Aguardando avaliação…'}
+                        </p>
+                        <div className="mt-1 flex items-center gap-1.5">
+                          <MelhoriaStatusBadge status={item.status} />
+                          <span className="text-xs text-muted-foreground">
+                            {fmtData(item.created_at)}
+                          </span>
+                        </div>
+                      </div>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+
+          {/* Rodapé */}
+          <div className="border-t pt-1">
+            <Button
+              variant="ghost"
+              size="sm"
+              className="w-full justify-center text-xs"
+              onClick={irParaPagina}
+            >
+              Ver todas
+            </Button>
+          </div>
+        </PopoverContent>
+      </Popover>
+
+      <MelhoriaDialog open={dialogOpen} onOpenChange={setDialogOpen} />
+    </>
+  );
+}

--- a/src/lib/melhorias/__tests__/badge-helpers.test.ts
+++ b/src/lib/melhorias/__tests__/badge-helpers.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import {
+  contarMelhoriasNaoResolvidas,
+  isMelhoriaNaoResolvida,
+} from '../badge-helpers';
+import type { MelhoriaStatus } from '../types';
+
+const item = (status: MelhoriaStatus) => ({ status });
+
+describe('isMelhoriaNaoResolvida', () => {
+  it('conta aberto e em_andamento', () => {
+    expect(isMelhoriaNaoResolvida('aberto')).toBe(true);
+    expect(isMelhoriaNaoResolvida('em_andamento')).toBe(true);
+  });
+  it('NÃO conta resolvido nem descartado', () => {
+    expect(isMelhoriaNaoResolvida('resolvido')).toBe(false);
+    expect(isMelhoriaNaoResolvida('descartado')).toBe(false);
+  });
+});
+
+describe('contarMelhoriasNaoResolvidas', () => {
+  it('lista vazia => 0', () => {
+    expect(contarMelhoriasNaoResolvidas([])).toBe(0);
+  });
+  it('soma só os não-resolvidos', () => {
+    const itens = [
+      item('aberto'),
+      item('em_andamento'),
+      item('aberto'),
+      item('resolvido'),
+      item('descartado'),
+    ];
+    expect(contarMelhoriasNaoResolvidas(itens)).toBe(3);
+  });
+  it('todos finalizados => 0 (não fabrica badge)', () => {
+    expect(
+      contarMelhoriasNaoResolvidas([item('resolvido'), item('descartado')]),
+    ).toBe(0);
+  });
+});

--- a/src/lib/melhorias/badge-helpers.ts
+++ b/src/lib/melhorias/badge-helpers.ts
@@ -1,0 +1,21 @@
+// src/lib/melhorias/badge-helpers.ts
+// Contagem do badge "Minhas melhorias" (toggle no topo). Puro e testável.
+// NÃO é espelhado na edge (≠ triagem-helpers): é lógica de UI do cliente.
+import type { MelhoriaItem, MelhoriaStatus } from './types';
+
+/** Status que ainda exigem atenção do autor (contam no badge do topo). */
+const STATUS_NAO_RESOLVIDOS: ReadonlySet<MelhoriaStatus> = new Set([
+  'aberto',
+  'em_andamento',
+]);
+
+export function isMelhoriaNaoResolvida(status: MelhoriaStatus): boolean {
+  return STATUS_NAO_RESOLVIDOS.has(status);
+}
+
+/** Quantos itens do usuário seguem em aberto/andamento (badge do topo). */
+export function contarMelhoriasNaoResolvidas(
+  itens: ReadonlyArray<Pick<MelhoriaItem, 'status'>>,
+): number {
+  return itens.reduce((n, i) => (isMelhoriaNaoResolvida(i.status) ? n + 1 : n), 0);
+}

--- a/src/pages/Melhorias.tsx
+++ b/src/pages/Melhorias.tsx
@@ -10,6 +10,7 @@ import { PageSkeleton } from '@/components/ui/page-skeleton';
 import { EmptyState } from '@/components/EmptyState';
 import { MelhoriaThread } from '@/components/melhorias/MelhoriaThread';
 import { MelhoriaDialog } from '@/components/melhorias/MelhoriaDialog';
+import { MelhoriaStatusBadge } from '@/components/melhorias/MelhoriaStatusBadge';
 import {
   useMeusMelhoriaItens,
   useMelhoriaThread,
@@ -18,24 +19,7 @@ import {
 import { podeReplicar } from '@/lib/melhorias/triagem-helpers';
 import { toast } from 'sonner';
 import { useAuth } from '@/contexts/AuthContext';
-import type { MelhoriaItem, MelhoriaStatus } from '@/lib/melhorias/types';
-import { cn } from '@/lib/utils';
-
-// ── Badge de status ──────────────────────────────────────────────────────────
-
-const STATUS_LABEL: Record<MelhoriaStatus, string> = {
-  aberto: 'Aberto',
-  em_andamento: 'Em andamento',
-  resolvido: 'Resolvido',
-  descartado: 'Descartado',
-};
-
-const STATUS_CLASSES: Record<MelhoriaStatus, string> = {
-  aberto: 'bg-status-info-bg text-status-info border-transparent',
-  em_andamento: 'bg-status-warning-bg text-status-warning border-transparent',
-  resolvido: 'bg-status-success-bg text-status-success border-transparent',
-  descartado: 'bg-muted text-muted-foreground border-transparent',
-};
+import type { MelhoriaItem } from '@/lib/melhorias/types';
 
 // ── Card expansível ──────────────────────────────────────────────────────────
 
@@ -72,14 +56,7 @@ function MelhoriaCard({ item, userId }: { item: MelhoriaItem; userId: string }) 
       >
         <div className="flex-1 min-w-0">
           <div className="flex flex-wrap items-center gap-1.5 mb-1">
-            <span
-              className={cn(
-                'inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-semibold',
-                STATUS_CLASSES[item.status],
-              )}
-            >
-              {STATUS_LABEL[item.status]}
-            </span>
+            <MelhoriaStatusBadge status={item.status} />
             {item.tipo && (
               <Badge variant="outline" className="text-xs capitalize">
                 {item.tipo}


### PR DESCRIPTION
## O que muda
Move **Melhorias** do menu lateral para um **toggle no topo** (decisão do Lucas — limpar o menu).

- A lâmpada do topo vira `<MelhoriasPopover>`: badge de itens **não resolvidos** (aberto/em_andamento) + popover com lista enxuta (6 recentes), botão **Reportar** (reusa `MelhoriaDialog`) e **"Ver todas"** → `/melhorias`.
- Item "Melhorias" sai da seção *Principal* do menu — sai do **desktop e do mobile** juntos (mesma constante `unifiedNavSections`).
- Página `/melhorias` **mantida** (destino de "Ver todas" e dos cliques nos itens).
- Novo `<MelhoriaStatusBadge>` compartilhado: página + popover usam a mesma pílula de status (DRY).
- `badge-helpers.ts` puro + testes (não-resolvido nunca conta resolvido/descartado).
- Segue **staff-only** (`displayIsStaff`); sem migration, sem money-path, sem auth nova.

## Verificação
- Tipos OK · suite completa OK (484 arquivos / 3618 casos) · lint OK
- codex review: GATE PASS (sem achados)

## Deploy
Frontend-only. Após o merge: **Publish no Lovable** (sem edge function, sem migration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
