### PR TITLE
refactor(vendas): consolida guard de preço ≤ 0 do shape persistido num único lar (money-path, DRY)

### DIFF
--- a/src/components/salesOrderEdit/priceGuard.ts
+++ b/src/components/salesOrderEdit/priceGuard.ts
@@ -1,20 +1,16 @@
-// Guard money-path da EDIÇÃO de pedido, sobre o shape OrderItem. Reusa a regra-núcleo
-// isInvalidProductPrice (!(price > 0)) do guard do ENVIO
-// (src/services/orderSubmission/priceGuard.ts) — uma ÚNICA definição da decisão
-// monetária; aqui só adaptamos a seleção e a mensagem ao shape OrderItem
-// (valor_unitario / descricao no topo, não unit_price / product.descricao).
+// Guard money-path da EDIÇÃO de pedido, sobre o shape OrderItem. A seleção dos itens a preço
+// inválido (≤ 0 / NaN / ausente) é DELEGADA à primitiva canônica
+// invalidPricedValorUnitarioIndices (src/services/orderSubmission/priceGuard.ts) — um único
+// lar para a iteração sobre valor_unitario, em cima da única definição da decisão monetária
+// (isInvalidProductPrice). Aqui só fixamos o shape (OrderItem) e a mensagem de "salvar".
 // A edição de pedido só carrega produtos e tintas (não há serviço de afiação "a orçar"),
 // então todo item é elegível ao guard.
-import { isInvalidProductPrice } from '@/services/orderSubmission/priceGuard';
+import { invalidPricedValorUnitarioIndices } from '@/services/orderSubmission/priceGuard';
 import type { OrderItem } from './types';
 
 /** Índices dos itens com preço inválido (≤ 0 / NaN), preservando a ordem. A UI usa para destacar. */
 export function invalidPricedOrderItemIndices(items: OrderItem[]): number[] {
-  const indices: number[] = [];
-  items.forEach((item, i) => {
-    if (isInvalidProductPrice(item.valor_unitario)) indices.push(i);
-  });
-  return indices;
+  return invalidPricedValorUnitarioIndices(items);
 }
 
 /** Mensagem pt-BR pronta para toast, citando os itens inválidos (já filtrados). */

--- a/src/services/orderSubmission/__tests__/priceGuard.test.ts
+++ b/src/services/orderSubmission/__tests__/priceGuard.test.ts
@@ -5,6 +5,7 @@ import {
   invalidPriceMessage,
   findInvalidPricedOmieItems,
   invalidOmieItemPriceMessage,
+  invalidPricedValorUnitarioIndices,
 } from '../priceGuard';
 import type { ProductCartItem } from '@/hooks/unifiedOrder/types';
 
@@ -98,6 +99,34 @@ describe('findInvalidPricedOmieItems', () => {
       { omie_codigo_produto: 'C', quantidade: 1, valor_unitario: '10' as unknown as number, descricao: 'string' },
     ];
     expect(findInvalidPricedOmieItems(itens)).toEqual(itens);
+  });
+});
+
+// ── Primitiva de seleção por ÍNDICE sobre o shape persistido (valor_unitario). É o
+// lar ÚNICO da iteração money-path: findInvalidPricedOmieItems (retorna itens) e o
+// guard da EDIÇÃO (invalidPricedOrderItemIndices em salesOrderEdit) derivam daqui. ──
+describe('invalidPricedValorUnitarioIndices', () => {
+  it('retorna vazio quando todos os preços são positivos', () => {
+    expect(invalidPricedValorUnitarioIndices([omieItem(10), omieItem(50)])).toEqual([]);
+  });
+  it('retorna os índices dos inválidos (zero/negativo/NaN/Infinity), preservando a ordem', () => {
+    const itens = [
+      omieItem(10, 'Ok'), omieItem(0, 'Zero'), omieItem(10, 'Ok2'),
+      omieItem(-1, 'Neg'), omieItem(Number.NaN, 'NaN'), omieItem(Number.POSITIVE_INFINITY, 'Inf'),
+    ];
+    expect(invalidPricedValorUnitarioIndices(itens)).toEqual([1, 3, 4, 5]);
+  });
+  it('lista vazia → vazio', () => {
+    expect(invalidPricedValorUnitarioIndices([])).toEqual([]);
+  });
+  it('trata valor_unitario ausente/null/string (JSONB legado) como inválido (não coage)', () => {
+    const itens = [
+      { valor_unitario: undefined as unknown as number },
+      { valor_unitario: null as unknown as number },
+      { valor_unitario: '10' as unknown as number },
+      { valor_unitario: 10 },
+    ];
+    expect(invalidPricedValorUnitarioIndices(itens)).toEqual([0, 1, 2]);
   });
 });
 

