### PR TITLE
fix(db/test): mktemp dos 31 harnesses — estende o padrão TMPDIR do #968

### DIFF
--- a/db/test-a2-cmc-view.sh
+++ b/db/test-a2-cmc-view.sh
@@ -22,7 +22,7 @@ cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2
 mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
 cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
 
-cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; rm -f "${RR:-}"; }
 trap cleanup EXIT
 
 "$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
@@ -30,7 +30,7 @@ trap cleanup EXIT
 "$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres a2_verify
 P() { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d a2_verify "$@"; }
 
-RR="$(mktemp /tmp/snap-a2.XXXXXX.sql)"
+RR="$(mktemp "${TMPDIR:-/tmp}/snap-a2.XXXXXX")"
 sed -E 's/^(CREATE SCHEMA public;)/-- \1/' "$REPO_ROOT/supabase/schema-snapshot.sql" \
   | grep -vE '^\\(un)?restrict ' > "$RR"
 P -v ON_ERROR_STOP=1 -q -f "$REPO_ROOT/db/stubs-supabase.sql"

--- a/db/test-alerta-pedido-minimo.sh
+++ b/db/test-alerta-pedido-minimo.sh
@@ -21,7 +21,7 @@ cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2
 mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
 cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
 
-cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; rm -f "${RR:-}"; }
 trap cleanup EXIT
 
 "$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
@@ -29,7 +29,7 @@ trap cleanup EXIT
 "$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres alerta3k_verify
 P() { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d alerta3k_verify "$@"; }
 
-RR="$(mktemp /tmp/snap-alerta3k.XXXXXX.sql)"
+RR="$(mktemp "${TMPDIR:-/tmp}/snap-alerta3k.XXXXXX")"
 sed -E 's/^(CREATE SCHEMA public;)/-- \1/' "$REPO_ROOT/supabase/schema-snapshot.sql" \
   | grep -vE '^\\(un)?restrict ' > "$RR"
 

--- a/db/test-aplicar-snapshot-pendente.sh
+++ b/db/test-aplicar-snapshot-pendente.sh
@@ -31,7 +31,7 @@ cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2
 mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
 cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
 
-cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; rm -f "${RR:-}"; }
 trap cleanup EXIT
 
 "$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
@@ -39,7 +39,7 @@ trap cleanup EXIT
 "$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres snappend_verify
 P() { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d snappend_verify "$@"; }
 
-RR="$(mktemp /tmp/snap-snappend.XXXXXX.sql)"
+RR="$(mktemp "${TMPDIR:-/tmp}/snap-snappend.XXXXXX")"
 sed -E 's/^(CREATE SCHEMA public;)/-- \1/' "$REPO_ROOT/supabase/schema-snapshot.sql" \
   | grep -vE '^\\(un)?restrict ' > "$RR"
 

--- a/db/test-auto-aprovacao-piloto.sh
+++ b/db/test-auto-aprovacao-piloto.sh
@@ -25,7 +25,7 @@ cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2
 mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
 cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
 
-cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; rm -f "${RR:-}"; }
 trap cleanup EXIT
 
 "$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
@@ -33,7 +33,7 @@ trap cleanup EXIT
 "$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres autoaprov_verify
 P() { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d autoaprov_verify "$@"; }
 
-RR="$(mktemp /tmp/snap-autoaprov.XXXXXX.sql)"
+RR="$(mktemp "${TMPDIR:-/tmp}/snap-autoaprov.XXXXXX")"
 sed -E 's/^(CREATE SCHEMA public;)/-- \1/' "$REPO_ROOT/supabase/schema-snapshot.sql" \
   | grep -vE '^\\(un)?restrict ' > "$RR"
 

--- a/db/test-auto-aprovacao-v2.sh
+++ b/db/test-auto-aprovacao-v2.sh
@@ -24,7 +24,7 @@ cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2
 mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
 cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
 
-cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; rm -f "${RR:-}"; }
 trap cleanup EXIT
 
 "$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
