### PR TITLE
feat(tint-sync): catálogo automático SayerSystem no ar — corte do CSV (3 fixes money-path)

### DIFF
--- a/db/test-tint-promote-e4.sh
+++ b/db/test-tint-promote-e4.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# ╔══════════════════════════════════════════════════════════════════════════════╗
+# ║  PROVA PG17 — 20260618130000_tint_promote_e4_so_com_custo.sql                 ║
+# ║  Invariante: o E4 (recálculo de preço por corante) só roda quando há CUSTO.    ║
+# ║  Re-envio de corante SEM custo (só volume) → recalculadas=0 (mata o lock       ║
+# ║  timeout do 2º re-flip, incidente 18/06). COM custo → recalcula (preserva o    ║
+# ║  caso de uso legítimo). Falsificação: a 150000 (OR volume) recalcula à toa.    ║
+# ╚══════════════════════════════════════════════════════════════════════════════╝
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PGVER=17
+PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+PORT="${PGPORT_TEST:-5459}"
+SLUG="tint-e4"
+DATA="$(mktemp -d "/tmp/pgtest-${SLUG}.XXXXXX")/data"
+export LC_ALL=C LANG=C
+
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente"; exit 1; }
+CELLAR="$(brew --prefix "postgresql@${PGVER}")"
+cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
+mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
+cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
+
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+trap cleanup EXIT
+
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l "/tmp/pg-${SLUG}.log" -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres prove
+P()  { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d prove -v ON_ERROR_STOP=1 "$@"; }
+P0() { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d prove "$@"; }
+Pq() { P -tA "$@"; }
+
+P -q -f "$REPO_ROOT/db/stubs-supabase.sql"
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION auth.uid()  RETURNS uuid LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.uid',  true), '')::uuid $f$;
+CREATE OR REPLACE FUNCTION auth.role() RETURNS text LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.role', true), '') $f$;
+ALTER ROLE service_role BYPASSRLS;
+SQL
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  ✅ $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  ❌ $1"; }
+eq()  { if [ "$2" = "$3" ]; then ok "$1 (=$2)"; else bad "$1 — esperado [$3], veio [$2]"; fi; }
+gt0() { if [ "${2:-0}" -gt 0 ] 2>/dev/null; then ok "$1 (=$2)"; else bad "$1 — esperado >0, veio [$2]"; fi; }
+
+echo "═══ setup PG17 :$PORT ═══"
+RR="$(mktemp /tmp/snap-rr.XXXXXX.sql)"
+sed -E 's/^(CREATE SCHEMA public;)/-- \1/' "$REPO_ROOT/supabase/schema-snapshot.sql" | grep -vE '^\\(un)?restrict ' > "$RR"
+P -q -f "$REPO_ROOT/supabase/schema-extensions-prelude.sql" 2>/dev/null || true
+P0 -q -f "$RR" >/tmp/snap-apply.log 2>&1 || true
+rm -f "$RR"
+P -q <<'SQL'
+CREATE TABLE IF NOT EXISTS public.tint_staging_precos_base (
+  id uuid NOT NULL DEFAULT gen_random_uuid(), sync_run_id uuid, account text NOT NULL, store_code text NOT NULL,
+  cod_produto text NOT NULL, id_base text NOT NULL, id_embalagem text NOT NULL,
+  custo numeric, imposto_pct numeric, margem_pct numeric, raw_data jsonb, staging_status text,
+  created_at timestamptz NOT NULL DEFAULT now());
+ALTER TABLE public.tint_formulas ADD COLUMN IF NOT EXISTS desativada_em timestamptz;
+SQL
+for m in 20260609150000_tint_sync_promote 20260611190000_tint_sync_codex_fixes \
+         20260615140000_tint_promote_indices_timeout 20260615160000_tint_promote_set_based; do
+  P0 -q -f "$REPO_ROOT/supabase/migrations/${m}.sql" >>/tmp/mig-apply.log 2>&1 || true
+done
+echo "snapshot + cadeia aplicados"
+
+# ── ZONA 2: a migration REAL sob teste ──
+P -q -f "$REPO_ROOT/supabase/migrations/20260618130000_tint_promote_e4_so_com_custo.sql"
+echo "migration aplicada: 20260618130000_tint_promote_e4_so_com_custo.sql"
+
+# ── ZONA 3: seed ──
+# run1 promove COR1/CORNOVA (par P1,B1) + COR3 (P2,B2), todas com item do corante C1, preço base via P2.
+# runA = re-envio do corante C1 SEM custo (só volume) → E4 NÃO deve recalcular (fix).
+# runB = corante C1 COM custo → E4 recalcula as fórmulas que usam C1.
+P -q <<'SQL'
+INSERT INTO tint_produtos (id, account, cod_produto, descricao) VALUES
+ ('a0000000-0000-0000-0000-000000000001','colacor','P1','Produto 1'),
+ ('a0000000-0000-0000-0000-000000000002','colacor','P2','Produto 2');
+INSERT INTO tint_bases (id, account, id_base_sayersystem, descricao) VALUES
+ ('b0000000-0000-0000-0000-000000000001','colacor','B1','Base 1'),
+ ('b0000000-0000-0000-0000-000000000002','colacor','B2','Base 2');
+INSERT INTO tint_embalagens (id, account, id_embalagem_sayersystem, volume_ml) VALUES
+ ('c0000000-0000-0000-0000-000000000001','colacor','E1',900);
+INSERT INTO tint_corantes (id, account, id_corante_sayersystem, descricao, volume_total_ml) VALUES
+ ('d0000000-0000-0000-0000-000000000001','colacor','C1','Corante 1',1000);
+INSERT INTO tint_skus (id, account, produto_id, base_id, embalagem_id) VALUES
+ ('e0000000-0000-0000-0000-000000000001','colacor','a0000000-0000-0000-0000-000000000001','b0000000-0000-0000-0000-000000000001','c0000000-0000-0000-0000-000000000001'),
+ ('e0000000-0000-0000-0000-000000000002','colacor','a0000000-0000-0000-0000-000000000002','b0000000-0000-0000-0000-000000000002','c0000000-0000-0000-0000-000000000001');
+INSERT INTO tint_integration_settings (id, account, store_code) VALUES
+ ('10000000-0000-0000-0000-000000000001','colacor','M01');
+
+-- RUN 1: promove (cria COR1/CORNOVA/COR3 com itens C1)
+INSERT INTO tint_sync_runs (id, setting_id, account, store_code, sync_type, status) VALUES
+ ('20000000-0000-0000-0000-000000000001','10000000-0000-0000-0000-000000000001','colacor','M01','formulas','running');
+INSERT INTO tint_staging_produtos (sync_run_id, account, store_code, cod_produto) VALUES
+ ('20000000-0000-0000-0000-000000000001','colacor','M01','P1'),('20000000-0000-0000-0000-000000000001','colacor','M01','P2');
+INSERT INTO tint_staging_bases (sync_run_id, account, store_code, id_base_sayersystem, descricao) VALUES
+ ('20000000-0000-0000-0000-000000000001','colacor','M01','B1','Base 1'),('20000000-0000-0000-0000-000000000001','colacor','M01','B2','Base 2');
+INSERT INTO tint_staging_embalagens (sync_run_id, account, store_code, id_embalagem_sayersystem, volume_ml) VALUES
+ ('20000000-0000-0000-0000-000000000001','colacor','M01','E1',900);
+INSERT INTO tint_staging_corantes (sync_run_id, account, store_code, id_corante_sayersystem, descricao, custo, volume_ml) VALUES
+ ('20000000-0000-0000-0000-000000000001','colacor','M01','C1','Corante 1',NULL,1000);
+INSERT INTO tint_staging_skus (sync_run_id, account, store_code, cod_produto, id_base, id_embalagem) VALUES
+ ('20000000-0000-0000-0000-000000000001','colacor','M01','P1','B1','E1'),('20000000-0000-0000-0000-000000000001','colacor','M01','P2','B2','E1');
+INSERT INTO tint_staging_formulas (id, sync_run_id, account, store_code, cor_id, nome_cor, cod_produto, id_base, id_embalagem, volume_final_ml, preco_final, personalizada) VALUES
+ ('50000000-0000-0000-0000-000000000001','20000000-0000-0000-0000-000000000001','colacor','M01','COR1','Cor 1','P1','B1','E1',900,NULL,false),
+ ('50000000-0000-0000-0000-000000000002','20000000-0000-0000-0000-000000000001','colacor','M01','CORNOVA','Cor Nova','P1','B1','E1',900,NULL,false),
+ ('50000000-0000-0000-0000-000000000003','20000000-0000-0000-0000-000000000001','colacor','M01','COR3','Cor 3','P2','B2','E1',900,NULL,false);
+INSERT INTO tint_staging_formula_itens (sync_run_id, staging_formula_id, id_corante, qtd_ml, ordem) VALUES
+ ('20000000-0000-0000-0000-000000000001','50000000-0000-0000-0000-000000000001','C1',10,1),
+ ('20000000-0000-0000-0000-000000000001','50000000-0000-0000-0000-000000000002','C1',10,1),
+ ('20000000-0000-0000-0000-000000000001','50000000-0000-0000-0000-000000000003','C1',10,1);
+
+-- RUN A: re-envio do corante C1 SEM custo (só volume) — E4 NÃO deve recalcular
+INSERT INTO tint_sync_runs (id, setting_id, account, store_code, sync_type, status) VALUES
+ ('20000000-0000-0000-0000-0000000000aa','10000000-0000-0000-0000-000000000001','colacor','M01','catalogs','running');
+INSERT INTO tint_staging_corantes (sync_run_id, account, store_code, id_corante_sayersystem, descricao, custo, volume_ml) VALUES
+ ('20000000-0000-0000-0000-0000000000aa','colacor','M01','C1','Corante 1',NULL,1000);
+
+-- RUN B: corante C1 COM custo — E4 deve recalcular as fórmulas que usam C1
+INSERT INTO tint_sync_runs (id, setting_id, account, store_code, sync_type, status) VALUES
+ ('20000000-0000-0000-0000-0000000000bb','10000000-0000-0000-0000-000000000001','colacor','M01','catalogs','running');
+INSERT INTO tint_staging_corantes (sync_run_id, account, store_code, id_corante_sayersystem, descricao, custo, volume_ml) VALUES
+ ('20000000-0000-0000-0000-0000000000bb','colacor','M01','C1','Corante 1',3.5,1000);
+SQL
+echo "seed pronto"
+
+# ── RUN 1: promove ──
+R1=$(Pq -c "SELECT tint_promote_sync_run('20000000-0000-0000-0000-000000000001');")
+echo "run1 (promove): $R1"
+echo "── asserts ──"
+ITENS=$(Pq -c "SELECT count(*) FROM tint_formula_itens fi JOIN tint_formulas f ON f.id=fi.formula_id WHERE f.account='colacor' AND f.cor_id IN ('COR1','CORNOVA','COR3');")
+gt0 "sanidade: fórmulas promovidas com itens do corante C1" "$ITENS"
+
+# E4a — corante SEM custo NÃO recalcula (a CORREÇÃO da carga)
+A=$(Pq -c "SELECT (tint_promote_sync_run('20000000-0000-0000-0000-0000000000aa'))->>'recalculadas';")
+eq "E4a corante re-enviado SEM custo → recalculadas=0 (não trava)" "$A" "0"
+
+# E4b — corante COM custo recalcula (caso legítimo preservado)
+B=$(Pq -c "SELECT (tint_promote_sync_run('20000000-0000-0000-0000-0000000000bb'))->>'recalculadas';")
+gt0 "E4b corante COM custo → recalcula as fórmulas que usam C1" "$B"
+
+# ── FALSIFICAÇÃO: aplica a 150000 (condição OR volume_ml, SEM o fix) → run A recalcula à toa ──
+echo "── falsificação: aplica a versão SEM o fix (OR volume_ml) e re-roda o corante sem custo ──"
+P -q -f "$REPO_ROOT/supabase/migrations/20260617150000_tint_promote_reexpand_skus_novos.sql" >/dev/null
+FALSO=$(Pq -c "SELECT (tint_promote_sync_run('20000000-0000-0000-0000-0000000000aa'))->>'recalculadas';")
+if [ "${FALSO:-0}" -gt 0 ] 2>/dev/null; then
+  ok "falsificação tem dente: SEM o fix, corante sem custo recalcula à toa (recalculadas=$FALSO)"
+else
+  bad "falsificação FRACA: sem o fix o corante sem custo deveria recalcular, veio [$FALSO]"
+fi
+
+echo "──────────────────────────────"
+echo "RESULTADO: $PASS ok / $FAIL fail"
+[ "$FAIL" = "0" ] || { echo "❌ HARNESS VERMELHO"; exit 1; }
+echo "✅ HARNESS VERDE"

--- a/db/test-tint-promote-preserva-preco.sh
+++ b/db/test-tint-promote-preserva-preco.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# ╔══════════════════════════════════════════════════════════════════════════════╗
+# ║  PROVA PG17 — 20260617130000_tint_promote_preserva_preco.sql                  ║
+# ║  Invariante: a promoção PRESERVA preco_final_sayersystem quando o recálculo    ║
+# ║  dá NULL (precos_base vazio) — COALESCE(novo, atual). Sem isto o flip zeraria  ║
+# ║  o piso de ~19k cores. Lei de Ferro: função REAL + assert com dente +          ║
+# ║  FALSIFICAÇÃO (aplica a set_based SEM COALESCE → exige vermelho).              ║
+# ╚══════════════════════════════════════════════════════════════════════════════╝
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PGVER=17
+PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+PORT="${PGPORT_TEST:-5457}"
+SLUG="tint-preco"
+DATA="$(mktemp -d "/tmp/pgtest-${SLUG}.XXXXXX")/data"
+export LC_ALL=C LANG=C
+
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente: brew install postgresql@${PGVER} pgvector"; exit 1; }
+CELLAR="$(brew --prefix "postgresql@${PGVER}")"
+cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
+mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
+cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
+
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+trap cleanup EXIT
+
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l "/tmp/pg-${SLUG}.log" -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres prove
+P()  { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d prove -v ON_ERROR_STOP=1 "$@"; }
+P0() { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d prove "$@"; }   # tolera erro (snapshot não-tint)
+Pq() { P -tA "$@"; }
+
+P -q -f "$REPO_ROOT/db/stubs-supabase.sql"
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION auth.uid()  RETURNS uuid LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.uid',  true), '')::uuid $f$;
+CREATE OR REPLACE FUNCTION auth.role() RETURNS text LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.role', true), '') $f$;
+ALTER ROLE service_role BYPASSRLS;
+SQL
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  ✅ $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  ❌ $1"; }
+eq()  { if [ "$2" = "$3" ]; then ok "$1 (=$2)"; else bad "$1 — esperado [$3], veio [$2]"; fi; }
+
+echo "═══ setup PG17 :$PORT ═══"
+
+# ── ZONA 1: snapshot (tabelas tint; tolera erro em objetos não-tint) + helpers de prod ──
+RR="$(mktemp /tmp/snap-rr.XXXXXX.sql)"
+sed -E 's/^(CREATE SCHEMA public;)/-- \1/' "$REPO_ROOT/supabase/schema-snapshot.sql" \
+  | grep -vE '^\\(un)?restrict ' > "$RR"
+P -q -f "$REPO_ROOT/supabase/schema-extensions-prelude.sql" 2>/dev/null || true
+P0 -q -f "$RR" >/tmp/snap-apply.log 2>&1 || true
+rm -f "$RR"
+# snapshot STALE (§database.md): cria o que falta — tint_staging_precos_base (tabela inteira) e
+# desativada_em em tint_formulas (coluna). Schema reconstruído de prod via information_schema.
+P -q <<'SQL'
+CREATE TABLE IF NOT EXISTS public.tint_staging_precos_base (
+  id uuid NOT NULL DEFAULT gen_random_uuid(), sync_run_id uuid, account text NOT NULL, store_code text NOT NULL,
+  cod_produto text NOT NULL, id_base text NOT NULL, id_embalagem text NOT NULL,
+  custo numeric, imposto_pct numeric, margem_pct numeric, raw_data jsonb, staging_status text,
+  created_at timestamptz NOT NULL DEFAULT now());
+ALTER TABLE public.tint_formulas ADD COLUMN IF NOT EXISTS desativada_em timestamptz;
+SQL
+# setup-gate: as tabelas tint que a promoção toca PRECISAM existir
+for t in tint_produtos tint_bases tint_embalagens tint_corantes tint_skus tint_formulas tint_formula_itens \
+         tint_sync_runs tint_integration_settings tint_importacoes tint_staging_formulas tint_staging_formula_itens \
+         tint_staging_precos_base tint_staging_skus tint_staging_produtos tint_staging_bases tint_staging_embalagens tint_staging_corantes; do
+  EX=$(Pq -c "SELECT to_regclass('public.$t') IS NOT NULL;")
+  [ "$EX" = "t" ] || { echo "❌ SETUP: tabela $t não criada pelo snapshot (ver /tmp/snap-apply.log)"; exit 1; }
+done
+echo "snapshot aplicado; tabelas tint OK"
+# Cadeia de migrations da promoção (P0 tolera colisão de objetos já no snapshot). As 4 primeiras
+# criam os helpers (tint_calc_preco_final / tint_recalc_preco_oficial / tint_ensure_corante_stub)
+# + a promoção v1→v2 (set_based). A minha (v3) é a sob teste (ZONA 2, ON_ERROR_STOP).
+for m in 20260609150000_tint_sync_promote 20260611190000_tint_sync_codex_fixes \
+         20260615140000_tint_promote_indices_timeout 20260615160000_tint_promote_set_based; do
+  P0 -q -f "$REPO_ROOT/supabase/migrations/${m}.sql" >>/tmp/mig-apply.log 2>&1 || true
+done
+for fn in tint_calc_preco_final tint_recalc_preco_oficial tint_ensure_corante_stub; do
+  EX=$(Pq -c "SELECT count(*)>0 FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace WHERE n.nspname='public' AND p.proname='$fn';")
+  [ "$EX" = "t" ] || { echo "❌ SETUP: helper $fn não criado (ver /tmp/mig-apply.log)"; exit 1; }
+done
+echo "helpers + promoção (cadeia de migrations) aplicados"
+
+# ── ZONA 2: a migration REAL sob teste (ON_ERROR_STOP — tem que aplicar limpo) ──
+P -q -f "$REPO_ROOT/supabase/migrations/20260617130000_tint_promote_preserva_preco.sql"
+echo "migration aplicada: 20260617130000_tint_promote_preserva_preco.sql"
+
+# ── ZONA 3: seed ──
+# OFICIAL pré-existente: COR1/P1/B1/E1 com preço 100 (para provar a PRESERVAÇÃO).
+# Catálogo p/ 2 pares vendáveis: (P1,B1,E1) e (P2,B2,E1). Corante C1 com custo (p/ recálculo).
+P -q <<'SQL'
+INSERT INTO tint_produtos (id, account, cod_produto, descricao) VALUES
+ ('a0000000-0000-0000-0000-000000000001','colacor','P1','Produto 1'),
+ ('a0000000-0000-0000-0000-000000000002','colacor','P2','Produto 2');
+INSERT INTO tint_bases (id, account, id_base_sayersystem, descricao) VALUES
+ ('b0000000-0000-0000-0000-000000000001','colacor','B1','Base 1'),
+ ('b0000000-0000-0000-0000-000000000002','colacor','B2','Base 2');
+INSERT INTO tint_embalagens (id, account, id_embalagem_sayersystem, volume_ml) VALUES
+ ('c0000000-0000-0000-0000-000000000001','colacor','E1',900);
+INSERT INTO tint_corantes (id, account, id_corante_sayersystem, descricao, volume_total_ml) VALUES
+ ('d0000000-0000-0000-0000-000000000001','colacor','C1','Corante 1',1000);
+INSERT INTO tint_skus (id, account, produto_id, base_id, embalagem_id) VALUES
+ ('e0000000-0000-0000-0000-000000000001','colacor','a0000000-0000-0000-0000-000000000001','b0000000-0000-0000-0000-000000000001','c0000000-0000-0000-0000-000000000001'),
+ ('e0000000-0000-0000-0000-000000000002','colacor','a0000000-0000-0000-0000-000000000002','b0000000-0000-0000-0000-000000000002','c0000000-0000-0000-0000-000000000001');
+-- fórmula oficial JÁ EXISTENTE (preço 100) — o piso a preservar
+INSERT INTO tint_formulas (id, account, cor_id, nome_cor, produto_id, base_id, embalagem_id, sku_id, volume_final_ml, preco_final_sayersystem) VALUES
+ ('f0000000-0000-0000-0000-000000000001','colacor','COR1','Cor 1',
+  'a0000000-0000-0000-0000-000000000001','b0000000-0000-0000-0000-000000000001','c0000000-0000-0000-0000-000000000001',
+  'e0000000-0000-0000-0000-000000000001',900,100.00);
+
+-- run + settings
+INSERT INTO tint_integration_settings (id, account, store_code) VALUES
+ ('10000000-0000-0000-0000-000000000001','colacor','M01');
+INSERT INTO tint_sync_runs (id, setting_id, account, store_code, sync_type, status) VALUES
+ ('20000000-0000-0000-0000-000000000001','10000000-0000-0000-0000-000000000001','colacor','M01','formulas','running');
+
+-- staging catálogo (re-envio)
+INSERT INTO tint_staging_produtos (sync_run_id, account, store_code, cod_produto) VALUES
+ ('20000000-0000-0000-0000-000000000001','colacor','M01','P1'),
+ ('20000000-0000-0000-0000-000000000001','colacor','M01','P2');
+INSERT INTO tint_staging_bases (sync_run_id, account, store_code, id_base_sayersystem, descricao) VALUES
+ ('20000000-0000-0000-0000-000000000001','colacor','M01','B1','Base 1'),
+ ('20000000-0000-0000-0000-000000000001','colacor','M01','B2','Base 2');
+INSERT INTO tint_staging_embalagens (sync_run_id, account, store_code, id_embalagem_sayersystem, volume_ml) VALUES
+ ('20000000-0000-0000-0000-000000000001','colacor','M01','E1',900);
+INSERT INTO tint_staging_corantes (sync_run_id, account, store_code, id_corante_sayersystem, descricao, custo, volume_ml) VALUES
+ ('20000000-0000-0000-0000-000000000001','colacor','M01','C1','Corante 1',2.0,1000);
+INSERT INTO tint_staging_skus (sync_run_id, account, store_code, cod_produto, id_base, id_embalagem) VALUES
+ ('20000000-0000-0000-0000-000000000001','colacor','M01','P1','B1','E1'),
+ ('20000000-0000-0000-0000-000000000001','colacor','M01','P2','B2','E1');
+-- 3 fórmulas: COR1 (existe→preserva) · CORNOVA (nova,sem base→NULL) · COR3 (nova,COM base→positivo)
+INSERT INTO tint_staging_formulas (id, sync_run_id, account, store_code, cor_id, nome_cor, cod_produto, id_base, id_embalagem, volume_final_ml, preco_final, personalizada) VALUES
+ ('50000000-0000-0000-0000-000000000001','20000000-0000-0000-0000-000000000001','colacor','M01','COR1','Cor 1','P1','B1','E1',900,NULL,false),
+ ('50000000-0000-0000-0000-000000000002','20000000-0000-0000-0000-000000000001','colacor','M01','CORNOVA','Cor Nova','P1','B1','E1',900,NULL,false),
+ ('50000000-0000-0000-0000-000000000003','20000000-0000-0000-0000-000000000001','colacor','M01','COR3','Cor 3','P2','B2','E1',900,NULL,false);
+INSERT INTO tint_staging_formula_itens (sync_run_id, staging_formula_id, id_corante, qtd_ml, ordem) VALUES
+ ('20000000-0000-0000-0000-000000000001','50000000-0000-0000-0000-000000000001','C1',10,1),
+ ('20000000-0000-0000-0000-000000000001','50000000-0000-0000-0000-000000000002','C1',10,1),
+ ('20000000-0000-0000-0000-000000000001','50000000-0000-0000-0000-000000000003','C1',10,1);
+-- precos_base SÓ para (P2,B2,E1) → COR3 recalcula positivo; P1/B1 fica sem base (NULL).
+INSERT INTO tint_staging_precos_base (sync_run_id, account, store_code, cod_produto, id_base, id_embalagem, custo, imposto_pct, margem_pct) VALUES
+ ('20000000-0000-0000-0000-000000000001','colacor','M01','P2','B2','E1',50.0,0,0);
+SQL
+echo "seed pronto"
+
+# ── rodar a promoção REAL ──
+RES=$(Pq -c "SELECT tint_promote_sync_run('20000000-0000-0000-0000-000000000001');")
+echo "promoção retornou: $RES"
+
+# ── ZONA 4: asserts ──
+echo "── asserts ──"
+P1=$(Pq -c "SELECT coalesce(preco_final_sayersystem::text,'NULL') FROM tint_formulas WHERE account='colacor' AND cor_id='COR1' AND embalagem_id='c0000000-0000-0000-0000-000000000001';")
+eq "P1 preço preservado (precos_base vazio NÃO zera o piso)" "$P1" "100.00"
+P2=$(Pq -c "SELECT coalesce(preco_final_sayersystem::text,'NULL') FROM tint_formulas WHERE account='colacor' AND cor_id='CORNOVA';")
+eq "P2 cor nova sem base → NULL honesto (não fabrica)" "$P2" "NULL"
+P3=$(Pq -c "SELECT preco_final_sayersystem::text FROM tint_formulas WHERE account='colacor' AND cor_id='COR3';")
+eq "P3 recálculo legítimo com precos_base (50 + 0.02 corante)" "$P3" "50.02"
+P4=$(Pq -c "SELECT count(*) FROM tint_formulas WHERE account='colacor' AND cor_id IN ('CORNOVA','COR3');")
+eq "P4 catálogo promovido (cores novas inseridas)" "$P4" "2"
+P4b=$(Pq -c "SELECT count(*) FROM tint_formula_itens fi JOIN tint_formulas f ON f.id=fi.formula_id WHERE f.cor_id='COR3';")
+eq "P4b itens expandidos da cor nova" "$P4b" "1"
+
+# ── ZONA 5: FALSIFICAÇÃO (aplica a set_based SEM COALESCE → P1 deve QUEBRAR) ──
+echo "── falsificação: aplica a versão furada (set_based, SEM COALESCE) e re-roda ──"
+P -q -f "$REPO_ROOT/supabase/migrations/20260615160000_tint_promote_set_based.sql" >/dev/null
+Pq -c "SELECT tint_promote_sync_run('20000000-0000-0000-0000-000000000001');" >/dev/null
+FALSO=$(Pq -c "SELECT coalesce(preco_final_sayersystem::text,'NULO_ZERADO') FROM tint_formulas WHERE account='colacor' AND cor_id='COR1' AND embalagem_id='c0000000-0000-0000-0000-000000000001';")
+# sentinela anti-teatro: 'NULO_ZERADO' é texto MEU, não emitido pelo código; só aparece se o preço virou NULL
+if [ "$FALSO" = "NULO_ZERADO" ]; then
+  ok "falsificação tem dente: SEM o COALESCE o preço de COR1 ZEROU (era 100 → NULL)"
+else
+  bad "falsificação FRACA: sem o COALESCE o preço deveria zerar, mas veio [$FALSO] — o assert P1 não prova nada"
+fi
+
+echo "──────────────────────────────"
+echo "RESULTADO: $PASS ok / $FAIL fail"
+[ "$FAIL" = "0" ] || { echo "❌ HARNESS VERMELHO"; exit 1; }
+echo "✅ HARNESS VERDE"

