### PR TITLE
fix(vendas): bloqueia salvar edição de pedido com produto a preço <= 0 (guard money-path)

### DIFF
--- a/scripts/cep-aberto/importar-carteira.ts
+++ b/scripts/cep-aberto/importar-carteira.ts
@@ -1,0 +1,81 @@
+// Importa a CARTEIRA (1.283 CEPs distintos) no cep_geo via API do CEP Aberto e gera
+// um INSERT colável no SQL Editor do Lovable (writes não passam por mim). Decisão A
+// do gate (eu + Codex): carteira agora é viável/auditável/money-path; prospects ficam
+// no orgânico; bulk completo adiado. precision='postcode_centroid' (CEP-level honesto),
+// source='cep_aberto', ON CONFLICT anti-downgrade (idempotente; re-rodável).
+//   CEP_ABERTO_TOKEN=xxx bun scripts/cep-aberto/importar-carteira.ts /tmp/carteira-ceps.csv /tmp/carteira-import.sql
+import { readFileSync, writeFileSync } from 'node:fs';
+
+const TOKEN = process.env.CEP_ABERTO_TOKEN;
+if (!TOKEN) {
+  console.error('❌ Falta CEP_ABERTO_TOKEN no env.');
+  process.exit(1);
+}
+const CSV = process.argv[2] ?? '/tmp/carteira-ceps.csv';
+const OUT = process.argv[3] ?? '/tmp/carteira-import.sql';
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+const ceps = readFileSync(CSV, 'utf8')
+  .trim()
+  .split('\n')
+  .map((l) => l.trim())
+  .filter((c) => /^[0-9]{8}$/.test(c));
+
+async function cepAberto(cep: string): Promise<{ lat: number; lng: number; uf: string } | null | 'erro'> {
+  for (let tent = 0; tent < 4; tent++) {
+    try {
+      const r = await fetch(`https://www.cepaberto.com/api/v3/cep?cep=${cep}`, {
+        headers: { Authorization: `Token token=${TOKEN}` },
+      });
+      if (r.ok) {
+        const j = (await r.json()) as { latitude?: string; longitude?: string; estado?: { sigla?: string } };
+        if (j && j.latitude && j.longitude) {
+          return { lat: parseFloat(j.latitude), lng: parseFloat(j.longitude), uf: (j.estado?.sigla ?? '').toUpperCase() };
+        }
+        return null; // {} = não coberto
+      }
+      await sleep(2500); // backoff rate-limit
+    } catch {
+      await sleep(1500);
+    }
+  }
+  return 'erro';
+}
+
+(async () => {
+  const rows: string[] = [];
+  let hit = 0;
+  let miss = 0;
+  let erro = 0;
+  for (let i = 0; i < ceps.length; i++) {
+    const cep = ceps[i];
+    const ca = await cepAberto(cep);
+    await sleep(1600);
+    if (ca === 'erro') {
+      erro++;
+    } else if (ca === null) {
+      miss++;
+    } else {
+      hit++;
+      const uf = /^[A-Z]{2}$/.test(ca.uf) ? `'${ca.uf}'` : 'NULL';
+      rows.push(`('${cep}',${ca.lat},${ca.lng},'cep_aberto','postcode_centroid',${uf})`);
+    }
+    if ((i + 1) % 50 === 0) console.error(`... ${i + 1}/${ceps.length} (hit ${hit} miss ${miss} erro ${erro})`);
+  }
+
+  const sql = `-- Carteira import (Sub-PR 3, geocoding por CEP). ${hit} CEPs via CEP Aberto.
+-- postcode_centroid honesto, source cep_aberto. Idempotente (anti-downgrade). Colar 1x.
+INSERT INTO cep_geo (cep, lat, lng, source, precision, uf) VALUES
+${rows.join(',\n')}
+ON CONFLICT (cep) DO UPDATE SET
+  lat = EXCLUDED.lat, lng = EXCLUDED.lng, source = EXCLUDED.source,
+  precision = EXCLUDED.precision, uf = EXCLUDED.uf, updated_at = now()
+WHERE rank_precisao(EXCLUDED.precision) >= rank_precisao(cep_geo.precision);
+
+SELECT count(*) AS cep_geo_total, count(*) FILTER (WHERE source='cep_aberto') AS via_cep_aberto FROM cep_geo;
+`;
+  writeFileSync(OUT, sql);
+  console.log(`\n=== CARTEIRA IMPORT — pronto ===`);
+  console.log(`CEPs: ${ceps.length} · hit ${hit} · miss ${miss} · erro ${erro}`);
+  console.log(`SQL colável: ${OUT} (${(sql.length / 1024).toFixed(0)} KB, ${hit} linhas)`);
+})();

