### PR TITLE
docs(cfo): fechamento gerencial abril/2026 (skill cfo-colacor — 1ª execução)

### DIFF
--- a/docs/cfo/2026-04-fechamento.md
+++ b/docs/cfo/2026-04-fechamento.md
@@ -1,0 +1,180 @@
+# Fechamento gerencial — Grupo Colacor — Abril/2026
+
+> Diagnóstico gerencial, READ-ONLY, gerado pela skill `cfo-colacor` (1ª execução real).
+> **Não é apuração contábil/fiscal.** Números marcados com ⚠️ dependem de configuração
+> (mapeamento de categorias, estoque valorado) ou são estimativa observada — confirmar com
+> contador onde indicado. Dados extraídos do Supabase via SQL no Lovable em **2026-06-16**.
+> Último sync Omie: ~2026-06-15 (título mais recente da Colacor).
+
+## 0. Como ler este fechamento
+
+A 1ª rodada revelou que **a camada gerencial do financeiro está parcialmente configurada**:
+o caixa, a inadimplência e o capital de giro têm dado utilizável; o **resultado (DRE) e o
+tributário NÃO são confiáveis** porque as categorias de imposto e várias despesas estão sem
+mapeamento. A **ação nº1** que destrava o mês é mapear os impostos `2.06.*` em
+`/financeiro/mapping` e recalcular o DRE. Tudo aqui é leitura — o mapeamento é ação do dono.
+
+## 1. Resumo executivo
+
+- **Caixa**: grupo sustentado pela **Oben** (gera ~**+R$ 104 mil/mês**); **Colacor** (~−R$ 65 mil/mês)
+  e **Colacor SC** (~−R$ 32 mil/mês) queimam caixa e operam com o **Itaú estourado** (provável
+  cheque especial). Risco de liquidez concentrado nas duas que queimam.
+- **Resultado**: ⚠️ **não confiável neste fechamento** — DRE incompleto (impostos não mapeados =
+  R$ 0 no relatório; receita da Colacor ≈ metade do caixa). Não reportar resultado do mês até
+  remapear.
+- **Atenção nº1**: **mapeamento de categorias** — ~R$ 69 mil (Oben) e ~R$ 27 mil (Colacor) de
+  impostos pagos em abril estão **invisíveis no DRE**. Isso trava resultado e carga tributária.
+
+## 2. Caixa
+
+| Empresa | Saldo hoje (Itaú) | Tendência | Ponto baixo projetado | Bandeira |
+|---|--:|--:|--:|:--:|
+| Colacor | −R$ 395.718,97 | ~−R$ 65 mil/mês | ~−R$ 370 mil (alerta crítico) | 🔴 |
+| Oben | +R$ 123.015,20 | ~+R$ 104 mil/mês | folga | 🟢 |
+| Colacor SC | −R$ 152.377,35 | ~−R$ 32 mil/mês | aprofundando | 🔴 |
+
+**Movimentação líquida 90 dias** (cross-check via `fin_movimentacoes`): Colacor −R$ 195.200,47 ·
+Colacor SC −R$ 95.184,87 · Oben +R$ 311.873,09 — confirma a direção acima.
+
+**Alertas ativos do engine** (Colacor): `caixa_negativo` **crítico** (~−370k) · inadimplência
+**29,6%** · cobertura **0 dias** · concentração de recebíveis **1649%** (índice do engine).
+
+> ⚠️ O cross-check SQL não desconta inadimplência nem inclui folha/eventos. O Itaú profundamente
+> negativo das duas empresas sugere **uso de cheque especial / conta garantida** — os **juros**
+> dessa linha precisam aparecer no DRE (hoje não aparecem). Confronte com `/financeiro/capital-giro`.
+
+## 3. NCG / capital de giro
+
+| Empresa | NCG | Leitura |
+|---|--:|---|
+| Colacor | ~−R$ 627 mil | NCG **negativa** — fornecedor financia o ciclo (validado vs alerta do engine −618k) |
+| Oben | negativa ⚠️ | mesma leitura; valor isolado não recalculado nesta rodada |
+| Colacor SC | negativa ⚠️ | idem |
+
+- CR em aberto real da Colacor ≈ **R$ 129 mil** (status `A VENCER`/`ATRASADO`/`VENCE HOJE`).
+- ⚠️ **Estoque = R$ 0** em `fin_estoque_valor` (não valorado) → ACO subestimado → NCG **menos
+  negativa** do que parece. Valorar estoque é pré-requisito pra NCG fiel.
+
+> ⚠️ **Armadilha-mãe confirmada em produção**: a coluna `saldo` **não zera na baixa** — usá-la
+> inflava o CR aberto pra R$ 17,7 mi (real ≈ R$ 129 mil). O fechamento usa **`status_titulo`**,
+> nunca `saldo`/`data_recebimento`.
+
+## 4. Inadimplência (aging de recebíveis)
+
+| Empresa | Total vencido | D+90+ (fóssil) | % vencido | Perfil |
+|---|--:|--:|--:|---|
+| Colacor | R$ 83.902 | **R$ 78.486 (94%)** | 29,6% | quase tudo **fóssil** (até ~12 anos, máx. 4.548 dias) |
+| Oben | R$ 95.987 | ⚠️ a detalhar | — | perfil **mais novo** (recuperável) |
+| Colacor SC | ⚠️ n/d | — | — | não destacado nesta rodada |
+
+**Política de cobrança (definida pelo dono):**
+- **D+1**: WhatsApp/e-mail automático (manter inadimplência o mais baixa possível desde o 1º dia).
+- **D+7**: ligação.
+- **Fósseis (Colacor, R$ 78 mil em D+90 antigo)**: **provisionar/avaliar baixa**, não gastar
+  esforço de cobrança — são de até 12 anos atrás.
+
+> ⚠️ `nome_cliente` vem vazio nos títulos — a lista de cobrança agrupa por `omie_codigo_cliente`;
+> cruzar com o cadastro pra nome real antes de acionar.
+
+## 5. DRE gerencial — ⚠️ NÃO CONFIÁVEL nesta rodada
+
+| Linha | Colacor (competência) | Oben (caixa) | Colacor SC |
+|---|--:|--:|--:|
+| Receita bruta | R$ 68.194 ⚠️ | R$ 293.149 ⚠️ | n/d |
+| Impostos | **R$ 0** ⚠️ (não mapeado) | **R$ 0** ⚠️ | **R$ 0** ⚠️ |
+| Resultado líquido | −R$ 69.033 ⚠️ | n/d | n/d |
+
+**Por que não confiar:**
+1. **Impostos = R$ 0** porque as categorias de imposto não têm linha no DRE (ver bloco 6) — mas
+   os impostos **foram pagos** (estão em contas a pagar).
+2. Receita da Colacor no DRE (R$ 68 mil) ≈ **metade** do caixa do mês (~R$ 145 mil) → receita
+   provavelmente **subestimada** (vendas à vista podem não estar entrando como receita).
+3. Regimes diferentes por empresa (Colacor competência, Oben caixa) → **não somar "Grupo"**.
+
+> **Grupo = não consolidável nesta rodada** (regimes mistos + DRE incompleto + sem eliminação
+> intercompany).
+
+## 6. Confiabilidade do DRE
+
+| Empresa | Categorias sem mapeamento | Status |
+|---|--:|---|
+| Colacor | 22 | 🔴 baixa |
+| Oben | 23 | 🔴 baixa |
+| Colacor SC | ⚠️ a medir | 🔴 baixa |
+
+> `fin_confiabilidade` está **vazia** (`fin_calcular_confiabilidade` nunca rodou) — a contagem
+> acima vem da query direta de categorias sem mapeamento.
+
+**Categorias a classificar em `/financeiro/mapping` — priorizadas (abril/2026):**
+
+| Natureza | Códigos | → linha DRE | Valor abril | Prioridade |
+|---|---|---|--:|:--:|
+| **Impostos** | `2.06.*` (ICMS/IRPJ/CSLL/COFINS/PIS/DIFAL/DAS/parcelamento) | impostos / deduções | **Oben ~69k · Colacor ~27k · SC ~1,6k** | 🥇 destrava tudo |
+| Folha/pessoal | `2.03.*` (salários/FGTS/INSS/benefícios) | desp. pessoal | SC salários R$ 23k | direto |
+| Desp. operacionais | aluguel, manutenção, combustível, energia, contabilidade… | desp. operacionais/admin | — | direto |
+| Devoluções | `2.09.01`, `2.01.98` | deduções de receita | Oben R$ 5,8k | direto |
+| **Empréstimos** | `2.05.03` | — / desp. financeiras | **Oben R$ 81,6k · SC 20k · Colacor 20k** | ⚠️ contador |
+| Compra material uso/consumo | `2.01.9x` | CMV ou despesa? | Colacor 3k · SC 7,7k · Oben 1,3k | ⚠️ contador |
+| Categoria vazia | (sem código) | ? | Colacor **R$ 27.937** (5 títulos) | investigar |
+
+**Decomposição dos impostos não mapeados (abril/2026):**
+
+| Empresa | Composição | Total | Sem parcelamento (corrente) |
+|---|---|--:|--:|
+| **Oben** | IRPJ 14.260,65 · CSLL 11.227,16 · ICMS 10.800,23 · COFINS 9.335,60 · DIFAL 6.949,69 · PIS 2.414,00 · parcelamento 14.301,53 | **~R$ 69.289** | ~R$ 54.988 |
+| **Colacor** | ICMS 12.925,26 · IRPJ 4.658,10 · CSLL 4.095,14 · COFINS 1.577,30 · PIS 1.206,71 · parcelamento 2.942,34 | **~R$ 27.405** | ~R$ 24.463 |
+| **Colacor SC** | Simples DAS 100,56 · taxas diversas 1.512,91 | ~R$ 1.613 | ~R$ 1.613 |
+
+## 7. Carga tributária observada ⚠️ (NÃO é apuração)
+
+| Empresa | Regime | Impostos pagos abril | Receita base | Alíq. observada | Faixa esperada |
+|---|---|--:|--:|--:|---|
+| Colacor | Presumido | ~R$ 27.405 | ⚠️ R$ 68k (DRE) a R$ 145k (caixa) | ~19–40% ⚠️ | ~11–16% |
+| Oben | Presumido | ~R$ 69.289 | R$ 293.149 (caixa) | ~23,6% ⚠️ | ~11–16% |
+| Colacor SC | Simples | ~R$ 1.613 | ⚠️ n/d | — | faixa RBT12 |
+
+> ⚠️ **Não tirar conclusão fiscal disto.** A alíquota observada está distorcida por: (a) receita
+> base incerta (Colacor), (b) **parcelamento de impostos antigos** embutido (Oben R$ 14k, Colacor
+> R$ 3k — é dívida passada, não imposto do mês), (c) ICMS-ST/DIFAL/monofásico que só o contador
+> fecha. **Confirmar com contador.** A carga real só aparece depois do mapeamento + recálculo.
+
+## 8. Intercompany
+
+**N/A — não rastreado pelo sistema.**
+- `fin_ic_matches` = 0 linhas (motor de matching nunca rodou).
+- Nenhuma transferência `natureza='TRF'` em abril/2026.
+- Se há mútuo entre as empresas, está **embutido em "Pagamento de Empréstimos"** (Oben R$ 81,6k)
+  e **não dá pra cravar a contraparte** em read-only (nomes vazios). → **pergunta pro contador**.
+
+## 9. Orçado vs realizado + status de fechamento
+
+**N/A — processo inexistente.**
+- `fin_fechamentos` = 0 → **abril (e todo mês) nunca foi fechado formalmente**.
+- `fin_orcamento` = 0 → **sem orçamento cadastrado** → orçado-vs-realizado impossível.
+- `fin_forecast` = 0 → sem projeção formal salva.
+
+> **Decisão de processo** (setup, fora do read-only): operacionalizar o fechamento formal mensal
+> e cadastrar o orçamento 2026 pra ter régua de comparação.
+
+## 10. Movimento desde o último fechamento
+
+1ª execução do ritual — sem base anterior. A partir de maio, comparar caixa/inadimplência/DRE.
+
+---
+
+## Ações priorizadas (saída do fechamento)
+
+1. 🥇 **Mapear impostos `2.06.*`** em `/financeiro/mapping` → **recalcular DRE de abril**
+   (destrava blocos 5 e 7). *Ação do dono no Lovable — é escrita.*
+2. Mapear as demais categorias (folha, opex, devoluções) — completar a confiabilidade.
+3. Investigar a categoria vazia da Colacor (R$ 27.937, 5 títulos).
+4. **Provisionar** os fósseis da Colacor (R$ 78 mil) e **acionar cobrança D+1** na Oben.
+5. **Valorar o estoque** (`fin_estoque_valor`) pra NCG fiel.
+6. Levar a lista de **perguntas pro contador** (arquivo ao lado).
+7. *(processo)* operacionalizar fechamento formal + orçamento 2026.
+
+---
+
+## Perguntas pro contador
+
+Ver [`perguntas-contador.md`](./perguntas-contador.md) nesta pasta.

