### PR TITLE
fix(sayersync): conserta auto-update do conector p/ Windows (install em uso + crash-loop guard que expira)

### DIFF
--- a/connector/README.md
+++ b/connector/README.md
@@ -103,10 +103,22 @@ go test ./... -v -count=1 -timeout 120s
 
 O conector verifica o manifesto **uma vez por dia** e se atualiza sozinho
 (anti-downgrade: só aplica se `manifest.version > current`, semver estrito; sha256
-verificado antes de instalar; crash-loop guard restaura o `.prev` após 3 falhas em
-24h). A chamada vive **cedo** no `RunCycle` (`sync.go`), então o conector consegue
-se auto-curar mesmo quando o sync está quebrado (PG local fora / schema divergente)
-— justamente quando um fix precisa chegar.
+verificado antes de instalar). A chamada vive **cedo** no `RunCycle` (`sync.go`),
+então o conector consegue se auto-curar mesmo quando o sync está quebrado (PG local
+fora / schema divergente) — justamente quando um fix precisa chegar. O auto-update
+roda **só no serviço** (`run`); o subcomando `once` (debug/manual) não auto-atualiza.
+
+**Install Windows-safe + restart automático:** a imagem `.exe` em execução não pode
+ser sobrescrita no Windows (sharing violation), então o install **move** o exe atual
+para `<exe>.prev` e coloca o novo no lugar; em seguida o serviço **reinicia sozinho**
+(o processo sai com código de falha → o SCM, configurado com `OnFailure=restart` pelo
+`install`, relança o serviço a partir do binário novo). Sem esse restart o serviço
+seguiria rodando a imagem antiga e a próxima atualização falharia ao tentar substituir
+o `.prev` em uso.
+
+**Crash-loop guard:** 3 falhas de update em 24h → restaura o `.prev` e **pausa** as
+tentativas. A janela de 24h ancora na última **falha** (não no throttle diário), então
+ela **expira** e o conector volta a tentar — nunca trava permanentemente.
 
 ### 1. Gerar os artefatos
 
@@ -138,6 +150,22 @@ inexistente, falha o sha256 e conta como falha de update):
 > A primeira ativação ainda exige um redeploy manual do `.exe` no balcão: o
 > auto-update só passa a valer a partir de uma versão que já contenha a chamada no
 > ciclo.
+>
+> O restart automático depende do recovery `OnFailure=restart` do serviço Windows,
+> que o `install` já configura (`svcConfig` em `main.go`). Em um balcão que rodou
+> `install` de uma versão antiga, rode `sayersync.exe install` de novo (idempotente)
+> para garantir o recovery — sem ele, o `os.Exit` pós-update encerra o serviço e o
+> SCM **não** o relança. **Verifique ponta-a-ponta em um balcão Windows real** antes
+> de confiar: instalação do `.exe`, troca pelo `.prev` e relançamento pelo SCM só são
+> observáveis no Windows (os testes provam a sequência/lógica, não o SCM).
+>
+> ⚠️ **Limite conhecido (testar com release quebrado):** o crash-loop guard conta
+> falhas do *updater* (manifesto/download/sha256/install), **não** crashes do
+> *serviço*. Um binário que passa no sha256 mas quebra no boot (panic em `init`/`main`/
+> `LoadConfig`/`cmdRun`) reinicia em loop pelo SCM sem o guard pegar e sem restaurar o
+> `.prev`. Antes de ativar em produção, teste publicar um release deliberadamente
+> quebrado e confirme o comportamento — ou adote um handshake de boot (binário novo só
+> é "promovido" após 1 ciclo/heartbeat OK) antes de confiar no auto-restart.
 
 ---
 

