### PR TITLE
docs(meta): otimiza CLAUDE.md + 5 skills locais (qualidade de instrução)

### DIFF
--- a/.claude/skills/bi-colacor/SKILL.md
+++ b/.claude/skills/bi-colacor/SKILL.md
@@ -14,7 +14,8 @@ description: >-
   banco, em modo leitura. NÃO use para: escrever ou alterar dados (esta skill é estritamente
   read-only); construir telas, dashboards ou gráficos dentro do app (isso é frontend/código);
   escrever ou otimizar código de query, hooks react-query, índices ou migrations/DDL/RLS (use
-  a skill `supabase`); nem análise de produto/uso via PostHog.
+  a skill `supabase`); para fechamento mensal, NCG/capital de giro, projeção de caixa 13 semanas, DRE
+  por regime tributário ou "perguntas pro contador" use a skill `cfo-colacor`; nem análise de produto/uso via PostHog.
 ---
 
 # BI Colacor — BI executivo operacional via Lovable SQL

--- a/.claude/skills/cfo-colacor/SKILL.md
+++ b/.claude/skills/cfo-colacor/SKILL.md
@@ -87,14 +87,7 @@ Trabalhe em **lotes**: entregue as queries de uma etapa, espere os resultados, i
 e só então passe pra próxima. Não despeje 8 queries de uma vez — o usuário roda uma de cada
 vez no Lovable.
 
-**Primeira query sempre é a de sanidade** (`assets/sql/00-sanity-status.sql`): valida os
-valores reais de `status_titulo` e a data do último sync. **Duas armadilhas validadas em
-produção** (1º fechamento, 2026-06-16): (1) **o `saldo` NÃO zera quando o título é baixado** —
-só o `status_titulo` muda; então filtre "aberto" por `status_titulo`, **NUNCA por `saldo > 0`**
-(senão conta quitado como aberto e infla tudo — o CR da Colacor pulou de R$129k pra R$17,7M). (2) Os
-status reais vêm **com espaço**: receber = `'A VENCER'`/`'ATRASADO'`/`'VENCE HOJE'`/`'RECEBIDO'`/`'CANCELADO'`;
-pagar = `'A VENCER'`/`'ATRASADO'`/`'PAGO'`/`'CANCELADO'`. Confirme antes de confiar em qualquer
-filtro. Detalhes e as 8 armadilhas em `references/schema-financeiro.md`.
+**Primeira query sempre é a de sanidade** (`assets/sql/00-sanity-status.sql`): valida os valores reais de `status_titulo` e a data do último sync. **Armadilha-mãe (money-path):** o `saldo` **NÃO zera na baixa** — só o `status_titulo` muda; filtre "aberto" por `status_titulo`, **NUNCA por `saldo > 0`** (senão conta quitado como aberto e infla tudo). Os status vêm **com espaço**. Os valores exatos de status, as 8 armadilhas e o caso real (CR da Colacor: R$129k que aparecia como R$17,7M) em `references/schema-financeiro.md` — **leia antes do fechamento**.
 
 ## O ritual
 

--- a/.claude/skills/lovable-deploy-verify/SKILL.md
+++ b/.claude/skills/lovable-deploy-verify/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: lovable-deploy-verify
 description: >-
-  RASCUNHO v0 — Ritual de "está REALMENTE no ar?" para QUALQUER entrega neste repo (Afiação/Colacor),
+  Ritual de "está REALMENTE no ar?" para QUALQUER entrega neste repo (Afiação/Colacor),
   que roda em Lovable Cloud. Use SEMPRE que terminar de mergear um PR e precisar saber o que falta pra
   a mudança ir a produção, ou quando o usuário perguntar "já está no ar?", "deu pra ver no app?",
   "publiquei?", "preciso dar Publish?", "tem que deployar a edge?". Vale mesmo quando o usuário não

--- a/.claude/skills/prove-sql-money-path/SKILL.md
+++ b/.claude/skills/prove-sql-money-path/SKILL.md
@@ -27,7 +27,7 @@ description: >-
 
 Duas verdades deste repo se combinam num risco silencioso:
 
