### PR TITLE
fix(skills/cfo-colacor): templates 05/08 quebravam ao EXECUTAR no SQL Editor (1º fechamento real)

### DIFF
--- a/.claude/skills/cfo-colacor/SKILL.md
+++ b/.claude/skills/cfo-colacor/SKILL.md
@@ -197,9 +197,11 @@ Pergunta: "o resultado gerencial do mês é confiável o suficiente pra eu usar?
 
 ### 5. Categorias sem mapeamento — `assets/sql/05-categorias-sem-mapeamento.sql`
 Pergunta: "o que está caindo no balde errado do DRE?".
-Use a RPC pronta `fin_categorias_sem_mapping(p_company, p_start, p_end)` — retorna código,
-nome e valor no período das categorias Omie sem linha explícita em `fin_categoria_dre_mapping`
-(que então caem em heurística por palavra-chave, sujeita a erro).
+A query (a) do template lê **direto** as categorias Omie com movimento no período sem linha
+explícita em `fin_categoria_dre_mapping` (que então caem em heurística por palavra-chave, sujeita
+a erro). ⚠️ **Não use a RPC `fin_categorias_sem_mapping`** no SQL Editor: ela tem gate "requer
+perfil financeiro" e devolve `42501: Acesso negado` na sessão do Lovable — a query direta é a
+mesma lógica (CR+CP por `data_emissao`, fallback `_default`), sem gate.
 - Toda categoria com valor relevante sem mapeamento vira: (a) uma recomendação de classificar
   em `/financeiro/mapping`, e (b) uma candidata a **pergunta pro contador** ("a categoria X é
   custo (CMV) ou despesa operacional?").

--- a/.claude/skills/cfo-colacor/assets/sql/05-categorias-sem-mapeamento.sql
+++ b/.claude/skills/cfo-colacor/assets/sql/05-categorias-sem-mapeamento.sql
@@ -7,16 +7,50 @@
 -- erro). Cada uma com valor relevante vira: (a) classificar em /financeiro/mapping,
 -- (b) candidata a pergunta pro contador ("X é CMV ou despesa operacional?").
 -- READ-ONLY.
+--
+-- ⚠️ NÃO use a RPC fin_categorias_sem_mapping(company,start,end) no SQL Editor:
+--    ela é SECURITY DEFINER com gate "requer perfil financeiro"
+--    (auth.role()='service_role' OR fin_user_can_access(company)) e dá
+--    `ERROR: 42501: Acesso negado: requer perfil financeiro` na sessão do SQL
+--    Editor (sem perfil). A query (a) abaixo é a MESMA lógica, direta nas
+--    tabelas — roda sem gate.
 -- ============================================================================
 
--- (a) RPC pronta — rode 1× POR EMPRESA (a função recebe company + período).
---     EDITE company e datas:
-SELECT * FROM fin_categorias_sem_mapping('colacor', DATE '2026-04-01', DATE '2026-04-30')
-ORDER BY valor_periodo DESC;
--- repita trocando 'colacor' por 'oben' e depois 'colacor_sc'.
+-- (a) Categorias com movimento no período SEM linha no DRE (nem na empresa nem
+--     no _default). Réplica direta da RPC fin_categorias_sem_mapping, nas 3
+--     empresas de uma vez. EDITE só o período:
+WITH p AS (SELECT DATE '2026-04-01' AS ini, DATE '2026-04-30' AS fim),   -- <<< EDITE
+titulos AS (
+  SELECT company, categoria_codigo, categoria_descricao, valor_documento
+  FROM fin_contas_receber, p
+  WHERE data_emissao BETWEEN p.ini AND p.fim AND categoria_codigo IS NOT NULL
+  UNION ALL
+  SELECT company, categoria_codigo, categoria_descricao, valor_documento
+  FROM fin_contas_pagar, p
+  WHERE data_emissao BETWEEN p.ini AND p.fim AND categoria_codigo IS NOT NULL
+),
+agg AS (
+  SELECT company, categoria_codigo, categoria_descricao,
+         round(sum(COALESCE(valor_documento,0))::numeric, 2) AS valor_periodo,
+         count(*) AS qtd_titulos
+  FROM titulos
+  GROUP BY company, categoria_codigo, categoria_descricao
+)
+SELECT a.company, a.categoria_codigo, a.categoria_descricao,
+       a.valor_periodo, a.qtd_titulos
+FROM agg a
+LEFT JOIN fin_categoria_dre_mapping m_co
+       ON m_co.company = a.company   AND m_co.omie_codigo = a.categoria_codigo
+LEFT JOIN fin_categoria_dre_mapping m_def
+       ON m_def.company = '_default' AND m_def.omie_codigo = a.categoria_codigo
+WHERE COALESCE(m_co.dre_linha, m_def.dre_linha) IS NULL   -- não mapeada (empresa sobrepõe _default)
+  AND a.valor_periodo > 0
+ORDER BY a.valor_periodo DESC;
+-- categoria_descricao pode vir VAZIA (dado do Omie); o nome do plano de contas
+-- está em fin_categorias (omie_codigo, descricao) se precisar enriquecer.
 
