### PR TITLE
feat(deploy-verify): carimbo de SHA no build + monitor de smoke E2E autônomo

### DIFF
--- a/.claude/skills/lovable-deploy-verify/SKILL.md
+++ b/.claude/skills/lovable-deploy-verify/SKILL.md
@@ -132,6 +132,25 @@ founder é este, pelos bytes.
 
 ---
 
+## Smoke E2E autônomo (carimbo de SHA + monitor)
+
+O build **carimba o commit no bundle** (`vite.config` → `define __COMMIT_SHA__`; `main.tsx` →
+`window.__BUILD_SHA__`). Com isso o monitor responde "**o ar == `origin/main`?**" sem adivinhar um ALVO:
+
+```bash
+.claude/skills/lovable-deploy-verify/scripts/monitor-deploy.sh [url] [sentinela]
+# exit 0 = sincronizado · 3 = ATRASADO (Publish pendente) · 4 = deploy novo, versão indeterminada
+```
+
+- **Determinístico** quando o ar tem `__BUILD_SHA__="<sha>"` — compara com `origin/main`.
+- **Fallback**: se vier `"dev"` (Lovable sem `.git` no build) ou ausente (build pré-carimbo), passe uma
+  `sentinela` (string de UI única do HEAD) → o monitor cai pro `verify-frontend.sh`.
+- **Agendar** (cron de sistema, sem gastar Claude): `*/30 * * * * cd <repo> && bash .../monitor-deploy.sh
+  >> ~/.config/afiacao/deploy-monitor.log 2>&1` (exit 3/4 = avisar; combine com `osascript`/email).
+
+⚠️ O carimbo só vale a partir do **1º Publish que inclua o `vite.config` novo** — e depende de o build do
+Lovable ter `.git` (senão o SHA vira `"dev"` e o monitor usa a sentinela). Provado local; o ar confirma no 1º Publish.
+
 ## Referências
 - CLAUDE.md §"Deploy do FRONTEND (app) — Publish MANUAL no Lovable" (a técnica dos bytes; armadilha do chunk de nome inesperado)
 - CLAUDE.md §"Edge functions — caminho oficial Lovable" (deploy via chat, ler do repo, verbatim)
@@ -143,5 +162,5 @@ founder é este, pelos bytes.
 - [x] `evals/` com classificação de diff (8 casos + runner + mutation-check; espelha `lovable-db-operator/evals`).
 - [x] Domínio canônico `steu.lovable.app` confirmado (HTTP 200).
 - [x] **Edge:** verificação por escada — N1 existência (`verify-edge.sh`, OPTIONS, automático) · N2 versão (Management API, handoff de PAT) · N3 comportamento (probe gated). Fecha a assimetria com o frontend.
-- [ ] **Smoke ponta-a-ponta:** num próximo Publish real, rodar `verify-frontend.sh` com um ALVO conhecido e ver exit 0 (fecha o último elo — não dá com build local).
+- [x] **Smoke E2E autônomo:** carimbo de SHA no build (`__BUILD_SHA__`) + `monitor-deploy.sh` (cron) compara o ar vs `origin/main`. Provado local; **falta o 1º Publish ativar o carimbo no ar** (e confirmar que o Lovable tem `.git` no build — senão cai pra sentinela).
 - [ ] (menor) Confirmar se há ambiente de **preview** distinto do publicado a checar.

