### PR TITLE
feat(geocoding): Sub-PR 3 — edge-proxy CEP Aberto (orgânico de qualidade) + tooling do gate/carteira

### DIFF
--- a/scripts/cep-aberto/importar-carteira.ts
+++ b/scripts/cep-aberto/importar-carteira.ts
@@ -1,0 +1,81 @@
+// Importa a CARTEIRA (1.283 CEPs distintos) no cep_geo via API do CEP Aberto e gera
+// um INSERT colável no SQL Editor do Lovable (writes não passam por mim). Decisão A
+// do gate (eu + Codex): carteira agora é viável/auditável/money-path; prospects ficam
+// no orgânico; bulk completo adiado. precision='postcode_centroid' (CEP-level honesto),
+// source='cep_aberto', ON CONFLICT anti-downgrade (idempotente; re-rodável).
+//   CEP_ABERTO_TOKEN=xxx bun scripts/cep-aberto/importar-carteira.ts /tmp/carteira-ceps.csv /tmp/carteira-import.sql
+import { readFileSync, writeFileSync } from 'node:fs';
+
+const TOKEN = process.env.CEP_ABERTO_TOKEN;
+if (!TOKEN) {
+  console.error('❌ Falta CEP_ABERTO_TOKEN no env.');
+  process.exit(1);
+}
+const CSV = process.argv[2] ?? '/tmp/carteira-ceps.csv';
+const OUT = process.argv[3] ?? '/tmp/carteira-import.sql';
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+const ceps = readFileSync(CSV, 'utf8')
+  .trim()
+  .split('\n')
+  .map((l) => l.trim())
+  .filter((c) => /^[0-9]{8}$/.test(c));
+
+async function cepAberto(cep: string): Promise<{ lat: number; lng: number; uf: string } | null | 'erro'> {
+  for (let tent = 0; tent < 4; tent++) {
+    try {
+      const r = await fetch(`https://www.cepaberto.com/api/v3/cep?cep=${cep}`, {
+        headers: { Authorization: `Token token=${TOKEN}` },
+      });
+      if (r.ok) {
+        const j = (await r.json()) as { latitude?: string; longitude?: string; estado?: { sigla?: string } };
+        if (j && j.latitude && j.longitude) {
+          return { lat: parseFloat(j.latitude), lng: parseFloat(j.longitude), uf: (j.estado?.sigla ?? '').toUpperCase() };
+        }
+        return null; // {} = não coberto
+      }
+      await sleep(2500); // backoff rate-limit
+    } catch {
+      await sleep(1500);
+    }
+  }
+  return 'erro';
+}
+
+(async () => {
+  const rows: string[] = [];
+  let hit = 0;
+  let miss = 0;
+  let erro = 0;
+  for (let i = 0; i < ceps.length; i++) {
+    const cep = ceps[i];
+    const ca = await cepAberto(cep);
+    await sleep(1600);
+    if (ca === 'erro') {
+      erro++;
+    } else if (ca === null) {
+      miss++;
+    } else {
+      hit++;
+      const uf = /^[A-Z]{2}$/.test(ca.uf) ? `'${ca.uf}'` : 'NULL';
+      rows.push(`('${cep}',${ca.lat},${ca.lng},'cep_aberto','postcode_centroid',${uf})`);
+    }
+    if ((i + 1) % 50 === 0) console.error(`... ${i + 1}/${ceps.length} (hit ${hit} miss ${miss} erro ${erro})`);
+  }
+
+  const sql = `-- Carteira import (Sub-PR 3, geocoding por CEP). ${hit} CEPs via CEP Aberto.
+-- postcode_centroid honesto, source cep_aberto. Idempotente (anti-downgrade). Colar 1x.
+INSERT INTO cep_geo (cep, lat, lng, source, precision, uf) VALUES
+${rows.join(',\n')}
+ON CONFLICT (cep) DO UPDATE SET
+  lat = EXCLUDED.lat, lng = EXCLUDED.lng, source = EXCLUDED.source,
+  precision = EXCLUDED.precision, uf = EXCLUDED.uf, updated_at = now()
+WHERE rank_precisao(EXCLUDED.precision) >= rank_precisao(cep_geo.precision);
+
+SELECT count(*) AS cep_geo_total, count(*) FILTER (WHERE source='cep_aberto') AS via_cep_aberto FROM cep_geo;
+`;
+  writeFileSync(OUT, sql);
+  console.log(`\n=== CARTEIRA IMPORT — pronto ===`);
+  console.log(`CEPs: ${ceps.length} · hit ${hit} · miss ${miss} · erro ${erro}`);
+  console.log(`SQL colável: ${OUT} (${(sql.length / 1024).toFixed(0)} KB, ${hit} linhas)`);
+})();

