### PR TITLE
feat(sayersync): ativa auto-update do conector (wire + plumbing de release)

### DIFF
--- a/connector/README.md
+++ b/connector/README.md
@@ -99,21 +99,45 @@ go test ./... -v -count=1 -timeout 120s
 
 ---
 
-## Manifesto de auto-update
+## Auto-update — publicar uma nova versão
 
-Para publicar uma nova versão, faça upload do `.exe` para o bucket público do Supabase
-e atualize o arquivo `manifest.json`:
+O conector verifica o manifesto **uma vez por dia** e se atualiza sozinho
+(anti-downgrade: só aplica se `manifest.version > current`, semver estrito; sha256
+verificado antes de instalar; crash-loop guard restaura o `.prev` após 3 falhas em
+24h). A chamada vive **cedo** no `RunCycle` (`sync.go`), então o conector consegue
+se auto-curar mesmo quando o sync está quebrado (PG local fora / schema divergente)
+— justamente quando um fix precisa chegar.
 
-```json
-{
-  "version": "0.2.0",
-  "sha256": "<hex do sha256 do .exe>",
-  "url": "https://<project>.supabase.co/storage/v1/object/public/releases/sayersync/sayersync.exe"
-}
+### 1. Gerar os artefatos
+
+```bash
+cd connector/sayersync
+go test ./... -count=1        # nunca publique com teste vermelho
+./release.sh 0.2.0            # cross-compila, calcula sha256, gera dist/manifest.json
 ```
 
-O conector verifica o manifesto uma vez por dia e aplica a atualização automaticamente
-(anti-downgrade: só atualiza se `manifest.version > current`).
+Saída em `dist/`: `sayersync-0.2.0.exe` (binário **imutável e versionado** — evita
+cache stale do CDN do Storage) + `manifest.json` apontando para ele.
+
+### 2. Publicar (Supabase Storage → bucket `releases`, pasta `sayersync/`)
+
+Upload **nesta ordem** — o `.exe` ANTES do manifest (senão o conector baixa um alvo
+inexistente, falha o sha256 e conta como falha de update):
+
+1. `dist/sayersync-0.2.0.exe`
+2. `dist/manifest.json` (sobrescreve o ponteiro)
+
+### 3. Ativar (uma vez)
+
+- **Bucket** (global, uma vez): criar o bucket **público read-only** `releases` no
+  Supabase Storage — leitura `anon`, escrita só `service_role`.
+- **config.json** (em cada balcão): preencher `"update_manifest_url":
+  "https://fzvklzpomgnyikkfkzai.supabase.co/storage/v1/object/public/releases/sayersync/manifest.json"`.
+  Vazio = auto-update desativado (default seguro).
+
+> A primeira ativação ainda exige um redeploy manual do `.exe` no balcão: o
+> auto-update só passa a valer a partir de uma versão que já contenha a chamada no
+> ciclo.
 
 ---
 

--- a/connector/sayersync/.gitignore
+++ b/connector/sayersync/.gitignore
@@ -1,6 +1,8 @@
 # binários compilados (macOS e Windows)
 sayersync
 sayersync.exe
+# artefatos de release gerados por release.sh (binário versionado + manifest.json)
+dist/
 # arquivos de estado e configuração locais
 config.json
 config.json.tmp

--- a/connector/sayersync/release.sh
+++ b/connector/sayersync/release.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# release.sh — cross-compila o sayersync para Windows, calcula o sha256 e gera o
+# manifest.json de auto-update. Saída em ./dist. NÃO faz upload: o bucket é
+# escrita-só-service_role; o founder publica os 2 arquivos manualmente.
+#
+# Uso:  ./release.sh <versao-semver>        ex.: ./release.sh 0.2.0
+# Env:  BUCKET_BASE_URL   base pública do bucket (default: prod Colacor)
+#
+# Gera (para publicar em releases/sayersync/ no Supabase Storage):
+#   - sayersync-<versao>.exe   binário IMUTÁVEL e versionado (evita cache stale do CDN)
+#   - manifest.json            ponteiro MUTÁVEL: {version, sha256, url}
+set -euo pipefail
+
+VERSION="${1:-}"
+BUCKET_BASE_URL="${BUCKET_BASE_URL:-https://fzvklzpomgnyikkfkzai.supabase.co/storage/v1/object/public/releases/sayersync}"
+
+if [[ -z "$VERSION" ]]; then
+  echo "uso: $0 <versao-semver>   (ex.: $0 0.2.0)" >&2
+  exit 1
+fi
+# Semver estrito X.Y.Z — é exatamente o que o anti-downgrade do conector parseia
+# (parseSemver em update.go); um sufixo de pre-release não compararia como esperado.
+if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "ERRO: versao '$VERSION' nao e semver X.Y.Z (ex.: 0.2.0)" >&2
+  exit 1
+fi
+
+cd "$(dirname "$0")" || exit 1
+DIST="dist"
+EXE="sayersync-${VERSION}.exe"
+mkdir -p "$DIST"
+
+echo "-> cross-compile windows/amd64 (CGO off, stripped) v${VERSION}"
+CGO_ENABLED=0 GOOS=windows GOARCH=amd64 \
+  go build -ldflags "-s -w -X main.Version=${VERSION}" \
+  -o "${DIST}/${EXE}" .
+
+# sha256 portavel: sha256sum no Linux, shasum no macOS.
+if command -v sha256sum >/dev/null 2>&1; then
+  SHA="$(sha256sum "${DIST}/${EXE}" | cut -d' ' -f1)"
+else
+  SHA="$(shasum -a 256 "${DIST}/${EXE}" | cut -d' ' -f1)"
+fi
+
+URL="${BUCKET_BASE_URL}/${EXE}"
+cat > "${DIST}/manifest.json" <<EOF
+{
+  "version": "${VERSION}",
+  "sha256": "${SHA}",
+  "url": "${URL}"
+}
+EOF
+
+BYTES="$(wc -c < "${DIST}/${EXE}" | tr -d ' ')"
+echo "OK ${DIST}/${EXE}  (${BYTES} bytes)"
+echo "OK ${DIST}/manifest.json"
+echo
+echo "sha256: ${SHA}"
+echo
+echo "Publicar no Supabase Storage (bucket 'releases', pasta 'sayersync/') NESTA ORDEM:"
+echo "  1. upload ${DIST}/${EXE}          (binario imutavel)"
+echo "  2. upload ${DIST}/manifest.json   (ponteiro; SO depois do .exe)"
+echo
+echo "A ordem importa: se o manifest apontar para um .exe ainda nao publicado, o"
+echo "conector baixa, falha o sha256 e conta como falha de update (crash-loop guard)."

--- a/connector/sayersync/state.go
+++ b/connector/sayersync/state.go
@@ -30,18 +30,26 @@ type State struct {
 	// UPDATEs na origem que não toquem data_atualizacao.
 	LastFullRescan string `json:"last_full_rescan,omitempty"`
 
-	// UpdateFailCount conta falhas consecutivas do auto-update (crash-loop guard).
-	// Ao atingir 3 falhas em 10 min, o conector faz rollback para o binário anterior.
+	// UpdateFailCount conta falhas do auto-update para o crash-loop guard.
+	// Ao atingir 3 falhas (a tentativa é 1×/dia → ~3 dias) com a última tentativa
+	// dentro da janela de 24h, o conector restaura o binário anterior (.prev) e
+	// pausa as tentativas até a janela expirar. Zera ao primeiro update sem falha.
 	UpdateFailCount int `json:"update_fail_count,omitempty"`
 
-	// LastUpdateAttempt é o ISO 8601 da última tentativa de auto-update.
-	// Usado para resetar UpdateFailCount após a janela de 10 min.
+	// LastUpdateAttempt é o ISO 8601 (UTC) da última tentativa de auto-update.
+	// Throttle: no máximo uma verificação por dia. Também define a janela de 24h
+	// do crash-loop guard (acima).
 	LastUpdateAttempt string `json:"last_update_attempt,omitempty"`
 }
 
+// stateDir retorna o diretório onde state.json é lido/gravado. É uma variável
+// (e não chamada direta a exeDir) para permitir override em testes; em produção
+// aponta para o diretório do executável.
+var stateDir = exeDir
+
 // statePath retorna o caminho do state.json ao lado do executável.
 func statePath() string {
-	return filepath.Join(exeDir(), "state.json")
+	return filepath.Join(stateDir(), "state.json")
 }
 
 // LoadState carrega o state.json. Se o arquivo não existir, retorna um State

--- a/connector/sayersync/sync.go
+++ b/connector/sayersync/sync.go
@@ -542,6 +542,20 @@ func RunCycle(ctx context.Context, cfg *Config) bool {
 		st = &State{HWM: make(map[string]string)}
 	}
 
+	// Auto-update cedo no ciclo: o conector precisa conseguir se auto-curar mesmo
+	// quando o sync está quebrado (PG fora / schema divergente) — justamente quando
+	// um fix precisa chegar. CheckAndApplyUpdate muta `st` (LastUpdateAttempt,
+	// UpdateFailCount) e NÃO persiste; os early-returns de falha abaixo pulam o
+	// SaveState do fim do ciclo, então persistimos aqui (só quando houve tentativa)
+	// para o throttle diário e o crash-loop guard sobreviverem entre reinícios.
+	prevUpdateAttempt := st.LastUpdateAttempt
+	CheckAndApplyUpdate(ctx, cfg, st)
+	if st.LastUpdateAttempt != prevUpdateAttempt {
+		if saveErr := SaveState(st); saveErr != nil {
+			logger.Errorf("RunCycle: falha ao salvar state pós auto-update: %v", saveErr)
+		}
+	}
+
 	// Conecta ao PG.
 	db, err := Connect(ctx, cfg.PGConn)
 	if err != nil {

--- a/connector/sayersync/sync_test.go
+++ b/connector/sayersync/sync_test.go
@@ -2417,6 +2417,59 @@ func TestRunCycle_returnsFalseOnConnectFailure(t *testing.T) {
 	}
 }
 
+// TestRunCycle_autoUpdatePersistsDespitePGFailure prova o REQUISITO de auto-cura:
+// o auto-update roda CEDO no ciclo (antes do early-return de falha de conexão com
+// o PG) e seu estado é persistido FORA do SaveState do fim do ciclo — que esse
+// early-return pula. Sem isso, o throttle "1×/dia" e o crash-loop guard não
+// sobreviveriam a ciclos com o PG local fora (re-tentaria o update a cada ciclo).
+// Falsificação: mover a chamada para depois do early-return, ou tirar o save
+// dedicado, deixa este teste vermelho.
+func TestRunCycle_autoUpdatePersistsDespitePGFailure(t *testing.T) {
+	// state.json isolado num diretório temporário (seam stateDir).
+	dir := t.TempDir()
+	prev := stateDir
+	stateDir = func() string { return dir }
+	defer func() { stateDir = prev }()
+
+	// Manifesto responde 404 → update falha (silenciosamente) → UpdateFailCount++.
+	manifestSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer manifestSrv.Close()
+
+	// Heartbeat best-effort responde 200 na hora (evita o backoff de retry).
+	hbSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(AgentResponse{OK: true})
+	}))
+	defer hbSrv.Close()
+
+	cfg := &Config{
+		AppURL:            hbSrv.URL,
+		StoreCode:         "loja",
+		TokenPlainDev:     "tok",
+		PGConn:            "postgres://nouser:nopass@127.0.0.1:1/nodb?connect_timeout=1", // Connect falha → early-return
+		UpdateManifestURL: manifestSrv.URL,
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	if RunCycle(ctx, cfg) {
+		t.Error("RunCycle deveria retornar false quando não conecta ao PG")
+	}
+
+	// O auto-update precisa ter rodado e persistido o estado APESAR do early-return.
+	st, err := LoadState()
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	if st.LastUpdateAttempt == "" {
+		t.Error("LastUpdateAttempt deveria ter sido persistido apesar do early-return do RunCycle")
+	}
+	if st.UpdateFailCount != 1 {
+		t.Errorf("UpdateFailCount esperado 1 (manifesto 404), got %d", st.UpdateFailCount)
+	}
+}
+
 // ─────────────────────────────────────────────────────────────
 // composeCorPadrao — sufixo " - BS" (Base Solvente) das cores padrão
 // ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Resumo
- Ativa o `CheckAndApplyUpdate` (estava implementado/testado mas **morto** — sem call-site em `RunCycle`/`main.go`). Chamada **cedo** no `RunCycle` (antes do Connect ao PG) para o conector se auto-curar mesmo com o sync quebrado (PG fora / schema divergente).
- **Persistência gated** do state na chamada: os 3 early-returns de falha do `RunCycle` pulam o `SaveState` do fim → sem isso o throttle 1×/dia e o crash-loop guard não sobreviveriam a ciclos com PG fora.
- `release.sh`: cross-compile windows/amd64 (CGO off, stripped) + sha256 + `manifest.json` com binário **versionado/imutável** (evita cache stale do CDN). Não faz upload (bucket é escrita-só-service_role).
- Fix de comentário stale do guard (10min→24h) + seam `stateDir` p/ teste + README/.gitignore.

## Dormente até a infra (founder)
- [ ] Criar bucket público read-only `releases` no Supabase Storage (escrita só `service_role`)
- [ ] `./release.sh X.Y.Z` → publicar o `.exe` (antes) e o `manifest.json` (depois) no bucket
- [ ] Preencher `update_manifest_url` no `config.json` de cada balcão
- [ ] Redeploy manual do `.exe` no balcão (a 1ª versão que já contém o wire)

## Test Plan
- [x] `go vet ./...` limpo
- [x] `go test ./...` → ok (inclui teste novo placement+persistência, RED→GREEN)
- [x] cross-compile `GOOS=windows GOARCH=amd64 CGO_ENABLED=0` ok (~11MB)
- [ ] ⚠️ CI `validate` **não roda Go** — validação Go foi local
- [ ] End-to-end real (download→sha256→install→.prev) só após bucket+config

🤖 Generated with [Claude Code](https://claude.com/claude-code)