### PR TITLE
feat(geocoding): Sub-PR 2 (front) — worker por CEP distinto + precisão honesta

### DIFF
--- a/docs/superpowers/plans/2026-06-15-geocoding-subpr2-front.md
+++ b/docs/superpowers/plans/2026-06-15-geocoding-subpr2-front.md
@@ -1,0 +1,114 @@
+# Geocoding por CEP — Sub-PR 2 (front) Implementation Plan
+
+> **For agentic workers:** executando INLINE (superpowers:executing-plans). Design aprovado em `docs/superpowers/specs/2026-06-15-geocoding-cep-escala-design.md` (§5, §8, §9). Sub-PR 1 (banco) já LIVE em prod (PR #876).
+
+**Goal:** O roteirizador-campo consome `lat/lng/precision` já resolvidos pelas RPCs (Sub-PR 1), para de re-geocodificar a carteira em memória, e o worker geocodifica por **CEP distinto** (não por empresa) → `cep_geo_upsert`, pintando pino aproximado honesto para `city_centroid`.
+
+**Architecture:** Helpers puros (TDD) + rewire do worker no `useRoutePlanner`. O worker do contexto **campo** (`prospeccao`) passa a deduplicar por CEP; o contexto **equipe** fica intocado (zero regressão). `precisaoVisual(precisao).aproximado` dirige ao mesmo tempo o estilo do pino E a inclusão na fila de geocode (city_centroid/unknown/null = aproximado → tenta upgrade por CEP; street/postcode/rooftop = bom → fora da fila).
+
+**Tech Stack:** React 18 + TS strict + vitest. RPCs via `supabase.rpc(... as never)` (types.ts local stale — Lovable regenera). Nominatim 1/s (já existente). `cep_geo_upsert` persiste `postcode_centroid`.
+
+---
+
+## Invariantes (do design §11, não-negociáveis)
+
+- **OSM/grátis**; Google pago FORA. `useFarmerScoring` **intocado**.
+- Nominatim: geocodificar **CEP distinto**, nunca empresa, 1/s, **sempre persistir** (`cep_geo_upsert`).
+- **Precisão honesta:** `city_centroid` é VISÍVEL como aproximado (pino oco/tracejado + "aprox.") — degradar, não fabricar.
+- Equipe (`logistica/comercial/hibrido/manual`) = comportamento atual idêntico (worker por endereço preservado).
+- Não baixar mais o `re.lat` legado: prospect com `precision='street'` (re.lat) NÃO entra na fila (não regredir pra postcode).
+
+## Mapa de arquivos
+
+- Create: `src/lib/route/cep.ts` (+ `.test.ts`) — `normalizarCep(raw)`.
+- Modify: `src/lib/route/marker-visual.ts` (+ `.test.ts`) — `precisaoVisual(precisao)`.
+- Modify: `src/lib/route/geocode-fila.ts` (+ `.test.ts`) — `ordenarFilaGeocodeCep(stops, estado)`.
+- Modify: `src/lib/route/carteira-stop.ts` (+ `.test.ts`) — `CarteiraRow`/draft + adoção lat/lng/precision.
+- Modify: `src/lib/route/prospect-stop.ts` (+ `.test.ts`) — `ProspectRow.precision` + adoção lat/lng (ungated).
+- Modify: `src/components/reposicao/routePlanner/types.ts` — `RouteStop.precisao?` + tipo `Precisao`.
+- Modify: `src/hooks/useRoutePlanner.ts` — worker CEP (prospeccao), carteira pré-resolvida, chip N CEPs, `cep_geo_upsert`.
+- Modify: `src/pages/AdminRoutePlanner.tsx` — pino aproximado (`precisaoVisual`+`divIconAlvo`) + chip "N CEPs".
+
+---
+
+## T1 — `normalizarCep` (puro, TDD)
+
+**Files:** Create `src/lib/route/cep.ts` + `src/lib/route/cep.test.ts`.
+
+Espelha o SQL `normalizar_cep` (tira não-dígitos; vazio→null) E acrescenta a validade de 8 dígitos da PK `cep_geo` (CEP não-8 = não geocodificável → fora da fila/upsert).
+
+- [ ] **Step 1: teste falhando** — `'35.500-001'→'35500001'`, `' 35500001 '→'35500001'`, `'123'→null`, `'355000012'(9)→null`, `''→null`, `null→null`, `undefined→null`.
+- [ ] **Step 2: roda → falha** (`function not defined`).
+- [ ] **Step 3: implementa** — `const d = (raw ?? '').replace(/\D/g, ''); return /^[0-9]{8}$/.test(d) ? d : null;`
+- [ ] **Step 4: roda → passa.**
+- [ ] **Step 5: commit.**
+
+## T2 — `precisaoVisual` (puro, TDD)
+
+**Files:** Modify `src/lib/route/marker-visual.ts` + `.test.ts`.
+
+`precisaoVisual(precisao) → { aproximado: boolean; rotulo: string }`. `aproximado=true` para `'city_centroid'`/`'unknown'`/null/undefined (rotulo `'aprox.'`); `false` para `'rooftop'`/`'street'`/`'postcode_centroid'` (rotulo `''`). É o ÚNICO ponto de verdade do que é "aproximado" (pino E fila).
+
+- [ ] **Step 1: teste falhando** — os 6+ casos acima.
+- [ ] **Step 2: roda → falha.**
+- [ ] **Step 3: implementa** o helper + `export type Precisao`.
+- [ ] **Step 4: roda → passa.**
+- [ ] **Step 5: commit.**
+
+## T3 — `ordenarFilaGeocodeCep` (puro, TDD)
+
+**Files:** Modify `src/lib/route/geocode-fila.ts` + `.test.ts`. Mantém `ordenarFilaGeocode` (equipe usa).
+
+Dedup por CEP distinto. Pendente = `normalizarCep(zip)` válido E `precisaoVisual(precisao).aproximado` E cep ∉ resolvidos E cep ∉ falhados. Marcados-primeiro (CEP herda prioridade se QUALQUER stop dele está em `marcados`), depois ordem de 1ª aparição (estável). Devolve `CepPendente[] = {cep, cidade, uf}`.
+
+- [ ] **Step 1: teste falhando** — dedup (3 stops/2 CEPs → 2), exclui precisão boa (street/postcode/rooftop), exclui resolvidos/falhados/cep-inválido, marcados-primeiro, estável.
+- [ ] **Step 2: roda → falha.**
+- [ ] **Step 3: implementa** `EstadoFilaCep` + `CepPendente` + função.
+- [ ] **Step 4: roda → passa.**
+- [ ] **Step 5: commit.**
+
+## T4 — mappers adotam coord resolvida (TDD)
+
+**Files:** Modify `carteira-stop.ts`/`.test.ts`, `prospect-stop.ts`/`.test.ts`, `types.ts`.
+
+`CarteiraRow` += `lat/lng/precision` (RPC já devolve); `CarteiraStopDraft` += `lat?/lng?/precisao?`; `carteiraRowToStop` adota → **carteira vem pronta** (sem geocode em memória). `ProspectRow` += `precision`; `prospectRowToStopDraft` adota `row.lat/lng` **sempre que presentes** (não mais gated em `geocode_status='ok'` — a RPC já fez o COALESCE) + `precisao`. `RouteStop` += `precisao?: Precisao`.
+
+- [ ] **Step 1: testes falhando** — carteira adota lat/lng/precisao; carteira sem coord (null) → undefined; prospect adota lat/lng do município (precision city_centroid) mesmo com `geocode_status` null; prospect street legado preserva.
+- [ ] **Step 2: roda → falha.**
+- [ ] **Step 3: implementa** as 3 mudanças.
+- [ ] **Step 4: roda → passa.**
+- [ ] **Step 5: commit.**
+
+## T5 — hook: worker CEP + carteira pré-resolvida + chip N CEPs
+
+**Files:** Modify `src/hooks/useRoutePlanner.ts`.
+
+`loadCarteiraDaCidade`: base += `lat/lng/precisao` do draft (carteira deixa de depender do worker). `loadProspectStops`: base += `precisao`; cache de coord aceita as do RPC. Worker (efeito ~1/s): se `planningMode==='prospeccao'` → loop CEP via `ordenarFilaGeocodeCep`: query `"{cep}, {cidade}, {uf}, Brazil"`; hit → `cep_geo_upsert` (`postcode_centroid`) + patch de TODOS os stops com aquele CEP + `cepResolvidos.add(cep)`; miss → `cepFalhados.add(cep)`. `geocodingPendentes` = nº de CEPs distintos. Senão (equipe) → loop legado **idêntico**. Refs novos: `geocodedCepCoords` (cep→coord) reaplicado no efeito immediate-show; `cepResolvidos`/`cepFalhados`.
+
+- [ ] **Step 1:** carteira mapper já entrega coord; remover dependência do worker pra carteira (vem do T4).
+- [ ] **Step 2:** branch do worker por `planningMode`; loop CEP novo; equipe inalterado.
+- [ ] **Step 3:** `cep_geo_upsert` (`as never`) no hit; patch same-CEP; chip = CEPs distintos.
+- [ ] **Step 4:** `heavy bun run typecheck` verde.
+- [ ] **Step 5: commit.**
+
+## T6 — render: pino aproximado + chip "N CEPs"
+
+**Files:** Modify `src/pages/AdminRoutePlanner.tsx` (e `divIconAlvo` onde estiver).
+
+Campo: `const { aproximado } = precisaoVisual(stop.precisao)` → `divIconAlvo(tone, shape, numero, aproximado)` (oco/tracejado quando aproximado). Popup ganha "📍 aprox." quando aproximado. Chip: `localizando {geocodingPendentes} CEP{s>1?'s':''}…`.
+
+- [ ] **Step 1:** `divIconAlvo` aceita `aproximado` (borda tracejada + fill translúcido).
+- [ ] **Step 2:** consumir `precisaoVisual` no render + popup; chip "N CEPs".
+- [ ] **Step 3:** `heavy bun run typecheck` + `bun lint` verdes.
+- [ ] **Step 4: commit.**
+
+## T7 — verde + PR
+
+- [ ] `heavy bun run test` (suite toda) + `heavy bun run typecheck` + `bun lint` verdes.
+- [ ] `bunx knip` (sem deadcode novo) se rápido.
+- [ ] Auto-review do diff; push; abrir PR (não-draft → auto-merge no CI verde).
+- [ ] Roadmap no chat: Sub-PR 2 ✅; handoff Sub-PR 3 (gated CEP Aberto).
+
+## Verificação manual (founder, no device, pós-deploy front)
+
+2ª visita à cidade instantânea; chip "N CEPs"; pino aproximado (oco) visível p/ centróide de município; carteira não re-geocodifica ao reabrir.

--- a/src/components/reposicao/routePlanner/types.ts
+++ b/src/components/reposicao/routePlanner/types.ts
@@ -80,6 +80,10 @@ export interface RouteStop {
   // Recência da carteira (RPC carteira_por_municipio); null = nunca visitado.
   // Capturado no Sub-PR 2; consumido pelas cores do mapa no Sub-PR 4.
   diasDesdeVisita?: number | null;
+  // Precisão da coordenada resolvida pela RPC (cep_geo → centróide município).
+  // Geocoding por CEP (Sub-PR 2): dirige o pino aproximado e a fila. `string` (não
+  // o union Precisao) evita import circular com marker-visual; ver precisaoVisual.
+  precisao?: string;
 }
 
 /** Cidade retornada por radar_contagem_por_municipio, usada no CitySelector. */

--- a/src/hooks/useRoutePlanner.ts
+++ b/src/hooks/useRoutePlanner.ts
@@ -28,7 +28,7 @@ import type { Tables } from '@/integrations/supabase/types';
 import { visitasAgendadasTable } from '@/integrations/supabase/visitasAgendadas';
 import type { VisitaAgendadaRow } from '@/integrations/supabase/visitasAgendadas';
 import { agendaToRouteStop } from '@/lib/visitas/agenda-to-stop';
-import { prospectRowToStopDraft, buildGeocodeQuery } from '@/lib/route/prospect-stop';
+import { prospectRowToStopDraft } from '@/lib/route/prospect-stop';
 import type { ProspectRow } from '@/lib/route/prospect-stop';
 import {
   defaultContextForRole,
@@ -43,7 +43,8 @@ import {
 } from '@/lib/route/field-targets';
 import { carteiraRowToStop, type CarteiraRow } from '@/lib/route/carteira-stop';
 import { montarDetalheAlvo, type AlvoDetalhe } from '@/lib/route/alvo-detalhe';
-import { ordenarFilaGeocode } from '@/lib/route/geocode-fila';
+import { ordenarFilaGeocode, ordenarFilaGeocodeCep } from '@/lib/route/geocode-fila';
+import { normalizarCep } from '@/lib/route/cep';
 
 // Teto de prospects por cidade pedido à RPC (a RPC capa em 2000 no SQL).
 // Divinópolis (600) cabe inteira; metrópole mostra os 1000 mais quentes.
@@ -846,6 +847,7 @@ export function useRoutePlanner() {
           radarCnpj: draft.radarCnpj,
           geocodeFailed: draft.geocodeFailed,
           prospeccaoStatus: draft.prospeccaoStatus,
+          precisao: draft.precisao,
         };
         return enrichWithPriority(base);
       });
