### PR TITLE
feat(vendas): cursor+lease pro backfill confiável de pedidos Omie (sub-projeto 1)

### DIFF
--- a/db/test-sales_orders_omie_hash_unique.sh
+++ b/db/test-sales_orders_omie_hash_unique.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# ╔══════════════════════════════════════════════════════════════════════════════╗
+# ║  HARNESS PG17 — uniq_sales_orders_omie_hash (idempotência do sync de pedidos)  ║
+# ║  Prova: dup omie_ é REJEITADA (23505); dup NÃO-omie passa (índice parcial);    ║
+# ║  o escape LIKE 'omie\_%' escopa certo. Falsifica dropando o índice.            ║
+# ║  Rodar:  bash db/test-sales_orders_omie_hash_unique.sh > /tmp/t.log 2>&1; echo $? ║
+# ╚══════════════════════════════════════════════════════════════════════════════╝
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PGVER=17
+PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+PORT="${PGPORT_TEST:-5458}"
+SLUG="sales_orders_omie_hash_unique"
+DATA="$(mktemp -d "/tmp/pgtest-${SLUG}.XXXXXX")/data"
+export LC_ALL=C LANG=C
+
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente: brew install postgresql@${PGVER} pgvector"; exit 1; }
+CELLAR="$(brew --prefix "postgresql@${PGVER}")"
+cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
+mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
+cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
+
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+trap cleanup EXIT
+
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l "/tmp/pg-${SLUG}.log" -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres prove
+P()  { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d prove -v ON_ERROR_STOP=1 "$@"; }
+Pq() { P -tA "$@"; }
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  ✅ $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  ❌ $1"; }
+
+echo "═══ setup pronto (PG17 :$PORT) ═══"
+
+# ZONA 1 — stub mínimo de sales_orders (só o que o índice toca)
+P -q <<'SQL'
+CREATE TABLE IF NOT EXISTS public.sales_orders (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  account text,
+  hash_payload text,
+  status text
+);
+-- semeia o que existe em prod: pedidos omie_ (devem ser únicos) + placeholders não-omie (488 dups OK)
+INSERT INTO public.sales_orders(account, hash_payload, status) VALUES
+  ('oben',   'omie_oben_5001',  'importado'),
+  ('colacor','omie_colacor_900','importado'),
+  ('oben',   '-cah8zx',         'cancelado'),
+  ('oben',   '-cah8zx',         'cancelado');   -- dup NÃO-omie já existente: o índice parcial DEVE ignorar
+SQL
+
+# ZONA 2 — aplica a migration REAL
+MIG="$REPO_ROOT/supabase/migrations/20260617133634_sales_orders_omie_hash_unique.sql"
+P -q -f "$MIG"
+echo "migration aplicada: $(basename "$MIG")"
+
+# ZONA 3 — asserts
+echo "── asserts ──"
+
+# A1: índice criou (apesar das 488 dups não-omie pré-existentes) → predicado escopou certo
+IDX=$(Pq -c "SELECT count(*) FROM pg_indexes WHERE indexname='uniq_sales_orders_omie_hash';")
+[ "$IDX" = "1" ] && ok "A1 índice criado mesmo com dup não-omie pré-existente (predicado escopa)" || bad "A1 índice não criado (IDX=$IDX)"
+
+# A2: dup de pedido omie_ é REJEITADA (23505) — a idempotência money-path
+R=$(P -tA 2>&1 <<'SQL'
+DO $$ BEGIN
+  INSERT INTO public.sales_orders(account, hash_payload) VALUES ('oben','omie_oben_5001');
+  RAISE EXCEPTION 'DUP_NAO_BARROU';
+EXCEPTION WHEN unique_violation THEN RAISE NOTICE 'OMIE_DUP_BLOCKED';
+  WHEN OTHERS THEN RAISE; END $$;
+SQL
+)
+case "$R" in *OMIE_DUP_BLOCKED*) ok "A2 dup omie_ rejeitada (unique_violation) — idempotência travada" ;; *) bad "A2 — veio: $R" ;; esac
+
+# A3: dup NÃO-omie PASSA (índice parcial não cobre placeholders) — não quebra pedido manual/cancelado
+if P -q -c "INSERT INTO public.sales_orders(account, hash_payload) VALUES ('oben','-cah8zx');" >/dev/null 2>&1; then
+  ok "A3 dup não-omie passa (índice parcial ignora — não quebra pedido manual)"
+else
+  bad "A3 índice barrou um hash não-omie (predicado amplo demais)"
+fi
+
+# A4: mesmo hash em conta diferente passa (índice é por (account, hash_payload))
+if P -q -c "INSERT INTO public.sales_orders(account, hash_payload) VALUES ('colacor','omie_oben_5001');" >/dev/null 2>&1; then
+  ok "A4 (account,hash) — mesmo hash em conta distinta é permitido"
+else
+  bad "A4 índice barrou cross-account (deveria ser por account+hash)"
+fi
+
+# ZONA 4 — FALSIFICAÇÃO: dropa o índice → a dup omie_ que ANTES barrava agora PASSA
+echo "── falsificação ──"
+P -q -c "DROP INDEX public.uniq_sales_orders_omie_hash;"
+if P -q -c "INSERT INTO public.sales_orders(account, hash_payload) VALUES ('oben','omie_oben_5001');" >/dev/null 2>&1; then
+  ok "F1 sem o índice a dup omie_ passa (A2 tinha dente)"
+else
+  bad "F1 droppei o índice e a dup AINDA falhou → A2 não provava o índice"
+fi
+P -q -f "$MIG" >/dev/null 2>&1 || echo "  (nota: re-aplicar falha pq a falsificação já inseriu dup — esperado; o índice real é idempotente em prod limpa)"
+
+echo "──────────────────────────────"
+echo "RESULTADO: $PASS ok / $FAIL fail"
+[ "$FAIL" = "0" ] || { echo "❌ HARNESS VERMELHO"; exit 1; }
+echo "✅ HARNESS VERDE"

