### PR TITLE
feat(grupo-360): Grupo de Cliente 360 — visão consolidada por dono (Fase 1 + 2)

### DIFF
--- a/.claude/skills/farmer-industrial/SKILL.md
+++ b/.claude/skills/farmer-industrial/SKILL.md
@@ -86,9 +86,11 @@ normalizadas (minúsculas, sem acento, hífen→espaço). O usuário roda no Lov
 resultado. Você recebe, por cliente (consolidado por CNPJ): cidade, última compra, intervalo
 médio, gasto recente vs. histórico, `tier_queda` já calculado e os produtos comprados.
 - **CNPJs do mesmo cliente** (sucessão: encerrou um e abriu outro; ou multi-CNPJ ativo: fatura por
-  vários ao mesmo tempo): opcional e **confirm-first**. Tem armadilha de métrica séria (juntar
-  pedidos de CNPJs paralelos esconde queda) — **leia `references/unificacao-cnpj.md`** antes de
-  unir. Nunca una sem o dono confirmar. Até lá, o default por-CNPJ é o que roda (seguro).
+  vários ao mesmo tempo): o dono confirma os grupos na tela **Gestão → Grupos de Cliente**
+  (`cliente_grupos`), e a query da carteira (§2) **já consolida por grupo** no `cliente_key` — o
+  dono com vários CNPJs vira **1 entrada** (a Farmer não liga 2x). Atenção à armadilha de métrica
+  (intervalo pooled esconde um CNPJ parado num grupo ativo) — **leia `references/unificacao-cnpj.md`**;
+  pra grupo, olhe a recência **por documento** também. Sem grupo confirmado, consolida por CNPJ (seguro).
 
 ### Passo 3 — Mapear cidade → dia de rota
 Para cada cliente, ache o **dia da semana** pela cidade dele, usando o calendário de