--- a/db/test-tint-promote-reexpand.sh
+++ b/db/test-tint-promote-reexpand.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+# ╔══════════════════════════════════════════════════════════════════════════════╗
+# ║  PROVA PG17 — 20260617150000_tint_promote_reexpand_skus_novos.sql             ║
+# ║  Invariante: a re-expansão de fórmulas dispara só p/ pares de skus NOVOS       ║
+# ║  (não p/ todo sku tocado). Re-envio de sku existente → carga ZERO (mata o      ║
+# ║  lock timeout do incidente 17/06). Sku NOVO ainda re-expande (§11 P1-C).       ║
+# ║  Regressão: o COALESCE de preço da 130000 segue preservando o piso.            ║
+# ║  Falsificação: aplica a 130000 (usa _tp_sku, SEM o fix) → re-envio re-expande. ║
+# ╚══════════════════════════════════════════════════════════════════════════════╝
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PGVER=17
+PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+PORT="${PGPORT_TEST:-5458}"
+SLUG="tint-reexpand"
+DATA="$(mktemp -d "/tmp/pgtest-${SLUG}.XXXXXX")/data"
+export LC_ALL=C LANG=C
+
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente: brew install postgresql@${PGVER} pgvector"; exit 1; }
+CELLAR="$(brew --prefix "postgresql@${PGVER}")"
+cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
+mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
+cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
+
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+trap cleanup EXIT
+
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l "/tmp/pg-${SLUG}.log" -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres prove
+P()  { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d prove -v ON_ERROR_STOP=1 "$@"; }
+P0() { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d prove "$@"; }
+Pq() { P -tA "$@"; }
+
+P -q -f "$REPO_ROOT/db/stubs-supabase.sql"
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION auth.uid()  RETURNS uuid LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.uid',  true), '')::uuid $f$;
+CREATE OR REPLACE FUNCTION auth.role() RETURNS text LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.role', true), '') $f$;
+ALTER ROLE service_role BYPASSRLS;
+SQL
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  ✅ $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  ❌ $1"; }
+eq()  { if [ "$2" = "$3" ]; then ok "$1 (=$2)"; else bad "$1 — esperado [$3], veio [$2]"; fi; }
+gt0() { if [ "${2:-0}" -gt 0 ] 2>/dev/null; then ok "$1 (=$2)"; else bad "$1 — esperado >0, veio [$2]"; fi; }
+
+echo "═══ setup PG17 :$PORT ═══"
+
+# ── ZONA 1: snapshot + stale fixes + cadeia de helpers/promoção ──
+RR="$(mktemp /tmp/snap-rr.XXXXXX.sql)"
+sed -E 's/^(CREATE SCHEMA public;)/-- \1/' "$REPO_ROOT/supabase/schema-snapshot.sql" \
+  | grep -vE '^\\(un)?restrict ' > "$RR"
+P -q -f "$REPO_ROOT/supabase/schema-extensions-prelude.sql" 2>/dev/null || true
+P0 -q -f "$RR" >/tmp/snap-apply.log 2>&1 || true
+rm -f "$RR"
+P -q <<'SQL'
+CREATE TABLE IF NOT EXISTS public.tint_staging_precos_base (
+  id uuid NOT NULL DEFAULT gen_random_uuid(), sync_run_id uuid, account text NOT NULL, store_code text NOT NULL,
+  cod_produto text NOT NULL, id_base text NOT NULL, id_embalagem text NOT NULL,
+  custo numeric, imposto_pct numeric, margem_pct numeric, raw_data jsonb, staging_status text,
+  created_at timestamptz NOT NULL DEFAULT now());
+ALTER TABLE public.tint_formulas ADD COLUMN IF NOT EXISTS desativada_em timestamptz;
+SQL
+for t in tint_produtos tint_bases tint_embalagens tint_corantes tint_skus tint_formulas tint_formula_itens \
+         tint_sync_runs tint_integration_settings tint_importacoes tint_staging_formulas tint_staging_formula_itens \
+         tint_staging_precos_base tint_staging_skus tint_staging_produtos tint_staging_bases tint_staging_embalagens tint_staging_corantes; do
+  EX=$(Pq -c "SELECT to_regclass('public.$t') IS NOT NULL;")
+  [ "$EX" = "t" ] || { echo "❌ SETUP: tabela $t não criada (ver /tmp/snap-apply.log)"; exit 1; }
+done
+for m in 20260609150000_tint_sync_promote 20260611190000_tint_sync_codex_fixes \
+         20260615140000_tint_promote_indices_timeout 20260615160000_tint_promote_set_based; do
+  P0 -q -f "$REPO_ROOT/supabase/migrations/${m}.sql" >>/tmp/mig-apply.log 2>&1 || true
+done
+echo "snapshot + cadeia de migrations aplicados"
+
+# ── ZONA 2: a migration REAL sob teste ──
+P -q -f "$REPO_ROOT/supabase/migrations/20260617150000_tint_promote_reexpand_skus_novos.sql"
+echo "migration aplicada: 20260617150000_tint_promote_reexpand_skus_novos.sql"
+
+# ── ZONA 3: seed ──
+# Oficial: COR1/P1/B1/E1 (preço 100). Par (P1,B1) com sku E1. run1 promove COR1/CORNOVA/COR3.
+# run2 = re-envio do sku EXISTENTE (P1,B1,E1) — não deve re-expandir.
+# run3 = sku NOVO (P1,B1,E2, embalagem E2 nova) — deve re-expandir o par (P1-C).
+P -q <<'SQL'
+INSERT INTO tint_produtos (id, account, cod_produto, descricao) VALUES
+ ('a0000000-0000-0000-0000-000000000001','colacor','P1','Produto 1'),
+ ('a0000000-0000-0000-0000-000000000002','colacor','P2','Produto 2');
+INSERT INTO tint_bases (id, account, id_base_sayersystem, descricao) VALUES
+ ('b0000000-0000-0000-0000-000000000001','colacor','B1','Base 1'),
+ ('b0000000-0000-0000-0000-000000000002','colacor','B2','Base 2');
+INSERT INTO tint_embalagens (id, account, id_embalagem_sayersystem, volume_ml) VALUES
+ ('c0000000-0000-0000-0000-000000000001','colacor','E1',900);
+INSERT INTO tint_corantes (id, account, id_corante_sayersystem, descricao, volume_total_ml) VALUES
+ ('d0000000-0000-0000-0000-000000000001','colacor','C1','Corante 1',1000);
+INSERT INTO tint_skus (id, account, produto_id, base_id, embalagem_id) VALUES
+ ('e0000000-0000-0000-0000-000000000001','colacor','a0000000-0000-0000-0000-000000000001','b0000000-0000-0000-0000-000000000001','c0000000-0000-0000-0000-000000000001'),
+ ('e0000000-0000-0000-0000-000000000002','colacor','a0000000-0000-0000-0000-000000000002','b0000000-0000-0000-0000-000000000002','c0000000-0000-0000-0000-000000000001');
+INSERT INTO tint_formulas (id, account, cor_id, nome_cor, produto_id, base_id, embalagem_id, sku_id, volume_final_ml, preco_final_sayersystem) VALUES
+ ('f0000000-0000-0000-0000-000000000001','colacor','COR1','Cor 1',
+  'a0000000-0000-0000-0000-000000000001','b0000000-0000-0000-0000-000000000001','c0000000-0000-0000-0000-000000000001',
+  'e0000000-0000-0000-0000-000000000001',900,100.00);
+
+INSERT INTO tint_integration_settings (id, account, store_code) VALUES
+ ('10000000-0000-0000-0000-000000000001','colacor','M01');
+
+-- RUN 1 (catalogs+formulas): promove COR1/CORNOVA/COR3
+INSERT INTO tint_sync_runs (id, setting_id, account, store_code, sync_type, status) VALUES
+ ('20000000-0000-0000-0000-000000000001','10000000-0000-0000-0000-000000000001','colacor','M01','formulas','running');
+INSERT INTO tint_staging_produtos (sync_run_id, account, store_code, cod_produto) VALUES
+ ('20000000-0000-0000-0000-000000000001','colacor','M01','P1'),('20000000-0000-0000-0000-000000000001','colacor','M01','P2');
+INSERT INTO tint_staging_bases (sync_run_id, account, store_code, id_base_sayersystem, descricao) VALUES
+ ('20000000-0000-0000-0000-000000000001','colacor','M01','B1','Base 1'),('20000000-0000-0000-0000-000000000001','colacor','M01','B2','Base 2');
+INSERT INTO tint_staging_embalagens (sync_run_id, account, store_code, id_embalagem_sayersystem, volume_ml) VALUES
+ ('20000000-0000-0000-0000-000000000001','colacor','M01','E1',900);
+INSERT INTO tint_staging_corantes (sync_run_id, account, store_code, id_corante_sayersystem, descricao, custo, volume_ml) VALUES
+ ('20000000-0000-0000-0000-000000000001','colacor','M01','C1','Corante 1',2.0,1000);
+INSERT INTO tint_staging_skus (sync_run_id, account, store_code, cod_produto, id_base, id_embalagem) VALUES
+ ('20000000-0000-0000-0000-000000000001','colacor','M01','P1','B1','E1'),('20000000-0000-0000-0000-000000000001','colacor','M01','P2','B2','E1');
+INSERT INTO tint_staging_formulas (id, sync_run_id, account, store_code, cor_id, nome_cor, cod_produto, id_base, id_embalagem, volume_final_ml, preco_final, personalizada) VALUES
+ ('50000000-0000-0000-0000-000000000001','20000000-0000-0000-0000-000000000001','colacor','M01','COR1','Cor 1','P1','B1','E1',900,NULL,false),
+ ('50000000-0000-0000-0000-000000000002','20000000-0000-0000-0000-000000000001','colacor','M01','CORNOVA','Cor Nova','P1','B1','E1',900,NULL,false),
+ ('50000000-0000-0000-0000-000000000003','20000000-0000-0000-0000-000000000001','colacor','M01','COR3','Cor 3','P2','B2','E1',900,NULL,false);
+INSERT INTO tint_staging_formula_itens (sync_run_id, staging_formula_id, id_corante, qtd_ml, ordem) VALUES
+ ('20000000-0000-0000-0000-000000000001','50000000-0000-0000-0000-000000000001','C1',10,1),
+ ('20000000-0000-0000-0000-000000000001','50000000-0000-0000-0000-000000000002','C1',10,1),
+ ('20000000-0000-0000-0000-000000000001','50000000-0000-0000-0000-000000000003','C1',10,1);
+INSERT INTO tint_staging_precos_base (sync_run_id, account, store_code, cod_produto, id_base, id_embalagem, custo, imposto_pct, margem_pct) VALUES
+ ('20000000-0000-0000-0000-000000000001','colacor','M01','P2','B2','E1',50.0,0,0);
+
+-- RUN 2 (catalogs): re-envio do sku EXISTENTE (P1,B1,E1), SEM fórmulas
+INSERT INTO tint_sync_runs (id, setting_id, account, store_code, sync_type, status) VALUES
+ ('20000000-0000-0000-0000-000000000002','10000000-0000-0000-0000-000000000001','colacor','M01','catalogs','running');
+INSERT INTO tint_staging_skus (sync_run_id, account, store_code, cod_produto, id_base, id_embalagem) VALUES
+ ('20000000-0000-0000-0000-000000000002','colacor','M01','P1','B1','E1');
+
+-- RUN 3 (catalogs): sku NOVO (P1,B1,E2) + embalagem E2 nova, SEM fórmulas
+INSERT INTO tint_sync_runs (id, setting_id, account, store_code, sync_type, status) VALUES
+ ('20000000-0000-0000-0000-000000000003','10000000-0000-0000-0000-000000000001','colacor','M01','catalogs','running');
+INSERT INTO tint_staging_embalagens (sync_run_id, account, store_code, id_embalagem_sayersystem, volume_ml) VALUES
+ ('20000000-0000-0000-0000-000000000003','colacor','M01','E2',405);
+INSERT INTO tint_staging_skus (sync_run_id, account, store_code, cod_produto, id_base, id_embalagem) VALUES
+ ('20000000-0000-0000-0000-000000000003','colacor','M01','P1','B1','E2');
+SQL
+echo "seed pronto"
+
+# ── RUN 1: promove ──
+R1RES=$(Pq -c "SELECT tint_promote_sync_run('20000000-0000-0000-0000-000000000001');")
+echo "run1 (promove): $R1RES"
+
+echo "── asserts ──"
+# Regressão do PREÇO (a 150000 inclui o COALESCE da 130000)
+PRECO=$(Pq -c "SELECT coalesce(preco_final_sayersystem::text,'NULL') FROM tint_formulas WHERE account='colacor' AND cor_id='COR1' AND embalagem_id='c0000000-0000-0000-0000-000000000001';")
+eq "regressão: preço de COR1 preservado (COALESCE)" "$PRECO" "100.00"
+CAT=$(Pq -c "SELECT count(*) FROM tint_formulas WHERE account='colacor' AND cor_id IN ('CORNOVA','COR3');")
+eq "regressão: catálogo promovido (cores novas)" "$CAT" "2"
+
+# R1 — re-envio de sku EXISTENTE não re-expande (a CORREÇÃO da carga)
+R2RES=$(Pq -c "SELECT (tint_promote_sync_run('20000000-0000-0000-0000-000000000002'))->>'promovidas';")
+eq "R1 re-envio de sku EXISTENTE → carga ZERO (não re-expande)" "$R2RES" "0"
+
+# R2 — sku NOVO re-expande o par (P1-C preservado)
+R3RES=$(Pq -c "SELECT (tint_promote_sync_run('20000000-0000-0000-0000-000000000003'))->>'promovidas';")
+gt0 "R2 sku NOVO (embalagem E2) re-expande o par" "$R3RES"
+COR1EMB=$(Pq -c "SELECT count(DISTINCT embalagem_id) FROM tint_formulas WHERE account='colacor' AND cor_id='COR1';")
+eq "R2b COR1 ganhou a embalagem nova (E1→E1+E2)" "$COR1EMB" "2"
+
+# ── FALSIFICAÇÃO: aplica a 130000 (usa _tp_sku, SEM o fix de carga) → re-envio re-expande ──
+echo "── falsificação: aplica a versão SEM o fix (_tp_sku) e re-roda o run de re-envio ──"
+P -q -f "$REPO_ROOT/supabase/migrations/20260617130000_tint_promote_preserva_preco.sql" >/dev/null
+FALSO=$(Pq -c "SELECT (tint_promote_sync_run('20000000-0000-0000-0000-000000000002'))->>'promovidas';")
+# SEM o fix, o sku existente entra em _pares (via _tp_sku) → re-expande o par (P1,B1) → promovidas>0
+if [ "${FALSO:-0}" -gt 0 ] 2>/dev/null; then
+  ok "falsificação tem dente: SEM o fix, re-envio de sku existente re-expande (promovidas=$FALSO)"
+else
+  bad "falsificação FRACA: sem o fix o re-envio deveria re-expandir, veio promovidas=[$FALSO]"
+fi
+
+echo "──────────────────────────────"
+echo "RESULTADO: $PASS ok / $FAIL fail"
+[ "$FAIL" = "0" ] || { echo "❌ HARNESS VERMELHO"; exit 1; }
+echo "✅ HARNESS VERDE"