-1. **plpgsql é *late-bound*.** Uma função/RPC/trigger com SQL inválido (coluna ambígua, JOIN que referencia a tabela-alvo, `SUM` que colide com coluna OUT do `RETURNS TABLE`) **passa no `CREATE OR REPLACE`** — o Postgres só resolve os nomes ao **EXECUTAR**. Se essa função roda atrás de um cron ou de um `try/catch` best-effort, ela falha **silenciosamente por tempo indefinido**. Já aconteceu aqui ≥3 vezes (`aplicar_promocoes_no_ciclo` quebrada em prod por um JOIN inválido; `gerar_pedidos_oportunidade_ciclo` por `SUM` ambíguo; ambas atrás de chamador silencioso — o §10 do CLAUDE.md tem o histórico).
+1. **plpgsql é *late-bound*** (regra-base no CLAUDE.md; aqui mora o *porquê* de provar EXECUTANDO). SQL inválido — coluna ambígua, JOIN que referencia a tabela-alvo, `SUM` que colide com coluna OUT do `RETURNS TABLE` — **passa no `CREATE OR REPLACE`** e só falha ao **EXECUTAR**; atrás de cron/`try-catch` best-effort, **silenciosamente por tempo indefinido**. Já aconteceu ≥3× aqui (`aplicar_promocoes_no_ciclo` por JOIN inválido; `gerar_pedidos_oportunidade_ciclo` por `SUM` ambíguo — histórico no §10 do CLAUDE.md).
 
 2. **O founder não tem terminal pro backend.** Ele aplica SQL colando no SQL Editor do Lovable. Não há staging. O **único** teste possível **antes** de o SQL tocar produção é o que **eu** rodo num PostgreSQL 17 local descartável.
 

--- a/.claude/skills/reposicao-caixa/SKILL.md
+++ b/.claude/skills/reposicao-caixa/SKILL.md
@@ -218,20 +218,12 @@ não fura o piso."}
 7. **Classe manda no apetite de risco** (decisão do dono): confie na ABC/XYZ do sistema; A nunca
    pode faltar, C é o primeiro candidato a segurar caixa.
 
-## Detalhes técnicos do schema (validados contra produção em 2026-06-17)
+## Schema — gotchas que quebram a query ou o número
 
