### PR TITLE
feat(fase2): Fatia 1 — oferta viva na ligação (pré-gerada + card + fallback)

### DIFF
--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,12 +21,12 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **247** custom migrations totais
-- **906** objetos esperados (criados por estas migrations)
+- **248** custom migrations totais
+- **907** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
   - `function`: 260
   - `rls_policy`: 209
-  - `index`: 178
+  - `index`: 179
   - `cron_job`: 106
   - `table`: 103
   - `trigger`: 46
@@ -2146,6 +2146,12 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | --- | --- | --- |
 | `function` | `public.get_tint_price` | — |
 | `function` | `public.get_tint_prices` | — |
+
+### `20260616120001_idx_tactical_plans_lookup.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `index` | `public.idx_tactical_plans_lookup` | `farmer_tactical_plans` |
 
 ## Próximos passos quando algo der `❌`
 

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 247
+-- Total de custom migrations: 248
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -266,7 +266,8 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260615210000', 'reposicao_auto_aprovacao_v2', '20260615210000_reposicao_auto_aprovacao_v2.sql'),
   ('20260615210000', 'tint_get_prices_batch', '20260615210000_tint_get_prices_batch.sql'),
   ('20260616020000', 'fix_aging_views_status_vocab', '20260616020000_fix_aging_views_status_vocab.sql'),
-  ('20260616120000', 'tint_price_gate_ativo', '20260616120000_tint_price_gate_ativo.sql')
+  ('20260616120000', 'tint_price_gate_ativo', '20260616120000_tint_price_gate_ativo.sql'),
+  ('20260616120001', 'idx_tactical_plans_lookup', '20260616120001_idx_tactical_plans_lookup.sql')
 )
 SELECT
   e.version,
@@ -1190,7 +1191,8 @@ WITH expected_objects (migration, kind, schema_name, object_name, parent_name) A
   ('reposicao_auto_aprovacao_v2', 'function', 'public', 'reposicao_alerta_pedido_minimo_tick', ''),
   ('tint_get_prices_batch', 'function', 'public', 'get_tint_prices', ''),
   ('tint_price_gate_ativo', 'function', 'public', 'get_tint_price', ''),
-  ('tint_price_gate_ativo', 'function', 'public', 'get_tint_prices', '')
+  ('tint_price_gate_ativo', 'function', 'public', 'get_tint_prices', ''),
+  ('idx_tactical_plans_lookup', 'index', 'public', 'idx_tactical_plans_lookup', 'farmer_tactical_plans')
 )
 SELECT
   e.migration,

--- a/src/components/farmer/copilot/ActivePlanCard.tsx
+++ b/src/components/farmer/copilot/ActivePlanCard.tsx
@@ -11,19 +11,45 @@ interface ActivePlanCardProps {
   onToggle: () => void;
 }
 