@@ -32,7 +32,7 @@ trap cleanup EXIT
 "$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres autoaprovv2_verify
 P() { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d autoaprovv2_verify "$@"; }
 
-RR="$(mktemp /tmp/snap-autoaprovv2.XXXXXX.sql)"
+RR="$(mktemp "${TMPDIR:-/tmp}/snap-autoaprovv2.XXXXXX")"
 sed -E 's/^(CREATE SCHEMA public;)/-- \1/' "$REPO_ROOT/supabase/schema-snapshot.sql" \
   | grep -vE '^\\(un)?restrict ' > "$RR"
 

--- a/db/test-city-norm-paridade.sh
+++ b/db/test-city-norm-paridade.sh
@@ -36,7 +36,7 @@ cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2
 mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
 cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
 
-cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")" "$WORK"; }
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")" "$WORK"; rm -f "${RR:-}"; }
 trap cleanup EXIT
 
 "$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=en_US.UTF-8 >/dev/null
@@ -44,7 +44,7 @@ trap cleanup EXIT
 "$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres citynorm_verify
 P() { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d citynorm_verify "$@"; }
 
-RR="$(mktemp /tmp/snap-citynorm.XXXXXX.sql)"
+RR="$(mktemp "${TMPDIR:-/tmp}/snap-citynorm.XXXXXX")"
 sed -E 's/^(CREATE SCHEMA public;)/-- \1/' "$REPO_ROOT/supabase/schema-snapshot.sql" \
   | grep -vE '^\\(un)?restrict ' > "$RR"
 

--- a/db/test-claim-full-sync.sh
+++ b/db/test-claim-full-sync.sh
@@ -26,7 +26,7 @@ cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2
 mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
 cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
 
-cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; rm -f "${RR:-}"; }
 trap cleanup EXIT
 
 "$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
@@ -34,7 +34,7 @@ trap cleanup EXIT
 "$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres claim_verify
 P() { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d claim_verify "$@"; }
 
-RR="$(mktemp /tmp/snap-claim.XXXXXX.sql)"
+RR="$(mktemp "${TMPDIR:-/tmp}/snap-claim.XXXXXX")"
 sed -E 's/^(CREATE SCHEMA public;)/-- \1/' "$REPO_ROOT/supabase/schema-snapshot.sql" \
   | grep -vE '^\\(un)?restrict ' > "$RR"
 

--- a/db/test-data-health-estoque-marcador.sh
+++ b/db/test-data-health-estoque-marcador.sh
@@ -27,7 +27,7 @@ cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2
 mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
 cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
 
-cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; rm -f "${RR:-}"; }
 trap cleanup EXIT
 
 "$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
@@ -35,7 +35,7 @@ trap cleanup EXIT
 "$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres dhmark_verify
 P() { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d dhmark_verify "$@"; }
 
-RR="$(mktemp /tmp/snap-dhmark.XXXXXX.sql)"
+RR="$(mktemp "${TMPDIR:-/tmp}/snap-dhmark.XXXXXX")"
 sed -E 's/^(CREATE SCHEMA public;)/-- \1/' "$REPO_ROOT/supabase/schema-snapshot.sql" \
   | grep -vE '^\\(un)?restrict ' > "$RR"
 

--- a/db/test-data-health-familia-ausente.sh
+++ b/db/test-data-health-familia-ausente.sh
@@ -25,7 +25,7 @@ cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2
 mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
 cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
 
-cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; rm -f "${RR:-}"; }
 trap cleanup EXIT
 
 "$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
@@ -33,7 +33,7 @@ trap cleanup EXIT
 "$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres familia_verify
 P() { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d familia_verify "$@"; }
 
-RR="$(mktemp /tmp/snap-familia.XXXXXX.sql)"
+RR="$(mktemp "${TMPDIR:-/tmp}/snap-familia.XXXXXX")"
 sed -E 's/^(CREATE SCHEMA public;)/-- \1/' "$REPO_ROOT/supabase/schema-snapshot.sql" \
   | grep -vE '^\\(un)?restrict ' > "$RR"
 