--- (b) FALLBACK (se a RPC fin_categorias_sem_mapping não existir no banco):
---     lê o que o cálculo do DRE registrou como não-mapeado no snapshot.
+-- (b) CROSS-CHECK: o que o cálculo do DRE registrou como não-mapeado no snapshot
+--     (qtd + lista). Diverge MUITO de (a)? Snapshot do DRE defasado — rode o (a).
 WITH p AS (SELECT 2026 AS ano, 4 AS mes)   -- <<< EDITE
 SELECT d.company, d.regime, d.qtd_categorias_sem_mapeamento,
        d.detalhamento -> 'categorias_nao_mapeadas' AS categorias_nao_mapeadas
@@ -24,7 +58,8 @@ FROM fin_dre_snapshots d, p
 WHERE d.ano = p.ano AND d.mes = p.mes
 ORDER BY d.company, d.regime;
 
--- (c) FALLBACK extra: títulos sem categoria_codigo no período (não classificáveis)
+-- (c) Títulos SEM categoria_codigo no período (não entram em (a) — são o balde
+--     "nem código têm", não classificáveis):
 WITH p AS (SELECT DATE '2026-04-01' AS ini, DATE '2026-04-30' AS fim)   -- <<< EDITE
 SELECT 'receber' AS tabela, company, count(*) AS titulos, round(sum(valor_documento)::numeric,2) AS valor
 FROM fin_contas_receber, p

--- a/.claude/skills/cfo-colacor/assets/sql/08-orcamento-fechamento.sql
+++ b/.claude/skills/cfo-colacor/assets/sql/08-orcamento-fechamento.sql
@@ -17,11 +17,15 @@ WHERE f.ano = p.ano AND f.mes = p.mes
 ORDER BY f.company, f.versao DESC;
 -- Sem linha = mês ainda 'aberto' (nunca fechado formalmente). Reporte isso.
 