--- a/scripts/cep-aberto/medir.ts
+++ b/scripts/cep-aberto/medir.ts
@@ -1,0 +1,123 @@
+// Runner do gate CEP Aberto (Sub-PR 3, geocoding por CEP). Lê uma amostra (uf,cep)
+// e mede COBERTURA (o CEP Aberto tem a coord?) + CONFIABILIDADE (a coord cai na
+// cidade certa? — distância ao centróide IBGE do município que a própria API
+// reporta, via cidade.ibge → nosso municipio_geo). Nominatim foi descartado como
+// referência: não resolve CEP nu brasileiro de forma confiável (devolve lixo).
+// Token via env CEP_ABERTO_TOKEN (NÃO commitar). Roda 1× e imprime o relatório.
+//   CEP_ABERTO_TOKEN=xxx bun scripts/cep-aberto/medir.ts /tmp/cep-sample.csv /tmp/muni.csv
+import { readFileSync, writeFileSync } from 'node:fs';
+import { distanciaKm, resumoMedicao, type AmostraMedida } from '../../src/lib/cep/medicao';
+
+const TOKEN = process.env.CEP_ABERTO_TOKEN;
+if (!TOKEN) {
+  console.error('❌ Falta CEP_ABERTO_TOKEN no env.');
+  process.exit(1);
+}
+const CSV = process.argv[2] ?? '/tmp/cep-sample.csv';
+const MUNI = process.argv[3] ?? '/tmp/ibge.csv';
+const FORA_KM = 50; // > isso do centróide = provável cidade errada / coord lixo
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+type Coord = { lat: number; lng: number };
+
+// Centróides IBGE oficiais (codigo_ibge,nome,latitude,longitude,...). Chave = IBGE
+// 7 díg, que casa com o cidade.ibge devolvido pela API do CEP Aberto.
+const muni = new Map<string, Coord>();
+for (const l of readFileSync(MUNI, 'utf8').trim().split('\n').slice(1)) {
+  const p = l.split(',');
+  if (/^[0-9]{7}$/.test(p[0])) muni.set(p[0], { lat: parseFloat(p[2]), lng: parseFloat(p[3]) });
+}
+
+const linhas = readFileSync(CSV, 'utf8')
+  .trim()
+  .split('\n')
+  .map((l) => {
+    const [uf, cep] = l.split(',');
+    return { uf, cep };
+  })
+  .filter((l) => /^[0-9]{8}$/.test(l.cep));
+
+async function cepAberto(cep: string): Promise<{ lat: number; lng: number; ibge: string | null } | null | 'erro'> {
+  for (let tent = 0; tent < 4; tent++) {
+    try {
+      const r = await fetch(`https://www.cepaberto.com/api/v3/cep?cep=${cep}`, {
+        headers: { Authorization: `Token token=${TOKEN}` },
+      });
+      if (r.ok) {
+        const j = (await r.json()) as { latitude?: string; longitude?: string; cidade?: { ibge?: string } };
+        if (j && j.latitude && j.longitude) {
+          return { lat: parseFloat(j.latitude), lng: parseFloat(j.longitude), ibge: j.cidade?.ibge ?? null };
+        }
+        return null; // {} = não coberto
+      }
+      await sleep(2500); // não-ok (rate limit/transiente) → backoff e re-tenta
+    } catch {
+      await sleep(1500);
+    }
+  }
+  return 'erro';
+}
+
+(async () => {
+  const amostras: AmostraMedida[] = [];
+  const porUf = new Map<string, { hit: number; miss: number; erro: number }>();
+  const raw: string[] = ['uf,cep,status,ibge,dist_centroide_km'];
+  let erros = 0;
+  let foraCidade = 0;
+  let semMuni = 0;
+  let i = 0;
+  for (const { uf, cep } of linhas) {
+    i++;
+    const u = porUf.get(uf) ?? { hit: 0, miss: 0, erro: 0 };
+    const ca = await cepAberto(cep);
+    await sleep(1600); // CEP Aberto rate-limita abaixo de ~1,5s/req
+    if (ca === 'erro') {
+      u.erro++;
+      erros++;
+      porUf.set(uf, u);
+      raw.push(`${uf},${cep},erro,,`);
+      continue;
+    }
+    if (ca === null) {
+      u.miss++;
+      porUf.set(uf, u);
+      amostras.push({ coberto: false, distanciaKm: null });
+      raw.push(`${uf},${cep},miss,,`);
+      continue;
+    }
+    u.hit++;
+    porUf.set(uf, u);
+    const c = ca.ibge ? muni.get(ca.ibge) : undefined;
+    let d: number | null = null;
+    if (c) {
+      d = distanciaKm(ca.lat, ca.lng, c.lat, c.lng);
+      if (d > FORA_KM) foraCidade++;
+    } else {
+      semMuni++;
+    }
+    amostras.push({ coberto: true, distanciaKm: d });
+    raw.push(`${uf},${cep},hit,${ca.ibge ?? ''},${d != null ? d.toFixed(3) : ''}`);
+    if (i % 50 === 0) console.error(`... ${i}/${linhas.length} (hits ${amostras.filter((a) => a.coberto).length})`);
+  }
+
+  writeFileSync('/tmp/cep-gate-raw.csv', raw.join('\n'));
+  const r = resumoMedicao(amostras);
+  const naCidade = r.comReferencia - foraCidade;
+  const confPct = r.comReferencia ? Math.round((naCidade / r.comReferencia) * 1000) / 10 : 0;
+  console.log('\n=== GATE CEP ABERTO — RESULTADO ===');
+  console.log(`Amostra: ${linhas.length} CEPs · ${porUf.size} UFs · erros API: ${erros}`);
+  console.log(`COBERTURA: ${r.cobertos}/${r.total} = ${r.coberturaPct}%`);
+  console.log(
+    `CONFIABILIDADE: ${naCidade}/${r.comReferencia} = ${confPct}% na cidade certa (≤${FORA_KM}km do centróide IBGE) · fora: ${foraCidade} · sem centróide: ${semMuni}`,
+  );
+  console.log(
+    `Distância ao centróide (cobertos c/ ref): mediana ${r.distMedianaKm?.toFixed(2) ?? '—'}km · p90 ${r.distP90Km?.toFixed(2) ?? '—'}km`,
+  );
+  console.log('\nCobertura por UF (hit/total):');
+  [...porUf.entries()].sort().forEach(([uf, c]) => {
+    const tot = c.hit + c.miss;
+    const pct = tot ? Math.round((c.hit / tot) * 100) : 0;
+    console.log(`  ${uf}: ${c.hit}/${tot} = ${pct}%${c.erro ? ` (erro ${c.erro})` : ''}`);
+  });
+  console.log('\nRaw por CEP em /tmp/cep-gate-raw.csv');
+})();

--- a/src/components/salesOrderEdit/OrderItemCard.tsx
+++ b/src/components/salesOrderEdit/OrderItemCard.tsx
@@ -3,17 +3,20 @@
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Trash2 } from 'lucide-react';
+import { cn } from '@/lib/utils';
 import { type OrderItem } from './types';
 
 interface OrderItemCardProps {
   item: OrderItem;
   index: number;
   isBlocked: boolean;
+  /** Marca o preço como inválido (≤ 0): destaca o input e mostra aviso. Calculado pelo hook. */
+  isPriceInvalid?: boolean;
   onUpdate: (index: number, field: 'quantidade' | 'valor_unitario', value: number) => void;
   onRemove: (index: number) => void;
 }
 