--- a/.claude/skills/lovable-deploy-verify/scripts/monitor-deploy.sh
+++ b/.claude/skills/lovable-deploy-verify/scripts/monitor-deploy.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# monitor-deploy.sh — vigia se o frontend NO AR está sincronizado com origin/main.
+# Pensado pra rodar em cron (sem interação): detecta um Publish (o hash do entry muda) e
+# responde "ar == main?" pelo carimbo `__BUILD_SHA__` (vite.config + main.tsx), com FALLBACK
+# de sentinela de string quando o carimbo não está disponível.
+#
+# Exit:  0 = sincronizado (ou nada a relatar) · 3 = ar ATRASADO (Publish pendente)
+#        4 = deploy novo detectado mas versão indeterminada (sem carimbo nem sentinela)
+#        2 = site fora do ar / HTML mudou de forma
+# Estado: último hash de entry visto em $DEPLOY_MONITOR_STATE
+#         (default ~/.config/afiacao/deploy-monitor.state) — pra detectar "mudou desde a última vez".
+#
+# Uso:   monitor-deploy.sh [url] [sentinela-opcional]
+#   - rode com cwd DENTRO do repo (precisa de git pra saber o SHA de origin/main).
+#   - SENTINELA: string única do HEAD que sobrevive ao build (ex.: um texto de UI),
+#     usada SÓ se o carimbo vier "dev" (Lovable sem .git) ou ausente (build pré-carimbo).
+set -uo pipefail
+APP="${1:-https://steu.lovable.app}"
+SENTINELA="${2:-}"
+STATE="${DEPLOY_MONITOR_STATE:-$HOME/.config/afiacao/deploy-monitor.state}"
+SELF_DIR="$(cd "$(dirname "$0")" && pwd)"
+mkdir -p "$(dirname "$STATE")" 2>/dev/null || true
+TS=$(date +%FT%T 2>/dev/null || echo now)
+
+git fetch origin main --quiet 2>/dev/null || true
+MAIN_SHA=$(git rev-parse --short=8 origin/main 2>/dev/null || echo "?")
+
+ENTRY=$(curl -fsS "$APP/" 2>/dev/null | grep -oE '/assets/index-[A-Za-z0-9_-]+\.js' | head -1)
+[ -n "$ENTRY" ] || { echo "[$TS] monitor: $APP fora do ar ou HTML mudou de forma"; exit 2; }
+ENTRY_HASH=$(printf '%s' "$ENTRY" | grep -oE 'index-[A-Za-z0-9_-]+')
+PREV=$(cat "$STATE" 2>/dev/null || echo "")
+printf '%s\n' "$ENTRY_HASH" > "$STATE"
+if [ "$PREV" != "$ENTRY_HASH" ]; then DEPLOY="SIM (${PREV:-1a-vez} -> $ENTRY_HASH)"; else DEPLOY="nao"; fi
+
+BODY=$(curl -fsS "$APP$ENTRY" 2>/dev/null || echo "")
+AIR_SHA=$(printf '%s' "$BODY" | grep -oE '__BUILD_SHA__="[0-9a-f]{7,8}"' | grep -oE '[0-9a-f]{7,8}' | head -1)
+IS_DEV=$(printf '%s' "$BODY" | grep -cE '__BUILD_SHA__="dev"' || true)
+
+echo "[$TS] main=$MAIN_SHA  ar=${AIR_SHA:-$([ "${IS_DEV:-0}" -gt 0 ] && echo dev || echo sem-carimbo)}  deploy-novo=$DEPLOY"
+
+# Caminho determinístico: carimbo de SHA real no ar
+if [ -n "$AIR_SHA" ]; then
+  if [ "$AIR_SHA" = "$MAIN_SHA" ]; then echo "  ✅ sincronizado: ar serve $AIR_SHA == origin/main"; exit 0
+  else echo "  ⚠️ ATRASADO: ar serve $AIR_SHA, main em $MAIN_SHA → Publish pendente"; exit 3; fi
+fi
+
+# Fallback: carimbo "dev" (Lovable sem git no build) ou ausente (build pré-carimbo)
+if [ -n "$SENTINELA" ]; then
+  if "$SELF_DIR/verify-frontend.sh" "$SENTINELA" "$APP" >/dev/null 2>&1; then
+    echo "  fallback: sentinela '$SENTINELA' PRESENTE no ar → provavelmente sincronizado"; exit 0
+  else
+    echo "  fallback: sentinela '$SENTINELA' AUSENTE → Publish pendente (ou sentinela ruim)"; exit 3
+  fi
+fi
+if [ "$DEPLOY" = "nao" ]; then echo "  sem carimbo útil e nada mudou desde a última checagem → nada a relatar"; exit 0; fi
+echo "  deploy novo detectado, mas sem carimbo de SHA nem sentinela → não dá pra confirmar a versão"
+echo "  (quando o carimbo chegar ao ar no 1º Publish, este fallback some)"
+exit 4

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,12 +2,22 @@ import { createRoot } from "react-dom/client";
 import App from "./App.tsx";
 import "./index.css";
 