+function nomesDoBundle(b: Record<string, unknown> | undefined): string[] {
+  const prods = (b?.bundle_products ?? b?.products) as Array<{ name?: string; nome?: string; descricao?: string }> | undefined;
+  return Array.isArray(prods) ? prods.map((p) => p.name || p.nome || p.descricao || '').filter(Boolean) : [];
+}
+
 export function ActivePlanCard({ activePlan, showPlan, onToggle }: ActivePlanCardProps) {
+  const produtos = nomesDoBundle(activePlan.topBundle);
+  const temOferta = produtos.length > 0 || !!activePlan.offerTransition;
+
   return (
     <Card className="border-dashed border-primary/30">
-      <CardContent className="p-3">
+      <CardContent className="p-3 space-y-2">
+        {temOferta && (
+          <div className="space-y-1">
+            {produtos.length > 0 && (
+              <p className="text-[11px] font-semibold leading-tight">💡 Ofereça: {produtos.join(' + ')}</p>
+            )}
+            {activePlan.offerTransition && (
+              <p className="text-[10px] text-muted-foreground italic">"{activePlan.offerTransition}"</p>
+            )}
+            <div className="flex gap-1.5">
+              {activePlan.bundleIncrementalMargin > 0 && (
+                <Badge variant="outline" className="text-[7px]">+R$ {Math.round(activePlan.bundleIncrementalMargin)}/mês</Badge>
+              )}
+              {activePlan.bundleProbability > 0 && (
+                <Badge variant="outline" className="text-[7px]">{Math.round(activePlan.bundleProbability * 100)}% aceite</Badge>
+              )}
+            </div>
+          </div>
+        )}
         <div className="flex items-center justify-between" onClick={onToggle} role="button">
           <div className="flex items-center gap-2">
             <FileText className="w-3.5 h-3.5 text-primary" />
-            <span className="text-[10px] font-semibold">PTPL Ativo — {activePlan.planType === 'estrategico' ? 'Estratégico' : 'Essencial'}</span>
+            <span className="text-[10px] font-semibold">Tática — {activePlan.planType === 'estrategico' ? 'Estratégico' : 'Essencial'}</span>
           </div>
           {showPlan ? <ChevronUp className="w-3 h-3" /> : <ChevronDown className="w-3 h-3" />}
         </div>
         {showPlan && (
-          <div className="mt-2 space-y-1.5 text-[9px]">
+          <div className="space-y-1.5 text-[9px]">
             <div className="flex gap-1.5">
               <Badge variant="outline" className="text-[7px]">{getObjectiveLabel(activePlan.strategicObjective)}</Badge>
               <Badge variant="outline" className="text-[7px]">HS: {Math.round(activePlan.healthScore)}</Badge>

--- a/src/components/farmer/copilot/OfertaCruaCard.tsx
+++ b/src/components/farmer/copilot/OfertaCruaCard.tsx
@@ -1,0 +1,68 @@
+// Fallback de oferta para clientes sem plano pré-gerado (fora do top-25 noturno).
+// Busca o melhor bundle pendente diretamente de farmer_bundle_recommendations.
+import { useQuery } from '@tanstack/react-query';
+import { Card, CardContent } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { supabase } from '@/integrations/supabase/client';
+
+interface Props {
+  customerId: string;
+  farmerId: string;
+}
+
+interface BundleProduct {
+  name?: string;
+  nome?: string;
+}
+
+interface BundleRow {
+  bundle_products: unknown;
+  m_bundle: number | null;
+}
+
+function parseProdutos(raw: unknown): string[] {
+  if (!Array.isArray(raw)) return [];
+  return (raw as BundleProduct[])
+    .map((p) => (typeof p === 'object' && p !== null ? p.name || p.nome || '' : ''))
+    .filter((s): s is string => Boolean(s));
+}
+
+export function OfertaCruaCard({ customerId, farmerId }: Props) {
+  const { data: bundle } = useQuery<BundleRow | null>({
+    queryKey: ['oferta-crua', customerId, farmerId],
+    queryFn: async () => {
+      const { data } = await supabase
+        .from('farmer_bundle_recommendations')
+        .select('bundle_products, m_bundle')
+        .eq('customer_user_id', customerId)
+        .eq('farmer_id', farmerId)
+        .eq('status', 'pendente')
+        .order('lie_bundle', { ascending: false })
+        .limit(1)
+        .maybeSingle();
+      return data ?? null;
+    },
+    staleTime: 60_000,
+    enabled: Boolean(customerId) && Boolean(farmerId),
+  });
+
+  const produtos = parseProdutos(bundle?.bundle_products);
+  const margem = bundle?.m_bundle ?? null;
+
+  if (!bundle || produtos.length === 0) return null;
+
+  return (
+    <Card className="border-dashed border-muted-foreground/30">
+      <CardContent className="p-3 space-y-1">
+        <p className="text-[11px] font-semibold leading-tight">
+          💡 Ofereça: {produtos.join(' + ')}
+        </p>
+        {margem !== null && margem > 0 && (
+          <Badge variant="outline" className="text-[7px]">
+            +R$ {Math.round(margem)}/mês
+          </Badge>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/farmer/copilot/useFarmerCopilot.ts
+++ b/src/components/farmer/copilot/useFarmerCopilot.ts
@@ -247,6 +247,7 @@ export function useFarmerCopilot() {
     navigate,
     isStaff,
     isImpersonating,
+    userId: user?.id ?? null,
     copilot,
     selectedCustomer,
     setSelectedCustomer,

--- a/src/lib/tactical/__tests__/pregeracao.test.ts
+++ b/src/lib/tactical/__tests__/pregeracao.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { profitPerHora, selecionarParaPregeracao, PROFIT_PER_HOUR_THRESHOLD } from '../pregeracao';
+
+describe('profitPerHora', () => {
+  it('usa revenue_potential quando > 0', () => {
+    // (1000 * 30% * 0.1) / (15/60) = 30 / 0.25 = 120
+    expect(profitPerHora({ revenuePotential: 1000, avgSpend: 50, marginPct: 30 })).toBeCloseTo(120);
+  });
+  it('cai pra avgSpend quando revenue_potential = 0', () => {
+    // (500 * 20% * 0.1) / 0.25 = 10 / 0.25 = 40
+    expect(profitPerHora({ revenuePotential: 0, avgSpend: 500, marginPct: 20 })).toBeCloseTo(40);
+  });
+});
+
+describe('selecionarParaPregeracao', () => {
+  const base = (id: string, priority: number, rev: number, m: number) =>
+    ({ customerUserId: id, priorityScore: priority, revenuePotential: rev, avgSpend: 0, marginPct: m });
+
+  it('ordena por priority desc, filtra pelo gate, corta no topN', () => {
+    const scores = [
+      base('a', 90, 1000, 30), // pph 120 ✓
+      base('b', 80, 100, 10),  // pph (100*10%*0.1)/0.25 = 4 ✗ (abaixo de 50)
+      base('c', 70, 2000, 25), // pph (2000*25%*0.1)/0.25 = 200 ✓
+      base('d', 95, 5000, 40), // pph 800 ✓
+    ];
+    const sel = selecionarParaPregeracao(scores, 2);
+    expect(sel.map((s) => s.customerUserId)).toEqual(['d', 'a']); // top-2 por priority, ambos passam o gate
+  });
+
+  it('pula quem está abaixo do gate mesmo com priority alta', () => {
+    const sel = selecionarParaPregeracao([base('b', 99, 100, 10)], 25);
+    expect(sel).toEqual([]);
+  });
+
+  it('filtra o gate ANTES de cortar topN: mantém menor-priority elegível quando o de maior priority falha o gate', () => {
+    // a tem a maior priority mas falha o gate; b e c passam. Com topN=2 o resultado
+    // correto é [b, c] (top-2 DOS ELEGÍVEIS), não [b] (top-2 e depois filtra).
+    const scores = [
+      base('a', 90, 100, 10),  // pph 4 ✗ — alta priority, mas fora do gate
+      base('b', 80, 2000, 25), // pph 200 ✓
+      base('c', 70, 1000, 30), // pph 120 ✓
+    ];
+    const sel = selecionarParaPregeracao(scores, 2);
+    expect(sel.map((s) => s.customerUserId)).toEqual(['b', 'c']);
+  });
+
+  it('não muta o array de entrada', () => {
+    const scores = [base('a', 70, 1000, 30), base('b', 95, 1000, 30)];
+    const antes = scores.map((s) => s.customerUserId);
+    selecionarParaPregeracao(scores, 5);
+    expect(scores.map((s) => s.customerUserId)).toEqual(antes);
+  });
+
+  it('threshold exposto é 50 R$/h', () => {
+    expect(PROFIT_PER_HOUR_THRESHOLD).toBe(50);
+  });
+});

--- a/src/lib/tactical/pregeracao.ts
+++ b/src/lib/tactical/pregeracao.ts
@@ -1,0 +1,34 @@
+/** Pré-geração noturna do plano tático: gate de eficiência + seleção dos prioritários.
+ *  Oráculo puro — a edge tactical-plans-batch (Deno) replica esta lógica inline
+ *  (front e edge não compartilham módulo; este helper é a fonte da verdade testada). */
+export const PROFIT_PER_HOUR_THRESHOLD = 50; // R$/h — espelha useTacticalPlan.ts:198
+const AVG_CALL_MINUTES = 15;
+
+export interface ScoreParaSelecao {
+  customerUserId: string;
+  priorityScore: number;
+  revenuePotential: number;
+  avgSpend: number;
+  marginPct: number;
+}
+
+/** R$/h estimado por ligação. Espelha useTacticalPlan.checkEfficiency (linhas 313-318). */
+export function profitPerHora(
+  s: Pick<ScoreParaSelecao, 'revenuePotential' | 'avgSpend' | 'marginPct'>,
+): number {
+  const base = s.revenuePotential > 0 ? s.revenuePotential : s.avgSpend;
+  const marginPerCall = base * (s.marginPct / 100) * 0.1;
+  return marginPerCall / (AVG_CALL_MINUTES / 60);
+}
+
+/** Top-N por priorityScore desc, filtrando quem passa no gate de R$/h.
+ *  Filtra ANTES de cortar: retorna os N de maior priority DENTRE OS ELEGÍVEIS. */
+export function selecionarParaPregeracao(
+  scores: ScoreParaSelecao[],
+  topN: number,
+): ScoreParaSelecao[] {
+  return [...scores]
+    .sort((a, b) => b.priorityScore - a.priorityScore)
+    .filter((s) => profitPerHora(s) >= PROFIT_PER_HOUR_THRESHOLD)
+    .slice(0, topN);
+}

--- a/src/pages/FarmerCopilot.tsx
+++ b/src/pages/FarmerCopilot.tsx
@@ -7,6 +7,7 @@ import { SessionStartCard } from '@/components/farmer/copilot/SessionStartCard';
 import { DirectionIndicator } from '@/components/farmer/copilot/DirectionIndicator';
 import { SuggestionCard } from '@/components/farmer/copilot/SuggestionCard';
 import { ActivePlanCard } from '@/components/farmer/copilot/ActivePlanCard';
+import { OfertaCruaCard } from '@/components/farmer/copilot/OfertaCruaCard';
 import { ManualTextInput } from '@/components/farmer/copilot/ManualTextInput';
 import { TranscriptCard } from '@/components/farmer/copilot/TranscriptCard';
 import { AnalysisHistoryCard } from '@/components/farmer/copilot/AnalysisHistoryCard';
@@ -16,6 +17,7 @@ const FarmerCopilot = () => {
     navigate,
     isStaff,
     isImpersonating,
+    userId,
     copilot,
     selectedCustomer,
     setSelectedCustomer,
@@ -111,6 +113,11 @@ const FarmerCopilot = () => {
                 showPlan={showPlan}
                 onToggle={() => setShowPlan(!showPlan)}
               />
+            )}
+
+            {/* Fallback — cliente sem plano pré-gerado: exibe melhor bundle pendente */}
+            {!activePlan && selectedCustomer && userId && (
+              <OfertaCruaCard customerId={selectedCustomer} farmerId={userId} />
             )}
 
             {copilot.isAnalyzing && (

--- a/supabase/functions/generate-tactical-plan/index.ts
+++ b/supabase/functions/generate-tactical-plan/index.ts
@@ -15,22 +15,91 @@ serve(async (req) => {
   if (!__auth.ok) return __auth.response;
 
   try {
-    // Authenticate user
-    const authHeader = req.headers.get('Authorization');
-    if (!authHeader?.startsWith('Bearer ')) {
-      return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
-    }
-    const supabase = createClient(Deno.env.get('SUPABASE_URL')!, Deno.env.get('SUPABASE_ANON_KEY')!, {
-      global: { headers: { Authorization: authHeader } },
-      auth: { persistSession: false },
-    });
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
-    if (authError || !user) {
-      return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+    const body = await req.json();
+    // Modo self-contained (cron): body traz { customerId, farmerId } e a edge monta o
+    // contexto + grava o plano. Modo front (legado): body traz customerContext já montado
+    // e o front é quem grava (useTacticalPlan.generatePlan).
+    const selfContained = Boolean(body.customerId && body.farmerId);
+
+    // Modo front (legado): exige Bearer-user. Modo self-contained já foi autenticado por
+    // authorizeCronOrStaff (via x-cron-secret) lá em cima — não precisa do user token.
+    if (!selfContained) {
+      const authHeader = req.headers.get('Authorization');
+      if (!authHeader?.startsWith('Bearer ')) {
+        return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+      }
+      const supabase = createClient(Deno.env.get('SUPABASE_URL')!, Deno.env.get('SUPABASE_ANON_KEY')!, {
+        global: { headers: { Authorization: authHeader } },
+        auth: { persistSession: false },
+      });
+      const { data: { user }, error: authError } = await supabase.auth.getUser();
+      if (authError || !user) {
+        return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+      }
     }
 
-    const { customerContext, bundleContext, diagnosticData, historicalObjections, planType } = await req.json();
-    const mode = planType || 'essencial';
+    const mode = body.planType || 'essencial';
+
+    // No modo front estas chegam prontas no body; no self-contained são montadas abaixo.
+    let customerContext = body.customerContext;
+    let bundleContext = body.bundleContext;
+    let diagnosticData = body.diagnosticData;
+    let historicalObjections = body.historicalObjections;
+    let topBundleRow: Record<string, unknown> | null = null;
+    let secondBundleRow: Record<string, unknown> | null = null;
+
+    if (selfContained) {
+      const admin = createClient(Deno.env.get('SUPABASE_URL')!, Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!, { auth: { persistSession: false } });
+      const { customerId, farmerId } = body;
+
+      // Idempotência: pula se já há plano 'gerado' criado hoje (>= 00:00 UTC).
+      const hojeIso = new Date(new Date().toISOString().slice(0, 10) + 'T00:00:00Z').toISOString();
+      const { data: existente } = await admin.from('farmer_tactical_plans')
+        .select('id').eq('farmer_id', farmerId).eq('customer_user_id', customerId)
+        .eq('status', 'gerado').gte('created_at', hojeIso).limit(1);
+      if (existente?.length) {
+        return new Response(JSON.stringify({ id: existente[0].id, skipped: 'ja_gerado_hoje' }), { headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+      }
+
+      const [{ data: score }, { data: profile }, { data: bundles }, { data: allScores }, { data: objEvents }] = await Promise.all([
+        admin.from('farmer_client_scores').select('*').eq('customer_user_id', customerId).eq('farmer_id', farmerId).maybeSingle(),
+        admin.from('profiles').select('name, customer_type, cnae').eq('user_id', customerId).maybeSingle(),
+        admin.from('farmer_bundle_recommendations').select('*').eq('customer_user_id', customerId).eq('farmer_id', farmerId).eq('status', 'pendente').order('lie_bundle', { ascending: false }).limit(2),
+        admin.from('farmer_client_scores').select('gross_margin_pct').eq('farmer_id', farmerId),
+        admin.from('farmer_copilot_events').select('event_data').eq('event_type', 'suggestion').limit(20),
+      ]);
+      if (!score) {
+        return new Response(JSON.stringify({ skipped: 'sem_score' }), { headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+      }
+
+      const num = (v: unknown) => Number(v ?? 0);
+      const healthScore = num(score.health_score), churnRisk = num(score.churn_risk), avgSpend = num(score.avg_monthly_spend_180d);
+      const marginPct = num(score.gross_margin_pct), categoryCount = num(score.category_count), daysSince = num(score.days_since_last_purchase);
+      const clusterMargin = allScores?.length ? allScores.reduce((s: number, r: { gross_margin_pct: unknown }) => s + num(r.gross_margin_pct), 0) / allScores.length : 25;
+      const mixGap = Math.max(0, 8 - categoryCount);
+
+      // classifyProfile/selectObjective — espelham useTacticalPlan.ts:183-196 (validado).
+      const customerProfile = avgSpend < 500 && marginPct < 20 ? 'sensivel_preco'
+        : marginPct > 35 && categoryCount <= 3 ? 'orientado_qualidade'
+        : avgSpend > 2000 && categoryCount >= 4 && healthScore > 60 ? 'orientado_produtividade' : 'misto';
+      const strategicObjective = daysSince > 90 ? 'reativacao' : churnRisk > 60 ? 'recuperacao'
+        : mixGap > 3 ? 'expansao_mix' : marginPct < clusterMargin * 0.8 ? 'consolidacao_margem' : 'upsell_premium';
+
+      topBundleRow = bundles?.[0] ?? null;
+      secondBundleRow = bundles?.[1] ?? null;
+      historicalObjections = (objEvents ?? [])
+        .map((e: { event_data: { intent?: unknown } | null }) => (e.event_data as { intent?: unknown } | null)?.intent)
+        .filter((i: unknown): i is string => typeof i === 'string' && i.startsWith('objecao')).slice(0, 5);
+
+      customerContext = { name: profile?.name, cnae: profile?.cnae, customerType: profile?.customer_type, profile: customerProfile, healthScore, churnRisk, avgMonthlySpend: avgSpend, grossMarginPct: marginPct, categoryCount, daysSinceLastPurchase: daysSince, mixGap, clusterAvgMargin: clusterMargin, expansionPotential: num(score.expansion_score), revenuePotential: num(score.revenue_potential) };
+      bundleContext = topBundleRow ? { products: topBundleRow.bundle_products, lie: topBundleRow.lie_bundle, probability: topBundleRow.p_bundle, margin: topBundleRow.m_bundle } : null;
+      diagnosticData = { strategicObjective };
+      // Paridade com o front: no modo estratégico, inclui o 2º bundle p/ comparação.
+      if (mode === 'estrategico' && secondBundleRow) {
+        (diagnosticData as Record<string, unknown>).secondBundle = { products: secondBundleRow.bundle_products, lie: secondBundleRow.lie_bundle, probability: secondBundleRow.p_bundle, margin: secondBundleRow.m_bundle };
+      }
+      (body as Record<string, unknown>)._derived = { healthScore, churnRisk, mixGap, marginPct, clusterMargin, expansionPotential: num(score.expansion_score), customerProfile, strategicObjective };
+    }
 
     const LOVABLE_API_KEY = Deno.env.get('LOVABLE_API_KEY');
     if (!LOVABLE_API_KEY) {
@@ -181,6 +250,32 @@ ${JSON.stringify(historicalObjections || [], null, 2)}`;
 
     // Add plan_type to response
     plan.plan_type = mode;
+
+    // Modo self-contained (cron): grava o plano e devolve o id (colunas espelham o
+    // INSERT do front em useTacticalPlan.ts:432-461 — validado).
+    if (selfContained) {
+      const admin = createClient(Deno.env.get('SUPABASE_URL')!, Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!, { auth: { persistSession: false } });
+      const d = (body as { _derived: Record<string, number | string> })._derived;
+      const { data: ins } = await admin.from('farmer_tactical_plans').insert({
+        farmer_id: body.farmerId, customer_user_id: body.customerId,
+        bundle_recommendation_id: (topBundleRow as { id?: string } | null)?.id ?? null,
+        health_score: d.healthScore, churn_risk: d.churnRisk, mix_gap: d.mixGap,
+        current_margin_pct: d.marginPct, cluster_avg_margin_pct: d.clusterMargin, expansion_potential: d.expansionPotential,
+        strategic_objective: plan.strategic_objective || d.strategicObjective, customer_profile: d.customerProfile, plan_type: mode,
+        top_bundle: (topBundleRow ? topBundleRow.bundle_products : {}),
+        second_bundle: (secondBundleRow ? (secondBundleRow as { bundle_products: unknown }).bundle_products : {}),
+        bundle_lie: Number((topBundleRow as { lie_bundle?: unknown } | null)?.lie_bundle ?? 0),
+        bundle_probability: Number((topBundleRow as { p_bundle?: unknown } | null)?.p_bundle ?? 0),
+        bundle_incremental_margin: Number((topBundleRow as { m_bundle?: unknown } | null)?.m_bundle ?? 0),
+        best_individual_lie: 0,
+        diagnostic_questions: plan.diagnostic_questions ?? [], implication_question: plan.implication_question ?? '',
+        offer_transition: plan.offer_transition ?? '', probable_objections: plan.probable_objections ?? [],
+        approach_strategy: plan.approach_strategy ?? '', approach_strategy_b: plan.approach_strategy_b ?? '',
+        ltv_projection: plan.ltv_projection ?? null, expected_result: plan.expected_result ?? null,
+        operational_risks: plan.operational_risks ?? [], status: 'gerado',
+      }).select('id').single();
+      return new Response(JSON.stringify({ id: ins?.id, generated: true }), { headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+    }
 
     return new Response(
       JSON.stringify(plan),

--- a/supabase/functions/tactical-plans-batch/index.ts
+++ b/supabase/functions/tactical-plans-batch/index.ts
@@ -1,0 +1,164 @@
+// supabase/functions/tactical-plans-batch/index.ts
+//
+// Cron noturno que, para cada vendedora (farmer) com carteira, seleciona o
+// top-25 dos clientes por priority_score que passam no gate de R$/h e dispara
+// a pré-geração do plano tático chamando generate-tactical-plan no modo
+// self-contained. Idempotência fica na edge alvo (skipped: 'ja_gerado_hoje').
+//
+// Gate de R$/h: espelha src/lib/tactical/pregeracao.ts (oráculo testado por vitest).
+//   profitPerHora = ((rev > 0 ? rev : avg) * (margin / 100) * 0.1) / (15 / 60)
+//   Threshold: R$ 50/h.
+//
+// Semântica top-N: filtra o gate ANTES de cortar no TOP_25 — pega os 25 de
+// maior priority DENTRE os que passam (não os 25 de maior priority e filtra depois).
+//
+// Setup pg_cron (manual depois do merge):
+//   SELECT cron.schedule('tactical-plans-batch-nightly', '0 5 * * *',
+//     $$ SELECT net.http_post(
+//       url := 'https://<PROJECT_REF>.supabase.co/functions/v1/tactical-plans-batch',
+//       headers := jsonb_build_object('x-cron-secret', current_setting('app.cron_shared_key', true)),
+//       timeout_milliseconds := 55000
+//     ); $$
+//   );
+
+import { createClient } from 'npm:@supabase/supabase-js@^2';
+import { authorizeCronOrStaff, corsHeaders } from '../_shared/auth.ts';
+
+// ── Gate de R$/h (espelha src/lib/tactical/pregeracao.ts) ────────────────────
+const PROFIT_PER_HOUR_THRESHOLD = 50;
+
+function profitPerHora(rev: number, avg: number, marginPct: number): number {
+  const baseRev = rev > 0 ? rev : avg;
+  // 10% do GMV como proxy de margem operacional; visita ~15 min → 4 visitas/h.
+  return (baseRev * (marginPct / 100) * 0.1) / (15 / 60);
+}
+
+const TOP_N = 25;
+const CONCURRENCY = 5; // cada chamada faz 1 LLM (~3-5s); 5 em paralelo ~5s/chunk
+
+// ── Handler ──────────────────────────────────────────────────────────────────
+Deno.serve(async (req) => {
+  if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders });
+
+  const auth = await authorizeCronOrStaff(req);
+  if (!auth.ok) return auth.response;
+
+  const supabase = createClient(
+    Deno.env.get('SUPABASE_URL')!,
+    Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!,
+  );
+
+  const selfUrl = `${Deno.env.get('SUPABASE_URL')!}/functions/v1/generate-tactical-plan`;
+  const cronSecret = Deno.env.get('CRON_SECRET') ?? '';
+  if (!cronSecret) {
+    console.warn('[tactical-plans-batch] CRON_SECRET not set; downstream calls will be rejected');
+  }
+
+  // 1. Pagina farmer_client_scores e agrupa por farmer_id.
+  //    A carteira já está limpa de fornecedor pela Fase 1 (classificacao).
+  const porFarmer = new Map<string, Array<{
+    customer: string;
+    priority: number;
+    rev: number;
+    avg: number;
+    m: number;
+  }>>();
+
+  for (let from = 0; ; from += 1000) {
+    const { data, error } = await supabase
+      .from('farmer_client_scores')
+      .select('farmer_id, customer_user_id, priority_score, revenue_potential, avg_monthly_spend_180d, gross_margin_pct')
+      .order('farmer_id', { ascending: true })
+      .range(from, from + 999);
+
+    if (error) {
+      return new Response(
+        JSON.stringify({ ok: false, error: error.message }),
+        { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
+      );
+    }
+
+    const rows = (data ?? []) as Array<{
+      farmer_id: string;
+      customer_user_id: string;
+      priority_score: number | null;
+      revenue_potential: number | null;
+      avg_monthly_spend_180d: number | null;
+      gross_margin_pct: number | null;
+    }>;
+
+    for (const r of rows) {
+      const arr = porFarmer.get(r.farmer_id) ?? [];
+      arr.push({
+        customer: r.customer_user_id,
+        priority: Number(r.priority_score ?? 0),
+        rev: Number(r.revenue_potential ?? 0),
+        avg: Number(r.avg_monthly_spend_180d ?? 0),
+        m: Number(r.gross_margin_pct ?? 0),
+      });
+      porFarmer.set(r.farmer_id, arr);
+    }
+
+    if (rows.length < 1000) break;
+  }
+
+  // 2. Por farmer: ordena por priority desc, filtra gate R$/h, corta em TOP_N.
+  //    Semântica: pega os 25 de maior priority DENTRE os que passam no gate.
+  const alvos: Array<{ farmer: string; customer: string }> = [];
+
+  for (const [farmer, scores] of porFarmer) {
+    scores.sort((a, b) => b.priority - a.priority);
+    let n = 0;
+    for (const s of scores) {
+      if (n >= TOP_N) break;
+      if (profitPerHora(s.rev, s.avg, s.m) < PROFIT_PER_HOUR_THRESHOLD) continue;
+      alvos.push({ farmer, customer: s.customer });
+      n++;
+    }
+  }
+
+  // 3. Fan-out concorrente em chunks de 5. Idempotência é na edge alvo.
+  let gerados = 0;
+  let pulados = 0;
+  let erros = 0;
+
+  for (let i = 0; i < alvos.length; i += CONCURRENCY) {
+    const chunk = alvos.slice(i, i + CONCURRENCY);
+    await Promise.all(
+      chunk.map(async (a) => {
+        try {
+          const r = await fetch(selfUrl, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              'x-cron-secret': cronSecret,
+            },
+            body: JSON.stringify({
+              customerId: a.customer,
+              farmerId: a.farmer,
+              planType: 'estrategico',
+            }),
+          });
+          const j = await r.json().catch(() => ({})) as Record<string, unknown>;
+          if (j.generated) gerados++;
+          else if (j.skipped) pulados++;
+          else erros++;
+        } catch {
+          erros++;
+        }
+      }),
+    );
+  }
+
+  return new Response(
+    JSON.stringify({
+      ok: true,
+      farmers: porFarmer.size,
+      alvos: alvos.length,
+      gerados,
+      pulados,
+      erros,
+    }),
+    { headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
+  );
+});

--- a/supabase/migrations/20260616120001_idx_tactical_plans_lookup.sql
+++ b/supabase/migrations/20260616120001_idx_tactical_plans_lookup.sql
@@ -1,0 +1,12 @@
+-- ============================================================
+-- idx_tactical_plans_lookup — Fase 2 / Fatia 1 (oferta viva na ligação)
+-- Acelera dois acessos quentes a farmer_tactical_plans:
+--   1. getActivePlan(customerId): plano 'gerado' mais recente do par (farmer, cliente).
+--   2. Idempotência do cron tactical-plans-batch: "já há 'gerado' criado hoje?".
+-- Ambos filtram por (farmer_id, customer_user_id, status) e ordenam por created_at DESC.
+-- Sem o índice, hoje a tabela só tem o pkey em (id) → seq scan (confirmado em prod via psql-ro).
+-- Idempotente (IF NOT EXISTS) — não é tabela nova, então não há RLS a declarar.
+-- ============================================================
+
+CREATE INDEX IF NOT EXISTS idx_tactical_plans_lookup
+  ON public.farmer_tactical_plans (farmer_id, customer_user_id, status, created_at DESC);


### PR DESCRIPTION
## Fase 2 / Fatia 1 — Oferta viva na ligação

Quando a vendedora (farmer) abre o cliente pra ligar, a **oferta campeã + o gancho de conversa** já aparecem na tela — pré-gerados de madrugada pros clientes prioritários (top-25/farmer que passam no gate de R$/h). Cliente fora do top-25 cai num **fallback de oferta crua**. Nenhuma ligação abre "no escuro".

Spec: `docs/superpowers/specs/2026-06-15-rotina-comercial-oferta-na-ligacao-design.md` · Plano: `docs/superpowers/plans/2026-06-15-fase2-oferta-na-ligacao.md`

> ⚠️ Esta é a **Fatia 1** (oferta na ligação) — o primeiro passo visível. O **objetivo principal** da Fase 2 é a **Fatia 2** (o loop: a IA capta o sinal de cada gravação e retroalimenta oferta + catálogo). Não é o fim.

### O que mudou (6 commits)
- **T1** `src/lib/tactical/pregeracao.ts` (+teste) — helper puro: gate R$/h + top-N. Oráculo vitest (**7/7**), filtra-antes-de-cortar.
- **T2** `generate-tactical-plan` — modo **self-contained** (cron): monta contexto server-side (`service_role`) + grava em `farmer_tactical_plans`. **Modo front (Bearer) 100% intacto.**
- **T3** `tactical-plans-batch` (nova edge cron) — pagina `farmer_client_scores`, top-25/farmer pelo gate, fan-out chamando T2 via `x-cron-secret`.
- **T4** `ActivePlanCard` — oferta + gancho no topo (sempre visível); tática recolhe pro expandir.
- **T5** `OfertaCruaCard` (nova) + render do fallback em `src/pages/FarmerCopilot.tsx`.
- **T6** índice `idx_tactical_plans_lookup` + audit regenerado.

### Verificação local
- typecheck ✅ · vitest **3694/3694** ✅ · lint **0 errors** ✅
- `deno check` ✅ nas 2 edges · code review adversarial: **aprovado, sem críticos** (front preservado, money-path honesto, gate replicado bate com o oráculo testado).

---

## ⚠️ ROLLOUT MANUAL — Lovable não auto-aplica (merge ≠ produção). Nesta ordem:

### 1. 🟣 Migration do índice — SQL Editor → cola → Run
```sql
CREATE INDEX IF NOT EXISTS idx_tactical_plans_lookup
  ON public.farmer_tactical_plans (farmer_id, customer_user_id, status, created_at DESC);
```
Validação (cola depois — read-only):
```sql
SELECT CASE WHEN EXISTS (SELECT 1 FROM pg_indexes WHERE schemaname='public' AND indexname='idx_tactical_plans_lookup')
  THEN '✅ idx existe' ELSE '❌ FALTANDO — migration não aplicada' END AS status;
```

### 2. Deploy das edges (chat do Lovable, verbatim da main)
- `generate-tactical-plan` (ganhou o modo self-contained)
- `tactical-plans-batch` (nova)

### 3. Smoke test (com o CRON_SECRET)
```bash
# 1 cliente conhecido → espera {generated:true,id}; rodar 2× → 2ª vez {skipped:'ja_gerado_hoje'}
curl -s -X POST 'https://fzvklzpomgnyikkfkzai.supabase.co/functions/v1/generate-tactical-plan' \
  -H 'x-cron-secret: <CRON_SECRET>' -H 'Content-Type: application/json' \
  -d '{"customerId":"<uuid>","farmerId":"<uuid>","planType":"estrategico"}'
# batch inteiro → {ok:true, alvos, gerados, pulados, erros}
curl -s -X POST 'https://fzvklzpomgnyikkfkzai.supabase.co/functions/v1/tactical-plans-batch' \
  -H 'x-cron-secret: <CRON_SECRET>'
```
⚠️ Se vier **401** em vez de JSON, o gateway está exigindo JWT nessas edges → configure **`verify_jwt = false`** pra `tactical-plans-batch` e `generate-tactical-plan` (as outras edges de cron do projeto já operam só com `x-cron-secret`). Sem isso, o 401 vem antes do `authorizeCronOrStaff` e o batch nunca roda (falha silenciosa).

### 4. 🟣 Cron — SQL Editor (`timeout_milliseconds` explícito; default 5s mata silencioso)
**Recomendo 08:00**, não madrugada: o batch lê `farmer_client_scores`/`farmer_bundle_recommendations`, que só ficam frescos **depois** de `daily-calculate-scores` (06:00) e `carteira-rebuild-nightly` (07:30) — confirmei os horários via `psql-ro`. Rodar antes = plano com dados de ontem.
```sql
SELECT cron.schedule('tactical-plans-batch-nightly', '0 8 * * *',
  $$ SELECT net.http_post(
       url := 'https://fzvklzpomgnyikkfkzai.supabase.co/functions/v1/tactical-plans-batch',
       headers := jsonb_build_object('x-cron-secret', (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name='CRON_SECRET' LIMIT 1)),
       timeout_milliseconds := 150000
     ); $$);
```

### 5. Publish do front (ActivePlanCard + OfertaCruaCard)

### 6. Verificação D+1
De manhã, `/farmer/calls`: cliente top-da-agenda → **oferta+gancho** aparece sozinho; cliente da cauda → **oferta crua**.

---

## Ressalvas conhecidas (robustez operacional — não bloqueiam o merge)
- **Idempotência best-effort** (SELECT-then-INSERT, sem unique constraint): execuções *sobrepostas* (retry do cron + disparo manual no mesmo dia) podem gerar 1 plano duplicado — sem quebrar UX (`getActivePlan` pega o mais recente). Evite disparo manual sobreposto ao cron. Unique constraint foi **descartada de propósito** (quebraria o fluxo on-demand do front, que também insere `status='gerado'`).
- **Fan-out síncrono**: pra carteira grande (>~6 vendedoras × 25 ≈ 150 chamadas LLM) pode estourar o timeout do cron. Mitigação futura: `EdgeRuntime.waitUntil` + chunking (spec §4.1). É idempotente → o que faltar regenera no dia seguinte.

## ⚠️ Nota de migration manual (auto-merge)
Este PR adiciona `supabase/migrations/20260616120001_idx_tactical_plans_lookup.sql`. **Mergear NÃO aplica no banco** — ver passo 1 do rollout.

## Test plan
- [ ] Migration aplicada (validação `✅`)
- [ ] Edges deployadas + smoke test (`generated` → `skipped` na 2ª)
- [ ] Cron agendado (08:00, timeout 150s)
- [ ] Front publicado
- [ ] D+1: oferta+gancho na ligação (top); oferta crua (cauda)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