--- a/db/test-vendas_sync_cursor.sh
+++ b/db/test-vendas_sync_cursor.sh
@@ -1,0 +1,343 @@
+#!/usr/bin/env bash
+# ╔══════════════════════════════════════════════════════════════════════════════╗
+# ║  HARNESS PG17 — vendas_sync_cursor (cursor + lease do backfill de pedidos)     ║
+# ║  Prova money-path: serialização real (lease), retomada por next_page,         ║
+# ║  completude SÓ com fim-real, RLS (staff lê / service escreve / RPC gated),     ║
+# ║  e a lógica do cron de continuação (1 http_post por conta, a janela + antiga). ║
+# ║  Rodar:  bash db/test-vendas_sync_cursor.sh > /tmp/t.log 2>&1; echo "exit=$?"  ║
+# ╚══════════════════════════════════════════════════════════════════════════════╝
+set -euo pipefail
+
+# ── arranque PG17 descartável (contorna keg-only do brew) ──
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PGVER=17
+PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+PORT="${PGPORT_TEST:-5457}"
+SLUG="vendas_sync_cursor"
+DATA="$(mktemp -d "/tmp/pgtest-${SLUG}.XXXXXX")/data"
+export LC_ALL=C LANG=C
+
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente: brew install postgresql@${PGVER} pgvector"; exit 1; }
+
+CELLAR="$(brew --prefix "postgresql@${PGVER}")"
+cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
+mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
+cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
+
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+trap cleanup EXIT
+
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l "/tmp/pg-${SLUG}.log" -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres prove
+P()  { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d prove -v ON_ERROR_STOP=1 "$@"; }
+Pq() { P -tA "$@"; }
+
+P -q -f "$REPO_ROOT/db/stubs-supabase.sql"
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION auth.uid()  RETURNS uuid LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.uid',  true), '')::uuid $f$;
+CREATE OR REPLACE FUNCTION auth.role() RETURNS text LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.role', true), '') $f$;
+ALTER ROLE service_role BYPASSRLS;
+SQL
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  ✅ $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  ❌ $1"; }
+eq()  { if [ "$2" = "$3" ]; then ok "$1 (=$2)"; else bad "$1 — esperado [$3], veio [$2]"; fi; }
+
+echo "═══ setup pronto (PG17 :$PORT) ═══"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 1 — PRÉ-REQUISITOS (o que a migração lê/usa mas não cria):
+#   app_role + user_roles (RLS); cron/net/vault stubados p/ a migração REAL aplicar.
+# ══════════════════════════════════════════════════════════════════════════════
+P -q <<'SQL'
+DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname='app_role') THEN
+  CREATE TYPE public.app_role AS ENUM ('master','employee','customer'); END IF; END $$;
+CREATE TABLE IF NOT EXISTS public.user_roles (user_id uuid, role public.app_role);
+
+-- pg_cron: o schema + cron.job já vêm do stubs-supabase.sql (jobid bigint PK, sem unique em jobname).
+-- Só faltam as FUNÇÕES schedule/unschedule — GUARDAM o command (pra eu EXECUTAR a string REAL depois).
+CREATE OR REPLACE FUNCTION cron.schedule(p_jobname text, p_schedule text, p_command text)
+RETURNS bigint LANGUAGE plpgsql AS $$
+DECLARE v_id bigint;
+BEGIN
+  DELETE FROM cron.job WHERE jobname = p_jobname;          -- delete-then-insert (sem unique em jobname)
+  v_id := COALESCE((SELECT max(jobid) FROM cron.job), 0) + 1;
+  INSERT INTO cron.job(jobid, jobname, schedule, command, active) VALUES (v_id, p_jobname, p_schedule, p_command, true);
+  RETURN v_id;
+END $$;
+CREATE OR REPLACE FUNCTION cron.unschedule(p_jobname text)
+RETURNS boolean LANGUAGE sql AS $$ DELETE FROM cron.job WHERE jobname=$1; SELECT true; $$;
+
+-- pg_net stub: net.http_post REGISTRA cada chamada (assinatura nomeada idêntica à real).
+CREATE SCHEMA IF NOT EXISTS net;
+CREATE TABLE net._calls (id serial PRIMARY KEY, url text, body jsonb);
+CREATE OR REPLACE FUNCTION net.http_post(
+  url text, body jsonb DEFAULT '{}'::jsonb, params jsonb DEFAULT '{}'::jsonb,
+  headers jsonb DEFAULT '{}'::jsonb, timeout_milliseconds integer DEFAULT 5000)
+RETURNS bigint LANGUAGE sql AS $$
+  INSERT INTO net._calls(url, body) VALUES (url, body);
+  SELECT count(*)::bigint FROM net._calls; $$;
+
+-- vault stub (o cron lê o CRON_SECRET).
+CREATE SCHEMA IF NOT EXISTS vault;
+CREATE TABLE vault.decrypted_secrets (name text, decrypted_secret text);
+INSERT INTO vault.decrypted_secrets VALUES ('CRON_SECRET','test-secret');
+SQL
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 2 — APLICAR A MIGRATION REAL (Lei #1)
+# ══════════════════════════════════════════════════════════════════════════════
+MIG="$REPO_ROOT/supabase/migrations/20260617133633_vendas_sync_cursor.sql"
+P -q -f "$MIG"
+echo "migration aplicada: $(basename "$MIG")"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 3 — SEED + GRANTS
+# ══════════════════════════════════════════════════════════════════════════════
+P -q <<'SQL'
+INSERT INTO auth.users(id) VALUES
+  ('11111111-1111-1111-1111-111111111111'),   -- staff (employee)
+  ('22222222-2222-2222-2222-222222222222')    -- não-staff (customer)
+  ON CONFLICT DO NOTHING;
+INSERT INTO public.user_roles(user_id, role) VALUES
+  ('11111111-1111-1111-1111-111111111111','employee'),
+  ('22222222-2222-2222-2222-222222222222','customer') ON CONFLICT DO NOTHING;
+
+-- Janela base pros asserts de RPC (oben): pendente, retomar da pág 3.
+INSERT INTO public.vendas_sync_cursor(account, date_from, date_to, next_page)
+VALUES ('oben','2025-01-01','2025-01-31', 3);
+-- Janela colacor pro heartbeat.
+INSERT INTO public.vendas_sync_cursor(account, date_from, date_to, next_page)
+VALUES ('colacor','2025-03-01','2025-03-31', 1);
+
+-- migration é --no-privileges; concede SELECT p/ os asserts de RLS (a RLS filtra por cima).
+GRANT SELECT ON public.vendas_sync_cursor, public.user_roles TO authenticated, anon;
+SQL
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 4 — ASSERTS
+# ══════════════════════════════════════════════════════════════════════════════
+echo "── asserts: lease + cursor (money-path core) ──"
+
+# N1 + P2: serialização real. 1º acquire pega e RETOMA da pág 3 (não 1); 2º no-opa (lease vivo).
+A1=$(Pq -c "SELECT public.vendas_sync_lease_acquire('oben','2025-01-01','2025-01-31');")
+A2=$(Pq -c "SELECT public.vendas_sync_lease_acquire('oben','2025-01-01','2025-01-31');")
+eq "N1/P2 1º acquire pega e retoma do next_page" "$A1" "3"
+eq "N1 2º acquire no-opa (lease vivo → NULL)"     "$A2" ""
+
+# N3: lease MORTO (heartbeat > 3 min) é re-adquirível (retomada após crash).
+P -q -c "UPDATE public.vendas_sync_cursor SET heartbeat_at = now() - interval '4 minutes'
+         WHERE account='oben' AND date_from='2025-01-01';" >/dev/null
+A3=$(Pq -c "SELECT public.vendas_sync_lease_acquire('oben','2025-01-01','2025-01-31');")
+eq "N3 lease morto (>3min) re-adquirível"         "$A3" "3"
+
+# P4: finish PAUSA (budget/transitório) — mantém next_page, grava last_error_kind, NÃO completa, libera lease.
+Pq -c "SELECT public.vendas_sync_finish('oben','2025-01-01','2025-01-31', false, 7, 'rate_limit');" >/dev/null
+NP=$(Pq  -c "SELECT next_page FROM public.vendas_sync_cursor WHERE account='oben' AND date_from='2025-01-01';")
+CN=$(Pq  -c "SELECT completed_at IS NULL FROM public.vendas_sync_cursor WHERE account='oben' AND date_from='2025-01-01';")
+EK=$(Pq  -c "SELECT last_error_kind FROM public.vendas_sync_cursor WHERE account='oben' AND date_from='2025-01-01';")
+RS=$(Pq  -c "SELECT running_since IS NULL FROM public.vendas_sync_cursor WHERE account='oben' AND date_from='2025-01-01';")
+eq "P4 pausa mantém next_page"               "$NP" "7"
+eq "P4 pausa NÃO seta completed_at"          "$CN" "t"
+eq "P4 pausa grava last_error_kind"          "$EK" "rate_limit"
+eq "P4 pausa libera o lease"                 "$RS" "t"
+
+# P3: finish COMPLETE (fim real) — seta completed_at, limpa next_page e last_error_kind.
+Pq -c "SELECT public.vendas_sync_finish('oben','2025-01-01','2025-01-31', true, NULL, NULL);" >/dev/null
+DONE=$(Pq -c "SELECT completed_at IS NOT NULL FROM public.vendas_sync_cursor WHERE account='oben' AND date_from='2025-01-01';")
+NP2=$(Pq  -c "SELECT next_page FROM public.vendas_sync_cursor WHERE account='oben' AND date_from='2025-01-01';")
+EK2=$(Pq  -c "SELECT last_error_kind FROM public.vendas_sync_cursor WHERE account='oben' AND date_from='2025-01-01';")
+eq "P3 complete seta completed_at"           "$DONE" "t"
+eq "P3 complete limpa next_page"             "$NP2"  ""
+eq "P3 complete limpa last_error_kind"       "$EK2"  ""
+
+# N2: janela COMPLETA não é re-adquirível (completed_at IS NULL filtra).
+A4=$(Pq -c "SELECT public.vendas_sync_lease_acquire('oben','2025-01-01','2025-01-31');")
+eq "N2 janela completa não re-adquirível"    "$A4" ""
+
+# P5: heartbeat renova lease E PERSISTE progresso (next_page := página em curso); janela LIVRE intocada.
+Pq -c "SELECT public.vendas_sync_lease_acquire('colacor','2025-03-01','2025-03-31');" >/dev/null
+P -q -c "UPDATE public.vendas_sync_cursor SET heartbeat_at = now() - interval '2 minutes'
+         WHERE account='colacor' AND date_from='2025-03-01';" >/dev/null
+Pq -c "SELECT public.vendas_sync_heartbeat('colacor','2025-03-01','2025-03-31', 4);" >/dev/null  # processando pág 4
+HB=$(Pq -c "SELECT heartbeat_at > now() - interval '10 seconds' FROM public.vendas_sync_cursor WHERE account='colacor' AND date_from='2025-03-01';")
+NPH=$(Pq -c "SELECT next_page FROM public.vendas_sync_cursor WHERE account='colacor' AND date_from='2025-03-01';")
+eq "P5 heartbeat renova lease vivo"                       "$HB"  "t"
+eq "P5 heartbeat PERSISTE progresso (next_page=em curso)" "$NPH" "4"
+# guard: janela LIVRE (sem lease) → heartbeat não toca heartbeat NEM next_page
+P -q -c "UPDATE public.vendas_sync_cursor SET running_since=NULL, next_page=4, heartbeat_at=now()-interval '5 minutes'
+         WHERE account='colacor' AND date_from='2025-03-01';" >/dev/null
+Pq -c "SELECT public.vendas_sync_heartbeat('colacor','2025-03-01','2025-03-31', 9);" >/dev/null  # tenta avançar p/ 9
+HBF=$(Pq -c "SELECT heartbeat_at < now() - interval '4 minutes' FROM public.vendas_sync_cursor WHERE account='colacor' AND date_from='2025-03-01';")
+NPF=$(Pq -c "SELECT next_page FROM public.vendas_sync_cursor WHERE account='colacor' AND date_from='2025-03-01';")
+eq "P5 heartbeat NÃO renova janela livre"                "$HBF" "t"
+eq "P5 heartbeat NÃO avança next_page de janela livre"   "$NPF" "4"
+
+# P6: erro INESPERADO não rebobina — release preserva o next_page que o heartbeat persistiu (fix Codex).
+P -q -c "INSERT INTO public.vendas_sync_cursor(account,date_from,date_to,next_page) VALUES ('oben','2027-01-01','2027-01-31',1);" >/dev/null
+Pq -c "SELECT public.vendas_sync_lease_acquire('oben','2027-01-01','2027-01-31');" >/dev/null  # resume=1
+Pq -c "SELECT public.vendas_sync_heartbeat('oben','2027-01-01','2027-01-31', 6);" >/dev/null    # progrediu até a pág 6
+Pq -c "SELECT public.vendas_sync_release('oben','2027-01-01','2027-01-31', 'error');" >/dev/null  # erro inesperado escapou
+NPR=$(Pq -c "SELECT next_page FROM public.vendas_sync_cursor WHERE account='oben' AND date_from='2027-01-01';")
+RSR=$(Pq -c "SELECT running_since IS NULL FROM public.vendas_sync_cursor WHERE account='oben' AND date_from='2027-01-01';")
+EKR=$(Pq -c "SELECT last_error_kind FROM public.vendas_sync_cursor WHERE account='oben' AND date_from='2027-01-01';")
+CAR=$(Pq -c "SELECT completed_at IS NULL FROM public.vendas_sync_cursor WHERE account='oben' AND date_from='2027-01-01';")
+eq "P6 release NÃO rebobina (next_page=6 do heartbeat, não 1)" "$NPR" "6"
+eq "P6 release solta o lease"                                  "$RSR" "t"
+eq "P6 release grava o kind"                                   "$EKR" "error"
+eq "P6 release NÃO completa"                                   "$CAR" "t"
+
+echo "── asserts: CHECK constraints ──"
+# N5 account inválido
+R=$(P -tA 2>&1 <<'SQL'
+DO $$ BEGIN
+  INSERT INTO public.vendas_sync_cursor(account,date_from,date_to) VALUES ('xpto','2025-01-01','2025-01-31');
+  RAISE EXCEPTION 'CHECK_NAO_BARROU';
+EXCEPTION WHEN check_violation THEN RAISE NOTICE 'ACCOUNT_CHECK_OK';
+  WHEN OTHERS THEN RAISE; END $$;
+SQL
+)
+case "$R" in *ACCOUNT_CHECK_OK*) ok "N5 CHECK account rejeita inválido" ;; *) bad "N5 — veio: $R" ;; esac
+
+# N6 last_error_kind inválido
+R=$(P -tA 2>&1 <<'SQL'
+DO $$ BEGIN
+  INSERT INTO public.vendas_sync_cursor(account,date_from,date_to,last_error_kind)
+    VALUES ('oben','2099-01-01','2099-01-31','bogus');
+  RAISE EXCEPTION 'CHECK_NAO_BARROU';
+EXCEPTION WHEN check_violation THEN RAISE NOTICE 'KIND_CHECK_OK';
+  WHEN OTHERS THEN RAISE; END $$;
+SQL
+)
+case "$R" in *KIND_CHECK_OK*) ok "N6 CHECK last_error_kind rejeita inválido" ;; *) bad "N6 — veio: $R" ;; esac
+
+echo "── asserts: RLS + gate de EXECUTE ──"
+# R1 staff lê / R3 não-staff não vê / R2 anon não vê
+TOTAL=$(Pq -c "SELECT count(*) FROM public.vendas_sync_cursor;")   # superuser vê tudo (a verdade)
+STAFF=$(Pq -c "SET test.uid='11111111-1111-1111-1111-111111111111'; SET ROLE authenticated; SELECT count(*) FROM public.vendas_sync_cursor;" | tail -1)
+NOSTAFF=$(Pq -c "SET test.uid='22222222-2222-2222-2222-222222222222'; SET ROLE authenticated; SELECT count(*) FROM public.vendas_sync_cursor;" | tail -1)
+ANON=$(Pq -c "SET ROLE anon; SELECT count(*) FROM public.vendas_sync_cursor;" | tail -1)
+eq "R1 staff vê TODAS as janelas (== total)" "$STAFF" "$TOTAL"
+eq "R3 não-staff (customer) não vê"  "$NOSTAFF" "0"
+eq "R2 anon não vê"                  "$ANON"    "0"
+
+# R4 anon/authenticated NÃO executam o RPC de lease (REVOKE → insufficient_privilege 42501)
+R=$(P -tA 2>&1 <<'SQL'
+SET ROLE authenticated;
+DO $$ BEGIN
+  PERFORM public.vendas_sync_lease_acquire('oben','2025-01-01','2025-01-31');
+  RAISE EXCEPTION 'EXECUTE_NAO_BARROU';
+EXCEPTION WHEN insufficient_privilege THEN RAISE NOTICE 'EXECUTE_GATED_OK';
+  WHEN OTHERS THEN RAISE; END $$;
+SQL
+)
+case "$R" in *EXECUTE_GATED_OK*) ok "R4 authenticated NÃO executa lease_acquire (REVOKE)" ;; *) bad "R4 — veio: $R" ;; esac
+
+echo "── asserts: cron de continuação (DISTINCT ON account, janela + antiga) ──"
+# Limpa e semeia: oben com DUAS janelas pendentes (deve disparar só a + antiga) + colacor pendente + 1 completa.
+P -q <<'SQL'
+TRUNCATE net._calls;
+DELETE FROM public.vendas_sync_cursor;
+INSERT INTO public.vendas_sync_cursor(account,date_from,date_to,next_page,completed_at) VALUES
+  ('oben',   '2024-01-01','2024-01-31', 1, NULL),         -- + antiga do oben → DEVE disparar
+  ('oben',   '2024-02-01','2024-02-29', 1, NULL),         -- + nova do oben  → NÃO dispara (DISTINCT ON)
+  ('colacor','2024-05-01','2024-05-31', 1, NULL),         -- colacor          → DEVE disparar
+  ('oben',   '2023-12-01','2023-12-31', NULL, now());     -- completa         → NÃO dispara
+SQL
+# EXECUTA a string de comando REAL que a migração agendou (sem cópia → sem drift).
+P -q <<'SQL'
+DO $exec$ DECLARE c text; BEGIN
+  SELECT command INTO c FROM cron.job WHERE jobname='vendas-sync-continuacao-6min';
+  EXECUTE c;
+END $exec$;
+SQL
+NCALLS=$(Pq -c "SELECT count(*) FROM net._calls;")
+OBENWIN=$(Pq -c "SELECT body->>'date_from' FROM net._calls WHERE body->>'account'='oben';")
+eq "C1 cron dispara 1 http_post por conta pendente" "$NCALLS"  "2"
+eq "C2 cron escolhe a janela + ANTIGA do oben"      "$OBENWIN" "01/01/2024"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 5 — FALSIFICAÇÃO (Lei #3): sabota → exige VERMELHO → restaura
+# ══════════════════════════════════════════════════════════════════════════════
+echo "── falsificação ──"
+
+# F1: lease SEM a cláusula de concorrência → 2 acquires na mesma janela passam os dois (serialização morre).
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION public.vendas_sync_lease_acquire(p_account text, p_date_from date, p_date_to date)
+RETURNS integer LANGUAGE sql SECURITY DEFINER SET search_path = public, pg_temp AS $fn$
+  UPDATE public.vendas_sync_cursor SET running_since=now(), heartbeat_at=now()
+   WHERE account=p_account AND date_from=p_date_from AND date_to=p_date_to  -- SABOTADO: sem o guard de lease
+  RETURNING COALESCE(next_page,1);
+$fn$;
+INSERT INTO public.vendas_sync_cursor(account,date_from,date_to,next_page) VALUES ('oben','2030-01-01','2030-01-31',5);
+SQL
+S1=$(Pq -c "SELECT public.vendas_sync_lease_acquire('oben','2030-01-01','2030-01-31');")
+S2=$(Pq -c "SELECT public.vendas_sync_lease_acquire('oben','2030-01-01','2030-01-31');")
+if [ -n "$S1" ] && [ -n "$S2" ]; then ok "F1 lease furado deixa 2 acquires passarem (N1 tem dente)"; else bad "F1 sabotei o lease e N1 não mudou → assert fraco"; fi
+P -q -f "$MIG" >/dev/null   # restaura
+
+# F2: finish que SEMPRE seta completed_at (mesmo em pausa) → P4 "NÃO completa" viraria vermelho.
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION public.vendas_sync_finish(p_account text, p_date_from date, p_date_to date,
+  p_complete boolean, p_next_page integer, p_last_error_kind text)
+RETURNS void LANGUAGE sql SECURITY DEFINER SET search_path = public, pg_temp AS $fn$
+  UPDATE public.vendas_sync_cursor
+     SET next_page = CASE WHEN p_complete THEN NULL ELSE p_next_page END,
+         completed_at = now(),                 -- SABOTADO: completa mesmo em pausa
+         last_error_kind = CASE WHEN p_complete THEN NULL ELSE p_last_error_kind END,
+         running_since = NULL, heartbeat_at = now()
+   WHERE account=p_account AND date_from=p_date_from AND date_to=p_date_to;
+$fn$;
+INSERT INTO public.vendas_sync_cursor(account,date_from,date_to,next_page) VALUES ('oben','2031-01-01','2031-01-31',2);
+SQL
+Pq -c "SELECT public.vendas_sync_finish('oben','2031-01-01','2031-01-31', false, 4, 'rate_limit');" >/dev/null
+CNF=$(Pq -c "SELECT completed_at IS NULL FROM public.vendas_sync_cursor WHERE account='oben' AND date_from='2031-01-01';")
+if [ "$CNF" = "f" ]; then ok "F2 finish furado completa em pausa (P4 'NÃO completa' tem dente)"; else bad "F2 sabotei finish e completed_at seguiu NULL → assert fraco"; fi
+P -q -f "$MIG" >/dev/null   # restaura
+
+# F3: policy de SELECT como USING(true) → anon passaria a ver (R2 tem dente).
+P -q <<'SQL'
+DROP POLICY IF EXISTS "vendas_sync_cursor_select_staff" ON public.vendas_sync_cursor;
+CREATE POLICY "vendas_sync_cursor_select_staff" ON public.vendas_sync_cursor FOR SELECT USING (true);
+SQL
+ANON2=$(Pq -c "SET ROLE anon; SELECT count(*) FROM public.vendas_sync_cursor;" | tail -1)
+if [ "$ANON2" != "0" ]; then ok "F3 policy furada (USING true) deixa anon ver (R2 tem dente)"; else bad "F3 furei a policy e anon seguiu sem ver → assert fraco"; fi
+P -q -f "$MIG" >/dev/null   # restaura
+
+# F4: GRANT EXECUTE a authenticated → R4 deixaria de barrar.
+P -q -c "GRANT EXECUTE ON FUNCTION public.vendas_sync_lease_acquire(text,date,date) TO authenticated;" >/dev/null
+R=$(P -tA 2>&1 <<'SQL'
+SET ROLE authenticated;
+DO $$ BEGIN
+  PERFORM public.vendas_sync_lease_acquire('zzz','2025-01-01','2025-01-31');  -- conta inexistente: roda mas não barra por privilégio
+  RAISE NOTICE 'EXECUTOU_SEM_BARRAR';
+EXCEPTION WHEN insufficient_privilege THEN RAISE NOTICE 'AINDA_BARRA';
+  WHEN OTHERS THEN RAISE; END $$;
+SQL
+)
+case "$R" in *EXECUTOU_SEM_BARRAR*) ok "F4 com GRANT a authenticated o RPC executa (R4 tem dente)" ;; *) bad "F4 concedi EXECUTE e R4 seguiu barrando → assert fraco: $R" ;; esac
+P -q -f "$MIG" >/dev/null   # restaura (re-REVOKE)
+
+# F5: heartbeat que NÃO persiste progresso (versão antiga) → o rewind volta (P6 perde o dente).
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION public.vendas_sync_heartbeat(p_account text, p_date_from date, p_date_to date, p_page integer)
+RETURNS void LANGUAGE sql SECURITY DEFINER SET search_path = public, pg_temp AS $fn$
+  UPDATE public.vendas_sync_cursor SET heartbeat_at = now()  -- SABOTADO: não grava next_page
+   WHERE account=p_account AND date_from=p_date_from AND date_to=p_date_to AND running_since IS NOT NULL;
+$fn$;
+INSERT INTO public.vendas_sync_cursor(account,date_from,date_to,next_page) VALUES ('oben','2032-01-01','2032-01-31',1);
+SQL
+Pq -c "SELECT public.vendas_sync_lease_acquire('oben','2032-01-01','2032-01-31');" >/dev/null
+Pq -c "SELECT public.vendas_sync_heartbeat('oben','2032-01-01','2032-01-31', 6);" >/dev/null
+Pq -c "SELECT public.vendas_sync_release('oben','2032-01-01','2032-01-31', 'error');" >/dev/null
+NPS=$(Pq -c "SELECT next_page FROM public.vendas_sync_cursor WHERE account='oben' AND date_from='2032-01-01';")
+if [ "$NPS" = "1" ]; then ok "F5 heartbeat furado rebobina p/ 1 (P6 'não rebobina' tem dente)"; else bad "F5 sabotei o heartbeat e o next_page seguiu $NPS≠1 → P6 fraco"; fi
+P -q -f "$MIG" >/dev/null   # restaura
+
+# ── veredito ──
+echo "──────────────────────────────"
+echo "RESULTADO: $PASS ok / $FAIL fail"
+[ "$FAIL" = "0" ] || { echo "❌ HARNESS VERMELHO"; exit 1; }
+echo "✅ HARNESS VERDE"

