### PR TITLE
fix(vendas): conserto da raiz do #B — sync-reprocess idempotente por identidade

### DIFF
--- a/db/test-b-renamespace-orfaos.sh
+++ b/db/test-b-renamespace-orfaos.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# HARNESS PG17 — prova do RE-NAMESPACE #B (órfãs de-namespaced sem par 'omie_').
+#   bash db/test-b-renamespace-orfaos.sh > /tmp/t.log 2>&1; echo "exit=$?"
+# Lei de Ferro: aplica a migration REAL; asserts negativos c/ SQLSTATE+re-raise; falsifica → vermelho.
+# Mirror de prod: AMBOS os índices (uniq_sales_orders_omie_hash + uniq_sales_orders_omie_pedido_id).
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PGVER=17
+PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+PORT="${PGPORT_TEST:-5457}"
+SLUG="b-renamespace-orfaos"
+DATA="$(mktemp -d "/tmp/pgtest-${SLUG}.XXXXXX")/data"
+export LC_ALL=C LANG=C
+
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente: brew install postgresql@${PGVER} pgvector"; exit 1; }
+CELLAR="$(brew --prefix "postgresql@${PGVER}")"
+cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
+mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
+cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
+
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+trap cleanup EXIT
+
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l "/tmp/pg-${SLUG}.log" -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres prove
+P()  { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d prove -v ON_ERROR_STOP=1 "$@"; }
+Pq() { P -tA "$@"; }
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  ✅ $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  ❌ $1"; }
+eq()  { if [ "$2" = "$3" ]; then ok "$1 (=$2)"; else bad "$1 — esperado [$3], veio [$2]"; fi; }
+
+echo "═══ setup PG17 :$PORT ═══"
+
+# ══ ZONA 1 — schema stub + AMBOS os índices (mirror prod pós-cleanup) + SEED do estado ══
+P -q <<'SQL'
+CREATE TABLE public.sales_orders (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  account text NOT NULL,
+  hash_payload text,
+  omie_pedido_id bigint,
+  status text,
+  total numeric,
+  created_at timestamptz DEFAULT now()
+);
+-- índices REAIS de prod (#929 + cleanup #B):
+CREATE UNIQUE INDEX uniq_sales_orders_omie_hash ON public.sales_orders (account, hash_payload) WHERE hash_payload LIKE 'omie\_%';
+CREATE UNIQUE INDEX uniq_sales_orders_omie_pedido_id ON public.sales_orders (account, omie_pedido_id) WHERE hash_payload IS NOT NULL AND omie_pedido_id IS NOT NULL;
+
+-- O) 4 órfãs oben (de-namespaced, SEM par omie_, status cancelado mislabeled) → RE-NAMESPACE
+INSERT INTO public.sales_orders (id, account, hash_payload, omie_pedido_id, status, total) VALUES
+  ('00000000-0000-0000-0000-000000005001','oben','-aaa1',5001,'cancelado',123.60),
+  ('00000000-0000-0000-0000-000000005002','oben','-aaa2',5002,'cancelado',152.85),
+  ('00000000-0000-0000-0000-000000005003','oben','-aaa3',5003,'cancelado',107.70),
+  ('00000000-0000-0000-0000-000000005004','oben','-aaa4',5004,'cancelado',189.00);
+-- A) órfã colacor com o MESMO número de pid (5001) — re-namespace é account-aware (hash distinto)
+INSERT INTO public.sales_orders (id, account, hash_payload, omie_pedido_id, status, total) VALUES
+  ('00000000-0000-0000-0000-0000000c5001','colacor','-ccc1',5001,'cancelado',50.00);
+-- K) omie_ legítima (oben) — INTACTA
+INSERT INTO public.sales_orders (id, account, hash_payload, omie_pedido_id, status, total) VALUES
+  ('00000000-0000-0000-0000-000000006001','oben','omie_oben_6001',6001,'faturado',600);
+-- L) PUSH (hash NULL) no MESMO pid de K — coexiste e fica INTACTA
+INSERT INTO public.sales_orders (id, account, hash_payload, omie_pedido_id, status, total) VALUES
+  ('00000000-0000-0000-0000-0000000060f1','oben',NULL,6001,'enviado',600);
+SQL
+echo "seed: $(Pq -c "SELECT count(*) FROM public.sales_orders;") linhas"
+
+# ══ ZONA 2 — aplica a migration REAL sobre o estado ══
+MIG="$REPO_ROOT/supabase/migrations/20260618210000_b_renamespace_orfaos.sql"
+P -q -f "$MIG"
+echo "migration aplicada: $(basename "$MIG")"
+
+# ══ ZONA 4 — asserts ══
+echo "── asserts ──"
+eq "P1 órfã oben 5001 re-namespaced"  "$(Pq -c "SELECT hash_payload FROM public.sales_orders WHERE id='00000000-0000-0000-0000-000000005001';")" "omie_oben_5001"
+eq "P1 órfã oben 5004 re-namespaced"  "$(Pq -c "SELECT hash_payload FROM public.sales_orders WHERE id='00000000-0000-0000-0000-000000005004';")" "omie_oben_5004"
+eq "P1-acc órfã colacor 5001 (hash account-aware)" "$(Pq -c "SELECT hash_payload FROM public.sales_orders WHERE id='00000000-0000-0000-0000-0000000c5001';")" "omie_colacor_5001"
+eq "P-status NÃO muda (correção é do reprocess)" "$(Pq -c "SELECT status FROM public.sales_orders WHERE id='00000000-0000-0000-0000-000000005001';")" "cancelado"
+eq "N1 omie_ K intacta"               "$(Pq -c "SELECT hash_payload FROM public.sales_orders WHERE id='00000000-0000-0000-0000-000000006001';")" "omie_oben_6001"
+eq "N2 PUSH L segue hash NULL"        "$(Pq -c "SELECT coalesce(hash_payload,'NULL') FROM public.sales_orders WHERE id='00000000-0000-0000-0000-0000000060f1';")" "NULL"
+eq "P-naodestrutivo total inalterado" "$(Pq -c "SELECT count(*) FROM public.sales_orders;")" "7"
+eq "POST 0 órfãs de-namespaced restantes" "$(Pq -c "SELECT count(*) FROM public.sales_orders WHERE hash_payload IS NOT NULL AND hash_payload NOT LIKE 'omie\_%' AND omie_pedido_id IS NOT NULL;")" "0"
+
+# P-idem: re-rodar a migration casa 0 (idempotente) e não erra
+if P -q -f "$MIG" >/dev/null 2>&1; then ok "P-idem re-run idempotente (0 órfãs, sem erro)"; else bad "P-idem re-run FALHOU"; fi
+
+# P-index: a órfã re-namespaced virou a canônica → 2ª 'omie_oben_5001' colide (unique_violation)
+R=$(P -tA 2>&1 <<'SQL'
+DO $$ BEGIN
+  INSERT INTO public.sales_orders (account, hash_payload, omie_pedido_id, status)
+  VALUES ('oben','omie_oben_5001',5001,'faturado');
+  RAISE EXCEPTION 'INDICE_NAO_BARROU';
+EXCEPTION WHEN unique_violation THEN RAISE NOTICE 'SENT_PIDX_BARROU';
+  WHEN OTHERS THEN RAISE;
+END $$;
+SQL
+)
+case "$R" in *SENT_PIDX_BARROU*) ok "P-index re-namespaced é a canônica (hash dup barrado)";; *) bad "P-index — veio: $R";; esac
+
+# ══ ZONA 5 — FALSIFICAÇÃO ══
+echo "── falsificação ──"
+
+# F1: o NOT EXISTS protege contra colisão. Semeia uma de-namespaced COM par omie_ (estado que o
+# índice omie_pedido_id proíbe → dropa só ele p/ semear), roda a versão FURADA (sem NOT EXISTS):
+# ela re-namespearia a com-par → hash idêntico ao par → COLISÃO no índice de hash (23505).
+P -q -c "DROP INDEX public.uniq_sales_orders_omie_pedido_id;"
+P -q <<'SQL'
+INSERT INTO public.sales_orders (id, account, hash_payload, omie_pedido_id, status, total) VALUES
+  ('00000000-0000-0000-0000-000000007001','oben','omie_oben_7001',7001,'faturado',700),  -- par omie_
+  ('00000000-0000-0000-0000-0000000070d1','oben','-den7',7001,'cancelado',700);          -- de-namespaced COM par
+SQL
+R=$(P -tA 2>&1 <<'SQL'
+DO $$ BEGIN
+  UPDATE public.sales_orders s SET hash_payload='omie_'||s.account||'_'||s.omie_pedido_id
+  WHERE s.hash_payload IS NOT NULL AND s.hash_payload NOT LIKE 'omie\_%' AND s.omie_pedido_id IS NOT NULL
+    AND s.omie_pedido_id = 7001;  -- FURADO: sem o NOT EXISTS → pega a de-namespaced COM par
+  RAISE EXCEPTION 'FURADO_NAO_COLIDIU';
+EXCEPTION WHEN unique_violation THEN RAISE NOTICE 'SENT_F1_COLIDIU';
+  WHEN OTHERS THEN RAISE;
+END $$;
+SQL
+)
+case "$R" in *SENT_F1_COLIDIU*) ok "F1 sem NOT EXISTS a com-par colide no índice de hash (guard tem dente)";; *) bad "F1 — veio: $R";; esac
+P -q -c "DELETE FROM public.sales_orders WHERE omie_pedido_id=7001;" >/dev/null
+P -q -c "CREATE UNIQUE INDEX uniq_sales_orders_omie_pedido_id ON public.sales_orders (account, omie_pedido_id) WHERE hash_payload IS NOT NULL AND omie_pedido_id IS NOT NULL;" >/dev/null
+
+# F2: guard "2+ órfãs no mesmo (account,pid)" aborta (estado que o índice proíbe → dropa p/ semear).
+P -q -c "DROP INDEX public.uniq_sales_orders_omie_pedido_id;"
+P -q <<'SQL'
+INSERT INTO public.sales_orders (account, hash_payload, omie_pedido_id, status, total) VALUES
+  ('oben','-dup1',8001,'cancelado',1),
+  ('oben','-dup2',8001,'cancelado',1);  -- 2 órfãs, MESMO pid, SEM par omie_
+SQL
+if P -q -f "$MIG" >/dev/null 2>&1; then
+  bad "F2 2 órfãs no mesmo pid e a migration NÃO abortou → guard 2+ sem dente"
+else
+  ok "F2 2 órfãs no mesmo (account,pid) → migration aborta (guard 2+ tem dente)"
+fi
+P -q -c "DELETE FROM public.sales_orders WHERE omie_pedido_id=8001;" >/dev/null
+P -q -c "CREATE UNIQUE INDEX uniq_sales_orders_omie_pedido_id ON public.sales_orders (account, omie_pedido_id) WHERE hash_payload IS NOT NULL AND omie_pedido_id IS NOT NULL;" >/dev/null
+
+# F3: guard teto >50 aborta (semeia 51 órfãs).
+P -q <<'SQL'
+INSERT INTO public.sales_orders (account, hash_payload, omie_pedido_id, status, total)
+SELECT 'oben','-big'||g,90000+g,'cancelado',1 FROM generate_series(1,51) g;
+SQL
+if P -q -f "$MIG" >/dev/null 2>&1; then
+  bad "F3 51 órfãs e a migration NÃO abortou → guard >50 sem dente"
+else
+  ok "F3 51 órfãs → migration aborta (guard >50 tem dente)"
+fi
+
+# ── veredito ──
+echo "──────────────────────────────"
+echo "RESULTADO: $PASS ok / $FAIL fail"
+[ "$FAIL" = "0" ] || { echo "❌ HARNESS VERMELHO"; exit 1; }
+echo "✅ HARNESS VERDE"

