### PR TITLE
fix(financeiro): views de aging filtravam status morto → vazias em prod

### DIFF
--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,7 +21,7 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **245** custom migrations totais
+- **246** custom migrations totais
 - **904** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
   - `function`: 258
@@ -2135,6 +2135,10 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | Tipo | Objeto | Parent |
 | --- | --- | --- |
 | `function` | `public.get_tint_prices` | — |
+
+### `20260616020000_fix_aging_views_status_vocab.sql`
+
+> _Nenhum objeto extraído via regex._ Migration provavelmente é `ALTER TABLE` / `UPDATE` / `INSERT` / RLS-only. Validar manualmente.
 
 ## Próximos passos quando algo der `❌`
 

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 245
+-- Total de custom migrations: 246
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -264,7 +264,8 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260615194500', 'fix_tarefas_matcher_enum', '20260615194500_fix_tarefas_matcher_enum.sql'),
   ('20260615200000', 'tint_get_price_base', '20260615200000_tint_get_price_base.sql'),
   ('20260615210000', 'reposicao_auto_aprovacao_v2', '20260615210000_reposicao_auto_aprovacao_v2.sql'),
-  ('20260615210000', 'tint_get_prices_batch', '20260615210000_tint_get_prices_batch.sql')
+  ('20260615210000', 'tint_get_prices_batch', '20260615210000_tint_get_prices_batch.sql'),
+  ('20260616020000', 'fix_aging_views_status_vocab', '20260616020000_fix_aging_views_status_vocab.sql')
 )
 SELECT
   e.version,

--- a/supabase/migrations/20260616020000_fix_aging_views_status_vocab.sql
+++ b/supabase/migrations/20260616020000_fix_aging_views_status_vocab.sql
@@ -1,0 +1,50 @@
+-- ============================================================
+-- fix_aging_views_status_vocab — corrige vocabulário de status MORTO nas views de aging
+-- ============================================================
+-- Problema (diagnosticado via psql-ro, jun/2026): fin_aging_receber e fin_aging_pagar
+-- filtravam WHERE status_titulo IN ('ABERTO','VENCIDO','PARCIAL') — valores que NÃO
+-- existem nos dados. O Omie usa 'A VENCER','ATRASADO','VENCE HOJE','RECEBIDO','PAGO',
+-- 'CANCELADO'. Resultado: as views voltavam 0 linhas → painéis de aging vazios em prod
+-- (falha silenciosa money-path).
+--
+-- Fix: "em aberto" = status_titulo NOT IN ('RECEBIDO'/'PAGO','CANCELADO'). Só o WHERE muda;
+-- nomes/ordem das colunas e expressões de valor (sum(saldo)) preservados verbatim — `saldo`
+-- é 100% populado nas duas tabelas (42.637/42.637 e 15.717/15.717). Aging por data_vencimento.
+-- Provado contra dado real: receber overdue ≈ R$196k, bate com o cálculo do cru.
+--
+-- NÃO inclui fin_fluxo_caixa_diario: o lado "realizadas" agrupa por data_recebimento/
+-- data_pagamento, que são NULL até em títulos liquidados (gap do sync Omie) — precisa de
+-- correção de DADO upstream antes, não só de vocabulário. Tratar à parte.
+-- ============================================================
+
+CREATE OR REPLACE VIEW public.fin_aging_receber AS
+ SELECT company,
+    count(*) FILTER (WHERE data_vencimento >= CURRENT_DATE) AS a_vencer_qtd,
+    COALESCE(sum(saldo) FILTER (WHERE data_vencimento >= CURRENT_DATE), 0::numeric) AS a_vencer_valor,
+    count(*) FILTER (WHERE (CURRENT_DATE - data_vencimento) >= 1 AND (CURRENT_DATE - data_vencimento) <= 30) AS vencido_1_30_qtd,
+    COALESCE(sum(saldo) FILTER (WHERE (CURRENT_DATE - data_vencimento) >= 1 AND (CURRENT_DATE - data_vencimento) <= 30), 0::numeric) AS vencido_1_30_valor,
+    count(*) FILTER (WHERE (CURRENT_DATE - data_vencimento) >= 31 AND (CURRENT_DATE - data_vencimento) <= 60) AS vencido_31_60_qtd,
+    COALESCE(sum(saldo) FILTER (WHERE (CURRENT_DATE - data_vencimento) >= 31 AND (CURRENT_DATE - data_vencimento) <= 60), 0::numeric) AS vencido_31_60_valor,
+    count(*) FILTER (WHERE (CURRENT_DATE - data_vencimento) >= 61 AND (CURRENT_DATE - data_vencimento) <= 90) AS vencido_61_90_qtd,
+    COALESCE(sum(saldo) FILTER (WHERE (CURRENT_DATE - data_vencimento) >= 61 AND (CURRENT_DATE - data_vencimento) <= 90), 0::numeric) AS vencido_61_90_valor,
+    count(*) FILTER (WHERE (CURRENT_DATE - data_vencimento) > 90) AS vencido_90_plus_qtd,
+    COALESCE(sum(saldo) FILTER (WHERE (CURRENT_DATE - data_vencimento) > 90), 0::numeric) AS vencido_90_plus_valor
+   FROM public.fin_contas_receber
+  WHERE status_titulo <> ALL (ARRAY['RECEBIDO'::text, 'CANCELADO'::text])
+  GROUP BY company;
+
+CREATE OR REPLACE VIEW public.fin_aging_pagar AS
+ SELECT company,
+    count(*) FILTER (WHERE data_vencimento >= CURRENT_DATE) AS a_vencer_qtd,
+    COALESCE(sum(saldo) FILTER (WHERE data_vencimento >= CURRENT_DATE), 0::numeric) AS a_vencer_valor,
+    count(*) FILTER (WHERE (CURRENT_DATE - data_vencimento) >= 1 AND (CURRENT_DATE - data_vencimento) <= 30) AS vencido_1_30_qtd,
+    COALESCE(sum(saldo) FILTER (WHERE (CURRENT_DATE - data_vencimento) >= 1 AND (CURRENT_DATE - data_vencimento) <= 30), 0::numeric) AS vencido_1_30_valor,
+    count(*) FILTER (WHERE (CURRENT_DATE - data_vencimento) >= 31 AND (CURRENT_DATE - data_vencimento) <= 60) AS vencido_31_60_qtd,
+    COALESCE(sum(saldo) FILTER (WHERE (CURRENT_DATE - data_vencimento) >= 31 AND (CURRENT_DATE - data_vencimento) <= 60), 0::numeric) AS vencido_31_60_valor,
+    count(*) FILTER (WHERE (CURRENT_DATE - data_vencimento) >= 61 AND (CURRENT_DATE - data_vencimento) <= 90) AS vencido_61_90_qtd,
+    COALESCE(sum(saldo) FILTER (WHERE (CURRENT_DATE - data_vencimento) >= 61 AND (CURRENT_DATE - data_vencimento) <= 90), 0::numeric) AS vencido_61_90_valor,
+    count(*) FILTER (WHERE (CURRENT_DATE - data_vencimento) > 90) AS vencido_90_plus_qtd,
+    COALESCE(sum(saldo) FILTER (WHERE (CURRENT_DATE - data_vencimento) > 90), 0::numeric) AS vencido_90_plus_valor
+   FROM public.fin_contas_pagar
+  WHERE status_titulo <> ALL (ARRAY['PAGO'::text, 'CANCELADO'::text])
+  GROUP BY company;


