### PR TITLE
feat(vendas): atomicidade pai+filho do sync Omie (criar_pedidos_com_itens + reparo)

### DIFF
--- a/db/test-criar-pedidos-com-itens.sh
+++ b/db/test-criar-pedidos-com-itens.sh
@@ -1,0 +1,323 @@
+#!/usr/bin/env bash
+# ╔══════════════════════════════════════════════════════════════════════════════╗
+# ║ PROVA PG17 — criar_pedidos_com_itens (atomicidade pai+filho do sync Omie)      ║
+# ║ Spec: docs/superpowers/specs/2026-06-17-atomicidade-pedido-itens-omie-design.md║
+# ║ Rode: bash db/test-criar-pedidos-com-itens.sh > /tmp/t.log 2>&1; echo "exit=$?"║
+# ╚══════════════════════════════════════════════════════════════════════════════╝
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PGVER=17
+PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+PORT="${PGPORT_TEST:-5461}"
+SLUG="criar-pedidos-com-itens"
+DATA="$(mktemp -d "/tmp/pgtest-${SLUG}.XXXXXX")/data"
+export LC_ALL=C LANG=C
+
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente: brew install postgresql@${PGVER} pgvector"; exit 1; }
+CELLAR="$(brew --prefix "postgresql@${PGVER}")"
+cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
+mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
+cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
+
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+trap cleanup EXIT
+
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l "/tmp/pg-${SLUG}.log" -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres prove
+P()  { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d prove -v ON_ERROR_STOP=1 "$@"; }
+Pq() { P -tA "$@"; }
+
+P -q -f "$REPO_ROOT/db/stubs-supabase.sql"
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION auth.uid()  RETURNS uuid LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.uid', true), '')::uuid $f$;
+CREATE OR REPLACE FUNCTION auth.role() RETURNS text LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.role', true), '') $f$;
+ALTER ROLE service_role BYPASSRLS;
+SQL
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  ✅ $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  ❌ $1"; }
+eq()  { if [ "$2" = "$3" ]; then ok "$1 (=$2)"; else bad "$1 — esperado [$3], veio [$2]"; fi; }
+
+echo "═══ setup pronto (PG17 :$PORT) ═══"
+
+# UUIDs fixos
+c1="11111111-1111-1111-1111-111111111111"
+c2="22222222-2222-2222-2222-222222222222"
+sys="33333333-3333-3333-3333-333333333333"
+p1="aaaaaaaa-0000-0000-0000-000000000001"
+p2="aaaaaaaa-0000-0000-0000-000000000002"
+HOJE="$(date '+%Y-%m-%d')"
+
+# ── ZONA 1 — pré-requisitos de schema (fiel ao prod: NOT NULL/defaults/FK CASCADE) ──
+P -q <<'SQL'
+CREATE TABLE public.omie_products (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(), omie_codigo_produto bigint, account text);
+CREATE TABLE public.sales_orders (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  customer_user_id uuid NOT NULL, created_by uuid NOT NULL,
+  items jsonb NOT NULL DEFAULT '[]'::jsonb,
+  subtotal numeric NOT NULL DEFAULT 0, discount numeric NOT NULL DEFAULT 0, total numeric NOT NULL DEFAULT 0,
+  status text NOT NULL DEFAULT 'rascunho', notes text,
+  omie_pedido_id bigint, omie_numero_pedido text,
+  created_at timestamptz NOT NULL DEFAULT now(), updated_at timestamptz NOT NULL DEFAULT now(),
+  account text NOT NULL DEFAULT 'oben', hash_payload text,
+  customer_address text, customer_phone text, order_date_kpi date);
+CREATE TABLE public.order_items (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  sales_order_id uuid NOT NULL REFERENCES public.sales_orders(id) ON DELETE CASCADE,
+  customer_user_id uuid NOT NULL,
+  product_id uuid REFERENCES public.omie_products(id),
+  omie_codigo_produto bigint,
+  quantity numeric NOT NULL DEFAULT 1, unit_price numeric NOT NULL DEFAULT 0, discount numeric DEFAULT 0,
+  created_at timestamptz DEFAULT now(), hash_payload text);
+CREATE TABLE public.sales_price_history (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  customer_user_id uuid NOT NULL, product_id uuid NOT NULL, unit_price numeric NOT NULL,
+  sales_order_id uuid, created_at timestamptz NOT NULL DEFAULT now());
+ALTER TABLE public.sales_orders ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.order_items ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.sales_price_history ENABLE ROW LEVEL SECURITY;
+SQL
+
+# ── ZONA 2 — aplica a migration REAL (Lei #1) ──
+MIG="$REPO_ROOT/supabase/migrations/20260617160000_criar_pedidos_com_itens.sql"
+P -q -f "$MIG"
+echo "migration aplicada: $(basename "$MIG")"
+
+# índice unique foi criado?
+HASIDX=$(Pq -c "SELECT count(*) FROM pg_indexes WHERE indexname='uniq_sales_orders_omie_hash';")
+eq "M0 índice unique criado" "$HASIDX" "1"
+
+# ── ZONA 3 — seed (como postgres: superuser, sem RLS) ──
+P -q <<SQL
+INSERT INTO auth.users(id) VALUES ('$c1'),('$c2'),('$sys') ON CONFLICT DO NOTHING;
+INSERT INTO public.omie_products(id, omie_codigo_produto, account) VALUES
+  ('$p1',1001,'oben'),('$p2',1002,'oben');
+GRANT EXECUTE ON FUNCTION public.criar_pedidos_com_itens(jsonb) TO service_role;  -- (já na migration; idempotente)
+-- órfão 777 p/ reparo (created_at ANTIGO; cabeçalho casa com o payload do reparo)
+INSERT INTO public.sales_orders(customer_user_id,created_by,account,hash_payload,total,status,order_date_kpi,created_at,omie_pedido_id)
+  VALUES ('$c1','$sys','oben','omie_oben_777',50,'faturado','2023-01-15','2023-01-15T00:00:00Z',777);
+-- órfão 888 p/ divergência (total local=100)
+INSERT INTO public.sales_orders(customer_user_id,created_by,account,hash_payload,total,status,order_date_kpi,omie_pedido_id)
+  VALUES ('$c1','$sys','oben','omie_oben_888',100,'faturado','2024-02-02',888);
+-- completo 999 (já tem 1 item) p/ skip_complete
+WITH so AS (
+  INSERT INTO public.sales_orders(customer_user_id,created_by,account,hash_payload,total,status,omie_pedido_id)
+  VALUES ('$c1','$sys','oben','omie_oben_999',30,'faturado',999) RETURNING id)
+INSERT INTO public.order_items(sales_order_id,customer_user_id,omie_codigo_produto,product_id,quantity,unit_price)
+  SELECT id,'$c1',1001,'$p1',1,30 FROM so;
+-- órfãos p/ corrida (A9) e falsificações (556/778/889)
+INSERT INTO public.sales_orders(customer_user_id,created_by,account,hash_payload,total,status,order_date_kpi,created_at,omie_pedido_id) VALUES
+  ('$c1','$sys','oben','omie_oben_555',50,'faturado','2023-01-15','2023-01-15T00:00:00Z',555),
+  ('$c1','$sys','oben','omie_oben_556',50,'faturado','2023-01-15','2023-01-15T00:00:00Z',556),
+  ('$c1','$sys','oben','omie_oben_778',50,'faturado','2023-03-03','2023-03-03T00:00:00Z',778),
+  ('$c1','$sys','oben','omie_oben_889',100,'faturado','2024-02-02','2024-02-02T00:00:00Z',889);
+SQL
+
+# helper: chama a RPC 1x e popula INS REP SKC SKN DIV FAIL
+rpc() {
+  local row
+  row=$(Pq -c "WITH r AS (SELECT public.criar_pedidos_com_itens('$1'::jsonb) AS j)
+    SELECT j->>'inserted',j->>'repaired',j->>'skipped_complete',j->>'skipped_no_items',
+           jsonb_array_length(j->'divergence'),jsonb_array_length(j->'failed') FROM r;")
+  IFS='|' read -r INS REP SKC SKN DIV FAILED <<< "$row"   # FAILED (não FAIL — colidiria com o contador)
+}
+cnt() { Pq -c "SELECT count(*) FROM public.order_items oi JOIN public.sales_orders so ON so.id=oi.sales_order_id WHERE so.hash_payload='$1';"; }
+paiexiste() { Pq -c "SELECT count(*) FROM public.sales_orders WHERE hash_payload='$1';"; }
+
+echo "── asserts ──"
+
+# A0 — POSITIVO: pedido novo c/ 2 itens + 2 preços → pai+filhos atômico (G9/G10)
+J=$(cat <<EOF
+[{"account":"oben","hash_payload":"omie_oben_100","customer_user_id":"$c1","created_by":"$sys","total":40,"status":"faturado","omie_pedido_id":100,"order_date_kpi":"2026-06-10","created_at":"2026-06-10T12:00:00Z","itens":[{"omie_codigo_produto":1001,"product_id":"$p1","quantity":2,"unit_price":10},{"omie_codigo_produto":1002,"product_id":"$p2","quantity":1,"unit_price":20}],"precos":[{"product_id":"$p1","unit_price":10},{"product_id":"$p2","unit_price":20}]}]
+EOF
+)
+rpc "$J"
+eq "A0 inserted=1" "$INS" "1"
+eq "A0 2 order_items" "$(cnt omie_oben_100)" "2"
+PH=$(Pq -c "SELECT count(*) FROM public.sales_price_history WHERE sales_order_id=(SELECT id FROM public.sales_orders WHERE hash_payload='omie_oben_100');")
+eq "A0 2 sales_price_history (G10)" "$PH" "2"
+SAME0=$(Pq -c "SELECT bool_and(oi.created_at = so.created_at) FROM public.order_items oi JOIN public.sales_orders so ON so.id=oi.sales_order_id WHERE so.hash_payload='omie_oben_100';")
+eq "A0 created_at do item = do pai (G6)" "$SAME0" "t"
+
+# A1 — ATOMICIDADE (G9): pedido 102 c/ item de FK inválida reverte o PAI; 101 (bom) entra
+J=$(cat <<EOF
+[{"account":"oben","hash_payload":"omie_oben_101","customer_user_id":"$c1","created_by":"$sys","total":10,"status":"faturado","omie_pedido_id":101,"itens":[{"omie_codigo_produto":1001,"product_id":"$p1","quantity":1,"unit_price":10}]},{"account":"oben","hash_payload":"omie_oben_102","customer_user_id":"$c1","created_by":"$sys","total":20,"status":"faturado","omie_pedido_id":102,"itens":[{"omie_codigo_produto":9999,"product_id":"99999999-9999-9999-9999-999999999999","quantity":1,"unit_price":20}],"precos":[{"product_id":"99999999-9999-9999-9999-999999999999","unit_price":20}]}]
+EOF
+)
+rpc "$J"
+eq "A1 bom (101) entrou" "$(paiexiste omie_oben_101)" "1"
+eq "A1 ruim (102) pai REVERTIDO (atomicidade)" "$(paiexiste omie_oben_102)" "0"
+eq "A1 failed=1" "$FAILED" "1"
+PH102=$(Pq -c "SELECT count(*) FROM public.sales_price_history sph JOIN public.sales_orders so ON so.id=sph.sales_order_id WHERE so.hash_payload='omie_oben_102';")
+eq "A1 preço do 102 também revertido (G10 atômico)" "$PH102" "0"
+
+# A2 — IDEMPOTÊNCIA (G2): mesmo pedido novo 2x → não duplica pai
+J=$(cat <<EOF
+[{"account":"oben","hash_payload":"omie_oben_103","customer_user_id":"$c1","created_by":"$sys","total":10,"status":"faturado","omie_pedido_id":103,"itens":[{"omie_codigo_produto":1001,"product_id":"$p1","quantity":1,"unit_price":10}]}]
+EOF
+)
+rpc "$J"; rpc "$J"
+eq "A2 pai não duplica (1 só)" "$(paiexiste omie_oben_103)" "1"
+eq "A2 2ª chamada = skipped_complete" "$SKC" "1"
+
+# A3 — G7: pedido novo SEM item válido (codigo_produto null) → pai NÃO entra
+J=$(cat <<EOF
+[{"account":"oben","hash_payload":"omie_oben_104","customer_user_id":"$c1","created_by":"$sys","total":10,"status":"faturado","omie_pedido_id":104,"itens":[{"omie_codigo_produto":null,"product_id":"$p1","quantity":1,"unit_price":10}]}]
+EOF
+)
+rpc "$J"
+eq "A3 pai sem item NÃO criado (G7)" "$(paiexiste omie_oben_104)" "0"
+eq "A3 skipped_no_items=1" "$SKN" "1"
+
+# A4 — REPARO (G4) + created_at coerente (G6): órfão antigo 777 → itens c/ data do pai (2023), não hoje
+J=$(cat <<EOF
+[{"account":"oben","hash_payload":"omie_oben_777","customer_user_id":"$c1","created_by":"$sys","total":50,"status":"faturado","order_date_kpi":"2023-01-15","itens":[{"omie_codigo_produto":1001,"product_id":"$p1","quantity":1,"unit_price":25},{"omie_codigo_produto":1002,"product_id":"$p2","quantity":1,"unit_price":25}]}]
+EOF
+)
+rpc "$J"
+eq "A4 repaired=1" "$REP" "1"
+eq "A4 órfão reparado (2 itens)" "$(cnt omie_oben_777)" "2"
+SAME4=$(Pq -c "SELECT bool_and(oi.created_at = so.created_at) FROM public.order_items oi JOIN public.sales_orders so ON so.id=oi.sales_order_id WHERE so.hash_payload='omie_oben_777';")
+eq "A4 item reparado usa created_at do PAI (2023, não hoje — G6)" "$SAME4" "t"
+ANO=$(Pq -c "SELECT EXTRACT(year FROM oi.created_at)::int FROM public.order_items oi JOIN public.sales_orders so ON so.id=oi.sales_order_id WHERE so.hash_payload='omie_oben_777' LIMIT 1;")
+eq "A4 ano do item reparado = 2023 (não 2026)" "$ANO" "2023"
+
+# A5 — DIVERGÊNCIA (G5): órfão 888 (total local=100), payload total=999 → NÃO repara, marca divergence
+J=$(cat <<EOF
+[{"account":"oben","hash_payload":"omie_oben_888","customer_user_id":"$c1","created_by":"$sys","total":999,"status":"faturado","order_date_kpi":"2024-02-02","itens":[{"omie_codigo_produto":1001,"product_id":"$p1","quantity":1,"unit_price":999}]}]
+EOF
+)
+rpc "$J"
+eq "A5 divergence=1" "$DIV" "1"
+eq "A5 repaired=0 (não reconcilia)" "$REP" "0"
+eq "A5 órfão divergente segue SEM itens" "$(cnt omie_oben_888)" "0"
+
+# A6 — SKIP_COMPLETE (G4): pedido 999 já tem item → reparo é no-op (não vira 2)
+J=$(cat <<EOF
+[{"account":"oben","hash_payload":"omie_oben_999","customer_user_id":"$c1","created_by":"$sys","total":30,"status":"faturado","itens":[{"omie_codigo_produto":1001,"product_id":"$p1","quantity":1,"unit_price":30},{"omie_codigo_produto":1002,"product_id":"$p2","quantity":1,"unit_price":30}]}]
+EOF
+)
+rpc "$J"
+eq "A6 skipped_complete=1" "$SKC" "1"
+eq "A6 itens inalterados (1, não 2)" "$(cnt omie_oben_999)" "1"
+
+# A8 — GRANT (G1): authenticated NÃO executa; service_role executa
+R=$(P -tA 2>&1 <<'SQL'
+SET ROLE authenticated;
+DO $$ BEGIN
+  PERFORM public.criar_pedidos_com_itens('[]'::jsonb);
+  RAISE EXCEPTION 'EXECUTOU_NAO_DEVIA';
+EXCEPTION
+  WHEN insufficient_privilege THEN RAISE NOTICE 'GRANT_NEGADO_OK';
+  WHEN OTHERS THEN RAISE;
+END $$;
+SQL
+)
+case "$R" in *GRANT_NEGADO_OK*) ok "A8 authenticated negado (42501)" ;; *) bad "A8 — veio: $R" ;; esac
+SRV=$(Pq -c "SET ROLE service_role; SELECT (public.criar_pedidos_com_itens('[]'::jsonb))->>'inserted';" | tail -1)
+eq "A8 service_role executa" "$SRV" "0"
+
+# A9 — CORRIDA (G3): reparo concorrente do mesmo órfão (555) NÃO duplica itens
+corrida() {  # $1 = hash; popula CNT_R
+  local hash="$1"
+  ( P -q <<SQL
+BEGIN;
+SELECT id FROM public.sales_orders WHERE hash_payload='$hash' FOR UPDATE;
+SELECT pg_sleep(4);
+INSERT INTO public.order_items(sales_order_id,customer_user_id,omie_codigo_produto,product_id,quantity,unit_price,created_at)
+  SELECT id,customer_user_id,1001,'$p1',1,25,created_at FROM public.sales_orders WHERE hash_payload='$hash';
+COMMIT;
+SQL
+  ) &
+  local apid=$!
+  sleep 1.5
+  local jb
+  jb=$(cat <<EOF
+[{"account":"oben","hash_payload":"$hash","customer_user_id":"$c1","created_by":"$sys","total":50,"status":"faturado","order_date_kpi":"2023-01-15","itens":[{"omie_codigo_produto":1001,"product_id":"$p1","quantity":1,"unit_price":25}]}]
+EOF
+)
+  Pq -c "SELECT public.criar_pedidos_com_itens('$jb'::jsonb);" >/dev/null
+  wait $apid || true
+  CNT_R=$(cnt "$hash")
+}
+corrida omie_oben_555
+eq "A9 corrida: reparo concorrente não duplica (FOR UPDATE serializou)" "$CNT_R" "1"
+
+# ════════════════════════════════════════════════════════════════════════════
+# ZONA 5 — FALSIFICAÇÃO (Lei #3): sabota cada guard → exige VERMELHO → restaura
+# ════════════════════════════════════════════════════════════════════════════
+echo "── falsificação (sabota → exige vermelho → restaura) ──"
+SAB="/tmp/mig-sabotada-${SLUG}.sql"
+restaura() { P -q -f "$MIG"; }   # re-aplica a versão verdadeira (idempotente)
+
+# F1 (G3 FOR UPDATE): sem o lock, a corrida duplica → CNT vira 2
+sed 's/ FOR UPDATE;/;/' "$MIG" > "$SAB"; P -q -f "$SAB"
+corrida omie_oben_556
+if [ "$CNT_R" = "2" ]; then ok "F1 sem FOR UPDATE a corrida DUPLICA (=2) → A9 tem dente"; else bad "F1 sabotei FOR UPDATE e não duplicou (veio $CNT_R) → A9 fraco"; fi
+restaura
+
+# F2 (G6 created_at): trocando v_created_at por now(), reparo de órfão antigo vira HOJE
+sed 's/v_created_at  -- G6/now()  -- G6/g' "$MIG" > "$SAB"; P -q -f "$SAB"
+J=$(cat <<EOF
+[{"account":"oben","hash_payload":"omie_oben_778","customer_user_id":"$c1","created_by":"$sys","total":50,"status":"faturado","order_date_kpi":"2023-03-03","itens":[{"omie_codigo_produto":1001,"product_id":"$p1","quantity":1,"unit_price":50}]}]
+EOF
+)
+Pq -c "SELECT public.criar_pedidos_com_itens('$J'::jsonb);" >/dev/null
+SAMEF=$(Pq -c "SELECT bool_and(oi.created_at = so.created_at) FROM public.order_items oi JOIN public.sales_orders so ON so.id=oi.sales_order_id WHERE so.hash_payload='omie_oben_778';")
+if [ "$SAMEF" = "f" ]; then ok "F2 com now() o item NÃO bate com o pai → A4 tem dente"; else bad "F2 sabotei created_at e itens ainda batem com o pai (veio $SAMEF) → A4 fraco"; fi
+restaura
+
+# F3 (G5 divergência): sem o guard, repara cabeçalho divergente (889 total=100, payload=999)
+sed 's/IF v_diverge THEN/IF false THEN/' "$MIG" > "$SAB"; P -q -f "$SAB"
+J=$(cat <<EOF
+[{"account":"oben","hash_payload":"omie_oben_889","customer_user_id":"$c1","created_by":"$sys","total":999,"status":"faturado","order_date_kpi":"2024-02-02","itens":[{"omie_codigo_produto":1001,"product_id":"$p1","quantity":1,"unit_price":999}]}]
+EOF
+)
+Pq -c "SELECT public.criar_pedidos_com_itens('$J'::jsonb);" >/dev/null
+DI=$(cnt omie_oben_889)
+if [ "$DI" != "0" ]; then ok "F3 sem o guard, cabeçalho divergente é reparado (itens=$DI) → A5 tem dente"; else bad "F3 sabotei divergência e não reparou → A5 fraco"; fi
+restaura
+P -q -c "DELETE FROM public.order_items oi USING public.sales_orders so WHERE oi.sales_order_id=so.id AND so.hash_payload='omie_oben_889';" >/dev/null
+
+# F4 (G7 não-cria-sem-item): com WHERE true, pai sem item válido é criado
+sed 's/WHERE v_item_count > 0/WHERE true/' "$MIG" > "$SAB"; P -q -f "$SAB"
+J=$(cat <<EOF
+[{"account":"oben","hash_payload":"omie_oben_106","customer_user_id":"$c1","created_by":"$sys","total":10,"status":"faturado","omie_pedido_id":106,"itens":[{"omie_codigo_produto":null,"quantity":1,"unit_price":10}]}]
+EOF
+)
+Pq -c "SELECT public.criar_pedidos_com_itens('$J'::jsonb);" >/dev/null
+if [ "$(paiexiste omie_oben_106)" = "1" ]; then ok "F4 sem o WHERE, pai órfão é criado → A3 tem dente"; else bad "F4 sabotei G7 e o pai não entrou → A3 fraco"; fi
+restaura
+
+# F5 (G1 grant): concedendo a authenticated, A8 deixa de barrar
+P -q -c "GRANT EXECUTE ON FUNCTION public.criar_pedidos_com_itens(jsonb) TO authenticated;"
+R=$(P -tA 2>&1 <<'SQL'
+SET ROLE authenticated;
+DO $$ BEGIN
+  PERFORM public.criar_pedidos_com_itens('[]'::jsonb);
+  RAISE NOTICE 'SABOTAGEM_EXECUTOU';
+EXCEPTION WHEN OTHERS THEN RAISE NOTICE 'AINDA_BARRA'; END $$;
+SQL
+)
+case "$R" in *SABOTAGEM_EXECUTOU*) ok "F5 com grant a authenticated o gate cai → A8 tem dente" ;; *) bad "F5 concedi grant e ainda barrou → A8 fraco" ;; esac
+restaura  # re-aplica REVOKE FROM authenticated da migration
+
+# F6 (G2 índice): sem o índice unique, a RPC não consegue ON CONFLICT → pedido vai p/ failed (42P10)
+P -q -c "DROP INDEX public.uniq_sales_orders_omie_hash;"
+J=$(cat <<EOF
+[{"account":"oben","hash_payload":"omie_oben_107","customer_user_id":"$c1","created_by":"$sys","total":10,"status":"faturado","omie_pedido_id":107,"itens":[{"omie_codigo_produto":1001,"product_id":"$p1","quantity":1,"unit_price":10}]}]
+EOF
+)
+SS=$(Pq -c "SELECT (public.criar_pedidos_com_itens('$J'::jsonb))#>>'{failed,0,sqlstate}';")
+if [ "$SS" = "42P10" ]; then ok "F6 sem o índice a RPC falha (42P10) → o índice é necessário p/ o ON CONFLICT"; else bad "F6 droppei o índice e não veio 42P10 (veio '$SS')"; fi
+restaura  # recria o índice
+
+# ── veredito ──
+echo "──────────────────────────────"
+echo "RESULTADO: $PASS ok / $FAIL fail"
+[ "$FAIL" = "0" ] || { echo "❌ HARNESS VERMELHO"; exit 1; }
+echo "✅ HARNESS VERDE"

