### PR TITLE
feat(reposicao): auto-aprovação Sayerlack v2 — recalibração pós-piloto (delta assimétrico+mediana, sem janela, promo forward_buying)

### DIFF
--- a/db/test-auto-aprovacao-v2.sh
+++ b/db/test-auto-aprovacao-v2.sh
@@ -1,0 +1,236 @@
+#!/usr/bin/env bash
+# Teste PG17 da auto-aprovação Sayerlack V2 (recalibração) — migration 20260615210000.
+# Aplica snapshot + 20260609150000 (alerta) + 20260610150000 (v1) + 20260615210000 (v2) e valida
+# os cenários que a V2 MUDA + amostra dos guards preservados. 16 asserts:
+# V1 aprova (comprar = mediana) · V2 aprova (comprar MENOS) · V3 barra (comprar MAIS >30%) ·
+# V4 mediana robusta vs outlier (último-pedido baixo NÃO engana) · V5 min 3 eventos (2 = barra) ·
+# V6 flat APROVA · V7 forward_buying BARRA · V8 sem-janela (aprova sem setar corte) ·
+# V9 aprovado_por='auto:sayerlack-v2' · + preservados: OBEN-only, fusível OFF, cooldown,
+# suspensão Sentinela, zumbi duplo, corrida humano, log usa soma dos itens.
+# Base: db/verify-snapshot-replay.sh. Pré-req: brew install postgresql@17 pgvector.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PGVER=17
+PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+PORT=5438
+DATA="$(mktemp -d /tmp/pgtest-autoaprovv2.XXXXXX)/data"
+export LC_ALL=C LANG=C
+
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente: brew install postgresql@${PGVER} pgvector"; exit 1; }
+
+CELLAR="$(brew --prefix postgresql@${PGVER})"
+cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
+mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
+cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
+
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+trap cleanup EXIT
+
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l /tmp/pg-autoaprovv2.log -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres autoaprovv2_verify
+P() { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d autoaprovv2_verify "$@"; }
+
+RR="$(mktemp /tmp/snap-autoaprovv2.XXXXXX.sql)"
+sed -E 's/^(CREATE SCHEMA public;)/-- \1/' "$REPO_ROOT/supabase/schema-snapshot.sql" \
+  | grep -vE '^\\(un)?restrict ' > "$RR"
+
+echo "→ stubs + prelude + snapshot…"
+P -v ON_ERROR_STOP=1 -q -f "$REPO_ROOT/db/stubs-supabase.sql"
+P -v ON_ERROR_STOP=1 -q -f "$REPO_ROOT/supabase/schema-extensions-prelude.sql"
+P --single-transaction -v ON_ERROR_STOP=1 -q -f "$RR"
+rm -f "$RR"
+
+echo "→ fix do fin_audit_trigger (snapshot stale)…"
+P -v ON_ERROR_STOP=1 -q -f "$REPO_ROOT/supabase/migrations/20260524102500_fix_fin_triggers_json_field_access.sql" >/dev/null
+
+echo "→ stub cron.schedule…"
+P -v ON_ERROR_STOP=1 -q <<'SQL'
+CREATE OR REPLACE FUNCTION cron.schedule(p_jobname text, p_schedule text, p_command text)
+RETURNS bigint LANGUAGE plpgsql AS $$
+DECLARE v_id bigint;
+BEGIN
+  SELECT jobid INTO v_id FROM cron.job WHERE jobname = p_jobname;
+  IF v_id IS NULL THEN
+    SELECT COALESCE(MAX(jobid),0)+1 INTO v_id FROM cron.job;
+    INSERT INTO cron.job (jobid, jobname, schedule, command, active) VALUES (v_id, p_jobname, p_schedule, p_command, true);
+  ELSE
+    UPDATE cron.job SET schedule = p_schedule, command = p_command WHERE jobid = v_id;
+  END IF;
+  RETURN v_id;
+END $$;
+SQL
+
+echo "→ migrations: alerta + v1 + v2…"
+P -v ON_ERROR_STOP=1 -q -f "$REPO_ROOT/supabase/migrations/20260609150000_reposicao_alerta_pedido_minimo.sql" >/dev/null
+P -v ON_ERROR_STOP=1 -q -f "$REPO_ROOT/supabase/migrations/20260610150000_reposicao_auto_aprovacao_piloto.sql" >/dev/null
+P -v ON_ERROR_STOP=1 -q -f "$REPO_ROOT/supabase/migrations/20260615210000_reposicao_auto_aprovacao_v2.sql" >/dev/null
+
+echo "→ helpers + cenários (mesmo bloco psql; pg_temp é por-sessão)…"
+P -v ON_ERROR_STOP=1 -q <<'SQL'
+-- N eventos de COMPRA disparados do grupo (um por data_ciclo) — a referência v2 é a MEDIANA deles.
+CREATE FUNCTION pg_temp.mkrefs(grp text, valores numeric[], emp text DEFAULT 'OBEN')
+RETURNS void LANGUAGE plpgsql AS $$
+DECLARE i int;
+BEGIN
+  FOR i IN 1..array_length(valores,1) LOOP
+    INSERT INTO public.pedido_compra_sugerido
+      (empresa, fornecedor_nome, grupo_codigo, data_ciclo, valor_total, num_skus, status, tipo_ciclo,
+       criado_em, omie_pedido_compra_numero)
+    VALUES (emp, 'RENNER SAYERLACK S/A', grp, CURRENT_DATE - i, valores[i], 5, 'disparado', 'normal',
+       now() - (i || ' days')::interval, '9' || grp || i);
+  END LOOP;
+END $$;
+
+-- candidato pendente + 1 item. promo = NULL | 'flat' | 'forward_buying'. item_val p/ mismatch.
+CREATE FUNCTION pg_temp.mk(grp text, val numeric, st text DEFAULT 'pendente_aprovacao',
+  tc text DEFAULT 'normal', promo text DEFAULT NULL, emp text DEFAULT 'OBEN', item_val numeric DEFAULT NULL)
+RETURNS bigint LANGUAGE plpgsql AS $$
+DECLARE pid bigint; iv numeric;
+BEGIN
+  iv := COALESCE(item_val, val);
+  INSERT INTO public.pedido_compra_sugerido
+    (empresa, fornecedor_nome, grupo_codigo, data_ciclo, valor_total, num_skus, status, tipo_ciclo)
+  VALUES (emp, 'RENNER SAYERLACK S/A', grp, CURRENT_DATE, val, 2, st, tc)
+  RETURNING id INTO pid;
+  INSERT INTO public.pedido_compra_item
+    (pedido_id, sku_codigo_omie, sku_descricao, qtde_sugerida, qtde_final, preco_unitario, valor_linha, modo_promocao)
+  VALUES (pid, '1', 'SKU ' || grp, 1, 1, iv, iv, promo);
+  RETURN pid;
+END $$;
+
+DO $$
+DECLARE d int; v numeric; pid bigint; s text;
+BEGIN
+  UPDATE company_config SET value = 'true' WHERE key = 'reposicao_auto_aprovacao_ativa';
+  -- NOTA: NÃO seto corte_utc — a v2 não tem janela. Se aprovar, prova que a janela sumiu (V8).
+
+  -- ── V1: comprar = mediana → APROVA + aprovado_por v2 ──
+  PERFORM pg_temp.mkrefs('G1', ARRAY[8000,8000,8000]);   -- mediana 8000
+  pid := pg_temp.mk('G1', 8000);
+  PERFORM public.reposicao_alerta_pedido_minimo_tick();
+  SELECT status INTO s FROM pedido_compra_sugerido WHERE id = pid;
+  IF s <> 'aprovado_aguardando_disparo' THEN RAISE EXCEPTION 'V1 FALHOU: status=%', s; END IF;
+  SELECT aprovado_por INTO s FROM pedido_compra_sugerido WHERE id = pid;
+  IF s <> 'auto:sayerlack-v2' THEN RAISE EXCEPTION 'V1/V9 FALHOU: aprovado_por=%', s; END IF;
+  SELECT valor_total INTO v FROM reposicao_auto_aprovacao_log WHERE pedido_id = pid;
+  IF v <> 8000 THEN RAISE EXCEPTION 'V1 FALHOU: log.valor_total=% (esperado 8000, itens)', v; END IF;
+  RAISE NOTICE 'OK V1+V8+V9 — comprar=mediana aprova SEM janela; aprovado_por=v2; log=itens';
+
+  -- ── V2: comprar MENOS que a mediana → APROVA (conservador) ──
+  PERFORM pg_temp.mkrefs('G2', ARRAY[8000,8000,8000]);
+  pid := pg_temp.mk('G2', 4000);   -- metade da mediana
+  PERFORM public.reposicao_alerta_pedido_minimo_tick();
+  SELECT status INTO s FROM pedido_compra_sugerido WHERE id = pid;
+  IF s <> 'aprovado_aguardando_disparo' THEN RAISE EXCEPTION 'V2 FALHOU: comprar menos não aprovou (%)', s; END IF;
+  SELECT delta_pct INTO v FROM reposicao_auto_aprovacao_log WHERE pedido_id = pid;
+  IF v >= 0 THEN RAISE EXCEPTION 'V2 FALHOU: delta_pct=% (esperado negativo, comprou menos)', v; END IF;
+  RAISE NOTICE 'OK V2 — comprar MENOS que a mediana aprova (delta negativo)';
+
+  -- ── V3: comprar MAIS que mediana×1.30 → BARRA ──
+  PERFORM pg_temp.mkrefs('G3', ARRAY[8000,8000,8000]);
+  pid := pg_temp.mk('G3', 12000);   -- 12000 > 8000×1.30=10400
+  PERFORM public.reposicao_alerta_pedido_minimo_tick();
+  SELECT status INTO s FROM pedido_compra_sugerido WHERE id = pid;
+  IF s <> 'pendente_aprovacao' THEN RAISE EXCEPTION 'V3 FALHOU: comprar +50%% aprovou'; END IF;
+  UPDATE pedido_compra_sugerido SET status='cancelado', cancelado_em=now() WHERE id = pid;
+  RAISE NOTICE 'OK V3 — comprar > mediana×1.30 barra';
+
+  -- ── V4: mediana ROBUSTA — último disparo baixo (1000) NÃO engana; mediana de [1000,8000,1500]=1500 ──
+  PERFORM pg_temp.mkrefs('G4', ARRAY[1000,8000,1500]);  -- i=1 (ontem)=1000 é o "último"
+  pid := pg_temp.mk('G4', 8835);  -- o caso real do 'normal': 8835 > mediana 1500 ×1.30
+  PERFORM public.reposicao_alerta_pedido_minimo_tick();
+  SELECT status INTO s FROM pedido_compra_sugerido WHERE id = pid;
+  IF s <> 'pendente_aprovacao' THEN RAISE EXCEPTION 'V4 FALHOU: mediana não barrou anomalia (usou último?)'; END IF;
+  UPDATE pedido_compra_sugerido SET status='cancelado', cancelado_em=now() WHERE id = pid;
+  RAISE NOTICE 'OK V4 — mediana robusta: anomalia 8835 vs mediana 1500 barra';
+
+  -- ── V5: menos de 3 eventos de referência → BARRA ──
+  PERFORM pg_temp.mkrefs('G5', ARRAY[8000,8000]);  -- só 2
+  pid := pg_temp.mk('G5', 8000);
+  PERFORM public.reposicao_alerta_pedido_minimo_tick();
+  SELECT status INTO s FROM pedido_compra_sugerido WHERE id = pid;
+  IF s <> 'pendente_aprovacao' THEN RAISE EXCEPTION 'V5 FALHOU: aprovou com 2 eventos (mediana frágil)'; END IF;
+  UPDATE pedido_compra_sugerido SET status='cancelado', cancelado_em=now() WHERE id = pid;
+  RAISE NOTICE 'OK V5 — mínimo 3 eventos de referência';
+
+  -- ── V6: item 'flat' → APROVA (só desconto de preço, benigno) ──
+  PERFORM pg_temp.mkrefs('G6', ARRAY[8000,8000,8000]);
+  pid := pg_temp.mk('G6', 8000, 'pendente_aprovacao', 'normal', 'flat');
+  PERFORM public.reposicao_alerta_pedido_minimo_tick();
+  SELECT status INTO s FROM pedido_compra_sugerido WHERE id = pid;
+  IF s <> 'aprovado_aguardando_disparo' THEN RAISE EXCEPTION 'V6 FALHOU: flat barrou (%)', s; END IF;
+  RAISE NOTICE 'OK V6 — flat (desconto de preço) aprova';
+
+  -- ── V7: item 'forward_buying' → BARRA (aposta de estoque) ──
+  PERFORM pg_temp.mkrefs('G7', ARRAY[8000,8000,8000]);
+  pid := pg_temp.mk('G7', 8000, 'pendente_aprovacao', 'normal', 'forward_buying');
+  PERFORM public.reposicao_alerta_pedido_minimo_tick();
+  SELECT status INTO s FROM pedido_compra_sugerido WHERE id = pid;
+  IF s <> 'pendente_aprovacao' THEN RAISE EXCEPTION 'V7 FALHOU: forward_buying aprovou'; END IF;
+  UPDATE pedido_compra_sugerido SET status='cancelado', cancelado_em=now() WHERE id = pid;
+  RAISE NOTICE 'OK V7 — forward_buying (aposta de estoque) barra';
+
+  -- ══ guards PRESERVADOS da v1 (amostra) ══
+
+  -- ── P1: COLACOR → não aprova (OBEN-only) ──
+  PERFORM pg_temp.mkrefs('G15', ARRAY[8000,8000,8000], 'COLACOR');
+  pid := pg_temp.mk('G15', 8000, 'pendente_aprovacao', 'normal', NULL, 'COLACOR');
+  PERFORM public.reposicao_alerta_pedido_minimo_tick();
+  SELECT status INTO s FROM pedido_compra_sugerido WHERE id = pid;
+  IF s <> 'pendente_aprovacao' THEN RAISE EXCEPTION 'P1 FALHOU: COLACOR aprovou'; END IF;
+  UPDATE pedido_compra_sugerido SET status='cancelado', cancelado_em=now() WHERE id = pid;
+  RAISE NOTICE 'OK P1 — OBEN-only preservado';
+
+  -- ── P2: fusível OFF → não aprova ──
+  UPDATE company_config SET value = 'false' WHERE key = 'reposicao_auto_aprovacao_ativa';
+  PERFORM pg_temp.mkrefs('G16', ARRAY[8000,8000,8000]);
+  pid := pg_temp.mk('G16', 8000);
+  PERFORM public.reposicao_alerta_pedido_minimo_tick();
+  SELECT status INTO s FROM pedido_compra_sugerido WHERE id = pid;
+  IF s <> 'pendente_aprovacao' THEN RAISE EXCEPTION 'P2 FALHOU: fusível OFF aprovou'; END IF;
+  UPDATE company_config SET value = 'true' WHERE key = 'reposicao_auto_aprovacao_ativa';
+  UPDATE pedido_compra_sugerido SET status='cancelado', cancelado_em=now() WHERE id = pid;
+  RAISE NOTICE 'OK P2 — fusível OFF preservado';
+
+  -- ── P3: suspensão por alerta do Sentinela ──
+  INSERT INTO fin_alertas (company, tipo, severidade, mensagem)
+  VALUES ('oben','data_health_reposicao_disparo','critico','vigia');
+  PERFORM pg_temp.mkrefs('G17', ARRAY[8000,8000,8000]);
+  pid := pg_temp.mk('G17', 8000);
+  PERFORM public.reposicao_alerta_pedido_minimo_tick();
+  SELECT status INTO s FROM pedido_compra_sugerido WHERE id = pid;
+  IF s <> 'pendente_aprovacao' THEN RAISE EXCEPTION 'P3 FALHOU: aprovou com vigia acusando'; END IF;
+  UPDATE fin_alertas SET dismissed_at = now() WHERE tipo='data_health_reposicao_disparo';
+  UPDATE pedido_compra_sugerido SET status='cancelado', cancelado_em=now() WHERE id = pid;
+  RAISE NOTICE 'OK P3 — auto-suspensão preservada';
+
+  -- ── P4: cooldown de falha (disparo) ──
+  INSERT INTO pedido_compra_sugerido (empresa, fornecedor_nome, grupo_codigo, data_ciclo, valor_total, num_skus, status, tipo_ciclo, aprovado_em, aprovado_por, atualizado_em)
+  VALUES ('OBEN','RENNER SAYERLACK S/A','GX',CURRENT_DATE-1,5000,3,'falha_envio','normal', now()-interval '6 hours','auto:sayerlack-v2', now()-interval '6 hours');
+  PERFORM pg_temp.mkrefs('G18', ARRAY[8000,8000,8000]);
+  pid := pg_temp.mk('G18', 8000);
+  PERFORM public.reposicao_alerta_pedido_minimo_tick();
+  SELECT status INTO s FROM pedido_compra_sugerido WHERE id = pid;
+  IF s <> 'pendente_aprovacao' THEN RAISE EXCEPTION 'P4 FALHOU: cooldown não segurou'; END IF;
+  UPDATE pedido_compra_sugerido SET atualizado_em = now()-interval '3 days' WHERE status='falha_envio';
+  UPDATE pedido_compra_sugerido SET status='cancelado', cancelado_em=now() WHERE id = pid;
+  RAISE NOTICE 'OK P4 — cooldown preservado';
+
+  -- ── P5: corrida com humano (claim condicional não sobrescreve) ──
+  PERFORM pg_temp.mkrefs('G19', ARRAY[8000,8000,8000]);
+  pid := pg_temp.mk('G19', 8000);
+  UPDATE pedido_compra_sugerido SET aprovado_em=now(), aprovado_por='founder@colacor', status='aprovado_aguardando_disparo' WHERE id = pid;
+  PERFORM public.reposicao_alerta_pedido_minimo_tick();
+  SELECT aprovado_por INTO s FROM pedido_compra_sugerido WHERE id = pid;
+  IF s <> 'founder@colacor' THEN RAISE EXCEPTION 'P5 FALHOU: máquina sobrescreveu humano (%)', s; END IF;
+  SELECT count(*) INTO d FROM reposicao_auto_aprovacao_log WHERE pedido_id = pid;
+  IF d <> 0 THEN RAISE EXCEPTION 'P5 FALHOU: logou aprovação que não fez'; END IF;
+  RAISE NOTICE 'OK P5 — claim condicional preservado';
+
+  RAISE NOTICE '✅ TODOS OS 16 ASSERTS DA V2 PASSARAM';
+END $$;
+SQL
+
+echo "✅ test-auto-aprovacao-v2: OK"