--- a/db/test-familia-ausente-lista-email.sh
+++ b/db/test-familia-ausente-lista-email.sh
@@ -26,7 +26,7 @@ cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2
 mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
 cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
 
-cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; rm -f "${RR:-}"; }
 trap cleanup EXIT
 
 "$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
@@ -34,7 +34,7 @@ trap cleanup EXIT
 "$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres familia_lista_verify
 P() { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d familia_lista_verify "$@"; }
 
-RR="$(mktemp /tmp/snap-familia-lista.XXXXXX.sql)"
+RR="$(mktemp "${TMPDIR:-/tmp}/snap-familia-lista.XXXXXX")"
 sed -E 's/^(CREATE SCHEMA public;)/-- \1/' "$REPO_ROOT/supabase/schema-snapshot.sql" \
   | grep -vE '^\\(un)?restrict ' > "$RR"
 

--- a/db/test-fase0-sales-orders-identity.sh
+++ b/db/test-fase0-sales-orders-identity.sh
@@ -12,13 +12,13 @@ SOCK="$(dirname "$DATA")"  # socket+log isolados por run → sem colisão de por
 CELLAR="$(brew --prefix postgresql@${PGVER})"
 cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
 mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"; cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
-cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; rm -f "${RR:-}"; }
 trap cleanup EXIT
 "$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
 "$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k $SOCK -c listen_addresses=" -l "$SOCK/pg-fase0.log" -w start >/dev/null
 "$PGBIN/createdb" -p "$PORT" -h "$SOCK" -U postgres fase0_verify
 P() { "$PGBIN/psql" -p "$PORT" -h "$SOCK" -U postgres -d fase0_verify "$@"; }
-RR="$(mktemp /tmp/snap-rr.XXXXXX.sql)"
+RR="$(mktemp "${TMPDIR:-/tmp}/snap-rr.XXXXXX")"
 sed -E 's/^(CREATE SCHEMA public;)/-- \1/' "$REPO_ROOT/supabase/schema-snapshot.sql" | grep -vE '^\\(un)?restrict ' > "$RR"
 P -v ON_ERROR_STOP=1 -q -f "$REPO_ROOT/db/stubs-supabase.sql"
 P -v ON_ERROR_STOP=1 -q -f "$REPO_ROOT/supabase/schema-extensions-prelude.sql"

--- a/db/test-fixes-codex-711.sh
+++ b/db/test-fixes-codex-711.sh
@@ -22,7 +22,7 @@ cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2
 mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
 cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
 
-cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; rm -f "${RR:-}"; }
 trap cleanup EXIT
 
 "$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
@@ -30,7 +30,7 @@ trap cleanup EXIT
 "$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres fixcodex_verify
 P() { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d fixcodex_verify "$@"; }
 
-RR="$(mktemp /tmp/snap-fixcodex.XXXXXX.sql)"
+RR="$(mktemp "${TMPDIR:-/tmp}/snap-fixcodex.XXXXXX")"
 sed -E 's/^(CREATE SCHEMA public;)/-- \1/' "$REPO_ROOT/supabase/schema-snapshot.sql" \
   | grep -vE '^\\(un)?restrict ' > "$RR"
 

--- a/db/test-fornecedores-classificacao.sh
+++ b/db/test-fornecedores-classificacao.sh
@@ -28,7 +28,7 @@ cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2
 mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
 cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
 
-cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; rm -f "${RR:-}"; }
 trap cleanup EXIT
 
 "$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
@@ -36,7 +36,7 @@ trap cleanup EXIT
 "$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres fornec_verify
 P() { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d fornec_verify "$@"; }
 
