### PR TITLE
fix(valor-cockpit): custo_proxy — proveniência do custo no EVP (v2 do #953)

### DIFF
--- a/docs/superpowers/specs/2026-06-18-valor-cockpit-cost-final-contract-design.md
+++ b/docs/superpowers/specs/2026-06-18-valor-cockpit-cost-final-contract-design.md
@@ -1,0 +1,72 @@
+# Cockpit de Valor (Oben) — proveniência do custo do EVP (v2 do #953): `custo_proxy` como eixo de incerteza
+
+> Spec/design. Money-path (EVP → recomendação comercial). Codex P2 `cost-final-ignorado`.
+> 2ª opinião: Codex (consult adversário 2026-06-18 + challenge no diff da reconciliação).
+
+## Reviravolta (por que isto é uma v2, não a correção principal)
+
+Enquanto este PR (#959) estava em voo, **sessões paralelas mergearam o núcleo na `main`**:
+
+- **#953** — `custo do EVP por cost_final (motor) com fallback cost_price`. Trocou `cost_price` (legado, sticky) por `cost_final` (vivo) com fallback. +R$72,6k de cm corrigida. **Resolveu o núcleo do P2.** Mas o próprio commit deixou explícito: *"cost_source/cost_confidence (degradar confiança por custo-proxy: 102 DEFAULT_PROXY + 63 FAMILY_MARGIN_PROXY) ficam p/ v2 (helper espelhado + UI)"*.
+- **#958** — `cobertura bidirecional (ar_por_app + app_por_ar)`.
+- **#961** — `EVP-teto marcado` (capital ausente ≠ R$0): introduziu `evp_parcial` (EVP é teto), `cm_incompleto` (grupo com custo ausente) e `evp_teto_receita_pct` (ponderado por receita). O "Crescer / proteger" passou a sair **com ressalva** (não suprime) quando incerto.
+
+**Este PR é a v2 que o #953 prometeu** — e encaixa no padrão que o #961 estabeleceu.
+
+## Problema que sobra após #953
+
+O #953 usa `cost_final` como custo MESMO quando a proveniência é PROXY (FAMILY_MARGIN_PROXY/0.5, DEFAULT_PROXY/0.25 — custo **inventado**). Logo, ~165 SKUs do cockpit Oben entram na margem/EVP com custo-chute tratado como se fosse real: o "Crescer / proteger" pode sair limpo sobre margem fabricada, e a confiança não reflete isso.
+
+## Evidência de produção (psql-ro, 2026-06-18/19; role claude_ro)
+
+`product_costs` (universo): **1181 SKUs proxy** (905 FAMILY + 276 DEFAULT), todos com `cost_final>0`; 622 PRODUCT_COST; 1523 CMC (350 com `cost_final>0` + **1173** no fallback `cost_price`, todos CMC). Recorte cockpit/oben (do #953): 102 DEFAULT + 63 FAMILY = **~165 SKUs proxy**; **16,4% da receita** sob custo proxy; **87 de 433 clientes (20%)** com a maioria da receita sob custo não-real.
+
+→ Duas opções de v2: **(i) proxy → null** (remove → regride a cobertura que o #953 estabeleceu, esconde a margem de 20% dos clientes) ou **(ii) proxy mantém custo + marca incerto**. Escolhida **(ii)** (decisão do founder + Codex): preserva cobertura, honra money-path (chute alimenta a margem mas não vira certeza).
+
+## Decisão — `custo_proxy` como terceiro eixo de incerteza (irmão de `cm_incompleto`/`evp_teto`)
+
+### 1. `resolverCustoCockpit(row) → { custo, real }` (helper puro, espelhado verbatim no edge)
+
+```
+REAL = {PRODUCT_COST, CMC}            (cost_source normalizado: trim + upper)
+custo = finitePositive(cost_final) ? cost_final
+      : finitePositive(cost_price)  ? cost_price   (fallback legado — paridade #953, preserva cobertura)
+      : null                                        (ausente ≠ R$0)
+real  = cost_source ∈ REAL                          (proxy/UNKNOWN/sem-source → false, fail-closed)
+```
+
+O custo entra na margem **independente da proveniência** (sem regressão vs #953); `real` é a flag de qualidade. `finitePositive` rejeita ≤0/NaN/Infinity.
+
+### 2. `custo_proxy` por célula → rollup → empresa
+
+- Célula: `custo_proxy = cm != null && custo_real === false` (tem margem, mas o custo é chute). Omitir a flag ⇒ real (retrocompat).
+- Rollup (cliente/SKU/empresa): `custo_proxy` booleano se QUALQUER célula é proxy — igual ao `cm_incompleto` do #961.
+- `custo_proxy_receita_pct` = Σreceita(proxy) / Σreceita(com-cm), **ponderado por receita** (irmão do `evp_teto_receita_pct`). Célula sem custo fica fora do denominador (é `cm_incompleto`, eixo distinto).
+
+### 3. Recomendação — "Crescer / proteger" só limpo se NÃO houver proxy
+
+`recomendarAcaoComercial` ganha `custo_proxy?`. Integra à lógica de ressalva do #961: `evp>0` com proxy → "Crescer / proteger, **a confirmar**: custo estimado (proxy) em parte da carteira". **Não suprime** (preserva o sinal), **não afirma** (marca incerto). As demais regras seguem.
+
+### 4. Confiança — rebaixa por custo proxy material
+
+`scoreConfiancaCockpit` ganha `custo_proxy_receita_pct?`. `>0,15` da margem (por receita) sob proxy → rebaixa para **média**; `>0` → motivo de transparência (nunca verde mudo). Threshold alinhado ao `custo_ausente_pct`. Oben (~16%) → média, refletindo a realidade do cadastro de custo.
+
+## Riscos residuais aceitos (registrados)
+
+- **[CRÍTICO — dívida da FONTE] Proveniência lavada: proxy promovido a `PRODUCT_COST` (Codex P1).** O motor (`omie-analytics-sync` `computeCosts`) grava `cost_price` STICKY (`existing?.cost_price || costFinal`, index.ts:1067): um proxy grava seu valor em `cost_price` na 1ª run; na 2ª run esse valor passa o `sanityCheck` (index.ts:1021 — foi construído com margem plausível, então cai dentro da faixa) e é promovido a `PRODUCT_COST`/conf 0.95. Um custo inventado vira "real" → a flag `real` mente p/ esses SKUs → "Crescer" pode sair "sem alertas" sobre custo-proxy. **Pré-existente e fora do escopo:** afeta TODOS os consumidores de `cost_source` (#953, recommend, esta v2), NÃO é introduzido aqui, e a correção pertence à FONTE (money-path próprio). Esta v2 ainda melhora o consumidor (distingue os ~1181 SKUs HOJE rotulados proxy; fica robusta quando a fonte parar de lavar). → tarefa separada.
+- **Fallback amplo (paridade #953):** PRODUCT_COST com `cost_final` inválido cairia em `cost_price`. Medição: 0 casos (PRODUCT_COST sempre tem `cost_final>0`); todos os 1173 do fallback são CMC. Mantido o fallback amplo do #953 (mínima divergência); `real` é pela source, então um PRODUCT_COST-via-fallback continuaria real.
+- **P1 da v1 (margem% sobre receita-com-cm) NÃO reintroduzido:** o #961 usa `cm / receita_liquida`. Com proxy mantendo custo, a receita-sem-cm cai para ~5,4% (só sem-custo), e o `cm_incompleto` já a sinaliza. Débito menor, registrado.
+- **Threshold de proxy (0,15) e de teto (0,05) divergem:** proxy tem um número (chute), teto não tem o encargo — escolha deliberada. Codex sinalizou; defensável.
+
+## Fora de escopo (dívida colateral → tarefa separada)
+
+- **[FONTE, do Codex P1] `omie-analytics-sync` promove proxy a `PRODUCT_COST`** via `cost_price` sticky + `sanityCheck`. Lava a proveniência de TODA a escada → mina `cost_source` para todos os consumidores. Correção na fonte (parar de reusar `cost_price`-proxy como custo de produto, ou marcar a origem sticky). Money-path próprio.
+- `recommend/index.ts` e `algorithm-a-audit/index.ts` fazem `cost_final || 0` (ausência → margem cheia). Mesma régua, PR próprio.
+- O #961 mergeou **sem cobertura de mutcheck** para `evp_parcial`/`cm_incompleto`/`evp_teto`, e seu `evp_teto_receita_pct` não tem clamp [0,1] (mesma classe do P2 que clampei aqui) — oportunidade de fortalecer (não-regressão minha).
+
+## Prova & entrega
+
+- **vitest** no helper puro: `resolverCustoCockpit` (todos os branches + falsificação ≤0/NaN/Inf + normalização de source); `custo_proxy` na célula/rollup/empresa + ponderação; ressalva no "Crescer"; rebaixamento da confiança.
+- **mutcheck.d/valor-cockpit-helpers.mut**: 12 invariantes da v2 (proxy-vira-real, finitePositive, inversão real↔proxy, proxy-sem-margem, acumuladores numerador/denominador, gate, ressalva, threshold, `?? 0`-não-fabrica, clamp [0,1]). Cada mutação dá VERMELHO. Total **22/22 pegas** (com as pré-existentes).
+- **Codex challenge** (adversarial money-path): **1 P1** = proveniência lavada na FONTE (registrado como risco crítico + tarefa, fora de escopo); **2 P2 CORRIGIDOS** = clamp [0,1] do `custo_proxy_receita_pct` (receita negativa de devolução) + normalização (`trim/upper`) do warn `sourcesDesconhecidas`, coerente com o resolver.
+- Espelhar verbatim no edge. **Deploy MANUAL da edge no chat do Lovable após merge** (merge ≠ produção). Frontend não muda; o efeito propaga pelo payload (`custo_proxy_receita_pct` novo + confiança/recomendação ajustadas).

--- a/scripts/mutcheck.d/valor-cockpit-helpers.mut
+++ b/scripts/mutcheck.d/valor-cockpit-helpers.mut
@@ -20,3 +20,18 @@ PEGA | pedidoContaNoFaturamento: blocklist→allowlist (tira !)| s/return !STATU
 PEGA | evp_parcial: OU-de-pernas-ausentes vira E          | s/ar_indisponivel \|\| estoque_indisponivel/ar_indisponivel && estoque_indisponivel/
 PEGA | guard anti-piso: capital negativo entra como num   | s/Number\.isFinite\(estSraw\) && estSraw >= 0/Number.isFinite(estSraw)/
 PEGA | confianca: limiar teto-por-receita 5% afrouxa p/15%| s/tetoPct > 0\.05/tetoPct > 0.15/
+# Contrato de custo (Codex P2 cost-final-ignorado — v2 do #953): proveniência (PRODUCT_COST/CMC=real, proxy=não-real);
+# o custo PROXY MANTÉM a margem (preserva cobertura) mas degrada "Crescer"→a-confirmar + rebaixa a confiança (eixo
+# irmão do cm_incompleto/evp_teto do #961). custo_proxy_receita_pct ponderado por receita. Cada mutação deve dar VERMELHO.
+PEGA | resolverCusto: toda fonte vira real (tira a checagem de source)      | s/ && COST_SOURCES_REAIS\.has\(source\)//
+PEGA | finitePositive aceita <=0/NaN (custo 0/sujo entra na margem)         | s/Number\.isFinite\(x\) && x > 0/Number.isFinite(x)/
+PEGA | célula: custo_proxy inverte real↔proxy (=== false vira !== false)    | s/c\.custo_real === false/c.custo_real !== false/
+PEGA | célula: custo_proxy marca proxy mesmo sem margem (tira cm!=null)     | s/cm != null && c\.custo_real === false/c.custo_real === false/
+PEGA | rollup: custoProxy não acumula (grupo nunca marca proxy)             | s/if \(cel\.custo_proxy\) acc\.custoProxy = true;//
+PEGA | empresa: recProxy não acumula (numerador do proxy_pct zera)          | s/custoProxyEmp = true; recProxy \+= cel\.receita_liquida;/custoProxyEmp = true;/
+PEGA | empresa: recComCm não acumula (denominador do proxy_pct zera)        | s/cmNull = false; recComCm \+= cel\.receita_liquida;/cmNull = false;/
+PEGA | gate "Crescer" ignora custo_proxy (proxy vira "sem alertas")         | s/ && !custoProxy//
+PEGA | "Crescer": ressalva de proxy nunca adicionada                        | s/if \(custoProxy\) ressalvas\.push/if (false) ressalvas.push/
+PEGA | confiança: proxy material não rebaixa (threshold impossível)         | s/proxyPct > 0\.15/proxyPct > 1/
+PEGA | confiança: proxy ausente fabrica 100% (?? 0 vira ?? 1)               | s/input\.custo_proxy_receita_pct \?\? 0/input.custo_proxy_receita_pct ?? 1/
+PEGA | proxy_pct sem clamp [0,1] (receita negativa estoura — Codex P2)       | s/Math\.max\(0, Math\.min\(1, recProxy \/ recComCm\)\)/recProxy \/ recComCm/

--- a/src/lib/financeiro/__tests__/valor-cockpit-helpers.test.ts
+++ b/src/lib/financeiro/__tests__/valor-cockpit-helpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { margemContribuicao, arMedioTTM, statusLiquidadoAR, montarCelulasComboEVP, recomendarAcaoComercial, scoreConfiancaCockpit, resolverHurdleCockpit, pedidoContaNoFaturamento, tituloFaturavelAR, coberturaBidirecional } from '../valor-cockpit-helpers';
+import { margemContribuicao, arMedioTTM, statusLiquidadoAR, montarCelulasComboEVP, recomendarAcaoComercial, scoreConfiancaCockpit, resolverHurdleCockpit, pedidoContaNoFaturamento, tituloFaturavelAR, coberturaBidirecional, resolverCustoCockpit } from '../valor-cockpit-helpers';
 
 // helper de fixture: TituloAR completo com defaults (reduz ruído nos casos)
 function tit(p: Partial<Parameters<typeof arMedioTTM>[0]['titulos'][number]>) {
@@ -537,5 +537,146 @@ describe('scoreConfiancaCockpit — evp_teto_receita_pct', () => {
     const r = scoreConfiancaCockpit({ ...okBase, evp_teto_receita_pct: 0 });
     expect(r.nivel).toBe('alta');
     expect(r.motivos.some((m) => m.toLowerCase().includes('teto'))).toBe(false);
+  });
+});
+
+// ===== v2 do #953 (Codex P2 cost-final-ignorado): proveniência do custo + eixo custo_proxy =====
+describe('resolverCustoCockpit (contrato de custo — v2 do #953)', () => {
+  it('PRODUCT_COST com cost_final>0 → custo vivo, real=true', () => {
+    expect(resolverCustoCockpit({ cost_source: 'PRODUCT_COST', cost_final: 12.5, cost_price: 99 })).toEqual({ custo: 12.5, real: true });
+  });
+  it('CMC com cost_final>0 → cost_final, real=true', () => {
+    expect(resolverCustoCockpit({ cost_source: 'CMC', cost_final: 8, cost_price: 20 })).toEqual({ custo: 8, real: true });
+  });
+  it('PROXY (FAMILY_MARGIN_PROXY) com cost_final>0 → MANTÉM o custo na margem mas real=FALSE (não esconde, marca chute)', () => {
+    // caso real medido: FAMILY 81,90(price) vs 401,91(final) — proxy ~5× o custo legado
+    expect(resolverCustoCockpit({ cost_source: 'FAMILY_MARGIN_PROXY', cost_final: 401.91, cost_price: 81.9 })).toEqual({ custo: 401.91, real: false });
+  });
+  it('DEFAULT_PROXY → custo presente, real=false', () => {
+    expect(resolverCustoCockpit({ cost_source: 'DEFAULT_PROXY', cost_final: 5, cost_price: null })).toEqual({ custo: 5, real: false });
+  });
+  it('UNKNOWN / fonte nova / sem source → não-real (fail-closed); custo segue se válido', () => {
+    expect(resolverCustoCockpit({ cost_source: 'UNKNOWN', cost_final: 5, cost_price: null }).real).toBe(false);
+    expect(resolverCustoCockpit({ cost_source: 'FONTE_NOVA', cost_final: 5, cost_price: null }).real).toBe(false);
+    expect(resolverCustoCockpit({ cost_source: null, cost_final: 5, cost_price: null }).real).toBe(false);
+  });
+  it('normaliza espaço/caixa do cost_source (backfill) — "cmc " e " Product_Cost" → real', () => {
+    expect(resolverCustoCockpit({ cost_source: 'cmc ', cost_final: 8, cost_price: null }).real).toBe(true);
+    expect(resolverCustoCockpit({ cost_source: ' Product_Cost', cost_final: 8, cost_price: null }).real).toBe(true);
+  });
+  it('fallback amplo (paridade #953): cost_final inválido → cost_price; `real` é pela SOURCE, não pelo campo', () => {
+    expect(resolverCustoCockpit({ cost_source: 'CMC', cost_final: 0, cost_price: 7 })).toEqual({ custo: 7, real: true });    // os 14 SKUs CMC legado
+    expect(resolverCustoCockpit({ cost_source: 'CMC', cost_final: null, cost_price: 7 })).toEqual({ custo: 7, real: true });
+    expect(resolverCustoCockpit({ cost_source: 'DEFAULT_PROXY', cost_final: 0, cost_price: 9 })).toEqual({ custo: 9, real: false }); // proxy cai no fallback mas segue chute
+  });
+  it('FALSIFICAÇÃO: cost_final ≤0/NaN/Inf rejeitado (não vira custo 0/sujo); sem cost_price → null', () => {
+    for (const bad of [0, -5, NaN, Infinity]) {
+      expect(resolverCustoCockpit({ cost_source: 'PRODUCT_COST', cost_final: bad, cost_price: null }).custo).toBeNull();
+    }
+  });
+  it('custo ausente nos dois campos → custo null (ausente ≠ R$0); row null → {null,false}', () => {
+    expect(resolverCustoCockpit({ cost_source: 'PRODUCT_COST', cost_final: null, cost_price: null }).custo).toBeNull();
+    expect(resolverCustoCockpit(null)).toEqual({ custo: null, real: false });
+    expect(resolverCustoCockpit(undefined)).toEqual({ custo: null, real: false });
+  });
+});
+
+describe('montarCelulasComboEVP — custo_proxy (margem com custo estimado, eixo irmão do cm_incompleto)', () => {
+  const capCli = [{ cliente: 'C1', ar_medio: 600 }];
+  const capSku = [{ sku: 'S1', estoque_valor: 800 }, { sku: 'S2', estoque_valor: 400 }];
+  it('combo custo_real=false → célula custo_proxy=true, MAS margem preservada (não vira null)', () => {
+    const r = montarCelulasComboEVP({ combos: [{ cliente: 'C1', sku: 'S1', receita_liquida: 1000, quantidade: 100, custo_unitario: 6, custo_real: false }], capitalClientes: capCli, capitalSKUs: capSku, k: 0.2 });
+    expect(r.celulas[0].cm).toBe(400);            // cobertura preservada — paridade #953
+    expect(r.celulas[0].custo_proxy).toBe(true);
+  });
+  it('combo custo_real=true → custo_proxy=false; omitir a flag também → false (retrocompat)', () => {
+    const real = montarCelulasComboEVP({ combos: [{ cliente: 'C1', sku: 'S1', receita_liquida: 1000, quantidade: 100, custo_unitario: 6, custo_real: true }], capitalClientes: capCli, capitalSKUs: capSku, k: 0.2 });
+    const semFlag = montarCelulasComboEVP({ combos: [{ cliente: 'C1', sku: 'S1', receita_liquida: 1000, quantidade: 100, custo_unitario: 6 }], capitalClientes: capCli, capitalSKUs: capSku, k: 0.2 });
+    expect(real.celulas[0].custo_proxy).toBe(false);
+    expect(semFlag.celulas[0].custo_proxy).toBe(false);
+  });
+  it('custo ausente (cm null) NÃO é proxy — é cm_incompleto (eixos distintos)', () => {
+    const r = montarCelulasComboEVP({ combos: [{ cliente: 'C1', sku: 'S1', receita_liquida: 1000, quantidade: 100, custo_unitario: null, custo_real: false }], capitalClientes: capCli, capitalSKUs: capSku, k: 0.2 });
+    expect(r.celulas[0].custo_proxy).toBe(false);
+    expect(r.empresa.cm_incompleto).toBe(true);
+    expect(r.empresa.custo_proxy).toBe(false);
+  });
+  it('rollup/empresa marcam custo_proxy se QUALQUER célula é proxy', () => {
+    const r = montarCelulasComboEVP({ combos: [
+      { cliente: 'C1', sku: 'S1', receita_liquida: 1000, quantidade: 100, custo_unitario: 6, custo_real: true },
+      { cliente: 'C1', sku: 'S2', receita_liquida: 1000, quantidade: 50, custo_unitario: 10, custo_real: false },
+    ], capitalClientes: capCli, capitalSKUs: capSku, k: 0.2 });
+    expect(r.porCliente[0].custo_proxy).toBe(true);
+    expect(r.empresa.custo_proxy).toBe(true);
+  });
+  it('custo_proxy_receita_pct ponderado por receita-COM-MARGEM (proxy 1000 de 2000) = 0,5', () => {
+    const r = montarCelulasComboEVP({ combos: [
+      { cliente: 'C1', sku: 'S1', receita_liquida: 1000, quantidade: 100, custo_unitario: 6, custo_real: true },
+      { cliente: 'C1', sku: 'S2', receita_liquida: 1000, quantidade: 50, custo_unitario: 10, custo_real: false },
+    ], capitalClientes: capCli, capitalSKUs: capSku, k: 0.2 });
+    expect(r.custo_proxy_receita_pct).toBeCloseTo(0.5, 6);
+  });
+  it('célula sem custo NÃO entra no denominador (recComCm) — proxy_pct ignora a fatia ausente', () => {
+    // real 1000 + proxy 1000 + sem-custo 500 → 1000/(1000+1000)=0,5 (não /2500)
+    const r = montarCelulasComboEVP({ combos: [
+      { cliente: 'C1', sku: 'S1', receita_liquida: 1000, quantidade: 100, custo_unitario: 6, custo_real: true },
+      { cliente: 'C1', sku: 'S2', receita_liquida: 1000, quantidade: 50, custo_unitario: 10, custo_real: false },
+      { cliente: 'C1', sku: 'S3', receita_liquida: 500, quantidade: 10, custo_unitario: null, custo_real: false },
+    ], capitalClientes: capCli, capitalSKUs: [{ sku: 'S1', estoque_valor: 800 }, { sku: 'S2', estoque_valor: 400 }, { sku: 'S3', estoque_valor: 100 }], k: 0.2 });
+    expect(r.custo_proxy_receita_pct).toBeCloseTo(0.5, 6);
+  });
+  it('sem proxy → custo_proxy_receita_pct=0 e empresa.custo_proxy=false', () => {
+    const r = montarCelulasComboEVP({ combos: [{ cliente: 'C1', sku: 'S1', receita_liquida: 1000, quantidade: 100, custo_unitario: 6, custo_real: true }], capitalClientes: capCli, capitalSKUs: capSku, k: 0.2 });
+    expect(r.custo_proxy_receita_pct).toBe(0);
+    expect(r.empresa.custo_proxy).toBe(false);
+  });
+  it('clamp [0,1]: receita negativa (devolução/desconto) não estoura a fração — Codex P2', () => {
+    // proxy +1000 + real −600 (devolução) → recComCm=400, recProxy=1000 → 2,5 SEM clamp; clampado = 1
+    const acima = montarCelulasComboEVP({ combos: [
+      { cliente: 'C1', sku: 'S1', receita_liquida: 1000, quantidade: 100, custo_unitario: 6, custo_real: false },
+      { cliente: 'C1', sku: 'S2', receita_liquida: -600, quantidade: 1, custo_unitario: 10, custo_real: true },
+    ], capitalClientes: capCli, capitalSKUs: capSku, k: 0.2 });
+    expect(acima.custo_proxy_receita_pct).toBe(1);
+    // real +1000 + proxy −300 (devolução de proxy) → recComCm=700, recProxy=−300 → negativo SEM clamp; clampado = 0
+    const abaixo = montarCelulasComboEVP({ combos: [
+      { cliente: 'C1', sku: 'S1', receita_liquida: 1000, quantidade: 100, custo_unitario: 6, custo_real: true },
+      { cliente: 'C1', sku: 'S2', receita_liquida: -300, quantidade: 1, custo_unitario: 10, custo_real: false },
+    ], capitalClientes: capCli, capitalSKUs: capSku, k: 0.2 });
+    expect(abaixo.custo_proxy_receita_pct).toBe(0);
+  });
+});
+
+describe('recomendarAcaoComercial — custo_proxy (margem estimada)', () => {
+  const config = { margem_minima_pct: 0.15, desconto_max_pct: 0.10, prazo_alvo_dias: 30, dias_estoque_max: 120, sample_min_receita: 5000 };
+  it('evp>0 mas custo_proxy → "Crescer / proteger" QUALIFICADO (custo estimado a confirmar)', () => {
+    const r = recomendarAcaoComercial({ evp: 300, receita_liquida: 1000, cm: 400, desconto_total: 0, prazo_medio_dias: 0, dias_estoque: 0, config, custo_proxy: true });
+    const cresc = r.find((x) => x.acao === 'Crescer / proteger')!;
+    expect(cresc).toBeTruthy();
+    expect(cresc.motivo.toLowerCase()).toContain('proxy');
+    expect(cresc.motivo.toLowerCase()).toContain('confirmar');
+  });
+  it('evp>0 não-proxy → "Crescer / proteger" puro (sem ressalva de proxy)', () => {
+    const r = recomendarAcaoComercial({ evp: 300, receita_liquida: 1000, cm: 400, desconto_total: 0, prazo_medio_dias: 0, dias_estoque: 0, config, custo_proxy: false });
+    const cresc = r.find((x) => x.acao === 'Crescer / proteger')!;
+    expect(cresc.motivo).not.toMatch(/proxy|confirmar/i);
+  });
+});
+
+describe('scoreConfiancaCockpit — custo_proxy_receita_pct', () => {
+  const okBase = { cobertura_receita: 1, custo_ausente_pct: 0, ar_indisponivel_pct: 0, estoque_ausente_pct: 0, imposto_estimado: false };
+  it('proxy por receita > 15% → rebaixa para média + motivo (caso Oben ~16%)', () => {
+    const r = scoreConfiancaCockpit({ ...okBase, custo_proxy_receita_pct: 0.164 });
+    expect(r.nivel).toBe('media');
+    expect(r.motivos.some((m) => m.toLowerCase().includes('proxy'))).toBe(true);
+  });
+  it('0 < proxy ≤ 15% → só motivo, não rebaixa nível', () => {
+    const r = scoreConfiancaCockpit({ ...okBase, custo_proxy_receita_pct: 0.10 });
+    expect(r.nivel).toBe('alta');
+    expect(r.motivos.some((m) => m.toLowerCase().includes('proxy'))).toBe(true);
+  });
+  it('proxy = 0 → sem motivo de proxy, alta', () => {
+    const r = scoreConfiancaCockpit({ ...okBase, custo_proxy_receita_pct: 0 });
+    expect(r.nivel).toBe('alta');
+    expect(r.motivos.some((m) => m.toLowerCase().includes('proxy'))).toBe(false);
   });
 });

--- a/src/lib/financeiro/valor-cockpit-helpers.ts
+++ b/src/lib/financeiro/valor-cockpit-helpers.ts
@@ -8,6 +8,30 @@ export function margemContribuicao(input: { receita_liquida: number; custo_unita
   return Number.isFinite(m) ? m : null;
 }
 
+// Fonte do custo unitário do cockpit (Codex P2 cost-final-ignorado — v2 do #953). O motor (omie-analytics-sync
+// reprocessRecommendationCosts) grava cost_final (VIVO) + cost_source (proveniência): PRODUCT_COST/CMC = custo
+// REAL; FAMILY_MARGIN_PROXY/DEFAULT_PROXY/UNKNOWN = INVENTADO. Contrato money-path:
+//   • custo entra na margem MESMO quando proxy — preserva a cobertura que o #953 estabeleceu (proxy→null
+//     esconderia margem de 20% dos clientes); cost_final vivo preferido, fallback cost_price legado (paridade
+//     #953); <=0/NaN nos dois → custo ausente (cm null). "ausente ≠ R$0": nunca fabrica 0 como custo.
+//   • `real` marca a PROVENIÊNCIA: proxy/UNKNOWN/sem-source → false. Custo-chute alimenta a margem mas NÃO vira
+//     certeza — degrada "Crescer" p/ "a confirmar" + rebaixa a confiança (ausente ≠ fabricar CERTEZA). É o eixo
+//     irmão do evp_parcial/cm_incompleto do #961: o sinal aparece, mas marcado como otimista/incerto.
+export type CostRowCockpit = { cost_price: number | null; cost_final: number | null; cost_source: string | null };
+const COST_SOURCES_REAIS = new Set(['PRODUCT_COST', 'CMC']);
+function finitePositive(x: number | null | undefined): x is number {
+  return typeof x === 'number' && Number.isFinite(x) && x > 0;
+}
+export type CustoResolvido = { custo: number | null; real: boolean };
+export function resolverCustoCockpit(row: CostRowCockpit | null | undefined): CustoResolvido {
+  const source = row?.cost_source?.trim().toUpperCase() ?? null;        // normaliza espaço/caixa de backfill
+  const real = source != null && COST_SOURCES_REAIS.has(source);        // proxy/unknown/null/fonte nova → não-real
+  const custo = finitePositive(row?.cost_final) ? row!.cost_final       // vivo, preferido
+    : finitePositive(row?.cost_price) ? row!.cost_price                 // fallback legado (preserva cobertura — paridade #953)
+    : null;                                                             // sem custo válido → ausente (≠ R$0)
+  return { custo, real };
+}
+
 function numOrNull(x: unknown): number | null {
   if (x == null || typeof x === 'boolean' || Array.isArray(x)) return null;
   if (typeof x !== 'number' && typeof x !== 'string') return null;
@@ -135,7 +159,7 @@ export function arMedioTTM(input: { titulos: TituloAR[]; ttm_inicio: string; ttm
   return { ar_medio: soma / janelaDias, v_real, v_proxy, v_sem_fecho };
 }
 
-export type ComboInput = { cliente: string; sku: string; receita_liquida: number; quantidade: number; custo_unitario: number | null };
+export type ComboInput = { cliente: string; sku: string; receita_liquida: number; quantidade: number; custo_unitario: number | null; custo_real?: boolean };
 export type CapitalCliente = { cliente: string; ar_medio: number | null };
 export type CapitalSKU = { sku: string; estoque_valor: number | null };
 export type CelulaEVP = {
@@ -144,20 +168,25 @@ export type CelulaEVP = {
   ar_indisponivel: boolean; estoque_indisponivel: boolean;
   // EVP existe mas alguma perna de capital indisponível → encargo é piso → evp é TETO (upper bound). Codex 2026-06-18.
   evp_parcial: boolean;
+  // tem margem (cm≠null) mas o custo veio de PROXY/sem-proveniência (não PRODUCT_COST/CMC) → margem é chute. Codex P2.
+  custo_proxy: boolean;
 };
 // `encargo` = encargo de capital SÓ das células com cm conhecido (mantém a identidade evp = cm − encargo).
 // `encargo_total` = encargo de TODAS as células (inclui as de margem desconhecida) — transparência.
 // encargo/encargo_total = null quando o hurdle (k) está indisponível (ausente ≠ R$0).
 // evp_parcial = algum EVP contribuinte do grupo é teto; cm_incompleto = grupo tem célula sem custo (excluída do EVP).
-export type RollupCliente = { cliente: string; receita: number; cm: number | null; encargo: number | null; encargo_total: number | null; evp: number | null; evp_parcial: boolean; cm_incompleto: boolean };
-export type RollupSKU = { sku: string; receita: number; quantidade: number; cm: number | null; encargo: number | null; encargo_total: number | null; evp: number | null; evp_parcial: boolean; cm_incompleto: boolean };
+// custo_proxy = grupo tem célula com margem de custo PROXY (estimado, não PRODUCT_COST/CMC) — margem otimista/incerta.
+export type RollupCliente = { cliente: string; receita: number; cm: number | null; encargo: number | null; encargo_total: number | null; evp: number | null; evp_parcial: boolean; cm_incompleto: boolean; custo_proxy: boolean };
+export type RollupSKU = { sku: string; receita: number; quantidade: number; cm: number | null; encargo: number | null; encargo_total: number | null; evp: number | null; evp_parcial: boolean; cm_incompleto: boolean; custo_proxy: boolean };
 export type ComboEVPResult = {
   celulas: CelulaEVP[];
   porCliente: RollupCliente[];
   porSKU: RollupSKU[];
-  empresa: { receita: number; cm: number | null; encargo: number | null; encargo_total: number | null; evp: number | null; evp_parcial: boolean; cm_incompleto: boolean };
+  empresa: { receita: number; cm: number | null; encargo: number | null; encargo_total: number | null; evp: number | null; evp_parcial: boolean; cm_incompleto: boolean; custo_proxy: boolean };
   // [0,1] fração da receita-com-EVP cujo EVP é teto (capital não medido). Ponderado por receita, não contagem (Codex).
   evp_teto_receita_pct: number;
+  // [0,1] fração da receita-COM-MARGEM cujo custo é PROXY (estimado). Irmão do evp_teto: ponderado por receita.
+  custo_proxy_receita_pct: number;
 };
 
 export function montarCelulasComboEVP(input: {
@@ -199,17 +228,20 @@ export function montarCelulasComboEVP(input: {
     const evp = cm == null || encargo == null ? null : cm - encargo;
     // EVP existe mas alguma perna de capital indisponível → encargo é piso → evp é teto (upper bound).
     const evp_parcial = evp != null && (ar_indisponivel || estoque_indisponivel);
-    return { cliente: c.cliente, sku: c.sku, receita_liquida: c.receita_liquida, quantidade: c.quantidade, cm, a_cs, i_cs, encargo, evp, ar_indisponivel, estoque_indisponivel, evp_parcial };
+    // Tem margem, mas o custo é PROXY (estimado, custo_real===false) → margem incerta. Omitir a flag = real (retrocompat).
+    const custo_proxy = cm != null && c.custo_real === false;
+    return { cliente: c.cliente, sku: c.sku, receita_liquida: c.receita_liquida, quantidade: c.quantidade, cm, a_cs, i_cs, encargo, evp, ar_indisponivel, estoque_indisponivel, evp_parcial, custo_proxy };
   });
 
   const rollup = (keyFn: (c: CelulaEVP) => string) => {
-    const m = new Map<string, { receita: number; quantidade: number; cm: number; cmNull: boolean; encargo: number; encargoNull: boolean; encargoTotal: number; encargoTotalNull: boolean; evp: number; evpNull: boolean; evpParcial: boolean; cmIncompleto: boolean }>();
+    const m = new Map<string, { receita: number; quantidade: number; cm: number; cmNull: boolean; encargo: number; encargoNull: boolean; encargoTotal: number; encargoTotalNull: boolean; evp: number; evpNull: boolean; evpParcial: boolean; cmIncompleto: boolean; custoProxy: boolean }>();
     for (const cel of celulas) {
       const key = keyFn(cel);
-      const acc = m.get(key) ?? { receita: 0, quantidade: 0, cm: 0, cmNull: true, encargo: 0, encargoNull: true, encargoTotal: 0, encargoTotalNull: true, evp: 0, evpNull: true, evpParcial: false, cmIncompleto: false };
+      const acc = m.get(key) ?? { receita: 0, quantidade: 0, cm: 0, cmNull: true, encargo: 0, encargoNull: true, encargoTotal: 0, encargoTotalNull: true, evp: 0, evpNull: true, evpParcial: false, cmIncompleto: false, custoProxy: false };
       acc.receita += cel.receita_liquida;
       acc.quantidade += cel.quantidade;
       if (cel.cm == null) acc.cmIncompleto = true; // grupo tem célula sem margem (excluída do EVP)
+      if (cel.custo_proxy) acc.custoProxy = true;  // grupo tem célula com margem de custo proxy (estimado)
       if (cel.encargo != null) { acc.encargoTotal += cel.encargo; acc.encargoTotalNull = false; } // todas as células (null-aware)
       if (cel.cm != null) {
         acc.cm += cel.cm; acc.cmNull = false;
@@ -223,17 +255,21 @@ export function montarCelulasComboEVP(input: {
 
   const mc = rollup((c) => c.cliente);
   const ms = rollup((c) => c.sku);
-  const porCliente: RollupCliente[] = [...mc.entries()].map(([cliente, a]) => ({ cliente, receita: a.receita, cm: a.cmNull ? null : a.cm, encargo: a.encargoNull ? null : a.encargo, encargo_total: a.encargoTotalNull ? null : a.encargoTotal, evp: a.evpNull ? null : a.evp, evp_parcial: a.evpParcial, cm_incompleto: a.cmIncompleto }));
-  const porSKU: RollupSKU[] = [...ms.entries()].map(([sku, a]) => ({ sku, receita: a.receita, quantidade: a.quantidade, cm: a.cmNull ? null : a.cm, encargo: a.encargoNull ? null : a.encargo, encargo_total: a.encargoTotalNull ? null : a.encargoTotal, evp: a.evpNull ? null : a.evp, evp_parcial: a.evpParcial, cm_incompleto: a.cmIncompleto }));
+  const porCliente: RollupCliente[] = [...mc.entries()].map(([cliente, a]) => ({ cliente, receita: a.receita, cm: a.cmNull ? null : a.cm, encargo: a.encargoNull ? null : a.encargo, encargo_total: a.encargoTotalNull ? null : a.encargoTotal, evp: a.evpNull ? null : a.evp, evp_parcial: a.evpParcial, cm_incompleto: a.cmIncompleto, custo_proxy: a.custoProxy }));
+  const porSKU: RollupSKU[] = [...ms.entries()].map(([sku, a]) => ({ sku, receita: a.receita, quantidade: a.quantidade, cm: a.cmNull ? null : a.cm, encargo: a.encargoNull ? null : a.encargo, encargo_total: a.encargoTotalNull ? null : a.encargoTotal, evp: a.evpNull ? null : a.evp, evp_parcial: a.evpParcial, cm_incompleto: a.cmIncompleto, custo_proxy: a.custoProxy }));
 
   let cmEmp = 0, cmNull = true, encEmp = 0, encNull = true, encTotalEmp = 0, encTotalNull = true, evpEmp = 0, evpNull = true, recEmp = 0;
-  let evpParcialEmp = false, cmIncompletoEmp = false;
-  let recTeto = 0, recComEvp = 0; // ponderação por receita do evp_teto_receita_pct (Codex: contagem é fraca)
+  let evpParcialEmp = false, cmIncompletoEmp = false, custoProxyEmp = false;
+  let recTeto = 0, recComEvp = 0, recProxy = 0, recComCm = 0; // ponderação por receita (Codex: contagem é fraca)
   for (const cel of celulas) {
     recEmp += cel.receita_liquida;
     if (cel.cm == null) cmIncompletoEmp = true;
     if (cel.encargo != null) { encTotalEmp += cel.encargo; encTotalNull = false; }
-    if (cel.cm != null) { cmEmp += cel.cm; cmNull = false; if (cel.encargo != null) { encEmp += cel.encargo; encNull = false; } }
+    if (cel.cm != null) {
+      cmEmp += cel.cm; cmNull = false; recComCm += cel.receita_liquida;
+      if (cel.custo_proxy) { custoProxyEmp = true; recProxy += cel.receita_liquida; }
+      if (cel.encargo != null) { encEmp += cel.encargo; encNull = false; }
+    }
     if (cel.evp != null) {
       evpEmp += cel.evp; evpNull = false;
       recComEvp += cel.receita_liquida;
@@ -241,7 +277,8 @@ export function montarCelulasComboEVP(input: {
     }
   }
   const evp_teto_receita_pct = recComEvp > 0 ? recTeto / recComEvp : 0;
-  return { celulas, porCliente, porSKU, empresa: { receita: recEmp, cm: cmNull ? null : cmEmp, encargo: encNull ? null : encEmp, encargo_total: encTotalNull ? null : encTotalEmp, evp: evpNull ? null : evpEmp, evp_parcial: evpParcialEmp, cm_incompleto: cmIncompletoEmp }, evp_teto_receita_pct };
+  const custo_proxy_receita_pct = recComCm > 0 ? Math.max(0, Math.min(1, recProxy / recComCm)) : 0; // [0,1]: célula de receita negativa (devolução/desconto) não vira % absurda (Codex P2)
+  return { celulas, porCliente, porSKU, empresa: { receita: recEmp, cm: cmNull ? null : cmEmp, encargo: encNull ? null : encEmp, encargo_total: encTotalNull ? null : encTotalEmp, evp: evpNull ? null : evpEmp, evp_parcial: evpParcialEmp, cm_incompleto: cmIncompletoEmp, custo_proxy: custoProxyEmp }, evp_teto_receita_pct, custo_proxy_receita_pct };
 }
 
 export type CockpitConfig = {
@@ -264,6 +301,7 @@ export function recomendarAcaoComercial(input: {
   hurdle_indisponivel?: boolean;   // sem Ke → EVP não calculável globalmente; gateia as regras de valor
   evp_parcial?: boolean;           // EVP é teto (capital de cliente/SKU não medido) → não afirma valor positivo
   cm_incompleto?: boolean;         // grupo tem células sem custo (margem desconhecida em parte)
+  custo_proxy?: boolean;           // grupo tem margem com custo PROXY (estimado) → não afirma "Crescer" limpo
 }): Recomendacao[] {
   const r: Recomendacao[] = [];
   const c = input.config;
@@ -274,6 +312,7 @@ export function recomendarAcaoComercial(input: {
   const evpConhecivel = !input.hurdle_indisponivel;
   const evpTeto = !!input.evp_parcial;        // teto>0 NÃO é evidência de valor positivo (real ≤ teto)
   const cmIncompleto = !!input.cm_incompleto;
+  const custoProxy = !!input.custo_proxy;     // margem de custo estimado (proxy) → "Crescer" só a confirmar
   const evpNegConhecido = input.evp != null && input.evp < 0; // teto<0 ⟹ real<0 → alerta robusto
 
   // cortar desconto: desconto acima do máx e (sem hurdle OU valor não justifica OU teto não confirma)
@@ -298,14 +337,15 @@ export function recomendarAcaoComercial(input: {
   if (evpConhecivel && input.dias_estoque > c.dias_estoque_max && evpNegConhecido) {
     r.push({ acao: 'Despriorizar / liquidar estoque', motivo: `${input.dias_estoque.toFixed(0)} dias de estoque > limite ${c.dias_estoque_max}d e o item não gera valor.`, impacto_rs: null });
   }
-  // crescer: EVP positivo e nada disparou. SEM ressalva só se confiável (não-teto E cobertura de cm completa).
+  // crescer: EVP positivo e nada disparou. SEM ressalva só se confiável (não-teto E custo completo E não-proxy).
   if (r.length === 0 && input.evp != null && input.evp > 0) {
-    if (!evpTeto && !cmIncompleto) {
+    if (!evpTeto && !cmIncompleto && !custoProxy) {
       r.push({ acao: 'Crescer / proteger', motivo: 'Gera valor econômico positivo e sem alertas.', impacto_rs: null });
     } else {
       const ressalvas: string[] = [];
       if (evpTeto) ressalvas.push('capital não medido em parte da carteira (EVP é teto) — confirmar');
       if (cmIncompleto) ressalvas.push('margem desconhecida em parte (custo ausente)');
+      if (custoProxy) ressalvas.push('custo estimado (proxy) em parte da carteira — confirmar');
       r.push({ acao: 'Crescer / proteger', motivo: `Provável valor econômico positivo, a confirmar: ${ressalvas.join('; ')}.`, impacto_rs: null });
     }
   }
@@ -323,6 +363,7 @@ export function scoreConfiancaCockpit(input: {
   imposto_estimado: boolean;
   hurdle_indisponivel?: boolean; // sem Ke → EVP não calculável → confiança baixa
   evp_teto_receita_pct?: number; // [0,1] fração da receita-com-EVP cujo EVP é teto (capital não medido)
+  custo_proxy_receita_pct?: number; // [0,1] fração da receita-com-margem cujo custo é proxy (estimado) → rebaixa
   cobertura_app_por_ar?: number; // [0,1] venda app com AR faturável; <0,5 → divergência → rebaixa
 }): ConfiancaCockpit {
   const motivos: string[] = [];
@@ -336,6 +377,11 @@ export function scoreConfiancaCockpit(input: {
 
   if (input.custo_ausente_pct > 0.4) rebaixar(1, `${(input.custo_ausente_pct * 100).toFixed(0)}% das células sem custo — margem indisponível em boa parte.`);
   else if (input.custo_ausente_pct > 0.15) rebaixar(2, `${(input.custo_ausente_pct * 100).toFixed(0)}% sem custo cadastrado.`);
+  // Custo PROXY (estimado, ≠ ausente): a margem existe mas é chute. Motivo SEMPRE que >0 (nunca verde mudo);
+  // rebaixa quando material (>15% da receita-com-margem). Ponderado por receita, não contagem (irmão do teto).
+  const proxyPct = input.custo_proxy_receita_pct ?? 0;
+  if (proxyPct > 0.15) rebaixar(2, `${(proxyPct * 100).toFixed(0)}% da margem (por receita) usa custo estimado (proxy) — lucro otimista/incerto nessa fatia.`);
+  else if (proxyPct > 0) motivos.push(`${(proxyPct * 100).toFixed(0)}% da margem (por receita) usa custo estimado (proxy).`);
 
   if (input.ar_indisponivel_pct > 0.3) rebaixar(2, `${(input.ar_indisponivel_pct * 100).toFixed(0)}% das vendas sem AR vinculável — encargo de cliente subestimado.`);
   if (input.estoque_ausente_pct > 0.3) rebaixar(2, `${(input.estoque_ausente_pct * 100).toFixed(0)}% dos SKUs sem estoque — encargo de SKU subestimado.`);

--- a/supabase/functions/fin-valor-cockpit/index.ts
+++ b/supabase/functions/fin-valor-cockpit/index.ts
@@ -44,6 +44,23 @@ function margemContribuicao(input: { receita_liquida: number; custo_unitario: nu
   const m = input.receita_liquida - input.custo_unitario * input.quantidade;
   return Number.isFinite(m) ? m : null;
 }
+// Fonte do custo unitário (Codex P2 cost-final-ignorado, v2 do #953). Espelho VERBATIM de src. PRODUCT_COST/
+// CMC = custo REAL; PROXY/UNKNOWN/sem-source = não-real. custo entra na margem mesmo proxy (preserva cobertura
+// #953; cost_final vivo, fallback cost_price legado); `real` marca proveniência → proxy degrada "Crescer"+confiança.
+type CostRowCockpit = { cost_price: number | null; cost_final: number | null; cost_source: string | null };
+const COST_SOURCES_REAIS = new Set(["PRODUCT_COST", "CMC"]);
+function finitePositive(x: number | null | undefined): x is number {
+  return typeof x === "number" && Number.isFinite(x) && x > 0;
+}
+type CustoResolvido = { custo: number | null; real: boolean };
+function resolverCustoCockpit(row: CostRowCockpit | null | undefined): CustoResolvido {
+  const source = row?.cost_source?.trim().toUpperCase() ?? null;
+  const real = source != null && COST_SOURCES_REAIS.has(source);
+  const custo = finitePositive(row?.cost_final) ? row!.cost_final
+    : finitePositive(row?.cost_price) ? row!.cost_price
+    : null;
+  return { custo, real };
+}
 function numOrNull(x: unknown): number | null {
   if (x == null || typeof x === "boolean" || Array.isArray(x)) return null;
   if (typeof x !== "number" && typeof x !== "string") return null;
@@ -132,7 +149,7 @@ function arMedioTTM(input: { titulos: TituloAR[]; ttm_inicio: string; ttm_fim: s
   }
   return { ar_medio: soma / janelaDias, v_real, v_proxy, v_sem_fecho };
 }
-type ComboInput = { cliente: string; sku: string; receita_liquida: number; quantidade: number; custo_unitario: number | null };
+type ComboInput = { cliente: string; sku: string; receita_liquida: number; quantidade: number; custo_unitario: number | null; custo_real?: boolean };
 type CapitalCliente = { cliente: string; ar_medio: number | null };
 type CapitalSKU = { sku: string; estoque_valor: number | null };
 function montarCelulasComboEVP(input: { combos: ComboInput[]; capitalClientes: CapitalCliente[]; capitalSKUs: CapitalSKU[]; k: number | null }) {
@@ -160,16 +177,18 @@ function montarCelulasComboEVP(input: { combos: ComboInput[]; capitalClientes: C
     const encargo: number | null = k == null ? null : k * (a_cs + i_cs);
     const evp = cm == null || encargo == null ? null : cm - encargo;
     const evp_parcial = evp != null && (ar_indisponivel || estoque_indisponivel); // teto: encargo é piso
-    return { cliente: c.cliente, sku: c.sku, receita_liquida: c.receita_liquida, quantidade: c.quantidade, cm, a_cs, i_cs, encargo, evp, ar_indisponivel, estoque_indisponivel, evp_parcial };
+    const custo_proxy = cm != null && c.custo_real === false; // margem com custo proxy (estimado); omitir flag = real
+    return { cliente: c.cliente, sku: c.sku, receita_liquida: c.receita_liquida, quantidade: c.quantidade, cm, a_cs, i_cs, encargo, evp, ar_indisponivel, estoque_indisponivel, evp_parcial, custo_proxy };
   });
   type Cel = typeof celulas[number];
   const rollup = (keyFn: (c: Cel) => string) => {
-    const m = new Map<string, { receita: number; quantidade: number; cm: number; cmNull: boolean; encargo: number; encargoNull: boolean; encargoTotal: number; encargoTotalNull: boolean; evp: number; evpNull: boolean; evpParcial: boolean; cmIncompleto: boolean }>();
+    const m = new Map<string, { receita: number; quantidade: number; cm: number; cmNull: boolean; encargo: number; encargoNull: boolean; encargoTotal: number; encargoTotalNull: boolean; evp: number; evpNull: boolean; evpParcial: boolean; cmIncompleto: boolean; custoProxy: boolean }>();
     for (const cel of celulas) {
       const key = keyFn(cel);
-      const acc = m.get(key) ?? { receita: 0, quantidade: 0, cm: 0, cmNull: true, encargo: 0, encargoNull: true, encargoTotal: 0, encargoTotalNull: true, evp: 0, evpNull: true, evpParcial: false, cmIncompleto: false };
+      const acc = m.get(key) ?? { receita: 0, quantidade: 0, cm: 0, cmNull: true, encargo: 0, encargoNull: true, encargoTotal: 0, encargoTotalNull: true, evp: 0, evpNull: true, evpParcial: false, cmIncompleto: false, custoProxy: false };
       acc.receita += cel.receita_liquida; acc.quantidade += cel.quantidade;
       if (cel.cm == null) acc.cmIncompleto = true;
+      if (cel.custo_proxy) acc.custoProxy = true;
       if (cel.encargo != null) { acc.encargoTotal += cel.encargo; acc.encargoTotalNull = false; }
       if (cel.cm != null) { acc.cm += cel.cm; acc.cmNull = false; if (cel.encargo != null) { acc.encargo += cel.encargo; acc.encargoNull = false; } }
       if (cel.evp != null) { acc.evp += cel.evp; acc.evpNull = false; if (cel.evp_parcial) acc.evpParcial = true; }
@@ -179,17 +198,18 @@ function montarCelulasComboEVP(input: { combos: ComboInput[]; capitalClientes: C
   };
   const mc = rollup((c) => c.cliente);
   const ms = rollup((c) => c.sku);
-  const porCliente = [...mc.entries()].map(([cliente, a]) => ({ cliente, receita: a.receita, cm: a.cmNull ? null : a.cm, encargo: a.encargoNull ? null : a.encargo, encargo_total: a.encargoTotalNull ? null : a.encargoTotal, evp: a.evpNull ? null : a.evp, evp_parcial: a.evpParcial, cm_incompleto: a.cmIncompleto }));
-  const porSKU = [...ms.entries()].map(([sku, a]) => ({ sku, receita: a.receita, quantidade: a.quantidade, cm: a.cmNull ? null : a.cm, encargo: a.encargoNull ? null : a.encargo, encargo_total: a.encargoTotalNull ? null : a.encargoTotal, evp: a.evpNull ? null : a.evp, evp_parcial: a.evpParcial, cm_incompleto: a.cmIncompleto }));
+  const porCliente = [...mc.entries()].map(([cliente, a]) => ({ cliente, receita: a.receita, cm: a.cmNull ? null : a.cm, encargo: a.encargoNull ? null : a.encargo, encargo_total: a.encargoTotalNull ? null : a.encargoTotal, evp: a.evpNull ? null : a.evp, evp_parcial: a.evpParcial, cm_incompleto: a.cmIncompleto, custo_proxy: a.custoProxy }));
+  const porSKU = [...ms.entries()].map(([sku, a]) => ({ sku, receita: a.receita, quantidade: a.quantidade, cm: a.cmNull ? null : a.cm, encargo: a.encargoNull ? null : a.encargo, encargo_total: a.encargoTotalNull ? null : a.encargoTotal, evp: a.evpNull ? null : a.evp, evp_parcial: a.evpParcial, cm_incompleto: a.cmIncompleto, custo_proxy: a.custoProxy }));
   let cmEmp = 0, cmNull = true, encEmp = 0, encNull = true, encTotalEmp = 0, encTotalNull = true, evpEmp = 0, evpNull = true, recEmp = 0;
-  let evpParcialEmp = false, cmIncompletoEmp = false, recTeto = 0, recComEvp = 0;
-  for (const cel of celulas) { recEmp += cel.receita_liquida; if (cel.cm == null) cmIncompletoEmp = true; if (cel.encargo != null) { encTotalEmp += cel.encargo; encTotalNull = false; } if (cel.cm != null) { cmEmp += cel.cm; cmNull = false; if (cel.encargo != null) { encEmp += cel.encargo; encNull = false; } } if (cel.evp != null) { evpEmp += cel.evp; evpNull = false; recComEvp += cel.receita_liquida; if (cel.evp_parcial) { evpParcialEmp = true; recTeto += cel.receita_liquida; } } }
+  let evpParcialEmp = false, cmIncompletoEmp = false, custoProxyEmp = false, recTeto = 0, recComEvp = 0, recProxy = 0, recComCm = 0;
+  for (const cel of celulas) { recEmp += cel.receita_liquida; if (cel.cm == null) cmIncompletoEmp = true; if (cel.encargo != null) { encTotalEmp += cel.encargo; encTotalNull = false; } if (cel.cm != null) { cmEmp += cel.cm; cmNull = false; recComCm += cel.receita_liquida; if (cel.custo_proxy) { custoProxyEmp = true; recProxy += cel.receita_liquida; } if (cel.encargo != null) { encEmp += cel.encargo; encNull = false; } } if (cel.evp != null) { evpEmp += cel.evp; evpNull = false; recComEvp += cel.receita_liquida; if (cel.evp_parcial) { evpParcialEmp = true; recTeto += cel.receita_liquida; } } }
   const evp_teto_receita_pct = recComEvp > 0 ? recTeto / recComEvp : 0;
-  return { celulas, porCliente, porSKU, empresa: { receita: recEmp, cm: cmNull ? null : cmEmp, encargo: encNull ? null : encEmp, encargo_total: encTotalNull ? null : encTotalEmp, evp: evpNull ? null : evpEmp, evp_parcial: evpParcialEmp, cm_incompleto: cmIncompletoEmp }, evp_teto_receita_pct };
+  const custo_proxy_receita_pct = recComCm > 0 ? Math.max(0, Math.min(1, recProxy / recComCm)) : 0; // [0,1]: célula de receita negativa não vira % absurda (Codex P2)
+  return { celulas, porCliente, porSKU, empresa: { receita: recEmp, cm: cmNull ? null : cmEmp, encargo: encNull ? null : encEmp, encargo_total: encTotalNull ? null : encTotalEmp, evp: evpNull ? null : evpEmp, evp_parcial: evpParcialEmp, cm_incompleto: cmIncompletoEmp, custo_proxy: custoProxyEmp }, evp_teto_receita_pct, custo_proxy_receita_pct };
 }
 type CockpitConfig = { margem_minima_pct: number; desconto_max_pct: number; prazo_alvo_dias: number; dias_estoque_max: number; sample_min_receita: number };
 type Recomendacao = { acao: string; motivo: string; impacto_rs: number | null };
-function recomendarAcaoComercial(input: { evp: number | null; receita_liquida: number; cm: number | null; desconto_total: number; prazo_medio_dias: number; dias_estoque: number; config: CockpitConfig; hurdle_indisponivel?: boolean; evp_parcial?: boolean; cm_incompleto?: boolean }): Recomendacao[] {
+function recomendarAcaoComercial(input: { evp: number | null; receita_liquida: number; cm: number | null; desconto_total: number; prazo_medio_dias: number; dias_estoque: number; config: CockpitConfig; hurdle_indisponivel?: boolean; evp_parcial?: boolean; cm_incompleto?: boolean; custo_proxy?: boolean }): Recomendacao[] {
   const r: Recomendacao[] = []; const c = input.config;
   const receitaBruta = input.receita_liquida + input.desconto_total;
   const descontoPct = receitaBruta > 0 ? input.desconto_total / receitaBruta : 0;
@@ -197,6 +217,7 @@ function recomendarAcaoComercial(input: { evp: number | null; receita_liquida: n
   const evpConhecivel = !input.hurdle_indisponivel;
   const evpTeto = !!input.evp_parcial;
   const cmIncompleto = !!input.cm_incompleto;
+  const custoProxy = !!input.custo_proxy;
   const evpNegConhecido = input.evp != null && input.evp < 0;
   if (descontoPct > c.desconto_max_pct && (!evpConhecivel || input.evp == null || input.evp <= 0 || evpTeto)) {
     const motivo = !evpConhecivel
@@ -210,13 +231,13 @@ function recomendarAcaoComercial(input: { evp: number | null; receita_liquida: n
   if (cmPct != null && cmPct < c.margem_minima_pct) r.push({ acao: "Subir preço", motivo: `Margem ${(cmPct * 100).toFixed(0)}% < mínima ${(c.margem_minima_pct * 100).toFixed(0)}%.`, impacto_rs: Math.max(0, c.margem_minima_pct * input.receita_liquida - (input.cm as number)) });
   if (evpConhecivel && input.dias_estoque > c.dias_estoque_max && evpNegConhecido) r.push({ acao: "Despriorizar / liquidar estoque", motivo: `${input.dias_estoque.toFixed(0)} dias de estoque > limite ${c.dias_estoque_max}d e o item não gera valor.`, impacto_rs: null });
   if (r.length === 0 && input.evp != null && input.evp > 0) {
-    if (!evpTeto && !cmIncompleto) r.push({ acao: "Crescer / proteger", motivo: "Gera valor econômico positivo e sem alertas.", impacto_rs: null });
-    else { const ressalvas: string[] = []; if (evpTeto) ressalvas.push("capital não medido em parte da carteira (EVP é teto) — confirmar"); if (cmIncompleto) ressalvas.push("margem desconhecida em parte (custo ausente)"); r.push({ acao: "Crescer / proteger", motivo: `Provável valor econômico positivo, a confirmar: ${ressalvas.join("; ")}.`, impacto_rs: null }); }
+    if (!evpTeto && !cmIncompleto && !custoProxy) r.push({ acao: "Crescer / proteger", motivo: "Gera valor econômico positivo e sem alertas.", impacto_rs: null });
+    else { const ressalvas: string[] = []; if (evpTeto) ressalvas.push("capital não medido em parte da carteira (EVP é teto) — confirmar"); if (cmIncompleto) ressalvas.push("margem desconhecida em parte (custo ausente)"); if (custoProxy) ressalvas.push("custo estimado (proxy) em parte da carteira — confirmar"); r.push({ acao: "Crescer / proteger", motivo: `Provável valor econômico positivo, a confirmar: ${ressalvas.join("; ")}.`, impacto_rs: null }); }
   }
   // aviso de hurdle ausente vive na confiança + banner da UI (NÃO por cliente — vazaria pro A4).
   return r;
 }
-function scoreConfiancaCockpit(input: { cobertura_receita: number; custo_ausente_pct: number; ar_indisponivel_pct: number; estoque_ausente_pct: number; imposto_estimado: boolean; hurdle_indisponivel?: boolean; evp_teto_receita_pct?: number; cobertura_app_por_ar?: number }) {
+function scoreConfiancaCockpit(input: { cobertura_receita: number; custo_ausente_pct: number; ar_indisponivel_pct: number; estoque_ausente_pct: number; imposto_estimado: boolean; hurdle_indisponivel?: boolean; evp_teto_receita_pct?: number; custo_proxy_receita_pct?: number; cobertura_app_por_ar?: number }) {
   const motivos: string[] = []; let nivel = 3;
   const rebaixar = (para: number, m: string) => { if (para < nivel) nivel = para; motivos.push(m); };
   if (input.hurdle_indisponivel) rebaixar(1, "Sem Ke/hurdle configurado — lucro econômico (EVP) indisponível; configure em /financeiro/valor.");
@@ -225,6 +246,9 @@ function scoreConfiancaCockpit(input: { cobertura_receita: number; custo_ausente
   if (input.cobertura_app_por_ar != null && input.cobertura_app_por_ar < 0.5) rebaixar(2, `${((1 - input.cobertura_app_por_ar) * 100).toFixed(0)}% da venda do app sem AR faturável — encargo de cliente subestimado; possível divergência app↔financeiro.`);
   if (input.custo_ausente_pct > 0.4) rebaixar(1, `${(input.custo_ausente_pct * 100).toFixed(0)}% das células sem custo — margem indisponível em boa parte.`);
   else if (input.custo_ausente_pct > 0.15) rebaixar(2, `${(input.custo_ausente_pct * 100).toFixed(0)}% sem custo cadastrado.`);
+  const proxyPct = input.custo_proxy_receita_pct ?? 0;
+  if (proxyPct > 0.15) rebaixar(2, `${(proxyPct * 100).toFixed(0)}% da margem (por receita) usa custo estimado (proxy) — lucro otimista/incerto nessa fatia.`);
+  else if (proxyPct > 0) motivos.push(`${(proxyPct * 100).toFixed(0)}% da margem (por receita) usa custo estimado (proxy).`);
   if (input.ar_indisponivel_pct > 0.3) rebaixar(2, `${(input.ar_indisponivel_pct * 100).toFixed(0)}% das vendas sem AR vinculável — encargo de cliente subestimado.`);
   if (input.estoque_ausente_pct > 0.3) rebaixar(2, `${(input.estoque_ausente_pct * 100).toFixed(0)}% dos SKUs sem estoque — encargo de SKU subestimado.`);
   const tetoPct = input.evp_teto_receita_pct ?? 0;
@@ -345,22 +369,19 @@ serve(async (req: Request) => {
     // Mapas de apoio (paginados, sem .in para evitar URL gigante + truncamento)
     const clientesAll = await fetchAll<{ user_id: string; omie_codigo_cliente: number }>((f, t) => db.from("omie_clientes").select("user_id, omie_codigo_cliente").order("id", { ascending: true }).range(f, t), "omie_clientes");
     const userToOmie = new Map(clientesAll.map((c) => [c.user_id, String(c.omie_codigo_cliente)]));
-    // Custo canônico = cost_final (saída do motor de custo, MESMA fonte que o recommend usa p/ margem). Fallback
-    // p/ cost_price (legado) quando cost_final é ausente OU inválido (<=0/NaN) — preserva cobertura (14 SKUs Oben
-    // têm cost_final inválido mas cost_price real >0, psql-ro 2026-06-18). ausente≠zero: nunca usa 0 como custo
-    // real; <=0/null nos DOIS → SKU sem custo (cm null no combo). Codex P2: o fallback em cost_final INVÁLIDO (não
-    // só ausente) é INTENCIONAL (cost_price é custo real legado, dropar esconderia margem real) mas OBSERVÁVEL via
-    // warn — não-silencioso. cost_source/cost_confidence (degradar confiança por custo-proxy) ficam p/ v2 (helper
-    // espelhado + UI).
-    const custosAll = await fetchAll<{ product_id: string; cost_final: number | null; cost_price: number | null }>((f, t) => db.from("product_costs").select("product_id, cost_final, cost_price").order("id", { ascending: true }).range(f, t), "product_costs");
-    const custoValido = (x: number | null): number | null => (typeof x === "number" && Number.isFinite(x) && x > 0 ? x : null);
-    const custoPorProduto = new Map<string, number>();
-    let custoLegadoFallback = 0;
-    for (const c of custosAll) {
-      const canonico = custoValido(c.cost_final);
-      const custo = canonico ?? custoValido(c.cost_price);
-      if (custo != null) { custoPorProduto.set(c.product_id, custo); if (canonico == null) custoLegadoFallback++; }
-    }
+    // Custo do EVP via resolverCustoCockpit (v2 do #953): cost_final vivo, fallback cost_price legado; PROXY
+    // (FAMILY_MARGIN_PROXY/DEFAULT_PROXY) MANTÉM o custo na margem (preserva cobertura — paridade #953) mas marca
+    // custo_real=false → degrada "Crescer"→a-confirmar + rebaixa a confiança (NÃO esconde o SKU). ausente≠R$0:
+    // <=0/null nos dois → custo ausente (cm null). Observabilidade não-silenciosa (Codex): fonte nova não-mapeada
+    // → não-real (fail-closed); nº de SKUs no fallback legado logado.
+    const custosAll = await fetchAll<{ product_id: string } & CostRowCockpit>((f, t) => db.from("product_costs").select("product_id, cost_final, cost_price, cost_source").order("id", { ascending: true }).range(f, t), "product_costs");
+    const custoRowPorProduto = new Map(custosAll.map((c) => [c.product_id, c]));
+    const SOURCES_CONHECIDAS = new Set(["PRODUCT_COST", "CMC", "FAMILY_MARGIN_PROXY", "DEFAULT_PROXY", "UNKNOWN"]);
+    // Normaliza igual ao resolver (trim/upper) antes de checar — senão "cmc " logaria como desconhecido enquanto
+    // o resolver o trata como real (warn mentiria; Codex P2). Mantém o valor CRU no log p/ o operador ver o banco.
+    const sourcesDesconhecidas = [...new Set(custosAll.map((c) => c.cost_source).filter((s): s is string => s != null && !SOURCES_CONHECIDAS.has(s.trim().toUpperCase())))];
+    if (sourcesDesconhecidas.length > 0) console.warn(`[ValorCockpit][${COMPANY}] cost_source desconhecido(s) tratado(s) como custo não-real: ${sourcesDesconhecidas.join(", ")}`);
+    const custoLegadoFallback = custosAll.filter((c) => !finitePositive(c.cost_final) && finitePositive(c.cost_price)).length;
     if (custoLegadoFallback > 0) console.warn(`[ValorCockpit][${COMPANY}] ${custoLegadoFallback} SKUs com cost_final ausente/inválido → fallback p/ cost_price legado`);
     // Estoque com PONTE DE CONTAS (paridade com get_preco_cockpit / cockpit_preco_fixes): inventory_position
     // guarda o MESMO SKU em 'vendas' (conta Omie crua, omie-analytics-sync) e 'oben' (empresa, sync-reprocess)
@@ -398,7 +419,10 @@ serve(async (req: Request) => {
       acc.receita += receita; acc.qtd += l.quantity; acc.desconto += (l.discount ?? 0);
       comboMap.set(key, acc);
     }
-    const combos: ComboInput[] = [...comboMap.values()].map((c) => ({ cliente: c.cliente, sku: c.sku, receita_liquida: c.receita, quantidade: c.qtd, custo_unitario: c.product_id ? (custoPorProduto.get(c.product_id) ?? null) : null }));
+    const combos: ComboInput[] = [...comboMap.values()].map((c) => {
+      const resolved = c.product_id ? resolverCustoCockpit(custoRowPorProduto.get(c.product_id) ?? null) : { custo: null, real: false };
+      return { cliente: c.cliente, sku: c.sku, receita_liquida: c.receita, quantidade: c.qtd, custo_unitario: resolved.custo, custo_real: resolved.real };
+    });
 
     // AR da Oben relevante à janela (emitido na janela OU ainda em aberto) — serve p/ AR por cliente e cobertura.
     type CR = { omie_codigo_cliente: number | null; omie_codigo_lancamento: number | null; valor_documento: number; saldo: number; valor_recebido: number; data_emissao: string | null; data_vencimento: string | null; status_titulo: string };
@@ -455,7 +479,7 @@ serve(async (req: Request) => {
     for (const c of [...comboMap.values()]) descontoPorCliente.set(c.cliente, (descontoPorCliente.get(c.cliente) ?? 0) + c.desconto);
     const recomendacoesCliente = res.porCliente.map((rc) => ({
       cliente: rc.cliente,
-      recomendacoes: recomendarAcaoComercial({ evp: rc.evp, receita_liquida: rc.receita, cm: rc.cm, desconto_total: descontoPorCliente.get(rc.cliente) ?? 0, prazo_medio_dias: 0, dias_estoque: 0, config, hurdle_indisponivel, evp_parcial: rc.evp_parcial, cm_incompleto: rc.cm_incompleto }),
+      recomendacoes: recomendarAcaoComercial({ evp: rc.evp, receita_liquida: rc.receita, cm: rc.cm, desconto_total: descontoPorCliente.get(rc.cliente) ?? 0, prazo_medio_dias: 0, dias_estoque: 0, config, hurdle_indisponivel, evp_parcial: rc.evp_parcial, cm_incompleto: rc.cm_incompleto, custo_proxy: rc.custo_proxy }),
     }));
 
     const total = res.celulas.length || 1;
@@ -473,7 +497,7 @@ serve(async (req: Request) => {
     const arTotal = crsAll.filter((cr) => cr.data_emissao != null && cr.data_emissao >= ttm_inicio && tituloFaturavelAR(cr.status_titulo)).reduce((s, cr) => s + (cr.valor_documento || 0), 0);
     const { ar_por_app, app_por_ar } = coberturaBidirecional({ receita: res.empresa.receita, arFaturavel: arTotal });
     const cobertura_receita = ar_por_app; // retrocompat: mesmo valor de antes
-    const confianca = scoreConfiancaCockpit({ cobertura_receita, cobertura_app_por_ar: app_por_ar, custo_ausente_pct, ar_indisponivel_pct, estoque_ausente_pct, imposto_estimado: true, hurdle_indisponivel, evp_teto_receita_pct: res.evp_teto_receita_pct });
+    const confianca = scoreConfiancaCockpit({ cobertura_receita, cobertura_app_por_ar: app_por_ar, custo_ausente_pct, ar_indisponivel_pct, estoque_ausente_pct, imposto_estimado: true, hurdle_indisponivel, evp_teto_receita_pct: res.evp_teto_receita_pct, custo_proxy_receita_pct: res.custo_proxy_receita_pct });
 
     return jsonResponse({
       company: COMPANY, k, hurdle_indisponivel, ttm: { inicio: ttm_inicio, fim: ttm_fim },
@@ -481,6 +505,7 @@ serve(async (req: Request) => {
       recomendacoesCliente, confianca, cobertura_receita, cobertura_app_por_ar: app_por_ar,
       cobertura_baixa_ar: coberturaBaixaAR, // Fase 3: fração da AR liquidada com baixa derivada REAL (vs vencimento-proxy)
       evp_teto_receita_pct: res.evp_teto_receita_pct, // fração da receita-com-EVP cujo EVP é teto (UI entrega 2)
+      custo_proxy_receita_pct: res.custo_proxy_receita_pct, // fração da margem (por receita) com custo proxy (estimado)
       config,
     }, 200);
   } catch (e) {


### PR DESCRIPTION
## O quê

Adiciona o eixo **`custo_proxy`** ao cockpit de valor (Oben) — a **v2 que o #953 prometeu** (Codex P2 `cost-final-ignorado`). O #953 passou a usar `cost_final`, mas trata custo **PROXY** (`FAMILY_MARGIN_PROXY`/`DEFAULT_PROXY` = inventado) como real. Esta v2:

- **`resolverCustoCockpit(row) → {custo, real}`**: `cost_final` vivo, fallback `cost_price` legado (paridade #953); `real = cost_source ∈ {PRODUCT_COST, CMC}` (normalizado `trim/upper`).
- O custo proxy **mantém a margem** (preserva a cobertura que o #953 estabeleceu — `proxy→null` esconderia a margem de ~20% dos clientes) mas é marcado `custo_real=false` → vira `custo_proxy`, **eixo irmão do `cm_incompleto`/`evp_teto` do #961**.
- **"Crescer / proteger"** com proxy sai **"a confirmar"** (ressalva, não suprime); **confiança** rebaixa por `custo_proxy_receita_pct` (ponderado por receita, clampado `[0,1]`).
- Espelhado **VERBATIM** na edge Deno (`deno check` verde).

## Reviravolta (por que é v2, não a correção principal)

Em voo, sessões paralelas mergearam o núcleo: **#953** (cost_final), **#958** (cobertura bidirecional), **#961** (EVP-teto / `cm_incompleto`). Rebaseado sobre `main` (até #966); o conflito de mutcheck com **#965** foi reconciliado (3 mutações EVP-teto do #965 + 12 da v2 + 11 base = **26**).

## Prova (money-path; `prove-sql` não se aplica a edge TS)

- **vitest 106** (resolver: branches + falsificação ≤0/NaN/Inf + normalização; `custo_proxy` célula/rollup/empresa + ponderação + clamp; ressalva; confiança)
- **mutcheck 26/26 pegas · 0 sobreviventes · 0 inválidas**
- **typecheck 0 · deno check edge 0 · lint 0**

## Codex challenge (adversarial)

- **2 P2 CORRIGIDOS**: clamp `[0,1]` do `custo_proxy_receita_pct` (receita negativa de devolução não vira % absurda); normalização `trim/upper` do warn `sourcesDesconhecidas` coerente com o resolver.
- **1 P1 — dívida da FONTE, fora de escopo**: `omie-analytics-sync` promove proxy → `PRODUCT_COST` via `cost_price` sticky + `sanityCheck` (lava a proveniência). Pré-existente, afeta TODOS os consumidores de `cost_source` (#953, recommend, esta v2). Registrado na spec + tarefa separada.

## ⚠️ Deploy (3 camadas manuais — merge ≠ produção)

Só a **edge `fin-valor-cockpit`** muda. Após merge: **deploy MANUAL da edge no chat do Lovable** (ler do repo, verbatim). Sem migration; frontend não muda (efeito propaga pelo payload: `custo_proxy_receita_pct` novo + recomendação/confiança ajustadas).

**DRAFT de propósito** (gate humano money-path). Tirar do draft → auto-merge no CI verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
