### PR TITLE
fix(tint): gate de ativo no preço — não vender base/corante desativado no Omie

### DIFF
--- a/db/test-tint-get-price.sh
+++ b/db/test-tint-get-price.sh
@@ -93,7 +93,7 @@ SQL
 # ══════════════════════════════════════════════════════════════════════════════
 # ZONA 2 — APLICAR A MIGRATION REAL (Lei #1: o .sql commitado, não um stub)
 # ══════════════════════════════════════════════════════════════════════════════
-MIG="$REPO_ROOT/supabase/migrations/20260615200000_tint_get_price_base.sql"
+MIG="$REPO_ROOT/supabase/migrations/20260616120000_tint_price_gate_ativo.sql"
 P -q -f "$MIG"
 echo "migration aplicada: $(basename "$MIG")"
 
@@ -158,6 +158,24 @@ INSERT INTO public.tint_formula_itens(formula_id, corante_id, qtd_ml, ordem) VAL
 GRANT EXECUTE ON FUNCTION public.get_tint_price(uuid) TO authenticated, anon;
 SQL
 
+# Seed do GATE DE ativo (achado Codex 16/06): base/corante INATIVOS no Omie, valor congelado > 0.
+# (omie_products.ativo default é true; aqui setamos false EXPLÍCITO — é o que o gate testa.)
+P -q <<'SQL'
+INSERT INTO public.omie_products(id, valor_unitario, ativo) VALUES
+  ('b0000000-0000-0000-0000-000000000005', 500, false),  -- base INATIVA (valor > 0 congelado pós-desativação)
+  ('b0000000-0000-0000-0000-000000000006', 100, false);   -- corante c/ produto Omie INATIVO (valor > 0)
+INSERT INTO public.tint_skus(id, omie_product_id) VALUES
+  ('50000000-0000-0000-0000-000000000003','b0000000-0000-0000-0000-000000000005');  -- sku da base inativa
+INSERT INTO public.tint_corantes(id, descricao, volume_total_ml, omie_product_id) VALUES
+  ('c0000000-0000-0000-0000-000000000004','Corante c/ produto inativo', 1000, 'b0000000-0000-0000-0000-000000000006');
+INSERT INTO public.tint_formulas(id, sku_id) VALUES
+  ('f0000000-0000-0000-0000-000000000006','50000000-0000-0000-0000-000000000003'),  -- f_base_inat: base inativa + corante OK
+  ('f0000000-0000-0000-0000-000000000007','50000000-0000-0000-0000-000000000001');   -- f_cor_inat: base OK (ativa) + corante inativo
+INSERT INTO public.tint_formula_itens(formula_id, corante_id, qtd_ml, ordem) VALUES
+  ('f0000000-0000-0000-0000-000000000006','c0000000-0000-0000-0000-000000000001', 10, 1),  -- corante OK (ISOLA: o NULL vem da base inativa)
+  ('f0000000-0000-0000-0000-000000000007','c0000000-0000-0000-0000-000000000004', 10, 1);   -- corante inativo (ISOLA: a base é ativa)
+SQL
+
 
 # ══════════════════════════════════════════════════════════════════════════════
 # ZONA 4 — ASSERTS (positivo / negativo-com-SQLSTATE / RLS) — ver assert-patterns.md
@@ -177,6 +195,8 @@ F_ZERO="f0000000-0000-0000-0000-000000000002"
 F_PURA="f0000000-0000-0000-0000-000000000003"
 F_INC="f0000000-0000-0000-0000-000000000004"
 F_COR_ZERO="f0000000-0000-0000-0000-000000000005"
+F_BASE_INAT="f0000000-0000-0000-0000-000000000006"
+F_COR_INAT="f0000000-0000-0000-0000-000000000007"
 UID_STAFF="11111111-1111-1111-1111-111111111111"
 UID_CLI="22222222-2222-2222-2222-222222222222"
 # comparações numéricas (= devolve t/f) p/ não depender da formatação do numeric->text