--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,7 +21,7 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **266** custom migrations totais
+- **267** custom migrations totais
 - **991** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
   - `function`: 274
@@ -2336,6 +2336,10 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | Tipo | Objeto | Parent |
 | --- | --- | --- |
 | `function` | `public.get_customer_sales_summary` | — |
+
+### `20260618210000_b_renamespace_orfaos.sql`
+
+> _Nenhum objeto extraído via regex._ Migration provavelmente é `ALTER TABLE` / `UPDATE` / `INSERT` / RLS-only. Validar manualmente.
 
 ## Próximos passos quando algo der `❌`
 

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 266
+-- Total de custom migrations: 267
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -285,7 +285,8 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260618130000', 'tint_promote_e4_so_com_custo', '20260618130000_tint_promote_e4_so_com_custo.sql'),
   ('20260618180000', 'get_customer_sales_summary', '20260618180000_get_customer_sales_summary.sql'),
   ('20260618190000', 'b_cleanup_dups_oben', '20260618190000_b_cleanup_dups_oben.sql'),
-  ('20260618190000', 'get_customer_sales_summary_blocklist', '20260618190000_get_customer_sales_summary_blocklist.sql')
+  ('20260618190000', 'get_customer_sales_summary_blocklist', '20260618190000_get_customer_sales_summary_blocklist.sql'),
+  ('20260618210000', 'b_renamespace_orfaos', '20260618210000_b_renamespace_orfaos.sql')
 )
 SELECT
   e.version,