### PR DESCRIPTION
## ⚠️ ATENÇÃO: migration manual necessária

Este PR adiciona `supabase/migrations/20260616020000_fix_aging_views_status_vocab.sql`. **Lovable não aplica automaticamente** — mergear NÃO toca o banco. Precisa colar no SQL Editor do Lovable e rodar.

## Problema (diagnosticado via psql-ro durante teste da skill bi-colacor)

`fin_aging_receber` e `fin_aging_pagar` filtravam `WHERE status_titulo IN ('ABERTO','VENCIDO','PARCIAL')` — valores que **não existem** nos dados. O Omie usa `'A VENCER'`/`'ATRASADO'`/`'VENCE HOJE'`/`'RECEBIDO'`/`'PAGO'`/`'CANCELADO'`. Resultado: **0 linhas** → os painéis de aging do app mostram vazio há tempo (falha silenciosa money-path).

## Fix

`"em aberto" = status_titulo NOT IN ('RECEBIDO'/'PAGO','CANCELADO')`. Só o `WHERE` muda — colunas, ordem e `sum(saldo)` preservados verbatim (`saldo` é 100% populado: 42.637/42.637 e 15.717/15.717). **Provado contra dado real** (psql-ro): receber overdue ≈ R$196k, a vencer ≈ R$356k; bate com o cálculo do cru. View valida SQL no CREATE (não é late-bound).

**Fora de escopo:** `fin_fluxo_caixa_diario` — o lado "realizadas" agrupa por `data_recebimento`/`data_pagamento`, **NULL até em títulos liquidados** (gap de dado do Omie). Precisa de correção upstream, não só de vocabulário.

<details><summary>SQL pra aplicar</summary>

```sql
-- conteúdo de 20260616020000_fix_aging_views_status_vocab.sql (ver arquivo no PR)
```
</details>

Validação pós-apply (read-only):

```sql
SELECT CASE WHEN (SELECT count(*) FROM public.fin_aging_receber) > 0
             AND (SELECT count(*) FROM public.fin_aging_pagar) > 0
       THEN '✅ views de aging populadas' ELSE '❌ ainda vazias' END AS status;
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)