-- Empresa é **`'OBEN'` (maiúsculo)** nas tabelas de reposição (`sku_parametros`,
-  `sku_estoque_atual`, `v_oportunidade_economica_hoje`, ...) e **`'oben'` (minúsculo)** nas
-  financeiras (`fin_contas_correntes`, RPC `fin_projecao_13_semanas`).
-- `sku_codigo_omie` é **bigint/number** em `sku_parametros`/views de parâmetro e **text/string**
-  em `sku_estoque_atual` e `eventos_outlier` → **faça cast** (`::text`) nos joins.
-- **`custo_capital_efetivo_perc` (Query 1/3/5) está em % AO ANO**, não ao mês (ex. real: 25,75 =
-  25,75% a.a. ≈ 1,93%/mês). As faixas da skill (1/2,2/4,5) são **% ao mês** — **converta antes de
-  comparar** (erro de 12× se misturar; ver `references/modelo-financeiro.md`).
-- `fin_projecao_13_semanas('oben', saldo_inicial)` é uma **RPC gated a staff autenticado** —
-  retorna 13 linhas, mas só roda no **Lovable** (founder logado). Acesso read-only de diagnóstico
-  (`claude_ro`) recebe `permission denied for function` — ou seja, a folga de caixa **vem do
-  founder colando o resultado**, não de o assistente rodar a RPC. `saldo_inicial` = soma do
-  `saldo_atual` das contas ativas.
-- `sku_estoque_atual.ultima_sincronizacao` diz **quão fresco** é o estoque — use como sinal de
-  confiança (estoque velho = confiança baixa).
+Antes de adaptar qualquer query, confira (detalhe, exemplos e proveniência em `references/sql-queries.md` + `references/modelo-financeiro.md`):
+- **Grafia da empresa:** `'OBEN'` (maiúsc.) na reposição vs `'oben'` (minúsc.) no financeiro.
+- **`sku_codigo_omie`:** bigint num lado, text no outro → `::text` no join.
+- **`custo_capital_efetivo_perc`:** está em **% AO ANO**, não ao mês — as faixas da skill são % ao mês (**erro de 12× se misturar**).
+- **`fin_projecao_13_semanas`:** RPC gated a staff — só roda no Lovable; `claude_ro` recebe `permission denied` (a folga vem do founder colando).
+- **`ultima_sincronizacao`:** frescor do estoque = sinal de confiança (estoque velho → confiança baixa).
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ Diário de PR/entregas: `docs/historico/` (`bugs-resolvidos.md`, `programas-vend
 - **Money-path: ausente ≠ zero** (`Number(null)===0` é fabricação) → degradar para `null`/baixa-confiança, **nunca** fabricar número. Sinal money-path **nunca** em coluna jsonb multi-writer (upsert destrutivo) → coluna dedicada + 1 writer. → `money-path.md`
 - **Omie:** não confiar em `total_de_paginas` (paginar até página vazia + guard); enumeração pesada (~10k+) → bulk + `waitUntil` + retry, nunca N+1; após corrigir a FONTE, re-invocar o recompute (snapshots derivados não se regeneram). → `reposicao.md`/`sync.md`
 - **Lente "Ver como":** `useAuth()` é SEMPRE real (escrita/identidade/RLS); só LEITURA usa `display*`/`effectiveUserId`. WebRTC fura o write-guard → gatear na fonte. → `impersonation.md`
-- **Multi-sessão:** antes de tocar arquivo/função QUENTE, conferir `origin/main` + `gh pr list` + migrations paralelas (timestamp colidido é o aviso). → `worktrees.md`
+- **Multi-sessão (worktrees paralelas):** coordene antes de tocar arquivo/função QUENTE — o "como" e o isolamento ficam na §Multi-sessão ao fim. → `worktrees.md`
 - **Teste SQL negativo** com `WHEN OTHERS THEN 'OK'` é teatro → capturar a SQLSTATE esperada + re-lançar o resto + **falsificar** (sabotar a migration e exigir vermelho); RLS prova-se sob `SET ROLE authenticated` + GUC (psql é superuser, bypassaria). → `money-path.md`
 - **Shell:** `cmd | tail` **ENGOLE o exit code** → `> log 2>&1; echo $?` quando o exit importa. Comandos pesados (test/build/typecheck/vitest) → prefixar **`heavy`** (semáforo de RAM da M2 8GB). → `worktrees.md`
 
@@ -91,10 +91,10 @@ Tokens em `src/index.css` (paleta quase-neutra low-fatigue; `--status-*` dessatu
 
 Pages PascalCase; hooks `useX` camelCase; rotas **e** código em **pt-BR** (`/recebimento`, `agruparPorMes`); imports absolutos `@/`; tabelas Supabase `snake_case` PT. **LLM em edge:** código novo → Anthropic direto (`ANTHROPIC_API_KEY` + `claude-sonnet-4-6` + prompt caching + forced tool-use + gate `authorizeCronOrStaff`); legado usa o gateway Lovable/Gemini. Roteamento de skills (qual usar por tarefa): `docs/agent/skills.md`.
 
-## gstack (REQUIRED — global install)
+## gstack (REQUIRED)
 
-Antes de QUALQUER trabalho: `test -d ~/.claude/skills/gstack/bin && echo GSTACK_OK || echo GSTACK_MISSING`. Se faltar, **STOP** e instrua o founder a instalar (`git clone --depth 1 https://github.com/garrytan/gstack.git ~/.claude/skills/gstack && cd ~/.claude/skills/gstack && ./setup --team` → reiniciar). Use `/browse` para todo web browsing. Não contornar gstack ausente.
+Obrigatório para o trabalho assistido. O hook [`check-gstack.sh`](.claude/hooks/check-gstack.sh) **bloqueia o uso de skills** se faltar — com as instruções de instalação no próprio bloqueio. Não contornar. Web browsing → sempre `/browse`.
 
 ## Multi-sessão (regra — detalhe em `docs/agent/worktrees.md`)
 
-**Uma sessão Claude por working tree.** NUNCA 2 sessões no diretório principal (`/Users/lucassardenberg/Projetos/afiacao`) — o branch-flip vaza entre elas (risco de perda). Worktrees isolam (`bun run wt <branch>`). Higiene de RAM/Node na M2 8GB: `wt:status`/`wt:clean`/`wt:reap`/`wt:prune` (numa sessão Claude EU rodo `bun install` ao detectar `node_modules` limpo). MCPs enxutas via `.claude/settings.json` (Serena off por padrão — religar pontual).
+**Uma sessão Claude por working tree.** NUNCA 2 sessões no diretório principal (`/Users/lucassardenberg/Projetos/afiacao`) — o branch-flip vaza entre elas (risco de perda). Worktrees isolam (`bun run wt <branch>`). **Antes de tocar arquivo/função QUENTE:** conferir `origin/main` + `gh pr list` + migrations paralelas (timestamp colidido é o aviso). Higiene de RAM/Node na M2 8GB: `wt:status`/`wt:clean`/`wt:reap`/`wt:prune` (numa sessão Claude EU rodo `bun install` ao detectar `node_modules` limpo). MCPs enxutas via `.claude/settings.json` (Serena off por padrão — religar pontual).


### PR DESCRIPTION
## O que

Otimiza o CLAUDE.md e 5 skills locais — **qualidade de instrução**, sem conteúdo novo. Diff: 6 arquivos, +18/−32.

## CLAUDE.md (orçamento intacto — 12.687 B; o ganho é fragilidade, não bytes)
- **gstack** 5→2 linhas: a duplicação com o hook `check-gstack.sh` (que já bloqueia o uso de skills se faltar, com as instruções de instalação no próprio bloqueio) saiu. Hook = fonte única, sem risco de divergência.
- **worktrees**: a coordenação (`origin/main` + `gh pr list`) foi centralizada na §Multi-sessão; o bullet de Armadilhas virou ponteiro.

## Skills (`.claude/skills`) — vazamento de diário + fronteiras de trigger
- **bi-colacor**: ponteiro → `cfo-colacor` no frontmatter — "inadimplência/fluxo de caixa/margem" disparava as duas.
- **cfo-colacor**: armadilha-mãe money-path (`status_titulo`, nunca `saldo>0`) **mantida inline**; só a proveniência datada (caso R$129k→17,7M) foi pro `references`.
- **reposicao-caixa**: bloco "validados em 2026-06-17" → 5 gotchas-título + ponteiro (o detalhe já vivia no `references`).
- **lovable-deploy-verify**: "RASCUNHO v0" sai do `description` (poluía o texto de trigger); o aviso permanece no body. ⚠️ segue rascunho v0 (TODOs reais — promover a v1 é tarefa à parte).
- **prove-sql-money-path**: item late-bound reconhece a regra-base do CLAUDE.md; casos históricos preservados.

## Validação
- Guard-rails money-path preservados (`status_titulo`/`saldo>0`, `OBEN`, `% AO ANO`, `permission denied`) — grep ✓
- YAML dos frontmatters válido — o **harness recarregou** `bi-colacor` e `lovable-deploy-verify` com as novas descriptions (prova real)
- CLAUDE.md dentro do orçamento (`claude:size` ✓)
- Os `references` já continham o detalhe extraído → **zero perda de conhecimento**

> A skill **auto-ensino** (mutation-check de 2.933→822 chars → `references/mutation-check.md`) é global (`~/.claude`) e não entra neste PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)