--- a/scripts/cep-aberto/medir.ts
+++ b/scripts/cep-aberto/medir.ts
@@ -1,0 +1,123 @@
+// Runner do gate CEP Aberto (Sub-PR 3, geocoding por CEP). Lê uma amostra (uf,cep)
+// e mede COBERTURA (o CEP Aberto tem a coord?) + CONFIABILIDADE (a coord cai na
+// cidade certa? — distância ao centróide IBGE do município que a própria API
+// reporta, via cidade.ibge → nosso municipio_geo). Nominatim foi descartado como
+// referência: não resolve CEP nu brasileiro de forma confiável (devolve lixo).
+// Token via env CEP_ABERTO_TOKEN (NÃO commitar). Roda 1× e imprime o relatório.
+//   CEP_ABERTO_TOKEN=xxx bun scripts/cep-aberto/medir.ts /tmp/cep-sample.csv /tmp/muni.csv
+import { readFileSync, writeFileSync } from 'node:fs';
+import { distanciaKm, resumoMedicao, type AmostraMedida } from '../../src/lib/cep/medicao';
+
+const TOKEN = process.env.CEP_ABERTO_TOKEN;
+if (!TOKEN) {
+  console.error('❌ Falta CEP_ABERTO_TOKEN no env.');
+  process.exit(1);
+}
+const CSV = process.argv[2] ?? '/tmp/cep-sample.csv';
+const MUNI = process.argv[3] ?? '/tmp/ibge.csv';
+const FORA_KM = 50; // > isso do centróide = provável cidade errada / coord lixo
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+type Coord = { lat: number; lng: number };
+
+// Centróides IBGE oficiais (codigo_ibge,nome,latitude,longitude,...). Chave = IBGE
+// 7 díg, que casa com o cidade.ibge devolvido pela API do CEP Aberto.
+const muni = new Map<string, Coord>();
+for (const l of readFileSync(MUNI, 'utf8').trim().split('\n').slice(1)) {
+  const p = l.split(',');
+  if (/^[0-9]{7}$/.test(p[0])) muni.set(p[0], { lat: parseFloat(p[2]), lng: parseFloat(p[3]) });
+}
+
+const linhas = readFileSync(CSV, 'utf8')
+  .trim()
+  .split('\n')
+  .map((l) => {
+    const [uf, cep] = l.split(',');
+    return { uf, cep };
+  })
+  .filter((l) => /^[0-9]{8}$/.test(l.cep));
+
+async function cepAberto(cep: string): Promise<{ lat: number; lng: number; ibge: string | null } | null | 'erro'> {
+  for (let tent = 0; tent < 4; tent++) {
+    try {
+      const r = await fetch(`https://www.cepaberto.com/api/v3/cep?cep=${cep}`, {
+        headers: { Authorization: `Token token=${TOKEN}` },
+      });
+      if (r.ok) {
+        const j = (await r.json()) as { latitude?: string; longitude?: string; cidade?: { ibge?: string } };
+        if (j && j.latitude && j.longitude) {
+          return { lat: parseFloat(j.latitude), lng: parseFloat(j.longitude), ibge: j.cidade?.ibge ?? null };
+        }
+        return null; // {} = não coberto
+      }
+      await sleep(2500); // não-ok (rate limit/transiente) → backoff e re-tenta
+    } catch {
+      await sleep(1500);
+    }
+  }
+  return 'erro';
+}
+
+(async () => {
+  const amostras: AmostraMedida[] = [];
+  const porUf = new Map<string, { hit: number; miss: number; erro: number }>();
+  const raw: string[] = ['uf,cep,status,ibge,dist_centroide_km'];
+  let erros = 0;
+  let foraCidade = 0;
+  let semMuni = 0;
+  let i = 0;
+  for (const { uf, cep } of linhas) {
+    i++;
+    const u = porUf.get(uf) ?? { hit: 0, miss: 0, erro: 0 };
+    const ca = await cepAberto(cep);
+    await sleep(1600); // CEP Aberto rate-limita abaixo de ~1,5s/req
+    if (ca === 'erro') {
+      u.erro++;
+      erros++;
+      porUf.set(uf, u);
+      raw.push(`${uf},${cep},erro,,`);
+      continue;
+    }
+    if (ca === null) {
+      u.miss++;
+      porUf.set(uf, u);
+      amostras.push({ coberto: false, distanciaKm: null });
+      raw.push(`${uf},${cep},miss,,`);
+      continue;
+    }
+    u.hit++;
+    porUf.set(uf, u);
+    const c = ca.ibge ? muni.get(ca.ibge) : undefined;
+    let d: number | null = null;
+    if (c) {
+      d = distanciaKm(ca.lat, ca.lng, c.lat, c.lng);
+      if (d > FORA_KM) foraCidade++;
+    } else {
+      semMuni++;
+    }
+    amostras.push({ coberto: true, distanciaKm: d });
+    raw.push(`${uf},${cep},hit,${ca.ibge ?? ''},${d != null ? d.toFixed(3) : ''}`);
+    if (i % 50 === 0) console.error(`... ${i}/${linhas.length} (hits ${amostras.filter((a) => a.coberto).length})`);
+  }
+
+  writeFileSync('/tmp/cep-gate-raw.csv', raw.join('\n'));
+  const r = resumoMedicao(amostras);
+  const naCidade = r.comReferencia - foraCidade;
+  const confPct = r.comReferencia ? Math.round((naCidade / r.comReferencia) * 1000) / 10 : 0;
+  console.log('\n=== GATE CEP ABERTO — RESULTADO ===');
+  console.log(`Amostra: ${linhas.length} CEPs · ${porUf.size} UFs · erros API: ${erros}`);
+  console.log(`COBERTURA: ${r.cobertos}/${r.total} = ${r.coberturaPct}%`);
+  console.log(
+    `CONFIABILIDADE: ${naCidade}/${r.comReferencia} = ${confPct}% na cidade certa (≤${FORA_KM}km do centróide IBGE) · fora: ${foraCidade} · sem centróide: ${semMuni}`,
+  );
+  console.log(
+    `Distância ao centróide (cobertos c/ ref): mediana ${r.distMedianaKm?.toFixed(2) ?? '—'}km · p90 ${r.distP90Km?.toFixed(2) ?? '—'}km`,
+  );
+  console.log('\nCobertura por UF (hit/total):');
+  [...porUf.entries()].sort().forEach(([uf, c]) => {
+    const tot = c.hit + c.miss;
+    const pct = tot ? Math.round((c.hit / tot) * 100) : 0;
+    console.log(`  ${uf}: ${c.hit}/${tot} = ${pct}%${c.erro ? ` (erro ${c.erro})` : ''}`);
+  });
+  console.log('\nRaw por CEP em /tmp/cep-gate-raw.csv');
+})();

