### PR TITLE
fix(tarefas): tarefas_matcher_tick usava enum inexistente 'numero_errado' (cron parado desde 01/06)

### DIFF
--- a/db/test-tarefas-matcher-enum.sh
+++ b/db/test-tarefas-matcher-enum.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# PROVA PG17 — fix do enum em tarefas_matcher_tick() (numero_errado -> numero_invalido).
+# Lei de Ferro: aplica a migration REAL; assert negativo de comportamento; falsificação obrigatória.
+#   bash db/test-tarefas-matcher-enum.sh > /tmp/t.log 2>&1; echo "exit=$?"
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PGVER=17
+PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+PORT="${PGPORT_TEST:-5466}"
+SLUG="tarefas-matcher-enum"
+DATA="$(mktemp -d "/tmp/pgtest-${SLUG}.XXXXXX")/data"
+export LC_ALL=C LANG=C
+
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente: brew install postgresql@${PGVER} pgvector"; exit 1; }
+CELLAR="$(brew --prefix "postgresql@${PGVER}")"
+cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
+mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
+cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
+
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+trap cleanup EXIT
+
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l "/tmp/pg-${SLUG}.log" -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres prove
+P()  { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d prove -v ON_ERROR_STOP=1 "$@"; }
+Pq() { P -tA "$@"; }
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  ✅ $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  ❌ $1"; }
+eq()  { if [ "$2" = "$3" ]; then ok "$1 (=$2)"; else bad "$1 — esperado [$3], veio [$2]"; fi; }
+
+echo "═══ setup PG17 :$PORT ═══"
+
+# ── ZONA 1 — pré-requisitos (enum + tabelas que a função toca) ──
+P -q <<'SQL'
+CREATE TYPE public.farmer_call_result AS ENUM
+  ('contato_sucesso','sem_resposta','ocupado','caixa_postal','numero_invalido','reagendado');
+
+CREATE TABLE public.tarefas (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  status text, auto_satisfy_mode text, interacao_tipo text,
+  customer_user_id uuid, created_at timestamptz, assigned_to uuid,
+  concluida_em timestamptz, conclusao_origem text, updated_at timestamptz, target_texto text
+);
+CREATE TABLE public.farmer_calls (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  customer_user_id uuid, created_at timestamptz,
+  call_result public.farmer_call_result, farmer_id uuid, entities_extracted jsonb
+);
+CREATE TABLE public.route_visits (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  customer_user_id uuid, check_in_at timestamptz, visit_type text, visited_by uuid
+);
+CREATE TABLE public.carteira_coverage (
+  covered_user_id uuid, covering_user_id uuid, active boolean,
+  valid_from timestamptz, valid_until timestamptz
+);
+CREATE TABLE public.tarefa_eventos (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tarefa_id uuid, tipo_evento text, ator uuid, payload jsonb, created_at timestamptz DEFAULT now()
+);
+CREATE TABLE public.tarefa_satisfacao_candidatos (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tarefa_id uuid, source_type text, source_id uuid, mode text, confidence numeric,
+  motivo text, matched_payload jsonb, status text,
+  created_at timestamptz DEFAULT now(), resolved_at timestamptz,
+  UNIQUE (tarefa_id, source_type, source_id)
+);
+SQL
+
+# ── ZONA 2 — aplicar a migration REAL ──
+MIG="$REPO_ROOT/supabase/migrations/20260615194500_fix_tarefas_matcher_enum.sql"
+P -q -f "$MIG" >/dev/null
+echo "migration aplicada: $(basename "$MIG")"
+
+# ── ZONA 3 — seed: 1 tarefa que DEVE fechar (contato_sucesso), 1 que NÃO (numero_invalido) ──
+P -q <<'SQL'
+INSERT INTO public.tarefas (id, status, auto_satisfy_mode, interacao_tipo, customer_user_id, created_at, assigned_to) VALUES
+  ('aaaaaaaa-0000-0000-0000-000000000001','aberta','interacao','ligacao','c0000000-0000-0000-0000-000000000001', now()-interval '2 hours','f0000000-0000-0000-0000-000000000001'),
+  ('bbbbbbbb-0000-0000-0000-000000000001','aberta','interacao','ligacao','c0000000-0000-0000-0000-000000000002', now()-interval '2 hours','f0000000-0000-0000-0000-000000000001');
+INSERT INTO public.farmer_calls (id, customer_user_id, created_at, call_result, farmer_id) VALUES
+  (gen_random_uuid(),'c0000000-0000-0000-0000-000000000001', now()-interval '1 hour','contato_sucesso','f0000000-0000-0000-0000-000000000001'),
+  (gen_random_uuid(),'c0000000-0000-0000-0000-000000000002', now()-interval '1 hour','numero_invalido','f0000000-0000-0000-0000-000000000001');
+SQL
+
+# ── ZONA 4 — asserts ──
+echo "── asserts ──"
+# A1 — a função CORRIGIDA executa sem erro (o que destrava o cron; a buggy abortava)
+if P -q -c "SELECT public.tarefas_matcher_tick();" >/dev/null 2>&1; then
+  ok "A1 tick executa sem erro (fix destrava o cron)"
+else
+  bad "A1 tick FALHOU com o fix aplicado (não deveria)"
+fi
+# A2 — contato_sucesso (NÃO está no not-in) fecha a tarefa
+VA=$(Pq -c "SELECT status FROM public.tarefas WHERE id='aaaaaaaa-0000-0000-0000-000000000001';")
+eq "A2 contato_sucesso fecha a tarefa" "$VA" "concluida"
+# A3 — numero_invalido (ESTÁ no not-in) NÃO fecha a tarefa
+VB=$(Pq -c "SELECT status FROM public.tarefas WHERE id='bbbbbbbb-0000-0000-0000-000000000001';")
+eq "A3 numero_invalido NAO fecha a tarefa" "$VB" "aberta"
+
+# ── ZONA 5 — falsificação: a versão com 'numero_errado' DEVE abortar (era o bug real) ──
+echo "── falsificação ──"
+BUGGY=$(mktemp /tmp/buggy-matcher.XXXXXX.sql)
+sed 's/numero_invalido/numero_errado/g' "$MIG" > "$BUGGY"
+P -q -f "$BUGGY" >/dev/null 2>&1 || true   # CREATE passa (late-bound); valida só ao executar
+if P -q -c "SELECT public.tarefas_matcher_tick();" >/dev/null 2>&1; then
+  bad "FALSIFICAÇÃO: tick buggy PASSOU (devia abortar por enum inválido) — A1 sem dente"
+else
+  ok "FALSIFICAÇÃO: tick buggy aborta (confirma 'numero_errado' como o bug)"
+fi
+rm -f "$BUGGY"
+P -q -f "$MIG" >/dev/null   # restaura a versão verdadeira
+
+echo "──────────────────────────────"
+echo "RESULTADO: $PASS ok / $FAIL fail"
+[ "$FAIL" = "0" ] || { echo "❌ HARNESS VERMELHO"; exit 1; }
+echo "✅ HARNESS VERDE"

