### PR TITLE
chore(lint): ignora .claude/** e .claire/** no eslint flat config

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,7 +5,10 @@ import reactRefresh from "eslint-plugin-react-refresh";
 import tseslint from "typescript-eslint";
 
 export default tseslint.config(
-  { ignores: ["dist"] },
+  // worktrees git aninhados de outras sessões Claude (.claude/.claire são gitignored;
+  // o CI nunca os vê). Sem isto, `eslint .` local recorre neles e reporta erros-fantasma
+  // (no-explicit-any/prefer-const etc.) de código que não pertence a este checkout.
+  { ignores: ["dist", ".claude/**", ".claire/**"] },
   {
     extends: [js.configs.recommended, ...tseslint.configs.recommended],
     files: ["**/*.{ts,tsx}"],


### PR DESCRIPTION
## Problema

`bun lint` (`eslint .`) local recorre em **worktrees git aninhados de outras sessões Claude** — `.claude/worktrees/*` e `.claire/worktrees/*` — que são gitignored e que o **CI nunca vê** (checkout limpo). Resultado: ~154 *errors*-fantasma (`no-explicit-any`, `prefer-const` etc.) de código que não pertence a este checkout, poluindo `bun lint` e o `/health` local.

## Correção

Adiciona `.claude/**` e `.claire/**` ao array global de `ignores` do flat config. Escopo cirúrgico: **nenhuma regra alterada, nada em `src/`**.

## Verificação (falsificação antes/depois)

Como o checkout não tem worktrees aninhados, provei o mecanismo plantando um `.ts` com erro real dentro de `.claude/`:

| | exit | resultado |
|---|---|---|
| **antes** | 1 | 2 errors reais (`no-explicit-any` + `no-debugger`) → arquivo **lintado** |
| **depois** | 0 | `File ignored because of a matching ignore pattern` → **ignorado** |

`bun lint` completo na base deste PR: **0 errors** (76 warnings `react-hooks/exhaustive-deps` pré-existentes, intactos — prova de que `src/` segue plenamente lintado, sem *over-ignore*).

🤖 Generated with [Claude Code](https://claude.com/claude-code)