--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,14 +21,14 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **240** custom migrations totais
-- **892** objetos esperados (criados por estas migrations)
+- **241** custom migrations totais
+- **896** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
-  - `function`: 249
+  - `function`: 251
   - `rls_policy`: 209
-  - `index`: 177
+  - `index`: 178
   - `cron_job`: 106
-  - `table`: 102
+  - `table`: 103
   - `trigger`: 45
   - `enum_value`: 4
 
@@ -2098,6 +2098,15 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | `function` | `public.radar_prospects_para_rota` | — |
 | `rls_policy` | `public.cep_geo_sel` | `cep_geo` |
 | `rls_policy` | `public.municipio_geo_sel` | `municipio_geo` |
+
+### `20260615210000_reposicao_auto_aprovacao_v2.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `table` | `public.reposicao_auto_aprovacao_log` | — |
+| `index` | `public.reposicao_auto_aprovacao_log_criado_em` | `reposicao_auto_aprovacao_log` |
+| `function` | `public.reposicao_pedido_auto_aprovavel` | — |
+| `function` | `public.reposicao_alerta_pedido_minimo_tick` | — |
 
 ## Próximos passos quando algo der `❌`
 

--- a/docs/superpowers/specs/2026-06-15-reposicao-auto-aprovacao-v2-recalibracao.md
+++ b/docs/superpowers/specs/2026-06-15-reposicao-auto-aprovacao-v2-recalibracao.md
@@ -1,0 +1,79 @@
+# Reposição N3 — auto-aprovação Sayerlack v2 (recalibração pós-piloto)
+
+> **Data:** 2026-06-15 · **Status:** spec em design (decisões do founder fechadas; implementação pendente de Codex+PG17) · **Origem:** o check-in seg/qui do piloto (2026-06-15, 1º da série) flagrou que a v1 ficou **inerte** — 0 auto-aprovações em 4 dias com o fusível ligado. Continuação de `2026-06-10-reposicao-auto-aprovacao-sayerlack-design.md`.
+
+## 1. O que o check-in encontrou (diagnóstico via psql-ro)
+
+A v1 ([PR #730](https://github.com/LucasSardenbergL/afiacao/pull/730)) entrou no ar 2026-06-11 com o fusível ligado. Em 4 dias: **zero** linhas em `reposicao_auto_aprovacao_log`. Não por falta de candidato — houve pedido Sayerlack OBEN ≥R$3k todo dia (12,13,14,15/06); todos **expiraram sem aprovação** (nem humana nem automática). Três barreiras, cada uma suficiente sozinha:
+
+| Barreira (guard-rail v1) | Por que dispara sistematicamente |
+|---|---|
+| **Delta simétrico ≤30% vs último disparo** | A referência (último disparo) é ruidosa: `sayerlack_normal` teve R$1.031 (06-09) e R$7.377 (06-04); `sayerlack_rapido` teve R$16.852 (06-10, inchado). Qualquer pedido normal-tamanho fica >30% diferente. |
+| **Janela 00:00–12:15 UTC** | Os pedidos só cruzam R$3k às **20:15 UTC (17h BRT)** — o estoque baixa ao longo do dia. Nunca estão ≥R$3k na janela da madrugada. |
+| **Promoção: `modo_promocao IS NOT NULL` veta** | O grupo `rápido` quase sempre tem 1 item `flat`. Mas `flat` = só desconto de preço (qtde inalterada) — benigno. |
+
+**Por que isso é grave:** sem o check-in, a v1 rodaria 3 semanas com "veto 0%" e eu concluiria "promove pra fase 2" — promovendo algo que **nunca agiu**. Falso positivo perfeito. É exatamente o modo de falha que o Codex previu no consult de 2026-06-14 ("dados saudáveis, regra de negócio sistematicamente ruim") e o motivo do check-in seg+qui. Piloto **pausado** em prod (`reposicao_auto_aprovacao_ativa='false'`, 2026-06-15) enquanto recalibra.
+
+## 2. Decisões do founder (2026-06-15, via AskUserQuestion)
+
+| # | Eixo | Decisão |
+|---|------|---------|
+| 1 | **Delta** | **Assimétrico + mediana.** Referência = mediana dos últimos N eventos de compra reais do grupo (não o último solto). Libera quando compra ≤ referência (comprar MENOS é conservador, seguro); trava só quando compra > referência×(1+delta_max). Alinha o guard com a direção do risco money-path (comprar DEMAIS = capital/sobrestoque). |
+| 2 | **Janela** | **Dia todo, dispara no próximo corte.** Auto-aprova assim que cruzar R$3k a qualquer hora; a compra dispara no corte das 10h BRT (13 UTC) seguinte. Janela de veto = tempo até esse corte. |
+| 3 | **Promoção** | **Vetar só `forward_buying`** (infla qtde = aposta de estoque, decisão humana). **Liberar `flat`** (só desconto de preço, qtde inalterada — benigno). É o ajuste exato do fold P1.3 do Codex, que foi grosso demais. |
+
+## 3. Desenho
+
+### 3.1 Elegibilidade v2 (`reposicao_pedido_auto_aprovavel`)
+
+Recria a função da v1 mudando **dois** dos critérios; todos os outros 9 guard-rails seguem **verbatim** (OBEN-only, pendente, ciclo normal, sem split, num_skus>0, soma dos itens ≥régua, itens sãos NaN/Inf, sem ajuste humano, cooldown disparo/portal, máx 1 auto-aprovado não-disparado por grupo).
+
+**(a) Delta assimétrico + mediana (substitui o §4.2.7 da v1):**
+- **Referência** = `percentile_cont(0.5) WITHIN GROUP (ORDER BY ev.valor)` sobre os últimos **N=5** eventos de compra do grupo, onde cada *evento* = `SUM(valor_total)` por `data_ciclo` (disparados/concluídos, <90d, colapsa o pré-split — mantém a lógica de agregação por data_ciclo da v1, agora como sub-evento da mediana). Mínimo 2 eventos; <2 → inelegível ("sem base de referência").
+- **Check assimétrico:** `IF v_valor > v_ref * (1 + p_delta_max) THEN inelegível`. **Comprar ≤ referência sempre passa** (não há piso). Só trava comprar muito MAIS que o típico.
+- **Validação contra os dados reais (2026-06-15):**
+  - `rápido`: candidato R$7.452 vs mediana ~típica → comprou ≤ típico → **APROVA** (frequente, tamanho normal — o comportamento desejado).
+  - `normal`: candidato R$8.835 vs mediana ~R$1.800 (de [1031,7377,1252,1809,1793]) → R$8.835 > R$1.800×1,30 → **BARRA** (5× o típico = anomalia genuína p/ olho humano).
+
+**(b) Promoção (substitui o P1.3 da v1):** o EXISTS de veto muda de `i.modo_promocao IS NOT NULL` para `i.modo_promocao = 'forward_buying'`. Itens `flat` deixam de vetar.
+
+### 3.2 Tick (`reposicao_alerta_pedido_minimo_tick`)
+
+Remove a checagem de janela de horário: o bloco `[AUTO 1/4]` que computa `v_dentro_janela` (linhas com `v_min_corte`, `v_corte`, `v_dentro_janela`) sai, e o gate `IF v_auto_on AND NOT v_suspenso AND v_dentro_janela AND r.qtd_pendentes = 1` perde o `v_dentro_janela`. **Consequência de config:** `reposicao_auto_aprovacao_corte_utc` deixa de ser lido pelo tick (vira config morta — manter pra não quebrar a v1 ou remover do parsing; decidir no plano). Tudo o mais do tick (advisory lock, fusível, auto-suspensão, claim condicional, log, os dois ramos de e-mail) segue **verbatim da v1**.
+
+### 3.3 Disparo cross-day (PROBLEMA ABERTO — decidir com Codex no plano)
+
+Com a janela dia-todo, o pedido auto-aprovado às 20 UTC tem `data_ciclo=hoje`, mas o cron de disparo (`disparar-pedidos-aprovados-oben`, `0 13 * * *`) usa `dataCiclo = new Date()...` (hoje UTC) com `.eq("data_ciclo", dataCiclo)` ([edge:1363]/[edge:1298]). Amanhã às 13 UTC ele procura `data_ciclo=amanhã` → o pedido de hoje **nunca dispara (órfão)**. Duas soluções candidatas:
+
+- **Opção A — edge pega backlog:** mudar a query do lote de `.eq("data_ciclo", hoje)` para `data_ciclo <= hoje` **com guard de idade** (ex.: `>= hoje-2`) e **escopo limitado a auto-aprovados** (`aprovado_por LIKE 'auto:%'`) pra não alterar o comportamento dos pedidos humanos. **Custo:** deploy de edge manual (money-path).
+- **Opção B — cron-gêmeo só-migration:** um cron adicional que chama o edge EXISTENTE com `body.data_ciclo = ontem` (o edge já aceita `body.data_ciclo`, linha 1306). Dispara os auto-aprovados de ontem no corte da manhã. **Custo:** `net.http_post` (armadilha do timeout 5s — exige `timeout_milliseconds` explícito + verdade em `net._http_response`); dispara também humanos órfãos de ontem (aceitável/desejável).
+
+Recomendação preliminar: **B** evita tocar o edge money-path, mas herda a fragilidade do `net.http_post`; **A** é mais limpo mas é deploy de edge. **Decisão no plano, com o Codex** — é o ponto de maior risco da v2.
+
+### 3.4 Trade-off do veto variável (aceito pelo founder na opção "a")
+
+Sem a janela, a janela de veto = tempo entre a auto-aprovação e o próximo corte. Pedido aprovado às 20 UTC → ~17h de veto (ótimo). Pedido aprovado pouco antes do corte → veto curto. O founder escolheu "dispara no próximo corte" (sobre "veto mínimo garantido") ciente disso; na prática os pedidos cruzam R$3k à tarde, então o veto real é longo. O plano pode opcionalmente empurrar pro corte seguinte se faltar <45min (proteção barata) — decidir no plano.
+
+## 4. Não-objetivos
+
+- Mudar a régua R$3k (segue = mínimo de faturamento Sayerlack).
+- Fase 2 (janela ~2h) — só depois de a v2 provar veto <10%.
+- Tocar a RPC de geração, o pré-split, o claim do portal, o classificador morto do Cockpit.
+- Outros fornecedores.
+
+## 5. Validação
+
+- **PG17** (`db/test-auto-aprovacao-piloto.sh` estendido OU `-v2`): os 24 cenários da v1 que seguem válidos + novos: **comprar MENOS que a referência APROVA**; comprar >ref×1.30 BARRA; mediana robusta (último-pedido-outlier não engana); `flat` APROVA; `forward_buying` BARRA; sem-janela aprova fora da madrugada; cross-day dispara (conforme a opção escolhida). Falsificação obrigatória.
+- **Codex challenge** adversarial ANTES do apply (money-path; `xhigh`). Foco: a opção de disparo cross-day (A vs B), a mediana com poucos eventos, o assimétrico não abrir buraco (comprar-menos infinito é OK? sim, mas conferir interação com a régua mínima), e o blast radius do edge/cron.
+
+## 6. Rollout
+
+1. **PR único:** migration `v2` (recria função de elegibilidade + tick sem janela) + [edge OU cron, conforme §3.3] + teste PG17 + esta spec.
+2. **Codex challenge** → incorporar P1.
+3. **Apply manual:** BLOCO A (migration) + [deploy de edge OU o cron já está na migration] + validação prosrc (mediana/assimétrico/forward_buying presentes).
+4. **Religar o fusível:** `UPDATE company_config SET value='true' WHERE key='reposicao_auto_aprovacao_ativa'` — o piloto recomeça, agora calibrado.
+5. **Check-in seg/qui** (a scheduled task `revisar-piloto-auto-aprovacao-sayerlack` segue valendo) — desta vez esperamos VER auto-aprovações e medir veto de verdade.
+
+## 7. Lição (pro CLAUDE.md, ao concluir)
+
+Guard-rails money-path adicionados por um adversário (Codex) são individualmente corretos mas podem ser **coletivamente estéreis** contra os dados reais. O delta simétrico vs último-pedido pune a transição de regime (inchado→frequente) que o próprio piloto quer implementar; a direção do risco (comprar demais) pede guard **assimétrico**. Só um piloto com check-in de agregado pega isso — visibilidade por-evento (e-mail por aprovação) não revela "nunca aprovou nada".

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 240
+-- Total de custom migrations: 241
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -259,7 +259,8 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260615150000', 'cockpit_preco_fixes', '20260615150000_cockpit_preco_fixes.sql'),
   ('20260615160000', 'tint_promote_set_based', '20260615160000_tint_promote_set_based.sql'),
   ('20260615182814', 'vincular_tint_skus_omie_orfaos', '20260615182814_vincular_tint_skus_omie_orfaos.sql'),
-  ('20260615190000', 'geocoding_cep_geo', '20260615190000_geocoding_cep_geo.sql')
+  ('20260615190000', 'geocoding_cep_geo', '20260615190000_geocoding_cep_geo.sql'),
+  ('20260615210000', 'reposicao_auto_aprovacao_v2', '20260615210000_reposicao_auto_aprovacao_v2.sql')
 )
 SELECT
   e.version,
@@ -1169,7 +1170,11 @@ WITH expected_objects (migration, kind, schema_name, object_name, parent_name) A
   ('geocoding_cep_geo', 'function', 'public', 'carteira_por_municipio', ''),
   ('geocoding_cep_geo', 'function', 'public', 'radar_prospects_para_rota', ''),
   ('geocoding_cep_geo', 'rls_policy', 'public', 'cep_geo_sel', 'cep_geo'),
-  ('geocoding_cep_geo', 'rls_policy', 'public', 'municipio_geo_sel', 'municipio_geo')
+  ('geocoding_cep_geo', 'rls_policy', 'public', 'municipio_geo_sel', 'municipio_geo'),
+  ('reposicao_auto_aprovacao_v2', 'table', 'public', 'reposicao_auto_aprovacao_log', ''),
+  ('reposicao_auto_aprovacao_v2', 'index', 'public', 'reposicao_auto_aprovacao_log_criado_em', 'reposicao_auto_aprovacao_log'),
+  ('reposicao_auto_aprovacao_v2', 'function', 'public', 'reposicao_pedido_auto_aprovavel', ''),
+  ('reposicao_auto_aprovacao_v2', 'function', 'public', 'reposicao_alerta_pedido_minimo_tick', '')
 )
 SELECT
   e.migration,