-RR="$(mktemp /tmp/snap-fornec.XXXXXX.sql)"
+RR="$(mktemp "${TMPDIR:-/tmp}/snap-fornec.XXXXXX")"
 sed -E 's/^(CREATE SCHEMA public;)/-- \1/' "$REPO_ROOT/supabase/schema-snapshot.sql" \
   | grep -vE '^\\(un)?restrict ' > "$RR"
 

--- a/db/test-melhorias-rpcs.sh
+++ b/db/test-melhorias-rpcs.sh
@@ -22,7 +22,7 @@ cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2
 mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
 cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
 
-cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; rm -f "${RR:-}"; }
 trap cleanup EXIT
 
 "$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
@@ -31,7 +31,7 @@ trap cleanup EXIT
 P() { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d melhorias_verify "$@"; }
 
 # Snapshot restore-ready: remove meta-comandos psql e o CREATE SCHEMA public.
-RR="$(mktemp /tmp/snap-melhorias.XXXXXX.sql)"
+RR="$(mktemp "${TMPDIR:-/tmp}/snap-melhorias.XXXXXX")"
 sed -E 's/^(CREATE SCHEMA public;)/-- \1/' "$REPO_ROOT/supabase/schema-snapshot.sql" \
   | grep -vE '^\\(un)?restrict ' > "$RR"
 

--- a/db/test-minimo-forcado.sh
+++ b/db/test-minimo-forcado.sh
@@ -22,7 +22,7 @@ cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2
 mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
 cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
 
-cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; rm -f "${RR:-}"; }
 trap cleanup EXIT
 
 "$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
@@ -30,7 +30,7 @@ trap cleanup EXIT
 "$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres minforc_verify
 P() { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d minforc_verify "$@"; }
 
-RR="$(mktemp /tmp/snap-minforc.XXXXXX.sql)"
+RR="$(mktemp "${TMPDIR:-/tmp}/snap-minforc.XXXXXX")"
 sed -E 's/^(CREATE SCHEMA public;)/-- \1/' "$REPO_ROOT/supabase/schema-snapshot.sql" \
   | grep -vE '^\\(un)?restrict ' > "$RR"
 

--- a/db/test-motor-fonte-unica.sh
+++ b/db/test-motor-fonte-unica.sh
@@ -33,7 +33,7 @@ cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2
 mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
 cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
 
-cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; rm -f "${RR:-}"; }
 trap cleanup EXIT
 
 "$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
@@ -41,7 +41,7 @@ trap cleanup EXIT
 "$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres motorfu_verify
 P() { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d motorfu_verify "$@"; }
 
-RR="$(mktemp /tmp/snap-motorfu.XXXXXX.sql)"
+RR="$(mktemp "${TMPDIR:-/tmp}/snap-motorfu.XXXXXX")"
 sed -E 's/^(CREATE SCHEMA public;)/-- \1/' "$REPO_ROOT/supabase/schema-snapshot.sql" \
   | grep -vE '^\\(un)?restrict ' > "$RR"
 

--- a/db/test-order-feed-view.sh
+++ b/db/test-order-feed-view.sh
@@ -20,7 +20,7 @@ cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2
 mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
 cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
 
-cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; rm -f "${RR:-}"; }
 trap cleanup EXIT
 
 "$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
@@ -28,7 +28,7 @@ trap cleanup EXIT
 "$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres orderfeed_verify
 P() { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d orderfeed_verify "$@"; }
 
-RR="$(mktemp /tmp/snap-orderfeed.XXXXXX.sql)"
+RR="$(mktemp "${TMPDIR:-/tmp}/snap-orderfeed.XXXXXX")"
 sed -E 's/^(CREATE SCHEMA public;)/-- \1/' "$REPO_ROOT/supabase/schema-snapshot.sql" \
   | grep -vE '^\\(un)?restrict ' > "$RR"
 

--- a/db/test-param-auto.sh
+++ b/db/test-param-auto.sh
@@ -25,7 +25,7 @@ cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2
 mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
 cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
 
-cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; rm -f "${RR:-}"; }
 trap cleanup EXIT
 
 "$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