@@ -220,6 +240,23 @@ V=$(Pq -c "SELECT (public.get_tint_price('$F_INC'::uuid)->>'corantesCompletos');
 eq "N2b corante incompleto → corantesCompletos false" "$V" "false"
 V=$(Pq -c "SELECT ((public.get_tint_price('$F_INC'::uuid)->>'custoCorantes')::numeric = 1.0);")
 eq "N2c corante incompleto → custoCorantes mostra parcial (1,00)" "$V" "t"
+
+# N5 — base INATIVA no Omie (valor>0) → baseDisponivel false, custoBase/precoFinal NULL (não vende descontinuado)
+V=$(Pq -c "SELECT (public.get_tint_price('$F_BASE_INAT'::uuid)->>'baseDisponivel');")
+eq "N5 base inativa → baseDisponivel false" "$V" "false"
+V=$(Pq -c "SELECT (public.get_tint_price('$F_BASE_INAT'::uuid)->>'custoBase') IS NULL;")
+eq "N5b base inativa → custoBase NULL (não fabrica preço de produto morto)" "$V" "t"
+V=$(Pq -c "SELECT (public.get_tint_price('$F_BASE_INAT'::uuid)->>'precoFinal') IS NULL;")
+eq "N5c base inativa → precoFinal NULL (não vende base desativada no Omie)" "$V" "t"
+
+# N6 — corante cujo produto Omie está INATIVO → custo indisponível → corantesCompletos false, precoFinal NULL.
+#      A base do F_COR_INAT é ATIVA (ISOLA: o NULL vem do corante, não da base).
+V=$(Pq -c "SELECT (public.get_tint_price('$F_COR_INAT'::uuid)->>'baseDisponivel');")
+eq "N6 corante inativo → baseDisponivel true (a base existe e está ativa)" "$V" "true"
+V=$(Pq -c "SELECT (public.get_tint_price('$F_COR_INAT'::uuid)->>'corantesCompletos');")
+eq "N6b corante inativo → corantesCompletos false" "$V" "false"
+V=$(Pq -c "SELECT (public.get_tint_price('$F_COR_INAT'::uuid)->>'precoFinal') IS NULL;")
+eq "N6c corante inativo → precoFinal NULL (custo de insumo desativado é suspeito)" "$V" "t"
 
 # P3 — itensCorantes (a receita) só para staff (hardening preservado)
 ST=$(Pq -c "SET test.uid='$UID_STAFF'; SET ROLE authenticated; SELECT jsonb_array_length(public.get_tint_price('$F_OK'::uuid)->'itensCorantes');" | tail -1)
@@ -325,6 +362,52 @@ END; $fn$;
 SQL
 V=$(Pq -c "SELECT (public.get_tint_price('$F_PURA'::uuid)->>'precoFinal') IS NULL;")
 if [ "$V" = "f" ]; then ok "F4 fail-closed sabotado → N3 ficou vermelho (assert pega receita vazia)"; else bad "F4 sabotei o fail-closed e N3 seguiu verde → N3 é fraco"; fi
+P -q -f "$MIG"   # restaura
+
+# F5 — SABOTA o gate da BASE: tira o "AND v_base_ativo" → a base inativa volta a precificar.
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION public.get_tint_price(p_formula_id uuid)
+ RETURNS jsonb LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path TO 'public'
+AS $fn$
+DECLARE v_bp numeric; v_bd boolean; v_cb numeric; v_cc numeric; v_comp boolean;
+BEGIN
+  SELECT op.valor_unitario INTO v_bp FROM tint_formulas f
+  LEFT JOIN tint_skus s ON s.id=f.sku_id LEFT JOIN omie_products op ON op.id=s.omie_product_id WHERE f.id=p_formula_id;
+  v_bd := v_bp IS NOT NULL AND v_bp>0;   -- SABOTADO: sem AND v_base_ativo (ignora ativo da base)
+  v_cb := CASE WHEN v_bd THEN v_bp ELSE NULL END;
+  WITH calc AS (
+    SELECT (COALESCE(op.valor_unitario,0)>0 AND COALESCE(op.ativo,false) AND c.volume_total_ml>0) AS cd,
+           CASE WHEN COALESCE(op.valor_unitario,0)>0 AND COALESCE(op.ativo,false) AND c.volume_total_ml>0 THEN fi.qtd_ml*op.valor_unitario/c.volume_total_ml ELSE 0 END AS ci
+    FROM tint_formula_itens fi LEFT JOIN tint_corantes c ON c.id=fi.corante_id LEFT JOIN omie_products op ON op.id=c.omie_product_id WHERE fi.formula_id=p_formula_id)
+  SELECT COALESCE(SUM(ci),0), COALESCE(bool_and(cd),false) INTO v_cc, v_comp FROM calc;
+  RETURN jsonb_build_object('precoFinal', CASE WHEN v_bd AND v_comp THEN v_cb+v_cc ELSE NULL END);
+END; $fn$;
+SQL
+V=$(Pq -c "SELECT (public.get_tint_price('$F_BASE_INAT'::uuid)->>'precoFinal') IS NULL;")
+if [ "$V" = "f" ]; then ok "F5 gate-base sabotado → N5 ficou vermelho (base inativa voltou a precificar)"; else bad "F5 sabotei o gate da base e N5 seguiu verde → N5 é fraco"; fi
+P -q -f "$MIG"   # restaura
+
+# F6 — SABOTA o gate do CORANTE: tira o "AND COALESCE(op.ativo,false)" → o corante inativo volta a contar.
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION public.get_tint_price(p_formula_id uuid)
+ RETURNS jsonb LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path TO 'public'
+AS $fn$
+DECLARE v_bp numeric; v_ba boolean; v_bd boolean; v_cb numeric; v_cc numeric; v_comp boolean;
+BEGIN
+  SELECT op.valor_unitario, op.ativo INTO v_bp, v_ba FROM tint_formulas f
+  LEFT JOIN tint_skus s ON s.id=f.sku_id LEFT JOIN omie_products op ON op.id=s.omie_product_id WHERE f.id=p_formula_id;
+  v_bd := v_bp IS NOT NULL AND v_bp>0 AND v_ba;   -- gate da base PRESERVADO (isola o do corante)
+  v_cb := CASE WHEN v_bd THEN v_bp ELSE NULL END;
+  WITH calc AS (
+    SELECT (COALESCE(op.valor_unitario,0)>0 AND c.volume_total_ml>0) AS cd,   -- SABOTADO: sem AND COALESCE(op.ativo,false)
+           CASE WHEN COALESCE(op.valor_unitario,0)>0 AND c.volume_total_ml>0 THEN fi.qtd_ml*op.valor_unitario/c.volume_total_ml ELSE 0 END AS ci
+    FROM tint_formula_itens fi LEFT JOIN tint_corantes c ON c.id=fi.corante_id LEFT JOIN omie_products op ON op.id=c.omie_product_id WHERE fi.formula_id=p_formula_id)
+  SELECT COALESCE(SUM(ci),0), COALESCE(bool_and(cd),false) INTO v_cc, v_comp FROM calc;
+  RETURN jsonb_build_object('precoFinal', CASE WHEN v_bd AND v_comp THEN v_cb+v_cc ELSE NULL END);
+END; $fn$;
+SQL
+V=$(Pq -c "SELECT (public.get_tint_price('$F_COR_INAT'::uuid)->>'precoFinal') IS NULL;")
+if [ "$V" = "f" ]; then ok "F6 gate-corante sabotado → N6 ficou vermelho (corante inativo voltou a contar)"; else bad "F6 sabotei o gate do corante e N6 seguiu verde → N6 é fraco"; fi
 P -q -f "$MIG"   # restaura
 
 

--- a/db/test-tint-get-prices.sh
+++ b/db/test-tint-get-prices.sh
@@ -52,8 +52,19 @@ CREATE TABLE public.tint_formulas (id uuid PRIMARY KEY, sku_id uuid);
 CREATE TABLE public.tint_formula_itens (id uuid PRIMARY KEY DEFAULT gen_random_uuid(), formula_id uuid, corante_id uuid, qtd_ml numeric, ordem int);
 SQL
 
+# A migration de gate recria as DUAS RPCs: get_tint_prices (testada aqui) E get_tint_price
+# (single, plpgsql, referencia app_role/has_role/auth.uid no corpo). Stub mínimo p/ o arquivo
+# aplicar limpo — a single não é exercida neste harness, mas o CREATE dela vem junto.
+P -q <<'SQL'
+CREATE TYPE public.app_role AS ENUM ('customer','employee','master');
+CREATE TABLE public.user_roles (user_id uuid, role public.app_role);
+CREATE FUNCTION public.has_role(_uid uuid, _role public.app_role) RETURNS boolean
+  LANGUAGE sql STABLE AS $f$ SELECT EXISTS(SELECT 1 FROM public.user_roles WHERE user_id=_uid AND role=_role) $f$;
+CREATE OR REPLACE FUNCTION auth.uid() RETURNS uuid LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.uid', true), '')::uuid $f$;
+SQL
+
 # ── ZONA 2 — aplicar a migration REAL ──
-MIG="$REPO_ROOT/supabase/migrations/20260615210000_tint_get_prices_batch.sql"
+MIG="$REPO_ROOT/supabase/migrations/20260616120000_tint_price_gate_ativo.sql"
 P -q -f "$MIG"
 echo "migration aplicada: $(basename "$MIG")"
 
@@ -91,6 +102,23 @@ INSERT INTO public.tint_formula_itens(formula_id, corante_id, qtd_ml, ordem) VAL
 GRANT EXECUTE ON FUNCTION public.get_tint_prices(uuid[]) TO authenticated, anon;
 SQL
 
+# Seed do GATE DE ativo (achado Codex 16/06): base/corante INATIVOS no Omie, valor congelado > 0.
+P -q <<'SQL'
+INSERT INTO public.omie_products(id, valor_unitario, ativo) VALUES
+  ('b0000000-0000-0000-0000-000000000005', 500, false),  -- base INATIVA (valor > 0)
+  ('b0000000-0000-0000-0000-000000000006', 100, false);   -- corante c/ produto Omie INATIVO (valor > 0)
+INSERT INTO public.tint_skus(id, omie_product_id) VALUES
+  ('50000000-0000-0000-0000-000000000003','b0000000-0000-0000-0000-000000000005');
+INSERT INTO public.tint_corantes(id, descricao, volume_total_ml, omie_product_id) VALUES
+  ('c0000000-0000-0000-0000-000000000004','Corante c/ produto inativo', 1000, 'b0000000-0000-0000-0000-000000000006');
+INSERT INTO public.tint_formulas(id, sku_id) VALUES
+  ('f0000000-0000-0000-0000-000000000006','50000000-0000-0000-0000-000000000003'),  -- f_base_inat: base inativa + corante OK
+  ('f0000000-0000-0000-0000-000000000007','50000000-0000-0000-0000-000000000001');   -- f_cor_inat: base ativa + corante inativo
+INSERT INTO public.tint_formula_itens(formula_id, corante_id, qtd_ml, ordem) VALUES
+  ('f0000000-0000-0000-0000-000000000006','c0000000-0000-0000-0000-000000000001', 10, 1),  -- corante OK (isola: NULL vem da base)
+  ('f0000000-0000-0000-0000-000000000007','c0000000-0000-0000-0000-000000000004', 10, 1);   -- corante inativo (isola: base ativa)
+SQL
+
 # ── ZONA 4 — asserts ──
 echo "── asserts ──"
 F_OK="f0000000-0000-0000-0000-000000000001"
@@ -98,6 +126,8 @@ F_ZERO="f0000000-0000-0000-0000-000000000002"
 F_PURA="f0000000-0000-0000-0000-000000000003"
 F_INC="f0000000-0000-0000-0000-000000000004"
 F_COR_ZERO="f0000000-0000-0000-0000-000000000005"
+F_BASE_INAT="f0000000-0000-0000-0000-000000000006"
+F_COR_INAT="f0000000-0000-0000-0000-000000000007"
 GHOST="99999999-9999-9999-9999-999999999999"
 
 # P1 — single id no batch → precoFinal = base + corantes
@@ -128,6 +158,22 @@ V=$(Pq -c "SELECT (public.get_tint_prices(ARRAY['$F_PURA']::uuid[]) -> '$F_PURA'
 eq "N3 receita vazia → corantesCompletos false" "$V" "false"
 V=$(Pq -c "SELECT ((public.get_tint_prices(ARRAY['$F_INC']::uuid[]) -> '$F_INC' ->> 'custoCorantes')::numeric = 1.0);")
 eq "N2c corante incompleto → custoCorantes parcial (1,00)" "$V" "t"
+
+# N5 — base INATIVA no Omie (valor>0) → baseDisponivel false, custoBase/precoFinal NULL (não vende descontinuado)
+V=$(Pq -c "SELECT (public.get_tint_prices(ARRAY['$F_BASE_INAT']::uuid[]) -> '$F_BASE_INAT' ->> 'baseDisponivel');")
+eq "N5 base inativa → baseDisponivel false" "$V" "false"
+V=$(Pq -c "SELECT (public.get_tint_prices(ARRAY['$F_BASE_INAT']::uuid[]) -> '$F_BASE_INAT' ->> 'custoBase') IS NULL;")
+eq "N5b base inativa → custoBase NULL" "$V" "t"
+V=$(Pq -c "SELECT (public.get_tint_prices(ARRAY['$F_BASE_INAT']::uuid[]) -> '$F_BASE_INAT' ->> 'precoFinal') IS NULL;")
+eq "N5c base inativa → precoFinal NULL (não vende base desativada no Omie)" "$V" "t"
+
+# N6 — corante c/ produto Omie INATIVO → corantesCompletos false, precoFinal NULL (base é ativa → isola)
+V=$(Pq -c "SELECT (public.get_tint_prices(ARRAY['$F_COR_INAT']::uuid[]) -> '$F_COR_INAT' ->> 'baseDisponivel');")
+eq "N6 corante inativo → baseDisponivel true (base ativa)" "$V" "true"
+V=$(Pq -c "SELECT (public.get_tint_prices(ARRAY['$F_COR_INAT']::uuid[]) -> '$F_COR_INAT' ->> 'corantesCompletos');")
+eq "N6b corante inativo → corantesCompletos false" "$V" "false"
+V=$(Pq -c "SELECT (public.get_tint_prices(ARRAY['$F_COR_INAT']::uuid[]) -> '$F_COR_INAT' ->> 'precoFinal') IS NULL;")
+eq "N6c corante inativo → precoFinal NULL" "$V" "t"
 
 # Bordas do batch
 V=$(Pq -c "SELECT public.get_tint_prices(ARRAY[]::uuid[]) = '{}'::jsonb;")
@@ -238,6 +284,42 @@ $fn$;
 SQL
 V=$(Pq -c "SELECT (public.get_tint_prices(ARRAY['$F_PURA']::uuid[]) -> '$F_PURA' ->> 'precoFinal') IS NULL;")
 if [ "$V" = "f" ]; then ok "F5 fail-closed sabotado → PB[F_PURA] vermelho (receita vazia deixou de ser NULL)"; else bad "F5 sabotei o fail-closed e seguiu verde → fraco"; fi
+apply_real
+
+# F6 — SABOTA o gate da BASE: tira o "AND COALESCE(op.ativo,false)" da base → base inativa precifica.
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION public.get_tint_prices(p_formula_ids uuid[])
+ RETURNS jsonb LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO 'public'
+AS $fn$
+  WITH bases AS (SELECT f.id fid, op.valor_unitario bp, (op.valor_unitario IS NOT NULL AND op.valor_unitario>0) bd  -- SABOTADO: sem ativo
+    FROM tint_formulas f LEFT JOIN tint_skus s ON s.id=f.sku_id LEFT JOIN omie_products op ON op.id=s.omie_product_id WHERE f.id=ANY(p_formula_ids)),
+  cor AS (SELECT fi.formula_id, COALESCE(SUM(CASE WHEN COALESCE(op.valor_unitario,0)>0 AND COALESCE(op.ativo,false) AND c.volume_total_ml>0 THEN fi.qtd_ml*op.valor_unitario/c.volume_total_ml ELSE 0 END),0) cc,
+            COALESCE(bool_and(COALESCE(op.valor_unitario,0)>0 AND COALESCE(op.ativo,false) AND c.volume_total_ml>0), false) comp
+    FROM tint_formula_itens fi LEFT JOIN tint_corantes c ON c.id=fi.corante_id LEFT JOIN omie_products op ON op.id=c.omie_product_id WHERE fi.formula_id=ANY(p_formula_ids) GROUP BY fi.formula_id)
+  SELECT COALESCE(jsonb_object_agg(b.fid, jsonb_build_object('precoFinal', CASE WHEN b.bd AND COALESCE(co.comp,false) THEN b.bp+COALESCE(co.cc,0) ELSE NULL END)),'{}'::jsonb)
+  FROM bases b LEFT JOIN cor co ON co.formula_id=b.fid;
+$fn$;
+SQL
+V=$(Pq -c "SELECT (public.get_tint_prices(ARRAY['$F_BASE_INAT']::uuid[]) -> '$F_BASE_INAT' ->> 'precoFinal') IS NULL;")
+if [ "$V" = "f" ]; then ok "F6 gate-base sabotado → N5 vermelho (base inativa voltou a precificar)"; else bad "F6 sabotei o gate da base e N5 seguiu verde → fraco"; fi
+apply_real
+
+# F7 — SABOTA o gate do CORANTE: tira o "AND COALESCE(op.ativo,false)" do corante → corante inativo conta.
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION public.get_tint_prices(p_formula_ids uuid[])
+ RETURNS jsonb LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO 'public'
+AS $fn$
+  WITH bases AS (SELECT f.id fid, op.valor_unitario bp, (op.valor_unitario IS NOT NULL AND op.valor_unitario>0 AND COALESCE(op.ativo,false)) bd
+    FROM tint_formulas f LEFT JOIN tint_skus s ON s.id=f.sku_id LEFT JOIN omie_products op ON op.id=s.omie_product_id WHERE f.id=ANY(p_formula_ids)),
+  cor AS (SELECT fi.formula_id, COALESCE(SUM(CASE WHEN COALESCE(op.valor_unitario,0)>0 AND c.volume_total_ml>0 THEN fi.qtd_ml*op.valor_unitario/c.volume_total_ml ELSE 0 END),0) cc,  -- SABOTADO: sem ativo
+            COALESCE(bool_and(COALESCE(op.valor_unitario,0)>0 AND c.volume_total_ml>0), false) comp
+    FROM tint_formula_itens fi LEFT JOIN tint_corantes c ON c.id=fi.corante_id LEFT JOIN omie_products op ON op.id=c.omie_product_id WHERE fi.formula_id=ANY(p_formula_ids) GROUP BY fi.formula_id)
+  SELECT COALESCE(jsonb_object_agg(b.fid, jsonb_build_object('precoFinal', CASE WHEN b.bd AND COALESCE(co.comp,false) THEN b.bp+COALESCE(co.cc,0) ELSE NULL END)),'{}'::jsonb)
+  FROM bases b LEFT JOIN cor co ON co.formula_id=b.fid;
+$fn$;
+SQL
+V=$(Pq -c "SELECT (public.get_tint_prices(ARRAY['$F_COR_INAT']::uuid[]) -> '$F_COR_INAT' ->> 'precoFinal') IS NULL;")
+if [ "$V" = "f" ]; then ok "F7 gate-corante sabotado → N6 vermelho (corante inativo voltou a contar)"; else bad "F7 sabotei o gate do corante e N6 seguiu verde → fraco"; fi
 apply_real
 
 # ── veredito ──

--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,10 +21,10 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **246** custom migrations totais
-- **904** objetos esperados (criados por estas migrations)
+- **247** custom migrations totais
+- **906** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
-  - `function`: 258
+  - `function`: 260
   - `rls_policy`: 209
   - `index`: 178
   - `cron_job`: 106
@@ -2139,6 +2139,13 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 ### `20260616020000_fix_aging_views_status_vocab.sql`
 
 > _Nenhum objeto extraído via regex._ Migration provavelmente é `ALTER TABLE` / `UPDATE` / `INSERT` / RLS-only. Validar manualmente.
+
+### `20260616120000_tint_price_gate_ativo.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `public.get_tint_price` | — |
+| `function` | `public.get_tint_prices` | — |
 
 ## Próximos passos quando algo der `❌`
 

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 246
+-- Total de custom migrations: 247
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -265,7 +265,8 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260615200000', 'tint_get_price_base', '20260615200000_tint_get_price_base.sql'),
   ('20260615210000', 'reposicao_auto_aprovacao_v2', '20260615210000_reposicao_auto_aprovacao_v2.sql'),
   ('20260615210000', 'tint_get_prices_batch', '20260615210000_tint_get_prices_batch.sql'),
-  ('20260616020000', 'fix_aging_views_status_vocab', '20260616020000_fix_aging_views_status_vocab.sql')
+  ('20260616020000', 'fix_aging_views_status_vocab', '20260616020000_fix_aging_views_status_vocab.sql'),
+  ('20260616120000', 'tint_price_gate_ativo', '20260616120000_tint_price_gate_ativo.sql')
 )
 SELECT
   e.version,
@@ -1187,7 +1188,9 @@ WITH expected_objects (migration, kind, schema_name, object_name, parent_name) A
   ('reposicao_auto_aprovacao_v2', 'index', 'public', 'reposicao_auto_aprovacao_log_criado_em', 'reposicao_auto_aprovacao_log'),
   ('reposicao_auto_aprovacao_v2', 'function', 'public', 'reposicao_pedido_auto_aprovavel', ''),
   ('reposicao_auto_aprovacao_v2', 'function', 'public', 'reposicao_alerta_pedido_minimo_tick', ''),
-  ('tint_get_prices_batch', 'function', 'public', 'get_tint_prices', '')
+  ('tint_get_prices_batch', 'function', 'public', 'get_tint_prices', ''),
+  ('tint_price_gate_ativo', 'function', 'public', 'get_tint_price', ''),
+  ('tint_price_gate_ativo', 'function', 'public', 'get_tint_prices', '')
 )
 SELECT
   e.migration,

