### PR TITLE
fix(vendas): fecha a 4ª via de preço ≤ 0 — conversão de orçamento + guard no edge (money-path)

### DIFF
--- a/src/pages/SalesQuotes.tsx
+++ b/src/pages/SalesQuotes.tsx
@@ -12,10 +12,12 @@ import {
   AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent,
   AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, AlertDialogTrigger,
 } from '@/components/ui/alert-dialog';
-import { Loader2, Trash2, Send, FileText, ChevronLeft } from 'lucide-react';
+import { Loader2, Trash2, Send, FileText, ChevronLeft, AlertCircle } from 'lucide-react';
 import { toast } from 'sonner';
 import { format } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
+import { findInvalidPricedOmieItems, invalidOmieItemPriceMessage } from '@/services/orderSubmission/priceGuard';
+import { cn } from '@/lib/utils';
 
 const fmt = (v: number) => v.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
 
@@ -35,6 +37,8 @@ const SalesQuotes = () => {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const [converting, setConverting] = useState<string | null>(null);
+  // Orçamento destacado por ter item de produto a preço ≤ 0 (guard money-path da conversão).
+  const [invalidQuoteId, setInvalidQuoteId] = useState<string | null>(null);
 
   const { data: quotes, isLoading } = useQuery({
     queryKey: ['sales-quotes'],
@@ -80,6 +84,21 @@ const SalesQuotes = () => {
   });
 
   const convertToOrder = async (quote: SalesOrder) => {
+    // ── Guard money-path (4ª via) ──
+    // A conversão orçamento→pedido NÃO passa por submitOrder/submitQuote — vai direto ao
+    // edge omie-vendas-sync (criar_pedido). Um orçamento com produto a preço ≤ 0 (criado
+    // antes do guard, ou por qualquer outra via) viraria um PV COBRADO no Omie. Bloqueia
+    // ANTES do update de status e da chamada ao edge (fail-closed). O edge também rejeita
+    // (defense-in-depth). Orçamento só tem produto (afiação tem fluxo próprio), então
+    // preço ≤ 0 / NaN / Infinity é sempre erro — mesmo predicado do guard do carrinho.
+    const quoteItems = (quote.items as unknown as QuoteItem[]) || [];
+    const invalidPriced = findInvalidPricedOmieItems(quoteItems);
+    if (invalidPriced.length > 0) {
+      setInvalidQuoteId(quote.id);
+      toast.error(invalidOmieItemPriceMessage(invalidPriced));
+      return;
+    }
+    setInvalidQuoteId(null);
     setConverting(quote.id);
     try {
       // Get omie_clientes mapping
@@ -175,7 +194,7 @@ const SalesQuotes = () => {
             const items = (q.items as unknown as QuoteItem[]) || [];
             const itemCount = items.length;
             return (
-              <Card key={q.id}>
+              <Card key={q.id} className={cn(invalidQuoteId === q.id && 'border-status-error ring-1 ring-status-error')}>
                 <CardContent className="py-4">
                   <div className="flex items-start justify-between gap-3">
                     <div className="min-w-0 flex-1">
@@ -198,6 +217,12 @@ const SalesQuotes = () => {
                         {items.length > 3 && <div className="text-muted-foreground/60">+{items.length - 3} mais...</div>}
                       </div>
                       <p className="text-sm font-semibold mt-2">{fmt(q.total)}</p>
+                      {invalidQuoteId === q.id && (
+                        <p className="mt-2 text-xs text-status-error flex items-center gap-1">
+                          <AlertCircle className="w-3 h-3 shrink-0" />
+                          Item com preço R$ 0 ou inválido — edite o orçamento antes de enviar.
+                        </p>
+                      )}
                     </div>
                     <div className="flex flex-col gap-2 shrink-0">
                       <Button

--- a/src/pages/__tests__/SalesQuotes.priceGuard.test.tsx
+++ b/src/pages/__tests__/SalesQuotes.priceGuard.test.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+// Guard money-path da 4ª via: a conversão orçamento→pedido (SalesQuotes.convertToOrder)
+// NÃO passa por submitOrder/submitQuote — chama o edge omie-vendas-sync direto. Um orçamento
+// pré-existente com produto a R$0/negativo viraria um PV cobrado no Omie. Estes testes provam
+// que a conversão é bloqueada ANTES de qualquer chamada ao edge (e que o caso válido passa).
+
+const h = vi.hoisted(() => ({
+  invoke: vi.fn(() => Promise.resolve({ data: { success: true }, error: null })),
+  toastError: vi.fn(),
+  toastSuccess: vi.fn(),
+  toastInfo: vi.fn(),
+  quotes: [] as unknown[],
+}));
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => ({ user: { id: 'u1', email: 'staff@colacor' } }),
+}));
+vi.mock('sonner', () => ({
+  toast: { error: h.toastError, success: h.toastSuccess, info: h.toastInfo },
+}));
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    from: (table: string) => ({
+      select: () => ({
+        eq: () => ({
+          order: () => Promise.resolve({ data: table === 'sales_orders' ? h.quotes : [], error: null }),
+          // omie_clientes lookup (só alcançado se o guard NÃO bloquear)
+          maybeSingle: () => Promise.resolve({ data: { omie_codigo_cliente: 123, omie_codigo_vendedor: 9 }, error: null }),
+        }),
+        in: () => Promise.resolve({ data: [], error: null }),
+      }),
+      update: () => ({ eq: () => Promise.resolve({ error: null }) }),
+      delete: () => ({ eq: () => Promise.resolve({ error: null }) }),
+    }),
+    functions: { invoke: h.invoke },
+  },
+}));
+
+import SalesQuotes from '../SalesQuotes';
+
+function makeQuote(valor_unitario: number) {
+  return {
+    id: 'q1', customer_user_id: 'c1', account: 'oben', status: 'orcamento',
+    created_at: '2026-06-16T10:00:00Z', total: valor_unitario, notes: null,
+    items: [{ omie_codigo_produto: 'SKU1', quantidade: 1, valor_unitario, descricao: 'Disco de Corte 7"' }],
+  };
+}
+
+function renderPage() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter><SalesQuotes /></MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  h.invoke.mockClear();
+  h.toastError.mockClear();
+  h.toastSuccess.mockClear();
+  h.toastInfo.mockClear();
+});
+
+describe('SalesQuotes — guard de preço na conversão de orçamento (4ª via money-path)', () => {
+  it('NÃO envia ao Omie quando o orçamento tem item a preço ≤ 0', async () => {
+    h.quotes = [makeQuote(0)];
+    renderPage();
+    const btn = await screen.findByRole('button', { name: /Enviar Pedido/i });
+    fireEvent.click(btn);
+    await waitFor(() => expect(h.toastError).toHaveBeenCalled());
+    expect(h.invoke).not.toHaveBeenCalled();
+    expect(String(h.toastError.mock.calls[0][0]).toLowerCase()).toContain('preço');
+  }, 15000);
+
+  it('envia ao Omie normalmente quando todos os preços são positivos', async () => {
+    h.quotes = [makeQuote(10)];
+    renderPage();
+    const btn = await screen.findByRole('button', { name: /Enviar Pedido/i });
+    fireEvent.click(btn);
+    await waitFor(() => expect(h.invoke).toHaveBeenCalled());
+    expect(h.toastError).not.toHaveBeenCalled();
+  }, 15000);
+});

