### PR TITLE
fix(skills): reposicao-caixa — correções do teste real contra produção

### DIFF
--- a/.claude/skills/reposicao-caixa/SKILL.md
+++ b/.claude/skills/reposicao-caixa/SKILL.md
@@ -212,14 +212,20 @@ não fura o piso."}
 7. **Classe manda no apetite de risco** (decisão do dono): confie na ABC/XYZ do sistema; A nunca
    pode faltar, C é o primeiro candidato a segurar caixa.
 
-## Detalhes técnicos do schema (para as queries não quebrarem)
+## Detalhes técnicos do schema (validados contra produção em 2026-06-17)
 
 - Empresa é **`'OBEN'` (maiúsculo)** nas tabelas de reposição (`sku_parametros`,
   `sku_estoque_atual`, `v_oportunidade_economica_hoje`, ...) e **`'oben'` (minúsculo)** nas
   financeiras (`fin_contas_correntes`, RPC `fin_projecao_13_semanas`).
-- `sku_codigo_omie` é **number** em `sku_parametros`/views de parâmetro e **string** em
-  `sku_estoque_atual` e `eventos_outlier` → **faça cast** (`::text`) nos joins.
-- `fin_projecao_13_semanas('oben', saldo_inicial)` é uma **RPC** (função), retorna 13 linhas.
-  Passe o `saldo_inicial` = soma do `saldo_atual` das contas ativas.
+- `sku_codigo_omie` é **bigint/number** em `sku_parametros`/views de parâmetro e **text/string**
+  em `sku_estoque_atual` e `eventos_outlier` → **faça cast** (`::text`) nos joins.
+- **`custo_capital_efetivo_perc` (Query 1/3/5) está em % AO ANO**, não ao mês (ex. real: 25,75 =
+  25,75% a.a. ≈ 1,93%/mês). As faixas da skill (1/2,2/4,5) são **% ao mês** — **converta antes de
+  comparar** (erro de 12× se misturar; ver `references/modelo-financeiro.md`).
+- `fin_projecao_13_semanas('oben', saldo_inicial)` é uma **RPC gated a staff autenticado** —
+  retorna 13 linhas, mas só roda no **Lovable** (founder logado). Acesso read-only de diagnóstico
+  (`claude_ro`) recebe `permission denied for function` — ou seja, a folga de caixa **vem do
+  founder colando o resultado**, não de o assistente rodar a RPC. `saldo_inicial` = soma do
+  `saldo_atual` das contas ativas.
 - `sku_estoque_atual.ultima_sincronizacao` diz **quão fresco** é o estoque — use como sinal de
   confiança (estoque velho = confiança baixa).

--- a/.claude/skills/reposicao-caixa/references/modelo-financeiro.md
+++ b/.claude/skills/reposicao-caixa/references/modelo-financeiro.md
@@ -30,6 +30,15 @@ custo_capital_R$ = valor_da_compra_extra × custo_capital%
 `dias_carregando` ≈ tempo médio que o estoque extra fica parado. Para `N` dias extras sobre uma
 cobertura normal `C`, use a aproximação `H = C + N/2` (vende ao longo do tempo, não tudo no fim).
 
+> **⚠️ UNIDADE — não misture % a.a. com % a.m. (erro de 12×, money-path).** As faixas acima
+> (`r_mês` 1,0 / 2,2 / 4,5) são **% AO MÊS**. Mas a coluna `custo_capital_efetivo_perc` que o
+> sistema traz na Query 1/3/5 está em **% AO ANO** (ex.: real de produção: THINNER = 25,75 = 25,75% a.a.).
+> Se você jogar 25,75 na fórmula como se fosse mensal, erra o custo de carregar por ~12×.
+> **Converta antes de usar**: `r_mês ≈ (1 + r_ano)^(1/12) − 1` (ou aproxime `r_ano / 12`).
+> Ex.: 25,75% a.a. → ~1,93%/mês (cai entre CDI e antecipação — coerente). No memo, **sempre diga
+> a unidade** do número que usou. O número do sistema é uma referência; a faixa contextual
+> (CDI/antecipação/conta garantida) é a que decide.
+
 ---
 
 ## Caso B — Vale antecipar antes do aumento?

--- a/.claude/skills/reposicao-caixa/references/sql-queries.md
+++ b/.claude/skills/reposicao-caixa/references/sql-queries.md
@@ -78,6 +78,11 @@ Retorna 13 linhas (`semana_inicio`, `semana_fim`, `semana_label`, `entradas_prev
 É só CR/CP em aberto (não inclui estoque/folha). A compra à vista entra como saída nova na
 semana do pagamento — recalcule o piso subtraindo o valor da compra.
 
+> **Esta RPC é gated a staff autenticado** — só roda no 🟣 Lovable (founder logado). Confirmado
+> contra produção: o role de leitura/diagnóstico recebe `permission denied for function`. Logo a
+> folga de caixa **depende do founder colar o resultado** — o assistente não consegue rodá-la por
+> fora. (As demais queries deste arquivo são SELECTs em tabelas/views legíveis.)
+
 ---
 
 ## Query 3 — Oportunidades de hoje (aumentos + promoções unificados)


### PR DESCRIPTION
## Contexto

Segue o PR [afiacao#904](https://github.com/LucasSardenbergL/afiacao/pull/904) (skill v1, já mergeada). Testei a skill **rodando as queries contra o Postgres de produção** (read-only via `claude_ro`) — o teste mais forte possível, que falsifica as inferências de schema e exercita a lógica de ponta a ponta.

## Achados que o eval sintético não pegaria

1. **⚠️ money-path — erro de 12× evitado:** `custo_capital_efetivo_perc` (Query 1/3/5) está em **% AO ANO** (real de prod: THINNER = `25,75`), enquanto as faixas da skill (1/2,2/4,5) são **% ao mês**. Misturar erra o custo de carregar por ~12×. Travado: nota de unidade na fórmula central + `r_mês ≈ (1+r_ano)^(1/12)−1`.
2. **RPC de caixa é gated:** `fin_projecao_13_semanas` → `permission denied for function` sob `claude_ro`. Confirma o design "founder cola do Lovable" pra folga de caixa; documentado em `SKILL.md` + Query 2.
3. **Schema confirmado contra produção:** Query 1/3/5/6 + assinatura da RPC batem (todas as colunas existem). Marcado "validado contra produção 2026-06-17".

## Demonstração end-to-end (memorando real)

Promo real de **20% no THINNER DR.4403LT**: a skill recomendou **SEGURAR** — estoque 66 un = ~61 dias vs máximo 29 (sobrestocado 2,3×); classe AZ irregular (CV 1,12) + outlier crítico pendente → confiança baixa. O sistema sinalizava R$ 244 de economia; a skill olhou o estoque e disse "você não precisa disso". É o valor que a skill agrega sobre o número cru.

## Diff

3 arquivos, +25/−5 (só notas/correções; nenhuma mudança estrutural na v1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)