@@ -896,6 +898,9 @@ export function useRoutePlanner() {
             businessHoursClose: draft.businessHoursClose,
             status: 'carteira',
             diasDesdeVisita: draft.diasDesdeVisita,
+            lat: draft.lat,
+            lng: draft.lng,
+            precisao: draft.precisao,
           };
           stops.push(enrichWithPriority(base));
         }
@@ -925,6 +930,8 @@ export function useRoutePlanner() {
     setFiltros(FILTROS_ALVO_INICIAL);
     setRemovidos(new Set());
     geocodeFalhados.current.clear(); // nova cidade → permite re-tentar geocodes que falharam
+    cepFalhados.current.clear();
+    geocodedCepCoords.current.clear();
   }, [selectedCities]);
 
   // Merge stops based on planning mode
@@ -993,76 +1000,108 @@ export function useRoutePlanner() {
   const geocodedCoords = useRef<Map<string, { lat: number; lng: number }>>(new Map());
   const geocodingAbort = useRef<AbortController | null>(null);
   const geocodeFalhados = useRef<Set<string>>(new Set());
+  // Geocoding por CEP (campo): coord por CEP distinto + CEPs que falharam na sessão.
+  const geocodedCepCoords = useRef<Map<string, { lat: number; lng: number }>>(new Map());
+  const cepFalhados = useRef<Set<string>>(new Set());
+  // Modo atual num ref p/ o worker escolher a estratégia (CEP vs endereço) sem stale.
+  const planningModeRef = useRef(planningMode);
+  planningModeRef.current = planningMode;
   // Espelha a seleção num ref p/ o worker priorizar marcados sem re-disparar a fila.
   const selectedIdsRef = useRef<Set<string>>(new Set());
   selectedIdsRef.current = selectedTargetIds;
 
   const [geocodedAllStops, setGeocodedAllStops] = useState<RouteStop[]>([]);
 
-  // Immediately show stops without waiting for geocoding
+  // Mostra os stops já com a coord da RPC; reaplica os upgrades por CEP feitos
+  // nesta sessão (o CEP vence — é o refino postcode sobre o centróide do município).
   useEffect(() => {
     const enriched = allStops.map(s => {
+      const cepCoord = geocodedCepCoords.current.get(normalizarCep(s.address.zip_code) ?? '');
+      if (cepCoord) return { ...s, lat: cepCoord.lat, lng: cepCoord.lng, precisao: 'postcode_centroid' };
       const cached = geocodedCoords.current.get(s.id);
       return cached ? { ...s, lat: cached.lat, lng: cached.lng } : s;
     });
     setGeocodedAllStops(enriched);
   }, [allStops]);
 
-  // Geocoding progressivo (G): fila CONTÍNUA ~1/s, marcados-na-rota primeiro.
-  // Re-deriva a fila a cada ciclo (via ordenarFilaGeocode) → marcar um alvo no meio
-  // re-prioriza o PRÓXIMO pick; resolvidos/falhados saem da fila → o loop termina.
+  // Geocoding progressivo ~1/s, marcados-na-rota primeiro. CAMPO (prospeccao):
+  // geocodifica o CEP DISTINTO → cep_geo_upsert → pinta TODOS os alvos do CEP de uma
+  // vez (1234 empresas ≈ 574 CEPs). EQUIPE: legado por endereço/stop. Re-deriva a
+  // fila a cada ciclo → marcar um alvo re-prioriza o próximo pick; resolvidos/
+  // falhados saem da fila → o loop termina.
   useEffect(() => {
     geocodingAbort.current?.abort();
     const controller = new AbortController();
     geocodingAbort.current = controller;
 
+    const nominatim = async (query: string) => {
+      const res = await fetch(
+        `https://nominatim.openstreetmap.org/search?format=json&q=${encodeURIComponent(query)}&limit=1`,
+        { signal: controller.signal },
+      );
+      const data = await res.json();
+      return data?.[0] ? { lat: parseFloat(data[0].lat), lng: parseFloat(data[0].lon) } : null;
+    };
+
     (async () => {
       while (!controller.signal.aborted) {
-        const fila = ordenarFilaGeocode(allStops, {
-          resolvidos: new Set(geocodedCoords.current.keys()),
-          falhados: geocodeFalhados.current,
-          marcados: selectedIdsRef.current,
-        });
-        setGeocodingPendentes(fila.length);
-        if (fila.length === 0) break;
-        const stop = fila[0];
-        try {
-          const query = stop.stopType === 'prospect_visit'
-            ? buildGeocodeQuery(stop.address)
-            : `${stop.address.street}, ${stop.address.number}, ${stop.address.city}, ${stop.address.state}, Brazil`;
-          const res = await fetch(
-            `https://nominatim.openstreetmap.org/search?format=json&q=${encodeURIComponent(query)}&limit=1`,
-            { signal: controller.signal }
-          );
-          const data = await res.json();
-          if (data?.[0]) {
-            const coords = { lat: parseFloat(data[0].lat), lng: parseFloat(data[0].lon) };
-            geocodedCoords.current.set(stop.id, coords);
-            setGeocodedAllStops(prev => prev.map(s =>
-              s.id === stop.id ? { ...s, lat: coords.lat, lng: coords.lng } : s
-            ));
-            if (stop.stopType === 'prospect_visit' && stop.radarCnpj) {
-              void supabase.rpc('radar_salvar_geocode' as never, {
-                p_cnpj: stop.radarCnpj, p_lat: coords.lat, p_lng: coords.lng, p_status: 'ok',
+        if (planningModeRef.current === 'prospeccao') {
+          // ---- Campo: por CEP distinto, persiste no cep_geo (SoT) ----
+          const fila = ordenarFilaGeocodeCep(allStops, {
+            resolvidos: new Set(geocodedCepCoords.current.keys()),
+            falhados: cepFalhados.current,
+            marcados: selectedIdsRef.current,
+          });
+          setGeocodingPendentes(fila.length);
+          if (fila.length === 0) break;
+          const { cep, cidade, uf } = fila[0];
+          try {
+            const coords = await nominatim(`${cep}, ${cidade}, ${uf}, Brazil`);
+            if (coords) {
+              geocodedCepCoords.current.set(cep, coords);
+              setGeocodedAllStops(prev => prev.map(s =>
+                normalizarCep(s.address.zip_code) === cep
+                  ? { ...s, lat: coords.lat, lng: coords.lng, precisao: 'postcode_centroid' }
+                  : s,
+              ));
+              // Persiste: postcode_centroid; anti-downgrade no SQL. Gate = gestor/master
+              // (o contexto campo já exige). Compartilhado por todos os alvos do CEP.
+              void supabase.rpc('cep_geo_upsert' as never, {
+                p_cep: cep, p_lat: coords.lat, p_lng: coords.lng,
+                p_source: 'nominatim', p_precision: 'postcode_centroid',
               } as never);
+            } else {
+              cepFalhados.current.add(cep); // sem resultado → não recicla o mesmo CEP
             }
-          } else {
-            // sem resultado = falha; senão a fila reciclaria o mesmo stop pra sempre
-            geocodeFalhados.current.add(stop.id);
-            if (stop.stopType === 'prospect_visit' && stop.radarCnpj) {
-              void supabase.rpc('radar_salvar_geocode' as never, {
-                p_cnpj: stop.radarCnpj, p_lat: 0, p_lng: 0, p_status: 'falhou',
-              } as never);
-            }
+          } catch (e) {
+            if ((e as { name?: string })?.name === 'AbortError') break;
+            cepFalhados.current.add(cep);
           }
-        } catch (e) {
-          if ((e as { name?: string })?.name === 'AbortError') break;
-          console.warn('Geocode failed for', stop.address.street);
-          geocodeFalhados.current.add(stop.id);
-          if (stop.stopType === 'prospect_visit' && stop.radarCnpj) {
-            void supabase.rpc('radar_salvar_geocode' as never, {
-              p_cnpj: stop.radarCnpj, p_lat: 0, p_lng: 0, p_status: 'falhou',
-            } as never);
+        } else {
+          // ---- Equipe: legado por endereço, por stop (inalterado) ----
+          const fila = ordenarFilaGeocode(allStops, {
+            resolvidos: new Set(geocodedCoords.current.keys()),
+            falhados: geocodeFalhados.current,
+            marcados: selectedIdsRef.current,
+          });
+          setGeocodingPendentes(fila.length);
+          if (fila.length === 0) break;
+          const stop = fila[0];
+          try {
+            const coords = await nominatim(
+              `${stop.address.street}, ${stop.address.number}, ${stop.address.city}, ${stop.address.state}, Brazil`,
+            );
+            if (coords) {
+              geocodedCoords.current.set(stop.id, coords);
+              setGeocodedAllStops(prev => prev.map(s =>
+                s.id === stop.id ? { ...s, lat: coords.lat, lng: coords.lng } : s,
+              ));
+            } else {
+              geocodeFalhados.current.add(stop.id);
+            }
+          } catch (e) {
+            if ((e as { name?: string })?.name === 'AbortError') break;
+            geocodeFalhados.current.add(stop.id);
           }
         }
         // Nominatim rate limit: máx 1 req/s

--- a/src/lib/route/alvo-detalhe.test.ts
+++ b/src/lib/route/alvo-detalhe.test.ts
@@ -43,7 +43,7 @@ const prospectRow = (over: Partial<ProspectRow> = {}): ProspectRow => ({
   logradouro: 'Rua A', numero: '10', complemento: 'Sala 2', bairro: 'Centro',
   municipio_nome: 'DIVINOPOLIS', uf: 'MG', cep: '35500-000',
   telefone1: '37999990000', telefone2: '3733331111',
-  prospeccao_status: 'a_contatar', lat: null, lng: null, geocode_status: null,
+  prospeccao_status: 'a_contatar', lat: null, lng: null, geocode_status: null, precision: null,
   ...over,
 });
 

--- a/src/lib/route/carteira-stop.test.ts
+++ b/src/lib/route/carteira-stop.test.ts
@@ -9,6 +9,7 @@ const row = (over: Partial<CarteiraRow> = {}): CarteiraRow => ({
   city: 'DIVINOPOLIS (MG)', state: 'MG', zip_code: '35500-000', complement: 'Sala 2',
   business_hours_open: '08:00', business_hours_close: '18:00',
   ultima_visita: '2026-06-01T12:00:00Z', dias_desde_visita: 14,
+  lat: -20.1389, lng: -44.8839, precision: 'postcode_centroid',
   ...over,
 });
 
@@ -32,5 +33,20 @@ describe('carteiraRowToStop', () => {
     expect(d.customerName).toBe('Cliente');
     expect(d.phone).toBeNull();
     expect(d.address.complement).toBeUndefined();
+  });
+  it('adota lat/lng/precisao resolvidos pela RPC (não geocodifica em memória)', () => {
+    const d = carteiraRowToStop(row({ lat: -20.13, lng: -44.88, precision: 'postcode_centroid' }), 'X');
+    expect(d.lat).toBe(-20.13);
+    expect(d.lng).toBe(-44.88);
+    expect(d.precisao).toBe('postcode_centroid');
+  });
+  it('fallback município → precisao city_centroid (pino aproximado)', () => {
+    expect(carteiraRowToStop(row({ lat: -20, lng: -44.5, precision: 'city_centroid' }), 'X').precisao).toBe('city_centroid');
+  });
+  it('sem coord (lat/lng null) → lat/lng/precisao undefined (defensivo)', () => {
+    const d = carteiraRowToStop(row({ lat: null, lng: null, precision: null }), 'X');
+    expect(d.lat).toBeUndefined();
+    expect(d.lng).toBeUndefined();
+    expect(d.precisao).toBeUndefined();
   });
 });

--- a/src/lib/route/carteira-stop.ts
+++ b/src/lib/route/carteira-stop.ts
@@ -20,6 +20,10 @@ export interface CarteiraRow {
   business_hours_close: string | null;
   ultima_visita: string | null;
   dias_desde_visita: number | null;
+  // Geo resolvido pela RPC (Sub-PR 1): cep_geo por zip_code → centróide município.
+  lat: number | null;
+  lng: number | null;
+  precision: string | null;
 }
 
 export interface CarteiraStopDraft {
@@ -40,11 +44,17 @@ export interface CarteiraStopDraft {
   businessHoursOpen: string | null;
   businessHoursClose: string | null;
   diasDesdeVisita: number | null;
+  lat?: number;
+  lng?: number;
+  precisao?: string;
 }
 
 const s = (v: string | null | undefined): string => (v ?? '').trim();
 
 export function carteiraRowToStop(row: CarteiraRow, cityNome: string): CarteiraStopDraft {
+  // Coord já vem resolvida da RPC — a carteira NÃO geocodifica mais em memória.
+  // Adota só com ambos não-null (defensivo; a RPC COALESCE os dois da mesma fonte).
+  const temGeo = row.lat != null && row.lng != null;
   return {
     id: `carteira-cidade-${row.user_id}`,
     customerUserId: row.user_id,
@@ -63,5 +73,7 @@ export function carteiraRowToStop(row: CarteiraRow, cityNome: string): CarteiraS
     businessHoursOpen: s(row.business_hours_open) || null,
     businessHoursClose: s(row.business_hours_close) || null,
     diasDesdeVisita: row.dias_desde_visita,
+    ...(temGeo ? { lat: row.lat as number, lng: row.lng as number } : {}),
+    ...(row.precision ? { precisao: row.precision } : {}),
   };
 }

--- a/src/lib/route/cep.test.ts
+++ b/src/lib/route/cep.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { normalizarCep } from './cep';
+
+describe('normalizarCep', () => {
+  it('tira máscara (ponto/hífen/espaço) → 8 dígitos', () => {
+    expect(normalizarCep('35.500-001')).toBe('35500001');
+    expect(normalizarCep(' 35500001 ')).toBe('35500001');
+    expect(normalizarCep('35500001')).toBe('35500001');
+  });
+
+  it('não-8-dígitos → null (PK cep_geo exige exatamente 8)', () => {
+    expect(normalizarCep('123')).toBeNull(); // curto
+    expect(normalizarCep('355000012')).toBeNull(); // 9 dígitos
+    expect(normalizarCep('0000000a')).toBeNull(); // 7 dígitos após strip
+  });
+
+  it('vazio/sem-dígito/null/undefined → null (ausente ≠ fabricar)', () => {
+    expect(normalizarCep('')).toBeNull();
+    expect(normalizarCep('abcdefgh')).toBeNull();
+    expect(normalizarCep(null)).toBeNull();
+    expect(normalizarCep(undefined)).toBeNull();
+  });
+});

--- a/src/lib/route/cep.ts
+++ b/src/lib/route/cep.ts
@@ -1,0 +1,8 @@
+// Normalização canônica de CEP no front — espelha o SQL public.normalizar_cep
+// (tira tudo que não é dígito) E acrescenta a validade de 8 dígitos da PK cep_geo:
+// um CEP não-8 não é geocodificável (o upsert no banco faria no-op), então aqui já
+// vira null pra ficar fora da fila/dedup. Chave estável p/ agrupar empresas do CEP.
+export function normalizarCep(raw: string | null | undefined): string | null {
+  const digitos = (raw ?? '').replace(/\D/g, '');
+  return /^[0-9]{8}$/.test(digitos) ? digitos : null;
+}

--- a/src/lib/route/geocode-fila.cep.test.ts
+++ b/src/lib/route/geocode-fila.cep.test.ts
@@ -21,7 +21,7 @@ describe('ordenarFilaGeocodeCep', () => {
     const stops = [
       mk('a', '35500-001', 'city_centroid'),
       mk('b', '35500001', 'city_centroid'), // mesmo CEP normalizado que 'a'
-      mk('c', '35501-000', null),
+      mk('c', '35501-000', undefined), // precisão ausente (stop.precisao é string?, nunca null)
     ];
     const fila = ordenarFilaGeocodeCep(stops, vazio());
     expect(fila.map((f) => f.cep)).toEqual(['35500001', '35501000']);

--- a/src/lib/route/geocode-fila.cep.test.ts
+++ b/src/lib/route/geocode-fila.cep.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { ordenarFilaGeocodeCep, type EstadoFilaCep } from './geocode-fila';
+import type { RouteStop } from '@/components/reposicao/routePlanner/types';
+
+// Stop com CEP + precisão controlados (o que a fila por CEP olha).
+const mk = (
+  id: string,
+  zip: string,
+  precisao: string | undefined,
+  over: Partial<RouteStop> = {},
+): RouteStop => ({
+  id, stopType: 'prospect_visit', customerUserId: '', customerName: id, phone: null,
+  address: { street: 'Rua', number: '1', neighborhood: 'B', city: 'Divinópolis', state: 'MG', zip_code: zip },
+  timeSlot: null, businessHoursOpen: null, businessHoursClose: null, status: 'prospect',
+  visitReason: '', priorityScore: 0, priorityLabel: 'baixa', priorityFactors: [], precisao, ...over,
+});
+const vazio = (): EstadoFilaCep => ({ resolvidos: new Set(), falhados: new Set(), marcados: new Set() });
+
+describe('ordenarFilaGeocodeCep', () => {
+  it('deduplica por CEP distinto (3 stops, 2 CEPs → 2 entradas)', () => {
+    const stops = [
+      mk('a', '35500-001', 'city_centroid'),
+      mk('b', '35500001', 'city_centroid'), // mesmo CEP normalizado que 'a'
+      mk('c', '35501-000', null),
+    ];
+    const fila = ordenarFilaGeocodeCep(stops, vazio());
+    expect(fila.map((f) => f.cep)).toEqual(['35500001', '35501000']);
+  });
+
+  it('só inclui precisão aproximada (city_centroid/null) — pula street/postcode/rooftop', () => {
+    const stops = [
+      mk('bom1', '35500-001', 'street'),
+      mk('bom2', '35501-000', 'postcode_centroid'),
+      mk('bom3', '35502-000', 'rooftop'),
+      mk('aprox', '35503-000', 'city_centroid'),
+    ];
+    const fila = ordenarFilaGeocodeCep(stops, vazio());
+    expect(fila.map((f) => f.cep)).toEqual(['35503000']);
+  });
+
+  it('exclui CEP já resolvido ou já falhado nesta sessão', () => {
+    const stops = [
+      mk('a', '35500-001', 'city_centroid'),
+      mk('b', '35501-000', 'city_centroid'),
+      mk('c', '35502-000', 'city_centroid'),
+    ];
+    const estado: EstadoFilaCep = {
+      resolvidos: new Set(['35500001']),
+      falhados: new Set(['35501000']),
+      marcados: new Set(),
+    };
+    expect(ordenarFilaGeocodeCep(stops, estado).map((f) => f.cep)).toEqual(['35502000']);
+  });
+
+  it('exclui CEP inválido (não-8-dígitos) — fora da fila', () => {
+    const stops = [
+      mk('curto', '123', 'city_centroid'),
+      mk('vazio', '', 'city_centroid'),
+      mk('ok', '35500-001', 'city_centroid'),
+    ];
+    expect(ordenarFilaGeocodeCep(stops, vazio()).map((f) => f.cep)).toEqual(['35500001']);
+  });
+
+  it('CEPs com algum stop marcado vêm primeiro (CEP herda prioridade)', () => {
+    const stops = [
+      mk('a', '35500-001', 'city_centroid'),
+      mk('b', '35501-000', 'city_centroid'),
+      mk('c', '35502-000', 'city_centroid'),
+    ];
+    const estado: EstadoFilaCep = { ...vazio(), marcados: new Set(['c']) };
+    expect(ordenarFilaGeocodeCep(stops, estado).map((f) => f.cep)).toEqual(['35502000', '35500001', '35501000']);
+  });
+
+  it('leva cidade/uf do 1º stop do CEP p/ a query do Nominatim', () => {
+    const fila = ordenarFilaGeocodeCep([mk('a', '35500-001', 'city_centroid')], vazio());
+    expect(fila[0]).toEqual({ cep: '35500001', cidade: 'Divinópolis', uf: 'MG' });
+  });
+
+  it('estável: dentro de cada grupo preserva a ordem de 1ª aparição (prioridade da RPC)', () => {
+    const stops = [
+      mk('a', '35503-000', 'city_centroid'),
+      mk('b', '35501-000', 'city_centroid'),
+      mk('c', '35502-000', 'city_centroid'),
+    ];
+    expect(ordenarFilaGeocodeCep(stops, vazio()).map((f) => f.cep)).toEqual(['35503000', '35501000', '35502000']);
+  });
+});

--- a/src/lib/route/geocode-fila.ts
+++ b/src/lib/route/geocode-fila.ts
@@ -2,6 +2,8 @@
 // O worker no useRoutePlanner consome o head a cada ciclo (~1/s) e re-deriva a fila,
 // então marcar um alvo no meio do caminho re-prioriza o PRÓXIMO pick (fila contínua).
 import type { RouteStop } from '@/components/reposicao/routePlanner/types';
+import { normalizarCep } from './cep';
+import { precisaoVisual } from './marker-visual';
 
 export interface EstadoFila {
   resolvidos: Set<string>; // ids já com coord (cache em memória)
@@ -24,4 +26,46 @@ export function ordenarFilaGeocode(stops: RouteStop[], estado: EstadoFila): Rout
     .map((s, i) => ({ s, i, prio: estado.marcados.has(s.id) ? 0 : 1 }))
     .sort((a, b) => a.prio - b.prio || a.i - b.i)
     .map((x) => x.s);
+}
+
+// --- Fila por CEP DISTINTO (Sub-PR 2 geocoding por CEP) ---------------------
+// O contexto campo geocodifica o CEP, não a empresa: 1234 alvos da cidade viram
+// ~574 CEPs. O worker consome o head (~1/s), faz cep_geo_upsert e pinta TODOS os
+// alvos daquele CEP de uma vez. `marcados` é por stop id; o CEP herda a prioridade
+// se QUALQUER alvo dele está marcado pra rota.
+export interface EstadoFilaCep {
+  resolvidos: Set<string>; // CEPs (8 díg) já geocodificados nesta sessão
+  falhados: Set<string>; // CEPs que falharam nesta sessão (não re-tentar → loop termina)
+  marcados: Set<string>; // stop ids selecionados pra rota (prioridade 1)
+}
+
+export interface CepPendente {
+  cep: string; // 8 dígitos normalizado (chave do cep_geo)
+  cidade: string; // do 1º alvo do CEP — alimenta a query do Nominatim
+  uf: string;
+}
+
+/** CEPs DISTINTOS ainda aproximados (city_centroid/null), na ordem de processamento:
+ *  CEPs com algum alvo marcado primeiro, depois 1ª aparição (a lista já vem por
+ *  prioridade da RPC). Pula precisão boa (street/postcode/rooftop) e CEP já
+ *  resolvido/falhado nesta sessão. precisaoVisual é o único juiz de "aproximado". */
+export function ordenarFilaGeocodeCep(stops: RouteStop[], estado: EstadoFilaCep): CepPendente[] {
+  const porCep = new Map<string, { pend: CepPendente; ordem: number; marcado: boolean }>();
+  let ordem = 0;
+  for (const s of stops) {
+    const cep = normalizarCep(s.address.zip_code);
+    if (!cep) continue; // CEP inválido → não geocodificável
+    if (!precisaoVisual(s.precisao).aproximado) continue; // já bom o bastante
+    if (estado.resolvidos.has(cep) || estado.falhados.has(cep)) continue;
+    const marcado = estado.marcados.has(s.id);
+    const existente = porCep.get(cep);
+    if (!existente) {
+      porCep.set(cep, { pend: { cep, cidade: s.address.city, uf: s.address.state }, ordem: ordem++, marcado });
+    } else if (marcado && !existente.marcado) {
+      existente.marcado = true; // qualquer alvo marcado promove o CEP inteiro
+    }
+  }
+  return [...porCep.values()]
+    .sort((a, b) => Number(b.marcado) - Number(a.marcado) || a.ordem - b.ordem)
+    .map((x) => x.pend);
 }

--- a/src/lib/route/marker-visual.test.ts
+++ b/src/lib/route/marker-visual.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { markerVisual, recenciaFaixa, clusterStats } from './marker-visual';
+import { markerVisual, recenciaFaixa, clusterStats, precisaoVisual } from './marker-visual';
 import type { RouteStop } from '@/components/reposicao/routePlanner/types';
 
 const carteira = (over: Partial<RouteStop> = {}): RouteStop => ({
@@ -69,5 +69,24 @@ describe('clusterStats', () => {
     expect(st.total).toBe(0);
     expect(st.maiorUrgencia).toBe('neutral');
     expect(st.vermelhos).toBe(0);
+  });
+});
+
+describe('precisaoVisual', () => {
+  it('rooftop/street/postcode_centroid = bom → não aproximado, sem rótulo', () => {
+    expect(precisaoVisual('rooftop')).toEqual({ aproximado: false, rotulo: '' });
+    expect(precisaoVisual('street')).toEqual({ aproximado: false, rotulo: '' });
+    expect(precisaoVisual('postcode_centroid')).toEqual({ aproximado: false, rotulo: '' });
+  });
+
+  it('city_centroid/unknown/null/undefined → aproximado + "aprox."', () => {
+    expect(precisaoVisual('city_centroid')).toEqual({ aproximado: true, rotulo: 'aprox.' });
+    expect(precisaoVisual('unknown')).toEqual({ aproximado: true, rotulo: 'aprox.' });
+    expect(precisaoVisual(null)).toEqual({ aproximado: true, rotulo: 'aprox.' });
+    expect(precisaoVisual(undefined)).toEqual({ aproximado: true, rotulo: 'aprox.' });
+  });
+
+  it('valor inesperado da RPC → degrada honesto p/ aproximado', () => {
+    expect(precisaoVisual('xpto')).toEqual({ aproximado: true, rotulo: 'aprox.' });
   });
 });

--- a/src/lib/route/marker-visual.ts
+++ b/src/lib/route/marker-visual.ts
@@ -86,3 +86,24 @@ export function clusterStats(
   const maiorUrgencia = URGENCIA_ORDEM.find((t) => porTone[t] > 0) ?? 'neutral';
   return { total: stops.length, porTone, maiorUrgencia, vermelhos: porTone.error };
 }
+
+// --- Precisão honesta da coordenada (Sub-PR 2 geocoding por CEP) ------------
+// Espelha o CHECK de cep_geo.precision. Aceito `string` (a RPC devolve text) p/
+// degradar valor inesperado sem quebrar — ausente ≠ fabricar precisão.
+export type Precisao = 'rooftop' | 'street' | 'postcode_centroid' | 'city_centroid' | 'unknown';
+
+// "Boa o bastante" pra rota de visita = nível-CEP ou melhor. city_centroid
+// (centróide de município) / desconhecido / null são APROXIMADOS: pino oco +
+// "aprox." E entram na fila de geocode por CEP (tenta upgrade). Único ponto de
+// verdade do que é "aproximado" — pino e fila leem daqui.
+const PRECISAO_BOA = new Set<string>(['rooftop', 'street', 'postcode_centroid']);
+
+export interface PrecisaoVisual {
+  aproximado: boolean;
+  rotulo: string;
+}
+
+export function precisaoVisual(precisao: string | null | undefined): PrecisaoVisual {
+  const aproximado = !PRECISAO_BOA.has(precisao ?? '');
+  return { aproximado, rotulo: aproximado ? 'aprox.' : '' };
+}

--- a/src/lib/route/prospect-stop.test.ts
+++ b/src/lib/route/prospect-stop.test.ts
@@ -23,6 +23,7 @@ const base: ProspectRow = {
   lat: null,
   lng: null,
   geocode_status: null,
+  precision: null,
 };
 
 describe('prospectRowToStopDraft', () => {
@@ -59,29 +60,28 @@ describe('prospectRowToStopDraft', () => {
     expect(prospectRowToStopDraft({ ...base, telefone1: null, telefone2: null }).phone).toBeNull();
   });
 
-  it('adota lat/lng só quando geocode_status=ok com ambos não-null', () => {
-    const ok = prospectRowToStopDraft({ ...base, geocode_status: 'ok', lat: -19.97, lng: -44.2 });
-    expect(ok.lat).toBe(-19.97);
-    expect(ok.lng).toBe(-44.2);
-    expect(ok.geocodeFailed).toBeUndefined();
+  it('adota lat/lng resolvidos pela RPC independente de geocode_status', () => {
+    const r = prospectRowToStopDraft({ ...base, geocode_status: null, lat: -19.97, lng: -44.2, precision: 'city_centroid' });
+    expect(r.lat).toBe(-19.97);
+    expect(r.lng).toBe(-44.2);
+    expect(r.precisao).toBe('city_centroid');
   });
 
-  it('marca geocodeFailed quando status=falhou (sem lat/lng)', () => {
-    const f = prospectRowToStopDraft({ ...base, geocode_status: 'falhou' });
-    expect(f.geocodeFailed).toBe(true);
-    expect(f.lat).toBeUndefined();
-    expect(f.lng).toBeUndefined();
+  it('precisão street (re.lat legado) é adotada — não regride pra postcode', () => {
+    const r = prospectRowToStopDraft({ ...base, geocode_status: 'ok', lat: -19.9, lng: -44.1, precision: 'street' });
+    expect(r.precisao).toBe('street');
+    expect(r.lat).toBe(-19.9);
   });
 
-  it('status NULL = nunca tentado: sem lat/lng e sem geocodeFailed (geocodifica depois)', () => {
-    const d = prospectRowToStopDraft(base);
+  it('sem coord da RPC (lat/lng null) → sem lat/lng/precisao no draft', () => {
+    const d = prospectRowToStopDraft({ ...base, lat: null, lng: null, precision: null });
     expect(d.lat).toBeUndefined();
     expect(d.lng).toBeUndefined();
-    expect(d.geocodeFailed).toBeUndefined();
+    expect(d.precisao).toBeUndefined();
   });
 
-  it('não adota lat/lng se status=ok mas algum coord é null (defensivo)', () => {
-    const d = prospectRowToStopDraft({ ...base, geocode_status: 'ok', lat: -19.9, lng: null });
+  it('defensivo: lat presente mas lng null → não adota coord', () => {
+    const d = prospectRowToStopDraft({ ...base, lat: -19.9, lng: null, precision: 'city_centroid' });
     expect(d.lat).toBeUndefined();
     expect(d.lng).toBeUndefined();
   });

--- a/src/lib/route/prospect-stop.test.ts
+++ b/src/lib/route/prospect-stop.test.ts
@@ -1,10 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import {
-  prospectRowToStopDraft,
-  buildGeocodeQuery,
-  labelProspeccaoStatus,
-  type ProspectRow,
-} from './prospect-stop';
+import { prospectRowToStopDraft, labelProspeccaoStatus, type ProspectRow } from './prospect-stop';
 
 const base: ProspectRow = {
   cnpj: '00000000000001',
@@ -107,29 +102,6 @@ describe('prospectRowToStopDraft', () => {
     expect(d.address.street).toBe('');
     expect(d.address.number).toBe('');
     expect(d.address.complement).toBeUndefined();
-  });
-});
-
-describe('buildGeocodeQuery', () => {
-  it('monta rua, número, cidade, uf, Brazil', () => {
-    expect(buildGeocodeQuery({ street: 'Rua A', number: '10', city: 'Betim', state: 'MG' })).toBe(
-      'Rua A, 10, Betim, MG, Brazil',
-    );
-  });
-
-  it('pula partes vazias', () => {
-    expect(buildGeocodeQuery({ street: 'Rua A', number: '', city: 'Betim', state: 'MG' })).toBe(
-      'Rua A, Betim, MG, Brazil',
-    );
-    expect(buildGeocodeQuery({ street: '', number: '', city: 'Betim', state: 'MG' })).toBe(
-      'Betim, MG, Brazil',
-    );
-  });
-
-  it('trim nas partes', () => {
-    expect(buildGeocodeQuery({ street: '  Rua A  ', city: ' Betim ', state: 'MG' })).toBe(
-      'Rua A, Betim, MG, Brazil',
-    );
   });
 });
 

--- a/src/lib/route/prospect-stop.ts
+++ b/src/lib/route/prospect-stop.ts
@@ -3,9 +3,10 @@
 // os campos de priority (o client aplica enrichWithPriority) e sem acoplar ao tipo
 // RouteStop estendido (que muda no sub-PR B). Também monta a query do Nominatim.
 //
-// Regra de geo: a RPC só devolve lat/lng quando geocode_status='ok'. O draft só
-// adota lat/lng se status='ok' E ambos não-null (defensivo); 'falhou' vira a flag
-// geocodeFailed (o client pula o re-geocode); status NULL = nunca tentado (geocodifica).
+// Regra de geo (Sub-PR 2): a RPC já resolve lat/lng (cep_geo → re.lat legado →
+// centróide do município) + precision. O draft adota lat/lng sempre que ambos
+// não-null (defensivo) e a precision. O geocodeFailed legado não é mais setado —
+// a fila por CEP usa a precision (city_centroid/null = aproximado → tenta upgrade).
 
 export interface ProspectRow {
   cnpj: string;
@@ -24,6 +25,7 @@ export interface ProspectRow {
   lat: number | null;
   lng: number | null;
   geocode_status: string | null;
+  precision: string | null;
 }
 
 export interface ProspectAddress {
@@ -47,6 +49,7 @@ export interface ProspectStopDraft {
   lat?: number;
   lng?: number;
   geocodeFailed?: boolean;
+  precisao?: string;
 }
 
 const STATUS_LABEL: Record<string, string> = {
@@ -64,8 +67,8 @@ const s = (v: string | null | undefined): string => (v ?? '').trim();
 export function prospectRowToStopDraft(row: ProspectRow): ProspectStopDraft {
   const nome = s(row.nome_fantasia) || s(row.razao_social) || row.cnpj;
   const phone = s(row.telefone1) || s(row.telefone2) || null;
-  const temGeo = row.geocode_status === 'ok' && row.lat != null && row.lng != null;
-  const falhou = row.geocode_status === 'falhou';
+  // RPC já resolveu (cep_geo → re.lat → centróide município) — adota ambos não-null.
+  const temGeo = row.lat != null && row.lng != null;
   const reasonSuffix =
     row.prospeccao_status === 'a_contatar' ? '' : ` · ${labelProspeccaoStatus(row.prospeccao_status)}`;
   return {
@@ -85,7 +88,7 @@ export function prospectRowToStopDraft(row: ProspectRow): ProspectStopDraft {
     visitReason: `Prospecção${reasonSuffix}`,
     prospeccaoStatus: row.prospeccao_status,
     ...(temGeo ? { lat: row.lat as number, lng: row.lng as number } : {}),
-    ...(falhou ? { geocodeFailed: true } : {}),
+    ...(row.precision ? { precisao: row.precision } : {}),
   };
 }
 

--- a/src/lib/route/prospect-stop.ts
+++ b/src/lib/route/prospect-stop.ts
@@ -91,15 +91,3 @@ export function prospectRowToStopDraft(row: ProspectRow): ProspectStopDraft {
     ...(row.precision ? { precisao: row.precision } : {}),
   };
 }
-
-// Query do Nominatim a partir do endereço (filtra partes vazias; sempre termina em
-// "Brazil"). Extraída do inline do useRoutePlanner para o sub-PR B reusar e testar.
-export function buildGeocodeQuery(a: {
-  street?: string;
-  number?: string;
-  city?: string;
-  state?: string;
-}): string {
-  const parts = [s(a.street), s(a.number), s(a.city), s(a.state)].filter(Boolean);
-  return [...parts, 'Brazil'].join(', ');
-}

--- a/src/pages/AdminRoutePlanner.tsx
+++ b/src/pages/AdminRoutePlanner.tsx
@@ -27,7 +27,7 @@ import { escapeHtml } from '@/lib/escape-html';
 import 'leaflet.markercluster';
 import 'leaflet.markercluster/dist/MarkerCluster.css';
 import 'leaflet.markercluster/dist/MarkerCluster.Default.css';
-import { markerVisual, clusterStats, TONE_CSS, type MarkerTone, type MarkerShape } from '@/lib/route/marker-visual';
+import { markerVisual, clusterStats, precisaoVisual, TONE_CSS, type MarkerTone, type MarkerShape } from '@/lib/route/marker-visual';
 import { MapLegend } from '@/components/reposicao/routePlanner/MapLegend';
 
 // Fix default marker icons for Leaflet + bundlers
@@ -42,18 +42,22 @@ L.Icon.Default.mergeOptions({
 // error ganha borda dupla (reforço p/ daltonismo — não depender só da matiz).
 type StopMarker = L.Marker & { __stop?: RouteStop };
 
-function divIconAlvo(tone: MarkerTone, shape: MarkerShape, numero?: number): L.DivIcon {
+function divIconAlvo(tone: MarkerTone, shape: MarkerShape, numero?: number, aproximado = false): L.DivIcon {
   const cor = TONE_CSS[tone];
-  const borda = tone === 'error' ? '3px double #fff' : '2px solid #fff';
   const raio = shape === 'circle' ? '50%' : '3px';
   const rot = shape === 'diamond' ? 'rotate(45deg)' : 'none';
+  // Aproximado (centróide de município): pino OCO + borda tracejada na cor da
+  // urgência — precisão honesta, não finge rooftop. Preciso: preenchido, borda branca.
+  const fundo = aproximado ? 'hsl(var(--background))' : cor;
+  const borda = aproximado ? `2px dashed ${cor}` : tone === 'error' ? '3px double #fff' : '2px solid #fff';
+  const corConteudo = aproximado ? cor : '#fff';
   // número (posição na rota) num filho contra-rotacionado p/ não deitar no losango
   const conteudo = numero != null
-    ? `<span style="transform:${shape === 'diamond' ? 'rotate(-45deg)' : 'none'};color:#fff;font-weight:700;font-size:12px">${numero}</span>`
+    ? `<span style="transform:${shape === 'diamond' ? 'rotate(-45deg)' : 'none'};color:${corConteudo};font-weight:700;font-size:12px">${numero}</span>`
     : '';
   return L.divIcon({
     className: 'custom-marker',
-    html: `<div style="background:${cor};width:26px;height:26px;border-radius:${raio};transform:${rot};border:${borda};box-shadow:0 2px 6px rgba(0,0,0,.3);display:flex;align-items:center;justify-content:center">${conteudo}</div>`,
+    html: `<div style="background:${fundo};width:26px;height:26px;border-radius:${raio};transform:${rot};border:${borda};box-shadow:0 2px 6px rgba(0,0,0,.3);display:flex;align-items:center;justify-content:center">${conteudo}</div>`,
     iconSize: [26, 26], iconAnchor: [13, 13],
   });
 }
@@ -195,11 +199,13 @@ const AdminRoutePlanner = () => {
 
     fonteComCoords.forEach((stop) => {
       const numero = ordemRota.get(stop.id);
+      // Precisão honesta (campo): pino oco/tracejado + nota no popup p/ aproximado.
+      const aproximado = noModoCampo && precisaoVisual(stop.precisao).aproximado;
       let icon: L.DivIcon;
       if (noModoCampo) {
         // Campo: cor = urgência (mesmo marcado), forma = tipo; número se está na rota.
         const { tone, shape } = markerVisual(stop);
-        icon = divIconAlvo(tone, shape, numero);
+        icon = divIconAlvo(tone, shape, numero, aproximado);
       } else {
         // Equipe: comportamento antigo (cor do tipo, círculo numerado).
         const cor = STOP_CONFIG[stop.stopType].markerColor;
@@ -226,7 +232,7 @@ const AdminRoutePlanner = () => {
           ${escapeHtml(stop.address.street)}, ${escapeHtml(stop.address.number)}<br/>
           ${escapeHtml(stop.address.neighborhood)} - ${escapeHtml(stop.address.city)}<br/>
           <em>${escapeHtml(stop.visitReason)}</em><br/>
-          <em>Horário: ${hoursLabel}</em>
+          <em>Horário: ${hoursLabel}</em>${aproximado ? '<br/><em>📍 local aproximado (CEP)</em>' : ''}
         `);
       grupo.addLayer(m);
     });
@@ -344,7 +350,7 @@ const AdminRoutePlanner = () => {
           {geocodingPendentes > 0 && (
             <div className="pointer-events-none absolute right-3 top-3 z-[400] flex items-center gap-1.5 rounded-full bg-background/90 px-2.5 py-1 text-xs text-muted-foreground shadow-sm backdrop-blur">
               <Loader2 className="h-3 w-3 animate-spin" />
-              localizando {geocodingPendentes}…
+              localizando {geocodingPendentes}{planningContext === 'campo' ? ` CEP${geocodingPendentes > 1 ? 's' : ''}` : ''}…
             </div>
           )}
           <MapLegend />


### PR DESCRIPTION
## Sub-PR 2 (front) do geocoding por CEP em escala

Continuação do **Sub-PR 1 (banco)** ([#876](https://github.com/LucasSardenbergL/afiacao/pull/876), já LIVE). O roteirizador-campo (`/admin/route-planner`) passa a **consumir** o `lat/lng/precision` já resolvidos pelas RPCs e a geocodificar por **CEP distinto** em vez de por empresa.

### O que muda
- **Carteira e prospects entram no mapa já com coordenada** (RPC resolve `cep_geo` → centróide do município). A carteira **para de geocodificar em memória** a cada abertura.
- **Worker geocodifica CEP DISTINTO** (≈574 em vez de 1.234 empresas da cidade) a 1/s → persiste no `cep_geo` (SoT) via `cep_geo_upsert` (`postcode_centroid`, anti-downgrade no SQL) → pinta **todos os alvos do CEP** de uma vez. **2ª visita à praça fica instantânea.**
- **Precisão honesta:** `city_centroid` (centróide de município) aparece como pino **oco/tracejado + "📍 aprox."** — degrada, não fabrica.
- **Chip "localizando N CEPs…"** (evolução do chip do #871).
- **Contexto equipe intocado** (worker legado por endereço preservado; zero regressão).

### Módulos (helpers puros TDD)
- `normalizarCep` (espelha SQL + valida 8 díg) · `precisaoVisual` (juiz único de "aproximado": pino **e** fila) · `ordenarFilaGeocodeCep` (dedup por CEP distinto, marcados-primeiro).
- Mappers `carteiraRowToStop`/`prospectRowToStopDraft` adotam `lat/lng/precision`; `RouteStop.precisao`.
- Hook `useRoutePlanner`: worker branch CEP (campo) vs endereço (equipe).
- Render `AdminRoutePlanner`: `divIconAlvo(aproximado)` + popup + chip.

### Invariantes respeitadas
`useFarmerScoring` intocado · OSM/grátis (Google pago FORA) · Nominatim CEP-distinto 1/s sempre persistido · não regride o `re.lat` legado (`street` fica fora da fila).

### Verificação
- **typecheck** (strict, todo src+testes) ✅ · **lint** (0 errors no código real) ✅ · **test** (vitest — helpers novos: cep 3, precisaoVisual 9, fila-cep 7, mappers carteira 6/prospect 13) ✅ · **build** (vite + PWA) ✅
- Manual no device (founder, pós-deploy front): 2ª visita instantânea · chip N CEPs · pino aproximado visível · carteira não re-geocodifica.

Plano: `docs/superpowers/plans/2026-06-15-geocoding-subpr2-front.md` · Design: `docs/superpowers/specs/2026-06-15-geocoding-cep-escala-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)