### PR TITLE
fix(sync): pagina leituras PostgREST na omie-sync-status-produtos (cap 1000 silencioso)

### DIFF
--- a/supabase/functions/_shared/paginate.ts
+++ b/supabase/functions/_shared/paginate.ts
@@ -1,0 +1,31 @@
+// Paginação do PostgREST / Supabase Data API.
+//
+// FOOTGUN (docs/agent/database.md §5; CLAUDE.md → PostgREST): o Data API capa CADA
+// resposta em 1000 linhas, em SILÊNCIO — sem erro. Uma leitura `.select()` que
+// ultrapasse 1000 linhas devolve só as primeiras 1000 e a cauda some sem aviso.
+// Em espelhos/sincronizações isso vira dado stale (o caso que esta função previne).
+//
+// `fetchAll` lê em páginas de 1000 via `.range()` até a página vir incompleta.
+// O call-site DEVE encadear `.order()` numa coluna ESTÁVEL e única no recorte
+// (ex.: a PK), senão o `.range()` pode pular/duplicar linhas entre páginas.
+const PAGE = 1000;
+
+export async function fetchAll<T>(
+  build: (
+    from: number,
+    to: number,
+  ) => PromiseLike<{ data: T[] | null; error: { message: string } | null }>,
+  label: string,
+): Promise<T[]> {
+  let from = 0;
+  const out: T[] = [];
+  for (;;) {
+    const { data, error } = await build(from, from + PAGE - 1);
+    if (error) throw new Error(`${label}: ${error.message}`);
+    const rows = data ?? [];
+    out.push(...rows);
+    if (rows.length < PAGE) break;
+    from += PAGE;
+  }
+  return out;
+}

--- a/supabase/functions/_shared/paginate_test.ts
+++ b/supabase/functions/_shared/paginate_test.ts
@@ -1,0 +1,71 @@
+// Testa o CÓDIGO REAL de `fetchAll` (não uma cópia) no runtime real (Deno).
+// Roda com: deno test supabase/functions/_shared/paginate_test.ts
+import { fetchAll } from "./paginate.ts";
+
+function assertEquals(a: unknown, b: unknown, msg?: string) {
+  if (JSON.stringify(a) !== JSON.stringify(b)) {
+    throw new Error(msg ?? `assertEquals falhou: ${JSON.stringify(a)} !== ${JSON.stringify(b)}`);
+  }
+}
+
+// "Banco" fake de N linhas; o build() pagina por .range() como o PostgREST faria,
+// mas SEM o cap de 1000 (assim provamos que fetchAll busca a cauda inteira).
+function fakeTable(total: number) {
+  const all = Array.from({ length: total }, (_, i) => ({ id: i }));
+  let calls = 0;
+  const build = (from: number, to: number) => {
+    calls++;
+    return Promise.resolve({ data: all.slice(from, to + 1), error: null });
+  };
+  return { build, calls: () => calls };
+}
+
+Deno.test("abaixo do cap: retorna tudo em 1 request (estado real hoje: 292 linhas)", async () => {
+  const t = fakeTable(292);
+  const rows = await fetchAll<{ id: number }>(t.build, "t");
+  assertEquals(rows.length, 292);
+  assertEquals(t.calls(), 1);
+});
+
+Deno.test("ACIMA do cap (o bug): retorna a cauda inteira, não trunca em 1000", async () => {
+  const t = fakeTable(2300);
+  const rows = await fetchAll<{ id: number }>(t.build, "t");
+  assertEquals(rows.length, 2300); // sem paginação, o PostgREST devolveria só 1000
+  assertEquals((rows[2299] as { id: number }).id, 2299);
+  assertEquals(t.calls(), 3); // 1000 + 1000 + 300
+});
+
+Deno.test("exatamente no cap: 1 request extra vazio, sem perder nem duplicar", async () => {
+  const t = fakeTable(1000);
+  const rows = await fetchAll<{ id: number }>(t.build, "t");
+  assertEquals(rows.length, 1000);
+  assertEquals(t.calls(), 2); // 2ª página volta vazia → para
+});
+
+Deno.test("dois caps cheios + resto: 2001 linhas em 3 requests", async () => {
+  const t = fakeTable(2001);
+  const rows = await fetchAll<{ id: number }>(t.build, "t");
+  assertEquals(rows.length, 2001);
+  assertEquals(t.calls(), 3);
+});
+
+Deno.test("tabela vazia: 1 request, zero linhas", async () => {
+  const t = fakeTable(0);
+  const rows = await fetchAll<{ id: number }>(t.build, "t");
+  assertEquals(rows.length, 0);
+  assertEquals(t.calls(), 1);
+});
+
+Deno.test("erro: lança com o label prefixado", async () => {
+  let threw = false;
+  try {
+    await fetchAll(
+      (_f, _t) => Promise.resolve({ data: null, error: { message: "boom" } }),
+      "minha_tabela",
+    );
+  } catch (e) {
+    threw = true;
+    assertEquals((e as Error).message, "minha_tabela: boom");
+  }
+  assertEquals(threw, true);
+});

