### PR TITLE
fix(vendas): edição de pedido grava tint_formula_id no item de tinta

### DIFF
--- a/src/components/salesOrderEdit/__tests__/useSalesOrderEdit.tint.test.tsx
+++ b/src/components/salesOrderEdit/__tests__/useSalesOrderEdit.tint.test.tsx
@@ -1,0 +1,54 @@
+// Trava o contrato do item tintométrico na EDIÇÃO de pedido: o item gravado
+// precisa carregar `tint_formula_id` (a fórmula da cor), além de cor/nome — é o
+// que permite auditoria e re-precificação (flip do preço via get_tint_price).
+// Espelha o que o balcão já grava (src/services/orderSubmission/submitOrder.ts).
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+// Sem `id` na rota → loadOrder() não dispara: handleTintConfirm fica testável isolado.
+vi.mock('react-router-dom', () => ({
+  useParams: () => ({}),
+  useNavigate: () => vi.fn(),
+}));
+vi.mock('@/contexts/AuthContext', () => ({ useAuth: () => ({}) }));
+vi.mock('@/integrations/supabase/client', () => ({ supabase: {} }));
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() } }));
+
+import { useSalesOrderEdit } from '../useSalesOrderEdit';
+import type { OmieProduct } from '../types';
+
+const baseTint: OmieProduct = {
+  id: 'prod-base-1',
+  omie_codigo_produto: 9001,
+  codigo: 'BASE-INC',
+  descricao: 'Base Incolor Tintométrica',
+  unidade: 'GL',
+  valor_unitario: 80,
+  estoque: 10,
+  ativo: true,
+  is_tintometric: true,
+  tint_type: 'base',
+};
+
+describe('useSalesOrderEdit.handleTintConfirm', () => {
+  it('grava tint_formula_id (além de cor/nome) no item de tinta', () => {
+    const { result } = renderHook(() => useSalesOrderEdit());
+
+    // Selecionar a base tintométrica abre o diálogo de cor (seta tintPendingProduct).
+    act(() => {
+      result.current.addProduct(baseTint);
+    });
+
+    // onConfirm: (formulaId, corId, nomeCor, precoFinal, custoCorantes, alt?)
+    act(() => {
+      result.current.handleTintConfirm('formula-uuid-123', 'RAL5005', 'Azul Genciana', 120, 7);
+    });
+
+    expect(result.current.items).toHaveLength(1);
+    expect(result.current.items[0]).toMatchObject({
+      tint_cor_id: 'RAL5005',
+      tint_nome_cor: 'Azul Genciana',
+      tint_formula_id: 'formula-uuid-123',
+    });
+  });
+});

--- a/src/components/salesOrderEdit/types.ts
+++ b/src/components/salesOrderEdit/types.ts
@@ -12,6 +12,7 @@ export interface OrderItem {
   valor_total: number;
   tint_cor_id?: string;
   tint_nome_cor?: string;
+  tint_formula_id?: string;
 }
 
 export interface OmiePayload {

--- a/src/components/salesOrderEdit/useSalesOrderEdit.ts
+++ b/src/components/salesOrderEdit/useSalesOrderEdit.ts
@@ -152,7 +152,7 @@ export function useSalesOrderEdit() {
     toast.success(`"${product.descricao}" adicionado`);
   };
 
-  const handleTintConfirm = (_formulaId: string, corId: string, nomeCor: string, precoFinal: number, _custoCorantes: number, alternativeProduct?: Product) => {
+  const handleTintConfirm = (formulaId: string, corId: string, nomeCor: string, precoFinal: number, _custoCorantes: number, alternativeProduct?: Product) => {
     const product = alternativeProduct
       ? catalogProducts.find(p => p.id === alternativeProduct.id) || tintPendingProduct!
       : tintPendingProduct!;
@@ -167,6 +167,8 @@ export function useSalesOrderEdit() {
       valor_total: precoFinal,
       tint_cor_id: corId,
       tint_nome_cor: nomeCor,
+      // espelha o balcão (submitOrder.ts): grava a fórmula p/ auditoria e re-precificação.
+      tint_formula_id: formulaId,
     };
     setItems(prev => [...prev, newItem]);
     setTintPendingProduct(null);

--- a/src/hooks/unifiedOrder/__tests__/useCart.tint.test.ts
+++ b/src/hooks/unifiedOrder/__tests__/useCart.tint.test.ts
@@ -1,0 +1,53 @@
+// Trava o contrato do item tintométrico no BALCÃO: o item do carrinho carrega
+// `tint_formula_id` (a fórmula da cor) além de cor/nome/custo. Já era o
+// comportamento correto — este teste é a rede de regressão que mantém o balcão
+// em paridade com a edição (useSalesOrderEdit.handleTintConfirm).
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() } }));
+
+import { useCart } from '../useCart';
+import type { Product } from '@/hooks/useUnifiedOrder';
+
+const baseTint: Product = {
+  id: 'prod-base-1',
+  codigo: 'BASE-INC',
+  descricao: 'Base Incolor Tintométrica',
+  unidade: 'GL',
+  valor_unitario: 80,
+  estoque: 10,
+  ativo: true,
+  omie_codigo_produto: 9001,
+  account: 'oben',
+  is_tintometric: true,
+  tint_type: 'base',
+};
+
+function setup() {
+  return renderHook(() =>
+    useCart({
+      getProductPrice: (p) => p.valor_unitario ?? 0,
+      getServicePrice: () => null,
+      servicos: [],
+    }),
+  );
+}
+
+describe('useCart.addTintProductToCart', () => {
+  it('grava tint_formula_id (e cor/nome/custo) no item de tinta', () => {
+    const { result } = setup();
+
+    act(() => {
+      result.current.addTintProductToCart(baseTint, 'formula-uuid-123', 'RAL5005', 'Azul Genciana', 120, 7);
+    });
+
+    expect(result.current.productItems).toHaveLength(1);
+    expect(result.current.productItems[0]).toMatchObject({
+      tint_cor_id: 'RAL5005',
+      tint_nome_cor: 'Azul Genciana',
+      tint_custo_corantes: 7,
+      tint_formula_id: 'formula-uuid-123',
+    });
+  });
+});