--- a/.claude/skills/farmer-industrial/references/queries-sql.md
+++ b/.claude/skills/farmer-industrial/references/queries-sql.md
@@ -95,8 +95,15 @@ with pedidos as (
 cli as (   -- enriquece cada pedido com CNPJ (chave do cliente) + cidade do comprador
   select ped.*,
          p.name, p.customer_type, p.cnae,
-         coalesce(nullif(regexp_replace(coalesce(p.cnpj, p.document, ''), '\D','','g'),''),
-                  ped.customer_user_id::text) as cliente_key,
+         -- cliente_key consolida por GRUPO quando o documento está num cliente_grupo_membros
+         -- (dono com vários CNPJs = 1 entrada, não liga 2x); senão por CNPJ; senão por user_id.
+         -- Requer as tabelas do Grupo 360 (cliente_grupos/_membros). ⚙️ se não existirem, remova o 1º coalesce.
+         coalesce(
+           (select 'grupo:'||cgm.grupo_id::text from cliente_grupo_membros cgm
+             where cgm.documento = nullif(regexp_replace(coalesce(p.cnpj, p.document, ''),'\D','','g'),'')),
+           nullif(regexp_replace(coalesce(p.cnpj, p.document, ''), '\D','','g'),''),
+           ped.customer_user_id::text
+         ) as cliente_key,
          initcap(trim(regexp_replace(a.city, '\s*\([^)]*\)\s*$',''))) as cidade,
          upper(trim(a.state)) as uf,
          lower(translate(regexp_replace(trim(a.city), '\s*\([^)]*\)\s*$',''),
@@ -162,8 +169,16 @@ order by case tier_queda when 'critico' then 0 when 'alerta' then 1 when 'em_dia
 Notas:
 - Rode **um dia de rota por vez** (4–6 cidades no `in`) ou a semana inteira da Farmer. Se ficar
   lento, é aceitável — são ~6 mil pedidos.
-- **Consolidação por CNPJ** (`cliente_key`): junta os perfis Colacor+Oben do mesmo cliente, então
-  o `produtos_comprados` reflete o mix REAL entre as linhas (é onde mora o cross-sell).
+- **Consolidação por GRUPO e CNPJ** (`cliente_key`): se o documento está num grupo
+  (`cliente_grupo_membros`, criado na tela Grupos de Cliente), todos os CNPJs do dono colapsam
+  numa entrada só (`grupo:<uuid>`) — a Farmer **não liga 2x pro mesmo dono**, e o
+  `produtos_comprados` soma o mix de TODOS os documentos do grupo. Sem grupo, consolida por CNPJ.
+- ⚠️ **Cuidado de métrica em grupo (regra Codex):** o `intervalo_medio_dias` é pooled (junta os
+  pedidos do grupo) → pode encolher e **esconder um CNPJ do grupo que parou** se outro continua
+  comprando. Por isso, para clientes que são grupo (`cliente_key` começa com `grupo:`), **olhe
+  também a recência por documento** (um CNPJ sumido num grupo ativo é oportunidade de recuperação
+  que o `dias_desde_ultima` do grupo mascara). O corte absoluto `> 90d` e o `tier_queda` do grupo
+  pegam o grupo inteiro dormente; o drop por-documento dentro de grupo ativo é o caso a vigiar.
 - Clientes **sem CNPJ** caem no fallback `user_id` (não consolidam, mas aparecem). Clientes **sem
   cidade** não entram no `in (...)` — trate-os à parte (bucket "completar cadastro").
 

--- a/.claude/skills/farmer-industrial/references/unificacao-cnpj.md
+++ b/.claude/skills/farmer-industrial/references/unificacao-cnpj.md
@@ -142,11 +142,17 @@ Para cada par A/B com `A_first/A_last`, `B_first/B_last`:
   com **várias entidades de faturamento**.
 - Senão → `incerto`: dedup de ligação pode valer, fusão de métrica não.
 
-## 4. Confirmação sem tabela no banco (a interface é a skill, não o git)
+## 4. Confirmação — AGORA é a tabela real do app (Grupo de Cliente 360)
 
-Não dá pra persistir tabela (read-only). O dono também não edita `VALUES` cru com segurança.
-**Melhor**: o dono te passa um bloco estruturado simples (CSV/lista), **a skill gera o CTE** com
-metadata e auto-validação. O alias mínimo NÃO é `(doc, grupo)` — é:
+> **ATUALIZADO (2026-06-16):** o que abaixo era "sem tabela / VALUES inline" virou **feature de
+> produto**: a tela **Gestão → Grupos de Cliente** persiste `cliente_grupos` + `cliente_grupo_membros`
+> (com `relation_type`, `valid_from/to`, `UNIQUE(documento)`). O dono confirma os grupos na UI; a
+> query da carteira (§2) já **lê essa tabela** no `cliente_key` (`grupo:<uuid>`) → dedup automático.
+> Os diagnósticos abaixo (sucessão com âncora, multi-sinal) alimentam as **sugestões** dessa tela.
+> O VALUES inline a seguir fica como **fallback** (quando a tabela não existe ou pra teste pontual).
+
+Versão fallback (sem a tabela): o dono te passa um bloco estruturado simples (CSV/lista), **a
+skill gera o CTE** com metadata e auto-validação. O alias mínimo NÃO é `(doc, grupo)` — é:
 
 ```sql
 aliases(doc, grupo, relation_type, valid_from, valid_to, confirmed_at, note) as (

--- a/db/test-grupo-comercial.sh
+++ b/db/test-grupo-comercial.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# Prova money-path da view v_grupo_comercial (Grupo 360 Fase 2).
+# Migrations REAIS: 20260615120000_cliente_grupos.sql + 20260616140000_v_grupo_comercial.sql
+# Rode: bash db/test-grupo-comercial.sh > /tmp/t.log 2>&1; echo "exit=$?"
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PGVER=17; PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+PORT="${PGPORT_TEST:-5467}"; SLUG="grupo-comercial"
+DATA="$(mktemp -d "/tmp/pgtest-${SLUG}.XXXXXX")/data"
+export LC_ALL=C LANG=C
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente"; exit 1; }
+CELLAR="$(brew --prefix "postgresql@${PGVER}")"
+cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
+mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"; cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+trap cleanup EXIT
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l "/tmp/pg-${SLUG}.log" -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres prove
+P()  { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d prove -v ON_ERROR_STOP=1 "$@"; }
+Pq() { P -tA "$@"; }
+P -q -f "$REPO_ROOT/db/stubs-supabase.sql"
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION auth.uid()  RETURNS uuid LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.uid',  true), '')::uuid $f$;
+CREATE OR REPLACE FUNCTION auth.role() RETURNS text LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.role', true), '') $f$;
+ALTER ROLE service_role BYPASSRLS;
+SQL
+PASS=0; FAIL=0
+ok(){ PASS=$((PASS+1)); echo "  ✅ $1"; }; bad(){ FAIL=$((FAIL+1)); echo "  ❌ $1"; }
+eq(){ if [ "$2" = "$3" ]; then ok "$1 (=$2)"; else bad "$1 — esperado [$3], veio [$2]"; fi; }
+echo "═══ setup (PG17 :$PORT) ═══"
+
+# ── ZONA 1 — pré-requisitos ──
+P -q <<'SQL'
+create table public.user_roles (user_id uuid, role text);
+create table public.fin_permissoes (user_id uuid primary key, pode_ver_todas_empresas boolean default false, empresas text[] default '{}');
+create or replace function public.fin_user_can_access(check_company text default null)
+returns boolean language plpgsql stable security definer set search_path to 'public' as $$
+declare v_perm record;
+begin
+  if exists (select 1 from user_roles where user_id = auth.uid() and role in ('admin','manager','employee','master')) then return true; end if;
+  select * into v_perm from fin_permissoes where user_id = auth.uid();
+  if v_perm is null then return false; end if;
+  if check_company is null then return true; end if;
+  return v_perm.pode_ver_todas_empresas or check_company = any(v_perm.empresas);
+end; $$;
+
+create table public.profiles (user_id uuid primary key, cnpj text, document text, name text, razao_social text);
+create table public.sales_orders (
+  id uuid primary key default gen_random_uuid(),
+  customer_user_id uuid, account text, created_at timestamptz, status text,
+  deleted_at timestamptz, items jsonb, total numeric
+);
+alter table public.sales_orders enable row level security;
+create policy so_service on public.sales_orders for all using (auth.role()='service_role');
+create policy so_fin on public.sales_orders for select using (public.fin_user_can_access());
+SQL
+
+# ── ZONA 2 — migrations REAIS ──
+P -q -f "$REPO_ROOT/supabase/migrations/20260615120000_cliente_grupos.sql"
+MIG_VIEW="$REPO_ROOT/supabase/migrations/20260616140000_v_grupo_comercial.sql"
+P -q -f "$MIG_VIEW"
+echo "migrations aplicadas"
+
+# ── ZONA 3 — seeds ──
+P -q <<'SQL'
+insert into auth.users(id) values
+  ('11111111-1111-1111-1111-111111111111'),('22222222-2222-2222-2222-222222222222'),
+  ('aaaa1111-0000-0000-0000-000000000001'),('aaaa1111-0000-0000-0000-000000000002'),
+  ('aaaa1111-0000-0000-0000-000000000003'),('aaaa1111-0000-0000-0000-000000000004') on conflict do nothing;
+insert into public.user_roles(user_id,role) values ('11111111-1111-1111-1111-111111111111','employee');
+
+-- perfis dos compradores (cnpj formatado p/ testar normalização; CPF no document)
+insert into public.profiles(user_id, cnpj, document, name) values
+  ('aaaa1111-0000-0000-0000-000000000001','12.345.678/0001-99', null, 'Comprador CNPJ'),
+  ('aaaa1111-0000-0000-0000-000000000002', null, '111.222.333-44',    'Comprador CPF'),
+  ('aaaa1111-0000-0000-0000-000000000003','98765432000111', null,     'Comprador G2'),
+  ('aaaa1111-0000-0000-0000-000000000004','99999999000199', null,     'Sem grupo');
+
+-- grupos
+insert into public.cliente_grupos(id, nome) values
+  ('bbbbbbbb-0000-0000-0000-000000000001','Dono G1'),('bbbbbbbb-0000-0000-0000-000000000002','Dono G2');
+insert into public.cliente_grupo_membros(grupo_id, documento, relation_type) values
+  ('bbbbbbbb-0000-0000-0000-000000000001','12345678000199','multi_ativo'),
+  ('bbbbbbbb-0000-0000-0000-000000000001','11122233344','sucessao'),
+  ('bbbbbbbb-0000-0000-0000-000000000002','98765432000111','incerto');
+
+-- pedidos: cross-empresa, janela 90d vs anterior, status excluídos, vazamento
+insert into public.sales_orders(customer_user_id, account, created_at, status, deleted_at, total) values
+  ('aaaa1111-0000-0000-0000-000000000001','colacor',(current_date-10)::timestamptz,'faturado',  null,100),  -- 90d
+  ('aaaa1111-0000-0000-0000-000000000001','oben',   (current_date-120)::timestamptz,'importado', null,200), -- 90-180, cross-empresa
+  ('aaaa1111-0000-0000-0000-000000000002','colacor',(current_date-5)::timestamptz, 'faturado',  null, 50),  -- 90d, CPF
+  ('aaaa1111-0000-0000-0000-000000000001','colacor',(current_date-5)::timestamptz, 'cancelado', null,999),  -- EXCLUÍDO
+  ('aaaa1111-0000-0000-0000-000000000001','colacor',(current_date-5)::timestamptz, 'rascunho',  null,888),  -- EXCLUÍDO
+  ('aaaa1111-0000-0000-0000-000000000003','oben',   (current_date-10)::timestamptz,'faturado',  null, 70),  -- G2
+  ('aaaa1111-0000-0000-0000-000000000004','colacor',(current_date-5)::timestamptz, 'faturado',  null,777);  -- VAZAMENTO
+grant select on public.cliente_grupos, public.cliente_grupo_membros, public.sales_orders,
+  public.profiles, public.v_grupo_comercial to authenticated;
+SQL
+
+# ── ZONA 4 — asserts (postgres = vê tudo) ──
+echo "── asserts ──"
+G1="bbbbbbbb-0000-0000-0000-000000000001"
+eq "A1 faturamento_total G1 cross-empresa (100+200+50, sem 999/888)" "$(Pq -c "select faturamento_total from public.v_grupo_comercial where grupo_id='$G1';")" "350"
+eq "A2a fat_90d G1 (100+50)" "$(Pq -c "select fat_90d from public.v_grupo_comercial where grupo_id='$G1';")" "150"
+eq "A2b fat_90d_anterior G1 (200, janela 90-180)" "$(Pq -c "select fat_90d_anterior from public.v_grupo_comercial where grupo_id='$G1';")" "200"
+eq "A3a dias_desde_ultima G1 (=5)" "$(Pq -c "select dias_desde_ultima from public.v_grupo_comercial where grupo_id='$G1';")" "5"
+eq "A3b qtd_pedidos G1 (3 válidos; cancelado/rascunho fora)" "$(Pq -c "select qtd_pedidos from public.v_grupo_comercial where grupo_id='$G1';")" "3"
+eq "A4 sum faturamento todos grupos = 420 (350+70; SEM o 777 órfão)" "$(Pq -c "select coalesce(sum(faturamento_total),0) from public.v_grupo_comercial;")" "420"
+FIN=$(Pq -c "set test.uid='11111111-1111-1111-1111-111111111111'; set role authenticated; select count(*) from public.v_grupo_comercial;" | tail -1)
+eq "A6a fin vê 2 grupos" "$FIN" "2"
+NF=$(Pq -c "set test.uid='22222222-2222-2222-2222-222222222222'; set role authenticated; select count(*) from public.v_grupo_comercial;" | tail -1)
+eq "A6b NÃO-fin vê 0 (RLS via security_invoker)" "$NF" "0"
+
+# ── ZONA 5 — falsificação ──
+echo "── falsificação ──"
+# F1: sem filtro de status → cancelado(999)+rascunho(888) entram → A1 vira 350+999+888=2237
+P -q <<'SQL'
+create or replace view public.v_grupo_comercial with (security_invoker=true) as
+with ped as (select regexp_replace(coalesce(p.cnpj,p.document,''),'\D','','g') as doc, so.created_at::date data, so.total valor
+  from public.sales_orders so join public.profiles p on p.user_id=so.customer_user_id where so.deleted_at is null)  -- SEM where status
+select m.grupo_id, count(distinct ped.doc) filter (where ped.doc is not null) documentos_com_compra,
+  count(ped.data) qtd_pedidos, max(ped.data) ultima_compra, (current_date-max(ped.data)) dias_desde_ultima,
+  coalesce(sum(ped.valor),0) faturamento_total,
+  coalesce(sum(ped.valor) filter (where ped.data > current_date-90),0) fat_90d,
+  coalesce(sum(ped.valor) filter (where ped.data <= current_date-90 and ped.data > current_date-180),0) fat_90d_anterior,
+  round(coalesce(sum(ped.valor) filter (where ped.data > current_date-180),0)/6.0,2) media_mensal_6m
+from public.cliente_grupo_membros m left join ped on ped.doc=m.documento group by m.grupo_id;
+SQL
+eq "F1 sem filtro status → 2237 (prova dente do filtro)" "$(Pq -c "select faturamento_total from public.v_grupo_comercial where grupo_id='$G1';")" "2237"
+P -q -f "$MIG_VIEW"
+# F2: janela invertida (≤ vira >) → fat_90d pegaria o de 120d → vira 250 (100+200-... ) — prova que a janela tem dente
+P -q <<'SQL'
+create or replace view public.v_grupo_comercial with (security_invoker=true) as
+with ped as (select regexp_replace(coalesce(p.cnpj,p.document,''),'\D','','g') as doc, so.created_at::date data, so.total valor
+  from public.sales_orders so join public.profiles p on p.user_id=so.customer_user_id
+  where so.status in ('faturado','importado','separacao','enviado') and so.deleted_at is null)
+select m.grupo_id, count(distinct ped.doc) filter (where ped.doc is not null) documentos_com_compra,
+  count(ped.data) qtd_pedidos, max(ped.data) ultima_compra, (current_date-max(ped.data)) dias_desde_ultima,
+  coalesce(sum(ped.valor),0) faturamento_total,
+  coalesce(sum(ped.valor) filter (where ped.data <= current_date-90),0) fat_90d,  -- SABOTAGEM: <= em vez de >
+  coalesce(sum(ped.valor) filter (where ped.data <= current_date-90 and ped.data > current_date-180),0) fat_90d_anterior,
+  round(coalesce(sum(ped.valor) filter (where ped.data > current_date-180),0)/6.0,2) media_mensal_6m
+from public.cliente_grupo_membros m left join ped on ped.doc=m.documento group by m.grupo_id;
+SQL
+eq "F2 janela invertida → fat_90d=200 (prova dente da janela)" "$(Pq -c "select fat_90d from public.v_grupo_comercial where grupo_id='$G1';")" "200"
+P -q -f "$MIG_VIEW"
+# F3: sem security_invoker → não-fin vê
+P -q <<'SQL'
+create or replace view public.v_grupo_comercial with (security_invoker=false) as
+with ped as (select regexp_replace(coalesce(p.cnpj,p.document,''),'\D','','g') as doc, so.created_at::date data, so.total valor
+  from public.sales_orders so join public.profiles p on p.user_id=so.customer_user_id
+  where so.status in ('faturado','importado','separacao','enviado') and so.deleted_at is null)
+select m.grupo_id, count(distinct ped.doc) filter (where ped.doc is not null) documentos_com_compra,
+  count(ped.data) qtd_pedidos, max(ped.data) ultima_compra, (current_date-max(ped.data)) dias_desde_ultima,
+  coalesce(sum(ped.valor),0) faturamento_total,
+  coalesce(sum(ped.valor) filter (where ped.data > current_date-90),0) fat_90d,
+  coalesce(sum(ped.valor) filter (where ped.data <= current_date-90 and ped.data > current_date-180),0) fat_90d_anterior,
+  round(coalesce(sum(ped.valor) filter (where ped.data > current_date-180),0)/6.0,2) media_mensal_6m
+from public.cliente_grupo_membros m left join ped on ped.doc=m.documento group by m.grupo_id;
+SQL
+eq "F3 sem security_invoker → não-fin vê 2 (prova dente do A6b)" "$(Pq -c "set test.uid='22222222-2222-2222-2222-222222222222'; set role authenticated; select count(*) from public.v_grupo_comercial;" | tail -1)" "2"
+P -q -f "$MIG_VIEW"
+
+echo "──────────────────────────────"
+echo "RESULTADO: $PASS ok / $FAIL fail"
+[ "$FAIL" = "0" ] || { echo "❌ HARNESS VERMELHO"; exit 1; }
+echo "✅ HARNESS VERDE"

--- a/db/test-grupo-contas-receber.sh
+++ b/db/test-grupo-contas-receber.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+# Prova money-path da view v_grupo_contas_receber (Grupo 360 Fase 1, Task 3).
+# Migrations REAIS: 20260615120000_cliente_grupos.sql + 20260616120000_v_grupo_contas_receber.sql
+# Rode: bash db/test-grupo-contas-receber.sh > /tmp/t.log 2>&1; echo "exit=$?"
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PGVER=17
+PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+PORT="${PGPORT_TEST:-5466}"
+SLUG="grupo-contas-receber"
+DATA="$(mktemp -d "/tmp/pgtest-${SLUG}.XXXXXX")/data"
+export LC_ALL=C LANG=C
+
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente"; exit 1; }
+CELLAR="$(brew --prefix "postgresql@${PGVER}")"
+cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
+mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
+cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+trap cleanup EXIT
+
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l "/tmp/pg-${SLUG}.log" -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres prove
+P()  { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d prove -v ON_ERROR_STOP=1 "$@"; }
+Pq() { P -tA "$@"; }
+
+P -q -f "$REPO_ROOT/db/stubs-supabase.sql"
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION auth.uid()  RETURNS uuid LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.uid',  true), '')::uuid $f$;
+CREATE OR REPLACE FUNCTION auth.role() RETURNS text LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.role', true), '') $f$;
+ALTER ROLE service_role BYPASSRLS;
+SQL
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  ✅ $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  ❌ $1"; }
+eq()  { if [ "$2" = "$3" ]; then ok "$1 (=$2)"; else bad "$1 — esperado [$3], veio [$2]"; fi; }
+echo "═══ setup pronto (PG17 :$PORT) ═══"
+
+# ── ZONA 1 — pré-requisitos: user_roles, fin_permissoes, fin_contas_receber (+RLS) e fin_user_can_access ──
+P -q <<'SQL'
+create table public.user_roles (user_id uuid, role text);
+create table public.fin_permissoes (user_id uuid primary key, pode_ver_todas_empresas boolean default false, empresas text[] default '{}');
+
+create table public.fin_contas_receber (
+  id uuid primary key default gen_random_uuid(),
+  company text,
+  cnpj_cpf text,
+  nome_cliente text,
+  saldo numeric,
+  data_vencimento date,
+  status_titulo text
+);
+
+-- gate real do financeiro (SECURITY DEFINER lê user_roles/fin_permissoes como definer)
+create or replace function public.fin_user_can_access(check_company text default null)
+returns boolean language plpgsql stable security definer set search_path to 'public' as $$
+declare v_perm record;
+begin
+  if exists (select 1 from user_roles where user_id = auth.uid() and role in ('admin','manager','employee','master')) then
+    return true;
+  end if;
+  select * into v_perm from fin_permissoes where user_id = auth.uid();
+  if v_perm is null then return false; end if;
+  if check_company is null then return true; end if;
+  return v_perm.pode_ver_todas_empresas or check_company = any(v_perm.empresas);
+end; $$;
+
+-- RLS de fin_contas_receber (mesmo gate); a view security_invoker tem que respeitar isto
+alter table public.fin_contas_receber enable row level security;
+create policy fcr_service on public.fin_contas_receber for all using (auth.role() = 'service_role');
+create policy fcr_fin on public.fin_contas_receber for select using (public.fin_user_can_access(company));
+SQL
+
+# ── ZONA 2 — aplicar as migrations REAIS (Lei #1) ──
+P -q -f "$REPO_ROOT/supabase/migrations/20260615120000_cliente_grupos.sql"
+MIG_VIEW="$REPO_ROOT/supabase/migrations/20260616120000_v_grupo_contas_receber.sql"
+P -q -f "$MIG_VIEW"
+echo "migrations aplicadas (tabelas + view)"
+
+# ── ZONA 3 — seeds + grants ──
+P -q <<'SQL'
+insert into auth.users(id) values
+  ('11111111-1111-1111-1111-111111111111'),  -- fin user (employee)
+  ('22222222-2222-2222-2222-222222222222')   -- não-fin
+  on conflict do nothing;
+insert into public.user_roles(user_id, role) values
+  ('11111111-1111-1111-1111-111111111111','employee');  -- só o fin user tem role
+
+-- grupos
+insert into public.cliente_grupos(id, nome) values
+  ('aaaaaaaa-0000-0000-0000-000000000001','Dono G1'),
+  ('aaaaaaaa-0000-0000-0000-000000000002','Dono G2');
+-- membros: G1 = {CNPJ, CPF}; G2 = {outro CNPJ}
+insert into public.cliente_grupo_membros(grupo_id, documento, relation_type) values
+  ('aaaaaaaa-0000-0000-0000-000000000001','12345678000199','multi_ativo'),
+  ('aaaaaaaa-0000-0000-0000-000000000001','11122233344','sucessao'),
+  ('aaaaaaaa-0000-0000-0000-000000000002','98765432000111','incerto');
+
+-- títulos: cross-empresa, aging, status excluídos, CPF, formatado, e um SEM grupo (vazamento)
+insert into public.fin_contas_receber(company, cnpj_cpf, nome_cliente, saldo, data_vencimento, status_titulo) values
+  ('colacor','12.345.678/0001-99','CNPJ formatado', 100, current_date + 10, 'A VENCER'),   -- a_vencer + normalização
+  ('oben',   '12345678000199',    'CNPJ oben',       50, current_date - 45, 'ATRASADO'),    -- venc_31_60 + cross-empresa
+  ('colacor','111.222.333-44',    'CPF formatado',   30, current_date,      'VENCE HOJE'),  -- a_vencer + CPF + normalização
+  ('colacor','12345678000199',    'CNPJ recebido',  999, current_date - 5,  'RECEBIDO'),    -- EXCLUÍDO
+  ('colacor','12345678000199',    'CNPJ cancelado', 888, current_date - 5,  'CANCELADO'),   -- EXCLUÍDO
+  ('oben',   '98765432000111',    'G2',              70, current_date + 5,  'A VENCER'),    -- G2
+  ('colacor','99999999000199',    'Sem grupo',      777, current_date + 5,  'A VENCER');    -- VAZAMENTO (não pode aparecer)
+
+grant select on public.cliente_grupos, public.cliente_grupo_membros, public.fin_contas_receber,
+  public.v_grupo_contas_receber, public.v_grupo_contas_receber_por_doc to authenticated;
+SQL
+
+# ── ZONA 4 — asserts (como postgres = superuser, vê tudo: prova a matemática) ──
+echo "── asserts ──"
+V=$(Pq -c "select total_aberto from public.v_grupo_contas_receber where grupo_id='aaaaaaaa-0000-0000-0000-000000000001';")
+eq "A1 total_aberto G1 soma across empresa (100+50+30)" "$V" "180"
+
+AV=$(Pq -c "select a_vencer from public.v_grupo_contas_receber where grupo_id='aaaaaaaa-0000-0000-0000-000000000001';")
+eq "A2a a_vencer G1 (100 colacor futuro + 30 cpf hoje)" "$AV" "130"
+V3060=$(Pq -c "select venc_31_60 from public.v_grupo_contas_receber where grupo_id='aaaaaaaa-0000-0000-0000-000000000001';")
+eq "A2b venc_31_60 G1 (50 oben 45d)" "$V3060" "50"
+
+SUMALL=$(Pq -c "select coalesce(sum(total_aberto),0) from public.v_grupo_contas_receber;")
+eq "A3 sum de todos grupos = 250 (G1 180 + G2 70; SEM o 777 órfão e SEM recebido/cancelado)" "$SUMALL" "250"
+
+DOCSUM=$(Pq -c "select coalesce(sum(total_aberto),0) from public.v_grupo_contas_receber_por_doc where documento='12345678000199' and grupo_id='aaaaaaaa-0000-0000-0000-000000000001';")
+eq "A4 por-doc: CNPJ soma 150 (100+50, 2 empresas)" "$DOCSUM" "150"
+
+LEAK=$(Pq -c "select count(*) from public.v_grupo_contas_receber_por_doc where documento='99999999000199';")
+eq "A5 vazamento: documento órfão (777) NÃO aparece" "$LEAK" "0"
+
+# A7 RLS (security_invoker): fin vê, não-fin não vê
+FINCNT=$(Pq -c "set test.uid='11111111-1111-1111-1111-111111111111'; set role authenticated; select count(*) from public.v_grupo_contas_receber;" | tail -1)
+eq "A7a fin (employee) vê os 2 grupos" "$FINCNT" "2"
+NFCNT=$(Pq -c "set test.uid='22222222-2222-2222-2222-222222222222'; set role authenticated; select count(*) from public.v_grupo_contas_receber;" | tail -1)
+eq "A7b NÃO-fin vê 0 (RLS via security_invoker)" "$NFCNT" "0"
+
+# ── ZONA 5 — FALSIFICAÇÃO (sabota → exige vermelho → restaura) ──
+echo "── falsificação ──"
+
+# F1: join furado (t.doc = m.id::text nunca casa) → A1 deveria virar 0
+P -q <<'SQL'
+create or replace view public.v_grupo_contas_receber with (security_invoker = true) as
+with tit as (select regexp_replace(fcr.cnpj_cpf,'\D','','g') as doc, fcr.saldo, fcr.data_vencimento
+             from public.fin_contas_receber fcr where fcr.status_titulo <> all (array['RECEBIDO','CANCELADO']))
+select g.id as grupo_id, g.nome, 0::bigint as documentos_com_titulo,
+  coalesce(sum(t.saldo),0) as total_aberto, 0::numeric a_vencer, 0::numeric venc_1_30,
+  0::numeric venc_31_60, 0::numeric venc_61_90, 0::numeric venc_90_mais
+from public.cliente_grupos g join public.cliente_grupo_membros m on m.grupo_id=g.id
+left join tit t on t.doc = m.id::text   -- SABOTAGEM: id (uuid) nunca = doc (dígitos)
+where g.ativo group by g.id, g.nome;
+SQL
+VF=$(Pq -c "select total_aberto from public.v_grupo_contas_receber where grupo_id='aaaaaaaa-0000-0000-0000-000000000001';")
+eq "F1 join furado → 0 (prova que A1 tem dente)" "$VF" "0"
+P -q -f "$MIG_VIEW"  # restaura
+
+# F2: sem o filtro de status → recebido(999)+cancelado(888) entram → 2067
+P -q <<'SQL'
+create or replace view public.v_grupo_contas_receber with (security_invoker = true) as
+with tit as (select regexp_replace(fcr.cnpj_cpf,'\D','','g') as doc, fcr.saldo, fcr.data_vencimento
+             from public.fin_contas_receber fcr)   -- SABOTAGEM: sem WHERE status
+select g.id as grupo_id, g.nome, 0::bigint documentos_com_titulo,
+  coalesce(sum(t.saldo),0) as total_aberto, 0::numeric a_vencer, 0::numeric venc_1_30,
+  0::numeric venc_31_60, 0::numeric venc_61_90, 0::numeric venc_90_mais
+from public.cliente_grupos g join public.cliente_grupo_membros m on m.grupo_id=g.id
+left join tit t on t.doc = m.documento where g.ativo group by g.id, g.nome;
+SQL
+VF2=$(Pq -c "select total_aberto from public.v_grupo_contas_receber where grupo_id='aaaaaaaa-0000-0000-0000-000000000001';")
+eq "F2 sem filtro status → 2067 (180+999+888; prova dente do filtro)" "$VF2" "2067"
+P -q -f "$MIG_VIEW"  # restaura
+
+# F3: sem security_invoker → não-fin passa a ver (RLS deixa de aplicar)
+P -q <<'SQL'
+create or replace view public.v_grupo_contas_receber with (security_invoker = false) as
+with tit as (select regexp_replace(fcr.cnpj_cpf,'\D','','g') as doc, fcr.saldo, fcr.data_vencimento
+             from public.fin_contas_receber fcr where fcr.status_titulo <> all (array['RECEBIDO','CANCELADO']))
+select g.id as grupo_id, g.nome, 0::bigint documentos_com_titulo,
+  coalesce(sum(t.saldo),0) as total_aberto, 0::numeric a_vencer, 0::numeric venc_1_30,
+  0::numeric venc_31_60, 0::numeric venc_61_90, 0::numeric venc_90_mais
+from public.cliente_grupos g join public.cliente_grupo_membros m on m.grupo_id=g.id
+left join tit t on t.doc = m.documento where g.ativo group by g.id, g.nome;
+SQL
+NFF=$(Pq -c "set test.uid='22222222-2222-2222-2222-222222222222'; set role authenticated; select count(*) from public.v_grupo_contas_receber;" | tail -1)
+eq "F3 sem security_invoker → não-fin vê 2 (prova dente do A7b)" "$NFF" "2"
+P -q -f "$MIG_VIEW"  # restaura
+
+echo "──────────────────────────────"
+echo "RESULTADO: $PASS ok / $FAIL fail"
+[ "$FAIL" = "0" ] || { echo "❌ HARNESS VERMELHO"; exit 1; }
+echo "✅ HARNESS VERDE"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -105,6 +105,8 @@ const FinanceiroAnalytics = lazy(() => import("./pages/FinanceiroAnalytics"));
 const FinanceiroCockpit = lazy(() => import("./pages/FinanceiroCockpit"));
 const FinanceiroConciliacao = lazy(() => import("./pages/FinanceiroConciliacao"));
 const FinanceiroOrcamento = lazy(() => import("./pages/FinanceiroOrcamento"));
+const GestaoGruposCliente = lazy(() => import("./pages/GestaoGruposCliente"));
+const GrupoCliente360 = lazy(() => import("./pages/GrupoCliente360"));
 const FinanceiroIntercompany = lazy(() => import("./pages/FinanceiroIntercompany"));
 const FinanceiroIntercompanyFila = lazy(() => import("./pages/FinanceiroIntercompanyFila"));
 const FinanceiroTributario = lazy(() => import("./pages/FinanceiroTributario"));
@@ -265,6 +267,9 @@ const App = () => {
                 <Route path="financeiro/funding" element={<FinanceiroFunding />} />
                 <Route path="financeiro/gestao" element={<FinanceiroGestao />} />
                 <Route path="financeiro/analise" element={<FinanceiroAnalise />} />
+                {/* Grupo de Cliente 360 (mesmo gate do financeiro — mostra recebível) */}
+                <Route path="gestao/grupos-cliente" element={<GestaoGruposCliente />} />
+                <Route path="gestao/grupos-cliente/:grupoId" element={<GrupoCliente360 />} />
               </Route>
 
               {/* ─── Staff-only (fail-closed: todo o resto) ─── */}

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -178,6 +178,7 @@ const unifiedNavSections: { title: string; items: NavItem[] }[] = [
       { icon: UserCheck, label: 'Liberar Acessos', path: '/admin/approvals', staffOnly: true },
       { icon: Users, label: 'Departamentos', path: '/admin/departments', staffOnly: true },
       { icon: UserX, label: 'Clientes não-vinculados', path: '/admin/clientes-nao-vinculados', gestorComercialOuMaster: true },
+      { icon: Users, label: 'Grupos de Cliente', path: '/gestao/grupos-cliente', gestorComercialOuMaster: true },
       { icon: Radar, label: 'Radar de Clientes', path: '/radar', gestorComercialOuMaster: true },
       { icon: Library, label: 'Base de conhecimento', path: '/admin/knowledge-base', staffOnly: true },
       { icon: Calculator, label: 'Calculadora de rendimento', path: '/admin/calculadora' },

--- a/src/components/grupos/AddDocumentoDialog.tsx
+++ b/src/components/grupos/AddDocumentoDialog.tsx
@@ -1,0 +1,141 @@
+import { useEffect, useState } from 'react';
+import { toast } from 'sonner';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+  DialogDescription,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Loader2 } from 'lucide-react';
+import {
+  useAddMembro,
+  documentoValido,
+  normalizarDocumento,
+  type RelationType,
+} from '@/queries/useClienteGrupos';
+
+interface AddDocumentoDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  grupoId: string;
+  grupoNome: string;
+}
+
+const RELATION_LABELS: Record<RelationType, string> = {
+  incerto: 'Incerto (só agrupar)',
+  multi_ativo: 'Multi-CNPJ ativo (fatura junto)',
+  sucessao: 'Sucessão (encerrou um, abriu outro)',
+};
+
+export function AddDocumentoDialog({ open, onOpenChange, grupoId, grupoNome }: AddDocumentoDialogProps) {
+  const [documento, setDocumento] = useState('');
+  const [relationType, setRelationType] = useState<RelationType>('incerto');
+  const [note, setNote] = useState('');
+  const addMembro = useAddMembro();
+
+  useEffect(() => {
+    if (open) {
+      setDocumento('');
+      setRelationType('incerto');
+      setNote('');
+    }
+  }, [open]);
+
+  const digits = normalizarDocumento(documento);
+  const valido = documentoValido(documento);
+
+  const handleAdd = async () => {
+    if (!valido) {
+      toast.error('Informe um CPF (11 dígitos) ou CNPJ (14 dígitos).');
+      return;
+    }
+    try {
+      await addMembro.mutateAsync({ grupoId, documento, relationType, note: note.trim() || null });
+      toast.success('Documento adicionado ao grupo.');
+      onOpenChange(false);
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'Não consegui adicionar o documento.');
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Adicionar documento</DialogTitle>
+          <DialogDescription>Vincula um CNPJ/CPF ao grupo «{grupoNome}».</DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-2">
+          <div className="space-y-1.5">
+            <Label htmlFor="doc">CNPJ ou CPF</Label>
+            <Input
+              id="doc"
+              value={documento}
+              onChange={(e) => setDocumento(e.target.value)}
+              placeholder="00.000.000/0000-00 ou 000.000.000-00"
+              autoFocus
+            />
+            <p className="text-xs text-muted-foreground">
+              {digits.length > 0
+                ? valido
+                  ? `${digits.length === 11 ? 'CPF' : 'CNPJ'} válido (${digits.length} dígitos)`
+                  : `${digits.length} dígitos — precisa ser 11 (CPF) ou 14 (CNPJ)`
+                : 'Pode colar formatado; eu normalizo pra dígitos.'}
+            </p>
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="rel">Tipo de relação</Label>
+            <Select value={relationType} onValueChange={(v) => setRelationType(v as RelationType)}>
+              <SelectTrigger id="rel">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {(Object.keys(RELATION_LABELS) as RelationType[]).map((rt) => (
+                  <SelectItem key={rt} value={rt}>
+                    {RELATION_LABELS[rt]}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="note">Nota (opcional)</Label>
+            <Textarea
+              id="note"
+              value={note}
+              onChange={(e) => setNote(e.target.value)}
+              placeholder="Por que este documento é o mesmo dono."
+              rows={2}
+            />
+          </div>
+        </div>
+
+        <DialogFooter className="gap-2">
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={addMembro.isPending}>
+            Cancelar
+          </Button>
+          <Button onClick={handleAdd} disabled={addMembro.isPending || !valido} className="gap-2">
+            {addMembro.isPending && <Loader2 className="h-4 w-4 animate-spin" />}
+            Adicionar
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/grupos/GrupoComercialTab.tsx
+++ b/src/components/grupos/GrupoComercialTab.tsx
@@ -1,0 +1,95 @@
+import { Loader2, TrendingUp, TrendingDown, Minus } from 'lucide-react';
+import { Card, CardContent } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { useGrupoComercial, tendenciaGrupo } from '@/queries/useGrupoComercial';
+import { formatBRL } from '@/lib/grupos/format';
+
+function fmtData(d: string | null): string {
+  if (!d) return '—';
+  const [y, m, day] = d.slice(0, 10).split('-');
+  return `${day}/${m}/${y}`;
+}
+
+const TONE_CLASS: Record<string, string> = {
+  success: 'text-status-success',
+  warning: 'text-status-warning',
+  error: 'text-status-error',
+  muted: 'text-muted-foreground',
+};
+
+function Metric({ label, valor }: { label: string; valor: string }) {
+  return (
+    <Card>
+      <CardContent className="p-3">
+        <p className="text-xs text-muted-foreground">{label}</p>
+        <p className="mt-0.5 text-lg font-semibold tabular-nums">{valor}</p>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function GrupoComercialTab({ grupoId }: { grupoId: string }) {
+  const { data, isLoading, error } = useGrupoComercial(grupoId);
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center py-10">
+        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+  if (error) {
+    return <p className="text-sm text-status-error">Não consegui carregar o comercial: {error instanceof Error ? error.message : 'erro'}.</p>;
+  }
+
+  const c = data!;
+  if (c.qtd_pedidos === 0) {
+    return (
+      <Card>
+        <CardContent className="py-10 text-center text-sm text-muted-foreground">
+          Nenhuma compra registrada pros documentos deste grupo.
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const t = tendenciaGrupo(c);
+  const TrendIcon = t.tone === 'error' ? TrendingDown : t.tone === 'success' ? TrendingUp : Minus;
+  const pctTxt = t.pct == null ? '' : ` (${t.pct > 0 ? '+' : ''}${Math.round(t.pct * 100)}%)`;
+
+  return (
+    <div className="space-y-4">
+      {/* Faturamento total + tendência */}
+      <Card>
+        <CardContent className="flex flex-wrap items-end justify-between gap-3 p-4">
+          <div>
+            <p className="text-xs text-muted-foreground">Faturamento total (histórico)</p>
+            <p className="mt-0.5 text-3xl font-bold tabular-nums">{formatBRL(c.faturamento_total)}</p>
+          </div>
+          <Badge variant="outline" className={`gap-1 ${TONE_CLASS[t.tone]}`}>
+            <TrendIcon className="h-3.5 w-3.5" /> {t.label}{pctTxt}
+          </Badge>
+        </CardContent>
+      </Card>
+
+      {/* Janelas + média */}
+      <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+        <Metric label="Faturamento 90d" valor={formatBRL(c.fat_90d)} />
+        <Metric label="90d anteriores" valor={formatBRL(c.fat_90d_anterior)} />
+        <Metric label="Média mensal (6m)" valor={formatBRL(c.media_mensal_6m)} />
+      </div>
+
+      {/* Recência + volume */}
+      <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+        <Metric label="Última compra" valor={fmtData(c.ultima_compra)} />
+        <Metric label="Dias desde a última" valor={c.dias_desde_ultima == null ? '—' : String(c.dias_desde_ultima)} />
+        <Metric label="Pedidos · documentos" valor={`${c.qtd_pedidos} · ${c.documentos_com_compra}`} />
+      </div>
+
+      <p className="text-xs text-muted-foreground">
+        Tendência por janela (90d vs 90d anterior) — não por intervalo médio, pra não esconder queda quando CNPJs do grupo se alternam.
+        O mix ausente e o roteiro de recuperação vêm do plano da Farmer (skill farmer-industrial), que trata este grupo como um cliente só.
+      </p>
+    </div>
+  );
+}

--- a/src/components/grupos/GrupoContatosTab.tsx
+++ b/src/components/grupos/GrupoContatosTab.tsx
@@ -1,0 +1,85 @@
+import { Loader2, Phone, MapPin, Mail, UserCog } from 'lucide-react';
+import { Card, CardContent } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { useGrupoContatos, type GrupoContato } from '@/queries/useGrupoContatos';
+import { formatDoc } from '@/lib/grupos/format';
+
+function ContatoLinha({ c }: { c: GrupoContato }) {
+  return (
+    <div className="space-y-1 rounded-md border px-3 py-2 text-sm">
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="font-medium">{c.nome ?? 'Sem nome'}</span>
+        {c.empresa_omie && <Badge variant="outline" className="uppercase">{c.empresa_omie}</Badge>}
+      </div>
+      <div className="flex flex-wrap gap-x-4 gap-y-1 text-muted-foreground">
+        {c.phone && (
+          <span className="inline-flex items-center gap-1">
+            <Phone className="h-3.5 w-3.5" /> {c.phone}
+          </span>
+        )}
+        {(c.cidade || c.endereco) && (
+          <span className="inline-flex items-center gap-1">
+            <MapPin className="h-3.5 w-3.5" /> {[c.endereco, c.cidade && `${c.cidade}${c.uf ? '/' + c.uf : ''}`].filter(Boolean).join(' — ')}
+          </span>
+        )}
+        {c.email && (
+          <span className="inline-flex items-center gap-1">
+            <Mail className="h-3.5 w-3.5" /> {c.email}
+          </span>
+        )}
+        {c.omie_codigo_vendedor != null && (
+          <span className="inline-flex items-center gap-1">
+            <UserCog className="h-3.5 w-3.5" /> vendedor {c.omie_codigo_vendedor}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function GrupoContatosTab({ grupoId }: { grupoId: string }) {
+  const { data, isLoading, error } = useGrupoContatos(grupoId);
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center py-10">
+        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+  if (error) {
+    return <p className="text-sm text-status-error">Não consegui carregar os contatos: {error instanceof Error ? error.message : 'erro'}.</p>;
+  }
+
+  const contatos = data ?? [];
+  if (contatos.length === 0) {
+    return (
+      <Card>
+        <CardContent className="py-10 text-center text-sm text-muted-foreground">
+          Nenhum cadastro encontrado pros documentos deste grupo. (Os documentos podem não ter perfil vinculado no app.)
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // agrupa por documento
+  const porDoc = new Map<string, GrupoContato[]>();
+  for (const c of contatos) {
+    const arr = porDoc.get(c.documento) ?? [];
+    arr.push(c);
+    porDoc.set(c.documento, arr);
+  }
+
+  return (
+    <div className="space-y-3">
+      {[...porDoc.entries()].map(([doc, linhas]) => (
+        <div key={doc} className="space-y-1.5">
+          <p className="font-mono text-xs text-muted-foreground">{formatDoc(doc)}</p>
+          {linhas.map((c) => (
+            <ContatoLinha key={`${c.documento}-${c.user_id}`} c={c} />
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/grupos/GrupoFinanceiroTab.tsx
+++ b/src/components/grupos/GrupoFinanceiroTab.tsx
@@ -1,0 +1,87 @@
+import { Loader2, Info } from 'lucide-react';
+import { Card, CardContent } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { useGrupoFinanceiro } from '@/queries/useGrupoFinanceiro';
+import { formatDoc, formatBRL } from '@/lib/grupos/format';
+
+function Metric({ label, valor, tone }: { label: string; valor: number; tone?: 'warning' | 'error' }) {
+  const color = tone === 'error' ? 'text-status-error' : tone === 'warning' ? 'text-status-warning' : 'text-foreground';
+  return (
+    <Card>
+      <CardContent className="p-3">
+        <p className="text-xs text-muted-foreground">{label}</p>
+        <p className={`mt-0.5 text-lg font-semibold tabular-nums ${color}`}>{formatBRL(valor)}</p>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function GrupoFinanceiroTab({ grupoId }: { grupoId: string }) {
+  const { data, isLoading, error } = useGrupoFinanceiro(grupoId);
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center py-10">
+        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+  if (error) {
+    return <p className="text-sm text-status-error">Não consegui carregar o financeiro: {error instanceof Error ? error.message : 'erro'}.</p>;
+  }
+
+  const r = data!.resumo;
+  const semTitulo = r.total_aberto === 0 && data!.porDoc.length === 0;
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-start gap-2 rounded-md border border-status-info/30 bg-status-info/5 px-3 py-2 text-xs text-muted-foreground">
+        <Info className="mt-0.5 h-3.5 w-3.5 shrink-0 text-status-info" />
+        <span>Visão consolidada — a cobrança é emitida no Omie por documento; aqui é só a soma dos {r.documentos_com_titulo} documento(s) com título em aberto.</span>
+      </div>
+
+      {semTitulo ? (
+        <Card>
+          <CardContent className="py-10 text-center text-sm text-muted-foreground">
+            Nenhum recebível em aberto pros documentos deste grupo.
+          </CardContent>
+        </Card>
+      ) : (
+        <>
+          {/* Exposição total + aging */}
+          <Card>
+            <CardContent className="p-4">
+              <p className="text-xs text-muted-foreground">Exposição total (em aberto)</p>
+              <p className="mt-0.5 text-3xl font-bold tabular-nums">{formatBRL(r.total_aberto)}</p>
+            </CardContent>
+          </Card>
+          <div className="grid grid-cols-2 gap-2 sm:grid-cols-5">
+            <Metric label="A vencer" valor={r.a_vencer} />
+            <Metric label="Vencido 1–30" valor={r.venc_1_30} tone="warning" />
+            <Metric label="Vencido 31–60" valor={r.venc_31_60} tone="warning" />
+            <Metric label="Vencido 61–90" valor={r.venc_61_90} tone="error" />
+            <Metric label="Vencido 90+" valor={r.venc_90_mais} tone="error" />
+          </div>
+
+          {/* Por documento (expor a composição) */}
+          <div className="space-y-1.5">
+            <h3 className="text-sm font-medium text-muted-foreground">Por documento</h3>
+            {data!.porDoc.map((d) => (
+              <div key={`${d.documento}-${d.company ?? ''}`} className="flex items-center justify-between gap-2 rounded-md border px-3 py-2 text-sm">
+                <div className="flex min-w-0 items-center gap-2">
+                  <span className="font-mono">{formatDoc(d.documento)}</span>
+                  {d.company && <Badge variant="outline" className="shrink-0 uppercase">{d.company}</Badge>}
+                  {d.nome_cliente && <span className="truncate text-muted-foreground">{d.nome_cliente}</span>}
+                </div>
+                <div className="shrink-0 text-right tabular-nums">
+                  <span className="font-medium">{formatBRL(d.total_aberto)}</span>
+                  {d.vencido > 0 && <span className="ml-2 text-xs text-status-error">({formatBRL(d.vencido)} vencido)</span>}
+                </div>
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/grupos/GrupoFormDialog.tsx
+++ b/src/components/grupos/GrupoFormDialog.tsx
@@ -1,0 +1,108 @@
+import { useEffect, useState } from 'react';
+import { toast } from 'sonner';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+  DialogDescription,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { Loader2 } from 'lucide-react';
+import { useCreateGrupo, useUpdateGrupo, type ClienteGrupo } from '@/queries/useClienteGrupos';
+
+interface GrupoFormDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Quando presente, edita; senão, cria. */
+  grupo?: Pick<ClienteGrupo, 'id' | 'nome' | 'notas'>;
+  /** Recebe o id do grupo criado (útil pra navegar pro 360). */
+  onCreated?: (grupoId: string) => void;
+}
+
+export function GrupoFormDialog({ open, onOpenChange, grupo, onCreated }: GrupoFormDialogProps) {
+  const editando = !!grupo;
+  const [nome, setNome] = useState('');
+  const [notas, setNotas] = useState('');
+  const createGrupo = useCreateGrupo();
+  const updateGrupo = useUpdateGrupo();
+  const salvando = createGrupo.isPending || updateGrupo.isPending;
+
+  useEffect(() => {
+    if (open) {
+      setNome(grupo?.nome ?? '');
+      setNotas(grupo?.notas ?? '');
+    }
+  }, [open, grupo]);
+
+  const handleSalvar = async () => {
+    const nomeTrim = nome.trim();
+    if (!nomeTrim) {
+      toast.error('Dê um nome ao grupo (o nome do dono).');
+      return;
+    }
+    try {
+      if (editando && grupo) {
+        await updateGrupo.mutateAsync({ id: grupo.id, nome: nomeTrim, notas: notas.trim() || null });
+        toast.success('Grupo atualizado.');
+      } else {
+        const id = await createGrupo.mutateAsync({ nome: nomeTrim, notas: notas.trim() || null });
+        toast.success('Grupo criado.');
+        onCreated?.(id);
+      }
+      onOpenChange(false);
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'Não consegui salvar o grupo.');
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>{editando ? 'Editar grupo' : 'Novo grupo de cliente'}</DialogTitle>
+          <DialogDescription>
+            Um grupo é a identidade única de um dono — junta os CNPJs/CPFs dele nas 3 empresas.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-2">
+          <div className="space-y-1.5">
+            <Label htmlFor="grupo-nome">Nome do dono / grupo</Label>
+            <Input
+              id="grupo-nome"
+              value={nome}
+              onChange={(e) => setNome(e.target.value)}
+              placeholder="Ex.: João da Silva (Marcenaria + Esquadrias)"
+              autoFocus
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="grupo-notas">Notas (opcional)</Label>
+            <Textarea
+              id="grupo-notas"
+              value={notas}
+              onChange={(e) => setNotas(e.target.value)}
+              placeholder="Contexto: por que estes documentos são o mesmo dono."
+              rows={3}
+            />
+          </div>
+        </div>
+
+        <DialogFooter className="gap-2">
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={salvando}>
+            Cancelar
+          </Button>
+          <Button onClick={handleSalvar} disabled={salvando} className="gap-2">
+            {salvando && <Loader2 className="h-4 w-4 animate-spin" />}
+            {editando ? 'Salvar' : 'Criar grupo'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/lib/grupos/format.ts
+++ b/src/lib/grupos/format.ts
@@ -1,0 +1,15 @@
+/** Formatação compartilhada das telas de Grupo de Cliente 360. */
+
+/** Formata documento (só-dígitos) como CNPJ ou CPF; devolve cru se não for 11/14. */
+export function formatDoc(d: string): string {
+  if (d.length === 14) return d.replace(/(\d{2})(\d{3})(\d{3})(\d{4})(\d{2})/, '$1.$2.$3/$4-$5');
+  if (d.length === 11) return d.replace(/(\d{3})(\d{3})(\d{3})(\d{2})/, '$1.$2.$3-$4');
+  return d;
+}
+
+const BRL = new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL' });
+
+/** Formata em Real. Aceita number ou string (a view numérica do Supabase vem como string). */
+export function formatBRL(v: number | string | null | undefined): string {
+  return BRL.format(Number(v ?? 0));
+}

--- a/src/pages/GestaoGruposCliente.tsx
+++ b/src/pages/GestaoGruposCliente.tsx
@@ -1,0 +1,152 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { toast } from 'sonner';
+import { Users, Plus, Trash2, ArrowRight, Building2, Loader2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  useClienteGrupos,
+  useRemoveMembro,
+  type ClienteGrupo,
+  type RelationType,
+} from '@/queries/useClienteGrupos';
+import { GrupoFormDialog } from '@/components/grupos/GrupoFormDialog';
+import { AddDocumentoDialog } from '@/components/grupos/AddDocumentoDialog';
+
+const RELATION_BADGE: Record<RelationType, string> = {
+  sucessao: 'sucessão',
+  multi_ativo: 'multi-CNPJ',
+  incerto: 'incerto',
+};
+
+function formatDoc(d: string): string {
+  if (d.length === 14) return d.replace(/(\d{2})(\d{3})(\d{3})(\d{4})(\d{2})/, '$1.$2.$3/$4-$5');
+  if (d.length === 11) return d.replace(/(\d{3})(\d{3})(\d{3})(\d{2})/, '$1.$2.$3-$4');
+  return d;
+}
+
+function GrupoCard({ grupo }: { grupo: ClienteGrupo }) {
+  const navigate = useNavigate();
+  const [addOpen, setAddOpen] = useState(false);
+  const removeMembro = useRemoveMembro();
+
+  const handleRemove = async (membroId: string, doc: string) => {
+    try {
+      await removeMembro.mutateAsync(membroId);
+      toast.success(`Documento ${formatDoc(doc)} removido do grupo.`);
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'Não consegui remover.');
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between gap-2 pb-3">
+        <div className="min-w-0">
+          <CardTitle className="truncate text-base">{grupo.nome}</CardTitle>
+          <p className="text-xs text-muted-foreground">
+            {grupo.membros.length} documento{grupo.membros.length === 1 ? '' : 's'}
+          </p>
+        </div>
+        <Button variant="ghost" size="sm" className="gap-1" onClick={() => navigate(`/gestao/grupos-cliente/${grupo.id}`)}>
+          Ver 360 <ArrowRight className="h-4 w-4" />
+        </Button>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        {grupo.membros.length === 0 && (
+          <p className="text-sm text-muted-foreground">Nenhum documento ainda — adicione os CNPJs/CPFs do dono.</p>
+        )}
+        {grupo.membros.map((m) => (
+          <div key={m.id} className="flex items-center justify-between gap-2 rounded-md border px-3 py-2 text-sm">
+            <div className="flex min-w-0 items-center gap-2">
+              <Building2 className="h-4 w-4 shrink-0 text-muted-foreground" />
+              <span className="font-mono">{formatDoc(m.documento)}</span>
+              <Badge variant="outline" className="shrink-0">{RELATION_BADGE[m.relation_type]}</Badge>
+            </div>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7 text-muted-foreground hover:text-status-error"
+              onClick={() => handleRemove(m.id, m.documento)}
+              disabled={removeMembro.isPending}
+              aria-label="Remover documento"
+            >
+              <Trash2 className="h-4 w-4" />
+            </Button>
+          </div>
+        ))}
+        <Button variant="outline" size="sm" className="mt-1 gap-1" onClick={() => setAddOpen(true)}>
+          <Plus className="h-4 w-4" /> Adicionar documento
+        </Button>
+      </CardContent>
+      <AddDocumentoDialog open={addOpen} onOpenChange={setAddOpen} grupoId={grupo.id} grupoNome={grupo.nome} />
+    </Card>
+  );
+}
+
+export default function GestaoGruposCliente() {
+  const { data: grupos, isLoading, error } = useClienteGrupos();
+  const [novoOpen, setNovoOpen] = useState(false);
+  const navigate = useNavigate();
+
+  return (
+    <div className="container mx-auto max-w-5xl space-y-6 p-4 sm:p-6">
+      <header className="flex flex-col justify-between gap-3 sm:flex-row sm:items-center">
+        <div className="flex items-center gap-3">
+          <Users className="h-6 w-6 text-primary" />
+          <div>
+            <h1 className="font-display" style={{ fontSize: '2rem', fontWeight: 500 }}>
+              Grupos de Cliente
+            </h1>
+            <p className="text-sm text-muted-foreground">
+              Junte os CNPJs/CPFs de um mesmo dono numa identidade só — dados e cobrança somados nas 3 empresas.
+            </p>
+          </div>
+        </div>
+        <Button className="gap-2" onClick={() => setNovoOpen(true)}>
+          <Plus className="h-4 w-4" /> Novo grupo
+        </Button>
+      </header>
+
+      {isLoading && (
+        <div className="flex justify-center py-12">
+          <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+        </div>
+      )}
+
+      {error && (
+        <p className="text-sm text-status-error">Não consegui carregar os grupos: {error instanceof Error ? error.message : 'erro'}.</p>
+      )}
+
+      {!isLoading && !error && grupos && grupos.length === 0 && (
+        <Card>
+          <CardContent className="flex flex-col items-center gap-3 py-12 text-center">
+            <Users className="h-8 w-8 text-muted-foreground" />
+            <div>
+              <p className="font-medium">Nenhum grupo ainda</p>
+              <p className="text-sm text-muted-foreground">Crie o primeiro grupo pra consolidar um dono que tem mais de um documento.</p>
+            </div>
+            <Button className="gap-2" onClick={() => setNovoOpen(true)}>
+              <Plus className="h-4 w-4" /> Criar grupo
+            </Button>
+          </CardContent>
+        </Card>
+      )}
+
+      {!isLoading && grupos && grupos.length > 0 && (
+        <div className="grid gap-4 sm:grid-cols-2">
+          {grupos.map((g) => (
+            <GrupoCard key={g.id} grupo={g} />
+          ))}
+        </div>
+      )}
+
+      <GrupoFormDialog
+        open={novoOpen}
+        onOpenChange={setNovoOpen}
+        onCreated={(id) => navigate(`/gestao/grupos-cliente/${id}`)}
+      />
+    </div>
+  );
+}

--- a/src/pages/GestaoGruposCliente.tsx
+++ b/src/pages/GestaoGruposCliente.tsx
@@ -13,18 +13,13 @@ import {
 } from '@/queries/useClienteGrupos';
 import { GrupoFormDialog } from '@/components/grupos/GrupoFormDialog';
 import { AddDocumentoDialog } from '@/components/grupos/AddDocumentoDialog';
+import { formatDoc } from '@/lib/grupos/format';
 
 const RELATION_BADGE: Record<RelationType, string> = {
   sucessao: 'sucessão',
   multi_ativo: 'multi-CNPJ',
   incerto: 'incerto',
 };
-
-function formatDoc(d: string): string {
-  if (d.length === 14) return d.replace(/(\d{2})(\d{3})(\d{3})(\d{4})(\d{2})/, '$1.$2.$3/$4-$5');
-  if (d.length === 11) return d.replace(/(\d{3})(\d{3})(\d{3})(\d{2})/, '$1.$2.$3-$4');
-  return d;
-}
 
 function GrupoCard({ grupo }: { grupo: ClienteGrupo }) {
   const navigate = useNavigate();

--- a/src/pages/GrupoCliente360.tsx
+++ b/src/pages/GrupoCliente360.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { toast } from 'sonner';
-import { ArrowLeft, Building2, Plus, Trash2, Wallet, Users, Loader2 } from 'lucide-react';
+import { ArrowLeft, Building2, Plus, Trash2, Wallet, Users, Loader2, BarChart3 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
@@ -12,6 +12,7 @@ import {
 } from '@/queries/useClienteGrupos';
 import { AddDocumentoDialog } from '@/components/grupos/AddDocumentoDialog';
 import { GrupoFinanceiroTab } from '@/components/grupos/GrupoFinanceiroTab';
+import { GrupoComercialTab } from '@/components/grupos/GrupoComercialTab';
 import { GrupoContatosTab } from '@/components/grupos/GrupoContatosTab';
 import { formatDoc } from '@/lib/grupos/format';
 
@@ -108,13 +109,18 @@ export default function GrupoCliente360() {
 
       {/* Rollups consolidados */}
       <Tabs defaultValue="financeiro" className="space-y-4">
-        <TabsList className="grid w-full grid-cols-2 sm:w-auto sm:inline-flex">
+        <TabsList className="grid w-full grid-cols-3 sm:w-auto sm:inline-flex">
           <TabsTrigger value="financeiro" className="gap-1.5"><Wallet className="h-4 w-4" /> Financeiro</TabsTrigger>
+          <TabsTrigger value="comercial" className="gap-1.5"><BarChart3 className="h-4 w-4" /> Comercial</TabsTrigger>
           <TabsTrigger value="contatos" className="gap-1.5"><Users className="h-4 w-4" /> Contatos</TabsTrigger>
         </TabsList>
 
         <TabsContent value="financeiro" className="m-0">
           <GrupoFinanceiroTab grupoId={grupo.id} />
+        </TabsContent>
+
+        <TabsContent value="comercial" className="m-0">
+          <GrupoComercialTab grupoId={grupo.id} />
         </TabsContent>
 
         <TabsContent value="contatos" className="m-0">

--- a/src/pages/GrupoCliente360.tsx
+++ b/src/pages/GrupoCliente360.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { toast } from 'sonner';
-import { ArrowLeft, Building2, Plus, Trash2, Wallet, Users, Loader2, Info } from 'lucide-react';
+import { ArrowLeft, Building2, Plus, Trash2, Wallet, Users, Loader2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent } from '@/components/ui/card';
@@ -12,18 +12,14 @@ import {
   type RelationType,
 } from '@/queries/useClienteGrupos';
 import { AddDocumentoDialog } from '@/components/grupos/AddDocumentoDialog';
+import { GrupoFinanceiroTab } from '@/components/grupos/GrupoFinanceiroTab';
+import { formatDoc } from '@/lib/grupos/format';
 
 const RELATION_BADGE: Record<RelationType, string> = {
   sucessao: 'sucessão',
   multi_ativo: 'multi-CNPJ',
   incerto: 'incerto',
 };
-
-function formatDoc(d: string): string {
-  if (d.length === 14) return d.replace(/(\d{2})(\d{3})(\d{3})(\d{4})(\d{2})/, '$1.$2.$3/$4-$5');
-  if (d.length === 11) return d.replace(/(\d{3})(\d{3})(\d{3})(\d{2})/, '$1.$2.$3-$4');
-  return d;
-}
 
 /** Estado "aguardando a view de consolidação" (Financeiro/Contatos chegam na Task 3). */
 function PendingRollup({ icon: Icon, titulo, descricao }: { icon: typeof Wallet; titulo: string; descricao: string }) {
@@ -130,16 +126,8 @@ export default function GrupoCliente360() {
           <TabsTrigger value="contatos" className="gap-1.5"><Users className="h-4 w-4" /> Contatos</TabsTrigger>
         </TabsList>
 
-        <TabsContent value="financeiro" className="m-0 space-y-2">
-          <div className="flex items-start gap-2 rounded-md border border-status-info/30 bg-status-info/5 px-3 py-2 text-xs text-muted-foreground">
-            <Info className="mt-0.5 h-3.5 w-3.5 shrink-0 text-status-info" />
-            <span>Visão consolidada — a cobrança é emitida no Omie por documento; aqui é só a soma.</span>
-          </div>
-          <PendingRollup
-            icon={Wallet}
-            titulo="Recebíveis consolidados (em implementação)"
-            descricao="A soma de recebíveis em aberto e aging do grupo, somando os documentos nas 3 empresas, chega com a view de recebível (próximo passo da Fase 1)."
-          />
+        <TabsContent value="financeiro" className="m-0">
+          <GrupoFinanceiroTab grupoId={grupo.id} />
         </TabsContent>
 
         <TabsContent value="contatos" className="m-0">

--- a/src/pages/GrupoCliente360.tsx
+++ b/src/pages/GrupoCliente360.tsx
@@ -1,0 +1,157 @@
+import { useState } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { toast } from 'sonner';
+import { ArrowLeft, Building2, Plus, Trash2, Wallet, Users, Loader2, Info } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent } from '@/components/ui/card';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
+import {
+  useClienteGrupos,
+  useRemoveMembro,
+  type RelationType,
+} from '@/queries/useClienteGrupos';
+import { AddDocumentoDialog } from '@/components/grupos/AddDocumentoDialog';
+
+const RELATION_BADGE: Record<RelationType, string> = {
+  sucessao: 'sucessão',
+  multi_ativo: 'multi-CNPJ',
+  incerto: 'incerto',
+};
+
+function formatDoc(d: string): string {
+  if (d.length === 14) return d.replace(/(\d{2})(\d{3})(\d{3})(\d{4})(\d{2})/, '$1.$2.$3/$4-$5');
+  if (d.length === 11) return d.replace(/(\d{3})(\d{3})(\d{3})(\d{2})/, '$1.$2.$3-$4');
+  return d;
+}
+
+/** Estado "aguardando a view de consolidação" (Financeiro/Contatos chegam na Task 3). */
+function PendingRollup({ icon: Icon, titulo, descricao }: { icon: typeof Wallet; titulo: string; descricao: string }) {
+  return (
+    <Card>
+      <CardContent className="flex flex-col items-center gap-2 py-10 text-center">
+        <Icon className="h-7 w-7 text-muted-foreground" />
+        <p className="font-medium">{titulo}</p>
+        <p className="max-w-md text-sm text-muted-foreground">{descricao}</p>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default function GrupoCliente360() {
+  const { grupoId } = useParams<{ grupoId: string }>();
+  const navigate = useNavigate();
+  const { data: grupos, isLoading } = useClienteGrupos();
+  const removeMembro = useRemoveMembro();
+  const [addOpen, setAddOpen] = useState(false);
+
+  const grupo = grupos?.find((g) => g.id === grupoId);
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center py-16">
+        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (!grupo) {
+    return (
+      <div className="container mx-auto max-w-3xl space-y-4 p-4 sm:p-6">
+        <Button variant="ghost" size="sm" className="gap-1" onClick={() => navigate('/gestao/grupos-cliente')}>
+          <ArrowLeft className="h-4 w-4" /> Grupos
+        </Button>
+        <p className="text-sm text-muted-foreground">Grupo não encontrado.</p>
+      </div>
+    );
+  }
+
+  const relationTypes = [...new Set(grupo.membros.map((m) => m.relation_type))];
+
+  const handleRemove = async (membroId: string, doc: string) => {
+    try {
+      await removeMembro.mutateAsync(membroId);
+      toast.success(`Documento ${formatDoc(doc)} removido.`);
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'Não consegui remover.');
+    }
+  };
+
+  return (
+    <div className="container mx-auto max-w-4xl space-y-6 p-4 sm:p-6">
+      <Button variant="ghost" size="sm" className="gap-1 -ml-2" onClick={() => navigate('/gestao/grupos-cliente')}>
+        <ArrowLeft className="h-4 w-4" /> Grupos
+      </Button>
+
+      <header className="space-y-2">
+        <h1 className="font-display" style={{ fontSize: '2rem', fontWeight: 500 }}>{grupo.nome}</h1>
+        <div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+          <span>{grupo.membros.length} documento{grupo.membros.length === 1 ? '' : 's'}</span>
+          {relationTypes.map((rt) => (
+            <Badge key={rt} variant="outline">{RELATION_BADGE[rt]}</Badge>
+          ))}
+        </div>
+        {grupo.notas && <p className="text-sm text-muted-foreground">{grupo.notas}</p>}
+      </header>
+
+      {/* Documentos do grupo */}
+      <section className="space-y-2">
+        <div className="flex items-center justify-between">
+          <h2 className="text-sm font-medium text-muted-foreground">Documentos (CNPJ/CPF)</h2>
+          <Button variant="outline" size="sm" className="gap-1" onClick={() => setAddOpen(true)}>
+            <Plus className="h-4 w-4" /> Adicionar
+          </Button>
+        </div>
+        {grupo.membros.map((m) => (
+          <div key={m.id} className="flex items-center justify-between gap-2 rounded-md border px-3 py-2 text-sm">
+            <div className="flex min-w-0 items-center gap-2">
+              <Building2 className="h-4 w-4 shrink-0 text-muted-foreground" />
+              <span className="font-mono">{formatDoc(m.documento)}</span>
+              <Badge variant="outline" className="shrink-0">{RELATION_BADGE[m.relation_type]}</Badge>
+            </div>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7 text-muted-foreground hover:text-status-error"
+              onClick={() => handleRemove(m.id, m.documento)}
+              disabled={removeMembro.isPending}
+              aria-label="Remover documento"
+            >
+              <Trash2 className="h-4 w-4" />
+            </Button>
+          </div>
+        ))}
+      </section>
+
+      {/* Rollups consolidados */}
+      <Tabs defaultValue="financeiro" className="space-y-4">
+        <TabsList className="grid w-full grid-cols-2 sm:w-auto sm:inline-flex">
+          <TabsTrigger value="financeiro" className="gap-1.5"><Wallet className="h-4 w-4" /> Financeiro</TabsTrigger>
+          <TabsTrigger value="contatos" className="gap-1.5"><Users className="h-4 w-4" /> Contatos</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="financeiro" className="m-0 space-y-2">
+          <div className="flex items-start gap-2 rounded-md border border-status-info/30 bg-status-info/5 px-3 py-2 text-xs text-muted-foreground">
+            <Info className="mt-0.5 h-3.5 w-3.5 shrink-0 text-status-info" />
+            <span>Visão consolidada — a cobrança é emitida no Omie por documento; aqui é só a soma.</span>
+          </div>
+          <PendingRollup
+            icon={Wallet}
+            titulo="Recebíveis consolidados (em implementação)"
+            descricao="A soma de recebíveis em aberto e aging do grupo, somando os documentos nas 3 empresas, chega com a view de recebível (próximo passo da Fase 1)."
+          />
+        </TabsContent>
+
+        <TabsContent value="contatos" className="m-0">
+          <PendingRollup
+            icon={Users}
+            titulo="Contatos consolidados (em implementação)"
+            descricao="Telefones, endereços e vendedor dos documentos do grupo, num lugar só — chega com a view de contatos (próximo passo da Fase 1)."
+          />
+        </TabsContent>
+      </Tabs>
+
+      <AddDocumentoDialog open={addOpen} onOpenChange={setAddOpen} grupoId={grupo.id} grupoNome={grupo.nome} />
+    </div>
+  );
+}

--- a/src/pages/GrupoCliente360.tsx
+++ b/src/pages/GrupoCliente360.tsx
@@ -4,7 +4,6 @@ import { toast } from 'sonner';
 import { ArrowLeft, Building2, Plus, Trash2, Wallet, Users, Loader2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
-import { Card, CardContent } from '@/components/ui/card';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import {
   useClienteGrupos,
@@ -13,6 +12,7 @@ import {
 } from '@/queries/useClienteGrupos';
 import { AddDocumentoDialog } from '@/components/grupos/AddDocumentoDialog';
 import { GrupoFinanceiroTab } from '@/components/grupos/GrupoFinanceiroTab';
+import { GrupoContatosTab } from '@/components/grupos/GrupoContatosTab';
 import { formatDoc } from '@/lib/grupos/format';
 
 const RELATION_BADGE: Record<RelationType, string> = {
@@ -20,19 +20,6 @@ const RELATION_BADGE: Record<RelationType, string> = {
   multi_ativo: 'multi-CNPJ',
   incerto: 'incerto',
 };
-
-/** Estado "aguardando a view de consolidação" (Financeiro/Contatos chegam na Task 3). */
-function PendingRollup({ icon: Icon, titulo, descricao }: { icon: typeof Wallet; titulo: string; descricao: string }) {
-  return (
-    <Card>
-      <CardContent className="flex flex-col items-center gap-2 py-10 text-center">
-        <Icon className="h-7 w-7 text-muted-foreground" />
-        <p className="font-medium">{titulo}</p>
-        <p className="max-w-md text-sm text-muted-foreground">{descricao}</p>
-      </CardContent>
-    </Card>
-  );
-}
 
 export default function GrupoCliente360() {
   const { grupoId } = useParams<{ grupoId: string }>();
@@ -131,11 +118,7 @@ export default function GrupoCliente360() {
         </TabsContent>
 
         <TabsContent value="contatos" className="m-0">
-          <PendingRollup
-            icon={Users}
-            titulo="Contatos consolidados (em implementação)"
-            descricao="Telefones, endereços e vendedor dos documentos do grupo, num lugar só — chega com a view de contatos (próximo passo da Fase 1)."
-          />
+          <GrupoContatosTab grupoId={grupo.id} />
         </TabsContent>
       </Tabs>
 

--- a/src/queries/useClienteGrupos.ts
+++ b/src/queries/useClienteGrupos.ts
@@ -1,0 +1,150 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+
+/**
+ * Grupo de Cliente 360 — camada de dados (CRUD de grupos + membros).
+ * Spec: docs/superpowers/specs/2026-06-15-grupo-cliente-360-design.md
+ *
+ * NOTA: as tabelas `cliente_grupos` / `cliente_grupo_membros` ainda não estão nos tipos
+ * gerados do Supabase (regen é a Task 4). Até lá, usamos `db` (cast) — mesmo idioma que o
+ * repo usa pra `.rpc` não-tipada. Quando os tipos forem regenerados, troque `db` por `supabase`
+ * e remova o cast + os tipos manuais abaixo.
+ */
+// Cast TEMPORÁRIO até a regen de tipos (Task 4): as tabelas cliente_grupos/_membros ainda não
+// estão nos tipos gerados do Supabase. Trocar `db` por `supabase` direto quando os tipos existirem.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const db = supabase as unknown as { from: (table: string) => any };
+
+export type RelationType = 'sucessao' | 'multi_ativo' | 'incerto';
+
+export interface ClienteGrupoMembro {
+  id: string;
+  grupo_id: string;
+  documento: string; // só dígitos
+  relation_type: RelationType;
+  valid_from: string | null;
+  valid_to: string | null;
+  note: string | null;
+  created_at: string;
+}
+
+export interface ClienteGrupo {
+  id: string;
+  nome: string;
+  notas: string | null;
+  ativo: boolean;
+  created_at: string;
+  updated_at: string;
+  membros: ClienteGrupoMembro[];
+}
+
+const GRUPOS_KEY = ['cliente-grupos'] as const;
+
+/** Só dígitos (CPF 11 / CNPJ 14). Espelha o CHECK da migration. */
+export function normalizarDocumento(doc: string): string {
+  return (doc || '').replace(/\D/g, '');
+}
+
+export function documentoValido(doc: string): boolean {
+  const d = normalizarDocumento(doc);
+  return d.length === 11 || d.length === 14;
+}
+
+/** Lista os grupos ativos com seus membros. */
+export function useClienteGrupos() {
+  return useQuery({
+    queryKey: GRUPOS_KEY,
+    queryFn: async (): Promise<ClienteGrupo[]> => {
+      const { data, error } = await db
+        .from('cliente_grupos')
+        .select('id, nome, notas, ativo, created_at, updated_at, membros:cliente_grupo_membros(*)')
+        .eq('ativo', true)
+        .order('nome', { ascending: true });
+      if (error) throw error;
+      return (data ?? []) as ClienteGrupo[];
+    },
+  });
+}
+
+/** Cria um grupo. Retorna o id criado. */
+export function useCreateGrupo() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (input: { nome: string; notas?: string | null }): Promise<string> => {
+      const { data: userData } = await supabase.auth.getUser();
+      const { data, error } = await db
+        .from('cliente_grupos')
+        .insert({ nome: input.nome.trim(), notas: input.notas ?? null, created_by: userData.user?.id ?? null })
+        .select('id')
+        .single();
+      if (error) throw error;
+      return (data as { id: string }).id;
+    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: GRUPOS_KEY }),
+  });
+}
+
+/** Edita nome/notas/ativo de um grupo. */
+export function useUpdateGrupo() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (input: { id: string; nome?: string; notas?: string | null; ativo?: boolean }) => {
+      const patch: Record<string, unknown> = {};
+      if (input.nome !== undefined) patch.nome = input.nome.trim();
+      if (input.notas !== undefined) patch.notas = input.notas;
+      if (input.ativo !== undefined) patch.ativo = input.ativo;
+      const { error } = await db.from('cliente_grupos').update(patch).eq('id', input.id);
+      if (error) throw error;
+    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: GRUPOS_KEY }),
+  });
+}
+
+/**
+ * Adiciona um documento ao grupo. Normaliza pra dígitos.
+ * Erro de UNIQUE(documento) vira mensagem clara (documento já está em outro grupo).
+ */
+export function useAddMembro() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (input: {
+      grupoId: string;
+      documento: string;
+      relationType?: RelationType;
+      note?: string | null;
+    }) => {
+      const documento = normalizarDocumento(input.documento);
+      if (!documentoValido(documento)) {
+        throw new Error('Documento inválido: informe um CPF (11 dígitos) ou CNPJ (14 dígitos).');
+      }
+      const { data: userData } = await supabase.auth.getUser();
+      const { error } = await db.from('cliente_grupo_membros').insert({
+        grupo_id: input.grupoId,
+        documento,
+        relation_type: input.relationType ?? 'incerto',
+        note: input.note ?? null,
+        confirmed_by: userData.user?.id ?? null,
+      });
+      if (error) {
+        // 23505 = unique_violation
+        if ((error as { code?: string }).code === '23505') {
+          throw new Error('Este documento já pertence a outro grupo. Remova-o de lá antes de mover.');
+        }
+        throw error;
+      }
+    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: GRUPOS_KEY }),
+  });
+}
+
+/** Remove um documento do grupo. */
+export function useRemoveMembro() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (membroId: string) => {
+      const { error } = await db.from('cliente_grupo_membros').delete().eq('id', membroId);
+      if (error) throw error;
+    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: GRUPOS_KEY }),
+  });
+}

--- a/src/queries/useGrupoComercial.ts
+++ b/src/queries/useGrupoComercial.ts
@@ -1,0 +1,67 @@
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+
+/**
+ * Comercial consolidado do grupo (lê a view v_grupo_comercial): faturamento + recência +
+ * tendência por janela (90d vs 90d anterior), somando os documentos nas 3 empresas.
+ * Tendência por janela (não intervalo pooled) — regra do Codex. Provada em db/test-grupo-comercial.sh.
+ * Cast temporário até a regen de tipos (Task 4).
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const db = supabase as unknown as { from: (table: string) => any };
+
+export interface GrupoComercial {
+  documentos_com_compra: number;
+  qtd_pedidos: number;
+  ultima_compra: string | null;
+  dias_desde_ultima: number | null;
+  faturamento_total: number;
+  fat_90d: number;
+  fat_90d_anterior: number;
+  media_mensal_6m: number;
+}
+
+const ZERO: GrupoComercial = {
+  documentos_com_compra: 0, qtd_pedidos: 0, ultima_compra: null, dias_desde_ultima: null,
+  faturamento_total: 0, fat_90d: 0, fat_90d_anterior: 0, media_mensal_6m: 0,
+};
+
+const num = (v: unknown) => Number(v ?? 0);
+
+export function useGrupoComercial(grupoId: string | undefined) {
+  return useQuery({
+    queryKey: ['grupo-comercial', grupoId],
+    enabled: !!grupoId,
+    queryFn: async (): Promise<GrupoComercial> => {
+      const { data, error } = await db
+        .from('v_grupo_comercial')
+        .select('*')
+        .eq('grupo_id', grupoId)
+        .maybeSingle();
+      if (error) throw error;
+      const r = data as Record<string, unknown> | null;
+      if (!r) return ZERO;
+      return {
+        documentos_com_compra: num(r.documentos_com_compra),
+        qtd_pedidos: num(r.qtd_pedidos),
+        ultima_compra: (r.ultima_compra as string) ?? null,
+        dias_desde_ultima: r.dias_desde_ultima == null ? null : num(r.dias_desde_ultima),
+        faturamento_total: num(r.faturamento_total),
+        fat_90d: num(r.fat_90d),
+        fat_90d_anterior: num(r.fat_90d_anterior),
+        media_mensal_6m: num(r.media_mensal_6m),
+      };
+    },
+  });
+}
+
+/** Classifica a tendência do grupo pela janela (90d vs 90d anterior). Sem intervalo pooled. */
+export function tendenciaGrupo(c: GrupoComercial): { label: string; tone: 'success' | 'warning' | 'error' | 'muted'; pct: number | null } {
+  const { fat_90d, fat_90d_anterior } = c;
+  if (fat_90d_anterior === 0 && fat_90d === 0) return { label: 'sem compras recentes', tone: 'muted', pct: null };
+  if (fat_90d_anterior === 0) return { label: 'novo / retomando', tone: 'success', pct: null };
+  const pct = (fat_90d - fat_90d_anterior) / fat_90d_anterior;
+  if (fat_90d < 0.6 * fat_90d_anterior) return { label: 'caindo', tone: 'error', pct };
+  if (fat_90d > 1.1 * fat_90d_anterior) return { label: 'subindo', tone: 'success', pct };
+  return { label: 'estável', tone: 'muted', pct };
+}

--- a/src/queries/useGrupoContatos.ts
+++ b/src/queries/useGrupoContatos.ts
@@ -1,0 +1,37 @@
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+
+/**
+ * Contatos consolidados do grupo (lê a view v_grupo_contatos): nome/telefone/endereço/vendedor
+ * por documento. Read-only. Cast temporário até a regen de tipos (Task 4).
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const db = supabase as unknown as { from: (table: string) => any };
+
+export interface GrupoContato {
+  documento: string;
+  user_id: string;
+  nome: string | null;
+  phone: string | null;
+  email: string | null;
+  cidade: string | null;
+  uf: string | null;
+  endereco: string | null;
+  omie_codigo_vendedor: number | null;
+  empresa_omie: string | null;
+}
+
+export function useGrupoContatos(grupoId: string | undefined) {
+  return useQuery({
+    queryKey: ['grupo-contatos', grupoId],
+    enabled: !!grupoId,
+    queryFn: async (): Promise<GrupoContato[]> => {
+      const { data, error } = await db
+        .from('v_grupo_contatos')
+        .select('*')
+        .eq('grupo_id', grupoId);
+      if (error) throw error;
+      return (data ?? []) as GrupoContato[];
+    },
+  });
+}

--- a/src/queries/useGrupoFinanceiro.ts
+++ b/src/queries/useGrupoFinanceiro.ts
@@ -1,0 +1,82 @@
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+
+/**
+ * Recebível consolidado do grupo (lê as views v_grupo_contas_receber*).
+ * As views vêm de produção e somam `saldo` em aberto (status NOT IN RECEBIDO/CANCELADO),
+ * aging por data_vencimento, across as 3 empresas. Provadas em db/test-grupo-contas-receber.sh.
+ *
+ * Cast temporário até a regen de tipos (Task 4) — igual a useClienteGrupos.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const db = supabase as unknown as { from: (table: string) => any };
+
+export interface GrupoFinanceiroResumo {
+  total_aberto: number;
+  a_vencer: number;
+  venc_1_30: number;
+  venc_31_60: number;
+  venc_61_90: number;
+  venc_90_mais: number;
+  documentos_com_titulo: number;
+}
+
+export interface GrupoFinanceiroPorDoc {
+  documento: string;
+  company: string | null;
+  nome_cliente: string | null;
+  total_aberto: number;
+  vencido: number;
+}
+
+export interface GrupoFinanceiro {
+  resumo: GrupoFinanceiroResumo;
+  porDoc: GrupoFinanceiroPorDoc[];
+}
+
+const ZERO: GrupoFinanceiroResumo = {
+  total_aberto: 0, a_vencer: 0, venc_1_30: 0, venc_31_60: 0, venc_61_90: 0, venc_90_mais: 0,
+  documentos_com_titulo: 0,
+};
+
+const num = (v: unknown) => Number(v ?? 0);
+
+export function useGrupoFinanceiro(grupoId: string | undefined) {
+  return useQuery({
+    queryKey: ['grupo-financeiro', grupoId],
+    enabled: !!grupoId,
+    queryFn: async (): Promise<GrupoFinanceiro> => {
+      const [resumoRes, porDocRes] = await Promise.all([
+        db.from('v_grupo_contas_receber').select('*').eq('grupo_id', grupoId).maybeSingle(),
+        db.from('v_grupo_contas_receber_por_doc').select('*').eq('grupo_id', grupoId).order('total_aberto', { ascending: false }),
+      ]);
+      if (resumoRes.error) throw resumoRes.error;
+      if (porDocRes.error) throw porDocRes.error;
+
+      const r = resumoRes.data as Record<string, unknown> | null;
+      const resumo: GrupoFinanceiroResumo = r
+        ? {
+            total_aberto: num(r.total_aberto),
+            a_vencer: num(r.a_vencer),
+            venc_1_30: num(r.venc_1_30),
+            venc_31_60: num(r.venc_31_60),
+            venc_61_90: num(r.venc_61_90),
+            venc_90_mais: num(r.venc_90_mais),
+            documentos_com_titulo: num(r.documentos_com_titulo),
+          }
+        : ZERO;
+
+      const porDoc: GrupoFinanceiroPorDoc[] = (porDocRes.data ?? [])
+        .map((d: Record<string, unknown>) => ({
+          documento: String(d.documento ?? ''),
+          company: (d.company as string) ?? null,
+          nome_cliente: (d.nome_cliente as string) ?? null,
+          total_aberto: num(d.total_aberto),
+          vencido: num(d.vencido),
+        }))
+        .filter((d: GrupoFinanceiroPorDoc) => d.total_aberto > 0 || d.company !== null);
+
+      return { resumo, porDoc };
+    },
+  });
+}

--- a/supabase/migrations/20260615120000_cliente_grupos.sql
+++ b/supabase/migrations/20260615120000_cliente_grupos.sql
@@ -1,0 +1,78 @@
+-- Grupo de Cliente 360 — Fase 1: tabelas de agrupamento de documentos (CNPJ/CPF) do mesmo dono.
+-- Spec: docs/superpowers/specs/2026-06-15-grupo-cliente-360-design.md
+-- ATENÇÃO: migration custom — aplicar manualmente no Lovable SQL Editor (não aplica sozinha).
+
+-- ============================================================
+-- 1. Tabelas
+-- ============================================================
+
+-- cliente_grupos: um dono/grupo (identidade única que atravessa as 3 empresas)
+create table if not exists public.cliente_grupos (
+  id uuid primary key default gen_random_uuid(),
+  nome text not null,
+  notas text,
+  ativo boolean not null default true,
+  created_by uuid references auth.users(id),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+-- cliente_grupo_membros: os documentos (CNPJ/CPF) do grupo
+create table if not exists public.cliente_grupo_membros (
+  id uuid primary key default gen_random_uuid(),
+  grupo_id uuid not null references public.cliente_grupos(id) on delete cascade,
+  documento text not null,                          -- SÓ DÍGITOS (CPF=11 / CNPJ=14)
+  relation_type text not null default 'incerto'
+    check (relation_type in ('sucessao','multi_ativo','incerto')),
+  valid_from date,
+  valid_to date,
+  confirmed_by uuid references auth.users(id),
+  confirmed_at timestamptz default now(),
+  note text,
+  created_at timestamptz not null default now(),
+  -- 1 documento pertence a no máximo UM grupo (mata transitividade A=B,B=C)
+  constraint cliente_grupo_membros_documento_key unique (documento),
+  -- guard: documento só dígitos, tamanho de CPF ou CNPJ
+  constraint cliente_grupo_membros_documento_digits
+    check (documento ~ '^[0-9]+$' and char_length(documento) in (11, 14))
+);
+
+create index if not exists idx_cgm_grupo on public.cliente_grupo_membros(grupo_id);
+create index if not exists idx_cgm_documento on public.cliente_grupo_membros(documento);
+
+-- ============================================================
+-- 2. updated_at trigger (self-contained — não há função compartilhada no repo)
+-- ============================================================
+create or replace function public.cliente_grupos_set_updated_at()
+returns trigger language plpgsql as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_cliente_grupos_updated_at on public.cliente_grupos;
+create trigger trg_cliente_grupos_updated_at
+  before update on public.cliente_grupos
+  for each row execute function public.cliente_grupos_set_updated_at();
+
+-- ============================================================
+-- 3. RLS — mesmo gate do financeiro (fin_user_can_access) + service_role bypass.
+--    fin_user_can_access() com company NULL = acesso geral ao financeiro:
+--    staff (admin/manager/employee/master) passa; demais via fin_permissoes.
+--    A restrição fina (só gestor gere/vê) é reforçada no app (rota), como nas telas fin_*.
+-- ============================================================
+alter table public.cliente_grupos enable row level security;
+alter table public.cliente_grupo_membros enable row level security;
+
+create policy "cliente_grupos_service" on public.cliente_grupos
+  for all using (auth.role() = 'service_role');
+create policy "cliente_grupos_fin_access" on public.cliente_grupos
+  for all using (public.fin_user_can_access())
+  with check (public.fin_user_can_access());
+
+create policy "cgm_service" on public.cliente_grupo_membros
+  for all using (auth.role() = 'service_role');
+create policy "cgm_fin_access" on public.cliente_grupo_membros
+  for all using (public.fin_user_can_access())
+  with check (public.fin_user_can_access());

--- a/supabase/migrations/20260616120000_v_grupo_contas_receber.sql
+++ b/supabase/migrations/20260616120000_v_grupo_contas_receber.sql
@@ -1,0 +1,63 @@
+-- Grupo de Cliente 360 — Fase 1, Task 3: view de recebível consolidado por grupo.
+-- Spec: docs/superpowers/specs/2026-06-15-grupo-cliente-360-design.md
+-- ATENÇÃO: migration custom — aplicar manualmente no Lovable SQL Editor.
+--
+-- Padrão copiado VERBATIM de fin_aging_receber (migration 20260616020000_fix_aging_views_status_vocab):
+--   "em aberto" = status_titulo NOT IN ('RECEBIDO','CANCELADO'); aging por data_vencimento; sum(saldo).
+--   (status vocab real do Omie: 'A VENCER','ATRASADO','VENCE HOJE','RECEBIDO','PAGO','CANCELADO'.)
+-- Só adiciona a dimensão GRUPO (join por documento normalizado) e soma across `company` (as 3 empresas).
+--
+-- security_invoker = true: a view roda com a RLS do INVOCADOR, então respeita o gate de
+-- fin_contas_receber (fin_user_can_access) e das tabelas de grupo. Só quem tem acesso ao
+-- financeiro enxerga linhas — mais seguro que as views fin_* atuais (que dependem de grant).
+
+-- ============================================================
+-- 1. Recebível consolidado POR GRUPO (total + aging), somando os documentos nas 3 empresas
+-- ============================================================
+create or replace view public.v_grupo_contas_receber
+with (security_invoker = true) as
+with tit as (
+  select regexp_replace(fcr.cnpj_cpf, '\D', '', 'g') as doc,
+         fcr.saldo,
+         fcr.data_vencimento
+  from public.fin_contas_receber fcr
+  where fcr.status_titulo <> all (array['RECEBIDO'::text, 'CANCELADO'::text])
+)
+select g.id as grupo_id,
+       g.nome,
+       count(distinct m.documento) filter (where t.doc is not null) as documentos_com_titulo,
+       coalesce(sum(t.saldo), 0::numeric) as total_aberto,
+       coalesce(sum(t.saldo) filter (where t.data_vencimento >= current_date), 0::numeric) as a_vencer,
+       coalesce(sum(t.saldo) filter (where (current_date - t.data_vencimento) between 1 and 30), 0::numeric) as venc_1_30,
+       coalesce(sum(t.saldo) filter (where (current_date - t.data_vencimento) between 31 and 60), 0::numeric) as venc_31_60,
+       coalesce(sum(t.saldo) filter (where (current_date - t.data_vencimento) between 61 and 90), 0::numeric) as venc_61_90,
+       coalesce(sum(t.saldo) filter (where (current_date - t.data_vencimento) > 90), 0::numeric) as venc_90_mais
+from public.cliente_grupos g
+join public.cliente_grupo_membros m on m.grupo_id = g.id
+left join tit t on t.doc = m.documento          -- m.documento já é só-dígitos (CHECK na tabela)
+where g.ativo = true
+group by g.id, g.nome;
+
+-- ============================================================
+-- 2. Recebível POR DOCUMENTO dentro do grupo (expor a composição — exigência do design/Codex)
+-- ============================================================
+create or replace view public.v_grupo_contas_receber_por_doc
+with (security_invoker = true) as
+with tit as (
+  select regexp_replace(fcr.cnpj_cpf, '\D', '', 'g') as doc,
+         fcr.company,
+         fcr.nome_cliente,
+         fcr.saldo,
+         fcr.data_vencimento
+  from public.fin_contas_receber fcr
+  where fcr.status_titulo <> all (array['RECEBIDO'::text, 'CANCELADO'::text])
+)
+select m.grupo_id,
+       m.documento,
+       t.company,
+       max(t.nome_cliente) as nome_cliente,
+       coalesce(sum(t.saldo), 0::numeric) as total_aberto,
+       coalesce(sum(t.saldo) filter (where (current_date - t.data_vencimento) > 0), 0::numeric) as vencido
+from public.cliente_grupo_membros m
+left join tit t on t.doc = m.documento
+group by m.grupo_id, m.documento, t.company;

--- a/supabase/migrations/20260616130000_v_grupo_contatos.sql
+++ b/supabase/migrations/20260616130000_v_grupo_contatos.sql
@@ -1,0 +1,23 @@
+-- Grupo de Cliente 360 — Fase 1: view de contatos consolidados do grupo (aba Contatos).
+-- Read-only (não money-path): nome/telefone/endereço/vendedor por documento do grupo.
+-- security_invoker = true: respeita a RLS de profiles/addresses/omie_clientes (staff vê tudo).
+-- ATENÇÃO: migration custom — aplicar manualmente no Lovable SQL Editor.
+
+create or replace view public.v_grupo_contatos
+with (security_invoker = true) as
+select m.grupo_id,
+       m.documento,
+       p.user_id,
+       coalesce(p.razao_social, p.name) as nome,
+       p.phone,
+       p.email,
+       a.city  as cidade,
+       a.state as uf,
+       nullif(trim(coalesce(a.street,'') || ' ' || coalesce(a.number,'')), '') as endereco,
+       oc.omie_codigo_vendedor,
+       oc.empresa_omie
+from public.cliente_grupo_membros m
+join public.profiles p
+  on regexp_replace(coalesce(p.cnpj, p.document, ''), '\D', '', 'g') = m.documento
+left join public.addresses a on a.user_id = p.user_id and a.is_default = true   -- ⚙️ se addresses não tiver is_default, remover o predicado
+left join public.omie_clientes oc on oc.user_id = p.user_id;

--- a/supabase/migrations/20260616140000_v_grupo_comercial.sql
+++ b/supabase/migrations/20260616140000_v_grupo_comercial.sql
@@ -1,0 +1,34 @@
+-- Grupo de Cliente 360 — Fase 2, Task: view comercial consolidada por grupo (aba Comercial).
+-- Faturamento + recência + TENDÊNCIA POR JANELA (90d vs 90d anterior), somando os documentos
+-- do grupo nas 3 empresas. Segue a regra do Codex (unificacao-cnpj.md): faturamento/recência
+-- somam (post-merge OK); a queda é por JANELA MÓVEL, não por intervalo médio pooled (que
+-- esconderia cliente caindo quando CNPJs paralelos se alternam).
+-- security_invoker = true (respeita a RLS de sales_orders/profiles). Money-path → provar PG17.
+-- ATENÇÃO: migration custom — aplicar manualmente no Lovable SQL Editor.
+
+create or replace view public.v_grupo_comercial
+with (security_invoker = true) as
+with ped as (
+  select regexp_replace(coalesce(p.cnpj, p.document, ''), '\D', '', 'g') as doc,
+         so.created_at::date as data,
+         coalesce(so.total, (
+           select sum((it->>'quantity')::numeric * (it->>'unit_price')::numeric)
+           from jsonb_array_elements(so.items) it
+         )) as valor
+  from public.sales_orders so
+  join public.profiles p on p.user_id = so.customer_user_id
+  where so.status in ('faturado','importado','separacao','enviado')
+    and so.deleted_at is null
+)
+select m.grupo_id,
+       count(distinct ped.doc) filter (where ped.doc is not null)        as documentos_com_compra,
+       count(ped.data)                                                    as qtd_pedidos,
+       max(ped.data)                                                      as ultima_compra,
+       (current_date - max(ped.data))                                     as dias_desde_ultima,
+       coalesce(sum(ped.valor), 0::numeric)                               as faturamento_total,
+       coalesce(sum(ped.valor) filter (where ped.data > current_date - 90), 0::numeric)                                  as fat_90d,
+       coalesce(sum(ped.valor) filter (where ped.data <= current_date - 90 and ped.data > current_date - 180), 0::numeric) as fat_90d_anterior,
+       round(coalesce(sum(ped.valor) filter (where ped.data > current_date - 180), 0::numeric) / 6.0, 2)                  as media_mensal_6m
+from public.cliente_grupo_membros m
+left join ped on ped.doc = m.documento
+group by m.grupo_id;


### PR DESCRIPTION
## O que é

Um lugar no app pra **agrupar os CNPJs/CPFs de um mesmo dono numa identidade única** e ver **dados e cobrança somados em cima do grupo**, atravessando as 3 empresas (Colacor, Oben, Colacor SC). Visão consolidada read-only (a cobrança continua nascendo no Omie por documento — **não** é emissão).

Spec: `docs/superpowers/specs/2026-06-15-grupo-cliente-360-design.md` · Plano: `docs/superpowers/plans/2026-06-15-grupo-cliente-360-fase1.md` (já na main via #887).

## Fase 1
- **Tabelas** `cliente_grupos` + `cliente_grupo_membros` (RLS `fin_user_can_access`, `UNIQUE(documento)`, CHECK dígitos CPF/CNPJ).
- **Gestão** (`/gestao/grupos-cliente`): criar grupo, add/remover documentos com `relation_type` (sucessão/multi-ativo/incerto).
- **Ficha Grupo 360** — aba **Financeiro** (recebível em aberto + aging + por-documento, somando as 3 empresas) e aba **Contatos** (nome/telefone/endereço/vendedor por documento).
- Rota sob `RequireFinanceiroAccess`; menu Gestão → "Grupos de Cliente" (gestor/master).

## Fase 2
- **Aba Comercial**: faturamento total/90d/anterior + média mensal + recência + **tendência por janela** (não intervalo pooled — regra do Codex pra não esconder cliente caindo).
- **Dedup no plano da Farmer** (skill `farmer-industrial`): a query da carteira lê `cliente_grupo_membros` → dono com vários CNPJs vira **1 entrada** (não liga 2x; mix somado do grupo).

## Money-path provado (PG17 local + falsificação)
As 3 views de soma de dinheiro foram provadas num Postgres 17 descartável **antes** de tocar produção, com falsificação confirmando o dente dos asserts:
- `db/test-grupo-contas-receber.sh` — 11 ok / 0 fail (soma cross-empresa, aging, status, vazamento, RLS `security_invoker`).
- `db/test-grupo-comercial.sh` — 11 ok / 0 fail (faturamento cross-empresa, janelas, status, vazamento, RLS).

## Deploy (Lovable, 3 camadas manuais)
As migrations (`supabase/migrations/2026061*_*.sql`) **não auto-aplicam** — foram coladas no SQL Editor e validadas durante o desenvolvimento (tabelas + 3 views já em produção). Falta o **Publish do frontend** pra a tela aparecer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)