### PR TITLE
fix(config): dedup [functions.radar-ingest] — TOML inválido quebrava o supabase CLI

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -134,6 +134,3 @@ verify_jwt = false
 
 [functions.enviar-push]
 verify_jwt = false
-
-[functions.radar-ingest]
-verify_jwt = false


### PR DESCRIPTION
## O que

Remove a entrada **duplicada** `[functions.radar-ingest]` em `supabase/config.toml`.

## Por que

A entrada aparecia 2× → TOML inválido (`ProjectConfigParseError: trying to redefine an already defined table`), o que **quebrava o `supabase` CLI** no parse. Provado: antes falhava no parser TOML; depois do fix o CLI avança para `internal/functions/list`. As duas ocorrências eram idênticas (`verify_jwt = false`) → remover a 2ª **não altera comportamento**, só torna o arquivo válido.

## Contexto — a edge `n`

Este PR começou removendo também `supabase/functions/n/` (clone byte-idêntico de `calculate-scores`, sem nenhum invocador — verificado via `psql-ro`: cron/`pg_proc`/webhooks/código/CI todos vazios). Mas o **próprio Lovable já removeu `n`** (edge + diretório) na `main` no commit `59b4af22` *"Removed edge function n"*, após o delete no painel. Essa parte virou no-op no rebase; sobra só o fix do `config.toml`.

⚠️ A duplicata foi (provavelmente) introduzida pelo bot do Lovable e pode reaparecer num futuro "Changes" — se voltar, é o mesmo fix de 1 linha.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