--- a/src/services/orderSubmission/__tests__/priceGuard.test.ts
+++ b/src/services/orderSubmission/__tests__/priceGuard.test.ts
@@ -3,6 +3,8 @@ import {
   isInvalidProductPrice,
   findInvalidPricedProductItems,
   invalidPriceMessage,
+  findInvalidPricedOmieItems,
+  invalidOmieItemPriceMessage,
 } from '../priceGuard';
 import type { ProductCartItem } from '@/hooks/unifiedOrder/types';
 
@@ -11,6 +13,12 @@ function prod(unit_price: number, descricao = 'Lixa'): ProductCartItem {
     type: 'product', account: 'oben', quantity: 1, unit_price,
     product: { id: 'p', omie_codigo_produto: 'X', codigo: 'C', descricao, unidade: 'UN' },
   } as unknown as ProductCartItem;
+}
+
+/** Shape PERSISTIDO de item (orçamento/pedido em sales_orders.items e payload do edge):
+ * preço em `valor_unitario` (não `unit_price`) e nome em `descricao` (não `product.descricao`). */
+function omieItem(valor_unitario: number, descricao = 'Lixa', omie_codigo_produto = 'SKU') {
+  return { omie_codigo_produto, quantidade: 1, valor_unitario, descricao };
 }
 
 describe('isInvalidProductPrice', () => {
@@ -59,5 +67,49 @@ describe('invalidPriceMessage', () => {
     expect(msg).toContain('Disco 7"');
     expect(msg).toContain('Lixa 120');
     expect(msg.toLowerCase()).toContain('preço');
+  });
+});
+
+// ── Variante para o shape PERSISTIDO (valor_unitario) — usada na conversão de
+// orçamento (SalesQuotes) e espelhada no edge omie-vendas-sync. Mesmo predicado
+// money-path (isInvalidProductPrice), shape diferente do carrinho. ──
+describe('findInvalidPricedOmieItems', () => {
+  it('retorna vazio quando todos os preços são positivos', () => {
+    expect(findInvalidPricedOmieItems([omieItem(10), omieItem(50)])).toEqual([]);
+  });
+  it('pega zero/negativo/NaN/Infinity, preservando a ordem original', () => {
+    const ok = omieItem(10, 'Ok');
+    const zero = omieItem(0, 'Zero');
+    const neg = omieItem(-1, 'Neg');
+    const nan = omieItem(Number.NaN, 'NaN');
+    const inf = omieItem(Number.POSITIVE_INFINITY, 'Inf');
+    expect(findInvalidPricedOmieItems([ok, zero, neg, nan, inf])).toEqual([zero, neg, nan, inf]);
+  });
+  it('lista vazia → vazio', () => {
+    expect(findInvalidPricedOmieItems([])).toEqual([]);
+  });
+  it('trata valor_unitario ausente/null/string (JSONB legado) como inválido', () => {
+    // Orçamento pré-existente (a "4ª via") pode ter valor_unitario corrompido no JSONB —
+    // o cast `quote.items as QuoteItem[]` é cego. Number.isFinite NÃO coage, então
+    // undefined/null/string caem como inválido (money-path: ausente ≠ zero).
+    const itens = [
+      { omie_codigo_produto: 'A', quantidade: 1, valor_unitario: undefined as unknown as number, descricao: 'sem preço' },
+      { omie_codigo_produto: 'B', quantidade: 1, valor_unitario: null as unknown as number, descricao: 'null' },
+      { omie_codigo_produto: 'C', quantidade: 1, valor_unitario: '10' as unknown as number, descricao: 'string' },
+    ];
+    expect(findInvalidPricedOmieItems(itens)).toEqual(itens);
+  });
+});
+
+describe('invalidOmieItemPriceMessage', () => {
+  it('cita as descrições dos itens inválidos', () => {
+    const msg = invalidOmieItemPriceMessage([omieItem(0, 'Disco 7"'), omieItem(0, 'Lixa 120')]);
+    expect(msg).toContain('Disco 7"');
+    expect(msg).toContain('Lixa 120');
+    expect(msg.toLowerCase()).toContain('preço');
+  });
+  it('cai pro código Omie quando falta descrição', () => {
+    const msg = invalidOmieItemPriceMessage([{ omie_codigo_produto: 'SKU9', valor_unitario: 0 }]);
+    expect(msg).toContain('SKU9');
   });
 });

