### PR TITLE
fix(valor-cockpit): exclui titulo CANCELADO do denominador da cobertura_receita (simetria c/ #935)

### DIFF
--- a/src/lib/financeiro/__tests__/valor-cockpit-helpers.test.ts
+++ b/src/lib/financeiro/__tests__/valor-cockpit-helpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { margemContribuicao, arMedioTTM, statusLiquidadoAR, montarCelulasComboEVP, recomendarAcaoComercial, scoreConfiancaCockpit, resolverHurdleCockpit, pedidoContaNoFaturamento } from '../valor-cockpit-helpers';
+import { margemContribuicao, arMedioTTM, statusLiquidadoAR, montarCelulasComboEVP, recomendarAcaoComercial, scoreConfiancaCockpit, resolverHurdleCockpit, pedidoContaNoFaturamento, tituloFaturavelAR } from '../valor-cockpit-helpers';
 
 // helper de fixture: TituloAR completo com defaults (reduz ruído nos casos)
 function tit(p: Partial<Parameters<typeof arMedioTTM>[0]['titulos'][number]>) {
@@ -29,6 +29,22 @@ describe('statusLiquidadoAR', () => {
     expect(statusLiquidadoAR('A VENCER')).toBe(false);
     expect(statusLiquidadoAR('ATRASADO')).toBe(false);
     expect(statusLiquidadoAR(null)).toBe(false);
+  });
+});
+
+describe('tituloFaturavelAR (denominador de cobertura — simetria do AR)', () => {
+  it('RECEBIDO/A VENCER/ATRASADO/VENCE HOJE → conta', () => {
+    for (const s of ['RECEBIDO', 'A VENCER', 'ATRASADO', 'VENCE HOJE']) expect(tituloFaturavelAR(s)).toBe(true);
+  });
+  it('CANCELADO → NÃO conta (simetria com pedido cancelado no numerador)', () => {
+    expect(tituloFaturavelAR('CANCELADO')).toBe(false);
+  });
+  it('status novo/desconhecido → conta por default (blocklist semântica, não subconta)', () => {
+    expect(tituloFaturavelAR('PROTESTADO')).toBe(true);
+  });
+  it('NULL/undefined → CONTA (não infla a cobertura; AR sempre tem status no Omie)', () => {
+    expect(tituloFaturavelAR(null)).toBe(true);
+    expect(tituloFaturavelAR(undefined)).toBe(true);
   });
 });
 

--- a/src/lib/financeiro/valor-cockpit-helpers.ts
+++ b/src/lib/financeiro/valor-cockpit-helpers.ts
@@ -56,6 +56,17 @@ export function pedidoContaNoFaturamento(status: string | null | undefined, dele
   return !STATUS_NAO_FATURAVEL.includes(status);  // default-inclui status conhecido novo
 }
 