@@ -33,7 +33,7 @@ trap cleanup EXIT
 "$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres paramauto_verify
 P() { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d paramauto_verify "$@"; }
 
-RR="$(mktemp /tmp/snap-paramauto.XXXXXX.sql)"
+RR="$(mktemp "${TMPDIR:-/tmp}/snap-paramauto.XXXXXX")"
 sed -E 's/^(CREATE SCHEMA public;)/-- \1/' "$REPO_ROOT/supabase/schema-snapshot.sql" \
   | grep -vE '^\\(un)?restrict ' > "$RR"
 

--- a/db/test-preco-pedido-cmc-account.sh
+++ b/db/test-preco-pedido-cmc-account.sh
@@ -20,7 +20,7 @@ CELLAR="$(brew --prefix postgresql@${PGVER})"
 cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
 mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
 cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
-cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; rm -f "${RR:-}"; }
 trap cleanup EXIT
 
 "$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
@@ -28,7 +28,7 @@ trap cleanup EXIT
 "$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres ppacc_verify
 P() { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d ppacc_verify "$@"; }
 
-RR="$(mktemp /tmp/snap-ppacc.XXXXXX.sql)"
+RR="$(mktemp "${TMPDIR:-/tmp}/snap-ppacc.XXXXXX")"
 sed -E 's/^(CREATE SCHEMA public;)/-- \1/' "$REPO_ROOT/supabase/schema-snapshot.sql" \
   | grep -vE '^\\(un)?restrict ' > "$RR"
 P -v ON_ERROR_STOP=1 -q -f "$REPO_ROOT/db/stubs-supabase.sql"

--- a/db/test-preco-pedido-cmc.sh
+++ b/db/test-preco-pedido-cmc.sh
@@ -20,7 +20,7 @@ CELLAR="$(brew --prefix postgresql@${PGVER})"
 cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
 mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
 cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
-cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; rm -f "${RR:-}"; }
 trap cleanup EXIT
 
 "$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
@@ -28,7 +28,7 @@ trap cleanup EXIT
 "$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres pp_verify
 P() { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d pp_verify "$@"; }
 
-RR="$(mktemp /tmp/snap-pp.XXXXXX.sql)"
+RR="$(mktemp "${TMPDIR:-/tmp}/snap-pp.XXXXXX")"
 sed -E 's/^(CREATE SCHEMA public;)/-- \1/' "$REPO_ROOT/supabase/schema-snapshot.sql" \
   | grep -vE '^\\(un)?restrict ' > "$RR"
 P -v ON_ERROR_STOP=1 -q -f "$REPO_ROOT/db/stubs-supabase.sql"

--- a/db/test-qtde-inteira-persist.sh
+++ b/db/test-qtde-inteira-persist.sh
@@ -24,7 +24,7 @@ cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2
 mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
 cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
 
-cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; rm -f "${RR:-}"; }
 trap cleanup EXIT
 
 "$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
@@ -32,7 +32,7 @@ trap cleanup EXIT
 "$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres qtdepersist_verify
 P() { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d qtdepersist_verify "$@"; }
 
-RR="$(mktemp /tmp/snap-qtdepersist.XXXXXX.sql)"
+RR="$(mktemp "${TMPDIR:-/tmp}/snap-qtdepersist.XXXXXX")"
 sed -E 's/^(CREATE SCHEMA public;)/-- \1/' "$REPO_ROOT/supabase/schema-snapshot.sql" \
   | grep -vE '^\\(un)?restrict ' > "$RR"
 

--- a/db/test-qtde-inteira.sh
+++ b/db/test-qtde-inteira.sh
@@ -27,7 +27,7 @@ cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2
 mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
 cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
 
-cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; rm -f "${RR:-}"; }
 trap cleanup EXIT
 
 "$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
@@ -35,7 +35,7 @@ trap cleanup EXIT
 "$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres qtdeint_verify
 P() { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d qtdeint_verify "$@"; }
 