--- a/src/pages/FarmerCalls.tsx
+++ b/src/pages/FarmerCalls.tsx
@@ -327,7 +327,7 @@ const FarmerCalls = () => {
       if (error) throw error;
 
       const rev = parseFloat(revenue) || 0;
-      const noContactResults = ['sem_resposta', 'ocupado', 'caixa_postal', 'numero_errado'];
+      const noContactResults = ['sem_resposta', 'ocupado', 'caixa_postal', 'numero_invalido'];
 
       if (noContactResults.includes(callResult)) {
         toast.success('Registrado — tente novamente', {

--- a/supabase/migrations/20260615194500_fix_tarefas_matcher_enum.sql
+++ b/supabase/migrations/20260615194500_fix_tarefas_matcher_enum.sql
@@ -1,0 +1,104 @@
+-- 20260615194500_fix_tarefas_matcher_enum.sql
+-- FIX: tarefas_matcher_tick() usava 'numero_errado' (valor INEXISTENTE no enum
+-- farmer_call_result, cujos valores são contato_sucesso/sem_resposta/ocupado/
+-- caixa_postal/numero_invalido/reagendado). O cast falhava em RUNTIME → o cron
+-- tarefas-matcher-15min abortava a cada 15min DESDE 2026-06-01 (~1.399 falhas).
+-- Correção cirúrgica: 'numero_errado' -> 'numero_invalido' (1 linha, na CTE `fechadas`).
+-- Corpo recriado verbatim do pg_get_functiondef de PROD (2026-06-15) — só o valor mudou.
+-- Provado no PG17 local: db/test-tarefas-matcher-enum.sh (positivo + negativo + falsificação).
+
+CREATE OR REPLACE FUNCTION public.tarefas_matcher_tick()
+ RETURNS void
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+begin
+  with fechadas as (
+    update public.tarefas t
+    set status='concluida', concluida_em=now(), conclusao_origem='auto_interacao', updated_at=now()
+    from public.farmer_calls fc
+    where t.status='aberta' and t.auto_satisfy_mode='interacao' and t.interacao_tipo='ligacao'
+      and fc.customer_user_id = t.customer_user_id
+      and fc.created_at > t.created_at
+      and fc.created_at > now() - interval '1 day'
+      and fc.call_result is not null
+      and fc.call_result not in ('sem_resposta','ocupado','caixa_postal','numero_invalido')
+      and ( fc.farmer_id = t.assigned_to
+            or exists (select 1 from public.carteira_coverage cc
+                       where cc.covered_user_id=t.assigned_to and cc.covering_user_id=fc.farmer_id
+                         and cc.active and now()>=cc.valid_from and (cc.valid_until is null or now()<=cc.valid_until)) )
+    returning t.id, t.assigned_to, fc.id as fonte, fc.farmer_id as fechou
+  )
+  insert into public.tarefa_eventos (tarefa_id, tipo_evento, ator, payload)
+  select id, 'concluida_auto', fechou,
+         jsonb_build_object('via','ligacao','source_id',fonte,'responsavel_efetivo',fechou,'assigned_to',assigned_to)
+  from fechadas;
+
+  with fechadas_v as (
+    update public.tarefas t
+    set status='concluida', concluida_em=now(), conclusao_origem='auto_interacao', updated_at=now()
+    from public.route_visits rv
+    where t.status='aberta' and t.auto_satisfy_mode='interacao' and t.interacao_tipo in ('visita','entrega')
+      and rv.customer_user_id = t.customer_user_id
+      and rv.check_in_at > t.created_at
+      and rv.check_in_at > now() - interval '1 day'
+      and ( (t.interacao_tipo='visita' and rv.visit_type='comercial')
+            or (t.interacao_tipo='entrega' and rv.visit_type='entrega') )
+      and ( rv.visited_by = t.assigned_to
+            or exists (select 1 from public.carteira_coverage cc
+                       where cc.covered_user_id=t.assigned_to and cc.covering_user_id=rv.visited_by
+                         and cc.active and now()>=cc.valid_from and (cc.valid_until is null or now()<=cc.valid_until)) )
+    returning t.id, t.assigned_to, rv.id as fonte, rv.visited_by as fechou
+  )
+  insert into public.tarefa_eventos (tarefa_id, tipo_evento, ator, payload)
+  select id, 'concluida_auto', fechou,
+         jsonb_build_object('via','visita_entrega','source_id',fonte,'responsavel_efetivo',fechou,'assigned_to',assigned_to)
+  from fechadas_v;
+
+  with novos as (
+    insert into public.tarefa_satisfacao_candidatos
+      (tarefa_id, source_type, source_id, mode, confidence, motivo, matched_payload, status)
+    select t.id, 'farmer_call', fc.id, 'conteudo',
+           coalesce(m.confidence, 0.0),
+           case when m.value is not null then 'Mencionou na ligação: '||m.value
+                else 'Ligação aconteceu — confirmar se ofereceu' end,
+           case when m.value is not null
+                then jsonb_build_object('entity_type', m.etype, 'value', m.value, 'context', m.context)
+                else null end,
+           'pending'
+    from public.tarefas t
+    join public.farmer_calls fc
+      on fc.customer_user_id = t.customer_user_id
+     and fc.created_at > t.created_at
+     and fc.created_at > now() - interval '1 day'
+     and ( fc.farmer_id = t.assigned_to
+           or exists (select 1 from public.carteira_coverage cc
+                      where cc.covered_user_id=t.assigned_to and cc.covering_user_id=fc.farmer_id
+                        and cc.active and now()>=cc.valid_from and (cc.valid_until is null or now()<=cc.valid_until)) )
+    left join lateral (
+      select e->>'value' as value, e->>'type' as etype, e->>'context' as context,
+             (e->>'confidence')::numeric as confidence
+      from jsonb_array_elements(coalesce(fc.entities_extracted, '[]'::jsonb)) e
+      where e->>'type' in ('product','price')
+        and t.target_texto is not null
+        and e->>'value' ilike '%'||t.target_texto||'%'
+      order by (e->>'confidence')::numeric desc nulls last
+      limit 1
+    ) m on true
+    where t.status='aberta' and t.auto_satisfy_mode='conteudo' and t.interacao_tipo='ligacao'
+    on conflict (tarefa_id, source_type, source_id) do nothing
+    returning tarefa_id, id
+  )
+  insert into public.tarefa_eventos (tarefa_id, tipo_evento, ator, payload)
+  select tarefa_id, 'sugestao_criada', null, jsonb_build_object('candidato_id', id) from novos;
+
+  update public.tarefa_satisfacao_candidatos
+  set status='expired', resolved_at=now()
+  where status='pending' and created_at < now() - interval '14 days';
+end $function$;
+
+-- validação pós-apply: a função NÃO deve mais referenciar 'numero_errado'
+SELECT 'FIX OK' AS status,
+  (pg_get_functiondef('public.tarefas_matcher_tick()'::regprocedure) ILIKE '%numero_errado%') AS ainda_tem_bug,
+  (pg_get_functiondef('public.tarefas_matcher_tick()'::regprocedure) ILIKE '%numero_invalido%') AS tem_valor_correto;


### PR DESCRIPTION
## O quê
O cron **`tarefas-matcher-15min`** falha a cada 15 min **desde 2026-06-01** (~1.399 falhas) com `invalid input value for enum farmer_call_result: "numero_errado"`. A função `tarefas_matcher_tick()` compara `call_result not in (...,'numero_errado')`, mas o enum só tem **`numero_invalido`** → o cast falha em runtime e aborta o tick. Resultado: **tarefas pararam de fechar/casar a partir de ligações por ~2 semanas**.

Descoberto durante o diagnóstico do incidente de cron de 15/06 (o backfill da Oben já estava em prod).

## Correção
- **`supabase/migrations/20260615194500_fix_tarefas_matcher_enum.sql`**: recria `tarefas_matcher_tick()` **verbatim do `pg_get_functiondef` de PROD**, trocando só `'numero_errado'`→`'numero_invalido'` (1 linha, CTE `fechadas`). ⚠️ **Não auto-aplica no Lovable — handoff pro SQL Editor.**
- **`db/test-tarefas-matcher-enum.sh`**: prova no PG17 local — **4 asserts + falsificação**:
  - A1: o tick corrigido **executa sem erro** (destrava o cron);
  - A2: `contato_sucesso` **fecha** a tarefa; A3: `numero_invalido` **não fecha**;
  - **Falsificação:** a versão com `'numero_errado'` **aborta** (confirma o bug e o dente do A1). → `4 ok / 0 fail`.
- **`src/pages/FarmerCalls.tsx`**: mesmo valor morto no array `noContactResults` (`'numero_errado'` nunca casava) → `'numero_invalido'`.

## Verificação
- SQL: PG17 local verde (com falsificação). Frontend: mudança trivial de string literal (validada pelo CI).

## Pós-merge (founder)
Aplicar a migration no **SQL Editor** do Lovable (a função em prod ainda tem o bug até lá) + **Publish** (frontend). Depois o cron volta a funcionar no próximo tick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)