+// Faturabilidade do TÍTULO de AR (denominador de cobertura_receita) — contraparte de
+// pedidoContaNoFaturamento (numerador). Exclui só status_titulo='CANCELADO' (medido = 2,66% do
+// arTotal Oben, psql-ro 2026-06-18; estorno/duplicata/outra-conta = 0 no AR). NÃO filtra por status
+// do PEDIDO: o vínculo título→pedido é parcial (37% sem numero_pedido) e desacoplado (título
+// CANCELADO coexiste com pedido vivo). NULL → CONTA (assimétrico vs o numerador, que exclui NULL):
+// nos dois lados a escolha conservadora é NÃO superestimar a cobertura — excluir do denominador a infla.
+const STATUS_TITULO_NAO_FATURAVEL = ['CANCELADO'];
+export function tituloFaturavelAR(statusTitulo: string | null | undefined): boolean {
+  return statusTitulo == null ? true : !STATUS_TITULO_NAO_FATURAVEL.includes(statusTitulo);
+}
+
 export type TituloAR = {
   valor_documento: number; saldo: number; valor_recebido: number;
   data_emissao: string | null;

--- a/supabase/functions/fin-valor-cockpit/index.ts
+++ b/supabase/functions/fin-valor-cockpit/index.ts
@@ -77,6 +77,14 @@ function pedidoContaNoFaturamento(status: string | null | undefined, deletedAt: 
   if (status == null) return false;
   return !STATUS_NAO_FATURAVEL.includes(status);
 }
+// Faturabilidade do TÍTULO de AR (denominador de cobertura_receita) — contraparte de
+// pedidoContaNoFaturamento. Exclui só status_titulo='CANCELADO' (2,66% do arTotal Oben; estorno/dup/
+// outra-conta = 0 no AR, psql-ro 2026-06-18). NÃO filtra por status do PEDIDO (vínculo título→pedido
+// parcial e desacoplado). NULL → CONTA (assimétrico vs o numerador): conservador é NÃO superestimar a cobertura.
+const STATUS_TITULO_NAO_FATURAVEL = ['CANCELADO'];
+function tituloFaturavelAR(statusTitulo: string | null | undefined): boolean {
+  return statusTitulo == null ? true : !STATUS_TITULO_NAO_FATURAVEL.includes(statusTitulo);
+}
 type TituloAR = {
   valor_documento: number; saldo: number; valor_recebido: number;
   data_emissao: string | null; data_vencimento: string | null;
@@ -350,8 +358,15 @@ serve(async (req: Request) => {
     const custo_ausente_pct = res.celulas.filter((c) => c.cm == null).length / total;
     const ar_indisponivel_pct = res.celulas.filter((c) => c.ar_indisponivel).length / total;
     const estoque_ausente_pct = res.celulas.filter((c) => c.estoque_indisponivel).length / total;
-    // cobertura: receita Oben do cockpit ÷ AR Oben emitido no TTM (mesmo conjunto crsAll).
-    const arTotal = crsAll.filter((cr) => cr.data_emissao != null && cr.data_emissao >= ttm_inicio).reduce((s, cr) => s + (cr.valor_documento || 0), 0);
+    // cobertura_receita: receita Oben do cockpit ÷ AR Oben FATURÁVEL emitido no TTM (mesmo crsAll).
+    // PROXY DIRECIONAL de confiança, NÃO reconciliação contábil: numerador = receita comercial de
+    // itens (unit_price·qty−desc, data do PEDIDO); denominador = valor_documento de títulos AR
+    // (impostos/frete/parcelas, data de EMISSÃO), fonte independente (Omie financeiro, sem FK a
+    // sales_orders). Nem toda venda vira AR (à vista) e vice-versa → numerador pode exceder o
+    // denominador (Oben ~R$5,1M vs ~R$4,2M em 2026-06-18) e a cobertura satura em 1,0 (Math.min);
+    // a métrica só detecta "AR sem venda no app", não o inverso. Daí os thresholds largos. Exclui
+    // CANCELADO (tituloFaturavelAR) p/ simetria com o numerador (pedidoContaNoFaturamento).
+    const arTotal = crsAll.filter((cr) => cr.data_emissao != null && cr.data_emissao >= ttm_inicio && tituloFaturavelAR(cr.status_titulo)).reduce((s, cr) => s + (cr.valor_documento || 0), 0);
     const cobertura_receita = arTotal > 0 ? Math.min(1, res.empresa.receita / arTotal) : 1;
     const confianca = scoreConfiancaCockpit({ cobertura_receita, custo_ausente_pct, ar_indisponivel_pct, estoque_ausente_pct, imposto_estimado: true, hurdle_indisponivel });
 


### PR DESCRIPTION
## O quê
Contraparte simétrica do #935. O #935 fez o **numerador** da `cobertura_receita` (faturamento Oben) excluir pedido `cancelado`/`rascunho`/soft-deletado. Este PR faz o **denominador** (`arTotal`, soma de `fin_contas_receber`) excluir `status_titulo='CANCELADO'`, via helper `tituloFaturavelAR` (espelhado verbatim no edge).

## Por quê — investigação read-only (psql-ro 2026-06-18, TTM Oben)
O Codex (review do #935) levantou que o denominador não-filtrado poderia rebaixar a `cobertura_receita` "falsamente". Medi a composição do `arTotal`:

| Componente | R$ | % |
|---|---|---|
| arTotal bruto | 4.165.802 | 100% |
| **CANCELADO** | **110.982** | **2,66%** |
| estornos (valor<0) | 0 | 0% |
| duplicata de registro | 0 | 0% |
| outras contas (company≠oben) | 0 | 0% |
| fuga (título vivo de pedido morto) | 0 | 0% |

- Único não-faturável identificável: `CANCELADO` (2,66%). `company` já escopa por account; sem estorno/dup/outlier (maior título isolado = R$39.856).
- **Junção título→pedido é inviável**: 37% dos títulos sem `numero_pedido`, e título-CANCELADO coexiste com pedido vivo (101 títulos, R$83k — fontes desacopladas). Logo filtra-se por `status_titulo`, nunca por status do pedido.
- **Efeito nulo hoje**: numerador (~R$5,1M) > denominador (~R$4,2M) → `cobertura_receita` satura em 1,0 com ou sem o filtro; `scoreConfiancaCockpit` não rebaixa. É **higiene/robustez** (simetria com o #935), **não conserto** de problema ativo.

## Decisão (founder delegou a Claude+Codex; convergem)
- Filtrar `CANCELADO` + **documentar** que `cobertura_receita` compara fontes independentes de grandezas distintas (proxy direcional capado em 1,0, não reconciliação contábil).
- `NULL → inclui` (assimétrico vs o numerador, que exclui NULL): em ambos os lados a escolha conservadora é **não superestimar** a cobertura.
- Codex consult (gpt-5.5 high): "filtraria CANCELADO, mas como **higiene semântica, não correção material**; documentar agressivamente." Confirmou que o risco de inflar a cobertura (pedido vivo + título cancelado) não mata o filtro — incluir cancelado também rebaixaria confiança injustamente.

## Verificação
- `tituloFaturavelAR`: 4 casos + **falsificação** (sabotei o helper → caso CANCELADO ficou vermelho; teste tem dente).
- Suíte `valor-cockpit-helpers`: **54 verdes**. Typecheck: ok.

## ⚠️ Deploy
Edge `fin-valor-cockpit` → **deploy MANUAL no Lovable pós-merge** (chat do Lovable, ler do repo verbatim). Merge em main ≠ produção.

## Follow-up (deferido — gatilho: cobertura sair do teto 1,0)
Codex (d): a métrica é **unidirecional** — só detecta "AR sem venda no app", não "venda no app sem AR", e perde sinal quando o ratio passa de 1 (regime atual da Oben). Evolução possível: dois sinais (`cobertura_ar_por_app` + `cobertura_app_por_ar`). Fora de escopo aqui (muda shape do retorno + UI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