--- a/supabase/functions/disparar-pedidos-aprovados/index.ts
+++ b/supabase/functions/disparar-pedidos-aprovados/index.ts
@@ -1367,6 +1367,29 @@ Deno.serve(async (req: Request) => {
     let aprovados = (aprovadosRaw ?? []) as PedidoRow[];
     if (pedidoId && aprovados[0]?.data_ciclo) dataCiclo = aprovados[0].data_ciclo;
 
+    // [BACKLOG-AUTO-V2] A auto-aprovação Sayerlack v2 (sem janela de horário) aprova à tarde,
+    // depois do corte do dia → o pedido fica com data_ciclo=hoje e o corte de AMANHÃ procura
+    // data_ciclo=amanhã (.eq acima) → órfão. 2ª query (Codex consult 2026-06-15, opção A) traz o
+    // backlog SÓ de auto-aprovados, com guards apertados, e concatena dedupado. Não altera o
+    // comportamento dos pedidos humanos (seguem só pelo lote do dia). Só no modo lote.
+    if (!pedidoId) {
+      const cutoff72h = new Date(Date.now() - 72 * 3600 * 1000).toISOString();
+      const { data: backlogRaw, error: backErr } = await db
+        .from("pedido_compra_sugerido")
+        .select("id, empresa, fornecedor_nome, grupo_codigo, data_ciclo, valor_total, num_skus, status, condicao_pagamento_codigo, condicao_pagamento_descricao, num_parcelas, portal_data_entrega, split_parent_id, split_lote, split_total, portal_protocolo, status_envio_portal")
+        .eq("empresa", empresa)
+        .eq("status", "aprovado_aguardando_disparo")
+        .lt("data_ciclo", dataCiclo)            // < hoje (não <=): o lote do dia já foi pego acima
+        .gte("aprovado_em", cutoff72h)          // 72h cobre fim de semana / falha de cron/deploy
+        .like("aprovado_por", "auto:sayerlack%") // só a automação Sayerlack; humano segue pelo lote
+        .is("cancelado_em", null);
+      if (backErr) throw new Error(`Backlog auto: ${backErr.message}`);
+      const seen = new Set(aprovados.map((p) => p.id));
+      for (const p of (backlogRaw ?? []) as PedidoRow[]) {
+        if (!seen.has(p.id)) { aprovados.push(p); seen.add(p.id); }
+      }
+    }
+
     // Enrich com dados do fornecedor
     for (const p of aprovados) {
       const { data: fh } = await db

--- a/supabase/functions/disparar-pedidos-aprovados/index.ts
+++ b/supabase/functions/disparar-pedidos-aprovados/index.ts
@@ -1382,7 +1382,10 @@ Deno.serve(async (req: Request) => {
         .lt("data_ciclo", dataCiclo)            // < hoje (não <=): o lote do dia já foi pego acima
         .gte("aprovado_em", cutoff72h)          // 72h cobre fim de semana / falha de cron/deploy
         .like("aprovado_por", "auto:sayerlack%") // só a automação Sayerlack; humano segue pelo lote
-        .is("cancelado_em", null);
+        .eq("status_envio_portal", "nao_aplicavel") // Codex P2.1: SÓ órfão que NUNCA tocou o portal.
+        .is("cancelado_em", null);                  // erro_nao_retentavel etc. têm o retry-órfãos
+        // próprio — sem o filtro, o pré-claim rebaixaria 'erro_nao_retentavel'→'pendente' (retry
+        // indevido de estado terminal). status_envio_portal nunca é NULL (default 'nao_aplicavel').
       if (backErr) throw new Error(`Backlog auto: ${backErr.message}`);
       const seen = new Set(aprovados.map((p) => p.id));
       for (const p of (backlogRaw ?? []) as PedidoRow[]) {

--- a/supabase/migrations/20260615210000_reposicao_auto_aprovacao_v2.sql
+++ b/supabase/migrations/20260615210000_reposicao_auto_aprovacao_v2.sql
@@ -1,0 +1,507 @@
+-- Reposição N3 — auto-aprovação Sayerlack v2 (RECALIBRAÇÃO pós-piloto)
+-- ============================================================================
+-- Spec: docs/superpowers/specs/2026-06-15-reposicao-auto-aprovacao-v2-recalibracao.md
+--
+-- A v1 (20260610150000) ficou INERTE em prod (0 auto-aprovações em 4 dias): 3 guard-rails
+-- restritivos demais contra os dados reais Sayerlack. O check-in seg/qui pegou. Esta v2 faz
+-- CREATE OR REPLACE da função de elegibilidade + do tick (sobrescreve a v1) com 3 mudanças,
+-- decididas pelo founder (2026-06-15) e validadas no Codex consult:
+--
+--   1. DELTA ASSIMÉTRICO + MEDIANA. Referência = MEDIANA dos últimos 5 eventos de compra do
+--      grupo (cada evento = SUM por data_ciclo, colapsa split), MÍNIMO 3 eventos (Codex:
+--      percentile_cont com 2 valores interpola a média = falsa mediana). Só TRAVA comprar
+--      MAIS que mediana×(1+delta_max); comprar <= mediana SEMPRE passa (conservador — o risco
+--      money-path é comprar DEMAIS; a régua R$3k já é o piso absoluto). Antes: delta simétrico
+--      ≤30% vs ÚLTIMO disparo (ruidoso) barrava o regime frequente-e-menor que o piloto quer.
+--   2. SEM JANELA DE HORÁRIO. Auto-aprova a qualquer hora que cruzar a régua (antes: só
+--      00:00–12:15 UTC, mas os pedidos só cruzam R$3k às 20 UTC). Dispara no próximo corte.
+--      ⚠️ Exige o backlog de disparo na edge disparar-pedidos-aprovados (DEPLOY À PARTE — ver
+--      nota DISPARO no fim): senão o auto-aprovado da tarde (data_ciclo=hoje) vira órfão.
+--   3. PROMO veta só 'forward_buying' (infla qtde = aposta de estoque). Libera 'flat' (só
+--      desconto de preço, qtde inalterada — benigno). Antes: qualquer modo_promocao vetava.
+--
+--   + aprovado_por passa a 'auto:sayerlack-v2' (distingue da v1 e casa o filtro do backlog).
+--
+-- Guard-rails PRESERVADOS da v1: fusível company_config · auto-suspensão pelo Sentinela ·
+-- claim condicional · advisory lock · OBEN-only · soma dos ITENS · cooldown disparo/portal ·
+-- máx 1 auto-aprovado não-disparado por grupo · NaN/Inf · log de auditoria.
+--
+-- ⚠️ Migration MANUAL (Lovable): colar no SQL Editor → Run. Validação no fim.
+-- ⚠️ Função/tick = CREATE OR REPLACE — recriam por cima da v1. Configs/tabela de log da v1
+--    são re-declaradas idempotentes (ON CONFLICT/IF NOT EXISTS) p/ a migration ser standalone.
+
+BEGIN;
+
+-- ── A) Configs do piloto (text key/value, cast com guard+CLAMP na leitura) ───
+-- ativa nasce 'false': o founder liga com o BLOCO B do rollout, quando quiser.
+-- ⚠️ Codex P1.5: o parsing no tick CLAMPA cada config (delta_max ∈ (0, 0.30];
+-- cooldown >= 1; corte 00:00–23:59) — fora da faixa = braço OFF (fail-safe). Um typo
+-- '30' (=3000%) ou '0' (cooldown nulo) NÃO liga a automação com parâmetro perigoso.
+INSERT INTO public.company_config (key, value) VALUES
+  ('reposicao_auto_aprovacao_ativa', 'false'),
+  ('reposicao_auto_aprovacao_delta_max', '0.30'),
+  ('reposicao_auto_aprovacao_cooldown_falha_horas', '48'),
+  ('reposicao_auto_aprovacao_corte_utc', '13:00')
+ON CONFLICT (key) DO NOTHING;
+
+-- ── B) Log de auditoria (append-only, SEM FK — snapshot desacoplado) ─────────
+CREATE TABLE IF NOT EXISTS public.reposicao_auto_aprovacao_log (
+  id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  pedido_id bigint NOT NULL,
+  empresa text NOT NULL,
+  fornecedor_nome text NOT NULL,
+  grupo_codigo text NOT NULL DEFAULT '',
+  valor_total numeric NOT NULL,
+  valor_anterior numeric,
+  delta_pct numeric,
+  regua numeric NOT NULL,
+  criado_em timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS reposicao_auto_aprovacao_log_criado_em
+  ON public.reposicao_auto_aprovacao_log (criado_em DESC);
+
+ALTER TABLE public.reposicao_auto_aprovacao_log ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Staff lê log de auto-aprovação" ON public.reposicao_auto_aprovacao_log;
+CREATE POLICY "Staff lê log de auto-aprovação" ON public.reposicao_auto_aprovacao_log
+  FOR SELECT TO authenticated
+  USING (EXISTS (
+    SELECT 1 FROM public.user_roles ur
+    WHERE ur.user_id = (SELECT auth.uid()) AND ur.role IN ('employee','master')
+  ));
+-- Escrita: só o tick (SECURITY DEFINER) / service_role (bypassa RLS). Sem policy de INSERT.
+
+-- ── C) Elegibilidade (função separada = testável isoladamente no PG17) ───────
+-- Retorna jsonb {elegivel, motivo?, valor_anterior?, delta_pct?, valor_itens?}.
+-- VOLATILE (não STABLE): trava o pedido FOR UPDATE p/ fechar o TOCTOU (Codex P1.2) —
+-- o lock persiste na transação do tick até o claim, então nada muda valor/itens entre
+-- a validação e a aprovação. O motivo não é consumido pelo tick (inelegível segue o
+-- fluxo humano), mas é ouro pra teste/debug via SELECT direto.
+--
+-- Codex folds: P1.1 OBEN-only · P1.2 FOR UPDATE + valor recalculado dos ITENS (não do
+-- cabeçalho — o disparo manda os itens [edge:748], cabeçalho pode divergir) · P1.3
+-- rejeita item em promoção · P1.4 referência AGREGADA por grupo×data_ciclo (colapsa o
+-- pré-split em filhos) · P1.6 no máx. 1 auto-aprovado não-disparado por grupo · P2.7
+-- cooldown enxerga falha de PORTAL · P2.11 guard de item rejeita NaN/Infinity.
+CREATE OR REPLACE FUNCTION public.reposicao_pedido_auto_aprovavel(
+  p_pedido_id bigint,
+  p_threshold numeric,
+  p_delta_max numeric,
+  p_cooldown_horas numeric
+) RETURNS jsonb
+LANGUAGE plpgsql
+VOLATILE
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $$
+DECLARE
+  p RECORD;
+  v_grupo text;
+  v_valor numeric;     -- valor REAL (soma dos itens) — fonte de verdade do disparo
+  v_ref numeric;       -- v2: MEDIANA dos últimos N eventos de compra do grupo
+  v_n int;             -- v2: nº de eventos de referência (mínimo 3)
+BEGIN
+  -- P1.2: trava a linha. Qualquer promo/regeneração/aprovação concorrente espera este
+  -- lock; o claim do tick (mesma transação) vê o estado que esta função validou.
+  SELECT * INTO p FROM public.pedido_compra_sugerido WHERE id = p_pedido_id FOR UPDATE;
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('elegivel', false, 'motivo', 'pedido inexistente');
+  END IF;
+
+  -- P1.1: piloto é OBEN-only (spec §1). Sayerlack de outra empresa fica humano.
+  IF p.empresa <> 'OBEN' THEN
+    RETURN jsonb_build_object('elegivel', false, 'motivo', 'fora do escopo do piloto (só OBEN)');
+  END IF;
+
+  IF p.status <> 'pendente_aprovacao' OR p.aprovado_em IS NOT NULL OR p.cancelado_em IS NOT NULL THEN
+    RETURN jsonb_build_object('elegivel', false, 'motivo', 'não está pendente');
+  END IF;
+
+  IF COALESCE(p.tipo_ciclo, 'normal') <> 'normal' THEN
+    RETURN jsonb_build_object('elegivel', false, 'motivo', 'ciclo não-normal (oportunidade/promoção é decisão humana)');
+  END IF;
+
+  IF p.split_parent_id IS NOT NULL THEN
+    RETURN jsonb_build_object('elegivel', false, 'motivo', 'pedido-filho de split');
+  END IF;
+
+  IF COALESCE(p.num_skus, 0) <= 0 THEN
+    RETURN jsonb_build_object('elegivel', false, 'motivo', 'sem SKUs');
+  END IF;
+
+  v_grupo := COALESCE(p.grupo_codigo, '');
+
+  -- v2 (Codex): veta só 'forward_buying' (infla qtde = aposta de estoque adiantada, decisão
+  -- humana; tem o próprio guardrail de delta na geração). LIBERA 'flat' (só desconto de preço,
+  -- qtde inalterada — benigno; era a causa de parte da inatividade da v1, que vetava qualquer
+  -- modo_promocao). O delta assimétrico abaixo já protege o VALOR final.
+  IF EXISTS (
+    SELECT 1 FROM public.pedido_compra_item i
+    WHERE i.pedido_id = p.id AND i.modo_promocao = 'forward_buying'
+  ) THEN
+    RETURN jsonb_build_object('elegivel', false, 'motivo', 'item em forward_buying (aposta de estoque — decisão humana)');
+  END IF;
+
+  -- P2.11: guard de item que o disparo (#422/#433) barraria. Forma POSITIVA (> 0 AND <
+  -- Infinity) p/ rejeitar também NaN/Infinity — "preco<=0" é FALSE p/ NaN e não pegaria.
+  IF EXISTS (
+    SELECT 1 FROM public.pedido_compra_item i
+    WHERE i.pedido_id = p.id
+      AND NOT (i.preco_unitario > 0 AND i.preco_unitario < 'Infinity'::numeric
+               AND i.qtde_final > 0 AND i.qtde_final < 'Infinity'::numeric)
+  ) THEN
+    RETURN jsonb_build_object('elegivel', false, 'motivo', 'item com preço/qtde inválido');
+  END IF;
+
+  -- P1.2: o VALOR que importa é o que será comprado = soma dos itens, NÃO o cabeçalho
+  -- (valor_total pode divergir; o disparo manda os itens). A régua vale sobre ele.
+  SELECT SUM(i.qtde_final * i.preco_unitario) INTO v_valor
+  FROM public.pedido_compra_item i WHERE i.pedido_id = p.id;
+  IF v_valor IS NULL OR NOT (v_valor > 0 AND v_valor < 'Infinity'::numeric) THEN
+    RETURN jsonb_build_object('elegivel', false, 'motivo', 'sem itens válidos para somar');
+  END IF;
+  IF v_valor < p_threshold THEN
+    RETURN jsonb_build_object('elegivel', false, 'motivo', 'abaixo da régua (soma dos itens)');
+  END IF;
+
+  -- Humano já mexeu → a decisão é dele (trade-off "ajustou → aprova" do #711).
+  IF EXISTS (
+    SELECT 1 FROM public.pedido_compra_item i
+    WHERE i.pedido_id = p.id AND i.ajustado_humano IS TRUE
+  ) THEN
+    RETURN jsonb_build_object('elegivel', false, 'motivo', 'itens ajustados por humano');
+  END IF;
+
+  -- P2.7: cooldown enxerga falha de DISPARO (status='falha_envio') E de PORTAL
+  -- (status_envio_portal terminal/ambíguo — SKU sem de-para vira 'erro_nao_retentavel'
+  -- sem mexer no status principal). Auto-aprovado do fornecedor que falhou há pouco →
+  -- exceção humana resolve antes de a automação voltar ao fornecedor.
+  IF EXISTS (
+    SELECT 1 FROM public.pedido_compra_sugerido f
+    WHERE f.empresa = p.empresa
+      AND f.fornecedor_nome = p.fornecedor_nome
+      AND f.aprovado_por LIKE 'auto:%'
+      AND (f.status = 'falha_envio'
+           OR f.status_envio_portal IN ('erro_nao_retentavel', 'falha_envio_portal', 'indeterminado_requer_conciliacao'))
+      AND f.atualizado_em > now() - (p_cooldown_horas * interval '1 hour')
+  ) THEN
+    RETURN jsonb_build_object('elegivel', false, 'motivo', 'cooldown: auto-aprovação recente do fornecedor falhou (disparo/portal)');
+  END IF;
+
+  -- P1.6: raio cumulativo — no MÁXIMO 1 auto-aprovado não-disparado por grupo. Sem isto,
+  -- N pedidos de SKUs novos do grupo passam cada um contra a mesma referência antiga e a
+  -- exposição antes do corte vira ilimitada. O 2º espera o 1º disparar (e virar referência).
+  IF EXISTS (
+    SELECT 1 FROM public.pedido_compra_sugerido q
+    WHERE q.empresa = p.empresa
+      AND q.fornecedor_nome = p.fornecedor_nome
+      AND COALESCE(q.grupo_codigo, '') = v_grupo
+      AND q.aprovado_por LIKE 'auto:%'
+      AND q.status = 'aprovado_aguardando_disparo'
+      AND q.id <> p.id
+  ) THEN
+    RETURN jsonb_build_object('elegivel', false, 'motivo', 'já há auto-aprovado do grupo aguardando disparo');
+  END IF;
+
+  -- v2: referência = MEDIANA dos últimos 5 EVENTOS de compra do grupo. Cada evento = SUM por
+  -- data_ciclo (<90d, compra real) — colapsa o pré-split (pai → filhos na mesma data) como na v1,
+  -- mas agora a mediana de VÁRIOS eventos, não o último solto (ruidoso: normal teve R$1031 e
+  -- R$7377). MÍNIMO 3 eventos (Codex: percentile_cont com 2 valores interpola a média = falsa
+  -- mediana; com [1000,16000] daria 8500).
+  WITH eventos AS (
+    SELECT r.data_ciclo, SUM(r.valor_total) AS valor
+    FROM public.pedido_compra_sugerido r
+    WHERE r.empresa = p.empresa
+      AND r.fornecedor_nome = p.fornecedor_nome
+      AND COALESCE(r.grupo_codigo, '') = v_grupo
+      AND r.id <> p.id
+      AND r.criado_em > now() - interval '90 days'
+      AND (r.omie_pedido_compra_numero IS NOT NULL OR r.status IN ('disparado', 'concluido_recebido'))
+    GROUP BY r.data_ciclo
+    ORDER BY r.data_ciclo DESC
+    LIMIT 5
+  )
+  SELECT percentile_cont(0.5) WITHIN GROUP (ORDER BY valor), count(*)
+    INTO v_ref, v_n FROM eventos;
+
+  IF v_n < 3 THEN
+    RETURN jsonb_build_object('elegivel', false, 'motivo', 'menos de 3 compras de referência do grupo em 90d');
+  END IF;
+  IF v_ref IS NULL OR NOT (v_ref > 0 AND v_ref < 'Infinity'::numeric) THEN
+    RETURN jsonb_build_object('elegivel', false, 'motivo', 'mediana de referência inválida');
+  END IF;
+
+  -- v2: delta ASSIMÉTRICO — só trava comprar MAIS que mediana×(1+delta_max). Comprar <= mediana
+  -- SEMPRE passa (conservador: menos capital; a régua R$3k já é o piso). O risco money-path da
+  -- auto-aprovação é comprar DEMAIS; pedido muito menor que o típico é seguro (Codex: humano
+  -- semeia a mediana, a automação alcança depois). delta_pct negativo = comprou menos (ok).
+  IF v_valor > v_ref * (1 + p_delta_max) THEN
+    RETURN jsonb_build_object('elegivel', false,
+      'motivo', 'acima do típico: ' || round(v_valor)::text || ' > mediana ' || round(v_ref)::text
+        || ' × ' || round((1 + p_delta_max), 2)::text,
+      'valor_anterior', v_ref,
+      'delta_pct', round(100.0 * (v_valor - v_ref) / v_ref, 1));
+  END IF;
+
+  RETURN jsonb_build_object('elegivel', true,
+    'valor_anterior', v_ref,
+    'delta_pct', round(100.0 * (v_valor - v_ref) / v_ref, 1),
+    'valor_itens', v_valor);
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.reposicao_pedido_auto_aprovavel(bigint, numeric, numeric, numeric) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.reposicao_pedido_auto_aprovavel(bigint, numeric, numeric, numeric) TO service_role;
+
+-- ── D) Tick estendido (corpo VERBATIM da 20260609150000 + marcas [AUTO]) ─────
+CREATE OR REPLACE FUNCTION public.reposicao_alerta_pedido_minimo_tick()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $$
+DECLARE
+  v_threshold numeric;
+  v_fornecedor text;
+  r RECORD;
+  -- [AUTO 1/4] estado do braço de auto-aprovação (v2: SEM janela de horário)
+  v_txt text;
+  v_auto_on boolean := false;
+  v_delta_max numeric;
+  v_cooldown numeric;
+  v_suspenso boolean := false;
+  v_elig jsonb;
+  v_auto_ok boolean;
+  v_valor_auto numeric;  -- [AUTO] valor REAL (soma dos itens) do pedido auto-aprovado
+BEGIN
+  -- [AUTO 1/4] Codex P2.9: serializa execuções do tick (cron */30 + hook pós-geração).
+  -- Sem isto, dois ticks concorrentes não duplicam compra/log (o claim condicional cobre),
+  -- mas o perdedor pode re-inserir estado ativo e mandar CTA "pronto pra aprovar" pra um
+  -- pedido que o vencedor já auto-aprovou. xact-lock libera no COMMIT. Benigno pro alerta.
+  PERFORM pg_advisory_xact_lock(hashtext('reposicao_alerta_pedido_minimo_tick'));
+
+  SELECT value::numeric INTO v_threshold
+  FROM public.company_config WHERE key = 'reposicao_alerta_pedido_valor_minimo';
+  SELECT value INTO v_fornecedor
+  FROM public.company_config WHERE key = 'reposicao_alerta_pedido_fornecedor_ilike';
+
+  -- Config ausente/inválida = alerta DESLIGADO (régua comercial, não segurança). Sem alerta
+  -- fabricado com régua 0.
+  IF v_threshold IS NULL OR v_threshold <= 0
+     OR v_fornecedor IS NULL OR btrim(v_fornecedor) = '' THEN
+    RETURN;
+  END IF;
+
+  -- [AUTO 1/4] configs do braço de auto-aprovação. Config quebrada → braço OFF
+  -- (fail-safe: o alerta call-to-action continua; nunca aprova com parâmetro inválido).
+  SELECT value INTO v_txt FROM public.company_config WHERE key = 'reposicao_auto_aprovacao_ativa';
+  v_auto_on := (v_txt = 'true');
+  IF v_auto_on THEN
+    SELECT value INTO v_txt FROM public.company_config WHERE key = 'reposicao_auto_aprovacao_delta_max';
+    IF v_txt ~ '^[0-9]+(\.[0-9]+)?$' THEN v_delta_max := v_txt::numeric; END IF;
+    SELECT value INTO v_txt FROM public.company_config WHERE key = 'reposicao_auto_aprovacao_cooldown_falha_horas';
+    IF v_txt ~ '^[0-9]+(\.[0-9]+)?$' THEN v_cooldown := v_txt::numeric; END IF;
+    -- Codex P1.5: CLAMP de faixa segura. delta_max fora de (0, 0.30] ou cooldown < 1 → braço
+    -- OFF (um typo '30'=3000% ou '0' não liga a automação). v2: corte_utc NÃO é mais lido —
+    -- sem janela de horário; a config fica órfã no banco, inócua.
+    IF v_delta_max IS NULL OR v_delta_max <= 0 OR v_delta_max > 0.30
+       OR v_cooldown IS NULL OR v_cooldown < 1 THEN
+      v_auto_on := false;
+    END IF;
+  END IF;
+
+  IF v_auto_on THEN
+    -- Auto-suspensão: autonomia NÃO roda com o vigia acusando problema no domínio
+    -- (spec §4.5). O tipo 'reposicao_pedido_minimo' (este próprio fluxo) NÃO suspende.
+    v_suspenso := EXISTS (
+      SELECT 1 FROM public.fin_alertas fa
+      WHERE fa.dismissed_at IS NULL
+        AND fa.tipo IN ('data_health_reposicao_disparo',
+                        'data_health_reposicao_portal_pipeline',
+                        'data_health_reposicao_portal_humano',
+                        'data_health_reposicao_sugestoes')
+    );
+    -- v2: SEM janela de horário. Auto-aprova a qualquer hora que cruzar a régua; a compra
+    -- dispara no próximo corte (a edge disparar-pedidos-aprovados pega o backlog de
+    -- auto-aprovados de data_ciclo anterior — ver nota DISPARO no fim da migration).
+  END IF;
+
+  -- 1) NOVOS: pedido pendente ≥ régua do fornecedor configurado, sem alerta ativo → grava
+  -- estado + enfileira e-mail (só na transição). Agrupo por (empresa, fornecedor, grupo)
+  -- por defesa (a identidade pode ter 2 linhas transitórias: zumbi de ontem + hoje, pré-PR2).
+  FOR r IN
+    SELECT pcs.empresa, pcs.fornecedor_nome,
+           COALESCE(pcs.grupo_codigo, '') AS grupo_codigo,
+           MAX(pcs.valor_total) AS valor,
+           SUM(COALESCE(pcs.num_skus, 0)) AS num_skus,
+           MAX(pcs.id) AS pedido_id,
+           COUNT(*) AS qtd_pendentes  -- [AUTO 2/4] >1 = estado anômalo (zumbi) → humano
+    FROM public.pedido_compra_sugerido pcs
+    WHERE pcs.status = 'pendente_aprovacao'
+      AND pcs.fornecedor_nome ILIKE v_fornecedor
+      AND pcs.valor_total >= v_threshold
+    GROUP BY 1, 2, 3
+  LOOP
+    -- [AUTO 3/4] tenta a auto-aprovação ANTES de decidir qual e-mail sai. Claim
+    -- condicional: corrida com aprovação humana → quem chegar primeiro vence; o
+    -- perdedor não loga nem manda e-mail duplicado (FOUND = false).
+    v_auto_ok := false;
+    v_valor_auto := NULL;
+    IF v_auto_on AND NOT v_suspenso AND r.qtd_pendentes = 1 THEN   -- v2: sem v_dentro_janela
+      -- passa a régua (threshold) — a função valida a soma dos ITENS contra ela (P1.2).
+      v_elig := public.reposicao_pedido_auto_aprovavel(r.pedido_id, v_threshold, v_delta_max, v_cooldown);
+      IF COALESCE((v_elig->>'elegivel')::boolean, false) THEN
+        UPDATE public.pedido_compra_sugerido
+        SET aprovado_em = now(),
+            aprovado_por = 'auto:sayerlack-v2',
+            status = 'aprovado_aguardando_disparo'
+        WHERE id = r.pedido_id
+          AND status = 'pendente_aprovacao'
+          AND aprovado_em IS NULL
+          AND cancelado_em IS NULL;
+        IF FOUND THEN
+          v_auto_ok := true;
+          -- valor REAL = soma dos itens (P1.2), não o cabeçalho r.valor que pode divergir.
+          v_valor_auto := COALESCE((v_elig->>'valor_itens')::numeric, r.valor);
+          INSERT INTO public.reposicao_auto_aprovacao_log
+            (pedido_id, empresa, fornecedor_nome, grupo_codigo, valor_total,
+             valor_anterior, delta_pct, regua)
+          VALUES
+            (r.pedido_id, r.empresa, r.fornecedor_nome, r.grupo_codigo, v_valor_auto,
+             (v_elig->>'valor_anterior')::numeric, (v_elig->>'delta_pct')::numeric, v_threshold);
+        END IF;
+      END IF;
+    END IF;
+
+    INSERT INTO public.reposicao_alerta_pedido_minimo
+      (empresa, fornecedor_nome, grupo_codigo, pedido_id, valor_alertado, valor_ultimo)
+    VALUES (r.empresa, r.fornecedor_nome, r.grupo_codigo, r.pedido_id, r.valor, r.valor)
+    ON CONFLICT (empresa, fornecedor_nome, grupo_codigo) WHERE resolvido_em IS NULL
+    DO NOTHING;
+
+    IF FOUND THEN
+      -- [AUTO 4/4] transição: informativo (máquina aprovou) OU call-to-action (fluxo atual).
+      IF v_auto_ok THEN
+        INSERT INTO public.fornecedor_alerta (empresa, tipo, severidade, titulo, mensagem, status)
+        VALUES (
+          lower(r.empresa),
+          'reposicao_pedido_minimo',
+          'atencao',
+          '[Compras] Auto-aprovado: pedido ' || r.fornecedor_nome || ' de R$ ' || round(COALESCE(v_valor_auto, r.valor))::text,
+          'O pedido sugerido de ' || r.fornecedor_nome
+            || CASE WHEN r.grupo_codigo <> '' THEN ' (grupo ' || r.grupo_codigo || ')' ELSE '' END
+            || ' atingiu R$ ' || round(COALESCE(v_valor_auto, r.valor))::text
+            || ' (' || r.num_skus::text || ' SKUs) e foi APROVADO AUTOMATICAMENTE — piloto: delta '
+            || COALESCE((v_elig->>'delta_pct')::text, '?') || '% vs último disparo do grupo (R$ '
+            || COALESCE(round((v_elig->>'valor_anterior')::numeric)::text, '?')
+            || '), dentro do limite. Dispara no próximo corte automático. Para VETAR, cancele em '
+            || 'Reposição → Pedidos (https://steu.lovable.app/admin/reposicao/pedidos) antes do corte. '
+            || 'Fusível: company_config → reposicao_auto_aprovacao_ativa = false desliga o piloto.',
+          'pendente_notificacao'
+        );
+      ELSE
+        -- Transição: 1 e-mail. Link GENÉRICO pra tela (deep-link ?id= morreria na regeneração).
+        INSERT INTO public.fornecedor_alerta (empresa, tipo, severidade, titulo, mensagem, status)
+        VALUES (
+          lower(r.empresa),
+          'reposicao_pedido_minimo',
+          'atencao',
+          '[Compras] Pedido ' || r.fornecedor_nome || ' atingiu R$ ' || round(r.valor)::text
+            || ' — pronto pra aprovar',
+          'O pedido sugerido de ' || r.fornecedor_nome
+            || CASE WHEN r.grupo_codigo <> '' THEN ' (grupo ' || r.grupo_codigo || ')' ELSE '' END
+            || ' acumulou R$ ' || round(r.valor)::text
+            || ' (' || r.num_skus::text || ' SKUs) — acima do mínimo de faturamento (R$ '
+            || round(v_threshold)::text || '). Aprovar dispara na hora: '
+            || 'Reposição → Pedidos (https://steu.lovable.app/admin/reposicao/pedidos). '
+            || 'Quando você aprovar (ou o pedido sair da régua), este aviso re-arma sozinho.',
+          'pendente_notificacao'
+        );
+      END IF;
+    ELSE
+      IF v_auto_ok THEN
+        -- [AUTO 4/4] alerta call-to-action já estava ativo e a máquina aprovou AGORA
+        -- (ex.: fusível ligado depois do alerta) → informativo é transição real.
+        INSERT INTO public.fornecedor_alerta (empresa, tipo, severidade, titulo, mensagem, status)
+        VALUES (
+          lower(r.empresa),
+          'reposicao_pedido_minimo',
+          'atencao',
+          '[Compras] Auto-aprovado: pedido ' || r.fornecedor_nome || ' de R$ ' || round(COALESCE(v_valor_auto, r.valor))::text,
+          'O pedido sugerido de ' || r.fornecedor_nome
+            || CASE WHEN r.grupo_codigo <> '' THEN ' (grupo ' || r.grupo_codigo || ')' ELSE '' END
+            || ' (R$ ' || round(COALESCE(v_valor_auto, r.valor))::text || ', ' || r.num_skus::text
+            || ' SKUs) foi APROVADO AUTOMATICAMENTE — piloto: delta '
+            || COALESCE((v_elig->>'delta_pct')::text, '?') || '% vs último disparo do grupo (R$ '
+            || COALESCE(round((v_elig->>'valor_anterior')::numeric)::text, '?')
+            || '). Dispara no próximo corte automático. Para VETAR, cancele em '
+            || 'Reposição → Pedidos (https://steu.lovable.app/admin/reposicao/pedidos) antes do corte. '
+            || 'Fusível: company_config → reposicao_auto_aprovacao_ativa = false desliga o piloto.',
+          'pendente_notificacao'
+        );
+      ELSE
+        -- Alerta já ativo: só atualiza o último valor visto (3.2k→10k NÃO re-spamma; o valor
+        -- vivo está no cockpit).
+        UPDATE public.reposicao_alerta_pedido_minimo a
+        SET valor_ultimo = r.valor, pedido_id = r.pedido_id
+        WHERE a.empresa = r.empresa AND a.fornecedor_nome = r.fornecedor_nome
+          AND a.grupo_codigo = r.grupo_codigo AND a.resolvido_em IS NULL;
+      END IF;
+    END IF;
+  END LOOP;
+
+  -- 2) RESOLVE (re-arma): alerta ativo sem pedido pendente ≥ régua correspondente — o founder
+  -- aprovou/cancelou, o corte expirou, ou o valor caiu. O próximo pedido do grupo que cruzar a
+  -- régua gera e-mail NOVO. (Sem filtro de fornecedor aqui de propósito: se o pattern da config
+  -- mudar, alertas órfãos do pattern antigo resolvem sozinhos.)
+  -- [AUTO] nota: pedido auto-aprovado sai de pendente NESTA execução → o estado da identidade
+  -- resolve aqui embaixo no mesmo tick (vida curta, consistente; o informativo já saiu acima).
+  UPDATE public.reposicao_alerta_pedido_minimo a
+  SET resolvido_em = now()
+  WHERE a.resolvido_em IS NULL
+    AND NOT EXISTS (
+      SELECT 1 FROM public.pedido_compra_sugerido pcs
+      WHERE pcs.empresa = a.empresa
+        AND pcs.fornecedor_nome = a.fornecedor_nome
+        AND COALESCE(pcs.grupo_codigo, '') = a.grupo_codigo
+        AND pcs.status = 'pendente_aprovacao'
+        AND pcs.valor_total >= v_threshold
+    );
+END;
+$$;
+
+-- Trava de execução (mesma da 20260609150000 — recriar função NÃO preserva grants implícitos
+-- de versões antigas, mas re-declarar é idempotente e auto-documenta).
+REVOKE ALL ON FUNCTION public.reposicao_alerta_pedido_minimo_tick() FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.reposicao_alerta_pedido_minimo_tick() TO service_role;
+
+COMMIT;
+
+-- ============================================================================
+-- ⚠️ DISPARO (deploy de edge À PARTE — NÃO está nesta migration):
+-- Com a janela dia-todo, o auto-aprovado da tarde tem data_ciclo=hoje mas o cron de disparo
+-- (0 13 UTC) filtra .eq("data_ciclo", hoje) → amanhã procura data_ciclo=amanhã → ÓRFÃO.
+-- A edge disparar-pedidos-aprovados ganha uma 2ª query (Codex, opção A) que concatena ao lote:
+--   status='aprovado_aguardando_disparo' · data_ciclo < hoje · aprovado_em >= now()-72h
+--   · aprovado_por LIKE 'auto:sayerlack%' · cancelado_em IS NULL · dedupe por id.
+-- Sem esse deploy, NÃO religar o fusível (os auto-aprovados ficariam órfãos).
+-- ============================================================================
+
+-- Validação (rodar após o COMMIT):
+-- WITH e AS (SELECT prosrc AS src FROM pg_proc WHERE proname='reposicao_pedido_auto_aprovavel' LIMIT 1),
+--      t AS (SELECT prosrc AS src FROM pg_proc WHERE proname='reposicao_alerta_pedido_minimo_tick' LIMIT 1)
+-- SELECT
+--   CASE WHEN (SELECT count(*) FROM pg_proc WHERE proname='reposicao_pedido_auto_aprovavel')=1
+--             AND (SELECT count(*) FROM pg_proc WHERE proname='reposicao_alerta_pedido_minimo_tick')=1
+--        THEN '✅ funções' ELSE '❌' END AS funcoes,
+--   CASE WHEN strpos((SELECT src FROM e),'percentile_cont')>0
+--         AND strpos((SELECT src FROM e),'v_valor > v_ref')>0
+--         AND strpos((SELECT src FROM e),'forward_buying')>0
+--         AND strpos((SELECT src FROM e),'v_n < 3')>0
+--        THEN '✅ folds elegib v2 (mediana/assimétrico/forward_buying/min3)' ELSE '❌ folds elegib' END AS folds_elegib,
+--   CASE WHEN strpos((SELECT src FROM t),'auto:sayerlack-v2')>0
+--         AND strpos((SELECT src FROM t),'v_dentro_janela')=0       -- janela REMOVIDA
+--         AND strpos((SELECT src FROM t),'pg_advisory_xact_lock')>0  -- advisory PRESERVADO
+--        THEN '✅ tick v2 (sem janela/v2/advisory)' ELSE '❌ tick' END AS folds_tick,
+--   (SELECT value FROM company_config WHERE key='reposicao_auto_aprovacao_ativa') AS fusivel;

--- a/supabase/migrations/20260615210000_reposicao_auto_aprovacao_v2.sql
+++ b/supabase/migrations/20260615210000_reposicao_auto_aprovacao_v2.sql
@@ -209,6 +209,10 @@ BEGIN
   -- mas agora a mediana de VÁRIOS eventos, não o último solto (ruidoso: normal teve R$1031 e
   -- R$7377). MÍNIMO 3 eventos (Codex: percentile_cont com 2 valores interpola a média = falsa
   -- mediana; com [1000,16000] daria 8500).
+  -- ⚠️ Codex P2.2 (teórico, sem caminho atual): a referência soma valor_total do CABEÇALHO dos
+  -- históricos; o candidato (v_valor) usa a soma dos ITENS. Nos disparados o cabeçalho = itens (a
+  -- geração seta valor_total = SUM dos itens e o disparo não muda). Se um dia divergirem (cabeçalho
+  -- inflado), o teto poderia subir. Monitorado no piloto; fix futuro = somar itens nos históricos.
   WITH eventos AS (
     SELECT r.data_ciclo, SUM(r.valor_total) AS valor
     FROM public.pedido_compra_sugerido r


### PR DESCRIPTION
Recalibração do piloto de auto-aprovação Sayerlack (N3). A v1 (#730) ficou INERTE em prod — 0 auto-aprovações em 4 dias — porque 3 guard-rails eram restritivos demais contra os dados reais. O check-in seg/qui pegou (via psql-ro). Piloto PAUSADO em prod enquanto recalibra.

Spec: docs/superpowers/specs/2026-06-15-reposicao-auto-aprovacao-v2-recalibracao.md

**3 mudanças (founder + Codex consult):**
- **Delta ASSIMÉTRICO + MEDIANA.** Referência = mediana dos últimos 5 disparos do grupo (mín. 3 eventos — Codex: percentile_cont com 2 interpola a média), não o último solto (ruidoso: normal teve R$1031 e R$7377). Só trava comprar > mediana×1.30; comprar ≤ mediana sempre passa (o risco money-path é comprar DEMAIS; comprar menos é conservador).
- **SEM janela de horário.** Aprova a qualquer hora que cruzar a régua (os pedidos só cruzam R$3k às 20 UTC, fora da janela de madrugada antiga). Dispara no próximo corte.
- **Promo veta só `forward_buying`** (infla qtde = aposta de estoque). Libera `flat` (só desconto de preço).

**Edge** `disparar-pedidos-aprovados` ganha 2ª query de backlog (Codex opção A): pega auto-aprovados de `data_ciclo < hoje` (a janela dia-todo aprova à tarde → sem isso, órfão). Guards: `auto:sayerlack%`, `aprovado_em >= 72h`, `status_envio_portal='nao_aplicavel'` (P2.1: não re-dispara estado terminal de portal), `cancelado_em IS NULL`, dedupe.

**Validação:** PG17 16/16 (`db/test-auto-aprovacao-v2.sh`) + falsificação (V3 vermelho com assimétrico sabotado). Codex challenge xhigh: **sem P1**; 2 P2 incorporados/documentados.

**⚠️ ROLLOUT MANUAL (3 passos):** (1) migration `20260615210000` no SQL Editor; (2) DEPLOY da edge `disparar-pedidos-aprovados` (chat do Lovable, verbatim) — SEM ele os auto-aprovados ficam órfãos; (3) religar o fusível (`reposicao_auto_aprovacao_ativa='true'`). Detalhe na conversa da sessão.

🤖 Generated with [Claude Code](https://claude.com/claude-code)