-RR="$(mktemp /tmp/snap-qtdeint.XXXXXX.sql)"
+RR="$(mktemp "${TMPDIR:-/tmp}/snap-qtdeint.XXXXXX")"
 sed -E 's/^(CREATE SCHEMA public;)/-- \1/' "$REPO_ROOT/supabase/schema-snapshot.sql" \
   | grep -vE '^\\(un)?restrict ' > "$RR"
 

--- a/db/test-rpc-account-aware.sh
+++ b/db/test-rpc-account-aware.sh
@@ -24,7 +24,7 @@ cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2
 mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
 cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
 
-cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; rm -f "${RR:-}"; }
 trap cleanup EXIT
 
 "$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
@@ -32,7 +32,7 @@ trap cleanup EXIT
 "$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres acctaware_verify
 P() { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d acctaware_verify "$@"; }
 
-RR="$(mktemp /tmp/snap-acctaware.XXXXXX.sql)"
+RR="$(mktemp "${TMPDIR:-/tmp}/snap-acctaware.XXXXXX")"
 sed -E 's/^(CREATE SCHEMA public;)/-- \1/' "$REPO_ROOT/supabase/schema-snapshot.sql" \
   | grep -vE '^\\(un)?restrict ' > "$RR"
 

--- a/db/test-rpc-intraday.sh
+++ b/db/test-rpc-intraday.sh
@@ -22,7 +22,7 @@ cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2
 mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
 cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
 
-cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; rm -f "${RR:-}"; }
 trap cleanup EXIT
 
 "$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
@@ -30,7 +30,7 @@ trap cleanup EXIT
 "$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres intraday_verify
 P() { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d intraday_verify "$@"; }
 
-RR="$(mktemp /tmp/snap-intraday.XXXXXX.sql)"
+RR="$(mktemp "${TMPDIR:-/tmp}/snap-intraday.XXXXXX")"
 sed -E 's/^(CREATE SCHEMA public;)/-- \1/' "$REPO_ROOT/supabase/schema-snapshot.sql" \
   | grep -vE '^\\(un)?restrict ' > "$RR"
 

--- a/db/test-tarefas-matcher-enum.sh
+++ b/db/test-tarefas-matcher-enum.sh
@@ -18,7 +18,7 @@ cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2
 mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
 cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
 
-cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; rm -f "${BUGGY:-}"; }
 trap cleanup EXIT
 
 "$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
@@ -103,7 +103,7 @@ eq "A3 numero_invalido NAO fecha a tarefa" "$VB" "aberta"
 
 # ── ZONA 5 — falsificação: a versão com 'numero_errado' DEVE abortar (era o bug real) ──
 echo "── falsificação ──"
-BUGGY=$(mktemp /tmp/buggy-matcher.XXXXXX.sql)
+BUGGY=$(mktemp "${TMPDIR:-/tmp}/buggy-matcher.XXXXXX")
 sed 's/numero_invalido/numero_errado/g' "$MIG" > "$BUGGY"
 P -q -f "$BUGGY" >/dev/null 2>&1 || true   # CREATE passa (late-bound); valida só ao executar
 if P -q -c "SELECT public.tarefas_matcher_tick();" >/dev/null 2>&1; then

--- a/db/test-tint-get-price.sh
+++ b/db/test-tint-get-price.sh
@@ -29,7 +29,7 @@ cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2
 mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
 cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
 
-cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; rm -f "${RR:-}"; }
 trap cleanup EXIT
 
 "$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
@@ -67,7 +67,7 @@ echo "═══ setup pronto (PG17 :$PORT) ═══"
 # SQL
 #
 # Opção (b) FIEL — aplica o snapshot inteiro (pega dependências reais; mais lento):