--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,14 +21,14 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **256** custom migrations totais
-- **974** objetos esperados (criados por estas migrations)
+- **258** custom migrations totais
+- **984** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
-  - `function`: 264
-  - `rls_policy`: 217
-  - `index`: 183
-  - `table`: 107
-  - `cron_job`: 106
+  - `function`: 268
+  - `rls_policy`: 219
+  - `index`: 185
+  - `table`: 108
+  - `cron_job`: 107
   - `trigger`: 48
   - `view`: 45
   - `enum_value`: 4
@@ -2270,6 +2270,26 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 ### `20260617091500_sinal_classe_config_check_classe.sql`
 
 > _Nenhum objeto extraído via regex._ Migration provavelmente é `ALTER TABLE` / `UPDATE` / `INSERT` / RLS-only. Validar manualmente.
+
+### `20260617133633_vendas_sync_cursor.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `public.vendas_sync_lease_acquire` | — |
+| `function` | `public.vendas_sync_heartbeat` | — |
+| `function` | `public.vendas_sync_release` | — |
+| `function` | `public.vendas_sync_finish` | — |
+| `table` | `public.vendas_sync_cursor` | — |
+| `index` | `public.idx_vendas_sync_cursor_pendentes` | `vendas_sync_cursor` |
+| `cron_job` | `cron.vendas-sync-continuacao-6min` | — |
+| `rls_policy` | `public.vendas_sync_cursor_select_staff` | `vendas_sync_cursor` |
+| `rls_policy` | `public.vendas_sync_cursor_service_all` | `vendas_sync_cursor` |
+
+### `20260617133634_sales_orders_omie_hash_unique.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `index` | `public.uniq_sales_orders_omie_hash` | `sales_orders` |
 
 ## Próximos passos quando algo der `❌`
 

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 256
+-- Total de custom migrations: 258
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -275,7 +275,9 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260616130000', 'v_grupo_contatos', '20260616130000_v_grupo_contatos.sql'),
   ('20260616140000', 'v_grupo_comercial', '20260616140000_v_grupo_comercial.sql'),
   ('20260616140941', 'fatia2_sinais_ligacao', '20260616140941_fatia2_sinais_ligacao.sql'),
