### PR TITLE
chore(db): regenera schema-snapshot.sql — estava gravemente stale (23.7k→35.4k linhas)

### DIFF
--- a/supabase/schema-snapshot.manifest.md
+++ b/supabase/schema-snapshot.manifest.md
@@ -4,27 +4,29 @@
 
 | Campo | Valor |
 |---|---|
-| Gerado em | 2026-05-24 |
-| Fonte | produção (Supabase Lovable, `fzvklzpomgnyikkfkzai`) |
+| Gerado em | 2026-06-19 |
+| Fonte | produção (Supabase Lovable, `fzvklzpomgnyikkfkzai`) — regen via `~/.config/afiacao/psql-ro` (`claude_ro`, read-only, pooler eu-west-1); **escopo-equivalente** ao dump do Lovable (mesmos flags), validado por composição + remoções confirmadas em prod |
 | Versão do banco | PostgreSQL 17.6 |
-| pg_dump | 17.9 |
+| pg_dump | 17.10 |
 | Flags | `--schema-only --schema=public --no-owner --no-privileges` |
-| Linhas do arquivo | 23.745 |
-| Tamanho | ~838 KB |
+| Linhas do arquivo | 35.366 |
+| Tamanho | ~1,3 MB |
+
+> **Geração anterior (2026-05-24, pg_dump 17.9, 23.745 linhas) estava gravemente stale:** faltavam ~60 tabelas, ~124 funções, ~105 policies criadas por migrations posteriores. As ~16 policies + 1 matview que "sumiram" nesta geração são **remoções reais** em prod (o hardening de RLS substituiu as policies amplas `"Staff can manage …"` pelas granulares por carteira; matview `mv_sku_ranking_negociacao_paralela` dropada) — confirmado via psql-ro.
 
 ## Contagens por tipo (schema `public`)
 
 | Objeto | Quantidade |
 |---|---:|
-| `CREATE TABLE` | 212 |
-| `CREATE VIEW` | 37 |
-| `CREATE MATERIALIZED VIEW` | 4 |
-| `CREATE FUNCTION` | 86 |
-| `CREATE TRIGGER` | 76 |
+| `CREATE TABLE` | 272 |
+| `CREATE VIEW` | 53 |
+| `CREATE MATERIALIZED VIEW` | 3 |
+| `CREATE FUNCTION` | 210 |
+| `CREATE TRIGGER` | 91 |
 | `CREATE TYPE` | 14 |
-| `CREATE POLICY` | 474 |
-| `ENABLE ROW LEVEL SECURITY` | 212 |
-| views com `security_invoker` | 34 |
+| `CREATE POLICY` | 579 |
+| `ENABLE ROW LEVEL SECURITY` | 269 |
+| views com `security_invoker` | 52 |
 
 ## Extensions referenciadas pelo `public` (ver `schema-extensions-prelude.sql`)
 

--- a/supabase/schema-snapshot.sql
+++ b/supabase/schema-snapshot.sql
@@ -2,22 +2,21 @@
 -- PostgreSQL database dump
 --
 
-\restrict rgDpiIOdBCwqGQSNgHMMNPhi5bHUgj6TCZY72Pd9Jcp4bgnxOtBM06gL7Pq43ky
+\restrict ci1Du82o7fSYSbQLg3x7NeuzDfdN6jlVEQL6fMupwGKCBVsGZMsHCUQHfrl8omp
 
 -- Dumped from database version 17.6
--- Dumped by pg_dump version 17.9
+-- Dumped by pg_dump version 17.10 (Homebrew)
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
 SET idle_in_transaction_session_timeout = 0;
 SET transaction_timeout = 0;
-SET client_encoding = 'SQL_ASCII';
-SET standard_conforming_strings = off;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
 SELECT pg_catalog.set_config('search_path', '', false);
 SET check_function_bodies = false;
 SET xmloption = content;
 SET client_min_messages = warning;
-SET escape_string_warning = off;
 SET row_security = off;
 
 --
@@ -35363,5 +35362,5 @@ ALTER TABLE public.whatsapp_webhook_events ENABLE ROW LEVEL SECURITY;
 -- PostgreSQL database dump complete
 --
 
-\unrestrict rgDpiIOdBCwqGQSNgHMMNPhi5bHUgj6TCZY72Pd9Jcp4bgnxOtBM06gL7Pq43ky
+\unrestrict ci1Du82o7fSYSbQLg3x7NeuzDfdN6jlVEQL6fMupwGKCBVsGZMsHCUQHfrl8omp
 


### PR DESCRIPTION
## O que
Regenera `supabase/schema-snapshot.sql` (artefato de DR/auditoria) + atualiza o manifest. **Achado: o snapshot estava gravemente stale.**

## Por que
O snapshot commitado era de **2026-05-24** (23.745 linhas) e prod cresceu MUITO desde então:

| objeto | snapshot velho | prod agora |
|---|---:|---:|
| tabelas | 212 | 272 (+60) |
| funções | 86 | 210 (+124) |
| policies | 474 | 579 (+105) |
| índices | 203 | 278 (+75) |
| constraints | 449 | 542 (+93) |

Inclui o drift da **Opção A** (motivo original do investigar): `farmer_client_scores`/`customer_visit_scores` agora `UNIQUE(customer_user_id)` + `idx_fcs_customer`/`idx_cvs_customer`.

## Como
`pg_dump --schema-only --schema=public --no-owner --no-privileges` via `~/.config/afiacao/psql-ro` (`claude_ro`, read-only, pooler) — **mesmos flags** do dump original.

## Validação de fidelidade (read-only)
- ✅ **Escopo-equivalente:** GRANT/REVOKE/OWNER = 0/0 nos dois; `CREATE SCHEMA` 1/1; `security_invoker` 34→52.
- ✅ **Completude:** dump MAIOR em toda categoria → `claude_ro` não esconde objetos (sem omissão por visibilidade de role).
- ✅ **Remoções reais:** as ~16 policies + 1 matview ausentes vs o snapshot velho são drops/renames reais (hardening RLS trocou `"Staff can manage …"` pelas granulares por carteira; matview `mv_sku_ranking_negociacao_paralela` dropada) — **confirmado em prod via psql-ro** (count 0).
- ✅ **Integridade:** pg_dump EXIT 0, sem erros, marcador `-- PostgreSQL database dump complete`.

## ⚠️ DRAFT — gate de DR
Não armei auto-merge: é artefato de DR de 35k linhas. **Recomendo a validação de replay** (restaurar o snapshot num PG17 local + `schema-extensions-prelude.sql`) antes do merge — posso rodar se quiser. `pg_dump` 17.10 (vs 17.9 do original — patch-version, formato compatível; documentado no manifest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
