### PR TITLE
fix(sayersync): recovery externo de crash-loop de boot do auto-update (F2/F3/F5)

### DIFF
--- a/connector/README.md
+++ b/connector/README.md
@@ -92,6 +92,7 @@ go test ./... -v -count=1 -timeout 120s
 | `sync.go` | Orquestrador `RunCycle`; mapeadores de entidade; lógica de batch |
 | `api.go` | Cliente HTTP com retry exponencial (1s/4s/16s); Heartbeat |
 | `update.go` | Auto-update diário: manifesto → semver → sha256 → install + crash-loop guard |
+| `recovery.go` · `recovery_windows.go` · `recovery_other.go` | Recuperação de crash-loop de BOOT: recovery-copy estável, failure actions do SCM, rollback rename-based, quarentena de versão |
 | `mapping.go` | Carregamento do schema de mapeamento tintométrico |
 | `discovery.go` | Descoberta de entidades no schema |
 | `dpapi_windows.go` | DPAPI (CryptProtectData) para Windows |
@@ -116,9 +117,25 @@ para `<exe>.prev` e coloca o novo no lugar; em seguida o serviço **reinicia soz
 seguiria rodando a imagem antiga e a próxima atualização falharia ao tentar substituir
 o `.prev` em uso.
 
-**Crash-loop guard:** 3 falhas de update em 24h → restaura o `.prev` e **pausa** as
-tentativas. A janela de 24h ancora na última **falha** (não no throttle diário), então
-ela **expira** e o conector volta a tentar — nunca trava permanentemente.
+**Crash-loop guard (do updater):** 3 falhas de update em 24h → restaura o `.prev` e
+**pausa** as tentativas. A janela de 24h ancora na última **falha** (não no throttle
+diário), então ela **expira** e o conector volta a tentar — nunca trava permanentemente.
+
+**Recuperação de crash-loop de BOOT (rede externa ao binário):** o guard acima cobre
+falhas do *updater*. Um binário que passa no sha256 mas **panica no boot**
+(`init`/`main`/`LoadConfig`/`cmdRun`) seria relançado para sempre pelo SCM — e o código
+de restauração, por viver no mesmo binário que não boota, nunca rodaria. Por isso o
+recovery é **externo ao binário que quebra**: o `install` grava uma cópia estável
+`sayersync-recovery.exe` (que o auto-update **nunca** toca) e estende as failure actions
+do serviço para `[restart, restart, run_command]` (`dwResetPeriod` de 1h). Após 2
+restarts falhos consecutivos, o SCM roda `sayersync-recovery.exe rollback --target <exe>`
+num processo **fresco e bom**, que restaura o `.prev` (rename-based, Windows-safe) e
+reinicia o serviço (o `run_command` do SCM não reinicia sozinho). A versão ruim é
+**quarentenada** (`quarantined_version` no `state.json`): o auto-update a pula até o
+manifesto publicar **outra** — senão o binário restaurado reinstalaria o mesmo manifesto
+ruim no dia seguinte (brick *diário* em vez de permanente). E antes de cada troca de
+binário o updater **verifica/repara** essas failure actions; se não conseguir, **pula** o
+update (não ativa versão nova sem rede de rollback).
 
 ### 1. Gerar os artefatos
 
@@ -147,25 +164,29 @@ inexistente, falha o sha256 e conta como falha de update):
   "https://fzvklzpomgnyikkfkzai.supabase.co/storage/v1/object/public/releases/sayersync/manifest.json"`.
   Vazio = auto-update desativado (default seguro).
 
-> A primeira ativação ainda exige um redeploy manual do `.exe` no balcão: o
-> auto-update só passa a valer a partir de uma versão que já contenha a chamada no
-> ciclo.
+> **Rollout em 2 passos (importante):** o recovery externo só existe a partir de uma
+> versão que já o contenha. Num balcão que rodou `install` de uma versão antiga:
+> **(1)** faça um redeploy manual desta versão (rollback-capable) e rode
+> `sayersync.exe install` de novo — idempotente: recria a recovery-copy e as failure
+> actions `[restart, restart, run_command]`; **(2)** só então preencha o
+> `update_manifest_url`. Ativar o manifesto antes disso deixaria o primeiro auto-update
+> sem rede de recuperação. (O updater também verifica/repara as failure actions e pula
+> o update se faltarem — mas não conte com isso para o bootstrap.)
 >
-> O restart automático depende do recovery `OnFailure=restart` do serviço Windows,
-> que o `install` já configura (`svcConfig` em `main.go`). Em um balcão que rodou
-> `install` de uma versão antiga, rode `sayersync.exe install` de novo (idempotente)
-> para garantir o recovery — sem ele, o `os.Exit` pós-update encerra o serviço e o
-> SCM **não** o relança. **Verifique ponta-a-ponta em um balcão Windows real** antes
-> de confiar: instalação do `.exe`, troca pelo `.prev` e relançamento pelo SCM só são
-> observáveis no Windows (os testes provam a sequência/lógica, não o SCM).
+> **Verificação ponta-a-ponta EXIGE um balcão Windows real.** Os testes provam a
+> *lógica* (restore rename-based, quarentena, gate de recovery, montagem do
+> `lpCommand`), mas a semântica do SCM — contagem de falhas, `dwResetPeriod`, execução
+> do `run_command` — só é observável no Windows. Antes de confiar, publique um release
+> **deliberadamente quebrado** (compila, passa sha256, mas **panica no boot**) e confirme
+> que o SCM dispara o `rollback`, o `.prev` é restaurado, o serviço **volta a sincronizar**
+> e a versão ruim fica **quarentenada**.
 >
-> ⚠️ **Limite conhecido (testar com release quebrado):** o crash-loop guard conta
-> falhas do *updater* (manifesto/download/sha256/install), **não** crashes do
-> *serviço*. Um binário que passa no sha256 mas quebra no boot (panic em `init`/`main`/
-> `LoadConfig`/`cmdRun`) reinicia em loop pelo SCM sem o guard pegar e sem restaurar o
-> `.prev`. Antes de ativar em produção, teste publicar um release deliberadamente
-> quebrado e confirme o comportamento — ou adote um handshake de boot (binário novo só
-> é "promovido" após 1 ciclo/heartbeat OK) antes de confiar no auto-restart.
+> **Limites ainda abertos (degradação aceita, não resolvida):** **(F4)** queda de energia
+> *entre* os dois renames do restore pode deixar o `exe` ausente por um instante — limite
+> inerente do self-replace; só um launcher/watchdog dedicado resolveria. **(F9)** o sha256
+> garante **integridade**, não **autenticidade** — assinar os releases (chave pinada /
+> Authenticode) fica para o roadmap. Nenhum bloqueia a ativação; ambos devem entrar no
+> backlog do conector.
 
 ---
 
@@ -175,7 +196,8 @@ inexistente, falha o sha256 e conta como falha de update):
 - Serviço roda como `LocalService` (menor privilégio: só localhost + HTTPS outbound)
 - `UpdateManifestURL` aponta para bucket read-only público; escrita = `service_role` apenas
 - sha256 verificado antes de instalar o binário baixado
-- Crash-loop guard: 3 falhas de update em 24h → restaura `.prev` e para de tentar
+- Crash-loop guard (updater): 3 falhas em 24h → restaura `.prev`; a janela ancora na última falha e **expira** (não trava permanentemente)
+- Recuperação de crash-loop de **boot**: ator externo (recovery-copy) restaura o `.prev` via SCM `run_command` e **quarentena** a versão ruim; o auto-update é gateado pela verificação dessa rede de recuperação
 
 ---
 

--- a/connector/sayersync/main.go
+++ b/connector/sayersync/main.go
@@ -234,9 +234,17 @@ func cmdInstall() {
 	// auto-update não tem rollback automático. (Codex F2/F5)
 	if exePath, exeErr := executablePath(); exeErr != nil {
 		fmt.Fprintf(os.Stderr, "AVISO: não resolvi o caminho do exe para configurar recovery: %v\n", exeErr)
-	} else if recErr := configureServiceRecovery(exePath); recErr != nil {
-		fmt.Fprintf(os.Stderr, "AVISO: não configurei as ações de recovery do serviço: %v\n", recErr)
-		fmt.Fprintln(os.Stderr, "       O auto-update fica SEM rollback automático até isso ser corrigido (re-rodar install).")
+	} else {
+		// install é deliberado: FORÇA o refresh do ator do rollback (mesmo se já
+		// existe) para um balcão com recovery-copy velha/bugada poder atualizá-la
+		// re-rodando install. O repair automático (start/pre-update) preserva. (Codex P1)
+		if refErr := refreshRecoveryCopy(exePath); refErr != nil {
+			fmt.Fprintf(os.Stderr, "AVISO: não atualizei a recovery-copy: %v\n", refErr)
+		}
+		if recErr := configureServiceRecovery(exePath); recErr != nil {
+			fmt.Fprintf(os.Stderr, "AVISO: não configurei as ações de recovery do serviço: %v\n", recErr)
+			fmt.Fprintln(os.Stderr, "       O auto-update fica SEM rollback automático até isso ser corrigido (re-rodar install).")
+		}
 	}
 
 	if err := s.Start(); err != nil {
@@ -298,17 +306,11 @@ func cmdRun() {
 		os.Exit(1)
 	}
 
-	// Self-heal (Codex F5): instalações antigas ou edições manuais do serviço podem
-	// não ter as ações de recovery. Verifica e repara no start, antes de subir — o
-	// auto-update mais tarde dependerá delas para se recuperar de um binário ruim.
-	if exePath, exeErr := executablePath(); exeErr == nil {
-		if ok, _ := verifyServiceRecovery(exePath); !ok {
-			if recErr := configureServiceRecovery(exePath); recErr != nil {
-				logger.Warnf("recovery: não (re)configurei as ações de recovery no start: %v", recErr)
-			} else {
-				logger.Infof("recovery: ações de recovery do serviço reparadas no start")
-			}
-		}
+	// Self-heal (Codex F5): instalações antigas ou edições manuais podem não ter as
+	// ações de recovery OU a recovery-copy. ensureRecoveryConfigured checa AMBOS
+	// (actions + ator do rollback) e repara; loga sem bloquear o start.
+	if err := ensureRecoveryConfigured(); err != nil {
+		logger.Warnf("recovery: rede de recuperação incompleta no start: %v", err)
 	}
 
 	if err := s.Run(); err != nil {

--- a/connector/sayersync/main.go
+++ b/connector/sayersync/main.go
@@ -117,6 +117,9 @@ func main() {
 	case "discovery":
 		cmdDiscovery()
 
+	case "rollback":
+		cmdRollback()
+
 	default:
 		fmt.Fprintf(os.Stderr, "Subcomando desconhecido: %q\n\n", cmd)
 		printUsage()
@@ -135,6 +138,7 @@ Comandos:
   run        Entry-point do serviço (chamado pelo Windows SCM)
   once       Executar 1 ciclo de sync no console (teste/debug)
   discovery  Despejar o schema do SayerSystem em sayersystem-schema.txt
+  rollback   Restaurar o binário anterior (uso interno: SCM run_command de recovery)
   version    Mostrar a versão do binário
 `, Version)
 }