-export function OrderItemCard({ item, index, isBlocked, onUpdate, onRemove }: OrderItemCardProps) {
+export function OrderItemCard({ item, index, isBlocked, isPriceInvalid = false, onUpdate, onRemove }: OrderItemCardProps) {
   return (
     <div className="border rounded-lg p-3 space-y-2">
       <div className="flex items-start justify-between gap-2">
@@ -65,8 +68,12 @@ export function OrderItemCard({ item, index, isBlocked, onUpdate, onRemove }: Or
             onFocus={(e) => e.target.select()}
             onChange={(e) => onUpdate(index, 'valor_unitario', Number(e.target.value) || 0)}
             disabled={isBlocked}
-            className="h-8 text-sm"
+            aria-invalid={isPriceInvalid || undefined}
+            className={cn('h-8 text-sm', isPriceInvalid && 'border-status-error focus-visible:ring-status-error')}
           />
+          {isPriceInvalid && (
+            <p className="text-xs text-status-error mt-1">Defina um valor maior que zero.</p>
+          )}
         </div>
         <div>
           <label className="text-xs text-muted-foreground">Total</label>

--- a/src/components/salesOrderEdit/__tests__/priceGuard.test.ts
+++ b/src/components/salesOrderEdit/__tests__/priceGuard.test.ts
@@ -1,0 +1,46 @@
+// Guard money-path da EDIÇÃO de pedido: nenhum item de produto pode ser salvo com
+// valor_unitario <= 0. Espelha src/services/orderSubmission/priceGuard.ts (envio),
+// mas sobre o shape OrderItem (valor_unitario + descricao no topo, não unit_price /
+// product.descricao). Reusa a regra-núcleo isInvalidProductPrice (!(price > 0)).
+import { describe, it, expect } from 'vitest';
+import { invalidPricedOrderItemIndices, invalidOrderPriceMessage } from '../priceGuard';
+import type { OrderItem } from '../types';
+
+function item(valor_unitario: number, descricao = 'Lixa'): OrderItem {
+  return { omie_codigo_produto: 1, descricao, quantidade: 1, valor_unitario, valor_total: valor_unitario };
+}
+
+describe('invalidPricedOrderItemIndices', () => {
+  it('vazio quando todos os preços são positivos', () => {
+    expect(invalidPricedOrderItemIndices([item(10), item(50)])).toEqual([]);
+  });
+  it('retorna os índices dos itens com preço inválido, preservando a ordem', () => {
+    const result = invalidPricedOrderItemIndices([item(10, 'Ok'), item(0, 'Zerado'), item(-1, 'Negativo')]);
+    expect(result).toEqual([1, 2]);
+  });
+  it('zero (campo esvaziado vira Number("") || 0) é inválido', () => {
+    expect(invalidPricedOrderItemIndices([item(0)])).toEqual([0]);
+  });
+  it('NaN é inválido (defesa money-path)', () => {
+    expect(invalidPricedOrderItemIndices([item(10), item(Number.NaN)])).toEqual([1]);
+  });
+  it('centavo (0.01) é válido', () => {
+    expect(invalidPricedOrderItemIndices([item(0.01)])).toEqual([]);
+  });
+  it('lista vazia → vazio', () => {
+    expect(invalidPricedOrderItemIndices([])).toEqual([]);
+  });
+});
+
+describe('invalidOrderPriceMessage', () => {
+  it('cita as descrições dos itens inválidos e pede preço maior que zero', () => {
+    const msg = invalidOrderPriceMessage([item(0, 'Disco 7"'), item(0, 'Lixa 120')]);
+    expect(msg).toContain('Disco 7"');
+    expect(msg).toContain('Lixa 120');
+    expect(msg.toLowerCase()).toContain('maior que zero');
+  });
+  it('usa o código quando a descrição está vazia', () => {
+    const semDesc: OrderItem = { omie_codigo_produto: 9, codigo: 'COD-9', descricao: '', quantidade: 1, valor_unitario: 0, valor_total: 0 };
+    expect(invalidOrderPriceMessage([semDesc])).toContain('COD-9');
+  });
+});

--- a/src/components/salesOrderEdit/__tests__/useSalesOrderEdit.priceGuard.test.tsx
+++ b/src/components/salesOrderEdit/__tests__/useSalesOrderEdit.priceGuard.test.tsx
@@ -1,0 +1,149 @@
+// Guard money-path imperativo em handleSave: um item de produto com valor_unitario <= 0
+// NÃO pode persistir nem agendar o sync ao Omie. O input do card faz Number(value) || 0,
+// então esvaziar o campo vira 0 silencioso (PV com valor zerado = prejuízo / pedido
+// inválido). Botão desabilitado é só conveniência; o bloqueio real vive no handleSave.
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+
+const navigateSpy = vi.fn();
+vi.mock('react-router-dom', () => ({
+  useParams: () => ({ id: 'ord-1' }),
+  useNavigate: () => navigateSpy,
+}));
+vi.mock('@/contexts/AuthContext', () => ({ useAuth: () => ({}) }));
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() } }));
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: { from: vi.fn(), functions: { invoke: vi.fn() } },
+}));
+
+import { supabase } from '@/integrations/supabase/client';
+import { toast } from 'sonner';
+import { useSalesOrderEdit } from '../useSalesOrderEdit';
+
+const mockedFrom = vi.mocked(supabase.from);
+const mockedInvoke = vi.mocked(supabase.functions.invoke);
+
+const salesOrderRow = {
+  id: 'ord-1',
+  customer_user_id: 'cust-1',
+  items: [
+    { omie_codigo_produto: 1, codigo: 'C1', descricao: 'Lixa Grão 120', unidade: 'UN', quantidade: 2, valor_unitario: 10, valor_total: 20 },
+  ],
+  subtotal: 20, total: 20, status: 'pendente', notes: null, account: 'oben',
+  omie_pedido_id: 42, omie_numero_pedido: '1001', omie_payload: null, created_at: '2026-01-01',
+};
+
+const updateEqSpy = vi.fn().mockResolvedValue({ error: null });
+const updateSpy = vi.fn().mockReturnValue({ eq: updateEqSpy });
+
+function chainFor(table: string) {
+  if (table === 'sales_orders') {
+    return {
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          single: vi.fn().mockResolvedValue({ data: salesOrderRow, error: null }),
+        }),
+      }),
+      update: updateSpy,
+    };
+  }
+  if (table === 'profiles') {
+    return {
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          single: vi.fn().mockResolvedValue({ data: { name: 'Cliente X' }, error: null }),
+        }),
+      }),
+    };
+  }
+  // omie_products
+  return {
+    select: vi.fn().mockReturnValue({
+      eq: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          order: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue({ data: [], error: null }),
+          }),
+        }),
+      }),
+    }),
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  updateSpy.mockReturnValue({ eq: updateEqSpy });
+  mockedInvoke.mockResolvedValue({ data: { formas: [] }, error: null } as never);
+  mockedFrom.mockImplementation((table) => chainFor(table as string) as never);
+});
+
+async function renderLoaded() {
+  const hook = renderHook(() => useSalesOrderEdit());
+  await waitFor(() => expect(hook.result.current.loading).toBe(false));
+  await waitFor(() => expect(hook.result.current.order).toBeTruthy());
+  return hook;
+}
+
+describe('useSalesOrderEdit — guard de preço ao salvar', () => {
+  it('BLOQUEIA salvar quando um item fica com valor_unitario 0 (não persiste, não sincroniza)', async () => {
+    const { result } = await renderLoaded();
+    mockedInvoke.mockClear(); // descarta as chamadas do load (listar_formas)
+    updateSpy.mockClear();
+
+    act(() => {
+      result.current.updateItem(0, 'valor_unitario', 0);
+    });
+
+    await act(async () => {
+      await result.current.handleSave();
+    });
+
+    expect(toast.error).toHaveBeenCalled();
+    expect(updateSpy).not.toHaveBeenCalled();
+    expect(mockedInvoke).not.toHaveBeenCalledWith(
+      'omie-vendas-sync',
+      expect.objectContaining({ body: expect.objectContaining({ action: 'alterar_pedido' }) }),
+    );
+    expect(navigateSpy).not.toHaveBeenCalled();
+  });
+
+  it('BLOQUEIA salvar com valor_unitario negativo', async () => {
+    const { result } = await renderLoaded();
+    updateSpy.mockClear();
+
+    act(() => {
+      result.current.updateItem(0, 'valor_unitario', -5);
+    });
+    await act(async () => {
+      await result.current.handleSave();
+    });
+
+    expect(toast.error).toHaveBeenCalled();
+    expect(updateSpy).not.toHaveBeenCalled();
+  });
+
+  it('expõe os índices inválidos para a UI destacar e travar o botão', async () => {
+    const { result } = await renderLoaded();
+    expect(result.current.invalidPriceItemIndices).toEqual([]);
+
+    act(() => {
+      result.current.updateItem(0, 'valor_unitario', 0);
+    });
+
+    expect(result.current.invalidPriceItemIndices).toEqual([0]);
+  });
+
+  it('PERMITE salvar quando todos os preços são > 0 (caminho feliz não regride)', async () => {
+    const { result } = await renderLoaded();
+    mockedInvoke.mockClear();
+    updateSpy.mockClear();
+
+    await act(async () => {
+      await result.current.handleSave();
+    });
+
+    expect(updateSpy).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(navigateSpy).toHaveBeenCalledWith('/sales'));
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/salesOrderEdit/priceGuard.ts
+++ b/src/components/salesOrderEdit/priceGuard.ts
@@ -1,0 +1,24 @@
+// Guard money-path da EDIÇÃO de pedido, sobre o shape OrderItem. Reusa a regra-núcleo
+// isInvalidProductPrice (!(price > 0)) do guard do ENVIO
+// (src/services/orderSubmission/priceGuard.ts) — uma ÚNICA definição da decisão
+// monetária; aqui só adaptamos a seleção e a mensagem ao shape OrderItem
+// (valor_unitario / descricao no topo, não unit_price / product.descricao).
+// A edição de pedido só carrega produtos e tintas (não há serviço de afiação "a orçar"),
+// então todo item é elegível ao guard.
+import { isInvalidProductPrice } from '@/services/orderSubmission/priceGuard';
+import type { OrderItem } from './types';
+
+/** Índices dos itens com preço inválido (≤ 0 / NaN), preservando a ordem. A UI usa para destacar. */
+export function invalidPricedOrderItemIndices(items: OrderItem[]): number[] {
+  const indices: number[] = [];
+  items.forEach((item, i) => {
+    if (isInvalidProductPrice(item.valor_unitario)) indices.push(i);
+  });
+  return indices;
+}
+
+/** Mensagem pt-BR pronta para toast, citando os itens inválidos (já filtrados). */
+export function invalidOrderPriceMessage(invalidItems: OrderItem[]): string {
+  const nomes = invalidItems.map((it) => it.descricao || it.codigo || 'item sem nome').join(', ');
+  return `Defina um preço maior que zero antes de salvar. Itens com preço inválido: ${nomes}.`;
+}

--- a/src/components/salesOrderEdit/useSalesOrderEdit.ts
+++ b/src/components/salesOrderEdit/useSalesOrderEdit.ts
@@ -15,6 +15,7 @@ import {
   type FormasPagamentoResponse,
   type OmieProduct,
 } from './types';
+import { invalidPricedOrderItemIndices, invalidOrderPriceMessage } from './priceGuard';
 
 export function useSalesOrderEdit() {
   const { id } = useParams<{ id: string }>();
@@ -201,11 +202,21 @@ export function useSalesOrderEdit() {
   }, [productSearch, catalogProducts]);
 
   const subtotal = items.reduce((s, i) => s + i.valor_total, 0);
+  // Índices dos itens com preço inválido (≤ 0 / NaN) — MESMA fonte para o bloqueio no
+  // save e para o destaque na UI (aria-invalid + botão travado).
+  const invalidPriceItemIndices = useMemo(() => invalidPricedOrderItemIndices(items), [items]);
 
   const handleSave = async () => {
     if (!order) return;
     if (items.length === 0) {
       toast.error('O pedido precisa ter pelo menos 1 item');
+      return;
+    }
+    // Guard money-path: nenhum item de produto pode ser salvo com preço ≤ 0 (esvaziar o
+    // campo vira Number("")||0 = 0). Bloqueia ANTES de qualquer update local ou sync ao
+    // Omie, nos dois caminhos (com e sem omie_pedido_id) — fail-closed imperativo, não só UI.
+    if (invalidPriceItemIndices.length > 0) {
+      toast.error(invalidOrderPriceMessage(invalidPriceItemIndices.map((i) => items[i])));
       return;
     }
     setSaving(true);
@@ -322,6 +333,7 @@ export function useSalesOrderEdit() {
     tintProductAsProduct,
     filteredProducts,
     subtotal,
+    invalidPriceItemIndices,
     handleSave,
     isBlocked,
   };

--- a/src/hooks/useRoutePlanner.ts
+++ b/src/hooks/useRoutePlanner.ts
@@ -44,6 +44,7 @@ import {
 import { carteiraRowToStop, type CarteiraRow } from '@/lib/route/carteira-stop';
 import { montarDetalheAlvo, type AlvoDetalhe } from '@/lib/route/alvo-detalhe';
 import { ordenarFilaGeocode, ordenarFilaGeocodeCep } from '@/lib/route/geocode-fila';
+import { interpretarResolver } from '@/lib/route/cep-resolver';
 import { normalizarCep } from '@/lib/route/cep';
 
 // Teto de prospects por cidade pedido à RPC (a RPC capa em 2000 no SQL).
@@ -1001,7 +1002,7 @@ export function useRoutePlanner() {
   const geocodingAbort = useRef<AbortController | null>(null);
   const geocodeFalhados = useRef<Set<string>>(new Set());
   // Geocoding por CEP (campo): coord por CEP distinto + CEPs que falharam na sessão.
-  const geocodedCepCoords = useRef<Map<string, { lat: number; lng: number }>>(new Map());
+  const geocodedCepCoords = useRef<Map<string, { lat: number; lng: number; precisao: string }>>(new Map());
   const cepFalhados = useRef<Set<string>>(new Set());
   // Modo atual num ref p/ o worker escolher a estratégia (CEP vs endereço) sem stale.
   const planningModeRef = useRef(planningMode);
@@ -1017,18 +1018,19 @@ export function useRoutePlanner() {
   useEffect(() => {
     const enriched = allStops.map(s => {
       const cepCoord = geocodedCepCoords.current.get(normalizarCep(s.address.zip_code) ?? '');
-      if (cepCoord) return { ...s, lat: cepCoord.lat, lng: cepCoord.lng, precisao: 'postcode_centroid' };
+      if (cepCoord) return { ...s, lat: cepCoord.lat, lng: cepCoord.lng, precisao: cepCoord.precisao };
       const cached = geocodedCoords.current.get(s.id);
       return cached ? { ...s, lat: cached.lat, lng: cached.lng } : s;
     });
     setGeocodedAllStops(enriched);
   }, [allStops]);
 
-  // Geocoding progressivo ~1/s, marcados-na-rota primeiro. CAMPO (prospeccao):
-  // geocodifica o CEP DISTINTO → cep_geo_upsert → pinta TODOS os alvos do CEP de uma
-  // vez (1234 empresas ≈ 574 CEPs). EQUIPE: legado por endereço/stop. Re-deriva a
-  // fila a cada ciclo → marcar um alvo re-prioriza o próximo pick; resolvidos/
-  // falhados saem da fila → o loop termina.
+  // Geocoding progressivo, marcados-na-rota primeiro. CAMPO (prospeccao): resolve o
+  // CEP DISTINTO via edge `cep-geo-resolver` (cache cep_geo → CEP Aberto, token
+  // server-side; a edge já persiste no cep_geo/SoT) → pinta TODOS os alvos do CEP de
+  // uma vez (1234 empresas ≈ 574 CEPs). EQUIPE: legado por endereço/stop via Nominatim.
+  // Re-deriva a fila a cada ciclo → marcar um alvo re-prioriza o próximo pick;
+  // resolvidos/falhados saem da fila → o loop termina.
   useEffect(() => {
     geocodingAbort.current?.abort();
     const controller = new AbortController();
@@ -1056,22 +1058,21 @@ export function useRoutePlanner() {
           if (fila.length === 0) break;
           const { cep, cidade, uf } = fila[0];
           try {
-            const coords = await nominatim(`${cep}, ${cidade}, ${uf}, Brazil`);
+            // A edge guarda o token, faz cache + CEP Aberto e já persiste no cep_geo (SoT).
+            const { data, error } = await supabase.functions.invoke('cep-geo-resolver', {
+              body: { cep, cidade, uf },
+            });
+            if (controller.signal.aborted) break;
+            const coords = error ? null : interpretarResolver(data);
             if (coords) {
-              geocodedCepCoords.current.set(cep, coords);
+              geocodedCepCoords.current.set(cep, { lat: coords.lat, lng: coords.lng, precisao: coords.precisao });
               setGeocodedAllStops(prev => prev.map(s =>
                 normalizarCep(s.address.zip_code) === cep
-                  ? { ...s, lat: coords.lat, lng: coords.lng, precisao: 'postcode_centroid' }
+                  ? { ...s, lat: coords.lat, lng: coords.lng, precisao: coords.precisao }
                   : s,
               ));
-              // Persiste: postcode_centroid; anti-downgrade no SQL. Gate = gestor/master
-              // (o contexto campo já exige). Compartilhado por todos os alvos do CEP.
-              void supabase.rpc('cep_geo_upsert' as never, {
-                p_cep: cep, p_lat: coords.lat, p_lng: coords.lng,
-                p_source: 'nominatim', p_precision: 'postcode_centroid',
-              } as never);
             } else {
-              cepFalhados.current.add(cep); // sem resultado → não recicla o mesmo CEP
+              cepFalhados.current.add(cep); // miss / edge indisponível → não recicla o CEP nesta sessão
             }
           } catch (e) {
             if ((e as { name?: string })?.name === 'AbortError') break;
@@ -1104,8 +1105,9 @@ export function useRoutePlanner() {
             geocodeFalhados.current.add(stop.id);
           }
         }
-        // Nominatim rate limit: máx 1 req/s
-        if (!controller.signal.aborted) await new Promise(r => setTimeout(r, 1100));
+        // Pacing: CEP Aberto rate-limita < ~1,6s/req (campo); Nominatim ~1/s (equipe).
+        const espera = planningModeRef.current === 'prospeccao' ? 1600 : 1100;
+        if (!controller.signal.aborted) await new Promise(r => setTimeout(r, espera));
       }
       if (!controller.signal.aborted) setGeocodingPendentes(0);
     })();

--- a/src/lib/cep/medicao.test.ts
+++ b/src/lib/cep/medicao.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { distanciaKm, amostrarPorUf, resumoMedicao, type AmostraMedida } from './medicao';
+
+describe('distanciaKm (haversine)', () => {
+  it('mesmo ponto → 0', () => {
+    expect(distanciaKm(-20.14, -44.88, -20.14, -44.88)).toBe(0);
+  });
+  it('1° de latitude ≈ 111,19 km', () => {
+    expect(distanciaKm(0, 0, 1, 0)).toBeCloseTo(111.19, 1);
+  });
+  it('1° de longitude no equador ≈ 111,19 km', () => {
+    expect(distanciaKm(0, 0, 0, 1)).toBeCloseTo(111.19, 1);
+  });
+  it('simétrica', () => {
+    const ab = distanciaKm(-20.14, -44.88, -23.55, -46.63);
+    const ba = distanciaKm(-23.55, -46.63, -20.14, -44.88);
+    expect(ab).toBeCloseTo(ba, 6);
+  });
+  it('Divinópolis↔São Paulo ≈ 430 km (sanidade)', () => {
+    expect(distanciaKm(-20.14, -44.88, -23.55, -46.63)).toBeGreaterThan(400);
+    expect(distanciaKm(-20.14, -44.88, -23.55, -46.63)).toBeLessThan(460);
+  });
+});
+
+describe('amostrarPorUf (estratificada determinística)', () => {
+  const itens = [
+    { uf: 'MG', cep: '1' }, { uf: 'MG', cep: '2' }, { uf: 'MG', cep: '3' },
+    { uf: 'SP', cep: '4' }, { uf: 'sp', cep: '5' }, { uf: 'RJ', cep: '6' },
+  ];
+  it('limita nPorUf por UF, ordem estável', () => {
+    expect(amostrarPorUf(itens, 2).map((i) => i.cep)).toEqual(['1', '2', '4', '5', '6']);
+  });
+  it('uppercase une mg/MG no mesmo balde', () => {
+    expect(amostrarPorUf([{ uf: 'mg', cep: 'a' }, { uf: 'MG', cep: 'b' }], 1).map((i) => i.cep)).toEqual(['a']);
+  });
+  it('nPorUf 0 → vazio', () => {
+    expect(amostrarPorUf(itens, 0)).toEqual([]);
+  });
+});
+
+describe('resumoMedicao', () => {
+  const mk = (coberto: boolean, distanciaKm: number | null): AmostraMedida => ({ coberto, distanciaKm });
+  it('cobertura %, mediana, p90 e grosseiros (>10km)', () => {
+    const amostras = [
+      mk(true, 0.2), mk(true, 0.5), mk(true, 1.0), mk(true, 2.0),
+      mk(true, 15.0), // grosseiro (erro de cidade)
+      mk(false, null), mk(false, null), // não cobertos
+    ];
+    const r = resumoMedicao(amostras);
+    expect(r.total).toBe(7);
+    expect(r.cobertos).toBe(5);
+    expect(r.coberturaPct).toBeCloseTo(71.4, 1);
+    expect(r.comReferencia).toBe(5);
+    expect(r.grosseirosMaior10km).toBe(1);
+    expect(r.distMedianaKm).not.toBeNull();
+    expect(r.distP90Km).not.toBeNull();
+  });
+  it('vazio → zeros e nulls (ausente ≠ fabricar)', () => {
+    const r = resumoMedicao([]);
+    expect(r).toEqual({
+      total: 0, cobertos: 0, coberturaPct: 0, comReferencia: 0,
+      distMedianaKm: null, distP90Km: null, grosseirosMaior10km: 0,
+    });
+  });
+  it('coberto sem referência não entra na distância', () => {
+    const r = resumoMedicao([{ coberto: true, distanciaKm: null }]);
+    expect(r.cobertos).toBe(1);
+    expect(r.comReferencia).toBe(0);
+    expect(r.distMedianaKm).toBeNull();
+  });
+});

--- a/src/lib/cep/medicao.ts
+++ b/src/lib/cep/medicao.ts
@@ -1,0 +1,74 @@
+// Núcleo PURO da medição do gate CEP Aberto (Sub-PR 3, geocoding por CEP).
+// "Meça antes de confiar" (Codex): antes de importar 1,1M CEPs, medimos numa AMOSTRA
+// estratificada dos nossos CEPs — cobertura (o CEP Aberto tem a coord?) + precisão
+// (a coord concorda com o Nominatim do mesmo CEP?). Esta lógica decide um veredito
+// que afeta o mapa de visitas → é testada (distância errada = veredito errado).
+
+// Haversine: distância em km entre dois pontos (lat/lng em graus). Correto p/ as
+// distâncias curtas do gate (concordância CEP Aberto × Nominatim do mesmo CEP).
+export function distanciaKm(aLat: number, aLng: number, bLat: number, bLng: number): number {
+  const R = 6371; // raio médio da Terra (km)
+  const rad = (g: number) => (g * Math.PI) / 180;
+  const dLat = rad(bLat - aLat);
+  const dLng = rad(bLng - aLng);
+  const h =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(rad(aLat)) * Math.cos(rad(bLat)) * Math.sin(dLng / 2) ** 2;
+  return 2 * R * Math.asin(Math.min(1, Math.sqrt(h)));
+}
+
+// Amostra estratificada: até nPorUf itens por UF, ordem estável (DETERMINÍSTICA —
+// sem Math.random, p/ reprodutibilidade do gate). Pega os primeiros nPorUf de cada UF.
+export function amostrarPorUf<T extends { uf: string }>(itens: T[], nPorUf: number): T[] {
+  const contagem = new Map<string, number>();
+  const out: T[] = [];
+  for (const it of itens) {
+    const uf = (it.uf ?? '').toUpperCase();
+    const n = contagem.get(uf) ?? 0;
+    if (n < nPorUf) {
+      out.push(it);
+      contagem.set(uf, n + 1);
+    }
+  }
+  return out;
+}
+
+export interface AmostraMedida {
+  coberto: boolean; // CEP Aberto retornou coordenada?
+  distanciaKm: number | null; // distância vs referência (Nominatim); null se sem ref
+}
+
+export interface ResumoMedicao {
+  total: number;
+  cobertos: number;
+  coberturaPct: number; // 0..100
+  comReferencia: number;
+  distMedianaKm: number | null;
+  distP90Km: number | null;
+  grosseirosMaior10km: number; // outliers (>10km = provável erro de cidade)
+}
+
+// Percentil por nearest-rank (suficiente p/ o gate; sem interpolação).
+function percentil(ordenado: number[], p: number): number | null {
+  if (ordenado.length === 0) return null;
+  const i = Math.min(ordenado.length - 1, Math.floor((p / 100) * ordenado.length));
+  return ordenado[i];
+}
+
+export function resumoMedicao(amostras: AmostraMedida[]): ResumoMedicao {
+  const total = amostras.length;
+  const cobertos = amostras.filter((a) => a.coberto).length;
+  const dists = amostras
+    .filter((a) => a.distanciaKm != null)
+    .map((a) => a.distanciaKm as number)
+    .sort((x, y) => x - y);
+  return {
+    total,
+    cobertos,
+    coberturaPct: total ? Math.round((cobertos / total) * 1000) / 10 : 0,
+    comReferencia: dists.length,
+    distMedianaKm: percentil(dists, 50),
+    distP90Km: percentil(dists, 90),
+    grosseirosMaior10km: dists.filter((d) => d > 10).length,
+  };
+}

--- a/src/lib/route/cep-resolver.test.ts
+++ b/src/lib/route/cep-resolver.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { interpretarResolver } from './cep-resolver';
+
+describe('interpretarResolver', () => {
+  it('adota coord quando resolved=true com lat/lng finitos', () => {
+    expect(
+      interpretarResolver({ resolved: true, lat: -20.1, lng: -44.8, precision: 'postcode_centroid' }),
+    ).toEqual({ lat: -20.1, lng: -44.8, precisao: 'postcode_centroid' });
+  });
+
+  it('preserva a precisão vinda do cache (ex.: rooftop)', () => {
+    expect(interpretarResolver({ resolved: true, lat: 1, lng: 2, precision: 'rooftop', cached: true })).toEqual({
+      lat: 1,
+      lng: 2,
+      precisao: 'rooftop',
+    });
+  });
+
+  it('default postcode_centroid quando precision ausente', () => {
+    expect(interpretarResolver({ resolved: true, lat: 1, lng: 2 })).toEqual({
+      lat: 1,
+      lng: 2,
+      precisao: 'postcode_centroid',
+    });
+  });
+
+  it('retorna null no miss (resolved=false) → worker mantém centróide', () => {
+    expect(interpretarResolver({ resolved: false })).toBeNull();
+  });
+
+  it('NÃO fabrica pino: resolved=true mas lat/lng null → null', () => {
+    expect(interpretarResolver({ resolved: true, lat: null, lng: null })).toBeNull();
+  });
+
+  it('NÃO fabrica pino: lat/lng não-finito (NaN/Infinity) → null', () => {
+    expect(interpretarResolver({ resolved: true, lat: NaN, lng: 2 })).toBeNull();
+    expect(interpretarResolver({ resolved: true, lat: 1, lng: Infinity })).toBeNull();
+  });
+
+  it('rejeita lat/lng como string (sem coerção implícita = sem número fabricado)', () => {
+    expect(interpretarResolver({ resolved: true, lat: '-20.1', lng: '-44.8' })).toBeNull();
+  });
+
+  it('entrada inválida (null/undefined/string/number/array) → null', () => {
+    expect(interpretarResolver(null)).toBeNull();
+    expect(interpretarResolver(undefined)).toBeNull();
+    expect(interpretarResolver('x')).toBeNull();
+    expect(interpretarResolver(42)).toBeNull();
+    expect(interpretarResolver([])).toBeNull();
+  });
+});

--- a/src/lib/route/cep-resolver.ts
+++ b/src/lib/route/cep-resolver.ts
@@ -1,0 +1,21 @@
+// Interpreta a resposta da edge `cep-geo-resolver` para o worker do roteirizador.
+// Money-path (mapa de visita do vendedor): só adota coord se a edge marcou
+// resolved=true E lat/lng são números FINITOS — NUNCA fabrica pino a partir de
+// resposta ausente/garbage (ausente ≠ zero; sem coerção de string→número). No
+// miss devolve null → o worker mantém o pino aproximado do centróide do município.
+export interface CoordResolvida {
+  lat: number;
+  lng: number;
+  precisao: string;
+}
+
+export function interpretarResolver(data: unknown): CoordResolvida | null {
+  if (!data || typeof data !== 'object') return null;
+  const d = data as Record<string, unknown>;
+  if (d.resolved !== true) return null;
+  const { lat, lng } = d;
+  if (typeof lat !== 'number' || typeof lng !== 'number') return null;
+  if (!Number.isFinite(lat) || !Number.isFinite(lng)) return null;
+  const precisao = typeof d.precision === 'string' && d.precision ? d.precision : 'postcode_centroid';
+  return { lat, lng, precisao };
+}

--- a/src/pages/SalesOrderEdit.tsx
+++ b/src/pages/SalesOrderEdit.tsx
@@ -35,6 +35,7 @@ const SalesOrderEdit = () => {
     tintProductAsProduct,
     filteredProducts,
     subtotal,
+    invalidPriceItemIndices,
     handleSave,
     isBlocked,
   } = useSalesOrderEdit();
@@ -123,6 +124,7 @@ const SalesOrderEdit = () => {
                 item={item}
                 index={index}
                 isBlocked={isBlocked}
+                isPriceInvalid={invalidPriceItemIndices.includes(index)}
                 onUpdate={updateItem}
                 onRemove={removeItem}
               />
@@ -177,7 +179,7 @@ const SalesOrderEdit = () => {
         {!isBlocked && (
           <Button
             onClick={handleSave}
-            disabled={saving || items.length === 0}
+            disabled={saving || items.length === 0 || invalidPriceItemIndices.length > 0}
             className="w-full gap-2"
             size="lg"
           >

--- a/src/services/orderSubmission/__tests__/priceGuard.test.ts
+++ b/src/services/orderSubmission/__tests__/priceGuard.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isInvalidProductPrice,
+  findInvalidPricedProductItems,
+  invalidPriceMessage,
+} from '../priceGuard';
+import type { ProductCartItem } from '@/hooks/unifiedOrder/types';
+
+function prod(unit_price: number, descricao = 'Lixa'): ProductCartItem {
+  return {
+    type: 'product', account: 'oben', quantity: 1, unit_price,
+    product: { id: 'p', omie_codigo_produto: 'X', codigo: 'C', descricao, unidade: 'UN' },
+  } as unknown as ProductCartItem;
+}
+
+describe('isInvalidProductPrice', () => {
+  it('zero é inválido', () => {
+    expect(isInvalidProductPrice(0)).toBe(true);
+  });
+  it('negativo é inválido', () => {
+    expect(isInvalidProductPrice(-5)).toBe(true);
+  });
+  it('NaN é inválido (parseFlot("") || 0 nunca chega aqui, mas defesa money-path)', () => {
+    expect(isInvalidProductPrice(Number.NaN)).toBe(true);
+  });
+  it('Infinity é inválido (parseFloat("1e309") vira Infinity → não pode ir ao Omie)', () => {
+    expect(isInvalidProductPrice(Number.POSITIVE_INFINITY)).toBe(true);
+  });
+  it('-Infinity é inválido', () => {
+    expect(isInvalidProductPrice(Number.NEGATIVE_INFINITY)).toBe(true);
+  });
+  it('preço positivo é válido', () => {
+    expect(isInvalidProductPrice(10)).toBe(false);
+  });
+  it('preço positivo pequeno (centavo) é válido', () => {
+    expect(isInvalidProductPrice(0.01)).toBe(false);
+  });
+});
+
+describe('findInvalidPricedProductItems', () => {
+  it('retorna vazio quando todos os preços são positivos', () => {
+    expect(findInvalidPricedProductItems([prod(10), prod(50)])).toEqual([]);
+  });
+  it('retorna apenas os itens com preço inválido', () => {
+    const zero = prod(0, 'Zerado');
+    const neg = prod(-1, 'Negativo');
+    const ok = prod(10, 'Ok');
+    const result = findInvalidPricedProductItems([ok, zero, neg]);
+    expect(result).toEqual([zero, neg]);
+  });
+  it('lista vazia → vazio', () => {
+    expect(findInvalidPricedProductItems([])).toEqual([]);
+  });
+});
+
+describe('invalidPriceMessage', () => {
+  it('lista as descrições dos itens inválidos na mensagem', () => {
+    const msg = invalidPriceMessage([prod(0, 'Disco 7"'), prod(0, 'Lixa 120')]);
+    expect(msg).toContain('Disco 7"');
+    expect(msg).toContain('Lixa 120');
+    expect(msg.toLowerCase()).toContain('preço');
+  });
+});

--- a/src/services/orderSubmission/priceGuard.ts
+++ b/src/services/orderSubmission/priceGuard.ts
@@ -1,0 +1,31 @@
+import type { ProductCartItem } from '@/hooks/unifiedOrder/types';
+
+/**
+ * Guard money-path: item de PRODUTO (Oben/Colacor) com preço unitário ≤ 0 é sempre
+ * erro silencioso. O input do carrinho faz `parseFloat(e.target.value) || 0` (CartItemList),
+ * então esvaziar o campo vira 0; e o cockpit de markup / Régua de Preço filtram `preco > 0`,
+ * deixando o item zerado INVISÍVEL às proteções e ainda enviável (PV com valor zerado no
+ * Omie = prejuízo / pedido inválido). Não há caso legítimo de produto a R$0 (decisão do
+ * founder 2026-06-16: sem bonificação modelada — se um dia houver, virá com marcador próprio).
+ *
+ * `!(Number.isFinite(price) && price > 0)` trata 0, negativo, NaN, ±Infinity, null e
+ * undefined como inválido (money-path: ausente ≠ zero; e `parseFloat("1e309")` vira
+ * Infinity, que jamais pode ir ao Omie). Serviço de afiação NÃO passa por aqui: preço
+ * null/0 ("a orçar") é legítimo.
+ */
+export function isInvalidProductPrice(price: number): boolean {
+  return !(Number.isFinite(price) && price > 0);
+}
+
+/** Itens de produto com preço inválido, preservando a ordem original. */
+export function findInvalidPricedProductItems(productItems: ProductCartItem[]): ProductCartItem[] {
+  return productItems.filter(item => isInvalidProductPrice(item.unit_price));
+}
+
+/** Mensagem pt-BR pronta para erro estruturado / toast, citando os itens inválidos. */
+export function invalidPriceMessage(items: ProductCartItem[]): string {
+  const nomes = items
+    .map(it => it.product?.descricao || it.product?.codigo || 'item sem nome')
+    .join(', ');
+  return `Defina um preço maior que zero antes de enviar. Itens com preço inválido (R$ 0 ou negativo): ${nomes}.`;
+}

--- a/supabase/functions/cep-geo-resolver/index.ts
+++ b/supabase/functions/cep-geo-resolver/index.ts
@@ -1,0 +1,132 @@
+// Edge `cep-geo-resolver` — resolve UM CEP em coord (lat/lng) para o worker do
+// Roteirizador-campo, com o token do CEP Aberto guardado SERVER-SIDE (nunca no
+// browser). Cadeia: cep_geo (cache/SoT) → CEP Aberto → não-resolvido. NÃO usa
+// Nominatim: o gate (Sub-PR 3) provou que ele devolve lixo p/ CEP nu; o miss aqui
+// cai no centróide do município (a RPC da carteira/prospect já faz COALESCE) — pino
+// honestamente "aproximado", nunca um pino errado (precisão > recall, money-path).
+//
+// Persistência: reencaminha o JWT do staff e chama o cep_geo_upsert existente
+// (SECURITY DEFINER, gate gestor/master, idempotente, anti-downgrade de precisão) —
+// zero migration nova. Gate da fronteira: authorizeCronOrStaff.
+//
+// Secret necessária (founder seta no Lovable): CEP_ABERTO_TOKEN.
+import { createClient } from "npm:@supabase/supabase-js@2";
+import { authorizeCronOrStaff, corsHeaders } from "../_shared/auth.ts";
+
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
+const SERVICE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+const ANON_KEY = Deno.env.get("SUPABASE_ANON_KEY")!;
+const CEP_ABERTO_TOKEN = Deno.env.get("CEP_ABERTO_TOKEN") ?? "";
+
+const json = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+
+function normalizarCep(raw: unknown): string | null {
+  const d = String(raw ?? "").replace(/\D/g, "");
+  return /^\d{8}$/.test(d) ? d : null;
+}
+
+Deno.serve(async (req) => {
+  if (req.method === "OPTIONS") return new Response(null, { headers: corsHeaders });
+
+  try {
+    const auth = await authorizeCronOrStaff(req);
+    if (!auth.ok) return auth.response;
+
+    let body: Record<string, unknown> = {};
+    try {
+      body = await req.json();
+    } catch {
+      /* corpo vazio é tratado como CEP inválido abaixo */
+    }
+    const cep = normalizarCep(body.cep);
+    if (!cep) return json({ resolved: false, error: "CEP inválido" }, 400);
+
+    const admin = createClient(SUPABASE_URL, SERVICE_KEY);
+
+    // 1) Cache: cep_geo é a fonte da verdade. Já resolvido → devolve na hora
+    //    (preserva a precisão real — pode ser melhor que postcode, ex.: rooftop).
+    const { data: cached } = await admin
+      .from("cep_geo")
+      .select("lat,lng,precision,source")
+      .eq("cep", cep)
+      .maybeSingle();
+    if (cached && cached.lat != null && cached.lng != null) {
+      return json({
+        resolved: true,
+        lat: Number(cached.lat),
+        lng: Number(cached.lng),
+        precision: cached.precision ?? "postcode_centroid",
+        source: cached.source ?? "cep_geo",
+        cached: true,
+      });
+    }
+
+    if (!CEP_ABERTO_TOKEN) {
+      console.error("CEP_ABERTO_TOKEN ausente — defina a secret no Supabase.");
+      return json({ resolved: false, error: "sem token" });
+    }
+
+    // 2) CEP Aberto (token server-side). Timeout curto p/ não travar o worker;
+    //    429/5xx/timeout/{} → lat/lng ficam null → não-resolvido (cai no centróide).
+    let lat: number | null = null;
+    let lng: number | null = null;
+    try {
+      const ctrl = new AbortController();
+      const timer = setTimeout(() => ctrl.abort(), 5000);
+      const r = await fetch(`https://www.cepaberto.com/api/v3/cep?cep=${cep}`, {
+        headers: { Authorization: `Token token=${CEP_ABERTO_TOKEN}` },
+        signal: ctrl.signal,
+      });
+      clearTimeout(timer);
+      if (r.ok) {
+        const j = (await r.json()) as { latitude?: string; longitude?: string };
+        if (j && j.latitude && j.longitude) {
+          lat = parseFloat(j.latitude);
+          lng = parseFloat(j.longitude);
+        }
+      } else {
+        console.warn("CEP Aberto não-ok:", r.status);
+      }
+    } catch (e) {
+      console.warn("CEP Aberto falhou/timeout:", e instanceof Error ? e.message : String(e));
+    }
+
+    if (lat == null || lng == null || !Number.isFinite(lat) || !Number.isFinite(lng)) {
+      return json({ resolved: false });
+    }
+
+    // 3) Persiste no cep_geo via RPC gated/anti-downgrade, reencaminhando o JWT do
+    //    staff (o worker roda em contexto gestor/master). Falha no upsert NÃO impede
+    //    devolver a coord — só não popula o cache desta vez.
+    const authHeader = req.headers.get("Authorization") ?? "";
+    if (authHeader.startsWith("Bearer ")) {
+      const userClient = createClient(SUPABASE_URL, ANON_KEY, {
+        global: { headers: { Authorization: authHeader } },
+      });
+      const { error: upErr } = await userClient.rpc("cep_geo_upsert", {
+        p_cep: cep,
+        p_lat: lat,
+        p_lng: lng,
+        p_source: "cep_aberto",
+        p_precision: "postcode_centroid",
+      });
+      if (upErr) console.error("cep_geo_upsert falhou:", upErr.message);
+    }
+
+    return json({
+      resolved: true,
+      lat,
+      lng,
+      precision: "postcode_centroid",
+      source: "cep_aberto",
+      cached: false,
+    });
+  } catch (err) {
+    console.error("cep-geo-resolver erro:", err instanceof Error ? err.message : String(err));
+    return json({ resolved: false, error: "erro interno" }, 500);
+  }
+});


### PR DESCRIPTION
## O quê
Bloqueia **salvar a edição** de um pedido quando algum item de produto tem `valor_unitario ≤ 0`. Espelha o guard `validate_price` do fluxo de ENVIO.

## Por quê (money-path)
O input "Valor Unit." faz `Number(value)||0` → esvaziar o campo vira **0 silencioso**. PV com valor zerado no Omie = prejuízo / pedido inválido. Não há produto legítimo a R$0 (decisão do founder 2026-06-16); a edição só lida com **produtos/tintas** (sem serviço de afiação "a orçar") → bloqueio sempre.

## Como
- **Guard imperativo** em `handleSave`, ANTES do `update` local **e** do sync ao Omie, nos **dois** caminhos (com/sem `omie_pedido_id`). Fail-closed.
- Reusa a regra-núcleo `isInvalidProductPrice` (`!(price>0)`) — uma única definição money-path. `find`/`message` adaptados ao shape `OrderItem` num helper local (`salesOrderEdit/priceGuard.ts`).
- UI: `aria-invalid` + `border-status-error` + aviso inline; botão **Salvar desabilitado**. Mesma fonte (`invalidPriceItemIndices`) para UI e bloqueio.
- TDD RED→GREEN; decisão de reuso validada com **Codex** (consult adversarial).

## ⚠️ Coordenação multi-sessão (ordem de merge)
`src/services/orderSubmission/priceGuard.ts` (+ teste) foram criados **byte-idênticos** à sessão irmã do **ENVIO** (worktree `cool-hodgkin`, ainda não-commitada) de propósito — dois `add` idênticos se fundem sem conflito. Se o PR do envio mergear depois, rebaseia limpo; se alterar o arquivo antes de commitar, vira conflito add/add trivial. **Atenção à ordem de merge entre este PR e o do envio.**

## Verificação
- typecheck (strict) verde
- suíte de testes — 3676/3676 verde
- eslint (arquivos tocados) — 0 errors (1 warning `exhaustive-deps` pré-existente)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