-  ('20260617091500', 'sinal_classe_config_check_classe', '20260617091500_sinal_classe_config_check_classe.sql')
+  ('20260617091500', 'sinal_classe_config_check_classe', '20260617091500_sinal_classe_config_check_classe.sql'),
+  ('20260617133633', 'vendas_sync_cursor', '20260617133633_vendas_sync_cursor.sql'),
+  ('20260617133634', 'sales_orders_omie_hash_unique', '20260617133634_sales_orders_omie_hash_unique.sql')
 )
 SELECT
   e.version,
@@ -1267,7 +1269,17 @@ WITH expected_objects (migration, kind, schema_name, object_name, parent_name) A
   ('fatia2_sinais_ligacao', 'trigger', 'public', 'trg_farmer_calls_enqueue_recalc_sinais', 'farmer_calls'),
   ('fatia2_sinais_ligacao', 'rls_policy', 'public', 'sinal_classe_config_select_staff', 'sinal_classe_config'),
   ('fatia2_sinais_ligacao', 'rls_policy', 'public', 'sinal_classe_config_master_all', 'sinal_classe_config'),
-  ('fatia2_sinais_ligacao', 'rls_policy', 'public', 'sinal_classe_config_service_all', 'sinal_classe_config')
+  ('fatia2_sinais_ligacao', 'rls_policy', 'public', 'sinal_classe_config_service_all', 'sinal_classe_config'),
+  ('vendas_sync_cursor', 'function', 'public', 'vendas_sync_lease_acquire', ''),
+  ('vendas_sync_cursor', 'function', 'public', 'vendas_sync_heartbeat', ''),
+  ('vendas_sync_cursor', 'function', 'public', 'vendas_sync_release', ''),
+  ('vendas_sync_cursor', 'function', 'public', 'vendas_sync_finish', ''),
+  ('vendas_sync_cursor', 'table', 'public', 'vendas_sync_cursor', ''),
+  ('vendas_sync_cursor', 'index', 'public', 'idx_vendas_sync_cursor_pendentes', 'vendas_sync_cursor'),
+  ('vendas_sync_cursor', 'cron_job', 'cron', 'vendas-sync-continuacao-6min', ''),
+  ('vendas_sync_cursor', 'rls_policy', 'public', 'vendas_sync_cursor_select_staff', 'vendas_sync_cursor'),
+  ('vendas_sync_cursor', 'rls_policy', 'public', 'vendas_sync_cursor_service_all', 'vendas_sync_cursor'),
+  ('sales_orders_omie_hash_unique', 'index', 'public', 'uniq_sales_orders_omie_hash', 'sales_orders')
 )
 SELECT
   e.migration,

--- a/supabase/functions/omie-vendas-sync/index.ts
+++ b/supabase/functions/omie-vendas-sync/index.ts
@@ -1,6 +1,7 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient, type SupabaseClient } from "npm:@supabase/supabase-js@2";
 import { authorizeCronOrStaff } from "../_shared/auth.ts";
+import { omieDateToIso, classifyOmieTransient, classifyPedidosPage } from "./pagination.ts";
 
 type OmieGenericResponse = Record<string, unknown> & { faultstring?: string; codigo_status?: number | string; descricao_status?: string };
 