--- a/supabase/functions/_shared/omie-pedido.ts
+++ b/supabase/functions/_shared/omie-pedido.ts
@@ -1,0 +1,189 @@
+// Canon Omie pedido → campos locais (sales_orders/order_items). FONTE ÚNICA do mapeamento
+// etapa→status, do subtotal-com-desconto e do snapshot items-jsonb, para o sync (omie-vendas-sync)
+// e o reprocess (sync-reprocess) NÃO divergirem. Essa divergência foi a causa do #B: o reprocess
+// tinha o mapa INVERTIDO (60→cancelado / 50→faturado) e reescrevia o hash_payload de identidade.
+// Puro (zero Deno/DB): provado por `deno test supabase/functions/_shared/omie-pedido_test.ts`.
+//
+// ⚠️ omie-vendas-sync ainda mantém o mapa/subtotal/itemsJson inline (L1166-1193) — unificar num
+//    follow-up. Este módulo já é a fonte canônica; o teste trava o canon contra regressão (#B).
+
+const STATUS_OMIE = new Set(["importado", "separacao", "enviado", "faturado", "cancelado"]);
+const ETAPAS_CONHECIDAS = new Set(["20", "50", "60", "70", "80"]);
+
+/** etapa (cabecalho.etapa do Omie) → status local. Default 'importado' (etapa 10/desconhecida). */
+export function omieEtapaToStatus(etapa: string | undefined | null): string {
+  const e = etapa || "";
+  if (e === "60" || e === "70") return "faturado";
+  if (e === "50") return "separacao";
+  if (e === "20") return "enviado";
+  if (e === "80") return "cancelado";
+  return "importado";
+}
+
+/** etapa reconhecida? O reprocess só reconcilia status com etapa CONHECIDA — não rebaixa para
+ *  'importado' a partir de uma leitura malformada/sem etapa (precisão>recall). */
+export function etapaConhecida(etapa: string | undefined | null): boolean {
+  return ETAPAS_CONHECIDAS.has(etapa || "");
+}
+
+/** status local é gerido pelo Omie? O reprocess NÃO sobrescreve status app-avançado
+ *  (confirmado/entregue/rascunho/pendente…) — só reconcilia quando o local veio do mapa do Omie. */
+export function statusEhOmie(status: string | undefined | null): boolean {
+  return STATUS_OMIE.has(status || "");
+}
+
+interface DetInput {
+  produto?: {
+    codigo_produto?: number | string;
+    descricao?: string;
+    quantidade?: number;
+    valor_unitario?: number;
+    desconto?: number;
+  };
+  observacao?: { obs_item?: string };
+  inf_adic?: { dados_adicionais_item?: string };
+}
+
+/** subtotal = Σ qty·preço·(1 − desconto%/100), arredondado a 2 casas. `desconto` é PERCENTUAL.
+ *  MESMA semântica do omie-vendas-sync (L1170-1173): `|| ` (qty 0 → 1, igual ao sync) — NÃO `??`. */
+export function subtotalPedidoComDesconto(det: DetInput[]): number {
+  let subtotal = 0;
+  for (const d of det) {
+    const prod = d.produto || {};
+    const qty = prod.quantidade || 1;
+    const price = prod.valor_unitario || 0;
+    const desc = prod.desconto || 0;
+    subtotal += qty * price * (1 - desc / 100);
+  }
+  return Math.round(subtotal * 100) / 100;
+}
+
+/** Cor de tinta a partir da obs do item ("Cor: <label> - <embalagem>"). Espelha o parseCorObs do
+ *  omie-vendas-sync verbatim (a cor vai em obs_item na ida; o sync extrai de volta). */
+function parseCorObs(obs: string | null | undefined): { tint_nome_cor: string } | null {
+  if (!obs) return null;
+  const m = /^\s*cor:\s*(.+)$/i.exec(obs);
+  if (!m) return null;
+  const label = m[1].replace(/\s*-\s*(?:QT|GL|LT|\d+(?:[.,]\d+)?\s*ML)\s*$/i, "").trim();
+  if (!label) return null;
+  return { tint_nome_cor: label };
+}
+
+interface ItemJson {
+  omie_codigo_produto: number | string | undefined;
+  descricao: string;
+  quantidade: number;
+  valor_unitario: number;
+  desconto: number;
+  tint_nome_cor?: string;
+}
+
+/** Reconstrói o snapshot sales_orders.items (jsonb) IGUAL ao omie-vendas-sync (L1178-1185):
+ *  mesmas chaves, desconto bruto, cor de tinta da obs. Mantém os MUITOS leitores de items-jsonb
+ *  (scoring/cross-sell/bundle/UI/print) consistentes com order_items após o reconcile (achado #B
+ *  Codex A2 — o reprocess antigo atualizava order_items mas deixava items-jsonb stale). */
+export function construirItemsJson(det: DetInput[]): ItemJson[] {
+  const out: ItemJson[] = [];
+  for (const d of det) {
+    const prod = d.produto || {};
+    const cor = parseCorObs(d.observacao?.obs_item ?? d.inf_adic?.dados_adicionais_item);
+    out.push({
+      omie_codigo_produto: prod.codigo_produto,
+      descricao: prod.descricao || "",
+      quantidade: prod.quantidade || 1,
+      valor_unitario: prod.valor_unitario || 0,
+      desconto: prod.desconto || 0,
+      ...(cor ? { tint_nome_cor: cor.tint_nome_cor } : {}),
+    });
+  }
+  return out;
+}
+
+// ── Reconciliação de itens (order_items) por IDENTIDADE (omie_codigo_produto), preservando o
+//    hash_payload de identidade `omie_<account>_<pid>_<codigo>` — NUNCA reescrever p/ hash de
+//    conteúdo (foi o #B no nível item). Itens inseridos/atualizados carregam o hash de identidade;
+//    item pré-existente inalterado mantém o seu hash legado (INERTE — não é lido p/ idempotência:
+//    a RPC do sync não re-insere itens de pedido existente). ──
+
+export interface ItemLocal {
+  id: string;
+  omie_codigo_produto: number;
+  quantity: number;
+  unit_price: number;
+  discount: number;
+  product_id: string | null;
+}
+export interface ItemDesejado {
+  omie_codigo_produto: number;
+  quantity: number;
+  unit_price: number;
+  discount: number;
+  product_id: string | null;
+  hash_payload: string;
+}
+interface ItemUpdate {
+  id: string;
+  quantity: number;
+  unit_price: number;
+  discount: number;
+  product_id: string | null;
+  hash_payload: string; // A3: o update repara a identidade do item
+}
+interface DiffItens {
+  inserir: ItemDesejado[];
+  atualizar: ItemUpdate[];
+  deletar: string[]; // ids dos order_items a remover
+}
+
+const EPS = 1e-6;
+function numEq(a: number, b: number): boolean {
+  return Math.abs((a ?? 0) - (b ?? 0)) < EPS;
+}
+
+/**
+ * Diff de itens por omie_codigo_produto (chave de identidade dentro do pedido):
+ *  - inserir   = no Omie e SEM correspondente local (carrega o hash de identidade);
+ *  - atualizar = local com CONTEÚDO divergente (qty/preço/desconto/product_id) → grava o conteúdo
+ *                novo E o hash de identidade (repara hash legado de conteúdo de passada);
+ *  - deletar   = local SEM correspondente no Omie (item REMOVIDO — o reprocess antigo nunca
+ *                deletava → total/positivação inflados por item fantasma).
+ * Conteúdo igual ⇒ no-op (não dispara update só por hash → evita burst de reescrita inerte).
+ * Premissa de codigo_produto único no pedido (mesma do sync); o caller PULA o reconcile de itens
+ * quando o Omie repete um SKU (ambíguo) p/ não deletar linha legítima.
+ */
+export function diffOrderItens(locais: ItemLocal[], desejados: ItemDesejado[]): DiffItens {
+  const mapLocal = new Map<number, ItemLocal>();
+  for (const l of locais) mapLocal.set(l.omie_codigo_produto, l);
+  const mapDesejado = new Map<number, ItemDesejado>();
+  for (const d of desejados) mapDesejado.set(d.omie_codigo_produto, d);
+
+  const inserir: ItemDesejado[] = [];
+  const atualizar: ItemUpdate[] = [];
+  const deletar: string[] = [];
+
+  for (const d of mapDesejado.values()) {
+    const l = mapLocal.get(d.omie_codigo_produto);
+    if (!l) {
+      inserir.push(d);
+      continue;
+    }
+    const igual = numEq(l.quantity, d.quantity)
+      && numEq(l.unit_price, d.unit_price)
+      && numEq(l.discount, d.discount)
+      && (l.product_id ?? null) === (d.product_id ?? null);
+    if (!igual) {
+      atualizar.push({
+        id: l.id,
+        quantity: d.quantity,
+        unit_price: d.unit_price,
+        discount: d.discount,
+        product_id: d.product_id,
+        hash_payload: d.hash_payload,
+      });
+    }
+  }
+  for (const l of mapLocal.values()) {
+    if (!mapDesejado.has(l.omie_codigo_produto)) deletar.push(l.id);
+  }
+  return { inserir, atualizar, deletar };
+}