@@ -224,6 +228,17 @@ func cmdInstall() {
 		fmt.Fprintf(os.Stderr, "ERRO ao instalar serviço: %v\n", instErr)
 		os.Exit(1)
 	}
+
+	// Configura a rede de recuperação de crash-loop de BOOT: recovery-copy estável +
+	// failure actions [restart, restart, run_command → rollback]. Sem isso o
+	// auto-update não tem rollback automático. (Codex F2/F5)
+	if exePath, exeErr := executablePath(); exeErr != nil {
+		fmt.Fprintf(os.Stderr, "AVISO: não resolvi o caminho do exe para configurar recovery: %v\n", exeErr)
+	} else if recErr := configureServiceRecovery(exePath); recErr != nil {
+		fmt.Fprintf(os.Stderr, "AVISO: não configurei as ações de recovery do serviço: %v\n", recErr)
+		fmt.Fprintln(os.Stderr, "       O auto-update fica SEM rollback automático até isso ser corrigido (re-rodar install).")
+	}
+
 	if err := s.Start(); err != nil {
 		fmt.Fprintf(os.Stderr, "AVISO: serviço instalado mas não iniciou: %v\n", err)
 		fmt.Fprintln(os.Stderr, "       Rode 'sayersync.exe once' para ver o erro no console.")
@@ -281,6 +296,19 @@ func cmdRun() {
 	if err != nil {
 		logger.Errorf("Falha ao criar serviço: %v", err)
 		os.Exit(1)
+	}
+
+	// Self-heal (Codex F5): instalações antigas ou edições manuais do serviço podem
+	// não ter as ações de recovery. Verifica e repara no start, antes de subir — o
+	// auto-update mais tarde dependerá delas para se recuperar de um binário ruim.
+	if exePath, exeErr := executablePath(); exeErr == nil {
+		if ok, _ := verifyServiceRecovery(exePath); !ok {
+			if recErr := configureServiceRecovery(exePath); recErr != nil {
+				logger.Warnf("recovery: não (re)configurei as ações de recovery no start: %v", recErr)
+			} else {
+				logger.Infof("recovery: ações de recovery do serviço reparadas no start")
+			}
+		}
 	}
 
 	if err := s.Run(); err != nil {
@@ -348,12 +376,34 @@ func cmdDiscovery() {
 }
 
 // ──────────────────────────────────────────────
+// rollback (ATOR EXTERNO de recovery — via SCM run_command)
+// ──────────────────────────────────────────────
+
+// cmdRollback é o ator externo do recovery de crash-loop de BOOT: o SCM o dispara
+// (SC_ACTION_RUN_COMMAND) a partir da recovery-copy estável quando o binário novo
+// crash-loopa no boot. Restaura o .prev, quarentena a versão ruim e reinicia o
+// serviço. Recebe o exe-alvo via --target — a recovery-copy roda de OUTRO caminho,
+// então NÃO pode derivar o alvo de os.Executable. (Codex F2)
+func cmdRollback() {
+	target := parseTargetFlag(os.Args)
+	if target == "" {
+		fmt.Fprintln(os.Stderr, "ERRO: rollback requer --target <caminho absoluto do sayersync.exe>")
+		os.Exit(1)
+	}
+	if err := doRollback(target); err != nil {
+		logger.Errorf("rollback falhou: %v", err)
+		os.Exit(1)
+	}
+	fmt.Println("Rollback concluído.")
+}
+
+// ──────────────────────────────────────────────
 // svcConfig — configuração do serviço Windows
 // ──────────────────────────────────────────────
 
 func svcConfig(_ *Config) *service.Config {
 	return &service.Config{
-		Name:        "SayerSync",
+		Name:        serviceName, // = "SayerSync"; casa com as syscalls de recovery
 		DisplayName: "SayerSync — Colacor Tintométrico",
 		Description: "Sincroniza formulas e precos do SayerSystem com o app Colacor.",
 		// O SCM do Windows executa o binário com ESTES argumentos. Sem o "run",

--- a/connector/sayersync/recovery.go
+++ b/connector/sayersync/recovery.go
@@ -20,7 +20,6 @@
 package main
 
 import (
-	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -94,8 +93,10 @@ func restorePrevTo(targetExe string) error {
 
 	// 3. Coloca o .prev no lugar do target.
 	if err := renameWithRetry(prevPath, targetExe); err != nil {
-		// Reverte: devolve o .bad ao target para não deixar o serviço sem binário.
-		if rbErr := renameFile(badPath, targetExe); rbErr != nil {
+		// Reverte com o MESMO retry (a mesma sharing violation transitória que travou
+		// o passo acima pode travar este). Devolve o .bad ao target para não deixar o
+		// serviço sem binário. (Codex P1)
+		if rbErr := renameWithRetry(badPath, targetExe); rbErr != nil {
 			return fmt.Errorf("restore: mover .prev para target: %w; ROLLBACK FALHOU — exe ficou em %s: %v", err, badPath, rbErr)
 		}
 		return fmt.Errorf("restore: mover .prev para target (revertido ao binário atual): %w", err)
@@ -134,20 +135,36 @@ func recoveryExePath(exePath string) string {
 	return filepath.Join(filepath.Dir(exePath), recoveryExeName)
 }
 
-// ensureRecoveryCopy grava/atualiza a recovery-copy (cópia estável do exe usada
-// como ator do rollback). Idempotente: não reescreve se já idêntica. O auto-update
-// NUNCA chama esta função — a recovery-copy precisa ficar numa versão boa e estável.
+// recoveryCopyHealthy reporta se a recovery-copy (o ATOR do rollback) existe e é
+// não-vazia. O gate F5 exige isto além das failure actions: um lpCommand correto
+// apontando para um ator ausente (deletado/truncado por AV) faria o SCM rodar nada
+// no crash-loop, e o rollback nunca aconteceria.
+func recoveryCopyHealthy(exePath string) bool {
+	info, err := os.Stat(recoveryExePath(exePath))
+	return err == nil && info.Size() > 0
+}
+
+// ensureRecoveryCopy grava a recovery-copy (cópia estável do exe usada como ator do
+// rollback) quando ela está AUSENTE ou vazia. PRESERVA uma recovery-copy existente e
+// não-vazia: ela é o ator conhecido-bom, e um repair (ex.: no service start, já com um
+// binário novo rodando) não pode trocá-la por algo não comprovado. O write é atômico
+// (tmp + rename) para que um write parcial não destrua o único ator externo. (Codex P2)
 func ensureRecoveryCopy(exePath string) error {
+	if recoveryCopyHealthy(exePath) {
+		return nil
+	}
 	dst := recoveryExePath(exePath)
 	data, err := os.ReadFile(exePath)
 	if err != nil {
 		return fmt.Errorf("recovery-copy: ler exe atual: %w", err)
 	}
-	if existing, err := os.ReadFile(dst); err == nil && bytes.Equal(existing, data) {
-		return nil // já idêntica — evita I/O e churn de mtime
+	tmp := dst + ".tmp"
+	if err := os.WriteFile(tmp, data, 0755); err != nil { //nolint:gosec
+		return fmt.Errorf("recovery-copy: gravar tmp: %w", err)
 	}
-	if err := os.WriteFile(dst, data, 0755); err != nil { //nolint:gosec
-		return fmt.Errorf("recovery-copy: gravar %s: %w", dst, err)
+	if err := renameFile(tmp, dst); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("recovery-copy: rename atômico para %s: %w", dst, err)
 	}
 	return nil
 }
@@ -162,14 +179,20 @@ func ensureRecoveryConfigured() error {
 	if err != nil {
 		return fmt.Errorf("recovery: caminho do exe: %w", err)
 	}
-	ok, vErr := verifyServiceRecovery(exePath)
-	if ok {
+	actionsOK, vErr := verifyServiceRecovery(exePath)
+	// O ator do rollback (recovery-copy) precisa EXISTIR, não só o lpCommand apontá-lo:
+	// um ator deletado/truncado por AV faria o SCM rodar nada no crash-loop. (Codex P1)
+	if actionsOK && recoveryCopyHealthy(exePath) {
 		return nil
 	}
 	if cErr := configureServiceRecovery(exePath); cErr != nil {
-		return fmt.Errorf("rede de recuperação ausente e reparo falhou (verify=%v): %w", vErr, cErr)
+		return fmt.Errorf("rede de recuperação incompleta e reparo falhou (actions_ok=%v verify_err=%v): %w", actionsOK, vErr, cErr)
 	}
-	logger.Infof("recovery: ações de recovery do serviço (re)configuradas antes do update")
+	// Pós-reparo, o ator do rollback PRECISA existir — senão o update fica sem rede.
+	if !recoveryCopyHealthy(exePath) {
+		return fmt.Errorf("recovery-copy ausente mesmo após reparo (%s)", recoveryExePath(exePath))
+	}
+	logger.Infof("recovery: rede de recuperação (re)configurada antes do update")
 	return nil
 }
 
@@ -195,34 +218,32 @@ var (
 //  2. quarentena a versão ruim (lida de PendingUpdateVersion) e reseta o guard;
 //  3. reinicia o serviço (o SCM não reinicia após run_command).
 func doRollback(targetExe string) error {
-	st, err := LoadState()
-	if err != nil {
-		return fmt.Errorf("rollback: carregar state: %w", err)
-	}
-
-	// A versão que estava sendo ativada é a candidata a quarentena (capturada
-	// antes de limpar PendingUpdateVersion).
-	bad := st.PendingUpdateVersion
-
-	// 1. Restaura o binário anterior (last-known-good).
+	// 1. PRIMARY: restaura o binário anterior (last-known-good). NÃO depende do state
+	//    — um state.json corrompido não pode impedir a recuperação do crash-loop. (Codex P1)
 	if err := restorePrevTo(targetExe); err != nil {
 		return fmt.Errorf("rollback: %w", err)
 	}
 
-	// 2. Quarentena a versão ruim para o auto-update NÃO reinstalá-la amanhã
-	//    (brick diário). Reseta o crash-loop guard do updater — o rollback resolveu.
-	if bad != "" {
-		st.QuarantinedVersion = bad
-		logger.Warnf("rollback: versão %q quarentenada após crash-loop de boot", bad)
-	}
-	st.PendingUpdateVersion = ""
-	st.UpdateFailCount = 0
-	st.LastUpdateFailure = ""
-	if err := SaveState(st); err != nil {
-		return fmt.Errorf("rollback: persistir state: %w", err)
+	// 2. Best-effort: quarentena a versão ruim (para o updater não reinstalá-la amanhã,
+	//    brick diário) e reseta o guard. Falha aqui NÃO bloqueia o restart — recuperar
+	//    agora vale mais que evitar repetir amanhã. (Codex P1)
+	if st, err := LoadState(); err != nil {
+		logger.Errorf("rollback: state ilegível, pulando quarentena (best-effort): %v", err)
+	} else {
+		if bad := st.PendingUpdateVersion; bad != "" {
+			st.QuarantinedVersion = bad
+			logger.Warnf("rollback: versão %q quarentenada após crash-loop de boot", bad)
+		}
+		st.PendingUpdateVersion = ""
+		st.UpdateFailCount = 0
+		st.LastUpdateFailure = ""
+		if err := SaveState(st); err != nil {
+			logger.Errorf("rollback: falha ao persistir quarentena (best-effort): %v", err)
+		}
 	}
 
-	// 3. Reinicia o serviço com o binário restaurado.
+	// 3. PRIMARY: reinicia o serviço com o binário restaurado (o run_command do SCM
+	//    não reinicia sozinho).
 	if err := startRecoveredService(); err != nil {
 		return fmt.Errorf("rollback: reiniciar serviço: %w", err)
 	}

--- a/connector/sayersync/recovery.go
+++ b/connector/sayersync/recovery.go
@@ -1,0 +1,232 @@
+// recovery.go — recuperação de crash-loop de BOOT do conector (Codex F2).
+//
+// O crash-loop guard de update.go cobre falhas do UPDATER (fetch/download/
+// sha256/install). NÃO cobre um binário que passa no sha256 mas PANICA no boot
+// (init/main/LoadConfig/cmdRun): o SCM (OnFailure=restart) o relança para sempre
+// e o .prev nunca é restaurado, porque o código de restauração vive no MESMO
+// binário que não boota. A correção exige um ATOR EXTERNO ao binário que quebra.
+//
+// Mecanismo (parte cross-platform aqui; syscalls do SCM em recovery_windows.go):
+//   - install grava uma CÓPIA estável `sayersync-recovery.exe` (intocada pelo
+//     auto-update) e configura a recovery do serviço como
+//     [restart, restart, run_command], onde run_command =
+//     `sayersync-recovery.exe rollback --target <exe>`.
+//   - após N crashes de boot, o SCM roda esse comando num processo FRESCO e BOM
+//     (a recovery-copy sempre boota), que restaura o .prev (rename-based) e
+//     reinicia o serviço.
+//
+// Verificação ponta-a-ponta EXIGE um balcão Windows real (semântica do SCM:
+// contagem de falhas, dwResetPeriod, execução do run_command).
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"time"
+)
+
+// serviceName é o nome do serviço Windows (deve casar com svcConfig em main.go).
+// Usado pelas syscalls de recovery (recovery_windows.go) para abrir o serviço.
+const serviceName = "SayerSync"
+
+// recoveryExeName é a cópia estável do binário usada como ATOR do rollback. O
+// auto-update NUNCA a substitui, então ela sempre boota — diferente do exe
+// principal (que pode estar quebrado) e do .prev (cujo nome `.exe.prev` o SCM
+// poderia recusar executar). Fica ao lado do exe principal.
+const recoveryExeName = "sayersync-recovery.exe"
+
+// renameRetries/renameBackoff controlam o retry de rename contra
+// ERROR_SHARING_VIOLATION transitório no Windows (AV/indexer/teardown do handle
+// do processo do serviço que acabou de morrer). Fora do Windows a 1ª tentativa
+// sucede. São variáveis para permitir override em testes.
+var (
+	renameRetries = 5
+	renameBackoff = 100 * time.Millisecond
+)
+
+// renameWithRetry tenta renomear com backoff — defesa contra sharing violation
+// transitória logo após o processo do serviço encerrar.
+func renameWithRetry(oldPath, newPath string) error {
+	var err error
+	for i := 0; i < renameRetries; i++ {
+		if err = renameFile(oldPath, newPath); err == nil {
+			return nil
+		}
+		if i < renameRetries-1 {
+			time.Sleep(renameBackoff)
+		}
+	}
+	return err
+}
+
+// restorePrevTo restaura <targetExe>.prev por cima de targetExe usando RENAME
+// (Windows-safe), não cópia: a imagem em uso pode ser renomeada mas não
+// sobrescrita. Ordem obrigatória (Codex F3):
+//  1. valida o .prev ANTES de tocar no target — sem fonte, não mexe em nada
+//     (jamais deixar o serviço sem binário no exePath);
+//  2. move o target (binário ruim, possivelmente em uso) para .bad.<ts>
+//     (preserva para diagnóstico; o destino fica ausente);
+//  3. move o .prev para o target.
+//
+// Se o passo 3 falhar depois do 2, devolve o .bad ao target (best-effort).
+func restorePrevTo(targetExe string) error {
+	prevPath := targetExe + ".prev"
+
+	// 1. Valida a fonte antes de qualquer rename destrutivo.
+	info, err := os.Stat(prevPath)
+	if err != nil {
+		return fmt.Errorf("restore: .prev indisponível (%s): %w", prevPath, err)
+	}
+	if info.Size() == 0 {
+		return fmt.Errorf("restore: .prev vazio (%s) — não restaura", prevPath)
+	}
+
+	// 2. Move o binário atual (ruim) para .bad.<ts>. Renomear a imagem em uso é
+	//    permitido no Windows; sobrescrever não é — por isso o destino fica
+	//    ausente antes do passo 3.
+	badPath := targetExe + ".bad." + strconv.FormatInt(time.Now().UnixNano(), 10)
+	if err := renameWithRetry(targetExe, badPath); err != nil {
+		return fmt.Errorf("restore: mover binário atual para .bad: %w", err)
+	}
+
+	// 3. Coloca o .prev no lugar do target.
+	if err := renameWithRetry(prevPath, targetExe); err != nil {
+		// Reverte: devolve o .bad ao target para não deixar o serviço sem binário.
+		if rbErr := renameFile(badPath, targetExe); rbErr != nil {
+			return fmt.Errorf("restore: mover .prev para target: %w; ROLLBACK FALHOU — exe ficou em %s: %v", err, badPath, rbErr)
+		}
+		return fmt.Errorf("restore: mover .prev para target (revertido ao binário atual): %w", err)
+	}
+
+	return nil
+}
+
+// isQuarantined reporta se `version` está quarentenada (causou um rollback) e deve
+// ser PULADA pelo auto-update até o manifesto publicar uma versão diferente.
+func isQuarantined(version string, st *State) bool {
+	return st.QuarantinedVersion != "" && version == st.QuarantinedVersion
+}
+
+// buildRollbackCommand monta o lpCommand do SC_ACTION_RUN_COMMAND: o ator é a
+// recovery-copy (sempre boota), com caminhos ABSOLUTOS entre aspas (o working dir
+// do SCM não é contrato; paths com espaço, ex. "Program Files", precisam de aspas).
+// Aspas literais, não %q — %q escaparia os "\" do path Windows.
+func buildRollbackCommand(recoveryExe, targetExe string) string {
+	return `"` + recoveryExe + `" rollback --target "` + targetExe + `"`
+}
+
+// parseTargetFlag extrai o valor de `--target` dos argumentos do subcomando
+// rollback (o SCM passa o caminho absoluto do exe a restaurar).
+func parseTargetFlag(args []string) string {
+	for i := 0; i < len(args)-1; i++ {
+		if args[i] == "--target" {
+			return args[i+1]
+		}
+	}
+	return ""
+}
+
+// recoveryExePath é o caminho da recovery-copy ao lado do exe principal.
+func recoveryExePath(exePath string) string {
+	return filepath.Join(filepath.Dir(exePath), recoveryExeName)
+}
+
+// ensureRecoveryCopy grava/atualiza a recovery-copy (cópia estável do exe usada
+// como ator do rollback). Idempotente: não reescreve se já idêntica. O auto-update
+// NUNCA chama esta função — a recovery-copy precisa ficar numa versão boa e estável.
+func ensureRecoveryCopy(exePath string) error {
+	dst := recoveryExePath(exePath)
+	data, err := os.ReadFile(exePath)
+	if err != nil {
+		return fmt.Errorf("recovery-copy: ler exe atual: %w", err)
+	}
+	if existing, err := os.ReadFile(dst); err == nil && bytes.Equal(existing, data) {
+		return nil // já idêntica — evita I/O e churn de mtime
+	}
+	if err := os.WriteFile(dst, data, 0755); err != nil { //nolint:gosec
+		return fmt.Errorf("recovery-copy: gravar %s: %w", dst, err)
+	}
+	return nil
+}
+
+// ensureRecoveryConfigured garante que o serviço tem a rede de recuperação (as
+// failure actions com a 3ª ação run_command) ANTES de um update. Verifica e, se
+// divergir, tenta reparar; se o reparo falhar, retorna erro — o chamador PULA o
+// update, porque ativar um binário novo sem rollback automático é o que o F2
+// proíbe (o os.Exit(90) pós-install passa a depender do SCM para se recuperar). (Codex F5)
+func ensureRecoveryConfigured() error {
+	exePath, err := executablePath()
+	if err != nil {
+		return fmt.Errorf("recovery: caminho do exe: %w", err)
+	}
+	ok, vErr := verifyServiceRecovery(exePath)
+	if ok {
+		return nil
+	}
+	if cErr := configureServiceRecovery(exePath); cErr != nil {
+		return fmt.Errorf("rede de recuperação ausente e reparo falhou (verify=%v): %w", vErr, cErr)
+	}
+	logger.Infof("recovery: ações de recovery do serviço (re)configuradas antes do update")
+	return nil
+}
+
+// As ações de recovery do serviço são syscalls do SCM (recovery_windows.go) por
+// trás de variáveis, para permitir override nos testes do gate/wiring. Em produção
+// apontam para as implementações reais; fora do Windows, para no-ops/stubs.
+// startRecoveredService: o SC_ACTION_RUN_COMMAND do SCM NÃO reinicia o serviço
+// sozinho, então o rollback reinicia explicitamente. (Codex)
+var (
+	configureServiceRecovery = configureServiceRecoveryPlatform
+	verifyServiceRecovery    = verifyServiceRecoveryPlatform
+	startRecoveredService    = startServicePlatform
+)
+
+// doRollback é executado pela recovery-copy (sayersync-recovery.exe) quando o SCM
+// detecta crash-loop de boot do binário novo. Roda num processo FRESCO e BOM
+// (a recovery-copy nunca é atualizada), então NÃO esbarra na armadilha de
+// "o código de restauração vive no binário que não boota". (Codex F2)
+//
+// Quando o run_command do SCM dispara, o serviço já está DOWN (acabou de crashar),
+// então não há concorrência de imagem em uso. Ordem:
+//  1. restaura o .prev por cima do targetExe (rename-based);
+//  2. quarentena a versão ruim (lida de PendingUpdateVersion) e reseta o guard;
+//  3. reinicia o serviço (o SCM não reinicia após run_command).
+func doRollback(targetExe string) error {
+	st, err := LoadState()
+	if err != nil {
+		return fmt.Errorf("rollback: carregar state: %w", err)
+	}
+
+	// A versão que estava sendo ativada é a candidata a quarentena (capturada
+	// antes de limpar PendingUpdateVersion).
+	bad := st.PendingUpdateVersion
+
+	// 1. Restaura o binário anterior (last-known-good).
+	if err := restorePrevTo(targetExe); err != nil {
+		return fmt.Errorf("rollback: %w", err)
+	}
+
+	// 2. Quarentena a versão ruim para o auto-update NÃO reinstalá-la amanhã
+	//    (brick diário). Reseta o crash-loop guard do updater — o rollback resolveu.
+	if bad != "" {
+		st.QuarantinedVersion = bad
+		logger.Warnf("rollback: versão %q quarentenada após crash-loop de boot", bad)
+	}
+	st.PendingUpdateVersion = ""
+	st.UpdateFailCount = 0
+	st.LastUpdateFailure = ""
+	if err := SaveState(st); err != nil {
+		return fmt.Errorf("rollback: persistir state: %w", err)
+	}
+
+	// 3. Reinicia o serviço com o binário restaurado.
+	if err := startRecoveredService(); err != nil {
+		return fmt.Errorf("rollback: reiniciar serviço: %w", err)
+	}
+
+	logger.Infof("rollback: concluído — serviço reiniciado com o binário anterior")
+	return nil
+}

--- a/connector/sayersync/recovery.go
+++ b/connector/sayersync/recovery.go
@@ -144,15 +144,12 @@ func recoveryCopyHealthy(exePath string) bool {
 	return err == nil && info.Size() > 0
 }
 
-// ensureRecoveryCopy grava a recovery-copy (cópia estável do exe usada como ator do
-// rollback) quando ela está AUSENTE ou vazia. PRESERVA uma recovery-copy existente e
-// não-vazia: ela é o ator conhecido-bom, e um repair (ex.: no service start, já com um
-// binário novo rodando) não pode trocá-la por algo não comprovado. O write é atômico
-// (tmp + rename) para que um write parcial não destrua o único ator externo. (Codex P2)
-func ensureRecoveryCopy(exePath string) error {
-	if recoveryCopyHealthy(exePath) {
-		return nil
-	}
+// refreshRecoveryCopy escreve a recovery-copy a partir do exe atual SEMPRE (force),
+// de forma atômica (tmp + rename — REPLACE_EXISTING no Windows). É o caminho do
+// `install` deliberado: um balcão com um ator velho/bugado precisa poder atualizá-lo
+// re-rodando o install (o que o README promete). Um write parcial não destrói o ator
+// porque o destino só é trocado pelo rename atômico. (Codex P1)
+func refreshRecoveryCopy(exePath string) error {
 	dst := recoveryExePath(exePath)
 	data, err := os.ReadFile(exePath)
 	if err != nil {
@@ -167,6 +164,18 @@ func ensureRecoveryCopy(exePath string) error {
 		return fmt.Errorf("recovery-copy: rename atômico para %s: %w", dst, err)
 	}
 	return nil
+}
+
+// ensureRecoveryCopy garante que a recovery-copy existe, PRESERVANDO uma existente e
+// não-vazia (o ator conhecido-bom): um repair automático (service start ou pre-update,
+// já com um binário novo rodando) não pode trocá-la por algo não comprovado. Só
+// (re)cria quando ausente ou vazia (ex.: removida/truncada por AV). O refresh
+// deliberado é só no `install` (refreshRecoveryCopy). (Codex P1/P2)
+func ensureRecoveryCopy(exePath string) error {
+	if recoveryCopyHealthy(exePath) {
+		return nil
+	}
+	return refreshRecoveryCopy(exePath)
 }
 
 // ensureRecoveryConfigured garante que o serviço tem a rede de recuperação (as
@@ -228,7 +237,15 @@ func doRollback(targetExe string) error {
 	//    brick diário) e reseta o guard. Falha aqui NÃO bloqueia o restart — recuperar
 	//    agora vale mais que evitar repetir amanhã. (Codex P1)
 	if st, err := LoadState(); err != nil {
-		logger.Errorf("rollback: state ilegível, pulando quarentena (best-effort): %v", err)
+		// State ilegível: não há como saber qual versão quarentenar. Reseta o
+		// state.json (atômico) para o conector se recuperar nos próximos ciclos — o
+		// próximo doUpdate volta a gravar PendingUpdateVersion, então um eventual
+		// re-loop se auto-quarentena. Os HWMs já estavam perdidos (state ilegível); o
+		// full re-scan semanal é a rede de segurança. (Codex P2)
+		logger.Errorf("rollback: state ilegível (%v) — resetando state.json", err)
+		if sErr := SaveState(&State{HWM: map[string]string{}}); sErr != nil {
+			logger.Errorf("rollback: falha ao resetar state.json: %v", sErr)
+		}
 	} else {
 		if bad := st.PendingUpdateVersion; bad != "" {
 			st.QuarantinedVersion = bad

--- a/connector/sayersync/recovery_other.go
+++ b/connector/sayersync/recovery_other.go
@@ -9,8 +9,9 @@ package main
 import "errors"
 
 // configureServiceRecoveryPlatform configuraria SERVICE_FAILURE_ACTIONS no SCM.
-// No-op fora do Windows.
-func configureServiceRecoveryPlatform(exePath string) error { return nil }
+// Fora do Windows não há SCM, mas a recovery-copy é cross-platform — criá-la mantém
+// o gate F5 (que exige a recovery-copy) coerente em dev/teste.
+func configureServiceRecoveryPlatform(exePath string) error { return ensureRecoveryCopy(exePath) }
 
 // verifyServiceRecoveryPlatform confirmaria a config de recovery via
 // QueryServiceConfig2. Fora do Windows não há serviço a gatear → reporta "ok" para

--- a/connector/sayersync/recovery_other.go
+++ b/connector/sayersync/recovery_other.go
@@ -1,0 +1,24 @@
+//go:build !windows
+
+// recovery_other.go — stubs de plataforma para builds de DEV (macOS/Linux).
+// Não há Windows SCM aqui: as ações de recovery do serviço não existem. Estes
+// stubs deixam o pacote compilar e os testes da lógica cross-platform rodarem;
+// em produção (Windows) valem as implementações de recovery_windows.go.
+package main
+
+import "errors"
+
+// configureServiceRecoveryPlatform configuraria SERVICE_FAILURE_ACTIONS no SCM.
+// No-op fora do Windows.
+func configureServiceRecoveryPlatform(exePath string) error { return nil }
+
+// verifyServiceRecoveryPlatform confirmaria a config de recovery via
+// QueryServiceConfig2. Fora do Windows não há serviço a gatear → reporta "ok" para
+// não bloquear dev/teste.
+func verifyServiceRecoveryPlatform(exePath string) (bool, error) { return true, nil }
+
+// startServicePlatform reiniciaria o serviço via StartService. Indisponível fora
+// do Windows.
+func startServicePlatform() error {
+	return errors.New("start de serviço suportado apenas no Windows")
+}

--- a/connector/sayersync/recovery_test.go
+++ b/connector/sayersync/recovery_test.go
@@ -288,6 +288,41 @@ func TestDoRollback_restoresQuarantinesAndRestarts(t *testing.T) {
 	}
 }
 
+// Codex P1: restaurar o binário e reiniciar são PRIMARY; a quarentena é best-effort.
+// Um state.json corrompido não pode bloquear a recuperação de um crash-loop.
+func TestDoRollback_corruptStateStillRestoresAndRestarts(t *testing.T) {
+	dir := t.TempDir()
+	exe := filepath.Join(dir, "sayersync.exe")
+	if err := os.WriteFile(exe, []byte("BAD"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(exe+".prev", []byte("GOOD"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	origStateDir := stateDir
+	stateDir = func() string { return dir }
+	defer func() { stateDir = origStateDir }()
+	if err := os.WriteFile(filepath.Join(dir, "state.json"), []byte("{not valid json"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	started := false
+	origStart := startRecoveredService
+	startRecoveredService = func() error { started = true; return nil }
+	defer func() { startRecoveredService = origStart }()
+
+	if err := doRollback(exe); err != nil {
+		t.Fatalf("doRollback não deveria falhar por state corrompido: %v", err)
+	}
+	if got, _ := os.ReadFile(exe); string(got) != "GOOD" {
+		t.Errorf("restore deveria acontecer apesar do state corrompido: got %q", got)
+	}
+	if !started {
+		t.Error("serviço deveria reiniciar apesar do state corrompido")
+	}
+}
+
 // ─────────────────────────────────────────────────────────────
 // buildRollbackCommand — lpCommand do SC_ACTION_RUN_COMMAND (F2)
 // ─────────────────────────────────────────────────────────────
@@ -338,6 +373,47 @@ func TestEnsureRecoveryCopy_createsStableCopy(t *testing.T) {
 	}
 	if string(got) != "BINARY-V2" {
 		t.Errorf("recovery-copy = %q, want BINARY-V2", got)
+	}
+}
+
+func TestRecoveryCopyHealthy(t *testing.T) {
+	dir := t.TempDir()
+	exe := filepath.Join(dir, "sayersync.exe")
+	if recoveryCopyHealthy(exe) {
+		t.Error("sem recovery-copy deveria ser unhealthy")
+	}
+	if err := os.WriteFile(recoveryExePath(exe), []byte("actor"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if !recoveryCopyHealthy(exe) {
+		t.Error("recovery-copy não-vazia deveria ser healthy")
+	}
+	if err := os.WriteFile(recoveryExePath(exe), nil, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if recoveryCopyHealthy(exe) {
+		t.Error("recovery-copy vazia deveria ser unhealthy")
+	}
+}
+
+// Codex P2: a recovery-copy é o ATOR estável; um repair (ex.: no service start, já
+// com um binário novo rodando) NÃO pode sobrescrevê-la com um binário não-comprovado.
+func TestEnsureRecoveryCopy_preservesExistingActor(t *testing.T) {
+	dir := t.TempDir()
+	exe := filepath.Join(dir, "sayersync.exe")
+	if err := os.WriteFile(exe, []byte("NEW-UNPROVEN-BINARY"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	rec := recoveryExePath(exe)
+	if err := os.WriteFile(rec, []byte("OLD-GOOD-ACTOR"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ensureRecoveryCopy(exe); err != nil {
+		t.Fatal(err)
+	}
+	if got, _ := os.ReadFile(rec); string(got) != "OLD-GOOD-ACTOR" {
+		t.Errorf("ensureRecoveryCopy sobrescreveu o ator estável: got %q", got)
 	}
 }
 

--- a/connector/sayersync/recovery_test.go
+++ b/connector/sayersync/recovery_test.go
@@ -321,6 +321,11 @@ func TestDoRollback_corruptStateStillRestoresAndRestarts(t *testing.T) {
 	if !started {
 		t.Error("serviço deveria reiniciar apesar do state corrompido")
 	}
+	// Auto-cura: o state.json corrompido deve ter sido resetado para o conector se
+	// recuperar nos próximos ciclos (LoadState volta a funcionar). (Codex P2)
+	if _, err := LoadState(); err != nil {
+		t.Errorf("state.json deveria ter sido resetado, mas LoadState ainda falha: %v", err)
+	}
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -414,6 +419,27 @@ func TestEnsureRecoveryCopy_preservesExistingActor(t *testing.T) {
 	}
 	if got, _ := os.ReadFile(rec); string(got) != "OLD-GOOD-ACTOR" {
 		t.Errorf("ensureRecoveryCopy sobrescreveu o ator estável: got %q", got)
+	}
+}
+
+// Codex P1: o `install` deliberado DEVE refrescar o ator — um balcão com uma
+// recovery-copy velha/bugada precisa poder atualizá-la re-rodando install.
+func TestRefreshRecoveryCopy_overwritesExistingActor(t *testing.T) {
+	dir := t.TempDir()
+	exe := filepath.Join(dir, "sayersync.exe")
+	if err := os.WriteFile(exe, []byte("NEW-FIXED-BINARY"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	rec := recoveryExePath(exe)
+	if err := os.WriteFile(rec, []byte("OLD-BUGGY-ACTOR"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := refreshRecoveryCopy(exe); err != nil {
+		t.Fatal(err)
+	}
+	if got, _ := os.ReadFile(rec); string(got) != "NEW-FIXED-BINARY" {
+		t.Errorf("refreshRecoveryCopy não atualizou o ator: got %q", got)
 	}
 }
 

--- a/connector/sayersync/recovery_test.go
+++ b/connector/sayersync/recovery_test.go
@@ -1,0 +1,389 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// ─────────────────────────────────────────────────────────────
+// restorePrevTo — restauração rename-based (F3 + fonte do rollback)
+// ─────────────────────────────────────────────────────────────
+
+func TestRestorePrevTo_renameBased(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "sayersync.exe")
+	prev := target + ".prev"
+
+	if err := os.WriteFile(target, []byte("BAD-binary"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(prev, []byte("GOOD-prev-binary"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := restorePrevTo(target); err != nil {
+		t.Fatalf("restorePrevTo: %v", err)
+	}
+
+	// target agora deve ter o conteúdo do .prev (bom).
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("ler target restaurado: %v", err)
+	}
+	if string(got) != "GOOD-prev-binary" {
+		t.Errorf("target não foi restaurado: got %q, want %q", got, "GOOD-prev-binary")
+	}
+
+	// .prev foi consumido (movido para o target).
+	if _, err := os.Stat(prev); !os.IsNotExist(err) {
+		t.Errorf(".prev deveria ter sido movido para o target (ainda existe)")
+	}
+
+	// o binário ruim foi PRESERVADO num .bad* (diagnóstico, não apagado).
+	bads, _ := filepath.Glob(target + ".bad*")
+	if len(bads) == 0 {
+		t.Fatalf("binário ruim deveria ter sido preservado em .bad*")
+	}
+	badContent, _ := os.ReadFile(bads[0])
+	if string(badContent) != "BAD-binary" {
+		t.Errorf(".bad deveria conter o binário ruim, got %q", badContent)
+	}
+}
+
+// Codex: "If .prev is missing, rollback must not move the bad exe away first."
+// Sem .prev, a função falha SEM tocar no target (não deixa o serviço sem binário).
+func TestRestorePrevTo_missingPrev_leavesTargetIntact(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "sayersync.exe")
+	if err := os.WriteFile(target, []byte("current-binary"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	// Sem .prev.
+
+	if err := restorePrevTo(target); err == nil {
+		t.Fatal("restorePrevTo sem .prev deveria retornar erro")
+	}
+
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("target deveria continuar existindo: %v", err)
+	}
+	if string(got) != "current-binary" {
+		t.Errorf("target não deveria ter sido tocado quando .prev falta, got %q", got)
+	}
+	// Não deixou .bad para trás.
+	if bads, _ := filepath.Glob(target + ".bad*"); len(bads) != 0 {
+		t.Errorf("não deveria ter criado .bad quando .prev falta: %v", bads)
+	}
+}
+
+// Invariante de ORDEM (Codex): sem .prev válido, o target em uso NÃO pode ser
+// movido — nem transitoriamente. Spy em renameFile pega a violação que o assert de
+// resultado mascararia (o rollback-on-fail "conserta" o estado final).
+func TestRestorePrevTo_missingPrev_neverMovesTarget(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "sayersync.exe")
+	if err := os.WriteFile(target, []byte("current"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	var renames [][2]string
+	orig := renameFile
+	renameFile = func(o, n string) error { renames = append(renames, [2]string{o, n}); return orig(o, n) }
+	defer func() { renameFile = orig }()
+
+	_ = restorePrevTo(target) // erro esperado; o que importa é o que NÃO foi movido
+
+	for _, r := range renames {
+		if r[0] == target {
+			t.Errorf("o target foi movido com .prev ausente (origem %q → %q) — viola a ordem do Codex", r[0], r[1])
+		}
+	}
+}
+
+// restorePrev() (guard interno) deve usar o caminho rename-based (F3): a impl
+// antiga os.WriteFile(exe, prevData) falharia no Windows (exe em uso). Provamos
+// que é rename-based pela presença do .bad — que a versão WriteFile não cria.
+func TestRestorePrev_usesRenameBased(t *testing.T) {
+	dir := t.TempDir()
+	exe := filepath.Join(dir, "sayersync.exe")
+	if err := os.WriteFile(exe, []byte("BAD"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(exe+".prev", []byte("GOOD"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	orig := executablePath
+	executablePath = func() (string, error) { return exe, nil }
+	defer func() { executablePath = orig }()
+
+	if err := restorePrev(); err != nil {
+		t.Fatalf("restorePrev: %v", err)
+	}
+	if got, _ := os.ReadFile(exe); string(got) != "GOOD" {
+		t.Errorf("restorePrev não restaurou: got %q", got)
+	}
+	if bads, _ := filepath.Glob(exe + ".bad*"); len(bads) == 0 {
+		t.Errorf("restorePrev deveria ser rename-based (nenhum .bad criado)")
+	}
+}
+
+// ─────────────────────────────────────────────────────────────
+// isQuarantined — pular a versão que causou rollback (F2)
+// ─────────────────────────────────────────────────────────────
+
+func TestIsQuarantined(t *testing.T) {
+	st := &State{QuarantinedVersion: "1.2.3"}
+	if !isQuarantined("1.2.3", st) {
+		t.Error("versão igual à quarentenada deveria ser pulada")
+	}
+	if isQuarantined("1.2.4", st) {
+		t.Error("versão diferente da quarentenada não deveria ser pulada")
+	}
+	if isQuarantined("1.2.3", &State{}) {
+		t.Error("sem QuarantinedVersion, nada é pulado")
+	}
+}
+
+// doUpdate deve PULAR a versão quarentenada já no manifesto — sem nem baixar o
+// binário. (executablePath é isolado para um tmp para que, se a quarentena
+// falhasse e o fluxo prosseguisse, o installBinary não tocasse o binário do
+// próprio test runner.)
+func TestDoUpdate_skipsQuarantinedVersion(t *testing.T) {
+	bin := []byte("bad-binary-v999")
+	binHits := 0
+	binSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		binHits++
+		_, _ = w.Write(bin)
+	}))
+	defer binSrv.Close()
+
+	manifest := UpdateManifest{Version: "999.0.0", SHA256: sha256Hex(bin), URL: binSrv.URL}
+	mSrv := serveManifest(t, manifest)
+	defer mSrv.Close()
+
+	dir := t.TempDir()
+	exe := filepath.Join(dir, "sayersync.exe")
+	if err := os.WriteFile(exe, []byte("current"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	origExe := executablePath
+	executablePath = func() (string, error) { return exe, nil }
+	defer func() { executablePath = origExe }()
+
+	cfg := &Config{UpdateManifestURL: mSrv.URL}
+	st := &State{QuarantinedVersion: "999.0.0"}
+
+	installed, err := doUpdate(context.Background(), cfg, st)
+	if err != nil {
+		t.Fatalf("doUpdate: %v", err)
+	}
+	if installed {
+		t.Error("não deveria instalar versão quarentenada")
+	}
+	if binHits != 0 {
+		t.Errorf("não deveria baixar binário quarentenado: %d hits", binHits)
+	}
+}
+
+// Ao instalar com sucesso, doUpdate registra a versão em PendingUpdateVersion
+// (para o rollback saber o que quarentenar) e limpa qualquer quarentena anterior
+// (a nova versão supera a ruim passada).
+func TestDoUpdate_setsPendingVersionAndClearsQuarantine(t *testing.T) {
+	bin := []byte("good-binary-v2")
+	binSrv := serveBinary(t, bin)
+	defer binSrv.Close()
+
+	manifest := UpdateManifest{Version: "2.0.0", SHA256: sha256Hex(bin), URL: binSrv.URL}
+	mSrv := serveManifest(t, manifest)
+	defer mSrv.Close()
+
+	dir := t.TempDir()
+	exe := filepath.Join(dir, "sayersync.exe")
+	if err := os.WriteFile(exe, []byte("v1-current"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	origExe := executablePath
+	executablePath = func() (string, error) { return exe, nil }
+	defer func() { executablePath = origExe }()
+
+	cfg := &Config{UpdateManifestURL: mSrv.URL}
+	st := &State{QuarantinedVersion: "1.0.0"} // quarentena antiga, de outra versão
+
+	installed, err := doUpdate(context.Background(), cfg, st)
+	if err != nil {
+		t.Fatalf("doUpdate: %v", err)
+	}
+	if !installed {
+		t.Fatal("deveria ter instalado a 2.0.0")
+	}
+	if st.PendingUpdateVersion != "2.0.0" {
+		t.Errorf("PendingUpdateVersion = %q, want 2.0.0", st.PendingUpdateVersion)
+	}
+	if st.QuarantinedVersion != "" {
+		t.Errorf("instalar versão nova deveria limpar a quarentena antiga, got %q", st.QuarantinedVersion)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────
+// doRollback — ator externo: restaura .prev + quarentena + reinicia (F2)
+// ─────────────────────────────────────────────────────────────
+
+func TestDoRollback_restoresQuarantinesAndRestarts(t *testing.T) {
+	dir := t.TempDir()
+	exe := filepath.Join(dir, "sayersync.exe")
+	if err := os.WriteFile(exe, []byte("BAD-v999"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(exe+".prev", []byte("GOOD-v2"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// state.json no tmp, com a versão ruim "pendente" (que estava sendo ativada).
+	origStateDir := stateDir
+	stateDir = func() string { return dir }
+	defer func() { stateDir = origStateDir }()
+	if err := SaveState(&State{
+		PendingUpdateVersion: "999.0.0",
+		UpdateFailCount:      2,
+		LastUpdateFailure:    "2026-01-01T00:00:00Z",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Não inicia serviço real no teste; só registra que foi chamado.
+	started := false
+	origStart := startRecoveredService
+	startRecoveredService = func() error { started = true; return nil }
+	defer func() { startRecoveredService = origStart }()
+
+	if err := doRollback(exe); err != nil {
+		t.Fatalf("doRollback: %v", err)
+	}
+
+	// 1. binário restaurado (rename-based).
+	if got, _ := os.ReadFile(exe); string(got) != "GOOD-v2" {
+		t.Errorf("exe não restaurado: got %q", got)
+	}
+	// 2. a versão ruim foi quarentenada; pending limpo; guard resetado.
+	st, _ := LoadState()
+	if st.QuarantinedVersion != "999.0.0" {
+		t.Errorf("QuarantinedVersion = %q, want 999.0.0", st.QuarantinedVersion)
+	}
+	if st.PendingUpdateVersion != "" {
+		t.Errorf("PendingUpdateVersion deveria ser limpo, got %q", st.PendingUpdateVersion)
+	}
+	if st.UpdateFailCount != 0 {
+		t.Errorf("UpdateFailCount deveria resetar, got %d", st.UpdateFailCount)
+	}
+	// 3. serviço reiniciado (run_command do SCM não reinicia sozinho).
+	if !started {
+		t.Error("doRollback deveria reiniciar o serviço")
+	}
+}
+
+// ─────────────────────────────────────────────────────────────
+// buildRollbackCommand — lpCommand do SC_ACTION_RUN_COMMAND (F2)
+// ─────────────────────────────────────────────────────────────
+
+func TestBuildRollbackCommand_absoluteQuotedNoEscape(t *testing.T) {
+	recovery := `C:\Program Files\sayer\sayersync-recovery.exe`
+	target := `C:\Program Files\sayer\sayersync.exe`
+	got := buildRollbackCommand(recovery, target)
+	want := `"C:\Program Files\sayer\sayersync-recovery.exe" rollback --target "C:\Program Files\sayer\sayersync.exe"`
+	if got != want {
+		t.Errorf("buildRollbackCommand =\n  %s\nwant\n  %s", got, want)
+	}
+}
+
+func TestParseTargetFlag(t *testing.T) {
+	if got := parseTargetFlag([]string{"rollback", "--target", `C:\x\sayersync.exe`}); got != `C:\x\sayersync.exe` {
+		t.Errorf("got %q, want C:\\x\\sayersync.exe", got)
+	}
+	if got := parseTargetFlag([]string{"rollback"}); got != "" {
+		t.Errorf("sem flag deveria ser vazio, got %q", got)
+	}
+	if got := parseTargetFlag([]string{"rollback", "--target"}); got != "" {
+		t.Errorf("--target sem valor deveria ser vazio, got %q", got)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────
+// ensureRecoveryCopy — cópia estável que atua no rollback (F2)
+// ─────────────────────────────────────────────────────────────
+
+func TestEnsureRecoveryCopy_createsStableCopy(t *testing.T) {
+	dir := t.TempDir()
+	exe := filepath.Join(dir, "sayersync.exe")
+	if err := os.WriteFile(exe, []byte("BINARY-V2"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := recoveryExePath(exe); got != filepath.Join(dir, recoveryExeName) {
+		t.Errorf("recoveryExePath = %q, want %q", got, filepath.Join(dir, recoveryExeName))
+	}
+
+	if err := ensureRecoveryCopy(exe); err != nil {
+		t.Fatalf("ensureRecoveryCopy: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, recoveryExeName))
+	if err != nil {
+		t.Fatalf("recovery-copy não criada: %v", err)
+	}
+	if string(got) != "BINARY-V2" {
+		t.Errorf("recovery-copy = %q, want BINARY-V2", got)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────
+// Gate F5 — não ativa update sem rede de recuperação
+// ─────────────────────────────────────────────────────────────
+
+func TestDoUpdate_skipsWhenRecoveryUnconfigurable(t *testing.T) {
+	bin := []byte("new-binary-v5")
+	binHits := 0
+	binSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		binHits++
+		_, _ = w.Write(bin)
+	}))
+	defer binSrv.Close()
+
+	manifest := UpdateManifest{Version: "5.0.0", SHA256: sha256Hex(bin), URL: binSrv.URL}
+	mSrv := serveManifest(t, manifest)
+	defer mSrv.Close()
+
+	dir := t.TempDir()
+	exe := filepath.Join(dir, "sayersync.exe")
+	if err := os.WriteFile(exe, []byte("current"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	origExe := executablePath
+	executablePath = func() (string, error) { return exe, nil }
+	defer func() { executablePath = origExe }()
+
+	// Recovery não configurado E o reparo falha (ex.: sem permissão no SCM).
+	origV, origC := verifyServiceRecovery, configureServiceRecovery
+	verifyServiceRecovery = func(string) (bool, error) { return false, nil }
+	configureServiceRecovery = func(string) error { return errors.New("sem acesso ao SCM") }
+	defer func() { verifyServiceRecovery, configureServiceRecovery = origV, origC }()
+
+	cfg := &Config{UpdateManifestURL: mSrv.URL}
+	st := &State{}
+	installed, err := doUpdate(context.Background(), cfg, st)
+
+	if err == nil {
+		t.Error("doUpdate deveria falhar quando não há rede de recuperação")
+	}
+	if installed {
+		t.Error("não deveria instalar sem rede de recuperação")
+	}
+	if binHits != 0 {
+		t.Errorf("não deveria nem baixar sem rede de recuperação: %d hits", binHits)
+	}
+}

--- a/connector/sayersync/recovery_windows.go
+++ b/connector/sayersync/recovery_windows.go
@@ -104,6 +104,13 @@ func verifyServiceRecoveryPlatform(exePath string) (bool, error) {
 		acts[2].Type != windows.SC_ACTION_RUN_COMMAND {
 		return false, nil
 	}
+	// Também os delays e o ResetPeriod: uma config com a sequência certa mas delays
+	// enormes passaria e deixaria a recuperação inutilizavelmente lenta. (Codex P2)
+	if acts[0].Delay != recoveryRestartDelayMs1 ||
+		acts[1].Delay != recoveryRestartDelayMs2 ||
+		acts[2].Delay != recoveryRunCmdDelayMs {
+		return false, nil
+	}
 	if fa.ResetPeriod != recoveryResetPeriodSec {
 		return false, nil
 	}

--- a/connector/sayersync/recovery_windows.go
+++ b/connector/sayersync/recovery_windows.go
@@ -1,0 +1,148 @@
+//go:build windows
+
+// recovery_windows.go — syscalls do Windows SCM para o recovery de crash-loop de
+// boot (Codex F2). Estende a recovery do serviço com uma 3ª ação SC_ACTION_RUN_COMMAND
+// que o SCM executa, num processo FRESCO, após N crashes consecutivos — apontando
+// para a recovery-copy estável `<dir>\sayersync-recovery.exe rollback --target <exe>`.
+//
+// O kardianos/service só configura "restart" simples; aqui vamos direto no SCM via
+// ChangeServiceConfig2/QueryServiceConfig2. Verificação ponta-a-ponta exige um
+// balcão Windows real (a semântica de contagem/reset do SCM não se reproduz fora dele).
+package main
+
+import (
+	"fmt"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+const (
+	// Delays das ações de recovery (ms). Curtos: queremos recuperar rápido.
+	recoveryRestartDelayMs1 = 10_000
+	recoveryRestartDelayMs2 = 30_000
+	recoveryRunCmdDelayMs   = 5_000
+
+	// dwResetPeriod (s): zera o contador de falhas do SCM após este tempo SEM
+	// falha. 1h fica BEM abaixo da cadência diária de update (senão o os.Exit(90)
+	// de updates saudáveis acumularia até a 3ª ação) e bem acima da duração de um
+	// loop de crash de boot (segundos), que assim alcança a ação run_command. (Codex)
+	recoveryResetPeriodSec = 3600
+)
+
+// configureServiceRecoveryPlatform grava a recovery-copy e configura
+// [restart, restart, run_command] no SCM. Idempotente (install + reparo).
+func configureServiceRecoveryPlatform(exePath string) error {
+	// A recovery-copy precisa existir ANTES — o lpCommand a referencia.
+	if err := ensureRecoveryCopy(exePath); err != nil {
+		return err
+	}
+
+	svc, closeFn, err := openServiceForAccess(windows.SERVICE_CHANGE_CONFIG | windows.SERVICE_START)
+	if err != nil {
+		return err
+	}
+	defer closeFn()
+
+	cmdPtr, err := windows.UTF16PtrFromString(buildRollbackCommand(recoveryExePath(exePath), exePath))
+	if err != nil {
+		return fmt.Errorf("recovery: codificar lpCommand: %w", err)
+	}
+
+	actions := []windows.SC_ACTION{
+		{Type: windows.SC_ACTION_RESTART, Delay: recoveryRestartDelayMs1},
+		{Type: windows.SC_ACTION_RESTART, Delay: recoveryRestartDelayMs2},
+		{Type: windows.SC_ACTION_RUN_COMMAND, Delay: recoveryRunCmdDelayMs},
+	}
+	fa := windows.SERVICE_FAILURE_ACTIONS{
+		ResetPeriod:  recoveryResetPeriodSec,
+		Command:      cmdPtr,
+		ActionsCount: uint32(len(actions)),
+		Actions:      &actions[0],
+	}
+	if err := windows.ChangeServiceConfig2(svc, windows.SERVICE_CONFIG_FAILURE_ACTIONS, (*byte)(unsafe.Pointer(&fa))); err != nil {
+		return fmt.Errorf("recovery: ChangeServiceConfig2(FAILURE_ACTIONS): %w", err)
+	}
+	return nil
+}
+
+// verifyServiceRecoveryPlatform confirma que a recovery do serviço está EXATAMENTE
+// como configureServiceRecovery deixaria (3 ações, a 3ª = run_command apontando para
+// a recovery-copy correta). Retorna (false, nil) quando a config diverge — o chamador
+// decide reparar ou pular o update.
+func verifyServiceRecoveryPlatform(exePath string) (bool, error) {
+	svc, closeFn, err := openServiceForAccess(windows.SERVICE_QUERY_CONFIG)
+	if err != nil {
+		return false, err
+	}
+	defer closeFn()
+
+	// 1ª chamada: descobre o tamanho do buffer.
+	var needed uint32
+	err = windows.QueryServiceConfig2(svc, windows.SERVICE_CONFIG_FAILURE_ACTIONS, nil, 0, &needed)
+	if err != nil && err != windows.ERROR_INSUFFICIENT_BUFFER {
+		return false, fmt.Errorf("recovery: QueryServiceConfig2(tamanho): %w", err)
+	}
+	if needed == 0 {
+		return false, nil
+	}
+	buf := make([]byte, needed)
+	if err := windows.QueryServiceConfig2(svc, windows.SERVICE_CONFIG_FAILURE_ACTIONS, &buf[0], needed, &needed); err != nil {
+		return false, fmt.Errorf("recovery: QueryServiceConfig2: %w", err)
+	}
+
+	fa := (*windows.SERVICE_FAILURE_ACTIONS)(unsafe.Pointer(&buf[0]))
+	if fa.ActionsCount < 3 || fa.Actions == nil {
+		return false, nil
+	}
+	acts := unsafe.Slice(fa.Actions, fa.ActionsCount)
+	if acts[2].Type != windows.SC_ACTION_RUN_COMMAND {
+		return false, nil
+	}
+	gotCmd := ""
+	if fa.Command != nil {
+		gotCmd = windows.UTF16PtrToString(fa.Command)
+	}
+	return gotCmd == buildRollbackCommand(recoveryExePath(exePath), exePath), nil
+}
+
+// startServicePlatform reinicia o serviço (chamado pelo rollback: o SCM NÃO
+// reinicia após SC_ACTION_RUN_COMMAND). "Já rodando" não é erro.
+func startServicePlatform() error {
+	svc, closeFn, err := openServiceForAccess(windows.SERVICE_START)
+	if err != nil {
+		return err
+	}
+	defer closeFn()
+
+	if err := windows.StartService(svc, 0, nil); err != nil {
+		if err == windows.ERROR_SERVICE_ALREADY_RUNNING {
+			return nil
+		}
+		return fmt.Errorf("start: StartService: %w", err)
+	}
+	return nil
+}
+
+// openServiceForAccess abre o SCM e o serviço SayerSync com o acesso pedido,
+// devolvendo o handle do serviço e um closer que fecha ambos.
+func openServiceForAccess(access uint32) (windows.Handle, func(), error) {
+	mgr, err := windows.OpenSCManager(nil, nil, windows.SC_MANAGER_CONNECT)
+	if err != nil {
+		return 0, nil, fmt.Errorf("recovery: OpenSCManager: %w", err)
+	}
+	namePtr, err := windows.UTF16PtrFromString(serviceName)
+	if err != nil {
+		windows.CloseServiceHandle(mgr)
+		return 0, nil, err
+	}
+	svc, err := windows.OpenService(mgr, namePtr, access)
+	if err != nil {
+		windows.CloseServiceHandle(mgr)
+		return 0, nil, fmt.Errorf("recovery: OpenService(%s): %w", serviceName, err)
+	}
+	return svc, func() {
+		windows.CloseServiceHandle(svc)
+		windows.CloseServiceHandle(mgr)
+	}, nil
+}

--- a/connector/sayersync/recovery_windows.go
+++ b/connector/sayersync/recovery_windows.go
@@ -96,7 +96,15 @@ func verifyServiceRecoveryPlatform(exePath string) (bool, error) {
 		return false, nil
 	}
 	acts := unsafe.Slice(fa.Actions, fa.ActionsCount)
-	if acts[2].Type != windows.SC_ACTION_RUN_COMMAND {
+	// Valida TODA a sequência, não só a 3ª ação: sem os 2 restarts antes, o binário
+	// ruim não é relançado e a ação run_command nunca é alcançada; e o ResetPeriod
+	// errado pode zerar o contador antes da 3ª falha (ou acumular falsos). (Codex P1)
+	if acts[0].Type != windows.SC_ACTION_RESTART ||
+		acts[1].Type != windows.SC_ACTION_RESTART ||
+		acts[2].Type != windows.SC_ACTION_RUN_COMMAND {
+		return false, nil
+	}
+	if fa.ResetPeriod != recoveryResetPeriodSec {
 		return false, nil
 	}
 	gotCmd := ""

--- a/connector/sayersync/state.go
+++ b/connector/sayersync/state.go
@@ -48,6 +48,20 @@ type State struct {
 	// campo a janela nunca expirava → brick permanente após 3 falhas. Zera junto
 	// com UpdateFailCount ao primeiro update sem falha.
 	LastUpdateFailure string `json:"last_update_failure,omitempty"`
+
+	// PendingUpdateVersion é a versão que o auto-update acabou de instalar e vai
+	// ativar via restart (gravada ANTES do os.Exit 90). Se o binário novo entra
+	// em crash-loop de BOOT, o rollback externo (sayersync-recovery.exe) lê este
+	// campo para saber QUAL versão quarentenar. Sobrescrita a cada install; só é
+	// lida no rollback. (Codex F2)
+	PendingUpdateVersion string `json:"pending_update_version,omitempty"`
+
+	// QuarantinedVersion é a versão que causou um rollback (binário ruim). doUpdate
+	// PULA esta versão no manifesto até o manifesto publicar OUTRA — senão, após o
+	// rollback, o binário restaurado reinstalaria o mesmo manifesto ruim no dia
+	// seguinte (brick DIÁRIO em vez de permanente). Limpa quando uma versão
+	// diferente é instalada. (Codex F2)
+	QuarantinedVersion string `json:"quarantined_version,omitempty"`
 }
 
 // stateDir retorna o diretório onde state.json é lido/gravado. É uma variável

--- a/connector/sayersync/update.go
+++ b/connector/sayersync/update.go
@@ -208,6 +208,21 @@ func doUpdate(ctx context.Context, cfg *Config, st *State) (bool, error) {
 		logger.Infof("update: versão atual %q já é a mais recente (manifesto: %q)", Version, manifest.Version)
 		return false, nil
 	}
+	// Quarentena (Codex F2): se esta versão já causou um rollback, NÃO reinstala —
+	// senão o binário restaurado reinstalaria o mesmo manifesto ruim no dia seguinte
+	// (brick diário). Só desbloqueia quando o manifesto publicar uma versão diferente.
+	if isQuarantined(manifest.Version, st) {
+		logger.Warnf("update: versão %q quarentenada (causou rollback anterior) — pulando até o manifesto publicar outra", manifest.Version)
+		return false, nil
+	}
+
+	// Gate F5 (Codex): não ativa um update sem a rede de recuperação no lugar.
+	// Verifica/repara as failure actions do serviço ANTES de baixar; se não der,
+	// pula — melhor ficar na versão atual do que ativar uma sem rollback automático.
+	if err := ensureRecoveryConfigured(); err != nil {
+		return false, fmt.Errorf("doUpdate: %w", err)
+	}
+
 	logger.Infof("update: nova versão disponível %q (atual: %q) — baixando", manifest.Version, Version)
 
 	// 3. Baixa o binário.
@@ -225,6 +240,12 @@ func doUpdate(ctx context.Context, cfg *Config, st *State) (bool, error) {
 	if err := installBinary(binData); err != nil {
 		return false, fmt.Errorf("doUpdate: instalar binário: %w", err)
 	}
+
+	// Registra a versão recém-instalada para o rollback externo saber QUAL versão
+	// quarentenar se ela quebrar no boot; e limpa qualquer quarentena anterior —
+	// esta versão a supera. Persistido antes do restart por CheckAndApplyUpdate. (Codex F2)
+	st.PendingUpdateVersion = manifest.Version
+	st.QuarantinedVersion = ""
 
 	logger.Infof("update: versão %q instalada — reiniciando o serviço para ativar", manifest.Version)
 	return true, nil
@@ -384,22 +405,16 @@ func installBinary(data []byte) error {
 // restorePrev — crash-loop guard
 // ─────────────────────────────────────────────────────────────
 
-// restorePrev restaura o binário anterior a partir de <exe>.prev.
+// restorePrev restaura o binário anterior a partir de <exe>.prev sobre o exe em
+// execução. Delega a restorePrevTo (rename-based, Windows-safe): a versão antiga
+// os.WriteFile(exePath, ...) falhava no Windows porque exePath é a imagem em uso
+// — mesma classe do P1 corrigido em installBinary. (Codex F3)
 func restorePrev() error {
 	exePath, err := executablePath()
 	if err != nil {
 		return err
 	}
-	prevPath := exePath + ".prev"
-
-	prevData, err := os.ReadFile(prevPath)
-	if err != nil {
-		return fmt.Errorf("ler .prev: %w", err)
-	}
-	if err := os.WriteFile(exePath, prevData, 0755); err != nil { //nolint:gosec
-		return fmt.Errorf("restaurar .prev para exe: %w", err)
-	}
-	return nil
+	return restorePrevTo(exePath)
 }
 
 // ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## O que / por quê

Fecha **F2/F3/F5** do auto-updater do conector `sayersync` — o gap que deve ser resolvido **antes** de ligar o auto-update em produção (hoje dormente: só ativa com `update_manifest_url` preenchido + bucket `releases`).

**F2 (review do Codex):** o crash-loop guard contava falhas do *updater* (fetch/download/sha256/install), não crashes do *serviço*. Um binário que passa no sha256 mas panica no boot era relançado para sempre pelo SCM e o `.prev` nunca era restaurado — o código de restauração vive no mesmo binário que não boota.

## Como (ator EXTERNO ao binário que quebra — Claude + Codex challenge)

- **F2 ator externo:** recovery-copy estável (`sayersync-recovery.exe`, intocada pelo auto-update) + `.prev` como fonte. `SERVICE_FAILURE_ACTIONS [restart, restart, run_command]` via `ChangeServiceConfig2` (`dwResetPeriod=3600`). Após 2 restarts falhos, o SCM roda `sayersync-recovery.exe rollback --target <exe>` num processo fresco que restaura o `.prev` e reinicia o serviço.
- **F2 quarentena:** `state.json` guarda `pending_update_version`/`quarantined_version`; `doUpdate` pula a versão que causou rollback até o manifesto publicar outra (senão vira brick *diário*).
- **F3:** `restorePrev` rename-based (`exe→.bad`, `.prev→exe`) — `os.WriteFile` no exe em uso falha no Windows.
- **F5:** gate triplo (install, service start, e antes de cada troca de binário).

Arquivos novos: `recovery.go` (lógica cross-platform), `recovery_windows.go` (syscalls SCM), `recovery_other.go` (stubs dev), subcomando `rollback`.

## Testes

- TDD: 10 testes novos (red→green em cada). `go test ./...` verde de dentro de `connector/sayersync/`.
- Falsificação: sabotei a validação do `.prev` → o teste de ordem ficou vermelho.
- Cross-build `GOOS=windows` ok; `gofmt`/`go vet` limpos.
- ⚠️ O CI `validate` provavelmente não roda os testes Go (módulo separado).

## ⚠️ Por que DRAFT

Verificação ponta-a-ponta **exige um balcão Windows real** — a semântica do SCM (contagem de falhas, `dwResetPeriod`, execução do `run_command`) só se observa no Windows. Antes de tornar não-draft / ligar o auto-update:

1. Redeploy manual desta versão (rollback-capable) + `sayersync.exe install` (recria recovery-copy + failure actions).
2. Publicar um release **deliberadamente quebrado** (compila, passa sha256, panica no boot) → confirmar que o rollback dispara, o `.prev` é restaurado, o balcão volta a sincronizar e a versão ruim fica quarentenada.
3. Só então preencher `update_manifest_url`.

## Notas de coordenação

Inclui a base `ce694ae2` (P1/P2/F1/F6/F7/F8) da sessão irmã `strange-jennings` via `merge --ff-only` (mesmo SHA → não colide se aquela mergear). Se a sessão irmã abrir PR de `ce694ae2`, ele vira redundante — convém fechá-la.

## Limites ainda abertos (documentados, fora de escopo)

- **F4:** power-loss entre os 2 renames do restore (só um launcher dedicado resolve).
- **F9:** sha256 ≠ autenticidade (assinar releases: chave pinada / Authenticode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