--- a/src/hooks/useRoutePlanner.ts
+++ b/src/hooks/useRoutePlanner.ts
@@ -44,6 +44,7 @@ import {
 import { carteiraRowToStop, type CarteiraRow } from '@/lib/route/carteira-stop';
 import { montarDetalheAlvo, type AlvoDetalhe } from '@/lib/route/alvo-detalhe';
 import { ordenarFilaGeocode, ordenarFilaGeocodeCep } from '@/lib/route/geocode-fila';
+import { interpretarResolver } from '@/lib/route/cep-resolver';
 import { normalizarCep } from '@/lib/route/cep';
 
 // Teto de prospects por cidade pedido à RPC (a RPC capa em 2000 no SQL).
@@ -1001,7 +1002,7 @@ export function useRoutePlanner() {
   const geocodingAbort = useRef<AbortController | null>(null);
   const geocodeFalhados = useRef<Set<string>>(new Set());
   // Geocoding por CEP (campo): coord por CEP distinto + CEPs que falharam na sessão.
-  const geocodedCepCoords = useRef<Map<string, { lat: number; lng: number }>>(new Map());
+  const geocodedCepCoords = useRef<Map<string, { lat: number; lng: number; precisao: string }>>(new Map());
   const cepFalhados = useRef<Set<string>>(new Set());
   // Modo atual num ref p/ o worker escolher a estratégia (CEP vs endereço) sem stale.
   const planningModeRef = useRef(planningMode);
@@ -1017,18 +1018,19 @@ export function useRoutePlanner() {
   useEffect(() => {
     const enriched = allStops.map(s => {
       const cepCoord = geocodedCepCoords.current.get(normalizarCep(s.address.zip_code) ?? '');
-      if (cepCoord) return { ...s, lat: cepCoord.lat, lng: cepCoord.lng, precisao: 'postcode_centroid' };
+      if (cepCoord) return { ...s, lat: cepCoord.lat, lng: cepCoord.lng, precisao: cepCoord.precisao };
       const cached = geocodedCoords.current.get(s.id);
       return cached ? { ...s, lat: cached.lat, lng: cached.lng } : s;
     });
     setGeocodedAllStops(enriched);
   }, [allStops]);
 
-  // Geocoding progressivo ~1/s, marcados-na-rota primeiro. CAMPO (prospeccao):
-  // geocodifica o CEP DISTINTO → cep_geo_upsert → pinta TODOS os alvos do CEP de uma
-  // vez (1234 empresas ≈ 574 CEPs). EQUIPE: legado por endereço/stop. Re-deriva a
-  // fila a cada ciclo → marcar um alvo re-prioriza o próximo pick; resolvidos/
-  // falhados saem da fila → o loop termina.
+  // Geocoding progressivo, marcados-na-rota primeiro. CAMPO (prospeccao): resolve o
+  // CEP DISTINTO via edge `cep-geo-resolver` (cache cep_geo → CEP Aberto, token
+  // server-side; a edge já persiste no cep_geo/SoT) → pinta TODOS os alvos do CEP de
+  // uma vez (1234 empresas ≈ 574 CEPs). EQUIPE: legado por endereço/stop via Nominatim.
+  // Re-deriva a fila a cada ciclo → marcar um alvo re-prioriza o próximo pick;
+  // resolvidos/falhados saem da fila → o loop termina.
   useEffect(() => {
     geocodingAbort.current?.abort();
     const controller = new AbortController();
@@ -1056,22 +1058,21 @@ export function useRoutePlanner() {
           if (fila.length === 0) break;
           const { cep, cidade, uf } = fila[0];
           try {
-            const coords = await nominatim(`${cep}, ${cidade}, ${uf}, Brazil`);
+            // A edge guarda o token, faz cache + CEP Aberto e já persiste no cep_geo (SoT).
+            const { data, error } = await supabase.functions.invoke('cep-geo-resolver', {
+              body: { cep, cidade, uf },
+            });
+            if (controller.signal.aborted) break;
+            const coords = error ? null : interpretarResolver(data);
             if (coords) {
-              geocodedCepCoords.current.set(cep, coords);
+              geocodedCepCoords.current.set(cep, { lat: coords.lat, lng: coords.lng, precisao: coords.precisao });
               setGeocodedAllStops(prev => prev.map(s =>
                 normalizarCep(s.address.zip_code) === cep
-                  ? { ...s, lat: coords.lat, lng: coords.lng, precisao: 'postcode_centroid' }
+                  ? { ...s, lat: coords.lat, lng: coords.lng, precisao: coords.precisao }
                   : s,
               ));
-              // Persiste: postcode_centroid; anti-downgrade no SQL. Gate = gestor/master
-              // (o contexto campo já exige). Compartilhado por todos os alvos do CEP.
-              void supabase.rpc('cep_geo_upsert' as never, {
-                p_cep: cep, p_lat: coords.lat, p_lng: coords.lng,
-                p_source: 'nominatim', p_precision: 'postcode_centroid',
-              } as never);
             } else {
-              cepFalhados.current.add(cep); // sem resultado → não recicla o mesmo CEP
+              cepFalhados.current.add(cep); // miss / edge indisponível → não recicla o CEP nesta sessão
             }
           } catch (e) {
             if ((e as { name?: string })?.name === 'AbortError') break;
@@ -1104,8 +1105,9 @@ export function useRoutePlanner() {
             geocodeFalhados.current.add(stop.id);
           }
         }
-        // Nominatim rate limit: máx 1 req/s
-        if (!controller.signal.aborted) await new Promise(r => setTimeout(r, 1100));
+        // Pacing: CEP Aberto rate-limita < ~1,6s/req (campo); Nominatim ~1/s (equipe).
+        const espera = planningModeRef.current === 'prospeccao' ? 1600 : 1100;
+        if (!controller.signal.aborted) await new Promise(r => setTimeout(r, espera));
       }
       if (!controller.signal.aborted) setGeocodingPendentes(0);
     })();

--- a/src/lib/cep/medicao.test.ts
+++ b/src/lib/cep/medicao.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { distanciaKm, amostrarPorUf, resumoMedicao, type AmostraMedida } from './medicao';
+
+describe('distanciaKm (haversine)', () => {
+  it('mesmo ponto → 0', () => {
+    expect(distanciaKm(-20.14, -44.88, -20.14, -44.88)).toBe(0);
+  });
+  it('1° de latitude ≈ 111,19 km', () => {
+    expect(distanciaKm(0, 0, 1, 0)).toBeCloseTo(111.19, 1);
+  });
+  it('1° de longitude no equador ≈ 111,19 km', () => {
+    expect(distanciaKm(0, 0, 0, 1)).toBeCloseTo(111.19, 1);
+  });
+  it('simétrica', () => {
+    const ab = distanciaKm(-20.14, -44.88, -23.55, -46.63);
+    const ba = distanciaKm(-23.55, -46.63, -20.14, -44.88);
+    expect(ab).toBeCloseTo(ba, 6);
+  });
+  it('Divinópolis↔São Paulo ≈ 430 km (sanidade)', () => {
+    expect(distanciaKm(-20.14, -44.88, -23.55, -46.63)).toBeGreaterThan(400);
+    expect(distanciaKm(-20.14, -44.88, -23.55, -46.63)).toBeLessThan(460);
+  });
+});
+
+describe('amostrarPorUf (estratificada determinística)', () => {
+  const itens = [
+    { uf: 'MG', cep: '1' }, { uf: 'MG', cep: '2' }, { uf: 'MG', cep: '3' },
+    { uf: 'SP', cep: '4' }, { uf: 'sp', cep: '5' }, { uf: 'RJ', cep: '6' },
+  ];
+  it('limita nPorUf por UF, ordem estável', () => {
+    expect(amostrarPorUf(itens, 2).map((i) => i.cep)).toEqual(['1', '2', '4', '5', '6']);
+  });
+  it('uppercase une mg/MG no mesmo balde', () => {
+    expect(amostrarPorUf([{ uf: 'mg', cep: 'a' }, { uf: 'MG', cep: 'b' }], 1).map((i) => i.cep)).toEqual(['a']);
+  });
+  it('nPorUf 0 → vazio', () => {
+    expect(amostrarPorUf(itens, 0)).toEqual([]);
+  });
+});
+
+describe('resumoMedicao', () => {
+  const mk = (coberto: boolean, distanciaKm: number | null): AmostraMedida => ({ coberto, distanciaKm });
+  it('cobertura %, mediana, p90 e grosseiros (>10km)', () => {
+    const amostras = [
+      mk(true, 0.2), mk(true, 0.5), mk(true, 1.0), mk(true, 2.0),
+      mk(true, 15.0), // grosseiro (erro de cidade)
+      mk(false, null), mk(false, null), // não cobertos
+    ];
+    const r = resumoMedicao(amostras);
+    expect(r.total).toBe(7);
+    expect(r.cobertos).toBe(5);
+    expect(r.coberturaPct).toBeCloseTo(71.4, 1);
+    expect(r.comReferencia).toBe(5);
+    expect(r.grosseirosMaior10km).toBe(1);
+    expect(r.distMedianaKm).not.toBeNull();
+    expect(r.distP90Km).not.toBeNull();
+  });
+  it('vazio → zeros e nulls (ausente ≠ fabricar)', () => {
+    const r = resumoMedicao([]);
+    expect(r).toEqual({
+      total: 0, cobertos: 0, coberturaPct: 0, comReferencia: 0,
+      distMedianaKm: null, distP90Km: null, grosseirosMaior10km: 0,
+    });
+  });
+  it('coberto sem referência não entra na distância', () => {
+    const r = resumoMedicao([{ coberto: true, distanciaKm: null }]);
+    expect(r.cobertos).toBe(1);
+    expect(r.comReferencia).toBe(0);
+    expect(r.distMedianaKm).toBeNull();
+  });
+});

--- a/src/lib/cep/medicao.ts
+++ b/src/lib/cep/medicao.ts
@@ -1,0 +1,74 @@
+// Núcleo PURO da medição do gate CEP Aberto (Sub-PR 3, geocoding por CEP).
+// "Meça antes de confiar" (Codex): antes de importar 1,1M CEPs, medimos numa AMOSTRA
+// estratificada dos nossos CEPs — cobertura (o CEP Aberto tem a coord?) + precisão
+// (a coord concorda com o Nominatim do mesmo CEP?). Esta lógica decide um veredito
+// que afeta o mapa de visitas → é testada (distância errada = veredito errado).
+
+// Haversine: distância em km entre dois pontos (lat/lng em graus). Correto p/ as
+// distâncias curtas do gate (concordância CEP Aberto × Nominatim do mesmo CEP).
+export function distanciaKm(aLat: number, aLng: number, bLat: number, bLng: number): number {
+  const R = 6371; // raio médio da Terra (km)
+  const rad = (g: number) => (g * Math.PI) / 180;
+  const dLat = rad(bLat - aLat);
+  const dLng = rad(bLng - aLng);
+  const h =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(rad(aLat)) * Math.cos(rad(bLat)) * Math.sin(dLng / 2) ** 2;
+  return 2 * R * Math.asin(Math.min(1, Math.sqrt(h)));
+}
+
+// Amostra estratificada: até nPorUf itens por UF, ordem estável (DETERMINÍSTICA —
+// sem Math.random, p/ reprodutibilidade do gate). Pega os primeiros nPorUf de cada UF.
+export function amostrarPorUf<T extends { uf: string }>(itens: T[], nPorUf: number): T[] {
+  const contagem = new Map<string, number>();
+  const out: T[] = [];
+  for (const it of itens) {
+    const uf = (it.uf ?? '').toUpperCase();
+    const n = contagem.get(uf) ?? 0;
+    if (n < nPorUf) {
+      out.push(it);
+      contagem.set(uf, n + 1);
+    }
+  }
+  return out;
+}
+
+export interface AmostraMedida {
+  coberto: boolean; // CEP Aberto retornou coordenada?
+  distanciaKm: number | null; // distância vs referência (Nominatim); null se sem ref
+}
+
+export interface ResumoMedicao {
+  total: number;
+  cobertos: number;
+  coberturaPct: number; // 0..100
+  comReferencia: number;
+  distMedianaKm: number | null;
+  distP90Km: number | null;
+  grosseirosMaior10km: number; // outliers (>10km = provável erro de cidade)
+}
+
+// Percentil por nearest-rank (suficiente p/ o gate; sem interpolação).
+function percentil(ordenado: number[], p: number): number | null {
+  if (ordenado.length === 0) return null;
+  const i = Math.min(ordenado.length - 1, Math.floor((p / 100) * ordenado.length));
+  return ordenado[i];
+}
+
+export function resumoMedicao(amostras: AmostraMedida[]): ResumoMedicao {
+  const total = amostras.length;
+  const cobertos = amostras.filter((a) => a.coberto).length;
+  const dists = amostras
+    .filter((a) => a.distanciaKm != null)
+    .map((a) => a.distanciaKm as number)
+    .sort((x, y) => x - y);
+  return {
+    total,
+    cobertos,
+    coberturaPct: total ? Math.round((cobertos / total) * 1000) / 10 : 0,
+    comReferencia: dists.length,
+    distMedianaKm: percentil(dists, 50),
+    distP90Km: percentil(dists, 90),
+    grosseirosMaior10km: dists.filter((d) => d > 10).length,
+  };
+}

--- a/src/lib/route/cep-resolver.test.ts
+++ b/src/lib/route/cep-resolver.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { interpretarResolver } from './cep-resolver';
+
+describe('interpretarResolver', () => {
+  it('adota coord quando resolved=true com lat/lng finitos', () => {
+    expect(
+      interpretarResolver({ resolved: true, lat: -20.1, lng: -44.8, precision: 'postcode_centroid' }),
+    ).toEqual({ lat: -20.1, lng: -44.8, precisao: 'postcode_centroid' });
+  });
+
+  it('preserva a precisão vinda do cache (ex.: rooftop)', () => {
+    expect(interpretarResolver({ resolved: true, lat: 1, lng: 2, precision: 'rooftop', cached: true })).toEqual({
+      lat: 1,
+      lng: 2,
+      precisao: 'rooftop',
+    });
+  });
+
+  it('default postcode_centroid quando precision ausente', () => {
+    expect(interpretarResolver({ resolved: true, lat: 1, lng: 2 })).toEqual({
+      lat: 1,
+      lng: 2,
+      precisao: 'postcode_centroid',
+    });
+  });
+
+  it('retorna null no miss (resolved=false) → worker mantém centróide', () => {
+    expect(interpretarResolver({ resolved: false })).toBeNull();
+  });
+
+  it('NÃO fabrica pino: resolved=true mas lat/lng null → null', () => {
+    expect(interpretarResolver({ resolved: true, lat: null, lng: null })).toBeNull();
+  });
+
+  it('NÃO fabrica pino: lat/lng não-finito (NaN/Infinity) → null', () => {
+    expect(interpretarResolver({ resolved: true, lat: NaN, lng: 2 })).toBeNull();
+    expect(interpretarResolver({ resolved: true, lat: 1, lng: Infinity })).toBeNull();
+  });
+
+  it('rejeita lat/lng como string (sem coerção implícita = sem número fabricado)', () => {
+    expect(interpretarResolver({ resolved: true, lat: '-20.1', lng: '-44.8' })).toBeNull();
+  });
+
+  it('entrada inválida (null/undefined/string/number/array) → null', () => {
+    expect(interpretarResolver(null)).toBeNull();
+    expect(interpretarResolver(undefined)).toBeNull();
+    expect(interpretarResolver('x')).toBeNull();
+    expect(interpretarResolver(42)).toBeNull();
+    expect(interpretarResolver([])).toBeNull();
+  });
+});

--- a/src/lib/route/cep-resolver.ts
+++ b/src/lib/route/cep-resolver.ts
@@ -1,0 +1,21 @@
+// Interpreta a resposta da edge `cep-geo-resolver` para o worker do roteirizador.
+// Money-path (mapa de visita do vendedor): só adota coord se a edge marcou
+// resolved=true E lat/lng são números FINITOS — NUNCA fabrica pino a partir de
+// resposta ausente/garbage (ausente ≠ zero; sem coerção de string→número). No
+// miss devolve null → o worker mantém o pino aproximado do centróide do município.
+export interface CoordResolvida {
+  lat: number;
+  lng: number;
+  precisao: string;
+}
+
+export function interpretarResolver(data: unknown): CoordResolvida | null {
+  if (!data || typeof data !== 'object') return null;
+  const d = data as Record<string, unknown>;
+  if (d.resolved !== true) return null;
+  const { lat, lng } = d;
+  if (typeof lat !== 'number' || typeof lng !== 'number') return null;
+  if (!Number.isFinite(lat) || !Number.isFinite(lng)) return null;
+  const precisao = typeof d.precision === 'string' && d.precision ? d.precision : 'postcode_centroid';
+  return { lat, lng, precisao };
+}

--- a/supabase/functions/cep-geo-resolver/index.ts
+++ b/supabase/functions/cep-geo-resolver/index.ts
@@ -1,0 +1,132 @@
+// Edge `cep-geo-resolver` — resolve UM CEP em coord (lat/lng) para o worker do
+// Roteirizador-campo, com o token do CEP Aberto guardado SERVER-SIDE (nunca no
+// browser). Cadeia: cep_geo (cache/SoT) → CEP Aberto → não-resolvido. NÃO usa
+// Nominatim: o gate (Sub-PR 3) provou que ele devolve lixo p/ CEP nu; o miss aqui
+// cai no centróide do município (a RPC da carteira/prospect já faz COALESCE) — pino
+// honestamente "aproximado", nunca um pino errado (precisão > recall, money-path).
+//
+// Persistência: reencaminha o JWT do staff e chama o cep_geo_upsert existente
+// (SECURITY DEFINER, gate gestor/master, idempotente, anti-downgrade de precisão) —
+// zero migration nova. Gate da fronteira: authorizeCronOrStaff.
+//
+// Secret necessária (founder seta no Lovable): CEP_ABERTO_TOKEN.
+import { createClient } from "npm:@supabase/supabase-js@2";
+import { authorizeCronOrStaff, corsHeaders } from "../_shared/auth.ts";
+
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
+const SERVICE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+const ANON_KEY = Deno.env.get("SUPABASE_ANON_KEY")!;
+const CEP_ABERTO_TOKEN = Deno.env.get("CEP_ABERTO_TOKEN") ?? "";
+
+const json = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+
+function normalizarCep(raw: unknown): string | null {
+  const d = String(raw ?? "").replace(/\D/g, "");
+  return /^\d{8}$/.test(d) ? d : null;
+}
+
+Deno.serve(async (req) => {
+  if (req.method === "OPTIONS") return new Response(null, { headers: corsHeaders });
+
+  try {
+    const auth = await authorizeCronOrStaff(req);
+    if (!auth.ok) return auth.response;
+
+    let body: Record<string, unknown> = {};
+    try {
+      body = await req.json();
+    } catch {
+      /* corpo vazio é tratado como CEP inválido abaixo */
+    }
+    const cep = normalizarCep(body.cep);
+    if (!cep) return json({ resolved: false, error: "CEP inválido" }, 400);
+
+    const admin = createClient(SUPABASE_URL, SERVICE_KEY);
+
+    // 1) Cache: cep_geo é a fonte da verdade. Já resolvido → devolve na hora
+    //    (preserva a precisão real — pode ser melhor que postcode, ex.: rooftop).
+    const { data: cached } = await admin
+      .from("cep_geo")
+      .select("lat,lng,precision,source")
+      .eq("cep", cep)
+      .maybeSingle();
+    if (cached && cached.lat != null && cached.lng != null) {
+      return json({
+        resolved: true,
+        lat: Number(cached.lat),
+        lng: Number(cached.lng),
+        precision: cached.precision ?? "postcode_centroid",
+        source: cached.source ?? "cep_geo",
+        cached: true,
+      });
+    }
+
+    if (!CEP_ABERTO_TOKEN) {
+      console.error("CEP_ABERTO_TOKEN ausente — defina a secret no Supabase.");
+      return json({ resolved: false, error: "sem token" });
+    }
+
+    // 2) CEP Aberto (token server-side). Timeout curto p/ não travar o worker;
+    //    429/5xx/timeout/{} → lat/lng ficam null → não-resolvido (cai no centróide).
+    let lat: number | null = null;
+    let lng: number | null = null;
+    try {
+      const ctrl = new AbortController();
+      const timer = setTimeout(() => ctrl.abort(), 5000);
+      const r = await fetch(`https://www.cepaberto.com/api/v3/cep?cep=${cep}`, {
+        headers: { Authorization: `Token token=${CEP_ABERTO_TOKEN}` },
+        signal: ctrl.signal,
+      });
+      clearTimeout(timer);
+      if (r.ok) {
+        const j = (await r.json()) as { latitude?: string; longitude?: string };
+        if (j && j.latitude && j.longitude) {
+          lat = parseFloat(j.latitude);
+          lng = parseFloat(j.longitude);
+        }
+      } else {
+        console.warn("CEP Aberto não-ok:", r.status);
+      }
+    } catch (e) {
+      console.warn("CEP Aberto falhou/timeout:", e instanceof Error ? e.message : String(e));
+    }
+
+    if (lat == null || lng == null || !Number.isFinite(lat) || !Number.isFinite(lng)) {
+      return json({ resolved: false });
+    }
+
+    // 3) Persiste no cep_geo via RPC gated/anti-downgrade, reencaminhando o JWT do
+    //    staff (o worker roda em contexto gestor/master). Falha no upsert NÃO impede
+    //    devolver a coord — só não popula o cache desta vez.
+    const authHeader = req.headers.get("Authorization") ?? "";
+    if (authHeader.startsWith("Bearer ")) {
+      const userClient = createClient(SUPABASE_URL, ANON_KEY, {
+        global: { headers: { Authorization: authHeader } },
+      });
+      const { error: upErr } = await userClient.rpc("cep_geo_upsert", {
+        p_cep: cep,
+        p_lat: lat,
+        p_lng: lng,
+        p_source: "cep_aberto",
+        p_precision: "postcode_centroid",
+      });
+      if (upErr) console.error("cep_geo_upsert falhou:", upErr.message);
+    }
+
+    return json({
+      resolved: true,
+      lat,
+      lng,
+      precision: "postcode_centroid",
+      source: "cep_aberto",
+      cached: false,
+    });
+  } catch (err) {
+    console.error("cep-geo-resolver erro:", err instanceof Error ? err.message : String(err));
+    return json({ resolved: false, error: "erro interno" }, 500);
+  }
+});


### PR DESCRIPTION
## O que é

**Sub-PR 3** do geocoding por CEP. Eleva o orgânico do Roteirizador-campo da qualidade Nominatim para **CEP Aberto** (gate: 91,5% cobertura · 98% na cidade certa · mediana 3,9km), com o token **server-side**. Inclui o tooling do gate e do import da carteira.

## Mudança shippable: edge-proxy `cep-geo-resolver`

O worker (modo `prospeccao`) **deixa de chamar o Nominatim no browser** e passa a invocar a edge `cep-geo-resolver`:

1. **cache `cep_geo`** (SoT) → se já resolvido, devolve na hora (preserva precisão real, ex.: rooftop);
2. **CEP Aberto** com `CEP_ABERTO_TOKEN` guardado server-side;
3. **persiste** no `cep_geo` via `cep_geo_upsert` (SECURITY DEFINER, gated, **anti-downgrade**), reencaminhando o JWT do staff.

**Miss / 429 / timeout → não-resolvido →** o pino fica no **centróide do município** (a RPC já faz COALESCE) — honestamente *aproximado*, nunca um pino errado. **Precisão > recall** (money-path: mapa de visita do vendedor).

**Nominatim sai do caminho do CEP** (o gate provou que devolve lixo p/ CEP nu — 5850km); segue só no modo `equipe` (endereço completo).

### Arquivos
- `src/lib/route/cep-resolver.ts` — `interpretarResolver` (parser **puro**, guard money-path: sem coerção string→número, só adota `lat/lng` finitos). **8 testes**.
- `src/hooks/useRoutePlanner.ts` — worker invoca a edge; precisão preservada no cache de sessão; pacing **1,6s** no campo (rate-limit CEP Aberto), 1,1s no equipe.
- `supabase/functions/cep-geo-resolver/index.ts` — Deno; gate `authorizeCronOrStaff` + `corsHeaders`; cadeia cache→CEP Aberto→upsert.

## Tooling (fora do CI / não-shippable)
- `scripts/cep-aberto/medir.ts` + `src/lib/cep/medicao.ts` — runner do **gate** (haversine + cobertura + amostra estratificada, TDD).
- `scripts/cep-aberto/importar-carteira.ts` — import da **carteira** (1.283 CEPs) → SQL colável idempotente (anti-downgrade).

## ✅ Verificação local
- typecheck ✅ · `eslint src` **0 errors** ✅ · **3653 testes** ✅ · build ✅
- (Os 2 lint errors locais são de `.claire/worktrees/*` de outras sessões — não existem no checkout limpo do CI.)

## 🚀 Deploy (founder, MANUAL — fora desta PR)
1. **Secret:** setar `CEP_ABERTO_TOKEN` no Supabase (Lovable).
2. **Edge:** deploy da função `cep-geo-resolver` pelo chat do Lovable.
3. **Publish** do frontend (este worker + o Sub-PR 2 #884).

> Sem (1)+(2), o campo **degrada para centróides** (não quebra). O `cep_geo` cresce com `source='cep_aberto'` — verificável por psql-ro.