--- a/db/test-criar-pedidos-com-itens.sh
+++ b/db/test-criar-pedidos-com-itens.sh
@@ -113,7 +113,12 @@ INSERT INTO public.sales_orders(customer_user_id,created_by,account,hash_payload
   ('$c1','$sys','oben','omie_oben_555',50,'faturado','2023-01-15','2023-01-15T00:00:00Z',555),
   ('$c1','$sys','oben','omie_oben_556',50,'faturado','2023-01-15','2023-01-15T00:00:00Z',556),
   ('$c1','$sys','oben','omie_oben_778',50,'faturado','2023-03-03','2023-03-03T00:00:00Z',778),
-  ('$c1','$sys','oben','omie_oben_889',100,'faturado','2024-02-02','2024-02-02T00:00:00Z',889);
+  ('$c1','$sys','oben','omie_oben_889',100,'faturado','2024-02-02','2024-02-02T00:00:00Z',889),
+  ('$c1','$sys','oben','omie_oben_780',50,'separacao','2024-03-03','2024-03-03T00:00:00Z',780),
+  ('$c1','$sys','oben','omie_oben_781',50,'faturado','2024-04-04','2024-04-04T00:00:00Z',781);
+-- price pré-existente p/ o 781 (Codex P2: reparo não pode duplicar histórico de preço)
+INSERT INTO public.sales_price_history(customer_user_id, product_id, unit_price, sales_order_id)
+  SELECT '$c1','$p1',50, id FROM public.sales_orders WHERE hash_payload='omie_oben_781';
 SQL
 
 # helper: chama a RPC 1x e popula INS REP SKC SKN DIV FAIL
@@ -205,6 +210,27 @@ EOF
 rpc "$J"
 eq "A6 skipped_complete=1" "$SKC" "1"
 eq "A6 itens inalterados (1, não 2)" "$(cnt omie_oben_999)" "1"
+
+# A5b — STATUS evoluiu não bloqueia reparo (Codex P1#2): órfão 'separacao' total=50,
+# payload 'faturado' total=50 (MESMO total) → repara (status fora do guard)
+J=$(cat <<EOF
+[{"account":"oben","hash_payload":"omie_oben_780","customer_user_id":"$c1","created_by":"$sys","total":50,"status":"faturado","order_date_kpi":"2024-03-03","itens":[{"omie_codigo_produto":1001,"product_id":"$p1","quantity":1,"unit_price":50}]}]
+EOF
+)
+rpc "$J"
+eq "A5b status evoluiu (separacao→faturado) NÃO bloqueia (P1#2)" "$REP" "1"
+eq "A5b sem divergência espúria" "$DIV" "0"
+eq "A5b 780 reparado (1 item)" "$(cnt omie_oben_780)" "1"
+
+# A7b — price idempotente no reparo (Codex P2): órfão 781 já tem 1 price → reparo não duplica
+J=$(cat <<EOF
+[{"account":"oben","hash_payload":"omie_oben_781","customer_user_id":"$c1","created_by":"$sys","total":50,"status":"faturado","order_date_kpi":"2024-04-04","itens":[{"omie_codigo_produto":1001,"product_id":"$p1","quantity":1,"unit_price":50}],"precos":[{"product_id":"$p1","unit_price":50}]}]
+EOF
+)
+rpc "$J"
+eq "A7b 781 reparado (1 item)" "$(cnt omie_oben_781)" "1"
+PH781=$(Pq -c "SELECT count(*) FROM public.sales_price_history sph JOIN public.sales_orders so ON so.id=sph.sales_order_id WHERE so.hash_payload='omie_oben_781';")
+eq "A7b reparo NÃO duplica price (1, não 2)" "$PH781" "1"
 
 # A8 — GRANT (G1): authenticated NÃO executa; service_role executa
 R=$(P -tA 2>&1 <<'SQL'

--- a/db/test-criar-pedidos-com-itens.sh
+++ b/db/test-criar-pedidos-com-itens.sh
@@ -79,6 +79,10 @@ CREATE TABLE public.sales_price_history (
 ALTER TABLE public.sales_orders ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.order_items ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.sales_price_history ENABLE ROW LEVEL SECURITY;
+-- Índice canônico (em prod vem da migration 20260617133634 #929) — PRÉ-REQUISITO da RPC.
+-- Predicado 'omie\_%' (underscore LITERAL); a RPC usa o MESMO no ON CONFLICT (match exato exigido).
+CREATE UNIQUE INDEX uniq_sales_orders_omie_hash
+  ON public.sales_orders (account, hash_payload) WHERE hash_payload LIKE 'omie\_%';
 SQL
 
 # ── ZONA 2 — aplica a migration REAL (Lei #1) ──
@@ -86,9 +90,9 @@ MIG="$REPO_ROOT/supabase/migrations/20260617160000_criar_pedidos_com_itens.sql"
 P -q -f "$MIG"
 echo "migration aplicada: $(basename "$MIG")"
 
-# índice unique foi criado?
+# índice canônico (pré-req da 133634) presente — a RPC só casa o ON CONFLICT se o predicado bater
 HASIDX=$(Pq -c "SELECT count(*) FROM pg_indexes WHERE indexname='uniq_sales_orders_omie_hash';")
-eq "M0 índice unique criado" "$HASIDX" "1"
+eq "M0 índice canônico presente (pré-req; A0/A2 provam o ON CONFLICT casa omie\\_%)" "$HASIDX" "1"
 
 # ── ZONA 3 — seed (como postgres: superuser, sem RLS) ──
 P -q <<SQL

--- a/db/test-criar-pedidos-com-itens.sh
+++ b/db/test-criar-pedidos-com-itens.sh
@@ -49,7 +49,6 @@ c2="22222222-2222-2222-2222-222222222222"
 sys="33333333-3333-3333-3333-333333333333"
 p1="aaaaaaaa-0000-0000-0000-000000000001"
 p2="aaaaaaaa-0000-0000-0000-000000000002"
-HOJE="$(date '+%Y-%m-%d')"
 
 # ── ZONA 1 — pré-requisitos de schema (fiel ao prod: NOT NULL/defaults/FK CASCADE) ──
 P -q <<'SQL'
@@ -121,9 +120,9 @@ SQL
 rpc() {
   local row
   row=$(Pq -c "WITH r AS (SELECT public.criar_pedidos_com_itens('$1'::jsonb) AS j)
-    SELECT j->>'inserted',j->>'repaired',j->>'skipped_complete',j->>'skipped_no_items',
+    SELECT j->>'inserted',j->>'repaired',j->>'items',j->>'skipped_complete',j->>'skipped_no_items',
            jsonb_array_length(j->'divergence'),jsonb_array_length(j->'failed') FROM r;")
-  IFS='|' read -r INS REP SKC SKN DIV FAILED <<< "$row"   # FAILED (não FAIL — colidiria com o contador)
+  IFS='|' read -r INS REP ITEMS SKC SKN DIV FAILED <<< "$row"   # FAILED (não FAIL — colidiria com o contador)
 }
 cnt() { Pq -c "SELECT count(*) FROM public.order_items oi JOIN public.sales_orders so ON so.id=oi.sales_order_id WHERE so.hash_payload='$1';"; }
 paiexiste() { Pq -c "SELECT count(*) FROM public.sales_orders WHERE hash_payload='$1';"; }
@@ -137,6 +136,7 @@ EOF
 )
 rpc "$J"
 eq "A0 inserted=1" "$INS" "1"
+eq "A0 items=2 (contador da RPC)" "$ITEMS" "2"
 eq "A0 2 order_items" "$(cnt omie_oben_100)" "2"
 PH=$(Pq -c "SELECT count(*) FROM public.sales_price_history WHERE sales_order_id=(SELECT id FROM public.sales_orders WHERE hash_payload='omie_oben_100');")
 eq "A0 2 sales_price_history (G10)" "$PH" "2"
@@ -180,6 +180,7 @@ EOF
 )
 rpc "$J"
 eq "A4 repaired=1" "$REP" "1"
+eq "A4 items=2 (restaurados)" "$ITEMS" "2"
 eq "A4 órfão reparado (2 itens)" "$(cnt omie_oben_777)" "2"
 SAME4=$(Pq -c "SELECT bool_and(oi.created_at = so.created_at) FROM public.order_items oi JOIN public.sales_orders so ON so.id=oi.sales_order_id WHERE so.hash_payload='omie_oben_777';")
 eq "A4 item reparado usa created_at do PAI (2023, não hoje — G6)" "$SAME4" "t"

--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,12 +21,12 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **256** custom migrations totais
-- **974** objetos esperados (criados por estas migrations)
+- **257** custom migrations totais
+- **976** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
-  - `function`: 264
+  - `function`: 265
   - `rls_policy`: 217
-  - `index`: 183
+  - `index`: 184
   - `table`: 107
   - `cron_job`: 106
   - `trigger`: 48
@@ -2270,6 +2270,13 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 ### `20260617091500_sinal_classe_config_check_classe.sql`
 
 > _Nenhum objeto extraído via regex._ Migration provavelmente é `ALTER TABLE` / `UPDATE` / `INSERT` / RLS-only. Validar manualmente.
+
+### `20260617160000_criar_pedidos_com_itens.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `public.criar_pedidos_com_itens` | — |
+| `index` | `public.uniq_sales_orders_omie_hash` | `sales_orders` |
 
 ## Próximos passos quando algo der `❌`
 

--- a/docs/superpowers/specs/2026-06-17-atomicidade-pedido-itens-omie-design.md
+++ b/docs/superpowers/specs/2026-06-17-atomicidade-pedido-itens-omie-design.md
@@ -1,0 +1,108 @@
+# Atomicidade pai+filho do sync de pedidos Omie (`sales_orders`/`order_items`) — Design
+
+> **Origem:** achado #5 do `/codex challenge` (2026-06-17) ao revisar o sub-projeto 1 do [cursor+lease de vendas](./2026-06-17-vendas-omie-cursor-lease-design.md). **Débito pré-existente** — não foi introduzido pelo cursor/lease; é independente e pode (deve) ser entregue antes dele.
+>
+> **Money-path crítico:** `order_items` alimenta positivação/OTE/comissão dos farmers (`fin-valor-cockpit` usa `order_items.created_at >= ttm_inicio`; views `v_caca_*`). `sales_price_history` alimenta o preço-cliente sugerido (`analyze-unified-order`, `useCustomerSelection`). Erro aqui = dinheiro errado. Segue `docs/agent/money-path.md` (precisão>recall, gate humano, prove-sql, Codex em cada etapa).
+>
+> **2ª opinião:** `/codex consult` (reasoning high, 2026-06-17) — validou a direção (RPC transacional) e adicionou 7 guards (ver §4). **Codex challenge adversarial do CÓDIGO** fica para o PR (pós-implementação).
+
+## 1. Problema
+
+Em `supabase/functions/omie-vendas-sync/index.ts`, `syncPedidos` (linhas 902-1320), o pai (`sales_orders`) e o filho (`order_items`) são escritos em **duas chamadas PostgREST `.insert()` separadas** — `index.ts:1217` (pai, com `.select('id, hash_payload')`) e `index.ts:1300` (itens em batch). Cada `.insert()` é **um POST HTTP = uma transação Postgres distinta**: pai e filho nunca compartilham transação. Se o pai entra e os itens falham, o pedido fica **órfão (sem itens)**. Três caminhos:
+
+- **(A)** batch de itens falha → só `console.error` (`index.ts:1301`), **nunca re-tentado**;
+- **(B)** fallback one-by-one: insere o pai single (`index.ts:1228`) e depois `order_items.insert` (`index.ts:1249`) **sem checar erro nenhum**;
+- **(C)** 1 item inválido derruba um batch de 200 itens que é **cross-pedido** (`allItemRows` agrega itens de vários pedidos), orfanando **vários pais de uma vez**.
+
+**Trinco (não é self-healing):** a próxima invocação pré-carrega todos os `hash_payload` de pai em memória (`existingHashes`, `index.ts:944-961`) e na `index.ts:1140` faz `if (existingHashes.has(hash)) { skippedExisting++; continue }` → **pula o pedido inteiro, nunca olha os itens** → os itens faltantes **nunca são reparados**.
+
+## 2. Estado atual (empírico — `psql-ro` prod, 2026-06-17)
+
+| Fato | Valor |
+|---|---|
+| Pais Omie sem itens (órfãos) | **405** de 6255 (**6,5%**) |
+| Órfãos presos >90d (não reaparecem na janela do cron) | **~358 (88%)** — `oben` 400 / `colacor` 5; mais antigo 2020 |
+| Status dos órfãos | **374 "faturado"** (92%) = comissão real faltando |
+| Índice `uniq_sales_orders_omie_hash (account, hash_payload) WHERE hash_payload LIKE 'omie_%'` | **NÃO existe em prod** (migration 20260617133634 escrita mas não aplicada — falha silenciosa Lovable). 0 dups → **criável limpo** |
+| `order_items.hash_payload` | **nullable, sem UNIQUE; 363 grupos duplicados LEGÍTIMOS** (hash = `omie_<acct>_<pedido>_<produto>`; mesmo produto em 2 linhas do pedido colide). Histórico já dropou `UNIQUE(sales_order_id, omie_codigo_produto)` (cc886ba2) |
+| FK | `order_items.sales_order_id → sales_orders.id ON DELETE CASCADE` |
+| `order_items.created_at` | sync atual **não seta** → `DEFAULT now()`. Consumido por `fin-valor-cockpit` (TTM) e `v_caca_*` → money-path |
+| `ConsultarPedido` | **já usado** no edge (`index.ts:1615`, reconciliação de duplicado) → reusável no job de reparo |
+
+**Leitura:** a não-atomicidade é a causa raiz. O hash do item **não é naturalmente único** → idempotência do reparo tem que ser por "este pedido já tem itens?" (NOT EXISTS), não por `ON CONFLICT` no item. 88% dos órfãos estão **presos fora da janela** → o reparo do histórico é um **job dedicado** (`ConsultarPedido`), não efeito colateral do skip-path.
+
+## 3. Decisões (founder 2026-06-17 + Codex)
+
+| Decisão | Escolha |
+|---|---|
+| Correção | **RPC transacional** (fronteira única no Postgres), não 2 inserts PostgREST. Descarta "Opção 2 pura" (mantém janela de corrupção + não fecha corrida). |
+| Escopo | **Pacote completo numa entrega:** prevenção (RPC+índice+edge) **+** job de reparo dos ~358 presos (`ConsultarPedido` → mesma RPC). |
+| `sales_price_history` | **Dentro da mesma transação da RPC** (é money-path; custo trivial). |
+| Reconciliação de pedido **alterado** (total/status/cliente/data) | **PROIBIDA** (Fase 2). Reparo só preenche relação filha **ausente** de cabeçalho **compatível**. |
+| Quem executa | Migration/edge deploy = **humano** (SQL Editor + chat Lovable, verbatim). Monitoramento/disparo de reparo = **eu via `psql-ro`** + o humano aciona o job. |
+
+## 4. Guards money-path (os 7 do Codex + 3 derivados viram requisitos)
+
+- **G1 — `SECURITY INVOKER`, não `DEFINER`.** O edge já usa `service_role`. `GRANT EXECUTE` só `service_role`; `REVOKE FROM PUBLIC, anon, authenticated`. `SET search_path = ''` + nomes qualificados (`public.…`). (DEFINER seria write-primitive que bypassa RLS à toa.)
+- **G2 — `ON CONFLICT (account, hash_payload) WHERE hash_payload LIKE 'omie_%' DO NOTHING`.** Índice parcial exige alvo parcial; não é nomeável por `ON CONSTRAINT`.
+- **G3 — `SELECT … FOR UPDATE` no pai** (após o `ON CONFLICT DO NOTHING`, quando conflitou) **antes** do `NOT EXISTS`. **Fecha a corrida sem depender do lease** (sub-projeto 1, não deployado): row lock ligado ao dado real, não advisory lock.
+- **G4 — Idempotência por `NOT EXISTS` no nível do pedido.** Nunca UNIQUE no hash do item (363 dups legítimos).
+- **G5 — Guard de divergência.** Repara **só** se o cabeçalho local for compatível com o payload (mesmo `total`/`status`/`customer_user_id`/`order_date_kpi`). Divergiu → **não repara**, marca `divergence[]` (relatório Fase 2). Senão é "reconciliação parcial disfarçada".
+- **G6 — `order_items.created_at := sales_orders.created_at`** (nunca `now()`). Reparar pedido antigo com `now()` joga venda velha na janela TTM atual → infla positivação do período errado.
+- **G7 — Não criar pai sem item válido** no payload (hoje é fábrica de órfãos "válidos"). *(Validar consumidores que contam pedidos-sem-item; default = não-criar + relatar.)*
+- **G8 — Telemetria estruturada.** RPC retorna `{inserted, repaired, skipped_complete, skipped_no_items, divergence[], failed[]}` (cada `failed`/`divergence` com `codigo_pedido` + motivo). Nunca engolir erro por pedido como sucesso invisível.
+- **G9 — Subtransação por pedido** (`BEGIN/EXCEPTION` no loop): 1 pedido ruim não derruba os outros.
+- **G10 — `sales_price_history` na mesma transação** (replica a regra `valor_unitario > 0` + `product_id` mapeado).
+
+### Limites declarados (monitorar, NÃO auto-corrigir)
+- **L1** — `NOT EXISTS` só repara **zero-itens**. Pedido **parcialmente** preenchido (caminho C) não é reparado → **monitorar item-count mismatch**, não auto-corrigir.
+- **L2** — Pai sem item no próprio Omie não é reparável → **relatório**.
+- **L3** — Divergência de cabeçalho → **Fase 2** (não auto-reconcilia).
+
+## 5. Desenho
+
+### 5.1 Migration (SQL Editor, após `prove-sql-money-path`)
+1. `CREATE UNIQUE INDEX uniq_sales_orders_omie_hash ON public.sales_orders (account, hash_payload) WHERE hash_payload LIKE 'omie_%';` (limpo, 0 dups).
+2. RPC `public.criar_pedidos_com_itens(p_pedidos jsonb) RETURNS jsonb` — INVOKER + grants (G1). Contrato: `p_pedidos` = array de `{ <campos do pai>, itens: [<campos do item>], precos: [<campos de price_history>] }`. Loop por pedido em subtransação (G9), aplicando G2-G8, G10. Retorna o agregado (G8).
+
+### 5.2 Edge — prevenção (`syncPedidos`)
+- Trocar os 2 inserts (+ fallback one-by-one + batch de itens + batch de preços, `index.ts:1216-1310`) por **1 chamada à RPC por página** (array de pedidos válidos).
+- **Skip: de "pai existe" para "pai existe COM itens".** Pré-carregar o set de `hash_payload` de pais **que já têm ≥1 item** (em vez de todos os pais); pedido com pai-sem-itens **não é pulado** → vai à RPC, que **auto-repara** (G3-G6). *(Alternativa do Codex: mandar todos os válidos e "deixar o banco decidir" — adotar a versão com pré-load de hashes-com-itens por eficiência no backfill; cair para "manda todos" se a lógica de pré-load ficar frágil.)*
+
+### 5.3 Edge — reparo dos presos (novo `case "reparar_orfaos_itens"`)
+- Query (eu calculo via `psql-ro`; o edge recebe a lista ou pagina por `account`): `sales_orders` órfãos (`hash_payload LIKE 'omie_%'` + `NOT EXISTS order_items`).
+- Para cada (bulk + `waitUntil` + retry, **nunca N+1 ingênuo** — Omie pune; ver `reposicao.md`): `ConsultarPedido({ codigo_pedido: omie_pedido_id })` → monta payload → chama a **mesma RPC** (idempotente; G3-G6 protegem). Telemetria por lote.
+
+### 5.4 Monitoramento (eu, `psql-ro`, read-only)
+- **Órfãos novos**: contagem pós-deploy (deve tender a 0).
+- **Item-count mismatch** (L1): pedidos com nº de itens ≠ esperado.
+- **Recência** (G6): `order_items.created_at` dos reparados = `sales_orders.created_at` (amostra antes/depois).
+- **Duplicação** (G3): nenhum item duplicado além dos 363 grupos legítimos pré-existentes.
+
+## 6. Gates humanos — NUNCA automático
+Aplicar migration (SQL Editor) · redeploy do edge (chat Lovable, verbatim) · disparar o job `reparar_orfaos_itens` · aprovar o relatório de divergência (L3) · declarar "histórico reparado". **Eu gero evidência (read-only) e empacoto a ação; o humano cola/aprova.**
+
+## 7. Testes — `prove-sql-money-path` (PG17 local, falsificável)
+Cada assert **positivo E negativo** (SQLSTATE + re-raise), cada um **falsificado** (sabotar a migration → exigir vermelho):
+1. **Atomicidade**: item inválido no payload → pai **NÃO** entra (rollback da subtransação), e os **outros** pedidos do lote entram (G9).
+2. **`ON CONFLICT` parcial** (G2): re-enviar o mesmo pedido → não duplica pai.
+3. **Corrida `FOR UPDATE`** (G3): 2 sessões concorrentes reparando o mesmo órfão → **só 1** insere itens (sem duplicar). *(harness com 2 conexões.)*
+4. **Reparo idempotente** (G4): pai já com itens → reparo é no-op.
+5. **Divergência** (G5): pai local com `total`/`status` ≠ payload → **não repara**, marca `divergence`.
+6. **`created_at` coerente** (G6): reparo de pedido antigo → `order_items.created_at = sales_orders.created_at`, **não** `now()`.
+7. **Não-cria-pai-sem-item** (G7): payload sem item válido → pai não entra.
+8. **Grants** (G1): `SET ROLE authenticated` → `EXECUTE` negado; `service_role` → ok.
+9. **`sales_price_history`** (G10): entra na mesma transação; rollback do pedido também reverte os preços daquele pedido.
+
+## 8. Riscos e limites
+- **Deploy do edge é manual** (Lovable, verbatim) — coordenar com `lovable-deploy-verify`. Migration custom não auto-aplica (validar com `pg_get_functiondef` pós-apply via `psql-ro`).
+- **Reescrita do write-path do edge** é a parte mais invasiva → `/codex challenge` adversarial do diff antes do merge; piloto com **1 janela pequena de 1 conta** antes de qualquer backfill grande.
+- **G7 muda semântica** (deixa de criar pai sem item) — confirmar que nenhum consumidor conta pedidos-sem-item antes de cravar.
+- **Job de reparo é N+1 controlado** no Omie (~358 `ConsultarPedido`) → batching + `waitUntil` + retry; rodar fora de pico; eu monitoro a cadência.
+
+## 9. Plano de implementação (alto nível)
+1. Migration: índice unique + RPC (INVOKER, FOR UPDATE, grants) → **`prove-sql-money-path`** (§7, falsificável).
+2. Edge prevenção: `syncPedidos` chama a RPC + skip por "pai-com-itens" → `/codex challenge` → deploy manual → `lovable-deploy-verify`.
+3. **Monitorar órfãos novos 24-48h** (`psql-ro`) — confirmar que a torneira fechou.
+4. Edge reparo: `case "reparar_orfaos_itens"` (`ConsultarPedido` → RPC) → piloto (1 lote pequeno) → backfill dos 358 → eu valido cobertura/recência/duplicação (§5.4).
+5. *(Independente: sub-projeto 1 cursor+lease segue seu próprio fluxo — não bloqueia isto.)*

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 256
+-- Total de custom migrations: 257
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -275,7 +275,8 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260616130000', 'v_grupo_contatos', '20260616130000_v_grupo_contatos.sql'),
   ('20260616140000', 'v_grupo_comercial', '20260616140000_v_grupo_comercial.sql'),
   ('20260616140941', 'fatia2_sinais_ligacao', '20260616140941_fatia2_sinais_ligacao.sql'),
-  ('20260617091500', 'sinal_classe_config_check_classe', '20260617091500_sinal_classe_config_check_classe.sql')
+  ('20260617091500', 'sinal_classe_config_check_classe', '20260617091500_sinal_classe_config_check_classe.sql'),
+  ('20260617160000', 'criar_pedidos_com_itens', '20260617160000_criar_pedidos_com_itens.sql')
 )
 SELECT
   e.version,
@@ -1267,7 +1268,9 @@ WITH expected_objects (migration, kind, schema_name, object_name, parent_name) A
   ('fatia2_sinais_ligacao', 'trigger', 'public', 'trg_farmer_calls_enqueue_recalc_sinais', 'farmer_calls'),
   ('fatia2_sinais_ligacao', 'rls_policy', 'public', 'sinal_classe_config_select_staff', 'sinal_classe_config'),
   ('fatia2_sinais_ligacao', 'rls_policy', 'public', 'sinal_classe_config_master_all', 'sinal_classe_config'),
-  ('fatia2_sinais_ligacao', 'rls_policy', 'public', 'sinal_classe_config_service_all', 'sinal_classe_config')
+  ('fatia2_sinais_ligacao', 'rls_policy', 'public', 'sinal_classe_config_service_all', 'sinal_classe_config'),
+  ('criar_pedidos_com_itens', 'function', 'public', 'criar_pedidos_com_itens', ''),
+  ('criar_pedidos_com_itens', 'index', 'public', 'uniq_sales_orders_omie_hash', 'sales_orders')
 )
 SELECT
   e.migration,

--- a/supabase/functions/omie-vendas-sync/index.ts
+++ b/supabase/functions/omie-vendas-sync/index.ts
@@ -135,42 +135,8 @@ interface OrderItemPayload {
   tint_nome_cor?: string;
 }
 
-interface OrderBatchRow {
-  customer_user_id: string;
-  created_by: string;
-  items: OrderItemPayload[];
-  subtotal: number;
-  discount: number;
-  total: number;
-  status: string;
-  omie_pedido_id: number;
-  omie_numero_pedido: string;
-  account: Account;
-  hash_payload: string;
-  created_at: string;
-  notes: string | null;
-  customer_address: string | null;
-  customer_phone: string | null;
-}
-
-interface OrderItemBatchRow {
-  sales_order_id: string;
-  customer_user_id: string;
-  product_id: string | null;
-  omie_codigo_produto: number | null;
-  quantity: number;
-  unit_price: number;
-  discount: number;
-  hash_payload: string;
-}
-
-interface PriceHistoryBatchRow {
-  customer_user_id: string;
-  product_id: string;
-  unit_price: number;
-  sales_order_id: string;
-  created_at: string;
-}
+// (OrderBatchRow/OrderItemBatchRow/PriceHistoryBatchRow removidos: o sync agora monta o payload
+//  da RPC criar_pedidos_com_itens — pai+itens+preços atômicos — em vez de 3 inserts soltos.)
 
 interface EditItemInput {
   product_id?: string | null;
@@ -940,25 +906,12 @@ async function syncPedidos(
   }
   console.log(`[sync_pedidos][${account}] Document map: ${docToUserMap.size} profiles`);
 
-  // ── Pre-load ALL existing hash_payloads for this account (skip duplicates in bulk) ──
-  const existingHashes = new Set<string>();
-  let hPage = 0;
-  hasMore = true;
-  while (hasMore) {
-    const { data: batch } = await supabase
-      .from('sales_orders')
-      .select('hash_payload')
-      .eq('account', account)
-      .not('hash_payload', 'is', null)
-      .range(hPage * pgSize, (hPage + 1) * pgSize - 1);
-    if (!batch || batch.length === 0) { hasMore = false; }
-    else {
-      for (const row of batch) if (row.hash_payload) existingHashes.add(row.hash_payload);
-      if (batch.length < pgSize) hasMore = false;
-      hPage++;
-    }
-  }
-  console.log(`[sync_pedidos][${account}] Existing hashes: ${existingHashes.size}`);
+  // Dedupe DENTRO da run (evita mandar o mesmo pedido 2x na mesma chamada). NÃO pré-carregamos
+  // hashes do banco: todos os pedidos válidos da janela vão para a RPC criar_pedidos_com_itens,
+  // que decide insert/skip-completo/reparo atomicamente (ON CONFLICT parcial + SELECT FOR UPDATE
+  // + NOT EXISTS). Assim um órfão (pai sem itens) que reaparece na janela é AUTO-REPARADO — antes
+  // era pulado pelo hash do pai e os itens nunca eram restaurados.
+  const seenHashes = new Set<string>();
 
   // ── Pre-load omie_clientes mapping (codigo_cliente -> user_id) to AVOID API calls ──
   const clientCache = new Map<number, string | null>();
@@ -1120,9 +1073,8 @@ async function syncPedidos(
       }
     }
 
-    // ── Prepare batch arrays ──
-    const orderBatch: OrderBatchRow[] = [];
-    const orderMeta: Array<{ hashPayload: string; detalhes: OmieDetalheItem[]; customerUserId: string; createdAt: string }> = [];
+    // ── Monta o array de pedidos (pai + itens + preços) para a RPC transacional ──
+    const pedidosRpc: Array<Record<string, unknown>> = [];
 
     for (const pedido of pedidos) {
       const cab = pedido.cabecalho || {};
@@ -1136,9 +1088,9 @@ async function syncPedidos(
 
       const hashPayload = `omie_${account}_${codigoPedido}`;
 
-      // Skip if already synced (in-memory check, no DB call)
-      if (existingHashes.has(hashPayload)) { skippedExisting++; continue; }
-      existingHashes.add(hashPayload); // prevent duplicates within same run
+      // Dedupe dentro da run (a RPC decide skip-completo/reparo no banco — não pulamos por hash aqui).
+      if (seenHashes.has(hashPayload)) continue;
+      seenHashes.add(hashPayload);
 
       const detalhes: OmieDetalheItem[] = pedido.det || [];
       const itemsJson: OrderItemPayload[] = [];
@@ -1191,7 +1143,34 @@ async function syncPedidos(
       // Get cached address/phone for this client
       const clientInfo = clientAddressCache.get(codigoCliente) || { address: '', phone: '' };
 
-      orderBatch.push({
+      // Itens (order_items) e preços (sales_price_history) deste pedido — entram na MESMA
+      // transação da RPC (atômico com o pai). Mantém o filtro por codigo_produto e a regra
+      // de preço (>0 + produto mapeado) do comportamento anterior.
+      const itensRpc: Array<Record<string, unknown>> = [];
+      const precosRpc: Array<Record<string, unknown>> = [];
+      for (const det of detalhes) {
+        const prod = det.produto || {};
+        if (!prod.codigo_produto) continue;
+        const productId = productMap.get(prod.codigo_produto) || null;
+        itensRpc.push({
+          customer_user_id: customerUserId,
+          product_id: productId,
+          omie_codigo_produto: prod.codigo_produto,
+          quantity: prod.quantidade || 1,
+          unit_price: prod.valor_unitario || 0,
+          discount: prod.desconto || 0,
+          hash_payload: `${hashPayload}_${prod.codigo_produto}`,
+        });
+        if (productId && (prod.valor_unitario || 0) > 0) {
+          precosRpc.push({
+            customer_user_id: customerUserId,
+            product_id: productId,
+            unit_price: prod.valor_unitario,
+          });
+        }
+      }
+
+      pedidosRpc.push({
         customer_user_id: customerUserId,
         created_by: systemUserId,
         items: itemsJson,
@@ -1208,115 +1187,152 @@ async function syncPedidos(
         notes: cab.observacoes_pedido || null,
         customer_address: clientInfo.address || null,
         customer_phone: clientInfo.phone || null,
+        itens: itensRpc,
+        precos: precosRpc,
       });
-      orderMeta.push({ hashPayload, detalhes, customerUserId, createdAt });
     }
 
-    // ── Batch insert orders ──
-    if (orderBatch.length > 0) {
-      const { data: insertedOrders, error: orderErr } = await supabase
-        .from('sales_orders')
-        .insert(orderBatch)
-        .select('id, hash_payload');
-
-      if (orderErr) {
-        console.error(`[sync_pedidos][${account}] Batch insert error pág ${pagina}:`, orderErr.message);
-        // Fallback: try one-by-one
-        for (let idx = 0; idx < orderBatch.length; idx++) {
-          const { data: single, error: singleErr } = await supabase
-            .from('sales_orders')
-            .insert(orderBatch[idx])
-            .select('id')
-            .single();
-          if (!singleErr && single) {
-            totalSynced++;
-            // Insert items + prices for this order
-            const meta = orderMeta[idx];
-            const itemRows = meta.detalhes.map((det) => {
-              const prod = det.produto || {};
-              return {
-                sales_order_id: single.id,
-                customer_user_id: meta.customerUserId,
-                product_id: (prod.codigo_produto ? productMap.get(prod.codigo_produto) : null) || null,
-                omie_codigo_produto: prod.codigo_produto || null,
-                quantity: prod.quantidade || 1,
-                unit_price: prod.valor_unitario || 0,
-                discount: prod.desconto || 0,
-                hash_payload: `${meta.hashPayload}_${prod.codigo_produto}`,
-              };
-            }).filter((i) => i.omie_codigo_produto);
-            if (itemRows.length > 0) {
-              await supabase.from('order_items').insert(itemRows);
-              totalItems += itemRows.length;
-            }
-          }
-        }
-      } else if (insertedOrders) {
-        totalSynced += insertedOrders.length;
-
-        // Build hash -> id map for inserted orders
-        const hashToId = new Map<string, string>();
-        for (const o of insertedOrders) if (o.hash_payload) hashToId.set(o.hash_payload, o.id);
-
-        // ── Batch insert order_items ──
-        const allItemRows: OrderItemBatchRow[] = [];
-        const allPriceRows: PriceHistoryBatchRow[] = [];
-
-        for (const meta of orderMeta) {
-          const orderId = hashToId.get(meta.hashPayload);
-          if (!orderId) continue;
-
-          for (const det of meta.detalhes) {
-            const prod = det.produto || {};
-            if (!prod.codigo_produto) continue;
-
-            allItemRows.push({
-              sales_order_id: orderId,
-              customer_user_id: meta.customerUserId,
-              product_id: productMap.get(prod.codigo_produto) || null,
-              omie_codigo_produto: prod.codigo_produto,
-              quantity: prod.quantidade || 1,
-              unit_price: prod.valor_unitario || 0,
-              discount: prod.desconto || 0,
-              hash_payload: `${meta.hashPayload}_${prod.codigo_produto}`,
-            });
-
-            const productId = productMap.get(prod.codigo_produto);
-            if (productId && prod.valor_unitario > 0) {
-              allPriceRows.push({
-                customer_user_id: meta.customerUserId,
-                product_id: productId,
-                unit_price: prod.valor_unitario,
-                sales_order_id: orderId,
-                created_at: meta.createdAt,
-              });
-            }
-          }
-        }
-
-        // Insert items in batches of 200
-        for (let i = 0; i < allItemRows.length; i += 200) {
-          const batch = allItemRows.slice(i, i + 200);
-          const { error: itemsErr } = await supabase.from('order_items').insert(batch);
-          if (itemsErr) console.error(`[sync_pedidos][${account}] Items batch error:`, itemsErr.message);
-          else totalItems += batch.length;
-        }
-
-        // Insert prices in batches of 200
-        for (let i = 0; i < allPriceRows.length; i += 200) {
-          const batch = allPriceRows.slice(i, i + 200);
-          await supabase.from('sales_price_history').insert(batch);
-        }
+    // ── Escrita ATÔMICA pai+filhos via RPC (substitui os 2 inserts PostgREST não-transacionais
+    // que deixavam pedidos órfãos sem itens). A RPC decide por pedido: insert (novo) / repair
+    // (órfão de cabeçalho compatível) / skip (completo ou divergente). Ver migration
+    // 20260617160000_criar_pedidos_com_itens.sql + prove em db/test-criar-pedidos-com-itens.sh.
+    if (pedidosRpc.length > 0) {
+      const { data: rpcRes, error: rpcErr } = await supabase.rpc('criar_pedidos_com_itens', { p_pedidos: pedidosRpc });
+      if (rpcErr) {
+        console.error(`[sync_pedidos][${account}] RPC criar_pedidos_com_itens falhou pág ${pagina}:`, rpcErr.message);
+      } else if (rpcRes) {
+        const r = rpcRes as { inserted?: number; repaired?: number; items?: number; skipped_complete?: number; skipped_no_items?: number; divergence?: unknown[]; failed?: unknown[] };
+        totalSynced += (r.inserted || 0) + (r.repaired || 0);
+        totalItems += r.items || 0;
+        skippedExisting += r.skipped_complete || 0;
+        const divs = r.divergence || [];
+        const fails = r.failed || [];
+        if (divs.length > 0) console.warn(`[sync_pedidos][${account}] ${divs.length} pedido(s) com cabeçalho divergente (Fase 2, NÃO reconciliado):`, JSON.stringify(divs.slice(0, 5)));
+        if (fails.length > 0) console.error(`[sync_pedidos][${account}] ${fails.length} pedido(s) FALHARAM na RPC pág ${pagina}:`, JSON.stringify(fails.slice(0, 5)));
+        console.log(`[sync_pedidos][${account}] RPC pág ${pagina}: inserted=${r.inserted || 0} repaired=${r.repaired || 0} items=${r.items || 0} skip_completo=${r.skipped_complete || 0} skip_sem_item=${r.skipped_no_items || 0} divergencia=${divs.length} falhas=${fails.length}`);
       }
     }
 
-    console.log(`[sync_pedidos][${account}] Página ${pagina}/${totalPaginas} — ${orderBatch.length} novos, ${skippedExisting} existentes`);
+    console.log(`[sync_pedidos][${account}] Página ${pagina}/${totalPaginas} — ${pedidosRpc.length} processados, ${skippedNoClient} sem cliente`);
     pagina++;
     pagesProcessed++;
   }
 
   const complete = pagina > totalPaginas;
   return { totalSynced, totalItems, skippedNoClient, skippedExisting, totalPaginas, lastPage: pagina - 1, nextPage: complete ? null : pagina, complete };
+}
+
+// ── Reparo dos órfãos PRESOS (pai sem itens, fora da janela do cron) ──────────────────
+// Recebe a lista de omie_pedido_id a reparar (calculada via psql-ro). Para cada um:
+// ConsultarPedido no Omie → monta itens → chama a MESMA RPC criar_pedidos_com_itens, que só
+// repara se o cabeçalho local for compatível (guard de divergência). customer_user_id/created_by/
+// order_date_kpi vêm do PAI existente; total/status vêm do Omie ATUAL, para a RPC detectar pedido
+// alterado (→ relatório, não reconcilia). Idempotente: reprocessar é seguro (RPC faz NOT EXISTS).
+async function repararOrfaosItens(
+  supabase: SupabaseClient,
+  account: Account,
+  pedidoIds: number[],
+) {
+  let reparados = 0, itens = 0, divergencias = 0, falhas = 0, semDados = 0, jaCompletos = 0;
+  const divergenciaAmostra: unknown[] = [];
+  if (!Array.isArray(pedidoIds) || pedidoIds.length === 0) {
+    return { reparados, itens, divergencias, falhas, semDados, jaCompletos, total: 0, divergenciaAmostra };
+  }
+
+  // Pre-load product map (codigo_produto -> product_id)
+  const productMap = new Map<number, string>();
+  {
+    let page = 0; const sz = 1000; let more = true;
+    while (more) {
+      const { data: batch } = await supabase
+        .from('omie_products').select('id, omie_codigo_produto')
+        .eq('account', account).range(page * sz, (page + 1) * sz - 1);
+      if (!batch || batch.length === 0) { more = false; }
+      else { for (const p of batch) productMap.set(p.omie_codigo_produto, p.id); if (batch.length < sz) more = false; page++; }
+    }
+  }
+
+  // Busca os pais órfãos em lote (só reparamos o que já existe como pai)
+  const paiByPedido = new Map<number, { customer_user_id: string; created_by: string; hash_payload: string; order_date_kpi: string | null }>();
+  for (let i = 0; i < pedidoIds.length; i += 300) {
+    const { data: pais } = await supabase
+      .from('sales_orders')
+      .select('omie_pedido_id, customer_user_id, created_by, hash_payload, order_date_kpi')
+      .eq('account', account)
+      .in('omie_pedido_id', pedidoIds.slice(i, i + 300));
+    for (const p of (pais || [])) paiByPedido.set(p.omie_pedido_id, p);
+  }
+
+  const LOTE = 20;
+  for (let i = 0; i < pedidoIds.length; i += LOTE) {
+    const lote = pedidoIds.slice(i, i + LOTE);
+    const pedidosRpc: Array<Record<string, unknown>> = [];
+
+    for (const pid of lote) {
+      const pai = paiByPedido.get(pid);
+      if (!pai) { semDados++; continue; } // sem pai órfão p/ esse id
+
+      const consulta = await callOmieVendasApi(
+        "produtos/pedido/", "ConsultarPedido", { codigo_pedido: pid }, account,
+      ) as { pedido_venda_produto?: OmiePedidoVendaProduto } | OmiePedidoVendaProduto | null;
+      if (!consulta) { semDados++; continue; }
+      const pv = ((consulta as { pedido_venda_produto?: OmiePedidoVendaProduto }).pedido_venda_produto ?? consulta) as OmiePedidoVendaProduto;
+      const det: OmieDetalheItem[] = pv.det || [];
+      const cab = pv.cabecalho || {};
+
+      const itensRpc: Array<Record<string, unknown>> = [];
+      const precosRpc: Array<Record<string, unknown>> = [];
+      let subtotal = 0;
+      for (const d of det) {
+        const prod = d.produto || {};
+        if (!prod.codigo_produto) continue;
+        const qty = prod.quantidade || 1, price = prod.valor_unitario || 0, desc = prod.desconto || 0;
+        subtotal += qty * price * (1 - desc / 100);
+        const productId = productMap.get(prod.codigo_produto) || null;
+        itensRpc.push({
+          customer_user_id: pai.customer_user_id, product_id: productId,
+          omie_codigo_produto: prod.codigo_produto,
+          quantity: qty, unit_price: price, discount: desc,
+          hash_payload: `${pai.hash_payload}_${prod.codigo_produto}`,
+        });
+        if (productId && price > 0) precosRpc.push({ customer_user_id: pai.customer_user_id, product_id: productId, unit_price: price });
+      }
+      if (itensRpc.length === 0) { semDados++; continue; } // Omie tb não tem item válido (limite L2)
+
+      let status = 'importado';
+      const etapa = cab.etapa || '';
+      if (etapa === '60' || etapa === '70') status = 'faturado';
+      else if (etapa === '50') status = 'separacao';
+      else if (etapa === '20') status = 'enviado';
+      else if (etapa === '80') status = 'cancelado';
+
+      pedidosRpc.push({
+        account, hash_payload: pai.hash_payload, omie_pedido_id: pid,
+        customer_user_id: pai.customer_user_id, created_by: pai.created_by,
+        total: Math.round(subtotal * 100) / 100, status, order_date_kpi: pai.order_date_kpi,
+        itens: itensRpc, precos: precosRpc,
+      });
+    }
+
+    if (pedidosRpc.length > 0) {
+      const { data: r, error } = await supabase.rpc('criar_pedidos_com_itens', { p_pedidos: pedidosRpc });
+      if (error) {
+        falhas += pedidosRpc.length;
+        console.error(`[reparar_orfaos][${account}] RPC falhou no lote ${i}:`, error.message);
+      } else if (r) {
+        const rr = r as { repaired?: number; items?: number; skipped_complete?: number; divergence?: unknown[]; failed?: unknown[] };
+        reparados += rr.repaired || 0;
+        itens += rr.items || 0;
+        jaCompletos += rr.skipped_complete || 0;
+        divergencias += (rr.divergence || []).length;
+        falhas += (rr.failed || []).length;
+        for (const d of (rr.divergence || [])) if (divergenciaAmostra.length < 20) divergenciaAmostra.push(d);
+      }
+    }
+    console.log(`[reparar_orfaos][${account}] lote ${Math.floor(i / LOTE) + 1}: reparados=${reparados} itens=${itens} divergencias=${divergencias} falhas=${falhas} semDados=${semDados}`);
+  }
+
+  return { reparados, itens, divergencias, falhas, semDados, jaCompletos, total: pedidoIds.length, divergenciaAmostra };
 }
 
 // Buscar transportadora pelo nome (razão social) no Omie
@@ -2283,6 +2299,16 @@ serve(async (req) => {
         break;
       }
 
+      case "reparar_orfaos_itens": {
+        // Reparo dos órfãos PRESOS (pai sem itens, fora da janela do cron). A lista de
+        // omie_pedido_id é calculada via psql-ro (read-only) e passada em pedido_ids.
+        const pedidoIdsReparo = Array.isArray(params.pedido_ids) ? (params.pedido_ids as number[]) : [];
+        if (pedidoIdsReparo.length === 0) throw new Error("reparar_orfaos_itens requer pedido_ids: number[] (omie_pedido_id dos órfãos)");
+        const reparoResult = await repararOrfaosItens(supabaseAdmin, account, pedidoIdsReparo);
+        result = { success: true, ...reparoResult };
+        break;
+      }
+
       case "historico_produtos_cliente": {
         const { codigo_cliente: codCliHist } = params;
         if (!codCliHist) throw new Error("Código do cliente é obrigatório");
@@ -2301,7 +2327,7 @@ serve(async (req) => {
               },
               account
             );
-            const lista = pedidos?.pedido_venda_produto || [];
+            const lista = ((pedidos as { pedido_venda_produto?: OmiePedidoVendaProduto[] } | null)?.pedido_venda_produto) || [];
             for (const pedido of lista) {
               const dataPedido = pedido?.cabecalho?.data_previsao || pedido?.infoCadastro?.dInc || '';
               const itens = pedido?.det || [];
@@ -2312,7 +2338,7 @@ serve(async (req) => {
                 }
               }
             }
-            const totalPages = pedidos?.total_de_paginas || 1;
+            const totalPages = ((pedidos as { total_de_paginas?: number } | null)?.total_de_paginas) || 1;
             if (page >= totalPages) break;
           }
         } catch (e) {

--- a/supabase/functions/omie-vendas-sync/index.ts
+++ b/supabase/functions/omie-vendas-sync/index.ts
@@ -880,6 +880,7 @@ async function syncPedidos(
   let pagesProcessed = 0;
   let skippedNoClient = 0;
   let skippedExisting = 0;
+  let totalFailed = 0;
 
   // ── Pre-load document -> user_id mapping from profiles ──
   const docToUserMap = new Map<string, string>();
@@ -1199,7 +1200,10 @@ async function syncPedidos(
     if (pedidosRpc.length > 0) {
       const { data: rpcRes, error: rpcErr } = await supabase.rpc('criar_pedidos_com_itens', { p_pedidos: pedidosRpc });
       if (rpcErr) {
-        console.error(`[sync_pedidos][${account}] RPC criar_pedidos_com_itens falhou pág ${pagina}:`, rpcErr.message);
+        // Money-path: a RPC é o ÚNICO caminho de escrita agora. Se ela falha (migration não
+        // aplicada, grant, schema, conexão), LANÇAR — senão o sync fica verde sem gravar nada e
+        // o fin_sync_log marca 'complete' mascarando perda total (achado /codex challenge).
+        throw new Error(`[sync_pedidos][${account}] RPC criar_pedidos_com_itens falhou pág ${pagina}: ${rpcErr.message}`);
       } else if (rpcRes) {
         const r = rpcRes as { inserted?: number; repaired?: number; items?: number; skipped_complete?: number; skipped_no_items?: number; divergence?: unknown[]; failed?: unknown[] };
         totalSynced += (r.inserted || 0) + (r.repaired || 0);
@@ -1207,6 +1211,7 @@ async function syncPedidos(
         skippedExisting += r.skipped_complete || 0;
         const divs = r.divergence || [];
         const fails = r.failed || [];
+        totalFailed += fails.length;
         if (divs.length > 0) console.warn(`[sync_pedidos][${account}] ${divs.length} pedido(s) com cabeçalho divergente (Fase 2, NÃO reconciliado):`, JSON.stringify(divs.slice(0, 5)));
         if (fails.length > 0) console.error(`[sync_pedidos][${account}] ${fails.length} pedido(s) FALHARAM na RPC pág ${pagina}:`, JSON.stringify(fails.slice(0, 5)));
         console.log(`[sync_pedidos][${account}] RPC pág ${pagina}: inserted=${r.inserted || 0} repaired=${r.repaired || 0} items=${r.items || 0} skip_completo=${r.skipped_complete || 0} skip_sem_item=${r.skipped_no_items || 0} divergencia=${divs.length} falhas=${fails.length}`);
@@ -1219,7 +1224,7 @@ async function syncPedidos(
   }
 
   const complete = pagina > totalPaginas;
-  return { totalSynced, totalItems, skippedNoClient, skippedExisting, totalPaginas, lastPage: pagina - 1, nextPage: complete ? null : pagina, complete };
+  return { totalSynced, totalItems, totalFailed, skippedNoClient, skippedExisting, totalPaginas, lastPage: pagina - 1, nextPage: complete ? null : pagina, complete };
 }
 
 // ── Reparo dos órfãos PRESOS (pai sem itens, fora da janela do cron) ──────────────────
@@ -1252,15 +1257,17 @@ async function repararOrfaosItens(
     }
   }
 
-  // Busca os pais órfãos em lote (só reparamos o que já existe como pai)
-  const paiByPedido = new Map<number, { customer_user_id: string; created_by: string; hash_payload: string; order_date_kpi: string | null }>();
+  // Busca os pais por hash_payload determinístico (omie_<account>_<pid>), NÃO por omie_pedido_id:
+  // (account, omie_pedido_id) é duplicado por design (push×pull, ver onda1_fase0) → buscar por id
+  // pegaria a linha errada (ex.: a do push com hash_payload NULL). O hash é único (índice parcial).
+  const paiByHash = new Map<string, { customer_user_id: string; created_by: string; hash_payload: string; order_date_kpi: string | null }>();
   for (let i = 0; i < pedidoIds.length; i += 300) {
+    const hashes = pedidoIds.slice(i, i + 300).map((pid) => `omie_${account}_${pid}`);
     const { data: pais } = await supabase
       .from('sales_orders')
-      .select('omie_pedido_id, customer_user_id, created_by, hash_payload, order_date_kpi')
-      .eq('account', account)
-      .in('omie_pedido_id', pedidoIds.slice(i, i + 300));
-    for (const p of (pais || [])) paiByPedido.set(p.omie_pedido_id, p);
+      .select('customer_user_id, created_by, hash_payload, order_date_kpi')
+      .in('hash_payload', hashes);
+    for (const p of (pais || [])) paiByHash.set(p.hash_payload, p);
   }
 
   const LOTE = 20;
@@ -1269,8 +1276,8 @@ async function repararOrfaosItens(
     const pedidosRpc: Array<Record<string, unknown>> = [];
 
     for (const pid of lote) {
-      const pai = paiByPedido.get(pid);
-      if (!pai) { semDados++; continue; } // sem pai órfão p/ esse id
+      const pai = paiByHash.get(`omie_${account}_${pid}`);
+      if (!pai) { semDados++; continue; } // sem pai (com hash omie) p/ esse id
 
       const consulta = await callOmieVendasApi(
         "produtos/pedido/", "ConsultarPedido", { codigo_pedido: pid }, account,

--- a/supabase/migrations/20260617160000_criar_pedidos_com_itens.sql
+++ b/supabase/migrations/20260617160000_criar_pedidos_com_itens.sql
@@ -39,8 +39,8 @@ DECLARE
   v_skipped_no_items int := 0;
   v_divergence jsonb := '[]'::jsonb;
   v_failed     jsonb := '[]'::jsonb;
-  v_db_total numeric; v_db_status text; v_db_customer uuid; v_db_kpi date;
-  v_pl_total numeric; v_pl_status text; v_pl_customer uuid; v_pl_kpi date;
+  v_db_total numeric; v_db_customer uuid;
+  v_pl_total numeric; v_pl_customer uuid;
 BEGIN
   IF p_pedidos IS NULL OR jsonb_typeof(p_pedidos) <> 'array' THEN
     RAISE EXCEPTION 'p_pedidos deve ser array jsonb (veio %)', jsonb_typeof(p_pedidos)
@@ -92,8 +92,8 @@ BEGIN
         v_do_items := true;                       -- pai novo → grava filhos
       ELSE
         -- não inseriu: ou G7 filtrou (pai novo sem item válido), ou conflito (já existe)
-        SELECT id, created_at, total, status, customer_user_id, order_date_kpi
-          INTO v_existing, v_created_at, v_db_total, v_db_status, v_db_customer, v_db_kpi
+        SELECT id, created_at, total, customer_user_id
+          INTO v_existing, v_created_at, v_db_total, v_db_customer
           FROM public.sales_orders
          WHERE account = v_account AND hash_payload = v_hash
          FOR UPDATE;                              -- G3: trava o pai (fecha corrida sem lease)
@@ -108,15 +108,16 @@ BEGIN
             v_skipped_no_items := v_skipped_no_items + 1;    -- L2: órfão e payload sem item
           ELSE
             -- ── G5: guard de divergência (reparo ≠ reconciliação) ──
+            -- Divergência = sinal de que os ITENS mudaram, não o cabeçalho. NÃO comparamos
+            -- status (evolui naturalmente: separacao→faturado→...) nem a data — só travariam
+            -- reparos legítimos, escondendo positivação. total = soma dos itens (mesma fórmula
+            -- na criação e no reparo) → proxy de mudança de item/valor; tolerância de arredondamento.
+            -- customer = reatribuição do pedido a outro cliente (vira outro pedido).
             v_pl_total    := coalesce((v_pedido->>'total')::numeric, 0);
-            v_pl_status   := coalesce(v_pedido->>'status', 'importado');
             v_pl_customer := (v_pedido->>'customer_user_id')::uuid;
-            v_pl_kpi      := (v_pedido->>'order_date_kpi')::date;
-            v_diverge := (v_db_total    IS DISTINCT FROM v_pl_total
-                       OR v_db_status   IS DISTINCT FROM v_pl_status
-                       OR v_db_customer IS DISTINCT FROM v_pl_customer
-                       OR v_db_kpi      IS DISTINCT FROM v_pl_kpi);
-            IF v_diverge THEN   -- G5: cabeçalho mudou no Omie → não repara (Fase 2)
+            v_diverge := (abs(coalesce(v_db_total, 0) - v_pl_total) > 0.01
+                       OR v_db_customer IS DISTINCT FROM v_pl_customer);
+            IF v_diverge THEN   -- G5: itens/cliente divergem do pai → não repara (Fase 2)
               v_divergence := v_divergence || jsonb_build_object(
                 'codigo_pedido', v_pedido->'omie_pedido_id',
                 'hash', v_hash, 'motivo', 'cabecalho diverge do payload');
@@ -149,18 +150,22 @@ BEGIN
         GET DIAGNOSTICS v_n = ROW_COUNT;
         v_items := v_items + v_n;
 
-        -- ── G10: sales_price_history na MESMA transação, created_at coerente ──
-        INSERT INTO public.sales_price_history (
-          customer_user_id, product_id, unit_price, sales_order_id, created_at
-        )
-        SELECT coalesce((pr->>'customer_user_id')::uuid, (v_pedido->>'customer_user_id')::uuid),
-               (pr->>'product_id')::uuid,
-               (pr->>'unit_price')::numeric,
-               v_order_id,
-               v_created_at  -- G6
-        FROM jsonb_array_elements(coalesce(v_pedido->'precos', '[]'::jsonb)) AS pr
-        WHERE (pr->>'product_id') IS NOT NULL
-          AND coalesce((pr->>'unit_price')::numeric, 0) > 0;
+        -- ── G10: sales_price_history na MESMA transação (created_at coerente). Só se ainda NÃO
+        -- houver preço para este pedido — idempotente no reparo (evita duplicar histórico se o
+        -- fluxo antigo já gravou preço mas perdeu os itens). ──
+        IF NOT EXISTS (SELECT 1 FROM public.sales_price_history WHERE sales_order_id = v_order_id) THEN
+          INSERT INTO public.sales_price_history (
+            customer_user_id, product_id, unit_price, sales_order_id, created_at
+          )
+          SELECT coalesce((pr->>'customer_user_id')::uuid, (v_pedido->>'customer_user_id')::uuid),
+                 (pr->>'product_id')::uuid,
+                 (pr->>'unit_price')::numeric,
+                 v_order_id,
+                 v_created_at  -- G6
+          FROM jsonb_array_elements(coalesce(v_pedido->'precos', '[]'::jsonb)) AS pr
+          WHERE (pr->>'product_id') IS NOT NULL
+            AND coalesce((pr->>'unit_price')::numeric, 0) > 0;
+        END IF;
       END IF;
 
     EXCEPTION WHEN OTHERS THEN

--- a/supabase/migrations/20260617160000_criar_pedidos_com_itens.sql
+++ b/supabase/migrations/20260617160000_criar_pedidos_com_itens.sql
@@ -1,0 +1,185 @@
+-- Atomicidade pai+filho do sync de pedidos Omie (sales_orders/order_items)
+-- Spec: docs/superpowers/specs/2026-06-17-atomicidade-pedido-itens-omie-design.md
+-- Achado #5 do /codex challenge ao sub-projeto 1 do cursor+lease. Money-path:
+-- order_items alimenta positivação/OTE/comissão; sales_price_history alimenta pricing.
+--
+-- Provado em PG17 local (db/test-criar-pedidos-com-itens.sh) com falsificação.
+-- ⚠️ MIGRATION MANUAL — Lovable NÃO auto-aplica nome custom. Colar no SQL Editor → Run.
+-- Idempotente (CREATE INDEX IF NOT EXISTS + CREATE OR REPLACE FUNCTION); re-colar é seguro.
+
+-- ── 1. Índice unique parcial do pai (habilita o ON CONFLICT da RPC; G2) ──
+-- 0 duplicatas de (account, hash_payload) em prod (2026-06-17) → criável limpo.
+CREATE UNIQUE INDEX IF NOT EXISTS uniq_sales_orders_omie_hash
+  ON public.sales_orders (account, hash_payload)
+  WHERE hash_payload LIKE 'omie_%';
+
+-- ── 2. RPC transacional pai+filho (fronteira única; substitui 2 inserts PostgREST) ──
+CREATE OR REPLACE FUNCTION public.criar_pedidos_com_itens(p_pedidos jsonb)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY INVOKER            -- G1: edge já usa service_role; DEFINER seria write-primitive à toa
+SET search_path = ''       -- G1: nomes qualificados (public.*); built-ins via pg_catalog
+AS $$
+DECLARE
+  v_pedido     jsonb;
+  v_account    text;
+  v_hash       text;
+  v_order_id   uuid;
+  v_existing   uuid;
+  v_created_at timestamptz;
+  v_item_count int;
+  v_has_items  boolean;
+  v_do_items   boolean;
+  v_diverge    boolean;
+  v_inserted   int := 0;
+  v_repaired   int := 0;
+  v_skipped_complete int := 0;
+  v_skipped_no_items int := 0;
+  v_divergence jsonb := '[]'::jsonb;
+  v_failed     jsonb := '[]'::jsonb;
+  v_db_total numeric; v_db_status text; v_db_customer uuid; v_db_kpi date;
+  v_pl_total numeric; v_pl_status text; v_pl_customer uuid; v_pl_kpi date;
+BEGIN
+  IF p_pedidos IS NULL OR jsonb_typeof(p_pedidos) <> 'array' THEN
+    RAISE EXCEPTION 'p_pedidos deve ser array jsonb (veio %)', jsonb_typeof(p_pedidos)
+      USING ERRCODE = '22023';
+  END IF;
+
+  FOR v_pedido IN SELECT * FROM jsonb_array_elements(p_pedidos)
+  LOOP
+    v_order_id := NULL; v_existing := NULL; v_do_items := false;
+    BEGIN  -- ── G9: subtransação por pedido (1 ruim não derruba os outros) ──
+      v_account := v_pedido->>'account';
+      v_hash    := v_pedido->>'hash_payload';
+      IF v_account IS NULL OR v_hash IS NULL THEN
+        RAISE EXCEPTION 'pedido sem account/hash_payload' USING ERRCODE = '22023';
+      END IF;
+
+      -- conta itens VÁLIDOS (com codigo_produto) — base do G7
+      SELECT count(*) INTO v_item_count
+      FROM jsonb_array_elements(coalesce(v_pedido->'itens', '[]'::jsonb)) AS it
+      WHERE (it->>'omie_codigo_produto') IS NOT NULL;
+
+      -- ── tenta inserir o pai: só com item válido (G7); ON CONFLICT parcial (G2) ──
+      INSERT INTO public.sales_orders (
+        customer_user_id, created_by, items, subtotal, discount, total, status,
+        omie_pedido_id, omie_numero_pedido, account, hash_payload, created_at,
+        order_date_kpi, notes, customer_address, customer_phone
+      )
+      SELECT
+        (v_pedido->>'customer_user_id')::uuid,
+        (v_pedido->>'created_by')::uuid,
+        coalesce(v_pedido->'items', '[]'::jsonb),
+        coalesce((v_pedido->>'subtotal')::numeric, 0),
+        coalesce((v_pedido->>'discount')::numeric, 0),
+        coalesce((v_pedido->>'total')::numeric, 0),
+        coalesce(v_pedido->>'status', 'importado'),
+        (v_pedido->>'omie_pedido_id')::bigint,
+        v_pedido->>'omie_numero_pedido',
+        v_account, v_hash,
+        coalesce((v_pedido->>'created_at')::timestamptz, now()),
+        (v_pedido->>'order_date_kpi')::date,
+        v_pedido->>'notes', v_pedido->>'customer_address', v_pedido->>'customer_phone'
+      WHERE v_item_count > 0
+      ON CONFLICT (account, hash_payload) WHERE hash_payload LIKE 'omie_%'
+      DO NOTHING
+      RETURNING id, created_at INTO v_order_id, v_created_at;
+
+      IF v_order_id IS NOT NULL THEN
+        v_inserted := v_inserted + 1;
+        v_do_items := true;                       -- pai novo → grava filhos
+      ELSE
+        -- não inseriu: ou G7 filtrou (pai novo sem item válido), ou conflito (já existe)
+        SELECT id, created_at, total, status, customer_user_id, order_date_kpi
+          INTO v_existing, v_created_at, v_db_total, v_db_status, v_db_customer, v_db_kpi
+          FROM public.sales_orders
+         WHERE account = v_account AND hash_payload = v_hash
+         FOR UPDATE;                              -- G3: trava o pai (fecha corrida sem lease)
+
+        IF v_existing IS NULL THEN
+          v_skipped_no_items := v_skipped_no_items + 1;     -- G7: pai novo sem item válido
+        ELSE
+          v_has_items := EXISTS(SELECT 1 FROM public.order_items WHERE sales_order_id = v_existing);
+          IF v_has_items THEN
+            v_skipped_complete := v_skipped_complete + 1;   -- G4: já completo, no-op
+          ELSIF v_item_count = 0 THEN
+            v_skipped_no_items := v_skipped_no_items + 1;    -- L2: órfão e payload sem item
+          ELSE
+            -- ── G5: guard de divergência (reparo ≠ reconciliação) ──
+            v_pl_total    := coalesce((v_pedido->>'total')::numeric, 0);
+            v_pl_status   := coalesce(v_pedido->>'status', 'importado');
+            v_pl_customer := (v_pedido->>'customer_user_id')::uuid;
+            v_pl_kpi      := (v_pedido->>'order_date_kpi')::date;
+            v_diverge := (v_db_total    IS DISTINCT FROM v_pl_total
+                       OR v_db_status   IS DISTINCT FROM v_pl_status
+                       OR v_db_customer IS DISTINCT FROM v_pl_customer
+                       OR v_db_kpi      IS DISTINCT FROM v_pl_kpi);
+            IF v_diverge THEN   -- G5: cabeçalho mudou no Omie → não repara (Fase 2)
+              v_divergence := v_divergence || jsonb_build_object(
+                'codigo_pedido', v_pedido->'omie_pedido_id',
+                'hash', v_hash, 'motivo', 'cabecalho diverge do payload');
+            ELSE
+              v_order_id := v_existing;            -- reparo
+              v_repaired := v_repaired + 1;
+              v_do_items := true;
+            END IF;
+          END IF;
+        END IF;
+      END IF;
+
+      IF v_do_items THEN
+        -- ── G6: order_items.created_at = created_at do PAI (nunca now()) ──
+        INSERT INTO public.order_items (
+          sales_order_id, customer_user_id, product_id, omie_codigo_produto,
+          quantity, unit_price, discount, hash_payload, created_at
+        )
+        SELECT v_order_id,
+               coalesce((it->>'customer_user_id')::uuid, (v_pedido->>'customer_user_id')::uuid),
+               (it->>'product_id')::uuid,
+               (it->>'omie_codigo_produto')::bigint,
+               coalesce((it->>'quantity')::numeric, 1),
+               coalesce((it->>'unit_price')::numeric, 0),
+               coalesce((it->>'discount')::numeric, 0),
+               it->>'hash_payload',
+               v_created_at  -- G6
+        FROM jsonb_array_elements(coalesce(v_pedido->'itens', '[]'::jsonb)) AS it
+        WHERE (it->>'omie_codigo_produto') IS NOT NULL;
+
+        -- ── G10: sales_price_history na MESMA transação, created_at coerente ──
+        INSERT INTO public.sales_price_history (
+          customer_user_id, product_id, unit_price, sales_order_id, created_at
+        )
+        SELECT coalesce((pr->>'customer_user_id')::uuid, (v_pedido->>'customer_user_id')::uuid),
+               (pr->>'product_id')::uuid,
+               (pr->>'unit_price')::numeric,
+               v_order_id,
+               v_created_at  -- G6
+        FROM jsonb_array_elements(coalesce(v_pedido->'precos', '[]'::jsonb)) AS pr
+        WHERE (pr->>'product_id') IS NOT NULL
+          AND coalesce((pr->>'unit_price')::numeric, 0) > 0;
+      END IF;
+
+    EXCEPTION WHEN OTHERS THEN
+      -- G8: registra a falha do pedido (SQLSTATE + msg), não engole como sucesso invisível
+      v_failed := v_failed || jsonb_build_object(
+        'codigo_pedido', v_pedido->'omie_pedido_id',
+        'hash', v_pedido->>'hash_payload',
+        'sqlstate', SQLSTATE, 'erro', SQLERRM);
+    END;
+  END LOOP;
+
+  RETURN jsonb_build_object(
+    'inserted', v_inserted, 'repaired', v_repaired,
+    'skipped_complete', v_skipped_complete, 'skipped_no_items', v_skipped_no_items,
+    'divergence', v_divergence, 'failed', v_failed);
+END;
+$$;
+
+COMMENT ON FUNCTION public.criar_pedidos_com_itens(jsonb) IS
+  'Sync Omie: insere pai+filhos atômico (subtransação/pedido). ON CONFLICT parcial (account,hash_payload). '
+  'Repara órfão (pai sem itens) só se cabeçalho compatível (G5) — não reconcilia pedido alterado (Fase 2). '
+  'created_at dos filhos = created_at do pai. Retorna {inserted,repaired,skipped_complete,skipped_no_items,divergence[],failed[]}.';
+
+-- ── 3. Grants (G1): só service_role executa; revogar anon/authenticated por NOME (§54 database.md) ──
+REVOKE ALL ON FUNCTION public.criar_pedidos_com_itens(jsonb) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.criar_pedidos_com_itens(jsonb) TO service_role;

--- a/supabase/migrations/20260617160000_criar_pedidos_com_itens.sql
+++ b/supabase/migrations/20260617160000_criar_pedidos_com_itens.sql
@@ -33,6 +33,8 @@ DECLARE
   v_diverge    boolean;
   v_inserted   int := 0;
   v_repaired   int := 0;
+  v_items      int := 0;   -- itens de fato inseridos (impacto do reparo)
+  v_n          int;
   v_skipped_complete int := 0;
   v_skipped_no_items int := 0;
   v_divergence jsonb := '[]'::jsonb;
@@ -144,6 +146,8 @@ BEGIN
                v_created_at  -- G6
         FROM jsonb_array_elements(coalesce(v_pedido->'itens', '[]'::jsonb)) AS it
         WHERE (it->>'omie_codigo_produto') IS NOT NULL;
+        GET DIAGNOSTICS v_n = ROW_COUNT;
+        v_items := v_items + v_n;
 
         -- ── G10: sales_price_history na MESMA transação, created_at coerente ──
         INSERT INTO public.sales_price_history (
@@ -169,7 +173,7 @@ BEGIN
   END LOOP;
 
   RETURN jsonb_build_object(
-    'inserted', v_inserted, 'repaired', v_repaired,
+    'inserted', v_inserted, 'repaired', v_repaired, 'items', v_items,
     'skipped_complete', v_skipped_complete, 'skipped_no_items', v_skipped_no_items,
     'divergence', v_divergence, 'failed', v_failed);
 END;

--- a/supabase/migrations/20260617160000_criar_pedidos_com_itens.sql
+++ b/supabase/migrations/20260617160000_criar_pedidos_com_itens.sql
@@ -5,15 +5,14 @@
 --
 -- Provado em PG17 local (db/test-criar-pedidos-com-itens.sh) com falsificação.
 -- ⚠️ MIGRATION MANUAL — Lovable NÃO auto-aplica nome custom. Colar no SQL Editor → Run.
--- Idempotente (CREATE INDEX IF NOT EXISTS + CREATE OR REPLACE FUNCTION); re-colar é seguro.
+-- Idempotente (CREATE OR REPLACE FUNCTION); re-colar é seguro.
+--
+-- O índice uniq_sales_orders_omie_hash (account, hash_payload) WHERE hash_payload LIKE 'omie\_%'
+-- vem da migration 20260617133634 (#929) — aplicar ANTES desta. O ON CONFLICT abaixo usa o MESMO
+-- predicado 'omie\_%' (o ON CONFLICT exige match EXATO do predicado do índice parcial: 'omie_%'
+-- com underscore-wildcard NÃO casa 'omie\_%' com underscore-literal → 42P10; testado em PG17).
 
--- ── 1. Índice unique parcial do pai (habilita o ON CONFLICT da RPC; G2) ──
--- 0 duplicatas de (account, hash_payload) em prod (2026-06-17) → criável limpo.
-CREATE UNIQUE INDEX IF NOT EXISTS uniq_sales_orders_omie_hash
-  ON public.sales_orders (account, hash_payload)
-  WHERE hash_payload LIKE 'omie_%';
-
--- ── 2. RPC transacional pai+filho (fronteira única; substitui 2 inserts PostgREST) ──
+-- ── RPC transacional pai+filho (fronteira única; substitui 2 inserts PostgREST) ──
 CREATE OR REPLACE FUNCTION public.criar_pedidos_com_itens(p_pedidos jsonb)
 RETURNS jsonb
 LANGUAGE plpgsql
@@ -83,7 +82,7 @@ BEGIN
         (v_pedido->>'order_date_kpi')::date,
         v_pedido->>'notes', v_pedido->>'customer_address', v_pedido->>'customer_phone'
       WHERE v_item_count > 0
-      ON CONFLICT (account, hash_payload) WHERE hash_payload LIKE 'omie_%'
+      ON CONFLICT (account, hash_payload) WHERE hash_payload LIKE 'omie\_%'
       DO NOTHING
       RETURNING id, created_at INTO v_order_id, v_created_at;
 


### PR DESCRIPTION
## Atomicidade pai+filho do sync de pedidos Omie (RPC transacional + reparo)

Conserta o débito de atomicidade (achado #5 do `/codex challenge` ao #929): `sales_orders` (pai) e `order_items`/`sales_price_history` (filhos) eram escritos em **2 POSTs PostgREST não-transacionais** → **405 pedidos órfãos sem itens** em prod (88% presos >90d, 92% faturado = comissão/positivação real faltando).

### O que muda
- **RPC `criar_pedidos_com_itens`** (migration `20260617160000`) — pai+filhos numa subtransação por pedido: `ON CONFLICT` parcial `omie\_%`, `SELECT FOR UPDATE` (fecha corrida sem depender do lease), guard de divergência (`total`+`customer`, **não** `status` — evolui naturalmente), `created_at` do pai, price idempotente. `SECURITY INVOKER`, grant só `service_role`.
- **Edge `syncPedidos`** — chama a RPC (1 call/página) em vez dos 2 inserts; sem skip por hash → órfão que reaparece é **auto-reparado**. Integrado sobre o cursor+lease (#929).
- **Edge `reparar_orfaos_itens`** — job para os ~358 órfãos presos (`ConsultarPedido` → mesma RPC).

### Prova
- PG17 local (`db/test-criar-pedidos-com-itens.sh`): **38 asserts + 6 falsificações** (cada guard money-path/auth sabotado exige vermelho).
- `/codex consult` (metodologia) + `/codex challenge` (código — 4 findings, 3×P1, todos consertados).
- `deno check` + eslint + shellcheck verdes.

## ⚠️ Aplicação manual no banco (Lovable não auto-aplica) + ORDEM

1. **(Re)aplicar a RPC** no SQL Editor — cole `supabase/migrations/20260617160000_criar_pedidos_com_itens.sql`. **A v1 colada antes usava `ON CONFLICT omie_%` (wildcard), que NÃO casa o índice canônico `omie\_%` da #929 → falharia em runtime.** Esta v2 usa `omie\_%`. O índice já vem da #929 (não recriar).
2. **Merge deste PR** → código na `main`.
3. **Deploy do edge** `omie-vendas-sync` verbatim (chat Lovable) — só depois do merge.

Validação da RPC pós-apply:
```sql
SELECT pg_get_functiondef('public.criar_pedidos_com_itens(jsonb)'::regprocedure) ~ 'omie\\\\_%' AS rpc_predicado_canonico;
-- esperado: t
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
