### PR TITLE
feat(regua-preco): toggles da régua (carrinho + 360) na tela de Configurações

### DIFF
--- a/src/pages/SettingsConfig.tsx
+++ b/src/pages/SettingsConfig.tsx
@@ -88,6 +88,8 @@ const SettingsConfig = () => {
   const [hasChanges, setHasChanges] = useState(false);
   const [newVisualEnabled, toggleNewVisual] = useFeatureFlag('newVisual', true);
   const [filaPanelEnabled, toggleFilaPanel] = useFeatureFlag('filaContextPanel', false);
+  const [reguaCarrinhoEnabled, toggleReguaCarrinho] = useFeatureFlag('regua_preco_carrinho', false);
+  const [regua360Enabled, toggleRegua360] = useFeatureFlag('regua_preco_360', false);
 
   const updateWeight = (key: string, value: number) => {
     setWeights(prev => prev.map(w => w.key === key ? { ...w, value } : w));
@@ -156,6 +158,54 @@ const SettingsConfig = () => {
               </div>
             </div>
             <Switch checked={filaPanelEnabled} onCheckedChange={toggleFilaPanel} />
+          </CardContent>
+        </Card>
+
+        {/* Régua de Preço no carrinho — flag REAL (localStorage); liga só neste navegador (sombra) */}
+        <Card>
+          <CardContent className="p-4 flex items-center justify-between gap-3">
+            <div className="flex items-start gap-3 min-w-0">
+              <div className={cn(
+                'p-2 rounded-md shrink-0',
+                reguaCarrinhoEnabled ? 'bg-foreground text-background' : 'bg-muted text-muted-foreground',
+              )}>
+                <Target className="w-4 h-4" />
+              </div>
+              <div className="min-w-0">
+                <p className="text-sm font-medium">
+                  Régua de Preço no carrinho
+                  <Badge variant="outline" className="ml-2 text-2xs">{reguaCarrinhoEnabled ? 'on' : 'off'}</Badge>
+                </p>
+                <p className="text-xs text-muted-foreground mt-0.5">
+                  No carrinho (Oben), mostra o piso de margem e o benchmark de preço da carteira como recibo — sem prometer aceitação. Liga só <span className="font-medium">neste navegador</span> (teste em sombra; nenhum outro vendedor vê). Rollout pra todos é no código.
+                </p>
+              </div>
+            </div>
+            <Switch checked={reguaCarrinhoEnabled} onCheckedChange={toggleReguaCarrinho} />
+          </CardContent>
+        </Card>
+
+        {/* Régua de Preço no Customer 360 — flag REAL (localStorage); liga só neste navegador (sombra) */}
+        <Card>
+          <CardContent className="p-4 flex items-center justify-between gap-3">
+            <div className="flex items-start gap-3 min-w-0">
+              <div className={cn(
+                'p-2 rounded-md shrink-0',
+                regua360Enabled ? 'bg-foreground text-background' : 'bg-muted text-muted-foreground',
+              )}>
+                <TrendingUp className="w-4 h-4" />
+              </div>
+              <div className="min-w-0">
+                <p className="text-sm font-medium">
+                  Régua de Preço no Customer 360
+                  <Badge variant="outline" className="ml-2 text-2xs">{regua360Enabled ? 'on' : 'off'}</Badge>
+                </p>
+                <p className="text-xs text-muted-foreground mt-0.5">
+                  Nos itens preferidos do cliente (Oben), sinaliza quem está abaixo do piso ou com folga vs carteira — insight pré-visita, só leitura. Liga só <span className="font-medium">neste navegador</span> (teste em sombra).
+                </p>
+              </div>
+            </div>
+            <Switch checked={regua360Enabled} onCheckedChange={toggleRegua360} />
           </CardContent>
         </Card>
 


### PR DESCRIPTION
Adiciona 2 interruptores em **Configurações** (`/settings`) pra ligar/desligar a Régua de Preço sem console — mesmo padrão dos toggles `newVisual`/`filaContextPanel` que já existem na tela.

- 🟢 **Régua de Preço no carrinho** (`regua_preco_carrinho`)
- 🟢 **Régua no Customer 360** (`regua_preco_360`)

A copy de cada card deixa claro que **liga só neste navegador** (teste em sombra — nenhum outro vendedor vê); rollout pra todos é no código. Flags seguem **off** por padrão.

Mudança de **UI pura** (2 cards `Card`+`Switch`, ícones `Target`/`TrendingUp` já importados). Validação completa pelo CI (typecheck/lint/build/test/mutcheck) — o auto-merge só mergeia no verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