--- a/src/components/tintColorSelect/SelectedFormulaCard.tsx
+++ b/src/components/tintColorSelect/SelectedFormulaCard.tsx
@@ -23,6 +23,7 @@ const MOTIVO_SEM_PRECO: Record<SemPrecoMotivo, string> = {
   base: 'A base não tem preço cadastrado no Omie. Ajuste o produto no Omie para vender esta cor.',
   corante: 'Falta o custo de um corante no Omie. Avise o tintométrico para vincular o corante.',
   receita: 'A receita desta cor está incompleta. Avise o tintométrico.',
+  indisponivel: 'Não foi possível calcular o preço agora (motor de preço indisponível). Tente de novo; se persistir, avise o suporte.',
 };
 
 interface SelectedFormulaCardProps {
@@ -223,7 +224,7 @@ export function SelectedFormulaCard({
             <AlertTriangle className="w-5 h-5 text-status-warning shrink-0 mt-0.5" />
             <div>
               <p className="text-sm font-semibold text-status-warning-foreground">Sem preço para esta cor</p>
-              <p className="text-xs text-status-warning mt-1">{MOTIVO_SEM_PRECO[motivoSemPreco ?? 'receita']}</p>
+              <p className="text-xs text-status-warning mt-1">{MOTIVO_SEM_PRECO[motivoSemPreco ?? 'indisponivel']}</p>
             </div>
           </div>
         )}

--- a/src/components/tintColorSelect/useTintColorSelect.ts
+++ b/src/components/tintColorSelect/useTintColorSelect.ts
@@ -202,7 +202,7 @@ export function useTintColorSelect({ product, open, customerUserId, initialSearc
   const globalColorExists = globalColorData?.colorExists ?? false;
 
   // Pricing breakdown for selected formula (motor honesto get_tint_price)
-  const { data: pricing, isLoading: pricingLoading } = useTintPricing(selectedFormula?.id || null);
+  const { data: pricing, isLoading: pricingLoading, isError: pricingError } = useTintPricing(selectedFormula?.id || null);
 
   // Last practiced price for this color+base for the customer
   const { data: lastPracticedPrice, isLoading: loadingLastPrice } = useQuery({
@@ -341,10 +341,17 @@ export function useTintColorSelect({ product, open, customerUserId, initialSearc
   // antes de saber. A UI mostra "calculando" e segura o "Adicionar".
   const precoCarregando = !!selectedFormula && (pricingLoading || loadingLastPrice);
 
+  // A RPC de preço pode FALHAR (erro/permissão/runtime) e o hook devolve pricing null igual a
+  // "carregando". Sem distinguir, a seleção cairia no CSV legado/preço-cliente e venderia base/
+  // corante inativo que a RPC barra. Fail-closed: fórmula selecionada + parou de carregar + a RPC
+  // não confirmou breakdown (erro ou sem dado) ⇒ motor falhou ⇒ sem preço (regra 0 de select-price).
+  const motorFalhou = !!selectedFormula && !pricingLoading && (pricingError || pricing == null);
+
   const selection = selectTintPrice({
     lastPracticedPrice: lastPracticedPrice?.price ?? null,
     precoCsv: rawCsv,
     pricing: pricing ?? null,
+    motorFalhou,
   });
 
   // Qualquer "sem preço confiável" (base ausente/zero ex. PRD03657, corante sem custo, receita

--- a/src/hooks/useTintPricing.ts
+++ b/src/hooks/useTintPricing.ts
@@ -23,8 +23,11 @@ export function useTintPricing(formulaId: string | null) {
       const { data, error } = await supabase
         .rpc('get_tint_price' as never, { p_formula_id: formulaId } as never);
 
-      if (error || !data) return null;
-      return data as unknown as TintPriceBreakdown;
+      // Erro real (rede/permissão/runtime) → PROPAGA (throw): react-query expõe isError e o balcão
+      // fail-closa (sem preço) em vez de mascarar como null e cair no CSV legado — o que venderia
+      // base/corante inativo que a RPC barra. A RPC sempre devolve objeto p/ fórmula válida.
+      if (error) throw error;
+      return (data ?? null) as unknown as TintPriceBreakdown | null;
     },
   });
 }

--- a/src/lib/tint/__tests__/compute-price.test.ts
+++ b/src/lib/tint/__tests__/compute-price.test.ts
@@ -161,4 +161,25 @@ describe('computeTintPrice — a base entra no preço (Passo 1, money-path)', ()
     const r = computeTintPrice(items, corantes, omie, 449.9);
     expect(r.precoFinal).toBeCloseTo(563.44, 2);
   });
+
+  it('base com preço mas INATIVA no Omie (baseAtiva=false) → indisponível, precoFinal null (gate de ativo)', () => {
+    const items = [{ corante_id: 'c1', qtd_ml: 10 }];
+    const corantes = [corante('c1', 'Amarelo', 1000, 'o1')];
+    const omie: TintOmiePriceMap = { o1: { valor_unitario: 100, ativo: true } };
+    const r = computeTintPrice(items, corantes, omie, 449.9, false); // base desativada no Omie
+    expect(r.baseDisponivel).toBe(false);
+    expect(r.custoBase).toBeNull();
+    expect(r.precoFinal).toBeNull(); // não vende base que a empresa desativou
+  });
+
+  it('corante cujo produto Omie está INATIVO (ativo=false) → custo indisponível, precoFinal null', () => {
+    const items = [{ corante_id: 'c1', qtd_ml: 10 }];
+    const corantes = [corante('c1', 'Corante inativo', 1000, 'o1')];
+    const omie: TintOmiePriceMap = { o1: { valor_unitario: 100, ativo: false } };
+    const r = computeTintPrice(items, corantes, omie, 449.9); // base ativa (default)
+    expect(r.itensCorantes[0].custoDisponivel).toBe(false);
+    expect(r.corantesCompletos).toBe(false);
+    expect(r.precoFinal).toBeNull();
+    expect(r.baseDisponivel).toBe(true); // base existe e ativa → isola: o NULL veio do corante
+  });
 });

--- a/src/lib/tint/__tests__/select-price.test.ts
+++ b/src/lib/tint/__tests__/select-price.test.ts
@@ -137,6 +137,20 @@ describe('selectTintPrice — seleção honesta da fonte de preço (Passo 2, mon
     expect(r.source).toBeNull();
     expect(r.precoSemDesconto).toBeNull();
   });
