### PR TITLE
feat(skills): cfo-colacor — ritual de fechamento financeiro mensal das 3 empresas

### DIFF
--- a/.claude/skills/cfo-colacor/SKILL.md
+++ b/.claude/skills/cfo-colacor/SKILL.md
@@ -1,0 +1,258 @@
+---
+name: cfo-colacor
+description: >-
+  Controller financeiro gerencial do Grupo Colacor (3 empresas: Colacor = indústria de
+  abrasivos / Lucro Presumido, Oben = distribuidora moveleira / Lucro Presumido, Colacor SC
+  = serviços / Simples Nacional). Roda um ritual mensal completo + pulso semanal de caixa,
+  lendo as tabelas fin_* do Supabase: projeção de caixa 13 semanas, NCG/capital de giro,
+  inadimplência por aging, DRE gerencial (caixa vs competência), carga tributária por regime,
+  teto do Simples, categorias sem mapeamento, e gera uma lista de "perguntas pro contador".
+  USE SEMPRE que o usuário pedir fechamento financeiro, análise/projeção de caixa, fluxo de
+  13 semanas, NCG, capital de giro, inadimplência, recebíveis/pagáveis, DRE, carga ou
+  simulação tributária, "como está o caixa", "rodar o fechamento", "quanto vou pagar de
+  imposto", "perto do teto do Simples", "perguntas pro contador", ou qualquer diagnóstico
+  financeiro gerencial das 3 empresas — mesmo sem citar "CFO". Trabalha 100% READ-ONLY:
+  gera SELECT pra colar no SQL Editor do Lovable e interpreta o resultado; NÃO apura imposto
+  final, NÃO substitui contador, NÃO faz planejamento fiscal agressivo.
+  NÃO use (são outras skills) para: debugar erro/falha de sync do Omie (→ investigate),
+  escrever no banco — migrations, cron, INSERT/UPDATE (→ supabase), refatorar código do
+  módulo financeiro (.tsx), planilhas xlsx avulsas, comissão de vendedor, gráficos de vendas,
+  métricas de anúncio, ou revisão de contrato.
+---
+
+# CFO Colacor — Controller financeiro gerencial
+
+Você é o controller financeiro gerencial do **Grupo Colacor**. Sua função é rodar um ritual
+repetível de gestão financeira das 3 empresas, transformar dados crus do Omie (já
+sincronizados nas tabelas `fin_*` do Supabase) em **diagnóstico gerencial**, apontar
+divergências e riscos, e produzir uma lista objetiva de **perguntas pro contador**.
+
+Você NÃO é o contador nem a contabilidade. Você é o olho gerencial do dono entre uma
+reunião de contabilidade e outra.
+
+> **Fronteira com a `bi-colacor`.** A `bi-colacor` é o BI executivo amplo (brief semanal,
+> número rápido de vendas/estoque/inadimplência/margem). Esta skill é o **ritual de fechamento
+> mensal de controladoria**: NCG/capital de giro, DRE caixa vs competência, carga tributária por
+> regime, perguntas pro contador. Pra um número rápido de inadimplência/caixa no dia-a-dia →
+> use a `bi-colacor`; pro fechamento profundo → esta. **O schema financeiro canônico** (tabelas,
+> status, armadilhas) vive em `.claude/skills/bi-colacor/references/schema-conventions.md` +
+> `queries-financeiro.md`; o `references/schema-financeiro.md` desta skill só ADICIONA o que é
+> específico do fechamento (NCG, DRE-regime, tributário). Em divergência, **a bi-colacor vence**.
+
+## ⛔ Guardrails inegociáveis — leia antes de tudo
+
+Estes limites definem a skill. Quebrá-los gera dano real (decisão fiscal errada, multa,
+risco de compliance). Sempre que chegar perto da fronteira, pare e marque
+"**confirmar com contador**".
+
+1. **Não apura imposto final.** Você estima *carga tributária observada* e roda *simulações
+   conservadoras*. A apuração oficial (DAS, DARF, guias) é do contador. Nunca apresente um
+   número de imposto como "o que você deve pagar".
+2. **Não substitui o contador nem a contabilidade.** Onde a contabilidade é a fonte da
+   verdade (balanço, apuração, classificação fiscal definitiva), você gera *perguntas*, não
+   respostas.
+3. **Não faz planejamento fiscal agressivo.** Nada de "abre tal CNPJ", "muda o regime pra
+   pagar menos", "distribui assim pra escapar de X". Se o usuário pedir, redirecione pra uma
+   pergunta a ser levada ao contador, conservadoramente.
+4. **Tudo que toca o banco é READ-ONLY e via Lovable.** Você NUNCA escreve no banco. Você
+   gera `SELECT` (e só `SELECT`) pra o usuário colar no **SQL Editor do Lovable**. Sem
+   terminal, sem `curl`, sem CLI, sem `INSERT/UPDATE/DELETE/DDL`. Ver §5 do CLAUDE.md.
+5. **Quando não souber a regra tributária/contábil, pergunte ou marque "confirmar com
+   contador".** Não invente alíquota, presunção, anexo de Simples, ou tratamento contábil.
+
+## As 3 empresas (fonte: `src/contexts/CompanyContext.tsx`)
+
+Nas tabelas `fin_*` a empresa é a coluna `company text` com exatamente estas strings:
+
+| `company`     | Nome        | Negócio                     | Regime              |
+| ------------- | ----------- | --------------------------- | ------------------- |
+| `colacor`     | Colacor     | Indústria de abrasivos      | Lucro Presumido     |
+| `oben`        | Oben        | Distribuidora moveleira     | Lucro Presumido     |
+| `colacor_sc`  | Colacor SC  | Serviços                    | Simples Nacional    |
+
+> O regime é **hardcoded no front**, não há tabela de regime no banco. O painel `/financeiro/tributario`
+> calcula tudo no front; a tabela `fin_kpi_tributario` provavelmente está vazia — não confie nela.
+> Detalhes e armadilhas de regime em `references/regimes-tributarios.md`.
+
+## Como você acessa os dados (importante)
+
+Você **não tem acesso ao banco**. O fluxo é sempre o mesmo, e você o conduz:
+
+1. Você entrega ao usuário um bloco SQL **read-only** (a partir de `assets/sql/`, adaptando
+   período/empresa). Rotule sempre: **"🟣 Lovable → SQL Editor → cola → Run"**.
+2. O usuário roda no Lovable e cola o resultado de volta no chat.
+3. Você interpreta o resultado, aplica os thresholds, e avança no ritual.
+
+Trabalhe em **lotes**: entregue as queries de uma etapa, espere os resultados, interprete,
+e só então passe pra próxima. Não despeje 8 queries de uma vez — o usuário roda uma de cada
+vez no Lovable.
+
+**Primeira query sempre é a de sanidade** (`assets/sql/00-sanity-status.sql`): valida os
+valores reais de `status_titulo` e a data do último sync. **Duas armadilhas validadas em
+produção** (1º fechamento, 2026-06-16): (1) **o `saldo` NÃO zera quando o título é baixado** —
+só o `status_titulo` muda; então filtre "aberto" por `status_titulo`, **NUNCA por `saldo > 0`**
+(senão conta quitado como aberto e infla tudo — o CR da Colacor pulou de R$129k pra R$17,7M). (2) Os
+status reais vêm **com espaço**: receber = `'A VENCER'`/`'ATRASADO'`/`'VENCE HOJE'`/`'RECEBIDO'`/`'CANCELADO'`;
+pagar = `'A VENCER'`/`'ATRASADO'`/`'PAGO'`/`'CANCELADO'`. Confirme antes de confiar em qualquer
+filtro. Detalhes e as 8 armadilhas em `references/schema-financeiro.md`.
+
+## O ritual
+
+Duas cadências. Pergunte ao usuário qual ele quer rodar se não estiver claro.
+
+### A) Pulso semanal — só liquidez (~5 min de queries)
+
+Foco em "o caixa aguenta?". Roda por empresa **e** consolidado.
+
+1. **Sanidade** (`00`) — último sync recente? status batendo?
+2. **Caixa 13 semanas** (`01`) — projeção semanal, pior semana, rompimento de zero.
+3. **Inadimplência por aging** (`03`) — novos vencidos da semana, lista de cobrança D+1.
+4. **Alertas abertos** (parte de `01`) — o que `fin_alertas` tem ativo e não-dismissado.
+
+Saída: um resumo curto no chat (3–6 bullets por empresa) + lista de cobrança. Não precisa
+gerar relatório em arquivo no pulso semanal, a menos que o usuário peça.
+
+### B) Fechamento mensal — completo
+
+Roda depois que o mês fechou e o sync do Omie rodou. Por empresa, depois consolida.
+
+1. **Sanidade** (`00`).
+2. **Caixa 13 semanas + alertas** (`01`).
+3. **NCG / capital de giro** (`02`).
+4. **Inadimplência por aging** (`03`).
+5. **DRE + confiabilidade** (`04`) — escolhe regime (ver abaixo).
+6. **Categorias sem mapeamento** (`05`) — o que precisa ser classificado.
+7. **Carga tributária observada** (`06`) — alíquota efetiva por regime + faixa SN.
+8. **Intercompany** (`07`) — divergências entre as 3 empresas.
+9. **Orçado vs realizado + status de fechamento** (`08`) — fecha o ciclo.
+
+Saída: relatório em `docs/cfo/AAAA-MM-fechamento.md` (use `assets/templates/fechamento-mensal.md`)
++ seção **Perguntas pro contador** (use `assets/templates/perguntas-contador.md`).
+
+## Os blocos de diagnóstico — o que cada um responde
+
+Para cada bloco: a pergunta gerencial, o template SQL, e como interpretar. Os nomes exatos
+de tabela/coluna e as armadilhas estão em `references/schema-financeiro.md` — **leia esse
+arquivo antes de adaptar qualquer SQL**, porque há divergências entre o que o front usa e o
+que está no banco.
+
+### 1. Caixa 13 semanas — `assets/sql/01-caixa-13-semanas.sql`
+Pergunta: "o caixa fura o zero nas próximas 13 semanas?".
+A fonte canônica é o engine `fin-cashflow-engine` (tela `/financeiro/capital-giro`, tab "Fluxo 13s").
+O SQL **triangula 3 ângulos** (lição do 1º fechamento — projeção só-CR engana): (a) projeção CR,
+(b) **saldo por conta** (acha a conta-vilã — ex.: um Itaú estourado), (c) **fluxo real 90d** via
+`fin_movimentacoes` (pega o faturamento à vista que entra por cartão/PIX e não vira CR).
+- **Alerta vermelho** (decisão do dono): saldo projetado **negativo em qualquer semana**
+  **OU** dias de cobertura abaixo do threshold de `fin_config_cashflow.thresholds->>'dias_cobertura_min'`.
+- **Não conclua só pela projeção (a).** Se a empresa fatura à vista (entradas_90d ≫ CR aberto),
+  a projeção CR é cega e exagera o vermelho — a verdade do caixa está em (b)+(c) e no engine.
+  Um saldo negativo concentrado numa conta (b) costuma ser cheque especial (juros caros → checar
+  "despesas financeiras" no DRE) ou conta não-conciliada; investigue antes de soar alarme.
+
+### 2. NCG / capital de giro — `assets/sql/02-ncg-capital-giro.sql`
+Pergunta: "quanto de dinheiro o ciclo operacional está consumindo, e eu tenho colchão pra isso?".
+NCG = **ACO − PCO**:
+- ACO = CR aberto + estoque + adiantamentos a fornecedor.
+- PCO = CP fornecedor aberto + folha 30d + tributos a pagar.
+- **Ressalva crítica**: o engine usa `estoque = 0` (hardcoded). O valor real, se cadastrado,
+  está em `fin_estoque_valor` (preenchimento manual). Sem estoque valorado, a NCG vem
+  **subestimada** — sinalize isso sempre.
+- Indicador-chave: **NCG > Capital de Giro Próprio** = déficit de liquidez (o ciclo consome
+  mais do que a empresa banca sozinha → depende de banco/atraso de fornecedor).
+
+### 3. Inadimplência por aging — `assets/sql/03-inadimplencia-aging.sql`
+Pergunta: "quem está me devendo, há quanto tempo, e qual a ação?".
+Política do dono: **flag desde o 1º dia de atraso** (cobrança cedo = caixa mais saudável),
+mas a ação é graduada por faixa de aging:
+
+| Faixa            | Natureza            | Ação recomendada                          |
+| ---------------- | ------------------- | ----------------------------------------- |
+| A vencer         | normal              | —                                         |
+| D+1 a D+7        | atraso recente      | WhatsApp / e-mail automático              |
+| D+8 a D+30       | atraso              | Ligação                                   |
+| D+31 a D+90      | atraso relevante    | Negociação / escalonamento / análise de crédito |
+| **D+90+**        | **inadimplência dura** | **Provisão pra perda + cobrança formal** |
+
+> A faixa **>90d** é a que alimenta a *taxa de inadimplência* da projeção de caixa (engine).
+> Não confunda "vencido há 2 dias" (recuperável, não vira provisão) com "inadimplência dura".
+> Aging: pegue o CONJUNTO de vencidos por `status_titulo IN ('ATRASADO','VENCE HOJE')` e a FAIXA
+> por **data** (`CURRENT_DATE − data_vencimento`). **NUNCA** use `saldo > 0`/`data_recebimento` pra
+> definir aberto/vencido — o `saldo` não zera na baixa (armadilha 1 do schema) e conta quitado como vencido.
+- Também mostre **concentração**: top 1 cliente vencido vs total vencido. Acima do threshold
+  `concentracao_top1_max_pct` = risco de concentração.
+
+### 4. DRE + confiabilidade — `assets/sql/04-dre-confiabilidade.sql`
+Pergunta: "o resultado gerencial do mês é confiável o suficiente pra eu usar?".
+- O DRE vive em `fin_dre_snapshots`, **uma linha por `(company, ano, mes, regime)`** — sempre
+  filtre `regime`, senão duplica. `regime IN ('caixa','competencia')`.
+- **Regra de escolha de regime**: prefira **competência** como principal *quando confiável*
+  (`fin_confiabilidade.pct_valor_mapeado` alto e `qtd_categorias_sem_mapeamento` baixo). Se a
+  confiabilidade for baixa, caia pra **caixa** e marque o badge de ressalva. Sempre diga ao
+  usuário qual regime você usou e por quê.
+  > ⚠️ `fin_confiabilidade` costuma estar **VAZIA** (a rotina nunca rodou). Plano B: decida o regime
+  > pelo `qtd_categorias_sem_mapeamento` do próprio snapshot do DRE (bloco 5) e marque baixa-confiança.
+- **Regra de ouro** (da doc `FINANCEIRO_CONFIABILIDADE.md`): se o DRE mostra R$ em
+  "Despesas Operacionais" e você não sabe o que é, **não use como número de controller** —
+  vá pro bloco 5 (mapeamento) primeiro.
+
+### 5. Categorias sem mapeamento — `assets/sql/05-categorias-sem-mapeamento.sql`
+Pergunta: "o que está caindo no balde errado do DRE?".
+Use a RPC pronta `fin_categorias_sem_mapping(p_company, p_start, p_end)` — retorna código,
+nome e valor no período das categorias Omie sem linha explícita em `fin_categoria_dre_mapping`
+(que então caem em heurística por palavra-chave, sujeita a erro).
+- Toda categoria com valor relevante sem mapeamento vira: (a) uma recomendação de classificar
+  em `/financeiro/mapping`, e (b) uma candidata a **pergunta pro contador** ("a categoria X é
+  custo (CMV) ou despesa operacional?").
+
+### 6. Carga tributária observada — `assets/sql/06-carga-tributaria.sql`
+Pergunta: "quanto de imposto está saindo, proporcionalmente, e isso faz sentido pro regime?".
+**Isto NÃO é apuração** (ver guardrail 1). É a *alíquota efetiva observada* = `impostos ÷ receita_bruta`
+do DRE, por empresa/período, mais o acumulado 12m de receita (relevante pra faixa do Simples
+no caso da Colacor SC).
+- Compare a alíquota efetiva observada com a faixa esperada do regime (Presumido vs Simples —
+  ver `references/regimes-tributarios.md`). Divergência grande → **pergunta pro contador**, não
+  conclusão.
+- Para Colacor SC (Simples), sinalize a faixa do RBT12 e a proximidade do teto de R$ 4,8 mi.
+  Fator R e enquadramento de anexo: **sempre confirmar com contador**.
+
+### 7. Intercompany — `assets/sql/07-intercompany.sql`
+Pergunta: "as operações entre as 3 empresas batem entre si?".
+Use `fin_ic_matches` (status `divergencia_valor` / `sem_contrapartida`) e `fin_eliminacoes_log`.
+Divergências aqui distorcem o consolidado e quase sempre viram pergunta pro contador
+(ex.: "a NF da Colacor pra Oben está lançada nas duas pontas pelo mesmo valor?").
+
+### 8. Orçado vs realizado + status de fechamento — `assets/sql/08-orcamento-fechamento.sql`
+Pergunta: "o mês já foi formalmente fechado, e o realizado bateu com o que eu orçei?".
+- `fin_fechamentos` diz se o período está `aberto`/`em_revisao`/`fechado`/`reaberto`. Sem linha
+  = nunca foi fechado formalmente — reporte. Não force fechamento (é write; fora do escopo).
+- Orçado vs realizado só funciona se houver linhas em `fin_orcamento`. Sem orçamento cadastrado,
+  a query (b) volta vazia — não é erro, só registre "sem orçamento pra comparar". Destaque os
+  maiores desvios (em R$ e %) por linha do DRE — eles costumam virar pergunta pro contador ou
+  ajuste de premissa pro próximo mês.
+
+## Consolidação das 3 empresas
+
+Quando o usuário pedir a visão do grupo, rode por empresa e some, **mas** avise: o consolidado
+bruto tem dupla contagem de operações intercompany. A eliminação formal depende de
+`fin_eliminacoes_log` estar populada. Se não estiver, apresente o consolidado como
+"**soma simples, sem eliminação intercompany**" e liste as divergências do bloco 7.
+
+## Saída
+
+- **Pulso semanal**: resumo no chat. Bullets por empresa + lista de cobrança D+1.
+- **Fechamento mensal**: relatório em `docs/cfo/AAAA-MM-fechamento.md` seguindo
+  `assets/templates/fechamento-mensal.md`, terminando com a seção **Perguntas pro contador**
+  (`assets/templates/perguntas-contador.md`). Crie a pasta `docs/cfo/` se não existir.
+
+Toda métrica derivada de classificação heurística ou de estoque não-valorado leva uma
+ressalva explícita. Prefira "não sei, confirmar com contador" a um número falsamente preciso.
+
+## Arquivos da skill
+
+- `references/schema-financeiro.md` — tabelas/colunas exatas, armadilhas (status, empresa,
+  regime no DRE, estoque=0). **Leia antes de adaptar SQL.**
+- `references/regimes-tributarios.md` — Presumido vs Simples, o que é hardcoded no front, o
+  que sempre vai pro contador, escopo das simulações conservadoras.
+- `assets/sql/00..08` — templates read-only canônicos pra colar no Lovable.
+- `assets/templates/fechamento-mensal.md` — estrutura do relatório mensal.
+- `assets/templates/perguntas-contador.md` — estrutura da lista de perguntas.

--- a/.claude/skills/cfo-colacor/assets/sql/00-sanity-status.sql
+++ b/.claude/skills/cfo-colacor/assets/sql/00-sanity-status.sql
@@ -1,0 +1,39 @@
+-- ============================================================================
+-- 00 — SANIDADE (rode SEMPRE primeiro)
+-- 🟣 Lovable → SQL Editor → cola → Run
+-- ----------------------------------------------------------------------------
+-- Valida os valores REAIS de status_titulo e o frescor dos dados antes de tudo.
+-- Status reais (COM espaço): receber = 'A VENCER'/'ATRASADO'/'VENCE HOJE'/'RECEBIDO'/'CANCELADO';
+-- pagar = 'A VENCER'/'ATRASADO'/'PAGO'/'CANCELADO'.
+-- 🔴 ARMADILHA-MÃE: o `saldo` NÃO zera na baixa. Se na query (a) os status quitados
+-- ('RECEBIDO'/'PAGO') aparecerem com saldo_total ALTO (não ~0), está CONFIRMADO que o saldo
+-- é furado → filtre "aberto" por status_titulo, NUNCA por saldo>0. (Ver schema, armadilha 1.)
+-- READ-ONLY. Não altera nada.
+-- ============================================================================
+
+-- (a) valores reais de status_titulo por empresa (CR e CP)
+SELECT 'receber' AS tabela, company, status_titulo,
+       count(*) AS qtd, round(sum(saldo)::numeric, 2) AS saldo_total
+FROM fin_contas_receber
+GROUP BY company, status_titulo
+UNION ALL
+SELECT 'pagar' AS tabela, company, status_titulo,
+       count(*), round(sum(saldo)::numeric, 2)
+FROM fin_contas_pagar
+GROUP BY company, status_titulo
+ORDER BY tabela, company, status_titulo;
+
+-- (b) frescor: até quando os dados vão por empresa (datas confirmadas no schema)
+SELECT company,
+       count(*)               AS titulos_cr,
+       max(data_emissao)      AS ultima_emissao,
+       max(data_vencimento)   AS ultimo_vencimento
+FROM fin_contas_receber
+GROUP BY company
+ORDER BY company;
+
+-- (c) último sync registrado (se a tabela tiver coluna de timestamp; senão use fin_confiabilidade.ultimo_sync)
+SELECT company, ano, mes, ultimo_sync, fechamento_status
+FROM fin_confiabilidade
+ORDER BY ano DESC, mes DESC, company
+LIMIT 9;

--- a/.claude/skills/cfo-colacor/assets/sql/01-caixa-13-semanas.sql
+++ b/.claude/skills/cfo-colacor/assets/sql/01-caixa-13-semanas.sql
@@ -1,0 +1,107 @@
+-- ============================================================================
+-- 01 — CAIXA: projeção 13 semanas + TRIANGULAÇÃO (saldo por conta + fluxo real)
+-- 🟣 Lovable → SQL Editor → cola → Run  (rode uma query por vez)
+-- ----------------------------------------------------------------------------
+-- ⚠️ CORRIGIDO (1º fechamento real, 2026-06-16):
+--  • "Aberto" filtra por status_titulo, NUNCA por saldo>0 — o saldo NÃO zera na
+--    baixa neste banco (ver armadilha 1 em references/schema-financeiro.md).
+--  • A projeção por CR é CEGA a quem fatura à vista (entra por cartão/PIX, não vira
+--    CR). Por isso esta versão TRIANGULA: (a) projeção CR + (b) saldo por conta +
+--    (c) fluxo real de caixa via fin_movimentacoes. Cruze os três antes de concluir.
+--  • Verdade canônica = engine /financeiro/capital-giro. Aqui é cross-check.
+-- READ-ONLY.
+-- ============================================================================
+
+-- (a) projeção semanal por empresa (entradas = CR aberto vencendo; saídas = CP aberto)
+WITH comp(company) AS (VALUES ('colacor'),('oben'),('colacor_sc')),
+semanas AS (
+  SELECT generate_series(
+           date_trunc('week', CURRENT_DATE)::date,
+           (date_trunc('week', CURRENT_DATE) + interval '12 weeks')::date,
+           interval '1 week')::date AS semana_ini
+),
+saldo_ini AS (
+  SELECT company, COALESCE(sum(saldo_atual),0) AS saldo_inicial
+  FROM fin_contas_correntes WHERE ativo GROUP BY company
+),
+entradas AS (
+  SELECT company, date_trunc('week', data_vencimento)::date AS semana_ini, sum(valor_documento) AS entra
+  FROM fin_contas_receber
+  WHERE status_titulo IN ('A VENCER','ATRASADO','VENCE HOJE')   -- status, NÃO saldo
+    AND data_vencimento >= date_trunc('week', CURRENT_DATE)::date
+    AND data_vencimento <  (date_trunc('week', CURRENT_DATE) + interval '13 weeks')::date
+  GROUP BY company, 2
+),
+saidas AS (
+  SELECT company, date_trunc('week', data_vencimento)::date AS semana_ini, sum(valor_documento) AS sai
+  FROM fin_contas_pagar
+  WHERE status_titulo IN ('A VENCER','ATRASADO')               -- status, NÃO saldo
+    AND data_vencimento >= date_trunc('week', CURRENT_DATE)::date
+    AND data_vencimento <  (date_trunc('week', CURRENT_DATE) + interval '13 weeks')::date
+  GROUP BY company, 2
+),
+base AS (
+  SELECT c.company, s.semana_ini,
+         COALESCE(e.entra,0) AS entradas, COALESCE(p.sai,0) AS saidas
+  FROM comp c CROSS JOIN semanas s
+  LEFT JOIN entradas e ON e.company = c.company AND e.semana_ini = s.semana_ini
+  LEFT JOIN saidas  p ON p.company = c.company AND p.semana_ini = s.semana_ini
+)
+SELECT b.company, b.semana_ini,
+       round(b.entradas::numeric,2) AS entradas,
+       round(b.saidas::numeric,2)   AS saidas,
+       round((b.entradas - b.saidas)::numeric,2) AS fluxo_liquido,
+       round((COALESCE(si.saldo_inicial,0)
+              + sum(b.entradas - b.saidas) OVER (PARTITION BY b.company ORDER BY b.semana_ini))::numeric,2)
+         AS saldo_projetado_cr_only  -- ⚠️ só CR: cego a faturamento à vista; cruze com (c)
+FROM base b
+LEFT JOIN saldo_ini si ON si.company = b.company
+ORDER BY b.company, b.semana_ini;
+
+-- (b) SALDO POR CONTA — decompõe o caixa pra achar a "conta-vilã" (ex.: Itaú estourado)
+SELECT company, descricao, banco, tipo, ativo,
+       saldo_data, round(saldo_atual::numeric,2) AS saldo_atual
+FROM fin_contas_correntes
+WHERE ativo
+ORDER BY company, saldo_atual;   -- a mais negativa primeiro
+
+-- (c) FLUXO REAL de caixa últimos 90d (fin_movimentacoes) — pega o à vista que o CR não vê.
+--     Se entradas_90d >> CR aberto, a empresa fatura à vista → projeção (a) subestima entrada.
+SELECT company,
+       round(sum(valor) FILTER (WHERE tipo = 'E')::numeric,2) AS entradas_caixa_90d,
+       round(sum(valor) FILTER (WHERE tipo = 'S')::numeric,2) AS saidas_caixa_90d,
+       round((sum(valor) FILTER (WHERE tipo = 'E')
+            - sum(valor) FILTER (WHERE tipo = 'S'))::numeric,2) AS fluxo_liquido_90d,
+       count(*)            AS movimentos,
+       max(data_movimento) AS ultimo_movimento
+FROM fin_movimentacoes
+WHERE data_movimento >= CURRENT_DATE - interval '90 days'
+GROUP BY company ORDER BY company;
+
+-- (d) OVERLAY: eventos que a projeção (a) NÃO inclui — recorrentes (folha) e eventuais
+SELECT company, 'recorrente' AS origem, descricao, tipo, valor, dia_do_mes AS dia, is_folha
+FROM fin_eventos_recorrentes
+WHERE ativo AND (fim IS NULL OR fim >= CURRENT_DATE)
+UNION ALL
+SELECT company, 'eventual', descricao, tipo, valor,
+       EXTRACT(DAY FROM data_prevista)::int, false
+FROM fin_eventos_eventuais
+WHERE status IN ('previsto','confirmado')
+  AND data_prevista BETWEEN CURRENT_DATE AND (CURRENT_DATE + interval '90 days')
+ORDER BY company, origem, tipo;
+-- (vazio = folha/eventos nunca cadastrados → projeção subestima saídas futuras; ação de setup)
+
+-- (e) alertas de caixa ativos (engine = âncora; cruze com sua leitura)
+SELECT company, tipo, severidade, mensagem, valor, threshold
+FROM fin_alertas
+WHERE dismissed_at IS NULL AND (dismissed_until IS NULL OR dismissed_until < now())
+ORDER BY company, array_position(ARRAY['critico','aviso','info']::text[], severidade);
+
+-- (f) thresholds configurados (pra avaliar caixa negativo / cobertura)
+SELECT company,
+       thresholds->>'dias_cobertura_min'        AS dias_cobertura_min,
+       thresholds->>'caixa_negativo_semanas'    AS caixa_negativo_semanas,
+       thresholds->>'inadimplencia_max_pct'     AS inadimplencia_max_pct,
+       thresholds->>'concentracao_top1_max_pct' AS concentracao_top1_max_pct,
+       thresholds->>'ncg_deficit_alerta'        AS ncg_deficit_alerta
+FROM fin_config_cashflow ORDER BY company;

--- a/.claude/skills/cfo-colacor/assets/sql/02-ncg-capital-giro.sql
+++ b/.claude/skills/cfo-colacor/assets/sql/02-ncg-capital-giro.sql
@@ -1,0 +1,80 @@
+-- ============================================================================
+-- 02 — NCG / CAPITAL DE GIRO (decomposição ACO − PCO), por empresa
+-- 🟣 Lovable → SQL Editor → cola → Run
+-- ----------------------------------------------------------------------------
+-- NCG = ACO − PCO
+--   ACO = CR aberto + estoque + adiantamentos a fornecedor
+--   PCO = CP fornecedor aberto + folha 30d + tributos a pagar
+-- ⚠️ CORRIGIDO (1º fechamento, 2026-06-16): "aberto" filtra por status_titulo, NUNCA
+--    por saldo>0 (o saldo não zera na baixa — armadilha 1 do schema). Valor = valor_documento.
+-- VALIDE contra o engine: os números aqui devem bater com os alertas ncg_deficit /
+--    Liquidez Operacional Líquida do fin_alertas. Se divergir MUITO, é contaminação.
+-- RESSALVAS:
+--  • estoque vem de fin_estoque_valor (VAZIO neste ambiente → 0 → NCG subestimada). Sinalize.
+--  • folha vem de fin_eventos_recorrentes is_folha (VAZIO → 0). Sinalize.
+--  • 'adiantamentos' usa fin_config_cashflow.adiantamento_categorias_codigos (se não configurado, 0).
+--  • 'tributos' = CP com categoria_codigo LIKE '3.99%' (o '%' é WILDCARD do LIKE, não "por cento").
+--    Confirme na sanidade que seus tributos têm código começando em "3.99"; senão ajuste/ignore.
+--  • NCG < Capital de Giro Próprio negativo = ciclo depende de banco/fornecedor. Leia junto do bloco 1.
+-- READ-ONLY.
+-- ============================================================================
+
+WITH comp(company) AS (VALUES ('colacor'),('oben'),('colacor_sc')),
+cfg AS (
+  SELECT company, COALESCE(adiantamento_categorias_codigos, ARRAY[]::text[]) AS adiant_cods
+  FROM fin_config_cashflow
+),
+estoque AS (
+  SELECT DISTINCT ON (company) company, valor AS estoque_valor, data_ref
+  FROM fin_estoque_valor ORDER BY company, data_ref DESC
+),
+cr AS (
+  SELECT company, sum(valor_documento) AS cr_aberto
+  FROM fin_contas_receber
+  WHERE status_titulo IN ('A VENCER','ATRASADO','VENCE HOJE')   -- status, NÃO saldo
+  GROUP BY company
+),
+cp AS (
+  SELECT p.company,
+    COALESCE(sum(p.valor_documento) FILTER (WHERE p.categoria_codigo = ANY(c.adiant_cods)),0)  AS adiantamentos,
+    COALESCE(sum(p.valor_documento) FILTER (WHERE p.categoria_codigo LIKE '3.99%'),0)          AS tributos,
+    COALESCE(sum(p.valor_documento) FILTER (WHERE p.categoria_codigo IS NOT NULL
+                 AND p.categoria_codigo NOT LIKE '3.99%'
+                 AND NOT (p.categoria_codigo = ANY(c.adiant_cods))),0)                         AS cp_fornecedor,
+    COALESCE(sum(p.valor_documento) FILTER (WHERE p.categoria_codigo IS NULL),0)               AS cp_sem_categoria
+  FROM fin_contas_pagar p
+  LEFT JOIN cfg c ON c.company = p.company
+  WHERE p.status_titulo IN ('A VENCER','ATRASADO')             -- status, NÃO saldo
+  GROUP BY p.company
+),
+folha AS (
+  SELECT company, sum(valor) AS folha_30d
+  FROM fin_eventos_recorrentes
+  WHERE ativo AND is_folha AND tipo = 'saida' GROUP BY company
+),
+cc AS (
+  SELECT company, sum(saldo_atual) AS saldo_cc
+  FROM fin_contas_correntes WHERE ativo GROUP BY company
+)
+SELECT comp.company,
+  round(COALESCE(cr.cr_aberto,0)::numeric,2)        AS cr_aberto,
+  round(COALESCE(e.estoque_valor,0)::numeric,2)     AS estoque,
+  round(COALESCE(cp.adiantamentos,0)::numeric,2)    AS adiantamentos,
+  round((COALESCE(cr.cr_aberto,0)+COALESCE(e.estoque_valor,0)+COALESCE(cp.adiantamentos,0))::numeric,2) AS aco,
+  round(COALESCE(cp.cp_fornecedor,0)::numeric,2)    AS cp_fornecedor,
+  round(COALESCE(f.folha_30d,0)::numeric,2)         AS folha_30d,
+  round(COALESCE(cp.tributos,0)::numeric,2)         AS tributos_a_pagar,
+  round((COALESCE(cp.cp_fornecedor,0)+COALESCE(f.folha_30d,0)+COALESCE(cp.tributos,0))::numeric,2) AS pco,
+  round(((COALESCE(cr.cr_aberto,0)+COALESCE(e.estoque_valor,0)+COALESCE(cp.adiantamentos,0))
+       - (COALESCE(cp.cp_fornecedor,0)+COALESCE(f.folha_30d,0)+COALESCE(cp.tributos,0)))::numeric,2) AS ncg,
+  round(COALESCE(cc.saldo_cc,0)::numeric,2)         AS saldo_cc,
+  round((COALESCE(cc.saldo_cc,0)+COALESCE(cr.cr_aberto,0)+COALESCE(e.estoque_valor,0)
+       - (COALESCE(cp.cp_fornecedor,0)+COALESCE(f.folha_30d,0)+COALESCE(cp.tributos,0)))::numeric,2) AS capital_giro_proprio,
+  round(COALESCE(cp.cp_sem_categoria,0)::numeric,2) AS alerta_cp_sem_categoria
+FROM comp
+LEFT JOIN cr      ON cr.company = comp.company
+LEFT JOIN cp      ON cp.company = comp.company
+LEFT JOIN folha f ON f.company  = comp.company
+LEFT JOIN estoque e ON e.company = comp.company
+LEFT JOIN cc      ON cc.company = comp.company
+ORDER BY comp.company;

--- a/.claude/skills/cfo-colacor/assets/sql/03-inadimplencia-aging.sql
+++ b/.claude/skills/cfo-colacor/assets/sql/03-inadimplencia-aging.sql
@@ -1,0 +1,66 @@
+-- ============================================================================
+-- 03 — INADIMPLÊNCIA POR AGING (recebíveis)
+-- 🟣 Lovable → SQL Editor → cola → Run
+-- ----------------------------------------------------------------------------
+-- Política do dono: flag desde o 1º dia de atraso, ação graduada por faixa:
+--   D+1 a D+7   → WhatsApp/e-mail   | D+8 a D+30 → ligação
+--   D+31 a D+90 → negociação        | D+90+      → inadimplência dura (provisão)
+-- ⚠️ CORRIGIDO (1º fechamento, 2026-06-16):
+--  • CONJUNTO de vencidos = status_titulo IN ('ATRASADO','VENCE HOJE'), NUNCA saldo>0
+--    (o saldo não zera na baixa → contaria quitado como vencido). Valor = valor_documento.
+--  • FAIXA (dias) = CURRENT_DATE − data_vencimento (o status defasa 1-7 dias).
+--  • nome_cliente/cnpj_cpf VAZIOS no banco → agrupar por omie_codigo_cliente (ver armadilha 4).
+--  • Atenção a fósseis (dias_max > 1000): dívida prescrita a PROVISIONAR/dar baixa, não cobrar.
+-- READ-ONLY.
+-- ============================================================================
+
+-- (a) aging consolidado por empresa (conjunto por status, faixa por data)
+WITH cr_vencido AS (
+  SELECT company, valor_documento AS valor, (CURRENT_DATE - data_vencimento) AS dias_atraso
+  FROM fin_contas_receber
+  WHERE status_titulo IN ('ATRASADO','VENCE HOJE')
+)
+SELECT company,
+  round(sum(valor) FILTER (WHERE dias_atraso <= 0)::numeric,2)             AS vence_hoje,
+  round(sum(valor) FILTER (WHERE dias_atraso BETWEEN 1 AND 7)::numeric,2)  AS d1_7,
+  round(sum(valor) FILTER (WHERE dias_atraso BETWEEN 8 AND 30)::numeric,2) AS d8_30,
+  round(sum(valor) FILTER (WHERE dias_atraso BETWEEN 31 AND 90)::numeric,2) AS d31_90,
+  round(sum(valor) FILTER (WHERE dias_atraso > 90)::numeric,2)             AS d90_mais,
+  round(sum(valor)::numeric,2)                                             AS total_vencido,
+  count(*)                                                                 AS titulos,
+  max(dias_atraso)                                                         AS dias_atraso_max
+FROM cr_vencido
+GROUP BY company ORDER BY company;
+
+-- (b) lista de cobrança: top devedores por CÓDIGO (nome não existe no banco — ver armadilha 4).
+--     Cruze o omie_codigo_cliente com o Omie pra saber quem é. Filtre 1 empresa por vez se quiser.
+WITH cr_vencido AS (
+  SELECT company, omie_codigo_cliente, valor_documento AS valor,
+         (CURRENT_DATE - data_vencimento) AS dias_atraso
+  FROM fin_contas_receber WHERE status_titulo = 'ATRASADO'
+)
+SELECT company, omie_codigo_cliente,
+       round(sum(valor)::numeric,2) AS total_vencido,
+       max(dias_atraso)             AS dias_max,
+       count(*)                     AS titulos,
+       CASE WHEN max(dias_atraso) > 365 THEN 'FÓSSIL (>1 ano) — provisionar/baixar'
+            WHEN max(dias_atraso) > 90  THEN 'D+90 provisão'
+            WHEN max(dias_atraso) > 30  THEN 'D+31-90 negociação'
+            WHEN max(dias_atraso) > 7   THEN 'D+8-30 ligação'
+            ELSE 'D+1-7 whatsapp/email' END AS acao
+FROM cr_vencido
+GROUP BY company, omie_codigo_cliente
+ORDER BY company, total_vencido DESC
+LIMIT 60;
+
+-- (c) concentração: top 1 devedor vencido vs total vencido (por código de cliente)
+WITH cr_vencido AS (
+  SELECT company, omie_codigo_cliente, sum(valor_documento) AS valor_cli
+  FROM fin_contas_receber WHERE status_titulo = 'ATRASADO'
+  GROUP BY company, omie_codigo_cliente
+)
+SELECT company,
+       round(max(valor_cli)::numeric,2)            AS top1_vencido,
+       round(sum(valor_cli)::numeric,2)            AS total_vencido,
+       round(100.0*max(valor_cli)/NULLIF(sum(valor_cli),0),1) AS pct_concentracao_top1
+FROM cr_vencido GROUP BY company ORDER BY company;

--- a/.claude/skills/cfo-colacor/assets/sql/04-dre-confiabilidade.sql
+++ b/.claude/skills/cfo-colacor/assets/sql/04-dre-confiabilidade.sql
@@ -1,0 +1,53 @@
+-- ============================================================================
+-- 04 — DRE GERENCIAL + CONFIABILIDADE
+-- 🟣 Lovable → SQL Editor → cola → Run
+-- ----------------------------------------------------------------------------
+-- fin_dre_snapshots tem 1 linha por (company, ano, mes, regime). SEMPRE filtre
+-- regime ('caixa' | 'competencia') — senão soma os dois e dobra tudo.
+-- Regra de escolha: prefira COMPETÊNCIA se a confiabilidade (04b) for alta
+-- (pct_valor_mapeado alto, qtd_categorias_sem_mapeamento baixo). Senão use CAIXA
+-- com ressalva. Diga sempre qual regime usou e por quê.
+-- Regra de ouro: se há R$ em "despesas_operacionais" e você não sabe o que é,
+-- rode 05 (categorias sem mapeamento) ANTES de usar o número.
+-- EDITE ano/mes abaixo.
+-- READ-ONLY.
+-- ============================================================================
+
+-- (a) DRE do período, lado a lado caixa vs competência, por empresa
+WITH p AS (SELECT 2026 AS ano, 4 AS mes)   -- <<< EDITE
+SELECT d.company, d.regime,
+       round(d.receita_bruta::numeric,2)            AS receita_bruta,
+       round(d.deducoes::numeric,2)                 AS deducoes,
+       round(d.receita_liquida::numeric,2)          AS receita_liquida,
+       round(d.cmv::numeric,2)                      AS cmv,
+       round(d.lucro_bruto::numeric,2)              AS lucro_bruto,
+       round(d.despesas_operacionais::numeric,2)    AS desp_operacionais,
+       round(d.despesas_administrativas::numeric,2) AS desp_administrativas,
+       round(d.despesas_comerciais::numeric,2)      AS desp_comerciais,
+       round(d.despesas_financeiras::numeric,2)     AS desp_financeiras,
+       round(d.resultado_operacional::numeric,2)    AS resultado_operacional,
+       round(d.resultado_antes_impostos::numeric,2) AS resultado_antes_impostos,
+       round(d.impostos::numeric,2)                 AS impostos,
+       round(d.resultado_liquido::numeric,2)        AS resultado_liquido,
+       d.qtd_categorias_sem_mapeamento
+FROM fin_dre_snapshots d, p
+WHERE d.ano = p.ano AND d.mes = p.mes
+ORDER BY d.company, d.regime;
+
+-- (b) confiabilidade do período (decide se competência é confiável)
+WITH p AS (SELECT 2026 AS ano, 4 AS mes)   -- <<< EDITE (mesmo período)
+SELECT c.company,
+       c.pct_valor_mapeado,
+       c.dre_categorias_mapeadas, c.dre_categorias_heuristica, c.dre_categorias_total,
+       c.cr_sem_categoria, c.cp_sem_categoria,
+       c.pct_mov_conciliado, c.fechamento_status, c.ultimo_sync
+FROM fin_confiabilidade c, p
+WHERE c.ano = p.ano AND c.mes = p.mes
+ORDER BY c.company;
+
+-- (c) tendência: resultado líquido dos últimos 6 meses (regime competência)
+SELECT company, ano, mes, round(resultado_liquido::numeric,2) AS resultado_liquido
+FROM fin_dre_snapshots
+WHERE regime = 'competencia'
+  AND make_date(ano, mes, 1) > (CURRENT_DATE - interval '6 months')
+ORDER BY company, ano, mes;

--- a/.claude/skills/cfo-colacor/assets/sql/05-categorias-sem-mapeamento.sql
+++ b/.claude/skills/cfo-colacor/assets/sql/05-categorias-sem-mapeamento.sql
@@ -1,0 +1,38 @@
+-- ============================================================================
+-- 05 — CATEGORIAS SEM MAPEAMENTO DRE
+-- 🟣 Lovable → SQL Editor → cola → Run
+-- ----------------------------------------------------------------------------
+-- Categorias Omie com movimento no período que NÃO têm linha explícita em
+-- fin_categoria_dre_mapping — caem na heurística por palavra-chave (sujeita a
+-- erro). Cada uma com valor relevante vira: (a) classificar em /financeiro/mapping,
+-- (b) candidata a pergunta pro contador ("X é CMV ou despesa operacional?").
+-- READ-ONLY.
+-- ============================================================================
+
+-- (a) RPC pronta — rode 1× POR EMPRESA (a função recebe company + período).
+--     EDITE company e datas:
+SELECT * FROM fin_categorias_sem_mapping('colacor', DATE '2026-04-01', DATE '2026-04-30')
+ORDER BY valor_periodo DESC;
+-- repita trocando 'colacor' por 'oben' e depois 'colacor_sc'.
+
+-- (b) FALLBACK (se a RPC fin_categorias_sem_mapping não existir no banco):
+--     lê o que o cálculo do DRE registrou como não-mapeado no snapshot.
+WITH p AS (SELECT 2026 AS ano, 4 AS mes)   -- <<< EDITE
+SELECT d.company, d.regime, d.qtd_categorias_sem_mapeamento,
+       d.detalhamento -> 'categorias_nao_mapeadas' AS categorias_nao_mapeadas
+FROM fin_dre_snapshots d, p
+WHERE d.ano = p.ano AND d.mes = p.mes
+ORDER BY d.company, d.regime;
+
+-- (c) FALLBACK extra: títulos sem categoria_codigo no período (não classificáveis)
+WITH p AS (SELECT DATE '2026-04-01' AS ini, DATE '2026-04-30' AS fim)   -- <<< EDITE
+SELECT 'receber' AS tabela, company, count(*) AS titulos, round(sum(valor_documento)::numeric,2) AS valor
+FROM fin_contas_receber, p
+WHERE categoria_codigo IS NULL AND data_emissao BETWEEN p.ini AND p.fim
+GROUP BY company
+UNION ALL
+SELECT 'pagar', company, count(*), round(sum(valor_documento)::numeric,2)
+FROM fin_contas_pagar, p
+WHERE categoria_codigo IS NULL AND data_emissao BETWEEN p.ini AND p.fim
+GROUP BY company
+ORDER BY tabela, company;

--- a/.claude/skills/cfo-colacor/assets/sql/06-carga-tributaria.sql
+++ b/.claude/skills/cfo-colacor/assets/sql/06-carga-tributaria.sql
@@ -1,0 +1,45 @@
+-- ============================================================================
+-- 06 — CARGA TRIBUTÁRIA OBSERVADA (NÃO é apuração — ver guardrail 1 do SKILL.md)
+-- 🟣 Lovable → SQL Editor → cola → Run
+-- ----------------------------------------------------------------------------
+-- Isto é um TERMÔMETRO gerencial: alíquota efetiva = impostos ÷ receita_bruta do
+-- DRE. NÃO é o imposto a pagar (DAS/DARF), que é do contador. Divergência grande
+-- vs a faixa esperada do regime = pergunta pro contador, nunca conclusão.
+-- Regimes: colacor/oben = Lucro Presumido ; colacor_sc = Simples Nacional.
+-- (Detalhes e faixas em references/regimes-tributarios.md.)
+-- READ-ONLY.
+-- ============================================================================
+
+-- (a) alíquota efetiva observada do mês, por empresa
+WITH p AS (SELECT 2026 AS ano, 4 AS mes, 'competencia'::text AS regime_dre)  -- <<< EDITE
+SELECT d.company, d.regime,
+       round(d.receita_bruta::numeric,2) AS receita_bruta,
+       round(d.impostos::numeric,2)      AS impostos,
+       CASE WHEN d.receita_bruta > 0
+            THEN round(100.0 * d.impostos / d.receita_bruta, 2) END AS aliquota_efetiva_pct
+FROM fin_dre_snapshots d, p
+WHERE d.ano = p.ano AND d.mes = p.mes AND d.regime = p.regime_dre
+ORDER BY d.company;
+
+-- (b) RBT12: receita bruta acumulada 12 meses (faixa do Simples / teto R$ 4,8mi).
+--     Crítico pra colacor_sc. EDITE o mês-base (último mês fechado):
+WITH p AS (SELECT 2026 AS ano, 4 AS mes, 'competencia'::text AS regime_dre)  -- <<< EDITE
+SELECT d.company,
+       round(sum(d.receita_bruta)::numeric,2)                       AS rbt12,
+       round(100.0 * sum(d.receita_bruta) / 4800000.0, 1)           AS pct_do_teto_4_8mi
+FROM fin_dre_snapshots d, p
+WHERE d.regime = p.regime_dre
+  AND make_date(d.ano, d.mes, 1) >  (make_date(p.ano, p.mes, 1) - interval '12 months')
+  AND make_date(d.ano, d.mes, 1) <= make_date(p.ano, p.mes, 1)
+GROUP BY d.company
+ORDER BY d.company;
+
+-- (c) tendência da alíquota efetiva (últimos 6 meses, competência) — pra ver oscilação
+SELECT company, ano, mes,
+       round(receita_bruta::numeric,2) AS receita_bruta,
+       round(impostos::numeric,2)      AS impostos,
+       CASE WHEN receita_bruta > 0 THEN round(100.0*impostos/receita_bruta,2) END AS aliquota_efetiva_pct
+FROM fin_dre_snapshots
+WHERE regime = 'competencia'
+  AND make_date(ano, mes, 1) > (CURRENT_DATE - interval '6 months')
+ORDER BY company, ano, mes;

--- a/.claude/skills/cfo-colacor/assets/sql/07-intercompany.sql
+++ b/.claude/skills/cfo-colacor/assets/sql/07-intercompany.sql
@@ -1,0 +1,33 @@
+-- ============================================================================
+-- 07 — INTERCOMPANY (operações entre Colacor, Oben e Colacor SC)
+-- 🟣 Lovable → SQL Editor → cola → Run
+-- ----------------------------------------------------------------------------
+-- Divergências aqui distorcem o consolidado e quase sempre viram pergunta pro
+-- contador (ex.: "a NF da Colacor pra Oben está lançada nas duas pontas pelo
+-- mesmo valor?"). A eliminação formal depende de fin_eliminacoes_log estar
+-- populada; sem isso, apresente o consolidado como "soma simples, sem eliminação".
+-- READ-ONLY.
+-- ============================================================================
+
+-- (a) divergências de matching CR↔CP entre empresas
+SELECT empresa_origem, empresa_destino, status,
+       count(*) AS qtd, round(sum(diff_valor)::numeric,2) AS soma_diferenca
+FROM fin_ic_matches
+WHERE status IN ('divergencia_valor','sem_contrapartida')
+GROUP BY empresa_origem, empresa_destino, status
+ORDER BY empresa_origem, empresa_destino, status;
+
+-- (b) detalhe das maiores divergências (pra investigar título a título)
+SELECT empresa_origem, empresa_destino, status,
+       cr_id, cp_id, round(diff_valor::numeric,2) AS diff_valor
+FROM fin_ic_matches
+WHERE status IN ('divergencia_valor','sem_contrapartida')
+ORDER BY abs(diff_valor) DESC NULLS LAST
+LIMIT 30;
+
+-- (c) eliminações intercompany aplicadas no período (se a tabela estiver populada)
+WITH p AS (SELECT 2026 AS ano, 4 AS mes)   -- <<< EDITE
+SELECT l.ano, l.mes, round(sum(l.valor_eliminado)::numeric,2) AS total_eliminado, count(*) AS qtd
+FROM fin_eliminacoes_log l, p
+WHERE l.ano = p.ano AND l.mes = p.mes
+GROUP BY l.ano, l.mes;

--- a/.claude/skills/cfo-colacor/assets/sql/08-orcamento-fechamento.sql
+++ b/.claude/skills/cfo-colacor/assets/sql/08-orcamento-fechamento.sql
@@ -1,0 +1,50 @@
+-- ============================================================================
+-- 08 — ORÇADO vs REALIZADO + STATUS DE FECHAMENTO
+-- 🟣 Lovable → SQL Editor → cola → Run
+-- ----------------------------------------------------------------------------
+-- Fecha o ritual mensal: (a) o mês já foi formalmente fechado/aprovado no sistema?
+-- (b) o realizado bateu com o orçamento por linha do DRE? Só roda se houver
+-- orçamento cadastrado em fin_orcamento (senão (b) volta vazio — não é erro).
+-- READ-ONLY.
+-- ============================================================================
+
+-- (a) status de fechamento formal do período, por empresa
+WITH p AS (SELECT 2026 AS ano, 4 AS mes)   -- <<< EDITE
+SELECT f.company, f.ano, f.mes, f.status, f.versao,
+       f.fechado_em, f.aprovado_em
+FROM fin_fechamentos f, p
+WHERE f.ano = p.ano AND f.mes = p.mes
+ORDER BY f.company, f.versao DESC;
+-- Sem linha = mês ainda 'aberto' (nunca fechado formalmente). Reporte isso.
+
+-- (b) orçado vs realizado por linha do DRE (realizado = snapshot competência)
+WITH p AS (SELECT 2026 AS ano, 4 AS mes, 'competencia'::text AS regime_dre),  -- <<< EDITE
+real_lines AS (
+  SELECT d.company, v.dre_linha, v.valor_real
+  FROM fin_dre_snapshots d, p,
+  LATERAL (VALUES
+    ('receita_bruta',           d.receita_bruta),
+    ('deducoes',                d.deducoes),
+    ('cmv',                     d.cmv),
+    ('despesas_operacionais',   d.despesas_operacionais),
+    ('despesas_administrativas',d.despesas_administrativas),
+    ('despesas_comerciais',     d.despesas_comerciais),
+    ('despesas_financeiras',    d.despesas_financeiras),
+    ('receitas_financeiras',    d.receitas_financeiras),
+    ('outras_receitas',         d.outras_receitas),
+    ('outras_despesas',         d.outras_despesas),
+    ('impostos',                d.impostos)
+  ) AS v(dre_linha, valor_real)
+  WHERE d.ano = p.ano AND d.mes = p.mes AND d.regime = p.regime_dre
+)
+SELECT o.company, o.dre_linha,
+       round(o.valor_orcado::numeric,2)              AS orcado,
+       round(COALESCE(r.valor_real,0)::numeric,2)    AS realizado,
+       round((COALESCE(r.valor_real,0) - o.valor_orcado)::numeric,2) AS desvio,
+       CASE WHEN o.valor_orcado <> 0
+            THEN round(100.0*(COALESCE(r.valor_real,0) - o.valor_orcado)/abs(o.valor_orcado),1)
+       END                                           AS desvio_pct
+FROM fin_orcamento o, p
+LEFT JOIN real_lines r ON r.company = o.company AND r.dre_linha = o.dre_linha
+WHERE o.ano = p.ano AND o.mes = p.mes
+ORDER BY o.company, abs(COALESCE(r.valor_real,0) - o.valor_orcado) DESC;

--- a/.claude/skills/cfo-colacor/assets/templates/fechamento-mensal.md
+++ b/.claude/skills/cfo-colacor/assets/templates/fechamento-mensal.md
@@ -1,0 +1,94 @@
+# Fechamento gerencial — Grupo Colacor — {MÊS}/{ANO}
+
+> Diagnóstico gerencial, READ-ONLY, gerado pela skill `cfo-colacor`. **Não é apuração
+> contábil/fiscal.** Números marcados com ⚠️ dependem de configuração (mapeamento, estoque
+> valorado) ou são estimativa observada — confirmar com contador onde indicado.
+> Dados extraídos do Supabase via SQL no Lovable em {DATA_EXTRACAO}. Último sync Omie: {ULTIMO_SYNC}.
+
+## 1. Resumo executivo (3 linhas)
+- **Caixa**: {situação em 1 frase — folga/aperto, pior semana das 13}.
+- **Resultado**: {resultado líquido do grupo no mês, regime usado}.
+- **Atenção**: {o risco nº1 do mês — inadimplência / NCG / tributo / divergência}.
+
+## 2. Caixa — projeção 13 semanas
+| Empresa | Saldo hoje | Pior semana (saldo) | Quando | Bandeira |
+|---|--:|--:|---|---|
+| Colacor |  |  |  | 🟢/🟡/🔴 |
+| Oben |  |  |  |  |
+| Colacor SC |  |  |  |  |
+
+Gatilho de alerta vermelho: saldo projetado negativo em qualquer semana **OU** dias de
+cobertura abaixo do threshold de `fin_config_cashflow`. Alertas ativos: {listar de 01d}.
+> O cross-check SQL não desconta inadimplência nem inclui folha/eventos (01c). Confronte com
+> a tela /financeiro/capital-giro (engine canônico) antes de concluir.
+
+## 3. NCG / capital de giro
+| Empresa | ACO | PCO | NCG | Cap. Giro Próprio | NCG > CGP? |
+|---|--:|--:|--:|--:|---|
+| Colacor |  |  |  |  |  |
+| Oben |  |  |  |  |  |
+| Colacor SC |  |  |  |  |  |
+
+⚠️ Estoque = {valor de fin_estoque_valor ou "0 (não valorado → NCG subestimada)"}.
+
+## 4. Inadimplência (aging de recebíveis)
+| Empresa | A vencer | D+1–7 | D+8–30 | D+31–90 | D+90+ | % vencido | Conc. top1 |
+|---|--:|--:|--:|--:|--:|--:|--:|
+| Colacor |  |  |  |  |  |  |  |
+| Oben |  |  |  |  |  |  |  |
+| Colacor SC |  |  |  |  |  |  |  |
+
+**Lista de cobrança prioritária** (top devedores vencidos, ação por faixa): {tabela de 03b}.
+
+## 5. DRE gerencial
+Regime usado: **{caixa|competência}** — motivo: {confiabilidade, pct_valor_mapeado}.
+| Linha | Colacor | Oben | Colacor SC | Grupo* |
+|---|--:|--:|--:|--:|
+| Receita bruta |  |  |  |  |
+| Receita líquida |  |  |  |  |
+| Lucro bruto |  |  |  |  |
+| Resultado operacional |  |  |  |  |
+| Impostos |  |  |  |  |
+| **Resultado líquido** |  |  |  |  |
+
+\* Grupo = soma simples ⚠️ {com|sem} eliminação intercompany.
+
+## 6. Confiabilidade do DRE
+| Empresa | % valor mapeado | Categorias sem mapeamento | Heurística | Status |
+|---|--:|--:|--:|---|
+| Colacor |  |  |  |  |
+| Oben |  |  |  |  |
+| Colacor SC |  |  |  |  |
+
+Categorias a classificar em /financeiro/mapping: {lista de 05, por valor}.
+
+## 7. Carga tributária observada ⚠️ (não é apuração)
+| Empresa | Regime | Receita bruta | Impostos | Alíq. efetiva | Faixa esperada | Bandeira |
+|---|---|--:|--:|--:|---|---|
+| Colacor | Presumido |  |  |  | ~11–16% |  |
+| Oben | Presumido |  |  |  | ~11–16% |  |
+| Colacor SC | Simples |  |  |  | faixa RBT12 |  |
+
+Colacor SC — RBT12: {valor} ({pct}% do teto de R$ 4,8 mi).
+> Itens não cobertos (ICMS/IPI/ST/monofásico/Fator R): só o contador fecha.
+
+## 8. Intercompany
+Divergências: {de 07a/07b}. Eliminações aplicadas no período: {07c}.
+
+## 9. Orçado vs realizado + status de fechamento
+Status formal do período (08a): {aberto / em_revisão / fechado / reaberto, por empresa — ou "nunca fechado"}.
+| Empresa | Linha DRE | Orçado | Realizado | Desvio | Desvio % |
+|---|---|--:|--:|--:|--:|
+| | | | | | |
+
+> Sem orçamento cadastrado em `fin_orcamento`? Registre "sem base orçamentária pra comparar"
+> e siga. Maiores desvios viram pergunta pro contador ou ajuste de premissa.
+
+## 10. Movimento desde o último fechamento
+{O que mudou vs o mês anterior — caixa melhorou/piorou, inadimplência subiu, etc. Use a
+tendência de 04c/06c. Pule na 1ª execução.}
+
+---
+
+## Perguntas pro contador
+{Cole aqui a saída de assets/templates/perguntas-contador.md preenchida.}

--- a/.claude/skills/cfo-colacor/assets/templates/perguntas-contador.md
+++ b/.claude/skills/cfo-colacor/assets/templates/perguntas-contador.md
@@ -1,0 +1,35 @@
+# Perguntas pro contador — {MÊS}/{ANO}
+
+> Lista objetiva pro dono levar à contabilidade. Cada item: a pergunta, por que importa, e o
+> dado que motivou. Ordene por impacto (R$ ou risco). NÃO traga conclusões fiscais — traga
+> perguntas. Gere só itens com lastro nos dados do fechamento; corte os que não se aplicam.
+
+## Como montar
+Para cada achado do diagnóstico que toca a fronteira contábil/fiscal, crie um item no
+formato abaixo. Fontes típicas de pergunta, por bloco:
+
+- **Categorias sem mapeamento (bloco 5)** → "A categoria Omie `{código} — {nome}` (R$ {valor}
+  no mês) entra como CMV, despesa operacional ou outra linha do DRE?"
+- **Carga tributária (bloco 7)** → quando a alíquota efetiva observada destoa muito da faixa
+  esperada do regime: "A alíquota efetiva da {empresa} foi {x}% — está coerente com {Presumido/Simples}?
+  Tem ICMS-ST / IPI / monofásico afetando isso?"
+- **Simples / Colacor SC** → "Com RBT12 em R$ {valor} ({pct}% do teto), e Fator R em {…}, o
+  enquadramento de anexo segue o melhor pra nós? Há risco de desenquadramento no horizonte?"
+- **Intercompany (bloco 8)** → "A operação {origem}→{destino} de R$ {valor} está lançada nas
+  duas pontas pelo mesmo valor? A divergência de R$ {diff} é diferença de data ou erro?"
+- **DRE caixa vs competência** → "O resultado por competência diverge {x}% do caixa. A
+  diferença é timing de recebimento/pagamento ou tem lançamento faltando?"
+- **CP sem categoria / conciliação baixa** → "Há R$ {valor} em contas a pagar sem categoria e
+  {pct}% de movimentações não conciliadas — como classificar?"
+
+## Modelo de item
+```
+### {nº}. {pergunta curta}
+- **Por quê**: {impacto gerencial — R$, risco, decisão que depende disso}
+- **Dado**: {empresa, valor, período, de onde saiu}
+- **Categoria**: [classificação DRE | tributário | intercompany | conciliação | regime]
+- **Urgência**: [alta | média | baixa]
+```
+
+## Lista
+{Preencher com os itens reais do fechamento. Se um bloco não gerou pergunta, não invente.}

--- a/.claude/skills/cfo-colacor/evals/trigger-eval.json
+++ b/.claude/skills/cfo-colacor/evals/trigger-eval.json
@@ -1,0 +1,22 @@
+[
+  { "query": "roda o fechamento financeiro de abril das tres empresas", "should_trigger": true },
+  { "query": "como ta o caixa da Colacor pros proximos meses? consigo pagar a folha sem aperto?", "should_trigger": true },
+  { "query": "me mostra a inadimplencia, quem ta me devendo e ha quanto tempo, ordenado por valor", "should_trigger": true },
+  { "query": "preciso da projecao de caixa de 13 semanas antes da reuniao com o gerente do banco amanha de manha", "should_trigger": true },
+  { "query": "quanto a Oben ta pagando de imposto proporcionalmente? isso ta normal pra lucro presumido de distribuidora?", "should_trigger": true },
+  { "query": "qual capital de giro eu to precisando? sinto que a NCG ta comendo meu caixa", "should_trigger": true },
+  { "query": "monta a lista de perguntas pro contador desse mes com base no que ta estranho no DRE", "should_trigger": true },
+  { "query": "o DRE da Colacor SC ta confiavel? tem muita categoria caindo em despesa operacional sem eu saber o que e", "should_trigger": true },
+  { "query": "faz um diagnostico financeiro geral do grupo, tipo um controller olhando recebiveis, pagaveis e resultado", "should_trigger": true },
+  { "query": "a Colacor SC cresceu bastante esse ano, sera que to perto de estourar o teto do Simples Nacional?", "should_trigger": true },
+  { "query": "adiciona uma coluna de margem de lucro nesse xlsx que minha contadora mandou, revenue na C e custo na D", "should_trigger": false },
+  { "query": "o FinanceiroDashboard.tsx ta com 1242 linhas, quebra ele em subcomponentes menores", "should_trigger": false },
+  { "query": "cria uma migration pra adicionar a coluna deleted_at na tabela sales_orders pra soft delete", "should_trigger": false },
+  { "query": "por que o sync do Omie de contas a receber ta falhando com erro 500 desde ontem?", "should_trigger": false },
+  { "query": "escreve um cold email pros leads de marcenaria que pediram orcamento e nao responderam", "should_trigger": false },
+  { "query": "qual a comissao que o vendedor externo ganha nesse pedido de R$ 12 mil da Oben?", "should_trigger": false },
+  { "query": "faz um grafico de barras das vendas por mes de 2026 pra eu colar na apresentacao do conselho", "should_trigger": false },
+  { "query": "preciso revisar o contrato de fornecimento da Oben com aquele distribuidor antes de assinar", "should_trigger": false },
+  { "query": "configura o cron fin-cashflow-snapshot-diario no SQL Editor do Lovable pra rodar todo dia", "should_trigger": false },
+  { "query": "quanto gastei de Google Ads esse mes e qual foi o ROAS das campanhas de abrasivo?", "should_trigger": false }
+]

--- a/.claude/skills/cfo-colacor/references/regimes-tributarios.md
+++ b/.claude/skills/cfo-colacor/references/regimes-tributarios.md
@@ -1,0 +1,72 @@
+# Regimes tributários — o que a skill pode e o que vai pro contador
+
+⚠️ **Releia o guardrail 1 do SKILL.md.** Esta skill **não apura imposto**. Tudo aqui serve
+pra (a) ler a *carga tributária observada* do DRE, (b) comparar com a faixa *esperada* do
+regime e sinalizar quando algo destoa, e (c) rodar *simulações conservadoras* claramente
+rotuladas. Número de imposto a pagar = contador.
+
+## O que está no banco vs no front
+- **Não há tabela de regime por empresa.** O regime vive em `COMPANIES[co].regime`
+  (`src/contexts/CompanyContext.tsx`): `colacor` e `oben` = `presumido`, `colacor_sc` = `simples`.
+- `useFinanceiroRegime.ts` / `RegimeToggle.tsx` **não têm a ver com tributos** — alternam só o
+  regime *contábil do DRE* (`'caixa'|'competencia'`). Não confunda.
+- `FinanceiroTributario.tsx` calcula tudo **no front, hardcoded** (faixas SN, alíquotas LP).
+  `fin_kpi_tributario` provavelmente está vazia. Logo: a fonte confiável de carga é o DRE
+  (`fin_dre_snapshots.impostos` / `receita_bruta`), não a tabela tributária.
+
+## Carga tributária observada (o que a skill calcula)
+```
+alíquota efetiva observada = impostos do DRE ÷ receita_bruta do DRE   (por empresa, por período)
+```
+Isso é um **termômetro gerencial**, não apuração. Use pra responder "a mordida do imposto
+está dentro do esperado pro meu regime?". Divergência grande entre o observado e a faixa
+esperada (abaixo) = **pergunta pro contador**, nunca uma conclusão de que "está errado".
+
+## Lucro Presumido — Colacor (indústria) e Oben (distribuidora)
+Parâmetros de referência (LP, regra geral — **confirme com o contador**, há exceções por
+produto, ST, monofásico, benefícios estaduais):
+- **Presunção de base** (sobre receita): comércio/indústria ~**8%** pra IRPJ e ~**12%** pra CSLL;
+  serviços ~**32%**. Como Colacor é indústria e Oben é distribuidora, a presunção típica é a de
+  comércio/indústria — mas produtos/serviços mistos mudam isso.
+- **IRPJ** 15% sobre a base presumida + adicional 10% sobre o que exceder R$ 20.000/mês de base.
+- **CSLL** 9% sobre a base presumida.
+- **PIS** 0,65% e **COFINS** 3,0% sobre o faturamento (regime cumulativo do LP).
+- **ICMS** (estadual) e eventuais **IPI** (indústria): variam muito por NCM, ST, origem/destino.
+  A skill **não** estima ICMS/IPI item a item — isso é do contador/fiscal.
+- Carga efetiva total típica de LP costuma cair numa faixa ampla (≈ 11% a 16%+ da receita,
+  muito dependente de ICMS). Use como ordem de grandeza, não como meta.
+
+> Para Colacor (indústria) atenção ao **IPI** e ao **ICMS-ST**; para Oben (distribuidora)
+> atenção a **ST** e **monofásico** (PIS/COFINS podem estar zerados em revenda de certos itens).
+> Ambos são motivo de pergunta pro contador, não de cálculo automático.
+
+## Simples Nacional — Colacor SC (serviços)
+- Tributação por **faixa do RBT12** (receita bruta dos últimos 12 meses) e por **Anexo**.
+  Serviços podem cair no Anexo III ou V dependendo do **Fator R** (folha ÷ receita 12m ≥ 28%
+  → Anexo III, mais barato). **Enquadramento de anexo e Fator R: sempre confirmar com contador.**
+- A skill calcula o **RBT12** (Σ `receita_bruta` dos últimos 12 meses no DRE) pra situar a
+  faixa, e sinaliza **proximidade do teto de R$ 4,8 milhões/ano** (desenquadramento).
+- **Não** declare a alíquota nominal da faixa como "o imposto" — a alíquota *efetiva* do SN
+  desconta a parcela a deduzir da tabela. Use a efetiva observada do DRE e deixe a apuração
+  (DAS) pro contador.
+
+## Simulações conservadoras — o que é permitido
+Permitido (sempre rotular **"simulação conservadora — confirmar com contador"**):
+- "Se o faturamento da Colacor SC crescer X%, ela se aproxima do teto do Simples / muda de faixa?"
+- "Mantida a alíquota efetiva observada, quanto de imposto sai sobre a receita projetada?"
+- "Sensibilidade: +10% de receita ⇒ +R$ Y de carga, mantida a proporção atual."
+
+**Proibido** (guardrail 3 — não faça, redirecione pra pergunta ao contador):
+- Recomendar troca de regime pra pagar menos.
+- Sugerir abrir/fechar CNPJ, segregar atividades, ou distribuir receita entre as empresas pra
+  reduzir tributo.
+- Otimização de Fator R "forçando" folha, ou qualquer estrutura cujo único objetivo é fiscal.
+- Tratamento de ST/monofásico/benefício fiscal sem confirmação contábil.
+
+## Como sinalizar no relatório
+Para cada empresa, no bloco tributário:
+1. Alíquota efetiva observada (DRE) — com a ressalva de que é observada, não apurada.
+2. Faixa esperada do regime (acima) — ordem de grandeza.
+3. Se observado ≪ ou ≫ esperado: **bandeira amarela + pergunta pro contador**.
+4. Colacor SC: faixa do RBT12 + distância do teto de R$ 4,8 mi.
+5. Lembrete de itens não cobertos (ICMS/IPI/ST/monofásico) que só o contador fecha.

--- a/.claude/skills/cfo-colacor/references/schema-financeiro.md
+++ b/.claude/skills/cfo-colacor/references/schema-financeiro.md
@@ -1,0 +1,202 @@
+# Schema financeiro — tabelas, colunas e armadilhas
+
+> 📌 **Fonte canônica do schema financeiro = `.claude/skills/bi-colacor/references/schema-conventions.md`
+> + `queries-financeiro.md`.** Este doc NÃO duplica — só registra o que é específico do ritual de
+> fechamento (NCG, DRE caixa vs competência, tributário por regime). As armadilhas de status/saldo
+> abaixo estão **alinhadas com a bi-colacor** (mesma verdade, validada no 1º fechamento real). Em
+> qualquer divergência, a bi-colacor vence — atualize este doc, não invente.
+
+Referência técnica pra adaptar os templates SQL. Identificadores **exatos** (não parafrasear).
+Tudo read-only. Fonte: migrations `supabase/migrations/2026032820*`, `2026051900*` +
+`src/integrations/supabase/types.ts` + hooks/edge functions financeiras + a `bi-colacor`.
+
+## Índice
+- [Convenção de empresa](#convenção-de-empresa)
+- [Armadilhas que quebram query](#armadilhas-que-quebram-query)
+- [Tabelas núcleo (Omie sincronizado)](#tabelas-núcleo-omie-sincronizado)
+- [DRE, confiabilidade e tributário](#dre-confiabilidade-e-tributário)
+- [Cashflow / NCG / eventos / alertas](#cashflow--ncg--eventos--alertas)
+- [Fechamento, orçamento, intercompany](#fechamento-orçamento-intercompany)
+- [RPCs e views úteis](#rpcs-e-views-úteis)
+
+## Convenção de empresa
+- Tabelas `fin_*`: coluna **`company text`**, valores `'colacor' | 'oben' | 'colacor_sc'`.
+  `CHECK (company IN ('oben','colacor','colacor_sc'))`. A tabela `fin_categoria_dre_mapping`
+  aceita também o valor especial `'_default'` (regra padrão de mapeamento).
+- ⚠️ Tabelas **Omie/vendas** usam outra convenção: `omie_clientes.empresa_omie`,
+  `sales_orders.account`. **Não dá pra juntar direto** com `fin_*` por empresa sem mapear.
+  Cada empresa é uma conta Omie separada (credenciais `OMIE_<OBEN|COLACOR|COLACOR_SC>_*`).
+- Regime tributário **não está no banco** — é `COMPANIES[co].regime` no front
+  (`colacor`/`oben` = `presumido`, `colacor_sc` = `simples`).
+
+## Armadilhas que quebram query
+> ⚠️ Itens 1-5 validados CONTRA PRODUÇÃO no 1º fechamento real (2026-06-16) — foram as
+> armadilhas que quebraram o fechamento. Leia antes de confiar em qualquer filtro.
+
+1. **🔴 `saldo` NÃO zera na baixa — filtre por `status_titulo`, NUNCA por `saldo > 0`.** Armadilha-mãe.
+   Quando o Omie baixa um título, o sync **não** zera `saldo` nem preenche `data_recebimento`/`valor_recebido`
+   — só muda o `status_titulo`. Logo títulos QUITADOS continuam com `saldo = valor_documento` e
+   `data_recebimento IS NULL`, e `saldo > 0 AND data_recebimento IS NULL` conta quitado como aberto
+   (ex.: CR aberto da Colacor apareceu como R$17,7M; o real era R$129k). O único marcador confiável é `status_titulo`.
+2. **Valores reais de `status_titulo`** (o sync grava COM espaço — a doc antiga dizia MAIÚSCULO, errado):
+   - **Receber**: aberto `IN ('A VENCER','ATRASADO','VENCE HOJE')` · quitado `'RECEBIDO'` · `'CANCELADO'`.
+   - **Pagar**: aberto `IN ('A VENCER','ATRASADO')` · quitado `'PAGO'` · `'CANCELADO'`.
+   - Vencido = `'ATRASADO'`. **NÃO existem** `'ABERTO'`/`'VENCIDO'`/`'PARCIAL'`/`'LIQUIDADO'`.
+   - **Rode `00-sanity-status.sql` primeiro** — é onde se vê se o sync mudou os rótulos.
+3. **Aging: conjunto por status, faixa por data.** Pegue os vencidos por `status_titulo IN ('ATRASADO','VENCE HOJE')`
+   e calcule os dias com `CURRENT_DATE − data_vencimento`. O status defasa 1-7 dias (um "VENCE HOJE" já venceu),
+   então a FAIXA vem da data; o CONJUNTO vem do status (nunca de `saldo`/`data_recebimento`, furados).
+4. **`nome_cliente`/`cnpj_cpf` VAZIOS** em `fin_contas_receber`/`_pagar`; `omie_clientes` **não tem coluna
+   de nome** (só `omie_codigo_cliente`, `empresa_omie`, `omie_codigo_vendedor`). Lista de cobrança sai por
+   `omie_codigo_cliente`; nome real só via tabela de pedidos (`nome_fantasia`) — enriquecimento pendente.
+   Nunca fabrique nome.
+5. **Cruze com o engine como âncora.** Os alertas do engine (`fin_alertas`: `ncg_deficit`, `caixa_negativo`,
+   `inadimplencia_alta`) usam a lógica certa (status). Se seu SQL diverge MUITO do engine, é contaminação
+   por `saldo` — o engine é a verdade, conserte o SQL.
+6. **DRE: sempre filtre `regime`.** `fin_dre_snapshots` tem UNIQUE `(company, ano, mes, regime)`.
+   Sem o filtro de `regime` você soma caixa + competência e dobra tudo.
+7. **Estoque = 0 e folha = 0 na prática.** `fin_estoque_valor` e `fin_eventos_recorrentes` (folha) estão
+   VAZIAS neste ambiente → NCG e projeção saem cegas pro maior ativo (estoque) e maior saída (folha).
+   Primeira ação de setup: valorar estoque + cadastrar folha. Sinalize sempre.
+8. **`fin_kpi_tributario` e `fin_confiabilidade` provavelmente VAZIAS.** O painel tributário calcula no
+   front; a confiabilidade nunca foi rodada. Pra carga use `fin_dre_snapshots.impostos / receita_bruta`;
+   pra escolher regime do DRE tenha plano B (ver SKILL bloco 4), pois `pct_valor_mapeado` pode não existir.
+
+## Tabelas núcleo (Omie sincronizado)
+Migration `20260328200000_financial_module.sql`. PK `id uuid`, todas com `company text`.
+
+### `fin_contas_receber`
+`omie_codigo_lancamento bigint`, `omie_codigo_cliente bigint`, `nome_cliente text`,
+`cnpj_cpf text`, `numero_documento text`, `numero_pedido text`,
+`data_emissao date`, `data_vencimento date`, `data_recebimento date`, `data_previsao date`,
+`valor_documento numeric(15,2)`, `valor_recebido numeric(15,2)`, `valor_desconto`,
+`valor_juros`, `valor_multa`, **`saldo numeric GENERATED (= valor_documento − valor_recebido)`** —
+⚠️ **NÃO confiável**: `valor_recebido` não é preenchido na baixa, então `saldo` não zera em título quitado
+(ver armadilha 1). Pra "aberto", filtre por `status_titulo`, não por `saldo`.
+`status_titulo text` (valores: `'A VENCER'`/`'ATRASADO'`/`'VENCE HOJE'`/`'RECEBIDO'`/`'CANCELADO'`),
+`categoria_codigo text`, `categoria_descricao text`, `departamento text`,
+`centro_custo text`, `vendedor_id bigint`, `omie_ncodcc bigint`.
+UNIQUE `(company, omie_codigo_lancamento)`.
+
+### `fin_contas_pagar`
+Espelha CR, com: `omie_codigo_cliente_fornecedor bigint`, `nome_fornecedor text`,
+`data_pagamento date`, `valor_pago numeric(15,2)`,
+**`saldo numeric GENERATED (= valor_documento − valor_pago)`**, `codigo_barras text`,
+`tipo_documento text`, `categoria_codigo text`.
+
+### `fin_contas_correntes`
+`omie_ncodcc bigint`, `descricao text`, `banco text`, `agencia text`, `numero_conta text`,
+`tipo text` (CC/PP/CI/CX), `saldo_data date`, **`saldo_atual numeric(15,2)`**, `ativo boolean`.
+UNIQUE `(company, omie_ncodcc)`. **Saldo inicial de caixa = Σ `saldo_atual` WHERE `ativo`.**
+
+### `fin_movimentacoes`
+`omie_ncodmov bigint`, `omie_ncodcc bigint`, `data_movimento date`, `tipo text` (`'E'`/`'S'`),
+`valor numeric`, `categoria_codigo text`, `conciliado boolean`, `omie_codigo_lancamento bigint`,
+`natureza text` (CP/CR/TRF/OUT).
+
+### `fin_categorias`
+Plano de contas Omie: `omie_codigo text`, `descricao text`, `tipo text` (`'R'`/`'D'`/`'T'`),
+`conta_pai text`, `nivel int`, `totalizadora boolean`, `ativo boolean`.
+UNIQUE `(company, omie_codigo)`.
+
+## DRE, confiabilidade e tributário
+
+### `fin_dre_snapshots`
+`ano int`, `mes int`, **`regime text NOT NULL ('caixa'|'competencia')`**, e as linhas
+(`numeric(15,2)`): `receita_bruta`, `deducoes`, `receita_liquida`, `cmv`, `lucro_bruto`,
+`despesas_operacionais`, `despesas_administrativas`, `despesas_comerciais`,
+`despesas_financeiras`, `receitas_financeiras`, `resultado_operacional`, `outras_receitas`,
+`outras_despesas`, `resultado_antes_impostos`, `impostos`, `resultado_liquido`.
+Mais: **`qtd_categorias_sem_mapeamento int`**, `detalhamento jsonb`
+(`{receitas, despesas, categorias_nao_mapeadas[]}`). UNIQUE `(company, ano, mes, regime)`.
+- **caixa**: agrupa por `data_vencimento` (proxy histórico), filtra recebido/pago, usa
+  `valor_recebido`/`valor_pago`.
+- **competencia**: agrupa por `data_emissao`, tudo exceto CANCELADO, usa `valor_documento`.
+  Default do front é `'competencia'`.
+
+### `fin_confiabilidade`
+Cobertura por `(company, ano, mes)`: `total_cr`, `total_cp`, `total_mov`, `cr_sem_categoria`,
+`cp_sem_categoria`, `pct_mov_conciliado`, `mov_sem_titulo`, `dre_categorias_mapeadas`,
+`dre_categorias_heuristica`, `dre_categorias_total`, **`pct_valor_mapeado numeric(5,2)`**,
+`fechamento_status text`, `ultimo_sync timestamptz`. Populada pela RPC
+`fin_calcular_confiabilidade(p_company, p_ano, p_mes)`.
+- **Regra de regime**: `pct_valor_mapeado` alto + `dre_categorias_heuristica`/`qtd_categorias_sem_mapeamento`
+  baixos ⇒ competência confiável. Senão, usar caixa com ressalva.
+
+### `fin_categoria_dre_mapping`
+`company text` (aceita `'_default'`), `omie_codigo text`, `dre_linha text` (CHECK em 11
+valores: `receita_bruta, deducoes, cmv, despesas_operacionais, despesas_administrativas,
+despesas_comerciais, despesas_financeiras, receitas_financeiras, outras_receitas,
+outras_despesas, impostos`). UNIQUE `(company, omie_codigo)`. Empresa-específico **sobrepõe**
+`_default`.
+
+### `fin_kpi_tributario` (provavelmente vazia — não confie)
+`ano`, `mes`, `regime`, `receita_bruta_acumulada` (RBT12 p/ Simples), `aliquota_efetiva`,
+`carga_tributaria_total`, `faixa_sn text`, `fator_r`, `base_presuncao_*`, `irpj`, `csll`,
+`pis`, `cofins`, `iss`, `icms`, `detalhamento jsonb`. Existe no schema mas sem código que a
+popule — calcule carga via DRE.
+
+## Cashflow / NCG / eventos / alertas
+Migrations `20260519000*`. Fonte canônica de cálculo = edge function `fin-cashflow-engine`
+(runtime, não persiste; por empresa única, não consolida).
+
+### `fin_config_cashflow` (PK = `company`, 1 linha por empresa)
+`overrides_cenario jsonb`, **`thresholds jsonb`** com chaves: `caixa_negativo_semanas`,
+`ncg_deficit_alerta`, `dias_cobertura_min`, `inadimplencia_max_pct`,
+`concentracao_top1_max_pct`, `pmr_crescimento_max_pct_90d`. `adiantamento_categorias_codigos text[]`.
+
+### `fin_eventos_recorrentes`
+`descricao`, `valor numeric(15,2)`, `tipo text ('entrada'|'saida')`, `categoria_dre text`,
+**`is_folha boolean`**, `dia_do_mes int`, `inicio date`, `fim date`, `ativo boolean`.
+Folha 30d (pro PCO) = Σ `valor` WHERE `is_folha AND tipo='saida' AND ativo`.
+
+### `fin_eventos_eventuais`
+`descricao`, `valor`, `tipo`, `categoria_dre`, `data_prevista date`, `data_realizada date`,
+`status text ('previsto'|'confirmado'|'cancelado'|'realizado')`. Projeção usa `previsto`+`confirmado`.
+
+### `fin_alertas`
+`tipo text`, `severidade text ('info'|'aviso'|'critico')`, `mensagem text`, `valor numeric`,
+`threshold numeric`, `contexto jsonb`, `dismissed_at`, `dismissed_by`, `dismissed_until`.
+Alertas ativos = `dismissed_at IS NULL AND (dismissed_until IS NULL OR dismissed_until < now())`.
+
+### `fin_projecao_snapshots`
+`snapshot_at`, `cenario text ('realista'|'otimista'|'pessimista')`, `horizon_weeks int`,
+`dados jsonb`, `ncg numeric`, `capital_giro_proprio numeric`, `saldo_tesouraria numeric`,
+`dias_cobertura numeric`, `premissas jsonb`. Permite trend "a projeção piorou?".
+
+### `fin_estoque_valor`
+`data_ref date`, `valor numeric`, `fonte text`, `cobertura_pct`, `observacao`. Fonte do
+estoque no ACO/NCG (mas o engine não lê — usa 0). Pega o `valor` mais recente por empresa.
+
+## Fechamento, orçamento, intercompany
+- `fin_fechamentos` — `ano`, `mes`, `status ('aberto'|'em_revisao'|'fechado'|'reaberto')`,
+  `versao int`, `snapshot_dre_caixa_id`, `snapshot_dre_competencia_id`, `fechado_por/em`,
+  `aprovado_por/em`. UNIQUE `(company, ano, mes, versao)`.
+- `fin_orcamento` — `ano`, `mes`, `dre_linha text`, `valor_orcado numeric`. UNIQUE
+  `(company, ano, mes, dre_linha)`. (Budget vs actual = juntar com `fin_dre_snapshots`.)
+- `fin_forecast` — `tipo ('caixa'|'dre')`, `ano`, `mes`, `dre_linha`, `valor_forecast`,
+  `metodo`, `confianca`.
+- `fin_ic_matches` — matching intercompany CR↔CP: `empresa_origem`, `empresa_destino`,
+  `cr_id`, `cp_id`, `diff_valor numeric GENERATED`, `status text` (inclui `divergencia_valor`,
+  `sem_contrapartida`).
+- `fin_eliminacoes_intercompany` (regras) + `fin_eliminacoes_log` (`ano`, `mes`, `valor_eliminado`).
+- `fin_conciliacao` — `mov_id`, `tipo_titulo ('CR'|'CP')`, `titulo_id`, `status`,
+  `diferenca numeric GENERATED`.
+
+## RPCs e views úteis
+- **`fin_categorias_sem_mapping(p_company text, p_start date, p_end date)`** → `(omie_codigo,
+  categoria_nome, valor_periodo)` de categorias com valor sem linha em `fin_categoria_dre_mapping`.
+  Filtra por `data_emissao`. **Use isto pro bloco 5.**
+- `fin_calcular_confiabilidade(p_company, p_ano, p_mes)` — popula `fin_confiabilidade` (write —
+  **não chamar**; só ler a tabela).
+- `fin_projecao_13_semanas(p_company, p_saldo_inicial)` — projeção SQL simples (sem
+  inadimplência nem eventos). Menos sofisticada que o engine; serve de cross-check rápido.
+- Views agregadas (por `company`): `fin_aging_receber`, `fin_aging_pagar` (buckets
+  `a_vencer`/`vencido_1_30`/`31_60`/`61_90`/`90_plus`, sufixos `_qtd`/`_valor`),
+  `fin_fluxo_caixa_diario`, `fin_dre_competencia_base`.
+
+## RLS
+Todas as `fin_*` têm RLS. As policies têm duas gerações (`admin/manager` legado vs
+`employee/master` nas tabelas A1) e podem não casar com os roles reais do app. **Irrelevante
+pro SQL do dono no Lovable** (roda como `postgres`/service, bypassa RLS). Só relevante se a
+skill orientar acesso autenticado pela app — o que ela não faz.

--- a/docs/agent/skills.md
+++ b/docs/agent/skills.md
@@ -16,7 +16,8 @@
 | Brainstorm | `brainstorming` (superpowers) | |
 | Task Supabase (DB/Auth/Edge/RLS) | `supabase` (oficial) — SQL/RLS idiomático | |
 | Mudança de banco sob Lovable | **`lovable-db-operator`** — migration + bloco SQL Editor + validação + audit | design com `supabase`, entrega com este |
-| BI executivo / número de negócio via Lovable (brief da semana, vendas/estoque/inadimplência/margem) | **`bi-colacor`** (proprietária) — SQL read-only versionado p/ colar no Lovable→SQL Editor → interpreta → decisão; conhece as 4 grafias de empresa + confiabilidade do dado | leitura (≠ `lovable-db-operator`, que escreve); não `data:*`/`finance:*` (text-to-SQL sem nosso schema) |
+| BI executivo / número de negócio via Lovable (brief da semana, vendas/estoque/inadimplência/margem) | **`bi-colacor`** (proprietária) — SQL read-only versionado p/ colar no Lovable→SQL Editor → interpreta → decisão; conhece as 4 grafias de empresa + confiabilidade do dado | leitura (≠ `lovable-db-operator`, que escreve); não `data:*`/`finance:*` (text-to-SQL sem nosso schema). Fechamento profundo (NCG/DRE-regime/tributário/contador) → `cfo-colacor` |
+| Ritual de fechamento financeiro mensal / controladoria (NCG, DRE caixa-vs-competência, carga tributária por regime, projeção 13 semanas, perguntas pro contador) | **`cfo-colacor`** (proprietária) — SQL read-only p/ Lovable, ritual de 9 levas + relatório mensal + perguntas pro contador; **NÃO** apura imposto nem substitui contador | sobrepõe `bi-colacor` em inadimplência/caixa: número rápido/brief semanal → `bi-colacor`; fechamento profundo → esta. **Schema financeiro canônico mora na `bi-colacor`** (esta referencia, não duplica) |
 | Otimizar query/schema PG | `supabase-postgres-best-practices` | |
 | Provar SQL money-path | **`prove-sql-money-path`** (PG17 falsificável) | |
 | Diagnosticar sync/cron | **`diagnose-supabase-sync`** (8 passos + queries `psql-ro`) | |


### PR DESCRIPTION
## O que é

Skill proprietária project-scoped (**`.claude/skills/cfo-colacor/`**) de **controladoria** — roda o ritual de fechamento financeiro mensal + pulso semanal do Grupo Colacor (Colacor/Oben presumido, Colacor SC simples), lendo as `fin_*` via **SQL read-only** colado no SQL Editor do Lovable e interpretando o resultado.

## Capacidades (9 levas)
Caixa 13 semanas (triangulado: projeção CR + saldo por conta + fluxo real via `fin_movimentacoes`) · NCG/capital de giro · inadimplência por aging · DRE caixa vs competência · carga tributária por regime · categorias sem mapeamento · intercompany · orçado vs realizado + status de fechamento · **perguntas pro contador**.

## Validada contra produção
Nasceu de um **1º fechamento real (abril/2026)** que virou o melhor eval possível. Achados que entraram na skill:
- 🔴 **`saldo` não zera na baixa** → todo filtro de "aberto" é por `status_titulo`, nunca por `saldo > 0` (o erro inflava o CR da Colacor de R$129k → R$17,7M). Mesma verdade que a `bi-colacor` já documentava — validação independente.
- Status reais **com espaço** (`A VENCER`/`ATRASADO`/`VENCE HOJE`/`RECEBIDO`/`PAGO`/`CANCELADO`).
- Caixa **triangulado** (projeção só-CR é cega a quem fatura à vista).

## Guardrails
100% **read-only** (só `SELECT`/`WITH`). **NÃO** apura imposto, **NÃO** substitui contador, **NÃO** faz planejamento fiscal agressivo. Tudo via Lovable.

## Fronteira com a `bi-colacor` (decidida com o founder)
- `bi-colacor` = BI amplo / brief semanal (número rápido de inadimplência/caixa/margem).
- `cfo-colacor` = fechamento profundo mensal (NCG/DRE-regime/tributário/contador).
- **Schema financeiro canônico mora na `bi-colacor`** — esta referencia, não duplica. Registrado em `docs/agent/skills.md` (roteamento nos dois sentidos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)