### PR DESCRIPTION
## Problema

No fluxo de venda tintométrica, o item de pedido deveria gravar `tint_formula_id` (uuid da fórmula da cor) além de `tint_cor_id`/`tint_nome_cor` — é o que permite **auditoria** e **re-precificar/validar** o item depois (especialmente no flip do preço tintométrico: CSV `preco_final_sayersystem` → cálculo `get_tint_price`).

O Codex apontou que `handleTintConfirm` (`src/components/salesOrderEdit/useSalesOrderEdit.ts`) recebia `_formulaId` e o **descartava** ao montar o `OrderItem` — o item editado ficava sem a fórmula. Itens gravados pelo balcão já têm `tint_formula_id` no jsonb de `sales_orders.items` (confirmado em prod).

## Diagnóstico dos dois fluxos

| Fluxo | Caminho | Antes |
|---|---|---|
| Balcão | `useCart.addTintProductToCart` → `submitOrder` | ✅ já gravava `tint_formula_id` |
| Edição | `useSalesOrderEdit.handleTintConfirm` | ❌ descartava o `formulaId` |

## Correção (frontend, sem migration)

- `OrderItem` (`salesOrderEdit/types.ts`) ganha `tint_formula_id?: string`
- `handleTintConfirm`: `_formulaId` → `formulaId` e grava `tint_formula_id: formulaId` no item (no caso de embalagem alternativa, o `formulaId` já é o `alt.formulaId`)
- Como `handleSave` persiste `items` inteiro no jsonb, o campo passa a constar em `sales_orders.items` sem mexer no save

## Decisões de paridade (registro)

- **`tint_custo_corantes` ficou de fora de propósito.** O balcão **não** o persiste no jsonb (`submitOrder.ts` grava só `tint_cor_id`/`tint_nome_cor`/`tint_formula_id`); ele vive apenas no `ProductCartItem` em memória, para o cockpit de preço. Gravá-lo na edição criaria divergência de contrato. Se quisermos custo no snapshot de auditoria, mudar **os dois** fluxos juntos.
- **Payload de sync pro Omie** (`handleSave`) não foi alterado: é contrato com sistema externo (Omie não consome `formula_id`); a auditoria interna usa o jsonb, já resolvido.

## Testes

- `useSalesOrderEdit.tint.test.tsx` — **vermelho→verde**: provei a falha antes (item sem `tint_formula_id`, cor/nome casavam), depois a correção
- `useCart.tint.test.ts` — rede de regressão de paridade do balcão (já era verde)

## Verificação

- typecheck ✅
- suite completa — 486 arquivos / 3620 casos ✅
- eslint nos arquivos tocados — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