+
+  it('motor falhou (RPC erro, ≠ carregando) → sem preço, ignora CSV E cliente (fail-closed, regra 0)', () => {
+    // A RPC pode estar barrando base/corante inativo justamente quando falha → não cair no importado.
+    const r = selectTintPrice({ lastPracticedPrice: 200, precoCsv: 180, pricing: null, motorFalhou: true });
+    expect(r.source).toBeNull();
+    expect(r.precoSemDesconto).toBeNull();
+    expect(r.motivoSemPreco).toBe('indisponivel');
+  });
+
+  it('motorFalhou=false com pricing null + CSV → ainda usa o CSV (loading ≠ falha, não regride o Passo 2)', () => {
+    const r = selectTintPrice({ lastPracticedPrice: null, precoCsv: 180, pricing: null, motorFalhou: false });
+    expect(r.source).toBe('tabela');
+    expect(r.precoSemDesconto).toBe(180);
+  });
 });
 
 describe('selectAltPrice — preço de embalagem alternativa (1b)', () => {

--- a/src/lib/tint/compute-price.ts
+++ b/src/lib/tint/compute-price.ts
@@ -43,22 +43,27 @@ export interface TintCoranteInput {
   omie_product_id: string | null;
 }
 
-/** `valor_unitario` do produto Omie, indexado por `omie_product_id`. */
-export type TintOmiePriceMap = Record<string, { valor_unitario: number }>;
+/** `valor_unitario` + status `ativo` do produto Omie, indexado por `omie_product_id`.
+ *  `ativo` omitido = tratado como ativo (default da coluna omie_products.ativo é `true`). */
+export type TintOmiePriceMap = Record<string, { valor_unitario: number; ativo?: boolean }>;
 
 /**
  * Preço de uma fórmula = base + Σ (qtd_ml × valor_unitario / volume_total_ml).
  * @param precoBase `valor_unitario` Omie da base (do SKU da fórmula); `null`/`<=0` = indisponível.
+ * @param baseAtiva a base está ATIVA no Omie? `false` = produto descontinuado → indisponível,
+ *   mesmo com preço > 0. Espelha o gate de ativo da RPC get_tint_price (não vender produto
+ *   que a empresa desativou no Omie). Default `true` para compat dos testes legados.
  *
- * `precoFinal` só é número quando a base existe E todos os corantes têm custo.
- * Senão é `null` (degradação honesta), enquanto `custoCorantes` ainda traz a
- * soma parcial para exibição.
+ * `precoFinal` só é número quando a base existe E está ATIVA E todos os corantes têm custo E
+ * estão ATIVOS. Senão é `null` (degradação honesta), enquanto `custoCorantes` ainda traz a soma
+ * parcial para exibição. Oráculo de paridade da RPC — manter o gate de ativo sincronizado aqui.
  */
 export function computeTintPrice(
   items: TintFormulaItemInput[],
   corantes: TintCoranteInput[],
   omieProducts: TintOmiePriceMap,
   precoBase: number | null,
+  baseAtiva: boolean = true,
 ): TintPriceBreakdown {
   const itensCorantes: TintCoranteItem[] = items.map((item) => {
     const corante = corantes.find((c) => c.id === item.corante_id);
@@ -68,7 +73,8 @@ export function computeTintPrice(
 
     const omie = corante.omie_product_id ? omieProducts[corante.omie_product_id] : null;
     // valor_unitario > 0 (não só presente): preço 0/negativo é dado inválido, não custo real.
-    const custoDisponivel = !!omie && omie.valor_unitario > 0 && !!corante.volume_total_ml && corante.volume_total_ml > 0;
+    // omie.ativo !== false: corante desativado no Omie tem custo suspeito → indisponível (gate de ativo).
+    const custoDisponivel = !!omie && omie.valor_unitario > 0 && omie.ativo !== false && !!corante.volume_total_ml && corante.volume_total_ml > 0;
     const custoPorMl = custoDisponivel ? omie!.valor_unitario / corante.volume_total_ml! : 0;
     const custoItem = item.qtd_ml * custoPorMl;
 
@@ -86,7 +92,7 @@ export function computeTintPrice(
   // Cobrar só a base subfaturaria (confirmado em prod). Fail closed → precoFinal null.
   const corantesCompletos = itensCorantes.length > 0 && itensCorantes.every((i) => i.custoDisponivel);
 
-  const baseDisponivel = precoBase != null && precoBase > 0;
+  const baseDisponivel = precoBase != null && precoBase > 0 && baseAtiva;
   const custoBase = baseDisponivel ? precoBase : null;
   const precoFinal = baseDisponivel && corantesCompletos ? custoBase! + custoCorantes : null;
 

--- a/src/lib/tint/select-price.ts
+++ b/src/lib/tint/select-price.ts
@@ -11,6 +11,9 @@
 // Omie mais novo, ou dado a revisar): nessas, manter o CSV (não baixar por engano).
 //
 // Regras (money-path — precisão > recall, nunca fabricar, nunca baixar silencioso):
+//  0. Motor (RPC) FALHOU/não respondeu e NÃO está mais carregando → SEM PREÇO (fail-closed):
+//     não cair no CSV/cliente quando a fronteira honesta não confirmou (a RPC pode estar barrando
+//     base/corante inativo ou zerado). Diferente de "carregando" (aí o consumidor segura a venda).
 //  1. Base ausente/zero num produto vendável → SEM PREÇO, mesmo havendo CSV/cliente
 //     (o CSV também subfatura aqui; ex.: PRD03657). Corrigir no Omie.
 //  2. Preço do cliente (último praticado) vence — é acordo comercial explícito.
@@ -28,7 +31,7 @@ export type TintPriceBreakdownLite = Omit<TintPriceBreakdown, 'itensCorantes'>;
 
 export type TintPriceSource = 'cliente' | 'tabela' | 'calculado';
 /** Por que não há preço — alimenta a mensagem honesta na UI. */
-export type SemPrecoMotivo = 'base' | 'corante' | 'receita';
+export type SemPrecoMotivo = 'base' | 'corante' | 'receita' | 'indisponivel';
 
 export interface TintPriceSelection {
   /** Fonte escolhida; NULL = sem preço (não vender com número fabricado). */
@@ -70,8 +73,18 @@ export function selectTintPrice(input: {
   precoCsv: number | null;
   /** Breakdown do motor honesto; null enquanto carrega. */
   pricing: TintPriceBreakdownLite | null;
+  /** A RPC do motor já respondeu mas FALHOU (erro/permissão/runtime) ou não trouxe breakdown, e
+   *  NÃO está mais carregando. Fail-closed: aqui NÃO cair no CSV legado / preço-cliente — a RPC é a
+   *  fronteira honesta (pode estar barrando base/corante inativo); número velho subfatura ou vende
+   *  produto desativado. ≠ `pricing == null` por loading (nesse caso o consumidor segura a venda). */
+  motorFalhou?: boolean;
 }): TintPriceSelection {
   const { lastPracticedPrice, pricing } = input;
+
+  // 0. Motor falhou (≠ carregando) → SEM PREÇO, mesmo havendo CSV/cliente. A RPC não confirmou o
+  //    preço honesto; cair no importado aqui venderia justamente o que a RPC poderia estar barrando.
+  if (input.motorFalhou) return semPreco('indisponivel');
+
   const csv = input.precoCsv != null && input.precoCsv > 0 ? arredonda(input.precoCsv) : null;
   const calc = pricing?.precoFinal != null ? arredonda(pricing.precoFinal) : null;
 

--- a/supabase/migrations/20260616120000_tint_price_gate_ativo.sql
+++ b/supabase/migrations/20260616120000_tint_price_gate_ativo.sql
@@ -1,0 +1,143 @@
+-- Passo 1c do flip tintométrico: GATE DE `ativo` no preço (achado adversarial Codex, 16/06).
+--
+-- Furo: get_tint_price/get_tint_prices marcavam a base "disponível" só por
+-- valor_unitario > 0 — IGNORAVAM omie_products.ativo. Uma base (ou corante) que a
+-- empresa DESATIVOU no Omie, mas que ainda tem valor_unitario congelado > 0,
+-- seguia precificada e VENDÁVEL no balcão. O sync TRAZ produtos inativos
+-- (oben 2.757 / colacor 2.117) e desativar NÃO zera o valor (3.606 inativos com
+-- valor > 0 hoje) — o furo é LATENTE, não teórico: a 1ª base/corante tintométrico
+-- desativado com fórmula viva passaria a vender produto morto, em silêncio.
+--
+-- Correção (fronteira money-path única — o front herda "sem preço" via
+-- src/lib/tint/select-price.ts: precoFinal NULL => "Adicionar" desabilita): base e
+-- corante só entram no preço se o produto Omie estiver ATIVO. Mesma régua de
+-- "ausente != zero": inativo => baseDisponivel / custo_disponivel = false =>
+-- precoFinal NULL (fail closed, self-healing no Omie), nunca o preço de um produto
+-- descontinuado. O gate do corante é simetria com a blindagem de preço ≤0 já feita
+-- (mesma família: custo de insumo não-confiável).
+--
+-- Impacto na aplicação: ZERO regressão — medido em prod, 0 fórmulas vivas têm base
+-- OU corante inativo hoje; é blindagem preventiva, não muda nenhum preço atual.
+-- Espelha o helper TS src/lib/tint/compute-price.ts (manter paridade — atualizar lá).
+-- Provado em db/test-tint-get-price.sh + db/test-tint-get-prices.sh (PG17, F5/F6).
+
+CREATE OR REPLACE FUNCTION public.get_tint_price(p_formula_id uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ STABLE SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_is_staff boolean;
+  v_base_preco numeric;
+  v_base_ativo boolean;
+  v_base_disponivel boolean;
+  v_custo_base numeric;
+  v_custo_corantes numeric;
+  v_corantes_completos boolean;
+  v_preco_final numeric;
+  v_itens jsonb;
+BEGIN
+  v_is_staff := auth.uid() IS NOT NULL
+    AND (public.has_role(auth.uid(),'employee'::app_role) OR public.has_role(auth.uid(),'master'::app_role));
+
+  -- Base: preço E status do produto Omie vinculado ao SKU da fórmula.
+  SELECT op.valor_unitario, op.ativo INTO v_base_preco, v_base_ativo
+  FROM tint_formulas f
+  LEFT JOIN tint_skus s ON s.id = f.sku_id
+  LEFT JOIN omie_products op ON op.id = s.omie_product_id
+  WHERE f.id = p_formula_id;
+
+  -- Money-path: base inativa no Omie NÃO é vendável (produto descontinuado), mesmo
+  -- com valor_unitario congelado > 0. COALESCE(...,false) = paridade VERBATIM com o batch
+  -- e robustez se `ativo` virar nullable; produto ausente => v_base_preco NULL já barra
+  -- (false AND <qualquer> = false na lógica de 3 valores).
+  v_base_disponivel := v_base_preco IS NOT NULL AND v_base_preco > 0 AND COALESCE(v_base_ativo, false);
+  v_custo_base := CASE WHEN v_base_disponivel THEN v_base_preco ELSE NULL END;
+
+  -- Corantes: custo só quando o produto Omie do corante tem preço > 0, está ATIVO e
+  -- o volume é válido. COALESCE(op.ativo,false): corante sem produto Omie (op NULL via
+  -- LEFT JOIN) => indisponível (já barrado por valor=0, mas explícito).
+  WITH calc AS (
+    SELECT
+      fi.ordem,
+      COALESCE(c.descricao, '?') AS corante_descricao,
+      fi.qtd_ml,
+      (COALESCE(op.valor_unitario, 0) > 0 AND COALESCE(op.ativo, false) AND c.volume_total_ml IS NOT NULL AND c.volume_total_ml > 0) AS custo_disponivel,
+      CASE WHEN COALESCE(op.valor_unitario, 0) > 0 AND COALESCE(op.ativo, false) AND c.volume_total_ml IS NOT NULL AND c.volume_total_ml > 0
+           THEN op.valor_unitario / c.volume_total_ml ELSE 0 END AS custo_por_ml,
+      CASE WHEN COALESCE(op.valor_unitario, 0) > 0 AND COALESCE(op.ativo, false) AND c.volume_total_ml IS NOT NULL AND c.volume_total_ml > 0
+           THEN fi.qtd_ml * (op.valor_unitario / c.volume_total_ml) ELSE 0 END AS custo_item
+    FROM tint_formula_itens fi
+    LEFT JOIN tint_corantes c  ON c.id = fi.corante_id
+    LEFT JOIN omie_products op ON op.id = c.omie_product_id
+    WHERE fi.formula_id = p_formula_id
+  )
+  SELECT
+    COALESCE(SUM(custo_item), 0),
+    COALESCE(bool_and(custo_disponivel), false),  -- fórmula sem itens => receita faltando (fail closed), não base pura
+    COALESCE(jsonb_agg(jsonb_build_object(
+      'coranteDescricao', corante_descricao, 'qtdMl', qtd_ml, 'custoPorMl', custo_por_ml,
+      'custoItem', custo_item, 'custoDisponivel', custo_disponivel
+    ) ORDER BY ordem), '[]'::jsonb)
+  INTO v_custo_corantes, v_corantes_completos, v_itens
+  FROM calc;
+
+  -- Money-path: só há preço quando a base existe E todos os corantes têm custo.
+  v_preco_final := CASE WHEN v_base_disponivel AND v_corantes_completos
+                        THEN v_custo_base + v_custo_corantes ELSE NULL END;
+
+  RETURN jsonb_build_object(
+    'custoBase', v_custo_base,
+    'baseDisponivel', v_base_disponivel,
+    'custoCorantes', v_custo_corantes,
+    'corantesCompletos', v_corantes_completos,
+    'precoFinal', v_preco_final,
+    'itensCorantes', CASE WHEN v_is_staff THEN v_itens ELSE '[]'::jsonb END
+  );
+END; $function$;
+
+
+-- Versão BATCH (paridade VERBATIM das regras money-path da single, incl. o gate de ativo).
+CREATE OR REPLACE FUNCTION public.get_tint_prices(p_formula_ids uuid[])
+ RETURNS jsonb
+ LANGUAGE sql
+ STABLE SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+  WITH bases AS (
+    SELECT f.id AS formula_id,
+           op.valor_unitario AS base_preco,
+           (op.valor_unitario IS NOT NULL AND op.valor_unitario > 0 AND COALESCE(op.ativo, false)) AS base_disponivel
+    FROM tint_formulas f
+    LEFT JOIN tint_skus s ON s.id = f.sku_id
+    LEFT JOIN omie_products op ON op.id = s.omie_product_id
+    WHERE f.id = ANY(p_formula_ids)
+  ),
+  corantes AS (
+    SELECT fi.formula_id,
+           COALESCE(SUM(CASE WHEN COALESCE(op.valor_unitario,0) > 0 AND COALESCE(op.ativo, false) AND c.volume_total_ml IS NOT NULL AND c.volume_total_ml > 0
+                             THEN fi.qtd_ml * op.valor_unitario / c.volume_total_ml ELSE 0 END), 0) AS custo_corantes,
+           COALESCE(bool_and(COALESCE(op.valor_unitario,0) > 0 AND COALESCE(op.ativo, false) AND c.volume_total_ml IS NOT NULL AND c.volume_total_ml > 0), false) AS corantes_completos
+    FROM tint_formula_itens fi
+    LEFT JOIN tint_corantes c  ON c.id = fi.corante_id
+    LEFT JOIN omie_products op ON op.id = c.omie_product_id
+    WHERE fi.formula_id = ANY(p_formula_ids)
+    GROUP BY fi.formula_id
+  )
+  SELECT COALESCE(jsonb_object_agg(b.formula_id, jsonb_build_object(
+    'custoBase', CASE WHEN b.base_disponivel THEN b.base_preco ELSE NULL END,
+    'baseDisponivel', b.base_disponivel,
+    'custoCorantes', COALESCE(co.custo_corantes, 0),
+    'corantesCompletos', COALESCE(co.corantes_completos, false),
+    'precoFinal', CASE WHEN b.base_disponivel AND COALESCE(co.corantes_completos, false)
+                       THEN b.base_preco + COALESCE(co.custo_corantes, 0) ELSE NULL END
+  )), '{}'::jsonb)
+  FROM bases b
+  LEFT JOIN corantes co ON co.formula_id = b.formula_id;
+$function$;
+
+-- Mesmo escopo: só authenticated executa (não PUBLIC/anon). CREATE OR REPLACE preserva
+-- a ACL; reafirmado por idempotência (espelha a migration 20260615210000).
+REVOKE ALL ON FUNCTION public.get_tint_prices(uuid[]) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.get_tint_prices(uuid[]) TO authenticated;


### PR DESCRIPTION
## O quê

Gate de `ativo` no preço tintométrico. As RPCs `get_tint_price`/`get_tint_prices` marcavam a base "disponível" só por `valor_unitario > 0`, **ignorando `omie_products.ativo`** — produto desativado no Omie com valor congelado `> 0` (**3.606 em prod**) seguia precificável e vendável no balcão. Achado adversarial do Codex (16/06).

Furo **latente** (medido em prod: **0 fórmulas vivas** com base/corante inativo hoje), mas a mecânica é real: o sync **traz** inativos (oben 2.757 / colacor 2.117) e desativar **não zera** o valor.

## Mudanças

- **RPC (fronteira money-path):** base **e** corante só entram no preço se `op.ativo` (`COALESCE(...,false)`, paridade verbatim single=batch). `precoFinal` NULL quando inativo → o front herda "sem preço" via `select-price.ts`.
- **Front fail-closed (2º achado do Codex, pré-existente):** quando a RPC **falha** (erro/permissão/runtime), `useTintPricing` devolvia `pricing=null` e o `select-price` caía no CSV legado / preço-cliente, vendendo mesmo assim. Nova **regra 0** (`motorFalhou`) + `useTintPricing` propaga o erro (`isError`) + `useTintColorSelect` computa o flag. As "alternativas" já fail-closavam.
- **Oráculo TS** `compute-price.ts` re-sincronizado com o gate (mantém a paridade verbatim que o arquivo declara).

## Prova

- **PG17 falsificável:** `db/test-tint-get-price.sh` 30/30, `db/test-tint-get-prices.sh` 27/27 (asserts N5/N6 provam o gate; sabotagens F5/F6/F7 confirmam o dente).
- **vitest** 34/34 (select-price + compute-price), **typecheck** + **lint** limpos.
- **Codex challenge:** núcleo sólido (`false AND NULL = false` protege o caminho do produto ausente), endossou o gate do corante, e achou o furo do front.

## Impacto

ZERO regressão hoje — não muda nenhum preço atual; é blindagem preventiva da fronteira de venda.

## Fora de escopo (task à parte)

`src/hooks/unifiedOrder/useProductCatalog.ts` (catálogo de venda **geral**, Oben+Colacor) também não filtra `ativo`. Mais amplo que o tint e com decisão de negócio embutida (inativo-com-estoque é vendável?) → tratado em sessão dedicada.

## ⚠️ ATENÇÃO: migration manual necessária

Este PR adiciona `supabase/migrations/20260616120000_tint_price_gate_ativo.sql`. **Lovable não aplica automaticamente** — mergear **NÃO** toca o banco. Alguém precisa colar no SQL Editor do Lovable e rodar.

<details><summary>SQL pra aplicar (idêntico ao arquivo commitado)</summary>

```sql
CREATE OR REPLACE FUNCTION public.get_tint_price(p_formula_id uuid)
 RETURNS jsonb LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path TO 'public'
AS $function$
DECLARE
  v_is_staff boolean; v_base_preco numeric; v_base_ativo boolean; v_base_disponivel boolean;
  v_custo_base numeric; v_custo_corantes numeric; v_corantes_completos boolean; v_preco_final numeric; v_itens jsonb;
BEGIN
  v_is_staff := auth.uid() IS NOT NULL
    AND (public.has_role(auth.uid(),'employee'::app_role) OR public.has_role(auth.uid(),'master'::app_role));
  SELECT op.valor_unitario, op.ativo INTO v_base_preco, v_base_ativo
  FROM tint_formulas f
  LEFT JOIN tint_skus s ON s.id = f.sku_id
  LEFT JOIN omie_products op ON op.id = s.omie_product_id
  WHERE f.id = p_formula_id;
  v_base_disponivel := v_base_preco IS NOT NULL AND v_base_preco > 0 AND COALESCE(v_base_ativo, false);
  v_custo_base := CASE WHEN v_base_disponivel THEN v_base_preco ELSE NULL END;
  WITH calc AS (
    SELECT fi.ordem, COALESCE(c.descricao, '?') AS corante_descricao, fi.qtd_ml,
      (COALESCE(op.valor_unitario, 0) > 0 AND COALESCE(op.ativo, false) AND c.volume_total_ml IS NOT NULL AND c.volume_total_ml > 0) AS custo_disponivel,
      CASE WHEN COALESCE(op.valor_unitario, 0) > 0 AND COALESCE(op.ativo, false) AND c.volume_total_ml IS NOT NULL AND c.volume_total_ml > 0
           THEN op.valor_unitario / c.volume_total_ml ELSE 0 END AS custo_por_ml,
      CASE WHEN COALESCE(op.valor_unitario, 0) > 0 AND COALESCE(op.ativo, false) AND c.volume_total_ml IS NOT NULL AND c.volume_total_ml > 0
           THEN fi.qtd_ml * (op.valor_unitario / c.volume_total_ml) ELSE 0 END AS custo_item
    FROM tint_formula_itens fi
    LEFT JOIN tint_corantes c  ON c.id = fi.corante_id
    LEFT JOIN omie_products op ON op.id = c.omie_product_id
    WHERE fi.formula_id = p_formula_id
  )
  SELECT COALESCE(SUM(custo_item), 0), COALESCE(bool_and(custo_disponivel), false),
    COALESCE(jsonb_agg(jsonb_build_object('coranteDescricao', corante_descricao, 'qtdMl', qtd_ml,
      'custoPorMl', custo_por_ml, 'custoItem', custo_item, 'custoDisponivel', custo_disponivel) ORDER BY ordem), '[]'::jsonb)
  INTO v_custo_corantes, v_corantes_completos, v_itens FROM calc;
  v_preco_final := CASE WHEN v_base_disponivel AND v_corantes_completos THEN v_custo_base + v_custo_corantes ELSE NULL END;
  RETURN jsonb_build_object('custoBase', v_custo_base, 'baseDisponivel', v_base_disponivel,
    'custoCorantes', v_custo_corantes, 'corantesCompletos', v_corantes_completos, 'precoFinal', v_preco_final,
    'itensCorantes', CASE WHEN v_is_staff THEN v_itens ELSE '[]'::jsonb END);
END; $function$;

CREATE OR REPLACE FUNCTION public.get_tint_prices(p_formula_ids uuid[])
 RETURNS jsonb LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO 'public'
AS $function$
  WITH bases AS (
    SELECT f.id AS formula_id, op.valor_unitario AS base_preco,
           (op.valor_unitario IS NOT NULL AND op.valor_unitario > 0 AND COALESCE(op.ativo, false)) AS base_disponivel
    FROM tint_formulas f
    LEFT JOIN tint_skus s ON s.id = f.sku_id
    LEFT JOIN omie_products op ON op.id = s.omie_product_id
    WHERE f.id = ANY(p_formula_ids)
  ),
  corantes AS (
    SELECT fi.formula_id,
           COALESCE(SUM(CASE WHEN COALESCE(op.valor_unitario,0) > 0 AND COALESCE(op.ativo, false) AND c.volume_total_ml IS NOT NULL AND c.volume_total_ml > 0
                             THEN fi.qtd_ml * op.valor_unitario / c.volume_total_ml ELSE 0 END), 0) AS custo_corantes,
           COALESCE(bool_and(COALESCE(op.valor_unitario,0) > 0 AND COALESCE(op.ativo, false) AND c.volume_total_ml IS NOT NULL AND c.volume_total_ml > 0), false) AS corantes_completos
    FROM tint_formula_itens fi
    LEFT JOIN tint_corantes c  ON c.id = fi.corante_id
    LEFT JOIN omie_products op ON op.id = c.omie_product_id
    WHERE fi.formula_id = ANY(p_formula_ids)
    GROUP BY fi.formula_id
  )
  SELECT COALESCE(jsonb_object_agg(b.formula_id, jsonb_build_object(
    'custoBase', CASE WHEN b.base_disponivel THEN b.base_preco ELSE NULL END,
    'baseDisponivel', b.base_disponivel,
    'custoCorantes', COALESCE(co.custo_corantes, 0),
    'corantesCompletos', COALESCE(co.corantes_completos, false),
    'precoFinal', CASE WHEN b.base_disponivel AND COALESCE(co.corantes_completos, false)
                       THEN b.base_preco + COALESCE(co.custo_corantes, 0) ELSE NULL END
  )), '{}'::jsonb)
  FROM bases b LEFT JOIN corantes co ON co.formula_id = b.formula_id;
$function$;

REVOKE ALL ON FUNCTION public.get_tint_prices(uuid[]) FROM PUBLIC, anon;
GRANT EXECUTE ON FUNCTION public.get_tint_prices(uuid[]) TO authenticated;
```
</details>

Validação pós-apply (read-only, esperado `✅`):

```sql
WITH defs AS (
  SELECT pg_get_functiondef('public.get_tint_price(uuid)'::regprocedure) AS single_def,
         pg_get_functiondef('public.get_tint_prices(uuid[])'::regprocedure) AS batch_def
)
SELECT CASE WHEN single_def LIKE '%COALESCE(v_base_ativo, false)%'
             AND single_def LIKE '%COALESCE(op.ativo, false)%'
             AND batch_def  LIKE '%COALESCE(op.ativo, false)%'
       THEN '✅ gate de ativo presente nas duas RPCs (base + corante)'
       ELSE '❌ FALTANDO — gate de ativo ausente; migration não aplicada' END AS status
FROM defs;
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