@@ -906,6 +907,9 @@ async function syncPedidos(
   account: Account = "oben",
   dateFrom?: string, // DD/MM/YYYY
   dateTo?: string,   // DD/MM/YYYY
+  // Modo cursor (backfill): presença ⟹ heartbeat do lease por página + completude
+  // null-discriminada (vendas_sync_cursor). df/dt são as datas ISO (PK do cursor).
+  cursor?: { df: string; dt: string },
 ) {
   let pagina = startPage;
   let totalPaginas = 1;
@@ -914,6 +918,8 @@ async function syncPedidos(
   let pagesProcessed = 0;
   let skippedNoClient = 0;
   let skippedExisting = 0;
+  let reachedEnd = false;            // true SÓ no fim real do Omie (null = "Não existem registros", ou página vazia)
+  let lastErrorKind: 'rate_limit' | 'transient' | 'http' | null = null;
 
   // ── Pre-load document -> user_id mapping from profiles ──
   const docToUserMap = new Map<string, string>();
@@ -1015,13 +1021,18 @@ async function syncPedidos(
   // Helper: resolve codigo_cliente -> user_id (cache-first, API fallback only for unknown)
   async function resolveClientUserId(codigoCliente: number): Promise<string | null> {
     if (clientCache.has(codigoCliente)) return clientCache.get(codigoCliente) || null;
-    // Fallback: call Omie API only for clients NOT in omie_clientes table
+    // Fallback: call Omie API only for clients NOT in omie_clientes table.
+    // Modo cursor (backfill): throwOnTransient — um rate-limit/transitório aqui NÃO pode
+    // virar "cliente ausente" cacheado (#4 Codex): isso pularia o pedido (skippedNoClient)
+    // e a janela poderia COMPLETAR sem ele → perda permanente. Re-lançamos o transitório
+    // p/ o loop PAUSAR a janela e retomar depois (o cliente genuinamente sem doc segue null).
     try {
       const result = (await callOmieVendasApi(
         "geral/clientes/",
         "ConsultarCliente",
         { codigo_cliente_omie: codigoCliente },
-        account
+        account,
+        cursor ? { throwOnTransient: true } : undefined,
       )) as OmieClienteCadastro | null;
       if (!result) {
         clientCache.set(codigoCliente, null);
@@ -1039,6 +1050,11 @@ async function syncPedidos(
         return userId;
       }
     } catch (e) {
+      // Backfill (#A Codex): QUALQUER erro de lookup (transitório, HTTP, rede, fault
+      // não-classificado) re-lança → o loop PAUSA a janela, não cacheia ausência FALSA.
+      // Só o caminho SEM erro cacheia null: `if (!result)` (Omie diz que não existe) e
+      // doc<11 (cliente existe, sem doc usável) — esses são skip LEGÍTIMO, não erro.
+      if (cursor) throw e;
       console.warn(`[sync_pedidos][${account}] ConsultarCliente ${codigoCliente} falhou:`, (e as Error).message);
     }
     clientCache.set(codigoCliente, null);
@@ -1075,27 +1091,67 @@ async function syncPedidos(
     return { address: '', phone: '' };
   }
 
-  // mesmo fix (syncPedidos): força a 1ª iteração p/ startPage>1 funcionar (era no-op). startPage=1 inalterado —
-  // o fluxo do cron (start_page=1 + janela de data) NÃO muda; só destrava paginação manual além de maxPages.
-  while ((pagina <= totalPaginas || pagesProcessed === 0) && pagesProcessed < maxPages) {
+  // Loop de paginação. A COMPLETUDE vem do FIM REAL do Omie — `null` ("Não existem
+  // registros", desambiguado por throwOnTransient) ou página vazia — NUNCA de
+  // total_de_paginas (que mente; CLAUDE.md: "paginar até página vazia + guard").
+  // maxPages limita a invocação; no modo cursor a próxima retoma do next_page.
+  // throwOnTransient distingue rate-limit/transitório (throw → PAUSA, não completa)
+  // de fim real (null) — conserta o defeito #1 do spec (null ambíguo).
+  while (pagesProcessed < maxPages) {
+    // Modo cursor: renova o lease + persiste progresso (next_page := pagina em curso)
+    // ANTES da página longa (~40s/pág + lookups). Crash → retoma daqui, não do run-start.
+    if (cursor) await heartbeatVendasCursor(supabase, account, cursor.df, cursor.dt, pagina);
+
     const listParams: Record<string, unknown> = { pagina, registros_por_pagina: 50, filtrar_apenas_inclusao: "N" };
     if (dateFrom) listParams.filtrar_por_data_de = dateFrom;
     if (dateTo) listParams.filtrar_por_data_ate = dateTo;
 
-    const result = await callOmieVendasApi(
-      "produtos/pedido/",
-      "ListarPedidos",
-      listParams,
-      account
-    );
+    let result: OmieGenericResponse | null = null;
+    try {
+      result = await callOmieVendasApi(
+        "produtos/pedido/",
+        "ListarPedidos",
+        listParams,
+        account,
+        { throwOnTransient: true },
+      );
+    } catch (e) {
+      const msg = (e as Error).message || '';
+      if (msg.startsWith('OMIE_TRANSIENT')) {
+        // rate-limit/transitório esgotado → PAUSA (nextPage retoma, NÃO marca completo).
+        lastErrorKind = classifyOmieTransient(msg);
+        console.log(`[sync_pedidos][${account}] transitório (${lastErrorKind}) na pág ${pagina} — pausa, não marca completo`);
+        break;
+      }
+      if (cursor) {
+        // Erro Omie não-transitório no backfill: pausa graciosa (kind fica visível no
+        // cursor p/ o relatório §4.4), sem derrubar o edge nem marcar completo.
+        lastErrorKind = 'http';
+        console.error(`[sync_pedidos][${account}] erro Omie não-transitório na pág ${pagina} (cursor pausa):`, msg);
+        break;
+      }
+      throw e; // incremental: propaga (comportamento de hoje → 500 + fin_sync_log error)
+    }
 
-    if (!result) {
-      console.log(`[sync_pedidos][${account}] Pedidos sync interrupted by rate limit at page ${pagina}`);
+    const pageClass = classifyPedidosPage(result, pagina);
+    if (pageClass === 'end') {
+      // FIM REAL: result null ("Não existem registros") OU página vazia que não
+      // contradiz total_de_paginas. throwOnTransient garante que NÃO é rate-limit.
+      // Só ISTO completa a janela (nunca total_de_paginas como autoridade de fim).
+      reachedEnd = true;
+      console.log(`[sync_pedidos][${account}] fim real na pág ${pagina} (sem registros)`);
+      break;
+    }
+    if (pageClass === 'anomaly') {
+      // Página vazia CONTRADIZENDO total_de_paginas → suspeito → PAUSA, não completa
+      // (precisão > recall: janela presa visível no cursor > falsa completude silenciosa).
+      lastErrorKind = 'http';
+      console.error(`[sync_pedidos][${account}] ANOMALIA pág ${pagina} vazia mas total_de_paginas diz que há mais — pausa, NÃO completa`);
       break;
     }
 
-    totalPaginas = (result.total_de_paginas as number) || 1;
-    const pedidos: OmiePedidoVendaProduto[] = (result.pedido_venda_produto as OmiePedidoVendaProduto[] | undefined) || [];
+    totalPaginas = (result!.total_de_paginas as number) || 1; // só p/ log/ETA — NÃO decide completude
+    const pedidos: OmiePedidoVendaProduto[] = (result!.pedido_venda_produto as OmiePedidoVendaProduto[] | undefined) || [];
 
     // Resolve only unknown client codes (most should be in cache from omie_clientes)
     const uniqueClientCodes = [...new Set(pedidos.map((p) => p.cabecalho?.codigo_cliente).filter((c): c is number => Boolean(c)))];
@@ -1105,8 +1161,20 @@ async function syncPedidos(
       // Antes: for of await (serial). Agora: chunks de 5 em paralelo pra acelerar
       // sem floodar API Omie (rate limits Omie não documentados; 5 é conservador).
       const CHUNK = 5;
-      for (let i = 0; i < unknownCodes.length; i += CHUNK) {
-        await Promise.all(unknownCodes.slice(i, i + CHUNK).map(c => resolveClientUserId(c)));
+      try {
+        for (let i = 0; i < unknownCodes.length; i += CHUNK) {
+          await Promise.all(unknownCodes.slice(i, i + CHUNK).map(c => resolveClientUserId(c)));
+        }
+      } catch (e) {
+        // #4/#A: no backfill, QUALQUER erro ao resolver cliente PAUSA a janela (não
+        // cacheia ausência falsa nem completa sem o pedido). `break` sai do while.
+        const msg = (e as Error).message || '';
+        if (cursor) {
+          lastErrorKind = msg.startsWith('OMIE_TRANSIENT') ? classifyOmieTransient(msg) : 'http';
+          console.log(`[sync_pedidos][${account}] erro (${lastErrorKind}) ao resolver cliente na pág ${pagina} — pausa, não marca completo`);
+          break;
+        }
+        throw e; // incremental: propaga (comportamento de hoje)
       }
     }
 
@@ -1315,8 +1383,10 @@ async function syncPedidos(
     pagesProcessed++;
   }
 
-  const complete = pagina > totalPaginas;
-  return { totalSynced, totalItems, skippedNoClient, skippedExisting, totalPaginas, lastPage: pagina - 1, nextPage: complete ? null : pagina, complete };
+  // Completude = FIM REAL alcançado (null/página vazia), NUNCA pagina>totalPaginas.
+  // Pausa (transitório/erro) ou budget de página esgotado ⟹ complete=false, retoma do `pagina`.
+  const complete = reachedEnd;
+  return { totalSynced, totalItems, skippedNoClient, skippedExisting, totalPaginas, lastPage: pagina - 1, nextPage: complete ? null : pagina, complete, lastErrorKind };
 }
 
 // Buscar transportadora pelo nome (razão social) no Omie
@@ -1698,6 +1768,66 @@ async function completeVendaSync(
   } catch (e) {
     console.error("[Omie Vendas] completeVendaSync falhou (best-effort):", e);
   }
+}
+
+// ─── Cursor + lease do BACKFILL de pedidos (tabela vendas_sync_cursor) ───
+// Espelha o state-machine SQL da migration 20260617133633 (lease_acquire/heartbeat/
+// finish — SECURITY DEFINER gated a service_role). `omieDateToIso` (DD/MM/YYYY → ISO,
+// PK date) vem de ./pagination.ts (puro/testado).
+// O lease atômico tem que ser RPC: `.or()` em UPDATE do PostgREST quebra (42703, CLAUDE.md).
+
+// Tenta tomar o lease ATOMICAMENTE. Retorna a página de retomada, ou null se NÃO
+// conseguiu (outra invocação viva / janela completa / inexistente / RPC ausente)
+// ⟹ o caller sai no-op. Degradação segura: sem a migration aplicada, é sempre no-op.
+async function acquireVendasLease(
+  db: SupabaseClient, account: Account, dfIso: string, dtIso: string,
+): Promise<number | null> {
+  const { data, error } = await db.rpc('vendas_sync_lease_acquire', {
+    p_account: account, p_date_from: dfIso, p_date_to: dtIso,
+  });
+  if (error) {
+    console.error(`[sync_pedidos][${account}] lease_acquire falhou (no-op):`, error.message);
+    return null;
+  }
+  return typeof data === 'number' ? data : null;
+}
+
+// Renova o lease por página (best-effort: uma falha de heartbeat não derruba o sync).
+// supabase-js .rpc() NÃO lança em erro de RPC — resolve {error} (Codex). Por isso
+// checamos `error` (try/catch não pegaria), pra ao menos LOGAR um heartbeat negado.
+// Renova o lease E persiste o progresso: next_page := a página EM CURSO (`page`).
+// Assim um crash retoma da página em curso (re-faz ≤1 página, idempotente), nunca o run.
+async function heartbeatVendasCursor(
+  db: SupabaseClient, account: Account, dfIso: string, dtIso: string, page: number,
+): Promise<void> {
+  const { error } = await db.rpc('vendas_sync_heartbeat', { p_account: account, p_date_from: dfIso, p_date_to: dtIso, p_page: page });
+  if (error) console.warn(`[sync_pedidos][${account}] heartbeat falhou (segue):`, error.message);
+}
+
+// Encerra e LIBERA o lease. complete=true ⟹ fecha completed_at (fim real); false ⟹
+// pausa (retoma do nextPage, grava last_error_kind). A RPC zera running_since sempre.
+async function finishVendasCursor(
+  db: SupabaseClient, account: Account, dfIso: string, dtIso: string,
+  complete: boolean, nextPage: number | null, lastErrorKind: string | null,
+): Promise<void> {
+  const { error } = await db.rpc('vendas_sync_finish', {
+    p_account: account, p_date_from: dfIso, p_date_to: dtIso,
+    p_complete: complete,
+    p_next_page: complete ? null : nextPage,
+    p_last_error_kind: complete ? null : lastErrorKind,
+  });
+  if (error) console.error(`[sync_pedidos][${account}] finish falhou:`, error.message);
+}
+
+// LIBERA o lease preservando o next_page (o progresso que o heartbeat persistiu). Para
+// o erro INESPERADO escapado do syncPedidos: solta o lease + grava o kind sem rebobinar.
+async function releaseVendasCursor(
+  db: SupabaseClient, account: Account, dfIso: string, dtIso: string, lastErrorKind: string,
+): Promise<void> {
+  const { error } = await db.rpc('vendas_sync_release', {
+    p_account: account, p_date_from: dfIso, p_date_to: dtIso, p_last_error_kind: lastErrorKind,
+  });
+  if (error) console.error(`[sync_pedidos][${account}] release falhou:`, error.message);
 }
 
 serve(async (req) => {
@@ -2274,10 +2404,41 @@ serve(async (req) => {
       }
 
       case "sync_pedidos": {
-        const startPagePedidos = params.start_page || 1;
-        const maxPagesPedidos = params.max_pages || 10;
+        const maxPagesPedidos = Number(params.max_pages) || 10;
         const dateFrom = params.date_from || undefined; // DD/MM/YYYY
         const dateTo = params.date_to || undefined;     // DD/MM/YYYY
+
+        // Modo BACKFILL (cursor + lease) — o cron de continuação */6 passa use_cursor:true.
+        if (params.use_cursor === true) {
+          if (!dateFrom || !dateTo) throw new Error("use_cursor exige date_from e date_to");
+          const dfIso = omieDateToIso(dateFrom);
+          const dtIso = omieDateToIso(dateTo);
+          if (!dfIso || !dtIso) throw new Error(`Datas inválidas (esperado DD/MM/YYYY): ${dateFrom}..${dateTo}`);
+
+          // Lease atômico: serialização REAL (não intervalo de cron). 0 linhas = outra
+          // invocação viva / janela já completa → sai no-op (não processa).
+          const resumePage = await acquireVendasLease(supabaseAdmin, account, dfIso, dtIso);
+          if (resumePage == null) {
+            result = { success: true, skipped: "lease_nao_adquirido", account, date_from: dateFrom, date_to: dateTo };
+            break;
+          }
+          try {
+            const r = await syncPedidos(supabaseAdmin, resumePage, maxPagesPedidos, account, dateFrom, dateTo, { df: dfIso, dt: dtIso });
+            // Fecha o cursor: completo (fim real) OU pausa (budget/transitório/erro Omie).
+            await finishVendasCursor(supabaseAdmin, account, dfIso, dtIso, r.complete, r.nextPage, r.lastErrorKind);
+            result = { success: true, use_cursor: true, resume_page: resumePage, ...r };
+          } catch (e) {
+            // Erro inesperado (DB/bug) escapou do syncPedidos: LIBERA o lease preservando
+            // o next_page que o heartbeat persistiu (retoma da página EM CURSO, re-faz ≤1
+            // página idempotente — NÃO o run inteiro, achado Codex). Propaga p/ visibilidade.
+            await releaseVendasCursor(supabaseAdmin, account, dfIso, dtIso, "error");
+            throw e;
+          }
+          break;
+        }
+
+        // Modo INCREMENTAL (rolante, sem cursor) — inalterado: cron 2h, start_page=1, janela today-5..today.
+        const startPagePedidos = params.start_page || 1;
         const syncPedidosResult = await syncPedidos(supabaseAdmin, startPagePedidos, maxPagesPedidos, account, dateFrom, dateTo);
         result = { success: true, ...syncPedidosResult };
         break;

--- a/supabase/functions/omie-vendas-sync/pagination.ts
+++ b/supabase/functions/omie-vendas-sync/pagination.ts
@@ -1,0 +1,63 @@
+// Helpers PUROS da discriminação de paginação do sync de pedidos (sem fetch/DB →
+// testáveis em isolamento; ver pagination_test.ts, que roda o CÓDIGO REAL daqui).
+//
+// Contexto money-path (spec 2026-06-17-vendas-omie-cursor-lease-design.md): o
+// backfill de pedidos do Omie quebrava porque (defeito #1) `null` colapsava
+// "fim real" e "rate-limit esgotado". O conserto é usar throwOnTransient no loop
+// (rate-limit → throw; fim real → null) e decidir a completude pelo FIM REAL, nunca
+// por total_de_paginas (que mente — CLAUDE.md "paginar até página vazia + guard").
+// Estas três decisões são o núcleo testável dessa lógica.
+
+// Converte data do Omie (DD/MM/YYYY) para ISO (YYYY-MM-DD), usada como PK (date) do
+// vendas_sync_cursor. Retorna null se o formato OU o calendário não casar — valida data
+// real (31/02 não existe) por round-trip UTC, rejeitando na BORDA em vez de estourar no
+// cast SQL/RPC depois (Codex: guard de borda money-path).
+export function omieDateToIso(ddmmyyyy: string): string | null {
+  const m = /^(\d{2})\/(\d{2})\/(\d{4})$/.exec(ddmmyyyy.trim());
+  if (!m) return null;
+  const [, dd, mm, yyyy] = m;
+  const iso = `${yyyy}-${mm}-${dd}`;
+  const d = new Date(`${iso}T00:00:00Z`);
+  if (
+    Number.isNaN(d.getTime()) ||
+    d.getUTCFullYear() !== Number(yyyy) ||
+    d.getUTCMonth() + 1 !== Number(mm) ||
+    d.getUTCDate() !== Number(dd)
+  ) return null; // data impossível (ex.: 31/02, 00/13) → rejeita
+  return iso;
+}
+
+// Classifica o erro transitório do Omie a partir da mensagem do OMIE_TRANSIENT
+// (lançado por callOmieVendasApi quando throwOnTransient e os retries esgotaram).
+// Vira o `last_error_kind` gravado no cursor (rate_limit | transient).
+export function classifyOmieTransient(msg: string): 'rate_limit' | 'transient' {
+  return msg.includes('rate limit') ? 'rate_limit' : 'transient';
+}
+
+// Classifica uma página de ListarPedidos (3 vias). Com throwOnTransient, rate-limit/
+// transitório JÁ viraram throw antes daqui, então:
+//   • 'data'    → tem pedidos → processar.
+//   • 'end'     → FIM REAL: result null ("Não existem registros") OU página vazia
+//                 que NÃO contradiz total_de_paginas → marca completo.
+//   • 'anomaly' → página vazia que CONTRADIZ total_de_paginas (Omie diz que há mais
+//                 páginas) → SUSPEITO → PAUSA, NUNCA completa.
+//
+// Money-path (achado Codex #6): tratar TODA página vazia como fim podia setar
+// completed_at com páginas faltando (ex.: Omie devolve {total_de_paginas:8,
+// pedido_venda_produto:[]} na pág 5 → pgs 6-8 perdidas). total_de_paginas NÃO é a
+// autoridade de fim (ele mente — CLAUDE.md), mas serve de GUARD: precisão > recall,
+// uma janela presa (visível no cursor, retomável) é infinitamente melhor que uma
+// falsamente completa (perda silenciosa de pedido = comissão errada). `null` segue
+// sendo o fim autoritativo; o guard só pega o caso vazio-no-meio.
+export function classifyPedidosPage(
+  result: Record<string, unknown> | null,
+  pagina: number,
+): 'data' | 'end' | 'anomaly' {
+  if (!result) return 'end'; // null = "Não existem registros para a página"
+  const pedidos = (result.pedido_venda_produto as unknown[] | undefined) ?? [];
+  if (pedidos.length > 0) return 'data';
+  // página vazia: usa total_de_paginas SÓ como guard anti-falsa-completude
+  const total = Number(result.total_de_paginas) || 0;
+  if (total > 0 && pagina < total) return 'anomaly'; // Omie afirma que há mais → não completa
+  return 'end';
+}

--- a/supabase/functions/omie-vendas-sync/pagination_test.ts
+++ b/supabase/functions/omie-vendas-sync/pagination_test.ts
@@ -1,0 +1,80 @@
+// Testa o CÓDIGO REAL de pagination.ts (não uma cópia) no runtime real (Deno).
+// Roda com: deno test supabase/functions/omie-vendas-sync/pagination_test.ts
+//
+// Cobre a discriminação money-path do spec (defeito #1: null ambíguo): a página do
+// loop de sync_pedidos deve distinguir FIM REAL (null/vazio → completa) de TRANSITÓRIO
+// (throw → pausa, não completa), e converter as datas do cursor sem ambiguidade.
+import { omieDateToIso, classifyOmieTransient, classifyPedidosPage } from "./pagination.ts";
+
+function assertEquals(a: unknown, b: unknown, msg?: string) {
+  if (JSON.stringify(a) !== JSON.stringify(b)) {
+    throw new Error(msg ?? `assertEquals falhou: ${JSON.stringify(a)} !== ${JSON.stringify(b)}`);
+  }
+}
+
+// ── omieDateToIso: DD/MM/YYYY (Omie) → ISO (PK date do cursor) ──
+Deno.test("omieDateToIso: converte DD/MM/YYYY → YYYY-MM-DD", () => {
+  assertEquals(omieDateToIso("17/06/2026"), "2026-06-17");
+  assertEquals(omieDateToIso("01/01/2025"), "2025-01-01");
+  assertEquals(omieDateToIso("31/12/2024"), "2024-12-31");
+});
+
+Deno.test("omieDateToIso: tolera espaços nas bordas", () => {
+  assertEquals(omieDateToIso("  05/03/2025  "), "2025-03-05");
+});
+
+Deno.test("omieDateToIso: formato inválido → null (caller rejeita a invocação)", () => {
+  assertEquals(omieDateToIso("2026-06-17"), null);   // já-ISO não casa
+  assertEquals(omieDateToIso("17/6/2026"), null);    // sem zero à esquerda
+  assertEquals(omieDateToIso("xx/yy/zzzz"), null);
+  assertEquals(omieDateToIso(""), null);
+});
+
+Deno.test("omieDateToIso: data de calendário IMPOSSÍVEL → null (Codex: guard de borda)", () => {
+  assertEquals(omieDateToIso("31/02/2025"), null);   // fev não tem 31
+  assertEquals(omieDateToIso("00/01/2025"), null);   // dia 0
+  assertEquals(omieDateToIso("01/13/2025"), null);   // mês 13
+  assertEquals(omieDateToIso("31/04/2025"), null);   // abr não tem 31
+  assertEquals(omieDateToIso("29/02/2024"), "2024-02-29"); // bissexto válido
+});
+
+// ── classifyOmieTransient: tipo do transitório p/ o last_error_kind ──
+Deno.test("classifyOmieTransient: rate-limit vs transitório genérico", () => {
+  // mensagens EXATAS que callOmieVendasApi emite no throw OMIE_TRANSIENT
+  assertEquals(classifyOmieTransient("OMIE_TRANSIENT (oben): rate limit persistiu após 3 tentativas — não dá pra afirmar ausência"), "rate_limit");
+  assertEquals(classifyOmieTransient("OMIE_TRANSIENT (colacor): erro transitório persistiu após 3 tentativas — não dá pra afirmar ausência"), "transient");
+});
+
+// ── classifyPedidosPage: a decisão de completude (3 vias) ──
+Deno.test("classifyPedidosPage: null = fim real (Não existem registros)", () => {
+  assertEquals(classifyPedidosPage(null, 3), "end");
+});
+
+Deno.test("classifyPedidosPage: página com pedidos = data (processa)", () => {
+  assertEquals(classifyPedidosPage({ pedido_venda_produto: [{ cabecalho: { codigo_pedido: 1 } }] }, 1), "data");
+  // total_de_paginas NÃO decide fim: com dados, é 'data' mesmo com total=1
+  assertEquals(classifyPedidosPage({ total_de_paginas: 1, pedido_venda_produto: [{ x: 1 }, { x: 2 }] }, 1), "data");
+});
+
+Deno.test("classifyPedidosPage: vazia coerente com total = fim", () => {
+  // vazia sem total → fim
+  assertEquals(classifyPedidosPage({ pedido_venda_produto: [] }, 5), "end");
+  assertEquals(classifyPedidosPage({}, 9), "end");
+  // vazia E pagina >= total (passou do fim) → fim legítimo
+  assertEquals(classifyPedidosPage({ total_de_paginas: 5, pedido_venda_produto: [] }, 5), "end");
+  assertEquals(classifyPedidosPage({ total_de_paginas: 5, pedido_venda_produto: [] }, 6), "end");
+});
+
+// #6 (Codex): vazia CONTRADIZENDO total → anomalia → PAUSA, nunca falsa-completude
+Deno.test("classifyPedidosPage: vazia no MEIO (pagina < total) = anomaly (não completa)", () => {
+  assertEquals(classifyPedidosPage({ total_de_paginas: 8, pedido_venda_produto: [] }, 5), "anomaly");
+  assertEquals(classifyPedidosPage({ total_de_paginas: 2, pedido_venda_produto: [] }, 1), "anomaly");
+});
+
+// ── Cenário do spec §8: rate-limit (throw=pausa) vs página-vazia (null=fim) ──
+Deno.test("cenário: o fim-real completa, mas o transitório NÃO (caminhos distintos)", () => {
+  assertEquals(classifyPedidosPage(null, 4), "end");           // fim real → completa
+  assertEquals(classifyPedidosPage({ pedido_venda_produto: [{ x: 1 }] }, 4), "data"); // dados → processa
+  // o kind do transitório (que vem por throw, nunca por esta função) é classificado p/ o cursor
+  assertEquals(classifyOmieTransient("OMIE_TRANSIENT (oben): rate limit ..."), "rate_limit");
+});

--- a/supabase/migrations/20260617133633_vendas_sync_cursor.sql
+++ b/supabase/migrations/20260617133633_vendas_sync_cursor.sql
@@ -1,0 +1,206 @@
+-- ============================================================
+-- vendas_sync_cursor — cursor + lease pro BACKFILL confiável de pedidos do Omie.
+--
+-- Contexto (spec docs/superpowers/specs/2026-06-17-vendas-omie-cursor-lease-design.md,
+-- §4.2): o backfill de pedidos (omie-vendas-sync / sync_pedidos → sales_orders,
+-- MONEY-PATH: positivação/OTE/comissão) é frágil porque o edge (1) colapsa
+-- rate-limit e fim-de-página no mesmo `null` (pode parar no meio achando que
+-- acabou), (2) não tem serialização real (só o intervalo de cron, e o edge roda
+-- em background além do timeout → concorrência → rate-limit silencioso), e (3)
+-- valida completude por contagem (prova crescimento, não completude).
+--
+-- Esta tabela é a FUNDAÇÃO do conserto (Opção A aprovada — cursor + lease +
+-- null-discriminado, mantendo insert-only):
+--   • cursor por janela (account, date_from, date_to) → retoma do next_page.
+--   • completed_at só fecha com FIM REAL (null-discriminado no edge), nunca por
+--     total_de_paginas (que mente — CLAUDE.md) nem por contagem.
+--   • lease atômico (running_since/heartbeat_at) = serialização REAL: 1 invocação
+--     viva por janela. O cron de continuação dispara 1 janela POR CONTA (a mais
+--     antiga pendente) → mesma conta serializada, contas distintas em paralelo
+--     (rate-limit do Omie é por conta).
+--
+-- O state-machine do cursor vive em 3 RPCs SQL (lease_acquire/heartbeat/finish),
+-- não em UPDATEs do edge — (a) o lease atômico EXIGE a cláusula
+-- `running_since IS NULL OR heartbeat_at < now()-3min`, e `.or()` em UPDATE do
+-- PostgREST quebra com 42703 (CLAUDE.md) → RPC SQL-pura; (b) assim o state-machine
+-- inteiro é provável no PG17 (prove-sql-money-path) antes de ir a produção.
+--
+-- ⚠️ Espelha 20260525020000_fin_sync_cursor.sql (RLS staff-lê/service-escreve) e
+-- REQUER redeploy do omie-vendas-sync (que passa a ler/gravar o cursor). Sem o
+-- edge novo, a tabela fica ociosa e o cron */6 é no-op (nenhuma janela semeada).
+-- Semear janelas = humano cola (sub-projeto 2), gate humano (spec §6).
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS public.vendas_sync_cursor (
+  account        text NOT NULL CHECK (account IN ('oben','colacor')),
+  date_from      date NOT NULL,
+  date_to        date NOT NULL,
+  next_page      int,                       -- NULL = sem resume pendente (janela fechada)
+  completed_at   timestamptz,               -- NULL até a janela fechar de VERDADE (fim real null-discriminado)
+  last_error_kind text CHECK (last_error_kind IS NULL OR last_error_kind IN ('rate_limit','transient','http','error')),
+  running_since  timestamptz,               -- NULL = livre (lease)
+  heartbeat_at   timestamptz,               -- renovado por página (detecta lease morto > 3 min)
+  updated_at     timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (account, date_from, date_to)
+);
+
+-- Índice pro cron de continuação varrer SÓ pendentes (janela aberta).
+-- Predicado do spec; (account, date_from) serve o DISTINCT ON (account) ORDER BY date_from do cron.
+CREATE INDEX IF NOT EXISTS idx_vendas_sync_cursor_pendentes
+  ON public.vendas_sync_cursor (account, date_from)
+  WHERE next_page IS NOT NULL OR completed_at IS NULL;
+
+-- ─────────────────────────── RLS (espelha fin_sync_cursor) ───────────────────────────
+ALTER TABLE public.vendas_sync_cursor ENABLE ROW LEVEL SECURITY;
+
+-- Staff lê (observabilidade: eu monitoro o cursor real via psql-ro, não por contagem).
+DROP POLICY IF EXISTS "vendas_sync_cursor_select_staff" ON public.vendas_sync_cursor;
+CREATE POLICY "vendas_sync_cursor_select_staff"
+  ON public.vendas_sync_cursor FOR SELECT
+  USING (
+    EXISTS (SELECT 1 FROM public.user_roles
+            WHERE user_id = auth.uid()
+              AND role IN ('employee'::public.app_role, 'master'::public.app_role))
+  );
+
+-- Service role (sync/cron) escreve.
+DROP POLICY IF EXISTS "vendas_sync_cursor_service_all" ON public.vendas_sync_cursor;
+CREATE POLICY "vendas_sync_cursor_service_all"
+  ON public.vendas_sync_cursor FOR ALL
+  USING (auth.role() = 'service_role')
+  WITH CHECK (auth.role() = 'service_role');
+
+-- ─────────────────────────── State-machine do cursor (RPC SQL) ───────────────────────────
+-- SECURITY DEFINER (bypassa RLS internamente) + gate na FRONTEIRA via REVOKE/GRANT
+-- (só service_role executa — é o edge). search_path pinado (anti-hijack).
+
+-- (1) lease_acquire: tenta tomar o lease ATOMICAMENTE. Retorna a página de
+-- retomada se conseguiu; NULL se NÃO conseguiu (outra invocação viva, ou janela
+-- já completa, ou janela inexistente). É o coração da serialização real.
+CREATE OR REPLACE FUNCTION public.vendas_sync_lease_acquire(
+  p_account text, p_date_from date, p_date_to date
+) RETURNS integer
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+  UPDATE public.vendas_sync_cursor
+     SET running_since = now(), heartbeat_at = now(), updated_at = now()
+   WHERE account = p_account AND date_from = p_date_from AND date_to = p_date_to
+     AND completed_at IS NULL
+     AND (running_since IS NULL OR heartbeat_at < now() - interval '3 minutes')
+  RETURNING COALESCE(next_page, 1);
+$$;
+
+-- (2) heartbeat: renova o lease E PERSISTE o progresso por página (next_page := a
+-- página EM CURSO). Mantém o lease vivo no run longo (>3min de steal) e — crucial —
+-- garante que um crash/erro inesperado retome da página em curso, re-fazendo no
+-- máximo 1 página (idempotente via uniq_sales_orders_omie_hash), nunca o run inteiro
+-- (achado Codex cursor-finish-rewind). Só age se a janela tem lease ativo
+-- (running_since IS NOT NULL). 0 linhas = janela liberada/roubada.
+CREATE OR REPLACE FUNCTION public.vendas_sync_heartbeat(
+  p_account text, p_date_from date, p_date_to date, p_page integer
+) RETURNS void
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+  UPDATE public.vendas_sync_cursor
+     SET heartbeat_at = now(), next_page = p_page, updated_at = now()
+   WHERE account = p_account AND date_from = p_date_from AND date_to = p_date_to
+     AND running_since IS NOT NULL;
+$$;
+
+-- (2b) release: LIBERA o lease (running_since := NULL) preservando o next_page (o
+-- progresso que o heartbeat persistiu). É o caminho do erro INESPERADO escapado do
+-- edge: solta o lease + grava o kind, mas NÃO rebobina o next_page nem completa.
+-- Difere do finish (que decide next_page/completed_at) — aqui o progresso já está no
+-- cursor pelo heartbeat e deve ser preservado.
+CREATE OR REPLACE FUNCTION public.vendas_sync_release(
+  p_account text, p_date_from date, p_date_to date, p_last_error_kind text
+) RETURNS void
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+  UPDATE public.vendas_sync_cursor
+     SET running_since = NULL, last_error_kind = p_last_error_kind,
+         heartbeat_at = now(), updated_at = now()
+   WHERE account = p_account AND date_from = p_date_from AND date_to = p_date_to;
+$$;
+
+-- (3) finish: encerra a invocação e LIBERA o lease (running_since := NULL) SEMPRE.
+--   p_complete = true  → fim REAL (null-discriminado): next_page := NULL,
+--                        completed_at := now(), last_error_kind := NULL.
+--   p_complete = false → pausa (budget de página esgotado, transitório, ou erro):
+--                        next_page := p_next_page (retoma daqui), grava last_error_kind.
+-- completed_at NUNCA é setado com p_complete=false → completude só com fim real.
+CREATE OR REPLACE FUNCTION public.vendas_sync_finish(
+  p_account text, p_date_from date, p_date_to date,
+  p_complete boolean, p_next_page integer, p_last_error_kind text
+) RETURNS void
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+  UPDATE public.vendas_sync_cursor
+     SET next_page       = CASE WHEN p_complete THEN NULL ELSE p_next_page END,
+         completed_at     = CASE WHEN p_complete THEN now() ELSE completed_at END,
+         last_error_kind  = CASE WHEN p_complete THEN NULL ELSE p_last_error_kind END,
+         running_since    = NULL,
+         heartbeat_at     = now(),
+         updated_at       = now()
+   WHERE account = p_account AND date_from = p_date_from AND date_to = p_date_to;
+$$;
+
+-- Gate na fronteira: só service_role (o edge) executa o state-machine.
+REVOKE ALL ON FUNCTION public.vendas_sync_lease_acquire(text, date, date) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.vendas_sync_heartbeat(text, date, date, integer) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.vendas_sync_finish(text, date, date, boolean, integer, text) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.vendas_sync_release(text, date, date, text) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.vendas_sync_lease_acquire(text, date, date) TO service_role;
+GRANT EXECUTE ON FUNCTION public.vendas_sync_heartbeat(text, date, date, integer) TO service_role;
+GRANT EXECUTE ON FUNCTION public.vendas_sync_finish(text, date, date, boolean, integer, text) TO service_role;
+GRANT EXECUTE ON FUNCTION public.vendas_sync_release(text, date, date, text) TO service_role;
+
+-- ─────────────────────────── Cron de continuação (*/6) ───────────────────────────
+-- A cada 6 min, dispara 1 janela POR CONTA (a mais antiga pendente) → mesma conta
+-- serializada pelo lease (tick novo no-opa se a invocação anterior ainda roda),
+-- contas distintas em paralelo. No-op enquanto não houver janela semeada.
+-- timeout_milliseconds explícito (default 5s mataria silencioso — CLAUDE.md/sync.md);
+-- o edge roda em background ALÉM desse timeout, o lease é quem serializa de verdade.
+SELECT cron.unschedule('vendas-sync-continuacao-6min')
+  WHERE EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'vendas-sync-continuacao-6min');
+SELECT cron.schedule(
+  'vendas-sync-continuacao-6min',
+  '*/6 * * * *',
+  $cron$
+  DO $inner$
+  DECLARE r record;
+  BEGIN
+    FOR r IN
+      SELECT DISTINCT ON (account) account, date_from, date_to
+        FROM public.vendas_sync_cursor
+       WHERE completed_at IS NULL
+       ORDER BY account, date_from
+    LOOP
+      PERFORM net.http_post(
+        url := 'https://fzvklzpomgnyikkfkzai.supabase.co/functions/v1/omie-vendas-sync',
+        headers := jsonb_build_object(
+          'Content-Type', 'application/json',
+          'x-cron-secret', (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'CRON_SECRET' LIMIT 1)
+        ),
+        body := jsonb_build_object(
+          'action', 'sync_pedidos',
+          'account', r.account,
+          'date_from', to_char(r.date_from, 'DD/MM/YYYY'),
+          'date_to',   to_char(r.date_to,   'DD/MM/YYYY'),
+          'use_cursor', true,
+          'max_pages', 10
+        ),
+        timeout_milliseconds := 150000
+      );
+    END LOOP;
+  END $inner$;
+  $cron$
+);

--- a/supabase/migrations/20260617133634_sales_orders_omie_hash_unique.sql
+++ b/supabase/migrations/20260617133634_sales_orders_omie_hash_unique.sql
@@ -1,0 +1,28 @@
+-- ============================================================
+-- sales_orders: índice UNIQUE PARCIAL em (account, hash_payload) p/ pedidos do sync Omie.
+--
+-- Por quê (MONEY-PATH, achado Codex #3 do challenge 2026-06-17): o sync de pedidos
+-- (omie-vendas-sync / sync_pedidos) é INSERT-ONLY e dedupa por um Set EM MEMÓRIA de
+-- hash_payload pré-carregado no início da invocação. Isso NÃO segura concorrência: dois
+-- runners que pré-carregam antes de qualquer insert podem inserir o MESMO pedido →
+-- sales_orders + order_items duplicados → positivação/OTE/COMISSÃO dobrada. O cursor+lease
+-- (20260617133633) reduz a concorrência, mas o lease é best-effort (race de lease morto);
+-- a ÚNICA garantia de integridade é o banco. Este índice é o guard na fronteira que toda
+-- via de insert cruza (princípio money-path #5): um insert duplicado vira `unique_violation`
+-- (23505), que o fallback one-by-one do edge já trata pulando — idempotência REAL.
+--
+-- PARCIAL `WHERE hash_payload LIKE 'omie\_%'`: escopa SÓ os pedidos criados pelo sync
+-- (hash `omie_<conta>_<codigoPedido>`, único por conta+pedido). Verificado em prod
+-- (psql-ro, 2026-06-17): 0 duplicatas nesse subset (6.242 pedidos: 5.123 oben + 1.119
+-- colacor). As 488 linhas duplicadas de sales_orders são pedidos `cancelado` com hash
+-- placeholder não-omie (ex.: '-cah8zx' ×253) — EXCLUÍDAS pelo predicado, intocadas.
+--
+-- ⚠️ Idempotente. NÃO usa CONCURRENTLY (o SQL Editor do Lovable roda em transação; trava
+-- a tabela brevemente — aceitável, sales_orders é pequena). Se o apply falhar com
+-- "could not create unique index ... duplicate key", surgiu duplicata omie_ NOVA entre a
+-- verificação e o apply → me avise (é um bug de sync a investigar ANTES de forçar o índice).
+-- ============================================================
+
+CREATE UNIQUE INDEX IF NOT EXISTS uniq_sales_orders_omie_hash
+  ON public.sales_orders (account, hash_payload)
+  WHERE hash_payload LIKE 'omie\_%';


### PR DESCRIPTION
## Sub-projeto 1 — fundação cursor+lease pro backfill de pedidos Omie

**Money-path** (`sales_orders`/`order_items` → positivação/OTE/comissão). Implementa a Opção A do spec `docs/superpowers/specs/2026-06-17-vendas-omie-cursor-lease-design.md`: cursor + lease + completude null-discriminada, **insert-only**.

### O que entra
- **migration `20260617133633_vendas_sync_cursor.sql`** — tabela + RLS (staff lê / service escreve) + índice parcial de pendentes + **4 RPCs** SECURITY DEFINER gated a `service_role` (`lease_acquire` atômico, `heartbeat` com progresso/página, `finish`, `release`) + cron `*/6` (1 janela por conta, `DISTINCT ON`, `timeout_milliseconds` explícito).
- **migration `20260617133634_sales_orders_omie_hash_unique.sql`** — índice **UNIQUE parcial** `(account, hash_payload) WHERE hash_payload LIKE 'omie\_%'` → idempotência insert-only garantida no banco (a fronteira), não só na memória do edge.
- **edge `omie-vendas-sync`** (`index.ts` + novo `pagination.ts`) — `throwOnTransient` (null=fim real, throw=pausa); lê/grava o cursor; lease + heartbeat com **progresso por página** (retoma da página em curso, não do run); `classifyPedidosPage` 3-vias (vazio que contradiz `total_de_paginas` → pausa, nunca falsa-completude); cliente-transitório pausa a janela; caminho incremental preservado.
- **provas** — `db/test-vendas_sync_cursor.sh` (PG17, 32/0 + 5 falsificações), `db/test-sales_orders_omie_hash_unique.sh` (5/0 + falsif.), `pagination_test.ts` (Deno 10/10). Validado por 3 Codex challenges xhigh + painel tri-modelo (Claude+Codex; Gemini fora por quota).

### ⚠️ Migrations manuais — JÁ APLICADAS em prod
As 2 migrations **já foram coladas no SQL Editor e verificadas** (psql-ro: tabela, 4 RPCs, índices, cron, RLS, gate de EXECUTE — `service_role` only, zero PUBLIC/anon/authenticated). O merge não re-aplica nada.

### 🔧 AÇÃO DO FOUNDER pós-merge — deploy do edge (Lovable chat, verbatim)
> Edit the edge function `omie-vendas-sync`. Replace `index.ts` with `supabase/functions/omie-vendas-sync/index.ts` from `main`, **and create/replace the sibling `pagination.ts`** with `supabase/functions/omie-vendas-sync/pagination.ts` (index.ts imports `./pagination.ts`). Deploy **verbatim** — do NOT modify/improve/reformat. Confirm **Active**.

⚠️ O deploy muda também o **sync incremental 2h** (frescor diário). Após deployar, verificar que `fin_sync_log` (action=`sync_pedidos`) segue `complete` e `sales_orders` continua fresco.

### 🚧 Piloto (próxima sessão) — colacor, NÃO oben
Com edge no ar, semear **1 janela mensal pequena de colacor** (limpo: 0 de-namespaced), pausar o cron incremental dessa conta, e monitorar o cursor real até `completed_at`. **Oben está BLOQUEADO** (ver gate abaixo).

### Gates / follow-ups (tasks)
- **#B (bloqueia backfill de oben):** o cron `sync-reprocess` reescreve `hash_payload` `omie_`→estrutural → re-sync poderia duplicar. Oben já tem ~511 dups por `omie_numero_pedido` HOJE (pré-existente; pode inflar comissão — checar o read-path antes de limpar). Dedup durável necessário antes do backfill de oben.
- **#5:** insert pedido+itens não-atômico (pré-existente; itens podem faltar sem reparo). Rede: relatório "pedido sem item" (sub-projeto 2).
- **Residual idempotente (P2):** se o heartbeat falhar E um erro inesperado escapar, retoma do último heartbeat (re-faz N páginas, idempotente via índice — não corrompe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