--- a/docs/runbooks/tint-sync-corte-csv.md
+++ b/docs/runbooks/tint-sync-corte-csv.md
@@ -1,0 +1,173 @@
+# Runbook — Corte do CSV do Tintométrico (faxina → re-scan → reconciliação → flip)
+
+> Operação de **corte**: aposentar o CSV manual de catálogo e ligar o sync SayerSystem em tempo real.
+> Gerado em 2026-06-16 (sessão `reverent-snyder`). Spec: `docs/superpowers/specs/2026-06-09-tint-sync-sayersystem-design.md` (§13–14).
+> ⚠️ **money-path:** o **flip** (§Bloco B) é a operação de RISCO (precisão > recall). Só flipe após a reconciliação provar divergência ~zero (§3). Se o sync falhar silencioso em `automatic_primary`, o balcão mostra fórmula errada/faltando.
+
+## 0. Estado de produção (diagnóstico 16/06 23:33 Brasília, via `psql-ro` read-only)
+
+- `integration_mode = shadow_mode` — **seguro** (a promoção não roda; o balcão lê do oficial + preço via Omie).
+- Conector **v0.1.7** (host `DESKTOP-BCTR6K6`), parado às 17:18 Brasília (**máquina desligada**). O **fix do loop (v0.2.0) está no PR #914 — DRAFT, não deployado**.
+- `tint_staging_formulas`: **9,2 M linhas / 7 GB** · `tint_staging_formula_itens`: **32,8 M / 5,8 GB** → lixo do loop (full-scan permanente). Faxina = Bloco A.
+- `tint_formulas` (oficial): **481.721 fórmulas, 0 desativadas** — íntegro. **O balcão NÃO depende do conector** (catálogo já no oficial; preço via Omie).
+- Funções em prod ✅: `tint_promote_sync_run(uuid)`, `tint_run_reconciliation(uuid)`, `tint_apply_keys_snapshot(uuid)` (todas SECURITY DEFINER).
+- **O flip já foi exercido em prod** (129 importações `tipo='sync_agent'`, última 16/06 11:54): a edge em prod **tem o gate de promoção e ela rodou sem dano aparente** (oficial íntegro). ⚠️ Mas rodou sobre o staging **poluído** → a **reconciliação limpa** (§3d) é o juiz final, não esse histórico.
+
+## 1. Pré-requisitos (antes de iniciar o corte)
+
+1. **PR #914 mergeado** na `main` (tirar do DRAFT → auto-merge no CI verde).
+2. **`sayersync.exe` v0.2.0 buildado** — cross-compile `GOOS=windows GOARCH=amd64` **sem CGO** (procedimento no corpo do #914).
+3. **Edge `tint-sync-agent` em PROD** — ✅ **já confirmado por evidência**: 129 promoções `sync_agent` rodaram em prod (última 16/06 11:54), logo o gate existe e funciona (`index.ts:397` `/catalogs`, `index.ts:542` `/formulas`). **Revalidar com `lovable-deploy-verify` só se a edge for redeployada** antes do flip.
+
+> 🛡️ **Proteção barata até o v0.2.0:** o serviço `SayerSync` pode ficar **PARADO/desabilitado** sem nenhum impacto no balcão. **NÃO** religar o v0.1.7 (reenche o staging). Como a máquina está desligada, o risco é só amanhã ao abrir a loja — deixar o serviço em *startup manual* elimina o risco.
+
+## 2. Sequência de corte (a ORDEM importa — anti-corrida)
+
+Founder no balcão (PowerShell Admin) + SQL Editor do Lovable, na ordem, **antes de o v0.1.7 rodar um ciclo**:
+
+1. **[Balcão]** `net stop SayerSync` — garantir parado (se a máquina acabou de ligar, parar **antes** do 1º ciclo).
+2. **[Balcão]** Trocar o exe pelo **v0.2.0** (preserva `config.json`).
+3. **[Balcão]** Apagar **`state.json`** (zera o high-water mark → força full re-scan) **E `hashes.json`** (senão o cache de hash acha que "já enviou tudo" e não reenvia nada).
+4. **[Banco / SQL Editor]** Rodar o **Bloco A** (faxina). Conferir staging ~0.
+5. **[Balcão]** `net start SayerSync`. 1º ciclo = full-scan: envia ~485k fórmulas **limpas** + popula `hashes.json`. Ciclos seguintes: só delta (~0) → **loop morto**.
+6. Acompanhar **§3** (re-scan saudável + reconciliação ~zero).
+7. Só então **Bloco B** (flip).
+
+---
+
+## Bloco A — Faxina do staging  ·  `🟣 Lovable → SQL Editor → cola → Run`
+
+```sql
+-- FAXINA: apaga ~12,8 GB de lixo do loop de re-envio.
+-- Seguro: zero triggers nas staging; NENHUMA tabela oficial referencia staging
+-- (FKs só staging→tint_sync_runs e filho→pai). TRUNCATE (não DELETE): instantâneo + libera disco.
+BEGIN;
+TRUNCATE TABLE
+  tint_staging_formulas,
+  tint_staging_formula_itens,
+  tint_staging_produtos,
+  tint_staging_bases,
+  tint_staging_embalagens,
+  tint_staging_skus,
+  tint_staging_corantes,
+  tint_staging_cores_catalogo,
+  tint_staging_cores_personalizadas,
+  tint_staging_preparacoes,
+  tint_staging_preparacao_itens,
+  tint_staging_precos_base
+CASCADE;
+COMMIT;
+```
+
+**Validação pós-faxina** (agora o `count` é instantâneo — tabela vazia):
+
+```sql
+SELECT 'formulas' AS t, count(*) FROM tint_staging_formulas
+UNION ALL SELECT 'formula_itens', count(*) FROM tint_staging_formula_itens;
+-- esperado: 0 e 0.
+```
+
+> Higiene opcional (separada, não-urgente): `tint_formulas_backup_preflip` (481.721 linhas / 103 MB) é resíduo do flip prematuro revertido. Pode ser `DROP`ada **depois** que o flip definitivo estabilizar — mantenha como rede até lá.
+
+---
+
+## 3. Validação pós re-scan (read-only — Claude roda via `psql-ro`, ou founder no SQL Editor)
+
+```sql
+-- (a) o loop morreu? runs/hora deve despencar (era ~400-510/h)
+SELECT date_trunc('hour', started_at) AS hora, count(*) AS runs, sum(total_records) AS regs
+FROM tint_sync_runs WHERE started_at > now() - interval '6 hours'
+GROUP BY 1 ORDER BY 1 DESC;
+
+-- (b) staging estabilizou em ~121k (fórmulas CRUAS; expandem ~4× p/ ~481k no oficial), não crescendo
+SELECT count(*) FROM tint_staging_formulas;   -- esperado ~121k, ESTÁVEL entre ciclos (NÃO 9M)
+
+-- (c) conector é v0.2.0 e heartbeat fresco
+SELECT agent_version, last_heartbeat_at, now() - last_heartbeat_at AS idade
+FROM tint_integration_settings WHERE store_code = 'M01';   -- esperado: 0.2.0
+
+-- (d) reconciliação (rodar pela tela TintReconciliation → /tintometrico/integracao; resultado aqui)
+SELECT started_at, status, total_compared, matches, divergences, only_csv, only_sync
+FROM tint_reconciliation_runs ORDER BY started_at DESC LIMIT 3;
+-- meta: divergences ~0 (ou explicadas = cores novas da Sayerlack desde o último CSV).
+```
+
+> ⚠️ A `tint_reconciliation_runs` formal só tem registros de **29/03** (testes iniciais, 9–36 comparações). A reconciliação de 12/06 (spec §13.2) foi **spot-check manual** — **rode a formal de novo** sobre o staging limpo (tela `TintReconciliation`) antes do flip.
+
+---
+
+## Bloco B — Flip → `automatic_primary`  ·  `🟣 SQL Editor` (só após §3 = divergência ~zero)
+
+**Pré-condições — confirmar TODAS:**
+- [ ] **migration `20260617130000_tint_promote_preserva_preco` aplicada em prod** — a promoção PRESERVA o preço (COALESCE); SEM ela o flip grava `preco_final_sayersystem=NULL` em tudo → subfatura ~19k cores (calc<CSV). Provada em PG17 + Codex (sem P1). Validar com a query do Bloco C.
+- [ ] conector **v0.2.0** no heartbeat (§3c)
+- [ ] **loop morto** (§3a: runs/hora baixo)
+- [ ] **staging estável ~121k cru** (§3b)
+- [ ] **reconciliação ~zero** (§3d)
+- [ ] **edge `tint-sync-agent` em PROD** com o gate de promoção — ✅ já confirmado (129 promoções `sync_agent` rodaram; §0)
+
+**B.1 — Flip** (`🟣 SQL Editor`, idempotente):
+```sql
+BEGIN;
+UPDATE tint_integration_settings
+SET integration_mode = 'automatic_primary', updated_at = now()
+WHERE store_code = 'M01' AND integration_mode = 'shadow_mode';
+-- ⚠️ deve afetar EXATAMENTE 1 linha. Se 0 → já flipado ou store errado: ROLLBACK e investigar.
+COMMIT;
+```
+
+**B.2 — Forçar o re-envio** (⚠️ CRÍTICO — sem isto o flip não promove NADA). Com o hash, o conector
+já enviou tudo e manda ~0/ciclo; a promoção processa só as chaves DO RUN (`WHERE sync_run_id=...`),
+então sem dado novo ela não promove. Force um re-envio em `automatic_primary` — no balcão (Prompt Admin):
+```cmd
+net stop SayerSync
+del "C:\SayerSync\hashes.json"
+del "C:\SayerSync\state.json"
+net start SayerSync
+```
+O 1º ciclo re-envia catalogs + as ~121k fórmulas em `automatic_primary` → cada run dispara
+`tint_promote_sync_run` → o oficial é atualizado (151 cores novas entram; preço PRESERVADO). ~8 min.
+(O staging cresce com o re-envio; a purga automática de 30d limpa o excedente.)
+
+**B.3 — Validar** (read-only — Claude via psql-ro, ou founder no SQL Editor):
+```sql
+SELECT count(*) AS total,
+       count(*) FILTER (WHERE preco_final_sayersystem IS NULL) AS sem_preco,
+       count(*) FILTER (WHERE desativada_em IS NOT NULL) AS desativadas,
+       max(updated_at) AS ult_update
+FROM tint_formulas;
+-- ⚠️ 'sem_preco' tem que continuar BAIXO (~0). Se disparar p/ centenas de milhares → a migration de
+--    preço NÃO estava aplicada: REVERTER o flip (§4) e aplicar a migration antes. 'desativadas' pequeno.
+```
+
+**Blast-radius pós-flip** (a promoção tem guarda >20% das ativas OU snapshot <50% → ABORTA;
+481.721 ativas → 20% ≈ 96.344): em B.3, `desativadas` perto disso = parar e investigar.
+
+---
+
+## Bloco C — Deploy da migration de preço (PRÉ-REQUISITO do flip) · `🟣 SQL Editor`
+
+A migration `supabase/migrations/20260617130000_tint_promote_preserva_preco.sql` faz
+`CREATE OR REPLACE` de `tint_promote_sync_run` com o `COALESCE` que preserva o preço. **Aplique
+ANTES do flip.** Cole o conteúdo INTEIRO do arquivo no SQL Editor e Run (é a função set_based de
+prod + 3 linhas de COALESCE; provada em PG17 `db/test-tint-promote-preserva-preco.sh` + Codex sem P1).
+
+**Validação pós-apply** (read-only — confirma que a versão com COALESCE está no ar):
+```sql
+SELECT CASE WHEN pg_get_functiondef('public.tint_promote_sync_run(uuid)'::regprocedure)
+  LIKE '%COALESCE(EXCLUDED.preco_final_sayersystem%'
+  THEN '✅ promoção preserva o preço (COALESCE no ar)'
+  ELSE '❌ versão SEM COALESCE ainda no ar — NÃO flipar' END AS status;
+```
+
+## 4. Reversão (se algo der errado pós-flip)
+
+```sql
+-- volta ao modo seguro (a promoção para de rodar; balcão volta a depender só do oficial atual)
+UPDATE tint_integration_settings SET integration_mode='shadow_mode', updated_at=now() WHERE store_code='M01';
+-- rede: tint_formulas_backup_preflip preserva o oficial de antes do 1º flip (481.721 linhas).
+```
+
+## 5. Critério de pronto (spec §8.6)
+
+Founder altera um preço no **Omie** → o balcão reflete (sync de produtos Omie ~2h). E altera uma **fórmula** no SayerSystem → o app reflete em ≤ ~15 min, **sem ação humana, sem CSV**.

--- a/docs/runbooks/tint-sync-corte-csv.md
+++ b/docs/runbooks/tint-sync-corte-csv.md
@@ -4,6 +4,16 @@
 > Gerado em 2026-06-16 (sessão `reverent-snyder`). Spec: `docs/superpowers/specs/2026-06-09-tint-sync-sayersystem-design.md` (§13–14).
 > ⚠️ **money-path:** o **flip** (§Bloco B) é a operação de RISCO (precisão > recall). Só flipe após a reconciliação provar divergência ~zero (§3). Se o sync falhar silencioso em `automatic_primary`, o balcão mostra fórmula errada/faltando.
 
+## ✅ DESFECHO (18/06 17:57 UTC) — catálogo automático NO AR, CSV aposentado
+
+Após **3 incidentes resolvidos** (loop de re-envio → hash v0.2.0; lock timeout na re-expansão em massa → `_skus_novos`; lock timeout no recálculo por corante → E4 `custo IS NOT NULL`), o flip definitivo **completou sem travar**. Verificação money-path em prod:
+- `integration_mode = automatic_primary`; conector v0.2.0 manda ~0 (loop morto); advisory lock limpo.
+- **482.665 fórmulas · 8.502 cores** (vs 8.388 do gabarito 12/06 = +114 cores novas).
+- **Preço:** 944 sem `preco_final_sayersystem` = **todas cores NOVAS** (criadas hoje); **0 existentes perderam preço** (COALESCE provado em prod). Cores novas têm preço via Omie (§14).
+- **0 desativadas** (nada removido indevidamente). Migrations em prod: `20260617130000` + `20260617150000` + `20260618130000`.
+
+**Follow-ups (Codex, não-urgentes — custo/precos_base não existem hoje):** (a) E4/precos_base usam loop-por-fórmula → migrar p/ set-based se algum dia vier custo em massa; (b) E1 atualiza `tint_corantes.volume_total_ml` mas preserva `preco_litro` (incoerência se algo ler direto); (c) defesa de infra `idle_in_transaction_session_timeout` no role (mata conexão presa antes que trave o lock); (d) higiene: `DROP TABLE tint_formulas_backup_preflip` (103 MB) após estabilizar.
+
 ## 0. Estado de produção (diagnóstico 16/06 23:33 Brasília, via `psql-ro` read-only)
 
 - `integration_mode = shadow_mode` — **seguro** (a promoção não roda; o balcão lê do oficial + preço via Omie).

--- a/docs/runbooks/tint-sync-corte-csv.md
+++ b/docs/runbooks/tint-sync-corte-csv.md
@@ -180,3 +180,30 @@ UPDATE tint_integration_settings SET integration_mode='shadow_mode', updated_at=
 ## 5. Critério de pronto (spec §8.6)
 
 Founder altera um preço no **Omie** → o balcão reflete (sync de produtos Omie ~2h). E altera uma **fórmula** no SayerSystem → o app reflete em ≤ ~15 min, **sem ação humana, sem CSV**.
+
+## 6. Fix pendente — carga da promoção no re-envio (BLOQUEADOR do flip, dx incidente 17/06)
+
+**Diagnóstico (confirmado na lógica da promoção, `pg_get_functiondef`):** a promoção monta os pares a
+re-expandir como **fórmulas tocadas no run ∪ TODOS os skus tocados** (`_tp_sku`):
+```sql
+CREATE TEMP TABLE _pares ... AS
+  SELECT ... FROM tint_staging_formulas WHERE sync_run_id = p_sync_run_id ...
+  UNION
+  SELECT cod_produto, id_base FROM _tp_sku;   -- ← TODOS os skus do run, não só os novos
+```
+No re-envio, o run de `catalogs` traz os 220 skus = **todos os pares** → `_formulas_latest` (restrita aos
+pares) = **TODAS as ~121k fórmulas** → E2/E3 re-expande tudo num único run → > gateway timeout →
+conexão idle-in-transaction segura o advisory lock → as demais promoções morrem (55P03).
+
+**Fix proposto (cirúrgico — money-path, exige `prove-sql-money-path` + `/codex` + re-flip):**
+re-expandir só os pares de skus **REALMENTE NOVOS** (embalagem nova p/ o par), não os re-enviados.
+1. Antes do upsert de skus (E1/loop), capturar `_skus_novos` = pares de `_tp_sku` que **NÃO existem**
+   ainda em `tint_skus` (join produto/base/embalagem por identidade).
+2. Na montagem de `_pares`, trocar `UNION ... FROM _tp_sku` por `UNION ... FROM _skus_novos`.
+
+Efeito: re-envio → run de `catalogs` (skus já existem) re-expande **0**; runs de `formulas` re-expandem só
+suas ~1000 (carga distribuída, leve por run); embalagem **nova** → re-expande só aquele par (§11 P1-C preservado).
+
+**Provar (PG17):** (a) sku re-enviado existente → `_pares` de catalogs vazio, 0 re-expansão; (b) sku NOVO →
+re-expande o par; (c) fórmula tocada → promove normal. **Falsificar:** voltar p/ `_tp_sku` → o teste (a) fica vermelho.
+**Depois:** re-flip (Bloco B) — o re-envio agora distribui a carga por lote, sem travar.

--- a/docs/runbooks/tint-sync-corte-csv.md
+++ b/docs/runbooks/tint-sync-corte-csv.md
@@ -116,6 +116,15 @@ WHERE store_code = 'M01' AND integration_mode = 'shadow_mode';
 COMMIT;
 ```
 
+> 🚧 **INCIDENTE 17/06 — o re-envio em massa abaixo TRAVOU a promoção (lock timeout, SQLSTATE 55P03).**
+> Causa provável: ao truncar+re-enviar, a promoção de `catalogs` vê os 220 skus como "novos" e
+> re-expande TODAS as ~481k fórmulas de uma vez (§6.2.2) → estoura o timeout do gateway → a conexão
+> PostgREST fica **idle-in-transaction segurando o advisory lock** (`idle_in_transaction_session_timeout=0`,
+> nunca morre) → as próximas promoções morrem esperando o lock. Oficial ficou **INTACTO** (rollback).
+> Revertido p/ `shadow_mode` + `pg_terminate_backend` na sessão presa. **NÃO repetir este re-envio em
+> massa até corrigir a CARGA da promoção** (fix pendente — ver §6). O conserto do PREÇO (Bloco C) é
+> ortogonal e está OK; o bloqueador do flip agora é a carga/lock, não o preço.
+
 **B.2 — Forçar o re-envio** (⚠️ CRÍTICO — sem isto o flip não promove NADA). Com o hash, o conector
 já enviou tudo e manda ~0/ciclo; a promoção processa só as chaves DO RUN (`WHERE sync_run_id=...`),
 então sem dado novo ela não promove. Force um re-envio em `automatic_primary` — no balcão (Prompt Admin):

--- a/supabase/migrations/20260617130000_tint_promote_preserva_preco.sql
+++ b/supabase/migrations/20260617130000_tint_promote_preserva_preco.sql
@@ -1,0 +1,618 @@
+-- 20260617130000_tint_promote_preserva_preco.sql
+-- MUDANÇA money-path (PREÇO): a promoção PRESERVA preco_final_sayersystem quando o recálculo dá
+-- NULL — COALESCE(novo, atual) em E2 (upsert) e E4 (recálculo por insumo). Motivo: a fonte de
+-- preço da base (tint_staging_precos_base) NUNCA é populada (precos_base não existe no SayerSystem;
+-- o preço do balcão vem do Omie via get_tint_price). Sem este COALESCE, o flip→automatic_primary
+-- gravaria preco_final_sayersystem=NULL em TODA fórmula promovida, derrubando o PISO que
+-- select-price.ts usa (regra 3: mantém o MAIOR entre calc e CSV) → subfaturaria ~19k cores onde
+-- calc<CSV. Com o COALESCE, a promoção atualiza o CATÁLOGO (cores/fórmulas/itens) SEM tocar no
+-- preço existente; cor NOVA fica com preço NULL (degradação honesta — sem piso histórico, o balcão
+-- usa o calc do Omie). Espelha o padrão COALESCE já usado p/ corantes (preco_litro) nesta função.
+-- Provado em PG17: db/test-tint-promote-preserva-preco.sh (preservação · cor-nova-NULL · recálculo
+-- legítimo com precos_base · falsificação). Codex challenge (sem P1): NULL NÃO vira R$0/venda
+-- indevida (gate de select-price.ts + useTintColorSelect) e o RHS do ON CONFLICT lê a linha
+-- pré-update. 3 [P2] da classe "piso stale" (o COALESCE mantém o CSV quando o recálculo dá NULL
+-- → o balcão, regra 3 MAIOR, pode vender CARO demais se o preço devia baixar) = a decisão §14(3)
+-- (manter o CSV, NÃO baixar por engano), não regressão. Follow-up conhecido: reativação
+-- (desativada_em=NULL) de cor que volta com receita diferente preserva o preço antigo como piso.
+-- O RESTO é VERBATIM da 20260615160000 (a última a recriar vence; §database.md).
+--
+-- [HERDADO de 20260615160000_tint_promote_set_based.sql:]
+-- Reescreve o MOTOR de fórmulas (E2/E3) da tint_promote_sync_run de PROCEDURAL (FOR LOOP
+-- aninhado: O(fórmulas × embalagens), com tint_calc_preco_final por linha) para SET-BASED
+-- (INSERT...SELECT em massa). Mesma regra de negócio, executada em lote.
+--
+-- Motivo (flip 15/06): o loop processava ~481k expansões 1-a-1 chamando tint_calc_preco_final
+-- (subqueries por chamada) — inviável dentro do request do gateway na carga inicial (statement
+-- timeout 57014 → depois lock timeout + upstream timeout em cascata). Os índices de
+-- 20260615140000 ajudaram mas não bastaram: o gargalo é a NATUREZA procedural. Set-based, a
+-- mesma carga roda em segundos (1 INSERT...SELECT com joins, não 481k iterações).
+--
+-- IDENTIDADE (money-path, precisão > recall): o conjunto de fórmulas/itens/preços promovido é
+-- IDÊNTICO ao do loop. Espelho dos oráculos src/lib/tint/sync-promote.ts (expandirFormula /
+-- precoFinalSayer) — mesma regra de 3 (fator = vol_destino / vol_formulacao), mesmo preço pág 9
+-- (base×(1+imp/100)×(1+marg/100) + Σ corante×qtd/vol), MESMO NULL-honesto (base ausente OU
+-- qualquer corante sem custo/volume → preço NULL, NUNCA 0). Provado em PG17:
+-- db/test-tint-promote.sh — os 12 cenários C1-C12 (valores do oráculo, inalterados) + um cenário
+-- de VOLUME que roda o loop ANTIGO (preservado via RENAME no teste) e o set-based sobre o MESMO
+-- seed e exige EXCEPT vazio nos dois sentidos (identidade contábil) + falsificação.
+--
+-- O QUE NÃO MUDA (copiado VERBATIM da 20260611190000 — a última a recriar vence; §database.md):
+--   S1 advisory lock · upsert de importação · latest-staging-por-chave (_tp_*) · E1 catálogo +
+--   loop de skus · E4 recálculo por insumo (tint_recalc_preco_oficial) · E5 contadores/purge.
+--   Os helpers (tint_calc_preco_final / tint_recalc_preco_oficial / tint_ensure_corante_stub /
+--   tint_apply_keys_snapshot) ficam como estão (20260609150000/20260611190000) — esta migration
+--   só faz CREATE OR REPLACE da tint_promote_sync_run. tint_calc_preco_final deixa de ser chamada
+--   pela promoção (o preço virou CTE em massa), mas continua definida (sem DROP).
+--
+-- SET statement_timeout='300s' fica NO CABEÇALHO da função: CREATE OR REPLACE substitui as
+-- cláusulas SET, então sem isto o ALTER de 20260615140000 seria perdido. Carga inicial é pesada
+-- por natureza; deltas diários são leves. Migration manual via SQL Editor (§deploy.md).
+
+CREATE OR REPLACE FUNCTION public.tint_promote_sync_run(p_sync_run_id uuid)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public
+SET statement_timeout = '300s'
+AS $$
+DECLARE
+  v_run            record;
+  v_account        text;
+  v_store          text;
+  v_importacao_id  uuid;
+  v_promovidas     int := 0;
+  v_erros          int := 0;
+  v_recalc         int := 0;
+  v_tmp            int := 0;
+  v_zero_uuid      constant uuid := '00000000-0000-0000-0000-000000000000';
+  r                record;
+  v_produto_id     uuid;
+  v_base_id        uuid;
+  v_subcolecao_id  uuid;
+  v_sku_id         uuid;
+  v_emb_id         uuid;
+  v_formula_id     uuid;
+  v_fator          numeric;
+  v_preco          numeric;
+  v_qtd_vendaveis  int;
+BEGIN
+  SELECT * INTO v_run FROM tint_sync_runs WHERE id = p_sync_run_id;
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('ok', false, 'error', 'run não encontrado');
+  END IF;
+  v_account := v_run.account;
+  v_store   := v_run.store_code;
+
+  -- S1 (codex P1-7): serializa promoções concorrentes do mesmo (account+store). Sem isto, dois
+  -- runs simultâneos do mesmo par leem o latest-staging e escrevem o oficial interleavados (o mais
+  -- VELHO podia vencer). Lock de transação → libera automaticamente no commit/rollback.
+  PERFORM pg_advisory_xact_lock(hashtext('tint_sync:' || v_account || ':' || v_store));
+
+  -- Cria/reusa o registro de importação (reusa a tela de histórico). arquivo_hash = run_id
+  -- colide com UNIQUE(account, arquivo_hash) em re-execução → ON CONFLICT reusa a linha (idempotente).
+  INSERT INTO tint_importacoes (account, tipo, arquivo_nome, arquivo_hash, status)
+  VALUES (v_account, 'sync_agent', 'sync:' || p_sync_run_id::text, p_sync_run_id::text, 'processando')
+  ON CONFLICT (account, arquivo_hash) DO UPDATE
+    SET status = 'processando', registros_importados = 0, registros_erro = 0
+  RETURNING id INTO v_importacao_id;
+
+  -- ──────────────────────────────────────────────────────────────────────────
+  -- LATEST-STAGING-POR-CHAVE: views temporárias com a linha mais recente por chave
+  -- natural (across TODOS os runs do mesmo account+store), restritas às chaves
+  -- tocadas POR ESTE run (§11 P1-C). DISTINCT ON (chave) ORDER BY created_at DESC, id DESC.
+  -- ──────────────────────────────────────────────────────────────────────────
+
+  -- Produtos tocados pelo run → latest (descrição mais recente; stub se ausente).
+  CREATE TEMP TABLE _tp_prod ON COMMIT DROP AS
+  WITH chaves AS (
+    SELECT DISTINCT cod_produto FROM tint_staging_produtos
+    WHERE sync_run_id = p_sync_run_id AND cod_produto IS NOT NULL
+  ),
+  latest AS (
+    SELECT DISTINCT ON (s.cod_produto) s.cod_produto, s.descricao
+    FROM tint_staging_produtos s
+    JOIN chaves c ON c.cod_produto = s.cod_produto
+    WHERE s.account = v_account AND s.store_code = v_store
+    ORDER BY s.cod_produto, s.created_at DESC, s.id DESC
+  )
+  SELECT cod_produto, descricao FROM latest;
+
+  CREATE TEMP TABLE _tp_base ON COMMIT DROP AS
+  WITH chaves AS (
+    SELECT DISTINCT id_base_sayersystem FROM tint_staging_bases
+    WHERE sync_run_id = p_sync_run_id AND id_base_sayersystem IS NOT NULL
+  ),
+  latest AS (
+    SELECT DISTINCT ON (s.id_base_sayersystem) s.id_base_sayersystem, s.descricao
+    FROM tint_staging_bases s
+    JOIN chaves c ON c.id_base_sayersystem = s.id_base_sayersystem
+    WHERE s.account = v_account AND s.store_code = v_store
+    ORDER BY s.id_base_sayersystem, s.created_at DESC, s.id DESC
+  )
+  SELECT id_base_sayersystem, descricao FROM latest;
+
+  CREATE TEMP TABLE _tp_emb ON COMMIT DROP AS
+  WITH chaves AS (
+    SELECT DISTINCT id_embalagem_sayersystem FROM tint_staging_embalagens
+    WHERE sync_run_id = p_sync_run_id AND id_embalagem_sayersystem IS NOT NULL
+  ),
+  latest AS (
+    SELECT DISTINCT ON (s.id_embalagem_sayersystem) s.id_embalagem_sayersystem, s.descricao, s.volume_ml
+    FROM tint_staging_embalagens s
+    JOIN chaves c ON c.id_embalagem_sayersystem = s.id_embalagem_sayersystem
+    WHERE s.account = v_account AND s.store_code = v_store
+    ORDER BY s.id_embalagem_sayersystem, s.created_at DESC, s.id DESC
+  )
+  SELECT id_embalagem_sayersystem, descricao, volume_ml FROM latest;
+
+  -- Corantes tocados → latest (descricao + preco_litro + custo/volume p/ preço).
+  CREATE TEMP TABLE _tp_cor ON COMMIT DROP AS
+  WITH chaves AS (
+    SELECT DISTINCT id_corante_sayersystem FROM tint_staging_corantes
+    WHERE sync_run_id = p_sync_run_id AND id_corante_sayersystem IS NOT NULL
+  ),
+  latest AS (
+    SELECT DISTINCT ON (s.id_corante_sayersystem)
+           s.id_corante_sayersystem, s.descricao, s.preco_litro, s.custo, s.volume_ml
+    FROM tint_staging_corantes s
+    JOIN chaves c ON c.id_corante_sayersystem = s.id_corante_sayersystem
+    WHERE s.account = v_account AND s.store_code = v_store
+    ORDER BY s.id_corante_sayersystem, s.created_at DESC, s.id DESC
+  )
+  SELECT id_corante_sayersystem, descricao, preco_litro, custo, volume_ml FROM latest;
+
+  -- Skus tocados → latest por (cod_produto,id_base,id_embalagem).
+  CREATE TEMP TABLE _tp_sku ON COMMIT DROP AS
+  WITH chaves AS (
+    SELECT DISTINCT cod_produto, id_base, id_embalagem FROM tint_staging_skus
+    WHERE sync_run_id = p_sync_run_id
+      AND cod_produto IS NOT NULL AND id_base IS NOT NULL AND id_embalagem IS NOT NULL
+  ),
+  latest AS (
+    SELECT DISTINCT ON (s.cod_produto, s.id_base, s.id_embalagem)
+           s.cod_produto, s.id_base, s.id_embalagem
+    FROM tint_staging_skus s
+    JOIN chaves c ON c.cod_produto = s.cod_produto AND c.id_base = s.id_base AND c.id_embalagem = s.id_embalagem
+    WHERE s.account = v_account AND s.store_code = v_store
+    ORDER BY s.cod_produto, s.id_base, s.id_embalagem, s.created_at DESC, s.id DESC
+  )
+  SELECT cod_produto, id_base, id_embalagem FROM latest;
+
+  -- ──────────────────────────────────────────────────────────────────────────
+  -- E1) Catálogo: upsert oficial a partir do latest-staging (espelha onConflict do tint-import).
+  -- ──────────────────────────────────────────────────────────────────────────
+  INSERT INTO tint_produtos (account, cod_produto, descricao)
+  SELECT v_account, cod_produto, COALESCE(descricao, cod_produto) FROM _tp_prod
+  ON CONFLICT (account, cod_produto) DO UPDATE SET descricao = EXCLUDED.descricao;
+
+  INSERT INTO tint_bases (account, id_base_sayersystem, descricao)
+  SELECT v_account, id_base_sayersystem, COALESCE(descricao, id_base_sayersystem) FROM _tp_base
+  ON CONFLICT (account, id_base_sayersystem) DO UPDATE SET descricao = EXCLUDED.descricao;
+
+  -- volume_ml NULL/0 do staging NUNCA rebaixa o volume oficial existente (espelha o
+  -- COALESCE/NULLIF do corante): senão a expansão (guard volume_ml>0) dropa as fórmulas
+  -- da embalagem silenciosamente. INSERT de embalagem nova com volume NULL → stub 0 (não
+  -- vendável, não satisfaz o guard de expansão). descricao idem (NULL não apaga a oficial).
+  INSERT INTO tint_embalagens (account, id_embalagem_sayersystem, descricao, volume_ml)
+  SELECT v_account, id_embalagem_sayersystem, COALESCE(descricao, id_embalagem_sayersystem), COALESCE(volume_ml, 0) FROM _tp_emb
+  ON CONFLICT (account, id_embalagem_sayersystem) DO UPDATE
+    SET descricao = COALESCE(EXCLUDED.descricao, tint_embalagens.descricao),
+        volume_ml = COALESCE(NULLIF(EXCLUDED.volume_ml, 0), tint_embalagens.volume_ml);
+
+  -- Corantes: volume_total_ml é NOT NULL no oficial → preferir staging volume_ml, senão preservar
+  -- o existente, senão 1000 (default do CSV-import p/ stub). preco_litro derivado de custo/volume
+  -- (R$/L) quando os dois presentes; senão preserva o staging.preco_litro.
+  INSERT INTO tint_corantes (account, id_corante_sayersystem, descricao, volume_total_ml, preco_litro)
+  SELECT
+    v_account,
+    c.id_corante_sayersystem,
+    COALESCE(c.descricao, c.id_corante_sayersystem),
+    COALESCE(c.volume_ml, ex.volume_total_ml, 1000),
+    CASE
+      WHEN c.custo IS NOT NULL AND c.volume_ml IS NOT NULL AND c.volume_ml > 0
+        THEN round((c.custo / c.volume_ml * 1000)::numeric, 2)
+      ELSE c.preco_litro
+    END
+  FROM _tp_cor c
+  LEFT JOIN tint_corantes ex ON ex.account = v_account AND ex.id_corante_sayersystem = c.id_corante_sayersystem
+  ON CONFLICT (account, id_corante_sayersystem) DO UPDATE
+    SET descricao        = EXCLUDED.descricao,
+        volume_total_ml  = EXCLUDED.volume_total_ml,
+        preco_litro      = COALESCE(EXCLUDED.preco_litro, tint_corantes.preco_litro);
+
+  -- Skus de produto_base_embalagem: resolve FKs (cria stub de produto/base/embalagem se a
+  -- linha do sku referenciar id ainda não-visto no run — espelha ensure* do CSV).
+  FOR r IN SELECT cod_produto, id_base, id_embalagem FROM _tp_sku LOOP
+    INSERT INTO tint_produtos (account, cod_produto, descricao)
+    VALUES (v_account, r.cod_produto, r.cod_produto)
+    ON CONFLICT (account, cod_produto) DO NOTHING;
+    INSERT INTO tint_bases (account, id_base_sayersystem, descricao)
+    VALUES (v_account, r.id_base, r.id_base)
+    ON CONFLICT (account, id_base_sayersystem) DO NOTHING;
+    INSERT INTO tint_embalagens (account, id_embalagem_sayersystem, descricao, volume_ml)
+    VALUES (v_account, r.id_embalagem, r.id_embalagem, 0)
+    ON CONFLICT (account, id_embalagem_sayersystem) DO NOTHING;
+
+    SELECT id INTO v_produto_id FROM tint_produtos WHERE account = v_account AND cod_produto = r.cod_produto;
+    SELECT id INTO v_base_id    FROM tint_bases    WHERE account = v_account AND id_base_sayersystem = r.id_base;
+    SELECT id INTO v_emb_id     FROM tint_embalagens WHERE account = v_account AND id_embalagem_sayersystem = r.id_embalagem;
+
+    INSERT INTO tint_skus (account, produto_id, base_id, embalagem_id)
+    VALUES (v_account, v_produto_id, v_base_id, v_emb_id)
+    ON CONFLICT (account, produto_id, base_id, embalagem_id) DO NOTHING;
+  END LOOP;
+
+  -- ══════════════════════════════════════════════════════════════════════════
+  -- E2/E3) Fórmulas — SET-BASED (substitui o FOR LOOP aninhado procedural).
+  --   Mesma regra de negócio do loop, em massa. Pares afetados + latest-staging por chave de
+  --   fórmula são VERBATIM do loop; o que muda é a expansão/preço/upsert/itens (INSERT...SELECT).
+  -- ══════════════════════════════════════════════════════════════════════════
+
+  -- Pares (cod_produto, id_base) afetados = pares com fórmula tocada NESTE run ∪ pares de sku
+  -- tocado (§11 P1-C: embalagem nova ⇒ re-expandir).
+  CREATE TEMP TABLE _pares ON COMMIT DROP AS
+  SELECT DISTINCT cod_produto, id_base FROM (
+    SELECT cod_produto, id_base FROM tint_staging_formulas
+      WHERE sync_run_id = p_sync_run_id AND cod_produto IS NOT NULL AND id_base IS NOT NULL
+    UNION
+    SELECT cod_produto, id_base FROM _tp_sku
+  ) u;
+
+  -- Latest staging de fórmula por (cor_id, cod_produto, id_base, sub_norm, personalizada),
+  -- restrita aos pares afetados — across TODOS os runs.
+  CREATE TEMP TABLE _formulas_latest ON COMMIT DROP AS
+  WITH alvo AS (
+    SELECT s.*
+    FROM tint_staging_formulas s
+    JOIN _pares p ON p.cod_produto = s.cod_produto AND p.id_base = s.id_base
+    WHERE s.account = v_account AND s.store_code = v_store
+      AND s.cor_id IS NOT NULL AND s.cod_produto IS NOT NULL AND s.id_base IS NOT NULL
+  )
+  SELECT DISTINCT ON (cor_id, cod_produto, id_base, COALESCE(subcolecao, ''), personalizada)
+         id AS staging_formula_id, cor_id, nome_cor, cod_produto, id_base, id_embalagem,
+         subcolecao, volume_final_ml, personalizada
+  FROM alvo
+  ORDER BY cor_id, cod_produto, id_base, COALESCE(subcolecao, ''), personalizada,
+           created_at DESC, id DESC;
+
+  -- Resolve FK produto/base por JOIN (não SELECT por linha). LEFT JOIN p/ separar os não-resolvidos.
+  CREATE TEMP TABLE _fl_resolved ON COMMIT DROP AS
+  SELECT fl.*, p.id AS produto_id, b.id AS base_id
+  FROM _formulas_latest fl
+  LEFT JOIN tint_produtos p ON p.account = v_account AND p.cod_produto = fl.cod_produto
+  LEFT JOIN tint_bases    b ON b.account = v_account AND b.id_base_sayersystem = fl.id_base;
+
+  -- Guard 1 — produto/base não resolvido (catálogo incompleto). Espelha o 1º CONTINUE do loop.
+  INSERT INTO tint_sync_errors (sync_run_id, entity_type, entity_id, error_message, error_details)
+  SELECT p_sync_run_id, 'formula_promote', fl.cor_id,
+         'produto/base não resolvido (catálogo incompleto)',
+         jsonb_build_object('cod_produto', fl.cod_produto, 'id_base', fl.id_base)
+  FROM _fl_resolved fl
+  WHERE fl.produto_id IS NULL OR fl.base_id IS NULL;
+  GET DIAGNOSTICS v_tmp = ROW_COUNT; v_erros := v_erros + v_tmp;
+
+  -- Subcoleções: ensure p/ fórmulas com produto/base resolvido e subcoleção não-vazia (o loop
+  -- ensura DEPOIS do guard de produto/base, ANTES dos guards de volume/vendável). id = texto CRU.
+  INSERT INTO tint_subcolecoes (account, id_subcolecao_sayersystem, descricao)
+  SELECT DISTINCT v_account, fl.subcolecao, fl.subcolecao
+  FROM _fl_resolved fl
+  WHERE fl.produto_id IS NOT NULL AND fl.base_id IS NOT NULL
+    AND fl.subcolecao IS NOT NULL AND btrim(fl.subcolecao) <> ''
+  ON CONFLICT (account, id_subcolecao_sayersystem) DO NOTHING;
+
+  -- Guard 2 — volume de formulação <= 0/nulo (entre os resolvidos). Espelha o 2º CONTINUE.
+  INSERT INTO tint_sync_errors (sync_run_id, entity_type, entity_id, error_message, error_details)
+  SELECT p_sync_run_id, 'formula_promote', fl.cor_id,
+         'volume de formulação <= 0 ou nulo',
+         jsonb_build_object('volume_final_ml', fl.volume_final_ml)
+  FROM _fl_resolved fl
+  WHERE fl.produto_id IS NOT NULL AND fl.base_id IS NOT NULL
+    AND (fl.volume_final_ml IS NULL OR fl.volume_final_ml <= 0);
+  GET DIAGNOSTICS v_tmp = ROW_COUNT; v_erros := v_erros + v_tmp;
+
+  -- Guard 3 — zero embalagens vendáveis para o par (entre resolvidos com volume OK). 3º CONTINUE.
+  INSERT INTO tint_sync_errors (sync_run_id, entity_type, entity_id, error_message, error_details)
+  SELECT p_sync_run_id, 'formula_promote', fl.cor_id,
+         'zero embalagens vendáveis para o par (produto,base)',
+         jsonb_build_object('cod_produto', fl.cod_produto, 'id_base', fl.id_base)
+  FROM _fl_resolved fl
+  WHERE fl.produto_id IS NOT NULL AND fl.base_id IS NOT NULL
+    AND fl.volume_final_ml IS NOT NULL AND fl.volume_final_ml > 0
+    AND NOT EXISTS (
+      SELECT 1 FROM tint_skus sk
+      JOIN tint_embalagens e ON e.id = sk.embalagem_id
+      WHERE sk.account = v_account AND sk.produto_id = fl.produto_id AND sk.base_id = fl.base_id
+        AND e.volume_ml IS NOT NULL AND e.volume_ml > 0
+    );
+  GET DIAGNOSTICS v_tmp = ROW_COUNT; v_erros := v_erros + v_tmp;
+
+  -- Expansão (regra de 3): 1 linha por (fórmula que passou TODOS os guards × embalagem vendável).
+  -- fator = vol_destino / vol_formulacao (espelho expandirFormula). subcolecao_id resolvido por
+  -- LEFT JOIN (NULL quando vazio). eid = chave surrogate p/ casar o preço.
+  CREATE TEMP TABLE _expand ON COMMIT DROP AS
+  SELECT
+    row_number() OVER () AS eid,
+    fl.staging_formula_id, fl.cor_id, fl.nome_cor, fl.cod_produto, fl.id_base, fl.personalizada,
+    fl.subcolecao,  -- texto CRU (p/ o desempate espelhar a ordem do loop; ver _expand_uniq)
+    fl.produto_id, fl.base_id,
+    sub.id AS subcolecao_id,
+    sk.id  AS sku_id,
+    sk.embalagem_id AS emb_id,
+    e.id_embalagem_sayersystem AS id_emb,
+    e.volume_ml AS vol_destino,
+    (e.volume_ml / fl.volume_final_ml) AS fator
+  FROM _fl_resolved fl
+  JOIN tint_skus sk ON sk.account = v_account AND sk.produto_id = fl.produto_id AND sk.base_id = fl.base_id
+  JOIN tint_embalagens e ON e.id = sk.embalagem_id
+  LEFT JOIN tint_subcolecoes sub
+    ON sub.account = v_account
+   AND fl.subcolecao IS NOT NULL AND btrim(fl.subcolecao) <> ''
+   AND sub.id_subcolecao_sayersystem = fl.subcolecao
+  WHERE fl.produto_id IS NOT NULL AND fl.base_id IS NOT NULL
+    AND fl.volume_final_ml IS NOT NULL AND fl.volume_final_ml > 0
+    AND e.volume_ml IS NOT NULL AND e.volume_ml > 0;
+
+  -- v_promovidas = nº de expansões (= incrementos do loop interno, inclui colisão personalizada).
+  SELECT count(*) INTO v_promovidas FROM _expand;
+
+  -- Preço pág 9 por expansão — SET-BASED, NULL-honesto (espelho precoFinalSayer + S2 store + S3
+  -- latest não-nulo). base ausente OU qualquer corante sem custo/volume(>0)/finito → preço NULL.
+  CREATE TEMP TABLE _preco ON COMMIT DROP AS
+  WITH base_latest AS (   -- S2: store_code; S3: custo IS NOT NULL. Latest por chave de base.
+    SELECT DISTINCT ON (cod_produto, id_base, id_embalagem)
+           cod_produto, id_base, id_embalagem, custo, imposto_pct, margem_pct
+    FROM tint_staging_precos_base
+    WHERE account = v_account AND store_code = v_store AND custo IS NOT NULL
+    ORDER BY cod_produto, id_base, id_embalagem, created_at DESC, id DESC
+  ),
+  cor_latest AS (         -- S2: store_code; S3: custo+volume NÃO-NULOS. Latest por corante.
+    SELECT DISTINCT ON (id_corante_sayersystem)
+           id_corante_sayersystem, custo, volume_ml
+    FROM tint_staging_corantes
+    WHERE account = v_account AND store_code = v_store
+      AND custo IS NOT NULL AND volume_ml IS NOT NULL
+    ORDER BY id_corante_sayersystem, created_at DESC, id DESC
+  ),
+  itens AS (              -- Σ corantes por expansão; flag de corante faltante (NULL-honesto).
+    SELECT ex.eid,
+           bool_or(
+             cl.id_corante_sayersystem IS NULL
+             OR cl.volume_ml IS NULL OR cl.volume_ml <= 0
+             OR NOT (cl.custo > '-Infinity'::numeric AND cl.custo < 'Infinity'::numeric)
+           ) AS faltante,
+           sum(CASE WHEN cl.volume_ml > 0 THEN (cl.custo / cl.volume_ml) * (si.qtd_ml * ex.fator) ELSE 0 END) AS soma
+    FROM _expand ex
+    JOIN tint_staging_formula_itens si ON si.staging_formula_id = ex.staging_formula_id
+    LEFT JOIN cor_latest cl ON cl.id_corante_sayersystem = si.id_corante
+    WHERE si.id_corante IS NOT NULL AND si.id_corante <> '' AND COALESCE(si.qtd_ml, 0) > 0
+    GROUP BY ex.eid
+  )
+  SELECT
+    ex.eid,
+    CASE
+      WHEN bl.custo IS NULL THEN NULL                                                   -- base ausente
+      WHEN NOT (bl.custo > '-Infinity'::numeric AND bl.custo < 'Infinity'::numeric) THEN NULL  -- custo não-finito
+      WHEN COALESCE(it.faltante, false) THEN NULL                                       -- corante sem preço
+      ELSE round(
+        ( bl.custo * (1 + COALESCE(bl.imposto_pct, 0) / 100) * (1 + COALESCE(bl.margem_pct, 0) / 100) )
+        + COALESCE(it.soma, 0)
+      , 2)
+    END AS preco
+  FROM _expand ex
+  LEFT JOIN base_latest bl
+    ON bl.cod_produto = ex.cod_produto AND bl.id_base = ex.id_base AND bl.id_embalagem = ex.id_emb
+  LEFT JOIN itens it ON it.eid = ex.eid;
+
+  -- Dedup pela CHAVE OFICIAL (uq_tint_formulas_chave — SEM personalizada): INSERT...SELECT não pode
+  -- ter a mesma chave 2× no mesmo comando (cardinality violation). O loop processa _formulas_latest
+  -- em ORDER BY ... COALESCE(subcolecao,'') ASC, personalizada ASC e o ÚLTIMO vence o upsert. A chave
+  -- oficial COLAPSA subcoleções que resolvem ao MESMO subcolecao_id (NULL e whitespace-only viram
+  -- NULL → btrim vazio), então a colisão pode ser entre linhas com COALESCE(subcolecao,'') DIFERENTE
+  -- (não só personalizada). Para escolher o MESMO vencedor do loop, desempata por COALESCE(subcolecao,
+  -- '') DESC PRIMEIRO, depois personalizada DESC (= o último que o loop processaria), eid DESC final.
+  CREATE TEMP TABLE _expand_uniq ON COMMIT DROP AS
+  SELECT DISTINCT ON (ex.cor_id, ex.produto_id, ex.base_id, COALESCE(ex.subcolecao_id, v_zero_uuid), ex.emb_id)
+         ex.staging_formula_id, ex.cor_id, ex.nome_cor, ex.personalizada,
+         ex.produto_id, ex.base_id, ex.subcolecao_id, ex.sku_id, ex.emb_id, ex.vol_destino, ex.fator,
+         pr.preco
+  FROM _expand ex
+  JOIN _preco pr ON pr.eid = ex.eid
+  ORDER BY ex.cor_id, ex.produto_id, ex.base_id, COALESCE(ex.subcolecao_id, v_zero_uuid), ex.emb_id,
+           COALESCE(ex.subcolecao, '') DESC, ex.personalizada DESC, ex.eid DESC;
+
+  -- Corante stubs em massa ANTES dos itens (espelha tint_ensure_corante_stub: volume 1000).
+  -- A partir de _expand (todas as expansões, inclui colisão) p/ casar o side-effect do loop.
+  INSERT INTO tint_corantes (account, id_corante_sayersystem, descricao, volume_total_ml)
+  SELECT DISTINCT v_account, si.id_corante, si.id_corante, 1000
+  FROM tint_staging_formula_itens si
+  WHERE si.staging_formula_id IN (SELECT DISTINCT staging_formula_id FROM _expand)
+    AND si.id_corante IS NOT NULL AND si.id_corante <> '' AND COALESCE(si.qtd_ml, 0) > 0
+  ON CONFLICT (account, id_corante_sayersystem) DO NOTHING;
+
+  -- Upsert oficial em massa por uq_tint_formulas_chave; desativada_em = NULL (reativa). Captura
+  -- formula_id ↔ (staging_formula_id, fator) p/ os itens (RETURNING casado de volta ao _expand_uniq).
+  CREATE TEMP TABLE _promoted ON COMMIT DROP AS
+  WITH ups AS (
+    INSERT INTO tint_formulas (
+      account, cor_id, nome_cor, produto_id, base_id, embalagem_id, subcolecao_id, sku_id,
+      volume_final_ml, preco_final_sayersystem, personalizada, importacao_id, updated_at, desativada_em
+    )
+    SELECT
+      v_account, eu.cor_id, eu.nome_cor, eu.produto_id, eu.base_id, eu.emb_id, eu.subcolecao_id, eu.sku_id,
+      eu.vol_destino, eu.preco, eu.personalizada, v_importacao_id, now(), NULL
+    FROM _expand_uniq eu
+    ON CONFLICT (account, cor_id, produto_id, base_id, COALESCE(subcolecao_id, '00000000-0000-0000-0000-000000000000'::uuid), embalagem_id)
+    DO UPDATE SET
+      nome_cor                = EXCLUDED.nome_cor,
+      sku_id                  = EXCLUDED.sku_id,
+      volume_final_ml         = EXCLUDED.volume_final_ml,
+      -- 20260617: PRESERVA o preço existente quando o novo é NULL (precos_base vazio → eu.preco NULL).
+      -- Sem isto o flip zeraria o piso de ~19k cores (calc<CSV). Espelha o COALESCE de preco_litro acima.
+      preco_final_sayersystem = COALESCE(EXCLUDED.preco_final_sayersystem, tint_formulas.preco_final_sayersystem),
+      personalizada           = EXCLUDED.personalizada,
+      importacao_id           = EXCLUDED.importacao_id,
+      updated_at              = now(),
+      desativada_em           = NULL
+    RETURNING id, cor_id, produto_id, base_id, subcolecao_id, embalagem_id
+  )
+  SELECT u.id AS formula_id, eu.staging_formula_id, eu.fator
+  FROM ups u
+  JOIN _expand_uniq eu
+    ON eu.cor_id = u.cor_id AND eu.produto_id = u.produto_id AND eu.base_id = u.base_id
+   AND COALESCE(eu.subcolecao_id, v_zero_uuid) = COALESCE(u.subcolecao_id, v_zero_uuid)
+   AND eu.emb_id = u.embalagem_id;
+
+  -- Itens em massa: limpa + reinsere (espelha o delete+insert por fórmula do loop). qtd expandida
+  -- = qtd_formulacao × fator, arredondada a 6 casas (sub-µL — elimina artefato de escala da divisão
+  -- numeric sem mudar o valor prático). Corante já garantido (stub acima) → JOIN resolve o id.
+  DELETE FROM tint_formula_itens fi USING _promoted pr WHERE fi.formula_id = pr.formula_id;
+
+  INSERT INTO tint_formula_itens (formula_id, corante_id, ordem, qtd_ml)
+  SELECT pr.formula_id, co.id, si.ordem, round((si.qtd_ml * pr.fator)::numeric, 6)
+  FROM _promoted pr
+  JOIN tint_staging_formula_itens si ON si.staging_formula_id = pr.staging_formula_id
+  JOIN tint_corantes co ON co.account = v_account AND co.id_corante_sayersystem = si.id_corante
+  WHERE si.id_corante IS NOT NULL AND si.id_corante <> '' AND COALESCE(si.qtd_ml, 0) > 0;
+
+  -- ──────────────────────────────────────────────────────────────────────────
+  -- E4) Recálculo de preço por mudança de INSUMO (§11 P1-A — caso de uso PRINCIPAL).
+  --   Run tocou precos_base/corantes → recalcula preco_final_sayersystem das fórmulas
+  --   oficiais ATIVAS afetadas, SEM re-expandir itens. NÃO mexe nas fórmulas que E2 já
+  --   tocou (importacao_id = v_importacao_id) — essas já saíram com o preço novo.
+  -- ──────────────────────────────────────────────────────────────────────────
+  -- Pares (produto,base,embalagem oficial) afetados por precos_base deste run.
+  FOR r IN
+    SELECT DISTINCT f.id AS formula_id, f.cor_id, p.cod_produto, b.id_base_sayersystem AS id_base, e.id_embalagem_sayersystem AS id_emb
+    FROM tint_staging_precos_base sp
+    JOIN tint_produtos   p ON p.account = v_account AND p.cod_produto = sp.cod_produto
+    JOIN tint_bases      b ON b.account = v_account AND b.id_base_sayersystem = sp.id_base
+    JOIN tint_embalagens e ON e.account = v_account AND e.id_embalagem_sayersystem = sp.id_embalagem
+    JOIN tint_formulas   f ON f.account = v_account AND f.produto_id = p.id AND f.base_id = b.id AND f.embalagem_id = e.id
+    WHERE sp.sync_run_id = p_sync_run_id
+      AND f.desativada_em IS NULL
+      AND (f.importacao_id IS DISTINCT FROM v_importacao_id)
+  LOOP
+    -- S2: +v_store.
+    v_preco := tint_recalc_preco_oficial(v_account, v_store, r.formula_id, r.cod_produto, r.id_base, r.id_emb);
+    -- 20260617: só baixa/sobe se o recálculo deu valor; NULL (sem precos_base) PRESERVA o piso atual.
+    UPDATE tint_formulas SET preco_final_sayersystem = COALESCE(v_preco, preco_final_sayersystem), updated_at = now() WHERE id = r.formula_id;
+    v_recalc := v_recalc + 1;
+  END LOOP;
+
+  -- Fórmulas que usam um corante cujo custo/volume mudou neste run.
+  FOR r IN
+    SELECT DISTINCT f.id AS formula_id, f.cor_id, pr.cod_produto, ba.id_base_sayersystem AS id_base, em.id_embalagem_sayersystem AS id_emb
+    FROM tint_staging_corantes sc
+    JOIN tint_corantes      co ON co.account = v_account AND co.id_corante_sayersystem = sc.id_corante_sayersystem
+    JOIN tint_formula_itens fi ON fi.corante_id = co.id
+    JOIN tint_formulas      f  ON f.id = fi.formula_id
+    JOIN tint_produtos      pr ON pr.id = f.produto_id
+    JOIN tint_bases         ba ON ba.id = f.base_id
+    JOIN tint_embalagens    em ON em.id = f.embalagem_id
+    WHERE sc.sync_run_id = p_sync_run_id
+      AND (sc.custo IS NOT NULL OR sc.volume_ml IS NOT NULL)
+      AND f.account = v_account
+      AND f.desativada_em IS NULL
+      AND (f.importacao_id IS DISTINCT FROM v_importacao_id)
+  LOOP
+    -- S2: +v_store.
+    v_preco := tint_recalc_preco_oficial(v_account, v_store, r.formula_id, r.cod_produto, r.id_base, r.id_emb);
+    -- 20260617: só baixa/sobe se o recálculo deu valor; NULL (sem precos_base) PRESERVA o piso atual.
+    UPDATE tint_formulas SET preco_final_sayersystem = COALESCE(v_preco, preco_final_sayersystem), updated_at = now() WHERE id = r.formula_id;
+    v_recalc := v_recalc + 1;
+  END LOOP;
+
+  -- ──────────────────────────────────────────────────────────────────────────
+  -- E5) Contadores + purge staging SUPERSEDED >30d (preserva latest-per-key) +
+  --     runs órfãos >30min → error.
+  -- ──────────────────────────────────────────────────────────────────────────
+  UPDATE tint_importacoes
+    SET status = 'concluido', registros_importados = v_promovidas, registros_erro = v_erros
+  WHERE id = v_importacao_id;
+
+  UPDATE tint_sync_runs
+    SET inserts = v_promovidas, errors = v_erros, metadata = COALESCE(metadata, '{}'::jsonb) || jsonb_build_object('recalculadas', v_recalc)
+  WHERE id = p_sync_run_id;
+
+  -- PURGE: NUNCA apaga a linha MAIS RECENTE por chave natural (account+store) — a promoção
+  -- lê latest-staging-por-chave PRA SEMPRE (recalc por insumo + re-expansão por sku novo
+  -- dependem dela mesmo que o insumo não mude por >30d → nunca é re-enviado). Só remove
+  -- linhas SUPERSEDED (>30d E com uma linha mais nova da MESMA chave). §11 P2-1.
+  -- Ordem de chave: (created_at, id) — idêntica ao DISTINCT ON da promoção.
+  DELETE FROM tint_staging_produtos s
+  WHERE s.created_at < now() - interval '30 days'
+    AND EXISTS (SELECT 1 FROM tint_staging_produtos n
+      WHERE n.account = s.account AND n.store_code = s.store_code
+        AND n.cod_produto = s.cod_produto
+        AND (n.created_at, n.id) > (s.created_at, s.id));
+
+  DELETE FROM tint_staging_bases s
+  WHERE s.created_at < now() - interval '30 days'
+    AND EXISTS (SELECT 1 FROM tint_staging_bases n
+      WHERE n.account = s.account AND n.store_code = s.store_code
+        AND n.id_base_sayersystem = s.id_base_sayersystem
+        AND (n.created_at, n.id) > (s.created_at, s.id));
+
+  DELETE FROM tint_staging_embalagens s
+  WHERE s.created_at < now() - interval '30 days'
+    AND EXISTS (SELECT 1 FROM tint_staging_embalagens n
+      WHERE n.account = s.account AND n.store_code = s.store_code
+        AND n.id_embalagem_sayersystem = s.id_embalagem_sayersystem
+        AND (n.created_at, n.id) > (s.created_at, s.id));
+
+  DELETE FROM tint_staging_corantes s
+  WHERE s.created_at < now() - interval '30 days'
+    AND EXISTS (SELECT 1 FROM tint_staging_corantes n
+      WHERE n.account = s.account AND n.store_code = s.store_code
+        AND n.id_corante_sayersystem = s.id_corante_sayersystem
+        AND (n.created_at, n.id) > (s.created_at, s.id));
+
+  DELETE FROM tint_staging_skus s
+  WHERE s.created_at < now() - interval '30 days'
+    AND EXISTS (SELECT 1 FROM tint_staging_skus n
+      WHERE n.account = s.account AND n.store_code = s.store_code
+        AND n.cod_produto = s.cod_produto AND n.id_base = s.id_base AND n.id_embalagem = s.id_embalagem
+        AND (n.created_at, n.id) > (s.created_at, s.id));
+
+  -- Fórmulas: chave = (cod_produto,id_base,cor_id,COALESCE(subcolecao,''),personalizada),
+  -- idêntica ao DISTINCT ON de _formulas_latest. Itens cascateiam pela formula-pai apagada.
+  DELETE FROM tint_staging_formula_itens si
+  WHERE si.staging_formula_id IN (
+    SELECT s.id FROM tint_staging_formulas s
+    WHERE s.created_at < now() - interval '30 days'
+      AND EXISTS (SELECT 1 FROM tint_staging_formulas n
+        WHERE n.account = s.account AND n.store_code = s.store_code
+          AND n.cor_id = s.cor_id AND n.cod_produto = s.cod_produto AND n.id_base = s.id_base
+          AND COALESCE(n.subcolecao, '') = COALESCE(s.subcolecao, '')
+          AND n.personalizada = s.personalizada
+          AND (n.created_at, n.id) > (s.created_at, s.id)));
+
+  DELETE FROM tint_staging_formulas s
+  WHERE s.created_at < now() - interval '30 days'
+    AND EXISTS (SELECT 1 FROM tint_staging_formulas n
+      WHERE n.account = s.account AND n.store_code = s.store_code
+        AND n.cor_id = s.cor_id AND n.cod_produto = s.cod_produto AND n.id_base = s.id_base
+        AND COALESCE(n.subcolecao, '') = COALESCE(s.subcolecao, '')
+        AND n.personalizada = s.personalizada
+        AND (n.created_at, n.id) > (s.created_at, s.id));
+
+  DELETE FROM tint_staging_precos_base s
+  WHERE s.created_at < now() - interval '30 days'
+    AND EXISTS (SELECT 1 FROM tint_staging_precos_base n
+      WHERE n.account = s.account AND n.store_code = s.store_code
+        AND n.cod_produto = s.cod_produto AND n.id_base = s.id_base AND n.id_embalagem = s.id_embalagem
+        AND (n.created_at, n.id) > (s.created_at, s.id));
+
+  -- keys-snapshot: point-in-time (não latest-per-key) → purge por tempo é correto.
+  DELETE FROM tint_keys_snapshots          WHERE created_at < now() - interval '30 days';
+
+  UPDATE tint_sync_runs
+    SET status = 'error', completed_at = COALESCE(completed_at, now())
+  WHERE status = 'running' AND started_at < now() - interval '30 minutes';
+
+  RETURN jsonb_build_object(
+    'ok', true, 'promovidas', v_promovidas, 'recalculadas', v_recalc,
+    'erros', v_erros, 'importacao_id', v_importacao_id);
+END $$;
+REVOKE EXECUTE ON FUNCTION public.tint_promote_sync_run(uuid) FROM anon, authenticated, PUBLIC;
+
+SELECT 'tint_promote_sync_run SET-BASED OK' AS status;

--- a/supabase/migrations/20260617150000_tint_promote_reexpand_skus_novos.sql
+++ b/supabase/migrations/20260617150000_tint_promote_reexpand_skus_novos.sql
@@ -1,0 +1,645 @@
+-- 20260617150000_tint_promote_reexpand_skus_novos.sql
+-- MUDANÇA money-path (CARGA): a re-expansão de fórmulas (E2/E3) dispara SÓ para pares de skus
+-- REALMENTE NOVOS (embalagem nova p/ o par), não para TODO sku tocado no run. Incidente 17/06: o
+-- flip→automatic_primary + re-envio em massa fez o run de catalogs (todos os 220 skus) re-expandir
+-- TODAS as ~121k fórmulas de uma vez → gateway timeout → conexão idle-in-transaction segurando o
+-- advisory lock → cascata de lock timeout (55P03) → a promoção NUNCA completou. Fix: _skus_novos
+-- (pares de _tp_sku que ainda NÃO existem em tint_skus) entra no _pares no lugar de _tp_sku. Re-envio:
+-- catalogs re-expande 0 (skus já existem); formulas distribuem a carga por lote. Embalagem NOVA →
+-- re-expande só aquele par (§11 P1-C preservado). INCLUI o COALESCE de preço da 20260617130000
+-- (CREATE OR REPLACE — a última a recriar vence). Provado em PG17 + Codex.
+--
+-- [HERDADO da 20260617130000_tint_promote_preserva_preco.sql:]
+-- MUDANÇA money-path (PREÇO): a promoção PRESERVA preco_final_sayersystem quando o recálculo dá
+-- NULL — COALESCE(novo, atual) em E2 (upsert) e E4 (recálculo por insumo). Motivo: a fonte de
+-- preço da base (tint_staging_precos_base) NUNCA é populada (precos_base não existe no SayerSystem;
+-- o preço do balcão vem do Omie via get_tint_price). Sem este COALESCE, o flip→automatic_primary
+-- gravaria preco_final_sayersystem=NULL em TODA fórmula promovida, derrubando o PISO que
+-- select-price.ts usa (regra 3: mantém o MAIOR entre calc e CSV) → subfaturaria ~19k cores onde
+-- calc<CSV. Com o COALESCE, a promoção atualiza o CATÁLOGO (cores/fórmulas/itens) SEM tocar no
+-- preço existente; cor NOVA fica com preço NULL (degradação honesta — sem piso histórico, o balcão
+-- usa o calc do Omie). Espelha o padrão COALESCE já usado p/ corantes (preco_litro) nesta função.
+-- Provado em PG17: db/test-tint-promote-preserva-preco.sh (preservação · cor-nova-NULL · recálculo
+-- legítimo com precos_base · falsificação). Codex challenge (sem P1): NULL NÃO vira R$0/venda
+-- indevida (gate de select-price.ts + useTintColorSelect) e o RHS do ON CONFLICT lê a linha
+-- pré-update. 3 [P2] da classe "piso stale" (o COALESCE mantém o CSV quando o recálculo dá NULL
+-- → o balcão, regra 3 MAIOR, pode vender CARO demais se o preço devia baixar) = a decisão §14(3)
+-- (manter o CSV, NÃO baixar por engano), não regressão. Follow-up conhecido: reativação
+-- (desativada_em=NULL) de cor que volta com receita diferente preserva o preço antigo como piso.
+-- O RESTO é VERBATIM da 20260615160000 (a última a recriar vence; §database.md).
+--
+-- [HERDADO de 20260615160000_tint_promote_set_based.sql:]
+-- Reescreve o MOTOR de fórmulas (E2/E3) da tint_promote_sync_run de PROCEDURAL (FOR LOOP
+-- aninhado: O(fórmulas × embalagens), com tint_calc_preco_final por linha) para SET-BASED
+-- (INSERT...SELECT em massa). Mesma regra de negócio, executada em lote.
+--
+-- Motivo (flip 15/06): o loop processava ~481k expansões 1-a-1 chamando tint_calc_preco_final
+-- (subqueries por chamada) — inviável dentro do request do gateway na carga inicial (statement
+-- timeout 57014 → depois lock timeout + upstream timeout em cascata). Os índices de
+-- 20260615140000 ajudaram mas não bastaram: o gargalo é a NATUREZA procedural. Set-based, a
+-- mesma carga roda em segundos (1 INSERT...SELECT com joins, não 481k iterações).
+--
+-- IDENTIDADE (money-path, precisão > recall): o conjunto de fórmulas/itens/preços promovido é
+-- IDÊNTICO ao do loop. Espelho dos oráculos src/lib/tint/sync-promote.ts (expandirFormula /
+-- precoFinalSayer) — mesma regra de 3 (fator = vol_destino / vol_formulacao), mesmo preço pág 9
+-- (base×(1+imp/100)×(1+marg/100) + Σ corante×qtd/vol), MESMO NULL-honesto (base ausente OU
+-- qualquer corante sem custo/volume → preço NULL, NUNCA 0). Provado em PG17:
+-- db/test-tint-promote.sh — os 12 cenários C1-C12 (valores do oráculo, inalterados) + um cenário
+-- de VOLUME que roda o loop ANTIGO (preservado via RENAME no teste) e o set-based sobre o MESMO
+-- seed e exige EXCEPT vazio nos dois sentidos (identidade contábil) + falsificação.
+--
+-- O QUE NÃO MUDA (copiado VERBATIM da 20260611190000 — a última a recriar vence; §database.md):
+--   S1 advisory lock · upsert de importação · latest-staging-por-chave (_tp_*) · E1 catálogo +
+--   loop de skus · E4 recálculo por insumo (tint_recalc_preco_oficial) · E5 contadores/purge.
+--   Os helpers (tint_calc_preco_final / tint_recalc_preco_oficial / tint_ensure_corante_stub /
+--   tint_apply_keys_snapshot) ficam como estão (20260609150000/20260611190000) — esta migration
+--   só faz CREATE OR REPLACE da tint_promote_sync_run. tint_calc_preco_final deixa de ser chamada
+--   pela promoção (o preço virou CTE em massa), mas continua definida (sem DROP).
+--
+-- SET statement_timeout='300s' fica NO CABEÇALHO da função: CREATE OR REPLACE substitui as
+-- cláusulas SET, então sem isto o ALTER de 20260615140000 seria perdido. Carga inicial é pesada
+-- por natureza; deltas diários são leves. Migration manual via SQL Editor (§deploy.md).
+
+CREATE OR REPLACE FUNCTION public.tint_promote_sync_run(p_sync_run_id uuid)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public
+SET statement_timeout = '300s'
+AS $$
+DECLARE
+  v_run            record;
+  v_account        text;
+  v_store          text;
+  v_importacao_id  uuid;
+  v_promovidas     int := 0;
+  v_erros          int := 0;
+  v_recalc         int := 0;
+  v_tmp            int := 0;
+  v_zero_uuid      constant uuid := '00000000-0000-0000-0000-000000000000';
+  r                record;
+  v_produto_id     uuid;
+  v_base_id        uuid;
+  v_subcolecao_id  uuid;
+  v_sku_id         uuid;
+  v_emb_id         uuid;
+  v_formula_id     uuid;
+  v_fator          numeric;
+  v_preco          numeric;
+  v_qtd_vendaveis  int;
+BEGIN
+  SELECT * INTO v_run FROM tint_sync_runs WHERE id = p_sync_run_id;
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('ok', false, 'error', 'run não encontrado');
+  END IF;
+  v_account := v_run.account;
+  v_store   := v_run.store_code;
+
+  -- S1 (codex P1-7): serializa promoções concorrentes do mesmo (account+store). Sem isto, dois
+  -- runs simultâneos do mesmo par leem o latest-staging e escrevem o oficial interleavados (o mais
+  -- VELHO podia vencer). Lock de transação → libera automaticamente no commit/rollback.
+  PERFORM pg_advisory_xact_lock(hashtext('tint_sync:' || v_account || ':' || v_store));
+
+  -- Cria/reusa o registro de importação (reusa a tela de histórico). arquivo_hash = run_id
+  -- colide com UNIQUE(account, arquivo_hash) em re-execução → ON CONFLICT reusa a linha (idempotente).
+  INSERT INTO tint_importacoes (account, tipo, arquivo_nome, arquivo_hash, status)
+  VALUES (v_account, 'sync_agent', 'sync:' || p_sync_run_id::text, p_sync_run_id::text, 'processando')
+  ON CONFLICT (account, arquivo_hash) DO UPDATE
+    SET status = 'processando', registros_importados = 0, registros_erro = 0
+  RETURNING id INTO v_importacao_id;
+
+  -- ──────────────────────────────────────────────────────────────────────────
+  -- LATEST-STAGING-POR-CHAVE: views temporárias com a linha mais recente por chave
+  -- natural (across TODOS os runs do mesmo account+store), restritas às chaves
+  -- tocadas POR ESTE run (§11 P1-C). DISTINCT ON (chave) ORDER BY created_at DESC, id DESC.
+  -- ──────────────────────────────────────────────────────────────────────────
+
+  -- Produtos tocados pelo run → latest (descrição mais recente; stub se ausente).
+  CREATE TEMP TABLE _tp_prod ON COMMIT DROP AS
+  WITH chaves AS (
+    SELECT DISTINCT cod_produto FROM tint_staging_produtos
+    WHERE sync_run_id = p_sync_run_id AND cod_produto IS NOT NULL
+  ),
+  latest AS (
+    SELECT DISTINCT ON (s.cod_produto) s.cod_produto, s.descricao
+    FROM tint_staging_produtos s
+    JOIN chaves c ON c.cod_produto = s.cod_produto
+    WHERE s.account = v_account AND s.store_code = v_store
+    ORDER BY s.cod_produto, s.created_at DESC, s.id DESC
+  )
+  SELECT cod_produto, descricao FROM latest;
+
+  CREATE TEMP TABLE _tp_base ON COMMIT DROP AS
+  WITH chaves AS (
+    SELECT DISTINCT id_base_sayersystem FROM tint_staging_bases
+    WHERE sync_run_id = p_sync_run_id AND id_base_sayersystem IS NOT NULL
+  ),
+  latest AS (
+    SELECT DISTINCT ON (s.id_base_sayersystem) s.id_base_sayersystem, s.descricao
+    FROM tint_staging_bases s
+    JOIN chaves c ON c.id_base_sayersystem = s.id_base_sayersystem
+    WHERE s.account = v_account AND s.store_code = v_store
+    ORDER BY s.id_base_sayersystem, s.created_at DESC, s.id DESC
+  )
+  SELECT id_base_sayersystem, descricao FROM latest;
+
+  CREATE TEMP TABLE _tp_emb ON COMMIT DROP AS
+  WITH chaves AS (
+    SELECT DISTINCT id_embalagem_sayersystem FROM tint_staging_embalagens
+    WHERE sync_run_id = p_sync_run_id AND id_embalagem_sayersystem IS NOT NULL
+  ),
+  latest AS (
+    SELECT DISTINCT ON (s.id_embalagem_sayersystem) s.id_embalagem_sayersystem, s.descricao, s.volume_ml
+    FROM tint_staging_embalagens s
+    JOIN chaves c ON c.id_embalagem_sayersystem = s.id_embalagem_sayersystem
+    WHERE s.account = v_account AND s.store_code = v_store
+    ORDER BY s.id_embalagem_sayersystem, s.created_at DESC, s.id DESC
+  )
+  SELECT id_embalagem_sayersystem, descricao, volume_ml FROM latest;
+
+  -- Corantes tocados → latest (descricao + preco_litro + custo/volume p/ preço).
+  CREATE TEMP TABLE _tp_cor ON COMMIT DROP AS
+  WITH chaves AS (
+    SELECT DISTINCT id_corante_sayersystem FROM tint_staging_corantes
+    WHERE sync_run_id = p_sync_run_id AND id_corante_sayersystem IS NOT NULL
+  ),
+  latest AS (
+    SELECT DISTINCT ON (s.id_corante_sayersystem)
+           s.id_corante_sayersystem, s.descricao, s.preco_litro, s.custo, s.volume_ml
+    FROM tint_staging_corantes s
+    JOIN chaves c ON c.id_corante_sayersystem = s.id_corante_sayersystem
+    WHERE s.account = v_account AND s.store_code = v_store
+    ORDER BY s.id_corante_sayersystem, s.created_at DESC, s.id DESC
+  )
+  SELECT id_corante_sayersystem, descricao, preco_litro, custo, volume_ml FROM latest;
+
+  -- Skus tocados → latest por (cod_produto,id_base,id_embalagem).
+  CREATE TEMP TABLE _tp_sku ON COMMIT DROP AS
+  WITH chaves AS (
+    SELECT DISTINCT cod_produto, id_base, id_embalagem FROM tint_staging_skus
+    WHERE sync_run_id = p_sync_run_id
+      AND cod_produto IS NOT NULL AND id_base IS NOT NULL AND id_embalagem IS NOT NULL
+  ),
+  latest AS (
+    SELECT DISTINCT ON (s.cod_produto, s.id_base, s.id_embalagem)
+           s.cod_produto, s.id_base, s.id_embalagem
+    FROM tint_staging_skus s
+    JOIN chaves c ON c.cod_produto = s.cod_produto AND c.id_base = s.id_base AND c.id_embalagem = s.id_embalagem
+    WHERE s.account = v_account AND s.store_code = v_store
+    ORDER BY s.cod_produto, s.id_base, s.id_embalagem, s.created_at DESC, s.id DESC
+  )
+  SELECT cod_produto, id_base, id_embalagem FROM latest;
+
+  -- 20260617 (fix CARGA): pares de skus REALMENTE NOVOS (ainda não existem no oficial). SÓ esses
+  -- precisam re-expandir (embalagem nova p/ o par). Capturado ANTES do upsert de skus (E1/loop) —
+  -- depois eles já existiriam. Sem isto, um run de catalogs com TODOS os skus re-expandiria TODAS as
+  -- fórmulas de uma vez → gateway timeout → advisory lock preso → lock timeout (incidente 17/06).
+  CREATE TEMP TABLE _skus_novos ON COMMIT DROP AS
+  SELECT DISTINCT t.cod_produto, t.id_base
+  FROM _tp_sku t
+  WHERE NOT EXISTS (
+    SELECT 1 FROM tint_skus sk
+    JOIN tint_produtos   p ON p.id = sk.produto_id  AND p.account = v_account AND p.cod_produto             = t.cod_produto
+    JOIN tint_bases      b ON b.id = sk.base_id      AND b.account = v_account AND b.id_base_sayersystem     = t.id_base
+    JOIN tint_embalagens e ON e.id = sk.embalagem_id AND e.account = v_account AND e.id_embalagem_sayersystem = t.id_embalagem
+  );
+
+  -- ──────────────────────────────────────────────────────────────────────────
+  -- E1) Catálogo: upsert oficial a partir do latest-staging (espelha onConflict do tint-import).
+  -- ──────────────────────────────────────────────────────────────────────────
+  INSERT INTO tint_produtos (account, cod_produto, descricao)
+  SELECT v_account, cod_produto, COALESCE(descricao, cod_produto) FROM _tp_prod
+  ON CONFLICT (account, cod_produto) DO UPDATE SET descricao = EXCLUDED.descricao;
+
+  INSERT INTO tint_bases (account, id_base_sayersystem, descricao)
+  SELECT v_account, id_base_sayersystem, COALESCE(descricao, id_base_sayersystem) FROM _tp_base
+  ON CONFLICT (account, id_base_sayersystem) DO UPDATE SET descricao = EXCLUDED.descricao;
+
+  -- volume_ml NULL/0 do staging NUNCA rebaixa o volume oficial existente (espelha o
+  -- COALESCE/NULLIF do corante): senão a expansão (guard volume_ml>0) dropa as fórmulas
+  -- da embalagem silenciosamente. INSERT de embalagem nova com volume NULL → stub 0 (não
+  -- vendável, não satisfaz o guard de expansão). descricao idem (NULL não apaga a oficial).
+  INSERT INTO tint_embalagens (account, id_embalagem_sayersystem, descricao, volume_ml)
+  SELECT v_account, id_embalagem_sayersystem, COALESCE(descricao, id_embalagem_sayersystem), COALESCE(volume_ml, 0) FROM _tp_emb
+  ON CONFLICT (account, id_embalagem_sayersystem) DO UPDATE
+    SET descricao = COALESCE(EXCLUDED.descricao, tint_embalagens.descricao),
+        volume_ml = COALESCE(NULLIF(EXCLUDED.volume_ml, 0), tint_embalagens.volume_ml);
+
+  -- Corantes: volume_total_ml é NOT NULL no oficial → preferir staging volume_ml, senão preservar
+  -- o existente, senão 1000 (default do CSV-import p/ stub). preco_litro derivado de custo/volume
+  -- (R$/L) quando os dois presentes; senão preserva o staging.preco_litro.
+  INSERT INTO tint_corantes (account, id_corante_sayersystem, descricao, volume_total_ml, preco_litro)
+  SELECT
+    v_account,
+    c.id_corante_sayersystem,
+    COALESCE(c.descricao, c.id_corante_sayersystem),
+    COALESCE(c.volume_ml, ex.volume_total_ml, 1000),
+    CASE
+      WHEN c.custo IS NOT NULL AND c.volume_ml IS NOT NULL AND c.volume_ml > 0
+        THEN round((c.custo / c.volume_ml * 1000)::numeric, 2)
+      ELSE c.preco_litro
+    END
+  FROM _tp_cor c
+  LEFT JOIN tint_corantes ex ON ex.account = v_account AND ex.id_corante_sayersystem = c.id_corante_sayersystem
+  ON CONFLICT (account, id_corante_sayersystem) DO UPDATE
+    SET descricao        = EXCLUDED.descricao,
+        volume_total_ml  = EXCLUDED.volume_total_ml,
+        preco_litro      = COALESCE(EXCLUDED.preco_litro, tint_corantes.preco_litro);
+
+  -- Skus de produto_base_embalagem: resolve FKs (cria stub de produto/base/embalagem se a
+  -- linha do sku referenciar id ainda não-visto no run — espelha ensure* do CSV).
+  FOR r IN SELECT cod_produto, id_base, id_embalagem FROM _tp_sku LOOP
+    INSERT INTO tint_produtos (account, cod_produto, descricao)
+    VALUES (v_account, r.cod_produto, r.cod_produto)
+    ON CONFLICT (account, cod_produto) DO NOTHING;
+    INSERT INTO tint_bases (account, id_base_sayersystem, descricao)
+    VALUES (v_account, r.id_base, r.id_base)
+    ON CONFLICT (account, id_base_sayersystem) DO NOTHING;
+    INSERT INTO tint_embalagens (account, id_embalagem_sayersystem, descricao, volume_ml)
+    VALUES (v_account, r.id_embalagem, r.id_embalagem, 0)
+    ON CONFLICT (account, id_embalagem_sayersystem) DO NOTHING;
+
+    SELECT id INTO v_produto_id FROM tint_produtos WHERE account = v_account AND cod_produto = r.cod_produto;
+    SELECT id INTO v_base_id    FROM tint_bases    WHERE account = v_account AND id_base_sayersystem = r.id_base;
+    SELECT id INTO v_emb_id     FROM tint_embalagens WHERE account = v_account AND id_embalagem_sayersystem = r.id_embalagem;
+
+    INSERT INTO tint_skus (account, produto_id, base_id, embalagem_id)
+    VALUES (v_account, v_produto_id, v_base_id, v_emb_id)
+    ON CONFLICT (account, produto_id, base_id, embalagem_id) DO NOTHING;
+  END LOOP;
+
+  -- ══════════════════════════════════════════════════════════════════════════
+  -- E2/E3) Fórmulas — SET-BASED (substitui o FOR LOOP aninhado procedural).
+  --   Mesma regra de negócio do loop, em massa. Pares afetados + latest-staging por chave de
+  --   fórmula são VERBATIM do loop; o que muda é a expansão/preço/upsert/itens (INSERT...SELECT).
+  -- ══════════════════════════════════════════════════════════════════════════
+
+  -- Pares (cod_produto, id_base) afetados = pares com fórmula tocada NESTE run ∪ pares de sku
+  -- NOVO (§11 P1-C: embalagem nova ⇒ re-expandir). 20260617 (fix CARGA): _skus_novos no lugar de
+  -- _tp_sku — sku re-enviado (já existente) NÃO dispara re-expansão; senão um run de catalogs com
+  -- todos os skus re-expandiria TODAS as fórmulas de uma vez (lock timeout, incidente 17/06).
+  CREATE TEMP TABLE _pares ON COMMIT DROP AS
+  SELECT DISTINCT cod_produto, id_base FROM (
+    SELECT cod_produto, id_base FROM tint_staging_formulas
+      WHERE sync_run_id = p_sync_run_id AND cod_produto IS NOT NULL AND id_base IS NOT NULL
+    UNION
+    SELECT cod_produto, id_base FROM _skus_novos
+  ) u;
+
+  -- Latest staging de fórmula por (cor_id, cod_produto, id_base, sub_norm, personalizada),
+  -- restrita aos pares afetados — across TODOS os runs.
+  CREATE TEMP TABLE _formulas_latest ON COMMIT DROP AS
+  WITH alvo AS (
+    SELECT s.*
+    FROM tint_staging_formulas s
+    JOIN _pares p ON p.cod_produto = s.cod_produto AND p.id_base = s.id_base
+    WHERE s.account = v_account AND s.store_code = v_store
+      AND s.cor_id IS NOT NULL AND s.cod_produto IS NOT NULL AND s.id_base IS NOT NULL
+  )
+  SELECT DISTINCT ON (cor_id, cod_produto, id_base, COALESCE(subcolecao, ''), personalizada)
+         id AS staging_formula_id, cor_id, nome_cor, cod_produto, id_base, id_embalagem,
+         subcolecao, volume_final_ml, personalizada
+  FROM alvo
+  ORDER BY cor_id, cod_produto, id_base, COALESCE(subcolecao, ''), personalizada,
+           created_at DESC, id DESC;
+
+  -- Resolve FK produto/base por JOIN (não SELECT por linha). LEFT JOIN p/ separar os não-resolvidos.
+  CREATE TEMP TABLE _fl_resolved ON COMMIT DROP AS
+  SELECT fl.*, p.id AS produto_id, b.id AS base_id
+  FROM _formulas_latest fl
+  LEFT JOIN tint_produtos p ON p.account = v_account AND p.cod_produto = fl.cod_produto
+  LEFT JOIN tint_bases    b ON b.account = v_account AND b.id_base_sayersystem = fl.id_base;
+
+  -- Guard 1 — produto/base não resolvido (catálogo incompleto). Espelha o 1º CONTINUE do loop.
+  INSERT INTO tint_sync_errors (sync_run_id, entity_type, entity_id, error_message, error_details)
+  SELECT p_sync_run_id, 'formula_promote', fl.cor_id,
+         'produto/base não resolvido (catálogo incompleto)',
+         jsonb_build_object('cod_produto', fl.cod_produto, 'id_base', fl.id_base)
+  FROM _fl_resolved fl
+  WHERE fl.produto_id IS NULL OR fl.base_id IS NULL;
+  GET DIAGNOSTICS v_tmp = ROW_COUNT; v_erros := v_erros + v_tmp;
+
+  -- Subcoleções: ensure p/ fórmulas com produto/base resolvido e subcoleção não-vazia (o loop
+  -- ensura DEPOIS do guard de produto/base, ANTES dos guards de volume/vendável). id = texto CRU.
+  INSERT INTO tint_subcolecoes (account, id_subcolecao_sayersystem, descricao)
+  SELECT DISTINCT v_account, fl.subcolecao, fl.subcolecao
+  FROM _fl_resolved fl
+  WHERE fl.produto_id IS NOT NULL AND fl.base_id IS NOT NULL
+    AND fl.subcolecao IS NOT NULL AND btrim(fl.subcolecao) <> ''
+  ON CONFLICT (account, id_subcolecao_sayersystem) DO NOTHING;
+
+  -- Guard 2 — volume de formulação <= 0/nulo (entre os resolvidos). Espelha o 2º CONTINUE.
+  INSERT INTO tint_sync_errors (sync_run_id, entity_type, entity_id, error_message, error_details)
+  SELECT p_sync_run_id, 'formula_promote', fl.cor_id,
+         'volume de formulação <= 0 ou nulo',
+         jsonb_build_object('volume_final_ml', fl.volume_final_ml)
+  FROM _fl_resolved fl
+  WHERE fl.produto_id IS NOT NULL AND fl.base_id IS NOT NULL
+    AND (fl.volume_final_ml IS NULL OR fl.volume_final_ml <= 0);
+  GET DIAGNOSTICS v_tmp = ROW_COUNT; v_erros := v_erros + v_tmp;
+
+  -- Guard 3 — zero embalagens vendáveis para o par (entre resolvidos com volume OK). 3º CONTINUE.
+  INSERT INTO tint_sync_errors (sync_run_id, entity_type, entity_id, error_message, error_details)
+  SELECT p_sync_run_id, 'formula_promote', fl.cor_id,
+         'zero embalagens vendáveis para o par (produto,base)',
+         jsonb_build_object('cod_produto', fl.cod_produto, 'id_base', fl.id_base)
+  FROM _fl_resolved fl
+  WHERE fl.produto_id IS NOT NULL AND fl.base_id IS NOT NULL
+    AND fl.volume_final_ml IS NOT NULL AND fl.volume_final_ml > 0
+    AND NOT EXISTS (
+      SELECT 1 FROM tint_skus sk
+      JOIN tint_embalagens e ON e.id = sk.embalagem_id
+      WHERE sk.account = v_account AND sk.produto_id = fl.produto_id AND sk.base_id = fl.base_id
+        AND e.volume_ml IS NOT NULL AND e.volume_ml > 0
+    );
+  GET DIAGNOSTICS v_tmp = ROW_COUNT; v_erros := v_erros + v_tmp;
+
+  -- Expansão (regra de 3): 1 linha por (fórmula que passou TODOS os guards × embalagem vendável).
+  -- fator = vol_destino / vol_formulacao (espelho expandirFormula). subcolecao_id resolvido por
+  -- LEFT JOIN (NULL quando vazio). eid = chave surrogate p/ casar o preço.
+  CREATE TEMP TABLE _expand ON COMMIT DROP AS
+  SELECT
+    row_number() OVER () AS eid,
+    fl.staging_formula_id, fl.cor_id, fl.nome_cor, fl.cod_produto, fl.id_base, fl.personalizada,
+    fl.subcolecao,  -- texto CRU (p/ o desempate espelhar a ordem do loop; ver _expand_uniq)
+    fl.produto_id, fl.base_id,
+    sub.id AS subcolecao_id,
+    sk.id  AS sku_id,
+    sk.embalagem_id AS emb_id,
+    e.id_embalagem_sayersystem AS id_emb,
+    e.volume_ml AS vol_destino,
+    (e.volume_ml / fl.volume_final_ml) AS fator
+  FROM _fl_resolved fl
+  JOIN tint_skus sk ON sk.account = v_account AND sk.produto_id = fl.produto_id AND sk.base_id = fl.base_id
+  JOIN tint_embalagens e ON e.id = sk.embalagem_id
+  LEFT JOIN tint_subcolecoes sub
+    ON sub.account = v_account
+   AND fl.subcolecao IS NOT NULL AND btrim(fl.subcolecao) <> ''
+   AND sub.id_subcolecao_sayersystem = fl.subcolecao
+  WHERE fl.produto_id IS NOT NULL AND fl.base_id IS NOT NULL
+    AND fl.volume_final_ml IS NOT NULL AND fl.volume_final_ml > 0
+    AND e.volume_ml IS NOT NULL AND e.volume_ml > 0;
+
+  -- v_promovidas = nº de expansões (= incrementos do loop interno, inclui colisão personalizada).
+  SELECT count(*) INTO v_promovidas FROM _expand;
+
+  -- Preço pág 9 por expansão — SET-BASED, NULL-honesto (espelho precoFinalSayer + S2 store + S3
+  -- latest não-nulo). base ausente OU qualquer corante sem custo/volume(>0)/finito → preço NULL.
+  CREATE TEMP TABLE _preco ON COMMIT DROP AS
+  WITH base_latest AS (   -- S2: store_code; S3: custo IS NOT NULL. Latest por chave de base.
+    SELECT DISTINCT ON (cod_produto, id_base, id_embalagem)
+           cod_produto, id_base, id_embalagem, custo, imposto_pct, margem_pct
+    FROM tint_staging_precos_base
+    WHERE account = v_account AND store_code = v_store AND custo IS NOT NULL
+    ORDER BY cod_produto, id_base, id_embalagem, created_at DESC, id DESC
+  ),
+  cor_latest AS (         -- S2: store_code; S3: custo+volume NÃO-NULOS. Latest por corante.
+    SELECT DISTINCT ON (id_corante_sayersystem)
+           id_corante_sayersystem, custo, volume_ml
+    FROM tint_staging_corantes
+    WHERE account = v_account AND store_code = v_store
+      AND custo IS NOT NULL AND volume_ml IS NOT NULL
+    ORDER BY id_corante_sayersystem, created_at DESC, id DESC
+  ),
+  itens AS (              -- Σ corantes por expansão; flag de corante faltante (NULL-honesto).
+    SELECT ex.eid,
+           bool_or(
+             cl.id_corante_sayersystem IS NULL
+             OR cl.volume_ml IS NULL OR cl.volume_ml <= 0
+             OR NOT (cl.custo > '-Infinity'::numeric AND cl.custo < 'Infinity'::numeric)
+           ) AS faltante,
+           sum(CASE WHEN cl.volume_ml > 0 THEN (cl.custo / cl.volume_ml) * (si.qtd_ml * ex.fator) ELSE 0 END) AS soma
+    FROM _expand ex
+    JOIN tint_staging_formula_itens si ON si.staging_formula_id = ex.staging_formula_id
+    LEFT JOIN cor_latest cl ON cl.id_corante_sayersystem = si.id_corante
+    WHERE si.id_corante IS NOT NULL AND si.id_corante <> '' AND COALESCE(si.qtd_ml, 0) > 0
+    GROUP BY ex.eid
+  )
+  SELECT
+    ex.eid,
+    CASE
+      WHEN bl.custo IS NULL THEN NULL                                                   -- base ausente
+      WHEN NOT (bl.custo > '-Infinity'::numeric AND bl.custo < 'Infinity'::numeric) THEN NULL  -- custo não-finito
+      WHEN COALESCE(it.faltante, false) THEN NULL                                       -- corante sem preço
+      ELSE round(
+        ( bl.custo * (1 + COALESCE(bl.imposto_pct, 0) / 100) * (1 + COALESCE(bl.margem_pct, 0) / 100) )
+        + COALESCE(it.soma, 0)
+      , 2)
+    END AS preco
+  FROM _expand ex
+  LEFT JOIN base_latest bl
+    ON bl.cod_produto = ex.cod_produto AND bl.id_base = ex.id_base AND bl.id_embalagem = ex.id_emb
+  LEFT JOIN itens it ON it.eid = ex.eid;
+
+  -- Dedup pela CHAVE OFICIAL (uq_tint_formulas_chave — SEM personalizada): INSERT...SELECT não pode
+  -- ter a mesma chave 2× no mesmo comando (cardinality violation). O loop processa _formulas_latest
+  -- em ORDER BY ... COALESCE(subcolecao,'') ASC, personalizada ASC e o ÚLTIMO vence o upsert. A chave
+  -- oficial COLAPSA subcoleções que resolvem ao MESMO subcolecao_id (NULL e whitespace-only viram
+  -- NULL → btrim vazio), então a colisão pode ser entre linhas com COALESCE(subcolecao,'') DIFERENTE
+  -- (não só personalizada). Para escolher o MESMO vencedor do loop, desempata por COALESCE(subcolecao,
+  -- '') DESC PRIMEIRO, depois personalizada DESC (= o último que o loop processaria), eid DESC final.
+  CREATE TEMP TABLE _expand_uniq ON COMMIT DROP AS
+  SELECT DISTINCT ON (ex.cor_id, ex.produto_id, ex.base_id, COALESCE(ex.subcolecao_id, v_zero_uuid), ex.emb_id)
+         ex.staging_formula_id, ex.cor_id, ex.nome_cor, ex.personalizada,
+         ex.produto_id, ex.base_id, ex.subcolecao_id, ex.sku_id, ex.emb_id, ex.vol_destino, ex.fator,
+         pr.preco
+  FROM _expand ex
+  JOIN _preco pr ON pr.eid = ex.eid
+  ORDER BY ex.cor_id, ex.produto_id, ex.base_id, COALESCE(ex.subcolecao_id, v_zero_uuid), ex.emb_id,
+           COALESCE(ex.subcolecao, '') DESC, ex.personalizada DESC, ex.eid DESC;
+
+  -- Corante stubs em massa ANTES dos itens (espelha tint_ensure_corante_stub: volume 1000).
+  -- A partir de _expand (todas as expansões, inclui colisão) p/ casar o side-effect do loop.
+  INSERT INTO tint_corantes (account, id_corante_sayersystem, descricao, volume_total_ml)
+  SELECT DISTINCT v_account, si.id_corante, si.id_corante, 1000
+  FROM tint_staging_formula_itens si
+  WHERE si.staging_formula_id IN (SELECT DISTINCT staging_formula_id FROM _expand)
+    AND si.id_corante IS NOT NULL AND si.id_corante <> '' AND COALESCE(si.qtd_ml, 0) > 0
+  ON CONFLICT (account, id_corante_sayersystem) DO NOTHING;
+
+  -- Upsert oficial em massa por uq_tint_formulas_chave; desativada_em = NULL (reativa). Captura
+  -- formula_id ↔ (staging_formula_id, fator) p/ os itens (RETURNING casado de volta ao _expand_uniq).
+  CREATE TEMP TABLE _promoted ON COMMIT DROP AS
+  WITH ups AS (
+    INSERT INTO tint_formulas (
+      account, cor_id, nome_cor, produto_id, base_id, embalagem_id, subcolecao_id, sku_id,
+      volume_final_ml, preco_final_sayersystem, personalizada, importacao_id, updated_at, desativada_em
+    )
+    SELECT
+      v_account, eu.cor_id, eu.nome_cor, eu.produto_id, eu.base_id, eu.emb_id, eu.subcolecao_id, eu.sku_id,
+      eu.vol_destino, eu.preco, eu.personalizada, v_importacao_id, now(), NULL
+    FROM _expand_uniq eu
+    ON CONFLICT (account, cor_id, produto_id, base_id, COALESCE(subcolecao_id, '00000000-0000-0000-0000-000000000000'::uuid), embalagem_id)
+    DO UPDATE SET
+      nome_cor                = EXCLUDED.nome_cor,
+      sku_id                  = EXCLUDED.sku_id,
+      volume_final_ml         = EXCLUDED.volume_final_ml,
+      -- 20260617: PRESERVA o preço existente quando o novo é NULL (precos_base vazio → eu.preco NULL).
+      -- Sem isto o flip zeraria o piso de ~19k cores (calc<CSV). Espelha o COALESCE de preco_litro acima.
+      preco_final_sayersystem = COALESCE(EXCLUDED.preco_final_sayersystem, tint_formulas.preco_final_sayersystem),
+      personalizada           = EXCLUDED.personalizada,
+      importacao_id           = EXCLUDED.importacao_id,
+      updated_at              = now(),
+      desativada_em           = NULL
+    RETURNING id, cor_id, produto_id, base_id, subcolecao_id, embalagem_id
+  )
+  SELECT u.id AS formula_id, eu.staging_formula_id, eu.fator
+  FROM ups u
+  JOIN _expand_uniq eu
+    ON eu.cor_id = u.cor_id AND eu.produto_id = u.produto_id AND eu.base_id = u.base_id
+   AND COALESCE(eu.subcolecao_id, v_zero_uuid) = COALESCE(u.subcolecao_id, v_zero_uuid)
+   AND eu.emb_id = u.embalagem_id;
+
+  -- Itens em massa: limpa + reinsere (espelha o delete+insert por fórmula do loop). qtd expandida
+  -- = qtd_formulacao × fator, arredondada a 6 casas (sub-µL — elimina artefato de escala da divisão
+  -- numeric sem mudar o valor prático). Corante já garantido (stub acima) → JOIN resolve o id.
+  DELETE FROM tint_formula_itens fi USING _promoted pr WHERE fi.formula_id = pr.formula_id;
+
+  INSERT INTO tint_formula_itens (formula_id, corante_id, ordem, qtd_ml)
+  SELECT pr.formula_id, co.id, si.ordem, round((si.qtd_ml * pr.fator)::numeric, 6)
+  FROM _promoted pr
+  JOIN tint_staging_formula_itens si ON si.staging_formula_id = pr.staging_formula_id
+  JOIN tint_corantes co ON co.account = v_account AND co.id_corante_sayersystem = si.id_corante
+  WHERE si.id_corante IS NOT NULL AND si.id_corante <> '' AND COALESCE(si.qtd_ml, 0) > 0;
+
+  -- ──────────────────────────────────────────────────────────────────────────
+  -- E4) Recálculo de preço por mudança de INSUMO (§11 P1-A — caso de uso PRINCIPAL).
+  --   Run tocou precos_base/corantes → recalcula preco_final_sayersystem das fórmulas
+  --   oficiais ATIVAS afetadas, SEM re-expandir itens. NÃO mexe nas fórmulas que E2 já
+  --   tocou (importacao_id = v_importacao_id) — essas já saíram com o preço novo.
+  -- ──────────────────────────────────────────────────────────────────────────
+  -- Pares (produto,base,embalagem oficial) afetados por precos_base deste run.
+  FOR r IN
+    SELECT DISTINCT f.id AS formula_id, f.cor_id, p.cod_produto, b.id_base_sayersystem AS id_base, e.id_embalagem_sayersystem AS id_emb
+    FROM tint_staging_precos_base sp
+    JOIN tint_produtos   p ON p.account = v_account AND p.cod_produto = sp.cod_produto
+    JOIN tint_bases      b ON b.account = v_account AND b.id_base_sayersystem = sp.id_base
+    JOIN tint_embalagens e ON e.account = v_account AND e.id_embalagem_sayersystem = sp.id_embalagem
+    JOIN tint_formulas   f ON f.account = v_account AND f.produto_id = p.id AND f.base_id = b.id AND f.embalagem_id = e.id
+    WHERE sp.sync_run_id = p_sync_run_id
+      AND f.desativada_em IS NULL
+      AND (f.importacao_id IS DISTINCT FROM v_importacao_id)
+  LOOP
+    -- S2: +v_store.
+    v_preco := tint_recalc_preco_oficial(v_account, v_store, r.formula_id, r.cod_produto, r.id_base, r.id_emb);
+    -- 20260617: só baixa/sobe se o recálculo deu valor; NULL (sem precos_base) PRESERVA o piso atual.
+    UPDATE tint_formulas SET preco_final_sayersystem = COALESCE(v_preco, preco_final_sayersystem), updated_at = now() WHERE id = r.formula_id;
+    v_recalc := v_recalc + 1;
+  END LOOP;
+
+  -- Fórmulas que usam um corante cujo custo/volume mudou neste run.
+  FOR r IN
+    SELECT DISTINCT f.id AS formula_id, f.cor_id, pr.cod_produto, ba.id_base_sayersystem AS id_base, em.id_embalagem_sayersystem AS id_emb
+    FROM tint_staging_corantes sc
+    JOIN tint_corantes      co ON co.account = v_account AND co.id_corante_sayersystem = sc.id_corante_sayersystem
+    JOIN tint_formula_itens fi ON fi.corante_id = co.id
+    JOIN tint_formulas      f  ON f.id = fi.formula_id
+    JOIN tint_produtos      pr ON pr.id = f.produto_id
+    JOIN tint_bases         ba ON ba.id = f.base_id
+    JOIN tint_embalagens    em ON em.id = f.embalagem_id
+    WHERE sc.sync_run_id = p_sync_run_id
+      AND (sc.custo IS NOT NULL OR sc.volume_ml IS NOT NULL)
+      AND f.account = v_account
+      AND f.desativada_em IS NULL
+      AND (f.importacao_id IS DISTINCT FROM v_importacao_id)
+  LOOP
+    -- S2: +v_store.
+    v_preco := tint_recalc_preco_oficial(v_account, v_store, r.formula_id, r.cod_produto, r.id_base, r.id_emb);
+    -- 20260617: só baixa/sobe se o recálculo deu valor; NULL (sem precos_base) PRESERVA o piso atual.
+    UPDATE tint_formulas SET preco_final_sayersystem = COALESCE(v_preco, preco_final_sayersystem), updated_at = now() WHERE id = r.formula_id;
+    v_recalc := v_recalc + 1;
+  END LOOP;
+
+  -- ──────────────────────────────────────────────────────────────────────────
+  -- E5) Contadores + purge staging SUPERSEDED >30d (preserva latest-per-key) +
+  --     runs órfãos >30min → error.
+  -- ──────────────────────────────────────────────────────────────────────────
+  UPDATE tint_importacoes
+    SET status = 'concluido', registros_importados = v_promovidas, registros_erro = v_erros
+  WHERE id = v_importacao_id;
+
+  UPDATE tint_sync_runs
+    SET inserts = v_promovidas, errors = v_erros, metadata = COALESCE(metadata, '{}'::jsonb) || jsonb_build_object('recalculadas', v_recalc)
+  WHERE id = p_sync_run_id;
+
+  -- PURGE: NUNCA apaga a linha MAIS RECENTE por chave natural (account+store) — a promoção
+  -- lê latest-staging-por-chave PRA SEMPRE (recalc por insumo + re-expansão por sku novo
+  -- dependem dela mesmo que o insumo não mude por >30d → nunca é re-enviado). Só remove
+  -- linhas SUPERSEDED (>30d E com uma linha mais nova da MESMA chave). §11 P2-1.
+  -- Ordem de chave: (created_at, id) — idêntica ao DISTINCT ON da promoção.
+  DELETE FROM tint_staging_produtos s
+  WHERE s.created_at < now() - interval '30 days'
+    AND EXISTS (SELECT 1 FROM tint_staging_produtos n
+      WHERE n.account = s.account AND n.store_code = s.store_code
+        AND n.cod_produto = s.cod_produto
+        AND (n.created_at, n.id) > (s.created_at, s.id));
+
+  DELETE FROM tint_staging_bases s
+  WHERE s.created_at < now() - interval '30 days'
+    AND EXISTS (SELECT 1 FROM tint_staging_bases n
+      WHERE n.account = s.account AND n.store_code = s.store_code
+        AND n.id_base_sayersystem = s.id_base_sayersystem
+        AND (n.created_at, n.id) > (s.created_at, s.id));
+
+  DELETE FROM tint_staging_embalagens s
+  WHERE s.created_at < now() - interval '30 days'
+    AND EXISTS (SELECT 1 FROM tint_staging_embalagens n
+      WHERE n.account = s.account AND n.store_code = s.store_code
+        AND n.id_embalagem_sayersystem = s.id_embalagem_sayersystem
+        AND (n.created_at, n.id) > (s.created_at, s.id));
+
+  DELETE FROM tint_staging_corantes s
+  WHERE s.created_at < now() - interval '30 days'
+    AND EXISTS (SELECT 1 FROM tint_staging_corantes n
+      WHERE n.account = s.account AND n.store_code = s.store_code
+        AND n.id_corante_sayersystem = s.id_corante_sayersystem
+        AND (n.created_at, n.id) > (s.created_at, s.id));
+
+  DELETE FROM tint_staging_skus s
+  WHERE s.created_at < now() - interval '30 days'
+    AND EXISTS (SELECT 1 FROM tint_staging_skus n
+      WHERE n.account = s.account AND n.store_code = s.store_code
+        AND n.cod_produto = s.cod_produto AND n.id_base = s.id_base AND n.id_embalagem = s.id_embalagem
+        AND (n.created_at, n.id) > (s.created_at, s.id));
+
+  -- Fórmulas: chave = (cod_produto,id_base,cor_id,COALESCE(subcolecao,''),personalizada),
+  -- idêntica ao DISTINCT ON de _formulas_latest. Itens cascateiam pela formula-pai apagada.
+  DELETE FROM tint_staging_formula_itens si
+  WHERE si.staging_formula_id IN (
+    SELECT s.id FROM tint_staging_formulas s
+    WHERE s.created_at < now() - interval '30 days'
+      AND EXISTS (SELECT 1 FROM tint_staging_formulas n
+        WHERE n.account = s.account AND n.store_code = s.store_code
+          AND n.cor_id = s.cor_id AND n.cod_produto = s.cod_produto AND n.id_base = s.id_base
+          AND COALESCE(n.subcolecao, '') = COALESCE(s.subcolecao, '')
+          AND n.personalizada = s.personalizada
+          AND (n.created_at, n.id) > (s.created_at, s.id)));
+
+  DELETE FROM tint_staging_formulas s
+  WHERE s.created_at < now() - interval '30 days'
+    AND EXISTS (SELECT 1 FROM tint_staging_formulas n
+      WHERE n.account = s.account AND n.store_code = s.store_code
+        AND n.cor_id = s.cor_id AND n.cod_produto = s.cod_produto AND n.id_base = s.id_base
+        AND COALESCE(n.subcolecao, '') = COALESCE(s.subcolecao, '')
+        AND n.personalizada = s.personalizada
+        AND (n.created_at, n.id) > (s.created_at, s.id));
+
+  DELETE FROM tint_staging_precos_base s
+  WHERE s.created_at < now() - interval '30 days'
+    AND EXISTS (SELECT 1 FROM tint_staging_precos_base n
+      WHERE n.account = s.account AND n.store_code = s.store_code
+        AND n.cod_produto = s.cod_produto AND n.id_base = s.id_base AND n.id_embalagem = s.id_embalagem
+        AND (n.created_at, n.id) > (s.created_at, s.id));
+
+  -- keys-snapshot: point-in-time (não latest-per-key) → purge por tempo é correto.
+  DELETE FROM tint_keys_snapshots          WHERE created_at < now() - interval '30 days';
+
+  UPDATE tint_sync_runs
+    SET status = 'error', completed_at = COALESCE(completed_at, now())
+  WHERE status = 'running' AND started_at < now() - interval '30 minutes';
+
+  RETURN jsonb_build_object(
+    'ok', true, 'promovidas', v_promovidas, 'recalculadas', v_recalc,
+    'erros', v_erros, 'importacao_id', v_importacao_id);
+END $$;
+REVOKE EXECUTE ON FUNCTION public.tint_promote_sync_run(uuid) FROM anon, authenticated, PUBLIC;
+
+SELECT 'tint_promote_sync_run SET-BASED OK' AS status;

--- a/supabase/migrations/20260618130000_tint_promote_e4_so_com_custo.sql
+++ b/supabase/migrations/20260618130000_tint_promote_e4_so_com_custo.sql
@@ -1,0 +1,660 @@
+-- 20260618130000_tint_promote_e4_so_com_custo.sql
+-- MUDANÇA money-path (CARGA, parte 2): o E4 (recálculo de preço por corante) só dispara quando há
+-- CUSTO no staging_corantes. Incidente 18/06 (no 2º re-flip): o re-envio promoveu 94% das fórmulas
+-- (E2/E3 + COALESCE OK em prod), mas o run de CORANTES travou — a condição antiga
+-- (custo IS NOT NULL OR volume_ml IS NOT NULL) disparava por volume_ml (sempre presente) e recalculava
+-- ~481k fórmulas por corante, uma a uma, num único run → gateway timeout → advisory lock preso →
+-- cascata 55P03. O SayerSystem NÃO manda custo (§14, preço vem do Omie) → sem custo o recálculo dá
+-- NULL e o COALESCE preserva o piso: era carga 100% inútil. Fix: condição vira só `custo IS NOT NULL`.
+-- INCLUI tudo da 20260617150000 (re-expansão só skus novos) + da 130000 (COALESCE preço). CREATE OR
+-- REPLACE — a última a recriar vence. Provado em PG17 + Codex.
+--
+-- [HERDADO da 20260617150000_tint_promote_reexpand_skus_novos.sql:]
+-- MUDANÇA money-path (CARGA): a re-expansão de fórmulas (E2/E3) dispara SÓ para pares de skus
+-- REALMENTE NOVOS (embalagem nova p/ o par), não para TODO sku tocado no run. Incidente 17/06: o
+-- flip→automatic_primary + re-envio em massa fez o run de catalogs (todos os 220 skus) re-expandir
+-- TODAS as ~121k fórmulas de uma vez → gateway timeout → conexão idle-in-transaction segurando o
+-- advisory lock → cascata de lock timeout (55P03) → a promoção NUNCA completou. Fix: _skus_novos
+-- (pares de _tp_sku que ainda NÃO existem em tint_skus) entra no _pares no lugar de _tp_sku. Re-envio:
+-- catalogs re-expande 0 (skus já existem); formulas distribuem a carga por lote. Embalagem NOVA →
+-- re-expande só aquele par (§11 P1-C preservado). INCLUI o COALESCE de preço da 20260617130000
+-- (CREATE OR REPLACE — a última a recriar vence). Provado em PG17 + Codex.
+--
+-- [HERDADO da 20260617130000_tint_promote_preserva_preco.sql:]
+-- MUDANÇA money-path (PREÇO): a promoção PRESERVA preco_final_sayersystem quando o recálculo dá
+-- NULL — COALESCE(novo, atual) em E2 (upsert) e E4 (recálculo por insumo). Motivo: a fonte de
+-- preço da base (tint_staging_precos_base) NUNCA é populada (precos_base não existe no SayerSystem;
+-- o preço do balcão vem do Omie via get_tint_price). Sem este COALESCE, o flip→automatic_primary
+-- gravaria preco_final_sayersystem=NULL em TODA fórmula promovida, derrubando o PISO que
+-- select-price.ts usa (regra 3: mantém o MAIOR entre calc e CSV) → subfaturaria ~19k cores onde
+-- calc<CSV. Com o COALESCE, a promoção atualiza o CATÁLOGO (cores/fórmulas/itens) SEM tocar no
+-- preço existente; cor NOVA fica com preço NULL (degradação honesta — sem piso histórico, o balcão
+-- usa o calc do Omie). Espelha o padrão COALESCE já usado p/ corantes (preco_litro) nesta função.
+-- Provado em PG17: db/test-tint-promote-preserva-preco.sh (preservação · cor-nova-NULL · recálculo
+-- legítimo com precos_base · falsificação). Codex challenge (sem P1): NULL NÃO vira R$0/venda
+-- indevida (gate de select-price.ts + useTintColorSelect) e o RHS do ON CONFLICT lê a linha
+-- pré-update. 3 [P2] da classe "piso stale" (o COALESCE mantém o CSV quando o recálculo dá NULL
+-- → o balcão, regra 3 MAIOR, pode vender CARO demais se o preço devia baixar) = a decisão §14(3)
+-- (manter o CSV, NÃO baixar por engano), não regressão. Follow-up conhecido: reativação
+-- (desativada_em=NULL) de cor que volta com receita diferente preserva o preço antigo como piso.
+-- O RESTO é VERBATIM da 20260615160000 (a última a recriar vence; §database.md).
+--
+-- [HERDADO de 20260615160000_tint_promote_set_based.sql:]
+-- Reescreve o MOTOR de fórmulas (E2/E3) da tint_promote_sync_run de PROCEDURAL (FOR LOOP
+-- aninhado: O(fórmulas × embalagens), com tint_calc_preco_final por linha) para SET-BASED
+-- (INSERT...SELECT em massa). Mesma regra de negócio, executada em lote.
+--
+-- Motivo (flip 15/06): o loop processava ~481k expansões 1-a-1 chamando tint_calc_preco_final
+-- (subqueries por chamada) — inviável dentro do request do gateway na carga inicial (statement
+-- timeout 57014 → depois lock timeout + upstream timeout em cascata). Os índices de
+-- 20260615140000 ajudaram mas não bastaram: o gargalo é a NATUREZA procedural. Set-based, a
+-- mesma carga roda em segundos (1 INSERT...SELECT com joins, não 481k iterações).
+--
+-- IDENTIDADE (money-path, precisão > recall): o conjunto de fórmulas/itens/preços promovido é
+-- IDÊNTICO ao do loop. Espelho dos oráculos src/lib/tint/sync-promote.ts (expandirFormula /
+-- precoFinalSayer) — mesma regra de 3 (fator = vol_destino / vol_formulacao), mesmo preço pág 9
+-- (base×(1+imp/100)×(1+marg/100) + Σ corante×qtd/vol), MESMO NULL-honesto (base ausente OU
+-- qualquer corante sem custo/volume → preço NULL, NUNCA 0). Provado em PG17:
+-- db/test-tint-promote.sh — os 12 cenários C1-C12 (valores do oráculo, inalterados) + um cenário
+-- de VOLUME que roda o loop ANTIGO (preservado via RENAME no teste) e o set-based sobre o MESMO
+-- seed e exige EXCEPT vazio nos dois sentidos (identidade contábil) + falsificação.
+--
+-- O QUE NÃO MUDA (copiado VERBATIM da 20260611190000 — a última a recriar vence; §database.md):
+--   S1 advisory lock · upsert de importação · latest-staging-por-chave (_tp_*) · E1 catálogo +
+--   loop de skus · E4 recálculo por insumo (tint_recalc_preco_oficial) · E5 contadores/purge.
+--   Os helpers (tint_calc_preco_final / tint_recalc_preco_oficial / tint_ensure_corante_stub /
+--   tint_apply_keys_snapshot) ficam como estão (20260609150000/20260611190000) — esta migration
+--   só faz CREATE OR REPLACE da tint_promote_sync_run. tint_calc_preco_final deixa de ser chamada
+--   pela promoção (o preço virou CTE em massa), mas continua definida (sem DROP).
+--
+-- SET statement_timeout='300s' fica NO CABEÇALHO da função: CREATE OR REPLACE substitui as
+-- cláusulas SET, então sem isto o ALTER de 20260615140000 seria perdido. Carga inicial é pesada
+-- por natureza; deltas diários são leves. Migration manual via SQL Editor (§deploy.md).
+
+CREATE OR REPLACE FUNCTION public.tint_promote_sync_run(p_sync_run_id uuid)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public
+SET statement_timeout = '300s'
+AS $$
+DECLARE
+  v_run            record;
+  v_account        text;
+  v_store          text;
+  v_importacao_id  uuid;
+  v_promovidas     int := 0;
+  v_erros          int := 0;
+  v_recalc         int := 0;
+  v_tmp            int := 0;
+  v_zero_uuid      constant uuid := '00000000-0000-0000-0000-000000000000';
+  r                record;
+  v_produto_id     uuid;
+  v_base_id        uuid;
+  v_subcolecao_id  uuid;
+  v_sku_id         uuid;
+  v_emb_id         uuid;
+  v_formula_id     uuid;
+  v_fator          numeric;
+  v_preco          numeric;
+  v_qtd_vendaveis  int;
+BEGIN
+  SELECT * INTO v_run FROM tint_sync_runs WHERE id = p_sync_run_id;
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('ok', false, 'error', 'run não encontrado');
+  END IF;
+  v_account := v_run.account;
+  v_store   := v_run.store_code;
+
+  -- S1 (codex P1-7): serializa promoções concorrentes do mesmo (account+store). Sem isto, dois
+  -- runs simultâneos do mesmo par leem o latest-staging e escrevem o oficial interleavados (o mais
+  -- VELHO podia vencer). Lock de transação → libera automaticamente no commit/rollback.
+  PERFORM pg_advisory_xact_lock(hashtext('tint_sync:' || v_account || ':' || v_store));
+
+  -- Cria/reusa o registro de importação (reusa a tela de histórico). arquivo_hash = run_id
+  -- colide com UNIQUE(account, arquivo_hash) em re-execução → ON CONFLICT reusa a linha (idempotente).
+  INSERT INTO tint_importacoes (account, tipo, arquivo_nome, arquivo_hash, status)
+  VALUES (v_account, 'sync_agent', 'sync:' || p_sync_run_id::text, p_sync_run_id::text, 'processando')
+  ON CONFLICT (account, arquivo_hash) DO UPDATE
+    SET status = 'processando', registros_importados = 0, registros_erro = 0
+  RETURNING id INTO v_importacao_id;
+
+  -- ──────────────────────────────────────────────────────────────────────────
+  -- LATEST-STAGING-POR-CHAVE: views temporárias com a linha mais recente por chave
+  -- natural (across TODOS os runs do mesmo account+store), restritas às chaves
+  -- tocadas POR ESTE run (§11 P1-C). DISTINCT ON (chave) ORDER BY created_at DESC, id DESC.
+  -- ──────────────────────────────────────────────────────────────────────────
+
+  -- Produtos tocados pelo run → latest (descrição mais recente; stub se ausente).
+  CREATE TEMP TABLE _tp_prod ON COMMIT DROP AS
+  WITH chaves AS (
+    SELECT DISTINCT cod_produto FROM tint_staging_produtos
+    WHERE sync_run_id = p_sync_run_id AND cod_produto IS NOT NULL
+  ),
+  latest AS (
+    SELECT DISTINCT ON (s.cod_produto) s.cod_produto, s.descricao
+    FROM tint_staging_produtos s
+    JOIN chaves c ON c.cod_produto = s.cod_produto
+    WHERE s.account = v_account AND s.store_code = v_store
+    ORDER BY s.cod_produto, s.created_at DESC, s.id DESC
+  )
+  SELECT cod_produto, descricao FROM latest;
+
+  CREATE TEMP TABLE _tp_base ON COMMIT DROP AS
+  WITH chaves AS (
+    SELECT DISTINCT id_base_sayersystem FROM tint_staging_bases
+    WHERE sync_run_id = p_sync_run_id AND id_base_sayersystem IS NOT NULL
+  ),
+  latest AS (
+    SELECT DISTINCT ON (s.id_base_sayersystem) s.id_base_sayersystem, s.descricao
+    FROM tint_staging_bases s
+    JOIN chaves c ON c.id_base_sayersystem = s.id_base_sayersystem
+    WHERE s.account = v_account AND s.store_code = v_store
+    ORDER BY s.id_base_sayersystem, s.created_at DESC, s.id DESC
+  )
+  SELECT id_base_sayersystem, descricao FROM latest;
+
+  CREATE TEMP TABLE _tp_emb ON COMMIT DROP AS
+  WITH chaves AS (
+    SELECT DISTINCT id_embalagem_sayersystem FROM tint_staging_embalagens
+    WHERE sync_run_id = p_sync_run_id AND id_embalagem_sayersystem IS NOT NULL
+  ),
+  latest AS (
+    SELECT DISTINCT ON (s.id_embalagem_sayersystem) s.id_embalagem_sayersystem, s.descricao, s.volume_ml
+    FROM tint_staging_embalagens s
+    JOIN chaves c ON c.id_embalagem_sayersystem = s.id_embalagem_sayersystem
+    WHERE s.account = v_account AND s.store_code = v_store
+    ORDER BY s.id_embalagem_sayersystem, s.created_at DESC, s.id DESC
+  )
+  SELECT id_embalagem_sayersystem, descricao, volume_ml FROM latest;
+
+  -- Corantes tocados → latest (descricao + preco_litro + custo/volume p/ preço).
+  CREATE TEMP TABLE _tp_cor ON COMMIT DROP AS
+  WITH chaves AS (
+    SELECT DISTINCT id_corante_sayersystem FROM tint_staging_corantes
+    WHERE sync_run_id = p_sync_run_id AND id_corante_sayersystem IS NOT NULL
+  ),
+  latest AS (
+    SELECT DISTINCT ON (s.id_corante_sayersystem)
+           s.id_corante_sayersystem, s.descricao, s.preco_litro, s.custo, s.volume_ml
+    FROM tint_staging_corantes s
+    JOIN chaves c ON c.id_corante_sayersystem = s.id_corante_sayersystem
+    WHERE s.account = v_account AND s.store_code = v_store
+    ORDER BY s.id_corante_sayersystem, s.created_at DESC, s.id DESC
+  )
+  SELECT id_corante_sayersystem, descricao, preco_litro, custo, volume_ml FROM latest;
+
+  -- Skus tocados → latest por (cod_produto,id_base,id_embalagem).
+  CREATE TEMP TABLE _tp_sku ON COMMIT DROP AS
+  WITH chaves AS (
+    SELECT DISTINCT cod_produto, id_base, id_embalagem FROM tint_staging_skus
+    WHERE sync_run_id = p_sync_run_id
+      AND cod_produto IS NOT NULL AND id_base IS NOT NULL AND id_embalagem IS NOT NULL
+  ),
+  latest AS (
+    SELECT DISTINCT ON (s.cod_produto, s.id_base, s.id_embalagem)
+           s.cod_produto, s.id_base, s.id_embalagem
+    FROM tint_staging_skus s
+    JOIN chaves c ON c.cod_produto = s.cod_produto AND c.id_base = s.id_base AND c.id_embalagem = s.id_embalagem
+    WHERE s.account = v_account AND s.store_code = v_store
+    ORDER BY s.cod_produto, s.id_base, s.id_embalagem, s.created_at DESC, s.id DESC
+  )
+  SELECT cod_produto, id_base, id_embalagem FROM latest;
+
+  -- 20260617 (fix CARGA): pares de skus REALMENTE NOVOS (ainda não existem no oficial). SÓ esses
+  -- precisam re-expandir (embalagem nova p/ o par). Capturado ANTES do upsert de skus (E1/loop) —
+  -- depois eles já existiriam. Sem isto, um run de catalogs com TODOS os skus re-expandiria TODAS as
+  -- fórmulas de uma vez → gateway timeout → advisory lock preso → lock timeout (incidente 17/06).
+  CREATE TEMP TABLE _skus_novos ON COMMIT DROP AS
+  SELECT DISTINCT t.cod_produto, t.id_base
+  FROM _tp_sku t
+  WHERE NOT EXISTS (
+    SELECT 1 FROM tint_skus sk
+    JOIN tint_produtos   p ON p.id = sk.produto_id  AND p.account = v_account AND p.cod_produto             = t.cod_produto
+    JOIN tint_bases      b ON b.id = sk.base_id      AND b.account = v_account AND b.id_base_sayersystem     = t.id_base
+    JOIN tint_embalagens e ON e.id = sk.embalagem_id AND e.account = v_account AND e.id_embalagem_sayersystem = t.id_embalagem
+  );
+
+  -- ──────────────────────────────────────────────────────────────────────────
+  -- E1) Catálogo: upsert oficial a partir do latest-staging (espelha onConflict do tint-import).
+  -- ──────────────────────────────────────────────────────────────────────────
+  INSERT INTO tint_produtos (account, cod_produto, descricao)
+  SELECT v_account, cod_produto, COALESCE(descricao, cod_produto) FROM _tp_prod
+  ON CONFLICT (account, cod_produto) DO UPDATE SET descricao = EXCLUDED.descricao;
+
+  INSERT INTO tint_bases (account, id_base_sayersystem, descricao)
+  SELECT v_account, id_base_sayersystem, COALESCE(descricao, id_base_sayersystem) FROM _tp_base
+  ON CONFLICT (account, id_base_sayersystem) DO UPDATE SET descricao = EXCLUDED.descricao;
+
+  -- volume_ml NULL/0 do staging NUNCA rebaixa o volume oficial existente (espelha o
+  -- COALESCE/NULLIF do corante): senão a expansão (guard volume_ml>0) dropa as fórmulas
+  -- da embalagem silenciosamente. INSERT de embalagem nova com volume NULL → stub 0 (não
+  -- vendável, não satisfaz o guard de expansão). descricao idem (NULL não apaga a oficial).
+  INSERT INTO tint_embalagens (account, id_embalagem_sayersystem, descricao, volume_ml)
+  SELECT v_account, id_embalagem_sayersystem, COALESCE(descricao, id_embalagem_sayersystem), COALESCE(volume_ml, 0) FROM _tp_emb
+  ON CONFLICT (account, id_embalagem_sayersystem) DO UPDATE
+    SET descricao = COALESCE(EXCLUDED.descricao, tint_embalagens.descricao),
+        volume_ml = COALESCE(NULLIF(EXCLUDED.volume_ml, 0), tint_embalagens.volume_ml);
+
+  -- Corantes: volume_total_ml é NOT NULL no oficial → preferir staging volume_ml, senão preservar
+  -- o existente, senão 1000 (default do CSV-import p/ stub). preco_litro derivado de custo/volume
+  -- (R$/L) quando os dois presentes; senão preserva o staging.preco_litro.
+  INSERT INTO tint_corantes (account, id_corante_sayersystem, descricao, volume_total_ml, preco_litro)
+  SELECT
+    v_account,
+    c.id_corante_sayersystem,
+    COALESCE(c.descricao, c.id_corante_sayersystem),
+    COALESCE(c.volume_ml, ex.volume_total_ml, 1000),
+    CASE
+      WHEN c.custo IS NOT NULL AND c.volume_ml IS NOT NULL AND c.volume_ml > 0
+        THEN round((c.custo / c.volume_ml * 1000)::numeric, 2)
+      ELSE c.preco_litro
+    END
+  FROM _tp_cor c
+  LEFT JOIN tint_corantes ex ON ex.account = v_account AND ex.id_corante_sayersystem = c.id_corante_sayersystem
+  ON CONFLICT (account, id_corante_sayersystem) DO UPDATE
+    SET descricao        = EXCLUDED.descricao,
+        volume_total_ml  = EXCLUDED.volume_total_ml,
+        preco_litro      = COALESCE(EXCLUDED.preco_litro, tint_corantes.preco_litro);
+
+  -- Skus de produto_base_embalagem: resolve FKs (cria stub de produto/base/embalagem se a
+  -- linha do sku referenciar id ainda não-visto no run — espelha ensure* do CSV).
+  FOR r IN SELECT cod_produto, id_base, id_embalagem FROM _tp_sku LOOP
+    INSERT INTO tint_produtos (account, cod_produto, descricao)
+    VALUES (v_account, r.cod_produto, r.cod_produto)
+    ON CONFLICT (account, cod_produto) DO NOTHING;
+    INSERT INTO tint_bases (account, id_base_sayersystem, descricao)
+    VALUES (v_account, r.id_base, r.id_base)
+    ON CONFLICT (account, id_base_sayersystem) DO NOTHING;
+    INSERT INTO tint_embalagens (account, id_embalagem_sayersystem, descricao, volume_ml)
+    VALUES (v_account, r.id_embalagem, r.id_embalagem, 0)
+    ON CONFLICT (account, id_embalagem_sayersystem) DO NOTHING;
+
+    SELECT id INTO v_produto_id FROM tint_produtos WHERE account = v_account AND cod_produto = r.cod_produto;
+    SELECT id INTO v_base_id    FROM tint_bases    WHERE account = v_account AND id_base_sayersystem = r.id_base;
+    SELECT id INTO v_emb_id     FROM tint_embalagens WHERE account = v_account AND id_embalagem_sayersystem = r.id_embalagem;
+
+    INSERT INTO tint_skus (account, produto_id, base_id, embalagem_id)
+    VALUES (v_account, v_produto_id, v_base_id, v_emb_id)
+    ON CONFLICT (account, produto_id, base_id, embalagem_id) DO NOTHING;
+  END LOOP;
+
+  -- ══════════════════════════════════════════════════════════════════════════
+  -- E2/E3) Fórmulas — SET-BASED (substitui o FOR LOOP aninhado procedural).
+  --   Mesma regra de negócio do loop, em massa. Pares afetados + latest-staging por chave de
+  --   fórmula são VERBATIM do loop; o que muda é a expansão/preço/upsert/itens (INSERT...SELECT).
+  -- ══════════════════════════════════════════════════════════════════════════
+
+  -- Pares (cod_produto, id_base) afetados = pares com fórmula tocada NESTE run ∪ pares de sku
+  -- NOVO (§11 P1-C: embalagem nova ⇒ re-expandir). 20260617 (fix CARGA): _skus_novos no lugar de
+  -- _tp_sku — sku re-enviado (já existente) NÃO dispara re-expansão; senão um run de catalogs com
+  -- todos os skus re-expandiria TODAS as fórmulas de uma vez (lock timeout, incidente 17/06).
+  CREATE TEMP TABLE _pares ON COMMIT DROP AS
+  SELECT DISTINCT cod_produto, id_base FROM (
+    SELECT cod_produto, id_base FROM tint_staging_formulas
+      WHERE sync_run_id = p_sync_run_id AND cod_produto IS NOT NULL AND id_base IS NOT NULL
+    UNION
+    SELECT cod_produto, id_base FROM _skus_novos
+  ) u;
+
+  -- Latest staging de fórmula por (cor_id, cod_produto, id_base, sub_norm, personalizada),
+  -- restrita aos pares afetados — across TODOS os runs.
+  CREATE TEMP TABLE _formulas_latest ON COMMIT DROP AS
+  WITH alvo AS (
+    SELECT s.*
+    FROM tint_staging_formulas s
+    JOIN _pares p ON p.cod_produto = s.cod_produto AND p.id_base = s.id_base
+    WHERE s.account = v_account AND s.store_code = v_store
+      AND s.cor_id IS NOT NULL AND s.cod_produto IS NOT NULL AND s.id_base IS NOT NULL
+  )
+  SELECT DISTINCT ON (cor_id, cod_produto, id_base, COALESCE(subcolecao, ''), personalizada)
+         id AS staging_formula_id, cor_id, nome_cor, cod_produto, id_base, id_embalagem,
+         subcolecao, volume_final_ml, personalizada
+  FROM alvo
+  ORDER BY cor_id, cod_produto, id_base, COALESCE(subcolecao, ''), personalizada,
+           created_at DESC, id DESC;
+
+  -- Resolve FK produto/base por JOIN (não SELECT por linha). LEFT JOIN p/ separar os não-resolvidos.
+  CREATE TEMP TABLE _fl_resolved ON COMMIT DROP AS
+  SELECT fl.*, p.id AS produto_id, b.id AS base_id
+  FROM _formulas_latest fl
+  LEFT JOIN tint_produtos p ON p.account = v_account AND p.cod_produto = fl.cod_produto
+  LEFT JOIN tint_bases    b ON b.account = v_account AND b.id_base_sayersystem = fl.id_base;
+
+  -- Guard 1 — produto/base não resolvido (catálogo incompleto). Espelha o 1º CONTINUE do loop.
+  INSERT INTO tint_sync_errors (sync_run_id, entity_type, entity_id, error_message, error_details)
+  SELECT p_sync_run_id, 'formula_promote', fl.cor_id,
+         'produto/base não resolvido (catálogo incompleto)',
+         jsonb_build_object('cod_produto', fl.cod_produto, 'id_base', fl.id_base)
+  FROM _fl_resolved fl
+  WHERE fl.produto_id IS NULL OR fl.base_id IS NULL;
+  GET DIAGNOSTICS v_tmp = ROW_COUNT; v_erros := v_erros + v_tmp;
+
+  -- Subcoleções: ensure p/ fórmulas com produto/base resolvido e subcoleção não-vazia (o loop
+  -- ensura DEPOIS do guard de produto/base, ANTES dos guards de volume/vendável). id = texto CRU.
+  INSERT INTO tint_subcolecoes (account, id_subcolecao_sayersystem, descricao)
+  SELECT DISTINCT v_account, fl.subcolecao, fl.subcolecao
+  FROM _fl_resolved fl
+  WHERE fl.produto_id IS NOT NULL AND fl.base_id IS NOT NULL
+    AND fl.subcolecao IS NOT NULL AND btrim(fl.subcolecao) <> ''
+  ON CONFLICT (account, id_subcolecao_sayersystem) DO NOTHING;
+
+  -- Guard 2 — volume de formulação <= 0/nulo (entre os resolvidos). Espelha o 2º CONTINUE.
+  INSERT INTO tint_sync_errors (sync_run_id, entity_type, entity_id, error_message, error_details)
+  SELECT p_sync_run_id, 'formula_promote', fl.cor_id,
+         'volume de formulação <= 0 ou nulo',
+         jsonb_build_object('volume_final_ml', fl.volume_final_ml)
+  FROM _fl_resolved fl
+  WHERE fl.produto_id IS NOT NULL AND fl.base_id IS NOT NULL
+    AND (fl.volume_final_ml IS NULL OR fl.volume_final_ml <= 0);
+  GET DIAGNOSTICS v_tmp = ROW_COUNT; v_erros := v_erros + v_tmp;
+
+  -- Guard 3 — zero embalagens vendáveis para o par (entre resolvidos com volume OK). 3º CONTINUE.
+  INSERT INTO tint_sync_errors (sync_run_id, entity_type, entity_id, error_message, error_details)
+  SELECT p_sync_run_id, 'formula_promote', fl.cor_id,
+         'zero embalagens vendáveis para o par (produto,base)',
+         jsonb_build_object('cod_produto', fl.cod_produto, 'id_base', fl.id_base)
+  FROM _fl_resolved fl
+  WHERE fl.produto_id IS NOT NULL AND fl.base_id IS NOT NULL
+    AND fl.volume_final_ml IS NOT NULL AND fl.volume_final_ml > 0
+    AND NOT EXISTS (
+      SELECT 1 FROM tint_skus sk
+      JOIN tint_embalagens e ON e.id = sk.embalagem_id
+      WHERE sk.account = v_account AND sk.produto_id = fl.produto_id AND sk.base_id = fl.base_id
+        AND e.volume_ml IS NOT NULL AND e.volume_ml > 0
+    );
+  GET DIAGNOSTICS v_tmp = ROW_COUNT; v_erros := v_erros + v_tmp;
+
+  -- Expansão (regra de 3): 1 linha por (fórmula que passou TODOS os guards × embalagem vendável).
+  -- fator = vol_destino / vol_formulacao (espelho expandirFormula). subcolecao_id resolvido por
+  -- LEFT JOIN (NULL quando vazio). eid = chave surrogate p/ casar o preço.
+  CREATE TEMP TABLE _expand ON COMMIT DROP AS
+  SELECT
+    row_number() OVER () AS eid,
+    fl.staging_formula_id, fl.cor_id, fl.nome_cor, fl.cod_produto, fl.id_base, fl.personalizada,
+    fl.subcolecao,  -- texto CRU (p/ o desempate espelhar a ordem do loop; ver _expand_uniq)
+    fl.produto_id, fl.base_id,
+    sub.id AS subcolecao_id,
+    sk.id  AS sku_id,
+    sk.embalagem_id AS emb_id,
+    e.id_embalagem_sayersystem AS id_emb,
+    e.volume_ml AS vol_destino,
+    (e.volume_ml / fl.volume_final_ml) AS fator
+  FROM _fl_resolved fl
+  JOIN tint_skus sk ON sk.account = v_account AND sk.produto_id = fl.produto_id AND sk.base_id = fl.base_id
+  JOIN tint_embalagens e ON e.id = sk.embalagem_id
+  LEFT JOIN tint_subcolecoes sub
+    ON sub.account = v_account
+   AND fl.subcolecao IS NOT NULL AND btrim(fl.subcolecao) <> ''
+   AND sub.id_subcolecao_sayersystem = fl.subcolecao
+  WHERE fl.produto_id IS NOT NULL AND fl.base_id IS NOT NULL
+    AND fl.volume_final_ml IS NOT NULL AND fl.volume_final_ml > 0
+    AND e.volume_ml IS NOT NULL AND e.volume_ml > 0;
+
+  -- v_promovidas = nº de expansões (= incrementos do loop interno, inclui colisão personalizada).
+  SELECT count(*) INTO v_promovidas FROM _expand;
+
+  -- Preço pág 9 por expansão — SET-BASED, NULL-honesto (espelho precoFinalSayer + S2 store + S3
+  -- latest não-nulo). base ausente OU qualquer corante sem custo/volume(>0)/finito → preço NULL.
+  CREATE TEMP TABLE _preco ON COMMIT DROP AS
+  WITH base_latest AS (   -- S2: store_code; S3: custo IS NOT NULL. Latest por chave de base.
+    SELECT DISTINCT ON (cod_produto, id_base, id_embalagem)
+           cod_produto, id_base, id_embalagem, custo, imposto_pct, margem_pct
+    FROM tint_staging_precos_base
+    WHERE account = v_account AND store_code = v_store AND custo IS NOT NULL
+    ORDER BY cod_produto, id_base, id_embalagem, created_at DESC, id DESC
+  ),
+  cor_latest AS (         -- S2: store_code; S3: custo+volume NÃO-NULOS. Latest por corante.
+    SELECT DISTINCT ON (id_corante_sayersystem)
+           id_corante_sayersystem, custo, volume_ml
+    FROM tint_staging_corantes
+    WHERE account = v_account AND store_code = v_store
+      AND custo IS NOT NULL AND volume_ml IS NOT NULL
+    ORDER BY id_corante_sayersystem, created_at DESC, id DESC
+  ),
+  itens AS (              -- Σ corantes por expansão; flag de corante faltante (NULL-honesto).
+    SELECT ex.eid,
+           bool_or(
+             cl.id_corante_sayersystem IS NULL
+             OR cl.volume_ml IS NULL OR cl.volume_ml <= 0
+             OR NOT (cl.custo > '-Infinity'::numeric AND cl.custo < 'Infinity'::numeric)
+           ) AS faltante,
+           sum(CASE WHEN cl.volume_ml > 0 THEN (cl.custo / cl.volume_ml) * (si.qtd_ml * ex.fator) ELSE 0 END) AS soma
+    FROM _expand ex
+    JOIN tint_staging_formula_itens si ON si.staging_formula_id = ex.staging_formula_id
+    LEFT JOIN cor_latest cl ON cl.id_corante_sayersystem = si.id_corante
+    WHERE si.id_corante IS NOT NULL AND si.id_corante <> '' AND COALESCE(si.qtd_ml, 0) > 0
+    GROUP BY ex.eid
+  )
+  SELECT
+    ex.eid,
+    CASE
+      WHEN bl.custo IS NULL THEN NULL                                                   -- base ausente
+      WHEN NOT (bl.custo > '-Infinity'::numeric AND bl.custo < 'Infinity'::numeric) THEN NULL  -- custo não-finito
+      WHEN COALESCE(it.faltante, false) THEN NULL                                       -- corante sem preço
+      ELSE round(
+        ( bl.custo * (1 + COALESCE(bl.imposto_pct, 0) / 100) * (1 + COALESCE(bl.margem_pct, 0) / 100) )
+        + COALESCE(it.soma, 0)
+      , 2)
+    END AS preco
+  FROM _expand ex
+  LEFT JOIN base_latest bl
+    ON bl.cod_produto = ex.cod_produto AND bl.id_base = ex.id_base AND bl.id_embalagem = ex.id_emb
+  LEFT JOIN itens it ON it.eid = ex.eid;
+
+  -- Dedup pela CHAVE OFICIAL (uq_tint_formulas_chave — SEM personalizada): INSERT...SELECT não pode
+  -- ter a mesma chave 2× no mesmo comando (cardinality violation). O loop processa _formulas_latest
+  -- em ORDER BY ... COALESCE(subcolecao,'') ASC, personalizada ASC e o ÚLTIMO vence o upsert. A chave
+  -- oficial COLAPSA subcoleções que resolvem ao MESMO subcolecao_id (NULL e whitespace-only viram
+  -- NULL → btrim vazio), então a colisão pode ser entre linhas com COALESCE(subcolecao,'') DIFERENTE
+  -- (não só personalizada). Para escolher o MESMO vencedor do loop, desempata por COALESCE(subcolecao,
+  -- '') DESC PRIMEIRO, depois personalizada DESC (= o último que o loop processaria), eid DESC final.
+  CREATE TEMP TABLE _expand_uniq ON COMMIT DROP AS
+  SELECT DISTINCT ON (ex.cor_id, ex.produto_id, ex.base_id, COALESCE(ex.subcolecao_id, v_zero_uuid), ex.emb_id)
+         ex.staging_formula_id, ex.cor_id, ex.nome_cor, ex.personalizada,
+         ex.produto_id, ex.base_id, ex.subcolecao_id, ex.sku_id, ex.emb_id, ex.vol_destino, ex.fator,
+         pr.preco
+  FROM _expand ex
+  JOIN _preco pr ON pr.eid = ex.eid
+  ORDER BY ex.cor_id, ex.produto_id, ex.base_id, COALESCE(ex.subcolecao_id, v_zero_uuid), ex.emb_id,
+           COALESCE(ex.subcolecao, '') DESC, ex.personalizada DESC, ex.eid DESC;
+
+  -- Corante stubs em massa ANTES dos itens (espelha tint_ensure_corante_stub: volume 1000).
+  -- A partir de _expand (todas as expansões, inclui colisão) p/ casar o side-effect do loop.
+  INSERT INTO tint_corantes (account, id_corante_sayersystem, descricao, volume_total_ml)
+  SELECT DISTINCT v_account, si.id_corante, si.id_corante, 1000
+  FROM tint_staging_formula_itens si
+  WHERE si.staging_formula_id IN (SELECT DISTINCT staging_formula_id FROM _expand)
+    AND si.id_corante IS NOT NULL AND si.id_corante <> '' AND COALESCE(si.qtd_ml, 0) > 0
+  ON CONFLICT (account, id_corante_sayersystem) DO NOTHING;
+
+  -- Upsert oficial em massa por uq_tint_formulas_chave; desativada_em = NULL (reativa). Captura
+  -- formula_id ↔ (staging_formula_id, fator) p/ os itens (RETURNING casado de volta ao _expand_uniq).
+  CREATE TEMP TABLE _promoted ON COMMIT DROP AS
+  WITH ups AS (
+    INSERT INTO tint_formulas (
+      account, cor_id, nome_cor, produto_id, base_id, embalagem_id, subcolecao_id, sku_id,
+      volume_final_ml, preco_final_sayersystem, personalizada, importacao_id, updated_at, desativada_em
+    )
+    SELECT
+      v_account, eu.cor_id, eu.nome_cor, eu.produto_id, eu.base_id, eu.emb_id, eu.subcolecao_id, eu.sku_id,
+      eu.vol_destino, eu.preco, eu.personalizada, v_importacao_id, now(), NULL
+    FROM _expand_uniq eu
+    ON CONFLICT (account, cor_id, produto_id, base_id, COALESCE(subcolecao_id, '00000000-0000-0000-0000-000000000000'::uuid), embalagem_id)
+    DO UPDATE SET
+      nome_cor                = EXCLUDED.nome_cor,
+      sku_id                  = EXCLUDED.sku_id,
+      volume_final_ml         = EXCLUDED.volume_final_ml,
+      -- 20260617: PRESERVA o preço existente quando o novo é NULL (precos_base vazio → eu.preco NULL).
+      -- Sem isto o flip zeraria o piso de ~19k cores (calc<CSV). Espelha o COALESCE de preco_litro acima.
+      preco_final_sayersystem = COALESCE(EXCLUDED.preco_final_sayersystem, tint_formulas.preco_final_sayersystem),
+      personalizada           = EXCLUDED.personalizada,
+      importacao_id           = EXCLUDED.importacao_id,
+      updated_at              = now(),
+      desativada_em           = NULL
+    RETURNING id, cor_id, produto_id, base_id, subcolecao_id, embalagem_id
+  )
+  SELECT u.id AS formula_id, eu.staging_formula_id, eu.fator
+  FROM ups u
+  JOIN _expand_uniq eu
+    ON eu.cor_id = u.cor_id AND eu.produto_id = u.produto_id AND eu.base_id = u.base_id
+   AND COALESCE(eu.subcolecao_id, v_zero_uuid) = COALESCE(u.subcolecao_id, v_zero_uuid)
+   AND eu.emb_id = u.embalagem_id;
+
+  -- Itens em massa: limpa + reinsere (espelha o delete+insert por fórmula do loop). qtd expandida
+  -- = qtd_formulacao × fator, arredondada a 6 casas (sub-µL — elimina artefato de escala da divisão
+  -- numeric sem mudar o valor prático). Corante já garantido (stub acima) → JOIN resolve o id.
+  DELETE FROM tint_formula_itens fi USING _promoted pr WHERE fi.formula_id = pr.formula_id;
+
+  INSERT INTO tint_formula_itens (formula_id, corante_id, ordem, qtd_ml)
+  SELECT pr.formula_id, co.id, si.ordem, round((si.qtd_ml * pr.fator)::numeric, 6)
+  FROM _promoted pr
+  JOIN tint_staging_formula_itens si ON si.staging_formula_id = pr.staging_formula_id
+  JOIN tint_corantes co ON co.account = v_account AND co.id_corante_sayersystem = si.id_corante
+  WHERE si.id_corante IS NOT NULL AND si.id_corante <> '' AND COALESCE(si.qtd_ml, 0) > 0;
+
+  -- ──────────────────────────────────────────────────────────────────────────
+  -- E4) Recálculo de preço por mudança de INSUMO (§11 P1-A — caso de uso PRINCIPAL).
+  --   Run tocou precos_base/corantes → recalcula preco_final_sayersystem das fórmulas
+  --   oficiais ATIVAS afetadas, SEM re-expandir itens. NÃO mexe nas fórmulas que E2 já
+  --   tocou (importacao_id = v_importacao_id) — essas já saíram com o preço novo.
+  -- ──────────────────────────────────────────────────────────────────────────
+  -- Pares (produto,base,embalagem oficial) afetados por precos_base deste run.
+  FOR r IN
+    SELECT DISTINCT f.id AS formula_id, f.cor_id, p.cod_produto, b.id_base_sayersystem AS id_base, e.id_embalagem_sayersystem AS id_emb
+    FROM tint_staging_precos_base sp
+    JOIN tint_produtos   p ON p.account = v_account AND p.cod_produto = sp.cod_produto
+    JOIN tint_bases      b ON b.account = v_account AND b.id_base_sayersystem = sp.id_base
+    JOIN tint_embalagens e ON e.account = v_account AND e.id_embalagem_sayersystem = sp.id_embalagem
+    JOIN tint_formulas   f ON f.account = v_account AND f.produto_id = p.id AND f.base_id = b.id AND f.embalagem_id = e.id
+    WHERE sp.sync_run_id = p_sync_run_id
+      AND f.desativada_em IS NULL
+      AND (f.importacao_id IS DISTINCT FROM v_importacao_id)
+  LOOP
+    -- S2: +v_store.
+    v_preco := tint_recalc_preco_oficial(v_account, v_store, r.formula_id, r.cod_produto, r.id_base, r.id_emb);
+    -- 20260617: só baixa/sobe se o recálculo deu valor; NULL (sem precos_base) PRESERVA o piso atual.
+    UPDATE tint_formulas SET preco_final_sayersystem = COALESCE(v_preco, preco_final_sayersystem), updated_at = now() WHERE id = r.formula_id;
+    v_recalc := v_recalc + 1;
+  END LOOP;
+
+  -- Fórmulas que usam um corante cujo CUSTO mudou neste run (volume sem custo → preço NULL: inútil).
+  FOR r IN
+    SELECT DISTINCT f.id AS formula_id, f.cor_id, pr.cod_produto, ba.id_base_sayersystem AS id_base, em.id_embalagem_sayersystem AS id_emb
+    FROM tint_staging_corantes sc
+    JOIN tint_corantes      co ON co.account = v_account AND co.id_corante_sayersystem = sc.id_corante_sayersystem
+    JOIN tint_formula_itens fi ON fi.corante_id = co.id
+    JOIN tint_formulas      f  ON f.id = fi.formula_id
+    JOIN tint_produtos      pr ON pr.id = f.produto_id
+    JOIN tint_bases         ba ON ba.id = f.base_id
+    JOIN tint_embalagens    em ON em.id = f.embalagem_id
+    WHERE sc.sync_run_id = p_sync_run_id
+      -- 20260618 (fix CARGA E4): SÓ recalcula quando há CUSTO. O SayerSystem não manda custo (preço vem
+      -- do Omie, §14) → sem isto o re-envio (volume_ml sempre presente) recalculava ~481k fórmulas por
+      -- corante, uma a uma, num único run → gateway timeout → advisory lock preso → cascata (incidente
+      -- 18/06). Sem custo o recálculo dá NULL e o COALESCE preserva o piso — ou seja, seria carga inútil.
+      AND sc.custo IS NOT NULL
+      AND f.account = v_account
+      AND f.desativada_em IS NULL
+      AND (f.importacao_id IS DISTINCT FROM v_importacao_id)
+  LOOP
+    -- S2: +v_store.
+    v_preco := tint_recalc_preco_oficial(v_account, v_store, r.formula_id, r.cod_produto, r.id_base, r.id_emb);
+    -- 20260617: só baixa/sobe se o recálculo deu valor; NULL (sem precos_base) PRESERVA o piso atual.
+    UPDATE tint_formulas SET preco_final_sayersystem = COALESCE(v_preco, preco_final_sayersystem), updated_at = now() WHERE id = r.formula_id;
+    v_recalc := v_recalc + 1;
+  END LOOP;
+
+  -- ──────────────────────────────────────────────────────────────────────────
+  -- E5) Contadores + purge staging SUPERSEDED >30d (preserva latest-per-key) +
+  --     runs órfãos >30min → error.
+  -- ──────────────────────────────────────────────────────────────────────────
+  UPDATE tint_importacoes
+    SET status = 'concluido', registros_importados = v_promovidas, registros_erro = v_erros
+  WHERE id = v_importacao_id;
+
+  UPDATE tint_sync_runs
+    SET inserts = v_promovidas, errors = v_erros, metadata = COALESCE(metadata, '{}'::jsonb) || jsonb_build_object('recalculadas', v_recalc)
+  WHERE id = p_sync_run_id;
+
+  -- PURGE: NUNCA apaga a linha MAIS RECENTE por chave natural (account+store) — a promoção
+  -- lê latest-staging-por-chave PRA SEMPRE (recalc por insumo + re-expansão por sku novo
+  -- dependem dela mesmo que o insumo não mude por >30d → nunca é re-enviado). Só remove
+  -- linhas SUPERSEDED (>30d E com uma linha mais nova da MESMA chave). §11 P2-1.
+  -- Ordem de chave: (created_at, id) — idêntica ao DISTINCT ON da promoção.
+  DELETE FROM tint_staging_produtos s
+  WHERE s.created_at < now() - interval '30 days'
+    AND EXISTS (SELECT 1 FROM tint_staging_produtos n
+      WHERE n.account = s.account AND n.store_code = s.store_code
+        AND n.cod_produto = s.cod_produto
+        AND (n.created_at, n.id) > (s.created_at, s.id));
+
+  DELETE FROM tint_staging_bases s
+  WHERE s.created_at < now() - interval '30 days'
+    AND EXISTS (SELECT 1 FROM tint_staging_bases n
+      WHERE n.account = s.account AND n.store_code = s.store_code
+        AND n.id_base_sayersystem = s.id_base_sayersystem
+        AND (n.created_at, n.id) > (s.created_at, s.id));
+
+  DELETE FROM tint_staging_embalagens s
+  WHERE s.created_at < now() - interval '30 days'
+    AND EXISTS (SELECT 1 FROM tint_staging_embalagens n
+      WHERE n.account = s.account AND n.store_code = s.store_code
+        AND n.id_embalagem_sayersystem = s.id_embalagem_sayersystem
+        AND (n.created_at, n.id) > (s.created_at, s.id));
+
+  DELETE FROM tint_staging_corantes s
+  WHERE s.created_at < now() - interval '30 days'
+    AND EXISTS (SELECT 1 FROM tint_staging_corantes n
+      WHERE n.account = s.account AND n.store_code = s.store_code
+        AND n.id_corante_sayersystem = s.id_corante_sayersystem
+        AND (n.created_at, n.id) > (s.created_at, s.id));
+
+  DELETE FROM tint_staging_skus s
+  WHERE s.created_at < now() - interval '30 days'
+    AND EXISTS (SELECT 1 FROM tint_staging_skus n
+      WHERE n.account = s.account AND n.store_code = s.store_code
+        AND n.cod_produto = s.cod_produto AND n.id_base = s.id_base AND n.id_embalagem = s.id_embalagem
+        AND (n.created_at, n.id) > (s.created_at, s.id));
+
+  -- Fórmulas: chave = (cod_produto,id_base,cor_id,COALESCE(subcolecao,''),personalizada),
+  -- idêntica ao DISTINCT ON de _formulas_latest. Itens cascateiam pela formula-pai apagada.
+  DELETE FROM tint_staging_formula_itens si
+  WHERE si.staging_formula_id IN (
+    SELECT s.id FROM tint_staging_formulas s
+    WHERE s.created_at < now() - interval '30 days'
+      AND EXISTS (SELECT 1 FROM tint_staging_formulas n
+        WHERE n.account = s.account AND n.store_code = s.store_code
+          AND n.cor_id = s.cor_id AND n.cod_produto = s.cod_produto AND n.id_base = s.id_base
+          AND COALESCE(n.subcolecao, '') = COALESCE(s.subcolecao, '')
+          AND n.personalizada = s.personalizada
+          AND (n.created_at, n.id) > (s.created_at, s.id)));
+
+  DELETE FROM tint_staging_formulas s
+  WHERE s.created_at < now() - interval '30 days'
+    AND EXISTS (SELECT 1 FROM tint_staging_formulas n
+      WHERE n.account = s.account AND n.store_code = s.store_code
+        AND n.cor_id = s.cor_id AND n.cod_produto = s.cod_produto AND n.id_base = s.id_base
+        AND COALESCE(n.subcolecao, '') = COALESCE(s.subcolecao, '')
+        AND n.personalizada = s.personalizada
+        AND (n.created_at, n.id) > (s.created_at, s.id));
+
+  DELETE FROM tint_staging_precos_base s
+  WHERE s.created_at < now() - interval '30 days'
+    AND EXISTS (SELECT 1 FROM tint_staging_precos_base n
+      WHERE n.account = s.account AND n.store_code = s.store_code
+        AND n.cod_produto = s.cod_produto AND n.id_base = s.id_base AND n.id_embalagem = s.id_embalagem
+        AND (n.created_at, n.id) > (s.created_at, s.id));
+
+  -- keys-snapshot: point-in-time (não latest-per-key) → purge por tempo é correto.
+  DELETE FROM tint_keys_snapshots          WHERE created_at < now() - interval '30 days';
+
+  UPDATE tint_sync_runs
+    SET status = 'error', completed_at = COALESCE(completed_at, now())
+  WHERE status = 'running' AND started_at < now() - interval '30 minutes';
+
+  RETURN jsonb_build_object(
+    'ok', true, 'promovidas', v_promovidas, 'recalculadas', v_recalc,
+    'erros', v_erros, 'importacao_id', v_importacao_id);
+END $$;
+REVOKE EXECUTE ON FUNCTION public.tint_promote_sync_run(uuid) FROM anon, authenticated, PUBLIC;
+
+SELECT 'tint_promote_sync_run SET-BASED OK' AS status;


### PR DESCRIPTION
## Catálogo automático do Tintométrico (SayerSystem) no ar — CSV de catálogo aposentado

Liga o sync SayerSystem → app em **tempo real** (`automatic_primary`) e aposenta o upload manual de CSV de catálogo. Arco de **3 incidentes** resolvidos, todos money-path.

### Os 3 fixes (migrations JÁ aplicadas em prod via SQL Editor — este PR versiona o código)

| Migration | Fix | Prova |
|---|---|---|
| `20260617130000` | promoção **preserva** `preco_final_sayersystem` quando o recálculo dá NULL (`COALESCE`) — sem isto o flip zeraria o piso de ~19k cores (calc < CSV) | PG17 + Codex + **prod** |
| `20260617150000` | re-expansão E2/E3 dispara só p/ **skus novos** (`_skus_novos`) — o re-envio em massa deixava o run de `catalogs` re-expandir todas as ~481k fórmulas → lock timeout 55P03 | PG17 + Codex |
| `20260618130000` | E4 (recálculo por corante) só com **`custo IS NOT NULL`** — sem isto o re-envio recalculava ~481k fórmulas por corante à toa (custo nunca vem; preço via Omie) → lock timeout | PG17 + Codex |

### Prova

- **3 harnesses PG17 descartáveis** (`db/test-tint-promote-*.sh`): aplicam a migration REAL, semeiam, asserts positivos + **falsificação** (sabota a condição → exige vermelho).
- **Codex challenge** em cada fix money-path (sem P1).
- **Em produção:** re-flip completou sem travar. 482.665 fórmulas / 8.502 cores (+114 vs gabarito 12/06); **944 sem preço = todas cores novas** (Omie cobre); **0 fórmulas existentes perderam preço**; 0 desativadas; loop morto; advisory lock limpo.

### Contexto / follow-ups

`docs/runbooks/tint-sync-corte-csv.md` — sequência de corte, os 3 incidentes, e follow-ups não-urgentes do Codex: (a) E4/precos_base loop-por-fórmula → set-based se vier custo em massa; (b) E1 `volume_total_ml` vs `preco_litro` (incoerência se algo ler direto); (c) defesa de infra `idle_in_transaction_session_timeout` no role; (d) higiene `DROP tint_formulas_backup_preflip`. O conector v0.2.0 (hash + auto-update) veio do #914.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