--- a/src/services/orderSubmission/priceGuard.ts
+++ b/src/services/orderSubmission/priceGuard.ts
@@ -27,5 +27,37 @@ export function invalidPriceMessage(items: ProductCartItem[]): string {
   const nomes = items
     .map(it => it.product?.descricao || it.product?.codigo || 'item sem nome')
     .join(', ');
+  return buildInvalidPriceMessage(nomes);
+}
+
+/** Shape mínimo de item PERSISTIDO/Omie (orçamento em `sales_orders.items`; payload do edge
+ * omie-vendas-sync): preço em `valor_unitario` (não `unit_price`) e nome em `descricao`
+ * (não `product.descricao`). É o shape que sai do carrinho e que vira pedido no Omie. */
+export interface PricedOmieItemLike {
+  valor_unitario: number;
+  descricao?: string;
+  omie_codigo_produto?: string | number;
+}
+
+/**
+ * Variante de `findInvalidPricedProductItems` para o shape PERSISTIDO (`valor_unitario`),
+ * usada na conversão de orçamento→pedido (`SalesQuotes`) e espelhada no edge omie-vendas-sync.
+ * MESMO predicado money-path (`isInvalidProductPrice`); só muda onde o preço mora. Aqui só
+ * trafegam itens de produto (afiação tem fluxo próprio), então preço ≤ 0 é sempre erro.
+ */
+export function findInvalidPricedOmieItems<T extends { valor_unitario: number }>(items: T[]): T[] {
+  return items.filter(item => isInvalidProductPrice(item.valor_unitario));
+}
+
+/** Mensagem pt-BR citando os itens inválidos (descrição, ou código Omie como fallback). */
+export function invalidOmieItemPriceMessage(items: PricedOmieItemLike[]): string {
+  const nomes = items
+    .map(it => it.descricao || (it.omie_codigo_produto != null ? String(it.omie_codigo_produto) : 'item sem nome'))
+    .join(', ');
+  return buildInvalidPriceMessage(nomes);
+}
+
+/** Frase única de erro (compartilhada pelas duas variantes — carrinho e shape persistido). */
+function buildInvalidPriceMessage(nomes: string): string {
   return `Defina um preço maior que zero antes de enviar. Itens com preço inválido (R$ 0 ou negativo): ${nomes}.`;
 }