--- a/supabase/functions/_shared/omie-pedido_test.ts
+++ b/supabase/functions/_shared/omie-pedido_test.ts
@@ -1,0 +1,89 @@
+// Canon de omie-pedido.ts (#B). Roda: deno test supabase/functions/_shared/omie-pedido_test.ts
+import {
+  omieEtapaToStatus,
+  etapaConhecida,
+  statusEhOmie,
+  subtotalPedidoComDesconto,
+  construirItemsJson,
+  diffOrderItens,
+} from "./omie-pedido.ts";
+
+function eq(a: unknown, b: unknown, msg: string) {
+  if (JSON.stringify(a) !== JSON.stringify(b)) {
+    throw new Error(`${msg}: ${JSON.stringify(a)} !== ${JSON.stringify(b)}`);
+  }
+}
+
+Deno.test("etapa→status casa o canon do omie-vendas-sync", () => {
+  eq(omieEtapaToStatus("50"), "separacao", "50");
+  eq(omieEtapaToStatus("60"), "faturado", "60");
+  eq(omieEtapaToStatus("70"), "faturado", "70");
+  eq(omieEtapaToStatus("80"), "cancelado", "80");
+  eq(omieEtapaToStatus("20"), "enviado", "20");
+  eq(omieEtapaToStatus("10"), "importado", "10→default");
+  eq(omieEtapaToStatus(""), "importado", "vazio→default");
+  eq(omieEtapaToStatus(undefined), "importado", "undefined→default");
+});
+
+Deno.test("REGRESSÃO #B: 60≠cancelado e 50≠faturado (mapa invertido do reprocess antigo)", () => {
+  if (omieEtapaToStatus("60") === "cancelado") throw new Error("60 não pode ser cancelado");
+  if (omieEtapaToStatus("50") === "faturado") throw new Error("50 não pode ser faturado");
+});
+
+Deno.test("etapaConhecida: só 20/50/60/70/80 (reprocess não rebaixa status em leitura malformada)", () => {
+  for (const e of ["20", "50", "60", "70", "80"]) eq(etapaConhecida(e), true, `conhecida ${e}`);
+  for (const e of ["10", "", undefined, "99", "x"]) eq(etapaConhecida(e), false, `desconhecida ${e}`);
+});
+
+Deno.test("statusEhOmie: gerido pelo Omie vs app-avançado (reprocess não clobbera confirmado/entregue)", () => {
+  for (const s of ["importado", "separacao", "enviado", "faturado", "cancelado"]) eq(statusEhOmie(s), true, `omie ${s}`);
+  for (const s of ["confirmado", "entregue", "rascunho", "pendente", "", undefined]) eq(statusEhOmie(s), false, `app ${s}`);
+});
+
+Deno.test("subtotal soma com desconto percentual, || (qty 0→1, igual ao sync) e arredonda", () => {
+  eq(subtotalPedidoComDesconto([{ produto: { quantidade: 2, valor_unitario: 10 } }]), 20, "sem desconto");
+  eq(subtotalPedidoComDesconto([{ produto: { quantidade: 1, valor_unitario: 100, desconto: 10 } }]), 90, "10%");
+  eq(subtotalPedidoComDesconto([{ produto: { quantidade: 3, valor_unitario: 33.333 } }]), 100, "arredonda");
+  eq(subtotalPedidoComDesconto([{ produto: { quantidade: 0, valor_unitario: 10 } }]), 10, "qty 0 → 1 (|| igual ao sync)");
+  eq(subtotalPedidoComDesconto([{}]), 0, "det sem produto");
+});
+
+Deno.test("construirItemsJson casa o snapshot do sync (chaves + cor de tinta da obs)", () => {
+  const det = [
+    { produto: { codigo_produto: 8, descricao: "PINO F15", quantidade: 3, valor_unitario: 13.85, desconto: 0 } },
+    { produto: { codigo_produto: 9, descricao: "BASE PU", quantidade: 1, valor_unitario: 86 }, observacao: { obs_item: "Cor: AZUL RAL 5010 - GL" } },
+  ];
+  const out = construirItemsJson(det);
+  eq(out[0], { omie_codigo_produto: 8, descricao: "PINO F15", quantidade: 3, valor_unitario: 13.85, desconto: 0 }, "item comum");
+  eq(out[1].tint_nome_cor, "AZUL RAL 5010", "cor de tinta extraída da obs");
+  eq(out[1].descricao, "BASE PU", "descricao");
+  // sem cor → sem chave tint
+  eq("tint_nome_cor" in construirItemsJson([{ produto: { codigo_produto: 1, descricao: "X", quantidade: 1, valor_unitario: 1 } }])[0], false, "sem obs → sem tint");
+});
+
+Deno.test("diff: insere novo, atualiza divergente (e grava hash de identidade), deleta removido, no-op igual", () => {
+  const locais = [
+    { id: "A", omie_codigo_produto: 1, quantity: 2, unit_price: 10, discount: 0, product_id: "p1" }, // igual → no-op
+    { id: "B", omie_codigo_produto: 2, quantity: 1, unit_price: 5, discount: 0, product_id: null }, // qty diverge → update
+    { id: "C", omie_codigo_produto: 3, quantity: 1, unit_price: 9, discount: 0, product_id: "p3" }, // removido → delete
+  ];
+  const desejados = [
+    { omie_codigo_produto: 1, quantity: 2, unit_price: 10, discount: 0, product_id: "p1", hash_payload: "omie_oben_77_1" },
+    { omie_codigo_produto: 2, quantity: 4, unit_price: 5, discount: 0, product_id: null, hash_payload: "omie_oben_77_2" },
+    { omie_codigo_produto: 9, quantity: 1, unit_price: 7, discount: 0, product_id: "p9", hash_payload: "omie_oben_77_9" }, // novo → insert
+  ];
+  const d = diffOrderItens(locais, desejados);
+  eq(d.inserir.map((i) => i.omie_codigo_produto), [9], "inserir");
+  eq(d.atualizar.map((u) => u.id), ["B"], "atualizar ids");
+  eq(d.atualizar[0].quantity, 4, "atualizar qty nova");
+  eq(d.atualizar[0].hash_payload, "omie_oben_77_2", "update grava hash de IDENTIDADE (repara legado)");
+  eq(d.deletar, ["C"], "deletar");
+});
+
+Deno.test("diff: tolerância numérica (float repr) não vira atualização espúria", () => {
+  const locais = [{ id: "A", omie_codigo_produto: 1, quantity: 1, unit_price: 152.85, discount: 0, product_id: "p1" }];
+  const desejados = [
+    { omie_codigo_produto: 1, quantity: 1, unit_price: 152.85000000000002, discount: 0, product_id: "p1", hash_payload: "h_1" },
+  ];
+  eq(diffOrderItens(locais, desejados).atualizar, [], "diferença de 2e-14 não é divergência");
+});