--- (b) orçado vs realizado por linha do DRE (realizado = snapshot competência)
-WITH p AS (SELECT 2026 AS ano, 4 AS mes, 'competencia'::text AS regime_dre),  -- <<< EDITE
-real_lines AS (
+-- (b) orçado vs realizado por linha do DRE (realizado = snapshot competência).
+--     EDITE ano/mes nos DOIS pontos marcados <<< EDITE. Período inlinado de
+--     propósito: um CTE de período no cross-join (FROM o, p LEFT JOIN ...) faz o
+--     ON enxergar só p e real_lines, não o → ERROR 42P01 "invalid reference to
+--     FROM-clause entry for table o". Por isso o filtro de período fica DENTRO
+--     do CTE real_lines e no WHERE final, e o FROM final é o LEFT JOIN direto.
+WITH real_lines AS (
   SELECT d.company, v.dre_linha, v.valor_real
-  FROM fin_dre_snapshots d, p,
+  FROM fin_dre_snapshots d,
   LATERAL (VALUES
     ('receita_bruta',           d.receita_bruta),
     ('deducoes',                d.deducoes),
@@ -35,7 +39,7 @@ real_lines AS (
     ('outras_despesas',         d.outras_despesas),
     ('impostos',                d.impostos)
   ) AS v(dre_linha, valor_real)
-  WHERE d.ano = p.ano AND d.mes = p.mes AND d.regime = p.regime_dre
+  WHERE d.ano = 2026 AND d.mes = 4 AND d.regime = 'competencia'   -- <<< EDITE ano/mes
 )
 SELECT o.company, o.dre_linha,
        round(o.valor_orcado::numeric,2)              AS orcado,
@@ -44,7 +48,7 @@ SELECT o.company, o.dre_linha,
        CASE WHEN o.valor_orcado <> 0
             THEN round(100.0*(COALESCE(r.valor_real,0) - o.valor_orcado)/abs(o.valor_orcado),1)
        END                                           AS desvio_pct
-FROM fin_orcamento o, p
+FROM fin_orcamento o
 LEFT JOIN real_lines r ON r.company = o.company AND r.dre_linha = o.dre_linha
-WHERE o.ano = p.ano AND o.mes = p.mes
+WHERE o.ano = 2026 AND o.mes = 4   -- <<< EDITE ano/mes
 ORDER BY o.company, abs(COALESCE(r.valor_real,0) - o.valor_orcado) DESC;

--- a/.claude/skills/cfo-colacor/references/schema-financeiro.md
+++ b/.claude/skills/cfo-colacor/references/schema-financeiro.md
@@ -186,7 +186,11 @@ estoque no ACO/NCG (mas o engine não lê — usa 0). Pega o `valor` mais recent
 ## RPCs e views úteis
 - **`fin_categorias_sem_mapping(p_company text, p_start date, p_end date)`** → `(omie_codigo,
   categoria_nome, valor_periodo)` de categorias com valor sem linha em `fin_categoria_dre_mapping`.
-  Filtra por `data_emissao`. **Use isto pro bloco 5.**
+  Filtra por `data_emissao`. ⚠️ **NÃO usar no SQL Editor** — é SECURITY DEFINER com gate de perfil
+  (`auth.role()='service_role' OR fin_user_can_access(company)`; senão `RAISE 'Acesso negado: requer
+  perfil financeiro'`, SQLSTATE **42501**), e a sessão do SQL Editor do Lovable não tem perfil. O
+  **bloco 5 usa a query DIRETA equivalente** nas tabelas (CR+CP por `data_emissao` + categoria sem
+  `dre_linha` no mapping, com fallback `_default`), não a RPC.
 - `fin_calcular_confiabilidade(p_company, p_ano, p_mes)` — popula `fin_confiabilidade` (write —
   **não chamar**; só ler a tabela).
 - `fin_projecao_13_semanas(p_company, p_saldo_inicial)` — projeção SQL simples (sem


### PR DESCRIPTION
## Contexto
A skill `cfo-colacor` (#909) gera SQL read-only que o founder cola no **SQL Editor do Lovable**. A **1ª execução real do fechamento mensal** revelou 2 bugs nos templates que só aparecem ao **EXECUTAR** (não ao criar) — armadilha de gate SECURITY DEFINER + escopo de FROM-clause.

## BUG 1 — `05-categorias-sem-mapeamento.sql`: RPC com gate de perfil → 42501
A query (a) chamava `fin_categorias_sem_mapping(company,start,end)`, que é **SECURITY DEFINER com gate**:
```sql
IF NOT (auth.role()='service_role' OR fin_user_can_access(p_company)) THEN
  RAISE EXCEPTION 'Acesso negado: requer perfil financeiro' USING ERRCODE='42501';
```
A sessão do SQL Editor não tem perfil → `ERROR: 42501: Acesso negado: requer perfil financeiro`.

**Fix:** trocada pela **query DIRETA equivalente** (mesma lógica interna da RPC): soma CR+CP por `categoria_codigo` no período (`data_emissao`), `LEFT JOIN fin_categoria_dre_mapping` com fallback `_default`, retorna categorias com `dre_linha` NULL e `valor>0`, nas 3 empresas de uma vez. RPC documentada como "tem gate — não usar no SQL Editor" (SKILL.md §5 + `references/schema-financeiro.md`).

## BUG 2 — `08-orcamento-fechamento.sql` (query b): escopo de FROM-clause → 42P01
`FROM fin_orcamento o, p LEFT JOIN real_lines r ON r.company = o.company ...` dava `ERROR: 42P01: invalid reference to FROM-clause entry for table "o"` — a vírgula (cross-join) + `LEFT JOIN` faz o `ON` enxergar só `p`/`real_lines`, não `o`.

**Fix:** removido o CTE `p` do cross-join, período inlinado (placeholders `<<< EDITE` em 2 pontos), filtro de período movido pra dentro do CTE `real_lines`, e `FROM fin_orcamento o LEFT JOIN real_lines r ON ...` direto.

## Validação (psql-ro / `claude_ro`, contra prod)
- **05(a)** corrigida → 63 categorias sem mapeamento nas 3 empresas (abr/2026). ✓
- **08(b)** corrigida → parseia/roda (0 linhas = sem orçamento cadastrado, esperado/documentado). ✓
- **Falsificação:** a original do 08(b) reproduz o `42P01`; a RPC do 05 reproduz o `42501`. ✓
- Todos os blocos dos 2 arquivos rodam sem `ERROR:`. **Read-only preservado** (só `SELECT`). Não toca `supabase/migrations/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)