### PR TITLE
fix(bi-colacor): nome de cliente via coalesce(razao_social, name, doc)

### DIFF
--- a/.claude/skills/bi-colacor/references/queries-financeiro.md
+++ b/.claude/skills/bi-colacor/references/queries-financeiro.md
@@ -24,7 +24,8 @@ order by total_vencido desc nulls last;
 Confiabilidade: **alta**. Fonte: `fin_contas_receber`. Nome do cliente via LEFT JOIN (opcional).
 ```sql
 select
-  cr.company as empresa, cr.omie_codigo_cliente, cr.cnpj_cpf, p.razao_social,
+  cr.company as empresa, cr.omie_codigo_cliente, cr.cnpj_cpf,
+  coalesce(p.razao_social, p.name, cr.cnpj_cpf) as nome_cliente,
   cr.numero_pedido, cr.data_vencimento,
   round(cr.valor_documento, 2)                                  as valor_documento,
   round(cr.valor_documento - coalesce(cr.valor_recebido,0), 2)  as saldo_aberto,

--- a/.claude/skills/bi-colacor/references/queries-vendas.md
+++ b/.claude/skills/bi-colacor/references/queries-vendas.md
@@ -54,7 +54,7 @@ order by valor_7d desc nulls last;
 ## #2 — Concentração de carteira (Pareto top 20), últimos 90 dias
 Confiabilidade: **alta**. Fonte: `venda_items_history`. Mostra quanto do faturamento vem dos
 maiores clientes (risco de dependência). Nome enriquecido por LEFT JOIN (opcional — remova as
-duas linhas de join e o `razao_social` se quiser só o código).
+duas linhas de join e o `nome_cliente` se quiser só o código).
 ```sql
 with vendas_cliente as (
   select v.empresa, v.cliente_codigo_omie,
@@ -74,7 +74,8 @@ ranked as (
   from vendas_cliente vc
 )
 select
-  r.empresa, r.rank_cliente, r.cliente_codigo_omie, r.cnpj_cpf, p.razao_social,
+  r.empresa, r.rank_cliente, r.cliente_codigo_omie, r.cnpj_cpf,
+  coalesce(p.razao_social, p.name, r.cnpj_cpf) as nome_cliente,
   round(r.faturamento_90d, 2)                                  as faturamento_90d,
   round(100.0 * r.faturamento_90d / nullif(r.total_empresa,0), 1) as pct_do_total,
   round(100.0 * r.acumulado      / nullif(r.total_empresa,0), 1) as pct_acumulado
@@ -92,7 +93,7 @@ Leitura: se `pct_acumulado` do top 10 já passa de ~60–70%, há concentração
 Confiabilidade: **alta**. Fonte: `customer_metrics_mv` (pré-agregado — barato e confiável).
 ```sql
 select
-  m.customer_user_id, p.razao_social, m.document,
+  m.customer_user_id, coalesce(p.razao_social, p.name, m.document) as nome_cliente, m.document,
   round(m.faturamento_prev_90d, 2)  as faturamento_90d_anterior,
   round(m.faturamento_90d, 2)       as faturamento_90d,
   round(100.0 * (m.faturamento_90d - m.faturamento_prev_90d) / nullif(m.faturamento_prev_90d, 0), 1) as variacao_pct,

--- a/.claude/skills/bi-colacor/references/schema-conventions.md
+++ b/.claude/skills/bi-colacor/references/schema-conventions.md
@@ -28,15 +28,20 @@ coluna for `text` de fato (ex.: status), trate como texto.
   `customer_preferred_items`, e como `cliente_codigo_omie` em `venda_items_history`,
   `fin_contas_receber`.
 - **Ponte:** `omie_clientes` (`user_id` ↔ `omie_codigo_cliente`). Para cruzar faturamento
-  fiscal (Omie) com scores/pedidos (user_id), passe por ela. `omie_clientes` não tem nome —
-  o nome legível (`razao_social`) está em `profiles`. Fallback de match: `profiles.cnpj` /
+  fiscal (Omie) com scores/pedidos (user_id), passe por ela. Fallback de match: `profiles.cnpj` /
   `profiles.document` ↔ `venda_items_history.cliente_cnpj_cpf` / `fin_contas_receber.cnpj_cpf`.
+- **Nome do cliente — NÃO use `razao_social` sozinho.** `profiles.razao_social` é nullable e
+  frequentemente **vazio** (no teste real veio NULL p/ todos). O padrão do app (`useRouteContactList`,
+  `usePropostaPreview`, `AgendaTodayList`) é **`razao_social || name`** — e `profiles.name` é
+  **NOT NULL** (sempre tem valor). Logo, para nome legível use sempre:
+  `coalesce(p.razao_social, p.name, <documento/cnpj>) as nome_cliente`. (`omie_clientes` também
+  tem `razao_social`/`nome_fantasia`, ambos nullable — úteis como fonte alternativa.)
 
 Enriquecer um resultado com nome do cliente (padrão LEFT JOIN, não derruba linhas):
 ```sql
 left join omie_clientes oc on oc.omie_codigo_cliente = <tabela>.cliente_codigo_omie
 left join profiles p on p.user_id = oc.user_id
--- ...select p.razao_social
+-- ...select coalesce(p.razao_social, p.name, <documento>) as nome_cliente  -- razao_social é esparso; name é NOT NULL
 ```
 
 ## 3. SKU/produto — `sku_codigo_omie` com tipo inconsistente


### PR DESCRIPTION
## Problema (pego no teste ao vivo da skill)

No Weekly Owner Brief de hoje, a query #3 (e por tabela #2 e #10b) tentava mostrar o nome do cliente via `profiles.razao_social` — **veio NULL para todos os 30 clientes**, então o brief só conseguia identificar por CNPJ/CPF. Inútil pra bater o olho e saber *quem* é.

## Causa

`profiles.razao_social` é nullable e está esparso/vazio. O app, em todo lugar que mostra nome de cliente (`useRouteContactList.ts:387`, `usePropostaPreview.ts:116`, `AgendaTodayList.tsx:40`), usa o fallback **`razao_social || name`** — e `profiles.name` é **NOT NULL** (sempre preenchido).

## Correção

As 3 queries que enriquecem com nome — **#2** (concentração), **#3** (clientes em queda), **#10b** (top devedores) — passam a usar `coalesce(p.razao_social, p.name, <documento>) as nome_cliente`, espelhando o padrão do app. Documentei a convenção no `schema-conventions.md` §2 para queries ad-hoc futuras herdarem. Read-only mantido; mudança só nos 3 arquivos de referência da skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)