+/** Carimbo de build: o Vite (`define`) substitui por uma string literal com o short SHA
+ *  do commit, ou "dev" se o build não tiver git. O cron/verify-frontend.sh grepa o SHA
+ *  da main nos bytes servidos → responde "o ar == origin/main?" sem adivinhar um ALVO. */
+declare const __COMMIT_SHA__: string;
+
 declare global {
   interface Window {
     /** Setado após o React montar; lido pelo watchdog de boot no index.html. */
     __APP_BOOTED__?: boolean;
+    /** Short SHA do commit deste build (carimbo). Lido pela verificação de deploy. */
+    __BUILD_SHA__?: string;
   }
 }
+
+// Carimba o SHA deste build no window logo no boot (side-effect — não é tree-shaken).
+window.__BUILD_SHA__ = __COMMIT_SHA__;
 
 const isInLovablePreview =
   window.location.hostname.includes("id-preview--") ||

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,11 +3,34 @@ import react from "@vitejs/plugin-react-swc";
 import path from "path";
 import { componentTagger } from "lovable-tagger";
 import { VitePWA } from "vite-plugin-pwa";
+import { execSync } from "node:child_process";
 
 const isLovablePreview = process.env.LOVABLE_PREVIEW === "true";
 
+// Carimbo de commit no bundle (lido pela verificação de deploy / cron de smoke E2E).
+// Ordem: env explícita (CI) → git local (funciona se o build tiver `.git`; INCERTO no
+// Lovable, confirmado só no 1º Publish) → "dev". Nunca quebra o build (try/catch).
+function resolveCommitSha(): string {
+  const env =
+    process.env.VITE_COMMIT_SHA || process.env.COMMIT_SHA || process.env.GITHUB_SHA;
+  if (env) return env.slice(0, 8);
+  try {
+    return execSync("git rev-parse --short=8 HEAD", {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    return "dev";
+  }
+}
+const commitSha = resolveCommitSha();
+
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
+  define: {
+    // Substituído LITERALMENTE nos bytes do bundle → grepável na verificação de deploy.
+    __COMMIT_SHA__: JSON.stringify(commitSha),
+  },
   server: {
     host: "::",
     port: 8080,


### PR DESCRIPTION
Fecha o **"testar sozinho depois"** do smoke E2E. O build passa a **carimbar o commit no bundle**, e um monitor compara o SHA no ar com `origin/main` — sem adivinhar um ALVO. **Mexe no APP** (`vite.config` + `main.tsx`), então vale a partir do seu próximo Publish.

## Mudanças
- **`vite.config.ts`**: `resolveCommitSha()` (env → `git rev-parse` → `"dev"`, `try/catch` nunca quebra o build) + `define __COMMIT_SHA__`. Não toca o `manualChunks`.
- **`src/main.tsx`**: `window.__BUILD_SHA__` (segue o padrão de `__APP_BOOTED__` que já existe).
- **`scripts/monitor-deploy.sh`**: detecta deploy (hash do entry muda) + responde "ar == main?" pelo carimbo, com **fallback de sentinela** (`verify-frontend.sh`) se vier `"dev"`/ausente. `exit 0=sincronizado / 3=atrasado / 4=indeterminado`.
- **`SKILL.md`**: seção "Smoke E2E autônomo" + como agendar via cron.

## Provado
- Local: typecheck ✓, build ✓, carimbo **`__BUILD_SHA__="5290d261"`** no `dist` ✓. Lint **0 errors**.
- Monitor: extrai o SHA do `dist` carimbado ✓; contra o ar (pré-carimbo) → honesto `sem-carimbo`, `exit 4`. shellcheck limpo.

## Incerteza honesta
O carimbo depende de o build do Lovable ter `.git`. O **mecanismo** está provado localmente; o ar confirma no **1º Publish** que inclua este `vite.config`. Se o Lovable não tiver git, o SHA vira `"dev"` e o monitor cai pra sentinela — por isso o fallback existe. Mudança **aditiva, sem regressão**.

## Próximo passo (seu)
No 1º Publish que incluir este `vite.config`: eu rodo o monitor e confirmo se o `__BUILD_SHA__` real apareceu (carimbo funcionou) ou `"dev"` (aí setamos `VITE_COMMIT_SHA` no Lovable, ou usamos a sentinela).

🤖 Generated with [Claude Code](https://claude.com/claude-code)