--- a/connector/sayersync/main.go
+++ b/connector/sayersync/main.go
@@ -294,6 +294,10 @@ func cmdRun() {
 // ──────────────────────────────────────────────
 
 func cmdOnce() {
+	// `once` é debug/manual: NÃO deve auto-atualizar (trocaria o binário de produção
+	// e os.Exit(90) fora do recovery do SCM; evita corrida com o serviço). (Codex F6/F7)
+	autoUpdateEnabled = false
+
 	cfg, err := LoadConfig()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Falha ao carregar config.json: %v\n", err)

--- a/connector/sayersync/state.go
+++ b/connector/sayersync/state.go
@@ -37,9 +37,17 @@ type State struct {
 	UpdateFailCount int `json:"update_fail_count,omitempty"`
 
 	// LastUpdateAttempt é o ISO 8601 (UTC) da última tentativa de auto-update.
-	// Throttle: no máximo uma verificação por dia. Também define a janela de 24h
-	// do crash-loop guard (acima).
+	// Throttle: no máximo uma verificação por dia. É renovado a cada passagem
+	// diária (inclusive quando o guard pula a tentativa), então NÃO serve de
+	// âncora para a janela do crash-loop guard — ver LastUpdateFailure.
 	LastUpdateAttempt string `json:"last_update_attempt,omitempty"`
+
+	// LastUpdateFailure é o ISO 8601 (UTC) da última FALHA de auto-update.
+	// Âncora da janela de 24h do crash-loop guard: a janela envelhece a partir
+	// daqui (não de LastUpdateAttempt, que o throttle renova todo dia). Sem este
+	// campo a janela nunca expirava → brick permanente após 3 falhas. Zera junto
+	// com UpdateFailCount ao primeiro update sem falha.
+	LastUpdateFailure string `json:"last_update_failure,omitempty"`
 }
 
 // stateDir retorna o diretório onde state.json é lido/gravado. É uma variável

--- a/connector/sayersync/update.go
+++ b/connector/sayersync/update.go
@@ -4,9 +4,11 @@
 //  1. Busca o manifesto JSON em Config.UpdateManifestURL (bucket público do Supabase Storage)
 //  2. Compara a versão do manifesto com a versão atual (semver, anti-downgrade)
 //  3. Baixa o novo binário e verifica o sha256
-//  4. Faz backup do binário atual para <exe>.prev
-//  5. Substitui o binário atual pelo novo (o serviço continuará rodando até o próximo restart)
-//  6. Guarda um crash-loop guard: se ≥3 falhas de update em 24h → restaura o .prev e para de tentar
+//  4. Instala Windows-safe: MOVE o exe em execução para <exe>.prev (backup) e MOVE
+//     o <exe>.new para <exe> — nessa ordem, porque a imagem em uso no Windows pode
+//     ser renomeada mas não sobrescrita (ver installBinary)
+//  5. Reinicia o serviço (os.Exit → SCM OnFailure=restart) para ativar o novo binário
+//  6. Guarda um crash-loop guard: se ≥3 falhas de update em 24h → restaura o .prev e pausa
 //
 // Chamado uma vez por RunCycle quando a data mudou desde a última verificação.
 //
@@ -14,7 +16,8 @@
 //   - UpdateManifestURL fica num bucket PÚBLICO read-only do Supabase; escrita = service_role apenas.
 //   - sha256 verificado antes de instalar (falha → descarta o download, conta como falha).
 //   - Anti-downgrade: só atualiza se manifest.version > current (semver estrito).
-//   - Crash-loop guard: 3 falhas em 24h → restaura .prev + desativa tentativas por 24h.
+//   - Crash-loop guard: 3 falhas em 24h → restaura .prev + pausa tentativas; a janela
+//     ancora na última FALHA (LastUpdateFailure) e expira 24h depois (NÃO trava para sempre).
 //
 // Spec: docs/superpowers/specs/2026-06-09-tint-sync-sayersystem-design.md §6.4
 package main
@@ -47,6 +50,28 @@ const crashLoopWindow = 24 * time.Hour
 // crashLoopThreshold é o número máximo de falhas antes de restaurar o .prev.
 const crashLoopThreshold = 3
 
+// exitCodeUpdateRestart é o código de saída após instalar um novo binário. O
+// processo encerra com FALHA de propósito: o SCM do Windows (OnFailure=restart,
+// ver svcConfig em main.go) relança o serviço a partir do exePath — agora o
+// binário novo. Sem o relançamento o serviço continuaria executando a imagem
+// antiga (movida para .prev) e a PRÓXIMA atualização falharia ao tentar
+// substituir o .prev em uso.
+const exitCodeUpdateRestart = 90
+
+// restartService reinicia o serviço para ativar o binário recém-instalado.
+// É uma variável para permitir override em testes; em produção NÃO retorna
+// (os.Exit → SCM relança). Verificação ponta-a-ponta exige um balcão Windows real.
+var restartService = func() {
+	logger.Infof("update: reiniciando o serviço para ativar o novo binário (exit %d → SCM OnFailure=restart)", exitCodeUpdateRestart)
+	os.Exit(exitCodeUpdateRestart)
+}
+
+// autoUpdateEnabled controla se o auto-update roda neste processo. Default true
+// (modo serviço). O subcomando `once` (debug/manual) o desliga: um run de debug
+// NÃO deve trocar o binário em produção nem os.Exit(90) fora do modelo de recovery
+// do SCM — e evita corrida de arquivos com o serviço rodando em paralelo. (Codex F6/F7)
+var autoUpdateEnabled = true
+
 // ─────────────────────────────────────────────────────────────
 // CheckAndApplyUpdate — ponto de entrada
 // ─────────────────────────────────────────────────────────────
@@ -56,6 +81,9 @@ const crashLoopThreshold = 3
 // Retorna nil se não há atualização necessária ou se a atualização foi bem-sucedida.
 // Erros são logados mas não propagam para não interromper o ciclo de sync.
 func CheckAndApplyUpdate(ctx context.Context, cfg *Config, st *State) {
+	if !autoUpdateEnabled {
+		return // desligado neste processo (ex.: subcomando `once`)
+	}
 	if cfg.UpdateManifestURL == "" {
 		return // auto-update desativado
 	}
@@ -74,9 +102,12 @@ func CheckAndApplyUpdate(ctx context.Context, cfg *Config, st *State) {
 		return
 	}
 
-	if err := doUpdate(ctx, cfg, st); err != nil {
+	installed, err := doUpdate(ctx, cfg, st)
+	if err != nil {
 		logger.Errorf("update: falha na atualização: %v", err)
 		st.UpdateFailCount++
+		// Âncora da janela do crash-loop guard na FALHA real (não no throttle).
+		st.LastUpdateFailure = time.Now().UTC().Format(time.RFC3339)
 
 		// Crash-loop guard: 3 falhas → restaura .prev.
 		if st.UpdateFailCount >= crashLoopThreshold {
@@ -87,9 +118,27 @@ func CheckAndApplyUpdate(ctx context.Context, cfg *Config, st *State) {
 				logger.Infof("update: .prev restaurado com sucesso")
 			}
 		}
-	} else {
-		// Sucesso: reseta o contador de falhas.
-		st.UpdateFailCount = 0
+		return
+	}
+
+	// Sucesso: reseta o contador de falhas e a âncora da janela.
+	st.UpdateFailCount = 0
+	st.LastUpdateFailure = ""
+
+	// Se um binário novo foi instalado, reinicia para ativá-lo. O processo atual
+	// ainda executa a imagem antiga (movida para .prev), então só o relançamento
+	// ativa o novo binário; além disso, sem ele a próxima atualização falharia ao
+	// tentar substituir o .prev em uso. Em produção restartService não retorna.
+	if installed {
+		// Persiste ANTES de reiniciar: o os.Exit pula o SaveState gated do RunCycle.
+		// Sem isso, após o restart o throttle ainda apontaria para ontem e um binário
+		// publicado com versão errada (ex.: build sem ldflag → "dev") viraria loop
+		// install→restart. Persistido, shouldCheckUpdate=false no mesmo dia → no
+		// máximo 1 tentativa/dia. (Codex F1)
+		if saveErr := SaveState(st); saveErr != nil {
+			logger.Errorf("update: falha ao persistir state antes do restart: %v", saveErr)
+		}
+		restartService()
 	}
 }
 
@@ -111,58 +160,74 @@ func shouldCheckUpdate(st *State) bool {
 }
 
 // isCrashLoopGuardActive retorna true se o guard de crash-loop está ativo.
-// O guard ativa quando UpdateFailCount >= crashLoopThreshold E a última tentativa
+// O guard ativa quando UpdateFailCount >= crashLoopThreshold E a última FALHA
 // foi dentro da janela de 24h.
+//
+// A janela ancora em LastUpdateFailure (não LastUpdateAttempt): o throttle diário
+// renova LastUpdateAttempt para "agora" em TODA passagem — inclusive quando o guard
+// pula a tentativa — então usá-lo como âncora fazia a janela nunca envelhecer e o
+// guard travar para sempre (P2). Ancorando na última falha real, a janela expira
+// 24h após a 3ª falha e uma nova tentativa volta a rodar.
 func isCrashLoopGuardActive(st *State) bool {
 	if st.UpdateFailCount < crashLoopThreshold {
 		return false
 	}
-	if st.LastUpdateAttempt == "" {
+	if st.LastUpdateFailure == "" {
 		return false
 	}
-	last, err := time.Parse(time.RFC3339, st.LastUpdateAttempt)
+	last, err := time.Parse(time.RFC3339, st.LastUpdateFailure)
 	if err != nil {
 		return false
 	}
-	return time.Since(last) < crashLoopWindow
+	elapsed := time.Since(last)
+	if elapsed < 0 {
+		// Timestamp no futuro (clock skew / state corrompido): time.Since negativo
+		// manteria o guard ativo até "futuro + 24h", pausando updates por tempo
+		// indefinido. Fail-open — não confiar na âncora corrompida. (Codex F8)
+		return false
+	}
+	return elapsed < crashLoopWindow
 }
 
 // ─────────────────────────────────────────────────────────────
 // doUpdate — baixa e instala a nova versão
 // ─────────────────────────────────────────────────────────────
 
-func doUpdate(ctx context.Context, cfg *Config, st *State) error {
+// doUpdate retorna (installed, err): installed=true só quando um binário novo foi
+// de fato colocado no lugar (dispara o restart em CheckAndApplyUpdate). "Já é a
+// versão mais recente" retorna (false, nil).
+func doUpdate(ctx context.Context, cfg *Config, st *State) (bool, error) {
 	// 1. Busca o manifesto.
 	manifest, err := fetchManifest(ctx, cfg.UpdateManifestURL)
 	if err != nil {
-		return fmt.Errorf("doUpdate: buscar manifesto: %w", err)
+		return false, fmt.Errorf("doUpdate: buscar manifesto: %w", err)
 	}
 
 	// 2. Compara versões (anti-downgrade: só atualiza se manifest.version > current).
 	if !isNewerVersion(manifest.Version, Version) {
 		logger.Infof("update: versão atual %q já é a mais recente (manifesto: %q)", Version, manifest.Version)
-		return nil
+		return false, nil
 	}
 	logger.Infof("update: nova versão disponível %q (atual: %q) — baixando", manifest.Version, Version)
 
 	// 3. Baixa o binário.
 	binData, err := downloadBinary(ctx, manifest.URL)
 	if err != nil {
-		return fmt.Errorf("doUpdate: baixar binário: %w", err)
+		return false, fmt.Errorf("doUpdate: baixar binário: %w", err)
 	}
 
 	// 4. Verifica sha256.
 	if err := verifySHA256(binData, manifest.SHA256); err != nil {
-		return fmt.Errorf("doUpdate: sha256 inválido: %w", err)
+		return false, fmt.Errorf("doUpdate: sha256 inválido: %w", err)
 	}
 
-	// 5. Instala (backup + substituição atômica).
+	// 5. Instala (move-aside-then-place Windows-safe).
 	if err := installBinary(binData); err != nil {
-		return fmt.Errorf("doUpdate: instalar binário: %w", err)
+		return false, fmt.Errorf("doUpdate: instalar binário: %w", err)
 	}
 
-	logger.Infof("update: versão %q instalada — reiniciar o serviço para ativar", manifest.Version)
-	return nil
+	logger.Infof("update: versão %q instalada — reiniciando o serviço para ativar", manifest.Version)
+	return true, nil
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -248,48 +313,68 @@ func verifySHA256(data []byte, expectedHex string) error {
 // installBinary
 // ─────────────────────────────────────────────────────────────
 
-// installBinary instala o novo binário de forma atômica:
-//  1. Grava o novo binário em <exe>.new
-//  2. Faz backup do atual para <exe>.prev
-//  3. Move o .new para <exe>
-//
-// Em caso de falha em qualquer passo, o binário original é preservado.
-func installBinary(data []byte) error {
-	exePath, err := os.Executable()
+// executablePath resolve o caminho real (symlinks resolvidos) do executável em
+// execução. É uma variável para permitir override em testes (mesmo padrão de
+// `var stateDir` em state.go), já que installBinary/restorePrev operam sobre ele.
+var executablePath = func() (string, error) {
+	exe, err := os.Executable()
 	if err != nil {
-		return fmt.Errorf("determinar caminho do executável: %w", err)
+		return "", fmt.Errorf("determinar caminho do executável: %w", err)
 	}
-	// Resolve symlinks para obter o caminho real.
-	exePath, err = filepath.EvalSymlinks(exePath)
+	exe, err = filepath.EvalSymlinks(exe)
 	if err != nil {
-		return fmt.Errorf("resolver symlinks do executável: %w", err)
+		return "", fmt.Errorf("resolver symlinks do executável: %w", err)
+	}
+	return exe, nil
+}
+
+// renameFile é os.Rename isolado em variável para permitir simular falha do passo
+// de "colocar o novo binário" em testes (cobertura do rollback).
+var renameFile = os.Rename
+
+// installBinary instala o novo binário de forma Windows-safe:
+//  1. Grava o novo binário em <exe>.new
+//  2. MOVE (rename) o exe atual em execução para <exe>.prev
+//  3. MOVE (rename) o <exe>.new para <exe>
+//
+// Por que mover o exe em uso ANTES de colocar o novo (e não sobrescrevê-lo):
+// no Windows a imagem em execução fica travada — não pode ser SOBRESCRITA nem
+// APAGADA — mas PODE ser renomeada/movida. Movendo-a para .prev primeiro, o
+// destino (exePath) deixa de existir e o passo 3 não esbarra em sharing violation.
+// O processo continua executando a imagem antiga (agora em .prev) até reiniciar;
+// o restart pós-install (ver CheckAndApplyUpdate) é o que ativa o novo binário.
+//
+// Se o passo 3 falhar depois do passo 2, faz rollback (devolve o exe original ao
+// lugar) para nunca deixar o serviço sem binário no exePath.
+func installBinary(data []byte) error {
+	exePath, err := executablePath()
+	if err != nil {
+		return err
 	}
 
 	newPath := exePath + ".new"
 	prevPath := exePath + ".prev"
 
-	// Grava o novo binário.
+	// 1. Grava o novo binário ao lado.
 	if err := os.WriteFile(newPath, data, 0755); err != nil { //nolint:gosec
 		return fmt.Errorf("gravar binário .new: %w", err)
 	}
 
-	// Backup do atual para .prev (sobrescreve prev anterior se existir).
-	curData, err := os.ReadFile(exePath)
-	if err != nil {
+	// 2. Move o exe ATUAL (em execução) para .prev — backup É o move, não cópia.
+	//    Substitui um .prev anterior se existir (os.Rename é REPLACE_EXISTING).
+	if err := renameFile(exePath, prevPath); err != nil {
 		_ = os.Remove(newPath)
-		return fmt.Errorf("ler binário atual para backup: %w", err)
-	}
-	if err := os.WriteFile(prevPath, curData, 0755); err != nil { //nolint:gosec
-		_ = os.Remove(newPath)
-		return fmt.Errorf("gravar .prev: %w", err)
+		return fmt.Errorf("mover exe atual para .prev: %w", err)
 	}
 
-	// Substitui o executável atual (em Windows, o arquivo em uso não pode ser renomeado
-	// enquanto o processo está em execução; o serviço usará o novo binário no próximo restart).
-	if err := os.Rename(newPath, exePath); err != nil {
-		// Tenta desfazer o .new se falhou.
+	// 3. Coloca o novo binário no lugar do exe (destino já não existe).
+	if err := renameFile(newPath, exePath); err != nil {
+		// Rollback: devolve o exe original ao lugar para não deixar o serviço sem binário.
+		if rbErr := renameFile(prevPath, exePath); rbErr != nil {
+			return fmt.Errorf("colocar .new no exe: %w; ROLLBACK FALHOU — exe ficou em %s: %v", err, prevPath, rbErr)
+		}
 		_ = os.Remove(newPath)
-		return fmt.Errorf("renomear .new para exe: %w", err)
+		return fmt.Errorf("colocar .new no exe (rollback ok): %w", err)
 	}
 
 	return nil
@@ -301,13 +386,9 @@ func installBinary(data []byte) error {
 
 // restorePrev restaura o binário anterior a partir de <exe>.prev.
 func restorePrev() error {
-	exePath, err := os.Executable()
+	exePath, err := executablePath()
 	if err != nil {
-		return fmt.Errorf("determinar caminho do executável: %w", err)
-	}
-	exePath, err = filepath.EvalSymlinks(exePath)
-	if err != nil {
-		return fmt.Errorf("resolver symlinks: %w", err)
+		return err
 	}
 	prevPath := exePath + ".prev"
 

--- a/connector/sayersync/update_test.go
+++ b/connector/sayersync/update_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 )
@@ -146,11 +147,11 @@ func TestCrashLoopGuard_inactive(t *testing.T) {
 }
 
 func TestCrashLoopGuard_thresholdButOld(t *testing.T) {
-	// 3 falhas mas última tentativa foi há mais de 24h → guard inativo
+	// 3 falhas mas última FALHA foi há mais de 24h → guard inativo
 	old := time.Now().UTC().Add(-25 * time.Hour).Format(time.RFC3339)
 	st := &State{
 		UpdateFailCount:   3,
-		LastUpdateAttempt: old,
+		LastUpdateFailure: old,
 	}
 	if isCrashLoopGuardActive(st) {
 		t.Error("falhas antigas (>24h) não devem ativar o guard")
@@ -161,7 +162,7 @@ func TestCrashLoopGuard_active(t *testing.T) {
 	recent := time.Now().UTC().Add(-1 * time.Hour).Format(time.RFC3339)
 	st := &State{
 		UpdateFailCount:   3,
-		LastUpdateAttempt: recent,
+		LastUpdateFailure: recent,
 	}
 	if !isCrashLoopGuardActive(st) {
 		t.Error("3 falhas recentes devem ativar o guard")
@@ -170,9 +171,52 @@ func TestCrashLoopGuard_active(t *testing.T) {
 
 func TestCrashLoopGuard_emptyAttempt(t *testing.T) {
 	st := &State{UpdateFailCount: 3}
-	// Sem LastUpdateAttempt → guard inativo (não temos janela de referência)
+	// Sem LastUpdateFailure → guard inativo (não temos janela de referência)
 	if isCrashLoopGuardActive(st) {
-		t.Error("sem LastUpdateAttempt o guard deve estar inativo")
+		t.Error("sem LastUpdateFailure o guard deve estar inativo")
+	}
+}
+
+// TestCrashLoopGuard_windowExpiresDespiteRenewedAttempt é a regressão do P2:
+// a janela de 24h DEVE envelhecer a partir da última FALHA real, não de
+// LastUpdateAttempt (que o throttle diário renova para "agora" em toda passagem,
+// inclusive nos dias em que o guard pula a tentativa). Sem isso, a janela nunca
+// expirava → 3 falhas transitórias = updates desligados PARA SEMPRE.
+func TestCrashLoopGuard_windowExpiresDespiteRenewedAttempt(t *testing.T) {
+	st := &State{
+		UpdateFailCount:   3,
+		LastUpdateFailure: time.Now().UTC().Add(-25 * time.Hour).Format(time.RFC3339), // falha há 25h → janela expirou
+		LastUpdateAttempt: time.Now().UTC().Format(time.RFC3339),                      // renovado HOJE (a condição do bug)
+	}
+	if isCrashLoopGuardActive(st) {
+		t.Error("janela deve expirar pela última falha (25h atrás), mesmo com LastUpdateAttempt renovado hoje")
+	}
+}
+
+// TestCrashLoopGuard_activeWithinFailureWindow: falha recente (<24h) mantém o
+// guard ativo, independentemente de LastUpdateAttempt.
+func TestCrashLoopGuard_activeWithinFailureWindow(t *testing.T) {
+	st := &State{
+		UpdateFailCount:   3,
+		LastUpdateFailure: time.Now().UTC().Add(-1 * time.Hour).Format(time.RFC3339), // falha há 1h → dentro da janela
+		LastUpdateAttempt: time.Now().UTC().Format(time.RFC3339),
+	}
+	if !isCrashLoopGuardActive(st) {
+		t.Error("falha recente (<24h) deve manter o guard ativo")
+	}
+}
+
+// TestCrashLoopGuard_futureFailureTimestampFailsOpen é a regressão do Codex F8:
+// um LastUpdateFailure no FUTURO (clock skew / state corrompido) torna time.Since
+// negativo e mantinha o guard ativo até esse instante + 24h — pausando updates por
+// tempo indefinido. Deve falhar ABERTO (guard inativo), não pausar.
+func TestCrashLoopGuard_futureFailureTimestampFailsOpen(t *testing.T) {
+	st := &State{
+		UpdateFailCount:   3,
+		LastUpdateFailure: time.Now().UTC().Add(48 * time.Hour).Format(time.RFC3339), // 48h no futuro
+	}
+	if isCrashLoopGuardActive(st) {
+		t.Error("timestamp de falha no futuro deve falhar aberto (guard inativo), não pausar updates indefinidamente")
 	}
 }
 
@@ -305,6 +349,34 @@ func TestCheckAndApplyUpdate_noURL(t *testing.T) {
 	}
 }
 
+// TestCheckAndApplyUpdate_disabledInProcess_skips: o gate do `once` (Codex F6/F7).
+// Com autoUpdateEnabled=false o auto-update é no-op total mesmo com manifesto válido
+// e versão mais nova: nada instala, nada reinicia, e retorna ANTES do throttle.
+func TestCheckAndApplyUpdate_disabledInProcess_skips(t *testing.T) {
+	orig := autoUpdateEnabled
+	autoUpdateEnabled = false
+	t.Cleanup(func() { autoUpdateEnabled = orig })
+
+	exePath := withFakeExe(t, "OLD")
+	restartCalls := withRecordedRestart(t)
+	manifestURL := serveUpdate(t, "999.0.0", []byte("NEW"))
+
+	yesterday := time.Now().UTC().AddDate(0, 0, -1).Format(time.RFC3339)
+	cfg := &Config{UpdateManifestURL: manifestURL}
+	st := &State{LastUpdateAttempt: yesterday}
+	CheckAndApplyUpdate(context.Background(), cfg, st)
+
+	if got, _ := os.ReadFile(exePath); string(got) != "OLD" {
+		t.Errorf("desabilitado não deve instalar; exe got %q", got)
+	}
+	if *restartCalls != 0 {
+		t.Errorf("desabilitado não deve reiniciar, got %d", *restartCalls)
+	}
+	if st.LastUpdateAttempt != yesterday {
+		t.Errorf("desabilitado deve retornar antes do throttle; LastUpdateAttempt virou %q", st.LastUpdateAttempt)
+	}
+}
+
 func TestCheckAndApplyUpdate_sameDay(t *testing.T) {
 	// Já verificou hoje → não tenta de novo
 	cfg := &Config{UpdateManifestURL: "http://example.com/manifest.json"}
@@ -317,16 +389,19 @@ func TestCheckAndApplyUpdate_sameDay(t *testing.T) {
 }
 
 func TestCheckAndApplyUpdate_crashLoopGuardActive(t *testing.T) {
-	// Guard ativo → não tenta, não muda o estado
-	recent := time.Now().UTC().Add(-30 * time.Minute).Format(time.RFC3339)
-	cfg := &Config{UpdateManifestURL: "http://example.com/manifest.json"}
+	// Throttle passa (última tentativa ontem), mas o guard (falha há 30min, <24h)
+	// bloqueia o doUpdate. URL inalcançável: se o guard NÃO bloquear, doUpdate
+	// falha e incrementa o contador — a regressão seria pega aqui.
+	yesterday := time.Now().UTC().AddDate(0, 0, -1).Format(time.RFC3339)
+	recentFailure := time.Now().UTC().Add(-30 * time.Minute).Format(time.RFC3339)
+	cfg := &Config{UpdateManifestURL: "http://127.0.0.1:1/manifest.json"}
 	st := &State{
 		UpdateFailCount:   3,
-		LastUpdateAttempt: recent,
+		LastUpdateFailure: recentFailure,
+		LastUpdateAttempt: yesterday,
 	}
-	// Deve registrar a tentativa mas não incrementar (guard bloqueia o doUpdate)
 	CheckAndApplyUpdate(context.Background(), cfg, st)
-	// O guard ativo faz o código retornar cedo; o UpdateFailCount não deve aumentar
+	// O guard ativo faz o doUpdate ser pulado; o UpdateFailCount não deve aumentar.
 	if st.UpdateFailCount != 3 {
 		t.Errorf("guard ativo não deve incrementar fail count, got %d", st.UpdateFailCount)
 	}
@@ -404,58 +479,225 @@ func TestCheckAndApplyUpdate_sha256Mismatch_incrementsFailCount(t *testing.T) {
 	}
 }
 
+// withRecordedRestart troca restartService por um contador (evita o os.Exit real)
+// e o restaura no fim do teste. Devolve um ponteiro para a contagem de chamadas.
+func withRecordedRestart(t *testing.T) *int {
+	t.Helper()
+	calls := 0
+	orig := restartService
+	restartService = func() { calls++ }
+	t.Cleanup(func() { restartService = orig })
+	return &calls
+}
+
+// serveUpdate serve um manifesto (versão muito nova) + o binário correspondente,
+// com sha256 válido. Devolve a URL do manifesto.
+func serveUpdate(t *testing.T, version string, binary []byte) string {
+	t.Helper()
+	binSrv := serveBinary(t, binary)
+	t.Cleanup(binSrv.Close)
+	mSrv := serveManifest(t, UpdateManifest{Version: version, SHA256: sha256Hex(binary), URL: binSrv.URL})
+	t.Cleanup(mSrv.Close)
+	return mSrv.URL
+}
+
+// TestCheckAndApplyUpdate_installsAndRestarts é o happy-path ponta-a-ponta:
+// manifesto com versão mais nova → download → sha256 ok → installBinary coloca o
+// novo binário → restartService é sinalizado exatamente uma vez → guard zerado.
+func TestCheckAndApplyUpdate_installsAndRestarts(t *testing.T) {
+	exePath := withFakeExe(t, "OLD-running-binary")
+	restartCalls := withRecordedRestart(t)
+
+	newData := []byte("NEW-binary-content")
+	manifestURL := serveUpdate(t, "999.0.0", newData)
+
+	yesterday := time.Now().UTC().AddDate(0, 0, -1).Format(time.RFC3339)
+	cfg := &Config{UpdateManifestURL: manifestURL}
+	st := &State{UpdateFailCount: 2, LastUpdateFailure: yesterday, LastUpdateAttempt: yesterday}
+
+	CheckAndApplyUpdate(context.Background(), cfg, st)
+
+	if got, _ := os.ReadFile(exePath); string(got) != string(newData) {
+		t.Errorf("exe deve ter o binário novo, got %q", got)
+	}
+	if got, _ := os.ReadFile(exePath + ".prev"); string(got) != "OLD-running-binary" {
+		t.Errorf(".prev deve ter o binário antigo, got %q", got)
+	}
+	if *restartCalls != 1 {
+		t.Errorf("restartService deve ser chamado 1×, got %d", *restartCalls)
+	}
+	if st.UpdateFailCount != 0 || st.LastUpdateFailure != "" {
+		t.Errorf("sucesso deve zerar o guard: count=%d failure=%q", st.UpdateFailCount, st.LastUpdateFailure)
+	}
+}
+
+// TestCheckAndApplyUpdate_guardExpires_retriesUpdate é o P2 ponta-a-ponta: 3
+// falhas mas a última foi há >24h → janela expirou → o guard NÃO bloqueia → a
+// tentativa volta a rodar e (aqui) conclui com sucesso. Sem o fix do P2 o guard
+// continuaria ativo para sempre e nada disto rodaria.
+func TestCheckAndApplyUpdate_guardExpires_retriesUpdate(t *testing.T) {
+	exePath := withFakeExe(t, "OLD")
+	restartCalls := withRecordedRestart(t)
+
+	manifestURL := serveUpdate(t, "999.0.0", []byte("NEW"))
+
+	cfg := &Config{UpdateManifestURL: manifestURL}
+	st := &State{
+		UpdateFailCount:   3,
+		LastUpdateFailure: time.Now().UTC().Add(-25 * time.Hour).Format(time.RFC3339), // janela expirou
+		LastUpdateAttempt: time.Now().UTC().AddDate(0, 0, -1).Format(time.RFC3339),    // throttle passa
+	}
+	CheckAndApplyUpdate(context.Background(), cfg, st)
+
+	if got, _ := os.ReadFile(exePath); string(got) != "NEW" {
+		t.Errorf("a tentativa deve voltar a rodar e instalar o novo binário, got %q", got)
+	}
+	if st.UpdateFailCount != 0 {
+		t.Errorf("após janela expirar e update OK, fail count deve zerar, got %d", st.UpdateFailCount)
+	}
+	if *restartCalls != 1 {
+		t.Errorf("restartService deve ser chamado 1× após o install, got %d", *restartCalls)
+	}
+}
+
+// TestCheckAndApplyUpdate_persistsStateBeforeRestart é a regressão do Codex F1:
+// o os.Exit do restart pula o SaveState gated do RunCycle, então o install-success
+// DEVE persistir o state ANTES de reiniciar. Senão, após o restart o throttle ainda
+// aponta para ontem e um binário publicado com versão errada (ex.: build sem ldflag
+// → "dev", que isNewerVersion considera sempre mais antigo que qualquer release)
+// vira loop install→restart no mesmo dia. Recarregamos do disco (= o que o binário
+// pós-restart enxergaria) e exigimos que já esteja "checado hoje".
+func TestCheckAndApplyUpdate_persistsStateBeforeRestart(t *testing.T) {
+	withFakeExe(t, "OLD")
+	withRecordedRestart(t)
+	manifestURL := serveUpdate(t, "999.0.0", []byte("NEW"))
+
+	cfg := &Config{UpdateManifestURL: manifestURL}
+	st := &State{LastUpdateAttempt: time.Now().UTC().AddDate(0, 0, -1).Format(time.RFC3339)}
+	CheckAndApplyUpdate(context.Background(), cfg, st)
+
+	reloaded, err := LoadState()
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	if shouldCheckUpdate(reloaded) {
+		t.Error("após install+restart o state persistido deve marcar 'checado hoje' — senão vira loop install→restart no mesmo dia")
+	}
+}
+
 // ─────────────────────────────────────────────────────────────
-// installBinary — teste com arquivo temporário real
+// installBinary — chamadas reais via o seam executablePath
 // ─────────────────────────────────────────────────────────────
 
-func TestInstallBinary_createsFiles(t *testing.T) {
-	// Cria um "executável" temporário para simular os.Executable()
-	tmpDir := t.TempDir()
-	exePath := tmpDir + "/sayersync.exe"
-	originalData := []byte("original-binary")
-	if err := os.WriteFile(exePath, originalData, 0755); err != nil {
+// withFakeExe aponta o seam executablePath para um exe temporário e devolve o
+// caminho. Restaura o seam no fim do teste.
+func withFakeExe(t *testing.T, content string) string {
+	t.Helper()
+	exePath := filepath.Join(t.TempDir(), "sayersync.exe")
+	if err := os.WriteFile(exePath, []byte(content), 0755); err != nil {
 		t.Fatalf("criar exe temporário: %v", err)
 	}
+	orig := executablePath
+	executablePath = func() (string, error) { return exePath, nil }
+	t.Cleanup(func() { executablePath = orig })
 
-	// Override do os.Executable via monkeypatching não é possível em Go padrão,
-	// então testamos as funções auxiliares diretamente.
+	// state.json vive ao lado do exe em produção; aponta o stateDir para o tmpdir
+	// para SaveState/LoadState não tocarem o diretório real do executável.
+	dir := filepath.Dir(exePath)
+	origSD := stateDir
+	stateDir = func() string { return dir }
+	t.Cleanup(func() { stateDir = origSD })
 
-	// Verifica que sha256 e restore funcionam corretamente com arquivos reais.
-	newData := []byte("new-binary-data")
-	newHash := sha256Hex(newData)
+	return exePath
+}
 
-	// Verifica sha256
-	if err := verifySHA256(newData, newHash); err != nil {
-		t.Errorf("verifySHA256 falhou para dado válido: %v", err)
+// TestInstallBinary_movesAsideThenPlaces é o cerne do P1: o backup do exe atual
+// para .prev tem que ser um MOVE (rename do exe em execução), não uma cópia, e o
+// novo binário entra DEPOIS — quando o destino já não existe. Sem isso, o
+// os.Rename sobre o exe em uso falha no Windows (sharing violation).
+//
+// os.SameFile distingue MOVE de CÓPIA: se .prev for o exe original renomeado,
+// compartilha a identidade de arquivo; se for uma cópia (ReadFile+WriteFile),
+// não. O estado final no disco é idêntico nos dois casos no Unix, então só a
+// identidade do arquivo prova a sequência.
+func TestInstallBinary_movesAsideThenPlaces(t *testing.T) {
+	oldData := "OLD-running-binary"
+	exePath := withFakeExe(t, oldData)
+	beforeFI, err := os.Stat(exePath)
+	if err != nil {
+		t.Fatal(err)
 	}
 
-	// Grava .prev e .new manualmente para testar o padrão
+	newData := []byte("NEW-binary-content")
+	if err := installBinary(newData); err != nil {
+		t.Fatalf("installBinary falhou: %v", err)
+	}
+
+	if got, _ := os.ReadFile(exePath); string(got) != string(newData) {
+		t.Errorf("exePath deve conter o binário novo, got %q", got)
+	}
+
 	prevPath := exePath + ".prev"
-	newPath := exePath + ".new"
+	prevFI, err := os.Stat(prevPath)
+	if err != nil {
+		t.Fatalf(".prev não existe: %v", err)
+	}
+	if !os.SameFile(beforeFI, prevFI) {
+		t.Error(".prev deve ser o exe original MOVIDO (mesma identidade), não uma cópia — senão o rename sobre o exe em uso falha no Windows")
+	}
+	if got, _ := os.ReadFile(prevPath); string(got) != oldData {
+		t.Errorf(".prev deve ter o conteúdo do exe antigo, got %q", got)
+	}
+	if _, err := os.Stat(exePath + ".new"); !os.IsNotExist(err) {
+		t.Error(".new não deve sobrar após o install (foi renomeado para o exe)")
+	}
+}
 
-	if err := os.WriteFile(prevPath, originalData, 0755); err != nil {
-		t.Fatalf("gravar .prev: %v", err)
-	}
-	if err := os.WriteFile(newPath, newData, 0755); err != nil {
-		t.Fatalf("gravar .new: %v", err)
-	}
-
-	// Verifica que os arquivos foram criados
-	if _, err := os.Stat(prevPath); os.IsNotExist(err) {
-		t.Error(".prev não foi criado")
-	}
-	if _, err := os.Stat(newPath); os.IsNotExist(err) {
-		t.Error(".new não foi criado")
+// TestInstallBinary_overwritesStalePrev: um .prev obsoleto de um update anterior
+// deve ser substituído pelo exe que estava em execução (os.Rename é REPLACE_EXISTING).
+func TestInstallBinary_overwritesStalePrev(t *testing.T) {
+	exePath := withFakeExe(t, "V2-running")
+	if err := os.WriteFile(exePath+".prev", []byte("V1-stale"), 0755); err != nil {
+		t.Fatal(err)
 	}
 
-	// Rename (parte final do installBinary)
-	if err := os.Rename(newPath, exePath); err != nil {
-		t.Fatalf("rename .new → exe: %v", err)
+	if err := installBinary([]byte("V3-new")); err != nil {
+		t.Fatalf("installBinary falhou: %v", err)
 	}
+	if got, _ := os.ReadFile(exePath); string(got) != "V3-new" {
+		t.Errorf("exe deve ter V3-new, got %q", got)
+	}
+	if got, _ := os.ReadFile(exePath + ".prev"); string(got) != "V2-running" {
+		t.Errorf(".prev deve conter V2-running (substituindo o V1 obsoleto), got %q", got)
+	}
+}
 
-	// Verifica que o exe foi atualizado
+// TestInstallBinary_rollsBackOnPlaceFailure: se "colocar o novo binário" (rename
+// .new → exe) falhar APÓS mover o exe atual para .prev, o install deve devolver o
+// exe original ao exePath — senão o serviço ficaria sem binário no caminho.
+func TestInstallBinary_rollsBackOnPlaceFailure(t *testing.T) {
+	oldData := "OLD-running-binary"
+	exePath := withFakeExe(t, oldData)
+
+	origRename := renameFile
+	calls := 0
+	renameFile = func(oldpath, newpath string) error {
+		calls++
+		if calls == 2 { // 1 = move-aside (exe→.prev); 2 = place (.new→exe)
+			return fmt.Errorf("erro simulado no place")
+		}
+		return origRename(oldpath, newpath)
+	}
+	defer func() { renameFile = origRename }()
+
+	if err := installBinary([]byte("NEW-binary-content")); err == nil {
+		t.Fatal("installBinary deveria retornar erro quando o place falha")
+	}
 	got, err := os.ReadFile(exePath)
-	if err != nil || string(got) != string(newData) {
-		t.Error("conteúdo do exe não foi atualizado após rename")
+	if err != nil {
+		t.Fatalf("exePath sumiu após rollback (serviço ficaria sem binário!): %v", err)
+	}
+	if string(got) != oldData {
+		t.Errorf("rollback deve devolver o exe antigo ao exePath, got %q", got)
 	}
 }


### PR DESCRIPTION
## O que

Conserta dois defeitos reais do auto-update do conector Go (`connector/sayersync/`), achados por review do Codex, que o tornavam quebrado/perigoso ao ser ativado. **Feature dormente** (liga só quando `update_manifest_url` é preenchido + bucket `releases` existe) — este merge **não ativa nada**.

## P1 — `installBinary` não substituía o `.exe` em uso no Windows
`os.Rename` por cima da imagem em execução = sharing violation → todo update falhava. Agora **move-aside-then-place**: grava `.new`, **renomeia** o exe em uso → `.prev`, move `.new` → exe (+ rollback se o place falhar). Após instalar, o serviço **reinicia** (`os.Exit(90)` → SCM `OnFailure=restart`) p/ ativar o novo binário.

## P2 — crash-loop guard nunca expirava (brick permanente)
A janela de 24h ancorava em `LastUpdateAttempt`, renovado pelo throttle diário a cada passagem → nunca envelhecia. Agora ancora em campo novo `State.LastUpdateFailure` (gravado só na falha real) → expira 24h após a 3ª falha e volta a tentar.

## Hardening (Codex challenge)
- **F1**: persiste state antes do `os.Exit` (release mal-versionado não loopa mais que 1×/dia).
- **F8**: fail-open em timestamp futuro (clock skew) — não pausa updates indefinidamente.
- **F6/F7**: `autoUpdateEnabled` desliga auto-update no subcomando `once` (debug não troca binário de produção).

## Limite conhecido (gate de ativação) — NÃO bloqueia o merge
**F2**: o crash-loop guard conta falhas do *updater*, não crash do *serviço*. Binário sha-válido que quebra no boot reinicia em loop pelo SCM sem rollback. Documentado no README; fix robusto (recovery do SCM com rollback / launcher externo + `restorePrev` rename-based) deferido p/ esforço dedicado de Windows (tarefa separada). **Antes de ativar: testar um release deliberadamente quebrado num balcão Windows real.**

## Verificação
- 20 testes de update (TDD, RED→GREEN, cada invariante novo falsificado por sabotagem).
- Suíte completa `ok`, `go vet` limpo, `gofmt` limpo, cross-compile Windows OK.
- Rebaseado sobre `main` (inclui #914 hashcache); arquivos disjuntos, zero conflito. **Não toca** hashcache nem `sync.go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)