### PR TITLE
docs(db): sincroniza manifest do snapshot (estava stale após a regen)

### DIFF
--- a/supabase/schema-snapshot.manifest.md
+++ b/supabase/schema-snapshot.manifest.md
@@ -4,27 +4,29 @@
 
 | Campo | Valor |
 |---|---|
-| Gerado em | 2026-05-24 |
-| Fonte | produção (Supabase Lovable, `fzvklzpomgnyikkfkzai`) |
+| Gerado em | 2026-06-19 |
+| Fonte | produção (Supabase Lovable, `fzvklzpomgnyikkfkzai`) — regen via chat do Lovable; conteúdo **cross-validado** por um `pg_dump` independente via `~/.config/afiacao/psql-ro` (idêntico objeto-por-objeto, só difere no header/token) |
 | Versão do banco | PostgreSQL 17.6 |
 | pg_dump | 17.9 |
 | Flags | `--schema-only --schema=public --no-owner --no-privileges` |
-| Linhas do arquivo | 23.745 |
-| Tamanho | ~838 KB |
+| Linhas do arquivo | 35.367 |
+| Tamanho | ~1,3 MB |
+
+> **Geração anterior (2026-05-24, pg_dump 17.9, 23.745 linhas) estava gravemente stale:** faltavam ~60 tabelas, ~124 funções, ~105 policies, ~75 índices criados por migrations posteriores (inclui o drift da Opção A: `farmer_client_scores`/`customer_visit_scores` → `UNIQUE(customer_user_id)` + `idx_fcs_customer`/`idx_cvs_customer`). As ~16 policies + 1 matview que "sumiram" são **remoções reais** em prod (hardening de RLS substituiu as policies amplas `"Staff can manage …"` pelas granulares por carteira; matview `mv_sku_ranking_negociacao_paralela` dropada) — confirmado via psql-ro.
 
 ## Contagens por tipo (schema `public`)
 
 | Objeto | Quantidade |
 |---|---:|
-| `CREATE TABLE` | 212 |
-| `CREATE VIEW` | 37 |
-| `CREATE MATERIALIZED VIEW` | 4 |
-| `CREATE FUNCTION` | 86 |
-| `CREATE TRIGGER` | 76 |
+| `CREATE TABLE` | 272 |
+| `CREATE VIEW` | 53 |
+| `CREATE MATERIALIZED VIEW` | 3 |
+| `CREATE FUNCTION` | 210 |
+| `CREATE TRIGGER` | 91 |
 | `CREATE TYPE` | 14 |
-| `CREATE POLICY` | 474 |
-| `ENABLE ROW LEVEL SECURITY` | 212 |
-| views com `security_invoker` | 34 |
+| `CREATE POLICY` | 579 |
+| `ENABLE ROW LEVEL SECURITY` | 269 |
+| views com `security_invoker` | 52 |
 
 ## Extensions referenciadas pelo `public` (ver `schema-extensions-prelude.sql`)
 


### PR DESCRIPTION
## O que
Atualiza `supabase/schema-snapshot.manifest.md` para descrever o snapshot **já regenerado** na main (commit `c1c29c56`, 35.367 linhas).

## Por que
A regen do snapshot atualizou o `.sql` mas **esqueceu o manifest** → contraditório (manifest dizia 23.745 linhas / 212 tabelas; snapshot tem 35.367 / 272). Quebra o workflow "diff do manifest = revisão de drift".

## Conteúdo (doc-only)
Contagens sincronizadas com o snapshot atual da main: 272 tabelas · 53 views · 210 funções · 91 triggers · 579 policies · 269 RLS · 52 security_invoker. pg_dump 17.9. Conteúdo cross-validado por pg_dump independente via psql-ro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