--- a/docs/cfo/perguntas-contador.md
+++ b/docs/cfo/perguntas-contador.md
@@ -1,0 +1,84 @@
+# Perguntas pro contador — Abril/2026 — Grupo Colacor
+
+> Lista objetiva pra levar à contabilidade. Cada item: a pergunta, por que importa e o dado
+> que motivou. Ordenada por impacto. **São perguntas, não conclusões fiscais.** Gerada pela
+> skill `cfo-colacor` a partir do fechamento de abril/2026 (read-only).
+
+## Lista
+
+### 1. Como classificar os impostos no DRE?
+- **Por quê**: hoje o DRE mostra **impostos = R$ 0** porque essas categorias não têm linha de
+  DRE — distorce resultado e carga tributária do grupo inteiro. É a ação nº1 do mês.
+- **Dado**: códigos `2.06.*` (ICMS, IRPJ, CSLL, COFINS, PIS, ICMS DIFAL, Simples DAS,
+  parcelamento). Abril: **Oben ~R$ 69.289 · Colacor ~R$ 27.405 · Colacor SC ~R$ 1.613**.
+- **Categoria**: classificação DRE / tributário
+- **Urgência**: alta
+
+### 2. "Pagamento de Empréstimos" — principal, juros, externo ou intercompany?
+- **Por quê**: é o maior item de saída do mês. Se for amortização de principal, **não vai ao
+  DRE** (reduz passivo); se tiver juros, os **juros vão pra despesas financeiras**. E precisamos
+  saber se é banco externo ou mútuo entre as empresas do grupo.
+- **Dado**: código `2.05.03`. Abril: **Oben R$ 81.643 · Colacor R$ 19.965 · Colacor SC R$ 20.000**.
+- **Categoria**: classificação DRE / intercompany
+- **Urgência**: alta
+
+### 3. As contas Itaú negativas são cheque especial? Qual limite e taxa?
+- **Por quê**: define o **runway real** e quanto de **juros** está sangrando o caixa (juros que
+  hoje não aparecem no DRE).
+- **Dado**: saldo Itaú em 2026-06-16 — **Colacor −R$ 395.718,97 · Colacor SC −R$ 152.377,35**.
+- **Categoria**: classificação DRE / caixa
+- **Urgência**: alta
+
+### 4. Por que a receita do DRE é metade do caixa? Vendas à vista entram como receita?
+- **Por quê**: se a receita está subestimada, o resultado e a margem estão errados pra baixo.
+- **Dado**: Colacor — receita DRE (competência) **R$ 68.194** vs entrada de caixa do mês ~**R$ 145
+  mil**. Há categoria de receita (`1.03.01` na Oben) possivelmente não mapeada.
+- **Categoria**: classificação DRE
+- **Urgência**: alta
+
+### 5. O "Parcelamento de Impostos Federais" é dívida tributária antiga? Quanto falta?
+- **Por quê**: infla a carga tributária aparente do mês (é passado, não imposto corrente) e é um
+  passivo relevante a acompanhar.
+- **Dado**: abril — **Oben R$ 14.301,53 · Colacor R$ 2.942,34**.
+- **Categoria**: tributário
+- **Urgência**: média
+
+### 6. As devoluções entram como dedução da receita bruta?
+- **Por quê**: classificação correta da receita líquida.
+- **Dado**: Oben — "Devoluções de Vendas" R$ 5.010 + "Devolução de Clientes" R$ 750 (`2.09.01`,
+  `2.01.98`).
+- **Categoria**: classificação DRE
+- **Urgência**: média
+
+### 7. A alíquota observada da Oben (~23,6%) é coerente com Lucro Presumido?
+- **Por quê**: a faixa esperada do Presumido é ~11–16%; 23,6% destoa. Pode ser ICMS-ST / DIFAL
+  interestadual (típico de distribuidora) + parcelamento embutido — ou sinal de algo a revisar.
+- **Dado**: Oben — impostos ~R$ 69.289 sobre receita ~R$ 293.149 (abril). Inclui DIFAL R$ 6.949.
+- **Categoria**: tributário / regime
+- **Urgência**: média
+
+### 8. Os títulos fósseis da Colacor devem ser provisionados/baixados?
+- **Por quê**: R$ 78 mil de recebíveis com até ~12 anos de atraso inflam o ativo e a inadimplência
+  e não serão recuperados.
+- **Dado**: Colacor — R$ 78.486 em D+90 (máx. 4.548 dias), de R$ 83.902 vencidos.
+- **Categoria**: classificação DRE / conciliação
+- **Urgência**: média
+
+### 9. O que é a categoria vazia da Colacor (R$ 27.937, 5 títulos)?
+- **Por quê**: valor relevante sem classificação nenhuma — não dá pra fechar o DRE sem saber o que é.
+- **Dado**: Colacor — 5 títulos com `categoria_codigo` em branco, R$ 27.937,83 (abril).
+- **Categoria**: classificação DRE / conciliação
+- **Urgência**: média
+
+### 10. Título da Oben com emissão futura (25/07/2026) — erro ou faturamento programado?
+- **Por quê**: emissão à frente da data atual pode ser erro de lançamento que distorce competência.
+- **Dado**: Oben — título mais recente com `data_emissao = 2026-07-25` (hoje é 2026-06-16).
+- **Categoria**: conciliação
+- **Urgência**: baixa
+
+### 11. Vale operacionalizar fechamento formal mensal + orçamento 2026?
+- **Por quê**: hoje nenhum mês foi fechado formalmente e não há orçamento — sem isso não há régua
+  de orçado-vs-realizado nem trava de reabertura.
+- **Dado**: `fin_fechamentos`, `fin_orcamento`, `fin_forecast` todas com 0 linhas.
+- **Categoria**: processo
+- **Urgência**: média


### PR DESCRIPTION
## Fechamento gerencial — Grupo Colacor — Abril/2026

Primeira execução real da skill `cfo-colacor`. Diagnóstico **read-only** das 9 levas + perguntas pro contador, em `docs/cfo/`.

**⚠️ DRAFT de propósito** — contém números financeiros reais das 3 empresas. Promova pra `main` (tire do draft) só se quiser versionar isso no repo; senão fica no branch.

### Resumo
- ✅ **Caixa / inadimplência / NCG** — completos e acionáveis
- 🚧 **DRE / tributário** — travados por mapeamento (impostos `2.06.*` invisíveis: Oben ~R$69k, Colacor ~R$27k)
- ✅ **Intercompany / fechamento / orçamento** — N/A (motores `fin_*` nunca ligados: `fin_ic_matches`/`fin_fechamentos`/`fin_orcamento`/`fin_forecast` = 0)

### Arquivos
- `docs/cfo/2026-04-fechamento.md` — relatório das 9 levas + ações priorizadas
- `docs/cfo/perguntas-contador.md` — 11 perguntas objetivas, ordenadas por impacto

### Ação nº1
Mapear impostos `2.06.*` em `/financeiro/mapping` → recalcular DRE de abril (destrava levas 5 e 7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)