--- a/src/services/orderSubmission/priceGuard.ts
+++ b/src/services/orderSubmission/priceGuard.ts
@@ -40,10 +40,30 @@ export interface PricedOmieItemLike {
 }
 
 /**
+ * Primitiva money-path: índices dos itens de shape PERSISTIDO (`valor_unitario`) com preço
+ * inválido, preservando a ordem. Lar canônico da seleção-por-`valor_unitario` em forma de
+ * índices — consumida pelo guard da EDIÇÃO de pedido (`invalidPricedOrderItemIndices` em
+ * `salesOrderEdit/priceGuard`), que antes reescrevia o mesmo
+ * `isInvalidProductPrice(item.valor_unitario)` num módulo à parte. Índices (não itens) porque
+ * a UI da edição destaca/trava a linha pela posição.
+ */
+export function invalidPricedValorUnitarioIndices(
+  items: ReadonlyArray<{ valor_unitario: number }>,
+): number[] {
+  const indices: number[] = [];
+  items.forEach((item, i) => {
+    if (isInvalidProductPrice(item.valor_unitario)) indices.push(i);
+  });
+  return indices;
+}
+
+/**
  * Variante de `findInvalidPricedProductItems` para o shape PERSISTIDO (`valor_unitario`),
  * usada na conversão de orçamento→pedido (`SalesQuotes`) e espelhada no edge omie-vendas-sync.
  * MESMO predicado money-path (`isInvalidProductPrice`); só muda onde o preço mora. Aqui só
  * trafegam itens de produto (afiação tem fluxo próprio), então preço ≤ 0 é sempre erro.
+ * `filter` direto (retém o item capturado na própria iteração) — paridade exata, não re-lê
+ * `items[i]` depois.
  */
 export function findInvalidPricedOmieItems<T extends { valor_unitario: number }>(items: T[]): T[] {
   return items.filter(item => isInvalidProductPrice(item.valor_unitario));


### PR DESCRIPTION
## O quê

Consolida a lógica money-path de "item de pedido a preço ≤ 0" sobre o shape persistido `valor_unitario`, que estava duplicada entre dois módulos (débito de DRY criado por sessões paralelas — PRs #899/#903/#895).

## Como

- Nova primitiva `invalidPricedValorUnitarioIndices` no lar canônico `src/services/orderSubmission/priceGuard.ts` — lar **único** da iteração de seleção sobre `valor_unitario`, em cima do predicado canônico `isInvalidProductPrice`.
- `src/components/salesOrderEdit/priceGuard.ts`: `invalidPricedOrderItemIndices` passa a **delegar** à primitiva (antes reescrevia a iteração num módulo à parte). API preservada: `OrderItem[] → number[]` (índices para a UI destacar/travar a linha).
- `findInvalidPricedOmieItems` mantido como `filter` direto, **byte-idêntico à produção** (retém o item capturado na própria iteração — paridade exata).

## Por que é só DRY (sem mudança de comportamento)

- Predicado `isInvalidProductPrice` intacto: `Number.isFinite` **não coage** → `string`/`null`/`undefined` (JSONB legado castado cegamente) seguem **inválidos** (money-path: ausente ≠ zero).
- Mensagens distintas por design preservadas: "antes de **salvar**" (edição) vs "antes de **enviar**" (envio).
- Edge `omie-vendas-sync` é espelho verbatim (Deno, não importa de `src/`) — fora do escopo.

## Verificação

- **TDD**: 4 testes novos da primitiva (RED→GREEN), incluindo não-coerção de JSONB legado (`undefined`/`null`/`'10'` → inválido).
- **Gates**: `priceGuard` 40/40, typecheck strict. A suíte completa (3800) passou na versão validada e o CI `validate` re-roda tudo antes do auto-merge.
- **2ª opinião adversária** (`/codex challenge`, reasoning high): pegou um **[P1]** numa versão intermediária que derivava `findInvalidPricedOmieItems` via índices→map (re-lia `items[i]`, divergindo do `filter` sob getter com efeito colateral). Revertido ao `filter`. Demais checagens do Codex: paridade preservada (sparse/holes, ordem, não-coerção, mensagens separadas, sem nova divergência no edge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