-# RR="$(mktemp /tmp/snap-rr.XXXXXX.sql)"
+# RR="$(mktemp "${TMPDIR:-/tmp}/snap-rr.XXXXXX")"
 # sed -E 's/^(CREATE SCHEMA public;)/-- \1/' "$REPO_ROOT/supabase/schema-snapshot.sql" \
 #   | grep -vE '^\\(un)?restrict ' > "$RR"
 # P -q -f "$REPO_ROOT/supabase/schema-extensions-prelude.sql"

--- a/db/test-tint-promote-e4.sh
+++ b/db/test-tint-promote-e4.sh
@@ -22,7 +22,7 @@ cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2
 mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
 cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
 
-cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; rm -f "${RR:-}"; }
 trap cleanup EXIT
 
 "$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
@@ -46,7 +46,7 @@ eq()  { if [ "$2" = "$3" ]; then ok "$1 (=$2)"; else bad "$1 — esperado [$3], 
 gt0() { if [ "${2:-0}" -gt 0 ] 2>/dev/null; then ok "$1 (=$2)"; else bad "$1 — esperado >0, veio [$2]"; fi; }
 
 echo "═══ setup PG17 :$PORT ═══"
-RR="$(mktemp /tmp/snap-rr.XXXXXX.sql)"
+RR="$(mktemp "${TMPDIR:-/tmp}/snap-rr.XXXXXX")"
 sed -E 's/^(CREATE SCHEMA public;)/-- \1/' "$REPO_ROOT/supabase/schema-snapshot.sql" | grep -vE '^\\(un)?restrict ' > "$RR"
 P -q -f "$REPO_ROOT/supabase/schema-extensions-prelude.sql" 2>/dev/null || true
 P0 -q -f "$RR" >/tmp/snap-apply.log 2>&1 || true

--- a/db/test-tint-promote-preserva-preco.sh
+++ b/db/test-tint-promote-preserva-preco.sh
@@ -22,7 +22,7 @@ cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2
 mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
 cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
 
-cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; rm -f "${RR:-}"; }
 trap cleanup EXIT
 
 "$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
@@ -47,7 +47,7 @@ eq()  { if [ "$2" = "$3" ]; then ok "$1 (=$2)"; else bad "$1 — esperado [$3], 
 echo "═══ setup PG17 :$PORT ═══"
 
 # ── ZONA 1: snapshot (tabelas tint; tolera erro em objetos não-tint) + helpers de prod ──
-RR="$(mktemp /tmp/snap-rr.XXXXXX.sql)"
+RR="$(mktemp "${TMPDIR:-/tmp}/snap-rr.XXXXXX")"
 sed -E 's/^(CREATE SCHEMA public;)/-- \1/' "$REPO_ROOT/supabase/schema-snapshot.sql" \
   | grep -vE '^\\(un)?restrict ' > "$RR"
 P -q -f "$REPO_ROOT/supabase/schema-extensions-prelude.sql" 2>/dev/null || true

--- a/db/test-tint-promote-reexpand.sh
+++ b/db/test-tint-promote-reexpand.sh
@@ -23,7 +23,7 @@ cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2
 mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
 cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
 
-cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; rm -f "${RR:-}"; }
 trap cleanup EXIT
 
 "$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
@@ -49,7 +49,7 @@ gt0() { if [ "${2:-0}" -gt 0 ] 2>/dev/null; then ok "$1 (=$2)"; else bad "$1 —
 echo "═══ setup PG17 :$PORT ═══"
 
 # ── ZONA 1: snapshot + stale fixes + cadeia de helpers/promoção ──
-RR="$(mktemp /tmp/snap-rr.XXXXXX.sql)"
+RR="$(mktemp "${TMPDIR:-/tmp}/snap-rr.XXXXXX")"
 sed -E 's/^(CREATE SCHEMA public;)/-- \1/' "$REPO_ROOT/supabase/schema-snapshot.sql" \
   | grep -vE '^\\(un)?restrict ' > "$RR"
 P -q -f "$REPO_ROOT/supabase/schema-extensions-prelude.sql" 2>/dev/null || true

--- a/db/test-tint-promote.sh
+++ b/db/test-tint-promote.sh
@@ -28,7 +28,7 @@ cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2
 mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
 cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
 
-cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; rm -f "${RR:-}"; }
 trap cleanup EXIT
 
 "$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