--- a/supabase/functions/omie-vendas-sync/index.ts
+++ b/supabase/functions/omie-vendas-sync/index.ts
@@ -1391,6 +1391,32 @@ function getAccountConfig(account: Account) {
   };
 }
 
+// ── Guard money-path (espelha src/services/orderSubmission/priceGuard.ts —
+// `isInvalidProductPrice`; Deno não importa de src/). Item de PRODUTO a preço ≤ 0 / NaN /
+// Infinity NUNCA pode virar PV no Omie: valor zerado = pedido cobrado errado / prejuízo, e
+// fica invisível ao cockpit de markup / Régua de Preço (que filtram preco > 0). Esta é a
+// fronteira definitiva — cobre TODAS as vias num só ponto: envio do unified-order
+// (submitOrder), conversão de orçamento (SalesQuotes) e edição de pedido (useSalesOrderEdit).
+// Só trafegam produtos aqui (afiação tem fluxo próprio), logo não há R$0 legítimo.
+// `typeof === "number"` endurece a borda: o payload é JSON cru, não confiável. ──
+function isInvalidOmieItemPrice(valor: unknown): boolean {
+  return !(typeof valor === "number" && Number.isFinite(valor) && valor > 0);
+}
+
+function assertOmieItemPricesValid(
+  items: Array<{ valor_unitario?: number; descricao?: string; omie_codigo_produto?: number | string }>,
+): void {
+  const invalidos = items.filter((it) => isInvalidOmieItemPrice(it.valor_unitario));
+  if (invalidos.length > 0) {
+    const nomes = invalidos
+      .map((it) => it.descricao || (it.omie_codigo_produto != null ? String(it.omie_codigo_produto) : "item sem nome"))
+      .join(", ");
+    throw new Error(
+      `Pedido rejeitado (preço inválido): item(ns) de produto com preço R$ 0 ou negativo: ${nomes}. Corrija o preço antes de enviar ao Omie.`,
+    );
+  }
+}
+
 // Criar pedido de venda no Omie
 async function criarPedidoVenda(
   supabase: SupabaseClient,
@@ -1858,6 +1884,8 @@ serve(async (req) => {
         if (!sales_order_id || !codigo_cliente || !items?.length) {
           throw new Error("Dados insuficientes para criar pedido de venda");
         }
+        // Guard money-path: rejeita ANTES de montar o payload Omie (ver assertOmieItemPricesValid).
+        assertOmieItemPricesValid(items);
         const pedido = await criarPedidoVenda(
           supabaseAdmin,
           sales_order_id,
@@ -1911,6 +1939,8 @@ serve(async (req) => {
           ordem_compra: editOrdemCompra,
         } = params;
         if (!editSoId || !editItems?.length) throw new Error("Dados insuficientes para alterar pedido");
+        // Guard money-path: rejeita ANTES de consultar/excluir itens no Omie (passo destrutivo).
+        assertOmieItemPricesValid(editItems);
 
         // Load existing order
         const { data: existingOrder } = await supabaseAdmin


### PR DESCRIPTION
## Problema (money-path)

Review adversarial do **Codex** (2026-06-16) achou uma 4ª via de preço ≤ 0 que escapava aos guards já mergeados:
- O guard do unified-order (#895, `submitOrder`/`submitQuote`) e o da edição (#899, `useSalesOrderEdit`) **não cobrem a conversão de orçamento→pedido**.
- `SalesQuotes.convertToOrder` chama o edge `omie-vendas-sync` (`criar_pedido`) **direto**. Um orçamento pré-existente (criado antes dos guards, ou por outra via) com produto a **R$0/negativo** virava um **PV cobrado no Omie**.

## Fix — 2 camadas

**1. Frontend** (`SalesQuotes.convertToOrder`): valida `quote.items` **antes** do `update status='rascunho'` e do edge — `toast` (sonner) + destaque do card. Helpers `findInvalidPricedOmieItems` + `invalidOmieItemPriceMessage` (shape persistido `valor_unitario`) em `orderSubmission/priceGuard.ts`, reusando o predicado canônico `isInvalidProductPrice`.

**2. Edge `omie-vendas-sync` (invariante definitiva):** `assertOmieItemPricesValid()` em `criar_pedido` (antes de montar o payload Omie) e `alterar_pedido` (antes do passo destrutivo de excluir itens no Omie). **Cobre TODAS as vias num só ponto** — unified-order, conversão de orçamento e edição. `typeof === "number"` endurece a borda (JSONB cru).

Afiação a R$0 ("a orçar") **não é afetada**: vai por `omie-sync`/OS (`servicos/os/`), não pelo PV. Codex confirmou: sem 5ª via de PV; guard do `alterar_pedido` antes do destrutivo; afiação intacta.

## Verificação
- **TDD:** 8 testes novos (priceGuard shape persistido + JSONB legado; SalesQuotes conversão — bloqueia inválido / não bloqueia válido).
- `typecheck` + `lint` + suíte completa (**3796 testes**) verdes.
- Edge: `deno check` diferencial — 0 erros novos vs a main (5 erros TS pré-existentes inalterados).

## Coordenação
O guard de **edição** (`useSalesOrderEdit`) já entrou na main via #899 (sessão paralela) — **não duplicado** aqui. Débito conhecido: `invalidPricedOrderItemIndices` (`salesOrderEdit/priceGuard`) e `findInvalidPricedOmieItems` (`orderSubmission/priceGuard`) cobrem o mesmo shape persistido; consolidar num follow-up.

## ⚠️ Deploy MANUAL pós-merge (Lovable) — merge na main ≠ produção
- [ ] **Publish** do frontend no editor do Lovable (toca `src/`).
- [ ] **Deploy do edge `omie-vendas-sync`** via chat do Lovable, **verbatim** de `supabase/functions/omie-vendas-sync/index.ts` na `main`, **só após o merge**. Confirmar `Active`.
- [ ] Verificar: orçamento/edição com item a R$0 → rejeitado (`Pedido rejeitado (preço inválido)…`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)