--- a/supabase/functions/sync-reprocess/index.ts
+++ b/supabase/functions/sync-reprocess/index.ts
@@ -1,6 +1,16 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient, type SupabaseClient } from "npm:@supabase/supabase-js@2";
 import { authorizeCron, corsHeaders } from "../_shared/auth.ts";
+import {
+  omieEtapaToStatus,
+  etapaConhecida,
+  statusEhOmie,
+  subtotalPedidoComDesconto,
+  construirItemsJson,
+  diffOrderItens,
+  type ItemDesejado,
+  type ItemLocal,
+} from "../_shared/omie-pedido.ts";
 
 const OMIE_API_URL = "https://app.omie.com.br/api/v1";
 
@@ -10,11 +20,15 @@ type Account = "oben" | "colacor";
 interface OmieProdutoItem {
   quantidade?: number;
   valor_unitario?: number;
+  desconto?: number;
+  descricao?: string;
   codigo_produto?: number | string;
 }
 
 interface OmiePedidoItem {
   produto?: OmieProdutoItem;
+  observacao?: { obs_item?: string };
+  inf_adic?: { dados_adicionais_item?: string };
 }
 
 interface OmiePedidoCabecalho {
@@ -103,18 +117,6 @@ async function callOmie(account: Account, endpoint: string, call: string, params
   return result;
 }
 
-// Simple hash for change detection
-function hashObject(obj: unknown): string {
-  const str = JSON.stringify(obj, Object.keys(obj as Record<string, unknown>).sort());
-  let hash = 0;
-  for (let i = 0; i < str.length; i++) {
-    const char = str.charCodeAt(i);
-    hash = ((hash << 5) - hash) + char;
-    hash |= 0;
-  }
-  return hash.toString(36);
-}
-
 function formatOmieDate(d: Date): string {
   return `${String(d.getDate()).padStart(2, "0")}/${String(d.getMonth() + 1).padStart(2, "0")}/${d.getFullYear()}`;
 }
@@ -190,8 +192,27 @@ async function reprocessOrders(
   let upserts = 0;
   let divergences = 0;
   let corrections = 0;
+  let falhas = 0;      // pedidos com erro de escrita (não engole — surfaça no log)
+  let skuRepetido = 0; // pedidos com SKU repetido (reconcile de itens pulado por ambiguidade)
 
   try {
+    // Preload codigo_produto -> product_id (1x por run; evita N+1 por item, igual ao repararOrfaos).
+    const productMap = new Map<number, string>();
+    {
+      let page = 0; const sz = 1000; let more = true;
+      while (more) {
+        const { data: batch } = await db
+          .from("omie_products").select("id, omie_codigo_produto")
+          .eq("account", account).range(page * sz, (page + 1) * sz - 1);
+        if (!batch || batch.length === 0) { more = false; }
+        else {
+          for (const p of batch) productMap.set(Number(p.omie_codigo_produto), p.id as string);
+          if (batch.length < sz) more = false;
+          page++;
+        }
+      }
+    }
+
     let pagina = 1;
     let totalPaginas = 1;
 
@@ -209,112 +230,130 @@ async function reprocessOrders(
 
       for (const pedido of pedidos) {
         const cab = pedido.cabecalho || {};
-        const codigoCliente = cab.codigo_cliente;
+        const codigoPedido = cab.codigo_pedido;
+        if (!codigoPedido) continue;
         const itens = pedido.det || [];
-        const omieNumPedido = String(cab.numero_pedido || cab.codigo_pedido);
-        const pedidoHash = hashObject({ cab, itens });
+        const hashPayload = `omie_${account}_${codigoPedido}`;
 
-        // Find customer
-        const { data: mapping } = await db
-          .from("omie_clientes")
-          .select("user_id")
-          .eq("omie_codigo_cliente", codigoCliente)
-          .maybeSingle();
+        // [A4] guard de leitura vazia/malformada: sem item VÁLIDO (codigo_produto) NÃO reconcilia
+        //      (mirror do G7 da RPC) — evita zerar total/apagar itens de um pedido real por um
+        //      ListarPedidos degenerado.
+        const itensValidos = itens.filter((it) => it.produto?.codigo_produto != null);
+        if (itensValidos.length === 0) continue;
 
-        if (!mapping) continue;
-
-        // Check existing order
-        const { data: existingOrder } = await db
+        // Identidade IMUTÁVEL: acha o pai pelo hash_payload determinístico (único pelo índice
+        // parcial uniq_sales_orders_omie_hash). NUNCA por omie_numero_pedido — pegaria a linha
+        // errada (push/de-namespaced). Se não existe, quem INSERE é o omie-vendas-sync; o
+        // reprocess só RECONCILIA o que já existe (a RPC não reconcilia pedido alterado — Fase 2).
+        const { data: order } = await db
           .from("sales_orders")
-          .select("id, hash_payload")
-          .eq("omie_numero_pedido", omieNumPedido)
+          .select("id, status, total, customer_user_id")
           .eq("account", account)
+          .eq("hash_payload", hashPayload)
           .maybeSingle();
+        if (!order) continue;
 
-        if (existingOrder) {
-          // Change detection via hash
-          if (existingOrder.hash_payload === pedidoHash) continue;
+        // [A1] total/itemsJson pelo canon compartilhado (|| igual ao sync). [A4] status só
+        //      reconcilia com etapa CONHECIDA e status local gerido pelo Omie — não rebaixa p/
+        //      'importado' em leitura malformada nem clobbera status app-avançado (confirmado/entregue).
+        const novoSubtotal = subtotalPedidoComDesconto(itens);
+        const itemsJson = construirItemsJson(itens);
+        const statusReconcilia = etapaConhecida(cab.etapa) && statusEhOmie(order.status);
+        const novoStatus = statusReconcilia ? omieEtapaToStatus(cab.etapa) : (order.status as string);
+        const statusMudou = order.status !== novoStatus;
+        const totalMudou = Math.abs(Number(order.total ?? 0) - novoSubtotal) > 0.01;
 
-          divergences++;
+        // ── Itens PRIMEIRO (sem transação: se um write de item falhar, NÃO gravo o cabeçalho com
+        //    total/itemsJson que não batem — o próximo ciclo reconcilia, idempotente). [A7] SKU
+        //    repetido no pedido é ambíguo (a identidade é por codigo) → pula o reconcile de itens
+        //    (não arrisca deletar linha legítima); o cabeçalho ainda reconcilia (total/itemsJson
+        //    somam TODAS as linhas, igual ao sync). NUNCA toca hash_payload do pai (causa-raiz #B);
+        //    o hash de identidade do ITEM `omie_<acc>_<pid>_<codigo>` é gravado no insert/update. ──
+        const codigosValidos = itensValidos.map((it) => Number(it.produto!.codigo_produto));
+        const temSkuRepetido = codigosValidos.length !== new Set(codigosValidos).size;
+        let itemErro = false;
+        let itensMudaram = false;
 
-          // Update sales_order status/data
-          const etapa = cab.etapa || "10";
-          const statusMap: Record<string, string> = {
-            "10": "rascunho", "20": "enviado", "50": "faturado", "60": "cancelado",
-          };
+        if (temSkuRepetido) {
+          skuRepetido++;
+          console.warn(`[Reprocess][${account}] pedido ${codigoPedido} com SKU repetido — itens não reconciliados`);
+        } else {
+          const { data: locaisRaw } = await db
+            .from("order_items")
+            .select("id, omie_codigo_produto, quantity, unit_price, discount, product_id")
+            .eq("sales_order_id", order.id);
+          const locais: ItemLocal[] = (locaisRaw || []).map((r) => ({
+            id: r.id as string,
+            omie_codigo_produto: Number(r.omie_codigo_produto),
+            quantity: Number(r.quantity ?? 0),
+            unit_price: Number(r.unit_price ?? 0),
+            discount: Number(r.discount ?? 0),
+            product_id: (r.product_id as string | null) ?? null,
+          }));
 
-          const totalPedido = itens.reduce((sum: number, i: OmiePedidoItem) => {
-            const prod = i.produto || {};
-            return sum + (prod.quantidade || 1) * (prod.valor_unitario || 0);
-          }, 0);
+          const desejados: ItemDesejado[] = itensValidos.map((it) => {
+            const prod = it.produto!;
+            const cod = Number(prod.codigo_produto);
+            return {
+              omie_codigo_produto: cod,
+              quantity: prod.quantidade || 1,
+              unit_price: prod.valor_unitario || 0,
+              discount: prod.desconto || 0,
+              product_id: productMap.get(cod) ?? null,
+              hash_payload: `${hashPayload}_${cod}`,
+            };
+          });
+          const diff = diffOrderItens(locais, desejados);
 
-          await db.from("sales_orders").update({
-            status: statusMap[etapa] || "enviado",
-            total: totalPedido,
-            subtotal: totalPedido,
-            hash_payload: pedidoHash,
-            updated_at: new Date().toISOString(),
-          }).eq("id", existingOrder.id);
-
-          // Reprocess order items
-          for (const item of itens) {
-            const prod = item.produto || {};
-            const codigoProduto = prod.codigo_produto;
-            const quantidade = prod.quantidade || 1;
-            const valorUnit = prod.valor_unitario || 0;
-            const itemHash = hashObject(prod);
-
-            const { data: product } = await db
-              .from("omie_products")
-              .select("id")
-              .eq("omie_codigo_produto", codigoProduto)
-              .eq("account", account)
-              .maybeSingle();
-
-            // Check existing item
-            const { data: existingItem } = await db
-              .from("order_items")
-              .select("id, hash_payload")
-              .eq("sales_order_id", existingOrder.id)
-              .eq("omie_codigo_produto", codigoProduto)
-              .maybeSingle();
-
-            if (existingItem) {
-              if (existingItem.hash_payload !== itemHash) {
-                await db.from("order_items").update({
-                  quantity: quantidade,
-                  unit_price: valorUnit,
-                  product_id: product?.id || null,
-                  hash_payload: itemHash,
-                }).eq("id", existingItem.id);
-                corrections++;
-              }
-            } else {
-              await db.from("order_items").insert({
-                sales_order_id: existingOrder.id,
-                customer_user_id: mapping.user_id,
-                product_id: product?.id || null,
-                omie_codigo_produto: codigoProduto,
-                quantity: quantidade,
-                unit_price: valorUnit,
-                hash_payload: itemHash,
-              });
-              corrections++;
-            }
-
-            // Update price history
-            if (product?.id && valorUnit > 0) {
-              await db.from("sales_price_history").upsert({
-                customer_user_id: mapping.user_id,
-                product_id: product.id,
-                unit_price: valorUnit,
-                sales_order_id: existingOrder.id,
-              }, { ignoreDuplicates: true });
-            }
+          for (const ins of diff.inserir) {
+            const { error } = await db.from("order_items").insert({
+              sales_order_id: order.id,
+              customer_user_id: order.customer_user_id,
+              product_id: ins.product_id,
+              omie_codigo_produto: ins.omie_codigo_produto,
+              quantity: ins.quantity,
+              unit_price: ins.unit_price,
+              discount: ins.discount,
+              hash_payload: ins.hash_payload,
+            });
+            if (error) { itemErro = true; console.error(`[Reprocess][${account}] insert item ${ins.omie_codigo_produto} ped ${codigoPedido}: ${error.message}`); }
+            else { corrections++; itensMudaram = true; }
           }
-
-          upserts++;
+          for (const upd of diff.atualizar) {
+            const { error } = await db.from("order_items").update({
+              quantity: upd.quantity,
+              unit_price: upd.unit_price,
+              discount: upd.discount,
+              product_id: upd.product_id,
+              hash_payload: upd.hash_payload,
+            }).eq("id", upd.id);
+            if (error) { itemErro = true; console.error(`[Reprocess][${account}] update item ${upd.id} ped ${codigoPedido}: ${error.message}`); }
+            else { corrections++; itensMudaram = true; }
+          }
+          if (diff.deletar.length > 0) {
+            const { error } = await db.from("order_items").delete().in("id", diff.deletar);
+            if (error) { itemErro = true; console.error(`[Reprocess][${account}] delete itens ped ${codigoPedido}: ${error.message}`); }
+            else { corrections += diff.deletar.length; itensMudaram = true; }
+          }
         }
+
+        // ── Cabeçalho DEPOIS: status/total/itemsJson do Omie ATUAL. Só grava se algo mudou e os
+        //    itens não falharam (consistência sem transação). sales_price_history fica a cargo do
+        //    sync (writer único, write-once por pedido) — reprocess não grava preço. ──
+        if (!itemErro && (statusMudou || totalMudou || itensMudaram)) {
+          const { error } = await db.from("sales_orders").update({
+            status: novoStatus,
+            total: novoSubtotal,
+            subtotal: novoSubtotal,
+            items: itemsJson,
+            updated_at: new Date().toISOString(),
+          }).eq("id", order.id);
+          if (error) { itemErro = true; console.error(`[Reprocess][${account}] update pedido ${codigoPedido}: ${error.message}`); }
+          else if (statusMudou || totalMudou) divergences++;
+        }
+
+        if (itemErro) falhas++;
+        else if (statusMudou || totalMudou || itensMudaram) upserts++;
       }
 
       console.log(`[Reprocess][${account}] Orders page ${pagina}/${totalPaginas}`);
@@ -326,10 +365,21 @@ async function reprocessOrders(
       divergences_found: divergences,
       corrections_applied: corrections,
       duration_ms: Date.now() - startTime,
-      metadata: { pages: totalPaginas, window_days: windowDays },
+      metadata: { pages: totalPaginas, window_days: windowDays, falhas, sku_repetido: skuRepetido },
+      // Reconcile parcial (erro de escrita) ou SKU repetido (order_items não reconciliado, pode
+      // divergir do cabeçalho) NÃO derruba a run (idempotente: próximo ciclo reconcilia), mas NÃO
+      // mente 'complete' limpo — surfaça em error_message p/ o watchdog/health (achado Codex).
+      ...((falhas > 0 || skuRepetido > 0)
+        ? {
+          error_message: [
+            falhas > 0 ? `${falhas} pedido(s) com erro de escrita (reconcile parcial)` : null,
+            skuRepetido > 0 ? `${skuRepetido} pedido(s) com SKU repetido (order_items pode divergir do cabeçalho)` : null,
+          ].filter(Boolean).join("; "),
+        }
+        : {}),
     });
 
-    return { upserts, divergences, corrections, duration_ms: Date.now() - startTime };
+    return { upserts, divergences, corrections, falhas, sku_repetido: skuRepetido, duration_ms: Date.now() - startTime };
   } catch (error) {
     await completeReprocessLog(db, logId, {
       upserts_count: upserts,
@@ -381,14 +431,6 @@ async function reprocessProducts(
         if (EXCLUDED_FAMILIES.some(ex => familia.includes(ex)) || familia.startsWith('jumbo')) continue;
         const descLower = (prod.descricao || '').toLowerCase();
         if (descLower.includes('810ml') || descLower.includes('810 ml')) continue;
-
-        const newHash = hashObject({
-          codigo: prod.codigo,
-          descricao: prod.descricao,
-          valor_unitario: prod.valor_unitario,
-          unidade: prod.unidade,
-          familia: prod.descricao_familia,
-        });
 
         // Check existing
         const { data: existing } = await db

--- a/supabase/migrations/20260618210000_b_renamespace_orfaos.sql
+++ b/supabase/migrations/20260618210000_b_renamespace_orfaos.sql
@@ -1,0 +1,93 @@
+-- ============================================================
+-- #B (resíduo) — RE-NAMESPACE das órfãs de-namespaced SEM par 'omie_'
+--
+-- Contexto: o edge sync-reprocess (PRÉ-conserto) reescrevia hash_payload de
+-- 'omie_<account>_<pid>' para um hash de CONTEÚDO. A cleanup #B (20260618190000) removeu as
+-- de-namespaced que tinham par 'omie_' (dups). Restaram as SEM par — ÓRFÃS criadas entre a
+-- medição e a contenção (hoje 4: oben, pids 12104598757/12104601737/12104602329/12104607815,
+-- pedidos 11551-11554). Elas são um problema duplo:
+--   (a) ÍNDICE/LANDMINE: ocupam (account, omie_pedido_id) no índice uniq_sales_orders_omie_pedido_id
+--       com hash NÃO-'omie_' → o omie-vendas-sync, ao tentar inserir a linha 'omie_' real do pedido,
+--       leva 23505 (a RPC engole como 'failed' → o pedido NUNCA sincroniza);
+--   (b) STATUS MISLABELED: o mapa invertido do reprocess antigo (60→cancelado, mas etapa 60 =
+--       faturado) → provável SUBcontagem de positivação.
+--
+-- Heal = restaurar a IDENTIDADE: hash_payload = 'omie_'||account||'_'||omie_pedido_id. A linha
+-- vira a canônica 'omie_' do pedido → o sync a acha por hash (ON CONFLICT DO NOTHING, sem 23505)
+-- e o reprocess CONSERTADO reconcilia o status pela etapa ATUAL do Omie (source-truth).
+-- ⚠️ NÃO mexe em status aqui — a correção de status é do reprocess (não de DEDUÇÃO).
+--
+-- ⚠️ PRÉ-REQUISITO: a cleanup #B (20260618190000) e o índice uniq_sales_orders_omie_hash (#929)
+--    já aplicados. Idempotente: re-rodar casa 0 (após re-namespace, hash LIKE 'omie\_%' → excluído).
+-- Provado em PG17 (db/test-b-renamespace-orfaos.sh) com falsificação.
+-- ============================================================
+
+BEGIN;
+
+-- anti-race com o sync de entrada (segue ativo) — não cria um 'omie_' do mesmo pid no meio.
+LOCK TABLE public.sales_orders IN SHARE ROW EXCLUSIVE MODE;
+
+-- [alvo] de-namespaced (hash NÃO-NULL e NÃO-'omie_') com pid e SEM par 'omie_' (órfã).
+-- Assinatura EXCLUSIVA do bug (sync grava 'omie_%', PUSH grava NULL). O NOT EXISTS é defesa: o
+-- índice uniq_sales_orders_omie_pedido_id já garante ≤1 linha hash-not-null por (account, pid),
+-- mas mantém a migration segura mesmo se o índice não existir.
+CREATE TEMP TABLE _b_orfaos ON COMMIT DROP AS
+SELECT a.id, a.account, a.omie_pedido_id
+FROM public.sales_orders a
+WHERE a.hash_payload IS NOT NULL
+  AND a.hash_payload NOT LIKE 'omie\_%'
+  AND a.omie_pedido_id IS NOT NULL
+  AND NOT EXISTS (
+    SELECT 1 FROM public.sales_orders b
+    WHERE b.account = a.account
+      AND b.omie_pedido_id = a.omie_pedido_id
+      AND b.hash_payload LIKE 'omie\_%'
+  );
+
+-- [guard] teto baixo (são ~4; >50 = anomalia). NÃO aborta em 0 (idempotência). E aborta se 2+
+-- órfãs no MESMO (account, pid) — re-namespeá-las geraria hash idêntico → colisão (investigar).
+DO $guard$
+DECLARE n int; c int;
+BEGIN
+  SELECT count(*) INTO n FROM _b_orfaos;
+  IF n > 50 THEN
+    RAISE EXCEPTION 'Re-namespace #B abortado: % órfãs (>50, fora da faixa segura)', n;
+  END IF;
+  SELECT count(*) INTO c FROM (
+    SELECT 1 FROM _b_orfaos GROUP BY account, omie_pedido_id HAVING count(*) > 1
+  ) x;
+  IF c > 0 THEN
+    RAISE EXCEPTION 'Re-namespace #B abortado: % (account,pid) com 2+ órfãs — re-namespace colidiria, investigar', c;
+  END IF;
+  RAISE NOTICE 'Re-namespace #B: % órfã(s)', n;
+END
+$guard$;
+
+-- [re-namespace] restaura a identidade imutável do Omie.
+UPDATE public.sales_orders s
+SET hash_payload = 'omie_' || s.account || '_' || s.omie_pedido_id
+FROM _b_orfaos o
+WHERE s.id = o.id;
+
+-- [post] 0 órfãs de-namespaced restantes (defesa anti-engano).
+DO $post$
+DECLARE d int;
+BEGIN
+  SELECT count(*) INTO d
+  FROM public.sales_orders s
+  WHERE s.hash_payload IS NOT NULL
+    AND s.hash_payload NOT LIKE 'omie\_%'
+    AND s.omie_pedido_id IS NOT NULL
+    AND NOT EXISTS (
+      SELECT 1 FROM public.sales_orders b
+      WHERE b.account = s.account AND b.omie_pedido_id = s.omie_pedido_id
+        AND b.hash_payload LIKE 'omie\_%'
+    );
+  IF d > 0 THEN
+    RAISE EXCEPTION 'Re-namespace #B postcondition FALHOU: % órfã(s) de-namespaced restante(s)', d;
+  END IF;
+  RAISE NOTICE 'Re-namespace #B postcondition OK: 0 órfãs restantes';
+END
+$post$;
+
+COMMIT;


### PR DESCRIPTION
## #B — conserto da RAIZ (edge `sync-reprocess`) + heal das 4 órfãs

Sequência do #B: PR #943 (cleanup, já em prod) parou a hemorragia; **este PR conserta a raiz** para poder religar o reprocess sem re-sujar, e cura as 4 órfãs residuais.

### O bug (causa-raiz)
`reprocessOrders` era uma 2ª implementação **divergente** do write de pedido: reescrevia `sales_orders.hash_payload` de identidade `omie_<acc>_<pid>` → hash de **conteúdo** → a linha saía do índice parcial → o `omie-vendas-sync` re-inseria → **dups** que inflavam positivação/comissão. Tinha ainda o **mapa de status invertido** (`60→cancelado`/`50→faturado`) e total **sem desconto**.

### O conserto
- **Nunca mais** toca `hash_payload`/`omie_pedido_id`; acha o pai por hash de **identidade**.
- **Canon compartilhado** [`_shared/omie-pedido.ts`](../blob/feat/b-edge-fix-sync-reprocess/supabase/functions/_shared/omie-pedido.ts) (deno test, 8 verdes): `etapa→status` **igual ao sync**, subtotal-com-desconto (`||` igual ao sync), `construirItemsJson` (rebuild de `items`-jsonb com cor de tinta), `diffOrderItens` (insere/atualiza/**deleta removido**; grava hash de identidade no item).
- **Guards (achados Codex challenge A1–A7):** skip em leitura vazia/malformada (não zera pedido real); status só reconcilia com **etapa conhecida** + status local **gerido pelo Omie** (não rebaixa p/ `importado`, não clobbera `confirmado`/`entregue`); **SKU repetido** pula reconcile de itens; **itens antes do cabeçalho** com checagem de erro por write; `falhas`/`skuRepetido` em `error_message` (não mente `complete`). Removeu o `sph`-write (writer único = o sync).

### Heal das 4 órfãs
`20260618210000_b_renamespace_orfaos.sql` — **re-namespace** (não-destrutivo, restaura a identidade), **provado em PG17** (`db/test-b-renamespace-orfaos.sh`: 13 asserts + 3 falsificações). O reprocess consertado reconcilia o status pela **etapa atual do Omie** (source-truth). Escolhido sobre delete-and-resync (Codex challenge → re-confirm aceitou): diferencial inerte + delete de órfã dependeria de resync por janela de **previsão**.

### Validação
deno check · eslint (gate CI) · canon 8 testes · harness PG17 13/3 · Codex challenge + re-confirm ("limpo o suficiente para o #B root fix").

---
### ⚠️ MANUAL no Lovable — **NESTA ORDEM** (merge ≠ produção)
1. **SQL Editor** → colar `supabase/migrations/20260618210000_b_renamespace_orfaos.sql` (destrava o índice/landmine das 4 órfãs; não-destrutivo).
2. **Deploy do edge** `sync-reprocess` pelo chat do Lovable (inclui o `_shared/omie-pedido.ts` importado).
3. **Religar o reprocess** — SÓ DEPOIS do deploy: `UPDATE sync_reprocess_config SET value=1 WHERE key IN ('operational_enabled','strategic_enabled')`. (Religar antes do deploy = o reprocess velho re-suja.)
4. **Verificar**: rodar `reprocess_orders` oben → as 4 órfãs viram `faturado` (etapa atual), `skuRepetido=0`, 0 dups residuais.

🤖 Generated with [Claude Code](https://claude.com/claude-code)