@@ -36,7 +36,7 @@ trap cleanup EXIT
 "$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres tintpromote_verify
 P() { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d tintpromote_verify "$@"; }
 
-RR="$(mktemp /tmp/snap-tintpromote.XXXXXX.sql)"
+RR="$(mktemp "${TMPDIR:-/tmp}/snap-tintpromote.XXXXXX")"
 sed -E 's/^(CREATE SCHEMA public;)/-- \1/' "$REPO_ROOT/supabase/schema-snapshot.sql" \
   | grep -vE '^\\(un)?restrict ' > "$RR"
 

--- a/db/test-tint-vigia-cobertura.sh
+++ b/db/test-tint-vigia-cobertura.sh
@@ -28,7 +28,7 @@ cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2
 mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
 cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
 
-cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; rm -f "${RR:-}"; }
 trap cleanup EXIT
 
 "$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
@@ -36,7 +36,7 @@ trap cleanup EXIT
 "$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres tintvigia_verify
 P() { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d tintvigia_verify "$@"; }
 
-RR="$(mktemp /tmp/snap-tintvigia.XXXXXX.sql)"
+RR="$(mktemp "${TMPDIR:-/tmp}/snap-tintvigia.XXXXXX")"
 sed -E 's/^(CREATE SCHEMA public;)/-- \1/' "$REPO_ROOT/supabase/schema-snapshot.sql" \
   | grep -vE '^\\(un)?restrict ' > "$RR"
 


### PR DESCRIPTION
## Problema

Os harnesses PG17 usavam `mktemp /tmp/snap-*.XXXXXX.sql`. No **BSD mktemp (macOS)**, o sufixo `.sql` depois dos `X` impede a substituição dos `X` — cria o arquivo **literal** `...XXXXXX.sql` na 1ª chamada e falha com `mkstemp failed ... File exists` nas seguintes.

Morde quando um harness **aborta antes do `rm -f "$RR"`** (o `trap cleanup` só removia o `$DATA`, não o `$RR`) ou em **execução concorrente**. 5 harnesses ainda compartilhavam o literal `/tmp/snap-rr.XXXXXX.sql` → colidiam **entre si**.

## Correção — estende o padrão do #968

O #968 já corrigiu o `db/verify-snapshot-replay.sh`. Este PR aplica o **mesmo padrão** aos **31 harnesses restantes**:

- **mktemp:** `/tmp/<nome>.XXXXXX.sql` → `"${TMPDIR:-/tmp}/<nome>.XXXXXX"` (X no fim → BSD mktemp substitui; respeita `TMPDIR`)
- **trap:** `+ rm -f "${RR:-}"` (limpa o temp em abort) — `${BUGGY:-}` no `test-tarefas-matcher-enum`; preserva o `"$WORK"` no `test-city-norm-paridade`

`verify-snapshot-replay.sh` **não** é tocado (já corrigido pelo #968).

## Provas (PG17 local)

- **3 padrões de trap verde:** `test-param-auto` (uniforme + money-path), `test-city-norm-paridade` (`$WORK`), `test-tarefas-matcher-enum` (`BUGGY`)
- **0 órfãos** no `/tmp` após as rodadas (trap limpa RR/WORK/BUGGY)
- `shellcheck` limpo · diff: 31 arquivos, +62/-62

## Nota — schema `private`

O motivador original (gap de DR do schema `private` no replay) **já foi resolvido** pela regeneração do snapshot como dump integral (`b1181880`, validado no #968): o snapshot já cria `CREATE SCHEMA private` + a MV. Um stub do `private` em `db/stubs-supabase.sql` **quebraria** o replay (`schema "private" already exists`). Por isso este PR contém só o `mktemp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)