--- a/supabase/functions/omie-sync-status-produtos/index.ts
+++ b/supabase/functions/omie-sync-status-produtos/index.ts
@@ -4,6 +4,7 @@
 
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
 import { authorizeCronOrStaff } from "../_shared/auth.ts";
+import { fetchAll } from "../_shared/paginate.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -137,26 +138,35 @@ Deno.serve(async (req) => {
   }
 
   try {
-    // 1) Lista de SKUs alvo: aqueles cujo fornecedor está habilitado para essa empresa
-    const { data: fornecedoresHab, error: fhErr } = await supabase
-      .from("fornecedor_habilitado_reposicao")
-      .select("fornecedor_nome")
-      .eq("empresa", empresa)
-      .eq("habilitado", true);
-    if (fhErr) throw fhErr;
-    const fornecNomes = (fornecedoresHab ?? []).map((r) => r.fornecedor_nome);
+    // 1) Lista de SKUs alvo: aqueles cujo fornecedor está habilitado para essa empresa.
+    // Leituras paginadas (.range() + .order estável): o PostgREST capa em 1000 linhas
+    // silencioso e estes conjuntos crescem com o catálogo de reposição. Ver _shared/paginate.ts.
+    const fornecedoresHab = await fetchAll<{ fornecedor_nome: string }>(
+      (f, t) =>
+        supabase
+          .from("fornecedor_habilitado_reposicao")
+          .select("fornecedor_nome")
+          .eq("empresa", empresa)
+          .eq("habilitado", true)
+          .order("fornecedor_nome", { ascending: true })
+          .range(f, t),
+      "fornecedor_habilitado_reposicao",
+    );
+    const fornecNomes = fornecedoresHab.map((r) => r.fornecedor_nome);
 
-    let skusQuery = supabase
-      .from("sku_parametros")
-      .select("sku_codigo_omie, sku_descricao, fornecedor_nome")
-      .eq("empresa", empresa);
-    if (fornecNomes.length > 0) {
-      skusQuery = skusQuery.in("fornecedor_nome", fornecNomes);
-    }
-    const { data: skus, error: skuErr } = await skusQuery;
-    if (skuErr) throw skuErr;
+    const skus = await fetchAll<{ sku_codigo_omie: string | number }>(
+      (f, t) => {
+        let q = supabase
+          .from("sku_parametros")
+          .select("sku_codigo_omie, sku_descricao, fornecedor_nome")
+          .eq("empresa", empresa);
+        if (fornecNomes.length > 0) q = q.in("fornecedor_nome", fornecNomes);
+        return q.order("sku_codigo_omie", { ascending: true }).range(f, t);
+      },
+      "sku_parametros",
+    );
 
-    const alvoSet = new Set<string>((skus ?? []).map((s) => String(s.sku_codigo_omie)));
+    const alvoSet = new Set<string>(skus.map((s) => String(s.sku_codigo_omie)));
     const totalAlvo = alvoSet.size;
 
     if (totalAlvo === 0) {
@@ -193,7 +203,7 @@ Deno.serve(async (req) => {
         filtrar_apenas_omiepdv: "N",
       });
 
-      totalPages = resp?.total_de_paginas ?? 1;
+      totalPages = (resp?.total_de_paginas as number) ?? 1;
       const produtos: OmieProduto[] = (resp as { produto_servico_cadastro?: OmieProduto[] })?.produto_servico_cadastro ?? [];
 
       for (const p of produtos) {
@@ -260,18 +270,26 @@ Deno.serve(async (req) => {
     // então mantemos os dois em sincronia para evitar SKUs inativos entrando em pedidos.
     try {
       const account = empresa.toLowerCase();
-      const { data: encontradosStatus } = await supabase
-        .from("sku_status_omie")
-        .select("sku_codigo_omie, ativo_no_omie")
-        .eq("empresa", empresa)
-        .in("fonte_sincronizacao", ["ListarProdutos"])
-        .not("ativo_no_omie", "is", null);
+      // Paginado: este espelho governa o gate de `ativo` no catálogo de venda. Truncar em
+      // 1000 deixaria a cauda stale nos DOIS sentidos (inativo→vendável / reativado→bloqueado).
+      const encontradosStatus = await fetchAll<{ sku_codigo_omie: string | number; ativo_no_omie: boolean | null }>(
+        (f, t) =>
+          supabase
+            .from("sku_status_omie")
+            .select("sku_codigo_omie, ativo_no_omie")
+            .eq("empresa", empresa)
+            .in("fonte_sincronizacao", ["ListarProdutos"])
+            .not("ativo_no_omie", "is", null)
+            .order("sku_codigo_omie", { ascending: true })
+            .range(f, t),
+        "sku_status_omie:espelho",
+      );
 
-      const inativos = (encontradosStatus ?? [])
+      const inativos = encontradosStatus
         .filter((r) => r.ativo_no_omie === false)
         .map((r) => Number(r.sku_codigo_omie))
         .filter((n) => Number.isFinite(n));
-      const ativos = (encontradosStatus ?? [])
+      const ativos = encontradosStatus
         .filter((r) => r.ativo_no_omie === true)
         .map((r) => Number(r.sku_codigo_omie))
         .filter((n) => Number.isFinite(n));
@@ -336,25 +354,37 @@ Deno.serve(async (req) => {
     // marca como 'resolvido_auto' qualquer evento_outlier pendente de tipo 'sku_inativado_omie'.
     let alertasResolvidosAuto = 0;
     try {
-      const { data: ativosAtuais } = await supabase
-        .from("sku_status_omie")
-        .select("sku_codigo_omie")
-        .eq("empresa", empresa)
-        .eq("ativo_no_omie", true);
+      const ativosAtuais = await fetchAll<{ sku_codigo_omie: string | number }>(
+        (f, t) =>
+          supabase
+            .from("sku_status_omie")
+            .select("sku_codigo_omie")
+            .eq("empresa", empresa)
+            .eq("ativo_no_omie", true)
+            .order("sku_codigo_omie", { ascending: true })
+            .range(f, t),
+        "sku_status_omie:ativos",
+      );
 
       const ativosSet = new Set(
-        (ativosAtuais ?? []).map((r) => String(r.sku_codigo_omie)),
+        ativosAtuais.map((r) => String(r.sku_codigo_omie)),
       );
 
       if (ativosSet.size > 0) {
-        const { data: pendentes } = await supabase
-          .from("eventos_outlier")
-          .select("id, sku_codigo_omie")
-          .eq("empresa", empresa)
-          .eq("tipo", "sku_inativado_omie")
-          .eq("status", "pendente");
+        const pendentes = await fetchAll<{ id: string; sku_codigo_omie: string | number }>(
+          (f, t) =>
+            supabase
+              .from("eventos_outlier")
+              .select("id, sku_codigo_omie")
+              .eq("empresa", empresa)
+              .eq("tipo", "sku_inativado_omie")
+              .eq("status", "pendente")
+              .order("id", { ascending: true })
+              .range(f, t),
+          "eventos_outlier:pendentes",
+        );
 
-        const idsParaFechar = (pendentes ?? [])
+        const idsParaFechar = pendentes
           .filter((e) => ativosSet.has(String(e.sku_codigo_omie)))
           .map((e) => e.id);
 


### PR DESCRIPTION
## Problema
O PostgREST capa **cada** resposta em **1000 linhas em silêncio** (sem erro). A edge `omie-sync-status-produtos` lia 5 listas sem paginação. O caso crítico é o **bloco 2.5**, que espelha `sku_status_omie` → `omie_products.ativo` — e esse `ativo` é o **gate do catálogo de venda** (e do submit de venda). Ao passar de 1000 linhas por empresa, a cauda ficaria *stale* nos **dois sentidos**: inativo no Omie permanecendo `ativo=true` (falso-vendável) e reativado permanecendo `ativo=false` (falso-bloqueado).

**Latente hoje:** `sku_status_omie` tem 292 linhas (só OBEN/ListarProdutos), abaixo do cap.

## Correção
Elimina a **classe inteira** do footgun na edge:
- Extrai o helper `fetchAll` (padrão já em produção de `fin-valor-cockpit`/`fin-funding`) para **`_shared/paginate.ts`** + teste Deno.
- Pagina as **5 leituras** PostgREST com `.range()` + `.order` estável:
  - `sku_status_omie` → espelho `omie_products.ativo` (**bloco 2.5**, o crítico)
  - `sku_status_omie` ativos → auto-resolução de alertas (**bloco 4**, gêmeo, mesma tabela)
  - `sku_parametros` (define o `alvoSet`)
  - `fornecedor_habilitado_reposicao`, `eventos_outlier` (defensivas, custo zero)
- Corrige de passagem 1 erro de tipo **pré-existente** (`total_de_paginas`, linha 206) — cast type-only, runtime idêntico — para `deno check` verde.

## Verificação
- `deno test _shared/paginate_test.ts` → **6/6**, validado por **falsificação** (sabotar `< PAGE`→`<= PAGE` deixa 3 testes vermelhos).
- `deno check` da edge → **type-clean** (a edge fica fora do `tsc` do CI — `deno` é a única rede de tipo dela).
- `bun lint` → **0 errors**.

## Investigação (read-only, `psql-ro`)
- **Por que só OBEN espelha:** `sku_parametros`/`fornecedor_habilitado_reposicao` só têm OBEN → `COLACOR` cai no early-return (`totalAlvo===0`). A Colacor **não espelha por aqui**; seu `ativo` vem 100% do writer primário `omie-vendas-sync` (4257 produtos colacor com `ativo` preenchido, zero no espelho). ✅

## ⚠️ Deploy MANUAL (pós-merge)
A edge é deployada via **chat do Lovable** (não auto). Instruir a deployar `omie-sync-status-produtos/index.ts` **e** o novo `_shared/paginate.ts` verbatim. Merge na `main` ≠ produção.

## 🔎 Achado colateral (fora do escopo)
5 divergências espelho × catálogo no estado atual (292 ≪ 1000, logo **não é o footgun**): 3 falso-vendável + 2 falso-bloqueado, todas com `ultima_sincronizacao=2026-06-10`. O espelho roda esparso (14/05, 15/05, 10/06) enquanto o `omie-vendas-sync` mantém o catálogo fresco → cheiro de **cadência/cron**, não de paginação. Não tocado — arco separado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
